### PR TITLE
Shift Left: Run selective build CI test with more restrictions

### DIFF
--- a/codegen/tools/CMakeLists.txt
+++ b/codegen/tools/CMakeLists.txt
@@ -24,8 +24,17 @@ target_include_directories(
 
 # Compile options
 target_compile_options(
-  selective_build PUBLIC -Wno-deprecated-declarations -fPIC -frtti -fexceptions
+  selective_build
+  PUBLIC -Wno-deprecated-declarations
+         -fPIC
+         -frtti
+         -fexceptions
+         -Werror
+         -Wunused-variable
+         -Wno-unknown-argument
 )
+# We suppress -Wno-unknown-argument because our build system passes -fPIC for
+# Unix builds, but we also build on Windows where it's ignored
 
 # Link against required libraries
 target_link_libraries(selective_build PRIVATE executorch_core program_schema)


### PR DESCRIPTION
Revert reason for https://github.com/pytorch/executorch/pull/14487 was that internal tests were running with "-Werror,-Wunused-variable" (https://www.internalfb.com/diff/D82981124) option but not OSS tests
