### PR TITLE
Make OS presets only build library

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -8,7 +8,7 @@
     },
     {
       "name": "macos",
-      "displayName": "Build everything buildable on macOS",
+      "displayName": "Build ExecuTorch for macOS",
       "inherits": ["common"],
       "generator": "Xcode",
       "cacheVariables": {
@@ -25,7 +25,7 @@
     },
     {
       "name": "ios",
-      "displayName": "Build everything buildable on iOS",
+      "displayName": "Build ExecuTorch for iOS",
       "inherits": ["common"],
       "generator": "Xcode",
       "cacheVariables": {
@@ -42,7 +42,7 @@
     },
     {
       "name": "ios-simulator",
-      "displayName": "Build everything buildable on iOS simulator",
+      "displayName": "Build ExecuTorch for iOS Simulator",
       "inherits": ["common"],
       "generator": "Xcode",
       "cacheVariables": {
@@ -59,7 +59,7 @@
     },
     {
       "name": "linux",
-      "displayName": "Build everything buildable on Linux",
+      "displayName": "Build ExecuTorch for Linux",
       "inherits": ["common"],
       "cacheVariables": {
         "CMAKE_SYSTEM_NAME": "Linux",
@@ -88,9 +88,7 @@
     {
         "name": "llm",
         "displayName": "Build LLM libraries",
-        "inherits": [
-            "common"
-        ],
+        "inherits": ["common"],
         "cacheVariables": {
             "EXECUTORCH_BUILD_PRESET_FILE": "${sourceDir}/tools/cmake/preset/llm.cmake",
             "CMAKE_OSX_DEPLOYMENT_TARGET": "12.0"
@@ -98,19 +96,13 @@
         "condition": {
             "type": "inList",
             "string": "${hostSystemName}",
-            "list": [
-                "Darwin",
-                "Linux",
-                "Windows"
-            ]
+            "list": ["Darwin", "Linux", "Windows"]
         }
     },
     {
         "name": "zephyr",
-        "displayName": "Build everything buildable on Zephyr RTOS",
-        "inherits": [
-            "common"
-        ],
+        "displayName": "Build ExecuTorch for Zephyr RTOS",
+        "inherits": ["common"],
         "cacheVariables": {
             "EXECUTORCH_BUILD_PRESET_FILE": "${sourceDir}/tools/cmake/preset/zephyr.cmake",
             "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/examples/zephyr/x86_64-linux-arm-zephyr-eabi-gcc.cmake"

--- a/tools/cmake/preset/linux.cmake
+++ b/tools/cmake/preset/linux.cmake
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-include(${PROJECT_SOURCE_DIR}/tools/cmake/preset/pybind.cmake)
 include(${PROJECT_SOURCE_DIR}/tools/cmake/preset/llm.cmake)
 
 set_overridable_option(EXECUTORCH_BUILD_EXECUTOR_RUNNER ON)
+set_overridable_option(EXECUTORCH_BUILD_EXTENSION_RUNNER_UTIL ON)

--- a/tools/cmake/preset/llm.cmake
+++ b/tools/cmake/preset/llm.cmake
@@ -4,9 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# Enable logging even when in release mode. We are building for desktop, where
-# saving a few kB is less important than showing useful error information to
-# users.
 # keep sorted
 set_overridable_option(EXECUTORCH_BUILD_EXTENSION_DATA_LOADER ON)
 set_overridable_option(EXECUTORCH_BUILD_EXTENSION_FLAT_TENSOR ON)

--- a/tools/cmake/preset/macos.cmake
+++ b/tools/cmake/preset/macos.cmake
@@ -5,8 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 include(${PROJECT_SOURCE_DIR}/tools/cmake/preset/apple_common.cmake)
-include(${PROJECT_SOURCE_DIR}/tools/cmake/preset/pybind.cmake)
-include(${PROJECT_SOURCE_DIR}/tools/cmake/preset/llm.cmake)
 
 set_overridable_option(EXECUTORCH_BUILD_EXECUTOR_RUNNER ON)
 set_overridable_option(EXECUTORCH_COREML_BUILD_EXECUTOR_RUNNER ON)


### PR DESCRIPTION
### Summary

I think mixing these different motivations (i.e. pybind vs. ET lib) can causes issues in the future with conflicting flags. For example, pybind always enables `EXECUTORCH_ENABLE_LOGGING` regardless of build mode (https://github.com/pytorch/executorch/pull/12469). So, I think we should just make the platform presets build ET targeting that platform.

### Test plan

CI