### PR TITLE
Fix doc for Android build error in xnnpack_README.md

### DIFF
--- a/examples/demo-apps/android/LlamaDemo/docs/delegates/xnnpack_README.md
+++ b/examples/demo-apps/android/LlamaDemo/docs/delegates/xnnpack_README.md
@@ -183,6 +183,7 @@ If you need to use other dependencies (like tokenizer), please build from the lo
 ### Alternative 2: Command line
 Without Android Studio UI, we can run gradle directly to build the app. We need to set up the Android SDK path and invoke gradle.
 ```
+export ANDROID_SDK=<path_to_android_sdk_home>
 export ANDROID_HOME=<path_to_android_sdk_home>
 pushd examples/demo-apps/android/LlamaDemo
 ./gradlew :app:installDebug


### PR DESCRIPTION
In scripts/build_android_library.sh, there's 
```
ANDROID_HOME="${ANDROID_SDK:-/opt/android/sdk}" ./gradlew build
```
If ANDROID_SDK is not set, ANDROID_HOME will be /opt/android/sdk, which is wrong for Mac. Add `export ANDROID_SDK` instruction to avoid the build error if users have not exported it.

### Test plan
`sh scripts/build_android_library.sh`
