### PR TITLE
Broadcast implementation in quantized_add

### DIFF
--- a/backends/cadence/aot/ops_registrations.py
+++ b/backends/cadence/aot/ops_registrations.py
@@ -334,10 +334,9 @@ def quantized_add_meta(
     out_scale: float,
     out_zero_point: int,
 ) -> torch.Tensor:
-    out_size = X.size()
-    if list(X.size()) == [1]:
-        out_size = Y.size()
 
+    # Determine output shape by broadcasting X and Y
+    out_size = torch.broadcast_shapes(X.size(), Y.size())
     return X.new_empty(out_size, dtype=X.dtype)
 
 
@@ -352,10 +351,8 @@ def quantized_add_per_tensor_meta(
     out_scale: float,
     out_zero_point: int,
 ) -> torch.Tensor:
-    out_size = X.size()
-    if list(X.size()) == [1]:
-        out_size = Y.size()
 
+    out_size = torch.broadcast_shapes(X.size(), Y.size())
     return X.new_empty(out_size, dtype=X.dtype)
 
 


### PR DESCRIPTION
Summary:
This implementation introduces broadcast support in quantized_add by doing the following steps:

1) Compute the output tensor's shape using `torch.broadcast_shapes`
2) Implement the stride and offset logic for indexing into X and Y when using broadcast
3) Adds new tests for broadcast in quantized_add

Differential Revision: D74773433


