### PR TITLE
Fix 8w8a qat qconfig setting activations

### DIFF
--- a/backends/qualcomm/quantizer/qconfig.py
+++ b/backends/qualcomm/quantizer/qconfig.py
@@ -396,7 +396,6 @@ def get_8a8w_qnn_qat_config(
         qscheme=(
             torch.per_tensor_symmetric if act_symmetric else torch.per_tensor_affine
         ),
-        reduce_range=True,
         observer=act_observer,
     )
     act_quantization_spec = QuantizationSpec(


### PR DESCRIPTION
Summary: 8-bit activation qconfig should not use reduce_range=True which limits the range to 0,127. This diff fixes that issue.

Differential Revision: D80007226


