### PR TITLE
[cadence][hifi] Patch operators on build time issues

### DIFF
--- a/backends/cadence/aot/functions_hifi.yaml
+++ b/backends/cadence/aot/functions_hifi.yaml
@@ -75,7 +75,7 @@
 - op: clamp.Tensor_out
   kernels:
     - arg_meta: null
-      kernel_name: cadence::impl::HiFi::clamp_tensor_out
+      kernel_name: cadence::impl::HiFi::clamp_Tensor_out
 
 - op: clone.out
   kernels:
@@ -100,7 +100,7 @@
 - op: eq.Tensor_out
   kernels:
     - arg_meta: null
-      kernel_name: cadence::impl::HiFi::eq_tensor_out
+      kernel_name: cadence::impl::HiFi::eq_Tensor_out
 
 - op: fmod.Tensor_out
   kernels:
@@ -120,12 +120,12 @@
 - op: ge.Scalar_out
   kernels:
     - arg_meta: null
-      kernel_name: cadence::impl::HiFi::ge_scalar_out
+      kernel_name: cadence::impl::HiFi::ge_Scalar_out
 
 - op: ge.Tensor_out
   kernels:
     - arg_meta: null
-      kernel_name: cadence::impl::HiFi::ge_tensor_out
+      kernel_name: cadence::impl::HiFi::ge_Tensor_out
 
 - op: gelu.out
   kernels:
@@ -135,12 +135,12 @@
 - op: gt.Scalar_out
   kernels:
     - arg_meta: null
-      kernel_name: cadence::impl::HiFi::gt_scalar_out
+      kernel_name: cadence::impl::HiFi::gt_Scalar_out
 
 - op: gt.Tensor_out
   kernels:
     - arg_meta: null
-      kernel_name: cadence::impl::HiFi::gt_tensor_out
+      kernel_name: cadence::impl::HiFi::gt_Tensor_out
 
 - op: hardtanh.out
   kernels:
@@ -150,27 +150,27 @@
 - op: le.Scalar_out
   kernels:
     - arg_meta: null
-      kernel_name: cadence::impl::HiFi::le_scalar_out
+      kernel_name: cadence::impl::HiFi::le_Scalar_out
 
 - op: le.Tensor_out
   kernels:
     - arg_meta: null
-      kernel_name: cadence::impl::HiFi::le_tensor_out
+      kernel_name: cadence::impl::HiFi::le_Tensor_out
 
 - op: lt.Scalar_out
   kernels:
     - arg_meta: null
-      kernel_name: cadence::impl::HiFi::lt_scalar_out
+      kernel_name: cadence::impl::HiFi::lt_Scalar_out
 
 - op: lt.Tensor_out
   kernels:
     - arg_meta: null
-      kernel_name: cadence::impl::HiFi::lt_tensor_out
+      kernel_name: cadence::impl::HiFi::lt_Tensor_out
 
 - op: masked_fill.Scalar_out
   kernels:
     - arg_meta: null
-      kernel_name: cadence::impl::HiFi::masked_fill_scalar_out
+      kernel_name: cadence::impl::HiFi::masked_fill_Scalar_out
 
 - op: max_pool2d_with_indices.out
   kernels:
@@ -185,7 +185,7 @@
 - op: mean.out
   kernels:
     - arg_meta: null
-      kernel_name: cadence::impl::HiFi::mean_out   
+      kernel_name: cadence::impl::HiFi::mean_out
 
 - op: minimum.out
   kernels:
@@ -205,7 +205,7 @@
 - op: ne.Tensor_out
   kernels:
     - arg_meta: null
-      kernel_name: cadence::impl::HiFi::ne_tensor_out
+      kernel_name: cadence::impl::HiFi::ne_Tensor_out
 
 - op: permute_copy.out
   kernels:
@@ -289,11 +289,11 @@
   kernels:
     - arg_meta: null
       kernel_name: cadence::impl::HiFi::dequantize_per_tensor_out
-      
+
 - func: cadence::quantized_conv.out(Tensor input, Tensor weight, Tensor bias, int[] stride, SymInt[] padding, int[] dilation, int groups, int input_zero_point, Tensor weight_zero_point, Tensor bias_scale, float out_scale, int out_zero_point, Tensor out_multiplier, Tensor out_shift, bool channel_last=False, *, Tensor(a!) out) -> Tensor(a!)
   kernels:
     - arg_meta: null
-      kernel_name: cadence::impl::HiFi::quantized_conv_out      
+      kernel_name: cadence::impl::HiFi::quantized_conv_out
 
 - func: cadence::quantized_layer_norm.out(Tensor input, Tensor in_scale, Tensor in_zero_point, int[] normalized_shape, Tensor weight, Tensor bias, float eps, float output_scale, int output_zero_point, *, Tensor(a!) out) -> Tensor(a!)
   kernels:

--- a/backends/cadence/hifi/operators/CMakeLists.txt
+++ b/backends/cadence/hifi/operators/CMakeLists.txt
@@ -88,7 +88,7 @@ target_include_directories(
 
 # Custom ops that are needed to run the test model.
 add_library(
-  custom_ops "op_quantized_linear_out.cpp" "op_quantized_layer_norm.cpp" "quantized_matmul_out.cpp"
+  custom_ops "op_quantized_linear_out.cpp" "op_quantized_layer_norm.cpp" "op_quantized_matmul_out.cpp"
              "op_quantize_per_tensor.cpp" "op_quantized_relu_out.cpp" "op_dequantize_per_tensor.cpp"
              "op_quantized_conv_out.cpp" "op_quantized_fully_connected_out"
 )

--- a/backends/cadence/hifi/operators/op_bitwise_and.cpp
+++ b/backends/cadence/hifi/operators/op_bitwise_and.cpp
@@ -169,8 +169,8 @@ Tensor& bitwise_and_Tensor_out(
     return out;
   }
 
-  return torch::executor::native::internal::bitwise_tensor_out<op_name>(
-      ctx, a, b, out);
+  return torch::executor::native::internal::
+      bitwise_tensor_out<std::bit_and, op_name>(ctx, a, b, out);
 }
 
 Tensor& bitwise_and_Scalar_out(
@@ -180,8 +180,8 @@ Tensor& bitwise_and_Scalar_out(
     Tensor& out) {
   // @lint-ignore CLANGTIDY facebook-hte-CArray
   static constexpr const char op_name[] = "bitwise_and.Scalar_out";
-  return torch::executor::native::internal::bitwise_scalar_out<op_name>(
-      ctx, a, b, out);
+  return torch::executor::native::internal::
+      bitwise_scalar_out<std::bit_and, op_name>(ctx, a, b, out);
 }
 
 } // namespace native

--- a/backends/cadence/hifi/operators/op_bitwise_or.cpp
+++ b/backends/cadence/hifi/operators/op_bitwise_or.cpp
@@ -169,8 +169,8 @@ Tensor& bitwise_or_Tensor_out(
     return out;
   }
 
-  return torch::executor::native::internal::bitwise_tensor_out<op_name>(
-      ctx, a, b, out);
+  return torch::executor::native::internal::
+      bitwise_tensor_out<std::bit_or, op_name>(ctx, a, b, out);
 }
 
 Tensor& bitwise_or_Scalar_out(
@@ -180,8 +180,8 @@ Tensor& bitwise_or_Scalar_out(
     Tensor& out) {
   // @lint-ignore CLANGTIDY facebook-hte-CArray
   static constexpr const char op_name[] = "bitwise_or.Scalar_out";
-  return torch::executor::native::internal::bitwise_scalar_out<op_name>(
-      ctx, a, b, out);
+  return torch::executor::native::internal::
+      bitwise_scalar_out<std::bit_or, op_name>(ctx, a, b, out);
 }
 
 } // namespace native

--- a/backends/cadence/hifi/operators/op_bitwise_xor.cpp
+++ b/backends/cadence/hifi/operators/op_bitwise_xor.cpp
@@ -169,8 +169,8 @@ Tensor& bitwise_xor_Tensor_out(
     return out;
   }
 
-  return torch::executor::native::internal::bitwise_tensor_out<op_name>(
-      ctx, a, b, out);
+  return torch::executor::native::internal::
+      bitwise_tensor_out<std::bit_xor, op_name>(ctx, a, b, out);
 }
 
 Tensor& bitwise_xor_Scalar_out(
@@ -180,8 +180,8 @@ Tensor& bitwise_xor_Scalar_out(
     Tensor& out) {
   // @lint-ignore CLANGTIDY facebook-hte-CArray
   static constexpr const char op_name[] = "bitwise_xor.Scalar_out";
-  return torch::executor::native::internal::bitwise_scalar_out<op_name>(
-      ctx, a, b, out);
+  return torch::executor::native::internal::
+      bitwise_scalar_out<std::bit_xor, op_name>(ctx, a, b, out);
 }
 
 } // namespace native

--- a/backends/cadence/hifi/operators/op_clamp.cpp
+++ b/backends/cadence/hifi/operators/op_clamp.cpp
@@ -322,15 +322,6 @@ Tensor& clamp_Tensor_out(
   return out;
 }
 
-Tensor& clamp_tensor_out(
-    RuntimeContext& ctx,
-    const Tensor& in,
-    const std::optional<Tensor>& min_opt,
-    const std::optional<Tensor>& max_opt,
-    Tensor& out) {
-  return clamp_Tensor_out(ctx, in, min_opt, max_opt, out);
-}
-
 } // namespace native
 } // namespace HiFi
 } // namespace impl

--- a/backends/cadence/hifi/operators/op_eq.cpp
+++ b/backends/cadence/hifi/operators/op_eq.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <executorch/kernels/portable/cpu/pattern/comparison_op.h>
 #include <executorch/kernels/portable/cpu/scalar_utils.h>
 #include <executorch/kernels/portable/cpu/util/broadcast_util.h>
 #include <executorch/kernels/portable/cpu/util/functional_util.h>
@@ -28,7 +29,7 @@ namespace impl {
 namespace HiFi {
 namespace native {
 
-Tensor& eq_tensor_out(
+Tensor& eq_Tensor_out(
     RuntimeContext& ctx,
     const Tensor& a,
     const Tensor& b,
@@ -39,14 +40,14 @@ Tensor& eq_tensor_out(
       InvalidArgument,
       out);
 
-  ScalarType a_type = a.scalar_type();
-  ScalarType b_type = b.scalar_type();
   ScalarType out_type = out.scalar_type();
 
-  constexpr auto name = "eq.Tensor_out";
+  // @lint-ignore CLANGTIDY facebook-hte-CArray
+  static constexpr const char name[] = "eq.Tensor_out";
   constexpr int kNnlibMaxDim = 4; /*fallback if broadcast and dim > 4 */
 
-  int a_dim = a.dim(), b_dim = b.dim(), out_dim = out.dim();
+  int a_dim = a.dim();
+  int b_dim = b.dim();
   bool optimized = true;
   /*find broadcast*/
   const bool a_is_broadcasted = !out.sizes().equals(a.sizes());
@@ -110,32 +111,11 @@ Tensor& eq_tensor_out(
     return out;
   }
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, name, CTYPE_A, [&]() {
-    ET_SWITCH_REAL_TYPES_AND(Bool, b_type, ctx, name, CTYPE_B, [&]() {
-      using CTYPE_IN =
-          typename torch::executor::promote_types<CTYPE_A, CTYPE_B>::type;
-      ET_DCHECK(
-          CppTypeToScalarType<CTYPE_IN>::value == promoteTypes(a_type, b_type));
-      ET_SWITCH_REAL_TYPES_AND(Bool, out_type, ctx, name, CTYPE_OUT, [&]() {
-        torch::executor::
-            apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
-                [](const CTYPE_A val_a, const CTYPE_B val_b) {
-                  CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                  CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-                  bool value = a_casted == b_casted;
-                  return static_cast<CTYPE_OUT>(value);
-                },
-                a,
-                b,
-                out);
-      });
-    });
-  });
-
-  return out;
+  return torch::executor::native::internal::
+      comparison_tensor_out<std::equal_to, name>(ctx, a, b, out);
 }
 
-Tensor& eq_scalar_out(
+Tensor& eq_Scalar_out(
     RuntimeContext& ctx,
     const Tensor& a,
     const Scalar& b,
@@ -149,37 +129,11 @@ Tensor& eq_scalar_out(
       InvalidArgument,
       out,
       "Failed to resize output tensor.");
+  // @lint-ignore CLANGTIDY facebook-hte-CArray
+  static constexpr const char name[] = "eq.Scalar_out";
 
-  constexpr auto name = "eq.Scalar_out";
-
-  ScalarType a_type = a.scalar_type();
-  ScalarType b_type = torch::executor::native::utils::get_scalar_dtype(b);
-  ScalarType out_type = out.scalar_type();
-
-  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, name, CTYPE_A, [&]() {
-    ET_SWITCH_SCALAR_OBJ_TYPES(b_type, ctx, name, CTYPE_B, [&]() {
-      using CTYPE_IN =
-          typename torch::executor::promote_types<CTYPE_A, CTYPE_B>::type;
-      ET_DCHECK(
-          CppTypeToScalarType<CTYPE_IN>::value == promoteTypes(a_type, b_type));
-      ET_SWITCH_REAL_TYPES_AND(Bool, out_type, ctx, name, CTYPE_OUT, [&]() {
-        CTYPE_B val_b = 0;
-        torch::executor::native::utils::extract_scalar(b, &val_b);
-        torch::executor::apply_unary_map_fn(
-            [val_b](const CTYPE_A val_a) {
-              CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-              CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-              bool value = a_casted == b_casted;
-              return static_cast<CTYPE_OUT>(value);
-            },
-            a.const_data_ptr<CTYPE_A>(),
-            out.mutable_data_ptr<CTYPE_OUT>(),
-            out.numel());
-      });
-    });
-  });
-
-  return out;
+  return torch::executor::native::internal::
+      comparison_scalar_out<std::equal_to, name>(ctx, a, b, out);
 }
 
 } // namespace native

--- a/backends/cadence/hifi/operators/op_fmod.cpp
+++ b/backends/cadence/hifi/operators/op_fmod.cpp
@@ -8,12 +8,12 @@
 
 #include <cmath>
 
+#include <executorch/backends/cadence/hifi/kernels/kernels.h>
 #include <executorch/kernels/portable/cpu/scalar_utils.h>
 #include <executorch/kernels/portable/cpu/util/broadcast_util.h>
+#include <executorch/kernels/portable/cpu/util/elementwise_util.h>
 #include <executorch/kernels/portable/cpu/util/functional_util.h>
 #include <executorch/runtime/kernel/kernel_includes.h>
-
-#include "kernels.h"
 
 using exec_aten::Scalar;
 using exec_aten::ScalarType;
@@ -176,21 +176,36 @@ Tensor& fmod_Tensor_out(
 
   auto div_by_zero_error = false;
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, op_name, CTYPE_A, [&]() {
-    ET_SWITCH_REAL_TYPES_AND(Bool, b_type, ctx, op_name, CTYPE_B, [&]() {
-      using CTYPE_IN =
-          typename torch::executor::promote_types<CTYPE_A, CTYPE_B>::type;
-      ET_DCHECK(CppTypeToScalarType<CTYPE_IN>::value == common_type);
-      ET_SWITCH_REAL_TYPES(out_type, ctx, op_name, CTYPE_OUT, [&]() {
-        FmodInner<
-            !std::is_same<CTYPE_IN, bool>::value &&
-                can_cast<CTYPE_IN, CTYPE_OUT>::value,
-            CTYPE_A,
-            CTYPE_B,
-            CTYPE_IN,
-            CTYPE_OUT>::run(a, b, out, div_by_zero_error);
-      });
-    });
+  // Compute Dtype
+  ScalarType compute_type =
+      torch::executor::native::utils::get_compute_type(common_type);
+  if (compute_type != ScalarType::Float) {
+    compute_type = ScalarType::Double;
+  }
+  ET_SWITCH_FLOAT_TYPES(compute_type, ctx, op_name, CTYPE_COMPUTE, [&]() {
+    torch::executor::native::utils::apply_bitensor_elementwise_fn<
+        CTYPE_COMPUTE,
+        op_name,
+        torch::executor::native::utils::SupportedTensorDtypes::REALHBF16>(
+        [&div_by_zero_error](
+            const CTYPE_COMPUTE val_a, const CTYPE_COMPUTE val_b) {
+          // TODO: rewrite this to be vectorization-capable?
+          CTYPE_COMPUTE value = 0;
+          if (is_integral_type<CTYPE_COMPUTE, /*includeBool=*/true>::value) {
+            if (val_b == 0) {
+              div_by_zero_error = true;
+              return value;
+            }
+          }
+          value = std::fmod(val_a, val_b);
+          return value;
+        },
+        ctx,
+        a,
+        torch::executor::native::utils::SupportedTensorDtypes::REALHBBF16,
+        b,
+        torch::executor::native::utils::SupportedTensorDtypes::REALHBBF16,
+        out);
   });
 
   ET_KERNEL_CHECK_MSG(
@@ -218,6 +233,9 @@ Tensor& fmod_Scalar_out(
       out,
       "Failed to resize output tensor.");
 
+  // @lint-ignore CLANGTIDY facebook-hte-CArray
+  static constexpr const char op_name[] = "fmod.Scalar_out";
+
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = get_scalar_dtype(b);
   ScalarType common_type = promote_type_with_scalar(a_type, b);
@@ -228,12 +246,11 @@ Tensor& fmod_Scalar_out(
   // Check for integer division by zero
   if (isIntegralType(common_type, /*includeBool=*/true)) {
     auto is_zero = false;
-    ET_SWITCH_REAL_TYPES_AND(
-        Bool, b_type, ctx, "fmod.Scalar_out", CTYPE_B, [&]() {
-          CTYPE_B val_b = 0;
-          extract_scalar(b, &val_b);
-          is_zero = (val_b == 0);
-        });
+    ET_SWITCH_REAL_TYPES_AND(Bool, b_type, ctx, op_name, CTYPE_B, [&]() {
+      CTYPE_B val_b = 0;
+      extract_scalar(b, &val_b);
+      is_zero = (val_b == 0);
+    });
 
     ET_KERNEL_CHECK_MSG(
         ctx,
@@ -242,35 +259,28 @@ Tensor& fmod_Scalar_out(
         out,
         "Fmod operation encountered integer division by zero");
   }
+  // Compute Dtype
+  ScalarType compute_type =
+      torch::executor::native::utils::get_compute_type(common_type);
+  if (compute_type != ScalarType::Float) {
+    compute_type = ScalarType::Double;
+  }
 
-  ET_SWITCH_REAL_TYPES_AND(
-      Bool, a_type, ctx, "fmod.Scalar_out", CTYPE_A, [&]() {
-        ET_SWITCH_SCALAR_OBJ_TYPES(
-            b_type, ctx, "fmod.Scalar_out", CTYPE_B, [&]() {
-              CTYPE_B val_b = 0;
-              extract_scalar(b, &val_b);
-              ET_SWITCH_REAL_TYPES(
-                  common_type, ctx, "fmod.Scalar_out", CTYPE_IN, [&]() {
-                    ET_SWITCH_REAL_TYPES(
-                        out_type, ctx, "fmod.Scalar_out", CTYPE_OUT, [&]() {
-                          apply_unary_map_fn(
-                              [val_b](const CTYPE_A val_a) {
-                                CTYPE_IN a_casted =
-                                    static_cast<CTYPE_IN>(val_a);
-                                CTYPE_IN b_casted =
-                                    static_cast<CTYPE_IN>(val_b);
-                                CTYPE_IN value = std::fmod(a_casted, b_casted);
-
-                                return static_cast<CTYPE_OUT>(value);
-                              },
-                              a.const_data_ptr<CTYPE_A>(),
-                              out.mutable_data_ptr<CTYPE_OUT>(),
-                              out.numel());
-                        });
-                  });
-            });
-      });
-
+  ET_SWITCH_FLOAT_TYPES(compute_type, ctx, op_name, CTYPE_COMPUTE, [&]() {
+    const CTYPE_COMPUTE val_b =
+        torch::executor::native::utils::scalar_to<CTYPE_COMPUTE>(b);
+    torch::executor::native::utils::apply_unitensor_elementwise_fn<
+        CTYPE_COMPUTE,
+        op_name,
+        torch::executor::native::utils::SupportedTensorDtypes::REALHBF16>(
+        [val_b](const auto val_a) {
+          return executorch::math::fmod(val_a, (decltype(val_a))val_b);
+        },
+        ctx,
+        a,
+        torch::executor::native::utils::SupportedTensorDtypes::REALHBBF16,
+        out);
+  });
   return out;
 }
 

--- a/backends/cadence/hifi/operators/op_ge.cpp
+++ b/backends/cadence/hifi/operators/op_ge.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <executorch/kernels/portable/cpu/pattern/comparison_op.h>
 #include <executorch/kernels/portable/cpu/scalar_utils.h>
 #include <executorch/kernels/portable/cpu/util/broadcast_util.h>
 #include <executorch/kernels/portable/cpu/util/functional_util.h>
@@ -28,7 +29,7 @@ namespace impl {
 namespace HiFi {
 namespace native {
 
-Tensor& ge_tensor_out(
+Tensor& ge_Tensor_out(
     RuntimeContext& ctx,
     const Tensor& a,
     const Tensor& b,
@@ -40,14 +41,13 @@ Tensor& ge_tensor_out(
       InvalidArgument,
       out);
 
-  ScalarType a_type = a.scalar_type();
-  ScalarType b_type = b.scalar_type();
   ScalarType out_type = out.scalar_type();
 
-  constexpr auto name = "ge.Tensor_out";
+  // @lint-ignore CLANGTIDY facebook-hte-CArray
+  static constexpr const char name[] = "ge.Tensor_out";
   constexpr int kNnlibMaxDim = 4; /*fallback if broadcast and dim > 4 */
 
-  int a_dim = a.dim(), b_dim = b.dim(), out_dim = out.dim();
+  int a_dim = a.dim(), b_dim = b.dim();
   bool optimized = true;
   /*find broadcast*/
   const bool a_is_broadcasted = !out.sizes().equals(a.sizes());
@@ -111,32 +111,12 @@ Tensor& ge_tensor_out(
     return out;
   }
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, name, CTYPE_A, [&]() {
-    ET_SWITCH_REAL_TYPES_AND(Bool, b_type, ctx, name, CTYPE_B, [&]() {
-      using CTYPE_IN =
-          typename torch::executor::promote_types<CTYPE_A, CTYPE_B>::type;
-      ET_DCHECK(
-          CppTypeToScalarType<CTYPE_IN>::value == promoteTypes(a_type, b_type));
-      ET_SWITCH_REAL_TYPES_AND(Bool, out_type, ctx, name, CTYPE_OUT, [&]() {
-        torch::executor::
-            apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
-                [](const CTYPE_A val_a, const CTYPE_B val_b) {
-                  CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                  CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-                  bool value = a_casted >= b_casted;
-                  return static_cast<CTYPE_OUT>(value);
-                },
-                a,
-                b,
-                out);
-      });
-    });
-  });
-
-  return out;
+  // @lint-ignore CLANGTIDY facebook-hte-CArray
+  return torch::executor::native::internal::
+      comparison_tensor_out<std::greater_equal, name>(ctx, a, b, out);
 }
 
-Tensor& ge_scalar_out(
+Tensor& ge_Scalar_out(
     RuntimeContext& ctx,
     const Tensor& a,
     const Scalar& b,
@@ -151,7 +131,8 @@ Tensor& ge_scalar_out(
       out,
       "Failed to resize output tensor.");
 
-  constexpr auto name = "ge.Scalar_out";
+  // @lint-ignore CLANGTIDY facebook-hte-CArray
+  static constexpr const char name[] = "ge.Scalar_out";
 
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = torch::executor::native::utils::get_scalar_dtype(b);
@@ -159,28 +140,9 @@ Tensor& ge_scalar_out(
       torch::executor::native::utils::promote_type_with_scalar(a_type, b);
   ScalarType out_type = out.scalar_type();
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, name, CTYPE_A, [&]() {
-    ET_SWITCH_SCALAR_OBJ_TYPES(b_type, ctx, name, CTYPE_B, [&]() {
-      ET_SWITCH_REAL_TYPES_AND(Bool, common_type, ctx, name, CTYPE_IN, [&]() {
-        ET_SWITCH_REAL_TYPES_AND(Bool, out_type, ctx, name, CTYPE_OUT, [&]() {
-          CTYPE_B val_b = 0;
-          torch::executor::native::utils::extract_scalar(b, &val_b);
-          torch::executor::apply_unary_map_fn(
-              [val_b](const CTYPE_A val_a) {
-                CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-                bool value = a_casted >= b_casted;
-                return static_cast<CTYPE_OUT>(value);
-              },
-              a.const_data_ptr<CTYPE_A>(),
-              out.mutable_data_ptr<CTYPE_OUT>(),
-              out.numel());
-        });
-      });
-    });
-  });
-
-  return out;
+  // @lint-ignore CLANGTIDY facebook-hte-CArray
+  return torch::executor::native::internal::
+      comparison_scalar_out<std::greater_equal, name>(ctx, a, b, out);
 }
 
 } // namespace native

--- a/backends/cadence/hifi/operators/op_gt.cpp
+++ b/backends/cadence/hifi/operators/op_gt.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <executorch/kernels/portable/cpu/pattern/comparison_op.h>
 #include <executorch/kernels/portable/cpu/scalar_utils.h>
 #include <executorch/kernels/portable/cpu/util/broadcast_util.h>
 #include <executorch/kernels/portable/cpu/util/functional_util.h>
@@ -28,7 +29,7 @@ namespace impl {
 namespace HiFi {
 namespace native {
 
-Tensor& gt_tensor_out(
+Tensor& gt_Tensor_out(
     RuntimeContext& ctx,
     const Tensor& a,
     const Tensor& b,
@@ -44,7 +45,8 @@ Tensor& gt_tensor_out(
   ScalarType b_type = b.scalar_type();
   ScalarType out_type = out.scalar_type();
 
-  constexpr auto name = "gt.Tensor_out";
+  // @lint-ignore CLANGTIDY facebook-hte-CArray
+  static constexpr const char name[] = "gt.Tensor_out";
   constexpr int kNnlibMaxDim = 4; /*fallback if broadcast and dim > 4 */
 
   int a_dim = a.dim(), b_dim = b.dim(), out_dim = out.dim();
@@ -111,32 +113,11 @@ Tensor& gt_tensor_out(
     return out;
   }
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, name, CTYPE_A, [&]() {
-    ET_SWITCH_REAL_TYPES_AND(Bool, b_type, ctx, name, CTYPE_B, [&]() {
-      using CTYPE_IN =
-          typename torch::executor::promote_types<CTYPE_A, CTYPE_B>::type;
-      ET_DCHECK(
-          CppTypeToScalarType<CTYPE_IN>::value == promoteTypes(a_type, b_type));
-      ET_SWITCH_REAL_TYPES_AND(Bool, out_type, ctx, name, CTYPE_OUT, [&]() {
-        torch::executor::
-            apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
-                [](const CTYPE_A val_a, const CTYPE_B val_b) {
-                  CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                  CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-                  bool value = a_casted > b_casted;
-                  return static_cast<CTYPE_OUT>(value);
-                },
-                a,
-                b,
-                out);
-      });
-    });
-  });
-
-  return out;
+  return torch::executor::native::internal::
+      comparison_tensor_out<std::greater, name>(ctx, a, b, out);
 }
 
-Tensor& gt_scalar_out(
+Tensor& gt_Scalar_out(
     RuntimeContext& ctx,
     const Tensor& a,
     const Scalar& b,
@@ -151,36 +132,11 @@ Tensor& gt_scalar_out(
       out,
       "Failed to resize output tensor.");
 
-  constexpr auto name = "gt.Scalar_out";
+  // @lint-ignore CLANGTIDY facebook-hte-CArray
+  static constexpr const char name[] = "gt.Scalar_out";
 
-  ScalarType a_type = a.scalar_type();
-  ScalarType b_type = torch::executor::native::utils::get_scalar_dtype(b);
-  ScalarType common_type =
-      torch::executor::native::utils::promote_type_with_scalar(a_type, b);
-  ScalarType out_type = out.scalar_type();
-
-  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, name, CTYPE_A, [&]() {
-    ET_SWITCH_SCALAR_OBJ_TYPES(b_type, ctx, name, CTYPE_B, [&]() {
-      ET_SWITCH_REAL_TYPES_AND(Bool, common_type, ctx, name, CTYPE_IN, [&]() {
-        ET_SWITCH_REAL_TYPES_AND(Bool, out_type, ctx, name, CTYPE_OUT, [&]() {
-          CTYPE_B val_b = 0;
-          torch::executor::native::utils::extract_scalar(b, &val_b);
-          torch::executor::apply_unary_map_fn(
-              [val_b](const CTYPE_A val_a) {
-                CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-                bool value = a_casted > b_casted;
-                return static_cast<CTYPE_OUT>(value);
-              },
-              a.const_data_ptr<CTYPE_A>(),
-              out.mutable_data_ptr<CTYPE_OUT>(),
-              out.numel());
-        });
-      });
-    });
-  });
-
-  return out;
+  return torch::executor::native::internal::
+      comparison_scalar_out<std::greater, name>(ctx, a, b, out);
 }
 
 } // namespace native

--- a/backends/cadence/hifi/operators/op_le.cpp
+++ b/backends/cadence/hifi/operators/op_le.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <executorch/backends/cadence/hifi/kernels/kernels.h>
+#include <executorch/kernels/portable/cpu/pattern/comparison_op.h>
 #include <executorch/kernels/portable/cpu/scalar_utils.h>
 #include <executorch/kernels/portable/cpu/util/broadcast_util.h>
 #include <executorch/kernels/portable/cpu/util/functional_util.h>
@@ -27,7 +28,7 @@ namespace impl {
 namespace HiFi {
 namespace native {
 
-Tensor& le_tensor_out(
+Tensor& le_Tensor_out(
     RuntimeContext& ctx,
     const Tensor& a,
     const Tensor& b,
@@ -43,7 +44,8 @@ Tensor& le_tensor_out(
   ScalarType b_type = b.scalar_type();
   ScalarType out_type = out.scalar_type();
 
-  constexpr auto name = "le.Tensor_out";
+  // @lint-ignore CLANGTIDY facebook-hte-CArray
+  static constexpr const char name[] = "le.Tensor_out";
   constexpr int kNnlibMaxDim = 4; /*fallback if broadcast and dim > 4 */
 
   int a_dim = a.dim(), b_dim = b.dim(), out_dim = out.dim();
@@ -109,33 +111,11 @@ Tensor& le_tensor_out(
 
     return out;
   }
-
-  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, name, CTYPE_A, [&]() {
-    ET_SWITCH_REAL_TYPES_AND(Bool, b_type, ctx, name, CTYPE_B, [&]() {
-      using CTYPE_IN =
-          typename torch::executor::promote_types<CTYPE_A, CTYPE_B>::type;
-      ET_DCHECK(
-          CppTypeToScalarType<CTYPE_IN>::value == promoteTypes(a_type, b_type));
-      ET_SWITCH_REAL_TYPES_AND(Bool, out_type, ctx, name, CTYPE_OUT, [&]() {
-        torch::executor::
-            apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
-                [](const CTYPE_A val_a, const CTYPE_B val_b) {
-                  CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                  CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-                  bool value = a_casted <= b_casted;
-                  return static_cast<CTYPE_OUT>(value);
-                },
-                a,
-                b,
-                out);
-      });
-    });
-  });
-
-  return out;
+  return torch::executor::native::internal::
+      comparison_tensor_out<std::less_equal, name>(ctx, a, b, out);
 }
 
-Tensor& le_scalar_out(
+Tensor& le_Scalar_out(
     RuntimeContext& ctx,
     const Tensor& a,
     const Scalar& b,
@@ -149,37 +129,11 @@ Tensor& le_scalar_out(
       InvalidArgument,
       out,
       "Failed to resize output tensor.");
+  // @lint-ignore CLANGTIDY facebook-hte-CArray
+  static constexpr const char name[] = "le.Scalar_out";
 
-  constexpr auto name = "le.Scalar_out";
-
-  ScalarType a_type = a.scalar_type();
-  ScalarType b_type = torch::executor::native::utils::get_scalar_dtype(b);
-  ScalarType common_type =
-      torch::executor::native::utils::promote_type_with_scalar(a_type, b);
-  ScalarType out_type = out.scalar_type();
-
-  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, name, CTYPE_A, [&]() {
-    ET_SWITCH_SCALAR_OBJ_TYPES(b_type, ctx, name, CTYPE_B, [&]() {
-      ET_SWITCH_REAL_TYPES_AND(Bool, common_type, ctx, name, CTYPE_IN, [&]() {
-        ET_SWITCH_REAL_TYPES_AND(Bool, out_type, ctx, name, CTYPE_OUT, [&]() {
-          CTYPE_B val_b = 0;
-          torch::executor::native::utils::extract_scalar(b, &val_b);
-          torch::executor::apply_unary_map_fn(
-              [val_b](const CTYPE_A val_a) {
-                CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-                bool value = a_casted <= b_casted;
-                return static_cast<CTYPE_OUT>(value);
-              },
-              a.const_data_ptr<CTYPE_A>(),
-              out.mutable_data_ptr<CTYPE_OUT>(),
-              out.numel());
-        });
-      });
-    });
-  });
-
-  return out;
+  return torch::executor::native::internal::
+      comparison_scalar_out<std::less_equal, name>(ctx, a, b, out);
 }
 
 } // namespace native

--- a/backends/cadence/hifi/operators/op_lt.cpp
+++ b/backends/cadence/hifi/operators/op_lt.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <executorch/kernels/portable/cpu/pattern/comparison_op.h>
 #include <executorch/kernels/portable/cpu/scalar_utils.h>
 #include <executorch/kernels/portable/cpu/util/broadcast_util.h>
 #include <executorch/kernels/portable/cpu/util/functional_util.h>
@@ -28,7 +29,7 @@ namespace impl {
 namespace HiFi {
 namespace native {
 
-Tensor& lt_tensor_out(
+Tensor& lt_Tensor_out(
     RuntimeContext& ctx,
     const Tensor& a,
     const Tensor& b,
@@ -40,14 +41,12 @@ Tensor& lt_tensor_out(
       InvalidArgument,
       out);
 
-  ScalarType a_type = a.scalar_type();
-  ScalarType b_type = b.scalar_type();
   ScalarType out_type = out.scalar_type();
-
-  constexpr auto name = "lt.Tensor_out";
+  // @lint-ignore CLANGTIDY facebook-hte-CArray
+  static constexpr const char name[] = "lt.Tensor_out";
   constexpr int kNnlibMaxDim = 4; /*fallback if broadcast and dim > 4 */
 
-  int a_dim = a.dim(), b_dim = b.dim(), out_dim = out.dim();
+  int a_dim = a.dim(), b_dim = b.dim();
   bool optimized = true;
   /*find broadcast*/
   const bool a_is_broadcasted = !out.sizes().equals(a.sizes());
@@ -111,32 +110,11 @@ Tensor& lt_tensor_out(
     return out;
   }
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, name, CTYPE_A, [&]() {
-    ET_SWITCH_REAL_TYPES_AND(Bool, b_type, ctx, name, CTYPE_B, [&]() {
-      using CTYPE_IN =
-          typename torch::executor::promote_types<CTYPE_A, CTYPE_B>::type;
-      ET_DCHECK(
-          CppTypeToScalarType<CTYPE_IN>::value == promoteTypes(a_type, b_type));
-      ET_SWITCH_REAL_TYPES_AND(Bool, out_type, ctx, name, CTYPE_OUT, [&]() {
-        torch::executor::
-            apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
-                [](const CTYPE_A val_a, const CTYPE_B val_b) {
-                  CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                  CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-                  bool value = a_casted < b_casted;
-                  return static_cast<CTYPE_OUT>(value);
-                },
-                a,
-                b,
-                out);
-      });
-    });
-  });
-
-  return out;
+  return torch::executor::native::internal::
+      comparison_tensor_out<std::less, name>(ctx, a, b, out);
 }
 
-Tensor& lt_scalar_out(
+Tensor& lt_Scalar_out(
     RuntimeContext& ctx,
     const Tensor& a,
     const Scalar& b,
@@ -149,36 +127,11 @@ Tensor& lt_scalar_out(
       out,
       "Failed to resize output tensor.");
 
-  constexpr auto name = "lt.Scalar_out";
+  // @lint-ignore CLANGTIDY facebook-hte-CArray
+  static constexpr const char name[] = "lt.Scalar_out";
 
-  ScalarType a_type = a.scalar_type();
-  ScalarType b_type = torch::executor::native::utils::get_scalar_dtype(b);
-  ScalarType common_type =
-      torch::executor::native::utils::promote_type_with_scalar(a_type, b);
-  ScalarType out_type = out.scalar_type();
-
-  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, name, CTYPE_A, [&]() {
-    ET_SWITCH_SCALAR_OBJ_TYPES(b_type, ctx, name, CTYPE_B, [&]() {
-      ET_SWITCH_REAL_TYPES_AND(Bool, common_type, ctx, name, CTYPE_IN, [&]() {
-        ET_SWITCH_REAL_TYPES_AND(Bool, out_type, ctx, name, CTYPE_OUT, [&]() {
-          CTYPE_B val_b = 0;
-          torch::executor::native::utils::extract_scalar(b, &val_b);
-          torch::executor::apply_unary_map_fn(
-              [val_b](const CTYPE_A val_a) {
-                CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-                bool value = a_casted < b_casted;
-                return static_cast<CTYPE_OUT>(value);
-              },
-              a.const_data_ptr<CTYPE_A>(),
-              out.mutable_data_ptr<CTYPE_OUT>(),
-              out.numel());
-        });
-      });
-    });
-  });
-
-  return out;
+  return torch::executor::native::internal::
+      comparison_scalar_out<std::less, name>(ctx, a, b, out);
 }
 
 } // namespace native

--- a/backends/cadence/hifi/operators/op_masked_fill.cpp
+++ b/backends/cadence/hifi/operators/op_masked_fill.cpp
@@ -29,7 +29,7 @@ namespace impl {
 namespace HiFi {
 namespace native {
 
-Tensor& masked_fill_scalar_out(
+Tensor& masked_fill_Scalar_out(
     KernelRuntimeContext& ctx,
     const Tensor& in,
     const Tensor& mask,

--- a/backends/cadence/hifi/operators/op_ne.cpp
+++ b/backends/cadence/hifi/operators/op_ne.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <executorch/kernels/portable/cpu/pattern/comparison_op.h>
 #include <executorch/kernels/portable/cpu/scalar_utils.h>
 #include <executorch/kernels/portable/cpu/util/broadcast_util.h>
 #include <executorch/kernels/portable/cpu/util/functional_util.h>
@@ -28,7 +29,7 @@ namespace impl {
 namespace HiFi {
 namespace native {
 
-Tensor& ne_tensor_out(
+Tensor& ne_Tensor_out(
     RuntimeContext& ctx,
     const Tensor& a,
     const Tensor& b,
@@ -42,11 +43,12 @@ Tensor& ne_tensor_out(
   ScalarType a_type = a.scalar_type();
   ScalarType b_type = b.scalar_type();
   ScalarType out_type = out.scalar_type();
-
-  constexpr auto name = "ne.Tensor_out";
+  // @lint-ignore CLANGTIDY facebook-hte-CArray
+  static constexpr const char name[] = "ne.Tensor_out";
   constexpr int kNnlibMaxDim = 4; /*fallback if broadcast and dim > 4 */
 
-  int a_dim = a.dim(), b_dim = b.dim(), out_dim = out.dim();
+  int a_dim = a.dim();
+  int b_dim = b.dim();
   bool optimized = true;
   /*find broadcast*/
   const bool a_is_broadcasted = !out.sizes().equals(a.sizes());
@@ -110,32 +112,11 @@ Tensor& ne_tensor_out(
     return out;
   }
 
-  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, name, CTYPE_A, [&]() {
-    ET_SWITCH_REAL_TYPES_AND(Bool, b_type, ctx, name, CTYPE_B, [&]() {
-      using CTYPE_IN =
-          typename torch::executor::promote_types<CTYPE_A, CTYPE_B>::type;
-      ET_DCHECK(
-          CppTypeToScalarType<CTYPE_IN>::value == promoteTypes(a_type, b_type));
-      ET_SWITCH_REAL_TYPES_AND(Bool, out_type, ctx, name, CTYPE_OUT, [&]() {
-        torch::executor::
-            apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
-                [](const CTYPE_A val_a, const CTYPE_B val_b) {
-                  CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                  CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-                  bool value = a_casted != b_casted;
-                  return static_cast<CTYPE_OUT>(value);
-                },
-                a,
-                b,
-                out);
-      });
-    });
-  });
-
-  return out;
+  return torch::executor::native::internal::
+      comparison_tensor_out<std::not_equal_to, name>(ctx, a, b, out);
 }
 
-Tensor& ne_scalar_out(
+Tensor& ne_Scalar_out(
     RuntimeContext& ctx,
     const Tensor& a,
     const Scalar& b,
@@ -149,36 +130,10 @@ Tensor& ne_scalar_out(
       out,
       "Failed to resize output tensor.");
 
-  constexpr auto name = "ne.Scalar_out";
-
-  ScalarType a_type = a.scalar_type();
-  ScalarType b_type = torch::executor::native::utils::get_scalar_dtype(b);
-  ScalarType out_type = out.scalar_type();
-
-  ET_SWITCH_REAL_TYPES_AND(Bool, a_type, ctx, name, CTYPE_A, [&]() {
-    ET_SWITCH_SCALAR_OBJ_TYPES(b_type, ctx, name, CTYPE_B, [&]() {
-      using CTYPE_IN =
-          typename torch::executor::promote_types<CTYPE_A, CTYPE_B>::type;
-      ET_DCHECK(
-          CppTypeToScalarType<CTYPE_IN>::value == promoteTypes(a_type, b_type));
-      ET_SWITCH_REAL_TYPES_AND(Bool, out_type, ctx, name, CTYPE_OUT, [&]() {
-        CTYPE_B val_b = 0;
-        torch::executor::native::utils::extract_scalar(b, &val_b);
-        torch::executor::apply_unary_map_fn(
-            [val_b](const CTYPE_A val_a) {
-              CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-              CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-              bool value = a_casted != b_casted;
-              return static_cast<CTYPE_OUT>(value);
-            },
-            a.const_data_ptr<CTYPE_A>(),
-            out.mutable_data_ptr<CTYPE_OUT>(),
-            out.numel());
-      });
-    });
-  });
-
-  return out;
+  // @lint-ignore CLANGTIDY facebook-hte-CArray
+  static constexpr const char name[] = "ne.Scalar_out";
+  return torch::executor::native::internal::
+      comparison_scalar_out<std::not_equal_to, name>(ctx, a, b, out);
 }
 
 } // namespace native

--- a/backends/cadence/hifi/operators/targets.bzl
+++ b/backends/cadence/hifi/operators/targets.bzl
@@ -14,7 +14,9 @@ def define_operator(name: str, deps: list[str] | None = None) -> None:
         "//executorch/backends/cadence/hifi/kernels:kernels",
         "//executorch/kernels/portable/cpu/util:dtype_util",
         "//executorch/kernels/portable/cpu/util:elementwise_util",
-        "//executorch/backends/cadence/hifi/third-party/nnlib:nnlib-extensions"
+        "//executorch/kernels/portable/cpu/pattern:bitwise_op",
+        "//executorch/backends/cadence/hifi/third-party/nnlib:nnlib-extensions",
+        "//executorch/kernels/portable/cpu/pattern:comparison_op"
     ]
     if deps == None:
         deps = []

--- a/backends/cadence/hifi/third-party/nnlib/xa_nn_greater_lesser_equal_f32.c
+++ b/backends/cadence/hifi/third-party/nnlib/xa_nn_greater_lesser_equal_f32.c
@@ -54,7 +54,7 @@ WORD32 xa_nn_elm_greater_lesser_equal_f32xf32_f32(WORD8 * __restrict__ p_out,
               XT_LSX2IP(x2, inp2, 2*sizeof(FLOAT32));
               
               //y = XT_SUB_SX2(x2, x1);
-              xtbool2 check = xtfloatx2_LE_xtfloatx2(x2, x1);
+              xtbool2 check = XT_OLE_SX2(x2, x1);
               
               uint8_t val = AE_MOVAB2(check);
               
@@ -79,7 +79,7 @@ WORD32 xa_nn_elm_greater_lesser_equal_f32xf32_f32(WORD8 * __restrict__ p_out,
             XT_LASX2IP(x2, inp2_a, inp2);
             
             //y = XT_SUB_SX2(x2, x1);
-            xtbool2 check = xtfloatx2_LE_xtfloatx2(x2, x1);
+            xtbool2 check = XT_OLE_SX2(x2, x1);
             
             uint8_t val = AE_MOVAB2(check);
             
@@ -117,7 +117,7 @@ WORD32 xa_nn_elm_greater_lesser_equal_f32xf32_f32(WORD8 * __restrict__ p_out,
               XT_LSX2IP(x2, inp2, 2*sizeof(FLOAT32));
               
               //y = XT_SUB_SX2(x2, x1);
-              xtbool2 check = xtfloatx2_LT_xtfloatx2(x2, x1);
+              xtbool2 check = XT_OLT_SX2(x2, x1);
               
               uint8_t val = AE_MOVAB2(check);
               
@@ -142,7 +142,7 @@ WORD32 xa_nn_elm_greater_lesser_equal_f32xf32_f32(WORD8 * __restrict__ p_out,
             XT_LASX2IP(x2, inp2_a, inp2);
             
             //y = XT_SUB_SX2(x2, x1);
-            xtbool2 check = xtfloatx2_LT_xtfloatx2(x2, x1);
+            xtbool2 check = XT_OLT_SX2(x2, x1);
             
             uint8_t val = AE_MOVAB2(check);
             
@@ -180,7 +180,7 @@ WORD32 xa_nn_elm_greater_lesser_equal_f32xf32_f32(WORD8 * __restrict__ p_out,
               XT_LSX2IP(x2, inp2, 2*sizeof(FLOAT32));
               
               //y = XT_SUB_SX2(x1, x2);
-              xtbool2 check = xtfloatx2_LE_xtfloatx2(x1, x2);
+              xtbool2 check = XT_OLE_SX2(x1, x2);
               
               uint8_t val = AE_MOVAB2(check);
               
@@ -205,7 +205,7 @@ WORD32 xa_nn_elm_greater_lesser_equal_f32xf32_f32(WORD8 * __restrict__ p_out,
             XT_LASX2IP(x2, inp2_a, inp2);
             
             //y = XT_SUB_SX2(x1, x2);
-            xtbool2 check = xtfloatx2_LE_xtfloatx2(x1, x2);
+            xtbool2 check = XT_OLE_SX2(x1, x2);
             
             uint8_t val = AE_MOVAB2(check);
             
@@ -243,7 +243,7 @@ WORD32 xa_nn_elm_greater_lesser_equal_f32xf32_f32(WORD8 * __restrict__ p_out,
               XT_LSX2IP(x2, inp2, 2*sizeof(FLOAT32));
               
               //y = XT_SUB_SX2(x1, x2);
-              xtbool2 check = xtfloatx2_LT_xtfloatx2(x1, x2);
+              xtbool2 check = XT_OLT_SX2(x1, x2);
               
               uint8_t val = AE_MOVAB2(check);
               
@@ -268,7 +268,7 @@ WORD32 xa_nn_elm_greater_lesser_equal_f32xf32_f32(WORD8 * __restrict__ p_out,
             XT_LASX2IP(x2, inp2_a, inp2);
             
             //y = XT_SUB_SX2(x1, x2);
-            xtbool2 check = xtfloatx2_LT_xtfloatx2(x1, x2);
+            xtbool2 check = XT_OLT_SX2(x1, x2);
             
             uint8_t val = AE_MOVAB2(check);
             
@@ -306,7 +306,7 @@ WORD32 xa_nn_elm_greater_lesser_equal_f32xf32_f32(WORD8 * __restrict__ p_out,
               XT_LSX2IP(x2, inp2, 2*sizeof(FLOAT32));
               
               //y = XT_SUB_SX2(x2, x1);
-              xtbool2 check = xtfloatx2_EQ_xtfloatx2(x1, x2);
+              xtbool2 check = AE_EQ32(XT_AE_MOVINT32X2_FROMXTFLOATX2(x1), XT_AE_MOVINT32X2_FROMXTFLOATX2(x2));
               
               uint8_t val = AE_MOVAB2(check);
               
@@ -331,7 +331,7 @@ WORD32 xa_nn_elm_greater_lesser_equal_f32xf32_f32(WORD8 * __restrict__ p_out,
             XT_LASX2IP(x2, inp2_a, inp2);
             
             //y = XT_SUB_SX2(x2, x1);
-            xtbool2 check = xtfloatx2_EQ_xtfloatx2(x1, x2);
+            xtbool2 check = AE_EQ32(XT_AE_MOVINT32X2_FROMXTFLOATX2(x1), XT_AE_MOVINT32X2_FROMXTFLOATX2(x2));
             
             uint8_t val = AE_MOVAB2(check);
             
@@ -370,7 +370,7 @@ WORD32 xa_nn_elm_greater_lesser_equal_f32xf32_f32(WORD8 * __restrict__ p_out,
               XT_LSX2IP(x2, inp2, 2*sizeof(FLOAT32));
               
               //y = XT_SUB_SX2(x2, x1);
-              xtbool2 check = xtfloatx2_EQ_xtfloatx2(x1, x2);
+              xtbool2 check = AE_EQ32(XT_AE_MOVINT32X2_FROMXTFLOATX2(x1), XT_AE_MOVINT32X2_FROMXTFLOATX2(x2));
               
               ae_int32x2 store = AE_ZERO32();
               AE_MOVF32X2(store, ones, check);
@@ -393,7 +393,7 @@ WORD32 xa_nn_elm_greater_lesser_equal_f32xf32_f32(WORD8 * __restrict__ p_out,
             XT_LASX2IP(x2, inp2_a, inp2);
             
             //y = XT_SUB_SX2(x2, x1);
-            xtbool2 check = xtfloatx2_EQ_xtfloatx2(x1, x2);
+            xtbool2 check = AE_EQ32(XT_AE_MOVINT32X2_FROMXTFLOATX2(x1), XT_AE_MOVINT32X2_FROMXTFLOATX2(x2));
             
             ae_int32x2 store = AE_ZERO32();
             AE_MOVF32X2(store, ones, check);
@@ -477,7 +477,7 @@ static void internal_elm_greater_lesser_equal_broadcast_2D_f32xf32_f32(UWORD8 * 
             XT_LSX2IP(x2, p_b, 2*sizeof(FLOAT32));
             
             //y = XT_SUB_SX2(x1, x2);
-            xtbool2 check = xtfloatx2_LE_xtfloatx2(x1, x2);
+            xtbool2 check = XT_OLE_SX2(x1, x2);
             
             uint8_t val = AE_MOVAB2(check);
             
@@ -499,7 +499,7 @@ static void internal_elm_greater_lesser_equal_broadcast_2D_f32xf32_f32(UWORD8 * 
             XT_LASX2IP(x2, vinp2, p_b);
             
             //y = XT_SUB_SX2(x1, x2);
-            xtbool2 check = xtfloatx2_LE_xtfloatx2(x1, x2);
+            xtbool2 check = XT_OLE_SX2(x1, x2);
             
             uint8_t val = AE_MOVAB2(check);
             
@@ -535,7 +535,7 @@ static void internal_elm_greater_lesser_equal_broadcast_2D_f32xf32_f32(UWORD8 * 
             XT_LSX2IP(x2, p_b, 2*sizeof(FLOAT32));
             
             //y = XT_SUB_SX2(x1, x2);
-            xtbool2 check = xtfloatx2_LT_xtfloatx2(x1, x2);
+            xtbool2 check = XT_OLT_SX2(x1, x2);
             
             uint8_t val = AE_MOVAB2(check);
             
@@ -557,7 +557,7 @@ static void internal_elm_greater_lesser_equal_broadcast_2D_f32xf32_f32(UWORD8 * 
             XT_LASX2IP(x2, vinp2, p_b);
             
             //y = XT_SUB_SX2(x1, x2);
-            xtbool2 check = xtfloatx2_LT_xtfloatx2(x1, x2);
+            xtbool2 check = XT_OLT_SX2(x1, x2);
             
             uint8_t val = AE_MOVAB2(check);
             
@@ -593,7 +593,7 @@ static void internal_elm_greater_lesser_equal_broadcast_2D_f32xf32_f32(UWORD8 * 
             XT_LSX2IP(x2, p_b, 2*sizeof(FLOAT32));
             
             //y = XT_SUB_SX2(x2, x1);
-            xtbool2 check = xtfloatx2_LE_xtfloatx2(x2, x1);
+            xtbool2 check = XT_OLE_SX2(x2, x1);
             
             uint8_t val = AE_MOVAB2(check);
             
@@ -615,7 +615,7 @@ static void internal_elm_greater_lesser_equal_broadcast_2D_f32xf32_f32(UWORD8 * 
             XT_LASX2IP(x2, vinp2, p_b);
             
             //y = XT_SUB_SX2(x2, x1);
-            xtbool2 check = xtfloatx2_LE_xtfloatx2(x2, x1);
+            xtbool2 check = XT_OLE_SX2(x2, x1);
             
             uint8_t val = AE_MOVAB2(check);
             
@@ -651,7 +651,7 @@ static void internal_elm_greater_lesser_equal_broadcast_2D_f32xf32_f32(UWORD8 * 
             XT_LSX2IP(x2, p_b, 2*sizeof(FLOAT32));
             
             //y = XT_SUB_SX2(x2, x1);
-            xtbool2 check = xtfloatx2_LT_xtfloatx2(x2, x1);
+            xtbool2 check = XT_OLT_SX2(x2, x1);
             
             uint8_t val = AE_MOVAB2(check);
             
@@ -673,7 +673,7 @@ static void internal_elm_greater_lesser_equal_broadcast_2D_f32xf32_f32(UWORD8 * 
             XT_LASX2IP(x2, vinp2, p_b);
             
             //y = XT_SUB_SX2(x2, x1);
-            xtbool2 check = xtfloatx2_LT_xtfloatx2(x2, x1);
+            xtbool2 check = XT_OLT_SX2(x2, x1);
             
             uint8_t val = AE_MOVAB2(check);
             
@@ -709,7 +709,7 @@ static void internal_elm_greater_lesser_equal_broadcast_2D_f32xf32_f32(UWORD8 * 
             XT_LSX2IP(x2, p_b, 2*sizeof(FLOAT32));
             
             //y = XT_SUB_SX2(x1, x2);
-            xtbool2 check = xtfloatx2_EQ_xtfloatx2(x1, x2);
+            xtbool2 check = AE_EQ32(XT_AE_MOVINT32X2_FROMXTFLOATX2(x1), XT_AE_MOVINT32X2_FROMXTFLOATX2(x2));
             
             uint8_t val = AE_MOVAB2(check);
             
@@ -731,7 +731,7 @@ static void internal_elm_greater_lesser_equal_broadcast_2D_f32xf32_f32(UWORD8 * 
             XT_LASX2IP(x2, vinp2, p_b);
             
             //y = XT_SUB_SX2(x1, x2);
-            xtbool2 check = xtfloatx2_EQ_xtfloatx2(x1, x2);
+            xtbool2 check = AE_EQ32(XT_AE_MOVINT32X2_FROMXTFLOATX2(x1), XT_AE_MOVINT32X2_FROMXTFLOATX2(x2));
             
             uint8_t val = AE_MOVAB2(check);
             
@@ -768,7 +768,7 @@ static void internal_elm_greater_lesser_equal_broadcast_2D_f32xf32_f32(UWORD8 * 
             XT_LSX2IP(x2, p_b, 2*sizeof(FLOAT32));
             
             //y = XT_SUB_SX2(x1, x2);
-            xtbool2 check = xtfloatx2_EQ_xtfloatx2(x1, x2);
+            xtbool2 check = AE_EQ32(XT_AE_MOVINT32X2_FROMXTFLOATX2(x1), XT_AE_MOVINT32X2_FROMXTFLOATX2(x2));
             
             ae_int32x2 store = AE_ZERO32();
             AE_MOVF32X2(store, ones, check);
@@ -788,7 +788,7 @@ static void internal_elm_greater_lesser_equal_broadcast_2D_f32xf32_f32(UWORD8 * 
             XT_LASX2IP(x2, vinp2, p_b);
             
             //y = XT_SUB_SX2(x1, x2);
-            xtbool2 check = xtfloatx2_EQ_xtfloatx2(x1, x2);
+            xtbool2 check = AE_EQ32(XT_AE_MOVINT32X2_FROMXTFLOATX2(x1), XT_AE_MOVINT32X2_FROMXTFLOATX2(x2));
             
             ae_int32x2 store = AE_ZERO32();
             AE_MOVF32X2(store, ones, check);
@@ -833,7 +833,7 @@ static void internal_elm_greater_lesser_equal_broadcast_2D_f32xf32_f32(UWORD8 * 
             XT_LSX2IP(x2, p_b, 2*sizeof(FLOAT32));
             
             //y = XT_SUB_SX2(x2, x1);
-            xtbool2 check = xtfloatx2_LE_xtfloatx2(x2, x1);
+            xtbool2 check = XT_OLE_SX2(x2, x1);
             
             uint8_t val = AE_MOVAB2(check);
             
@@ -856,7 +856,7 @@ static void internal_elm_greater_lesser_equal_broadcast_2D_f32xf32_f32(UWORD8 * 
             XT_LASX2IP(x2, vinp2, p_b);
             
             //y = XT_SUB_SX2(x2, x1);
-            xtbool2 check = xtfloatx2_LE_xtfloatx2(x2, x1);
+            xtbool2 check = XT_OLE_SX2(x2, x1);
             
             uint8_t val = AE_MOVAB2(check);
             
@@ -892,7 +892,7 @@ static void internal_elm_greater_lesser_equal_broadcast_2D_f32xf32_f32(UWORD8 * 
             XT_LSX2IP(x2, p_b, 2*sizeof(FLOAT32));
             
             //y = XT_SUB_SX2(x2, x1);
-            xtbool2 check = xtfloatx2_LT_xtfloatx2(x2, x1);
+            xtbool2 check = XT_OLT_SX2(x2, x1);
             
             uint8_t val = AE_MOVAB2(check);
             
@@ -915,7 +915,7 @@ static void internal_elm_greater_lesser_equal_broadcast_2D_f32xf32_f32(UWORD8 * 
             XT_LASX2IP(x2, vinp2, p_b);
             
             //y = XT_SUB_SX2(x2, x1);
-            xtbool2 check = xtfloatx2_LT_xtfloatx2(x2, x1);
+            xtbool2 check = XT_OLT_SX2(x2, x1);
             
             uint8_t val = AE_MOVAB2(check);
             
@@ -951,7 +951,7 @@ static void internal_elm_greater_lesser_equal_broadcast_2D_f32xf32_f32(UWORD8 * 
             XT_LSX2IP(x2, p_b, 2*sizeof(FLOAT32));
             
             //y = XT_SUB_SX2(x1, x2);
-            xtbool2 check = xtfloatx2_LE_xtfloatx2(x1, x2);
+            xtbool2 check = XT_OLE_SX2(x1, x2);
             
             uint8_t val = AE_MOVAB2(check);
             
@@ -974,7 +974,7 @@ static void internal_elm_greater_lesser_equal_broadcast_2D_f32xf32_f32(UWORD8 * 
             XT_LASX2IP(x2, vinp2, p_b);
             
             //y = XT_SUB_SX2(x1, x2);
-            xtbool2 check = xtfloatx2_LE_xtfloatx2(x1, x2);
+            xtbool2 check = XT_OLE_SX2(x1, x2);
             
             uint8_t val = AE_MOVAB2(check);
             
@@ -1010,7 +1010,7 @@ static void internal_elm_greater_lesser_equal_broadcast_2D_f32xf32_f32(UWORD8 * 
             XT_LSX2IP(x2, p_b, 2*sizeof(FLOAT32));
             
             //y = XT_SUB_SX2(x1, x2);
-            xtbool2 check = xtfloatx2_LT_xtfloatx2(x1, x2);
+            xtbool2 check = XT_OLT_SX2(x1, x2);
             
             uint8_t val = AE_MOVAB2(check);
             
@@ -1033,7 +1033,7 @@ static void internal_elm_greater_lesser_equal_broadcast_2D_f32xf32_f32(UWORD8 * 
             XT_LASX2IP(x2, vinp2, p_b);
             
             //y = XT_SUB_SX2(x1, x2);
-            xtbool2 check = xtfloatx2_LT_xtfloatx2(x1, x2);
+            xtbool2 check = XT_OLT_SX2(x1, x2);
             
             uint8_t val = AE_MOVAB2(check);
             
@@ -1069,7 +1069,7 @@ static void internal_elm_greater_lesser_equal_broadcast_2D_f32xf32_f32(UWORD8 * 
             XT_LSX2IP(x2, p_b, 2*sizeof(FLOAT32));
             
             //y = XT_SUB_SX2(x2, x1);
-            xtbool2 check = xtfloatx2_EQ_xtfloatx2(x1, x2);
+            xtbool2 check = AE_EQ32(XT_AE_MOVINT32X2_FROMXTFLOATX2(x1), XT_AE_MOVINT32X2_FROMXTFLOATX2(x2));
             
             uint8_t val = AE_MOVAB2(check);
             
@@ -1092,7 +1092,7 @@ static void internal_elm_greater_lesser_equal_broadcast_2D_f32xf32_f32(UWORD8 * 
             XT_LASX2IP(x2, vinp2, p_b);
             
             //y = XT_SUB_SX2(x2, x1);
-            xtbool2 check = xtfloatx2_EQ_xtfloatx2(x1, x2);
+            xtbool2 check = AE_EQ32(XT_AE_MOVINT32X2_FROMXTFLOATX2(x1), XT_AE_MOVINT32X2_FROMXTFLOATX2(x2));
             
             uint8_t val = AE_MOVAB2(check);
             
@@ -1129,7 +1129,7 @@ static void internal_elm_greater_lesser_equal_broadcast_2D_f32xf32_f32(UWORD8 * 
             XT_LSX2IP(x2, p_b, 2*sizeof(FLOAT32));
             
             //y = XT_SUB_SX2(x2, x1);
-            xtbool2 check = xtfloatx2_EQ_xtfloatx2(x1, x2);
+            xtbool2 check = AE_EQ32(XT_AE_MOVINT32X2_FROMXTFLOATX2(x1), XT_AE_MOVINT32X2_FROMXTFLOATX2(x2));
             
             ae_int32x2 store = AE_ZERO32();
             AE_MOVF32X2(store, ones, check);
@@ -1150,7 +1150,7 @@ static void internal_elm_greater_lesser_equal_broadcast_2D_f32xf32_f32(UWORD8 * 
             XT_LASX2IP(x2, vinp2, p_b);
             
             //y = XT_SUB_SX2(x2, x1);
-            xtbool2 check = xtfloatx2_EQ_xtfloatx2(x1, x2);
+            xtbool2 check = AE_EQ32(XT_AE_MOVINT32X2_FROMXTFLOATX2(x1), XT_AE_MOVINT32X2_FROMXTFLOATX2(x2));
             
             ae_int32x2 store = AE_ZERO32();
             AE_MOVF32X2(store, ones, check);
@@ -1212,7 +1212,7 @@ static void internal_elm_greater_lesser_equal_broadcast_f32xf32_f32(UWORD8 * __r
           XT_LSX2IP(x1, p_a, 2 * sizeof(FLOAT32));
           //y = XT_SUB_SX2(x1, x2);
           
-          xtbool2 check = xtfloatx2_LE_xtfloatx2(x1, x2);
+          xtbool2 check = XT_OLE_SX2(x1, x2);
           
           uint8_t val = AE_MOVAB2(check);
           
@@ -1232,7 +1232,7 @@ static void internal_elm_greater_lesser_equal_broadcast_f32xf32_f32(UWORD8 * __r
           XT_LASX2IP(x1, inp1_a, p_a);
           //y = XT_SUB_SX2(x1, x2);
           
-          xtbool2 check = xtfloatx2_LE_xtfloatx2(x1, x2);
+          xtbool2 check = XT_OLE_SX2(x1, x2);
           
           uint8_t val = AE_MOVAB2(check);
           
@@ -1266,7 +1266,7 @@ static void internal_elm_greater_lesser_equal_broadcast_f32xf32_f32(UWORD8 * __r
           XT_LSX2IP(x1, p_a, 2 * sizeof(FLOAT32));
           //y = XT_SUB_SX2(x1, x2);
           
-          xtbool2 check = xtfloatx2_LT_xtfloatx2(x1, x2);
+          xtbool2 check = XT_OLT_SX2(x1, x2);
           
           uint8_t val = AE_MOVAB2(check);
           
@@ -1286,7 +1286,7 @@ static void internal_elm_greater_lesser_equal_broadcast_f32xf32_f32(UWORD8 * __r
           XT_LASX2IP(x1, inp1_a, p_a);
           //y = XT_SUB_SX2(x1, x2);
           
-          xtbool2 check = xtfloatx2_LT_xtfloatx2(x1, x2);
+          xtbool2 check = XT_OLT_SX2(x1, x2);
           
           uint8_t val = AE_MOVAB2(check);
           
@@ -1320,7 +1320,7 @@ static void internal_elm_greater_lesser_equal_broadcast_f32xf32_f32(UWORD8 * __r
           XT_LSX2IP(x1, p_a, 2 * sizeof(FLOAT32));
           //y = XT_SUB_SX2(x2, x1);
           
-          xtbool2 check = xtfloatx2_LE_xtfloatx2(x2, x1);
+          xtbool2 check = XT_OLE_SX2(x2, x1);
           
           uint8_t val = AE_MOVAB2(check);
           
@@ -1340,7 +1340,7 @@ static void internal_elm_greater_lesser_equal_broadcast_f32xf32_f32(UWORD8 * __r
           XT_LASX2IP(x1, inp1_a, p_a);
           //y = XT_SUB_SX2(x2, x1);
           
-          xtbool2 check = xtfloatx2_LE_xtfloatx2(x2, x1);
+          xtbool2 check = XT_OLE_SX2(x2, x1);
           
           uint8_t val = AE_MOVAB2(check);
           
@@ -1374,7 +1374,7 @@ static void internal_elm_greater_lesser_equal_broadcast_f32xf32_f32(UWORD8 * __r
           XT_LSX2IP(x1, p_a, 2 * sizeof(FLOAT32));
           //y = XT_SUB_SX2(x2, x1);
           
-          xtbool2 check = xtfloatx2_LT_xtfloatx2(x2, x1);
+          xtbool2 check = XT_OLT_SX2(x2, x1);
           
           uint8_t val = AE_MOVAB2(check);
           
@@ -1394,7 +1394,7 @@ static void internal_elm_greater_lesser_equal_broadcast_f32xf32_f32(UWORD8 * __r
           XT_LASX2IP(x1, inp1_a, p_a);
           //y = XT_SUB_SX2(x2, x1);
           
-          xtbool2 check = xtfloatx2_LT_xtfloatx2(x2, x1);
+          xtbool2 check = XT_OLT_SX2(x2, x1);
           
           uint8_t val = AE_MOVAB2(check);
           
@@ -1428,7 +1428,7 @@ static void internal_elm_greater_lesser_equal_broadcast_f32xf32_f32(UWORD8 * __r
           XT_LSX2IP(x1, p_a, 2 * sizeof(FLOAT32));
           //y = XT_SUB_SX2(x1, x2);
           
-          xtbool2 check = xtfloatx2_EQ_xtfloatx2(x1, x2);
+          xtbool2 check = AE_EQ32(XT_AE_MOVINT32X2_FROMXTFLOATX2(x1), XT_AE_MOVINT32X2_FROMXTFLOATX2(x2));
           
           uint8_t val = AE_MOVAB2(check);
           
@@ -1448,7 +1448,7 @@ static void internal_elm_greater_lesser_equal_broadcast_f32xf32_f32(UWORD8 * __r
           XT_LASX2IP(x1, inp1_a, p_a);
           //y = XT_SUB_SX2(x1, x2);
           
-          xtbool2 check = xtfloatx2_EQ_xtfloatx2(x1, x2);
+          xtbool2 check = AE_EQ32(XT_AE_MOVINT32X2_FROMXTFLOATX2(x1), XT_AE_MOVINT32X2_FROMXTFLOATX2(x2));
           
           uint8_t val = AE_MOVAB2(check);
           
@@ -1483,7 +1483,7 @@ static void internal_elm_greater_lesser_equal_broadcast_f32xf32_f32(UWORD8 * __r
           XT_LSX2IP(x1, p_a, 2 * sizeof(FLOAT32));
           //y = XT_SUB_SX2(x1, x2);
           
-          xtbool2 check = xtfloatx2_EQ_xtfloatx2(x1, x2);
+          xtbool2 check = AE_EQ32(XT_AE_MOVINT32X2_FROMXTFLOATX2(x1), XT_AE_MOVINT32X2_FROMXTFLOATX2(x2));
           
           ae_int32x2 store = AE_ZERO32();
           AE_MOVF32X2(store, ones, check);
@@ -1501,7 +1501,7 @@ static void internal_elm_greater_lesser_equal_broadcast_f32xf32_f32(UWORD8 * __r
           XT_LASX2IP(x1, inp1_a, p_a);
           //y = XT_SUB_SX2(x1, x2);
           
-          xtbool2 check = xtfloatx2_EQ_xtfloatx2(x1, x2);
+          xtbool2 check = AE_EQ32(XT_AE_MOVINT32X2_FROMXTFLOATX2(x1), XT_AE_MOVINT32X2_FROMXTFLOATX2(x2));
           
           ae_int32x2 store = AE_ZERO32();
           AE_MOVF32X2(store, ones, check);
@@ -1537,7 +1537,7 @@ static void internal_elm_greater_lesser_equal_broadcast_f32xf32_f32(UWORD8 * __r
           XT_LSX2IP(x1, p_a, 2 * sizeof(FLOAT32));
           //y = XT_SUB_SX2(x2, x1);
           
-          xtbool2 check = xtfloatx2_LE_xtfloatx2(x2, x1);
+          xtbool2 check = XT_OLE_SX2(x2, x1);
           
           uint8_t val = AE_MOVAB2(check);
           
@@ -1558,7 +1558,7 @@ static void internal_elm_greater_lesser_equal_broadcast_f32xf32_f32(UWORD8 * __r
           XT_LASX2IP(x1, inp1_a, p_a);
           //y = XT_SUB_SX2(x2, x1);
           
-          xtbool2 check = xtfloatx2_LE_xtfloatx2(x2, x1);
+          xtbool2 check = XT_OLE_SX2(x2, x1);
           
           uint8_t val = AE_MOVAB2(check);
           
@@ -1592,7 +1592,7 @@ static void internal_elm_greater_lesser_equal_broadcast_f32xf32_f32(UWORD8 * __r
           XT_LSX2IP(x1, p_a, 2 * sizeof(FLOAT32));
           //y = XT_SUB_SX2(x2, x1);
           
-          xtbool2 check = xtfloatx2_LT_xtfloatx2(x2, x1);
+          xtbool2 check = XT_OLT_SX2(x2, x1);
           
           uint8_t val = AE_MOVAB2(check);
           
@@ -1613,7 +1613,7 @@ static void internal_elm_greater_lesser_equal_broadcast_f32xf32_f32(UWORD8 * __r
           XT_LASX2IP(x1, inp1_a, p_a);
           //y = XT_SUB_SX2(x2, x1);
           
-          xtbool2 check = xtfloatx2_LT_xtfloatx2(x2, x1);
+          xtbool2 check = XT_OLT_SX2(x2, x1);
           
           uint8_t val = AE_MOVAB2(check);
           
@@ -1647,7 +1647,7 @@ static void internal_elm_greater_lesser_equal_broadcast_f32xf32_f32(UWORD8 * __r
           XT_LSX2IP(x1, p_a, 2 * sizeof(FLOAT32));
           //y = XT_SUB_SX2(x1, x2);
           
-          xtbool2 check = xtfloatx2_LE_xtfloatx2(x1, x2);
+          xtbool2 check = XT_OLE_SX2(x1, x2);
           
           uint8_t val = AE_MOVAB2(check);
           
@@ -1668,7 +1668,7 @@ static void internal_elm_greater_lesser_equal_broadcast_f32xf32_f32(UWORD8 * __r
           XT_LASX2IP(x1, inp1_a, p_a);
           //y = XT_SUB_SX2(x1, x2);
           
-          xtbool2 check = xtfloatx2_LE_xtfloatx2(x1, x2);
+          xtbool2 check = XT_OLE_SX2(x1, x2);
           
           uint8_t val = AE_MOVAB2(check);
           
@@ -1702,7 +1702,7 @@ static void internal_elm_greater_lesser_equal_broadcast_f32xf32_f32(UWORD8 * __r
           XT_LSX2IP(x1, p_a, 2 * sizeof(FLOAT32));
           //y = XT_SUB_SX2(x1, x2);
           
-          xtbool2 check = xtfloatx2_LT_xtfloatx2(x1, x2);
+          xtbool2 check = XT_OLT_SX2(x1, x2);
           
           uint8_t val = AE_MOVAB2(check);
           
@@ -1723,7 +1723,7 @@ static void internal_elm_greater_lesser_equal_broadcast_f32xf32_f32(UWORD8 * __r
           XT_LASX2IP(x1, inp1_a, p_a);
           //y = XT_SUB_SX2(x1, x2);
           
-        xtbool2 check = xtfloatx2_LT_xtfloatx2(x1, x2);
+        xtbool2 check = XT_OLT_SX2(x1, x2);
           
           uint8_t val = AE_MOVAB2(check);
           
@@ -1757,7 +1757,7 @@ static void internal_elm_greater_lesser_equal_broadcast_f32xf32_f32(UWORD8 * __r
           XT_LSX2IP(x1, p_a, 2 * sizeof(FLOAT32));
           //y = XT_SUB_SX2(x2, x1);
           
-          xtbool2 check = xtfloatx2_EQ_xtfloatx2(x1, x2);
+          xtbool2 check = AE_EQ32(XT_AE_MOVINT32X2_FROMXTFLOATX2(x1), XT_AE_MOVINT32X2_FROMXTFLOATX2(x2));
           
           uint8_t val = AE_MOVAB2(check);
           
@@ -1778,7 +1778,7 @@ static void internal_elm_greater_lesser_equal_broadcast_f32xf32_f32(UWORD8 * __r
           XT_LASX2IP(x1, inp1_a, p_a);
           //y = XT_SUB_SX2(x2, x1);
           
-          xtbool2 check = xtfloatx2_EQ_xtfloatx2(x1, x2);
+          xtbool2 check = AE_EQ32(XT_AE_MOVINT32X2_FROMXTFLOATX2(x1), XT_AE_MOVINT32X2_FROMXTFLOATX2(x2));
           
           uint8_t val = AE_MOVAB2(check);
           

--- a/kernels/portable/cpu/pattern/targets.bzl
+++ b/kernels/portable/cpu/pattern/targets.bzl
@@ -26,7 +26,7 @@ def define_common_targets():
             "bitwise_op.h",
         ],
         compiler_flags = [],
-        visibility = ["//executorch/kernels/portable/cpu/...", "//executorch/kernels/optimized/cpu/..."],
+        visibility = ["//executorch/kernels/portable/cpu/...", "//executorch/kernels/optimized/cpu/...", "//executorch/backends/cadence/..."],
     )
 
     runtime.cxx_library(
@@ -35,7 +35,7 @@ def define_common_targets():
             "comparison_op.h",
         ],
         compiler_flags = [],
-        visibility = ["//executorch/kernels/portable/cpu/...", "//executorch/kernels/optimized/cpu/..."],
+        visibility = ["//executorch/kernels/portable/cpu/...", "//executorch/kernels/optimized/cpu/...", "//executorch/backends/cadence/..."],
     )
 
     runtime.cxx_library(


### PR DESCRIPTION
Summary:
Resolve build failure 
- add check args on new operators
- change ops to out various in fallback
- match naming and letter cases of operators
- fix llvm build error from eq and ne
- modernize fallbacks of comparision ops to shrink code size
  - TODO: migrated `ne, eq, ge, gt, lt, le` for now. More to check 
- Fix for build issue in greater_lesser_equal ISA proto use: migrate off xtfloatx2 to current nnlib

Differential Revision: D77957939


