### PR TITLE
Migrate gen_oplist.py to use executorch/codegen instead of pytorch torchgen

### DIFF
--- a/codegen/parse.py
+++ b/codegen/parse.py
@@ -5,7 +5,12 @@ from typing import Any
 
 import yaml
 
-from executorch.codegen.model import ETKernelIndex, ETKernelKey
+try:
+    from executorch.codegen.model import ETKernelIndex, ETKernelKey
+except ImportError:
+    # If we build from source, executorch.codegen is not available.
+    # We can use relative import instead.
+    from .model import ETKernelIndex, ETKernelKey  # type: ignore[assignment]
 from torchgen.gen import LineLoader, parse_native_yaml
 from torchgen.model import (
     BackendMetadata,

--- a/codegen/tools/gen_oplist.py
+++ b/codegen/tools/gen_oplist.py
@@ -12,7 +12,13 @@ from enum import IntEnum
 from typing import Any, Dict, List, Optional, Set
 
 import yaml
-from torchgen.executorch.parse import strip_et_fields
+
+try:
+    from executorch.codegen.parse import strip_et_fields
+except ImportError:
+    # If we build from source, executorch.codegen is not available.
+    # We can use relative import instead.
+    from ..parse import strip_et_fields
 
 from torchgen.gen import LineLoader, parse_native_yaml_struct
 from torchgen.selective_build.operator import SelectiveBuildOperator

--- a/codegen/tools/targets.bzl
+++ b/codegen/tools/targets.bzl
@@ -15,8 +15,9 @@ def define_common_targets(is_fbcode = False):
         visibility = [
             "//executorch/...",
         ],
-        external_deps = ["torchgen"],
-        deps = select({
+        deps = [
+            "//executorch/codegen:gen_lib",
+        ] + select({
             "DEFAULT": [],
             "ovr_config//os:linux": [] if runtime.is_oss else ["//executorch/codegen/tools/fb:selective_build"],  # TODO(larryliu0820) :selective_build doesn't build in OSS yet
         }),

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -71,7 +71,7 @@ TORCH_NIGHTLY_URL = "https://download.pytorch.org/whl/nightly/cpu"
 #
 # NOTE: If you're changing, make the corresponding change in .ci/docker/ci_commit_pins/pytorch.txt
 # by picking the hash from the same date in https://hud.pytorch.org/hud/pytorch/pytorch/nightly/
-NIGHTLY_VERSION = "dev20250325"
+NIGHTLY_VERSION = "dev20250524"
 
 
 def install_requirements(use_pytorch_nightly):


### PR DESCRIPTION
Summary: As titled, after #10939 we are able to use `executorch.codegen` APIs instead of `torchgen.executorch` APIs. This PR moves `gen_oplist.py` to use the new `executorch.codgen` API.

Reviewed By: kirklandsign

Differential Revision: D75307480
