### PR TITLE
Revert "Disable tokenizers on Windows (#13667)"

### DIFF
--- a/install_requirements.py
+++ b/install_requirements.py
@@ -112,13 +112,8 @@ def install_requirements(use_pytorch_nightly):
 
     LOCAL_REQUIREMENTS = [
         "third-party/ao",  # We need the latest kernels for fast iteration, so not relying on pypi.
-    ] + (
-        [
-            "extension/llm/tokenizers",  # TODO(larryliu0820): Setup a pypi package for this.
-        ]
-        if sys.platform != "win32"
-        else []
-    )  # TODO(gjcomer): Re-enable when buildable on Windows.
+        "extension/llm/tokenizers",  # TODO(larryliu0820): Setup a pypi package for this.
+    ]
 
     # Install packages directly from local copy instead of pypi.
     # This is usually not recommended.


### PR DESCRIPTION
This reverts commit 5afe90dfa2ebf5912f90e9325160e3cc9516cbc5.

This is due to an Meta-internal sync issue - it needs to be reverted and re-merged.
