### PR TITLE
Fix bug in sub op to ignore alpha != 1 (fixes: #11684)

### DIFF
--- a/backends/xnnpack/partition/config/generic_node_configs.py
+++ b/backends/xnnpack/partition/config/generic_node_configs.py
@@ -9,6 +9,7 @@
 import logging
 from typing import cast, List, Optional
 
+import numpy as np
 import torch
 from executorch.backends.xnnpack.partition.config.xnnpack_config import (
     ConfigPrecisionType,
@@ -522,6 +523,17 @@ class SubConfig(GenericNodePartitionerConfig):
 
     def supported_precision_types(self) -> List[ConfigPrecisionType]:
         return [ConfigPrecisionType.FP32, ConfigPrecisionType.STATIC_QUANT]
+
+    def check_constraints(self, node: torch.fx.Node, ep: ExportedProgram) -> bool:
+        if not self.check_common_constraints(node, ep):
+            return False
+        # No support for sub nodes with alpha != 1
+        if "alpha" in node.kwargs and not np.isclose(
+            node.kwargs["alpha"], 1.0, atol=1e-9, rtol=1e-9
+        ):
+            why(node, reason="Sub node doesn't support alpha != 1")
+            return False
+        return True
 
 
 class BMMConfig(GenericNodePartitionerConfig):


### PR DESCRIPTION
### Summary
Sub node of XNNPack backend doesn't consider alpha value, this fixes the bug by falling back to portable ops and avoid partitioning the node.

(fixes: #11684)

### Test plan
```
$ python -m unittest backends/xnnpack/test/ops/test_sub.py

Ran 3 tests in 7.262s

OK

```

### Model run
```
import torch
from executorch.backends.xnnpack.partition.xnnpack_partitioner import XnnpackPartitioner
from executorch.exir import to_edge_transform_and_lower
from executorch.extension.pybindings.portable_lib import _load_for_executorch_from_buffer

class Model(torch.nn.Module):
    def forward(self, x, y):
        return torch.sub(x, y, alpha=10)

inputs = (
    torch.randn(10),
    torch.randn(10),
)
model = Model()

ep = torch.export.export(model, inputs)
lowered = to_edge_transform_and_lower(
    ep,
    partitioner=[XnnpackPartitioner()],
).to_executorch()

et_model = _load_for_executorch_from_buffer(lowered.buffer)

eager_output = model(*inputs)
et_output = et_model([*inputs])[0]

tolerance=1e-5
if torch.allclose(eager_output, et_output, atol=tolerance):
    print("Outputs are within the tolerance level.")
else:
    print("Outputs differ beyond the tolerance level.")

```
### output
```
Outputs are within the tolerance level.
```
