### PR TITLE
Added Pybindings for Method.h/cpp

### DIFF
--- a/extension/pybindings/portable_lib.py
+++ b/extension/pybindings/portable_lib.py
@@ -49,6 +49,7 @@ from executorch.extension.pybindings._portable_lib import (  # noqa: F401
     _reset_profile_results,  # noqa: F401
     _unsafe_reset_threadpool,  # noqa: F401
     BundledModule,  # noqa: F401
+    ExecuTorchMethod,  # noqa: F401
     ExecuTorchModule,  # noqa: F401
     ExecuTorchProgram,  # noqa: F401
     MethodMeta,  # noqa: F401

--- a/extension/pybindings/pybindings.cpp
+++ b/extension/pybindings/pybindings.cpp
@@ -468,12 +468,33 @@ struct PyBundledModule final {
   size_t program_len_;
 };
 
+// Program points to DataLoader so bundle them up into a struct to ensure that
+// it stays alive.
+struct ProgramState final {
+  std::unique_ptr<DataLoader> loader_;
+  std::unique_ptr<Program> program_;
+
+  explicit ProgramState(
+      std::unique_ptr<DataLoader> loader,
+      std::unique_ptr<Program> program)
+      : loader_(std::move(loader)), program_(std::move(program)) {}
+  ProgramState(const ProgramState&) = delete;
+  ProgramState& operator=(const ProgramState&) = delete;
+  ProgramState(ProgramState&&) = default;
+  ProgramState& operator=(ProgramState&&) = default;
+};
+
 /// Expose a subset of TensorInfo information to python.
 struct PyTensorInfo final {
   explicit PyTensorInfo(
       std::shared_ptr<Module> module,
       torch::executor::TensorInfo info)
-      : module_(std::move(module)), info_(info) {}
+      : module_(std::move(module)), state_(nullptr), info_(info) {}
+
+  explicit PyTensorInfo(
+      std::shared_ptr<ProgramState> state,
+      torch::executor::TensorInfo info)
+      : module_(nullptr), state_(std::move(state)), info_(info) {}
 
   py::tuple sizes() const {
     const auto shape = info_.sizes();
@@ -518,8 +539,9 @@ struct PyTensorInfo final {
   }
 
  private:
-  // TensorInfo relies on module to be alive.
+  // TensorInfo relies on either a module or program to be alive.
   std::shared_ptr<Module> module_;
+  std::shared_ptr<ProgramState> state_;
   torch::executor::TensorInfo info_;
 };
 
@@ -528,7 +550,12 @@ struct PyMethodMeta final {
   explicit PyMethodMeta(
       std::shared_ptr<Module> module,
       torch::executor::MethodMeta meta)
-      : module_(std::move(module)), meta_(meta) {}
+      : module_(std::move(module)), state_(nullptr), meta_(meta) {}
+
+  explicit PyMethodMeta(
+      std::shared_ptr<ProgramState> state,
+      torch::executor::MethodMeta meta)
+      : module_(nullptr), state_(std::move(state)), meta_(meta) {}
 
   const char* name() const {
     return meta_.name();
@@ -542,7 +569,11 @@ struct PyMethodMeta final {
     const auto result = meta_.input_tensor_meta(index);
     THROW_INDEX_IF_ERROR(
         result.error(), "Cannot get input tensor meta at %zu", index);
-    return std::make_unique<PyTensorInfo>(module_, result.get());
+    if (module_) {
+      return std::make_unique<PyTensorInfo>(module_, result.get());
+    } else {
+      return std::make_unique<PyTensorInfo>(state_, result.get());
+    }
   }
 
   size_t num_outputs() const {
@@ -553,7 +584,11 @@ struct PyMethodMeta final {
     const auto result = meta_.output_tensor_meta(index);
     THROW_INDEX_IF_ERROR(
         result.error(), "Cannot get output tensor meta at %zu", index);
-    return std::make_unique<PyTensorInfo>(module_, result.get());
+    if (module_) {
+      return std::make_unique<PyTensorInfo>(module_, result.get());
+    } else {
+      return std::make_unique<PyTensorInfo>(state_, result.get());
+    }
   }
 
   py::str repr() const {
@@ -585,8 +620,10 @@ struct PyMethodMeta final {
   }
 
  private:
-  // Must keep the Module object alive or else the meta object is invalidated.
+  // Must keep the either the Module or Program object alive or else the meta
+  // object is invalidated.
   std::shared_ptr<Module> module_;
+  std::shared_ptr<ProgramState> state_;
   torch::executor::MethodMeta meta_;
 };
 
@@ -983,46 +1020,417 @@ inline std::unique_ptr<DataLoader> loader_from_file(const std::string& path) {
   return std::make_unique<MmapDataLoader>(std::move(res.get()));
 }
 
-inline std::unique_ptr<Program> load_program(
-    DataLoader* loader,
+inline std::shared_ptr<ProgramState> load_program(
+    std::unique_ptr<DataLoader> loader,
     Program::Verification program_verification) {
-  Result<Program> res = Program::load(loader, program_verification);
+  Result<Program> res = Program::load(loader.get(), program_verification);
   THROW_IF_ERROR(
       res.error(),
       "Failed to load program, error: 0x:%" PRIx32,
       static_cast<uint32_t>(res.error()));
-  return std::make_unique<Program>(std::move(res.get()));
+  return std::make_shared<ProgramState>(
+      std::move(loader), std::make_unique<Program>(std::move(res.get())));
 }
+
+/// A wrapper/util class for executorch memory allocations/manager.
+class ProgramMemory {
+ public:
+  explicit ProgramMemory(std::vector<std::vector<uint8_t>>&& non_const_buffers)
+      : runtime_allocator_(),
+        non_const_buffers_(std::move(non_const_buffers)),
+        non_const_spans_(create_non_const_spans()),
+        non_const_allocator_(
+            {non_const_spans_.data(), non_const_spans_.size()}),
+        mem_manager_(
+            &const_allocator_,
+            &non_const_allocator_,
+            &runtime_allocator_,
+            &temp_allocator_) {}
+
+  /// Returns a pointer to the internal memory manager, the Memory instance
+  /// must outlive this pointer.
+  MemoryManager* mem_manager() {
+    return &mem_manager_;
+  }
+
+  ProgramMemory(const ProgramMemory&) = delete;
+  ProgramMemory& operator=(const ProgramMemory&) = delete;
+
+ private:
+  MemoryAllocator const_allocator_{MemoryAllocator(0, nullptr)};
+
+  MallocMemoryAllocator runtime_allocator_;
+
+  MemoryAllocator temp_allocator_{MemoryAllocator(0, nullptr)};
+
+  std::vector<std::vector<uint8_t>> non_const_buffers_;
+
+  std::vector<Span<uint8_t>> non_const_spans_;
+
+  HierarchicalAllocator non_const_allocator_;
+
+  MemoryManager mem_manager_;
+
+  std::vector<Span<uint8_t>> create_non_const_spans() {
+    std::vector<Span<uint8_t>> result;
+    for (size_t i = 0; i < non_const_buffers_.size(); i++) {
+      result.push_back(
+          {non_const_buffers_[i].data(), non_const_buffers_[i].size()});
+    }
+    return result;
+  }
+};
+
+struct PyMethod final {
+  explicit PyMethod(
+      std::shared_ptr<ProgramMemory> memory,
+      std::shared_ptr<ProgramState> state,
+      std::unique_ptr<Method> method)
+      : memory_(std::move(memory)),
+        state_(std::move(state)),
+        method_(std::move(method)) {}
+
+  void set_inputs(const py::sequence& inputs) {
+    const auto inputs_size = py::len(inputs);
+    std::vector<EValue> cpp_inputs;
+    cpp_inputs.reserve(inputs_size);
+
+#ifndef USE_ATEN_LIB // Portable mode
+    // So the ETensors and their metadata stay in scope for
+    // Module->set_inputs.
+    std::vector<torch::executor::TensorImpl> input_tensors;
+    std::vector<std::vector<torch::executor::Tensor::SizesType>> input_sizes;
+    std::vector<std::vector<torch::executor::Tensor::StridesType>>
+        input_strides;
+    std::vector<std::vector<torch::executor::Tensor::DimOrderType>>
+        input_dim_order;
+    // We store pointers to these vector elements so important to reserve so
+    // that we don't lose those on a vector resize. Don't need to do this for
+    // the others since they are vectors of vectors, and we don't store a
+    // pointer to the root level vector data.
+    input_tensors.reserve(inputs_size);
+#endif
+
+    // Convert python objects into EValues.
+    for (size_t i = 0; i < inputs_size; ++i) {
+      auto python_input = inputs[i];
+      const std::string& type_str = py::str(python_input.get_type());
+      if (type_str == "<class 'torch.Tensor'>") {
+        auto at_tensor = python_input.cast<at::Tensor>();
+
+#ifdef USE_ATEN_LIB
+        EValue evalue(at_tensor);
+#else
+        // convert at::Tensor to torch::executor::Tensor
+        auto type =
+            torch_to_executorch_scalar_type(at_tensor.options().dtype());
+        size_t dim = at_tensor.dim();
+        // cant directly alias at::Tensor sizes and strides due to int64 vs
+        // int32 typing conflict
+        input_sizes.emplace_back(
+            at_tensor.sizes().begin(), at_tensor.sizes().end());
+        input_strides.emplace_back(
+            at_tensor.strides().begin(), at_tensor.strides().end());
+
+        // Only works for MemoryFormat::Contiguous or MemoryFormat::ChannelsLast
+        // inputs
+        std::vector<torch::executor::Tensor::DimOrderType> dim_order;
+        if (at_tensor.is_contiguous()) {
+          for (size_t cur_dim = 0; cur_dim < dim; cur_dim++) {
+            dim_order.push_back(cur_dim);
+          }
+        } else if (
+            at_tensor.is_contiguous(at::MemoryFormat::ChannelsLast) &&
+            at_tensor.dim() == 4) {
+          dim_order = decltype(dim_order)({0, 2, 3, 1});
+        } else {
+          auto error_msg = "Input " + std::to_string(i) + "for method " +
+              method_->method_meta().name() +
+              " should be contiguous or channels-last.";
+          throw std::runtime_error(error_msg);
+        }
+        input_dim_order.push_back(std::move(dim_order));
+        input_tensors.emplace_back(
+            type,
+            dim,
+            input_sizes.back().data(),
+            nullptr,
+            input_dim_order.back().data(),
+            input_strides.back().data());
+
+        torch::executor::Tensor temp =
+            torch::executor::Tensor(&input_tensors.back());
+        alias_etensor_to_attensor(at_tensor, temp);
+        EValue evalue(temp);
+#endif
+
+        cpp_inputs.push_back(evalue);
+      } else if (py::isinstance<py::none>(python_input)) {
+        cpp_inputs.push_back(EValue());
+      } else if (py::isinstance<py::bool_>(python_input)) {
+        cpp_inputs.push_back(EValue(py::cast<bool>(python_input)));
+      } else if (py::isinstance<py::int_>(python_input)) {
+        cpp_inputs.push_back(EValue(py::cast<int64_t>(python_input)));
+      } else {
+        throw std::runtime_error(
+            "Unsupported python type " + type_str +
+            ". Ensure that inputs are passed as a flat list of tensors.");
+      }
+    }
+
+    executorch::aten::ArrayRef<EValue> input_evalue_list(
+        cpp_inputs.data(), cpp_inputs.size());
+
+    Error set_inputs_status = method_->set_inputs(input_evalue_list);
+    THROW_IF_ERROR(
+        set_inputs_status,
+        "method->set_inputs() for method '%s' failed with error 0x%" PRIx32,
+        method_->method_meta().name(),
+        static_cast<uint32_t>(set_inputs_status));
+  }
+
+  void execute() {
+    const auto num_outputs = method_->outputs_size();
+    allocate_output_storages();
+    std::vector<Span<uint8_t>> output_storage_spans(num_outputs);
+    for (int i = 0; i < output_storages_.size(); ++i) {
+      output_storage_spans[i] =
+          Span<uint8_t>(output_storages_[i].data(), output_storages_[i].size());
+    }
+#ifdef USE_ATEN_LIB
+    // [TLS handling] This is to workaround an assertion failure
+    // (https://fburl.com/code/302jyn8d) running `gelu` in ATen mode in fbcode
+    // (such as bento). The problem is ExecuTorch ATen mode doesn't have
+    // Thread Local State, but `torch-cpp` is assuming tls init is done. There
+    // are two more checks: MKLDNN disabled and C10_MOBILE, if any of them is
+    // true we won't be hitting this assertion error. However in `torch-cpp`
+    // lib both checks are false. Production impact: this should not make any
+    // impact in production environment, given that in xplat we are depending
+    // on a library that enables C10_MOBILE (`torch_mobile_core`).
+    c10::impl::ExcludeDispatchKeyGuard no_autograd(
+        c10::autograd_dispatch_keyset);
+#endif
+    setup_output_storage(*method_, output_storage_spans);
+    Error execute_status = method_->execute();
+    THROW_IF_ERROR(
+        execute_status,
+        "method->execute() failed with error 0x%" PRIx32,
+        static_cast<uint32_t>(execute_status));
+  }
+
+  py::list get_outputs(bool clone_outputs = true) {
+    std::vector<EValue> result(method_->outputs_size());
+
+    Error get_outputs_status =
+        method_->get_outputs(result.data(), method_->outputs_size());
+    THROW_IF_ERROR(
+        get_outputs_status,
+        "method->get_outputs() for method '%s' failed with error 0x%" PRIx32,
+        method_->method_meta().name(),
+        static_cast<uint32_t>(get_outputs_status));
+
+    // Retrieve outputs
+    return get_outputs_as_py_list(result, clone_outputs);
+  }
+
+  py::list call(const py::sequence& inputs, bool clone_outputs = true) {
+    set_inputs(inputs);
+    execute();
+    return get_outputs(clone_outputs);
+  }
+
+  py::list call_single_input(
+      const torch::Tensor& inputTensor,
+      bool clone_outputs = true) {
+    py::list py_list;
+    py_list.append(py::cast(inputTensor));
+    return call(py_list, clone_outputs);
+  }
+
+  py::object get_attribute(const std::string& name) {
+    Result<executorch::aten::Tensor> attr = method_->get_attribute(name);
+    THROW_IF_ERROR(
+        attr.error(),
+        "Failed to get attribute '%s' for method '%s', error: 0x:%" PRIx32,
+        name.c_str(),
+        method_->method_meta().name(),
+        static_cast<uint32_t>(attr.error()));
+#ifdef USE_ATEN_LIB
+    return py::cast(attr.get());
+#else
+    return py::cast(alias_attensor_to_etensor(attr.get()));
+#endif
+  }
+
+  PyMethodMeta method_meta() {
+    return PyMethodMeta(state_, method_->method_meta());
+  }
+
+ private:
+  // Method keeps a reference to the memory manager, so we need to keep this
+  // alive
+  std::shared_ptr<ProgramMemory> memory_;
+  // Method keeps a reference to the program, so we also need to keep this alive
+  std::shared_ptr<ProgramState> state_;
+  std::unique_ptr<Method> method_;
+  // Need to keep-alive output storages until they can be compared in case of
+  // bundled programs.
+  std::vector<std::vector<uint8_t>> output_storages_;
+
+  void allocate_output_storages() {
+    const auto num_outputs = method_->outputs_size();
+    // Skip if we already have the right number of storages.
+    if (output_storages_.size() == num_outputs) {
+      return;
+    }
+    // Create a buffer for each output tensor. Memory planned outputs and non
+    // tensor outputs get an empty buffer in this list which is ignored later.
+    output_storages_.reserve(num_outputs);
+    auto meta = method_->method_meta();
+    for (size_t i = 0; i < num_outputs; ++i) {
+      auto output_type = meta.output_tag(i);
+      THROW_IF_ERROR(
+          output_type.error(), "Failed to get output type for output %zu", i);
+      if (output_type.get() != Tag::Tensor) {
+        // Skip allocating storage for non-tensor outputs.
+        output_storages_.emplace_back();
+        continue;
+      }
+      const auto& output_tensor_meta =
+          method_->method_meta().output_tensor_meta(i);
+      THROW_IF_ERROR(
+          output_tensor_meta.error(),
+          "Failed to get output tensor meta for output %zu",
+          i);
+      if (output_tensor_meta.get().is_memory_planned()) {
+        // Skip allocating storage for planned memory outputs.
+        output_storages_.emplace_back();
+        continue;
+      }
+      // Allocate storage for the output tensor.
+      const size_t output_size = output_tensor_meta.get().nbytes();
+      output_storages_.emplace_back(output_size);
+    }
+  }
+
+  py::list get_outputs_as_py_list(
+      const std::vector<EValue>& outputs,
+      bool clone_outputs = true) {
+    const auto outputs_size = outputs.size();
+    py::list list(outputs_size);
+    for (size_t i = 0; i < outputs_size; ++i) {
+      auto& v = outputs[i];
+      if (Tag::None == v.tag) {
+        list[i] = py::none();
+      } else if (Tag::Int == v.tag) {
+        list[i] = py::cast(v.toInt());
+      } else if (Tag::Double == v.tag) {
+        list[i] = py::cast(v.toDouble());
+      } else if (Tag::Bool == v.tag) {
+        list[i] = py::cast(v.toBool());
+      } else if (Tag::String == v.tag) {
+        list[i] = py::cast(std::string(v.toString().data()));
+      } else if (Tag::Tensor == v.tag) {
+#ifdef USE_ATEN_LIB
+        // Clone so the outputs in python do not share a lifetime with the
+        // module object
+        if (clone_outputs) {
+          list[i] = py::cast(v.toTensor().clone());
+        } else {
+          list[i] = py::cast(v.toTensor());
+        }
+#else
+        if (clone_outputs) {
+          list[i] = py::cast(alias_attensor_to_etensor(v.toTensor()).clone());
+        } else {
+          list[i] = py::cast(alias_attensor_to_etensor(v.toTensor()));
+        }
+#endif
+      } else {
+        ET_ASSERT_UNREACHABLE_MSG("Invalid model output type");
+      }
+    }
+    return list;
+  }
+};
 
 struct PyProgram final {
   explicit PyProgram(
-      const py::bytes& buffer,
+      std::unique_ptr<DataLoader> loader,
+      std::unique_ptr<ETDumpGen> tracer = nullptr,
+      size_t debug_buffer_size = 0,
       Program::Verification program_verification =
           Program::Verification::Minimal)
-      : loader_(loader_from_buffer(
-            buffer.cast<std::string_view>().data(),
-            py::len(buffer))),
-        program_(load_program(loader_.get(), program_verification)) {}
+      : state_(load_program(std::move(loader), program_verification)),
+        event_tracer_(std::move(tracer)),
+        debug_buffer_size_(debug_buffer_size) {
+    // Figure out the size of each non_const layer we need to support every
+    // method in the program. Map will be easier to use than a list because we
+    // dont know how many non_const arenas there will be
+    std::map<size_t, int64_t> non_const_buffer_sizes;
+    for (size_t i = 0; i < state_->program_->num_methods(); ++i) {
+      auto name = state_->program_->get_method_name(i).get();
+      auto method_meta = state_->program_->method_meta(name).get();
+      for (size_t j = 0; j < method_meta.num_non_const_buffers(); j++) {
+        int64_t buffer_size = method_meta.non_const_buffer_size(j).get();
+        if (non_const_buffer_sizes.find(j) == non_const_buffer_sizes.end()) {
+          non_const_buffer_sizes.insert({j, buffer_size});
+        } else {
+          non_const_buffer_sizes[j] =
+              std::max(non_const_buffer_sizes[j], buffer_size);
+        }
+      }
+    }
 
-  explicit PyProgram(
-      const std::string& path,
-      Program::Verification program_verification =
-          Program::Verification::Minimal)
-      : loader_(loader_from_file(path)),
-        program_(load_program(loader_.get(), program_verification)) {}
+    // Allocate the arenas. Using vector because we need to remember the size as
+    // well, so vector is easier then unique_ptr.
+    std::vector<std::vector<uint8_t>> non_const_buffers_;
+    for (std::map<size_t, int64_t>::iterator i = non_const_buffer_sizes.begin();
+         i != non_const_buffer_sizes.end();
+         i++) {
+      non_const_buffers_.push_back(std::vector<uint8_t>(i->second));
+    }
+
+    memory_ = std::make_shared<ProgramMemory>(std::move(non_const_buffers_));
+    if (event_tracer_ && debug_buffer_size > 0) {
+      // If a debug buffer was requested for the ETDump, allocate it and make
+      // sure its lifetime is as long as the event_tracer.
+      debug_buffer_ = std::make_unique<uint8_t[]>(debug_buffer_size);
+      event_tracer_->set_debug_buffer(get_etdump_debug_buffer());
+      event_tracer_->set_event_tracer_debug_level(
+          EventTracerDebugLogLevel::kIntermediateOutputs);
+    }
+  }
 
   static std::unique_ptr<PyProgram> load_from_buffer(
       const py::bytes& buffer,
+      bool enable_etdump,
+      size_t debug_buffer_size,
       Program::Verification program_verification =
           Program::Verification::Minimal) {
-    return std::make_unique<PyProgram>(buffer, program_verification);
+    std::unique_ptr<DataLoader> loader = loader_from_buffer(
+        buffer.cast<std::string_view>().data(), py::len(buffer));
+    return std::make_unique<PyProgram>(
+        std::move(loader),
+        enable_etdump ? std::make_unique<torch::executor::ETDumpGen>()
+                      : nullptr,
+        debug_buffer_size,
+        program_verification);
   }
 
   static std::unique_ptr<PyProgram> load_from_file(
       const std::string& path,
+      bool enable_etdump,
+      size_t debug_buffer_size,
       Program::Verification program_verification =
           Program::Verification::Minimal) {
-    return std::make_unique<PyProgram>(path, program_verification);
+    std::unique_ptr<DataLoader> loader = loader_from_file(path);
+    return std::make_unique<PyProgram>(
+        std::move(loader),
+        enable_etdump ? std::make_unique<torch::executor::ETDumpGen>()
+                      : nullptr,
+        debug_buffer_size,
+        program_verification);
   }
 
   PyProgram(const PyProgram&) = delete;
@@ -1031,11 +1439,11 @@ struct PyProgram final {
   PyProgram& operator=(PyProgram&&) = default;
 
   size_t num_methods() const {
-    return program_->num_methods();
+    return state_->program_->num_methods();
   }
 
   std::string get_method_name(size_t method_index) const {
-    Result<const char*> res = program_->get_method_name(method_index);
+    Result<const char*> res = state_->program_->get_method_name(method_index);
     THROW_IF_ERROR(
         res.error(),
         "Failed get method name, error: 0x:%" PRIx32,
@@ -1043,9 +1451,39 @@ struct PyProgram final {
     return std::string(res.get());
   }
 
+  std::unique_ptr<PyMethod> load_method(const std::string& method_name) {
+    Result<Method> res = state_->program_->load_method(
+        method_name.c_str(), memory_->mem_manager());
+    THROW_IF_ERROR(
+        res.error(),
+        "Failed to load method %s, error: 0x:%" PRIx32,
+        method_name.c_str(),
+        static_cast<uint32_t>(res.error()));
+    return std::make_unique<PyMethod>(
+        memory_, state_, std::make_unique<Method>(std::move(res.get())));
+  }
+
+  Span<uint8_t> get_etdump_debug_buffer() {
+    return Span<uint8_t>(debug_buffer_.get(), debug_buffer_size_);
+  }
+
+  std::unique_ptr<PyMethodMeta> method_meta(const std::string& method_name) {
+    Result<torch::executor::MethodMeta> res =
+        state_->program_->method_meta(method_name.c_str());
+    THROW_IF_ERROR(
+        res.error(),
+        "Failed to get method meta for method %s, error: 0x:%" PRIx32,
+        method_name.c_str(),
+        static_cast<uint32_t>(res.error()));
+    return std::make_unique<PyMethodMeta>(state_, std::move(res.get()));
+  }
+
  private:
-  std::unique_ptr<DataLoader> loader_;
-  std::unique_ptr<Program> program_;
+  std::shared_ptr<ProgramMemory> memory_;
+  std::shared_ptr<ProgramState> state_;
+  std::unique_ptr<ETDumpGen> event_tracer_;
+  std::unique_ptr<uint8_t[]> debug_buffer_;
+  size_t debug_buffer_size_;
 };
 
 void create_profile_block(const std::string& name) {
@@ -1239,12 +1677,16 @@ PYBIND11_MODULE(EXECUTORCH_PYTHON_MODULE_NAME, m) {
       "_load_program",
       &PyProgram::load_from_file,
       py::arg("path"),
+      py::arg("enable_etdump") = false,
+      py::arg("debug_buffer_size") = 0,
       py::arg("program_verification") = Program::Verification::Minimal,
       call_guard);
   m.def(
       "_load_program_from_buffer",
       &PyProgram::load_from_buffer,
       py::arg("buffer"),
+      py::arg("enable_etdump") = false,
+      py::arg("debug_buffer_size") = 0,
       py::arg("program_verification") = Program::Verification::Minimal,
       call_guard);
   py::class_<PyProgram>(m, "ExecuTorchProgram")
@@ -1253,7 +1695,55 @@ PYBIND11_MODULE(EXECUTORCH_PYTHON_MODULE_NAME, m) {
           "get_method_name",
           &PyProgram::get_method_name,
           py::arg("method_index"),
+          call_guard)
+      .def(
+          "load_method",
+          &PyProgram::load_method,
+          py::arg("method_name"),
+          call_guard)
+      .def(
+          "method_meta",
+          &PyProgram::method_meta,
+          py::arg("method_name"),
           call_guard);
+  py::class_<PyMethod>(m, "ExecuTorchMethod")
+      .def("set_inputs", &PyMethod::set_inputs, py::arg("inputs"), call_guard)
+      .def("execute", &PyMethod::execute, call_guard)
+      .def(
+          "get_outputs",
+          &PyMethod::get_outputs,
+          py::arg("clone_outputs") = true,
+          call_guard)
+      .def(
+          "call",
+          &PyMethod::call,
+          py::arg("inputs") = py::list(),
+          py::arg("clone_outputs") = true,
+          call_guard)
+      .def(
+          "call",
+          &PyMethod::call_single_input,
+          py::arg("inputs") = py::list(),
+          py::arg("clone_outputs") = true,
+          call_guard)
+      .def(
+          "__call__",
+          &PyMethod::call,
+          py::arg("inputs") = py::list(),
+          py::arg("clone_outputs") = true,
+          call_guard)
+      .def(
+          "__call__",
+          &PyMethod::call_single_input,
+          py::arg("inputs") = py::list(),
+          py::arg("clone_outputs") = true,
+          call_guard)
+      .def(
+          "get_attribute",
+          &PyMethod::get_attribute,
+          py::arg("name"),
+          call_guard)
+      .def("method_meta", &PyMethod::method_meta, call_guard);
 }
 
 namespace {

--- a/extension/pybindings/test/make_test.py
+++ b/extension/pybindings/test/make_test.py
@@ -118,6 +118,24 @@ class ModuleAddConstReturn(torch.nn.Module):
         return (torch.ones(2, 2),)
 
 
+class ModuleAddWithAttributes(torch.nn.Module):
+    """The module to serialize and execute."""
+
+    def __init__(self):
+        super(ModuleAddWithAttributes, self).__init__()
+        self.register_buffer("state", torch.zeros(2, 2))
+
+    def forward(self, x, y):
+        self.state.add_(1)
+        return x + y + self.state
+
+    def get_methods_to_export(self):
+        return ("forward",)
+
+    def get_inputs(self):
+        return (torch.ones(2, 2), torch.ones(2, 2))
+
+
 def create_program(
     eager_module: torch.nn.Module,
     et_config: Optional[ExecutorchBackendConfig] = None,
@@ -505,6 +523,417 @@ def make_test(  # noqa: C901
 
             tester.assertRaises(RuntimeError, executorch_program.get_method_name, 2)
 
+        def test_method_e2e(tester):
+            # Create an ExecuTorch program from ModuleAdd.
+            exported_program, inputs = create_program(ModuleAdd())
+
+            # Use pybindings to load the program.
+            executorch_program = load_prog_fn(exported_program.buffer)
+
+            # Use pybindings to load and execute the method.
+            executorch_method = executorch_program.load_method("forward")
+            executorch_output = executorch_method.call(inputs)[0]
+
+            # The test module adds the two inputs, so its output should be the same
+            # as adding them directly.
+            expected = inputs[0] + inputs[1]
+
+            tester.assertEqual(str(expected), str(executorch_output))
+
+        def test_method_output_lifespan(tester):
+            def lower_function_call():
+                program, inputs = create_program(ModuleMulti())
+                executorch_program = load_prog_fn(program.buffer)
+
+                executorch_method = executorch_program.load_method("forward")
+                return executorch_method.call(inputs)
+                # executorch_program is destructed here and all of its memory is freed
+
+            outputs = lower_function_call()
+            tester.assertTrue(torch.allclose(outputs[0], torch.ones(2, 2) * 2))
+
+        def test_method_multiple_entry(tester):
+            program, inputs = create_program(ModuleMulti())
+            executorch_program = load_prog_fn(program.buffer)
+
+            executorch_method = executorch_program.load_method("forward")
+            executorch_output = executorch_method.call(inputs)[0]
+            tester.assertTrue(torch.allclose(executorch_output, torch.ones(2, 2) * 2))
+
+            executorch_method2 = executorch_program.load_method("forward2")
+            executorch_output2 = executorch_method2.call(inputs)[0]
+            tester.assertTrue(torch.allclose(executorch_output2, torch.ones(2, 2) * 3))
+
+        def test_method_by_parts(tester):
+            # Create an ExecuTorch program from ModuleAdd.
+            exported_program, inputs = create_program(ModuleAdd())
+
+            # Use pybindings to load the program.
+            executorch_program = load_prog_fn(exported_program.buffer)
+
+            # Use pybindings to load and the method.
+            executorch_method = executorch_program.load_method("forward")
+
+            # Call each part separately.
+            executorch_method.set_inputs(inputs)
+            executorch_method.execute()
+            executorch_output = executorch_method.get_outputs()[0]
+
+            # The test module adds the two inputs, so its output should be the same
+            # as adding them directly.
+            expected = inputs[0] + inputs[1]
+
+            tester.assertEqual(str(expected), str(executorch_output))
+
+        def test_method_callable(tester):
+            # Create an ExecuTorch program from ModuleAdd.
+            exported_program, inputs = create_program(ModuleAdd())
+
+            # Use pybindings to load and execute the program.
+            executorch_program = load_prog_fn(exported_program.buffer)
+            # Invoke the callable on executorch_method instead of calling module.forward.
+            executorch_method = executorch_program.load_method("forward")
+            executorch_output = executorch_method(inputs)[0]
+
+            # The test module adds the two inputs, so its output should be the same
+            # as adding them directly.
+            expected = inputs[0] + inputs[1]
+            tester.assertEqual(str(expected), str(executorch_output))
+
+        def test_method_single_input(tester):
+            # Create an ExecuTorch program from ModuleAdd.
+            exported_program, inputs = create_program(ModuleAddSingleInput())
+
+            # Use pybindings to load and execute the program.
+            executorch_program = load_prog_fn(exported_program.buffer)
+            # Inovke the callable on executorch_method instead of calling module.forward.
+            # Use only one input to test this case.
+            executorch_method = executorch_program.load_method("forward")
+            executorch_output = executorch_method(inputs[0])[0]
+
+            # The test module adds the two inputs, so its output should be the same
+            # as adding them directly.
+            expected = inputs[0] + inputs[0]
+            tester.assertEqual(str(expected), str(executorch_output))
+
+        def test_method_stderr_redirect(tester):
+            import sys
+            from io import StringIO
+
+            class RedirectedStderr:
+                def __init__(self):
+                    self._stderr = None
+                    self._string_io = None
+
+                def __enter__(self):
+                    self._stderr = sys.stderr
+                    sys.stderr = self._string_io = StringIO()
+                    return self
+
+                def __exit__(self, type, value, traceback):
+                    sys.stderr = self._stderr
+
+                def __str__(self):
+                    return self._string_io.getvalue()
+
+            with RedirectedStderr() as out:
+                try:
+                    # Create an ExecuTorch program from ModuleAdd.
+                    program, inputs = create_program(ModuleAdd())
+
+                    # Use pybindings to load the program.
+                    executorch_program = load_prog_fn(program.buffer)
+
+                    # Use pybindings to load and execute the method.
+                    executorch_method = executorch_program.load_method("forward")
+
+                    # add an extra input to trigger error
+                    inputs = (*inputs, 1)
+
+                    # Invoke the callable on executorch_module instead of calling module.forward.
+                    executorch_output = executorch_method(inputs)[0]  # noqa
+                    tester.assertFalse(True)  # should be unreachable
+                except Exception:
+                    tester.assertTrue(str(out).find("The length of given input array"))
+
+        def test_method_quantized_ops(tester):
+            eager_module = ModuleAdd()
+
+            from executorch.exir import EdgeCompileConfig
+            from executorch.exir.passes.quant_fusion_pass import QuantFusionPass
+            from torch.ao.quantization import get_default_qconfig_mapping
+            from torch.ao.quantization.backend_config.executorch import (
+                get_executorch_backend_config,
+            )
+            from torch.ao.quantization.quantize_fx import (
+                _convert_to_reference_decomposed_fx,
+                prepare_fx,
+            )
+
+            qconfig_mapping = get_default_qconfig_mapping("qnnpack")
+            example_inputs = (
+                torch.ones(1, 5, dtype=torch.float32),
+                torch.ones(1, 5, dtype=torch.float32),
+            )
+            m = prepare_fx(
+                eager_module,
+                qconfig_mapping,
+                example_inputs,
+                backend_config=get_executorch_backend_config(),
+            )
+            m = _convert_to_reference_decomposed_fx(m)
+            config = EdgeCompileConfig(_check_ir_validity=False)
+            m = to_edge(export(m, example_inputs, strict=True), compile_config=config)
+            m = m.transform([QuantFusionPass(_fix_node_meta_val=True)])
+
+            exec_prog = m.to_executorch()
+
+            executorch_program = load_prog_fn(exec_prog.buffer)
+            executorch_method = executorch_program.load_method("forward")
+            executorch_output = executorch_method(example_inputs)[0]
+
+            expected = example_inputs[0] + example_inputs[1]
+            tester.assertEqual(str(expected), str(executorch_output))
+
+        def test_method_constant_output_not_memory_planned(tester):
+            # Create an ExecuTorch program from ModuleAdd.
+            exported_program, _ = create_program(
+                ModuleAddConstReturn(),
+                et_config=ExecutorchBackendConfig(
+                    memory_planning_pass=MemoryPlanningPass(alloc_graph_output=False)
+                ),
+            )
+
+            # Use pybindings to load and execute the program.
+            executorch_program = load_prog_fn(exported_program.buffer)
+            # Invoke the callable on executorch_module instead of calling module.forward.
+            # Use only one input to test this case.
+            executorch_method = executorch_program.load_method("forward")
+            executorch_output = executorch_method((torch.ones(2, 2),))
+
+            # The test module adds the input to torch.ones(2,2), so its output should be the same
+            # as adding them directly.
+            expected = torch.ones(2, 2) + torch.ones(2, 2)
+            tester.assertTrue(torch.allclose(expected, executorch_output[0]))
+
+            # The test module returns the state. Check that its value is correct.
+            tester.assertEqual(str(torch.ones(2, 2)), str(executorch_output[1]))
+
+        def test_method_channels_last(tester) -> None:
+            # Create an ExecuTorch program from ModuleChannelsLast.
+            model = ModuleChannelsLast()
+            exported_program, inputs = create_program(model)
+
+            # Use pybindings to load and execute the program.
+            executorch_program = load_prog_fn(exported_program.buffer)
+            # Inovke the callable on executorch_module instead of calling module.forward.
+            # Use only one input to test this case.
+            executorch_method = executorch_program.load_method("forward")
+            executorch_output = executorch_method(inputs[0])[0]
+
+            # The test module adds the two inputs, so its output should be the same
+            # as adding them directly.
+            expected = model(inputs[0])
+            tester.assertTrue(torch.allclose(expected, executorch_output))
+
+        def test_method_unsupported_dim_order(tester) -> None:
+            """
+            Verify that the pybind layer rejects unsupported dim orders.
+            """
+
+            # Create an ExecuTorch program from ModuleChannelsLast.
+            model = ModuleChannelsLast()
+            exported_program, inputs = create_program(model)
+            inputs = (
+                torch.randn(1, 2, 3, 4, 5).to(memory_format=torch.channels_last_3d),
+            )
+
+            # Use pybindings to load and execute the program.
+            executorch_program = load_prog_fn(exported_program.buffer)
+            executorch_method = executorch_program.load_method("forward")
+
+            # We expect execution to error because of the invalid input dim order.
+            tester.assertRaises(RuntimeError, executorch_method, inputs[0])
+
+        def test_method_channels_last_in_default_out(tester) -> None:
+            # Create an ExecuTorch program from ModuleChannelsLastInDefaultOut.
+            model = ModuleChannelsLastInDefaultOut()
+            exported_program, inputs = create_program(model)
+
+            # Use pybindings to load and execute the program.
+            executorch_program = load_prog_fn(exported_program.buffer)
+            # Inovke the callable on executorch_module instead of calling module.forward.
+            # Use only one input to test this case.
+            executorch_method = executorch_program.load_method("forward")
+            executorch_output = executorch_method(inputs[0])[0]
+
+            # The test module adds the two inputs, so its output should be the same
+            # as adding them directly.
+            expected = model(inputs[0])
+            tester.assertTrue(torch.allclose(expected, executorch_output))
+
+        def test_method_bad_name(tester) -> None:
+            # Create an ExecuTorch program from ModuleAdd.
+            exported_program, inputs = create_program(ModuleAdd())
+
+            # Use pybindings to load and execute the program.
+            executorch_program = load_prog_fn(exported_program.buffer)
+            # Invoke the callable on executorch_module instead of calling module.forward.
+            with tester.assertRaises(RuntimeError):
+                executorch_program.load_method("not_a_real_method")
+
+        def test_program_verification_config(tester) -> None:
+            # Create an ExecuTorch program from ModuleAdd.
+            exported_program, inputs = create_program(ModuleAdd())
+            Verification = runtime.Verification
+
+            # Use pybindings to load and execute the program.
+            for config in [Verification.Minimal, Verification.InternalConsistency]:
+                executorch_program = load_prog_fn(
+                    exported_program.buffer,
+                    enable_etdump=False,
+                    debug_buffer_size=0,
+                    program_verification=config,
+                )
+
+                executorch_method = executorch_program.load_method("forward")
+                executorch_output = executorch_method(inputs)[0]
+
+                # The test module adds the two inputs, so its output should be the same
+                # as adding them directly.
+                expected = inputs[0] + inputs[1]
+
+                tester.assertEqual(str(expected), str(executorch_output))
+
+        def test_method_unsupported_input_type(tester):
+            exported_program, inputs = create_program(ModuleAdd())
+            executorch_program = load_prog_fn(exported_program.buffer)
+
+            # Pass an unsupported input type to the module.
+            inputs = ([*inputs],)
+
+            # This should raise a Python error, not hit a fatal assert in the C++ code.
+            executorch_method = executorch_program.load_method("forward")
+            tester.assertRaises(RuntimeError, executorch_method, inputs)
+
+        def test_method_attribute(tester):
+            eager_module = ModuleAddWithAttributes()
+
+            # Trace the test module and create a serialized ExecuTorch program.
+            inputs = eager_module.get_inputs()
+
+            exported_program = export(eager_module, inputs, strict=True)
+            exec_prog = to_edge(exported_program).to_executorch(
+                config=ExecutorchBackendConfig(
+                    emit_mutable_buffer_names=True,
+                )
+            )
+
+            # Create the ExecuTorch program from the graph.
+            exec_prog.dump_executorch_program(verbose=True)
+
+            # Use pybindings to load the program.
+            executorch_program = load_prog_fn(exec_prog.buffer)
+
+            # Use pybindings to load and execute the method.
+            executorch_method = executorch_program.load_method("forward")
+            executorch_method(inputs)
+            tester.assertEqual(
+                str(executorch_method.get_attribute("state")), str(torch.ones(2, 2))
+            )
+
+        def test_program_method_meta(tester) -> None:
+            exported_program, inputs = create_program(ModuleAdd())
+
+            # Use pybindings to load the program and query its metadata.
+            executorch_program = load_prog_fn(exported_program.buffer)
+            meta = executorch_program.method_meta("forward")
+
+            # Ensure that all these APIs work even if the module object is destroyed.
+            del executorch_program
+            tester.assertEqual(meta.name(), "forward")
+            tester.assertEqual(meta.num_inputs(), 2)
+            tester.assertEqual(meta.num_outputs(), 1)
+            # Common string for all these tensors.
+            tensor_info = "TensorInfo(sizes=[2, 2], dtype=Float, is_memory_planned=True, nbytes=16)"
+            float_dtype = 6
+            tester.assertEqual(
+                str(meta),
+                "MethodMeta(name='forward', num_inputs=2, "
+                f"input_tensor_meta=['{tensor_info}', '{tensor_info}'], "
+                f"num_outputs=1, output_tensor_meta=['{tensor_info}'])",
+            )
+
+            input_tensors = [meta.input_tensor_meta(i) for i in range(2)]
+            output_tensor = meta.output_tensor_meta(0)
+            # Check that accessing out of bounds raises IndexError.
+            with tester.assertRaises(IndexError):
+                meta.input_tensor_meta(2)
+            # Test that tensor metadata can outlive method metadata.
+            del meta
+            tester.assertEqual([t.sizes() for t in input_tensors], [(2, 2), (2, 2)])
+            tester.assertEqual(
+                [t.dtype() for t in input_tensors], [float_dtype, float_dtype]
+            )
+            tester.assertEqual(
+                [t.is_memory_planned() for t in input_tensors], [True, True]
+            )
+            tester.assertEqual([t.nbytes() for t in input_tensors], [16, 16])
+            tester.assertEqual(str(input_tensors), f"[{tensor_info}, {tensor_info}]")
+
+            tester.assertEqual(output_tensor.sizes(), (2, 2))
+            tester.assertEqual(output_tensor.dtype(), float_dtype)
+            tester.assertEqual(output_tensor.is_memory_planned(), True)
+            tester.assertEqual(output_tensor.nbytes(), 16)
+            tester.assertEqual(str(output_tensor), tensor_info)
+
+        def test_method_method_meta(tester) -> None:
+            exported_program, inputs = create_program(ModuleAdd())
+
+            # Use pybindings to load the program and query its metadata.
+            executorch_program = load_prog_fn(exported_program.buffer)
+            executorch_method = executorch_program.load_method("forward")
+            meta = executorch_method.method_meta()
+
+            # Ensure that all these APIs work even if the module object is destroyed.
+            del executorch_program
+            del executorch_method
+            tester.assertEqual(meta.name(), "forward")
+            tester.assertEqual(meta.num_inputs(), 2)
+            tester.assertEqual(meta.num_outputs(), 1)
+            # Common string for all these tensors.
+            tensor_info = "TensorInfo(sizes=[2, 2], dtype=Float, is_memory_planned=True, nbytes=16)"
+            float_dtype = 6
+            tester.assertEqual(
+                str(meta),
+                "MethodMeta(name='forward', num_inputs=2, "
+                f"input_tensor_meta=['{tensor_info}', '{tensor_info}'], "
+                f"num_outputs=1, output_tensor_meta=['{tensor_info}'])",
+            )
+
+            input_tensors = [meta.input_tensor_meta(i) for i in range(2)]
+            output_tensor = meta.output_tensor_meta(0)
+            # Check that accessing out of bounds raises IndexError.
+            with tester.assertRaises(IndexError):
+                meta.input_tensor_meta(2)
+            # Test that tensor metadata can outlive method metadata.
+            del meta
+            tester.assertEqual([t.sizes() for t in input_tensors], [(2, 2), (2, 2)])
+            tester.assertEqual(
+                [t.dtype() for t in input_tensors], [float_dtype, float_dtype]
+            )
+            tester.assertEqual(
+                [t.is_memory_planned() for t in input_tensors], [True, True]
+            )
+            tester.assertEqual([t.nbytes() for t in input_tensors], [16, 16])
+            tester.assertEqual(str(input_tensors), f"[{tensor_info}, {tensor_info}]")
+
+            tester.assertEqual(output_tensor.sizes(), (2, 2))
+            tester.assertEqual(output_tensor.dtype(), float_dtype)
+            tester.assertEqual(output_tensor.is_memory_planned(), True)
+            tester.assertEqual(output_tensor.nbytes(), 16)
+            tester.assertEqual(str(output_tensor), tensor_info)
+
         ######### RUN TEST CASES #########
         test_e2e(tester)
         test_multiple_entry(tester)
@@ -524,5 +953,23 @@ def make_test(  # noqa: C901
         test_program_methods_one(tester)
         test_program_methods_multi(tester)
         test_program_method_index_out_of_bounds(tester)
+        test_method_e2e(tester)
+        test_method_output_lifespan(tester)
+        test_method_multiple_entry(tester)
+        test_method_by_parts(tester)
+        test_method_callable(tester)
+        test_method_single_input(tester)
+        test_method_stderr_redirect(tester)
+        test_method_quantized_ops(tester)
+        test_method_constant_output_not_memory_planned(tester)
+        test_method_channels_last(tester)
+        test_method_unsupported_dim_order(tester)
+        test_method_channels_last_in_default_out(tester)
+        test_method_bad_name(tester)
+        test_program_verification_config(tester)
+        test_method_unsupported_input_type(tester)
+        test_method_attribute(tester)
+        test_program_method_meta(tester)
+        test_method_method_meta(tester)
 
     return wrapper

--- a/runtime/__init__.py
+++ b/runtime/__init__.py
@@ -45,8 +45,9 @@ from types import ModuleType
 from typing import Any, BinaryIO, Dict, List, Optional, Sequence, Set, Union
 
 try:
-    from executorch.extension.pybindings.portable_lib import (
-        ExecuTorchModule,
+    from executorch.extension.pybindings.portable_lib import (  # type: ignore[import-not-found]
+        ExecuTorchMethod,
+        ExecuTorchProgram,
         MethodMeta,
         Verification,
     )
@@ -62,10 +63,8 @@ class Method:
     This can be used to execute the method with inputs.
     """
 
-    def __init__(self, method_name: str, module: ExecuTorchModule) -> None:
-        # TODO: This class should be pybind to the C++ counterpart instead of hosting ExecuTorchModule.
-        self._method_name = method_name
-        self._module = module
+    def __init__(self, method: ExecuTorchMethod) -> None:
+        self._method = method
 
     def execute(self, inputs: Sequence[Any]) -> Sequence[Any]:
         """Executes the method with the given inputs.
@@ -76,7 +75,7 @@ class Method:
         Returns:
             The outputs of the method.
         """
-        return self._module.run_method(self._method_name, inputs)
+        return self._method(inputs)
 
     @property
     def metadata(self) -> MethodMeta:
@@ -85,7 +84,7 @@ class Method:
         Returns:
             The metadata for the method.
         """
-        return self._module.method_meta(self._method_name)
+        return self._method.method_meta()
 
 
 class Program:
@@ -94,17 +93,15 @@ class Program:
     This can be used to load the methods/models defined by the program.
     """
 
-    def __init__(self, module: ExecuTorchModule, data: Optional[bytes]) -> None:
+    def __init__(self, program: ExecuTorchProgram, data: Optional[bytes]) -> None:
         # Hold the data so the program is not freed.
         self._data = data
-        self._module = module
-        self._methods: Dict[str, Method] = {}
-        # ExecuTorchModule already pre-loads all Methods when created, so this
-        # doesn't do any extra work. TODO: Don't load a given Method until
-        # load_method() is called. Create a separate Method instance each time,
-        # to allow multiple independent instances of the same model.
-        for method_name in self._module.method_names():
-            self._methods[method_name] = Method(method_name, self._module)
+        self._program = program
+        self._methods: Dict[str, Optional[Method]] = {}
+        # The names of the methods are preemptively added to the dictionary,
+        # but only map to None until they are loaded.
+        for method_idx in range(self._program.num_methods()):
+            self._methods[self._program.get_method_name(method_idx)] = None
 
     @property
     def method_names(self) -> Set[str]:
@@ -122,7 +119,12 @@ class Program:
         Returns:
             The loaded method.
         """
-        return self._methods.get(name, None)
+
+        method = self._methods[name]
+        if method is None:
+            method = Method(self._program.load_method(name))
+            self._methods[name] = method
+        return method
 
 
 class BackendRegistry:
@@ -172,7 +174,7 @@ class Runtime:
     @functools.lru_cache(maxsize=1)
     def get() -> "Runtime":
         """Gets the Runtime singleton."""
-        import executorch.extension.pybindings.portable_lib as legacy_module
+        import executorch.extension.pybindings.portable_lib as legacy_module  # type: ignore[import-not-found]
 
         return Runtime(legacy_module=legacy_module)
 
@@ -199,13 +201,13 @@ class Runtime:
             The loaded program.
         """
         if isinstance(data, (Path, str)):
-            m = self._legacy_module._load_for_executorch(
+            p = self._legacy_module._load_program(
                 str(data),
                 enable_etdump=False,
                 debug_buffer_size=0,
                 program_verification=verification,
             )
-            return Program(m, data=None)
+            return Program(p, data=None)
         elif isinstance(data, BinaryIO):
             data_bytes = data.read()
         elif isinstance(data, bytearray):
@@ -216,11 +218,11 @@ class Runtime:
             raise TypeError(
                 f"Expected data to be bytes, bytearray, a path to a .pte file, or a file-like object, but got {type(data).__name__}."
             )
-        m = self._legacy_module._load_for_executorch_from_buffer(
+        p = self._legacy_module._load_program_from_buffer(
             data_bytes,
             enable_etdump=False,
             debug_buffer_size=0,
             program_verification=verification,
         )
 
-        return Program(m, data=data_bytes)
+        return Program(p, data=data_bytes)


### PR DESCRIPTION
Summary:
Continuing with migrating the pybindings API to expose the lower level ET API rather than just the `Module` level. The next step of that is to add pybindings for `Method`.

Bindings for the class Method and its methods `set_inputs`, `execute, get_outputs`, `get_attribute`, and `method_meta` were added along with `call` and `__call__` in order to easily call `set_inputs`, `execute`, and `get_outputs` all at once.

The `method_meta` method for `Program` was also added.

The `MethodMeta` binding was modified to include a shared reference to `Program` instead of `Module` if the `Module` API isn't used.

The `Program` and `Method` classes in `__init__.py` were modified to hold their pybinding equivalent rather than Module.

Differential Revision: D77565018


