### PR TITLE
Prim ops replace abort with error code

### DIFF
--- a/kernels/prim_ops/register_prim_ops.cpp
+++ b/kernels/prim_ops/register_prim_ops.cpp
@@ -22,9 +22,16 @@ namespace function {
 
 namespace {
 
-#define __ET_PRIM_OP_ERROR_IMPL(a, b, context)                \
-  else {                                                      \
-    ET_KERNEL_CHECK(context, false, InvalidType, /* void */); \
+#define __ET_PRIM_OP_ERROR_IMPL(a, b, context) \
+  else {                                       \
+    ET_KERNEL_CHECK_MSG(                       \
+        context,                               \
+        false,                                 \
+        InvalidType,                           \
+        /* void */,                            \
+        "%zu, %zu",                            \
+        (size_t)a.tag,                         \
+        (size_t)b.tag);                        \
   }
 
 #define __NUMBER_ET_PRIM_OP_IMPL(operator, stack, context) \
@@ -167,7 +174,14 @@ static Kernel prim_ops[] = {
           } else if (a.isDouble() && b.isInt()) {
             floor_div_double(a.toDouble(), static_cast<double>(b.toInt()), out);
           } else {
-            ET_KERNEL_CHECK(context, false, InvalidType, /* void */);
+            ET_KERNEL_CHECK_MSG(
+                context,
+                false,
+                InvalidType,
+                /* void */,
+                "%zu, %zu",
+                (size_t)a.tag,
+                (size_t)b.tag);
           }
         }),
 
@@ -191,7 +205,14 @@ static Kernel prim_ops[] = {
           } else if (a.isDouble() && b.isInt()) {
             out = EValue(a.toDouble() / b.toInt());
           } else {
-            ET_KERNEL_CHECK(context, false, InvalidType, /* void */);
+            ET_KERNEL_CHECK_MSG(
+                context,
+                false,
+                InvalidType,
+                /* void */,
+                "%zu, %zu",
+                (size_t)a.tag,
+                (size_t)b.tag);
           }
         }),
 
@@ -211,7 +232,8 @@ static Kernel prim_ops[] = {
             // TODO: This should be impossible
             out = EValue(a.toDouble());
           } else {
-            ET_KERNEL_CHECK(context, false, InvalidType, /* void */);
+            ET_KERNEL_CHECK_MSG(
+                context, false, InvalidType, /* void */, "%zu", (size_t)a.tag);
           }
         }),
 
@@ -261,7 +283,8 @@ static Kernel prim_ops[] = {
           } else if (a.isDouble()) {
             out = EValue(-a.toDouble());
           } else {
-            ET_KERNEL_CHECK(context, false, InvalidType, /* void */);
+            ET_KERNEL_CHECK_MSG(
+                context, false, InvalidType, /* void */, "%zu", (size_t)a.tag);
           }
         }),
 
@@ -298,7 +321,14 @@ static Kernel prim_ops[] = {
           if (a.isInt() && b.isInt()) {
             out = EValue(a.toInt() % b.toInt());
           } else {
-            ET_KERNEL_CHECK(context, false, InvalidType, /* void */);
+            ET_KERNEL_CHECK_MSG(
+                context,
+                false,
+                InvalidType,
+                /* void */,
+                "%zu, %zu",
+                (size_t)a.tag,
+                (size_t)b.tag);
           }
         }),
 
@@ -312,7 +342,13 @@ static Kernel prim_ops[] = {
           if (a.isDouble()) {
             out = EValue(static_cast<int64_t>(ceil(a.toDouble())));
           } else {
-            ET_KERNEL_CHECK(context, false, InvalidType, /* void */);
+            ET_KERNEL_CHECK_MSG(
+                context,
+                false,
+                InvalidType,
+                /* void */,
+                "Unsupported DType %zu",
+                (size_t)a.tag);
           }
         }),
 
@@ -343,7 +379,13 @@ static Kernel prim_ops[] = {
 
             out = EValue(static_cast<int64_t>(res));
           } else {
-            ET_KERNEL_CHECK(context, false, InvalidType, /* void */);
+            ET_KERNEL_CHECK_MSG(
+                context,
+                false,
+                InvalidType,
+                /* void */,
+                "Unsupported DType %zu",
+                (size_t)a.tag);
           }
         }),
 
@@ -357,7 +399,8 @@ static Kernel prim_ops[] = {
           if (a.isDouble()) {
             out = EValue(static_cast<int64_t>(trunc(a.toDouble())));
           } else {
-            ET_KERNEL_CHECK(context, false, InvalidType, /* void */);
+            ET_KERNEL_CHECK_MSG(
+                context, false, InvalidType, /* void */, "%zu", (size_t)a.tag);
           }
         }),
 

--- a/kernels/prim_ops/register_prim_ops.cpp
+++ b/kernels/prim_ops/register_prim_ops.cpp
@@ -22,12 +22,11 @@ namespace function {
 
 namespace {
 
-#define __ET_PRIM_OP_ERROR_IMPL(a, b, context)                     \
-  else {                                                           \
-    ET_CHECK_MSG(false, "%zu, %zu", (size_t)a.tag, (size_t)b.tag); \
+#define __ET_PRIM_OP_ERROR_IMPL(a, b, context)                \
+  else {                                                      \
+    ET_KERNEL_CHECK(context, false, InvalidType, /* void */); \
   }
 
-// TODO Fail using runtime context
 #define __NUMBER_ET_PRIM_OP_IMPL(operator, stack, context) \
   (void)context;                                           \
   EValue& a = *stack[0];                                   \
@@ -168,8 +167,7 @@ static Kernel prim_ops[] = {
           } else if (a.isDouble() && b.isInt()) {
             floor_div_double(a.toDouble(), static_cast<double>(b.toInt()), out);
           } else {
-            // TODO Fail using runtime context
-            ET_CHECK_MSG(false, "%zu, %zu", (size_t)a.tag, (size_t)b.tag);
+            ET_KERNEL_CHECK(context, false, InvalidType, /* void */);
           }
         }),
 
@@ -193,8 +191,7 @@ static Kernel prim_ops[] = {
           } else if (a.isDouble() && b.isInt()) {
             out = EValue(a.toDouble() / b.toInt());
           } else {
-            // TODO Fail using runtime context
-            ET_CHECK_MSG(false, "%zu, %zu", (size_t)a.tag, (size_t)b.tag);
+            ET_KERNEL_CHECK(context, false, InvalidType, /* void */);
           }
         }),
 
@@ -214,8 +211,7 @@ static Kernel prim_ops[] = {
             // TODO: This should be impossible
             out = EValue(a.toDouble());
           } else {
-            // TODO Fail using runtime context
-            ET_CHECK_MSG(false, "%zu", (size_t)a.tag);
+            ET_KERNEL_CHECK(context, false, InvalidType, /* void */);
           }
         }),
 
@@ -265,8 +261,7 @@ static Kernel prim_ops[] = {
           } else if (a.isDouble()) {
             out = EValue(-a.toDouble());
           } else {
-            // TODO Fail using runtime context
-            ET_CHECK_MSG(false, "%zu", (size_t)a.tag);
+            ET_KERNEL_CHECK(context, false, InvalidType, /* void */);
           }
         }),
 
@@ -303,7 +298,7 @@ static Kernel prim_ops[] = {
           if (a.isInt() && b.isInt()) {
             out = EValue(a.toInt() % b.toInt());
           } else {
-            ET_CHECK_MSG(false, "%zu, %zu", (size_t)a.tag, (size_t)b.tag);
+            ET_KERNEL_CHECK(context, false, InvalidType, /* void */);
           }
         }),
 
@@ -317,7 +312,7 @@ static Kernel prim_ops[] = {
           if (a.isDouble()) {
             out = EValue(static_cast<int64_t>(ceil(a.toDouble())));
           } else {
-            ET_CHECK_MSG(false, "Unsupported DType %zu", (size_t)a.tag);
+            ET_KERNEL_CHECK(context, false, InvalidType, /* void */);
           }
         }),
 
@@ -348,7 +343,7 @@ static Kernel prim_ops[] = {
 
             out = EValue(static_cast<int64_t>(res));
           } else {
-            ET_CHECK_MSG(false, "Unsupported DType %zu", (size_t)a.tag);
+            ET_KERNEL_CHECK(context, false, InvalidType, /* void */);
           }
         }),
 
@@ -362,7 +357,7 @@ static Kernel prim_ops[] = {
           if (a.isDouble()) {
             out = EValue(static_cast<int64_t>(trunc(a.toDouble())));
           } else {
-            ET_CHECK_MSG(false, "%zu", (size_t)a.tag);
+            ET_KERNEL_CHECK(context, false, InvalidType, /* void */);
           }
         }),
 

--- a/kernels/prim_ops/test/prim_ops_test.cpp
+++ b/kernels/prim_ops/test/prim_ops_test.cpp
@@ -326,8 +326,7 @@ TEST_F(RegisterPrimOpsTest, TestNegScalarWithTensorFails) {
 
   // Try to negate a tensor, which should cause a runtime error.
   ET_EXPECT_KERNEL_FAILURE(
-      context_,
-      getOpsFn("executorch_prim::neg.Scalar")(context_, stack));
+      context_, getOpsFn("executorch_prim::neg.Scalar")(context_, stack));
 }
 
 TEST_F(RegisterPrimOpsTest, TestETView) {

--- a/kernels/prim_ops/test/prim_ops_test.cpp
+++ b/kernels/prim_ops/test/prim_ops_test.cpp
@@ -308,7 +308,7 @@ TEST_F(RegisterPrimOpsTest, NegScalarReturnsCorrectValue) {
   EXPECT_EQ(stack[1]->toInt(), -5l);
 }
 
-TEST_F(RegisterPrimOpsTest, TestNegScalarWithTensorDies) {
+TEST_F(RegisterPrimOpsTest, TestNegScalarWithTensorFails) {
   testing::TensorFactory<ScalarType::Int> tf;
 
   EValue values[2];

--- a/kernels/prim_ops/test/prim_ops_test.cpp
+++ b/kernels/prim_ops/test/prim_ops_test.cpp
@@ -325,7 +325,9 @@ TEST_F(RegisterPrimOpsTest, TestNegScalarWithTensorDies) {
   }
 
   // Try to negate a tensor, which should cause a runtime error.
-  ET_EXPECT_DEATH(getOpsFn("executorch_prim::neg.Scalar")(context_, stack), "");
+  ET_EXPECT_KERNEL_FAILURE(
+      context_,
+      getOpsFn("executorch_prim::neg.Scalar")(context_, stack));
 }
 
 TEST_F(RegisterPrimOpsTest, TestETView) {


### PR DESCRIPTION
### Summary
We want to minimize the scenarios where ET fails fatally. If we need to check a precondition inside a kernel rather then calling ET_CHECK which internally dispatches to ABORT we should call ET_KERNEL_CHECK which sets an error state and returns.

### Test plan
Replaced TestNegScalarWithTensorDies with TestNegScalarWithTensorFails. Before, it would expect an abort when negating a tensor. The new test expects a failure state instead.

The test can be run with `test/run_oss_cpp_tests.sh`