### PR TITLE
Do not decompose view ops in CoreML partitioner

### DIFF
--- a/backends/apple/coreml/partition/coreml_partitioner.py
+++ b/backends/apple/coreml/partition/coreml_partitioner.py
@@ -26,6 +26,14 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
+def _is_view_op(op: torch._ops.OpOverload) -> bool:
+    schema = op._schema
+    if len(schema.arguments) == 0:
+        return False
+    alias_info = schema.arguments[0].alias_info
+    return (alias_info is not None) and (not alias_info.is_write)
+
+
 class _OperatorsSupportedForCoreMLBackend(OperatorSupportBase):
     def __init__(
         self,
@@ -119,6 +127,7 @@ class CoreMLPartitioner(Partitioner):
 
     def __init__(
         self,
+        *,
         skip_ops_for_coreml_delegation: Optional[List[str]] = None,
         compile_specs: Optional[List[CompileSpec]] = None,
         take_over_mutable_buffer: Optional[bool] = True,
@@ -209,6 +218,9 @@ class CoreMLPartitioner(Partitioner):
             torch.ops.aten.triu.default,
             # https://github.com/apple/coremltools/blob/release/8.3/coremltools/converters/mil/frontend/torch/ops.py#L6997-L6998
             torch.ops.aten.tril.default,
+            # CoreML's translation of repeat_interleave has poor perf
+            torch.ops.aten.repeat_interleave.self_int,
+            torch.ops.aten.repeat_interleave.self_Tensor,
         ]
         for node in ep.graph.nodes:
             if node.op == "call_function" and isinstance(
@@ -218,6 +230,7 @@ class CoreMLPartitioner(Partitioner):
                     if (
                         op_support.is_node_supported(None, node)
                         and node.target not in do_not_decompose_blocklist
+                        and not _is_view_op(node.target)
                     ):
                         do_not_decompose.append(node.target)
                 except Exception as e:


### PR DESCRIPTION
We have some evidence that preserving view ops can hurt performance in CoreML.

In addition, ET converts view ops to copy variants before lowering, but after checking op support, so we sometimes run into an issue where a view op is preserved, but its copy variant is unsupported.  This can lead to graph breaks.