### PR TITLE
Update install_requirements.py to include TORCH_NIGHTLY_URL for requirement-examples.txt

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -315,7 +315,7 @@ jobs:
         bash examples/models/moshi/mimi/install_requirements.sh
 
         # reinstall executorch
-        bash ./install_executorch.sh
+        bash ./install_executorch.sh --minimal
 
         # run python unittest
         python -m unittest examples.models.moshi.mimi.test_mimi

--- a/backends/openvino/scripts/openvino_build.sh
+++ b/backends/openvino/scripts/openvino_build.sh
@@ -52,7 +52,7 @@ main() {
         export CMAKE_BUILD_ARGS="--target openvino_backend"
 
         # Build the package
-        ./install_executorch.sh
+        ./install_executorch.sh --minimal
 
         # Install torchao
         pip install third-party/ao

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -174,6 +174,10 @@ def install_optional_example_requirements(use_pytorch_nightly):
             "install",
             "-r",
             "requirements-examples.txt",
+            "--extra-index-url",
+            TORCH_NIGHTLY_URL,
+            "--upgrade-strategy",
+            "only-if-needed",
         ],
         check=True,
     )


### PR DESCRIPTION
For failing mosh test, https://hud.pytorch.org/hud/pytorch/executorch/main/1?per_page=50&name_filter=test-moshi-linux&mergeEphemeralLF=true

First, ./install_executorch.sh correctly installs PyTorch nightly:
Successfully installed torch-2.9.0.dev20250725+cpu

Then processes requirements-examples.txt which contains timm==1.0.7
When installing timm, pip detects a dependency conflict and downgrades PyTorch to 2.4.1

Let's try adding --extra-index-url