### PR TITLE
Add qnn deps to LlamaDemo gradle

### DIFF
--- a/examples/demo-apps/android/LlamaDemo/app/build.gradle.kts
+++ b/examples/demo-apps/android/LlamaDemo/app/build.gradle.kts
@@ -13,7 +13,6 @@ plugins {
 
 val qnnVersion: String? = project.findProperty("qnnVersion") as? String
 
-
 android {
   namespace = "com.example.executorchllamademo"
   compileSdk = 34

--- a/examples/demo-apps/android/LlamaDemo/app/build.gradle.kts
+++ b/examples/demo-apps/android/LlamaDemo/app/build.gradle.kts
@@ -11,7 +11,8 @@ plugins {
   id("org.jetbrains.kotlin.android")
 }
 
-def qnnVersion = System.properties['qnnVersion']
+val qnnVersion: String? = project.findProperty("qnnVersion") as? String
+
 
 android {
   namespace = "com.example.executorchllamademo"
@@ -63,8 +64,8 @@ dependencies {
   implementation("com.google.android.material:material:1.12.0")
   implementation("androidx.activity:activity:1.9.0")
   implementation("org.json:json:20250107")
-  if (qnnVersion) {
-    implementation "com.qualcomm.qti:qnn-runtime:$qnnVersion"
+  if (!qnnVersion.isNullOrEmpty()) {
+    implementation("com.qualcomm.qti:qnn-runtime:$qnnVersion")
   }
   testImplementation("junit:junit:4.13.2")
   androidTestImplementation("androidx.test.ext:junit:1.1.5")

--- a/examples/demo-apps/android/LlamaDemo/app/build.gradle.kts
+++ b/examples/demo-apps/android/LlamaDemo/app/build.gradle.kts
@@ -11,6 +11,8 @@ plugins {
   id("org.jetbrains.kotlin.android")
 }
 
+def qnnVersion = System.properties['qnnVersion']
+
 android {
   namespace = "com.example.executorchllamademo"
   compileSdk = 34
@@ -61,6 +63,9 @@ dependencies {
   implementation("com.google.android.material:material:1.12.0")
   implementation("androidx.activity:activity:1.9.0")
   implementation("org.json:json:20250107")
+  if (qnnVersion) {
+    implementation "com.qualcomm.qti:qnn-runtime:$qnnVersion"
+  }
   testImplementation("junit:junit:4.13.2")
   androidTestImplementation("androidx.test.ext:junit:1.1.5")
   androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")

--- a/examples/demo-apps/android/LlamaDemo/docs/delegates/qualcomm_README.md
+++ b/examples/demo-apps/android/LlamaDemo/docs/delegates/qualcomm_README.md
@@ -212,6 +212,9 @@ sh examples/demo-apps/android/LlamaDemo/setup-with-qnn.sh
 This is running the shell script which configures the required core ExecuTorch, Llama2/3, and Android libraries, builds them into AAR, and copies it to the app.
 Note: If you are building the Android app mentioned in the next section on a separate machine (i.e. MacOS but building and exporting for QNN backend on Linux), make sure you copy the aar file generated from setup-with-qnn script to "examples/demo-apps/android/LlamaDemo/app/libs" before building the Android app.
 
+6. Set up the correct QNN version in gradle rule
+In app/build.gradle.kts, find the line `def qnnVersion = System.properties['qnnVersion']` and `implementation "com.qualcomm.qti:qnn-runtime:$qnnVersion"`. The gradle variable `qnnVersion` needs to be defined as the QNN SDK version (ex. 2.28). You can replace the line `def qnnVersion = System.properties['qnnVersion']` with `def qnnVersion = '2.28'` locally, or you can add `-DqnnVersion=2.28` when you trigger gradle build.
+
 
 ## Run the Android Demo App
 

--- a/examples/demo-apps/android/LlamaDemo/docs/delegates/qualcomm_README.md
+++ b/examples/demo-apps/android/LlamaDemo/docs/delegates/qualcomm_README.md
@@ -213,7 +213,7 @@ This is running the shell script which configures the required core ExecuTorch, 
 Note: If you are building the Android app mentioned in the next section on a separate machine (i.e. MacOS but building and exporting for QNN backend on Linux), make sure you copy the aar file generated from setup-with-qnn script to "examples/demo-apps/android/LlamaDemo/app/libs" before building the Android app.
 
 6. Set up the correct QNN version in gradle rule
-Currently, the gralde rule searches for the property `qnnVersion`. When this variable is defined, it will add QNN runtime library to the dependency. To use it, append the string `qnnVersion=<version>` (ex. `qnnVersion=2.28.0`) to the end of the `gradle.properties` file.
+Currently, the gralde rule searches for the property `qnnVersion`. When this variable is defined, it will add QNN runtime library to the dependency. To use it, append the string `qnnVersion=<version>` (ex. `qnnVersion=2.37.0`) to the end of the `gradle.properties` file.
 
 ## Run the Android Demo App
 

--- a/examples/demo-apps/android/LlamaDemo/docs/delegates/qualcomm_README.md
+++ b/examples/demo-apps/android/LlamaDemo/docs/delegates/qualcomm_README.md
@@ -213,8 +213,7 @@ This is running the shell script which configures the required core ExecuTorch, 
 Note: If you are building the Android app mentioned in the next section on a separate machine (i.e. MacOS but building and exporting for QNN backend on Linux), make sure you copy the aar file generated from setup-with-qnn script to "examples/demo-apps/android/LlamaDemo/app/libs" before building the Android app.
 
 6. Set up the correct QNN version in gradle rule
-In app/build.gradle.kts, find the line `def qnnVersion = System.properties['qnnVersion']` and `implementation "com.qualcomm.qti:qnn-runtime:$qnnVersion"`. The gradle variable `qnnVersion` needs to be defined as the QNN SDK version (ex. 2.28). You can replace the line `def qnnVersion = System.properties['qnnVersion']` with `def qnnVersion = '2.28'` locally, or you can add `-DqnnVersion=2.28` when you trigger gradle build.
-
+Currently, the gralde rule searches for the property `qnnVersion`. When this variable is defined, it will add QNN runtime library to the dependency. To use it, append the string `qnnVersion=<version>` (ex. `qnnVersion=2.28.0`) to the end of the `gradle.properties` file.
 
 ## Run the Android Demo App
 


### PR DESCRIPTION
### Summary
Now for QNN users, they can add the dependency `implementation "com.qualcomm.qti:qnn-runtime:$qnnVersion"` to add the runtime deps
### Test plan
CI