### PR TITLE
NXP backend: Update aot_neutron_compile.py example pipeline

### DIFF
--- a/backends/nxp/tests/executorch_pipeline.py
+++ b/backends/nxp/tests/executorch_pipeline.py
@@ -15,9 +15,6 @@ from executorch.backends.nxp.backend.custom_delegation_options import (
 from executorch.backends.nxp.edge_passes.neutron_edge_pass_manager import (
     NeutronEdgePassManager,
 )
-from executorch.backends.nxp.edge_passes.remove_io_quant_ops_pass import (
-    RemoveIOQuantOpsPass,
-)
 from executorch.backends.nxp.neutron_partitioner import NeutronPartitioner
 from executorch.backends.nxp.nxp_backend import generate_neutron_compile_spec
 from executorch.backends.nxp.quantizer.neutron_quantizer import NeutronQuantizer
@@ -115,12 +112,9 @@ def to_quantized_edge_program(
         edge_compile_config=edge_compile_config,
     )
 
-    edge_program_manager = NeutronEdgePassManager()(edge_program_manager)
-
-    if remove_quant_io_ops:
-        edge_program_manager = edge_program_manager.transform(
-            [RemoveIOQuantOpsPass(edge_program_manager=edge_program_manager)]
-        )
+    edge_program_manager = NeutronEdgePassManager(
+        remove_io_quant_ops=remove_quant_io_ops
+    )(edge_program_manager)
 
     compile_spec = generate_neutron_compile_spec(
         target,

--- a/backends/nxp/tests/executorch_pipeline.py
+++ b/backends/nxp/tests/executorch_pipeline.py
@@ -117,6 +117,11 @@ def to_quantized_edge_program(
 
     edge_program_manager = NeutronEdgePassManager()(edge_program_manager)
 
+    if remove_quant_io_ops:
+        edge_program_manager = edge_program_manager.transform(
+            [RemoveIOQuantOpsPass(edge_program_manager=edge_program_manager)]
+        )
+
     compile_spec = generate_neutron_compile_spec(
         target,
         operators_not_to_delegate=operators_not_to_delegate,
@@ -124,11 +129,6 @@ def to_quantized_edge_program(
     )
     partitioner = NeutronPartitioner(compile_spec, custom_delegation_options)
     edge_program_manager = edge_program_manager.to_backend(partitioner)
-
-    if remove_quant_io_ops:
-        edge_program_manager = edge_program_manager.transform(
-            [RemoveIOQuantOpsPass(edge_program_manager=edge_program_manager)]
-        )
 
     return edge_program_manager
 

--- a/examples/nxp/aot_neutron_compile.py
+++ b/examples/nxp/aot_neutron_compile.py
@@ -272,15 +272,15 @@ if __name__ == "__main__":  # noqa C901
     # 5. Delegate to Neutron
     if args.delegate:
         logging.info("Executing Neutron Partitioner and Delegate")
-        edge_program_manager = edge_program_manager.to_backend(
-            NeutronPartitioner(
-                generate_neutron_compile_spec(
-                    args.target,
-                    args.neutron_converter_flavor,
-                    operators_not_to_delegate=args.operators_not_to_delegate,
-                )
-            )
+
+        compile_spec = generate_neutron_compile_spec(
+            args.target,
+            operators_not_to_delegate=args.operators_not_to_delegate,
+            neutron_converter_flavor=args.neutron_converter_flavor,
         )
+        partitioner = NeutronPartitioner(compile_spec)
+
+        edge_program_manager = edge_program_manager.to_backend(partitioner)
         logging.debug(
             f"Lowered graph:\n{edge_program_manager.exported_program().graph}"
         )

--- a/examples/nxp/aot_neutron_compile.py
+++ b/examples/nxp/aot_neutron_compile.py
@@ -15,9 +15,6 @@ import executorch.extension.pybindings.portable_lib
 import executorch.kernels.quantized  # noqa F401
 
 import torch
-from executorch.backends.nxp.edge_passes.remove_io_quant_ops_pass import (
-    RemoveIOQuantOpsPass,
-)
 from executorch.backends.nxp.edge_passes.neutron_edge_pass_manager import (
     NeutronEdgePassManager,
 )
@@ -262,12 +259,9 @@ if __name__ == "__main__":  # noqa C901
 
     logging.debug(f"Exported graph:\n{edge_program_manager.exported_program().graph}")
 
-    edge_program_manager = NeutronEdgePassManager()(edge_program_manager)
-
-    if args.remove_quant_io_ops:
-        edge_program_manager = edge_program_manager.transform(
-            [RemoveIOQuantOpsPass(edge_program_manager=edge_program_manager)]
-        )
+    edge_program_manager = NeutronEdgePassManager(
+        remove_io_quant_ops=args.remove_quant_io_ops
+    )(edge_program_manager)
 
     # 5. Delegate to Neutron
     if args.delegate:


### PR DESCRIPTION
### Summary
Updates example in `aot_neutron_compile.py` to reflect current state of NXP backend.

### Test plan
AOT examples should run automatically in CI. You can manually test it using `backends/nxp/run_aot_example.sh`

cc @digantdesai @JakeStevens @robert-kalmar @MartinPavella @roman-janik-nxp 
