### PR TITLE
Arm backend: Run pytest model tests in parallell

### DIFF
--- a/backends/arm/test/test_arm_baremetal.sh
+++ b/backends/arm/test/test_arm_baremetal.sh
@@ -101,7 +101,7 @@ test_pytest_models() { # Test ops and other things
     source backends/arm/scripts/install_models_for_test.sh
 
     # Run arm baremetal pytest tests without FVP
-    pytest  --verbose --color=yes --durations=0 backends/arm/test/models
+    pytest  --verbose --color=yes --numprocesses=auto --durations=0 backends/arm/test/models
     echo "${TEST_SUITE_NAME}: PASS"
 }
 
@@ -141,7 +141,7 @@ test_pytest_models_ethosu_fvp() { # Same as test_pytest but also sometime verify
     source backends/arm/scripts/install_models_for_test.sh
 
     # Run arm baremetal pytest tests with FVP
-    pytest  --verbose --color=yes --durations=0 backends/arm/test/models
+    pytest  --verbose --color=yes --numprocesses=auto --durations=0 backends/arm/test/models
     echo "${TEST_SUITE_NAME}: PASS"
 }
 


### PR DESCRIPTION
Reduces time of pytest model jobs with ~50%. Upstream ci tested successfully 4 times, and easy to revert if it turns out to be flaky. 

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218