### PR TITLE
Build size_test binaries with debug info

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -366,6 +366,7 @@ jobs:
         # build module for executorch.extension.pybindings.portable_lib
         bash test/build_size_test.sh
         strip cmake-out/test/size_test
+        strip --strip-debug cmake-out/test/size_test
         output=$(ls -la cmake-out/test/size_test)
         arr=($output)
         size=${arr[4]}
@@ -403,6 +404,7 @@ jobs:
         # build module for executorch.extension.pybindings.portable_lib
         bash test/build_size_test.sh
         strip cmake-out/test/size_test
+        strip --strip-debug cmake-out/test/size_test
         output=$(ls -la cmake-out/test/size_test)
         arr=($output)
         size=${arr[4]}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -694,7 +694,7 @@ if(EXECUTORCH_BUILD_EXECUTOR_RUNNER)
   endif()
 
   add_executable(executor_runner ${_executor_runner__srcs})
-  if(CMAKE_BUILD_TYPE STREQUAL "Release")
+  if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
     if(APPLE)
       target_link_options(executor_runner PRIVATE "LINKER:-dead_strip")
     else()

--- a/backends/qualcomm/CMakeLists.txt
+++ b/backends/qualcomm/CMakeLists.txt
@@ -60,7 +60,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   add_link_options("-flto=auto")
 endif()
 
-if(CMAKE_BUILD_TYPE STREQUAL "Release")
+if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
   # strip symbols
   add_link_options("-s")
 
@@ -259,7 +259,7 @@ if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64")
     pybind11_strip(PyQnnWrapperAdaptor)
   endif()
 
-  if(CMAKE_BUILD_TYPE STREQUAL "Release")
+  if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
     # need to allow exceptions in pybind
     set(_pybind_compile_options -Wno-deprecated-declarations -fPIC -frtti
                                 -fexceptions

--- a/examples/models/llama/CMakeLists.txt
+++ b/examples/models/llama/CMakeLists.txt
@@ -209,7 +209,7 @@ if(ANDROID)
 endif()
 
 add_executable(llama_main ${_srcs})
-if(CMAKE_BUILD_TYPE STREQUAL "Release")
+if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
   if(APPLE)
     target_link_options(llama_main PRIVATE "LINKER:-dead_strip")
   else()

--- a/examples/models/llava/CMakeLists.txt
+++ b/examples/models/llava/CMakeLists.txt
@@ -197,7 +197,7 @@ list(APPEND _common_include_directories ${stb_SOURCE_DIR}
 )
 
 add_executable(llava_main ${_srcs})
-if(CMAKE_BUILD_TYPE STREQUAL "Release")
+if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
   if(APPLE)
     target_link_options(llava_main PRIVATE "LINKER:-dead_strip,-s")
   else()

--- a/examples/selective_build/CMakeLists.txt
+++ b/examples/selective_build/CMakeLists.txt
@@ -151,7 +151,7 @@ list(TRANSFORM _executor_runner__srcs PREPEND "${EXECUTORCH_ROOT}/")
 # link to
 #
 add_executable(selective_build_test ${_executor_runner__srcs})
-if(CMAKE_BUILD_TYPE EQUAL "Release")
+if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
   target_link_options(selective_build_test PRIVATE "LINKER:--gc-sections")
 endif()
 target_link_libraries(

--- a/kernels/portable/cpu/util/normalization_ops_util.cpp
+++ b/kernels/portable/cpu/util/normalization_ops_util.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <c10/util/irange.h>
+#include <array>
 #include <cstring>
 
 #include <executorch/kernels/portable/cpu/util/normalization_ops_util.h>
@@ -92,6 +93,11 @@ bool check_layer_norm_args(
       ", ndim = %zu",
       in.dim(),
       ndim);
+  ET_CHECK_OR_RETURN_FALSE(
+      ndim <= kTensorDimensionLimit,
+      "Expected normalized shape to have at most %zu dimensions but it had %zu",
+      kTensorDimensionLimit,
+      ndim);
   size_t shift = in.dim() - ndim;
   for (const auto d : c10::irange(ndim)) {
     ET_CHECK_OR_RETURN_FALSE(
@@ -103,7 +109,7 @@ bool check_layer_norm_args(
         d,
         normalized_shape[d]);
   }
-  executorch::aten::SizesType shape[ndim];
+  std::array<executorch::aten::SizesType, kTensorDimensionLimit> shape;
   for (const auto i : c10::irange(ndim)) {
     shape[i] = static_cast<executorch::aten::SizesType>(normalized_shape[i]);
   }
@@ -111,12 +117,12 @@ bool check_layer_norm_args(
   if (weight.has_value()) {
     ET_LOG_AND_RETURN_IF_FALSE(tensors_have_same_dtype(in, weight.value()));
     ET_LOG_AND_RETURN_IF_FALSE(
-        tensor_has_expected_size(weight.value(), {shape, ndim}));
+        tensor_has_expected_size(weight.value(), {shape.data(), ndim}));
   }
   if (bias.has_value()) {
     ET_LOG_AND_RETURN_IF_FALSE(tensors_have_same_dtype(in, bias.value()));
     ET_LOG_AND_RETURN_IF_FALSE(
-        tensor_has_expected_size(bias.value(), {shape, ndim}));
+        tensor_has_expected_size(bias.value(), {shape.data(), ndim}));
   }
   ET_LOG_AND_RETURN_IF_FALSE(tensors_have_same_dtype(in, out));
   ET_LOG_AND_RETURN_IF_FALSE(tensors_have_same_dtype(in, mean_out));

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -52,7 +52,7 @@ list(TRANSFORM _size_test__srcs PREPEND "${EXECUTORCH_ROOT}/")
 # when we cross compile to ios
 add_executable(size_test ${_size_test__srcs})
 target_link_libraries(size_test executorch)
-if(CMAKE_BUILD_TYPE EQUAL "Release")
+if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
   target_link_options(size_test PRIVATE "LINKER:--gc-sections")
 endif()
 
@@ -64,7 +64,7 @@ target_link_options_shared_lib(portable_ops_lib)
 target_link_libraries(
   size_test_all_ops executorch portable_ops_lib portable_kernels
 )
-if(CMAKE_BUILD_TYPE EQUAL "Release")
+if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
   target_link_options(size_test_all_ops PRIVATE "LINKER:--gc-sections")
 endif()
 
@@ -76,7 +76,7 @@ add_executable(size_test_all_optimized_ops ${_size_test__srcs})
 target_link_options_shared_lib(optimized_native_cpu_ops_lib)
 target_link_libraries(
   size_test_all_optimized_ops executorch optimized_native_cpu_ops_lib)
-if(CMAKE_BUILD_TYPE EQUAL "Release")
+if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
   target_link_options(size_test_all_optimized_ops PRIVATE "LINKER:--gc-sections")
 endif()
 endif()

--- a/test/build_optimized_size_test.sh
+++ b/test/build_optimized_size_test.sh
@@ -41,12 +41,15 @@ test_cmake_size_test() {
 
     echo 'ExecuTorch with no ops binary size, unstripped:'
     ls -al cmake-out/test/size_test
+    size cmake-out/test/size_test
 
     echo 'ExecuTorch with portable ops binary size, unstripped:'
     ls -al cmake-out/test/size_test_all_ops
+    size cmake-out/test/size_test_all_ops
 
     echo 'ExecuTorch with optimized ops binary size, unstripped:'
     ls -al cmake-out/test/size_test_all_optimized_ops
+    size cmake-out/test/size_test_all_optimized_ops
 }
 
 if [[ -z $PYTHON_EXECUTABLE ]]; then

--- a/test/build_size_test.sh
+++ b/test/build_size_test.sh
@@ -46,9 +46,11 @@ test_cmake_size_test() {
 
     echo 'ExecuTorch with no ops binary size, unstripped:'
     ls -al cmake-out/test/size_test
+    size cmake-out/test/size_test
 
     echo 'ExecuTorch with portable ops binary size, unstripped:'
     ls -al cmake-out/test/size_test_all_ops
+    size cmake-out/test/size_test_all_ops
 }
 
 if [[ -z $PYTHON_EXECUTABLE ]]; then

--- a/test/build_size_test.sh
+++ b/test/build_size_test.sh
@@ -26,23 +26,23 @@ cmake_install_executorch_lib() {
   CXXFLAGS="$COMMON_CXXFLAGS" retry cmake -DBUCK2="$BUCK2" \
           -DCMAKE_CXX_STANDARD_REQUIRED=ON \
           -DCMAKE_INSTALL_PREFIX=cmake-out \
-          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_BUILD_TYPE=RelWithDebInfo \
           -DEXECUTORCH_BUILD_EXECUTOR_RUNNER=OFF \
           -DEXECUTORCH_OPTIMIZE_SIZE=ON \
           -DPYTHON_EXECUTABLE="$PYTHON_EXECUTABLE" \
           ${EXTRA_BUILD_ARGS} \
           -Bcmake-out .
-  cmake --build cmake-out -j9 --target install --config Release
+  cmake --build cmake-out -j9 --target install --config RelWithDebInfo
 }
 
 test_cmake_size_test() {
-    CXXFLAGS="$COMMON_CXXFLAGS" retry cmake -DCMAKE_BUILD_TYPE=Release \
+    CXXFLAGS="$COMMON_CXXFLAGS" retry cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DCMAKE_INSTALL_PREFIX=cmake-out \
         ${EXTRA_BUILD_ARGS} \
         -Bcmake-out/test test
 
     echo "Build size test"
-    cmake --build cmake-out/test -j9 --config Release
+    cmake --build cmake-out/test -j9 --config RelWithDebInfo
 
     echo 'ExecuTorch with no ops binary size, unstripped:'
     ls -al cmake-out/test/size_test

--- a/test/build_size_test.sh
+++ b/test/build_size_test.sh
@@ -15,7 +15,10 @@ EXTRA_BUILD_ARGS="${@:-}"
 # TODO(#8357): Remove -Wno-int-in-bool-context
 # TODO: Replace -ET_HAVE_PREAD=0 with a CMake option.
 #  FileDataLoader used in the size_test breaks baremetal builds with pread when missing.
-COMMON_CXXFLAGS="-fno-exceptions -fno-rtti -Wall -Werror -Wno-int-in-bool-context -DET_HAVE_PREAD=0"
+# -Werror=maybe-uninitialized causes failures with GCC 9.5, which we
+# -currently use in CI. There were known issues with this warning and
+# -std::optional: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80635
+COMMON_CXXFLAGS="-fno-exceptions -fno-rtti -Wall -Werror -Wno-int-in-bool-context -Wno-maybe-uninitialized -DET_HAVE_PREAD=0"
 
 cmake_install_executorch_lib() {
   echo "Installing libexecutorch.a"

--- a/tools/cmake/preset/default.cmake
+++ b/tools/cmake/preset/default.cmake
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-if(CMAKE_BUILD_TYPE STREQUAL "Release")
+if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
   set(_is_build_type_release ON)
   set(_is_build_type_debug OFF)
 else()


### PR DESCRIPTION
The CI workflow already runs strip before checking size, so this shouldn't break it (and we'll see if it does on this PR). Having debug info makes it much easier to investigate issues with bloaty.