### PR TITLE
Require setting all inputs before execution.

### DIFF
--- a/backends/xnnpack/test/runtime/test_xnn_data_separation.cpp
+++ b/backends/xnnpack/test/runtime/test_xnn_data_separation.cpp
@@ -108,6 +108,21 @@ TEST_F(DataSeparationTest, TestE2E) {
       "forward", &mmm.get(), nullptr, linear_data_map_.get());
   ASSERT_EQ(method.error(), Error::Ok);
 
+  // Set a dummy input.
+  int32_t sizes[1] = {3};
+  uint8_t dim_order[1] = {0};
+  int32_t strides[1] = {1};
+  executorch::aten::TensorImpl impl(
+      executorch::aten::ScalarType::Float,
+      1,
+      sizes,
+      nullptr,
+      dim_order,
+      strides);
+  auto input_err = method->set_input(
+      executorch::runtime::EValue(executorch::aten::Tensor(&impl)), 0);
+  ASSERT_EQ(input_err, Error::Ok);
+
   // Can execute the method.
   Error err = method->execute();
   ASSERT_EQ(err, Error::Ok);

--- a/extension/runner_util/test/inputs_test.cpp
+++ b/extension/runner_util/test/inputs_test.cpp
@@ -75,6 +75,8 @@ class InputsTest : public ::testing::Test {
 TEST_F(InputsTest, Smoke) {
   Result<BufferCleanup> input_buffers = prepare_input_tensors(*method_);
   ASSERT_EQ(input_buffers.error(), Error::Ok);
+  auto input_err = method_->set_input(executorch::runtime::EValue(1.0), 2);
+  ASSERT_EQ(input_err, Error::Ok);
 
   // We can't look at the input tensors, but we can check that the outputs make
   // sense after executing the method.

--- a/runtime/core/error.h
+++ b/runtime/core/error.h
@@ -205,42 +205,37 @@ using ::executorch::runtime::error_code_t;
  * @param[in] ... Optional format string for the log error message and its
  * arguments.
  */
-#define ET_CHECK_OK_OR_RETURN_ERROR(error__, ...) \
-  ET_INTERNAL_CHECK_OK_OR_RETURN_ERROR(error__, ##__VA_ARGS__)
-
-// Internal only: Use ET_CHECK_OK_OR_RETURN_ERROR() instead.
-#define ET_INTERNAL_CHECK_OK_OR_RETURN_ERROR(...) \
-  ET_INTERNAL_CHECK_OK_OR_RETURN_ERROR_SELECT(    \
-      __VA_ARGS__, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1) \
-  (__VA_ARGS__)
+#define ET_CHECK_OK_OR_RETURN_ERROR(...) \
+  ET_INTERNAL_CHECK_OK_OR_RETURN_ERROR(__VA_ARGS__)
 
 /**
  * Internal only: Use ET_CHECK_OK_OR_RETURN_ERROR() instead.
  * This macro selects the correct version of
  * ET_INTERNAL_CHECK_OK_OR_RETURN_ERROR based on the number of arguments passed.
- * It uses a trick with the preprocessor to count the number of arguments and
- * then selects the appropriate macro.
- *
- * The macro expansion uses __VA_ARGS__ to accept any number of arguments and
- * then appends them to ET_INTERNAL_CHECK_OK_OR_RETURN_ERROR_, followed by the
- * count of arguments. The count is determined by the macro
- * ET_INTERNAL_CHECK_OK_OR_RETURN_ERROR_SELECT which takes the arguments and
- * passes them along with a sequence of numbers (2, 1). The preprocessor then
- * matches this sequence to the correct number of arguments provided.
- *
- * If two arguments are passed, ET_INTERNAL_CHECK_OK_OR_RETURN_ERROR_2 is
- * selected, suitable for cases where an error code and a custom message are
- * provided. If only one argument is passed,
- * ET_INTERNAL_CHECK_OK_OR_RETURN_ERROR_1 is selected, which is used for cases
- * with just an error code.
- *
- * Usage:
- * ET_CHECK_OK_OR_RETURN_ERROR(error_code); // Calls v1
- * ET_CHECK_OK_OR_RETURN_ERROR(error_code, "Error message", ...); // Calls v2
+ * It uses a helper that reliably picks the 1-arg or 2+-arg form on
+ * MSVC/Clang/GCC.
  */
-#define ET_INTERNAL_CHECK_OK_OR_RETURN_ERROR_SELECT( \
-    _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, N, ...) \
-  ET_INTERNAL_CHECK_OK_OR_RETURN_ERROR_##N
+#define ET_INTERNAL_EXPAND(x) x
+#define ET_INTERNAL_GET_MACRO(                          \
+    _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, NAME, ...) \
+  NAME
+
+// Internal only: Use ET_CHECK_OK_OR_RETURN_ERROR() instead.
+// Picks _2 for 2..10 args, _1 for exactly 1 arg.
+#define ET_INTERNAL_CHECK_OK_OR_RETURN_ERROR(...)      \
+  ET_INTERNAL_EXPAND(ET_INTERNAL_GET_MACRO(            \
+      __VA_ARGS__,                                     \
+      ET_INTERNAL_CHECK_OK_OR_RETURN_ERROR_2, /* 10 */ \
+      ET_INTERNAL_CHECK_OK_OR_RETURN_ERROR_2, /* 9  */ \
+      ET_INTERNAL_CHECK_OK_OR_RETURN_ERROR_2, /* 8  */ \
+      ET_INTERNAL_CHECK_OK_OR_RETURN_ERROR_2, /* 7  */ \
+      ET_INTERNAL_CHECK_OK_OR_RETURN_ERROR_2, /* 6  */ \
+      ET_INTERNAL_CHECK_OK_OR_RETURN_ERROR_2, /* 5  */ \
+      ET_INTERNAL_CHECK_OK_OR_RETURN_ERROR_2, /* 4  */ \
+      ET_INTERNAL_CHECK_OK_OR_RETURN_ERROR_2, /* 3  */ \
+      ET_INTERNAL_CHECK_OK_OR_RETURN_ERROR_2, /* 2  */ \
+      ET_INTERNAL_CHECK_OK_OR_RETURN_ERROR_1 /* 1  */  \
+      )(__VA_ARGS__))
 
 // Internal only: Use ET_CHECK_OK_OR_RETURN_ERROR() instead.
 #define ET_INTERNAL_CHECK_OK_OR_RETURN_ERROR_1(error__)   \
@@ -260,21 +255,3 @@ using ::executorch::runtime::error_code_t;
       return et_error__;                                                \
     }                                                                   \
   } while (0)
-
-// Internal only: Use ET_CHECK_OK_OR_RETURN_ERROR() instead.
-#define ET_INTERNAL_CHECK_OK_OR_RETURN_ERROR_3 \
-  ET_INTERNAL_CHECK_OK_OR_RETURN_ERROR_2
-#define ET_INTERNAL_CHECK_OK_OR_RETURN_ERROR_4 \
-  ET_INTERNAL_CHECK_OK_OR_RETURN_ERROR_2
-#define ET_INTERNAL_CHECK_OK_OR_RETURN_ERROR_5 \
-  ET_INTERNAL_CHECK_OK_OR_RETURN_ERROR_2
-#define ET_INTERNAL_CHECK_OK_OR_RETURN_ERROR_6 \
-  ET_INTERNAL_CHECK_OK_OR_RETURN_ERROR_2
-#define ET_INTERNAL_CHECK_OK_OR_RETURN_ERROR_7 \
-  ET_INTERNAL_CHECK_OK_OR_RETURN_ERROR_2
-#define ET_INTERNAL_CHECK_OK_OR_RETURN_ERROR_8 \
-  ET_INTERNAL_CHECK_OK_OR_RETURN_ERROR_2
-#define ET_INTERNAL_CHECK_OK_OR_RETURN_ERROR_9 \
-  ET_INTERNAL_CHECK_OK_OR_RETURN_ERROR_2
-#define ET_INTERNAL_CHECK_OK_OR_RETURN_ERROR_10 \
-  ET_INTERNAL_CHECK_OK_OR_RETURN_ERROR_2

--- a/runtime/executor/method.h
+++ b/runtime/executor/method.h
@@ -73,6 +73,7 @@ class Method final {
         event_tracer_(rhs.event_tracer_),
         n_value_(rhs.n_value_),
         values_(rhs.values_),
+        input_set_(rhs.input_set_),
         n_delegate_(rhs.n_delegate_),
         delegates_(rhs.delegates_),
         n_chains_(rhs.n_chains_),
@@ -85,6 +86,7 @@ class Method final {
     // anything twice.
     rhs.n_value_ = 0;
     rhs.values_ = nullptr;
+    rhs.input_set_ = nullptr;
     rhs.n_delegate_ = 0;
     rhs.delegates_ = nullptr;
 
@@ -181,6 +183,9 @@ class Method final {
   ET_NODISCARD Error get_outputs(EValue* output_evalues, size_t length);
 
   /**
+   * DEPRECATED: Use MethodMeta instead to access metadata, and set_input to
+   * update Method inputs.
+   *
    * Copies the method's inputs into the provided array.
    *
    * WARNING: The input contains shallow copies of internal tensor inputs.
@@ -194,7 +199,8 @@ class Method final {
    *
    * @returns Error::Ok on success, non-Ok on failure.
    */
-  ET_NODISCARD Error get_inputs(EValue* input_evalues, size_t length);
+  ET_DEPRECATED ET_NODISCARD Error
+  get_inputs(EValue* input_evalues, size_t length);
 
   /**
    *
@@ -314,6 +320,7 @@ class Method final {
         event_tracer_(event_tracer),
         n_value_(0),
         values_(nullptr),
+        input_set_(nullptr),
         n_delegate_(0),
         delegates_(nullptr),
         n_chains_(0),
@@ -362,6 +369,7 @@ class Method final {
 
   size_t n_value_;
   EValue* values_;
+  bool* input_set_;
 
   size_t n_delegate_;
   BackendDelegate* delegates_;

--- a/runtime/executor/test/allocation_failure_stress_test.cpp
+++ b/runtime/executor/test/allocation_failure_stress_test.cpp
@@ -88,6 +88,8 @@ TEST_F(AllocationFailureStressTest, End2EndIncreaseRuntimeMemUntilSuccess) {
     // once load was successful.
     auto input_cleanup = prepare_input_tensors(*method);
     ASSERT_EQ(input_cleanup.error(), Error::Ok);
+    auto input_err = method->set_input(executorch::runtime::EValue(1.0), 2);
+    ASSERT_EQ(input_err, Error::Ok);
     err = method->execute();
     ASSERT_EQ(err, Error::Ok);
   }
@@ -123,6 +125,8 @@ TEST_F(AllocationFailureStressTest, End2EndNonConstantMemUntilSuccess) {
     // once load was successful.
     auto input_cleanup = prepare_input_tensors(*method);
     ASSERT_EQ(input_cleanup.error(), Error::Ok);
+    auto input_err = method->set_input(executorch::runtime::EValue(1.0), 2);
+    ASSERT_EQ(input_err, Error::Ok);
     err = method->execute();
     ASSERT_EQ(err, Error::Ok);
   }

--- a/runtime/executor/test/backend_data_separation_test.cpp
+++ b/runtime/executor/test/backend_data_separation_test.cpp
@@ -95,6 +95,21 @@ TEST_F(BackendDataSeparationTest, TestSeparation) {
       /*named_data_map=*/linear_data_map_.get());
   ASSERT_EQ(method.error(), Error::Ok);
 
+  // Set a dummy input.
+  int32_t sizes[1] = {3};
+  uint8_t dim_order[1] = {0};
+  int32_t strides[1] = {1};
+  executorch::aten::TensorImpl impl(
+      executorch::aten::ScalarType::Float,
+      1,
+      sizes,
+      nullptr,
+      dim_order,
+      strides);
+  auto input_err = method->set_input(
+      executorch::runtime::EValue(executorch::aten::Tensor(&impl)), 0);
+  ASSERT_EQ(input_err, Error::Ok);
+
   // Can execute the method.
   Error err = method->execute();
   ASSERT_EQ(err, Error::Ok);

--- a/runtime/executor/test/backend_integration_test.cpp
+++ b/runtime/executor/test/backend_integration_test.cpp
@@ -603,6 +603,25 @@ TEST_P(BackendIntegrationTest, GetMethodNameDuringExecuteSuccess) {
   ManagedMemoryManager mmm(kDefaultNonConstMemBytes, kDefaultRuntimeMemBytes);
   Result<Method> method = program->load_method("forward", &mmm.get());
   EXPECT_TRUE(method.ok());
+
+  int32_t sizes[2] = {2, 2};
+  uint8_t dim_order[2] = {0, 1};
+  int32_t strides[2] = {2, 1};
+  executorch::aten::TensorImpl impl(
+      executorch::aten::ScalarType::Float,
+      2,
+      sizes,
+      nullptr,
+      dim_order,
+      strides);
+  auto input_err = method->set_input(
+      executorch::runtime::EValue(executorch::aten::Tensor(&impl)), 0);
+  input_err = method->set_input(
+      executorch::runtime::EValue(executorch::aten::Tensor(&impl)), 1);
+  input_err = method->set_input(
+      executorch::runtime::EValue(executorch::aten::Tensor(&impl)), 2);
+  ASSERT_EQ(input_err, Error::Ok);
+
   Error err = method->execute();
   ASSERT_EQ(err, Error::Ok);
 }

--- a/runtime/executor/test/kernel_integration_test.cpp
+++ b/runtime/executor/test/kernel_integration_test.cpp
@@ -248,6 +248,8 @@ class KernelIntegrationTest : public ::testing::Test {
     ASSERT_EQ(inputs_cleanup.error(), Error::Ok);
     inputs_cleanup_ = std::make_unique<executorch::extension::BufferCleanup>(
         std::move(*inputs_cleanup));
+    auto input_err = method_->set_input(executorch::runtime::EValue(1.0), 2);
+    ASSERT_EQ(input_err, Error::Ok);
   }
 
   void TearDown() override {

--- a/runtime/executor/test/method_test.cpp
+++ b/runtime/executor/test/method_test.cpp
@@ -104,9 +104,13 @@ TEST_F(MethodTest, MoveTest) {
   Result<Method> method = programs_["add"]->load_method("forward", &mmm.get());
   ASSERT_EQ(method.error(), Error::Ok);
 
-  // Can execute the method.
+  // Set dummy inputs.
   auto input_cleanup = prepare_input_tensors(*method);
   ASSERT_EQ(input_cleanup.error(), Error::Ok);
+  auto input_err = method->set_input(executorch::runtime::EValue(1.0), 2);
+  ASSERT_EQ(input_err, Error::Ok);
+
+  // Can execute the method.
   Error err = method->execute();
   ASSERT_EQ(err, Error::Ok);
 
@@ -312,6 +316,21 @@ TEST_F(MethodTest, ConstantSegmentTest) {
       programs_["add_mul"]->load_method("forward", &mmm.get());
   ASSERT_EQ(method.error(), Error::Ok);
 
+  // Set a dummy input.
+  int32_t sizes[2] = {2, 2};
+  uint8_t dim_order[2] = {0, 1};
+  int32_t strides[2] = {2, 1};
+  executorch::aten::TensorImpl impl(
+      executorch::aten::ScalarType::Float,
+      2,
+      sizes,
+      nullptr,
+      dim_order,
+      strides);
+  auto input_err = method->set_input(
+      executorch::runtime::EValue(executorch::aten::Tensor(&impl)), 0);
+  ASSERT_EQ(input_err, Error::Ok);
+
   // Can execute the method.
   Error err = method->execute();
   ASSERT_EQ(err, Error::Ok);
@@ -324,6 +343,21 @@ TEST_F(MethodTest, ConstantBufferTest) {
       programs_["linear_constant_buffer"]->load_method("forward", &mmm.get());
   ASSERT_EQ(method.error(), Error::Ok);
 
+  // Set a dummy input.
+  int32_t sizes[2] = {2, 2};
+  uint8_t dim_order[2] = {0, 1};
+  int32_t strides[2] = {2, 1};
+  executorch::aten::TensorImpl impl(
+      executorch::aten::ScalarType::Float,
+      2,
+      sizes,
+      nullptr,
+      dim_order,
+      strides);
+  auto input_err = method->set_input(
+      executorch::runtime::EValue(executorch::aten::Tensor(&impl)), 0);
+  ASSERT_EQ(input_err, Error::Ok);
+
   // Can execute the method.
   Error err = method->execute();
   ASSERT_EQ(err, Error::Ok);
@@ -334,6 +368,21 @@ TEST_F(MethodTest, ProgramDataSeparationTest) {
   Result<Method> method = programs_["add_mul_program"]->load_method(
       "forward", &mmm.get(), nullptr, data_maps_["add_mul_data"].get());
   ASSERT_EQ(method.error(), Error::Ok);
+
+  // Set a dummy input.
+  int32_t sizes[2] = {2, 2};
+  uint8_t dim_order[2] = {0, 1};
+  int32_t strides[2] = {2, 1};
+  executorch::aten::TensorImpl impl(
+      executorch::aten::ScalarType::Float,
+      2,
+      sizes,
+      nullptr,
+      dim_order,
+      strides);
+  auto input_err = method->set_input(
+      executorch::runtime::EValue(executorch::aten::Tensor(&impl)), 0);
+  ASSERT_EQ(input_err, Error::Ok);
 
   // Can execute the method.
   Error err = method->execute();
@@ -356,6 +405,21 @@ TEST_F(MethodTest, MethodGetAttributeTest) {
 
   // expect data to be set
   EXPECT_EQ(res->const_data_ptr(), &data);
+
+  // Set a dummy input.
+  int32_t sizes[1] = {1};
+  uint8_t dim_order[1] = {0};
+  int32_t strides[1] = {1};
+  executorch::aten::TensorImpl impl(
+      executorch::aten::ScalarType::Float,
+      1,
+      sizes,
+      nullptr,
+      dim_order,
+      strides);
+  auto input_err = method->set_input(
+      executorch::runtime::EValue(executorch::aten::Tensor(&impl)), 0);
+  ASSERT_EQ(input_err, Error::Ok);
 
   // Can execute the method.
   Error err = method->execute();


### PR DESCRIPTION
Summary: Method never cared to check all the inputs were properly set before execution and basically used some default allocated memory for unset inputs. Here we introduce a safety check to guarantee users don't forget to set all inputs explicitly.

Differential Revision: D79849134


