### PR TITLE
Wrap LLM runner tests in anonymous namespace (unbreak unittest-release)

### DIFF
--- a/extension/llm/runner/test/test_generation_config.cpp
+++ b/extension/llm/runner/test/test_generation_config.cpp
@@ -12,6 +12,7 @@
 using namespace ::testing;
 using executorch::extension::llm::GenerationConfig;
 
+namespace {
 class GenerationConfigTest : public Test {};
 
 TEST_F(GenerationConfigTest, TestResolveMaxNewTokensBothDefault) {
@@ -112,3 +113,4 @@ TEST_F(GenerationConfigTest, TestResolveMaxNewTokensBothSpecified) {
   // Expected: min(max_new_tokens, available) = min(5, 30) = 5
   EXPECT_EQ(config.resolve_max_new_tokens(100, 20), 5);
 }
+} // namespace

--- a/extension/llm/runner/test/test_multimodal_input.cpp
+++ b/extension/llm/runner/test/test_multimodal_input.cpp
@@ -16,6 +16,7 @@ using executorch::extension::llm::make_image_input;
 using executorch::extension::llm::make_text_input;
 using executorch::extension::llm::MultimodalInput;
 
+namespace {
 class MultimodalInputTest : public Test {
  protected:
   std::string createTestText() {
@@ -430,3 +431,4 @@ TEST_F(MultimodalInputTest, AssignmentBetweenTypes) {
   EXPECT_TRUE(input.is_text());
   EXPECT_EQ(input.get_text(), text);
 }
+} // namespace

--- a/extension/llm/runner/test/test_text_decoder_runner.cpp
+++ b/extension/llm/runner/test/test_text_decoder_runner.cpp
@@ -26,7 +26,7 @@ using executorch::runtime::EValue;
 using executorch::runtime::Result;
 using executorch::runtime::testing::TensorFactory;
 
-// Mock Module class for testing
+namespace {
 class MockModule : public Module {
  public:
   MockModule() : Module("") {}
@@ -204,3 +204,5 @@ TEST_F(TextDecoderRunnerTest, StepWithAllModels) {
   ASSERT_TRUE(any_model_tested)
       << "No models were tested despite environment variables being set";
 }
+
+} // namespace

--- a/extension/llm/runner/test/test_text_llm_runner.cpp
+++ b/extension/llm/runner/test/test_text_llm_runner.cpp
@@ -26,6 +26,8 @@ using executorch::extension::llm::TextTokenGenerator;
 using executorch::runtime::Error;
 using executorch::runtime::Result;
 using executorch::runtime::testing::TensorFactory;
+
+namespace {
 // Mock classes for dependencies
 class MockTokenizer : public ::tokenizers::Tokenizer {
  public:
@@ -392,3 +394,4 @@ TEST_F(RunnerTest, GenerateFromPosErrorsWithNegativeMaxNewTokens) {
   // Verify that an InvalidArgument error is returned
   EXPECT_EQ(err, Error::InvalidArgument);
 }
+} // namespace

--- a/extension/llm/runner/test/test_text_prefiller.cpp
+++ b/extension/llm/runner/test/test_text_prefiller.cpp
@@ -21,6 +21,7 @@ using executorch::runtime::Error;
 using executorch::runtime::Result;
 using executorch::runtime::testing::TensorFactory;
 
+namespace {
 // Mock class for TextDecoderRunner
 class MockTextDecoderRunner : public TextDecoderRunner {
  public:
@@ -304,3 +305,4 @@ TEST_F(TextPrefillerTest, PrefillChunkWorksWithParallelPrefill) {
   // Verify that start_pos has been updated correctly
   EXPECT_EQ(start_pos, prompt_tokens.size());
 }
+} // namespace


### PR DESCRIPTION
This prevents our test classes from colliding with other global-namespace classes. The specific cause was MockModule being (apparently) the name of a class in gmock or gtest, but I went ahead and did all the tests in this directory to be safe.