### PR TITLE
Define ET_HAS_EXCEPTIONS macro

### DIFF
--- a/runtime/platform/compiler.h
+++ b/runtime/platform/compiler.h
@@ -171,6 +171,14 @@
 using ssize_t = ptrdiff_t;
 #endif
 
+#ifdef __EXCEPTIONS
+#define ET_HAS_EXCEPTIONS 1
+#elif defined(_HAS_EXCEPTIONS) && _HAS_EXCEPTIONS
+#define ET_HAS_EXCEPTIONS 1
+#else
+#define ET_HAS_EXCEPTIONS 0
+#endif
+
 // DEPRECATED: Use the non-underscore-prefixed versions instead.
 // TODO(T199005537): Remove these once all users have stopped using them.
 #define __ET_DEPRECATED ET_DEPRECATED


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

To support passing ET_USE_PYTORCH_HEADERS only when exceptions are enabled.

Differential Revision: [D76470039](https://our.internmc.facebook.com/intern/diff/D76470039/)