### PR TITLE
Make hydra and omegaconf core dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,8 @@ dependencies=[
   "typing-extensions>=4.10.0",
   # Keep this version in sync with: ./backends/apple/coreml/scripts/install_requirements.sh
   "coremltools==8.3; platform_system == 'Darwin' or platform_system == 'Linux'",
+  "hydra-core>=1.3.0",
+  "omegaconf>=2.3.0",
 ]
 
 [project.urls]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,5 +10,3 @@ zstd  # Imported by resolve_buck.py.
 certifi  # Imported by resolve_buck.py.
 lintrunner==0.12.7
 lintrunner-adapters==0.12.4
-hydra-core>=1.3.0
-omegaconf>=2.3.0


### PR DESCRIPTION
Currently hydra and omegaconf are set as dependency during development only.

But it should just be part of the core dependencies now (it is being used in extensions/llm/export_llm.py) for the pip package.

Test Plan: 

`pip freeze | grep hydra` (no result)
`pip install -e . --no-build-isolation`
`pip freeze | grep hydra` (found hydra)