### PR TITLE
Allow for HOP to be in the etreord graph

### DIFF
--- a/devtools/debug_format/et_schema.py
+++ b/devtools/debug_format/et_schema.py
@@ -29,6 +29,11 @@ from executorch.devtools.debug_format.base_schema import (
     OperatorNode,
     ValueNode,
 )
+
+from torch._higher_order_ops.auto_functionalize import (
+    auto_functionalized,
+    auto_functionalized_v2,
+)
 from torch._subclasses import FakeTensor
 
 
@@ -120,6 +125,12 @@ class FXOperatorGraph(OperatorGraph):
         if node.op == "call_function" and hasattr(node.target, "_schema"):
             # pyre-ignore
             named_args = node.target._schema.arguments
+
+        if node.op == "call_function" and (
+            node.target == auto_functionalized or node.target == auto_functionalized_v2
+        ):
+            # for functioanlized HOPs, args for the corresponding functional op are stored in kwargs
+            args = tuple(kwargs.values())
 
         for index, arg in enumerate(args):
             if isinstance(arg, torch.fx.node.Node):


### PR DESCRIPTION
Summary: et_schema parsing cannot handle HOP. This diff fixes that by allowing HOP to be treated same as the op it wraps and just extracts args from kwargs.

Reviewed By: Gasoonjia

Differential Revision: D80118856


