### PR TITLE
Delete copy of quantized SDPA in torchao/experimental

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -699,9 +699,7 @@ if(EXECUTORCH_BUILD_KERNELS_TORCHAO)
       ${EXECUTORCH_ROOT}/backends/xnnpack/third-party/pthreadpool/include
       ${EXECUTORCH_ROOT}/backends/xnnpack/third-party/cpuinfo/include
   )
-  add_subdirectory(
-    ${CMAKE_CURRENT_SOURCE_DIR}/third-party/ao/torchao/experimental
-  )
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/third-party/ao/torchao/csrc/cpu)
   unset(EXECUTORCH_INCLUDE_DIRS)
 
   executorch_target_link_options_shared_lib(torchao_ops_executorch)

--- a/extension/llm/custom_ops/op_sdpa_impl.h
+++ b/extension/llm/custom_ops/op_sdpa_impl.h
@@ -24,7 +24,7 @@
 #endif
 #include <executorch/extension/kernel_util/make_boxed_from_unboxed_functor.h>
 
-#include <torchao/experimental/kernels/cpu/interface/quantized_matmul.h>
+#include <torchao/csrc/cpu/torch_free_kernels/interface/quantized_matmul.h>
 
 namespace torch {
 namespace executor {

--- a/extension/llm/custom_ops/targets.bzl
+++ b/extension/llm/custom_ops/targets.bzl
@@ -14,7 +14,7 @@ def _get_quantized_sdpa_deps():
     if runtime.is_oss:
         return []
     else:
-        return ["//pytorch/ao/torchao/experimental/kernels/cpu/interface:interface"]
+        return ["//pytorch/ao/torchao/csrc/cpu/torch_free_kernels/interface:interface"]
 
 def _get_quantized_preproc_flags():
     if runtime.is_oss:


### PR DESCRIPTION
Summary:
This deletes the SDPA/matmul kernels in torchao/experimental.

These kernels were already migrated to torchao/csrc/cpu/torch_free_kernels in the first diff, but we needed to keep them around in torchao/experimental to do a pin bump in ExecuTorch OSS after the first diff lands.

Differential Revision: D81640227


