### PR TITLE
Add ability to pass model_dir to .ci/scripts/test_huggingface_optimum

### DIFF
--- a/.ci/scripts/test_huggingface_optimum_model.py
+++ b/.ci/scripts/test_huggingface_optimum_model.py
@@ -262,7 +262,7 @@ def test_vit(model_id, model_dir, recipe, *, quantize=False, run_only=False):
 
     assert torch.allclose(
         eager_output.logits, et_output, atol=1e-02, rtol=1e-02
-    ), "CoreML output does not match eager"
+    ), "Model output does not match eager"
 
 
 if __name__ == "__main__":
@@ -270,7 +270,12 @@ if __name__ == "__main__":
     parser.add_argument("--model", type=str, required=True)
     parser.add_argument("--recipe", type=str, required=True)
     parser.add_argument("--quantize", action="store_true", help="Enable quantization")
-    parser.add_argument("--model_dir", type=str, required=False)
+    parser.add_argument(
+        "--model_dir",
+        type=str,
+        required=False,
+        help="When provided, write the pte file to this directory. Otherwise, a temporary directory is created for the test.",
+    )
     args = parser.parse_args()
 
     model_to_model_id_and_test_function = {
@@ -296,19 +301,10 @@ if __name__ == "__main__":
         )
 
     model_id, test_fn = model_to_model_id_and_test_function[args.model]
-    if args.model_dir is None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            test_fn(
-                model_id=model_id,
-                model_dir=tmp_dir,
-                recipe=args.recipe,
-                quantize=args.quantize,
-            )
-    else:
+    with tempfile.TemporaryDirectory() as tmp_dir:
         test_fn(
             model_id=model_id,
-            model_dir=args.model_dir,
+            model_dir=tmp_dir if args.model_dir is None else args.model_dir,
             recipe=args.recipe,
             quantize=args.quantize,
-            run_only=False,
         )

--- a/.ci/scripts/test_huggingface_optimum_model.py
+++ b/.ci/scripts/test_huggingface_optimum_model.py
@@ -270,6 +270,7 @@ if __name__ == "__main__":
     parser.add_argument("--model", type=str, required=True)
     parser.add_argument("--recipe", type=str, required=True)
     parser.add_argument("--quantize", action="store_true", help="Enable quantization")
+    parser.add_argument("--model_dir", type=str, required=False)
     args = parser.parse_args()
 
     model_to_model_id_and_test_function = {
@@ -294,11 +295,20 @@ if __name__ == "__main__":
             f"Unknown model name: {args.model}. Available models: {model_to_model_id_and_test_function.keys()}"
         )
 
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        model_id, test_fn = model_to_model_id_and_test_function[args.model]
+    model_id, test_fn = model_to_model_id_and_test_function[args.model]
+    if args.model_dir is None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            test_fn(
+                model_id=model_id,
+                model_dir=tmp_dir,
+                recipe=args.recipe,
+                quantize=args.quantize,
+            )
+    else:
         test_fn(
             model_id=model_id,
-            model_dir=tmp_dir,
+            model_dir=args.model_dir,
             recipe=args.recipe,
             quantize=args.quantize,
+            run_only=False,
         )


### PR DESCRIPTION
Adds ability to specify model_dir to optimum test script.  This is convinient if you want the pte file for local debugging.  If no model_dir is specified, a temp directory is created.
