### PR TITLE
lintrunner -a backends/qualcomm/CMakeLists.txt

### DIFF
--- a/backends/qualcomm/CMakeLists.txt
+++ b/backends/qualcomm/CMakeLists.txt
@@ -58,9 +58,7 @@ if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
 endif()
 
 include_directories(
-  BEFORE
-  ${_common_include_directories}
-  ${QNN_SDK_ROOT}/include/QNN
+  BEFORE ${_common_include_directories} ${QNN_SDK_ROOT}/include/QNN
   ${QNN_SDK_ROOT}/share/QNN/converter/jni
   ${EXECUTORCH_SOURCE_DIR}/runtime/core/portable_type/c10
 )


### PR DESCRIPTION
Fixes lint issues introduced by #12583