### PR TITLE
NXP backend: Fix unittest-nxp-neutron introduced in 0012ffaf9

### DIFF
--- a/backends/nxp/tests/ir/converter/node_converter/test_max_pool_2d_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_max_pool_2d_converter.py
@@ -61,7 +61,8 @@ def test_max_pool_2d_conversion(input_shape, padding):
     # Otherwise, we get violation that this op is not part of ATen Core ops.
     edge_program._verifiers = [
         EXIREdgeDialectVerifier(
-            class_only=True, exception_list=[torch.ops.aten.max_pool2d.default]
+            class_only=True,
+            core_aten_ops_exception_list=[torch.ops.aten.max_pool2d.default],
         )
     ]
 

--- a/backends/nxp/tests/test_node_format_inference.py
+++ b/backends/nxp/tests/test_node_format_inference.py
@@ -71,7 +71,8 @@ def test_maxpool2d():
     # Otherwise, we get violation that this op is not part of ATen Core ops.
     edge_program._verifiers = [
         EXIREdgeDialectVerifier(
-            class_only=True, exception_list=[torch.ops.aten.max_pool2d.default]
+            class_only=True,
+            core_aten_ops_exception_list=[torch.ops.aten.max_pool2d.default],
         )
     ]
 


### PR DESCRIPTION
### Summary

### Test plan
```
pytest -c /dev/null backends/nxp/tests/
```

cc @digantdesai @JakeStevens