### PR TITLE
Arm backend: Add pass order validation to ArmPassManager

### DIFF
--- a/backends/arm/_passes/add_bias_pass.py
+++ b/backends/arm/_passes/add_bias_pass.py
@@ -3,13 +3,15 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Set, Type
+
 import torch
 from executorch.backends.arm._passes import ArmPass
 from executorch.backends.arm._passes.arm_pass_utils import get_first_fake_tensor
 from executorch.backends.transforms.utils import create_constant_placeholder
 
 from executorch.exir.dialects._ops import ops as exir_ops
-from executorch.exir.pass_base import PassResult
+from executorch.exir.pass_base import ExportPass, PassResult
 from torch.export.graph_signature import InputKind
 
 
@@ -18,6 +20,8 @@ class AddBiasPass(ArmPass):
     This pass adds a bias input to convolution nodes that do not have one.
     The bias is set to zero.
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     targeted_ops = (exir_ops.edge.aten.convolution.default,)
 

--- a/backends/arm/_passes/annotate_decomposed_matmul.py
+++ b/backends/arm/_passes/annotate_decomposed_matmul.py
@@ -7,7 +7,7 @@
 
 import itertools
 import operator
-from typing import cast, List
+from typing import cast, List, Set, Type
 
 import torch
 from executorch.backends.arm._passes.arm_pass_utils import create_node
@@ -28,6 +28,8 @@ class AnnotateDecomposedMatmulPass(ExportPass):
     difficult. This helper function find all matmul partitions and annotate its
     matmul-op (can be mm or bmm).
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def _match_partition_to_node(
         self, node: torch.fx.Node, partitioned_inputs: List[torch.fx.Node]

--- a/backends/arm/_passes/annotate_output_dim_order_pass.py
+++ b/backends/arm/_passes/annotate_output_dim_order_pass.py
@@ -3,9 +3,12 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+
+from typing import Set, Type
+
 from executorch.backends.arm._passes import ArmPass
 from executorch.backends.arm._passes.arm_pass_utils import get_output_dim_orders
-from executorch.exir.pass_base import PassResult
+from executorch.exir.pass_base import ExportPass, PassResult
 
 
 class AnnotateOutputDimOrderPass(ArmPass):
@@ -13,6 +16,8 @@ class AnnotateOutputDimOrderPass(ArmPass):
     Stores the current output dim_orders in the meta dict of the output node. This is used
     for verifying that the dim order does not change unexpectedly in later passes.
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def call(self, graph_module):
         output_node = graph_module.graph.output_node()

--- a/backends/arm/_passes/arm_pass_manager.py
+++ b/backends/arm/_passes/arm_pass_manager.py
@@ -155,7 +155,6 @@ class ArmPassManager(PassManager):
         self.add_pass(RemoveGetItemPass())
         self.add_pass(ConvertSplitToSlicePass())
         self.add_pass(ConvertMmToBmmPass())
-        self.add_pass(DecomposeLinearVectorNormPass())
         self.add_pass(
             DecomposeMeanDimPass(exported_program.graph_module, self.tosa_spec)
         )

--- a/backends/arm/_passes/broadcast_args_pass.py
+++ b/backends/arm/_passes/broadcast_args_pass.py
@@ -3,6 +3,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Set, Type
+
 from executorch.backends.arm._passes import ArmPass
 
 from executorch.backends.arm._passes.arm_pass_utils import (
@@ -12,7 +14,7 @@ from executorch.backends.arm._passes.arm_pass_utils import (
 
 from executorch.exir.dialects._ops import ops as exir_ops
 
-from executorch.exir.pass_base import PassResult
+from executorch.exir.pass_base import ExportPass, PassResult
 from torch.fx import GraphModule, Node
 
 
@@ -21,6 +23,8 @@ class BroadcastArgsPass(ArmPass):
     Pass to manually broadcast arguments by inserting repeats.
     This is done when more than one arg needs broadcasting.
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     targeted_ops = {
         exir_ops.edge.aten.add.Tensor,

--- a/backends/arm/_passes/cast_bool_to_int8_pass.py
+++ b/backends/arm/_passes/cast_bool_to_int8_pass.py
@@ -6,6 +6,8 @@
 # The TOSA BITWISE_AND, BITWISE_OR, and BITWISE_XOR don't handle bool as input
 # If input/output is bool lest add a cast/conversion pass before/after to/from int8.
 
+from typing import Set, Type
+
 import torch
 
 from executorch.exir.dialects._ops import ops as exir_ops
@@ -14,6 +16,8 @@ from executorch.exir.pass_base import ExportPass
 
 class CastBoolToInt8Pass(ExportPass):
     """Casts the input to int8 if it is not already and casts back the output to the original input dtype."""
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     targeted_ops = {
         exir_ops.edge.aten.bitwise_and.Tensor,

--- a/backends/arm/_passes/cast_int64_pass.py
+++ b/backends/arm/_passes/cast_int64_pass.py
@@ -6,6 +6,7 @@
 # pyre-unsafe
 
 import logging
+from typing import Set, Type
 
 import torch
 from executorch.exir.pass_base import ExportPass, PassResult
@@ -18,6 +19,8 @@ class CastInt64BuffersToInt32Pass(ExportPass):
     """
     Cast int64 buffers to int32 if the int64 data is in int32 range.
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def __init__(self, exported_program: torch.export.ExportedProgram):
         super(CastInt64BuffersToInt32Pass, self).__init__()

--- a/backends/arm/_passes/cast_to_int32_pass.py
+++ b/backends/arm/_passes/cast_to_int32_pass.py
@@ -3,6 +3,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Set, Type
+
 import torch
 
 from executorch.exir.dialects._ops import ops as exir_ops
@@ -11,6 +13,8 @@ from executorch.exir.pass_base import ExportPass
 
 class CastToInt32Pass(ExportPass):
     """Casts the input to int32 if it is not already and casts back the output to the original input dtype."""
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     targeted_ops = {
         exir_ops.edge.aten.bitwise_left_shift.Tensor,

--- a/backends/arm/_passes/conv1d_unsqueeze_pass.py
+++ b/backends/arm/_passes/conv1d_unsqueeze_pass.py
@@ -6,6 +6,8 @@
 # LICENSE file in the root directory of this source tree.
 
 
+from typing import Set, Type
+
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass
 
@@ -20,6 +22,8 @@ class Conv1dUnsqueezePass(ExportPass):
     2) perform a conv2d (with a modified version of the original conv1d args)
     3) squeeze the output back down to 3d.
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def call_operator(self, op, args, kwargs, meta):
         if op != exir_ops.edge.aten.convolution.default:

--- a/backends/arm/_passes/convert_any_default_dim_dims_pass.py
+++ b/backends/arm/_passes/convert_any_default_dim_dims_pass.py
@@ -3,6 +3,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Set, Type
+
 import torch
 from executorch.exir.dialects._ops import (  # type: ignore[import-not-found]
     ops as exir_ops,
@@ -43,6 +45,8 @@ class ConvertAnyDefaultDimDimsPass(ExportPass):
         any.dim(dim2, keepdim = True)
         squeeze(dim = [dim1, dim2])
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def call(self, graph_module: torch.fx.GraphModule):
         modified = False

--- a/backends/arm/_passes/convert_expand_copy_to_repeat.py
+++ b/backends/arm/_passes/convert_expand_copy_to_repeat.py
@@ -6,7 +6,7 @@
 # pyre-unsafe
 
 import logging
-from typing import cast
+from typing import cast, Set, Type
 
 import torch
 
@@ -49,6 +49,8 @@ class ConvertExpandCopyToRepeatPass(ExportPass):
     """
     Replace expand copy with repeat since it is a repeat that can only repeat singleton dimensions.
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     expand_copy = exir_ops.edge.aten.expand_copy.default
     repeat = exir_ops.edge.aten.repeat.default

--- a/backends/arm/_passes/convert_full_like_to_full_pass.py
+++ b/backends/arm/_passes/convert_full_like_to_full_pass.py
@@ -3,6 +3,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Set, Type
+
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass
 
@@ -18,6 +20,8 @@ class ConvertFullLikeToFullPass(ExportPass):
                 )`
     Skip layout and device since it's not relevant for our backend.
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def call_operator(self, op, args, kwargs, meta):
         if op not in [

--- a/backends/arm/_passes/convert_int64_const_ops_to_int32.py
+++ b/backends/arm/_passes/convert_int64_const_ops_to_int32.py
@@ -7,6 +7,7 @@
 
 
 import logging
+from typing import Set, Type
 
 import torch
 from executorch.backends.arm._passes.fuse_constant_ops_pass import ComputeConstantOpsAOT
@@ -29,6 +30,8 @@ class ConvertInt64ConstOpsToInt32Pass(ExportPass):
       4. `torch.linspace`
       5. `torch.tensor`
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     torch_ops = [
         torch.ops.aten.full.default,

--- a/backends/arm/_passes/convert_int64_output_ops_to_int32.py
+++ b/backends/arm/_passes/convert_int64_output_ops_to_int32.py
@@ -7,6 +7,7 @@
 
 
 import logging
+from typing import Set, Type
 
 import torch
 from executorch.backends.arm._passes.arm_pass_utils import (
@@ -43,6 +44,8 @@ class ConvertInt64OutputOpsToInt32Pass(ExportPass):
     such checks, it is the user's responsibility to ensure that values fit within
     the int32 range.
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     aten_cast_ops = (
         torch.ops.aten.to.dtype,

--- a/backends/arm/_passes/convert_int_pow_to_mul.py
+++ b/backends/arm/_passes/convert_int_pow_to_mul.py
@@ -5,8 +5,11 @@
 
 # pyre-unsafe
 
+from typing import Set, Type
+
 from executorch.backends.arm._passes import ArmPass
 from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import ExportPass
 
 
 class ConvertIntPowToMuls(ArmPass):
@@ -15,6 +18,8 @@ class ConvertIntPowToMuls(ArmPass):
     Only handles pow.Tensor_Scalar and not pow.Tensor_Tensor.
     Needs to be run before doing scalar to tensor conversion.
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def call_operator(self, op, args, kwargs, meta):
         if op != exir_ops.edge.aten.pow.Tensor_Scalar:

--- a/backends/arm/_passes/convert_minmax_pass.py
+++ b/backends/arm/_passes/convert_minmax_pass.py
@@ -3,6 +3,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Set, Type
+
 import torch
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass, PassResult
@@ -28,6 +30,8 @@ class ConvertMinMaxPass(ExportPass):
         amax(dim2, keepdim = True)
         squeeze(dim = [dim1, dim2])
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def check_argmax(self, node):
         """

--- a/backends/arm/_passes/convert_split_to_slice.py
+++ b/backends/arm/_passes/convert_split_to_slice.py
@@ -5,6 +5,8 @@
 
 # pyre-unsafe
 
+from typing import Set, Type
+
 import torch.fx
 from executorch.backends.arm._passes.arm_pass_utils import (
     create_node,
@@ -18,6 +20,8 @@ class ConvertSplitToSlicePass(ExportPass):
     """
     Replace a split operation with many slice operations.
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     split_ops = (
         exir_ops.edge.aten.split_with_sizes_copy.default,

--- a/backends/arm/_passes/convert_squeezes_to_view.py
+++ b/backends/arm/_passes/convert_squeezes_to_view.py
@@ -6,6 +6,8 @@
 
 # pyre-unsafe
 
+from typing import Set, Type
+
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass
 
@@ -14,6 +16,8 @@ class ConvertSqueezesToViewPass(ExportPass):
     """
     Replaces squeeze/unsqueeze operators with view. These are simply special cases of the view op, so removing them gives us less cases to handle in the node visitiors.
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def call_operator(self, op, args, kwargs, meta):
         if op not in [

--- a/backends/arm/_passes/convert_to_clamp.py
+++ b/backends/arm/_passes/convert_to_clamp.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Tuple
+from typing import Set, Tuple, Type
 
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass
@@ -24,6 +24,8 @@ def get_clamp_params(op, args) -> Tuple[float | None, float | None]:
 
 
 class ConvertToClampPass(ExportPass):
+    _passes_required_after: Set[Type[ExportPass]] = set()
+
     def call_operator(self, op, args, kwargs, meta):
         if op not in edge_operators:
             return super().call_operator(op, args, kwargs, meta)

--- a/backends/arm/_passes/decompose_acosh_pass.py
+++ b/backends/arm/_passes/decompose_acosh_pass.py
@@ -5,8 +5,11 @@
 
 # pyre-unsafe
 
+from typing import Set, Type
+
 from executorch.backends.arm._passes import ArmPass
 from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import ExportPass
 
 # For MI case
 edge_acosh_op = exir_ops.edge.aten.acosh.default
@@ -18,6 +21,8 @@ class DecomposeAcoshPass(ArmPass):
     This decomposition is based on the mathematical identity:
         acosh(x) = log(x + sqrt((x-1)(x+1))
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def call_operator(self, op, args, kwargs, meta, updated=False):
 

--- a/backends/arm/_passes/decompose_adaptive_avg_pool2d_pass.py
+++ b/backends/arm/_passes/decompose_adaptive_avg_pool2d_pass.py
@@ -4,12 +4,14 @@
 # LICENSE file in the root directory of this source tree.
 
 from math import ceil, floor
+from typing import Set, Type
 
 import torch
 
 from executorch.backends.arm._passes import ArmPass
 
 from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import ExportPass
 
 edge_ops = (exir_ops.edge.aten._adaptive_avg_pool2d.default,)
 aten_ops = (torch.ops.aten.adaptive_avg_pool2d.default,)
@@ -40,6 +42,8 @@ class DecomposeAdaptiveAvgPool2dPass(ArmPass):
 
     The output is of size output_size_h x output_size_w for any input.
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def call_operator(self, op, args, kwargs, meta, updated=False):
         if op not in (edge_ops + aten_ops):

--- a/backends/arm/_passes/decompose_addmm_pass.py
+++ b/backends/arm/_passes/decompose_addmm_pass.py
@@ -3,10 +3,13 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Set, Type
+
 import torch
 
 from executorch.backends.arm._passes import ArmPass
 from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import ExportPass
 
 
 # For MI case
@@ -35,6 +38,8 @@ def get_ops(op):
 
 class DecomposeAddmmPass(ArmPass):
     """Decomposes the addmm operator into tensor multiplication and addition."""
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def call_operator(self, op, args, kwargs, meta):
         if op not in [edge_addmm, aten_addmm]:

--- a/backends/arm/_passes/decompose_asin_and_acos_pass.py
+++ b/backends/arm/_passes/decompose_asin_and_acos_pass.py
@@ -7,11 +7,13 @@
 
 import logging
 from math import pi
+from typing import Set, Type
 
 import torch
 
 from executorch.backends.arm._passes import ArmPass
 from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import ExportPass
 
 # For MI case
 edge_asin_op = (exir_ops.edge.aten.asin.default,)
@@ -53,6 +55,8 @@ class DecomposeAsinAndAcosPass(ArmPass):
     where P and Q are polynomials defined in the function and s is the square root of z.
 
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def _build_polynomial(
         self, coefficients: list[float], variable: torch.Tensor, meta: dict[str, str]

--- a/backends/arm/_passes/decompose_asinh_pass.py
+++ b/backends/arm/_passes/decompose_asinh_pass.py
@@ -6,8 +6,11 @@
 # pyre-unsafe
 
 
+from typing import Set, Type
+
 from executorch.backends.arm._passes import ArmPass
 from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import ExportPass
 
 # For MI case
 edge_asinh_op = (exir_ops.edge.aten.asinh.default,)
@@ -19,6 +22,8 @@ class DecomposeAsinhPass(ArmPass):
     This decomposition is based on the mathematical identity:
         asinh(x) = log(x + sqrt(x^2 + 1))
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def call_operator(self, op, args, kwargs, meta):
         if op not in edge_asinh_op:

--- a/backends/arm/_passes/decompose_atan_pass.py
+++ b/backends/arm/_passes/decompose_atan_pass.py
@@ -5,9 +5,11 @@
 
 import logging
 from math import pi
+from typing import Set, Type
 
 from executorch.backends.arm._passes import ArmPass
 from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import ExportPass
 
 
 edge_atan = exir_ops.edge.aten.atan.default  # MI case
@@ -34,6 +36,8 @@ def _get_atan_ops(op):
 
 class DecomposeAtanPass(ArmPass):
     """Decomposes the atan operator into a rational (Padé) approximation."""
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def _rational_approximation(self, z, ops, meta):
         """Creates a (2,1) Padé approximation for atan(x) on [-1, 1]."""

--- a/backends/arm/_passes/decompose_atanh_pass.py
+++ b/backends/arm/_passes/decompose_atanh_pass.py
@@ -3,8 +3,11 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Set, Type
+
 from executorch.backends.arm._passes import ArmPass
 from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import ExportPass
 
 
 edge_atanh = exir_ops.edge.aten.atanh.default  # MI case
@@ -29,6 +32,8 @@ class DecomposeAtanhPass(ArmPass):
     Decomposes the atanh operator into primitive ops.
     atanh(x) = 0.5 * log((1 + x) / (1 - x))
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def call_operator(self, op, args, kwargs, meta):
         if op is not edge_atanh:

--- a/backends/arm/_passes/decompose_avg_pool2d.py
+++ b/backends/arm/_passes/decompose_avg_pool2d.py
@@ -4,6 +4,8 @@
 # LICENSE file in the root directory of this source tree.
 
 
+from typing import Set, Type
+
 import torch
 from executorch.backends.arm.operators.operator_validation_utils import (
     adjust_pooling_pad_if_needed,
@@ -34,7 +36,7 @@ def get_decomposition(op) -> tuple:
 
 
 class DecomposeAvgPool2d(ExportPass):
-    """ """
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def call_operator(self, op, args, kwargs, meta):
         if op not in (edge_div_ops + aten_div_ops):

--- a/backends/arm/_passes/decompose_batch_norm_no_stats.py
+++ b/backends/arm/_passes/decompose_batch_norm_no_stats.py
@@ -6,12 +6,13 @@
 # pyre-unsafe
 
 import operator
+from typing import Set, Type
 
 import torch
 from executorch.backends.arm._passes import ArmPass
 from executorch.backends.arm._passes.arm_pass_utils import create_node
 from executorch.exir.dialects._ops import ops as exir_ops
-from executorch.exir.pass_base import PassResult
+from executorch.exir.pass_base import ExportPass, PassResult
 
 
 class DecomposeBatchNormNoStatsPass(ArmPass):
@@ -32,6 +33,8 @@ class DecomposeBatchNormNoStatsPass(ArmPass):
 
     Source: https://pytorch.org/docs/stable/generated/torch.nn.BatchNorm2d.html
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def call(self, graph_module: torch.fx.GraphModule) -> PassResult:  # noqa: C901
         bn_ops = (

--- a/backends/arm/_passes/decompose_cosh_pass.py
+++ b/backends/arm/_passes/decompose_cosh_pass.py
@@ -3,8 +3,11 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Set, Type
+
 from executorch.backends.arm._passes import ArmPass
 from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import ExportPass
 
 # For MI case
 edge_cosh = exir_ops.edge.aten.cosh.default
@@ -18,6 +21,8 @@ class DecomposeCoshPass(ArmPass):
         cosh(x) = 0.5 * (e^x + e^(-x))
 
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def call_operator(self, op, args, kwargs, meta, updated=False):
         if op is not edge_cosh:

--- a/backends/arm/_passes/decompose_cosine_similarity_pass.py
+++ b/backends/arm/_passes/decompose_cosine_similarity_pass.py
@@ -3,6 +3,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Set, Type
+
 import torch
 from executorch.exir.pass_base import ExportPass
 
@@ -21,6 +23,8 @@ class DecomposeCosineSimilarityPass(ExportPass):
       denom  = mul(n1c, n2c)
       out    = div(dot, denom)
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def call_operator(self, op, args, kwargs, meta):
         if op not in torch_cosine_similarity:

--- a/backends/arm/_passes/decompose_cumsum_pass.py
+++ b/backends/arm/_passes/decompose_cumsum_pass.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from math import prod
+from typing import Set, Type
 
 import torch
 from executorch.backends.arm._passes import ArmPass
@@ -12,7 +13,7 @@ from executorch.backends.arm._passes.quant_args import QuantArgs
 
 from executorch.backends.transforms.utils import create_constant_placeholder
 from executorch.exir.dialects._ops import ops as exir_ops
-from executorch.exir.pass_base import PassResult
+from executorch.exir.pass_base import ExportPass, PassResult
 from torch.export.graph_signature import InputKind
 
 
@@ -38,6 +39,8 @@ class DecomposeCumsumPass(ArmPass):
        W = <dims after cumsum dim>
     And the convolution is applied over dimension H.
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def call(self, graph_module):
         graph = graph_module.graph

--- a/backends/arm/_passes/decompose_div_pass.py
+++ b/backends/arm/_passes/decompose_div_pass.py
@@ -1,10 +1,12 @@
-# Copyright 2024 Arm Limited and/or its affiliates.
+# Copyright 2024-2025 Arm Limited and/or its affiliates.
 # All rights reserved.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
 # pyre-unsafe
+
+from typing import Set, Type
 
 import torch
 from executorch.exir.dialects._ops import ops as exir_ops
@@ -36,6 +38,8 @@ class DecomposeDivPass(ExportPass):
         x = reciprocal(b)
         y = mul(a,x)
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def call_operator(self, op, args, kwargs, meta):
         if op not in (edge_div_ops + aten_div_ops):

--- a/backends/arm/_passes/decompose_elu_pass.py
+++ b/backends/arm/_passes/decompose_elu_pass.py
@@ -3,8 +3,11 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Set, Type
+
 from executorch.backends.arm._passes import ArmPass
 from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import ExportPass
 
 edge_elu_ops = (exir_ops.edge.aten.elu.default,)
 
@@ -54,6 +57,8 @@ class DecomposeEluPass(ArmPass):
         - exir_ops.edge.aten.where.self
         - exir_ops.edge.aten.mul.Scalar
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def call_operator(self, op, args, kwargs, meta):
         if op not in edge_elu_ops:

--- a/backends/arm/_passes/decompose_embedding_pass.py
+++ b/backends/arm/_passes/decompose_embedding_pass.py
@@ -8,6 +8,7 @@
 
 import logging
 from math import prod
+from typing import Set, Type
 
 import torch
 from executorch.exir.dialects._ops import ops as exir_ops
@@ -32,6 +33,8 @@ class DecomposeEmbeddingPass(ExportPass):
     Note:
          i = indices is expected to be int32 before this pass
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     aten_ops = (torch.ops.aten.embedding.default,)
     edge_ops = (exir_ops.edge.aten.embedding.default,)

--- a/backends/arm/_passes/decompose_expm1_pass.py
+++ b/backends/arm/_passes/decompose_expm1_pass.py
@@ -3,8 +3,11 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Set, Type
+
 from executorch.backends.arm._passes import ArmPass
 from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import ExportPass
 
 
 edge_expm1_ops = (exir_ops.edge.aten.expm1.default,)  # MI case
@@ -67,6 +70,8 @@ class DecomposeExpm1Pass(ArmPass):
         - exir_ops.edge.aten.le.Scalar,
         - exir_ops.edge.aten.logical_and.default
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def call_operator(self, op, args, kwargs, meta):
         if op not in edge_expm1_ops:

--- a/backends/arm/_passes/decompose_gelu_pass.py
+++ b/backends/arm/_passes/decompose_gelu_pass.py
@@ -3,6 +3,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Set, Type
+
 import torch
 from executorch.backends.arm._passes.arm_pass_utils import get_node_arg
 from executorch.exir.dialects._ops import ops as exir_ops
@@ -76,6 +78,8 @@ class DecomposeGeluPass(ExportPass):
         %op6 = mul(%x, %op5)
         %op7 = mul(%op6, %FULL_0_5)
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def call_operator(self, op, args, kwargs, meta):
         if op not in torch_gelu + edge_gelu:

--- a/backends/arm/_passes/decompose_glu_pass.py
+++ b/backends/arm/_passes/decompose_glu_pass.py
@@ -3,9 +3,12 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Set, Type
+
 import torch
 from executorch.backends.arm._passes import ArmPass
 from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import ExportPass
 
 
 # For FP case
@@ -35,6 +38,8 @@ def get_ops(op):
 
 class DecomposeGluPass(ArmPass):
     """Decomposes the GLU operator into hadamard product and sigmoid."""
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def call_operator(self, op, args, kwargs, meta):
         if op not in [edge_glu, aten_glu]:

--- a/backends/arm/_passes/decompose_grouped_conv.py
+++ b/backends/arm/_passes/decompose_grouped_conv.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from copy import copy
+from typing import Set, Type
 
 import torch
 from executorch.backends.arm._passes.quant_args import QuantArgs
@@ -32,6 +33,8 @@ class DecomposeGroupedConv(ExportPass):
 
         x = cat(x1, x2)
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     @staticmethod
     def _get_decomposition(op):

--- a/backends/arm/_passes/decompose_groupnorm_pass.py
+++ b/backends/arm/_passes/decompose_groupnorm_pass.py
@@ -6,12 +6,13 @@
 # pyre-unsafe
 
 import operator
+from typing import Set, Type
 
 import torch
 from executorch.backends.arm._passes import ArmPass
 from executorch.backends.arm._passes.arm_pass_utils import create_node
 from executorch.exir.dialects._ops import ops as exir_ops
-from executorch.exir.pass_base import PassResult
+from executorch.exir.pass_base import ExportPass, PassResult
 
 
 def get_group_norm_decomposition(op) -> tuple:
@@ -56,6 +57,8 @@ class DecomposeGroupNormPass(ArmPass):
 
     Source: https://pytorch.org/docs/stable/generated/torch.nn.GroupNorm.html
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def call(self, graph_module: torch.fx.GraphModule):
         modified = False

--- a/backends/arm/_passes/decompose_layernorm_pass.py
+++ b/backends/arm/_passes/decompose_layernorm_pass.py
@@ -6,12 +6,13 @@
 # pyre-unsafe
 
 import operator
+from typing import Set, Type
 
 import torch
 from executorch.backends.arm._passes import ArmPass
 from executorch.backends.arm._passes.arm_pass_utils import create_node
 from executorch.exir.dialects._ops import ops as exir_ops
-from executorch.exir.pass_base import PassResult
+from executorch.exir.pass_base import ExportPass, PassResult
 
 
 def get_layer_norm_decomposition(op) -> tuple:
@@ -55,6 +56,8 @@ class DecomposeLayerNormPass(ArmPass):
 
     Source: https://pytorch.org/docs/stable/generated/torch.nn.LayerNorm.html
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def call(self, graph_module: torch.fx.GraphModule):
         for node in graph_module.graph.nodes:

--- a/backends/arm/_passes/decompose_leaky_relu_pass.py
+++ b/backends/arm/_passes/decompose_leaky_relu_pass.py
@@ -6,9 +6,12 @@
 
 # pyre-unsafe
 
+from typing import Set, Type
+
 import torch
 from executorch.backends.arm._passes import ArmPass
 from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import ExportPass
 
 edge_ops = (exir_ops.edge.aten.leaky_relu.default,)
 torch_ops = (torch.ops.aten.leaky_relu.default,)
@@ -45,6 +48,8 @@ class DecomposeLeakyReLUPass(ArmPass):
         %op4 = mul(%op3,%op2)
         %op5 = add(%op1,%op4)
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def call_operator(self, op, args, kwargs, meta):
         if op not in (edge_ops + torch_ops):

--- a/backends/arm/_passes/decompose_linalg_vector_norm_pass.py
+++ b/backends/arm/_passes/decompose_linalg_vector_norm_pass.py
@@ -3,6 +3,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Set, Type
+
 import torch
 from executorch.exir.pass_base import ExportPass
 
@@ -27,6 +29,8 @@ class DecomposeLinearVectorNormPass(ExportPass):
           In this case we need to wrap p into Tensor and we need to know
           dtype prior, but we dont know this from FX graph.
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     torch_linalg_vector_norm = (torch.ops.aten.linalg_vector_norm.default,)
 

--- a/backends/arm/_passes/decompose_linear_pass.py
+++ b/backends/arm/_passes/decompose_linear_pass.py
@@ -5,6 +5,8 @@
 
 # pyre-unsafe
 
+from typing import Set, Type
+
 import numpy as np
 from executorch.backends.arm._passes import ArmPass
 from executorch.backends.arm._passes.arm_pass_utils import (
@@ -12,7 +14,7 @@ from executorch.backends.arm._passes.arm_pass_utils import (
     get_first_fake_tensor,
 )
 from executorch.exir.dialects._ops import ops as exir_ops
-from executorch.exir.pass_base import PassResult
+from executorch.exir.pass_base import ExportPass, PassResult
 
 
 class DecomposeLinearPass(ArmPass):
@@ -24,6 +26,8 @@ class DecomposeLinearPass(ArmPass):
         conv2d           = conv2d(x_reshaped, weights_reshaped, bias)
         output           = view(conv2d)
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def call(self, graph_module):
         for node in graph_module.graph.nodes:

--- a/backends/arm/_passes/decompose_logit_pass.py
+++ b/backends/arm/_passes/decompose_logit_pass.py
@@ -3,10 +3,13 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Set, Type
+
 import torch
 
 from executorch.backends.arm._passes import ArmPass
 from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import ExportPass
 
 
 # For FP case
@@ -59,6 +62,8 @@ class DecomposeLogitPass(ArmPass):
             y = clamp(x, eps, 1 - eps)
             log(y * reciprocal((-1) * y + 1))
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def call_operator(self, op, args, kwargs, meta):
         if op not in [edge_logit, aten_logit]:

--- a/backends/arm/_passes/decompose_masked_fill.py
+++ b/backends/arm/_passes/decompose_masked_fill.py
@@ -6,10 +6,13 @@
 # pyre-unsafe
 
 
+from typing import Set, Type
+
 import torch
 
 from executorch.backends.arm._passes import ArmPass
 from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import ExportPass
 
 
 edge_ops = (exir_ops.edge.aten.masked_fill.Scalar,)
@@ -36,6 +39,8 @@ class DecomposeMaskedFill(ArmPass):
     Fills the tensor with the scalar value according to the boolean mask.
     Decomposed to a where and a full_like operator.
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def call_operator(self, op, args, kwargs, meta, updated=False):
         if op not in (edge_ops + aten_ops):

--- a/backends/arm/_passes/decompose_maxpool2d_with_dilation.py
+++ b/backends/arm/_passes/decompose_maxpool2d_with_dilation.py
@@ -6,9 +6,11 @@
 # pyre-unsafe
 
 import operator
+from typing import Set, Type
 
 from executorch.backends.arm._passes import ArmPass
 from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import ExportPass
 
 # We'll decompose only the EXIR edge max_pool2d ops when dilation > 1
 EDGE_MAXPOOL2D = (
@@ -21,6 +23,8 @@ class DecomposeMaxPool2DPass(ArmPass):
     """
     Decompose dilated max_pool2d (EXIR edge ops) into space-to-batch -> maxpool -> batch-to-space.
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def call_operator(self, op, args, kwargs, meta):
         # Only intercept EXIR edge max_pool2d ops

--- a/backends/arm/_passes/decompose_meandim_pass.py
+++ b/backends/arm/_passes/decompose_meandim_pass.py
@@ -5,12 +5,14 @@
 
 from copy import copy
 from math import prod
+from typing import Set, Type
 
 import torch
 from executorch.backends.arm._passes import ArmPass
 from executorch.backends.arm._passes.arm_pass_utils import get_node_arg
 from executorch.exir.backend.utils import WhyNoPartitionReporter
 from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import ExportPass
 
 
 def get_meandim_decomposition(op) -> tuple:
@@ -61,6 +63,8 @@ class DecomposeMeanDimPass(ArmPass):
         x = mul.Tensor(x, 1/c) # Divide by number of channels to get mean
         x = view_copy.default(x, new_shape=(h)) # Squeeze dims since keepdims = False
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def __init__(self, graph_module, tosa_spec):
         super().__init__()

--- a/backends/arm/_passes/decompose_ne_pass.py
+++ b/backends/arm/_passes/decompose_ne_pass.py
@@ -3,9 +3,12 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Set, Type
+
 import torch
 from executorch.backends.arm._passes import ArmPass
 from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import ExportPass
 
 edge_ne_ops = (exir_ops.edge.aten.ne.Tensor,)
 aten_ne_ops = (torch.ops.aten.ne.Tensor, torch.ops.aten.ne_.Tensor)
@@ -52,6 +55,8 @@ class DecomposeNotEqualPass(ArmPass):
         - aten.eq.Tensor or exir_ops.edge.aten.eq.Tensor
         - followed by aten.logical_not.default or its edge equivalent
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def call_operator(self, op, args, kwargs, meta):
         if op not in (edge_ne_ops + aten_ne_ops):

--- a/backends/arm/_passes/decompose_round_pass.py
+++ b/backends/arm/_passes/decompose_round_pass.py
@@ -3,10 +3,13 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Set, Type
+
 import torch
 from executorch.backends.arm._passes import ArmPass
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.dialects.edge._ops import EdgeOpOverload
+from executorch.exir.pass_base import ExportPass
 from torch._ops import OpOverload
 
 
@@ -55,6 +58,8 @@ class DecomposeRoundPass(ArmPass):
         %ceil = ceil(%minus_half)
         %result = where(%is_non_negative, %floor, %ceil)
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def call_operator(self, op, args, kwargs, meta, updated=False):
         if op not in (exir_ops.edge.aten.round.default, torch.ops.aten.round.default):

--- a/backends/arm/_passes/decompose_select.py
+++ b/backends/arm/_passes/decompose_select.py
@@ -6,6 +6,8 @@
 
 # pyre-unsafe
 
+from typing import Set, Type
+
 import torch
 from executorch.backends.arm._passes.arm_pass_utils import (
     create_node,
@@ -19,6 +21,8 @@ class DecomposeSelectPass(ExportPass):
     """
     This pass decomposes select into slice + squeeze to ensure that Aten and TOSA outputs has the same rank (input rank -1)
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def call(self, graph_module: torch.fx.GraphModule):
         for node in graph_module.graph.nodes:

--- a/backends/arm/_passes/decompose_sign_pass.py
+++ b/backends/arm/_passes/decompose_sign_pass.py
@@ -3,10 +3,13 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Set, Type
+
 import torch
 
 from executorch.backends.arm._passes import ArmPass
 from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import ExportPass
 
 
 # For MI case
@@ -41,6 +44,8 @@ def get_ops(op):
 
 class DecomposeSignPass(ArmPass):
     """Decomposes the sign operator into a sequence of operations that are supported by the Arm backend."""
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def call_operator(self, op, args, kwargs, meta):
         if op not in (edge_sign, aten_sign):

--- a/backends/arm/_passes/decompose_silu_pass.py
+++ b/backends/arm/_passes/decompose_silu_pass.py
@@ -5,6 +5,8 @@
 
 # pyre-unsafe
 
+from typing import Set, Type
+
 import torch
 from executorch.exir.pass_base import ExportPass
 
@@ -21,6 +23,8 @@ class DecomposeSiluPass(ExportPass):
         x = sigmoid(a)
         y = mul(a,x)
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def call_operator(self, op, args, kwargs, meta):
         if op not in (aten_silu_ops):

--- a/backends/arm/_passes/decompose_sinh_pass.py
+++ b/backends/arm/_passes/decompose_sinh_pass.py
@@ -4,8 +4,11 @@
 # LICENSE file in the root directory of this source tree.
 
 
+from typing import Set, Type
+
 from executorch.backends.arm._passes import ArmPass
 from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import ExportPass
 
 
 # For MI case
@@ -23,6 +26,8 @@ class DecomposeSinhPass(ArmPass):
     These are decomposed into exponentials, negation, subtraction,
         and scalar multiplication.
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def call_operator(self, op, args, kwargs, meta):
         if op is not edge_sinh:

--- a/backends/arm/_passes/decompose_softmax_pass.py
+++ b/backends/arm/_passes/decompose_softmax_pass.py
@@ -3,6 +3,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Set, Type
+
 import torch
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass
@@ -61,6 +63,8 @@ class DecomposeSoftmaxPass(ExportPass):
         %op6 = mul(%op3, %op5)
         (in logsoftmax case: %op7 = log(%op6))
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def call_operator(self, op, args, kwargs, meta):
         if op not in torch_softmax + edge_softmax:

--- a/backends/arm/_passes/decompose_softmax_unstable_pass.py
+++ b/backends/arm/_passes/decompose_softmax_unstable_pass.py
@@ -5,9 +5,12 @@
 
 # pyre-unsafe
 
+from typing import Set, Type
+
 import torch
 from executorch.backends.arm._passes import ArmPass
 from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import ExportPass
 
 # For BI case
 torch_softmax = (torch.ops.aten.softmax.int, torch.ops.aten.log_softmax.int)
@@ -56,6 +59,8 @@ class DecomposeSoftmaxUnstablePass(ArmPass):
         %op4 = mul(%op1, %op3)
         (in logsoftmax case: %op5 = log(%op4))
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def call_operator(self, op, args, kwargs, meta):
         if op not in torch_softmax + edge_softmax:

--- a/backends/arm/_passes/decompose_sqrt_pass.py
+++ b/backends/arm/_passes/decompose_sqrt_pass.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 # pyre-unsafe
-from typing import Tuple, Union
+from typing import Set, Tuple, Type, Union
 
 import torch
 from executorch.exir.dialects._ops import ops as exir_ops
@@ -27,6 +27,7 @@ def get_sqrt_decomposition(op) -> Union[Tuple, torch._ops.OpOverload]:
 
 
 class DecomposeSqrtPass(ExportPass):
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def call_operator(self, op, args, kwargs, meta):
         """

--- a/backends/arm/_passes/decompose_sum_pass.py
+++ b/backends/arm/_passes/decompose_sum_pass.py
@@ -3,6 +3,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Set, Type
+
 import torch
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass
@@ -39,6 +41,8 @@ class DecomposeSumPass(ExportPass):
         sum(dim_2, keep_dim = True) -> unsqueezed_shape
         view(shape = squeezed_shape) -> squeezed_shape
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def call_operator(self, op, args, kwargs, meta):
         if op not in [

--- a/backends/arm/_passes/decompose_var_pass.py
+++ b/backends/arm/_passes/decompose_var_pass.py
@@ -7,10 +7,13 @@
 # pyre-unsafe
 
 
+from typing import Set, Type
+
 import torch
 from executorch.backends.arm._passes import ArmPass
 from executorch.backends.arm._passes.arm_pass_utils import get_node_arg
 from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import ExportPass
 
 
 def get_var_decomposition(op) -> tuple:
@@ -46,6 +49,8 @@ class DecomposeVarPass(ArmPass):
         sum = sum(squared_diff, dim)
         y = div(sum, max(0, N-correction))
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def call_operator(self, op, args, kwargs, meta):
         if op not in (

--- a/backends/arm/_passes/decorate_fp32_to_int32_casting_pass.py
+++ b/backends/arm/_passes/decorate_fp32_to_int32_casting_pass.py
@@ -6,10 +6,13 @@
 # pyre-unsafe
 
 
+from typing import Set, Type
+
 import torch
 from executorch.backends.arm._passes import ArmPass
 from executorch.backends.arm._passes.arm_pass_utils import get_node_arg
 from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import ExportPass
 
 
 def _get_decorated_ops(op):
@@ -39,6 +42,8 @@ class DecorateFp32toInt32CastingPass(ArmPass):
         decorated_x = where(is_non_negative, floor_x, ceil_x)
         output = to_dim_order_copy(decorated_x, dtype=torch.int32)
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     targets = [
         exir_ops.edge.dim_order_ops._to_dim_order_copy.default,

--- a/backends/arm/_passes/fold_qdq_with_annotated_qparams_pass.py
+++ b/backends/arm/_passes/fold_qdq_with_annotated_qparams_pass.py
@@ -8,7 +8,7 @@
 
 import copy
 
-from typing import cast, Dict, Set, Tuple
+from typing import cast, Dict, Set, Tuple, Type
 
 from executorch.backends.arm._passes import ArmPass
 from executorch.backends.arm._passes.arm_pass_utils import (
@@ -99,6 +99,8 @@ class FoldAndAnnotateQParamsPass(ArmPass):
     The quantization parameters for x_dq and aten_add_tensor_q are stored in meta for the aten_add_tensor node.
 
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def fold_and_annotate_arg(
         self, graph_module: GraphModule, node: Node, arg_list: list[Node], i: int
@@ -210,6 +212,8 @@ class QuantizeOperatorArguments(ExportPass):
         - Makes sure the min and max values to clamp.default are quantized, if it's a quantized operator.
     """
 
+    _passes_required_after: Set[Type[ExportPass]] = set()
+
     def call(self, graph_module: GraphModule) -> PassResult:
         modified = False
         # Loop over the graph nodes and find full.default nodes.
@@ -256,6 +260,8 @@ class RetraceFoldedDtypesPass(ExportPass):
     This pass changes types of ops in self.targeted_ops, such as sum, so that
     the output type of that matches the type of the output_qparams.
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     targeted_ops: Set[EdgeOpOverload] = {
         exir_ops.edge.aten.sum.dim_IntList,

--- a/backends/arm/_passes/fuse_batchnorm2d_pass.py
+++ b/backends/arm/_passes/fuse_batchnorm2d_pass.py
@@ -5,6 +5,8 @@
 
 # pyre-unsafe
 
+from typing import Set, Type
+
 import torch
 from executorch.backends.arm._passes.arm_pass_utils import (
     create_node,
@@ -27,6 +29,8 @@ class FuseBatchnorm2DPass(ExportPass):
     """Fuses the pattern convolution -> batchnorm by updating
     the weights and bias of the convolution and removing the batchnorm.
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def __init__(self, exported_program: ExportedProgram):
         self.exported_program = exported_program

--- a/backends/arm/_passes/fuse_constant_ops_pass.py
+++ b/backends/arm/_passes/fuse_constant_ops_pass.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import logging
+from typing import Set, Type
 
 import torch._export.utils
 import torch.fx
@@ -40,6 +41,8 @@ class FuseConstantArgsPass(ExportPass):
         def f():
             return x
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def __init__(self, exported_program: ExportedProgram) -> None:
         super().__init__()
@@ -167,6 +170,8 @@ class ComputeConstantOpsAOT(ExportPass):
         def f(node_name_pre_computed):
             return node_name_pre_computed
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     targeted_ops = [
         exir_ops.edge.aten.full.default,

--- a/backends/arm/_passes/fuse_equal_placeholders_pass.py
+++ b/backends/arm/_passes/fuse_equal_placeholders_pass.py
@@ -5,6 +5,7 @@
 
 import hashlib
 from collections import defaultdict
+from typing import Set, Type
 
 import torch
 from executorch.backends.arm._passes.arm_pass_utils import (
@@ -26,6 +27,8 @@ class FuseEqualPlaceholdersPass(ExportPass):
     pointing to identical tensors and fusing them to one single placeholder
     with multiple users, using a cache for faster comparison.
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def __init__(self, exported_program: ExportedProgram):
         self.exported_program = exported_program

--- a/backends/arm/_passes/fuse_quantized_activation_pass.py
+++ b/backends/arm/_passes/fuse_quantized_activation_pass.py
@@ -5,6 +5,8 @@
 
 # pyre-unsafe
 
+from typing import Set, Type
+
 import torch
 from executorch.backends.arm._passes.quant_args import QuantArgs
 from executorch.backends.arm.constants import Q_OPS
@@ -14,6 +16,8 @@ from torch.fx import Node
 
 
 class FuseQuantizedActivationPass(ExportPass):
+    _passes_required_after: Set[Type[ExportPass]] = set()
+
     @staticmethod
     def _is_fuseable_quantized_activation(node: Node):
         """Fuse activations that have a 0 lower bound and quantized with a qmin zero-point"""

--- a/backends/arm/_passes/insert_rescales_pass.py
+++ b/backends/arm/_passes/insert_rescales_pass.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from copy import copy
-from typing import cast
+from typing import cast, Set, Type
 
 from executorch.backends.arm._passes.arm_pass_utils import create_node
 from executorch.backends.arm._passes.quant_args import QuantArgs
@@ -23,6 +23,8 @@ class InsertRescalePass(ExportPass):
     produced the dq and q nodes. The TOSA constraints are validated
     in the fake implementation of.
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def fold_dq_q_to_rescale(self, node: Node, user: Node, graph_module: GraphModule):
         dq_args = QuantArgs.from_operator(node.target, node.args)

--- a/backends/arm/_passes/insert_table_ops.py
+++ b/backends/arm/_passes/insert_table_ops.py
@@ -6,7 +6,7 @@
 # pyre-unsafe
 
 from itertools import chain
-from typing import Callable, cast, Dict, Iterator, Set
+from typing import Callable, cast, Dict, Iterator, Set, Type
 
 import torch
 from executorch.backends.arm._passes.arm_pass_utils import create_node
@@ -116,6 +116,8 @@ class InsertTableOpsPass(ExportPass):
     When lowering the _table node target_str will be used to find the corresponding torch operator
     which will be used to produce the table values in operators/op_table.py.
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def __init__(self, exported_program: ExportedProgram) -> None:
         super().__init__()

--- a/backends/arm/_passes/match_arg_dtype_pass.py
+++ b/backends/arm/_passes/match_arg_dtype_pass.py
@@ -3,6 +3,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Set, Type
+
 import torch
 from executorch.backends.arm._passes.arm_pass_utils import create_node, get_node_arg
 from executorch.exir.dialects._ops import ops as exir_ops
@@ -37,6 +39,8 @@ class MatchArgDtypePass(ExportPass):
     cast to int8 and then to the correct target data type.
 
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     targeted_ops = {exir_ops.edge.aten.sub.Tensor, exir_ops.edge.aten.where.self}
 

--- a/backends/arm/_passes/match_arg_ranks_pass.py
+++ b/backends/arm/_passes/match_arg_ranks_pass.py
@@ -7,7 +7,7 @@
 
 # pyre-unsafe
 
-from typing import cast
+from typing import cast, Set, Type
 
 from executorch.backends.arm._passes.arm_pass_utils import (
     create_node,
@@ -35,6 +35,8 @@ class MatchArgRanksPass(ExportPass):
         input1 = shape(1, 1, 2)
         input2 = shape(1, 3, 1)
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def __init__(self, exported_program):
         super().__init__()

--- a/backends/arm/_passes/mm_to_bmm_pass.py
+++ b/backends/arm/_passes/mm_to_bmm_pass.py
@@ -6,6 +6,8 @@
 
 # pyre-unsafe
 
+from typing import Set, Type
+
 import torch
 from executorch.backends.arm._passes.arm_pass_utils import (
     create_node,
@@ -27,6 +29,8 @@ class ConvertMmToBmmPass(ExportPass):
     2) Convert MM node to BMM.
     3) Squeeze output tensor to rank 2.
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def call(self, graph_module: torch.fx.GraphModule):
         modified_graph = False

--- a/backends/arm/_passes/remove_noop_pass.py
+++ b/backends/arm/_passes/remove_noop_pass.py
@@ -7,6 +7,7 @@
 # pyre-unsafe
 
 import logging
+from typing import Set, Type
 
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass
@@ -16,6 +17,8 @@ logger = logging.getLogger(__name__)
 
 class RemoveNoopPass(ExportPass):
     """Remove no-ops from graph_module"""
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def call_operator(self, op, args, kwargs, meta):
         if op not in (

--- a/backends/arm/_passes/replace_inf_values_pass.py
+++ b/backends/arm/_passes/replace_inf_values_pass.py
@@ -7,6 +7,8 @@
 # This pass is based on backends/qualcomm/_passes/replace_inf_values.py
 # with some modification to replaced inf values.
 
+from typing import Set, Type
+
 import torch
 from executorch.exir.pass_base import ExportPass, PassResult
 
@@ -15,6 +17,8 @@ class ReplaceInfValues(ExportPass):
     """
     Due to limitation in Quantizer, we need to change inf/-inf to more quantizable values.
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def __init__(self):
         super(ReplaceInfValues, self).__init__()

--- a/backends/arm/_passes/replace_scalar_with_tensor_pass.py
+++ b/backends/arm/_passes/replace_scalar_with_tensor_pass.py
@@ -6,7 +6,7 @@
 # pyre-unsafe
 
 
-from typing import Dict, Union
+from typing import Dict, Set, Type, Union
 
 import torch
 from executorch.backends.transforms.replace_scalar_with_tensor import (
@@ -15,6 +15,7 @@ from executorch.backends.transforms.replace_scalar_with_tensor import (
 from executorch.exir.dialects._ops import ops as exir_ops
 
 from executorch.exir.dialects.edge._ops import EdgeOpOverload
+from executorch.exir.pass_base import ExportPass
 
 
 # Operators that are included for both TOSA profiles
@@ -56,6 +57,8 @@ _common_ops: Dict[
 
 
 class ReplaceScalarWithTensorArgPassTOSAMI(ReplaceScalarWithTensorArgPass):
+    _passes_required_after: Set[Type[ExportPass]] = set()
+
     scalar_to_tensor_ops = _common_ops | {
         exir_ops.edge.aten.pow.Tensor_Scalar: exir_ops.edge.aten.pow.Tensor_Tensor,
         torch.ops.aten.pow.Tensor_Scalar: torch.ops.aten.pow.Tensor_Tensor,
@@ -66,6 +69,8 @@ class ReplaceScalarWithTensorArgPassTOSAMI(ReplaceScalarWithTensorArgPass):
 
 
 class ReplaceScalarWithTensorArgPassTOSABI(ReplaceScalarWithTensorArgPass):
+    _passes_required_after: Set[Type[ExportPass]] = set()
+
     scalar_to_tensor_ops = _common_ops
 
     def __init__(self):

--- a/backends/arm/_passes/scalars_to_attribute_pass.py
+++ b/backends/arm/_passes/scalars_to_attribute_pass.py
@@ -6,7 +6,7 @@
 
 # pyre-unsafe
 
-from typing import cast, Union
+from typing import cast, Set, Type, Union
 
 import torch
 from executorch.backends.arm._passes.arm_pass_utils import get_first_fake_tensor
@@ -21,6 +21,8 @@ class ScalarsToAttributePass(ExportPass):
     For ops in 'targeted_ops', convert inputs that are scalar values
     to attribute Nodes that output the same value.
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     targeted_ops = [
         torch.ops.aten.add.Tensor,

--- a/backends/arm/_passes/size_adjust_input_pass.py
+++ b/backends/arm/_passes/size_adjust_input_pass.py
@@ -5,7 +5,7 @@
 
 # pyre-unsafe
 
-from typing import cast, TypeAlias
+from typing import cast, Set, Type, TypeAlias
 
 import torch.fx
 from executorch.backends.arm._passes.arm_pass_utils import create_node
@@ -184,6 +184,8 @@ class SizeAdjustInputPass(ExportPass):
     slice op is inserted to remove the remaining edges (rows and columns) of the
     input.
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def call(self, graph_module: torch.fx.GraphModule) -> PassResult:
         graph = graph_module.graph

--- a/backends/arm/_passes/to_tosa_memory_format_pass.py
+++ b/backends/arm/_passes/to_tosa_memory_format_pass.py
@@ -7,6 +7,7 @@
 
 
 import logging
+from typing import Set, Type
 
 import torch
 from executorch.backends.arm._passes.annotate_decomposed_matmul import (
@@ -47,6 +48,14 @@ class ToTosaMemoryFormatPass(ExportPass):
     when a transition between 3D and 4D/5D tensors happen.
     The annotated tosa_dim_order is used to permute the node's shape such that it gives a TOSA-compliant shape.
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
+
+    NHWC_order = (0, 2, 3, 1)
+    NHWC_inverse_order = (0, 3, 1, 2)
+    HWCM_order = (2, 3, 0, 1)
+    NNHWC_order = (0, 1, 3, 4, 2)
+    NNHWC_inverse_order = (0, 1, 4, 2, 3)
 
     def __init__(self, exported_program: ExportedProgram) -> None:
         self.exported_program = exported_program

--- a/backends/arm/_passes/unsqueeze_before_repeat_pass.py
+++ b/backends/arm/_passes/unsqueeze_before_repeat_pass.py
@@ -1,9 +1,11 @@
-# Copyright 2024 Arm Limited and/or its affiliates.
+# Copyright 2024-2025 Arm Limited and/or its affiliates.
 # All rights reserved.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 # pyre-unsafe
+from typing import Set, Type
+
 import torch
 import torch.fx
 from executorch.backends.arm._passes.arm_pass_utils import (
@@ -28,6 +30,8 @@ class UnsqueezeBeforeRepeatPass(ExportPass):
         view(shape = [1]*num_new_dims + old_shape)
         repeat(multiples)
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def call(self, graph_module: torch.fx.GraphModule):
         modified_graph = False

--- a/backends/arm/_passes/unsqueeze_scalar_placeholders_pass.py
+++ b/backends/arm/_passes/unsqueeze_scalar_placeholders_pass.py
@@ -5,6 +5,8 @@
 
 # pyre-unsafe
 
+from typing import Set, Type
+
 import torch
 from executorch.exir.pass_base import ExportPass, PassResult
 from torch._export.utils import is_buffer, is_param
@@ -15,6 +17,8 @@ class UnsqueezeScalarPlaceholdersPass(ExportPass):
     Placeholders that have node.meta["val"].shape = () cause issues later in the lowering.
     This pass unsqueezes the placeholders to make sure shape is at least (1,).
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def __init__(self, exported_program):
         self.exported_program = exported_program

--- a/backends/arm/test/misc/test_pass_required_order.py
+++ b/backends/arm/test/misc/test_pass_required_order.py
@@ -1,0 +1,95 @@
+# Copyright 2025 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import re
+from typing import List, Set, Type
+
+import pytest
+from executorch.backends.arm._passes.arm_pass_manager import ArmPass, ArmPassManager
+from executorch.backends.arm.tosa.specification import TosaSpecification
+from executorch.exir.pass_base import ExportPass
+
+
+class PassC(ArmPass):
+    _passes_required_after: Set[Type[ExportPass]] = set()
+
+
+class PassB(ArmPass):
+    _passes_required_after = {PassC}
+
+
+class PassA(ArmPass):
+    _passes_required_after = {PassB, PassC}
+
+
+class IndependentPass(ArmPass):
+    _passes_required_after: Set[Type[ExportPass]] = set()
+
+
+def _setup_pass_manager(passes: List[ArmPass] | None = None):
+    tosa_spec = TosaSpecification.create_from_string("TOSA-1.00+INT")
+    pass_manager = ArmPassManager(tosa_spec)
+    if passes is not None:
+        for p in passes:
+            pass_manager.add_pass(p)
+    return pass_manager
+
+
+def test_no_passes():
+    pass_manager = _setup_pass_manager()
+    pass_manager.validate_constraints_mandatory()
+
+
+def test_correct_order():
+    pass_manager = _setup_pass_manager([PassA(), PassB(), PassC()])
+    pass_manager.validate_constraints_mandatory()
+
+
+def test_run_pass_twice():
+    pass_manager = _setup_pass_manager([PassA(), PassB(), PassB(), PassC()])
+    pass_manager.validate_constraints_mandatory()
+
+
+def test_independent_pass():
+    pass_manager = _setup_pass_manager(
+        [
+            IndependentPass(),
+            PassA(),
+            IndependentPass(),
+            PassB(),
+            IndependentPass(),
+            PassC(),
+            IndependentPass(),
+        ]
+    )
+    pass_manager.validate_constraints_mandatory()
+
+
+def test_duplicated_requiring_pass_put_last():
+    error_msg = """The following constraints for passes are not met:
+  - PassC must run after PassB
+"""
+    pass_manager = _setup_pass_manager([PassA(), PassB(), PassC(), PassB()])
+    with pytest.raises(RuntimeError, match=re.escape(error_msg)):
+        pass_manager.validate_constraints_mandatory()
+
+
+def test_two_passes_wrong_order():
+    error_msg = """The following constraints for passes are not met:
+  - PassC must run after PassB
+"""
+    pass_manager = _setup_pass_manager([PassC(), PassB()])
+    with pytest.raises(RuntimeError, match=re.escape(error_msg)):
+        pass_manager.validate_constraints_mandatory()
+
+
+def test_missing_passes():
+    error_msg = """The following constraints for passes are not met:
+  - PassC must run after PassA
+  - PassC must run after PassB
+"""
+    pass_manager = _setup_pass_manager([PassA(), PassB()])
+    with pytest.raises(RuntimeError, match=re.escape(error_msg)):
+        pass_manager.validate_constraints_mandatory()

--- a/backends/transforms/decompose_sdpa.py
+++ b/backends/transforms/decompose_sdpa.py
@@ -7,6 +7,7 @@
 # pyre-strict
 
 import math
+from typing import Set, Type
 
 import torch
 from executorch.exir.pass_base import ExportPass, PassResult
@@ -18,6 +19,8 @@ class DecomposeScaledDotProductAttention(ExportPass):
     """
     Decompose from scaled_dot_product_attention to multiple nodes.
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def __init__(self, allow_non_fake_inputs: bool = True) -> None:
         super().__init__()

--- a/backends/transforms/fuse_view_copy.py
+++ b/backends/transforms/fuse_view_copy.py
@@ -7,6 +7,8 @@
 
 # pyre-strict
 
+from typing import Set, Type
+
 import torch
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass, PassResult
@@ -62,6 +64,8 @@ def remove_noop_view_copy(graph: torch.fx.Graph) -> tuple[torch.fx.Graph, bool]:
 
 
 class FuseViewCopyTransform(ExportPass):
+    _passes_required_after: Set[Type[ExportPass]] = set()
+
     def call(self, graph_module: torch.fx.GraphModule) -> PassResult:
         graph_module.graph, merge_modified = merge_view_copy_chains(graph_module.graph)
         graph_module.graph, noop_modified = remove_noop_view_copy(graph_module.graph)


### PR DESCRIPTION
Introduce a mechanism to enforce required ordering of passes in ArmPassManager. Each ArmPass must now declare which passes are required to run after it, ensuring ordering constraints are always upheld.

This prevents accidental breakage when modifying pass ordering in the manager.

Ordering constraints are verified by the new method ArmPass.validate_constraints_mandatory. We considered reusing torch.fx.passes.infra.pass_manager.PassManager.validate_constraints, but that utility only checks pairwise ordering and cannot enforce that a pass is actually run, which did not meet our needs.

This patch only implements the mechanism and tests for it. Defining the actual pass orderings are done in a later patch.

### Test plan
The change comes with added unit tests in backends/arm/test/misc/test_pass_required_order.py


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218