### PR TITLE
Add sleef dependency on windows builds

### DIFF
--- a/runtime/core/portable_type/c10/c10/targets.bzl
+++ b/runtime/core/portable_type/c10/c10/targets.bzl
@@ -46,7 +46,9 @@ def get_sleef_deps():
                 "fbsource//third-party/sleef:sleef",
             ],
         }),
-        "ovr_config//os:windows": [],
+        "ovr_config//os:windows": [
+                "fbsource//third-party/sleef:sleef",
+        ],
     })
 
 def define_common_targets():


### PR DESCRIPTION
Summary: Windows (msvc and clang) try to include sleef header but are not applying buck dependency on it

Differential Revision: D82406586


