### PR TITLE
Unify and reorder replace passes.

### DIFF
--- a/backends/cadence/aot/replace_ops.py
+++ b/backends/cadence/aot/replace_ops.py
@@ -2242,6 +2242,17 @@ class ReplaceAdaptiveAvgPoolWithAtenAvgPoolPass(ExportPass):
         )
 
 
+class CommonReplacePasses:
+    passes = [
+        ReplaceSqueezeAndUnsqueezeWithViewPass,
+        ReplaceSplitWithSlicePass,
+        ReplaceSelectWithViewOpPass,
+        ReplaceMMWithAddMMPass,
+        ReplaceRepeatWithCatPass,
+        ReplaceFullLikeWithFullPass,
+    ]
+
+
 @register_cadence_pass(CadencePassAttribute(opt_level=0))
 class ReplaceAtenLinalgSvdWithCadenceLinalgSvdPass(ExportPass):
     """
@@ -2260,19 +2271,15 @@ class ReplaceAtenLinalgSvdWithCadenceLinalgSvdPass(ExportPass):
 # This class encapsulates all the functions that replace/switch one op in the
 # graph with another.
 class CadenceReplaceOpsInGraph:
-    passes = [
+    passes = CommonReplacePasses.passes + [
         ReplaceAtenLinalgSvdWithCadenceLinalgSvdPass,
         ReplaceEmptyTensorsWithFullPass,
         ReplaceFunctionallyEquivalentOpTargets,
         ReplacePermuteWithTransposePass,
         ReplaceScalarWithTensorArgPass,
         ReplaceConvolutionOptionalArgsWithConcreteArgsPass,
-        ReplaceMMWithAddMMPass,
-        ReplaceSqueezeAndUnsqueezeWithViewPass,
         ReplaceAddMMWithLinearPass,
         RemoveNopSelectOpPass,
-        ReplaceSelectWithViewOpPass,
-        ReplaceRepeatWithCatPass,
         ReplacePadWithCatPass,
         ReplaceConstantPadNdWithSlicePass,
         ReplaceAtenConvolutionWithCadenceConvolutionPass,
@@ -2287,7 +2294,6 @@ class CadenceReplaceOpsInGraph:
         ReplaceNopTransposeOrPermuteWithViewPass,
         ReplaceLinearWithFullyConnectedOpPass,
         ReplaceScalarTensorWithFullPass,
-        ReplaceFullLikeWithFullPass,
         ReplaceInfArgInFullWithValuePass,
         ReplaceLogicalNotBooleanWhereWithWherePass,
         ReplacePT2QuantWithCadenceQuantPass,
@@ -2297,7 +2303,6 @@ class CadenceReplaceOpsInGraph:
         ReplaceAtenAvgPoolWithCadenceAvgPoolPass,
         ReplaceWhereWithFullArgsWithWhereScalar,
         ReplaceAtenApproxGeluWithApproxGeluPass,
-        ReplaceSplitWithSlicePass,
         ReplacePowWithMulPass,
         ReplaceMulTensorWithMulAndFullOpsPass,
     ]


### PR DESCRIPTION
Summary:
Extract some of passes which are currently shared between Jarvis and Helios into an explicit shared list. 
With subsequent diffs I will be adding more and more shared passes.

Differential Revision: D81948451


