### PR TITLE
Add pendings ops to the to be supported list

### DIFF
--- a/backends/qualcomm/partition/common_defs.py
+++ b/backends/qualcomm/partition/common_defs.py
@@ -16,7 +16,23 @@ not_supported_operator = [
     exir_ops.edge.quantized_decomposed.embedding_4bit.dtype,
 ]
 
-to_be_implemented_operator = []
+to_be_implemented_operator = [
+    exir_ops.edge.aten._adaptive_avg_pool3d.default,
+    exir_ops.edge.aten.adaptive_max_pool2d.default,
+    exir_ops.edge.aten.avg_pool3d.default,
+    exir_ops.edge.aten.div.Tensor_mode,
+    exir_ops.edge.aten.index_select.default,
+    exir_ops.edge.aten.log10.default,
+    exir_ops.edge.aten.log1p.default,
+    exir_ops.edge.aten.log2.default,
+    exir_ops.edge.aten.flip.default,
+    exir_ops.edge.aten.max_pool3d_with_indices.default,
+    exir_ops.edge.aten.median.default,
+    exir_ops.edge.aten.median.dim,
+    exir_ops.edge.aten.round.decimals,
+    exir_ops.edge.aten.le.Scalar,
+    exir_ops.edge.aten.trunc.default,
+]
 
 constant_operator = [
     exir_ops.edge.aten.arange.start_step,


### PR DESCRIPTION
Summary:
Add the list of ops that will be implement later to prevent KeyError and they will fall back to portable for now

Rollback Plan:

Differential Revision: D81057438


