### PR TITLE
Expose gen_oplist_lib to clients

### DIFF
--- a/codegen/tools/targets.bzl
+++ b/codegen/tools/targets.bzl
@@ -14,6 +14,7 @@ def define_common_targets(is_fbcode = False):
         base_module = "executorch.codegen.tools",
         visibility = [
             "//executorch/...",
+            "@EXECUTORCH_CLIENTS",
         ],
         deps = [
             "//executorch/codegen:gen_lib",


### PR DESCRIPTION
Summary: I'm working on a linter that checks a model's ops against those available in our runtime environment (see D75110565), and I'd like to call `gen_oplist` programmatically. I can't do that because `gen_oplist_lib` is not visible outside the `executorch` subdir. If there are no objections, I'd like to expose it to clients.

Differential Revision: D75630096


