### PR TITLE
Pin transformers version to 4.53.1 to avoid breakage

### DIFF
--- a/requirements-examples.txt
+++ b/requirements-examples.txt
@@ -4,4 +4,4 @@ datasets == 3.6.0 # 4.0.0 deprecates trust_remote_code and load scripts. For now
 timm == 1.0.7
 torchsr == 1.0.4
 torchtune >= 0.6.1
-transformers >= 4.53.1
+transformers == 4.53.1


### PR DESCRIPTION
To avoid this error:

```
Traceback (most recent call last):
  File "/opt/conda/envs/py_3.10/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/opt/conda/envs/py_3.10/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/opt/conda/envs/py_3.10/lib/python3.10/site-packages/executorch/examples/models/phi-3-mini/export_phi-3-mini.py", line 168, in <module>
    main()
  File "/opt/conda/envs/py_3.10/lib/python3.10/site-packages/executorch/examples/models/phi-3-mini/export_phi-3-mini.py", line 164, in main
    export(parser.parse_args())
  File "/opt/conda/envs/py_3.10/lib/python3.10/site-packages/executorch/examples/models/phi-3-mini/export_phi-3-mini.py", line 79, in export
    exportable_module = TorchExportableModuleForDecoderOnlyLM(
  File "/opt/conda/envs/py_3.10/lib/python3.10/site-packages/transformers/integrations/executorch.py", line 67, in __init__
    self.model = TorchExportableModuleWithStaticCache(model)
  File "/opt/conda/envs/py_3.10/lib/python3.10/site-packages/transformers/integrations/executorch.py", line 293, in __init__
    max_batch_size=self.model.generation_config.cache_config.get("batch_size"),
AttributeError: 'StaticCacheConfig' object has no attribute 'get'
```

### Summary
[PLEASE REMOVE] See [CONTRIBUTING.md's Pull Requests](https://github.com/pytorch/executorch/blob/main/CONTRIBUTING.md#pull-requests) for ExecuTorch PR guidelines.

[PLEASE REMOVE] If this PR closes an issue, please add a `Fixes #<issue-id>` line.

[PLEASE REMOVE] If this PR introduces a fix or feature that should be the upcoming release notes, please add a "Release notes: <area>" label. For a list of available release notes labels, check out [CONTRIBUTING.md's Pull Requests](https://github.com/pytorch/executorch/blob/main/CONTRIBUTING.md#pull-requests).

### Test plan
[PLEASE REMOVE] How did you test this PR? Please write down any manual commands you used and note down tests that you have written if applicable.
