### PR TITLE
Remove spam log in runner

### DIFF
--- a/extension/llm/runner/text_decoder_runner.cpp
+++ b/extension/llm/runner/text_decoder_runner.cpp
@@ -66,11 +66,6 @@ TextDecoderRunner::TextDecoderRunner(Module* module) : module_(module) {}
       start_pos_tensor = from_blob(
           &start_pos, sizes_vec, ::executorch::aten::ScalarType::Long);
     }
-    ET_LOG(
-        Info,
-        "Start pos tensor numel: %zu, tokens numel: %zu",
-        start_pos_tensor->numel(),
-        tokens->numel());
     auto outputs_res = module_->forward({tokens, start_pos_tensor});
     ET_CHECK_OK_OR_RETURN_ERROR(outputs_res.error());
     ET_CHECK_MSG(


### PR DESCRIPTION
Summary:
Before this diff, we have lots of spam logs like
```
I 00:00:10.559895 executorch:text_prefiller.cpp:93] Prefill token result numel(): 32000
 fI 00:00:10.559960 executorch:text_llm_runner.cpp:184] RSS after prompt prefill: 4181.375000 MiB (0 if unsupported)
I 00:00:10.560417 executorch:text_decoder_runner.cpp:73] Start pos tensor numel: 1, tokens numel: 1
оI 00:00:10.604904 executorch:text_decoder_runner.cpp:73] Start pos tensor numel: 1, tokens numel: 1
 motI 00:00:10.650478 executorch:text_decoder_runner.cpp:73] Start pos tensor numel: 1, tokens numel: 1
ingI 00:00:10.692445 executorch:text_decoder_runner.cpp:73] Start pos tensor numel: 1, tokens numel: 1
ambdaI 00:00:10.734655 executorch:text_decoder_runner.cpp:73] Start pos tensor numel: 1, tokens numel: 1
I 00:00:10.776940 executorch:text_decoder_runner.cpp:73] Start pos tensor numel: 1, tokens numel: 1
onicaI 00:00:10.823573 executorch:text_decoder_runner.cpp:73] Start pos tensor numel: 1, tokens numel: 1
zI 00:00:10.866775 executorch:text_decoder_runner.cpp:73] Start pos tensor numel: 1, tokens numel: 1
uI 00:00:10.909472 executorch:text_decoder_runner.cpp:73] Start pos tensor numel: 1, tokens numel: 1
 FoodI 00:00:10.953019 executorch:text_decoder_runner.cpp:73] Start pos tensor numel: 1, tokens numel: 1
 flowI 00:00:10.996213 executorch:text_decoder_runner.cpp:73] Start pos tensor numel: 1, tokens numel: 1
2I 00:00:11.038988 executorch:text_decoder_runner.cpp:73] Start pos tensor numel: 1, tokens numel: 1
ouI 00:00:11.081957 executorch:text_decoder_runner.cpp:73] Start pos tensor numel: 1, tokens numel: 1
 frequI 00:00:11.125024 executorch:text_decoder_runner.cpp:73] Start pos tensor numel: 1, tokens numel: 1
 lightI 00:00:11.167362 executorch:text_decoder_runner.cpp:73] Start pos tensor numel: 1, tokens numel: 1
vI 00:00:11.210194 executorch:text_decoder_runner.cpp:73] Start pos tensor numel: 1, tokens numel: 1
I 00:00:11.253101 executorch:text_decoder_runner.cpp:73] Start pos tensor numel: 1, tokens numel: 1
enderI 00:00:11.295863 executorch:text_decoder_runner.cpp:73] Start pos tensor numel: 1, tokens numel: 1
 frequI 00:00:11.338831 executorch:text_decoder_runner.cpp:73] Start pos tensor numel: 1, tokens numel: 1
 lightI 00:00:11.381479 executorch:text_decoder_runner.cpp:73] Start pos tensor numel: 1, tokens numel: 1
 yI 00:00:11.424289 executorch:text_decoder_runner.cpp:73] Start pos tensor numel: 1, tokens numel: 1
    I 00:00:11.467112 executorch:text_decoder_runner.cpp:73] Start pos tensor numel: 1, tokens numel: 1
 batalI 00:00:11.509699 executorch:text_decoder_runner.cpp:73] Start pos tensor numel: 1, tokens numel: 1
esI 00:00:11.552216 executorch:text_decoder_runner.cpp:73] Start pos tensor numel: 1, tokens numel: 1
 assI 00:00:11.595533 executorch:text_decoder_runner.cpp:73] Start pos tensor numel: 1, tokens numel: 1
iodI 00:00:11.638349 executorch:text_decoder_runner.cpp:73] Start pos tensor numel: 1, tokens numel: 1
)I 00:00:11.680965 executorch:text_decoder_runner.cpp:73] Start pos tensor numel: 1, tokens numel: 1
);I 00:00:11.723977 executorch:text_decoder_runner.cpp:73] Start pos tensor numel: 1, tokens numel: 1
ouI 00:00:11.766852 executorch:text_decoder_runner.cpp:73] Start pos tensor numel: 1, tokens numel: 1
ceptorI 00:00:11.815769 executorch:text_decoder_runner.cpp:73] Start pos tensor numel: 1, tokens numel: 1
otI 00:00:11.858416 executorch:text_decoder_runner.cpp:73] Start pos tensor numel: 1, tokens numel: 1
```

Differential Revision: D78869518


