### PR TITLE
Remove unsupported method encode_prepack() from flash attention tests

### DIFF
--- a/backends/vulkan/test/op_tests/sdpa_test.cpp
+++ b/backends/vulkan/test/op_tests/sdpa_test.cpp
@@ -584,7 +584,6 @@ void test_vulkan_flash_attention(
   ValueRef staging_out = graph.set_output_tensor(r_out);
 
   graph.prepare();
-  graph.encode_prepack();
   graph.prepack();
   graph.encode_execute();
 
@@ -843,7 +842,6 @@ void test_reference_flash_attention(
   ValueRef staging_out = graph.set_output_tensor(r_out);
 
   graph.prepare();
-  graph.encode_prepack();
   graph.prepack();
   graph.encode_execute();
 


### PR DESCRIPTION
Summary: Remove unsupported method encode_prepack() from flash attention tests which was causing CI failure.

Reviewed By: mcr229

Differential Revision: D79128259


