### PR TITLE
Move c10::DeviceType to a standalone header file

### DIFF
--- a/runtime/core/portable_type/c10/c10/macros/Export.h
+++ b/runtime/core/portable_type/c10/c10/macros/Export.h
@@ -1,95 +1,10 @@
-#ifndef C10_MACROS_EXPORT_H_
-#define C10_MACROS_EXPORT_H_
-
-/* Header file to define the common scaffolding for exported symbols.
- *
- * Export is by itself a quite tricky situation to deal with, and if you are
- * hitting this file, make sure you start with the background here:
- * - Linux: https://gcc.gnu.org/wiki/Visibility
- * - Windows:
- * https://docs.microsoft.com/en-us/cpp/cpp/dllexport-dllimport?view=vs-2017
- *
- * Do NOT include this file directly. Instead, use c10/macros/Macros.h
- */
-
-// You do not need to edit this part of file unless you are changing the core
-// pytorch export abstractions.
-//
-// This part defines the C10 core export and import macros. This is controlled
-// by whether we are building shared libraries or not, which is determined
-// during build time and codified in c10/core/cmake_macros.h.
-// When the library is built as a shared lib, EXPORT and IMPORT will contain
-// visibility attributes. If it is being built as a static lib, then EXPORT
-// and IMPORT basically have no effect.
-
-// As a rule of thumb, you should almost NEVER mix static and shared builds for
-// libraries that depend on c10. AKA, if c10 is built as a static library, we
-// recommend everything dependent on c10 to be built statically. If c10 is built
-// as a shared library, everything dependent on it should be built as shared. In
-// the PyTorch project, all native libraries shall use the macro
-// C10_BUILD_SHARED_LIB to check whether pytorch is building shared or static
-// libraries.
-
-// For build systems that do not directly depend on CMake and directly build
-// from the source directory (such as Buck), one may not have a cmake_macros.h
-// file at all. In this case, the build system is responsible for providing
-// correct macro definitions corresponding to the cmake_macros.h.in file.
-//
-// In such scenarios, one should define the macro
-//     C10_USING_CUSTOM_GENERATED_MACROS
-// to inform this header that it does not need to include the cmake_macros.h
-// file.
+#pragma once
 
 #ifndef C10_USING_CUSTOM_GENERATED_MACROS
 #include <c10/macros/cmake_macros.h>
 #endif // C10_USING_CUSTOM_GENERATED_MACROS
 
-#ifdef _WIN32
-#define C10_HIDDEN
-#if defined(C10_BUILD_SHARED_LIBS)
-#define C10_EXPORT __declspec(dllexport)
-#define C10_IMPORT __declspec(dllimport)
-#else
-#define C10_EXPORT
-#define C10_IMPORT
-#endif
-#else // _WIN32
-#if defined(__GNUC__)
-#define C10_EXPORT __attribute__((__visibility__("default")))
-#define C10_HIDDEN __attribute__((__visibility__("hidden")))
-#else // defined(__GNUC__)
-#define C10_EXPORT
-#define C10_HIDDEN
-#endif // defined(__GNUC__)
-#define C10_IMPORT C10_EXPORT
-#endif // _WIN32
-
-#ifdef NO_EXPORT
-#undef C10_EXPORT
-#define C10_EXPORT
-#endif
-
-// Definition of an adaptive XX_API macro, that depends on whether you are
-// building the library itself or not, routes to XX_EXPORT and XX_IMPORT.
-// Basically, you will need to do this for each shared library that you are
-// building, and the instruction is as follows: assuming that you are building
-// a library called libawesome.so. You should:
-// (1) for your cmake target (usually done by "add_library(awesome, ...)"),
-//     define a macro called AWESOME_BUILD_MAIN_LIB using
-//     target_compile_options.
-// (2) define the AWESOME_API macro similar to the one below.
-// And in the source file of your awesome library, use AWESOME_API to
-// annotate public symbols.
-
-// Here, for the C10 library, we will define the macro C10_API for both import
-// and export.
-
-// This one is being used by libc10.so
-#ifdef C10_BUILD_MAIN_LIB
-#define C10_API C10_EXPORT
-#else
-#define C10_API C10_IMPORT
-#endif
+#include <torch/standalone/core/Export.h>
 
 // This one is being used by libtorch.so
 #ifdef CAFFE2_BUILD_MAIN_LIB
@@ -151,12 +66,3 @@
 #else
 #define TORCH_XPU_API C10_IMPORT
 #endif
-
-// Enums only need to be exported on windows for non-CUDA files
-#if defined(_WIN32) && defined(__CUDACC__)
-#define C10_API_ENUM C10_API
-#else
-#define C10_API_ENUM
-#endif
-
-#endif // C10_MACROS_MACROS_H_

--- a/runtime/core/portable_type/c10/c10/targets.bzl
+++ b/runtime/core/portable_type/c10/c10/targets.bzl
@@ -41,6 +41,12 @@ def define_common_targets():
             "//executorch/...",
             "@EXECUTORCH_CLIENTS",
         ],
+        fbcode_exported_deps = [
+            "//caffe2:torch_standalone_headers",
+        ] if not runtime.is_oss else [],
+        xplat_exported_deps = [
+            "//xplat/caffe2:torch_standalone_headers",
+        ],
         deps = select({
             "DEFAULT": [],
             # Half-inl.h depends on vec_half.h from ATen, but only when building for x86.


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/pytorch/pull/154654

The goal of this PR and future follow-up PRs is to group a set of header files required by AOTInductor Standalone in a separate directory, ensuring they are implemented in a header-only manner. More specifically, here is what this PR does:
* Extract the DeviceType enum class into a standalone header file in a new torch/standalone/header_only directory
* Retain the existing c10/core/DeviceType.[h|cpp] files to handle complex logic and static variables
* Import symbols from the new torch::standalone namespace into c10 for backward compatibility

This is an updated version of https://github.com/pytorch/pytorch/pull/152787, because we need to land in fbcode first. See the original comments and discussions in https://github.com/pytorch/pytorch/pull/152787.

Differential Revision: D75605373
