### PR TITLE
fix platform inconsistencies

### DIFF
--- a/backends/vulkan/test/op_tests/targets.bzl
+++ b/backends/vulkan/test/op_tests/targets.bzl
@@ -20,6 +20,7 @@ def define_test_targets(test_name, extra_deps = [], src_file = None, is_fbcode =
         compiler_flags = [
             "-Wno-unused-variable",
         ],
+        platforms = [ANDROID],
         define_static_target = False,
         deps = deps_list,
     )
@@ -134,6 +135,7 @@ def define_common_targets(is_fbcode = False):
             "//executorch/backends/vulkan:vulkan_graph_runtime",
             runtime.external_dep_location("libtorch"),
         ],
+        platforms = [ANDROID],
     )
 
     define_test_targets(

--- a/examples/qualcomm/executor_runner/targets.bzl
+++ b/examples/qualcomm/executor_runner/targets.bzl
@@ -1,9 +1,6 @@
 load(
     "@fbsource//tools/build_defs:default_platform_defs.bzl",
     "ANDROID",
-    "APPLE",
-    "CXX",
-    "is_apple_platform",
 )
 load("@fbsource//tools/build_defs:fbsource_utils.bzl", "is_fbcode")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
@@ -32,6 +29,7 @@ def define_common_targets():
             "//executorch/extension/runner_util:inputs",
             "//executorch/backends/qualcomm/runtime:runtime",
         ],
+        platforms = [ANDROID],
         external_deps = [
             "gflags",
         ],

--- a/examples/qualcomm/oss_scripts/llama/targets.bzl
+++ b/examples/qualcomm/oss_scripts/llama/targets.bzl
@@ -1,3 +1,7 @@
+load(
+    "@fbsource//tools/build_defs:default_platform_defs.bzl",
+    "ANDROID",
+)
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "get_oss_build_kwargs", "runtime")
 load("@fbsource//xplat/executorch/backends/qualcomm/qnn_version.bzl", "get_qnn_library_version")
 
@@ -33,6 +37,7 @@ def define_common_targets():
         external_deps = [
             "gflags",
         ],
+        platforms = [ANDROID],
         **get_oss_build_kwargs()
     )
 
@@ -51,5 +56,6 @@ def define_common_targets():
         external_deps = [
             "gflags",
         ],
+        platforms = [ANDROID],
         **get_oss_build_kwargs()
     )


### PR DESCRIPTION
Summary: When underlying dependencies have platform restrictions we need to propagate them to dependencts.

Differential Revision: D76402988
