### PR TITLE
Add pybindings for attribute tensors

### DIFF
--- a/extension/pybindings/pybindings.cpp
+++ b/extension/pybindings/pybindings.cpp
@@ -661,6 +661,21 @@ struct PyMethodMeta final {
     }
   }
 
+  size_t num_attributes() const {
+    return meta_.num_attributes();
+  }
+
+  std::unique_ptr<PyTensorInfo> attribute_tensor_meta(size_t index) const {
+    const auto result = meta_.attribute_tensor_meta(index);
+    THROW_INDEX_IF_ERROR(
+        result.error(), "Cannot get attribute tensor meta at %zu", index);
+    if (module_) {
+      return std::make_unique<PyTensorInfo>(module_, result.get());
+    } else {
+      return std::make_unique<PyTensorInfo>(state_, result.get());
+    }
+  }
+
   py::str repr() const {
     py::list input_meta_strs;
     for (size_t i = 0; i < meta_.num_inputs(); ++i) {
@@ -1641,6 +1656,7 @@ PYBIND11_MODULE(EXECUTORCH_PYTHON_MODULE_NAME, m) {
       .def("name", &PyMethodMeta::name, call_guard)
       .def("num_inputs", &PyMethodMeta::num_inputs, call_guard)
       .def("num_outputs", &PyMethodMeta::num_outputs, call_guard)
+      .def("num_attributes", &PyMethodMeta::num_attributes, call_guard)
       .def(
           "input_tensor_meta",
           &PyMethodMeta::input_tensor_meta,
@@ -1649,6 +1665,11 @@ PYBIND11_MODULE(EXECUTORCH_PYTHON_MODULE_NAME, m) {
       .def(
           "output_tensor_meta",
           &PyMethodMeta::output_tensor_meta,
+          py::arg("index"),
+          call_guard)
+      .def(
+          "attribute_tensor_meta",
+          &PyMethodMeta::attribute_tensor_meta,
           py::arg("index"),
           call_guard)
       .def("__repr__", &PyMethodMeta::repr, call_guard);

--- a/extension/pybindings/pybindings.pyi
+++ b/extension/pybindings/pybindings.pyi
@@ -133,6 +133,10 @@ class MethodMeta:
         internal buffers"""
         ...
 
+    def num_attributes(self) -> int:
+        """The number of attribute tensors from the method"""
+        ...
+
     def input_tensor_meta(self, index: int) -> TensorInfo:
         """The tensor info for the 'index'th input. Index must be in the interval
         [0, num_inputs()). Raises an IndexError if the index is out of bounds"""
@@ -141,6 +145,11 @@ class MethodMeta:
     def output_tensor_meta(self, index: int) -> TensorInfo:
         """The tensor info for the 'index'th output. Index must be in the interval
         [0, num_outputs()). Raises an IndexError if the index is out of bounds"""
+        ...
+
+    def attribute_tensor_meta(self, index: int) -> TensorInfo:
+        """The tensor info for the 'index'th attribute. Index must be in the interval
+        [0, num_attributes()). Raises an IndexError if the index is out of bounds"""
         ...
 
     def __repr__(self) -> str: ...


### PR DESCRIPTION
Summary: Add pybindings for grabbing attribute tensor information from method meta

Differential Revision: D80631040


