### PR TITLE
[tosa-tools] Remove v0.80 usage from ET

### DIFF
--- a/backends/arm/TARGETS
+++ b/backends/arm/TARGETS
@@ -22,7 +22,6 @@ runtime.python_library(
         "common/debug.py",
     ],
     deps = [
-        "fbsource//third-party/tosa_tools/v0.80/serialization_lib/python/serializer:serializer",
         "fbsource//third-party/tosa_tools/v1.00/serialization_lib/python/serializer:serializer",
         "//caffe2:torch",
         "//executorch/exir:lib",
@@ -37,9 +36,7 @@ runtime.python_library(
     deps = [
         "fbsource//third-party/pypi/flatbuffers:flatbuffers",
         "fbsource//third-party/pypi/ml-dtypes:ml-dtypes",
-        "fbsource//third-party/tosa_tools/v0.80/serialization_lib/python/serializer:serializer",
         "fbsource//third-party/tosa_tools/v1.00/serialization_lib/python/serializer:serializer",
-        "fbsource//third-party/tosa_tools/v0.80/serialization_lib/python/tosa:tosa",
         "fbsource//third-party/tosa_tools/v1.00/serialization_lib/python/tosa:tosa",
         ":process_node",
         "//executorch/exir/backend:compile_spec_schema",
@@ -83,7 +80,6 @@ runtime.python_library(
     name = "process_node",
     srcs = ["process_node.py"],
     deps = [
-        "fbsource//third-party/tosa_tools/v0.80/serialization_lib/python/tosa:tosa",
         "fbsource//third-party/tosa_tools/v1.00/serialization_lib/python/tosa:tosa",
         "//executorch/backends/arm/operators:node_visitor",
         "//executorch/backends/arm/tosa:mapping",

--- a/backends/arm/operators/TARGETS
+++ b/backends/arm/operators/TARGETS
@@ -20,7 +20,6 @@ runtime.python_library(
     name = "ops",
     srcs = glob(["op_*.py", "ops_*.py"]),
     deps = [
-        "fbsource//third-party/tosa_tools/v0.80/serialization_lib/python/tosa:tosa",
         "fbsource//third-party/tosa_tools/v1.00/serialization_lib/python/tosa:tosa",
         ":node_visitor",
         ":operator_validation_utils",

--- a/backends/arm/tosa/TARGETS
+++ b/backends/arm/tosa/TARGETS
@@ -6,7 +6,6 @@ runtime.python_library(
         "mapping.py",
     ],
     deps = [
-        "fbsource//third-party/tosa_tools/v0.80/serialization_lib/python/serializer:serializer",
         "fbsource//third-party/tosa_tools/v1.00/serialization_lib/python/serializer:serializer",
         "//caffe2:torch",
         ":specification",
@@ -19,9 +18,7 @@ runtime.python_library(
     ],
     deps = [
         "fbsource//third-party/pypi/numpy:numpy",
-        "fbsource//third-party/tosa_tools/v0.80/serialization_lib/python/serializer:serializer",
         "fbsource//third-party/tosa_tools/v1.00/serialization_lib/python/serializer:serializer",
-        "fbsource//third-party/tosa_tools/v0.80/serialization_lib/python/tosa:tosa",
         "fbsource//third-party/tosa_tools/v1.00/serialization_lib/python/tosa:tosa",
         "//executorch/backends/arm:constants",
         ":mapping",
@@ -44,7 +41,6 @@ runtime.python_library(
         "utils.py",
     ],
     deps = [
-        "fbsource//third-party/tosa_tools/v0.80/serialization_lib/python/serializer:serializer",
         ":quant_utils",
         "//executorch/backends/arm/operators:node_visitor",
     ],

--- a/backends/nxp/TARGETS
+++ b/backends/nxp/TARGETS
@@ -50,7 +50,7 @@ runtime.python_library(
     name = "neutron_sdk",
     srcs = glob(["backend/**/*.py"]),
     deps = [
-       "fbsource//third-party/pypi/neutron_converter:neutron_converter",
+        "fbsource//third-party/pypi/neutron_converter:neutron_converter",
     ],
 )
 
@@ -68,7 +68,6 @@ runtime.python_library(
         ":quantizer",
         "fbsource//third-party/pypi/flatbuffers:flatbuffers",
         "fbsource//third-party/pypi/ml-dtypes:ml-dtypes",
-        "fbsource//third-party/tosa_tools/v0.80/serialization_lib/python/serializer:serializer",
         "//executorch/exir:lib",
         "//executorch/backends/transforms:remove_getitem_op",
         "//caffe2:torch",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #14280
* #14279
* __->__ #14278

ET has completely migrated to v1.0. Internal users of ET have also been using v1.0 for a while. It is time to remove v0.80 usage completely.

Differential Revision: [D81773270](https://our.internmc.facebook.com/intern/diff/D81773270/)