### PR TITLE
Fix missing kernel header in stack util

### DIFF
--- a/kernels/portable/cpu/util/targets.bzl
+++ b/kernels/portable/cpu/util/targets.bzl
@@ -302,6 +302,8 @@ def define_common_targets():
         exported_headers = ["stack_util.h"],
         deps = [
             "//executorch/kernels/portable/cpu/util:copy_ops_util",
+        ],
+        exported_deps = [
             "//executorch/runtime/kernel:kernel_includes",
         ],
         visibility = ["//executorch/kernels/portable/cpu/...", "@EXECUTORCH_CLIENTS"],


### PR DESCRIPTION
Summary:
Given `stack_util.h` is exported and it includes `kernel_includes.h`, we need `kernel_includes` in the build dependency.

One solution is to expect the clients who use `slice_util` to also add `kernel_includes`. However, "doing it for them" via exported_deps seems like a nicer solution.

Reviewed By: silverguo

Differential Revision: D81930473


