### PR TITLE
Alternative format specifier for %zd

### DIFF
--- a/runtime/executor/method.cpp
+++ b/runtime/executor/method.cpp
@@ -748,7 +748,7 @@ Error Method::resolve_operator(
   if (!op_function.ok()) {
     ET_LOG(
         Error,
-        "Missing operator: [%zd] %s",
+        "Missing operator: [%" ET_PRIssize_t "] %s",
         static_cast<ssize_t>(op_index),
         operator_name);
     return op_function.error();

--- a/runtime/platform/compiler.h
+++ b/runtime/platform/compiler.h
@@ -149,8 +149,10 @@
 // As of G3 RJ-2024.3 toolchain, zu format specifier is not supported for Xtensa
 #if defined(__XTENSA__)
 #define ET_PRIsize_t "lu"
+#define ET_PRIssize_t "ld"
 #else
 #define ET_PRIsize_t "zu"
+#define ET_PRIssize_t "zd"
 #endif
 
 // Whether the compiler supports GNU statement expressions.


### PR DESCRIPTION
Summary: At runtime this format specifier is not correctly handled by our toolchain's libc implementation. The misformatted string get's passed to strlen and eventually causes an assertion.

Differential Revision: D79776266


