### PR TITLE
NXP backend: Support for Sigmoid operator conversion

### DIFF
--- a/backends/nxp/backend/edge_program_converter.py
+++ b/backends/nxp/backend/edge_program_converter.py
@@ -39,6 +39,7 @@ functions_converters = {
     exir_ops.edge.aten.relu.default: ReLUConverter,  # noqa F405
     exir_ops.edge.aten._softmax.default: SoftmaxConverter,  # noqa F405
     exir_ops.edge.aten.view_copy.default: ViewCopyConverter,  # noqa F405
+    exir_ops.edge.aten.sigmoid.default: SigmoidConverter,  # noqa F405
 }
 
 

--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/__init__.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/__init__.py
@@ -46,6 +46,9 @@ from executorch.backends.nxp.backend.ir.converter.node_converters.ops_converters
 from executorch.backends.nxp.backend.ir.converter.node_converters.ops_converters.relu_converter import (
     ReLUConverter,
 )
+from executorch.backends.nxp.backend.ir.converter.node_converters.ops_converters.sigmoid_converter import (
+    SigmoidConverter,
+)
 from executorch.backends.nxp.backend.ir.converter.node_converters.ops_converters.softmax_converter import (
     SoftmaxConverter,
 )
@@ -72,4 +75,5 @@ __all__ = [
     "AbsConverter",
     "AdaptiveAvgPool2dConverter",
     "HardTanhConverter",
+    "SigmoidConverter",
 ]

--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/sigmoid_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/sigmoid_converter.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 NXP
+# Copyright 2025 NXP
 # All rights reserved.
 #
 # This source code is licensed under the BSD-style license found in the
@@ -15,8 +15,15 @@ from torch.fx import Node
 from torch.nn import Parameter
 
 
-class ReLUConverter(NodeConverter):
-    supported_targets = [Target.RT700]
+class SigmoidConverter(NodeConverter):
+    @staticmethod
+    def _is_supported_on_target(target: Target) -> bool:
+        match target:
+            case Target.RT700:
+                return True
+
+            case _:
+                return False
 
     @staticmethod
     def _is_supported_in_IR(
@@ -28,6 +35,8 @@ class ReLUConverter(NodeConverter):
         self.assert_convertible(node)
 
         t_op = self._create_tflite_op_with_io_tensors(node)
-        t_op.opcode_index = self.builder.op_code_index_for_op_type(BuiltinOperator.RELU)
+        t_op.opcode_index = self.builder.op_code_index_for_op_type(
+            BuiltinOperator.LOGISTIC
+        )
 
         self.builder.append_operators([t_op])

--- a/backends/nxp/neutron_partitioner.py
+++ b/backends/nxp/neutron_partitioner.py
@@ -203,6 +203,7 @@ supported_ops = {
     exir_ops.edge.aten.relu.default: ReLUConverter,  # noqa F405
     exir_ops.edge.aten._softmax.default: SoftmaxConverter,  # noqa F405
     exir_ops.edge.aten.view_copy.default: ViewCopyConverter,  # noqa F405
+    exir_ops.edge.aten.sigmoid.default: SigmoidConverter,  # noqa F405
 }
 
 

--- a/backends/nxp/quantizer/neutron_quantizer.py
+++ b/backends/nxp/quantizer/neutron_quantizer.py
@@ -32,6 +32,7 @@ from executorch.backends.nxp.quantizer.patterns import (
     ReluPattern,
     ReshapePattern,
     SharedSpecPattern,
+    SigmoidPattern,
     SoftMaxPattern,
     ViewPattern,
 )
@@ -217,6 +218,7 @@ class NeutronQuantizer(ComposableQuantizer):
                 NeutronAtenQuantizer(ReluPattern(), static_qconfig),
                 NeutronAtenQuantizer(ReluInPlacePattern(), static_qconfig),
                 NeutronAtenQuantizer(ReshapePattern(), static_qconfig),
+                NeutronAtenQuantizer(SigmoidPattern(), static_qconfig),
                 NeutronAtenQuantizer(SoftMaxPattern(), static_qconfig),
                 NeutronAtenQuantizer(ViewPattern(), static_qconfig),
             ]

--- a/backends/nxp/tests/ir/converter/node_converter/test_sigmoid_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_sigmoid_converter.py
@@ -1,0 +1,76 @@
+# Copyright 2025 NXP
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import numpy as np
+import pytest
+import torch
+
+from executorch.backends.nxp.backend.edge_program_converter import (
+    EdgeProgramToIRConverter,
+)
+from executorch.backends.nxp.tests.executorch_pipeline import to_quantized_edge_program
+from executorch.backends.nxp.tests.executors import (
+    convert_run_compare,
+    ToNCHWPreprocess,
+    ToNHWCPreprocess,
+)
+from executorch.backends.nxp.tests.models import ConvWithSigmoid
+from torch import nn
+from torch.export import ExportedProgram
+
+
+@pytest.fixture(autouse=True)
+def reseed_model_per_test_run():
+    torch.manual_seed(23)
+    np.random.seed(23)
+
+
+def test_conv_sigmoid(mocker, input_shape: tuple[int] = (1, 3, 112, 112)):
+    model = ConvWithSigmoid(conv_in_channels=input_shape[1])
+
+    converter_spy = mocker.spy(EdgeProgramToIRConverter, "convert_program")
+
+    to_quantized_edge_program(model, input_shape).exported_program()
+
+    tflite_flatbuffers_model, io_formats = converter_spy.spy_return
+    exported_program: ExportedProgram = converter_spy.call_args.args[1]
+
+    input_data = (np.random.random(input_shape) * 50).astype(np.int8)
+    convert_run_compare(
+        exported_program,
+        tfl_model=tflite_flatbuffers_model,
+        tflite_input_preprocess=ToNHWCPreprocess(),
+        tflite_output_preprocess=ToNCHWPreprocess(),
+        input_data=input_data,
+        atol=1.0,
+    )
+
+
+@pytest.mark.parametrize(
+    "input_shape",
+    [
+        pytest.param((10,), id="Scalar"),
+        pytest.param((10, 25), id="1D"),
+        pytest.param((10, 25, 25), id="2D"),
+        pytest.param((10, 3, 25, 25), id="3D"),
+        pytest.param((10, 3, 25, 25, 25), id="4D"),
+    ],
+)
+def test_sigmoid_only(mocker, input_shape):
+    model = nn.Sigmoid()
+
+    converter_spy = mocker.spy(EdgeProgramToIRConverter, "convert_program")
+
+    to_quantized_edge_program(model, input_shape).exported_program()
+
+    tflite_flatbuffers_model, io_formats = converter_spy.spy_return
+    exported_program: ExportedProgram = converter_spy.call_args.args[1]
+
+    input_data = (np.random.random(input_shape) * 50).astype(np.int8)
+    convert_run_compare(
+        exported_program, tfl_model=tflite_flatbuffers_model, input_data=input_data
+    )

--- a/backends/nxp/tests/models.py
+++ b/backends/nxp/tests/models.py
@@ -85,6 +85,23 @@ class SoftmaxConvModule(torch.nn.Module):
         return self.softmax(x)
 
 
+class ConvWithSigmoid(torch.nn.Module):
+    def __init__(self, conv_in_channels: int = 3):
+        super().__init__()
+        self.block = torch.nn.Sequential(
+            torch.nn.Conv2d(
+                in_channels=conv_in_channels,
+                out_channels=3,
+                kernel_size=(2, 2),
+                stride=(2, 2),
+            ),
+            torch.nn.Sigmoid(),
+        )
+
+    def forward(self, x):
+        return self.block(x)
+
+
 class LinearModule(torch.nn.Module):
     def __init__(self, bias: bool):
         super().__init__()


### PR DESCRIPTION
### Summary

Adds implementation of converter and quantization pattern for `aten.sigmoid` operator.

### Test plan

Unit tests that covers Sigmoid operator were added.

cc @robert-kalmar 
