### PR TITLE
Arm backend: Add partial vulkan runtime support for VgfPipeline

### DIFF
--- a/backends/arm/test/common.py
+++ b/backends/arm/test/common.py
@@ -19,6 +19,7 @@ from executorch.backends.arm.test.runner_utils import (
     corstone300_installed,
     corstone320_installed,
     model_converter_installed,
+    vkml_emulation_layer_installed,
 )
 from executorch.backends.arm.tosa_specification import TosaSpecification
 from executorch.exir.backend.compile_spec_schema import CompileSpec
@@ -90,39 +91,6 @@ def get_tosa_compile_spec_unbuilt(
     return compile_spec_builder
 
 
-def get_vgf_compile_spec(
-    tosa_spec: str | TosaSpecification,
-    compiler_flags: Optional[str] = "",
-    custom_path=None,
-) -> list[CompileSpec]:
-    """
-    Default compile spec for VGF tests.
-    """
-    return get_vgf_compile_spec_unbuilt(tosa_spec, compiler_flags, custom_path).build()
-
-
-def get_vgf_compile_spec_unbuilt(
-    tosa_spec: str | TosaSpecification,
-    compiler_flags: Optional[str] = "",
-    custom_path=None,
-) -> ArmCompileSpecBuilder:
-    """Get the ArmCompileSpecBuilder for the default VGF tests, to modify
-    the compile spec before calling .build() to finalize it.
-    """
-    if not custom_path:
-        custom_path = maybe_get_tosa_collate_path()
-
-    if custom_path is not None:
-        os.makedirs(custom_path, exist_ok=True)
-    compile_spec_builder = (
-        ArmCompileSpecBuilder()
-        .vgf_compile_spec(tosa_spec, compiler_flags)
-        .dump_intermediate_artifacts_to(custom_path)
-    )
-
-    return compile_spec_builder
-
-
 def get_u55_compile_spec(
     macs: int = 128,
     system_config: str = "Ethos_U55_High_End_Embedded",
@@ -163,6 +131,17 @@ def get_u85_compile_spec(
         custom_path=custom_path,
         config=config,
     ).build()
+
+
+def get_vgf_compile_spec(
+    tosa_spec: str | TosaSpecification,
+    compiler_flags: Optional[str] = "",
+    custom_path=None,
+) -> list[CompileSpec]:
+    """
+    Default compile spec for VGF tests.
+    """
+    return get_vgf_compile_spec_unbuilt(tosa_spec, compiler_flags, custom_path).build()
 
 
 def get_u55_compile_spec_unbuilt(
@@ -228,6 +207,33 @@ def get_u85_compile_spec_unbuilt(
     return compile_spec  # type: ignore[return-value]
 
 
+def get_vgf_compile_spec_unbuilt(
+    tosa_spec: str | TosaSpecification,
+    compiler_flags: Optional[str] = "",
+    custom_path=None,
+) -> ArmCompileSpecBuilder:
+    """Get the ArmCompileSpecBuilder for the default VGF tests, to modify
+    the compile spec before calling .build() to finalize it.
+    """
+    if "FP" in repr(tosa_spec):
+        artifact_path = custom_path or tempfile.mkdtemp(prefix="arm_vgf_fp_")
+    elif "INT" in repr(tosa_spec):
+        artifact_path = custom_path or tempfile.mkdtemp(prefix="arm_vgf_int_")
+    else:
+        raise ValueError(f"Unsupported vgf compile_spec: {repr(tosa_spec)}")
+
+    if not os.path.exists(artifact_path):
+        os.makedirs(artifact_path, exist_ok=True)
+
+    compile_spec_builder = (
+        ArmCompileSpecBuilder()
+        .vgf_compile_spec(tosa_spec, compiler_flags)
+        .dump_intermediate_artifacts_to(artifact_path)
+    )
+
+    return compile_spec_builder
+
+
 XfailIfNoCorstone300 = pytest.mark.xfail(
     condition=not (
         corstone300_installed() and arm_executor_runner_exists("corstone-300")
@@ -251,7 +257,14 @@ SkipIfNoModelConverter = pytest.mark.skipif(
     raises=FileNotFoundError,
     reason="Did not find model-converter on path",
 )
-"""Xfails a test if model-converter is not installed"""
+"""Skips a test if model-converter is not installed"""
+
+XfailfNoVKMLEmulationLayer = pytest.mark.xfail(
+    condition=not (vkml_emulation_layer_installed()),
+    raises=TypeError,
+    reason="VKML environment is not set properly or executor_runner path is misused",
+)
+"""Xfails a test if VKML Emulation Layer is not installed"""
 
 xfail_type = str | tuple[str, type[Exception]]
 

--- a/backends/arm/test/ops/test_add.py
+++ b/backends/arm/test/ops/test_add.py
@@ -7,6 +7,7 @@
 
 from typing import Tuple
 
+import pytest
 import torch
 from executorch.backends.arm.quantizer import arm_quantizer
 from executorch.backends.arm.test import common, conftest
@@ -187,9 +188,19 @@ def test_add_tensor_u85_INT_2(test_data: input_t2):
 
 @common.parametrize("test_data", Add.test_data)
 @common.SkipIfNoModelConverter
+@common.XfailfNoVKMLEmulationLayer
+@pytest.mark.xfail(
+    reason="VGF runtime is not yet fully supported for FP pipeline (MLETORCH-1234)",
+    strict=True,
+)
 def test_add_tensor_vgf_FP(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
-        Add(), test_data(), aten_op, exir_op, tosa_version="TOSA-1.0+FP"
+        Add(),
+        test_data(),
+        aten_op,
+        exir_op,
+        tosa_version="TOSA-1.0+FP",
+        run_on_vulkan_runtime=True,
     )
     pipeline.run()
 

--- a/backends/arm/test/tester/arm_tester.py
+++ b/backends/arm/test/tester/arm_tester.py
@@ -51,7 +51,7 @@ from executorch.backends.arm.test.runner_utils import (
     get_output_nodes,
     get_output_quantization_params,
     get_target_board,
-    run_corstone,
+    run_target,
     TosaReferenceModelDispatch,
 )
 
@@ -212,7 +212,7 @@ class Serialize(tester.Serialize):
                 f"Did not find build arm_executor_runner in path {elf_path}, run setup_testing.sh?"
             )
 
-        return run_corstone(
+        return run_target(
             self.executorch_program_manager,
             inputs_flattened,
             intermediate_path,

--- a/backends/arm/test/tester/test_pipeline.py
+++ b/backends/arm/test/tester/test_pipeline.py
@@ -892,7 +892,9 @@ class VgfPipeline(BasePipelineMaker, Generic[T]):
        exir_ops: Exir dialect ops expected to be found in the graph after to_edge.
        if not using use_edge_to_transform_and_lower.
 
-       run_on_vulkan_runtime: Not yet supported.
+       run_on_vulkan_runtime: Partially supported. However, comparison between reference and model
+       outputs is expected to fail, as the VGF runtime doesn't dump the output tensors in a usable
+       format at the moment.
 
        vgf_compiler_flags: Optional compiler flags.
 
@@ -992,4 +994,11 @@ class VgfPipeline(BasePipelineMaker, Generic[T]):
             )
 
         if run_on_vulkan_runtime:
-            pass
+            self.add_stage(self.tester.serialize)
+            self.add_stage(
+                self.tester.run_method_and_compare_outputs,
+                atol=atol,
+                rtol=rtol,
+                qtol=qtol,
+                inputs=self.test_data,
+            )


### PR DESCRIPTION
- Add XfailIfNoVKMLEmulationLayer for VGF unit tests
- Introduce run_target_board() to unify FVP and VKML execution paths
- Implement run_vkml_emulation_layer() with NotImplementedError for output parsing, as the VGF runtime doesn't dump the output tensors in a usable format at the moment.

Change-Id: I3d936b737a694d90971869289b16875d6f6e55a4


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @SS-JIA @manuelcandales @cbilgin