### PR TITLE
Fix Arm tester after etrecord signature change

### DIFF
--- a/backends/arm/test/tester/arm_tester.py
+++ b/backends/arm/test/tester/arm_tester.py
@@ -376,6 +376,7 @@ class ArmTester(Tester):
         transform_passes: Optional[
             Union[Sequence[PassType], Dict[str, Sequence[PassType]]]
         ] = None,
+        generate_etrecord: bool = False,
     ):
         if to_edge_and_lower_stage is None:
             if partitioners is None:
@@ -403,6 +404,7 @@ class ArmTester(Tester):
                 edge_compile_config,
                 constant_methods=self.constant_methods,
                 transform_passes=self.transform_passes,
+                generate_etrecord=generate_etrecord,
             )
         else:
             if partitioners is not None:


### PR DESCRIPTION
### Summary
My recent tester changes added a generate_etrecord parameter to the tester to_edge_transform_and_lower API. This broke some of the ARM tests. I missed this due to pre-existing ARM CI failures (I didn't look closely enough at failure log). This change adds the parameter to the ARM tester to fix the signature. It should be a no-op for the ARM tests themselves.

### Test plan
CI