### PR TITLE
(release branch only) Revert "Respect selective build for dtype_specialized_elementwise_fn_impl in elementwise_util (#11975)"

### DIFF
--- a/kernels/portable/cpu/util/elementwise_util.h
+++ b/kernels/portable/cpu/util/elementwise_util.h
@@ -10,7 +10,6 @@
 
 #include <c10/util/irange.h>
 #include <executorch/kernels/portable/cpu/scalar_utils.h>
-#include <executorch/kernels/portable/cpu/selective_build.h>
 #include <executorch/kernels/portable/cpu/util/broadcast_indexes_range.h>
 #include <executorch/kernels/portable/cpu/util/broadcast_util.h>
 #include <executorch/kernels/portable/cpu/util/dtype_util.h>
@@ -319,22 +318,20 @@ inline void apply_elementwise_fn(
   }
 
   constexpr auto compute_type = CppTypeToScalarType<CTYPE_COMPUTE>::value;
-  if constexpr (should_include_kernel_dtype(op_name, compute_type)) {
-    const bool all_inputs_compute_dtype =
-        ((inputs.first->scalar_type() == compute_type) && ...);
+  const bool all_inputs_compute_dtype =
+      ((inputs.first->scalar_type() == compute_type) && ...);
 
-    constexpr ScalarType out_specialized_scalar_type =
-        specialized_output_scalar_type<CTYPE_COMPUTE>(out_dtypes);
-    if (all_inputs_compute_dtype &&
-        out.scalar_type() == out_specialized_scalar_type) {
-      using CTYPE_OUT =
-          typename ScalarTypeToCppType<out_specialized_scalar_type>::type;
-      dtype_specialized_elementwise_fn_impl<
-          CTYPE_COMPUTE,
-          CTYPE_OUT,
-          support_noncontiguous_tensors>(compute_fun, ctx, out, inputs...);
-      return;
-    }
+  constexpr ScalarType out_specialized_scalar_type =
+      specialized_output_scalar_type<CTYPE_COMPUTE>(out_dtypes);
+  if (all_inputs_compute_dtype &&
+      out.scalar_type() == out_specialized_scalar_type) {
+    using CTYPE_OUT =
+        typename ScalarTypeToCppType<out_specialized_scalar_type>::type;
+    dtype_specialized_elementwise_fn_impl<
+        CTYPE_COMPUTE,
+        CTYPE_OUT,
+        support_noncontiguous_tensors>(compute_fun, ctx, out, inputs...);
+    return;
   }
 
   apply_elementwise_fn_generic_impl<

--- a/kernels/portable/cpu/util/targets.bzl
+++ b/kernels/portable/cpu/util/targets.bzl
@@ -115,11 +115,11 @@ def define_common_targets():
             ":vectorized_math",
             "//executorch/runtime/core/portable_type/c10/c10:aten_headers_for_executorch",
             "//executorch/runtime/kernel:kernel_runtime_context",
-            "//executorch/kernels/portable/cpu:scalar_utils",
             "//executorch/extension/threadpool:threadpool",
             "//executorch/kernels/portable/cpu:scalar_utils",
         ],
         deps = [
+            "//executorch/kernels/portable/cpu:scalar_utils",
             "//executorch/runtime/kernel:kernel_includes",
         ],
         visibility = ["//executorch/kernels/portable/cpu/...", "//executorch/kernels/optimized/cpu/...", "@EXECUTORCH_CLIENTS"],


### PR DESCRIPTION
This reverts commit 8bc99d3f82df86e92b523fb8d59df201ace352fe. See comment on the original PR; I believe it has a bug and IIUC the correct action for the release branch is to revert to safety.
