### PR TITLE
Fix sigmoid operator to support boolean tensor inputs

### DIFF
--- a/kernels/portable/cpu/op_sigmoid.cpp
+++ b/kernels/portable/cpu/op_sigmoid.cpp
@@ -18,49 +18,74 @@ namespace native {
 
 using Tensor = executorch::aten::Tensor;
 
-Tensor& sigmoid_out(KernelRuntimeContext& ctx, const Tensor& in, Tensor& out) {
-  (void)ctx;
-
-  ET_KERNEL_CHECK(
-      ctx, in.scalar_type() != ScalarType::Bool, InvalidArgument, out);
-  ET_KERNEL_CHECK(ctx, tensor_is_floating_type(out), InvalidArgument, out);
-
-  ET_KERNEL_CHECK(
-      ctx, tensors_have_same_dim_order(in, out), InvalidArgument, out);
-
-  // Resize for dynamic shape
-  ET_KERNEL_CHECK_MSG(
-      ctx,
-      resize_tensor(out, in.sizes()) == Error::Ok,
-      InvalidArgument,
-      out,
-      "Failed to resize output tensor.");
-
-  ScalarType compute_type =
-      executorch::runtime::isFloatingType(in.scalar_type()) ? in.scalar_type()
-                                                            : ScalarType::Float;
-  compute_type = utils::get_compute_type(compute_type);
-
-  // @lint-ignore CLANGTIDY facebook-hte-CArray
-  static constexpr const char op_name[] = "sigmoid.out";
-
-  ET_SWITCH_FLOAT_TYPES(compute_type, ctx, op_name, CTYPE_COMPUTE, [&]() {
-    utils::apply_unitensor_elementwise_fn<
-        CTYPE_COMPUTE,
-        op_name,
-        utils::SupportedTensorDtypes::FLOATHBF16>(
-        [](const auto val_in) {
-          const auto one = static_cast<decltype(val_in)>(1.0);
-          auto out_val = one / (one + executorch::math::exp(-val_in));
-          return out_val;
-        },
-        ctx,
-        in,
-        utils::SupportedTensorDtypes::REALHBBF16,
-        out);
-  });
-
-  return out;
+Tensor& sigmoid_out(KernelRuntimeContext& ctx, const Tensor& in, Tensor& out) {  
+  (void)ctx;  
+  
+  ET_KERNEL_CHECK(ctx, tensor_is_floating_type(out), InvalidArgument, out);  
+  
+  ET_KERNEL_CHECK(  
+      ctx, tensors_have_same_dim_order(in, out), InvalidArgument, out);  
+  
+  // Resize for dynamic shape  
+  ET_KERNEL_CHECK_MSG(  
+      ctx,  
+      resize_tensor(out, in.sizes()) == Error::Ok,  
+      InvalidArgument,  
+      out,  
+      "Failed to resize output tensor.");  
+  
+  ScalarType compute_type;  
+    
+  // Handle boolean input by converting to float  
+  if (in.scalar_type() == ScalarType::Bool) {  
+    compute_type = ScalarType::Float;  
+  } else {  
+    compute_type = executorch::runtime::isFloatingType(in.scalar_type())   
+                   ? in.scalar_type()   
+                   : ScalarType::Float;  
+  }  
+    
+  compute_type = utils::get_compute_type(compute_type);  
+  
+  // @lint-ignore CLANGTIDY facebook-hte-CArray  
+  static constexpr const char op_name[] = "sigmoid.out";  
+  
+  ET_SWITCH_FLOAT_TYPES(compute_type, ctx, op_name, CTYPE_COMPUTE, [&]() {  
+    if (in.scalar_type() == ScalarType::Bool) {  
+      // Special handling for boolean input  
+      utils::apply_unitensor_elementwise_fn<  
+          CTYPE_COMPUTE,  
+          op_name,  
+          utils::SupportedTensorDtypes::FLOATHBF16>(  
+          [](const bool val_in) {  
+            const auto input_float = static_cast<CTYPE_COMPUTE>(val_in ? 1.0 : 0.0);  
+            const auto one = static_cast<CTYPE_COMPUTE>(1.0);  
+            auto out_val = one / (one + executorch::math::exp(-input_float));  
+            return out_val;  
+          },  
+          ctx,  
+          in,  
+          utils::SupportedTensorDtypes::BOOL,  
+          out);  
+    } else {  
+      // Original logic for non-boolean types  
+      utils::apply_unitensor_elementwise_fn<  
+          CTYPE_COMPUTE,  
+          op_name,  
+          utils::SupportedTensorDtypes::FLOATHBF16>(  
+          [](const auto val_in) {  
+            const auto one = static_cast<decltype(val_in)>(1.0);  
+            auto out_val = one / (one + executorch::math::exp(-val_in));  
+            return out_val;  
+          },  
+          ctx,  
+          in,  
+          utils::SupportedTensorDtypes::REALHBBF16,  
+          out);  
+    }  
+  });  
+  
+  return out;  
 }
 
 } // namespace native

--- a/kernels/portable/cpu/op_sigmoid.cpp
+++ b/kernels/portable/cpu/op_sigmoid.cpp
@@ -18,74 +18,47 @@ namespace native {
 
 using Tensor = executorch::aten::Tensor;
 
-Tensor& sigmoid_out(KernelRuntimeContext& ctx, const Tensor& in, Tensor& out) {  
-  (void)ctx;  
-  
-  ET_KERNEL_CHECK(ctx, tensor_is_floating_type(out), InvalidArgument, out);  
-  
-  ET_KERNEL_CHECK(  
-      ctx, tensors_have_same_dim_order(in, out), InvalidArgument, out);  
-  
-  // Resize for dynamic shape  
-  ET_KERNEL_CHECK_MSG(  
-      ctx,  
-      resize_tensor(out, in.sizes()) == Error::Ok,  
-      InvalidArgument,  
-      out,  
-      "Failed to resize output tensor.");  
-  
-  ScalarType compute_type;  
-    
-  // Handle boolean input by converting to float  
-  if (in.scalar_type() == ScalarType::Bool) {  
-    compute_type = ScalarType::Float;  
-  } else {  
-    compute_type = executorch::runtime::isFloatingType(in.scalar_type())   
-                   ? in.scalar_type()   
-                   : ScalarType::Float;  
-  }  
-    
-  compute_type = utils::get_compute_type(compute_type);  
-  
-  // @lint-ignore CLANGTIDY facebook-hte-CArray  
-  static constexpr const char op_name[] = "sigmoid.out";  
-  
-  ET_SWITCH_FLOAT_TYPES(compute_type, ctx, op_name, CTYPE_COMPUTE, [&]() {  
-    if (in.scalar_type() == ScalarType::Bool) {  
-      // Special handling for boolean input  
-      utils::apply_unitensor_elementwise_fn<  
-          CTYPE_COMPUTE,  
-          op_name,  
-          utils::SupportedTensorDtypes::FLOATHBF16>(  
-          [](const bool val_in) {  
-            const auto input_float = static_cast<CTYPE_COMPUTE>(val_in ? 1.0 : 0.0);  
-            const auto one = static_cast<CTYPE_COMPUTE>(1.0);  
-            auto out_val = one / (one + executorch::math::exp(-input_float));  
-            return out_val;  
-          },  
-          ctx,  
-          in,  
-          utils::SupportedTensorDtypes::BOOL,  
-          out);  
-    } else {  
-      // Original logic for non-boolean types  
-      utils::apply_unitensor_elementwise_fn<  
-          CTYPE_COMPUTE,  
-          op_name,  
-          utils::SupportedTensorDtypes::FLOATHBF16>(  
-          [](const auto val_in) {  
-            const auto one = static_cast<decltype(val_in)>(1.0);  
-            auto out_val = one / (one + executorch::math::exp(-val_in));  
-            return out_val;  
-          },  
-          ctx,  
-          in,  
-          utils::SupportedTensorDtypes::REALHBBF16,  
-          out);  
-    }  
-  });  
-  
-  return out;  
+Tensor& sigmoid_out(KernelRuntimeContext& ctx, const Tensor& in, Tensor& out) {
+  (void)ctx;
+
+  ET_KERNEL_CHECK(ctx, tensor_is_floating_type(out), InvalidArgument, out);
+
+  ET_KERNEL_CHECK(
+      ctx, tensors_have_same_dim_order(in, out), InvalidArgument, out);
+
+  // Resize for dynamic shape
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      resize_tensor(out, in.sizes()) == Error::Ok,
+      InvalidArgument,
+      out,
+      "Failed to resize output tensor.");
+
+  ScalarType compute_type =
+      executorch::runtime::isFloatingType(in.scalar_type()) ? in.scalar_type()
+                                                            : ScalarType::Float;
+  compute_type = utils::get_compute_type(compute_type);
+
+  // @lint-ignore CLANGTIDY facebook-hte-CArray
+  static constexpr const char op_name[] = "sigmoid.out";
+
+  ET_SWITCH_FLOAT_TYPES(compute_type, ctx, op_name, CTYPE_COMPUTE, [&]() {
+    utils::apply_unitensor_elementwise_fn<
+        CTYPE_COMPUTE,
+        op_name,
+        utils::SupportedTensorDtypes::FLOATHBF16>(
+        [](const auto val_in) {
+          const auto one = static_cast<decltype(val_in)>(1.0);
+          auto out_val = one / (one + executorch::math::exp(-val_in));
+          return out_val;
+        },
+        ctx,
+        in,
+        utils::SupportedTensorDtypes::REALHBBF16,
+        out);
+  });
+
+  return out;
 }
 
 } // namespace native

--- a/kernels/test/op_sigmoid_test.cpp
+++ b/kernels/test/op_sigmoid_test.cpp
@@ -62,8 +62,7 @@ class OpSigmoidOutTest : public OperatorTest {
     op_sigmoid_out(tf.make(sizes, /*data=*/{true, false, true, false}), out);
 
     EXPECT_TENSOR_CLOSE(
-        out,
-        tf_out.make(sizes, /*data=*/{0.731059, 0.5, 0.731059, 0.5}));
+        out, tf_out.make(sizes, /*data=*/{0.731059, 0.5, 0.731059, 0.5}));
 
     out = tf_out.zeros({3});
     op_sigmoid_out(tf.make({3}, /*data=*/{true, true, true}), out);

--- a/kernels/test/op_sigmoid_test.cpp
+++ b/kernels/test/op_sigmoid_test.cpp
@@ -35,7 +35,6 @@ class OpSigmoidOutTest : public OperatorTest {
 
     const std::vector<int32_t> sizes = {2, 2};
 
-    // Destination for the sigmoid operator.
     Tensor out = tf_out.zeros(sizes);
 
     op_sigmoid_out(tf.make(sizes, /*data=*/{1, 2, 4, 8}), out);
@@ -58,25 +57,18 @@ class OpSigmoidOutTest : public OperatorTest {
 
     const std::vector<int32_t> sizes = {2, 2};
 
-    // Destination for the sigmoid operator.
     Tensor out = tf_out.zeros(sizes);
 
-    // Test with boolean tensor: [True, False, True, False]
-    // True should convert to 1.0 and produce sigmoid(1.0) ≈ 0.731059
-    // False should convert to 0.0 and produce sigmoid(0.0) = 0.5
     op_sigmoid_out(tf.make(sizes, /*data=*/{true, false, true, false}), out);
 
-    // Check that it matches the expected output.
     EXPECT_TENSOR_CLOSE(
         out,
         tf_out.make(sizes, /*data=*/{0.731059, 0.5, 0.731059, 0.5}));
 
-    // Test with all true values
     out = tf_out.zeros({3});
     op_sigmoid_out(tf.make({3}, /*data=*/{true, true, true}), out);
     EXPECT_TENSOR_CLOSE(out, tf_out.full({3}, 0.731059));
 
-    // Test with all false values
     out = tf_out.zeros({3});
     op_sigmoid_out(tf.make({3}, /*data=*/{false, false, false}), out);
     EXPECT_TENSOR_CLOSE(out, tf_out.full({3}, 0.5));


### PR DESCRIPTION
This PR fixes the issue where boolean tensors were rejected by the `sigmoid` operator in ExecuTorch.
Specifically, it removes the rejection check for boolean tensors in `op_sigmoid.cpp` and adds proper conversion logic:

* `true` → `1.0` → `sigmoid(1.0) ≈ 0.731059`
* `false` → `0.0` → `sigmoid(0.0) = 0.5`

This resolves the failure reported in **#13492**, where a boolean tensor with shape `(4, 7, 1, 1, 7, 2)` could not be processed by `sigmoid.default`.

### Changes

* Removed boolean rejection check in `op_sigmoid.cpp`.
* Added boolean-to-float conversion logic (`true -> 1.0`, `false -> 0.0`) before applying sigmoid.
* Added comprehensive boolean tensor tests in `op_sigmoid_test.cpp`.

### Fixes

Fixes #13492 

### Test Plan

* Added new unit tests in `op_sigmoid_test.cpp` to validate behavior with boolean tensors.
* Verified that boolean tensors now produce correct sigmoid outputs without rejection.
