### PR TITLE
Fix jni_layer_llama.cpp generate_from_pos missing return

### DIFF
--- a/extension/android/jni/jni_layer_llama.cpp
+++ b/extension/android/jni/jni_layer_llama.cpp
@@ -311,12 +311,12 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
           .seq_len = seq_len,
           .temperature = temperature_,
       };
-      runner_->generate_from_pos(
+      return static_cast<jint>(runner_->generate_from_pos(
           prompt->toStdString(),
           start_pos,
           config,
           [callback](std::string result) { callback->onResult(result); },
-          [callback](const llm::Stats& stats) { callback->onStats(stats); });
+          [callback](const llm::Stats& stats) { callback->onStats(stats); }));
     }
   }
 


### PR DESCRIPTION
Fix the issue on #11952 where we are missing a return in generate_from_pos()
