### PR TITLE
Arm backend: Remove TOSA-0.80+BI from target list in aot_arm_compiler.py

### DIFF
--- a/examples/arm/aot_arm_compiler.py
+++ b/examples/arm/aot_arm_compiler.py
@@ -341,7 +341,6 @@ targets = [
     "ethos-u85-1024",
     "ethos-u85-2048",
     "vgf",
-    "TOSA-0.80+BI",
     "TOSA-1.0+INT",
     "TOSA-1.0+FP",
 ]
@@ -393,7 +392,7 @@ def get_compile_spec(
         try:
             tosa_spec = TosaSpecification.create_from_string(target)
         except:
-            tosa_spec = TosaSpecification.create_from_string("TOSA-0.80+BI")
+            tosa_spec = TosaSpecification.create_from_string("TOSA-1.0+INT")
         spec_builder = ArmCompileSpecBuilder().tosa_compile_spec(tosa_spec)
     elif "ethos-u" in target:
         spec_builder = ArmCompileSpecBuilder().ethosu_compile_spec(


### PR DESCRIPTION
Clean out TOSA-0.80 from the target list


cc @digantdesai @freddan80 @per @oscarandersson8218