### PR TITLE
[ET-VK][ez] Add ability to check for dot product extension support + upgrade glslc

### DIFF
--- a/backends/vulkan/runtime/api/Context.cpp
+++ b/backends/vulkan/runtime/api/Context.cpp
@@ -111,6 +111,12 @@ void Context::check_device_capabilities(const vkapi::ShaderInfo& shader) {
           shader.kernel_name, vkapi::VulkanExtension::INT8_STORAGE);
     }
   }
+  if (shader.requires_integer_dot_product) {
+    if (!adapter_p_->supports_int8_dot_product()) {
+      throw vkapi::ShaderNotSupportedError(
+          shader.kernel_name, vkapi::VulkanExtension::INTEGER_DOT_PRODUCT);
+    }
+  }
 }
 
 vkapi::DescriptorSet Context::get_descriptor_set(

--- a/backends/vulkan/runtime/gen_vulkan_spv.py
+++ b/backends/vulkan/runtime/gen_vulkan_spv.py
@@ -1103,6 +1103,7 @@ class ShaderInfo:
     requires_shader_int16_ext: bool = False
     requires_16bit_storage_ext: bool = False
     requires_8bit_storage_ext: bool = False
+    requires_integer_dot_product_ext: bool = False
 
 
 def getName(filePath: str) -> str:
@@ -1213,6 +1214,8 @@ def getShaderInfo(srcFilePath: str) -> ShaderInfo:
                     shader_info.requires_16bit_storage_ext = True
                 if "GL_EXT_shader_8bit_storage" in line:
                     shader_info.requires_8bit_storage_ext = True
+                if "GL_EXT_integer_dot_product" in line:
+                    shader_info.requires_integer_dot_product_ext = True
 
     return shader_info
 
@@ -1288,6 +1291,7 @@ def generateShaderInfoStr(shader_info: ShaderInfo, name: str, sizeBytes: int) ->
         to_cpp_str(shader_info.requires_shader_int16_ext),
         to_cpp_str(shader_info.requires_16bit_storage_ext),
         to_cpp_str(shader_info.requires_8bit_storage_ext),
+        to_cpp_str(shader_info.requires_integer_dot_product_ext),
     ]
 
     shader_info_str = textwrap.indent(

--- a/backends/vulkan/runtime/graph/ComputeGraph.cpp
+++ b/backends/vulkan/runtime/graph/ComputeGraph.cpp
@@ -155,6 +155,11 @@ ComputeGraph::ComputeGraph(GraphConfig config)
     config_.execute_threshold_node_count = 128;
     config_.execute_initial_threshold_node_count = 64;
   }
+
+  // Check if the underlying GPU can access accelerated integer dot product
+  // instructions
+  can_use_int8_dot_product_ =
+      context_->adapter_ptr()->supports_int8_dot_product();
 }
 
 ComputeGraph::~ComputeGraph() {

--- a/backends/vulkan/runtime/graph/ComputeGraph.h
+++ b/backends/vulkan/runtime/graph/ComputeGraph.h
@@ -221,6 +221,10 @@ class ComputeGraph final {
   // config.execute_threshold_node_count.
   size_t execute_threshold_node_count_ = 0;
 
+  // Whether the underlying GPU support accelerated integer dot product
+  // extensions
+  bool can_use_int8_dot_product_ = false;
+
  public:
   //
   // Accessors
@@ -1011,6 +1015,10 @@ class ComputeGraph final {
 
   inline size_t execute_count() const {
     return execute_count_;
+  }
+
+  inline bool can_use_int8_dot_product() const {
+    return can_use_int8_dot_product_;
   }
 
   /*

--- a/backends/vulkan/runtime/vk_api/Adapter.cpp
+++ b/backends/vulkan/runtime/vk_api/Adapter.cpp
@@ -109,6 +109,9 @@ VkDevice create_logical_device(
 #ifdef VK_KHR_shader_float16_int8
       VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME,
 #endif /* VK_KHR_shader_float16_int8 */
+#ifdef VK_KHR_shader_integer_dot_product
+      VK_KHR_SHADER_INTEGER_DOT_PRODUCT_EXTENSION_NAME,
+#endif /* VK_KHR_shader_integer_dot_product */
 #if defined(VK_KHR_pipeline_executable_properties) && defined(VULKAN_DEBUG)
       VK_KHR_PIPELINE_EXECUTABLE_PROPERTIES_EXTENSION_NAME,
 #endif /* VK_KHR_pipeline_executable_properties */
@@ -159,6 +162,14 @@ VkDevice create_logical_device(
   shader_float16_int8_types.pNext = extension_list_top;
   extension_list_top = &shader_float16_int8_types;
 #endif /* VK_KHR_shader_float16_int8 */
+
+#ifdef VK_KHR_shader_integer_dot_product
+  VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR
+      shader_int_dot_product_features{
+          physical_device.shader_int_dot_product_features};
+  shader_int_dot_product_features.pNext = extension_list_top;
+  extension_list_top = &shader_int_dot_product_features;
+#endif /* VK_KHR_shader_integer_dot_product */
 
   device_create_info.pNext = extension_list_top;
 
@@ -400,6 +411,107 @@ std::string Adapter::stringize() const {
   PRINT_PROP(physical_device_.shader_float16_int8_types, shaderInt8);
 #endif /* VK_KHR_shader_float16_int8 */
   ss << "    }" << std::endl;
+
+#ifdef VK_KHR_shader_integer_dot_product
+  ss << "    Shader Integer Dot Product Features {" << std::endl;
+  PRINT_PROP(
+      physical_device_.shader_int_dot_product_features,
+      shaderIntegerDotProduct);
+  ss << "    }" << std::endl;
+
+  ss << "    Shader Integer Dot Product Properties {" << std::endl;
+  PRINT_PROP(
+      physical_device_.shader_int_dot_product_properties,
+      integerDotProduct8BitUnsignedAccelerated);
+  PRINT_PROP(
+      physical_device_.shader_int_dot_product_properties,
+      integerDotProduct8BitSignedAccelerated);
+  PRINT_PROP(
+      physical_device_.shader_int_dot_product_properties,
+      integerDotProduct8BitMixedSignednessAccelerated);
+  PRINT_PROP(
+      physical_device_.shader_int_dot_product_properties,
+      integerDotProduct4x8BitPackedUnsignedAccelerated);
+  PRINT_PROP(
+      physical_device_.shader_int_dot_product_properties,
+      integerDotProduct4x8BitPackedSignedAccelerated);
+  PRINT_PROP(
+      physical_device_.shader_int_dot_product_properties,
+      integerDotProduct4x8BitPackedMixedSignednessAccelerated);
+  PRINT_PROP(
+      physical_device_.shader_int_dot_product_properties,
+      integerDotProduct16BitUnsignedAccelerated);
+  PRINT_PROP(
+      physical_device_.shader_int_dot_product_properties,
+      integerDotProduct16BitSignedAccelerated);
+  PRINT_PROP(
+      physical_device_.shader_int_dot_product_properties,
+      integerDotProduct16BitMixedSignednessAccelerated);
+  PRINT_PROP(
+      physical_device_.shader_int_dot_product_properties,
+      integerDotProduct32BitUnsignedAccelerated);
+  PRINT_PROP(
+      physical_device_.shader_int_dot_product_properties,
+      integerDotProduct32BitSignedAccelerated);
+  PRINT_PROP(
+      physical_device_.shader_int_dot_product_properties,
+      integerDotProduct32BitMixedSignednessAccelerated);
+  PRINT_PROP(
+      physical_device_.shader_int_dot_product_properties,
+      integerDotProduct64BitUnsignedAccelerated);
+  PRINT_PROP(
+      physical_device_.shader_int_dot_product_properties,
+      integerDotProduct64BitSignedAccelerated);
+  PRINT_PROP(
+      physical_device_.shader_int_dot_product_properties,
+      integerDotProduct64BitMixedSignednessAccelerated);
+  PRINT_PROP(
+      physical_device_.shader_int_dot_product_properties,
+      integerDotProductAccumulatingSaturating8BitUnsignedAccelerated);
+  PRINT_PROP(
+      physical_device_.shader_int_dot_product_properties,
+      integerDotProductAccumulatingSaturating8BitSignedAccelerated);
+  PRINT_PROP(
+      physical_device_.shader_int_dot_product_properties,
+      integerDotProductAccumulatingSaturating8BitMixedSignednessAccelerated);
+  PRINT_PROP(
+      physical_device_.shader_int_dot_product_properties,
+      integerDotProductAccumulatingSaturating4x8BitPackedUnsignedAccelerated);
+  PRINT_PROP(
+      physical_device_.shader_int_dot_product_properties,
+      integerDotProductAccumulatingSaturating4x8BitPackedSignedAccelerated);
+  PRINT_PROP(
+      physical_device_.shader_int_dot_product_properties,
+      integerDotProductAccumulatingSaturating4x8BitPackedMixedSignednessAccelerated);
+  PRINT_PROP(
+      physical_device_.shader_int_dot_product_properties,
+      integerDotProductAccumulatingSaturating16BitUnsignedAccelerated);
+  PRINT_PROP(
+      physical_device_.shader_int_dot_product_properties,
+      integerDotProductAccumulatingSaturating16BitSignedAccelerated);
+  PRINT_PROP(
+      physical_device_.shader_int_dot_product_properties,
+      integerDotProductAccumulatingSaturating16BitMixedSignednessAccelerated);
+  PRINT_PROP(
+      physical_device_.shader_int_dot_product_properties,
+      integerDotProductAccumulatingSaturating32BitUnsignedAccelerated);
+  PRINT_PROP(
+      physical_device_.shader_int_dot_product_properties,
+      integerDotProductAccumulatingSaturating32BitSignedAccelerated);
+  PRINT_PROP(
+      physical_device_.shader_int_dot_product_properties,
+      integerDotProductAccumulatingSaturating32BitMixedSignednessAccelerated);
+  PRINT_PROP(
+      physical_device_.shader_int_dot_product_properties,
+      integerDotProductAccumulatingSaturating64BitUnsignedAccelerated);
+  PRINT_PROP(
+      physical_device_.shader_int_dot_product_properties,
+      integerDotProductAccumulatingSaturating64BitSignedAccelerated);
+  PRINT_PROP(
+      physical_device_.shader_int_dot_product_properties,
+      integerDotProductAccumulatingSaturating64BitMixedSignednessAccelerated);
+  ss << "    }" << std::endl;
+#endif /* VK_KHR_shader_integer_dot_product */
 
   const VkPhysicalDeviceMemoryProperties& mem_props =
       physical_device_.memory_properties;

--- a/backends/vulkan/runtime/vk_api/Adapter.h
+++ b/backends/vulkan/runtime/vk_api/Adapter.h
@@ -212,6 +212,15 @@ class Adapter final {
 #endif /* VK_KHR_shader_float16_int8 */
   }
 
+  inline bool supports_int8_dot_product() {
+#ifdef VK_KHR_shader_integer_dot_product
+    return physical_device_.shader_int_dot_product_features
+               .shaderIntegerDotProduct == VK_TRUE;
+#else
+    return false;
+#endif /* VK_KHR_shader_integer_dot_product */
+  }
+
   inline bool supports_int16_shader_types() {
     return physical_device_.supports_int16_shader_types;
   }

--- a/backends/vulkan/runtime/vk_api/Device.cpp
+++ b/backends/vulkan/runtime/vk_api/Device.cpp
@@ -36,6 +36,12 @@ PhysicalDevice::PhysicalDevice(VkPhysicalDevice physical_device_handle)
       shader_float16_int8_types{
           VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES_KHR},
 #endif /* VK_KHR_shader_float16_int8 */
+#ifdef VK_KHR_shader_integer_dot_product
+      shader_int_dot_product_features{
+          VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_FEATURES_KHR},
+      shader_int_dot_product_properties{
+          VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_PROPERTIES_KHR},
+#endif
       queue_families{},
       num_compute_queues(0),
       supports_int16_shader_types(false),
@@ -76,6 +82,13 @@ PhysicalDevice::PhysicalDevice(VkPhysicalDevice physical_device_handle)
   shader_float16_int8_types.pNext = extension_list_top;
   extension_list_top = &shader_float16_int8_types;
 #endif /* VK_KHR_shader_float16_int8 */
+
+#ifdef VK_KHR_shader_integer_dot_product
+  shader_int_dot_product_features.pNext = extension_list_top;
+  extension_list_top = &shader_int_dot_product_features;
+  shader_int_dot_product_properties.pNext = extension_list_top;
+  extension_list_top = &shader_int_dot_product_properties;
+#endif /* VK_KHR_shader_integer_dot_product */
 
   features2.pNext = extension_list_top;
 

--- a/backends/vulkan/runtime/vk_api/Device.h
+++ b/backends/vulkan/runtime/vk_api/Device.h
@@ -44,6 +44,12 @@ struct PhysicalDevice final {
 #ifdef VK_KHR_shader_float16_int8
   VkPhysicalDeviceShaderFloat16Int8Features shader_float16_int8_types;
 #endif /* VK_KHR_shader_float16_int8 */
+#ifdef VK_KHR_shader_integer_dot_product
+  VkPhysicalDeviceShaderIntegerDotProductFeatures
+      shader_int_dot_product_features;
+  VkPhysicalDeviceShaderIntegerDotProductProperties
+      shader_int_dot_product_properties;
+#endif /* VK_KHR_shader_integer_dot_product */
 
   // Available GPU queues
   std::vector<VkQueueFamilyProperties> queue_families;

--- a/backends/vulkan/runtime/vk_api/Exception.cpp
+++ b/backends/vulkan/runtime/vk_api/Exception.cpp
@@ -92,6 +92,9 @@ std::ostream& operator<<(std::ostream& out, const VulkanExtension result) {
     case VulkanExtension::INT8_STORAGE:
       out << "VK_KHR_8bit_storage";
       break;
+    case VulkanExtension::INTEGER_DOT_PRODUCT:
+      out << "VK_KHR_shader_integer_dot_product";
+      break;
   }
   return out;
 }

--- a/backends/vulkan/runtime/vk_api/Exception.h
+++ b/backends/vulkan/runtime/vk_api/Exception.h
@@ -82,6 +82,7 @@ enum class VulkanExtension : uint8_t {
   SHADER_INT16,
   INT16_STORAGE,
   INT8_STORAGE,
+  INTEGER_DOT_PRODUCT,
 };
 
 class ShaderNotSupportedError : public std::exception {

--- a/backends/vulkan/runtime/vk_api/QueryPool.cpp
+++ b/backends/vulkan/runtime/vk_api/QueryPool.cpp
@@ -209,7 +209,7 @@ std::string QueryPool::generate_string_report() {
 
   std::stringstream ss;
 
-  int kernel_name_w = 40;
+  int kernel_name_w = 120;
   int global_size_w = 25;
   int local_size_w = 25;
   int duration_w = 25;

--- a/backends/vulkan/runtime/vk_api/Shader.cpp
+++ b/backends/vulkan/runtime/vk_api/Shader.cpp
@@ -31,7 +31,8 @@ ShaderInfo::ShaderInfo(
     const utils::uvec3 tile_size,
     const bool requires_shader_int16_ext,
     const bool requires_16bit_storage_ext,
-    const bool requires_8bit_storage_ext)
+    const bool requires_8bit_storage_ext,
+    const bool requires_integer_dot_product_ext)
     : src_code{
           spirv_bin,
           size,
@@ -41,7 +42,8 @@ ShaderInfo::ShaderInfo(
       out_tile_size(tile_size),
       requires_shader_int16(requires_shader_int16_ext),
       requires_16bit_storage(requires_16bit_storage_ext),
-      requires_8bit_storage(requires_8bit_storage_ext) {
+      requires_8bit_storage(requires_8bit_storage_ext),
+      requires_integer_dot_product(requires_integer_dot_product_ext) {
 }
 
 bool operator==(const ShaderInfo& _1, const ShaderInfo& _2) {

--- a/backends/vulkan/runtime/vk_api/Shader.h
+++ b/backends/vulkan/runtime/vk_api/Shader.h
@@ -65,6 +65,7 @@ struct ShaderInfo final {
   bool requires_shader_int16 = false;
   bool requires_16bit_storage = false;
   bool requires_8bit_storage = false;
+  bool requires_integer_dot_product = false;
 
   explicit ShaderInfo();
 
@@ -76,7 +77,8 @@ struct ShaderInfo final {
       const utils::uvec3 tile_size,
       const bool requires_shader_int16_ext,
       const bool requires_16bit_storage_ext,
-      const bool requires_8bit_storage_ext);
+      const bool requires_8bit_storage_ext,
+      const bool requires_integer_dot_product_ext);
 
   operator bool() const {
     return src_code.bin != nullptr;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #13812
* #13811
* #13810
* __->__ #13809

## Motivation

Prepare for shaders that will use accelerated int8 dot product GLSL extensions, i.e. `dotPacked4x8AccSatEXT`

## Changes

* Query for support for the shader integer dot product extension when creating the VkPhysicalDevice
* Request the shader integer dot product extension when creating VkDevice
* Provide APIs to check if the extension is available in the current runtime.

Differential Revision: [D81323427](https://our.internmc.facebook.com/intern/diff/D81323427/)