### PR TITLE
[Executorch][llm] Make runner return error if execution was not successful

### DIFF
--- a/examples/models/llama/main.cpp
+++ b/examples/models/llama/main.cpp
@@ -100,12 +100,20 @@ int32_t main(int32_t argc, char** argv) {
   }
 
   if (warmup) {
-    runner->warmup(prompt, /*max_new_tokens=*/seq_len);
+    auto error = runner->warmup(prompt, /*max_new_tokens=*/seq_len);
+    if (error != executorch::runtime::Error::Ok) {
+      ET_LOG(Error, "Failed to warmup llama runner");
+      return 1;
+    }
   }
   // generate
   executorch::extension::llm::GenerationConfig config{
       .seq_len = seq_len, .temperature = temperature};
-  runner->generate(prompt, config);
+  auto error = runner->generate(prompt, config);
+  if (error != executorch::runtime::Error::Ok) {
+    ET_LOG(Error, "Failed to warmup llama runner");
+    return 1;
+  }
 
   return 0;
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #12132
* #12131
* __->__ #12129

At the moment we continue execution and the stack fails later on as I found when running with quantize kv cache + ring attention

Differential Revision: [D77516822](https://our.internmc.facebook.com/intern/diff/D77516822/)