### PR TITLE
Add CI for checking file size

### DIFF
--- a/.github/workflows/_link_check.yml
+++ b/.github/workflows/_link_check.yml
@@ -55,3 +55,27 @@ jobs:
           echo "Or add \`@lint-ignore\` somewhere on the same line as the reference you want to skip checking."
           exit 1
         }
+
+  lint-file-size:
+    if: ${{ github.event_name == 'pull_request' }}
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    with:
+      runner: linux.2xlarge
+      docker-image: ci-image:executorch-ubuntu-22.04-linter
+      submodules: false
+      fetch-depth: 0
+      ref: ${{ inputs.ref }}
+      timeout: 30
+      script: |
+        ./scripts/lint_file_size.sh $(
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}"
+          else
+            echo "${{ github.event.before }}" "${{ github.sha }}"
+          fi
+        ) || {
+          echo
+          echo "File size lint failed: some files exceed the 1 MB limit."
+          echo "If you really need large files, consider using Git LFS or storing them elsewhere."
+          exit 1
+        }

--- a/.github/workflows/_link_check.yml
+++ b/.github/workflows/_link_check.yml
@@ -67,7 +67,7 @@ jobs:
       ref: ${{ inputs.ref }}
       timeout: 30
       script: |
-        sleep 900
+        chmod +x ./scripts/lint_file_size.sh
         ./scripts/lint_file_size.sh $(
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             echo "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/_link_check.yml
+++ b/.github/workflows/_link_check.yml
@@ -67,6 +67,7 @@ jobs:
       ref: ${{ inputs.ref }}
       timeout: 30
       script: |
+        sleep 900
         ./scripts/lint_file_size.sh $(
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             echo "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/_link_check.yml
+++ b/.github/workflows/_link_check.yml
@@ -60,7 +60,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
-      runner: linux.large
+      runner: linux.2xlarge
       docker-image: ci-image:executorch-ubuntu-22.04-linter
       submodules: false
       fetch-depth: 0

--- a/.github/workflows/_link_check.yml
+++ b/.github/workflows/_link_check.yml
@@ -77,5 +77,6 @@ jobs:
           echo
           echo "File size lint failed: some files exceed the 1 MB limit."
           echo "If you really need large files, consider using Git LFS or storing them elsewhere."
+          echo "If you really need to get unblocked and check in the file, can add it to the EXCEPTIONS list in scripts/lint_file_size.sh."
           exit 1
         }

--- a/.github/workflows/_link_check.yml
+++ b/.github/workflows/_link_check.yml
@@ -60,7 +60,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
-      runner: linux.2xlarge
+      runner: linux.large
       docker-image: ci-image:executorch-ubuntu-22.04-linter
       submodules: false
       fetch-depth: 0

--- a/scripts/lint_file_size.sh
+++ b/scripts/lint_file_size.sh
@@ -7,13 +7,6 @@
 
 set -euo pipefail
 
-# Default max file size in bytes (1 MB)
-if [[ "$filepath" =~ \.(png|jpg|jpeg|gif|svg)$ ]]; then
-  MAX_SIZE=$((5 * 1024 * 1024))  # 5 MB limit for pictures
-else
-  MAX_SIZE=$((1 * 1024 * 1024))  # 1 MB for others
-fi
-
 status=0
 
 green='\e[1;32m'; red='\e[1;31m'; cyan='\e[1;36m'; reset='\e[0m'
@@ -30,6 +23,13 @@ fi
 
 for file in $files; do
   if [ -f "$file" ]; then
+    # Set size limit depending on extension
+    if [[ "$file" =~ \.(png|jpg|jpeg|gif|svg|mp3|mp4)$ ]]; then
+      MAX_SIZE=$((8 * 1024 * 1024))  # 5 MB for pictures
+    else
+      MAX_SIZE=$((1 * 1024 * 1024))  # 1 MB for others
+    fi
+
     size=$(wc -c <"$file")
     if [ "$size" -gt "$MAX_SIZE" ]; then
       echo -e "${red}FAIL${reset} $file (${cyan}${size} bytes${reset}) exceeds ${MAX_SIZE} bytes"

--- a/scripts/lint_file_size.sh
+++ b/scripts/lint_file_size.sh
@@ -13,7 +13,7 @@ green='\e[1;32m'; red='\e[1;31m'; cyan='\e[1;36m'; reset='\e[0m'
 
 # Following is the rules for the file size linting:
 # 1. For all files, the file size can't be larger than 1MB
-# 2. For images/vidoes, the files size can't be larger than 7MB
+# 2. For images/videos, the file size can't be larger than 8MB
 # 3. There is an exception list defined in the script if it's really needed
 
 # List of files to skip (relative paths)
@@ -55,7 +55,7 @@ for file in $files; do
   if [ -f "$file" ]; then
     # Set size limit depending on extension
     if [[ "$file" =~ \.(png|jpg|jpeg|gif|svg|mp3|mp4)$ ]]; then
-      MAX_SIZE=$((8 * 1024 * 1024))  # 5 MB for pictures
+      MAX_SIZE=$((8 * 1024 * 1024))  # 8 MB for pictures
     else
       MAX_SIZE=$((1 * 1024 * 1024))  # 1 MB for others
     fi

--- a/scripts/lint_file_size.sh
+++ b/scripts/lint_file_size.sh
@@ -11,6 +11,11 @@ status=0
 
 green='\e[1;32m'; red='\e[1;31m'; cyan='\e[1;36m'; reset='\e[0m'
 
+# Following is the rules for the file size linting:
+# 1. For all files, the file size can't be larger than 1MB
+# 2. For images/vidoes, the files size can't be larger than 7MB
+# 3. There is an exception list defined in the script if it's really needed
+
 # List of files to skip (relative paths)
 EXCEPTIONS=(
   "examples/models/llama/params/demo_rand_params.pth"

--- a/scripts/lint_file_size.sh
+++ b/scripts/lint_file_size.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -euo pipefail
+
+# Default max file size in bytes (1 MB)
+MAX_SIZE=$((1024 * 1024))
+status=0
+
+green='\e[1;32m'; red='\e[1;31m'; cyan='\e[1;36m'; reset='\e[0m'
+
+if [ $# -eq 2 ]; then
+  base=$1
+  head=$2
+  echo "Checking changed files between $base...$head"
+  files=$(git diff --name-only "$base...$head")
+else
+  echo "Checking all files in repository"
+  files=$(git ls-files)
+fi
+
+for file in $files; do
+  if [ -f "$file" ]; then
+    size=$(wc -c <"$file")
+    if [ "$size" -gt "$MAX_SIZE" ]; then
+      echo -e "${red}FAIL${reset} $file (${cyan}${size} bytes${reset}) exceeds ${MAX_SIZE} bytes"
+      status=1
+    else
+      echo -e "${green}OK${reset}   $file (${size} bytes)"
+    fi
+  fi
+done
+
+exit $status

--- a/scripts/lint_file_size.sh
+++ b/scripts/lint_file_size.sh
@@ -11,6 +11,27 @@ status=0
 
 green='\e[1;32m'; red='\e[1;31m'; cyan='\e[1;36m'; reset='\e[0m'
 
+# List of files to skip (relative paths)
+EXCEPTIONS=(
+  "examples/models/llama/params/demo_rand_params.pth"
+  "examples/models/llama/tokenizer/test/resources/test_tiktoken_tokenizer.model"
+  "examples/qualcomm/oss_scripts/llama/artifacts/stories260k_hybrid_llama_qnn.pte"
+  # Following needs to be clean up
+  "examples/mediatek/models/llm_models/weights/Llama-3.2-1B-Instruct/tokenizer.json"
+  "examples/mediatek/models/llm_models/weights/Llama-3.2-3B-Instruct/tokenizer.json"
+  "examples/mediatek/models/llm_models/weights/llama3-8B-instruct/tokenizer.json"
+)
+
+is_exception() {
+  local f=$1
+  for ex in "${EXCEPTIONS[@]}"; do
+    if [[ "$f" == "$ex" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
 if [ $# -eq 2 ]; then
   base=$1
   head=$2
@@ -22,6 +43,10 @@ else
 fi
 
 for file in $files; do
+  if is_exception "$file"; then
+    echo -e "${cyan}SKIP${reset}  $file (in exception list)"
+    continue
+  fi
   if [ -f "$file" ]; then
     # Set size limit depending on extension
     if [[ "$file" =~ \.(png|jpg|jpeg|gif|svg|mp3|mp4)$ ]]; then

--- a/scripts/lint_file_size.sh
+++ b/scripts/lint_file_size.sh
@@ -8,7 +8,12 @@
 set -euo pipefail
 
 # Default max file size in bytes (1 MB)
-MAX_SIZE=$((1024 * 1024))
+if [[ "$filepath" =~ \.(png|jpg|jpeg|gif|svg)$ ]]; then
+  MAX_SIZE=$((5 * 1024 * 1024))  # 5 MB limit for pictures
+else
+  MAX_SIZE=$((1 * 1024 * 1024))  # 1 MB for others
+fi
+
 status=0
 
 green='\e[1;32m'; red='\e[1;31m'; cyan='\e[1;36m'; reset='\e[0m'


### PR DESCRIPTION
As title. xrefs will hang if the files change too much, however it's a bit hard to tell. Make file size check explicit. The rule is following
1. For all files, the file size can't be larger than 1MB
2. For images/vidoes, the files size can't be larger than 7MB
3. There is an exception list defined in the script if it's really needed