### PR TITLE
Use cadence replace ops passes in turing partitioner.

### DIFF
--- a/backends/cadence/aot/replace_ops.py
+++ b/backends/cadence/aot/replace_ops.py
@@ -2407,47 +2407,52 @@ class ReplaceAdaptiveAvgPoolWithAtenAvgPoolPass(ExportPass):
         )
 
 
-# This class encapsulates all the functions that replace/switch one op in the
-# graph with another.
-class CadenceReplaceOpsInGraph:
+# Encapsulates the generic graph improvement passes.
+class GenericReplaceOpsInGraph:
     passes = [
-        ReplaceEmptyTensorsWithFullPass,
-        ReplaceFunctionallyEquivalentOpTargets,
+            ReplaceSqueezeAndUnsqueezeWithViewPass,
+            ReplaceSplitWithSlicePass,
+            ReplaceSelectWithViewOpPass,
+            ReplaceMMWithAddMMPass,
+            ReplaceRepeatWithCatPass,
+            ReplaceFullLikeWithFullPass,
+            ReplaceFunctionallyEquivalentOpTargets,
+            ReplaceConvolutionOptionalArgsWithConcreteArgsPass,
+            ReplaceAddMMWithLinearPass,
+            ReplacePadWithCatPass,
+            ReplaceConstantPadNdWithSlicePass,
+            ReplaceTrivialConvWithLinear,
+            ReplaceScalarTensorWithFullPass,
+            ReplaceInfArgInFullWithValuePass,
+            ReplaceLogicalNotBooleanWhereWithWherePass,
+            ReplaceAdaptiveAvgPoolWithAtenAvgPoolPass,
+            ReplaceAtenApproxGeluWithApproxGeluPass,
+            ReplaceAtenConvolutionWithJarvisConvolutionPass,
+            ReplacePT2QuantWithCadenceQuantPass,
+            ReplacePT2DequantWithCadenceDequantPass,
+            ReplacePowWithMulPass,
+            ReplaceEmptyTensorsWithFullPass,
+            ReplaceScalarWithTensorArgPass,
+            RemoveNopSelectOpPass,
+            ReplaceNopTransposeOrPermuteWithViewPass,
+        ]
+
+# Encapsulates all the passes which replace ops in graph including Sadence specific ones.
+class CadenceReplaceOpsInGraph:
+    cadence_specific_passes =  [
         ReplacePermuteWithTransposePass,
-        ReplaceScalarWithTensorArgPass,
-        ReplaceConvolutionOptionalArgsWithConcreteArgsPass,
-        ReplaceMMWithAddMMPass,
-        ReplaceSqueezeAndUnsqueezeWithViewPass,
-        ReplaceAddMMWithLinearPass,
-        RemoveNopSelectOpPass,
-        ReplaceSelectWithViewOpPass,
-        ReplaceRepeatWithCatPass,
         ReplacePadWithCatPass,
-        ReplaceConstantPadNdWithSlicePass,
         ReplaceConvWithChannelLastConvPass,
-        ReplaceAtenConvolutionWithJarvisConvolutionPass,
         ForceChannelLastForConvPass,
-        ReplaceTrivialConvWithLinear,
         ReplaceConvWithIm2RowAndLinear,
         ReplaceTransposedConvWithLinearPass,
         # This pass should be after passes that replace conv -> im2row + linear.
         ReplaceIm2RowWithViewPass,
         MakeSliceAndCatDimOutermostPass,
         ReplaceMatmulWithTransposedMatmulPass,
-        ReplaceNopTransposeOrPermuteWithViewPass,
         ReplaceLinearWithFullyConnectedOpPass,
-        ReplaceScalarTensorWithFullPass,
-        ReplaceFullLikeWithFullPass,
-        ReplaceInfArgInFullWithValuePass,
-        ReplaceLogicalNotBooleanWhereWithWherePass,
-        ReplacePT2QuantWithCadenceQuantPass,
-        ReplacePT2DequantWithCadenceDequantPass,
         ReplaceSingleElementTensorArgumentsFromFullOpWithScalarPass,
-        ReplaceAdaptiveAvgPoolWithAtenAvgPoolPass,
         ReplaceAtenAvgPoolWithJarvisAvgPoolPass,
         ReplaceWhereWithFullArgsWithWhereScalar,
-        ReplaceAtenApproxGeluWithApproxGeluPass,
-        ReplaceSplitWithSlicePass,
-        ReplacePowWithMulPass,
-        ReplaceMulTensorWithMulAndFullOpsPass,
     ]
+    passes = GenericReplaceOpsInGraph.passes + cadence_specific_passes


### PR DESCRIPTION
Summary:
Jarvis&Helios passes unification.

Context: https://docs.google.com/document/d/1v3B-0ngdeEx0VoI8pAKovqeLkkByMM6hFBqtOzBboOw/edit?usp=sharing

Differential Revision: D78701343


