### PR TITLE
remove Numpy-2.0 incompatible use of numpy.product

### DIFF
--- a/backends/cadence/aot/tests/test_ref_implementations.py
+++ b/backends/cadence/aot/tests/test_ref_implementations.py
@@ -214,12 +214,12 @@ class TestRefImplementations(unittest.TestCase):
         expected_output: torch.Tensor,
     ) -> None:
         src = (
-            torch.arange(np.product(src_shape))
+            torch.arange(np.prod(src_shape))
             .reshape(src_shape)
             .to(expected_output.dtype)
         )
         weight = (
-            torch.arange(np.product(weight_shape))
+            torch.arange(np.prod(weight_shape))
             .reshape(weight_shape)
             .to(expected_output.dtype)
         )


### PR DESCRIPTION
Summary: Replaced with numpy.prod in Numpy 2.0+. Used ruff to replace instances.

Reviewed By: florazzz

Differential Revision: D81945242
