### PR TITLE
outline input validation in elementwise_util

### DIFF
--- a/kernels/portable/cpu/util/elementwise_util.cpp
+++ b/kernels/portable/cpu/util/elementwise_util.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/kernels/portable/cpu/util/elementwise_util.h>
+
+namespace torch::executor::native::utils::internal {
+
+template <typename... Args>
+inline bool validate_elementwise_fn_inputs_impl(
+    KernelRuntimeContext& ctx,
+    const Tensor& out,
+    SupportedTensorDtypes out_dtypes,
+    ScalarType compute_type,
+    Args... inputs) {
+  static_assert(
+      (std::is_same_v<Args, std::pair<const Tensor*, SupportedTensorDtypes>> &&
+       ...));
+  const auto check_input_dtype = [](auto input, auto compute_type) {
+    return internal::check_tensor_dtype(
+        *input.first, input.second, compute_type);
+  };
+  ET_KERNEL_CHECK(
+      ctx,
+      (check_input_dtype(inputs, compute_type) && ...) &&
+          internal::check_tensor_dtype(out, out_dtypes, compute_type),
+      InvalidArgument,
+      false);
+
+  return true;
+}
+
+bool validate_elementwise_fn_inputs(
+    KernelRuntimeContext& ctx,
+    const Tensor& out,
+    SupportedTensorDtypes out_dtypes,
+    ScalarType compute_type,
+    std::pair<const Tensor*, SupportedTensorDtypes> input) {
+  return validate_elementwise_fn_inputs_impl(
+      ctx,
+      out,
+      out_dtypes,
+      compute_type,
+      input);
+}
+
+bool validate_elementwise_fn_inputs(
+    KernelRuntimeContext& ctx,
+    const Tensor& out,
+    SupportedTensorDtypes out_dtypes,
+    ScalarType compute_type,
+    std::pair<const Tensor*, SupportedTensorDtypes> input0,
+    std::pair<const Tensor*, SupportedTensorDtypes> input1) {
+  return validate_elementwise_fn_inputs_impl(
+      ctx,
+      out,
+      out_dtypes,
+      compute_type,
+      input0,
+      input1);
+}
+
+bool validate_elementwise_fn_inputs(
+    KernelRuntimeContext& ctx,
+    const Tensor& out,
+    SupportedTensorDtypes out_dtypes,
+    ScalarType compute_type,
+    std::pair<const Tensor*, SupportedTensorDtypes> input0,
+    std::pair<const Tensor*, SupportedTensorDtypes> input1,
+    std::pair<const Tensor*, SupportedTensorDtypes> input2) {
+  return validate_elementwise_fn_inputs_impl(
+      ctx,
+      out,
+      out_dtypes,
+      compute_type,
+      input0,
+      input1,
+      input2);
+}
+
+
+} // namespace torch::executor::native::utils::internal

--- a/kernels/portable/cpu/util/targets.bzl
+++ b/kernels/portable/cpu/util/targets.bzl
@@ -104,6 +104,9 @@ def define_common_targets():
 
     runtime.cxx_library(
         name = "elementwise_util",
+        srcs = [
+            "elementwise_util.cpp",
+        ],
         exported_headers = [
             "elementwise_util.h",
         ],


### PR DESCRIPTION
This seems to improve code size. Comparing output of test/build_optimized_size_test.sh before/after this change:

(I've edited out the unchanged "no ops" test case.)

before:
```
ExecuTorch with portable ops binary size, unstripped:
-rwxr-xr-x  1 swolchok  staff  2004816 Jun 26 14:02 cmake-out/test/size_test_all_ops
__TEXT	__DATA	__OBJC	others	dec	hex
1441792	65536	0	4295524352	4297031680	1001f8000
ExecuTorch with optimized ops binary size, unstripped:
-rwxr-xr-x  1 swolchok  staff  6746968 Jun 26 14:02 cmake-out/test/size_test_all_optimized_ops
__TEXT	__DATA	__OBJC	others	dec	hex
4947968	65536	0	4296753152	4301766656	10067c000
```

after:
```
ExecuTorch with portable ops binary size, unstripped:
-rwxr-xr-x  1 swolchok  staff  1989392 Jun 26 14:37 cmake-out/test/size_test_all_ops
__TEXT	__DATA	__OBJC	others	dec	hex
1425408	65536	0	4295524352	4297015296	1001f4000
ExecuTorch with optimized ops binary size, unstripped:
-rwxr-xr-x  1 swolchok  staff  6731784 Jun 26 14:37 cmake-out/test/size_test_all_optimized_ops
__TEXT	__DATA	__OBJC	others	dec	hex
4931584	65536	0	4296753152	4301750272	100678000
```

for test/build_size_test.sh, we see a smaller improvment which is reflected in the file sizes but not the `size` command output, probably because the latter is rounded up to the next page:

before:
```
ExecuTorch with portable ops binary size, unstripped:
-rwxr-xr-x  1 swolchok  staff  2696640 Jun 26 13:44 cmake-out/test/size_test_all_ops
__TEXT	__DATA	__OBJC	others	dec	hex
2162688	65536	0	4295491584	4297719808	1002a0000
```

after:
```
ExecuTorch with portable ops binary size, unstripped:
-rwxr-xr-x  1 swolchok  staff  2695344 Jun 26 14:33 cmake-out/test/size_test_all_ops
__TEXT	__DATA	__OBJC	others	dec	hex
2162688	65536	0	4295491584	4297719808	1002a0000
```