### PR TITLE
Arm backend: Add validation for same dtype to operators

### DIFF
--- a/backends/arm/operators/op_abs.py
+++ b/backends/arm/operators/op_abs.py
@@ -15,6 +15,7 @@ from executorch.backends.arm.operators.node_visitor import (
 )
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
+    validate_same_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
@@ -43,13 +44,8 @@ class AbsVisitor_080_BI(NodeVisitor):
         import tosa_tools.v0_80.serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 1)
-        # Specification (0.80) states that input and output types
-        # should all be the same
-        if not (inputs[0].dtype == output.dtype):
-            raise ValueError(
-                "All inputs and outputs need same dtype."
-                f"Got {inputs[0].dtype=}, {output.dtype=}"
-            )
+        validate_same_dtype(self.target, [*inputs, output])
+
         # Handle int8 (quantized) and int32
         if not (inputs[0].dtype in [ts.DType.INT8, ts.DType.INT32]):
             raise ValueError(
@@ -110,13 +106,7 @@ class AbsVisitor_080_MI(AbsVisitor_080_BI):
         import tosa_tools.v0_80.serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 1)
-        # Specification (0.80) states that input and output types
-        # should all be the same
-        if not (inputs[0].dtype == output.dtype):
-            raise ValueError(
-                "All inputs and output need same dtype."
-                f"Got {inputs[0].dtype=}, {output.dtype=}"
-            )
+        validate_same_dtype(self.target, [*inputs, output])
 
         if inputs[0].dtype in [ts.DType.INT8, ts.DType.INT32]:
             # Call the inherited define_node for handling integers
@@ -163,14 +153,8 @@ class AbsVisitor_INT(NodeVisitor):
         import serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 1)
+        validate_same_dtype(self.target, [*inputs, output])
 
-        # Specification (1.0) states that input and output types
-        # should all be the same
-        if not (inputs[0].dtype == output.dtype):
-            raise ValueError(
-                "All inputs and outputs need same dtype."
-                f"Got {inputs[0].dtype=}, {output.dtype=}"
-            )
         # Handle int8 (quantized) and int32
         if not (inputs[0].dtype in [ts.DType.INT8, ts.DType.INT32]):
             raise ValueError(
@@ -232,14 +216,7 @@ class AbsVisitor_FP(AbsVisitor_INT):
         import serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 1)
-
-        # Specification (1.0) states that input and output types
-        # should all be the same
-        if not (inputs[0].dtype == output.dtype):
-            raise ValueError(
-                "All inputs and output need same dtype."
-                f"Got {inputs[0].dtype=}, {output.dtype=}"
-            )
+        validate_same_dtype(self.target, [*inputs, output])
 
         if inputs[0].dtype in [ts.DType.INT8, ts.DType.INT32]:
             # Call the inherited define_node for handling integers

--- a/backends/arm/operators/op_add.py
+++ b/backends/arm/operators/op_add.py
@@ -16,6 +16,7 @@ from executorch.backends.arm.operators.node_visitor import (
 )
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
+    validate_same_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
@@ -44,14 +45,8 @@ class AddVisitor_080_BI(NodeVisitor):
         import tosa_tools.v0_80.serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 2)
-        # Specification (0.80) states that input and output types
-        # should all be the same
-        if inputs[0].dtype != inputs[1].dtype or inputs[0].dtype != output.dtype:
-            raise TypeError(
-                f"All IO needs to have the same data type, got input 1: "
-                f"{inputs[0].dtype}, input 2: {inputs[1].dtype} and output: "
-                f"{output.dtype}"
-            )
+        validate_same_dtype(self.target, [*inputs, output])
+
         # Handle int8 (quantized) and int32
         supported_dtypes = [ts.DType.INT8, ts.DType.INT32]
         if inputs[0].dtype not in supported_dtypes:
@@ -123,14 +118,7 @@ class AddVisitor_080_MI(AddVisitor_080_BI):
         import tosa_tools.v0_80.serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 2)
-        # Specification (0.80) states that input and output types
-        # should all be the same
-        if inputs[0].dtype != inputs[1].dtype or inputs[0].dtype != output.dtype:
-            raise TypeError(
-                f"All IO needs to have the same data type, got input 1: "
-                f"{inputs[0].dtype}, input 2: {inputs[1].dtype} and output: "
-                f"{output.dtype}"
-            )
+        validate_same_dtype(self.target, [*inputs, output])
 
         if inputs[0].dtype in [ts.DType.INT8, ts.DType.INT32]:
             # Call the inherited define_node for handling integers
@@ -175,15 +163,8 @@ class AddVisitor_INT(NodeVisitor):
         import serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 2)
+        validate_same_dtype(self.target, [*inputs, output])
 
-        # Specification (1.0) states that input and output types
-        # should all be the same
-        if inputs[0].dtype != inputs[1].dtype or inputs[0].dtype != output.dtype:
-            raise TypeError(
-                f"All IO needs to have the same data type, got input 1: "
-                f"{inputs[0].dtype}, input 2: {inputs[1].dtype} and output: "
-                f"{output.dtype}"
-            )
         # Handle int8 (quantized) and int32
         supported_dtypes = [ts.DType.INT8, ts.DType.INT32]
         if inputs[0].dtype not in supported_dtypes:
@@ -245,15 +226,7 @@ class AddVisitor_FP(AddVisitor_INT):
         import serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 2)
-
-        # Specification (1.0) states that input and output types
-        # should all be the same
-        if inputs[0].dtype != inputs[1].dtype or inputs[0].dtype != output.dtype:
-            raise TypeError(
-                f"All IO needs to have the same data type, got input 1: "
-                f"{inputs[0].dtype}, input 2: {inputs[1].dtype} and output: "
-                f"{output.dtype}"
-            )
+        validate_same_dtype(self.target, [*inputs, output])
 
         if inputs[0].dtype in [ts.DType.INT8, ts.DType.INT32]:
             # Call the inherited define_node for handling integers

--- a/backends/arm/operators/op_amax.py
+++ b/backends/arm/operators/op_amax.py
@@ -11,6 +11,7 @@ from executorch.backends.arm.operators.node_visitor import (
 )
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
+    validate_same_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from torch.fx import Node
@@ -35,6 +36,7 @@ class MaxVisitor_0_80(NodeVisitor):
         import tosa_tools.v0_80.serializer.tosa_serializer as ts
 
         validate_num_inputs(self.target, inputs, 3)
+        validate_same_dtype(self.target, [inputs[0], output])
 
         input = inputs[0]
         dim = inputs[1].number
@@ -77,6 +79,7 @@ class MaxVisitor(NodeVisitor):
         import serializer.tosa_serializer as ts
 
         validate_num_inputs(self.target, inputs, 3)
+        validate_same_dtype(self.target, [inputs[0], output])
 
         input = inputs[0]
         dim = inputs[1].number

--- a/backends/arm/operators/op_amin.py
+++ b/backends/arm/operators/op_amin.py
@@ -11,6 +11,7 @@ from executorch.backends.arm.operators.node_visitor import (
 )
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
+    validate_same_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from torch.fx import Node
@@ -35,6 +36,7 @@ class MinVisitor_0_80(NodeVisitor):
         import tosa_tools.v0_80.serializer.tosa_serializer as ts
 
         validate_num_inputs(self.target, inputs, 3)
+        validate_same_dtype(self.target, [inputs[0], output])
 
         input = inputs[0]
         dim = inputs[1].number
@@ -77,6 +79,7 @@ class MinVisitor(NodeVisitor):
         import serializer.tosa_serializer as ts
 
         validate_num_inputs(self.target, inputs, 3)
+        validate_same_dtype(self.target, [inputs[0], output])
 
         input = inputs[0]
         dim = inputs[1].number

--- a/backends/arm/operators/op_any.py
+++ b/backends/arm/operators/op_any.py
@@ -12,6 +12,7 @@ from executorch.backends.arm.operators.node_visitor import (  # type: ignore
 )
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
+    validate_same_dtype,
 )
 
 from executorch.backends.arm.tosa_mapping import TosaArg  # type: ignore
@@ -34,12 +35,8 @@ class AnyVisitor_0_80(NodeVisitor):
         import tosa_tools.v0_80.serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 3)
+        validate_same_dtype(self.target, [inputs[0], output])
 
-        if not (inputs[0].dtype == output.dtype):
-            raise ValueError(
-                "All inputs and outputs need same dtype."
-                f"Got {ts.DTypeNames[inputs[0].dtype]=}, {ts.DTypeNames[output.dtype]=}."
-            )
         if not (inputs[0].dtype == ts.DType.BOOL):
             raise ValueError("All inputs need to be BOOL." f"Got {inputs[0].dtype=}")
 
@@ -75,12 +72,8 @@ class AnyVisitor(NodeVisitor):
         import serializer.tosa_serializer as ts
 
         validate_num_inputs(self.target, inputs, 3)
+        validate_same_dtype(self.target, [inputs[0], output])
 
-        if not (inputs[0].dtype == output.dtype):
-            raise ValueError(
-                "All inputs and outputs need same dtype."
-                f"Got {ts.DTypeNames[inputs[0].dtype]=}, {ts.DTypeNames[output.dtype]=}."
-            )
         if not (inputs[0].dtype == ts.DType.BOOL):
             raise ValueError("All inputs need to be BOOL." f"Got {inputs[0].dtype=}")
 

--- a/backends/arm/operators/op_avg_pool2d.py
+++ b/backends/arm/operators/op_avg_pool2d.py
@@ -18,6 +18,7 @@ from executorch.backends.arm.operators.node_visitor import (
 )
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
+    validate_same_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
@@ -89,6 +90,7 @@ class AvgPool2dVisitor_0_80_BI(NodeVisitor):
         import tosa_tools.v0_80.serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, [3, 4, 6])
+        validate_same_dtype(self.target, [inputs[0], output])
 
         supported_dtypes = [ts.DType.INT8]
         if inputs[0].dtype not in supported_dtypes:
@@ -128,6 +130,7 @@ class AvgPool2dVisitor_0_80_MI(AvgPool2dVisitor_0_80_BI):
         import tosa_tools.v0_80.serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, [3, 4, 6])
+        validate_same_dtype(self.target, [inputs[0], output])
 
         supported_dtypes = [ts.DType.INT8, ts.DType.FP32]
         if inputs[0].dtype not in supported_dtypes:
@@ -220,6 +223,7 @@ class AvgPool2dVisitor(NodeVisitor):
         import serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, [3, 4, 6])
+        validate_same_dtype(self.target, [inputs[0], output])
 
         supported_dtypes = [ts.DType.INT8]
         if inputs[0].dtype not in supported_dtypes:
@@ -262,6 +266,7 @@ class AvgPool2dVisitor_FP(AvgPool2dVisitor):
         import serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, [3, 4, 6])
+        validate_same_dtype(self.target, [inputs[0], output])
 
         supported_dtypes = [ts.DType.INT8, ts.DType.FP32]
         if inputs[0].dtype not in supported_dtypes:

--- a/backends/arm/operators/op_bmm.py
+++ b/backends/arm/operators/op_bmm.py
@@ -19,6 +19,7 @@ from executorch.backends.arm.operators.node_visitor import (
 )
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
+    validate_same_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_quant_utils import build_rescale, build_rescale_v0_80
@@ -49,11 +50,7 @@ class BMMVisitor_0_80(NodeVisitor):
         import tosa_tools.v0_80.serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 2)
-        if inputs[0].dtype != inputs[1].dtype or inputs[0].dtype != output.dtype:
-            raise TypeError(
-                f"All IO needs to have the same data type, got: "
-                f"{inputs[0].dtype=}, {inputs[1].dtype=} and {output.dtype=}"
-            )
+        validate_same_dtype(self.target, [*inputs, output])
 
         # aten.bmm maps directly to MATMUL
         # NOTE: For now, only INT8 & FP32 is supported
@@ -132,12 +129,7 @@ class BMMVisitor(NodeVisitor):
         import serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 2)
-
-        if inputs[0].dtype != inputs[1].dtype or inputs[0].dtype != output.dtype:
-            raise TypeError(
-                f"All IO needs to have the same data type, got: "
-                f"{inputs[0].dtype=}, {inputs[1].dtype=} and {output.dtype=}"
-            )
+        validate_same_dtype(self.target, [*inputs, output])
 
         # aten.bmm maps directly to MATMUL
         # NOTE: For now, only INT8 & FP32 is supported

--- a/backends/arm/operators/op_clamp.py
+++ b/backends/arm/operators/op_clamp.py
@@ -17,6 +17,7 @@ from executorch.backends.arm.operators.node_visitor import (
 )
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
+    validate_same_dtype,
 )
 
 from executorch.backends.arm.tosa_mapping import TosaArg
@@ -88,6 +89,7 @@ class ClampVisitor_080_BI(NodeVisitor):
         output: TosaArg,
     ) -> None:
         validate_num_inputs(self.target, inputs, [2, 3])
+        validate_same_dtype(self.target, [inputs[0], output])
 
         min_int8, max_int8 = self._get_min_max_arguments(
             node,
@@ -128,6 +130,7 @@ class ClampVisitor_080_MI(ClampVisitor_080_BI):
         import tosa_tools.v0_80.serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, [2, 3])
+        validate_same_dtype(self.target, [inputs[0], output])
 
         if inputs[0].dtype == ts.DType.INT8:
             # Call the inherited define_node for handling integers
@@ -194,6 +197,7 @@ class ClampVisitor_INT(NodeVisitor):
         import serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, [2, 3])
+        validate_same_dtype(self.target, [inputs[0], output])
 
         # NOTE: Quantization of the min/max arguments is handled by QuantizeOperatorArguments
         min_int8, max_int8 = self._get_min_max_arguments(
@@ -236,6 +240,7 @@ class ClampVisitor_FP(ClampVisitor_INT):
         import serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, [2, 3])
+        validate_same_dtype(self.target, [inputs[0], output])
 
         min_fp32, max_fp32 = self._get_min_max_arguments(
             node,

--- a/backends/arm/operators/op_constant_pad_nd.py
+++ b/backends/arm/operators/op_constant_pad_nd.py
@@ -18,6 +18,7 @@ from executorch.backends.arm.operators.node_visitor import (
 )
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
+    validate_same_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
@@ -43,6 +44,7 @@ class ConstantPadNDVisitor_0_80(NodeVisitor):
         import tosa_tools.v0_80.serializer.tosa_serializer as ts
 
         validate_num_inputs(self.target, inputs, 3)
+        validate_same_dtype(self.target, [inputs[0], output])
 
         if inputs[0].dtype == ts.DType.INT8:
             input_qparams = get_input_qparams(node)
@@ -106,6 +108,7 @@ class ConstantPadNDVisitor(NodeVisitor):
         import serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 3)
+        validate_same_dtype(self.target, [inputs[0], output])
 
         if inputs[0].dtype == ts.DType.INT8:
             input_qparams = get_input_qparams(node)

--- a/backends/arm/operators/op_cos.py
+++ b/backends/arm/operators/op_cos.py
@@ -13,6 +13,7 @@ from executorch.backends.arm.operators.node_visitor import (
 )
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
+    validate_same_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
@@ -37,6 +38,7 @@ class CosVisitor(NodeVisitor):
         output: TosaArg,
     ) -> None:
         validate_num_inputs(self.target, inputs, 1)
+        validate_same_dtype(self.target, [*inputs, output])
         if inputs[0].dtype != ts.DType.FP32 or output.dtype != ts.DType.FP32:
             raise ValueError(
                 f"Input and output for {self.target} need to be FP32, got input_dtype: "

--- a/backends/arm/operators/op_eq.py
+++ b/backends/arm/operators/op_eq.py
@@ -15,6 +15,7 @@ from executorch.backends.arm.operators.node_visitor import (
 )
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
+    validate_same_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
@@ -45,12 +46,7 @@ class EqualVisitor_0_80(NodeVisitor):
         import tosa_tools.v0_80.serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 2)
-
-        if inputs[0].dtype != inputs[1].dtype:
-            raise TypeError(
-                "All inputs need to have the same data type for operator EQ but got "
-                f"{inputs[0].dtype=}, {inputs[1].dtype=}"
-            )
+        validate_same_dtype(self.target, inputs)
 
         input_nodes = inputs
         # Handle quantization
@@ -95,12 +91,7 @@ class EqualVisitor(NodeVisitor):
         import serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 2)
-
-        if inputs[0].dtype != inputs[1].dtype:
-            raise TypeError(
-                "All inputs need to have the same data type for operator EQ but got "
-                f"{inputs[0].dtype=}, {inputs[1].dtype=}"
-            )
+        validate_same_dtype(self.target, inputs)
 
         input_nodes = inputs
         # Handle quantization

--- a/backends/arm/operators/op_erf.py
+++ b/backends/arm/operators/op_erf.py
@@ -12,6 +12,7 @@ from executorch.backends.arm.operators.node_visitor import (
 )
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
+    validate_same_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
@@ -37,12 +38,8 @@ class ERFVisitor_080_MI(NodeVisitor):
         import tosa_tools.v0_80.serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 1)
+        validate_same_dtype(self.target, [*inputs, output])
 
-        if not (inputs[0].dtype == output.dtype):
-            raise ValueError(
-                "All inputs and output need same dtype."
-                f"Got {inputs[0].dtype=}, {output.dtype=}"
-            )
         if not (inputs[0].dtype == ts.DType.FP32):
             raise ValueError("All inputs need to be FP32." f"Got {inputs[0].dtype=}")
         # MI lowering
@@ -69,12 +66,8 @@ class ERFVisitor(NodeVisitor):
         import serializer.tosa_serializer as ts
 
         validate_num_inputs(self.target, inputs, 1)
+        validate_same_dtype(self.target, [*inputs, output])
 
-        if not (inputs[0].dtype == output.dtype):
-            raise ValueError(
-                "All inputs and output need same dtype."
-                f"Got {inputs[0].dtype=}, {output.dtype=}"
-            )
         if not (inputs[0].dtype == ts.DType.FP32):
             raise ValueError("All inputs need to be FP32." f"Got {inputs[0].dtype=}")
 

--- a/backends/arm/operators/op_exp.py
+++ b/backends/arm/operators/op_exp.py
@@ -12,6 +12,7 @@ from executorch.backends.arm.operators.node_visitor import (
 )
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
+    validate_same_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
@@ -38,6 +39,7 @@ class ExpVisitor_0_80_MI(NodeVisitor):
         import tosa_tools.v0_80.serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 1)
+        validate_same_dtype(self.target, [*inputs, output])
 
         if inputs[0].dtype != ts.DType.FP32 or output.dtype != ts.DType.FP32:
             raise ValueError(
@@ -68,6 +70,7 @@ class ExpVisitor(NodeVisitor):
         import serializer.tosa_serializer as ts
 
         validate_num_inputs(self.target, inputs, 1)
+        validate_same_dtype(self.target, [*inputs, output])
 
         if inputs[0].dtype != ts.DType.FP32 or output.dtype != ts.DType.FP32:
             raise ValueError(

--- a/backends/arm/operators/op_ge.py
+++ b/backends/arm/operators/op_ge.py
@@ -15,6 +15,7 @@ from executorch.backends.arm.operators.node_visitor import (
 )
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
+    validate_same_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
@@ -45,12 +46,7 @@ class GreaterEqualVisitor_0_80(NodeVisitor):
         import tosa_tools.v0_80.serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 2)
-
-        if inputs[0].dtype != inputs[1].dtype:
-            raise TypeError(
-                "All inputs need to have the same data type for operator GE but got "
-                f"{inputs[0].dtype=}, {inputs[1].dtype=}"
-            )
+        validate_same_dtype(self.target, inputs)
 
         input_nodes = inputs
         # Handle quantization
@@ -94,12 +90,7 @@ class GreaterEqualVisitor(NodeVisitor):
         import serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 2)
-
-        if inputs[0].dtype != inputs[1].dtype:
-            raise TypeError(
-                "All inputs need to have the same data type for operator GE but got "
-                f"{inputs[0].dtype=}, {inputs[1].dtype=}"
-            )
+        validate_same_dtype(self.target, inputs)
 
         input_nodes = inputs
         # Handle quantization

--- a/backends/arm/operators/op_gt.py
+++ b/backends/arm/operators/op_gt.py
@@ -15,6 +15,7 @@ from executorch.backends.arm.operators.node_visitor import (
 )
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
+    validate_same_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
@@ -45,12 +46,7 @@ class GreaterThanVisitor_0_80(NodeVisitor):
         import tosa_tools.v0_80.serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 2)
-
-        if inputs[0].dtype != inputs[1].dtype:
-            raise TypeError(
-                "All inputs need to have the same data type for operator GT but got "
-                f"{inputs[0].dtype=}, {inputs[1].dtype=}"
-            )
+        validate_same_dtype(self.target, inputs)
 
         input_nodes = inputs
         # Handle quantization
@@ -94,12 +90,7 @@ class GreaterThanVisitor(NodeVisitor):
         import serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 2)
-
-        if inputs[0].dtype != inputs[1].dtype:
-            raise TypeError(
-                "All inputs need to have the same data type for operator GT but got "
-                f"{inputs[0].dtype=}, {inputs[1].dtype=}"
-            )
+        validate_same_dtype(self.target, inputs)
 
         input_nodes = inputs
         # Handle quantization

--- a/backends/arm/operators/op_le.py
+++ b/backends/arm/operators/op_le.py
@@ -15,6 +15,7 @@ from executorch.backends.arm.operators.node_visitor import (
 )
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
+    validate_same_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
@@ -45,12 +46,7 @@ class LessEqualVisitor_0_80(NodeVisitor):
         import tosa_tools.v0_80.serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 2)
-
-        if inputs[0].dtype != inputs[1].dtype:
-            raise TypeError(
-                "All inputs need to have the same data type for operator LE but got "
-                f"{inputs[0].dtype=}, {inputs[1].dtype=}"
-            )
+        validate_same_dtype(self.target, inputs)
 
         input_nodes = inputs
         # Handle quantization
@@ -94,12 +90,7 @@ class LessEqualVisitor(NodeVisitor):
         import serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 2)
-
-        if inputs[0].dtype != inputs[1].dtype:
-            raise TypeError(
-                "All inputs need to have the same data type for operator LE but got "
-                f"{inputs[0].dtype=}, {inputs[1].dtype=}"
-            )
+        validate_same_dtype(self.target, inputs)
 
         input_nodes = inputs
         # Handle quantization

--- a/backends/arm/operators/op_log.py
+++ b/backends/arm/operators/op_log.py
@@ -12,6 +12,7 @@ from executorch.backends.arm.operators.node_visitor import (
 )
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
+    validate_same_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
@@ -38,6 +39,7 @@ class LogVisitor_0_80_MI(NodeVisitor):
         import tosa_tools.v0_80.serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 1)
+        validate_same_dtype(self.target, [*inputs, output])
 
         if inputs[0].dtype != ts.DType.FP32 or output.dtype != ts.DType.FP32:
             raise ValueError(
@@ -68,6 +70,7 @@ class LogVisitor(NodeVisitor):
         import serializer.tosa_serializer as ts
 
         validate_num_inputs(self.target, inputs, 1)
+        validate_same_dtype(self.target, [*inputs, output])
 
         if inputs[0].dtype != ts.DType.FP32 or output.dtype != ts.DType.FP32:
             raise ValueError(

--- a/backends/arm/operators/op_lt.py
+++ b/backends/arm/operators/op_lt.py
@@ -15,6 +15,7 @@ from executorch.backends.arm.operators.node_visitor import (
 )
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
+    validate_same_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
@@ -45,12 +46,7 @@ class LessThanVisitor_0_80(NodeVisitor):
         import tosa_tools.v0_80.serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 2)
-
-        if inputs[0].dtype != inputs[1].dtype:
-            raise TypeError(
-                "All inputs need to have the same data type for operator LT but got "
-                f"{inputs[0].dtype=}, {inputs[1].dtype=}"
-            )
+        validate_same_dtype(self.target, inputs)
 
         input_nodes = inputs
         # Handle quantization
@@ -94,12 +90,7 @@ class LessThanVisitor(NodeVisitor):
         import serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 2)
-
-        if inputs[0].dtype != inputs[1].dtype:
-            raise TypeError(
-                "All inputs need to have the same data type for operator LT but got "
-                f"{inputs[0].dtype=}, {inputs[1].dtype=}"
-            )
+        validate_same_dtype(self.target, inputs)
 
         input_nodes = inputs
         # Handle quantization

--- a/backends/arm/operators/op_max_pool2d.py
+++ b/backends/arm/operators/op_max_pool2d.py
@@ -18,6 +18,7 @@ from executorch.backends.arm.operators.node_visitor import (
 )
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
+    validate_same_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
@@ -63,6 +64,7 @@ class MaxPool2dVisitor_0_80(NodeVisitor):
         import tosa_tools.v0_80.serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, [3, 4])
+        validate_same_dtype(self.target, [inputs[0], output])
 
         input_tensor = inputs[0]
         kernel_size = inputs[1].special
@@ -147,6 +149,7 @@ class MaxPool2dVisitor(NodeVisitor):
         import serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, [3, 4])
+        validate_same_dtype(self.target, [inputs[0], output])
 
         input_tensor = inputs[0]
         kernel_size = inputs[1].special

--- a/backends/arm/operators/op_maximum.py
+++ b/backends/arm/operators/op_maximum.py
@@ -19,6 +19,7 @@ from executorch.backends.arm.operators.node_visitor import (
 )
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
+    validate_same_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
@@ -49,13 +50,7 @@ class MaxVisitor_0_80(NodeVisitor):
         import tosa_tools.v0_80.serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 2)
-
-        if inputs[0].dtype != inputs[1].dtype and inputs[0].dtype != output.dtype:
-            raise TypeError(
-                f"Data type of inputs and output must be the same. Got input 0 dtype: "
-                f"{inputs[0].dtype}, input 1 dtype: {inputs[1].dtype} and output "
-                f"dtype: {output.dtype}"
-            )
+        validate_same_dtype(self.target, [*inputs, output])
 
         scale_back = 1.0
         max_output = output
@@ -118,13 +113,7 @@ class MaxVisitor(NodeVisitor):
         from tosa.NanPropagationMode import NanPropagationMode  # type: ignore
 
         validate_num_inputs(self.target, inputs, 2)
-
-        if inputs[0].dtype != inputs[1].dtype and inputs[0].dtype != output.dtype:
-            raise TypeError(
-                f"Data type of inputs and output must be the same. Got input 0 dtype: "
-                f"{inputs[0].dtype}, input 1 dtype: {inputs[1].dtype} and output "
-                f"dtype: {output.dtype}"
-            )
+        validate_same_dtype(self.target, [*inputs, output])
 
         scale_back = 1.0
         max_output = output

--- a/backends/arm/operators/op_minimum.py
+++ b/backends/arm/operators/op_minimum.py
@@ -18,6 +18,7 @@ from executorch.backends.arm.operators.node_visitor import (
 )
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
+    validate_same_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
@@ -48,13 +49,7 @@ class MinVisitor_0_80(NodeVisitor):
         import tosa_tools.v0_80.serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 2)
-
-        if inputs[0].dtype != inputs[1].dtype and inputs[0].dtype != output.dtype:
-            raise TypeError(
-                f"Data type of inputs and output must be the same. Got input 0 dtype: "
-                f"{inputs[0].dtype}, input 1 dtype: {inputs[1].dtype} and output "
-                f"dtype: {output.dtype}"
-            )
+        validate_same_dtype(self.target, [*inputs, output])
 
         scale_back = 1.0
         min_output = output
@@ -117,13 +112,7 @@ class MinVisitor(NodeVisitor):
         from tosa.NanPropagationMode import NanPropagationMode  # type: ignore
 
         validate_num_inputs(self.target, inputs, 2)
-
-        if inputs[0].dtype != inputs[1].dtype and inputs[0].dtype != output.dtype:
-            raise TypeError(
-                f"Data type of inputs and output must be the same. Got input 0 dtype: "
-                f"{inputs[0].dtype}, input 1 dtype: {inputs[1].dtype} and output "
-                f"dtype: {output.dtype}"
-            )
+        validate_same_dtype(self.target, [*inputs, output])
 
         scale_back = 1.0
         min_output = output

--- a/backends/arm/operators/op_mul.py
+++ b/backends/arm/operators/op_mul.py
@@ -21,6 +21,7 @@ from executorch.backends.arm.operators.node_visitor import (
 )
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
+    validate_same_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
@@ -46,6 +47,7 @@ class MulVisitor_080_BI(NodeVisitor):
         import tosa_tools.v0_80.serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 2)
+        validate_same_dtype(self.target, [*inputs, output])
 
         if (
             inputs[0].dtype != ts.DType.INT8
@@ -128,6 +130,7 @@ class MulVisitor_080_MI(MulVisitor_080_BI):
         import tosa_tools.v0_80.serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 2)
+        validate_same_dtype(self.target, [*inputs, output])
 
         if inputs[0].dtype == ts.DType.INT8:
             return super().define_node(node, tosa_graph, inputs, output)
@@ -160,6 +163,7 @@ class MulVisitor_INT(NodeVisitor):
         import serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 2)
+        validate_same_dtype(self.target, [*inputs, output])
 
         if (
             inputs[0].dtype != ts.DType.INT8
@@ -228,6 +232,7 @@ class MulVisitor_FP(MulVisitor_INT):
         import serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 2)
+        validate_same_dtype(self.target, [*inputs, output])
 
         if inputs[0].dtype == ts.DType.INT8:
             return super().define_node(node, tosa_graph, inputs, output)

--- a/backends/arm/operators/op_permute.py
+++ b/backends/arm/operators/op_permute.py
@@ -15,6 +15,7 @@ from executorch.backends.arm.operators.node_visitor import (
 )
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
+    validate_same_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 
@@ -111,6 +112,7 @@ class PermuteVisitor_0_80(NodeVisitor):
         import tosa_tools.v0_80.serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 2)
+        validate_same_dtype(self.target, [inputs[0], output])
 
         # The permutation vector describes a permutation P in default Pytorch dim_order.
         # For rank 4, the default dim_order NCHW.
@@ -150,6 +152,7 @@ class PermuteVisitor(NodeVisitor):
         import serializer.tosa_serializer as ts
 
         validate_num_inputs(self.target, inputs, 2)
+        validate_same_dtype(self.target, [inputs[0], output])
 
         # The permutation vector describes a permutation P in default Pytorch dim_order.
         # For rank 4, the default dim_order NCHW.

--- a/backends/arm/operators/op_pow.py
+++ b/backends/arm/operators/op_pow.py
@@ -13,6 +13,7 @@ from executorch.backends.arm.operators.node_visitor import (
 )
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
+    validate_same_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
@@ -40,12 +41,8 @@ class PowVisitor_080_MI(NodeVisitor):
         import tosa_tools.v0_80.serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 2)
+        validate_same_dtype(self.target, [*inputs, output])
 
-        if not (inputs[0].dtype == inputs[1].dtype == output.dtype):
-            raise ValueError(
-                "All inputs and outputs need same dtype."
-                f"Got {inputs[0].dtype=}, {inputs[1].dtype=}, {output.dtype=}"
-            )
         if inputs[0].dtype not in [ts.DType.FP32, ts.DType.FP16]:
             raise ValueError(
                 f"All inputs need to be FP32 or FP16. Got {inputs[0].dtype}"
@@ -83,12 +80,8 @@ class PowVisitor(NodeVisitor):
         import serializer.tosa_serializer as ts
 
         validate_num_inputs(self.target, inputs, 2)
+        validate_same_dtype(self.target, [*inputs, output])
 
-        if not (inputs[0].dtype == inputs[1].dtype == output.dtype):
-            raise ValueError(
-                "All inputs and outputs need same dtype."
-                f"Got {inputs[0].dtype=}, {inputs[1].dtype=}, {output.dtype=}"
-            )
         if inputs[0].dtype not in [ts.DType.FP32, ts.DType.FP16]:
             raise ValueError(
                 f"All inputs need to be FP32 or FP16. Got {inputs[0].dtype}"

--- a/backends/arm/operators/op_reciprocal.py
+++ b/backends/arm/operators/op_reciprocal.py
@@ -14,6 +14,7 @@ from executorch.backends.arm.operators.node_visitor import (
 )
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
+    validate_same_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
@@ -39,6 +40,7 @@ class ReciprocalVisitor_080_MI(NodeVisitor):
         import tosa_tools.v0_80.serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 1)
+        validate_same_dtype(self.target, [*inputs, output])
 
         if inputs[0].dtype != ts.DType.FP32 or output.dtype != ts.DType.FP32:
             raise ValueError(
@@ -71,6 +73,7 @@ class ReciprocalVisitor(NodeVisitor):
         import serializer.tosa_serializer as ts
 
         validate_num_inputs(self.target, inputs, 1)
+        validate_same_dtype(self.target, [*inputs, output])
 
         if inputs[0].dtype != ts.DType.FP32 or output.dtype != ts.DType.FP32:
             raise ValueError(

--- a/backends/arm/operators/op_repeat.py
+++ b/backends/arm/operators/op_repeat.py
@@ -14,6 +14,7 @@ from executorch.backends.arm.operators.node_visitor import (
 )
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
+    validate_same_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_utils import tosa_shape
@@ -38,6 +39,7 @@ class RepeatVisitor_0_80(NodeVisitor):
         import tosa_tools.v0_80.serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 2)
+        validate_same_dtype(self.target, [inputs[0], output])
 
         multiples = inputs[1].special
 
@@ -67,6 +69,7 @@ class RepeatVisitor(NodeVisitor):
         import serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 2)
+        validate_same_dtype(self.target, [inputs[0], output])
 
         multiples = inputs[1].special
 

--- a/backends/arm/operators/op_rshift_tensor.py
+++ b/backends/arm/operators/op_rshift_tensor.py
@@ -15,6 +15,7 @@ from executorch.backends.arm.operators.node_visitor import (
 )
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
+    validate_same_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 
@@ -35,6 +36,7 @@ class RshiftVisitor_0_80(NodeVisitor):
         import tosa_tools.v0_80.serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 2)
+        validate_same_dtype(self.target, [*inputs, output])
 
         attr = ts.TosaSerializerAttribute()
         round = False
@@ -68,6 +70,7 @@ class RshiftVisitor(NodeVisitor):
         import serializer.tosa_serializer as ts
 
         validate_num_inputs(self.target, inputs, 2)
+        validate_same_dtype(self.target, [*inputs, output])
 
         attr = ts.TosaSerializerAttribute()
         round = False

--- a/backends/arm/operators/op_rsqrt.py
+++ b/backends/arm/operators/op_rsqrt.py
@@ -14,6 +14,7 @@ from executorch.backends.arm.operators.node_visitor import (
 )
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
+    validate_same_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
@@ -39,6 +40,7 @@ class RsqrtVisitor_080_MI(NodeVisitor):
         import tosa_tools.v0_80.serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 1)
+        validate_same_dtype(self.target, [*inputs, output])
 
         if inputs[0].dtype != ts.DType.FP32 or output.dtype != ts.DType.FP32:
             raise ValueError(
@@ -69,6 +71,7 @@ class RsqrtVisitor(NodeVisitor):
         import serializer.tosa_serializer as ts
 
         validate_num_inputs(self.target, inputs, 1)
+        validate_same_dtype(self.target, [*inputs, output])
 
         if inputs[0].dtype != ts.DType.FP32 or output.dtype != ts.DType.FP32:
             raise ValueError(

--- a/backends/arm/operators/op_sigmoid.py
+++ b/backends/arm/operators/op_sigmoid.py
@@ -12,6 +12,7 @@ from executorch.backends.arm.operators.node_visitor import (
 )
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
+    validate_same_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
@@ -38,6 +39,7 @@ class SigmoidVisitor_080_MI(NodeVisitor):
         import tosa_tools.v0_80.serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 1)
+        validate_same_dtype(self.target, [*inputs, output])
 
         if inputs[0].dtype != ts.DType.FP32 or output.dtype != ts.DType.FP32:
             raise ValueError(
@@ -68,6 +70,7 @@ class SigmoidVisitor(NodeVisitor):
         import serializer.tosa_serializer as ts
 
         validate_num_inputs(self.target, inputs, 1)
+        validate_same_dtype(self.target, [*inputs, output])
 
         if inputs[0].dtype != ts.DType.FP32 or output.dtype != ts.DType.FP32:
             raise ValueError(

--- a/backends/arm/operators/op_sin.py
+++ b/backends/arm/operators/op_sin.py
@@ -13,6 +13,7 @@ from executorch.backends.arm.operators.node_visitor import (
 )
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
+    validate_same_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
@@ -37,6 +38,7 @@ class SinVisitor(NodeVisitor):
         output: TosaArg,
     ) -> None:
         validate_num_inputs(self.target, inputs, 1)
+        validate_same_dtype(self.target, [*inputs, output])
 
         if inputs[0].dtype != ts.DType.FP32 or output.dtype != ts.DType.FP32:
             raise ValueError(

--- a/backends/arm/operators/op_slice.py
+++ b/backends/arm/operators/op_slice.py
@@ -13,6 +13,7 @@ from executorch.backends.arm.operators.node_visitor import (
 )
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
+    validate_same_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from torch.fx import Node
@@ -51,6 +52,7 @@ class SliceVisitor_080(NodeVisitor):
         import tosa_tools.v0_80.serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, [4, 5])
+        validate_same_dtype(self.target, [inputs[0], output])
 
         # See slice_copy_support.py
         if not (len(inputs) == 4 or (len(inputs) == 5 and inputs[4].number == 1)):
@@ -113,6 +115,7 @@ class SliceVisitor(NodeVisitor):
         import serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, [4, 5])
+        validate_same_dtype(self.target, [inputs[0], output])
 
         # See slice_copy_support.py
         if not (len(inputs) == 4 or (len(inputs) == 5 and inputs[4].number == 1)):

--- a/backends/arm/operators/op_sub.py
+++ b/backends/arm/operators/op_sub.py
@@ -16,6 +16,7 @@ from executorch.backends.arm.operators.node_visitor import (
 )
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
+    validate_same_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
@@ -44,15 +45,7 @@ class SubVisitor_080_BI(NodeVisitor):
         import tosa_tools.v0_80.serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 2)
-
-        # Specification (0.80) states that input and output types
-        # should all be the same
-        if inputs[0].dtype != inputs[1].dtype or inputs[0].dtype != output.dtype:
-            raise TypeError(
-                f"All IO needs to have the same data type, got input 1: "
-                f"{inputs[0].dtype}, input 2: {inputs[1].dtype} and output: "
-                f"{output.dtype}"
-            )
+        validate_same_dtype(self.target, [*inputs, output])
 
         # Handle int8 (quantized) and int32
         supported_dtypes = [ts.DType.INT8, ts.DType.INT32]
@@ -119,15 +112,7 @@ class SubVisitor_080_MI(SubVisitor_080_BI):
         import tosa_tools.v0_80.serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 2)
-
-        # Specification (0.80) states that input and output types
-        # should all be the same
-        if inputs[0].dtype != inputs[1].dtype or inputs[0].dtype != output.dtype:
-            raise TypeError(
-                f"All IO needs to have the same data type, got input 1: "
-                f"{inputs[0].dtype}, input 2: {inputs[1].dtype} and output: "
-                f"{output.dtype}"
-            )
+        validate_same_dtype(self.target, [*inputs, output])
 
         if inputs[0].dtype in [ts.DType.INT8, ts.DType.INT32]:
             # Call the inherited define_node for handling integers
@@ -175,10 +160,8 @@ class SubVisitor_INT(NodeVisitor):
         import serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 2)
+        validate_same_dtype(self.target, [*inputs, output])
 
-        # Specification (1.0) states that input and output types
-        # should all be the same
-        assert inputs[0].dtype == inputs[1].dtype == output.dtype
         # Handle int8 (quantized) and int32
         assert inputs[0].dtype in [ts.DType.INT8, ts.DType.INT32]
 
@@ -238,10 +221,7 @@ class SubVisitor_FP(SubVisitor_INT):
         import serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 2)
-
-        # Specification (1.0) states that input and output types
-        # should all be the same
-        assert inputs[0].dtype == inputs[1].dtype == output.dtype
+        validate_same_dtype(self.target, [*inputs, output])
 
         if inputs[0].dtype in [ts.DType.INT8, ts.DType.INT32]:
             # Call the inherited define_node for handling integers

--- a/backends/arm/operators/op_sum.py
+++ b/backends/arm/operators/op_sum.py
@@ -16,6 +16,7 @@ from executorch.backends.arm.operators.node_visitor import (
 )
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
+    validate_same_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
@@ -44,6 +45,7 @@ class SumVisitor_080_BI(NodeVisitor):
         import tosa_tools.v0_80.serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 3)
+        validate_same_dtype(self.target, [inputs[0], output])
 
         tensor = inputs[0]
         input_shape = list(tensor.shape)
@@ -98,6 +100,9 @@ class SumVisitor_080_MI(SumVisitor_080_BI):
 
         import tosa_tools.v0_80.serializer.tosa_serializer as ts  # type: ignore
 
+        validate_num_inputs(self.target, inputs, 3)
+        validate_same_dtype(self.target, [inputs[0], output])
+
         if inputs[0].dtype == ts.DType.INT8:
             return super().define_node(node, tosa_graph, inputs, output)
 
@@ -143,6 +148,7 @@ class SumVisitor_INT(NodeVisitor):
         import serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 3)
+        validate_same_dtype(self.target, [inputs[0], output])
 
         tensor = inputs[0]
         input_shape = list(tensor.shape)
@@ -196,6 +202,7 @@ class SumVisitor_FP(SumVisitor_INT):
         import serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 3)
+        validate_same_dtype(self.target, [inputs[0], output])
 
         tensor = inputs[0]
         input_shape = list(tensor.shape)

--- a/backends/arm/operators/op_tanh.py
+++ b/backends/arm/operators/op_tanh.py
@@ -12,6 +12,7 @@ from executorch.backends.arm.operators.node_visitor import (
 )
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
+    validate_same_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
@@ -39,6 +40,7 @@ class TanhVisitor_0_80_MI(NodeVisitor):
         import tosa_tools.v0_80.serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 1)
+        validate_same_dtype(self.target, [*inputs, output])
 
         if inputs[0].dtype != ts.DType.FP32 or output.dtype != ts.DType.FP32:
             raise ValueError(
@@ -69,6 +71,7 @@ class TanhVisitor(NodeVisitor):
         import serializer.tosa_serializer as ts
 
         validate_num_inputs(self.target, inputs, 1)
+        validate_same_dtype(self.target, [*inputs, output])
 
         if inputs[0].dtype != ts.DType.FP32 or output.dtype != ts.DType.FP32:
             raise ValueError(

--- a/backends/arm/operators/op_transpose.py
+++ b/backends/arm/operators/op_transpose.py
@@ -15,6 +15,7 @@ from executorch.backends.arm.operators.node_visitor import (
 )
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
+    validate_same_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 
@@ -41,6 +42,7 @@ class TransposeVisitor_0_80(NodeVisitor):
         import tosa_tools.v0_80.serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 2)
+        validate_same_dtype(self.target, [inputs[0], output])
 
         output_rank = len(output.shape)
         perms = [dim % output_rank for dim in inputs[1].special]
@@ -73,6 +75,7 @@ class TransposeVisitor(NodeVisitor):
         import serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 2)
+        validate_same_dtype(self.target, [inputs[0], output])
 
         output_rank = len(output.shape)
         perms = [dim % output_rank for dim in inputs[1].special]

--- a/backends/arm/operators/op_upsample_bilinear2d.py
+++ b/backends/arm/operators/op_upsample_bilinear2d.py
@@ -14,6 +14,7 @@ from executorch.backends.arm.operators.node_visitor import (
 )
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
+    validate_same_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_quant_utils import build_rescale, build_rescale_v0_80
@@ -40,6 +41,7 @@ class UpsampleBilinear2dVisitor_0_80(NodeVisitor):
         from tosa_tools.v0_80.tosa.ResizeMode import ResizeMode  # type: ignore
 
         validate_num_inputs(self.target, inputs, 4)
+        validate_same_dtype(self.target, [inputs[0], output])
 
         if inputs[0].shape is None or output.shape is None:
             raise ValueError("Only static shapes are supported")
@@ -129,6 +131,7 @@ class UpsampleBilinear2dVisitor(NodeVisitor):
         from tosa.RoundingMode import RoundingMode  # type: ignore
 
         validate_num_inputs(self.target, inputs, 4)
+        validate_same_dtype(self.target, [inputs[0], output])
 
         if inputs[0].shape is None or output.shape is None:
             raise ValueError("Only static shapes are supported")

--- a/backends/arm/operators/op_upsample_nearest2d.py
+++ b/backends/arm/operators/op_upsample_nearest2d.py
@@ -14,6 +14,7 @@ from executorch.backends.arm.operators.node_visitor import (
 )
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
+    validate_same_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_utils import get_resize_parameters, tosa_shape
@@ -40,6 +41,7 @@ class UpsampleNearest2dVisitor_0_80(NodeVisitor):
         import tosa_tools.v0_80.serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 3)
+        validate_same_dtype(self.target, [inputs[0], output])
 
         if inputs[0].shape is None or output.shape is None:
             raise ValueError("Only static shapes are supported")
@@ -98,6 +100,7 @@ class UpsampleNearest2dVisitor(NodeVisitor):
         import serializer.tosa_serializer as ts
 
         validate_num_inputs(self.target, inputs, 3)
+        validate_same_dtype(self.target, [inputs[0], output])
 
         assert (
             inputs[0].shape is not None and output.shape is not None

--- a/backends/arm/operators/op_view.py
+++ b/backends/arm/operators/op_view.py
@@ -14,6 +14,7 @@ from executorch.backends.arm.operators.node_visitor import (
 )
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
+    validate_same_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_utils import tosa_shape
@@ -38,6 +39,7 @@ class ViewVisitor_0_80(NodeVisitor):
         import tosa_tools.v0_80.serializer.tosa_serializer as ts
 
         validate_num_inputs(self.target, inputs, 2)
+        validate_same_dtype(self.target, [inputs[0], output])
 
         attr = ts.TosaSerializerAttribute()
         new_shape = tosa_shape(inputs[1].special, output.dim_order)
@@ -67,6 +69,7 @@ class ViewVisitor(NodeVisitor):
         import serializer.tosa_serializer as ts
 
         validate_num_inputs(self.target, inputs, 2)
+        validate_same_dtype(self.target, [inputs[0], output])
 
         tosa_graph = cast(ts.TosaSerializer, tosa_graph)
 

--- a/backends/arm/operators/op_where.py
+++ b/backends/arm/operators/op_where.py
@@ -12,6 +12,7 @@ from executorch.backends.arm.operators.node_visitor import (
 
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
+    validate_same_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
@@ -39,14 +40,11 @@ class WhereVisitor_0_80_BI(NodeVisitor):
         import tosa_tools.v0_80.serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 3)
+        # Not first input, which is condition tensor.
+        validate_same_dtype(self.target, inputs[1:])
 
         if inputs[0].dtype is not ts.DType.BOOL:
             raise ValueError("Input 0 needs to have dtype BOOL")
-        if inputs[1].dtype != inputs[2].dtype:
-            raise ValueError(
-                "Non-condition tensors must have same data type, got "
-                f"{inputs[1].dtype} and {inputs[2].dtype}"
-            )
         for input_ in inputs[1:]:
             if input_.dtype not in supported_dtypes:
                 raise ValueError(
@@ -129,14 +127,11 @@ class WhereVisitor_INT(NodeVisitor):
         import serializer.tosa_serializer as ts
 
         validate_num_inputs(self.target, inputs, 3)
+        # Not first input, which is condition tensor.
+        validate_same_dtype(self.target, inputs[1:])
 
         if inputs[0].dtype is not ts.DType.BOOL:
             raise ValueError("Input 0 needs to have dtype BOOL")
-        if inputs[1].dtype != inputs[2].dtype:
-            raise ValueError(
-                "Non-condition tensors must have same data type, got "
-                f"{inputs[1].dtype} and {inputs[2].dtype}"
-            )
         for input_ in inputs[1:]:
             if input_.dtype not in supported_dtypes:
                 raise ValueError(

--- a/backends/arm/operators/operator_validation_utils.py
+++ b/backends/arm/operators/operator_validation_utils.py
@@ -41,7 +41,6 @@ def validate_num_inputs(op_name: str, inputs: List[Any], expected: int | List[in
     )
 
     validate_num_inputs(self.target, inputs, [3, 4])
-
     """
     if isinstance(expected, int):
         expected = [expected]
@@ -51,3 +50,52 @@ def validate_num_inputs(op_name: str, inputs: List[Any], expected: int | List[in
             f"{op_name}: Expected number of input(s) to be "
             f"[{expected_str}], got {len(inputs)}"
         )
+
+
+def validate_same_dtype(op_name: str, tensors: List[Any]):
+    """
+    Validates that all given tensors have the same dtype attribute.
+
+    This function checks whether all items in the `tensors` list have the same
+    `dtype` as the first item.
+
+    Parameters:
+    -----------
+    op_name : str
+        The name of the operation for which the dtype validation is being performed.
+        Used in the error message to provide context.
+
+    tensors : List[Any]
+        A list of tensors to be validated, each is assumed to have a `dtype` attribute.
+
+    Raises:
+    -------
+    ValueError
+        If the dtype of any item in the list does not match the dtype of the first item,
+        a `ValueError` is raised with a message indicating the operation name and the
+        mismatch in dtypes.
+
+    Example:
+    --------
+    # Example usage:
+    from executorch.backends.arm.operators.operator_validation_utils import (
+        validate_same_dtype,
+    )
+
+    validate_same_dtype(self.target, [input1, input2, output])
+
+    """
+    if not tensors:
+        raise ValueError(
+            f"{op_name}: Input tensor list is empty, cannot validate dtypes"
+        )
+
+    # Get dtype of the first tensor to reference for comparison
+    reference_dtype = tensors[0].dtype
+
+    for tensor in tensors:
+        if tensor.dtype != reference_dtype:
+            raise ValueError(
+                f"{op_name}: Expected all tensors to have dtype {reference_dtype}, but "
+                f"found inconsistent dtype {tensor.dtype}."
+            )

--- a/backends/arm/operators/ops_binary.py
+++ b/backends/arm/operators/ops_binary.py
@@ -16,6 +16,7 @@ from executorch.backends.arm.operators.node_visitor import (
 )
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
+    validate_same_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 
@@ -37,12 +38,7 @@ def binary_operator_factory_0_80(bw_target: str, tosa_op):
             import tosa_tools.v0_80.serializer.tosa_serializer as ts  # type: ignore  # noqa: F401
 
             validate_num_inputs(self.target, inputs, 2)
-
-            if not (inputs[0].dtype == inputs[1].dtype == output.dtype):
-                raise ValueError(
-                    "All inputs and outputs need same dtype."
-                    f"Got {inputs[0].dtype=}, {inputs[1].dtype=}, {output.dtype=}."
-                )
+            validate_same_dtype(self.target, [*inputs, output])
 
             tosa_graph.addOperator(
                 tosa_op, [inputs[0].name, inputs[1].name], [output.name]
@@ -68,12 +64,7 @@ def binary_operator_factory(bw_target: str, tosa_op):
             import serializer.tosa_serializer as ts  # type: ignore  # noqa: F401
 
             validate_num_inputs(self.target, inputs, 2)
-
-            if not (inputs[0].dtype == inputs[1].dtype == output.dtype):
-                raise ValueError(
-                    "All inputs and outputs need same dtype."
-                    f"Got {inputs[0].dtype=}, {inputs[1].dtype=}, {output.dtype=}."
-                )
+            validate_same_dtype(self.target, [*inputs, output])
 
             tosa_graph.addOperator(
                 tosa_op, [inputs[0].name, inputs[1].name], [output.name]

--- a/backends/arm/operators/ops_identity.py
+++ b/backends/arm/operators/ops_identity.py
@@ -16,6 +16,7 @@ from executorch.backends.arm.operators.node_visitor import (
 )
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
+    validate_same_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 
@@ -41,6 +42,7 @@ def identity_operator_factory_v0_80(identity_target: str):
             import tosa_tools.v0_80.serializer.tosa_serializer as ts
 
             validate_num_inputs(self.target, inputs, 1)
+            validate_same_dtype(self.target, [*inputs, output])
 
             # Simply add an identityOp
             tosa_graph.addOperator(
@@ -75,6 +77,7 @@ def identity_operator_factory(identity_target: str):
             import serializer.tosa_serializer as ts
 
             validate_num_inputs(self.target, inputs, 1)
+            validate_same_dtype(self.target, [*inputs, output])
 
             # Simply add an identityOp
             tosa_graph.addOperator(

--- a/backends/arm/operators/ops_unary.py
+++ b/backends/arm/operators/ops_unary.py
@@ -14,6 +14,7 @@ from executorch.backends.arm.operators.node_visitor import (
 )
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
+    validate_same_dtype,
 )
 
 from executorch.backends.arm.tosa_mapping import TosaArg
@@ -42,12 +43,7 @@ def unary_operator_factory_0_80(unary_target: str, tosa_op):
             import tosa_tools.v0_80.serializer.tosa_serializer as ts  # type: ignore  # noqa: F401
 
             validate_num_inputs(self.target, inputs, 1)
-
-            if not (inputs[0].dtype == output.dtype):
-                raise ValueError(
-                    "All inputs and output need same dtype."
-                    f"Got {inputs[0].dtype=}, {output.dtype=}"
-                )
+            validate_same_dtype(self.target, [*inputs, output])
 
             if self.target in fp_only_ops and not (inputs[0].dtype == ts.DType.FP32):
                 raise ValueError(
@@ -82,12 +78,7 @@ def unary_operator_factory(unary_target: str, tosa_op):
             import serializer.tosa_serializer as ts  # type: ignore  # noqa: F401
 
             validate_num_inputs(self.target, inputs, 1)
-
-            if not (inputs[0].dtype == output.dtype):
-                raise ValueError(
-                    "All inputs and output need same dtype."
-                    f"Got {inputs[0].dtype=}, {output.dtype=}"
-                )
+            validate_same_dtype(self.target, [*inputs, output])
 
             if self.target in fp_only_ops and not (inputs[0].dtype == ts.DType.FP32):
                 raise ValueError(


### PR DESCRIPTION
When applicable, check that the data types of inputs to a given operator are the same.


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218