### PR TITLE
Fix text_llm_runner unit test

### DIFF
--- a/extension/llm/runner/text_llm_runner.cpp
+++ b/extension/llm/runner/text_llm_runner.cpp
@@ -128,9 +128,13 @@ Error TextLLMRunner::generate_from_pos(
 
   // Reduce max_context_len by start_pos
   int64_t max_context_len = metadata_.at(kMaxContextLen) - start_pos;
-  ET_CHECK_MSG(num_prompt_tokens >= 1, "Expected at least 1 prompt token");
-  ET_CHECK_MSG(
+  ET_CHECK_OR_RETURN_ERROR(
+      num_prompt_tokens >= 1,
+      InvalidArgument,
+      "Expected at least 1 prompt token");
+  ET_CHECK_OR_RETURN_ERROR(
       num_prompt_tokens < max_context_len,
+      InvalidArgument,
       "num_prompt_tokens %d >= max_context_len %" PRId64
       ", Max seq length exceeded - please increase max seq len value in your export script",
       num_prompt_tokens,


### PR DESCRIPTION
Summary:
This is a follow-up of #11570 (D76457271)

We should not abort when num_prompt_tokens >= max_context_len, instead we should return error.

Differential Revision: D76791781
