### PR TITLE
Fixed runtime merging logics

### DIFF
--- a/devtools/inspector/_inspector.py
+++ b/devtools/inspector/_inspector.py
@@ -1211,7 +1211,9 @@ class Inspector:
                     # TODO: One debug handle can be associated with multiple op names
                     debug_handle_to_op_names[debug_handle] = [event.name]
 
-        merge_runtime_overlapping_debug_handles(debug_handle_to_output)
+        debug_handle_to_output = merge_runtime_overlapping_debug_handles(
+            debug_handle_to_output
+        )
         return {
             k: v[1] for k, v in debug_handle_to_output.items()
         }, debug_handle_to_op_names

--- a/devtools/inspector/tests/inspector_utils_test.py
+++ b/devtools/inspector/tests/inspector_utils_test.py
@@ -278,6 +278,27 @@ class TestInspectorUtils(unittest.TestCase):
             actual_value = intermediate_outputs[key][1]
             self.assertTrue(torch.allclose(expected_value, actual_value))
 
+    def test_merge_overlapping_debug_handles_edge_cases(self):
+        intermediate_outputs = {
+            (9,): (1, "val1"),
+            (
+                9,
+                9,
+                9,
+            ): (2, "val2"),
+            (
+                9,
+                9,
+            ): (3, "val3"),
+        }
+        intermediate_outputs = merge_runtime_overlapping_debug_handles(
+            intermediate_outputs
+        )
+        expected_intermediate_outputs = {
+            (9,): (3, "val3"),
+        }
+        self.assertEqual(intermediate_outputs, expected_intermediate_outputs)
+
     def test_map_runtime_aot_intermediate_outputs_empty_inputs(self):
         # When the inputs are empty, the output should also be empty
         aot_intermediate_outputs = {}


### PR DESCRIPTION
Summary: This PR first added a missing return statement so that merge_runtime_overlapping_debug_handles now returns the updated debug_handle_to_output instead of doing nothing. Also updated the condition to use set intersection for more clearer checking of any common elements between debug_handle and existing_debug_handle.

Differential Revision: D78182279


