### PR TITLE
Arm backend: Add embedding.default + index_select

### DIFF
--- a/backends/arm/_passes/__init__.py
+++ b/backends/arm/_passes/__init__.py
@@ -22,6 +22,7 @@ from .convert_squeezes_to_view import ConvertSqueezesToViewPass  # noqa
 from .convert_to_clamp import ConvertToClampPass  # noqa
 from .decompose_cosine_similarity_pass import DecomposeCosineSimilarityPass  # noqa
 from .decompose_div_pass import DecomposeDivPass  # noqa
+from .decompose_embedding_pass import DecomposeEmbeddingPass  # noqa  # noqa
 from .decompose_gelu_pass import DecomposeGeluPass  # noqa
 from .decompose_groupnorm_pass import DecomposeGroupNormPass  # noqa
 from .decompose_layernorm_pass import DecomposeLayerNormPass  # noqa
@@ -46,6 +47,9 @@ from .fuse_batchnorm2d_pass import FuseBatchnorm2DPass  # noqa
 from .fuse_constant_ops_pass import ComputeConstantOpsAOT, FuseConstantArgsPass  # noqa
 from .fuse_equal_placeholders_pass import FuseEqualPlaceholdersPass  # noqa
 from .fuse_quantized_activation_pass import FuseQuantizedActivationPass  # noqa
+from .insert_int64_input_cast_pass import (  # noqa  # noqa
+    InsertCastForOpsWithInt64InputPass,
+)
 from .insert_rescales_pass import InsertRescalePass  # noqa
 from .insert_table_ops import InsertTableOpsPass  # noqa
 from .match_arg_ranks_pass import MatchArgRanksPass  # noqa

--- a/backends/arm/_passes/arm_pass_manager.py
+++ b/backends/arm/_passes/arm_pass_manager.py
@@ -6,7 +6,6 @@
 # LICENSE file in the root directory of this source tree.
 
 # pyre-unsafe
-
 from executorch.backends.arm._passes import (
     AnnotateChannelsLastDimOrder,
     AnnotateDecomposedMatmulPass,
@@ -26,6 +25,7 @@ from executorch.backends.arm._passes import (
     ConvertToClampPass,
     DecomposeCosineSimilarityPass,
     DecomposeDivPass,
+    DecomposeEmbeddingPass,
     DecomposeGeluPass,
     DecomposeGroupNormPass,
     DecomposeLayerNormPass,
@@ -46,6 +46,7 @@ from executorch.backends.arm._passes import (
     FuseConstantArgsPass,
     FuseEqualPlaceholdersPass,
     FuseQuantizedActivationPass,
+    InsertCastForOpsWithInt64InputPass,
     InsertRescalePass,
     InsertTableOpsPass,
     MatchArgRanksPass,
@@ -139,6 +140,7 @@ class ArmPassManager(PassManager):
         self.add_pass(DecomposeSqrtPass())
         self.add_pass(ConvertIntPowToMuls())
         self.add_pass(ReplaceScalarWithTensorArgPassTOSAMI())
+        self.add_pass(DecomposeEmbeddingPass())
         self.add_pass(FuseQuantizedActivationPass())
         self.add_pass(RemoveGetItemPass())
         self.add_pass(ConvertSplitToSlicePass())
@@ -211,6 +213,8 @@ class ArmPassManager(PassManager):
             )
 
     def transform_for_annotation_pipeline(self, graph_module: GraphModule):
+        self.add_pass(InsertCastForOpsWithInt64InputPass())
+        self.add_pass(DecomposeEmbeddingPass())
         self.add_pass(DecomposeScaledDotProductAttention())
         self.add_pass(ReplaceScalarWithTensorArgPassTOSABI())
         self.add_pass(ScalarsToAttributePass())

--- a/backends/arm/_passes/decompose_embedding_pass.py
+++ b/backends/arm/_passes/decompose_embedding_pass.py
@@ -1,0 +1,120 @@
+# Copyright 2025 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+
+import logging
+from math import prod
+
+import torch
+from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import ExportPass, PassResult
+
+from .arm_pass_utils import create_node, get_first_fake_tensor
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.WARNING)
+
+
+class DecomposeEmbeddingPass(ExportPass):
+    """
+    This pass decomposes embedding into index_select.
+
+    Example:
+          o = embedding(w, i)
+    Becomes:
+          i = view_copy(i)  # flatten indices
+          o = index_select(w, i)
+          o = view_copy(o)  # reshape back output
+    Note:
+         i = indices is expected to be int32 before this pass
+    """
+
+    aten_ops = (torch.ops.aten.embedding.default,)
+    edge_ops = (exir_ops.edge.aten.embedding.default,)
+
+    def get_decomposition(self, op):
+        if op in self.aten_ops:
+            return (
+                torch.ops.aten.view_copy.default,
+                torch.ops.aten.index_select.default,
+            )
+
+        if op in self.edge_ops:
+            return (
+                exir_ops.edge.aten.view_copy.default,
+                exir_ops.edge.aten.index_select.default,
+            )
+        raise RuntimeError(
+            f"[{self.__class__.__name__}] Can't get decomposition for op {op}"
+        )
+
+    def call(self, graph_module):
+        graph = graph_module.graph
+        modified_graph = False
+
+        for node in graph.nodes:
+            if node.op != "call_function":
+                continue
+            if node.target not in self.aten_ops + self.edge_ops:
+                continue
+
+            args = node.args
+
+            weights = args[0]
+            indices = args[1]
+
+            weights_shape = get_first_fake_tensor(weights).shape
+            indices_shape = get_first_fake_tensor(indices).shape
+
+            output_shape = torch.Size(list(indices_shape) + [weights_shape[1]])
+            if output_shape != get_first_fake_tensor(node).shape:
+                raise RuntimeError(
+                    f"[{self.__class__.__name__}] Unexpected output shape mismatch {output_shape} "
+                    "!= {get_first_fake_tensor(node).shape}"
+                )
+
+            view_copy_op, index_select_op = self.get_decomposition(node.target)
+
+            with graph.inserting_before(node):
+                reshaped_indices = [prod(list(indices_shape))]
+                flattened_indices = create_node(
+                    graph=graph,
+                    op_target=view_copy_op,
+                    args=(indices, reshaped_indices),
+                )
+                node.replace_input_with(indices, flattened_indices)
+
+                index_select = create_node(
+                    graph=graph,
+                    op_target=index_select_op,
+                    args=(weights, 0, flattened_indices),
+                )
+                node.replace_all_uses_with(index_select)
+                graph.erase_node(node)
+
+            with graph.inserting_after(index_select):
+                restored_output = create_node(
+                    graph,
+                    view_copy_op,
+                )
+                restored_output.args = (
+                    index_select,
+                    output_shape,
+                )
+                original_users = [
+                    user for user in index_select.users if user != restored_output
+                ]
+                for user in original_users:
+                    user.replace_input_with(index_select, restored_output)
+
+            modified_graph = True
+
+        if modified_graph:
+            graph.eliminate_dead_code()
+            graph_module.recompile()
+            graph_module = super().call(graph_module).graph_module
+        return PassResult(graph_module, modified_graph)

--- a/backends/arm/_passes/insert_int64_input_cast_pass.py
+++ b/backends/arm/_passes/insert_int64_input_cast_pass.py
@@ -1,0 +1,94 @@
+# Copyright 2025 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+
+import logging
+
+import torch
+from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import ExportPass, PassResult
+
+from .arm_pass_utils import create_node, get_first_fake_tensor
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.WARNING)
+
+
+class InsertCastForOpsWithInt64InputPass(ExportPass):
+
+    aten_ops = (torch.ops.aten.embedding.default,)
+    edge_ops = (exir_ops.edge.aten.embedding.default,)
+
+    def get_decomposition(self, op):
+        if op in self.edge_ops:
+            return exir_ops.edge.aten._to_copy.default
+
+        if op in self.aten_ops:
+            return torch.ops.aten._to_copy.default
+
+        raise RuntimeError(
+            f"[{self.__class__.__name__}] Can't get decomposition for op {op}"
+        )
+
+    def _check_aten_embedding_within_int32(self, weights, indices, node: torch.fx.Node):
+        weights_shape = get_first_fake_tensor(weights).shape
+        vocab_size = weights_shape[0]
+
+        # Essentially output = weight[indices] which means 0 <= indices[i] < vocab_size
+        # So should be good if vocab size or number embeddings is below max int32
+        if vocab_size >= torch.iinfo(torch.int32).max:
+            logger.warning(
+                f"[{node.name}] has size ({vocab_size}) that exceeds int32 limit,"
+                "so aten.embedding will not be lowered to TOSA."
+            )
+            return False
+
+        return True
+
+    def call(self, graph_module):
+        graph = graph_module.graph
+        modified_graph = False
+
+        for node in list(graph.nodes):
+            if node.op != "call_function":
+                continue
+            if node.target not in self.aten_ops + self.edge_ops:
+                continue
+
+            args = node.args
+            weights = args[0]
+            indices = args[1]
+
+            valid_for_insert = False
+            if node.target in (
+                exir_ops.edge.aten.embedding.default,
+                torch.ops.aten.embedding.default,
+            ):
+                valid_for_insert = self._check_aten_embedding_within_int32(
+                    weights, indices, node
+                )
+
+            if valid_for_insert:
+                to_copy_op = self.get_decomposition(node.target)
+                with graph.inserting_before(node):
+                    cast_before = create_node(
+                        graph,
+                        to_copy_op,
+                        args=(indices,),
+                        kwargs={
+                            "dtype": torch.int32,
+                            "memory_format": torch.preserve_format,
+                        },
+                    )
+                    node.replace_input_with(indices, cast_before)
+
+                modified_graph = True
+
+        if modified_graph:
+            graph_module.recompile()
+            graph_module = super().call(graph_module).graph_module
+        return PassResult(graph_module, True)

--- a/backends/arm/operator_support/__init__.py
+++ b/backends/arm/operator_support/__init__.py
@@ -7,7 +7,9 @@
 
 from . import (  # noqa
     convolution_support,
+    embedding_support,
     ethos_u55_support,
+    index_select_support,
     minmax_support,
     pool_2d_support,
     reduce_sum_support,

--- a/backends/arm/operator_support/embedding_support.py
+++ b/backends/arm/operator_support/embedding_support.py
@@ -1,0 +1,47 @@
+# Copyright 2025 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import torch
+
+import torch.fx as fx
+from executorch.backends.arm.operator_support.tosa_supported_operators import (
+    register_tosa_support_check,
+    SupportedTOSAOperatorCheck,
+)
+from executorch.backends.arm.tosa_specification import TosaSpecification
+from executorch.exir.dialects._ops import ops as exir_ops
+
+
+@register_tosa_support_check
+class EmbeddingSupported(SupportedTOSAOperatorCheck):
+    targets = [exir_ops.edge.aten.embedding.default]
+
+    tosa_specs = [
+        TosaSpecification.create_from_string("TOSA-0.80+BI"),
+        TosaSpecification.create_from_string("TOSA-0.80+MI"),
+        TosaSpecification.create_from_string("TOSA-1.0+INT"),
+        TosaSpecification.create_from_string("TOSA-1.0+FP"),
+    ]
+
+    def is_node_tosa_supported(
+        self, node: fx.Node, tosa_spec: TosaSpecification
+    ) -> bool:  # type: ignore[override, misc]
+        # Note aten.embedding.default requires int64 indices and TOSA does not support it.
+        # Int32 indices here for aten.embedding.default is ok since it will be decomposed into ops that can handle it.
+        assert (
+            len(node.all_input_nodes) == 2
+        ), "Number of inputs to aten.embedding is not 2"
+        indices_val = node.all_input_nodes[1].meta["val"]
+        indices_dtype = indices_val.dtype
+
+        if indices_dtype != torch.int32:
+            self.reporter.report_reject(
+                node,
+                f"Indices dtype {indices_val.dtype} is not supported in {node.target}.",
+            )
+            return False
+
+        return True

--- a/backends/arm/operator_support/index_select_support.py
+++ b/backends/arm/operator_support/index_select_support.py
@@ -1,0 +1,50 @@
+# Copyright 2025 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+import torch.fx as fx
+from executorch.backends.arm.operator_support.tosa_supported_operators import (
+    register_tosa_support_check,
+    SupportedTOSAOperatorCheck,
+)
+from executorch.backends.arm.tosa_specification import TosaSpecification
+from executorch.exir.dialects._ops import ops as exir_ops
+
+
+@register_tosa_support_check
+class IndexSelectSupported(SupportedTOSAOperatorCheck):
+    targets = [exir_ops.edge.aten.index_select.default]
+
+    tosa_specs = [
+        TosaSpecification.create_from_string("TOSA-0.80+BI"),
+        TosaSpecification.create_from_string("TOSA-0.80+MI"),
+        TosaSpecification.create_from_string("TOSA-1.0+INT"),
+        TosaSpecification.create_from_string("TOSA-1.0+FP"),
+    ]
+
+    def is_node_tosa_supported(
+        self, node: fx.Node, tosa_spec: TosaSpecification
+    ) -> bool:  # type: ignore[override, misc]
+
+        weights_shape = node.all_input_nodes[0].meta["val"].shape
+        indices_val = node.all_input_nodes[1].meta["val"]
+        indices_dtype = indices_val.dtype
+
+        if indices_dtype != torch.int32:
+            self.reporter.report_reject(
+                node,
+                f"Indices dtype {indices_val.dtype} is not supported in {node.target}.",
+            )
+            return False
+
+        if not (
+            len(weights_shape) == 2
+            or (len(weights_shape) == 3 and weights_shape[0] == 1)
+        ):
+            self.reporter.report_reject(
+                node, f"{node.target} with weights shape {weights_shape} not supported."
+            )
+            return False
+        return True

--- a/backends/arm/operators/__init__.py
+++ b/backends/arm/operators/__init__.py
@@ -24,6 +24,7 @@ from . import (  # noqa
     op_exp,
     op_ge,
     op_gt,
+    op_index_select,
     op_le,
     op_log,
     op_lt,

--- a/backends/arm/operators/op_index_select.py
+++ b/backends/arm/operators/op_index_select.py
@@ -1,0 +1,185 @@
+# Copyright 2025 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+from typing import Any, List
+
+import executorch.backends.arm.tosa_quant_utils as tqutils  # noqa: F401
+
+from executorch.backends.arm.operators.node_visitor import (
+    NodeVisitor,
+    register_node_visitor,
+)
+from executorch.backends.arm.tosa_mapping import TosaArg
+
+from executorch.backends.arm.tosa_utils import build_reshape, build_reshape_tosa_1_0
+from torch.fx import Node
+
+
+@register_node_visitor
+class IndexSelectVisitor(NodeVisitor):
+    """
+    Simple example:
+          o = index_select(weights, index, indices)
+    Becomes:
+          i = view_copy(i)  # reshape flattened indicies, i.e. [I] => [1, I]
+          o = index_select(w, index, i)
+
+    Additional steps in case weights (w) are rank 2:
+          - before: insert view_copy to make rank 3, [x,y] => [1, x, y]
+          - after: insert view_copy to squeeze back output dims, [1, x, y] = [x,y]
+    """
+
+    target = "aten.index_select.default"
+    tosa_specs = NodeVisitor.tosa_specs_1_00
+
+    def __init__(self, *args):
+        super().__init__(*args)
+
+    def define_node(
+        self,
+        node: Node,
+        tosa_graph: Any,
+        inputs: List[TosaArg],
+        output: TosaArg,
+    ) -> None:
+
+        import serializer.tosa_serializer as ts  # type: ignore
+
+        if len(inputs) != 3:
+            raise ValueError(f"Number of inputs are not 3: {len(inputs)}")
+
+        weights, index, indices = inputs
+
+        if len(weights.shape) == 2:
+            weights_new_shape = [1, weights.shape[0], weights.shape[1]]
+            weights_reshaped = tosa_graph.addIntermediate(
+                weights_new_shape,
+                weights.dtype,
+            )
+            build_reshape_tosa_1_0(
+                tosa_graph, weights.name, weights_new_shape, weights_reshaped.name
+            )
+
+            output_new_shape = [1, output.shape[0], output.shape[1]]
+            output_reshaped = tosa_graph.addIntermediate(
+                output_new_shape,
+                output.dtype,
+            )
+
+        else:
+            weights_reshaped = weights
+            output_reshaped = output
+
+        output_name = output_reshaped.name
+
+        # Reshape flattened indicies, i.e. [I] => [1, I]
+        indices_new_shape = [1, indices.shape[0]]
+        indices_reshaped = tosa_graph.addIntermediate(
+            indices_new_shape,
+            indices.dtype,
+        )
+        build_reshape_tosa_1_0(
+            tosa_graph, indices.name, indices_new_shape, indices_reshaped.name
+        )
+
+        tosa_graph.addOperator(
+            ts.TosaOp.Op().GATHER,
+            [weights_reshaped.name, indices_reshaped.name],
+            [output_name],
+            None,
+        )
+
+        if len(weights.shape) == 2:
+            output_real_shape = [output.shape[0], output.shape[1]]
+            build_reshape_tosa_1_0(
+                tosa_graph, output_name, output_real_shape, output.name
+            )
+
+
+@register_node_visitor
+class IndexSelectVisitor_0_80(NodeVisitor):
+    """
+    Simple example:
+          o = index_select(weights, index, indices)
+    Becomes:
+          i = view_copy(i)  # reshape flattened indicies, i.e. [I] => [1, I]
+          o = index_select(w, index, i)
+
+    Additional steps in case weights (w) are rank 2:
+          - before: insert view_copy to make rank 3, [x,y] => [1, x, y]
+          - after: insert view_copy to squeeze back output dims, [1, x, y] = [x,y]
+    """
+
+    target = "aten.index_select.default"
+    tosa_specs = NodeVisitor.tosa_specs_0_80
+
+    def __init__(self, *args):
+        super().__init__(*args)
+
+    def define_node(
+        self,
+        node: Node,
+        tosa_graph: Any,
+        inputs: List[TosaArg],
+        output: TosaArg,
+    ) -> None:
+        import tosa_tools.v0_80.serializer.tosa_serializer as ts_v0_80  # type: ignore
+
+        # Specification (0.80) states that input and output types
+        # should all be the same
+        if inputs[0].dtype != output.dtype:
+            raise ValueError(
+                f"Input and output type not same: {inputs[0].dtype} != {output.dtype:}"
+            )
+
+        if len(inputs) != 3:
+            raise ValueError(f"Number of inputs are not 3: {len(inputs)}")
+
+        weights, index, indices = inputs
+
+        if len(weights.shape) == 2:
+            weights_new_shape = [1, weights.shape[0], weights.shape[1]]
+            weights_reshaped = tosa_graph.addIntermediate(
+                weights_new_shape,
+                weights.dtype,
+            )
+            build_reshape(
+                tosa_graph, weights.name, weights_new_shape, weights_reshaped.name
+            )
+
+            output_new_shape = [1, output.shape[0], output.shape[1]]
+            output_reshaped = tosa_graph.addIntermediate(
+                output_new_shape,
+                output.dtype,
+            )
+
+        else:
+            weights_reshaped = weights
+            output_reshaped = output
+
+        output_name = output_reshaped.name
+
+        # Reshape flattened indicies, i.e. [I] => [1, I]
+        indices_new_shape = [1, indices.shape[0]]
+        indices_reshaped = tosa_graph.addIntermediate(
+            indices_new_shape,
+            indices.dtype,
+        )
+        build_reshape(
+            tosa_graph, indices.name, indices_new_shape, indices_reshaped.name
+        )
+
+        tosa_graph.addOperator(
+            ts_v0_80.TosaOp.Op().GATHER,
+            [weights_reshaped.name, indices_reshaped.name],
+            [output_name],
+            None,
+        )
+
+        if len(weights.shape) == 2:
+            output_real_shape = [output.shape[0], output.shape[1]]
+            build_reshape(tosa_graph, output_name, output_real_shape, output.name)

--- a/backends/arm/quantizer/quantization_annotator.py
+++ b/backends/arm/quantizer/quantization_annotator.py
@@ -259,6 +259,7 @@ _one_to_one_shared_input_qspec = [
     torch.ops.aten.clamp.default,
     torch.ops.aten.clamp.Tensor,
     torch.ops.aten.unflatten.int,
+    torch.ops.aten.index_select.default,
 ]
 
 _one_to_one_shared_input_or_input_act_qspec = [

--- a/backends/arm/test/models/test_llama.py
+++ b/backends/arm/test/models/test_llama.py
@@ -15,6 +15,7 @@ from typing import Tuple
 
 import pytest
 import torch
+from executorch.backends.arm._passes import InsertCastForOpsWithInt64InputPass
 
 from executorch.backends.arm.test import conftest
 from executorch.backends.arm.test.tester.test_pipeline import (
@@ -110,6 +111,7 @@ def test_llama_tosa_MI():
             aten_op=[],
             exir_op=[],
             use_to_edge_transform_and_lower=True,
+            transform_passes=[InsertCastForOpsWithInt64InputPass()],
         )
         pipeline.run()
 

--- a/backends/arm/test/ops/test_embedding.py
+++ b/backends/arm/test/ops/test_embedding.py
@@ -1,0 +1,86 @@
+# Copyright 2025 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+from typing import Tuple
+
+import torch
+from executorch.backends.arm._passes import InsertCastForOpsWithInt64InputPass
+
+from executorch.backends.arm.test import common
+from executorch.backends.arm.test.tester.test_pipeline import (
+    TosaPipelineBI,
+    TosaPipelineMI,
+)
+
+
+class Embedding(torch.nn.Module):
+
+    aten_op = "torch.ops.aten.embedding.default"
+    exir_op = "executorch_exir_dialects_edge__ops_aten_embedding_default"
+
+    def forward(self, weights: torch.Tensor, indices: torch.Tensor):
+        return torch.embedding(weights, indices)
+
+
+input_params = Tuple[torch.Tensor, torch.Tensor, torch.dtype]
+
+
+test_input: dict[input_params] = {
+    "test_1": (
+        torch.randn(10, 3),
+        torch.tensor([[1, 2, 3], [4, 5, 6]], dtype=torch.int32),
+    ),
+    "test_2": (
+        torch.randn(10, 4),
+        torch.tensor([[1, 4, 3], [4, 3, 2]], dtype=torch.int32),
+    ),
+    "test_3": (
+        torch.randn(9, 3),
+        torch.tensor([[1, 2, 3], [4, 5, 6]], dtype=torch.int64),
+    ),
+    "test_4": (
+        torch.randn(11, 5),
+        torch.randint(low=0, high=10, size=(4, 3), dtype=torch.int64),
+    ),
+    "test_5": (
+        torch.randn(11, 5),
+        torch.randint(low=0, high=10, size=(4, 3, 2), dtype=torch.int64),
+    ),
+    "test_6": (
+        torch.randn(11, 5),
+        torch.randint(low=0, high=10, size=(4, 3, 2, 5), dtype=torch.int64),
+    ),
+}
+
+
+@common.parametrize("test_input", test_input)
+def test_embedding_tosa_MI(test_input: input_params):
+    op = Embedding()
+    pipeline = TosaPipelineMI[input_params](
+        op,
+        test_input,
+        op.aten_op,
+        op.exir_op,
+        use_to_edge_transform_and_lower=True,
+        transform_passes=[InsertCastForOpsWithInt64InputPass()],
+    )
+    pipeline.run()
+
+
+@common.parametrize("test_input", test_input)
+def test_embedding_tosa_BI(test_input: input_params):
+    op = Embedding()
+    pipeline = TosaPipelineBI[input_params](
+        op,
+        test_input,
+        op.aten_op,
+        op.exir_op,
+        use_to_edge_transform_and_lower=True,
+    )
+    pipeline.pop_stage("check.aten")
+    pipeline.pop_stage("check_count.exir")
+
+    pipeline.run()

--- a/backends/arm/test/ops/test_index_select.py
+++ b/backends/arm/test/ops/test_index_select.py
@@ -1,0 +1,117 @@
+# Copyright 2025 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+from typing import Tuple
+
+import pytest
+
+import torch
+from executorch.backends.arm.test.tester.test_pipeline import (
+    TosaPipelineBI,
+    TosaPipelineMI,
+)
+
+
+class IndexSelect(torch.nn.Module):
+    aten_op = "torch.ops.aten.index_select.default"
+    exir_op = "executorch_exir_dialects_edge__ops_aten_index_select_default"
+
+    def forward(self, input_: torch.Tensor, dim, index_: torch.Tensor):
+        return torch.index_select(input_, dim=dim, index=index_)
+
+
+input_params = Tuple[torch.Tensor, int, torch.Tensor]
+
+
+test_input: dict[input_params] = {
+    "test_1": (
+        torch.tensor(
+            [[[0.1, 0.2, 0.3], [1.1, 1.2, 1.3], [2.1, 2.2, 2.3], [3.1, 3.2, 3.3]]],
+            dtype=torch.float32,
+        ),  # Shape: [N=1, K=4, C=3]
+        1,
+        torch.tensor(
+            [1, 3], dtype=torch.int32
+        ),  # Shape: [2] => Note TOSA requires [N=1, W=2]
+    ),
+    "test_2": (
+        torch.tensor(
+            [[0.1, 0.2, 0.3], [1.1, 1.2, 1.3], [2.1, 2.2, 2.3], [3.1, 3.2, 3.3]],
+            dtype=torch.float32,
+        ),  # Shape: [K=4, C=3]
+        0,
+        torch.tensor(
+            [1, 3], dtype=torch.int32
+        ),  # Shape: [2] => Note TOSA requires [N=1, W=2]
+    ),
+    "test_3_mult_batches": (
+        torch.randn(2, 4, 3),  # Batches > 1 not supported
+        1,
+        torch.tensor(
+            [1, 3], dtype=torch.int32
+        ),  # Shape: [2] => Note TOSA requires [N=1, W=2]
+    ),
+    "test_4_rand": (
+        torch.randn(1, 4, 3),
+        1,
+        torch.tensor(
+            [1, 3], dtype=torch.int32
+        ),  # Shape: [2] => Note TOSA requires [N=1, W=2]
+    ),
+}
+
+
+test_data = {
+    "index_select_test_1": (IndexSelect(), test_input["test_1"]),
+    "index_select_test_2": (IndexSelect(), test_input["test_2"]),
+    "index_select_test_3": pytest.param(
+        (IndexSelect(), test_input["test_3_mult_batches"]),
+        marks=pytest.mark.xfail(
+            reason="Rank3 weights with first dim larger than 1 is currently not supported"
+        ),
+    ),
+    "index_select_test_4": (IndexSelect(), test_input["test_4_rand"]),
+}
+
+
+@pytest.mark.parametrize("test_data", list(test_data.values()))
+def test_index_select_tosa_MI(test_data: input_params):
+    op, test_input = test_data
+    pipeline = TosaPipelineMI[input_params](
+        op, test_input, op.aten_op, op.exir_op, use_to_edge_transform_and_lower=True
+    )
+    pipeline.run()
+
+
+@pytest.mark.parametrize("test_data", list(test_data.values())[:-1])
+def test_index_select_tosa_BI(test_data: input_params):
+    op, test_input = test_data
+
+    pipeline = TosaPipelineBI[input_params](
+        op,
+        test_input,
+        op.aten_op,
+        op.exir_op,
+        use_to_edge_transform_and_lower=True,
+    )
+    pipeline.run()
+
+
+@pytest.mark.parametrize("test_data", list(test_data.values())[-1:])
+def test_index_select_tosa_BI_rand(test_data: input_params):
+    op, test_input = test_data
+
+    pipeline = TosaPipelineBI[input_params](
+        op,
+        test_input,
+        op.aten_op,
+        op.exir_op,
+        use_to_edge_transform_and_lower=True,
+    )
+    pipeline.change_args(
+        "run_method_and_compare_outputs", inputs=test_input, atol=0.9, rtol=0.2, qtol=1
+    )
+    pipeline.run()

--- a/backends/arm/test/passes/test_insert_int64_to_int32_cast_pass.py
+++ b/backends/arm/test/passes/test_insert_int64_to_int32_cast_pass.py
@@ -1,0 +1,46 @@
+# Copyright 2025 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Tuple
+
+import torch
+from executorch.backends.arm._passes import InsertCastForOpsWithInt64InputPass
+
+from executorch.backends.arm.test.tester.test_pipeline import PassPipeline
+
+input_t = Tuple[torch.Tensor]  # Input x
+
+
+class Int64InputModel(torch.nn.Module):
+
+    def forward(self, weights: torch.Tensor, indices: torch.Tensor):
+        return torch.embedding(weights, indices)
+
+    def get_inputs(self) -> input_t:
+        return (
+            torch.randn(9, 3),
+            torch.tensor([[1, 2, 3], [4, 5, 6]], dtype=torch.int64),
+        )
+
+
+def test_int64_model_tosa_MI():
+    module = Int64InputModel()
+    op_checks_before = {
+        "executorch_exir_dialects_edge__ops_aten_embedding_default": 1,
+    }
+    op_checks_after = {
+        "executorch_exir_dialects_edge__ops_aten__to_copy_default": 1,
+        "executorch_exir_dialects_edge__ops_aten_embedding_default": 1,
+    }
+
+    pipeline = PassPipeline[input_t](
+        module,
+        module.get_inputs(),
+        ops_before_pass=op_checks_before,
+        ops_after_pass=op_checks_after,
+        pass_list=[InsertCastForOpsWithInt64InputPass],
+    )
+    pipeline.pop_stage(-1)  # Do not compare output
+    pipeline.run()

--- a/backends/arm/test/passes/test_int32_cast_embedding_pass.py
+++ b/backends/arm/test/passes/test_int32_cast_embedding_pass.py
@@ -1,0 +1,46 @@
+# Copyright 2025 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Tuple
+
+import torch
+from executorch.backends.arm._passes import DecomposeEmbeddingPass
+
+from executorch.backends.arm.test.tester.test_pipeline import PassPipeline
+
+input_t = Tuple[torch.Tensor]  # Input x
+
+
+class Int32Embedding(torch.nn.Module):
+
+    def forward(self, weights: torch.Tensor, indices: torch.Tensor):
+        return torch.embedding(weights, indices)
+
+    def get_inputs(self) -> input_t:
+        return (
+            torch.randn(9, 3),
+            torch.tensor([[1, 2, 3], [4, 5, 6]], dtype=torch.int32),
+        )
+
+
+def test_int64_model_tosa_MI():
+    module = Int32Embedding()
+    op_checks_before = {
+        "executorch_exir_dialects_edge__ops_aten_embedding_default": 1,
+    }
+    op_checks_after = {
+        "executorch_exir_dialects_edge__ops_aten_view_copy": 2,
+        "executorch_exir_dialects_edge__ops_aten_index_select": 1,
+    }
+
+    pipeline = PassPipeline[input_t](
+        module,
+        module.get_inputs(),
+        ops_before_pass=op_checks_before,
+        ops_after_pass=op_checks_after,
+        pass_list=[DecomposeEmbeddingPass],
+    )
+    pipeline.pop_stage(-1)  # Do not compare output
+    pipeline.run()

--- a/backends/arm/test/runner_utils.py
+++ b/backends/arm/test/runner_utils.py
@@ -124,7 +124,7 @@ def get_input_quantization_params(
             ):  # break early if we have all the inputs quantized parameters
                 break
     if len(quant_params) == 0:
-        raise RuntimeError("No Quantization parameters found in exported model.")
+        logger.warning("No input quantization parameters found in exported model.")
     return quant_params
 
 

--- a/backends/arm/test/tester/analyze_output_utils.py
+++ b/backends/arm/test/tester/analyze_output_utils.py
@@ -125,7 +125,9 @@ def print_error_diffs(
         result = result[0]
 
     if not result.shape == reference.shape:
-        raise ValueError("Output needs to be of same shape")
+        raise ValueError(
+            f"Output needs to be of same shape: {result.shape} != {reference.shape}"
+        )
     shape = result.shape
 
     match len(shape):

--- a/backends/arm/test/tester/test_pipeline.py
+++ b/backends/arm/test/tester/test_pipeline.py
@@ -4,7 +4,20 @@
 # LICENSE file in the root directory of this source tree.
 
 import logging
-from typing import Any, Callable, Dict, Generic, List, Optional, Tuple, Type, TypeVar
+
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Generic,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+)
 
 import torch
 
@@ -89,6 +102,9 @@ class BasePipelineMaker(Generic[T]):
         exir_ops: Optional[str | List[str]] = None,
         use_to_edge_transform_and_lower: bool = True,
         dynamic_shapes: Optional[Tuple[Any]] = None,
+        transform_passes: Optional[
+            Union[Sequence[PassType], Dict[str, Sequence[PassType]]]
+        ] = None,
     ):
 
         self.tester = ArmTester(
@@ -96,6 +112,7 @@ class BasePipelineMaker(Generic[T]):
             example_inputs=test_data,
             compile_spec=compile_spec,
             dynamic_shapes=dynamic_shapes,
+            transform_passes=transform_passes,
         )
 
         self.aten_ops = aten_ops if isinstance(aten_ops, list) else [aten_ops]
@@ -388,6 +405,9 @@ class TosaPipelineMI(BasePipelineMaker, Generic[T]):
         rtol: float = 1e-03,
         qtol: int = 0,
         dynamic_shapes: Optional[Tuple[Any]] = None,
+        transform_passes: Optional[
+            Union[Sequence[PassType], Dict[str, Sequence[PassType]]]
+        ] = None,
     ):
         tosa_profiles = {
             "0.80": TosaSpecification.create_from_string("TOSA-0.80+MI"),
@@ -405,7 +425,8 @@ class TosaPipelineMI(BasePipelineMaker, Generic[T]):
             compile_spec,
             exir_op,
             use_to_edge_transform_and_lower,
-            dynamic_shapes,
+            dynamic_shapes=dynamic_shapes,
+            transform_passes=transform_passes,
         )
         self.add_stage_after(
             "export",

--- a/backends/arm/tosa_utils.py
+++ b/backends/arm/tosa_utils.py
@@ -9,7 +9,10 @@ import logging
 import os
 from typing import Any, Optional
 
+import numpy as np
+
 import sympy  # type: ignore
+
 import torch
 import tosa_tools.v0_80.serializer.tosa_serializer as ts  # type: ignore
 from executorch.backends.arm.tosa_mapping import TosaArg
@@ -114,6 +117,26 @@ def build_reshape(tosa_fb, input_name, new_shape, output_name):
     attr = ts.TosaSerializerAttribute()
     attr.ReshapeAttribute(new_shape)
     tosa_fb.addOperator(TosaOp.Op().RESHAPE, [input_name], [output_name], attr)
+
+
+def build_reshape_tosa_1_0(tosa_graph, input_name, new_shape, output_name):
+    import serializer.tosa_serializer as ts_  # type: ignore
+
+    shape = tosa_graph.addConst(
+        np.array(new_shape).shape,
+        ts_.DType.SHAPE,
+        np.array(new_shape),
+        name=output_name + "_shape",
+    )
+
+    attr = ts_.TosaSerializerAttribute()
+    attr.ReshapeAttribute()
+    tosa_graph.addOperator(
+        ts_.TosaOp.Op().RESHAPE,
+        [input_name, shape.name],
+        [output_name],
+        attr,
+    )
 
 
 def reshape_for_broadcast(tosa_fb, inputs, dim_order=None):


### PR DESCRIPTION
aten.embedding.default is requiring int64 indices which is not supported by TOSA. A pass is introduced to insert a int64->int32 cast. This enables aten.embedding to be decomposed into index_select, which can handle int32 indices and maps easier to TOSA. So support for aten.index_select is added as well, and for now it only supports [1, x, y] and [x, y] dimension inputs since that covers aten.embedding.default use case.

In summary this patch adds:
- One pass for inserting a cast, which is done very early since it needs to be rejected until TOSA supports int64
- One pass for decomposing aten.embedding
- Mapping of index select to TOSA
- Unit tests for above



cc @digantdesai @freddan80 @per @zingo @oscarandersson8218