### PR TITLE
Create an iOS and macOS preset

### DIFF
--- a/.github/workflows/build-presets.yml
+++ b/.github/workflows/build-presets.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        preset: [macos-arm64, pybind, llm]
+        preset: [macos, ios, ios-simulator, pybind, llm]
     with:
       job-name: build
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -7,15 +7,49 @@
       "binaryDir": "${sourceDir}/cmake-out"
     },
     {
-      "name": "macos-arm64",
-      "displayName": "Build everything buildable on macOS arm64",
+      "name": "macos",
+      "displayName": "Build everything buildable on macOS",
       "inherits": ["common"],
       "generator": "Xcode",
       "cacheVariables": {
         "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/third-party/ios-cmake/ios.toolchain.cmake",
-        "EXECUTORCH_BUILD_PRESET_FILE": "${sourceDir}/tools/cmake/preset/macos-arm64.cmake",
+        "EXECUTORCH_BUILD_PRESET_FILE": "${sourceDir}/tools/cmake/preset/macos.cmake",
         "PLATFORM": "MAC_ARM64",
         "DEPLOYMENT_TARGET": "10.15"
+      },
+      "condition": {
+        "lhs": "${hostSystemName}",
+        "type": "equals",
+        "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "ios",
+      "displayName": "Build everything buildable on iOS",
+      "inherits": ["common"],
+      "generator": "Xcode",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/third-party/ios-cmake/ios.toolchain.cmake",
+        "EXECUTORCH_BUILD_PRESET_FILE": "${sourceDir}/tools/cmake/preset/ios.cmake",
+        "PLATFORM": "OS64",
+        "DEPLOYMENT_TARGET": "17.0"
+      },
+      "condition": {
+        "lhs": "${hostSystemName}",
+        "type": "equals",
+        "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "ios-simulator",
+      "displayName": "Build everything buildable on iOS simulator",
+      "inherits": ["common"],
+      "generator": "Xcode",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/third-party/ios-cmake/ios.toolchain.cmake",
+        "EXECUTORCH_BUILD_PRESET_FILE": "${sourceDir}/tools/cmake/preset/ios.cmake",
+        "PLATFORM": "SIMULATORARM64",
+        "DEPLOYMENT_TARGET": "17.0"
       },
       "condition": {
         "lhs": "${hostSystemName}",

--- a/tools/cmake/preset/apple_common.cmake
+++ b/tools/cmake/preset/apple_common.cmake
@@ -1,0 +1,28 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++${CMAKE_CXX_STANDARD}")
+set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++")
+
+set(
+  _compiler_flags
+  "-ffile-prefix-map=${PROJECT_SOURCE_DIR}=/executorch"
+  "-fdebug-prefix-map=${PROJECT_SOURCE_DIR}=/executorch"
+)
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${_compiler_flags}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${_compiler_flags}")
+
+set_overridable_option(EXECUTORCH_BUILD_XNNPACK ON)
+set_overridable_option(EXECUTORCH_BUILD_COREML ON)
+set_overridable_option(EXECUTORCH_BUILD_MPS ON)
+set_overridable_option(EXECUTORCH_XNNPACK_SHARED_WORKSPACE ON)
+set_overridable_option(EXECUTORCH_BUILD_EXTENSION_APPLE ON)
+set_overridable_option(EXECUTORCH_BUILD_EXTENSION_DATA_LOADER ON)
+set_overridable_option(EXECUTORCH_BUILD_EXTENSION_MODULE ON)
+set_overridable_option(EXECUTORCH_BUILD_EXTENSION_TENSOR ON)
+set_overridable_option(EXECUTORCH_BUILD_KERNELS_CUSTOM ON)
+set_overridable_option(EXECUTORCH_BUILD_KERNELS_OPTIMIZED ON)
+set_overridable_option(EXECUTORCH_BUILD_KERNELS_QUANTIZED ON)

--- a/tools/cmake/preset/ios.cmake
+++ b/tools/cmake/preset/ios.cmake
@@ -4,4 +4,4 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-set_overridable_option(EXECUTORCH_BUILD_COREML ON)
+include(${PROJECT_SOURCE_DIR}/tools/cmake/preset/apple_common.cmake)

--- a/tools/cmake/preset/macos.cmake
+++ b/tools/cmake/preset/macos.cmake
@@ -1,0 +1,10 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+include(${PROJECT_SOURCE_DIR}/tools/cmake/preset/apple_common.cmake)
+include(${PROJECT_SOURCE_DIR}/tools/cmake/preset/pybind.cmake)
+
+set_overridable_option(EXECUTORCH_BUILD_EXECUTOR_RUNNER ON)


### PR DESCRIPTION
### Summary

* Create a `macos`, `ios`, and `ios-simulator` preset
* The flags are copied from [scripts/build_apple_frameworks.sh](https://github.com/pytorch/executorch/blob/f2fb35159b2287ad8de2e0343b18520356abe305/scripts/build_apple_frameworks.sh#L177-L212). In an upcoming PR, I will replace that command with this preset

### Test plan

CI +

```
$ cmake --preset macos && cmake --build cmake-out -j $(sysctl -n hw.ncpu)
$ cmake --preset ios && cmake --build cmake-out -j $(sysctl -n hw.ncpu)
$ cmake --preset ios-simulator && cmake --build cmake-out -j $(sysctl -n hw.ncpu)
```


cc @larryliu0820