### PR TITLE
Name Correction op_mean

### DIFF
--- a/kernels/portable/cpu/op_mean.cpp
+++ b/kernels/portable/cpu/op_mean.cpp
@@ -47,7 +47,7 @@ Tensor& mean_dim_out(
 
   MapReduceOverDimListPlan plan(in, dim_list);
   // @lint-ignore CLANGTIDY facebook-hte-CArray
-  static constexpr const char op_name[] = "add.out";
+  static constexpr const char op_name[] = "mean.out";
   ET_SWITCH_REALHBBF16_TYPES(in.scalar_type(), ctx, op_name, CTYPE_IN, [&] {
     ET_SWITCH_FLOATHBF16_TYPES(out.scalar_type(), ctx, op_name, CTYPE_OUT, [&] {
       CTYPE_OUT* out_data = out.mutable_data_ptr<CTYPE_OUT>();


### PR DESCRIPTION
### Summary

Operator and dtype selective build requires operator names to match operators in use. This changes corrects the name for `mean` operator. Change is similar to that in #12755.