### PR TITLE
Reland "Implement load_into for Mmap Data Loader"

### DIFF
--- a/extension/data_loader/mmap_data_loader.cpp
+++ b/extension/data_loader/mmap_data_loader.cpp
@@ -150,10 +150,10 @@ void MunmapSegment(void* context, void* data, size_t size) {
 }
 } // namespace
 
-Result<FreeableBuffer> MmapDataLoader::load(
-    size_t offset,
-    size_t size,
-    ET_UNUSED const DataLoader::SegmentInfo& segment_info) const {
+/**
+ * Validates that file read range is within bounds.
+ */
+Error MmapDataLoader::validate_input(size_t offset, size_t size) const {
   ET_CHECK_OR_RETURN_ERROR(
       // Probably had its value moved to another instance.
       fd_ >= 0,
@@ -173,6 +173,18 @@ Result<FreeableBuffer> MmapDataLoader::load(
       InvalidArgument,
       "Offset %zu too large for off_t",
       offset);
+  return Error::Ok;
+}
+
+Result<FreeableBuffer> MmapDataLoader::load(
+    size_t offset,
+    size_t size,
+    ET_UNUSED const DataLoader::SegmentInfo& segment_info) const {
+  // Ensure read range is valid.
+  auto err = validate_input(offset, size);
+  if (err != Error::Ok) {
+    return err;
+  }
 
   // mmap() will fail if the size is zero.
   if (size == 0) {
@@ -265,6 +277,70 @@ Result<size_t> MmapDataLoader::size() const {
       InvalidState,
       "Uninitialized");
   return file_size_;
+}
+
+Error MmapDataLoader::load_into(
+    size_t offset,
+    size_t size,
+    ET_UNUSED const SegmentInfo& segment_info,
+    void* buffer) const {
+  ET_CHECK_OR_RETURN_ERROR(
+      buffer != nullptr, InvalidArgument, "Buffer is null");
+
+  // Ensure read range is valid.
+  auto err = validate_input(offset, size);
+  if (err != Error::Ok) {
+    return err;
+  }
+
+  // Nothing to copy.
+  if (size == 0) {
+    return Error::Ok;
+  }
+
+  // Find the range of pages that covers the requested region.
+  Range range =
+      get_overlapping_pages(static_cast<uintptr_t>(offset), size, page_size_);
+
+  size_t map_size = range.size;
+  if (range.start + map_size > file_size_) {
+    // Clamp to the end of the file.
+    //
+    // The Windows implementation of mmap uses CreateFileMapping which returns
+    // error STATUS_SECTION_TOO_BIG (0xc0000040) if we try to map past the end
+    // of the last page of a file mapped in as read-only.
+    map_size = file_size_ - range.start;
+  }
+
+  // Map the pages read-only. MAP_PRIVATE vs. MAP_SHARED doesn't matter since
+  // the data is read-only, but use PRIVATE just to further avoid accidentally
+  // modifying the file.
+  void* pages = ::mmap(
+      nullptr,
+      map_size,
+      PROT_READ,
+      MAP_PRIVATE,
+      fd_,
+      static_cast<off_t>(range.start));
+  ET_CHECK_OR_RETURN_ERROR(
+      pages != MAP_FAILED,
+      AccessFailed,
+      "Failed to map %s: mmap(..., size=%zd, ..., fd=%d, offset=0x%zx)",
+      file_name_,
+      range.size,
+      fd_,
+      range.start);
+
+  // Offset into mapped region.
+  const size_t map_delta = offset - range.start;
+
+  // Copy data into caller's buffer.
+  std::memcpy(buffer, static_cast<uint8_t*>(pages) + map_delta, size);
+
+  // Unmap mapped region.
+  ::munmap(pages, map_size);
+
+  return Error::Ok;
 }
 
 } // namespace extension

--- a/extension/data_loader/mmap_data_loader.cpp
+++ b/extension/data_loader/mmap_data_loader.cpp
@@ -181,9 +181,9 @@ Result<FreeableBuffer> MmapDataLoader::load(
     size_t size,
     ET_UNUSED const DataLoader::SegmentInfo& segment_info) const {
   // Ensure read range is valid.
-  auto err = validate_input(offset, size);
-  if (err != Error::Ok) {
-    return err;
+  auto validation_err = validate_input(offset, size);
+  if (validation_err != Error::Ok) {
+    return validation_err;
   }
 
   // mmap() will fail if the size is zero.

--- a/extension/data_loader/mmap_data_loader.h
+++ b/extension/data_loader/mmap_data_loader.h
@@ -95,6 +95,13 @@ class MmapDataLoader final : public executorch::runtime::DataLoader {
 
   ET_NODISCARD executorch::runtime::Result<size_t> size() const override;
 
+  ET_NODISCARD
+  executorch::runtime::Error load_into(
+      size_t offset,
+      size_t size,
+      ET_UNUSED const SegmentInfo& segment_info,
+      void* buffer) const override;
+
  private:
   MmapDataLoader(
       int fd,
@@ -112,6 +119,10 @@ class MmapDataLoader final : public executorch::runtime::DataLoader {
   MmapDataLoader(const MmapDataLoader&) = delete;
   MmapDataLoader& operator=(const MmapDataLoader&) = delete;
   MmapDataLoader& operator=(MmapDataLoader&&) = delete;
+
+  ET_NODISCARD executorch::runtime::Error validate_input(
+      size_t offset,
+      size_t size) const;
 
   const char* const file_name_; // String data is owned by the instance.
   const size_t file_size_;


### PR DESCRIPTION
### Summary
https://github.com/pytorch/executorch/pull/11654 was reverted in https://github.com/pytorch/executorch/pull/11928 due to a Meta-internal build breakage. This PR re-lands the changes along with a fix for the variable name shadowing. I will update OSS CI to run with -Wshadow enabled as a follow-up to catch this in GitHub in the future.