### PR TITLE
Update Neutron Converter

### DIFF
--- a/backends/nxp/TARGETS
+++ b/backends/nxp/TARGETS
@@ -50,7 +50,7 @@ python_library(
     name = "neutron_sdk",
     srcs = glob(["backend/**/*.py"]),
     deps = [
-       "fbsource//third-party/pypi/neutron_convertor_SDK_25_03:neutron_convertor_SDK_25_03",
+       "fbsource//third-party/pypi/neutron_converter:neutron_converter",
     ],
 )
 


### PR DESCRIPTION
Summary:
allow-large-files

Newest update released, bumping version.

Note, for some reason NXP has the full qualifier like

neutron_converter_SDK_25_06.neutron_converter

so we have to update the test.

Differential Revision: D80261684
