### PR TITLE
Fixing the broken unit tests caused by missing portable lib import.

### DIFF
--- a/backends/nxp/tests/ir/edge_passes/test_remove_io_quant_ops_pass.py
+++ b/backends/nxp/tests/ir/edge_passes/test_remove_io_quant_ops_pass.py
@@ -5,6 +5,7 @@
 
 import itertools
 
+import executorch.extension.pybindings.portable_lib
 import executorch.kernels.quantized  # noqa F401
 import torch
 from executorch.backends.nxp.tests.executorch_pipeline import to_quantized_edge_program


### PR DESCRIPTION
### Summary
Adding missing portable lib import.

### Test plan
This is a fix for broken NXP unit tests.


cc @digantdesai @JakeStevens @robert-kalmar