### PR TITLE
New Docker Build for Zephyr Projects

### DIFF
--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -43,6 +43,10 @@ case "${IMAGE_NAME}" in
     ARM_SDK=yes
     CLANG_VERSION=12
     ;;
+  executorch-ubuntu-22.04-zephyr-sdk)
+    ZEPHYR_SDK=yes
+    GCC_VERSION=11
+    ;;
   executorch-ubuntu-22.04-qnn-sdk)
     QNN_SDK=yes
     CLANG_VERSION=12
@@ -87,6 +91,7 @@ docker build \
   --build-arg "LINTRUNNER=${LINTRUNNER:-}" \
   --build-arg "BUILD_DOCS=${BUILD_DOCS}" \
   --build-arg "ARM_SDK=${ARM_SDK:-}" \
+  --build-arg "ZEPHYR_SDK=${ZEPHYR_SDK:-}" \
   --build-arg "QNN_SDK=${QNN_SDK:-}" \
   --build-arg "MEDIATEK_SDK=${MEDIATEK_SDK:-}" \
   --build-arg "ANDROID_NDK_VERSION=${ANDROID_NDK_VERSION:-}" \

--- a/.ci/docker/common/install_zephyr.sh
+++ b/.ci/docker/common/install_zephyr.sh
@@ -90,4 +90,3 @@ install_sdk() {
 
 install_prerequiresites
 install_sdk
-

--- a/.ci/docker/common/install_zephyr.sh
+++ b/.ci/docker/common/install_zephyr.sh
@@ -1,0 +1,74 @@
+
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -ex
+
+# Double check if the NDK version is set
+[ -n "${ZEPHYR_SDK}" ]
+
+install_prerequiresites() {
+    rm /var/lib/dpkg/info/libc-bin.*
+    apt-get clean
+    apt-get -y update
+    apt-get install -y libc-bin
+    apt-get -y update
+    apt-get clean
+    apt-get install --no-install-recommends -y dos2unix
+    apt-get install --no-install-recommends -y ca-certificates
+    apt-get install -y --reinstall libc-bin
+    apt-get install --no-install-recommends -y file
+    apt-get install --no-install-recommends -y locales
+    apt-get install --no-install-recommends -y git
+    apt-get install --no-install-recommends -y build-essential
+    apt-get install --no-install-recommends -y cmake
+    apt-get install --no-install-recommends -y ninja-build gperf
+    apt-get install --no-install-recommends -y device-tree-compiler
+    apt-get install --no-install-recommends -y wget
+    apt-get install --no-install-recommends -y curl
+    apt-get install --no-install-recommends -y xz-utils
+    apt-get install --no-install-recommends -y dos2unix
+    apt-get install --no-install-recommends -y vim
+    apt-get install --no-install-recommends -y nano
+    apt-get install --no-install-recommends -y mc
+    apt-get install --no-install-recommends -y openssh-server
+    apt-get install -y gdb
+
+    # Zephyr SDK relies on python 3.12
+    apt install software-properties-common -y
+    add-apt-repository ppa:deadsnakes/ppa -y
+    apt update
+    apt install -y python3.12 python3.12-dev python3.12-venv python3-pip
+    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1
+
+    # Upgrade cmake ot 3.24
+    apt update
+    apt install cmake
+    apt install software-properties-common lsb-release
+    apt update
+    test -f /usr/share/doc/kitware-archive-keyring/copyright || \
+        wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
+    "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/kitware.list > /dev/null
+    apt update
+    apt install cmake
+
+    # Install additional required software for Zephyr
+    apt install --no-install-recommends -y ccache \
+        dfu-util \
+        python3-setuptools \
+        python3-tk \
+        python3-wheel \
+        make \
+        gcc \
+        libsdl2-dev \
+        libmagic1 \
+        xterm \
+        telnet \
+        net-tools
+}
+
+install_prerequiresites

--- a/.ci/docker/common/install_zephyr.sh
+++ b/.ci/docker/common/install_zephyr.sh
@@ -69,6 +69,25 @@ install_prerequiresites() {
         xterm \
         telnet \
         net-tools
+    apt install --no-install-recommends -y gcc-multilib g++-multilib
+    apt-get clean -y
+    apt-get autoremove --purge -y
+    rm -rf /var/lib/apt/lists/*
+    wget https://apt.kitware.com/kitware-archive.sh && \
+        chmod +x kitware-archive.sh && \
+        ./kitware-archive.sh && \
+        rm -f kitware-archive.sh
+    useradd -d /home/zephyruser -m -s /bin/bash zephyruser
+}
+
+install_sdk() {
+    wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.0/zephyr-sdk-0.16.0_linux-x86_64.tar.xz && \
+         tar -xf zephyr-sdk-0.16.0_linux-x86_64.tar.xz && \
+         rm -f zephyr-sdk-0.16.0_linux-x86_64.tar.xz && \
+         cd zephyr-sdk-0.16.0/ && \
+         ./setup.sh -c -t arm-zephyr-eabi
 }
 
 install_prerequiresites
+install_sdk
+

--- a/.ci/docker/ubuntu/Dockerfile
+++ b/.ci/docker/ubuntu/Dockerfile
@@ -84,6 +84,11 @@ RUN rm install_android.sh
 
 ARG ARM_SDK
 
+ARG ZEPHYR_SDK
+COPY ./common/install_zephyr.sh install_zephyr.sh
+RUN if [ -n "${ZEPHYR_SDK}" ]; then bash ./install_zephyr.sh; fi
+RUN rm install_zephyr.sh
+
 ARG QNN_SDK
 
 ARG MEDIATEK_SDK

--- a/.github/workflows/build-presets.yml
+++ b/.github/workflows/build-presets.yml
@@ -44,7 +44,7 @@ jobs:
       job-name: build
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       runner: linux.2xlarge
-      docker-image: ci-image:executorch-ubuntu-22.04-arm-sdk
+      docker-image: ci-image:executorch-ubuntu-22.04-zephyr-sdk
       submodules: recursive
       timeout: 90
       script: |

--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -37,6 +37,7 @@ jobs:
           executorch-ubuntu-22.04-clang12,
           executorch-ubuntu-22.04-linter,
           executorch-ubuntu-22.04-arm-sdk,
+          executorch-ubuntu-22.04-zephyr-sdk,
           executorch-ubuntu-22.04-qnn-sdk,
           executorch-ubuntu-22.04-mediatek-sdk,
           executorch-ubuntu-22.04-clang12-android


### PR DESCRIPTION
### Summary
To officially support Zephyr and ensure CI tests code paths in the executorch repo that target builds for Zephyr, the environment that the CI runs in must have all the necessary packages and tools to build a zephyr project. This PR starts the process for supporting a new docker image that will have everything necessary to build executorch zephyr projects. This PR is prompted by the discussion on #12348. Eventually, CI tests will use the added Zephyr PAL for more in depth CI tests. 

### Test plan
Currently, the zephyr cmake preset relies on the `arm-sdk` docker image. This change adds a new `zephyr-sdk` image, and the `build-preset` test has been updated to use this new image.  


cc @larryliu0820 @jathu