### PR TITLE
set a dependency job to limit qnn jobs to specific paths

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -973,7 +973,25 @@ jobs:
         # Test llama2
         PYTHON_EXECUTABLE=python bash .ci/scripts/test_llama.sh -model stories110M -build_tool "${BUILD_TOOL}" -mode "${MODE}" -dtype "${DTYPE}" -pt2e_quantize "${PT2E_QUANTIZE}"
 
+  # this is for filtering out the qnn changes such that qnn jobs only triggered when the specific files are changed
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      qnn: ${{ steps.filter.outputs.qnn }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            qnn:
+              - 'backends/qualcomm/**'
+              - 'examples/qualcomm/**'
+              - 'examples/models/llama/**'
+
   test-static-llama-qnn-eval-linux:
+    needs: changes # has dependency on changes jobs defined above
+    if: needs.changes.outputs.qnn == 'true'
     name: test-static-llama-qnn-eval-linux
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     permissions:

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -991,7 +991,7 @@ jobs:
 
   test-static-llama-qnn-eval-linux:
     # needs: changes # has dependency on changes jobs defined above
-    if: needs.changes.outputs.qnn == 'true'
+    # if: needs.changes.outputs.qnn == 'true'
     name: test-static-llama-qnn-eval-linux
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     permissions:

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -973,24 +973,24 @@ jobs:
         # Test llama2
         PYTHON_EXECUTABLE=python bash .ci/scripts/test_llama.sh -model stories110M -build_tool "${BUILD_TOOL}" -mode "${MODE}" -dtype "${DTYPE}" -pt2e_quantize "${PT2E_QUANTIZE}"
 
-  # # this is for filtering out the qnn changes such that qnn jobs only triggered when the specific files are changed
-  # changes:
-  #   runs-on: ubuntu-latest
-  #   outputs:
-  #     qnn: ${{ steps.filter.outputs.qnn }}
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: dorny/paths-filter@v3
-  #       id: filter
-  #       with:
-  #         filters: |
-  #           qnn:
-  #             - 'backends/qualcomm/**'
-  #             - 'examples/qualcomm/**'
-  #             - 'examples/models/llama/**'
+  # this is for filtering out the qnn changes such that qnn jobs only triggered when the specific files are changed
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      qnn: ${{ steps.filter.outputs.qnn }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            qnn:
+              - 'backends/qualcomm/**'
+              - 'examples/qualcomm/**'
+              - 'examples/models/llama/**'
 
   test-static-llama-qnn-eval-linux:
-    # needs: changes # has dependency on changes jobs defined above
+    needs: changes # has dependency on changes jobs defined above
     if: needs.changes.outputs.qnn == 'true'
     name: test-static-llama-qnn-eval-linux
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -990,8 +990,8 @@ jobs:
               - 'examples/models/llama/**'
 
   test-static-llama-qnn-eval-linux:
-    # needs: changes # has dependency on changes jobs defined above
-    # if: needs.changes.outputs.qnn == 'true'
+    needs: changes # has dependency on changes jobs defined above
+    if: needs.changes.outputs.qnn == 'true'
     name: test-static-llama-qnn-eval-linux
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     permissions:

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -973,24 +973,24 @@ jobs:
         # Test llama2
         PYTHON_EXECUTABLE=python bash .ci/scripts/test_llama.sh -model stories110M -build_tool "${BUILD_TOOL}" -mode "${MODE}" -dtype "${DTYPE}" -pt2e_quantize "${PT2E_QUANTIZE}"
 
-  # this is for filtering out the qnn changes such that qnn jobs only triggered when the specific files are changed
-  changes:
-    runs-on: ubuntu-latest
-    outputs:
-      qnn: ${{ steps.filter.outputs.qnn }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          filters: |
-            qnn:
-              - 'backends/qualcomm/**'
-              - 'examples/qualcomm/**'
-              - 'examples/models/llama/**'
+  # # this is for filtering out the qnn changes such that qnn jobs only triggered when the specific files are changed
+  # changes:
+  #   runs-on: ubuntu-latest
+  #   outputs:
+  #     qnn: ${{ steps.filter.outputs.qnn }}
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: dorny/paths-filter@v3
+  #       id: filter
+  #       with:
+  #         filters: |
+  #           qnn:
+  #             - 'backends/qualcomm/**'
+  #             - 'examples/qualcomm/**'
+  #             - 'examples/models/llama/**'
 
   test-static-llama-qnn-eval-linux:
-    needs: changes # has dependency on changes jobs defined above
+    # needs: changes # has dependency on changes jobs defined above
     if: needs.changes.outputs.qnn == 'true'
     name: test-static-llama-qnn-eval-linux
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -990,7 +990,7 @@ jobs:
               - 'examples/models/llama/**'
 
   test-static-llama-qnn-eval-linux:
-    needs: changes # has dependency on changes jobs defined above
+    # needs: changes # has dependency on changes jobs defined above
     if: needs.changes.outputs.qnn == 'true'
     name: test-static-llama-qnn-eval-linux
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main

--- a/backends/qualcomm/README.md
+++ b/backends/qualcomm/README.md
@@ -12,6 +12,7 @@ A website version of the tutorial is [here](https://pytorch.org/executorch/main/
 
 ## Delegate Options
 
+
 Please check `generate_qnn_executorch_compiler_spec()` in
 [utils.py](utils/utils.py) for supported SoC and inference type.
 

--- a/backends/qualcomm/README.md
+++ b/backends/qualcomm/README.md
@@ -12,7 +12,6 @@ A website version of the tutorial is [here](https://pytorch.org/executorch/main/
 
 ## Delegate Options
 
-
 Please check `generate_qnn_executorch_compiler_spec()` in
 [utils.py](utils/utils.py) for supported SoC and inference type.
 


### PR DESCRIPTION
without dependency: https://github.com/pytorch/executorch/actions/runs/18017807043/job/51267174825?pr=14603

with the dependency: eems like the job is skipped https://github.com/pytorch/executorch/actions/runs/18017569385/job/51266354486?pr=14603


with the dependency and trigger with qcom changes: https://github.com/pytorch/executorch/actions/runs/18017856742/job/51267377173?pr=14603