### PR TITLE
adjust compatibility for the cortex_m backend

### DIFF
--- a/backends/cortex_m/ops/targets.bzl
+++ b/backends/cortex_m/ops/targets.bzl
@@ -45,6 +45,7 @@ def define_common_targets():
             "//executorch/...",
             "@EXECUTORCH_CLIENTS",
         ],
+        platforms = CXX,
         exported_deps = all_op_targets,
     )
 

--- a/backends/cortex_m/test/targets.bzl
+++ b/backends/cortex_m/test/targets.bzl
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+load("@fbsource//tools/build_defs:platform_defs.bzl", "CXX")
 
 OPERATORS = [
     "quantize_per_tensor",
@@ -17,6 +18,7 @@ def define_operator_test_target(op):
         srcs = [
             "op_{}_test.cpp".format(op),
         ],
+        platforms = CXX,
         deps = [
             "//executorch/runtime/kernel:kernel_includes",
             "//executorch/kernels/test:test_util",


### PR DESCRIPTION
Summary:
This backend only works with the CXX platform, so let's mark the target accordingly.

release notes: none

Differential Revision: D76128868


