### PR TITLE
Support for cmdline flag to toggle Debug vs Release build types in cmake

### DIFF
--- a/.ci/scripts/utils.sh
+++ b/.ci/scripts/utils.sh
@@ -156,13 +156,14 @@ build_executorch_runner() {
 }
 
 cmake_install_executorch_lib() {
+  build_type="${1:-Release}"
   echo "Installing libexecutorch.a and libportable_kernels.a"
   clean_executorch_install_folders
   retry cmake -DCMAKE_INSTALL_PREFIX=cmake-out \
-          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_BUILD_TYPE=${build_type} \
           -DPYTHON_EXECUTABLE="$PYTHON_EXECUTABLE" \
           -Bcmake-out .
-  cmake --build cmake-out -j9 --target install --config Release
+  cmake --build cmake-out -j9 --target install --config ${build_type}
 }
 
 download_stories_model_artifacts() {

--- a/examples/selective_build/test_selective_build.sh
+++ b/examples/selective_build/test_selective_build.sh
@@ -167,7 +167,7 @@ test_cmake_select_ops_in_model() {
     local example_dir=examples/selective_build
     local build_dir=cmake-out/${example_dir}
     rm -rf ${build_dir}
-    retry cmake -DCMAKE_BUILD_TYPE=Release \
+    retry cmake -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE \
             -DEXECUTORCH_SELECT_OPS_FROM_MODEL="./mv2.pte" \
             -DCMAKE_INSTALL_PREFIX=cmake-out \
             -DPYTHON_EXECUTABLE="$PYTHON_EXECUTABLE" \
@@ -175,7 +175,7 @@ test_cmake_select_ops_in_model() {
             ${example_dir}
 
     echo "Building ${example_dir}"
-    cmake --build ${build_dir} -j9 --config Release
+    cmake --build ${build_dir} -j9 --config $CMAKE_BUILD_TYPE
 
     echo 'Running selective build test'
     ${build_dir}/selective_build_test --model_path="./mv2.pte"
@@ -194,9 +194,14 @@ then
   PYTHON_EXECUTABLE=python3
 fi
 
+if [[ -z $CMAKE_BUILD_TYPE ]];
+then
+  CMAKE_BUILD_TYPE=Release
+fi
+
 if [[ $1 == "cmake" ]];
 then
-    cmake_install_executorch_lib
+    cmake_install_executorch_lib $CMAKE_BUILD_TYPE
     test_cmake_select_all_ops
     test_cmake_select_ops_in_list
     test_cmake_select_ops_in_yaml


### PR DESCRIPTION
### Summary
Adds support for command line option to toggle the cmake build mode from `Debug` vs `Release`. 

### Test plan
An example use case is shown in `examples/selective_build/test_selective_build.sh` in the `test_cmake_select_ops_in_model()` function. For example, you could run the following to build executorch and run the test in `Debug` mode:

```
CMAKE_BUILD_TYPE=Debug bash examples/selective_build/test_selective_build.sh cmake
```
