### PR TITLE
Summary: MCU Tests:  Add two basic qadd , qlinear qdq tests

### DIFF
--- a/examples/arm/aot_arm_compiler.py
+++ b/examples/arm/aot_arm_compiler.py
@@ -297,6 +297,19 @@ class MultipleOutputsModule(torch.nn.Module):
     can_delegate = True
 
 
+class QuantLinearTest(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        # Define a simple linear layer
+        self.linear = torch.nn.Linear(61, 37)
+
+    def forward(self, x):
+        return self.linear(x)
+
+    example_input = (torch.randn([8, 61], dtype=torch.float32),)
+    can_delegate = True
+
+
 models = {
     "add": AddModule,
     "add2": AddModule2,
@@ -306,6 +319,9 @@ models = {
     "qops": QuantOpTest,
     "softmax": SoftmaxModule,
     "MultipleOutputsModule": MultipleOutputsModule,
+    # TODO: Remove this from here, once we have dedicated MCU test pipeline ready. This is an interim solution.
+    # See https://github.com/pytorch/executorch/discussions/13944
+    "qlinear": QuantLinearTest,
 }
 
 calibration_data = {
@@ -330,6 +346,7 @@ calibration_data = {
         torch.randn(32, 2, 1) * 1000,
     ),
     "softmax": (torch.randn(32, 2, 2),),
+    "qlinear": (torch.randn(37, 61),),
 }
 
 evaluators = {

--- a/examples/arm/run_mcu_models_fvp.sh
+++ b/examples/arm/run_mcu_models_fvp.sh
@@ -24,9 +24,9 @@ VALID_TARGETS=(
 )
 
 # Default models for MCU validation with portable kernels
-DEFAULT_MODELS=(mv2 mv3 lstm)
+DEFAULT_MODELS=(mv2 mv3 lstm qadd qlinear)
 # Available models (on FVP)
-AVAILABLE_MODELS=(mv2 mv3 lstm)
+AVAILABLE_MODELS=(mv2 mv3 lstm qadd qlinear)
 # Add the following models if you want to enable them later (atm they are not working on FVP)
 # edsr w2l ic3 ic4 resnet18 resnet50
 
@@ -257,6 +257,7 @@ for model in "${MODELS[@]}"; do
         -m "$model" \
         --target="$ETHOS_TARGET" \
         --quantize \
+        --enable_qdq_fusion_pass \
         --output="arm_test/$model"; then
         echo "❌ AOT compilation failed for $model"
         MODEL_SUCCESS=false


### PR DESCRIPTION
- Enable on CI for consistent signals
- Note that this is interim solution until a proper MCU testing standalone pipeline is ready

Test Plan:
- examples/arm/run_mcu_models_fvp.sh --target=cortex-m55 --models=qadd,qlinear ════════════════════════════════════════════════════════════════ 🏁 MCU MODEL VALIDATION SUMMARY - TARGET: cortex-m55 ════════════════════════════════════════════════════════════════

qadd         : ✅ Passed
qlinear      : ✅ Passed

Reviewers:

Subscribers:

Tasks:

Tags:

### Summary
[PLEASE REMOVE] See [CONTRIBUTING.md's Pull Requests](https://github.com/pytorch/executorch/blob/main/CONTRIBUTING.md#pull-requests) for ExecuTorch PR guidelines.

[PLEASE REMOVE] If this PR closes an issue, please add a `Fixes #<issue-id>` line.

[PLEASE REMOVE] If this PR introduces a fix or feature that should be the upcoming release notes, please add a "Release notes: <area>" label. For a list of available release notes labels, check out [CONTRIBUTING.md's Pull Requests](https://github.com/pytorch/executorch/blob/main/CONTRIBUTING.md#pull-requests).

### Test plan
[PLEASE REMOVE] How did you test this PR? Please write down any manual commands you used and note down tests that you have written if applicable.
