### PR TITLE
Fix calibration data propagation

### DIFF
--- a/backends/cadence/aot/compiler.py
+++ b/backends/cadence/aot/compiler.py
@@ -275,6 +275,7 @@ def quantize_and_export_to_edge(
     quantizer: Optional[CadenceQuantizer] = None,
     dump_graphs: bool = False,
     constant_methods: Optional[dict[str, object]] = None,
+    calibration_data: Optional[list[tuple[object, ...]]] = None,
 ) -> EdgeProgramManager:
     """
     Trace, quantize and lower a model/inputs pair to edge IR.
@@ -283,6 +284,7 @@ def quantize_and_export_to_edge(
         model,
         inputs,
         quantizer=quantizer,
+        calibration_data=calibration_data,
         dump_graphs=dump_graphs,
     )
 


### PR DESCRIPTION
Summary: `quantize_and_export_to_executorch` is not using the variable. Propagate it properly to `quantize_and_export_to_edge` and then `quantize_pt2`

Differential Revision: D75532269


