### PR TITLE
Arm backend: Refactor setup.sh $PATH creation

### DIFF
--- a/backends/arm/scripts/mlsdk_utils.sh
+++ b/backends/arm/scripts/mlsdk_utils.sh
@@ -124,5 +124,29 @@ function setup_model_converter() {
     popd
 }
 
+function setup_path_model_converter() {
+    cd "${root_dir}"
+    model_converter_bin_path="$(cd ${mlsdk_manifest_dir}/sw/model-converter/build && pwd)"
+    append_env_in_setup_path PATH ${model_converter_bin_path}
+}
+
+function setup_path_vgf_lib() {
+    cd "${root_dir}"
+    model_vgf_path="$(cd ${mlsdk_manifest_dir}/sw/vgf-lib/deploy && pwd)"
+    append_env_in_setup_path PATH ${model_vgf_path}/bin
+    append_env_in_setup_path LD_LIBRARY_PATH "${model_vgf_path}/lib"
+    append_env_in_setup_path DYLD_LIBRARY_PATH "${model_vgf_path}/lib"
+}
+
+function setup_path_emulation_layer() {
+    cd "${root_dir}"
+    model_emulation_layer_path="$(cd ${mlsdk_manifest_dir}/sw/emulation-layer/ && pwd)"
+    prepend_env_in_setup_path LD_LIBRARY_PATH "${model_emulation_layer_path}/deploy/lib"
+    prepend_env_in_setup_path DYLD_LIBRARY_PATH "${model_emulation_layer_path}/deploy/lib"
+    prepend_env_in_setup_path VK_INSTANCE_LAYERS VK_LAYER_ML_Tensor_Emulation
+    prepend_env_in_setup_path VK_INSTANCE_LAYERS VK_LAYER_ML_Graph_Emulation
+    prepend_env_in_setup_path VK_ADD_LAYER_PATH "${model_emulation_layer_path}/deploy/share/vulkan/explicit_layer.d"
+}
+
 #setup_model_converter() $1
 # `"$manifest_dir"'

--- a/backends/arm/scripts/toolchain_utils.sh
+++ b/backends/arm/scripts/toolchain_utils.sh
@@ -80,3 +80,8 @@ function setup_toolchain() {
     rm -rf "${toolchain_dir}"
     tar xf "${toolchain_dir}.tar.xz"
 }
+
+function setup_path_toolchain() {
+    toolchain_bin_path="$(cd ${toolchain_dir}/bin && pwd)"
+    append_env_in_setup_path PATH ${toolchain_bin_path}
+}

--- a/backends/arm/scripts/utils.sh
+++ b/backends/arm/scripts/utils.sh
@@ -4,6 +4,16 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# Important to check for unset variables since this script is always sourced from setup.sh
+set -u
+
+# Check if the script is being sourced
+(return 0 2>/dev/null)
+if [[ $? -ne 0 ]]; then
+    echo "Error: This script must be sourced."
+    exit 1
+fi
+
 function verify_md5() {
     # Compare the md5 of a file with a provided expected value.
 
@@ -89,4 +99,20 @@ function check_os_support() {
             exit 1
         fi
     fi
+}
+
+function prepend_env_in_setup_path() {
+    echo "export $1=$2:\${$1-}" >> ${setup_path_script}.sh
+    echo "set --path -pgx $1 $2" >> ${setup_path_script}.fish
+}
+
+function append_env_in_setup_path() {
+    echo "export $1=\${$1-}:$2" >> ${setup_path_script}.sh
+    echo "set --path -agx $1 $2" >> ${setup_path_script}.fish
+}
+
+function clear_setup_path() {
+    # Clear setup_path_script
+    echo "" > "${setup_path_script}.sh"
+    echo "" > "${setup_path_script}.fish"
 }

--- a/backends/arm/scripts/vulkan_utils.sh
+++ b/backends/arm/scripts/vulkan_utils.sh
@@ -64,3 +64,9 @@ function setup_vulkan_sdk() {
         exit 1
     fi
 }
+
+function setup_path_vulkan() {
+    cd "${root_dir}"
+    vulkan_sdk_bin_path="$(cd ${vulkan_sdk_bin_dir} && pwd)"
+    append_env_in_setup_path PATH ${vulkan_sdk_bin_path}
+}

--- a/examples/arm/setup.sh
+++ b/examples/arm/setup.sh
@@ -183,62 +183,37 @@ function setup_ethos_u_tools() {
     CMAKE_POLICY_VERSION_MINIMUM=3.5 BUILD_PYBIND=1 pip install --no-dependencies -r $et_dir/backends/arm/requirements-arm-ethos-u.txt
 }
 
-function prepend_env_in_setup_path() {
-    echo "export $1=$2:\${$1-}" >> ${setup_path_script}.sh
-    echo "set --path -pgx $1 $2" >> ${setup_path_script}.fish
-}
-
-function append_env_in_setup_path() {
-    echo "export $1=\${$1-}:$2" >> ${setup_path_script}.sh
-    echo "set --path -agx $1 $2" >> ${setup_path_script}.fish
-}
-
 function create_setup_path(){
     cd "${root_dir}"
 
-    # Clear setup_path_script
-    echo "" > "${setup_path_script}.sh"
-    echo "" > "${setup_path_script}.fish"
+    clear_setup_path
 
     if [[ "${enable_fvps}" -eq 1 ]]; then
         setup_path_fvp
     fi
 
     if [[ "${enable_baremetal_toolchain}" -eq 1 ]]; then
-        toolchain_bin_path="$(cd ${toolchain_dir}/bin && pwd)"
-        append_env_in_setup_path PATH ${toolchain_bin_path}
+        setup_path_toolchain
     fi
 
     if [[ "${enable_vulkan_sdk}" -eq 1 ]]; then
-        cd "${root_dir}"
-        vulkan_sdk_bin_path="$(cd ${vulkan_sdk_bin_dir} && pwd)"
-        append_env_in_setup_path PATH ${vulkan_sdk_bin_path}
+        setup_path_vulkan
     fi
 
     if [[ "${enable_model_converter}" -eq 1 ]]; then
-        cd "${root_dir}"
-        model_converter_bin_path="$(cd ${mlsdk_manifest_dir}/sw/model-converter/build && pwd)"
-        append_env_in_setup_path PATH ${model_converter_bin_path}
+        setup_path_model_converter
     fi
 
-    # Add Path for vgf-lib and emulation-layer
     if [[ "${enable_vgf_lib}" -eq 1 ]]; then
-        cd "${root_dir}"
-        model_vgf_path="$(cd ${mlsdk_manifest_dir}/sw/vgf-lib/deploy && pwd)"
-        append_env_in_setup_path PATH ${model_vgf_path}/bin
-        append_env_in_setup_path LD_LIBRARY_PATH "${model_vgf_path}/lib"
-        append_env_in_setup_path DYLD_LIBRARY_PATH "${model_vgf_path}/lib"
+        setup_path_vgf_lib
     fi
 
     if [[ "${enable_emulation_layer}" -eq 1 ]]; then
-        cd "${root_dir}"
-        model_emulation_layer_path="$(cd ${mlsdk_manifest_dir}/sw/emulation-layer/ && pwd)"
-        prepend_env_in_setup_path LD_LIBRARY_PATH "${model_emulation_layer_path}/deploy/lib"
-        prepend_env_in_setup_path DYLD_LIBRARY_PATH "${model_emulation_layer_path}/deploy/lib"
-        prepend_env_in_setup_path VK_INSTANCE_LAYERS VK_LAYER_ML_Tensor_Emulation
-        prepend_env_in_setup_path VK_INSTANCE_LAYERS VK_LAYER_ML_Graph_Emulation
-        prepend_env_in_setup_path VK_ADD_LAYER_PATH "${model_emulation_layer_path}/deploy/share/vulkan/explicit_layer.d"
+        setup_path_emulation_layer
     fi
+
+    echo "[main] Update path by running 'source ${setup_path_script}.sh'"
+    echo "[main] Or for fish shell use 'source ${setup_path_script}.fish'"
 }
 
 
@@ -305,13 +280,8 @@ if [[ $is_script_sourced -eq 0 ]]; then
         setup_model_converter ${root_dir} ${mlsdk_manifest_dir} ${enable_model_converter} ${enable_vgf_lib} ${enable_emulation_layer}
     fi
 
-    # Create new setup_path script
-    if [[ "${enable_baremetal_toolchain}" -eq 1 || \
-           "${enable_fvps}" -eq 1 || \
-           "${enable_vulkan_sdk}" -eq 1 || \
-          "${enable_model_converter}" -eq 1 ]]; then
-        create_setup_path
-    fi
+    # Create the setup_path.sh used to create the PATH variable for shell
+    create_setup_path
 
     # Setup the tosa_reference_model and dependencies
     CMAKE_POLICY_VERSION_MINIMUM=3.5 BUILD_PYBIND=1 pip install --no-dependencies -r $et_dir/backends/arm/requirements-arm-tosa.txt
@@ -320,8 +290,6 @@ if [[ $is_script_sourced -eq 0 ]]; then
         setup_ethos_u_tools
     fi
 
-    echo "[main] Update path by running 'source ${setup_path_script}.sh'"
-    hash fish 2>/dev/null && echo >&2 "[main] Or for fish shell use 'source ${setup_path_script}.fish'"
     echo "[main] success!"
     exit 0
 fi


### PR DESCRIPTION
Break up the create_setup_path() function and move the path creation code specific for each module into their respective sub script to not clutter up setup.sh.

Functions added in respective script are "setup_path_X" for each sub script.

Signed-off-by: per.held@arm.com
Change-Id: Ie9ab8c5c722a8e450c08b7b519faa34b8b55f699
