### PR TITLE
Allow zero-element tensors for shared inputs.

### DIFF
--- a/runtime/core/exec_aten/util/tensor_util_portable.cpp
+++ b/runtime/core/exec_aten/util/tensor_util_portable.cpp
@@ -147,12 +147,17 @@ Error share_tensor_data(
       t_dst.nbytes(),
       t_src.nbytes());
 
+  // Either the t_src is empty or contains valid data.
   ET_CHECK_OR_RETURN_ERROR(
-      t_src.mutable_data_ptr() != nullptr,
+      t_src.mutable_data_ptr() != nullptr || t_src.nbytes() == 0,
       InvalidArgument,
       "Source tensor should have data_ptr not being nullptr.");
+
+  // Setting data_ptr to nullptr explicitly when t_src is empty.
+  void* t_src_data_ptr =
+      t_src.numel() == 0 ? nullptr : t_src.mutable_data_ptr();
   // Assign internal data_ptr as the one in forwarded tensor
-  t_dst.unsafeGetTensorImpl()->set_data(t_src.mutable_data_ptr());
+  t_dst.unsafeGetTensorImpl()->set_data(t_src_data_ptr);
 
   return Error::Ok;
 }


### PR DESCRIPTION
Summary: Adds support for the case where method inputs are zero-element. Similar to https://github.com/pytorch/executorch/pull/13623, but adds support for shared input instead.

Differential Revision: D81653487


