### PR TITLE
Rename Apple simulator libs to maintain backwards compatibility

### DIFF
--- a/scripts/build_apple_frameworks.sh
+++ b/scripts/build_apple_frameworks.sh
@@ -9,6 +9,8 @@ set -euxo pipefail
 
 MODES=("Release" "Debug")
 PRESETS=("ios" "ios-simulator" "macos")
+# To support backwards compatibility, we want to retain the same output directory.
+PRESETS_RELATIVE_OUT_DIR=("ios" "simulator" "macos")
 
 SOURCE_ROOT_DIR=$(git rev-parse --show-toplevel)
 OUTPUT_DIR="${SOURCE_ROOT_DIR}/cmake-out"
@@ -142,20 +144,22 @@ done
 echo "Building libraries"
 
 rm -rf "${OUTPUT_DIR}"
-for preset in "${PRESETS[@]}"; do
+for preset_index in "${!PRESETS[@]}"; do
+  preset="${PRESETS[$preset_index]}"
+  preset_output_dir="${OUTPUT_DIR}/${PRESETS_RELATIVE_OUT_DIR[$preset_index]}"
+
   for mode in "${MODES[@]}"; do
-    output_dir="${OUTPUT_DIR}/${preset}"
-    echo "Building preset ${preset} (${mode}) in ${output_dir}..."
+    echo "Building preset ${preset} (${mode}) in ${preset_output_dir}..."
 
     # Do NOT add options here. Update the respective presets instead.
     cmake -S "${SOURCE_ROOT_DIR}" \
-          -B "${output_dir}" \
-          -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY="${output_dir}" \
+          -B "${preset_output_dir}" \
+          -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY="${preset_output_dir}" \
           -DCMAKE_BUILD_TYPE="${mode}" \
           ${CMAKE_OPTIONS_OVERRIDE[@]:-} \
           --preset "${preset}"
 
-    cmake --build "${output_dir}" \
+    cmake --build "${preset_output_dir}" \
           --config "${mode}" \
           -j$(sysctl -n hw.ncpu)
   done
@@ -220,9 +224,9 @@ append_framework_flag() {
 
 for mode in "${MODES[@]}"; do
   FRAMEWORK_FLAGS=()
-  for preset in "${PRESETS[@]}"; do
-    echo "Framework directory: ${preset}/${mode}"
-    FRAMEWORK_FLAGS+=("--directory=${preset}/${mode}")
+  for preset_out_dir in "${PRESETS_RELATIVE_OUT_DIR[@]}"; do
+    echo "Framework directory: ${preset_out_dir}/${mode}"
+    FRAMEWORK_FLAGS+=("--directory=${preset_out_dir}/${mode}")
   done
 
   append_framework_flag "" "$FRAMEWORK_EXECUTORCH" "$mode"
@@ -240,8 +244,8 @@ done
 
 echo "Cleaning up"
 
-for preset in "${PRESETS[@]}"; do
-  rm -rf "${OUTPUT_DIR}/${preset}/$preset"
+for preset_out_dir in "${PRESETS_RELATIVE_OUT_DIR[@]}"; do
+  rm -rf "${OUTPUT_DIR}/${preset_out_dir}"
 done
 
 rm -rf "$HEADERS_ABSOLUTE_PATH"


### PR DESCRIPTION
### Summary

Given people hardcode these lib values, let's just maintain backwards compatibility when generating the frameworks.

### Test plan

Built the framework and checked the simulator suffix.
