### PR TITLE
gitignore HF tokenizer file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ pip-out/
 # Any exported models and profiling outputs
 *.bin
 *.model
+tokenizer.json
 *.pte
 !test_bpe_tokenizer.bin
 !test_tiktoken_tokenizer.model


### PR DESCRIPTION
### Summary
As we added support to run HF models in our apps, we should ignore adding/showing HF specific artifacts in our repo. For example, when drop in the `tokenizer.json` to the resource dir in iOS app:
```
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	extension/benchmark/apple/Benchmark/Resources/tokenizer.json
```
