### PR TITLE
Arm backend: Make sure we tests correctly with and without Corstone FVP

### DIFF
--- a/backends/arm/test/test_arm_baremetal.sh
+++ b/backends/arm/test/test_arm_baremetal.sh
@@ -73,6 +73,11 @@ all() { # Run all tests
 test_pytest_ops() { # Test ops and other things
     echo "${TEST_SUITE_NAME}: Run pytest"
 
+    # Make sure to not run this tests on FVP by removing the elf builds,
+    # as they are detected by the unit tests and used if they exists
+    rm -Rf arm_test/arm_semihosting_executor_runner_corstone-300
+    rm -Rf arm_test/arm_semihosting_executor_runner_corstone-320
+
     # Prepare for pytest
     backends/arm/scripts/build_executorch.sh
 
@@ -83,6 +88,11 @@ test_pytest_ops() { # Test ops and other things
 
 test_pytest_models() { # Test ops and other things
     echo "${TEST_SUITE_NAME}: Run pytest"
+
+    # Make sure to not run this tests on FVP by removing the elf builds,
+    # as they are detected by the unit tests and used if they exists
+    rm -Rf arm_test/arm_semihosting_executor_runner_corstone-300
+    rm -Rf arm_test/arm_semihosting_executor_runner_corstone-320
 
     # Prepare for pytest
     backends/arm/scripts/build_executorch.sh
@@ -105,7 +115,9 @@ test_pytest_ops_ethosu_fvp() { # Same as test_pytest but also sometime verify us
     # Prepare Corstone-3x0 FVP for pytest
     backends/arm/scripts/build_executorch.sh
     backends/arm/scripts/build_portable_kernels.sh
-    # Build semihosting version of the runner used by pytest testing when
+    # Build semihosting version of the runner used by pytest testing. This builds:
+    # arm_test/arm_semihosting_executor_runner_corstone-300
+    # arm_test/arm_semihosting_executor_runner_corstone-320
     backends/arm/test/setup_testing.sh
 
     # Run arm baremetal pytest tests with FVP
@@ -119,7 +131,9 @@ test_pytest_models_ethosu_fvp() { # Same as test_pytest but also sometime verify
     # Prepare Corstone-3x0 FVP for pytest
     backends/arm/scripts/build_executorch.sh
     backends/arm/scripts/build_portable_kernels.sh
-    # Build semihosting version of the runner used by pytest testing
+    # Build semihosting version of the runner used by pytest testing. This builds:
+    # arm_test/arm_semihosting_executor_runner_corstone-300
+    # arm_test/arm_semihosting_executor_runner_corstone-320
     backends/arm/test/setup_testing.sh
 
     # Run arm baremetal pytest tests with FVP


### PR DESCRIPTION
### Summary
If the elf for running pytest with Corstone FVP exists pytests will pick it up and run with it. This change make sure to remove the elf for the FVP tests if it exists in the none FVP tests before running the tests. As it is (already) build in the FVP versions of the tests, this fix a problem that if you run the test after each other the non FVP tests  could find the elf and run on the FVP even if it was not supposed to.

### Test plan
GitHub and local verification.

cc @digantdesai @freddan80 @per @oscarandersson8218