### PR TITLE
Update maven plugin

### DIFF
--- a/extension/android/build.gradle
+++ b/extension/android/build.gradle
@@ -17,7 +17,7 @@ allprojects {
 
         dependencies {
             classpath 'com.android.tools.build:gradle:8.9.0'
-            classpath 'com.vanniktech:gradle-maven-publish-plugin:0.31.0'
+            classpath 'com.vanniktech:gradle-maven-publish-plugin:0.34.0'
         }
 
     }

--- a/extension/android/executorch_android/build.gradle
+++ b/extension/android/executorch_android/build.gradle
@@ -8,7 +8,7 @@
 
 plugins {
     id "com.android.library" version "8.9.0"
-    id "com.vanniktech.maven.publish" version "0.34.0"
+    id "com.vanniktech.maven.publish" version "0.31.0"
     alias(libs.plugins.jetbrains.kotlin.android)
 }
 
@@ -50,10 +50,12 @@ dependencies {
     implementation libs.core.ktx
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.assertj:assertj-core:3.27.2'
+    testImplementation 'org.jetbrains.kotlin:kotlin-test:1.9.23'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test:rules:1.2.0'
     androidTestImplementation 'commons-io:commons-io:2.4'
     androidTestImplementation 'org.json:json:20250107'
+    androidTestImplementation 'org.jetbrains.kotlin:kotlin-test:1.9.23'
 }
 
 mavenPublishing {

--- a/extension/android/executorch_android/build.gradle
+++ b/extension/android/executorch_android/build.gradle
@@ -8,7 +8,7 @@
 
 plugins {
     id "com.android.library" version "8.9.0"
-    id "com.vanniktech.maven.publish" version "0.31.0"
+    id "com.vanniktech.maven.publish" version "0.34.0"
     alias(libs.plugins.jetbrains.kotlin.android)
 }
 
@@ -50,21 +50,17 @@ dependencies {
     implementation libs.core.ktx
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.assertj:assertj-core:3.27.2'
-    testImplementation 'org.jetbrains.kotlin:kotlin-test:1.9.23'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test:rules:1.2.0'
     androidTestImplementation 'commons-io:commons-io:2.4'
     androidTestImplementation 'org.json:json:20250107'
-    androidTestImplementation 'org.jetbrains.kotlin:kotlin-test:1.9.23'
 }
 
-import com.vanniktech.maven.publish.SonatypeHost
-
 mavenPublishing {
-  publishToMavenCentral(SonatypeHost.DEFAULT)
+  publishToMavenCentral()
   signAllPublications()
 
-  coordinates("org.pytorch", "executorch-android", "0.7.0")
+  coordinates("org.pytorch", "executorch-android", "0.7.0-SNAPSHOT")
 
   pom {
     name = "ExecuTorch Android"
@@ -96,6 +92,6 @@ mavenPublishing {
 
 repositories {
     maven {
-        url "https://oss.sonatype.org/content/repositories/snapshots"
+        url "https://central.sonatype.com/repository/maven-snapshots/"
     }
 }


### PR DESCRIPTION
### Summary
Now we need to upload to central portal instead of OSSRH
### Test plan
Example workflow: https://github.com/pytorch/executorch/actions/runs/16602690475