### PR TITLE
Fix installation that causes torch conflict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ dist/
 ethos-u-scratch/
 executorch.egg-info
 pip-out/
+constraints.txt
 
 # Any exported models and profiling outputs
 *.bin

--- a/install_executorch.py
+++ b/install_executorch.py
@@ -65,6 +65,8 @@ def clean():
             print("ccache not found, skipping ccache cleanup.")
     except (subprocess.CalledProcessError, FileNotFoundError):
         print("ccache not found, skipping ccache cleanup.")
+    
+    shutil.rmtree("constraints.txt", ignore_errors=True)
 
     print("Done cleaning build artifacts.")
 


### PR DESCRIPTION
When pip installs timm==1.0.7 (from requirements-examples.txt), it's pulling its dependencies from PyPI, and since the PyPI version of timm has a dependency on torch without any version constraints, pip is "upgrading" your nightly torch to the latest stable release from PyPI.

Here's what's happening:

I have torch==2.9.0.dev20250725 (nightly) installed
When pip installs timm, it sees that timm requires torch
Pip finds torch==2.7.1 on PyPI (the latest stable release)
Since 2.9.0.dev20250725 is considered a pre-release version, pip thinks 2.7.1 is "newer" in terms of stable releases
Pip uninstalls the nightly and installs the stable version.
