### PR TITLE
[Release 0.7] bump torchao pins to 0.12.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ dependencies=[
   "pyyaml",
   "ruamel.yaml",
   "sympy",
+  "torchao==0.12.0",
   "tabulate",
   # See also third-party/TARGETS for buck's typing-extensions version.
   "typing-extensions>=4.10.0",


### PR DESCRIPTION
Summary:

1. The pin in third-party/ao is bumped to branch "release/0.12.0".
https://github.com/pytorch/ao/commits/release/0.12.0
Commit hash: 442232fbfb0f6cdfdb9c3eac20f57e5a746ee1bf

2. We add "torchao==0.12.0" to the pyproject.toml.
