### PR TITLE
D81187339: [Cadence] Add backend-agnostic implementation for quantized_add

### DIFF
--- a/backends/cadence/aot/ref_implementations.py
+++ b/backends/cadence/aot/ref_implementations.py
@@ -48,7 +48,13 @@ def quantize_per_tensor(
             is already provided.
         - dtype (torch.dtype): The type of the output tensor
     """
-    supported_quant_types = [torch.int8, torch.int16, torch.int32]
+    supported_quant_types = [
+        torch.int8,
+        torch.int16,
+        torch.int32,
+        torch.uint8,
+        torch.uint16,
+    ]
     if dtype not in supported_quant_types:
         raise ValueError(
             f"Unsupported dtype to quantize to. Supported dtypes must be one of {supported_quant_types}"
@@ -110,6 +116,65 @@ def dequantize_per_tensor(
         input_tensor = input_tensor.to(torch.int32)
 
     return (input_tensor - zero_point).to(dtype) * scale
+
+
+@impl(m, "quantized_add")
+def quantized_add(
+    X: torch.Tensor,
+    X_scale: torch.Tensor,
+    X_zero_point: torch.Tensor,
+    Y: torch.Tensor,
+    Y_scale: torch.Tensor,
+    Y_zero_point: torch.Tensor,
+    out_scale: float,
+    out_zero_point: int,
+) -> torch.Tensor:
+    """
+    Sums up two quantized tensors and returns another quantized tensor. The intuition
+    is that we want dequant(out) ~= dequant(X) + dequant(Y)
+
+    If we do that math, we get
+    out_scale(out - out_zero_point) = X_scale(X - X_zero_point) + Y_scale(Y - Y_zero_point)
+
+    Rearranging, we get
+    out = (X_scale(X - X_zero_point) + Y_scale(Y - Y_zero_point)) / out_scale + out_zero_point
+
+    Args:
+        - X (Tensor): The first operand
+        - X_scale (Tensor): The ratio between the sizes of X's floating point and quantized
+            ranges
+        - X_zero_point (Tensor): The quantized mapping of zero for X
+        - Y (Tensor): The second operand
+        - Y_scale (Tensor): The ratio between the sizes of Y's floating point and quantized
+            ranges
+        - Y_zero_point (Tensor): The quantized mapping of zero for Y
+        - out_scale (float): The ratio between the sizes of the output's floating point and
+            quantized ranges
+        - out_zero_point (int): The quantized mapping of zero for the output
+    """
+    supported_dtypes = [torch.int8, torch.uint8]
+    if X.dtype != Y.dtype:
+        raise ValueError("X and Y dtypes need to match")
+
+    dtype = X.dtype
+    if dtype not in supported_dtypes:
+        raise ValueError(
+            f"X and Y dtypes need to be in {supported_dtypes}. Got {dtype}"
+        )
+
+    if dtype == torch.uint8:
+        X = X.to(torch.int8)
+        Y = Y.to(torch.int8)
+
+    # TODO(agrebenisan): This should be done in fixed point arithmetic, but to match the quantized_add_out.cpp
+    # reference implementation, we'll do it in floating point.
+    dequant_X = X_scale * (X - X_zero_point)
+    dequant_Y = Y_scale * (Y - Y_zero_point)
+
+    # q_min/q_max are unused args
+    return quantize_per_tensor(
+        dequant_X + dequant_Y, out_scale, out_zero_point, -128, 127, dtype
+    )
 
 
 @impl(m, "requantize")


### PR DESCRIPTION
Summary: Part of an ongoing task to provide backend-agnostic implementations for all of the cadence custom ops.

Differential Revision: D81341103
