### PR TITLE
Allow for matching debug handles with partial overlap between aten graph and runtime

### DIFF
--- a/devtools/inspector/tests/inspector_utils_test.py
+++ b/devtools/inspector/tests/inspector_utils_test.py
@@ -334,13 +334,15 @@ class TestInspectorUtils(unittest.TestCase):
         self.assertEqual(actual, expected)
 
     def test_map_runtime_aot_intermediate_outputs_partial_match(self):
-        # Partial match between aot and runtime debug_handles will return empty
+        # Partial match between aot and runtime debug_handles will return
+        # matching debug handles from runtime
         aot_intermediate_outputs = {(2,): 100, (9,): 300}
         runtime_intermediate_outputs = {(2, 3): (200, 1), (8, 9): (300, 1)}
         actual = map_runtime_aot_intermediate_outputs(
             aot_intermediate_outputs, runtime_intermediate_outputs
         )
-        expected = {}
+        # Since the runtime output debug handle of 9 is there in aot debug handle
+        expected = {((8, 9), 300): ((8, 9), 300)}
         self.assertEqual(actual, expected)
 
     def test_map_runtime_aot_intermediate_outputs_multiple_aot_to_one_runtime(self):


### PR DESCRIPTION
Summary:
When aten graph is modified for debug, for instance using int4 matmul, it wont have complete
overlap with debug handles recorded by the delegate. For example, original model will have
chose_qparams,q, dq, dq, linear nodes. Delegate will record debug hanlde for all of those.
Say those are (4, 5, 6, 7, 8). When int4 matmul rewrite pass, from torchao, is applied,
we just inherit from_node information from linear node. Thus only the last debug handle 8
is associated with custom op int4 node. Thus when we map delegate debug handles with custom op
we find overlap for 8 only.
This diff allows to look for overlapping match instead of exact match.
Plus it also changes the code for AOT debug handle so that we can look for all ancestor nodes
instead of just parent node. This is also needed so as to allow for numerical comparison despite
passes applied on original aten graph.

Reviewed By: Gasoonjia

Differential Revision: D82229367


