### PR TITLE
[ez] Fix idx in duplicate_constant_node_pass

### DIFF
--- a/exir/backend/canonical_partitioners/duplicate_constant_node_pass.py
+++ b/exir/backend/canonical_partitioners/duplicate_constant_node_pass.py
@@ -61,10 +61,14 @@ def duplicate_constant_node(
     new_input_specs = []
     old_signature = exported_program.graph_signature
     copied_nodes = set()
-    for idx, node in enumerate(exported_program.graph.nodes):
+
+    placeholder_idx = -1
+    for node in exported_program.graph.nodes:
         if node.op != "placeholder":
             continue
-        old_input_spec = old_signature.input_specs[idx]
+
+        placeholder_idx += 1
+        old_input_spec = old_signature.input_specs[placeholder_idx]
         old_input_spec_copy = copy.deepcopy(old_input_spec)
         if node == to_be_copied[0]:
             constant_or_attribute_node = node


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #13461

Summary:
## Context

Prevent errors like

```
Export failed with error: Command '['optimum-cli', 'export', 'executorch', '--model', 'NousResearch/Llama-3.2-1B', '--task', 'text-generation', '--recipe', 'vulkan', '--output_dir', '/var/folders/ch/wpn5l1rx3p17k4r6w3mhsdgr0000gn/T/tmp7zzmlks6']' returned non-zero exit status 2.
    test_fn(
  File "/Users/ssjia/scratch/scripts/test_hf_model.py", line 74, in test_text_generation
    model = ExecuTorchModelForCausalLM.from_pretrained(model_id, recipe=recipe)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ssjia/Github/optimum-executorch/optimum/executorch/modeling.py", line 341, in from_pretrained
    models_dict = cls._export(
                  ^^^^^^^^^^^^
  File "/Users/ssjia/Github/optimum-executorch/optimum/executorch/modeling.py", line 249, in _export
    executorch_progs = main_export(
                       ^^^^^^^^^^^^
  File "/Users/ssjia/Github/optimum-executorch/optimum/exporters/executorch/__main__.py", line 140, in main_export
    return export_to_executorch(
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ssjia/Github/optimum-executorch/optimum/exporters/executorch/convert.py", line 83, in export_to_executorch
    executorch_progs = recipe_func(model, **kwargs)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ssjia/Github/optimum-executorch/optimum/exporters/executorch/recipes/vulkan.py", line 123, in export_to_executorch_with_vulkan
    return _lower_to_executorch(exported_progs, model.metadata)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ssjia/Github/optimum-executorch/optimum/exporters/executorch/recipes/vulkan.py", line 80, in _lower_to_executorch
    et_progs[pte_name] = to_edge_transform_and_lower(
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ssjia/Github/executorch/src/executorch/exir/program/_program.py", line 113, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ssjia/Github/executorch/src/executorch/exir/program/_program.py", line 1342, in to_edge_transform_and_lower
    edge_manager = edge_manager.to_backend(method_to_partitioner)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ssjia/Github/executorch/src/executorch/exir/program/_program.py", line 113, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ssjia/Github/executorch/src/executorch/exir/program/_program.py", line 1643, in to_backend
    new_edge_programs = to_backend(method_to_programs_and_partitioners)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/fbcode/platform010/Python3.12.framework/Versions/3.12/lib/python3.12/functools.py", line 912, in wrapper
    return dispatch(args[0].__class__)(*args, **kw)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ssjia/Github/executorch/src/executorch/exir/backend/backend_api.py", line 732, in _
    _maybe_duplicate_constant_nodes(tagged_exported_program, tag)
  File "/Users/ssjia/Github/executorch/src/executorch/exir/backend/utils.py", line 244, in _maybe_duplicate_constant_nodes
    duplicate_constant_node(tagged_exported_program, candidate_node)
  File "/Users/ssjia/Github/executorch/src/executorch/exir/backend/canonical_partitioners/duplicate_constant_node_pass.py", line 67, in duplicate_constant_node
    old_input_spec = old_signature.input_specs[idx]
                     ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^
IndexError: list index out of range
```

This happens when there are non-placeholder nodes that appear before the last placeholder nodes in `exported_program.graph.nodes`; in this case the pass will try to access an input spec outside the bounds of the graph signature.

## Fix

Instead of tracking the index of the the current node being processed, track the number of placeholder nodes observed. This will ensure that the input spec being accessed will match the current placeholder node being processed.