### PR TITLE
Make sure allocate() doesn't overflow

### DIFF
--- a/runtime/core/memory_allocator.h
+++ b/runtime/core/memory_allocator.h
@@ -84,7 +84,7 @@ class MemoryAllocator {
 
     // If the end of this allocation exceeds the end of this allocator, print
     // error messages and return nullptr
-    if (end > end_) {
+    if (end > end_ || end < start) {
       ET_LOG(
           Error,
           "Memory allocation failed: %zuB requested (adjusted for alignment), %zuB available",


### PR DESCRIPTION
Summary:
Making sure:
* `allocate()` have necessary overflow checks before doing size addition.
* `alignPointer()` doesn't overflow when adding 1 to address.

Differential Revision: D78675995


