### PR TITLE
Propagate core_aten_exceptions to quantize_and_export_to_executorch and export_to_executorch.

### DIFF
--- a/backends/cadence/aot/compiler.py
+++ b/backends/cadence/aot/compiler.py
@@ -278,6 +278,7 @@ def quantize_and_export_to_edge(
     dump_graphs: bool = False,
     constant_methods: Optional[dict[str, object]] = None,
     calibration_data: Optional[list[tuple[object, ...]]] = None,
+    core_aten_exceptions: Optional[list[torch._ops.OpOverload]] = None,
 ) -> EdgeProgramManager:
     """
     Trace, quantize and lower a model/inputs pair to edge IR.
@@ -294,6 +295,7 @@ def quantize_and_export_to_edge(
         quantized_model,
         dump_graphs=dump_graphs,
         constant_methods=constant_methods,
+        core_aten_exceptions=core_aten_exceptions,
     )
 
 


### PR DESCRIPTION
Summary: A follow-up diff on comments in D75997936.

Differential Revision: D76860649
