### PR TITLE
Automatically determine presets for known platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,11 @@ if(NOT CMAKE_SYSTEM_PROCESSOR)
 endif()
 announce_configured_options(CMAKE_SYSTEM_PROCESSOR)
 
+if(NOT CMAKE_SYSTEM_NAME)
+  set(CMAKE_SYSTEM_NAME ${CMAKE_HOST_SYSTEM_NAME})
+endif()
+announce_configured_options(CMAKE_SYSTEM_NAME)
+
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Debug)
 endif()
@@ -83,7 +88,7 @@ announce_configured_options(BUCK2)
 announce_configured_options(CMAKE_CXX_COMPILER_ID)
 announce_configured_options(CMAKE_TOOLCHAIN_FILE)
 
-load_build_preset()
+load_executorch_build_preset_file()
 include(${PROJECT_SOURCE_DIR}/tools/cmake/preset/default.cmake)
 
 # Print all the configs that were called with announce_configured_options.

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -13,7 +13,6 @@
       "generator": "Xcode",
       "cacheVariables": {
         "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/third-party/ios-cmake/ios.toolchain.cmake",
-        "EXECUTORCH_BUILD_PRESET_FILE": "${sourceDir}/tools/cmake/preset/macos.cmake",
         "PLATFORM": "MAC_ARM64",
         "DEPLOYMENT_TARGET": "12.0"
       },
@@ -30,7 +29,6 @@
       "generator": "Xcode",
       "cacheVariables": {
         "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/third-party/ios-cmake/ios.toolchain.cmake",
-        "EXECUTORCH_BUILD_PRESET_FILE": "${sourceDir}/tools/cmake/preset/ios.cmake",
         "PLATFORM": "OS64",
         "DEPLOYMENT_TARGET": "17.0"
       },
@@ -47,7 +45,6 @@
       "generator": "Xcode",
       "cacheVariables": {
         "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/third-party/ios-cmake/ios.toolchain.cmake",
-        "EXECUTORCH_BUILD_PRESET_FILE": "${sourceDir}/tools/cmake/preset/ios.cmake",
         "PLATFORM": "SIMULATORARM64",
         "DEPLOYMENT_TARGET": "17.0"
       },
@@ -62,8 +59,7 @@
       "displayName": "Build everything buildable on Linux",
       "inherits": ["common"],
       "cacheVariables": {
-        "CMAKE_SYSTEM_NAME": "Linux",
-        "EXECUTORCH_BUILD_PRESET_FILE": "${sourceDir}/tools/cmake/preset/linux.cmake"
+        "CMAKE_SYSTEM_NAME": "Linux"
       },
       "condition": {
         "lhs": "${hostSystemName}",
@@ -88,9 +84,7 @@
     {
         "name": "llm",
         "displayName": "Build LLM libraries",
-        "inherits": [
-            "common"
-        ],
+        "inherits": ["common"],
         "cacheVariables": {
             "EXECUTORCH_BUILD_PRESET_FILE": "${sourceDir}/tools/cmake/preset/llm.cmake",
             "CMAKE_OSX_DEPLOYMENT_TARGET": "12.0"
@@ -98,11 +92,7 @@
         "condition": {
             "type": "inList",
             "string": "${hostSystemName}",
-            "list": [
-                "Darwin",
-                "Linux",
-                "Windows"
-            ]
+            "list": ["Darwin", "Linux", "Windows"]
         }
     }
   ]

--- a/backends/apple/coreml/CMakeLists.txt
+++ b/backends/apple/coreml/CMakeLists.txt
@@ -212,9 +212,13 @@ if(APPLE)
   target_link_options_shared_lib(coremldelegate)
 
   if(EXECUTORCH_COREML_BUILD_EXECUTOR_RUNNER)
-    target_link_libraries(
-      coremldelegate PRIVATE portable_ops_lib portable_kernels
-    )
+    if(EXECUTORCH_BUILD_KERNELS_OPTIMIZED)
+      target_link_libraries(coremldelegate PRIVATE optimized_native_cpu_ops_lib)
+    else()
+      target_link_libraries(coremldelegate PRIVATE portable_ops_lib)
+    endif()
+
+    target_link_libraries(coremldelegate PRIVATE portable_kernels)
   endif()
 
   target_compile_options(

--- a/tools/cmake/common/preset.cmake
+++ b/tools/cmake/common/preset.cmake
@@ -94,15 +94,27 @@ macro(set_overridable_option NAME VALUE)
   endif()
 endmacro()
 
+
 # Detemine the build preset and load it.
-macro(load_build_preset)
+macro(load_executorch_build_preset_file)
+  # If EXECUTORCH_BUILD_PRESET_FILE is not set, then try to infer it.
+  if(NOT DEFINED EXECUTORCH_BUILD_PRESET_FILE)
+    if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+      set(EXECUTORCH_BUILD_PRESET_FILE "${PROJECT_SOURCE_DIR}/tools/cmake/preset/macos.cmake")
+    elseif(CMAKE_SYSTEM_NAME STREQUAL "iOS")
+      set(EXECUTORCH_BUILD_PRESET_FILE "${PROJECT_SOURCE_DIR}/tools/cmake/preset/ios.cmake")
+    elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+      set(EXECUTORCH_BUILD_PRESET_FILE "${PROJECT_SOURCE_DIR}/tools/cmake/preset/linux.cmake")
+    else()
+      message(WARNING "Unknown CMAKE_SYSTEM_NAME, unable to determine EXECUTORCH_BUILD_PRESET_FILE")
+    endif()
+  endif()
+
   if(DEFINED EXECUTORCH_BUILD_PRESET_FILE)
     announce_configured_options(EXECUTORCH_BUILD_PRESET_FILE)
     message(STATUS "Loading build preset: ${EXECUTORCH_BUILD_PRESET_FILE}")
     include(${EXECUTORCH_BUILD_PRESET_FILE})
   endif()
-  # For now, just continue if the preset file is not set. In the future, we will
-  # try to determine a preset file.
 endmacro()
 
 

--- a/tools/cmake/preset/apple_common.cmake
+++ b/tools/cmake/preset/apple_common.cmake
@@ -4,18 +4,24 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++${CMAKE_CXX_STANDARD}")
-set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++")
+if(CMAKE_GENERATOR STREQUAL "Xcode")
+  set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++${CMAKE_CXX_STANDARD}")
+  set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++")
 
-# Clean up the paths LLDB sees in DWARF.
-set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS}   -gno-record-gcc-switches")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -gno-record-gcc-switches")
+  # Clean up the paths LLDB sees in DWARF.
+  set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS}   -gno-record-gcc-switches")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -gno-record-gcc-switches")
+
+  # Swift requires Xcode
+  set_overridable_option(EXECUTORCH_BUILD_EXTENSION_APPLE ON)
+else()
+  message(WARNING "Building Apple targets without Xcode disables some features.")
+endif()
 
 set_overridable_option(EXECUTORCH_BUILD_XNNPACK ON)
 set_overridable_option(EXECUTORCH_BUILD_COREML ON)
 set_overridable_option(EXECUTORCH_BUILD_MPS ON)
 set_overridable_option(EXECUTORCH_XNNPACK_SHARED_WORKSPACE ON)
-set_overridable_option(EXECUTORCH_BUILD_EXTENSION_APPLE ON)
 set_overridable_option(EXECUTORCH_BUILD_EXTENSION_DATA_LOADER ON)
 set_overridable_option(EXECUTORCH_BUILD_EXTENSION_MODULE ON)
 set_overridable_option(EXECUTORCH_BUILD_EXTENSION_FLAT_TENSOR ON)


### PR DESCRIPTION
### Summary

For well known platforms, we should automatically infer the preset to choose if the user has not explicitly specified it. Why are am I removing this from `CMakePresets.json`? Just so we have a single location of mapping from platform → preset file.

If ET is used within other cmake projects, we should be able top automatically pick up the right preset!

### Test plan

With this, we can finally just build with just:

```
$ cmake -S . -B cmake-out
$ cmake --build cmake-out -j $(sysctl -n hw.ncpu)
```

Presets continue to work:

```
$ cmake --preset ios
$ cmake --build cmake-out -j $(sysctl -n hw.ncpu)
```


cc @larryliu0820