### PR TITLE
Revert "Add (and fix) OSS check that et_operator_library dtype_select…

### DIFF
--- a/.ci/scripts/unittest-buck2.sh
+++ b/.ci/scripts/unittest-buck2.sh
@@ -25,9 +25,7 @@ BUILDABLE_KERNELS_PRIM_OPS_TARGETS=$(buck2 query //kernels/prim_ops/... | grep -
 # //runtime/kernel/... is failing because //third-party:torchgen_files's shell script can't find python on PATH.
 # //runtime/test/... requires Python torch, which we don't have in our OSS buck setup.
 for op in "build" "test"; do
-    buck2 $op $BUILDABLE_OPTIMIZED_OPS \
-          //examples/selective_build:select_all_dtype_selective_lib_portable_lib \
-          //kernels/portable/... \
+    buck2 $op $BUILDABLE_OPTIMIZED_OPS //kernels/portable/... \
           $BUILDABLE_KERNELS_PRIM_OPS_TARGETS //runtime/backend/... //runtime/core/... \
           //runtime/executor: //runtime/kernel/... //runtime/platform/...
 done

--- a/examples/selective_build/targets.bzl
+++ b/examples/selective_build/targets.bzl
@@ -25,21 +25,6 @@ def define_common_targets():
         ],
     )
 
-    executorch_generated_lib(
-        name = "select_all_dtype_selective_lib",
-        functions_yaml_target = "//executorch/kernels/portable:functions.yaml",
-        kernel_deps = [
-            "//executorch/kernels/portable:operators",
-        ],
-        # Setting dtype_selective_build without using list or dict selection isn't a
-        # typical use case; we just do it here so that we can test that our mechanism
-        # for getting buck deps right for dtype_selective_build is working.
-        dtype_selective_build = True,
-        deps = [
-            ":select_all_ops",
-        ],
-    )
-
     # Select a list of operators: defined in `ops`
     et_operator_library(
         name = "select_ops_in_list",

--- a/shim_et/xplat/executorch/codegen/codegen.bzl
+++ b/shim_et/xplat/executorch/codegen/codegen.bzl
@@ -752,7 +752,7 @@ def executorch_generated_lib(
             See: https://www.internalfb.com/wiki/PyTorch/Teams/Edge/PyTorch_Edge_Core_Team/Dtype_Selective_Build/""")
 
     if dtype_selective_build:
-        if not expose_operator_symbols and not (is_xplat() or runtime.is_oss):
+        if not expose_operator_symbols and not is_xplat():
             fail("""
                 Dtype selective build with expose_operator_symbols=False works only in xplat -
                 there are undefined symbols otherwise. Please try to use xplat, or talk to the


### PR DESCRIPTION
…ive_build builds (#9245)"

This reverts commit 7933ac97dc1cf1946d91a36f6d1fcc4ff152b1f0.

### Summary
[PLEASE REMOVE] See [CONTRIBUTING.md's Pull Requests](https://github.com/pytorch/executorch/blob/main/CONTRIBUTING.md#pull-requests) for ExecuTorch PR guidelines.

[PLEASE REMOVE] If this PR closes an issue, please add a `Fixes #<issue-id>` line.

[PLEASE REMOVE] If this PR introduces a fix or feature that should be the upcoming release notes, please add a "Release notes: <area>" label. For a list of available release notes labels, check out [CONTRIBUTING.md's Pull Requests](https://github.com/pytorch/executorch/blob/main/CONTRIBUTING.md#pull-requests).

### Test plan
[PLEASE REMOVE] How did you test this PR? Please write down any manual commands you used and note down tests that you have written if applicable.
