### PR TITLE
Temporarily fix Moshi test

### DIFF
--- a/examples/models/moshi/mimi/install_requirements.sh
+++ b/examples/models/moshi/mimi/install_requirements.sh
@@ -7,7 +7,7 @@
 
 set -x
 
-pip install -U moshi
+pip install moshi==0.2.4
 pip install bitsandbytes soundfile
 # Run llama2/install requirements for torchao deps
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )


### PR DESCRIPTION
### Summary
Moshi 0.2.5 was released 13 hours ago, breaking our Moshi test which relies on some old code from 0.2.4. Not sure what the long term fix is, temporarily pinning Moshi to 0.2.4 to fix the test for now.
