### PR TITLE
Fix for overriding installed executorch when running optimum-et models

### DIFF
--- a/.github/workflows/android-perf.yml
+++ b/.github/workflows/android-perf.yml
@@ -342,8 +342,8 @@ jobs:
               git clone https://github.com/huggingface/optimum-executorch
               pushd optimum-executorch
               # There is no release yet, for CI stability, always test from the same commit on main
-              git checkout 1c653dc49812fc431a22312c7295d97005d22e12
-              python install_dev.py
+              git checkout 4c3b18f6cca68c5ccff809131d570062723d7188
+              python install_dev.py --skip_override_torch
               pip list
 
               ARGS=(

--- a/.github/workflows/apple-perf.yml
+++ b/.github/workflows/apple-perf.yml
@@ -347,8 +347,8 @@ jobs:
             git clone https://github.com/huggingface/optimum-executorch
             pushd optimum-executorch
             # There is no release yet, for CI stability, always test from the same commit on main
-            git checkout 1c653dc49812fc431a22312c7295d97005d22e12
-            ${CONDA_RUN} python install_dev.py
+            git checkout 4c3b18f6cca68c5ccff809131d570062723d7188
+            ${CONDA_RUN} python install_dev.py --skip_override_torch
             pip list
 
             ARGS=(

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -571,9 +571,8 @@ jobs:
         git clone https://github.com/huggingface/optimum-executorch
         pushd optimum-executorch
         # There is no release yet, for CI stability, always test from the same commit on main
-        git checkout 1c653dc49812fc431a22312c7295d97005d22e12
-        pip install .[tests]
-        pip install transformers==4.52.4
+        git checkout 4c3b18f6cca68c5ccff809131d570062723d7188
+        python install_dev.py --skip_override_torch
         popd
         pip list
         echo "::endgroup::"


### PR DESCRIPTION
### Summary
Running `install_dev.py` for `optimum-executorch` will force overriding installed `executorch` and torch deps to the pinned nightly in `optimum-executorch`. In ExecuTorch CI including the benchmark, we would want to always run the optimum-executorch models with ExecuTorch from source to catch issues/regressions.  

### Test plan
Verified the installed deps in the CI and benchmark jobs
