### PR TITLE
Fix regnet on XNNPACK

### DIFF
--- a/backends/xnnpack/_passes/fuse_batch_norm.py
+++ b/backends/xnnpack/_passes/fuse_batch_norm.py
@@ -18,6 +18,7 @@ from executorch.backends.xnnpack.utils.utils import (
     get_param_tensor,
     get_tensor_name,
     is_param_node,
+    sanitize_node_name,
 )
 from executorch.exir import ExportedProgram
 from executorch.exir.dialects._ops import ops as exir_ops
@@ -208,13 +209,13 @@ class FuseBatchNormPass(XNNPACKPass):
             # Otherwise, this is a linear node.
             fused_weight, fused_bias = fuse_linear_bn_weights(*fuse_args)
 
-        fused_weight_name = (input_node_weight_name + "_fused_bn").replace(".", "_")
+        fused_weight_name = sanitize_node_name(input_node_weight_name + "_fused_bn")
         if input_node_bias_name == "":
-            fused_bias_name = (input_node_weight_name + "_bias_fused_bn").replace(
-                ".", "_"
+            fused_bias_name = sanitize_node_name(
+                input_node_weight_name + "_bias_fused_bn"
             )
         else:
-            fused_bias_name = (input_node_bias_name + "_fused_bn").replace(".", "_")
+            fused_bias_name = sanitize_node_name(input_node_bias_name + "_fused_bn")
 
         # Modify the graph by updating the weight and bias of the conv or linear op
         # with the fused weight and bias params, and replacing all the users

--- a/backends/xnnpack/test/models/regnet.py
+++ b/backends/xnnpack/test/models/regnet.py
@@ -1,0 +1,29 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+import torchvision
+from executorch.backends.xnnpack.test.tester import Tester
+
+
+class TestInceptionV4(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
+    regnet = torchvision.models.regnet_y_32gf()
+    model_inputs = (torch.randn(3, 299, 299).unsqueeze(0),)
+
+    def test_fp32_regnet(self):
+        (
+            Tester(self.regnet, self.model_inputs)
+            .export()
+            .to_edge_transform_and_lower()
+            .to_executorch()
+            .serialize()
+            .run_method_and_compare_outputs()
+        )

--- a/backends/xnnpack/utils/utils.py
+++ b/backends/xnnpack/utils/utils.py
@@ -219,3 +219,15 @@ def is_depthwise_conv(
     return (
         group_input_channels == 1 and group_output_channels % group_input_channels == 0
     )
+
+
+def sanitize_node_name(name: str) -> str:
+    """
+    Modify a (generated) node name to replace invalid characters (. and -) with underscores.
+    """
+    INVALID_CHARS = [".", "-"]
+
+    sanitized = name
+    for c in INVALID_CHARS:
+        sanitized = sanitized.replace(c, "_")
+    return sanitized


### PR DESCRIPTION
### Summary
The regnet_y_32gf model from torchvision does not lower on XNNPACK. This is because a "-" in a generated weight name (from conv + bn fusion) causes things to blow up. I've updated the fusion logic to properly sanitize the generated weight name and added a test for regnet to validate the fix.

Here's the part of the eager mode model responsible for this:
```
(trunk_output): Sequential(
    (block1): AnyStage(
      (block1-0): ResBottleneckBlock(
        (proj): Conv2dNormActivation(
          (0): Conv2d(32, 232, kernel_size=(1, 1), stride=(2, 2), bias=False)
          (1): BatchNorm2d(232, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
        )
```

cc @digantdesai @mcr229 @cbilgin