### PR TITLE
NXP backend: Use default (non-shared) quantization params for HardTanh

### DIFF
--- a/backends/nxp/quantizer/patterns.py
+++ b/backends/nxp/quantizer/patterns.py
@@ -279,7 +279,7 @@ class FlattenPattern(SharedSpecPattern):
         return [torch.ops.aten.flatten.using_ints]
 
 
-class HardTanhPattern(SharedSpecPattern):
+class HardTanhPattern(QuantizationPattern):
     """
     Quantizer for HardTanh operator. Shared quantization spec is selected, as activation functions usually follows
     computation layer.
@@ -288,8 +288,23 @@ class HardTanhPattern(SharedSpecPattern):
     def partition_types(self):
         return [torch.ops.aten.hardtanh.default]
 
+    def get_anchors(
+        self, gm: fx.GraphModule, fused_partition: List[fx.GraphModule]
+    ) -> PartitionAnchors | None:
+        node = fused_partition[0].nodes[-1]
 
-class HardTanhInPlacePattern(SharedSpecPattern):
+        return PartitionAnchors(
+            inputs=[(node, 0)],
+            weights=[],
+            biases=[],
+            output=[(node,)],
+        )
+
+    def replacement_op(self):
+        raise AssertionError()
+
+
+class HardTanhInPlacePattern(QuantizationPattern):
     """
     Quantizer for HardTanh operator with param inplace=True. Shared quantization spec is selected, as activation
     functions usually follows computation layer.
@@ -297,6 +312,21 @@ class HardTanhInPlacePattern(SharedSpecPattern):
 
     def partition_types(self):
         return [torch.ops.aten.hardtanh_.default]
+
+    def get_anchors(
+        self, gm: fx.GraphModule, fused_partition: List[fx.GraphModule]
+    ) -> PartitionAnchors | None:
+        node = fused_partition[0].nodes[-1]
+
+        return PartitionAnchors(
+            inputs=[(node, 0)],
+            weights=[],
+            biases=[],
+            output=[(node,)],
+        )
+
+    def replacement_op(self):
+        raise AssertionError()
 
 
 class LinearPattern(QuantizationPattern):

--- a/backends/nxp/tests/executorch_pipeline.py
+++ b/backends/nxp/tests/executorch_pipeline.py
@@ -31,6 +31,15 @@ def _quantize_model(model, calibration_inputs: list[tuple[torch.Tensor]]):
     return m
 
 
+def get_random_float_data(input_shapes: tuple[int] | list[tuple[int]]):
+    # TODO: Replace with something more robust.
+    return (
+        (torch.randn(input_shapes),)
+        if type(input_shapes) is tuple
+        else tuple(torch.randn(input_shape) for input_shape in input_shapes)
+    )
+
+
 def to_quantized_edge_program(
     model: torch.nn.Module,
     input_shapes: tuple[int] | list[tuple[int]],
@@ -43,12 +52,7 @@ def to_quantized_edge_program(
             "For multiple inputs, provide" " list[tuple[int]]."
         )
 
-    random_tensors = (
-        (torch.randn(input_shapes),)
-        if type(input_shapes) is tuple
-        else tuple(torch.randn(input_shape) for input_shape in input_shapes)
-    )
-    calibration_inputs = [random_tensors, random_tensors]
+    calibration_inputs = [get_random_float_data(input_shapes) for _ in range(4)]
     example_input = (
         (torch.ones(input_shapes),)
         if type(input_shapes) is tuple


### PR DESCRIPTION
### Summary
Replaces shared quantization parameters specs for fixed ones in HardTanh operator.

### Test plan
Existing unit test files were updated to correspond to this change.

cc @skywall 
