### PR TITLE
Always run build-presets workflow on PRs/pushes

### DIFF
--- a/.github/workflows/build-presets.yml
+++ b/.github/workflows/build-presets.yml
@@ -6,8 +6,6 @@ on:
     branches:
       - main
       - release/*
-    paths:
-      - .github/workflows/build-presets.yml
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
The build-presets workflow currently runs only when the workflow file itself is updated. As we update docs to recommend using presets, we should run this job on all PRs.

Note that the Windows preset is currently reporting success despite failing to actually build. I'm intending to resolve that shortly as a follow-up.