### PR TITLE
                  Arm backend: Skip int operation tests as for FP profile

### DIFF
--- a/backends/arm/test/ops/test_embedding.py
+++ b/backends/arm/test/ops/test_embedding.py
@@ -6,6 +6,7 @@
 
 from typing import Tuple
 
+import pytest
 import torch
 from executorch.backends.arm._passes import InsertCastForOpsWithInt64InputPass
 
@@ -57,6 +58,7 @@ test_input: dict[input_params] = {
 }
 
 
+@pytest.mark.skip(reason="MLETORCH-1274 Improve data type checks during partitioning")
 @common.parametrize("test_input", test_input)
 def test_embedding_tosa_FP(test_input: input_params):
     op = Embedding()
@@ -87,6 +89,7 @@ def test_embedding_tosa_INT(test_input: input_params):
     pipeline.run()
 
 
+@pytest.mark.skip("reason=MLETORCH-1274 Improve data type checks during partitioning")
 @common.parametrize("test_input", test_input)
 @common.SkipIfNoModelConverter
 def test_embedding_vgf_FP(test_input: input_params):

--- a/backends/arm/test/ops/test_eye.py
+++ b/backends/arm/test/ops/test_eye.py
@@ -3,6 +3,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import pytest
 import torch
 from executorch.backends.arm.test import common
 from executorch.backends.arm.test.tester.test_pipeline import (
@@ -48,6 +49,9 @@ class EyeAdd(torch.nn.Module):
     }
 
 
+# skip test since int32 isn't support on FP profile
+# "int32_int32": "view/RESHAPE of integer tensor is not supported for +FP profile"
+@pytest.mark.skip(reason="MLETORCH-1274 Improve data type checks during partitioning")
 @common.parametrize("test_data", EyeAdd.test_data)
 def test_eye_tosa_FP(test_data: test_data_t):
     input_data, init_data = test_data
@@ -99,6 +103,9 @@ def test_eye_u85_INT(test_data: test_data_t):
     pipeline.run()
 
 
+# skip since int32 isn't support on FP profile
+# "int32_int32": "view/RESHAPE of integer tensor is not supported for +FP profile"
+@pytest.mark.skip(reason="MLETORCH-1274 Improve data type checks during partitioning")
 @common.parametrize(
     "test_data",
     EyeAdd.test_data,

--- a/backends/arm/test/ops/test_mul.py
+++ b/backends/arm/test/ops/test_mul.py
@@ -129,7 +129,17 @@ def test_mul_tensor_tosa_FP_diff_input_ranks(test_data: torch.Tensor):
     pipeline.run()
 
 
-@common.parametrize("test_data", test_data_suite_int32)
+# MLETORCH-1274 Improve data type checks during partitioning
+# view/RESHAPE of integer tensor is not supported for +FP profile which causes issues
+# with view_copy (RESHAPE) which isn't supported in FP so removing the int32 tests
+# to allow for the dtype validation patches to land.
+# filter out the 'op_mul_rank4_randn_int32' only
+test_data_int32_without_broadcasting = {
+    k: v for k, v in test_data_suite_int32.items() if k != "op_mul_rank4_randn_int32"
+}
+
+
+@common.parametrize("test_data", test_data_int32_without_broadcasting)
 def test_mul_tensor_tosa_FP_int32(test_data: torch.Tensor):
     pipeline = TosaPipelineFP[input_t1](
         Mul(),
@@ -228,8 +238,14 @@ def test_mul_tensor_u85_INT_int32(test_data: torch.Tensor):
     pipeline.run()
 
 
+# view/RESHAPE of integer tensor is not supported for +FP profile which causes issues
+# with view_copy (RESHAPE) which isn't supported in FP so removing the int32 tests
+# to allow for the dtype validation patches to land.
+
+
 @common.parametrize(
-    "test_data", test_data_suite | test_data_suite_2 | test_data_suite_int32
+    "test_data",
+    test_data_suite | test_data_suite_2 | test_data_int32_without_broadcasting,
 )
 @common.SkipIfNoModelConverter
 def test_mul_tensor_vgf_FP(test_data: torch.Tensor):

--- a/backends/arm/test/ops/test_scalars.py
+++ b/backends/arm/test/ops/test_scalars.py
@@ -417,6 +417,9 @@ def test_div_scalar_u85_INT():
 
 
 # SHIFT ETHOS-U ------------------------------------------------------
+@pytest.mark.skip(
+    reason="integer operations (shift and sub) are not supported on FP profile"
+)
 def test_bitwise_right_shift_tensor_tosa_FP_inplace():
     pipeline = TosaPipelineFP[input_t1](
         ShiftInplaceSub(),


### PR DESCRIPTION
### Summary
Switching to TOSA 1.0 the FP profile doesn't support int (as the 0.80 MI profile did). The test was not updated to reflect that, so skip them for op argument validation patches to land.

### Test plan
Tested through unit tests.

cc @digantdesai @freddan80 @zingo @oscarandersson8218