### PR TITLE
Try fixing arm tests

### DIFF
--- a/backends/arm/quantizer/__init__.py
+++ b/backends/arm/quantizer/__init__.py
@@ -19,11 +19,19 @@ from .arm_quantizer_utils import is_annotated  # noqa
 try:
     import executorch.extension.pybindings.portable_lib
     import executorch.kernels.quantized  # noqa
-except:
+except ImportError as e:
     import logging
 
-    logging.info(
-        "Failed to load portable_lib and quantized_aot_lib. To run quantized kernels AOT, either build "
+    logging.warning(
+        f"Failed to load portable_lib and quantized_aot_lib: {e}. To run quantized kernels AOT, either build "
+        "Executorch with pybindings, or load your own custom built op library using torch.ops.load_library."
+    )
+    del logging
+except Exception as e:
+    import logging
+
+    logging.warning(
+        f"Unexpected error loading quantized ops: {e}. To run quantized kernels AOT, either build "
         "Executorch with pybindings, or load your own custom built op library using torch.ops.load_library."
     )
     del logging

--- a/exir/passes/__init__.py
+++ b/exir/passes/__init__.py
@@ -314,6 +314,18 @@ def make_alloc_node(
     return alloc
 
 
+# Ensure quantized operators are available for ToOutVarPass
+# This prevents "Missing out variants" errors for quantized_decomposed operators
+try:
+    from torch.ao.quantization.fx._decomposed import quantized_decomposed_lib  # noqa: F401
+    # Also import ExecutorTorch quantized kernels which define the out variants
+    import executorch.extension.pybindings.portable_lib  # noqa: F401
+    import executorch.kernels.quantized  # noqa: F401
+except ImportError:
+    # Quantized operators are optional, continue without them
+    pass
+
+
 class ToOutVarPass(PassBase):
     def __init__(self, ignore_to_out_var_failure: bool = False) -> None:
         self.ignore_to_out_var_failure = ignore_to_out_var_failure


### PR DESCRIPTION
Mostly dogscience

Summary of the fix:
  - Root cause: Missing quantized_decomposed_lib import causing quantized_decomposed operators to not be properly registered with their out variants
  - Solution: Added the missing import along with ExecutorTorch quantized kernels in the ToOutVarPass module
  - Impact: Prevents "Missing out variants" errors for quantized_decomposed operators during the to_executorch conversion

The changes ensure that when the ToOutVarPass runs, the quantized operators are properly loaded and registered, resolving the original error you encountered.
