### PR TITLE
Arm backend: Move the portable kernels section to bigger memory

### DIFF
--- a/examples/arm/ethos-u-setup/core_platform/0003-Move-the-portable-kernels-to-the-BRAM.patch
+++ b/examples/arm/ethos-u-setup/core_platform/0003-Move-the-portable-kernels-to-the-BRAM.patch
@@ -1,0 +1,42 @@
+From 81f5bd9092bc25c343d8d85b692698c6d961d0bd Mon Sep 17 00:00:00 2001
+From: George Gekov <george.gekov@arm.com>
+Date: Mon, 28 Jul 2025 15:23:50 +0100
+Subject: [PATCH] Move the portable kernels to the BRAM
+
+On the Corstone-300, we have 512KB of ITCM and by default,
+the .text section lives in the ITCM. However, as we build more
+portable kernels, we sometimes overflow and the .text section
+no longer fits in the ITCM. This patch moves the portable kernels
+to the BRAM as we have 1MB of BRAM
+---
+ targets/corstone-300/platform.ld | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/targets/corstone-300/platform.ld b/targets/corstone-300/platform.ld
+index 5043be2..399e9f7 100644
+--- a/targets/corstone-300/platform.ld
++++ b/targets/corstone-300/platform.ld
+@@ -135,7 +135,11 @@ SECTIONS
+   {
+     _vectors = .;
+     KEEP(*(.vectors))
+-    *(.text*)
++    *(EXCLUDE_FILE(
++                  *op_*.cpp.obj
++                   )
++
++    .text*)
+ 
+     KEEP(*(.init))
+     KEEP(*(.fini))
+@@ -299,6 +303,7 @@ SECTIONS
+     __sram_data_start__ = .;
+     *(.sram.data)
+     . = ALIGN(4);
++    *op_*.cpp.obj (*.text*)
+     __sram_data_end__ = .;
+   } > BRAM AT >DDR :rom_dram
+ 
+-- 
+2.39.5 (Apple Git-154)
+


### PR DESCRIPTION
This patch moves the portable kernels from the ITCM to the BRAM so that we don't overflow on the ITCM when linking the application



cc @digantdesai @freddan80 @per @zingo @oscarandersson8218