### PR TITLE
NXP backend: Update to Neutron Converter SDK_25.06

### DIFF
--- a/backends/nxp/backend/neutron_converter_manager.py
+++ b/backends/nxp/backend/neutron_converter_manager.py
@@ -50,6 +50,8 @@ class NeutronConverterManager:
 
         cctx = neutron_converter.CompilationContext()
         cctx.targetOpts = neutron_converter.getNeutronTarget(target)
+        # New switch since Neutron Converter SDK_25.06
+        cctx.compilationOpts.minNumOpsPerGraph = 1
         model_converted = neutron_converter.convertModel(list(tflite_model), cctx)
 
         return bytes(model_converted)

--- a/backends/nxp/nxp_backend.py
+++ b/backends/nxp/nxp_backend.py
@@ -64,7 +64,7 @@ class NeutronCompileSpecBuilder:
         Args:
             config: Neutron accelerator configuration, e.g. "imxrt700"
             neutron_converter_flavor: Flavor of the neutron-converter module to use. Neutron-converter module named "
-             "'neutron_converter_SDK_25_03' has flavor 'SDK_25_03'.
+             "'neutron_converter_SDK_25_06' has flavor 'SDK_25_06'.
             extra_flags: Extra flags for the Neutron compiler
             operators_not_to_delegate: List of operators that should not be delegated
         """

--- a/backends/nxp/requirements-tests-eiq.txt
+++ b/backends/nxp/requirements-tests-eiq.txt
@@ -1,2 +1,2 @@
 --index-url https://eiq.nxp.com/repository
-neutron_converter_SDK_25_03
+neutron_converter_SDK_25_06

--- a/backends/nxp/tests/executorch_pipeline.py
+++ b/backends/nxp/tests/executorch_pipeline.py
@@ -88,7 +88,7 @@ def to_quantized_edge_program(
         [tuple[ModelInputSpec, ...]], list[tuple[torch.Tensor, ...]]
     ] = get_random_calibration_inputs,
     target="imxrt700",
-    neutron_converter_flavor="SDK_25_03",
+    neutron_converter_flavor="SDK_25_06",
     remove_quant_io_ops=False,
     custom_delegation_options=CustomDelegationOptions(),  # noqa B008
 ) -> EdgeProgramManager:

--- a/backends/nxp/tests/test_neutron_converter_manager.py
+++ b/backends/nxp/tests/test_neutron_converter_manager.py
@@ -30,7 +30,7 @@ def test_conv2d_neutron_conversion__default_flavor():
 
     neutron_converter_manager = NeutronConverterManager()
     neutron_model = neutron_converter_manager.convert(
-        tflite_model, "imxrt700", "SDK_25_03"
+        tflite_model, "imxrt700", "SDK_25_06"
     )
 
     assert len(

--- a/examples/nxp/README.md
+++ b/examples/nxp/README.md
@@ -13,7 +13,7 @@ $ examples/nxp/setup.sh
 2. Now run the `aot_neutron_compile.py` example with the `cifar10` model 
 ```commandline
 $ python -m examples.nxp.aot_neutron_compile --quantize \
-    --delegate --neutron_converter_flavor SDK_25_03 -m cifar10 
+    --delegate --neutron_converter_flavor SDK_25_06 -m cifar10 
 ```
 
 3. It will generate you `cifar10_nxp_delegate.pte` file which can be used with the MXUXpresso SDK `cifarnet_example` project, presented [here](https://mcuxpresso.nxp.com/mcuxsdk/latest/html/middleware/eiq/executorch/docs/nxp/topics/example_applications.html#how-to-build-and-run-executorch-cifarnet-example).

--- a/examples/nxp/aot_neutron_compile.py
+++ b/examples/nxp/aot_neutron_compile.py
@@ -167,7 +167,7 @@ if __name__ == "__main__":  # noqa C901
         "-c",
         "--neutron_converter_flavor",
         required=False,
-        default="SDK_25_03",
+        default="SDK_25_06",
         help="Flavor of installed neutron-converter module. Neutron-converter module named "
         "'neutron_converter_SDK_24_12' has flavor 'SDK_24_12'.",
     )

--- a/examples/nxp/run_aot_example.sh
+++ b/examples/nxp/run_aot_example.sh
@@ -13,6 +13,6 @@ cd $EXECUTORCH_DIR
 
 # Run the AoT example
 python -m examples.nxp.aot_neutron_compile --quantize \
-    --delegate --neutron_converter_flavor SDK_25_03 -m ${MODEL}
+    --delegate --neutron_converter_flavor SDK_25_06 -m ${MODEL}
 # verify file exists
 test -f ${MODEL}_nxp_delegate.pte

--- a/examples/nxp/setup.sh
+++ b/examples/nxp/setup.sh
@@ -7,4 +7,4 @@
 set -u
 
 # Install neutron-converter
-pip install --index-url https://eiq.nxp.com/repository neutron_converter_SDK_25_03
+pip install --index-url https://eiq.nxp.com/repository neutron_converter_SDK_25_06


### PR DESCRIPTION
### Summary

Bumps Neutron Converter SDK version and decreases min-num-ops-per-graph to revert the original Neutron Converter functionality.

### Test plan

You can test this change by running NXP backend tests since almost all of them rely on Neutron Converter.

cc @digantdesai @JakeStevens @robert-kalmar 