### PR TITLE
NXP backend: Add infrastructure for context dependant partitioning

### DIFF
--- a/backends/nxp/backend/ir/converter/node_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converter.py
@@ -18,6 +18,7 @@ from executorch.backends.nxp.backend.ir.converter.builder.aten_model_builder_dir
 from executorch.backends.nxp.backend.ir.tflite_generator import tflite_model
 from executorch.exir.dialects._ops import ops as exir_ops
 from torch.fx import Node
+from torch.fx.passes.infra.partitioner import Partition
 from torch.nn import Parameter
 
 
@@ -124,6 +125,23 @@ class NodeConverter(ABC):
         ) and cls._is_supported_on_target(
             node, target, parameters_mapping, custom_delegation_options
         )
+
+    @classmethod
+    def supports_partitioning_result(
+        cls,
+        node: Node,
+        partition_list: list[Partition],
+        custom_delegation_options: CustomDelegationOptions,
+    ):
+        """Check if the given `node` supports the assigned partitioning, which is stored  the `partition_list`. Child
+            classes can overwrite this method in case they have delegation restrictions based on the context defined by
+            the partitioning result.
+
+        :param node: torch.Node to check.
+        :param partition_list: List of proposed partitions.
+        :param custom_delegation_options: Custom user options which affect node delegation.
+        """
+        return True
 
     @staticmethod
     def _has_shared_q_params_if_quantized(node: Node) -> bool:

--- a/backends/nxp/backend/ir/converter/node_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converter.py
@@ -38,6 +38,10 @@ def _is_dequant_node(node: torch.fx.Node) -> bool:
     ]
 
 
+def is_not_qdq_node(node: torch.fx.Node) -> bool:
+    return not (_is_quant_node(node) or _is_dequant_node(node))
+
+
 class Target(Enum):
     IGNORE = "ignore"  # No target platform. Any target specific restrictions will be ignored.
 

--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/view_copy_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/view_copy_converter.py
@@ -14,6 +14,7 @@ from executorch.backends.nxp.backend.ir.converter import quantization_utils
 from executorch.backends.nxp.backend.ir.converter.conversion.common import OpsList
 from executorch.backends.nxp.backend.ir.converter.node_converter import (
     CustomDelegationOptions,
+    is_not_qdq_node,
     NodeConverter,
 )
 from executorch.backends.nxp.backend.ir.converter.node_converters.shared.reshape_transposition import (
@@ -23,6 +24,7 @@ from executorch.backends.nxp.backend.ir.tflite_generator.builtin_options import 
     reshape_options,
 )
 from torch.fx import Node
+from torch.fx.passes.infra.partitioner import Partition
 from torch.nn import Parameter
 
 
@@ -41,6 +43,27 @@ class ViewCopyConverter(NodeConverter):
         flat_output_size = ViewCopyConverter._safe_compute_flat_size(list(y.size()))
 
         if tensor_rank(y) >= 8 or flat_input_size != flat_output_size:
+            return False
+
+        return True
+
+    @classmethod
+    def supports_partitioning_result(
+        cls,
+        node: Node,
+        partition_list: list[Partition],
+        custom_delegation_options: CustomDelegationOptions,
+    ):
+        view_copy_partitions = [
+            partition for partition in partition_list if node in partition.nodes
+        ]
+        assert len(view_copy_partitions) == 1
+        non_q_dq_partition_nodes = list(
+            filter(is_not_qdq_node, view_copy_partitions[0].nodes)
+        )
+
+        if len(non_q_dq_partition_nodes) == 1:
+            # The `view_copy` cannot be the only node in a partition.
             return False
 
         return True

--- a/backends/nxp/tests/test_context_sensitive_delegation.py
+++ b/backends/nxp/tests/test_context_sensitive_delegation.py
@@ -1,0 +1,71 @@
+# Copyright 2025 NXP
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import numpy as np
+import torch
+
+from executorch.backends.nxp.backend.ir.converter.node_converters.ops_converters import (
+    ViewCopyConverter,
+)
+from executorch.backends.nxp.tests.executorch_pipeline import to_quantized_edge_program
+from executorch.backends.nxp.tests.executors import graph_contains_any_of_ops
+from executorch.exir.dialects._ops import ops as exir_ops
+
+
+class SingleViewCopyModule(torch.nn.Module):
+    def __init__(self, new_shape: list[int]):
+        super().__init__()
+        self.new_shape = new_shape
+
+    def forward(self, x):
+        return torch.reshape(x, self.new_shape)
+
+
+class TestContextSensitiveDelegation(unittest.TestCase):
+    __test__ = False  # Prevent interfering with PyTest tests.
+
+    @classmethod
+    def setUpClass(cls):
+        torch.manual_seed(23)
+        np.random.seed(42)
+
+    def test_single_view_copy_partition(self):
+        input_shape = (2, 10)
+        module = SingleViewCopyModule([1, 20])
+
+        ep = to_quantized_edge_program(module, input_shape).exported_program()
+
+        # Make sure the `view_copy` was not delegated.
+        assert graph_contains_any_of_ops(
+            ep.graph, [exir_ops.edge.aten.view_copy.default]
+        )
+        assert not any("delegate" in n.name for n in ep.graph.nodes)
+
+    def test_single_view_copy_partition__forced_delegation(self):
+        input_shape = (2, 10)
+        module = SingleViewCopyModule([1, 20])
+
+        def _supported_partitioning(*_):
+            return True
+
+        # Replace the partition support check function, to accept anything.
+        original_supports_partitioning_result = (
+            ViewCopyConverter.supports_partitioning_result
+        )
+        ViewCopyConverter.supports_partitioning_result = _supported_partitioning
+
+        with self.assertRaises(RuntimeError) as e:
+            to_quantized_edge_program(module, input_shape).exported_program()
+        assert (
+            str(e.exception)
+            == "Model converted with neutron-converter does not contain a NeutronGraph node."
+        )
+
+        # Return to the original partition support check function.
+        ViewCopyConverter.supports_partitioning_result = (
+            original_supports_partitioning_result
+        )


### PR DESCRIPTION
### Summary
This PR adds the option to specify delegation conditions which depend on the partition a particular node ends up in. This infrastructure is applied to the `view_copy` node.

### Test plan
Unit tests provided.


cc @robert-kalmar @roman-janik-nxp @StrycekSimon @jirioc