### PR TITLE
Extract DeviceType to a standalone header file

### DIFF
--- a/runtime/core/portable_type/c10/c10/targets.bzl
+++ b/runtime/core/portable_type/c10/c10/targets.bzl
@@ -65,6 +65,7 @@ def define_common_targets():
         fbcode_exported_deps = ([
             "//caffe2:aten-headers-cpu",
             "//caffe2:generated-config-header",
+            "//caffe2:torch_standalone_headers",
             "//caffe2/c10:c10_headers",
         ] + select({
             "DEFAULT": [],
@@ -83,6 +84,7 @@ def define_common_targets():
         ] + get_sleef_preprocessor_flags(),
         xplat_exported_deps = [
             "//xplat/caffe2:aten_header",
+            "//xplat/caffe2:torch_standalone_headers",
             "//xplat/caffe2/c10:c10_headers",
         ] + ["//xplat/caffe2:ovrsource_aten_Config.h" if is_arvr_mode() else "//xplat/caffe2:generated_aten_config_header",],
         exported_preprocessor_flags = select({


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/pytorch/pull/154417

The goal of this PR and future follow-up PRs is to group a set of header files required by AOTInductor Standalone in a separate directory, ensuring they are implemented in a header-only manner. More specifically, here is what this PR does:
* Extract the DeviceType enum class into a standalone header file in a new torch/standalone/header_only directory
* Retain the existing c10/core/DeviceType.[h|cpp] files to handle complex logic and static variables
* Import symbols from the new torch::standalone namespace into c10 for backward compatibility

This is an updated version of https://github.com/pytorch/pytorch/pull/152787, because we need to land in fbcode first. See the original comments and discussions in https://github.com/pytorch/pytorch/pull/152787.

Differential Revision: D75313723


