### PR TITLE
Arm backend: Migrate asinh tests to TOSA 1.0

### DIFF
--- a/backends/arm/test/ops/test_asinh.py
+++ b/backends/arm/test/ops/test_asinh.py
@@ -9,10 +9,10 @@ import torch
 
 from executorch.backends.arm.test import common
 from executorch.backends.arm.test.tester.test_pipeline import (
-    EthosU55PipelineBI,
-    EthosU85PipelineBI,
-    TosaPipelineBI,
-    TosaPipelineMI,
+    EthosU55PipelineINT,
+    EthosU85PipelineINT,
+    TosaPipelineFP,
+    TosaPipelineINT,
 )
 
 input_t = Tuple[torch.Tensor]  # Input x
@@ -36,8 +36,8 @@ class Asinh(torch.nn.Module):
 
 
 @common.parametrize("test_data", test_data_suite)
-def test_asin_tosa_MI(test_data: Tuple):
-    pipeline = TosaPipelineMI[input_t](
+def test_asinh_tosa_FP(test_data: Tuple):
+    pipeline = TosaPipelineFP[input_t](
         Asinh(),
         (test_data(),),
         aten_op,
@@ -47,8 +47,8 @@ def test_asin_tosa_MI(test_data: Tuple):
 
 
 @common.parametrize("test_data", test_data_suite)
-def test_asin_tosa_BI(test_data: Tuple):
-    pipeline = TosaPipelineBI[input_t](
+def test_asinh_tosa_INT(test_data: Tuple):
+    pipeline = TosaPipelineINT[input_t](
         Asinh(),
         (test_data(),),
         aten_op=[],
@@ -59,8 +59,8 @@ def test_asin_tosa_BI(test_data: Tuple):
 
 @common.parametrize("test_data", test_data_suite)
 @common.XfailIfNoCorstone300
-def test_asin_u55_BI(test_data: Tuple):
-    pipeline = EthosU55PipelineBI[input_t](
+def test_asinh_u55_INT(test_data: Tuple):
+    pipeline = EthosU55PipelineINT[input_t](
         Asinh(),
         (test_data(),),
         aten_ops=[],
@@ -70,8 +70,8 @@ def test_asin_u55_BI(test_data: Tuple):
 
 @common.parametrize("test_data", test_data_suite)
 @common.XfailIfNoCorstone320
-def test_asin_u85_BI(test_data: Tuple):
-    pipeline = EthosU85PipelineBI[input_t](
+def test_asinh_u85_INT(test_data: Tuple):
+    pipeline = EthosU85PipelineINT[input_t](
         Asinh(),
         (test_data(),),
         aten_ops=[],


### PR DESCRIPTION
This fix a Arm unit tests fail caused by merged order vs test order in the TOSA 0.80.1 removal


cc @digantdesai @freddan80 @per @oscarandersson8218