### PR TITLE
Add support for fusing Conv+ReLU

### DIFF
--- a/backends/cadence/aot/quantizer/utils.py
+++ b/backends/cadence/aot/quantizer/utils.py
@@ -234,3 +234,19 @@ def find_sequential_partitions_aten(
         if _partitions_sequential(candidate):
             fused_partitions.append(candidate)
     return fused_partitions
+
+
+def check_out_zero_point_is_min_range(
+    out_zero_point: int,
+    out_dtype: torch.dtype,
+) -> bool:
+    """
+    Checks if the out_zero_point is the minimum range of the quant type.
+    """
+    if out_dtype == torch.int8:
+        return out_zero_point == -128
+    elif out_dtype == torch.int16:
+        return out_zero_point == -32768
+    elif out_dtype == torch.uint8 or torch.uint16:
+        return out_zero_point == 0
+    return False


### PR DESCRIPTION
Summary:
This diff adds support for *implicitly* fusing Conv2d+ReLU

We add a new pattern which will capture this sequence of events and ensure the subgraph is treated as one node during calculation of qparam.

Then, during fuse, we replace this subgraph with just the conv and drop the ReLU.

Reviewed By: ethansfng, hsharma35

Differential Revision: D79381533


