### PR TITLE
Add 'kernels_torchao' to the Apple workflow

### DIFF
--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -156,6 +156,7 @@ jobs:
           "kernels_llm"
           "kernels_optimized"
           "kernels_quantized"
+          "kernels_torchao"
           "threadpool"
         )
 


### PR DESCRIPTION
Otherwise we don't upload the binary deliverables to S3

