### PR TITLE
Remove ET_EXPERIMENTAL from program-data separation APIs

### DIFF
--- a/extension/flat_tensor/targets.bzl
+++ b/extension/flat_tensor/targets.bzl
@@ -21,6 +21,6 @@ def define_common_targets():
                 "//executorch/extension/flat_tensor/serialize:generated_headers",
             ],
             visibility = [
-                "//executorch/...",
+                "@EXECUTORCH_CLIENTS",
             ],
         )

--- a/runtime/core/named_data_map.h
+++ b/runtime/core/named_data_map.h
@@ -8,12 +8,6 @@
 
 #pragma once
 
-#ifdef __GNUC__
-// Disable -Wdeprecated-declarations, as some builds use 'Werror'.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-
 #include <executorch/runtime/core/exec_aten/exec_aten.h>
 #include <executorch/runtime/core/freeable_buffer.h>
 #include <executorch/runtime/core/result.h>
@@ -27,7 +21,7 @@ namespace ET_RUNTIME_NAMESPACE {
  * Interface to access and retrieve data via name.
  * See executorch/extension/flat_tensor/ for an example.
  */
-class ET_EXPERIMENTAL NamedDataMap {
+class NamedDataMap {
  public:
   virtual ~NamedDataMap() = default;
   /**
@@ -81,7 +75,3 @@ class ET_EXPERIMENTAL NamedDataMap {
 
 } // namespace ET_RUNTIME_NAMESPACE
 } // namespace executorch
-
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif

--- a/runtime/core/tensor_layout.h
+++ b/runtime/core/tensor_layout.h
@@ -19,7 +19,7 @@ namespace ET_RUNTIME_NAMESPACE {
 /**
  * Describes the layout of a tensor.
  */
-class ET_EXPERIMENTAL TensorLayout final {
+class TensorLayout final {
  public:
   TensorLayout() = delete;
 

--- a/runtime/executor/program.h
+++ b/runtime/executor/program.h
@@ -8,12 +8,6 @@
 
 #pragma once
 
-#ifdef __GNUC__
-// Disable -Wdeprecated-declarations, as some builds use 'Werror'.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-
 #include <cinttypes>
 #include <cstdint>
 #include <optional>
@@ -322,7 +316,3 @@ namespace executor {
 using ::executorch::ET_RUNTIME_NAMESPACE::Program;
 } // namespace executor
 } // namespace torch
-
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif


### PR DESCRIPTION
Summary: These APIs are relatively stable, and the ET_EXPERIMENTAL is causing issues with builds (e.g. for internal users), with deprecation warnings-as-errors.

Differential Revision: D79206305


