### PR TITLE
Arm backend: Refactor check_platform_support

### DIFF
--- a/backends/arm/scripts/utils.sh
+++ b/backends/arm/scripts/utils.sh
@@ -56,3 +56,37 @@ function patch_repo() {
     echo -e "[${FUNCNAME[0]}] Patched ${name} @ $(git describe --all --long 2> /dev/null) in ${repo_dir} dir.\n"
     popd
 }
+
+function check_platform_support() {
+    # No args
+    # Exits with return code 1 if the platform is unsupported
+
+    # Make sure we are on a supported platform
+    if [[ "${ARCH}" != "x86_64" ]] && [[ "${ARCH}" != "aarch64" ]] \
+        && [[ "${ARCH}" != "arm64" ]]; then
+        echo "[main] Error: only x86-64 & aarch64 architecture is supported for now!"
+        exit 1
+    fi
+}
+
+function check_os_support() {
+    # No args
+    # Exits with return code 1 if invalid combination of platform and os
+
+    # Check valid combinations of OS and platform
+
+    # Linux on x86_64
+    if [[ "${ARCH}" == "x86_64" ]] && [[ "${OS}" != "Linux" ]]; then
+        echo "Error: Only Linux is supported on x86_64"
+        exit 1
+    fi
+
+    # Linux on arm64/aarch64
+    # Darwin on arm64/aarch64
+    if [[ "${ARCH}" == "aarch64" ]] || [[ "${ARCH}" == "arm64" ]]; then
+        if [[ "${OS}" != "Darwin" ]] || [[ "${OS}" != "Linux" ]]; then
+            echo "Error: Only Linux and Darwin are supported on arm64"
+            exit 1
+        fi
+    fi
+}

--- a/examples/arm/setup.sh
+++ b/examples/arm/setup.sh
@@ -347,15 +347,6 @@ function create_setup_path(){
     fi
 }
 
-function check_platform_support() {
-    # Make sure we are on a supported platform
-    if [[ "${ARCH}" != "x86_64" ]] && [[ "${ARCH}" != "aarch64" ]] \
-        && [[ "${ARCH}" != "arm64" ]]; then
-        echo "[main] Error: only x86-64 & aarch64 architecture is supported for now!"
-        exit 1
-    fi
-}
-
 
 ########
 ### main
@@ -367,9 +358,13 @@ if [[ $is_script_sourced -eq 0 ]]; then
 
     check_options "$@"
 
+    # Import utils
+    source $et_dir/backends/arm/scripts/utils.sh
     source $et_dir/backends/arm/scripts/fvp_utils.sh
 
+    echo "[main]: Checking platform and os"
     check_platform_support
+    check_os_support
 
     cd "${script_dir}"
 
@@ -386,9 +381,6 @@ if [[ $is_script_sourced -eq 0 ]]; then
     echo "enable-vulkan-sdk=${enable_vulkan_sdk}"
     echo "enable-vela=${enable_vela}"
     echo "mlsdk-manifest-url=${mlsdk_manifest_url}"
-
-    # Import utils
-    source $et_dir/backends/arm/scripts/utils.sh
 
     # Select appropriate toolchain
     select_toolchain


### PR DESCRIPTION
Move check_platform_support() to utils.sh file since it will be used by other scripts in coming commits.

Add check_os_support() in utils.sh and call it from main.

Change-Id: Ia9da3ece1e3f561a042f6796c0741f97b11c6f4c
Signed-off-by: per.held@arm.com
