### PR TITLE
Arm Zephyr PAL is now functional

### DIFF
--- a/runtime/platform/default/arm_zephyr.cpp
+++ b/runtime/platform/default/arm_zephyr.cpp
@@ -1,10 +1,14 @@
+#include <executorch/runtime/platform/platform.h>
+#include <executorch/runtime/platform/compiler.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
+#include <cstdlib>
+#include <cstdio>
 
 void et_pal_init(void) {}
 
 ET_NORETURN void et_pal_abort(void) {
-  _exit(-1);
+  _Exit(-1);
 }
 
 et_timestamp_t et_pal_current_ticks(void) {
@@ -21,13 +25,13 @@ et_tick_ratio_t et_pal_ticks_to_ns_multiplier(void) {
  * Emit a log message via platform output (serial port, console, etc).
  */
 void et_pal_emit_log_message(
-    ET_UNUSED et_timestamp_t timestamp,
+    et_timestamp_t timestamp,
     et_pal_log_level_t level,
     const char* filename,
-    ET_UNUSED const char* function,
+    const char* function,
     size_t line,
     const char* message,
-    ET_UNUSED size_t length) {
+     size_t length) {
   fprintf(
       stderr,
       "%c [executorch:%s:%zu %s()] %s\n",
@@ -42,6 +46,6 @@ void* et_pal_allocate(size_t size) {
   return k_malloc(size);
 }
 
-void et_pal_free(ET_UNUSED void* ptr) {
+void et_pal_free( void* ptr) {
   k_free(ptr);
 }

--- a/runtime/platform/default/arm_zephyr.cpp
+++ b/runtime/platform/default/arm_zephyr.cpp
@@ -1,9 +1,9 @@
-#include <executorch/runtime/platform/platform.h>
 #include <executorch/runtime/platform/compiler.h>
+#include <executorch/runtime/platform/platform.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
-#include <cstdlib>
 #include <cstdio>
+#include <cstdlib>
 
 void et_pal_init(void) {}
 
@@ -31,7 +31,7 @@ void et_pal_emit_log_message(
     const char* function,
     size_t line,
     const char* message,
-     size_t length) {
+    size_t length) {
   fprintf(
       stderr,
       "%c [executorch:%s:%zu %s()] %s\n",
@@ -46,6 +46,6 @@ void* et_pal_allocate(size_t size) {
   return k_malloc(size);
 }
 
-void et_pal_free( void* ptr) {
+void et_pal_free(void* ptr) {
   k_free(ptr);
 }


### PR DESCRIPTION
### Summary
Previously the PAL file was uploaded as a placeholder for Zephyr apps to use. However, building `arm_zephyr.o` object was unsuccessful. The PAL has been updated and can now be used and linked to zephyr executorch applications.

### Test plan
Tested on a simple add model arm executor runner, see [here](https://github.com/BujSet/zephyr/blob/5801a783883f3cf9bb172213d891c0de596c3dcf/samples/modules/executorch/arm-fvp-tutorials/models/CMakeLists.txt#L61) for a concrete example. CI tests are WIP, see [here](https://github.com/pytorch/executorch/pull/12734).