### PR TITLE
Fix pyre errors

### DIFF
--- a/exir/backend/test/demos/rpc/executor_backend_partitioner.py
+++ b/exir/backend/test/demos/rpc/executor_backend_partitioner.py
@@ -8,6 +8,8 @@ import typing
 from typing import final
 
 import torch
+import torch.fx
+
 from executorch.exir.backend.canonical_partitioners.pattern_op_partitioner import (
     generate_pattern_op_partitions,
 )
@@ -65,8 +67,9 @@ class ExecutorBackendPartitioner(Partitioner):
                 partition_tags[delegation_tag] = self.delegation_spec
 
                 # Tag the delegate submodules
-                if node.args[0].op == "get_attr":
-                    node.args[0].meta["delegation_tag"] = delegation_tag
+                arg0 = node.args[0]
+                if isinstance(arg0, torch.fx.Node) and arg0.op == "get_attr":
+                    arg0.meta["delegation_tag"] = delegation_tag
 
         return PartitionResult(
             tagged_exported_program=edge_exported_program,

--- a/exir/backend/test/test_backends_nested.py
+++ b/exir/backend/test/test_backends_nested.py
@@ -197,8 +197,11 @@ class Backend1PartitionerDemo(Partitioner):
                     and node.target is torch.ops.higher_order.cond
                 ):
                     # Tag the arguments that take in the submodules to cond
-                    node.args[1].meta["delegation_tag"] = delegation_tag
-                    node.args[2].meta["delegation_tag"] = delegation_tag
+                    arg1, arg2 = node.args[1], node.args[2]
+                    if isinstance(arg1, torch.fx.Node):
+                        arg1.meta["delegation_tag"] = delegation_tag
+                    if isinstance(arg2, torch.fx.Node):
+                        arg2.meta["delegation_tag"] = delegation_tag
                 node.meta["delegation_tag"] = delegation_tag
                 partition_tags[delegation_tag] = self.delegation_spec
         return partition_tags


### PR DESCRIPTION
Summary:
attempt to fix
```
    [executorch/exir/backend/test/demos/rpc/executor_backend_partitioner.py:68:19] Undefined attribute [16]: `None` has no attribute `op`.
    [executorch/exir/backend/test/demos/rpc/executor_backend_partitioner.py:69:20] Undefined attribute [16]: `None` has no attribute `meta`.
    [executorch/exir/backend/test/test_backends_nested.py:200:20] Undefined attribute [16]: `None` has no attribute `meta`.
```

in D79768387

Differential Revision: D79828275


