### PR TITLE
Refactor Memory Allocator from Arm Executor Runner 

### DIFF
--- a/examples/arm/executor_runner/CMakeLists.txt
+++ b/examples/arm/executor_runner/CMakeLists.txt
@@ -566,7 +566,7 @@ endif()
 add_executable(arm_executor_runner)
 
 target_sources(
-  arm_executor_runner PRIVATE arm_executor_runner.cpp arm_perf_monitor.cpp
+  arm_executor_runner PRIVATE arm_executor_runner.cpp arm_perf_monitor.cpp arm_memory_allocator.cpp
 )
 
 # Include the target's bare-metal linker script

--- a/examples/arm/executor_runner/arm_executor_runner.cpp
+++ b/examples/arm/executor_runner/arm_executor_runner.cpp
@@ -19,8 +19,8 @@
 #include <memory>
 #include <vector>
 
-#include "arm_perf_monitor.h"
 #include "arm_memory_allocator.h"
+#include "arm_perf_monitor.h"
 
 #if defined(ET_BUNDLE_IO)
 #include <executorch/devtools/bundled_program/bundled_program.h>

--- a/examples/arm/executor_runner/arm_memory_allocator.cpp
+++ b/examples/arm/executor_runner/arm_memory_allocator.cpp
@@ -1,0 +1,46 @@
+/* Copyright 2025 Arm Limited and/or its affiliates.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "arm_memory_allocator.h"
+
+ArmMemoryAllocator::ArmMemoryAllocator(uint32_t size, uint8_t* base_address)
+      : MemoryAllocator(size, base_address), used_(0), peak_used_(0) {}
+
+void* ArmMemoryAllocator::allocate(size_t size, size_t alignment = kDefaultAlignment) override {
+    void* ret = executorch::runtime::MemoryAllocator::allocate(size, alignment);
+    if (ret != nullptr) {
+      // Align with the same code as in MemoryAllocator::allocate() to keep
+      // used_ "in sync" As alignment is expected to be power of 2 (checked by
+      // MemoryAllocator::allocate()) we can check it the lower bits
+      // (same as alignment - 1) is zero or not.
+      if ((size & (alignment - 1)) == 0) {
+        // Already aligned.
+        used_ += size;
+      } else {
+        used_ = (used_ | (alignment - 1)) + 1 + size;
+      }
+      if (used_ > peak_used_)
+        peak_used_ = used_;
+    }
+    return ret;
+}
+
+size_t ArmMemoryAllocator::used_size() const {
+    return used_;
+}
+
+size_t ArmMemoryAllocator::peak_used() const {
+    return peak_used_;
+}
+
+size_t ArmMemoryAllocator::free_size() const {
+    return executorch::runtime::MemoryAllocator::size() - used_;
+}
+
+void ArmMemoryAllocator::reset() {
+    executorch::runtime::MemoryAllocator::reset();
+    used_ = 0;
+}

--- a/examples/arm/executor_runner/arm_memory_allocator.cpp
+++ b/examples/arm/executor_runner/arm_memory_allocator.cpp
@@ -9,9 +9,7 @@
 ArmMemoryAllocator::ArmMemoryAllocator(uint32_t size, uint8_t* base_address)
     : MemoryAllocator(size, base_address), used_(0), peak_used_(0) {}
 
-void* ArmMemoryAllocator::allocate(
-    size_t size,
-    size_t alignment = kDefaultAlignment) override {
+void* ArmMemoryAllocator::allocate(size_t size, size_t alignment) {
   void* ret = executorch::runtime::MemoryAllocator::allocate(size, alignment);
   if (ret != nullptr) {
     // Align with the same code as in MemoryAllocator::allocate() to keep

--- a/examples/arm/executor_runner/arm_memory_allocator.cpp
+++ b/examples/arm/executor_runner/arm_memory_allocator.cpp
@@ -7,40 +7,42 @@
 #include "arm_memory_allocator.h"
 
 ArmMemoryAllocator::ArmMemoryAllocator(uint32_t size, uint8_t* base_address)
-      : MemoryAllocator(size, base_address), used_(0), peak_used_(0) {}
+    : MemoryAllocator(size, base_address), used_(0), peak_used_(0) {}
 
-void* ArmMemoryAllocator::allocate(size_t size, size_t alignment = kDefaultAlignment) override {
-    void* ret = executorch::runtime::MemoryAllocator::allocate(size, alignment);
-    if (ret != nullptr) {
-      // Align with the same code as in MemoryAllocator::allocate() to keep
-      // used_ "in sync" As alignment is expected to be power of 2 (checked by
-      // MemoryAllocator::allocate()) we can check it the lower bits
-      // (same as alignment - 1) is zero or not.
-      if ((size & (alignment - 1)) == 0) {
-        // Already aligned.
-        used_ += size;
-      } else {
-        used_ = (used_ | (alignment - 1)) + 1 + size;
-      }
-      if (used_ > peak_used_)
-        peak_used_ = used_;
+void* ArmMemoryAllocator::allocate(
+    size_t size,
+    size_t alignment = kDefaultAlignment) override {
+  void* ret = executorch::runtime::MemoryAllocator::allocate(size, alignment);
+  if (ret != nullptr) {
+    // Align with the same code as in MemoryAllocator::allocate() to keep
+    // used_ "in sync" As alignment is expected to be power of 2 (checked by
+    // MemoryAllocator::allocate()) we can check it the lower bits
+    // (same as alignment - 1) is zero or not.
+    if ((size & (alignment - 1)) == 0) {
+      // Already aligned.
+      used_ += size;
+    } else {
+      used_ = (used_ | (alignment - 1)) + 1 + size;
     }
-    return ret;
+    if (used_ > peak_used_)
+      peak_used_ = used_;
+  }
+  return ret;
 }
 
 size_t ArmMemoryAllocator::used_size() const {
-    return used_;
+  return used_;
 }
 
 size_t ArmMemoryAllocator::peak_used() const {
-    return peak_used_;
+  return peak_used_;
 }
 
 size_t ArmMemoryAllocator::free_size() const {
-    return executorch::runtime::MemoryAllocator::size() - used_;
+  return executorch::runtime::MemoryAllocator::size() - used_;
 }
 
 void ArmMemoryAllocator::reset() {
-    executorch::runtime::MemoryAllocator::reset();
-    used_ = 0;
+  executorch::runtime::MemoryAllocator::reset();
+  used_ = 0;
 }

--- a/examples/arm/executor_runner/arm_memory_allocator.h
+++ b/examples/arm/executor_runner/arm_memory_allocator.h
@@ -33,4 +33,3 @@ class ArmMemoryAllocator : public executorch::runtime::MemoryAllocator {
   size_t used_;
   size_t peak_used_;
 };
-

--- a/examples/arm/executor_runner/arm_memory_allocator.h
+++ b/examples/arm/executor_runner/arm_memory_allocator.h
@@ -1,0 +1,36 @@
+/* Copyright 2025 Arm Limited and/or its affiliates.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/runtime/core/memory_allocator.h>
+
+using executorch::runtime::MemoryAllocator;
+
+#pragma once
+
+// Setup our own allocator that can show some extra stuff like used and free
+// memory info
+class ArmMemoryAllocator : public executorch::runtime::MemoryAllocator {
+ public:
+  ArmMemoryAllocator(uint32_t size, uint8_t* base_address);
+
+  void* allocate(size_t size, size_t alignment = kDefaultAlignment) override;
+
+  // Returns the used size of the allocator's memory buffer.
+  size_t used_size() const;
+
+  // Returns the peak memory usage of the allocator's memory buffer
+  // Peak usage is useful when doing multiple allocations & resets
+  size_t peak_used() const;
+
+  // Returns the free size of the allocator's memory buffer.
+  size_t free_size() const;
+  void reset();
+
+ private:
+  size_t used_;
+  size_t peak_used_;
+};
+


### PR DESCRIPTION
### Summary
Some applications desire using more minimal memory allocators when leveraging the existing the exist arm_executor_runner.cpp, e.g. [here](https://github.com/BujSet/zephyr/blob/executorch-module-integration/samples/modules/executorch/arm/hello_world/src/et_memory_allocator.hpp). This change decouples a custom memory allocator wrapper from the executor runner so that apps can choose different implementations as needed. 

### Test plan
Ran the steps of the [Arm EthosU tutorial](https://docs.pytorch.org/executorch/main/tutorial-arm-ethos-u.html) to ensure that existing flow still works. I.e. running:

```
./examples/arm/setup.sh --i-agree-to-the-contained-eula
source ...
./examples/arm/run.sh --model_name=add --no_quantize --target=ethos-u55-128
``` 

still produces the following output:

```
I [executorch:arm_executor_runner.cpp:762 main()] Model executed successfully.
I [executorch:arm_executor_runner.cpp:768 main()] model_pte_program_size:     2064 bytes.
I [executorch:arm_executor_runner.cpp:769 main()] model_pte_loaded_size:      2064 bytes.
I [executorch:arm_executor_runner.cpp:783 main()] method_allocator_used:     320 / 62914560  free: 62914240 ( used: 0 % )
I [executorch:arm_executor_runner.cpp:790 main()] method_allocator_planned:  64 bytes
I [executorch:arm_executor_runner.cpp:794 main()] method_allocator_loaded:   232 bytes
I [executorch:arm_executor_runner.cpp:798 main()] method_allocator_input:    24 bytes
I [executorch:arm_executor_runner.cpp:799 main()] method_allocator_executor: 0 bytes
I [executorch:arm_executor_runner.cpp:802 main()] peak_temp_allocator:       64 / 2097152 free: 2097152 ( used: 0 % ) 
I [executorch:arm_executor_runner.cpp:812 main()] 1 outputs:
Output[0][0]: (int) 2
Output[0][1]: (int) 2
Output[0][2]: (int) 2
Output[0][3]: (int) 2
Output[0][4]: (int) 2
I [executorch:arm_executor_runner.cpp:952 main()] Program complete, exiting.
I [executorch:arm_executor_runner.cpp:956 main()] ♦
Info: /OSCI/SystemC: Simulation stopped by user.
[warning ][main@0][3440 ns] Simulation stopped by user
[backends/arm/scripts/run_fvp.sh] Simulation complete, 0
Checking for problems in log:
No problems found!
+ set +x
```
