### PR TITLE
buckification

### DIFF
--- a/exir/dialects/edge/_ops.py
+++ b/exir/dialects/edge/_ops.py
@@ -16,7 +16,6 @@ from executorch.exir.dialects.edge.dtype.supported import regular_tensor_str_to_
 from executorch.exir.dialects.edge.op.api import to_variant
 from executorch.exir.dialects.edge.spec.utils import get_tensor_variable_names
 
-# pyre-ignore
 from ruamel.yaml import YAML
 from torchgen.model import SchemaKind
 
@@ -166,7 +165,6 @@ class FunctionDtypeConstraint:
 
 
 def _load_edge_dialect_info() -> Dict[str, Dict[str, Any]]:
-    # pyre-ignore
     yaml = YAML(typ="safe")
     edge_yaml = resources.read_text(edge_package, "edge.yaml", encoding="utf-8")
     edge_dialect_yaml_info = yaml.load(edge_yaml)

--- a/exir/dialects/edge/spec/gen.py
+++ b/exir/dialects/edge/spec/gen.py
@@ -34,7 +34,6 @@ name_to_opinfo = {
     op.aten_name if op.aten_name is not None else op.name: op for op in op_db
 }
 
-# pyre-ignore
 yaml = ruamel.yaml.YAML()
 
 dtr = DtypeRunner()


### PR DESCRIPTION
Summary:
# Buckification Summary

Buckified `ruamel-yaml==0.18.15`. This diff is part of the stack to import `ruamel-yaml==0.18.15`.

Signals should be green prior to landing.
If anything looks wrong, please look into the BUCK file and fix.
If failed, please refer to the [Manual Buckification Wiki page](https://www.internalfb.com/wiki/Third-Party_%40_Meta/third-party/Using_mgt_to_Import_Third-Party_Code/Python_%28PyPI%29/Manual_Buckification_of_Packages/) to fix the BUCK file.

Differential Revision: D82025749


