### PR TITLE
Install examples and domain libraries as last (optional) step

### DIFF
--- a/install_executorch.py
+++ b/install_executorch.py
@@ -16,6 +16,7 @@ import sys
 from contextlib import contextmanager
 
 from install_requirements import (
+    install_optional_example_requirements,
     install_requirements,
     python_is_compatible,
     TORCH_NIGHTLY_URL,
@@ -157,6 +158,13 @@ def _parse_args() -> argparse.Namespace:
         "picked up without rebuilding the wheel. Extension libraries will be "
         "installed inside the source tree.",
     )
+    parser.add_argument(
+        "--minimal",
+        "-m",
+        action="store_true",
+        help="Only installs necessary dependencies for core executorch and skips "
+        " packages necessary for running example scripts.",
+    )
     return parser.parse_args()
 
 
@@ -182,9 +190,13 @@ def main(args):
     # This option is used in CI to make sure that PyTorch build from the pinned commit
     # is used instead of nightly. CI jobs wouldn't be able to catch regression from the
     # latest PT commit otherwise
-    install_requirements(use_pytorch_nightly=not args.use_pt_pinned_commit)
-    os.execvp(
-        sys.executable,
+    use_pytorch_nightly = not args.use_pt_pinned_commit
+
+    # Step 1: Install core dependencies first
+    install_requirements(use_pytorch_nightly)
+
+    # Step 2: Install core package
+    cmd = (
         [
             sys.executable,
             "-m",
@@ -198,8 +210,13 @@ def main(args):
             "-v",
             "--extra-index-url",
             TORCH_NIGHTLY_URL,
-        ],
+        ]
     )
+    subprocess.run(cmd, check=True)
+
+    # Step 3: Extra (optional) packages that is only useful for running examples.
+    if not args.minimal:
+        install_optional_example_requirements(use_pytorch_nightly)
 
 
 if __name__ == "__main__":

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,5 @@
+# Pip packages needed to build from source. Mainly for development of ExecuTorch.
+
 cmake>=3.19, <4.0.0  # For building binary targets in the wheel.
 pip>=23  # For building the pip package.
 pyyaml  # Imported by the kernel codegen tools.
@@ -5,3 +7,5 @@ setuptools>=63  # For building the pip package contents.
 tomli  # Imported by extract_sources.py when using python < 3.11.
 wheel  # For building the pip package archive.
 zstd  # Imported by resolve_buck.py.
+lintrunner==0.12.7
+lintrunner-adapters==0.12.4

--- a/requirements-lintrunner.txt
+++ b/requirements-lintrunner.txt
@@ -1,7 +1,3 @@
-# Lintrunner itself
-lintrunner==0.12.7
-lintrunner-adapters==0.12.4
-
 # Flake 8 and its dependencies
 flake8==6.1.0
 flake8-breakpoint==1.1.0


### PR DESCRIPTION
Install requirements is installing so many things that's not necessary for core executorch runtime. For example, it's not necessary to install packages that is used in examples. 

Ideally, developers should just run to install core ET. 

```
install_requirement.sh
pip install . -e
```