### PR TITLE
[1.0 Release] Add 1.0 doc link

### DIFF
--- a/versions.html
+++ b/versions.html
@@ -20,6 +20,9 @@
           <a class="reference internal" href="main/">main (unstable)</a>
         </li>
         <li class="toctree-l1">
+          <a class="reference internal" href="1.0">1.0 (release candidate)</a>
+        </li>
+        <li class="toctree-l1">
           <a class="reference internal" href="0.7">0.7 (stable release)</a>
         </li>
         <li class="toctree-l1">


### PR DESCRIPTION
### Summary
Add a dropdown entry / link for 1.0. Mark as a release candidate. I verified that 1.0 docs are live at https://docs.pytorch.org/executorch/1.0/index.html.