### PR TITLE
Export recipes integration in export_llama

### DIFF
--- a/export/recipe.py
+++ b/export/recipe.py
@@ -49,17 +49,17 @@ class QuantizationRecipe:
         quantizer: Optional quantizer for model quantization
     """
 
-    quantizer: Optional[Quantizer] = None
+    quantizers: Optional[List[Quantizer]] = None
     ao_base_config: Optional[List[AOBaseConfig]] = None
 
-    def get_quantizer(self) -> Optional[Quantizer]:
+    def get_quantizers(self) -> Optional[Quantizer]:
         """
         Get the quantizer associated with this recipe.
 
         Returns:
             The quantizer if one is set, otherwise None
         """
-        return self.quantizer
+        return self.quantizers
 
 
 @experimental(
@@ -94,10 +94,11 @@ class ExportRecipe:
     )
     pre_edge_transform_passes: Optional[
         Callable[[ExportedProgram], ExportedProgram]
+        | List[Callable[[ExportedProgram], ExportedProgram]]
     ] = None
     edge_transform_passes: Optional[Sequence[PassType]] = None
     transform_check_ir_validity: bool = True
-    partitioners: Optional[list[Partitioner]] = None
+    partitioners: Optional[List[Partitioner]] = None
     executorch_backend_config: Optional[ExecutorchBackendConfig] = (
         None  # pyre-ignore[11]: Type not defined
     )

--- a/extension/llm/export/export_passes.py
+++ b/extension/llm/export/export_passes.py
@@ -3,6 +3,7 @@ import logging
 import torch
 
 from executorch.exir.pass_base import ExportPass
+from executorch.exir.program._program import _update_exported_program_graph_module
 from torch._subclasses import FakeTensor
 from torch.fx.passes.infra.pass_base import PassResult
 
@@ -97,6 +98,14 @@ class RemoveRedundantTransposes(ExportPass):
         graph_module.recompile()
 
         return PassResult(graph_module, graph_changed)
+
+
+def remove_redundant_transposes(
+    ep: torch.export.ExportedProgram,
+) -> torch.export.ExportedProgram:
+    res = RemoveRedundantTransposes()(ep.graph_module)
+    assert res is not None
+    return _update_exported_program_graph_module(ep, res.graph_module)
 
 
 class ReplaceSDPAWithCustomSDPAPass(ExportPass):

--- a/extension/llm/export/recipes.py
+++ b/extension/llm/export/recipes.py
@@ -1,0 +1,36 @@
+from executorch.export.recipe import ExportRecipe, QuantizationRecipe
+from executorch.exir import EdgeCompileConfig
+from executorch.extension.llm.export.quantizer_lib import get_quantizer_and_quant_params
+from executorch.extension.llm.export.export_passes import remove_redundant_transposes
+from executorch.extension.llm.export.partitioner_lib import (
+    get_coreml_partitioner,
+    get_mps_partitioner,
+    get_qnn_partitioner,
+    get_vulkan_partitioner,
+    get_xnnpack_partitioner,
+)
+
+def get_llm_recipe(args) -> ExportRecipe:
+    pt2e_quant_params, quantizers, quant_dtype = get_quantizer_and_quant_params(args)
+
+    if pt2e_quant_params is not None and pt2e_quant_params.quantize_linear is not None:
+        # Force xnnpack to be true if pt2e_quant_params is not None and args.xnnpack is False
+        args.xnnpack = True
+
+    quant_recipe = QuantizationRecipe(
+        quantizers=quantizers,
+    )
+
+    partitioners = []
+    if args.xnnpack:
+        partitioners.append(get_xnnpack_partitioner(dynamic_quant_only_partitioner=True))
+    if args.xnnpack_extended_ops:
+        partitioners.append(get_xnnpack_partitioner(dynamic_quant_only_partitioner=False))
+    
+    return ExportRecipe(
+        quantization_recipe=quant_recipe,
+        edge_compile_config=EdgeCompileConfig(_check_ir_validity=False),
+        pre_edge_transform_passes=[remove_redundant_transposes],
+        edge_transform_passes=[],
+        partitioners=partitioners,
+    )


### PR DESCRIPTION
This PR makes the changes required to integrate XNNPack recipes into the export_llama flow. It adds a helper utility to generate XNNpack recipes and adds an experimental flag to export_llama to use the recipe based flow.
