### PR TITLE
Eliminate squeeze->op->unsqueeze patterns.

### DIFF
--- a/backends/cadence/aot/tests/test_remove_ops_passes.py
+++ b/backends/cadence/aot/tests/test_remove_ops_passes.py
@@ -8,6 +8,7 @@
 
 
 import unittest
+from copy import deepcopy
 from typing import cast, List, Tuple
 
 import executorch.backends.cadence.aot.ops_registrations  # noqa
@@ -30,6 +31,7 @@ from executorch.backends.cadence.aot.remove_ops import (
     RemoveNopSelectOpPass,
     RemoveNopSliceOrViewOpPass,
     RemovePermutesAroundElementwiseOps,
+    RemoveSqueezeViewBeforeElementwiseOps,
     RemoveToOpsPass,
     RemoveZeroSizedCatArgsPass,
     RemoveZeroSizedConstantPadNd,
@@ -568,6 +570,102 @@ class TestRemoveOpsPasses(unittest.TestCase):
         )
         self.assertEqual(len(slices), 1)
         self.assertEqual(slices[0].args[1], 2)
+
+    def test_remove_squeeze_view_before_elemwise_ops(self) -> None:
+        builder = GraphBuilder()
+        x = builder.placeholder("x", torch.randn(8, 1, 4, 4))
+        squeeze = builder.call_operator(
+            op=exir_ops.edge.aten.view_copy.default,
+            args=(x, [8, 4, 4]),
+        )
+        quantize = builder.call_operator(
+            op=exir_ops.edge.quantized_decomposed.quantize_per_tensor.default,
+            args=(squeeze, 0.12, -4, -128, 127, torch.int8),
+        )
+        slice_copy = builder.call_operator(
+            op=exir_ops.edge.aten.slice_copy.Tensor,
+            args=(quantize, 1, 0, 2, 1),
+        )
+        unsqueeze = builder.call_operator(
+            op=exir_ops.edge.aten.view_copy.default,
+            args=(slice_copy, [8, 1, 2, 4]),
+        )
+        builder.output([unsqueeze])
+        model = builder.get_graph_module()
+        original = deepcopy(model)
+
+        p = RemoveSqueezeViewBeforeElementwiseOps()
+        transformed = cast(PassResult, p(model)).graph_module
+
+        # First view should be eliminated and second view should be trivial.
+        views = transformed.graph.find_nodes(
+            op="call_function", target=exir_ops.edge.aten.view_copy.default
+        )
+        self.assertEqual(len(views), 1)
+        self.assertEqual(views[0].args[0].meta["val"].shape, views[0].meta["val"].shape)
+
+        # Verify that slice dimension was updated correctly.
+        slices = transformed.graph.find_nodes(
+            op="call_function", target=exir_ops.edge.aten.slice_copy.Tensor
+        )
+        self.assertEqual(len(slices), 1)
+        self.assertEqual(slices[0].args[1], 2)
+
+        # Verify the output of the model is the same as the original.
+        sample_input = torch.randn(8, 1, 4, 4)
+        self.assertTrue(
+            torch.allclose(
+                original(sample_input)[0],
+                transformed(sample_input)[0],
+            )
+        )
+
+    def test_remove_squeeze_view_before_elemwise_ops_multiple_squeeze(self) -> None:
+        builder = GraphBuilder()
+        x = builder.placeholder("x", torch.randn(8, 1, 1, 4, 1, 4))
+        squeeze = builder.call_operator(
+            op=exir_ops.edge.aten.view_copy.default,
+            args=(x, [8, 4, 4]),
+        )
+        quantize = builder.call_operator(
+            op=exir_ops.edge.quantized_decomposed.quantize_per_tensor.default,
+            args=(squeeze, 0.12, -4, -128, 127, torch.int8),
+        )
+        slice_copy = builder.call_operator(
+            op=exir_ops.edge.aten.slice_copy.Tensor,
+            args=(quantize, 1, 0, 2, 1),
+        )
+        view_copy = builder.call_operator(
+            op=exir_ops.edge.aten.view_copy.default,
+            args=(slice_copy, [16, 4]),
+        )
+        builder.output([view_copy])
+        model = builder.get_graph_module()
+        original = deepcopy(model)
+
+        p = RemoveSqueezeViewBeforeElementwiseOps()
+        transformed = cast(PassResult, p(model)).graph_module
+
+        # First view should be eliminated.
+        self.assertEqual(
+            count_node(transformed, exir_ops.edge.aten.view_copy.default), 1
+        )
+
+        # Verify that slice dimension was updated correctly.
+        slices = transformed.graph.find_nodes(
+            op="call_function", target=exir_ops.edge.aten.slice_copy.Tensor
+        )
+        self.assertEqual(len(slices), 1)
+        self.assertEqual(slices[0].args[1], 3)
+
+        # Verify the output of the model is the same as the original.
+        sample_input = torch.randn(8, 1, 1, 4, 1, 4)
+        self.assertTrue(
+            torch.allclose(
+                original(sample_input)[0],
+                transformed(sample_input)[0],
+            )
+        )
 
     def test_remove_permutes_around_elemwise_ops_mul(self) -> None:
         builder = GraphBuilder()


### PR DESCRIPTION
Summary:
Pre-partitioner pattern to eliminate squeeze->[elementwise ops+slice]->unsqueeze patterns in the graph. For context, this is a pattern seen in MicroGestures model.

Also postpone PostponePermuteOpBelowSqueezeOrUnsqueezeLikeView after quant/dequant fusion since it enables more patterns to be fused.

Differential Revision: D78104324


