### PR TITLE
USe -WShadow in clang builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,6 +255,13 @@ endif()
 # TODO(dbort): Fix these warnings and remove this flag.
 set(_common_compile_options -Wno-deprecated-declarations -fPIC)
 
+# Clang and GCC's semantics for -Wshadow differ in handling constructor args
+# with names that match a constructor field. We want Clang's semantics, as this
+# is enforced in certain existing use cases, which have caused reverts.
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  list(APPEND _common_compile_options -Wshadow -Werror=shadow)
+endif()
+
 # Let files say "include <executorch/path/to/header.h>".
 # TODO(#6475): This requires/assumes that the repo lives in a directory named
 # exactly `executorch`. Check the assumption first. Remove this check once we


### PR DESCRIPTION
### Summary
Enable -Wshadow and -Werror=shadow for Clang builds. This is due to needing to revert or forward fix several commits when Meta-internal builds fail due to enforcing this. The option is enabled only on Clang as GCC's version is stricter (mainly around constructor parameters with the same name as class fields), which requires larger changes that I don't personally feel are necessary. Enforcing Clang's version in CI will be sufficient to prevent further reverts / issues as a result of shadowing.

### Test plan
CI