### PR TITLE
Remove buck-out on clean ET install

### DIFF
--- a/install_executorch.py
+++ b/install_executorch.py
@@ -47,6 +47,8 @@ def clean():
     for d in dirs:
         print(f"Cleaning {d}...")
         shutil.rmtree(d, ignore_errors=True)
+    print("Cleaning buck-out/...")
+    shutil.rmtree("buck-out/", ignore_errors=True)
     print("Done cleaning build artifacts.")
 
 


### PR DESCRIPTION
### Summary

Removing `buck-out` directory on clean builds.

`Fixes #<#11564>` [11564](https://github.com/pytorch/executorch/issues/11564).

### Test plan

Ran a few of the scripts in the `examples` directory intermixing `./intsall_executorch.sh --clean`. Saw no problems.