### PR TITLE
feat: enable adding executorch as a module to zephyr

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,0 +1,4 @@
+name: executorch
+build:
+  cmake-ext: True
+  kconfig-ext: True


### PR DESCRIPTION
### Summary
This pull request introduces the necessary structure to allow executorch to be added as a module to the Zephyr RTOS. Specifically, it adds a zephyr/ directory containing a module.yml file, which is required by Zephyr's module system.
No functional changes are introduced to the codebase—this PR is purely structural to support integration with Zephyr's build system.

## Details
Added: zephyr/module.yml
Purpose: Enables executorch to be recognized and used as a Zephyr module via west or CMake.

## Motivation
Zephyr requires a specific directory layout and metadata (module.yml) to include external projects as modules. This change ensures compatibility and simplifies integration for users who want to use executorch within Zephyr-based projects.

##Notes
This change is non-invasive and does not affect existing functionality.
Future enhancements may include additional configuration or integration logic as needed.
