### PR TITLE
Clean cache between Apple builds

### DIFF
--- a/scripts/build_apple_frameworks.sh
+++ b/scripts/build_apple_frameworks.sh
@@ -153,13 +153,11 @@ for preset_index in "${!PRESETS[@]}"; do
     echo "Building preset ${preset} (${mode}) in ${preset_output_dir}..."
 
     # Do NOT add options here. Update the respective presets instead.
-    # Xcode multi-config presets leave CMAKE_BUILD_TYPE empty, so force EXECUTORCH_ENABLE_LOGGING per-mode.
     cmake -S "${SOURCE_ROOT_DIR}" \
           -B "${preset_output_dir}" \
+          --fresh \
           -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY="${preset_output_dir}" \
           -DCMAKE_BUILD_TYPE="${mode}" \
-          -UEXECUTORCH_ENABLE_LOGGING \
-          -DEXECUTORCH_ENABLE_LOGGING=$([ "${mode}" = "Debug" ] && echo ON || echo OFF) \
           ${CMAKE_OPTIONS_OVERRIDE[@]:-} \
           --preset "${preset}"
 


### PR DESCRIPTION
### Summary

In this diff, we clear the CMakeCache.txt between builds since we reuse the same build output for all the builds. Keeping the cache means that configuration between each build won't be reflected (i.e. https://github.com/pytorch/executorch/pull/12469).

### Test plan
CI

I also tested to ensure that `EXECUTORCH_ENABLE_LOGGING` is being properly set based on the build mode.

```
-- PLATFORM: OS64
-- CMAKE_BUILD_TYPE: Release
-- EXECUTORCH_ENABLE_LOGGING: OFF
-- ----------------------------------------------------
-- PLATFORM: OS64
-- CMAKE_BUILD_TYPE: Debug
-- EXECUTORCH_ENABLE_LOGGING: ON
-- ----------------------------------------------------
-- PLATFORM: SIMULATORARM64
-- CMAKE_BUILD_TYPE: Release
-- EXECUTORCH_ENABLE_LOGGING: OFF
-- ----------------------------------------------------
-- PLATFORM: SIMULATORARM64
-- CMAKE_BUILD_TYPE: Debug
-- EXECUTORCH_ENABLE_LOGGING: ON
-- ----------------------------------------------------
-- PLATFORM: MAC_ARM64
-- CMAKE_BUILD_TYPE: Release
-- EXECUTORCH_ENABLE_LOGGING: OFF
-- ----------------------------------------------------
-- PLATFORM: MAC_ARM64
-- CMAKE_BUILD_TYPE: Debug
-- EXECUTORCH_ENABLE_LOGGING: ON
-- ----------------------------------------------------
```