### PR TITLE
Qualcomm AI Engine Direct - Fix broken unpacking in T5 dataset loading

### DIFF
--- a/backends/qualcomm/tests/test_qnn_delegate.py
+++ b/backends/qualcomm/tests/test_qnn_delegate.py
@@ -5619,7 +5619,7 @@ class TestExampleOssScript(TestQNN):
             "python",
             f"{self.executorch_root}/examples/qualcomm/oss_scripts/t5/t5.py",
             "--dataset",
-            self.sentence_dataset,
+            self.qa_dataset,
             "--artifact",
             self.artifact_dir,
             "--build_folder",
@@ -6487,6 +6487,11 @@ def setup_environment():
         type=str,
     )
     parser.add_argument(
+        "--qa_dataset",
+        help="Location for QA dataset",
+        type=str,
+    )
+    parser.add_argument(
         "--sentence_dataset",
         help="Location for sentence dataset",
         type=str,
@@ -6549,6 +6554,7 @@ def setup_environment():
     TestQNN.executorch_root = args.executorch_root
     TestQNN.artifact_dir = args.artifact_dir
     TestQNN.image_dataset = args.image_dataset
+    TestQNN.qa_dataset = args.qa_dataset
     TestQNN.sentence_dataset = args.sentence_dataset
     TestQNN.pretrained_weight = args.pretrained_weight
     TestQNN.model_name = args.model_name

--- a/examples/qualcomm/utils.py
+++ b/examples/qualcomm/utils.py
@@ -637,7 +637,7 @@ def get_masked_language_model_dataset(dataset_path, tokenizer, data_size, shuffl
     # prepare input data
     inputs, targets = [], []
     data_loader = get_data_loader()
-    for _, data in enumerate(data_loader):
+    for data in data_loader:
         if len(inputs) >= data_size:
             break
         input_ids = data[0]
@@ -729,9 +729,9 @@ def get_seq2seq_dataset_from_squad_csv(  # noqa: C901
             dataset, batch_size=1, shuffle=shuffle, collate_fn=collator
         )
 
-    inputs, targets, input_list = [], [], ""
+    inputs, targets = [], []
     data_loader = get_data_loader(max_hidden_seq_length)
-    for idx, batch in enumerate(data_loader):
+    for batch in data_loader:
         if len(inputs) >= data_size:
             break
         input_ids = batch["input_ids"]
@@ -750,9 +750,8 @@ def get_seq2seq_dataset_from_squad_csv(  # noqa: C901
             )
         )
         targets.append(labels)
-        input_list += f"input_{idx}_0.raw input_{idx}_1.raw input_{idx}_2.raw\n"
 
-    return inputs, targets, input_list
+    return inputs, targets
 
 
 def setup_common_args_and_variables():


### PR DESCRIPTION
### Summary
Fix broken unpacking in T5 dataset loading

### Test plan
``` bash 
python backends/qualcomm/tests/test_qnn_delegate.py TestExampleOssScript.test_t5 -s ${device_id} -m ${soc} --build_folder build-android/ --executorch_root . --artifact_dir . --qa_dataset ${path_to_SQuAD-v1.1.csv}
```