### PR TITLE
Enable all platform tests in CMake

### DIFF
--- a/runtime/platform/test/CMakeLists.txt
+++ b/runtime/platform/test/CMakeLists.txt
@@ -19,10 +19,8 @@ include(${EXECUTORCH_ROOT}/tools/cmake/Test.cmake)
 
 et_cxx_test(platform_test SOURCES executor_pal_test.cpp)
 
-# TODO: Re-enable this test on OSS
-# et_cxx_test(platform_death_test SOURCES executor_pal_death_test.cpp)
+et_cxx_test(platform_death_test SOURCES executor_pal_death_test.cpp)
 
 et_cxx_test(logging_test SOURCES logging_test.cpp)
 
-# TODO: Re-enable this test on OSS
-# et_cxx_test(clock_test SOURCES clock_test.cpp stub_platform.cpp)
+et_cxx_test(clock_test SOURCES clock_test.cpp stub_platform.cpp)


### PR DESCRIPTION
### Summary
Enable platform_death_test and clock_test in CMake. They were previously disabled. They seem to run fine locally and will be nice to run in OSS with the upcoming PAL changes.

### Test plan
I built and ran the tests locally without issue. I'm also relying on CI to validate that the tests are healthy.
