### PR TITLE
NXP backend: Fix Copyright findings

### DIFF
--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/sigmoid_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/sigmoid_converter.py
@@ -1,5 +1,4 @@
 # Copyright 2025 NXP
-# All rights reserved.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.

--- a/backends/nxp/backend/ir/converter/node_converters/shared/conv_utils.py
+++ b/backends/nxp/backend/ir/converter/node_converters/shared/conv_utils.py
@@ -1,8 +1,7 @@
 # Copyright 2023-2025 NXP
 #
-# License: LA_OPT_NXP_Software_License
-# See the LICENSE_LA_OPT_NXP_Software_License for more details.
-#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
 
 from copy import copy
 from dataclasses import dataclass

--- a/backends/nxp/backend/ir/tflite_generator/builtin_options/add_n_options.py
+++ b/backends/nxp/backend/ir/tflite_generator/builtin_options/add_n_options.py
@@ -1,5 +1,6 @@
 #
 # Copyright 2023 Martin Pavella
+# Copyright 2024 NXP
 #
 # License: MIT
 # See the LICENSE_MIT for more details.

--- a/backends/nxp/backend/ir/tflite_generator/builtin_options/add_options.py
+++ b/backends/nxp/backend/ir/tflite_generator/builtin_options/add_options.py
@@ -1,5 +1,6 @@
 #
 # Copyright 2023 Martin Pavella
+# Copyright 2024 NXP
 #
 # License: MIT
 # See the LICENSE_MIT for more details.

--- a/backends/nxp/backend/ir/tflite_generator/builtin_options/average_pool_2d_options.py
+++ b/backends/nxp/backend/ir/tflite_generator/builtin_options/average_pool_2d_options.py
@@ -1,5 +1,6 @@
 #
 # Copyright 2023 Martin Pavella
+# Copyright 2024 NXP
 #
 # License: MIT
 # See the LICENSE_MIT for more details.

--- a/backends/nxp/backend/ir/tflite_generator/builtin_options/leaky_relu_options.py
+++ b/backends/nxp/backend/ir/tflite_generator/builtin_options/leaky_relu_options.py
@@ -1,5 +1,6 @@
 #
 # Copyright 2023 Martin Pavella
+# Copyright 2024 NXP
 #
 # License: MIT
 # See the LICENSE_MIT for more details.

--- a/backends/nxp/backend/ir/tflite_generator/builtin_options/log_softmax_options.py
+++ b/backends/nxp/backend/ir/tflite_generator/builtin_options/log_softmax_options.py
@@ -1,5 +1,6 @@
 #
 # Copyright 2023 Martin Pavella
+# Copyright 2024 NXP
 #
 # License: MIT
 # See the LICENSE_MIT for more details.

--- a/backends/nxp/backend/ir/tflite_generator/builtin_options/max_pool_2d_options.py
+++ b/backends/nxp/backend/ir/tflite_generator/builtin_options/max_pool_2d_options.py
@@ -1,5 +1,6 @@
 #
 # Copyright 2023 Martin Pavella
+# Copyright 2024 NXP
 #
 # License: MIT
 # See the LICENSE_MIT for more details.

--- a/backends/nxp/backend/ir/tflite_generator/builtin_options/reshape_options.py
+++ b/backends/nxp/backend/ir/tflite_generator/builtin_options/reshape_options.py
@@ -1,5 +1,6 @@
 #
 # Copyright 2023 Martin Pavella
+# Copyright 2024 NXP
 #
 # License: MIT
 # See the LICENSE_MIT for more details.

--- a/backends/nxp/backend/ir/tflite_generator/builtin_options/softmax_options.py
+++ b/backends/nxp/backend/ir/tflite_generator/builtin_options/softmax_options.py
@@ -1,5 +1,6 @@
 #
 # Copyright 2023 Martin Pavella
+# Copyright 2024 NXP
 #
 # License: MIT
 # See the LICENSE_MIT for more details.

--- a/backends/nxp/backend/ir/tflite_generator/builtin_options/sub_options.py
+++ b/backends/nxp/backend/ir/tflite_generator/builtin_options/sub_options.py
@@ -1,5 +1,6 @@
 #
 # Copyright 2023 Martin Pavella
+# Copyright 2024 NXP
 #
 # License: MIT
 # See the LICENSE_MIT for more details.

--- a/backends/nxp/backend/ir/tflite_generator/builtin_options/transpose_options.py
+++ b/backends/nxp/backend/ir/tflite_generator/builtin_options/transpose_options.py
@@ -1,5 +1,6 @@
 #
 # Copyright 2023 Martin Pavella
+# Copyright 2024 NXP
 #
 # License: MIT
 # See the LICENSE_MIT for more details.

--- a/backends/nxp/neutron_partitioner.py
+++ b/backends/nxp/neutron_partitioner.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 NXP
+# Copyright 2024-2025 NXP
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.

--- a/backends/nxp/tests/ir/converter/node_converter/test_sigmoid_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_sigmoid_converter.py
@@ -1,5 +1,4 @@
 # Copyright 2025 NXP
-# All rights reserved.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.

--- a/backends/nxp/tests/ir/edge_passes/test_remove_io_quant_ops_pass.py
+++ b/backends/nxp/tests/ir/edge_passes/test_remove_io_quant_ops_pass.py
@@ -1,7 +1,8 @@
-# Copyright 2025 NXP
+# Copyright 2024-2025 NXP
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+
 import itertools
 
 import executorch.kernels.quantized  # noqa F401


### PR DESCRIPTION
### Summary

Fixes Copyright notes in NXP co-authored files.

cc @robert-kalmar @jirioc 