### PR TITLE
Remove int32_t support for quant/dequant kernels

### DIFF
--- a/backends/cadence/hifi/operators/op_dequantize_per_tensor.cpp
+++ b/backends/cadence/hifi/operators/op_dequantize_per_tensor.cpp
@@ -46,9 +46,6 @@ void dequantize_per_tensor_out(
       input.scalar_type() == ScalarType::UInt16) {
     const uint16_t* input_data = input.const_data_ptr<uint16_t>();
     dequantize<uint16_t>(out_data, input_data, scale, zero_point, numel);
-  } else if (input.scalar_type() == ScalarType::Int) {
-    const int32_t* input_data = input.const_data_ptr<int32_t>();
-    dequantize<int32_t>(out_data, input_data, scale, zero_point, numel);
   } else {
     ET_CHECK_MSG(
         false,

--- a/backends/cadence/hifi/operators/op_quantize_per_tensor.cpp
+++ b/backends/cadence/hifi/operators/op_quantize_per_tensor.cpp
@@ -109,10 +109,6 @@ void quantize_per_tensor_out(
     uint16_t* out_data = out.mutable_data_ptr<uint16_t>();
     cadence::impl::HiFi::kernels::quantize<uint16_t>(
         out_data, input_data, 1. / scale, zero_point, numel);
-  } else if (out.scalar_type() == ScalarType::Int) {
-    int32_t* out_data = out.mutable_data_ptr<int32_t>();
-    cadence::impl::HiFi::kernels::quantize<int32_t>(
-        out_data, input_data, 1. / scale, zero_point, numel);
   } else {
     ET_KERNEL_CHECK_MSG(
         ctx,

--- a/backends/cadence/reference/kernels/kernels.cpp
+++ b/backends/cadence/reference/kernels/kernels.cpp
@@ -64,7 +64,6 @@ typed_quantize_val(int8_t);
 typed_quantize_val(uint8_t);
 typed_quantize_val(int16_t);
 typed_quantize_val(uint16_t);
-typed_quantize_val(int32_t);
 #undef typed_quantize_val
 
 #define typed_quantize_vec(dtype)  \
@@ -78,7 +77,6 @@ typed_quantize_vec(int8_t);
 typed_quantize_vec(uint8_t);
 typed_quantize_vec(int16_t);
 typed_quantize_vec(uint16_t);
-typed_quantize_vec(int32_t);
 #undef typed_quantize_vec
 
 #define typed_dequantize_val(dtype) \
@@ -87,7 +85,6 @@ typed_dequantize_val(int8_t);
 typed_dequantize_val(uint8_t);
 typed_dequantize_val(int16_t);
 typed_dequantize_val(uint16_t);
-typed_dequantize_val(int32_t);
 #undef typed_dequantize_val
 
 #define typed_dequantize_vec(dtype) \
@@ -101,7 +98,6 @@ typed_dequantize_vec(int8_t);
 typed_dequantize_vec(uint8_t);
 typed_dequantize_vec(int16_t);
 typed_dequantize_vec(uint16_t);
-typed_dequantize_vec(int32_t);
 #undef typed_dequantize_vec
 
 }; // namespace kernels

--- a/backends/cadence/reference/operators/dequantize_per_tensor.cpp
+++ b/backends/cadence/reference/operators/dequantize_per_tensor.cpp
@@ -47,10 +47,6 @@ void dequantize_per_tensor_out(
     const int16_t* input_data = input.const_data_ptr<int16_t>();
     impl::reference::kernels::dequantize<int16_t>(
         out_data, input_data, scale, zero_point, numel);
-  } else if (input.scalar_type() == ScalarType::Int) {
-    const int32_t* input_data = input.const_data_ptr<int32_t>();
-    impl::reference::kernels::dequantize<int32_t>(
-        out_data, input_data, scale, zero_point, numel);
   } else {
     ET_CHECK_MSG(
         false,

--- a/backends/cadence/reference/operators/quantize_per_tensor.cpp
+++ b/backends/cadence/reference/operators/quantize_per_tensor.cpp
@@ -49,10 +49,6 @@ void quantize_per_tensor_out(
     int16_t* out_data = out.mutable_data_ptr<int16_t>();
     impl::reference::kernels::quantize<int16_t>(
         out_data, input_data, 1. / scale, zero_point, numel);
-  } else if (out.scalar_type() == ScalarType::Int) {
-    int32_t* out_data = out.mutable_data_ptr<int32_t>();
-    impl::reference::kernels::quantize<int32_t>(
-        out_data, input_data, 1. / scale, zero_point, numel);
   } else {
     ET_CHECK_MSG(
         false,


### PR DESCRIPTION
Summary: As titled. Biases use int32 quant, but they're always constant folded, so we should never need them. This will save a bit of code size.

Reviewed By: ethansfng

Differential Revision: D80988283


