### PR TITLE
custom fbcode serialize stage to run FVP internally on arm ops tests

### DIFF
--- a/backends/arm/test/TARGETS
+++ b/backends/arm/test/TARGETS
@@ -40,8 +40,17 @@ runtime.python_library(
 )
 
 runtime.python_library(
-    name = "arm_tester",
-    srcs = glob(["tester/*.py"]),
+    name = "arm_tester_serialize",
+    srcs = ["tester/serialize.py"],
+    deps = [
+        "//executorch/backends/xnnpack/test/tester:tester",
+        "//executorch/devtools/backend_debug:delegation_info",
+    ]
+)
+
+runtime.python_library(
+    name = "arm_tester_lib",
+    srcs = glob(["tester/*.py"], exclude = ["tester/serialize.py"]),
     deps = [
         ":common",
         "//executorch/backends/xnnpack/test/tester:tester",
@@ -52,6 +61,15 @@ runtime.python_library(
         "//executorch/devtools/backend_debug:delegation_info",
         "//executorch/exir/backend:operator_support",
         "fbsource//third-party/pypi/tabulate:tabulate",
+    ]
+)
+
+
+runtime.python_library(
+    name = "arm_tester",
+    deps = [
+        "//executorch/backends/arm/test:arm_tester_lib",
+        "//executorch/backends/arm/test:arm_tester_serialize",
     ]
 )
 

--- a/backends/arm/test/ops/test_tanh.py
+++ b/backends/arm/test/ops/test_tanh.py
@@ -70,25 +70,27 @@ def test_tanh_tosa_INT(test_data: Tuple):
 
 
 @common.parametrize("test_data", test_data_suite)
+@common.XfailIfNoCorstone300
 def test_tanh_u55_INT(test_data: Tuple):
     pipeline = EthosU55PipelineINT[input_t1](
         Tanh(),
         (test_data(),),
         aten_op,
         exir_ops=[],
-        run_on_fvp=False,
+        run_on_fvp=True,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data_suite)
+@common.XfailIfNoCorstone320
 def test_tanh_u85_INT(test_data: Tuple):
     pipeline = EthosU85PipelineINT[input_t1](
         Tanh(),
         (test_data(),),
         aten_op,
         exir_ops=[],
-        run_on_fvp=False,
+        run_on_fvp=True,
     )
     pipeline.run()
 

--- a/backends/arm/test/targets.bzl
+++ b/backends/arm/test/targets.bzl
@@ -1,4 +1,5 @@
 # load("//caffe2/test/fb:defs.bzl", "define_tests")
+load("@fbsource//tools/build_defs:fbsource_utils.bzl", "is_fbcode")
 load("@fbcode_macros//build_defs:python_pytest.bzl", "python_pytest")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 
@@ -59,7 +60,7 @@ def define_arm_tests():
                 "//executorch/kernels/quantized:custom_ops_generated_lib",
             ],
             deps = [
-                "//executorch/backends/arm/test:arm_tester",
+                "//executorch/backends/arm/test/tester/fb:arm_tester_fb" if is_fbcode else "//executorch/backends/arm/test:arm_tester",
                 "//executorch/backends/arm/test:conftest",
                 "//executorch/backends/arm:ethosu",
                 "//executorch/backends/arm/tosa:compile_spec",

--- a/backends/arm/test/tester/serialize.py
+++ b/backends/arm/test/tester/serialize.py
@@ -1,0 +1,75 @@
+# Copyright 2024-2025 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+import os
+from typing import Optional
+
+import executorch.backends.xnnpack.test.tester.tester as tester
+
+import torch.fx
+
+from executorch.backends.arm.common.arm_compile_spec import ArmCompileSpec
+
+from executorch.backends.arm.test.runner_utils import (
+    get_elf_path,
+    get_target_board,
+    run_target,
+)
+
+from executorch.exir import ExecutorchProgramManager
+from torch.utils._pytree import tree_flatten
+
+
+logger = logging.getLogger(__name__)
+
+
+class Serialize(tester.Serialize):
+    def __init__(
+        self,
+        compile_spec: ArmCompileSpec,
+        module: Optional[torch.nn.Module],
+        timeout: int = 120,
+    ):
+        """
+        Args:
+            compile_spec: CompileSpecs to be used for serialization.
+            module: Original Module to be used for serialization. Optional - can be used for reference output generation.
+            timeout: Timeout for fvp. Default is 120 seconds.
+        """
+        super().__init__()
+        self.module = module
+        self.timeout = timeout
+        self.executorch_program_manager: ExecutorchProgramManager | None
+        self.compile_spec = compile_spec
+
+    def run(self, artifact: ExecutorchProgramManager, inputs=None) -> None:
+        super().run(artifact, inputs)
+        # Keep the entire ExecutorchProgramManager for execution.
+        self.executorch_program_manager = artifact
+
+    def run_artifact(self, inputs):
+        if self.executorch_program_manager is None:
+            raise RuntimeError(
+                "Tried running artifact from Serialize stage without running the stage."
+            )
+        inputs_flattened, _ = tree_flatten(inputs)
+        intermediate_path = self.compile_spec.get_intermediate_path()
+        target_board = get_target_board(self.compile_spec)
+        elf_path = get_elf_path(target_board)
+
+        if not os.path.exists(elf_path):
+            raise FileNotFoundError(
+                f"Did not find build arm_executor_runner in path {elf_path}, run setup_testing.sh?"
+            )
+
+        return run_target(
+            self.executorch_program_manager,
+            inputs_flattened,
+            intermediate_path,
+            target_board,
+            elf_path,
+            self.timeout,
+        )


### PR DESCRIPTION
Summary:
update the codebase to allow a system whereby:

- the test inventory in https://www.internalfb.com/code/fbsource/fbcode/executorch/backends/arm/test/ops/, which until now runs on open source CI can all be exercised internally on our internal diff-time sandcastle and CI runs
- those tests can **transparently** switch between running an internal version of FVP using Meta's FVP runtimes, build configs and artifacts when run in fbsrouce, but then use the open-source FVp runtime when executed in github opens-ource CI

Differential Revision: D81159036


