### PR TITLE
Fix build_apple_frameworks.sh to use proper EXECUTORCH_ENABLE_LOGGING…

### DIFF
--- a/scripts/build_apple_frameworks.sh
+++ b/scripts/build_apple_frameworks.sh
@@ -148,11 +148,11 @@ for preset_index in "${!PRESETS[@]}"; do
     echo "Building preset ${preset} (${mode}) in ${preset_output_dir}..."
 
     # Do NOT add options here. Update the respective presets instead.
+    # Xcode multi-config presets leave CMAKE_BUILD_TYPE empty, so force EXECUTORCH_ENABLE_LOGGING per-mode.
     cmake -S "${SOURCE_ROOT_DIR}" \
           -B "${preset_output_dir}" \
           -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY="${preset_output_dir}" \
           -DCMAKE_BUILD_TYPE="${mode}" \
-          # Xcode multi-config presets leave CMAKE_BUILD_TYPE empty, so force our logging flag per-mode.
           -UEXECUTORCH_ENABLE_LOGGING \
           -DEXECUTORCH_ENABLE_LOGGING=$([ "${mode}" = "Debug" ] && echo ON || echo OFF) \
           ${CMAKE_OPTIONS_OVERRIDE[@]:-} \

--- a/scripts/build_apple_frameworks.sh
+++ b/scripts/build_apple_frameworks.sh
@@ -152,6 +152,9 @@ for preset_index in "${!PRESETS[@]}"; do
           -B "${preset_output_dir}" \
           -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY="${preset_output_dir}" \
           -DCMAKE_BUILD_TYPE="${mode}" \
+          # Xcode multi-config presets leave CMAKE_BUILD_TYPE empty, so force our logging flag per-mode.
+          -UEXECUTORCH_ENABLE_LOGGING \
+          -DEXECUTORCH_ENABLE_LOGGING=$([ "${mode}" = "Debug" ] && echo ON || echo OFF) \
           ${CMAKE_OPTIONS_OVERRIDE[@]:-} \
           --preset "${preset}"
 


### PR DESCRIPTION
EXECUTORCH_ENABLE_LOGGING doesn't pick up based on the build mode, as it should based on [default.cmake](https://github.com/pytorch/executorch/blob/main/tools/cmake/preset/default.cmake#L20)
Meanwhile macOS preset in macos.cmake always enabled logging due to the fact it includes [pybind.cmake](https://github.com/pytorch/executorch/blob/main/tools/cmake/preset/pybind.cmake#L10-L13) which deliberately enables it with an override.
Thus for Apple frameworks build we get logging disabled permanently, except for macos where it's always enabled based on a pretty unrelated pybind settings.