### PR TITLE
Don't use git to get the repo root

### DIFF
--- a/examples/apple/coreml/scripts/build_executor_runner.sh
+++ b/examples/apple/coreml/scripts/build_executor_runner.sh
@@ -33,8 +33,7 @@ for arg in "$@"; do
   esac
 done
 
-
-EXECUTORCH_ROOT_PATH=$(git rev-parse --show-toplevel)
+EXECUTORCH_ROOT_PATH=$(realpath -m "$0/../../../../..")
 COREML_DIR_PATH="$EXECUTORCH_ROOT_PATH/backends/apple/coreml"
 EXAMPLES_COREML_DIR_PATH="$EXECUTORCH_ROOT_PATH/examples/apple/coreml"
 IOS_TOOLCHAIN_PATH="$EXECUTORCH_ROOT_PATH/third-party/ios-cmake/ios.toolchain.cmake"

--- a/scripts/build_apple_frameworks.sh
+++ b/scripts/build_apple_frameworks.sh
@@ -12,7 +12,7 @@ PRESETS=("ios" "ios-simulator" "macos")
 # To support backwards compatibility, we want to retain the same output directory.
 PRESETS_RELATIVE_OUT_DIR=("ios" "simulator" "macos")
 
-SOURCE_ROOT_DIR=$(git rev-parse --show-toplevel)
+SOURCE_ROOT_DIR=$(realpath -m "$0/../..")
 OUTPUT_DIR="${SOURCE_ROOT_DIR}/cmake-out"
 HEADERS_RELATIVE_PATH="include"
 HEADERS_ABSOLUTE_PATH="${OUTPUT_DIR}/${HEADERS_RELATIVE_PATH}"

--- a/scripts/release/apply-release-changes.sh
+++ b/scripts/release/apply-release-changes.sh
@@ -18,7 +18,7 @@
 
 set -eou pipefail
 
-GIT_TOP_DIR=$(git rev-parse --show-toplevel)
+GIT_TOP_DIR=$(realpath -m "$0/../../..")
 RELEASE_VERSION=${RELEASE_VERSION:-$(cut -d'.' -f1-2 "${GIT_TOP_DIR}/version.txt")}
 RELEASE_BRANCH="release/${RELEASE_VERSION}"
 

--- a/scripts/release/cut-release-branch.sh
+++ b/scripts/release/cut-release-branch.sh
@@ -20,7 +20,7 @@ or to cut from main branch:
 
 set -eou pipefail
 
-GIT_TOP_DIR=$(git rev-parse --show-toplevel)
+GIT_TOP_DIR=$(realpath -m "$0/../../..")
 GIT_REMOTE=${GIT_REMOTE:-origin}
 GIT_BRANCH_TO_CUT_FROM=${GIT_BRANCH_TO_CUT_FROM:-viable/strict}
 


### PR DESCRIPTION
### Summary

When using tools like [Sapling](https://sapling-scm.com/) or [Jujutsu](https://jj-vcs.github.io/jj/latest/), these scripts will fail since the `.git` dir does not exist. 

```bash
rg "git rev-parse --show-toplevel" --hidden
```

### Test plan

CI