### PR TITLE
[ET-VK][ez] Fix partitioner logic

### DIFF
--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -1257,6 +1257,7 @@ def to_edge_transform_and_lower(
         for name, partitioner_list in partitioner.items():
             if i < len(partitioner_list):
                 method_to_partitioner[name] = partitioner_list[i]
+        print("to_backen")
         edge_manager = edge_manager.to_backend(method_to_partitioner)
 
     for name, program in edge_manager._edge_programs.items():


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #12194

Summary:
## Changes

* In partitioner, check if buffer storage can be used only after it has been determined that no valid texture layouts are available

## Context

Currently, the logic in the vulkan partitioner is incorrect.

1. First, it checks what texture layouts may be used to represent the tensors involved in the computation
2. If no texture layouts are available, it checks if buffer support is available and the tensors are small enough to be within Vulkan buffer limits
3. Then, it checks if all valid texture layouts are supported by the op.

This introduces a bug in situations where 3 fails, but 2 would pass. However, 2 is not checked due to the way the logic is structured.

The fix is to switch the order of 2 and 3.


Test Plan:
## Test Plan

Manual verification + CI