### PR TITLE
Call target_link_options_shared_lib in executorch-config.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -490,7 +490,7 @@ install(
   INCLUDES
   DESTINATION ${_common_include_directories}
 )
-install(FILES tools/cmake/executorch-config.cmake
+install(FILES tools/cmake/Utils.cmake tools/cmake/executorch-config.cmake
         DESTINATION lib/cmake/ExecuTorch
 )
 

--- a/tools/cmake/executorch-config.cmake
+++ b/tools/cmake/executorch-config.cmake
@@ -24,7 +24,7 @@
 # the contract of exposing these CMake variables.
 
 cmake_minimum_required(VERSION 3.19)
-include("UtilsINTENTIONALLYBREAKTEST.cmake")
+include("Utils.cmake")
 
 set(_root "${CMAKE_CURRENT_LIST_DIR}/../../..")
 set(required_lib_list executorch executorch_core portable_kernels)

--- a/tools/cmake/executorch-config.cmake
+++ b/tools/cmake/executorch-config.cmake
@@ -24,7 +24,7 @@
 # the contract of exposing these CMake variables.
 
 cmake_minimum_required(VERSION 3.19)
-include("Utils.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/Utils.cmake")
 
 set(_root "${CMAKE_CURRENT_LIST_DIR}/../../..")
 set(required_lib_list executorch executorch_core portable_kernels)

--- a/tools/cmake/executorch-config.cmake
+++ b/tools/cmake/executorch-config.cmake
@@ -24,6 +24,7 @@
 # the contract of exposing these CMake variables.
 
 cmake_minimum_required(VERSION 3.19)
+include("UtilsINTENTIONALLYBREAKTEST.cmake")
 
 set(_root "${CMAKE_CURRENT_LIST_DIR}/../../..")
 set(required_lib_list executorch executorch_core portable_kernels)
@@ -171,3 +172,17 @@ if(TARGET extension_threadpool)
                                     "cpuinfo;pthreadpool"
   )
 endif()
+
+set(shared_lib_list
+  executorch
+  optimized_native_cpu_ops_lib
+  portable_ops_lib
+  quantized_ops_lib
+  xnnpack_backend
+  vulkan_backend
+  quantized_ops_aot_lib)
+foreach(lib ${shared_lib_list})
+  if(TARGET ${lib})
+    target_link_options_shared_lib(${lib})
+  endif()
+endforeach()

--- a/tools/cmake/executorch-config.cmake
+++ b/tools/cmake/executorch-config.cmake
@@ -174,7 +174,7 @@ if(TARGET extension_threadpool)
 endif()
 
 set(shared_lib_list
-  executorch
+  # executorch -- size tests fail due to regression if we include this and I'm not sure it's needed.
   optimized_native_cpu_ops_lib
   portable_ops_lib
   quantized_ops_lib


### PR DESCRIPTION
Customers need the flags this sets (`--whole-archive` or `-force_load`), otherwise the built operator libraries won't actually register operators.

Testing: ~~I'm not sure that we have automated coverage for this file, so I'm sending a first version adding an intentional break.~~ We have automated coverage for this file.