### PR TITLE
Compare full key value when retrieving named data

### DIFF
--- a/extension/flat_tensor/flat_tensor_data_map.cpp
+++ b/extension/flat_tensor/flat_tensor_data_map.cpp
@@ -56,7 +56,8 @@ Result<const flat_tensor_flatbuffer::NamedData*> get_named_data(
     return Error::NotFound;
   }
   for (int i = 0; i < named_data->size(); i++) {
-    if (std::strncmp(
+    if (key.size() == named_data->Get(i)->key()->size() &&
+        std::strncmp(
             named_data->Get(i)->key()->c_str(),
             key.data(),
             named_data->Get(i)->key()->size()) == 0) {


### PR DESCRIPTION
Summary:
Compare full input key value when retrieving named data.

Previous implementation iterates through the key values, comparing the input key value up to the length of the iterated key value length. This causes wrong data access when there is a key before this value and has partial match in the front part, e.g., "delegate_1" and "delegate_10".

Differential Revision: D82129824


