### PR TITLE
[EXIR] Add dim order aware clone operator

### DIFF
--- a/exir/passes/dim_order_ops_registry.py
+++ b/exir/passes/dim_order_ops_registry.py
@@ -28,6 +28,14 @@ lib.define(
     "_empty_dim_order.out(int[] size, *, int[]? dim_order=None, Tensor(a!) out) -> Tensor(a!)"
 )
 
+lib.define(
+    "_clone_dim_order(Tensor self, *, bool non_blocking=False, int[]? dim_order=None) -> Tensor"
+)
+
+lib.define(
+    "_clone_dim_order.out(Tensor self, *, bool non_blocking=False, int[]? dim_order=None, Tensor(a!) out) -> Tensor(a!)"
+)
+
 
 def _op_impl(target, *args, **kwargs):
     kwargs["memory_format"] = get_memory_format(kwargs.get("dim_order", None))
@@ -57,12 +65,23 @@ def _empty_dim_order_out_impl(*args, **kwargs):
     return _op_impl(torch.ops.aten.empty.out, *args, **kwargs)
 
 
+@impl(lib, "_clone_dim_order", "CompositeImplicitAutograd")
+def _clone_dim_order_impl(*args, **kwargs):
+    return _op_impl(torch.ops.aten.clone.default, *args, **kwargs)
+
+
+@impl(lib, "_clone_dim_order.out", "CompositeImplicitAutograd")
+def _clone_dim_order_out_impl(*args, **kwargs):
+    return _op_impl(torch.ops.aten.clone.out, *args, **kwargs)
+
+
 """
 Defines a map of edge ops to the corresponding dim_order ops for quick lookup
 """
 DimOrderOpsMap = {
     exir_ops.edge.aten._to_copy.default: exir_ops.edge.dim_order_ops._to_dim_order_copy.default,
     exir_ops.edge.aten.empty.memory_format: exir_ops.edge.dim_order_ops._empty_dim_order.default,
+    exir_ops.edge.aten.clone.default: exir_ops.edge.dim_order_ops._clone_dim_order.default,
 }
 
 """

--- a/exir/tests/test_memory_format_ops_pass_utils.py
+++ b/exir/tests/test_memory_format_ops_pass_utils.py
@@ -38,6 +38,10 @@ MemoryFormatOps2Str: Dict[torch._ops.OpOverload, List[str]] = {
         "torch.ops.aten.empty.memory_format",
         "executorch_exir_dialects_edge__ops_dim_order_ops__empty_dim_order_default",
     ),
+    torch.ops.aten.clone.default: (
+        "torch.ops.aten.clone.default",
+        "executorch_exir_dialects_edge__ops_dim_order_ops__clone_dim_order_default",
+    ),
 }
 
 
@@ -68,6 +72,22 @@ class SimpleToCopyChannelsLastModule(torch.nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return x.to(dtype=torch.double, memory_format=torch.channels_last)
+
+
+class SimpleCloneContiguousModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x.clone(memory_format=torch.contiguous_format)
+
+
+class SimpleCloneChannelsLastModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x.clone(memory_format=torch.channels_last)
 
 
 class SimpleEmptyContiguoustModule(torch.nn.Module):

--- a/kernels/aten/cpu/op__clone_dim_order.cpp
+++ b/kernels/aten/cpu/op__clone_dim_order.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <executorch/kernels/aten/cpu/util/copy_ops_util.h>
 #include <executorch/runtime/core/exec_aten/util/dim_order_util.h>
 #include <executorch/runtime/kernel/kernel_includes.h>
 
@@ -13,100 +14,36 @@ namespace torch {
 namespace executor {
 namespace native {
 
+using Tensor = executorch::aten::Tensor;
+using MemoryFormat = executorch::aten::MemoryFormat;
+
 template <typename T>
 using OptionalArrayRef = executorch::aten::OptionalArrayRef<T>;
 
 template <typename T>
 using Optional = std::optional<T>;
 
-using Tensor = executorch::aten::Tensor;
-using MemoryFormat = executorch::aten::MemoryFormat;
-
-namespace {
-// TODO Create shared helper - get_memory_format() and
-// check__clone_dim_order_args() (cpu/op__to_dim_order_copy.cpp)
-
-// Get memory format (contiguous or channels_last) from the dim_order.
-Optional<MemoryFormat> get_memory_format(OptionalArrayRef<int64_t> dim_order) {
-  if (!dim_order.has_value()) {
-    return executorch::aten::nullopt;
-  }
-  if (is_contiguous_dim_order(
-          dim_order.value().data(), dim_order.value().size())) {
-    return MemoryFormat::Contiguous;
-  } else if (is_channels_last_dim_order(
-                 dim_order.value().data(), dim_order.value().size())) {
-    return MemoryFormat::ChannelsLast;
-  } else {
-    ET_ASSERT_UNREACHABLE();
-  }
-}
-
-bool check__clone_dim_order_args(
-    const Tensor& input,
-    bool non_blocking,
-    executorch::aten::OptionalArrayRef<int64_t> dim_order,
-    Tensor& out) {
-  // Right now we only support blocking data transfer
-  ET_LOG_AND_RETURN_IF_FALSE(non_blocking == false);
-
-  // dim_order is set, the target dim_order will be either contiguous or
-  // channels_last memory format
-  if (dim_order.has_value()) {
-    executorch::aten::ArrayRef<int64_t> dim_order_ref = dim_order.value();
-
-    // dim order size shall equal to input dim
-    ET_LOG_AND_RETURN_IF_FALSE(dim_order_ref.size() == input.dim());
-
-    ET_LOG_AND_RETURN_IF_FALSE(
-        is_channels_last_dim_order(
-            dim_order.value().data(), dim_order.value().size()) ||
-        is_contiguous_dim_order(
-            dim_order.value().data(), dim_order.value().size()));
-
-    // Out Aten tensor shall have same memory format stride as dim_order
-    const size_t kMaxNumOfDimensions = 16;
-    ET_LOG_AND_RETURN_IF_FALSE(kMaxNumOfDimensions >= out.dim());
-    executorch::aten::StridesType target_strides[kMaxNumOfDimensions];
-    dim_order_to_stride_nocheck(
-        out.sizes().data(),
-        dim_order_ref.data(),
-        dim_order_ref.size(),
-        target_strides);
-    ET_LOG_AND_RETURN_IF_FALSE(out.dim() == dim_order_ref.size());
-    for (size_t i = 0; i < dim_order_ref.size(); i++) {
-      ET_LOG_AND_RETURN_IF_FALSE(target_strides[i] == out.strides()[i]);
-    }
-
-  } else { // dim_order is not set, preserve the dim order of input
-
-    auto out_strides = out.strides();
-    auto input_strides = input.strides();
-    ET_LOG_AND_RETURN_IF_FALSE(input_strides.size() == out_strides.size());
-    for (size_t i = 0; i < input_strides.size(); i++) {
-      ET_LOG_AND_RETURN_IF_FALSE(input_strides[i] == out_strides[i]);
-    }
-  }
-  return true;
-}
-
-} // namespace
-
-// _clone_dim_order.out(Tensor self, *, bool non_blocking=False, int[]?
-// dim_order=None, Tensor(a!) out) -> Tensor(a!)
+/**
+ * _clone_dim_order.out(Tensor self, *, bool non_blocking=False, int[]?
+ * dim_order=None, Tensor(a!) out) -> Tensor(a!)
+ *
+ * Clones with explicit dim_order, using the corresponding memory format.
+ */
 Tensor& _clone_dim_order_out(
     KernelRuntimeContext& ctx,
     const Tensor& self,
     bool non_blocking,
     OptionalArrayRef<int64_t> dim_order,
     Tensor& out) {
+  // Ensure output has the same layout as input or matches dim_order.
   ET_KERNEL_CHECK(
       ctx,
-      check__clone_dim_order_args(self, non_blocking, dim_order, out),
+      check__to_dim_order_copy_args(self, non_blocking, dim_order, out),
       InvalidArgument,
       out);
+
   Optional<MemoryFormat> memory_format = get_memory_format(dim_order);
-  at::clone_outf(self, non_blocking, memory_format, out);
+  at::clone_outf(self, memory_format, out);
 
   return out;
 }

--- a/kernels/aten/cpu/op__clone_dim_order.cpp
+++ b/kernels/aten/cpu/op__clone_dim_order.cpp
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/runtime/core/exec_aten/util/dim_order_util.h>
+#include <executorch/runtime/kernel/kernel_includes.h>
+
+namespace torch {
+namespace executor {
+namespace native {
+
+template <typename T>
+using OptionalArrayRef = executorch::aten::OptionalArrayRef<T>;
+
+template <typename T>
+using Optional = std::optional<T>;
+
+using Tensor = executorch::aten::Tensor;
+using MemoryFormat = executorch::aten::MemoryFormat;
+
+namespace {
+// TODO Create shared helper - get_memory_format() and
+// check__clone_dim_order_args() (cpu/op__to_dim_order_copy.cpp)
+
+// Get memory format (contiguous or channels_last) from the dim_order.
+Optional<MemoryFormat> get_memory_format(OptionalArrayRef<int64_t> dim_order) {
+  if (!dim_order.has_value()) {
+    return executorch::aten::nullopt;
+  }
+  if (is_contiguous_dim_order(
+          dim_order.value().data(), dim_order.value().size())) {
+    return MemoryFormat::Contiguous;
+  } else if (is_channels_last_dim_order(
+                 dim_order.value().data(), dim_order.value().size())) {
+    return MemoryFormat::ChannelsLast;
+  } else {
+    ET_ASSERT_UNREACHABLE();
+  }
+}
+
+bool check__clone_dim_order_args(
+    const Tensor& input,
+    bool non_blocking,
+    executorch::aten::OptionalArrayRef<int64_t> dim_order,
+    Tensor& out) {
+  // Right now we only support blocking data transfer
+  ET_LOG_AND_RETURN_IF_FALSE(non_blocking == false);
+
+  // dim_order is set, the target dim_order will be either contiguous or
+  // channels_last memory format
+  if (dim_order.has_value()) {
+    executorch::aten::ArrayRef<int64_t> dim_order_ref = dim_order.value();
+
+    // dim order size shall equal to input dim
+    ET_LOG_AND_RETURN_IF_FALSE(dim_order_ref.size() == input.dim());
+
+    ET_LOG_AND_RETURN_IF_FALSE(
+        is_channels_last_dim_order(
+            dim_order.value().data(), dim_order.value().size()) ||
+        is_contiguous_dim_order(
+            dim_order.value().data(), dim_order.value().size()));
+
+    // Out Aten tensor shall have same memory format stride as dim_order
+    const size_t kMaxNumOfDimensions = 16;
+    ET_LOG_AND_RETURN_IF_FALSE(kMaxNumOfDimensions >= out.dim());
+    executorch::aten::StridesType target_strides[kMaxNumOfDimensions];
+    dim_order_to_stride_nocheck(
+        out.sizes().data(),
+        dim_order_ref.data(),
+        dim_order_ref.size(),
+        target_strides);
+    ET_LOG_AND_RETURN_IF_FALSE(out.dim() == dim_order_ref.size());
+    for (size_t i = 0; i < dim_order_ref.size(); i++) {
+      ET_LOG_AND_RETURN_IF_FALSE(target_strides[i] == out.strides()[i]);
+    }
+
+  } else { // dim_order is not set, preserve the dim order of input
+
+    auto out_strides = out.strides();
+    auto input_strides = input.strides();
+    ET_LOG_AND_RETURN_IF_FALSE(input_strides.size() == out_strides.size());
+    for (size_t i = 0; i < input_strides.size(); i++) {
+      ET_LOG_AND_RETURN_IF_FALSE(input_strides[i] == out_strides[i]);
+    }
+  }
+  return true;
+}
+
+} // namespace
+
+// _clone_dim_order.out(Tensor self, *, bool non_blocking=False, int[]?
+// dim_order=None, Tensor(a!) out) -> Tensor(a!)
+Tensor& _clone_dim_order_out(
+    KernelRuntimeContext& ctx,
+    const Tensor& self,
+    bool non_blocking,
+    OptionalArrayRef<int64_t> dim_order,
+    Tensor& out) {
+  ET_KERNEL_CHECK(
+      ctx,
+      check__clone_dim_order_args(self, non_blocking, dim_order, out),
+      InvalidArgument,
+      out);
+  Optional<MemoryFormat> memory_format = get_memory_format(dim_order);
+  at::clone_outf(self, non_blocking, memory_format, out);
+
+  return out;
+}
+
+Tensor& _clone_dim_order_out(
+    const Tensor& self,
+    bool non_blocking,
+    OptionalArrayRef<int64_t> dim_order,
+    Tensor& out) {
+  KernelRuntimeContext ctx{};
+  return _clone_dim_order_out(ctx, self, non_blocking, dim_order, out);
+}
+
+} // namespace native
+} // namespace executor
+} // namespace torch

--- a/kernels/aten/cpu/util/copy_ops_util.cpp
+++ b/kernels/aten/cpu/util/copy_ops_util.cpp
@@ -15,6 +15,28 @@ namespace torch {
 namespace executor {
 
 using Tensor = executorch::aten::Tensor;
+using MemoryFormat = executorch::aten::MemoryFormat;
+
+/**
+ * Determines the memory format (Contiguous or ChannelsLast) corresponding to
+ * the dim_order. Provides support for bridging torch.memory_format with
+ * ExecuTorch's dim_order.
+ */
+std::optional<MemoryFormat> get_memory_format(
+    executorch::aten::OptionalArrayRef<int64_t> dim_order) {
+  if (!dim_order.has_value()) {
+    return executorch::aten::nullopt;
+  }
+  if (is_contiguous_dim_order(
+          dim_order.value().data(), dim_order.value().size())) {
+    return MemoryFormat::Contiguous;
+  } else if (is_channels_last_dim_order(
+                 dim_order.value().data(), dim_order.value().size())) {
+    return MemoryFormat::ChannelsLast;
+  } else {
+    ET_ASSERT_UNREACHABLE();
+  }
+}
 
 bool check__to_dim_order_copy_args(
     const Tensor& input,

--- a/kernels/aten/cpu/util/copy_ops_util.h
+++ b/kernels/aten/cpu/util/copy_ops_util.h
@@ -13,6 +13,9 @@
 namespace torch {
 namespace executor {
 
+std::optional<MemoryFormat> get_memory_format(
+    executorch::aten::OptionalArrayRef<int64_t> dim_order);
+
 bool check__to_dim_order_copy_args(
     const Tensor& input,
     bool non_blocking,

--- a/kernels/aten/edge_dialect_aten_op.yaml
+++ b/kernels/aten/edge_dialect_aten_op.yaml
@@ -11,3 +11,8 @@
   kernels:
     - arg_meta: null
       kernel_name: torch::executor::_to_dim_order_copy_out
+
+- func: dim_order_ops::_clone_dim_order.out(Tensor self, *, bool non_blocking=False, int[]? dim_order=None, Tensor(a!) out) -> Tensor(a!)
+  kernels:
+    - arg_meta: null
+      kernel_name: torch::executor::_clone_dim_order_out

--- a/kernels/portable/cpu/op__clone_dim_order.cpp
+++ b/kernels/portable/cpu/op__clone_dim_order.cpp
@@ -6,10 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <c10/util/irange.h>
-
 #include <executorch/kernels/portable/cpu/scalar_utils.h>
-#include <executorch/kernels/portable/cpu/util/broadcast_util.h>
 #include <executorch/kernels/portable/cpu/util/copy_ops_util.h>
 #include <executorch/runtime/kernel/kernel_includes.h>
 
@@ -22,33 +19,12 @@ using Tensor = executorch::aten::Tensor;
 template <typename T>
 using OptionalArrayRef = executorch::aten::OptionalArrayRef<T>;
 
-namespace {
-// TODO Create shared helper - _clone_dim_order_impl()
-// (portable/op__to_dim_order_copy.cpp)
-
-template <typename SELF_CTYPE, typename OUT_CTYPE>
-void _clone_dim_order_impl(const Tensor& self, Tensor& out) {
-  auto self_data = self.mutable_data_ptr<SELF_CTYPE>();
-  auto out_data = out.mutable_data_ptr<OUT_CTYPE>();
-
-  // Here we make a slightly off-label use of
-  // BroadcastIndexesRange. It always assumes it doesn't have to care
-  // about different dim_order between input and output, but we can
-  // just force it to respect strides (and thus dim_order) for its
-  // inputs using support_noncontiguous_input_tensors=true, and then pretend
-  // the output is just another input.
-  for (const auto [unused_index, self_data_index, out_data_index] :
-       BroadcastIndexesRange<2, /*support_noncontiguous_input_tensors=*/true>(
-           /*dummy output*/ self, self, out)) {
-    (void)unused_index;
-    out_data[out_data_index] =
-        static_cast<OUT_CTYPE>(self_data[self_data_index]);
-  }
-}
-} // namespace
-
-// _clone_dim_order.out(Tensor self, *, bool non_blocking=False, int[]?
-// dim_order=None, Tensor(a!) out) -> Tensor(a!)
+/**
+ * _clone_dim_order.out(Tensor self, *, bool non_blocking=False, int[]?
+ * dim_order=None, Tensor(a!) out) -> Tensor(a!)
+ *
+ * Clones via element-wise copy while preserving dim_order.
+ */
 Tensor& _clone_dim_order_out(
     KernelRuntimeContext& ctx,
     const Tensor& self,
@@ -57,32 +33,35 @@ Tensor& _clone_dim_order_out(
     Tensor& out) {
   (void)ctx;
 
+  // Ensure input and output dtype match.
   ET_KERNEL_CHECK(
       ctx, self.scalar_type() == out.scalar_type(), InvalidArgument, out);
 
+  // Ensure output has the same layout as input or matches dim_order.
   ET_KERNEL_CHECK(
       ctx,
-      check__clone_dim_order_args(self, non_blocking, dim_order, out),
+      check__to_dim_order_copy_args(self, non_blocking, dim_order, out),
       InvalidArgument,
       out);
 
+  // Ensure input and output shapes match, resizing if necessary.
   ET_KERNEL_CHECK(
       ctx,
       resize_tensor(out, self.sizes()) == torch::executor::Error::Ok,
       InvalidArgument,
       out);
 
-  // Return if empty tensor.
   if (self.numel() == 0) {
     return out;
   }
 
+  // Select the correct input dtype and copy the tensors.
   ET_SWITCH_REALHBBF16_TYPES(
       self.scalar_type(),
       ctx,
       "dim_order_ops::_clone_dim_order.out",
       CTYPE,
-      [&] { _clone_dim_order_impl<CTYPE, CTYPE>(self, out); });
+      [&] { _to_dim_order_copy_impl<CTYPE, CTYPE>(self, out); });
 
   return out;
 }

--- a/kernels/portable/cpu/op__clone_dim_order.cpp
+++ b/kernels/portable/cpu/op__clone_dim_order.cpp
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <c10/util/irange.h>
+
+#include <executorch/kernels/portable/cpu/scalar_utils.h>
+#include <executorch/kernels/portable/cpu/util/broadcast_util.h>
+#include <executorch/kernels/portable/cpu/util/copy_ops_util.h>
+#include <executorch/runtime/kernel/kernel_includes.h>
+
+namespace torch {
+namespace executor {
+namespace native {
+
+using Tensor = executorch::aten::Tensor;
+
+template <typename T>
+using OptionalArrayRef = executorch::aten::OptionalArrayRef<T>;
+
+namespace {
+// TODO Create shared helper - _clone_dim_order_impl()
+// (portable/op__to_dim_order_copy.cpp)
+
+template <typename SELF_CTYPE, typename OUT_CTYPE>
+void _clone_dim_order_impl(const Tensor& self, Tensor& out) {
+  auto self_data = self.mutable_data_ptr<SELF_CTYPE>();
+  auto out_data = out.mutable_data_ptr<OUT_CTYPE>();
+
+  // Here we make a slightly off-label use of
+  // BroadcastIndexesRange. It always assumes it doesn't have to care
+  // about different dim_order between input and output, but we can
+  // just force it to respect strides (and thus dim_order) for its
+  // inputs using support_noncontiguous_input_tensors=true, and then pretend
+  // the output is just another input.
+  for (const auto [unused_index, self_data_index, out_data_index] :
+       BroadcastIndexesRange<2, /*support_noncontiguous_input_tensors=*/true>(
+           /*dummy output*/ self, self, out)) {
+    (void)unused_index;
+    out_data[out_data_index] =
+        static_cast<OUT_CTYPE>(self_data[self_data_index]);
+  }
+}
+} // namespace
+
+// _clone_dim_order.out(Tensor self, *, bool non_blocking=False, int[]?
+// dim_order=None, Tensor(a!) out) -> Tensor(a!)
+Tensor& _clone_dim_order_out(
+    KernelRuntimeContext& ctx,
+    const Tensor& self,
+    bool non_blocking,
+    OptionalArrayRef<int64_t> dim_order,
+    Tensor& out) {
+  (void)ctx;
+  ET_KERNEL_CHECK(
+      ctx,
+      check__clone_dim_order_args(self, non_blocking, dim_order, out),
+      InvalidArgument,
+      out);
+
+  ET_KERNEL_CHECK(
+      ctx,
+      resize_tensor(out, self.sizes()) == torch::executor::Error::Ok,
+      InvalidArgument,
+      out);
+
+  // Return if empty tensor.
+  if (self.numel() == 0) {
+    return out;
+  }
+
+  ET_SWITCH_REALHBBF16_TYPES(
+      self.scalar_type(),
+      ctx,
+      "dim_order_ops::_clone_dim_order.out",
+      CTYPE_IN,
+      [&] {
+        ET_SWITCH_REALHBBF16_TYPES(
+            out.scalar_type(),
+            ctx,
+            "dim_order_ops::_clone_dim_order.out",
+            CTYPE_OUT,
+            [&] { _clone_dim_order_impl<CTYPE_IN, CTYPE_OUT>(self, out); });
+      });
+
+  return out;
+}
+
+Tensor& _clone_dim_order_out(
+    const Tensor& self,
+    bool non_blocking,
+    OptionalArrayRef<int64_t> dim_order,
+    Tensor& out) {
+  executorch::ET_RUNTIME_NAMESPACE::KernelRuntimeContext context{};
+  return _clone_dim_order_out(context, self, non_blocking, dim_order, out);
+}
+
+} // namespace native
+} // namespace executor
+} // namespace torch

--- a/kernels/portable/cpu/op__clone_dim_order.cpp
+++ b/kernels/portable/cpu/op__clone_dim_order.cpp
@@ -56,6 +56,10 @@ Tensor& _clone_dim_order_out(
     OptionalArrayRef<int64_t> dim_order,
     Tensor& out) {
   (void)ctx;
+
+  ET_KERNEL_CHECK(
+      ctx, self.scalar_type() == out.scalar_type(), InvalidArgument, out);
+
   ET_KERNEL_CHECK(
       ctx,
       check__clone_dim_order_args(self, non_blocking, dim_order, out),
@@ -77,15 +81,8 @@ Tensor& _clone_dim_order_out(
       self.scalar_type(),
       ctx,
       "dim_order_ops::_clone_dim_order.out",
-      CTYPE_IN,
-      [&] {
-        ET_SWITCH_REALHBBF16_TYPES(
-            out.scalar_type(),
-            ctx,
-            "dim_order_ops::_clone_dim_order.out",
-            CTYPE_OUT,
-            [&] { _clone_dim_order_impl<CTYPE_IN, CTYPE_OUT>(self, out); });
-      });
+      CTYPE,
+      [&] { _clone_dim_order_impl<CTYPE, CTYPE>(self, out); });
 
   return out;
 }

--- a/kernels/portable/cpu/util/copy_ops_util.cpp
+++ b/kernels/portable/cpu/util/copy_ops_util.cpp
@@ -802,47 +802,6 @@ bool check__to_dim_order_copy_args(
   return true;
 }
 
-// TODO Create shared helper - check__to_dim_order_copy_args()
-bool check__clone_dim_order_args(
-    const Tensor& input,
-    bool non_blocking,
-    executorch::aten::OptionalArrayRef<int64_t> dim_order,
-    Tensor& out) {
-  // Right now we only support blocking data transfer
-  ET_LOG_AND_RETURN_IF_FALSE(non_blocking == false);
-
-  if (dim_order.has_value()) {
-    executorch::aten::ArrayRef<int64_t> dim_order_ref = dim_order.value();
-
-    // dim order size shall equal to input dim
-    ET_LOG_AND_RETURN_IF_FALSE(
-        static_cast<ssize_t>(dim_order_ref.size()) == input.dim());
-
-    ET_LOG_AND_RETURN_IF_FALSE(
-        is_channels_last_dim_order(
-            dim_order.value().data(), dim_order.value().size()) ||
-        is_contiguous_dim_order(
-            dim_order.value().data(), dim_order.value().size()));
-
-    // Out tensor shall have same dim order as dim_order
-    auto out_dim_order = out.dim_order();
-    ET_LOG_AND_RETURN_IF_FALSE(out_dim_order.size() == dim_order_ref.size());
-    for (const auto i : c10::irange(dim_order_ref.size())) {
-      ET_LOG_AND_RETURN_IF_FALSE(out_dim_order[i] == dim_order_ref[i]);
-    }
-  } else { // dim_order is not set, preserve the dim order of input
-
-    // Out tensor shall have same dim order as input dim_order
-    auto out_dim_order = out.dim_order();
-    auto input_dim_order = input.dim_order();
-    ET_LOG_AND_RETURN_IF_FALSE(out_dim_order.size() == input_dim_order.size());
-    for (const auto i : c10::irange(input_dim_order.size())) {
-      ET_LOG_AND_RETURN_IF_FALSE(out_dim_order[i] == input_dim_order[i]);
-    }
-  }
-  return true;
-}
-
 bool check_unsqueeze_copy_args(
     const Tensor input,
     int64_t dim,

--- a/kernels/portable/cpu/util/copy_ops_util.cpp
+++ b/kernels/portable/cpu/util/copy_ops_util.cpp
@@ -802,6 +802,47 @@ bool check__to_dim_order_copy_args(
   return true;
 }
 
+// TODO Create shared helper - check__to_dim_order_copy_args()
+bool check__clone_dim_order_args(
+    const Tensor& input,
+    bool non_blocking,
+    executorch::aten::OptionalArrayRef<int64_t> dim_order,
+    Tensor& out) {
+  // Right now we only support blocking data transfer
+  ET_LOG_AND_RETURN_IF_FALSE(non_blocking == false);
+
+  if (dim_order.has_value()) {
+    executorch::aten::ArrayRef<int64_t> dim_order_ref = dim_order.value();
+
+    // dim order size shall equal to input dim
+    ET_LOG_AND_RETURN_IF_FALSE(
+        static_cast<ssize_t>(dim_order_ref.size()) == input.dim());
+
+    ET_LOG_AND_RETURN_IF_FALSE(
+        is_channels_last_dim_order(
+            dim_order.value().data(), dim_order.value().size()) ||
+        is_contiguous_dim_order(
+            dim_order.value().data(), dim_order.value().size()));
+
+    // Out tensor shall have same dim order as dim_order
+    auto out_dim_order = out.dim_order();
+    ET_LOG_AND_RETURN_IF_FALSE(out_dim_order.size() == dim_order_ref.size());
+    for (const auto i : c10::irange(dim_order_ref.size())) {
+      ET_LOG_AND_RETURN_IF_FALSE(out_dim_order[i] == dim_order_ref[i]);
+    }
+  } else { // dim_order is not set, preserve the dim order of input
+
+    // Out tensor shall have same dim order as input dim_order
+    auto out_dim_order = out.dim_order();
+    auto input_dim_order = input.dim_order();
+    ET_LOG_AND_RETURN_IF_FALSE(out_dim_order.size() == input_dim_order.size());
+    for (const auto i : c10::irange(input_dim_order.size())) {
+      ET_LOG_AND_RETURN_IF_FALSE(out_dim_order[i] == input_dim_order[i]);
+    }
+  }
+  return true;
+}
+
 bool check_unsqueeze_copy_args(
     const Tensor input,
     int64_t dim,

--- a/kernels/portable/cpu/util/copy_ops_util.h
+++ b/kernels/portable/cpu/util/copy_ops_util.h
@@ -9,6 +9,7 @@
 #pragma once
 #include <c10/util/irange.h>
 
+#include <executorch/kernels/portable/cpu/util/broadcast_util.h>
 #include <executorch/runtime/kernel/kernel_includes.h>
 
 namespace torch {
@@ -74,6 +75,29 @@ void as_strided_copy(
     out_data[0] = in_data[0];
   } else {
     _as_strided_copy<CTYPE>(in_data, out_data, out, size, stride, 0);
+  }
+}
+
+/**
+ * Copies and casts a tensor while preserving input dim_order.
+ */
+template <typename SELF_CTYPE, typename OUT_CTYPE>
+void _to_dim_order_copy_impl(const Tensor& self, Tensor& out) {
+  auto self_data = self.mutable_data_ptr<SELF_CTYPE>();
+  auto out_data = out.mutable_data_ptr<OUT_CTYPE>();
+
+  // Here we make a slightly off-label use of
+  // BroadcastIndexesRange. It always assumes it doesn't have to care
+  // about different dim_order between input and output, but we can
+  // just force it to respect strides (and thus dim_order) for its
+  // inputs using support_noncontiguous_input_tensors=true, and then pretend
+  // the output is just another input.
+  for (const auto [unused_index, self_data_index, out_data_index] :
+       BroadcastIndexesRange<2, /*support_noncontiguous_input_tensors=*/true>(
+           /*dummy output*/ self, self, out)) {
+    (void)unused_index;
+    out_data[out_data_index] =
+        static_cast<OUT_CTYPE>(self_data[self_data_index]);
   }
 }
 
@@ -205,13 +229,6 @@ bool check_to_copy_args(
     Tensor& out);
 
 bool check__to_dim_order_copy_args(
-    const Tensor& input,
-    bool non_blocking,
-    executorch::aten::OptionalArrayRef<int64_t> dim_order,
-    Tensor& out);
-
-// TODO Create shared helper - check__to_dim_order_copy_args()
-bool check__clone_dim_order_args(
     const Tensor& input,
     bool non_blocking,
     executorch::aten::OptionalArrayRef<int64_t> dim_order,

--- a/kernels/portable/cpu/util/copy_ops_util.h
+++ b/kernels/portable/cpu/util/copy_ops_util.h
@@ -210,6 +210,13 @@ bool check__to_dim_order_copy_args(
     executorch::aten::OptionalArrayRef<int64_t> dim_order,
     Tensor& out);
 
+// TODO Create shared helper - check__to_dim_order_copy_args()
+bool check__clone_dim_order_args(
+    const Tensor& input,
+    bool non_blocking,
+    executorch::aten::OptionalArrayRef<int64_t> dim_order,
+    Tensor& out);
+
 bool check_unsqueeze_copy_args(
     const Tensor input,
     int64_t dim,

--- a/kernels/portable/functions.yaml
+++ b/kernels/portable/functions.yaml
@@ -1009,3 +1009,8 @@
   kernels:
     - arg_meta: null
       kernel_name: torch::executor::_to_dim_order_copy_out
+
+- func: dim_order_ops::_clone_dim_order.out(Tensor self, *, bool non_blocking=False, int[]? dim_order=None, Tensor(a!) out) -> Tensor(a!)
+  kernels:
+    - arg_meta: null
+      kernel_name: torch::executor::_clone_dim_order_out


### PR DESCRIPTION
### Summary
Currently, clone ops are removed during export as no-ops, causing memory layout (dim order) changes to be lost. This can cause backend failures, incorrect outputs when ops expect specific layouts, and performance degradation.

This PR adds a dim order aware clone op, `clone_dim_order`, that preserves memory layout changes by explicitly storing dim order information. It's implemented by replacing standard clone ops with this variant during export and updating the clone removal transform to preserve clones that change layout.

Fixes #12645 

### Test plan
Tests were added to verify:
- `clone_dim_order` kernel implementation
- Preservation of dim order changes
- Removal of no-op clones (dim order not changed)

All tests passed via:
`python -m unittest exir.tests.test_memory_format_ops_pass`
