### PR TITLE
Bump torchao pin and use v2 torchao tensors

### DIFF
--- a/backends/apple/coreml/test/test_coreml_recipes.py
+++ b/backends/apple/coreml/test/test_coreml_recipes.py
@@ -3,6 +3,7 @@
 # Please refer to the license found in the LICENSE file in the root directory of the source tree.
 
 
+import copy
 import unittest
 
 import coremltools as ct
@@ -152,8 +153,9 @@ class TestCoreMLRecipes(unittest.TestCase):
         # Test with different group sizes
         for group_size in [8, 16, 32]:
             with self.subTest(group_size=group_size):
+                model_to_export = copy.deepcopy(model)
                 session = export(
-                    model=model,
+                    model=model_to_export,
                     example_inputs=example_inputs,
                     export_recipe=ExportRecipe.get_recipe(
                         CoreMLRecipeType.TORCHAO_INT4_WEIGHT_ONLY_PER_GROUP,

--- a/backends/apple/coreml/test/test_coreml_recipes.py
+++ b/backends/apple/coreml/test/test_coreml_recipes.py
@@ -221,8 +221,9 @@ class TestCoreMLRecipes(unittest.TestCase):
         # Test with different group sizes
         for group_size in [16, 32, 64]:
             with self.subTest(group_size=group_size):
+                model_to_export = copy.deepcopy(model)
                 session = export(
-                    model=model,
+                    model=model_to_export,
                     example_inputs=example_inputs,
                     export_recipe=ExportRecipe.get_recipe(
                         CoreMLRecipeType.TORCHAO_INT8_WEIGHT_ONLY_PER_GROUP,

--- a/backends/vulkan/test/test_vulkan_delegate.py
+++ b/backends/vulkan/test/test_vulkan_delegate.py
@@ -2680,14 +2680,17 @@ class TestVulkanBackend(unittest.TestCase):
             def apply_8da4w_quantization(self):
                 """Apply TorchAO 8da4w quantization (int8 dynamic activation + int4 weight)."""
                 from torchao.quantization import (
-                    int8_dynamic_activation_int4_weight,
+                    Int8DynamicActivationIntxWeightConfig,
                     quantize_,
                 )
+                from torchao.quantization.granularity import PerGroup
                 from torchao.utils import unwrap_tensor_subclass
 
                 quantize_(
                     self,
-                    int8_dynamic_activation_int4_weight(group_size=self.group_size),
+                    Int8DynamicActivationIntxWeightConfig(
+                        weight_dtype=torch.int4, granularity=PerGroup(self.group_size)
+                    ),
                 )
                 unwrap_tensor_subclass(self)
                 return self

--- a/backends/xnnpack/test/ops/test_linear.py
+++ b/backends/xnnpack/test/ops/test_linear.py
@@ -34,8 +34,9 @@ from executorch.backends.xnnpack.test.tester.tester import (
 from torch.export.graph_signature import ExportGraphSignature, InputKind
 
 try:
+    from torchao.quantization.granularity import PerGroup
     from torchao.quantization.quant_api import (
-        int8_dynamic_activation_int4_weight,
+        Int8DynamicActivationIntxWeightConfig,
         quantize_,
     )
     from torchao.utils import unwrap_tensor_subclass
@@ -391,7 +392,12 @@ class TestLinear(unittest.TestCase):
         """
         Helper function to test groupwise dynamic quantized linear op with different configurations.
         """
-        quantize_(mod, int8_dynamic_activation_int4_weight(group_size=group_size))
+        quantize_(
+            mod,
+            Int8DynamicActivationIntxWeightConfig(
+                weight_dtype=torch.int4, weight_granularity=PerGroup(group_size)
+            ),
+        )
         unwrap_tensor_subclass(mod)
         DynamicallyQuantizedPartitioner = XnnpackPartitioner(
             config_precisions=ConfigPrecisionType.DYNAMIC_QUANT,


### PR DESCRIPTION
This PR bumps the torchao pin in ExecuTorch, and adjusts the code in ExecuTorch to rely less on deprecated features.  In particular,

* torchao/experimental folder is being deprecated, so we switch embedding / tied embedding quantizers to their new home
* v1 tensors based on AffineQuantizedTensor + QDQLayout are being deprecated.  This switches ExecuTorch to use v2 tensors.  See https://github.com/pytorch/ao/issues/2967.