### PR TITLE
solve typo ExecutorTorch to ExecuTorch

### DIFF
--- a/.ci/scripts/test-cuda-build.sh
+++ b/.ci/scripts/test-cuda-build.sh
@@ -9,14 +9,14 @@ set -exu
 
 CUDA_VERSION=${1:-"12.6"}
 
-echo "=== Testing ExecutorTorch CUDA ${CUDA_VERSION} Build ==="
+echo "=== Testing ExecuTorch CUDA ${CUDA_VERSION} Build ==="
 
-# Function to build and test ExecutorTorch with CUDA support
+# Function to build and test ExecuTorch with CUDA support
 test_executorch_cuda_build() {
     local cuda_version=$1
 
-    echo "Building ExecutorTorch with CUDA ${cuda_version} support..."
-    echo "ExecutorTorch will automatically detect CUDA and install appropriate PyTorch wheel"
+    echo "Building ExecuTorch with CUDA ${cuda_version} support..."
+    echo "ExecuTorch will automatically detect CUDA and install appropriate PyTorch wheel"
 
     # Check available resources before starting
     echo "=== System Information ==="
@@ -27,11 +27,11 @@ test_executorch_cuda_build() {
     nvcc --version || echo "nvcc not found"
     nvidia-smi || echo "nvidia-smi not found"
 
-    # Set CMAKE_ARGS to enable CUDA build - ExecutorTorch will handle PyTorch installation automatically
+    # Set CMAKE_ARGS to enable CUDA build - ExecuTorch will handle PyTorch installation automatically
     export CMAKE_ARGS="-DEXECUTORCH_BUILD_CUDA=ON"
 
-    echo "=== Starting ExecutorTorch Installation ==="
-    # Install ExecutorTorch with CUDA support with timeout and error handling
+    echo "=== Starting ExecuTorch Installation ==="
+    # Install ExecuTorch with CUDA support with timeout and error handling
     timeout 5400 ./install_executorch.sh || {
         local exit_code=$?
         echo "ERROR: install_executorch.sh failed with exit code: $exit_code"
@@ -41,15 +41,15 @@ test_executorch_cuda_build() {
         exit $exit_code
     }
 
-    echo "SUCCESS: ExecutorTorch CUDA build completed"
+    echo "SUCCESS: ExecuTorch CUDA build completed"
 
     # Verify the installation
-    echo "=== Verifying ExecutorTorch CUDA Installation ==="
+    echo "=== Verifying ExecuTorch CUDA Installation ==="
 
-    # Test that ExecutorTorch was built successfully
+    # Test that ExecuTorch was built successfully
     python -c "
 import executorch
-print('SUCCESS: ExecutorTorch imported successfully')
+print('SUCCESS: ExecuTorch imported successfully')
 "
 
     # Test CUDA availability and show details
@@ -60,7 +60,7 @@ try:
     print('INFO: CUDA available:', torch.cuda.is_available())
 
     if torch.cuda.is_available():
-        print('SUCCESS: CUDA is available for ExecutorTorch')
+        print('SUCCESS: CUDA is available for ExecuTorch')
         print('INFO: CUDA version:', torch.version.cuda)
         print('INFO: GPU device count:', torch.cuda.device_count())
         print('INFO: Current GPU device:', torch.cuda.current_device())
@@ -74,16 +74,16 @@ try:
         print('SUCCESS: CUDA tensor operation completed on device:', z.device)
         print('INFO: Result tensor shape:', z.shape)
 
-        print('SUCCESS: ExecutorTorch CUDA integration verified')
+        print('SUCCESS: ExecuTorch CUDA integration verified')
     else:
-        print('WARNING: CUDA not detected, but ExecutorTorch built successfully')
+        print('WARNING: CUDA not detected, but ExecuTorch built successfully')
         exit(1)
 except Exception as e:
-    print('ERROR: ExecutorTorch CUDA test failed:', e)
+    print('ERROR: ExecuTorch CUDA test failed:', e)
     exit(1)
 "
 
-    echo "SUCCESS: ExecutorTorch CUDA ${cuda_version} build and verification completed successfully"
+    echo "SUCCESS: ExecuTorch CUDA ${cuda_version} build and verification completed successfully"
 }
 
 # Main execution

--- a/backends/cortex_m/test/test_quantize_op_fusion_pass.py
+++ b/backends/cortex_m/test/test_quantize_op_fusion_pass.py
@@ -313,7 +313,7 @@ class TestQuantizedOpFusionPass(unittest.TestCase):
         # Apply passes
         transformed_program = self._apply_passes(edge_program)
 
-        # Generate ExecutorTorch program
+        # Generate ExecuTorch program
         executorch_program = transformed_program.to_executorch()
 
         # Verify the program contains the expected fused operator

--- a/backends/vulkan/test/utils.py
+++ b/backends/vulkan/test/utils.py
@@ -303,13 +303,13 @@ def run_and_check_output(
     Returns:
         bool: True if outputs match within tolerance, False otherwise
     """
-    # Load the ExecutorTorch program
+    # Load the ExecuTorch program
     executorch_module = _load_for_executorch_from_buffer(executorch_program.buffer)
 
     # Flatten inputs for execution
     inputs_flattened, _ = tree_flatten(sample_inputs)
 
-    # Run the ExecutorTorch program
+    # Run the ExecuTorch program
     model_output = executorch_module.run_method("forward", tuple(inputs_flattened))
 
     # Generate reference outputs using the reference model

--- a/devtools/scripts/profile_model.sh
+++ b/devtools/scripts/profile_model.sh
@@ -7,7 +7,7 @@
 
 #!/bin/bash
 
-# ExecutorTorch Model Profiling Script
+# ExecuTorch Model Profiling Script
 #
 # This script automates the process of building executor_runner with profiling enabled,
 # running model inference with ETDump collection, and generating CSV profiling reports.

--- a/docs/source/llm/export-llm.md
+++ b/docs/source/llm/export-llm.md
@@ -4,7 +4,7 @@ Instead of needing to manually write code to call torch.export(), use ExecuTorch
 
 ## Prerequisites
 
-The LLM export functionality requires the `pytorch_tokenizers` package. If you encounter a `ModuleNotFoundError: No module named 'pytorch_tokenizers'` error, install it from the ExecutorTorch source code:
+The LLM export functionality requires the `pytorch_tokenizers` package. If you encounter a `ModuleNotFoundError: No module named 'pytorch_tokenizers'` error, install it from the ExecuTorch source code:
 
 ```bash
 pip install -e ./extension/llm/tokenizers/

--- a/docs/source/ptd-file-format.md
+++ b/docs/source/ptd-file-format.md
@@ -111,7 +111,7 @@ The flatbuffer-encoded metadata follows the headers and contains:
 ### Tensor Layout
 
 If a data segment contains a canonical tensor, it may have associated layout information:
-- **Scalar type**: Data type (float32, int32, etc.) using ExecutorTorch scalar types.
+- **Scalar type**: Data type (float32, int32, etc.) using ExecuTorch scalar types.
 - **Sizes**: Dimensions of the tensor.
 - **Dim order**: Memory layout order specifying how dimensions are arranged in memory.
 

--- a/docs/source/using-executorch-faqs.md
+++ b/docs/source/using-executorch-faqs.md
@@ -16,7 +16,7 @@ if you are using Ubuntu, or use an equivalent install command.
 
 ### ModuleNotFoundError: No module named 'pytorch_tokenizers'
 
-The `pytorch_tokenizers` package is required for LLM export functionality. Install it from the ExecutorTorch source code:
+The `pytorch_tokenizers` package is required for LLM export functionality. Install it from the ExecuTorch source code:
 ```
 pip install -e ./extension/llm/tokenizers/
 ```

--- a/examples/vulkan/export.py
+++ b/examples/vulkan/export.py
@@ -210,7 +210,7 @@ def main() -> None:
         else:
             logging.error("✗ Model test FAILED - outputs do not match reference")
             raise RuntimeError(
-                "Model validation failed: ExecutorTorch outputs do not match reference model outputs"
+                "Model validation failed: ExecuTorch outputs do not match reference model outputs"
             )
 
     if args.bundled:

--- a/exir/emit/test/test_emit.py
+++ b/exir/emit/test/test_emit.py
@@ -1920,7 +1920,7 @@ class TestEmit(unittest.TestCase):
             program_buffer = et_program.buffer
             et_module = _load_for_executorch_from_buffer(program_buffer)
             for _, (inp, expected) in enumerate(zip(test_inputs, reference_outputs)):
-                # Execute with ExecutorTorch
+                # Execute with ExecuTorch
                 et_output = et_module.forward([inp])
                 et_result = et_output[0]  # Get first output
                 # Compare results

--- a/extension/audio/mel_spectrogram.py
+++ b/extension/audio/mel_spectrogram.py
@@ -213,7 +213,7 @@ def export_processor(model=None, output_file="whisper_preprocess.pte"):
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Export WhisperAudioProcessor to ExecutorTorch"
+        description="Export WhisperAudioProcessor to ExecuTorch"
     )
     parser.add_argument(
         "--feature_size",

--- a/extension/llm/runner/README.md
+++ b/extension/llm/runner/README.md
@@ -1,6 +1,6 @@
-# LLM Runner Framework for ExecutorTorch
+# LLM Runner Framework for ExecuTorch
 
-This directory contains the LLM Runner framework for ExecutorTorch, providing high-level C++ APIs for running Large Language Models with both text-only and multimodal capabilities.
+This directory contains the LLM Runner framework for ExecuTorch, providing high-level C++ APIs for running Large Language Models with both text-only and multimodal capabilities.
 
 ## Overview
 
@@ -474,7 +474,7 @@ DeepFusion is another popular model architecture type where a pretrained encoder
 - **Llama 3.2 Vision**: Uses cross-attention layers for vision-text fusion
 - **Other cross-attention based multimodal models**
 
-For DeepFusion support, consider using the model's native inference framework or wait for future ExecutorTorch updates that may include DeepFusion architecture support.
+For DeepFusion support, consider using the model's native inference framework or wait for future ExecuTorch updates that may include DeepFusion architecture support.
 
 ## Building and Integration
 

--- a/extension/training/examples/CIFAR/data_utils.py
+++ b/extension/training/examples/CIFAR/data_utils.py
@@ -277,7 +277,7 @@ def parse_args() -> argparse.Namespace:
     Parse command line arguments for the CIFAR-10 training script.
 
     This function sets up an argument parser with various configuration options
-    for training a CIFAR-10 model with ExecutorTorch, including data paths,
+    for training a CIFAR-10 model with ExecuTorch, including data paths,
     training hyperparameters, and model save locations.
 
     Returns:

--- a/extension/training/examples/CIFAR/export.py
+++ b/extension/training/examples/CIFAR/export.py
@@ -27,12 +27,12 @@ def export_model_combined(
     with_external_tensor_data: bool = False,
 ) -> ExecuTorchModule:
     """
-    Export a PyTorch model to an ExecutorTorch module format, optionally with external tensor data.
+    Export a PyTorch model to an ExecuTorch module format, optionally with external tensor data.
 
     This function takes a PyTorch model and sample input/label tensors,
     wraps the model with a loss function, exports it using torch.export,
     applies forward-backward pass optimization, converts it to edge format,
-    and finally to ExecutorTorch format. If with_external_tensor_data is True,
+    and finally to ExecuTorch format. If with_external_tensor_data is True,
     the model will be exported with external constants and mutable weights.
 
     TODO: set dynamic shape for the batch size here.
@@ -45,7 +45,7 @@ def export_model_combined(
             Defaults to False.
 
     Returns:
-        ExecuTorchModule: The exported model in ExecutorTorch format ready for deployment
+        ExecuTorchModule: The exported model in ExecuTorch format ready for deployment
     """
     criterion = torch.nn.CrossEntropyLoss()
     model_with_loss = ModelWithLoss(net, criterion)
@@ -72,17 +72,17 @@ def export_model_combined(
 
 def get_pte_only(net: torch.nn.Module) -> ExecuTorchModule:
     """
-    Generate an ExecutorTorch module from a PyTorch model without external tensor data.
+    Generate an ExecuTorch module from a PyTorch model without external tensor data.
 
     This function retrieves a sample input and label tensor from the test data loader,
-    and uses them to export the given PyTorch model to an ExecutorTorch module format
+    and uses them to export the given PyTorch model to an ExecuTorch module format
     without external constants or mutable weights.
 
     Args:
         net (torch.nn.Module): The PyTorch model to be exported.
 
     Returns:
-        ExecuTorchModule: The exported model in ExecutorTorch format.
+        ExecuTorchModule: The exported model in ExecuTorch format.
     """
     _, test_loader = get_data_loaders()
     # get a sample input and label tensor
@@ -95,17 +95,17 @@ def get_pte_only(net: torch.nn.Module) -> ExecuTorchModule:
 
 def get_pte_with_ptd(net: torch.nn.Module) -> ExecuTorchModule:
     """
-    Generate an ExecutorTorch module from a PyTorch model with external tensor data.
+    Generate an ExecuTorch module from a PyTorch model with external tensor data.
 
     This function retrieves a sample input and label tensor from the test data loader,
-    and uses them to export the given PyTorch model to an ExecutorTorch module format
+    and uses them to export the given PyTorch model to an ExecuTorch module format
     with external constants and mutable weights.
 
     Args:
         net (torch.nn.Module): The PyTorch model to be exported.
 
     Returns:
-        ExecuTorchModule: The exported model in ExecutorTorch format with external tensor data.
+        ExecuTorchModule: The exported model in ExecuTorch format with external tensor data.
     """
     _, test_loader = get_data_loaders()
     # get a sample input and label tensor
@@ -121,7 +121,7 @@ def export_model(
     with_ptd: bool = False,
 ) -> ExecuTorchModule:
     """
-    Export a PyTorch model to ExecutorTorch format, optionally with external tensor data.
+    Export a PyTorch model to ExecuTorch format, optionally with external tensor data.
 
     This function is a high-level wrapper that handles getting sample data and
     calling the appropriate export function based on the with_ptd flag.
@@ -132,7 +132,7 @@ def export_model(
             Defaults to False.
 
     Returns:
-        ExecuTorchModule: The exported model in ExecutorTorch format
+        ExecuTorchModule: The exported model in ExecuTorch format
     """
     _, test_loader = get_data_loaders()
     validation_sample_data = next(iter(test_loader))
@@ -145,13 +145,13 @@ def export_model(
 
 def save_model(ep: ExecuTorchModule, model_path: str) -> None:
     """
-    Save an ExecutorTorch model to a specified file path.
+    Save an ExecuTorch model to a specified file path.
 
-    This function writes the buffer of an ExecutorTorchModule to a
+    This function writes the buffer of an ExecuTorchModule to a
     file in binary format.
 
     Args:
-        ep (ExecuTorchModule): The ExecutorTorch module to be saved.
+        ep (ExecuTorchModule): The ExecuTorch module to be saved.
         model_path (str): The file path where the model will be saved.
     """
     with open(model_path, "wb") as file:

--- a/extension/training/examples/CIFAR/main.py
+++ b/extension/training/examples/CIFAR/main.py
@@ -28,7 +28,7 @@ def parse_args() -> argparse.Namespace:
     Parse command line arguments for the CIFAR-10 training script.
 
     This function sets up an argument parser with various configuration options
-    for training a CIFAR-10 model with ExecutorTorch, including data paths,
+    for training a CIFAR-10 model with ExecuTorch, including data paths,
     training hyperparameters, and model save locations.
 
     Returns:

--- a/extension/training/examples/CIFAR/train_utils.py
+++ b/extension/training/examples/CIFAR/train_utils.py
@@ -195,15 +195,15 @@ def fine_tune_executorch_model(
     momentum: float = 0.9,
 ) -> tuple[ExecuTorchModule, typing.Dict[int, typing.Dict[str, float]]]:
     """
-    Fine-tune an ExecutorTorch model using a training and validation dataset.
+    Fine-tune an ExecuTorch model using a training and validation dataset.
 
-    This function loads an ExecutorTorch model from a file, fine-tunes it using
+    This function loads an ExecuTorch model from a file, fine-tunes it using
     the provided training data loader, and evaluates it on the validation data
     loader. The function returns the fine-tuned model and a history dictionary
     containing training and validation metrics.
 
     Args:
-        model_path (str): Path to the ExecutorTorch model file to be
+        model_path (str): Path to the ExecuTorch model file to be
         fine-tuned.
         save_path (str): Path where the fine-tuned model will be saved.
         train_loader (DataLoader): DataLoader for the training dataset.
@@ -215,7 +215,7 @@ def fine_tune_executorch_model(
         (default: 0.9).
 
     Returns:
-        tuple: A tuple containing the fine-tuned ExecutorTorchModule
+        tuple: A tuple containing the fine-tuned ExecuTorchModule
                and a dictionary with training and validation metrics.
     """
     with open(model_path, "rb") as f:
@@ -335,7 +335,7 @@ def train_both_models(
     typing.Dict[int, typing.Dict[str, float]],
 ]:
     """
-    Train both a PyTorch model and an ExecutorTorch model simultaneously using the same data.
+    Train both a PyTorch model and an ExecuTorch model simultaneously using the same data.
 
     This function trains both models in parallel, using the same data batches for both,
     which makes debugging and comparison easier. It tracks metrics for both models
@@ -343,7 +343,7 @@ def train_both_models(
 
     Args:
         pytorch_model (torch.nn.Module): The PyTorch model to be trained
-        et_model_path (str): Path to the ExecutorTorch model file
+        et_model_path (str): Path to the ExecuTorch model file
         train_loader (DataLoader): DataLoader for the training dataset
         test_loader (DataLoader): DataLoader for the testing/validation dataset
         epochs (int, optional): Number of epochs for training. Defaults to 10.
@@ -354,11 +354,11 @@ def train_both_models(
     Returns:
         tuple: A tuple containing:
             - The trained PyTorch model
-            - The trained ExecutorTorch model
+            - The trained ExecuTorch model
             - Dictionary with PyTorch training and validation metrics
-            - Dictionary with ExecutorTorch training and validation metrics
+            - Dictionary with ExecuTorch training and validation metrics
     """
-    # Load the ExecutorTorch model
+    # Load the ExecuTorch model
     with open(et_model_path, "rb") as f:
         model_bytes = f.read()
         et_mod = _load_for_executorch_for_training_from_buffer(model_bytes)
@@ -442,7 +442,7 @@ def train_both_models(
             # Accumulate loss
             pytorch_epoch_loss += pytorch_loss.detach().item()
 
-            # ---- ExecutorTorch model training ----
+            # ---- ExecuTorch model training ----
             et_start_time = time.time()
 
             # Forward pass
@@ -476,7 +476,7 @@ def train_both_models(
             f"PyTorch - Train Loss: {avg_pytorch_train_loss:.4f}, Train Accuracy: {pytorch_train_accuracy:.2f}%"
         )
         print(
-            f"ExecutorTorch - Train Loss: {avg_et_train_loss:.4f}, Train Accuracy: {et_train_accuracy:.2f}%"
+            f"ExecuTorch - Train Loss: {avg_et_train_loss:.4f}, Train Accuracy: {et_train_accuracy:.2f}%"
         )
 
         # Testing/Validation phase
@@ -513,7 +513,7 @@ def train_both_models(
                 pytorch_test_correct += (pytorch_predicted == labels).sum().item()
                 pytorch_test_total += batch_size
 
-                # ---- ExecutorTorch model testing ----
+                # ---- ExecuTorch model testing ----
                 et_test_start = time.time()
 
                 et_out = et_mod.forward_backward(
@@ -540,7 +540,7 @@ def train_both_models(
             f"PyTorch - Test Loss: {avg_pytorch_test_loss:.4f}, Test Accuracy: {pytorch_test_accuracy:.2f}%"
         )
         print(
-            f"ExecutorTorch - Test Loss: {avg_et_test_loss:.4f}, Test Accuracy: {et_test_accuracy:.2f}%"
+            f"ExecuTorch - Test Loss: {avg_et_test_loss:.4f}, Test Accuracy: {et_test_accuracy:.2f}%"
         )
 
         # Compare losses
@@ -555,16 +555,14 @@ def train_both_models(
                 f"New best PyTorch model saved with test loss: {avg_pytorch_test_loss:.4f}"
             )
 
-        # Save the best ExecutorTorch model
+        # Save the best ExecuTorch model
         if avg_et_test_loss < best_et_test_loss:
             best_et_test_loss = avg_et_test_loss
-            # Save the ExecutorTorch model
+            # Save the ExecuTorch model
             save_dir = os.path.dirname(et_save_path)
             if save_dir and not os.path.exists(save_dir):
                 os.makedirs(save_dir)
-            print(
-                f"New best ExecutorTorch model with test loss: {avg_et_test_loss:.4f}"
-            )
+            print(f"New best ExecuTorch model with test loss: {avg_et_test_loss:.4f}")
 
         # Store history for both models
         pytorch_history[epoch] = {
@@ -605,7 +603,7 @@ def train_both_models(
             f"PyTorch training time: {pytorch_train_time:.4f}s, testing time: {pytorch_test_time:.4f}s"
         )
         print(
-            f"ExecutorTorch training time: {et_train_time:.4f}s, testing time: {et_test_time:.4f}s"
+            f"ExecuTorch training time: {et_train_time:.4f}s, testing time: {et_test_time:.4f}s"
         )
         print(f"Training time ratio (ET/PT): {et_train_time/pytorch_train_time:.4f}")
         print(f"Testing time ratio (ET/PT): {et_test_time/pytorch_test_time:.4f}")
@@ -613,12 +611,12 @@ def train_both_models(
     print("\nTraining Completed!\n")
     print("\n###########SUMMARY#############\n")
     print(f"Best PyTorch test loss: {best_pytorch_test_loss:.4f}")
-    print(f"Best ExecutorTorch test loss: {best_et_test_loss:.4f}")
+    print(f"Best ExecuTorch test loss: {best_et_test_loss:.4f}")
     print(
         f"Final loss difference: {abs(best_pytorch_test_loss - best_et_test_loss):.6f}"
     )
     print(f"PyTorch model saved at: {pytorch_save_path}")
-    print(f"ExecutorTorch model path: {et_save_path}")
+    print(f"ExecuTorch model path: {et_save_path}")
     print("################################\n")
 
     return pytorch_model, et_mod, pytorch_history, et_history


### PR DESCRIPTION
Summary: fix typo ExecutorTorch -> ExecuTorch

Reviewed By: GregoryComer

Differential Revision: D83006323


