### PR TITLE
Revert "Add EXECUTORCH_THREADPOOL_SIZE options, default to u…

### DIFF
--- a/extension/threadpool/CMakeLists.txt
+++ b/extension/threadpool/CMakeLists.txt
@@ -20,16 +20,6 @@ if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)
 endif()
 
-# Threadpool size specifiers. Mutual exclusion is checking in default.cmake.
-# Default to using performance cores if
-# EXECUTORCH_THREADPOOL_USE_ALL_LOGICAL_CORES isn't set.
-set(_threadpool_size_flag)
-if(EXECUTORCH_THREADPOOL_USE_ALL_LOGICAL_CORES)
-  set(_threadpool_size_flag "EXECUTORCH_THREADPOOL_USE_ALL_LOGICAL_CORES")
-else()
-  set(_threadpool_size_flag "EXECUTORCH_THREADPOOL_USE_PERFORMANCE_CORES")
-endif()
-
 add_library(
   extension_threadpool threadpool.cpp threadpool_guard.cpp thread_parallel.cpp
                        cpuinfo_utils.cpp
@@ -46,9 +36,7 @@ target_include_directories(
     $<BUILD_INTERFACE:${EXECUTORCH_ROOT}/backends/xnnpack/third-party/cpuinfo/include>
     $<BUILD_INTERFACE:${EXECUTORCH_ROOT}/backends/xnnpack/third-party/pthreadpool/include>
 )
-target_compile_definitions(
-  extension_threadpool PUBLIC ET_USE_THREADPOOL ${_threadpool_size_flag}
-)
+target_compile_definitions(extension_threadpool PUBLIC ET_USE_THREADPOOL)
 target_compile_options(extension_threadpool PUBLIC ${_common_compile_options})
 
 # Install libraries

--- a/extension/threadpool/targets.bzl
+++ b/extension/threadpool/targets.bzl
@@ -22,7 +22,6 @@ def define_common_targets():
         name = "threadpool_lib",
         srcs = _THREADPOOL_SRCS,
         deps = [
-            ":cpuinfo_utils",
             "//executorch/runtime/core:core",
             "//executorch/runtime/core/portable_type/c10/c10:c10",
         ],

--- a/extension/threadpool/test/threadpool_test.cpp
+++ b/extension/threadpool/test/threadpool_test.cpp
@@ -7,7 +7,6 @@
  */
 
 #include <executorch/extension/threadpool/threadpool.h>
-#include <executorch/runtime/platform/runtime.h>
 
 #include <mutex>
 #include <numeric>
@@ -72,8 +71,6 @@ void run_lambda_with_size(
 } // namespace
 
 TEST(ThreadPoolTest, ParallelAdd) {
-  executorch::runtime::runtime_init();
-
   std::vector<int32_t> a, b, c, c_ref;
   size_t vector_size = 100;
   size_t grain_size = 10;
@@ -114,8 +111,6 @@ TEST(ThreadPoolTest, ParallelAdd) {
 
 // Test parallel reduction where we acquire lock within lambda
 TEST(ThreadPoolTest, ParallelReduce) {
-  executorch::runtime::runtime_init();
-
   std::vector<int32_t> a;
   int32_t c = 0, c_ref = 0;
   size_t vector_size = 100;
@@ -149,8 +144,6 @@ TEST(ThreadPoolTest, ParallelReduce) {
 // Copied from
 // caffe2/aten/src/ATen/test/test_thread_pool_guard.cp
 TEST(TestNoThreadPoolGuard, TestThreadPoolGuard) {
-  executorch::runtime::runtime_init();
-
   auto threadpool_ptr = ::executorch::extension::threadpool::get_pthreadpool();
 
   ASSERT_NE(threadpool_ptr, nullptr);
@@ -180,8 +173,6 @@ TEST(TestNoThreadPoolGuard, TestThreadPoolGuard) {
 }
 
 TEST(TestNoThreadPoolGuard, TestRunWithGuard) {
-  executorch::runtime::runtime_init();
-
   const std::vector<int64_t> array = {1, 2, 3};
 
   auto pool = ::executorch::extension::threadpool::get_threadpool();

--- a/extension/threadpool/threadpool.cpp
+++ b/extension/threadpool/threadpool.cpp
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <executorch/extension/threadpool/cpuinfo_utils.h>
 #include <executorch/extension/threadpool/threadpool.h>
 
 #include <algorithm>
@@ -15,25 +14,8 @@
 
 #include <executorch/extension/threadpool/threadpool_guard.h>
 #include <executorch/runtime/platform/assert.h>
-#include <executorch/runtime/platform/runtime.h>
 
 #include <cpuinfo.h>
-
-// At most one mode should be set.
-#if (                                                       \
-    defined(EXECUTORCH_THREADPOOL_USE_ALL_LOGICAL_CORES) && \
-    defined(EXECUTORCH_THREADPOOL_USE_PERFORMANCE_CORES))
-#error Multiple \
-            threadpool size specifiers are set.At most one of                \
-    EXECUTORCH_THREADPOOL_USE_ALL_LOGICAL_CORES,                             \
-    and EXECUTORCH_THREADPOOL_USE_PERFORMANCE_CORES may be defined.
-#endif
-
-// Default to EXECUTORCH_THREADPOOL_USE_ALL_LOGICAL_CORES if no mode is set.
-#if !defined(EXECUTORCH_THREADPOOL_USE_ALL_LOGICAL_CORES) && \
-    !defined(EXECUTORCH_THREADPOOL_USE_PERFORMANCE_CORES)
-#define EXECUTORCH_THREADPOOL_USE_ALL_LOGICAL_CORES 1
-#endif
 
 namespace executorch::extension::threadpool {
 
@@ -114,25 +96,12 @@ void ThreadPool::run(
 // get_threadpool is not thread safe due to leak_corrupted_threadpool
 // Make this part threadsafe: TODO(kimishpatel)
 ThreadPool* get_threadpool() {
-  executorch::runtime::runtime_init();
-
   if (!cpuinfo_initialize()) {
     ET_LOG(Error, "cpuinfo initialization failed");
     return nullptr; // NOLINT(facebook-hte-NullableReturn)
   }
 
-  // Choose the number of threads according to the EXECUTORCH_THREADPOOL_
-  // options. See the description in threadpool.h.
-
-#if defined(EXECUTORCH_THREADPOOL_USE_ALL_LOGICAL_CORES)
-  // Use threads=cores.
-  static int num_threads = cpuinfo_get_processors_count();
-#else
-  // Set threads equal to the number of performance cores.
-  static int num_threads =
-      ::executorch::extension::cpuinfo::get_num_performant_cores();
-#endif
-
+  int num_threads = cpuinfo_get_processors_count();
   /*
    * For llvm-tsan, holding limit for the number of locks for a single thread
    * is 63 (because of comparison < 64 instead of <=). pthreadpool's worst

--- a/extension/threadpool/threadpool.h
+++ b/extension/threadpool/threadpool.h
@@ -14,22 +14,6 @@
 
 #include <pthreadpool.h>
 
-/*
- * Threadpool Options:
- *
- * Threadpool size has a sizble affect on performance. By default, the
- * threadpool will be sized according to the number of performance cores. This
- * behavior can be overriden with the following build-time options. Note that
- * these options are mutually exclusive.
- *
- * - EXECUTORCH_THREADPOOL_USE_PERFORMANCE_CORES (flag) - Sizes the threadpool
- * equal to the number of performance cores on the system. This is the default
- * behavior.
- * - EXECUTORCH_THREADPOOL_USE_ALL_LOGICAL_CORES (flag) - Sizes the threadpool
- * equal to the number of logical cores on system. This is the historical
- * behavior.
- */
-
 namespace executorch::extension::threadpool {
 
 class ThreadPool final {

--- a/tools/cmake/preset/default.cmake
+++ b/tools/cmake/preset/default.cmake
@@ -176,36 +176,6 @@ define_overridable_option(
   ${_default_executorch_build_cpuinfo}
 )
 
-# Threadpool size options. At most one can be specified. Note that the default
-# is managed in threadpool.cpp to allow the user to specify an alternate mode
-# without needing to explicitly set the default to off.
-define_overridable_option(
-  EXECUTORCH_THREADPOOL_USE_PERFORMANCE_CORES
-  "Set the number of threads used for CPU parallel computation equal to the number of performant CPU cores."
-  BOOL
-  OFF
-)
-define_overridable_option(
-  EXECUTORCH_THREADPOOL_USE_ALL_LOGICAL_CORES
-  "Set the number of threads used for CPU parallel computation equal to the number of logical CPU cores."
-  BOOL
-  OFF
-)
-
-check_required_options_on(
-  IF_ON EXECUTORCH_THREADPOOL_USE_ALL_LOGICAL_CORES REQUIRES
-  EXECUTORCH_BUILD_PTHREADPOOL EXECUTORCH_BUILD_CPUINFO
-)
-check_required_options_on(
-  IF_ON EXECUTORCH_THREADPOOL_USE_PERFORMANCE_CORES REQUIRES
-  EXECUTORCH_BUILD_PTHREADPOOL EXECUTORCH_BUILD_CPUINFO
-)
-
-check_conflicting_options_on(
-  IF_ON EXECUTORCH_THREADPOOL_USE_PERFORMANCE_CORES CONFLICTS_WITH
-  EXECUTORCH_THREADPOOL_USE_ALL_LOGICAL_CORES
-)
-
 # TODO(jathu): move this to platform specific presets when created
 set(_default_executorch_build_executor_runner ON)
 if(APPLE AND "${SDK_NAME}" STREQUAL "iphoneos")


### PR DESCRIPTION
…sing only performance cores (#14090)"

This reverts commit 72d50b2fc0059ec2887915cec99a529ff24ef88f.

### Summary
Seeing crashes in macos unittest job.