### PR TITLE
Fix -Wformat issues from #8612

### DIFF
--- a/runtime/core/exec_aten/testing_util/tensor_factory.h
+++ b/runtime/core/exec_aten/testing_util/tensor_factory.h
@@ -624,8 +624,8 @@ inline void validate_strides(
       if ((strides[i] == strides[j])) {
         ET_CHECK_MSG(
             false,
-            "Stride value and size dont comply at index %d."
-            " strides[%d]: %d, strides[%d] = %d, sizes[%d] = %d, sizes[%d] = %d",
+            "Stride value and size dont comply at index %lu."
+            " strides[%lu]: %d, strides[%d] = %d, sizes[%lu] = %d, sizes[%d] = %d",
             i,
             i,
             strides[i],


### PR DESCRIPTION
Built locally with -Wformat -Werror=format on a recent version of clang. (Apparently, clang12 which we use on CI is not new enough?)