### PR TITLE
[tosa-tools] Add top level targets for tosa, serializer

### DIFF
--- a/backends/arm/TARGETS
+++ b/backends/arm/TARGETS
@@ -22,7 +22,7 @@ runtime.python_library(
         "common/debug.py",
     ],
     deps = [
-        "fbsource//third-party/tosa_tools/v1.00/serialization_lib/python/serializer:serializer",
+        "fbsource//third-party/tosa_tools:serializer",
         "//caffe2:torch",
         "//executorch/exir:lib",
     ],
@@ -36,8 +36,8 @@ runtime.python_library(
     deps = [
         "fbsource//third-party/pypi/flatbuffers:flatbuffers",
         "fbsource//third-party/pypi/ml-dtypes:ml-dtypes",
-        "fbsource//third-party/tosa_tools/v1.00/serialization_lib/python/serializer:serializer",
-        "fbsource//third-party/tosa_tools/v1.00/serialization_lib/python/tosa:tosa",
+        "fbsource//third-party/tosa_tools:serializer",
+        "fbsource//third-party/tosa_tools:tosa",
         ":process_node",
         "//executorch/exir/backend:compile_spec_schema",
         "//executorch/backends/arm/operators:lib",
@@ -80,7 +80,7 @@ runtime.python_library(
     name = "process_node",
     srcs = ["process_node.py"],
     deps = [
-        "fbsource//third-party/tosa_tools/v1.00/serialization_lib/python/tosa:tosa",
+        "fbsource//third-party/tosa_tools:tosa",
         "//executorch/backends/arm/operators:node_visitor",
         "//executorch/backends/arm/tosa:mapping",
         "//executorch/backends/arm/tosa:quant_utils",

--- a/backends/arm/debug/TARGETS
+++ b/backends/arm/debug/TARGETS
@@ -8,7 +8,7 @@ runtime.python_library(
         "schema.py",
     ],
     deps = [
-        "fbsource//third-party/tosa_tools/v1.00/serialization_lib/python/serializer:serializer",
+        "fbsource//third-party/tosa_tools:serializer",
         "//caffe2:torch",
     ],
 )

--- a/backends/arm/operators/TARGETS
+++ b/backends/arm/operators/TARGETS
@@ -20,7 +20,7 @@ runtime.python_library(
     name = "ops",
     srcs = glob(["op_*.py", "ops_*.py"]),
     deps = [
-        "fbsource//third-party/tosa_tools/v1.00/serialization_lib/python/tosa:tosa",
+        "fbsource//third-party/tosa_tools:tosa",
         ":node_visitor",
         ":operator_validation_utils",
         "//executorch/backends/arm/tosa:mapping",

--- a/backends/arm/tosa/TARGETS
+++ b/backends/arm/tosa/TARGETS
@@ -6,7 +6,7 @@ runtime.python_library(
         "mapping.py",
     ],
     deps = [
-        "fbsource//third-party/tosa_tools/v1.00/serialization_lib/python/serializer:serializer",
+        "fbsource//third-party/tosa_tools:serializer",
         "//caffe2:torch",
         ":specification",
     ],
@@ -18,8 +18,8 @@ runtime.python_library(
     ],
     deps = [
         "fbsource//third-party/pypi/numpy:numpy",
-        "fbsource//third-party/tosa_tools/v1.00/serialization_lib/python/serializer:serializer",
-        "fbsource//third-party/tosa_tools/v1.00/serialization_lib/python/tosa:tosa",
+        "fbsource//third-party/tosa_tools:serializer",
+        "fbsource//third-party/tosa_tools:tosa",
         "//executorch/backends/arm:constants",
         ":mapping",
         "//executorch/exir/dialects:lib",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #14280
* __->__ #14279
* #14278

To remove version number from the buck target path, and make it simpler to upgrade tosa-tools in the future

Differential Revision: [D81775117](https://our.internmc.facebook.com/intern/diff/D81775117/)