### PR TITLE
Bump Zephyr SDK Version in CI Image from v0.16.0 -> v0.17.2

### DIFF
--- a/.ci/scripts/zephyr-utils.sh
+++ b/.ci/scripts/zephyr-utils.sh
@@ -6,9 +6,9 @@
 # LICENSE file in the root directory of this source tree.
 
 download_arm_zephyr_sdk () {
-    wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.0/zephyr-sdk-0.16.0_linux-x86_64.tar.xz
-    tar -xf zephyr-sdk-0.16.0_linux-x86_64.tar.xz
-    rm -f zephyr-sdk-0.16.0_linux-x86_64.tar.xz
+    wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.17.2/zephyr-sdk-0.17.2_linux-x86_64.tar.xz
+    tar -xf zephyr-sdk-0.17.2_linux-x86_64.tar.xz
+    rm -f zephyr-sdk-0.17.2_linux-x86_64.tar.xz
 }
 
 setup_zephyr_et_module () {

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -92,7 +92,7 @@ jobs:
 
         # TODO @Bujji: Should see if this can be moved into the docker image itself
         download_arm_zephyr_sdk
-        ./zephyr-sdk-0.16.0/setup.sh -c -t arm-zephyr-eabi
+        ./zephyr-sdk-0.17.2/setup.sh -c -t arm-zephyr-eabi
         cd $ZEPHYR_PROJ_ROOT
         setup_zephyr_et_module
 


### PR DESCRIPTION
### Summary
Previously, the CI docker image that was used for the Zephyr tests downloaded and used the v0.16.0 version of the Zephyr SDK. Zephyr has updated their documentation to recommend user to use v0.17.2. This PR makes the needed change so that the CI job that runs the Zephyr tests pulls the v0.17.2 version of the SDK. 

### Test Plan
Tested on local repro of Docker image, and all support models (`add`, `softmax`, and `mv2`) still pass.