### PR TITLE
Arm backend: Fix bug in memory allocation

### DIFF
--- a/examples/arm/executor_runner/arm_memory_allocator.cpp
+++ b/examples/arm/executor_runner/arm_memory_allocator.cpp
@@ -7,7 +7,7 @@
 #include "arm_memory_allocator.h"
 
 ArmMemoryAllocator::ArmMemoryAllocator(uint32_t size, uint8_t* base_address)
-    : MemoryAllocator(size, base_address), used_(0), peak_used_(0) {}
+    : MemoryAllocator(size, base_address), used_(0) {}
 
 void* ArmMemoryAllocator::allocate(size_t size, size_t alignment) {
   void* ret = executorch::runtime::MemoryAllocator::allocate(size, alignment);
@@ -22,18 +22,12 @@ void* ArmMemoryAllocator::allocate(size_t size, size_t alignment) {
     } else {
       used_ = (used_ | (alignment - 1)) + 1 + size;
     }
-    if (used_ > peak_used_)
-      peak_used_ = used_;
   }
   return ret;
 }
 
 size_t ArmMemoryAllocator::used_size() const {
   return used_;
-}
-
-size_t ArmMemoryAllocator::peak_used() const {
-  return peak_used_;
 }
 
 size_t ArmMemoryAllocator::free_size() const {

--- a/examples/arm/executor_runner/arm_memory_allocator.h
+++ b/examples/arm/executor_runner/arm_memory_allocator.h
@@ -21,15 +21,10 @@ class ArmMemoryAllocator : public executorch::runtime::MemoryAllocator {
   // Returns the used size of the allocator's memory buffer.
   size_t used_size() const;
 
-  // Returns the peak memory usage of the allocator's memory buffer
-  // Peak usage is useful when doing multiple allocations & resets
-  size_t peak_used() const;
-
   // Returns the free size of the allocator's memory buffer.
   size_t free_size() const;
   void reset();
 
  private:
   size_t used_;
-  size_t peak_used_;
 };


### PR DESCRIPTION
If running multiple inferences on the same Ethos-U custom delegate, we need to reset the temp_allocator after every inference. Otherwise, we keep allocating more memory within the temp_allocator rather than reuse the temp_allocator between inferences.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218