### PR TITLE
Arm backend: Add mean.dim to CheckProperQuantization

### DIFF
--- a/backends/arm/operator_support/tosa_supported_operators.py
+++ b/backends/arm/operator_support/tosa_supported_operators.py
@@ -327,6 +327,7 @@ class CheckProperQuantization(OperatorSupportBase):
         exir_ops.edge.aten.upsample_bilinear2d.vec,
         exir_ops.edge.aten.upsample_nearest2d.vec,
         torch.ops.aten.scalar_tensor.default,
+        exir_ops.edge.aten.mean.dim,
         *TableOps.included_ops(),
     )
 


### PR DESCRIPTION
mean.dim decomposes into an avg_pool2d, which occurs after quantization annotation. This led to the avg_pool2d node not having quantization parameters for the output. mean.dim is added to CheckProperQuantization so that if the decomposition occurs the avg_pool2d operator will not be delegated.


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218