### PR TITLE
Removing spamming log

### DIFF
--- a/extension/llm/runner/util.h
+++ b/extension/llm/runner/util.h
@@ -121,10 +121,6 @@ inline runtime::Result<TensorPtr> populate_start_pos_or_cache_position(
   auto second_input_sizes = second_input_info.sizes();
   auto numel = second_input_sizes[0];
 
-  for (int i = 0; i < second_input_sizes.size(); ++i) {
-    ET_LOG(Error, "second_input_sizes[%d] = %d", i, second_input_sizes[i]);
-  }
-
   TensorPtr start_pos_tensor;
   if (numel > 1) {
     // `cache_position` goes from start_pos to start_pos +


### PR DESCRIPTION
As title, otherwise output like 
```
E 00:00:03.830554 executorch:util.h:125] second_input_sizes[0] = 1
 thereE 00:00:03.883490 executorch:util.h:125] second_input_sizes[0] = 1
 isE 00:00:03.929477 executorch:util.h:125] second_input_sizes[0] = 1
 noE 00:00:03.983967 executorch:util.h:125] second_input_sizes[0] = 1
 ultimateE 00:00:04.033875 executorch:util.h:125] second_input_sizes[0] = 1
 questionE 00:00:04.088452 executorch:util.h:125] second_input_sizes[0] = 1
.E 00:00:04.139406 executorch:util.h:125] second_input_sizes[0] = 1
 ItE 00:00:04.191997 executorch:util.h:125] second_input_sizes[0] = 1
 isE 00:00:04.241043 executorch:util.h:125] second_input_sizes[0] = 1
 aE 00:00:04.289894 executorch:util.h:125] second_input_sizes[0] = 1
 questionE 00:00:04.341772 executorch:util.h:125] second_input_sizes[0] = 1
 thatE 00:00:04.399873 executorch:util.h:125] second_input_sizes[0] = 1
 hasE 00:00:04.455845 executorch:util.h:125] second_input_sizes[0] = 1
 noE 00:00:04.509937 executorch:util.h:125] second_input_sizes[0] = 1
 questionE 00:00:04.555430 executorch:util.h:125] second_input_sizes[0] = 1
```

### Summary
[PLEASE REMOVE] See [CONTRIBUTING.md's Pull Requests](https://github.com/pytorch/executorch/blob/main/CONTRIBUTING.md#pull-requests) for ExecuTorch PR guidelines.

[PLEASE REMOVE] If this PR closes an issue, please add a `Fixes #<issue-id>` line.

[PLEASE REMOVE] If this PR introduces a fix or feature that should be the upcoming release notes, please add a "Release notes: <area>" label. For a list of available release notes labels, check out [CONTRIBUTING.md's Pull Requests](https://github.com/pytorch/executorch/blob/main/CONTRIBUTING.md#pull-requests).

### Test plan
[PLEASE REMOVE] How did you test this PR? Please write down any manual commands you used and note down tests that you have written if applicable.
