### PR TITLE
[Backend Tester] Don't run fp64 model tests

### DIFF
--- a/backends/test/suite/models/__init__.py
+++ b/backends/test/suite/models/__init__.py
@@ -22,7 +22,6 @@ from executorch.backends.test.suite.runner import run_test
 DTYPES: list[torch.dtype] = [
     torch.float16,
     torch.float32,
-    torch.float64,
 ]
 
 


### PR DESCRIPTION
They add to a lot of failures and double precision isn't commonly used. We can look at re-enabling these in the future. Ideally all backends would just not delegate if they can't run it.