### PR TITLE
Arm backend: Bump cortex-m size test threshold

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -262,7 +262,7 @@ jobs:
         output=$(ls -la ${elf})
         arr=($output)
         size=${arr[4]}
-        threshold="103068" # ~100KiB
+        threshold="103268" # ~100KiB
         echo "size: $size, threshold: $threshold"
         if [[ "$size" -le "$threshold" ]]; then
           echo "Success $size <= $threshold"


### PR DESCRIPTION
Size to runtime has grown and this started to fail after some code was improved/added in the "Refactor FlatTensor" change: https://github.com/pytorch/executorch/pull/11499 and we got ~50 Bytes over the limit. 

cc @digantdesai @freddan80 @per @oscarandersson8218