### PR TITLE
[Backend Test] Backend test reporting skeleton

### DIFF
--- a/backends/test/suite/context.py
+++ b/backends/test/suite/context.py
@@ -1,0 +1,28 @@
+# Test run context management. This is used to determine the test context for reporting
+# purposes.
+class TestContext:
+    def __init__(self, test_name: str, flow_name: str, params: dict | None):
+        self.test_name = test_name
+        self.flow_name = flow_name
+        self.params = params
+
+    def __enter__(self):
+        global _active_test_context
+        import sys
+
+        if _active_test_context is not None:
+            print(f"Active context: {_active_test_context.test_name}", file=sys.stderr)
+        assert _active_test_context is None
+        _active_test_context = self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        global _active_test_context
+        _active_test_context = None
+
+
+_active_test_context: TestContext | None = None
+
+
+def get_active_test_context() -> TestContext | None:
+    global _active_test_context
+    return _active_test_context

--- a/backends/test/suite/reporting.py
+++ b/backends/test/suite/reporting.py
@@ -1,0 +1,163 @@
+from collections import Counter
+from dataclasses import dataclass
+from enum import IntEnum, nonmember
+
+
+class TestResult(IntEnum):
+    """Represents the result of a test case run, indicating success or a specific failure reason."""
+
+    SUCCESS = 0
+    """ The test succeeded with the backend delegate part or all of the graph. """
+
+    SUCCESS_UNDELEGATED = 1
+    """ The test succeeded without the backend delegating anything. """
+
+    EAGER_FAIL = 2
+    """ The test failed due to the model failing to run in eager mode. """
+
+    EXPORT_FAIL = 3
+    """ The test failed due to the model failing to export. """
+
+    LOWER_FAIL = 4
+    """ The test failed due to a failure in partitioning or lowering. """
+
+    PTE_LOAD_FAIL = 5
+    """ The test failed due to the resulting PTE failing to load. """
+
+    PTE_RUN_FAIL = 6
+    """ The test failed due to the resulting PTE failing to run. """
+
+    OUTPUT_MISMATCH_FAIL = 7
+    """ The test failed due to a mismatch between runtime and reference outputs. """
+
+    UNKNOWN_FAIL = 8
+    """ The test failed in an unknown or unexpected manner. """
+
+    @nonmember
+    def is_success(self):
+        return self in {TestResult.SUCCESS, TestResult.SUCCESS_UNDELEGATED}
+
+    @nonmember
+    def is_non_backend_failure(self):
+        return self in {TestResult.EAGER_FAIL, TestResult.EAGER_FAIL}
+
+    @nonmember
+    def is_backend_failure(self):
+        return not self.is_success() and not self.is_non_backend_failure()
+
+    @nonmember
+    def display_name(self):
+        if self == TestResult.SUCCESS:
+            return "Success (Delegated)"
+        elif self == TestResult.SUCCESS_UNDELEGATED:
+            return "Success (Undelegated)"
+        elif self == TestResult.EAGER_FAIL:
+            return "Fail (Eager)"
+        elif self == TestResult.EXPORT_FAIL:
+            return "Fail (Export)"
+        elif self == TestResult.LOWER_FAIL:
+            return "Fail (Lowering)"
+        elif self == TestResult.PTE_LOAD_FAIL:
+            return "Fail (PTE Load)"
+        elif self == TestResult.PTE_RUN_FAIL:
+            return "Fail (PTE Run)"
+        elif self == TestResult.OUTPUT_MISMATCH_FAIL:
+            return "Fail (Output Mismatch)"
+        elif self == TestResult.UNKNOWN_FAIL:
+            return "Fail (Other)"
+        else:
+            raise ValueError(f"Invalid TestResult value: {self}.")
+
+
+@dataclass
+class TestCaseSummary:
+    """
+    Contains summary results for the execution of a single test case.
+    """
+
+    name: str
+    """ The qualified name of the test, not including the flow suffix. """
+
+    flow: str
+    """ The backend-specific flow name. Corresponds to flows registered in backends/test/suite/__init__.py. """
+
+    params: dict | None
+    """ Test-specific parameters, such as dtype. """
+
+    result: TestResult
+    """ The top-level result, such as SUCCESS or LOWER_FAIL. """
+
+    error: Exception | None
+    """ The Python exception object, if any. """
+
+
+class TestSessionState:
+    test_case_summaries: list[TestCaseSummary]
+
+    def __init__(self):
+        self.test_case_summaries = []
+
+
+@dataclass
+class RunSummary:
+    aggregated_results: dict[TestResult, int]
+    num_test_cases: int
+    test_case_summaries: list[TestCaseSummary]
+    total_failed: int
+    total_passed: int
+    total_skipped: int
+
+    @classmethod
+    def from_session(cls, session: TestSessionState) -> "RunSummary":
+        # Total each outcome type.
+        aggregated_results = dict(
+            sorted(Counter(s.result for s in session.test_case_summaries).items())
+        )
+
+        total_failed = 0
+        total_passed = 0
+        total_skipped = 0
+
+        for k, v in aggregated_results.items():
+            if k.is_success():
+                total_passed += v
+            elif k.is_backend_failure():
+                total_failed += v
+            else:
+                total_skipped += v
+
+        return cls(
+            aggregated_results=aggregated_results,
+            num_test_cases=len(session.test_case_summaries),
+            test_case_summaries=session.test_case_summaries,
+            total_failed=total_failed,
+            total_passed=total_passed,
+            total_skipped=total_skipped,
+        )
+
+
+_active_session: TestSessionState | None = None
+
+
+def begin_test_session():
+    global _active_session
+
+    assert _active_session is None, "A test session is already active."
+    _active_session = TestSessionState()
+
+
+def log_test_summary(summary: TestCaseSummary):
+    global _active_session
+
+    if _active_session is not None:
+        _active_session.test_case_summaries.append(summary)
+
+
+def complete_test_session() -> RunSummary:
+    global _active_session
+
+    assert _active_session is not None, "No test session is active."
+    summary = RunSummary.from_session(_active_session)
+    _active_session = None
+
+    return summary

--- a/backends/test/suite/runner.py
+++ b/backends/test/suite/runner.py
@@ -1,0 +1,153 @@
+import argparse
+import unittest
+
+from typing import Callable
+
+import torch
+
+from executorch.backends.test.harness import Tester
+from executorch.backends.test.suite.reporting import (
+    begin_test_session,
+    complete_test_session,
+    RunSummary,
+    TestCaseSummary,
+    TestResult,
+)
+
+
+def run_test(  # noqa: C901
+    model: torch.nn.Module,
+    inputs: any,
+    tester_factory: Callable[[], Tester],
+    test_name: str,
+    flow_name: str,
+    params: dict | None,
+) -> TestCaseSummary:
+    """
+    Top-level test run function for a model, input set, and tester. Handles test execution
+    and reporting.
+    """
+
+    # Helper method to construct the summary.
+    def build_result(
+        result: TestResult, error: Exception | None = None
+    ) -> TestCaseSummary:
+        return TestCaseSummary(
+            name=test_name,
+            flow=flow_name,
+            params=params,
+            result=result,
+            error=error,
+        )
+
+    # Ensure the model can run in eager mode.
+    try:
+        model(*inputs)
+    except Exception as e:
+        return build_result(TestResult.EAGER_FAIL, e)
+
+    try:
+        tester = tester_factory(model, inputs)
+    except Exception as e:
+        return build_result(TestResult.UNKNOWN_FAIL, e)
+
+    try:
+        tester.export()
+    except Exception as e:
+        return build_result(TestResult.EXPORT_FAIL, e)
+
+    try:
+        tester.to_edge_transform_and_lower()
+    except Exception as e:
+        return build_result(TestResult.LOWER_FAIL, e)
+
+    is_delegated = any(
+        n.target == torch._higher_order_ops.executorch_call_delegate
+        for n in tester.stages[tester.cur].graph_module.graph.nodes
+        if n.op == "call_function"
+    )
+
+    # Only run the runtime portion if something was delegated.
+    if is_delegated:
+        try:
+            tester.to_executorch().serialize()
+        except Exception as e:
+            # We could introduce a result value for this, but I'm not sure it's necessary.
+            # We can do this if we ever see to_executorch() or serialize() fail due a backend issue.
+            return build_result(TestResult.UNKNOWN_FAIL, e)
+
+        # TODO We should consider refactoring the tester slightly to return more signal on
+        # the cause of a failure in run_method_and_compare_outputs. We can look for
+        # AssertionErrors to catch output mismatches, but this might catch more than that.
+        try:
+            tester.run_method_and_compare_outputs()
+        except AssertionError as e:
+            return build_result(TestResult.OUTPUT_MISMATCH_FAIL, e)
+        except Exception as e:
+            return build_result(TestResult.PTE_RUN_FAIL, e)
+    else:
+        return build_result(TestResult.SUCCESS_UNDELEGATED)
+
+    return build_result(TestResult.SUCCESS)
+
+
+def print_summary(summary: RunSummary):
+    print()
+    print("Test Session Summary:")
+
+    print()
+    print(f"{summary.total_passed:>5} Passed / {summary.num_test_cases}")
+    print(f"{summary.total_failed:>5} Failed / {summary.num_test_cases}")
+    print(f"{summary.total_skipped:>5} Skipped / {summary.num_test_cases}")
+
+    print()
+    print("[Success]")
+    print(f"{summary.aggregated_results.get(TestResult.SUCCESS, 0):>5} Delegated")
+    print(
+        f"{summary.aggregated_results.get(TestResult.SUCCESS_UNDELEGATED, 0):>5} Undelegated"
+    )
+
+    print()
+    print("[Failure]")
+    print(
+        f"{summary.aggregated_results.get(TestResult.LOWER_FAIL, 0):>5} Lowering Fail"
+    )
+    print(
+        f"{summary.aggregated_results.get(TestResult.PTE_LOAD_FAIL, 0):>5} PTE Load Fail"
+    )
+    print(
+        f"{summary.aggregated_results.get(TestResult.PTE_RUN_FAIL, 0):>5} PTE Run Fail"
+    )
+    print(
+        f"{summary.aggregated_results.get(TestResult.OUTPUT_MISMATCH_FAIL, 0):>5} Output Mismatch Fail"
+    )
+
+    print()
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        prog="ExecuTorch Backend Test Suite",
+        description="Run ExecuTorch backend tests.",
+    )
+    parser.add_argument("test_path", nargs="?", help="Prefix filter for tests to run.")
+    return parser.parse_args()
+
+
+def runner_main():
+    args = parse_args()
+
+    begin_test_session()
+
+    test_path = args.test_path or "executorch.backends.test.suite.operators"
+
+    loader = unittest.TestLoader()
+    suite = loader.loadTestsFromName(test_path)
+    unittest.TextTestRunner().run(suite)
+
+    summary = complete_test_session()
+    print_summary(summary)
+
+
+if __name__ == "__main__":
+    runner_main()


### PR DESCRIPTION
### Summary
Add the initial skeleton of reporting code for the backend tester. This PR is primarily focused on putting the hooks and runner structure in place. Follow-up work will expand the scope of collection and reporting outputs.

This PR adds the following:
- CLI runner for the test suite.
- Basic test result breakdown by success / fail and cause (failing in lowering vs output mismatch, for example).
- Refactoring of test suite logic to clean things up.

Next steps:
- Aggregate results by flow (backend).
- Add additional CLI flags to allow filtering backends and dtypes.
- Land more of the operator test suite.
- Wire up flows for quantized operators.

Note that this PR is stacked on (and thus includes) https://github.com/pytorch/executorch/pull/11960. I accidently broke my ghstack, so I'm converting this to a normal PR.

Sample output (XNNPACK):
```
Test Session Summary:

   84 Passed / 95
   11 Failed / 95
    0 Skipped / 95

[Success]
   66 Delegated
   18 Undelegated

[Failure]
    4 Lowering Fail
    0 PTE Load Fail
    0 PTE Run Fail
    6 Output Mismatch Fail
```
Reproduce with `ET_TEST_ENABLED_BACKENDS=xnnpack python -m executorch.backends.test.suite.runner.executorch.backends.test.suite`. I've temporarily commented out non-f32 dtypes to work around some crashes in XNNPACK, which are non-recoverable from Python.
