### PR TITLE
Arm backend: Handle None arg for creating empty TosaArg

### DIFF
--- a/backends/arm/tosa_mapping.py
+++ b/backends/arm/tosa_mapping.py
@@ -102,8 +102,6 @@ class TosaArg:
     def __init__(
         self, argument: Any, tosa_spec: Optional[TosaSpecification] = None
     ) -> None:
-        if argument is None:
-            return
         if tosa_spec is None:
             raise ValueError("tosa_spec is None")
         elif not isinstance(tosa_spec, TosaSpecification):
@@ -123,6 +121,13 @@ class TosaArg:
             return
         if isinstance(argument, torch.dtype):
             # Dtype is parsed from fake tensor
+            return
+
+        if argument is None:
+            self.name = ""
+            self.dtype = None
+            self.shape = None
+            self.dim_order = None
             return
 
         raise RuntimeError(


### PR DESCRIPTION
### Summary
In order to get the same number and order of arguments from fx.Node.args and the list[TosaArg] used in nodevisitor, we need to allow for empty (None) args. The empty TosaArg is represented with fields set to None and empty string for name.


cc @digantdesai @freddan80 @zingo @oscarandersson8218