### PR TITLE
Add XOR example to Android JNI setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ pip-out/
 *.model
 tokenizer.json
 *.pte
+*.ptd
 !test_bpe_tokenizer.bin
 !test_tiktoken_tokenizer.model
 

--- a/extension/android/executorch_android/android_test_setup.sh
+++ b/extension/android/executorch_android/android_test_setup.sh
@@ -18,6 +18,12 @@ prepare_add() {
   python3 -m test.models.export_program --modules "ModuleAdd" --outdir "${BASEDIR}/src/androidTest/resources/"
 }
 
+prepare_xor() {
+  python3 -m extension.training.examples.XOR.export_model  --outdir "${BASEDIR}/src/androidTest/resources/"
+  mv "${BASEDIR}/src/androidTest/resources/xor.pte" "${BASEDIR}/src/androidTest/resources/xor_only.pte"
+  python3 -m extension.training.examples.XOR.export_model  --outdir "${BASEDIR}/src/androidTest/resources/" --external
+}
+
 prepare_tinyllama() {
   pushd "${BASEDIR}/../../../"
   curl -C - -Ls "https://huggingface.co/karpathy/tinyllamas/resolve/main/stories15M.pt" --output stories15M.pt
@@ -43,5 +49,6 @@ prepare_vision() {
 }
 
 prepare_add
+prepare_xor
 prepare_tinyllama
 prepare_vision


### PR DESCRIPTION
### Summary
In preparation for adding the Android JNI, add the xor training model to the test prep script. Since the script will be adding the .ptd external weights to the test directory, also update the git ignore to account for this.
- `xor_only.pte` -- includes model weights
- `xor.pte` and `xor.ptd` includes XOR model with external weights, to be used together.  

### Test plan
Ensure that xor_only.pte, xor.pte, and xor.ptd are generated. Check CI is successful.
```
sh executorch_android/android_test_setup.sh
```
