### PR TITLE
Use fbjni 0.7.0 and set ANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON

### DIFF
--- a/docs/source/using-executorch-android.md
+++ b/docs/source/using-executorch-android.md
@@ -83,7 +83,7 @@ To add the AAR file to your app:
 An AAR file itself does not contain dependency info, unlike the Maven one which bundled with pom.xml. The Java package requires `fbjni` and `soloader`, and currently requires users to explicitly declare the dependency. Therefore, two more `dependencies` in gradle rule is required:
 ```
 implementation("com.facebook.soloader:soloader:0.10.5")
-implementation("com.facebook.fbjni:fbjni:0.5.1")
+implementation("com.facebook.fbjni:fbjni:0.7.0")
 ```
 
 ### Example usage
@@ -100,7 +100,7 @@ And include it in gradle:
 dependencies {
     implementation(files("libs/executorch.aar"))
     implementation("com.facebook.soloader:soloader:0.10.5")
-    implementation("com.facebook.fbjni:fbjni:0.5.1")
+    implementation("com.facebook.fbjni:fbjni:0.7.0")
 }
 ```
 

--- a/examples/demo-apps/android/LlamaDemo/app/build.gradle.kts
+++ b/examples/demo-apps/android/LlamaDemo/app/build.gradle.kts
@@ -57,7 +57,7 @@ dependencies {
   implementation("androidx.appcompat:appcompat:1.6.1")
   implementation("androidx.camera:camera-core:1.3.0-rc02")
   implementation("androidx.constraintlayout:constraintlayout:2.2.0-alpha12")
-  implementation("com.facebook.fbjni:fbjni:0.5.1")
+  implementation("com.facebook.fbjni:fbjni:0.7.0")
   implementation("com.google.code.gson:gson:2.8.6")
   implementation(files("libs/executorch.aar"))
   implementation("com.google.android.material:material:1.12.0")

--- a/extension/android/CMakeLists.txt
+++ b/extension/android/CMakeLists.txt
@@ -30,7 +30,7 @@ endif()
 # libc++ dependencies are consistent. WARNING # Users need to use the SAME fbjni
 # version here and in app gradle dependency for runtime compatibility!
 if(NOT FBJNI_VERSION)
-  set(FBJNI_VERSION 0.5.1)
+  set(FBJNI_VERSION 0.7.0)
 endif()
 
 set(FBJNI_AAR_URL

--- a/extension/android/build.gradle
+++ b/extension/android/build.gradle
@@ -6,7 +6,7 @@ allprojects {
             compileSdkVersion = 34
             buildToolsVersion = '33.0.1'
 
-            fbjniJavaOnlyVersion = "0.5.1"
+            fbjniJavaOnlyVersion = "0.7.0"
             soLoaderNativeLoaderVersion = "0.10.5"
         }
 

--- a/extension/android/executorch_android/build.gradle
+++ b/extension/android/executorch_android/build.gradle
@@ -49,7 +49,7 @@ task copyTestRes(type: Exec) {
 }
 
 dependencies {
-    implementation 'com.facebook.fbjni:fbjni:0.5.1'
+    implementation 'com.facebook.fbjni:fbjni:0.7.0'
     implementation 'com.facebook.soloader:nativeloader:0.10.5'
     implementation libs.core.ktx
     testImplementation 'junit:junit:4.12'

--- a/extension/benchmark/android/benchmark/app/build.gradle.kts
+++ b/extension/benchmark/android/benchmark/app/build.gradle.kts
@@ -42,7 +42,7 @@ android {
 dependencies {
   implementation(files("libs/executorch.aar"))
   implementation("com.facebook.soloader:soloader:0.10.5")
-  implementation("com.facebook.fbjni:fbjni:0.5.1")
+  implementation("com.facebook.fbjni:fbjni:0.7.0")
   implementation("com.google.code.gson:gson:2.8.6")
   implementation("org.json:json:20250107")
   implementation("androidx.core:core-ktx:1.13.1")

--- a/scripts/build_android_library.sh
+++ b/scripts/build_android_library.sh
@@ -36,6 +36,7 @@ build_android_native_library() {
 
   cmake . -DCMAKE_INSTALL_PREFIX="${CMAKE_OUT}" \
     -DCMAKE_TOOLCHAIN_FILE="${ANDROID_NDK}/build/cmake/android.toolchain.cmake" \
+    -DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON \
     --preset "android-${ANDROID_ABI}" \
     -DANDROID_PLATFORM=android-26 \
     -DEXECUTORCH_ENABLE_EVENT_TRACER="${EXECUTORCH_ANDROID_PROFILING:-OFF}" \


### PR DESCRIPTION
### Summary

Partial fix for https://github.com/pytorch/executorch/issues/11597

We can upgrade to NDK 28 when fbjni upgrades.

### Test plan
CI