### PR TITLE
Fix BFloat16 support for op_index

### DIFF
--- a/kernels/portable/cpu/op_index.cpp
+++ b/kernels/portable/cpu/op_index.cpp
@@ -213,7 +213,7 @@ Tensor& index_Tensor_out(
   if (block_count == 0) {
     ET_KERNEL_CHECK(
         ctx, resize_tensor(out, in.sizes()) == Error::Ok, InvalidArgument, out);
-    ET_SWITCH_REALHB_TYPES(in_type, ctx, "index.Tensor_out", CTYPE, [&]() {
+    ET_SWITCH_REALHBBF16_TYPES(in_type, ctx, "index.Tensor_out", CTYPE, [&]() {
       const CTYPE* const in_data = in.const_data_ptr<CTYPE>();
       CTYPE* const out_data = out.mutable_data_ptr<CTYPE>();
       memcpy(out_data, in_data, in.nbytes());


### PR DESCRIPTION
Summary: Previously, the portable op index didn't support BFloat16 when all the indices were null. This PR fixes this, and adds comprehensive testing for this edge case.

Differential Revision: D82134506


