### PR TITLE
Re-enable Windows build CI

### DIFF
--- a/.github/workflows/build-presets.yml
+++ b/.github/workflows/build-presets.yml
@@ -103,3 +103,37 @@ jobs:
         ./install_requirements.sh > /dev/null
         cmake --preset ${{ matrix.preset }}
         cmake --build cmake-out -j$(( $(nproc) - 1 ))
+
+  windows:
+    uses: pytorch/test-infra/.github/workflows/windows_job.yml@main
+    strategy:
+      fail-fast: false
+      matrix:
+        preset: [windows]
+    with:
+      job-name: build
+      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      submodules: recursive
+      timeout: 90
+      script: |
+        set -eux
+        conda init powershell
+        powershell -Command "& {
+          Set-PSDebug -Trace 1
+          \$ErrorActionPreference = 'Stop'
+          \$PSNativeCommandUseErrorActionPreference = \$true
+          conda create --yes --quiet -n et python=3.12
+          conda activate et
+          python install_requirements.py
+          cmake --preset ${{ matrix.preset }} -T ClangCL
+          if (\$LASTEXITCODE -ne 0) {
+            Write-Host "CMake configuration was unsuccessful. Exit code: \$LASTEXITCODE."
+            exit \$LASTEXITCODE
+          }
+          \$numCores = [System.Environment]::GetEnvironmentVariable('NUMBER_OF_PROCESSORS') - 1
+          cmake --build cmake-out -j \$numCores
+          if (\$LASTEXITCODE -ne 0) {
+            Write-Host "CMake build was unsuccessful. Exit code: \$LASTEXITCODE."
+            exit \$LASTEXITCODE
+          }
+        }"


### PR DESCRIPTION
The Windows CI build job was disabled in https://github.com/pytorch/executorch/pull/13669 due to a new Windows build failure in https://github.com/pytorch/executorch/pull/13485. Since that diff was reverted in https://github.com/pytorch/executorch/pull/13685, we can re-enable the job.

I started fixing the issue in https://github.com/pytorch/executorch/pull/13672, but dropped it due to the revert. It's a simple change, so it can likely be bundled when the affected PR is re-landed.

Test Plan:
The Build Preset / Windows job is passing on this PR.