### PR TITLE
Removing uneeded buck deps in cmake build flow

### DIFF
--- a/.ci/scripts/utils.sh
+++ b/.ci/scripts/utils.sh
@@ -158,8 +158,7 @@ build_executorch_runner() {
 cmake_install_executorch_lib() {
   echo "Installing libexecutorch.a and libportable_kernels.a"
   clean_executorch_install_folders
-  retry cmake -DBUCK2="$BUCK" \
-          -DCMAKE_INSTALL_PREFIX=cmake-out \
+  retry cmake -DCMAKE_INSTALL_PREFIX=cmake-out \
           -DCMAKE_BUILD_TYPE=Release \
           -DPYTHON_EXECUTABLE="$PYTHON_EXECUTABLE" \
           -Bcmake-out .

--- a/examples/selective_build/test_selective_build.sh
+++ b/examples/selective_build/test_selective_build.sh
@@ -92,8 +92,7 @@ test_cmake_select_all_ops() {
     local example_dir=examples/selective_build
     local build_dir=cmake-out/${example_dir}
     rm -rf ${build_dir}
-    retry cmake -DBUCK2="$BUCK" \
-            -DCMAKE_BUILD_TYPE=Release \
+    retry cmake -DCMAKE_BUILD_TYPE=Release \
             -DEXECUTORCH_SELECT_ALL_OPS=ON \
             -DCMAKE_INSTALL_PREFIX=cmake-out \
             -DPYTHON_EXECUTABLE="$PYTHON_EXECUTABLE" \
@@ -118,8 +117,7 @@ test_cmake_select_ops_in_list() {
     local build_dir=cmake-out/${example_dir}
     # set MAX_KERNEL_NUM=22: 19 primops, add, mul
     rm -rf ${build_dir}
-    retry cmake -DBUCK2="$BUCK" \
-            -DCMAKE_BUILD_TYPE=Release \
+    retry cmake -DCMAKE_BUILD_TYPE=Release \
             -DMAX_KERNEL_NUM=22 \
             -DEXECUTORCH_SELECT_OPS_LIST="aten::convolution.out,\
 aten::_native_batch_norm_legit_no_training.out,aten::hardtanh.out,aten::add.out,\
@@ -146,8 +144,7 @@ test_cmake_select_ops_in_yaml() {
     local example_dir=examples/selective_build
     local build_dir=cmake-out/${example_dir}
     rm -rf ${build_dir}
-    retry cmake -DBUCK2="$BUCK" \
-            -DCMAKE_BUILD_TYPE=Release \
+    retry cmake -DCMAKE_BUILD_TYPE=Release \
             -DEXECUTORCH_SELECT_OPS_YAML=ON \
             -DCMAKE_INSTALL_PREFIX=cmake-out \
             -DPYTHON_EXECUTABLE="$PYTHON_EXECUTABLE" \


### PR DESCRIPTION
### Summary
The buck and cmake build flows should be independent, where the cmake build flow should not rely on buck targets to be built or used.

### Test plan
Tested on examples and tutorials, and no functional difference was seen between runs before and after change. 
