### PR TITLE
Arm backend: Fix bug in decompose_linear_pass

### DIFF
--- a/backends/arm/_passes/decompose_linear_pass.py
+++ b/backends/arm/_passes/decompose_linear_pass.py
@@ -88,6 +88,7 @@ class DecomposeLinearPass(ArmPass):
                     op_target=exir_ops.edge.aten.view_copy.default,
                     args=(conv, list(output_shape)),
                     kwargs={},
+                    from_node=node,
                 )
 
             node.replace_all_uses_with(output)


### PR DESCRIPTION
The output of the decomposition did not get any metadata which is troublesome when you have two consecutive linear layers.

cc @digantdesai @freddan80 @per @zingo