### PR TITLE
Dont require method loading for meta meta in module api

### DIFF
--- a/extension/module/module.cpp
+++ b/extension/module/module.cpp
@@ -229,8 +229,8 @@ runtime::Error Module::load_method(
 
 runtime::Result<MethodMeta> Module::method_meta(
     const std::string& method_name) {
-  ET_CHECK_OK_OR_RETURN_ERROR(load_method(method_name));
-  return methods_.at(method_name).method->method_meta();
+  ET_CHECK_OK_OR_RETURN_ERROR(load());
+  return program_->method_meta(method_name.c_str());
 }
 
 runtime::Result<std::vector<runtime::EValue>> Module::execute(

--- a/extension/module/module.h
+++ b/extension/module/module.h
@@ -221,7 +221,7 @@ class Module {
 
   /**
    * Get a method metadata struct by method name.
-   * Loads the program and method if needed.
+   * Loads the program if needed.
    *
    * @param[in] method_name The name of the method to get the metadata for.
    *


### PR DESCRIPTION
Summary: Program load is still required but this is very cheap. Method load is not needed.

Differential Revision: D76278890


