### PR TITLE
Remove is_arvr_mode() from xplat/executorch/runtime/core/portable_type/c10/c10/targets.bzl

### DIFF
--- a/runtime/core/portable_type/c10/c10/targets.bzl
+++ b/runtime/core/portable_type/c10/c10/targets.bzl
@@ -78,9 +78,10 @@ def define_common_targets():
         xplat_exported_deps = [
             "//xplat/caffe2:aten_header",
             "//xplat/caffe2/c10:c10_headers",
-            ("//xplat/caffe2:ovrsource_aten_Config.h"
-            if is_arvr_mode() else "//xplat/caffe2:generated_aten_config_header"),
-        ] + get_sleef_deps(),
+        ] + select({
+            "DEFAULT": ["//xplat/caffe2:generated_aten_config_header"],
+            "ovr_config//build_mode:arvr_mode": ["//xplat/caffe2:ovrsource_aten_Config.h"],
+        }) + get_sleef_deps(),
         fbcode_exported_deps = ([
             "//caffe2:aten-headers-cpu",
             "//caffe2:generated-config-header",


### PR DESCRIPTION
Summary:
Remove is_arvr_mode() from fbcode/executorch/runtime/core/portable_type/c10/c10/targets.bzl.

This is an effort to unify the xplat and rl target graphs in the citadel orchestrator
See post for context https://fb.workplace.com/groups/3454295018049629/permalink/3734068433405618/

Reviewed By: autozimu

Differential Revision: D76755925


