### PR TITLE
Arm backend: Add support for custom vela.ini

### DIFF
--- a/backends/arm/test/common.py
+++ b/backends/arm/test/common.py
@@ -95,6 +95,7 @@ def get_u55_compile_spec(
     memory_mode: str = "Shared_Sram",
     extra_flags: str = "--debug-force-regor --output-format=raw",
     custom_path: Optional[str] = None,
+    config: Optional[str] = "Arm/vela.ini",
 ) -> list[CompileSpec]:
     """
     Compile spec for Ethos-U55.
@@ -105,6 +106,7 @@ def get_u55_compile_spec(
         memory_mode=memory_mode,
         extra_flags=extra_flags,
         custom_path=custom_path,
+        config=config,
     ).build()
 
 
@@ -114,6 +116,7 @@ def get_u85_compile_spec(
     memory_mode="Shared_Sram",
     extra_flags="--output-format=raw",
     custom_path=None,
+    config: Optional[str] = "Arm/vela.ini",
 ) -> list[CompileSpec]:
     """
     Compile spec for Ethos-U85.
@@ -124,6 +127,7 @@ def get_u85_compile_spec(
         memory_mode=memory_mode,
         extra_flags=extra_flags,
         custom_path=custom_path,
+        config=config,
     ).build()
 
 
@@ -133,6 +137,7 @@ def get_u55_compile_spec_unbuilt(
     memory_mode: str,
     extra_flags: str,
     custom_path: Optional[str],
+    config: Optional[str],
 ) -> ArmCompileSpecBuilder:
     """Get the ArmCompileSpecBuilder for the Ethos-U55 tests, to modify
     the compile spec before calling .build() to finalize it.
@@ -151,6 +156,7 @@ def get_u55_compile_spec_unbuilt(
             system_config=system_config,
             memory_mode=memory_mode,
             extra_flags=extra_flags,
+            config_ini=config,
         )
         .dump_intermediate_artifacts_to(artifact_path)
     )
@@ -163,6 +169,7 @@ def get_u85_compile_spec_unbuilt(
     memory_mode: str,
     extra_flags: str,
     custom_path: Optional[str],
+    config: Optional[str],
 ) -> list[CompileSpec]:
     """Get the ArmCompileSpecBuilder for the Ethos-U85 tests, to modify
     the compile spec before calling .build() to finalize it.
@@ -180,6 +187,7 @@ def get_u85_compile_spec_unbuilt(
             system_config=system_config,
             memory_mode=memory_mode,
             extra_flags=extra_flags,
+            config_ini=config,
         )
         .dump_intermediate_artifacts_to(artifact_path)
     )

--- a/examples/arm/aot_arm_compiler.py
+++ b/examples/arm/aot_arm_compiler.py
@@ -386,6 +386,7 @@ def get_compile_spec(
     system_config: Optional[str] = None,
     memory_mode: Optional[str] = None,
     quantize: bool = False,
+    config: Optional[str] = None,
 ) -> list[CompileSpec]:
     spec_builder = None
     if target.startswith("TOSA"):
@@ -400,6 +401,7 @@ def get_compile_spec(
             system_config=system_config,
             memory_mode=memory_mode,
             extra_flags="--verbose-operators --verbose-cycle-estimate",
+            config_ini=config,
         )
     elif "vgf" in target:
         if quantize:
@@ -573,6 +575,12 @@ def get_args():
         default=None,
         help="Memory mode to select from the Vela configuration file (see vela.ini). Default is 'Shared_Sram' for Ethos-U55 targets and 'Sram_Only' for Ethos-U85 targets",
     )
+    parser.add_argument(
+        "--config",
+        required=False,
+        default="Arm/vela.ini",
+        help="Specify custom vela configuration file (vela.ini)",
+    )
     args = parser.parse_args()
 
     if args.evaluate and (
@@ -706,6 +714,7 @@ def to_edge_TOSA_delegate(
         args.system_config,
         args.memory_mode,
         args.quantize,
+        args.config,
     )
 
     model_int8 = None
@@ -746,6 +755,7 @@ def to_edge_no_delegate(exported_program, args, model: torch.nn.Module, example_
             args.system_config,
             args.memory_mode,
             args.quantize,
+            args.config,
         )
         model, exported_program = quantize_model(
             args, model, example_inputs, compile_spec

--- a/examples/arm/run.sh
+++ b/examples/arm/run.sh
@@ -33,6 +33,7 @@ build_type="Release"
 extra_build_flags=""
 build_only=false
 system_config=""
+config=""
 memory_mode=""
 et_build_root="${et_root_dir}/arm_test"
 ethos_u_scratch_dir=${script_dir}/ethos-u-scratch
@@ -57,6 +58,7 @@ function help() {
     echo "  --build_only                           Only build, don't run FVP"
     echo "  --system_config=<CONFIG>               System configuration to select from the Vela configuration file (see vela.ini). Default: Ethos_U55_High_End_Embedded for EthosU55 targets, Ethos_U85_SYS_DRAM_Mid for EthosU85 targets."
     echo "                                            NOTE: If given, this option must match the given target. This option also sets timing adapter values customized for specific hardware, see ./executor_runner/CMakeLists.txt."
+    echo "  --config=<FILEPATH>                    System configuration file that specifies system configurations (vela.ini)"
     echo "  --memory_mode=<MODE>                   Memory mode to select from the Vela configuration file (see vela.ini), e.g. Shared_Sram/Sram_Only. Default: 'Shared_Sram' for Ethos-U55 targets, 'Sram_Only' for Ethos-U85 targets"
     echo "  --et_build_root=<FOLDER>               Executorch build output root folder to use, defaults to ${et_build_root}"
     echo "  --scratch-dir=<FOLDER>                 Path to your Ethos-U scrach dir if you not using default ${ethos_u_scratch_dir}"
@@ -80,6 +82,7 @@ for arg in "$@"; do
       --extra_build_flags=*) extra_build_flags="${arg#*=}";;
       --build_only) build_only=true ;;
       --system_config=*) system_config="${arg#*=}";;
+      --config=*) config="${arg#*=}";;
       --memory_mode=*) memory_mode="${arg#*=}";;
       --et_build_root=*) et_build_root="${arg#*=}";;
       --scratch-dir=*) ethos_u_scratch_dir="${arg#*=}" ; scratch_dir_set=true ;;
@@ -112,6 +115,11 @@ then
     then
         memory_mode="Dedicated_Sram_384KB"
     fi
+fi
+
+if [[ ${config} == "" ]]
+then
+    config="Arm/vela.ini"
 fi
 
 function check_setup () {
@@ -242,7 +250,7 @@ for i in "${!test_model[@]}"; do
         model_compiler_flags="${model_compiler_flags} --model_input=${model_input}"
     fi
 
-    ARM_AOT_CMD="python3 -m examples.arm.aot_arm_compiler --model_name=${model} --target=${target} ${model_compiler_flags} --intermediate=${output_folder} --output=${pte_file} --system_config=${system_config} --memory_mode=${memory_mode} $bundleio_flag"
+    ARM_AOT_CMD="python3 -m examples.arm.aot_arm_compiler --model_name=${model} --target=${target} ${model_compiler_flags} --intermediate=${output_folder} --output=${pte_file} --system_config=${system_config} --memory_mode=${memory_mode} $bundleio_flag --config=${config}"
     echo "CALL ${ARM_AOT_CMD}" >&2
     ${ARM_AOT_CMD} 1>&2
 


### PR DESCRIPTION
The vela compiler supports the option to specify a custom vela.ini file. But none of the scripts in the arm backend handles this option and forwards it to vela.

Previous to this commit this was always hardcoded to "Arm/vela.ini"

Now this can be specified with --config that is being forwarded to vela for the following scripts:
  * examples/arm/run.sh
  * examples/arm/aot_arm_compiler.py

While keeping the default of "Arm/vela.ini" in test/common to not break CI.

Change-Id: I5ab25f1784006df96a1e10f97c994024362875da
Signed-off-by: per.held@arm.com


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218