### PR TITLE
getMethodMetadata should contain used backend name

### DIFF
--- a/extension/android/executorch_android/src/androidTest/java/org/pytorch/executorch/ModuleE2ETest.kt
+++ b/extension/android/executorch_android/src/androidTest/java/org/pytorch/executorch/ModuleE2ETest.kt
@@ -18,11 +18,13 @@ import java.io.IOException
 import java.net.URISyntaxException
 import org.apache.commons.io.FileUtils
 import org.junit.Assert
+import org.junit.Assert.assertArrayEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.pytorch.executorch.TensorImageUtils.bitmapToFloat32Tensor
 import org.pytorch.executorch.TestFileUtils.getTestFilePath
+import org.junit.Assert.assertEquals
 
 /** Unit tests for [Module]. */
 @RunWith(AndroidJUnit4::class)
@@ -70,6 +72,7 @@ class ModuleE2ETest {
 
         val module = Module.load(getTestFilePath("/mv3_xnnpack_fp32.pte"))
         val expectedBackends = arrayOf("XnnpackBackend")
+        assertArrayEquals(expectedBackends, module.getMethodMetadata("forward").backends)
     }
 
     @Test

--- a/extension/android/executorch_android/src/androidTest/java/org/pytorch/executorch/ModuleE2ETest.kt
+++ b/extension/android/executorch_android/src/androidTest/java/org/pytorch/executorch/ModuleE2ETest.kt
@@ -10,7 +10,6 @@ package org.pytorch.executorch
 import android.Manifest
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
-import androidx.test.InstrumentationRegistry
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.GrantPermissionRule
 import java.io.File
@@ -24,7 +23,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.pytorch.executorch.TensorImageUtils.bitmapToFloat32Tensor
 import org.pytorch.executorch.TestFileUtils.getTestFilePath
-import org.junit.Assert.assertEquals
 
 /** Unit tests for [Module]. */
 @RunWith(AndroidJUnit4::class)

--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/Module.java
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/Module.java
@@ -203,7 +203,13 @@ public class Module {
     if (!mMethodMetadata.containsKey(name)) {
       throw new RuntimeException("method " + name + "does not exist for this module");
     }
-    return mMethodMetadata.get(name);
+
+    MethodMetadata methodMetadata =mMethodMetadata.get(name);
+    if (methodMetadata != null) {
+      methodMetadata.setBackends(getUsedBackends(name));
+
+    }
+    return methodMetadata;
   }
 
   /** Retrieve the in-memory log buffer, containing the most recent ExecuTorch log entries. */


### PR DESCRIPTION
### Summary
This change added the metadata for used backend name for API getMethodMetadata()

### Test plan
Run E2E test locally