### PR TITLE
Upgrade lm_eval to fix pull / test-eval_llama-mmlu-linux / linux-job

### DIFF
--- a/examples/models/llama/install_requirements.sh
+++ b/examples/models/llama/install_requirements.sh
@@ -10,7 +10,7 @@
 # Install tokenizers for hf .json tokenizer.
 # Install snakeviz for cProfile flamegraph
 # Install lm-eval for Model Evaluation with lm-evalution-harness.
-pip install hydra-core huggingface_hub tiktoken torchtune sentencepiece tokenizers snakeviz lm_eval==0.4.5 blobfile
+pip install hydra-core huggingface_hub tiktoken torchtune sentencepiece tokenizers snakeviz lm_eval==0.4.9 blobfile
 
 # Call the install helper for further setup
 python examples/models/llama/install_requirement_helper.py


### PR DESCRIPTION
Summary:
As title; try upgrading the `lm_eval` version to fix the pull / test-eval_llama-mmlu-linux / linux-job which is currently broken on main.

The failure appears to original from within the `lm_eval` module, where it's trying to get a dataset from huggingface which no longer exists.