### PR TITLE
Added Command Line Option to Select Arm Zephyr Toolchain

### DIFF
--- a/examples/arm/setup.sh
+++ b/examples/arm/setup.sh
@@ -19,12 +19,18 @@ OS="$(uname -s)"
 root_dir="${script_dir}/ethos-u-scratch"
 eula_acceptance=0
 skip_toolchain_setup=0
+target_toolchain=""
 skip_fvp_setup=0
 skip_vela_setup=0
 
 
 # Figure out if setup.sh was called or sourced and save it into "is_script_sourced"
 (return 0 2>/dev/null) && is_script_sourced=1 || is_script_sourced=0
+
+# Global scope these so they can be set later
+toolchain_url=""
+toolchain_dir=""
+toolchain_md5_checksum=""
 
 if [[ "${ARCH}" == "x86_64" ]]; then
     # FVPs
@@ -35,11 +41,6 @@ if [[ "${ARCH}" == "x86_64" ]]; then
     corstone320_url="https://developer.arm.com/-/media/Arm%20Developer%20Community/Downloads/OSS/FVP/Corstone-320/FVP_Corstone_SSE-320_11.27_25_Linux64.tgz?rev=a507bffc219a4d5792f1192ab7002d89&hash=D9A824AA8227D2E679C9B9787FF4E8B6FBE3D7C6"
     corstone320_model_dir="Linux64_GCC-9.3"
     corstone320_md5_checksum="3deb3c68f9b2d145833f15374203514d"
-
-    # toochain
-    toolchain_url="https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/13.3.rel1/binrel/arm-gnu-toolchain-13.3.rel1-x86_64-arm-none-eabi.tar.xz"
-    toolchain_dir="arm-gnu-toolchain-13.3.rel1-x86_64-arm-none-eabi"
-    toolchain_md5_checksum="0601a9588bc5b9c99ad2b56133b7f118"
 elif [[ "${ARCH}" == "aarch64" ]] || [[ "${ARCH}" == "arm64" ]]; then
     # FVPs
     corstone300_url="https://developer.arm.com/-/media/Arm%20Developer%20Community/Downloads/OSS/FVP/Corstone-300/FVP_Corstone_SSE-300_11.22_20_Linux64_armv8l.tgz?rev=9cc6e9a32bb947ca9b21fa162144cb01&hash=7657A4CF27D42E892E3F08D452AAB073"
@@ -49,17 +50,6 @@ elif [[ "${ARCH}" == "aarch64" ]] || [[ "${ARCH}" == "arm64" ]]; then
     corstone320_url="https://developer.arm.com/-/media/Arm%20Developer%20Community/Downloads/OSS/FVP/Corstone-320/FVP_Corstone_SSE-320_11.27_25_Linux64_armv8l.tgz?rev=b6ebe0923cb84f739e017385fd3c333c&hash=8965C4B98E2FF7F792A099B08831FE3CB6120493"
     corstone320_model_dir="Linux64_armv8l_GCC-9.3"
     corstone320_md5_checksum="3889f1d80a6d9861ea4aa6f1c88dd0ae"
-
-    # toochain
-    if [[ "${OS}" == "Darwin" ]]; then
-        toolchain_url="https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/13.3.rel1/binrel/arm-gnu-toolchain-13.3.rel1-darwin-arm64-arm-none-eabi.tar.xz"
-        toolchain_dir="arm-gnu-toolchain-13.3.rel1-darwin-arm64-arm-none-eabi"
-        toolchain_md5_checksum="f1c18320bb3121fa89dca11399273f4e"
-    elif [[ "${OS}" == "Linux" ]]; then
-        toolchain_url="https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/13.3.rel1/binrel/arm-gnu-toolchain-13.3.rel1-aarch64-arm-none-eabi.tar.xz"
-        toolchain_dir="arm-gnu-toolchain-13.3.rel1-aarch64-arm-none-eabi"
-        toolchain_md5_checksum="303102d97b877ebbeb36b3158994b218"
-    fi
 else
     echo "[main] Error: only x86-64 & aarch64/arm64 architecture is supported for now!"; exit 1;
 fi
@@ -73,7 +63,7 @@ vela_rev="8cac2b9a7204b57125a8718049519b091a98846c"
 ########
 
 function print_usage() {
-    echo "Usage: $(basename $0) <--i-agree-to-the-contained-eula> [--root-dir path-to-a-scratch-dir] [--skip-fvp-setup] [--skip-toolchain-setup] [--skip-vela-setup]"
+    echo "Usage: $(basename $0) <--i-agree-to-the-contained-eula> [--root-dir path-to-a-scratch-dir] [--target-toolchain toolchain name] [--skip-fvp-setup] [--skip-toolchain-setup] [--skip-vela-setup]"
     echo "Supplied args: $*"
 }
 
@@ -100,6 +90,19 @@ function check_options() {
             --skip-toolchain-setup)
                 skip_toolchain_setup=1
                 shift
+                ;;
+            --target-toolchain)
+                # Only change default root dir if the script is being executed and not sourced.
+                if [[ $is_script_sourced -eq 0 ]]; then
+                    target_toolchain=${2:-"${target_toolchain}"}
+                fi
+
+                if [[ $# -ge 2 ]]; then
+                    shift 2
+                else
+                    print_usage "$@"
+                    exit 1
+                fi
                 ;;
             --skip-fvp-setup)
                 skip_fvp_setup=1
@@ -197,16 +200,59 @@ function setup_fvp() {
     done
 }
 
+function select_toolchain() {
+    if [[ "${ARCH}" == "x86_64" ]]; then
+        if [[ "${OS}" == "Linux" ]]; then
+	    if [[ "${target_toolchain}" == "zephyr" ]]; then
+	        # TODO can include support for zephyr toolchain for other host platforms later
+                toolchain_url="https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.17.2/toolchain_linux-x86_64_arm-zephyr-eabi.tar.xz"
+                toolchain_dir="arm-zephyr-eabi"
+                toolchain_md5_checksum="93128be0235cf5cf5f1ee561aa6eac5f"
+            else
+                toolchain_url="https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/13.3.rel1/binrel/arm-gnu-toolchain-13.3.rel1-x86_64-arm-none-eabi.tar.xz"
+                toolchain_dir="arm-gnu-toolchain-13.3.rel1-x86_64-arm-none-eabi"
+                toolchain_md5_checksum="0601a9588bc5b9c99ad2b56133b7f118"
+	    fi
+        else
+            echo "[main] Error: only Linux is currently supported for x86-64 architecture now!"; exit 1;
+	fi
+   elif [[ "${ARCH}" == "aarch64" ]] || [[ "${ARCH}" == "arm64" ]]; then
+        if [[ "${OS}" == "Darwin" ]]; then
+	    if [[ "${target_toolchain}" == "zephyr" ]]; then
+                echo "[main] Error: only Linux OS is currently supported for aarch64 architecture targeting Zephyr now!"; exit 1;
+	    else
+                toolchain_url="https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/13.3.rel1/binrel/arm-gnu-toolchain-13.3.rel1-darwin-arm64-arm-none-eabi.tar.xz"
+                toolchain_dir="arm-gnu-toolchain-13.3.rel1-darwin-arm64-arm-none-eabi"
+                toolchain_md5_checksum="f1c18320bb3121fa89dca11399273f4e"
+	    fi
+        elif [[ "${OS}" == "Linux" ]]; then
+	    if [[ "${target_toolchain}" == "zephyr" ]]; then
+	        # eventually, this can be support by downloading the the toolchain from 
+		# "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.17.2/toolchain_linux-aarch64_arm-zephyr-eabi.tar.xz"
+		# but for now, we error if user tries to specify this
+                echo "[main] Error: currently target_toolchain zephyr is only support for x86-64 Linux host systems!"; exit 1;
+	    else
+                toolchain_url="https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/13.3.rel1/binrel/arm-gnu-toolchain-13.3.rel1-aarch64-arm-none-eabi.tar.xz"
+                toolchain_dir="arm-gnu-toolchain-13.3.rel1-aarch64-arm-none-eabi"
+                toolchain_md5_checksum="303102d97b877ebbeb36b3158994b218"
+	    fi
+        fi
+    else
+        echo "[main] Error: only x86-64 & aarch64/arm64 architecture is supported for now!"; exit 1;
+    fi
+    echo "[main] Info selected ${toolchain_dir} for ${ARCH} - ${OS} platform"
+}
 function setup_toolchain() {
-    # Download and install the arm-none-eabi toolchain
+    # Download and install the arm toolchain (default is arm-none-eabi)
+    # setting --target-toolchain to zephyr sets this to arm-zephyr-eabi
     cd "${root_dir}"
     if [[ ! -e "${toolchain_dir}.tar.xz" ]]; then
-        echo "[${FUNCNAME[0]}] Downloading toolchain ..."
-        curl --output "${toolchain_dir}.tar.xz" "${toolchain_url}"
+        echo "[${FUNCNAME[0]}] Downloading ${toolchain_dir} toolchain ..."
+        curl --output "${toolchain_dir}.tar.xz" -L "${toolchain_url}"
         verify_md5 ${toolchain_md5_checksum} "${toolchain_dir}.tar.xz" || exit 1
     fi
 
-    echo "[${FUNCNAME[0]}] Installing toolchain ..."
+    echo "[${FUNCNAME[0]}] Installing ${toolchain_dir} toolchain ..."
     rm -rf "${toolchain_dir}"
     tar xf "${toolchain_dir}.tar.xz"
 }
@@ -272,11 +318,15 @@ if [[ $is_script_sourced -eq 0 ]]; then
     cd "${root_dir}"
     echo "[main] Using root dir ${root_dir} and options:"
     echo "skip-fvp-setup=${skip_fvp_setup}"
+    echo "target-toolchain=${target_toolchain}"
     echo "skip-toolchain-setup=${skip_toolchain_setup}"
     echo "skip-vela-setup=${skip_vela_setup}"
 
     # Import utils
     source $et_dir/backends/arm/scripts/utils.sh
+
+    # Select appropriate toolchain
+    select_toolchain
 
     # Setup toolchain
     if [[ "${skip_toolchain_setup}" -eq 0 ]]; then


### PR DESCRIPTION
### Summary
Adds the command line option `--target-toolchain` to the `examples/arm/setup.sh` script so that Arm Zephyr toolchain for x86-64 Linux host systems can be used. Sourcing the generated `setup_path.sh` puts the selected toolchain on the `PATH` environment variable.

### Test plan

Running:
```
./examples/arm/setup.sh --i-agree-to-the-contained-eula  --target-toolchain zephyr
source /home/zephyruser/executorch/examples/arm/ethos-u-scratch/setup_path.sh
arm-zephyr-eabi-gcc --version
```

Now produces the following output:

```
arm-zephyr-eabi-gcc (Zephyr SDK 0.17.2) 12.2.0
Copyright (C) 2022 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

While running: 

```
./examples/arm/setup.sh --i-agree-to-the-contained-eula
source /home/zephyruser/executorch/examples/arm/ethos-u-scratch/setup_path.sh
arm-none-eabi-gcc --version
```

Still produces the following output:

```
arm-none-eabi-gcc (Arm GNU Toolchain 13.3.Rel1 (Build arm-13.24)) 13.3.1 20240614
Copyright (C) 2023 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```