### PR TITLE
Arm backend: Replace asserts with exceptions in passes

### DIFF
--- a/backends/arm/_passes/annotate_channels_last_dim_order_pass.py
+++ b/backends/arm/_passes/annotate_channels_last_dim_order_pass.py
@@ -35,7 +35,10 @@ lib.define("_transpose(Tensor self, int[] dim_order) -> Tensor")
 def _transpose_impl(*args, **kwargs):
     # Validate length of dim_order array
     dim = args[1]
-    assert len(dim) in (4, 5)
+    if len(dim) != 4 and len(dim) != 5:
+        raise ValueError(
+            f"Dim order length must be either 4 or 5, got {len(dim)}: {dim}"
+        )
     # Pass-through in edge-IR
     return args[0]
 

--- a/backends/arm/_passes/convert_split_to_slice.py
+++ b/backends/arm/_passes/convert_split_to_slice.py
@@ -41,9 +41,14 @@ class ConvertSplitToSlicePass(ExportPass):
             dim = split_node.args[2] if len(split_node.args) > 2 else 0
             dim = (dim + rank) % rank
 
-            assert (
-                sum(split_lengths) == shape[dim]
-            ), "Given split lengths don't sum up to the size of the dimension."
+            # Validate that split lengths cover the entire dimension
+            length_sum = sum(split_lengths)
+            dim_size = shape[dim]
+            if length_sum != dim_size:
+                raise ValueError(
+                    f"Split sizes {split_lengths} sum to {length_sum}, "
+                    f"but dimension {dim} has size {dim_size}"
+                )
 
             # Convert split argument 'split_lengths' to slice arguments start and end.
             starts = [0] * len(split_lengths)

--- a/backends/arm/_passes/insert_table_ops.py
+++ b/backends/arm/_passes/insert_table_ops.py
@@ -240,8 +240,17 @@ class InsertTableOpsPass(ExportPass):
                     args=(node.args[0],),
                 )
                 output_node = table_node
-                assert len(input_qparams) == 1
-                assert len(output_qparams) == 1
+                # Expect exactly one quantization parameter for input and output
+                if len(input_qparams) != 1:
+                    raise ValueError(
+                        f"InsertTableOpsPass expected exactly one input quantization parameter, "
+                        f"got {len(input_qparams)} for node {node.name}"
+                    )
+                if len(output_qparams) != 1:
+                    raise ValueError(
+                        f"InsertTableOpsPass expected exactly one output quantization parameter, "
+                        f"got {len(output_qparams)} for node {node.name}"
+                    )
 
                 # Generate table buffer and how much to lshift the table output.
                 buffer, lshift = self.generate_table_values(

--- a/backends/arm/_passes/remove_clone_pass.py
+++ b/backends/arm/_passes/remove_clone_pass.py
@@ -17,5 +17,8 @@ class RemoveClonePass(ExportPass):
         if op != exir_ops.edge.aten.clone.default:
             return super().call_operator(op, args, kwargs, meta)
 
-        assert len(args) == 1
+        if len(args) != 1:
+            raise ValueError(
+                f"clone operator expects exactly one argument, got {len(args)}"
+            )
         return args[0]


### PR DESCRIPTION
- annotate_channels_last_dim_order_pass: raise on dim_order length != 4 and != 5
- remove_clone_pass: ValueError if args count != 1
- fold_qdq_with_annotated_qparams_pass: RuntimeError if dq_op mismatch or unexpected meta key presence
- convert_split_to_slice: ValueError if split sizes don't match dim
- insert_table_ops: ValueError if input/output quant params count != 1

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218