### PR TITLE
Readme say set ANDROID_SDK

### DIFF
--- a/extension/android/README.md
+++ b/extension/android/README.md
@@ -23,7 +23,7 @@ Under `extension/android/`,
 
 The usage is:
 ```sh
-export ANDROID_HOME=/path/to/sdk
+export ANDROID_SDK=/path/to/sdk
 export ANDROID_NDK=/path/to/ndk
 sh scripts/build_android_library.sh
 ```


### PR DESCRIPTION
Summary: The README should say to set ANDROID_SDK (not ANDROID_HOME, which is set inside the script `build_android_library.sh`)

Reviewed By: cccclai

Differential Revision: D79387440
