### PR TITLE
Updating documentation for cmake dtype selective build

### DIFF
--- a/docs/source/kernel-library-selective-build.md
+++ b/docs/source/kernel-library-selective-build.md
@@ -49,6 +49,7 @@ gen_selected_ops(
 )
 ```
 
+The macro makes a call to gen_oplist.py, which requires a [distinct selection](https://github.com/BujSet/executorch/blob/main/codegen/tools/gen_oplist.py#L222-L228) of API choice. `OPS_SCHEMA_YAML`, `ROOT_OPS`, `INCLUDE_ALL_OPS`, and `OPS_FROM_MODEL` are mutually exclusive options, and should not be used in conjunction. 
 
 ### Select all ops
 
@@ -70,7 +71,7 @@ This API lets users pass in a pte file of an exported model. When used, the pte 
 
 ### Dtype Selective Build
 
-Beyond pruning the binary to remove unused operators, the binary size can furhter reduced by enforcing checks on what dtypes are used by the specific operators. For example, if your model only uses floats for the `add` operator, then including variants of the `add` operators for `doubles` and `ints` is unnecessary. The flag `DTYPE_SELECTIVE_BUILD` can be set to `ON` to support this additional optimization. Currently, dtype selective build is only support with the model API described above. Once enabled, a header file that specifies only the operators and dtypes used by the model is created and linked against a rebuild of the `portable_kernels` lib. This feature is not yet supported for other libs.
+Beyond pruning the binary to remove unused operators, the binary size can further reduced by removing unused dtypes. For example, if your model only uses floats for the `add` operator, then including variants of the `add` operators for `doubles` and `ints` is unnecessary. The flag `DTYPE_SELECTIVE_BUILD` can be set to `ON` to support this additional optimization. Currently, dtype selective build is only supported with the model API described above. Once enabled, a header file that specifies only the operators and dtypes used by the model is created and linked against a rebuild of the `portable_kernels` lib. This feature is only supported for the portable kernels library; it's not supported for optimized, quantized or custom kernel libraries.
 
 ## Example Walkthrough
 

--- a/docs/source/kernel-library-selective-build.md
+++ b/docs/source/kernel-library-selective-build.md
@@ -91,4 +91,3 @@ These options allow a user to tailor the cmake build process to utilize the diff
 |<code><br> cmake -D… -DSELECT_OPS_YAML=ON <br></code> | <code><br>  set(_custom_ops_yaml ${EXECUTORCH_ROOT}/examples/portable/custom_ops/custom_ops.yaml) <br> gen_selected_ops("${_custom_ops_yaml}" "" "") <br></code> |
 |<code><br> cmake -D… -DEXECUTORCH_SELECT_OPS_FROM_MODEL="model.pte.out" <br></code> | <code><br> gen_selected_ops("" "" "" "${_model_path}" "") <br></code> |
 |<code><br> cmake -D… -DEXECUTORCH_SELECT_OPS_FROM_MODEL="model.pte.out" -DEXECUTORCH_DTYPE_SELECTIVE_BUILD=ON<br></code> | <code><br> gen_selected_ops("" "" "" "${_model_path}" "ON") <br></code> |
-

--- a/examples/selective_build/README.md
+++ b/examples/selective_build/README.md
@@ -12,13 +12,12 @@ cd executorch
 bash examples/selective_build/test_selective_build.sh cmake
 ```
 
-Check out `CMakeLists.txt` for demo of 4 selective build APIs:
+Check out `CMakeLists.txt` for demo of selective build APIs:
 1. `SELECT_ALL_OPS`: Select all ops from the dependency kernel libraries, register all of them into ExecuTorch runtime.
 2. `SELECT_OPS_LIST`: Only select operators from a list.
 3. `SELECT_OPS_YAML`: Only select operators from a yaml file.
-3. `SELECT_OPS_FROM_MODEL`: Only select operators from a from an exported model pte.
+4. `SELECT_OPS_FROM_MODEL`: Only select operators from a from an exported model pte.
+5. `DTYPE_SELECTIVE_BUILD`: Enable rebuild of `portable_kernels` to use dtype selection. Currently only supported for `SELECTED_OPS_FROM_MODEL` API and `portable_kernels` lib.
 
 Other configs:
 - `MAX_KERNEL_NUM=N`: Only allocate memory for N operators.
-
-We have one more API incoming: only select from an exported model file (.pte).

--- a/examples/selective_build/README.md
+++ b/examples/selective_build/README.md
@@ -12,10 +12,11 @@ cd executorch
 bash examples/selective_build/test_selective_build.sh cmake
 ```
 
-Check out `CMakeLists.txt` for demo of 3 selective build APIs:
+Check out `CMakeLists.txt` for demo of 4 selective build APIs:
 1. `SELECT_ALL_OPS`: Select all ops from the dependency kernel libraries, register all of them into ExecuTorch runtime.
 2. `SELECT_OPS_LIST`: Only select operators from a list.
 3. `SELECT_OPS_YAML`: Only select operators from a yaml file.
+3. `SELECT_OPS_FROM_MODEL`: Only select operators from a from an exported model pte.
 
 Other configs:
 - `MAX_KERNEL_NUM=N`: Only allocate memory for N operators.


### PR DESCRIPTION
### Summary
Updating documentation for cmake dtype selective build with model API. Table at `selective_build_model_doc/docs/source/kernel-library-selective-build.md` now looks like:

![image](https://github.com/user-attachments/assets/68b7c8fe-dfc5-4ae4-9756-5599680357bf)


Fixes #12065

cc @mergennachin @byjlw