### PR TITLE
Remove remaining reference to torchgen.gen_executorch

### DIFF
--- a/codegen/api/et_cpp.py
+++ b/codegen/api/et_cpp.py
@@ -2,15 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from executorch.codegen.api.types import (
-    ArrayRefCType,
-    BaseTypeToCppMapping,
-    OptionalCType,
-    scalarT,
-    tensorListT,
-    tensorT,
-)
-
 from torchgen import local
 from torchgen.api.types import (
     ArgName,
@@ -39,6 +30,15 @@ from torchgen.model import (
     Type,
 )
 from typing_extensions import assert_never
+
+from .types import (
+    ArrayRefCType,
+    BaseTypeToCppMapping,
+    OptionalCType,
+    scalarT,
+    tensorListT,
+    tensorT,
+)
 
 
 if TYPE_CHECKING:

--- a/codegen/api/types/__init__.py
+++ b/codegen/api/types/__init__.py
@@ -1,5 +1,5 @@
 # flake8: noqa: F403, F401
-from executorch.codegen.api.types.types import *
+from .types import *
 
 # flake8: noqa: F403, F401
-from executorch.codegen.api.types.signatures import *  # usort: skip
+from .signatures import *  # usort: skip

--- a/codegen/api/types/signatures.py
+++ b/codegen/api/types/signatures.py
@@ -4,7 +4,8 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import torchgen.api.cpp as aten_cpp
-from executorch.codegen.api.types.types import contextArg
+
+from .types import contextArg
 
 
 if TYPE_CHECKING:
@@ -73,4 +74,4 @@ class ExecutorchCppSignature:
         )
 
 
-from executorch.codegen.api import et_cpp
+from .. import et_cpp

--- a/codegen/gen.py
+++ b/codegen/gen.py
@@ -8,15 +8,32 @@ from pathlib import Path
 from typing import Any, Callable, TextIO, TYPE_CHECKING
 
 import yaml
-from executorch.codegen.api import et_cpp
-from executorch.codegen.api.custom_ops import (
-    ComputeNativeFunctionStub,
-    gen_custom_ops_registration,
-)
-from executorch.codegen.api.types import contextArg, ExecutorchCppSignature
-from executorch.codegen.api.unboxing import Unboxing
-from executorch.codegen.model import ETKernelIndex, ETKernelKey, ETParsedYaml
-from executorch.codegen.parse import ET_FIELDS, parse_et_yaml, parse_et_yaml_struct
+
+try:
+    from executorch.codegen.api import et_cpp
+    from executorch.codegen.api.custom_ops import (
+        ComputeNativeFunctionStub,
+        gen_custom_ops_registration,
+    )
+    from executorch.codegen.api.types import contextArg, ExecutorchCppSignature
+    from executorch.codegen.api.unboxing import Unboxing
+    from executorch.codegen.model import ETKernelIndex, ETKernelKey, ETParsedYaml
+    from executorch.codegen.parse import ET_FIELDS, parse_et_yaml, parse_et_yaml_struct
+except ImportError:
+    # If we build from source, executorch.codegen is not available.
+    from .api import et_cpp  # type: ignore[no-redef]
+    from .api.custom_ops import (  # type: ignore
+        ComputeNativeFunctionStub,
+        gen_custom_ops_registration,
+    )
+    from .api.types import contextArg, ExecutorchCppSignature  # type: ignore
+    from .api.unboxing import Unboxing  # type: ignore
+    from .model import ETKernelIndex, ETKernelKey, ETParsedYaml  # type: ignore
+    from .parse import (  # type: ignore[no-redef]
+        ET_FIELDS,
+        parse_et_yaml,
+        parse_et_yaml_struct,
+    )
 
 # Parse native_functions.yaml into a sequence of NativeFunctions and Backend Indices.
 from torchgen import dest

--- a/codegen/test/test_executorch_custom_ops.py
+++ b/codegen/test/test_executorch_custom_ops.py
@@ -15,8 +15,8 @@ import expecttest
 
 import torchgen
 from executorch.codegen.api.custom_ops import ComputeNativeFunctionStub
+from executorch.codegen.gen import gen_headers
 from executorch.codegen.model import ETKernelIndex
-from torchgen.gen_executorch import gen_headers
 from torchgen.model import Location, NativeFunction
 from torchgen.selective_build.selector import SelectiveBuilder
 from torchgen.utils import FileManager

--- a/codegen/test/test_executorch_gen.py
+++ b/codegen/test/test_executorch_gen.py
@@ -11,15 +11,15 @@ import tempfile
 import unittest
 
 import yaml
-
-from executorch.codegen.model import ETKernelIndex, ETKernelKey
-from torchgen.gen import LineLoader
-from torchgen.gen_executorch import (
+from executorch.codegen.gen import (
     ComputeCodegenUnboxedKernels,
     gen_functions_declarations,
     parse_yaml_files,
     translate_native_yaml,
 )
+
+from executorch.codegen.model import ETKernelIndex, ETKernelKey
+from torchgen.gen import LineLoader
 from torchgen.model import (
     BackendIndex,
     BackendMetadata,

--- a/codegen/tools/gen_oplist.py
+++ b/codegen/tools/gen_oplist.py
@@ -20,6 +20,7 @@ except ImportError:
     # We can use relative import instead.
     from ..parse import strip_et_fields
 
+
 from torchgen.gen import LineLoader, parse_native_yaml_struct
 from torchgen.selective_build.operator import SelectiveBuildOperator
 from torchgen.selective_build.selector import merge_et_kernel_metadata

--- a/third-party/TARGETS
+++ b/third-party/TARGETS
@@ -81,18 +81,6 @@ runtime.python_binary(
     _is_external_target = True,
 )
 
-runtime.python_binary(
-    name = "gen_executorch",
-    main_module = "torchgen.gen_executorch",
-    visibility = [
-        "PUBLIC",
-    ],
-    deps = [
-        ":torchgen",
-    ],
-    _is_external_target = True,
-)
-
 runtime.filegroup(
     name = "aten_src_path",
     srcs = [

--- a/tools/cmake/Codegen.cmake
+++ b/tools/cmake/Codegen.cmake
@@ -91,8 +91,9 @@ function(generate_bindings_for_kernels)
     OUTPUT_STRIP_TRAILING_WHITESPACE
   )
   file(GLOB_RECURSE _torchgen_srcs "${torchgen-out}/*.py")
+  # Not using module executorch.codegen.gen because it's not installed yet.
   set(_gen_command
-      "${PYTHON_EXECUTABLE}" -m torchgen.gen_executorch
+      "${PYTHON_EXECUTABLE}" -m codegen.gen
       --source-path=${EXECUTORCH_ROOT}/codegen --install-dir=${_out_dir}
       --tags-path=${torchgen-out}/packaged/ATen/native/tags.yaml
       --aten-yaml-path=${torchgen-out}/packaged/ATen/native/native_functions.yaml


### PR DESCRIPTION
Summary:
Fixes #11232
This is part of an effort to remove ExecuTorch related codegen code in pytorch/pytorch's torchgen module. We need to remove `torchgen.gen_executorch` in ExecuTorch and use `executorch.codegen.gen` instead.

Differential Revision: D75800153


