### PR TITLE
Enable BNNS copy for FP16 to FP32

### DIFF
--- a/backends/apple/coreml/runtime/delegate/multiarray.mm
+++ b/backends/apple/coreml/runtime/delegate/multiarray.mm
@@ -125,7 +125,7 @@ bool init_bnns_descriptor(BNNSNDArrayDescriptor& bnns_descriptor, const MultiArr
 bool copy_using_bnns(const MultiArray& src, MultiArray& dst) {
     if (src.layout().dataType() != dst.layout().dataType()) {
         // Copying from FP16 to FP32 is supported and this is a common use case
-        if !(src.layout().dataType() == MultiArray::DataType::Float16 && dst.layout().dataType() == MultiArray::DataType::Float32) {
+        if (!(src.layout().dataType() == MultiArray::DataType::Float16 && dst.layout().dataType() == MultiArray::DataType::Float32)) {
             return false;
         }
     }

--- a/backends/apple/coreml/runtime/delegate/multiarray.mm
+++ b/backends/apple/coreml/runtime/delegate/multiarray.mm
@@ -124,7 +124,10 @@ bool init_bnns_descriptor(BNNSNDArrayDescriptor& bnns_descriptor, const MultiArr
 
 bool copy_using_bnns(const MultiArray& src, MultiArray& dst) {
     if (src.layout().dataType() != dst.layout().dataType()) {
-        return false;
+        // Copying from FP16 to FP32 is supported and this is a common use case
+        if !(src.layout().dataType() == MultiArray::DataType::Float16 && dst.layout().dataType() == MultiArray::DataType::Float32) {
+            return false;
+        }
     }
     if (dst.layout().num_bytes() < src.layout().num_bytes()) {
         return false;


### PR DESCRIPTION
This enables using BNNS copy for FP16 to FP32
