### PR TITLE
Documentation on reproducing BUCK CI failures

### DIFF
--- a/.ci/docker/common/install_buck.sh
+++ b/.ci/docker/common/install_buck.sh
@@ -9,17 +9,23 @@ set -ex
 
 install_ubuntu() {
   apt-get update
-  apt-get install -y zstd
+  apt-get install -y zstd python3-certifi
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+  
+  # Create a cache directory for buck2
+  CACHE_DIR="/tmp/buck2_cache"
+  mkdir -p "${CACHE_DIR}"
 
-  BUCK2=buck2-x86_64-unknown-linux-gnu.zst
-  wget -q "https://github.com/facebook/buck2/releases/download/${BUCK2_VERSION}/${BUCK2}"
-  zstd -d "${BUCK2}" -o buck2
+  # Run resolve_buck.py to get the buck2 binary
+  BUCK2_PATH=$(python "${REPO_ROOT}/tools/cmake/resolve_buck.py" --cache_dir "${CACHE_DIR}")
 
-  chmod +x buck2
-  mv buck2 /usr/bin/
+  # Move buck2 to /usr/bin/
+  mv "${BUCK2_PATH}" /usr/bin/buck2
+  chmod +x /usr/bin/buck2
 
-  rm "${BUCK2}"
-  # Cleanup package manager
+  # Cleanup
+  rm -rf "${CACHE_DIR}"
   apt-get autoclean && apt-get clean
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -329,6 +329,24 @@ the CI (continuous integration) jobs. If `main` is broken, consider rebasing
 your PR onto the `viable/strict` branch, which points to the most recent
 all-green commit.
 
+### BUCK tests
+In addition to CMake, we run `buck` tests in our CI pipeline to ensure continued integration with certain customers. We recognize that `buck` is not a widely used build system and may not be installed on your local machine. If you encounter a failure in the `buck` CI and wish to reproduce it locally, follow these steps:
+
+```
+# Install buck
+pip install zstd certifi
+BUCK2_PATH=$(python tools/cmake/resolve_buck.py --cache_dir=/tmp/)
+mv "${BUCK2_PATH}" ~/buck2
+chmod +x ~/buck2
+
+# Build example
+~/buck2 build //runtime/platform/... # replace with other targets
+
+# Test example
+~/buck2 test //runtime/platform/...  # replace with other targets
+```
+
+Please refer to the [official buck documentation](https://buck.build/command/build.html).
 &nbsp;
 
 ## Updating Documentation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,6 @@ requires = [
   "pyyaml",  # Imported by the kernel codegen tools.
   "setuptools>=63",  # For building the pip package contents.
   "wheel",  # For building the pip package archive.
-  "zstd",  # Imported by resolve_buck.py.
-  "certifi",  # Imported by resolve_buck.py.
 ]
 build-backend = "setuptools.build_meta"
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,5 @@ pip>=23  # For building the pip package.
 pyyaml  # Imported by the kernel codegen tools.
 setuptools>=63  # For building the pip package contents.
 wheel  # For building the pip package archive.
-zstd  # Imported by resolve_buck.py.
-certifi  # Imported by resolve_buck.py.
 lintrunner==0.12.7
 lintrunner-adapters==0.12.6


### PR DESCRIPTION
I found having resolve_buck.py script helpful to reproduce buck tests locally.

I know @swolchok wanted to delete, but how about having it in our codebase, but actually use it in our CI? 