### PR TITLE
Arm backend: Fix logging info in decomposition pass for asin

### DIFF
--- a/backends/arm/_passes/decompose_asin_pass.py
+++ b/backends/arm/_passes/decompose_asin_pass.py
@@ -85,12 +85,11 @@ class DecomposeAsinPass(ArmPass):
         return result
 
     def call_operator(self, op, args, kwargs, meta):
+        if op not in edge_asin_op:
+            return super().call_operator(op, args, kwargs, meta)
         logging.info(
             f"Approximating asin. This may introduce small numerical errors. For details, see {__file__}."
         )
-        if op not in edge_asin_op:
-            return super().call_operator(op, args, kwargs, meta)
-
         x = args[0]
         half = 0.5
         one = 1.0


### PR DESCRIPTION
Logging info about asin being approximated was placed before the if-statement in call_operator resulting in it being triggered for all ops, not just asin.


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218