### PR TITLE
refactor: remove backward compatibility and simplify Llama2Model configuration

### DIFF
--- a/examples/models/llama/export_llama_lib.py
+++ b/examples/models/llama/export_llama_lib.py
@@ -1226,11 +1226,6 @@ def _load_llama_model(
         EagerModelFactory.create_model(
             module_name,
             model_class_name,
-            checkpoint=checkpoint,
-            checkpoint_dir=checkpoint_dir,
-            params=params_path,
-            fairseq2=weight_type == WeightType.FAIRSEQ2,
-            dtype=torch_dtype,
             llm_config=llm_config,
         )
     )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #11171
* #11170
* __->__ #11169
* #11168
* #11167
* #11166
* #11165
* #11162
* #11081
* #11029
* #11028

