### PR TITLE
Update Cortex-M Size target

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -262,7 +262,7 @@ jobs:
         output=$(ls -la ${elf})
         arr=($output)
         size=${arr[4]}
-        threshold="102400" # 100KiB
+        threshold="103068" # ~100KiB
         echo "size: $size, threshold: $threshold"
         if [[ "$size" -le "$threshold" ]]; then
           echo "Success $size <= $threshold"


### PR DESCRIPTION
### Summary
The recent PAL changes (https://github.com/pytorch/executorch/pull/10675) increased runtime size slightly. This was approved and size targets were updated for the main size jobs. However, I missed the Cortex-M job and am updating here.

### Test plan
CI
