### PR TITLE
Chang the tmp directory where  to-be-compiled models are stored to use the assetsDirectoryPath

### DIFF
--- a/backends/apple/coreml/runtime/delegate/ETCoreMLModelManager.mm
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLModelManager.mm
@@ -431,7 +431,7 @@ ETCoreMLModelDebugInfo * _Nullable get_model_debug_info(const inmemoryfs::InMemo
         return nil;
     }
     
-    NSURL *dstURL = [self.assetManager.assetsDirectoryPath URLByAppendingPathComponent:[NSUUID UUID].UUIDString];
+    NSURL *dstURL = [self.assetManager.assetsDirectoryURL URLByAppendingPathComponent:[NSUUID UUID].UUIDString];
     NSURL *modelURL = ::write_model_files(dstURL, self.fileManager, identifier, modelAssetType.value(), inMemoryFS, error);
     switch (modelAssetType.value()) {
         case ModelAssetType::CompiledModel: {

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLModelManager.mm
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLModelManager.mm
@@ -431,7 +431,7 @@ ETCoreMLModelDebugInfo * _Nullable get_model_debug_info(const inmemoryfs::InMemo
         return nil;
     }
     
-    NSURL *dstURL = [self.assetManager.assetsDirectoryURL URLByAppendingPathComponent:[NSUUID UUID].UUIDString];
+    NSURL *dstURL = [self.assetManager.trashDirectoryURL URLByAppendingPathComponent:[NSUUID UUID].UUIDString];
     NSURL *modelURL = ::write_model_files(dstURL, self.fileManager, identifier, modelAssetType.value(), inMemoryFS, error);
     switch (modelAssetType.value()) {
         case ModelAssetType::CompiledModel: {

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLModelManager.mm
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLModelManager.mm
@@ -431,7 +431,7 @@ ETCoreMLModelDebugInfo * _Nullable get_model_debug_info(const inmemoryfs::InMemo
         return nil;
     }
     
-    NSURL *dstURL = [self.assetManager.trashDirectoryURL URLByAppendingPathComponent:[NSUUID UUID].UUIDString];
+    NSURL *dstURL = [self.assetManager.assetsDirectoryPath URLByAppendingPathComponent:[NSUUID UUID].UUIDString];
     NSURL *modelURL = ::write_model_files(dstURL, self.fileManager, identifier, modelAssetType.value(), inMemoryFS, error);
     switch (modelAssetType.value()) {
         case ModelAssetType::CompiledModel: {
@@ -444,6 +444,10 @@ ETCoreMLModelDebugInfo * _Nullable get_model_debug_info(const inmemoryfs::InMemo
             NSURL *compiledModelURL = [ETCoreMLModelCompiler compileModelAtURL:modelURL
                                                           maxWaitTimeInSeconds:(5 * 60)
                                                                          error:error];
+            // Clean up modelURL
+            if (modelURL && modelURL.isFileURL) {
+                [self.fileManager removeItemAtURL:modelURL error:nil];
+            }
             
             return compiledModelURL;
         }


### PR DESCRIPTION
This PR changes the temporary directory where to-be-compiled models are stored to use assetsDirectoryPath (NSCachesDirectory) instead of trashDirectory (NSTemporaryDirectory).

This is to prevent errors when the temp directory is deleted between when the model to-be-compiled is written to disk, and it is compiled.

It also cleans up the modelURL if compilation finishes.

The compiled asset is later moved to a permanent location.
