### PR TITLE
Use cadence reorder ops passes in turing partitioner.

### DIFF
--- a/backends/cadence/aot/reorder_ops.py
+++ b/backends/cadence/aot/reorder_ops.py
@@ -835,4 +835,5 @@ class CadenceReorderOpsInGraph:
         # These passes work on branches instead of linear chains to advance
         # quantize op beyond their def.
         AdvanceQuantizeOpAboveDefInBranchPass,
+        PostponePermuteOpBelowSqueezeOrUnsqueezeLikeView,
     ]


### PR DESCRIPTION
Summary:
Jarvis&Helios passes unification.
Context: https://docs.google.com/document/d/1v3B-0ngdeEx0VoI8pAKovqeLkkByMM6hFBqtOzBboOw/edit?usp=sharing

Differential Revision: D78702133


