### PR TITLE
Sync LLaMARunner.h with Meta internal copy

### DIFF
--- a/examples/demo-apps/apple_ios/LLaMA/LLaMARunner/LLaMARunner/Exported/LLaMARunner.h
+++ b/examples/demo-apps/apple_ios/LLaMA/LLaMARunner/LLaMARunner/Exported/LLaMARunner.h
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <UIKit/UIKit.h>
+#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION
### Summary
This file is out of sync with the internal Meta code repo. This change updates the Git copy to match, putting it back in sync.

### Test plan
CI