### PR TITLE
NXP Backend: Update Neutron Software to version SDK_25.09

### DIFF
--- a/backends/nxp/nxp_backend.py
+++ b/backends/nxp/nxp_backend.py
@@ -64,7 +64,7 @@ class NeutronCompileSpecBuilder:
         Args:
             config: Neutron accelerator configuration, e.g. "imxrt700"
             neutron_converter_flavor: Flavor of the neutron-converter module to use. Neutron-converter module named "
-             "'neutron_converter_SDK_25_06' has flavor 'SDK_25_06'.
+             "'neutron_converter_SDK_25_09' has flavor 'SDK_25_09'.
             extra_flags: Extra flags for the Neutron compiler
             operators_not_to_delegate: List of operators that should not be delegated
         """

--- a/backends/nxp/requirements-tests-eiq.txt
+++ b/backends/nxp/requirements-tests-eiq.txt
@@ -1,2 +1,2 @@
 --index-url https://eiq.nxp.com/repository
-neutron_converter_SDK_25_06
+neutron_converter_SDK_25_09

--- a/backends/nxp/runtime/NeutronErrors.h
+++ b/backends/nxp/runtime/NeutronErrors.h
@@ -39,6 +39,32 @@ typedef enum ERROR_COMPONENT_ID {
   ERROR_COMPONENT_DRIVER = 0x3
 } ERROR_COMPONENT_ID;
 
+/* Neutron Firmware error category codes */
+typedef enum ERROR_CATEGORY_FW {
+  ERROR_CATEGORY_FW_GENERIC, /* Generic error category */
+  ERROR_CATEGORY_FW_UCODE, /* Microcode bad magic or version incompatible. */
+  ERROR_CATEGORY_FW_BUFFER_OVERFLOW, /* Buffer overflow error category */
+  ERROR_CATEGORY_FW_NULL_POINTER, /* Pointer is null */
+  ERROR_CATEGORY_FW_INTR_ERROR, /* Interrupt triggering error */
+  ERROR_CATEGORY_FW_DMAPI_ERROR, /* DM API parameter error */
+} ERROR_CATEGORY_FW;
+
+/* Neutron Driver error category codes */
+typedef enum ERROR_CATEGORY_DRIVER {
+  ERROR_CATEGORY_DRIVER_GENERIC, /* Generic error category */
+  ERROR_CATEGORY_DRIVER_UNSUPPORTED, /* Unsupported function */
+  ERROR_CATEGORY_DRIVER_UCODE, /* Microcode bad magic or version incompatible.
+                                */
+  ERROR_CATEGORY_DRIVER_INVALID, /* Invalid arguments */
+  ERROR_CATEGORY_DRIVER_BAD_HANDLE, /* Bad inference handle */
+  ERROR_CATEGORY_DRIVER_NO_MEMORY, /* Not enough memory */
+  ERROR_CATEGORY_DRIVER_INTERNAL_FAULT, /* Internal error */
+  ERROR_CATEGORY_DRIVER_UNKNOWN_ARCH, /* Unknown architecture */
+  ERROR_CATEGORY_DRIVER_TRACE_NOT_RUN, /* Tracing did not run, but trace buffer
+                                          was requested. */
+  ERROR_CATEGORY_DRIVER_TIMEOUT /* Timeout error. */
+} ERROR_CATEGORY_DRIVER;
+
 /// Retrieve component name as string from NeutronError code.
 char* getNeutronErrorComponent(NeutronError ne);
 

--- a/backends/nxp/tests/executorch_pipeline.py
+++ b/backends/nxp/tests/executorch_pipeline.py
@@ -88,7 +88,7 @@ def to_quantized_edge_program(
         [tuple[ModelInputSpec, ...]], list[tuple[torch.Tensor, ...]]
     ] = get_random_calibration_inputs,
     target="imxrt700",
-    neutron_converter_flavor="SDK_25_06",
+    neutron_converter_flavor="SDK_25_09",
     remove_quant_io_ops=False,
     custom_delegation_options=CustomDelegationOptions(),  # noqa B008
 ) -> EdgeProgramManager:

--- a/backends/nxp/tests/ir/converter/node_converter/test_conv_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_conv_converter.py
@@ -76,7 +76,18 @@ def test_conv1d_quant_conversion(stride, dilation, kernel_size, mocker):
 
 @pytest.mark.parametrize("stride", [1, 2])
 @pytest.mark.parametrize("dilation", [2, 1])
-@pytest.mark.parametrize("kernel_size", [(1,), (3,)])
+@pytest.mark.parametrize(
+    "kernel_size",
+    [
+        pytest.param(
+            (1,),
+            marks=pytest.mark.xfail(
+                reason="Regression in Neutron SW 2.1.x (AIR-13336)", strict=True
+            ),
+        ),
+        (3,),
+    ],
+)
 @pytest.mark.parametrize("padding", [(1,), 2])
 def test_conv1d_quant_conversion__padded(
     stride, dilation, kernel_size, padding, mocker
@@ -179,7 +190,18 @@ def test_conv1d_quant_conversion__depthwise(stride, dilation, kernel_size, mocke
 
 @pytest.mark.parametrize("stride", [1, 2])
 @pytest.mark.parametrize("dilation", [2, 1])
-@pytest.mark.parametrize("kernel_size", [(1,), (3,)])
+@pytest.mark.parametrize(
+    "kernel_size",
+    [
+        pytest.param(
+            (1,),
+            marks=pytest.mark.xfail(
+                reason="Regression in Neutron SW 2.1.x (AIR-13336)", strict=True
+            ),
+        ),
+        (3,),
+    ],
+)
 @pytest.mark.parametrize("padding", [(1,), 2])
 def test_conv1d_quant_conversion__depthwise__padded(
     stride, dilation, kernel_size, padding, mocker

--- a/backends/nxp/tests/test_neutron_converter_manager.py
+++ b/backends/nxp/tests/test_neutron_converter_manager.py
@@ -30,7 +30,7 @@ def test_conv2d_neutron_conversion__default_flavor():
 
     neutron_converter_manager = NeutronConverterManager()
     neutron_model = neutron_converter_manager.convert(
-        tflite_model, "imxrt700", "SDK_25_06"
+        tflite_model, "imxrt700", "SDK_25_09"
     )
 
     assert len(

--- a/backends/nxp/tests/test_split_group_convolution.py
+++ b/backends/nxp/tests/test_split_group_convolution.py
@@ -49,7 +49,7 @@ def _quantize_and_lower_module(
         edge_compile_config=edge_compile_config,
     )
 
-    compile_spec = generate_neutron_compile_spec(target, "SDK_25_06")
+    compile_spec = generate_neutron_compile_spec(target, "SDK_25_09")
     partitioner = NeutronPartitioner(compile_spec)
     return edge_program_manager.to_backend(partitioner)
 

--- a/examples/nxp/README.md
+++ b/examples/nxp/README.md
@@ -13,7 +13,7 @@ $ examples/nxp/setup.sh
 2. Now run the `aot_neutron_compile.py` example with the `cifar10` model 
 ```commandline
 $ python -m examples.nxp.aot_neutron_compile --quantize \
-    --delegate --neutron_converter_flavor SDK_25_06 -m cifar10 
+    --delegate --neutron_converter_flavor SDK_25_09 -m cifar10 
 ```
 
 3. It will generate you `cifar10_nxp_delegate.pte` file which can be used with the MXUXpresso SDK `cifarnet_example` project, presented [here](https://mcuxpresso.nxp.com/mcuxsdk/latest/html/middleware/eiq/executorch/docs/nxp/topics/example_applications.html#how-to-build-and-run-executorch-cifarnet-example).

--- a/examples/nxp/aot_neutron_compile.py
+++ b/examples/nxp/aot_neutron_compile.py
@@ -164,9 +164,9 @@ if __name__ == "__main__":  # noqa C901
         "-c",
         "--neutron_converter_flavor",
         required=False,
-        default="SDK_25_06",
+        default="SDK_25_09",
         help="Flavor of installed neutron-converter module. Neutron-converter module named "
-        "'neutron_converter_SDK_24_12' has flavor 'SDK_24_12'.",
+        "'neutron_converter_SDK_25_09' has flavor 'SDK_25_09'.",
     )
     parser.add_argument(
         "-q",

--- a/examples/nxp/run_aot_example.sh
+++ b/examples/nxp/run_aot_example.sh
@@ -13,6 +13,6 @@ cd $EXECUTORCH_DIR
 
 # Run the AoT example
 python -m examples.nxp.aot_neutron_compile --quantize \
-    --delegate --neutron_converter_flavor SDK_25_06 -m ${MODEL}
+    --delegate --neutron_converter_flavor SDK_25_09 -m ${MODEL}
 # verify file exists
 test -f ${MODEL}_nxp_delegate.pte

--- a/examples/nxp/setup.sh
+++ b/examples/nxp/setup.sh
@@ -7,4 +7,4 @@
 set -u
 
 # Install neutron-converter
-pip install --index-url https://eiq.nxp.com/repository neutron_converter_SDK_25_06
+pip install --index-url https://eiq.nxp.com/repository neutron_converter_SDK_25_09


### PR DESCRIPTION
### Summary
Update Neutron Software to version SDK 25.09. 
Test updated, as there is a known issue with SDK 25.09, tracked internally as AIR-13336.


### Test plan
Unit test updated. 

CC @JakeStevens 


cc @digantdesai @JakeStevens