### PR TITLE
Revert "Switch fbcode builds of ExecuTorch and PyTorch to fbsource sl…

### DIFF
--- a/kernels/optimized/lib_defs.bzl
+++ b/kernels/optimized/lib_defs.bzl
@@ -111,6 +111,10 @@ def get_preprocessor_flags():
     return preprocessor_flags
 
 
+# Currently, having a dependency on fbsource//third-party/sleef:sleef may cause
+# duplicate symbol errors when linking fbcode targets in opt mode that also
+# depend on ATen. This is because ATen accesses sleef via the third-party folder
+# in caffe2 (caffe2/third-party//sleef:sleef).
 # TODO(ssjia): Enable -DCPU_CAPABILITY_AVX2 in fbcode, which requires sleef.
 def define_libs(is_fbcode=False):
     runtime.cxx_library(

--- a/runtime/core/portable_type/c10/c10/targets.bzl
+++ b/runtime/core/portable_type/c10/c10/targets.bzl
@@ -1,47 +1,10 @@
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime", "is_arvr_mode")
 
-def get_preprocessor_flags(is_fbcode):
-    flags = ["-DSTANDALONE_TORCH_HEADER"]
-    if runtime.is_oss:
-        return flags
-    arm64_flags = [
-        "-DCPU_CAPABILITY_DEFAULT",
-    ]
-    if is_fbcode:
-        # TODO: enable Sleef in xplat?
-        arm64_flags = arm64_flags + ["-DAT_BUILD_ARM_VEC256_WITH_SLEEF"]
-
-    x86_avx2_flags = [
-        "-DCPU_CAPABILITY_AVX2",
-        "-DHAVE_AVX2_CPU_DEFINITION",
-    ]
-    default_flags = [
-        "-DCPU_CAPABILITY_DEFAULT",
-    ]
-    fbcode_flags = select({
-        "ovr_config//cpu:x86_64": x86_avx2_flags,
-        "ovr_config//cpu:arm64": arm64_flags,
-        "DEFAULT": default_flags,
-    })
-    non_fbcode_flags = select({
-        "ovr_config//cpu/x86:avx2": x86_avx2_flags,
-        "ovr_config//cpu:arm64": arm64_flags,
-        "DEFAULT": default_flags,
-    })
-    return flags + ["-DET_USE_PYTORCH_HEADERS"] + (fbcode_flags if is_fbcode else non_fbcode_flags)
-
-def get_sleef_deps():
+def get_sleef_preprocessor_flags():
     if runtime.is_oss:
         return []
-    return select({
-        "DEFAULT": [],
-        "ovr_config//cpu:x86_64": [
-            "fbsource//third-party/sleef:sleef",
-        ],
-        "ovr_config//cpu:arm64": [
-            "fbsource//third-party/sleef:sleef",
-        ],
-    })
+    return ["-DAT_BUILD_ARM_VEC256_WITH_SLEEF"]
+
 
 def define_common_targets():
     """Defines targets that should be shared between fbcode and xplat.
@@ -91,30 +54,42 @@ def define_common_targets():
         name = "aten_headers_for_executorch",
         srcs = [],
         visibility = ["//executorch/kernels/optimized/...", "@EXECUTORCH_CLIENTS"],
-        # select() on ovr_config//runtime:fbcode does not work
-        # properly in all cases. I have seen
-        # //xplat/executorch/runtime/core/portable_type/c10/c10:aten_headers_for_executorch
-        # pass such a select in (at least) arvr mode. Going back to
-        # fbcode_exported_deps accordingly.
         exported_deps = select({
             "DEFAULT": [],
             "ovr_config//cpu:arm64": [
                 "fbsource//third-party/sleef:sleef",
             ] if not runtime.is_oss else [],
+            # fbsource//third-party/sleef:sleef currently fails to
+            # link with missing symbols, hence the fbcode-specific dep below.
         }),
-        xplat_exported_deps = [
-            "//xplat/caffe2:aten_header",
-            "//xplat/caffe2/c10:c10_headers",
-            ("//xplat/caffe2:ovrsource_aten_Config.h"
-            if is_arvr_mode() else "//xplat/caffe2:generated_aten_config_header"),
-        ], # + get_sleef_deps(), # TODO: enable Sleef in xplat?
         fbcode_exported_deps = ([
             "//caffe2:aten-headers-cpu",
             "//caffe2:generated-config-header",
             "//caffe2/c10:c10_headers",
-        ] + get_sleef_deps()) if not runtime.is_oss else [],
-        exported_preprocessor_flags = get_preprocessor_flags(is_fbcode=False)
-        + ([] if runtime.is_oss else ["-DET_USE_PYTORCH_HEADERS"]),
-        fbcode_exported_preprocessor_flags = get_preprocessor_flags(is_fbcode=True)
-        + ([] if runtime.is_oss else ["-DET_USE_PYTORCH_HEADERS"]),
+        ] + select({
+            "DEFAULT": [],
+            "ovr_config//cpu:x86_64": [
+                "third-party//sleef:sleef",
+            ]
+        })) if not runtime.is_oss else [],
+        fbcode_exported_preprocessor_flags = [
+            # We don't -DCPU_CAPABILITY=AVX2 because that trips
+            # -Wmacro-redefined, and we only care about getting
+            # reasonable vectorization and Sleef support.
+            "-DCPU_CAPABILITY_AVX2",
+            "-DET_USE_PYTORCH_HEADERS",
+            "-DHAVE_AVX2_CPU_DEFINITION",
+            "-DSTANDALONE_TORCH_HEADER",
+        ] + get_sleef_preprocessor_flags(),
+        xplat_exported_deps = [
+            "//xplat/caffe2:aten_header",
+            "//xplat/caffe2/c10:c10_headers",
+        ] + ["//xplat/caffe2:ovrsource_aten_Config.h" if is_arvr_mode() else "//xplat/caffe2:generated_aten_config_header",],
+        exported_preprocessor_flags = select({
+            # Intentionally punting on non-fbcode x86 sleef support
+            # for now because of fbsource//third-party/sleef:sleef
+            # linker failure.
+            "ovr_config//cpu:arm64": get_sleef_preprocessor_flags(),
+            "DEFAULT": [],
+        }) + ["-DSTANDALONE_TORCH_HEADER"] + ([] if runtime.is_oss else ["-DET_USE_PYTORCH_HEADERS"]),
     )

--- a/shim_et/xplat/executorch/kernels/optimized/lib_defs.bzl
+++ b/shim_et/xplat/executorch/kernels/optimized/lib_defs.bzl
@@ -69,14 +69,15 @@ def get_vec_cxx_preprocessor_flags():
     return preprocessor_flags
 
 def get_vec_fbcode_preprocessor_flags():
-    preprocessor_flags = select({
-        "ovr_config//cpu/x86:avx2": [
-            "-DCPU_CAPABILITY_AVX2",
-        ],
-        "DEFAULT": [],
-    })
+    preprocessor_flags = [
+        "-DCPU_CAPABILITY_AVX2",
+    ]
     return preprocessor_flags
 
+# Currently, having a dependency on fbsource//third-party/sleef:sleef may cause
+# duplicate symbol errors when linking fbcode targets in opt mode that also
+# depend on ATen. This is because ATen accesses sleef via the third-party folder
+# in caffe2 (caffe2/third-party//sleef:sleef).
 # TODO(ssjia): Enable -DCPU_CAPABILITY_AVX2 in fbcode, which requires sleef.
 def define_libs():
     runtime.cxx_library(


### PR DESCRIPTION
…eef (#11352)"

This reverts commit 7d0e9547ab035f836b82fa3f3d395939194fbc8a.

It's already reverted internally, updating OSS and then we can skip the difftrain [D75968042](https://www.internalfb.com/diff/D75968042)


```
git revert 7d0e9547ab
```