### PR TITLE
Arm backend: Add VGF to pybind build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -829,6 +829,10 @@ if(EXECUTORCH_BUILD_PYBIND)
     list(APPEND _dep_libs vulkan_backend)
   endif()
 
+  if(EXECUTORCH_BUILD_VGF)
+    list(APPEND _dep_libs vgf_backend)
+  endif()
+
   # compile options for pybind
   set(_pybind_compile_options -Wno-deprecated-declarations -fPIC -frtti
                               -fexceptions

--- a/tools/cmake/preset/pybind.cmake
+++ b/tools/cmake/preset/pybind.cmake
@@ -1,5 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
+# Copyright 2025 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -13,6 +14,8 @@ set_overridable_option(EXECUTORCH_BUILD_KERNELS_QUANTIZED_AOT ON)
 set_overridable_option(EXECUTORCH_ENABLE_LOGGING ON)
 set_overridable_option(EXECUTORCH_LOG_LEVEL Info)
 set_overridable_option(EXECUTORCH_BUILD_XNNPACK ON)
+set_overridable_option(EXECUTORCH_BUILD_VULKAN ON)
+set_overridable_option(EXECUTORCH_BUILD_VGF ON)
 set_overridable_option(EXECUTORCH_BUILD_EXTENSION_TENSOR ON)
 set_overridable_option(EXECUTORCH_BUILD_EXTENSION_RUNNER_UTIL ON)
 set_overridable_option(EXECUTORCH_BUILD_KERNELS_LLM ON)


### PR DESCRIPTION
Minor build additions for the VGF backend to work with the pybind runtime build. I suspect some testing will break on the runtime dependencies (layer driver shared objects, etc) - so ci will flush some of that out.

only so far tested on:

```
from pathlib import Path

import torch
from executorch.runtime import Verification, Runtime, Program, Method

et_runtime: Runtime = Runtime.get()
program: Program = et_runtime.load_program(
    Path("./models_v1/out_add.pte"),
    verification=Verification.Minimal,
)
print("Program methods:", program.method_names)
forward: Method = program.load_method("forward")

inputs = (torch.ones((5), dtype=torch.int32))
outputs = forward.execute(inputs)
print(f"Ran forward({inputs})")
print(f"  outputs: {outputs}")

```


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218