### PR TITLE
Name Correction op_full_like

### DIFF
--- a/kernels/portable/cpu/op_full_like.cpp
+++ b/kernels/portable/cpu/op_full_like.cpp
@@ -50,7 +50,7 @@ Tensor& full_like_out(
 
   ScalarType out_type = out.scalar_type();
 
-  constexpr auto name = "scalar_tensor.out";
+  constexpr auto name = "full_like.out";
 
   ET_SWITCH_REALHBBF16_TYPES(out_type, ctx, name, CTYPE_OUT, [&] {
     auto opt_val_casted =


### PR DESCRIPTION
### Summary
Operator and dtype selective build requires operator names to match operators in use. This changes corrects the name for `full_like` operator.

### Test plan
OpenAI's whisper-tiny encoder model requires the full_like operator. Modified the `examples/selective_build/test_selective_build.sh` script to use the pte from this model. Model previous crashed with missing operator, but now completes without error. I.e. ran `bash examples/selective_build/test_selective_build.sh cmake`.
