### PR TITLE
CI Tests for Zephyr Integration

### DIFF
--- a/.ci/docker/common/install_zephyr.sh
+++ b/.ci/docker/common/install_zephyr.sh
@@ -81,6 +81,7 @@ install_prerequiresites() {
         ./kitware-archive.sh && \
         rm -f kitware-archive.sh
     pip_install --no-cache-dir west
+    pip_install pyelftools
 }
 
 install_prerequiresites

--- a/.ci/docker/common/install_zephyr.sh
+++ b/.ci/docker/common/install_zephyr.sh
@@ -83,13 +83,4 @@ install_prerequiresites() {
     pip_install --no-cache-dir west
 }
 
-install_sdk() {
-    wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.0/zephyr-sdk-0.16.0_linux-x86_64.tar.xz && \
-         tar -xf zephyr-sdk-0.16.0_linux-x86_64.tar.xz && \
-         rm -f zephyr-sdk-0.16.0_linux-x86_64.tar.xz && \
-         cd zephyr-sdk-0.16.0/ && \
-         ./setup.sh -c -t arm-zephyr-eabi
-}
-
 install_prerequiresites
-install_sdk

--- a/.ci/docker/common/install_zephyr.sh
+++ b/.ci/docker/common/install_zephyr.sh
@@ -88,5 +88,16 @@ install_sdk() {
          ./setup.sh -c -t arm-zephyr-eabi
 }
 
+init_zephyr() {
+    git clone https://github.com/BujSet/zephyr.git
+    cd zephyr/
+    git switch -c executorch-module-integration origin/executorch-module-integration
+    cd ../
+    west init -l zephyr
+    west config manifest.project-filter -- +executorch
+    west -v update
+}
+
 install_prerequiresites
 install_sdk
+init_zephyr

--- a/.ci/docker/common/install_zephyr.sh
+++ b/.ci/docker/common/install_zephyr.sh
@@ -8,6 +8,9 @@
 
 set -ex
 
+# shellcheck source=/dev/null
+source "$(dirname "${BASH_SOURCE[0]}")/utils.sh"
+
 # Double check if the NDK version is set
 [ -n "${ZEPHYR_SDK}" ]
 

--- a/.ci/docker/common/install_zephyr.sh
+++ b/.ci/docker/common/install_zephyr.sh
@@ -91,16 +91,5 @@ install_sdk() {
          ./setup.sh -c -t arm-zephyr-eabi
 }
 
-init_zephyr() {
-    git clone https://github.com/BujSet/zephyr.git
-    cd zephyr/
-    git switch -c executorch-module-integration origin/executorch-module-integration
-    cd ../
-    west init -l zephyr
-    west config manifest.project-filter -- +executorch
-    west -v update
-}
-
 install_prerequiresites
 install_sdk
-init_zephyr

--- a/.ci/docker/common/install_zephyr.sh
+++ b/.ci/docker/common/install_zephyr.sh
@@ -77,7 +77,7 @@ install_prerequiresites() {
         chmod +x kitware-archive.sh && \
         ./kitware-archive.sh && \
         rm -f kitware-archive.sh
-    useradd -d /home/zephyruser -m -s /bin/bash zephyruser
+    pip_install --no-cache-dir west
 }
 
 install_sdk() {

--- a/.ci/docker/ubuntu/Dockerfile
+++ b/.ci/docker/ubuntu/Dockerfile
@@ -86,8 +86,9 @@ ARG ARM_SDK
 
 ARG ZEPHYR_SDK
 COPY ./common/install_zephyr.sh install_zephyr.sh
+COPY ./common/utils.sh utils.sh
 RUN if [ -n "${ZEPHYR_SDK}" ]; then bash ./install_zephyr.sh; fi
-RUN rm install_zephyr.sh
+RUN rm install_zephyr.sh utils.sh
 
 ARG QNN_SDK
 

--- a/.ci/scripts/zephyr-utils.sh
+++ b/.ci/scripts/zephyr-utils.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+download_arm_zephyr_sdk () {
+    wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.0/zephyr-sdk-0.16.0_linux-x86_64.tar.xz
+    tar -xf zephyr-sdk-0.16.0_linux-x86_64.tar.xz
+    rm -f zephyr-sdk-0.16.0_linux-x86_64.tar.xz
+}
+
+setup_zephyr_et_module () {
+    git clone --branch executorch-module-integration https://github.com/BujSet/zephyr.git
+    west init -l zephyr
+    west config manifest.project-filter -- +executorch
+    west -v update
+}

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -64,6 +64,7 @@ jobs:
       fail-fast: false
     with:
       runner: linux.2xlarge
+      docker-image: ci-image:executorch-ubuntu-22.04-zephyr-sdk
       submodules: 'recursive'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout: 120

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -76,9 +76,6 @@ jobs:
         source .ci/scripts/utils.sh
         pwd
         ls
-        cd ../
-        pwd
-        ls
         git clone https://github.com/BujSet/zephyr.git
         cd zephyr/
         git switch -c executorch-module-integration origin/executorch-module-integration

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -92,9 +92,9 @@ jobs:
         source $ZEPHYR_PROJ_ROOT/zephyr/zephyr-env.sh
         cd $ZEPHYR_PROJ_ROOT/zephyr/samples/modules/executorch/arm/hello_world
         west build -p always -b mps3/corstone300/fvp
-        FVP_Corstone_SSE-300_Ethos-U55 -a build/zephyr/zephyr.elf -C mps3_board.visualisation.disable-visualisation=1 -C mps3_board.telnetterminal0.start_telnet=0 -C mps3_board.uart0.out_file='sim.out'  -C cpu0.CFGITCMSZ=15 -C cpu0.CFGDTCMSZ=15 --simlimit 60
+        FVP_Corstone_SSE-300_Ethos-U55 -a build/zephyr/zephyr.elf -C mps3_board.visualisation.disable-visualisation=1 -C mps3_board.telnetterminal0.start_telnet=0 -C mps3_board.uart0.out_file='sim.out'  -C cpu0.CFGITCMSZ=15 -C cpu0.CFGDTCMSZ=15 --simlimit 120
 
-        grep -q "Output[0][0]: (float) 2.000000" sim.out; then
+        grep -q "Output[0][0]: (float) 2.000000" sim.out
         exit_status=$? #store 0 if found (success), 1 if not (failure)
         exit $exit_status
 

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -74,31 +74,36 @@ jobs:
         conda activate "${CONDA_ENV}"
 
         source .ci/scripts/utils.sh
+        source .ci/scripts/zephyr-utils.sh
         mkdir -p zephyr_scratch/
         cd zephyr_scratch
         export ZEPHYR_PROJ_ROOT=$(realpath $(pwd))
 
-        wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.0/zephyr-sdk-0.16.0_linux-x86_64.tar.xz
-        tar -xf zephyr-sdk-0.16.0_linux-x86_64.tar.xz
-        rm -f zephyr-sdk-0.16.0_linux-x86_64.tar.xz
-        cd zephyr-sdk-0.16.0/
-        ./setup.sh -c -t arm-zephyr-eabi
+        download_arm_zephyr_sdk
+        ./zephyr-sdk-0.16.0/setup.sh -c -t arm-zephyr-eabi
+
+        #wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.0/zephyr-sdk-0.16.0_linux-x86_64.tar.xz
+        #tar -xf zephyr-sdk-0.16.0_linux-x86_64.tar.xz
+        #rm -f zephyr-sdk-0.16.0_linux-x86_64.tar.xz
+        #cd zephyr-sdk-0.16.0/
+        #./setup.sh -c -t arm-zephyr-eabi
 
         cd $ZEPHYR_PROJ_ROOT
-        git clone https://github.com/BujSet/zephyr.git
-        cd zephyr/
-        git switch -c executorch-module-integration origin/executorch-module-integration
-        cd $ZEPHYR_PROJ_ROOT
-        west init -l zephyr
-        west config manifest.project-filter -- +executorch
-        west -v update
+        setup_zephyr_et_module
+        #git clone https://github.com/BujSet/zephyr.git
+        #cd zephyr/
+        #git switch -c executorch-module-integration origin/executorch-module-integration
+        #cd $ZEPHYR_PROJ_ROOT
+        #west init -l zephyr
+        #west config manifest.project-filter -- +executorch
+        #west -v update
 
         cd $ZEPHYR_PROJ_ROOT/modules/lib/executorch
         install_executorch "--use-pt-pinned-commit"
         .ci/scripts/setup-arm-baremetal-tools.sh --target-toolchain zephyr
         source examples/arm/ethos-u-scratch/setup_path.sh
-        cd $ZEPHYR_PROJ_ROOT
-        source zephyr/zephyr-env.sh
+        #cd $ZEPHYR_PROJ_ROOT
+        source $ZEPHYR_PROJ_ROOT/zephyr/zephyr-env.sh
         cd $ZEPHYR_PROJ_ROOT/zephyr/samples/modules/executorch/arm/hello_world
         west build -p always -b mps3/corstone300/fvp
         FVP_Corstone_SSE-300_Ethos-U55 -a build/zephyr/zephyr.elf -C mps3_board.visualisation.disable-visualisation=1 -C mps3_board.telnetterminal0.start_telnet=0 -C mps3_board.uart0.out_file='sim.out'  -C cpu0.CFGITCMSZ=15 -C cpu0.CFGDTCMSZ=15 --simlimit 60

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -82,33 +82,18 @@ jobs:
         download_arm_zephyr_sdk
         ./zephyr-sdk-0.16.0/setup.sh -c -t arm-zephyr-eabi
 
-        #wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.0/zephyr-sdk-0.16.0_linux-x86_64.tar.xz
-        #tar -xf zephyr-sdk-0.16.0_linux-x86_64.tar.xz
-        #rm -f zephyr-sdk-0.16.0_linux-x86_64.tar.xz
-        #cd zephyr-sdk-0.16.0/
-        #./setup.sh -c -t arm-zephyr-eabi
-
         cd $ZEPHYR_PROJ_ROOT
         setup_zephyr_et_module
-        #git clone https://github.com/BujSet/zephyr.git
-        #cd zephyr/
-        #git switch -c executorch-module-integration origin/executorch-module-integration
-        #cd $ZEPHYR_PROJ_ROOT
-        #west init -l zephyr
-        #west config manifest.project-filter -- +executorch
-        #west -v update
 
         cd $ZEPHYR_PROJ_ROOT/modules/lib/executorch
         install_executorch "--use-pt-pinned-commit"
         .ci/scripts/setup-arm-baremetal-tools.sh --target-toolchain zephyr
         source examples/arm/ethos-u-scratch/setup_path.sh
-        #cd $ZEPHYR_PROJ_ROOT
         source $ZEPHYR_PROJ_ROOT/zephyr/zephyr-env.sh
         cd $ZEPHYR_PROJ_ROOT/zephyr/samples/modules/executorch/arm/hello_world
         west build -p always -b mps3/corstone300/fvp
         FVP_Corstone_SSE-300_Ethos-U55 -a build/zephyr/zephyr.elf -C mps3_board.visualisation.disable-visualisation=1 -C mps3_board.telnetterminal0.start_telnet=0 -C mps3_board.uart0.out_file='sim.out'  -C cpu0.CFGITCMSZ=15 -C cpu0.CFGDTCMSZ=15 --simlimit 60
 
-        cat sim.out
         grep -q "Output[0][0]: (float) 2.000000" sim.out; then
         exit_status=$? #store 0 if found (success), 1 if not (failure)
         exit $exit_status

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -55,6 +55,30 @@ jobs:
         # Build and test executorch
         PYTHON_EXECUTABLE=python ${CONDA_RUN} bash .ci/scripts/test_model.sh "${MODEL_NAME}" "${BUILD_TOOL}" "${BACKEND}"
 
+  test-models-arm-zephyr:
+    name: test-models-arm-zephyr
+    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+    strategy:
+      matrix:
+        model: [add]
+      fail-fast: false
+    with:
+      runner: linux.2xlarge
+      submodules: 'recursive'
+      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      timeout: 120
+      script: |
+        MODEL_NAME=${{ matrix.model }}
+        CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
+        conda activate "${CONDA_ENV}"
+
+        source .ci/scripts/utils.sh
+        install_executorch "--use-pt-pinned-commit"
+        .ci/scripts/setup-arm-baremetal-tools.sh --target-toolchain zephyr
+        source examples/arm/ethos-u-scratch/setup_path.sh
+        pwd
+        ls
+
   test-models-linux-aarch64:
     name: test-models-linux-aarch64
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -80,6 +80,13 @@ jobs:
         cd zephyr_scratch
         export ZEPHYR_PROJ_ROOT=$(realpath $(pwd))
 
+        wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.0/zephyr-sdk-0.16.0_linux-x86_64.tar.xz
+        tar -xf zephyr-sdk-0.16.0_linux-x86_64.tar.xz
+        rm -f zephyr-sdk-0.16.0_linux-x86_64.tar.xz
+        cd zephyr-sdk-0.16.0/
+        ./setup.sh -c -t arm-zephyr-eabi
+
+        cd $ZEPHYR_PROJ_ROOT
         git clone https://github.com/BujSet/zephyr.git
         cd zephyr/
         git switch -c executorch-module-integration origin/executorch-module-integration

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -94,7 +94,7 @@ jobs:
         west build -p always -b mps3/corstone300/fvp
         FVP_Corstone_SSE-300_Ethos-U55 -a build/zephyr/zephyr.elf -C mps3_board.visualisation.disable-visualisation=1 -C mps3_board.telnetterminal0.start_telnet=0 -C mps3_board.uart0.out_file='sim.out'  -C cpu0.CFGITCMSZ=15 -C cpu0.CFGDTCMSZ=15 --simlimit 120
 
-        grep -q "Output[0][0]: (float) 2.000000" sim.out
+        grep -qF "Output[0][0]: (float) 2.000000" sim.out
         exit_status=$? #store 0 if found (success), 1 if not (failure)
         exit $exit_status
 

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -78,24 +78,30 @@ jobs:
         pwd
         ls
         cd zephyr_scratch
+        export ZEPHYR_PROJ_ROOT=$(realpath $(pwd))
+
         git clone https://github.com/BujSet/zephyr.git
         cd zephyr/
         git switch -c executorch-module-integration origin/executorch-module-integration
-        cd ../
+        cd $ZEPHYR_PROJ_ROOT
         west init -l zephyr
         west config manifest.project-filter -- +executorch
         west -v update
         pwd
         ls
 
-        cd modules/lib/executorch
+        cd $ZEPHYR_PROJ_ROOT/modules/lib/executorch
         #python3 -m venv .venv && source .venv/bin/activate && pip install --upgrade pip
         install_executorch "--use-pt-pinned-commit"
         .ci/scripts/setup-arm-baremetal-tools.sh --target-toolchain zephyr
         source examples/arm/ethos-u-scratch/setup_path.sh
-        cd ../
+        pwd
+        ls
+        cd $ZEPHYR_PROJ_ROOT
+        pwd
+        ls
         source zephyr/zephyr-env.sh
-        cd /zephyr/samples/modules/executorch/arm/hello_world
+        cd $ZEPHYR_PROJ_ROOT/zephyr/samples/modules/executorch/arm/hello_world
         west build -p always -b mps3/corstone300/fvp
         FVP_Corstone_SSE-300_Ethos-U55 -a build/zephyr/zephyr.elf -C mps3_board.visualisation.disable-visualisation=1 -C mps3_board.telnetterminal0.start_telnet=0 -C mps3_board.uart0.out_file='sim.out'  -C cpu0.CFGITCMSZ=15 -C cpu0.CFGDTCMSZ=15 --simlimit 60
         pwd

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -76,6 +76,28 @@ jobs:
         install_executorch "--use-pt-pinned-commit"
         .ci/scripts/setup-arm-baremetal-tools.sh --target-toolchain zephyr
         source examples/arm/ethos-u-scratch/setup_path.sh
+
+        cd ../
+        rm -rf executorch/
+        git clone https://github.com/BujSet/zephyr.git
+        cd zephyr/
+        git switch -c executorch-module-integration origin/executorch-module-integration
+        python3 -m pip install --upgrade pip
+        python3 -m pip install --upgrade cmake==3.31.6
+        python3 -m pip install west torch numpy
+        python3 -m pip install -r scripts/requirements.txt
+        cd ../
+        west init -l zephyr
+        west config manifest.project-filter -- +executorch
+        west -v update
+        source zephyr/zephyr-env.sh
+        cd modules/lib/executorch
+        ./install_executorch.sh
+        ./examples/arm/setup.sh --i-agree-to-the-contained-eula  --target-toolchain zephyr
+        source examples/arm/ethos-u-scratch/setup_path.sh
+        cd ../../../zephyr/samples/modules/executorch/arm/hello_world
+        west build -p always -b mps3/corstone300/fvp
+        FVP_Corstone_SSE-300_Ethos-U55 -a build/zephyr/zephyr.elf -C mps3_board.visualisation.disable-visualisation=1 -C mps3_board.telnetterminal0.start_telnet=0 -C mps3_board.uart0.out_file='sim.out'  -C cpu0.CFGITCMSZ=15 -C cpu0.CFGDTCMSZ=15 --simlimit 60
         pwd
         ls
 

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -74,11 +74,23 @@ jobs:
         conda activate "${CONDA_ENV}"
 
         source .ci/scripts/utils.sh
-
         pwd
         ls
+        cd ../
+        pwd
+        ls
+        git clone https://github.com/BujSet/zephyr.git
+        cd zephyr/
+        git switch -c executorch-module-integration origin/executorch-module-integration
+        cd ../
+        west init -l zephyr
+        west config manifest.project-filter -- +executorch
+        west -v update
+        pwd
+        ls
+
         cd modules/lib/executorch
-        python3 -m venv .venv && source .venv/bin/activate && pip install --upgrade pip
+        #python3 -m venv .venv && source .venv/bin/activate && pip install --upgrade pip
         ./install_executorch.sh
         ./examples/arm/setup.sh --i-agree-to-the-contained-eula  --target-toolchain zephyr
         source examples/arm/ethos-u-scratch/setup_path.sh

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -74,33 +74,29 @@ jobs:
         conda activate "${CONDA_ENV}"
 
         source .ci/scripts/utils.sh
-        install_executorch "--use-pt-pinned-commit"
-        .ci/scripts/setup-arm-baremetal-tools.sh --target-toolchain zephyr
-        source examples/arm/ethos-u-scratch/setup_path.sh
 
         cd ../
-        rm -rf executorch/
         git clone https://github.com/BujSet/zephyr.git
         cd zephyr/
         git switch -c executorch-module-integration origin/executorch-module-integration
-        python3 -m pip install --upgrade pip
-        python3 -m pip install --upgrade cmake==3.31.6
-        python3 -m pip install west torch numpy
-        python3 -m pip install -r scripts/requirements.txt
         cd ../
         west init -l zephyr
         west config manifest.project-filter -- +executorch
         west -v update
-        source zephyr/zephyr-env.sh
         cd modules/lib/executorch
+        python3 -m venv .venv && source .venv/bin/activate && pip install --upgrade pip
         ./install_executorch.sh
         ./examples/arm/setup.sh --i-agree-to-the-contained-eula  --target-toolchain zephyr
         source examples/arm/ethos-u-scratch/setup_path.sh
-        cd ../../../zephyr/samples/modules/executorch/arm/hello_world
+        python3 -m pip install west
+        cd ../
+        source zephyr/zephyr-env.sh
+        cd /zephyr/samples/modules/executorch/arm/hello_world
         west build -p always -b mps3/corstone300/fvp
         FVP_Corstone_SSE-300_Ethos-U55 -a build/zephyr/zephyr.elf -C mps3_board.visualisation.disable-visualisation=1 -C mps3_board.telnetterminal0.start_telnet=0 -C mps3_board.uart0.out_file='sim.out'  -C cpu0.CFGITCMSZ=15 -C cpu0.CFGDTCMSZ=15 --simlimit 60
         pwd
         ls
+        cat sim.out
 
   test-models-linux-aarch64:
     name: test-models-linux-aarch64

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -75,8 +75,6 @@ jobs:
 
         source .ci/scripts/utils.sh
         mkdir -p zephyr_scratch/
-        pwd
-        ls
         cd zephyr_scratch
         export ZEPHYR_PROJ_ROOT=$(realpath $(pwd))
 
@@ -94,26 +92,21 @@ jobs:
         west init -l zephyr
         west config manifest.project-filter -- +executorch
         west -v update
-        pwd
-        ls
 
         cd $ZEPHYR_PROJ_ROOT/modules/lib/executorch
-        #python3 -m venv .venv && source .venv/bin/activate && pip install --upgrade pip
         install_executorch "--use-pt-pinned-commit"
         .ci/scripts/setup-arm-baremetal-tools.sh --target-toolchain zephyr
         source examples/arm/ethos-u-scratch/setup_path.sh
-        pwd
-        ls
         cd $ZEPHYR_PROJ_ROOT
-        pwd
-        ls
         source zephyr/zephyr-env.sh
         cd $ZEPHYR_PROJ_ROOT/zephyr/samples/modules/executorch/arm/hello_world
         west build -p always -b mps3/corstone300/fvp
         FVP_Corstone_SSE-300_Ethos-U55 -a build/zephyr/zephyr.elf -C mps3_board.visualisation.disable-visualisation=1 -C mps3_board.telnetterminal0.start_telnet=0 -C mps3_board.uart0.out_file='sim.out'  -C cpu0.CFGITCMSZ=15 -C cpu0.CFGDTCMSZ=15 --simlimit 60
-        pwd
-        ls
+
         cat sim.out
+        grep -q "Output[0][0]: (float) 2.000000" sim.out; then
+        exit_status=$? #store 0 if found (success), 1 if not (failure)
+        exit $exit_status
 
   test-models-linux-aarch64:
     name: test-models-linux-aarch64

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -74,8 +74,10 @@ jobs:
         conda activate "${CONDA_ENV}"
 
         source .ci/scripts/utils.sh
+        mkdir -p zephyr_scratch/
         pwd
         ls
+        cd zephyr_scratch
         git clone https://github.com/BujSet/zephyr.git
         cd zephyr/
         git switch -c executorch-module-integration origin/executorch-module-integration

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -90,10 +90,9 @@ jobs:
 
         cd modules/lib/executorch
         #python3 -m venv .venv && source .venv/bin/activate && pip install --upgrade pip
-        ./install_executorch.sh
-        ./examples/arm/setup.sh --i-agree-to-the-contained-eula  --target-toolchain zephyr
+        install_executorch "--use-pt-pinned-commit"
+        .ci/scripts/setup-arm-baremetal-tools.sh --target-toolchain zephyr
         source examples/arm/ethos-u-scratch/setup_path.sh
-        python3 -m pip install west
         cd ../
         source zephyr/zephyr-env.sh
         cd /zephyr/samples/modules/executorch/arm/hello_world

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -75,14 +75,8 @@ jobs:
 
         source .ci/scripts/utils.sh
 
-        cd ../
-        git clone https://github.com/BujSet/zephyr.git
-        cd zephyr/
-        git switch -c executorch-module-integration origin/executorch-module-integration
-        cd ../
-        west init -l zephyr
-        west config manifest.project-filter -- +executorch
-        west -v update
+        pwd
+        ls
         cd modules/lib/executorch
         python3 -m venv .venv && source .venv/bin/activate && pip install --upgrade pip
         ./install_executorch.sh


### PR DESCRIPTION
### Summary
Adding in CI tests to verify and maintain support for Zephyr projects that build executorch as a module. The main zephyr application source code is hosted externally for now, but the process to host an Executorch as an official module of zephyr is in progress.

This PR runs the simple Add model as unit tests, and verifies that the output is `2.0` (1D tensor + 1D tensor, values filled with `1.0s`). This is intended to be a simple and fast test to exemplify how to use executorch to build an executor_runner for other models. 

### Test plan
Added a new CI test called `test-models-arm-zephyr` that exits with status 0 on success, and 1 on failure.
