### PR TITLE
Arm backend: Enable capture of debug information during TOSA serialization

### DIFF
--- a/backends/arm/operators/node_visitor.py
+++ b/backends/arm/operators/node_visitor.py
@@ -5,10 +5,11 @@
 
 # pyre-unsafe
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import torch
 
+from executorch.backends.arm.debug.schema import DebugHook
 from executorch.backends.arm.tosa_mapping import TosaArg
 from executorch.backends.arm.tosa_specification import TosaSpecification
 from torch.export import ExportedProgram
@@ -29,9 +30,38 @@ class NodeVisitor:
         TosaSpecification.create_from_string("TOSA-1.0+FP"),
     ]
 
-    def __init__(self, exported_program: ExportedProgram, tosa_spec: TosaSpecification):
+    def __init__(
+        self,
+        exported_program: ExportedProgram,
+        tosa_spec: TosaSpecification,
+        debug_hook: Optional[DebugHook] = None,
+    ):
         self._exported_program = exported_program
         self.tosa_spec = tosa_spec
+        self.debug_hook = debug_hook
+
+    def _serialize_operator(
+        self,
+        node: torch.fx.Node,
+        tosa_graph: Any,
+        tosa_op: Any,
+        inputs: List[str],
+        outputs: List[str],
+        attributes: Optional[Any] = None,
+    ) -> None:
+        tosa_graph.addOperator(
+            tosa_op,
+            inputs=inputs,
+            outputs=outputs,
+            attributes=attributes,
+        )
+
+        if self.debug_hook:
+            self.debug_hook.add(
+                node,
+                tosa_op=outputs[0],
+                tosa_op_id=tosa_op,
+            )
 
     def define_node(
         self,

--- a/backends/arm/operators/op_abs.py
+++ b/backends/arm/operators/op_abs.py
@@ -123,7 +123,9 @@ class AbsVisitor_FP(AbsVisitor_INT):
             )
 
             # MI lowering
-            tosa_graph.addOperator(
+            self._serialize_operator(
+                node,
+                tosa_graph,
                 ts.TosaOp.Op().ABS,
                 [inputs[0].name],
                 [output.name],

--- a/backends/arm/operators/op_add.py
+++ b/backends/arm/operators/op_add.py
@@ -73,7 +73,9 @@ class AddVisitor_INT(NodeVisitor):
         input1, input2 = rescaled_inputs
 
         # Do the INT32 Add
-        tosa_graph.addOperator(
+        self._serialize_operator(
+            node,
+            tosa_graph,
             ts.TosaOp.Op().ADD,
             [input1.name, input2.name],
             [add_output.name],
@@ -127,7 +129,9 @@ class AddVisitor_FP(AddVisitor_INT):
             input1, input2 = inputs
 
             # FP lowering
-            tosa_graph.addOperator(
+            self._serialize_operator(
+                node,
+                tosa_graph,
                 ts.TosaOp.Op().ADD,
                 [input1.name, input2.name],
                 [output.name],

--- a/backends/arm/operators/op_amax.py
+++ b/backends/arm/operators/op_amax.py
@@ -61,6 +61,11 @@ class MaxVisitor(NodeVisitor):
 
         attr = ts.TosaSerializerAttribute()
         attr.ReduceMaxAttribute(axis=input.dim_order.index(dim), nan_mode=1)
-        tosa_graph.addOperator(
-            ts.TosaOp.Op().REDUCE_MAX, [input.name], [output.name], attr
+        self._serialize_operator(
+            node,
+            tosa_graph,
+            ts.TosaOp.Op().REDUCE_MAX,
+            [input.name],
+            [output.name],
+            attr,
         )

--- a/backends/arm/operators/op_amin.py
+++ b/backends/arm/operators/op_amin.py
@@ -61,6 +61,11 @@ class MinVisitor(NodeVisitor):
 
         attr = ts.TosaSerializerAttribute()
         attr.ReduceMinAttribute(axis=input.dim_order.index(dim), nan_mode=1)
-        tosa_graph.addOperator(
-            ts.TosaOp.Op().REDUCE_MIN, [input.name], [output.name], attr
+        self._serialize_operator(
+            node,
+            tosa_graph,
+            ts.TosaOp.Op().REDUCE_MIN,
+            [input.name],
+            [output.name],
+            attr,
         )

--- a/backends/arm/operators/op_any.py
+++ b/backends/arm/operators/op_any.py
@@ -52,6 +52,11 @@ class AnyVisitor(NodeVisitor):
         attr = ts.TosaSerializerAttribute()
         attr.ReduceAnyAttribute(inputs[0].dim_order.index(dim))
 
-        tosa_graph.addOperator(
-            ts.TosaOp.Op().REDUCE_ANY, [inputs[0].name], [output.name], attr
+        self._serialize_operator(
+            node,
+            tosa_graph,
+            ts.TosaOp.Op().REDUCE_ANY,
+            [inputs[0].name],
+            [output.name],
+            attr,
         )

--- a/backends/arm/operators/op_avg_pool2d.py
+++ b/backends/arm/operators/op_avg_pool2d.py
@@ -100,7 +100,9 @@ class AvgPool2dVisitor(NodeVisitor):
             shape=[1], dtype=output.dtype, vals=[output_zp]
         )
 
-        tosa_graph.addOperator(
+        self._serialize_operator(
+            node,
+            tosa_graph,
             ts.TosaOp.Op().AVG_POOL2D,
             [input_tensor.name, input_zp_tensor.name, output_zp_tensor.name],
             [output.name],

--- a/backends/arm/operators/op_bmm.py
+++ b/backends/arm/operators/op_bmm.py
@@ -78,7 +78,9 @@ class BMMVisitor(NodeVisitor):
         tosa_graph.addConst([1], inputs[1].dtype, [input1_zp], name=f"{node.name}_B_ZP")
 
         # Add the MATMUL to the TOSA graph.
-        tosa_graph.addOperator(
+        self._serialize_operator(
+            node,
+            tosa_graph,
             ts.TosaOp.Op().MATMUL,
             [
                 inputs[0].name,

--- a/backends/arm/operators/op_cat.py
+++ b/backends/arm/operators/op_cat.py
@@ -47,7 +47,9 @@ class CatVisitor(NodeVisitor):
         attr = ts.TosaSerializerAttribute()
         attr.ConcatAttribute(dim)
 
-        tosa_graph.addOperator(
+        self._serialize_operator(
+            node,
+            tosa_graph,
             ts.TosaOp.Op().CONCAT,
             [tensor.name for tensor in tensors],
             [output.name],

--- a/backends/arm/operators/op_clamp.py
+++ b/backends/arm/operators/op_clamp.py
@@ -90,8 +90,13 @@ class ClampVisitor_INT(NodeVisitor):
             nan_mode=1,
         )
 
-        tosa_graph.addOperator(
-            ts.TosaOp.Op().CLAMP, [inputs[0].name], [output.name], attr
+        self._serialize_operator(
+            node,
+            tosa_graph,
+            ts.TosaOp.Op().CLAMP,
+            [inputs[0].name],
+            [output.name],
+            attr,
         )
 
 
@@ -138,6 +143,11 @@ class ClampVisitor_FP(ClampVisitor_INT):
             nan_mode=1,
         )
 
-        tosa_graph.addOperator(
-            ts.TosaOp.Op().CLAMP, [inputs[0].name], [output.name], attr
+        self._serialize_operator(
+            node,
+            tosa_graph,
+            ts.TosaOp.Op().CLAMP,
+            [inputs[0].name],
+            [output.name],
+            attr,
         )

--- a/backends/arm/operators/op_constant_pad_nd.py
+++ b/backends/arm/operators/op_constant_pad_nd.py
@@ -100,7 +100,9 @@ class ConstantPadNDVisitor(NodeVisitor):
             shape=[1], dtype=pad_const_dtype, vals=[pad_const_val]
         )
 
-        tosa_graph.addOperator(
+        self._serialize_operator(
+            node,
+            tosa_graph,
             ts.TosaOp.Op().PAD,
             [inputs[0].name, padding.name, pad_const.name],
             [output.name],

--- a/backends/arm/operators/op_conv2d.py
+++ b/backends/arm/operators/op_conv2d.py
@@ -157,7 +157,9 @@ class Conv2dVisitor(NodeVisitor):
 
             reshape_attr = ts.TosaSerializerAttribute()
             reshape_attr.ReshapeAttribute()
-            tosa_graph.addOperator(
+            self._serialize_operator(
+                node,
+                tosa_graph,
                 ts.TosaOp.Op().RESHAPE,
                 [weight.name, shape.name],
                 [weight_reshaped.name],
@@ -188,7 +190,9 @@ class Conv2dVisitor(NodeVisitor):
                 acc_type=acc_type,
             )
 
-        tosa_graph.addOperator(
+        self._serialize_operator(
+            node,
+            tosa_graph,
             tosa_op,
             [
                 input.name,

--- a/backends/arm/operators/op_cos.py
+++ b/backends/arm/operators/op_cos.py
@@ -44,4 +44,6 @@ class CosVisitor(NodeVisitor):
             self.target, [*inputs, output], ts.DType.FP32, output.tosa_spec
         )
 
-        tosa_graph.addOperator(ts.TosaOp.Op().COS, [inputs[0].name], [output.name])
+        self._serialize_operator(
+            node, tosa_graph, ts.TosaOp.Op().COS, [inputs[0].name], [output.name]
+        )

--- a/backends/arm/operators/op_eq.py
+++ b/backends/arm/operators/op_eq.py
@@ -68,9 +68,11 @@ class EqualVisitor(NodeVisitor):
             input_nodes = rescaled_inputs
 
         # Do the equal comparison
-        tosa_graph.addOperator(
+        self._serialize_operator(
+            node,
+            tosa_graph,
             ts.TosaOp.Op().EQUAL,
             [input_nodes[0].name, input_nodes[1].name],
-            output.name,
+            [output.name],
             None,
         )

--- a/backends/arm/operators/op_erf.py
+++ b/backends/arm/operators/op_erf.py
@@ -48,4 +48,6 @@ class ERFVisitor(NodeVisitor):
         )
 
         # MI lowering
-        tosa_graph.addOperator(ts.TosaOp.Op().ERF, [inputs[0].name], [output.name])
+        self._serialize_operator(
+            node, tosa_graph, ts.TosaOp.Op().ERF, [inputs[0].name], [output.name]
+        )

--- a/backends/arm/operators/op_exp.py
+++ b/backends/arm/operators/op_exp.py
@@ -48,4 +48,6 @@ class ExpVisitor(NodeVisitor):
             output.tosa_spec,
         )
 
-        tosa_graph.addOperator(ts.TosaOp.Op().EXP, [inputs[0].name], [output.name])
+        self._serialize_operator(
+            node, tosa_graph, ts.TosaOp.Op().EXP, [inputs[0].name], [output.name]
+        )

--- a/backends/arm/operators/op_ge.py
+++ b/backends/arm/operators/op_ge.py
@@ -67,7 +67,9 @@ class GreaterEqualVisitor(NodeVisitor):
             # Update IO
             input_nodes = rescaled_inputs
 
-        tosa_graph.addOperator(
+        self._serialize_operator(
+            node,
+            tosa_graph,
             ts.TosaOp.Op().GREATER_EQUAL,
             [input_nodes[0].name, input_nodes[1].name],
             [output.name],

--- a/backends/arm/operators/op_gt.py
+++ b/backends/arm/operators/op_gt.py
@@ -67,7 +67,9 @@ class GreaterThanVisitor(NodeVisitor):
             # Update IO
             input_nodes = rescaled_inputs
 
-        tosa_graph.addOperator(
+        self._serialize_operator(
+            node,
+            tosa_graph,
             ts.TosaOp.Op().GREATER,
             [input_nodes[0].name, input_nodes[1].name],
             [output.name],

--- a/backends/arm/operators/op_index_select.py
+++ b/backends/arm/operators/op_index_select.py
@@ -86,7 +86,9 @@ class IndexSelectVisitor(NodeVisitor):
             tosa_graph, indices.name, indices_new_shape, indices_reshaped.name
         )
 
-        tosa_graph.addOperator(
+        self._serialize_operator(
+            node,
+            tosa_graph,
             ts.TosaOp.Op().GATHER,
             [weights_reshaped.name, indices_reshaped.name],
             [output_name],

--- a/backends/arm/operators/op_index_tensor.py
+++ b/backends/arm/operators/op_index_tensor.py
@@ -167,7 +167,9 @@ class IndexTensorVisitor(CommonIndexTensorVisitor):
             data = np.full(index_shape, int(values_strides[i] / C))
             mul_const = tosa_graph.addConst(index_shape, index_dtype, data)
             tosa_graph.addConst([1], ts.DType.INT8, 0, name=f"{node.name}_{i}_shift")
-            tosa_graph.addOperator(
+            self._serialize_operator(
+                node,
+                tosa_graph,
                 ts.TosaOp.Op().MUL,
                 [index_name, mul_const.name, f"{node.name}_{i}_shift"],
                 [stride_shifted_indices.name],
@@ -194,7 +196,9 @@ class IndexTensorVisitor(CommonIndexTensorVisitor):
                     reshaped_idxs.shape,
                     reshaped_idxs.dtype,
                 )
-                tosa_graph.addOperator(
+                self._serialize_operator(
+                    node,
+                    tosa_graph,
                     ts.TosaOp.Op().ADD,
                     [gather_index_name, reshaped_idxs.name],
                     [add_idxs.name],
@@ -217,7 +221,9 @@ class IndexTensorVisitor(CommonIndexTensorVisitor):
             gather_out_shape,
             output.dtype,
         )
-        tosa_graph.addOperator(
+        self._serialize_operator(
+            node,
+            tosa_graph,
             ts.TosaOp.Op().GATHER,
             [reshaped_input.name, gather_index_name],
             [gather_out.name],

--- a/backends/arm/operators/op_le.py
+++ b/backends/arm/operators/op_le.py
@@ -67,7 +67,9 @@ class LessEqualVisitor(NodeVisitor):
             # Update IO
             input_nodes = rescaled_inputs
 
-        tosa_graph.addOperator(
+        self._serialize_operator(
+            node,
+            tosa_graph,
             ts.TosaOp.Op().GREATER_EQUAL,
             [input_nodes[1].name, input_nodes[0].name],
             [output.name],

--- a/backends/arm/operators/op_log.py
+++ b/backends/arm/operators/op_log.py
@@ -45,4 +45,6 @@ class LogVisitor(NodeVisitor):
             self.target, [*inputs, output], ts.DType.FP32, output.tosa_spec
         )
 
-        tosa_graph.addOperator(ts.TosaOp.Op().LOG, [inputs[0].name], [output.name])
+        self._serialize_operator(
+            node, tosa_graph, ts.TosaOp.Op().LOG, [inputs[0].name], [output.name]
+        )

--- a/backends/arm/operators/op_lt.py
+++ b/backends/arm/operators/op_lt.py
@@ -67,7 +67,9 @@ class LessThanVisitor(NodeVisitor):
             # Update IO
             input_nodes = rescaled_inputs
 
-        tosa_graph.addOperator(
+        self._serialize_operator(
+            node,
+            tosa_graph,
             ts.TosaOp.Op().GREATER,
             [input_nodes[1].name, input_nodes[0].name],
             [output.name],

--- a/backends/arm/operators/op_max_pool2d.py
+++ b/backends/arm/operators/op_max_pool2d.py
@@ -94,7 +94,9 @@ class MaxPool2dVisitor(NodeVisitor):
             kernel=kernel_size, stride=stride, pad=pad_size_list, nan_mode=1
         )
 
-        tosa_graph.addOperator(
+        self._serialize_operator(
+            node,
+            tosa_graph,
             ts.TosaOp.Op().MAX_POOL2D,
             [input_tensor.name],
             [output.name],

--- a/backends/arm/operators/op_maximum.py
+++ b/backends/arm/operators/op_maximum.py
@@ -87,7 +87,9 @@ class MaxVisitor(NodeVisitor):
         # Set to PROPOGATE as default
         attr_maximum.MaximumAttribute(nan_mode=NanPropagationMode.PROPAGATE)
 
-        tosa_graph.addOperator(
+        self._serialize_operator(
+            node,
+            tosa_graph,
             ts.TosaOp.Op().MAXIMUM,
             [
                 operand_inputs[0].name,

--- a/backends/arm/operators/op_minimum.py
+++ b/backends/arm/operators/op_minimum.py
@@ -86,7 +86,9 @@ class MinVisitor(NodeVisitor):
         # Set to PROPOGATE as default
         attr_minimum.MinimumAttribute(nan_mode=NanPropagationMode.PROPAGATE)
 
-        tosa_graph.addOperator(
+        self._serialize_operator(
+            node,
+            tosa_graph,
             ts.TosaOp.Op().MINIMUM,
             [
                 operand_inputs[0].name,

--- a/backends/arm/operators/op_mul.py
+++ b/backends/arm/operators/op_mul.py
@@ -93,7 +93,9 @@ class MulVisitor_INT(NodeVisitor):
 
         # Do the INT32 Mul
         tosa_graph.addConst([1], ts.DType.INT8, 0, name=f"{node.name}_shift")
-        tosa_graph.addOperator(
+        self._serialize_operator(
+            node,
+            tosa_graph,
             ts.TosaOp.Op().MUL,
             [input_A_rescaled.name, input_B_rescaled.name, f"{node.name}_shift"],
             [mul_output.name],
@@ -135,7 +137,9 @@ class MulVisitor_FP(MulVisitor_INT):
         input1, input2 = inputs
 
         tosa_graph.addConst([1], ts.DType.INT8, 0, name=f"{node.name}_shift")
-        tosa_graph.addOperator(
+        self._serialize_operator(
+            node,
+            tosa_graph,
             ts.TosaOp.Op().MUL,
             [input1.name, input2.name, f"{node.name}_shift"],
             [output.name],

--- a/backends/arm/operators/op_neg.py
+++ b/backends/arm/operators/op_neg.py
@@ -82,7 +82,9 @@ class NegVisitor(NodeVisitor):
             (1,), output.dtype, [output_zp], name=output.name + "_output_zp"
         )
 
-        tosa_graph.addOperator(
+        self._serialize_operator(
+            node,
+            tosa_graph,
             ts.TosaOp.Op().NEGATE,
             [inputs[0].name, input_zp_tensor.name, output_zp_tensor.name],
             [output.name],

--- a/backends/arm/operators/op_permute.py
+++ b/backends/arm/operators/op_permute.py
@@ -135,6 +135,11 @@ class PermuteVisitor(NodeVisitor):
 
         attr = ts.TosaSerializerAttribute()
         attr.TransposeAttribute(permutation_vector)
-        tosa_graph.addOperator(
-            ts.TosaOp.Op().TRANSPOSE, [inputs[0].name], [output.name], attr
+        self._serialize_operator(
+            node,
+            tosa_graph,
+            ts.TosaOp.Op().TRANSPOSE,
+            [inputs[0].name],
+            [output.name],
+            attr,
         )

--- a/backends/arm/operators/op_pow.py
+++ b/backends/arm/operators/op_pow.py
@@ -50,7 +50,9 @@ class PowVisitor(NodeVisitor):
             output.tosa_spec,
         )
 
-        tosa_graph.addOperator(
+        self._serialize_operator(
+            node,
+            tosa_graph,
             ts.TosaOp.Op().POW,
             [
                 inputs[0].name,

--- a/backends/arm/operators/op_reciprocal.py
+++ b/backends/arm/operators/op_reciprocal.py
@@ -46,6 +46,6 @@ class ReciprocalVisitor(NodeVisitor):
             self.target, [*inputs, output], ts.DType.FP32, output.tosa_spec
         )
 
-        tosa_graph.addOperator(
-            ts.TosaOp.Op().RECIPROCAL, [inputs[0].name], [output.name]
+        self._serialize_operator(
+            node, tosa_graph, ts.TosaOp.Op().RECIPROCAL, [inputs[0].name], [output.name]
         )

--- a/backends/arm/operators/op_repeat.py
+++ b/backends/arm/operators/op_repeat.py
@@ -60,7 +60,9 @@ class RepeatVisitor(NodeVisitor):
             name=node.name + "_multiples",
         )
 
-        tosa_graph.addOperator(
+        self._serialize_operator(
+            node,
+            tosa_graph,
             ts.TosaOp.Op().TILE,
             [inputs[0].name, multiple_shapes.name],
             [output.name],

--- a/backends/arm/operators/op_rshift_tensor.py
+++ b/backends/arm/operators/op_rshift_tensor.py
@@ -53,7 +53,9 @@ class RshiftVisitor(NodeVisitor):
             round = True
         attr.ArithmeticRightShiftAttribute(round=round)
 
-        tosa_graph.addOperator(
+        self._serialize_operator(
+            node,
+            tosa_graph,
             ts.TosaOp.Op().ARITHMETIC_RIGHT_SHIFT,
             [inputs[0].name, inputs[1].name],
             [output.name],

--- a/backends/arm/operators/op_rsqrt.py
+++ b/backends/arm/operators/op_rsqrt.py
@@ -46,4 +46,6 @@ class RsqrtVisitor(NodeVisitor):
             self.target, [*inputs, output], ts.DType.FP32, output.tosa_spec
         )
 
-        tosa_graph.addOperator(ts.TosaOp.Op().RSQRT, [inputs[0].name], [output.name])
+        self._serialize_operator(
+            node, tosa_graph, ts.TosaOp.Op().RSQRT, [inputs[0].name], [output.name]
+        )

--- a/backends/arm/operators/op_sigmoid.py
+++ b/backends/arm/operators/op_sigmoid.py
@@ -45,4 +45,6 @@ class SigmoidVisitor(NodeVisitor):
             self.target, [*inputs, output], ts.DType.FP32, output.tosa_spec
         )
 
-        tosa_graph.addOperator(ts.TosaOp.Op().SIGMOID, [inputs[0].name], [output.name])
+        self._serialize_operator(
+            node, tosa_graph, ts.TosaOp.Op().SIGMOID, [inputs[0].name], [output.name]
+        )

--- a/backends/arm/operators/op_sin.py
+++ b/backends/arm/operators/op_sin.py
@@ -44,4 +44,6 @@ class SinVisitor(NodeVisitor):
             self.target, [*inputs, output], ts.DType.FP32, output.tosa_spec
         )
 
-        tosa_graph.addOperator(ts.TosaOp.Op().SIN, [inputs[0].name], [output.name])
+        self._serialize_operator(
+            node, tosa_graph, ts.TosaOp.Op().SIN, [inputs[0].name], [output.name]
+        )

--- a/backends/arm/operators/op_slice.py
+++ b/backends/arm/operators/op_slice.py
@@ -117,7 +117,9 @@ class SliceVisitor(NodeVisitor):
             (sizes_len,), ts.DType.SHAPE, sizes, node.name + "_sizes_shape"
         )
 
-        tosa_graph.addOperator(
+        self._serialize_operator(
+            node,
+            tosa_graph,
             ts.TosaOp.Op().SLICE,
             [input_node.name, start_tensor.name, sizes_tensor.name],
             [output.name],

--- a/backends/arm/operators/op_sub.py
+++ b/backends/arm/operators/op_sub.py
@@ -72,7 +72,9 @@ class SubVisitor_INT(NodeVisitor):
             sub_output = output
 
         # Do the INT32 Sub
-        tosa_graph.addOperator(
+        self._serialize_operator(
+            node,
+            tosa_graph,
             ts.TosaOp.Op().SUB,
             [
                 rescaled_inputs[0].name,
@@ -127,7 +129,9 @@ class SubVisitor_FP(SubVisitor_INT):
             )
 
             # MI lowering
-            tosa_graph.addOperator(
+            self._serialize_operator(
+                node,
+                tosa_graph,
                 ts.TosaOp.Op().SUB,
                 [inputs[0].name, inputs[1].name],
                 [output.name],

--- a/backends/arm/operators/op_table.py
+++ b/backends/arm/operators/op_table.py
@@ -60,7 +60,9 @@ class TableVisitor(NodeVisitor):
             name=table_tensor_name,
         )
 
-        tosa_graph.addOperator(
+        self._serialize_operator(
+            node,
+            tosa_graph,
             ts.TosaOp.Op().TABLE,
             [inputs[0].name, table_tensor_name],
             [output.name],

--- a/backends/arm/operators/op_tanh.py
+++ b/backends/arm/operators/op_tanh.py
@@ -46,4 +46,6 @@ class TanhVisitor(NodeVisitor):
             self.target, [*inputs, output], ts.DType.FP32, output.tosa_spec
         )
 
-        tosa_graph.addOperator(ts.TosaOp.Op().TANH, [inputs[0].name], [output.name])
+        self._serialize_operator(
+            node, tosa_graph, ts.TosaOp.Op().TANH, [inputs[0].name], [output.name]
+        )

--- a/backends/arm/operators/op_to_copy.py
+++ b/backends/arm/operators/op_to_copy.py
@@ -44,4 +44,6 @@ class ToCopyVisitor(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 1)
 
-        tosa_graph.addOperator(ts.TosaOp.Op().CAST, [inputs[0].name], [output.name])
+        self._serialize_operator(
+            node, tosa_graph, ts.TosaOp.Op().CAST, [inputs[0].name], [output.name]
+        )

--- a/backends/arm/operators/op_to_dim_order_copy.py
+++ b/backends/arm/operators/op_to_dim_order_copy.py
@@ -44,4 +44,6 @@ class ToDimOrderCopyVisitor(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 1)
 
-        tosa_graph.addOperator(ts.TosaOp.Op().CAST, [inputs[0].name], [output.name])
+        self._serialize_operator(
+            node, tosa_graph, ts.TosaOp.Op().CAST, [inputs[0].name], [output.name]
+        )

--- a/backends/arm/operators/op_transpose.py
+++ b/backends/arm/operators/op_transpose.py
@@ -62,6 +62,11 @@ class TransposeVisitor(NodeVisitor):
         perms = [dim % output_rank for dim in inputs[1].special]
         attr = ts.TosaSerializerAttribute()
         attr.TransposeAttribute(perms)
-        tosa_graph.addOperator(
-            ts.TosaOp.Op().TRANSPOSE, [inputs[0].name], [output.name], attr
+        self._serialize_operator(
+            node,
+            tosa_graph,
+            ts.TosaOp.Op().TRANSPOSE,
+            [inputs[0].name],
+            [output.name],
+            attr,
         )

--- a/backends/arm/operators/op_upsample_bilinear2d.py
+++ b/backends/arm/operators/op_upsample_bilinear2d.py
@@ -98,7 +98,9 @@ class UpsampleBilinear2dVisitor(NodeVisitor):
             [len(border)], ts.DType.SHAPE, border, node.name + "_border"
         )
         if input_dtype == output.dtype == ts.DType.FP32:
-            tosa_graph.addOperator(
+            self._serialize_operator(
+                node,
+                tosa_graph,
                 ts.TosaOp.Op().RESIZE,
                 [
                     inputs[0].name,
@@ -114,7 +116,9 @@ class UpsampleBilinear2dVisitor(NodeVisitor):
             intermediate = tosa_graph.addIntermediate(
                 tosa_shape(output.shape, output.dim_order), ts.DType.INT32
             )
-            tosa_graph.addOperator(
+            self._serialize_operator(
+                node,
+                tosa_graph,
                 ts.TosaOp.Op().RESIZE,
                 [
                     inputs[0].name,

--- a/backends/arm/operators/op_upsample_nearest2d.py
+++ b/backends/arm/operators/op_upsample_nearest2d.py
@@ -89,7 +89,9 @@ class UpsampleNearest2dVisitor(NodeVisitor):
             mode=ResizeMode.NEAREST,
         )
 
-        tosa_graph.addOperator(
+        self._serialize_operator(
+            node,
+            tosa_graph,
             ts.TosaOp.Op().RESIZE,
             [
                 inputs[0].name,

--- a/backends/arm/operators/op_view.py
+++ b/backends/arm/operators/op_view.py
@@ -66,6 +66,11 @@ class ViewVisitor(NodeVisitor):
 
         attr = ts.TosaSerializerAttribute()
         attr.ReshapeAttribute()
-        tosa_graph.addOperator(
-            ts.TosaOp.Op().RESHAPE, [inputs[0].name, shape.name], [output.name], attr
+        self._serialize_operator(
+            node,
+            tosa_graph,
+            ts.TosaOp.Op().RESHAPE,
+            [inputs[0].name, shape.name],
+            [output.name],
+            attr,
         )

--- a/backends/arm/operators/op_where.py
+++ b/backends/arm/operators/op_where.py
@@ -33,6 +33,7 @@ class WhereVisitor_INT(NodeVisitor):
 
     def _add_node_to_tosa_graph(
         self,
+        node: Node,
         tosa_graph: Any,
         inputs: List[TosaArg],
         output: TosaArg,
@@ -51,7 +52,9 @@ class WhereVisitor_INT(NodeVisitor):
             output.tosa_spec,
         )
 
-        tosa_graph.addOperator(
+        self._serialize_operator(
+            node,
+            tosa_graph,
             ts.TosaOp.Op().SELECT,
             [inputs[0].name, inputs[1].name, inputs[2].name],
             [output.name],
@@ -73,7 +76,9 @@ class WhereVisitor_INT(NodeVisitor):
             ts.DType.INT32,
             ts.DType.BOOL,
         ]
-        self._add_node_to_tosa_graph(tosa_graph, inputs, output, bi_supported_dtypes)
+        self._add_node_to_tosa_graph(
+            node, tosa_graph, inputs, output, bi_supported_dtypes
+        )
 
 
 @register_node_visitor
@@ -103,4 +108,6 @@ class WhereVisitor_FP(WhereVisitor_INT):
             ts.DType.INT32,
             ts.DType.BOOL,
         ]
-        self._add_node_to_tosa_graph(tosa_graph, inputs, output, mi_supported_dtypes)
+        self._add_node_to_tosa_graph(
+            node, tosa_graph, inputs, output, mi_supported_dtypes
+        )

--- a/backends/arm/operators/ops_binary.py
+++ b/backends/arm/operators/ops_binary.py
@@ -65,8 +65,12 @@ def binary_operator_factory(bw_target: str, tosa_op):
                     output.tosa_spec,
                 )
 
-            tosa_graph.addOperator(
-                tosa_op, [inputs[0].name, inputs[1].name], [output.name]
+            self._serialize_operator(
+                node,
+                tosa_graph,
+                tosa_op,
+                [inputs[0].name, inputs[1].name],
+                [output.name],
             )
 
     register_node_visitor(BinaryOperator)

--- a/backends/arm/operators/ops_identity.py
+++ b/backends/arm/operators/ops_identity.py
@@ -45,8 +45,12 @@ def identity_operator_factory(identity_target: str):
             validate_same_dtype(self.target, [*inputs, output], ts)
 
             # Simply add an identityOp
-            tosa_graph.addOperator(
-                ts.TosaOp.Op().IDENTITY, [inputs[0].name], [output.name]
+            self._serialize_operator(
+                node,
+                tosa_graph,
+                ts.TosaOp.Op().IDENTITY,
+                [inputs[0].name],
+                [output.name],
             )
 
     register_node_visitor(IdentityOperatorVisitor)

--- a/backends/arm/operators/ops_unary.py
+++ b/backends/arm/operators/ops_unary.py
@@ -54,7 +54,9 @@ def unary_operator_factory(unary_target: str, tosa_op):
                     output.tosa_spec,
                 )
 
-            tosa_graph.addOperator(tosa_op, [inputs[0].name], [output.name])
+            self._serialize_operator(
+                node, tosa_graph, tosa_op, [inputs[0].name], [output.name]
+            )
 
     register_node_visitor(UnaryOperator)
 

--- a/backends/arm/test/common.py
+++ b/backends/arm/test/common.py
@@ -63,16 +63,24 @@ def maybe_get_tosa_collate_path() -> str | None:
 
 
 def get_tosa_compile_spec(
-    tosa_spec: str | TosaSpecification, custom_path=None
+    tosa_spec: str | TosaSpecification,
+    custom_path: Optional[str] = None,
+    tosa_debug_mode: Optional[ArmCompileSpecBuilder.DebugMode] = None,
 ) -> list[CompileSpec]:
     """
     Default compile spec for TOSA tests.
     """
-    return get_tosa_compile_spec_unbuilt(tosa_spec, custom_path).build()
+    return get_tosa_compile_spec_unbuilt(
+        tosa_spec,
+        custom_path,
+        tosa_debug_mode,
+    ).build()
 
 
 def get_tosa_compile_spec_unbuilt(
-    tosa_spec: str | TosaSpecification, custom_path=None
+    tosa_spec: str | TosaSpecification,
+    custom_path: Optional[str],
+    tosa_debug_mode: Optional[ArmCompileSpecBuilder.DebugMode],
 ) -> ArmCompileSpecBuilder:
     """Get the ArmCompileSpecBuilder for the default TOSA tests, to modify
     the compile spec before calling .build() to finalize it.
@@ -82,11 +90,15 @@ def get_tosa_compile_spec_unbuilt(
 
     if custom_path is not None:
         os.makedirs(custom_path, exist_ok=True)
+
     compile_spec_builder = (
         ArmCompileSpecBuilder()
         .tosa_compile_spec(tosa_spec)
         .dump_intermediate_artifacts_to(custom_path)
     )
+
+    if tosa_debug_mode is not None:
+        compile_spec_builder.dump_debug_info(tosa_debug_mode)
 
     return compile_spec_builder
 
@@ -97,6 +109,7 @@ def get_u55_compile_spec(
     memory_mode: str = "Shared_Sram",
     extra_flags: str = "--debug-force-regor --output-format=raw",
     custom_path: Optional[str] = None,
+    tosa_debug_mode: Optional[ArmCompileSpecBuilder.DebugMode] = None,
     config: Optional[str] = "Arm/vela.ini",
 ) -> list[CompileSpec]:
     """
@@ -108,16 +121,18 @@ def get_u55_compile_spec(
         memory_mode=memory_mode,
         extra_flags=extra_flags,
         custom_path=custom_path,
+        tosa_debug_mode=tosa_debug_mode,
         config=config,
     ).build()
 
 
 def get_u85_compile_spec(
     macs: int = 128,
-    system_config="Ethos_U85_SYS_DRAM_Mid",
-    memory_mode="Shared_Sram",
-    extra_flags="--output-format=raw",
-    custom_path=None,
+    system_config: str = "Ethos_U85_SYS_DRAM_Mid",
+    memory_mode: str = "Shared_Sram",
+    extra_flags: str = "--output-format=raw",
+    custom_path: Optional[str] = None,
+    tosa_debug_mode: Optional[ArmCompileSpecBuilder.DebugMode] = None,
     config: Optional[str] = "Arm/vela.ini",
 ) -> list[CompileSpec]:
     """
@@ -129,6 +144,7 @@ def get_u85_compile_spec(
         memory_mode=memory_mode,
         extra_flags=extra_flags,
         custom_path=custom_path,
+        tosa_debug_mode=tosa_debug_mode,
         config=config,
     ).build()
 
@@ -136,12 +152,15 @@ def get_u85_compile_spec(
 def get_vgf_compile_spec(
     tosa_spec: str | TosaSpecification,
     compiler_flags: Optional[str] = "",
-    custom_path=None,
+    custom_path: Optional[str] = "",
+    tosa_debug_mode: Optional[ArmCompileSpecBuilder.DebugMode] = None,
 ) -> list[CompileSpec]:
     """
     Default compile spec for VGF tests.
     """
-    return get_vgf_compile_spec_unbuilt(tosa_spec, compiler_flags, custom_path).build()
+    return get_vgf_compile_spec_unbuilt(
+        tosa_spec, compiler_flags, custom_path, tosa_debug_mode
+    ).build()
 
 
 def get_u55_compile_spec_unbuilt(
@@ -150,6 +169,7 @@ def get_u55_compile_spec_unbuilt(
     memory_mode: str,
     extra_flags: str,
     custom_path: Optional[str],
+    tosa_debug_mode: Optional[ArmCompileSpecBuilder.DebugMode],
     config: Optional[str],
 ) -> ArmCompileSpecBuilder:
     """Get the ArmCompileSpecBuilder for the Ethos-U55 tests, to modify
@@ -173,6 +193,10 @@ def get_u55_compile_spec_unbuilt(
         )
         .dump_intermediate_artifacts_to(artifact_path)
     )
+
+    if tosa_debug_mode is not None:
+        compile_spec.dump_debug_info(tosa_debug_mode)
+
     return compile_spec
 
 
@@ -182,6 +206,7 @@ def get_u85_compile_spec_unbuilt(
     memory_mode: str,
     extra_flags: str,
     custom_path: Optional[str],
+    tosa_debug_mode: Optional[ArmCompileSpecBuilder.DebugMode],
     config: Optional[str],
 ) -> list[CompileSpec]:
     """Get the ArmCompileSpecBuilder for the Ethos-U85 tests, to modify
@@ -204,13 +229,18 @@ def get_u85_compile_spec_unbuilt(
         )
         .dump_intermediate_artifacts_to(artifact_path)
     )
+
+    if tosa_debug_mode is not None:
+        compile_spec.dump_debug_info(tosa_debug_mode)
+
     return compile_spec  # type: ignore[return-value]
 
 
 def get_vgf_compile_spec_unbuilt(
     tosa_spec: str | TosaSpecification,
-    compiler_flags: Optional[str] = "",
-    custom_path=None,
+    compiler_flags: Optional[str],
+    custom_path: Optional[str],
+    tosa_debug_mode: Optional[ArmCompileSpecBuilder.DebugMode],
 ) -> ArmCompileSpecBuilder:
     """Get the ArmCompileSpecBuilder for the default VGF tests, to modify
     the compile spec before calling .build() to finalize it.
@@ -230,6 +260,9 @@ def get_vgf_compile_spec_unbuilt(
         .vgf_compile_spec(tosa_spec, compiler_flags)
         .dump_intermediate_artifacts_to(artifact_path)
     )
+
+    if tosa_debug_mode is not None:
+        compile_spec_builder.dump_debug_info(tosa_debug_mode)
 
     return compile_spec_builder
 

--- a/backends/arm/test/misc/test_debug_feats.py
+++ b/backends/arm/test/misc/test_debug_feats.py
@@ -3,15 +3,18 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import json
 import os
 import shutil
 import tempfile
 
+from pathlib import Path
 from typing import Tuple
 
 import pytest
 
 import torch
+from executorch.backends.arm.arm_backend import ArmCompileSpecBuilder
 from executorch.backends.arm.test import common
 from executorch.backends.arm.test.tester.test_pipeline import (
     EthosU55PipelineINT,
@@ -186,6 +189,37 @@ def test_collate_tosa_INT_tests(test_data: input_t1):
 
     os.environ.pop("TOSA_TESTCASES_BASE_PATH")
     shutil.rmtree("test_collate_tosa_tests", ignore_errors=True)
+
+
+@common.parametrize("test_data", Linear.inputs)
+def test_dump_tosa_debug_json(test_data: input_t1):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        pipeline = TosaPipelineINT[input_t1](
+            module=Linear(),
+            test_data=test_data,
+            aten_op=[],
+            exir_op=[],
+            custom_path=tmpdir,
+            tosa_debug_mode=ArmCompileSpecBuilder.DebugMode.JSON,
+        )
+
+        pipeline.pop_stage("run_method_and_compare_outputs")
+        pipeline.run()
+
+        json_output_path = Path(tmpdir) / "debug.json"
+
+        # The file should exist
+        assert json_output_path.exists()
+
+        # Check the file is valid JSON and can be loaded
+        with json_output_path.open("r") as file:
+            try:
+                data = json.load(file)
+
+                # Check it's not empty
+                assert data
+            except json.JSONDecodeError:
+                pytest.fail("Failed to load debug JSON file")
 
 
 @common.parametrize("test_data", Linear.inputs)

--- a/backends/arm/test/tester/test_pipeline.py
+++ b/backends/arm/test/tester/test_pipeline.py
@@ -22,6 +22,7 @@ from typing import (
 
 import torch
 
+from executorch.backends.arm.arm_backend import ArmCompileSpecBuilder
 from executorch.backends.arm.quantizer import (
     EthosUQuantizer,
     get_symmetric_quantization_config,
@@ -339,6 +340,7 @@ class TosaPipelineINT(TOSAPipelineMaker, Generic[T]):
         per_channel_quantization: bool = True,
         use_to_edge_transform_and_lower: bool = True,
         custom_path: str = None,
+        tosa_debug_mode: Optional[ArmCompileSpecBuilder.DebugMode] = None,
         atol: float = 1e-03,
         rtol: float = 1e-03,
         qtol: int = 1,
@@ -355,7 +357,9 @@ class TosaPipelineINT(TOSAPipelineMaker, Generic[T]):
         tosa_version = conftest.get_option("tosa_version")
 
         compile_spec = common.get_tosa_compile_spec(
-            tosa_profiles[tosa_version], custom_path=custom_path
+            tosa_profiles[tosa_version],
+            custom_path=custom_path,
+            tosa_debug_mode=tosa_debug_mode,
         )
 
         quantizer = TOSAQuantizer(tosa_profiles[tosa_version])
@@ -441,6 +445,7 @@ class TosaPipelineFP(TOSAPipelineMaker, Generic[T]):
         run_on_tosa_ref_model: bool = True,
         use_to_edge_transform_and_lower: bool = True,
         custom_path: str = None,
+        tosa_debug_mode: Optional[ArmCompileSpecBuilder.DebugMode] = None,
         atol: float = 1e-03,
         rtol: float = 1e-03,
         qtol: int = 0,
@@ -460,7 +465,9 @@ class TosaPipelineFP(TOSAPipelineMaker, Generic[T]):
         tosa_version = conftest.get_option("tosa_version")
 
         compile_spec = common.get_tosa_compile_spec(
-            tosa_profiles[tosa_version], custom_path=custom_path
+            tosa_profiles[tosa_version],
+            custom_path=custom_path,
+            tosa_debug_mode=tosa_debug_mode,
         )
         super().__init__(
             module,
@@ -519,11 +526,15 @@ class EthosU55PipelineINT(BasePipelineMaker, Generic[T]):
         per_channel_quantization: bool = True,
         use_to_edge_transform_and_lower: bool = True,
         custom_path: str = None,
+        tosa_debug_mode: Optional[ArmCompileSpecBuilder.DebugMode] = None,
         atol: float = 1e-03,
         rtol: float = 1e-03,
         qtol: int = 1,
     ):
-        compile_spec = common.get_u55_compile_spec(custom_path=custom_path)
+        compile_spec = common.get_u55_compile_spec(
+            custom_path=custom_path,
+            tosa_debug_mode=tosa_debug_mode,
+        )
         quantizer = EthosUQuantizer(compile_spec)
         quantization_config = get_symmetric_quantization_config(
             is_per_channel=per_channel_quantization
@@ -606,11 +617,15 @@ class EthosU85PipelineINT(BasePipelineMaker, Generic[T]):
         per_channel_quantization: bool = True,
         use_to_edge_transform_and_lower: bool = True,
         custom_path: str = None,
+        tosa_debug_mode: Optional[ArmCompileSpecBuilder.DebugMode] = None,
         atol: float = 1e-03,
         rtol: float = 1e-03,
         qtol: int = 1,
     ):
-        compile_spec = common.get_u85_compile_spec(custom_path=custom_path)
+        compile_spec = common.get_u85_compile_spec(
+            custom_path=custom_path,
+            tosa_debug_mode=tosa_debug_mode,
+        )
         quantizer = EthosUQuantizer(compile_spec)
         quantization_config = get_symmetric_quantization_config(
             is_per_channel=per_channel_quantization
@@ -915,6 +930,7 @@ class VgfPipeline(BasePipelineMaker, Generic[T]):
         per_channel_quantization: bool = True,
         use_to_edge_transform_and_lower: bool = True,
         custom_path: str = None,
+        tosa_debug_mode: Optional[ArmCompileSpecBuilder.DebugMode] = None,
         atol: float = 1e-03,
         rtol: float = 1e-03,
         qtol: int = 1,
@@ -931,7 +947,10 @@ class VgfPipeline(BasePipelineMaker, Generic[T]):
             tosa_version + "".join([f"+{ext}" for ext in tosa_extensions])
         )
         compile_spec = common.get_vgf_compile_spec(
-            tosa_spec, compiler_flags=vgf_compiler_flags, custom_path=custom_path
+            tosa_spec,
+            compiler_flags=vgf_compiler_flags,
+            custom_path=custom_path,
+            tosa_debug_mode=tosa_debug_mode,
         )
 
         super().__init__(

--- a/backends/arm/tosa_backend.py
+++ b/backends/arm/tosa_backend.py
@@ -14,6 +14,7 @@ import logging
 from typing import cast, final, List
 
 import serializer.tosa_serializer as ts  # type: ignore
+from executorch.backends.arm.debug.schema import DebugHook
 from executorch.backends.arm.operators.node_visitor import get_node_visitors
 from executorch.backends.arm.tosa_specification import get_tosa_spec
 from executorch.backends.arm._passes import (
@@ -62,6 +63,7 @@ class TOSABackend(BackendDetails):
         artifact_path = None
         output_format = ""
         compile_flags = []
+        dump_debug_info = None
         for spec in compile_spec:
             if spec.key == "debug_artifact_path":
                 artifact_path = spec.value.decode()
@@ -69,6 +71,8 @@ class TOSABackend(BackendDetails):
                 output_format = spec.value.decode()
             if spec.key == "compile_flags":
                 compile_flags.append(spec.value.decode())
+            if spec.key == "dump_debug_info":
+                dump_debug_info = spec.value.decode()
 
         # Check that the output format is set correctly in the compile spec
         if output_format != "tosa":
@@ -95,7 +99,11 @@ class TOSABackend(BackendDetails):
             exported_program=edge_program
         )
 
-        node_visitors = get_node_visitors(edge_program, tosa_spec)
+        debug_hook = None
+        if dump_debug_info is not None:
+            debug_hook = DebugHook()
+
+        node_visitors = get_node_visitors(edge_program, tosa_spec, debug_hook)
         input_count = 0
         for node in graph_module.graph.nodes:
             node = cast(Node, node)
@@ -125,6 +133,11 @@ class TOSABackend(BackendDetails):
                 artifact_path,
                 suffix="{}".format(f"_{tag}" if tag else "") + (f"_{tosa_spec}"),
             )
+
+            if debug_hook:
+                json_output = debug_hook.serialize()
+                with open(f"{artifact_path}/debug.json", "w") as f:
+                    f.write(json_output)
 
         # Serialize and return the TOSA flatbuffer.
         binary = bytes(tosa_graph.serialize())


### PR DESCRIPTION
* Add _serialize_operator() function to NodeVisitor
* Enable passing of DebugHook to NodeVisitor if enabled
* Add option dump_debug_info to ArmCompileSpecBuilder

Change-Id: I9dc8da50a7ef16053b778ab33a03a990035de5ad


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218