### PR TITLE
Arm backend: Add aten.select to "view" operator support check

### DIFF
--- a/backends/arm/operator_support/ethos_u55_support.py
+++ b/backends/arm/operator_support/ethos_u55_support.py
@@ -6,15 +6,16 @@
 # pyre-unsafe
 
 import typing
+from typing import cast
 
 import torch
 import torch.fx as fx
+
 from executorch.backends.arm._passes.arm_pass_utils import get_first_fake_tensor
 from executorch.backends.arm._passes.insert_table_ops import TableOps
 from executorch.backends.arm.operators.op_permute import transform_permutation_vector
 from executorch.backends.arm.tosa_utils import tosa_shape
 from executorch.exir.backend.utils import WhyNoPartitionReporter
-
 from executorch.exir.dialects._ops import ops as exir_ops
 from torch.fx.passes.operator_support import OperatorSupportBase
 
@@ -212,19 +213,51 @@ class EthosU55ViewCheck(OperatorSupportBase):
         Returns:
             False if the operator is not support and True if it is supported.
         """
-        if not node.target == exir_ops.edge.aten.view_copy.default:
+        # Select decomposes into squeeze, which in turn becomes a view. Therefore,
+        # perform the same check on select operators as view operators.
+        if node.target not in (
+            exir_ops.edge.aten.view_copy.default,
+            exir_ops.edge.aten.select.int,
+            exir_ops.edge.aten.select_copy.int,
+        ):
             return True
 
-        shape = list(get_first_fake_tensor(node).shape)
+        if node.target in (
+            exir_ops.edge.aten.select.int,
+            exir_ops.edge.aten.select_copy.int,
+        ):
+            input_node, dim, index = cast(tuple[fx.Node, int, int], node.args)
+
+            shape = input_node.meta["val"].shape
+            rank = len(shape)
+            if not -rank <= dim < rank:
+                raise IndexError(
+                    f"Dim {dim} is outside of the range for tensor '{node.target}' of "
+                    f"rank {rank}"
+                )
+            dim = dim % rank
+
+            size = shape[dim]
+            if not -size <= index < size:
+                raise IndexError(
+                    f"Index {index} is outside of the range for dim {dim} with size "
+                    f"{size} for tensor {node.target}"
+                )
+            index = index % size
+
+            # Shape after squeeze. This may get converted into a view which may become
+            # a transpose. This is why we're checking select.
+            squeezed_shape = shape[:dim] + shape[dim + 1 :]
+            shape = squeezed_shape
+        else:
+            shape = list(get_first_fake_tensor(node).shape)
+
         dtype = _try_determine_dtype(node)
-        permutation = list(typing.cast(list[int], node.args[1]))
 
         rank = len(shape)
         if rank > 4:
             if dtype == torch.int32:
-                self.reporter.report_reject(
-                    node, f"No support for {permutation=} in int32."
-                )
+                self.reporter.report_reject(node, "No support for rank > 4 in int32.")
                 return False
 
         if dtype in (torch.int8, torch.int16):


### PR DESCRIPTION
Select decomposes into squeeze, which in turn becomes a view. Therefore, perform the same check on select operators as view operators.


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218