### PR TITLE
Enforce clang for Windows builds

### DIFF
--- a/.github/workflows/build-presets.yml
+++ b/.github/workflows/build-presets.yml
@@ -71,6 +71,7 @@ jobs:
         # Build Arm Zephyr Preset
         cmake --preset ${{ matrix.preset }}
         cmake --build cmake-out -j$(( $(nproc) - 1 ))
+
   linux:
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     strategy:
@@ -117,26 +118,9 @@ jobs:
       timeout: 90
       script: |
         set -eux
-        conda init powershell
-        powershell -Command "& {
-          Set-PSDebug -Trace 1
-          \$ErrorActionPreference = 'Stop'
-          \$PSNativeCommandUseErrorActionPreference = \$true
+        conda create --yes --quiet -n et python=3.12
+        conda activate et
 
-          conda create --yes --quiet -n et python=3.12
-          conda activate et
-          python install_requirements.py
-
-          cmake --preset ${{ matrix.preset }} -T ClangCL
-          if (\$LASTEXITCODE -ne 0) {
-            Write-Host "CMake configuration was unsuccessful. Exit code: \$LASTEXITCODE."
-            exit \$LASTEXITCODE
-          }
-
-          \$numCores = [System.Environment]::GetEnvironmentVariable('NUMBER_OF_PROCESSORS') - 1
-          cmake --build cmake-out -j \$numCores
-          if (\$LASTEXITCODE -ne 0) {
-            Write-Host "CMake build was unsuccessful. Exit code: \$LASTEXITCODE."
-            exit \$LASTEXITCODE
-          }
-        }"
+        ./install_requirements.sh
+        cmake -G "Visual Studio 17 2022" -T ClangCL --preset ${{ matrix.preset }}
+        cmake --build cmake-out -j$(( $(nproc) - 1 ))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,12 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 announce_configured_options(CMAKE_BUILD_TYPE)
 
+if(WIN32)
+  if(NOT "${CMAKE_GENERATOR_TOOLSET}" STREQUAL "" AND NOT CMAKE_GENERATOR_TOOLSET MATCHES "Clang")
+    message(FATAL_ERROR "Windows requires clang. Pass '-T ClangCL' in the cmake build command. Current CMAKE_GENERATOR_TOOLSET: ${CMAKE_GENERATOR_TOOLSET}")
+  endif()
+endif()
+
 if(NOT PYTHON_EXECUTABLE)
   resolve_python_executable()
 endif()


### PR DESCRIPTION
### Summary
* We currently only support MSVC+clang, so let's enforce it
* Use clang in CI after https://github.com/pytorch/test-infra/pull/6654

### Test plan
CI
