### PR TITLE
make ExecuTorch program always has valid debug handle map and delegate map

### DIFF
--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -613,7 +613,7 @@ class ExecutorchProgram:
     def debug_handle_map(self) -> Dict[int, Union[int, List[int]]]:
         if self._emitter_output:
             return self._emitter_output.debug_handle_map
-        return {}
+        return self._get_emitter_output().debug_handle_map
 
     @property
     def delegate_map(
@@ -621,7 +621,7 @@ class ExecutorchProgram:
     ) -> Dict[str, Dict[int, Dict[str, Union[str, _DelegateDebugIdentifierMap]]]]:
         if self._emitter_output:
             return self._emitter_output.method_to_delegate_debug_id_map
-        return {}
+        return self._get_emitter_output().method_to_delegate_debug_id_map
 
     @property
     def graph_module(self) -> torch.fx.GraphModule:


### PR DESCRIPTION
Summary:
Currently ExecuTorchProgram's debug handle map and delegate map will be empty if we didn't call its _get_emitter_output function directly or indrectly before. This behavior doesn't make sense because:
a. the empty result can not reflect the executorch program's state
b. not in line with ExecuTorchProgramManager behavior
c. other attributes, like self.buffer and self.program, do not have such behavir and can always return valid result.

This PR makes them always has valid value..

Differential Revision: D79706058


