### PR TITLE
Fix cache_positions tensor size in TextLLMRunner

### DIFF
--- a/extension/llm/runner/text_prefiller.h
+++ b/extension/llm/runner/text_prefiller.h
@@ -21,7 +21,7 @@ class ET_EXPERIMENTAL TextPrefiller {
  public:
   TextPrefiller(
       TextDecoderRunner* text_decoder_runner,
-      bool use_kv_cache_,
+      bool use_kv_cache,
       bool enable_parallel_prefill,
       int64_t max_seq_len = 128);
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #12477
* __->__ #12476

In Huggingface causal LM forward convention, `cache_position` should
have the same length as `input_ids`. The previous logic will allocate
`cache_position` based on method metadata which by default is equal to
the maximum length of this tensor (normally max context length). Now
changing the logic to align the size of `cache_position` to `input_ids`.