### PR TITLE
Avoid use-after-return caused by double move

### DIFF
--- a/runtime/core/result.h
+++ b/runtime/core/result.h
@@ -70,8 +70,9 @@ class Result final {
   /// Value copy constructor.
   /* implicit */ Result(const T& val) : value_(val), hasValue_(true) {}
 
-  /// Value move constructor.
-  /* implicit */ Result(T&& val) : value_(std::move(val)), hasValue_(true) {}
+  /// Value forwarding constructor.
+  /* implicit */ Result(T&& val)
+      : value_(std::forward<T>(val)), hasValue_(true) {}
 
   /// Result move constructor.
   /* implicit */ Result(Result&& rhs) noexcept : hasValue_(rhs.hasValue_) {


### PR DESCRIPTION
Summary:

Previously, `Result<T>`'s constructor used `std::move(val)` to initialize the
value. This resulted in an unnecessary extra move and destructor call on a
moved-from stack object, triggering an HWASAN stack tag mismatch when the
moved-from object was later destructed.

Replacing `std::move(val)` with `std::forward<T>(val)` avoids the extra move
while preserving correct semantics. This ensures only one move occurs and
avoids lifetime violations that can lead to tag mismatches under HWASAN.

Differential Revision: D76271359


