### PR TITLE
[ET][Optimized] Fallback to portable op utils (add/div/mul/sub/le)

### DIFF
--- a/kernels/optimized/cpu/op_add.cpp
+++ b/kernels/optimized/cpu/op_add.cpp
@@ -9,6 +9,7 @@
 #include <ATen/cpu/vec/functional.h>
 #include <ATen/cpu/vec/vec.h>
 #include <executorch/kernels/optimized/cpu/binary_ops.h>
+#include <executorch/kernels/portable/cpu/op_add.h>
 #include <executorch/kernels/portable/cpu/scalar_utils.h>
 #include <executorch/kernels/portable/cpu/util/broadcast_util.h>
 #include <executorch/runtime/kernel/kernel_includes.h>
@@ -137,29 +138,7 @@ Tensor& opt_add_scalar_out(
           out.numel());
     });
   } else {
-    ET_SWITCH_REALHBBF16_TYPES(a_type, ctx, "add.Scalar_out", CTYPE_A, [&]() {
-      ET_SWITCH_REALB_TYPES(
-          common_type, ctx, "add.Scalar_out", CTYPE_IN, [&]() {
-            ET_SWITCH_REALHBBF16_TYPES(
-                out_type, ctx, "add.Scalar_out", CTYPE_OUT, [&]() {
-                  CTYPE_IN b_casted = utils::scalar_to<CTYPE_IN>(b);
-                  CTYPE_IN alpha_val;
-                  ET_KERNEL_CHECK(
-                      ctx,
-                      utils::extract_scalar(alpha, &alpha_val),
-                      InvalidArgument, );
-
-                  const size_t n = a.numel();
-                  const CTYPE_A* a_data = a.const_data_ptr<CTYPE_A>();
-                  CTYPE_OUT* out_data = out.mutable_data_ptr<CTYPE_OUT>();
-                  for (auto i = 0; i < n; ++i) {
-                    out_data[i] = static_cast<CTYPE_OUT>(
-                        static_cast<CTYPE_IN>(a_data[i]) +
-                        alpha_val * b_casted);
-                  }
-                });
-          });
-    });
+    utils::add_scalar_out(ctx, a, b, alpha, out);
   }
 
   return out;

--- a/kernels/optimized/cpu/op_mul.cpp
+++ b/kernels/optimized/cpu/op_mul.cpp
@@ -9,6 +9,7 @@
 #include <ATen/cpu/vec/functional.h>
 #include <ATen/cpu/vec/vec.h>
 #include <executorch/kernels/optimized/cpu/binary_ops.h>
+#include <executorch/kernels/portable/cpu/op_mul.h>
 #include <executorch/kernels/portable/cpu/scalar_utils.h>
 #include <executorch/kernels/portable/cpu/util/broadcast_util.h>
 #include <executorch/runtime/core/exec_aten/util/tensor_util.h> // IWYU pragma: export
@@ -21,54 +22,6 @@ namespace native {
 
 using Tensor = executorch::aten::Tensor;
 using ScalarType = executorch::aten::ScalarType;
-
-namespace {
-
-template <
-    bool can_cast,
-    typename CTYPE_A,
-    typename CTYPE_B,
-    typename CTYPE_IN,
-    typename CTYPE_OUT>
-struct MulInner;
-
-template <
-    typename CTYPE_A,
-    typename CTYPE_B,
-    typename CTYPE_IN,
-    typename CTYPE_OUT>
-struct MulInner<true, CTYPE_A, CTYPE_B, CTYPE_IN, CTYPE_OUT> {
-  static void run(const Tensor& a, const Tensor& b, Tensor& out) {
-    apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
-        // NOLINTNEXTLINE(facebook-hte-ConstantArgumentPassByValue)
-        [](const CTYPE_A val_a, const CTYPE_B val_b) {
-          CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-          CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-          CTYPE_IN value = a_casted * b_casted;
-
-          return static_cast<CTYPE_OUT>(value);
-        },
-        a,
-        b,
-        out);
-  }
-};
-
-struct ReportCanCastBug {
-  static void run(const Tensor&, const Tensor&, Tensor&) {
-    ET_DCHECK_MSG(false, "BUG: canCast should have been checked above");
-  }
-};
-
-template <
-    typename CTYPE_A,
-    typename CTYPE_B,
-    typename CTYPE_IN,
-    typename CTYPE_OUT>
-struct MulInner<false, CTYPE_A, CTYPE_B, CTYPE_IN, CTYPE_OUT>
-    : public ReportCanCastBug {};
-
-} // namespace
 
 Tensor& opt_mul_out(
     KernelRuntimeContext& ctx,
@@ -159,52 +112,7 @@ Tensor& opt_mul_out(
       });
     }
   } else {
-    ScalarType common_type =
-        promoteTypes(a_type, b_type, /*half_to_float*/ true);
-    ET_KERNEL_CHECK(ctx, canCast(common_type, out_type), InvalidArgument, out);
-
-    ET_KERNEL_CHECK(
-        ctx,
-        resize_to_broadcast_target_size(a, b, out) == Error::Ok,
-        InvalidArgument,
-        out);
-
-    if (executorch::runtime::isComplexType(a_type) ||
-        executorch::runtime::isComplexType(b_type) ||
-        executorch::runtime::isComplexType(out_type)) {
-      ET_KERNEL_CHECK(
-          ctx, a_type == b_type && a_type == out_type, InvalidArgument, out);
-
-      ET_SWITCH_COMPLEXH_TYPES(out_type, ctx, "mul.out", CTYPE, [&]() {
-        apply_binary_elementwise_fn<CTYPE, CTYPE, CTYPE>(
-            [](const CTYPE val_a, const CTYPE val_b) { return val_a * val_b; },
-            a,
-            b,
-            out);
-      });
-    } else {
-      ET_SWITCH_REALHBBF16_TYPES(a_type, ctx, "mul.out", CTYPE_A, [&]() {
-        ET_SWITCH_REALHBBF16_TYPES(b_type, ctx, "mul.out", CTYPE_B, [&]() {
-          using CTYPE_IN = typename torch::executor::
-              promote_types<CTYPE_A, CTYPE_B, /*half_to_float*/ true>::type;
-          ET_DCHECK(CppTypeToScalarType<CTYPE_IN>::value == common_type);
-          ET_SWITCH_REALHBBF16_TYPES(
-              out_type, ctx, "mul.out", CTYPE_OUT, [&]() {
-                apply_binary_elementwise_fn<CTYPE_A, CTYPE_B, CTYPE_OUT>(
-                    [](const CTYPE_A val_a, const CTYPE_B val_b) {
-                      CTYPE_IN a_casted = static_cast<CTYPE_IN>(val_a);
-                      CTYPE_IN b_casted = static_cast<CTYPE_IN>(val_b);
-                      CTYPE_IN value = a_casted * b_casted;
-
-                      return static_cast<CTYPE_OUT>(value);
-                    },
-                    a,
-                    b,
-                    out);
-              });
-        });
-      });
-    }
+    utils::mul_out(ctx, a, b, out);
   }
 
   return out;
@@ -245,23 +153,7 @@ Tensor& opt_mul_scalar_out(
           out.numel());
     });
   } else {
-    ET_SWITCH_REALHBBF16_TYPES(a_type, ctx, "mul.Scalar_out", CTYPE_A, [&]() {
-      ET_SWITCH_REALB_TYPES(
-          common_type, ctx, "mul.Scalar_out", CTYPE_IN, [&]() {
-            ET_SWITCH_REALHBBF16_TYPES(
-                out_type, ctx, "mul.Scalar_out", CTYPE_OUT, [&]() {
-                  CTYPE_IN b_casted = utils::scalar_to<CTYPE_IN>(b);
-
-                  const size_t n = a.numel();
-                  const CTYPE_A* a_data = a.const_data_ptr<CTYPE_A>();
-                  CTYPE_OUT* out_data = out.mutable_data_ptr<CTYPE_OUT>();
-                  for (auto i = 0; i < n; ++i) {
-                    out_data[i] = static_cast<CTYPE_OUT>(
-                        static_cast<CTYPE_IN>(a_data[i]) * b_casted);
-                  }
-                });
-          });
-    });
+    utils::mul_scalar_out(ctx, a, b, out);
   }
 
   return out;

--- a/kernels/optimized/cpu/targets.bzl
+++ b/kernels/optimized/cpu/targets.bzl
@@ -28,6 +28,8 @@ def define_common_targets():
         visibility = ["//executorch/kernels/optimized/cpu/...", "@EXECUTORCH_CLIENTS",],
         exported_deps = [
             "//executorch/runtime/core:core",
+            "//executorch/kernels/portable/cpu:op_add_util",
+            "//executorch/kernels/portable/cpu:op_sub_util",
             "//executorch/kernels/portable/cpu/util:broadcast_indexes_range",
         ],
     )

--- a/shim_et/xplat/executorch/kernels/optimized/op_registration_util.bzl
+++ b/shim_et/xplat/executorch/kernels/optimized/op_registration_util.bzl
@@ -151,6 +151,7 @@ OPTIMIZED_ATEN_OPS = (
         deps = [
             ":binary_ops",
             ":add_sub_impl",
+            "//executorch/kernels/portable/cpu:op_add_util",
             "//executorch/kernels/portable/cpu:scalar_utils",
             "//executorch/kernels/portable/cpu/util:broadcast_util",
             "//executorch/runtime/core/portable_type/c10/c10:aten_headers_for_executorch",
@@ -178,6 +179,7 @@ OPTIMIZED_ATEN_OPS = (
         }),
         deps = [
             ":binary_ops",
+            "//executorch/kernels/portable/cpu:op_div_util",
             "//executorch/kernels/portable/cpu:scalar_utils",
             "//executorch/kernels/portable/cpu/util:broadcast_util",
             "//executorch/runtime/core/portable_type/c10/c10:aten_headers_for_executorch",
@@ -224,9 +226,9 @@ OPTIMIZED_ATEN_OPS = (
         name = "op_le",
         deps = [
             ":binary_ops",
+            "//executorch/kernels/portable/cpu:op_le_util",
             "//executorch/kernels/portable/cpu:scalar_utils",
             "//executorch/kernels/portable/cpu/util:broadcast_util",
-            "//executorch/kernels/portable/cpu/pattern:comparison_op",
             "//executorch/kernels/portable/cpu/util:elementwise_util",
             "//executorch/runtime/core/portable_type/c10/c10:aten_headers_for_executorch",
         ],
@@ -257,6 +259,7 @@ OPTIMIZED_ATEN_OPS = (
         name = "op_mul",
         deps = [
             ":binary_ops",
+            "//executorch/kernels/portable/cpu:op_mul_util",
             "//executorch/kernels/portable/cpu:scalar_utils",
             "//executorch/kernels/portable/cpu/util:broadcast_util",
             "//executorch/runtime/core/exec_aten/util:tensor_util",
@@ -276,6 +279,7 @@ OPTIMIZED_ATEN_OPS = (
         deps = [
             ":binary_ops",
             ":add_sub_impl",
+            "//executorch/kernels/portable/cpu:op_sub_util",
             "//executorch/kernels/portable/cpu:scalar_utils",
             "//executorch/kernels/portable/cpu/util:broadcast_util",
             "//executorch/runtime/core/portable_type/c10/c10:aten_headers_for_executorch",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #13650
* __->__ #13649
* #13648

Optimized implementations of `add`, `div`, `mul`, `sub` & `le` fallback to portable implementations (via portable op utils) for the generic case.

Differential Revision: [D80963874](https://our.internmc.facebook.com/intern/diff/D80963874/)