### PR TITLE
Arm backend: Add unit tests for per-channel quantization

### DIFF
--- a/backends/arm/test/models/test_mobilenet_v2_arm.py
+++ b/backends/arm/test/models/test_mobilenet_v2_arm.py
@@ -32,6 +32,12 @@ model_inputs = (normalize(torch.rand((1, 3, 224, 224))),)
 input_t = Tuple[torch.Tensor]
 
 
+quant_test_data = {
+    "per_channel_quantization=true": True,
+    "per_channel_quantization=false": False,
+}
+
+
 def test_mv2_tosa_MI():
     pipeline = TosaPipelineMI[input_t](
         mv2, model_inputs, aten_op=[], exir_op=[], use_to_edge_transform_and_lower=True
@@ -39,14 +45,15 @@ def test_mv2_tosa_MI():
     pipeline.run()
 
 
-def test_mv2_tosa_BI():
+@common.parametrize("per_channel_quantization", quant_test_data)
+def test_mv2_tosa_BI(per_channel_quantization):
     pipeline = TosaPipelineBI[input_t](
         mv2,
         model_inputs,
         aten_op=[],
         exir_op=[],
         use_to_edge_transform_and_lower=True,
-        per_channel_quantization=True,
+        per_channel_quantization=per_channel_quantization,
         atol=0.25,
         qtol=1,
     )
@@ -55,7 +62,8 @@ def test_mv2_tosa_BI():
 
 @pytest.mark.slow
 @common.XfailIfNoCorstone300
-def test_mv2_u55_BI():
+@common.parametrize("per_channel_quantization", quant_test_data)
+def test_mv2_u55_BI(per_channel_quantization):
     pipeline = EthosU55PipelineBI[input_t](
         mv2,
         model_inputs,
@@ -63,7 +71,7 @@ def test_mv2_u55_BI():
         exir_ops=[],
         run_on_fvp=True,
         use_to_edge_transform_and_lower=True,
-        per_channel_quantization=True,
+        per_channel_quantization=per_channel_quantization,
         atol=0.25,
         qtol=1,
     )
@@ -72,7 +80,8 @@ def test_mv2_u55_BI():
 
 @pytest.mark.slow
 @common.XfailIfNoCorstone320
-def test_mv2_u85_BI():
+@common.parametrize("per_channel_quantization", quant_test_data)
+def test_mv2_u85_BI(per_channel_quantization):
     pipeline = EthosU85PipelineBI[input_t](
         mv2,
         model_inputs,
@@ -80,7 +89,7 @@ def test_mv2_u85_BI():
         exir_ops=[],
         run_on_fvp=True,
         use_to_edge_transform_and_lower=True,
-        per_channel_quantization=True,
+        per_channel_quantization=per_channel_quantization,
         atol=0.25,
         qtol=1,
     )

--- a/backends/arm/test/ops/test_conv1d.py
+++ b/backends/arm/test/ops/test_conv1d.py
@@ -249,7 +249,7 @@ two_conv1d = Conv1d(
     batches=1,
 )
 
-test_modules = {
+test_data_MI = {
     "2_3x2x40_nobias": lambda: conv1d_2_3x2x40_nobias,
     "3_1x3x256_st1": lambda: conv1d_3_1x3x256_st1,
     "3_1x3x12_st2_pd1": lambda: conv1d_3_1x3x12_st2_pd1,
@@ -265,53 +265,65 @@ test_modules = {
     "two_conv1d": lambda: two_conv1d,
 }
 
+test_data_BI = {
+    f"{k},per_channel_quant={q}": (lambda v=v, q=q: (v(), q))
+    for (k, v) in test_data_MI.items()
+    for q in [True, False]
+}
 
-@common.parametrize("test_module", test_modules)
-def test_convolution_1d_tosa_MI(test_module):
+
+@common.parametrize("test_data", test_data_MI)
+def test_convolution_1d_tosa_MI(test_data):
     pipeline = TosaPipelineMI[input_t](
-        test_module(),
-        test_module().get_inputs(),
+        test_data(),
+        test_data().get_inputs(),
         aten_op,
         exir_op,
     )
     pipeline.run()
 
 
-@common.parametrize("test_module", test_modules)
-def test_convolution_1d_tosa_BI(test_module):
+@common.parametrize("test_data", test_data_BI)
+def test_convolution_1d_tosa_BI(test_data):
+    model, per_channel_quantization = test_data()
     pipeline = TosaPipelineBI[input_t](
-        test_module(),
-        test_module().get_inputs(),
+        model,
+        model.get_inputs(),
         aten_op,
         exir_op,
+        per_channel_quantization=per_channel_quantization,
+        qtol=1,
     )
-    pipeline.change_args("run_method_and_compare_outputs", qtol=1)
     pipeline.run()
 
 
-@common.parametrize("test_module", test_modules)
+@common.parametrize("test_data", test_data_BI)
 @common.XfailIfNoCorstone300
-def test_convolution_1d_u55_BI(test_module):
+def test_convolution_1d_u55_BI(test_data):
+    model, per_channel_quantization = test_data()
     pipeline = EthosU55PipelineBI[input_t](
-        test_module(),
-        test_module().get_inputs(),
+        model,
+        model.get_inputs(),
         aten_op,
         exir_op,
         run_on_fvp=True,
+        per_channel_quantization=per_channel_quantization,
+        qtol=1,
     )
-    pipeline.change_args("run_method_and_compare_outputs", qtol=1)
     pipeline.run()
 
 
-@common.parametrize("test_module", test_modules)
+@common.parametrize("test_data", test_data_BI)
 @common.XfailIfNoCorstone320
-def test_convolution_1d_u85_BI(test_module):
+def test_convolution_1d_u85_BI(test_data):
+    model, per_channel_quantization = test_data()
     pipeline = EthosU85PipelineBI[input_t](
-        test_module(),
-        test_module().get_inputs(),
+        model,
+        model.get_inputs(),
         aten_op,
         exir_op,
         run_on_fvp=True,
+        per_channel_quantization=per_channel_quantization,
+        qtol=1,
     )
-    pipeline.change_args("run_method_and_compare_outputs", qtol=1)
     pipeline.run()

--- a/backends/arm/test/ops/test_depthwise_conv.py
+++ b/backends/arm/test/ops/test_depthwise_conv.py
@@ -154,7 +154,7 @@ two_dw_conv2d = Conv2d(
 )
 
 # Shenanigan to get a nicer output when test fails.
-testsuite_conv2d = {
+test_data_conv2d_MI = {
     "2x2_1x6x4x4_gp6_st1": lambda: dw_conv2d_2x2_1x6x4x4_gp6_st1,
     "3x3_1x3x256x256_gp3_st1": lambda: dw_conv2d_3x3_1x3x256x256_gp3_st1,
     "3x3_1x4x256x256_gp4_nobias": lambda: dw_conv2d_3x3_1x4x256x256_gp4_nobias,
@@ -163,26 +163,45 @@ testsuite_conv2d = {
     "two_dw_conv2d": lambda: two_dw_conv2d,
 }
 
-testsuite_conv2d_u85 = {
-    "2x2_1x6x4x4_gp6_st1": lambda: dw_conv2d_2x2_1x6x4x4_gp6_st1,
-    "3x3_1x3x256x256_gp3_st1": lambda: dw_conv2d_3x3_1x3x256x256_gp3_st1,
-    "3x3_1x4x256x256_gp4_st1": lambda: dw_conv2d_3x3_1x4x256x256_gp4_st1,
-    "3x3_1x4x256x256_gp4_nobias": lambda: dw_conv2d_3x3_1x4x256x256_gp4_nobias,
+# Generate a new test set paired with per_channel_quant=True/False.
+test_data_conv2d_BI = {
+    f"{k},per_channel_quant={q}": (lambda v=v, q=q: (v(), q))
+    for (k, v) in test_data_conv2d_MI.items()
+    for q in [True, False]
 }
 
-testsuite_conv1d = {
+# Generate a new test set paired with per_channel_quant=True/False.
+test_data_conv2d_u85 = {
+    f"{k},per_channel_quant={q}": (lambda v=v, q=q: (v(), q))
+    for (k, v) in {
+        "2x2_1x6x4x4_gp6_st1": lambda: dw_conv2d_2x2_1x6x4x4_gp6_st1,
+        "3x3_1x3x256x256_gp3_st1": lambda: dw_conv2d_3x3_1x3x256x256_gp3_st1,
+        "3x3_1x4x256x256_gp4_st1": lambda: dw_conv2d_3x3_1x4x256x256_gp4_st1,
+        "3x3_1x4x256x256_gp4_nobias": lambda: dw_conv2d_3x3_1x4x256x256_gp4_nobias,
+    }.items()
+    for q in [True, False]
+}
+
+test_data_conv1d_MI = {
     "2_1x6x4_gp6_st1": lambda: dw_conv1d_2_1x6x4_gp6_st1,
     "two_dw_conv1d": lambda: two_dw_conv1d,
     "3_1x3x256_gp3_st1": lambda: dw_conv1d_3_1x3x256_gp3_st1,
     "3_1x3x14_gp3_st1": lambda: dw_conv1d_3_1x3x14_gp3_st1,
 }
 
+# Generate a new test set paired with per_channel_quant=True/False.
+test_data_conv1d_BI = {
+    f"{k},per_channel_quant={q}": (lambda v=v, q=q: (v(), q))
+    for (k, v) in test_data_conv1d_MI.items()
+    for q in [True, False]
+}
 
-@common.parametrize("test_module", testsuite_conv1d | testsuite_conv2d)
-def test_convolution_2d_tosa_MI_depth_wise(test_module: torch.nn.Module):
+
+@common.parametrize("test_data", test_data_conv1d_MI | test_data_conv2d_MI)
+def test_depthwise_convolution_2d_tosa_MI(test_data: torch.nn.Module):
     pipeline = TosaPipelineMI[input_t](
-        test_module(),
-        test_module().get_inputs(),
+        test_data(),
+        test_data().get_inputs(),
         aten_op=[],
         exir_op=exir_op,
     )
@@ -190,70 +209,84 @@ def test_convolution_2d_tosa_MI_depth_wise(test_module: torch.nn.Module):
 
 
 @pytest.mark.flaky(reruns=5)  # TODO: Investigate flakyness (MLTORCH-307)
-@common.parametrize("test_module", testsuite_conv1d | testsuite_conv2d)
-def test_convolution_2d_tosa_BI_depth_wise(test_module: torch.nn.Module):
+@common.parametrize("test_data", test_data_conv1d_BI | test_data_conv2d_BI)
+def test_depthwise_convolution_2d_tosa_BI(test_data):
+    model, per_channel_quantization = test_data()
     pipeline = TosaPipelineBI[input_t](
-        test_module(),
-        test_module().get_inputs(),
+        model,
+        model.get_inputs(),
         aten_op=[],
         exir_op=exir_op,
+        per_channel_quantization=per_channel_quantization,
     )
     pipeline.run()
 
 
 x_fails = {
-    "3x3_2x8x198x198_gp8_st3": "MLETORCH-517: Operators fail with batches > 1",
-    "two_dw_conv2d": "MLETORCH-517: Operators fail with batches > 1",
+    f"{k},per_channel_quant={q}": reason
+    for k, reason in {
+        "3x3_2x8x198x198_gp8_st3": "MLETORCH-517: Operators fail with batches > 1",
+        "two_dw_conv2d": "MLETORCH-517: Operators fail with batches > 1",
+    }.items()
+    for q in [True, False]
 }
 
 
 @common.XfailIfNoCorstone300  # TODO: MLETORCH-516
-@common.parametrize("test_module", testsuite_conv2d, x_fails)
-def test_convolution_2d_u55_BI_depth_wise(test_module: torch.nn.Module):
+@common.parametrize("test_data", test_data_conv2d_BI, x_fails)
+def test_depthwise_convolution_2d_u55_BI(test_data):
+    model, per_channel_quantization = test_data()
     pipeline = EthosU55PipelineBI[input_t](
-        test_module(),
-        test_module().get_inputs(),
+        model,
+        model.get_inputs(),
         aten_ops=[],
         exir_ops=exir_op,
         run_on_fvp=True,
+        per_channel_quantization=per_channel_quantization,
     )
     pipeline.run()
 
 
 @common.XfailIfNoCorstone300  # TODO: MLETORCH-516
-@common.parametrize("test_module", testsuite_conv1d)
-def test_convolution_1d_u55_BI_depth_wise(test_module: torch.nn.Module):
+@common.parametrize("test_data", test_data_conv1d_BI)
+def test_depthwise_convolution_1d_u55_BI(test_data):
+    model, per_channel_quantization = test_data()
     pipeline = EthosU55PipelineBI[input_t](
-        test_module(),
-        test_module().get_inputs(),
+        model,
+        model.get_inputs(),
         aten_ops=[],
         exir_ops=exir_op,
         run_on_fvp=True,
+        per_channel_quantization=per_channel_quantization,
     )
     pipeline.run()
 
 
 @common.XfailIfNoCorstone320  # TODO: MLETORCH-516
-@common.parametrize("test_module", testsuite_conv2d, x_fails)
-def test_convolution_2d_u85_BI_depth_wise(test_module: torch.nn.Module):
+@common.parametrize("test_data", test_data_conv2d_BI, x_fails)
+def test_depthwise_convolution_2d_u85_BI(test_data):
+    model, per_channel_quantization = test_data()
     pipeline = EthosU85PipelineBI[input_t](
-        test_module(),
-        test_module().get_inputs(),
+        model,
+        model.get_inputs(),
         aten_ops=[],
         exir_ops=exir_op,
         run_on_fvp=True,
+        per_channel_quantization=per_channel_quantization,
     )
     pipeline.run()
 
 
 @common.XfailIfNoCorstone320  # TODO: MLETORCH-516
-@common.parametrize("test_module", testsuite_conv1d, x_fails)
-def test_convolution_1d_u85_BI_depth_wise(test_module: torch.nn.Module):
+@common.parametrize("test_data", test_data_conv1d_BI, x_fails)
+def test_depthwise_convolution_1d_u85_BI(test_data):
+    model, per_channel_quantization = test_data()
     pipeline = EthosU85PipelineBI[input_t](
-        test_module(),
-        test_module().get_inputs(),
+        model,
+        model.get_inputs(),
         aten_ops=[],
         exir_ops=exir_op,
         run_on_fvp=True,
+        per_channel_quantization=per_channel_quantization,
     )
     pipeline.run()


### PR DESCRIPTION
Add explicit tests for per-channel quantization to all applicable operators (Convolutions and Linear ops). This is achieved by parametrizing the unit tests such that they both run per-channel and per-tensor quantization.

### Test plan
The unit tests themselves are changed. Thus the code is tested.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218