### PR TITLE
Resolve buck earlier

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,9 +75,13 @@ if(NOT PYTHON_EXECUTABLE)
 endif()
 announce_configured_options(PYTHON_EXECUTABLE)
 
+if(NOT BUCK2)
+  resolve_buck2()
+endif()
+announce_configured_options(BUCK2)
+
 announce_configured_options(CMAKE_CXX_COMPILER_ID)
 announce_configured_options(CMAKE_TOOLCHAIN_FILE)
-announce_configured_options(BUCK2)
 
 load_build_preset()
 include(${PROJECT_SOURCE_DIR}/tools/cmake/preset/default.cmake)
@@ -290,9 +294,6 @@ set(_common_include_directories
 #
 
 if(NOT EXECUTORCH_SRCS_FILE)
-  # Find or download buck2 binary.
-  resolve_buck2()
-
   # A file wasn't provided. Run a script to extract the source lists from the
   # buck2 build system and write them to a file we can include.
   #


### PR DESCRIPTION
### Summary
Since we resolve buck2 later on, it results in the value of buck2 being empty. It now shows the location:

### Test plan

```
$ cmake --preset pybind && cmake --build cmake-out -j $(sysctl -n hw.ncpu)

-- --- Configured Options ---

-- CMAKE_CXX_STANDARD                      : 17
-- CMAKE_SYSTEM_PROCESSOR                  : arm64
-- CMAKE_BUILD_TYPE                        : Debug
-- PYTHON_EXECUTABLE                       : /Users/jathu/executorch/.venv/bin/python3
-- BUCK2                                   : /Users/jathu/executorch/buck2-bin/buck2-2025-05-06-201beb86106fecdc84e30260b0f1abb5bf576988
```


cc @larryliu0820