### PR TITLE
NXP backend: Fix incorrect `linear` test.

### DIFF
--- a/backends/nxp/tests/ir/converter/node_converter/test_linear_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_linear_converter.py
@@ -10,6 +10,7 @@ import torch
 from executorch.backends.nxp.tests.executorch_pipeline import to_edge_program
 from executorch.backends.nxp.tests.executors import convert_run_compare
 from executorch.backends.nxp.tests.models import LinearModule
+from executorch.exir.dialects._ops import ops as exir_ops
 
 
 @pytest.fixture(autouse=True)
@@ -26,15 +27,23 @@ def test_linear_conversion__with_bias():
 
     input_data = np.random.random(input_shape).astype(np.float32)
 
-    convert_run_compare(edge_program, input_data=input_data, atol=1.0e-6)
+    nodes = list(edge_program.graph.nodes)
+    assert nodes[4].target == exir_ops.edge.aten.addmm.default
+    assert len(nodes[4].args) == 3  # Has bias.
+
+    convert_run_compare(edge_program, input_data=input_data)
 
 
 def test_linear_conversion__without_bias():
     input_shape = (10, 32)
     edge_program = to_edge_program(
-        LinearModule(bias=True), input_shape
+        LinearModule(bias=False), input_shape
     ).exported_program()
 
     input_data = np.random.random(input_shape).astype(np.float32)
 
-    convert_run_compare(edge_program, input_data=input_data, atol=1.0e-6)
+    nodes = list(edge_program.graph.nodes)
+    assert nodes[3].target == exir_ops.edge.aten.mm.default
+    assert len(nodes[3].args) == 2  # No bias.
+
+    convert_run_compare(edge_program, input_data=input_data)


### PR DESCRIPTION
### Summary
This PR fixes an incorrect `linear` test without a bias.

### Test plan
Unit test provided.

cc @robert-kalmar @jirioc @JakeStevens 
