### PR TITLE
Qualcomm AI Engine Direct - Scripts and accuracy improvement for Qwen3_0.6B/1.7B and Qwen 2.5_1.5B

### DIFF
--- a/backends/qualcomm/tests/test_qnn_delegate.py
+++ b/backends/qualcomm/tests/test_qnn_delegate.py
@@ -4550,7 +4550,7 @@ class TestExampleLLMScript(TestQNN):
             "--ptq",
             "16a8w",
             "--decoder_model",
-            "qwen2_5",
+            "qwen2_5-0_5b",
             "--model_mode",
             "kv",
             "--max_seq_len",
@@ -4613,13 +4613,15 @@ class TestExampleLLMScript(TestQNN):
             "--ptq",
             "16a8w",
             "--decoder_model",
-            "qwen3_0_6b",
+            "qwen3-0_6b",
             "--model_mode",
             "hybrid",
             "--prefill_ar_len",
             "32",
             "--max_seq_len",
             "128",
+            "--r3",
+            "--enable_masked_softmax",
         ]
         if self.compile_only:
             cmds.extend(["--compile_only"])
@@ -4632,8 +4634,8 @@ class TestExampleLLMScript(TestQNN):
         if self.pre_gen_pte:
             cmds.extend(["--pre_gen_pte", self.pre_gen_pte])
 
-        # Accuracy is bad for now. Just check user's prompt is returned.
-        golden_start_with = "My favourite condiment is "
+        # TODO: Change to PPL evaluation
+        golden_start_with = "<|im_start|>user"
         p = subprocess.Popen(cmds, stdout=subprocess.DEVNULL)
         with Listener((self.ip, self.port)) as listener:
             conn = listener.accept()

--- a/examples/qualcomm/oss_scripts/llama/README.md
+++ b/examples/qualcomm/oss_scripts/llama/README.md
@@ -5,7 +5,7 @@ This file provides you the instructions to run LLM Decoder model with different 
  1. LLAMA2 Stories 110M
  2. LLAMA3.2 1B
  3. LLAMA3.2 3B
- 4. QWEN2.5 0.5B
+ 4. QWEN2.5 0.5B / 1.5B
  5. QWEN3 0.6B / 1.7B
  6. Phi4-mini-instruct
  7. SMOLLM2 135M
@@ -72,7 +72,25 @@ python examples/qualcomm/oss_scripts/llama/llama.py -b build-android -s ${SERIAL
 #### QWEN2.5 0.5B
 Default example using hybrid mode
 ```bash
-python examples/qualcomm/oss_scripts/llama/llama.py -b build-android -s ${SERIAL_NUM} -m ${SOC_MODEL} --temperature 0 --model_mode hybrid --max_seq_len 1024 --prefill_ar_len 128 --ptq 16a8w --enable_masked_softmax --r3 --decoder_model qwen2_5 --prompt "I would like to learn python, could you teach me with a simple example?"
+python examples/qualcomm/oss_scripts/llama/llama.py -b build-android -s ${SERIAL_NUM} -m ${SOC_MODEL} --temperature 0 --model_mode hybrid --max_seq_len 1024 --prefill_ar_len 128 --ptq 16a8w --enable_masked_softmax --r3 --decoder_model qwen2_5-0_5b --prompt "I would like to learn python, could you teach me with a simple example?"
+```
+
+#### QWEN2.5 1.5B
+Default example using hybrid mode
+```bash
+python examples/qualcomm/oss_scripts/llama/llama.py -b build-android -s ${SERIAL_NUM} -m ${SOC_MODEL} --temperature 0 --model_mode hybrid --max_seq_len 1024 --prefill_ar_len 128 --ptq 16a8w --enable_masked_softmax --r3 --decoder_model qwen2_5-1_5b --prompt "I would like to learn python, could you teach me with a simple example?"
+```
+
+#### QWEN3 0.6B
+Default example using hybrid mode
+```bash
+python examples/qualcomm/oss_scripts/llama/llama.py -b build-android -s ${SERIAL_NUM} -m ${SOC_MODEL} --temperature 0 --model_mode hybrid --max_seq_len 1024 --prefill_ar_len 128 --ptq 16a8w --enable_masked_softmax --r3 --decoder_model qwen3-0_6b --prompt "I would like to learn python, could you teach me with a simple example?"
+```
+
+#### QWEN3 1.7B
+Default example using hybrid mode
+```bash
+python examples/qualcomm/oss_scripts/llama/llama.py -b build-android -s ${SERIAL_NUM} -m ${SOC_MODEL} --temperature 0 --model_mode hybrid --max_seq_len 1024 --prefill_ar_len 128 --ptq 16a8w --enable_masked_softmax --r3 --decoder_model qwen3-1_7b --prompt "I would like to learn python, could you teach me with a simple example?"
 ```
 
 #### SMOLLM2
@@ -175,18 +193,18 @@ To evaluate the perplexity across all 3 phases, users should provide the `--eval
 
 For example, using the Qwen model and 1 wikitext sample as the evaluation task, users can assess all 3 phases perplexity score in a single run by including the appropriate configuration:
 ```bash
-python examples/qualcomm/oss_scripts/llama/llama.py -b build-android -s ${SERIAL_NUM} -m ${SOC_MODEL} --prompt "What is 1+1?" --temperature 0 --model_mode kv --max_seq_len 1024 --ptq 16a8w --decoder_model qwen2_5 --eval_perplexity --tasks wikitext --limit 1
+python examples/qualcomm/oss_scripts/llama/llama.py -b build-android -s ${SERIAL_NUM} -m ${SOC_MODEL} --prompt "What is 1+1?" --temperature 0 --model_mode kv --max_seq_len 1024 --ptq 16a8w --decoder_model qwen2_5-0_5b --eval_perplexity --tasks wikitext --limit 1
 ```
 
 For the example script above, 1 wikitext sample is used to evaluate all 3 phases. However, there are cases where a user may want to use one sample for quantization calibration and multiple samples for perplexity evaluation. In this case, the process should be split into two runs. In the 1st run, the model is compiled using one sample. In the 2nd run, the user can provide a different configuration for QNN device execution.
 Example:
 ```bash
 # 1st run to compile with --limit 1
-python examples/qualcomm/oss_scripts/llama/llama.py -b build-android -s ${SERIAL_NUM} -m ${SOC_MODEL} --prompt "What is 1+1?" --temperature 0 --model_mode kv --max_seq_len 1024 --ptq 16a8w --decoder_model qwen2_5 --eval_perplexity --tasks wikitext --limit 1 --compile_only
+python examples/qualcomm/oss_scripts/llama/llama.py -b build-android -s ${SERIAL_NUM} -m ${SOC_MODEL} --prompt "What is 1+1?" --temperature 0 --model_mode kv --max_seq_len 1024 --ptq 16a8w --decoder_model qwen2_5-0_5b --eval_perplexity --tasks wikitext --limit 1 --compile_only
 ```
 ```bash
 # 2nd run to perform QNN device execution with --limit 3
-python examples/qualcomm/oss_scripts/llama/llama.py -b build-android -s ${SERIAL_NUM} -m ${SOC_MODEL} --prompt "What is 1+1?" --temperature 0 --model_mode kv --max_seq_len 1024 --ptq 16a8w --decoder_model qwen2_5 --eval_perplexity --tasks wikitext --limit 3 --pre_gen_pte ${PATH_TO_ARTIFACT_IN_1ST_RUN} --quant_attrs_path ${PATH_TO_ARTIFACT_IN_1ST_RUN}/kv_llama_qnn_quant_attrs.json
+python examples/qualcomm/oss_scripts/llama/llama.py -b build-android -s ${SERIAL_NUM} -m ${SOC_MODEL} --prompt "What is 1+1?" --temperature 0 --model_mode kv --max_seq_len 1024 --ptq 16a8w --decoder_model qwen2_5-0_5b --eval_perplexity --tasks wikitext --limit 3 --pre_gen_pte ${PATH_TO_ARTIFACT_IN_1ST_RUN} --quant_attrs_path ${PATH_TO_ARTIFACT_IN_1ST_RUN}/kv_llama_qnn_quant_attrs.json
 ```
 
 #### Tasks quantization calibration

--- a/examples/qualcomm/oss_scripts/llama/README.md
+++ b/examples/qualcomm/oss_scripts/llama/README.md
@@ -96,7 +96,7 @@ python examples/qualcomm/oss_scripts/llama/llama.py -b build-android -s ${SERIAL
 #### SMOLLM2
 Default example using hybrid mode.
 ```bash
-python examples/qualcomm/oss_scripts/llama/llama.py -b build-android -H mlgtw-linux -s ${SERIAL_NUM} -m ${SOC_MODEL} --ptq 16a8w --tokenizer_bin tokenizer.bin --decoder_model smollm2 --model_mode hybrid --prefill_ar_len 128 --max_seq_len 1024 --prompt "I would like to learn python, could you teach me with a simple example?"
+python examples/qualcomm/oss_scripts/llama/llama.py -b build-android -H mlgtw-linux -s ${SERIAL_NUM} -m ${SOC_MODEL} --ptq 16a8w --decoder_model smollm2_135m --model_mode hybrid --prefill_ar_len 128 --max_seq_len 1024 --prompt "I would like to learn python, could you teach me with a simple example?"
 ```
 
 ### KV Cache update mechanism

--- a/examples/qualcomm/oss_scripts/llama/__init__.py
+++ b/examples/qualcomm/oss_scripts/llama/__init__.py
@@ -19,16 +19,13 @@ from executorch.examples.models.qwen3 import convert_weights as convert_qwen3_we
 from executorch.examples.models.smollm2 import (
     convert_weights as convert_smollm2_weights,
 )
-from executorch.examples.qualcomm.oss_scripts.llama.decoder_constants import (
-    DECODER_MODEL_VERSION,
-)
 
 BASE_DIR = os.path.dirname(__file__)
 
 
 @dataclass(init=False, frozen=True)
 class HFModel(ABC):
-    """ Base class for all hugging face models
+    """Base class for all hugging face models
 
     repo_id: Hugging Face Repo ID.
     params_path: Path to model's config.json. If the corresponding .json has not yet exsit, please create one.
@@ -36,6 +33,7 @@ class HFModel(ABC):
     transform_weight: Set to true to change HuggingFace weight to improve the performance of RoPE in HTP backend.
     instruct_model: True if the model uses chat templates. Check Hugging Face model card to ensure the model uses chat templates.
     """
+
     repo_id: str
     params_path: str
     convert_weights: Callable

--- a/examples/qualcomm/oss_scripts/llama/__init__.py
+++ b/examples/qualcomm/oss_scripts/llama/__init__.py
@@ -6,7 +6,7 @@
 
 import os
 from abc import ABC
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Callable, Dict, Type
 
 from executorch.examples.models.phi_4_mini import (
@@ -28,10 +28,19 @@ BASE_DIR = os.path.dirname(__file__)
 
 @dataclass(init=False, frozen=True)
 class HFModel(ABC):
+    """ Base class for all hugging face models
+
+    repo_id: Hugging Face Repo ID.
+    params_path: Path to model's config.json. If the corresponding .json has not yet exsit, please create one.
+    convert_weights: Used to convert Hugging Face weights parameters to Static Decoder's parameter naming.
+    transform_weight: Set to true to change HuggingFace weight to improve the performance of RoPE in HTP backend.
+    instruct_model: True if the model uses chat templates. Check Hugging Face model card to ensure the model uses chat templates.
+    """
     repo_id: str
     params_path: str
-    runner_version: str
     convert_weights: Callable
+    transform_weight: bool
+    instruct_model: bool
 
 
 SUPPORTED_HF_MODELS: Dict[str, HFModel] = {}
@@ -45,40 +54,52 @@ def register_hf_model(name: str):
     return decorator
 
 
-@register_hf_model("qwen2_5")
+@register_hf_model("qwen2_5-0_5b")
 @dataclass(init=False, frozen=True)
-class Qwen2_5(HFModel):
+class Qwen2_5_0_5B(HFModel):
     repo_id: str = "Qwen/Qwen2.5-0.5B"
     params_path: str = os.path.join(
         BASE_DIR, "../../../models/qwen2_5/config/0_5b_config.json"
     )
-    runner_version: str = field(default=DECODER_MODEL_VERSION["qwen2_5"])
     convert_weights = convert_qwen2_5_weights
     transform_weight = False
+    instruct_model = False
 
 
-@register_hf_model("qwen3_0_6b")
+@register_hf_model("qwen2_5-1_5b")
+@dataclass(init=False, frozen=True)
+class Qwen2_5_1_5B(HFModel):
+    repo_id: str = "Qwen/Qwen2.5-1.5B"
+    params_path: str = os.path.join(
+        BASE_DIR, "../../../models/qwen2_5/config/1_5b_config.json"
+    )
+    convert_weights = convert_qwen2_5_weights
+    transform_weight = False
+    instruct_model = False
+
+
+@register_hf_model("qwen3-0_6b")
 @dataclass(init=False, frozen=True)
 class Qwen3_0_6B(HFModel):
     repo_id: str = "Qwen/Qwen3-0.6B"
     params_path: str = os.path.join(
         BASE_DIR, "../../../models/qwen3/config/0_6b_config.json"
     )
-    runner_version: str = field(default=DECODER_MODEL_VERSION["qwen2_5"])
     convert_weights = convert_qwen3_weights
     transform_weight = False
+    instruct_model = True
 
 
-@register_hf_model("qwen3_1_7b")
+@register_hf_model("qwen3-1_7b")
 @dataclass(init=False, frozen=True)
 class Qwen3_1_7B(HFModel):
     repo_id: str = "Qwen/Qwen3-1.7B"
     params_path: str = os.path.join(
         BASE_DIR, "../../../models/qwen3/config/1_7b_config.json"
     )
-    runner_version: str = field(default=DECODER_MODEL_VERSION["qwen2_5"])
     convert_weights = convert_qwen3_weights
     transform_weight = False
+    instruct_model = True
 
 
 @register_hf_model("phi_4_mini")
@@ -88,9 +109,9 @@ class Phi4Mini(HFModel):
     params_path: str = os.path.join(
         BASE_DIR, "../../../models/phi_4_mini/config/config.json"
     )
-    runner_version: str = field(default=DECODER_MODEL_VERSION["phi_4_mini"])
     convert_weights = convert_phi_4_mini_weights
     transform_weight = False
+    instruct_model = True
 
 
 @register_hf_model("smollm2_135m")
@@ -100,6 +121,6 @@ class Smollm2_135M(HFModel):
     params_path: str = os.path.join(
         BASE_DIR, "../../../models/smollm2/135M_config.json"
     )
-    runner_version: str = field(default=DECODER_MODEL_VERSION["smollm2_135m"])
     convert_weights = convert_smollm2_weights
     transform_weight = True
+    instruct_model = True

--- a/examples/qualcomm/oss_scripts/llama/decoder_constants.py
+++ b/examples/qualcomm/oss_scripts/llama/decoder_constants.py
@@ -10,13 +10,15 @@ EVAL_MODE = {
     "lookahead": 2,
 }
 
+# The dict's value is mainly for runner to decide what special tokens are required to wrap the prompt.
 DECODER_MODEL_VERSION = {
     "stories260k": "llama2",
     "stories110m": "llama2",
     "llama3_2": "llama3",
-    "qwen2_5": "qwen2_5",
-    "qwen3_0_6b": "qwen2_5",  # TODO: temp workaround, use special token for qwen3 in runner
-    "qwen3_1_7b": "qwen2_5",
+    "qwen2_5-0_5b": "qwen2_5",
+    "qwen2_5-1_5b": "qwen2_5",
+    "qwen3-0_6b": "qwen3",
+    "qwen3-1_7b": "qwen3",
     "phi_4_mini": "phi_4_mini",
     "smollm2_135m": "smollm2_135m",
 }

--- a/examples/qualcomm/oss_scripts/llama/decoder_utils.py
+++ b/examples/qualcomm/oss_scripts/llama/decoder_utils.py
@@ -458,22 +458,34 @@ def prefill_inference(
 
 
 def graph_module_inference(
-    args,
-    use_kv_cache,
+    use_kv_cache: bool,
     get_example_inputs: Callable,
     module: torch.fx.GraphModule,
     tokenizer,
     ar_len=1,
     max_seq_len=512,
     kv_updater=smart_mask_updater,
+    prompt=None,
+    tasks=None,
+    tasks_limit=1,
+    num_fewshot=None,
     use_i64_token=False,
     event_name: Optional[str] = None,
 ):
-    if args.tasks is None:
+    """
+    This function supports model execution from static nn.Module decoder model
+    all the way to edge program.
+    Users could choose to provide either the prompt or tasks for execution but not both.
+    """
+    # Checks 1 and only 1 is provided.
+    assert (tasks is None) != (
+        prompt is None
+    ), "Please provide either tasks or prompt - not both or neither"
+    if tasks is None:
         if use_kv_cache:
             kv_inference(
                 get_example_inputs,
-                args.prompt[0],
+                prompt,
                 module,
                 tokenizer,
                 ar_len,
@@ -485,7 +497,7 @@ def graph_module_inference(
         else:
             prefill_inference(
                 get_example_inputs,
-                args.prompt[0],
+                prompt,
                 module,
                 tokenizer,
                 max_seq_len,
@@ -507,9 +519,24 @@ def graph_module_inference(
         with torch.no_grad():
             eval_results = simple_evaluate(
                 model=calibration_wrapper,
-                tasks=args.tasks,
-                limit=args.limit,
+                tasks=tasks,
+                num_fewshot=num_fewshot,
+                limit=tasks_limit,
             )
         logging.info(f"Perplexity evaluation summary for {event_name}")
         for task, res in eval_results["results"].items():
             logging.info(f"{task}: {res}")
+
+
+def apply_prompt_template(
+    chat_template: Callable, prompt: str, system_prompt: str = None
+):
+    messages = [{"role": "user", "content": prompt}]
+    if system_prompt:
+        messages.append({"role": "system", "content": system_prompt})
+
+    template_prompt = chat_template(
+        messages, tokenize=False, add_generation_prompt=True
+    )
+    logging.info(f"Prompt after applying template: {template_prompt}")
+    return template_prompt

--- a/examples/qualcomm/oss_scripts/llama/llama.py
+++ b/examples/qualcomm/oss_scripts/llama/llama.py
@@ -1248,7 +1248,7 @@ def export_llama(args) -> None:
         chat_template = (
             tokenizer.apply_chat_template
             if hasattr(tokenizer, "apply_chat_template")
-            and SUPPORTED_HF_MODELS[args.decoder_model].transform_weight
+            and SUPPORTED_HF_MODELS[args.decoder_model].instruct_model
             else None
         )
         runtime_tokenizer_path = tokenizer.save_pretrained(args.artifact)[-1]

--- a/examples/qualcomm/oss_scripts/llama/llama.py
+++ b/examples/qualcomm/oss_scripts/llama/llama.py
@@ -70,6 +70,7 @@ from executorch.examples.qualcomm.oss_scripts.llama.decoder_constants import (
     EVAL_MODE,
 )
 from executorch.examples.qualcomm.oss_scripts.llama.decoder_utils import (
+    apply_prompt_template,
     graph_module_inference,
     QnnRunnerEvalWrapper,
     shift_pointer_updater,
@@ -219,6 +220,7 @@ class SingleLlama:
         tokenizer,
         custom_annotations=(),
         scales_state_dict=None,
+        chat_template=None,
     ):
         self.quant_dtype = quant_dtype
         quantizer = make_custom_quantizer(
@@ -244,8 +246,31 @@ class SingleLlama:
         logging.info("Quantizing the model...")
 
         # Calibration
+        if args.tasks is not None:
+            graph_module_inference(
+                use_kv_cache=self.llama_meta["get_use_kv_cache"],
+                get_example_inputs=self.get_example_inputs,
+                module=fx_graph_module,
+                tokenizer=tokenizer,
+                ar_len=self.llama_meta["get_ar_len"],
+                max_seq_len=self.llama_meta["get_max_seq_len"],
+                kv_updater=args.kv_updater,
+                tasks=args.tasks,
+                tasks_limit=args.limit,
+                num_fewshot=args.num_fewshot,
+                use_i64_token=args.embedding_quantize is not None,
+                event_name="prepare_pt2e_tasks",
+            )
+
+        # Check user's prompt, helps calibrate special token
+        prompt = (
+            args.prompt[0]
+            if chat_template is None
+            else apply_prompt_template(
+                chat_template, args.prompt[0], args.system_prompt
+            )
+        )
         graph_module_inference(
-            args=args,
             use_kv_cache=self.llama_meta["get_use_kv_cache"],
             get_example_inputs=self.get_example_inputs,
             module=fx_graph_module,
@@ -253,8 +278,9 @@ class SingleLlama:
             ar_len=self.llama_meta["get_ar_len"],
             max_seq_len=self.llama_meta["get_max_seq_len"],
             kv_updater=args.kv_updater,
+            prompt=prompt,
             use_i64_token=args.embedding_quantize is not None,
-            event_name="prepare_pt2e",
+            event_name="prepare_pt2e_prompt",
         )
 
         if scales_state_dict:
@@ -264,11 +290,34 @@ class SingleLlama:
 
         self.llama_graph_module = convert_pt2e(fx_graph_module)
 
-        if args.eval_perplexity:
+        if args.verbose:
             logging.info("Verifying the QDQ model...")
-            # Check qdq cpu results
+            # qdq cpu ppl evaluation is time consuming, only enable when eval_perplexity
+            if args.eval_perplexity:
+                # Check qdq cpu results
+                graph_module_inference(
+                    use_kv_cache=self.llama_meta["get_use_kv_cache"],
+                    get_example_inputs=self.get_example_inputs,
+                    module=self.llama_graph_module,
+                    tokenizer=tokenizer,
+                    ar_len=self.llama_meta["get_ar_len"],
+                    max_seq_len=self.llama_meta["get_max_seq_len"],
+                    kv_updater=args.kv_updater,
+                    tasks=args.tasks,
+                    tasks_limit=args.limit,
+                    num_fewshot=args.num_fewshot,
+                    use_i64_token=args.embedding_quantize is not None,
+                    event_name="convert_pt2e_tasks",
+                )
+            # Check user's prompt
+            prompt = (
+                args.prompt[0]
+                if chat_template is None
+                else apply_prompt_template(
+                    chat_template, args.prompt[0], args.system_prompt
+                )
+            )
             graph_module_inference(
-                args=args,
                 use_kv_cache=self.llama_meta["get_use_kv_cache"],
                 get_example_inputs=self.get_example_inputs,
                 module=self.llama_graph_module,
@@ -276,8 +325,9 @@ class SingleLlama:
                 ar_len=self.llama_meta["get_ar_len"],
                 max_seq_len=self.llama_meta["get_max_seq_len"],
                 kv_updater=args.kv_updater,
+                prompt=prompt,
                 use_i64_token=args.embedding_quantize is not None,
-                event_name="convert_pt2e",
+                event_name="convert_pt2e_prompt",
             )
 
     def lowering_modules(
@@ -344,7 +394,7 @@ class SingleLlama:
         return self.quant_attrs
 
 
-def compile(args, pte_filename, tokenizer):
+def compile(args, pte_filename, tokenizer, chat_template):
     os.makedirs(args.artifact, exist_ok=True)
     start_ts = time.time()
 
@@ -573,6 +623,7 @@ def compile(args, pte_filename, tokenizer):
         llama_instance_list[i] = SingleLlama(
             llama_instance_list[i].eval(), pte_filename
         )
+
         if args.embedding_quantize:
             llama_instance_list[i].passes_job[I64toI32][
                 QCOM_PASS_ARGS_KWARGS_DEFAULTS_KEY
@@ -596,6 +647,7 @@ def compile(args, pte_filename, tokenizer):
                 tokenizer=tokenizer,
                 custom_annotations=custom_annotations,
                 scales_state_dict=scales_state_dict,
+                chat_template=chat_template,
             )
             # If hybrid and lookahead mode, we store kv output quant_attrs and apply to prefill output quant_attrs later
             if i == 0 and args.model_mode in ["hybrid", "lookahead"]:
@@ -1160,6 +1212,7 @@ def export_llama(args) -> None:
 
     tokenizer = None
     runtime_tokenizer_path = ""
+    chat_template = None
     if args.decoder_model in {"stories110m", "stories260k"}:
         tokenizer = get_tokenizer(args.tokenizer_model)
         assert isinstance(
@@ -1178,6 +1231,7 @@ def export_llama(args) -> None:
     elif args.decoder_model == "phi_4_mini":
         model_id = SUPPORTED_HF_MODELS[args.decoder_model].repo_id
         tokenizer = AutoTokenizer.from_pretrained(model_id)
+        chat_template = getattr(tokenizer, "apply_chat_template", None)
         runtime_tokenizer_path = tokenizer.save_pretrained(args.artifact)[-1]
         tokenizer = get_tokenizer(runtime_tokenizer_path)
         with open(runtime_tokenizer_path, "r+") as file:
@@ -1191,6 +1245,12 @@ def export_llama(args) -> None:
     elif args.decoder_model in SUPPORTED_HF_MODELS:
         model_id = SUPPORTED_HF_MODELS[args.decoder_model].repo_id
         tokenizer = AutoTokenizer.from_pretrained(model_id)
+        chat_template = (
+            tokenizer.apply_chat_template
+            if hasattr(tokenizer, "apply_chat_template")
+            and SUPPORTED_HF_MODELS[args.decoder_model].transform_weight
+            else None
+        )
         runtime_tokenizer_path = tokenizer.save_pretrained(args.artifact)[-1]
         tokenizer = get_tokenizer(runtime_tokenizer_path)
     else:
@@ -1215,7 +1275,7 @@ def export_llama(args) -> None:
         return
 
     if args.compile_only:
-        compile(args, pte_filename, tokenizer)
+        compile(args, pte_filename, tokenizer, chat_template)
 
         if args.ip and args.port != -1:
             pte_path = f"{args.artifact}/{pte_filename}.pte"
@@ -1231,7 +1291,7 @@ def export_llama(args) -> None:
         print(f"Finish compile_only and save to {args.artifact}")
         return
 
-    compile(args, pte_filename, tokenizer)
+    compile(args, pte_filename, tokenizer, chat_template)
     inference(args, pte_filename, runtime_tokenizer_path, tokenizer)
 
 

--- a/examples/qualcomm/oss_scripts/llama/qnn_llama_runner.cpp
+++ b/examples/qualcomm/oss_scripts/llama/qnn_llama_runner.cpp
@@ -9,8 +9,8 @@
 /**
  * @file
  *
- * This tool can run Llama2 110M, Llama3.2 1B / 3B, Qwen2.5 0.5B, Qwen3 0.6B
- * / 1.7B, phi4-mini-instruct, Smollm2 135M with Qualcomm AI Engine Direct.
+ * This tool can run Llama2 110M, Llama3.2 1B / 3B, Qwen2.5 0.5B / 1.5B, Qwen3
+ * 0.6B / 1.7B, phi4-mini-instruct, Smollm2 135M with Qualcomm AI Engine Direct.
  *
  */
 
@@ -104,6 +104,17 @@ std::string get_formatted_prompt(
     case example::DecoderModelVersion::kLlama2:
     case example::DecoderModelVersion::kQwen2_5:
       formatted_prompt.append(prompt);
+      break;
+    case example::DecoderModelVersion::kQwen3:
+      formatted_prompt.append("<|im_start|>user\n");
+      formatted_prompt.append(prompt);
+      formatted_prompt.append("<|im_end|>\n");
+      if (!system_prompt.empty()) {
+        formatted_prompt.append("<|im_start|>system\n");
+        formatted_prompt.append(system_prompt);
+        formatted_prompt.append("<|im_end|>\n");
+      }
+      formatted_prompt.append("<|im_start|>assistant");
       break;
     case example::DecoderModelVersion::kPhi4:
       if (!system_prompt.empty()) {

--- a/examples/qualcomm/oss_scripts/llama/runner/runner.cpp
+++ b/examples/qualcomm/oss_scripts/llama/runner/runner.cpp
@@ -124,6 +124,8 @@ Runner<T>::Runner(
     decoder_model_version_ = DecoderModelVersion::kLlama3;
   } else if (decoder_model_version == "qwen2_5") {
     decoder_model_version_ = DecoderModelVersion::kQwen2_5;
+  } else if (decoder_model_version == "qwen3") {
+    decoder_model_version_ = DecoderModelVersion::kQwen3;
   } else if (decoder_model_version == "phi_4_mini") {
     decoder_model_version_ = DecoderModelVersion::kPhi4;
   } else if (decoder_model_version == "smollm2_135m") {

--- a/examples/qualcomm/oss_scripts/llama/runner/runner.h
+++ b/examples/qualcomm/oss_scripts/llama/runner/runner.h
@@ -32,6 +32,7 @@ enum DecoderModelVersion {
   kLlama2 = 0,
   kLlama3,
   kQwen2_5,
+  kQwen3,
   kPhi4,
   kSmollm2_135m
 };


### PR DESCRIPTION
### Summary
- Adding static Qwen 2.5 - 1.5B to script.
- Adding static Qwen 3 0.6B/1.5B to script
- Adding back `skip_advanced_requant`.
- Adding prompt + special token for calibration, which helps certain models to improve accuracy.

#### Example Scripts:
`python examples/qualcomm/oss_scripts/llama/llama.py -b build-android -H haowhsu-linux -s 5f396958 -m SM8750 --prompt "How many r's in strawberries?" --temperature 0 --model_mode kv --max_seq_len 1024 --ptq 16a8w --decoder_model qwen3-0_6b --tasks wikitext --limit 1 --artifact ./qwen3-0_6b`

#### Statistics on SM8750, seq_len=1024
qwen2 1.5B: ~34tok/sec. QNN on device PPL=9.4 (CPU FP=9.1)
qwen3 0.6B: ~56tok/sec. QNN on device PPL=16.8 (CPU FP=16.26)
qwen3 1.7B: ~14tok/sec. QNN on device PPL=14.1 (CPU FP=13.52)


### Test plan
E2E in test_qnn_delegate.py
