### PR TITLE
Integrate the `IntermediateOutputCapturer` into Inspector

### DIFF
--- a/devtools/inspector/TARGETS
+++ b/devtools/inspector/TARGETS
@@ -18,6 +18,7 @@ python_library(
         "//executorch/devtools/etdump:schema_flatcc",
         "//executorch/devtools/etrecord:etrecord",
         "//executorch/exir:lib",
+        "//executorch/devtools/inspector:intermediate_output_capturer",
     ],
 )
 

--- a/devtools/inspector/_inspector.py
+++ b/devtools/inspector/_inspector.py
@@ -59,6 +59,9 @@ from executorch.devtools.inspector._inspector_utils import (
     TimeScale,
     verify_debug_data_equivalence,
 )
+from executorch.devtools.inspector._intermediate_output_capturer import (
+    IntermediateOutputCapturer,
+)
 from executorch.exir import ExportedProgram
 
 
@@ -1074,6 +1077,7 @@ class Inspector:
         # Key str is method name; value is list of ProgramOutputs because of list of test cases
         self._reference_outputs: Dict[str, List[ProgramOutput]] = {}
         self._enable_module_hierarchy = enable_module_hierarchy
+        self._aot_intermediate_outputs: Optional[Dict[Tuple[int, ...], Any]] = None
         self._consume_etrecord()
 
     def _consume_etrecord(self) -> None:
@@ -1134,6 +1138,16 @@ class Inspector:
                     event_block.reference_output = self._reference_outputs[FORWARD][
                         index
                     ]
+        # Capture intermediate outputs only if _representative_inputs are provided
+        # when using bundled program to create the etrecord
+        if self._etrecord._representative_inputs is None:
+            return
+        export_program = self._etrecord.edge_dialect_program
+        graph_module = export_program.module()
+        capturer = IntermediateOutputCapturer(graph_module)
+        self._aot_intermediate_outputs = capturer.run_and_capture(
+            self._etrecord._representative_inputs
+        )
 
     def to_dataframe(
         self,


### PR DESCRIPTION
Summary:
This Diff Integrate `IntermediateOutputCapturer`  into the Inspector class by:
1.Extracting the Graph: Ensuring the forward graph module is extracted from the etrecord.
2.Running and Capturing Outputs: Using an IntermediateOutputCapturer to run the graph with example inputs and capture intermediate tensor values.
3.Storing Results: Saving the captured intermediate outputs in an instance attribute for further analysis.

Differential Revision: D75828351


