### PR TITLE
Fix unused-local-typedef issue

### DIFF
--- a/runtime/core/exec_aten/util/scalar_type_util.h
+++ b/runtime/core/exec_aten/util/scalar_type_util.h
@@ -897,14 +897,14 @@ struct promote_types {
 #define ET_INTERNAL_SWITCH_CASE(enum_type, CTYPE_ALIAS, ...)         \
   case enum_type: {                                                  \
     ET_INTERNAL_CHECK_SELECTIVE_BUILD(enum_type);                    \
-    using CTYPE_ALIAS =                                              \
+    using CTYPE_ALIAS [[maybe_unused]] =                             \
         ::executorch::runtime::ScalarTypeToCppType<enum_type>::type; \
     return __VA_ARGS__();                                            \
   }
 #else
 #define ET_INTERNAL_SWITCH_CASE(enum_type, CTYPE_ALIAS, ...)         \
   case enum_type: {                                                  \
-    using CTYPE_ALIAS =                                              \
+    using CTYPE_ALIAS [[maybe_unused]] =                             \
         ::executorch::runtime::ScalarTypeToCppType<enum_type>::type; \
     return __VA_ARGS__();                                            \
   }


### PR DESCRIPTION
Summary:
LLVM has a warning `-Wunused-local-typedef` which we are enabling to remove unused code. This has the side-effect of making it easier to do refactors should as removing unnecessary includes.

For questions/comments, contact r-barnes.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Differential Revision: D79834770


