### PR TITLE
Arm backend: avg_pool2d test not assume availibility of tosa_ref_model

### DIFF
--- a/backends/arm/test/ops/test_avg_pool2d.py
+++ b/backends/arm/test/ops/test_avg_pool2d.py
@@ -8,6 +8,8 @@
 
 from typing import Tuple
 
+import conftest
+
 import torch
 
 from executorch.backends.arm.test import common
@@ -119,6 +121,7 @@ def test_avg_pool2d_tosa_MI(test_module):
         input_tensor,
         aten_op,
         exir_op,
+        run_on_tosa_ref_model=conftest.is_option_enabled("tosa_ref_model"),
     )
     pipeline.run()
 
@@ -132,6 +135,7 @@ def test_avg_pool2d_tosa_BI(test_module):
         input_tensor,
         aten_op,
         exir_op,
+        run_on_tosa_ref_model=conftest.is_option_enabled("tosa_ref_model"),
     )
     pipeline.run()
 


### PR DESCRIPTION
Summary: tosa_ref_model may not be always available. Two parallel fixes as we run into issues, (1) make sure the sim is available everywhere, and (2) update tests in the meanwhile to respect the pytest config for tosa_ref_model

Reviewed By: GregoryComer

Differential Revision: D77278468
