### PR TITLE
Set Weight Loading to be strict

### DIFF
--- a/examples/qualcomm/oss_scripts/llama/llama.py
+++ b/examples/qualcomm/oss_scripts/llama/llama.py
@@ -591,7 +591,7 @@ def compile(args, pte_filename, tokenizer):
     for llama_instance in llama_instance_list:
         llama_instance.load_state_dict(
             state_dict,
-            strict=False,
+            strict=True,
             assign=True,
         )
     end_load_ts = time.time()


### PR DESCRIPTION
Summary: It often causes confusion and weird downstream error when the weight is not properly loaded. Set `load_state_dict` to be True so the error populated early.

Differential Revision: D77626023


