### PR TITLE
Arm backend: Remove submodule serialization_lib

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "backends/arm/third-party/ethos-u-core-driver"]
 	path = backends/arm/third-party/ethos-u-core-driver
 	url = https://git.gitlab.arm.com/artificial-intelligence/ethos-u/ethos-u-core-driver.git
-[submodule "backends/arm/third-party/serialization_lib"]
-	path = backends/arm/third-party/serialization_lib
-	url = https://git.gitlab.arm.com/tosa/tosa-serialization.git
 [submodule "backends/vulkan/third-party/Vulkan-Headers"]
 	path = backends/vulkan/third-party/Vulkan-Headers
 	url = https://github.com/KhronosGroup/Vulkan-Headers


### PR DESCRIPTION
Remove the git submodule serialization_lib since its pointing to an old 0.80 tag and is not used by the arm backend.

Instead this library is now cloned part of the tosa-reference-module when needed.

Change-Id: I34a3707b35cab6413e8aa5365fc41d404b4eb9fa
Signed-off-by: per.held@arm.com


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218