### PR TITLE
Re-introduce the type-erasing tensor class.

### DIFF
--- a/extension/apple/ExecuTorch/Exported/ExecuTorch+Module.swift
+++ b/extension/apple/ExecuTorch/Exported/ExecuTorch+Module.swift
@@ -60,7 +60,7 @@ public extension Module {
   /// - Returns: An array of `Value` objects representing the outputs.
   /// - Throws: An error if method execution fails.
   func execute(_ method: String, _ inputs: [ValueConvertible]) throws -> [Value] {
-    try __executeMethod(method, withInputs: inputs.map { $0.objcValue() } )
+    try __executeMethod(method, withInputs: inputs.map { $0.asValue() } )
   }
 
   /// Executes a specific method with a single input value.
@@ -72,7 +72,7 @@ public extension Module {
   /// - Returns: An array of `Value` objects representing the outputs.
   /// - Throws: An error if method execution fails.
   func execute(_ method: String, _ input: ValueConvertible) throws -> [Value] {
-    try __executeMethod(method, withInputs: [input.objcValue()])
+    try __executeMethod(method, withInputs: [input.asValue()])
   }
 
   /// Executes the "forward" method with the provided input values.
@@ -82,7 +82,7 @@ public extension Module {
   /// - Returns: An array of `Value` objects representing the outputs.
   /// - Throws: An error if method execution fails.
   func forward(_ inputs: [ValueConvertible]) throws -> [Value] {
-    try __executeMethod("forward", withInputs: inputs.map { $0.objcValue() })
+    try __executeMethod("forward", withInputs: inputs.map { $0.asValue() })
   }
 
   /// Executes the "forward" method with a single input value.
@@ -92,6 +92,6 @@ public extension Module {
   /// - Returns: An array of `Value` objects representing the outputs.
   /// - Throws: An error if method execution fails.
   func forward(_ input: ValueConvertible) throws -> [Value] {
-    try __executeMethod("forward", withInputs: [input.objcValue()])
+    try __executeMethod("forward", withInputs: [input.asValue()])
   }
 }

--- a/extension/apple/ExecuTorch/Exported/ExecuTorch+Tensor.swift
+++ b/extension/apple/ExecuTorch/Exported/ExecuTorch+Tensor.swift
@@ -8,6 +8,15 @@
 
 @_exported import ExecuTorch
 
+/// Computes the total number of elements in a tensor based on its shape.
+///
+/// - Parameter shape: An array of integers, where each element represents a dimension size.
+/// - Returns: An integer equal to the product of the sizes of all dimensions.
+@available(*, deprecated, message: "This API is experimental.")
+public func elementCount(ofShape shape: [Int]) -> Int {
+  __ExecuTorchElementCountOfShape(shape.map(NSNumber.init))
+}
+
 /// A protocol that types conform to in order to be used as tensor element types.
 /// Provides the mapping from the Swift type to the underlying `DataType`.
 @available(*, deprecated, message: "This API is experimental.")
@@ -122,36 +131,482 @@ extension UInt: Scalar {
   public func asNSNumber() -> NSNumber { NSNumber(value: self) }
 }
 
-/// A tensor class for ExecuTorch operations.
+/// A type-erasing tensor class for ExecuTorch operations.
+@available(*, deprecated, message: "This API is experimental.")
+public extension AnyTensor {
+  /// The shape of the tensor.
+  var shape: [Int] { __shape.map(\.intValue) }
+
+  /// The strides of the tensor.
+  var strides: [Int] { __strides.map(\.intValue) }
+
+  /// The order of dimensions in the tensor.
+  var dimensionOrder: [Int] { __dimensionOrder.map(\.intValue) }
+
+  /// The total number of elements in the tensor.
+  var count: Int { __count }
+
+  /// Initializes a tensor without copying the provided data.
+  ///
+  /// - Parameters:
+  ///   - pointer: A pointer to the data buffer.
+  ///   - shape: An array of integers representing the tensor's shape.
+  ///   - strides: An array of integers representing the tensor's strides.
+  ///   - dimensionOrder: An array of integers indicating the order of dimensions.
+  ///   - dataType: A `DataType` value specifying the element type.
+  ///   - shapeDynamism: A `ShapeDynamism` value indicating whether the shape is static or dynamic.
+  convenience init(
+    bytesNoCopy pointer: UnsafeMutableRawPointer,
+    shape: [Int],
+    strides: [Int] = [],
+    dimensionOrder: [Int] = [],
+    dataType: DataType,
+    shapeDynamism: ShapeDynamism = .dynamicBound
+  ) {
+    self.init(
+      __bytesNoCopy:    pointer,
+      shape:          shape.map(NSNumber.init),
+      strides:        strides.map(NSNumber.init),
+      dimensionOrder: dimensionOrder.map(NSNumber.init),
+      dataType:       dataType,
+      shapeDynamism:  shapeDynamism
+    )
+  }
+
+  /// Initializes a tensor by copying bytes from the provided pointer.
+  ///
+  /// - Parameters:
+  ///   - pointer: A pointer to the source data buffer.
+  ///   - shape: An array of integers representing the tensor's shape.
+  ///   - strides: An array of integers representing the tensor's strides.
+  ///   - dimensionOrder: An array of integers indicating the order of dimensions.
+  ///   - dataType: A `DataType` value specifying the element type.
+  ///   - shapeDynamism: A `ShapeDynamism` value indicating the shape dynamism.
+  convenience init(
+    bytes pointer: UnsafeRawPointer,
+    shape: [Int],
+    strides: [Int] = [],
+    dimensionOrder: [Int] = [],
+    dataType: DataType,
+    shapeDynamism: ShapeDynamism = .dynamicBound
+  ) {
+    self.init(
+      __bytes: pointer,
+      shape: shape.map(NSNumber.init),
+      strides: strides.map(NSNumber.init),
+      dimensionOrder: dimensionOrder.map(NSNumber.init),
+      dataType: dataType,
+      shapeDynamism: shapeDynamism
+    )
+  }
+
+  /// Initializes a tensor using a `Data` object. The tensor holds a reference
+  /// to the `Data` object to ensure its buffer remains alive. The data is not copied.
+  ///
+  /// - Parameters:
+  ///   - data: A `Data` object containing the tensor data.
+  ///   - shape: An array of integers representing the tensor's shape.
+  ///   - strides: An array of integers representing the tensor's strides.
+  ///   - dimensionOrder: An array of integers indicating the order of dimensions.
+  ///   - dataType: A `DataType` value specifying the element type.
+  ///   - shapeDynamism: A `ShapeDynamism` value indicating the shape dynamism.
+  convenience init(
+    data: Data,
+    shape: [Int],
+    strides: [Int] = [],
+    dimensionOrder: [Int] = [],
+    dataType: DataType,
+    shapeDynamism: ShapeDynamism = .dynamicBound
+  ) {
+    self.init(
+      __data: data,
+      shape: shape.map(NSNumber.init),
+      strides: strides.map(NSNumber.init),
+      dimensionOrder: dimensionOrder.map(NSNumber.init),
+      dataType: dataType,
+      shapeDynamism: shapeDynamism
+    )
+  }
+
+  /// Resizes the tensor to a new shape.
+  ///
+  /// - Parameter shape: An array of `Int` representing the desired new shape.
+  /// - Throws: An error if the resize operation fails.
+  func resize(to shape: [Int]) throws {
+    try __resize(toShape: shape.map(NSNumber.init))
+  }
+
+  // MARK: Equatable
+
+  /// Determines whether the current tensor is equal to another tensor.
+  ///
+  /// - Parameters:
+  ///   - lhs: The left-hand side tensor.
+  ///   - rhs: The right-hand side tensor.
+  /// - Returns: `true` if the tensors have the same type, shape, strides, and data; otherwise, `false`.
+  static func == (lhs: AnyTensor, rhs: AnyTensor) -> Bool {
+    lhs.__isEqual(to: rhs)
+  }
+
+  /// Attempts to convert this type-erased `AnyTensor` into a strongly-typed `Tensor<T>`.
+  ///
+  /// - Returns: An `AnyTensor` if `self.dataType == T.dataType`,
+  ///            otherwise `nil` when the runtime dtype doesn’t match.
+  func asTensor<T: Scalar>() -> Tensor<T>? {
+    guard dataType == T.dataType else { return nil }
+    return Tensor<T>(self)
+  }
+}
+
+@available(*, deprecated, message: "This API is experimental.")
+public extension AnyTensor {
+  /// Creates an empty tensor with the specified properties.
+  ///
+  /// - Parameters:
+  ///   - shape: An array of integers representing the desired shape.
+  ///   - strides: An array of integers representing the desired strides.
+  ///   - dataType: A `DataType` value specifying the element type.
+  ///   - shapeDynamism: A value specifying whether the shape is static or dynamic.
+  /// - Returns: A new, empty `AnyTensor` instance.
+  static func empty(
+    shape: [Int],
+    strides: [Int] = [],
+    dataType: DataType,
+    shapeDynamism: ShapeDynamism = .dynamicBound
+  ) -> AnyTensor {
+    __empty(
+      withShape: shape.map(NSNumber.init),
+      strides: strides.map(NSNumber.init),
+      dataType: dataType,
+      shapeDynamism: shapeDynamism
+    )
+  }
+
+  /// Creates an empty tensor with the same properties as a given tensor.
+  ///
+  /// - Parameters:
+  ///   - like: An existing `AnyTensor` instance whose shape and strides are used.
+  ///   - dataType: A `DataType` value specifying the element type.
+  ///   - shapeDynamism: A value specifying whether the shape is static or dynamic.
+  /// - Returns: A new, empty `AnyTensor` instance.
+  static func empty(
+    like tensor: AnyTensor,
+    dataType: DataType = .undefined,
+    shapeDynamism: ShapeDynamism = .dynamicBound
+  ) -> AnyTensor {
+    __emptyTensorLike(
+      tensor,
+      dataType: dataType == .undefined ? tensor.dataType : dataType,
+      shapeDynamism: shapeDynamism
+    )
+  }
+}
+
+@available(*, deprecated, message: "This API is experimental.")
+public extension AnyTensor {
+  /// Creates a tensor filled with the specified scalar value.
+  ///
+  /// - Parameters:
+  ///   - shape: An array of integers representing the desired shape.
+  ///   - scalar: The value to fill the tensor with.
+  ///   - strides: An array of integers representing the desired strides.
+  ///   - shapeDynamism: A value specifying whether the shape is static or dynamic.
+  /// - Returns: A new `AnyTensor` instance filled with the scalar value.
+  static func full<T: Scalar>(
+    shape: [Int],
+    scalar: T,
+    strides: [Int] = [],
+    shapeDynamism: ShapeDynamism = .dynamicBound
+  ) -> AnyTensor {
+    __fullTensor(
+      withShape: shape.map(NSNumber.init),
+      scalar: scalar.asNSNumber(),
+      strides: strides.map(NSNumber.init),
+      dataType: T.dataType,
+      shapeDynamism: shapeDynamism
+    )
+  }
+
+  /// Creates a tensor filled with a scalar value, with the same properties as a given tensor.
+  ///
+  /// - Parameters:
+  ///   - like: An existing `AnyTensor` instance whose shape and strides are used.
+  ///   - scalar: The value to fill the tensor with.
+  ///   - shapeDynamism: A value specifying whether the shape is static or dynamic.
+  /// - Returns: A new `AnyTensor` instance filled with the scalar value.
+  static func full<T: Scalar>(
+    like tensor: AnyTensor,
+    scalar: T,
+    shapeDynamism: ShapeDynamism = .dynamicBound
+  ) -> AnyTensor {
+    __fullTensorLike(
+      tensor,
+      scalar: scalar.asNSNumber(),
+      dataType: T.dataType,
+      shapeDynamism: shapeDynamism
+    )
+  }
+}
+
+@available(*, deprecated, message: "This API is experimental.")
+public extension AnyTensor {
+  /// Creates a tensor filled with ones.
+  ///
+  /// - Parameters:
+  ///   - shape: An array of integers representing the desired shape.
+  ///   - strides: An array of integers representing the desired strides.
+  ///   - dataType: A `DataType` value specifying the element type.
+  ///   - shapeDynamism: A value specifying whether the shape is static or dynamic.
+  /// - Returns: A new `AnyTensor` instance filled with ones.
+  static func ones(
+    shape: [Int],
+    strides: [Int] = [],
+    dataType: DataType,
+    shapeDynamism: ShapeDynamism = .dynamicBound
+  ) -> AnyTensor {
+    __onesTensor(
+      withShape: shape.map(NSNumber.init),
+      dataType: dataType,
+      shapeDynamism: shapeDynamism
+    )
+  }
+
+  /// Creates a tensor of ones with the same properties as a given tensor.
+  ///
+  /// - Parameters:
+  ///   - like: An existing `AnyTensor` instance whose shape and strides are used.
+  ///   - shapeDynamism: A value specifying whether the shape is static or dynamic.
+  /// - Returns: A new `AnyTensor` instance filled with ones.
+  static func ones(
+    like tensor: AnyTensor,
+    dataType: DataType = .undefined,
+    shapeDynamism: ShapeDynamism = .dynamicBound
+  ) -> AnyTensor {
+    __onesTensorLike(
+      tensor,
+      dataType: dataType == .undefined ? tensor.dataType : dataType,
+      shapeDynamism: shapeDynamism
+    )
+  }
+}
+
+@available(*, deprecated, message: "This API is experimental.")
+public extension AnyTensor {
+  /// Creates a tensor filled with zeros.
+  ///
+  /// - Parameters:
+  ///   - shape: An array of integers representing the desired shape.
+  ///   - strides: An array of integers representing the desired strides.
+  ///   - dataType: A `DataType` value specifying the element type.
+  ///   - shapeDynamism: A value specifying whether the shape is static or dynamic.
+  /// - Returns: A new `AnyTensor` instance filled with zeros.
+  static func zeros(
+    shape: [Int],
+    strides: [Int] = [],
+    dataType: DataType,
+    shapeDynamism: ShapeDynamism = .dynamicBound
+  ) -> AnyTensor {
+    __zerosTensor(
+      withShape: shape.map(NSNumber.init),
+      dataType: dataType,
+      shapeDynamism: shapeDynamism
+    )
+  }
+
+  /// Creates a tensor of zeros with the same properties as a given tensor.
+  ///
+  /// - Parameters:
+  ///   - like: An existing `AnyTensor` instance whose shape and strides are used.
+  ///   - dataType: A `DataType` value specifying the element type.
+  ///   - shapeDynamism: A value specifying whether the shape is static or dynamic.
+  /// - Returns: A new `AnyTensor` instance filled with zeros.
+  static func zeros(
+    like tensor: AnyTensor,
+    dataType: DataType = .undefined,
+    shapeDynamism: ShapeDynamism = .dynamicBound
+  ) -> AnyTensor {
+    __zerosTensorLike(
+      tensor,
+      dataType: dataType == .undefined ? tensor.dataType : dataType,
+      shapeDynamism: shapeDynamism
+    )
+  }
+}
+
+@available(*, deprecated, message: "This API is experimental.")
+public extension AnyTensor {
+  /// Creates a tensor with random values uniformly distributed in `[0, 1)`.
+  ///
+  /// - Parameters:
+  ///   - shape: An array of integers representing the desired shape.
+  ///   - strides: An array of integers representing the desired strides.
+  ///   - dataType: A `DataType` value specifying the element type.
+  ///   - shapeDynamism: A value specifying whether the shape is static or dynamic.
+  /// - Returns: A new `AnyTensor` instance filled with random values.
+  static func rand(
+    shape: [Int],
+    strides: [Int] = [],
+    dataType: DataType,
+    shapeDynamism: ShapeDynamism = .dynamicBound
+  ) -> AnyTensor {
+    __randomTensor(
+      withShape: shape.map(NSNumber.init),
+      strides: strides.map(NSNumber.init),
+      dataType: dataType,
+      shapeDynamism: shapeDynamism
+    )
+  }
+
+  /// Creates a tensor with random values with the same properties as a given tensor.
+  ///
+  /// - Parameters:
+  ///   - like: An existing `AnyTensor` instance whose shape and strides are used.
+  ///   - dataType: A `DataType` value specifying the element type.
+  ///   - shapeDynamism: A value specifying whether the shape is static or dynamic.
+  /// - Returns: A new `AnyTensor` instance filled with random values.
+  static func rand(
+    like tensor: AnyTensor,
+    dataType: DataType = .undefined,
+    shapeDynamism: ShapeDynamism = .dynamicBound
+  ) -> AnyTensor {
+    __randomTensorLike(
+      tensor,
+      dataType: dataType == .undefined ? tensor.dataType : dataType,
+      shapeDynamism: shapeDynamism
+    )
+  }
+}
+
+@available(*, deprecated, message: "This API is experimental.")
+public extension AnyTensor {
+  /// Creates a tensor with random values from a normal distribution with mean `0` and variance `1`.
+  ///
+  /// - Parameters:
+  ///   - shape: An array of integers representing the desired shape.
+  ///   - strides: An array of integers representing the desired strides.
+  ///   - dataType: A `DataType` value specifying the element type.
+  ///   - shapeDynamism: A value specifying whether the shape is static or dynamic.
+  /// - Returns: A new `AnyTensor` instance filled with values from a normal distribution.
+  static func randn(
+    shape: [Int],
+    strides: [Int] = [],
+    dataType: DataType,
+    shapeDynamism: ShapeDynamism = .dynamicBound
+  ) -> AnyTensor {
+    __randomNormalTensor(
+      withShape: shape.map(NSNumber.init),
+      strides: strides.map(NSNumber.init),
+      dataType: dataType,
+      shapeDynamism: shapeDynamism
+    )
+  }
+
+  /// Creates a tensor with random normal values with the same properties as a given tensor.
+  ///
+  /// - Parameters:
+  ///   - like: An existing `AnyTensor` instance whose shape and strides are used.
+  ///   - dataType: A `DataType` value specifying the element type.
+  ///   - shapeDynamism: A value specifying whether the shape is static or dynamic.
+  /// - Returns: A new `AnyTensor` instance filled with values from a normal distribution.
+  static func randn(
+    like tensor: AnyTensor,
+    dataType: DataType = .undefined,
+    shapeDynamism: ShapeDynamism = .dynamicBound
+  ) -> AnyTensor {
+    __randomNormalTensorLike(
+      tensor,
+      dataType: dataType == .undefined ? tensor.dataType : dataType,
+      shapeDynamism: shapeDynamism
+    )
+  }
+}
+
+@available(*, deprecated, message: "This API is experimental.")
+public extension AnyTensor {
+  /// Creates a tensor with random integers from `low` (inclusive) to `high` (exclusive).
+  ///
+  /// - Parameters:
+  ///   - low: The inclusive lower bound of the random integer range.
+  ///   - high: The exclusive upper bound of the random integer range.
+  ///   - shape: An array of integers representing the desired shape.
+  ///   - strides: An array of integers representing the desired strides.
+  ///   - dataType: A `DataType` value specifying the element type.
+  ///   - shapeDynamism: A value specifying whether the shape is static or dynamic.
+  /// - Returns: A new `AnyTensor` instance filled with random integer values.
+  static func randint(
+    low: Int,
+    high: Int,
+    shape: [Int],
+    strides: [Int] = [],
+    dataType: DataType,
+    shapeDynamism: ShapeDynamism = .dynamicBound
+  ) -> AnyTensor {
+    __randomIntegerTensor(
+      withLow: low,
+      high: high,
+      shape: shape.map(NSNumber.init),
+      strides: strides.map(NSNumber.init),
+      dataType: dataType,
+      shapeDynamism: shapeDynamism
+    )
+  }
+
+  /// Creates a tensor with random integers with the same properties as a given tensor.
+  ///
+  /// - Parameters:
+  ///   - like: An existing `AnyTensor` instance whose shape and strides are used.
+  ///   - low: The inclusive lower bound of the random integer range.
+  ///   - high: The exclusive upper bound of the random integer range.
+  ///   - dataType: A `DataType` value specifying the element type.
+  ///   - shapeDynamism: A value specifying whether the shape is static or dynamic.
+  /// - Returns: A new `AnyTensor` instance filled with random integer values.
+  static func randint(
+    like tensor: AnyTensor,
+    low: Int,
+    high: Int,
+    dataType: DataType = .undefined,
+    shapeDynamism: ShapeDynamism = .dynamicBound
+  ) -> AnyTensor {
+    __randomIntegerTensorLike(
+      tensor,
+      low: low,
+      high: high,
+      dataType: dataType == .undefined ? tensor.dataType : dataType,
+      shapeDynamism: shapeDynamism
+    )
+  }
+}
+
+/// A generic tensor class for ExecuTorch operations.
 ///
-/// This class encapsulates a native `ExecuTorchTensor` instance and provides a variety of
+/// This class encapsulates a type-erasing `AnyTensor` instance and provides a variety of
 /// initializers and utility methods to work with tensor data.
 @available(*, deprecated, message: "This API is experimental.")
 public class Tensor<T: Scalar>: Equatable {
   /// The data type of the tensor's elements.
-  public var dataType: DataType { objcTensor.dataType }
+  public var dataType: DataType { anyTensor.dataType }
 
   /// The shape of the tensor.
-  public var shape: [Int] { objcTensor.shape.map(\.intValue) }
+  public var shape: [Int] { anyTensor.shape }
 
   /// The strides of the tensor.
-  public var strides: [Int] { objcTensor.strides.map(\.intValue) }
+  public var strides: [Int] { anyTensor.strides }
 
   /// The order of dimensions in the tensor.
-  public var dimensionOrder: [Int] { objcTensor.dimensionOrder.map(\.intValue) }
+  public var dimensionOrder: [Int] { anyTensor.dimensionOrder }
 
   /// The dynamism of the tensor's shape.
-  public var shapeDynamism: ShapeDynamism { objcTensor.shapeDynamism }
+  public var shapeDynamism: ShapeDynamism { anyTensor.shapeDynamism }
 
   /// The total number of elements in the tensor.
-  public var count: Int { objcTensor.count }
+  public var count: Int { anyTensor.count }
 
-  /// Initializes a tensor with an `ExecuTorchTensor` instance.
+  /// Initializes a tensor with an `AnyTensor` instance.
   ///
-  /// - Parameter tensor: An `ExecuTorchTensor` instance.
-  public init(_ tensor: __ExecuTorchTensor) {
+  /// - Parameter tensor: An `AnyTensor` instance.
+  public init(_ tensor: AnyTensor) {
     precondition(tensor.dataType == T.dataType)
-    objcTensor = tensor
+    anyTensor = tensor
   }
 
   /// Creates a new tensor that shares the underlying data storage with the
@@ -159,7 +614,7 @@ public class Tensor<T: Scalar>: Equatable {
   ///
   /// - Parameter tensor: The tensor to create a view of.
   public convenience init(_ tensor: Tensor<T>) {
-    self.init(__ExecuTorchTensor(tensor.objcTensor))
+    self.init(AnyTensor(tensor.anyTensor))
   }
 
   /// Initializes a tensor without copying the provided data.
@@ -177,11 +632,11 @@ public class Tensor<T: Scalar>: Equatable {
     dimensionOrder: [Int] = [],
     shapeDynamism: ShapeDynamism = .dynamicBound
   ) {
-    self.init(__ExecuTorchTensor(
+    self.init(AnyTensor(
       bytesNoCopy: pointer,
-      shape: shape.map(NSNumber.init),
-      strides: strides.map(NSNumber.init),
-      dimensionOrder: dimensionOrder.map(NSNumber.init),
+      shape: shape,
+      strides: strides,
+      dimensionOrder: dimensionOrder,
       dataType: T.dataType,
       shapeDynamism: shapeDynamism
     ))
@@ -202,11 +657,11 @@ public class Tensor<T: Scalar>: Equatable {
     dimensionOrder: [Int] = [],
     shapeDynamism: ShapeDynamism = .dynamicBound
   ) {
-    self.init(__ExecuTorchTensor(
+    self.init(AnyTensor(
       bytes: pointer,
-      shape: shape.map(NSNumber.init),
-      strides: strides.map(NSNumber.init),
-      dimensionOrder: dimensionOrder.map(NSNumber.init),
+      shape: shape,
+      strides: strides,
+      dimensionOrder: dimensionOrder,
       dataType: T.dataType,
       shapeDynamism: shapeDynamism
     ))
@@ -228,11 +683,11 @@ public class Tensor<T: Scalar>: Equatable {
     dimensionOrder: [Int] = [],
     shapeDynamism: ShapeDynamism = .dynamicBound
   ) {
-    self.init(__ExecuTorchTensor(
+    self.init(AnyTensor(
       data: data,
-      shape: shape.map(NSNumber.init),
-      strides: strides.map(NSNumber.init),
-      dimensionOrder: dimensionOrder.map(NSNumber.init),
+      shape: shape,
+      strides: strides,
+      dimensionOrder: dimensionOrder,
       dataType: T.dataType,
       shapeDynamism: shapeDynamism
     ))
@@ -253,14 +708,14 @@ public class Tensor<T: Scalar>: Equatable {
     dimensionOrder: [Int] = [],
     shapeDynamism: ShapeDynamism = .dynamicBound
   ) {
-    let nsShape = (shape.isEmpty ? [scalars.count] : shape).map(NSNumber.init)
-    precondition(scalars.count == elementCount(ofShape: nsShape))
-    self.init(scalars.withUnsafeBufferPointer { buffer in
-      __ExecuTorchTensor(
-        bytes: buffer.baseAddress!,
-        shape: nsShape,
-        strides: strides.map(NSNumber.init),
-        dimensionOrder: dimensionOrder.map(NSNumber.init),
+    let newShape = shape.isEmpty ? [scalars.count] : shape
+    precondition(scalars.count == elementCount(ofShape: newShape))
+    self.init(scalars.withUnsafeBufferPointer {
+      AnyTensor(
+        bytes: $0.baseAddress!,
+        shape: newShape,
+        strides: strides,
+        dimensionOrder: dimensionOrder,
         dataType: T.dataType,
         shapeDynamism: shapeDynamism
       )
@@ -271,14 +726,14 @@ public class Tensor<T: Scalar>: Equatable {
   ///
   /// - Parameter scalar: A scalar value.
   public convenience init(_ scalar: T) {
-    self.init(__ExecuTorchTensor(scalar.asNSNumber(), dataType: T.dataType))
+    self.init(AnyTensor(__scalar: scalar.asNSNumber(), dataType: T.dataType))
   }
 
   /// Returns a copy of the tensor.
   ///
   /// - Returns: A new `Tensor` instance that is a duplicate of the current tensor.
   public func copy() -> Tensor<T> {
-    Tensor<T>(objcTensor.copy())
+    Tensor<T>(anyTensor.copy())
   }
 
   /// Calls the closure with a typed, immutable buffer pointer over the tensor’s elements.
@@ -288,7 +743,7 @@ public class Tensor<T: Scalar>: Equatable {
   /// - Throws: Any error thrown by `body`.
   public func withUnsafeBytes<R>(_ body: (UnsafeBufferPointer<T>) throws -> R) throws -> R {
     var result: Result<R, Error>?
-    objcTensor.bytes { pointer, count, _ in
+    anyTensor.bytes { pointer, count, _ in
       result = Result { try body(
         UnsafeBufferPointer(
           start: pointer.assumingMemoryBound(to: T.self),
@@ -306,7 +761,7 @@ public class Tensor<T: Scalar>: Equatable {
   /// - Throws: Any error thrown by `body`.
   public func withUnsafeMutableBytes<R>(_ body: (UnsafeMutableBufferPointer<T>) throws -> R) throws -> R {
     var result: Result<R, Error>?
-    objcTensor.mutableBytes { pointer, count, _ in
+    anyTensor.mutableBytes { pointer, count, _ in
       result = Result { try body(
         UnsafeMutableBufferPointer(
           start: pointer.assumingMemoryBound(to: T.self),
@@ -322,7 +777,7 @@ public class Tensor<T: Scalar>: Equatable {
   /// - Parameter shape: An array of `Int` representing the desired new shape.
   /// - Throws: An error if the resize operation fails.
   public func resize(to shape: [Int]) throws {
-    try objcTensor.resize(to: shape.map(NSNumber.init))
+    try anyTensor.resize(to: shape)
   }
 
   // MARK: Equatable
@@ -334,12 +789,12 @@ public class Tensor<T: Scalar>: Equatable {
   ///   - rhs: The right-hand side tensor.
   /// - Returns: `true` if the tensors have the same type, shape, strides, and data; otherwise, `false`.
   public static func == (lhs: Tensor<T>, rhs: Tensor<T>) -> Bool {
-    lhs.objcTensor.isEqual(to: rhs.objcTensor)
+    lhs.anyTensor == rhs.anyTensor
   }
 
   // MARK: Internal
 
-  let objcTensor: __ExecuTorchTensor
+  let anyTensor: AnyTensor
 }
 
 @available(*, deprecated, message: "This API is experimental.")
@@ -367,9 +822,9 @@ public extension Tensor {
     strides: [Int] = [],
     shapeDynamism: ShapeDynamism = .dynamicBound
   ) -> Tensor<T> {
-    Tensor<T>(__ExecuTorchTensor.empty(
-      shape: shape.map(NSNumber.init),
-      strides: strides.map(NSNumber.init),
+    Tensor<T>(AnyTensor.empty(
+      shape: shape,
+      strides: strides,
       dataType: T.dataType,
       shapeDynamism: shapeDynamism
     ))
@@ -382,12 +837,11 @@ public extension Tensor {
   ///   - shapeDynamism: A value specifying whether the shape is static or dynamic.
   /// - Returns: A new, empty `Tensor` instance.
   static func empty(
-    like: Tensor<T>,
+    like tensor: Tensor<T>,
     shapeDynamism: ShapeDynamism = .dynamicBound
   ) -> Tensor<T> {
-    Tensor<T>(__ExecuTorchTensor.empty(
-      like: like.objcTensor,
-      dataType: T.dataType,
+    Tensor<T>(AnyTensor.empty(
+      like: tensor.anyTensor,
       shapeDynamism: shapeDynamism
     ))
   }
@@ -409,11 +863,10 @@ public extension Tensor {
     strides: [Int] = [],
     shapeDynamism: ShapeDynamism = .dynamicBound
   ) -> Tensor<T> {
-    Tensor<T>(__ExecuTorchTensor.full(
-      shape: shape.map(NSNumber.init),
-      scalar: scalar.asNSNumber(),
-      strides: strides.map(NSNumber.init),
-      dataType: T.dataType,
+    Tensor<T>(AnyTensor.full(
+      shape: shape,
+      scalar: scalar,
+      strides: strides,
       shapeDynamism: shapeDynamism
     ))
   }
@@ -426,14 +879,13 @@ public extension Tensor {
   ///   - shapeDynamism: A value specifying whether the shape is static or dynamic.
   /// - Returns: A new `Tensor` instance filled with the scalar value.
   static func full(
-    like: Tensor<T>,
+    like tensor: Tensor<T>,
     scalar: T,
     shapeDynamism: ShapeDynamism = .dynamicBound
   ) -> Tensor<T> {
-    Tensor<T>(__ExecuTorchTensor.full(
-      like: like.objcTensor,
-      scalar: scalar.asNSNumber(),
-      dataType: T.dataType,
+    Tensor<T>(AnyTensor.full(
+      like: tensor.anyTensor,
+      scalar: scalar,
       shapeDynamism: shapeDynamism
     ))
   }
@@ -453,8 +905,8 @@ public extension Tensor {
     strides: [Int] = [],
     shapeDynamism: ShapeDynamism = .dynamicBound
   ) -> Tensor<T> {
-    Tensor<T>(__ExecuTorchTensor.ones(
-      shape: shape.map(NSNumber.init),
+    Tensor<T>(AnyTensor.ones(
+      shape: shape,
       dataType: T.dataType,
       shapeDynamism: shapeDynamism
     ))
@@ -467,12 +919,11 @@ public extension Tensor {
   ///   - shapeDynamism: A value specifying whether the shape is static or dynamic.
   /// - Returns: A new `Tensor` instance filled with ones.
   static func ones(
-    like: Tensor<T>,
+    like tensor: Tensor<T>,
     shapeDynamism: ShapeDynamism = .dynamicBound
   ) -> Tensor<T> {
-    Tensor<T>(__ExecuTorchTensor.ones(
-      like: like.objcTensor,
-      dataType: T.dataType,
+    Tensor<T>(AnyTensor.ones(
+      like: tensor.anyTensor,
       shapeDynamism: shapeDynamism
     ))
   }
@@ -492,8 +943,8 @@ public extension Tensor {
     strides: [Int] = [],
     shapeDynamism: ShapeDynamism = .dynamicBound
   ) -> Tensor<T> {
-    Tensor<T>(__ExecuTorchTensor.zeros(
-      shape: shape.map(NSNumber.init),
+    Tensor<T>(AnyTensor.zeros(
+      shape: shape,
       dataType: T.dataType,
       shapeDynamism: shapeDynamism
     ))
@@ -506,12 +957,11 @@ public extension Tensor {
   ///   - shapeDynamism: A value specifying whether the shape is static or dynamic.
   /// - Returns: A new `Tensor` instance filled with zeros.
   static func zeros(
-    like: Tensor<T>,
+    like tensor: Tensor<T>,
     shapeDynamism: ShapeDynamism = .dynamicBound
   ) -> Tensor<T> {
-    Tensor<T>(__ExecuTorchTensor.zeros(
-      like: like.objcTensor,
-      dataType: T.dataType,
+    Tensor<T>(AnyTensor.zeros(
+      like: tensor.anyTensor,
       shapeDynamism: shapeDynamism
     ))
   }
@@ -531,8 +981,9 @@ public extension Tensor {
     strides: [Int] = [],
     shapeDynamism: ShapeDynamism = .dynamicBound
   ) -> Tensor<T> {
-    Tensor<T>(__ExecuTorchTensor.rand(
-      shape: shape.map(NSNumber.init),
+    Tensor<T>(AnyTensor.rand(
+      shape: shape,
+      strides: strides,
       dataType: T.dataType,
       shapeDynamism: shapeDynamism
     ))
@@ -545,12 +996,11 @@ public extension Tensor {
   ///   - shapeDynamism: A value specifying whether the shape is static or dynamic.
   /// - Returns: A new `Tensor` instance filled with random values.
   static func rand(
-    like: Tensor<T>,
+    like tensor: Tensor<T>,
     shapeDynamism: ShapeDynamism = .dynamicBound
   ) -> Tensor<T> {
-    Tensor<T>(__ExecuTorchTensor.rand(
-      like: like.objcTensor,
-      dataType: T.dataType,
+    Tensor<T>(AnyTensor.rand(
+      like: tensor.anyTensor,
       shapeDynamism: shapeDynamism
     ))
   }
@@ -570,8 +1020,9 @@ public extension Tensor {
     strides: [Int] = [],
     shapeDynamism: ShapeDynamism = .dynamicBound
   ) -> Tensor<T> {
-    Tensor<T>(__ExecuTorchTensor.randn(
-      shape: shape.map(NSNumber.init),
+    Tensor<T>(AnyTensor.randn(
+      shape: shape,
+      strides: strides,
       dataType: T.dataType,
       shapeDynamism: shapeDynamism
     ))
@@ -584,12 +1035,11 @@ public extension Tensor {
   ///   - shapeDynamism: A value specifying whether the shape is static or dynamic.
   /// - Returns: A new `Tensor` instance filled with values from a normal distribution.
   static func randn(
-    like: Tensor<T>,
+    like tensor: Tensor<T>,
     shapeDynamism: ShapeDynamism = .dynamicBound
   ) -> Tensor<T> {
-    Tensor<T>(__ExecuTorchTensor.randn(
-      like: like.objcTensor,
-      dataType: T.dataType,
+    Tensor<T>(AnyTensor.randn(
+      like: tensor.anyTensor,
       shapeDynamism: shapeDynamism
     ))
   }
@@ -613,10 +1063,11 @@ public extension Tensor {
     strides: [Int] = [],
     shapeDynamism: ShapeDynamism = .dynamicBound
   ) -> Tensor<T> {
-    Tensor<T>(__ExecuTorchTensor.randint(
+    Tensor<T>(AnyTensor.randint(
       low: low,
       high: high,
-      shape: shape.map(NSNumber.init),
+      shape: shape,
+      strides: strides,
       dataType: T.dataType,
       shapeDynamism: shapeDynamism
     ))
@@ -631,16 +1082,15 @@ public extension Tensor {
   ///   - shapeDynamism: A value specifying whether the shape is static or dynamic.
   /// - Returns: A new `Tensor` instance filled with random integer values.
   static func randint(
-    like: Tensor<T>,
+    like tensor: Tensor<T>,
     low: Int,
     high: Int,
     shapeDynamism: ShapeDynamism = .dynamicBound
   ) -> Tensor<T> {
-    Tensor<T>(__ExecuTorchTensor.randint(
-      like: like.objcTensor,
+    Tensor<T>(AnyTensor.randint(
+      like: tensor.anyTensor,
       low: low,
       high: high,
-      dataType: T.dataType,
       shapeDynamism: shapeDynamism
     ))
   }

--- a/extension/apple/ExecuTorch/Exported/ExecuTorch+Value.swift
+++ b/extension/apple/ExecuTorch/Exported/ExecuTorch+Value.swift
@@ -13,7 +13,7 @@
 @available(*, deprecated, message: "This API is experimental.")
 public protocol ValueConvertible {
   /// Converts the instance into a `Value`.
-  func objcValue() -> Value
+  func asValue() -> Value
 }
 
 @available(*, deprecated, message: "This API is experimental.")
@@ -22,7 +22,14 @@ public extension Value {
   ///
   /// - Parameter tensor: The `Tensor` to wrap.
   convenience init<T: Scalar>(_ tensor: Tensor<T>) {
-    self.init(__tensor: tensor.objcTensor)
+    self.init(tensor.anyTensor)
+  }
+
+  /// Attempts to return the underlying type-erased `AnyTensor` if the `Value` contains one.
+  ///
+  /// - Returns: An `AnyTensor`, or `nil` if the `Value` is not a tensor.
+  var anyTensor: AnyTensor? {
+    __tensorValue
   }
 
   /// Attempts to return the underlying `Tensor` if the `Value` contains one.
@@ -30,8 +37,7 @@ public extension Value {
   /// - Returns: A `Tensor` of the specified scalar type, or `nil` if the
   ///   `Value` is not a tensor or the data type does not match.
   func tensor<T: Scalar>() -> Tensor<T>? {
-    guard isTensor, let tensor = __tensorValue, tensor.dataType == T.dataType else { return nil }
-    return Tensor<T>(tensor)
+    anyTensor?.asTensor()
   }
 }
 
@@ -40,101 +46,107 @@ public extension Value {
 @available(*, deprecated, message: "This API is experimental.")
 extension Value: ValueConvertible {
   /// Returns the `Value` itself.
-  public func objcValue() -> Value { self }
+  public func asValue() -> Value { self }
+}
+
+@available(*, deprecated, message: "This API is experimental.")
+extension AnyTensor: ValueConvertible {
+  /// Converts the `Tensor` into a `Value`.
+  public func asValue() -> Value { Value(self) }
 }
 
 @available(*, deprecated, message: "This API is experimental.")
 extension Tensor: ValueConvertible {
   /// Converts the `Tensor` into a `Value`.
-  public func objcValue() -> Value { Value(self) }
+  public func asValue() -> Value { Value(self) }
 }
 
 @available(*, deprecated, message: "This API is experimental.")
 extension String: ValueConvertible {
   /// Converts the `String` into a `Value`.
-  public func objcValue() -> Value { Value(self) }
+  public func asValue() -> Value { Value(self) }
 }
 
 @available(*, deprecated, message: "This API is experimental.")
 extension NSNumber: ValueConvertible {
   /// Converts the `NSNumber` into a `Value`.
-  public func objcValue() -> Value { Value(self) }
+  public func asValue() -> Value { Value(self) }
 }
 
 @available(*, deprecated, message: "This API is experimental.")
 extension UInt8: ValueConvertible {
   /// Converts the `UInt8` into a `Value`.
-  public func objcValue() -> Value { Value(NSNumber(value: Int(self))) }
+  public func asValue() -> Value { Value(NSNumber(value: Int(self))) }
 }
 
 @available(*, deprecated, message: "This API is experimental.")
 extension Int8: ValueConvertible {
   /// Converts the `Int8` into a `Value`.
-  public func objcValue() -> Value { Value(NSNumber(value: Int(self))) }
+  public func asValue() -> Value { Value(NSNumber(value: Int(self))) }
 }
 
 @available(*, deprecated, message: "This API is experimental.")
 extension Int16: ValueConvertible {
   /// Converts the `Int16` into a `Value`.
-  public func objcValue() -> Value { Value(NSNumber(value: self)) }
+  public func asValue() -> Value { Value(NSNumber(value: self)) }
 }
 
 @available(*, deprecated, message: "This API is experimental.")
 extension Int32: ValueConvertible {
   /// Converts the `Int32` into a `Value`.
-  public func objcValue() -> Value { Value(NSNumber(value: self)) }
+  public func asValue() -> Value { Value(NSNumber(value: self)) }
 }
 
 @available(*, deprecated, message: "This API is experimental.")
 extension Int64: ValueConvertible {
   /// Converts the `Int64` into a `Value`.
-  public func objcValue() -> Value { Value(NSNumber(value: self)) }
+  public func asValue() -> Value { Value(NSNumber(value: self)) }
 }
 
 @available(*, deprecated, message: "This API is experimental.")
 extension Int: ValueConvertible {
   /// Converts the `Int` into a `Value`.
-  public func objcValue() -> Value { Value(self) }
+  public func asValue() -> Value { Value(self) }
 }
 
 @available(*, deprecated, message: "This API is experimental.")
 extension Float: ValueConvertible {
   /// Converts the `Float` into a `Value`.
-  public func objcValue() -> Value { Value(self) }
+  public func asValue() -> Value { Value(self) }
 }
 
 @available(*, deprecated, message: "This API is experimental.")
 extension Double: ValueConvertible {
   /// Converts the `Double` into a `Value`.
-  public func objcValue() -> Value { Value(self) }
+  public func asValue() -> Value { Value(self) }
 }
 
 @available(*, deprecated, message: "This API is experimental.")
 extension Bool: ValueConvertible {
   /// Converts the `Bool` into a `Value`.
-  public func objcValue() -> Value { Value(self) }
+  public func asValue() -> Value { Value(self) }
 }
 
 @available(*, deprecated, message: "This API is experimental.")
 extension UInt16: ValueConvertible {
   /// Converts the `UInt16` into a `Value`.
-  public func objcValue() -> Value { Value(NSNumber(value: self)) }
+  public func asValue() -> Value { Value(NSNumber(value: self)) }
 }
 
 @available(*, deprecated, message: "This API is experimental.")
 extension UInt32: ValueConvertible {
   /// Converts the `UInt32` into a `Value`.
-  public func objcValue() -> Value { Value(NSNumber(value: self)) }
+  public func asValue() -> Value { Value(NSNumber(value: self)) }
 }
 
 @available(*, deprecated, message: "This API is experimental.")
 extension UInt64: ValueConvertible {
   /// Converts the `UInt64` into a `Value`.
-  public func objcValue() -> Value { Value(NSNumber(value: self)) }
+  public func asValue() -> Value { Value(NSNumber(value: self)) }
 }
 
 @available(*, deprecated, message: "This API is experimental.")
 extension UInt: ValueConvertible {
   /// Converts the `UInt` into a `Value`.
-  public func objcValue() -> Value { Value(NSNumber(value: self)) }
+  public func asValue() -> Value { Value(NSNumber(value: self)) }
 }

--- a/extension/apple/ExecuTorch/Exported/ExecuTorchTensor.h
+++ b/extension/apple/ExecuTorch/Exported/ExecuTorchTensor.h
@@ -81,7 +81,7 @@ NSInteger ExecuTorchSizeOfDataType(ExecuTorchDataType dataType)
 FOUNDATION_EXPORT
 __attribute__((deprecated("This API is experimental.")))
 NSInteger ExecuTorchElementCountOfShape(NSArray<NSNumber *> *shape)
-    NS_SWIFT_NAME(elementCount(ofShape:));
+    NS_REFINED_FOR_SWIFT;
 
 /**
  * A tensor class for ExecuTorch operations.
@@ -89,7 +89,7 @@ NSInteger ExecuTorchElementCountOfShape(NSArray<NSNumber *> *shape)
  * This class encapsulates a native TensorPtr instance and provides a variety of
  * initializers and utility methods to work with tensor data.
  */
-NS_REFINED_FOR_SWIFT
+ NS_SWIFT_NAME(AnyTensor)
 __attribute__((deprecated("This API is experimental.")))
 @interface ExecuTorchTensor : NSObject<NSCopying>
 
@@ -112,21 +112,21 @@ __attribute__((deprecated("This API is experimental.")))
  *
  * @return An NSArray of NSNumber objects representing the size of each dimension.
  */
-@property(nonatomic, readonly) NSArray<NSNumber *> *shape;
+@property(nonatomic, readonly) NSArray<NSNumber *> *shape NS_REFINED_FOR_SWIFT;
 
 /**
  * The order of dimensions in the tensor.
  *
  * @return An NSArray of NSNumber objects representing the tensor’s dimension order.
  */
-@property(nonatomic, readonly) NSArray<NSNumber *> *dimensionOrder;
+@property(nonatomic, readonly) NSArray<NSNumber *> *dimensionOrder NS_REFINED_FOR_SWIFT;
 
 /**
  * The strides of the tensor.
  *
  * @return An NSArray of NSNumber objects representing the step sizes for each dimension.
  */
-@property(nonatomic, readonly) NSArray<NSNumber *> *strides;
+@property(nonatomic, readonly) NSArray<NSNumber *> *strides NS_REFINED_FOR_SWIFT;
 
 /**
  * The dynamism of the tensor's shape.
@@ -140,7 +140,7 @@ __attribute__((deprecated("This API is experimental.")))
  *
  * @return An NSInteger representing the total element count.
  */
-@property(nonatomic, readonly) NSInteger count;
+@property(nonatomic, readonly) NSInteger count NS_REFINED_FOR_SWIFT;
 
 /**
  * Initializes a tensor with a native TensorPtr instance.
@@ -149,7 +149,8 @@ __attribute__((deprecated("This API is experimental.")))
  * @return An initialized ExecuTorchTensor instance.
  */
 - (instancetype)initWithNativeInstance:(void *)nativeInstance
-    NS_DESIGNATED_INITIALIZER NS_SWIFT_UNAVAILABLE("");
+    NS_DESIGNATED_INITIALIZER
+    NS_SWIFT_UNAVAILABLE("");
 
 /**
  * Creates a new tensor that shares the underlying data storage with the
@@ -200,7 +201,7 @@ __attribute__((deprecated("This API is experimental.")))
  */
 - (BOOL)resizeToShape:(NSArray<NSNumber *> *)shape
                 error:(NSError **)error
-    NS_SWIFT_NAME(resize(to:));
+    NS_REFINED_FOR_SWIFT;
 
 /**
  * Determines whether the current tensor is equal to another tensor.
@@ -209,7 +210,8 @@ __attribute__((deprecated("This API is experimental.")))
  * @return YES if the tensors have the same data type, shape, dimension order,
  * strides, and underlying data; otherwise, NO.
  */
-- (BOOL)isEqualToTensor:(nullable ExecuTorchTensor *)other;
+- (BOOL)isEqualToTensor:(nullable ExecuTorchTensor *)other
+    NS_REFINED_FOR_SWIFT;
 
 + (instancetype)new NS_UNAVAILABLE;
 - (instancetype)init NS_UNAVAILABLE;
@@ -236,7 +238,8 @@ __attribute__((deprecated("This API is experimental.")))
                             strides:(NSArray<NSNumber *> *)strides
                      dimensionOrder:(NSArray<NSNumber *> *)dimensionOrder
                            dataType:(ExecuTorchDataType)dataType
-                      shapeDynamism:(ExecuTorchShapeDynamism)shapeDynamism;
+                      shapeDynamism:(ExecuTorchShapeDynamism)shapeDynamism
+    NS_REFINED_FOR_SWIFT;
 
 /**
  * Initializes a tensor without copying data using dynamic bound shape (default strides and dimension order).
@@ -252,7 +255,8 @@ __attribute__((deprecated("This API is experimental.")))
                               shape:(NSArray<NSNumber *> *)shape
                             strides:(NSArray<NSNumber *> *)strides
                      dimensionOrder:(NSArray<NSNumber *> *)dimensionOrder
-                           dataType:(ExecuTorchDataType)dataType;
+                           dataType:(ExecuTorchDataType)dataType
+    NS_SWIFT_UNAVAILABLE("");
 
 /**
  * Initializes a tensor without copying data, with an explicit shape dynamism.
@@ -266,7 +270,8 @@ __attribute__((deprecated("This API is experimental.")))
 - (instancetype)initWithBytesNoCopy:(void *)pointer
                               shape:(NSArray<NSNumber *> *)shape
                            dataType:(ExecuTorchDataType)dataType
-                      shapeDynamism:(ExecuTorchShapeDynamism)shapeDynamism;
+                      shapeDynamism:(ExecuTorchShapeDynamism)shapeDynamism
+    NS_SWIFT_UNAVAILABLE("");
 
 /**
  * Initializes a tensor without copying data, specifying only the shape and data type.
@@ -278,7 +283,8 @@ __attribute__((deprecated("This API is experimental.")))
  */
 - (instancetype)initWithBytesNoCopy:(void *)pointer
                               shape:(NSArray<NSNumber *> *)shape
-                           dataType:(ExecuTorchDataType)dataType;
+                           dataType:(ExecuTorchDataType)dataType
+    NS_SWIFT_UNAVAILABLE("");
 
 @end
 
@@ -302,7 +308,8 @@ __attribute__((deprecated("This API is experimental.")))
                       strides:(NSArray<NSNumber *> *)strides
                dimensionOrder:(NSArray<NSNumber *> *)dimensionOrder
                      dataType:(ExecuTorchDataType)dataType
-                shapeDynamism:(ExecuTorchShapeDynamism)shapeDynamism;
+                shapeDynamism:(ExecuTorchShapeDynamism)shapeDynamism
+    NS_REFINED_FOR_SWIFT;
 
 /**
  * Initializes a tensor by copying bytes from the provided pointer with dynamic bound shape.
@@ -318,7 +325,8 @@ __attribute__((deprecated("This API is experimental.")))
                         shape:(NSArray<NSNumber *> *)shape
                       strides:(NSArray<NSNumber *> *)strides
                dimensionOrder:(NSArray<NSNumber *> *)dimensionOrder
-                     dataType:(ExecuTorchDataType)dataType;
+                     dataType:(ExecuTorchDataType)dataType
+    NS_SWIFT_UNAVAILABLE("");
 
 /**
  * Initializes a tensor by copying bytes from the provided pointer, specifying shape, data type, and explicit shape dynamism.
@@ -332,7 +340,8 @@ __attribute__((deprecated("This API is experimental.")))
 - (instancetype)initWithBytes:(const void *)pointer
                         shape:(NSArray<NSNumber *> *)shape
                      dataType:(ExecuTorchDataType)dataType
-                shapeDynamism:(ExecuTorchShapeDynamism)shapeDynamism;
+                shapeDynamism:(ExecuTorchShapeDynamism)shapeDynamism
+    NS_SWIFT_UNAVAILABLE("");
 
 /**
  * Initializes a tensor by copying bytes from the provided pointer, specifying only the shape and data type.
@@ -344,7 +353,8 @@ __attribute__((deprecated("This API is experimental.")))
  */
 - (instancetype)initWithBytes:(const void *)pointer
                         shape:(NSArray<NSNumber *> *)shape
-                     dataType:(ExecuTorchDataType)dataType;
+                     dataType:(ExecuTorchDataType)dataType
+    NS_SWIFT_UNAVAILABLE("");
 
 @end
 
@@ -370,7 +380,8 @@ __attribute__((deprecated("This API is experimental.")))
                      strides:(NSArray<NSNumber *> *)strides
               dimensionOrder:(NSArray<NSNumber *> *)dimensionOrder
                     dataType:(ExecuTorchDataType)dataType
-               shapeDynamism:(ExecuTorchShapeDynamism)shapeDynamism;
+               shapeDynamism:(ExecuTorchShapeDynamism)shapeDynamism
+    NS_REFINED_FOR_SWIFT;
 
 /**
  * Initializes a tensor using an NSData object as the underlying data buffer with dynamic bound shape.
@@ -386,7 +397,8 @@ __attribute__((deprecated("This API is experimental.")))
                        shape:(NSArray<NSNumber *> *)shape
                      strides:(NSArray<NSNumber *> *)strides
               dimensionOrder:(NSArray<NSNumber *> *)dimensionOrder
-                    dataType:(ExecuTorchDataType)dataType;
+                    dataType:(ExecuTorchDataType)dataType
+    NS_SWIFT_UNAVAILABLE("");
 
 /**
  * Initializes a tensor using an NSData object as the underlying data buffer, specifying shape, data type, and explicit shape dynamism.
@@ -400,7 +412,8 @@ __attribute__((deprecated("This API is experimental.")))
 - (instancetype)initWithData:(NSData *)data
                        shape:(NSArray<NSNumber *> *)shape
                     dataType:(ExecuTorchDataType)dataType
-               shapeDynamism:(ExecuTorchShapeDynamism)shapeDynamism;
+               shapeDynamism:(ExecuTorchShapeDynamism)shapeDynamism
+    NS_SWIFT_UNAVAILABLE("");
 
 /**
  * Initializes a tensor using an NSData object as the underlying data buffer, specifying only the shape and data type.
@@ -412,7 +425,8 @@ __attribute__((deprecated("This API is experimental.")))
  */
 - (instancetype)initWithData:(NSData *)data
                        shape:(NSArray<NSNumber *> *)shape
-                    dataType:(ExecuTorchDataType)dataType;
+                    dataType:(ExecuTorchDataType)dataType
+    NS_SWIFT_UNAVAILABLE("");
 
 @end
 
@@ -437,7 +451,7 @@ __attribute__((deprecated("This API is experimental.")))
                  dimensionOrder:(NSArray<NSNumber *> *)dimensionOrder
                        dataType:(ExecuTorchDataType)dataType
                   shapeDynamism:(ExecuTorchShapeDynamism)shapeDynamism
-    NS_SWIFT_NAME(init(_:shape:strides:dimensionOrder:dataType:shapeDynamism:));
+    NS_SWIFT_UNAVAILABLE("");
 
 /**
  * Initializes a tensor with an array of scalar values, specifying shape, strides, dimension order, and data type,
@@ -455,7 +469,7 @@ __attribute__((deprecated("This API is experimental.")))
                         strides:(NSArray<NSNumber *> *)strides
                  dimensionOrder:(NSArray<NSNumber *> *)dimensionOrder
                        dataType:(ExecuTorchDataType)dataType
-    NS_SWIFT_NAME(init(_:shape:strides:dimensionOrder:dataType:));
+    NS_SWIFT_UNAVAILABLE("");
 
 /**
  * Initializes a tensor with an array of scalar values, specifying the desired shape, data type, and explicit shape dynamism.
@@ -470,7 +484,7 @@ __attribute__((deprecated("This API is experimental.")))
                           shape:(NSArray<NSNumber *> *)shape
                        dataType:(ExecuTorchDataType)dataType
                   shapeDynamism:(ExecuTorchShapeDynamism)shapeDynamism
-    NS_SWIFT_NAME(init(_:shape:dataType:shapeDynamism:));
+    NS_SWIFT_UNAVAILABLE("");
 
 /**
  * Initializes a tensor with an array of scalar values and a specified shape,
@@ -484,7 +498,7 @@ __attribute__((deprecated("This API is experimental.")))
 - (instancetype)initWithScalars:(NSArray<NSNumber *> *)scalars
                           shape:(NSArray<NSNumber *> *)shape
                        dataType:(ExecuTorchDataType)dataType
-    NS_SWIFT_NAME(init(_:shape:dataType:));
+    NS_SWIFT_UNAVAILABLE("");
 
 /**
  * Initializes a tensor with an array of scalar values, specifying the tensor data type and explicit shape dynamism.
@@ -498,7 +512,7 @@ __attribute__((deprecated("This API is experimental.")))
 - (instancetype)initWithScalars:(NSArray<NSNumber *> *)scalars
                        dataType:(ExecuTorchDataType)dataType
                   shapeDynamism:(ExecuTorchShapeDynamism)shapeDynamism
-    NS_SWIFT_NAME(init(_:dataType:shapeDynamism:));
+    NS_SWIFT_UNAVAILABLE("");
 
 /**
  * Initializes a tensor with an array of scalar values, specifying the tensor data type.
@@ -510,7 +524,7 @@ __attribute__((deprecated("This API is experimental.")))
  */
 - (instancetype)initWithScalars:(NSArray<NSNumber *> *)scalars
                        dataType:(ExecuTorchDataType)dataType
-    NS_SWIFT_NAME(init(_:dataType:));
+    NS_SWIFT_UNAVAILABLE("");
 
 /**
  * Initializes a tensor with an array of scalar values, a specified shape and explicit shape dynamism.
@@ -524,7 +538,7 @@ __attribute__((deprecated("This API is experimental.")))
 - (instancetype)initWithScalars:(NSArray<NSNumber *> *)scalars
                           shape:(NSArray<NSNumber *> *)shape
                   shapeDynamism:(ExecuTorchShapeDynamism)shapeDynamism
-    NS_SWIFT_NAME(init(_:shape:shapeDynamism:));
+    NS_SWIFT_UNAVAILABLE("");
 
 /**
  * Initializes a tensor with an array of scalar values and a specified shape.
@@ -536,7 +550,7 @@ __attribute__((deprecated("This API is experimental.")))
  */
 - (instancetype)initWithScalars:(NSArray<NSNumber *> *)scalars
                           shape:(NSArray<NSNumber *> *)shape
-    NS_SWIFT_NAME(init(_:shape:));
+    NS_SWIFT_UNAVAILABLE("");
 
 /**
  * Initializes a tensor with an array of scalar values, automatically deducing the tensor shape and data type.
@@ -545,7 +559,7 @@ __attribute__((deprecated("This API is experimental.")))
  * @return An initialized ExecuTorchTensor instance with shape and data type deduced.
  */
 - (instancetype)initWithScalars:(NSArray<NSNumber *> *)scalars
-    NS_SWIFT_NAME(init(_:));
+    NS_SWIFT_UNAVAILABLE("");
 
 @end
 
@@ -559,7 +573,8 @@ __attribute__((deprecated("This API is experimental.")))
  * @return An initialized ExecuTorchTensor instance representing the scalar.
  */
 - (instancetype)initWithScalar:(NSNumber *)scalar
-                      dataType:(ExecuTorchDataType)dataType NS_SWIFT_NAME(init(_:dataType:));
+                      dataType:(ExecuTorchDataType)dataType
+    NS_REFINED_FOR_SWIFT;
 
 /**
  * Initializes a tensor with a single scalar value, automatically deducing its data type.
@@ -567,7 +582,8 @@ __attribute__((deprecated("This API is experimental.")))
  * @param scalar An NSNumber representing the scalar value.
  * @return An initialized ExecuTorchTensor instance representing the scalar.
  */
-- (instancetype)initWithScalar:(NSNumber *)scalar NS_SWIFT_NAME(init(_:));
+- (instancetype)initWithScalar:(NSNumber *)scalar
+    NS_SWIFT_UNAVAILABLE("");
 
 /** 
  * Initializes a tensor with a byte scalar value.
@@ -575,7 +591,8 @@ __attribute__((deprecated("This API is experimental.")))
  * @param scalar A uint8_t value.
  * @return An initialized ExecuTorchTensor instance.
  */
-- (instancetype)initWithByte:(uint8_t)scalar NS_SWIFT_NAME(init(_:));
+- (instancetype)initWithByte:(uint8_t)scalar
+    NS_SWIFT_UNAVAILABLE("");
 
 /** 
  * Initializes a tensor with a char scalar value.
@@ -583,7 +600,8 @@ __attribute__((deprecated("This API is experimental.")))
  * @param scalar An int8_t value.
  * @return An initialized ExecuTorchTensor instance.
  */
-- (instancetype)initWithChar:(int8_t)scalar NS_SWIFT_NAME(init(_:));
+- (instancetype)initWithChar:(int8_t)scalar
+    NS_SWIFT_UNAVAILABLE("");
 
 /** 
  * Initializes a tensor with a short scalar value.
@@ -591,7 +609,8 @@ __attribute__((deprecated("This API is experimental.")))
  * @param scalar An int16_t value.
  * @return An initialized ExecuTorchTensor instance.
  */
-- (instancetype)initWithShort:(int16_t)scalar NS_SWIFT_NAME(init(_:));
+- (instancetype)initWithShort:(int16_t)scalar
+    NS_SWIFT_UNAVAILABLE("");
 
 /** 
  * Initializes a tensor with an int scalar value.
@@ -599,7 +618,8 @@ __attribute__((deprecated("This API is experimental.")))
  * @param scalar An int32_t value.
  * @return An initialized ExecuTorchTensor instance.
  */
-- (instancetype)initWithInt:(int32_t)scalar NS_SWIFT_NAME(init(_:));
+- (instancetype)initWithInt:(int32_t)scalar
+    NS_SWIFT_UNAVAILABLE("");
 
 /** 
  * Initializes a tensor with a long scalar value.
@@ -607,7 +627,8 @@ __attribute__((deprecated("This API is experimental.")))
  * @param scalar An int64_t value.
  * @return An initialized ExecuTorchTensor instance.
  */
-- (instancetype)initWithLong:(int64_t)scalar NS_SWIFT_NAME(init(_:));
+- (instancetype)initWithLong:(int64_t)scalar
+    NS_SWIFT_UNAVAILABLE("");
 
 /** 
  * Initializes a tensor with a float scalar value.
@@ -615,7 +636,8 @@ __attribute__((deprecated("This API is experimental.")))
  * @param scalar A float value.
  * @return An initialized ExecuTorchTensor instance.
  */
-- (instancetype)initWithFloat:(float)scalar NS_SWIFT_NAME(init(_:));
+- (instancetype)initWithFloat:(float)scalar
+    NS_SWIFT_UNAVAILABLE("");
 
 /** 
  * Initializes a tensor with a double scalar value.
@@ -623,7 +645,8 @@ __attribute__((deprecated("This API is experimental.")))
  * @param scalar A double value.
  * @return An initialized ExecuTorchTensor instance.
  */
-- (instancetype)initWithDouble:(double)scalar NS_SWIFT_NAME(init(_:));
+- (instancetype)initWithDouble:(double)scalar
+    NS_SWIFT_UNAVAILABLE("");
 
 /** 
  * Initializes a tensor with a boolean scalar value.
@@ -631,7 +654,8 @@ __attribute__((deprecated("This API is experimental.")))
  * @param scalar A BOOL value.
  * @return An initialized ExecuTorchTensor instance.
  */
-- (instancetype)initWithBool:(BOOL)scalar NS_SWIFT_NAME(init(_:));
+- (instancetype)initWithBool:(BOOL)scalar
+    NS_SWIFT_UNAVAILABLE("");
 
 /** 
  * Initializes a tensor with a uint16 scalar value.
@@ -639,7 +663,8 @@ __attribute__((deprecated("This API is experimental.")))
  * @param scalar A uint16_t value.
  * @return An initialized ExecuTorchTensor instance.
  */
-- (instancetype)initWithUInt16:(uint16_t)scalar NS_SWIFT_NAME(init(_:));
+- (instancetype)initWithUInt16:(uint16_t)scalar
+    NS_SWIFT_NAME(init(_:));
 
 /** 
  * Initializes a tensor with a uint32 scalar value.
@@ -647,7 +672,8 @@ __attribute__((deprecated("This API is experimental.")))
  * @param scalar A uint32_t value.
  * @return An initialized ExecuTorchTensor instance.
  */
-- (instancetype)initWithUInt32:(uint32_t)scalar NS_SWIFT_NAME(init(_:));
+- (instancetype)initWithUInt32:(uint32_t)scalar
+    NS_SWIFT_NAME(init(_:));
 
 /** 
  * Initializes a tensor with a uint64 scalar value.
@@ -655,7 +681,8 @@ __attribute__((deprecated("This API is experimental.")))
  * @param scalar A uint64_t value.
  * @return An initialized ExecuTorchTensor instance.
  */
-- (instancetype)initWithUInt64:(uint64_t)scalar NS_SWIFT_NAME(init(_:));
+- (instancetype)initWithUInt64:(uint64_t)scalar
+    NS_SWIFT_NAME(init(_:));
 
 /** 
  * Initializes a tensor with an NSInteger scalar value.
@@ -663,7 +690,8 @@ __attribute__((deprecated("This API is experimental.")))
  * @param scalar An NSInteger value.
  * @return An initialized ExecuTorchTensor instance.
  */
-- (instancetype)initWithInteger:(NSInteger)scalar NS_SWIFT_NAME(init(_:));
+- (instancetype)initWithInteger:(NSInteger)scalar
+    NS_SWIFT_NAME(init(_:));
 
 /** 
  * Initializes a tensor with an NSUInteger scalar value.
@@ -671,7 +699,8 @@ __attribute__((deprecated("This API is experimental.")))
  * @param scalar An NSUInteger value.
  * @return An initialized ExecuTorchTensor instance.
  */
-- (instancetype)initWithUnsignedInteger:(NSUInteger)scalar NS_SWIFT_NAME(init(_:));
+- (instancetype)initWithUnsignedInteger:(NSUInteger)scalar
+    NS_SWIFT_NAME(init(_:));
 
 @end
 
@@ -692,7 +721,7 @@ __attribute__((deprecated("This API is experimental.")))
                              strides:(NSArray<NSNumber *> *)strides
                             dataType:(ExecuTorchDataType)dataType
                        shapeDynamism:(ExecuTorchShapeDynamism)shapeDynamism
-    NS_SWIFT_NAME(empty(shape:strides:dataType:shapeDynamism:))
+    NS_REFINED_FOR_SWIFT
     NS_RETURNS_RETAINED;
 
 /**
@@ -706,7 +735,7 @@ __attribute__((deprecated("This API is experimental.")))
 + (instancetype)emptyTensorWithShape:(NSArray<NSNumber *> *)shape
                             dataType:(ExecuTorchDataType)dataType
                        shapeDynamism:(ExecuTorchShapeDynamism)shapeDynamism
-    NS_SWIFT_NAME(empty(shape:dataType:shapeDynamism:))
+    NS_SWIFT_UNAVAILABLE("")
     NS_RETURNS_RETAINED;
 
 /**
@@ -718,7 +747,7 @@ __attribute__((deprecated("This API is experimental.")))
  */
 + (instancetype)emptyTensorWithShape:(NSArray<NSNumber *> *)shape
                             dataType:(ExecuTorchDataType)dataType
-    NS_SWIFT_NAME(empty(shape:dataType:))
+    NS_SWIFT_UNAVAILABLE("")
     NS_RETURNS_RETAINED;
 
 /**
@@ -732,7 +761,7 @@ __attribute__((deprecated("This API is experimental.")))
 + (instancetype)emptyTensorLikeTensor:(ExecuTorchTensor *)tensor
                              dataType:(ExecuTorchDataType)dataType
                         shapeDynamism:(ExecuTorchShapeDynamism)shapeDynamism
-    NS_SWIFT_NAME(empty(like:dataType:shapeDynamism:))
+    NS_REFINED_FOR_SWIFT
     NS_RETURNS_RETAINED;
 
 /**
@@ -744,7 +773,7 @@ __attribute__((deprecated("This API is experimental.")))
  */
 + (instancetype)emptyTensorLikeTensor:(ExecuTorchTensor *)tensor
                              dataType:(ExecuTorchDataType)dataType
-    NS_SWIFT_NAME(empty(like:dataType:))
+    NS_SWIFT_UNAVAILABLE("")
     NS_RETURNS_RETAINED;
 
 /**
@@ -754,7 +783,7 @@ __attribute__((deprecated("This API is experimental.")))
  * @return A new, empty ExecuTorchTensor instance with the same properties as the provided tensor.
  */
 + (instancetype)emptyTensorLikeTensor:(ExecuTorchTensor *)tensor
-    NS_SWIFT_NAME(empty(like:))
+    NS_SWIFT_UNAVAILABLE("")
     NS_RETURNS_RETAINED;
 
 @end
@@ -778,7 +807,7 @@ __attribute__((deprecated("This API is experimental.")))
                             strides:(NSArray<NSNumber *> *)strides
                            dataType:(ExecuTorchDataType)dataType
                       shapeDynamism:(ExecuTorchShapeDynamism)shapeDynamism
-    NS_SWIFT_NAME(full(shape:scalar:strides:dataType:shapeDynamism:))
+    NS_REFINED_FOR_SWIFT
     NS_RETURNS_RETAINED;
 
 /**
@@ -794,7 +823,7 @@ __attribute__((deprecated("This API is experimental.")))
                              scalar:(NSNumber *)scalar
                            dataType:(ExecuTorchDataType)dataType
                       shapeDynamism:(ExecuTorchShapeDynamism)shapeDynamism
-    NS_SWIFT_NAME(full(shape:scalar:dataType:shapeDynamism:))
+    NS_SWIFT_UNAVAILABLE("")
     NS_RETURNS_RETAINED;
 
 /**
@@ -809,7 +838,7 @@ __attribute__((deprecated("This API is experimental.")))
 + (instancetype)fullTensorWithShape:(NSArray<NSNumber *> *)shape
                              scalar:(NSNumber *)scalar
                            dataType:(ExecuTorchDataType)dataType
-    NS_SWIFT_NAME(full(shape:scalar:dataType:))
+    NS_SWIFT_UNAVAILABLE("")
     NS_RETURNS_RETAINED;
 
 /**
@@ -825,7 +854,7 @@ __attribute__((deprecated("This API is experimental.")))
                               scalar:(NSNumber *)scalar
                             dataType:(ExecuTorchDataType)dataType
                        shapeDynamism:(ExecuTorchShapeDynamism)shapeDynamism
-    NS_SWIFT_NAME(full(like:scalar:dataType:shapeDynamism:))
+    NS_REFINED_FOR_SWIFT
     NS_RETURNS_RETAINED;
 
 /**
@@ -839,7 +868,7 @@ __attribute__((deprecated("This API is experimental.")))
 + (instancetype)fullTensorLikeTensor:(ExecuTorchTensor *)tensr
                               scalar:(NSNumber *)scalar
                             dataType:(ExecuTorchDataType)dataType
-    NS_SWIFT_NAME(full(like:scalar:dataType:))
+    NS_SWIFT_UNAVAILABLE("")
     NS_RETURNS_RETAINED;
 
 /**
@@ -851,7 +880,7 @@ __attribute__((deprecated("This API is experimental.")))
  */
 + (instancetype)fullTensorLikeTensor:(ExecuTorchTensor *)tensr
                               scalar:(NSNumber *)scalar
-    NS_SWIFT_NAME(full(like:scalar:))
+    NS_SWIFT_UNAVAILABLE("")
     NS_RETURNS_RETAINED;
 
 @end
@@ -871,7 +900,7 @@ __attribute__((deprecated("This API is experimental.")))
 + (instancetype)onesTensorWithShape:(NSArray<NSNumber *> *)shape
                            dataType:(ExecuTorchDataType)dataType
                       shapeDynamism:(ExecuTorchShapeDynamism)shapeDynamism
-    NS_SWIFT_NAME(ones(shape:dataType:shapeDynamism:))
+    NS_REFINED_FOR_SWIFT
     NS_RETURNS_RETAINED;
 
 /**
@@ -883,7 +912,7 @@ __attribute__((deprecated("This API is experimental.")))
  */
 + (instancetype)onesTensorWithShape:(NSArray<NSNumber *> *)shape
                            dataType:(ExecuTorchDataType)dataType
-    NS_SWIFT_NAME(ones(shape:dataType:))
+    NS_SWIFT_UNAVAILABLE("")
     NS_RETURNS_RETAINED;
 
 /**
@@ -897,7 +926,7 @@ __attribute__((deprecated("This API is experimental.")))
 + (instancetype)onesTensorLikeTensor:(ExecuTorchTensor *)tensor
                             dataType:(ExecuTorchDataType)dataType
                        shapeDynamism:(ExecuTorchShapeDynamism)shapeDynamism
-    NS_SWIFT_NAME(ones(like:dataType:shapeDynamism:))
+    NS_REFINED_FOR_SWIFT
     NS_RETURNS_RETAINED;
 
 /**
@@ -909,7 +938,7 @@ __attribute__((deprecated("This API is experimental.")))
  */
 + (instancetype)onesTensorLikeTensor:(ExecuTorchTensor *)tensor
                             dataType:(ExecuTorchDataType)dataType
-    NS_SWIFT_NAME(ones(like:dataType:))
+    NS_SWIFT_UNAVAILABLE("")
     NS_RETURNS_RETAINED;
 
 /**
@@ -919,7 +948,7 @@ __attribute__((deprecated("This API is experimental.")))
  * @return A new ExecuTorchTensor instance filled with ones.
  */
 + (instancetype)onesTensorLikeTensor:(ExecuTorchTensor *)tensor
-    NS_SWIFT_NAME(ones(like:))
+    NS_SWIFT_UNAVAILABLE("")
     NS_RETURNS_RETAINED;
 
 @end
@@ -939,7 +968,7 @@ __attribute__((deprecated("This API is experimental.")))
 + (instancetype)zerosTensorWithShape:(NSArray<NSNumber *> *)shape
                             dataType:(ExecuTorchDataType)dataType
                        shapeDynamism:(ExecuTorchShapeDynamism)shapeDynamism
-    NS_SWIFT_NAME(zeros(shape:dataType:shapeDynamism:))
+    NS_REFINED_FOR_SWIFT
     NS_RETURNS_RETAINED;
 
 /**
@@ -951,7 +980,7 @@ __attribute__((deprecated("This API is experimental.")))
  */
 + (instancetype)zerosTensorWithShape:(NSArray<NSNumber *> *)shape
                             dataType:(ExecuTorchDataType)dataType
-    NS_SWIFT_NAME(zeros(shape:dataType:))
+    NS_SWIFT_UNAVAILABLE("")
     NS_RETURNS_RETAINED;
 
 /**
@@ -965,7 +994,7 @@ __attribute__((deprecated("This API is experimental.")))
 + (instancetype)zerosTensorLikeTensor:(ExecuTorchTensor *)tensor
                              dataType:(ExecuTorchDataType)dataType
                         shapeDynamism:(ExecuTorchShapeDynamism)shapeDynamism
-    NS_SWIFT_NAME(zeros(like:dataType:shapeDynamism:))
+    NS_REFINED_FOR_SWIFT
     NS_RETURNS_RETAINED;
 
 /**
@@ -977,7 +1006,7 @@ __attribute__((deprecated("This API is experimental.")))
  */
 + (instancetype)zerosTensorLikeTensor:(ExecuTorchTensor *)tensor
                              dataType:(ExecuTorchDataType)dataType
-    NS_SWIFT_NAME(zeros(like:dataType:))
+    NS_SWIFT_UNAVAILABLE("")
     NS_RETURNS_RETAINED;
 
 /**
@@ -987,7 +1016,7 @@ __attribute__((deprecated("This API is experimental.")))
  * @return A new ExecuTorchTensor instance filled with zeros.
  */
 + (instancetype)zerosTensorLikeTensor:(ExecuTorchTensor *)tensor
-    NS_SWIFT_NAME(zeros(like:))
+    NS_SWIFT_UNAVAILABLE("")
     NS_RETURNS_RETAINED;
 
 @end
@@ -1009,7 +1038,7 @@ __attribute__((deprecated("This API is experimental.")))
                               strides:(NSArray<NSNumber *> *)strides
                              dataType:(ExecuTorchDataType)dataType
                         shapeDynamism:(ExecuTorchShapeDynamism)shapeDynamism
-    NS_SWIFT_NAME(rand(shape:strides:dataType:shapeDynamism:))
+    NS_REFINED_FOR_SWIFT
     NS_RETURNS_RETAINED;
 
 /**
@@ -1023,7 +1052,7 @@ __attribute__((deprecated("This API is experimental.")))
 + (instancetype)randomTensorWithShape:(NSArray<NSNumber *> *)shape
                              dataType:(ExecuTorchDataType)dataType
                         shapeDynamism:(ExecuTorchShapeDynamism)shapeDynamism
-    NS_SWIFT_NAME(rand(shape:dataType:shapeDynamism:))
+    NS_SWIFT_UNAVAILABLE("")
     NS_RETURNS_RETAINED;
 
 /**
@@ -1035,7 +1064,7 @@ __attribute__((deprecated("This API is experimental.")))
  */
 + (instancetype)randomTensorWithShape:(NSArray<NSNumber *> *)shape
                              dataType:(ExecuTorchDataType)dataType
-    NS_SWIFT_NAME(rand(shape:dataType:))
+    NS_SWIFT_UNAVAILABLE("")
     NS_RETURNS_RETAINED;
 
 /**
@@ -1049,7 +1078,7 @@ __attribute__((deprecated("This API is experimental.")))
 + (instancetype)randomTensorLikeTensor:(ExecuTorchTensor *)tensor
                               dataType:(ExecuTorchDataType)dataType
                          shapeDynamism:(ExecuTorchShapeDynamism)shapeDynamism
-    NS_SWIFT_NAME(rand(like:dataType:shapeDynamism:))
+    NS_REFINED_FOR_SWIFT
     NS_RETURNS_RETAINED;
 
 /**
@@ -1061,7 +1090,7 @@ __attribute__((deprecated("This API is experimental.")))
  */
 + (instancetype)randomTensorLikeTensor:(ExecuTorchTensor *)tensor
                               dataType:(ExecuTorchDataType)dataType
-    NS_SWIFT_NAME(rand(like:dataType:))
+    NS_SWIFT_UNAVAILABLE("")
     NS_RETURNS_RETAINED;
 
 /**
@@ -1071,7 +1100,7 @@ __attribute__((deprecated("This API is experimental.")))
  * @return A new ExecuTorchTensor instance filled with random values.
  */
 + (instancetype)randomTensorLikeTensor:(ExecuTorchTensor *)tensor
-    NS_SWIFT_NAME(rand(like:))
+    NS_SWIFT_UNAVAILABLE("")
     NS_RETURNS_RETAINED;
 
 @end
@@ -1094,7 +1123,7 @@ __attribute__((deprecated("This API is experimental.")))
                                     strides:(NSArray<NSNumber *> *)strides
                                    dataType:(ExecuTorchDataType)dataType
                               shapeDynamism:(ExecuTorchShapeDynamism)shapeDynamism
-    NS_SWIFT_NAME(randn(shape:strides:dataType:shapeDynamism:))
+    NS_REFINED_FOR_SWIFT
     NS_RETURNS_RETAINED;
 
 /**
@@ -1109,7 +1138,7 @@ __attribute__((deprecated("This API is experimental.")))
 + (instancetype)randomNormalTensorWithShape:(NSArray<NSNumber *> *)shape
                                    dataType:(ExecuTorchDataType)dataType
                               shapeDynamism:(ExecuTorchShapeDynamism)shapeDynamism
-    NS_SWIFT_NAME(randn(shape:dataType:shapeDynamism:))
+    NS_SWIFT_UNAVAILABLE("")
     NS_RETURNS_RETAINED;
 
 /**
@@ -1122,7 +1151,7 @@ __attribute__((deprecated("This API is experimental.")))
  */
 + (instancetype)randomNormalTensorWithShape:(NSArray<NSNumber *> *)shape
                                    dataType:(ExecuTorchDataType)dataType
-    NS_SWIFT_NAME(randn(shape:dataType:))
+    NS_SWIFT_UNAVAILABLE("")
     NS_RETURNS_RETAINED;
 
 /**
@@ -1137,7 +1166,7 @@ __attribute__((deprecated("This API is experimental.")))
 + (instancetype)randomNormalTensorLikeTensor:(ExecuTorchTensor *)tensor
                                     dataType:(ExecuTorchDataType)dataType
                                shapeDynamism:(ExecuTorchShapeDynamism)shapeDynamism
-    NS_SWIFT_NAME(randn(like:dataType:shapeDynamism:))
+    NS_REFINED_FOR_SWIFT
     NS_RETURNS_RETAINED;
 
 /**
@@ -1150,7 +1179,7 @@ __attribute__((deprecated("This API is experimental.")))
  */
 + (instancetype)randomNormalTensorLikeTensor:(ExecuTorchTensor *)tensor
                                     dataType:(ExecuTorchDataType)dataType
-    NS_SWIFT_NAME(randn(like:dataType:))
+    NS_SWIFT_UNAVAILABLE("")
     NS_RETURNS_RETAINED;
 
 /**
@@ -1160,7 +1189,7 @@ __attribute__((deprecated("This API is experimental.")))
  * @return A new ExecuTorchTensor instance filled with values from a normal distribution.
  */
 + (instancetype)randomNormalTensorLikeTensor:(ExecuTorchTensor *)tensor
-    NS_SWIFT_NAME(randn(like:))
+    NS_SWIFT_UNAVAILABLE("")
     NS_RETURNS_RETAINED;
 
 @end
@@ -1187,7 +1216,7 @@ __attribute__((deprecated("This API is experimental.")))
                                    strides:(NSArray<NSNumber *> *)strides
                                   dataType:(ExecuTorchDataType)dataType
                              shapeDynamism:(ExecuTorchShapeDynamism)shapeDynamism
-    NS_SWIFT_NAME(randint(low:high:shape:strides:dataType:shapeDynamism:))
+    NS_REFINED_FOR_SWIFT
     NS_RETURNS_RETAINED;
 
 /**
@@ -1206,7 +1235,7 @@ __attribute__((deprecated("This API is experimental.")))
                                      shape:(NSArray<NSNumber *> *)shape
                                   dataType:(ExecuTorchDataType)dataType
                              shapeDynamism:(ExecuTorchShapeDynamism)shapeDynamism
-    NS_SWIFT_NAME(randint(low:high:shape:dataType:shapeDynamism:))
+    NS_SWIFT_UNAVAILABLE("")
     NS_RETURNS_RETAINED;
 
 /**
@@ -1223,7 +1252,7 @@ __attribute__((deprecated("This API is experimental.")))
                                       high:(NSInteger)high
                                      shape:(NSArray<NSNumber *> *)shape
                                   dataType:(ExecuTorchDataType)dataType
-    NS_SWIFT_NAME(randint(low:high:shape:dataType:))
+    NS_SWIFT_UNAVAILABLE("")
     NS_RETURNS_RETAINED;
 
 /**
@@ -1242,7 +1271,7 @@ __attribute__((deprecated("This API is experimental.")))
                                          high:(NSInteger)high
                                      dataType:(ExecuTorchDataType)dataType
                                 shapeDynamism:(ExecuTorchShapeDynamism)shapeDynamism
-    NS_SWIFT_NAME(randint(like:low:high:dataType:shapeDynamism:))
+    NS_REFINED_FOR_SWIFT
     NS_RETURNS_RETAINED;
 
 /**
@@ -1259,7 +1288,7 @@ __attribute__((deprecated("This API is experimental.")))
                                           low:(NSInteger)low
                                          high:(NSInteger)high
                                      dataType:(ExecuTorchDataType)dataType
-    NS_SWIFT_NAME(randint(like:low:high:dataType:))
+    NS_SWIFT_UNAVAILABLE("")
     NS_RETURNS_RETAINED;
 
 /**
@@ -1273,7 +1302,7 @@ __attribute__((deprecated("This API is experimental.")))
 + (instancetype)randomIntegerTensorLikeTensor:(ExecuTorchTensor *)tensor
                                           low:(NSInteger)low
                                          high:(NSInteger)high
-    NS_SWIFT_NAME(randint(like:low:high:))
+    NS_SWIFT_UNAVAILABLE("")
     NS_RETURNS_RETAINED;
 
 @end

--- a/extension/apple/ExecuTorch/Exported/ExecuTorchValue.h
+++ b/extension/apple/ExecuTorch/Exported/ExecuTorchValue.h
@@ -174,7 +174,7 @@ __attribute__((deprecated("This API is experimental.")))
  * @return A new ExecuTorchValue instance with a tag of ExecuTorchValueTagTensor.
  */
 + (instancetype)valueWithTensor:(ExecuTorchTensor *)value
-    NS_REFINED_FOR_SWIFT
+    NS_SWIFT_NAME(init(_:))
     NS_RETURNS_RETAINED;
 
 /**


### PR DESCRIPTION
Summary: It's useful for cases when we want to specify the data type at runtime, e.g. create a random tensor based on some data type known at runtime only.

Reviewed By: bsoyluoglu

Differential Revision: D76908591
