### PR TITLE
Arm backend: Fix broken logic when checking os in utils.sh

### DIFF
--- a/backends/arm/scripts/utils.sh
+++ b/backends/arm/scripts/utils.sh
@@ -84,7 +84,7 @@ function check_os_support() {
     # Linux on arm64/aarch64
     # Darwin on arm64/aarch64
     if [[ "${ARCH}" == "aarch64" ]] || [[ "${ARCH}" == "arm64" ]]; then
-        if [[ "${OS}" != "Darwin" ]] || [[ "${OS}" != "Linux" ]]; then
+        if [[ "${OS}" != "Darwin" ]] && [[ "${OS}" != "Linux" ]]; then
             echo "Error: Only Linux and Darwin are supported on arm64"
             exit 1
         fi


### PR DESCRIPTION
The logic was flawed due to incorrect use of the logical OR operator.

This condition will always evaluate to true because an OS cant be both Darwin and Linux simultaneously.

Signed-off-by: per.held@arm.com
Change-Id: I562d715dba34b3eaf91351ba245b20767a634358
