### PR TITLE
Fix null-deref in parse_cond_value

### DIFF
--- a/runtime/executor/method.cpp
+++ b/runtime/executor/method.cpp
@@ -271,6 +271,8 @@ Result<bool> parse_cond_value(const EValue& cond_value) {
         static_cast<int8_t>(cond_val.scalar_type()));
 
     const bool* cond_data = cond_val.const_data_ptr<bool>();
+    ET_CHECK_OR_RETURN_ERROR(
+        cond_data != nullptr, InvalidState, "Tensor data is null");
     for (size_t i = 0; i < static_cast<size_t>(cond_val.numel()); i++) {
       if (!cond_data[i]) {
         return false;


### PR DESCRIPTION
Summary:

- Fuzzer mutates .pte files and expects the loader/executor to handle corrupted input robustly. The crash was due to ***cond_val***. returning nullptr (invalid/corrupted input). 
- Fix the crash by checking for nullptr and returning an error code.
- Fuzzer test case also required to be modified to handle the new returned error code. (The intent of a fuzzing test is to ensure the code does not crash or misbehave on malformed input, not that it always succeeds.)

Differential Revision: D77827830


