### PR TITLE
Fix lookahead decoding cache buffer size

### DIFF
--- a/examples/models/llama/runner/static_attention_io_manager.h
+++ b/examples/models/llama/runner/static_attention_io_manager.h
@@ -396,7 +396,7 @@ template <typename TokenT>
 class SuffixCache {
  public:
   SuffixCache(size_t n, size_t capacity)
-      : n_(n), capacity_(capacity), pos_(0), cache_(n_ * capacity_) {}
+      : n_(n), capacity_(capacity), pos_(0), cache_((n_ - 1) * capacity_) {}
 
   void add(executorch::runtime::Span<TokenT> suffix) {
     if (suffix.size() != n_ - 1) {


### PR DESCRIPTION
Summary: For n-grams we are only storing the suffixes of size n-1. Over sizing the buffer here leads to subsequent memcpy copying too much.

Differential Revision: D78759433


