### PR TITLE
Switch to conda-forge on MacOS

### DIFF
--- a/.ci/docker/common/install_conda.sh
+++ b/.ci/docker/common/install_conda.sh
@@ -35,7 +35,7 @@ install_miniconda() {
 install_python() {
   pushd /opt/conda
   # Install the selected Python version for CI jobs
-  as_ci_user conda create -n "py_${PYTHON_VERSION}" -y --file /opt/conda/conda-env-ci.txt python="${PYTHON_VERSION}"
+  as_ci_user conda create -c conda-forge -n "py_${PYTHON_VERSION}" -y --file /opt/conda/conda-env-ci.txt python="${PYTHON_VERSION}"
 
   # From https://github.com/pytorch/pytorch/blob/main/.ci/docker/common/install_conda.sh
   if [[ $(uname -m) == "aarch64" ]]; then

--- a/.ci/docker/common/install_conda.sh
+++ b/.ci/docker/common/install_conda.sh
@@ -35,7 +35,7 @@ install_miniconda() {
 install_python() {
   pushd /opt/conda
   # Install the selected Python version for CI jobs
-  as_ci_user conda create -c conda-forge -n "py_${PYTHON_VERSION}" -y --file /opt/conda/conda-env-ci.txt python="${PYTHON_VERSION}"
+  as_ci_user conda create -n "py_${PYTHON_VERSION}" -y --file /opt/conda/conda-env-ci.txt python="${PYTHON_VERSION}"
 
   # From https://github.com/pytorch/pytorch/blob/main/.ci/docker/common/install_conda.sh
   if [[ $(uname -m) == "aarch64" ]]; then

--- a/.ci/scripts/setup-conda.sh
+++ b/.ci/scripts/setup-conda.sh
@@ -9,7 +9,7 @@ set -ex
 
 install_conda() {
   pushd .ci/docker || return
-  ${CONDA_INSTALL} -y --file conda-env-ci.txt
+  ${CONDA_INSTALL} -c conda-forge -y --file conda-env-ci.txt
   popd || return
 }
 


### PR DESCRIPTION
### Summary

This helps mitigate the issue with the broken `llvm-openmp` in trunk

### Test plan
CI
