### PR TITLE
Remove torchcodec from install_requirements.py

### DIFF
--- a/examples/models/moshi/mimi/install_requirements.sh
+++ b/examples/models/moshi/mimi/install_requirements.sh
@@ -8,6 +8,7 @@
 set -x
 
 conda install "ffmpeg<8"
+pip install torchcodec==0.7.0.dev20250906 --extra-index-url https://download.pytorch.org/whl/nightly/cpu
 pip install moshi==0.2.4
 pip install bitsandbytes soundfile
 # Run llama2/install requirements for torchao deps

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -155,9 +155,6 @@ def install_optional_example_requirements(use_pytorch_nightly):
             else "torchvision"
         ),
         f"torchaudio==2.8.0.{NIGHTLY_VERSION}" if use_pytorch_nightly else "torchaudio",
-        # We probably don't need explicit torchcodec, see comment here
-        # https://github.com/pytorch/audio/pull/4039#issuecomment-3274648824
-        f"torchcodec==0.7.0.{NIGHTLY_VERSION}" if use_pytorch_nightly else "torchcodec",
     ]
     # Then install domain libraries
     subprocess.run(


### PR DESCRIPTION
Summary:

torchcodec is used when only torchaudio users use torch.save and torch.load. It is an optional requirement.

Only moshi test uses torch.save and torch.load, and we shouldn't make this to install across the board.

Currently, it is blocking linux aarch64 wheel building (https://github.com/pytorch/executorch/pull/13946) because during smoke testing it is trying to install torchcodec on linux aarch64 machine and it is failing
