### PR TITLE
Return Result to fail gracefully instead of aborting

### DIFF
--- a/runtime/executor/method_meta.h
+++ b/runtime/executor/method_meta.h
@@ -77,12 +77,31 @@ class TensorInfo final {
   friend class MethodMeta;
   friend class testing::TensorInfoTestFriend;
 
-  TensorInfo(
+  /**
+   * Create a TensorInfo instance.
+   *
+   * @param[in] sizes The sizes of the tensor.
+   * @param[in] dim_order The dim order of the tensor.
+   * @param[in] scalar_type The scalar type of the tensor.
+   * @param[in] is_memory_planned Whether the tensor's memory was planned.
+   * @param[in] name The fully qualified name of the tensor.
+   * @returns A Result containing the TensorInfo on success, or an error on
+   * failure.
+   */
+  static Result<TensorInfo> create(
       Span<const int32_t> sizes,
       Span<const uint8_t> dim_order,
       executorch::aten::ScalarType scalar_type,
       const bool is_memory_planned,
       std::string_view name);
+
+  TensorInfo(
+      Span<const int32_t> sizes,
+      Span<const uint8_t> dim_order,
+      executorch::aten::ScalarType scalar_type,
+      const bool is_memory_planned,
+      std::string_view name,
+      size_t nbytes);
 
   /**
    * The sizes of the tensor.

--- a/runtime/executor/test/method_meta_test.cpp
+++ b/runtime/executor/test/method_meta_test.cpp
@@ -39,12 +39,13 @@ class TensorInfoTestFriend final {
       executorch::aten::ScalarType scalar_type,
       const bool is_memory_planned,
       executorch::aten::string_view name) {
-    return TensorInfo(
-        Span<const int32_t>(sizes.data(), sizes.size()),
-        Span<const uint8_t>(dim_order.data(), dim_order.size()),
-        scalar_type,
-        is_memory_planned,
-        name);
+    return TensorInfo::create(
+               Span<const int32_t>(sizes.data(), sizes.size()),
+               Span<const uint8_t>(dim_order.data(), dim_order.size()),
+               scalar_type,
+               is_memory_planned,
+               name)
+        .get();
   }
 };
 } // namespace testing


### PR DESCRIPTION
Summary:
- Make TensorInfo static factory pattern to allow returning Result.
- Return Result type to fail gracefully instead of directly aborting in the runtime.

Differential Revision: D78187751


