### PR TITLE
Arm backend: Remove function getNodeArgs

### DIFF
--- a/backends/arm/process_node.py
+++ b/backends/arm/process_node.py
@@ -14,7 +14,7 @@ import torch.fx
 from executorch.backends.arm.operators.node_visitor import NodeVisitor
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
-from executorch.backends.arm.tosa_utils import getNodeArgs, tosa_shape
+from executorch.backends.arm.tosa_utils import tosa_shape
 from torch._export.utils import (
     get_buffer,
     get_lifted_tensor_constant,
@@ -33,7 +33,10 @@ def process_call_function(
     tosa_spec: TosaSpecification,
 ):
     # Unpack arguments and convert
-    inputs = getNodeArgs(node, tosa_spec)
+    try:
+        inputs = [TosaArg(arg, tosa_spec) for arg in node.args]
+    except ValueError as e:
+        raise ValueError(f"Failed processing args to op:\n{node}") from e
 
     # Convert output (this node itself)
     try:

--- a/backends/arm/tosa_utils.py
+++ b/backends/arm/tosa_utils.py
@@ -15,7 +15,7 @@ import sympy  # type: ignore
 
 import torch
 
-from executorch.backends.arm.tosa_mapping import extract_tensor_meta, TosaArg
+from executorch.backends.arm.tosa_mapping import extract_tensor_meta
 
 from executorch.backends.arm.tosa_specification import TosaSpecification
 from executorch.exir.dialects._ops import ops as exir_ops
@@ -24,13 +24,6 @@ from torch._subclasses.fake_tensor import FakeTensor
 from torch.fx import Node
 
 logger = logging.getLogger(__name__)
-
-
-def getNodeArgs(node: Node, tosa_spec: TosaSpecification) -> list[TosaArg]:
-    try:
-        return [TosaArg(arg, tosa_spec) for arg in node.args]
-    except ValueError as e:
-        raise ValueError(f"Failed processing args to op:\n{node}") from e
 
 
 def are_fake_tensors_broadcastable(


### PR DESCRIPTION
The function was only used in one place and it was only a couple of lines so the logic was moved to where the function was originally called, which is in process_node.py.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218