### PR TITLE
Use Q_ANNOTATION_KEY

### DIFF
--- a/backends/arm/quantizer/arm_quantizer_utils.py
+++ b/backends/arm/quantizer/arm_quantizer_utils.py
@@ -18,22 +18,21 @@ from torch._subclasses import FakeTensor
 from torch.fx import GraphModule, Node
 
 from torchao.quantization.pt2e.quantizer import QuantizationAnnotation
+from torchao.quantization.pt2e.quantizer.quantizer import Q_ANNOTATION_KEY
 
 
 def is_annotated(node: Node) -> bool:
     """Given a node return whether the node is annotated."""
     return (
-        "quantization_annotation" in node.meta
-        and cast(
-            QuantizationAnnotation, node.meta["quantization_annotation"]
-        )._annotated
+        Q_ANNOTATION_KEY in node.meta
+        and cast(QuantizationAnnotation, node.meta[Q_ANNOTATION_KEY])._annotated
     )
 
 
 def is_output_annotated(node: Node) -> bool:
     """Given a node, return whether the output of the node is annotated."""
-    if "quantization_annotation" in node.meta:
-        annotation = cast(QuantizationAnnotation, node.meta["quantization_annotation"])
+    if Q_ANNOTATION_KEY in node.meta:
+        annotation = cast(QuantizationAnnotation, node.meta[Q_ANNOTATION_KEY])
         return annotation._annotated and annotation.output_qspec is not None
     else:
         return False
@@ -43,9 +42,9 @@ def mark_node_as_annotated(node: Node) -> None:
     """Marks node as annotated. If needed, an empty  QuantizationAnnotation is added
     to the quantization_annotation node meta entry.
     """
-    if "quantization_annotation" not in node.meta:
-        node.meta["quantization_annotation"] = QuantizationAnnotation()
-    node.meta["quantization_annotation"]._annotated = True
+    if Q_ANNOTATION_KEY not in node.meta:
+        node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation()
+    node.meta[Q_ANNOTATION_KEY]._annotated = True
 
 
 def is_ok_for_quantization(node: Node, gm: GraphModule):

--- a/backends/cadence/aot/quantizer/quantizer.py
+++ b/backends/cadence/aot/quantizer/quantizer.py
@@ -42,6 +42,7 @@ from torchao.quantization.pt2e.quantizer import (
     QuantizationSpec,
     Quantizer,
 )
+from torchao.quantization.pt2e.quantizer.quantizer import Q_ANNOTATION_KEY
 
 
 act_qspec_asym8s = QuantizationSpec(
@@ -127,7 +128,7 @@ class CadenceAtenQuantizer(Quantizer):
 
             for output, *custom_spec in anchors.output:
                 # pyre-ignore[16]: no attribute
-                output.meta["quantization_annotation"] = QuantizationAnnotation(
+                output.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
                     # pyre-ignore[6]: incompatible parameter type
                     output_qspec=(custom_spec[0] if custom_spec else output_act_qspec),
                     _annotated=True,
@@ -143,7 +144,7 @@ class CadenceAtenQuantizer(Quantizer):
                 for node, idx, *custom_spec in inputs:
                     # pyre-ignore[16]: no attribute
                     annotation = node.meta.get(
-                        "quantization_annotation",
+                        Q_ANNOTATION_KEY,
                         QuantizationAnnotation(_annotated=True),
                     )
                     arg = (
@@ -157,7 +158,7 @@ class CadenceAtenQuantizer(Quantizer):
                         custom_spec[0] if custom_spec else spec
                     )
                     # pyre-ignore[16]: no attribute
-                    node.meta["quantization_annotation"] = annotation
+                    node.meta[Q_ANNOTATION_KEY] = annotation
 
             def annotate_weights_or_biases(
                 weights_or_biases: List[Tuple[fx.Node, int]],
@@ -165,13 +166,13 @@ class CadenceAtenQuantizer(Quantizer):
             ) -> None:
                 for node, idx, *custom_spec in weights_or_biases:
                     annotation = node.meta.get(
-                        "quantization_annotation",
+                        Q_ANNOTATION_KEY,
                         QuantizationAnnotation(_annotated=True),
                     )
                     annotation.input_qspec_map[node.args[idx]] = (
                         custom_spec[0] if custom_spec else spec
                     )
-                    node.meta["quantization_annotation"] = annotation
+                    node.meta[Q_ANNOTATION_KEY] = annotation
 
             # pyre-ignore[6]: incompatible parameter type
             annotate_inputs(anchors.inputs, input_act_qspec)

--- a/backends/cadence/aot/quantizer/utils.py
+++ b/backends/cadence/aot/quantizer/utils.py
@@ -21,6 +21,7 @@ from torch.fx.passes.utils.source_matcher_utils import (
     SourcePartition,
 )
 from torchao.quantization.pt2e import ObserverOrFakeQuantize
+from torchao.quantization.pt2e.quantizer.quantizer import Q_ANNOTATION_KEY
 
 
 def quantize_tensor_multiplier(
@@ -88,8 +89,7 @@ def is_annotated(nodes: List[fx.Node]) -> bool:
     annotated = False
     for node in nodes:
         annotated = annotated or (
-            "quantization_annotation" in node.meta
-            and node.meta["quantization_annotation"]._annotated
+            Q_ANNOTATION_KEY in node.meta and node.meta[Q_ANNOTATION_KEY]._annotated
         )
     return annotated
 

--- a/backends/cortex_m/test/test_replace_quant_nodes.py
+++ b/backends/cortex_m/test/test_replace_quant_nodes.py
@@ -25,6 +25,7 @@ from torchao.quantization.pt2e.quantizer import (
     QuantizationSpec,
     Quantizer,
 )
+from torchao.quantization.pt2e.quantizer.quantizer import Q_ANNOTATION_KEY
 
 
 @dataclass(eq=True, frozen=True)
@@ -67,10 +68,7 @@ class AddQuantizer(Quantizer):
             ]:
                 continue
 
-            if (
-                "quantization_annotation" in node.meta
-                and node.meta["quantization_annotation"]._annotated
-            ):
+            if Q_ANNOTATION_KEY in node.meta and node.meta[Q_ANNOTATION_KEY]._annotated:
                 continue
 
             input_qspec_map = {
@@ -78,7 +76,7 @@ class AddQuantizer(Quantizer):
                 node.args[1]: config.input_activation,
             }
 
-            node.meta["quantization_annotation"] = QuantizationAnnotation(
+            node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
                 input_qspec_map=input_qspec_map,
                 output_qspec=config.output_activation,
                 _annotated=True,

--- a/backends/example/example_operators/utils.py
+++ b/backends/example/example_operators/utils.py
@@ -5,11 +5,12 @@
 # LICENSE file in the root directory of this source tree.
 
 from torchao.quantization.pt2e.quantizer import QuantizationAnnotation
+from torchao.quantization.pt2e.quantizer.quantizer import Q_ANNOTATION_KEY
 
 
 def _nodes_are_annotated(node_list):
     for node in node_list:
-        quantization_annotation = node.meta.get("quantization_annotation", None)
+        quantization_annotation = node.meta.get(Q_ANNOTATION_KEY, None)
         if not quantization_annotation:
             return False
         if quantization_annotation._annotated:
@@ -23,11 +24,11 @@ def _annotate_nodes(node_tuples, quant_spec, input_node=False):
     for node_tuple in node_tuples:
         node = node_tuple[0]
         quant_annotation = node.meta.get(
-            "quantization_annotation", QuantizationAnnotation(_annotated=True)
+            Q_ANNOTATION_KEY, QuantizationAnnotation(_annotated=True)
         )
         if input_node:
             input_node = node_tuple[1]
             quant_annotation.input_qspec_map[input_node] = quant_spec
         else:
             quant_annotation.output_qspec = quant_spec
-        node.meta["quantization_annotation"] = quant_annotation
+        node.meta[Q_ANNOTATION_KEY] = quant_annotation

--- a/backends/mediatek/quantizer/annotator.py
+++ b/backends/mediatek/quantizer/annotator.py
@@ -21,6 +21,7 @@ from torchao.quantization.pt2e.quantizer import (
     annotate_output_qspec as _annotate_output_qspec,
     QuantizationAnnotation,
 )
+from torchao.quantization.pt2e.quantizer.quantizer import Q_ANNOTATION_KEY
 
 from .qconfig import QuantizationConfig
 
@@ -57,12 +58,12 @@ def _is_annotated(node: Node):
     return True if any of the node
     is annotated, otherwise return False
     """
-    KEY = "quantization_annotation"
+    KEY = Q_ANNOTATION_KEY
     return KEY in node.meta and node.meta[KEY]._annotated
 
 
 def _mark_as_annotated(nodes: List[Node]):
-    KEY = "quantization_annotation"
+    KEY = Q_ANNOTATION_KEY
     for node in nodes:
         if KEY not in node.meta:
             node.meta[KEY] = QuantizationAnnotation()

--- a/backends/nxp/quantizer/neutron_quantizer.py
+++ b/backends/nxp/quantizer/neutron_quantizer.py
@@ -51,6 +51,7 @@ from torchao.quantization.pt2e.quantizer import (
     QuantizationSpec,
     Quantizer,
 )
+from torchao.quantization.pt2e.quantizer.quantizer import Q_ANNOTATION_KEY
 
 
 class NeutronAtenQuantizer(Quantizer):
@@ -92,7 +93,7 @@ class NeutronAtenQuantizer(Quantizer):
 
             for output, *custom_spec in anchors.output:
                 # pyre-ignore[16]: no attribute
-                output.meta["quantization_annotation"] = QuantizationAnnotation(
+                output.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
                     # pyre-ignore[6]: incompatible parameter type
                     output_qspec=(custom_spec[0] if custom_spec else output_act_qspec),
                     _annotated=True,
@@ -108,7 +109,7 @@ class NeutronAtenQuantizer(Quantizer):
                 for node, idx, *custom_spec in inputs:
                     # pyre-ignore[16]: no attribute
                     annotation = node.meta.get(
-                        "quantization_annotation",
+                        Q_ANNOTATION_KEY,
                         QuantizationAnnotation(_annotated=True),
                     )
                     arg = (
@@ -122,7 +123,7 @@ class NeutronAtenQuantizer(Quantizer):
                         custom_spec[0] if custom_spec else spec
                     )
                     # pyre-ignore[16]: no attribute
-                    node.meta["quantization_annotation"] = annotation
+                    node.meta[Q_ANNOTATION_KEY] = annotation
 
             def annotate_weights_or_biases(
                 weights_or_biases: List[Tuple[fx.Node, int]],
@@ -130,13 +131,13 @@ class NeutronAtenQuantizer(Quantizer):
             ) -> None:
                 for node, idx, *custom_spec in weights_or_biases:
                     annotation = node.meta.get(
-                        "quantization_annotation",
+                        Q_ANNOTATION_KEY,
                         QuantizationAnnotation(_annotated=True),
                     )
                     annotation.input_qspec_map[node.args[idx]] = (
                         custom_spec[0] if custom_spec else spec
                     )
-                    node.meta["quantization_annotation"] = annotation
+                    node.meta[Q_ANNOTATION_KEY] = annotation
 
             # pyre-ignore[6]: incompatible parameter type
             annotate_inputs(anchors.inputs, input_act_qspec)

--- a/backends/nxp/quantizer/patterns.py
+++ b/backends/nxp/quantizer/patterns.py
@@ -19,6 +19,7 @@ from torchao.quantization.pt2e.quantizer import (
     FixedQParamsQuantizationSpec,
     SharedQuantizationSpec,
 )
+from torchao.quantization.pt2e.quantizer.quantizer import Q_ANNOTATION_KEY
 
 
 @dataclass
@@ -90,7 +91,7 @@ class SharedSpecPattern(QuantizationPattern):
         prev_node = fused_partition[0].input_nodes[0]
 
         # Previous node was not quantized => we are not able to share q-params
-        if "quantization_annotation" not in prev_node.meta:
+        if Q_ANNOTATION_KEY not in prev_node.meta:
             return None
 
         qspec = SharedQuantizationSpec(prev_node)

--- a/backends/nxp/quantizer/utils.py
+++ b/backends/nxp/quantizer/utils.py
@@ -19,14 +19,14 @@ from torch.fx.passes.utils.source_matcher_utils import (
     SourcePartition,
 )
 from torchao.quantization.pt2e import ObserverOrFakeQuantize
+from torchao.quantization.pt2e.quantizer.quantizer import Q_ANNOTATION_KEY
 
 
 def is_annotated(nodes: List[fx.Node]) -> bool:
     annotated = False
     for node in nodes:
         annotated = annotated or (
-            "quantization_annotation" in node.meta
-            and node.meta["quantization_annotation"]._annotated
+            Q_ANNOTATION_KEY in node.meta and node.meta[Q_ANNOTATION_KEY]._annotated
         )
     return annotated
 

--- a/backends/openvino/quantizer/quantizer.py
+++ b/backends/openvino/quantizer/quantizer.py
@@ -30,8 +30,7 @@ from torchao.quantization.pt2e.quantizer import (
     Quantizer,
     SharedQuantizationSpec,
 )
-
-QUANT_ANNOTATION_KEY = "quantization_annotation"
+from torchao.quantization.pt2e.quantizer.quantizer import Q_ANNOTATION_KEY
 
 
 class QuantizationMode(Enum):
@@ -174,8 +173,8 @@ class OpenVINOQuantizer(Quantizer):
                 self._fill_torch_ao_annotation(edge_or_node, qspec, annotation)
 
         for node, annotation in node_vs_torch_annotation.items():
-            assert QUANT_ANNOTATION_KEY not in node.meta
-            node.meta[QUANT_ANNOTATION_KEY] = annotation
+            assert Q_ANNOTATION_KEY not in node.meta
+            node.meta[Q_ANNOTATION_KEY] = annotation
         return model
 
     @staticmethod

--- a/backends/qualcomm/quantizer/annotators.py
+++ b/backends/qualcomm/quantizer/annotators.py
@@ -23,6 +23,7 @@ from torchao.quantization.pt2e.quantizer import (
     QuantizationSpec,
     SharedQuantizationSpec,
 )
+from torchao.quantization.pt2e.quantizer.quantizer import Q_ANNOTATION_KEY
 
 from .qconfig import (
     get_16a16w_qnn_ptq_config,
@@ -32,7 +33,6 @@ from .qconfig import (
 )
 
 
-QUANT_ANNOTATION_KEY = "quantization_annotation"
 OP_ANNOTATOR: Dict[OpOverload, Callable] = {}
 
 
@@ -53,8 +53,7 @@ def _is_annotated(nodes: List[Node]):
     annotated = False
     for node in nodes:
         annotated = annotated or (
-            QUANT_ANNOTATION_KEY in node.meta
-            and node.meta[QUANT_ANNOTATION_KEY]._annotated
+            Q_ANNOTATION_KEY in node.meta and node.meta[Q_ANNOTATION_KEY]._annotated
         )
     return annotated
 
@@ -74,9 +73,9 @@ def _is_float_tensor(node: Node):
 
 def _mark_nodes_as_annotated(nodes: List[Node]):
     for node in nodes:
-        if QUANT_ANNOTATION_KEY not in node.meta:
-            node.meta[QUANT_ANNOTATION_KEY] = QuantizationAnnotation()
-        node.meta[QUANT_ANNOTATION_KEY]._annotated = True
+        if Q_ANNOTATION_KEY not in node.meta:
+            node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation()
+        node.meta[Q_ANNOTATION_KEY]._annotated = True
 
 
 def annotate_in_out_obs_sharing_op(
@@ -91,15 +90,15 @@ def annotate_in_out_obs_sharing_op(
     # only annotate input output sharing operator
     # when the output of the input node is annotated
     if (
-        QUANT_ANNOTATION_KEY not in input_act.meta
-        or not input_act.meta[QUANT_ANNOTATION_KEY]._annotated
-        or input_act.meta[QUANT_ANNOTATION_KEY].output_qspec is None
+        Q_ANNOTATION_KEY not in input_act.meta
+        or not input_act.meta[Q_ANNOTATION_KEY]._annotated
+        or input_act.meta[Q_ANNOTATION_KEY].output_qspec is None
         or not _is_float_tensor(input_act)
     ):
         return
 
     act_qspec = SharedQuantizationSpec(input_act)
-    node.meta[QUANT_ANNOTATION_KEY] = QuantizationAnnotation(
+    node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
         input_qspec_map={
             input_act: act_qspec,
         },
@@ -121,7 +120,7 @@ def annotate_single_in_share_out(
         input_qspec_map[input_act] = quantization_config.input_activation
 
     if _is_float_tensor(node):
-        node.meta[QUANT_ANNOTATION_KEY] = QuantizationAnnotation(
+        node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
             input_qspec_map=input_qspec_map,
             output_qspec=SharedQuantizationSpec((input_act, node)),
             _annotated=True,
@@ -137,7 +136,7 @@ def annotate_single_in(node: Node, quantization_config: QuantizationConfig) -> N
     assert isinstance(input_act, Node)
     input_qspec_map[input_act] = quantization_config.input_activation
 
-    node.meta[QUANT_ANNOTATION_KEY] = QuantizationAnnotation(
+    node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
         input_qspec_map=input_qspec_map,
         _annotated=True,
     )
@@ -156,7 +155,7 @@ def annotate_single_in_single_out(
         input_qspec_map[input_act] = quantization_config.input_activation
 
     if _is_float_tensor(node):
-        node.meta[QUANT_ANNOTATION_KEY] = QuantizationAnnotation(
+        node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
             input_qspec_map=input_qspec_map,
             output_qspec=quantization_config.output_activation,
             _annotated=True,
@@ -194,7 +193,7 @@ def annotate_binary(node: Node, quantization_config: QuantizationConfig) -> None
     if _is_float_tensor(input_act1):
         input_qspec_map[input_act1] = input_act_qspec
 
-    node.meta[QUANT_ANNOTATION_KEY] = QuantizationAnnotation(
+    node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
         input_qspec_map=input_qspec_map,
         output_qspec=output_act_qspec,
         _annotated=True,
@@ -269,7 +268,7 @@ def annotate_masked_fill(node: Node, quantization_config: QuantizationConfig) ->
         if _is_float_tensor(input_node):
             input_qspec_map[input_node] = quantization_config.input_activation
 
-    node.meta[QUANT_ANNOTATION_KEY] = QuantizationAnnotation(
+    node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
         input_qspec_map=input_qspec_map,
         output_qspec=(
             quantization_config.output_activation if _is_float_tensor(node) else None
@@ -361,7 +360,7 @@ def annotate_div(node: Node, quantization_config: QuantizationConfig) -> None:
         if _is_float_tensor(input_act0):
             input_qspec_map[input_act0] = input_act_qspec
 
-        node.meta[QUANT_ANNOTATION_KEY] = QuantizationAnnotation(
+        node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
             input_qspec_map=input_qspec_map,
             output_qspec=output_act_qspec,
             _annotated=True,
@@ -399,7 +398,7 @@ def annotate_arange(node: Node, quantization_config: QuantizationConfig) -> None
     if _is_float_tensor(node):
         # workaround for node with kwargs could not be correctly annotated
         node.kwargs = {}
-        node.meta[QUANT_ANNOTATION_KEY] = QuantizationAnnotation(
+        node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
             input_qspec_map={},
             output_qspec=quantization_config.output_activation,
             _annotated=True,
@@ -464,7 +463,7 @@ def annotate_scalar_tensor(node: Node, quantization_config: QuantizationConfig) 
     if _is_float_tensor(node):
         # workaround for node with kwargs could not be correctly annotated
         node.kwargs = {}
-        node.meta[QUANT_ANNOTATION_KEY] = QuantizationAnnotation(
+        node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
             input_qspec_map={},
             output_qspec=quantization_config.output_activation,
             _annotated=True,
@@ -484,7 +483,7 @@ def annotate_full(node: Node, quantization_config: QuantizationConfig) -> None:
     if _is_float_tensor(node):
         # workaround for node with kwargs could not be correctly annotated
         node.kwargs = {}
-        node.meta[QUANT_ANNOTATION_KEY] = QuantizationAnnotation(
+        node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
             input_qspec_map={},
             output_qspec=quantization_config.output_activation,
             _annotated=True,
@@ -779,7 +778,7 @@ def annotate_sigmoid(node: Node, quantization_config: QuantizationConfig) -> Non
     )
 
     if _is_float_tensor(node):
-        node.meta[QUANT_ANNOTATION_KEY] = QuantizationAnnotation(
+        node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
             input_qspec_map=input_qspec_map,
             output_qspec=out_act_quantization_spec,
             _annotated=True,
@@ -840,7 +839,7 @@ def annotate_embedding(node: Node, quantization_config: QuantizationConfig) -> N
     input_qspec_map = {}
     input_qspec_map[weight] = quantization_config.input_activation
 
-    node.meta[QUANT_ANNOTATION_KEY] = QuantizationAnnotation(
+    node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
         input_qspec_map=input_qspec_map,
         output_qspec=SharedQuantizationSpec((weight, node)),
         _annotated=True,
@@ -864,7 +863,7 @@ def annotate_index_put(node: Node, quantization_config: QuantizationConfig) -> N
     input_qspec_map = {}
     input_qspec_map[value] = quantization_config.input_activation
 
-    node.meta[QUANT_ANNOTATION_KEY] = QuantizationAnnotation(
+    node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
         input_qspec_map=input_qspec_map,
         output_qspec=SharedQuantizationSpec((value, node)),
         _annotated=True,
@@ -881,7 +880,7 @@ def annotate_index_copy(node: Node, quantization_config: QuantizationConfig) -> 
     input_qspec_map = {}
     input_qspec_map[value] = quantization_config.input_activation
 
-    node.meta[QUANT_ANNOTATION_KEY] = QuantizationAnnotation(
+    node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
         input_qspec_map=input_qspec_map,
         output_qspec=SharedQuantizationSpec((value, node)),
         _annotated=True,
@@ -961,7 +960,7 @@ def annotate_stack(node: Node, quantization_config: QuantizationConfig) -> None:
             assert isinstance(input_node, Node)
             input_qspec_map[input_node] = share_qparams_with_input_act0_qspec
 
-    node.meta[QUANT_ANNOTATION_KEY] = QuantizationAnnotation(
+    node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
         input_qspec_map=input_qspec_map,
         output_qspec=share_qparams_with_input_act0_qspec,
         _annotated=True,
@@ -990,7 +989,7 @@ def annotate_matmul(node: Node, quantization_config: QuantizationConfig) -> None
         else:
             input_qspec_map[input_act1] = input_act_qspec
 
-    node.meta[QUANT_ANNOTATION_KEY] = QuantizationAnnotation(
+    node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
         input_qspec_map=input_qspec_map,
         output_qspec=output_act_qspec,
         _annotated=True,
@@ -1019,7 +1018,7 @@ def annotate_bmm(node: Node, quantization_config: QuantizationConfig) -> None:
         else:
             input_qspec_map[input_act1] = input_act_qspec
 
-    node.meta[QUANT_ANNOTATION_KEY] = QuantizationAnnotation(
+    node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
         input_qspec_map=input_qspec_map,
         output_qspec=output_act_qspec,
         _annotated=True,
@@ -1071,7 +1070,7 @@ def annotate_conv(node: Node, quantization_config: QuantizationConfig) -> None:
             else:
                 input_qspec_map[bias] = quantization_config.bias
 
-    node.meta[QUANT_ANNOTATION_KEY] = QuantizationAnnotation(
+    node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
         input_qspec_map=input_qspec_map,
         output_qspec=quantization_config.output_activation,
         _annotated=True,
@@ -1232,7 +1231,7 @@ def annotate_cat(node: Node, quantization_config: QuantizationConfig) -> None:
             if _is_float_tensor(input_node):
                 input_qspec_map[input_node] = share_qparams_with_input_act0_qspec
 
-    node.meta[QUANT_ANNOTATION_KEY] = QuantizationAnnotation(
+    node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
         input_qspec_map=input_qspec_map,
         output_qspec=share_qparams_with_input_act0_qspec,
         _annotated=True,
@@ -1250,14 +1249,14 @@ def annotate_unbind(node: Node, quantization_config: QuantizationConfig) -> None
     share_qparams_with_out_node0_qspec = SharedQuantizationSpec((node.args[0], node))
     input_qspec_map[input_act] = quantization_config.input_activation
 
-    node.meta[QUANT_ANNOTATION_KEY] = QuantizationAnnotation(
+    node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
         input_qspec_map=input_qspec_map,
         output_qspec=share_qparams_with_out_node0_qspec,
         _annotated=True,
     )
 
     for user in node.users:
-        user.meta[QUANT_ANNOTATION_KEY] = QuantizationAnnotation(
+        user.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
             output_qspec=share_qparams_with_out_node0_qspec,
             _annotated=True,
         )
@@ -1279,13 +1278,13 @@ def annotate_chunk(node: Node, quantization_config: QuantizationConfig) -> None:
     assert isinstance(input_act, Node)
     input_qspec_map[input_act] = quantization_config.input_activation
 
-    node.meta[QUANT_ANNOTATION_KEY] = QuantizationAnnotation(
+    node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
         input_qspec_map=input_qspec_map,
         _annotated=True,
     )
 
     for user in node.users:
-        user.meta[QUANT_ANNOTATION_KEY] = QuantizationAnnotation(
+        user.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
             output_qspec=quantization_config.output_activation,
             _annotated=True,
         )
@@ -1302,7 +1301,7 @@ def annotate_where(node: Node, quantization_config: QuantizationConfig) -> None:
         if _is_float_tensor(input_node):
             input_qspec_map[input_node] = quantization_config.input_activation
 
-    node.meta[QUANT_ANNOTATION_KEY] = QuantizationAnnotation(
+    node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
         input_qspec_map=input_qspec_map,
         output_qspec=(
             quantization_config.output_activation if _is_float_tensor(node) else None
@@ -1318,7 +1317,7 @@ def annotate_zeros(node: Node, quantization_config: QuantizationConfig) -> None:
 
     # workaround for node with kwargs could not be correctly annotated
     node.kwargs = {}
-    node.meta[QUANT_ANNOTATION_KEY] = QuantizationAnnotation(
+    node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
         input_qspec_map={},
         output_qspec=quantization_config.output_activation,
         _annotated=True,

--- a/backends/qualcomm/quantizer/custom_annotation.py
+++ b/backends/qualcomm/quantizer/custom_annotation.py
@@ -8,7 +8,7 @@ from typing import Sequence
 import torch
 from executorch.backends.qualcomm.quantizer.annotators import (
     _is_float_tensor,
-    QUANT_ANNOTATION_KEY,
+    Q_ANNOTATION_KEY,
 )
 from executorch.backends.qualcomm.quantizer.quantizer import (
     get_16a8w_qnn_ptq_config,
@@ -50,7 +50,7 @@ def annotate_eurobert(gm: torch.fx.GraphModule):
             assert isinstance(to_node, Node)
             input_spec = quantization_config_8a8w.input_activation
             input_qspec_map[to_node] = input_spec
-            to_node.meta[QUANT_ANNOTATION_KEY] = QuantizationAnnotation(
+            to_node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
                 input_qspec_map=input_qspec_map,
                 output_qspec=quantization_config_8a8w.output_activation,
                 _annotated=True,
@@ -81,7 +81,7 @@ def annotate_mimi_decoder(gm: torch.fx.GraphModule):
                 bias = node.args[2]
                 input_qspec_map[bias] = quantization_config_8a8w.bias
 
-            node.meta[QUANT_ANNOTATION_KEY] = QuantizationAnnotation(
+            node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
                 input_qspec_map=input_qspec_map,
                 output_qspec=quantization_config_8a8w.output_activation,
                 _annotated=True,
@@ -99,7 +99,7 @@ def annotate_linear_16a8w_in_affine_layer(gm: torch.fx.GraphModule) -> None:
         weight = node.args[1]
         input_qspec_map[weight] = quantization_config.weight
 
-        node.meta[QUANT_ANNOTATION_KEY] = QuantizationAnnotation(
+        node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
             input_qspec_map=input_qspec_map,
             output_qspec=quantization_config.output_activation,
             _annotated=True,
@@ -146,7 +146,7 @@ def annotate_prefill_kv_output(gm: torch.fx.GraphModule, kv_quant_attrs: dict):
                     if isinstance(input, Node):
                         input_qspec_map[input] = fixed_output_spec
 
-                prefill_output.meta[QUANT_ANNOTATION_KEY] = QuantizationAnnotation(
+                prefill_output.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
                     input_qspec_map=input_qspec_map,
                     output_qspec=fixed_output_spec,
                     _annotated=True,
@@ -174,7 +174,7 @@ def annotate_matmul_16a8w(gm: torch.fx.GraphModule) -> None:  # noqa: C901
         input_spec1 = quantization_config.weight
         input_qspec_map[input_act1] = input_spec1
 
-        node.meta[QUANT_ANNOTATION_KEY] = QuantizationAnnotation(
+        node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
             input_qspec_map=input_qspec_map,
             output_qspec=quantization_config.output_activation,
             _annotated=True,
@@ -194,7 +194,7 @@ def annotate_matmul_16a8w(gm: torch.fx.GraphModule) -> None:  # noqa: C901
             if input_node not in input_qspec_map:
                 input_qspec_map[input_node] = share_qparams_with_input_act0_qspec
 
-        node.meta[QUANT_ANNOTATION_KEY] = QuantizationAnnotation(
+        node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
             input_qspec_map=input_qspec_map,
             output_qspec=share_qparams_with_input_act0_qspec,
             _annotated=True,
@@ -209,7 +209,7 @@ def annotate_matmul_16a8w(gm: torch.fx.GraphModule) -> None:  # noqa: C901
         weight = node.args[1]
         input_qspec_map[weight] = quantization_config.weight
 
-        node.meta[QUANT_ANNOTATION_KEY] = QuantizationAnnotation(
+        node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
             input_qspec_map=input_qspec_map,
             output_qspec=quantization_config.output_activation,
             _annotated=True,
@@ -241,7 +241,7 @@ def annotate_matmul_16a8w(gm: torch.fx.GraphModule) -> None:  # noqa: C901
         input_act = node.args[0]
         input_qspec_map[input_act] = quantization_config.input_activation
 
-        node.meta[QUANT_ANNOTATION_KEY] = QuantizationAnnotation(
+        node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
             input_qspec_map=input_qspec_map,
             output_qspec=quantization_config.output_activation,
             _annotated=True,
@@ -255,7 +255,7 @@ def annotate_matmul_16a8w(gm: torch.fx.GraphModule) -> None:  # noqa: C901
         input_act = node.args[0]
         input_qspec_map[input_act] = quantization_config.input_activation
 
-        node.meta[QUANT_ANNOTATION_KEY] = QuantizationAnnotation(
+        node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
             input_qspec_map=input_qspec_map,
             output_qspec=SharedQuantizationSpec((input_act, node)),
             _annotated=True,
@@ -275,7 +275,7 @@ def annotate_matmul_16a8w(gm: torch.fx.GraphModule) -> None:  # noqa: C901
             if input_node not in input_qspec_map:
                 input_qspec_map[input_node] = share_qparams_with_input_act0_qspec
 
-        node.meta[QUANT_ANNOTATION_KEY] = QuantizationAnnotation(
+        node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
             input_qspec_map=input_qspec_map,
             output_qspec=share_qparams_with_input_act0_qspec,
             _annotated=True,
@@ -348,7 +348,7 @@ def custom_annotate_llama_matmul_16a8w(gm: torch.fx.GraphModule) -> None:  # noq
         input_act1 = node.args[1]
         input_spec1 = quantization_config.weight
         input_qspec_map[input_act1] = input_spec1
-        node.meta[QUANT_ANNOTATION_KEY] = QuantizationAnnotation(
+        node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
             input_qspec_map=input_qspec_map,
             output_qspec=quantization_config.output_activation,
             _annotated=True,
@@ -361,7 +361,7 @@ def custom_annotate_llama_matmul_16a8w(gm: torch.fx.GraphModule) -> None:  # noq
         input_qspec_map = {}
         input_qspec_map[value] = quantization_config.input_activation
 
-        node.meta[QUANT_ANNOTATION_KEY] = QuantizationAnnotation(
+        node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
             input_qspec_map=input_qspec_map,
             output_qspec=SharedQuantizationSpec((value, node)),
             _annotated=True,
@@ -373,7 +373,7 @@ def custom_annotate_llama_matmul_16a8w(gm: torch.fx.GraphModule) -> None:  # noq
         input_qspec_map = {}
         input_act = node.args[0]
         input_qspec_map[input_act] = quantization_config.input_activation
-        node.meta[QUANT_ANNOTATION_KEY] = QuantizationAnnotation(
+        node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
             input_qspec_map=input_qspec_map,
             output_qspec=quantization_config.output_activation,
             _annotated=True,
@@ -394,7 +394,7 @@ def custom_annotate_llama_matmul_16a8w(gm: torch.fx.GraphModule) -> None:  # noq
             if input_node not in input_qspec_map:
                 assert isinstance(input_node, Node)
                 input_qspec_map[input_node] = share_qparams_with_input_act0_qspec
-        node.meta[QUANT_ANNOTATION_KEY] = QuantizationAnnotation(
+        node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
             input_qspec_map=input_qspec_map,
             output_qspec=share_qparams_with_input_act0_qspec,
             _annotated=True,
@@ -447,7 +447,7 @@ def custom_annotate_llama_last_conv_16a8w(gm: torch.fx.GraphModule) -> None:
         weight = node.args[1]
         input_qspec_map[weight] = quantization_config.weight
 
-        node.meta[QUANT_ANNOTATION_KEY] = QuantizationAnnotation(
+        node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
             input_qspec_map=input_qspec_map,
             output_qspec=quantization_config.output_activation,
             _annotated=True,
@@ -480,7 +480,7 @@ def custom_annotate_matmul_16a8w(gm: torch.fx.GraphModule):
         input_act1 = node.args[1]
         input_spec1 = quantization_config.weight
         input_qspec_map[input_act1] = input_spec1
-        node.meta[QUANT_ANNOTATION_KEY] = QuantizationAnnotation(
+        node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
             input_qspec_map=input_qspec_map,
             output_qspec=quantization_config.output_activation,
             _annotated=True,

--- a/backends/transforms/duplicate_dynamic_quant_chain.py
+++ b/backends/transforms/duplicate_dynamic_quant_chain.py
@@ -13,6 +13,7 @@ from torch.fx.node import map_arg
 from torch.fx.passes.infra.pass_base import PassBase, PassResult
 
 from torchao.quantization.pt2e.quantizer import is_valid_annotation
+from torchao.quantization.pt2e.quantizer.quantizer import Q_ANNOTATION_KEY
 from torchao.quantization.pt2e.utils import _filter_sym_size_users
 
 
@@ -126,7 +127,7 @@ def _maybe_duplicate_dynamic_quantize_chain(
     num_dq_users = len(dq_node.users)
     dq_node_users = list(dq_node.users.copy())
     for user in dq_node_users:
-        annotation = user.meta.get("quantization_annotation", None)
+        annotation = user.meta.get(Q_ANNOTATION_KEY, None)
         if not is_valid_annotation(annotation):
             return
         with gm.graph.inserting_after(dq_node):


### PR DESCRIPTION
Summary: https://github.com/pytorch/ao/pull/2525 introduced Q_ANNOTATION_KEY to avoid manually typing "quantization_annotation". Trying to apply it in our codebase

Reviewed By: jerryzh168

Differential Revision: D78193037


