### PR TITLE
[ET-VK][ez] Allow Vulkan operator tests to run on devserver and Mac

### DIFF
--- a/backends/vulkan/test/op_tests/targets.bzl
+++ b/backends/vulkan/test/op_tests/targets.bzl
@@ -1,4 +1,4 @@
-load("@fbsource//tools/build_defs:platform_defs.bzl", "ANDROID", "CXX")
+load("@fbsource//tools/build_defs:platform_defs.bzl", "ANDROID")
 load("@fbsource//xplat/caffe2:pt_defs.bzl", "get_pt_ops_deps")
 load("@fbsource//xplat/caffe2:pt_ops.bzl", "pt_operator_library")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")

--- a/backends/vulkan/test/op_tests/targets.bzl
+++ b/backends/vulkan/test/op_tests/targets.bzl
@@ -1,7 +1,11 @@
-load("@fbsource//tools/build_defs:platform_defs.bzl", "ANDROID")
+load("@fbsource//tools/build_defs:platform_defs.bzl", "ANDROID", "CXX")
 load("@fbsource//xplat/caffe2:pt_defs.bzl", "get_pt_ops_deps")
 load("@fbsource//xplat/caffe2:pt_ops.bzl", "pt_operator_library")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+load(
+    "@fbsource//xplat/executorch/backends/vulkan:targets.bzl",
+    "get_platforms",
+)
 
 def define_test_targets(test_name, extra_deps = [], src_file = None, is_fbcode = False):
     deps_list = [
@@ -20,7 +24,7 @@ def define_test_targets(test_name, extra_deps = [], src_file = None, is_fbcode =
         compiler_flags = [
             "-Wno-unused-variable",
         ],
-        platforms = [ANDROID],
+        platforms = get_platforms(),
         define_static_target = False,
         deps = deps_list,
     )
@@ -135,7 +139,7 @@ def define_common_targets(is_fbcode = False):
             "//executorch/backends/vulkan:vulkan_graph_runtime",
             runtime.external_dep_location("libtorch"),
         ],
-        platforms = [ANDROID],
+        platforms = get_platforms(),
     )
 
     define_test_targets(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #11648

## Context

https://github.com/pytorch/executorch/pull/11547 was landed recently which restricted vulkan operator tests to the `ANDROID` platform.

Simply update to use the utility function `get_platforms()` so that the tests can run everywhere the vulkan delegate can be built.

Differential Revision: [D76620647](https://our.internmc.facebook.com/intern/diff/D76620647/)

cc @manuelcandales @cbilgin