### PR TITLE
Integrated debug_handle to operator name mapping into inspector

### DIFF
--- a/devtools/inspector/_inspector_utils.py
+++ b/devtools/inspector/_inspector_utils.py
@@ -784,3 +784,23 @@ def get_aot_debug_handle_to_op_name_mapping(
             )
             debug_handle_to_op_name[key] = node.name
     return debug_handle_to_op_name
+
+
+def find_op_names(
+    target_debug_handle: Tuple[int, ...],
+    debug_handle_to_op_name: Dict[Tuple[int, ...], str],
+) -> List[str]:
+    """
+    Record the operator names only if their debug handles are part of the target debug handle.
+    The debug handles in `debug_handle_to_op_name` have undergone merging and remain unchanged,
+    and this function identifies operations corresponding to these transformed handles.
+    """
+    dh_set = set(target_debug_handle)
+    result = []
+
+    for key_tuple, op_name in debug_handle_to_op_name.items():
+        # Check if key is a subset of the target_debug_handle
+        if set(key_tuple).issubset(dh_set):
+            result.append(op_name)
+
+    return result

--- a/devtools/inspector/tests/inspector_test_utils.py
+++ b/devtools/inspector/tests/inspector_test_utils.py
@@ -83,6 +83,26 @@ class ConvlLinearModel(nn.Module):
             (21,): [torch.tensor([[0.9734]]), torch.tensor([[0.9891]])],
         }
 
+    @staticmethod
+    def get_expected_debug_handle_to_op_name():
+        """
+        Returns the expected debug handle and op name mapping for this model for the given input.
+        """
+        return {
+            (10,): "aten_convolution_default",
+            (11,): "aten_view_copy_default",
+            (12,): "aten_permute_copy_default",
+            (13,): "aten_addmm_default",
+            (14,): "aten_add_tensor",
+            (15,): "aten_sub_tensor",
+            (16,): "aten_mul_tensor",
+            (17,): "aten_add_tensor_1",
+            (18,): "aten_div_tensor",
+            (19,): "aten_relu_default",
+            (20,): "aten_sigmoid_default",
+            (21,): "aten_split_with_sizes_copy_default",
+        }
+
 
 # Global model registry
 model_registry = {
@@ -115,4 +135,22 @@ def check_if_final_outputs_match(model_name, actual_outputs_with_handles):
         else:
             if not torch.allclose(actual_output, expected_output, rtol=1e-4, atol=1e-5):
                 return False
+    return True
+
+
+def check_if_debug_handle_to_op_name_match(model_name, actual_debug_handle_to_op_name):
+    """
+    Checks if the actual op names match the expected op names for the specified model.
+    Returns True if all match, otherwise returns False.
+    """
+    model_instance = model_registry[model_name]
+    expected_debug_handle_to_op_name = (
+        model_instance.get_expected_debug_handle_to_op_name()
+    )
+    if len(actual_debug_handle_to_op_name) != len(expected_debug_handle_to_op_name):
+        return False
+    for debug_handle, expected_op_name in expected_debug_handle_to_op_name.items():
+        actual_op_name = actual_debug_handle_to_op_name.get(debug_handle)
+        if actual_op_name != expected_op_name:
+            return False
     return True

--- a/devtools/inspector/tests/inspector_utils_test.py
+++ b/devtools/inspector/tests/inspector_utils_test.py
@@ -32,6 +32,7 @@ from executorch.devtools.inspector._inspector_utils import (
     convert_to_float_tensor,
     create_debug_handle_to_op_node_mapping,
     EDGE_DIALECT_GRAPH_KEY,
+    find_op_names,
     find_populated_event,
     gen_graphs_from_etrecord,
     get_aot_debug_handle_to_op_name_mapping,
@@ -471,6 +472,23 @@ class TestInspectorUtils(unittest.TestCase):
         mock_node_op_type_mismatch.meta["debug_handle"] = (1, 2)
         # Test that the filter doesn't match the mock node (op_type mismatch)
         self.assertFalse(node_filter.matches(mock_node_op_type_mismatch))
+
+    def test_find_op_names_empty_debug_handle(self):
+        debug_handle = ()
+        debug_handle_to_op_name = {(1, 2): "op1", (3, 4): "op2"}
+        self.assertEqual(find_op_names(debug_handle, debug_handle_to_op_name), [])
+
+    def test_find_op_names_no_matching_handles(self):
+        debug_handle = (1, 2)
+        debug_handle_to_op_name = {(3, 4): "op1", (5, 6): "op2"}
+        self.assertEqual(find_op_names(debug_handle, debug_handle_to_op_name), [])
+
+    def test_find_op_names_matching_handles(self):
+        debug_handle = (1, 2, 3)
+        debug_handle_to_op_name = {(1, 2): "op1", (2, 3): "op2", (4, 5, 6): "op3"}
+        self.assertEqual(
+            find_op_names(debug_handle, debug_handle_to_op_name), ["op1", "op2"]
+        )
 
 
 def gen_mock_operator_graph_with_expected_map() -> (


### PR DESCRIPTION
Summary: This PR utilizes the runtime and AOT debug_handle to operator name mapping we built previously to convert debug_handles to their corresponding operator names within the inspector, thereby enhancing how results are displayed and making it easier for users to understand.

Differential Revision: D77269265


