### PR TITLE
Add boolean support for op_unbind_copy

### DIFF
--- a/kernels/portable/cpu/op_unbind_copy.cpp
+++ b/kernels/portable/cpu/op_unbind_copy.cpp
@@ -55,9 +55,9 @@ void unbind_copy_int_out(
   ScalarType in_type = input.scalar_type();
   ScalarType out_type = out[0].scalar_type();
 
-  ET_SWITCH_REALHBF16_TYPES(
+  ET_SWITCH_REALHBBF16_TYPES(
       in_type, ctx, "unbind_copy.int_out", CTYPE_IN, [&]() {
-        ET_SWITCH_REALHBF16_TYPES(
+        ET_SWITCH_REALHBBF16_TYPES(
             out_type, ctx, "unbind_copy.int_out", CTYPE_OUT, [&]() {
               const CTYPE_IN* const input_data =
                   input.const_data_ptr<CTYPE_IN>();


### PR DESCRIPTION
Fixes https://github.com/pytorch/executorch/issues/13552

🐛 Problem

The unbind_copy kernel crashed with fatal error when processing boolean tensors:
[op_unbind_copy.cpp:79] assert failed (false): Unhandled dtype Bool for unbind_copy.int_out
zsh: abort

✅ Solution

Extended type support to include boolean tensors by switching from ET_SWITCH_REALHBF16_TYPES to ET_SWITCH_REALHBBF16_TYPES macro.

📝 Changes

kernels/portable/cpu/op_unbind_copy.cpp:
// Before: Crashed on boolean tensors
ET_SWITCH_REALHBF16_TYPES(...)

// After: Supports boolean tensors
ET_SWITCH_REALHBBF16_TYPES(...)  // Includes Bool type

kernels/test/op_unbind_copy_test.cpp:
- Added BooleanTensorUnbindDim2 test case with input torch.bool (1, 7, 4) unbinding on dimension 2
- Validates correct output shape and data integrity

🛡️ Benefits

- No more crashes: Boolean tensors are now properly handled
- Broader compatibility: Supports additional data type for unbind operations
- Regression protection: Test ensures boolean support is maintained

✅ Testing

Verified boolean tensor unbinding works correctly on both portable and optimized kernels with comprehensive test coverage.
