### PR TITLE
Create a cmake function to test for conflicting flags

### DIFF
--- a/tools/cmake/common/preset.cmake
+++ b/tools/cmake/common/preset.cmake
@@ -124,3 +124,23 @@ function(check_required_options_on)
     endforeach()
   endif()
 endfunction()
+
+
+# Check if flags conflict with each other.
+function(check_conflicting_options_on)
+  cmake_parse_arguments(
+    ARG
+    ""
+    "IF_ON"
+    "CONFLICTS_WITH"
+    ${ARGN}
+  )
+
+  if(${${ARG_IF_ON}})
+    foreach(conflict ${ARG_CONFLICTS_WITH})
+      if(${${conflict}})
+        message(FATAL_ERROR "Both '${ARG_IF_ON}' and '${conflict}' can't be ON")
+      endif()
+    endforeach()
+  endif()
+endfunction()

--- a/tools/cmake/common/preset_test.py
+++ b/tools/cmake/common/preset_test.py
@@ -416,3 +416,88 @@ class TestPreset(CMakeTestCase):
         self.run_cmake(
             error_contains="Use of 'FEATURE_FLAG' requires 'REQUIRED_OPTION1'"
         )
+
+    def test_check_conflicting_options_on_if_on_off(self):
+        """Test that when IF_ON is OFF, no conflict checks are performed."""
+
+        _cmake_lists_txt = """
+            cmake_minimum_required(VERSION 3.24)
+            project(test_preset)
+            include(${PROJECT_SOURCE_DIR}/preset.cmake)
+            set(FEATURE_FLAG OFF)
+            set(CONFLICTING_OPTION1 ON)
+            set(CONFLICTING_OPTION2 ON)
+            check_conflicting_options_on(
+                IF_ON
+                    FEATURE_FLAG
+                CONFLICTS_WITH
+                    CONFLICTING_OPTION1
+                    CONFLICTING_OPTION2
+            )
+        """
+        self.create_workspace({"CMakeLists.txt": _cmake_lists_txt})
+        self.run_cmake()
+
+    def test_check_conflicting_options_on_no_conflicts(self):
+        """Test that when IF_ON is ON but no conflicting options are ON, no error occurs."""
+        _cmake_lists_txt = """
+            cmake_minimum_required(VERSION 3.24)
+            project(test_preset)
+            include(${PROJECT_SOURCE_DIR}/preset.cmake)
+            set(FEATURE_FLAG ON)
+            set(CONFLICTING_OPTION1 OFF)
+            set(CONFLICTING_OPTION2 OFF)
+            check_conflicting_options_on(
+                IF_ON
+                    FEATURE_FLAG
+                CONFLICTS_WITH
+                    CONFLICTING_OPTION1
+                    CONFLICTING_OPTION2
+            )
+        """
+        self.create_workspace({"CMakeLists.txt": _cmake_lists_txt})
+        self.run_cmake()
+
+    def test_check_conflicting_options_on_one_conflict(self):
+        """Test that when IF_ON is ON and one conflicting option is also ON, a fatal error occurs."""
+        _cmake_lists_txt = """
+            cmake_minimum_required(VERSION 3.24)
+            project(test_preset)
+            include(${PROJECT_SOURCE_DIR}/preset.cmake)
+            set(FEATURE_FLAG ON)
+            set(CONFLICTING_OPTION1 ON)
+            set(CONFLICTING_OPTION2 OFF)
+            check_conflicting_options_on(
+                IF_ON
+                    FEATURE_FLAG
+                CONFLICTS_WITH
+                    CONFLICTING_OPTION1
+                    CONFLICTING_OPTION2
+            )
+        """
+        self.create_workspace({"CMakeLists.txt": _cmake_lists_txt})
+        self.run_cmake(
+            error_contains="Both 'FEATURE_FLAG' and 'CONFLICTING_OPTION1' can't be ON"
+        )
+
+    def test_check_conflicting_options_on_multiple_conflicts(self):
+        """Test that when IF_ON is ON and multiple conflicting options are ON, a fatal error occurs for the first conflict."""
+        _cmake_lists_txt = """
+            cmake_minimum_required(VERSION 3.24)
+            project(test_preset)
+            include(${PROJECT_SOURCE_DIR}/preset.cmake)
+            set(FEATURE_FLAG ON)
+            set(CONFLICTING_OPTION1 ON)
+            set(CONFLICTING_OPTION2 ON)
+            check_conflicting_options_on(
+                IF_ON
+                    FEATURE_FLAG
+                CONFLICTS_WITH
+                    CONFLICTING_OPTION1
+                    CONFLICTING_OPTION2
+            )
+        """
+        self.create_workspace({"CMakeLists.txt": _cmake_lists_txt})
+        self.run_cmake(
+            error_contains="Both 'FEATURE_FLAG' and 'CONFLICTING_OPTION1' can't be ON"
+        )


### PR DESCRIPTION
### Summary
We currently have some flags that cannot be turned on with other flags. We currently work around this be implicitly flipping the other flags. Let's make this violation explicit now and expect the users to exclude the conflicting flag.

Example:
https://github.com/pytorch/executorch/blob/b63290657e63f8264e7a03b1b2e37a02eea7c687/CMakeLists.txt#L550-L563

### Test plan

```
$ python -m unittest tools.cmake.common.preset_test.TestPreset
```


cc @larryliu0820