### PR TITLE
Update batch size default

### DIFF
--- a/examples/models/llama/model_args.py
+++ b/examples/models/llama/model_args.py
@@ -14,7 +14,7 @@ class ModelArgs:
     multiple_of: int = 256  # make SwiGLU hidden layer size multiple of large power of 2
     ffn_dim_multiplier: Optional[float] = None
     norm_eps: float = 1e-5
-    max_batch_size: int = 32
+    max_batch_size: int = 1
     max_seq_len: int = 2048
     max_context_len: int = 2048
     moe: bool = False  # True to enable the MoE (Mixture of Experts)


### PR DESCRIPTION
Summary: 32 is a bad default 1 is significantly more common.

Differential Revision: D75089945


