### PR TITLE
Arm backend: Add INT64 support to to_copy

### DIFF
--- a/backends/arm/test/models/stable_diffusion/test_T5EncoderModel.py
+++ b/backends/arm/test/models/stable_diffusion/test_T5EncoderModel.py
@@ -33,8 +33,9 @@ class TestT5EncoderModel(unittest.TestCase):
     # .to_executorch step, i.e. after Arm partitioner.
     ops_after_partitioner = {
         "executorch_exir_dialects_edge__ops_aten__to_copy_default": 2,
+        "executorch_exir_dialects_edge__ops_dim_order_ops__to_dim_order_copy_default": 1,
         "executorch_exir_dialects_edge__ops_aten_view_copy_default": 1,
-        "torch.ops.higher_order.executorch_call_delegate": 2,
+        "torch.ops.higher_order.executorch_call_delegate": 3,
     }
 
     def _prepare_inputs(

--- a/backends/arm/test/ops/test_to_copy.py
+++ b/backends/arm/test/ops/test_to_copy.py
@@ -70,6 +70,16 @@ def test_copy_tosa_FP(test_data: Tuple):
         aten_op=[],
         exir_op=[],
     )
+    # int to int cast is not supported in TOSA+FP profile
+    if not new_dtype.is_floating_point and not torch.is_floating_point(test_tensor):
+        pipeline.change_args(
+            "check_count.exir",
+            {
+                "torch.ops.higher_order.executorch_call_delegate": 0,
+                "executorch_exir_dialects_edge__ops_dim_order_ops__to_dim_order_copy_default": 1,
+            },
+        )
+        pipeline.pop_stage("run_method_and_compare_outputs")
     pipeline.run()
 
 
@@ -84,6 +94,15 @@ def test_copy_vgf_FP(test_data: Tuple):
         exir_op=[],
         tosa_version="TOSA-1.0+FP",
     )
+    # int to int cast is not supported in TOSA+FP profile
+    if not new_dtype.is_floating_point and not torch.is_floating_point(test_tensor):
+        pipeline.change_args(
+            "check_count.exir",
+            {
+                "torch.ops.higher_order.executorch_call_delegate": 0,
+                "executorch_exir_dialects_edge__ops_dim_order_ops__to_dim_order_copy_default": 1,
+            },
+        )
     pipeline.run()
 
 

--- a/backends/arm/test/passes/test_convert_int64_output_ops_to_int32.py
+++ b/backends/arm/test/passes/test_convert_int64_output_ops_to_int32.py
@@ -32,16 +32,7 @@ class CastingToInt64Model(torch.nn.Module):
 test_data_suite_convert = {
     "fp32_input": lambda: (torch.rand((1, 2, 3, 4), dtype=torch.float32), torch.int64),
     "fp16_input": lambda: (torch.rand((1, 2, 3, 4), dtype=torch.float16), torch.int64),
-    "int16_input": lambda: (
-        torch.randint(-127, 128, (1, 2, 3, 4), dtype=torch.int16),
-        torch.int64,
-    ),
-    "int8_input": lambda: (
-        torch.randint(-127, 128, (1, 2, 3, 4), dtype=torch.int8),
-        torch.int64,
-    ),
 }
-
 
 test_data_suite_remove = {
     "int32_input": lambda: (
@@ -52,7 +43,7 @@ test_data_suite_remove = {
 
 
 @common.parametrize("test_data", test_data_suite_convert)
-def test_convert_or_remove_casting_to_int64_covnert_tosa_FP(test_data: Tuple):
+def test_convert_or_remove_casting_to_int64_convert_tosa_FP(test_data: Tuple):
     test_tensor, target_dtype = test_data()
     module = CastingToInt64Model(target_dtype)
 


### PR DESCRIPTION
Partition to_copy from INT64 as these will be computed AOT and cast to INT32. Also disables partitioning of int-to-int casts for FP-profile.


cc @digantdesai @freddan80 @per @zingo