### PR TITLE
Support dim_order in CoreML

### DIFF
--- a/backends/apple/coreml/compiler/torch_ops.py
+++ b/backends/apple/coreml/compiler/torch_ops.py
@@ -13,9 +13,11 @@ from coremltools import _logger as logger
 from coremltools.converters.mil.frontend import _utils
 from coremltools.converters.mil.frontend.torch.ops import (
     _get_inputs,
+    _get_kwinputs,
     NUM_TO_NUMPY_DTYPE,
     NUM_TO_TORCH_DTYPE,
     split,
+    to,
     transpose,
     unbind,
 )
@@ -24,6 +26,7 @@ from coremltools.converters.mil.frontend.torch.torch_op_registry import (
     register_torch_op,
 )
 from coremltools.converters.mil.mil import types
+from executorch.exir.dim_order_utils import get_memory_format
 
 
 # https://github.com/apple/coremltools/pull/2556
@@ -42,6 +45,26 @@ def unbind_copy(context, node):
 @register_torch_op(override=False)
 def split_copy(context, node):
     split(context, node)
+
+
+@register_torch_op(
+    torch_alias=[
+        "dim_order_ops::_to_dim_order_copy",
+        "dim_order_ops._to_dim_order_copy",
+    ],
+    override=False,
+)
+def _to_dim_order_copy(context, node):
+    dim_order = _get_kwinputs(context, node, "dim_order", default=[None])[0]
+    node.kwinputs.pop("dim_order")
+
+    # In CoreML, dim_order.val will be an ndarray, so we convert it to a list
+    dim_order = [int(d) for d in dim_order.val]
+    memory_format = get_memory_format(dim_order)
+    assert (
+        memory_format == _torch.contiguous_format
+    ), "Only contiguous memory format is supported in CoreML"
+    to(context, node)
 
 
 # https://github.com/apple/coremltools/pull/2558

--- a/examples/apple/coreml/llama/export.py
+++ b/examples/apple/coreml/llama/export.py
@@ -21,7 +21,7 @@ from executorch.examples.apple.coreml.llama.utils import (
 
 from executorch.exir import to_edge_transform_and_lower
 from executorch.exir.backend.utils import format_delegated_graph
-from executorch.exir.capture._config import EdgeCompileConfig, ExecutorchBackendConfig
+from executorch.exir.capture._config import ExecutorchBackendConfig
 from executorch.exir.passes import MemoryPlanningPass
 from executorch.exir.passes.quant_fusion_pass import QuantFusionPass
 from executorch.exir.passes.sym_shape_eval_pass import ConstraintBasedSymShapeEvalPass
@@ -203,10 +203,6 @@ def main() -> None:
     edge_manager = to_edge_transform_and_lower(
         ep,
         partitioner=[partitioner],
-        compile_config=EdgeCompileConfig(
-            # TODO: fix lowering when dim_order is enabled
-            _skip_dim_order=True,
-        ),
     )
 
     print("Delegated program")


### PR DESCRIPTION
Add support for dim_order op in CoreML.

Currently, the dim_order op is skipped.  This occasionally leads to lowering / runtime errors, so often you have a better experience by setting _skip_dim_order=True.

This will fix the CI failure in trunk / test-models-macos-coreml (emformer_transcribe) / macos-job