### PR TITLE
Use the built-in notify crate for OSS Buck

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -39,6 +39,7 @@
 
 [buck2]
 restarter=true
+file_watcher=notify
 
 [oss]
 folly_cxx_tests = False


### PR DESCRIPTION
Facilitate internal builds so that it doesn't try to use edenfs and fail with:

```bash
Error initializing DaemonStateData

Caused by:
    0: Error creating a FileWatcher for project root ~/executorch
    1: Invalid buck2.file_watcher: edenfs
```