### PR TITLE
Qualcomm AI Engine Direct - Support simple_eval in calibration, perpl…

### DIFF
--- a/examples/qualcomm/oss_scripts/llama/README.md
+++ b/examples/qualcomm/oss_scripts/llama/README.md
@@ -114,11 +114,14 @@ We have two distinct mechanisms for updating the key-value (KV) cache, which can
 </table>
 
 ### Additional Configs when running the script
+
+#### Compile Only
 If you would like to compile the model only, we have provided the flag `--compile_only`. Taking LLAMA3.2 as an example:
 ```bash
 python examples/qualcomm/oss_scripts/llama/llama.py -b build-android -m ${SOC_MODEL} --ptq 16a4w --checkpoint consolidated.00.pth --params params.json --tokenizer_model tokenizer.model --llama_model llama3_2 --model_mode hybrid --prefill_ar_len 32 --max_seq_len 128 --prompt "what is 1+1" --compile_only
 ```
 
+#### Pre Generated PTE
 On the other hand, if you already have a pre-compiled .pte model, you can perform inference by providing the flag `--pre_gen_pte` and specifying the folder that contains the .pte model. Taking LLAMA3.2 as an example:
 ```bash
 python examples/qualcomm/oss_scripts/llama/llama.py -b build-android -s ${SERIAL_NUM} -m ${SOC_MODEL} --ptq 16a4w --checkpoint consolidated.00.pth --params params.json --tokenizer_model tokenizer.model --llama_model llama3_2 --model_mode hybrid --prefill_ar_len 32 --max_seq_len 128 --prompt "what is 1+1" --pre_gen_pte ${FOLDER_TO_PRE_GEN_PTE}
@@ -149,3 +152,28 @@ python examples/qualcomm/oss_scripts/llama/llama.py -b build-android -s ${SERIAL
 
 You can enable MaskedSoftmax feature by providing the flag `--enable_masked_softmax`. It is designed to optimize the LLMs accuracy and performance executed on HTP backend. MaskedSoftmax is used to replace the Softmax(Add(In, Mask)) structure in attention block in LLMs during backend optimization. For more details, please refer to QNN documents.
 Note that it is only supported starting from QNN 2.35.
+
+#### Perplexity Evaluation
+This script supports perplexity evaluation and is capable of assessing perplexity scores across 3 phases: prepare_pt2e(CPU FP), convert_pt2e(CPU QDQ), QNN on device.
+
+To evaluate the perplexity across all 3 phases, users should provide the `--eval_perplexity` flag and specify the evaluation task. Please notice when this flag is provided, the `--prompt ${PROMPT}` will be ignored.
+
+For example, using the Qwen model and 1 wikitext sample as the evaluation task, users can assess all 3 phases perplexity score in a single run by including the appropriate configuration:
+```bash
+python examples/qualcomm/oss_scripts/llama/llama.py -b build-android -s ${SERIAL_NUM} -m ${SOC_MODEL} --prompt "What is 1+1?" --temperature 0 --model_mode kv --max_seq_len 1024 --ptq 16a8w --decoder_model qwen2_5 --eval_perplexity --tasks wikitext --limit 1
+```
+
+For the example script above, 1 wikitext sample is used to evaluate all 3 phases. However, there are cases where a user may want to use one sample for quantization calibration and multiple samples for perplexity evaluation. In this case, the process should be split into two runs. In the 1st run, the model is compiled using one sample. In the 2nd run, the user can provide a different configuration for QNN device execution.
+Example:
+```bash
+# 1st run to compile with --limit 1
+python examples/qualcomm/oss_scripts/llama/llama.py -b build-android -s ${SERIAL_NUM} -m ${SOC_MODEL} --prompt "What is 1+1?" --temperature 0 --model_mode kv --max_seq_len 1024 --ptq 16a8w --decoder_model qwen2_5 --eval_perplexity --tasks wikitext --limit 1 --compile_only
+```
+```bash
+# 2nd run to perform QNN device execution with --limit 3
+python examples/qualcomm/oss_scripts/llama/llama.py -b build-android -s ${SERIAL_NUM} -m ${SOC_MODEL} --prompt "What is 1+1?" --temperature 0 --model_mode kv --max_seq_len 1024 --ptq 16a8w --decoder_model qwen2_5 --eval_perplexity --tasks wikitext --limit 3 --pre_gen_pte ${PATH_TO_ARTIFACT_IN_1ST_RUN} --quant_attrs_path ${PATH_TO_ARTIFACT_IN_1ST_RUN}/kv_llama_qnn_quant_attrs.json
+```
+
+#### Tasks quantization calibration
+If `--tasks ${TASK}` is not provided, the program will use `--prompt ${PROMPT}` as the dataset for quantization calibration.
+Regardless of whether `--eval_perplexity` is provided, as long as `--tasks ${TASK}` is specified, the specified tasks will be used for model quantization calibration instead of the prompt.

--- a/examples/qualcomm/oss_scripts/llama/decoder_constants.py
+++ b/examples/qualcomm/oss_scripts/llama/decoder_constants.py
@@ -1,0 +1,20 @@
+# Copyright (c) Qualcomm Innovation Center, Inc.
+# All rights reserved
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+HUGGING_FACE_REPO_IDS = {"qwen2_5": "Qwen/Qwen2.5-0.5B"}
+
+EVAL_MODE = {
+    "kv": 0,
+    "hybrid": 1,
+    "lookahead": 2,
+}
+
+DECODER_MODEL_VERSION = {
+    "stories260k": "llama2",
+    "stories110m": "llama2",
+    "llama3_2": "llama3",
+    "qwen2_5": "qwen2_5",
+}

--- a/examples/qualcomm/oss_scripts/llama/decoder_utils.py
+++ b/examples/qualcomm/oss_scripts/llama/decoder_utils.py
@@ -1,0 +1,454 @@
+# Copyright (c) Qualcomm Innovation Center, Inc.
+# All rights reserved
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import getpass
+import json
+import logging
+import os
+from typing import Callable, Optional, Union
+
+import numpy as np
+
+import torch
+from executorch.examples.models.llama.evaluate.eager_eval import EagerEvalWrapper
+
+from executorch.examples.qualcomm.oss_scripts.llama.decoder_constants import (
+    DECODER_MODEL_VERSION,
+    EVAL_MODE,
+)
+
+from executorch.examples.qualcomm.utils import make_output_dir, SimpleADB
+from executorch.exir._serialize._program import deserialize_pte_binary
+from pytorch_tokenizers.hf_tokenizer import HuggingFaceTokenizer
+from pytorch_tokenizers.llama2c import Llama2cTokenizer as SentencePieceTokenizer
+from pytorch_tokenizers.tiktoken import TiktokenTokenizer
+
+try:
+    from lm_eval.evaluator import simple_evaluate
+except ImportError:
+    raise ImportError(
+        "Please install the llm eval dependency via examples/models/llama/install_requirements.sh"
+    )
+
+
+class GraphModuleCalibrationWrapper(EagerEvalWrapper):
+    """
+    A wrapper class for calibration
+    """
+
+    def __init__(
+        self,
+        model: torch.fx.GraphModule,
+        tokenizer: Union[
+            SentencePieceTokenizer, TiktokenTokenizer, HuggingFaceTokenizer
+        ],
+        max_seq_length: Optional[int],
+        ar_len: int,
+        use_kv_cache: bool,
+        get_example_inputs: Callable,
+        kv_updater: Callable,
+        use_i64_token: bool,
+    ):
+        # n seq len = n-1 cache len, so we len(inps) = n-1 during _model_call
+        super().__init__(
+            model=model, tokenizer=tokenizer, max_seq_length=max_seq_length - 1
+        )
+        self._model = model.to(self.device)
+        self.ar_len = ar_len
+        self._use_kv_cache = use_kv_cache
+        self.get_example_inputs = get_example_inputs
+        self.max_seq_length = max_seq_length
+        self.kv_updater = kv_updater
+        self.use_i64_token = use_i64_token
+
+    def _model_call(self, inps):
+        all_logits = None
+        if self._use_kv_cache:
+            all_logits = kv_inference(
+                self.get_example_inputs,
+                inps,
+                self._model,
+                self._tokenizer,
+                self.ar_len,
+                self.max_seq_length,
+                kv_updater=self.kv_updater,
+                use_i64_token=self.use_i64_token,
+                collect_logits=True,
+            )
+        else:
+            all_logits = prefill_inference(
+                self.get_example_inputs,
+                inps,
+                self._model,
+                self._tokenizer,
+                self.ar_len,
+                self.max_seq_length,
+                use_i64_token=self.use_i64_token,
+                collect_logits=True,
+            )
+        return all_logits
+
+
+class QnnRunnerEvalWrapper(EagerEvalWrapper):
+    """
+    A wrapper class to run PPL scores with QNN on device.
+    """
+
+    def __init__(
+        self,
+        args,
+        pte_path: str,
+        tokenizer: Union[
+            SentencePieceTokenizer, TiktokenTokenizer, HuggingFaceTokenizer
+        ],
+        runtime_tokenizer_path,
+        max_seq_length: int,
+    ):
+        self.args = args
+        self.pte_path = pte_path
+
+        with open(pte_path, "rb") as f:
+            program_data = f.read()
+        program = deserialize_pte_binary(program_data)
+
+        # Retrieve vocab_size from get_metadata under static_llama that is passed to edge manager
+        self.output_vocab_size = None
+        pte_max_seq_len = None
+        for method in program.execution_plan:
+            # Don't use tokenizer.n_words, the numbers are off once calling get_tokenizer()
+            if method.name == "get_vocab_size":
+                self.output_vocab_size = method.values[0].val.int_val
+            if method.name == "get_max_seq_len":
+                pte_max_seq_len = method.values[0].val.int_val
+        assert self.output_vocab_size is not None, "Couldn't find the vocab size"
+        assert pte_max_seq_len is not None, "Couldn't find the max_seq_len from pte"
+        if pte_max_seq_len != max_seq_length:
+            logging.warning(
+                f"The pte provided has a max_seq_len {pte_max_seq_len}, which is different from --max_seq_len {max_seq_length} provided to the script, please ensure this is desired."
+            )
+            if pte_max_seq_len < max_seq_length:
+                logging.warning(
+                    f"The pte max_seq_len {pte_max_seq_len} is used since it is shorter than --max_seq_len {max_seq_length}"
+                )
+                max_seq_length = pte_max_seq_len
+        self.max_seq_length = max_seq_length
+
+        assert (
+            args.quant_attrs_path is not None
+        ), "Please provide path to quant_attrs json file"
+        self.quant_attrs = json.load(open(args.quant_attrs_path))
+        self.runtime_tokenizer_path = runtime_tokenizer_path
+
+        self.output_dir = args.artifact
+
+        self.workspace = f"/data/local/tmp/{getpass.getuser()}/executorch/single_llama"
+        self.adb = SimpleADB(
+            qnn_sdk=os.getenv("QNN_SDK_ROOT"),
+            build_path=args.build_folder,
+            pte_path=pte_path,
+            workspace=self.workspace,
+            device_id=args.device,
+            host_id=args.host,
+            soc_model=args.model,
+            runner="examples/qualcomm/oss_scripts/llama/qnn_llama_runner",
+        )
+        self.adb.push(inputs=[], input_list="", files=[self.runtime_tokenizer_path])
+        # n seq len = n-1 cache len, so we len(inps) = n-1 during _model_call
+        super().__init__(None, tokenizer, max_seq_length - 1)
+
+    def _model_call(self, inps):
+
+        input_file_name = f"{self.args.artifact}/input_tokens.raw"
+        inps = inps.to(torch.uint64).numpy()
+        inps.tofile(input_file_name)
+
+        outputs_path = "outputs/outputs.txt"
+        dump_logits_path = "outputs/all_logit.raw"
+        performance_output_path = "outputs/inference_speed.txt"
+        runner_cmd = " ".join(
+            [
+                f"cd {self.workspace} &&",
+                "./qnn_llama_runner",
+                f"--decoder_model_version {DECODER_MODEL_VERSION[self.args.decoder_model]}",
+                f"--tokenizer_path {os.path.basename(self.runtime_tokenizer_path)}",
+                f"--model_path {os.path.basename(self.pte_path)}",
+                f"--seq_len {self.max_seq_length}",
+                f"--output_path {outputs_path}",
+                f"--performance_output_path {performance_output_path}",
+                f"--kv_updater {'SmartMask' if self.args.kv_updater == smart_mask_updater else 'ShiftPointer'}",
+                f"--window {self.args.window}",
+                f"--gcap {self.args.gcap}",
+                f"--ngram {self.args.ngram}",
+                f"--eval_mode {EVAL_MODE[self.args.model_mode]}",
+                "--temperature 0",
+                f"--dump_logits_path {dump_logits_path}",
+                f"--tokenized_prompt {os.path.basename(input_file_name)}",
+            ]
+        )
+
+        self.adb.push(inputs=[], input_list="", files=[input_file_name], init_env=False)
+        self.adb.execute(custom_runner_cmd=runner_cmd)
+        output_data_folder = f"{self.output_dir}/outputs"
+        make_output_dir(output_data_folder)
+        output_tensor_list = []
+
+        def post_process():
+            with open(f"{self.args.artifact}/{dump_logits_path}", "r") as f:
+                output_tensor = torch.from_numpy(
+                    np.fromfile(f.name, dtype=np.uint16).reshape(
+                        1, -1, self.output_vocab_size
+                    )
+                )
+                output_tensor = (
+                    output_tensor.to(torch.float32) - self.quant_attrs["zero_point"]
+                ) * self.quant_attrs["scale"]
+                output_tensor_list.append(output_tensor)
+
+            # simple_eval will run multiple rounds, use last run for inference speed
+            with open(f"{self.args.artifact}/{performance_output_path}", "r") as f:
+                self.inference_speed = float(f.read())
+
+        self.adb.pull(output_path=self.output_dir, callback=post_process)
+        return output_tensor_list[0]
+
+
+def smart_mask_updater(
+    ar_len, atten_mask, pos, k_caches, v_caches, new_k_caches, new_v_caches
+):
+    # Update the KV cache input for the next inference when the position exceeds the autoregressive length.
+    if pos >= ar_len:
+        for i, k_cache in enumerate(k_caches):
+            k_cache[:, :, pos - ar_len] = new_k_caches[i][:, :, 0]
+
+        for i, v_cache in enumerate(v_caches):
+            v_cache[:, pos - ar_len, :] = new_v_caches[i][:, 0, :]
+        atten_mask[:, :, pos - ar_len] = 0
+
+    pos += 1
+    return (atten_mask, pos, k_caches, v_caches)
+
+
+def shift_pointer_updater(
+    ar_len, atten_mask, pos, k_caches, v_caches, new_k_caches, new_v_caches
+):
+    # Update the KV cache input for the next inference when the position exceeds the autoregressive length.
+    if pos >= ar_len:
+        k_caches = [
+            torch.cat([k_cache[:, :, 1:], new_k_caches[i][:, :, :1]], dim=-1)
+            for i, k_cache in enumerate(k_caches)
+        ]
+        v_caches = [
+            torch.cat([v_cache[:, 1:, :], new_v_caches[i][:, :1, :]], dim=1)
+            for i, v_cache in enumerate(v_caches)
+        ]
+        atten_mask[:, :, -pos - 1] = 0
+
+    pos += 1
+    return (atten_mask, pos, k_caches, v_caches)
+
+
+def kv_inference(
+    get_example_inputs,
+    prompt: Union[str, list],
+    module: torch.fx.GraphModule,
+    tokenizer,
+    ar_len=1,
+    max_seq_len=512,
+    kv_updater=smart_mask_updater,
+    use_i64_token=False,
+    collect_logits=False,
+):
+    _, atten_mask, _, k_caches, v_caches = get_example_inputs(use_kv_cache=True)
+
+    # TODO: change criteria & support batch inputs if necessary
+    all_pos = torch.arange(0, max_seq_len, 1, dtype=torch.int32).unsqueeze(0)
+
+    token_list, result_logits = [], []
+
+    if isinstance(prompt, str):
+        # Llama2 tokenizer has no special tokens
+        if isinstance(tokenizer, (SentencePieceTokenizer, HuggingFaceTokenizer)):
+            token_list = tokenizer.encode(prompt, bos=True, eos=False)
+        elif isinstance(tokenizer, TiktokenTokenizer):
+            token_list = tokenizer.encode(
+                prompt, bos=True, eos=False, allowed_special="all"
+            )
+        else:
+            raise RuntimeError("Unknown tokenizer")
+    else:
+        token_list = prompt.flatten().tolist()
+    pos = len(token_list) if len(token_list) < ar_len else ar_len
+    dtype = torch.int64 if use_i64_token else torch.int32
+
+    with torch.no_grad():
+        while token_list[-1] != tokenizer.eos_id and pos < max_seq_len:
+            tmp_token_list = torch.tensor(
+                token_list[pos - ar_len : pos], dtype=dtype
+            ).reshape(1, -1)
+            tmp_pos = all_pos[:, pos - ar_len : pos]
+            tmp_atten_mask = atten_mask
+            if pos < ar_len:
+                tmp_token_list = torch.cat(
+                    [
+                        torch.zeros((1, ar_len - pos), dtype=dtype),
+                        torch.tensor(token_list, dtype=dtype).reshape(1, -1),
+                    ],
+                    dim=1,
+                )
+                tmp_pos = torch.cat(
+                    [
+                        torch.zeros((1, ar_len - pos), dtype=torch.int32),
+                        all_pos[:, :pos],
+                    ],
+                    dim=1,
+                )
+                tmp_atten_mask = torch.cat(
+                    [
+                        torch.ones(1, ar_len, max_seq_len - pos) * -255.0,
+                        atten_mask[:, :, -pos:],
+                    ],
+                    dim=-1,
+                )
+
+            logits, new_k_caches, new_v_caches = module(
+                tmp_token_list,
+                tmp_atten_mask,
+                tmp_pos,
+                *k_caches,
+                *v_caches,
+            )
+            if collect_logits:
+                result_logits.append(logits)
+            atten_mask, pos, k_caches, v_caches = kv_updater(
+                ar_len, atten_mask, pos, k_caches, v_caches, new_k_caches, new_v_caches
+            )
+            if pos > len(token_list):
+                token_list.append(torch.argmax(logits[:, -1], dim=-1).item())
+
+    logging.info(f"kv inference result:\n{tokenizer.decode(token_list)}")
+    if collect_logits:
+        result_logits = torch.cat(result_logits, dim=1)
+    return result_logits
+
+
+def prefill_inference(
+    get_example_inputs,
+    prompt: Union[str, list],
+    module: torch.fx.GraphModule,
+    tokenizer,
+    max_seq_len=512,
+    use_i64_token=False,
+    collect_logits=False,
+):
+    _, atten_mask = get_example_inputs(use_kv_cache=False)
+
+    # TODO: change criteria & support batch inputs if necessary
+
+    token_list, result_logits = [], []
+
+    if isinstance(prompt, str):
+        # Llama2 tokenizer has no special tokens
+        if isinstance(tokenizer, (SentencePieceTokenizer, HuggingFaceTokenizer)):
+            token_list = tokenizer.encode(prompt, bos=True, eos=False)
+        elif isinstance(tokenizer, TiktokenTokenizer):
+            token_list = tokenizer.encode(
+                prompt, bos=True, eos=False, allowed_special="all"
+            )
+        else:
+            raise RuntimeError("Unknown tokenizer")
+    else:
+        token_list = prompt.flatten().tolist()
+
+    pos = len(token_list)
+    dtype = torch.int64 if use_i64_token else torch.int32
+
+    with torch.no_grad():
+        while token_list[-1] != tokenizer.eos_id and pos < max_seq_len:
+            tmp_token_list = torch.tensor(token_list, dtype=dtype).reshape(1, -1)
+            if pos < max_seq_len:
+                tmp_token_list = torch.cat(
+                    [
+                        tmp_token_list,
+                        torch.zeros((1, max_seq_len - pos), dtype=dtype),
+                    ],
+                    dim=1,
+                )
+            results = module(
+                tmp_token_list,
+                atten_mask,
+            )
+            if len(results) == 3:
+                logits, new_k_caches, new_v_caches = results
+            elif len(results) == 1:
+                logits = results
+            logits = torch.argmax(logits[:, pos - 1], dim=-1).item()
+            token_list.append(logits)
+            if collect_logits:
+                result_logits.append(logits)
+            pos += 1
+
+    logging.info(f"prefill inference result:\n{tokenizer.decode(token_list)}")
+    if collect_logits:
+        result_logits = torch.cat(result_logits, dim=1)
+    return result_logits
+
+
+def graph_module_inference(
+    args,
+    use_kv_cache,
+    get_example_inputs: Callable,
+    module: torch.fx.GraphModule,
+    tokenizer,
+    ar_len=1,
+    max_seq_len=512,
+    kv_updater=smart_mask_updater,
+    use_i64_token=False,
+    event_name: str = None,
+):
+    if args.tasks is None:
+        if use_kv_cache:
+            kv_inference(
+                get_example_inputs,
+                args.prompt[0],
+                module,
+                tokenizer,
+                ar_len,
+                max_seq_len,
+                kv_updater=kv_updater,
+                use_i64_token=use_i64_token,
+                collect_logits=False,
+            )
+        else:
+            prefill_inference(
+                get_example_inputs,
+                args.prompt[0],
+                module,
+                tokenizer,
+                max_seq_len,
+                use_i64_token,
+                collect_logits=False,
+            )
+    else:
+        calibration_wrapper = GraphModuleCalibrationWrapper(
+            model=module,
+            tokenizer=tokenizer,
+            max_seq_length=max_seq_len,
+            ar_len=ar_len,
+            use_kv_cache=use_kv_cache,
+            get_example_inputs=get_example_inputs,
+            kv_updater=kv_updater,
+            use_i64_token=use_i64_token,
+        )
+        # Evaluate the model
+        with torch.no_grad():
+            eval_results = simple_evaluate(
+                model=calibration_wrapper,
+                tasks=args.tasks,
+                limit=args.limit,
+            )
+        logging.info(f"Perplexity evaluation summary for {event_name}")
+        for task, res in eval_results["results"].items():
+            logging.info(f"{task}: {res}")

--- a/examples/qualcomm/oss_scripts/llama/eval_llama_qnn.py
+++ b/examples/qualcomm/oss_scripts/llama/eval_llama_qnn.py
@@ -38,7 +38,7 @@ from executorch.examples.models.llama.source_transformation.quantize import (
     get_quant_embedding_transform,
 )
 
-from executorch.examples.qualcomm.oss_scripts.llama.llama import calibrate
+from executorch.examples.qualcomm.oss_scripts.llama.decoder_utils import calibrate
 
 from executorch.examples.qualcomm.oss_scripts.llama.model.static_llama import (
     LlamaModel,

--- a/examples/qualcomm/oss_scripts/llama/llama.py
+++ b/examples/qualcomm/oss_scripts/llama/llama.py
@@ -46,7 +46,6 @@ from executorch.backends.qualcomm.utils.constants import (
     QCOM_QUANT_ATTRS_MAP,
 )
 from executorch.backends.qualcomm.utils.utils import (
-    capture_program,
     convert_linear_to_conv2d,
     generate_htp_compiler_spec,
     generate_qnn_executorch_compiler_spec,
@@ -65,6 +64,17 @@ from executorch.examples.models.llama.hf_download import (
 from executorch.examples.models.llama.source_transformation.quantize import (
     get_quant_embedding_transform,
 )
+from executorch.examples.qualcomm.oss_scripts.llama.decoder_constants import (
+    DECODER_MODEL_VERSION,
+    EVAL_MODE,
+    HUGGING_FACE_REPO_IDS,
+)
+from executorch.examples.qualcomm.oss_scripts.llama.decoder_utils import (
+    graph_module_inference,
+    QnnRunnerEvalWrapper,
+    shift_pointer_updater,
+    smart_mask_updater,
+)
 from executorch.examples.qualcomm.oss_scripts.llama.model.static_llama import (
     LlamaModel,
     ModelArgs,
@@ -79,7 +89,6 @@ from executorch.examples.qualcomm.oss_scripts.llama.range_setting_pt2e import (
 
 from executorch.examples.qualcomm.utils import (
     make_output_dir,
-    make_quantizer,
     setup_common_args_and_variables,
     SimpleADB,
 )
@@ -89,221 +98,30 @@ from executorch.exir.passes.memory_planning_pass import MemoryPlanningPass
 from executorch.extension.llm.custom_ops import model_sharding
 from executorch.extension.llm.export.builder import DType
 from pytorch_tokenizers import get_tokenizer, TiktokenTokenizer
-from pytorch_tokenizers.hf_tokenizer import HuggingFaceTokenizer
 from pytorch_tokenizers.llama2c import Llama2cTokenizer as SentencePieceTokenizer
 
 from torchao.prototype.spinquant import apply_spinquant
 
-from torchao.quantization.pt2e import MinMaxObserver
 from torchao.quantization.pt2e.quantize_pt2e import convert_pt2e, prepare_pt2e
-from transformers import AutoConfig, AutoTokenizer
+from transformers import AutoTokenizer
+
+try:
+    from lm_eval.evaluator import simple_evaluate
+except ImportError:
+    raise ImportError(
+        "Please install the llm eval dependency via examples/models/llama/install_requirements.sh"
+    )
 
 sys.setrecursionlimit(4096)
 FORMAT = "[%(levelname)s %(asctime)s %(filename)s:%(lineno)s] %(message)s"
 logging.basicConfig(level=logging.INFO, format=FORMAT)
 logging.getLogger().setLevel(logging.INFO)
 
-HUGGING_FACE_REPO_IDS = {"qwen2_5": "Qwen/Qwen2.5-0.5B"}
-
 
 def next_power_of_two(n):
     if n == 0:
         return 1
     return 2 ** math.ceil(math.log2(n))
-
-
-def smart_mask_updater(
-    ar_len, atten_mask, pos, k_caches, v_caches, new_k_caches, new_v_caches
-):
-    # Update the KV cache input for the next inference when the position exceeds the autoregressive length.
-    if pos >= ar_len:
-        for i, k_cache in enumerate(k_caches):
-            k_cache[:, :, pos - ar_len] = new_k_caches[i][:, :, 0]
-
-        for i, v_cache in enumerate(v_caches):
-            v_cache[:, pos - ar_len, :] = new_v_caches[i][:, 0, :]
-        atten_mask[:, :, pos - ar_len] = 0
-
-    pos += 1
-    return (atten_mask, pos, k_caches, v_caches)
-
-
-def shift_pointer_updater(
-    ar_len, atten_mask, pos, k_caches, v_caches, new_k_caches, new_v_caches
-):
-    # Update the KV cache input for the next inference when the position exceeds the autoregressive length.
-    if pos >= ar_len:
-        k_caches = [
-            torch.cat([k_cache[:, :, 1:], new_k_caches[i][:, :, :1]], dim=-1)
-            for i, k_cache in enumerate(k_caches)
-        ]
-        v_caches = [
-            torch.cat([v_cache[:, 1:, :], new_v_caches[i][:, :1, :]], dim=1)
-            for i, v_cache in enumerate(v_caches)
-        ]
-        atten_mask[:, :, -pos - 1] = 0
-
-    pos += 1
-    return (atten_mask, pos, k_caches, v_caches)
-
-
-def _kv_calibrate(
-    example_inputs,
-    user_prompts,
-    module: torch.fx.GraphModule,
-    tokenizer,
-    ar_len=1,
-    max_seq_len=512,
-    updater=smart_mask_updater,
-    use_i64_token=False,
-):
-    _, atten_mask, _, k_caches, v_caches = example_inputs
-
-    # TODO: change criteria & support batch inputs if necessary
-    all_pos = torch.arange(0, max_seq_len, 1, dtype=torch.int32).unsqueeze(0)
-
-    token_list = []
-    # Llama2 tokenizer has no special tokens
-    if isinstance(tokenizer, (SentencePieceTokenizer, HuggingFaceTokenizer)):
-        token_list = tokenizer.encode(user_prompts, bos=True, eos=False)
-    elif isinstance(tokenizer, TiktokenTokenizer):
-        token_list = tokenizer.encode(
-            user_prompts, bos=True, eos=False, allowed_special="all"
-        )
-    else:
-        raise RuntimeError("Unkown tokenizer")
-    pos = len(token_list) if len(token_list) < ar_len else ar_len
-    dtype = torch.int64 if use_i64_token else torch.int32
-
-    with torch.no_grad():
-        while token_list[-1] != tokenizer.eos_id and pos < max_seq_len:
-            tmp_token_list = torch.tensor(
-                token_list[pos - ar_len : pos], dtype=dtype
-            ).reshape(1, -1)
-            tmp_pos = all_pos[:, pos - ar_len : pos]
-            tmp_atten_mask = atten_mask
-            if pos < ar_len:
-                tmp_token_list = torch.cat(
-                    [
-                        torch.zeros((1, ar_len - pos), dtype=dtype),
-                        torch.tensor(token_list, dtype=dtype).reshape(1, -1),
-                    ],
-                    dim=1,
-                )
-                tmp_pos = torch.cat(
-                    [
-                        torch.zeros((1, ar_len - pos), dtype=torch.int32),
-                        all_pos[:, :pos],
-                    ],
-                    dim=1,
-                )
-                tmp_atten_mask = torch.cat(
-                    [
-                        torch.ones(1, ar_len, max_seq_len - pos) * -255.0,
-                        atten_mask[:, :, -pos:],
-                    ],
-                    dim=-1,
-                )
-
-            logits, new_k_caches, new_v_caches = module(
-                tmp_token_list,
-                tmp_atten_mask,
-                tmp_pos,
-                *k_caches,
-                *v_caches,
-            )
-            atten_mask, pos, k_caches, v_caches = updater(
-                ar_len, atten_mask, pos, k_caches, v_caches, new_k_caches, new_v_caches
-            )
-            if pos > len(token_list):
-                token_list.append(torch.argmax(logits[:, -1], dim=-1).item())
-
-    print(f"kv calibration data:\n{tokenizer.decode(token_list)}")
-
-
-def _prefill_calibrate(
-    example_inputs,
-    user_prompts,
-    module: torch.fx.GraphModule,
-    tokenizer,
-    max_seq_len=512,
-    use_i64_token=False,
-):
-    _, atten_mask = example_inputs
-
-    # TODO: change criteria & support batch inputs if necessary
-
-    token_list = []
-    # Llama2 tokenizer has no special tokens
-    if isinstance(tokenizer, (SentencePieceTokenizer, HuggingFaceTokenizer)):
-        token_list = tokenizer.encode(user_prompts, bos=True, eos=False)
-    elif isinstance(tokenizer, TiktokenTokenizer):
-        token_list = tokenizer.encode(
-            user_prompts, bos=True, eos=False, allowed_special="all"
-        )
-    else:
-        raise RuntimeError("Unkown tokenizer")
-
-    pos = len(token_list)
-    dtype = torch.int64 if use_i64_token else torch.int32
-
-    with torch.no_grad():
-        while token_list[-1] != tokenizer.eos_id and pos < max_seq_len:
-            tmp_token_list = torch.tensor(token_list, dtype=dtype).reshape(1, -1)
-            if pos < max_seq_len:
-                tmp_token_list = torch.cat(
-                    [
-                        tmp_token_list,
-                        torch.zeros((1, max_seq_len - pos), dtype=dtype),
-                    ],
-                    dim=1,
-                )
-            results = module(
-                tmp_token_list,
-                atten_mask,
-            )
-            if len(results) == 3:
-                logits, new_k_caches, new_v_caches = results
-            elif len(results) == 1:
-                logits = results
-            token_list.append(torch.argmax(logits[:, pos - 1], dim=-1).item())
-            pos += 1
-
-    print(f"prefill calibration data:\n{tokenizer.decode(token_list)}")
-
-
-def calibrate(
-    example_inputs,
-    user_prompts,
-    module: torch.fx.GraphModule,
-    tokenizer,
-    ar_len=1,
-    max_seq_len=512,
-    kv_updater=smart_mask_updater,
-    use_i64_token=False,
-):
-    if len(example_inputs) == 2:
-        _prefill_calibrate(
-            example_inputs,
-            user_prompts,
-            module,
-            tokenizer,
-            max_seq_len,
-            use_i64_token,
-        )
-    elif len(example_inputs) == 5:
-        _kv_calibrate(
-            example_inputs,
-            user_prompts,
-            module,
-            tokenizer,
-            ar_len,
-            max_seq_len,
-            updater=kv_updater,
-            use_i64_token=use_i64_token,
-        )
-    else:
-        raise RuntimeError("Get wrong inputs")
 
 
 class SingleLlama:
@@ -426,15 +244,18 @@ class SingleLlama:
 
         logging.info("Quantizing the model...")
 
-        calibrate(
-            self.get_example_inputs(self.llama_meta["get_use_kv_cache"]),
-            args.prompt[0],
-            fx_graph_module,
+        # Calibration
+        graph_module_inference(
+            args=args,
+            use_kv_cache=self.llama_meta["get_use_kv_cache"],
+            get_example_inputs=self.get_example_inputs,
+            module=fx_graph_module,
             tokenizer=tokenizer,
             ar_len=self.llama_meta["get_ar_len"],
             max_seq_len=self.llama_meta["get_max_seq_len"],
             kv_updater=args.kv_updater,
             use_i64_token=args.embedding_quantize is not None,
+            event_name="prepare_pt2e",
         )
 
         if scales_state_dict:
@@ -443,6 +264,22 @@ class SingleLlama:
             )
 
         self.llama_graph_module = convert_pt2e(fx_graph_module)
+
+        logging.info("Verifying the QDQ model...")
+        if args.eval_perplexity:
+            # Check qdq cpu results
+            graph_module_inference(
+                args=args,
+                use_kv_cache=self.llama_meta["get_use_kv_cache"],
+                get_example_inputs=self.get_example_inputs,
+                module=self.llama_graph_module,
+                tokenizer=tokenizer,
+                ar_len=self.llama_meta["get_ar_len"],
+                max_seq_len=self.llama_meta["get_max_seq_len"],
+                kv_updater=args.kv_updater,
+                use_i64_token=args.embedding_quantize is not None,
+                event_name="convert_pt2e",
+            )
 
     def lowering_modules(
         self,
@@ -537,6 +374,7 @@ def compile(args, pte_filename, tokenizer):
     kv_config.max_seq_len = args.max_seq_len
     kv_config.use_kv_cache = True
     kv_config.enable_masked_softmax = args.enable_masked_softmax
+    kv_config.enable_r3 = args.r3
 
     prefill_config = copy.copy(kv_config)
     prefill_config.use_kv_cache = (
@@ -888,27 +726,80 @@ def compile(args, pte_filename, tokenizer):
             exec_prog_mgr.write_to_file(file)
 
     end_lowering_ts = time.time()
-    logging.info(f"Time for compiling: {end_lowering_ts - start_lowering_ts}")
-    return quant_attrs
 
-
-def inference(args, pte_filename, runtime_tokenizer_path, decoder_model_version):
-    workspace = f"/data/local/tmp/{getpass.getuser()}/executorch/single_llama"
-
-    if args.model_mode == "kv":
-        eval_mode = 0
-    elif args.model_mode == "hybrid":
-        eval_mode = 1
-    elif args.model_mode == "lookahead":
-        eval_mode = 2
+    quant_attrs_path = (
+        f"{args.artifact}/{pte_filename}_quant_attrs.json"
+        if args.quant_attrs_path is None
+        else args.quant_attrs_path
+    )
+    if quant_attrs:
+        json.dump(
+            {
+                "scale": quant_attrs["scale"],
+                "zero_point": quant_attrs["zero_point"],
+            },
+            open(quant_attrs_path, "w"),
+        )
     else:
-        raise RuntimeError(f"Unknown model_mode: {args.model_mode}.")
+        logging.warning("Quant attributes of the logit is None.")
+    if args.quant_attrs_path is None:
+        args.quant_attrs_path = quant_attrs_path
+
+    logging.info(f"Time for compiling: {end_lowering_ts - start_lowering_ts}")
+
+
+def inference(args, pte_filename, runtime_tokenizer_path, tokenizer):
+    assert args.model_mode in EVAL_MODE, f"Unknown model_mode: {args.model_mode}."
+    assert (
+        args.decoder_model in DECODER_MODEL_VERSION
+    ), f"Unknown decoder_model: {args.decoder_model}."
 
     pte_path = (
         f"{args.pre_gen_pte}/{pte_filename}.pte"
         if args.pre_gen_pte
         else f"{args.artifact}/{pte_filename}.pte"
     )
+
+    if args.eval_perplexity:
+        # Generate the eval wrapper
+        eval_wrapper = QnnRunnerEvalWrapper(
+            args=args,
+            pte_path=pte_path,
+            tokenizer=tokenizer,
+            runtime_tokenizer_path=runtime_tokenizer_path,
+            max_seq_length=args.max_seq_len,
+        )
+
+        # Evaluate the model
+        with torch.no_grad():
+            eval_results = simple_evaluate(
+                model=eval_wrapper,
+                tasks=args.tasks,
+                num_fewshot=args.num_fewshot,
+                limit=args.limit,
+            )
+
+        if args.ip and args.port != -1:
+            assert (
+                len(args.tasks) == 1 and args.tasks[0] == "wikitext"
+            ), "CI currently supports wikitext only"
+            wiki_ppl = eval_results["results"][args.tasks[0]]["word_perplexity,none"]
+            pte_size = os.path.getsize(pte_path)
+            with Client((args.ip, args.port)) as conn:
+                conn.send(
+                    json.dumps(
+                        {
+                            "wiki_ppl": wiki_ppl,
+                            "pte_size": pte_size,
+                            "inference_speed": eval_wrapper.inference_speed,
+                        }
+                    )
+                )
+        else:
+            for task, res in eval_results["results"].items():
+                logging.info(f"{task}: {res}")
+        return
+    workspace = f"/data/local/tmp/{getpass.getuser()}/executorch/single_llama"
 
     # collect output data
     output_data_folder = f"{args.artifact}/outputs"
@@ -924,7 +815,7 @@ def inference(args, pte_filename, runtime_tokenizer_path, decoder_model_version)
     runner_args = " ".join(
         [
             multi_prompts,
-            f"--eval_mode {eval_mode}",
+            f"--eval_mode {EVAL_MODE[args.model_mode]}",
             f"--temperature {args.temperature}",
             f"--system_prompt '{args.system_prompt}'",
         ]
@@ -947,7 +838,7 @@ def inference(args, pte_filename, runtime_tokenizer_path, decoder_model_version)
             [
                 f"export LD_LIBRARY_PATH={qnn_sdk}/lib/{target}/:{args.build_folder}/lib &&",
                 f"./{args.build_folder}/examples/qualcomm/oss_scripts/llama/qnn_llama_runner",
-                f"--decoder_model_version {decoder_model_version}",
+                f"--decoder_model_version {DECODER_MODEL_VERSION[args.decoder_model]}",
                 f"--tokenizer_path {runtime_tokenizer_path}",
                 f"--model_path {pte_path}",
                 f"--seq_len {seq_len}",
@@ -969,7 +860,7 @@ def inference(args, pte_filename, runtime_tokenizer_path, decoder_model_version)
             [
                 f"cd {workspace} &&",
                 f"./qnn_llama_runner",
-                f"--decoder_model_version {decoder_model_version}",
+                f"--decoder_model_version {DECODER_MODEL_VERSION[args.decoder_model]}",
                 f"--tokenizer_path {os.path.basename(runtime_tokenizer_path)}",
                 f"--model_path {pte_filename}.pte",
                 f"--seq_len {seq_len}",
@@ -1022,8 +913,49 @@ def inference(args, pte_filename, runtime_tokenizer_path, decoder_model_version)
             logging.info(f"Results[{idx}]:\n{output}")
 
 
+def _build_tasks_parser(parser):
+    parser.add_argument(
+        "--eval_perplexity",
+        help="If enabled, this will use the tasks provided under args.tasks to calibrate the model",
+        action="store_true",
+        default=False,
+    )
+
+    parser.add_argument(
+        "--tasks",
+        nargs="+",
+        type=str,
+        default=None,
+        help="list of lm-eluther tasks to evaluate usage: --tasks task1 task2",
+    )
+
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=1,
+        help="number of samples to evalulate. If not set, evaluate all samples",
+    )
+    parser.add_argument(
+        "--num_fewshot",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Number of examples in few-shot context",
+    )
+
+    parser.add_argument(
+        "--quant_attrs_path",
+        help="A json file holding logit's quant_attributes. This file is generated after model compilation, stored under the artifacts. This file is required when eval_perplexity is enabled",
+        type=str,
+        required=False,
+    )
+
+    return parser
+
+
 def _build_parser():
     parser = setup_common_args_and_variables()
+    parser = _build_tasks_parser(parser)
     parser.add_argument(
         "-a",
         "--artifact",
@@ -1195,6 +1127,13 @@ def _build_parser():
         action="store_true",
     )
 
+    parser.add_argument(
+        "--r3",
+        help="Enable SpinQuant R3 quantization optimization. Please notice enable R3 could possibly cause performance drop.",
+        action="store_true",
+        default=False,
+    )
+
     parser.add_argument("-v", "--verbose", action="store_true")
 
     return parser
@@ -1203,6 +1142,10 @@ def _build_parser():
 def export_llama(args) -> None:
     if args.compile_only and args.pre_gen_pte:
         raise RuntimeError("Cannot set both compile_only and pre_gen_pte as true")
+    if args.eval_perplexity and args.model_mode != "kv":
+        raise RuntimeError("Eval device perplexity is only supported for KV mode")
+    if args.eval_perplexity and args.tasks is None:
+        raise RuntimeError("Please provide --tasks to eval perplexity")
 
     if args.model_mode == "kv":
         pte_filename = "kv_llama_qnn"
@@ -1226,7 +1169,7 @@ def export_llama(args) -> None:
         pte_filename = f"{args.decoder_model}_" + pte_filename
 
     tokenizer = None
-    runtime_tokenizer_path, decoder_model_version = "", ""
+    runtime_tokenizer_path = ""
     if args.decoder_model in {"stories110m", "stories260k"}:
         tokenizer = get_tokenizer(args.tokenizer_model)
         assert isinstance(
@@ -1236,29 +1179,17 @@ def export_llama(args) -> None:
             args.tokenizer_bin is not None
         ), "Please provide tokenizer_bin for stories."
         runtime_tokenizer_path = args.tokenizer_bin
-        decoder_model_version = "llama2"
     elif args.decoder_model == "llama3_2":
         tokenizer = get_tokenizer(args.tokenizer_model)
         assert isinstance(
             tokenizer, TiktokenTokenizer
         ), f"Wrong tokenizer provided for llama3_2."
         runtime_tokenizer_path = args.tokenizer_model
-        decoder_model_version = "llama3"
     elif args.decoder_model == "qwen2_5":
         model_id = HUGGING_FACE_REPO_IDS[args.decoder_model]
         tokenizer = AutoTokenizer.from_pretrained(model_id)
         runtime_tokenizer_path = tokenizer.save_pretrained(args.artifact)[-1]
         tokenizer = get_tokenizer(runtime_tokenizer_path)
-        decoder_model_version = args.decoder_model
-
-        with open(runtime_tokenizer_path, "r+") as file:
-            data = json.load(file)
-            # TODO: Encountered the following error during runtime, so switched behavior for now.
-            # Error: libc++abi: terminating due to uncaught exception of type std::runtime_error: Unsupported Normalizer type: NFC.
-            data.pop("normalizer")
-            file.seek(0)
-            json.dump(data, file, indent=4)
-            file.truncate()
     else:
         raise RuntimeError(f"Unknown decoder_model: {args.decoder_model}.")
 
@@ -1276,7 +1207,7 @@ def export_llama(args) -> None:
         )
 
     if args.pre_gen_pte:
-        inference(args, pte_filename, runtime_tokenizer_path, decoder_model_version)
+        inference(args, pte_filename, runtime_tokenizer_path, tokenizer)
         print(f"Finish the running pre_gen_pte from {args.pre_gen_pte}")
         return
 
@@ -1298,7 +1229,7 @@ def export_llama(args) -> None:
         return
 
     compile(args, pte_filename, tokenizer)
-    inference(args, pte_filename, runtime_tokenizer_path, decoder_model_version)
+    inference(args, pte_filename, runtime_tokenizer_path, tokenizer)
 
 
 def main():

--- a/examples/qualcomm/oss_scripts/llama/model/static_llama.py
+++ b/examples/qualcomm/oss_scripts/llama/model/static_llama.py
@@ -7,8 +7,10 @@
 # TODO: reenable pyre after fixing the issues
 # pyre-ignore-all-errors
 
+import math
 from typing import List, Optional, Tuple
 
+import scipy
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -67,6 +69,18 @@ class LlamaAttention(nn.Module):
         self.attn_softmax = torch.nn.Softmax(dim=-1)
 
         self.scale = float(self.head_dim) ** 0.5
+
+        if config.enable_r3:
+            self.register_buffer(
+                "r3_weight",
+                torch.tensor(
+                    scipy.linalg.hadamard(self.head_dim, dtype=float)
+                    / math.sqrt(self.head_dim),
+                    dtype=torch.float32,
+                    device="cpu",
+                ),
+                persistent=False,
+            )
 
     def prepare_sha(self):
         self.wq_sha = nn.ModuleList(
@@ -172,8 +186,13 @@ class LlamaAttention(nn.Module):
         ]
         for i in range(len(q)):
             q[i] = apply_rotary_emb_single(q[i], freqs_cos, freqs_sin)
+            if self.config.enable_r3:
+                q[i] = torch.matmul(q[i], self.r3_weight.T)
         for i in range(len(k)):
-            k[i] = apply_rotary_emb_single(k[i], freqs_cos, freqs_sin).transpose(1, 2)
+            k[i] = apply_rotary_emb_single(k[i], freqs_cos, freqs_sin)
+            if self.config.enable_r3:
+                k[i] = torch.matmul(k[i], self.r3_weight.T)
+            k[i] = k[i].transpose(1, 2)
 
         output_y = []
         kh, vh = [], []

--- a/examples/qualcomm/oss_scripts/llama/runner/lhd_token_generator.cpp
+++ b/examples/qualcomm/oss_scripts/llama/runner/lhd_token_generator.cpp
@@ -176,7 +176,8 @@ Result<int64_t> LhdTokenGenerator::generate(
     std::vector<uint64_t> tokens,
     int64_t start_pos,
     int32_t seq_len,
-    std::function<void(const std::string&)> token_callback) {
+    std::function<void(const std::string&)> token_callback,
+    bool dump_logits) {
   ET_CHECK_MSG(
       !tokens.empty(), "Token generation loop shouldn't take empty tokens");
   // position in the sequence

--- a/examples/qualcomm/oss_scripts/llama/runner/lhd_token_generator.h
+++ b/examples/qualcomm/oss_scripts/llama/runner/lhd_token_generator.h
@@ -76,7 +76,8 @@ class LhdTokenGenerator : public TokenGenerator {
       std::vector<uint64_t> tokens,
       int64_t start_pos,
       int32_t seq_len,
-      std::function<void(const std::string&)> token_callback) override;
+      std::function<void(const std::string&)> token_callback,
+      bool dump_logits) override;
 
  private:
   /**

--- a/examples/qualcomm/oss_scripts/llama/runner/prompt_processor.cpp
+++ b/examples/qualcomm/oss_scripts/llama/runner/prompt_processor.cpp
@@ -160,6 +160,10 @@ void PromptProcessor::init_io(
   }
 }
 
+const std::vector<uint16_t>& PromptProcessor::get_all_logits() {
+  return prompt_all_logits_;
+}
+
 void PromptProcessor::prepare_io(
     const std::vector<uint64_t>& prompt_tokens,
     int64_t prompt_pos,
@@ -187,7 +191,8 @@ void PromptProcessor::prepare_io(
 
 Result<uint64_t> PromptProcessor::prefill(
     std::vector<uint64_t> prompt_tokens,
-    int64_t start_pos) {
+    int64_t start_pos,
+    bool dump_logits) {
   ET_CHECK_MSG(!prompt_tokens.empty(), "Prompt cannot be null");
 
   // Calculate number of blocks
@@ -251,6 +256,12 @@ Result<uint64_t> PromptProcessor::prefill(
     }
     // Run inference
     decoder_runner_->step(method_name_, inputs_);
+    if (dump_logits) {
+      prompt_all_logits_.insert(
+          prompt_all_logits_.end(),
+          logits_.data,
+          logits_.data + metadata_.ar_len * metadata_.vocab_size);
+    }
     // In the last run, offset to the meaningful logits.
     if (i == num_iters - 1) {
       n_update = 1 + ((num_prompt_tokens - 1) % metadata_.ar_len);

--- a/examples/qualcomm/oss_scripts/llama/runner/prompt_processor.h
+++ b/examples/qualcomm/oss_scripts/llama/runner/prompt_processor.h
@@ -46,16 +46,26 @@ class PromptProcessor {
       executorch::runtime::Result<executorch::runtime::MethodMeta> method_meta);
 
   /**
+   * @brief Get the all logits generated
+   *
+   * @return std::vector<uint16_t>& all the logits generated
+   */
+  virtual const std::vector<uint16_t>& get_all_logits();
+
+  /**
    * Prefill an LLM Module with the given text input.
    * @param prompt_tokens The text prompt tokens to the LLM Module. Encoded by
    * tokenizer.
    * @param start_pos The starting position in KV cache of the input in the LLM
    * Module.
+   * @param dump_logits Used to save all logits. Only enable when analyzing
+   * accuracy.
    * @return The next token of the LLM Module after prefill.
    */
   executorch::runtime::Result<uint64_t> prefill(
       std::vector<uint64_t> prompt_tokens,
-      int64_t start_pos);
+      int64_t start_pos,
+      bool dump_logits);
   /**
    * @brief Get total I/O size in bytes (excluding the KV cache size)
    * @return Total I/O size in bytes.
@@ -107,5 +117,8 @@ class PromptProcessor {
   std::vector<executorch::runtime::EValue> inputs_;
   std::vector<executorch::aten::Tensor> input_tensors_;
   std::vector<executorch::aten::Tensor> output_tensors_;
+
+  // Unused by default, only used when dump_logits_path is provided.
+  std::vector<uint16_t> prompt_all_logits_;
 };
 } // namespace example

--- a/examples/qualcomm/oss_scripts/llama/runner/runner.h
+++ b/examples/qualcomm/oss_scripts/llama/runner/runner.h
@@ -39,6 +39,7 @@ class Runner {
       const std::string& model_path,
       const std::string& tokenizer_path,
       const std::string& performance_output_path,
+      const std::string& dump_logits_path,
       const float temperature = 0.8f,
       const int eval_mode = EvalMode::kKVCached,
       const std::string& kv_updater = "SmartMask",
@@ -52,6 +53,7 @@ class Runner {
   // TODO: Support echo and warming
   executorch::runtime::Error generate(
       const std::string& prompt,
+      bool tokenized_prompt,
       int32_t seq_len,
       std::function<void(const std::string&)> token_callback = {},
       std::function<void(const executorch::llm::Stats&)> stats_callback = {},
@@ -78,6 +80,7 @@ class Runner {
 
   std::string tokenizer_path_;
   std::string performance_output_path_;
+  std::string dump_logits_path_;
   float temperature_;
   EvalMode eval_mode_;
   DecoderModelVersion decoder_model_version_;

--- a/examples/qualcomm/oss_scripts/llama/runner/token_generator.h
+++ b/examples/qualcomm/oss_scripts/llama/runner/token_generator.h
@@ -51,6 +51,13 @@ class TokenGenerator {
       executorch::runtime::Result<executorch::runtime::MethodMeta> method_meta);
 
   /**
+   * @brief Get the all logits generated
+   *
+   * @return std::vector<uint16_t>& all the logits generated
+   */
+  virtual const std::vector<uint16_t>& get_all_logits();
+
+  /**
      * @brief Generate tokens.
      * @param tokens Vector of input tokens.
      * @param start_pos Starting position for generation.
@@ -62,7 +69,8 @@ class TokenGenerator {
       std::vector<uint64_t> tokens,
       int64_t start_pos,
       int32_t seq_len,
-      std::function<void(const std::string&)> token_callback);
+      std::function<void(const std::string&)> token_callback,
+      bool dump_logits);
   inline const size_t total_token_generator_io_size_in_bytes() const {
     return input_toks_.size + input_pos_.size + attention_mask_.size +
         logits_.size;
@@ -108,5 +116,8 @@ class TokenGenerator {
 
   // metadata
   Metadata metadata_;
+
+  // Unused by default, only used when dump_logits_path is provided.
+  std::vector<uint16_t> token_all_logits_;
 };
 } // namespace example

--- a/examples/qualcomm/utils.py
+++ b/examples/qualcomm/utils.py
@@ -115,28 +115,30 @@ class SimpleADB:
             cmds, stdout=subprocess.DEVNULL if self.error_only else sys.stdout
         )
 
-    def push(self, inputs=None, input_list=None, files=None):
-        self._adb(["shell", f"rm -rf {self.workspace}"])
-        self._adb(["shell", f"mkdir -p {self.workspace}"])
+    def push(self, inputs=None, input_list=None, files=None, init_env=True):
+        artifacts = []
+        if init_env:
+            self._adb(["shell", f"rm -rf {self.workspace}"])
+            self._adb(["shell", f"mkdir -p {self.workspace}"])
 
-        # necessary artifacts
-        artifacts = [
-            *self.pte_path,
-            f"{self.qnn_sdk}/lib/aarch64-android/libQnnHtp.so",
-            (
-                f"{self.qnn_sdk}/lib/hexagon-v{self.htp_arch}/"
-                f"unsigned/libQnnHtpV{self.htp_arch}Skel.so"
-            ),
-            (
-                f"{self.qnn_sdk}/lib/aarch64-android/"
-                f"libQnnHtpV{self.htp_arch}Stub.so"
-            ),
-            f"{self.qnn_sdk}/lib/aarch64-android/libQnnHtpPrepare.so",
-            f"{self.qnn_sdk}/lib/aarch64-android/libQnnSystem.so",
-            f"{self.build_path}/{self.runner}",
-            f"{self.build_path}/backends/qualcomm/libqnn_executorch_backend.so",
-            f"{self.qnn_sdk}/lib/aarch64-android/libQnnModelDlc.so",
-        ]
+            # necessary artifacts
+            artifacts = [
+                *self.pte_path,
+                f"{self.qnn_sdk}/lib/aarch64-android/libQnnHtp.so",
+                (
+                    f"{self.qnn_sdk}/lib/hexagon-v{self.htp_arch}/"
+                    f"unsigned/libQnnHtpV{self.htp_arch}Skel.so"
+                ),
+                (
+                    f"{self.qnn_sdk}/lib/aarch64-android/"
+                    f"libQnnHtpV{self.htp_arch}Stub.so"
+                ),
+                f"{self.qnn_sdk}/lib/aarch64-android/libQnnHtpPrepare.so",
+                f"{self.qnn_sdk}/lib/aarch64-android/libQnnSystem.so",
+                f"{self.build_path}/{self.runner}",
+                f"{self.build_path}/backends/qualcomm/libqnn_executorch_backend.so",
+                f"{self.qnn_sdk}/lib/aarch64-android/libQnnModelDlc.so",
+            ]
         input_list_file, input_files = generate_inputs(
             self.working_dir, self.input_list_filename, inputs, input_list
         )


### PR DESCRIPTION
### Summary

- Enable Perplexity Evaluation on device with `llama.py`
- Evaluate perplexity after qdq cpu
- Enable quantization to use simple_eval as calibration dataset.
- Enable UT to check perplexity for QWEN, which should be more reliable than checking the string output.

Will have a follow up PR to address:
- External CI enablement for qwen on x86 (If it does not take too long).
- Hide Logits scale/offset to metadata in model


#### Script
`python examples/qualcomm/oss_scripts/llama/llama.py -b build-android -s $DEVICE -m SM8750 --prompt "What is 1+1?" --temperature 0 --model_mode kv --max_seq_len 1024 --ptq 16a8w --decoder_model qwen2_5 --eval_perplexity --tasks wikitext`


### Test plan
`python backends/qualcomm/tests/test_qnn_delegate.py -k TestExampleLLMScript.test_static_qwen2_5 --model SM8650 --build_folder build-android/ --executorch_root . -s $DEVICE`

Author: @shewu-quic, @winskuo-quic 
