### PR TITLE
Guard against existing cache when configuring options

### DIFF
--- a/tools/cmake/common/preset.cmake
+++ b/tools/cmake/common/preset.cmake
@@ -76,7 +76,7 @@ macro(define_overridable_option NAME DESCRIPTION VALUE_TYPE DEFAULT_VALUE)
     message(FATAL_ERROR "Invalid option (${NAME}) value type '${VALUE_TYPE}', must be either STRING or BOOL")
   endif()
 
-  if(DEFINED ${NAME})
+  if(DEFINED ${NAME} AND NOT DEFINED CACHE{${NAME}})
     set(${NAME} ${${NAME}} CACHE ${VALUE_TYPE} ${DESCRIPTION} FORCE)
   else()
     set(${NAME} ${DEFAULT_VALUE} CACHE ${VALUE_TYPE} ${DESCRIPTION})

--- a/tools/cmake/common/preset_test.py
+++ b/tools/cmake/common/preset_test.py
@@ -8,6 +8,8 @@ import os
 
 from tools.cmake.common import CMakeTestCase, TESTABLE_CMAKE_FILES
 
+from . import _list_cmake_cache
+
 
 class TestPreset(CMakeTestCase):
 
@@ -201,12 +203,11 @@ class TestPreset(CMakeTestCase):
         # Setting the value after should not affect the cache.
         self.assert_cmake_cache("EXECUTORCH_TEST_MESSAGE", "default value", "STRING")
 
-    def test_define_overridable_option_cli_override_with_set_override(self):
+    def test_define_overridable_option_override_existing_cache_with_cli(self):
         _cmake_lists_txt = """
             cmake_minimum_required(VERSION 3.24)
             project(test_preset)
             include(${PROJECT_SOURCE_DIR}/preset.cmake)
-            set(EXECUTORCH_TEST_MESSAGE "set value")
             add_subdirectory(example)
         """
         _example_cmake_lists_txt = """
@@ -220,9 +221,14 @@ class TestPreset(CMakeTestCase):
                 },
             }
         )
+        self.run_cmake()
+        self.assert_cmake_cache("EXECUTORCH_TEST_MESSAGE", "default value", "STRING")
+
+        # Since we cache the get operations, clear it so that it's read again for tests.
+        _list_cmake_cache.cache_clear()
+
         self.run_cmake(cmake_args=["-DEXECUTORCH_TEST_MESSAGE='cli value'"])
-        # If an option is set through cmake, it should NOT be overridable from the CLI.
-        self.assert_cmake_cache("EXECUTORCH_TEST_MESSAGE", "set value", "STRING")
+        self.assert_cmake_cache("EXECUTORCH_TEST_MESSAGE", "cli value", "STRING")
 
     def test_set_overridable_option_before(self):
         _cmake_lists_txt = """


### PR DESCRIPTION
### Summary

@kirklandsign came across an issue where if the existing `cmake-out` folder was not deleted, it would just use the existing cache. We want to override this and always use whatever the current value is.

### Test plan

unittest + CI


cc @larryliu0820