### PR TITLE
Update deprecated pkg_resources api in edge._ops

### DIFF
--- a/backends/apple/mps/serialization/mps_graph_serialize.py
+++ b/backends/apple/mps/serialization/mps_graph_serialize.py
@@ -1,14 +1,16 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
+# Copyright 2025 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import importlib.resources as _resources
 import json
 import os
 import tempfile
 
-import pkg_resources
+import executorch.backends.apple.mps.serialization as serialization_package
 from executorch.backends.apple.mps.serialization.mps_graph_schema import MPSGraph
 from executorch.exir._serialize._dataclass import _DataclassEncoder
 from executorch.exir._serialize._flatbuffer import _flatc_compile
@@ -19,7 +21,9 @@ def convert_to_flatbuffer(mps_graph: MPSGraph) -> bytes:
     with tempfile.TemporaryDirectory() as d:
         schema_path = os.path.join(d, "schema.fbs")
         with open(schema_path, "wb") as schema_file:
-            schema_file.write(pkg_resources.resource_string(__name__, "schema.fbs"))
+            schema_file.write(
+                _resources.read_binary(serialization_package, "schema.fbs")
+            )
         json_path = os.path.join(d, "schema.json")
         with open(json_path, "wb") as json_file:
             json_file.write(mps_graph_json.encode("ascii"))

--- a/backends/arm/test/ops/test_sum.py
+++ b/backends/arm/test/ops/test_sum.py
@@ -60,6 +60,7 @@ def test_sum_dim_intlist_tosa_INT(test_data: input_t1):
         aten_op,
         exir_op=[],
     )
+    pipeline.dump_artifact("export")
     pipeline.run()
 
 

--- a/backends/qualcomm/serialization/qc_schema_serialize.py
+++ b/backends/qualcomm/serialization/qc_schema_serialize.py
@@ -1,14 +1,16 @@
 # Copyright (c) Qualcomm Innovation Center, Inc.
+# Copyright 2025 Arm Limited and/or its affiliates.
 # All rights reserved
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import importlib.resources as _resources
 import json
 import os
 import tempfile
 
-import pkg_resources
+import executorch.backends.qualcomm.serialization as serialization_package
 from executorch.backends.qualcomm.serialization.qc_schema import QnnExecuTorchOptions
 from executorch.exir._serialize._dataclass import _DataclassEncoder, _json_to_dataclass
 from executorch.exir._serialize._flatbuffer import _flatc_compile, _flatc_decompile
@@ -19,7 +21,9 @@ def _convert_to_flatbuffer(obj, schema: str):
     with tempfile.TemporaryDirectory() as d:
         schema_path = os.path.join(d, f"{schema}.fbs")
         with open(schema_path, "wb") as schema_file:
-            schema_file.write(pkg_resources.resource_string(__name__, f"{schema}.fbs"))
+            schema_file.write(
+                _resources.read_binary(serialization_package, f"{schema}.fbs")
+            )
         json_path = os.path.join(d, f"{schema}.json")
         with open(json_path, "wb") as json_file:
             json_file.write(obj_json.encode("ascii"))
@@ -36,7 +40,9 @@ def _convert_to_object(flatbuffers: bytes, obj_type, schema: str):
         schema_path = os.path.join(d, f"{schema}.fbs")
         bin_path = os.path.join(d, f"{schema}.bin")
         with open(schema_path, "wb") as schema_file:
-            schema_file.write(pkg_resources.resource_string(__name__, f"{schema}.fbs"))
+            schema_file.write(
+                _resources.read_binary(serialization_package, f"{schema}.fbs")
+            )
         with open(bin_path, "wb") as bin_file:
             bin_file.write(flatbuffers)
 

--- a/backends/vulkan/serialization/vulkan_graph_serialize.py
+++ b/backends/vulkan/serialization/vulkan_graph_serialize.py
@@ -1,5 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
+# Copyright 2025 Arm Limited and/or its affiliates.
 #
 # pyre-strict
 #
@@ -7,14 +8,15 @@
 # LICENSE file in the root directory of this source tree.
 
 import ctypes
+import importlib.resources as _resources
 import json
 import os
 import tempfile
-
 from dataclasses import dataclass
 from typing import ClassVar, List
 
-import pkg_resources
+import executorch.backends.vulkan.serialization as serialization_package
+
 import torch
 
 from executorch.backends.vulkan.serialization.vulkan_graph_schema import (
@@ -22,7 +24,6 @@ from executorch.backends.vulkan.serialization.vulkan_graph_schema import (
     VkGraph,
 )
 from executorch.exir._serialize._dataclass import _DataclassEncoder, _json_to_dataclass
-
 from executorch.exir._serialize._flatbuffer import _flatc_compile, _flatc_decompile
 
 
@@ -32,7 +33,9 @@ def convert_to_flatbuffer(vk_graph: VkGraph) -> bytes:
     with tempfile.TemporaryDirectory() as d:
         schema_path = os.path.join(d, "schema.fbs")
         with open(schema_path, "wb") as schema_file:
-            schema_file.write(pkg_resources.resource_string(__name__, "schema.fbs"))
+            schema_file.write(
+                _resources.read_binary(serialization_package, "schema.fbs")
+            )
         json_path = os.path.join(d, "schema.json")
         with open(json_path, "wb") as json_file:
             json_file.write(vk_graph_json.encode("ascii"))
@@ -48,7 +51,9 @@ def flatbuffer_to_vk_graph(flatbuffers: bytes) -> VkGraph:
     with tempfile.TemporaryDirectory() as d:
         schema_path = os.path.join(d, "schema.fbs")
         with open(schema_path, "wb") as schema_file:
-            schema_file.write(pkg_resources.resource_string(__name__, "schema.fbs"))
+            schema_file.write(
+                _resources.read_binary(serialization_package, "schema.fbs")
+            )
 
         bin_path = os.path.join(d, "schema.bin")
         with open(bin_path, "wb") as bin_file:

--- a/backends/xnnpack/serialization/xnnpack_graph_serialize.py
+++ b/backends/xnnpack/serialization/xnnpack_graph_serialize.py
@@ -1,22 +1,21 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
+# Copyright 2025 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import importlib.resources as _resources
 import json
-
 import logging
 import os
 import tempfile
-
 from dataclasses import dataclass, fields, is_dataclass
 from typing import ClassVar, Literal, Optional
 
-import pkg_resources
+import executorch.backends.xnnpack.serialization as serialization_package
 from executorch.backends.xnnpack.serialization.xnnpack_graph_schema import XNNGraph
 from executorch.exir._serialize._dataclass import _DataclassEncoder
-
 from executorch.exir._serialize._flatbuffer import _flatc_compile
 
 logger = logging.getLogger(__name__)
@@ -317,7 +316,9 @@ def convert_to_flatbuffer(xnnpack_graph: XNNGraph) -> bytes:
     with tempfile.TemporaryDirectory() as d:
         schema_path = os.path.join(d, "schema.fbs")
         with open(schema_path, "wb") as schema_file:
-            schema_file.write(pkg_resources.resource_string(__name__, "schema.fbs"))
+            schema_file.write(
+                _resources.read_binary(serialization_package, "schema.fbs")
+            )
         json_path = os.path.join(d, "schema.json")
         with open(json_path, "wb") as json_file:
             json_file.write(xnnpack_graph_json.encode("ascii"))

--- a/devtools/bundled_program/serialize/__init__.py
+++ b/devtools/bundled_program/serialize/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
+# Copyright 2025 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -8,16 +9,15 @@
 
 # TODO(T138924864): Refactor to unify the serialization for bundled program and executorch program.
 
+import importlib.resources as _resources
 import json
 import os
 import tempfile
 
 import executorch.devtools.bundled_program.schema as bp_schema
 
-# @manual=fbsource//third-party/pypi/setuptools:setuptools
-import pkg_resources
+import executorch.devtools.bundled_program.serialize as serialization_package
 from executorch.devtools.bundled_program.core import BundledProgram
-
 from executorch.exir._serialize._dataclass import _DataclassEncoder, _json_to_dataclass
 from executorch.exir._serialize._flatbuffer import _flatc_compile, _flatc_decompile
 
@@ -30,7 +30,7 @@ def write_schema(d: str, schema_name: str) -> None:
     schema_path = os.path.join(d, "{}.fbs".format(schema_name))
     with open(schema_path, "wb") as schema_file:
         schema_file.write(
-            pkg_resources.resource_string(__name__, "{}.fbs".format(schema_name))
+            _resources.read_binary(serialization_package, f"{schema_name}.fbs")
         )
 
 

--- a/devtools/etdump/serialize.py
+++ b/devtools/etdump/serialize.py
@@ -1,20 +1,20 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
+# Copyright 2025 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
 # pyre-strict
 
+import importlib.resources as _resources
 import json
 import os
 import tempfile
 
-import pkg_resources
+import executorch.devtools.etdump as etdump_package
 from executorch.devtools.etdump.schema_flatcc import ETDumpFlatCC
-
 from executorch.exir._serialize._dataclass import _DataclassEncoder, _json_to_dataclass
-
 from executorch.exir._serialize._flatbuffer import _flatc_compile, _flatc_decompile
 
 # The prefix of schema files used for etdump
@@ -25,9 +25,7 @@ SCALAR_TYPE_SCHEMA_NAME = "scalar_type"
 def _write_schema(d: str, schema_name: str) -> None:
     schema_path = os.path.join(d, "{}.fbs".format(schema_name))
     with open(schema_path, "wb") as schema_file:
-        schema_file.write(
-            pkg_resources.resource_string(__name__, "{}.fbs".format(schema_name))
-        )
+        schema_file.write(_resources.read_binary(etdump_package, f"{schema_name}.fbs"))
 
 
 def _serialize_from_etdump_to_json(etdump: ETDumpFlatCC) -> str:

--- a/examples/models/llama/export_llama_lib.py
+++ b/examples/models/llama/export_llama_lib.py
@@ -17,25 +17,22 @@ import re
 import shlex
 from enum import Enum
 from functools import partial
+
+from importlib import resources as _resources
 from json import JSONDecodeError
 from pathlib import Path
 from typing import Callable, List, Optional, Union
 
-import pkg_resources
 import torch
 
 from executorch.devtools.backend_debug import print_delegation_info
-
 from executorch.devtools.etrecord import generate_etrecord as generate_etrecord_func
 from executorch.examples.models.llama.hf_download import (
     download_and_convert_hf_checkpoint,
 )
 from executorch.exir.passes.init_mutable_pass import InitializedMutableBufferPass
-
 from executorch.extension.llm.export.builder import DType, LLMEdgeManager
-
 from executorch.extension.llm.export.config.llm_config import LlmConfig
-
 from executorch.extension.llm.export.partitioner_lib import (
     get_coreml_partitioner,
     get_mps_partitioner,
@@ -43,7 +40,6 @@ from executorch.extension.llm.export.partitioner_lib import (
     get_vulkan_partitioner,
     get_xnnpack_partitioner,
 )
-
 from executorch.extension.llm.export.quantizer_lib import (
     get_coreml_quantizer,
     get_pt2e_quantization_params,
@@ -52,7 +48,6 @@ from executorch.extension.llm.export.quantizer_lib import (
     get_vulkan_quantizer,
 )
 from executorch.util.activation_memory_profiler import generate_memory_trace
-
 from omegaconf import DictConfig
 
 from ..model_factory import EagerModelFactory
@@ -60,14 +55,12 @@ from .source_transformation.apply_spin_quant_r1_r2 import (
     fuse_layer_norms,
     get_model_with_r1_r2,
 )
-
 from .source_transformation.attention import replace_attention_to_attention_sha
 from .source_transformation.custom_kv_cache import (
     replace_kv_cache_with_custom_kv_cache,
     replace_kv_cache_with_quantized_kv_cache,
     replace_kv_cache_with_ring_kv_cache,
 )
-
 from .source_transformation.quantize import (
     get_quant_embedding_transform,
     get_quant_weight_transform,
@@ -129,7 +122,7 @@ def set_pkg_name(name: str) -> None:
 
 
 def get_resource_path(resource_name) -> str:
-    return pkg_resources.resource_filename(pkg_name, resource_name)
+    return str(_resources.files(pkg_name).joinpath(resource_name))
 
 
 def set_verbosity(val):
@@ -575,7 +568,7 @@ def canonical_path(path: Union[str, Path], *, dir: bool = False) -> str:
         print("not FBCODE")
         return path[4:]
     else:
-        return_val = pkg_resources.resource_filename(pkg_name, path[4:])
+        return_val = str(_resources.files(pkg_name).joinpath(path[4:]))
         if verbose_export():
             print(f"canonical name is: {return_val}")
         return return_val

--- a/exir/dialects/edge/_ops.py
+++ b/exir/dialects/edge/_ops.py
@@ -1,12 +1,14 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
+# Copyright 2025 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from importlib import resources
 from typing import Any, Dict, List, Optional, Set, Union
 
-import pkg_resources
+import executorch.exir.dialects.edge as edge_package
 
 import torch
 
@@ -166,9 +168,8 @@ class FunctionDtypeConstraint:
 def _load_edge_dialect_info() -> Dict[str, Dict[str, Any]]:
     # pyre-ignore
     yaml = YAML(typ="safe")
-    edge_dialect_yaml_info = yaml.load(
-        pkg_resources.resource_string(__name__, "edge.yaml").decode("utf8")
-    )
+    edge_yaml = resources.read_text(edge_package, "edge.yaml", encoding="utf-8")
+    edge_dialect_yaml_info = yaml.load(edge_yaml)
     if edge_dialect_yaml_info:
         return {
             edge_op_yaml_info["inherits"]: edge_op_yaml_info

--- a/exir/serde/schema_check.py
+++ b/exir/serde/schema_check.py
@@ -1,5 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
+# Copyright 2025 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -205,15 +206,16 @@ class _Commit:
 
 
 def update_schema():
-    import importlib.resources
+    import importlib.resources as _resources
+    import executorch.exir.serde as serde_package
 
-    if importlib.resources.is_resource(__package__, "schema.yaml"):
-        content = importlib.resources.read_text(__package__, "schema.yaml")
+    if _resources.is_resource(serde_package, "schema.yaml"):
+        content = _resources.read_text(serde_package, "schema.yaml")
         match = re.search("checksum<<([A-Fa-f0-9]{64})>>", content)
         _check(match is not None, "checksum not found in schema.yaml")
         assert match is not None
         checksum_base = match.group(1)
-        from yaml import load, Loader
+        from yaml import Loader, load
 
         dst = load(content, Loader=Loader)
         assert isinstance(dst, dict)

--- a/extension/flat_tensor/serialize/serialize.py
+++ b/extension/flat_tensor/serialize/serialize.py
@@ -1,11 +1,13 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
+# Copyright 2025 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
 # pyre-strict
 
+import importlib.resources as _resources
 import json
 import math
 import os
@@ -13,10 +15,10 @@ import tempfile
 from dataclasses import dataclass
 from typing import ClassVar, Dict, List, Literal, Optional
 
-import pkg_resources
+import executorch.extension.flat_tensor.serialize as serialize_package
+
 from executorch.exir._serialize._cord import Cord
 from executorch.exir._serialize._dataclass import _DataclassEncoder, _json_to_dataclass
-
 from executorch.exir._serialize._flatbuffer import _flatc_compile, _flatc_decompile
 from executorch.exir._serialize._program import _insert_flatbuffer_header
 from executorch.exir._serialize.data_serializer import (
@@ -24,9 +26,7 @@ from executorch.exir._serialize.data_serializer import (
     DataPayload,
     DataSerializer,
 )
-
 from executorch.exir._serialize.padding import aligned_size, pad_to, padding_required
-
 from executorch.extension.flat_tensor.serialize.flat_tensor_schema import (
     DataSegment,
     FlatTensor,
@@ -49,12 +49,12 @@ def _serialize_to_flatbuffer(flat_tensor: FlatTensor) -> Cord:
         schema_path = os.path.join(d, "flat_tensor.fbs")
         with open(schema_path, "wb") as schema_file:
             schema_file.write(
-                pkg_resources.resource_string(__name__, "flat_tensor.fbs")
+                _resources.read_binary(serialize_package, "flat_tensor.fbs")
             )
         scalar_type_path = os.path.join(d, "scalar_type.fbs")
         with open(scalar_type_path, "wb") as scalar_type_file:
             scalar_type_file.write(
-                pkg_resources.resource_string(__name__, "scalar_type.fbs")
+                _resources.read_binary(serialize_package, "scalar_type.fbs")
             )
         json_path = os.path.join(d, "flat_tensor.json")
         with open(json_path, "wb") as json_file:
@@ -72,13 +72,13 @@ def _deserialize_to_flat_tensor(flatbuffer: bytes) -> FlatTensor:
         schema_path = os.path.join(d, "flat_tensor.fbs")
         with open(schema_path, "wb") as schema_file:
             schema_file.write(
-                pkg_resources.resource_string(__name__, "flat_tensor.fbs")
+                _resources.read_binary(serialize_package, "flat_tensor.fbs")
             )
 
         scalar_type_path = os.path.join(d, "scalar_type.fbs")
         with open(scalar_type_path, "wb") as scalar_type_file:
             scalar_type_file.write(
-                pkg_resources.resource_string(__name__, "scalar_type.fbs")
+                _resources.read_binary(serialize_package, "scalar_type.fbs")
             )
 
         bin_path = os.path.join(d, "flat_tensor.bin")

--- a/kernels/test/gen_supported_features.py
+++ b/kernels/test/gen_supported_features.py
@@ -1,14 +1,15 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
+# Copyright 2025 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import importlib.resources as _resources
 import os
 import sys
 from typing import Any, List
 
-import pkg_resources
 import yaml
 
 
@@ -27,9 +28,12 @@ def generate_header(d: dict):
     if os.path.isfile(ini_path):
         header_file = open(ini_path, encoding="utf-8").read()
     else:
-        header_file = pkg_resources.resource_string(
-            __package__, "supported_features_header.ini"
-        ).decode("utf-8")
+        assert (
+            __package__ is not None
+        ), "Can't find supported_features_header.ini when __package__ is None."
+        header_file = _resources.read_text(
+            __package__, "supported_features_header.ini", encoding="utf-8"
+        )
 
     return header_file.replace("$header_entries", "".join(generate_header_entry(d)))
 
@@ -74,9 +78,12 @@ def generate_definition(d: dict):
     if os.path.isfile(ini_path):
         definition_file = open(ini_path, encoding="utf-8").read()
     else:
-        definition_file = pkg_resources.resource_string(
-            __package__, "supported_features_definition.ini"
-        ).decode("utf-8")
+        assert (
+            __package__ is not None
+        ), "Can't find supported_features_header.ini when __package__ is None."
+        definition_file = _resources.read_text(
+            __package__, "supported_features_definition.ini", encoding="utf-8"
+        )
 
     return definition_file.replace(
         "$definition_entries", "".join(generate_definition_entry(d))


### PR DESCRIPTION
pkg_resources is deprecated and set to be removed from setuptools as early as end of 2025. Since ET doesn't have an upper bound on the setuptools dependency this could be an issue. Additionally, this outputs a warning message everytime an executor_runner is built.

This change updates the pkg_resrouces api to the more modern importlib.resources

Test plan:
Build linux wheels using ci.
Download python 3.10 and wheel and install in new venv
run
```
from executorch.exir.dialects._ops import ops as exir_ops
from executorch.backends.apple.mps import serialization
from executorch.backends.vulkan import serialization
from executorch.backends.xnnpack import serialization
from executorch.devtools.bundled_program import serialize
from executorch.devtools.etdump import serialize
from executorch.examples.models import checkpoint
checkpoint.get_default_model_resource_dir("examples/models/llama")
from executorch.exir.serde import schema_check
from executorch.extension.flat_tensor.serialize import serialize
```
in a fresh python interpreter for every import
The imports should not crash (due to importlib), and should not generate the warning message that it currently does

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218