### PR TITLE
Evalue** -> Span

### DIFF
--- a/codegen/gen.py
+++ b/codegen/gen.py
@@ -297,7 +297,7 @@ class ComputeCodegenUnboxedKernels:
                 f"""
 Kernel(
     "{f.namespace}::{f.func.name}",{newline + '"' + (k + '",') if k != "default" else ""}
-    []({contextArg.defn()}, EValue** stack) {{
+    []({contextArg.defn()}, Span<EValue*> stack) {{
         {code_connector.join(code_list)}
 
 {exception_boundary_begin}

--- a/codegen/test/test_executorch_gen.py
+++ b/codegen/test/test_executorch_gen.py
@@ -507,7 +507,7 @@ class TestComputeCodegenUnboxedKernels(unittest.TestCase):
 Kernel(
     "custom_1::op_1",
     "v1/7;0,1,2,3|7;0,1,2,3|7;0,1,2,3",
-    [](torch::executor::KernelRuntimeContext & context, EValue** stack) {
+    [](torch::executor::KernelRuntimeContext & context, Span<EValue*> stack) {
         """
             + """
 
@@ -605,7 +605,7 @@ Kernel(
             """
 Kernel(
     "custom_1::op_1",
-    [](torch::executor::KernelRuntimeContext & context, EValue** stack) {
+    [](torch::executor::KernelRuntimeContext & context, Span<EValue*> stack) {
         """
             + """
 
@@ -632,7 +632,7 @@ Kernel(
             """
 Kernel(
     "custom_1::op_1",
-    [](torch::executor::KernelRuntimeContext & context, EValue** stack) {
+    [](torch::executor::KernelRuntimeContext & context, Span<EValue*> stack) {
         """
             + """
 
@@ -675,7 +675,7 @@ Kernel(
             """
 Kernel(
     "custom_1::op_1",
-    [](torch::executor::KernelRuntimeContext & context, EValue** stack) {
+    [](torch::executor::KernelRuntimeContext & context, Span<EValue*> stack) {
         """
             + """
 

--- a/extension/kernel_util/make_boxed_from_unboxed_functor.h
+++ b/extension/kernel_util/make_boxed_from_unboxed_functor.h
@@ -112,8 +112,8 @@ struct evalue_to_arg<executorch::aten::ArrayRef<std::optional<T>>> final {
 
 template <class Functor, size_t... evalue_arg_indices, typename... ArgTypes>
 void call_functor_with_args_from_stack(
-    ::executorch::runtime::KernelRuntimeContext& ctx,
-    executorch::runtime::EValue** stack,
+    executorch::runtime::KernelRuntimeContext& ctx,
+    executorch::runtime::Span<executorch::runtime::EValue*> stack,
     std::index_sequence<evalue_arg_indices...>,
     typelist<ArgTypes...>*) {
   (*Functor::func_ptr())(
@@ -151,7 +151,7 @@ struct WrapUnboxedIntoFunctor {
 
   static void call(
       ::executorch::runtime::KernelRuntimeContext& ctx,
-      executorch::runtime::EValue** stack) {
+      executorch::runtime::Span<executorch::runtime::EValue*> stack) {
     constexpr size_t num_inputs =
         kernel_util_internal::size<ContextRemovedArgsType>::value;
     return kernel_util_internal::call_functor_with_args_from_stack<FuncType>(

--- a/kernels/prim_ops/et_copy_index.cpp
+++ b/kernels/prim_ops/et_copy_index.cpp
@@ -64,7 +64,7 @@ constexpr size_t kTensorDimensionLimit = 16;
 //
 // The output of each iteration (copy_from) is copied into the copy_to tensor at
 // the specified index. This operator is supported in both ATen and lean modes.
-void et_copy_index(KernelRuntimeContext& context, EValue** stack) {
+void et_copy_index(KernelRuntimeContext& context, Span<EValue*> stack) {
   (void)context;
   SizesType expected_output_size[kTensorDimensionLimit];
 

--- a/kernels/prim_ops/et_copy_index.h
+++ b/kernels/prim_ops/et_copy_index.h
@@ -9,13 +9,14 @@
 #pragma once
 
 #include <executorch/runtime/core/evalue.h>
+#include <executorch/runtime/core/span.h>
 #include <executorch/runtime/kernel/kernel_runtime_context.h>
 
 namespace torch {
 namespace executor {
 namespace function {
 
-void et_copy_index(KernelRuntimeContext& context, EValue** stack);
+void et_copy_index(KernelRuntimeContext& context, Span<EValue*> stack);
 
 } // namespace function
 } // namespace executor

--- a/kernels/prim_ops/et_view.cpp
+++ b/kernels/prim_ops/et_view.cpp
@@ -65,7 +65,7 @@ bool get_view_target_size(
 }
 } // namespace
 
-void et_view(KernelRuntimeContext& context, EValue** stack) {
+void et_view(KernelRuntimeContext& context, Span<EValue*> stack) {
   (void)context;
 
   auto self = (*stack[0]).toTensor();

--- a/kernels/prim_ops/et_view.h
+++ b/kernels/prim_ops/et_view.h
@@ -9,13 +9,14 @@
 #pragma once
 
 #include <executorch/runtime/core/evalue.h>
+#include <executorch/runtime/core/span.h>
 #include <executorch/runtime/kernel/kernel_runtime_context.h>
 
 namespace torch {
 namespace executor {
 namespace function {
 
-void et_view(KernelRuntimeContext& context, EValue** stack);
+void et_view(KernelRuntimeContext& context, Span<EValue*> stack);
 
 } // namespace function
 } // namespace executor

--- a/kernels/prim_ops/register_prim_ops.cpp
+++ b/kernels/prim_ops/register_prim_ops.cpp
@@ -79,7 +79,7 @@ static Kernel prim_ops[] = {
     // aten::sym_size.int(Tensor self, int dim) -> SymInt
     Kernel(
         "aten::sym_size.int",
-        [](KernelRuntimeContext& context, EValue** stack) {
+        [](KernelRuntimeContext& context, Span<EValue*> stack) {
           (void)context;
           EValue& self = *stack[0];
           EValue& dim = *stack[1];
@@ -93,7 +93,7 @@ static Kernel prim_ops[] = {
     // aten::_local_scalar_dense(Tensor self) -> Scalar
     Kernel(
         "aten::_local_scalar_dense",
-        [](KernelRuntimeContext& context, EValue** stack) {
+        [](KernelRuntimeContext& context, Span<EValue*> stack) {
           (void)context;
           EValue& self = *stack[0];
           EValue& out = *stack[1];
@@ -112,7 +112,7 @@ static Kernel prim_ops[] = {
     // aten::sym_numel(Tensor self) -> SymInt
     Kernel(
         "aten::sym_numel",
-        [](KernelRuntimeContext& context, EValue** stack) {
+        [](KernelRuntimeContext& context, Span<EValue*> stack) {
           (void)context;
           EValue& self = *stack[0];
           EValue& out = *stack[1];
@@ -124,7 +124,7 @@ static Kernel prim_ops[] = {
     // executorch_prim::sym_max.Scalar(SymInt a, SymInt b) -> SymInt
     Kernel(
         "executorch_prim::sym_max.Scalar",
-        [](KernelRuntimeContext& context, EValue** stack) {
+        [](KernelRuntimeContext& context, Span<EValue*> stack) {
           (void)context;
           EValue& a = *stack[0];
           EValue& b = *stack[1];
@@ -145,7 +145,7 @@ static Kernel prim_ops[] = {
     // executorch_prim::sym_min.Scalar(SymInt a, SymInt b) -> SymInt
     Kernel(
         "executorch_prim::sym_min.Scalar",
-        [](KernelRuntimeContext& context, EValue** stack) {
+        [](KernelRuntimeContext& context, Span<EValue*> stack) {
           (void)context;
           EValue& a = *stack[0];
           EValue& b = *stack[1];
@@ -166,7 +166,7 @@ static Kernel prim_ops[] = {
     // executorch_prim::add.Scalar(Scalar, Scalar) -> Scalar
     Kernel(
         "executorch_prim::add.Scalar",
-        [](KernelRuntimeContext& context, EValue** stack) {
+        [](KernelRuntimeContext& context, Span<EValue*> stack) {
           (void)context;
           ALGEBRA_ET_PRIM_OP(+, stack, context);
         }),
@@ -174,14 +174,14 @@ static Kernel prim_ops[] = {
     // executorch_prim::sub.Scalar(Scalar, Scalar) -> Scalar
     Kernel(
         "executorch_prim::sub.Scalar",
-        [](KernelRuntimeContext& context, EValue** stack) {
+        [](KernelRuntimeContext& context, Span<EValue*> stack) {
           ALGEBRA_ET_PRIM_OP(-, stack, context);
         }),
 
     // executorch_prim::mul.Scalar(Scalar, Scalar) -> Scalar
     Kernel(
         "executorch_prim::mul.Scalar",
-        [](KernelRuntimeContext& context, EValue** stack) {
+        [](KernelRuntimeContext& context, Span<EValue*> stack) {
           ALGEBRA_ET_PRIM_OP(*, stack, context);
         }),
 
@@ -196,7 +196,7 @@ static Kernel prim_ops[] = {
      */
     Kernel(
         "executorch_prim::floordiv.Scalar",
-        [](KernelRuntimeContext& context, EValue** stack) {
+        [](KernelRuntimeContext& context, Span<EValue*> stack) {
           (void)context;
           EValue& a = *stack[0];
           EValue& b = *stack[1];
@@ -231,7 +231,7 @@ static Kernel prim_ops[] = {
     // executorch_prim::floordiv.Scalar(Scalar, Scalar) -> Scalar
     Kernel(
         "executorch_prim::truediv.Scalar",
-        [](KernelRuntimeContext& context, EValue** stack) {
+        [](KernelRuntimeContext& context, Span<EValue*> stack) {
           // can't use macro because of custom casting behavior
           (void)context;
           EValue& a = *stack[0];
@@ -262,7 +262,7 @@ static Kernel prim_ops[] = {
     // executorch_prim::sym_float.Scalar(Scalar) -> Scalar
     Kernel(
         "executorch_prim::sym_float.Scalar",
-        [](KernelRuntimeContext& context, EValue** stack) {
+        [](KernelRuntimeContext& context, Span<EValue*> stack) {
           // can't use macro because of custom casting behavior
           // TODO: Now that we are reliably generating conversion operators,
           // we can remove the mixed type handling for other operators
@@ -283,41 +283,41 @@ static Kernel prim_ops[] = {
     // executorch_prim::eq.Scalar(Scalar, Scalar) -> bool
     Kernel(
         "executorch_prim::eq.Scalar",
-        [](KernelRuntimeContext& context, EValue** stack) {
+        [](KernelRuntimeContext& context, Span<EValue*> stack) {
           BOOLEAN_ET_PRIM_OP(==, stack, context);
         }),
 
     // executorch_prim::gt.Scalar(Scalar, Scalar) -> bool
     Kernel(
         "executorch_prim::gt.Scalar",
-        [](KernelRuntimeContext& context, EValue** stack) {
+        [](KernelRuntimeContext& context, Span<EValue*> stack) {
           BOOLEAN_ET_PRIM_OP(>, stack, context);
         }),
 
     // executorch_prim::lt.Scalar(Scalar, Scalar) -> bool
     Kernel(
         "executorch_prim::lt.Scalar",
-        [](KernelRuntimeContext& context, EValue** stack) {
+        [](KernelRuntimeContext& context, Span<EValue*> stack) {
           BOOLEAN_ET_PRIM_OP(<, stack, context);
         }),
 
     // executorch_prim::ge.Scalar(Scalar, Scalar) -> bool
     Kernel(
         "executorch_prim::ge.Scalar",
-        [](KernelRuntimeContext& context, EValue** stack) {
+        [](KernelRuntimeContext& context, Span<EValue*> stack) {
           BOOLEAN_ET_PRIM_OP(>=, stack, context);
         }),
 
     // executorch_prim::le.Scalar(Scalar, Scalar) -> bool
     Kernel(
         "executorch_prim::le.Scalar",
-        [](KernelRuntimeContext& context, EValue** stack) {
+        [](KernelRuntimeContext& context, Span<EValue*> stack) {
           BOOLEAN_ET_PRIM_OP(<=, stack, context);
         }),
     // executorch_prim::neg.Scalar(Scalar) -> Scalar
     Kernel(
         "executorch_prim::neg.Scalar",
-        [](KernelRuntimeContext& context, EValue** stack) {
+        [](KernelRuntimeContext& context, Span<EValue*> stack) {
           (void)context;
           EValue& a = *stack[0];
           EValue& out = *stack[1];
@@ -334,7 +334,7 @@ static Kernel prim_ops[] = {
     // executorch_prim::floordiv.int(int, int) -> int
     Kernel(
         "executorch_prim::floordiv.int",
-        [](KernelRuntimeContext& context, EValue** stack) {
+        [](KernelRuntimeContext& context, Span<EValue*> stack) {
           (void)context;
           EValue& a = *stack[0];
           EValue& b = *stack[1];
@@ -345,7 +345,7 @@ static Kernel prim_ops[] = {
     // executorch_prim::mod.int(int, int) -> int
     Kernel(
         "executorch_prim::mod.int",
-        [](KernelRuntimeContext& context, EValue** stack) {
+        [](KernelRuntimeContext& context, Span<EValue*> stack) {
           (void)context;
           EValue& a = *stack[0];
           EValue& b = *stack[1];
@@ -356,7 +356,7 @@ static Kernel prim_ops[] = {
     // executorch_prim::mod.Scalar(Scalar, Scalar) -> Scalar
     Kernel(
         "executorch_prim::mod.Scalar",
-        [](KernelRuntimeContext& context, EValue** stack) {
+        [](KernelRuntimeContext& context, Span<EValue*> stack) {
           (void)context;
           EValue& a = *stack[0];
           EValue& b = *stack[1];
@@ -378,7 +378,7 @@ static Kernel prim_ops[] = {
     // ceil.Scalar(Scalar a) -> Scalar
     Kernel(
         "executorch_prim::ceil.Scalar",
-        [](KernelRuntimeContext& context, EValue** stack) {
+        [](KernelRuntimeContext& context, Span<EValue*> stack) {
           (void)context;
           EValue& a = *stack[0];
           EValue& out = *stack[1];
@@ -398,7 +398,7 @@ static Kernel prim_ops[] = {
     // round.Scalar(Scalar a) -> Scalar
     Kernel(
         "executorch_prim::round.Scalar",
-        [](KernelRuntimeContext& context, EValue** stack) {
+        [](KernelRuntimeContext& context, Span<EValue*> stack) {
           (void)context;
           EValue& a = *stack[0];
           EValue& out = *stack[1];
@@ -435,7 +435,7 @@ static Kernel prim_ops[] = {
     // trunc.Scalar(Scalar a) -> Scalar
     Kernel(
         "executorch_prim::trunc.Scalar",
-        [](KernelRuntimeContext& context, EValue** stack) {
+        [](KernelRuntimeContext& context, Span<EValue*> stack) {
           (void)context;
           EValue& a = *stack[0];
           EValue& out = *stack[1];
@@ -450,13 +450,13 @@ static Kernel prim_ops[] = {
     // executorch_prim::et_copy_index.tensor(tensor, tensor) -> tensor
     Kernel(
         "executorch_prim::et_copy_index.tensor",
-        [](KernelRuntimeContext& context, EValue** stack) {
+        [](KernelRuntimeContext& context, Span<EValue*> stack) {
           et_copy_index(context, stack);
         }),
     // executorch_prim::et_view.default(Tensor, int[]) -> Tensor
     Kernel(
         "executorch_prim::et_view.default",
-        [](KernelRuntimeContext& context, EValue** stack) {
+        [](KernelRuntimeContext& context, Span<EValue*> stack) {
           et_view(context, stack);
         }),
 

--- a/kernels/prim_ops/targets.bzl
+++ b/kernels/prim_ops/targets.bzl
@@ -17,6 +17,7 @@ def define_common_targets():
             exported_headers = ["et_copy_index.h"],
             deps = [
                 "//executorch/runtime/kernel:kernel_includes" + aten_suffix,
+                "//executorch/runtime/core:core",
             ],
             exported_deps = [
                 "//executorch/runtime/core:evalue" + aten_suffix,
@@ -31,6 +32,7 @@ def define_common_targets():
             exported_headers = ["et_view.h"],
             deps = [
                 "//executorch/runtime/kernel:kernel_includes" + aten_suffix,
+                "//executorch/runtime/core:core",
             ],
             exported_deps = [
                 "//executorch/runtime/core:evalue" + aten_suffix,

--- a/runtime/executor/method.cpp
+++ b/runtime/executor/method.cpp
@@ -1319,7 +1319,7 @@ Error Method::execute_instruction() {
       // TODO(T147221312): Also expose tensor resizer via the context.
       KernelRuntimeContext context(event_tracer_, temp_allocator_);
       auto args = chain.argument_lists_[step_state_.instr_idx];
-      chain.kernels_[step_state_.instr_idx](context, args.data());
+      chain.kernels_[step_state_.instr_idx](context, args);
       // We reset the temp_allocator after the switch statement
       err = context.failure_state();
       if (err != Error::Ok) {

--- a/runtime/executor/method.h
+++ b/runtime/executor/method.h
@@ -48,7 +48,7 @@ class Program;
 class BackendDelegate;
 struct Chain;
 class KernelRuntimeContext;
-using OpFunction = void (*)(KernelRuntimeContext&, EValue**);
+using OpFunction = void (*)(KernelRuntimeContext&, Span<EValue*>);
 /// A list of pointers into the master values table that together compose the
 /// argument list for a single instruction
 using InstructionArgs = Span<EValue*>;

--- a/runtime/executor/test/executor_test.cpp
+++ b/runtime/executor/test/executor_test.cpp
@@ -31,6 +31,7 @@ using executorch::ET_RUNTIME_NAMESPACE::registry_has_op_function;
 using executorch::runtime::Error;
 using executorch::runtime::EValue;
 using executorch::runtime::Result;
+using executorch::runtime::Span;
 using executorch::runtime::testing::TensorFactory;
 
 namespace pytree = ::executorch::extension::pytree;
@@ -165,7 +166,7 @@ TEST_F(ExecutorTest, EValueToScalar) {
   ASSERT_EQ(s.to<int64_t>(), 2);
 }
 
-void test_op(KernelRuntimeContext& /*unused*/, EValue** /*unused*/) {}
+void test_op(KernelRuntimeContext& /*unused*/, Span<EValue*> /*unused*/) {}
 
 TEST_F(ExecutorTest, OpRegistration) {
   auto s1 = register_kernel(Kernel("test", test_op));
@@ -182,7 +183,7 @@ TEST_F(ExecutorTest, OpRegistration) {
 TEST_F(ExecutorTest, OpRegistrationWithContext) {
   auto op = Kernel(
       "test_op_with_context",
-      [](KernelRuntimeContext& context, EValue** values) {
+      [](KernelRuntimeContext& context, Span<EValue*> values) {
         (void)context;
         *(values[0]) = Scalar(100);
       });

--- a/runtime/executor/test/kernel_integration_test.cpp
+++ b/runtime/executor/test/kernel_integration_test.cpp
@@ -38,6 +38,7 @@ using executorch::runtime::MemoryAllocator;
 using executorch::runtime::Method;
 using executorch::runtime::Program;
 using executorch::runtime::Result;
+using executorch::runtime::Span;
 using executorch::runtime::testing::ManagedMemoryManager;
 using torch::executor::util::FileDataLoader;
 
@@ -128,7 +129,7 @@ struct KernelControl {
    */
   static void kernel_hook(
       KernelRuntimeContext& context,
-      ET_UNUSED EValue** args) {
+      ET_UNUSED Span<EValue*> args) {
     auto* control = KernelControl::singleton();
     control->call_count++;
     if (control->call_context_fail) {

--- a/runtime/executor/test/kernel_resolution_test.cpp
+++ b/runtime/executor/test/kernel_resolution_test.cpp
@@ -36,6 +36,7 @@ using executorch::runtime::Method;
 using executorch::runtime::Program;
 using executorch::runtime::register_kernel;
 using executorch::runtime::Result;
+using executorch::runtime::Span;
 using executorch::runtime::TensorMeta;
 using executorch::runtime::testing::ManagedMemoryManager;
 using torch::executor::util::FileDataLoader;
@@ -73,7 +74,9 @@ class KernelResolutionTest : public ::testing::Test {
 TEST_F(KernelResolutionTest, InitExecutionPlanSuccess) {
   // register kernel with fallback kernel key
   Kernel kernel_1 = Kernel(
-      "aten::add.out", {}, [](KernelRuntimeContext& context, EValue** stack) {
+      "aten::add.out",
+      {},
+      [](KernelRuntimeContext& context, Span<EValue*> stack) {
         (void)context;
         *(stack[0]) = Scalar(100);
       });
@@ -105,7 +108,9 @@ TEST_F(KernelResolutionTest, ResolveKernelKeySuccess) {
   //     TensorMeta(ScalarType::Float, contiguous)};
   KernelKey key = KernelKey("v1/6;0,1|6;0,1|6;0,1|6;0,1");
   Kernel kernel_1 = Kernel(
-      "aten::add.out", key, [](KernelRuntimeContext& context, EValue** stack) {
+      "aten::add.out",
+      key,
+      [](KernelRuntimeContext& context, Span<EValue*> stack) {
         (void)context;
         *(stack[0]) = Scalar(100);
       });

--- a/runtime/kernel/operator_registry.h
+++ b/runtime/kernel/operator_registry.h
@@ -43,7 +43,7 @@ namespace executorch {
 namespace ET_RUNTIME_NAMESPACE {
 
 class KernelRuntimeContext; // Forward declaration
-using OpFunction = void (*)(KernelRuntimeContext&, EValue**);
+using OpFunction = void (*)(KernelRuntimeContext&, Span<EValue*>);
 
 /**
  * Dtype and dim order metadata for a Tensor argument to an operator.

--- a/runtime/kernel/test/kernel_double_registration_test.cpp
+++ b/runtime/kernel/test/kernel_double_registration_test.cpp
@@ -21,6 +21,7 @@ using executorch::runtime::EValue;
 using executorch::runtime::Kernel;
 using executorch::runtime::KernelRuntimeContext;
 using executorch::runtime::register_kernels;
+using executorch::runtime::Span;
 
 class KernelDoubleRegistrationTest : public ::testing::Test {
  public:
@@ -33,7 +34,7 @@ TEST_F(KernelDoubleRegistrationTest, Basic) {
   Kernel kernels[] = {Kernel(
       "aten::add.out",
       "v1/7;0,1,2,3|7;0,1,2,3|7;0,1,2,3",
-      [](KernelRuntimeContext&, EValue**) {})};
+      [](KernelRuntimeContext&, Span<EValue*>) {})};
   Error err = Error::RegistrationAlreadyRegistered;
 
   ET_EXPECT_DEATH(

--- a/runtime/kernel/test/operator_registry_max_kernel_num_test.cpp
+++ b/runtime/kernel/test/operator_registry_max_kernel_num_test.cpp
@@ -23,6 +23,7 @@ using executorch::runtime::Kernel;
 using executorch::runtime::KernelRuntimeContext;
 using executorch::runtime::register_kernels;
 using executorch::runtime::registry_has_op_function;
+using executorch::runtime::Span;
 
 class OperatorRegistryMaxKernelNumTest : public ::testing::Test {
  public:
@@ -33,7 +34,8 @@ class OperatorRegistryMaxKernelNumTest : public ::testing::Test {
 
 // Register one kernel when max_kernel_num=1; success
 TEST_F(OperatorRegistryMaxKernelNumTest, RegisterOneOp) {
-  Kernel kernels[] = {Kernel("foo", [](KernelRuntimeContext&, EValue**) {})};
+  Kernel kernels[] = {
+      Kernel("foo", [](KernelRuntimeContext&, Span<EValue*>) {})};
   auto s1 = register_kernels({kernels});
   EXPECT_EQ(s1, Error::Ok);
   EXPECT_FALSE(registry_has_op_function("fpp"));
@@ -43,8 +45,8 @@ TEST_F(OperatorRegistryMaxKernelNumTest, RegisterOneOp) {
 // Register two kernels when max_kernel_num=1; fail
 TEST_F(OperatorRegistryMaxKernelNumTest, RegisterTwoOpsFail) {
   Kernel kernels[] = {
-      Kernel("foo1", [](KernelRuntimeContext&, EValue**) {}),
-      Kernel("foo2", [](KernelRuntimeContext&, EValue**) {})};
+      Kernel("foo1", [](KernelRuntimeContext&, Span<EValue*>) {}),
+      Kernel("foo2", [](KernelRuntimeContext&, Span<EValue*>) {})};
   ET_EXPECT_DEATH(
       { (void)register_kernels({kernels}); },
       "The total number of kernels to be registered is larger than the limit 1");

--- a/runtime/kernel/test/operator_registry_test.cpp
+++ b/runtime/kernel/test/operator_registry_test.cpp
@@ -183,7 +183,8 @@ class OperatorRegistryTest : public ::testing::Test {
 };
 
 TEST_F(OperatorRegistryTest, Basic) {
-  Kernel kernels[] = {Kernel("foo", [](KernelRuntimeContext&, EValue**) {})};
+  Kernel kernels[] = {
+      Kernel("foo", [](KernelRuntimeContext&, Span<EValue*>) {})};
   Span<const Kernel> kernels_span(kernels);
   Error err = register_kernels(kernels_span);
   ASSERT_EQ(err, Error::Ok);
@@ -193,8 +194,8 @@ TEST_F(OperatorRegistryTest, Basic) {
 
 TEST_F(OperatorRegistryTest, RegisterOpsMoreThanOnceDie) {
   Kernel kernels[] = {
-      Kernel("foo", [](KernelRuntimeContext&, EValue**) {}),
-      Kernel("foo", [](KernelRuntimeContext&, EValue**) {})};
+      Kernel("foo", [](KernelRuntimeContext&, Span<EValue*>) {}),
+      Kernel("foo", [](KernelRuntimeContext&, Span<EValue*>) {})};
   Span<const Kernel> kernels_span = Span<const Kernel>(kernels);
   ET_EXPECT_DEATH({ (void)register_kernels(kernels_span); }, "");
 }
@@ -275,7 +276,7 @@ TEST_F(OperatorRegistryTest, RegisterKernels) {
   KernelKey key = KernelKey(buf_long_contiguous.data());
 
   Kernel kernel_1 = Kernel(
-      "test::boo", key, [](KernelRuntimeContext& context, EValue** stack) {
+      "test::boo", key, [](KernelRuntimeContext& context, Span<EValue*> stack) {
         (void)context;
         *(stack[0]) = Scalar(100);
       });
@@ -326,12 +327,16 @@ TEST_F(OperatorRegistryTest, RegisterTwoKernels) {
   ASSERT_EQ(err, Error::Ok);
   KernelKey key_2 = KernelKey(buf_float_contiguous.data());
   Kernel kernel_1 = Kernel(
-      "test::bar", key_1, [](KernelRuntimeContext& context, EValue** stack) {
+      "test::bar",
+      key_1,
+      [](KernelRuntimeContext& context, Span<EValue*> stack) {
         (void)context;
         *(stack[0]) = Scalar(100);
       });
   Kernel kernel_2 = Kernel(
-      "test::bar", key_2, [](KernelRuntimeContext& context, EValue** stack) {
+      "test::bar",
+      key_2,
+      [](KernelRuntimeContext& context, Span<EValue*> stack) {
         (void)context;
         *(stack[0]) = Scalar(50);
       });
@@ -392,12 +397,12 @@ TEST_F(OperatorRegistryTest, DoubleRegisterKernelsDies) {
   KernelKey key = KernelKey(buf_long_contiguous.data());
 
   Kernel kernel_1 = Kernel(
-      "test::baz", key, [](KernelRuntimeContext& context, EValue** stack) {
+      "test::baz", key, [](KernelRuntimeContext& context, Span<EValue*> stack) {
         (void)context;
         *(stack[0]) = Scalar(100);
       });
   Kernel kernel_2 = Kernel(
-      "test::baz", key, [](KernelRuntimeContext& context, EValue** stack) {
+      "test::baz", key, [](KernelRuntimeContext& context, Span<EValue*> stack) {
         (void)context;
         *(stack[0]) = Scalar(50);
       });
@@ -417,7 +422,7 @@ TEST_F(OperatorRegistryTest, ExecutorChecksKernel) {
   KernelKey key = KernelKey(buf_long_contiguous.data());
 
   Kernel kernel_1 = Kernel(
-      "test::qux", key, [](KernelRuntimeContext& context, EValue** stack) {
+      "test::qux", key, [](KernelRuntimeContext& context, Span<EValue*> stack) {
         (void)context;
         *(stack[0]) = Scalar(100);
       });
@@ -453,7 +458,9 @@ TEST_F(OperatorRegistryTest, ExecutorUsesKernel) {
   KernelKey key = KernelKey(buf_long_contiguous.data());
 
   Kernel kernel_1 = Kernel(
-      "test::quux", key, [](KernelRuntimeContext& context, EValue** stack) {
+      "test::quux",
+      key,
+      [](KernelRuntimeContext& context, Span<EValue*> stack) {
         (void)context;
         *(stack[0]) = Scalar(100);
       });
@@ -485,7 +492,7 @@ TEST_F(OperatorRegistryTest, ExecutorUsesFallbackKernel) {
   Kernel kernel_1 = Kernel(
       "test::corge",
       KernelKey{},
-      [](KernelRuntimeContext& context, EValue** stack) {
+      [](KernelRuntimeContext& context, Span<EValue*> stack) {
         (void)context;
         *(stack[0]) = Scalar(100);
       });


### PR DESCRIPTION
Summary: We want to add safety checks inside the kernels on the amount of args they have received. To do that we need a pointer and a length instead of just a pointer. So swapping to span fixes that.

Differential Revision: D78904269


