### PR TITLE
Add minimum_length to extended header for BC

### DIFF
--- a/schema/extended_header.h
+++ b/schema/extended_header.h
@@ -22,7 +22,8 @@ namespace runtime {
 struct ExtendedHeader {
   /**
    * To find the header, callers should provide at least this many bytes of the
-   * head of the serialized Program data.
+   * head of the serialized Program data. Keep this in sync with NUM_HEAD_BYTES
+   * in //executorch/exir/_serialize/program.py
    */
   static constexpr size_t kNumHeadBytes = 64;
 


### PR DESCRIPTION
Summary:
Error happening when we have older PTE files with extended header size 24. 

When we call 'from_bytes', we expect header size 32 after adding segment_data_size field. 

This is BC on C++ side because we have a minimum length.
Add minimum length to python to make the change BC.

Differential Revision: D82492169


