### PR TITLE
Create a pybind preset

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -15,6 +15,7 @@
     },
     {
       "name": "macos-arm64",
+      "displayName": "Build everything buildable on macOS arm64",
       "inherits": ["common"],
       "generator": "Xcode",
       "cacheVariables": {
@@ -27,6 +28,20 @@
         "lhs": "${hostSystemName}",
         "type": "equals",
         "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "pybind",
+      "displayName": "Build pybindings exported in the wheel",
+      "inherits": ["common"],
+      "cacheVariables": {
+        "EXECUTORCH_BUILD_PRESET_FILE": "${sourceDir}/tools/cmake/preset/pybind.cmake",
+        "CMAKE_OSX_DEPLOYMENT_TARGET": "10.15"
+      },
+      "condition": {
+        "type": "inList",
+        "string": "${hostSystemName}",
+        "list": ["Darwin", "Linux", "Windows"]
       }
     }
   ]

--- a/backends/xnnpack/CMakeLists.txt
+++ b/backends/xnnpack/CMakeLists.txt
@@ -25,24 +25,6 @@ endif()
 
 include(${EXECUTORCH_ROOT}/tools/cmake/Utils.cmake)
 
-# NB: Enabling this will serialize execution of delegate instances Keeping this
-# OFF by default to maintain existing behavior, to be revisited.
-option(EXECUTORCH_XNNPACK_SHARED_WORKSPACE
-       "Enable workspace sharing across different delegate instances" ON
-)
-# Keeping this OFF by default due to regressions in decode and model load with
-# kleidi kernels
-option(EXECUTORCH_XNNPACK_ENABLE_KLEIDI "Enable Arm Kleidi kernels" OFF)
-
-# Turning this on cache weights between partitions and methods. If weights
-# are shared across methods/partitions then this can reduce load time and
-# memory usage
-
-# Keeping this off maintains existing behavior. Turning this on serializes
-# execution and initialization of delegates, to be revisited
-option(EXECUTORCH_XNNPACK_ENABLE_WEIGHT_CACHE
-        "Enable weights cache to cache and manage all packed weights" OFF)
-
 if(EXECUTORCH_XNNPACK_ENABLE_WEIGHT_CACHE)
   add_definitions(-DENABLE_XNNPACK_WEIGHTS_CACHE)
 endif()

--- a/kernels/quantized/CMakeLists.txt
+++ b/kernels/quantized/CMakeLists.txt
@@ -10,10 +10,6 @@
 # ~~~
 cmake_minimum_required(VERSION 3.19)
 
-option(EXECUTORCH_BUILD_KERNELS_QUANTIZED_AOT
-       "Build the optimized ops library for AOT export usage" OFF
-)
-
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)
@@ -91,7 +87,13 @@ if(NOT CMAKE_GENERATOR STREQUAL "Xcode"
     # pybindings.
     if(TARGET portable_lib)
       add_library(quantized_pybind_kernels_lib ${_quantized_kernels__srcs})
-      target_link_libraries(quantized_pybind_kernels_lib PRIVATE portable_lib)
+      target_link_libraries(
+        quantized_pybind_kernels_lib
+        PRIVATE
+          portable_lib
+          executorch_core
+          kernels_util_all_deps
+      )
       target_compile_options(
         quantized_pybind_kernels_lib PUBLIC ${_common_compile_options}
       )

--- a/runtime/executor/test/CMakeLists.txt
+++ b/runtime/executor/test/CMakeLists.txt
@@ -148,6 +148,7 @@ et_cxx_test(
   portable_kernels
   extension_data_loader
   extension_runner_util
+  program_schema
 )
 add_dependencies(tensor_parser_test generated_pte_files)
 set_property(TEST tensor_parser_test PROPERTY ENVIRONMENT ${test_env})

--- a/tools/cmake/preset/default.cmake
+++ b/tools/cmake/preset/default.cmake
@@ -75,6 +75,11 @@ define_overridable_option(
   BOOL OFF
 )
 define_overridable_option(
+  EXECUTORCH_BUILD_KERNELS_QUANTIZED_AOT
+  "Build the optimized ops library for AOT export usage"
+  BOOL OFF
+)
+define_overridable_option(
   EXECUTORCH_BUILD_EXTENSION_DATA_LOADER
   "Build the Data Loader extension"
   BOOL OFF
@@ -107,6 +112,11 @@ define_overridable_option(
 define_overridable_option(
   EXECUTORCH_BUILD_EXTENSION_TRAINING
   "Build the training extension"
+  BOOL OFF
+)
+define_overridable_option(
+  EXECUTORCH_BUILD_EXTENSION_APPLE
+  "Build the Apple extension"
   BOOL OFF
 )
 define_overridable_option(
@@ -227,11 +237,39 @@ define_overridable_option(
 set(_default_executorch_build_executor_runner ON)
 if(APPLE AND "${SDK_NAME}" STREQUAL "iphoneos")
   set(_default_executorch_build_executor_runner OFF)
+elseif(DEFINED EXECUTORCH_BUILD_PRESET_FILE)
+  set(_default_executorch_build_executor_runner OFF)
 endif()
 define_overridable_option(
   EXECUTORCH_BUILD_EXECUTOR_RUNNER
   "Build the executor_runner executable"
   BOOL ${_default_executorch_build_executor_runner}
+)
+
+# NB: Enabling this will serialize execution of delegate instances Keeping this
+# OFF by default to maintain existing behavior, to be revisited.
+define_overridable_option(
+  EXECUTORCH_XNNPACK_SHARED_WORKSPACE
+  "Enable workspace sharing across different delegate instances"
+  BOOL ON
+)
+# Keeping this OFF by default due to regressions in decode and model load with
+# kleidi kernels
+define_overridable_option(
+  EXECUTORCH_XNNPACK_ENABLE_KLEIDI
+  "Enable Arm Kleidi kernels"
+  BOOL OFF
+)
+# Turning this on cache weights between partitions and methods. If weights
+# are shared across methods/partitions then this can reduce load time and
+# memory usage
+#
+# Keeping this off maintains existing behavior. Turning this on serializes
+# execution and initialization of delegates, to be revisited
+define_overridable_option(
+  EXECUTORCH_XNNPACK_ENABLE_WEIGHT_CACHE
+  "Enable weights cache to cache and manage all packed weights"
+  BOOL OFF
 )
 
 # MARK: - Validations

--- a/tools/cmake/preset/pybind.cmake
+++ b/tools/cmake/preset/pybind.cmake
@@ -1,0 +1,30 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+set_overridable_option(EXECUTORCH_BUILD_PYBIND ON)
+set_overridable_option(EXECUTORCH_BUILD_KERNELS_QUANTIZED ON)
+set_overridable_option(EXECUTORCH_BUILD_KERNELS_QUANTIZED_AOT ON)
+# Enable logging even when in release mode. We are building for desktop, where
+# saving a few kB is less important than showing useful error information to
+# users.
+set_overridable_option(EXECUTORCH_ENABLE_LOGGING ON)
+set_overridable_option(EXECUTORCH_LOG_LEVEL Info)
+set_overridable_option(EXECUTORCH_BUILD_XNNPACK ON)
+set_overridable_option(EXECUTORCH_BUILD_EXTENSION_TENSOR ON)
+set_overridable_option(EXECUTORCH_BUILD_EXTENSION_RUNNER_UTIL ON)
+set_overridable_option(EXECUTORCH_BUILD_KERNELS_CUSTOM ON)
+set_overridable_option(EXECUTORCH_BUILD_KERNELS_CUSTOM_AOT ON)
+
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+  set_overridable_option(EXECUTORCH_BUILD_COREML ON)
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  # Linux-specific code here
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows" OR CMAKE_SYSTEM_NAME STREQUAL "WIN32")
+  # Windows or other OS-specific code here
+else()
+  message(FATAL_ERROR "Unsupported CMAKE_SYSTEM_NAME for pybind: ${CMAKE_SYSTEM_NAME}")
+endif()


### PR DESCRIPTION
### Summary

In this diff we create a `pybind` preset that is copied with configurations from [setup.py](https://github.com/pytorch/executorch/blob/7175ca420dc5a173f8635da976457bf6f17bbbc1/setup.py). In upcoming diffs, we will completely gut setup.py and point directly to this preset.

### Test plan

```
$ cmake --list-presets
Available configure presets:

  "macos-arm64"  - Build everything buildable on macOS arm64
  "pybind" - Build pybindings exported in the wheel
```
```
$ cmake --preset pybind && cmake --build cmake-out --parallel
```

cc @larryliu0820