### PR TITLE
Move to Span<EValue*> instead of EValue** in delegate interface

### DIFF
--- a/backends/apple/coreml/runtime/delegate/coreml_backend_delegate.mm
+++ b/backends/apple/coreml/runtime/delegate/coreml_backend_delegate.mm
@@ -46,6 +46,7 @@ using executorch::runtime::FreeableBuffer;
 using executorch::runtime::get_backend_class;
 using executorch::runtime::Result;
 using executorch::aten::SizesType;
+using executorch::runtime::Span;
 using executorch::aten::Tensor;
 using executorch::runtime::kTensorDimensionLimit;
 
@@ -197,7 +198,7 @@ CoreMLBackendDelegate::init(BackendInitContext& context,
 
 Error CoreMLBackendDelegate::execute(BackendExecutionContext& context,
                                      DelegateHandle* handle,
-                                     EValue** args) const {
+                                     Span<EValue*> args) const {
     const auto& nArgs = impl_->get_num_arguments(handle);
     std::vector<MultiArray> delegate_args;
     size_t nInputs = nArgs.first;

--- a/backends/apple/coreml/runtime/include/coreml_backend/delegate.h
+++ b/backends/apple/coreml/runtime/include/coreml_backend/delegate.h
@@ -48,7 +48,7 @@ public:
     /// @retval On success, `Error::Ok` otherwise any other `Error` case.
     executorch::runtime::Error execute(executorch::runtime::BackendExecutionContext& context,
                                        executorch::runtime::DelegateHandle* handle,
-                                       executorch::runtime::EValue** args) const override;
+                                       executorch::runtime::Span<executorch::runtime::EValue*> args) const override;
 
     /// Returns `true` if the delegate is available otherwise `false`.
     bool is_available() const override;

--- a/backends/apple/mps/runtime/MPSBackend.mm
+++ b/backends/apple/mps/runtime/MPSBackend.mm
@@ -30,6 +30,7 @@ using executorch::runtime::EValue;
 using executorch::runtime::Error;
 using executorch::runtime::FreeableBuffer;
 using executorch::runtime::Result;
+using executorch::runtime::Span;
 
 class MPSBackend final : public ::executorch::runtime::BackendInterface {
  public:
@@ -72,7 +73,7 @@ class MPSBackend final : public ::executorch::runtime::BackendInterface {
   Error execute(
     ET_UNUSED BackendExecutionContext& context,
     DelegateHandle* handle,
-    EValue** args) const override {
+    Span<EValue*> args) const override {
     auto executor = static_cast<mps::delegate::MPSExecutor*>(handle);
     std::vector<const Tensor*> input_pointers;
     std::vector<const Tensor*> output_pointers;

--- a/backends/arm/runtime/EthosUBackend.cpp
+++ b/backends/arm/runtime/EthosUBackend.cpp
@@ -70,6 +70,7 @@ using executorch::runtime::EValue;
 using executorch::runtime::FreeableBuffer;
 using executorch::runtime::MemoryAllocator;
 using executorch::runtime::Result;
+using executorch::runtime::Span;
 
 #define ETHOSU_NUM_BASE_ADDRS 3
 
@@ -140,7 +141,7 @@ class EthosUBackend final : public ::executorch::runtime::BackendInterface {
   Error execute(
       BackendExecutionContext& context,
       DelegateHandle* input_handle,
-      EValue** args) const override {
+      Span<EValue*> args) const override {
 #if defined(ET_EVENT_TRACER_ENABLED)
     EventTracer* event_tracer = context.event_tracer();
     EventTracerEntry event_tracer_local_scope;

--- a/backends/arm/runtime/VGFBackend.cpp
+++ b/backends/arm/runtime/VGFBackend.cpp
@@ -152,7 +152,7 @@ class VGFBackend final : public ::executorch::runtime::BackendInterface {
   Error execute(
       ET_UNUSED BackendExecutionContext& context,
       DelegateHandle* handle,
-      EValue** args) const override {
+      Span<EValue*> args) const override {
     VgfRepr* repr = static_cast<VgfRepr*>(handle);
 
     // Copy all inputs from EValue to VkDeviceMemory

--- a/backends/mediatek/runtime/NeuronBackend.cpp
+++ b/backends/mediatek/runtime/NeuronBackend.cpp
@@ -34,6 +34,7 @@ using executorch::runtime::EValue;
 using executorch::runtime::FreeableBuffer;
 using executorch::runtime::MemoryAllocator;
 using executorch::runtime::Result;
+using executorch::runtime::Span;
 
 const char kHighAddrKey[] = "HighAddr";
 const char kImportForeverKey[] = "ImportForever";
@@ -86,7 +87,7 @@ Result<DelegateHandle*> NeuronBackend::init(
 Error NeuronBackend::execute(
     ET_UNUSED BackendExecutionContext& context,
     DelegateHandle* handle,
-    EValue** args) const {
+    Span<EValue*> args) const {
   NeuronExecuTorchDelegate* delegate =
       reinterpret_cast<NeuronExecuTorchDelegate*>(handle);
   return delegate->execute(context, args);
@@ -106,7 +107,7 @@ bool NeuronBackend::is_available() const {
 
 Error NeuronExecuTorchDelegate::execute(
     BackendExecutionContext& context,
-    EValue** args) const {
+    Span<EValue*> args) const {
   if (HintNeuronBackend(args) != NEURON_NO_ERROR) {
     return Error::InvalidState;
   };
@@ -163,8 +164,8 @@ Error NeuronExecuTorchDelegate::execute(
                                                 : Error::InvalidState;
 };
 
-int NeuronExecuTorchDelegate::HintNeuronBackend(EValue** args) const {
-  auto HintImportForever = [this](EValue** args) -> int {
+int NeuronExecuTorchDelegate::HintNeuronBackend(Span<EValue*> args) const {
+  auto HintImportForever = [this](Span<EValue*> args) -> int {
     auto& allocator = GET_NEURON_ALLOCATOR;
     size_t inputCount = mInputSizes.size(), outputCount = mOutputSizes.size();
     for (int i = 0; i < inputCount; i++) {

--- a/backends/mediatek/runtime/include/NeuronBackend.h
+++ b/backends/mediatek/runtime/include/NeuronBackend.h
@@ -38,7 +38,8 @@ class NeuronBackend final : public ::executorch::runtime::BackendInterface {
   ::executorch::runtime::Error execute(
       ET_UNUSED ::executorch::runtime::BackendExecutionContext& context,
       ::executorch::runtime::DelegateHandle* handle,
-      ::executorch::runtime::EValue** args) const override;
+      ::executorch::runtime::Span<::executorch::runtime::EValue*> args)
+      const override;
 
   void destroy(::executorch::runtime::DelegateHandle* handle) const override;
 
@@ -115,7 +116,7 @@ class NeuronExecuTorchDelegate {
 
   ::executorch::runtime::Error execute(
       ET_UNUSED ::executorch::runtime::BackendExecutionContext& context,
-      ::executorch::runtime::EValue** args) const;
+      ::executorch::runtime::Span<::executorch::runtime::EValue*> args) const;
 
  private:
   template <bool isInput>
@@ -148,7 +149,8 @@ class NeuronExecuTorchDelegate {
     return NEURON_NO_ERROR;
   }
 
-  int HintNeuronBackend(::executorch::runtime::EValue** args) const;
+  int HintNeuronBackend(
+      ::executorch::runtime::Span<::executorch::runtime::EValue*> args) const;
 
  private:
   std::vector<size_t> mInputSizes;

--- a/backends/nxp/runtime/NeutronBackend.cpp
+++ b/backends/nxp/runtime/NeutronBackend.cpp
@@ -330,7 +330,7 @@ class NeutronBackend final : public PyTorchBackendInterface {
   Error execute(
       BackendExecutionContext& context,
       DelegateHandle* input_handle,
-      EValue** args) const override {
+      Span<EValue*> args) const override {
     NeutronConfig* cfg = static_cast<NeutronConfig*>(input_handle);
 
     // Allocate place for input and output pointers.

--- a/backends/openvino/runtime/OpenvinoBackend.cpp
+++ b/backends/openvino/runtime/OpenvinoBackend.cpp
@@ -93,7 +93,7 @@ exr::Result<exr::DelegateHandle*> OpenvinoBackend::init(
 exr::Error OpenvinoBackend::execute(
     exr::BackendExecutionContext& context,
     exr::DelegateHandle* input_handle,
-    exr::EValue** args) const {
+    exr::Span<exr::EValue*> args) const {
   ExecutionHandle* execution_handle = (ExecutionHandle*)input_handle;
 
   auto infer_request = execution_handle->infer_request;

--- a/backends/openvino/runtime/OpenvinoBackend.h
+++ b/backends/openvino/runtime/OpenvinoBackend.h
@@ -45,7 +45,7 @@ class OpenvinoBackend final : public ::exr::BackendInterface {
   exr::Error execute(
       exr::BackendExecutionContext& context,
       exr::DelegateHandle* input_handle,
-      exr::EValue** args) const override;
+      exr::Span<exr::EValue*> args) const override;
   void destroy(exr::DelegateHandle* handle) const override;
 
  private:

--- a/backends/qualcomm/runtime/QnnExecuTorchBackend.cpp
+++ b/backends/qualcomm/runtime/QnnExecuTorchBackend.cpp
@@ -28,6 +28,7 @@ using executorch::runtime::EValue;
 using executorch::runtime::FreeableBuffer;
 using executorch::runtime::MemoryAllocator;
 using executorch::runtime::Result;
+using executorch::runtime::Span;
 
 // ========== Public method implementations =========================
 constexpr const char* QNN_COMPILE_SPEC = "qnn_compile_spec";
@@ -116,7 +117,7 @@ Result<DelegateHandle*> QnnExecuTorchBackend::init(
 Error QnnExecuTorchBackend::execute(
     BackendExecutionContext& context,
     DelegateHandle* handle,
-    EValue** args) const {
+    Span<EValue*> args) const {
   ET_CHECK_OR_RETURN_ERROR(
       delegate_map_rev_.count(handle) != 0,
       Internal,

--- a/backends/qualcomm/runtime/QnnExecuTorchBackend.h
+++ b/backends/qualcomm/runtime/QnnExecuTorchBackend.h
@@ -33,7 +33,8 @@ class QnnExecuTorchBackend final
   executorch::runtime::Error execute(
       ET_UNUSED executorch::runtime::BackendExecutionContext& context,
       executorch::runtime::DelegateHandle* handle,
-      executorch::runtime::EValue** args) const override;
+      executorch::runtime::Span<executorch::runtime::EValue*> args)
+      const override;
 
   ET_NODISCARD executorch::runtime::Error set_option(
       executorch::runtime::BackendOptionContext& context,

--- a/backends/vulkan/runtime/VulkanBackend.cpp
+++ b/backends/vulkan/runtime/VulkanBackend.cpp
@@ -48,6 +48,7 @@ using executorch::runtime::EValue;
 using executorch::runtime::FreeableBuffer;
 using executorch::runtime::kTensorDimensionLimit;
 using executorch::runtime::Result;
+using executorch::runtime::Span;
 
 using namespace vkcompute;
 
@@ -547,7 +548,7 @@ class VulkanBackend final : public ::executorch::runtime::BackendInterface {
   Error execute(
       ET_UNUSED BackendExecutionContext& context,
       DelegateHandle* handle,
-      EValue** args) const override {
+      Span<EValue*> args) const override {
     EXECUTORCH_SCOPE_PROF("VulkanBackend::execute");
 
     ComputeGraph* compute_graph = static_cast<ComputeGraph*>(handle);

--- a/backends/xnnpack/runtime/XNNExecutor.cpp
+++ b/backends/xnnpack/runtime/XNNExecutor.cpp
@@ -21,6 +21,7 @@ using executorch::runtime::Error;
 using executorch::runtime::EValue;
 using executorch::runtime::is_contiguous_dim_order;
 using executorch::runtime::kTensorDimensionLimit;
+using executorch::runtime::Span;
 
 /**
  * Initializes the XNNExecutor with the runtime and given number of
@@ -69,7 +70,7 @@ ET_NODISCARD Error XNNExecutor::initialize(
  * runtime correspond to their index in the list of arg passed into
  * delegate->execute()
  */
-ET_NODISCARD Error XNNExecutor::prepare_args(EValue** args) {
+ET_NODISCARD Error XNNExecutor::prepare_args(Span<EValue*> args) {
   ET_CHECK_OR_RETURN_ERROR(
       runtime_ != nullptr,
       Internal,
@@ -196,7 +197,7 @@ ET_NODISCARD Error XNNExecutor::forward(BackendExecutionContext& context) {
  * XNNPACK gives the index tensor to us as int32, we need to convert it
  * back to int64 for ExecuTorch.
  */
-ET_NODISCARD Error XNNExecutor::resize_outputs(EValue** args) const {
+ET_NODISCARD Error XNNExecutor::resize_outputs(Span<EValue*> args) const {
   size_t output_idx_start = input_ids_.size();
   for (size_t i = output_idx_start; i < externals_.size(); ++i) {
     uint32_t ext_id = externals_[i].id;

--- a/backends/xnnpack/runtime/XNNExecutor.h
+++ b/backends/xnnpack/runtime/XNNExecutor.h
@@ -69,7 +69,7 @@ class XNNExecutor {
    * any additional memory planning as needed
    */
   ET_NODISCARD executorch::runtime::Error prepare_args(
-      executorch::runtime::EValue** args);
+      executorch::runtime::Span<executorch::runtime::EValue*> args);
 
   /**
    * Executes the graph using the args prepared at prepare_args().
@@ -83,7 +83,7 @@ class XNNExecutor {
    * Performs any post processing of outputs like tensor resizing
    */
   ET_NODISCARD executorch::runtime::Error resize_outputs(
-      executorch::runtime::EValue** args) const;
+      executorch::runtime::Span<executorch::runtime::EValue*> args) const;
 
   friend class XNNCompiler;
 };

--- a/backends/xnnpack/runtime/XNNPACKBackend.cpp
+++ b/backends/xnnpack/runtime/XNNPACKBackend.cpp
@@ -33,6 +33,7 @@ using executorch::runtime::Error;
 using executorch::runtime::EValue;
 using executorch::runtime::FreeableBuffer;
 using executorch::runtime::Result;
+using executorch::runtime::Span;
 
 class XnnpackBackend final
     : public ::executorch::ET_RUNTIME_NAMESPACE::BackendInterface {
@@ -126,7 +127,7 @@ class XnnpackBackend final
   Error execute(
       BackendExecutionContext& context,
       DelegateHandle* handle,
-      EValue** args) const override {
+      Span<EValue*> args) const override {
     auto executor = static_cast<xnnpack::delegate::XNNExecutor*>(handle);
 
 #ifdef ENABLE_XNNPACK_SHARED_WORKSPACE

--- a/backends/xnnpack/test/runtime/test_xnnexecutor.cpp
+++ b/backends/xnnpack/test/runtime/test_xnnexecutor.cpp
@@ -14,6 +14,7 @@
 using executorch::backends::xnnpack::delegate::XNNExecutor;
 using executorch::runtime::Error;
 using executorch::runtime::EValue;
+using executorch::runtime::Span;
 using executorch::runtime::testing::TensorFactory;
 
 TEST(XNNExecutorTest, ArgumentWithTooManyDimensions) {
@@ -90,6 +91,7 @@ TEST(XNNExecutorTest, ArgumentWithTooManyDimensions) {
   EValue input_ev(input_tensor);
   EValue output_ev(output_tensor);
   std::array<EValue*, 2> args = {&input_ev, &output_ev};
+  Span<EValue*> stack_args(args.data(), 2);
   // Check for invalid number of dimensions should fail without stack overflow.
-  EXPECT_EQ(executor.prepare_args(args.data()), Error::InvalidArgument);
+  EXPECT_EQ(executor.prepare_args(stack_args), Error::InvalidArgument);
 }

--- a/codegen/api/unboxing.py
+++ b/codegen/api/unboxing.py
@@ -34,7 +34,7 @@ class Unboxing:
     Takes a sequence of Bindings and unbox EValues to these Bindings. Return generated code that performs correct unboxing.
     A sample generated code:
     // aten::mul.out(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
-    void mul_out(EValue** stack) {
+    void mul_out(Span<EValue*> stack) {
         EValue& self = *stack[0];
         EValue& other = *stack[1];
         EValue& out = *stack[2];

--- a/docs/source/compiler-delegate-and-partitioner.md
+++ b/docs/source/compiler-delegate-and-partitioner.md
@@ -99,7 +99,7 @@ ET_NODISCARD virtual Result<DelegateHandle*> init(
 ET_NODISCARD virtual Error execute(
     BackendExecutionContext& context,
     DelegateHandle* handle,
-    EValue** args);
+    Span<EValue*> args);
 
 // [optional] Runtime destroy. Destroy the resource held by the backend
 virtual void destroy(ET_UNUSED DelegateHandle* handle);

--- a/exir/backend/test/demos/rpc/ExecutorBackend.cpp
+++ b/exir/backend/test/demos/rpc/ExecutorBackend.cpp
@@ -188,7 +188,7 @@ class ExecutorBackend final : public ::executorch::runtime::BackendInterface {
   Error execute(
       ET_UNUSED BackendExecutionContext& context,
       DelegateHandle* handle,
-      EValue** args) const override {
+      Span<EValue*> args) const override {
     Method* client_method = static_cast<Method*>(handle);
     auto num_inputs = client_method->inputs_size();
     Error status = Error::Ok;

--- a/runtime/backend/interface.h
+++ b/runtime/backend/interface.h
@@ -99,7 +99,7 @@ class BackendInterface {
   ET_NODISCARD virtual Error execute(
       BackendExecutionContext& context,
       DelegateHandle* handle,
-      EValue** args) const = 0;
+      Span<EValue*> args) const = 0;
 
   /**
    * Responsible update the backend status, if any. The backend options are

--- a/runtime/backend/test/backend_interface_update_test.cpp
+++ b/runtime/backend/test/backend_interface_update_test.cpp
@@ -30,6 +30,7 @@ using executorch::runtime::FreeableBuffer;
 using executorch::runtime::get_backend_class;
 using executorch::runtime::MemoryAllocator;
 using executorch::runtime::Result;
+using executorch::runtime::Span;
 
 class MockBackend : public BackendInterface {
  public:
@@ -50,7 +51,7 @@ class MockBackend : public BackendInterface {
   Error execute(
       __ET_UNUSED BackendExecutionContext& context,
       __ET_UNUSED DelegateHandle* handle,
-      __ET_UNUSED EValue** args) const override {
+      __ET_UNUSED Span<EValue*> args) const override {
     execute_count++;
     return Error::Ok;
   }
@@ -243,7 +244,7 @@ TEST_F(BackendInterfaceUpdateTest, UpdateAfterInitBeforeExecute) {
 
   // Now execute
   DelegateHandle* handle = handle_or_error.get();
-  EValue** args = nullptr; // Not used in mock
+  Span<EValue*> args((EValue**)nullptr, (size_t)0); // Not used in mock
   err = mock_backend->execute(execute_context, handle, args);
   EXPECT_EQ(err, Error::Ok);
 
@@ -269,7 +270,7 @@ TEST_F(BackendInterfaceUpdateTest, UpdateBetweenExecutes) {
   DelegateHandle* handle = handle_or_error.get();
 
   // First execute
-  EValue** args = nullptr;
+  Span<EValue*> args((EValue**)nullptr, (size_t)0); // Not used in mock
   Error err = mock_backend->execute(execute_context, handle, args);
   EXPECT_EQ(err, Error::Ok);
 
@@ -308,7 +309,7 @@ class StubBackend : public BackendInterface {
   Error execute(
       BackendExecutionContext& context,
       DelegateHandle* handle,
-      EValue** args) const override {
+      Span<EValue*> args) const override {
     return Error::Ok;
   }
 

--- a/runtime/executor/method.cpp
+++ b/runtime/executor/method.cpp
@@ -127,7 +127,7 @@ class BackendDelegate final {
 
   Error Execute(
       BackendExecutionContext& backend_execution_context,
-      EValue** args) const {
+      Span<EValue*> args) const {
     EXECUTORCH_SCOPE_PROF("delegate_execute");
     return backend_->execute(backend_execution_context, handle_, args);
   }
@@ -1366,7 +1366,7 @@ Error Method::execute_instruction() {
           /*method_name=*/serialization_plan_->name()->c_str());
       err = delegates_[delegate_idx].Execute(
           backend_execution_context,
-          chain.argument_lists_[step_state_.instr_idx].data());
+          chain.argument_lists_[step_state_.instr_idx]);
       if (err != Error::Ok) {
         ET_LOG(
             Error,

--- a/runtime/executor/test/test_backend_compiler_lib.cpp
+++ b/runtime/executor/test/test_backend_compiler_lib.cpp
@@ -25,6 +25,7 @@ using executorch::runtime::EValue;
 using executorch::runtime::FreeableBuffer;
 using executorch::runtime::MemoryAllocator;
 using executorch::runtime::Result;
+using executorch::runtime::Span;
 
 struct DemoOp {
   const char* name;
@@ -171,7 +172,7 @@ class BackendWithCompiler final : public BackendInterface {
   Error execute(
       ET_UNUSED BackendExecutionContext& context,
       DelegateHandle* handle,
-      EValue** args) const override {
+      Span<EValue*> args) const override {
     EXECUTORCH_SCOPE_PROF("BackendWithCompiler::execute");
 
     // example: [('prim::Constant#1', 14), ('aten::add', 15)]

--- a/runtime/executor/test/test_backend_with_delegate_mapping.cpp
+++ b/runtime/executor/test/test_backend_with_delegate_mapping.cpp
@@ -26,6 +26,7 @@ using executorch::runtime::EValue;
 using executorch::runtime::FreeableBuffer;
 using executorch::runtime::MemoryAllocator;
 using executorch::runtime::Result;
+using executorch::runtime::Span;
 
 struct DemoOp {
   const char* name;
@@ -135,7 +136,7 @@ class BackendWithDelegateMapping final : public BackendInterface {
   Error execute(
       ET_UNUSED BackendExecutionContext& context,
       DelegateHandle* handle,
-      EValue** args) const override {
+      Span<EValue*> args) const override {
     (void)args;
     // example: [('prim::Constant#1', 14), ('aten::add', 15)]
     auto op_list = static_cast<const DemoOpList*>(handle);


### PR DESCRIPTION
Summary: For better safety we want to provide a pointer and a length instead of just a pointer. This is a breaking change of the delegate interface so have to update everyone at once. Span implements operator [], so I expect this to functionally be a no-op today.

Differential Revision: D79268134


