### PR TITLE
Add test when there are no segments

### DIFF
--- a/runtime/executor/program.cpp
+++ b/runtime/executor/program.cpp
@@ -172,7 +172,18 @@ Result<executorch_flatbuffer::ExecutionPlan*> get_execution_plan(
   // only offset, the constant segment is empty and does not need to be loaded.
   const auto* constant_segment = flatbuffer_program->constant_segment();
   if (constant_segment != nullptr && constant_segment->offsets() != nullptr &&
-      constant_segment->offsets()->size() > 1) {
+      constant_segment->offsets()->size() > 0) {
+    if (constant_segment->offsets()->size() == 1) {
+      // No constants; the constant segment is empty and does not
+      // need to be loaded.
+      return Program(
+          loader,
+          segment_base_offset,
+          std::move(program_data.get()),
+          flatbuffer_program,
+          /*constant_segment_data=*/FreeableBuffer{},
+          std::move(pte_data_map));
+    }
     // The constant data is inside a separate segment.
     const auto* constant_buffer = flatbuffer_program->constant_buffer();
     ET_CHECK_OR_RETURN_ERROR(


### PR DESCRIPTION
Summary:
The deprecation warning should only appear when there are values inside the constant_buffer and nothing inside the constant_segment.

Even when there are no constants in the program, we expect to have one 'segment' storing the placeholder for non-constants.

Fix failing jobs caused by error logging from #12295
Test failures: https://hud.pytorch.org/pr/pytorch/executorch/12631#46239138027

Arm test is using a recently-generated PTE, however hitting the deprecation warning because the pte has no constants.

Differential Revision: D78568839


