### PR TITLE
[not for landing] Test overriding get/set option in coreml

### DIFF
--- a/backends/apple/coreml/runtime/delegate/coreml_backend_delegate.mm
+++ b/backends/apple/coreml/runtime/delegate/coreml_backend_delegate.mm
@@ -37,6 +37,8 @@ using executorch::runtime::ArrayRef;
 using executorch::runtime::Backend;
 using executorch::runtime::BackendExecutionContext;
 using executorch::runtime::BackendInitContext;
+using executorch::runtime::BackendOptionContext;
+using executorch::runtime::BackendOption;
 using executorch::runtime::CompileSpec;
 using executorch::runtime::DelegateHandle;
 using executorch::runtime::EValue;
@@ -45,6 +47,7 @@ using executorch::runtime::EventTracerDebugLogLevel;
 using executorch::runtime::FreeableBuffer;
 using executorch::runtime::get_backend_class;
 using executorch::runtime::Result;
+using executorch::runtime::Span;
 using executorch::aten::SizesType;
 using executorch::aten::Tensor;
 using executorch::runtime::kTensorDimensionLimit;
@@ -269,6 +272,16 @@ bool CoreMLBackendDelegate::is_available() const {
 void CoreMLBackendDelegate::destroy(DelegateHandle* handle) const {
     ET_LOG(Debug, "%s: destroy called.", ETCoreMLStrings.delegateIdentifier.UTF8String);
     impl_->destroy(handle);
+}
+
+Error set_option(BackendOptionContext& context, const Span<BackendOption>& backend_options) {
+    ET_LOG(Debug, "%s: set_option called.", ETCoreMLStrings.delegateIdentifier.UTF8String);
+    return Error::Ok;
+}
+
+Error get_option(BackendOptionContext& context, Span<BackendOption>& backend_options) {
+    ET_LOG(Debug, "%s: get_option called.", ETCoreMLStrings.delegateIdentifier.UTF8String);
+    return Error::Ok;
 }
 
 bool CoreMLBackendDelegate::purge_models_cache() const noexcept {

--- a/backends/apple/coreml/runtime/include/coreml_backend/delegate.h
+++ b/backends/apple/coreml/runtime/include/coreml_backend/delegate.h
@@ -10,6 +10,9 @@
 #include <executorch/runtime/backend/interface.h>
 #include <executorch/runtime/core/error.h>
 #include <executorch/runtime/core/evalue.h>
+#include <executorch/runtime/backend/backend_init_context.h>
+#include <executorch/runtime/backend/backend_option_context.h>
+#include <executorch/runtime/backend/options.h>
 
 #include <memory>
 
@@ -52,6 +55,16 @@ public:
 
     /// Returns `true` if the delegate is available otherwise `false`.
     bool is_available() const override;
+
+    executorch::runtime::Error set_option(
+      executorch::runtime::BackendOptionContext& context,
+      const executorch::runtime::Span<executorch::runtime::BackendOption>& backend_options) override;
+
+
+    executorch::runtime::Error get_option(
+    executorch::runtime::BackendOptionContext& context,
+    executorch::runtime::Span<executorch::runtime::BackendOption>& backend_options) override;
+
 
     /// Unloads the loaded CoreML model with the  specified handle.
     ///


### PR DESCRIPTION
Building ET on this PR:

```
cmake -DPYTHON_EXECUTABLE=python \
    -DCMAKE_INSTALL_PREFIX=cmake-out \
    -DEXECUTORCH_ENABLE_LOGGING=1 \
    -DCMAKE_BUILD_TYPE=Debug \
    -DEXECUTORCH_BUILD_EXTENSION_DATA_LOADER=ON \
    -DEXECUTORCH_BUILD_EXTENSION_MODULE=ON \
    -DEXECUTORCH_BUILD_EXTENSION_TENSOR=ON \
    -DEXECUTORCH_BUILD_EXTENSION_FLAT_TENSOR=ON \
    -DEXECUTORCH_BUILD_XNNPACK=OFF \
    -DEXECUTORCH_BUILD_COREML=ON \
    -DEXECUTORCH_BUILD_KERNELS_QUANTIZED=ON \
    -DEXECUTORCH_BUILD_KERNELS_OPTIMIZED=ON \
    -DEXECUTORCH_BUILD_KERNELS_CUSTOM=ON \
    -Bcmake-out .
```

results in an override error:

```
In file included from /Users/scroy/repos/executorch/backends/apple/coreml/runtime/delegate/coreml_backend_delegate.mm:8:
/Users/scroy/repos/executorch/backends/apple/coreml/runtime/include/coreml_backend/delegate.h:61:93: error: only virtual member functions can be marked 'override'
   61 |       const executorch::runtime::Span<executorch::runtime::BackendOption>& backend_options) override;
      |                                                                                             ^~~~~~~~
/Users/scroy/repos/executorch/backends/apple/coreml/runtime/include/coreml_backend/delegate.h:66:85: error: only virtual member functions can be marked 'override'
   66 |     executorch::runtime::Span<executorch::runtime::BackendOption>& backend_options) override;
      |                                                                                     ^~~~~~~~
2 errors generated.
make[2]: *** [backends/apple/coreml/CMakeFiles/coremldelegate.dir/runtime/delegate/coreml_backend_delegate.mm.o] Error 1
make[1]: *** [backends/apple/coreml/CMakeFiles/coremldelegate.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
[ 62%] Built target optimized_portable_kernels
[ 93%] Built target portable_kernels
make: *** [all] Error 2
```
