### PR TITLE
migrate all test_aten_ops to facto

### DIFF
--- a/backends/cadence/utils/facto_util.py
+++ b/backends/cadence/utils/facto_util.py
@@ -10,6 +10,8 @@ import copy
 from functools import lru_cache
 from typing import List, OrderedDict, Tuple
 
+import facto.specdb.function as fn
+
 import torch
 from facto.inputgen.argtuple.gen import ArgumentTupleGenerator
 from facto.inputgen.specs.model import ConstraintProducer as cp
@@ -22,13 +24,21 @@ MAX_CASES = 50
 
 def apply_tensor_contraints(op_name: str, index: int) -> list[object]:
     tensor_constraints = [
-        cp.Dtype.In(lambda deps: [torch.int, torch.float]),
-        cp.Dtype.NotIn(lambda deps: [torch.int64, torch.float64]),
+        cp.Dtype.In(
+            lambda deps: [
+                torch.int8,
+                torch.int16,
+                torch.uint8,
+                torch.uint16,
+                torch.float32,
+            ]
+        ),
         cp.Value.Ge(lambda deps, dtype, struct: -(2**4)),
         cp.Value.Le(lambda deps, dtype, struct: 2**4),
         cp.Rank.Ge(lambda deps: 1),
         cp.Size.Ge(lambda deps, r, d: 1),
         cp.Size.Le(lambda deps, r, d: 2**9),
+        cp.Rank.Le(lambda deps: 2**3),
     ]
 
     match op_name:
@@ -36,7 +46,6 @@ def apply_tensor_contraints(op_name: str, index: int) -> list[object]:
             if index == 0:  # condition
                 tensor_constraints = [
                     cp.Dtype.In(lambda deps: [torch.bool]),
-                    cp.Dtype.NotIn(lambda deps: [torch.int64, torch.float64]),
                     cp.Value.Ge(lambda deps, dtype, struct: -(2**4)),
                     cp.Value.Le(lambda deps, dtype, struct: 2**4),
                     cp.Rank.Ge(lambda deps: 1),
@@ -45,19 +54,35 @@ def apply_tensor_contraints(op_name: str, index: int) -> list[object]:
                 ]
             else:
                 tensor_constraints = [
-                    cp.Dtype.In(lambda deps: [torch.float, torch.int]),
-                    cp.Dtype.NotIn(lambda deps: [torch.int64, torch.float64]),
+                    cp.Dtype.In(
+                        lambda deps: [
+                            torch.int8,
+                            torch.int16,
+                            torch.uint8,
+                            torch.uint16,
+                            torch.float32,
+                        ]
+                    ),
                     cp.Value.Ge(lambda deps, dtype, struct: -(2**4)),
                     cp.Value.Le(lambda deps, dtype, struct: 2**4),
                     cp.Rank.Ge(lambda deps: 1),
                     cp.Size.Ge(lambda deps, r, d: 1),
                     cp.Size.Le(lambda deps, r, d: 2**9),
                 ]
+        case "embedding.default":
+            tensor_constraints = [
+                cp.Dtype.In(lambda deps: [torch.float, torch.int]),
+                cp.Dtype.NotIn(lambda deps: [torch.int64, torch.float64]),
+                cp.Value.Ge(lambda deps, dtype, struct: -(2**4)),
+                cp.Value.Le(lambda deps, dtype, struct: 2**4),
+                cp.Rank.Ge(lambda deps: 1),
+                cp.Size.Ge(lambda deps, r, d: 1),
+                cp.Size.Le(lambda deps, r, d: 2**9),
+            ]
         case "sigmoid.default":
             tensor_constraints.extend(
                 [
-                    cp.Dtype.In(lambda deps: [torch.float]),
-                    cp.Rank.Le(lambda deps: 2**2),
+                    cp.Dtype.In(lambda deps: [torch.float32]),
                     cp.Value.Ge(lambda deps, dtype, struct: -2),
                     cp.Value.Le(lambda deps, dtype, struct: 2),
                 ]
@@ -65,8 +90,7 @@ def apply_tensor_contraints(op_name: str, index: int) -> list[object]:
         case "rsqrt.default":
             tensor_constraints.extend(
                 [
-                    cp.Dtype.In(lambda deps: [torch.float]),
-                    cp.Rank.Le(lambda deps: 2**2),
+                    cp.Dtype.In(lambda deps: [torch.float32]),
                     cp.Value.Gt(
                         lambda deps, dtype, struct: 0
                     ),  # only generate real numbers
@@ -76,14 +100,12 @@ def apply_tensor_contraints(op_name: str, index: int) -> list[object]:
         case "mean.dim":
             tensor_constraints.extend(
                 [
-                    cp.Dtype.In(lambda deps: [torch.float]),
-                    cp.Rank.Le(lambda deps: 2**2),
+                    cp.Dtype.In(lambda deps: [torch.float32]),
                 ]
             )
         case "exp.default":
             tensor_constraints.extend(
                 [
-                    cp.Rank.Le(lambda deps: 2**3),
                     cp.Value.Ge(lambda deps, dtype, struct: -(2**2)),
                     cp.Value.Le(lambda deps, dtype, struct: 2**2),
                 ]
@@ -96,26 +118,96 @@ def apply_tensor_contraints(op_name: str, index: int) -> list[object]:
                     cp.Value.Le(lambda deps, dtype, struct: 2),
                 ]
             )
-        case _:
+        case "constant_pad_nd.default":
             tensor_constraints.extend(
                 [
-                    cp.Rank.Le(lambda deps: 2**2),
+                    cp.Dtype.In(lambda deps: [torch.float32]),
+                    cp.Size.Le(lambda deps, r, d: 2**2),
                 ]
             )
+        case "avg_pool2d.default":
+            tensor_constraints.extend(
+                [
+                    cp.Rank.Eq(lambda deps: 4),
+                ]
+            )
+        case "bmm.default" | "addmm.default" | "mm.default":
+            tensor_constraints.extend(
+                [
+                    cp.Dtype.Eq(lambda deps: torch.float),
+                    cp.Size.Le(lambda deps, r, d: 2**2),
+                    cp.Value.Le(lambda deps, dtype, struct: 2**4),
+                ]
+            )
+        case "div.Tensor":
+            tensor_constraints.extend(
+                [
+                    cp.Value.Ne(lambda deps, dtype, struct: 0),
+                ]
+            )
+        case "div.Tensor_mode" | "minimum.default":
+            if index == 0:
+                tensor_constraints = [
+                    cp.Dtype.In(lambda deps: [torch.int64, torch.int32, torch.float32]),
+                    cp.Value.Ge(lambda deps, dtype, struct: -(2**4)),
+                    cp.Value.Le(lambda deps, dtype, struct: 2**4),
+                    cp.Rank.Ge(lambda deps: 1),
+                    cp.Size.Ge(lambda deps, r, d: 1),
+                    cp.Size.Le(lambda deps, r, d: 2**2),
+                ]
+            else:
+                tensor_constraints = [
+                    cp.Dtype.In(lambda deps: [torch.int64, torch.int32, torch.float32]),
+                    cp.Value.Ge(lambda deps, dtype, struct: -(2**4)),
+                    cp.Value.Le(lambda deps, dtype, struct: 2**4),
+                    cp.Rank.Ge(lambda deps: 1),
+                    cp.Rank.Eq(lambda deps: deps[0].dim()),
+                    cp.Size.Eq(lambda deps, r, d: fn.safe_size(deps[0], d)),
+                ]
+        case "_native_batch_norm_legit_no_training.default":
+            tensor_constraints.extend(
+                [
+                    cp.Rank.Le(lambda deps: 3),
+                ],
+            )
+        case "reciprocal.default":
+            tensor_constraints = [
+                cp.Value.Ge(lambda deps, dtype, struct: -(2**2)),
+                cp.Value.Le(lambda deps, dtype, struct: 2**2),
+                cp.Size.Le(lambda deps, r, d: 2**3),
+            ]
+        case "_softmax.default":
+            tensor_constraints.extend(
+                [
+                    cp.Dtype.Eq(lambda deps: torch.float32),
+                    cp.Size.Le(lambda deps, r, d: 2**2),
+                ]
+            )
+        case _:
+            pass
     return tensor_constraints
 
 
 def apply_scalar_contraints(op_name: str) -> list[ScalarDtype]:
     match op_name:
-        case "add.Scalar" | "sub.Scalar" | "mul.Scalar" | "div.Scalar":
+        case (
+            "add.Scalar"
+            | "sub.Scalar"
+            | "mul.Scalar"
+            | "div.Scalar"
+            | "constant_pad_nd.default"
+        ):
             return [ScalarDtype.int]
-
+        case "full.default":
+            return [ScalarDtype.int]
         case _:
             return [ScalarDtype.float, ScalarDtype.int]
 
 
 @lru_cache(maxsize=None)
-def facto_testcase_gen(op_name: str) -> List[Tuple[List[str], OrderedDict[str, str]]]:
+def facto_testcase_gen(  # noqa: C901
+    op_name: str,
+) -> List[Tuple[List[str], OrderedDict[str, str]]]:
     # minimal example to test add.Tensor using FACTO
     spec = SpecDictDB[op_name]
 
@@ -149,6 +241,12 @@ def facto_testcase_gen(op_name: str) -> List[Tuple[List[str], OrderedDict[str, s
                     cp.Dtype.In(lambda deps: apply_scalar_contraints(op_name)),
                 ]
             )
+            if in_spec.name == "dtype":  # full.default
+                spec.inspec[index].constraints.extend(
+                    [
+                        cp.Dtype.In(lambda deps: [torch.long, torch.float]),
+                    ]
+                )
         elif in_spec.type.is_tensor():
             spec.inspec[index].constraints.extend(
                 apply_tensor_contraints(op_name, index)
@@ -164,6 +262,29 @@ def facto_testcase_gen(op_name: str) -> List[Tuple[List[str], OrderedDict[str, s
             spec.inspec[index].constraints.extend(
                 [
                     cp.Dtype.In(lambda deps: [torch.bool]),
+                ]
+            )
+        elif in_spec.type.is_length_list():
+            spec.inspec[index].constraints.extend(
+                [
+                    cp.Value.Ge(lambda deps, dtype, struct: 0),
+                ]
+            )
+            if op_name == "avg_pool2d.default":
+                spec.inspec[index].constraints.extend(
+                    [
+                        cp.Length.Eq(lambda deps: 2),
+                    ]
+                )
+        elif in_spec.type.is_shape():
+            spec.inspec[index].constraints.extend(
+                [
+                    cp.Rank.Ge(lambda deps: 1),
+                    cp.Rank.Le(lambda deps: 2**2),
+                    cp.Value.Gt(lambda deps, dtype, struct: 0),
+                    cp.Value.Le(lambda deps, dtype, struct: 2**2),
+                    cp.Size.Ge(lambda deps, r, d: 1),
+                    cp.Size.Le(lambda deps, r, d: 2**2),
                 ]
             )
 


### PR DESCRIPTION
Summary:
**Have to ship this as an intermediate step to unblock 3 workstreams on the stack**

Modify aten tests to ingress FACTO generated testcases.
- Each test gets 30~50 cases with good coverage on
  - Optimized VS unoptimized flows
  - dtype switch cases

Known issues:
- FACTO test class is too big to run on default "heavyweight" CI
  - current skipping the whole target on CI. Will add back once skycastle flow is ready
- some FACTO is creating inputs that kernels does not handle, mainly dtypes
  - will create exception handling for that.
- TODO marks the 2 FACTO doesnt work well on the 2 ops.

Differential Revision: D79121474


