### PR TITLE
Fix installation that causes torch conflict

### DIFF
--- a/install_requirements.py
+++ b/install_requirements.py
@@ -142,19 +142,6 @@ def install_requirements(use_pytorch_nightly):
 
 
 def install_optional_example_requirements(use_pytorch_nightly):
-    print("Installing packages in requirements-examples.txt")
-    subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "pip",
-            "install",
-            "-r",
-            "requirements-examples.txt",
-        ],
-        check=True,
-    )
-
     print("Installing torch domain libraries")
     DOMAIN_LIBRARIES = [
         (
@@ -174,6 +161,19 @@ def install_optional_example_requirements(use_pytorch_nightly):
             *DOMAIN_LIBRARIES,
             "--extra-index-url",
             TORCH_NIGHTLY_URL,
+        ],
+        check=True,
+    )
+
+    print("Installing packages in requirements-examples.txt")
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "-r",
+            "requirements-examples.txt",
         ],
         check=True,
     )


### PR DESCRIPTION
Looking into resolving this: https://github.com/pytorch/pytorch/issues/159599

A package in requirements-examples.txt had a dependency on torchvision, and we ended up installing stable release from standard pypi package. And transitively we ended up installing stable torch and uninstalling existing torch nightly.

We just need to swap the installation (first install domain libraries and torch) and then necessary examples packages.

Test Plan: 

`python ./install_requirements.sh --example`

Outputs

```
(executorch_test_9) mnachin@mnachin-mbp executorch % pip freeze | grep torch
pytorch_tokenizers @ file:///Users/mnachin/executorch/extension/llm/tokenizers
torch==2.9.0.dev20250725
torchao @ file:///Users/mnachin/executorch/third-party/ao
torchaudio==2.8.0.dev20250725
torchdata==0.11.0
torchsr==1.0.4
torchtune==0.6.1
torchvision==0.24.0.dev20250725
```