### PR TITLE
Don't specify generator for presets

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -4,8 +4,7 @@
     {
       "name": "common",
       "hidden": true,
-      "binaryDir": "${sourceDir}/cmake-out",
-      "generator": "Unix Makefiles"
+      "binaryDir": "${sourceDir}/cmake-out"
     },
     {
       "name": "macos-arm64",


### PR DESCRIPTION
### Summary
Windows doesn't have "Unix Makefiles", so let's just rely on the default generator used in CMake.

### Test plan

CI