### PR TITLE
add safety check to prim kernels

### DIFF
--- a/kernels/prim_ops/et_copy_index.cpp
+++ b/kernels/prim_ops/et_copy_index.cpp
@@ -65,7 +65,14 @@ constexpr size_t kTensorDimensionLimit = 16;
 // The output of each iteration (copy_from) is copied into the copy_to tensor at
 // the specified index. This operator is supported in both ATen and lean modes.
 void et_copy_index(KernelRuntimeContext& context, Span<EValue*> stack) {
-  (void)context;
+  ET_KERNEL_CHECK_MSG(
+      context,
+      stack.size() == 3,
+      InvalidProgram,
+      /* void */,
+      "Expected %zu args, got %zu",
+      (size_t)3,
+      stack.size());
   SizesType expected_output_size[kTensorDimensionLimit];
 
   auto copy_to = (*stack[0]).toTensor();

--- a/kernels/prim_ops/et_view.cpp
+++ b/kernels/prim_ops/et_view.cpp
@@ -66,7 +66,14 @@ bool get_view_target_size(
 } // namespace
 
 void et_view(KernelRuntimeContext& context, Span<EValue*> stack) {
-  (void)context;
+  ET_KERNEL_CHECK_MSG(
+      context,
+      stack.size() == 3,
+      InvalidProgram,
+      /* void */,
+      "Expected %zu args, got %zu",
+      (size_t)3,
+      stack.size());
 
   auto self = (*stack[0]).toTensor();
   auto size = (*stack[1]).toIntList();

--- a/kernels/prim_ops/register_prim_ops.cpp
+++ b/kernels/prim_ops/register_prim_ops.cpp
@@ -36,7 +36,6 @@ namespace {
   }
 
 #define __NUMBER_ET_PRIM_OP_IMPL(operator, stack, context) \
-  (void)context;                                           \
   EValue& a = *stack[0];                                   \
   EValue& b = *stack[1];                                   \
   EValue& out = *stack[2];                                 \
@@ -50,11 +49,23 @@ namespace {
     out = EValue(a.toDouble() operator b.toInt());         \
   }
 
+#define __ET_PRIM_OP_NUM_ARGS_CHECK_IMPL(stack, context) \
+  ET_KERNEL_CHECK_MSG(                                   \
+      context,                                           \
+      stack.size() == 3,                                 \
+      InvalidProgram,                                    \
+      /* void */,                                        \
+      "Expected %zu args, got %zu",                      \
+      (size_t)3,                                         \
+      stack.size());
+
 #define ALGEBRA_ET_PRIM_OP(operator, stack, context) \
+  __ET_PRIM_OP_NUM_ARGS_CHECK_IMPL(stack, context)   \
   __NUMBER_ET_PRIM_OP_IMPL(operator, stack, context) \
   __ET_PRIM_OP_ERROR_IMPL(a, b, context)
 
 #define BOOLEAN_ET_PRIM_OP(operator, stack, context) \
+  __ET_PRIM_OP_NUM_ARGS_CHECK_IMPL(stack, context)   \
   __NUMBER_ET_PRIM_OP_IMPL(operator, stack, context) \
   else if (a.isBool() && b.isBool()) {               \
     out = EValue(a.toBool() operator b.toBool());    \
@@ -80,7 +91,14 @@ static Kernel prim_ops[] = {
     Kernel(
         "aten::sym_size.int",
         [](KernelRuntimeContext& context, Span<EValue*> stack) {
-          (void)context;
+          ET_KERNEL_CHECK_MSG(
+              context,
+              stack.size() == 3,
+              InvalidProgram,
+              /* void */,
+              "Expected %zu args, got %zu",
+              (size_t)3,
+              stack.size());
           EValue& self = *stack[0];
           EValue& dim = *stack[1];
           EValue& out = *stack[2];
@@ -94,7 +112,14 @@ static Kernel prim_ops[] = {
     Kernel(
         "aten::_local_scalar_dense",
         [](KernelRuntimeContext& context, Span<EValue*> stack) {
-          (void)context;
+          ET_KERNEL_CHECK_MSG(
+              context,
+              stack.size() == 2,
+              InvalidProgram,
+              /* void */,
+              "Expected %zu args, got %zu",
+              (size_t)2,
+              stack.size());
           EValue& self = *stack[0];
           EValue& out = *stack[1];
           executorch::aten::Tensor self_tensor =
@@ -113,7 +138,14 @@ static Kernel prim_ops[] = {
     Kernel(
         "aten::sym_numel",
         [](KernelRuntimeContext& context, Span<EValue*> stack) {
-          (void)context;
+          ET_KERNEL_CHECK_MSG(
+              context,
+              stack.size() == 2,
+              InvalidProgram,
+              /* void */,
+              "Expected %zu args, got %zu",
+              (size_t)2,
+              stack.size());
           EValue& self = *stack[0];
           EValue& out = *stack[1];
           executorch::aten::Tensor self_tensor =
@@ -125,7 +157,15 @@ static Kernel prim_ops[] = {
     Kernel(
         "executorch_prim::sym_max.Scalar",
         [](KernelRuntimeContext& context, Span<EValue*> stack) {
-          (void)context;
+          ET_KERNEL_CHECK_MSG(
+              context,
+              stack.size() == 3,
+              InvalidProgram,
+              /* void */,
+              "Expected %zu args, got %zu",
+              (size_t)3,
+              stack.size());
+
           EValue& a = *stack[0];
           EValue& b = *stack[1];
           EValue& out = *stack[2];
@@ -146,7 +186,14 @@ static Kernel prim_ops[] = {
     Kernel(
         "executorch_prim::sym_min.Scalar",
         [](KernelRuntimeContext& context, Span<EValue*> stack) {
-          (void)context;
+          ET_KERNEL_CHECK_MSG(
+              context,
+              stack.size() == 3,
+              InvalidProgram,
+              /* void */,
+              "Expected %zu args, got %zu",
+              (size_t)3,
+              stack.size());
           EValue& a = *stack[0];
           EValue& b = *stack[1];
           EValue& out = *stack[2];
@@ -167,7 +214,6 @@ static Kernel prim_ops[] = {
     Kernel(
         "executorch_prim::add.Scalar",
         [](KernelRuntimeContext& context, Span<EValue*> stack) {
-          (void)context;
           ALGEBRA_ET_PRIM_OP(+, stack, context);
         }),
 
@@ -197,7 +243,14 @@ static Kernel prim_ops[] = {
     Kernel(
         "executorch_prim::floordiv.Scalar",
         [](KernelRuntimeContext& context, Span<EValue*> stack) {
-          (void)context;
+          ET_KERNEL_CHECK_MSG(
+              context,
+              stack.size() == 3,
+              InvalidProgram,
+              /* void */,
+              "Expected %zu args, got %zu",
+              (size_t)3,
+              stack.size());
           EValue& a = *stack[0];
           EValue& b = *stack[1];
           EValue& out = *stack[2];
@@ -233,7 +286,14 @@ static Kernel prim_ops[] = {
         "executorch_prim::truediv.Scalar",
         [](KernelRuntimeContext& context, Span<EValue*> stack) {
           // can't use macro because of custom casting behavior
-          (void)context;
+          ET_KERNEL_CHECK_MSG(
+              context,
+              stack.size() == 3,
+              InvalidProgram,
+              /* void */,
+              "Expected %zu args, got %zu",
+              (size_t)3,
+              stack.size());
           EValue& a = *stack[0];
           EValue& b = *stack[1];
           EValue& out = *stack[2];
@@ -266,7 +326,14 @@ static Kernel prim_ops[] = {
           // can't use macro because of custom casting behavior
           // TODO: Now that we are reliably generating conversion operators,
           // we can remove the mixed type handling for other operators
-          (void)context;
+          ET_KERNEL_CHECK_MSG(
+              context,
+              stack.size() == 2,
+              InvalidProgram,
+              /* void */,
+              "Expected %zu args, got %zu",
+              (size_t)2,
+              stack.size());
           EValue& a = *stack[0];
           EValue& out = *stack[1];
           if (a.isInt()) {
@@ -318,7 +385,14 @@ static Kernel prim_ops[] = {
     Kernel(
         "executorch_prim::neg.Scalar",
         [](KernelRuntimeContext& context, Span<EValue*> stack) {
-          (void)context;
+          ET_KERNEL_CHECK_MSG(
+              context,
+              stack.size() == 2,
+              InvalidProgram,
+              /* void */,
+              "Expected %zu args, got %zu",
+              (size_t)2,
+              stack.size());
           EValue& a = *stack[0];
           EValue& out = *stack[1];
           if (a.isInt()) {
@@ -335,7 +409,14 @@ static Kernel prim_ops[] = {
     Kernel(
         "executorch_prim::floordiv.int",
         [](KernelRuntimeContext& context, Span<EValue*> stack) {
-          (void)context;
+          ET_KERNEL_CHECK_MSG(
+              context,
+              stack.size() == 3,
+              InvalidProgram,
+              /* void */,
+              "Expected %zu args, got %zu",
+              (size_t)3,
+              stack.size());
           EValue& a = *stack[0];
           EValue& b = *stack[1];
           EValue& out = *stack[2];
@@ -346,7 +427,14 @@ static Kernel prim_ops[] = {
     Kernel(
         "executorch_prim::mod.int",
         [](KernelRuntimeContext& context, Span<EValue*> stack) {
-          (void)context;
+          ET_KERNEL_CHECK_MSG(
+              context,
+              stack.size() == 3,
+              InvalidProgram,
+              /* void */,
+              "Expected %zu args, got %zu",
+              (size_t)3,
+              stack.size());
           EValue& a = *stack[0];
           EValue& b = *stack[1];
           EValue& out = *stack[2];
@@ -357,7 +445,14 @@ static Kernel prim_ops[] = {
     Kernel(
         "executorch_prim::mod.Scalar",
         [](KernelRuntimeContext& context, Span<EValue*> stack) {
-          (void)context;
+          ET_KERNEL_CHECK_MSG(
+              context,
+              stack.size() == 3,
+              InvalidProgram,
+              /* void */,
+              "Expected %zu args, got %zu",
+              (size_t)3,
+              stack.size());
           EValue& a = *stack[0];
           EValue& b = *stack[1];
           EValue& out = *stack[2];
@@ -379,7 +474,14 @@ static Kernel prim_ops[] = {
     Kernel(
         "executorch_prim::ceil.Scalar",
         [](KernelRuntimeContext& context, Span<EValue*> stack) {
-          (void)context;
+          ET_KERNEL_CHECK_MSG(
+              context,
+              stack.size() == 2,
+              InvalidProgram,
+              /* void */,
+              "Expected %zu args, got %zu",
+              (size_t)2,
+              stack.size());
           EValue& a = *stack[0];
           EValue& out = *stack[1];
           if (a.isDouble()) {
@@ -399,7 +501,14 @@ static Kernel prim_ops[] = {
     Kernel(
         "executorch_prim::round.Scalar",
         [](KernelRuntimeContext& context, Span<EValue*> stack) {
-          (void)context;
+          ET_KERNEL_CHECK_MSG(
+              context,
+              stack.size() == 2,
+              InvalidProgram,
+              /* void */,
+              "Expected %zu args, got %zu",
+              (size_t)2,
+              stack.size());
           EValue& a = *stack[0];
           EValue& out = *stack[1];
           if (a.isDouble()) {
@@ -436,7 +545,14 @@ static Kernel prim_ops[] = {
     Kernel(
         "executorch_prim::trunc.Scalar",
         [](KernelRuntimeContext& context, Span<EValue*> stack) {
-          (void)context;
+          ET_KERNEL_CHECK_MSG(
+              context,
+              stack.size() == 2,
+              InvalidProgram,
+              /* void */,
+              "Expected %zu args, got %zu",
+              (size_t)2,
+              stack.size());
           EValue& a = *stack[0];
           EValue& out = *stack[1];
           if (a.isDouble()) {

--- a/kernels/prim_ops/test/prim_ops_test.cpp
+++ b/kernels/prim_ops/test/prim_ops_test.cpp
@@ -179,6 +179,8 @@ TEST_F(RegisterPrimOpsTest, TestAlgebraOps) {
     stack[i] = &values[i];
   }
 
+  EValue* stack2[2] = {&values[0], &values[1]};
+
   getOpsFn("executorch_prim::add.Scalar")(context_, stack);
   EXPECT_EQ(stack[2]->toInt(), 7);
 
@@ -200,7 +202,7 @@ TEST_F(RegisterPrimOpsTest, TestAlgebraOps) {
   getOpsFn("executorch_prim::mod.Scalar")(context_, stack);
   EXPECT_EQ(stack[2]->toInt(), 3);
 
-  getOpsFn("executorch_prim::sym_float.Scalar")(context_, stack);
+  getOpsFn("executorch_prim::sym_float.Scalar")(context_, stack2);
   EXPECT_FLOAT_EQ(stack[1]->toDouble(), 3.0);
 }
 
@@ -645,6 +647,269 @@ TEST_F(RegisterPrimOpsTest, TestTrunc) {
 
     getOpsFn("executorch_prim::trunc.Scalar")(context_, stack);
     EXPECT_EQ(stack[1]->toInt(), expected[i]);
+  }
+}
+
+// Test that each prim op returns InvalidProgram error when given a stack that's
+// one element shorter than expected
+TEST_F(RegisterPrimOpsTest, TestInvalidProgramErrorOnShortStack) {
+  // Test aten::sym_size.int with a stack of size 2 (missing output)
+  {
+    testing::TensorFactory<ScalarType::Int> tf;
+    Tensor self_tensor = tf.ones({3, 5});
+    EValue values[2];
+    int64_t dim = 1;
+    values[0] = EValue(self_tensor);
+    values[1] = EValue(dim);
+
+    EValue* stack[2];
+    for (size_t i = 0; i < 2; i++) {
+      stack[i] = &values[i];
+    }
+
+    ET_EXPECT_KERNEL_FAILURE(
+        context_, getOpsFn("aten::sym_size.int")(context_, stack));
+    EXPECT_EQ(context_.failure_state(), torch::executor::Error::InvalidProgram);
+  }
+
+  // Test aten::sym_numel with a stack of size 1 (missing output)
+  {
+    testing::TensorFactory<ScalarType::Int> tf;
+    Tensor self_tensor = tf.ones({3, 5});
+    EValue values[1];
+    values[0] = EValue(self_tensor);
+
+    EValue* stack[1];
+    stack[0] = &values[0];
+
+    ET_EXPECT_KERNEL_FAILURE(
+        context_, getOpsFn("aten::sym_numel")(context_, stack));
+    EXPECT_EQ(context_.failure_state(), torch::executor::Error::InvalidProgram);
+  }
+
+  // Test executorch_prim::sym_max.Scalar with a stack of size 2 (missing
+  // output)
+  {
+    EValue values[2];
+    int64_t a = 5;
+    int64_t b = 3;
+    values[0] = EValue(a);
+    values[1] = EValue(b);
+
+    EValue* stack[2];
+    for (size_t i = 0; i < 2; i++) {
+      stack[i] = &values[i];
+    }
+
+    ET_EXPECT_KERNEL_FAILURE(
+        context_, getOpsFn("executorch_prim::sym_max.Scalar")(context_, stack));
+    EXPECT_EQ(context_.failure_state(), Error::InvalidProgram);
+  }
+
+  // Test executorch_prim::sym_min.Scalar with a stack of size 2 (missing
+  // output)
+  {
+    EValue values[2];
+    int64_t a = 5;
+    int64_t b = 3;
+    values[0] = EValue(a);
+    values[1] = EValue(b);
+
+    EValue* stack[2];
+    for (size_t i = 0; i < 2; i++) {
+      stack[i] = &values[i];
+    }
+
+    ET_EXPECT_KERNEL_FAILURE(
+        context_, getOpsFn("executorch_prim::sym_min.Scalar")(context_, stack));
+    EXPECT_EQ(context_.failure_state(), Error::InvalidProgram);
+  }
+
+  // Test algebra ops with a stack of size 2 (missing output)
+  {
+    EValue values[2];
+    int64_t a = 3;
+    int64_t b = 4;
+    values[0] = EValue(a);
+    values[1] = EValue(b);
+
+    EValue* stack[2];
+    for (size_t i = 0; i < 2; i++) {
+      stack[i] = &values[i];
+    }
+
+    ET_EXPECT_KERNEL_FAILURE(
+        context_, getOpsFn("executorch_prim::add.Scalar")(context_, stack));
+    EXPECT_EQ(context_.failure_state(), Error::InvalidProgram);
+
+    ET_EXPECT_KERNEL_FAILURE(
+        context_, getOpsFn("executorch_prim::sub.Scalar")(context_, stack));
+    EXPECT_EQ(context_.failure_state(), Error::InvalidProgram);
+
+    ET_EXPECT_KERNEL_FAILURE(
+        context_, getOpsFn("executorch_prim::mul.Scalar")(context_, stack));
+    EXPECT_EQ(context_.failure_state(), Error::InvalidProgram);
+
+    ET_EXPECT_KERNEL_FAILURE(
+        context_,
+        getOpsFn("executorch_prim::floordiv.Scalar")(context_, stack));
+    EXPECT_EQ(context_.failure_state(), Error::InvalidProgram);
+
+    ET_EXPECT_KERNEL_FAILURE(
+        context_, getOpsFn("executorch_prim::truediv.Scalar")(context_, stack));
+    EXPECT_EQ(context_.failure_state(), Error::InvalidProgram);
+
+    ET_EXPECT_KERNEL_FAILURE(
+        context_, getOpsFn("executorch_prim::mod.int")(context_, stack));
+    EXPECT_EQ(context_.failure_state(), Error::InvalidProgram);
+
+    ET_EXPECT_KERNEL_FAILURE(
+        context_, getOpsFn("executorch_prim::mod.Scalar")(context_, stack));
+    EXPECT_EQ(context_.failure_state(), Error::InvalidProgram);
+  }
+
+  // Test executorch_prim::sym_float.Scalar with a stack of size 1 (missing
+  // output)
+  {
+    EValue values[1];
+    int64_t a = 3;
+    values[0] = EValue(a);
+
+    EValue* stack[1];
+    stack[0] = &values[0];
+
+    ET_EXPECT_KERNEL_FAILURE(
+        context_,
+        getOpsFn("executorch_prim::sym_float.Scalar")(context_, stack));
+    EXPECT_EQ(context_.failure_state(), Error::InvalidProgram);
+  }
+
+  // Test boolean ops with a stack of size 2 (missing output)
+  {
+    EValue values[2];
+    double a = 3;
+    double b = 4;
+    values[0] = EValue(a);
+    values[1] = EValue(b);
+
+    EValue* stack[2];
+    for (size_t i = 0; i < 2; i++) {
+      stack[i] = &values[i];
+    }
+
+    ET_EXPECT_KERNEL_FAILURE(
+        context_, getOpsFn("executorch_prim::ge.Scalar")(context_, stack));
+    EXPECT_EQ(context_.failure_state(), Error::InvalidProgram);
+
+    ET_EXPECT_KERNEL_FAILURE(
+        context_, getOpsFn("executorch_prim::gt.Scalar")(context_, stack));
+    EXPECT_EQ(context_.failure_state(), Error::InvalidProgram);
+
+    ET_EXPECT_KERNEL_FAILURE(
+        context_, getOpsFn("executorch_prim::le.Scalar")(context_, stack));
+    EXPECT_EQ(context_.failure_state(), Error::InvalidProgram);
+
+    ET_EXPECT_KERNEL_FAILURE(
+        context_, getOpsFn("executorch_prim::lt.Scalar")(context_, stack));
+    EXPECT_EQ(context_.failure_state(), Error::InvalidProgram);
+
+    ET_EXPECT_KERNEL_FAILURE(
+        context_, getOpsFn("executorch_prim::eq.Scalar")(context_, stack));
+    EXPECT_EQ(context_.failure_state(), Error::InvalidProgram);
+  }
+
+  // Test aten::_local_scalar_dense with a stack of size 1 (missing output)
+  {
+    testing::TensorFactory<ScalarType::Int> tf;
+    Tensor self_tensor = tf.ones({1});
+    EValue values[1];
+    values[0] = EValue(self_tensor);
+
+    EValue* stack[1];
+    stack[0] = &values[0];
+
+    ET_EXPECT_KERNEL_FAILURE(
+        context_, getOpsFn("aten::_local_scalar_dense")(context_, stack));
+    EXPECT_EQ(context_.failure_state(), Error::InvalidProgram);
+  }
+
+  // Test executorch_prim::neg.Scalar with a stack of size 1 (missing output)
+  {
+    EValue values[1];
+    values[0] = EValue(5.0f);
+
+    EValue* stack[1];
+    stack[0] = &values[0];
+
+    ET_EXPECT_KERNEL_FAILURE(
+        context_, getOpsFn("executorch_prim::neg.Scalar")(context_, stack));
+    EXPECT_EQ(context_.failure_state(), Error::InvalidProgram);
+  }
+
+  // Test executorch_prim::et_copy_index.tensor with a stack of size 2 (missing
+  // index)
+  {
+    testing::TensorFactory<ScalarType::Int> tf;
+    auto copy_to = tf.make({2, 2}, {0, 0, 0, 0});
+    auto to_copy = tf.make({2}, {3, 4});
+
+    EValue values[2];
+    values[0] = EValue(copy_to);
+    values[1] = EValue(to_copy);
+
+    EValue* stack[2];
+    stack[0] = &values[0];
+    stack[1] = &values[1];
+
+    ET_EXPECT_KERNEL_FAILURE(
+        context_,
+        getOpsFn("executorch_prim::et_copy_index.tensor")(context_, stack));
+    EXPECT_EQ(context_.failure_state(), Error::InvalidProgram);
+  }
+
+  // Test executorch_prim::et_view.default with a stack of size 2 (missing
+  // output)
+  {
+    testing::TensorFactory<ScalarType::Int> tf;
+    auto self = tf.make({3, 2}, {1, 2, 3, 4, 5, 6});
+    auto self_evalue = EValue(self);
+
+    int64_t size[3] = {1, 3, -1};
+    EValue size_as_evals[3] = {
+        EValue(size[0]), EValue(size[1]), EValue(size[2])};
+    EValue* size_wrapped_vals[3] = {
+        &size_as_evals[0], &size_as_evals[1], &size_as_evals[2]};
+    int64_t size_unwrapped_vals[3] = {0, 0, 0};
+    EValue size_int_list_evalue = EValue(
+        BoxedEvalueList<int64_t>(size_wrapped_vals, size_unwrapped_vals, 3));
+
+    EValue* stack[2] = {&self_evalue, &size_int_list_evalue};
+
+    ET_EXPECT_KERNEL_FAILURE(
+        context_,
+        getOpsFn("executorch_prim::et_view.default")(context_, stack));
+    EXPECT_EQ(context_.failure_state(), Error::InvalidProgram);
+  }
+
+  // Test ceil, round, trunc with a stack of size 1 (missing output)
+  {
+    EValue values[1];
+    values[0] = EValue(5.5);
+
+    EValue* stack[1];
+    stack[0] = &values[0];
+
+    ET_EXPECT_KERNEL_FAILURE(
+        context_, getOpsFn("executorch_prim::ceil.Scalar")(context_, stack));
+    EXPECT_EQ(context_.failure_state(), Error::InvalidProgram);
+
+    ET_EXPECT_KERNEL_FAILURE(
+        context_, getOpsFn("executorch_prim::round.Scalar")(context_, stack));
+    EXPECT_EQ(context_.failure_state(), Error::InvalidProgram);
+
+    ET_EXPECT_KERNEL_FAILURE(
+        context_, getOpsFn("executorch_prim::trunc.Scalar")(context_, stack));
+    EXPECT_EQ(context_.failure_state(), Error::InvalidProgram);
   }
 }
 


### PR DESCRIPTION
Summary: Just safety checking that we have as many args as we expected

Differential Revision: D79124770


