### PR TITLE
Arm backend: Make pre-push non-interactive on one argument

### DIFF
--- a/backends/arm/scripts/pre-push
+++ b/backends/arm/scripts/pre-push
@@ -4,9 +4,9 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# Calling this script with any argument is equal to launching it in
+# Calling this script with one argument is equal to launching it in
 # non-interactive mode. "$#" gives the number of positional arguments.
-[ "$#" -eq 0 ] && is_script_interactive=1 || is_script_interactive=0
+[ "$#" -eq 1 ] && is_script_interactive=1 || is_script_interactive=0
 
 if [ $is_script_interactive -eq 1 ]; then
     RESET='\e[0m'


### PR DESCRIPTION
Calling pre-push as a git hook actually supplies it with 2 arguments, remote-name and remote-url. So the logic of automatically going non-interactive when there are any arguments is flawed.

This commit makes sure pre-push only goes non-interactive when there is only one argument.

Signed-off-by: per.held@arm.com
Change-Id: I21cc05b24521bb075c2f74fe4ed7f773b797b085


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218