### PR TITLE
Add llm runner into apple frameworks build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -544,10 +544,6 @@ if(EXECUTORCH_BUILD_EXTENSION_MODULE)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/extension/module)
 endif()
 
-if(EXECUTORCH_BUILD_EXTENSION_LLM)
-  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/extension/llm/tokenizers)
-endif()
-
 if(EXECUTORCH_BUILD_EXTENSION_LLM_RUNNER)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/extension/llm/runner)
 endif()

--- a/tools/cmake/preset/apple_common.cmake
+++ b/tools/cmake/preset/apple_common.cmake
@@ -13,12 +13,14 @@ add_compile_options(
   -fdebug-prefix-map=${PROJECT_SOURCE_DIR}=/executorch
 )
 
+set_overridable_option(BUILD_TESTING OFF)
 set_overridable_option(EXECUTORCH_BUILD_XNNPACK ON)
 set_overridable_option(EXECUTORCH_BUILD_COREML ON)
 set_overridable_option(EXECUTORCH_BUILD_MPS ON)
 set_overridable_option(EXECUTORCH_XNNPACK_SHARED_WORKSPACE ON)
 set_overridable_option(EXECUTORCH_BUILD_EXTENSION_APPLE ON)
 set_overridable_option(EXECUTORCH_BUILD_EXTENSION_DATA_LOADER ON)
+set_overridable_option(EXECUTORCH_BUILD_EXTENSION_LLM_RUNNER ON)
 set_overridable_option(EXECUTORCH_BUILD_EXTENSION_MODULE ON)
 set_overridable_option(EXECUTORCH_BUILD_EXTENSION_FLAT_TENSOR ON)
 set_overridable_option(EXECUTORCH_BUILD_EXTENSION_TENSOR ON)

--- a/tools/cmake/preset/default.cmake
+++ b/tools/cmake/preset/default.cmake
@@ -90,7 +90,7 @@ define_overridable_option(
   BOOL OFF
 )
 define_overridable_option(
-  EXECUTORCH_BUILD_EXTENSION_LLM
+  EXECUTORCH_BUILD_EXTENSION_LLM_RUNNER
   "Build the LLM extension"
   BOOL OFF
 )

--- a/tools/cmake/preset/llm.cmake
+++ b/tools/cmake/preset/llm.cmake
@@ -8,8 +8,10 @@
 # saving a few kB is less important than showing useful error information to
 # users.
 # keep sorted
+set_overridable_option(BUILD_TESTING OFF)
 set_overridable_option(EXECUTORCH_BUILD_EXTENSION_DATA_LOADER ON)
 set_overridable_option(EXECUTORCH_BUILD_EXTENSION_FLAT_TENSOR ON)
+set_overridable_option(EXECUTORCH_BUILD_EXTENSION_LLM_RUNNER ON)
 set_overridable_option(EXECUTORCH_BUILD_EXTENSION_MODULE ON)
 set_overridable_option(EXECUTORCH_BUILD_EXTENSION_TENSOR ON)
 set_overridable_option(EXECUTORCH_BUILD_KERNELS_CUSTOM ON)


### PR DESCRIPTION
Remove `EXECUTORCH_BUILD_EXTENSION_LLM` and promote `EXECUTORCH_BUILD_EXTENSION_LLM_RUNNER` to be an overridable option.

Enable it by default in llm and apple preset.
