### PR TITLE
Default Export for Mv2 with Real Image Input

### DIFF
--- a/.ci/docker/common/install_zephyr.sh
+++ b/.ci/docker/common/install_zephyr.sh
@@ -84,4 +84,5 @@ install_prerequiresites() {
     pip_install pyelftools
 }
 
+
 install_prerequiresites

--- a/.ci/docker/common/install_zephyr.sh
+++ b/.ci/docker/common/install_zephyr.sh
@@ -84,5 +84,4 @@ install_prerequiresites() {
     pip_install pyelftools
 }
 
-
 install_prerequiresites

--- a/examples/models/mobilenet_v2/model.py
+++ b/examples/models/mobilenet_v2/model.py
@@ -15,8 +15,8 @@ from ..model_base import EagerModelBase
 
 
 class MV2Model(EagerModelBase):
-    def __init__(self, useRealInput=True):
-        self.useRealInput = useRealInput
+    def __init__(self, use_real_input=True):
+        self.use_real_input = use_real_input
         pass
 
     def get_eager_model(self) -> torch.nn.Module:
@@ -28,7 +28,7 @@ class MV2Model(EagerModelBase):
     def get_example_inputs(self):
         tensor_size = (1, 3, 224, 224)
         input_batch = (torch.randn(tensor_size),)
-        if self.useRealInput:
+        if self.use_real_input:
             logging.info("Loaded real input image dog.jpg")
             import urllib
             url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")

--- a/examples/models/mobilenet_v2/model.py
+++ b/examples/models/mobilenet_v2/model.py
@@ -15,7 +15,8 @@ from ..model_base import EagerModelBase
 
 
 class MV2Model(EagerModelBase):
-    def __init__(self):
+    def __init__(self, useRealInput=True):
+        self.useRealInput = useRealInput
         pass
 
     def get_eager_model(self) -> torch.nn.Module:
@@ -26,6 +27,27 @@ class MV2Model(EagerModelBase):
 
     def get_example_inputs(self):
         tensor_size = (1, 3, 224, 224)
+        input_batch = (torch.randn(tensor_size),)
+        if self.useRealInput:
+            logging.info("Loaded real input image dog.jpg")
+            import urllib
+            url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
+            try: 
+                urllib.URLopener().retrieve(url, filename)
+            except: 
+                urllib.request.urlretrieve(url, filename)
+            from PIL import Image
+            from torchvision import transforms
+            input_image = Image.open(filename)
+            preprocess = transforms.Compose([
+                transforms.Resize(256),
+                transforms.CenterCrop(224),
+                transforms.ToTensor(),
+                transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
+            ])
+            input_tensor = preprocess(input_image)
+            input_batch = input_tensor.unsqueeze(0)
+            input_batch = (input_batch,)
         return (torch.randn(tensor_size),)
 
 

--- a/examples/models/mobilenet_v2/model.py
+++ b/examples/models/mobilenet_v2/model.py
@@ -31,20 +31,29 @@ class MV2Model(EagerModelBase):
         if self.use_real_input:
             logging.info("Loaded real input image dog.jpg")
             import urllib
-            url, filename = ("https://github.com/pytorch/hub/raw/master/images/dog.jpg", "dog.jpg")
-            try: 
+
+            url, filename = (
+                "https://github.com/pytorch/hub/raw/master/images/dog.jpg",
+                "dog.jpg",
+            )
+            try:
                 urllib.URLopener().retrieve(url, filename)
-            except: 
+            except:
                 urllib.request.urlretrieve(url, filename)
             from PIL import Image
             from torchvision import transforms
+
             input_image = Image.open(filename)
-            preprocess = transforms.Compose([
-                transforms.Resize(256),
-                transforms.CenterCrop(224),
-                transforms.ToTensor(),
-                transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
-            ])
+            preprocess = transforms.Compose(
+                [
+                    transforms.Resize(256),
+                    transforms.CenterCrop(224),
+                    transforms.ToTensor(),
+                    transforms.Normalize(
+                        mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
+                    ),
+                ]
+            )
             input_tensor = preprocess(input_image)
             input_batch = input_tensor.unsqueeze(0)
             input_batch = (input_batch,)


### PR DESCRIPTION
### Summary
When testing executorch inference runners on real MCUs, it's helpful if the default export of the model includes a real input (rather than just filled with random values or all 1.0s). This PR does this for the mobilenet_v2 model, following the steps from the tutorial [here](https://pytorch.org/hub/pytorch_vision_mobilenet_v2/).  


### Test plan
Ran `python -m examples.portable.scripts.export --model_name="mv2"` and saw the PTE now contains values associated with the `dog.jpg` image. 
