### PR TITLE
Del redundant-static-def in executorch/schema/extended_header.cpp +2

### DIFF
--- a/schema/extended_header.cpp
+++ b/schema/extended_header.cpp
@@ -91,8 +91,5 @@ uint64_t GetUInt64LE(const uint8_t* data) {
   };
 }
 
-// Define storage for the static.
-constexpr char ExtendedHeader::kMagic[kMagicSize];
-
 } // namespace runtime
 } // namespace executorch


### PR DESCRIPTION
Summary:
LLVM has a warning `-Wdeprecated-redundant-constexpr-static-def` which raises the warning:

> warning: out-of-line definition of constexpr static data member is redundant in C++17 and is deprecated

Since we are now on C++20, we can remove the out-of-line definition of constexpr static data members. This diff does so.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Differential Revision: D81359733


