### PR TITLE
Test xnnpack with pybindings

### DIFF
--- a/.ci/scripts/test_model.sh
+++ b/.ci/scripts/test_model.sh
@@ -134,10 +134,10 @@ test_model_with_xnnpack() {
   # Delegation and test with pybindings
   if [[ ${WITH_QUANTIZATION} == true ]]; then
     SUFFIX="q8"
-    "${PYTHON_EXECUTABLE}" -m examples.xnnpack.aot_compiler --model_name="${MODEL_NAME}" --delegate --quantize --test_with_pybindings
+    "${PYTHON_EXECUTABLE}" -m examples.xnnpack.aot_compiler --model_name="${MODEL_NAME}" --delegate --quantize --test_after_export
   else
     SUFFIX="fp32"
-    "${PYTHON_EXECUTABLE}" -m examples.xnnpack.aot_compiler --model_name="${MODEL_NAME}" --delegate --test_with_pybindings
+    "${PYTHON_EXECUTABLE}" -m examples.xnnpack.aot_compiler --model_name="${MODEL_NAME}" --delegate --test_after_export
   fi
 
   OUTPUT_MODEL_PATH="${MODEL_NAME}_xnnpack_${SUFFIX}.pte"

--- a/.ci/scripts/test_model.sh
+++ b/.ci/scripts/test_model.sh
@@ -131,13 +131,13 @@ test_model_with_xnnpack() {
     return 0
   fi
 
-  # Delegation
+  # Delegation and test with pybindings
   if [[ ${WITH_QUANTIZATION} == true ]]; then
     SUFFIX="q8"
-    "${PYTHON_EXECUTABLE}" -m examples.xnnpack.aot_compiler --model_name="${MODEL_NAME}" --delegate --quantize
+    "${PYTHON_EXECUTABLE}" -m examples.xnnpack.aot_compiler --model_name="${MODEL_NAME}" --delegate --quantize --test_with_pybindings
   else
     SUFFIX="fp32"
-    "${PYTHON_EXECUTABLE}" -m examples.xnnpack.aot_compiler --model_name="${MODEL_NAME}" --delegate
+    "${PYTHON_EXECUTABLE}" -m examples.xnnpack.aot_compiler --model_name="${MODEL_NAME}" --delegate --test_with_pybindings
   fi
 
   OUTPUT_MODEL_PATH="${MODEL_NAME}_xnnpack_${SUFFIX}.pte"

--- a/examples/xnnpack/aot_compiler.py
+++ b/examples/xnnpack/aot_compiler.py
@@ -129,6 +129,14 @@ if __name__ == "__main__":
     if args.test_pybind:
         logging.info("Testing the pte with pybind")
         from executorch.extension.pybindings.portable_lib import _load_for_executorch_from_buffer
+        # Import custom ops. This requires portable_lib to be loaded first.
+        from executorch.extension.llm.custom_ops import (  # noqa: F401, F403
+            custom_ops,
+        )  # usort: skip
 
+        # Import quantized ops. This requires portable_lib to be loaded first.
+        from executorch.kernels import quantized  # usort: skip # noqa: F401, F403
         m = _load_for_executorch_from_buffer(exec_prog.buffer)
-        m.run_method("forward", example_inputs)
+        logging.info("Successfully loaded the model")
+        res = m.run_method("forward", example_inputs)
+        logging.info("Successfully ran the model")

--- a/examples/xnnpack/aot_compiler.py
+++ b/examples/xnnpack/aot_compiler.py
@@ -61,6 +61,14 @@ if __name__ == "__main__":
         default="",
         help="Generate and save an ETRecord to the given file location",
     )
+    parser.add_argument(
+        "-t",
+        "--test_with_pybindings",
+        action="store_true",
+        required=False,
+        default=False,
+        help="Test the pte with pybindings",
+    )
     parser.add_argument("-o", "--output_dir", default=".", help="output directory")
 
     args = parser.parse_args()
@@ -117,3 +125,10 @@ if __name__ == "__main__":
     quant_tag = "q8" if args.quantize else "fp32"
     model_name = f"{args.model_name}_xnnpack_{quant_tag}"
     save_pte_program(exec_prog, model_name, args.output_dir)
+
+    if args.test_pybind:
+        logging.info("Testing the pte with pybind")
+        from executorch.extension.pybindings.portable_lib import _load_for_executorch_from_buffer
+
+        m = _load_for_executorch_from_buffer(exec_prog.buffer)
+        m.run_method("forward", example_inputs)

--- a/examples/xnnpack/aot_compiler.py
+++ b/examples/xnnpack/aot_compiler.py
@@ -63,7 +63,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "-t",
-        "--test_with_pybindings",
+        "--test_after_export",
         action="store_true",
         required=False,
         default=False,
@@ -126,7 +126,7 @@ if __name__ == "__main__":
     model_name = f"{args.model_name}_xnnpack_{quant_tag}"
     save_pte_program(exec_prog, model_name, args.output_dir)
 
-    if args.test_with_pybindings:
+    if args.test_after_export:
         logging.info("Testing the pte with pybind")
         from executorch.extension.pybindings.portable_lib import (
             _load_for_executorch_from_buffer,

--- a/examples/xnnpack/aot_compiler.py
+++ b/examples/xnnpack/aot_compiler.py
@@ -142,5 +142,5 @@ if __name__ == "__main__":
 
         m = _load_for_executorch_from_buffer(exec_prog.buffer)
         logging.info("Successfully loaded the model")
-        res = m.run_method("forward", example_inputs)
+        res = m.run_method("forward", *example_inputs)
         logging.info("Successfully ran the model")

--- a/examples/xnnpack/aot_compiler.py
+++ b/examples/xnnpack/aot_compiler.py
@@ -128,7 +128,10 @@ if __name__ == "__main__":
 
     if args.test_pybind:
         logging.info("Testing the pte with pybind")
-        from executorch.extension.pybindings.portable_lib import _load_for_executorch_from_buffer
+        from executorch.extension.pybindings.portable_lib import (
+            _load_for_executorch_from_buffer,
+        )
+
         # Import custom ops. This requires portable_lib to be loaded first.
         from executorch.extension.llm.custom_ops import (  # noqa: F401, F403
             custom_ops,
@@ -136,6 +139,7 @@ if __name__ == "__main__":
 
         # Import quantized ops. This requires portable_lib to be loaded first.
         from executorch.kernels import quantized  # usort: skip # noqa: F401, F403
+
         m = _load_for_executorch_from_buffer(exec_prog.buffer)
         logging.info("Successfully loaded the model")
         res = m.run_method("forward", example_inputs)

--- a/examples/xnnpack/aot_compiler.py
+++ b/examples/xnnpack/aot_compiler.py
@@ -139,8 +139,10 @@ if __name__ == "__main__":
 
         # Import quantized ops. This requires portable_lib to be loaded first.
         from executorch.kernels import quantized  # usort: skip # noqa: F401, F403
+        from torch.utils._pytree import tree_flatten
 
         m = _load_for_executorch_from_buffer(exec_prog.buffer)
         logging.info("Successfully loaded the model")
-        res = m.run_method("forward", *example_inputs)
+        flattened = tree_flatten(example_inputs)[0]
+        res = m.run_method("forward", flattened)
         logging.info("Successfully ran the model")

--- a/examples/xnnpack/aot_compiler.py
+++ b/examples/xnnpack/aot_compiler.py
@@ -126,7 +126,7 @@ if __name__ == "__main__":
     model_name = f"{args.model_name}_xnnpack_{quant_tag}"
     save_pte_program(exec_prog, model_name, args.output_dir)
 
-    if args.test_pybind:
+    if args.test_with_pybindings:
         logging.info("Testing the pte with pybind")
         from executorch.extension.pybindings.portable_lib import (
             _load_for_executorch_from_buffer,


### PR DESCRIPTION
Make sure we run xnnpack delegated model using pybindings, in `test_models.sh`.
