### PR TITLE
Add manifest extension AoT

### DIFF
--- a/extension/manifest/TARGETS
+++ b/extension/manifest/TARGETS
@@ -1,0 +1,15 @@
+load("@fbcode_macros//build_defs:python_library.bzl", "python_library")
+
+oncall("executorch")
+
+python_library(
+    name = "_manifest",
+    srcs = [
+        "_manifest.py",
+    ],
+    deps = [
+        "//executorch/exir/_serialize:lib",
+        "//executorch/exir:_warnings",
+    ],
+    visibility = ["PUBLIC"],
+)

--- a/extension/manifest/__init__.py
+++ b/extension/manifest/__init__.py
@@ -1,0 +1,12 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from executorch.extension.manifest._manifest import append_manifest, Manifest
+
+__all__ = [
+    "Manifest",
+    "append_manifest",
+]

--- a/extension/manifest/_manifest.py
+++ b/extension/manifest/_manifest.py
@@ -1,0 +1,206 @@
+from dataclasses import dataclass
+from typing import ClassVar, Literal
+
+from executorch.exir._serialize.padding import padding_required
+from executorch.exir._warnings import experimental
+
+# Byte order of numbers written to the manifest. Always little-endian
+# regardless of the host system, since all commonly-used modern CPUs are little
+# endian.
+_MANIFEST_BYTEORDER: Literal["little"] = "little"
+
+
+@dataclass
+class _ManifestLayout:
+    """Python class mirroring the binary layout of the manifest.
+    separate from the Manifest class, which is the user facing
+    representation.
+    """
+
+    EXPECTED_MAGIC: ClassVar[bytes] = b"em00"
+
+    MAX_SIGNATURE_SIZE: ClassVar[int] = 512
+
+    EXPECTED_MIN_LENGTH: ClassVar[int] = (
+        # Header magic
+        4
+        # Header length
+        + 4
+        # program offset
+        + 8
+        # Padding
+        + 4
+        # signature size
+        + 4
+    )
+
+    EXPECTED_MAX_LENGTH: ClassVar[int] = EXPECTED_MIN_LENGTH + MAX_SIGNATURE_SIZE
+
+    signature: bytes
+
+    # The actual size of the signature
+    signature_size: int = 0
+
+    # The size of any padding required
+    padding_size: int = 0
+
+    # Size in bytes between the top of the manifest and the start of the data it was appended to.
+    program_offset: int = 0
+
+    # The manifest length, in bytes, read from or to be written to the binary
+    # footer.
+    length: int = 0
+
+    # The magic bytes read from or to be written to the binary footer.
+    magic: bytes = EXPECTED_MAGIC
+
+    def __post_init__(self):
+        """Post init hook to validate the manifest."""
+        if self.signature_size == 0:
+            self.signature_size = len(self.signature)
+        if self.length == 0:
+            self.length = _ManifestLayout.EXPECTED_MIN_LENGTH + self.signature_size
+
+        # Not using self.is_valid() here to deliver better error messages.
+        if len(self.signature) > _ManifestLayout.MAX_SIGNATURE_SIZE:
+            raise ValueError(
+                f"Signature is too large. {self.signature_size}. Manifest only supports signatures up to {_ManifestLayout.MAX_SIGNATURE_SIZE} bytes."
+            )
+        if self.magic != _ManifestLayout.EXPECTED_MAGIC:
+            raise ValueError(
+                f"Invalid magic. Expected {_ManifestLayout.EXPECTED_MAGIC}. Got {self.magic}"
+            )
+        if self.length < _ManifestLayout.EXPECTED_MIN_LENGTH:
+            raise ValueError(
+                f"Invalid length. Expected at least {_ManifestLayout.EXPECTED_MIN_LENGTH}. Got {self.length}"
+            )
+        if self.length > _ManifestLayout.EXPECTED_MAX_LENGTH:
+            raise ValueError(
+                f"Invalid length. Expected at most {_ManifestLayout.EXPECTED_MAX_LENGTH}. Got {self.length}"
+            )
+        if self.signature_size != len(self.signature):
+            raise ValueError(
+                f"Invalid signature size must match len(self.signature). Expected {len(self.signature)}. Got {self.signature_size}"
+            )
+
+    def is_valid(self) -> bool:
+        """Returns true if the manifest appears to be well-formed."""
+        return (
+            self.magic == _ManifestLayout.EXPECTED_MAGIC
+            and self.length >= _ManifestLayout.EXPECTED_MIN_LENGTH
+            and self.length <= _ManifestLayout.EXPECTED_MAX_LENGTH
+            and self.signature_size >= 0
+            and self.signature_size <= _ManifestLayout.MAX_SIGNATURE_SIZE
+            and self.program_offset >= 0
+            and len(self.signature) == self.signature_size
+        )
+
+    def to_bytes(self) -> bytes:
+        """"Returns the binary representation of the Manifest. Written bottom up
+        to allow for BC considerations. The compatibility-preserving way to make
+        changes is to increase the header's length field and add new fields at
+        the top. This means we can always check the last 8 bytes for the magic
+        and size, and then load the full footer."
+        """
+        if not self.is_valid():
+            raise ValueError("Cannot serialize an invalid manifest")
+
+        data: bytes = (
+            # bytes: Signature unique ID for the data the manifest was appended to.
+            self.signature
+            # actual size of the signature
+            + self.signature_size.to_bytes(4, byteorder=_MANIFEST_BYTEORDER)
+            # uint32_t: Any padding required to align the manifest.
+            + self.padding_size.to_bytes(4, byteorder=_MANIFEST_BYTEORDER)
+            # uint64_t: Size in bytes between the manifest and the data it was appended to.
+            + self.program_offset.to_bytes(8, byteorder=_MANIFEST_BYTEORDER)
+            # uint32_t: Actual size of this manifest.
+            + self.length.to_bytes(4, byteorder=_MANIFEST_BYTEORDER)
+            # Manifest magic. This lets consumers detect whether the
+            # manifest was inserted or not. Always use the proper magic value
+            # (i.e., ignore self.magic) since there's no reason to create an
+            # invalid manifest.
+            + self.EXPECTED_MAGIC
+        )
+        return data
+
+    @staticmethod
+    def from_bytes(data: bytes) -> "_ManifestLayout":
+        """Tries to read a manifest from the provided data.
+
+        Does not validate that the header is well-formed. Callers should
+        use is_valid().
+
+        Args:
+            data: The data to read from.
+        Returns:
+            The contents of the serialized manifest.
+        Raises:
+            ValueError: If not enough data is provided.
+        """
+        if len(data) <= _ManifestLayout.EXPECTED_MIN_LENGTH:
+            raise ValueError(
+                f"Not enough data for the manifest: {len(data)} "
+                + f"< {_ManifestLayout.EXPECTED_MIN_LENGTH}"
+            )
+        magic = data[-4:]
+        length = int.from_bytes(data[-8:-4], byteorder=_MANIFEST_BYTEORDER)
+        program_offset = int.from_bytes(data[-16:-8], byteorder=_MANIFEST_BYTEORDER)
+        padding_size = int.from_bytes(data[-20:-16], byteorder=_MANIFEST_BYTEORDER)
+        signature_size = int.from_bytes(data[-24:-20], byteorder=_MANIFEST_BYTEORDER)
+        signature = data[-(signature_size + 24) : -24]
+        return _ManifestLayout(
+            signature=signature,
+            signature_size=signature_size,
+            padding_size=padding_size,
+            program_offset=program_offset,
+            length=length,
+            magic=magic,
+        )
+
+    @staticmethod
+    def from_manifest(manifest: "Manifest") -> "_ManifestLayout":
+        return _ManifestLayout(
+            signature=manifest.signature,
+            signature_size=len(manifest.signature),
+            length=_ManifestLayout.EXPECTED_MIN_LENGTH + len(manifest.signature),
+            # program_offset and padding_size are set at append time.
+        )
+
+
+@experimental("This API is experimental and subject to change without notice.")
+@dataclass
+class Manifest:
+    """A manifest that can be appended to a binary blob. The manifest contains
+    meta information about the binary blob. You must know who created the manifest
+    to be able to interpret the data in the manifest."""
+
+    # Unique ID for the data the manifest was appended to. Often this might contain
+    # a crytographic signature for the data.
+    signature: bytes
+
+    @staticmethod
+    def _from_manifest_layout(layout: _ManifestLayout) -> "Manifest":
+        return Manifest(
+            signature=layout.signature,
+        )
+
+    @staticmethod
+    def from_bytes(data: bytes) -> "Manifest":
+        """Tries to read a manifest from the provided data."""
+        layout = _ManifestLayout.from_bytes(data)
+        if not layout.is_valid():
+            raise ValueError("Cannot parse manifest from bytes")
+        return Manifest._from_manifest_layout(layout)
+
+
+@experimental("This API is experimental and subject to change without notice.")
+def append_manifest(pte_data: bytes, manifest: Manifest, alignment: int = 16):
+    """Appends a manifest to the provided data."""
+    padding = padding_required(len(pte_data), alignment)
+
+    manifest_layout = _ManifestLayout.from_manifest(manifest)
+    manifest_layout.program_offset = len(pte_data) + manifest_layout.padding_size
+    manifest_layout.padding_size = padding
+
+    return pte_data + (b"\x00" * padding) + manifest_layout.to_bytes()

--- a/extension/manifest/test/TARGETS
+++ b/extension/manifest/test/TARGETS
@@ -1,0 +1,16 @@
+load("@fbcode_macros//build_defs:python_unittest.bzl", "python_unittest")
+
+oncall("executorch")
+
+python_unittest(
+    name = "test_manifest",
+    srcs = [
+        "test_manifest.py",
+    ],
+    deps = [
+        "//executorch/extension/manifest:_manifest",
+        "//executorch/extension/pybindings:portable_lib",
+        "//executorch/exir:lib",
+        "//caffe2:torch",
+    ],
+)

--- a/extension/manifest/test/test_manifest.py
+++ b/extension/manifest/test/test_manifest.py
@@ -1,0 +1,317 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+
+from executorch.exir import to_edge
+from executorch.extension.manifest._manifest import (
+    _MANIFEST_BYTEORDER,
+    _ManifestLayout,
+    append_manifest,
+    Manifest,
+)
+from executorch.extension.pybindings.portable_lib import (
+    _load_for_executorch_from_buffer,
+)
+from torch.export import export
+
+
+class TestManifestLayout(unittest.TestCase):
+    """Test cases for _ManifestLayout class."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.valid_signature = b"test_signature_123"
+        self.valid_signature_size = len(self.valid_signature)
+        self.valid_program_offset = 1008
+        self.valid_padding_size = 8
+        self.manifest_layout = _ManifestLayout(
+            signature=self.valid_signature,
+            program_offset=self.valid_program_offset,
+            padding_size=self.valid_padding_size,
+        )
+
+    def test_init_with_defaults(self):
+        """Test initialization with default values."""
+        layout = _ManifestLayout(signature=b"test123")
+        self.assertEqual(layout.signature, b"test123")
+        self.assertEqual(layout.signature_size, 7)
+        self.assertEqual(layout.magic, _ManifestLayout.EXPECTED_MAGIC)
+
+    def test_is_valid_true(self):
+        """Test is_valid returns True for valid manifest."""
+        self.assertTrue(self.manifest_layout.is_valid())
+
+    def test_is_valid_false_wrong_magic(self):
+        """Test is_valid returns False for wrong magic."""
+        self.manifest_layout.magic = b"bad!"
+        self.assertFalse(self.manifest_layout.is_valid())
+
+    def test_is_valid_false_short_length(self):
+        """Test is_valid returns False for length too short."""
+        self.manifest_layout.length = _ManifestLayout.EXPECTED_MIN_LENGTH - 1
+        self.assertFalse(self.manifest_layout.is_valid())
+
+    def test_to_bytes(self):
+        """Test converting manifest layout to bytes."""
+        data = self.manifest_layout.to_bytes()
+
+        # Should be exactly EXPECTED_MIN_LENGTH + signature_size bytes
+        expected_length = (
+            _ManifestLayout.EXPECTED_MIN_LENGTH + self.valid_signature_size
+        )
+        self.assertEqual(len(data), expected_length)
+
+        # Check magic at the end
+        self.assertEqual(data[-4:], _ManifestLayout.EXPECTED_MAGIC)
+
+        # Check length field
+        expected_length_bytes = expected_length.to_bytes(
+            4, byteorder=_MANIFEST_BYTEORDER
+        )
+        self.assertEqual(data[-8:-4], expected_length_bytes)
+
+        # Check program offset (8 bytes)
+        expected_program_offset = self.valid_program_offset.to_bytes(
+            8, byteorder=_MANIFEST_BYTEORDER
+        )
+        self.assertEqual(data[-16:-8], expected_program_offset)
+
+        # Check padding size (4 bytes)
+        expected_padding_size = self.valid_padding_size.to_bytes(
+            4, byteorder=_MANIFEST_BYTEORDER
+        )
+        self.assertEqual(data[-20:-16], expected_padding_size)
+
+        # Check signature size (4 bytes)
+        expected_signature_size = self.valid_signature_size.to_bytes(
+            4, byteorder=_MANIFEST_BYTEORDER
+        )
+        self.assertEqual(data[-24:-20], expected_signature_size)
+
+        # Check signature (variable length bytes at the beginning)
+        self.assertEqual(data[: self.valid_signature_size], self.valid_signature)
+
+    def test_from_bytes_valid_data(self):
+        """Test creating manifest layout from valid bytes."""
+        original_data = self.manifest_layout.to_bytes()
+
+        # Add some extra data at the beginning to simulate real usage
+        full_data = b"some_data_here" + original_data
+
+        layout = _ManifestLayout.from_bytes(full_data)
+
+        self.assertEqual(layout.signature, self.valid_signature)
+        self.assertEqual(layout.signature_size, self.valid_signature_size)
+        self.assertEqual(
+            layout.length,
+            _ManifestLayout.EXPECTED_MIN_LENGTH + self.valid_signature_size,
+        )
+        self.assertEqual(layout.magic, _ManifestLayout.EXPECTED_MAGIC)
+
+    def test_from_bytes_insufficient_data(self):
+        """Test from_bytes raises ValueError with insufficient data."""
+        short_data = b"short"
+
+        with self.assertRaises(ValueError) as cm:
+            _ManifestLayout.from_bytes(short_data)
+
+        self.assertIn("Not enough data for the manifest", str(cm.exception))
+
+    def test_from_bytes_success(self):
+        """Test from_bytes works with exactly the required length."""
+        data = self.manifest_layout.to_bytes()
+        layout = _ManifestLayout.from_bytes(data)
+
+        self.assertEqual(layout.signature, self.valid_signature)
+        self.assertEqual(layout.signature_size, self.valid_signature_size)
+
+    def test_from_manifest(self):
+        """Test creating manifest layout from Manifest object."""
+        manifest = Manifest(signature=self.valid_signature)
+        layout = _ManifestLayout.from_manifest(manifest)
+
+        self.assertEqual(layout.signature, self.valid_signature)
+
+    def test_roundtrip_to_bytes_from_bytes(self):
+        """Test that to_bytes and from_bytes are inverse operations."""
+        original = self.manifest_layout
+        data = original.to_bytes()
+        reconstructed = _ManifestLayout.from_bytes(data)
+
+        self.assertEqual(original.signature, reconstructed.signature)
+        self.assertEqual(original.signature_size, reconstructed.signature_size)
+        self.assertEqual(original.program_offset, reconstructed.program_offset)
+        self.assertEqual(original.magic, reconstructed.magic)
+
+
+class TestManifest(unittest.TestCase):
+    """Test cases for Manifest class."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.valid_signature = b"manifest_test_sig"
+        self.manifest = Manifest(signature=self.valid_signature)
+
+    def test_from_bytes_valid(self):
+        """Test creating Manifest from valid bytes."""
+        layout = _ManifestLayout(signature=self.valid_signature)
+        data = layout.to_bytes()
+
+        manifest = Manifest.from_bytes(data)
+        print("foobar")
+        print(layout)
+        print(manifest)
+
+        self.assertEqual(manifest.signature, self.valid_signature)
+
+    def test_from_bytes_invalid_data(self):
+        """Test from_bytes raises ValueError with invalid data."""
+        # Create invalid layout with wrong magic
+        layout = _ManifestLayout(signature=self.valid_signature)
+        layout.magic = b"bad!"
+        # Can't easily construct invalid data since to_bytes() enforces validity
+        # Instead, create some invalid bytes manually
+        data = b"invalid_data_too_short"
+
+        with self.assertRaises(ValueError) as cm:
+            Manifest.from_bytes(data)
+
+        self.assertIn("Not enough data for the manifest", str(cm.exception))
+
+    def test_from_bytes_insufficient_data(self):
+        """Test from_bytes raises ValueError with insufficient data."""
+        short_data = b"short"
+
+        with self.assertRaises(ValueError):
+            Manifest.from_bytes(short_data)
+
+
+class TestAppendManifest(unittest.TestCase):
+    """Test cases for append_manifest function."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.signature = b"test_append_sig"
+        self.manifest = Manifest(signature=self.signature)
+        self.test_data = b"12345678"
+
+    def test_append_manifest_default_alignment(self):
+        """Test append_manifest with default alignment."""
+        result = append_manifest(self.test_data, self.manifest)
+
+        # Check that data was appended
+        self.assertGreater(len(result), len(self.test_data))
+
+        # The manifest should be at the end
+        expected_manifest_length = _ManifestLayout.EXPECTED_MIN_LENGTH + len(
+            self.signature
+        )
+        manifest_data = result[-expected_manifest_length:]
+        reconstructed_manifest_layout = _ManifestLayout.from_bytes(manifest_data)
+        reconstructed_manifest = Manifest.from_bytes(manifest_data)
+
+        self.assertEqual(reconstructed_manifest.signature, self.signature)
+        self.assertEqual(
+            reconstructed_manifest_layout.signature_size, len(self.signature)
+        )
+        self.assertEqual(
+            reconstructed_manifest_layout.program_offset, len(self.test_data)
+        )
+
+
+class TestEndToEndManifestIntegration(unittest.TestCase):
+    """End-to-end integration test for ExecutorTorch models with manifests."""
+
+    def test_simple_nn_module_with_manifest(self):
+        """Test creating a simple nn.Module, lowering to ExecutorTorch, adding manifest, and running."""
+
+        # Create a simple neural network module
+        class SimpleLinearModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(4, 2)
+                self.relu = torch.nn.ReLU()
+
+            def forward(self, x):
+                x = self.linear(x)
+                x = self.relu(x)
+                return x
+
+        # Create model and sample input
+        model = SimpleLinearModel()
+        sample_input = (torch.ones(1, 4, dtype=torch.float32),)
+
+        # Lower to ExecutorTorch
+        exported_program = export(model, sample_input, strict=True)
+        edge_program = to_edge(exported_program)
+        executorch_program = edge_program.to_executorch()
+
+        # Get the serialized program data
+        program_data = executorch_program.buffer
+        self.assertGreater(len(program_data), 0, "Program data should not be empty")
+
+        # Create a manifest with a unique signature
+        test_signature = b"integration_test_sig"
+        manifest = Manifest(signature=test_signature)
+
+        # Add manifest to the program data
+        final_data = append_manifest(program_data, manifest, alignment=16)
+
+        # Check that the manifest was appended
+        self.assertGreater(
+            len(final_data),
+            len(program_data),
+            "Data should be larger after adding manifest",
+        )
+
+        # Verify manifest fields are correct
+        expected_manifest_length = _ManifestLayout.EXPECTED_MIN_LENGTH + len(
+            test_signature
+        )
+        manifest_bytes = final_data[-expected_manifest_length:]
+        reconstructed_layout = _ManifestLayout.from_bytes(manifest_bytes)
+        reconstructed_manifest = Manifest.from_bytes(manifest_bytes)
+
+        # Check manifest fields
+        self.assertTrue(reconstructed_layout.is_valid(), "Manifest should be valid")
+        self.assertEqual(
+            reconstructed_manifest.signature, test_signature, "Signature should match"
+        )
+        self.assertEqual(
+            reconstructed_layout.magic,
+            _ManifestLayout.EXPECTED_MAGIC,
+            "Magic should match",
+        )
+        self.assertEqual(
+            reconstructed_layout.signature_size,
+            len(test_signature),
+            "Signature size should match",
+        )
+
+        # Check program offset calculation
+        self.assertEqual(
+            reconstructed_layout.program_offset,
+            len(program_data),
+            "Program offset should be correct",
+        )
+
+        # Load and execute the model with ExecutorTorch runtime
+        module = _load_for_executorch_from_buffer(final_data)
+
+        test_input = torch.ones(1, 4, dtype=torch.float32)
+        output = module.run_method("forward", (test_input,))
+
+        with torch.no_grad():
+            expected_output = model(test_input)
+
+        torch.testing.assert_close(output[0], expected_output, atol=1e-5, rtol=1e-5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
Add some infra for us to optionally add some key structured data to the end of a pte. This diff is around enabling users to easily tag their model with a cryptographic signature. Has room to expand later.

A key design motivation is it would be ideal if this is transparent to the rest of the extensions we have today. Im claiming the prime footer real estate for this which is unused today by anything in tree. This should let it be composable with other formats like bundledProgram too.

Differential Revision: D82052721


