### PR TITLE
Force -O3 for executorch op_div.cpp in clang 19

### DIFF
--- a/shim_et/xplat/executorch/kernels/optimized/op_registration_util.bzl
+++ b/shim_et/xplat/executorch/kernels/optimized/op_registration_util.bzl
@@ -165,6 +165,17 @@ OPTIMIZED_ATEN_OPS = (
     ),
     op_target(
         name = "op_div",
+        # A bug in instruction selection in clang 19 for android seems to trigger some
+        # terrible, multiple hour, backend generation when building for asan with thinlto.
+        # generally maybe a good idea to just make this fully optimized anyway, but -O2
+        # is not sufficient to avoid it.
+        compiler_flags = [] if runtime.is_oss else select({
+            "DEFAULT": [],
+            "ovr_config//toolchain/clang/constraints:19": select({
+                "DEFAULT": [],
+                "ovr_config//os:android": ["-O3"],
+            }),
+        }),
         deps = [
             ":binary_ops",
             "//executorch/kernels/portable/cpu:scalar_utils",


### PR DESCRIPTION
Summary:
A bug in clang 19's backend causes it to take more than 3 hours
to do instruction selection for arm when compiling with -Oz and/or asan
and/or thinlto. But forcing O3 seems to trigger enough of the right optimizations
to avoid that.

Reviewed By: scutexasece, Polyomino

Differential Revision: D80374269


