### PR TITLE
Fix bug in add op to ignore alpha != 1 (fixes: #11683)

### DIFF
--- a/backends/xnnpack/partition/config/generic_node_configs.py
+++ b/backends/xnnpack/partition/config/generic_node_configs.py
@@ -9,6 +9,7 @@
 import logging
 from typing import cast, List, Optional
 
+import numpy as np
 import torch
 from executorch.backends.xnnpack.partition.config.xnnpack_config import (
     ConfigPrecisionType,
@@ -105,6 +106,17 @@ class AddConfig(GenericNodePartitionerConfig):
 
     def supported_precision_types(self) -> List[ConfigPrecisionType]:
         return [ConfigPrecisionType.FP32, ConfigPrecisionType.STATIC_QUANT]
+
+    def check_constraints(self, node: torch.fx.Node, ep: ExportedProgram) -> bool:
+        if not self.check_common_constraints(node, ep):
+            return False
+        # No support for add nodes with alpha != 1
+        if "alpha" in node.kwargs and not np.isclose(
+            node.kwargs["alpha"], 1.0, atol=1e-9, rtol=1e-9
+        ):
+            why(node, reason="Add node doesn't support alpha != 1")
+            return False
+        return True
 
 
 class ReLUConfig(GenericNodePartitionerConfig):

--- a/backends/xnnpack/test/ops/test_add.py
+++ b/backends/xnnpack/test/ops/test_add.py
@@ -240,3 +240,27 @@ class TestAdd(unittest.TestCase):
             .serialize()
             .run_method_and_compare_outputs()
         )
+
+    class AddWithAlpha(torch.nn.Module):
+        def forward(self, x, y):
+            # node with alpha = 1.0 will be partitioned
+            out1 = torch.add(x, y, alpha=1)
+            # node with alpha != 1.0 will not be partitioned
+            out2 = torch.add(x, y, alpha=2)
+            return out1, out2
+
+    def test_add_with_alpha(self):
+        inputs = (torch.randn(1, 1, 4, 4), torch.randn(1, 1, 4, 4))
+        (
+            Tester(self.AddWithAlpha(), inputs)
+            .export()
+            .check_count({"torch.ops.aten.add.Tensor": 2})
+            .to_edge_transform_and_lower()
+            # unpartitioned node
+            .check_count({"executorch_exir_dialects_edge__ops_aten_add_Tensor": 1})
+            # partitioned node
+            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            .to_executorch()
+            .serialize()
+            .run_method_and_compare_outputs()
+        )


### PR DESCRIPTION
### Summary
Add node of XNNPack backend doesn't consider alpha value, this fixes the bug by falling back to portable ops and avoid partitioning the node.

(fixes: #11683)

### Test plan
python -m unittest backends/xnnpack/test/ops/test_add.py

```
----------------------------------------------------------------------
Ran 11 tests in 26.689s

OK
```

```
import torch
from executorch.backends.xnnpack.partition.xnnpack_partitioner import XnnpackPartitioner
from executorch.exir import to_edge_transform_and_lower
from executorch.extension.pybindings.portable_lib import _load_for_executorch_from_buffer

class Model(torch.nn.Module):
    def forward(self, x, y):
        return torch.add(x, y, alpha=10)

inputs = (
    torch.randn(10),
    torch.randn(10),
)
model = Model()

ep = torch.export.export(model, inputs)
lowered = to_edge_transform_and_lower(
    ep,
    partitioner=[XnnpackPartitioner()],
).to_executorch()

et_model = _load_for_executorch_from_buffer(lowered.buffer)

eager_output = model(*inputs)
et_output = et_model([*inputs])[0]

tolerance=1e-5
if torch.allclose(eager_output, et_output, atol=tolerance):
    print("Outputs are within the tolerance level.")
else:
    print("Outputs differ beyond the tolerance level.")
```

## Output of above run (tolerance = 1e-5)
```
Outputs are within the tolerance level.
```

