### PR TITLE
NXP Backend: Use --index-url for eiq.nxp.com/repository

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -855,7 +855,8 @@ jobs:
         .ci/scripts/setup-linux.sh --build-tool "cmake"
 
         # Install test requirements
-        pip install -r backends/nxp/requirements-tests.txt
+        pip install -r backends/nxp/requirements-tests-pypi.txt
+        pip install -r backends/nxp/requirements-tests-eiq.txt
 
         # Run pytest
         PYTHON_EXECUTABLE=python bash backends/nxp/run_unittests.sh

--- a/backends/nxp/requirements-tests-eiq.txt
+++ b/backends/nxp/requirements-tests-eiq.txt
@@ -1,0 +1,2 @@
+--index-url https://eiq.nxp.com/repository
+neutron_converter_SDK_25_03

--- a/backends/nxp/requirements-tests-pypi.txt
+++ b/backends/nxp/requirements-tests-pypi.txt
@@ -1,0 +1,4 @@
+tensorflow==2.18.0
+pytest-mock
+tflite
+GvGen

--- a/backends/nxp/requirements-tests.txt
+++ b/backends/nxp/requirements-tests.txt
@@ -1,6 +1,0 @@
---extra-index-url https://eiq.nxp.com/repository
-tensorflow==2.18.0
-pytest-mock
-tflite
-GvGen
-neutron_converter_SDK_25_03

--- a/examples/nxp/setup.sh
+++ b/examples/nxp/setup.sh
@@ -7,4 +7,4 @@
 set -u
 
 # Install neutron-converter
-pip install --extra-index-url https://eiq.nxp.com/repository neutron_converter_SDK_25_03
+pip install --index-url https://eiq.nxp.com/repository neutron_converter_SDK_25_03


### PR DESCRIPTION
### Summary
Avoid attack on PyPI index. If `--extra-index-url` is used there is an attack vector when adversary publish a malicious package with same name on pypi.org. And pip might pick the malicious package instead of one on eiq.nxp.com/repository, as "there is no priority in the locations that are searched" [https://pip.pypa.io/en/stable/cli/pip_install/]
Using --index-url eliminates this attack. 

### Test plan
N/A

cc @digantdesai @JakeStevens