### PR TITLE
Make Flat Tensor Map Usable By Clients

### DIFF
--- a/extension/flat_tensor/targets.bzl
+++ b/extension/flat_tensor/targets.bzl
@@ -8,6 +8,9 @@ def define_common_targets():
             srcs = [
                 "flat_tensor_data_map.cpp",
             ],
+                compiler_flags = [
+        "-Wno-deprecated-declarations",
+    ],
             exported_headers = ["flat_tensor_data_map.h"],
             deps = [
                 "//executorch/runtime/core:core",
@@ -21,6 +24,6 @@ def define_common_targets():
                 "//executorch/extension/flat_tensor/serialize:generated_headers",
             ],
             visibility = [
-                "//executorch/...",
+                "@EXECUTORCH_CLIENTS",
             ],
         )

--- a/runtime/core/named_data_map.h
+++ b/runtime/core/named_data_map.h
@@ -27,7 +27,7 @@ namespace ET_RUNTIME_NAMESPACE {
  * Interface to access and retrieve data via name.
  * See executorch/extension/flat_tensor/ for an example.
  */
-class ET_EXPERIMENTAL NamedDataMap {
+class NamedDataMap {
  public:
   virtual ~NamedDataMap() = default;
   /**

--- a/runtime/core/tensor_layout.h
+++ b/runtime/core/tensor_layout.h
@@ -19,7 +19,7 @@ namespace ET_RUNTIME_NAMESPACE {
 /**
  * Describes the layout of a tensor.
  */
-class ET_EXPERIMENTAL TensorLayout final {
+class TensorLayout final {
  public:
   TensorLayout() = delete;
 


### PR DESCRIPTION
Summary: This library needs to be used by clients to allow for program data separation. Additionally, the experimental/deprecated dependency needs to be removed.

Reviewed By: JacobSzwejbka

Differential Revision: D79173718


