### PR TITLE
Plumbing for dtype selection in cmake flow - header generation

### DIFF
--- a/examples/selective_build/CMakeLists.txt
+++ b/examples/selective_build/CMakeLists.txt
@@ -61,6 +61,10 @@ option(EXECUTORCH_SELECT_OPS_LIST "Register a list of ops, separated by comma"
 option(EXECUTORCH_SELECT_ALL_OPS
        "Whether to register all ops defined in portable kernel library." OFF
 )
+
+# Option to enable dtype selective build
+option(EXECUTORCH_SELECT_DTYPE "Enable dtype selection during build." OFF
+)
 # ------------------------------- OPTIONS END --------------------------------
 
 #
@@ -108,16 +112,30 @@ gen_selected_ops(
   "${EXECUTORCH_SELECT_OPS_LIST}"
   INCLUDE_ALL_OPS
   "${EXECUTORCH_SELECT_ALL_OPS}"
+  DTYPE_SELECT
+  "${EXECUTORCH_SELECT_DTYPE}"
 )
 
 generate_bindings_for_kernels(
-  LIB_NAME "select_build_lib" FUNCTIONS_YAML
-  ${EXECUTORCH_ROOT}/kernels/portable/functions.yaml CUSTOM_OPS_YAML
+  LIB_NAME
+  "select_build_lib"
+  FUNCTIONS_YAML
+  ${EXECUTORCH_ROOT}/kernels/portable/functions.yaml
+  CUSTOM_OPS_YAML
   "${_custom_ops_yaml}"
+  DTYPE_SELECT
+  "${EXECUTORCH_SELECT_DTYPE}"
 )
 
 gen_operators_lib(
-  LIB_NAME "select_build_lib" KERNEL_LIBS ${_kernel_lib} DEPS executorch_core
+  LIB_NAME
+  "select_build_lib"
+  KERNEL_LIBS
+  ${_kernel_lib}
+  DEPS
+  executorch_core
+  DTYPE_SELECT
+  "${EXECUTORCH_SELECT_DTYPE}"
 )
 
 list(TRANSFORM _executor_runner__srcs PREPEND "${EXECUTORCH_ROOT}/")

--- a/examples/selective_build/test_selective_build.sh
+++ b/examples/selective_build/test_selective_build.sh
@@ -94,6 +94,7 @@ test_cmake_select_all_ops() {
     rm -rf ${build_dir}
     retry cmake -DCMAKE_BUILD_TYPE=Release \
             -DEXECUTORCH_SELECT_ALL_OPS=ON \
+            -DEXECUTORCH_SELECT_DTYPE=ON \
             -DCMAKE_INSTALL_PREFIX=cmake-out \
             -DPYTHON_EXECUTABLE="$PYTHON_EXECUTABLE" \
             -B${build_dir} \
@@ -123,6 +124,7 @@ test_cmake_select_ops_in_list() {
 aten::_native_batch_norm_legit_no_training.out,aten::hardtanh.out,aten::add.out,\
 aten::mean.out,aten::view_copy.out,aten::permute_copy.out,aten::addmm.out,\
 aten,aten::clone.out" \
+            -DEXECUTORCH_SELECT_DTYPE=ON \
             -DCMAKE_INSTALL_PREFIX=cmake-out \
             -DPYTHON_EXECUTABLE="$PYTHON_EXECUTABLE" \
             -B${build_dir} \
@@ -146,6 +148,7 @@ test_cmake_select_ops_in_yaml() {
     rm -rf ${build_dir}
     retry cmake -DCMAKE_BUILD_TYPE=Release \
             -DEXECUTORCH_SELECT_OPS_YAML=ON \
+            -DEXECUTORCH_SELECT_DTYPE=ON \
             -DCMAKE_INSTALL_PREFIX=cmake-out \
             -DPYTHON_EXECUTABLE="$PYTHON_EXECUTABLE" \
             -B${build_dir} \


### PR DESCRIPTION
### Summary
This change introduces a new `cmake` command line option that can be enable via `-DEXECUTORCH_SELECT_DTYPE=ON.` For now , enabling this flag does *not* change the generated binary size. This change simply add the header file generation to the cmake build flow. Next steps will include automatically have the cmake build flow transplant the contents of the generated header file directly into the `kernels/portable/cpu/selective_build.h` file. This step must manually be done by a user to enable directed dtype pruning.

### Test plan
Changes were tested via `bash examples/selective_build/test_dtype_selective_build.sh cmake`. The resultant header file generated by the flow is now created and retained at `cmake-out/examples/selective_build/select_build_lib/selected_op_variants.h`.