### PR TITLE
Arm backend: Reduce atol in vector_norm test

### DIFF
--- a/backends/arm/test/ops/test_linalg_vector_norm.py
+++ b/backends/arm/test/ops/test_linalg_vector_norm.py
@@ -72,7 +72,6 @@ def test_vector_norm_tosa_MI(test_module):
 
     pipeline = TosaPipelineMI[input_t](model, input_tensor, aten_op, exir_op)
 
-    pipeline.change_args("run_method_and_compare_outputs", qtol=1, atol=1e-4, rtol=1e-4)
     pipeline.run()
 
 
@@ -90,7 +89,6 @@ def test_vector_norm_tosa_BI(test_module):
         exir_op,
         symmetric_io_quantization=True,
     )
-    pipeline.change_args("run_method_and_compare_outputs", qtol=1, atol=1, rtol=1)
     pipeline.run()
 
 
@@ -107,13 +105,12 @@ def test_vector_norm_u55_BI_fvp(test_module):
         run_on_fvp=True,
         symmetric_io_quantization=True,
     )
-    pipeline.change_args("run_method_and_compare_outputs", qtol=1, atol=1, rtol=1)
     pipeline.pop_stage("check_not.exir")
     pipeline.run()
 
 
 @common.parametrize("test_module", test_modules)
-@common.XfailIfNoCorstone300
+@common.XfailIfNoCorstone320
 def test_vector_norm_u85_BI_fvp(test_module):
     model, input_tensor = test_module
 
@@ -126,6 +123,5 @@ def test_vector_norm_u85_BI_fvp(test_module):
         run_on_fvp=True,
         symmetric_io_quantization=True,
     )
-    pipeline.change_args("run_method_and_compare_outputs", qtol=1, atol=1, rtol=1)
     pipeline.pop_stage("check_not.exir")
     pipeline.run()


### PR DESCRIPTION
pipeline.change_args("run_method_and_compare_outputs",...) was used to change qtol, but as no inputs were passed in the call run_method_and_compare_outputs produced new inputs with a different distribution (randn), than what was used for calibration (rand).


cc @digantdesai @freddan80 @per @zingo