### PR TITLE
Add where layer to ops registry

### DIFF
--- a/backends/vulkan/op_registry.py
+++ b/backends/vulkan/op_registry.py
@@ -259,6 +259,17 @@ def register_binary_op(features: OpFeatures):
         valid_packed_dims=all_packed_dims,
     )
     features.resize_fn = True
+    features.buffer_impl = True
+    return features
+
+
+@update_features(exir_ops.edge.aten.where.self)
+def register_where_op(features: OpFeatures):
+    features.texture_impl = TextureImplFeatures(
+        valid_packed_dims=all_packed_dims,
+    )
+    features.buffer_impl = True
+    features.resize_fn = True
     return features
 
 


### PR DESCRIPTION
Summary: To export models to the ET vulkan backend it is necessary that the op is added to the registry. This also registers the buffer implementation of the binary operations.

Differential Revision: D75686562


