### PR TITLE
[ET-VK] Adding get or create int function to read int value.

### DIFF
--- a/backends/vulkan/runtime/graph/ComputeGraph.cpp
+++ b/backends/vulkan/runtime/graph/ComputeGraph.cpp
@@ -549,6 +549,22 @@ vkapi::BufferBindInfo ComputeGraph::get_or_create_int_param_buffer(
   }
 }
 
+int32_t ComputeGraph::get_or_create_int(const ValueRef idx) {
+  if (values_.at(idx).isInt()) {
+    return extract_scalar<int32_t>(idx);
+  }
+  VK_THROW("Cannot create a int param buffer for the given value");
+}
+
+int32_t ComputeGraph::get_or_create_int(
+    const ValueRef idx,
+    const int32_t default_val) {
+  if (values_.at(idx).isNone()) {
+    return default_val;
+  }
+  return get_or_create_int(idx);
+}
+
 void ComputeGraph::set_symint(const ValueRef idx, const int32_t val) {
   get_symint(idx)->set(val);
 }

--- a/backends/vulkan/runtime/graph/ComputeGraph.h
+++ b/backends/vulkan/runtime/graph/ComputeGraph.h
@@ -424,6 +424,12 @@ class ComputeGraph final {
   // Scalar Value Extraction
   //
 
+  bool is_scalar(const ValueRef idx) const {
+    const Value& value = values_.at(idx);
+    return value.isInt() || value.isDouble() || value.isBool() ||
+        value.isNone();
+  }
+
   template <typename T>
   T extract_scalar(const ValueRef idx) {
     Value& value = values_.at(idx);
@@ -678,6 +684,10 @@ class ComputeGraph final {
   vkapi::BufferBindInfo get_or_create_int_param_buffer(
       const ValueRef idx,
       const int32_t default_value);
+
+  int32_t get_or_create_int(const ValueRef idx);
+
+  int32_t get_or_create_int(const ValueRef idx, const int32_t default_value);
 
   void set_symint(const ValueRef idx, const int32_t val);
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

This diff adds a new function `get_or_create_int` to the `ComputeGraph` class, which allows reading an integer value from a `ValueRef` index. The function returns the extracted integer value if the value at the index is an integer, otherwise it throws an error. Additionally, an overload of the function is added to return a default value if the value at the index is `None`.

Differential Revision: [D78094858](https://our.internmc.facebook.com/intern/diff/D78094858/)