### PR TITLE
Update EVal Payload to use pointers for larger objects

### DIFF
--- a/devtools/etdump/tests/etdump_test.cpp
+++ b/devtools/etdump/tests/etdump_test.cpp
@@ -345,7 +345,7 @@ TEST_F(ProfilerETDumpTest, DebugEventTensorList) {
       EValue* values_p[2] = {&evalue_1, &evalue_2};
 
       BoxedEvalueList<executorch::aten::Tensor> a_box(values_p, storage, 2);
-      EValue evalue(a_box);
+      EValue evalue(&a_box);
       evalue.tag = Tag::ListTensor;
 
       etdump_gen[i]->create_event_block("test_block");

--- a/extension/evalue_util/test/print_evalue_test.cpp
+++ b/extension/evalue_util/test/print_evalue_test.cpp
@@ -154,21 +154,24 @@ TEST(PrintEvalueTest, NaNDouble) {
 
 TEST(PrintEvalueTest, EmptyString) {
   std::string str = "";
-  EValue value(str.c_str(), str.size());
+  ArrayRef<char> str_ref(const_cast<char*>(str.c_str()), str.size());
+  EValue value(&str_ref);
   expect_output(value, "\"\"");
 }
 
 TEST(PrintEvalueTest, BasicString) {
   // No escaping required.
   std::string str = "Test Data";
-  EValue value(str.c_str(), str.size());
+  ArrayRef<char> str_ref(const_cast<char*>(str.c_str()), str.size());
+  EValue value(&str_ref);
   expect_output(value, "\"Test Data\"");
 }
 
 TEST(PrintEvalueTest, EscapedString) {
   // Contains characters that need to be escaped.
   std::string str = "double quote: \" backslash: \\";
-  EValue value(str.c_str(), str.size());
+  ArrayRef<char> str_ref(const_cast<char*>(str.c_str()), str.size());
+  EValue value(&str_ref);
   expect_output(value, "\"double quote: \\\" backslash: \\\\\"");
 }
 
@@ -267,31 +270,38 @@ TEST(PrintEvalueTest, UnelidedBoolLists) {
   // case; the other scalar types use the same underlying code, so they don't
   // need to test this again.
   {
-    EValue value(ArrayRef<bool>(list.data(), static_cast<size_t>(0ul)));
+    ArrayRef<bool> bool_ref(list.data(), static_cast<size_t>(0ul));
+    EValue value(&bool_ref);
     expect_output(value, "(len=0)[]");
   }
   {
-    EValue value(ArrayRef<bool>(list.data(), 1));
+    ArrayRef<bool> bool_ref(list.data(), 1);
+    EValue value(&bool_ref);
     expect_output(value, "(len=1)[True]");
   }
   {
-    EValue value(ArrayRef<bool>(list.data(), 2));
+    ArrayRef<bool> bool_ref(list.data(), 2);
+    EValue value(&bool_ref);
     expect_output(value, "(len=2)[True, False]");
   }
   {
-    EValue value(ArrayRef<bool>(list.data(), 3));
+    ArrayRef<bool> bool_ref(list.data(), 3);
+    EValue value(&bool_ref);
     expect_output(value, "(len=3)[True, False, True]");
   }
   {
-    EValue value(ArrayRef<bool>(list.data(), 4));
+    ArrayRef<bool> bool_ref(list.data(), 4);
+    EValue value(&bool_ref);
     expect_output(value, "(len=4)[True, False, True, False]");
   }
   {
-    EValue value(ArrayRef<bool>(list.data(), 5));
+    ArrayRef<bool> bool_ref(list.data(), 5);
+    EValue value(&bool_ref);
     expect_output(value, "(len=5)[True, False, True, False, True]");
   }
   {
-    EValue value(ArrayRef<bool>(list.data(), 6));
+    ArrayRef<bool> bool_ref(list.data(), 6);
+    EValue value(&bool_ref);
     expect_output(value, "(len=6)[True, False, True, False, True, False]");
   }
 }
@@ -302,16 +312,19 @@ TEST(PrintEvalueTest, ElidedBoolLists) {
 
   {
     // Default edge items is 3, so the shortest elided list length is 7.
-    EValue value(ArrayRef<bool>(list.data(), 7));
+    ArrayRef<bool> bool_ref(list.data(), 7);
+    EValue value(&bool_ref);
     expect_output(value, "(len=7)[True, False, True, ..., True, False, True]");
   }
   {
-    EValue value(ArrayRef<bool>(list.data(), 8));
+    ArrayRef<bool> bool_ref(list.data(), 8);
+    EValue value(&bool_ref);
     expect_output(value, "(len=8)[True, False, True, ..., False, True, False]");
   }
   {
     // Multi-digit length.
-    EValue value(ArrayRef<bool>(list.data(), 10));
+    ArrayRef<bool> bool_ref(list.data(), 10);
+    EValue value(&bool_ref);
     expect_output(
         value, "(len=10)[True, False, True, ..., False, True, False]");
   }
@@ -342,19 +355,19 @@ TEST(PrintEvalueTest, UnelidedIntLists) {
   {
     BoxedEvalueList<int64_t> list(
         wrapped_values.data(), unwrapped_values.data(), 0);
-    EValue value(list);
+    EValue value(&list);
     expect_output(value, "(len=0)[]");
   }
   {
     BoxedEvalueList<int64_t> list(
         wrapped_values.data(), unwrapped_values.data(), 3);
-    EValue value(list);
+    EValue value(&list);
     expect_output(value, "(len=3)[-2, -1, 0]");
   }
   {
     BoxedEvalueList<int64_t> list(
         wrapped_values.data(), unwrapped_values.data(), 6);
-    EValue value(list);
+    EValue value(&list);
     expect_output(value, "(len=6)[-2, -1, 0, 1, 2, 3]");
   }
 }
@@ -392,20 +405,20 @@ TEST(PrintEvalueTest, ElidedIntLists) {
     // Default edge items is 3, so the shortest elided list length is 7.
     BoxedEvalueList<int64_t> list(
         wrapped_values.data(), unwrapped_values.data(), 7);
-    EValue value(list);
+    EValue value(&list);
     expect_output(value, "(len=7)[-4, -3, -2, ..., 0, 1, 2]");
   }
   {
     BoxedEvalueList<int64_t> list(
         wrapped_values.data(), unwrapped_values.data(), 8);
-    EValue value(list);
+    EValue value(&list);
     expect_output(value, "(len=8)[-4, -3, -2, ..., 1, 2, 3]");
   }
   {
     // Multi-digit length.
     BoxedEvalueList<int64_t> list(
         wrapped_values.data(), unwrapped_values.data(), 10);
-    EValue value(list);
+    EValue value(&list);
     expect_output(value, "(len=10)[-4, -3, -2, ..., 3, 4, 5]");
   }
 }
@@ -419,15 +432,18 @@ TEST(PrintEvalueTest, UnelidedDoubleLists) {
   std::array<double, 6> list = {-2.2, -1, 0, INFINITY, NAN, 3.3};
 
   {
-    EValue value(ArrayRef<double>(list.data(), static_cast<size_t>(0ul)));
+    ArrayRef<double> double_ref(list.data(), static_cast<size_t>(0ul));
+    EValue value(&double_ref);
     expect_output(value, "(len=0)[]");
   }
   {
-    EValue value(ArrayRef<double>(list.data(), 3));
+    ArrayRef<double> double_ref(list.data(), 3);
+    EValue value(&double_ref);
     expect_output(value, "(len=3)[-2.2, -1., 0.]");
   }
   {
-    EValue value(ArrayRef<double>(list.data(), 6));
+    ArrayRef<double> double_ref(list.data(), 6);
+    EValue value(&double_ref);
     expect_output(value, "(len=6)[-2.2, -1., 0., inf, nan, 3.3]");
   }
 }
@@ -438,16 +454,19 @@ TEST(PrintEvalueTest, ElidedDoubleLists) {
 
   {
     // Default edge items is 3, so the shortest elided list length is 7.
-    EValue value(ArrayRef<double>(list.data(), 7));
+    ArrayRef<double> double_ref(list.data(), 7);
+    EValue value(&double_ref);
     expect_output(value, "(len=7)[-4.4, -3., -2.2, ..., 0., inf, nan]");
   }
   {
-    EValue value(ArrayRef<double>(list.data(), 8));
+    ArrayRef<double> double_ref(list.data(), 8);
+    EValue value(&double_ref);
     expect_output(value, "(len=8)[-4.4, -3., -2.2, ..., inf, nan, 3.3]");
   }
   {
     // Multi-digit length.
-    EValue value(ArrayRef<double>(list.data(), 10));
+    ArrayRef<double> double_ref(list.data(), 10);
+    EValue value(&double_ref);
     expect_output(value, "(len=10)[-4.4, -3., -2.2, ..., 3.3, 4., 5.5]");
   }
 }
@@ -503,7 +522,7 @@ void expect_tensor_list_output(size_t num_tensors, const char* expected) {
   ASSERT_LE(num_tensors, wrapped_values.size());
   BoxedEvalueList<executorch::aten::Tensor> list(
       wrapped_values.data(), unwrapped_values, num_tensors);
-  EValue value(list);
+  EValue value(&list);
   expect_output(value, expected);
 }
 
@@ -579,7 +598,7 @@ void expect_list_optional_tensor_output(
   ASSERT_LE(num_tensors, wrapped_values.size());
   BoxedEvalueList<std::optional<executorch::aten::Tensor>> list(
       wrapped_values.data(), unwrapped_values, num_tensors);
-  EValue value(list);
+  EValue value(&list);
   expect_output(value, expected);
 }
 
@@ -628,7 +647,8 @@ TEST(PrintEvalueTest, UnknownTag) {
 
 TEST(PrintEvalueTest, EdgeItemsOverride) {
   std::array<double, 7> list = {-3.0, -2.2, -1, 0, 3.3, 4.0, 5.5};
-  EValue value(ArrayRef<double>(list.data(), 7));
+  ArrayRef<double> double_ref(list.data(), 7);
+  EValue value(&double_ref);
 
   {
     // Default edge items is 3, so this should elide.
@@ -653,7 +673,8 @@ TEST(PrintEvalueTest, EdgeItemsOverride) {
 
 TEST(PrintEvalueTest, EdgeItemsDefaults) {
   std::array<double, 7> list = {-3.0, -2.2, -1, 0, 3.3, 4.0, 5.5};
-  EValue value(ArrayRef<double>(list.data(), 7));
+  ArrayRef<double> double_ref(list.data(), 7);
+  EValue value(&double_ref);
 
   {
     // Default edge items is 3, so this should elide.
@@ -680,7 +701,8 @@ TEST(PrintEvalueTest, EdgeItemsDefaults) {
 
 TEST(PrintEvalueTest, EdgeItemsSingleStream) {
   std::array<double, 7> list = {-3.0, -2.2, -1, 0, 3.3, 4.0, 5.5};
-  EValue value(ArrayRef<double>(list.data(), 7));
+  ArrayRef<double> double_ref(list.data(), 7);
+  EValue value(&double_ref);
   std::ostringstream os_before;
 
   // Print to the same stream multiple times, showing that evalue_edge_items
@@ -750,7 +772,8 @@ TEST(PrintEvalueTest, ListWrapping) {
 
   {
     // Should elide by default and print on a single line.
-    EValue value(ArrayRef<double>(list.data(), list.size()));
+    ArrayRef<double> double_ref(list.data(), list.size());
+    EValue value(&double_ref);
 
     std::ostringstream os;
     os << value;
@@ -759,7 +782,8 @@ TEST(PrintEvalueTest, ListWrapping) {
   {
     // Exactly the per-line length should not wrap when increasing the number of
     // edge items to disable elision.
-    EValue value(ArrayRef<double>(list.data(), kItemsPerLine));
+    ArrayRef<double> double_ref(list.data(), kItemsPerLine);
+    EValue value(&double_ref);
 
     std::ostringstream os;
     os << torch::executor::util::evalue_edge_items(1000) << value;
@@ -768,7 +792,8 @@ TEST(PrintEvalueTest, ListWrapping) {
   }
   {
     // One more than the per-line length should wrap; no elision.
-    EValue value(ArrayRef<double>(list.data(), kItemsPerLine + 1));
+    ArrayRef<double> double_ref(list.data(), kItemsPerLine + 1);
+    EValue value(&double_ref);
 
     std::ostringstream os;
     os << torch::executor::util::evalue_edge_items(1000) << value;
@@ -781,7 +806,8 @@ TEST(PrintEvalueTest, ListWrapping) {
   }
   {
     // Exactly twice the per-line length, without elision.
-    EValue value(ArrayRef<double>(list.data(), kItemsPerLine * 2));
+    ArrayRef<double> double_ref(list.data(), kItemsPerLine * 2);
+    EValue value(&double_ref);
 
     std::ostringstream os;
     os << torch::executor::util::evalue_edge_items(1000) << value;
@@ -795,7 +821,8 @@ TEST(PrintEvalueTest, ListWrapping) {
   }
   {
     // Exactly one whole line, with elision.
-    EValue value(ArrayRef<double>(list.data(), kItemsPerLine * 3));
+    ArrayRef<double> double_ref(list.data(), kItemsPerLine * 3);
+    EValue value(&double_ref);
 
     std::ostringstream os;
     os << torch::executor::util::evalue_edge_items(kItemsPerLine) << value;
@@ -810,7 +837,8 @@ TEST(PrintEvalueTest, ListWrapping) {
   }
   {
     // Edge item count slightly larger than per-line length, with elision.
-    EValue value(ArrayRef<double>(list.data(), kItemsPerLine * 3));
+    ArrayRef<double> double_ref(list.data(), kItemsPerLine * 3);
+    EValue value(&double_ref);
 
     std::ostringstream os;
     os << torch::executor::util::evalue_edge_items(kItemsPerLine + 1) << value;
@@ -829,7 +857,8 @@ TEST(PrintEvalueTest, ListWrapping) {
   }
   {
     // Large wrapped, ragged, elided example.
-    EValue value(ArrayRef<double>(list.data(), list.size()));
+    ArrayRef<double> double_ref(list.data(), list.size());
+    EValue value(&double_ref);
 
     std::ostringstream os;
     os << torch::executor::util::evalue_edge_items(33) << value;
@@ -946,7 +975,7 @@ TEST(PrintEvalueTest, WrappedTensorLists) {
   // Demonstrate the formatting when printing a list with multiple tensors.
   BoxedEvalueList<executorch::aten::Tensor> list(
       wrapped_values.data(), unwrapped_values, wrapped_values.size());
-  EValue value(list);
+  EValue value(&list);
 
   std::ostringstream os;
   os << torch::executor::util::evalue_edge_items(15) << value;

--- a/extension/kernel_util/test/make_boxed_from_unboxed_functor_test.cpp
+++ b/extension/kernel_util/test/make_boxed_from_unboxed_functor_test.cpp
@@ -133,7 +133,7 @@ TEST_F(MakeBoxedFromUnboxedFunctorTest, UnboxArrayRef) {
   EValue evalues[2] = {storage[0], storage[1]};
   EValue* values_p[2] = {&evalues[0], &evalues[1]};
   BoxedEvalueList<Tensor> a_box(values_p, storage, 2);
-  EValue boxed_array_ref(a_box);
+  EValue boxed_array_ref(&a_box);
   // prepare out tensor.
   EValue out(tf.zeros({5}));
 
@@ -186,7 +186,7 @@ TEST_F(MakeBoxedFromUnboxedFunctorTest, UnboxOptionalArrayRef) {
   EValue evalues[2] = {EValue(tf.ones({5})), EValue()};
   EValue* values_p[2] = {&evalues[0], &evalues[1]};
   BoxedEvalueList<optional<Tensor>> a_box(values_p, storage, 2);
-  EValue boxed_array_ref(a_box);
+  EValue boxed_array_ref(&a_box);
 
   // prepare out tensor.
   EValue out(tf.zeros({5}));

--- a/kernels/prim_ops/test/prim_ops_test.cpp
+++ b/kernels/prim_ops/test/prim_ops_test.cpp
@@ -434,8 +434,9 @@ TEST_F(RegisterPrimOpsTest, TestETView) {
   EValue* size_wrapped_vals[3] = {
       &size_as_evals[0], &size_as_evals[1], &size_as_evals[2]};
   int64_t size_unwrapped_vals[3] = {0, 0, 0};
-  EValue size_int_list_evalue = EValue(
-      BoxedEvalueList<int64_t>(size_wrapped_vals, size_unwrapped_vals, 3));
+  BoxedEvalueList<int64_t> size_boxed_list(
+      size_wrapped_vals, size_unwrapped_vals, 3);
+  EValue size_int_list_evalue = EValue(&size_boxed_list);
 
   int64_t bad_size1[3] = {-1, 3, -1}; // two inferred dimensions
   EValue bad_size_as_evals1[3] = {
@@ -443,8 +444,9 @@ TEST_F(RegisterPrimOpsTest, TestETView) {
   EValue* bad_size_wrapped_vals1[3] = {
       &bad_size_as_evals1[0], &bad_size_as_evals1[1], &bad_size_as_evals1[2]};
   int64_t bad_size_unwrapped_vals1[3] = {0, 0, 0};
-  EValue bad_size_int_list_evalue1 = EValue(BoxedEvalueList<int64_t>(
-      bad_size_wrapped_vals1, bad_size_unwrapped_vals1, 3));
+  BoxedEvalueList<int64_t> bad_size_boxed_list1(
+      bad_size_wrapped_vals1, bad_size_unwrapped_vals1, 3);
+  EValue bad_size_int_list_evalue1 = EValue(&bad_size_boxed_list1);
 
   int64_t bad_size2[3] = {-2, -3, 1}; // negative size not supported
   EValue bad_size_as_evals2[3] = {
@@ -452,8 +454,9 @@ TEST_F(RegisterPrimOpsTest, TestETView) {
   EValue* bad_size_wrapped_vals2[3] = {
       &bad_size_as_evals2[0], &bad_size_as_evals2[1], &bad_size_as_evals2[2]};
   int64_t bad_size_unwrapped_vals2[3] = {0, 0, 0};
-  EValue bad_size_int_list_evalue2 = EValue(BoxedEvalueList<int64_t>(
-      bad_size_wrapped_vals2, bad_size_unwrapped_vals2, 3));
+  BoxedEvalueList<int64_t> bad_size_boxed_list2(
+      bad_size_wrapped_vals2, bad_size_unwrapped_vals2, 3);
+  EValue bad_size_int_list_evalue2 = EValue(&bad_size_boxed_list2);
 
   // ***************************************************************************
   // Make outs for tests
@@ -525,8 +528,9 @@ TEST_F(RegisterPrimOpsTest, TestETViewDynamic) {
   EValue* size_wrapped_vals[3] = {
       &size_as_evals[0], &size_as_evals[1], &size_as_evals[2]};
   int64_t size_unwrapped_vals[3] = {0, 0, 0};
-  EValue size_int_list_evalue = EValue(
-      BoxedEvalueList<int64_t>(size_wrapped_vals, size_unwrapped_vals, 3));
+  BoxedEvalueList<int64_t> size_boxed_list_2(
+      size_wrapped_vals, size_unwrapped_vals, 3);
+  EValue size_int_list_evalue = EValue(&size_boxed_list_2);
 
 #ifdef USE_ATEN_LIB
   // ATen mode tensors don't need dynamism specification.
@@ -560,8 +564,9 @@ TEST_F(RegisterPrimOpsTest, TestETViewEmpty) {
   EValue* size_wrapped_vals[3] = {
       &size_as_evals[0], &size_as_evals[1], &size_as_evals[2]};
   int64_t size_unwrapped_vals[3] = {0, 0, 0};
-  EValue size_int_list_evalue = EValue(
-      BoxedEvalueList<int64_t>(size_wrapped_vals, size_unwrapped_vals, 3));
+  BoxedEvalueList<int64_t> size_boxed_list_3(
+      size_wrapped_vals, size_unwrapped_vals, 3);
+  EValue size_int_list_evalue = EValue(&size_boxed_list_3);
 
   int64_t bad_size[3] = {0, 1, -1}; // bad size: cannot infer with 0
   EValue bad_size_as_evals[3] = {
@@ -569,8 +574,9 @@ TEST_F(RegisterPrimOpsTest, TestETViewEmpty) {
   EValue* bad_size_wrapped_vals[3] = {
       &bad_size_as_evals[0], &bad_size_as_evals[1], &bad_size_as_evals[2]};
   int64_t bad_size_unwrapped_vals[3] = {0, 0, 0};
-  EValue bad_size_int_list_evalue = EValue(BoxedEvalueList<int64_t>(
-      bad_size_wrapped_vals, bad_size_unwrapped_vals, 3));
+  BoxedEvalueList<int64_t> bad_size_boxed_list(
+      bad_size_wrapped_vals, bad_size_unwrapped_vals, 3);
+  EValue bad_size_int_list_evalue = EValue(&bad_size_boxed_list);
 
   auto out = tf.make({3, 1, 0}, {}, {});
   EValue out_evalue = EValue(out);
@@ -880,8 +886,9 @@ TEST_F(RegisterPrimOpsTest, TestInvalidProgramErrorOnShortStack) {
     EValue* size_wrapped_vals[3] = {
         &size_as_evals[0], &size_as_evals[1], &size_as_evals[2]};
     int64_t size_unwrapped_vals[3] = {0, 0, 0};
-    EValue size_int_list_evalue = EValue(
-        BoxedEvalueList<int64_t>(size_wrapped_vals, size_unwrapped_vals, 3));
+    BoxedEvalueList<int64_t> size_boxed_list_4(
+        size_wrapped_vals, size_unwrapped_vals, 3);
+    EValue size_int_list_evalue = EValue(&size_boxed_list_4);
 
     EValue* stack[2] = {&self_evalue, &size_int_list_evalue};
 

--- a/runtime/core/test/evalue_test.cpp
+++ b/runtime/core/test/evalue_test.cpp
@@ -166,7 +166,9 @@ TEST_F(EValueTest, ToScalarType) {
 }
 
 TEST_F(EValueTest, toString) {
-  const EValue e("foo", 3);
+  auto string_ref =
+      std::make_unique<executorch::aten::ArrayRef<char>>("foo", 3);
+  const EValue e(string_ref.get());
   EXPECT_TRUE(e.isString());
   EXPECT_FALSE(e.isNone());
 
@@ -218,11 +220,12 @@ TEST_F(EValueTest, toOptionalTensorList) {
   EValue* values_p[2] = {&values[0], &values[1]};
   std::optional<executorch::aten::Tensor> storage[2];
   // wrap in array ref
-  BoxedEvalueList<std::optional<executorch::aten::Tensor>> a(
+  auto boxed_list = std::make_unique<
+      BoxedEvalueList<std::optional<executorch::aten::Tensor>>>(
       values_p, storage, 2);
 
   // create Evalue
-  EValue e(a);
+  EValue e(boxed_list.get());
   e.tag = Tag::ListOptionalTensor;
   EXPECT_TRUE(e.isListOptionalTensor());
 

--- a/runtime/executor/method.cpp
+++ b/runtime/executor/method.cpp
@@ -507,8 +507,12 @@ Error Method::parse_values(const NamedDataMap* external_data_map) {
               j);
           evalp_list[j] = &values_[static_cast<size_t>(value_index)];
         }
-        new (&values_[i]) EValue(
-            BoxedEvalueList<int64_t>(evalp_list, int_list, items->size()));
+        auto* boxed_list_mem =
+            memory_manager_->method_allocator()
+                ->allocateInstance<BoxedEvalueList<int64_t>>();
+        auto boxed_list = new (boxed_list_mem)
+            BoxedEvalueList<int64_t>(evalp_list, int_list, items->size());
+        new (&values_[i]) EValue(boxed_list);
       } break;
       case executorch_flatbuffer::KernelTypes::BoolList: {
         const auto items =
@@ -525,8 +529,12 @@ Error Method::parse_values(const NamedDataMap* external_data_map) {
         // portable here we need to allocate a new array of bool and copy cast
         // the flatbuffer data into it, but because of how exceptionally rare
         // this case is its low prio TODO: jakeszwe
-        new (&values_[i]) EValue(executorch::aten::ArrayRef<bool>(
-            (const bool*)items->data(), items->size()));
+        auto* bool_list_mem =
+            memory_manager_->method_allocator()
+                ->allocateInstance<executorch::aten::ArrayRef<bool>>();
+        auto bool_list = new (bool_list_mem) executorch::aten::ArrayRef<bool>(
+            (const bool*)items->data(), items->size());
+        new (&values_[i]) EValue(bool_list);
       } break;
       case executorch_flatbuffer::KernelTypes::DoubleList: {
         const auto items =
@@ -536,8 +544,12 @@ Error Method::parse_values(const NamedDataMap* external_data_map) {
             InvalidProgram,
             "Missing list at index %" ET_PRIsize_t,
             i);
-        new (&values_[i]) EValue(
-            executorch::aten::ArrayRef<double>(items->data(), items->size()));
+        auto* double_list_mem =
+            memory_manager_->method_allocator()
+                ->allocateInstance<executorch::aten::ArrayRef<double>>();
+        auto double_list = new (double_list_mem)
+            executorch::aten::ArrayRef<double>(items->data(), items->size());
+        new (&values_[i]) EValue(double_list);
       } break;
       case executorch_flatbuffer::KernelTypes::String: {
         const auto fb_str =
@@ -548,7 +560,12 @@ Error Method::parse_values(const NamedDataMap* external_data_map) {
             InvalidProgram,
             "Missing string at index %" ET_PRIsize_t,
             i);
-        new (&values_[i]) EValue(fb_str->c_str(), fb_str->size());
+        auto* char_list_mem =
+            memory_manager_->method_allocator()
+                ->allocateInstance<executorch::aten::ArrayRef<char>>();
+        auto char_list = new (char_list_mem)
+            executorch::aten::ArrayRef<char>(fb_str->c_str(), fb_str->size());
+        new (&values_[i]) EValue(char_list);
       } break;
       case executorch_flatbuffer::KernelTypes::Tensor: {
         auto t = deserialization::parseTensor(
@@ -588,7 +605,12 @@ Error Method::parse_values(const NamedDataMap* external_data_map) {
               static_cast<uint32_t>(tensors.error()));
           return tensors.error();
         }
-        new (&values_[i]) EValue(tensors.get());
+        auto* boxed_tensor_list_mem =
+            memory_manager_->method_allocator()
+                ->allocateInstance<BoxedEvalueList<executorch::aten::Tensor>>();
+        auto boxed_tensor_list = new (boxed_tensor_list_mem)
+            BoxedEvalueList<executorch::aten::Tensor>(std::move(tensors.get()));
+        new (&values_[i]) EValue(boxed_tensor_list);
       } break;
       case executorch_flatbuffer::KernelTypes::OptionalTensorList: {
         const auto items =
@@ -612,7 +634,14 @@ Error Method::parse_values(const NamedDataMap* external_data_map) {
               static_cast<uint32_t>(tensors.error()));
           return tensors.error();
         }
-        new (&values_[i]) EValue(tensors.get());
+        auto* boxed_optional_tensor_list_mem =
+            memory_manager_->method_allocator()
+                ->allocateInstance<
+                    BoxedEvalueList<std::optional<executorch::aten::Tensor>>>();
+        auto boxed_optional_tensor_list = new (boxed_optional_tensor_list_mem)
+            BoxedEvalueList<std::optional<executorch::aten::Tensor>>(
+                std::move(tensors.get()));
+        new (&values_[i]) EValue(boxed_optional_tensor_list);
       } break;
       default:
         // flatbuffer enums start at 0, but they generate a hidden NONE enum


### PR DESCRIPTION
Summary:
As noted in the comment, switching to ptrs in the union can save memory.

Specifically, the size of this object goes from 24 bytes -> 8 bytes.

In this diff, we move to pointers for some of the larger objects. When parsing the flatbuffer, we allocate memory from the method allocator and store this in the EVal. The get* functions then de-reference that pointer.

Differential Revision: D79286076


