### PR TITLE
CoreML partitioner improvements

### DIFF
--- a/backends/apple/coreml/partition/coreml_partitioner.py
+++ b/backends/apple/coreml/partition/coreml_partitioner.py
@@ -37,10 +37,6 @@ class OperatorsSupportedForCoreMLBackend(OperatorSupportBase):
         super().__init__()
         self.skip_ops_for_coreml_delegation = skip_ops_for_coreml_delegation
         self.lower_full_graph = lower_full_graph
-        if self.lower_full_graph:
-            assert (
-                len(self.skip_ops_for_coreml_delegation or []) == 0
-            ), "Cannot have skip_ops_for_coreml_delegation when lower_full_graph is True"
         self._logged_msgs = set()
 
     def log_once(self, msg: str) -> None:
@@ -138,6 +134,17 @@ class CoreMLPartitioner(Partitioner):
         self.lower_full_graph = lower_full_graph
         self.take_over_constant_data = take_over_constant_data
         self._logged_msgs = set()
+
+        if self.lower_full_graph:
+            assert (
+                len(self.skip_ops_for_coreml_delegation) == 0
+            ), "When lower_full_graph=True, you cannot set skip_ops_for_coreml_delegation"
+            assert (
+                self.take_over_constant_data
+            ), "When lower_full_graph=True, you must set take_over_constant_data=True"
+            assert (
+                self.take_over_mutable_buffer
+            ), "When lower_full_graph=True, you must set take_over_mutable_buffer=True"
 
     def partition(self, exported_program: ExportedProgram) -> PartitionResult:
         # Run the CapabilityBasedPartitioner to return the largest possible

--- a/backends/apple/coreml/test/test_coreml_partitioner.py
+++ b/backends/apple/coreml/test/test_coreml_partitioner.py
@@ -253,6 +253,7 @@ class TestCoreMLPartitioner(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             edge_program_manager2.to_backend(CoreMLPartitioner(lower_full_graph=True))
 
+    # TODO: enable this after bugs are fixed in ExecuTorch's partitioner
     # def test_symint_arg(self):
     #     class Model(torch.nn.Module):
     #         def forward(self, x, w, b, y):
@@ -330,9 +331,6 @@ class TestCoreMLPartitioner(unittest.TestCase):
             self.assertTrue(
                 torch.allclose(et_outputs, eager_outputs, atol=1e-02, rtol=1e-02)
             )
-
-            with open("/tmp/et_model.pte", "wb") as file:
-                et_prog.write_to_file(file)
 
 
 if __name__ == "__main__":

--- a/backends/apple/coreml/test/test_coreml_partitioner.py
+++ b/backends/apple/coreml/test/test_coreml_partitioner.py
@@ -38,7 +38,6 @@ def _(
 
 
 _TEST_RUNTIME = sys.platform == "darwin"
-_TEST_RUNTIME = False  # Disable until segfault fixed: https://github.com/pytorch/executorch/issues/12408
 
 
 class TestCoreMLPartitioner(unittest.TestCase):


### PR DESCRIPTION
This creates several improvements for the CoreML partitioner:

* We now log when nodes are skipped for partitioning and the reason they are skipped.
* We add new partitioner option lower_full_graph that raises Exception if the model cannot be fully delegated.  In future, when this option is enabled we plan to support additional CoreML features like enumerated shapes.
* We add take_over_constant_data option to tell CoreML delegate to not consume weight data.