### PR TITLE
[Backend Tester] Add CoreML tester implementation

### DIFF
--- a/backends/apple/coreml/test/tester.py
+++ b/backends/apple/coreml/test/tester.py
@@ -1,0 +1,61 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, List, Optional, Tuple
+
+import executorch
+import executorch.backends.test.harness.stages as BaseStages
+
+import torch
+from executorch.backends.apple.coreml.partition import CoreMLPartitioner
+from executorch.backends.test.harness import Tester as TesterBase
+from executorch.backends.test.harness.stages import StageType
+from executorch.exir import EdgeCompileConfig
+from executorch.exir.backend.partitioner import Partitioner
+
+
+class Partition(BaseStages.Partition):
+    def __init__(self, partitioner: Optional[Partitioner] = None):
+        super().__init__(
+            partitioner=partitioner or CoreMLPartitioner,
+        )
+
+
+class ToEdgeTransformAndLower(BaseStages.ToEdgeTransformAndLower):
+    def __init__(
+        self,
+        partitioners: Optional[List[Partitioner]] = None,
+        edge_compile_config: Optional[EdgeCompileConfig] = None,
+    ):
+        super().__init__(
+            default_partitioner_cls=CoreMLPartitioner,
+            partitioners=partitioners,
+            edge_compile_config=edge_compile_config,
+        )
+
+
+class CoreMLTester(TesterBase):
+    def __init__(
+        self,
+        module: torch.nn.Module,
+        example_inputs: Tuple[torch.Tensor],
+        dynamic_shapes: Optional[Tuple[Any]] = None,
+    ):
+        # Specialize for XNNPACK
+        stage_classes = (
+            executorch.backends.test.harness.Tester.default_stage_classes()
+            | {
+                StageType.PARTITION: Partition,
+                StageType.TO_EDGE_TRANSFORM_AND_LOWER: ToEdgeTransformAndLower,
+            }
+        )
+
+        super().__init__(
+            module=module,
+            stage_classes=stage_classes,
+            example_inputs=example_inputs,
+            dynamic_shapes=dynamic_shapes,
+        )

--- a/backends/test/operators/test_facto.py
+++ b/backends/test/operators/test_facto.py
@@ -4,7 +4,16 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# pyre-strict
+# pyre-unsafe
+
+#
+# This file contains logic to run generated operator tests using the FACTO
+# library (https://github.com/pytorch-labs/FACTO). To run the tests, first
+# clone and install FACTO by running pip install . from the FACTO source
+# directory. Then, from the executorch root directory, run the following:
+#
+# python -m unittest backends.test.operators.test_facto.FactoTestsXNNPACK
+#
 
 import copy
 import functools
@@ -26,9 +35,9 @@ from .facto_specs import ExtraSpecDB
 CombinedSpecDB = SpecDictDB | ExtraSpecDB
 
 COMMON_TENSOR_CONSTRAINTS = [
-    cp.Rank.Ge(lambda deps: 1),
+    cp.Rank.Ge(lambda deps: 1),  # Avoid zero and high rank tensors.
     cp.Rank.Le(lambda deps: 4),
-    cp.Size.Ge(lambda deps, r, d: 1),
+    cp.Size.Ge(lambda deps, r, d: 1),  # Keep sizes reasonable.
     cp.Size.Le(lambda deps, r, d: 2**9),
 ]
 
@@ -171,7 +180,7 @@ class FactoTestsBase(unittest.TestCase):
     def setUp(self):
         torch.set_printoptions(threshold=3)
 
-    def _test_op(self, op: OpOverload) -> None:  # noqa
+    def _test_op(self, op: OpOverload) -> None:  # noqa: C901
         random_manager.seed(0)
 
         # Strip namespace


### PR DESCRIPTION
Add a tester implementation for Core ML. This uses the common backend tester framework to allow Core ML to plug into the test harness using pybindings.