### PR TITLE
Set a doc build variable for executorch version

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -142,6 +142,12 @@ source_suffix = [".rst", ".md"]
 
 autodoc_typehints = "none"
 
+html_context = {
+    "version": version,
+    "aar_version": "0.7.0",
+}
+
+
 # Add any paths that contain templates here, relative to this directory.
 # templates_path = ["../_templates"]
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -142,12 +142,6 @@ source_suffix = [".rst", ".md"]
 
 autodoc_typehints = "none"
 
-html_context = {
-    "version": version,
-    "aar_version": "0.7.0",
-}
-
-
 # Add any paths that contain templates here, relative to this directory.
 # templates_path = ["../_templates"]
 

--- a/docs/source/executorch_custom_versions.py
+++ b/docs/source/executorch_custom_versions.py
@@ -11,6 +11,8 @@ This custom extension pulls third-party version strings from files in the
 .ci/docker/ci_commit_pins directory, and uses them to expand specific strings in
 markdown files.
 
+Users can also specify their custom version strings in the global variable `variables`
+
 For example, `${executorch_version:pytorch}` will be replaced with the
 appropriate pytorch version string used by CI.
 """
@@ -24,7 +26,10 @@ version_file_names = [
     "pytorch.txt",
 ]
 
-variables: dict[str, str] = {}
+
+variables: dict[str, str] = {
+    "aar_version": "0.7.0",
+}
 
 
 def read_version_files():

--- a/docs/source/executorch_custom_versions.py
+++ b/docs/source/executorch_custom_versions.py
@@ -7,11 +7,12 @@
 """
 Sphinx extension to replace ${executorch_version:TAG} with version numbers.
 
+It also defines a special variable ${executorch_version} that is set to the value
+of `EXECUTORCH_VERSION` defined in this file.
+
 This custom extension pulls third-party version strings from files in the
 .ci/docker/ci_commit_pins directory, and uses them to expand specific strings in
 markdown files.
-
-Users can also specify their custom version strings in the global variable `variables`
 
 For example, `${executorch_version:pytorch}` will be replaced with the
 appropriate pytorch version string used by CI.
@@ -26,13 +27,11 @@ version_file_names = [
     "pytorch.txt",
 ]
 
-
-variables: dict[str, str] = {
-    "aar_version": "0.7.0",
-}
+EXECUTORCH_VERSION = "0.7.0"
 
 
-def read_version_files():
+def populate_version_variable():
+    variables["${executorch_version}"] = EXECUTORCH_VERSION
     cwd = os.getcwd()
     version_file_path = os.path.join(cwd, "..", ".ci", "docker", "ci_commit_pins")
 
@@ -43,7 +42,7 @@ def read_version_files():
             variables[var_name] = f.read().strip()
 
 
-read_version_files()
+populate_version_variable()
 
 
 def replace_variables(app, doctree, docname):

--- a/docs/source/executorch_custom_versions.py
+++ b/docs/source/executorch_custom_versions.py
@@ -29,6 +29,8 @@ version_file_names = [
 
 EXECUTORCH_VERSION = "0.7.0"
 
+variables: dict[str, str] = {}
+
 
 def populate_version_variable():
     variables["${executorch_version}"] = EXECUTORCH_VERSION

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -124,7 +124,7 @@ To add the library to your app, add the following dependency to gradle build rul
 ```
 # app/build.gradle.kts
 dependencies {
-  implementation("org.pytorch:executorch-android:{{ executorch_version:aar_version }}")
+  implementation("org.pytorch:executorch-android:${executorch_version:aar_version}")
 }
 
 # See latest available versions in https://mvnrepository.com/artifact/org.pytorch/executorch-android

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -124,7 +124,7 @@ To add the library to your app, add the following dependency to gradle build rul
 ```
 # app/build.gradle.kts
 dependencies {
-  implementation("org.pytorch:executorch-android:0.6.0")
+  implementation("org.pytorch:executorch-android:{{ aar_version }}")
 }
 
 # See latest available versions in https://mvnrepository.com/artifact/org.pytorch/executorch-android

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -124,7 +124,7 @@ To add the library to your app, add the following dependency to gradle build rul
 ```
 # app/build.gradle.kts
 dependencies {
-  implementation("org.pytorch:executorch-android:${executorch_version:aar_version}")
+  implementation("org.pytorch:executorch-android:${executorch_version}")
 }
 
 # See latest available versions in https://mvnrepository.com/artifact/org.pytorch/executorch-android

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -124,7 +124,7 @@ To add the library to your app, add the following dependency to gradle build rul
 ```
 # app/build.gradle.kts
 dependencies {
-  implementation("org.pytorch:executorch-android:{{ aar_version }}")
+  implementation("org.pytorch:executorch-android:{{ executorch_version:aar_version }}")
 }
 
 # See latest available versions in https://mvnrepository.com/artifact/org.pytorch/executorch-android

--- a/docs/source/using-executorch-android.md
+++ b/docs/source/using-executorch-android.md
@@ -28,13 +28,13 @@ The AAR library can be used for generic Android device with arm64-v8a or x86_64 
 
 ExecuTorch is available on [Maven Central](https://mvnrepository.com/artifact/org.pytorch/executorch-android).
 
-Simply add the target [`org.pytorch:executorch-android:0.6.0-rc1`](https://repo.maven.apache.org/maven2/org/pytorch/executorch-android/0.6.0-rc1/) to your Android app dependency (build.gradle), and build your app.
+Simply add the target [`org.pytorch:executorch-android:{{ aar_version }}`](https://repo.maven.apache.org/maven2/org/pytorch/executorch-android/{{ aar_version }}/) to your Android app dependency (build.gradle), and build your app.
 
 For example:
 ```
 # app/build.gradle.kts
 dependencies {
-    implementation("org.pytorch:executorch-android:0.6.0-rc1")
+    implementation("org.pytorch:executorch-android:{{ aar_version }}")
 }
 ```
 
@@ -53,7 +53,7 @@ You can also directly specify an AAR file in the app. We upload pre-built AAR to
 
 | Version | AAR | SHASUMS |
 | ------- | --- | ------- |
-| [v0.6.0-rc1](https://github.com/pytorch/executorch/releases/tag/v0.6.0-rc1) | [executorch.aar](https://ossci-android.s3.amazonaws.com/executorch/release/v0.6.0-rc1/executorch.aar) | [executorch.aar.sha256sums](https://ossci-android.s3.amazonaws.com/executorch/release/v0.6.0-rc1/executorch.aar.sha256sums) |
+| [{{ aar_version }}](https://github.com/pytorch/executorch/releases/tag/{{ aar_version }}) | [executorch.aar](https://ossci-android.s3.amazonaws.com/executorch/release/{{ aar_version }}/executorch.aar) | [executorch.aar.sha256sums](https://ossci-android.s3.amazonaws.com/executorch/release/{{ aar_version }}/executorch.aar.sha256sums) |
 | [v0.5.0](https://github.com/pytorch/executorch/releases/tag/v0.5.0) | [executorch.aar](https://ossci-android.s3.amazonaws.com/executorch/release/v0.5.0-rc3/executorch.aar) | [executorch.aar.sha256sums](https://ossci-android.s3.amazonaws.com/executorch/release/v0.5.0-rc3/executorch.aar.sha256sums) |
 
 ### Snapshots from main branch
@@ -90,7 +90,7 @@ implementation("com.facebook.fbjni:fbjni:0.5.1")
 In your app working directory, such as executorch/examples/demo-apps/android/LlamaDemo,
 ```
 mkdir -p app/libs
-curl https://ossci-android.s3.amazonaws.com/executorch/release/v0.6.0-rc1/executorch.aar -o app/libs/executorch.aar
+curl https://ossci-android.s3.amazonaws.com/executorch/release/{{ aar_version }}/executorch.aar -o app/libs/executorch.aar
 ```
 
 And include it in gradle:

--- a/docs/source/using-executorch-android.md
+++ b/docs/source/using-executorch-android.md
@@ -28,13 +28,13 @@ The AAR library can be used for generic Android device with arm64-v8a or x86_64 
 
 ExecuTorch is available on [Maven Central](https://mvnrepository.com/artifact/org.pytorch/executorch-android).
 
-Simply add the target [`org.pytorch:executorch-android:{{ executorch_version:aar_version }}`](https://repo.maven.apache.org/maven2/org/pytorch/executorch-android/{{ executorch_version:aar_version }}/) to your Android app dependency (build.gradle), and build your app.
+Simply add the target [`org.pytorch:executorch-android:${executorch_version:aar_version}`](https://repo.maven.apache.org/maven2/org/pytorch/executorch-android/${executorch_version:aar_version}/) to your Android app dependency (build.gradle), and build your app.
 
 For example:
 ```
 # app/build.gradle.kts
 dependencies {
-    implementation("org.pytorch:executorch-android:{{ executorch_version:aar_version }}")
+    implementation("org.pytorch:executorch-android:${executorch_version:aar_version}")
 }
 ```
 
@@ -53,7 +53,7 @@ You can also directly specify an AAR file in the app. We upload pre-built AAR to
 
 | Version | AAR | SHASUMS |
 | ------- | --- | ------- |
-| [{{ executorch_version:aar_version }}](https://github.com/pytorch/executorch/releases/tag/{{ executorch_version:aar_version }}) | [executorch.aar](https://ossci-android.s3.amazonaws.com/executorch/release/{{ executorch_version:aar_version }}/executorch.aar) | [executorch.aar.sha256sums](https://ossci-android.s3.amazonaws.com/executorch/release/{{ executorch_version:aar_version }}/executorch.aar.sha256sums) |
+| [${executorch_version:aar_version}](https://github.com/pytorch/executorch/releases/tag/${executorch_version:aar_version}) | [executorch.aar](https://ossci-android.s3.amazonaws.com/executorch/release/${executorch_version:aar_version}/executorch.aar) | [executorch.aar.sha256sums](https://ossci-android.s3.amazonaws.com/executorch/release/${executorch_version:aar_version}/executorch.aar.sha256sums) |
 | [v0.6.0](https://github.com/pytorch/executorch/releases/tag/v0.6.0) | [executorch.aar](https://ossci-android.s3.amazonaws.com/executorch/release/v0.6.0/executorch.aar) | [executorch.aar.sha256sums](https://ossci-android.s3.amazonaws.com/executorch/release/v0.6.0/executorch.aar.sha256sums) |
 | [v0.5.0](https://github.com/pytorch/executorch/releases/tag/v0.5.0) | [executorch.aar](https://ossci-android.s3.amazonaws.com/executorch/release/v0.5.0-rc3/executorch.aar) | [executorch.aar.sha256sums](https://ossci-android.s3.amazonaws.com/executorch/release/v0.5.0-rc3/executorch.aar.sha256sums) |
 
@@ -91,7 +91,7 @@ implementation("com.facebook.fbjni:fbjni:0.5.1")
 In your app working directory, such as executorch/examples/demo-apps/android/LlamaDemo,
 ```
 mkdir -p app/libs
-curl https://ossci-android.s3.amazonaws.com/executorch/release/{{ executorch_version:aar_version }}/executorch.aar -o app/libs/executorch.aar
+curl https://ossci-android.s3.amazonaws.com/executorch/release/${executorch_version:aar_version}/executorch.aar -o app/libs/executorch.aar
 ```
 
 And include it in gradle:

--- a/docs/source/using-executorch-android.md
+++ b/docs/source/using-executorch-android.md
@@ -28,13 +28,13 @@ The AAR library can be used for generic Android device with arm64-v8a or x86_64 
 
 ExecuTorch is available on [Maven Central](https://mvnrepository.com/artifact/org.pytorch/executorch-android).
 
-Simply add the target [`org.pytorch:executorch-android:{{ aar_version }}`](https://repo.maven.apache.org/maven2/org/pytorch/executorch-android/{{ aar_version }}/) to your Android app dependency (build.gradle), and build your app.
+Simply add the target [`org.pytorch:executorch-android:{{ executorch_version:aar_version }}`](https://repo.maven.apache.org/maven2/org/pytorch/executorch-android/{{ executorch_version:aar_version }}/) to your Android app dependency (build.gradle), and build your app.
 
 For example:
 ```
 # app/build.gradle.kts
 dependencies {
-    implementation("org.pytorch:executorch-android:{{ aar_version }}")
+    implementation("org.pytorch:executorch-android:{{ executorch_version:aar_version }}")
 }
 ```
 
@@ -53,7 +53,8 @@ You can also directly specify an AAR file in the app. We upload pre-built AAR to
 
 | Version | AAR | SHASUMS |
 | ------- | --- | ------- |
-| [{{ aar_version }}](https://github.com/pytorch/executorch/releases/tag/{{ aar_version }}) | [executorch.aar](https://ossci-android.s3.amazonaws.com/executorch/release/{{ aar_version }}/executorch.aar) | [executorch.aar.sha256sums](https://ossci-android.s3.amazonaws.com/executorch/release/{{ aar_version }}/executorch.aar.sha256sums) |
+| [{{ executorch_version:aar_version }}](https://github.com/pytorch/executorch/releases/tag/{{ executorch_version:aar_version }}) | [executorch.aar](https://ossci-android.s3.amazonaws.com/executorch/release/{{ executorch_version:aar_version }}/executorch.aar) | [executorch.aar.sha256sums](https://ossci-android.s3.amazonaws.com/executorch/release/{{ executorch_version:aar_version }}/executorch.aar.sha256sums) |
+| [v0.6.0](https://github.com/pytorch/executorch/releases/tag/v0.6.0) | [executorch.aar](https://ossci-android.s3.amazonaws.com/executorch/release/v0.6.0/executorch.aar) | [executorch.aar.sha256sums](https://ossci-android.s3.amazonaws.com/executorch/release/v0.6.0/executorch.aar.sha256sums) |
 | [v0.5.0](https://github.com/pytorch/executorch/releases/tag/v0.5.0) | [executorch.aar](https://ossci-android.s3.amazonaws.com/executorch/release/v0.5.0-rc3/executorch.aar) | [executorch.aar.sha256sums](https://ossci-android.s3.amazonaws.com/executorch/release/v0.5.0-rc3/executorch.aar.sha256sums) |
 
 ### Snapshots from main branch
@@ -90,7 +91,7 @@ implementation("com.facebook.fbjni:fbjni:0.5.1")
 In your app working directory, such as executorch/examples/demo-apps/android/LlamaDemo,
 ```
 mkdir -p app/libs
-curl https://ossci-android.s3.amazonaws.com/executorch/release/{{ aar_version }}/executorch.aar -o app/libs/executorch.aar
+curl https://ossci-android.s3.amazonaws.com/executorch/release/{{ executorch_version:aar_version }}/executorch.aar -o app/libs/executorch.aar
 ```
 
 And include it in gradle:

--- a/docs/source/using-executorch-android.md
+++ b/docs/source/using-executorch-android.md
@@ -28,13 +28,13 @@ The AAR library can be used for generic Android device with arm64-v8a or x86_64 
 
 ExecuTorch is available on [Maven Central](https://mvnrepository.com/artifact/org.pytorch/executorch-android).
 
-Simply add the target [`org.pytorch:executorch-android:${executorch_version:aar_version}`](https://repo.maven.apache.org/maven2/org/pytorch/executorch-android/${executorch_version:aar_version}/) to your Android app dependency (build.gradle), and build your app.
+Simply add the target [`org.pytorch:executorch-android:${executorch_version}`](https://repo.maven.apache.org/maven2/org/pytorch/executorch-android/${executorch_version}/) to your Android app dependency (build.gradle), and build your app.
 
 For example:
 ```
 # app/build.gradle.kts
 dependencies {
-    implementation("org.pytorch:executorch-android:${executorch_version:aar_version}")
+    implementation("org.pytorch:executorch-android:${executorch_version}")
 }
 ```
 
@@ -53,7 +53,7 @@ You can also directly specify an AAR file in the app. We upload pre-built AAR to
 
 | Version | AAR | SHASUMS |
 | ------- | --- | ------- |
-| [${executorch_version:aar_version}](https://github.com/pytorch/executorch/releases/tag/${executorch_version:aar_version}) | [executorch.aar](https://ossci-android.s3.amazonaws.com/executorch/release/${executorch_version:aar_version}/executorch.aar) | [executorch.aar.sha256sums](https://ossci-android.s3.amazonaws.com/executorch/release/${executorch_version:aar_version}/executorch.aar.sha256sums) |
+| [${executorch_version}](https://github.com/pytorch/executorch/releases/tag/${executorch_version}) | [executorch.aar](https://ossci-android.s3.amazonaws.com/executorch/release/${executorch_version}/executorch.aar) | [executorch.aar.sha256sums](https://ossci-android.s3.amazonaws.com/executorch/release/${executorch_version}/executorch.aar.sha256sums) |
 | [v0.6.0](https://github.com/pytorch/executorch/releases/tag/v0.6.0) | [executorch.aar](https://ossci-android.s3.amazonaws.com/executorch/release/v0.6.0/executorch.aar) | [executorch.aar.sha256sums](https://ossci-android.s3.amazonaws.com/executorch/release/v0.6.0/executorch.aar.sha256sums) |
 | [v0.5.0](https://github.com/pytorch/executorch/releases/tag/v0.5.0) | [executorch.aar](https://ossci-android.s3.amazonaws.com/executorch/release/v0.5.0-rc3/executorch.aar) | [executorch.aar.sha256sums](https://ossci-android.s3.amazonaws.com/executorch/release/v0.5.0-rc3/executorch.aar.sha256sums) |
 
@@ -91,7 +91,7 @@ implementation("com.facebook.fbjni:fbjni:0.5.1")
 In your app working directory, such as executorch/examples/demo-apps/android/LlamaDemo,
 ```
 mkdir -p app/libs
-curl https://ossci-android.s3.amazonaws.com/executorch/release/${executorch_version:aar_version}/executorch.aar -o app/libs/executorch.aar
+curl https://ossci-android.s3.amazonaws.com/executorch/release/${executorch_version}/executorch.aar -o app/libs/executorch.aar
 ```
 
 And include it in gradle:


### PR DESCRIPTION
### Summary
Now in docs we can use `${executorch_version}` to represent executorch version. 

It's defined in docs/source/executorch_custom_versions.py `EXECUTORCH_VERSION = "0.7.0"`

### Test plan

In https://docs-preview.pytorch.org/pytorch/executorch/13351/getting-started.html#id1, the version is correct:
```
implementation("org.pytorch:executorch-android:0.7.0")
```