### PR TITLE
Arm backend: Move TOSA unittests to 1.0

### DIFF
--- a/backends/arm/test/conftest.py
+++ b/backends/arm/test/conftest.py
@@ -44,7 +44,7 @@ def pytest_configure(config):
     if getattr(config.option, "fast_fvp", False):
         pytest._test_options["fast_fvp"] = config.option.fast_fvp  # type: ignore[attr-defined]
 
-    pytest._test_options["tosa_version"] = "0.80"  # type: ignore[attr-defined]
+    pytest._test_options["tosa_version"] = "1.0"  # type: ignore[attr-defined]
     if config.option.arm_run_tosa_version:
         pytest._test_options["tosa_version"] = config.option.arm_run_tosa_version
 
@@ -81,7 +81,7 @@ def pytest_addoption(parser):
         nargs="+",
         help="List of two files. Firstly .pt file. Secondly .json",
     )
-    try_addoption("--arm_run_tosa_version", action="store", default="0.80")
+    try_addoption("--arm_run_tosa_version", action="store", default="1.0")
 
 
 def pytest_sessionstart(session):


### PR DESCRIPTION
### Summary
Swtich to run the TOSA 1.0 unit tests by default.

### Test plan
Internal and external CI unit tests.

cc @digantdesai @freddan80 @zingo @oscarandersson8218