### PR TITLE
Don't depend on `aten_headers_for_executorch` when running with HTP simulator since it already gets this dep from xplat

### DIFF
--- a/runtime/core/portable_type/c10/c10/targets.bzl
+++ b/runtime/core/portable_type/c10/c10/targets.bzl
@@ -44,7 +44,8 @@ def define_common_targets():
         deps = select({
             "DEFAULT": [],
             # Half-inl.h depends on vec_half.h from ATen, but only when building for x86.
-            "ovr_config//cpu:x86_64": [
+            # Deps get pulled in twice if HTP sim is enabled.
+            "ovr_config//cpu:x86_64": [] if read_config("user", "enable_fllm_on_htp_sim", "false") == "true" else [
                 ":aten_headers_for_executorch",
             ],
         }),


### PR DESCRIPTION
Differential Revision: D75488427

This prevents linker errors when building with `-c user.enable_fllm_on_htp_sim=true`.
