### PR TITLE
Fix et_logger by remove the self args in the et_logger decorator

### DIFF
--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -109,8 +109,8 @@ except ImportError:
     # Define a stub decorator that does nothing
     def et_logger(api_name: str) -> Callable[[Any], Any]:
         def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
-            def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
-                return func(self, *args, **kwargs)
+            def wrapper(*args: Any, **kwargs: Any) -> Any:
+                return func(*args, **kwargs)
 
             return wrapper
 


### PR DESCRIPTION
Summary: Had the similar change in D67420902 and now hits the same error in oss. Port the changes over for the fix

Differential Revision: D79665973
