### PR TITLE
Log info instead of error

### DIFF
--- a/runtime/executor/program.cpp
+++ b/runtime/executor/program.cpp
@@ -227,7 +227,7 @@ Result<executorch_flatbuffer::ExecutionPlan*> get_execution_plan(
     // For support, contact the PyTorch Edge team or make an issue in:
     // https://github.com/pytorch/executorch/issues.
     ET_LOG(
-        Error,
+        Info,
         "!!DEPRECATED!! This branch is deprecated from ExecuTorch 0.7; re-export this PTE file to ensure support on newer runtimes.");
     return Program(
         loader,


### PR DESCRIPTION
Fix failing jobs caused by error logging from https://github.com/pytorch/executorch/pull/12295

Test failures: https://hud.pytorch.org/pr/pytorch/executorch/12631#46239138027

Note: logging errors doesn't cause an abort in the et runtime; seems like the arm test is being extra careful and parsing the log script for errors, which is causing this failure.

https://github.com/pytorch/executorch/blob/aab802135cb9b41927893fb5870f0dc43e5719f8/backends/arm/scripts/run_fvp.sh#L111-L117