### PR TITLE
Re-introduce some logging after backout

### DIFF
--- a/backends/apple/coreml/runtime/delegate/ETCoreMLModelManager.mm
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLModelManager.mm
@@ -436,11 +436,13 @@ ETCoreMLModelDebugInfo * _Nullable get_model_debug_info(const inmemoryfs::InMemo
     switch (modelAssetType.value()) {
         case ModelAssetType::CompiledModel: {
             // Model is already compiled.
+            ETCoreMLLogInfo("The model in the pte file is pre-compiled.  Skipping compilation.");
             return modelURL;
         }
             
         case ModelAssetType::Model: {
             // Compile the model.
+            ETCoreMLLogInfo("The model in the pte file is not pre-compiled.  Compiling with a 5 min timeout.");
             NSURL *compiledModelURL = [ETCoreMLModelCompiler compileModelAtURL:modelURL
                                                           maxWaitTimeInSeconds:(5 * 60)
                                                                          error:error];


### PR DESCRIPTION
Summary:
Since D80715432 landed, we also landed D81256207 to add more logging.  To prevent conflicts, we backout in 3 steps:

* In diff 1/3, we backout D81256207, which added more logging
* In diff 2/3, we backout D80715432, which is the problematic diff we're trying to revert
* In diff 3/3, we introduce some of the logging we backed out in diff 1/3

Differential Revision: D82581441


