### PR TITLE
support function + method variants

### DIFF
--- a/codegen/gen.py
+++ b/codegen/gen.py
@@ -134,14 +134,13 @@ class ComputeFunction:
         if not self.selector.is_root_operator(f"{f.namespace}::{f.func.name}"):
             return None
 
+        if Variant.function not in f.variants and Variant.method not in f.variants:
+            raise Exception(  # noqa: TRY002
+                f"Expected one of function or method to be in variants for {f.func.name}"
+            )
+
         if Variant.function not in f.variants and Variant.method in f.variants:
             is_method_variant = True
-
-        # only valid remaining case is only function is in f.variants
-        elif not (Variant.function in f.variants and Variant.method not in f.variants):
-            raise Exception(  # noqa: TRY002
-                f"Can't handle native function {f.func} with the following variant specification {f.variants}."
-            )
 
         sig: CppSignature | ExecutorchCppSignature = (
             CppSignatureGroup.from_native_function(


### PR DESCRIPTION
Summary: Previously think we didnt need this so just threw an exception. Now we are adding index_put_ and other inplace ops besides copy_ (which is only function variant) so adding it.

Differential Revision: D75006941


