### PR TITLE
Arm backend: Update Vela to 4.4.0 python package

### DIFF
--- a/backends/arm/requirements-arm-ethos-u.txt
+++ b/backends/arm/requirements-arm-ethos-u.txt
@@ -3,4 +3,4 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-ethos-u-vela @ git+https://gitlab.arm.com/artificial-intelligence/ethos-u/ethos-u-vela@d37febc1715edf0d236c2ff555739a8a9aadcf9a
+ethos-u-vela == 4.4.0

--- a/backends/arm/test/ops/test_logical.py
+++ b/backends/arm/test/ops/test_logical.py
@@ -86,9 +86,6 @@ class Not(torch.nn.Module):
 #################
 
 
-xfails = {"rand_rank4": "MLBEDSW-11031: Output diff on u85 bool transpose."}
-
-
 @common.parametrize("test_data", And().test_data)
 def test_logical_and_tosa_FP(test_data: input_t2):
     pipeline = TosaPipelineFP[input_t2](
@@ -132,7 +129,7 @@ def test_logical_and_u55_INT_not_delegated(test_data: input_t2):
     pipeline.run()
 
 
-@common.parametrize("test_data", And().test_data, xfails=xfails)
+@common.parametrize("test_data", And().test_data)
 @common.XfailIfNoCorstone320
 def test_logical_and_u85_INT(test_data: input_t2):
     pipeline = EthosU85PipelineINT[input_t2](
@@ -226,7 +223,7 @@ def test_logical_xor_u55_INT_not_delegated(test_data: input_t2):
     pipeline.run()
 
 
-@common.parametrize("test_data", Xor().test_data, xfails=xfails)
+@common.parametrize("test_data", Xor().test_data)
 @common.XfailIfNoCorstone320
 def test_logical_xor_u85_INT(test_data: input_t2):
     pipeline = EthosU85PipelineINT[input_t2](
@@ -320,7 +317,7 @@ def test_logical_or_u55_INT_not_delegated(test_data: input_t2):
     pipeline.run()
 
 
-@common.parametrize("test_data", Or().test_data, xfails=xfails)
+@common.parametrize("test_data", Or().test_data)
 @common.XfailIfNoCorstone320
 def test_logical_or_u85_INT(test_data: input_t2):
     pipeline = EthosU85PipelineINT[input_t2](
@@ -414,7 +411,7 @@ def test_logical_not_u55_INT_not_delegated(test_data: input_t2):
     pipeline.run()
 
 
-@common.parametrize("test_data", Not().test_data, xfails=xfails)
+@common.parametrize("test_data", Not().test_data)
 @common.XfailIfNoCorstone320
 def test_logical_not_u85_INT(test_data: input_t2):
     pipeline = EthosU85PipelineINT[input_t2](

--- a/backends/arm/test/ops/test_logsoftmax.py
+++ b/backends/arm/test/ops/test_logsoftmax.py
@@ -64,13 +64,7 @@ def test_log_softmax_tosa_INT(test_data):
     pipeline.run()
 
 
-@common.parametrize(
-    "test_data",
-    LogSoftmax.test_data,
-    xfails={
-        "randn_neg_dim": "MLBEDSW-11032: ILLEGAL_OFM_BASE error: Base addresses must be aligned to brick depth on u55."
-    },
-)
+@common.parametrize("test_data", LogSoftmax.test_data)
 @common.XfailIfNoCorstone300()
 def test_log_softmax_u55_INT(test_data):
     data, dim = test_data()

--- a/backends/arm/test/ops/test_softmax.py
+++ b/backends/arm/test/ops/test_softmax.py
@@ -61,13 +61,7 @@ def test_softmax_tosa_INT(test_data):
     pipeline.run()
 
 
-@common.parametrize(
-    "test_data",
-    Softmax.test_data,
-    {
-        "randn_neg_dim": "MLBEDSW-11032: ILLEGAL_OFM_BASE error: Base addresses must be aligned to brick depth on u55."
-    },
-)
+@common.parametrize("test_data", Softmax.test_data)
 @common.XfailIfNoCorstone300
 def test_softmax_u55_INT(test_data):
     data, dim = test_data()

--- a/backends/arm/test/passes/test_rescale_pass.py
+++ b/backends/arm/test/passes/test_rescale_pass.py
@@ -172,14 +172,7 @@ def test_quantized_rescale_tosa_bi(test_data: tuple[torch.Tensor, torch.Tensor])
     pipeline.run()
 
 
-u55_xfails = {
-    "ones": "MLBEDSW-11032: ILLEGAL_OFM_BASE error: Base addresses must be aligned to brick depth on u55.",
-    "randn_ones": "MLBEDSW-11032: ILLEGAL_OFM_BASE error: Base addresses must be aligned to brick depth on u55.",
-    "randn_large": "MLBEDSW-11032: ILLEGAL_OFM_BASE error: Base addresses must be aligned to brick depth on u55.",
-}
-
-
-@common.parametrize("test_data", RescaleNetwork.test_data, xfails=u55_xfails)
+@common.parametrize("test_data", RescaleNetwork.test_data)
 @common.XfailIfNoCorstone300
 def test_quantized_rescale_u55(test_data: tuple[torch.Tensor, torch.Tensor]):
     """Tests a model with many ops that requires rescales. As more ops are quantized to int32 and


### PR DESCRIPTION
### Summary
Update to Vela 4.4.0. python packages, this fix some bugs.

### Test plan
Testcases updated and moved from expected fails to pass in the PR

cc @digantdesai @freddan80 @per @oscarandersson8218