### PR TITLE
Support for Header File Generation in DTYPE Selective Build in OSS

### DIFF
--- a/examples/selective_build/CMakeLists.txt
+++ b/examples/selective_build/CMakeLists.txt
@@ -66,9 +66,8 @@ option(EXECUTORCH_SELECT_ALL_OPS
 option(EXECUTORCH_SELECT_OPS_FROM_MODEL "Enable op selection from pte during build." OFF
 )
 
-# Option to enable dtype header selective build process
+# Option to enable dtype selective build. Note: must be using selective build model API.
 option(EXECUTORCH_DTYPE_SELECTIVE_BUILD "Enable dtype selective build." OFF
->>>>>>> 6ae80f260 (Support for header file generation with dtype)
 )
 # ------------------------------- OPTIONS END --------------------------------
 

--- a/examples/selective_build/CMakeLists.txt
+++ b/examples/selective_build/CMakeLists.txt
@@ -65,6 +65,11 @@ option(EXECUTORCH_SELECT_ALL_OPS
 # Option to enable parsing ops and dtypes directly from model pte file
 option(EXECUTORCH_SELECT_OPS_FROM_MODEL "Enable op selection from pte during build." OFF
 )
+
+# Option to enable dtype header selective build process
+option(EXECUTORCH_DTYPE_SELECTIVE_BUILD "Enable dtype selective build." OFF
+>>>>>>> 6ae80f260 (Support for header file generation with dtype)
+)
 # ------------------------------- OPTIONS END --------------------------------
 
 #
@@ -114,6 +119,8 @@ gen_selected_ops(
   "${EXECUTORCH_SELECT_ALL_OPS}"
   OPS_FROM_MODEL
   "${EXECUTORCH_SELECT_OPS_FROM_MODEL}"
+  DTYPE_SELECTIVE_BUILD
+  "${EXECUTORCH_DTYPE_SELECTIVE_BUILD}"
 )
 
 generate_bindings_for_kernels(

--- a/tools/cmake/Codegen.cmake
+++ b/tools/cmake/Codegen.cmake
@@ -75,7 +75,7 @@ function(gen_selected_ops)
       COMMENT "Generating selected_op_variants.h for ${GEN_LIB_NAME}"
       OUTPUT ${_opvariant_h}
       COMMAND ${_gen_opvariant_command}
-      DEPENDS ${_optlist_yaml} ${_codegen_tools_srcs}
+      DEPENDS ${_oplist_yaml} ${_codegen_tools_srcs}
       WORKING_DIRECTORY ${EXECUTORCH_ROOT}
     )
   endif()

--- a/tools/cmake/Codegen.cmake
+++ b/tools/cmake/Codegen.cmake
@@ -12,15 +12,19 @@
 include(${EXECUTORCH_ROOT}/tools/cmake/Utils.cmake)
 
 function(gen_selected_ops)
-  set(arg_names LIB_NAME OPS_SCHEMA_YAML ROOT_OPS INCLUDE_ALL_OPS OPS_FROM_MODEL)
+  set(arg_names LIB_NAME OPS_SCHEMA_YAML ROOT_OPS INCLUDE_ALL_OPS OPS_FROM_MODEL DTYPE_SELECTIVE_BUILD)
   cmake_parse_arguments(GEN "" "" "${arg_names}" ${ARGN})
 
-  message(STATUS "Generating operator lib:")
+  message(STATUS "Generating selected operator lib:")
   message(STATUS "  LIB_NAME: ${GEN_LIB_NAME}")
   message(STATUS "  OPS_SCHEMA_YAML: ${GEN_OPS_SCHEMA_YAML}")
   message(STATUS "  ROOT_OPS: ${GEN_ROOT_OPS}")
   message(STATUS "  INCLUDE_ALL_OPS: ${GEN_INCLUDE_ALL_OPS}")
   message(STATUS "  OPS_FROM_MODEL: ${GEN_OPS_FROM_MODEL}")
+  message(STATUS "  DTYPE_SELECTIVE_BUILD: ${GEN_DTYPE_SELECTIVE_BUILD}")
+  if(GEN_DTYPE_SELECTIVE_BUILD)
+     message(STATUS "  DTYPE_SELECTIVE_BUILD is still WIP and may not be fully functional")
+  endif()
 
   set(_oplist_yaml
       ${CMAKE_CURRENT_BINARY_DIR}/${GEN_LIB_NAME}/selected_operators.yaml
@@ -58,6 +62,23 @@ function(gen_selected_ops)
     WORKING_DIRECTORY ${EXECUTORCH_ROOT}
   )
 
+  if(GEN_DTYPE_SELECTIVE_BUILD)
+    set(_opvariant_h
+      ${CMAKE_CURRENT_BINARY_DIR}/${GEN_LIB_NAME}/selected_op_variants.h
+    )
+    set(_gen_opvariant_command "${PYTHON_EXECUTABLE}" -m codegen.tools.gen_selected_op_variants
+                          --yaml-file=${_oplist_yaml}
+                          --output-dir=${CMAKE_CURRENT_BINARY_DIR}/${GEN_LIB_NAME}/
+    )
+    message("Command - ${_gen_opvariant_command}")
+    add_custom_command(
+      COMMENT "Generating selected_op_variants.h for ${GEN_LIB_NAME}"
+      OUTPUT ${_opvariant_h}
+      COMMAND ${_gen_opvariant_command}
+      DEPENDS ${_optlist_yaml} ${_codegen_tools_srcs}
+      WORKING_DIRECTORY ${EXECUTORCH_ROOT}
+    )
+  endif()
 endfunction()
 
 # Codegen for registering kernels. Kernels are defined in functions_yaml and


### PR DESCRIPTION
### Summary

Part of the process for enabling the dtype selective build flow requires a header file to be generated that includes information about kernel operators and their dtypes. This change adds support for generating this header file when operators are specified. This functionality is enabled via the command line flag: `-DEXECUTORCH_DTYPE_SELECTIVE_BUILD=ON`. When enabled, the resultant `selected_op_variants.h` file will be generated.