### PR TITLE
skip et quantizer numeric debugging tests for infra update

### DIFF
--- a/backends/xnnpack/test/quantizer/test_pt2e_quantization.py
+++ b/backends/xnnpack/test/quantizer/test_pt2e_quantization.py
@@ -6,6 +6,8 @@
 
 # pyre-unsafe
 
+import unittest
+
 from collections import Counter
 from typing import Dict, Tuple
 
@@ -723,6 +725,7 @@ class TestQuantizePT2E(PT2EQuantizationTestCase):
 instantiate_parametrized_tests(TestQuantizePT2E)
 
 
+@unittest.skip("TODO: Reenable it after debug infrature finish update")
 class TestNumericDebugger(TestCase):
     def _extract_debug_handles(self, model) -> Dict[str, int]:
         debug_handle_map: Dict[str, int] = {}


### PR DESCRIPTION
Summary: skip the numeric debugging test first for infra update. D76842934 will bring it back after infra update

Reviewed By: jerryzh168

Differential Revision: D76842266
