### PR TITLE
Arm backend: Add --enable_debug_mode to AOT compiler

### DIFF
--- a/backends/arm/operators/op_abs.py
+++ b/backends/arm/operators/op_abs.py
@@ -73,7 +73,9 @@ class AbsVisitor_INT(NodeVisitor):
             abs_output = output
 
         # Do the INT32 Abs
-        tosa_graph.addOperator(
+        self._serialize_operator(
+            node,
+            tosa_graph,
             ts.TosaOp.Op().ABS,
             [
                 rescaled_inputs[0].name,

--- a/backends/arm/operators/op_sum.py
+++ b/backends/arm/operators/op_sum.py
@@ -67,7 +67,9 @@ class SumVisitor_INT(NodeVisitor):
             dtype=ts.DType.INT32,
         )
 
-        tosa_graph.addOperator(
+        self._serialize_operator(
+            node,
+            tosa_graph,
             ts.TosaOp.Op().REDUCE_SUM,
             [rescaled_inputs[0].name],
             [intermediate.name],
@@ -111,7 +113,9 @@ class SumVisitor_FP(SumVisitor_INT):
         attr = ts.TosaSerializerAttribute()
         attr.ReduceSumAttribute(tensor.dim_order.index(dim))
 
-        tosa_graph.addOperator(
+        self._serialize_operator(
+            node,
+            tosa_graph,
             ts.TosaOp.Op().REDUCE_SUM,
             [tensor.name],
             [output.name],


### PR DESCRIPTION
* Add --enable_debug_mode to enable ATen to TOSA debugging
* Dump ATen graph when --intermediates is enabled
* Add missing _serialize_operator() calls

Signed-off-by: Tom Allsop <tom.allsop@arm.com>

Change-Id: Ibb8f03594c6afac887ef177a70034a210b31441a

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218