### PR TITLE
Arm backend: Remove _vgf_ op pytest xfails

### DIFF
--- a/backends/arm/scripts/mlsdk_utils.sh
+++ b/backends/arm/scripts/mlsdk_utils.sh
@@ -145,7 +145,7 @@ function setup_path_emulation_layer() {
     prepend_env_in_setup_path DYLD_LIBRARY_PATH "${model_emulation_layer_path}/deploy/lib"
     prepend_env_in_setup_path VK_INSTANCE_LAYERS VK_LAYER_ML_Tensor_Emulation
     prepend_env_in_setup_path VK_INSTANCE_LAYERS VK_LAYER_ML_Graph_Emulation
-    prepend_env_in_setup_path VK_ADD_LAYER_PATH "${model_emulation_layer_path}/deploy/share/vulkan/explicit_layer.d"
+    prepend_env_in_setup_path VK_LAYER_PATH "${model_emulation_layer_path}/deploy/share/vulkan/explicit_layer.d"
 }
 
 #setup_model_converter() $1

--- a/backends/arm/test/ops/test_add.py
+++ b/backends/arm/test/ops/test_add.py
@@ -209,7 +209,6 @@ filtered_test_data = {k: v for k, v in Add.test_data.items() if k not in skip_ke
 
 @common.parametrize("test_data", filtered_test_data)
 @common.SkipIfNoModelConverter
-@pytest.mark.xfail(reason="'Failed to load VKML extensions' error in ci.")
 def test_add_tensor_vgf_FP(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         Add(),
@@ -227,7 +226,6 @@ def test_add_tensor_vgf_FP(test_data: input_t1):
 
 @common.parametrize("test_data", filtered_test_data)
 @common.SkipIfNoModelConverter
-@pytest.mark.xfail(reason="'Failed to load VKML extensions' error in ci.")
 def test_add_tensor_vgf_INT(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         Add(),


### PR DESCRIPTION
Use VK_LAYER_PATH instead of VK_ADD_LAYER_PATH when setting up mlsdk deps since looks like some loaders ignore VK_ADD_LAYER_PATH.


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218