### PR TITLE
adjust compatibility for the cadence backend

### DIFF
--- a/backends/cadence/fusion_g3/operators/targets.bzl
+++ b/backends/cadence/fusion_g3/operators/targets.bzl
@@ -24,6 +24,7 @@ def define_operator(name: str, deps: list[str] | None = None) -> None:
             "//executorch/backends/cadence/...",
             "@EXECUTORCH_CLIENTS",
         ],
+        compatible_with = ["ovr_config//cpu:xtensa"],
         deps = deps + common_deps,
         exported_deps = [
             ":operators_header",

--- a/backends/cadence/hifi/kernels/targets.bzl
+++ b/backends/cadence/hifi/kernels/targets.bzl
@@ -13,6 +13,7 @@ def define_common_targets():
             "kernels.h",
         ],
         deps = common_deps,
+        compatible_with = ["ovr_config//cpu:xtensa"],
         visibility = [
             "//executorch/backends/cadence/...",
         ],

--- a/backends/cadence/hifi/operators/targets.bzl
+++ b/backends/cadence/hifi/operators/targets.bzl
@@ -27,6 +27,7 @@ def define_operator(name: str, deps: list[str] | None = None) -> None:
             "//executorch/backends/cadence/...",
             "@EXECUTORCH_CLIENTS",
         ],
+        compatible_with = ["ovr_config//cpu:xtensa"],
         deps = deps + common_deps,
         exported_headers = ["operators.h"],
     )

--- a/backends/cadence/hifi/third-party/nnlib/targets.bzl
+++ b/backends/cadence/hifi/third-party/nnlib/targets.bzl
@@ -12,6 +12,7 @@ def define_common_targets():
             "//executorch/backends/cadence/...",
             "@EXECUTORCH_CLIENTS",
         ],
+        compatible_with = ["ovr_config//cpu:xtensa"],
         deps = [
             "fbsource//third-party/nnlib-hifi4/xa_nnlib:libxa_nnlib",
         ],


### PR DESCRIPTION
Summary:
The cadence backend requires xtensa OS, so let's mark the target accordingly.

release notes: none

Differential Revision: D76128535


