### PR TITLE
adjust platform compatibility for qnn backend

### DIFF
--- a/backends/qualcomm/targets.bzl
+++ b/backends/qualcomm/targets.bzl
@@ -92,4 +92,5 @@ def define_common_targets():
         exported_deps = [
             ":schema",
         ],
+        platforms = [ANDROID],
     )


### PR DESCRIPTION
Summary: The Qualcomm dependencies are only available for Android, so let's mark the target accordingly.

Differential Revision: D75139951


