### PR TITLE
Arm backend: Dont try to fuse const for TOSA ops

### DIFF
--- a/backends/arm/_passes/fuse_constant_ops_pass.py
+++ b/backends/arm/_passes/fuse_constant_ops_pass.py
@@ -107,7 +107,11 @@ class FuseConstantArgsPass(ExportPass):
         for node in graph_module.graph.nodes:
             if node.op != "call_function":
                 continue
-            if node.target == exir_ops.backend.tosa.TABLE.default:
+            if node.target in [
+                exir_ops.backend.tosa.TABLE.default,
+                exir_ops.backend.tosa.RESCALE.default,
+                exir_ops.backend.tosa.TRANSPOSE.default,
+            ]:
                 continue
 
             input_nodes = node.all_input_nodes


### PR DESCRIPTION
### Summary
The TOSA ops doesn't have any backed reference implementation, so avoid trying to fuse constant ops and leave for the backend compiler to do the work.

### Test plan
Tested through unit tests.

cc @digantdesai @freddan80 @zingo @oscarandersson8218