### PR TITLE
Fix libflatccrt race

### DIFF
--- a/.ci/scripts/build-qnn-sdk.sh
+++ b/.ci/scripts/build-qnn-sdk.sh
@@ -11,17 +11,12 @@ set -o xtrace
 
 build_qnn_backend() {
   echo "Start building qnn backend."
-  export ANDROID_NDK_ROOT=/opt/ndk
-  export QNN_SDK_ROOT=/tmp/qnn/2.28.0.241029
+  export ANDROID_NDK_ROOT=${ANDROID_NDK_ROOT:-/opt/ndk}
+  export QNN_SDK_ROOT=${QNN_SDK_ROOT:-/tmp/qnn/2.28.0.241029}
   export EXECUTORCH_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
 
-  # Workaround to avoid issues around missing flatccrt library (depending on the
-  # number of jobs used), see issue #7300:
-  # Build twice (second time with `--no_clean`) to make sure libflatccrt.a is
-  # available.
-  # TODO: Remove this workaround once the underlying issue is fixed.
-  bash backends/qualcomm/scripts/build.sh --skip_aarch64 --job_number 2 --release || \
-  bash backends/qualcomm/scripts/build.sh --skip_aarch64 --job_number 2 --release --no_clean
+  parallelism=$(( $(nproc) - 1 ))
+  bash backends/qualcomm/scripts/build.sh --skip_aarch64 --job_number ${parallelism} --release
 }
 
 set_up_aot() {

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -582,6 +582,7 @@ if(EXECUTORCH_BUILD_PYBIND)
       ${TORCH_PYTHON_LIBRARY}
       bundled_program
       etdump
+      flatccrt
       executorch
       extension_data_loader
       util

--- a/examples/apple/mps/CMakeLists.txt
+++ b/examples/apple/mps/CMakeLists.txt
@@ -98,12 +98,6 @@ if(NOT CMAKE_TOOLCHAIN_FILE MATCHES ".*(iOS|ios\.toolchain)\.cmake$")
   add_executable(mps_executor_runner ${_mps_executor_runner__srcs})
 
   if(CMAKE_BUILD_TYPE MATCHES "Debug")
-    set(FLATCC_LIB flatccrt_d)
-  else()
-    set(FLATCC_LIB flatccrt)
-  endif()
-
-  if(CMAKE_BUILD_TYPE MATCHES "Debug")
     target_link_options(mps_executor_runner PUBLIC -fsanitize=undefined)
   endif()
 
@@ -113,7 +107,7 @@ if(NOT CMAKE_TOOLCHAIN_FILE MATCHES ".*(iOS|ios\.toolchain)\.cmake$")
     executorch
     gflags
     etdump
-    ${FLATCC_LIB}
+    flatccrt
     mpsdelegate
     mps_portable_ops_lib
     ${mps_executor_runner_libs}

--- a/examples/arm/executor_runner/CMakeLists.txt
+++ b/examples/arm/executor_runner/CMakeLists.txt
@@ -583,22 +583,16 @@ if(EXECUTORCH_ENABLE_EVENT_TRACER)
             "${ET_BUILD_DIR_PATH}/lib/libetdump.a"
   )
 
-  if(CMAKE_BUILD_TYPE MATCHES "Debug")
-    set(FLATCCRT_LIB flatccrt_d)
-  else()
-    set(FLATCCRT_LIB flatccrt)
-  endif()
-
-  add_library(${FLATCCRT_LIB} STATIC IMPORTED)
+  add_library(flatccrt STATIC IMPORTED)
   set_property(
-      TARGET ${FLATCCRT_LIB}
+      TARGET flatccrt
       PROPERTY IMPORTED_LOCATION
-            "${ET_BUILD_DIR_PATH}/lib/lib${FLATCCRT_LIB}.a"
+            "${ET_BUILD_DIR_PATH}/lib/libflatccrt.a"
   )
 
   list(APPEND arm_executor_runner_link
     etdump
-    ${FLATCCRT_LIB}
+    flatccrt
   )
 endif()
 

--- a/examples/qualcomm/executor_runner/CMakeLists.txt
+++ b/examples/qualcomm/executor_runner/CMakeLists.txt
@@ -20,7 +20,7 @@ target_include_directories(
 )
 target_link_libraries(
   qnn_executor_runner qnn_executorch_backend full_portable_ops_lib etdump
-  ${FLATCCRT_LIB} gflags
+  flatccrt gflags
 )
 set_target_properties(
   qnn_executor_runner PROPERTIES LINK_FLAGS "-Wl,-rpath='$ORIGIN'"

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -68,6 +68,7 @@ ExternalProject_Add(
              -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=${CMAKE_OSX_DEPLOYMENT_TARGET}
   BUILD_BYPRODUCTS <INSTALL_DIR>/bin/flatcc
 )
+file(REMOVE_RECURSE ${PROJECT_SOURCE_DIR}/third-party/flatcc/lib)
 ExternalProject_Get_Property(flatcc_external_project INSTALL_DIR)
 add_executable(flatcc_cli IMPORTED GLOBAL)
 add_dependencies(flatcc_cli flatcc_external_project)
@@ -83,6 +84,11 @@ set(FLATCC_REFLECTION OFF CACHE BOOL "")
 set(FLATCC_DEBUG_CLANG_SANITIZE OFF CACHE BOOL "")
 set(FLATCC_INSTALL OFF CACHE BOOL "")
 add_subdirectory(flatcc)
+# Unfortunately flatcc writes libs directly in to the source tree [1]. So to
+# ensure the target lib is created last, force flatcc_cli to build first.
+#
+# [1] https://github.com/dvidelabs/flatcc/blob/896db54787e8b730a6be482c69324751f3f5f117/CMakeLists.txt#L168
+add_dependencies(flatccrt flatcc_cli)
 # Fix for "relocation R_X86_64_32 against `.rodata' can not be used when making
 # a shared object; recompile with -fPIC" when building on some x86 linux
 # systems.

--- a/tools/cmake/executorch-config.cmake
+++ b/tools/cmake/executorch-config.cmake
@@ -56,18 +56,12 @@ set(EXECUTORCH_FOUND ON)
 
 target_link_libraries(executorch INTERFACE executorch_core)
 
-if(CMAKE_BUILD_TYPE MATCHES "Debug")
-  set(FLATCCRT_LIB flatccrt_d)
-else()
-  set(FLATCCRT_LIB flatccrt)
-endif()
-
 set(lib_list
+    flatccrt
     etdump
     bundled_program
     extension_data_loader
     extension_flat_tensor
-    ${FLATCCRT_LIB}
     coreml_util
     coreml_inmemoryfs
     coremldelegate
@@ -152,6 +146,10 @@ if(TARGET coremldelegate)
     coremldelegate PROPERTIES INTERFACE_LINK_LIBRARIES
                               "coreml_inmemoryfs;coreml_util"
   )
+endif()
+
+if(TARGET etdump)
+  set_target_properties(etdump PROPERTIES INTERFACE_LINK_LIBRARIES "flatccrt;executorch")
 endif()
 
 if(TARGET optimized_native_cpu_ops_lib)


### PR DESCRIPTION
### Summary

Seems like there is a race in building `libflatccrt.a`. This issue has existed for a while: https://github.com/pytorch/executorch/issues/7300. It was temporarily mitigated in https://github.com/pytorch/executorch/pull/7570 by just reducing the parallelism. 

In this diff I attempt to fix it. This is just my assumption of what is wrong. Given flatccrt builds a debug version with a `_d` suffix, if the target isn't depended on (i.e. some target don't use the conditional target name) then the order of how the lib is built causes a race. So for now, always use the non-debug version.

Given it's a race, I was never able to repro the issue locally — I can't guarantee this is the problem. However, it seems my recent changes in https://github.com/pytorch/executorch/pull/10855 has increased the frequency of the problem in CI.  

### Test plan

CI

cc @larryliu0820