### PR TITLE
Fix moshi test: Update ffmpeg installation command in script

### DIFF
--- a/examples/models/moshi/mimi/install_requirements.sh
+++ b/examples/models/moshi/mimi/install_requirements.sh
@@ -7,7 +7,7 @@
 
 set -x
 
-conda install "ffmpeg<8"
+conda install -c conda-forge "ffmpeg<8" -y
 pip install torchcodec==0.7.0.dev20250906 --extra-index-url https://download.pytorch.org/whl/nightly/cpu
 pip install moshi==0.2.4
 pip install bitsandbytes soundfile


### PR DESCRIPTION
Currently failing with this test 

```
2025-09-12T09:41:44.2499052Z + bash examples/models/moshi/mimi/install_requirements.sh
2025-09-12T09:41:44.2499462Z + conda install 'ffmpeg<8'
2025-09-12T09:41:44.2499798Z Retrieving notices: ...working... done
2025-09-12T09:41:44.2500105Z Channels:
2025-09-12T09:41:44.2500304Z  - defaults
2025-09-12T09:41:44.2500526Z Platform: linux-64
2025-09-12T09:41:44.2501182Z Collecting package metadata (repodata.json): \ ␈␈| ␈␈/ ␈␈- ␈␈\ ␈␈| ␈␈/ ␈␈- ␈␈\ ␈␈| ␈␈/ ␈␈- ␈␈\ ␈␈| ␈␈/ ␈␈- ␈␈\ ␈␈| ␈␈/ ␈␈- ␈␈\ ␈␈| ␈␈/ ␈␈- ␈␈\ ␈␈| ␈␈/ ␈␈- ␈␈\ ␈␈| ␈␈/ ␈␈- ␈␈\ ␈␈| ␈␈/ ␈␈- ␈␈\ ␈␈| ␈␈/ ␈␈- ␈␈\ ␈␈| ␈␈/ ␈␈done
2025-09-12T09:41:44.2501805Z Solving environment: \ ␈␈| ␈␈done
2025-09-12T09:41:44.2502037Z 
2025-09-12T09:41:44.2502161Z ## Package Plan ##
2025-09-12T09:41:44.2502302Z 
2025-09-12T09:41:44.2502440Z   environment location: /opt/conda/envs/py_3.10
2025-09-12T09:41:44.2502689Z 
2025-09-12T09:41:44.2502801Z   added / updated specs:
2025-09-12T09:41:44.2503057Z     - ffmpeg[version='<8']
2025-09-12T09:41:44.2503239Z 
2025-09-12T09:41:44.2503243Z 
2025-09-12T09:41:44.2503367Z The following packages will be downloaded:
2025-09-12T09:41:44.2503598Z 
2025-09-12T09:41:44.2503733Z     package                    |            build
2025-09-12T09:41:44.2504065Z     ---------------------------|-----------------
2025-09-12T09:41:44.2504435Z     aom-3.6.0                  |       h6a678d5_0         2.8 MB
2025-09-12T09:41:44.2504860Z     ca-certificates-2025.9.9   |       h06a4308_0         127 KB
2025-09-12T09:41:44.2505298Z     cairo-1.18.4               |       h44eff21_0         728 KB
2025-09-12T09:41:44.2505684Z     dav1d-1.2.1                |       h5eee18b_0         823 KB
2025-09-12T09:41:44.2506089Z     ffmpeg-6.1.1               |       h2a67f75_3         9.6 MB
2025-09-12T09:41:44.2506496Z     fontconfig-2.14.1          |       h55d465d_3         281 KB
2025-09-12T09:41:44.2506926Z     freetype-2.13.3            |       h4a9f257_0         686 KB
2025-09-12T09:41:44.2507337Z     giflib-5.2.2               |       h5eee18b_0          80 KB
2025-09-12T09:41:44.2507737Z     graphite2-1.3.14           |       h295c915_1          97 KB
2025-09-12T09:41:44.2508200Z     harfbuzz-10.2.0            |       hdfddeaa_1         2.3 MB
2025-09-12T09:41:44.2508593Z     jpeg-9f                    |       h5ce9db8_0         242 KB
2025-09-12T09:41:44.2509055Z     lame-3.100                 |       h7b6447c_0         323 KB
2025-09-12T09:41:44.2509462Z     leptonica-1.82.0           |       hfdeec58_3         2.5 MB
2025-09-12T09:41:44.2509870Z     lerc-4.0.0                 |       h6a678d5_0         261 KB
2025-09-12T09:41:44.2510277Z     libarchive-3.8.1           |       h13d4d48_0         954 KB
2025-09-12T09:41:44.2510696Z     libdeflate-1.22            |       h5eee18b_0          68 KB
2025-09-12T09:41:44.2511119Z     libglib-2.84.2             |       h37c7471_0         1.7 MB
2025-09-12T09:41:44.2511523Z     libiconv-1.16              |       h5eee18b_3         759 KB
2025-09-12T09:41:44.2511931Z     libogg-1.3.5               |       h27cfd23_1         199 KB
2025-09-12T09:41:44.2512324Z     libopus-1.3.1              |       h5eee18b_1         345 KB
2025-09-12T09:41:44.2512741Z     libpng-1.6.39              |       h5eee18b_0         304 KB
2025-09-12T09:41:44.2513163Z     libtheora-1.1.1            |       h7f8727e_3         338 KB
2025-09-12T09:41:44.2513566Z     libtiff-4.7.0              |       hde9077f_0         447 KB
2025-09-12T09:41:44.2513982Z     libvorbis-1.3.7            |       h7b6447c_0         398 KB
2025-09-12T09:41:44.2514385Z     libvpx-1.13.1              |       h6a678d5_0         1.0 MB
2025-09-12T09:41:44.2514792Z     libwebp-1.3.2              |       h9f374a3_1          94 KB
2025-09-12T09:41:44.2515208Z     libwebp-base-1.3.2         |       h5eee18b_1         425 KB
2025-09-12T09:41:44.2515635Z     libxml2-2.13.8             |       hfdd30dd_0         739 KB
2025-09-12T09:41:44.2516091Z     openh264-2.1.1             |       h4ff587b_0         711 KB
2025-09-12T09:41:44.2516498Z     openjpeg-2.5.2             |       h0d4d230_1         373 KB
2025-09-12T09:41:44.2516906Z     pcre2-10.42                |       hebb0a14_1         1.3 MB
2025-09-12T09:41:44.2517325Z     pixman-0.46.4              |       h7934f7d_0         1.9 MB
2025-09-12T09:41:44.2517747Z     tesseract-5.2.0            |       hb0d2e87_3       167.9 MB
2025-09-12T09:41:44.2518169Z     xorg-libxext-1.3.6         |       h9b100fa_0          49 KB
2025-09-12T09:41:44.2518709Z     xorg-libxrender-0.9.12     |       h9b100fa_0          31 KB
2025-09-12T09:41:44.2519144Z     ------------------------------------------------------------
2025-09-12T09:41:44.2519496Z                                            Total:       200.7 MB
2025-09-12T09:41:44.2519719Z 
2025-09-12T09:41:44.2519719Z 
2025-09-12T09:41:44.2519866Z The following NEW packages will be INSTALLED:
2025-09-12T09:41:44.2520107Z 
2025-09-12T09:41:44.2520275Z   aom                pkgs/main/linux-64::aom-3.6.0-h6a678d5_0 
2025-09-12T09:41:44.2520694Z   cairo              pkgs/main/linux-64::cairo-1.18.4-h44eff21_0 
2025-09-12T09:41:44.2521120Z   dav1d              pkgs/main/linux-64::dav1d-1.2.1-h5eee18b_0 
2025-09-12T09:41:44.2521544Z   ffmpeg             pkgs/main/linux-64::ffmpeg-6.1.1-h2a67f75_3 
2025-09-12T09:41:44.2522028Z   fontconfig         pkgs/main/linux-64::fontconfig-2.14.1-h55d465d_3 
2025-09-12T09:41:44.2522578Z   freetype           pkgs/main/linux-64::freetype-2.13.3-h4a9f257_0 
2025-09-12T09:41:44.2523038Z   giflib             pkgs/main/linux-64::giflib-5.2.2-h5eee18b_0 
2025-09-12T09:41:44.2523486Z   graphite2          pkgs/main/linux-64::graphite2-1.3.14-h295c915_1 
2025-09-12T09:41:44.2523970Z   harfbuzz           pkgs/main/linux-64::harfbuzz-10.2.0-hdfddeaa_1 
2025-09-12T09:41:44.2524404Z   icu                pkgs/main/linux-64::icu-73.1-h6a678d5_0 
2025-09-12T09:41:44.2524787Z   jpeg               pkgs/main/linux-64::jpeg-9f-h5ce9db8_0 
2025-09-12T09:41:44.2525192Z   lame               pkgs/main/linux-64::lame-3.100-h7b6447c_0 
2025-09-12T09:41:44.2525630Z   leptonica          pkgs/main/linux-64::leptonica-1.82.0-hfdeec58_3 
2025-09-12T09:41:44.2526075Z   lerc               pkgs/main/linux-64::lerc-4.0.0-h6a678d5_0 
2025-09-12T11:04:50.9711802Z ##[error]The operation was canceled.
```

### Summary
[PLEASE REMOVE] See [CONTRIBUTING.md's Pull Requests](https://github.com/pytorch/executorch/blob/main/CONTRIBUTING.md#pull-requests) for ExecuTorch PR guidelines.

[PLEASE REMOVE] If this PR closes an issue, please add a `Fixes #<issue-id>` line.

[PLEASE REMOVE] If this PR introduces a fix or feature that should be the upcoming release notes, please add a "Release notes: <area>" label. For a list of available release notes labels, check out [CONTRIBUTING.md's Pull Requests](https://github.com/pytorch/executorch/blob/main/CONTRIBUTING.md#pull-requests).

### Test plan
[PLEASE REMOVE] How did you test this PR? Please write down any manual commands you used and note down tests that you have written if applicable.
