### PR TITLE
Arm backend: Add validate_valid_dtype

### DIFF
--- a/backends/arm/operators/op_abs.py
+++ b/backends/arm/operators/op_abs.py
@@ -16,6 +16,7 @@ from executorch.backends.arm.operators.node_visitor import (
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
     validate_same_dtype,
+    validate_valid_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
@@ -45,12 +46,13 @@ class AbsVisitor_080_BI(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 1)
         validate_same_dtype(self.target, [*inputs, output], ts)
-
         # Handle int8 (quantized) and int32
-        if not (inputs[0].dtype in [ts.DType.INT8, ts.DType.INT32]):
-            raise ValueError(
-                "All inputs need to be INT8 or INT32." f"Got {inputs[0].dtype=}"
-            )
+        validate_valid_dtype(
+            self.target,
+            [*inputs, output],
+            [ts.DType.INT8, ts.DType.INT32],
+            output.tosa_spec,
+        )
 
         if inputs[0].dtype == ts.DType.INT8:
             rescaled_inputs, scale_back = tqutils.insert_rescale_ops_to_int32(
@@ -113,14 +115,9 @@ class AbsVisitor_080_MI(AbsVisitor_080_BI):
             super().define_node(node, tosa_graph, inputs, output)
         else:
             # FP32 Abs lowering
-
-            if not (inputs[0].dtype == ts.DType.FP32):
-                raise ValueError(
-                    "All inputs need to be FP32." f"Got {inputs[0].dtype=}"
-                )
-
-            if not (output.dtype == ts.DType.FP32):
-                raise ValueError("All outputs need to be FP32." f"Got {output.dtype=}")
+            validate_valid_dtype(
+                self.target, [*inputs, output], ts.DType.FP32, output.tosa_spec
+            )
 
             # MI lowering
             tosa_graph.addOperator(
@@ -156,10 +153,12 @@ class AbsVisitor_INT(NodeVisitor):
         validate_same_dtype(self.target, [*inputs, output], ts)
 
         # Handle int8 (quantized) and int32
-        if not (inputs[0].dtype in [ts.DType.INT8, ts.DType.INT32]):
-            raise ValueError(
-                "All inputs need to be INT8 or INT32." f"Got {inputs[0].dtype=}"
-            )
+        validate_valid_dtype(
+            self.target,
+            [*inputs, output],
+            [ts.DType.INT8, ts.DType.INT32],
+            output.tosa_spec,
+        )
 
         scale_back = 1.0
         if inputs[0].dtype == ts.DType.INT8:
@@ -224,13 +223,9 @@ class AbsVisitor_FP(AbsVisitor_INT):
         else:
             # FP32 Abs lowering
 
-            if not (inputs[0].dtype == ts.DType.FP32):
-                raise ValueError(
-                    "All inputs need to be FP32." f"Got {inputs[0].dtype=}"
-                )
-
-            if not (output.dtype == ts.DType.FP32):
-                raise ValueError("All outputs need to be FP32." f"Got {output.dtype=}")
+            validate_valid_dtype(
+                self.target, [*inputs, output], ts.DType.FP32, output.tosa_spec
+            )
 
             # MI lowering
             tosa_graph.addOperator(

--- a/backends/arm/operators/op_amax.py
+++ b/backends/arm/operators/op_amax.py
@@ -12,6 +12,7 @@ from executorch.backends.arm.operators.node_visitor import (
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
     validate_same_dtype,
+    validate_valid_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from torch.fx import Node
@@ -37,6 +38,12 @@ class MaxVisitor_0_80(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 3)
         validate_same_dtype(self.target, [inputs[0], output], ts)
+        validate_valid_dtype(
+            self.target,
+            [inputs[0], output],
+            [ts.DType.INT8, ts.DType.INT16, ts.DType.INT32, ts.DType.FP32],
+            output.tosa_spec,
+        )
 
         input = inputs[0]
         dim = inputs[1].number
@@ -80,6 +87,12 @@ class MaxVisitor(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 3)
         validate_same_dtype(self.target, [inputs[0], output], ts)
+        validate_valid_dtype(
+            self.target,
+            [inputs[0], output],
+            [ts.DType.INT8, ts.DType.INT16, ts.DType.INT32, ts.DType.FP32],
+            output.tosa_spec,
+        )
 
         input = inputs[0]
         dim = inputs[1].number

--- a/backends/arm/operators/op_amin.py
+++ b/backends/arm/operators/op_amin.py
@@ -12,6 +12,7 @@ from executorch.backends.arm.operators.node_visitor import (
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
     validate_same_dtype,
+    validate_valid_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from torch.fx import Node
@@ -37,6 +38,12 @@ class MinVisitor_0_80(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 3)
         validate_same_dtype(self.target, [inputs[0], output], ts)
+        validate_valid_dtype(
+            self.target,
+            [inputs[0], output],
+            [ts.DType.INT8, ts.DType.INT16, ts.DType.INT32, ts.DType.FP32],
+            output.tosa_spec,
+        )
 
         input = inputs[0]
         dim = inputs[1].number
@@ -80,6 +87,12 @@ class MinVisitor(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 3)
         validate_same_dtype(self.target, [inputs[0], output], ts)
+        validate_valid_dtype(
+            self.target,
+            [inputs[0], output],
+            [ts.DType.INT8, ts.DType.INT16, ts.DType.INT32, ts.DType.FP32],
+            output.tosa_spec,
+        )
 
         input = inputs[0]
         dim = inputs[1].number

--- a/backends/arm/operators/op_any.py
+++ b/backends/arm/operators/op_any.py
@@ -13,6 +13,7 @@ from executorch.backends.arm.operators.node_visitor import (  # type: ignore
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
     validate_same_dtype,
+    validate_valid_dtype,
 )
 
 from executorch.backends.arm.tosa_mapping import TosaArg  # type: ignore
@@ -36,9 +37,9 @@ class AnyVisitor_0_80(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 3)
         validate_same_dtype(self.target, [inputs[0], output], ts)
-
-        if not (inputs[0].dtype == ts.DType.BOOL):
-            raise ValueError("All inputs need to be BOOL." f"Got {inputs[0].dtype=}")
+        validate_valid_dtype(
+            self.target, [inputs[0], output], ts.DType.BOOL, output.tosa_spec
+        )
 
         input_shape = list(inputs[0].shape)
         dim = cast(int, inputs[1].number) % len(
@@ -73,9 +74,9 @@ class AnyVisitor(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 3)
         validate_same_dtype(self.target, [inputs[0], output], ts)
-
-        if not (inputs[0].dtype == ts.DType.BOOL):
-            raise ValueError("All inputs need to be BOOL." f"Got {inputs[0].dtype=}")
+        validate_valid_dtype(
+            self.target, [inputs[0], output], ts.DType.BOOL, output.tosa_spec
+        )
 
         input_shape = list(inputs[0].shape)
         dim = cast(int, inputs[1].number) % len(

--- a/backends/arm/operators/op_avg_pool2d.py
+++ b/backends/arm/operators/op_avg_pool2d.py
@@ -20,6 +20,7 @@ from executorch.backends.arm.operators.operator_validation_utils import (
     adjust_pooling_pad_if_needed,
     validate_num_inputs,
     validate_same_dtype,
+    validate_valid_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
@@ -106,13 +107,9 @@ class AvgPool2dVisitor_0_80_BI(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, [3, 4, 6])
         validate_same_dtype(self.target, [inputs[0], output], ts)
-
-        supported_dtypes = [ts.DType.INT8]
-        if inputs[0].dtype not in supported_dtypes:
-            raise TypeError(
-                f"IO data type needs to be one of {supported_dtypes}, got "
-                f'"{inputs[0].dtype}"'
-            )
+        validate_valid_dtype(
+            self.target, [inputs[0], output], ts.DType.INT8, output.tosa_spec
+        )
 
         accumulator_type = ts.DType.INT32
 
@@ -146,13 +143,12 @@ class AvgPool2dVisitor_0_80_MI(AvgPool2dVisitor_0_80_BI):
 
         validate_num_inputs(self.target, inputs, [3, 4, 6])
         validate_same_dtype(self.target, [inputs[0], output], ts)
-
-        supported_dtypes = [ts.DType.INT8, ts.DType.FP32]
-        if inputs[0].dtype not in supported_dtypes:
-            raise TypeError(
-                f"IO data type needs to be one of {supported_dtypes}, got "
-                f'"{inputs[0].dtype}"'
-            )
+        validate_valid_dtype(
+            self.target,
+            [inputs[0], output],
+            [ts.DType.INT8, ts.DType.FP32],
+            output.tosa_spec,
+        )
 
         if inputs[0].dtype == ts.DType.INT8:
             super().define_node(node, tosa_graph, inputs, output)
@@ -253,13 +249,9 @@ class AvgPool2dVisitor(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, [3, 4, 6])
         validate_same_dtype(self.target, [inputs[0], output], ts)
-
-        supported_dtypes = [ts.DType.INT8]
-        if inputs[0].dtype not in supported_dtypes:
-            raise TypeError(
-                f"IO data type needs to be one of {supported_dtypes}, got "
-                f'"{inputs[0].dtype}"'
-            )
+        validate_valid_dtype(
+            self.target, [inputs[0], output], ts.DType.INT8, output.tosa_spec
+        )
 
         accumulator_type = ts.DType.INT32
 
@@ -296,13 +288,12 @@ class AvgPool2dVisitor_FP(AvgPool2dVisitor):
 
         validate_num_inputs(self.target, inputs, [3, 4, 6])
         validate_same_dtype(self.target, [inputs[0], output], ts)
-
-        supported_dtypes = [ts.DType.INT8, ts.DType.FP32]
-        if inputs[0].dtype not in supported_dtypes:
-            raise TypeError(
-                f"IO data type needs to be one of {supported_dtypes}, got "
-                f'"{inputs[0].dtype}"'
-            )
+        validate_valid_dtype(
+            self.target,
+            [inputs[0], output],
+            [ts.DType.INT8, ts.DType.FP32],
+            output.tosa_spec,
+        )
 
         if inputs[0].dtype == ts.DType.INT8:
             super().define_node(node, tosa_graph, inputs, output)

--- a/backends/arm/operators/op_bmm.py
+++ b/backends/arm/operators/op_bmm.py
@@ -20,6 +20,7 @@ from executorch.backends.arm.operators.node_visitor import (
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
     validate_same_dtype,
+    validate_valid_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_quant_utils import build_rescale, build_rescale_v0_80
@@ -51,15 +52,12 @@ class BMMVisitor_0_80(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 2)
         validate_same_dtype(self.target, [*inputs, output], ts)
-
-        # aten.bmm maps directly to MATMUL
-        # NOTE: For now, only INT8 & FP32 is supported
-        supported_dtypes = [ts.DType.INT8, ts.DType.FP32]
-        for input in inputs:
-            if input.dtype not in supported_dtypes:
-                raise TypeError(
-                    f'IO data type needs to be {supported_dtypes}, got "{input.dtype}"'
-                )
+        validate_valid_dtype(
+            self.target,
+            [*inputs, output],
+            [ts.DType.INT8, ts.DType.FP32],
+            output.tosa_spec,
+        )
 
         # aten.bmm maps directly to MATMUL
 
@@ -130,18 +128,14 @@ class BMMVisitor(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 2)
         validate_same_dtype(self.target, [*inputs, output], ts)
+        validate_valid_dtype(
+            self.target,
+            [*inputs, output],
+            [ts.DType.INT8, ts.DType.FP32],
+            output.tosa_spec,
+        )
 
         # aten.bmm maps directly to MATMUL
-        # NOTE: For now, only INT8 & FP32 is supported
-        supported_dtypes = [ts.DType.INT8, ts.DType.FP32]
-        for input in inputs:
-            if input.dtype not in supported_dtypes:
-                raise TypeError(
-                    f'IO data type needs to be {supported_dtypes}, got "{input.dtype}"'
-                )
-
-        # aten.bmm maps directly to MATMUL
-        # NOTE: For now, only INT8 & FP32 is supported
 
         # For INT8, we need to get the zero points and add an intermediate tensor
         # for a later rescale.

--- a/backends/arm/operators/op_clamp.py
+++ b/backends/arm/operators/op_clamp.py
@@ -18,6 +18,7 @@ from executorch.backends.arm.operators.node_visitor import (
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
     validate_same_dtype,
+    validate_valid_dtype,
 )
 
 from executorch.backends.arm.tosa_mapping import TosaArg
@@ -92,6 +93,12 @@ class ClampVisitor_080_BI(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, [2, 3])
         validate_same_dtype(self.target, [inputs[0], output], ts)
+        validate_valid_dtype(
+            self.target,
+            [inputs[0], output],
+            [ts.DType.INT8],
+            output.tosa_spec,
+        )
 
         min_int8, max_int8 = self._get_min_max_arguments(
             node,
@@ -133,6 +140,12 @@ class ClampVisitor_080_MI(ClampVisitor_080_BI):
 
         validate_num_inputs(self.target, inputs, [2, 3])
         validate_same_dtype(self.target, [inputs[0], output], ts)
+        validate_valid_dtype(
+            self.target,
+            [inputs[0], output],
+            [ts.DType.INT8, ts.DType.FP16, ts.DType.FP32],
+            output.tosa_spec,
+        )
 
         if inputs[0].dtype == ts.DType.INT8:
             # Call the inherited define_node for handling integers
@@ -200,6 +213,9 @@ class ClampVisitor_INT(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, [2, 3])
         validate_same_dtype(self.target, [inputs[0], output], ts)
+        validate_valid_dtype(
+            self.target, [inputs[0], output], [ts.DType.INT8], output.tosa_spec
+        )
 
         # NOTE: Quantization of the min/max arguments is handled by QuantizeOperatorArguments
         min_int8, max_int8 = self._get_min_max_arguments(
@@ -243,6 +259,12 @@ class ClampVisitor_FP(ClampVisitor_INT):
 
         validate_num_inputs(self.target, inputs, [2, 3])
         validate_same_dtype(self.target, [inputs[0], output], ts)
+        validate_valid_dtype(
+            self.target,
+            [inputs[0], output],
+            [ts.DType.FP16, ts.DType.FP32],
+            output.tosa_spec,
+        )
 
         min_fp32, max_fp32 = self._get_min_max_arguments(
             node,

--- a/backends/arm/operators/op_constant_pad_nd.py
+++ b/backends/arm/operators/op_constant_pad_nd.py
@@ -19,6 +19,7 @@ from executorch.backends.arm.operators.node_visitor import (
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
     validate_same_dtype,
+    validate_valid_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
@@ -45,6 +46,17 @@ class ConstantPadNDVisitor_0_80(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 3)
         validate_same_dtype(self.target, [inputs[0], output], ts)
+        validate_valid_dtype(
+            self.target,
+            [inputs[0], output],
+            [
+                ts.DType.INT8,
+                ts.DType.INT32,
+                ts.DType.FP32,
+                ts.DType.BOOL,
+            ],
+            output.tosa_spec,
+        )
 
         if inputs[0].dtype == ts.DType.INT8:
             input_qparams = get_input_qparams(node)
@@ -109,6 +121,17 @@ class ConstantPadNDVisitor(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 3)
         validate_same_dtype(self.target, [inputs[0], output], ts)
+        validate_valid_dtype(
+            self.target,
+            [inputs[0], output],
+            [
+                ts.DType.INT8,
+                ts.DType.INT32,
+                ts.DType.FP32,
+                ts.DType.BOOL,
+            ],
+            output.tosa_spec,
+        )
 
         if inputs[0].dtype == ts.DType.INT8:
             input_qparams = get_input_qparams(node)

--- a/backends/arm/operators/op_cos.py
+++ b/backends/arm/operators/op_cos.py
@@ -14,6 +14,7 @@ from executorch.backends.arm.operators.node_visitor import (
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
     validate_same_dtype,
+    validate_valid_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
@@ -39,10 +40,8 @@ class CosVisitor(NodeVisitor):
     ) -> None:
         validate_num_inputs(self.target, inputs, 1)
         validate_same_dtype(self.target, [*inputs, output], ts)
-        if inputs[0].dtype != ts.DType.FP32 or output.dtype != ts.DType.FP32:
-            raise ValueError(
-                f"Input and output for {self.target} need to be FP32, got input_dtype: "
-                f"{inputs[0].dtype} and output_dtype: {output.dtype}"
-            )
+        validate_valid_dtype(
+            self.target, [*inputs, output], ts.DType.FP32, output.tosa_spec
+        )
 
         tosa_graph.addOperator(ts.TosaOp.Op().COS, [inputs[0].name], [output.name])

--- a/backends/arm/operators/op_eq.py
+++ b/backends/arm/operators/op_eq.py
@@ -16,6 +16,7 @@ from executorch.backends.arm.operators.node_visitor import (
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
     validate_same_dtype,
+    validate_valid_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
@@ -47,6 +48,13 @@ class EqualVisitor_0_80(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 2)
         validate_same_dtype(self.target, inputs, ts)
+        validate_valid_dtype(
+            self.target,
+            inputs,
+            [ts.DType.INT8, ts.DType.INT32, ts.DType.FP32],
+            output.tosa_spec,
+        )
+        validate_valid_dtype(self.target, output, ts.DType.BOOL, output.tosa_spec)
 
         input_nodes = inputs
         # Handle quantization
@@ -92,6 +100,13 @@ class EqualVisitor(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 2)
         validate_same_dtype(self.target, inputs, ts)
+        validate_valid_dtype(
+            self.target,
+            inputs,
+            [ts.DType.INT8, ts.DType.INT32, ts.DType.FP32],
+            output.tosa_spec,
+        )
+        validate_valid_dtype(self.target, output, ts.DType.BOOL, output.tosa_spec)
 
         input_nodes = inputs
         # Handle quantization

--- a/backends/arm/operators/op_erf.py
+++ b/backends/arm/operators/op_erf.py
@@ -13,6 +13,7 @@ from executorch.backends.arm.operators.node_visitor import (
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
     validate_same_dtype,
+    validate_valid_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
@@ -39,9 +40,13 @@ class ERFVisitor_080_MI(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 1)
         validate_same_dtype(self.target, [*inputs, output], ts)
+        validate_valid_dtype(
+            self.target,
+            [*inputs, output],
+            ts.DType.FP32,
+            output.tosa_spec,
+        )
 
-        if not (inputs[0].dtype == ts.DType.FP32):
-            raise ValueError("All inputs need to be FP32." f"Got {inputs[0].dtype=}")
         # MI lowering
         tosa_graph.addOperator(ts.TosaOp.Op().ERF, [inputs[0].name], [output.name])
 
@@ -67,9 +72,12 @@ class ERFVisitor(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 1)
         validate_same_dtype(self.target, [*inputs, output], ts)
-
-        if not (inputs[0].dtype == ts.DType.FP32):
-            raise ValueError("All inputs need to be FP32." f"Got {inputs[0].dtype=}")
+        validate_valid_dtype(
+            self.target,
+            [*inputs, output],
+            ts.DType.FP32,
+            output.tosa_spec,
+        )
 
         # MI lowering
         tosa_graph.addOperator(ts.TosaOp.Op().ERF, [inputs[0].name], [output.name])

--- a/backends/arm/operators/op_exp.py
+++ b/backends/arm/operators/op_exp.py
@@ -13,6 +13,7 @@ from executorch.backends.arm.operators.node_visitor import (
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
     validate_same_dtype,
+    validate_valid_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
@@ -40,12 +41,12 @@ class ExpVisitor_0_80_MI(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 1)
         validate_same_dtype(self.target, [*inputs, output], ts)
-
-        if inputs[0].dtype != ts.DType.FP32 or output.dtype != ts.DType.FP32:
-            raise ValueError(
-                f"Input and output for {self.target} need to be FP32, got input dtype: "
-                f"{inputs[0].dtype} and output dtype: {output.dtype}"
-            )
+        validate_valid_dtype(
+            self.target,
+            [*inputs, output],
+            ts.DType.FP32,
+            output.tosa_spec,
+        )
 
         tosa_graph.addOperator(ts.TosaOp.Op().EXP, [inputs[0].name], [output.name])
 
@@ -71,11 +72,11 @@ class ExpVisitor(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 1)
         validate_same_dtype(self.target, [*inputs, output], ts)
-
-        if inputs[0].dtype != ts.DType.FP32 or output.dtype != ts.DType.FP32:
-            raise ValueError(
-                f"Input and output for {self.target} need to be FP32, got input dtype: "
-                f"{inputs[0].dtype} and output dtype: {output.dtype}"
-            )
+        validate_valid_dtype(
+            self.target,
+            [*inputs, output],
+            ts.DType.FP32,
+            output.tosa_spec,
+        )
 
         tosa_graph.addOperator(ts.TosaOp.Op().EXP, [inputs[0].name], [output.name])

--- a/backends/arm/operators/op_ge.py
+++ b/backends/arm/operators/op_ge.py
@@ -16,6 +16,7 @@ from executorch.backends.arm.operators.node_visitor import (
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
     validate_same_dtype,
+    validate_valid_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
@@ -47,6 +48,13 @@ class GreaterEqualVisitor_0_80(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 2)
         validate_same_dtype(self.target, inputs, ts)
+        validate_valid_dtype(
+            self.target,
+            inputs,
+            [ts.DType.INT8, ts.DType.INT32, ts.DType.FP32],
+            output.tosa_spec,
+        )
+        validate_valid_dtype(self.target, output, ts.DType.BOOL, output.tosa_spec)
 
         input_nodes = inputs
         # Handle quantization
@@ -91,6 +99,13 @@ class GreaterEqualVisitor(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 2)
         validate_same_dtype(self.target, inputs, ts)
+        validate_valid_dtype(
+            self.target,
+            inputs,
+            [ts.DType.INT8, ts.DType.INT32, ts.DType.FP32],
+            output.tosa_spec,
+        )
+        validate_valid_dtype(self.target, output, ts.DType.BOOL, output.tosa_spec)
 
         input_nodes = inputs
         # Handle quantization

--- a/backends/arm/operators/op_gt.py
+++ b/backends/arm/operators/op_gt.py
@@ -16,6 +16,7 @@ from executorch.backends.arm.operators.node_visitor import (
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
     validate_same_dtype,
+    validate_valid_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
@@ -47,6 +48,13 @@ class GreaterThanVisitor_0_80(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 2)
         validate_same_dtype(self.target, inputs, ts)
+        validate_valid_dtype(
+            self.target,
+            inputs,
+            [ts.DType.INT8, ts.DType.INT32, ts.DType.FP32],
+            output.tosa_spec,
+        )
+        validate_valid_dtype(self.target, output, ts.DType.BOOL, output.tosa_spec)
 
         input_nodes = inputs
         # Handle quantization
@@ -91,6 +99,13 @@ class GreaterThanVisitor(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 2)
         validate_same_dtype(self.target, inputs, ts)
+        validate_valid_dtype(
+            self.target,
+            inputs,
+            [ts.DType.INT8, ts.DType.INT32, ts.DType.FP32],
+            output.tosa_spec,
+        )
+        validate_valid_dtype(self.target, output, ts.DType.BOOL, output.tosa_spec)
 
         input_nodes = inputs
         # Handle quantization

--- a/backends/arm/operators/op_le.py
+++ b/backends/arm/operators/op_le.py
@@ -16,6 +16,7 @@ from executorch.backends.arm.operators.node_visitor import (
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
     validate_same_dtype,
+    validate_valid_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
@@ -47,6 +48,13 @@ class LessEqualVisitor_0_80(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 2)
         validate_same_dtype(self.target, inputs, ts)
+        validate_valid_dtype(
+            self.target,
+            inputs,
+            [ts.DType.INT8, ts.DType.INT32, ts.DType.FP32],
+            output.tosa_spec,
+        )
+        validate_valid_dtype(self.target, output, ts.DType.BOOL, output.tosa_spec)
 
         input_nodes = inputs
         # Handle quantization
@@ -91,6 +99,13 @@ class LessEqualVisitor(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 2)
         validate_same_dtype(self.target, inputs, ts)
+        validate_valid_dtype(
+            self.target,
+            inputs,
+            [ts.DType.INT8, ts.DType.INT32, ts.DType.FP32],
+            output.tosa_spec,
+        )
+        validate_valid_dtype(self.target, output, ts.DType.BOOL, output.tosa_spec)
 
         input_nodes = inputs
         # Handle quantization

--- a/backends/arm/operators/op_log.py
+++ b/backends/arm/operators/op_log.py
@@ -13,6 +13,7 @@ from executorch.backends.arm.operators.node_visitor import (
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
     validate_same_dtype,
+    validate_valid_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
@@ -40,12 +41,9 @@ class LogVisitor_0_80_MI(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 1)
         validate_same_dtype(self.target, [*inputs, output], ts)
-
-        if inputs[0].dtype != ts.DType.FP32 or output.dtype != ts.DType.FP32:
-            raise ValueError(
-                f"Input and output for {self.target} need to be FP32, got input_dtype: "
-                f"{inputs[0].dtype} and output_dtype: {output.dtype}"
-            )
+        validate_valid_dtype(
+            self.target, [*inputs, output], ts.DType.FP32, output.tosa_spec
+        )
 
         tosa_graph.addOperator(ts.TosaOp.Op().LOG, [inputs[0].name], [output.name])
 
@@ -71,11 +69,8 @@ class LogVisitor(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 1)
         validate_same_dtype(self.target, [*inputs, output], ts)
-
-        if inputs[0].dtype != ts.DType.FP32 or output.dtype != ts.DType.FP32:
-            raise ValueError(
-                f"Input and output for {self.target} need to be FP32, got input_dtype: "
-                f"{inputs[0].dtype} and output_dtype: {output.dtype}"
-            )
+        validate_valid_dtype(
+            self.target, [*inputs, output], ts.DType.FP32, output.tosa_spec
+        )
 
         tosa_graph.addOperator(ts.TosaOp.Op().LOG, [inputs[0].name], [output.name])

--- a/backends/arm/operators/op_lt.py
+++ b/backends/arm/operators/op_lt.py
@@ -16,6 +16,7 @@ from executorch.backends.arm.operators.node_visitor import (
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
     validate_same_dtype,
+    validate_valid_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
@@ -47,6 +48,13 @@ class LessThanVisitor_0_80(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 2)
         validate_same_dtype(self.target, inputs, ts)
+        validate_valid_dtype(
+            self.target,
+            inputs,
+            [ts.DType.INT8, ts.DType.INT32, ts.DType.FP32],
+            output.tosa_spec,
+        )
+        validate_valid_dtype(self.target, output, ts.DType.BOOL, output.tosa_spec)
 
         input_nodes = inputs
         # Handle quantization
@@ -91,6 +99,13 @@ class LessThanVisitor(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 2)
         validate_same_dtype(self.target, inputs, ts)
+        validate_valid_dtype(
+            self.target,
+            inputs,
+            [ts.DType.INT8, ts.DType.INT32, ts.DType.FP32],
+            output.tosa_spec,
+        )
+        validate_valid_dtype(self.target, output, ts.DType.BOOL, output.tosa_spec)
 
         input_nodes = inputs
         # Handle quantization

--- a/backends/arm/operators/op_max_pool2d.py
+++ b/backends/arm/operators/op_max_pool2d.py
@@ -20,6 +20,7 @@ from executorch.backends.arm.operators.operator_validation_utils import (
     adjust_pooling_pad_if_needed,
     validate_num_inputs,
     validate_same_dtype,
+    validate_valid_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
@@ -48,6 +49,12 @@ class MaxPool2dVisitor_0_80(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, [3, 4])
         validate_same_dtype(self.target, [inputs[0], output], ts)
+        validate_valid_dtype(
+            self.target,
+            [inputs[0], output],
+            [ts.DType.INT8, ts.DType.FP32],
+            output.tosa_spec,
+        )
 
         input_tensor = inputs[0]
         kernel_size = inputs[1].special
@@ -133,6 +140,12 @@ class MaxPool2dVisitor(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, [3, 4])
         validate_same_dtype(self.target, [inputs[0], output], ts)
+        validate_valid_dtype(
+            self.target,
+            [inputs[0], output],
+            [ts.DType.INT8, ts.DType.FP32],
+            output.tosa_spec,
+        )
 
         input_tensor = inputs[0]
         kernel_size = inputs[1].special

--- a/backends/arm/operators/op_maximum.py
+++ b/backends/arm/operators/op_maximum.py
@@ -20,6 +20,7 @@ from executorch.backends.arm.operators.node_visitor import (
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
     validate_same_dtype,
+    validate_valid_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
@@ -51,6 +52,12 @@ class MaxVisitor_0_80(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 2)
         validate_same_dtype(self.target, [*inputs, output], ts)
+        validate_valid_dtype(
+            self.target,
+            [*inputs, output],
+            [ts.DType.INT8, ts.DType.INT32, ts.DType.FP32],
+            output.tosa_spec,
+        )
 
         scale_back = 1.0
         max_output = output
@@ -114,6 +121,12 @@ class MaxVisitor(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 2)
         validate_same_dtype(self.target, [*inputs, output], ts)
+        validate_valid_dtype(
+            self.target,
+            [*inputs, output],
+            [ts.DType.INT8, ts.DType.INT32, ts.DType.FP32],
+            output.tosa_spec,
+        )
 
         scale_back = 1.0
         max_output = output

--- a/backends/arm/operators/op_minimum.py
+++ b/backends/arm/operators/op_minimum.py
@@ -19,6 +19,7 @@ from executorch.backends.arm.operators.node_visitor import (
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
     validate_same_dtype,
+    validate_valid_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
@@ -50,6 +51,12 @@ class MinVisitor_0_80(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 2)
         validate_same_dtype(self.target, [*inputs, output], ts)
+        validate_valid_dtype(
+            self.target,
+            [*inputs, output],
+            [ts.DType.INT8, ts.DType.INT32, ts.DType.FP32],
+            output.tosa_spec,
+        )
 
         scale_back = 1.0
         min_output = output
@@ -113,6 +120,12 @@ class MinVisitor(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 2)
         validate_same_dtype(self.target, [*inputs, output], ts)
+        validate_valid_dtype(
+            self.target,
+            [*inputs, output],
+            [ts.DType.INT8, ts.DType.INT32, ts.DType.FP32],
+            output.tosa_spec,
+        )
 
         scale_back = 1.0
         min_output = output

--- a/backends/arm/operators/op_mul.py
+++ b/backends/arm/operators/op_mul.py
@@ -22,6 +22,7 @@ from executorch.backends.arm.operators.node_visitor import (
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
     validate_same_dtype,
+    validate_valid_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
@@ -48,16 +49,9 @@ class MulVisitor_080_BI(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 2)
         validate_same_dtype(self.target, [*inputs, output], ts)
-
-        if (
-            inputs[0].dtype != ts.DType.INT8
-            or inputs[1].dtype != ts.DType.INT8
-            or output.dtype != ts.DType.INT8
-        ):
-            raise ValueError(
-                f"Inputs and output for {self.target} need to be INT8, got "
-                f"{inputs[0].dtype=}, {inputs[1].dtype=} and {output.dtype=}"
-            )
+        validate_valid_dtype(
+            self.target, [*inputs, output], ts.DType.INT8, output.tosa_spec
+        )
 
         dim_order = (
             inputs[0].dim_order
@@ -164,16 +158,9 @@ class MulVisitor_INT(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 2)
         validate_same_dtype(self.target, [*inputs, output], ts)
-
-        if (
-            inputs[0].dtype != ts.DType.INT8
-            or inputs[1].dtype != ts.DType.INT8
-            or output.dtype != ts.DType.INT8
-        ):
-            raise ValueError(
-                f"Inputs and output for {self.target} need to be INT8, got "
-                f"{inputs[0].dtype=}, {inputs[1].dtype=} and {output.dtype=}"
-            )
+        validate_valid_dtype(
+            self.target, [*inputs, output], ts.DType.INT8, output.tosa_spec
+        )
 
         input_A = inputs[0]
         input_B = inputs[1]

--- a/backends/arm/operators/op_neg.py
+++ b/backends/arm/operators/op_neg.py
@@ -19,6 +19,7 @@ from executorch.backends.arm.operators.node_visitor import (
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
     validate_same_dtype,
+    validate_valid_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 
@@ -54,20 +55,20 @@ class NegVisitor_0_80(NodeVisitor):
     ) -> None:
         import tosa_tools.v0_80.serializer.tosa_serializer as ts  # type: ignore
 
-        supported_dtypes = {
+        supported_dtypes = [
             ts.DType.INT8,
             ts.DType.INT16,
             ts.DType.INT32,
             ts.DType.FP16,
             ts.DType.BF16,
             ts.DType.FP32,
-        }
+        ]
 
         validate_num_inputs(self.target, inputs, 1)
         validate_same_dtype(self.target, [*inputs, output], ts)
-
-        if inputs[0].dtype not in supported_dtypes:
-            raise ValueError(f"Unsupported dtype for NEGATE: {inputs[0].dtype}")
+        validate_valid_dtype(
+            self.target, [*inputs, output], supported_dtypes, output.tosa_spec
+        )
 
         input_zp, output_zp = get_negate_zero_points(
             node, inputs[0].dtype == ts.DType.INT8
@@ -101,20 +102,20 @@ class NegVisitor(NodeVisitor):
     ) -> None:
         import serializer.tosa_serializer as ts  # type: ignore
 
-        supported_dtypes = {
+        supported_dtypes = [
             ts.DType.INT8,
             ts.DType.INT16,
             ts.DType.INT32,
             ts.DType.FP16,
             ts.DType.BF16,
             ts.DType.FP32,
-        }
+        ]
 
         validate_num_inputs(self.target, inputs, 1)
         validate_same_dtype(self.target, [*inputs, output], ts)
-
-        if inputs[0].dtype not in supported_dtypes:
-            raise ValueError(f"Unsupported dtype for NEGATE: {inputs[0].dtype}")
+        validate_valid_dtype(
+            self.target, [*inputs, output], supported_dtypes, output.tosa_spec
+        )
 
         input_zp, output_zp = get_negate_zero_points(
             node, inputs[0].dtype == ts.DType.INT8

--- a/backends/arm/operators/op_permute.py
+++ b/backends/arm/operators/op_permute.py
@@ -16,6 +16,7 @@ from executorch.backends.arm.operators.node_visitor import (
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
     validate_same_dtype,
+    validate_valid_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 
@@ -113,6 +114,12 @@ class PermuteVisitor_0_80(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 2)
         validate_same_dtype(self.target, [inputs[0], output], ts)
+        validate_valid_dtype(
+            self.target,
+            [inputs[0], output],
+            [ts.DType.INT8, ts.DType.INT32, ts.DType.FP32],
+            output.tosa_spec,
+        )
 
         # The permutation vector describes a permutation P in default Pytorch dim_order.
         # For rank 4, the default dim_order NCHW.
@@ -153,6 +160,12 @@ class PermuteVisitor(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 2)
         validate_same_dtype(self.target, [inputs[0], output], ts)
+        validate_valid_dtype(
+            self.target,
+            [inputs[0], output],
+            [ts.DType.INT8, ts.DType.INT32, ts.DType.FP32],
+            output.tosa_spec,
+        )
 
         # The permutation vector describes a permutation P in default Pytorch dim_order.
         # For rank 4, the default dim_order NCHW.

--- a/backends/arm/operators/op_pow.py
+++ b/backends/arm/operators/op_pow.py
@@ -14,6 +14,7 @@ from executorch.backends.arm.operators.node_visitor import (
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
     validate_same_dtype,
+    validate_valid_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
@@ -42,11 +43,12 @@ class PowVisitor_080_MI(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 2)
         validate_same_dtype(self.target, [*inputs, output], ts)
-
-        if inputs[0].dtype not in [ts.DType.FP32, ts.DType.FP16]:
-            raise ValueError(
-                f"All inputs need to be FP32 or FP16. Got {inputs[0].dtype}"
-            )
+        validate_valid_dtype(
+            self.target,
+            [*inputs, output],
+            [ts.DType.FP16, ts.DType.FP32],
+            output.tosa_spec,
+        )
 
         tosa_graph.addOperator(
             ts.TosaOp.Op().POW,
@@ -81,11 +83,12 @@ class PowVisitor(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 2)
         validate_same_dtype(self.target, [*inputs, output], ts)
-
-        if inputs[0].dtype not in [ts.DType.FP32, ts.DType.FP16]:
-            raise ValueError(
-                f"All inputs need to be FP32 or FP16. Got {inputs[0].dtype}"
-            )
+        validate_valid_dtype(
+            self.target,
+            [*inputs, output],
+            [ts.DType.FP16, ts.DType.FP32],
+            output.tosa_spec,
+        )
 
         tosa_graph.addOperator(
             ts.TosaOp.Op().POW,

--- a/backends/arm/operators/op_reciprocal.py
+++ b/backends/arm/operators/op_reciprocal.py
@@ -15,6 +15,7 @@ from executorch.backends.arm.operators.node_visitor import (
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
     validate_same_dtype,
+    validate_valid_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
@@ -41,12 +42,9 @@ class ReciprocalVisitor_080_MI(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 1)
         validate_same_dtype(self.target, [*inputs, output], ts)
-
-        if inputs[0].dtype != ts.DType.FP32 or output.dtype != ts.DType.FP32:
-            raise ValueError(
-                f"Input and output for {self.target} need to be FP32, got "
-                f"{inputs[0].dtype=} and {output.dtype=}"
-            )
+        validate_valid_dtype(
+            self.target, [*inputs, output], ts.DType.FP32, output.tosa_spec
+        )
 
         tosa_graph.addOperator(
             ts.TosaOp.Op().RECIPROCAL, [inputs[0].name], [output.name]
@@ -74,12 +72,9 @@ class ReciprocalVisitor(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 1)
         validate_same_dtype(self.target, [*inputs, output], ts)
-
-        if inputs[0].dtype != ts.DType.FP32 or output.dtype != ts.DType.FP32:
-            raise ValueError(
-                f"Input and output for {self.target} need to be FP32, got "
-                f"{inputs[0].dtype=} and {output.dtype=}"
-            )
+        validate_valid_dtype(
+            self.target, [*inputs, output], ts.DType.FP32, output.tosa_spec
+        )
 
         tosa_graph.addOperator(
             ts.TosaOp.Op().RECIPROCAL, [inputs[0].name], [output.name]

--- a/backends/arm/operators/op_repeat.py
+++ b/backends/arm/operators/op_repeat.py
@@ -15,6 +15,7 @@ from executorch.backends.arm.operators.node_visitor import (
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
     validate_same_dtype,
+    validate_valid_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_utils import tosa_shape
@@ -40,6 +41,12 @@ class RepeatVisitor_0_80(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 2)
         validate_same_dtype(self.target, [inputs[0], output], ts)
+        validate_valid_dtype(
+            self.target,
+            [inputs[0], output],
+            [ts.DType.INT8, ts.DType.INT32, ts.DType.FP32],
+            output.tosa_spec,
+        )
 
         multiples = inputs[1].special
 
@@ -70,6 +77,12 @@ class RepeatVisitor(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 2)
         validate_same_dtype(self.target, [inputs[0], output], ts)
+        validate_valid_dtype(
+            self.target,
+            [inputs[0], output],
+            [ts.DType.INT8, ts.DType.INT32, ts.DType.FP32],
+            output.tosa_spec,
+        )
 
         multiples = inputs[1].special
 

--- a/backends/arm/operators/op_rshift_tensor.py
+++ b/backends/arm/operators/op_rshift_tensor.py
@@ -16,6 +16,7 @@ from executorch.backends.arm.operators.node_visitor import (
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
     validate_same_dtype,
+    validate_valid_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 
@@ -37,6 +38,12 @@ class RshiftVisitor_0_80(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 2)
         validate_same_dtype(self.target, [*inputs, output], ts)
+        validate_valid_dtype(
+            self.target,
+            [*inputs, output],
+            [ts.DType.INT8, ts.DType.INT16, ts.DType.INT32],
+            output.tosa_spec,
+        )
 
         attr = ts.TosaSerializerAttribute()
         round = False
@@ -71,6 +78,12 @@ class RshiftVisitor(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 2)
         validate_same_dtype(self.target, [*inputs, output], ts)
+        validate_valid_dtype(
+            self.target,
+            [*inputs, output],
+            [ts.DType.INT8, ts.DType.INT16, ts.DType.INT32],
+            output.tosa_spec,
+        )
 
         attr = ts.TosaSerializerAttribute()
         round = False

--- a/backends/arm/operators/op_rsqrt.py
+++ b/backends/arm/operators/op_rsqrt.py
@@ -15,6 +15,7 @@ from executorch.backends.arm.operators.node_visitor import (
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
     validate_same_dtype,
+    validate_valid_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
@@ -41,12 +42,9 @@ class RsqrtVisitor_080_MI(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 1)
         validate_same_dtype(self.target, [*inputs, output], ts)
-
-        if inputs[0].dtype != ts.DType.FP32 or output.dtype != ts.DType.FP32:
-            raise ValueError(
-                f"Input and output for {self.target} need to be FP32, got "
-                f"{inputs[0].dtype=} and {output.dtype=}"
-            )
+        validate_valid_dtype(
+            self.target, [*inputs, output], ts.DType.FP32, output.tosa_spec
+        )
 
         tosa_graph.addOperator(ts.TosaOp.Op().RSQRT, [inputs[0].name], [output.name])
 
@@ -72,11 +70,8 @@ class RsqrtVisitor(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 1)
         validate_same_dtype(self.target, [*inputs, output], ts)
-
-        if inputs[0].dtype != ts.DType.FP32 or output.dtype != ts.DType.FP32:
-            raise ValueError(
-                f"Input and output for {self.target} need to be FP32, got "
-                f"{inputs[0].dtype=} and {output.dtype=}"
-            )
+        validate_valid_dtype(
+            self.target, [*inputs, output], ts.DType.FP32, output.tosa_spec
+        )
 
         tosa_graph.addOperator(ts.TosaOp.Op().RSQRT, [inputs[0].name], [output.name])

--- a/backends/arm/operators/op_sigmoid.py
+++ b/backends/arm/operators/op_sigmoid.py
@@ -13,6 +13,7 @@ from executorch.backends.arm.operators.node_visitor import (
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
     validate_same_dtype,
+    validate_valid_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
@@ -40,12 +41,9 @@ class SigmoidVisitor_080_MI(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 1)
         validate_same_dtype(self.target, [*inputs, output], ts)
-
-        if inputs[0].dtype != ts.DType.FP32 or output.dtype != ts.DType.FP32:
-            raise ValueError(
-                f"Input and output for {self.target} need to be FP32, got input_dtype: "
-                f"{inputs[0].dtype} and output_dtype: {output.dtype}"
-            )
+        validate_valid_dtype(
+            self.target, [*inputs, output], ts.DType.FP32, output.tosa_spec
+        )
 
         tosa_graph.addOperator(ts.TosaOp.Op().SIGMOID, [inputs[0].name], [output.name])
 
@@ -71,11 +69,8 @@ class SigmoidVisitor(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 1)
         validate_same_dtype(self.target, [*inputs, output], ts)
-
-        if inputs[0].dtype != ts.DType.FP32 or output.dtype != ts.DType.FP32:
-            raise ValueError(
-                f"Input and output for {self.target} need to be FP32, got input_dtype: "
-                f"{inputs[0].dtype} and output_dtype: {output.dtype}"
-            )
+        validate_valid_dtype(
+            self.target, [*inputs, output], ts.DType.FP32, output.tosa_spec
+        )
 
         tosa_graph.addOperator(ts.TosaOp.Op().SIGMOID, [inputs[0].name], [output.name])

--- a/backends/arm/operators/op_sin.py
+++ b/backends/arm/operators/op_sin.py
@@ -14,6 +14,7 @@ from executorch.backends.arm.operators.node_visitor import (
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
     validate_same_dtype,
+    validate_valid_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
@@ -39,11 +40,8 @@ class SinVisitor(NodeVisitor):
     ) -> None:
         validate_num_inputs(self.target, inputs, 1)
         validate_same_dtype(self.target, [*inputs, output], ts)
-
-        if inputs[0].dtype != ts.DType.FP32 or output.dtype != ts.DType.FP32:
-            raise ValueError(
-                f"Input and output for {self.target} need to be FP32, got input_dtype: "
-                f"{inputs[0].dtype} and output_dtype: {output.dtype}"
-            )
+        validate_valid_dtype(
+            self.target, [*inputs, output], ts.DType.FP32, output.tosa_spec
+        )
 
         tosa_graph.addOperator(ts.TosaOp.Op().SIN, [inputs[0].name], [output.name])

--- a/backends/arm/operators/op_slice.py
+++ b/backends/arm/operators/op_slice.py
@@ -14,6 +14,7 @@ from executorch.backends.arm.operators.node_visitor import (
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
     validate_same_dtype,
+    validate_valid_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from torch.fx import Node
@@ -53,6 +54,12 @@ class SliceVisitor_080(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, [4, 5])
         validate_same_dtype(self.target, [inputs[0], output], ts)
+        validate_valid_dtype(
+            self.target,
+            [inputs[0], output],
+            [ts.DType.INT8, ts.DType.INT32, ts.DType.FP32],
+            output.tosa_spec,
+        )
 
         # See slice_copy_support.py
         if not (len(inputs) == 4 or (len(inputs) == 5 and inputs[4].number == 1)):
@@ -116,6 +123,12 @@ class SliceVisitor(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, [4, 5])
         validate_same_dtype(self.target, [inputs[0], output], ts)
+        validate_valid_dtype(
+            self.target,
+            [inputs[0], output],
+            [ts.DType.INT8, ts.DType.INT32, ts.DType.FP32],
+            output.tosa_spec,
+        )
 
         # See slice_copy_support.py
         if not (len(inputs) == 4 or (len(inputs) == 5 and inputs[4].number == 1)):

--- a/backends/arm/operators/op_table.py
+++ b/backends/arm/operators/op_table.py
@@ -15,6 +15,7 @@ from executorch.backends.arm.operators.node_visitor import (
 )
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
+    validate_valid_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 
@@ -37,19 +38,17 @@ class TableVisitor_0_80(NodeVisitor):
         import tosa_tools.v0_80.serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 1)
+        validate_valid_dtype(
+            self.target, inputs, [ts.DType.INT8, ts.DType.INT16], output.tosa_spec
+        )
+        if inputs[0].dtype == ts.DType.INT8:
+            validate_valid_dtype(self.target, output, ts.DType.INT8, output.tosa_spec)
+        if inputs[0].dtype == ts.DType.INT16:
+            validate_valid_dtype(self.target, output, ts.DType.INT32, output.tosa_spec)
 
         if node.name not in self._exported_program.state_dict.keys():  # type: ignore[union-attr]
             raise RuntimeError(
                 f"Did not find key {node.name} in state_dict {self._exported_program.state_dict.keys()}."
-            )
-        if inputs[0].dtype == ts.DType.INT8 and output.dtype != ts.DType.INT8:
-            raise ValueError(f"Int8 tables need int8 output, got {output.dtype=}.")
-        if inputs[0].dtype == ts.DType.INT16 and output.dtype != ts.DType.INT32:
-            raise ValueError(f"Int16 tables need int32 output, got {output.dtype=}.")
-
-        if inputs[0].dtype not in (ts.DType.INT8, ts.DType.INT16):
-            raise ValueError(
-                f"TOSA.TABLE only supports int8 or int16 inputs, got {ts.DTypeNames[inputs[0].dtype]}"
             )
 
         table = self._exported_program.state_dict[node.name]  # type: ignore[union-attr]
@@ -77,19 +76,17 @@ class TableVisitor(NodeVisitor):
         import serializer.tosa_serializer as ts  # type: ignore
 
         validate_num_inputs(self.target, inputs, 1)
+        validate_valid_dtype(
+            self.target, inputs, [ts.DType.INT8, ts.DType.INT16], output.tosa_spec
+        )
+        if inputs[0].dtype == ts.DType.INT8:
+            validate_valid_dtype(self.target, output, ts.DType.INT8, output.tosa_spec)
+        if inputs[0].dtype == ts.DType.INT16:
+            validate_valid_dtype(self.target, output, ts.DType.INT32, output.tosa_spec)
 
         if node.name not in self._exported_program.state_dict.keys():  # type: ignore[union-attr]
             raise RuntimeError(
                 f"Did not find key {node.name} in state_dict {self._exported_program.state_dict.keys()}."
-            )
-        if inputs[0].dtype == ts.DType.INT8 and output.dtype != ts.DType.INT8:
-            raise ValueError(f"Int8 tables need int8 output, got {output.dtype=}.")
-        if inputs[0].dtype == ts.DType.INT16 and output.dtype != ts.DType.INT32:
-            raise ValueError(f"Int16 tables need int32 output, got {output.dtype=}.")
-
-        if inputs[0].dtype not in (ts.DType.INT8, ts.DType.INT16):
-            raise ValueError(
-                f"TOSA.TABLE only supports int8 or int16 inputs, got {ts.DTypeNames[inputs[0].dtype]}"
             )
 
         table = self._exported_program.state_dict[node.name]

--- a/backends/arm/operators/op_tanh.py
+++ b/backends/arm/operators/op_tanh.py
@@ -13,6 +13,7 @@ from executorch.backends.arm.operators.node_visitor import (
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
     validate_same_dtype,
+    validate_valid_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
@@ -41,12 +42,9 @@ class TanhVisitor_0_80_MI(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 1)
         validate_same_dtype(self.target, [*inputs, output], ts)
-
-        if inputs[0].dtype != ts.DType.FP32 or output.dtype != ts.DType.FP32:
-            raise ValueError(
-                f"Input and output for {self.target} need to be FP32, got input_dtype: "
-                f"{inputs[0].dtype} and output_dtype: {output.dtype}"
-            )
+        validate_valid_dtype(
+            self.target, [*inputs, output], ts.DType.FP32, output.tosa_spec
+        )
 
         tosa_graph.addOperator(ts.TosaOp.Op().TANH, [inputs[0].name], [output.name])
 
@@ -72,11 +70,8 @@ class TanhVisitor(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 1)
         validate_same_dtype(self.target, [*inputs, output], ts)
-
-        if inputs[0].dtype != ts.DType.FP32 or output.dtype != ts.DType.FP32:
-            raise ValueError(
-                f"Input and output for {self.target} need to be FP32, got input_dtype: "
-                f"{inputs[0].dtype} and output_dtype: {output.dtype}"
-            )
+        validate_valid_dtype(
+            self.target, [*inputs, output], ts.DType.FP32, output.tosa_spec
+        )
 
         tosa_graph.addOperator(ts.TosaOp.Op().TANH, [inputs[0].name], [output.name])

--- a/backends/arm/operators/op_transpose.py
+++ b/backends/arm/operators/op_transpose.py
@@ -16,6 +16,7 @@ from executorch.backends.arm.operators.node_visitor import (
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
     validate_same_dtype,
+    validate_valid_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 
@@ -43,6 +44,12 @@ class TransposeVisitor_0_80(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 2)
         validate_same_dtype(self.target, [inputs[0], output], ts)
+        validate_valid_dtype(
+            self.target,
+            [inputs[0], output],
+            [ts.DType.INT8, ts.DType.INT32, ts.DType.FP32],
+            output.tosa_spec,
+        )
 
         output_rank = len(output.shape)
         perms = [dim % output_rank for dim in inputs[1].special]
@@ -76,6 +83,12 @@ class TransposeVisitor(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 2)
         validate_same_dtype(self.target, [inputs[0], output], ts)
+        validate_valid_dtype(
+            self.target,
+            [inputs[0], output],
+            [ts.DType.INT8, ts.DType.INT32, ts.DType.FP32],
+            output.tosa_spec,
+        )
 
         output_rank = len(output.shape)
         perms = [dim % output_rank for dim in inputs[1].special]

--- a/backends/arm/operators/op_upsample_bilinear2d.py
+++ b/backends/arm/operators/op_upsample_bilinear2d.py
@@ -15,6 +15,7 @@ from executorch.backends.arm.operators.node_visitor import (
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
     validate_same_dtype,
+    validate_valid_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_quant_utils import build_rescale, build_rescale_v0_80
@@ -42,6 +43,12 @@ class UpsampleBilinear2dVisitor_0_80(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 4)
         validate_same_dtype(self.target, [inputs[0], output], ts)
+        validate_valid_dtype(
+            self.target,
+            [inputs[0], output],
+            [ts.DType.INT8, ts.DType.INT32, ts.DType.FP32],
+            output.tosa_spec,
+        )
 
         if inputs[0].shape is None or output.shape is None:
             raise ValueError("Only static shapes are supported")
@@ -135,6 +142,12 @@ class UpsampleBilinear2dVisitor(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 4)
         validate_same_dtype(self.target, [inputs[0], output], ts)
+        validate_valid_dtype(
+            self.target,
+            [inputs[0], output],
+            [ts.DType.INT8, ts.DType.INT32, ts.DType.FP32],
+            output.tosa_spec,
+        )
 
         if inputs[0].shape is None or output.shape is None:
             raise ValueError("Only static shapes are supported")

--- a/backends/arm/operators/op_upsample_nearest2d.py
+++ b/backends/arm/operators/op_upsample_nearest2d.py
@@ -15,6 +15,7 @@ from executorch.backends.arm.operators.node_visitor import (
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
     validate_same_dtype,
+    validate_valid_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_utils import get_resize_parameters
@@ -42,6 +43,12 @@ class UpsampleNearest2dVisitor_0_80(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 3)
         validate_same_dtype(self.target, [inputs[0], output], ts)
+        validate_valid_dtype(
+            self.target,
+            [inputs[0], output],
+            [ts.DType.INT8, ts.DType.INT32, ts.DType.FP32],
+            output.tosa_spec,
+        )
 
         # tosa_shape output is NHWC, take HW
         input_size_yx = tuple([inputs[0].shape[dim] for dim in inputs[0].dim_order])[
@@ -98,6 +105,12 @@ class UpsampleNearest2dVisitor(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 3)
         validate_same_dtype(self.target, [inputs[0], output], ts)
+        validate_valid_dtype(
+            self.target,
+            [inputs[0], output],
+            [ts.DType.INT8, ts.DType.INT32, ts.DType.FP32],
+            output.tosa_spec,
+        )
 
         # tosa_shape output is NHWC, take HW
         input_size_yx = tuple([inputs[0].shape[dim] for dim in inputs[0].dim_order])[

--- a/backends/arm/operators/op_view.py
+++ b/backends/arm/operators/op_view.py
@@ -15,6 +15,7 @@ from executorch.backends.arm.operators.node_visitor import (
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
     validate_same_dtype,
+    validate_valid_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_utils import tosa_shape
@@ -40,6 +41,12 @@ class ViewVisitor_0_80(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 2)
         validate_same_dtype(self.target, [inputs[0], output], ts)
+        validate_valid_dtype(
+            self.target,
+            [inputs[0], output],
+            [ts.DType.INT8, ts.DType.INT32, ts.DType.FP32, ts.DType.BOOL],
+            output.tosa_spec,
+        )
 
         attr = ts.TosaSerializerAttribute()
         new_shape = tosa_shape(inputs[1].special, output.dim_order)
@@ -70,6 +77,12 @@ class ViewVisitor(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 2)
         validate_same_dtype(self.target, [inputs[0], output], ts)
+        validate_valid_dtype(
+            self.target,
+            [inputs[0], output],
+            [ts.DType.INT8, ts.DType.INT32, ts.DType.FP32, ts.DType.BOOL],
+            output.tosa_spec,
+        )
 
         tosa_graph = cast(ts.TosaSerializer, tosa_graph)
 

--- a/backends/arm/operators/op_where.py
+++ b/backends/arm/operators/op_where.py
@@ -13,6 +13,7 @@ from executorch.backends.arm.operators.node_visitor import (
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
     validate_same_dtype,
+    validate_valid_dtype,
 )
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
@@ -42,14 +43,13 @@ class WhereVisitor_0_80_BI(NodeVisitor):
         validate_num_inputs(self.target, inputs, 3)
         # Not first input, which is condition tensor.
         validate_same_dtype(self.target, inputs[1:], ts)
-
-        if inputs[0].dtype is not ts.DType.BOOL:
-            raise ValueError("Input 0 needs to have dtype BOOL")
-        for input_ in inputs[1:]:
-            if input_.dtype not in supported_dtypes:
-                raise ValueError(
-                    f"Input needs to be of torch dtype {supported_dtypes}, got {input_.dtype}"
-                )
+        validate_valid_dtype(self.target, inputs[0], ts.DType.BOOL, output.tosa_spec)
+        validate_valid_dtype(
+            self.target,
+            [*inputs[1:], output],
+            supported_dtypes,
+            output.tosa_spec,
+        )
 
         tosa_graph.addOperator(
             ts.TosaOp.Op().SELECT,
@@ -129,14 +129,13 @@ class WhereVisitor_INT(NodeVisitor):
         validate_num_inputs(self.target, inputs, 3)
         # Not first input, which is condition tensor.
         validate_same_dtype(self.target, inputs[1:], ts)
-
-        if inputs[0].dtype is not ts.DType.BOOL:
-            raise ValueError("Input 0 needs to have dtype BOOL")
-        for input_ in inputs[1:]:
-            if input_.dtype not in supported_dtypes:
-                raise ValueError(
-                    f"Input needs to be of torch dtype {supported_dtypes}, got {input_.dtype}"
-                )
+        validate_valid_dtype(self.target, inputs[0], ts.DType.BOOL, output.tosa_spec)
+        validate_valid_dtype(
+            self.target,
+            [*inputs[1:], output],
+            supported_dtypes,
+            output.tosa_spec,
+        )
 
         tosa_graph.addOperator(
             ts.TosaOp.Op().SELECT,

--- a/backends/arm/operators/ops_unary.py
+++ b/backends/arm/operators/ops_unary.py
@@ -15,6 +15,7 @@ from executorch.backends.arm.operators.node_visitor import (
 from executorch.backends.arm.operators.operator_validation_utils import (
     validate_num_inputs,
     validate_same_dtype,
+    validate_valid_dtype,
 )
 
 from executorch.backends.arm.tosa_mapping import TosaArg
@@ -45,9 +46,12 @@ def unary_operator_factory_0_80(unary_target: str, tosa_op):
             validate_num_inputs(self.target, inputs, 1)
             validate_same_dtype(self.target, [*inputs, output], ts)
 
-            if self.target in fp_only_ops and not (inputs[0].dtype == ts.DType.FP32):
-                raise ValueError(
-                    "All inputs need to be FP32." f"Got {inputs[0].dtype=}"
+            if self.target in fp_only_ops:
+                validate_valid_dtype(
+                    self.target,
+                    inputs[0],
+                    ts.DType.FP32,
+                    output.tosa_spec,
                 )
 
             tosa_graph.addOperator(tosa_op, [inputs[0].name], [output.name])
@@ -80,9 +84,12 @@ def unary_operator_factory(unary_target: str, tosa_op):
             validate_num_inputs(self.target, inputs, 1)
             validate_same_dtype(self.target, [*inputs, output], ts)
 
-            if self.target in fp_only_ops and not (inputs[0].dtype == ts.DType.FP32):
-                raise ValueError(
-                    "All inputs need to be FP32." f"Got {inputs[0].dtype=}"
+            if self.target in fp_only_ops:
+                validate_valid_dtype(
+                    self.target,
+                    inputs[0],
+                    ts.DType.FP32,
+                    output.tosa_spec,
                 )
 
             tosa_graph.addOperator(tosa_op, [inputs[0].name], [output.name])


### PR DESCRIPTION
Add a new validate_valid_dtype helper in operator_validation_utils to centralize and standardize dtype validation logic across all ARM backend operators. Manual, duplicated dtype checks in individual operator visitors have been replaced with calls to validate_valid_dtype.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218