### PR TITLE
Add unload method to module

### DIFF
--- a/extension/module/module.h
+++ b/extension/module/module.h
@@ -195,6 +195,17 @@ class Module {
   }
 
   /**
+   * Unload a specific method from the program.
+   *
+   * @param[in] method_name The name of the method to unload.
+   *
+   * @returns True if the method is unloaded, false if no-op.
+   */
+  inline bool unload_method(const std::string& method_name) {
+    return methods_.erase(method_name);
+  }
+
+  /**
    * Get a method by it's name. Not recommended to use this method directly as
    * an end user. It's exposed to allow for composability of module in apis that
    * operate on method.
@@ -226,6 +237,15 @@ class Module {
   ET_DEPRECATED ET_NODISCARD inline runtime::Error load_forward(
       torch::executor::EventTracer* event_tracer) {
     return load_forward(nullptr, event_tracer);
+  }
+
+  /**
+   * Unload the 'forward' method from the program.
+   *
+   * @returns True if the 'forward' method is unloaded, false if no-op.
+   */
+  inline bool unload_forward() {
+    return unload_method("forward");
   }
 
   /**

--- a/extension/module/test/module_test.cpp
+++ b/extension/module/test/module_test.cpp
@@ -91,6 +91,25 @@ TEST_F(ModuleTest, TestLoadMethod) {
   EXPECT_TRUE(module.is_loaded());
 }
 
+TEST_F(ModuleTest, TestUnloadMethod) {
+  Module module(model_path_);
+
+  EXPECT_FALSE(module.is_method_loaded("forward"));
+  const auto errorLoad = module.load_method("forward");
+  EXPECT_EQ(errorLoad, Error::Ok);
+  EXPECT_TRUE(module.is_method_loaded("forward"));
+  // Unload method
+  EXPECT_TRUE(module.unload_method("forward"));
+  EXPECT_FALSE(module.is_method_loaded("forward"));
+  // Try unload method again
+  EXPECT_FALSE(module.unload_method("forward"));
+  // Load method again
+  const auto errorReload = module.load_method("forward");
+  EXPECT_EQ(errorReload, Error::Ok);
+  EXPECT_TRUE(module.is_method_loaded("forward"));
+  EXPECT_TRUE(module.is_loaded());
+}
+
 TEST_F(ModuleTest, TestLoadNonExistentMethod) {
   Module module(model_path_);
 


### PR DESCRIPTION
Summary: We would like to do grid search on device when training the model, ideally we can unload/load the model weights after trained with each specific hyperparameter set.

Differential Revision: D79184972


