### PR TITLE
Arm backend: Fix shared qspec edge case

### DIFF
--- a/backends/arm/test/ops/test_avg_pool2d.py
+++ b/backends/arm/test/ops/test_avg_pool2d.py
@@ -99,7 +99,6 @@ def test_avg_pool2d_tosa_BI(test_module):
         input_tensor,
         aten_op,
         exir_op,
-        symmetric_io_quantization=True,
         run_on_tosa_ref_model=conftest.is_option_enabled("tosa_ref_model"),
     )
     if conftest.is_option_enabled("tosa_ref_model"):
@@ -118,7 +117,6 @@ def test_avg_pool2d_u55_BI(test_module):
         aten_op,
         exir_op,
         run_on_fvp=True,
-        symmetric_io_quantization=True,
     )
     pipeline.change_args("run_method_and_compare_outputs", qtol=1, atol=1, rtol=1)
     pipeline.run()
@@ -135,7 +133,6 @@ def test_avg_pool2d_u85_BI(test_module):
         aten_op,
         exir_op,
         run_on_fvp=True,
-        symmetric_io_quantization=True,
     )
     pipeline.change_args("run_method_and_compare_outputs", qtol=1, atol=1, rtol=1)
 
@@ -164,7 +161,7 @@ reject_modules = {
 
 
 @common.parametrize("reject_module", reject_modules)
-def test_avg_pool2d_tosa_BI_not_delegated(reject_module):
+def test_avg_pool2d_u55_BI_not_delegated(reject_module):
 
     model, test_data = reject_module()
 
@@ -174,5 +171,6 @@ def test_avg_pool2d_tosa_BI_not_delegated(reject_module):
         non_delegated_ops={},
         n_expected_delegates=0,
         quantize=True,
+        u55_subset=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_clamp.py
+++ b/backends/arm/test/ops/test_clamp.py
@@ -77,7 +77,6 @@ def test_clamp_tosa_BI(test_data):
         (input_tensor,),
         aten_op,
         exir_op,
-        symmetric_io_quantization=True,
     )
     pipeline.change_args("run_method_and_compare_outputs", qtol=1)
 
@@ -97,7 +96,6 @@ def test_clamp_u55_BI(test_data):
         aten_op,
         exir_op,
         run_on_fvp=True,
-        symmetric_io_quantization=True,
     )
 
     pipeline.change_args("run_method_and_compare_outputs", qtol=1)
@@ -117,7 +115,6 @@ def test_clamp_u85_BI(test_data):
         aten_op,
         exir_op,
         run_on_fvp=True,
-        symmetric_io_quantization=True,
     )
     pipeline.change_args("run_method_and_compare_outputs", qtol=1)
 

--- a/backends/arm/test/ops/test_clone.py
+++ b/backends/arm/test/ops/test_clone.py
@@ -65,7 +65,6 @@ def test_clone_tosa_BI(test_data):
         test_data(),
         aten_op,
         exir_op,
-        symmetric_io_quantization=True,
     )
     pipeline.run()
 
@@ -82,7 +81,6 @@ def test_clone_u55_BI(test_data):
         aten_op,
         exir_op,
         run_on_fvp=True,
-        symmetric_io_quantization=True,
     )
 
     pipeline.run()
@@ -100,7 +98,6 @@ def test_clone_u85_BI(test_data):
         aten_op,
         exir_op,
         run_on_fvp=True,
-        symmetric_io_quantization=True,
     )
 
     pipeline.run()

--- a/backends/arm/test/ops/test_hardtanh.py
+++ b/backends/arm/test/ops/test_hardtanh.py
@@ -58,7 +58,6 @@ def test_hardtanh_tosa_BI(test_data: torch.Tensor):
         (test_data(),),
         aten_op,
         exir_op,
-        symmetric_io_quantization=True,
     )
     pipeline.run()
 
@@ -72,7 +71,6 @@ def test_hardtanh_u55_BI(test_data: torch.Tensor):
         aten_op,
         exir_op,
         run_on_fvp=True,
-        symmetric_io_quantization=True,
     )
     pipeline.run()
 
@@ -86,6 +84,5 @@ def test_hardtanh_u85_BI(test_data: torch.Tensor):
         aten_op,
         exir_op,
         run_on_fvp=True,
-        symmetric_io_quantization=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_max_pool.py
+++ b/backends/arm/test/ops/test_max_pool.py
@@ -74,7 +74,6 @@ def test_max_pool2d_tosa_BI(test_data: torch.Tensor):
         (test_data,),
         aten_op,
         exir_op,
-        symmetric_io_quantization=True,
     )
     pipeline.run()
 
@@ -88,7 +87,6 @@ def test_max_pool2d_u55_BI(test_data: torch.Tensor):
         (test_data,),
         aten_op,
         exir_ops=[],
-        symmetric_io_quantization=True,
         run_on_fvp=True,
     ).run()
 
@@ -102,7 +100,6 @@ def test_max_pool2d_u85_BI(test_data: torch.Tensor):
         (test_data,),
         aten_op,
         exir_ops=[],
-        symmetric_io_quantization=True,
         run_on_fvp=True,
     ).run()
 
@@ -127,7 +124,6 @@ def test_max_pool2d_tosa_BI_mult_batches(test_data: torch.Tensor):
         (test_data,),
         aten_op,
         exir_op,
-        symmetric_io_quantization=True,
     )
     pipeline.run()
 
@@ -145,7 +141,6 @@ def test_max_pool2d_u55_BI_mult_batches(test_data: torch.Tensor):
         aten_op,
         exir_ops=[],
         run_on_fvp=True,
-        symmetric_io_quantization=True,
         use_to_edge_transform_and_lower=True,
     ).run()
 
@@ -160,7 +155,6 @@ def test_max_pool2d_u85_BI_mult_batches(test_data: torch.Tensor):
         aten_op,
         exir_op,
         run_on_fvp=True,
-        symmetric_io_quantization=True,
         use_to_edge_transform_and_lower=True,
     ).run()
 
@@ -182,7 +176,6 @@ def test_max_pool2d_u55_BI_failure_set(test_data: Tuple):
         aten_op,
         exir_op,
         run_on_fvp=False,
-        symmetric_io_quantization=True,
         use_to_edge_transform_and_lower=True,
     )
     pipeline.pop_stage("check_count.exir")

--- a/backends/arm/test/ops/test_permute.py
+++ b/backends/arm/test/ops/test_permute.py
@@ -67,7 +67,6 @@ def test_permute_tosa_BI(test_data: torch.Tensor):
         (test_data,),
         aten_op,
         exir_op,
-        symmetric_io_quantization=True,
     )
     pipeline.run()
 
@@ -88,7 +87,6 @@ def test_permute_u55_BI(test_data):
         aten_op,
         exir_ops="executorch_exir_dialects_edge__ops_aten_permute_copy_default",
         run_on_fvp=True,
-        symmetric_io_quantization=True,
     )
     pipeline.run()
 
@@ -104,6 +102,5 @@ def test_permute_u85_BI(test_data: torch.Tensor):
         aten_op,
         exir_ops="executorch_exir_dialects_edge__ops_aten_permute_copy_default",
         run_on_fvp=True,
-        symmetric_io_quantization=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_reciprocal.py
+++ b/backends/arm/test/ops/test_reciprocal.py
@@ -58,7 +58,6 @@ def test_reciprocal_tosa_BI(test_data: torch.Tensor):
         (test_data(),),
         aten_op,
         exir_op=[],
-        symmetric_io_quantization=True,
     )
     pipeline.run()
 
@@ -72,7 +71,6 @@ def test_reciprocal_u55_BI(test_data: torch.Tensor):
         aten_op,
         exir_ops=[],
         run_on_fvp=False,
-        symmetric_io_quantization=True,
     )
     pipeline.run()
 

--- a/backends/arm/test/ops/test_relu.py
+++ b/backends/arm/test/ops/test_relu.py
@@ -60,7 +60,6 @@ def test_relu_tosa_BI(test_data: torch.Tensor):
         (test_data(),),
         aten_op,
         exir_op,
-        symmetric_io_quantization=True,
     )
     pipeline.run()
 
@@ -73,7 +72,6 @@ def test_relu_u55_BI(test_data: torch.Tensor):
         aten_op,
         exir_op,
         run_on_fvp=False,
-        symmetric_io_quantization=True,
     )
     pipeline.run()
 
@@ -86,6 +84,5 @@ def test_relu_u85_BI(test_data: torch.Tensor):
         aten_op,
         exir_op,
         run_on_fvp=False,
-        symmetric_io_quantization=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_scalar_tensor.py
+++ b/backends/arm/test/ops/test_scalar_tensor.py
@@ -85,7 +85,6 @@ def test_scalar_tensor_u55_BI(test_data):
         ScalarTensor(scalar, dtype),
         tuple(data),
         ScalarTensor.aten_op,
-        symmetric_io_quantization=True,
         run_on_fvp=True,
     ).run()
 
@@ -98,6 +97,5 @@ def test_scalar_tensor_u85_BI(test_data):
         ScalarTensor(scalar, dtype),
         tuple(data),
         ScalarTensor.aten_op,
-        symmetric_io_quantization=True,
         run_on_fvp=True,
     ).run()

--- a/backends/arm/test/ops/test_var.py
+++ b/backends/arm/test/ops/test_var.py
@@ -175,7 +175,6 @@ def test_var_dim_tosa_BI_no_dim(test_data: Tuple):
         (test_data,),
         aten_op=[],
         exir_op=[],
-        symmetric_io_quantization=True,
     )
     pipeline.run()
 
@@ -190,7 +189,6 @@ def test_var_dim_u55_BI_no_dim(test_data: Tuple):
         aten_ops=[],
         exir_ops=[],
         run_on_fvp=True,
-        symmetric_io_quantization=True,
     )
     pipeline.run()
 
@@ -205,7 +203,6 @@ def test_var_dim_u85_BI_no_dim(test_data: Tuple):
         aten_ops=[],
         exir_ops=[],
         run_on_fvp=True,
-        symmetric_io_quantization=True,
     )
     pipeline.run()
 
@@ -231,7 +228,6 @@ def test_var_dim_tosa_BI(test_data: Tuple):
         (test_data,),
         aten_op=[],
         exir_op=[],
-        symmetric_io_quantization=True,
     )
     pipeline.run()
 
@@ -246,7 +242,6 @@ def test_var_dim_u55_BI(test_data: Tuple):
         aten_ops=[],
         exir_ops=[],
         run_on_fvp=True,
-        symmetric_io_quantization=True,
     )
     pipeline.run()
 
@@ -261,7 +256,6 @@ def test_var_dim_u85_BI(test_data: Tuple):
         aten_ops=[],
         exir_ops=[],
         run_on_fvp=True,
-        symmetric_io_quantization=True,
     )
     pipeline.run()
 
@@ -286,7 +280,6 @@ def test_var_dim_tosa_BI_correction(test_data: Tuple):
         (test_data,),
         aten_op=[],
         exir_op=[],
-        symmetric_io_quantization=True,
     )
     pipeline.run()
 
@@ -301,7 +294,6 @@ def test_var_dim_u55_BI_correction(test_data: Tuple):
         aten_ops=[],
         exir_ops=[],
         run_on_fvp=True,
-        symmetric_io_quantization=True,
     )
     pipeline.run()
 
@@ -316,6 +308,5 @@ def test_var_dim_u85_BI_correction(test_data: Tuple):
         aten_ops=[],
         exir_ops=[],
         run_on_fvp=True,
-        symmetric_io_quantization=True,
     )
     pipeline.run()


### PR DESCRIPTION
Moving ops in the quantization annotator from _parent_shared_qspec to _one_to_one_shared_input_or_input_act_qspec makes sure they are properly annotated also when not preceeded by an annotated node. This removes the need for symmetric_io_quantization=True in the unittests for these ops.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218