### PR TITLE
removed cron schedule runs to workflow until the GitHub token issue is fixed

### DIFF
--- a/.github/workflows/add-unanswered-to-project.yml
+++ b/.github/workflows/add-unanswered-to-project.yml
@@ -1,8 +1,8 @@
 name: Add Open External Contributor PRs and Issues to PyTorch Org Project 136
 
 on:
-  schedule:
-    - cron: '0 * * * *'
+ # schedule:
+  #  - cron: '0 * * * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/add-unanswered-to-project.yml
+++ b/.github/workflows/add-unanswered-to-project.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Add open issues and open, non-draft PRs to org project (excluding certain authors)
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.PYTORCH_PROJECT_PAT }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const projectId = "PVT_kwDOAUB9vs4A_PUL"; // PyTorch org project 136
             const owner = 'pytorch';


### PR DESCRIPTION
removed cron schedule runs until the [GitHub token issue](https://github.com/pytorch/executorch/actions/runs/16917031468/job/47933438463) is fixed
