### PR TITLE
Ability to set external instance + devices

### DIFF
--- a/backends/vulkan/runtime/VulkanBackend.cpp
+++ b/backends/vulkan/runtime/VulkanBackend.cpp
@@ -13,6 +13,8 @@
 
 #include <executorch/backends/vulkan/runtime/graph/ops/OperatorRegistry.h>
 
+#include <executorch/backends/vulkan/runtime/vk_api/Runtime.h>
+
 #include <executorch/runtime/backend/interface.h>
 #include <executorch/runtime/core/error.h>
 #include <executorch/runtime/core/evalue.h>
@@ -528,7 +530,9 @@ class VulkanBackend final : public ::executorch::runtime::BackendInterface {
       return Error::MemoryAllocationFailed;
     }
 
-    new (compute_graph) ComputeGraph(get_graph_config(compile_specs));
+    GraphConfig graph_config = get_graph_config(compile_specs);
+    graph_config.external_adapter = vkapi::set_and_get_external_adapter();
+    new (compute_graph) ComputeGraph(graph_config);
 
     Error err = compileModel(processed->data(), compute_graph);
 

--- a/backends/vulkan/runtime/api/Context.cpp
+++ b/backends/vulkan/runtime/api/Context.cpp
@@ -24,10 +24,10 @@
 namespace vkcompute {
 namespace api {
 
-Context::Context(size_t adapter_i, const ContextConfig& config)
+Context::Context(vkapi::Adapter* adapter, const ContextConfig& config)
     : config_(config),
       // Important handles
-      adapter_p_(vkapi::runtime()->get_adapter_p(adapter_i)),
+      adapter_p_(adapter),
       device_(adapter_p_->device_handle()),
       queue_(adapter_p_->request_queue()),
       // Resource pools
@@ -256,7 +256,7 @@ Context* context() {
           query_pool_config,
       };
 
-      return new Context(vkapi::runtime()->default_adapter_i(), config);
+      return new Context(vkapi::runtime()->get_adapter_p(), config);
     } catch (...) {
     }
 

--- a/backends/vulkan/runtime/api/Context.h
+++ b/backends/vulkan/runtime/api/Context.h
@@ -42,7 +42,7 @@ struct ContextConfig final {
 
 class Context final {
  public:
-  explicit Context(size_t adapter_i, const ContextConfig&);
+  explicit Context(vkapi::Adapter*, const ContextConfig&);
 
   Context(const Context&) = delete;
   Context& operator=(const Context&) = delete;

--- a/backends/vulkan/runtime/graph/ComputeGraph.cpp
+++ b/backends/vulkan/runtime/graph/ComputeGraph.cpp
@@ -122,7 +122,8 @@ ComputeGraph::ComputeGraph(GraphConfig config)
       prepack_descriptor_counts_{},
       execute_descriptor_counts_{},
       context_{new api::Context(
-          vkapi::runtime()->default_adapter_i(),
+          config.external_adapter ? config.external_adapter
+                                  : vkapi::runtime()->get_adapter_p(),
           config_.context_config)},
       shared_objects_{},
       values_{},

--- a/backends/vulkan/runtime/graph/GraphConfig.cpp
+++ b/backends/vulkan/runtime/graph/GraphConfig.cpp
@@ -65,6 +65,8 @@ GraphConfig::GraphConfig() {
   local_wg_size_override = {};
 
   expect_dynamic_shapes = false;
+
+  external_adapter = nullptr;
 }
 
 void GraphConfig::set_storage_type_override(utils::StorageType storage_type) {

--- a/backends/vulkan/runtime/graph/GraphConfig.h
+++ b/backends/vulkan/runtime/graph/GraphConfig.h
@@ -36,6 +36,8 @@ struct GraphConfig final {
   // Whether or not the ComputeGraph should expect input shapes to be dynamic
   bool expect_dynamic_shapes;
 
+  vkapi::Adapter* external_adapter;
+
   // Generate a default graph config with pre-configured settings
   explicit GraphConfig();
 

--- a/backends/vulkan/runtime/vk_api/Adapter.cpp
+++ b/backends/vulkan/runtime/vk_api/Adapter.cpp
@@ -17,17 +17,12 @@ namespace vkapi {
 
 namespace {
 
-VkDevice create_logical_device(
+void find_compute_queues(
     const PhysicalDevice& physical_device,
     const uint32_t num_queues_to_create,
-    std::vector<Adapter::Queue>& queues,
-    std::vector<uint32_t>& queue_usage) {
-  // Find compute queues up to the requested number of queues
-
-  std::vector<VkDeviceQueueCreateInfo> queue_create_infos;
+    std::vector<VkDeviceQueueCreateInfo>& queue_create_infos,
+    std::vector<std::pair<uint32_t, uint32_t>>& queues_to_get) {
   queue_create_infos.reserve(num_queues_to_create);
-
-  std::vector<std::pair<uint32_t, uint32_t>> queues_to_get;
   queues_to_get.reserve(num_queues_to_create);
 
   uint32_t remaining_queues = num_queues_to_create;
@@ -60,12 +55,44 @@ VkDevice create_logical_device(
       break;
     }
   }
+}
 
+void populate_queue_info(
+    const PhysicalDevice& physical_device,
+    VkDevice logical_device,
+    const std::vector<std::pair<uint32_t, uint32_t>>& queues_to_get,
+    std::vector<Adapter::Queue>& queues,
+    std::vector<uint32_t>& queue_usage) {
   queues.reserve(queues_to_get.size());
   queue_usage.reserve(queues_to_get.size());
 
-  // Create the VkDevice
+  // Obtain handles for the created queues and initialize queue usage heuristic
 
+  for (const std::pair<uint32_t, uint32_t>& queue_idx : queues_to_get) {
+    VkQueue queue_handle = VK_NULL_HANDLE;
+    VkQueueFlags flags =
+        physical_device.queue_families.at(queue_idx.first).queueFlags;
+    vkGetDeviceQueue(
+        logical_device, queue_idx.first, queue_idx.second, &queue_handle);
+    queues.push_back({queue_idx.first, queue_idx.second, flags, queue_handle});
+    // Initial usage value
+    queue_usage.push_back(0);
+  }
+}
+
+VkDevice create_logical_device(
+    const PhysicalDevice& physical_device,
+    const uint32_t num_queues_to_create,
+    std::vector<Adapter::Queue>& queues,
+    std::vector<uint32_t>& queue_usage) {
+  // Find compute queues up to the requested number of queues
+
+  std::vector<VkDeviceQueueCreateInfo> queue_create_infos;
+  std::vector<std::pair<uint32_t, uint32_t>> queues_to_get;
+  find_compute_queues(
+      physical_device, num_queues_to_create, queue_create_infos, queues_to_get);
+
+  // Create the VkDevice
   std::vector<const char*> requested_device_extensions{
 #ifdef VK_KHR_portability_subset
       VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME,
@@ -143,19 +170,42 @@ VkDevice create_logical_device(
   volkLoadDevice(handle);
 #endif /* USE_VULKAN_VOLK */
 
-  // Obtain handles for the created queues and initialize queue usage heuristic
-
-  for (const std::pair<uint32_t, uint32_t>& queue_idx : queues_to_get) {
-    VkQueue queue_handle = VK_NULL_HANDLE;
-    VkQueueFlags flags =
-        physical_device.queue_families.at(queue_idx.first).queueFlags;
-    vkGetDeviceQueue(handle, queue_idx.first, queue_idx.second, &queue_handle);
-    queues.push_back({queue_idx.first, queue_idx.second, flags, queue_handle});
-    // Initial usage value
-    queue_usage.push_back(0);
-  }
+  populate_queue_info(
+      physical_device, handle, queues_to_get, queues, queue_usage);
 
   return handle;
+}
+
+bool test_linear_tiling_3d_image_support(VkDevice device) {
+  // Test creating a 3D image with linear tiling to see if it is supported.
+  // According to the Vulkan spec, linear tiling may not be supported for 3D
+  // images.
+  VkExtent3D image_extents{1u, 1u, 1u};
+  const VkImageCreateInfo image_create_info{
+      VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO, // sType
+      nullptr, // pNext
+      0u, // flags
+      VK_IMAGE_TYPE_3D, // imageType
+      VK_FORMAT_R32G32B32A32_SFLOAT, // format
+      image_extents, // extents
+      1u, // mipLevels
+      1u, // arrayLayers
+      VK_SAMPLE_COUNT_1_BIT, // samples
+      VK_IMAGE_TILING_LINEAR, // tiling
+      VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_STORAGE_BIT, // usage
+      VK_SHARING_MODE_EXCLUSIVE, // sharingMode
+      0u, // queueFamilyIndexCount
+      nullptr, // pQueueFamilyIndices
+      VK_IMAGE_LAYOUT_UNDEFINED, // initialLayout
+  };
+  VkImage image = VK_NULL_HANDLE;
+  VkResult res = vkCreateImage(device, &image_create_info, nullptr, &image);
+
+  if (res == VK_SUCCESS) {
+    vkDestroyImage(device, image, nullptr);
+  }
+
+  return res == VK_SUCCESS;
 }
 
 } // namespace
@@ -186,37 +236,44 @@ Adapter::Adapter(
       compute_pipeline_cache_(device_.handle, cache_data_path),
       sampler_cache_(device_.handle),
       vma_(instance_, physical_device_.handle, device_.handle),
-      linear_tiling_3d_enabled_{true} {
-  // Test creating a 3D image with linear tiling to see if it is supported.
-  // According to the Vulkan spec, linear tiling may not be supported for 3D
-  // images.
-  VkExtent3D image_extents{1u, 1u, 1u};
-  const VkImageCreateInfo image_create_info{
-      VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO, // sType
-      nullptr, // pNext
-      0u, // flags
-      VK_IMAGE_TYPE_3D, // imageType
-      VK_FORMAT_R32G32B32A32_SFLOAT, // format
-      image_extents, // extents
-      1u, // mipLevels
-      1u, // arrayLayers
-      VK_SAMPLE_COUNT_1_BIT, // samples
-      VK_IMAGE_TILING_LINEAR, // tiling
-      VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_STORAGE_BIT, // usage
-      VK_SHARING_MODE_EXCLUSIVE, // sharingMode
-      0u, // queueFamilyIndexCount
-      nullptr, // pQueueFamilyIndices
-      VK_IMAGE_LAYOUT_UNDEFINED, // initialLayout
-  };
-  VkImage image = VK_NULL_HANDLE;
-  VkResult res =
-      vkCreateImage(device_.handle, &image_create_info, nullptr, &image);
-  if (res != VK_SUCCESS) {
-    linear_tiling_3d_enabled_ = false;
-  } else {
-    vkDestroyImage(device_.handle, image, nullptr);
+      linear_tiling_3d_enabled_{
+          test_linear_tiling_3d_image_support(device_.handle)},
+      owns_device_{true} {}
+
+Adapter::Adapter(
+    VkInstance instance,
+    VkPhysicalDevice physical_device,
+    VkDevice logical_device,
+    const uint32_t num_queues,
+    const std::string& cache_data_path)
+    : queue_usage_mutex_{},
+      physical_device_(physical_device),
+      queues_{},
+      queue_usage_{},
+      queue_mutexes_{},
+      instance_(instance),
+      device_(logical_device),
+      shader_layout_cache_(device_.handle),
+      shader_cache_(device_.handle),
+      pipeline_layout_cache_(device_.handle),
+      compute_pipeline_cache_(device_.handle, cache_data_path),
+      sampler_cache_(device_.handle),
+      vma_(instance_, physical_device_.handle, device_.handle),
+      linear_tiling_3d_enabled_{
+          test_linear_tiling_3d_image_support(device_.handle)},
+      owns_device_{false} {
+  std::vector<VkDeviceQueueCreateInfo> queue_create_infos;
+  std::vector<std::pair<uint32_t, uint32_t>> queues_to_get;
+  find_compute_queues(
+      physical_device_, num_queues, queue_create_infos, queues_to_get);
+  populate_queue_info(
+      physical_device_, device_.handle, queues_to_get, queues_, queue_usage_);
+}
+
+Adapter::~Adapter() {
+  if (!owns_device_) {
+    device_.handle = VK_NULL_HANDLE;
   }
-  return;
 }
 
 Adapter::Queue Adapter::request_queue() {

--- a/backends/vulkan/runtime/vk_api/Adapter.h
+++ b/backends/vulkan/runtime/vk_api/Adapter.h
@@ -56,13 +56,20 @@ class Adapter final {
       const uint32_t num_queues,
       const std::string& cache_data_path);
 
+  explicit Adapter(
+      VkInstance instance,
+      VkPhysicalDevice physical_device,
+      VkDevice logical_device,
+      const uint32_t num_queues,
+      const std::string& cache_data_path);
+
   Adapter(const Adapter&) = delete;
   Adapter& operator=(const Adapter&) = delete;
 
   Adapter(Adapter&&) = delete;
   Adapter& operator=(Adapter&&) = delete;
 
-  ~Adapter() = default;
+  ~Adapter();
 
   struct Queue {
     uint32_t family_index;
@@ -94,6 +101,7 @@ class Adapter final {
   Allocator vma_;
   // Miscellaneous
   bool linear_tiling_3d_enabled_;
+  bool owns_device_;
 
  public:
   // Physical Device metadata

--- a/backends/vulkan/runtime/vk_api/Runtime.cpp
+++ b/backends/vulkan/runtime/vk_api/Runtime.cpp
@@ -14,6 +14,12 @@
 #include <iostream>
 #include <sstream>
 
+#ifdef USE_VOLK_HEADER_ONLY
+// For volk.h, define this before including volk.h in exactly one CPP file.
+#define VOLK_IMPLEMENTATION
+#include <volk.h>
+#endif /* USE_VOLK_HEADER_ONLY */
+
 namespace vkcompute {
 namespace vkapi {
 
@@ -407,6 +413,36 @@ Runtime* runtime() {
       "because it failed to initialize.");
 
   return p_runtime.get();
+}
+
+std::unique_ptr<Adapter> init_external_adapter(
+    const VkInstance instance,
+    const VkPhysicalDevice physical_device,
+    const VkDevice logical_device,
+    const uint32_t num_queues,
+    const std::string& cache_data_path) {
+  if (instance == VK_NULL_HANDLE || physical_device == VK_NULL_HANDLE ||
+      logical_device == VK_NULL_HANDLE) {
+    return std::unique_ptr<Adapter>(nullptr);
+  }
+
+  return std::make_unique<Adapter>(
+      instance, physical_device, logical_device, num_queues, cache_data_path);
+}
+
+Adapter* set_and_get_external_adapter(
+    const VkInstance instance,
+    const VkPhysicalDevice physical_device,
+    const VkDevice logical_device) {
+  static const std::unique_ptr<Adapter> p_external_adapter =
+      init_external_adapter(
+          instance,
+          physical_device,
+          logical_device,
+          1,
+          set_and_get_pipeline_cache_data_path(""));
+
+  return p_external_adapter.get();
 }
 
 } // namespace vkapi

--- a/backends/vulkan/runtime/vk_api/Runtime.h
+++ b/backends/vulkan/runtime/vk_api/Runtime.h
@@ -106,5 +106,11 @@ std::string& set_and_get_pipeline_cache_data_path(const std::string& file_path);
 // a static local variable.
 Runtime* runtime();
 
+// Used to share instance + devices between client code and ETVK
+Adapter* set_and_get_external_adapter(
+    const VkInstance instance = VK_NULL_HANDLE,
+    const VkPhysicalDevice physical_device = VK_NULL_HANDLE,
+    const VkDevice logical_device = VK_NULL_HANDLE);
+
 } // namespace vkapi
 } // namespace vkcompute

--- a/backends/vulkan/runtime/vk_api/Types.h
+++ b/backends/vulkan/runtime/vk_api/Types.h
@@ -17,6 +17,11 @@
 #include <cstddef>
 #include <cstdint>
 
+// X11 headers via volk define Bool, so we need to undef it
+#if defined(__linux__)
+#undef Bool
+#endif
+
 #ifdef USE_VULKAN_FP16_INFERENCE
 #define VK_FORMAT_FLOAT4 VK_FORMAT_R16G16B16A16_SFLOAT
 #else

--- a/backends/vulkan/targets.bzl
+++ b/backends/vulkan/targets.bzl
@@ -1,7 +1,7 @@
 load("@fbsource//tools/target_determinator/macros:ci.bzl", "ci")
 load("@fbcode_macros//build_defs:native_rules.bzl", "buck_genrule")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
-load("@fbsource//tools/build_defs:platform_defs.bzl", "ANDROID", "CXX", "FBCODE")
+load("@fbsource//tools/build_defs:platform_defs.bzl", "ANDROID", "CXX", "FBCODE", "APPLE")
 
 
 def get_vulkan_compiler_flags():
@@ -13,17 +13,66 @@ def get_vulkan_compiler_flags():
         "ovr_config//os:windows": [],
     })
 
+def get_vulkan_preprocessor_flags(no_volk, is_fbcode):
+    VK_API_PREPROCESSOR_FLAGS = []
+
+    default_flags = []
+    android_flags = []
+
+    if not no_volk:
+        for flags in [default_flags, android_flags]:
+            flags.append("-DUSE_VULKAN_WRAPPER")
+            flags.append("-DUSE_VULKAN_VOLK")
+            flags.append("-DUSE_VOLK_HEADER_ONLY")
+        android_flags.append("-DVK_ANDROID_external_memory_android_hardware_buffer")
+
+    if not is_fbcode:
+        link_moltenvk = no_volk and read_config("etvk", "link_moltenvk", "1") == "1"
+        mac_flags = default_flags
+        if link_moltenvk:
+            mac_flags = []
+
+        VK_API_PREPROCESSOR_FLAGS += select({
+            "DEFAULT": default_flags,
+            "ovr_config//os:android": android_flags,
+            "ovr_config//os:macos": mac_flags,
+        }) + select({
+            "//third-party/cuda:windows-cuda-11": [
+                "-DVK_USE_PLATFORM_WIN32_KHR",
+            ],
+            "DEFAULT": [],
+            "ovr_config//os:android": [
+                "-DVK_USE_PLATFORM_ANDROID_KHR",
+            ],
+            "ovr_config//os:linux": [
+                "-DVK_USE_PLATFORM_XLIB_KHR",
+            ],
+            "ovr_config//os:macos": [
+                "-DVK_USE_PLATFORM_MACOS_MVK",
+            ],
+            "ovr_config//os:windows": [
+                "-DVK_USE_PLATFORM_WIN32_KHR",
+            ],
+        })
+
+        etvk_default_cache_path = read_config("etvk", "default_cache_path", "")
+        if etvk_default_cache_path != "":
+            VK_API_PREPROCESSOR_FLAGS += ["-DETVK_DEFAULT_CACHE_PATH={}".format(etvk_default_cache_path)]
+
+        debug_mode = read_config("etvk", "debug", "0") == "1"
+        if debug_mode:
+            VK_API_PREPROCESSOR_FLAGS += ["-DVULKAN_DEBUG"]
+
+    return VK_API_PREPROCESSOR_FLAGS
+
 def get_labels(no_volk):
     if no_volk:
         return ci.labels(ci.linux(ci.mode("fbsource//arvr/mode/android/mac/dbg")))
     else:
         return []
 
-def get_platforms(no_volk):
-    if no_volk:
-        return [ANDROID]
-    else:
-        return [ANDROID, CXX]
+def get_platforms():
+    return [ANDROID, APPLE, CXX]
 
 def vulkan_spv_shader_lib(name, spv_filegroups, is_fbcode = False, no_volk = False):
     gen_vulkan_spv_target = "//xplat/executorch/backends/vulkan:gen_vulkan_spv_bin"
@@ -73,7 +122,7 @@ def vulkan_spv_shader_lib(name, spv_filegroups, is_fbcode = False, no_volk = Fal
         ],
         compiler_flags = get_vulkan_compiler_flags(),
         labels = get_labels(no_volk),
-        platforms = get_platforms(no_volk),
+        platforms = get_platforms(),
         define_static_target = True,
         # Static initialization is used to register shaders to the global shader registry,
         # therefore link_whole must be True to make sure unused symbols are not discarded.
@@ -122,25 +171,20 @@ def define_common_targets(is_fbcode = False):
 
         suffix = "_no_volk" if no_volk else ""
 
-        VK_API_PREPROCESSOR_FLAGS = []
         VK_API_DEPS = [
             "fbsource//third-party/VulkanMemoryAllocator/3.0.1:VulkanMemoryAllocator_xplat",
         ]
 
         default_deps = []
         android_deps = ["fbsource//third-party/toolchains:android"]
-        default_flags = []
-        android_flags = []
 
         if no_volk:
-            android_deps.append("fbsource//third-party/toolchains:vulkan")
+            for deps in [default_deps, android_deps]:
+                deps.append("fbsource//third-party/toolchains:vulkan")
+                deps.append("fbsource//third-party/khronos:vulkan-headers")
         else:
             for deps in [default_deps, android_deps]:
-                deps.append("fbsource//third-party/volk:volk")
-            for flags in [default_flags, android_flags]:
-                flags.append("-DUSE_VULKAN_WRAPPER")
-                flags.append("-DUSE_VULKAN_VOLK")
-            android_flags.append("-DVK_ANDROID_external_memory_android_hardware_buffer")
+                deps.append("fbsource//third-party/volk:volk-header")
 
         if is_fbcode:
             VK_API_DEPS += [
@@ -149,34 +193,23 @@ def define_common_targets(is_fbcode = False):
                 "fbsource//third-party/swiftshader/lib/linux-x64:libvk_swiftshader_so",
             ]
         else:
-            link_moltenvk = read_config("etvk", "link_moltenvk", "1") == "1"
+            link_moltenvk = no_volk and read_config("etvk", "link_moltenvk", "1") == "1"
             mac_deps = default_deps
             if link_moltenvk:
                 mac_deps = [
                     "//third-party/khronos:moltenVK_static"
                 ]
-            mac_flags = default_flags
-            if link_moltenvk:
-                mac_flags = []
 
             VK_API_DEPS += select({
                 "DEFAULT": default_deps,
                 "ovr_config//os:android": android_deps,
                 "ovr_config//os:macos": mac_deps,
+            }) + select({
+                "DEFAULT": [],
+                "ovr_config//os:linux": [
+                    "//arvr/third-party/libX11:libX11",
+                ]
             })
-            VK_API_PREPROCESSOR_FLAGS += select({
-                "DEFAULT": default_flags,
-                "ovr_config//os:android": android_flags,
-                "ovr_config//os:macos": mac_flags,
-            })
-
-            etvk_default_cache_path = read_config("etvk", "default_cache_path", "")
-            if etvk_default_cache_path != "":
-                VK_API_PREPROCESSOR_FLAGS += ["-DETVK_DEFAULT_CACHE_PATH={}".format(etvk_default_cache_path)]
-
-            debug_mode = read_config("etvk", "debug", "0") == "1"
-            if debug_mode:
-                VK_API_PREPROCESSOR_FLAGS += ["-DVULKAN_DEBUG"]
 
         runtime.cxx_library(
             name = "vulkan_compute_api{}".format(suffix),
@@ -192,12 +225,22 @@ def define_common_targets(is_fbcode = False):
                 "runtime/vk_api/**/*.h",
             ]),
             labels = get_labels(no_volk),
-            platforms = get_platforms(no_volk),
+            platforms = get_platforms(),
             visibility = [
                 "//executorch/backends/vulkan/...",
                 "@EXECUTORCH_CLIENTS",
             ],
-            exported_preprocessor_flags = VK_API_PREPROCESSOR_FLAGS,
+            fbobjc_frameworks = select({
+                "DEFAULT": [],
+                "ovr_config//os:macos": [
+                    "$SDKROOT/System/Library/Frameworks/CoreGraphics.framework",
+                    "$SDKROOT/System/Library/Frameworks/Foundation.framework",
+                    "$SDKROOT/System/Library/Frameworks/AppKit.framework",
+                    "$SDKROOT/System/Library/Frameworks/Metal.framework",
+                    "$SDKROOT/System/Library/Frameworks/QuartzCore.framework",
+                ],
+            }),
+            exported_preprocessor_flags = get_vulkan_preprocessor_flags(no_volk, is_fbcode),
             exported_deps = VK_API_DEPS,
         )
 
@@ -211,7 +254,7 @@ def define_common_targets(is_fbcode = False):
                 "runtime/graph/**/*.h",
             ]),
             labels = get_labels(no_volk),
-            platforms = get_platforms(no_volk),
+            platforms = get_platforms(),
             visibility = [
                 "//executorch/backends/...",
                 "//executorch/extension/pybindings/...",
@@ -249,7 +292,7 @@ def define_common_targets(is_fbcode = False):
                 "runtime/*.h",
             ]),
             labels = get_labels(no_volk),
-            platforms = get_platforms(no_volk),
+            platforms = get_platforms(),
             visibility = [
                 "//executorch/backends/...",
                 "//executorch/extension/pybindings/...",

--- a/backends/vulkan/test/compute_api_tests.bzl
+++ b/backends/vulkan/test/compute_api_tests.bzl
@@ -32,7 +32,7 @@ def define_compute_api_test_targets():
             ],
             apple_sdks = MACOSX,
             labels = get_labels(no_volk),
-            platforms = get_platforms(no_volk),
+            platforms = get_platforms(),
             visibility = ["PUBLIC"],
             deps = [
                 ":test_shader_lib{}".format(suffix),

--- a/extension/aten_util/make_aten_functor_from_et_functor.h
+++ b/extension/aten_util/make_aten_functor_from_et_functor.h
@@ -22,6 +22,12 @@
 #include <executorch/extension/kernel_util/type_list.h>
 #include <executorch/extension/tensor/tensor.h>
 #include <executorch/runtime/core/evalue.h>
+
+// X11 headers via volk define Complex, so we need to undef it
+#if defined(__linux__)
+#undef Complex
+#endif
+
 #include <torch/torch.h>
 
 namespace executorch {

--- a/runtime/core/tag.h
+++ b/runtime/core/tag.h
@@ -12,6 +12,11 @@
 #include <executorch/runtime/platform/compiler.h>
 #include <cstdint>
 
+// X11 headers via volk define None, so we need to undef it
+#if defined(__linux__)
+#undef None
+#endif
+
 namespace executorch {
 namespace runtime {
 


### PR DESCRIPTION
Summary: Adds a new function to ETVK, set_and_get_external_adapter, which allows clients to share their Vulkan instance/devices with ETVK.  This is useful when using volk, which does not support multiple devices when using volkLoadDevice.

Differential Revision: D71372344


