### PR TITLE
Fix unreachable-break issue in executorch/runtime/executor/method_meta.cpp +5

### DIFF
--- a/runtime/executor/method_meta.cpp
+++ b/runtime/executor/method_meta.cpp
@@ -24,24 +24,18 @@ Result<Tag> get_tag(
         return_type serialization_value,
     size_t index) {
   switch (serialization_value->val_type()) {
-    case executorch_flatbuffer::KernelTypes::Null: {
+    case executorch_flatbuffer::KernelTypes::Null:
       return Tag::None;
-    } break;
-    case executorch_flatbuffer::KernelTypes::Int: {
+    case executorch_flatbuffer::KernelTypes::Int:
       return Tag::Int;
-    } break;
-    case executorch_flatbuffer::KernelTypes::Double: {
+    case executorch_flatbuffer::KernelTypes::Double:
       return Tag::Double;
-    } break;
-    case executorch_flatbuffer::KernelTypes::Bool: {
+    case executorch_flatbuffer::KernelTypes::Bool:
       return Tag::Bool;
-    } break;
-    case executorch_flatbuffer::KernelTypes::String: {
+    case executorch_flatbuffer::KernelTypes::String:
       return Tag::String;
-    } break;
-    case executorch_flatbuffer::KernelTypes::Tensor: {
+    case executorch_flatbuffer::KernelTypes::Tensor:
       return Tag::Tensor;
-    } break;
     default:
       ET_LOG(
           Error,


### PR DESCRIPTION
Summary:
LLVM has a warning `-Wunreachable-code-break` which identifies `break` statements that cannot be reached. These compromise readability, are misleading, and may identify bugs. This diff removes such statements.

Such statements once existed to prevent accidental fallthroughs in switch statements. However, this is no longer necessary in C++17 because `[[fallthrough]]` is used to indicate intentional fallthroughs and we raise compilation errors for fallthroughs that are not annotated with `[[fallthrough]]` using `-Wimplicit-fallthrough`.

For questions/comments, contact r-barnes.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: dtolnay

Differential Revision: D78275955


