### PR TITLE
CI: Enable trunk jobs on PRs

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -8,12 +8,6 @@ on:
     tags:
       - ciflow/trunk/*
   pull_request:
-    paths:
-      - .ci/docker/ci_commit_pins/pytorch.txt
-      - .ci/scripts/**
-    branches:
-      - main
-      - release/*
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Enable trunk jobs on any PR

Reverts https://github.com/pytorch/executorch/pull/14060

