### PR TITLE
Add SCALE_DTYPE and ZP_DTYPE support for quantization shaders

### DIFF
--- a/backends/vulkan/_passes/fuse_quantized_ops.py
+++ b/backends/vulkan/_passes/fuse_quantized_ops.py
@@ -499,7 +499,7 @@ class FuseQuantizedOpsTransform(ExportPass):
                 continue
 
             # Check for linear_qta8a_qga4w pattern (dynamic activation + grouped weight quantization)
-            qta8a_qga4w_details = matches_linear_qta8a_qga4w_pattern(self.program, node)
+            qta8a_qga4w_details = None
             if qta8a_qga4w_details is not None:
                 group_size, weight_bits = qta8a_qga4w_details
                 fuse_into_linear_qta8a_qga4w_node(

--- a/backends/vulkan/runtime/graph/ops/glsl/choose_qparams_buffer.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/choose_qparams_buffer.yaml
@@ -1,9 +1,17 @@
 choose_qparams_buffer:
   parameter_names_with_default_values:
     IN_DTYPE: float
+    SCALE_OUT_DTYPE: float
+    ZP_OUT_DTYPE: int32
     MODE: per_tensor
   generate_variant_forall:
     IN_DTYPE:
+      - VALUE: float
+    SCALE_OUT_DTYPE:
+      - VALUE: float
+    ZP_OUT_DTYPE:
+      - VALUE: int32
+      - VALUE: int8
       - VALUE: float
   shader_variants:
     - NAME: choose_qparams_tensor_buffer

--- a/backends/vulkan/runtime/graph/ops/glsl/choose_qparams_texture.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/choose_qparams_texture.yaml
@@ -1,9 +1,17 @@
 choose_qparams_texture:
   parameter_names_with_default_values:
     IN_DTYPE: float
+    SCALE_OUT_DTYPE: float
+    ZP_OUT_DTYPE: int32
     MODE: per_tensor
   generate_variant_forall:
     IN_DTYPE:
+      - VALUE: float
+    SCALE_OUT_DTYPE:
+      - VALUE: float
+    ZP_OUT_DTYPE:
+      - VALUE: int32
+      - VALUE: int8
       - VALUE: float
   shader_variants:
     - NAME: choose_qparams_tensor_texture3d

--- a/backends/vulkan/runtime/graph/ops/glsl/dequantize_buffer.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/dequantize_buffer.yaml
@@ -2,6 +2,8 @@ dequantize_buffer:
   parameter_names_with_default_values:
     IN_DTYPE: int32
     OUT_DTYPE: float
+    SCALE_DTYPE: float
+    ZP_DTYPE: int32
     MODE: per_tensor
   generate_variant_forall:
     IN_DTYPE:
@@ -12,6 +14,12 @@ dequantize_buffer:
       - VALUE: half
       - VALUE: float
       - VALUE: double
+    SCALE_DTYPE:
+      - VALUE: float
+    ZP_DTYPE:
+      - VALUE: int8
+      - VALUE: int32
+      - VALUE: float
   shader_variants:
     - NAME: dequantize_per_tensor_buffer
       MODE: per_tensor

--- a/backends/vulkan/runtime/graph/ops/glsl/dequantize_texture.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/dequantize_texture.glsl
@@ -15,12 +15,16 @@
 
 #define OUT_T ${buffer_scalar_type(OUT_DTYPE)}
 #define FVEC4_T ${texel_load_type(OUT_DTYPE, "texture3d")}
+#define SCALE_T ${buffer_scalar_type(SCALE_DTYPE)}
+#define ZP_T ${buffer_scalar_type(ZP_DTYPE)}
 
 #define ${MODE}
 
 ${define_active_storage_type("texture3d")}
 ${define_required_extensions(IN_DTYPE)}
 ${define_required_extensions(OUT_DTYPE)}
+${define_required_extensions(SCALE_DTYPE)}
+${define_required_extensions(ZP_DTYPE)}
 
 #extension GL_EXT_control_flow_attributes : require
 
@@ -30,16 +34,16 @@ ${layout_declare_tensor(B, "w", "t_out", OUT_DTYPE, "texture3d")}
 ${layout_declare_tensor(B, "r", "t_in", IN_DTYPE, "texture3d")}
 
 $if MODE == "per_tensor":
-  ${layout_declare_tensor(B, "r", "t_scale", "float", "buffer")}
-  ${layout_declare_tensor(B, "r", "t_zero_point", "int", "buffer")}
+  ${layout_declare_tensor(B, "r", "t_scale", SCALE_DTYPE, "buffer")}
+  ${layout_declare_tensor(B, "r", "t_zero_point", ZP_DTYPE, "buffer")}
 
   layout(push_constant) uniform restrict Block {
     int quant_min;
     int quant_max;
   };
 $if MODE == "per_token":
-  ${layout_declare_tensor(B, "r", "t_scale", "float", "buffer")}
-  ${layout_declare_tensor(B, "r", "t_zero_point", "int", "buffer")}
+  ${layout_declare_tensor(B, "r", "t_scale", SCALE_DTYPE, "buffer")}
+  ${layout_declare_tensor(B, "r", "t_zero_point", ZP_DTYPE, "buffer")}
 
   layout(push_constant) uniform restrict Block {
     int num_tokens;
@@ -47,8 +51,8 @@ $if MODE == "per_token":
     int quant_max;
   };
 $if MODE == "per_channel":
-  ${layout_declare_tensor(B, "r", "t_scale", "float", "buffer")}
-  ${layout_declare_tensor(B, "r", "t_zero_point", "int", "buffer")}
+  ${layout_declare_tensor(B, "r", "t_scale", SCALE_DTYPE, "buffer")}
+  ${layout_declare_tensor(B, "r", "t_zero_point", ZP_DTYPE, "buffer")}
 
   layout(push_constant) uniform restrict Block {
     int axis;
@@ -57,8 +61,8 @@ $if MODE == "per_channel":
     int quant_max;
   };
 $if MODE == "block_wise":
-  ${layout_declare_tensor(B, "r", "t_scale", "float", "buffer")}
-  ${layout_declare_tensor(B, "r", "t_zero_point", "int", "buffer")}
+  ${layout_declare_tensor(B, "r", "t_scale", SCALE_DTYPE, "buffer")}
+  ${layout_declare_tensor(B, "r", "t_zero_point", ZP_DTYPE, "buffer")}
 
   layout(push_constant) uniform restrict Block {
     ivec4 blockSize;     // bW, bH, bC, bN
@@ -160,7 +164,7 @@ void dequantize_per_tensor() {
 
   [[unroll]] for (int i = 0; i < 4; ++i) {
     IN_T qvalue = IN_T(intex[i]);
-    OUT_T value = dequantize_val(qvalue, t_scale[0], t_zero_point[0]);
+    OUT_T value = dequantize_val(qvalue, float(t_scale[0]), int(t_zero_point[0]));
 
     $if OUT_DTYPE == "double":
       outtex[i] = float(value);
@@ -196,8 +200,8 @@ void dequantize_per_token() {
   token_idx = min(token_idx, num_tokens - 1);
 
   // Scale and zero_point are prepacked as buffers, so direct access
-  float scale_val = t_scale[token_idx];
-  int zero_point_val = t_zero_point[token_idx];
+  float scale_val = float(t_scale[token_idx]);
+  int zero_point_val = int(t_zero_point[token_idx]);
 
   FVEC4_T outtex;
   [[unroll]] for (int i = 0; i < 4; ++i) {
@@ -238,8 +242,8 @@ void dequantize_per_channel() {
       int channel_idx = pos.x * 4 + i;
       channel_idx = min(channel_idx, num_channels - 1);
 
-      float scale_val = t_scale[channel_idx];
-      int zero_point_val = t_zero_point[channel_idx];
+      float scale_val = float(t_scale[channel_idx]);
+      int zero_point_val = int(t_zero_point[channel_idx]);
       OUT_T value = dequantize_val(qvalue, scale_val, zero_point_val);
       $if OUT_DTYPE == "double":
         outtex[i] = float(value);
@@ -249,8 +253,8 @@ void dequantize_per_channel() {
   } else if (axis == 1) {
     int channel_idx = pos.y;
     channel_idx = min(channel_idx, num_channels - 1);
-    float scale_val = t_scale[channel_idx];
-    int zero_point_val = t_zero_point[channel_idx];
+    float scale_val = float(t_scale[channel_idx]);
+    int zero_point_val = int(t_zero_point[channel_idx]);
 
     [[unroll]] for (int i = 0; i < 4; ++i) {
       IN_T qvalue = IN_T(intex[i]);
@@ -267,8 +271,8 @@ void dequantize_per_channel() {
     int folded_idx = pos.z;
     int channel_idx = folded_idx % num_channels;
 
-    float scale_val = t_scale[channel_idx];
-    int zero_point_val = t_zero_point[channel_idx];
+    float scale_val = float(t_scale[channel_idx]);
+    int zero_point_val = int(t_zero_point[channel_idx]);
 
     [[unroll]] for (int i = 0; i < 4; ++i) {
       IN_T qvalue = IN_T(intex[i]);
@@ -287,8 +291,8 @@ void dequantize_per_channel() {
     // the C dimension N(C)HW
     int channel_idx = folded_idx / num_channels;
 
-    float scale_val = t_scale[channel_idx];
-    int zero_point_val = t_zero_point[channel_idx];
+    float scale_val = float(t_scale[channel_idx]);
+    int zero_point_val = int(t_zero_point[channel_idx]);
 
     [[unroll]] for (int i = 0; i < 4; ++i) {
       IN_T qvalue = IN_T(intex[i]);
@@ -326,7 +330,7 @@ void dequantize_block_wise() {
     int block_id = bcoord.x * blockStride.x + bcoord.y * blockStride.y + bcoord.z * blockStride.z + bcoord.w * blockStride.w;
 
     IN_T qvalue = IN_T(intex[i]);
-    OUT_T value = dequantize_val(qvalue, t_scale[block_id], t_zero_point[block_id]);
+    OUT_T value = dequantize_val(qvalue, float(t_scale[block_id]), int(t_zero_point[block_id]));
     $if OUT_DTYPE == "double":
       outtex[i] = float(value);
     $else:

--- a/backends/vulkan/runtime/graph/ops/glsl/dequantize_texture.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/dequantize_texture.yaml
@@ -2,6 +2,8 @@ dequantize_texture:
   parameter_names_with_default_values:
     IN_DTYPE: int32
     OUT_DTYPE: float
+    SCALE_DTYPE: float
+    ZP_DTYPE: int32
     MODE: per_tensor
   generate_variant_forall:
     IN_DTYPE:
@@ -12,6 +14,12 @@ dequantize_texture:
       - VALUE: half
       - VALUE: float
       - VALUE: double
+    SCALE_DTYPE:
+      - VALUE: float
+    ZP_DTYPE:
+      - VALUE: int8
+      - VALUE: int32
+      - VALUE: float
   shader_variants:
     - NAME: dequantize_per_tensor_texture3d
       MODE: per_tensor

--- a/backends/vulkan/runtime/graph/ops/glsl/quantize_buffer.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/quantize_buffer.glsl
@@ -12,12 +12,16 @@
 
 #define IN_T ${buffer_scalar_type(IN_DTYPE)}
 #define OUT_T ${buffer_scalar_type(OUT_DTYPE)}
+#define SCALE_T ${buffer_scalar_type(SCALE_DTYPE)}
+#define ZP_T ${buffer_scalar_type(ZP_DTYPE)}
 
 #define ${MODE}
 
 ${define_active_storage_type("buffer")}
 ${define_required_extensions(IN_DTYPE)}
 ${define_required_extensions(OUT_DTYPE)}
+${define_required_extensions(SCALE_DTYPE)}
+${define_required_extensions(ZP_DTYPE)}
 
 layout(std430) buffer;
 
@@ -27,16 +31,16 @@ ${layout_declare_tensor(B, "w", "t_out", OUT_DTYPE, "buffer")}
 ${layout_declare_tensor(B, "r", "t_in", IN_DTYPE, "buffer")}
 
 $if MODE == "per_tensor":
-  ${layout_declare_tensor(B, "r", "t_scale", "float", "buffer")}
-  ${layout_declare_tensor(B, "r", "t_zero_point", "int", "buffer")}
+  ${layout_declare_tensor(B, "r", "t_scale", SCALE_DTYPE, "buffer")}
+  ${layout_declare_tensor(B, "r", "t_zero_point", ZP_DTYPE, "buffer")}
 
   layout(push_constant) uniform restrict Block {
     int quant_min;
     int quant_max;
   };
 $if MODE == "per_token":
-  ${layout_declare_tensor(B, "r", "t_scale", "float", "buffer")}
-  ${layout_declare_tensor(B, "r", "t_zero_point", "int", "buffer")}
+  ${layout_declare_tensor(B, "r", "t_scale", SCALE_DTYPE, "buffer")}
+  ${layout_declare_tensor(B, "r", "t_zero_point", ZP_DTYPE, "buffer")}
 
   layout(push_constant) uniform restrict Block {
     int num_tokens;
@@ -44,8 +48,8 @@ $if MODE == "per_token":
     int quant_max;
   };
 $if MODE == "per_channel":
-  ${layout_declare_tensor(B, "r", "t_scale", "float", "buffer")}
-  ${layout_declare_tensor(B, "r", "t_zero_point", "int", "buffer")}
+  ${layout_declare_tensor(B, "r", "t_scale", SCALE_DTYPE, "buffer")}
+  ${layout_declare_tensor(B, "r", "t_zero_point", ZP_DTYPE, "buffer")}
 
   layout(push_constant) uniform restrict Block {
     int axis;
@@ -54,8 +58,8 @@ $if MODE == "per_channel":
     int quant_max;
   };
 $if MODE == "block_wise":
-  ${layout_declare_tensor(B, "r", "t_scale", "float", "buffer")}
-  ${layout_declare_tensor(B, "r", "t_zero_point", "int", "buffer")}
+  ${layout_declare_tensor(B, "r", "t_scale", SCALE_DTYPE, "buffer")}
+  ${layout_declare_tensor(B, "r", "t_zero_point", ZP_DTYPE, "buffer")}
 
   layout(push_constant) uniform restrict Block {
     ivec4 blockSize;     // bW, bH, bC, bN
@@ -144,7 +148,7 @@ void quantize_per_tensor() {
   const int in_bufi = tidx_to_bufi(out_tidx, t_in_strides);
 
   IN_T value = t_in[in_bufi];
-  OUT_T qvalue = quantize_val(value, t_scale[0], t_zero_point[0]);
+  OUT_T qvalue = quantize_val(value, float(t_scale[0]), int(t_zero_point[0]));
 
   t_out[out_bufi] = qvalue;
 }
@@ -179,7 +183,7 @@ void quantize_per_token() {
 
   token_idx = min(token_idx, num_tokens - 1);
 
-  OUT_T qvalue = quantize_val(value, t_scale[token_idx], t_zero_point[token_idx]);
+  OUT_T qvalue = quantize_val(value, float(t_scale[token_idx]), int(t_zero_point[token_idx]));
 
   t_out[out_bufi] = qvalue;
 }
@@ -218,7 +222,7 @@ void quantize_per_channel() {
 
   channel_idx = min(channel_idx, num_channels - 1);
 
-  OUT_T qvalue = quantize_val(value, t_scale[channel_idx], t_zero_point[channel_idx]);
+  OUT_T qvalue = quantize_val(value, float(t_scale[channel_idx]), int(t_zero_point[channel_idx]));
 
   t_out[out_bufi] = qvalue;
 }
@@ -241,7 +245,7 @@ void quantize_block_wise() {
 
   const int block_id = bcoord.x * blockStride.x + bcoord.y * blockStride.y + bcoord.z * blockStride.z + bcoord.w * blockStride.w;
 
-  const OUT_T qvalue = quantize_val(value, t_scale[block_id], t_zero_point[block_id]);
+  const OUT_T qvalue = quantize_val(value, float(t_scale[block_id]), int(t_zero_point[block_id]));
 
   t_out[out_bufi] = qvalue;
 }

--- a/backends/vulkan/runtime/graph/ops/glsl/quantize_buffer.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/quantize_buffer.yaml
@@ -2,6 +2,8 @@ quantize_buffer:
   parameter_names_with_default_values:
     IN_DTYPE: float
     OUT_DTYPE: int32
+    SCALE_DTYPE: float
+    ZP_DTYPE: int32
     MODE: per_tensor
   generate_variant_forall:
     IN_DTYPE:
@@ -12,6 +14,12 @@ quantize_buffer:
       - VALUE: uint8
       - VALUE: int8
       - VALUE: int32
+    SCALE_DTYPE:
+      - VALUE: float
+    ZP_DTYPE:
+      - VALUE: int8
+      - VALUE: int32
+      - VALUE: float
   shader_variants:
     - NAME: quantize_per_tensor_buffer
       MODE: per_tensor

--- a/backends/vulkan/runtime/graph/ops/glsl/quantize_texture.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/quantize_texture.yaml
@@ -2,6 +2,8 @@ quantize_texture:
   parameter_names_with_default_values:
     IN_DTYPE: float
     OUT_DTYPE: int32
+    SCALE_DTYPE: float
+    ZP_DTYPE: int32
     MODE: per_tensor
   generate_variant_forall:
     IN_DTYPE:
@@ -12,6 +14,12 @@ quantize_texture:
       - VALUE: uint8
       - VALUE: int8
       - VALUE: int32
+    SCALE_DTYPE:
+      - VALUE: float
+    ZP_DTYPE:
+      - VALUE: int8
+      - VALUE: int32
+      - VALUE: float
   shader_variants:
     - NAME: quantize_per_tensor_texture3d
       MODE: per_tensor

--- a/backends/vulkan/runtime/graph/ops/impl/Dequantize.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Dequantize.cpp
@@ -107,9 +107,35 @@ void add_dequantize_per_tensor_node(
   add_storage_type_suffix(kernel_name, graph.storage_type_of(input));
   add_dtype_suffix(kernel_name, graph.dtype_of(input));
   add_dtype_suffix(kernel_name, graph.dtype_of(output));
+  add_dtype_suffix(kernel_name, graph.dtype_of(scale));
+  add_dtype_suffix(kernel_name, graph.dtype_of(zero_point));
 
-  int quant_min_val = static_cast<int>(graph.get_int(quant_min));
-  int quant_max_val = static_cast<int>(graph.get_int(quant_max));
+  // Handle optional quant_min and quant_max parameters independently
+  auto bounds = get_dtype_bounds(graph.dtype_of(input));
+
+  int quant_min_val, quant_max_val;
+
+  // Handle quant_min
+  if (graph.val_is_none(quant_min)) {
+    quant_min_val = bounds.first;
+  } else {
+    VK_CHECK_COND(
+        graph.val_is_int(quant_min),
+        "quant_min must be an integer, got type: ",
+        graph.get_val_type(quant_min));
+    quant_min_val = static_cast<int>(graph.get_int(quant_min));
+  }
+
+  // Handle quant_max
+  if (graph.val_is_none(quant_max)) {
+    quant_max_val = bounds.second;
+  } else {
+    VK_CHECK_COND(
+        graph.val_is_int(quant_max),
+        "quant_max must be an integer, got type: ",
+        graph.get_val_type(quant_max));
+    quant_max_val = static_cast<int>(graph.get_int(quant_max));
+  }
 
   vkapi::ParamsBindList param_ubos;
   std::vector<PushConstantDataInfo> push_constants;
@@ -169,9 +195,35 @@ void add_dequantize_per_token_node(
   add_storage_type_suffix(kernel_name, graph.storage_type_of(input));
   add_dtype_suffix(kernel_name, graph.dtype_of(input));
   add_dtype_suffix(kernel_name, graph.dtype_of(output));
+  add_dtype_suffix(kernel_name, graph.dtype_of(scale));
+  add_dtype_suffix(kernel_name, graph.dtype_of(zero_point));
 
-  int quant_min_val = static_cast<int>(graph.get_int(quant_min));
-  int quant_max_val = static_cast<int>(graph.get_int(quant_max));
+  // Handle optional quant_min and quant_max parameters independently
+  auto bounds = get_dtype_bounds(graph.dtype_of(input));
+
+  int quant_min_val, quant_max_val;
+
+  // Handle quant_min
+  if (graph.val_is_none(quant_min)) {
+    quant_min_val = bounds.first;
+  } else {
+    VK_CHECK_COND(
+        graph.val_is_int(quant_min),
+        "quant_min must be an integer, got type: ",
+        graph.get_val_type(quant_min));
+    quant_min_val = static_cast<int>(graph.get_int(quant_min));
+  }
+
+  // Handle quant_max
+  if (graph.val_is_none(quant_max)) {
+    quant_max_val = bounds.second;
+  } else {
+    VK_CHECK_COND(
+        graph.val_is_int(quant_max),
+        "quant_max must be an integer, got type: ",
+        graph.get_val_type(quant_max));
+    quant_max_val = static_cast<int>(graph.get_int(quant_max));
+  }
 
   int num_tokens = static_cast<int>(graph.sizes_of(scale)[0]);
 
@@ -235,10 +287,37 @@ void add_dequantize_per_channel_node(
   add_storage_type_suffix(kernel_name, graph.storage_type_of(input));
   add_dtype_suffix(kernel_name, graph.dtype_of(input));
   add_dtype_suffix(kernel_name, graph.dtype_of(output));
+  add_dtype_suffix(kernel_name, graph.dtype_of(scale));
+  add_dtype_suffix(kernel_name, graph.dtype_of(zero_point));
 
   int axis_val = static_cast<int>(graph.get_int(axis));
-  int quant_min_val = static_cast<int>(graph.get_int(quant_min));
-  int quant_max_val = static_cast<int>(graph.get_int(quant_max));
+
+  // Handle optional quant_min and quant_max parameters independently
+  auto bounds = get_dtype_bounds(graph.dtype_of(input));
+
+  int quant_min_val, quant_max_val;
+
+  // Handle quant_min
+  if (graph.val_is_none(quant_min)) {
+    quant_min_val = bounds.first;
+  } else {
+    VK_CHECK_COND(
+        graph.val_is_int(quant_min),
+        "quant_min must be an integer, got type: ",
+        graph.get_val_type(quant_min));
+    quant_min_val = static_cast<int>(graph.get_int(quant_min));
+  }
+
+  // Handle quant_max
+  if (graph.val_is_none(quant_max)) {
+    quant_max_val = bounds.second;
+  } else {
+    VK_CHECK_COND(
+        graph.val_is_int(quant_max),
+        "quant_max must be an integer, got type: ",
+        graph.get_val_type(quant_max));
+    quant_max_val = static_cast<int>(graph.get_int(quant_max));
+  }
 
   // Normalize axis and convert from NCHW to WHCN using utility functions
   const auto input_sizes = graph.sizes_of(input);
@@ -320,9 +399,35 @@ void add_dequantize_block_wise_node(
   add_storage_type_suffix(kernel_name, graph.storage_type_of(input));
   add_dtype_suffix(kernel_name, graph.dtype_of(input));
   add_dtype_suffix(kernel_name, graph.dtype_of(output));
+  add_dtype_suffix(kernel_name, graph.dtype_of(scale));
+  add_dtype_suffix(kernel_name, graph.dtype_of(zero_point));
 
-  int quant_min_val = static_cast<int>(graph.get_int(quant_min));
-  int quant_max_val = static_cast<int>(graph.get_int(quant_max));
+  // Handle optional quant_min and quant_max parameters independently
+  auto bounds = get_dtype_bounds(graph.dtype_of(input));
+
+  int quant_min_val, quant_max_val;
+
+  // Handle quant_min
+  if (graph.val_is_none(quant_min)) {
+    quant_min_val = bounds.first;
+  } else {
+    VK_CHECK_COND(
+        graph.val_is_int(quant_min),
+        "quant_min must be an integer, got type: ",
+        graph.get_val_type(quant_min));
+    quant_min_val = static_cast<int>(graph.get_int(quant_min));
+  }
+
+  // Handle quant_max
+  if (graph.val_is_none(quant_max)) {
+    quant_max_val = bounds.second;
+  } else {
+    VK_CHECK_COND(
+        graph.val_is_int(quant_max),
+        "quant_max must be an integer, got type: ",
+        graph.get_val_type(quant_max));
+    quant_max_val = static_cast<int>(graph.get_int(quant_max));
+  }
 
   const auto input_sizes = graph.sizes_of(input);
   const auto block_size_list = graph.get_int_list(block_size);
@@ -423,6 +528,18 @@ void dequantize_per_tensor_impl(
       graph.dtype_of(input) == vkapi::kChar ||
       graph.dtype_of(input) == vkapi::kInt);
 
+  // Get scale and zero point dtypes
+  vkapi::ScalarType scale_dtype = graph.dtype_of(scale);
+  vkapi::ScalarType zero_point_dtype = graph.dtype_of(zero_point);
+
+  // Verify supported types for scale (fp32 only for now)
+  VK_CHECK_COND(scale_dtype == vkapi::kFloat);
+
+  // Verify supported types for zero point (int32, int8, fp32)
+  VK_CHECK_COND(
+      zero_point_dtype == vkapi::kInt || zero_point_dtype == vkapi::kChar ||
+      zero_point_dtype == vkapi::kFloat);
+
   // Check that scale and zero_point have buffer storage and width packing
   VK_CHECK_COND(graph.is_buffer_storage(scale));
   VK_CHECK_COND(graph.packed_dim_of(scale) == WHCN::kWidthDim);
@@ -469,6 +586,18 @@ void dequantize_per_token_impl(
       graph.dtype_of(input) == vkapi::kByte ||
       graph.dtype_of(input) == vkapi::kChar ||
       graph.dtype_of(input) == vkapi::kInt);
+
+  // Get scale and zero point dtypes
+  vkapi::ScalarType scale_dtype = graph.dtype_of(scale);
+  vkapi::ScalarType zero_point_dtype = graph.dtype_of(zero_point);
+
+  // Verify supported types for scale (fp32 only for now)
+  VK_CHECK_COND(scale_dtype == vkapi::kFloat);
+
+  // Verify supported types for zero point (int32, int8, fp32)
+  VK_CHECK_COND(
+      zero_point_dtype == vkapi::kInt || zero_point_dtype == vkapi::kChar ||
+      zero_point_dtype == vkapi::kFloat);
 
   // Check that scale and zero_point have buffer storage and width packing
   VK_CHECK_COND(graph.is_buffer_storage(scale));
@@ -544,6 +673,18 @@ void dequantize_per_channel_impl(
       graph.dtype_of(input) == vkapi::kByte ||
       graph.dtype_of(input) == vkapi::kChar ||
       graph.dtype_of(input) == vkapi::kInt);
+
+  // Get scale and zero point dtypes
+  vkapi::ScalarType scale_dtype = graph.dtype_of(scale);
+  vkapi::ScalarType zero_point_dtype = graph.dtype_of(zero_point);
+
+  // Verify supported types for scale (fp32 only for now)
+  VK_CHECK_COND(scale_dtype == vkapi::kFloat);
+
+  // Verify supported types for zero point (int32, int8, fp32)
+  VK_CHECK_COND(
+      zero_point_dtype == vkapi::kInt || zero_point_dtype == vkapi::kChar ||
+      zero_point_dtype == vkapi::kFloat);
 
   // Check that scale and zero_point have buffer storage and width packing
   VK_CHECK_COND(graph.is_buffer_storage(scale));
@@ -624,6 +765,18 @@ void dequantize_affine_impl(
       graph.dtype_of(input) == vkapi::kByte ||
       graph.dtype_of(input) == vkapi::kChar ||
       graph.dtype_of(input) == vkapi::kInt);
+
+  // Get scale and zero point dtypes
+  vkapi::ScalarType scale_dtype = graph.dtype_of(scale);
+  vkapi::ScalarType zero_point_dtype = graph.dtype_of(zero_point);
+
+  // Verify supported types for scale (fp32 only for now)
+  VK_CHECK_COND(scale_dtype == vkapi::kFloat);
+
+  // Verify supported types for zero point (int32, int8, fp32)
+  VK_CHECK_COND(
+      zero_point_dtype == vkapi::kInt || zero_point_dtype == vkapi::kChar ||
+      zero_point_dtype == vkapi::kFloat);
 
   // Check that scale and zero_point have buffer storage and width packing
   VK_CHECK_COND(graph.is_buffer_storage(scale));

--- a/backends/vulkan/runtime/graph/ops/impl/Quantize.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Quantize.cpp
@@ -108,9 +108,35 @@ void add_quantize_per_tensor_node(
   add_storage_type_suffix(kernel_name, graph.storage_type_of(input));
   add_dtype_suffix(kernel_name, graph.dtype_of(input));
   add_dtype_suffix(kernel_name, graph.dtype_of(output));
+  add_dtype_suffix(kernel_name, graph.dtype_of(scale));
+  add_dtype_suffix(kernel_name, graph.dtype_of(zero_point));
 
-  int quant_min_val = static_cast<int>(graph.get_int(quant_min));
-  int quant_max_val = static_cast<int>(graph.get_int(quant_max));
+  // Handle optional quant_min and quant_max parameters independently
+  auto bounds = get_dtype_bounds(graph.dtype_of(output));
+
+  int quant_min_val, quant_max_val;
+
+  // Handle quant_min
+  if (graph.val_is_none(quant_min)) {
+    quant_min_val = bounds.first;
+  } else {
+    VK_CHECK_COND(
+        graph.val_is_int(quant_min),
+        "quant_min must be an integer, got type: ",
+        graph.get_val_type(quant_min));
+    quant_min_val = static_cast<int>(graph.get_int(quant_min));
+  }
+
+  // Handle quant_max
+  if (graph.val_is_none(quant_max)) {
+    quant_max_val = bounds.second;
+  } else {
+    VK_CHECK_COND(
+        graph.val_is_int(quant_max),
+        "quant_max must be an integer, got type: ",
+        graph.get_val_type(quant_max));
+    quant_max_val = static_cast<int>(graph.get_int(quant_max));
+  }
 
   vkapi::ParamsBindList param_ubos;
   std::vector<PushConstantDataInfo> push_constants;
@@ -170,9 +196,35 @@ void add_quantize_per_token_node(
   add_storage_type_suffix(kernel_name, graph.storage_type_of(input));
   add_dtype_suffix(kernel_name, graph.dtype_of(input));
   add_dtype_suffix(kernel_name, graph.dtype_of(output));
+  add_dtype_suffix(kernel_name, graph.dtype_of(scale));
+  add_dtype_suffix(kernel_name, graph.dtype_of(zero_point));
 
-  int quant_min_val = static_cast<int>(graph.get_int(quant_min));
-  int quant_max_val = static_cast<int>(graph.get_int(quant_max));
+  // Handle optional quant_min and quant_max parameters independently
+  auto bounds = get_dtype_bounds(graph.dtype_of(output));
+
+  int quant_min_val, quant_max_val;
+
+  // Handle quant_min
+  if (graph.val_is_none(quant_min)) {
+    quant_min_val = bounds.first;
+  } else {
+    VK_CHECK_COND(
+        graph.val_is_int(quant_min),
+        "quant_min must be an integer, got type: ",
+        graph.get_val_type(quant_min));
+    quant_min_val = static_cast<int>(graph.get_int(quant_min));
+  }
+
+  // Handle quant_max
+  if (graph.val_is_none(quant_max)) {
+    quant_max_val = bounds.second;
+  } else {
+    VK_CHECK_COND(
+        graph.val_is_int(quant_max),
+        "quant_max must be an integer, got type: ",
+        graph.get_val_type(quant_max));
+    quant_max_val = static_cast<int>(graph.get_int(quant_max));
+  }
 
   int num_tokens = static_cast<int>(graph.sizes_of(scale)[0]);
 
@@ -243,10 +295,37 @@ void add_quantize_per_channel_node(
   add_storage_type_suffix(kernel_name, graph.storage_type_of(input));
   add_dtype_suffix(kernel_name, graph.dtype_of(input));
   add_dtype_suffix(kernel_name, graph.dtype_of(output));
+  add_dtype_suffix(kernel_name, graph.dtype_of(scale));
+  add_dtype_suffix(kernel_name, graph.dtype_of(zero_point));
 
   int axis_val = static_cast<int>(graph.get_int(axis));
-  int quant_min_val = static_cast<int>(graph.get_int(quant_min));
-  int quant_max_val = static_cast<int>(graph.get_int(quant_max));
+
+  // Handle optional quant_min and quant_max parameters independently
+  auto bounds = get_dtype_bounds(graph.dtype_of(output));
+
+  int quant_min_val, quant_max_val;
+
+  // Handle quant_min
+  if (graph.val_is_none(quant_min)) {
+    quant_min_val = bounds.first;
+  } else {
+    VK_CHECK_COND(
+        graph.val_is_int(quant_min),
+        "quant_min must be an integer, got type: ",
+        graph.get_val_type(quant_min));
+    quant_min_val = static_cast<int>(graph.get_int(quant_min));
+  }
+
+  // Handle quant_max
+  if (graph.val_is_none(quant_max)) {
+    quant_max_val = bounds.second;
+  } else {
+    VK_CHECK_COND(
+        graph.val_is_int(quant_max),
+        "quant_max must be an integer, got type: ",
+        graph.get_val_type(quant_max));
+    quant_max_val = static_cast<int>(graph.get_int(quant_max));
+  }
 
   // Normalize axis and convert from NCHW to WHCN using utility functions
   const auto input_sizes = graph.sizes_of(input);
@@ -336,9 +415,35 @@ void add_quantize_block_wise_node(
   add_storage_type_suffix(kernel_name, graph.storage_type_of(input));
   add_dtype_suffix(kernel_name, graph.dtype_of(input));
   add_dtype_suffix(kernel_name, graph.dtype_of(output));
+  add_dtype_suffix(kernel_name, graph.dtype_of(scale));
+  add_dtype_suffix(kernel_name, graph.dtype_of(zero_point));
 
-  int quant_min_val = static_cast<int>(graph.get_int(quant_min));
-  int quant_max_val = static_cast<int>(graph.get_int(quant_max));
+  // Handle optional quant_min and quant_max parameters independently
+  auto bounds = get_dtype_bounds(graph.dtype_of(output));
+
+  int quant_min_val, quant_max_val;
+
+  // Handle quant_min
+  if (graph.val_is_none(quant_min)) {
+    quant_min_val = bounds.first;
+  } else {
+    VK_CHECK_COND(
+        graph.val_is_int(quant_min),
+        "quant_min must be an integer, got type: ",
+        graph.get_val_type(quant_min));
+    quant_min_val = static_cast<int>(graph.get_int(quant_min));
+  }
+
+  // Handle quant_max
+  if (graph.val_is_none(quant_max)) {
+    quant_max_val = bounds.second;
+  } else {
+    VK_CHECK_COND(
+        graph.val_is_int(quant_max),
+        "quant_max must be an integer, got type: ",
+        graph.get_val_type(quant_max));
+    quant_max_val = static_cast<int>(graph.get_int(quant_max));
+  }
 
   const auto input_sizes = graph.sizes_of(input);
   const auto block_size_list = graph.get_int_list(block_size);
@@ -427,6 +532,8 @@ void quantize_per_tensor_impl(
 
   // Check tensor types
   VK_CHECK_COND(graph.val_is_tensor(input));
+  VK_CHECK_COND(graph.val_is_tensor(scale));
+  VK_CHECK_COND(graph.val_is_tensor(zero_point));
   VK_CHECK_COND(graph.val_is_tensor(output));
 
   // Verify input is a floating point type
@@ -434,6 +541,18 @@ void quantize_per_tensor_impl(
       graph.dtype_of(input) == vkapi::kDouble ||
       graph.dtype_of(input) == vkapi::kFloat ||
       graph.dtype_of(input) == vkapi::kHalf);
+
+  // Get scale and zero point dtypes
+  vkapi::ScalarType scale_dtype = graph.dtype_of(scale);
+  vkapi::ScalarType zero_point_dtype = graph.dtype_of(zero_point);
+
+  // Verify supported types for scale (fp32 only for now)
+  VK_CHECK_COND(scale_dtype == vkapi::kFloat);
+
+  // Verify supported types for zero point (int32, int8, fp32)
+  VK_CHECK_COND(
+      zero_point_dtype == vkapi::kInt || zero_point_dtype == vkapi::kChar ||
+      zero_point_dtype == vkapi::kFloat);
 
   add_quantize_per_tensor_node(
       graph, input, scale, zero_point, quant_min, quant_max, output);
@@ -465,6 +584,18 @@ void quantize_per_token_impl(
       graph.dtype_of(input) == vkapi::kDouble ||
       graph.dtype_of(input) == vkapi::kFloat ||
       graph.dtype_of(input) == vkapi::kHalf);
+
+  // Get scale and zero point dtypes
+  vkapi::ScalarType scale_dtype = graph.dtype_of(scale);
+  vkapi::ScalarType zero_point_dtype = graph.dtype_of(zero_point);
+
+  // Verify supported types for scale (fp32 only for now)
+  VK_CHECK_COND(scale_dtype == vkapi::kFloat);
+
+  // Verify supported types for zero point (int32, int8, fp32)
+  VK_CHECK_COND(
+      zero_point_dtype == vkapi::kInt || zero_point_dtype == vkapi::kChar ||
+      zero_point_dtype == vkapi::kFloat);
 
   // Check that scale and zero_point have buffer storage and width packing
   VK_CHECK_COND(graph.is_buffer_storage(scale));
@@ -538,6 +669,18 @@ void quantize_per_channel_impl(
       graph.dtype_of(input) == vkapi::kDouble ||
       graph.dtype_of(input) == vkapi::kFloat ||
       graph.dtype_of(input) == vkapi::kHalf);
+
+  // Get scale and zero point dtypes
+  vkapi::ScalarType scale_dtype = graph.dtype_of(scale);
+  vkapi::ScalarType zero_point_dtype = graph.dtype_of(zero_point);
+
+  // Verify supported types for scale (fp32 only for now)
+  VK_CHECK_COND(scale_dtype == vkapi::kFloat);
+
+  // Verify supported types for zero point (int32, int8, fp32)
+  VK_CHECK_COND(
+      zero_point_dtype == vkapi::kInt || zero_point_dtype == vkapi::kChar ||
+      zero_point_dtype == vkapi::kFloat);
 
   // Check that scale and zero_point have buffer storage and width packing
   VK_CHECK_COND(graph.is_buffer_storage(scale));
@@ -616,6 +759,18 @@ void quantize_affine_impl(
       graph.dtype_of(input) == vkapi::kDouble ||
       graph.dtype_of(input) == vkapi::kFloat ||
       graph.dtype_of(input) == vkapi::kHalf);
+
+  // Get scale and zero point dtypes
+  vkapi::ScalarType scale_dtype = graph.dtype_of(scale);
+  vkapi::ScalarType zero_point_dtype = graph.dtype_of(zero_point);
+
+  // Verify supported types for scale (fp32 only for now)
+  VK_CHECK_COND(scale_dtype == vkapi::kFloat);
+
+  // Verify supported types for zero point (int32, int8, fp32)
+  VK_CHECK_COND(
+      zero_point_dtype == vkapi::kInt || zero_point_dtype == vkapi::kChar ||
+      zero_point_dtype == vkapi::kFloat);
 
   // Check that scale and zero_point have buffer storage and width packing
   VK_CHECK_COND(graph.is_buffer_storage(scale));

--- a/backends/vulkan/runtime/graph/ops/impl/utils/ScalarUtils.h
+++ b/backends/vulkan/runtime/graph/ops/impl/utils/ScalarUtils.h
@@ -28,4 +28,22 @@ T extract_scalar(const Value& value) {
   VK_THROW("Cannot extract scalar from Value with type ", value.type());
 }
 
+// Helper function to get default quant_min and quant_max based on dtype
+// This matches the logic in _get_and_check_qmin_qmax from quant_primitives.py
+inline std::pair<int, int> get_dtype_bounds(vkapi::ScalarType dtype) {
+  switch (dtype) {
+    case vkapi::kByte: // uint8
+      return {0, 255};
+    case vkapi::kChar: // int8
+      return {-128, 127};
+    case vkapi::kShort: // int16
+      return {-(1 << 15), (1 << 15) - 1};
+    case vkapi::kInt: // int32
+      return {-(1LL << 31), (1LL << 31) - 1};
+    default:
+      // For unsupported types, throw an error instead of assuming int8
+      VK_THROW("Unsupported dtype for quantization bounds: ", dtype);
+  }
+}
+
 } // namespace vkcompute

--- a/backends/vulkan/test/test_vulkan_passes.py
+++ b/backends/vulkan/test/test_vulkan_passes.py
@@ -155,6 +155,9 @@ class TestVulkanPasses(unittest.TestCase):
         self.assertEqual(op_node_count(gm, "linear_qcs4w.default"), 1)
         self.assertEqual(op_node_count(gm, "dequantize_per_channel.default"), 0)
 
+    @unittest.skip(
+        "linear_qta8a_qga4w currently does not support E2E dynamic quantization"
+    )
     def test_fuse_linear_qta8a_qga4w(self):
         """Test fusion of dynamic activation + grouped weight quantized linear (QTA8A_QGA4W)."""
         K = 256


### PR DESCRIPTION
Summary:
This change adds support for parameterized SCALE_DTYPE and ZP_DTYPE to the quantization and dequantization shaders. This is necessary as when exporting llama with "8da4w" you might have different affine calls with various scale and zero point dtypes. I've also added functionality to automatically populate optional parameters.

NOTE: Disable the fusion for linear_qta8a_qga4w as the bug for why it doesn't work with exporting llama is being resolved.  

**Key Changes:**

(1) **YAML Configuration Updates:**
   - Added SCALE_DTYPE and ZP_DTYPE parameters to quantize_texture.yaml and dequantize_texture.yaml
   - Added generate_variant_forall entries for SCALE_DTYPE (float) and ZP_DTYPE (int8, int32, float)
   - This enables shader variants for different scale and zero_point data types

(2) **GLSL Shader Updates:**
   - Added SCALE_T and ZP_T type definitions using the new parameters
   - Updated tensor declarations to use parameterized types instead of hardcoded "float" and "int"
   - Added proper type casting (float() and int()) for all scale and zero_point accesses
   - Added required extensions for SCALE_DTYPE and ZP_DTYPE

(3) **C++ Implementation Updates:**
   - Added dtype suffixes for scale and zero_point in all quantize/dequantize node functions
   - Added comprehensive data type validation in all implementation functions:
     - Scale tensors: fp32 only (for now)
     - Zero point tensors: int32, int8, fp32
   - Updated Quantize.cpp, Dequantize.cpp, and ChooseQParams.cpp with consistent validation

This change resolves shader compilation errors and enables more flexible quantization strategies by supporting multiple data types for quantization parameters.

Differential Revision: D79835267


