### PR TITLE
Call ExportPass() inside ReplaceNopTransposeOrPermuteWithViewPass::call().

### DIFF
--- a/backends/cadence/aot/pass_utils.py
+++ b/backends/cadence/aot/pass_utils.py
@@ -13,7 +13,7 @@ import torch
 from executorch.backends.cadence.aot.utils import get_edge_overload_packet
 
 from executorch.exir.dialects.edge._ops import EdgeOpOverload, EdgeOpOverloadPacket
-from executorch.exir.pass_base import PassBase
+from executorch.exir.pass_base import PassBase, PassResult
 
 from torch._ops import OpOverloadPacket
 
@@ -224,3 +224,8 @@ def set_arg(
         node.update_arg(idx, value)
     else:
         node.update_kwarg(kwarg_name, value)
+
+
+def none_throws(x: Optional[PassResult]) -> PassResult:
+    assert x is not None
+    return x

--- a/backends/cadence/aot/replace_ops.py
+++ b/backends/cadence/aot/replace_ops.py
@@ -39,6 +39,7 @@ from executorch.backends.cadence.aot.fuse_ops import (
 )
 from executorch.backends.cadence.aot.pass_utils import (
     CadencePassAttribute,
+    none_throws,
     register_cadence_pass,
 )
 from executorch.backends.cadence.aot.remove_ops import RemoveNopSelectOpPass
@@ -1661,8 +1662,8 @@ class ReplaceNopTransposeOrPermuteWithViewPass(ExportPass):
 
     def call(self, graph_module: torch.fx.GraphModule) -> PassResult:
         result = super().call(graph_module)
-        result = FuseCascadedViewOps()(result.graph_module)
-        assert result is not None
+        fuse_cascaded_result = none_throws(FuseCascadedViewOps()(result.graph_module))
+        result = none_throws(ExportPass()(fuse_cascaded_result.graph_module))
         return result
 
 


### PR DESCRIPTION
Summary: Call ExportPass() inside ReplaceNopTransposeOrPermuteWithViewPass::call().

Differential Revision: D79212506


