### PR TITLE
[ET-VK][ez] Fix registration for convolution operator

### DIFF
--- a/backends/vulkan/op_registry.py
+++ b/backends/vulkan/op_registry.py
@@ -435,7 +435,19 @@ def register_2d_pool_op():
 )
 def register_convolution_op():
     return OpFeatures(
-        inputs_storage=utils.CHANNELS_PACKED_TEXTURE,
+        inputs_storage=[
+            utils.CHANNELS_PACKED_TEXTURE,  # input
+            utils.NO_STORAGE,  # weight (prepacked)
+            utils.NO_STORAGE,  # bias (prepacked)
+            utils.NO_STORAGE,  # stride (non tensor)
+            utils.NO_STORAGE,  # padding (non tensor)
+            utils.NO_STORAGE,  # dilation (non tensor)
+            utils.NO_STORAGE,  # transposed (non tensor)
+            utils.NO_STORAGE,  # output_padding (non tensor)
+            utils.NO_STORAGE,  # groups (non tensor)
+            utils.NO_STORAGE,  # output_min (non tensor)
+            utils.NO_STORAGE,  # output_max (non tensor)
+        ],
         supports_resize=True,
         supports_prepacking=True,
     )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #13227
* #13226

## Context

Update the registration of the convolution operator to indicate that the weight tensor is prepacked and should not undergo normal texture limits checking. The current registration may cause valid convolution operators to not be partitioned since the export logic will think the weight tensor is non representable using channels packed textures. An example weight size would be something like [256, 256, 1, 1] which would result in a texture with extents [1, 1, 16384] which may exceed texture limits on some machines.

Differential Revision: [D79893086](https://our.internmc.facebook.com/intern/diff/D79893086/)