### PR TITLE
Bump version of transformers and make it non-strict

### DIFF
--- a/requirements-examples.txt
+++ b/requirements-examples.txt
@@ -3,4 +3,4 @@
 timm == 1.0.7
 torchsr == 1.0.4
 torchtune >= 0.6.1
-transformers ==4.47.1
+transformers >=4.52.1


### PR DESCRIPTION
Got a bunch of GitHub alerts about vulnerabilities. Made requirement non-strict to hopefully avoid a future of manual bumps.