### PR TITLE
Move verification to after to_backend

### DIFF
--- a/exir/verification/verifier.py
+++ b/exir/verification/verifier.py
@@ -145,7 +145,7 @@ def EXIRATenDialectVerifier(  # noqa: C901
                     # which may affect memory planning.
                     if op.is_view:
                         raise RuntimeError(
-                            f"Cannot preserve operator {op} because it is a view or mutation."
+                            f"Cannot preserve operator {op} because it is a view."
                         )
                     if op._schema.is_mutable:
                         logging.warning(


### PR DESCRIPTION
Summary:
Some operators require preservation because they are intended to be consumed by a backend. These operators can contain view and mutation, as they won't be part of the graph after to_backend.

If there are still view and mutation ops after to_backend, verification should throw an error.

Differential Revision: D78535519


