### PR TITLE
Arm backend: increase atol, rtol to tosa_BI test in test_unary.py

### DIFF
--- a/backends/arm/test/ops/test_unary.py
+++ b/backends/arm/test/ops/test_unary.py
@@ -116,6 +116,8 @@ def test_unary_tosa_BI(test_data: input_t1):
         (test_data,),
         module.aten_op,
         module.exir_op,
+        atol=0.06,
+        rtol=0.01,
     )
     pipeline.run()
 


### PR DESCRIPTION
The patch solves the problem of flaky tosa_BI test in test_unary.py by increasing the atol and rtol.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218