### PR TITLE
NXP backend: Fix shared quantization bugs.

### DIFF
--- a/backends/nxp/backend/ir/converter/node_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converter.py
@@ -132,13 +132,8 @@ class NodeConverter(ABC):
             # Some exotic operator (only consumer or only produces)
             return True
 
-        pre_node = node.prev
-        post_node = node.next
-
-        if pre_node.name == node.all_input_nodes[0] and post_node.name == node.users[0]:
-            raise RuntimeError(
-                "Prev & next nodes are not the same as inputs and outputs."
-            )
+        pre_node = node.all_input_nodes[0]
+        post_node = list(node.users)[0]
 
         if _is_dequant_node(pre_node) and _is_quant_node(post_node):
             # Node is quantized

--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/convolution_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/convolution_converter.py
@@ -263,7 +263,7 @@ class ConvolutionConverter(NodeConverter):
                 )
 
             b = self.builder.create_zeros_tensor(
-                [output_channels], "zero_bias", bias_type, True
+                [output_channels], "zero_bias", bias_type, False
             )
 
             # Compute scale and zero point for bias tensor


### PR DESCRIPTION
### Summary
Fix 2 bugs related to quantization parameters that are shared between multiple tensors/nodes:
- Turn off bias tensor reuse in Convolution converter
- Fix _has_shared_q_params_if_quantized in Node converter

### Test plan
No direct unit tests are provided. Correct functionality is tested by all tests with quantized nodes.

cc @robert-kalmar @roman-janik-nxp @StrycekSimon @jirioc
