### PR TITLE
NXP backend: Enable initial unit tests workflow (#11396)

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -718,3 +718,32 @@ jobs:
       build-mode: Release
       build-tool: cmake
       docker-image: executorch-ubuntu-22.04-clang12
+
+  unittest-nxp-neutron:
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      runner: linux.2xlarge
+      docker-image: executorch-ubuntu-22.04-clang12
+      submodules: 'recursive'
+      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      timeout: 90
+      script: |
+        set -eux
+        
+        # The generic Linux job chooses to use base env, not the one setup by the image
+        CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
+        conda activate "${CONDA_ENV}"
+        
+        # Build and install Executorch
+        PYTHON_EXECUTABLE=python \
+        CMAKE_ARGS="-DEXECUTORCH_BUILD_NXP_NEUTRON=ON" \
+        .ci/scripts/setup-linux.sh --build-tool "cmake"
+        
+        # Install test requirements
+        pip install -r backends/nxp/requirements-tests.txt
+        
+        # Run pytest
+        PYTHON_EXECUTABLE=python bash backends/nxp/run_unittests.sh

--- a/backends/nxp/requirements-tests.txt
+++ b/backends/nxp/requirements-tests.txt
@@ -3,4 +3,4 @@ tensorflow==2.18.0
 pytest-mock
 tflite
 GvGen
-neutron-converter_SDK_25_03
+neutron_converter_SDK_25_03

--- a/backends/nxp/run_unittests.sh
+++ b/backends/nxp/run_unittests.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Copyright 2025 NXP
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+set -eux
+
+SCRIPT_DIR=$(dirname $(readlink -fm $0))
+EXECUTORCH_DIR=$(dirname $(dirname $SCRIPT_DIR))
+
+cd $EXECUTORCH_DIR
+
+# '-c /dev/null' is used to ignore root level pytest.ini.
+PYTHONPATH=`cd ..; pwd` pytest -c /dev/null backends/nxp/tests/

--- a/examples/nxp/setup.sh
+++ b/examples/nxp/setup.sh
@@ -7,4 +7,4 @@
 set -u
 
 # Install neutron-converter
-pip install --extra-index-url https://eiq.nxp.com/repository neutron-converter_SDK_25_03
+pip install --extra-index-url https://eiq.nxp.com/repository neutron_converter_SDK_25_03


### PR DESCRIPTION
### Summary
Initial workflow definition for running unit tests for Neutron (NXP) backend.

Follow up for the https://github.com/pytorch/executorch/pull/11109, our IT updated the eIQ PyPI, so the neutron-converter python package shall be reachable using the executorch's self-hosted agents too.
