### PR TITLE
Arm backend: Replace module() calls with graph_module

### DIFF
--- a/backends/arm/scripts/TOSA_minimal_example.ipynb
+++ b/backends/arm/scripts/TOSA_minimal_example.ipynb
@@ -62,7 +62,7 @@
     "model = Add()\n",
     "model = model.eval()\n",
     "exported_program = torch.export.export(model, example_inputs)\n",
-    "graph_module = exported_program.module()\n",
+    "graph_module = exported_program.graph_module\n",
     "\n",
     "_ = graph_module.print_readable()"
    ]
@@ -201,7 +201,7 @@
     "            config=ExecutorchBackendConfig(extract_delegate_segments=False)\n",
     "        )\n",
     "\n",
-    "executorch_program_manager.exported_program().module().print_readable()\n",
+    "executorch_program_manager.exported_program().graph_module.print_readable()\n",
     "\n",
     "# Save pte file\n",
     "pte_name = base_name + \".pte\"\n",

--- a/docs/source/tutorial-arm-ethos-u.md
+++ b/docs/source/tutorial-arm-ethos-u.md
@@ -85,7 +85,7 @@ example_inputs = (torch.ones(1,1,1,1),torch.ones(1,1,1,1))
 model = Add()
 model = model.eval()
 exported_program = torch.export.export(model, example_inputs)
-graph_module = exported_program.module()
+graph_module = exported_program.graph_module
 
 
 from executorch.backends.arm.ethosu import EthosUCompileSpec

--- a/docs/source/tutorial-arm-vgf.md
+++ b/docs/source/tutorial-arm-vgf.md
@@ -89,7 +89,7 @@ example_inputs = (torch.ones(1,1,1,1),torch.ones(1,1,1,1))
 model = Add()
 model = model.eval()
 exported_program = torch.export.export_for_training(model, example_inputs)
-graph_module = exported_program.module()
+graph_module = exported_program.graph_module
 
 
 from executorch.backends.arm.vgf import VgfCompileSpec

--- a/examples/arm/ethos_u_minimal_example.ipynb
+++ b/examples/arm/ethos_u_minimal_example.ipynb
@@ -58,7 +58,7 @@
     "model = Add()\n",
     "model = model.eval()\n",
     "exported_program = torch.export.export(model, example_inputs)\n",
-    "graph_module = exported_program.module()\n",
+    "graph_module = exported_program.graph_module\n",
     "\n",
     "_ = graph_module.print_readable()"
    ]
@@ -160,7 +160,7 @@
     "            config=ExecutorchBackendConfig(extract_delegate_segments=False)\n",
     "        )\n",
     "\n",
-    "_ = executorch_program_manager.exported_program().module().print_readable()\n",
+    "_ = executorch_program_manager.exported_program().graph_module.print_readable()\n",
     "\n",
     "# Save pte file\n",
     "save_pte_program(executorch_program_manager, \"ethos_u_minimal_example.pte\")"

--- a/examples/arm/vgf_minimal_example.ipynb
+++ b/examples/arm/vgf_minimal_example.ipynb
@@ -56,8 +56,8 @@
     "\n",
     "model = Add()\n",
     "model = model.eval()\n",
-    "exported_program = torch.export.export_for_training(model, example_inputs)\n",
-    "graph_module = exported_program.module()\n",
+    "exported_program = torch.export.export(model, example_inputs)\n",
+    "graph_module = exported_program.graph_module\n",
     "\n",
     "_ = graph_module.print_readable()"
    ]
@@ -197,7 +197,7 @@
     "            config=ExecutorchBackendConfig(extract_delegate_segments=False)\n",
     ")\n",
     "\n",
-    "executorch_program_manager.exported_program().module().print_readable()\n",
+    "executorch_program_manager.exported_program().graph_module.print_readable()\n",
     "\n",
     "# Save pte file\n",
     "cwd_dir = os.getcwd()\n",


### PR DESCRIPTION
Using ExportedProgram.module() in later versions of torch introduce guards on the input. These guards cause an error in the ExportInterpreter which forbid the use of call_module.

Fixes: https://github.com/pytorch/executorch/issues/14417
Change-Id: I0cb68af9671dd1e3b543660c1cc49ff28cbffddc


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218