### PR TITLE
Move ReplaceAtenConvolutionWithCadenceConvolutionPass to common section.

### DIFF
--- a/backends/cadence/aot/replace_ops.py
+++ b/backends/cadence/aot/replace_ops.py
@@ -2250,6 +2250,7 @@ class CommonReplacePasses:
         ReplaceMMWithAddMMPass,
         ReplaceRepeatWithCatPass,
         ReplaceFullLikeWithFullPass,
+        ReplaceAtenConvolutionWithCadenceConvolutionPass,
     ]
 
 
@@ -2282,7 +2283,6 @@ class CadenceReplaceOpsInGraph:
         RemoveNopSelectOpPass,
         ReplacePadWithCatPass,
         ReplaceConstantPadNdWithSlicePass,
-        ReplaceAtenConvolutionWithCadenceConvolutionPass,
         ReplaceConvWithChannelLastConvPass,
         ReplaceTrivialConvWithLinear,
         ReplaceConvWithIm2RowAndLinear,


### PR DESCRIPTION
Summary: Move ReplaceAtenConvolutionWithCadenceConvolutionPass to the common section. This diff changes the order of application of this pass for both Helios and Jarvis.

Reviewed By: DrJessop

Differential Revision: D82045868
