### PR TITLE
Add backend option setter to the dynamic shim

### DIFF
--- a/backends/xnnpack/runtime/XNNPACKBackend.h
+++ b/backends/xnnpack/runtime/XNNPACKBackend.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <executorch/runtime/platform/compiler.h>
-
 namespace executorch::backends::xnnpack {
 /// The key for the backend. This is used to register the backend, check
 /// availability, and get/set options.

--- a/backends/xnnpack/targets.bzl
+++ b/backends/xnnpack/targets.bzl
@@ -73,3 +73,13 @@ def define_common_targets():
             # @lint-ignore BUCKLINT: Avoid `link_whole=True` (https://fburl.com/avoid-link-whole)
             link_whole = True,
         )
+    
+    runtime.cxx_library(
+        name = "xnnpack_interface",
+        visibility = [
+            "@EXECUTORCH_CLIENTS",
+        ],
+        exported_headers = [
+            "runtime/XNNPACKBackend.h",
+        ],
+    )


### PR DESCRIPTION
Summary:
Add a new function to the dynamic shim interface to set runtime backend options with integer values. I've added this as a top-level function, intended to be loaded with dlsym, as opposed to on the DynamicShim class, as it needs to be set pre-model load.

Long-term, the whole shim interface needs to be refactored and we should likely have some sort of runtime abstraction to include this. As such, I'm not worrying about providing a full set of methods to get/set all option types.

I've also exposed XNNPACKBackend.h through a new buck target - xnnpack_interface. This is so that users don't have to hard-code keys. I might refactor this in the future, as it would be nice to have it be clearer what this header/target is intended for.

Differential Revision: D79314050


