### PR TITLE
Adding more explicit error code

### DIFF
--- a/runtime/core/error.h
+++ b/runtime/core/error.h
@@ -63,6 +63,12 @@ enum class Error : error_code_t {
   /// Operator(s) missing in the operator registry.
   OperatorMissing = 0x14,
 
+  /// Registration error: Exceeding the maximum number of kernels.
+  RegistrationExceedingMaxKernels = 0x15,
+
+  /// Registration error: The kernel is already registered.
+  RegistrationAlreadyRegistered = 0x16,
+
   /*
    * Resource errors.
    */
@@ -95,7 +101,6 @@ enum class Error : error_code_t {
   DelegateMemoryAllocationFailed = 0x31,
   /// Execute stage: The handle is invalid.
   DelegateInvalidHandle = 0x32,
-
 };
 
 // Stringify the Error enum.
@@ -137,6 +142,10 @@ constexpr const char* to_string(const Error error) {
       return "Error::DelegateMemoryAllocationFailed";
     case Error::DelegateInvalidHandle:
       return "Error::DelegateInvalidHandle";
+    case Error::RegistrationExceedingMaxKernels:
+      return "Error::RegistrationExceedingMaxKernels";
+    case Error::RegistrationAlreadyRegistered:
+      return "Error::RegistrationAlreadyRegistered";
   }
 }
 

--- a/runtime/kernel/operator_registry.cpp
+++ b/runtime/kernel/operator_registry.cpp
@@ -74,7 +74,7 @@ Error register_kernels_internal(const Span<const Kernel> kernels) {
       ET_LOG(Error, "%s", kernels[i].name_);
       ET_LOG_KERNEL_KEY(kernels[i].kernel_key_);
     }
-    return Error::Internal;
+    return Error::RegistrationExceedingMaxKernels;
   }
   // for debugging purpose
   ET_UNUSED const char* lib_name =
@@ -88,7 +88,7 @@ Error register_kernels_internal(const Span<const Kernel> kernels) {
           kernel.kernel_key_ == k.kernel_key_) {
         ET_LOG(Error, "Re-registering %s, from %s", k.name_, lib_name);
         ET_LOG_KERNEL_KEY(k.kernel_key_);
-        return Error::InvalidArgument;
+        return Error::RegistrationAlreadyRegistered;
       }
     }
     registered_kernels[num_registered_kernels++] = kernel;
@@ -106,7 +106,8 @@ Error register_kernels_internal(const Span<const Kernel> kernels) {
 // Registers the kernels, but panics if an error occurs. Always returns Ok.
 Error register_kernels(const Span<const Kernel> kernels) {
   Error success = register_kernels_internal(kernels);
-  if (success == Error::InvalidArgument || success == Error::Internal) {
+  if (success == Error::RegistrationAlreadyRegistered ||
+      success == Error::RegistrationExceedingMaxKernels) {
     ET_CHECK_MSG(
         false,
         "Kernel registration failed with error %" PRIu32

--- a/runtime/kernel/test/kernel_double_registration_test.cpp
+++ b/runtime/kernel/test/kernel_double_registration_test.cpp
@@ -34,7 +34,7 @@ TEST_F(KernelDoubleRegistrationTest, Basic) {
       "aten::add.out",
       "v1/7;0,1,2,3|7;0,1,2,3|7;0,1,2,3",
       [](KernelRuntimeContext&, EValue**) {})};
-  Error err = Error::InvalidArgument;
+  Error err = Error::RegistrationAlreadyRegistered;
 
   ET_EXPECT_DEATH(
       { (void)register_kernels({kernels}); },


### PR DESCRIPTION
Summary: {title}, the `Internal` and `InvalidArgument` errors don't tell what is really going wrong

Differential Revision: D78233596


