### PR TITLE
Make the intermediate output capturer more extensible

### DIFF
--- a/devtools/inspector/tests/intermediate_output_capturer_test.py
+++ b/devtools/inspector/tests/intermediate_output_capturer_test.py
@@ -111,8 +111,6 @@ class TestIntermediateOutputCapturer(unittest.TestCase):
             (19,): torch.tensor([[3.6000, 4.5067]]),
             (20,): torch.tensor([[0.9734, 0.9891]]),
             (21,): [torch.tensor([[0.9734]]), torch.tensor([[0.9891]])],
-            (22,): torch.tensor([[0.9734]]),
-            (23,): torch.tensor([[0.9891]]),
         }
         self.assertEqual(
             len(self.intermediate_outputs), len(expected_outputs_with_handles)


### PR DESCRIPTION
Summary: Make the intermediate output capturer more extensible by adding a NodeFilter class. Add one rule to the intermediate output capturer to skip the getitem node for now.

Differential Revision: D75699297


