### PR TITLE
pyre-fixmes for D75477355 - executorch

### DIFF
--- a/backends/cadence/aot/quantizer/patterns.py
+++ b/backends/cadence/aot/quantizer/patterns.py
@@ -109,6 +109,7 @@ class AddmmPattern(QuantizationPattern):
         )
 
     def replacement_op(self) -> OpOverload:
+        # pyre-fixme[7]: Expected `OpOverload` but got `OpOverloadPacket`.
         return torch.ops.cadence.quantized_linear
 
 


### PR DESCRIPTION
Summary: Additional pyre-fixmes needed by pytorch change D75477355 that weren't caught by diff-time CI.

Differential Revision: D77120307


