### PR TITLE
[ET-VK] Introduce `BufferMetadata` GLSL struct to abstract tensor layout

### DIFF
--- a/backends/vulkan/runtime/graph/ComputeGraph.h
+++ b/backends/vulkan/runtime/graph/ComputeGraph.h
@@ -357,6 +357,10 @@ class ComputeGraph final {
     return values_.at(idx).toConstTensor().has_buffer_storage();
   }
 
+  inline bool is_texture_storage(const ValueRef idx) const {
+    return !is_buffer_storage(idx);
+  }
+
   /*
    * Checks that the following is true:
    * 1. The value at `idx` is a tensor
@@ -409,6 +413,10 @@ class ComputeGraph final {
 
   inline vkapi::BufferBindInfo sizes_ubo(const ValueRef idx) {
     return values_.at(idx).toTensor().sizes_ubo();
+  }
+
+  inline vkapi::BufferBindInfo buffer_meta_ubo(const ValueRef idx) {
+    return values_.at(idx).toTensor().buffer_meta_ubo();
   }
 
   inline vkapi::BufferBindInfo strides_ubo(const ValueRef idx) {

--- a/backends/vulkan/runtime/graph/ops/glsl/buffer_to_nchw.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/buffer_to_nchw.glsl
@@ -4,40 +4,33 @@
 
 #define T ${buffer_scalar_type(DTYPE)}
 
-#include "indexing_utils.h"
-
 ${define_required_extensions(DTYPE)}
 
 layout(std430) buffer;
 
-${layout_declare_tensor(0, "w", "nchw_buf", DTYPE, STORAGE)}
-${layout_declare_tensor(1, "r", "t_in", DTYPE, STORAGE)}
+#include "indexing.glslh"
 
-$if USE_PUSH_CONST:
-  layout(push_constant) uniform restrict Block {
-    ivec4 in_sizes;
-    ivec4 in_strides;
-    int numel;
-  };
-$else:
-  ${layout_declare_ubo(2, "ivec4", "in_sizes")}
-  ${layout_declare_ubo(3, "ivec4", "in_strides")}
-  ${layout_declare_ubo(4, "int", "numel")}
+${layout_declare_tensor(B, "w", "nchw_buf", DTYPE, STORAGE)}
+${layout_declare_tensor(B, "r", "t_inp", DTYPE, STORAGE)}
+
+${layout_declare_ubo(B, "BufferMetadata", "inp")}
 
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
 
 // This constant is unused in this shader but is kept so that the signature is
 // consistent with image_to_nchw.
-layout(constant_id = 3) const int UNUSED_packed_dim = W_DIM;
+${layout_declare_spec_const(C, "int", "unused", "0")}
 
 void main() {
-  int nchwi = int(gl_GlobalInvocationID.x);
-  if (nchwi >= numel) {
+  uint inp_bufi = gl_GlobalInvocationID.x;
+  if (inp_bufi>= numel(inp)) {
     return;
   }
 
-  ivec4 in_tidx = nchwi_to_tidx(nchwi, in_sizes);
-  const int in_bufi = tidx_to_bufi(in_tidx, in_strides);
+  TensorIndex inp_tidx;
+  linear_idx_to_tensor_idx(inp, inp_bufi, inp_tidx);
 
-  nchw_buf[nchwi] = t_in[in_bufi];
+  uint nchwi = tensor_idx_to_contiguous_idx(inp, inp_tidx);
+
+  nchw_buf[nchwi] = t_inp[inp_bufi];
 }

--- a/backends/vulkan/runtime/graph/ops/glsl/buffer_to_nchw.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/buffer_to_nchw.yaml
@@ -19,5 +19,3 @@ buffer_to_nchw:
       - VALUE: int32
   shader_variants:
     - NAME: buffer_to_nchw
-    - NAME: buffer_to_nchw_no_pc
-      USE_PUSH_CONST: False

--- a/backends/vulkan/runtime/graph/ops/glsl/indexing.glslh
+++ b/backends/vulkan/runtime/graph/ops/glsl/indexing.glslh
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#ifndef INDEXING_GLSLH
+#define INDEXING_GLSLH
+
+#define DIMLIMIT 8
+#define DIMLIMIT_DIV4 2
+
+#define mul_4(x) ((x) << 2)
+#define div_4(x) ((x) >> 2)
+
+#define mod_4(x) ((x) & 3)
+
+//
+// BufferMetadata
+//
+
+struct BufferMetadata {
+  uvec4 sizes[DIMLIMIT_DIV4];
+  uvec4 dim_order[DIMLIMIT_DIV4];
+  uvec4 strides[DIMLIMIT_DIV4];
+  uvec2 ndim_numel;
+};
+
+uint ndim(const BufferMetadata meta) {
+  return meta.ndim_numel[0];
+}
+
+int int_ndim(const BufferMetadata meta) {
+  return int(meta.ndim_numel[0]);
+}
+
+uint numel(const BufferMetadata meta) {
+  return meta.ndim_numel[1];
+}
+
+uint dim_order_at(const BufferMetadata meta, const int dim) {
+  return meta.dim_order[div_4(dim)][mod_4(dim)];
+}
+
+uint dim_order_at(const BufferMetadata meta, const uint dim) {
+  return meta.dim_order[div_4(dim)][mod_4(dim)];
+}
+
+uint stride_at(const BufferMetadata meta, const int dim) {
+  return meta.strides[div_4(dim)][mod_4(dim)];
+}
+
+uint stride_at(const BufferMetadata meta, const uint dim) {
+  return meta.strides[div_4(dim)][mod_4(dim)];
+}
+
+uint size_at(const BufferMetadata meta, const int dim) {
+  return meta.sizes[div_4(dim)][mod_4(dim)];
+}
+
+uint size_at(const BufferMetadata meta, const uint dim) {
+  return meta.sizes[div_4(dim)][mod_4(dim)];
+}
+
+bool are_equal(const BufferMetadata meta1, const BufferMetadata meta2) {
+  // sizes and strides must be the same to be considered equal
+  if (meta1.sizes[0] != meta2.sizes[0]) {
+    return false;
+  }
+  if (meta1.sizes[1] != meta2.sizes[1]) {
+    return false;
+  }
+  if (meta1.strides[0] != meta2.strides[0]) {
+    return false;
+  }
+  if (meta1.strides[1] != meta2.strides[1]) {
+    return false;
+  }
+  return true;
+}
+
+//
+// TensorIndex
+//
+
+struct TensorIndex {
+  uvec4 data[DIMLIMIT_DIV4];
+};
+
+void initialize(out TensorIndex tidx) {
+  tidx.data[0] = uvec4(0);
+  tidx.data[1] = uvec4(0);
+}
+
+uint idx_at(const TensorIndex tidx, const int dim) {
+  return tidx.data[div_4(dim)][mod_4(dim)];
+}
+
+//
+// Index Conversions
+//
+
+void contiguous_idx_to_tensor_idx(
+    const BufferMetadata meta,
+    uint contiguous_idx,
+    out TensorIndex tidx) {
+  initialize(tidx);
+  int dim = int_ndim(meta);
+  int i = 0;
+
+  uint contiguous_strides[DIMLIMIT];
+  contiguous_strides[0] = 1;
+  for (int d = 1; d < DIMLIMIT; ++d) {
+    contiguous_strides[d] = size_at(meta, d - 1) * contiguous_strides[d - 1];
+  }
+
+  for (int d = max(dim - 1, 0); d >= 0; d--) {
+    uint dim_stride = contiguous_strides[d];
+
+    tidx.data[div_4(d)][mod_4(d)] = contiguous_idx / dim_stride;
+    contiguous_idx = contiguous_idx % dim_stride;
+  }
+}
+
+uint tensor_idx_to_contiguous_idx(
+    const BufferMetadata meta,
+    const TensorIndex tidx) {
+  uint contiguous_strides[DIMLIMIT];
+  contiguous_strides[0] = 1;
+  for (int d = 1; d < DIMLIMIT; ++d) {
+    contiguous_strides[d] = size_at(meta, d - 1) * contiguous_strides[d - 1];
+  }
+
+  uint contig_idx = 0;
+  for (int d = 0; d < ndim(meta); ++d) {
+    contig_idx += contiguous_strides[d] * idx_at(tidx, d);
+  }
+  return contig_idx;
+}
+
+void linear_idx_to_tensor_idx(
+    const BufferMetadata meta,
+    uint linear_idx,
+    out TensorIndex tidx) {
+  initialize(tidx);
+  int dim = int_ndim(meta);
+  int i = 0;
+  for (int d = max(dim - 1, 0); d >= 0; d--) {
+    uint dim_idx = dim_order_at(meta, d);
+    uint dim_stride = stride_at(meta, dim_idx);
+
+    tidx.data[div_4(dim_idx)][mod_4(dim_idx)] = linear_idx / dim_stride;
+    linear_idx = linear_idx % dim_stride;
+  }
+}
+
+uint tensor_idx_to_linear_idx(
+    const BufferMetadata meta,
+    const TensorIndex tidx) {
+  uint lin_idx = 0;
+  for (int d = 0; d < ndim(meta); ++d) {
+    lin_idx += stride_at(meta, d) * idx_at(tidx, d);
+  }
+  return lin_idx;
+}
+
+void clamp_tensor_idx(const BufferMetadata meta, inout TensorIndex tidx) {
+  tidx.data[0] = min(tidx.data[0], meta.sizes[0] - 1);
+  tidx.data[1] = min(tidx.data[1], meta.sizes[1] - 1);
+}
+
+//
+// Debug utilities
+//
+
+#ifdef DEBUG_MODE
+
+void printTensorIndex(const TensorIndex tidx) {
+    debugPrintfEXT(
+        "TensorIndex: tidx=[%u %u %u %u %u %u %u %u]\\n",
+        tidx.data[0][0], tidx.data[0][1], tidx.data[0][2], tidx.data[0][3],
+        tidx.data[1][0], tidx.data[1][1], tidx.data[1][2], tidx.data[1][3]
+    );
+}
+
+void printBufferMetadata(const BufferMetadata meta) {
+    debugPrintfEXT(
+        "BufferMetadata: ndim=%u numel=%u\\n  sizes=[%u %u %u %u %u %u %u %u]\\n  dim_order=[%u %u %u %u %u %u %u %u]\\n  strides=[%u %u %u %u %u %u %u %u]\\n",
+        meta.ndim_numel[0], meta.ndim_numel[1],
+        meta.sizes[0][0], meta.sizes[0][1], meta.sizes[0][2], meta.sizes[0][3],
+        meta.sizes[1][1], meta.sizes[1][1], meta.sizes[1][2], meta.sizes[1][3],
+        meta.dim_order[0][0], meta.dim_order[0][1],
+        meta.dim_order[0][2], meta.dim_order[0][3],
+        meta.dim_order[1][0], meta.dim_order[1][1],
+        meta.dim_order[1][2], meta.dim_order[1][3],
+        meta.strides[0][0], meta.strides[0][1],
+        meta.strides[0][2], meta.strides[0][3],
+        meta.strides[1][1], meta.strides[1][1],
+        meta.strides[1][2], meta.strides[1][3]
+    );
+}
+
+#endif
+
+#endif // INDEXING_GLSLH

--- a/backends/vulkan/runtime/graph/ops/glsl/nchw_to_buffer.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/nchw_to_buffer.glsl
@@ -4,46 +4,45 @@
 
 #define T ${buffer_scalar_type(DTYPE)}
 
-#include "indexing_utils.h"
-
 ${define_required_extensions(DTYPE)}
 
 layout(std430) buffer;
 
-${layout_declare_tensor(B, "w", "t_out", DTYPE, STORAGE)}
+#include "indexing.glslh"
+
+${layout_declare_tensor(B, "w", "t_outp", DTYPE, STORAGE)}
 ${layout_declare_tensor(B, "r", "nchw_in", DTYPE, STORAGE)}
 
-$if USE_PUSH_CONST:
-  layout(push_constant) uniform restrict Block {
-    ivec4 out_sizes;
-    ivec4 out_strides;
-    int numel;
-  };
-$else:
-  ${layout_declare_ubo(B, "ivec4", "out_sizes")}
-  ${layout_declare_ubo(B, "ivec4", "out_strides")}
-  ${layout_declare_ubo(B, "int", "numel")}
+${layout_declare_ubo(B, "BufferMetadata", "outp")}
 
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
 
-${layout_declare_spec_const(C, "int", "out_layout", "DEFAULT_DIM_ORDER")}
-const lowp ivec4 out_dim_order = unhash_dim_order(out_layout);
+// This constant is unused in this shader but is kept so that the signature is
+// consistent with nchw_to_image.
+${layout_declare_spec_const(C, "int", "unused", "0")}
 ${layout_declare_spec_const(C, "int", "transpose_hw", "0")}
 
 void main() {
-  int out_bufi = int(gl_GlobalInvocationID.x);
-  if (out_bufi >= numel) {
+  const uint outp_bufi = int(gl_GlobalInvocationID.x);
+  if (outp_bufi >= numel(outp)) {
     return;
   }
 
-  ivec4 out_tidx = bufi_to_tidx(out_bufi, out_strides, out_dim_order);
+  TensorIndex outp_tidx;
+  uint nchwi;
 
-  ivec4 sizes = out_sizes;
+  linear_idx_to_tensor_idx(outp, outp_bufi, outp_tidx);
+
   if (transpose_hw == 1) {
-    sizes.xy = sizes.yx;
-    out_tidx.xy = out_tidx.yx;
+    BufferMetadata transposed_meta = outp;
+    transposed_meta.sizes[0].xy = transposed_meta.sizes[0].yx;
+    outp_tidx.data[0].xy = outp_tidx.data[0].yx;
+    nchwi = tensor_idx_to_contiguous_idx(transposed_meta, outp_tidx);
   }
-  const int in_nchwi = tidx_to_nchwi(out_tidx, sizes);
+  // Normal case
+  else {
+    nchwi = tensor_idx_to_contiguous_idx(outp, outp_tidx);
+  }
 
-  t_out[out_bufi] = nchw_in[in_nchwi];
+  t_outp[outp_bufi] = nchw_in[nchwi];
 }

--- a/backends/vulkan/runtime/graph/ops/glsl/nchw_to_buffer.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/nchw_to_buffer.yaml
@@ -19,5 +19,3 @@ nchw_to_buffer:
       - VALUE: int32
   shader_variants:
     - NAME: nchw_to_buffer
-    - NAME: nchw_to_buffer_no_pc
-      USE_PUSH_CONST: False

--- a/backends/vulkan/runtime/graph/ops/impl/BinaryOp.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/BinaryOp.cpp
@@ -139,15 +139,11 @@ void add_binary_op_buffer_node(
       // Inputs and Outputs
       {{out, vkapi::kWrite}, {{in1, in2}, vkapi::kRead}},
       // Shader params buffers
-      {},
+      {graph.buffer_meta_ubo(out),
+       graph.buffer_meta_ubo(in1),
+       graph.buffer_meta_ubo(in2)},
       // Push Constants
       {{
-          graph.sizes_pc_of(in1),
-          graph.sizes_pc_of(in2),
-          graph.strides_pc_of(out),
-          graph.strides_pc_of(in1),
-          graph.strides_pc_of(in2),
-          graph.numel_pc_of(out),
           PushConstantDataInfo(&alpha_val, sizeof(float)),
       }},
       // Specialization Constants

--- a/backends/vulkan/runtime/graph/ops/utils/StagingUtils.cpp
+++ b/backends/vulkan/runtime/graph/ops/utils/StagingUtils.cpp
@@ -44,9 +44,6 @@ vkapi::ShaderInfo get_nchw_to_tensor_shader(
 
   if (dst_storage_type == utils::kBuffer) {
     kernel_name = "nchw_to_buffer";
-    if (!push_constant_variant) {
-      kernel_name += "_no_pc";
-    }
     add_dtype_suffix(kernel_name, dst_dtype);
     return VK_KERNEL_FROM_STR(kernel_name);
   }
@@ -85,9 +82,6 @@ vkapi::ShaderInfo get_tensor_to_nchw_shader(
 
   if (src_storage_type == utils::kBuffer) {
     kernel_name = "buffer_to_nchw";
-    if (!push_constant_variant) {
-      kernel_name += "_no_pc";
-    }
     add_dtype_suffix(kernel_name, src_dtype);
     return VK_KERNEL_FROM_STR(kernel_name);
   }

--- a/backends/vulkan/test/utils/test_utils.cpp
+++ b/backends/vulkan/test/utils/test_utils.cpp
@@ -43,9 +43,6 @@ vkapi::ShaderInfo get_nchw_to_tensor_shader(
 
   if (v_dst.storage_type() == utils::kBuffer) {
     kernel_name = "nchw_to_buffer";
-    if (!push_constant_variant) {
-      kernel_name += "_no_pc";
-    }
     add_dtype_suffix(kernel_name, v_dst.dtype());
     return VK_KERNEL_FROM_STR(kernel_name);
   }
@@ -80,9 +77,6 @@ vkapi::ShaderInfo get_tensor_to_nchw_shader(
 
   if (v_src.storage_type() == utils::kBuffer) {
     kernel_name = "buffer_to_nchw";
-    if (!push_constant_variant) {
-      kernel_name += "_no_pc";
-    }
     add_dtype_suffix(kernel_name, v_src.dtype());
     return VK_KERNEL_FROM_STR(kernel_name);
   }
@@ -120,9 +114,7 @@ void record_nchw_to_buffer_op(
           vkapi::PipelineStage::COMPUTE,
           vkapi::MemoryAccessType::WRITE),
       src_buffer,
-      v_dst.sizes_ubo(),
-      v_dst.strides_ubo(),
-      v_dst.numel_ubo());
+      v_dst.buffer_meta_ubo());
 }
 
 void record_buffer_to_nchw_op(
@@ -140,9 +132,7 @@ void record_buffer_to_nchw_op(
       0,
       dst_buffer,
       v_src.buffer(pipeline_barrier, vkapi::PipelineStage::COMPUTE),
-      v_src.sizes_ubo(),
-      v_src.strides_ubo(),
-      v_src.numel_ubo());
+      v_src.buffer_meta_ubo());
 }
 
 void record_nchw_to_image_op(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #13597
* #13596
* __->__ #13595
* #13594
* #13593
* #13600
* #13599
* #13598

Differential Revision: [D80800082](https://our.internmc.facebook.com/intern/diff/D80800082)