### PR TITLE
Leverage __call__ impl of nn Module instead of calling forward on attention

### DIFF
--- a/examples/models/llama/llama_transformer.py
+++ b/examples/models/llama/llama_transformer.py
@@ -117,7 +117,7 @@ class TransformerBlock(nn.Module):
         return TransformerBlock(args, attention)
 
     def forward(self, x, freqs_cos, freqs_sin, attn_options: ForwardOptions):  # x: 1xN
-        h, attn_options_update = self.attention.forward(
+        h, attn_options_update = self.attention(
             self.attention_norm(x), freqs_cos, freqs_sin, **attn_options
         )
 


### PR DESCRIPTION
Summary:
In the current llama transformer definition we explicitly invoke forward method on various attention impls. This prevents us from leveraging register_forward_hook which explicitly gets called only via __call__ override here https://github.com/pytorch/pytorch/blob/main/torch/nn/modules/module.py#L1781. 

By removing explicit call to forward we enable hooks to appropriately execute

Created from CodeHub with https://fburl.com/edit-in-codehub

Differential Revision: D83156099


