### PR TITLE
Add roi_align_box_processor DSP op

### DIFF
--- a/backends/cadence/aot/ops_registrations.py
+++ b/backends/cadence/aot/ops_registrations.py
@@ -276,6 +276,14 @@ lib.define(
     "requantize.per_tensor_out(Tensor input, float in_scale, int in_zero_point, float out_scale, "
     "int out_zero_point, ScalarType out_dtype, *, Tensor(a!) out) -> Tensor(a!)"
 )
+lib.define(
+    "roi_align_box_processor.out(Tensor rois, int output_size_h, int output_size_w, "
+    "int sampling_ratio, bool aligned, *, Tensor(a!) out) -> Tensor(a!)"
+)
+lib.define(
+    "roi_align_box_processor(Tensor rois, int output_size_h, int output_size_w, "
+    "int sampling_ratio, bool aligned) -> (Tensor out)"
+)
 
 # Custom ops with aten namespace. Need to specify the lib var as FRAGMENT type as aten library is already defined
 aten_lib = Library("aten", "FRAGMENT")
@@ -1038,3 +1046,14 @@ def idma_store_impl(
     channel: int = 0,
 ) -> torch.Tensor:
     return copy_idma_copy_impl(src, task_num, channel)
+
+
+@register_fake("cadence::roi_align_box_processor")
+def roi_align_box_processor_meta(
+    rois: torch.Tensor,
+    output_size_h: int,
+    output_size_w: int,
+    sampling_ratio: int,
+    aligned: bool,
+) -> torch.Tensor:
+    return rois.new_empty((rois.shape[0], 80), dtype=torch.uint8)


### PR DESCRIPTION
Summary:
Add the necessary infra code to get the roi_align_box_processor DSP op implemented. This op is responsible for converting the roi_align box coordinates from {x1, y1, x2, y2} format to the 80 bytes encoded Turing format (described here: https://docs.google.com/document/d/1IwPvQeRq34rXg-v2qDYO_91PTZPUg1pO4ZaNN1GcjDQ/edit?fbclid=IwY2xjawLCeilleHRuA2FlbQIxMQABHkwVHvvUSalyry20nNFMMU7KbvpExm6i92gPvV_jO1gNI71Zn8WNTp2Rn7kf_aem_nbrzf940O3zNRhet8DJvHg&tab=t.0#heading=h.iiq3n6kursay).
This new op will run on the DSP and will execute as a predecessor of the turing::roi_align op which will now work with the Turing native box coordinates.

Reviewed By: mcremon-meta, zonglinpeng, bingcy

Differential Revision: D78197430


