### PR TITLE
Android scheduled build add vulkan

### DIFF
--- a/.github/workflows/android-release-artifacts.yml
+++ b/.github/workflows/android-release-artifacts.yml
@@ -90,7 +90,7 @@ jobs:
         fi
 
         FLAVOR="${{ inputs.flavor }}"
-        if [[ "$FLAVOR" == "vulkan+xnnpack" ]]; then
+        if [[ "$FLAVOR" == "vulkan+xnnpack" || -z "$FLAVOR" ]]; then
           export EXECUTORCH_BUILD_VULKAN=ON
         fi
 


### PR DESCRIPTION
### Summary
Let's build xnnpack+vulkan and see how it goes

Size:
xnnpack: 10.4M
xnnpack+vulkan: 13.2M
as of [cad1214](https://github.com/pytorch/executorch/commit/cad1214c6a75d1f5a433078ba86c27cb4e8794e8)

### Test plan
CI

cc @SS-JIA @manuelcandales @cbilgin