### PR TITLE
[ET-VK][ez] Fix to codegen caching mechanism

### DIFF
--- a/backends/vulkan/runtime/gen_vulkan_spv.py
+++ b/backends/vulkan/runtime/gen_vulkan_spv.py
@@ -861,10 +861,6 @@ class SPVGenerator:
 
             # Construct generated file name
             gen_out_path = os.path.join(output_dir, f"{src_file_name}.{out_file_ext}")
-            # Construct path of cached generated file
-            cached_gen_out_path = os.path.join(
-                cache_dir, f"{src_file_name}.{out_file_ext}"
-            )
 
             # Execute codegen to generate the output file
             with codecs.open(src_file_fullpath, "r", encoding="utf-8") as input_file:
@@ -874,10 +870,6 @@ class SPVGenerator:
 
             with codecs.open(gen_out_path, "w", encoding="utf-8") as output_file:
                 output_file.write(output_text)
-
-            if cache_dir is not None:
-                # Store the generated file in the cache for SPIR-V compilation
-                shutil.copyfile(gen_out_path, cached_gen_out_path)
 
         def compile_spirv(shader_paths_pair):
             # Extract components from the input tuple
@@ -959,7 +951,10 @@ class SPVGenerator:
                     else:
                         raise RuntimeError(f"{err_msg_base} {e.stderr}") from e
 
+                # If compilation was successful, store the source GLSL file and the
+                # compiled SPIR-V file in the cache for future comparison.
                 if cache_dir is not None:
+                    shutil.copyfile(gen_out_path, cached_gen_out_path)
                     shutil.copyfile(spv_out_path, cached_spv_out_path)
 
             return (spv_out_path, gen_out_path)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #12272

## Changes

* Fixed a bug with caching the generated GLSL file too early in `gen_vulkan_spv.py`

## Context

Currently, the `gen_vulkan_spv.py` script saves the generated GLSL file to the cache immediately after generation.

Then, when compiling the GLSL to SPIR-V, it checks the current generated GLSL file against the one in the cache. However, because of the early caching, this check will always pass, even when the GLSL template was updated and a SPIR-V recompilation is needed.

The fix is to only store the generated GLSL file after the SPIR-V compilation succeeds.

Differential Revision: [D77933112](https://our.internmc.facebook.com/intern/diff/D77933112/)