### PR TITLE
Fix delegate node metadata

### DIFF
--- a/backends/arm/test/tester/arm_tester.py
+++ b/backends/arm/test/tester/arm_tester.py
@@ -726,7 +726,7 @@ def _get_dtype_distribution(
         if node.op == "placeholder":
             placeholder_dtypes.append(str(node.meta["val"].dtype))
         if node.op == "call_function":
-            if "val" in node.meta:
+            if "val" in node.meta and isinstance(node.meta["val"], torch.Tensor):
                 dtype, _, _ = extract_tensor_meta(node.meta, tosa_spec)
                 call_function_dtypes.append(ts.DTypeNames[dtype])
     return Counter(placeholder_dtypes), Counter(call_function_dtypes)

--- a/exir/backend/backend_api.py
+++ b/exir/backend/backend_api.py
@@ -235,7 +235,9 @@ def _insert_lowered_submodule(
             call_submodule_node.kwargs,
         )
         call_delegate_node.meta["debug_handle"] = generate_debug_handle(owning_program)
-        call_delegate_node.meta["val"] = submodule_output_node.meta["val"]
+        call_delegate_node.meta["val"] = [
+            out_arg.meta["val"] for out_arg in submodule_output_node.args[0]
+        ]
         call_submodule_node.replace_all_uses_with(call_delegate_node)
         owning_graph_module.graph.erase_node(call_submodule_node)
     if is_submodule:
@@ -472,11 +474,9 @@ def _create_partitions_in_graph_module(
                 tagged_graph_module, node_list, tag
             )
 
-        tagged_graph_module_output_node = tagged_graph_module.graph.output_node()
         submodule_output_node = submodule.graph.output_node()
         # Copy the output node meta from the original output node, because
         # create_submodule_from_nodes doesn't cover the meta field
-        submodule_output_node.meta = tagged_graph_module_output_node.meta
         logging.debug(f"Partitioned graph module: {tagged_graph_module}")
         (
             submodule_program,


### PR DESCRIPTION
Summary: The delegate node's metadata was set incorrectly, causing deserialization to fail

Reviewed By: mcr229

Differential Revision: D78350040


