### PR TITLE
Add visibility to codegen's gen_lib so users can use it

### DIFF
--- a/codegen/targets.bzl
+++ b/codegen/targets.bzl
@@ -61,6 +61,10 @@ def define_common_targets():
         deps = [
             ":api",
         ],
+        visibility = [
+            "@EXECUTORCH_CLIENTS",
+            "//executorch/codegen/...",
+        ],
     )
 
     runtime.python_binary(


### PR DESCRIPTION
Summary: This allows them to use executorch.codegen.gen

Differential Revision: D75996100


