### PR TITLE
Arm backend: Use padding for the base64 coded ETDump string

### DIFF
--- a/examples/arm/executor_runner/arm_executor_runner.cpp
+++ b/examples/arm/executor_runner/arm_executor_runner.cpp
@@ -759,7 +759,7 @@ void write_etdump(RunnerContext& ctx) {
   if (result.buf != nullptr && result.size > 0) {
     // On a device with no file system we can't just write it out
     // to the file-system so we base64 encode it and dump it on the log.
-    int mode = 0;
+    int mode = base64_enc_modifier_padding | base64_dec_modifier_skipspace;
     size_t len = result.size;
     size_t encoded_len = base64_encoded_size(result.size, mode);
     uint8_t* encoded_buf = reinterpret_cast<uint8_t*>(


### PR DESCRIPTION
This fix "base64: invalid input" errors you got sometimes when converting it to a file.

This change also avoid using ' ', '\r', and '\n' in the base64 string for a cleaner string.


cc @digantdesai @freddan80 @per @oscarandersson8218