### PR TITLE
Fix bug where source transform passes untransformed model to next stage

### DIFF
--- a/backends/apple/coreml/test/test_coreml_recipes.py
+++ b/backends/apple/coreml/test/test_coreml_recipes.py
@@ -166,7 +166,7 @@ class TestCoreMLRecipes(unittest.TestCase):
                     session, example_inputs, atol=1e-3
                 )
                 self._compare_eager_unquantized_model_outputs(
-                    session, model, example_inputs
+                    session, model, example_inputs, sqnr_threshold=15
                 )
 
     def test_int4_weight_only_per_group_validation(self):

--- a/backends/xnnpack/test/recipes/test_xnnpack_recipes.py
+++ b/backends/xnnpack/test/recipes/test_xnnpack_recipes.py
@@ -154,7 +154,7 @@ class TestXnnpackRecipes(unittest.TestCase):
             ),
             ExportRecipe.get_recipe(
                 XNNPackRecipeType.TORCHAO_INT8_DYNAMIC_ACT_INT4_WEIGHT_PER_TENSOR,
-                group_size=8,
+                group_size=32,
             ),
         ]
 

--- a/export/stages.py
+++ b/export/stages.py
@@ -332,7 +332,7 @@ class SourceTransformStage(Stage):
         self._transformed_models = copy.deepcopy(artifact.data)
 
         # Apply torchao quantize_ to each model
-        for _, model in artifact.data.items():
+        for _, model in self._transformed_models.items():
             # pyre-ignore
             if len(self._quantization_recipe.ao_quantization_configs) > 1:
                 raise ValueError(


### PR DESCRIPTION
Summary: `quantize_()` modifies model in place, we need to make a copy to avoid making changes to user passed model. Fix a bug as discussed in https://github.com/pytorch/executorch/pull/14171#discussion_r2338013170

Differential Revision: D82167495


