### PR TITLE
Force -O3 for executorch op_div.cpp in "clang 17" also

### DIFF
--- a/shim_et/xplat/executorch/kernels/optimized/op_registration_util.bzl
+++ b/shim_et/xplat/executorch/kernels/optimized/op_registration_util.bzl
@@ -174,9 +174,10 @@ OPTIMIZED_ATEN_OPS = (
         # is not sufficient to avoid it.
         compiler_flags = [] if runtime.is_oss else select({
             "DEFAULT": [],
-            "ovr_config//toolchain/clang/constraints:19": select({
+            "ovr_config//os:android": select({
                 "DEFAULT": [],
-                "ovr_config//os:android": ["-O3"],
+                "ovr_config//toolchain/clang/constraints:17": ["-O3"],
+                "ovr_config//toolchain/clang/constraints:19": ["-O3"],
             }),
         }),
         deps = [


### PR DESCRIPTION
Summary:
Some platforms use clang 19 under the hood but are setting the clang 17
constraint for bad reasons.

Differential Revision: D80980948


