### PR TITLE
Use optimized kernels when available in top-level selective build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -926,6 +926,19 @@ if(NOT EXECUTORCH_SELECT_OPS_YAML STREQUAL ""
    OR NOT EXECUTORCH_SELECT_OPS_LIST STREQUAL ""
    OR NOT EXECUTORCH_SELECT_OPS_MODEL STREQUAL ""
 )
+  # Use optimized kernels when available.
+  if(EXECUTORCH_BUILD_KERNELS_OPTIMIZED)
+    set(_selected_kernel_functions_yaml
+        ${CMAKE_CURRENT_BINARY_DIR}/configurations/merged.yaml
+    )
+    set(_selected_kernel_libs "optimized_kernels" "optimized_portable_kernels")
+  else()
+    set(_selected_kernel_functions_yaml
+        ${EXECUTORCH_ROOT}/kernels/portable/functions.yaml
+    )
+    set(_selected_kernel_libs "portable_kernels")
+  endif()
+
   gen_selected_ops(
     LIB_NAME
     "executorch_selected_kernels"
@@ -945,7 +958,7 @@ if(NOT EXECUTORCH_SELECT_OPS_YAML STREQUAL ""
     LIB_NAME
     "executorch_selected_kernels"
     FUNCTIONS_YAML
-    ${EXECUTORCH_ROOT}/kernels/portable/functions.yaml
+    ${_selected_kernel_functions_yaml}
     CUSTOM_OPS_YAML
     ""
     DTYPE_SELECTIVE_BUILD
@@ -956,13 +969,19 @@ if(NOT EXECUTORCH_SELECT_OPS_YAML STREQUAL ""
     LIB_NAME
     "executorch_selected_kernels"
     KERNEL_LIBS
-    "portable_kernels"
+    ${_selected_kernel_libs}
     DEPS
     executorch_core
     DTYPE_SELECTIVE_BUILD
     "${EXECUTORCH_ENABLE_DTYPE_SELECTIVE_BUILD}"
   )
   list(APPEND _executorch_kernels executorch_selected_kernels)
+
+  install(
+    TARGETS executorch_selected_kernels
+    EXPORT ExecuTorchTargets
+    DESTINATION lib
+  )
 else()
   # No selective build - link the full library.
   if(EXECUTORCH_BUILD_KERNELS_OPTIMIZED)

--- a/tools/cmake/Codegen.cmake
+++ b/tools/cmake/Codegen.cmake
@@ -342,6 +342,12 @@ function(merge_yaml)
     DEPENDS ${GEN_FUNCTIONS_YAML} ${GEN_FALLBACK_YAML}
     WORKING_DIRECTORY ${EXECUTORCH_ROOT}
   )
+
+  # Mark the file as generated to allow it to be referenced from other
+  # CMakeLists in the project.
+  set_source_files_properties(
+    ${GEN_OUTPUT_DIR}/merged.yaml PROPERTIES GENERATED TRUE
+  )
 endfunction()
 
 # Append the file list in the variable named `name` in build/build_variables.bzl


### PR DESCRIPTION
### Summary
Use optimized kernels for the top-level executorch_selected_kernels target when built.

### Test plan
I've manually built with top-level selective build to verify that this works. CI coverage will be provided with https://github.com/pytorch/executorch/pull/13741, which should land shortly.
