### PR TITLE
Temporarily disable OpenVINO CI job

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -779,6 +779,7 @@ jobs:
       contents: read
     strategy:
       fail-fast: false
+    if: false # TODO Re-enable after fixing timeouts (#14314)
     with:
       runner: linux.2xlarge
       docker-image: ci-image:executorch-ubuntu-22.04-gcc9


### PR DESCRIPTION
Temporarily disable the OpenVINO CI job due to consistent timeouts. See https://github.com/pytorch/executorch/issues/14314 for the tracking task, which has more details. It is intended that this job is fixed and re-enabled quickly.