### PR TITLE
Fixed bug for 16a4w ptq

### DIFF
--- a/extension/llm/export/quantizer_lib.py
+++ b/extension/llm/export/quantizer_lib.py
@@ -192,7 +192,7 @@ def get_qnn_quantizer(
             act_observer=MinMaxObserver,
         )
     elif quant_config == "16a4w":
-        quant_dtype = QuantDtype.use_16a16w  # pyre-fixme[16]
+        quant_dtype = QuantDtype.use_16a4w  # pyre-fixme[16]
         qnn_quantizer.set_default_quant_config(
             quant_dtype,
             is_qat=is_qat,


### PR DESCRIPTION
Summary: Currently running the script executorch/examples/models/llama/export_llama.py with the flag --ptq 16a4w, it does 16a16w quantization; this diff fixes this. This may be related to some GitHub issues

Differential Revision: D77671468


