### PR TITLE
Install headers from runtime/executor and extension/module in CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -450,6 +450,12 @@ install(
   PATTERN "*.h"
 )
 install(
+  DIRECTORY runtime/executor/
+  DESTINATION include/executorch/runtime/executor
+  FILES_MATCHING
+  PATTERN "*.h"
+)
+install(
   DIRECTORY runtime/kernel/
   DESTINATION include/executorch/runtime/kernel
   FILES_MATCHING
@@ -546,6 +552,12 @@ endif()
 
 if(EXECUTORCH_BUILD_EXTENSION_MODULE)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/extension/module)
+  install(
+    DIRECTORY extension/module/
+    DESTINATION include/executorch/extension/module
+    FILES_MATCHING
+    PATTERN "*.h"
+  )
 endif()
 
 if(EXECUTORCH_BUILD_EXTENSION_LLM)


### PR DESCRIPTION
This isn't a comprehensive rework of how we do installation, but these headers were missing and now they're not.