### PR TITLE
Return retained objects from NSError constructors.

### DIFF
--- a/extension/apple/ExecuTorch/Exported/ExecuTorchError.h
+++ b/extension/apple/ExecuTorch/Exported/ExecuTorchError.h
@@ -63,6 +63,7 @@ NSString *ExecuTorchErrorDescription(ExecuTorchErrorCode code)
  * @return An NSError with ExecuTorchErrorDomain, the specified code, and a localized description.
  */
 FOUNDATION_EXPORT
+NS_RETURNS_RETAINED
 __attribute__((deprecated("This API is experimental.")))
 NSError *ExecuTorchErrorWithCode(ExecuTorchErrorCode code)
     NS_SWIFT_NAME(Error(code:));
@@ -75,6 +76,7 @@ NSError *ExecuTorchErrorWithCode(ExecuTorchErrorCode code)
  * @return An NSError with ExecuTorchErrorDomain, the specified code, and a localized description.
  */
  FOUNDATION_EXPORT
+ NS_RETURNS_RETAINED
  __attribute__((deprecated("This API is experimental.")))
  NSError *ExecuTorchErrorWithCodeAndDescription(ExecuTorchErrorCode code, NSString * __nullable description)
      NS_SWIFT_NAME(Error(code:description:));

--- a/extension/apple/ExecuTorch/Exported/ExecuTorchError.m
+++ b/extension/apple/ExecuTorch/Exported/ExecuTorchError.m
@@ -58,9 +58,9 @@ NSError *ExecuTorchErrorWithCode(ExecuTorchErrorCode code) {
 }
 
 NSError *ExecuTorchErrorWithCodeAndDescription(ExecuTorchErrorCode code, NSString * __nullable description) {
-  return [NSError errorWithDomain:ExecuTorchErrorDomain
-                             code:code
-                         userInfo:@{
+  return [[NSError alloc] initWithDomain:ExecuTorchErrorDomain
+                                    code:code
+                                userInfo:@{
     NSLocalizedDescriptionKey:
       description.length > 0
         ? [ExecuTorchErrorDescription(code) stringByAppendingFormat:@": %@", description]


### PR DESCRIPTION
Summary: Don't use autorelease pool

Reviewed By: cccclai

Differential Revision: D76491603
