### PR TITLE
Fix Windows build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -835,7 +835,7 @@ def get_ext_modules() -> List[Extension]:
 
     ext_modules = [
         BuiltFile(
-            src_dir="%CMAKE_CACHE_DIR%/third-party/flatbuffers_external_project/bin/%BUILD_TYPE%/",
+            src_dir="%CMAKE_CACHE_DIR%/third-party/flatbuffers_external_project/bin/",
             src_name="flatc",
             dst="executorch/data/bin/",
             is_executable=True,

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -7,14 +7,19 @@
 
 # MARK: - flatbuffers
 
+if(WIN32)
+  set(_executorch_external_project_additional_args)
+else()
+  # Always use Make to avoid needing to codesign flatc if the project is using Xcode.
+  set(_executorch_external_project_additional_args CMAKE_GENERATOR "Unix Makefiles")
+endif()
+
 # We use ExternalProject to build flatc from source to force it target the host.
 # Otherwise, flatc will target the project's toolchain (i.e. iOS, or Android).
 ExternalProject_Add(
   flatbuffers_external_project
   PREFIX ${CMAKE_CURRENT_BINARY_DIR}/flatbuffers_external_project
   SOURCE_DIR ${PROJECT_SOURCE_DIR}/third-party/flatbuffers
-  # Always use Make to avoid needing to codesign flatc if the project is using Xcode.
-  CMAKE_GENERATOR "Unix Makefiles"
   CMAKE_ARGS -DFLATBUFFERS_BUILD_FLATC=ON
              -DFLATBUFFERS_INSTALL=ON
              -DFLATBUFFERS_BUILD_FLATHASH=OFF
@@ -28,6 +33,7 @@ ExternalProject_Add(
              $<$<AND:$<BOOL:${APPLE}>,$<BOOL:$<FILTER:${PLATFORM},EXCLUDE,^MAC>>>:-DCMAKE_OSX_SYSROOT=>
              -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=${CMAKE_OSX_DEPLOYMENT_TARGET}
   BUILD_BYPRODUCTS <INSTALL_DIR>/bin/flatc
+  ${_executorch_external_project_additional_args}
 )
 ExternalProject_Get_Property(flatbuffers_external_project INSTALL_DIR)
 add_executable(flatc IMPORTED GLOBAL)
@@ -35,7 +41,7 @@ add_dependencies(flatc flatbuffers_external_project)
 if(WIN32)
   # flatbuffers does not use CMAKE_BUILD_TYPE. Internally, the build forces Release
   # config, but from CMake's perspective the build type is always Debug.
-  set_target_properties(flatc PROPERTIES IMPORTED_LOCATION ${INSTALL_DIR}/$<CONFIG>/bin/flatc.exe)
+  set_target_properties(flatc PROPERTIES IMPORTED_LOCATION ${INSTALL_DIR}/bin/flatc.exe)
 else()
   set_target_properties(flatc PROPERTIES IMPORTED_LOCATION ${INSTALL_DIR}/bin/flatc)
 endif()
@@ -49,13 +55,22 @@ endif()
 
 # MARK: - flatcc
 
+if(WIN32)
+  # For some reason, when configuring the external project during build
+  # CMAKE_C_SIMULATE_ID is set to MSVC, but CMAKE_CXX_SIMULATE_ID is not set.
+  # To make sure the external project is configured correctly, set it explicitly
+  # here.
+  set(_flatcc_extra_cmake_args -DCMAKE_CXX_SIMULATE_ID=MSVC)
+else()
+  set(_flatcc_extra_cmake_args)
+endif()
+
 # Similar to flatbuffers, we want to build flatcc for the host. See inline comments
 # in the flatbuffers ExternalProject_Add for more details.
 ExternalProject_Add(
   flatcc_external_project
   PREFIX ${CMAKE_CURRENT_BINARY_DIR}/flatcc_external_project
   SOURCE_DIR ${PROJECT_SOURCE_DIR}/third-party/flatcc
-  CMAKE_GENERATOR "Unix Makefiles"
   CMAKE_ARGS -DFLATCC_RTONLY=OFF
              -DFLATCC_TEST=OFF
              -DFLATCC_REFLECTION=OFF
@@ -66,14 +81,16 @@ ExternalProject_Add(
              -DCMAKE_TOOLCHAIN_FILE=
              $<$<AND:$<BOOL:${APPLE}>,$<BOOL:$<FILTER:${PLATFORM},EXCLUDE,^MAC>>>:-DCMAKE_OSX_SYSROOT=>
              -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=${CMAKE_OSX_DEPLOYMENT_TARGET}
+             ${_flatcc_extra_cmake_args}
   BUILD_BYPRODUCTS <INSTALL_DIR>/bin/flatcc
+  {_executorch_external_project_additional_args}
 )
 file(REMOVE_RECURSE ${PROJECT_SOURCE_DIR}/third-party/flatcc/lib)
 ExternalProject_Get_Property(flatcc_external_project INSTALL_DIR)
 add_executable(flatcc_cli IMPORTED GLOBAL)
 add_dependencies(flatcc_cli flatcc_external_project)
 if(WIN32)
-  set_target_properties(flatcc_cli PROPERTIES IMPORTED_LOCATION ${INSTALL_DIR}/$<CONFIG>/bin/flatcc.exe)
+  set_target_properties(flatcc_cli PROPERTIES IMPORTED_LOCATION ${INSTALL_DIR}/bin/flatcc.exe)
 else()
   set_target_properties(flatcc_cli PROPERTIES IMPORTED_LOCATION ${INSTALL_DIR}/bin/flatcc)
 endif()


### PR DESCRIPTION

Summary:
## Context

Fix third party `CMakeLists.txt` to allow `flatcc` to build for Windows. Some CMake configuration settings need to be adjusted for windows platforms.

Test Plan:
## Test Plan

```
python install_executorch.py
```
