### PR TITLE
Qualcomm AI Engine Direct - GA Static Olmo-1b

### DIFF
--- a/backends/qualcomm/_passes/__init__.py
+++ b/backends/qualcomm/_passes/__init__.py
@@ -28,6 +28,7 @@ from .fold_qdq import FoldQDQ
 from .fuse_consecutive_cast import FuseConsecutiveCast
 from .fuse_consecutive_transpose import FuseConsecutiveTranspose
 from .i64_to_i32 import I64toI32
+from .insert_frozen_layer_norm_weight import InsertFrozenLayerNormWeight
 from .insert_io_qdq import InsertIOQDQ
 from .insert_requantize import InsertRequantize
 from .layout_transform import LayoutTransform
@@ -67,6 +68,7 @@ __all__ = [
     FuseConsecutiveCast,
     FuseConsecutiveTranspose,
     I64toI32,
+    InsertFrozenLayerNormWeight,
     InsertIOQDQ,
     InsertRequantize,
     LayoutTransform,

--- a/backends/qualcomm/_passes/insert_frozen_layer_norm_weight.py
+++ b/backends/qualcomm/_passes/insert_frozen_layer_norm_weight.py
@@ -1,0 +1,64 @@
+# Copyright (c) Qualcomm Innovation Center, Inc.
+# All rights reserved
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import torch
+from executorch.exir.pass_base import ExportPass, PassResult
+
+
+# TODO: Remove this workaround once HTP fixes the bug — LayerNorm without weights should be supported.
+class InsertFrozenLayerNormWeight(ExportPass):
+    """
+    This pass injects a frozen weight parameter (filled with ones) into LayerNorm ops
+    that were exported without weight (i.e., elementwise_affine=False), to satisfy
+    backends that require the presence of a weight parameter.
+
+    It operates at the ExportedProgram level, modifying both the FX graph and
+    the graph_signature to include the new frozen parameter.
+
+    Example transformation:
+
+        Before:
+            %out = aten.layer_norm(%x, normalized_shape=[128], weight=None, bias=None, eps=1e-5)
+
+        After:
+            %weight = get_attr("layer_norm_weight_0")
+            %out = aten.layer_norm(%x, normalized_shape=[128], weight=%weight, bias=None, eps=1e-5)
+
+    The injected weight is a frozen parameter with all values set to 1.0.
+    """
+
+    def __init__(self):
+        super(InsertFrozenLayerNormWeight, self).__init__()
+        self.layer_norm = torch.ops.aten.layer_norm.default
+
+    def call(self, graph_module: torch.fx.GraphModule) -> PassResult:
+        graph = graph_module.graph
+        modified = False
+        frozen_weight_idx = 0
+
+        for node in graph.nodes:
+            if node.op != "call_function" or node.target != self.layer_norm:
+                continue
+
+            # Detect LayerNorm ops missing the 'weight' argument
+            if len(node.args) < 3:
+                normalized_shape = node.args[1]
+
+                # Create a frozen weight tensor filled with ones
+                param_name = f"{self.layer_norm.__name__.split('.')[0]}_weight_{frozen_weight_idx}"
+                frozen_weight = torch.ones(normalized_shape)
+                graph_module.register_buffer(param_name, frozen_weight)
+                with graph.inserting_before(node):
+                    weight_node = graph.get_attr(param_name)
+                node.args = (node.args[0], node.args[1], weight_node, *node.args[3:])
+
+                frozen_weight_idx += 1
+                modified = True
+
+        graph.eliminate_dead_code()
+        graph_module.recompile()
+        return PassResult(graph_module, modified)

--- a/backends/qualcomm/_passes/qnn_pass_manager.py
+++ b/backends/qualcomm/_passes/qnn_pass_manager.py
@@ -33,6 +33,7 @@ from executorch.backends.qualcomm._passes import (
     FuseConsecutiveCast,
     FuseConsecutiveTranspose,
     I64toI32,
+    InsertFrozenLayerNormWeight,
     InsertIOQDQ,
     InsertRequantize,
     LayoutTransform,
@@ -201,6 +202,7 @@ class QnnPassManager(PassManager):
         self.add_pass(DecomposeEinsum())
         self.add_pass(DecomposeExpM1())
         self.add_pass(DecomposeLinalgVectorNorm(quantization_capture=True))
+        self.add_pass(InsertFrozenLayerNormWeight())
         self.add_pass(ReplaceInfValues())
         self.add_pass(LiftConstantScalarOperands())
         return self._transform(graph_module)
@@ -220,6 +222,7 @@ class QnnPassManager(PassManager):
         if convert_linear_to_conv2d:
             self.add_pass(ConvertLinearToConv2d(exported_program))
         self.add_pass(ConvertSquareToPow())
+        self.add_pass(InsertFrozenLayerNormWeight())
         self.add_pass(LiftConstantScalarOperands())
         self._transform(exported_program.graph_module)
         ep = lift_constant_tensor_pass(exported_program)

--- a/backends/qualcomm/builders/op_layer_norm.py
+++ b/backends/qualcomm/builders/op_layer_norm.py
@@ -40,6 +40,7 @@ class LayerNormVisitor(NodeVisitor):
             PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
             nodes_to_wrappers,
         )
+        layer_norm_input_tensors = [input_tensor_wrapper]
 
         normalized_shapes = node.args[1]
         if (
@@ -55,16 +56,16 @@ class LayerNormVisitor(NodeVisitor):
         axis_shape = [len(axis)]
 
         weight_node = self.get_node(node.args[2])
-        weight_tensor = get_parameter(weight_node, self.edge_program)
-        weight_tensor_wrapper = self.define_tensor(
-            weight_node,
-            node,
-            weight_tensor,
-            PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_STATIC,
-            nodes_to_wrappers,
-        )
-
-        layer_norm_input_tensors = [input_tensor_wrapper, weight_tensor_wrapper]
+        if weight_node is not None:
+            weight_tensor = get_parameter(weight_node, self.edge_program)
+            weight_tensor_wrapper = self.define_tensor(
+                weight_node,
+                node,
+                weight_tensor,
+                PyQnnWrapper.Qnn_TensorType_t.QNN_TENSOR_TYPE_STATIC,
+                nodes_to_wrappers,
+            )
+            layer_norm_input_tensors.append(weight_tensor_wrapper)
 
         bias_node = self.get_node(node.args[3])
         if bias_node is not None:

--- a/backends/qualcomm/tests/models.py
+++ b/backends/qualcomm/tests/models.py
@@ -1113,6 +1113,17 @@ class LargeTensorLinear(torch.nn.Module):
         return self.linear2(x1)
 
 
+class LayerNormWithoutParams(torch.nn.Module):
+    def __init__(self, hidden_size: int):
+        super().__init__()
+        self.normalized_shape = (hidden_size,)
+
+    def forward(self, x):
+        return torch.nn.functional.layer_norm(
+            x, self.normalized_shape, None, None, eps=1e-5
+        )
+
+
 class LayerNorm(torch.nn.Module):
     def __init__(self, bias=True):
         super().__init__()

--- a/examples/models/llama/model_args.py
+++ b/examples/models/llama/model_args.py
@@ -22,6 +22,7 @@ class ModelArgs:
     num_experts: int = 8  # Number of experts
     num_activated_experts: int = 2  # Number of experts to activate
     attention_type: str = "mha"  # Attention type, registered in attention.py
+    norm_type: str = "rmsnorm"  # Normalization type, registered in norm.py
     attention_qkv_bias: bool = False
     use_kv_cache: bool = False  # Use key/value cache
     use_sdpa_with_kv_cache_op: bool = (

--- a/examples/models/olmo/__init__.py
+++ b/examples/models/olmo/__init__.py
@@ -1,0 +1,16 @@
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from executorch.examples.models.llama.model import Llama2Model
+from executorch.examples.models.olmo.convert_weights import convert_weights
+
+
+class OlmoModel(Llama2Model):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+__all__ = [
+    "OlmoModel",
+    "convert_weights",
+]

--- a/examples/models/olmo/config/1b_config.json
+++ b/examples/models/olmo/config/1b_config.json
@@ -1,0 +1,13 @@
+{
+  "attention_qkv_bias": false,
+  "dim": 2048,
+  "hidden_dim": 8192,
+  "n_heads": 16,
+  "n_layers": 16,
+  "n_kv_heads": 16,
+  "norm_type": "olmo",
+  "norm_eps": 1e-05,
+  "use_scaled_rope": false,
+  "rope_theta": 10000.0,
+  "vocab_size": 50304
+}

--- a/examples/models/olmo/convert_weights.py
+++ b/examples/models/olmo/convert_weights.py
@@ -1,0 +1,109 @@
+import argparse
+
+import json
+import os
+from typing import Dict
+
+import torch
+
+from torchtune.models.convert_weights import get_mapped_key
+from safetensors.torch import load_file
+
+
+_HF_OLMO_FROM_META = {
+    "tok_embeddings.weight": "model.embed_tokens.weight",
+    "layers.{}.attention.wq.weight": "model.layers.{}.self_attn.q_proj.weight",
+    "layers.{}.attention.wk.weight": "model.layers.{}.self_attn.k_proj.weight",
+    "layers.{}.attention.wv.weight": "model.layers.{}.self_attn.v_proj.weight",
+    "layers.{}.attention.wo.weight": "model.layers.{}.self_attn.o_proj.weight",
+    "layers.{}.feed_forward.w1.weight": "model.layers.{}.mlp.gate_proj.weight",
+    "layers.{}.feed_forward.w3.weight": "model.layers.{}.mlp.up_proj.weight",
+    "layers.{}.feed_forward.w2.weight": "model.layers.{}.mlp.down_proj.weight",
+    "output.weight": "lm_head.weight",
+}
+
+def olmo_to_executorch(state_dict: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
+    """
+    Convert a state dict from hf's format to Meta's format.
+
+    Args:
+        state_dict (Dict[str, torch.Tensor]): State dict in hf's format.
+
+    Returns:
+        Dict[str, torch.Tensor]: State dict in Meta's format.
+    """
+    converted_state_dict = {}
+    inverted_mapping_dict = {v: k for k, v in _HF_OLMO_FROM_META.items()}
+    for key, value in state_dict.items():
+        new_key = get_mapped_key(key, inverted_mapping_dict)
+        converted_state_dict[new_key] = value
+
+    # If lm_head.weight is not present in state dict, assume tied embeddings (e.g., 0.6b and 4b models)
+    if "lm_head.weight" not in state_dict:
+        converted_state_dict["output.weight"] = converted_state_dict[
+            "tok_embeddings.weight"
+        ]
+    return converted_state_dict
+
+
+def load_checkpoint_from_safetensors(input_dir: str) -> Dict:
+    index_path = os.path.join(input_dir, "model.safetensors.index.json")
+    if os.path.exists(index_path):
+        # Sharded checkpoint.
+        with open(index_path, "r") as f:
+            index = json.load(f)
+        weight_map = index["weight_map"]
+        checkpoint_shards = sorted(set(weight_map.values()))
+
+        # Load all the shards into memory
+        shard_to_weights = {}
+        for shard in checkpoint_shards:
+            shard_to_weights[shard] = load_file(os.path.join(input_dir, shard))
+
+        # Merge tensors into consolidated state dict.
+        merged_state_dict = {}
+        for weight_name, shard in weight_map.items():
+            tensor = shard_to_weights[shard][weight_name]
+            merged_state_dict[weight_name] = tensor
+        return merged_state_dict
+    else:
+        # Single checkpoint.
+        state_dict = load_file(os.path.join(input_dir, "model.safetensors"))
+        return state_dict
+
+
+def load_checkpoint(input_dir: str) -> Dict:
+    pytorch_path = os.path.join(input_dir, "pytorch_model.bin")
+    if os.path.exists(pytorch_path):
+        print("Loading checkpoint from PyTorch .bin file")
+        return torch.load(pytorch_path, map_location="cpu", weights_only=True)
+    print("Loading checkpoint from safetensors directory")
+    return load_checkpoint_from_safetensors(input_dir)
+
+def convert_weights(input_dir: str, output_file: str) -> None:
+    print("Loading checkpoint...")
+    sd = load_checkpoint(input_dir)
+    print("Converting checkpoint...")
+    sd = olmo_to_executorch(sd)
+    print("Saving checkpoint...")
+    torch.save(sd, output_file)
+    print("Done.")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Convert Olmo weights to Meta format."
+    )
+    parser.add_argument(
+        "input_dir",
+        type=str,
+        help="Path to directory containing checkpoint files, or path to a single checkpoint file.",
+    )
+    parser.add_argument("output", type=str, help="Path to the output checkpoint")
+
+    args = parser.parse_args()
+    convert_weights(args.input_dir, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/qualcomm/oss_scripts/llama/README.md
+++ b/examples/qualcomm/oss_scripts/llama/README.md
@@ -5,10 +5,11 @@ This file provides you the instructions to run LLM Decoder model with different 
  1. LLAMA2 Stories 110M
  2. LLAMA3.2 1B
  3. LLAMA3.2 3B
- 4. QWEN2.5 0.5B / 1.5B
- 5. QWEN3 0.6B / 1.7B
- 6. Phi4-mini-instruct
- 7. SMOLLM2 135M
+ 4. OLMo 1B
+ 5. Phi4-mini-instruct
+ 6. QWEN2.5 0.5B / 1.5B
+ 7. QWEN3 0.6B / 1.7B
+ 8. SMOLLM2 135M
 
 We offer the following modes to execute the model:
 
@@ -67,6 +68,12 @@ python examples/qualcomm/oss_scripts/llama/llama.py -b build-android -s ${SERIAL
 Default example using hybrid mode.
 ```bash
 python examples/qualcomm/oss_scripts/llama/llama.py -b build-android -s ${SERIAL_NUM} -m ${SOC_MODEL} --checkpoint consolidated.00.pth --params params.json --tokenizer_model tokenizer.model --decoder_model llama3_2 --model_mode hybrid --prefill_ar_len 32 --max_seq_len 128 --prompt "what is 1+1"
+```
+
+#### OLMo 1B
+Default example using hybrid mode.
+```bash
+python examples/qualcomm/oss_scripts/llama/llama.py -b build-android -s ${SERIAL_NUM} -m ${SOC_MODEL} --decoder_model olmo-1b --model_mode hybrid --prefill_ar_len 128 --max_seq_len 1024 --prompt "Simply put, the theory of relativity states that" --tasks wikitext --limit 1
 ```
 
 #### Phi4-mini-instruct

--- a/examples/qualcomm/oss_scripts/llama/decoder_constants.py
+++ b/examples/qualcomm/oss_scripts/llama/decoder_constants.py
@@ -15,10 +15,11 @@ DECODER_MODEL_VERSION = {
     "stories260k": "llama2",
     "stories110m": "llama2",
     "llama3_2": "llama3",
+    "olmo-1b": "olmo",
+    "phi_4_mini": "phi_4_mini",
     "qwen2_5-0_5b": "qwen2_5",
     "qwen2_5-1_5b": "qwen2_5",
     "qwen3-0_6b": "qwen3",
     "qwen3-1_7b": "qwen3",
-    "phi_4_mini": "phi_4_mini",
     "smollm2_135m": "smollm2_135m",
 }

--- a/examples/qualcomm/oss_scripts/llama/eval_llama_qnn.py
+++ b/examples/qualcomm/oss_scripts/llama/eval_llama_qnn.py
@@ -16,7 +16,8 @@ import torch
 from executorch.backends.qualcomm.quantizer.custom_annotation import (
     annotate_kv_8bit,
     annotate_output_16a8w,
-    annotate_wv_sha,
+    annotate_qkv_proj_sha,
+    StaticLLMQuantConfig,
 )
 
 from executorch.backends.qualcomm.quantizer.observers.per_channel_param_observer import (
@@ -218,7 +219,9 @@ def gen_eval_wrapper(model_name, args):
         custom_annotations = (
             annotate_kv_8bit,
             partial(
-                annotate_wv_sha, quantization_config=quantization_config_wv_sha_8a4w
+                annotate_qkv_proj_sha,
+                qkv_tags={StaticLLMQuantConfig.wv_sha},
+                quantization_config=quantization_config_wv_sha_8a4w,
             ),
         )
         if args.llama_model == "stories110m":

--- a/examples/qualcomm/oss_scripts/llama/model/__init__.py
+++ b/examples/qualcomm/oss_scripts/llama/model/__init__.py
@@ -1,0 +1,12 @@
+# Copyright (c) Qualcomm Innovation Center, Inc.
+# All rights reserved
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from .layernom import NORM_REGISTRY
+
+
+__all__ = [
+    NORM_REGISTRY,
+]

--- a/examples/qualcomm/oss_scripts/llama/model/layernom.py
+++ b/examples/qualcomm/oss_scripts/llama/model/layernom.py
@@ -1,0 +1,59 @@
+# Copyright (c) Qualcomm Innovation Center, Inc.
+# All rights reserved
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from abc import ABC, abstractmethod
+from typing import Dict, Type
+
+import torch
+import torch.nn.functional as F
+
+
+class Norm(torch.nn.Module, ABC):
+    """Abstract base class for normalization layers with unified interface."""
+
+    @abstractmethod
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Forward pass for normalization layer.
+        Args:
+            x: Input tensor
+        Returns:
+            Normalized tensor
+        """
+        pass
+
+
+NORM_REGISTRY: Dict[str, Type[Norm]] = {}
+
+
+def register_norm(name: str):
+    """Decorator to register norm classes"""
+
+    def decorator(cls: Type[Norm]):
+        NORM_REGISTRY[name.lower()] = cls
+        return cls
+
+    return decorator
+
+
+# Copied from https://github.com/huggingface/transformers/blob/main/src/transformers/models/olmo/modular_olmo.py
+@register_norm("olmo")
+class OlmoLayerNorm(Norm):
+    """LayerNorm but with no learnable weight or bias."""
+
+    def __init__(self, hidden_size: int, eps=1e-5) -> None:
+        super().__init__()
+        self.normalized_shape = (hidden_size,)
+        self.eps = eps
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        orig_dtype = hidden_states.dtype
+        return F.layer_norm(
+            hidden_states.to(dtype=torch.float32),
+            self.normalized_shape,
+            None,
+            None,
+            eps=self.eps,
+        ).to(orig_dtype)

--- a/examples/qualcomm/oss_scripts/llama/qnn_llama_runner.cpp
+++ b/examples/qualcomm/oss_scripts/llama/qnn_llama_runner.cpp
@@ -103,6 +103,7 @@ std::string get_formatted_prompt(
   switch (decoder_model_version) {
     case example::DecoderModelVersion::kLlama2:
     case example::DecoderModelVersion::kQwen2_5:
+    case example::DecoderModelVersion::kOlmo:
       formatted_prompt.append(prompt);
       break;
     case example::DecoderModelVersion::kQwen3:

--- a/examples/qualcomm/oss_scripts/llama/runner/runner.cpp
+++ b/examples/qualcomm/oss_scripts/llama/runner/runner.cpp
@@ -122,6 +122,8 @@ Runner<T>::Runner(
     decoder_model_version_ = DecoderModelVersion::kLlama2;
   } else if (decoder_model_version == "llama3") {
     decoder_model_version_ = DecoderModelVersion::kLlama3;
+  } else if (decoder_model_version == "olmo") {
+    decoder_model_version_ = DecoderModelVersion::kOlmo;
   } else if (decoder_model_version == "qwen2_5") {
     decoder_model_version_ = DecoderModelVersion::kQwen2_5;
   } else if (decoder_model_version == "qwen3") {

--- a/examples/qualcomm/oss_scripts/llama/runner/runner.h
+++ b/examples/qualcomm/oss_scripts/llama/runner/runner.h
@@ -31,6 +31,7 @@ namespace example {
 enum DecoderModelVersion {
   kLlama2 = 0,
   kLlama3,
+  kOlmo,
   kQwen2_5,
   kQwen3,
   kPhi4,


### PR DESCRIPTION
Summary:
- e2e script for GA Static OLMo-1b
 - perf 16a4w block quant token rate in kv mode: ~= 63 tokens/sec(SM8750)
 - acc: PPL ~= (fp: 8.735 -> htp: 9.945) in wikitext dataset
- add model params file & model weight converter
- add workaround pass for LayerNorm without weight & unitest
- fix layernorm op builder & fix layernorm quant annotator

### Test plan
``` bash
python examples/qualcomm/oss_scripts/llama/llama.py -b build-android -s ${SERIAL_NUM} -m SM8750 --decoder_model olmo-1b --model_mode kv --max_seq_len 1024 --prompt "Simply put, the theory of relativity states that" --tasks wikitext --limit 1 --eval_perplexity
```
cc: @haowhsu-quic 