### PR TITLE
Arm backend: Bugfix TosaValueError

### DIFF
--- a/backends/arm/tosa/dialect/lib.py
+++ b/backends/arm/tosa/dialect/lib.py
@@ -51,9 +51,9 @@ def register_tosa_dialect_op(op_schema, func) -> Callable:
 
 
 class TosaValueError(ValueError):
-    def __init__(self, message="A TOSA value error occurred", *args, **kwargs):
-        super().__init__(message, *args, **kwargs)
-        self.op = kwargs.get("op", None)
+    def __init__(self, message="A TOSA value error occurred", *args, op=None):
+        super().__init__(message, *args)
+        self.op = op
 
     def __str__(self):
         base_message = super().__str__()


### PR DESCRIPTION
ValueError doesn't accept kwargs, so remove the usage and explicitly add the op arg instead.

cc @digantdesai @freddan80 @zingo @oscarandersson8218