### PR TITLE
Add idma Fake operators for AoT.

### DIFF
--- a/backends/cadence/aot/TARGETS
+++ b/backends/cadence/aot/TARGETS
@@ -518,3 +518,16 @@ python_unittest(
         "//executorch/exir/tests:models",
     ],
 )
+
+python_unittest(
+    name = "test_idma_ops",
+    srcs = [
+        "tests/test_idma_ops.py",
+    ],
+    typing = True,
+    deps = [
+        "//executorch/backends/cadence/aot:graph_builder",
+        "//executorch/backends/cadence/aot:ops_registrations",
+        "//later:lib",
+    ],
+)

--- a/backends/cadence/aot/tests/test_idma_ops.py
+++ b/backends/cadence/aot/tests/test_idma_ops.py
@@ -1,0 +1,31 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+# pyre-strict
+
+import executorch.backends.cadence.aot.ops_registrations  # noqa
+import torch
+
+from executorch.backends.cadence.aot.graph_builder import GraphBuilder
+from executorch.exir.dialects._ops import ops as exir_ops
+
+from later.unittest import TestCase
+
+
+class TestIdmaOps(TestCase):
+    def test_idma_load_store_wait(self) -> None:
+        """Check that the idma load/store/wait ops are registered correctly."""
+        builder = GraphBuilder()
+        x = builder.placeholder("x", torch.ones(2, 7, dtype=torch.float32))
+        load = builder.call_operator(
+            op=exir_ops.edge.cadence.idma_load.default, args=(x,)
+        )
+        wait = builder.call_operator(
+            op=exir_ops.edge.cadence.idma_wait.default, args=(load,)
+        )
+        store = builder.call_operator(
+            op=exir_ops.edge.cadence.idma_store.default, args=(wait,)
+        )
+        wait2 = builder.call_operator(
+            op=exir_ops.edge.cadence.idma_wait.default, args=(store,)
+        )
+        builder.output([wait2])


### PR DESCRIPTION
Summary:
Add idma copy and wait op definitions + fake implementation. These can be used for asynchronous copy/wait.

idma_load: Used for `Any -> DTCM` data transfers. (Note: DTCM to DTCM is ok)
idma_store: Used for `DTCM -> Any` (similar to idma_load).

Since the above ops explicitly specify the direction of data transfer, we can use these to plan memory in specific dtcm banks.

Reviewed By: nitish2112

Differential Revision: D77164673


