### PR TITLE
Arm backend: aot_arm_compiler.py: Create output dir

### DIFF
--- a/examples/arm/aot_arm_compiler.py
+++ b/examples/arm/aot_arm_compiler.py
@@ -668,6 +668,8 @@ def save_bpte_program(exec_prog, original_model: torch.nn.Module, output_name: s
         )
 
     # Generate BundledProgram
+    output_dir = os.path.dirname(output_name)
+    os.makedirs(output_dir, exist_ok=True)
     save_bundled_program(exec_prog, method_test_suites, output_name)
 
 


### PR DESCRIPTION
Create output directory for the generated BundledProgram if it does not already exist. This will save the user time by not having to rerun the program due to it complaining that the directory does not exist.


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218