### PR TITLE
Fix eval by pinning datasets version to 3.6.0

### DIFF
--- a/requirements-examples.txt
+++ b/requirements-examples.txt
@@ -1,5 +1,6 @@
 # pip packages needed to run examples.
 # TODO: Make each example publish its own requirements.txt
+datasets == 3.6.0
 timm == 1.0.7
 torchsr == 1.0.4
 torchtune >= 0.6.1

--- a/requirements-examples.txt
+++ b/requirements-examples.txt
@@ -1,6 +1,6 @@
 # pip packages needed to run examples.
 # TODO: Make each example publish its own requirements.txt
-datasets == 3.6.0
+datasets == 3.6.0 # 4.0.0 deprecates trust_remote_code and load scripts. For now pin to 3.6.0
 timm == 1.0.7
 torchsr == 1.0.4
 torchtune >= 0.6.1


### PR DESCRIPTION
datasets 4.0.0 just released and it deprecates `trust_remote_code` and loading script. Pinning it to 3.6.0 for now.