### PR TITLE
lintrunner init can fail, don't suppress stderr

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,7 +46,7 @@ jobs:
         fi
 
         # This has already been cached in the docker image
-        lintrunner init 2> /dev/null
+        lintrunner init
 
         RC=0
         # Run lintrunner on all files


### PR DESCRIPTION
Seeing it fail currently on https://github.com/pytorch/executorch/actions/runs/15647163870/job/44086495890?pr=11664 and cannot debug; let's not have this happen again.