### PR TITLE
Remove empty TARGETS file

### DIFF
--- a/tools/buck/constraints/TARGETS
+++ b/tools/buck/constraints/TARGETS
@@ -1,1 +1,0 @@
-oncall("executorch")


### PR DESCRIPTION
Summary: The `//executorch/tools/buck/constraints/TARGETS` file has no contents, which causes certain cquery command syntax to fail.

Differential Revision: D76355323
