### PR TITLE
fix Swift compiler assert (#10874)

### DIFF
--- a/extension/apple/ExecuTorch/Exported/ExecuTorchValue.h
+++ b/extension/apple/ExecuTorch/Exported/ExecuTorchValue.h
@@ -34,8 +34,7 @@ typedef NSNumber *ExecuTorchScalarValue
     NS_SWIFT_BRIDGED_TYPEDEF NS_SWIFT_NAME(ScalarValue);
 typedef NSString *ExecuTorchStringValue
     NS_SWIFT_BRIDGED_TYPEDEF NS_SWIFT_NAME(StringValue);
-typedef BOOL ExecuTorchBooleanValue
-    NS_SWIFT_BRIDGED_TYPEDEF NS_SWIFT_NAME(BoolValue);
+typedef BOOL ExecuTorchBooleanValue NS_SWIFT_NAME(BoolValue);
 typedef NSInteger ExecuTorchIntegerValue
     NS_SWIFT_BRIDGED_TYPEDEF NS_SWIFT_NAME(IntegerValue);
 typedef double ExecuTorchDoubleValue


### PR DESCRIPTION
Summary:

Asserts toolchains are crashing on compiling this header:
```
(struct_type decl="ObjectiveC.(file).ObjCBool")
(type_alias_type decl="ExecuTorch.(file).BoolValue@/ExecuTorch/ExecuTorchValue.h:37:14"
  (underlying=struct_type decl="Swift.(file).Bool"))
swift-frontend: swift/lib/ClangImporter/ImportType.cpp:928: ImportResult (anonymous namespace)::SwiftTypeConverter::VisitTypedefType(const clang::TypedefType *): Assertion `underlyingResult.AbstractType->isEqual(mappedType) && "typedef without special typedef kind was mapped " "differently from its underlying type?"' failed.
```
Remove `NS_SWIFT_BRIDGED_TYPEDEF` to mitigate.

Reviewed By: shoumikhin, AdamCmiel

Differential Revision: D74737507


