### PR TITLE
forward fix executorch slice copy tests

### DIFF
--- a/backends/xnnpack/test/ops/test_slice_copy.py
+++ b/backends/xnnpack/test/ops/test_slice_copy.py
@@ -67,7 +67,7 @@ class TestSliceCopy(unittest.TestCase):
 
         inputs = (torch.randn(1, 1, 3, 3),)
         # Note that two of the slices are optimized away as they are identity.
-        self._test_slice_copy(ConvSlice(), inputs, 4, 2)
+        self._test_slice_copy(ConvSlice(), inputs, 2, 2)
 
     def test_fp32_slice_copy_default_start(self):
         """
@@ -95,7 +95,7 @@ class TestSliceCopy(unittest.TestCase):
         (
             Tester(module, inputs)
             .export()
-            .check_count({"torch.ops.aten.slice.Tensor": 3})
+            .check_count({"torch.ops.aten.slice.Tensor": 1})
             .to_edge_transform_and_lower()
             .check_not(["torch.ops.higher_order.executorch_call_delegate"])
         )


### PR DESCRIPTION
Summary:
T230513957

D77745298 made it so less no-op slices are emitted by export in the first place

Reviewed By: mcr229, GregoryComer

Differential Revision: D78103869


