### PR TITLE
Source transform for HF RoPE in static attention

### DIFF
--- a/examples/models/llama/static_attention.py
+++ b/examples/models/llama/static_attention.py
@@ -730,6 +730,34 @@ class StaticAttention(Attention):
             self.k_norm = torch.nn.RMSNorm(other.k_norm_fn.dim, other.k_norm_fn.eps)
             self.k_norm.load_state_dict(other.k_norm_fn.state_dict())
 
+    def adopt_hf_rope(self):
+        if self.rope.use_hf_rope:
+            return
+
+        if self.use_conv2d:
+            raise RuntimeError(
+                "adopt_hf_rope needs to be called before linear_to_conv2d"
+            )
+
+        # Permute weights of qk projections and norms to match HF RoPE's channel order.
+        def permute(w):
+            shape = w.shape
+            return (
+                w.view((-1, 2) + shape[1:]).transpose(0, 1).reshape(shape).contiguous()
+            )
+
+        for wq in self.wqs:
+            wq.weight.data.copy_(permute(wq.weight.data))
+
+        for wk in self.wks:
+            wk.weight.data.copy_(permute(wk.weight.data))
+
+        if self.use_qk_norm:
+            self.q_norm.weight.data.copy_(permute(self.q_norm.weight.data))
+            self.k_norm.weight.data.copy_(permute(self.k_norm.weight.data))
+
+        self.rope.use_hf_rope = True
+
     def linear_to_conv2d(self):
         def transfer_weight(linear, conv2d):
             conv2d.weight.data.copy_(linear.weight[:, :, None, None])


### PR DESCRIPTION
Summary: LLama style RoPE shuffles/unshuffles the embedding dimension which is not as efficient as HF style RoPE. Add a source transform on static attention so HF style can be used.

Differential Revision: D78353775


