### PR TITLE
Add typing annotations to guard and source

### DIFF
--- a/exir/passes/sym_shape_eval_pass.py
+++ b/exir/passes/sym_shape_eval_pass.py
@@ -225,7 +225,7 @@ class HintBasedSymShapeEvalPass(PassBase):
                                 for i, v in enumerate(spec.shape):
                                     if concrete_shape[i] is None:
                                         # get updated shape from var_to_range
-                                        _value_range = shape_env.var_to_range[
+                                        _value_range = shape_env.var_to_range[  # pyre-fixme[16] `Optional` has no attribute `var_to_range`.
                                             v._sympy_()  # pyre-fixme[16] Undefined attribute: `int` has no attribute `_sympy_`.
                                         ]
                                         # cannot handle unbounded, unbacked symints; add a range to bound it.


### PR DESCRIPTION
Summary:
As part of better engineering week, we would like to improve out type support to improve dev experience in dynamo

This PR adds strict typing support to a critical set of files for dynamo, `source.py` and the base `_guards.py`

Running
```
mypy torch/_dynamo/source.py torch/_guards.py --linecount-report /tmp/coverage_log
```

| -------- | Lines Unannotated | Lines Total | % lines covered | Funcs Unannotated | Funcs Total | % funcs covered |
| -------- | ------- | -------- | ------- | ------- | ------- | ------- |
| Main  |  1227 | 2208 | 55.57% | 207 | 362 | 57.18% |
| This PR | 2217 | 2217 | 100.00% | 362 | 362 | 100.00% |
| Delta    | +990 | +9 | +44.43% | +155 | 0 | +42.82% |



cc jgong5 mingfeima XiaobingSuper sanchitintel ashokei jingxu10 jerryzh168 voznesenskym penguinwu EikanWang Guobing-Chen zhuhaozhe blzheng wenzhe-nrv jiayisunx ipiszy chenyang78 kadeng muchulee8 amjames chauhang aakhundov coconutruben

X-link: https://github.com/pytorch/pytorch/pull/158397

Reviewed By: yangw-dev

Differential Revision: D79199389

Pulled By: Lucaskabela


