### PR TITLE
Move undelegated constants

### DIFF
--- a/examples/models/llama/export_llama_lib.py
+++ b/examples/models/llama/export_llama_lib.py
@@ -1080,6 +1080,7 @@ def _export_llama(llm_config: LlmConfig) -> LLMEdgeManager:  # noqa: C901
 
             from executorch.exir.passes.external_constants_pass import (
                 delegate_external_constants_pass_unlifted,
+                external_constants_pass,
             )
 
             assert (
@@ -1088,6 +1089,11 @@ def _export_llama(llm_config: LlmConfig) -> LLMEdgeManager:  # noqa: C901
             delegate_external_constants_pass_unlifted(
                 module=builder_exported.pre_autograd_graph_module,
                 gen_tag_fn=gen_tag_fn,
+            )
+
+            # Also add a pass for 'to_executorch' to tag weights that aren't delegated.
+            additional_passes.append(
+                partial(external_constants_pass, gen_tag_fn=gen_tag_fn)
             )
 
         builder = _to_edge_and_lower_llama_xnnpack(

--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -808,11 +808,13 @@ def edge_to_executorch_passes(
     Get the pre memory planning passes based on the method name, if the pass is not in the dict, use the default pass.
     """
     passes: List[PassType] = [
-        *config.passes,
         SpecPropPass(),
         # ExecuTorch backend ops are unable to handle unbacked symints. So after
         # this pass, passes cannot be Interpreter-based, because it will fail if
         # there exists an unbacked symint operation.
+        *config.passes,
+        # config.passes may contain external_constants_pass. This pass has to
+        # run after SpecPropPass, which populates tensor names.
         EdgeToBackendOpsPass(),
         RemoveGraphAssertsPass(),
     ] + pre_memory_planning_passes(config, name)


### PR DESCRIPTION
Currently, the xnnpack + lora + program-data separation flow moves all delegated constants to the .ptd file. This change moves the undelegated constants as well, reducing the pte file size.

Run export_lora.sh from https://github.com/meta-pytorch/executorch-examples/pull/54

```
-rw-r--r-- 1 lfq users 5994013600 Aug 22 13:32 foundation.ptd
-rw-r--r-- 1 lfq users   27628928 Aug 22 13:32 llama_3_2_1B_lora.pte
-rw-r--r-- 1 lfq users 5994013600 Aug 22 13:30 llama_3_2_1B.ptd
-rw-r--r-- 1 lfq users     317248 Aug 22 13:30 llama_3_2_1B.pte
```

fp32 Weights: ~6GB
Program: ~300KB
Lora adapter weights: ~27MB