### PR TITLE
Export recipe changes for export_llama integration

### DIFF
--- a/export/TARGETS
+++ b/export/TARGETS
@@ -12,6 +12,7 @@ python_library(
         "//executorch/exir/backend:backend_api",
         "//executorch/exir:pass_manager",
         "//executorch/devtools/backend_debug:delegation_info",
+        "//executorch/extension/export_util:export_util",
     ]
 )
 

--- a/export/recipe.py
+++ b/export/recipe.py
@@ -49,17 +49,17 @@ class QuantizationRecipe:
         quantizer: Optional quantizer for model quantization
     """
 
-    quantizer: Optional[Quantizer] = None
+    quantizers: Optional[List[Quantizer]] = None
     ao_base_config: Optional[List[AOBaseConfig]] = None
 
-    def get_quantizer(self) -> Optional[Quantizer]:
+    def get_quantizers(self) -> Optional[Quantizer]:
         """
         Get the quantizer associated with this recipe.
 
         Returns:
             The quantizer if one is set, otherwise None
         """
-        return self.quantizer
+        return self.quantizers
 
 
 @experimental(
@@ -94,10 +94,11 @@ class ExportRecipe:
     )
     pre_edge_transform_passes: Optional[
         Callable[[ExportedProgram], ExportedProgram]
+        | List[Callable[[ExportedProgram], ExportedProgram]]
     ] = None
     edge_transform_passes: Optional[Sequence[PassType]] = None
     transform_check_ir_validity: bool = True
-    partitioners: Optional[list[Partitioner]] = None
+    partitioners: Optional[List[Partitioner]] = None
     executorch_backend_config: Optional[ExecutorchBackendConfig] = (
         None  # pyre-ignore[11]: Type not defined
     )


### PR DESCRIPTION
These were the changes needed to be made to support recipes integration in export_llama. Mainly the changes are:
- Making the quantizers a list and using ComposableQuantizer
- Making the partitioners a list and running through the list of partitioners
- Disable backend validation in to_edge_transform_and_lower which significantly speeds things up