### PR TITLE
make gh pr descrition as part of merge pr

### DIFF
--- a/.github/scripts/propose_ghstack_orig_pr.py
+++ b/.github/scripts/propose_ghstack_orig_pr.py
@@ -100,13 +100,16 @@ def create_prs_for_orig_branch(pr_stack: List[int], repo: Repository):
         # The PR we want to create is then "branch_to_merge" <- gh/user/x/orig
         # gh/user/x/orig is the clean diff between gh/user/x/base <- gh/user/x/head
         orig_branch_merge_head = pr.base.ref.replace("base", "orig")
+
+        try:
+            gh_pr_first_comment = pr.get_issue_comments()[0].body
+        except:
+            gh_pr_first_comment = ""
+
         bot_metadata = f"""This PR was created by the merge bot to help merge the original PR into the main branch.
 ghstack PR number: https://github.com/pytorch/executorch/pull/{pr.number} by @{pr.user.login}
+{gh_pr_first_comment}
 ^ Please use this as the source of truth for the PR details, comments, and reviews
-ghstack PR base: https://github.com/pytorch/executorch/tree/{pr.base.ref}
-ghstack PR head: https://github.com/pytorch/executorch/tree/{pr.head.ref}
-Merge bot PR base: https://github.com/pytorch/executorch/tree/{orig_branch_merge_base}
-Merge bot PR head: https://github.com/pytorch/executorch/tree/{orig_branch_merge_head}
 @diff-train-skip-merge"""
 
         existing_orig_pr = repo.get_pulls(


### PR DESCRIPTION
this pr makes ghexport merge pr contains the description of origianl gh pr, so that we do not need to copy and paste diff number in the commit note to link back to our diff,