### PR TITLE
[ET-VK][AOT] Enable exporting Q8 Quantized Linear + Convolution

### DIFF
--- a/backends/vulkan/_passes/TARGETS
+++ b/backends/vulkan/_passes/TARGETS
@@ -119,6 +119,19 @@ runtime.python_library(
 )
 
 runtime.python_library(
+    name = "fold_qdq",
+    srcs = ["fold_qdq.py"],
+    visibility = [
+        "//executorch/backends/...",
+    ],
+    deps = [
+        "//caffe2:torch",
+        "//executorch/backends/vulkan:utils_lib",
+        "//executorch/exir:pass_base",
+    ],
+)
+
+runtime.python_library(
     name = "fuse_patterns",
     srcs = ["fuse_patterns.py"],
     visibility = [
@@ -144,6 +157,7 @@ runtime.python_library(
         "//executorch/examples/...",
     ],
     deps = [
+        ":fold_qdq",
         ":fuse_patterns",
         ":fuse_quantized_ops",
         ":insert_prepack_nodes",

--- a/backends/vulkan/_passes/__init__.py
+++ b/backends/vulkan/_passes/__init__.py
@@ -6,6 +6,7 @@
 
 # pyre-strict
 
+from executorch.backends.vulkan._passes.fold_qdq import FoldQDQPass
 from executorch.backends.vulkan._passes.fuse_patterns import FusePatternsPass
 from executorch.backends.vulkan._passes.fuse_quantized_ops import (
     FuseQuantizedOpsTransform,
@@ -30,6 +31,7 @@ from executorch.backends.vulkan._passes.squeeze_unsqueeze_inputs import (
 from executorch.backends.vulkan._passes.tag_memory_meta_pass import TagMemoryMetaPass
 
 __all__ = [
+    "FoldQDQPass",
     "FusePatternsPass",
     "FuseQuantizedOpsTransform",
     "insert_prepack_nodes",

--- a/backends/vulkan/_passes/fold_qdq.py
+++ b/backends/vulkan/_passes/fold_qdq.py
@@ -1,0 +1,48 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import executorch.backends.vulkan.utils as utils
+import torch
+
+from executorch.exir.pass_base import ExportPass, PassResult
+from executorch.exir.passes import dead_code_elimination_pass
+
+
+class FoldQDQPass(ExportPass):
+    """
+    Erase Q/DQ chain introduced by PT2E quantization workflow. It is assumed that all
+    valid quant op patterns have already been fused before this pass.
+    """
+
+    def __init__(self, edge_program: torch.export.ExportedProgram):
+        super(FoldQDQPass, self).__init__()
+        self.edge_program = edge_program
+
+    def call(self, graph_module: torch.fx.GraphModule):
+        for node in graph_module.graph.nodes:
+            # Criteria for a foldable Q/DQ node:
+            # - only one user (dequantize)
+            if utils.is_quant_node(node):
+                if len(node.users) > 1:
+                    continue
+
+                dq_node = None
+                for user in node.users:
+                    if utils.is_dequant_node(user):
+                        dq_node = user
+
+                if dq_node is None:
+                    continue
+
+                original_node = node.args[0]
+                assert isinstance(original_node, torch.fx.Node)
+                dq_node.replace_all_uses_with(original_node)
+
+        graph_module.recompile()
+        dead_code_elimination_pass(graph_module)
+        # Re-trace to validate everything is ok
+        graph_module = super().call(graph_module).graph_module
+        return PassResult(graph_module, True)

--- a/backends/vulkan/custom_ops_lib.py
+++ b/backends/vulkan/custom_ops_lib.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Optional
+
 import executorch.backends.vulkan.patterns as vk_patterns
 import torch.library
 
@@ -321,6 +323,134 @@ lib.define(
 lib.impl(name, linear_qta8a_qga4w, "CompositeExplicitAutograd")
 linear_qta8a_qga4w_op = getattr(getattr(torch.ops, namespace), name)
 
+#################
+## qaqw_linear ##
+#################
+
+
+def linear_q8ta_q8csw(
+    x: torch.Tensor,
+    input_scale: float,
+    input_zero_point: int,
+    qweights: torch.Tensor,
+    weight_sums: torch.Tensor,
+    weight_scales: torch.Tensor,
+    bias: Optional[torch.Tensor] = None,
+):
+    weight_zeros = torch.zeros_like(weight_scales, dtype=torch.int32)
+    qweights = qweights.transpose(0, 1)
+    weights = torch.ops.quantized_decomposed.dequantize_per_channel(
+        qweights,
+        weight_scales,
+        weight_zeros,
+        0,
+        -127,
+        127,
+        torch.int8,
+    )
+
+    # Perform linear operation
+    out = torch.nn.functional.linear(x, weights)
+    if bias is not None:
+        out = out + bias
+
+    return out
+
+
+name = "linear_q8ta_q8csw"
+lib.define(
+    f"""
+    {name}(
+        Tensor x,
+        float input_scale,
+        int input_zero_point,
+        Tensor qweight,
+        Tensor weight_sums,
+        Tensor weight_scales,
+        Tensor? bias = None) -> Tensor
+    """
+)
+lib.impl(name, linear_q8ta_q8csw, "CompositeExplicitAutograd")
+qa_q8csw_linear = getattr(getattr(torch.ops, namespace), name)
+
+##################
+## conv2d_q8ta_q8csw ##
+##################
+
+
+def conv2d_q8ta_q8csw(
+    x: torch.Tensor,
+    input_scale: float,
+    input_zero_point: int,
+    qweights: torch.Tensor,
+    weight_sums: torch.Tensor,
+    weight_scales: torch.Tensor,
+    bias: Optional[torch.Tensor],
+    kernel_size: list,
+    stride: list,
+    padding: list,
+    dilation: list,
+    groups: int,
+):
+    weight_zeros = torch.zeros_like(weight_scales, dtype=torch.int32)
+
+    # Restore weight tensor from 2D format (IC * H * W, OC) back to 4D format (OC, IC, H, W)
+    # First transpose to get (OC, IC * H * W)
+    qweights_transposed = qweights.transpose(0, 1)
+
+    # Extract kernel dimensions from the provided kernel_size
+    H, W = kernel_size[0], kernel_size[1]
+
+    # Calculate dimensions
+    OC = qweights_transposed.shape[0]
+    IC_H_W = qweights_transposed.shape[1]
+    IC = IC_H_W // (H * W)
+
+    # Reshape to original 4D format (OC, IC, H, W)
+    qweights_4d = qweights_transposed.view(OC, IC, H, W)
+    print(qweights_4d.shape)
+
+    # Dequantize weights
+    weights = torch.ops.quantized_decomposed.dequantize_per_channel(
+        qweights_4d,
+        weight_scales,
+        weight_zeros,
+        0,  # axis=0 for output channel quantization
+        -127,
+        127,
+        torch.int8,
+    )
+    print(weights.shape)
+    print(x.shape)
+
+    # Perform convolution
+    out = torch.nn.functional.conv2d(
+        x, weights, bias, stride, padding, dilation, groups
+    )
+
+    return out
+
+
+name = "conv2d_q8ta_q8csw"
+lib.define(
+    f"""
+    {name}(
+        Tensor x,
+        float input_scale,
+        int input_zero_point,
+        Tensor qweight,
+        Tensor weight_sums,
+        Tensor weight_scales,
+        Tensor? bias,
+        SymInt[] kernel_size,
+        SymInt[] stride,
+        SymInt[] padding,
+        SymInt[] dilation,
+        SymInt groups) -> Tensor
+    """
+)
+lib.impl(name, conv2d_q8ta_q8csw, "CompositeExplicitAutograd")
+conv2d_q8ta_q8csw_op = getattr(getattr(torch.ops, namespace), name)
 ######################
 ## apply_rotary_emb ##
 ######################

--- a/backends/vulkan/op_registry.py
+++ b/backends/vulkan/op_registry.py
@@ -320,6 +320,19 @@ def register_int8_mm_op():
 
 @update_features(
     [
+        exir_ops.edge.et_vk.linear_q8ta_q8csw.default,
+    ]
+)
+def register_qa_qw_linear():
+    return OpFeatures(
+        inputs_storage=utils.CONTIGUOUS_ANY,
+        supports_prepacking=True,
+        supports_resize=False,
+    )
+
+
+@update_features(
+    [
         exir_ops.edge.et_vk.linear_weight_int4.default,
     ]
 )
@@ -453,6 +466,32 @@ def register_convolution_op():
             utils.NO_STORAGE,  # output_max (non tensor)
         ],
         supports_resize=True,
+        supports_prepacking=True,
+    )
+
+
+@update_features(
+    [
+        exir_ops.edge.et_vk.conv2d_q8ta_q8csw.default,
+    ]
+)
+def register_quantized_conv_op():
+    return OpFeatures(
+        inputs_storage=[
+            utils.CHANNELS_PACKED_TEXTURE,  # input
+            utils.NO_STORAGE,  # input_scale (non tensor)
+            utils.NO_STORAGE,  # input_zero_point (non tensor)
+            utils.NO_STORAGE,  # weight (prepacked)
+            utils.NO_STORAGE,  # weight_sums (prepacked)
+            utils.NO_STORAGE,  # weight_scales (prepacked)
+            utils.NO_STORAGE,  # bias (prepacked)
+            utils.NO_STORAGE,  # kernel_size (non tensor)
+            utils.NO_STORAGE,  # stride (non tensor)
+            utils.NO_STORAGE,  # padding (non tensor)
+            utils.NO_STORAGE,  # dilation (non tensor)
+            utils.NO_STORAGE,  # groups (non tensor)
+        ],
+        supports_resize=False,
         supports_prepacking=True,
     )
 

--- a/backends/vulkan/partitioner/vulkan_partitioner.py
+++ b/backends/vulkan/partitioner/vulkan_partitioner.py
@@ -22,6 +22,8 @@ from executorch.backends.vulkan.op_registry import (
     vulkan_supported_ops,
 )
 
+from executorch.backends.vulkan.patterns import PatternMatch
+
 from executorch.backends.vulkan.serialization.vulkan_graph_schema import (
     VkMemoryLayout,
     VkStorageType,
@@ -41,7 +43,6 @@ from torch.export.exported_program import ExportedProgram
 
 from torch.fx.passes.infra.partitioner import CapabilityBasedPartitioner
 from torch.fx.passes.operator_support import OperatorSupportBase
-from torch.fx.passes.utils.matcher_utils import InternalMatch
 
 # pyre-ignore
 ops_not_to_decompose = [
@@ -60,7 +61,7 @@ class VulkanSupportedOperators(OperatorSupportBase):
         require_dynamic_shape: bool = False,
         operator_blocklist: Optional[Set[OpKey]] = None,
         operator_allowlist: Optional[Set[OpKey]] = None,
-        fusable_subgraphs: Optional[List[InternalMatch]] = None,
+        fusable_subgraphs: Optional[List[PatternMatch]] = None,
         nn_module_blocklist: Optional[Set[str]] = None,
         nn_module_allowlist: Optional[Set[str]] = None,
     ) -> None:
@@ -72,13 +73,13 @@ class VulkanSupportedOperators(OperatorSupportBase):
             operator_blocklist if operator_blocklist is not None else set()
         )
         self.operator_allowlist = operator_allowlist
-        self.fusable_subgraphs: List[InternalMatch] = (
+        self.fusable_subgraphs: List[PatternMatch] = (
             fusable_subgraphs if fusable_subgraphs is not None else []
         )
         # Create a set of all nodes that are part of fusable subgraphs for quick lookup
         self.fusable_nodes: Set[torch.fx.Node] = set()
         for match in self.fusable_subgraphs:
-            self.fusable_nodes.update(match.nodes_map.values())
+            self.fusable_nodes.update(match.all_nodes)
 
         self.nn_module_blocklist = nn_module_blocklist
         self.nn_module_allowlist = nn_module_allowlist

--- a/backends/vulkan/patterns/TARGETS
+++ b/backends/vulkan/patterns/TARGETS
@@ -10,6 +10,7 @@ runtime.python_library(
         "pattern_registry.py",
         "rope.py",
         "quantized_linear.py",
+        "quantized_convolution.py",
     ],
     visibility = [
         "//executorch/backends/...",

--- a/backends/vulkan/patterns/pattern_registry.py
+++ b/backends/vulkan/patterns/pattern_registry.py
@@ -13,22 +13,65 @@ from executorch.exir import ExportedProgram
 from torch.fx.passes.utils.matcher_utils import InternalMatch
 
 GetGraphFn = Callable[[], List[torch.fx.GraphModule]]
+
+
+class PatternMatch:
+    __slots__ = ("input_nodes", "output_nodes", "all_nodes", "anchor_node")
+    """
+    The design of this class is based on InternalMatch from
+    torch.fx.passes.utils.matcher_utils. It represents nodes in a graph that
+    match a particular pattern.
+
+    The reason to not use InternalMatch directly is to enable more (i.e. custom)
+    methods to detect and represent matches other than through SubgraphMatcher.
+    """
+
+    def __init__(
+        self,
+        input_nodes: List[torch.fx.Node],
+        output_nodes: List[torch.fx.Node],
+        all_nodes: List[torch.fx.Node],
+        anchor_node: Optional[torch.fx.Node] = None,
+    ):
+        self.input_nodes = input_nodes
+        self.output_nodes = output_nodes
+        self.all_nodes = all_nodes
+        self.anchor_node = anchor_node
+
+
+def create_pattern_match_from_internal_match(
+    internal_match: InternalMatch,
+) -> PatternMatch:
+    return PatternMatch(
+        internal_match.placeholder_nodes,
+        internal_match.returning_nodes,
+        list(internal_match.nodes_map.values()),
+    )
+
+
 CreateReplacementFn = Callable[
-    [ExportedProgram, torch.fx.GraphModule, InternalMatch], None
+    [ExportedProgram, torch.fx.GraphModule, PatternMatch], None
 ]
+
+
+DetectorFn = Callable[[torch.fx.Node], Optional[PatternMatch]]
 
 
 class PatternEntry:
     def __init__(
         self,
         get_graphs_fn: Optional[GetGraphFn] = None,
+        detector_fn: Optional[DetectorFn] = None,
         create_replacement_fn: Optional[CreateReplacementFn] = None,
     ):
         self.get_graphs_fn = get_graphs_fn
+        self.detector_fn = detector_fn
         self.create_replacement_fn = create_replacement_fn
 
     def is_valid(self):
-        return self.get_graphs_fn is not None and self.create_replacement_fn is not None
+        return (
+            self.get_graphs_fn is not None or self.detector_fn is not None
+        ) and self.create_replacement_fn is not None
 
 
 fusable_patterns: Dict[str, PatternEntry] = {}
@@ -39,7 +82,24 @@ def register_pattern_graph(pattern_name: str):
         if pattern_name not in fusable_patterns:
             fusable_patterns[pattern_name] = PatternEntry()
 
+        # Cannot define both get_graphs_fn and detector_fn
+        assert fusable_patterns[pattern_name].detector_fn is None
         fusable_patterns[pattern_name].get_graphs_fn = fn
+
+        return fn
+
+    return decorator
+
+
+def register_pattern_detector(pattern_name: str):
+    def decorator(fn: DetectorFn):
+        if pattern_name not in fusable_patterns:
+            fusable_patterns[pattern_name] = PatternEntry()
+
+        # Cannot define both get_graphs_fn and detector_fn
+        assert fusable_patterns[pattern_name].get_graphs_fn is None
+        fusable_patterns[pattern_name].detector_fn = fn
+
         return fn
 
     return decorator

--- a/backends/vulkan/patterns/quantized_convolution.py
+++ b/backends/vulkan/patterns/quantized_convolution.py
@@ -1,0 +1,207 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Optional
+
+import executorch.backends.vulkan.utils as utils
+
+import torch
+
+from executorch.backends.transforms.utils import (
+    create_constant_placeholder,
+    get_param_tensor,
+)
+
+from executorch.backends.vulkan.patterns.pattern_registry import (
+    PatternMatch,
+    register_pattern_detector,
+    register_pattern_replacement,
+)
+
+from executorch.exir import ExportedProgram
+from executorch.exir.dialects._ops import ops as exir_ops
+
+from torch.export.graph_signature import InputKind
+
+
+class QuantizedConvolutionMatch(PatternMatch):
+    def __init__(self, conv_node: torch.fx.Node) -> None:
+        self.anchor_node = conv_node
+        self.match_found = False
+        self.all_nodes = [self.anchor_node]
+
+        # Extract convolution parameters
+        self.stride = conv_node.args[3] if len(conv_node.args) > 3 else [1, 1]
+        self.padding = conv_node.args[4] if len(conv_node.args) > 4 else [0, 0]
+        self.dilation = conv_node.args[5] if len(conv_node.args) > 5 else [1, 1]
+        self.groups = conv_node.args[8] if len(conv_node.args) > 8 else 1
+
+        const_node, arg_chain = utils.trace_args_until_placeholder(
+            self.anchor_node.args[1]
+        )
+
+        # weight is not a constant tensor - no match
+        if const_node is None:
+            return
+
+        dequantize_weight_node = None
+        # Search for a dequantize node in the arg chain of weight
+        for node in arg_chain:
+            if isinstance(node, torch.fx.Node) and utils.is_dequant_node(node):
+                dequantize_weight_node = node
+        # weight is not quantized - no match
+        if dequantize_weight_node is None:
+            return
+
+        self.weight_node = const_node
+        self.dequantize_weight_node = dequantize_weight_node
+        self.all_nodes.extend(arg_chain)
+
+        # Identify weight quantization parameter nodes
+        self.weight_scales_node, arg_chain = utils.trace_args_until_placeholder(
+            self.dequantize_weight_node.args[1]
+        )
+        assert self.weight_scales_node is not None
+        self.all_nodes.extend(arg_chain)
+
+        self.weight_zeros_node, arg_chain = utils.trace_args_until_placeholder(
+            self.dequantize_weight_node.args[2]
+        )
+        assert self.weight_zeros_node is not None
+        self.all_nodes.extend(arg_chain)
+
+        # Identify output node
+        self.output_node = self.anchor_node
+
+        # Identify bias node, if applicable
+        self.bias_node = None
+        if len(self.anchor_node.args) > 2 and self.anchor_node.args[2] is not None:
+            self.bias_node, arg_chain = utils.trace_args_until_placeholder(
+                self.anchor_node.args[2]
+            )
+            if self.bias_node is not None:
+                self.all_nodes.extend(arg_chain)
+
+        # Identify input node
+        self.fp_input_node, self.quantize_input_node, dq_node = (
+            utils.maybe_skip_q_dq_arg_chain(self.anchor_node.args[0])
+        )
+        assert self.fp_input_node is not None
+        self.all_nodes.append(self.fp_input_node)
+        assert self.quantize_input_node is not None
+        assert dq_node is not None
+
+        self.input_scales_node = self.quantize_input_node.args[1]
+        self.input_zeros_node = self.quantize_input_node.args[2]
+
+        self.all_nodes.extend(
+            [
+                self.quantize_input_node,
+                dq_node,
+            ]
+        )
+
+        self.match_found = True
+
+
+convolution_anchor_nodes = {
+    exir_ops.edge.aten.conv2d.default,
+    exir_ops.edge.aten.convolution.default,
+}
+
+
+@register_pattern_detector("quantized_convolution")
+def find_quantized_convolution_patterns(
+    node: torch.fx.Node,
+) -> Optional[QuantizedConvolutionMatch]:
+    if node.target not in convolution_anchor_nodes:
+        return None
+
+    matched_pattern = QuantizedConvolutionMatch(node)
+    if matched_pattern.match_found:
+        return matched_pattern
+
+    return None
+
+
+##
+## Pattern Replacement
+##
+
+
+@register_pattern_replacement("quantized_convolution")
+def make_conv2d_q8ta_q8csw_custom_op(
+    ep: ExportedProgram,
+    graph_module: torch.fx.GraphModule,
+    match: QuantizedConvolutionMatch,
+):
+    weight_tensor = get_param_tensor(ep, match.weight_node)
+    assert weight_tensor is not None
+
+    assert match.weight_scales_node is not None
+    weight_scales_tensor = get_param_tensor(ep, match.weight_scales_node)
+    assert weight_scales_tensor is not None
+
+    assert match.weight_zeros_node is not None
+    weight_zeros_tensor = get_param_tensor(ep, match.weight_zeros_node)
+    assert weight_zeros_tensor is not None
+
+    # Reshape weight tensor from (OC, IC, H, W) to (IC * H * W, OC) for matrix multiplication
+    # This prepares the weights for Im2Col-based convolution computation
+    OC, IC, H, W = weight_tensor.shape
+
+    weight_tensor_reshaped = (
+        weight_tensor.permute(2, 3, 1, 0).contiguous().view(IC * H * W, OC)
+    )
+    utils.update_program_state_dict(ep, match.weight_node.name, weight_tensor_reshaped)
+    # Need to make sure the fake tensor matches the updated tensor's properties
+    match.weight_node.meta["val"] = (
+        match.weight_node.meta["val"]
+        .permute(1, 2, 3, 0)
+        .contiguous()
+        .view(IC * H * W, OC)
+    )
+
+    first_graph_node = list(graph_module.graph.nodes)[0]
+    with graph_module.graph.inserting_before(first_graph_node):
+        qweight_tensor_name = utils.get_tensor_name(ep, match.weight_node)
+        # Pre-compute the weight sums which are needed to apply activation zero point
+        # when using integer accumulation. For the reshaped 2D weight matrix (IC * H * W, OC),
+        # sum over dimension 0 to get sums per output channel
+        sum_per_output_channel = (
+            weight_tensor_reshaped.sum(dim=0).to(torch.float).contiguous()
+        )
+        sums_name = qweight_tensor_name + "_sums"
+        weight_sums_node = create_constant_placeholder(
+            exp_program=ep,
+            graph=graph_module.graph,
+            kind=InputKind.CONSTANT_TENSOR,
+            name=sums_name,
+            data=sum_per_output_channel,
+        )
+
+    with graph_module.graph.inserting_before(match.output_node):
+        qconv_node = graph_module.graph.create_node(
+            "call_function",
+            exir_ops.edge.et_vk.conv2d_q8ta_q8csw.default,
+            args=(
+                match.fp_input_node,
+                match.input_scales_node,
+                match.input_zeros_node,
+                match.weight_node,
+                weight_sums_node,
+                match.weight_scales_node,
+                match.bias_node,  # Add bias after weight_scales
+                [H, W],  # Pass kernel size information before stride
+                match.stride,
+                match.padding,
+                match.dilation,
+                match.groups,
+            ),
+        )
+
+    qconv_node.meta["val"] = match.output_node.meta["val"]
+    match.output_node.replace_all_uses_with(qconv_node)

--- a/backends/vulkan/patterns/quantized_linear.py
+++ b/backends/vulkan/patterns/quantized_linear.py
@@ -4,131 +4,143 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from functools import lru_cache
-from typing import Callable, List, Optional
+from typing import Optional
 
 import executorch.backends.vulkan.utils as utils
 
 import torch
 import torch.nn.functional as F
 
-from executorch.backends.transforms.utils import get_param_tensor, is_param_node
+from executorch.backends.transforms.utils import (
+    create_constant_placeholder,
+    get_param_tensor,
+)
 
 from executorch.backends.vulkan.patterns.pattern_registry import (
-    register_pattern_graph,
+    PatternMatch,
+    register_pattern_detector,
     register_pattern_replacement,
 )
 
-from executorch.exir import EdgeCompileConfig, ExportedProgram, to_edge
+from executorch.exir import ExportedProgram
 from executorch.exir.dialects._ops import ops as exir_ops
 
-from torch.export import export
-from torch.fx.passes.utils.matcher_utils import InternalMatch
-
-from torchao.quantization.granularity import PerGroup
-from torchao.quantization.quant_api import IntxWeightOnlyConfig, quantize_
-from torchao.utils import unwrap_tensor_subclass
+from torch.export.graph_signature import InputKind
 
 
-class TorchAOWeightOnlyQuantizedLinearPattern(torch.nn.Module):
-    """
-    Quantized linear pattern produced when quantizing linear layers using
-    `torchao.quantization.quant_api.quantize_()` with IntxWeightOnlyConfig.
-    """
+class QuantizedLinearMatch(PatternMatch):
+    def __init__(self, mm_node: torch.fx.Node) -> None:
+        self.anchor_node = mm_node
+        self.match_found = False
+        self.all_nodes = [self.anchor_node]
 
-    def __init__(
-        self,
-        in_features: int = 512,
-        out_features: int = 256,
-        bias: bool = False,
-        group_size: int = 64,
-        weight_bits: int = 4,
-        granularity_class: Optional[Callable] = None,
-    ) -> None:
-        super().__init__()
-        self.linear = torch.nn.Linear(in_features, out_features, bias=bias)
-        self.group_size = group_size
-        self.weight_bits = weight_bits
-
-        if self.weight_bits == 4:
-            # pyre-ignore[16]
-            self.weight_dtype = torch.int4
-        else:
-            self.weight_dtype = torch.int8
-
-        if granularity_class is not None:
-            self.quant_granularity = granularity_class(self.group_size)
-        else:
-            self.quant_granularity = PerGroup(self.group_size)
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return self.linear(x)
-
-    def apply_quantization(self):
-        q_config = IntxWeightOnlyConfig(
-            weight_dtype=self.weight_dtype,
-            granularity=self.quant_granularity,
+        const_node, arg_chain = utils.trace_args_until_placeholder(
+            self.anchor_node.args[1]
         )
-        quantize_(self, q_config)
-        unwrap_tensor_subclass(self)
-        return self
+
+        # mat2 is not a constant tensor - no match
+        if const_node is None:
+            return
+
+        dequantize_weight_node = None
+        # Search for a dequantize node in the arg chain of weight
+        for node in arg_chain:
+            if isinstance(node, torch.fx.Node) and utils.is_dequant_node(node):
+                dequantize_weight_node = node
+        # weight is not quantized - no match
+        if dequantize_weight_node is None:
+            return
+
+        self.weight_node = const_node
+        self.dequantize_weight_node = dequantize_weight_node
+        self.all_nodes.extend(arg_chain)
+
+        # By default, assume dequant node is from quantized_decomposed namespace
+        scales_arg_idx = 1
+        zeros_arg_idx = 2
+        # torchao dequantize has a different function schema than quantized_decomposed
+        if (
+            self.dequantize_weight_node.target
+            == exir_ops.edge.torchao.dequantize_affine.default
+        ):
+            scales_arg_idx = 2
+            zeros_arg_idx = 3
+
+        # Identify weight quantization parameter nodes
+        self.weight_scales_node, arg_chain = utils.trace_args_until_placeholder(
+            self.dequantize_weight_node.args[scales_arg_idx]
+        )
+        assert self.weight_scales_node is not None
+        self.all_nodes.extend(arg_chain)
+
+        self.weight_zeros_node, arg_chain = utils.trace_args_until_placeholder(
+            self.dequantize_weight_node.args[zeros_arg_idx]
+        )
+        assert self.weight_zeros_node is not None
+        self.all_nodes.extend(arg_chain)
+
+        # Identify output node
+        self.output_node = self.anchor_node
+
+        # Identify input node
+        self.fp_input_node, self.quantize_input_node, dq_node = (
+            utils.maybe_skip_q_dq_arg_chain(self.anchor_node.args[0])
+        )
+        assert self.fp_input_node is not None
+        self.all_nodes.append(self.fp_input_node)
+
+        # Identify bias node, if applicable
+        self.bias_node = None
+        if self.anchor_node.target == exir_ops.edge.aten.addmm.default:
+            self.bias_node, arg_chain = utils.trace_args_until_placeholder(
+                self.anchor_node.args[2]
+            )
+            assert self.bias_node is not None
+            self.all_nodes.extend(arg_chain)
+
+        # If input is not quantized, then we are done
+        if self.quantize_input_node is None:
+            self.match_found = True
+            return
+
+        self.input_scales_node = self.quantize_input_node.args[1]
+        self.input_zeros_node = self.quantize_input_node.args[2]
+
+        assert dq_node is not None
+        self.all_nodes.extend(
+            [
+                self.quantize_input_node,
+                dq_node,
+            ]
+        )
+
+        self.match_found = True
 
 
-@lru_cache(maxsize=None)
-@register_pattern_graph("torchao_wo_quantized_linear")
-def get_torchao_wo_quantized_linear_graphs() -> List[torch.fx.GraphModule]:
-    graphs = []
+linear_anchor_nodes = {
+    exir_ops.edge.aten.linear.default,
+    exir_ops.edge.aten.mm.default,
+    exir_ops.edge.aten.addmm.default,
+}
 
-    # Different configurations to test
-    configs = [
-        # gemv pattern
-        (1, 1, 128, 128, False, 64, 4, PerGroup),
-        # gemm pattern
-        (1, 8, 128, 128, False, 64, 4, PerGroup),
-    ]
 
-    for (
-        batch_size,
-        seq_len,
-        in_features,
-        out_features,
-        bias,
-        group_size,
-        weight_bits,
-        granularity_class,
-    ) in configs:
-        for dtype in [torch.float32]:
-            xs = []
-            xs.append(torch.randn(batch_size, seq_len, in_features, dtype=dtype))
-            if batch_size == 1:
-                xs.append(torch.randn(seq_len, in_features, dtype=dtype))
+@register_pattern_detector("quantized_linear")
+def find_quantized_linear_patterns(
+    node: torch.fx.Node,
+) -> Optional[QuantizedLinearMatch]:
+    if node.target not in linear_anchor_nodes:
+        return None
 
-            for x in xs:
-                # Create and quantize the pattern
-                pattern = TorchAOWeightOnlyQuantizedLinearPattern(
-                    in_features=in_features,
-                    out_features=out_features,
-                    bias=bias,
-                    group_size=group_size,
-                    weight_bits=weight_bits,
-                    granularity_class=granularity_class,
-                )
+    matched_pattern = QuantizedLinearMatch(node)
+    if matched_pattern.match_found:
+        return matched_pattern
 
-                # Apply quantization
-                pattern = pattern.apply_quantization()
+    return None
 
-                # Export the quantized pattern
-                edge = to_edge(
-                    export(
-                        pattern,
-                        (x,),
-                    ),
-                    compile_config=EdgeCompileConfig(_check_ir_validity=False),
-                )
-                gm = edge.exported_program().graph_module
-                graphs.append(gm)
 
-    return graphs
+##
+## Constant tensor manipulation
+##
 
 
 def pack_4bit_weight_tensor(inp: torch.Tensor) -> torch.Tensor:
@@ -192,117 +204,130 @@ def make_combined_scales_and_zeros_tensor(
     return torch.cat((scales_reshaped, zeros_scaled), dim=2)
 
 
-def identify_wo_quantized_linear_io_nodes(  # noqa: C901
+##
+## Pattern Replacement
+##
+
+
+def make_linear_q4ga_op(
     ep: ExportedProgram,
     graph_module: torch.fx.GraphModule,
-    match: InternalMatch,
-) -> Optional[List[torch.fx.Node]]:
-    dequant_node = None
-    # First, find the dequant node
-    for node in match.nodes_map.values():
-        if utils.is_dequant_node(node):
-            dequant_node = node
-            break
-
-    if dequant_node is None:
-        return None
-
-    quantized_weight = dequant_node.args[0]
-    quant_scales = dequant_node.args[2]
-    quant_zeros = dequant_node.args[3]
-
-    if not isinstance(quantized_weight, torch.fx.Node) or not is_param_node(
-        ep, quantized_weight
-    ):
-        return None
-    if not isinstance(quant_scales, torch.fx.Node) or not is_param_node(
-        ep, quant_scales
-    ):
-        return None
-    if not isinstance(quant_zeros, torch.fx.Node) or not is_param_node(ep, quant_zeros):
-        return None
-
-    input_nodes = match.placeholder_nodes
-    if len(input_nodes) != 4:
-        return None
-
-    in_tensor_node = None
-    for node in input_nodes:
-        if node not in dequant_node.args:
-            in_tensor_node = node
-            break
-
-    if in_tensor_node is None:
-        return None
-
-    output_nodes = match.returning_nodes
-
-    if len(output_nodes) != 1:
-        return None
-
-    out_tensor_node = output_nodes[0]
-    if not isinstance(out_tensor_node, torch.fx.Node):
-        return None
-
-    return [
-        in_tensor_node,
-        quantized_weight,
-        quant_scales,
-        quant_zeros,
-        out_tensor_node,
-    ]
-
-
-# wo = "weight only"
-@register_pattern_replacement("torchao_wo_quantized_linear")
-def create_wo_quantized_linear_custom_op(
-    ep: ExportedProgram,
-    graph_module: torch.fx.GraphModule,
-    match: InternalMatch,
+    match: QuantizedLinearMatch,
 ):
-    io_nodes = identify_wo_quantized_linear_io_nodes(ep, graph_module, match)
-    if io_nodes is None:
-        return
+    weight_tensor = get_param_tensor(ep, match.weight_node)
+    assert weight_tensor is not None
 
-    assert len(io_nodes) == 5
-    in_tensor, quantized_weight, quant_scales, quant_zeros, out_tensor = io_nodes
+    assert match.weight_scales_node is not None
+    weight_scales_tensor = get_param_tensor(ep, match.weight_scales_node)
+    assert weight_scales_tensor is not None
 
-    quantized_weight_tensor = get_param_tensor(ep, quantized_weight)
-    if not isinstance(quantized_weight_tensor, torch.Tensor):
-        return
-    packed_quantized_weight_tensor = pack_4bit_weight_tensor(quantized_weight_tensor)
+    assert match.weight_zeros_node is not None
+    weight_zeros_tensor = get_param_tensor(ep, match.weight_zeros_node)
+    assert weight_zeros_tensor is not None
+
+    packed_quantized_weight_tensor = pack_4bit_weight_tensor(weight_tensor)
     utils.update_program_state_dict(
-        ep, quantized_weight.name, packed_quantized_weight_tensor
+        ep, match.weight_node.name, packed_quantized_weight_tensor
     )
-    quantized_weight.meta["val"] = quantized_weight.meta["val"][:, ::2].to(torch.uint8)
+    # Need to make sure corresponding FakeTensor has same size
+    match.weight_node.meta["val"] = match.weight_node.meta["val"][:, ::2].to(
+        torch.uint8
+    )
 
-    quant_scales_tensor = get_param_tensor(ep, quant_scales)
-    quant_zeros_tensor = get_param_tensor(ep, quant_zeros)
-
-    assert quantized_weight_tensor is not None
-    assert quant_scales_tensor is not None
-    assert quant_zeros_tensor is not None
-
-    group_size = quantized_weight_tensor.shape[1] // quant_scales_tensor.shape[1]
+    group_size = weight_tensor.shape[1] // weight_scales_tensor.shape[1]
 
     combined_scales_zeros_tensor = make_combined_scales_and_zeros_tensor(
-        quant_scales_tensor, quant_zeros_tensor
+        weight_scales_tensor, weight_zeros_tensor
     )
 
-    combined_scales_zeros_name = f"{quantized_weight.name}_scales_zeros"
+    combined_scales_zeros_name = f"{match.weight_node.name}_scales_zeros"
     graph_module.register_parameter(
         combined_scales_zeros_name, torch.nn.Parameter(combined_scales_zeros_tensor)
     )
 
-    with graph_module.graph.inserting_before(out_tensor):
+    with graph_module.graph.inserting_before(match.output_node):
         combined_scales_zeros = graph_module.graph.get_attr(combined_scales_zeros_name)
-        wo_qlinear = graph_module.graph.create_node(
+        linear_q4ga_node = graph_module.graph.create_node(
             "call_function",
             exir_ops.edge.et_vk.linear_weight_int4.default,
-            args=(in_tensor, quantized_weight, group_size, combined_scales_zeros, 1),
+            args=(
+                match.fp_input_node,
+                match.weight_node,
+                group_size,
+                combined_scales_zeros,
+                1,
+            ),
         )
 
-    if hasattr(out_tensor, "meta") and "val" in out_tensor.meta:
-        wo_qlinear.meta["val"] = out_tensor.meta["val"]
+    linear_q4ga_node.meta["val"] = match.output_node.meta["val"]
+    match.output_node.replace_all_uses_with(linear_q4ga_node)
 
-    out_tensor.replace_all_uses_with(wo_qlinear)
+
+def make_linear_q8ta_q8csw_custom_op(
+    ep: ExportedProgram,
+    graph_module: torch.fx.GraphModule,
+    match: QuantizedLinearMatch,
+):
+    weight_tensor = get_param_tensor(ep, match.weight_node)
+    assert weight_tensor is not None
+
+    assert match.weight_scales_node is not None
+    weight_scales_tensor = get_param_tensor(ep, match.weight_scales_node)
+    assert weight_scales_tensor is not None
+
+    assert match.weight_zeros_node is not None
+    weight_zeros_tensor = get_param_tensor(ep, match.weight_zeros_node)
+    assert weight_zeros_tensor is not None
+
+    # Transpose the weight matrix
+    weight_transposed = weight_tensor.transpose(0, 1).contiguous()
+    utils.update_program_state_dict(ep, match.weight_node.name, weight_transposed)
+    weight_tensor = weight_transposed
+    # Need to make sure the fake tensor matches the updated tensor's properties
+    match.weight_node.meta["val"] = match.weight_node.meta["val"].transpose(0, 1)
+
+    first_graph_node = list(graph_module.graph.nodes)[0]
+    with graph_module.graph.inserting_before(first_graph_node):
+        qweight_tensor_name = utils.get_tensor_name(ep, match.weight_node)
+        # Pre-compute the weight sums which are needed to apply activation zero point
+        # when using integer accumulation.
+        sum_per_output_channel = (
+            weight_transposed.sum(dim=0).to(torch.float).contiguous()
+        )
+        sums_name = qweight_tensor_name + "_sums"
+        weight_sums_node = create_constant_placeholder(
+            exp_program=ep,
+            graph=graph_module.graph,
+            kind=InputKind.CONSTANT_TENSOR,
+            name=sums_name,
+            data=sum_per_output_channel,
+        )
+
+    with graph_module.graph.inserting_before(match.output_node):
+        qlinear_node = graph_module.graph.create_node(
+            "call_function",
+            exir_ops.edge.et_vk.linear_q8ta_q8csw.default,
+            args=(
+                match.fp_input_node,
+                match.input_scales_node,
+                match.input_zeros_node,
+                match.weight_node,
+                weight_sums_node,
+                match.weight_scales_node,
+            ),
+        )
+
+    qlinear_node.meta["val"] = match.output_node.meta["val"]
+    match.output_node.replace_all_uses_with(qlinear_node)
+
+
+@register_pattern_replacement("quantized_linear")
+def replace_quantized_linear_patterns(
+    ep: ExportedProgram,
+    graph_module: torch.fx.GraphModule,
+    match: QuantizedLinearMatch,
+):
+    if match.quantize_input_node is None:
+        make_linear_q4ga_op(ep, graph_module, match)
+    else:
+        make_linear_q8ta_q8csw_custom_op(ep, graph_module, match)

--- a/backends/vulkan/test/TARGETS
+++ b/backends/vulkan/test/TARGETS
@@ -14,6 +14,7 @@ python_unittest(
         "//executorch/kernels/portable:custom_ops_generated_lib",
     ],
     deps = [
+        ":test_utils",
         "//caffe2:torch",
         "//executorch/backends/transforms:convert_dtype_pass",
         "//executorch/backends/vulkan:vulkan_preprocess",
@@ -67,4 +68,24 @@ runtime.python_library(
         "//executorch/backends/vulkan/partitioner:vulkan_partitioner",
         "//executorch/backends/vulkan:vulkan_preprocess",
     ]
+)
+
+runtime.python_library(
+    name = "test_utils",
+    srcs = [
+        "utils.py",
+    ],
+    deps = [
+        "//caffe2:torch",
+        "//executorch/backends/vulkan:vulkan_preprocess",
+        "//executorch/backends/vulkan/partitioner:vulkan_partitioner",
+        "//executorch/backends/xnnpack:xnnpack_preprocess",
+        "//executorch/backends/xnnpack/quantizer:xnnpack_quantizer",
+        "//executorch/backends/xnnpack/partition:xnnpack_partitioner",
+        "//executorch/devtools:lib",
+        "//executorch/devtools/bundled_program/serialize:lib",
+        "//executorch/exir:lib",
+        "//executorch/extension/pybindings:portable_lib",  # @manual
+        "//executorch/extension/pytree:pylib",
+    ],
 )

--- a/backends/vulkan/test/test_vulkan_delegate.py
+++ b/backends/vulkan/test/test_vulkan_delegate.py
@@ -10,6 +10,8 @@ import ctypes
 import unittest
 from typing import Tuple
 
+import executorch.backends.vulkan.test.utils as test_utils
+
 import torch
 
 from executorch.backends.transforms.convert_dtype_pass import I64toI32
@@ -18,12 +20,23 @@ from executorch.backends.vulkan.partitioner.vulkan_partitioner import VulkanPart
 
 from executorch.backends.vulkan.vulkan_preprocess import VulkanBackend
 
+from executorch.backends.xnnpack.quantizer.xnnpack_quantizer import (
+    get_symmetric_quantization_config,
+    XNNPACKQuantizer,
+)
+
 from executorch.exir import (
     EdgeCompileConfig,
     EdgeProgramManager,
     ExecutorchProgramManager,
+    to_edge_transform_and_lower,
 )
-from torch.export import Dim, export, export_for_training, ExportedProgram
+from executorch.extension.pybindings.portable_lib import (  # @manual
+    _load_for_executorch_from_buffer,
+)
+from executorch.extension.pytree import tree_flatten
+from torch.export import Dim, export, ExportedProgram
+
 from torchao.quantization.granularity import PerGroup
 
 from torchao.quantization.pt2e.quantize_pt2e import convert_pt2e, prepare_pt2e
@@ -32,14 +45,10 @@ from torchao.quantization.pt2e.quantizer import Quantizer
 from torchao.quantization.quant_api import IntxWeightOnlyConfig, quantize_
 from torchao.utils import unwrap_tensor_subclass
 
-ctypes.CDLL("libvulkan.so.1")
-
-
-from executorch.exir import to_edge_transform_and_lower
-from executorch.extension.pybindings.portable_lib import (  # @manual
-    _load_for_executorch_from_buffer,
-)
-from executorch.extension.pytree import tree_flatten
+try:
+    ctypes.CDLL("libvulkan.so.1")
+except:
+    pass
 
 
 def lower_module(
@@ -83,7 +92,7 @@ def quantize_and_lower_module(
         _skip_dim_order=False,  # TODO(T182928844): Delegate dim order op to backend.
     )
 
-    program = export_for_training(
+    program = export(
         model, sample_inputs, dynamic_shapes=dynamic_shapes, strict=True
     ).module()
 
@@ -94,6 +103,14 @@ def quantize_and_lower_module(
     program = convert_pt2e(program)
 
     program = export(program, sample_inputs, dynamic_shapes=dynamic_shapes)
+
+    print(program.graph_module.graph)
+    # test = to_edge(
+    #     program,
+    #     compile_config=EdgeCompileConfig(_check_ir_validity=False),
+    # )
+    # print(program.exported_program().graph_module)
+    # raise Exception("stop")
 
     edge_program = to_edge_transform_and_lower(
         program,
@@ -129,37 +146,47 @@ class TestVulkanBackend(unittest.TestCase):
             # Multiple outputs executor always returns tuple, even if there is one output
             self.assertTrue(len(ref_output) == len(model_output))
             if first_output_only:
-                self.assertTrue(
-                    torch.allclose(
-                        model_output[0],
-                        ref_output[0],
-                        atol=atol,
-                        rtol=rtol,
-                        equal_nan=equal_nan,
-                    )
-                )
-            else:
-                for i in range(len(ref_output)):
-                    self.assertTrue(
-                        torch.allclose(
-                            model_output[i],
-                            ref_output[i],
-                            atol=atol,
-                            rtol=rtol,
-                            equal_nan=equal_nan,
-                        )
-                    )
-        else:
-            # If one output, eager returns tensor while executor tuple of size 1
-            self.assertTrue(
-                torch.allclose(
+                result = torch.allclose(
                     model_output[0],
-                    ref_output,
+                    ref_output[0],
                     atol=atol,
                     rtol=rtol,
                     equal_nan=equal_nan,
                 )
+                if not result:
+                    test_utils.print_tensor_comparison_errors(
+                        model_output[0], ref_output[0], atol, rtol
+                    )
+                self.assertTrue(result)
+            else:
+                for i in range(len(ref_output)):
+                    result = torch.allclose(
+                        model_output[i],
+                        ref_output[i],
+                        atol=atol,
+                        rtol=rtol,
+                        equal_nan=equal_nan,
+                    )
+                    if not result:
+                        print(f"\n=== Output {i} comparison failed ===")
+                        test_utils.print_tensor_comparison_errors(
+                            model_output[i], ref_output[i], atol, rtol
+                        )
+                    self.assertTrue(result)
+        else:
+            # If one output, eager returns tensor while executor tuple of size 1
+            result = torch.allclose(
+                model_output[0],
+                ref_output,
+                atol=atol,
+                rtol=rtol,
+                equal_nan=equal_nan,
             )
+            if not result:
+                test_utils.print_tensor_comparison_errors(
+                    model_output[0], ref_output, atol, rtol
+                )
+            self.assertTrue(result)
 
     def check_no_delegation(self, et_program: ExecutorchProgramManager):
         self.assertEqual(
@@ -2387,4 +2414,169 @@ class TestVulkanBackend(unittest.TestCase):
         # Use higher tolerance since quantization introduces some error
         self.lower_module_and_test_output(
             quantized_linear_module_gemm, sample_inputs_gemm, atol=1e-2, rtol=1e-2
+        )
+
+    def test_vulkan_backend_xnnpack_pt2e_quantized_linear_sequence(self):
+        """
+        Test a sequence of linear layers quantized with XNNPACK quantization config.
+        This test creates a module with multiple linear layers in sequence and applies
+        XNNPACK symmetric quantization to test the quantized model execution.
+        """
+
+        import executorch.backends.vulkan.test.utils as test_utils
+
+        class LinearSequenceModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear1 = torch.nn.Linear(128, 64, bias=False)
+                self.linear2 = torch.nn.Linear(64, 32, bias=False)
+                self.linear3 = torch.nn.Linear(32, 16, bias=False)
+
+                MAX = 0.75
+                MIN = -0.25
+                self.linear1.weight.data = test_utils.random_uniform_tensor(
+                    self.linear1.weight.shape, MIN, MAX
+                )
+                self.linear2.weight.data = test_utils.random_uniform_tensor(
+                    self.linear2.weight.shape, MIN, MAX
+                )
+                self.linear3.weight.data = test_utils.random_uniform_tensor(
+                    self.linear3.weight.shape, MIN, MAX
+                )
+
+            def forward(self, x):
+                x = self.linear1(x)
+                x = self.linear2(x)
+                x = self.linear3(x)
+                return x
+
+        # Create the module
+        linear_sequence_module = LinearSequenceModule()
+
+        M = 32
+        # Create sample inputs
+        sample_inputs = (
+            (
+                test_utils.random_uniform_tensor(
+                    (M, linear_sequence_module.linear1.in_features),
+                    -0.25,
+                    0.75,
+                )
+            ),
+        )
+
+        # Create XNNPACK quantizer with symmetric quantization config
+        quantizer = XNNPACKQuantizer()
+        operator_config = get_symmetric_quantization_config(
+            is_per_channel=True,
+            is_dynamic=False,
+        )
+        quantizer.set_global(operator_config)
+
+        # Test the quantized module using the existing quantize_and_lower_module function
+        # Use higher tolerance since quantization introduces some error
+        edge_program = quantize_and_lower_module(
+            linear_sequence_module, sample_inputs, quantizer
+        )
+
+        et_program = edge_program.to_executorch()
+        self.check_vk_delegation(et_program)
+
+        self.run_delegated_model_and_check_output(
+            et_program,
+            linear_sequence_module,
+            sample_inputs,
+            atol=1e-2,
+            rtol=1e-1,
+        )
+
+    def test_vulkan_backend_xnnpack_pt2e_quantized_conv_sequence(self):
+        """
+        Test a sequence of convolution layers quantized with PT2E quantization.
+        This test creates a module with multiple Conv2d layers in sequence and applies
+        XNNPACK symmetric quantization to test the quantized model execution.
+        Similar to the linear sequence test but using convolution layers.
+        """
+
+        import executorch.backends.vulkan.test.utils as test_utils
+
+        class ConvSequenceModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv1 = torch.nn.Conv2d(
+                    in_channels=3,
+                    out_channels=16,
+                    kernel_size=3,
+                    padding=1,
+                    bias=False,
+                )
+                self.conv2 = torch.nn.Conv2d(
+                    in_channels=16,
+                    out_channels=32,
+                    kernel_size=3,
+                    padding=1,
+                    bias=False,
+                )
+                self.conv3 = torch.nn.Conv2d(
+                    in_channels=32,
+                    out_channels=64,
+                    kernel_size=3,
+                    padding=1,
+                    bias=False,
+                )
+
+                MAX = 0.75
+                MIN = -0.25
+                self.conv1.weight.data = test_utils.random_uniform_tensor(
+                    self.conv1.weight.shape, MIN, MAX
+                )
+                self.conv2.weight.data = test_utils.random_uniform_tensor(
+                    self.conv2.weight.shape, MIN, MAX
+                )
+                self.conv3.weight.data = test_utils.random_uniform_tensor(
+                    self.conv3.weight.shape, MIN, MAX
+                )
+
+            def forward(self, x):
+                x = self.conv1(x)
+                x = self.conv2(x)
+                x = self.conv3(x)
+                return x
+
+        # Create the module
+        conv_sequence_module = ConvSequenceModule()
+
+        input_tensor = test_utils.random_uniform_tensor(
+            (1, 3, 32, 32),
+            -0.25,
+            0.75,
+        )
+
+        input_tensor = torch.ones((1, 3, 32, 32), dtype=torch.float32)
+        # Create sample inputs
+        sample_inputs = (input_tensor,)
+
+        # Create XNNPACK quantizer with symmetric quantization config
+        quantizer = XNNPACKQuantizer()
+        operator_config = get_symmetric_quantization_config(
+            is_per_channel=True,
+            is_dynamic=False,
+        )
+        quantizer.set_global(operator_config)
+
+        # Test the quantized module using the existing quantize_and_lower_module function
+        # Use higher tolerance since quantization introduces some error
+        edge_program = quantize_and_lower_module(
+            conv_sequence_module, sample_inputs, quantizer
+        )
+
+        et_program = edge_program.to_executorch()
+        self.check_vk_delegation(et_program)
+
+        self.run_delegated_model_and_check_output(
+            et_program,
+            conv_sequence_module,
+            sample_inputs,
+            atol=1e-2,
+            rtol=1e-1,
         )

--- a/backends/vulkan/vulkan_preprocess.py
+++ b/backends/vulkan/vulkan_preprocess.py
@@ -19,6 +19,7 @@ from executorch.backends.transforms.view_copy_to_squeeze_unsqueeze import (
     ViewCopyToSqueezeUnsqueezePass,
 )
 from executorch.backends.vulkan._passes import (
+    FoldQDQPass,
     FuseQuantizedOpsTransform,
     insert_prepack_nodes,
     RemoveLocalScalarDenseOpsTransform,
@@ -157,6 +158,7 @@ class VulkanBackend(BackendDetails):
                 RemoveRedundantOpsTransform(),
                 AddmmToLinearTransform(),
                 FuseQuantizedOpsTransform(program),
+                FoldQDQPass(program),
                 SqueezeUnsqueezeInputs(),
                 FuseViewCopyTransform(),
                 ViewCopyToSqueezeUnsqueezePass(),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #13812
* #13811
* #13810
* #13809

As title. Introduce fusion patterns to enable fusing quantized convolution and linear graph patterns into a custom op.

## Changes

Introduce the concept of using custom pattern detection functions to detect graph patterns rather than solely relying on SubgraphMatcher. The issue with SubgraphMatcher is that a large number of graph patterns may need to be exported to obtain variants for different combinations of decompositions/quantization workflows. Having a custom detection function improves maintainability.

Implement detection + replacement functions for quantized linear and quantized conv2d.

Differential Revision: [D81323425](https://our.internmc.facebook.com/intern/diff/D81323425/)