### PR TITLE
Fix format string error in Android PAL initialization assert macro

### DIFF
--- a/runtime/platform/default/android.cpp
+++ b/runtime/platform/default/android.cpp
@@ -46,7 +46,6 @@
       __android_log_print(                                          \
           ANDROID_LOG_FATAL,                                        \
           "ExecuTorch",                                             \
-          "%s",                                                     \
           "ExecuTorch PAL must be initialized before call to %s()", \
           ET_FUNCTION);                                             \
     }                                                               \


### PR DESCRIPTION
Summary: The `__android_log_print` call had an extra `"%s"` format specifier that wasn't matched by the provided arguments, causing `-Werror,-Wformat-extra-args` compilation failures.

Reviewed By: smeenai

Differential Revision: D81949537


