### PR TITLE
Update test_remove_unused_parameters_pass.py

### DIFF
--- a/exir/tests/test_remove_unused_parameters_pass.py
+++ b/exir/tests/test_remove_unused_parameters_pass.py
@@ -196,7 +196,7 @@ class TestRemoveUnusedParametersPass(unittest.TestCase):
 
         self.assertEqual(1, len(runtime_outputs))
         self.assertTrue(
-            torch.allclose(runtime_outputs[0], eager_outputs, atol=2e-6),
+            torch.allclose(runtime_outputs[0], eager_outputs, atol=1e-5),
             "Values out of tolerance.\n"
             + f"  Strict: {strict}, ToEdge: {use_to_edge}, Delegate: {delegate}.\n"
             + f"  Eager: {eager_outputs}.\n"


### PR DESCRIPTION
Bump atol to avoid flaky behavior like in [this test run](https://github.com/pytorch/executorch/actions/runs/17109198553/job/48526045894#step:15:12991)

