### PR TITLE
[Android] Format all Java files

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -83,8 +83,13 @@ jobs:
       script: |
         FILES_NEEDS_FORMAT=$(/opt/google-java-format -n \
           extension/android/executorch_android/src/main/java/org/pytorch/executorch/*.java \
+          extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/*.java \
+          extension/android/executorch_android/src/main/java/org/pytorch/executorch/annotations/*.java \
+          extension/android/executorch_android/src/androidTest/java/org/pytorch/executorch/*.java \
           examples/demo-apps/android/LlamaDemo/app/src/main/java/com/example/executorchllamademo/*.java \
-          extension/benchmark/android/benchmark/app/src/main/java/org/pytorch/minibench/*.java)
+          examples/demo-apps/android/LlamaDemo/app/src/androidTest/java/com/example/executorchllamademo/*.java \
+          extension/benchmark/android/benchmark/app/src/main/java/org/pytorch/minibench/*.java \
+          extension/benchmark/android/benchmark/app/src/androidTest/java/org/pytorch/minibench/*.java)
         if [ -n "$FILES_NEEDS_FORMAT" ]; then
           echo "Warning: The following files need formatting. Please use google-java-format."
           echo "Use a binary from https://github.com/google/google-java-format/releases/"

--- a/extension/android/executorch_android/src/androidTest/java/org/pytorch/executorch/RuntimeInstrumentationTest.java
+++ b/extension/android/executorch_android/src/androidTest/java/org/pytorch/executorch/RuntimeInstrumentationTest.java
@@ -11,27 +11,27 @@ package org.pytorch.executorch;
 import static org.junit.Assert.assertNotNull;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
-import org.junit.runner.RunWith;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 /** Unit tests for {@link ExecuTorchRuntime}. */
 @RunWith(AndroidJUnit4.class)
 public class RuntimeInstrumentationTest {
 
-    @Test
-    public void testRuntimeApi() {
-        String[] ops = ExecuTorchRuntime.getRegisteredOps();
-        String[] backends = ExecuTorchRuntime.getRegisteredBackends();
+  @Test
+  public void testRuntimeApi() {
+    String[] ops = ExecuTorchRuntime.getRegisteredOps();
+    String[] backends = ExecuTorchRuntime.getRegisteredBackends();
 
-        assertNotNull(ops);
-        assertNotNull(backends);
+    assertNotNull(ops);
+    assertNotNull(backends);
 
-        for (String op : ops) {
-            assertNotNull(op);
-        }
-
-        for (String backend : backends) {
-            assertNotNull(backend);
-        }
+    for (String op : ops) {
+      assertNotNull(op);
     }
+
+    for (String backend : backends) {
+      assertNotNull(backend);
+    }
+  }
 }

--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmModule.java
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmModule.java
@@ -11,7 +11,6 @@ package org.pytorch.executorch.extension.llm;
 import com.facebook.jni.HybridData;
 import com.facebook.jni.annotations.DoNotStrip;
 import java.io.File;
-
 import org.pytorch.executorch.ExecuTorchRuntime;
 import org.pytorch.executorch.annotations.Experimental;
 


### PR DESCRIPTION
### Summary
Format all non-third-party Java files using `google-java-format -i`.
Expand lint workflow to include additional Android and demo directories.

Fixes #11024 
