### PR TITLE
Fix returning too early when setting options

### DIFF
--- a/tools/cmake/common/preset.cmake
+++ b/tools/cmake/common/preset.cmake
@@ -89,11 +89,9 @@ endmacro()
 # Set an overridable option.
 macro(set_overridable_option NAME VALUE)
   # If the user has explitily set the option, do not override it.
-  if(DEFINED ${NAME})
-    return()
+  if(NOT DEFINED ${NAME})
+    set(${NAME} ${VALUE} CACHE STRING "")
   endif()
-
-  set(${NAME} ${VALUE} CACHE STRING "")
 endmacro()
 
 # Detemine the build preset and load it.

--- a/tools/cmake/common/preset_test.py
+++ b/tools/cmake/common/preset_test.py
@@ -271,6 +271,34 @@ class TestPreset(CMakeTestCase):
         self.run_cmake()
         self.assert_cmake_cache("EXECUTORCH_TEST_MESSAGE", "move fast", "STRING")
 
+    def test_set_overridable_option_loaded_from_file(self):
+        _cmake_lists_txt = """
+            cmake_minimum_required(VERSION 3.24)
+            project(test_preset)
+            include(${PROJECT_SOURCE_DIR}/preset.cmake)
+            include(${PROJECT_SOURCE_DIR}/build/my_preset.cmake)
+            include(${PROJECT_SOURCE_DIR}/build/default.cmake)
+        """
+        _my_preset_txt = """
+            set_overridable_option(EXECUTORCH_FOO "hello world")
+        """
+        _default_preset_txt = """
+            define_overridable_option(EXECUTORCH_TEST_MESSAGE "test message" STRING "move fast")
+            define_overridable_option(EXECUTORCH_FOO "another test message" STRING "break things")
+        """
+        self.create_workspace(
+            {
+                "CMakeLists.txt": _cmake_lists_txt,
+                "build": {
+                    "my_preset.cmake": _my_preset_txt,
+                    "default.cmake": _default_preset_txt,
+                },
+            }
+        )
+        self.run_cmake(cmake_args=["-DEXECUTORCH_TEST_MESSAGE='from the cli'"])
+        self.assert_cmake_cache("EXECUTORCH_TEST_MESSAGE", "from the cli", "STRING")
+        self.assert_cmake_cache("EXECUTORCH_FOO", "hello world", "STRING")
+
     def test_set_overridable_option_with_cli_override(self):
         _cmake_lists_txt = """
             cmake_minimum_required(VERSION 3.24)


### PR DESCRIPTION
### Summary
Fixes a bug where we return too early since we are using a macro. This is only apparent if `set_overridable_option` is used outside of a top-level CMake file (i.e. different scope)

### Test plan
unittest + CI