### PR TITLE
Back out "Do not use BNNS copy when dtypes differ in CoreML (#13018)"

### DIFF
--- a/backends/apple/coreml/runtime/delegate/multiarray.mm
+++ b/backends/apple/coreml/runtime/delegate/multiarray.mm
@@ -123,9 +123,6 @@ bool init_bnns_descriptor(BNNSNDArrayDescriptor& bnns_descriptor, const MultiArr
 }
 
 bool copy_using_bnns(const MultiArray& src, MultiArray& dst) {
-    if (src.layout().dataType() != dst.layout().dataType()) {
-        return false;
-    }
     if (dst.layout().num_bytes() < src.layout().num_bytes()) {
         return false;
     }


### PR DESCRIPTION
Summary:
the diff D79416945 make the model inference slow
1. in old 08/01 build runner on Mac , P1905141721
Prefilled 18 tokens @ 250 tokens/second.
Generated 23 tokens @ 18.4 tokens/second.
2. in today 0814 build runner, on Mac,  P1905142300
refilled 18 tokens @ 36.5112 token/s in 493ms
Generated 23 tokens @ 2.25734 token/s in 10189ms

Differential Revision: D80362730


