### PR TITLE
Qualcomm AI Engine Direct - Avoid duplicated external ION memory registration

### DIFF
--- a/backends/qualcomm/runtime/backends/QnnMemManager.h
+++ b/backends/qualcomm/runtime/backends/QnnMemManager.h
@@ -68,6 +68,8 @@ class QnnMemManager {
   QnnContext* context_;
   QnnExecuTorchLogLevel log_level_;
   std::unordered_map<Qnn_MemHandle_t, void*> registered_map_;
+  // If an Ion buffer is already registered, look it up here to reuse the handle
+  std::unordered_map<void*, Qnn_MemHandle_t> inverse_ion_registered_map_;
   std::unordered_map<CustomMemTensorInfo, void*> pre_registered_handles_;
   std::unordered_map<executorch::aten::ScalarType, Qnn_DataType_t>
       scalar_type_to_qnn_dtype_ = {


### PR DESCRIPTION
Summary:
`inverse_ion_registered_map_` stores the mapping from an external ION buffer to a registered memory handle, it's only populate by `RegisterIonMem`. I don't quite understand the use case for `RegisterCustomMem` and `PreRegisterCustomMemHandle` so I didn't attempt to change the existing `registered_map_`. The goal is to support a same external ION buffer to be used for inputs of different graphs. It will be registered for the first graph and the same handle will be used for the other graphs. Without this duplicated registration errors will be logged on every inference.

By external ION buffer we I'm referring to buffers allocated outside of the immediate surrounding of the inference code not using any helpers from the QNN backend.

Rollback Plan:

Differential Revision: D80267040


