### PR TITLE
Add new dependency library for vulkan tests

### DIFF
--- a/backends/vulkan/test/op_tests/targets.bzl
+++ b/backends/vulkan/test/op_tests/targets.bzl
@@ -8,6 +8,7 @@ def define_test_targets(test_name, extra_deps = [], src_file = None, is_fbcode =
         "//third-party/googletest:gtest_main",
         "//executorch/backends/vulkan:vulkan_graph_runtime",
         runtime.external_dep_location("libtorch"),
+        runtime.external_dep_location("libtorch_cpu"),
     ] + extra_deps
 
     src_file_str = src_file if src_file else "{}.cpp".format(test_name)


### PR DESCRIPTION
**Background**:

We removed the inline flag of the symbol `torch::jit::GetBackendMetaSerialization()` from and moved it to .cpp in order to make the dynamic registration related to PyTorch serialization work properly.

However, after testing, it was found that Vulkan's tests depend on the symbol named `torch::jit::GetBackendMetaSerialization()`, so after the above changes, it is necessary to explicitly link libtorch_cpu (which contains the torch::jit::GetBackendMetaSerialization() symbol)

For more information, see [PR](https://github.com/pytorch/pytorch/pull/147095), especially this [comment](https://github.com/pytorch/pytorch/pull/147095#issuecomment-2788206845)

cc @SS-JIA @manuelcandales @cbilgin