### PR TITLE
Fix unreachable-break issue in dwio/rcfile/RcSerdeText.cpp +5

### DIFF
--- a/backends/vulkan/runtime/vk_api/Pipeline.cpp
+++ b/backends/vulkan/runtime/vk_api/Pipeline.cpp
@@ -82,7 +82,6 @@ VkImageLayout vk_layout(
         default:
           return VK_IMAGE_LAYOUT_GENERAL;
       }
-      break;
     case PipelineStage::TRANSFER:
       switch (access) {
         case MemoryAccessType::READ:

--- a/devtools/bundled_program/bundled_program.cpp
+++ b/devtools/bundled_program/bundled_program.cpp
@@ -329,7 +329,6 @@ ET_NODISCARD Error load_bundled_input(
             NotSupported,
             "Data type %hhu not supported",
             static_cast<uint8_t>(bundled_input->val_type()));
-        break;
       }
     }
 
@@ -441,7 +440,6 @@ ET_NODISCARD ErrorStats compute_method_output_error_stats(
             "Data type %hhd not supported",
             static_cast<uint8_t>(bundled_expected_output->val_type()));
         return {Error::NotSupported, 0, 0, 0, 0};
-        break; // Never reached
       }
     }
   }
@@ -523,7 +521,6 @@ ET_NODISCARD Error verify_method_outputs(
             NotSupported,
             "Data type %hhd not supported",
             static_cast<uint8_t>(bundled_expected_output->val_type()));
-        break;
       }
     }
   }


### PR DESCRIPTION
Summary:
LLVM has a warning `-Wunreachable-code-break` which identifies `break` statements that cannot be reached. These compromise readability, are misleading, and may identify bugs. This diff removes such statements.

Such statements once existed to prevent accidental fallthroughs in switch statements. However, this is no longer necessary in C++17 because `[[fallthrough]]` is used to indicate intentional fallthroughs and we raise compilation errors for fallthroughs that are not annotated with `[[fallthrough]]` using `-Wimplicit-fallthrough`.

For questions/comments, contact r-barnes.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: dtolnay

Differential Revision: D78276018


