### PR TITLE
Default CMAKE_SYSTEM_PROCESSOR to the host

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,11 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 announce_configured_options(CMAKE_CXX_STANDARD)
 
+if(NOT CMAKE_SYSTEM_PROCESSOR)
+  set(CMAKE_SYSTEM_PROCESSOR ${CMAKE_HOST_SYSTEM_PROCESSOR})
+endif()
+announce_configured_options(CMAKE_SYSTEM_PROCESSOR)
+
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Debug)
 endif()


### PR DESCRIPTION
### Summary

Although by default cmake use the host's architecture if `CMAKE_SYSTEM_PROCESSOR` isn't provided, it doesn't actually set the value. This can be an issue in cases where people try to read this value (i.e. [extension/llm/custom_ops/CMakeLists.txt](https://github.com/pytorch/executorch/blob/0a6f6220dd7252f5b79bf7b33edf1ea0631158f3/extension/llm/custom_ops/CMakeLists.txt#L52-L66)). So, let's just explicitly set it.

### Test plan

CI

cc @larryliu0820