### PR TITLE
Extend data file support for other pybindings

### DIFF
--- a/extension/pybindings/pybindings.pyi
+++ b/extension/pybindings/pybindings.pyi
@@ -185,6 +185,7 @@ def _load_for_executorch(
 @experimental("This API is experimental and subject to change without notice.")
 def _load_for_executorch_from_buffer(
     buffer: bytes,
+    data_map_buffer: Optional[bytes] = None,
     enable_etdump: bool = False,
     debug_buffer_size: int = 0,
     program_verification: Verification = Verification.InternalConsistency,
@@ -199,7 +200,10 @@ def _load_for_executorch_from_buffer(
 
 @experimental("This API is experimental and subject to change without notice.")
 def _load_for_executorch_from_bundled_program(
-    module: BundledModule, enable_etdump: bool = False, debug_buffer_size: int = 0
+    module: BundledModule,
+    data_map_buffer: Optional[bytes] = None,
+    enable_etdump: bool = False,
+    debug_buffer_size: int = 0,
 ) -> ExecuTorchModule:
     """Same as _load_for_executorch, but takes a bundled program instead of a file path.
 

--- a/extension/pybindings/test/TARGETS
+++ b/extension/pybindings/test/TARGETS
@@ -17,6 +17,9 @@ runtime.python_library(
     deps = [
         "//caffe2:torch",
         "//caffe2:torch_fx",
+        "//executorch/devtools/bundled_program:config",
+        "//executorch/devtools/bundled_program:core",
+        "//executorch/devtools/bundled_program/serialize:lib",
         "//executorch/exir:lib",
         "//executorch/exir:pass_manager",
         "//executorch/exir:scalar_type",

--- a/extension/pybindings/test/test_pybindings.py
+++ b/extension/pybindings/test/test_pybindings.py
@@ -635,6 +635,9 @@ class PybindingsTest(unittest.TestCase):
                 external_constants=True,
             )
         )
+        program_buffer = exec_program.buffer
+        assert len(exec_program._tensor_data) == 1
+        data_buffer = bytes(exec_program._tensor_data.pop("_default_external_constant"))
 
         import os
         import tempfile
@@ -642,17 +645,74 @@ class PybindingsTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             pte_file = os.path.join(tmpdir, "linear.pte")
             with open(pte_file, "wb") as f:
-                f.write(exec_program.buffer)
-
+                f.write(program_buffer)
             ptd_file = os.path.join(tmpdir, "linear.ptd")
             with open(ptd_file, "wb") as ptd:
-                tensor_data = bytes(
-                    exec_program._tensor_data.pop("_default_external_constant")
-                )
-                ptd.write(tensor_data)
-
-            executorch_program = self.runtime._load_for_executorch(pte_file, ptd_file)
-
+                ptd.write(data_buffer)
             expected = eager_module(inputs[0])
-            executorch_output = executorch_program.forward(inputs)[0]
-            self.assertTrue(torch.allclose(expected, executorch_output))
+            # Test 1: File-based loading with external data file
+            executorch_module_file = self.runtime._load_for_executorch(
+                pte_file, ptd_file
+            )
+            executorch_output_file = executorch_module_file.forward(inputs)[0]
+            self.assertTrue(torch.allclose(expected, executorch_output_file))
+
+        # Test 2: Buffer-based loading with external data buffer
+        executorch_module_buffer = self.load_fn(program_buffer, data_buffer)
+        executorch_output_buffer = executorch_module_buffer.forward(inputs)[0]
+        self.assertTrue(torch.allclose(expected, executorch_output_buffer))
+
+        # Test 3: Buffer-based loading without external data file (should fail or work differently)
+        # This should fail because the program expects external data
+        executorch_module_no_data = self.load_fn(program_buffer)
+        with self.assertRaises(RuntimeError):
+            executorch_module_no_data.forward(inputs)
+
+        # Test 4: Test with invalid data buffer (should fail)
+        invalid_bytes = b"invalid bytes"
+        executorch_module_invalid_data = self.load_fn(program_buffer, invalid_bytes)
+        with self.assertRaises(RuntimeError):
+            executorch_module_invalid_data.forward(inputs)
+
+        # Test 5: Test bundled program loading with external data
+        # First create a bundled program with external constants
+        from executorch.devtools.bundled_program.config import (
+            MethodTestCase,
+            MethodTestSuite,
+        )
+        from executorch.devtools.bundled_program.core import BundledProgram
+        from executorch.devtools.bundled_program.serialize import (
+            serialize_from_bundled_program_to_flatbuffer,
+        )
+
+        method_test_suites = [
+            MethodTestSuite(
+                method_name="forward",
+                test_cases=[
+                    MethodTestCase(
+                        inputs=input,
+                        expected_outputs=expected,
+                    )
+                    for input in inputs
+                ],
+            ),
+        ]
+        bundled_program = BundledProgram(exec_program, method_test_suites)
+        bundled_buffer = serialize_from_bundled_program_to_flatbuffer(bundled_program)
+        bundled_module = self.runtime._load_bundled_program_from_buffer(bundled_buffer)
+
+        # Load module from bundled program with external data
+        executorch_module_bundled = (
+            self.runtime._load_for_executorch_from_bundled_program(
+                bundled_module, data_buffer
+            )
+        )
+        executorch_output_bundled = executorch_module_bundled.forward(inputs)[0]
+        self.assertTrue(torch.allclose(expected, executorch_output_bundled))
+
+        # Test 6: Bundled program without external data should fail
+        executorch_module_bundled_no_data = (
+            self.runtime._load_for_executorch_from_bundled_program(bundled_module)
+        )
+        with self.assertRaises(RuntimeError):
+            executorch_module_bundled_no_data.forward(inputs)


### PR DESCRIPTION
Summary: This diff extends the support for external data_file to other executorch runtime pybindings.

Reviewed By: LeeOHzzZ

Differential Revision: D82046648


