### PR TITLE
Arm backend: Add arm-baremetal CMake preset

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -128,6 +128,15 @@
             "EXECUTORCH_BUILD_PRESET_FILE": "${sourceDir}/tools/cmake/preset/zephyr.cmake",
             "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/examples/zephyr/x86_64-linux-arm-zephyr-eabi-gcc.cmake"
         }
+    },
+    {
+        "name": "arm-baremetal",
+        "displayName": "Build ExecuTorch for Arm baremetal",
+        "inherits": ["common"],
+        "cacheVariables": {
+            "EXECUTORCH_BUILD_PRESET_FILE": "${sourceDir}/tools/cmake/preset/arm_baremetal.cmake",
+            "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/examples/arm/ethos-u-setup/arm-none-eabi-gcc.cmake"
+          }
     }
   ]
 }

--- a/backends/arm/scripts/build_executorch.sh
+++ b/backends/arm/scripts/build_executorch.sh
@@ -19,8 +19,8 @@ _setup_msg="please refer to ${et_root_dir}/examples/arm/setup.sh to properly ins
 
 et_build_root="${et_root_dir}/arm_test"
 build_type="Release"
-build_devtools=false
-build_with_etdump=false
+build_devtools=OFF
+build_with_etdump=OFF
 
 help() {
     echo "Usage: $(basename $0) [options]"
@@ -38,8 +38,8 @@ for arg in "$@"; do
       -h|--help) help ;;
       --et_build_root=*) et_build_root="${arg#*=}";;
       --build_type=*) build_type="${arg#*=}";;
-      --devtools) build_devtools=true ;;
-      --etdump) build_with_etdump=true ;;
+      --devtools) build_devtools=ON ;;
+      --etdump) build_with_etdump=ON ;;
       --toolchain=*) toolchain="${arg#*=}";;
       *)
       ;;
@@ -48,7 +48,7 @@ done
 
 if [[ ${toolchain} == "arm-none-eabi-gcc" ]]; then
     toolchain_cmake=${et_root_dir}/examples/arm/ethos-u-setup/${toolchain}.cmake
-elif [[ ${toolchain} == "arm-zephyr-eabi-gcc" ]]; then 
+elif [[ ${toolchain} == "arm-zephyr-eabi-gcc" ]]; then
     toolchain_cmake=${et_root_dir}/examples/zephyr/x86_64-linux-arm-zephyr-eabi-gcc.cmake
 else
     echo "Error: Invalid toolchain selection, provided: ${tolchain}"
@@ -74,40 +74,12 @@ cd "${et_root_dir}"
     echo "Build ExecuTorch target libs ${build_type} into '${et_build_dir}'" ;
     echo "--------------------------------------------------------------------------------" )
 
-build_devtools_flags=" -DEXECUTORCH_BUILD_DEVTOOLS=OFF "
-if [ "$build_devtools" = true ] ; then
-    build_devtools_flags=" -DEXECUTORCH_BUILD_DEVTOOLS=ON "
-fi
-
-build_with_etdump_flags=" -DEXECUTORCH_ENABLE_EVENT_TRACER=OFF "
-if [ "$build_with_etdump" = true ] ; then
-    # Add DevTools flags use in the Target build below
-    build_with_etdump_flags="-DEXECUTORCH_BUILD_DEVTOOLS=ON                    \
-                            -DEXECUTORCH_ENABLE_EVENT_TRACER=ON               \
-                            -DEXECUTORCH_BUILD_EXTENSION_DATA_LOADER=OFF      \
-                            -DFLATCC_ALLOW_WERROR=OFF "
-fi
-
-echo "Building with Devtools: ${build_devtools_flags} ${build_with_etdump_flags}"
-
-
 # Build
-cmake                                                 \
-    -DCMAKE_INSTALL_PREFIX=${et_build_dir}            \
-    -DCMAKE_BUILD_TYPE=${build_type}                  \
-    -DCMAKE_TOOLCHAIN_FILE="${toolchain_cmake}"       \
-    -DEXECUTORCH_BUILD_EXECUTOR_RUNNER=OFF            \
-    -DEXECUTORCH_BUILD_ARM_BAREMETAL=ON               \
-    -DEXECUTORCH_BUILD_KERNELS_QUANTIZED=ON           \
-    -DEXECUTORCH_BUILD_EXTENSION_RUNNER_UTIL=ON       \
-    -DEXECUTORCH_BUILD_CORTEX_M=ON                    \
-    -DEXECUTORCH_ENABLE_LOGGING=ON                    \
-    ${build_devtools_flags}                           \
-    ${build_with_etdump_flags}                        \
-    -B"${et_build_dir}"                               \
-    "${et_root_dir}"
-
-echo "[$(basename $0)] Configured CMAKE"
+cmake -DCMAKE_TOOLCHAIN_FILE=${toolchain_cmake} \
+-DCMAKE_BUILD_TYPE=Release \
+-DEXECUTORCH_BUILD_DEVTOOLS=$build_devtools \
+-DEXECUTORCH_BUILD_ARM_ETDUMP=$build_with_etdump \
+--preset arm-baremetal -B${et_build_dir}
 
 cmake --build ${et_build_dir} -j$(nproc) --target install --config ${build_type} --
 

--- a/tools/cmake/preset/arm_baremetal.cmake
+++ b/tools/cmake/preset/arm_baremetal.cmake
@@ -1,0 +1,25 @@
+# Copyright 2025 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}")
+set_overridable_option(EXECUTORCH_BUILD_EXECUTOR_RUNNER OFF)
+set_overridable_option(EXECUTORCH_BUILD_ARM_BAREMETAL ON)
+set_overridable_option(EXECUTORCH_BUILD_KERNELS_QUANTIZED ON)
+set_overridable_option(EXECUTORCH_BUILD_EXTENSION_RUNNER_UTIL ON)
+set_overridable_option(EXECUTORCH_BUILD_CORTEX_M ON)
+set_overridable_option(EXECUTORCH_ENABLE_LOGGING ON)
+
+define_overridable_option(
+  EXECUTORCH_BUILD_ARM_ETDUMP "Build etdump support for Arm" BOOL OFF
+)
+
+if("${EXECUTORCH_BUILD_ARM_ETDUMP}")
+  set(EXECUTORCH_BUILD_DEVTOOLS ON)
+  set(EXECUTORCH_ENABLE_EVENT_TRACER ON)
+  set(EXECUTORCH_BUILD_EXTENSION_DATA_LOADER OFF)
+  set(FLATCC_ALLOW_WERROR OFF)
+else()
+  set(EXECUTORCH_ENABLE_EVENT_TRACER OFF)
+endif()


### PR DESCRIPTION
- Executorch may be cross compiled for arm-baremetal targets using 'cmake --preset arm-baremetal'
- Adds a new flag EXECUTORCH_BUILD_ARM_ETDUMP used in the preset to easy enabling of ET_DUMP.
- backend/arm/scripts/build_executorch.sh is updated to use the new preset with same behaviour as before.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218