### PR TITLE
NXP backend: Fix `tanh` merge conflict.

### DIFF
--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/tanh_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/tanh_converter.py
@@ -3,6 +3,9 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from executorch.backends.nxp.backend.custom_delegation_options import (
+    CustomDelegationOptions,
+)
 from executorch.backends.nxp.backend.ir.converter.node_converter import NodeConverter
 from executorch.backends.nxp.backend.ir.lib.tflite.BuiltinOperator import (
     BuiltinOperator,
@@ -17,6 +20,7 @@ class TanhConverter(NodeConverter):
     def _is_supported_in_IR(
         node: Node,
         parameters_mapping: dict[str, Parameter],
+        custom_delegation_options: CustomDelegationOptions,
     ) -> bool:
         return True
 


### PR DESCRIPTION
### Summary
This PR fixes a conflict caused by merging support for the `aten.tanh` operator.

### Test plan
Tested by the unit tests in `test_tanh_converter.py`.


cc @digantdesai @JakeStevens @robert-kalmar