### PR TITLE
Typo Fix for Default Example Inputs to MobilenetV2 Export

### DIFF
--- a/examples/models/mobilenet_v2/model.py
+++ b/examples/models/mobilenet_v2/model.py
@@ -59,6 +59,7 @@ class MV2Model(EagerModelBase):
             input_batch = (input_batch,)
         return input_batch
 
+
 class MV2UntrainedModel(EagerModelBase):
     def __init__(self):
         pass

--- a/examples/models/mobilenet_v2/model.py
+++ b/examples/models/mobilenet_v2/model.py
@@ -57,8 +57,7 @@ class MV2Model(EagerModelBase):
             input_tensor = preprocess(input_image)
             input_batch = input_tensor.unsqueeze(0)
             input_batch = (input_batch,)
-        return (torch.randn(tensor_size),)
-
+        return input_batch
 
 class MV2UntrainedModel(EagerModelBase):
     def __init__(self):


### PR DESCRIPTION
### Summary
[PR](https://github.com/pytorch/executorch/pull/13019) forgot to change the return example input to use the default samoyed dog image when using real inputs. This PR fixes that typo.

### Test plan
Now the example runners that use the `mv2` export contain the dog image in the pte by default. 
