### PR TITLE
Updates to Arm Zephyr CI Add Model Test

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -99,7 +99,7 @@ jobs:
         cd $ARM_FVP_TUTORIALS_ROOT
         python build_model.py \
             --executorch-root $ZEPHYR_PROJ_ROOT/modules/lib/executorch \
-            --pte-file ~/modules/lib/executorch/${MODEL_NAME}.pte \
+            --pte-file $ZEPHYR_PROJ_ROOT/modules/lib/executorch/${MODEL_NAME}.pte \
             --output-path $ARM_FVP_TUTORIALS_ROOT/models/${MODEL_NAME}/src/
 
         cd $ARM_FVP_TUTORIALS_ROOT/models/${MODEL_NAME}/

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -120,13 +120,17 @@ jobs:
         grep -qF "ERROR" sim.out
         exit_status=$? #store 0 if found (failure), 1 if not (success)
         if [[ "$exit_status" -eq "0" ]]; then
+          cat sim.out
           exit 1
         fi
 
         # Report fail if simulation does not complete successfully
         grep -qF "SUCCESS: Program complete, exiting." sim.out
         exit_status=$? #store 0 if found (success), 1 if not (failure)
-        exit $exit_status
+        if [[ "$exit_status" -eq "1" ]]; then
+          cat sim.out
+          exit 1
+        fi
 
   test-models-linux-aarch64:
     name: test-models-linux-aarch64

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -100,9 +100,9 @@ jobs:
         python build_model.py \
             --executorch-root $ZEPHYR_PROJ_ROOT/modules/lib/executorch \
             --pte-file ~/modules/lib/executorch/${MODEL_NAME}.pte \
-            --output-path models/${MODEL_NAME}/src/
+            --output-path $ARM_FVP_TUTORIALS_ROOT/models/${MODEL_NAME}/src/
 
-        cd $ZEPHYR_PROJ_ROOT/zephyr/samples/modules/executorch/arm-fvp-tutorials/models/${MODEL_NAME}/
+        cd $ARM_FVP_TUTORIALS_ROOT/models/${MODEL_NAME}/
 
         # Build the zephyr elf
         west build -p always -b mps3/corstone300/fvp

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -97,7 +97,11 @@ jobs:
 
         # Generate the C-style header
         cd $ARM_FVP_TUTORIALS_ROOT
-        python build_model.py --pte-file ~/modules/lib/executorch/${MODEL_NAME}.pte --output-path models/${MODEL_NAME}/src/
+        python build_model.py \
+            --executorch-root $ZEPHYR_PROJ_ROOT/modules/lib/executorch \
+            --pte-file ~/modules/lib/executorch/${MODEL_NAME}.pte \
+            --output-path models/${MODEL_NAME}/src/
+
         cd $ZEPHYR_PROJ_ROOT/zephyr/samples/modules/executorch/arm-fvp-tutorials/models/${MODEL_NAME}/
 
         # Build the zephyr elf

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -78,6 +78,7 @@ jobs:
         mkdir -p zephyr_scratch/
         cd zephyr_scratch
         export ZEPHYR_PROJ_ROOT=$(realpath $(pwd))
+        export ARM_FVP_TUTORIALS_ROOT=$ZEPHYR_PROJ_ROOT/zephyr/samples/modules/executorch/arm-fvp-tutorials
 
         download_arm_zephyr_sdk
         ./zephyr-sdk-0.16.0/setup.sh -c -t arm-zephyr-eabi
@@ -90,11 +91,36 @@ jobs:
         .ci/scripts/setup-arm-baremetal-tools.sh --target-toolchain zephyr
         source examples/arm/ethos-u-scratch/setup_path.sh
         source $ZEPHYR_PROJ_ROOT/zephyr/zephyr-env.sh
-        cd $ZEPHYR_PROJ_ROOT/zephyr/samples/modules/executorch/arm/hello_world
-        west build -p always -b mps3/corstone300/fvp
-        FVP_Corstone_SSE-300_Ethos-U55 -a build/zephyr/zephyr.elf -C mps3_board.visualisation.disable-visualisation=1 -C mps3_board.telnetterminal0.start_telnet=0 -C mps3_board.uart0.out_file='sim.out'  -C cpu0.CFGITCMSZ=15 -C cpu0.CFGDTCMSZ=15 --simlimit 120
 
-        grep -qF "Output[0][0]: (float) 2.000000" sim.out
+        # Get the model as PTE
+        python -m examples.arm.aot_arm_compiler --model_name="${MODEL_NAME}" --output="${MODEL_NAME}.pte"
+
+        # Generate the C-style header
+        cd $ARM_FVP_TUTORIALS_ROOT
+        python build_model.py --pte-file ~/modules/lib/executorch/${MODEL_NAME}.pte --output-path models/${MODEL_NAME}/src/
+        cd $ZEPHYR_PROJ_ROOT/zephyr/samples/modules/executorch/arm-fvp-tutorials/models/${MODEL_NAME}/
+
+        # Build the zephyr elf
+        west build -p always -b mps3/corstone300/fvp
+
+        # Run the simulation
+        FVP_Corstone_SSE-300_Ethos-U55 -a build/zephyr/zephyr.elf \
+            -C mps3_board.visualisation.disable-visualisation=1 \
+            -C mps3_board.telnetterminal0.start_telnet=0 \
+            -C mps3_board.uart0.out_file='sim.out'  \
+            -C cpu0.CFGITCMSZ=15 \
+            -C cpu0.CFGDTCMSZ=15 \
+            --simlimit 120
+
+        # Report failure if any of the ouptut verification checks fail
+        grep -qF "ERROR" sim.out
+        exit_status=$? #store 0 if found (failure), 1 if not (success)
+        if [[ "$exit_status" -eq "0" ]]; then
+          exit 1
+        fi
+
+        # Report fail if simulation does not complete successfully
+        grep -qF "SUCCESS: Program complete, exiting." sim.out
         exit_status=$? #store 0 if found (success), 1 if not (failure)
         exit $exit_status
 


### PR DESCRIPTION
### Summary
Previously, the `test-models-arm-zephyr` CI job ran the Add model to test and verify the flow for running ExecuTorch models on a simulated device running Zephyr RTOS. The original test relied on hard coded paths and artifacts that made the test unusable for other models. Now, the test has been templatized so that adding models can be done easily (and will follow in a future PR).

### Test plan
Manually tested the commands, and the CI job will confirm that the test still passes. 