### PR TITLE
Bump tokenizers to 4ed91cc

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -27,7 +27,7 @@
 	url = https://github.com/google/pthreadpool.git
 [submodule "extension/llm/tokenizers"]
 	path = extension/llm/tokenizers
-	url = https://github.com/pytorch-labs/tokenizers.git
+	url = https://github.com/meta-pytorch/tokenizers.git
 [submodule "kernels/optimized/third-party/eigen"]
 	path = kernels/optimized/third-party/eigen
 	url = https://gitlab.com/libeigen/eigen.git


### PR DESCRIPTION
### Summary
Update the tokenizers dependency to 4ed91cc to pick up the Windows changes. Note that this also involves updating the submodule URL, as it's been recently migrated from pytorch-labs to meta-pytorch.

### Test plan
CI