### PR TITLE
[RELEASE ONLY CHANGES] Update torch pins to 2.9

### DIFF
--- a/.ci/docker/ci_commit_pins/pytorch.txt
+++ b/.ci/docker/ci_commit_pins/pytorch.txt
@@ -1,1 +1,1 @@
-4d4abec80f03cd8fdefe1d9cb3a60d3690cd777e
+release/2.9

--- a/.ci/docker/common/install_pytorch.sh
+++ b/.ci/docker/common/install_pytorch.sh
@@ -32,9 +32,9 @@ install_pytorch_and_domains() {
   pip_install "$(echo dist/*.whl)"
 
   # Grab the pinned audio and vision commits from PyTorch
-  TORCHAUDIO_VERSION=$(cat .github/ci_commit_pins/audio.txt)
+  TORCHAUDIO_VERSION=release/2.9
   export TORCHAUDIO_VERSION
-  TORCHVISION_VERSION=$(cat .github/ci_commit_pins/vision.txt)
+  TORCHVISION_VERSION=release/0.24
   export TORCHVISION_VERSION
 
   install_domains

--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [linux.2xlarge]
+        runner: [linux.4xlarge.memory]
         docker-image-name: [
           executorch-ubuntu-22.04-gcc9,
           executorch-ubuntu-22.04-clang12,

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -58,8 +58,8 @@ def python_is_compatible():
     return True
 
 
-# The pip repository that hosts nightly torch packages.
-TORCH_NIGHTLY_URL = "https://download.pytorch.org/whl/nightly/cpu"
+# The pip repository that hosts torch packages.
+TORCH_URL = "https://download.pytorch.org/whl/test/cpu"
 
 
 # Since ExecuTorch often uses main-branch features of pytorch, only the nightly
@@ -89,7 +89,7 @@ def install_requirements(use_pytorch_nightly):
         # Setting use_pytorch_nightly to false to test the pinned PyTorch commit. Note
         # that we don't need to set any version number there because they have already
         # been installed on CI before this step, so pip won't reinstall them
-        f"torch==2.9.0.{NIGHTLY_VERSION}" if use_pytorch_nightly else "torch",
+        "torch==2.9.0" if use_pytorch_nightly else "torch",
     ]
 
     # Install the requirements for core ExecuTorch package.
@@ -105,7 +105,7 @@ def install_requirements(use_pytorch_nightly):
             "requirements-dev.txt",
             *TORCH_PACKAGE,
             "--extra-index-url",
-            TORCH_NIGHTLY_URL,
+            TORCH_URL,
         ],
         check=True,
     )
@@ -149,12 +149,8 @@ def install_requirements(use_pytorch_nightly):
 def install_optional_example_requirements(use_pytorch_nightly):
     print("Installing torch domain libraries")
     DOMAIN_LIBRARIES = [
-        (
-            f"torchvision==0.24.0.{NIGHTLY_VERSION}"
-            if use_pytorch_nightly
-            else "torchvision"
-        ),
-        f"torchaudio==2.8.0.{NIGHTLY_VERSION}" if use_pytorch_nightly else "torchaudio",
+        ("torchvision==0.24.0" if use_pytorch_nightly else "torchvision"),
+        "torchaudio==2.9.0" if use_pytorch_nightly else "torchaudio",
     ]
     # Then install domain libraries
     subprocess.run(
@@ -165,7 +161,7 @@ def install_optional_example_requirements(use_pytorch_nightly):
             "install",
             *DOMAIN_LIBRARIES,
             "--extra-index-url",
-            TORCH_NIGHTLY_URL,
+            TORCH_URL,
         ],
         check=True,
     )
@@ -180,7 +176,7 @@ def install_optional_example_requirements(use_pytorch_nightly):
             "-r",
             "requirements-examples.txt",
             "--extra-index-url",
-            TORCH_NIGHTLY_URL,
+            TORCH_URL,
             "--upgrade-strategy",
             "only-if-needed",
         ],


### PR DESCRIPTION
### Summary
As described in the release manual, update torch pins to 2.9.0 for pytorch and torchaudio, 0.24.0 for torchvision. I've followed the same pattern as https://github.com/pytorch/executorch/pull/12137 (0.7 changes).