### PR TITLE
Arm backend: Fix warnings from cppcheck in runtime

### DIFF
--- a/backends/arm/runtime/EthosUBackend.cpp
+++ b/backends/arm/runtime/EthosUBackend.cpp
@@ -115,7 +115,7 @@ class EthosUBackend final : public ::executorch::runtime::BackendInterface {
       ArrayRef<CompileSpec> compile_specs) const override {
     ET_LOG(Info, "EthosUBackend::init %p", processed->data());
 
-    char* data = (char*)processed->data();
+    const char* data = static_cast<const char*>(processed->data());
     size_t size = processed->size();
 
     // Verify format of vela_bin
@@ -160,7 +160,8 @@ class EthosUBackend final : public ::executorch::runtime::BackendInterface {
     // we might do it).
     EthosUBackendExecuteCallbacks CollectArm_CPU_Cycles;
 
-    ExecutionHandle* execution_handle = (ExecutionHandle*)input_handle;
+    ExecutionHandle* execution_handle =
+        static_cast<ExecutionHandle*>(input_handle);
     VelaHandles handles;
 
     // Command stream - we know at this point it's aligned
@@ -168,7 +169,8 @@ class EthosUBackend final : public ::executorch::runtime::BackendInterface {
         event_tracer,
         event_tracer_local_scope,
         "+EthosUBackend::execute()processed_data");
-    char* data = (char*)execution_handle->processed->data();
+    const char* data =
+        static_cast<const char*>(execution_handle->processed->data());
     EXECUTORCH_PROF_END(event_tracer, event_tracer_local_scope);
 
     ET_LOG(Debug, "EthosUBackend::execute %p", data);
@@ -256,7 +258,7 @@ class EthosUBackend final : public ::executorch::runtime::BackendInterface {
           handles.inputs->io[i].elem_size == 2;
 
       // Select a compatible copy routine
-      if (both_char and permuted_input_shape) {
+      if (both_char && permuted_input_shape) {
         EXECUTORCH_PROF_SCOPE(
             event_tracer,
             "+EthosUBackend::execute()handles.input.permute_CHW_to_HWC()");
@@ -267,7 +269,7 @@ class EthosUBackend final : public ::executorch::runtime::BackendInterface {
             tensor_in.size(1),
             tensor_in.size(2),
             tensor_in.size(3));
-      } else if (both_char or both_int or both_short) {
+      } else if (both_char || both_int || both_short) {
         EXECUTORCH_PROF_SCOPE(
             event_tracer, "+EthosUBackend::execute()handles.input.memcpy()");
         // Sizes match and elt size matches so memcpy
@@ -322,7 +324,7 @@ class EthosUBackend final : public ::executorch::runtime::BackendInterface {
         event_tracer, event_tracer_local_scope, "+EthosUBackend::execute()NPU");
     result = ethosu_invoke_v3(
         driver.get(),
-        (void*)handles.cmd_data,
+        static_cast<const void*>(handles.cmd_data),
         handles.cmd_data_size,
         bases,
         bases_size,
@@ -357,13 +359,14 @@ class EthosUBackend final : public ::executorch::runtime::BackendInterface {
       bool permuted_output_shape;
       ET_CHECK_OK_OR_RETURN_ERROR(check_requires_permute(
           i, tensor_out, &handles.outputs->io[i], &permuted_output_shape));
-      if (tensor_out.scalar_type() == ScalarType::Char and
+      if (tensor_out.scalar_type() == ScalarType::Char &&
           permuted_output_shape) {
         EXECUTORCH_PROF_SCOPE(
             event_tracer,
             "+EthosUBackend::execute()handles.output.permute_HWC_to_CHW()");
 
-        char* output_address = (char*)output_addr;
+        const char* output_address = static_cast<const char*>(output_addr);
+
         permute_HWC_to_CHW(
             output_address,
             tensor_out.mutable_data_ptr<char>(),
@@ -375,10 +378,11 @@ class EthosUBackend final : public ::executorch::runtime::BackendInterface {
             event_tracer, "+EthosUBackend::execute()handles.output.move()");
         for (int j = 0; j < tensor_out.numel(); j++) {
           if (tensor_out.scalar_type() == ScalarType::Char) {
-            char* output_address = (char*)output_addr;
+            const char* output_address = static_cast<const char*>(output_addr);
             tensor_out.mutable_data_ptr<char>()[j] = output_address[j];
           } else {
-            int* output_address = (int*)output_addr;
+            const int* output_address =
+                reinterpret_cast<const int*>(output_addr);
             tensor_out.mutable_data_ptr<int>()[j] = output_address[j];
           }
         }
@@ -435,7 +439,7 @@ class EthosUBackend final : public ::executorch::runtime::BackendInterface {
     return Error::Ok;
   }
 
-  void permute_CHW_to_HWC(char* input, char* output, int C, int H, int W)
+  void permute_CHW_to_HWC(const char* input, char* output, int C, int H, int W)
       const {
     for (int i = 0; i != H * W; ++i) {
       for (int j = 0; j < C; ++j) {
@@ -444,7 +448,7 @@ class EthosUBackend final : public ::executorch::runtime::BackendInterface {
     }
   }
 
-  void permute_HWC_to_CHW(char* input, char* output, int C, int H, int W)
+  void permute_HWC_to_CHW(const char* input, char* output, int C, int H, int W)
       const {
     for (int i = 0; i != H * W; ++i) {
       for (int j = 0; j < C; ++j) {

--- a/backends/arm/runtime/VelaBinStream.cpp
+++ b/backends/arm/runtime/VelaBinStream.cpp
@@ -31,11 +31,11 @@ bool vela_bin_validate(const char* data, int size) {
   // Check 16 byte alignment
   bool valid = true;
   if ((uintptr_t)data != next_mul_16((uintptr_t)data)) {
-    ET_LOG(Error, "Vela bin ptr not aligned to 16 bytes: %p", (void*)data);
+    ET_LOG(Error, "Vela bin ptr not aligned to 16 bytes: %p", data);
     valid = false;
   }
   if ((uintptr_t)foot != next_mul_16((uintptr_t)foot)) {
-    ET_LOG(Error, "End of vela bin not aligned to 16 bytes: %p", (void*)foot);
+    ET_LOG(Error, "End of vela bin not aligned to 16 bytes: %p", foot);
     valid = false;
   }
   // Check header and footer blocks are the right format
@@ -55,12 +55,13 @@ bool vela_bin_read(const char* data, VelaHandles* handles, int size) {
   const char* ptr = data;
 
   while (ptr - data < size) {
-    VelaBinBlock* b = (VelaBinBlock*)ptr;
+    VelaBinBlock* b = reinterpret_cast<VelaBinBlock*>(const_cast<char*>(ptr));
     ptr += sizeof(VelaBinBlock) + next_mul_16(b->size);
 
     if (!strncmp(b->name, "vela_bin_stream", strlen("vela_bin_stream"))) {
       // expect vela_bin_stream first
-      if ((char*)b != (char*)data)
+      if (reinterpret_cast<char*>(b) !=
+          reinterpret_cast<char*>(const_cast<char*>(data)))
         return false;
     } else if (!strncmp(b->name, "cmd_data", strlen("cmd_data"))) {
       // This driver magic header confirms a valid command stream in binary
@@ -76,9 +77,9 @@ bool vela_bin_read(const char* data, VelaHandles* handles, int size) {
           reinterpret_cast<const uint32_t*>(b->data);
       handles->scratch_data_size = *scratch_size_ptr;
     } else if (!strncmp(b->name, "inputs", strlen("inputs"))) {
-      handles->inputs = (VelaIOs*)b->data;
+      handles->inputs = reinterpret_cast<VelaIOs*>(b->data);
     } else if (!strncmp(b->name, "outputs", strlen("outputs"))) {
-      handles->outputs = (VelaIOs*)b->data;
+      handles->outputs = reinterpret_cast<VelaIOs*>(b->data);
     } else if (!strncmp(
                    b->name, "vela_end_stream", strlen("vela_end_stream"))) {
       // expect vela_end_stream last


### PR DESCRIPTION
The runtime is written in C++ and had a bunch of cstyle castings and mixed operator tokens. This commit addresses these warnings.

Signed-off-by: per.held@arm.com

Change-Id: I8fa9d36ce61c98896b56b2db920d9d2db9fe972e



cc @larryliu0820 @JacobSzwejbka @lucylq @digantdesai @freddan80 @per @zingo @oscarandersson8218