### PR TITLE
Qualcomm AI Engine Direct - add seq_mse_candidates setting to SmolLM3 and fixed a bug in the graph drawer

### DIFF
--- a/backends/qualcomm/debugger/utils.py
+++ b/backends/qualcomm/debugger/utils.py
@@ -183,11 +183,11 @@ class DrawGraph:
                 cleanup=not self.dot_string,
             )
             source_file = os.path.join(temp_directory, f"{self.filename}.svg")
-            destination_file = os.path.join(".", f"{self.filename}.svg")
+            destination_file = os.path.join(self.directory, f"{self.filename}.svg")
             shutil.move(source_file, destination_file)
             if self.dot_string:
                 dot_file = os.path.join(temp_directory, f"{self.filename}")
-                dot_dest_file = os.path.join(".", f"{self.filename}.dot")
+                dot_dest_file = os.path.join(self.directory, f"{self.filename}.dot")
                 shutil.move(dot_file, dot_dest_file)
 
 

--- a/examples/qualcomm/oss_scripts/llama/__init__.py
+++ b/examples/qualcomm/oss_scripts/llama/__init__.py
@@ -501,6 +501,7 @@ class Smollm3_3B(LLMModelConfig):
     ptq = QuantDtype.use_16a4w_block
     group_size = 32
     masked_softmax = True
+    seq_mse_candidates = 0
     r1 = False
     r2 = False
     r3 = False


### PR DESCRIPTION
Qualcomm AI Engine Direct - add seq_mse_candidates setting to SmolLM3 and fixed a bug in the graph drawer
### Summary
 - add seq_mse_candidates setting to SmolLM3
 - fixed a bug in the graph drawer

### Test plan
DrawGraph Unit test
``` bash
python -m backends.qualcomm.tests.test_qnn_delegate TestQNNFloatingPointUtils.test_qnn_backend_draw_graph -s ${SERIAL_NUM} -m ${SOC_MODEL}  -b build-android -a . --executorch_root .
python -m backends.qualcomm.tests.test_qnn_delegate TestQNNQuantizedUtils.test_qnn_backend_draw_graph -s ${SERIAL_NUM} -m ${SOC_MODEL}  -b build-android -a . --executorch_root .
```
SmolLM3
script in `./examples/qualcomm/oss_scripts/llama/README.md` at SmolLM3 part
