### PR TITLE
Non-fatal error when ET_SWITCH encounters unsupported dtype

### DIFF
--- a/backends/cadence/fusion_g3/operators/op_clamp.cpp
+++ b/backends/cadence/fusion_g3/operators/op_clamp.cpp
@@ -45,6 +45,7 @@ bool is_out_of_bounds(CTYPE_VAL val) {
 }
 
 ET_NODISCARD bool check_bounds(
+    KernelRuntimeContext& ctx,
     const Scalar& val_scalar,
     const ScalarType& val_type,
     const ScalarType& out_type,
@@ -107,14 +108,14 @@ Tensor& clamp_out(
   if (has_min) {
     ET_KERNEL_CHECK(
         ctx,
-        check_bounds(min_opt.value(), min_type, out_type, "minimum"),
+        check_bounds(ctx, min_opt.value(), min_type, out_type, "minimum"),
         InvalidArgument,
         out);
   }
   if (has_max) {
     ET_KERNEL_CHECK(
         ctx,
-        check_bounds(max_opt.value(), max_type, out_type, "maximum"),
+        check_bounds(ctx, max_opt.value(), max_type, out_type, "maximum"),
         InvalidArgument,
         out);
   }

--- a/extension/llm/runner/text_decoder_runner.h
+++ b/extension/llm/runner/text_decoder_runner.h
@@ -68,12 +68,20 @@ class ET_EXPERIMENTAL TextDecoderRunner {
       const executorch::aten::Tensor& logits_tensor,
       const float temperature = 0.0f) {
     int32_t result = 0;
+
+    // Create a minimal context for error handling in ET_SWITCH
+    struct {
+      [[noreturn]] void fail(torch::executor::Error /* error */) {
+        ET_CHECK_MSG(false, "Unsupported dtype in logits_to_token");
+      }
+    } ctx;
+
     ET_SWITCH_THREE_TYPES(
         Float,
         Half,
         BFloat16,
         logits_tensor.scalar_type(),
-        unused,
+        ctx,
         "logits_to_token",
         CTYPE,
         [&]() {

--- a/extension/tensor/tensor_ptr.h
+++ b/extension/tensor/tensor_ptr.h
@@ -111,7 +111,15 @@ inline TensorPtr make_tensor_ptr(
         runtime::canCast(deduced_type, type),
         "Cannot cast deduced type to specified type.");
     std::vector<uint8_t> casted_data(data.size() * runtime::elementSize(type));
-    ET_SWITCH_REALHBBF16_TYPES(type, nullptr, "make_tensor_ptr", CTYPE, [&] {
+
+    // Create a minimal context for error handling in ET_SWITCH
+    struct {
+      [[noreturn]] void fail(torch::executor::Error /* error */) {
+        ET_CHECK_MSG(false, "Unsupported dtype in make_tensor_ptr");
+      }
+    } ctx;
+
+    ET_SWITCH_REALHBBF16_TYPES(type, ctx, "make_tensor_ptr", CTYPE, [&] {
       std::transform(
           data.begin(),
           data.end(),

--- a/extension/tensor/tensor_ptr_maker.cpp
+++ b/extension/tensor/tensor_ptr_maker.cpp
@@ -89,7 +89,14 @@ TensorPtr random_strided(
       empty_strided(std::move(sizes), std::move(strides), type, dynamism);
   std::default_random_engine gen{std::random_device{}()};
 
-  ET_SWITCH_REALHBBF16_TYPES(type, nullptr, "random_strided", CTYPE, [&] {
+  // Create a minimal context for error handling in ET_SWITCH
+  struct {
+    [[noreturn]] void fail(torch::executor::Error /* error */) {
+      ET_CHECK_MSG(false, "Unsupported dtype in random_strided");
+    }
+  } ctx;
+
+  ET_SWITCH_REALHBBF16_TYPES(type, ctx, "random_strided", CTYPE, [&] {
     std::generate_n(tensor->mutable_data_ptr<CTYPE>(), tensor->numel(), [&]() {
       return static_cast<CTYPE>(distribution(gen));
     });
@@ -124,7 +131,14 @@ TensorPtr full_strided(
     executorch::aten::TensorShapeDynamism dynamism) {
   auto tensor =
       empty_strided(std::move(sizes), std::move(strides), type, dynamism);
-  ET_SWITCH_REALHBBF16_TYPES(type, nullptr, "full_strided", CTYPE, [&] {
+  // Create a minimal context for error handling in ET_SWITCH
+  struct {
+    [[noreturn]] void fail(torch::executor::Error /* error */) {
+      ET_CHECK_MSG(false, "Unsupported data type in full_strided");
+    }
+  } ctx;
+
+  ET_SWITCH_REALHBBF16_TYPES(type, ctx, "full_strided", CTYPE, [&] {
     CTYPE value;
     ET_EXTRACT_SCALAR(fill_value, value);
     std::fill(

--- a/kernels/optimized/cpu/op_add_sub_impl.h
+++ b/kernels/optimized/cpu/op_add_sub_impl.h
@@ -144,13 +144,13 @@ Tensor& opt_add_sub_out_impl(
   } else if (selected_optimized_path != ElementwiseOptimizedPath::kNone) {
     // Cannot apply the trick of -alpha here because alpha is Scalar without
     // support for - operator. At least not right now.
-    ET_SWITCH_REALB_TYPES(out_type, ctx, op_name, CTYPE, [&]() {
+    ET_SWITCH_REALB_TYPES(out_type, ctx, op_name, CTYPE, [&]() -> void {
       CTYPE alpha_val;
       ET_KERNEL_CHECK_MSG(
           ctx,
           torch::executor::native::utils::extract_scalar(alpha, &alpha_val),
           InvalidArgument,
-          out,
+          ,
           "Failed to extract scalar alpha.");
       using Vec = at::vec::Vectorized<CTYPE>;
       Vec alpha_val_vec(alpha_val);
@@ -164,13 +164,13 @@ Tensor& opt_add_sub_out_impl(
           auto add_lambda = [&alpha_val_vec](auto x, auto y) {
             return y - alpha_val_vec * x;
           };
-          return torch::executor::handle_broadcast_elementwise<CTYPE>(
+          torch::executor::handle_broadcast_elementwise<CTYPE>(
               ctx, add_lambda, a, b, out, selected_optimized_path, alpha);
         } else {
           auto add_lambda = [&alpha_val_vec](auto x, auto y) {
             return x - alpha_val_vec * y;
           };
-          return torch::executor::handle_broadcast_elementwise<CTYPE>(
+          torch::executor::handle_broadcast_elementwise<CTYPE>(
               ctx, add_lambda, a, b, out, selected_optimized_path, alpha);
         }
       } else {
@@ -191,13 +191,13 @@ Tensor& opt_add_sub_out_impl(
           auto add_lambda = [&alpha_val_vec](auto x, auto y) {
             return y + alpha_val_vec * x;
           };
-          return torch::executor::handle_broadcast_elementwise<CTYPE>(
+          torch::executor::handle_broadcast_elementwise<CTYPE>(
               ctx, add_lambda, a, b, out, selected_optimized_path, alpha);
         } else {
           auto add_lambda = [&alpha_val_vec](auto x, auto y) {
             return x + alpha_val_vec * y;
           };
-          return torch::executor::handle_broadcast_elementwise<CTYPE>(
+          torch::executor::handle_broadcast_elementwise<CTYPE>(
               ctx, add_lambda, a, b, out, selected_optimized_path, alpha);
         }
       }

--- a/kernels/optimized/cpu/op_div.cpp
+++ b/kernels/optimized/cpu/op_div.cpp
@@ -130,11 +130,11 @@ Tensor& opt_div_out(
           selected_optimized_path ==
               ElementwiseOptimizedPath::kBroadcastNdByNdReverseArguments) {
         auto div_lambda = [](auto x, auto y) { return y / x; };
-        return torch::executor::handle_broadcast_elementwise<CTYPE>(
+        torch::executor::handle_broadcast_elementwise<CTYPE>(
             ctx, div_lambda, a, b, out, selected_optimized_path);
       } else {
         auto div_lambda = [](auto x, auto y) { return x / y; };
-        return torch::executor::handle_broadcast_elementwise<CTYPE>(
+        torch::executor::handle_broadcast_elementwise<CTYPE>(
             ctx, div_lambda, a, b, out, selected_optimized_path);
       }
     });

--- a/kernels/optimized/cpu/op_le.cpp
+++ b/kernels/optimized/cpu/op_le.cpp
@@ -57,7 +57,7 @@ Tensor& opt_le_tensor_out(
     // Handle optimized broadcast cases
     ET_SWITCH_REALB_TYPES(out_type, ctx, "le.Tensor_out", CTYPE, [&]() {
       auto le_lambda = [](auto x, auto y) { return x.le(y); };
-      return torch::executor::handle_broadcast_elementwise<CTYPE>(
+      torch::executor::handle_broadcast_elementwise<CTYPE>(
           ctx, le_lambda, a, b, out, selected_optimized_path);
     });
   } else {

--- a/kernels/optimized/cpu/op_mul.cpp
+++ b/kernels/optimized/cpu/op_mul.cpp
@@ -148,13 +148,13 @@ Tensor& opt_mul_out(
 
       ET_SWITCH_COMPLEXH_TYPES(out_type, ctx, "mul.out", CTYPE, [&]() {
         auto mul_lambda = [](auto x, auto y) { return x * y; };
-        return torch::executor::handle_broadcast_elementwise<CTYPE>(
+        torch::executor::handle_broadcast_elementwise<CTYPE>(
             ctx, mul_lambda, a, b, out, selected_optimized_path);
       });
     } else {
       ET_SWITCH_REALB_TYPES(out_type, ctx, "mul.out", CTYPE, [&]() {
         auto mul_lambda = [](auto x, auto y) { return x * y; };
-        return torch::executor::handle_broadcast_elementwise<CTYPE>(
+        torch::executor::handle_broadcast_elementwise<CTYPE>(
             ctx, mul_lambda, a, b, out, selected_optimized_path);
       });
     }

--- a/kernels/portable/cpu/op_clamp.cpp
+++ b/kernels/portable/cpu/op_clamp.cpp
@@ -34,6 +34,7 @@ bool is_out_of_bounds(CTYPE_CAST val_cast) {
 }
 
 ET_NODISCARD bool check_bounds(
+    KernelRuntimeContext& ctx,
     const Scalar& val_scalar,
     const torch::executor::native::ScalarType& val_type,
     const torch::executor::native::ScalarType& out_type,
@@ -107,14 +108,14 @@ Tensor& clamp_out(
   if (has_min) {
     ET_KERNEL_CHECK(
         ctx,
-        check_bounds(min_opt.value(), min_type, out_type, "minimum"),
+        check_bounds(ctx, min_opt.value(), min_type, out_type, "minimum"),
         InvalidArgument,
         out);
   }
   if (has_max) {
     ET_KERNEL_CHECK(
         ctx,
-        check_bounds(max_opt.value(), max_type, out_type, "maximum"),
+        check_bounds(ctx, max_opt.value(), max_type, out_type, "maximum"),
         InvalidArgument,
         out);
   }

--- a/kernels/portable/cpu/op_convolution.cpp
+++ b/kernels/portable/cpu/op_convolution.cpp
@@ -415,7 +415,7 @@ Tensor& convolution_out(
   ET_SWITCH_REALH_TYPES(in.scalar_type(), ctx, name, CTYPE, [&]() {
     const auto load_bias = bias.has_value()
         ? utils::internal::get_load_to_compute_fn<CTYPE, name>(
-              bias.value(), utils::SupportedTensorDtypes::REALHBF16)
+              ctx, bias.value(), utils::SupportedTensorDtypes::REALHBF16)
         : nullptr;
     convolution_wrapper<CTYPE>(
         in,

--- a/kernels/portable/cpu/op_cumsum.cpp
+++ b/kernels/portable/cpu/op_cumsum.cpp
@@ -111,10 +111,10 @@ Tensor& cumsum_out(
   // @lint-ignore CLANGTIDY facebook-hte-CArray
   static constexpr const char op_name[] = "cumsum.out";
 
-  ET_SWITCH_REALHBBF16_TYPES(out.scalar_type(), ctx, op_name, CTYPE_OUT, [&] {
+  ET_SWITCH_REALHBBF16_TYPES(out.scalar_type(), ctx, op_name, CTYPE_OUT, [&]() {
     const auto load_self =
         utils::internal::get_load_to_compute_fn<CTYPE_OUT, op_name>(
-            self, utils::SupportedTensorDtypes::REALHBBF16);
+            ctx, self, utils::SupportedTensorDtypes::REALHBBF16);
     cumsum_tensors<CTYPE_OUT>(self, load_self, dim, out);
   });
 

--- a/kernels/portable/cpu/op_fill.cpp
+++ b/kernels/portable/cpu/op_fill.cpp
@@ -90,7 +90,7 @@ Tensor& fill_tensor_out(
   static constexpr const char op_name[] = "fill.Tensor_out";
 
   ET_SWITCH_REALHBBF16_TYPES(a_type, ctx, op_name, CTYPE_A, [&] {
-    CTYPE_A b_casted;
+    CTYPE_A b_casted{};
     ET_SWITCH_REALHBBF16_TYPES(b_type, ctx, op_name, CTYPE_B, [&] {
       CTYPE_B b_val;
       ET_EXTRACT_SCALAR_TENSOR(b, b_val);

--- a/kernels/portable/cpu/op_index_put.cpp
+++ b/kernels/portable/cpu/op_index_put.cpp
@@ -160,6 +160,7 @@ Tensor& index_put_out(
 namespace {
 
 bool check_special_case_in_place_args(
+    KernelRuntimeContext& ctx,
     Tensor& in,
     TensorOptList indices,
     const Tensor& values,
@@ -285,7 +286,8 @@ Tensor& index_put_(
   size_t dim = 0;
   ET_KERNEL_CHECK(
       ctx,
-      check_special_case_in_place_args(in, indices, values, accumulate, &dim),
+      check_special_case_in_place_args(
+          ctx, in, indices, values, accumulate, &dim),
       InvalidArgument,
       in);
 

--- a/kernels/portable/cpu/op_scatter.cpp
+++ b/kernels/portable/cpu/op_scatter.cpp
@@ -104,25 +104,20 @@ void scatter_value_helper(
 } // namespace
 
 Tensor& scatter_src_out(
-    KernelRuntimeContext& context,
+    KernelRuntimeContext& ctx,
     const Tensor& in,
     int64_t dim,
     const Tensor& index,
     const Tensor& src,
     Tensor& out) {
-  (void)context;
-
   ET_KERNEL_CHECK(
-      context,
+      ctx,
       check_scatter_src_args(in, dim, index, src, out),
       InvalidArgument,
       out);
 
   ET_KERNEL_CHECK(
-      context,
-      resize_tensor(out, in.sizes()) == Error::Ok,
-      InvalidArgument,
-      out);
+      ctx, resize_tensor(out, in.sizes()) == Error::Ok, InvalidArgument, out);
 
   constexpr auto name = "scatter.src_out";
 

--- a/kernels/portable/cpu/op_scatter_add.cpp
+++ b/kernels/portable/cpu/op_scatter_add.cpp
@@ -52,38 +52,30 @@ void scatter_add_helper(
 } // namespace
 
 Tensor& scatter_add_out(
-    KernelRuntimeContext& context,
+    KernelRuntimeContext& ctx,
     const Tensor& self,
     int64_t dim,
     const Tensor& index,
     const Tensor& src,
     Tensor& out) {
-  (void)context;
-
   ET_KERNEL_CHECK(
-      context,
+      ctx,
       check_scatter_add_args(self, dim, index, src, out),
       InvalidArgument,
       out);
 
   ET_KERNEL_CHECK(
-      context,
-      tensors_have_same_dim_order(self, src, out),
-      InvalidArgument,
-      out);
+      ctx, tensors_have_same_dim_order(self, src, out), InvalidArgument, out);
 
   ET_KERNEL_CHECK(
-      context, tensor_is_default_dim_order(index), InvalidArgument, out);
+      ctx, tensor_is_default_dim_order(index), InvalidArgument, out);
 
   if (dim < 0) {
     dim += nonzero_dim(self);
   }
 
   ET_KERNEL_CHECK(
-      context,
-      resize_tensor(out, self.sizes()) == Error::Ok,
-      InvalidArgument,
-      out);
+      ctx, resize_tensor(out, self.sizes()) == Error::Ok, InvalidArgument, out);
 
   ScalarType self_type = self.scalar_type();
 

--- a/kernels/portable/cpu/util/elementwise_util.h
+++ b/kernels/portable/cpu/util/elementwise_util.h
@@ -119,9 +119,9 @@ inline void dtype_specialized_elementwise_fn_impl(
           // small-sized tests will test whether using Vectorized broke our
           // lambda.
 #ifndef NDEBUG
-              std::array<Vec, kNumInputs> loaded_inputs;
+              std::array<Vec, kNumInputs> loaded_inputs{};
 #else // NDEBUG
-              std::array<CTYPE_COMPUTE, kNumInputs> loaded_inputs;
+              std::array<CTYPE_COMPUTE, kNumInputs> loaded_inputs{};
 #endif // NDEBUG
               for (const auto input_idx : c10::irange(kNumInputs)) {
                 loaded_inputs[input_idx] = inputs_data_ptrs[input_idx][idx];
@@ -136,7 +136,7 @@ inline void dtype_specialized_elementwise_fn_impl(
             // Main vectorized loop.
             for (auto idx = vectorized_begin; idx < vectorized_end;
                  idx += Vec::size()) {
-              std::array<Vec, kNumInputs> loaded_vec_inputs;
+              std::array<Vec, kNumInputs> loaded_vec_inputs{};
               for (const auto input_idx : c10::irange(kNumInputs)) {
                 loaded_vec_inputs[input_idx] =
                     Vec::loadu(&inputs_data_ptrs[input_idx][idx]);
@@ -148,9 +148,9 @@ inline void dtype_specialized_elementwise_fn_impl(
             // Scalar epilogue.
             for (const auto idx : c10::irange(vectorized_end, end)) {
 #ifndef NDEBUG
-              std::array<Vec, kNumInputs> loaded_inputs;
+              std::array<Vec, kNumInputs> loaded_inputs{};
 #else // NDEBUG
-              std::array<CTYPE_COMPUTE, kNumInputs> loaded_inputs;
+              std::array<CTYPE_COMPUTE, kNumInputs> loaded_inputs{};
 #endif // NDEBUG
               for (const auto input_idx : c10::irange(kNumInputs)) {
                 loaded_inputs[input_idx] = inputs_data_ptrs[input_idx][idx];
@@ -184,7 +184,7 @@ inline void dtype_specialized_elementwise_fn_impl(
         begin_it += begin;
         for (; (*begin_it)[0] < end; ++begin_it) {
           const auto& indexes = *begin_it;
-          std::array<CTYPE_COMPUTE, kNumInputs> loaded_inputs;
+          std::array<CTYPE_COMPUTE, kNumInputs> loaded_inputs{};
           for (const auto idx : c10::irange(kNumInputs)) {
             loaded_inputs[idx] = inputs_data_ptrs[idx][indexes[idx + 1]];
           }
@@ -238,14 +238,14 @@ inline void apply_elementwise_fn_generic_impl(
   };
   std::array<InputInfo, kNumInputs> inputs_info = {(InputInfo{
       internal::get_load_to_compute_fn<CTYPE_COMPUTE, op_name>(
-          *inputs.first, inputs.second),
+          ctx, *inputs.first, inputs.second),
       reinterpret_cast<const char*>(inputs.first->const_data_ptr()),
       inputs.first->element_size(),
   })...};
 
   const auto store_compute_to_out =
       internal::get_store_compute_to_tensor_fn<CTYPE_COMPUTE, op_name>(
-          out, out_dtypes);
+          ctx, out, out_dtypes);
   char* const data_out = reinterpret_cast<char*>(out.mutable_data_ptr());
   const auto out_element_size = out.element_size();
 
@@ -261,7 +261,7 @@ inline void apply_elementwise_fn_generic_impl(
         begin_it += begin;
         for (; (*begin_it)[0] < end; ++begin_it) {
           const auto& indexes = *begin_it;
-          std::array<CTYPE_COMPUTE, kNumInputs> loaded_inputs;
+          std::array<CTYPE_COMPUTE, kNumInputs> loaded_inputs{};
           for (const auto idx : c10::irange(kNumInputs)) {
             const auto& input_info = inputs_info[idx];
             loaded_inputs[idx] = input_info.load_to_compute(

--- a/kernels/portable/test/dtype_selective_build_test.cpp
+++ b/kernels/portable/test/dtype_selective_build_test.cpp
@@ -15,6 +15,12 @@ using executorch::aten::ScalarType;
 using torch::executor::ScalarTypeToCppType;
 
 TEST(DtypeSelectiveBuildTest, UnknownOp) {
+  // Create a minimal context for error handling in ET_SWITCH
+  struct {
+    [[noreturn]] void fail(torch::executor::Error /* error */) {
+      ET_CHECK_MSG(false, "Unsupported dtype");
+    }
+  } ctx;
   ET_EXPECT_DEATH(
       ET_SWITCH_TWO_TYPES(
           Float,
@@ -29,6 +35,12 @@ TEST(DtypeSelectiveBuildTest, UnknownOp) {
 }
 
 TEST(DtypeSelectiveBuildTest, OpWithoutDtype) {
+  // Create a minimal context for error handling in ET_SWITCH
+  struct {
+    [[noreturn]] void fail(torch::executor::Error /* error */) {
+      ET_CHECK_MSG(false, "Unsupported dtype");
+    }
+  } ctx;
   ET_EXPECT_DEATH(
       ET_SWITCH_TWO_TYPES(
           Float,
@@ -43,6 +55,12 @@ TEST(DtypeSelectiveBuildTest, OpWithoutDtype) {
 }
 
 TEST(DtypeSelectiveBuildTest, OpWithDtype) {
+  // Create a minimal context for error handling in ET_SWITCH
+  struct {
+    [[noreturn]] void fail(torch::executor::Error /* error */) {
+      ET_CHECK_MSG(false, "Unsupported dtype");
+    }
+  } ctx;
   ASSERT_EQ(
       ET_SWITCH_TWO_TYPES(
           Float,

--- a/kernels/quantized/cpu/embeddingxb.cpp
+++ b/kernels/quantized/cpu/embeddingxb.cpp
@@ -258,6 +258,7 @@ void resize_out_tensor(
 Tensor& quantized_embedding_xbit_out(
     // TODO Evaluate whether this name is appropriate for an operator that takes
     // non quant input and returns fp output
+    KernelRuntimeContext& ctx,
     const Tensor& weight,
     const Tensor& weight_scales,
     const std::optional<Tensor>& opt_weight_zero_points,
@@ -267,6 +268,8 @@ Tensor& quantized_embedding_xbit_out(
     Tensor& out,
     int weight_nbit) {
   ScalarType out_type = out.scalar_type();
+
+  resize_out_tensor(weight, indices, out, weight_nbit);
 
   // TODO (jakeszwe): improve these to account for the size of out in relation
   // to weight and indices accounting for a possible batch dimension
@@ -296,7 +299,6 @@ Tensor& quantized_embedding_xbit_out(
 }
 
 Tensor& quantized_embedding_xbit_out(
-    KernelRuntimeContext& context,
     const Tensor& weight,
     const Tensor& weight_scales,
     const std::optional<Tensor>& opt_weight_zero_points,
@@ -307,9 +309,9 @@ Tensor& quantized_embedding_xbit_out(
     int weight_nbit) {
   // TODO(larryliu): Add a context arg to the real op function and remove this
   // wrapper
-  (void)context;
-  resize_out_tensor(weight, indices, out, weight_nbit);
-  return quantized_embedding_xbit_out(
+  KernelRuntimeContext context;
+  auto& res = quantized_embedding_xbit_out(
+      context,
       weight,
       weight_scales,
       opt_weight_zero_points,
@@ -318,11 +320,14 @@ Tensor& quantized_embedding_xbit_out(
       indices,
       out,
       weight_nbit);
+  ET_CHECK(context.failure_state() == Error::Ok);
+  return res;
 }
 
 Tensor& quantized_embedding_xbit_dtype_out(
     // TODO Evaluate whether this name is appropriate for an operator that takes
     // non quant input and returns fp output
+    KernelRuntimeContext& ctx,
     const Tensor& weight,
     const Tensor& weight_scales,
     const std::optional<Tensor>& opt_weight_zero_points,
@@ -332,6 +337,8 @@ Tensor& quantized_embedding_xbit_dtype_out(
     std::optional<ScalarType> out_dtype,
     Tensor& out,
     int weight_nbit) {
+  resize_out_tensor(weight, indices, out, weight_nbit);
+
   // TODO (jakeszwe): improve these to account for the size of out in relation
   // to weight and indices accounting for a possible batch dimension
   check_embedding_xbit_args(
@@ -365,7 +372,6 @@ Tensor& quantized_embedding_xbit_dtype_out(
 }
 
 Tensor& quantized_embedding_xbit_dtype_out(
-    KernelRuntimeContext& context,
     const Tensor& weight,
     const Tensor& weight_scales,
     const std::optional<Tensor>& opt_weight_zero_points,
@@ -377,9 +383,9 @@ Tensor& quantized_embedding_xbit_dtype_out(
     int weight_nbit) {
   // TODO(larryliu): Add a context arg to the real op function and remove this
   // wrapper
-  (void)context;
-  resize_out_tensor(weight, indices, out, weight_nbit);
-  return quantized_embedding_xbit_dtype_out(
+  KernelRuntimeContext context;
+  auto& res = quantized_embedding_xbit_dtype_out(
+      context,
       weight,
       weight_scales,
       opt_weight_zero_points,
@@ -389,6 +395,8 @@ Tensor& quantized_embedding_xbit_dtype_out(
       out_dtype,
       out,
       weight_nbit);
+  ET_CHECK(context.failure_state() == Error::Ok);
+  return res;
 }
 
 } // namespace native

--- a/kernels/quantized/cpu/op_embedding.cpp
+++ b/kernels/quantized/cpu/op_embedding.cpp
@@ -232,6 +232,7 @@ void resize_out_tensor(
 Tensor& quantized_embedding_byte_out(
     // TODO Evaluate whether this name is appropriate for an operator that takes
     // non quant input and returns fp output
+    KernelRuntimeContext& ctx,
     const Tensor& weight,
     const Tensor& weight_scales,
     const std::optional<Tensor>& opt_weight_zero_points,
@@ -241,6 +242,8 @@ Tensor& quantized_embedding_byte_out(
     Tensor& out) {
   ScalarType w_type = weight.scalar_type();
   ScalarType out_type = out.scalar_type();
+
+  resize_out_tensor(weight, indices, out);
 
   // TODO (jakeszwe): improve these to account for the size of out in relation
   // to weight and indices accounting for a possible batch dimension
@@ -266,7 +269,6 @@ Tensor& quantized_embedding_byte_out(
 }
 
 Tensor& quantized_embedding_byte_out(
-    KernelRuntimeContext& context,
     const Tensor& weight,
     const Tensor& weight_scales,
     const std::optional<Tensor>& opt_weight_zero_points,
@@ -276,9 +278,9 @@ Tensor& quantized_embedding_byte_out(
     Tensor& out) {
   // TODO(larryliu): Add a context arg to the real op function and remove this
   // wrapper
-  (void)context;
-  resize_out_tensor(weight, indices, out);
-  return quantized_embedding_byte_out(
+  KernelRuntimeContext context;
+  auto& res = quantized_embedding_byte_out(
+      context,
       weight,
       weight_scales,
       opt_weight_zero_points,
@@ -286,11 +288,14 @@ Tensor& quantized_embedding_byte_out(
       weight_quant_max,
       indices,
       out);
+  ET_CHECK(context.failure_state() == Error::Ok);
+  return res;
 }
 
 Tensor& quantized_embedding_byte_dtype_out(
     // TODO Evaluate whether this name is appropriate for an operator that takes
     // non quant input and returns fp output
+    KernelRuntimeContext& ctx,
     const Tensor& weight,
     const Tensor& weight_scales,
     const std::optional<Tensor>& opt_weight_zero_points,
@@ -299,6 +304,8 @@ Tensor& quantized_embedding_byte_dtype_out(
     const Tensor& indices,
     std::optional<ScalarType> out_dtype,
     Tensor& out) {
+  resize_out_tensor(weight, indices, out);
+
   // TODO (jakeszwe): improve these to account for the size of out in relation
   // to weight and indices accounting for a possible batch dimension
   check_embedding_byte_args(
@@ -329,7 +336,6 @@ Tensor& quantized_embedding_byte_dtype_out(
 }
 
 Tensor& quantized_embedding_byte_dtype_out(
-    KernelRuntimeContext& context,
     const Tensor& weight,
     const Tensor& weight_scales,
     const std::optional<Tensor>& opt_weight_zero_points,
@@ -340,9 +346,9 @@ Tensor& quantized_embedding_byte_dtype_out(
     Tensor& out) {
   // TODO(larryliu): Add a context arg to the real op function and remove this
   // wrapper
-  (void)context;
-  resize_out_tensor(weight, indices, out);
-  return quantized_embedding_byte_dtype_out(
+  KernelRuntimeContext context;
+  auto& res = quantized_embedding_byte_dtype_out(
+      context,
       weight,
       weight_scales,
       opt_weight_zero_points,
@@ -351,6 +357,8 @@ Tensor& quantized_embedding_byte_dtype_out(
       indices,
       out_dtype,
       out);
+  ET_CHECK(context.failure_state() == Error::Ok);
+  return res;
 }
 
 } // namespace native

--- a/kernels/quantized/cpu/op_mixed_mm.cpp
+++ b/kernels/quantized/cpu/op_mixed_mm.cpp
@@ -52,20 +52,29 @@ bool check_quantized_mixed_mm_args(
 }
 
 Tensor& quantized_mixed_mm_out(
+    KernelRuntimeContext& ctx,
     const Tensor& in,
     const Tensor& weight,
     const Tensor& weight_scales,
     const std::optional<Tensor>& opt_weight_zero_points,
     Tensor& out) {
-  ET_CHECK(check_quantized_mixed_mm_args(
-      in, weight, weight_scales, opt_weight_zero_points, out));
+  ET_KERNEL_CHECK(
+      ctx,
+      check_quantized_mixed_mm_args(
+          in, weight, weight_scales, opt_weight_zero_points, out),
+      InvalidArgument,
+      out);
 
   size_t output_ndim = 2;
   executorch::aten::SizesType output_sizes[kTensorDimensionLimit];
   output_sizes[0] = in.size(0);
   output_sizes[1] = weight.size(1);
 
-  ET_CHECK(resize_tensor(out, {output_sizes, output_ndim}) == Error::Ok);
+  ET_KERNEL_CHECK(
+      ctx,
+      resize_tensor(out, {output_sizes, output_ndim}) == Error::Ok,
+      InvalidArgument,
+      out);
 
   constexpr auto name = "quantized_decomposed::mixed_mm.out";
 
@@ -88,16 +97,17 @@ Tensor& quantized_mixed_mm_out(
 }
 
 Tensor& quantized_mixed_mm_out(
-    KernelRuntimeContext& ctx,
     const Tensor& in,
     const Tensor& weight,
     const Tensor& weight_scales,
     const std::optional<Tensor>& opt_weight_zero_points,
     Tensor& out) {
   // TODO(mcandales): Remove the need for this wrapper
-  (void)ctx;
-  return quantized_mixed_mm_out(
-      in, weight, weight_scales, opt_weight_zero_points, out);
+  KernelRuntimeContext context;
+  auto& res = quantized_mixed_mm_out(
+      context, in, weight, weight_scales, opt_weight_zero_points, out);
+  ET_CHECK(context.failure_state() == Error::Ok);
+  return res;
 }
 
 } // namespace native

--- a/runtime/core/exec_aten/util/scalar_type_util.h
+++ b/runtime/core/exec_aten/util/scalar_type_util.h
@@ -910,20 +910,21 @@ struct promote_types {
   }
 #endif
 
-#define ET_INTERNAL_SWITCH(TYPE, CONTEXT, NAME, ...) \
-  [&] {                                              \
-    const auto& _st = TYPE;                          \
-    constexpr const char* et_switch_name = NAME;     \
-    (void)et_switch_name; /* Suppress unused var */  \
-    switch (_st) {                                   \
-      __VA_ARGS__                                    \
-      default:                                       \
-        ET_CHECK_MSG(                                \
-            false,                                   \
-            "Unhandled dtype %s for %s",             \
-            ::executorch::runtime::toString(_st),    \
-            et_switch_name);                         \
-    }                                                \
+#define ET_INTERNAL_SWITCH(TYPE, CONTEXT, NAME, ...)           \
+  [&] {                                                        \
+    const auto& _st = TYPE;                                    \
+    constexpr const char* et_switch_name = NAME;               \
+    (void)et_switch_name; /* Suppress unused var */            \
+    switch (_st) {                                             \
+      __VA_ARGS__                                              \
+      default:                                                 \
+        CONTEXT.fail(torch::executor::Error::InvalidArgument); \
+        ET_LOG(                                                \
+            Error,                                             \
+            "Unhandled dtype %s for %s",                       \
+            ::executorch::runtime::toString(_st),              \
+            et_switch_name);                                   \
+    }                                                          \
   }()
 
 #define ET_INTERNAL_SWITCH_CASE_INT_TYPES(CTYPE_ALIAS, ...)            \


### PR DESCRIPTION
Summary: Modify `ET_INTERNAL_SWITCH` macro, so that we fail non-fatally in the default clause when we encounter an unsupported dtype.

Differential Revision: D80141272


