### PR TITLE
Updates to use torchao's updated choose_qparams_affine and quantize/dequantize_affine

### DIFF
--- a/backends/xnnpack/utils/quant_utils.py
+++ b/backends/xnnpack/utils/quant_utils.py
@@ -222,9 +222,6 @@ def extract_qdq_affine_op_args_for_decomposed_ops(node: torch.fx.Node):
 
     # add target_dtype_node after quant_min/quant_max
     args.append(target_dtype)
-    # zero_point_domain
-    if len(node.args) > 7 and node.args[7] != "INT":
-        return None, None
 
     if is_per_channel_group(node):
         block_sizes = cast(list[int], node.args[1])

--- a/exir/passes/_quant_patterns_and_replacements.py
+++ b/exir/passes/_quant_patterns_and_replacements.py
@@ -1017,7 +1017,6 @@ def _get_embedding_ops_patterns_and_replacements_torchao() -> (  # noqa C901
             torch.int8,
             -128,
             127,
-            "INT",
             output_dtype,
         )
         return torch.ops.aten.embedding.default(dq, indices)
@@ -1062,7 +1061,6 @@ def _get_embedding_ops_patterns_and_replacements_torchao() -> (  # noqa C901
             torch.int8,
             -2,
             1,
-            "INT",
             output_dtype,
         )
         return torch.ops.aten.embedding.default(dq, indices)
@@ -1110,7 +1108,6 @@ def _get_embedding_ops_patterns_and_replacements_torchao() -> (  # noqa C901
             torch.int8,
             -8,
             7,
-            "INT",
             output_dtype,
         )
         return torch.ops.aten.embedding.default(dq, indices)


### PR DESCRIPTION
Summary: Updates to use torchao's updated choose_qparams_affine and quantize/dequantize_affine. Remove zero_point_domain dependency

Differential Revision: D75228037


