### PR TITLE
［Do not merge] block quant observer for embedding QAT draft

### DIFF
--- a/backends/qualcomm/quantizer/observers/per_block_param_observer.py
+++ b/backends/qualcomm/quantizer/observers/per_block_param_observer.py
@@ -7,12 +7,19 @@
 from typing import Tuple
 
 import torch
-from torchao.quantization.pt2e import MappingType, PerBlock
+from torchao.quantization.pt2e import (
+    FakeQuantize,
+    MappingType,
+    PerBlock,
+)
 from torchao.quantization.pt2e._affine_quantization import (
     _get_reduction_params,
     AffineQuantizedMinMaxObserver,
     choose_qparams_affine_with_min_max,
+    dequantize_affine,
+    quantize_affine,
 )
+from torch.fx import Node
 
 
 class PerBlockParamObserver(AffineQuantizedMinMaxObserver):
@@ -23,6 +30,7 @@ class PerBlockParamObserver(AffineQuantizedMinMaxObserver):
         quant_min=None,
         quant_max=None,
         eps=torch.finfo(torch.float32).eps,  # noqa: B008
+        is_dynamic=False,
         **kwargs,
     ):
         super().__init__(
@@ -40,11 +48,12 @@ class PerBlockParamObserver(AffineQuantizedMinMaxObserver):
         self.bitwidth_of_scale = 4
         self.num_steps = 2**self.bitwidth_of_scale
         self.calibrated = False
-
+        
+        self.qscheme = torch.per_channel_symmetric
+        self.is_dynamic = is_dynamic
     def forward(self, input: torch.Tensor):
         if input.numel() == 0 or self.calibrated:
             return input
-
         input_detached = input.detach()
         self.original_dtype = input_detached.dtype
         shape_for_reduction, reduction_dims = _get_reduction_params(
@@ -89,3 +98,65 @@ class PerBlockParamObserver(AffineQuantizedMinMaxObserver):
             self.preserve_zero,
             self.zero_point_domain,
         )
+
+
+class PerBlockFakeQuantizeObserver(FakeQuantize):
+    def __init__(
+        self,
+        observer=PerBlockParamObserver,
+        quant_min=None,
+        quant_max=None,
+        eps=torch.finfo(torch.float32).eps,  # noqa: B008
+        **kwargs,
+    ):
+        super().__init__(observer, quant_min, quant_max, **kwargs)
+        self.dtype = self.activation_post_process.dtype
+        self.quant_min = quant_min
+        self.quant_max = quant_max
+        self.eps = eps
+        self.block_size = self.activation_post_process.block_size
+
+        self.register_buffer("scale", torch.tensor([], dtype=torch.float32), persistent=True)
+        self.register_buffer("zero_point", torch.tensor([], dtype=torch.int32), persistent=True)
+
+    def forward(self, x):
+        if self.observer_enabled[0] == 1:
+            self.activation_post_process(x)
+            scale, zero_point = self.calculate_qparams()
+            
+            if self.scale.numel() == 0 or self.scale.shape != scale.shape:
+                self.scale.resize_(scale.shape)
+            self.scale.copy_(scale.detach())
+                
+            if self.zero_point.numel() == 0 or self.zero_point.shape != zero_point.shape:
+                self.zero_point.resize_(zero_point.shape)
+            self.zero_point.copy_(zero_point.detach())
+
+        if self.fake_quant_enabled[0] == 1:
+            # Fake quantize per block
+            x = quantize_affine(
+                x,
+                self.activation_post_process.block_size,
+                self.scale,
+                self.zero_point,
+                self.activation_post_process.dtype,
+                self.activation_post_process.quant_min,
+                self.activation_post_process.quant_max,
+            )
+            x = dequantize_affine(
+                x,
+                self.activation_post_process.block_size,
+                self.scale,
+                self.zero_point,
+                self.activation_post_process.dtype,
+                self.activation_post_process.quant_min,
+                self.activation_post_process.quant_max,
+            )
+        return x
+
+    def calculate_qparams(self):
+        return self.activation_post_process.calculate_qparams()
+    
+    def convert(self, model: torch.fx.GraphModule, observer_node: Node):
+        self.activation_post_process.convert(model, observer_node)
+        return 

--- a/backends/qualcomm/quantizer/quantizer.py
+++ b/backends/qualcomm/quantizer/quantizer.py
@@ -29,6 +29,7 @@ from .qconfig import (
     get_ptq_per_block_quant_config,
     get_ptq_per_channel_quant_config,
     get_qat_per_channel_quant_config,
+    get_qat_per_block_quant_config,
     QuantizationConfig,
 )
 
@@ -46,6 +47,7 @@ __all__ = [
     "get_8a8w_qnn_qat_config",
     "get_16a4w_qnn_qat_config",
     "get_ptq_per_block_quant_config",
+    "get_qat_per_block_quant_config"
 ]
 
 
@@ -60,6 +62,7 @@ class QuantDtype(IntEnum):
     use_16a4w = 2
     use_16a4w_block = 3
     use_8a8w = 4
+    use_16a4w_block_qat = 5
 
 
 QUANT_CONFIG_DICT = {
@@ -110,6 +113,19 @@ QUANT_CONFIG_DICT = {
         None,
     ),
     # QAT,
+    (QuantDtype.use_16a4w_block_qat, False): (
+        get_16a4w_qnn_qat_config,
+        partial(
+            get_qat_per_channel_quant_config,
+            act_dtype=torch.uint16,
+            weight_dtype=torch.int4,
+        ),
+        partial(
+            get_qat_per_block_quant_config,
+            act_dtype=torch.uint16,
+            weight_dtype=torch.int4,
+        ),
+    ),
     (QuantDtype.use_16a4w, True): (
         get_16a4w_qnn_qat_config,
         partial(

--- a/examples/qualcomm/oss_scripts/llama/__init__.py
+++ b/examples/qualcomm/oss_scripts/llama/__init__.py
@@ -193,8 +193,8 @@ class LlamaStories260K(LLMModelConfig):
 
     num_sharding = 1
     # quant config
-    ptq = QuantDtype.use_16a4w
-    group_size = None
+    ptq = QuantDtype.use_16a4w_block_qat
+    group_size = 32
     masked_softmax = False
     seq_mse_candidates = 0
     r1 = False


### PR DESCRIPTION
per-block observer for embedding quantization in QAT

script 
``` bash
# tokenizer.model & stories260K.pt:
wget "https://huggingface.co/karpathy/tinyllamas/resolve/main/stories260K/stories260K.pt"
wget -O tokenizer.model "https://huggingface.co/karpathy/tinyllamas/resolve/main/stories260K/tok512.model"

# tokenizer.bin:
python -m pytorch_tokenizers.tools.llama2c.convert -t tokenizer.model -o tokenizer.bin

# params.json: (only use 1 layer for demo)
echo '{"dim": 64, "n_layers": 1, "n_heads": 8, "n_kv_heads": 4, "vocab_size": 512, "multiple_of": 4, "max_seq_len": 512}' > params.json

# Run script
python -m examples.qualcomm.oss_scripts.llama.llama -b build-android -m ${soc} -s ${device_id} --prompt "Once upon a time" --decoder_model stories260k --model_mode ${model_mode} --max_seq_len 1024 art . --checkpoint stories260K.pt --params params.json --tokenizer_bin tokenizer.bin --tokenizer_model tokenizer.model
```

<img width="1975" height="1237" alt="image" src="https://github.com/user-attachments/assets/88668519-b00c-44ee-b9b0-82cd0fb27227" />

