### PR TITLE
Arm backend: Convert remaining asserts to exceptions in tosa/

### DIFF
--- a/backends/arm/tosa/backend.py
+++ b/backends/arm/tosa/backend.py
@@ -104,10 +104,15 @@ class TOSABackend(BackendDetails):
         # const data directly. Path created and data written only in debug builds.
         tosa_graph = ts.TosaSerializer(artifact_path)
 
-        assert (
+        if not (
             tosa_spec.version.major == ts.TOSA_VERSION_MAJOR
             and tosa_spec.version.minor == ts.TOSA_VERSION_MINOR
-        ), f"TOSA serializer version ({ts.TOSA_VERSION_MAJOR}.{ts.TOSA_VERSION_MINOR}) doesn't match specification {tosa_spec}"
+        ):
+            raise RuntimeError(
+                f"TOSA serializer version "
+                f"({ts.TOSA_VERSION_MAJOR}.{ts.TOSA_VERSION_MINOR}) "
+                f"doesn't match specification {tosa_spec}"
+            )
 
         # TODO: Fix the need to lazily import this.
         from executorch.backends.arm._passes import ArmPassManager

--- a/backends/arm/tosa/mapping.py
+++ b/backends/arm/tosa/mapping.py
@@ -84,7 +84,8 @@ def extract_tensor_meta(meta, tosa_spec: TosaSpecification):
         ValueError: If ``meta['val']`` is not a ``FakeTensor``.
 
     """
-    assert meta.get("val") is not None
+    if meta.get("val") is None:
+        raise ValueError("Expected node.meta['val'] to be set to a FakeTensor")
     val = meta["val"]
     if type(val) is tuple:
         # TODO: should use first concrete representation

--- a/backends/arm/tosa/quant_utils.py
+++ b/backends/arm/tosa/quant_utils.py
@@ -245,7 +245,9 @@ def compute_multiplier_and_shift(
         const_2_power_15_or_31 = 1 << offset
         shifted_mantissa = round(mantissa * const_2_power_15_or_31)
 
-        assert shifted_mantissa <= const_2_power_15_or_31
+        assert (
+            shifted_mantissa <= const_2_power_15_or_31
+        ), f"Mantissa {shifted_mantissa} exceeds limit {const_2_power_15_or_31}"
 
         if shifted_mantissa == const_2_power_15_or_31:
             shifted_mantissa = shifted_mantissa // 2
@@ -255,7 +257,10 @@ def compute_multiplier_and_shift(
         shift = offset - shift
 
         # INT32_MAX, 2^31 - 1
-        assert shifted_mantissa <= (const_2_power_15_or_31 - 1)
+        assert shifted_mantissa <= (const_2_power_15_or_31 - 1), (
+            f"Mantissa {shifted_mantissa} exceeds signed max "
+            f"{const_2_power_15_or_31 - 1}"
+        )
 
         multiplier = shifted_mantissa
 


### PR DESCRIPTION
In `tosa/quant_utils.py`, add message to assert.
In `tosa/backend.py` and `tosa/mapping.py` convert asserts to exceptions.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218