### PR TITLE
Add `required_for_abi_source_only = True` to extension/android:executorch_llama

### DIFF
--- a/extension/android/BUCK
+++ b/extension/android/BUCK
@@ -5,6 +5,7 @@ oncall("executorch")
 
 non_fbcode_target(_kind = fb_android_library,
     name = "executorch",
+    required_for_source_only_abi = True,
     srcs = [
         "executorch_android/src/main/java/org/pytorch/executorch/DType.java",
         "executorch_android/src/main/java/org/pytorch/executorch/EValue.java",


### PR DESCRIPTION
Summary:
[Buck's document on Java source ABI](https://buck.build/concept/java_abis.html) recommends adding `required_for_source_abi = True` to targets that export annotations:

> ... All annotations and compile-time constants (including enum values) used in the interface of a rule must be present during source-only ABI generation.
> The error will suggest adding required_for_source_abi = True to any rule that defines an annotation type or a compile-time constant that is used from another rule, ...

Differential Revision: D77479748


