### PR TITLE
Revert D76283309: Multisect successfully blamed "D76000131: [pytorch/executorch][diff_train] Support exp op in XNNPACK backend (#11373)" for 100+ test failures

### DIFF
--- a/backends/xnnpack/partition/config/__init__.py
+++ b/backends/xnnpack/partition/config/__init__.py
@@ -26,7 +26,7 @@ from executorch.backends.xnnpack.partition.config.generic_node_configs import (
     DeQuantizedPerTensorConfig,
     DivConfig,
     # EluConfig,
-    # ExpConfig, # Bug in XNNPACK with exp op
+    ExpConfig,
     FloorConfig,
     GeluConfig,
     HardswishConfig,
@@ -81,7 +81,7 @@ ALL_PARTITIONER_CONFIGS: List[Type[XNNPartitionerConfig]] = [
     ClampConfig,
     DivConfig,
     # EluConfig, # Waiting for PyTorch Pin Update
-    # ExpConfig, # Bug in XNNPACK with exp op
+    ExpConfig,
     FloorConfig,
     GeluConfig,
     HardtanhConfig,

--- a/backends/xnnpack/partition/configs.py
+++ b/backends/xnnpack/partition/configs.py
@@ -59,7 +59,7 @@ SUPPORTED_OPS = [
     exir_ops.edge.aten.sigmoid.default,
     exir_ops.edge.aten._softmax.default,
     exir_ops.edge.aten.cat.default,
-    # exir_ops.edge.aten.exp.default, # Bug in XNNPACK with exp op
+    exir_ops.edge.aten.exp.default,
     exir_ops.edge.aten.elu.default,
     exir_ops.edge.aten.avg_pool2d.default,
     exir_ops.edge.aten.leaky_relu.default,

--- a/backends/xnnpack/test/ops/test_exp.py
+++ b/backends/xnnpack/test/ops/test_exp.py
@@ -34,12 +34,10 @@ class TestExp(unittest.TestCase):
             .run_method_and_compare_outputs()
         )
 
-    @unittest.skip("D76283309, bug to fix")
     def test_fp16_exp(self):
         inputs = (torch.randn(20).to(torch.float16),)
         self.run_exp_test(inputs)
 
-    @unittest.skip("D76283309, bug to fix")
     def test_fp32_exp(self):
         inputs = (torch.randn(20),)
         self.run_exp_test(inputs)


### PR DESCRIPTION
Summary:
This diff reverts D76283309
D76000131: [pytorch/executorch][diff_train] Support exp op in XNNPACK backend (#11373) by leafs1 causes the following test failures:


Depends on D76283309

Differential Revision: D76331094


