### PR TITLE
Do not run `lintrunner init` in lintrunner CI job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,9 +45,6 @@ jobs:
           cp -r "${CACHE_DIRECTORY}" . || true
         fi
 
-        # This has already been cached in the docker image
-        lintrunner init
-
         RC=0
         # Run lintrunner on all files
         if ! lintrunner --force-color --all-files --tee-json=lint.json 2> /dev/null; then


### PR DESCRIPTION
Two reasons:
1) It will end up spamming pip install -r requirements-dev.txt once for each linter because of the way we have init commands set up. This is fixable, but:
2) setup_linux sets up lintrunner for us already anyway via install_requirements.