### PR TITLE
Use ExternalProject_Add to build tokenizers

### DIFF
--- a/extension/llm/runner/CMakeLists.txt
+++ b/extension/llm/runner/CMakeLists.txt
@@ -44,18 +44,23 @@ target_include_directories(
 add_library(extension_llm_runner STATIC ${_extension_llm_runner__srcs})
 
 # add tokenizers
-add_subdirectory(
-  ${EXECUTORCH_ROOT}/extension/llm/tokenizers
-  ${CMAKE_CURRENT_BINARY_DIR}/../../../extension/llm/tokenizers
+ExternalProject_Add(
+  tokenizers_external_project
+  PREFIX ${CMAKE_CURRENT_BINARY_DIR}/../tokenizers
+  SOURCE_DIR ${EXECUTORCH_ROOT}/extension/llm/tokenizers
+  CMAKE_ARGS -DSUPPORT_REGEX_LOOKAHEAD=ON -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/../tokenizers
+  INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/../tokenizers
 )
-
-set(runner_deps executorch_core extension_module extension_tensor tokenizers)
+add_dependencies(extension_llm_runner tokenizers_external_project)
+find_package(tokenizers CONFIG HINTS ${CMAKE_INSTALL_PREFIX} ${CMAKE_CURRENT_BINARY_DIR}/../tokenizers)
+set(runner_deps executorch extension_module extension_tensor ${TOKENIZERS_LIBRARIES})
 
 target_link_libraries(extension_llm_runner PUBLIC ${runner_deps})
 
 target_include_directories(
-  extension_llm_runner INTERFACE ${_common_include_directories}
-                                 ${EXECUTORCH_ROOT}/extension/llm/tokenizers/include
+  extension_llm_runner PUBLIC ${_common_include_directories}
+                                 ${TOKENIZERS_INCLUDE_DIRS}
+                                 ${CMAKE_CURRENT_BINARY_DIR}/../tokenizers/include
 )
 
 if(BUILD_TESTING)


### PR DESCRIPTION
This way it avoids the CMake target name collision between XNNPACK's `memory` and Abseil's `memory`

This pull request updates the build configuration for the `extension_llm_runner` target in `CMakeLists.txt` and modifies the `tokenizers` submodule reference. The changes aim to improve dependency management by transitioning from a subdirectory approach to using `ExternalProject_Add`, and updating the `tokenizers` submodule to a new commit.

### Build Configuration Updates:

* [`extension/llm/runner/CMakeLists.txt`](diffhunk://#diff-ab47c38904702e3d66a37419ca35a07815f7d4735f7e94330d17643b9f77ad2bL47-R63): Replaced `add_subdirectory` for the `tokenizers` dependency with `ExternalProject_Add`, enabling more flexible configuration options such as setting regex lookahead support and specifying an installation directory. Updated dependency handling by adding `tokenizers_external_project` as a dependency and using `find_package` to locate `tokenizers`. Adjusted `target_include_directories` to use `TOKENIZERS_INCLUDE_DIRS` and the new installation path.

### Submodule Update:

* [`extension/llm/tokenizers`](diffhunk://#diff-21160e5cd8f4fd252e1aca3298b1d84f5cfc86bd4cfe83c44752f0311f330b94L1-R1): Updated the `tokenizers` submodule reference to commit `a2bac3b7a54a3816d66b8fd3e705f8724d2d5f2f`, to incorporate changes in this PR: https://github.com/pytorch-labs/tokenizers/pull/82
