### PR TITLE
Remove deprecation annotations from ObjC/Swift bindings.

### DIFF
--- a/extension/apple/ExecuTorch/Exported/ExecuTorch+Module.swift
+++ b/extension/apple/ExecuTorch/Exported/ExecuTorch+Module.swift
@@ -8,7 +8,6 @@
 
 @_exported import ExecuTorch
 
-@available(*, deprecated, message: "This API is experimental.")
 public extension TensorMetadata {
   /// The size of each dimension.
   var shape: [Int] { __shape.map(\.intValue) }
@@ -17,7 +16,6 @@ public extension TensorMetadata {
   var dimensionOrder: [Int] { __dimensionOrder.map(\.intValue) }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 public extension MethodMetadata {
   /// The declared input tags.
   var inputValueTags: [ValueTag] {
@@ -49,7 +47,6 @@ public extension MethodMetadata {
   }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 public extension Module {
   /// Executes a specific method with the provided input values.
   /// The method is loaded on demand if not already loaded.
@@ -94,7 +91,6 @@ public extension Module {
   }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 public extension Module {
   /// Executes a specific method and decodes the outputs into `Output` generic type.
   ///
@@ -177,7 +173,6 @@ public extension Module {
   }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 public extension Module {
   /// Sets a single input value for a method at the specified index.
   ///

--- a/extension/apple/ExecuTorch/Exported/ExecuTorch+Tensor.swift
+++ b/extension/apple/ExecuTorch/Exported/ExecuTorch+Tensor.swift
@@ -12,14 +12,12 @@
 ///
 /// - Parameter shape: An array of integers, where each element represents a dimension size.
 /// - Returns: An integer equal to the product of the sizes of all dimensions.
-@available(*, deprecated, message: "This API is experimental.")
 public func elementCount(ofShape shape: [Int]) -> Int {
   __ExecuTorchElementCountOfShape(shape.map(NSNumber.init))
 }
 
 /// A protocol that types conform to in order to be used as tensor element types.
 /// Provides the mapping from the Swift type to the underlying `DataType`.
-@available(*, deprecated, message: "This API is experimental.")
 public protocol Scalar {
   /// The `DataType` corresponding to this scalar type.
   static var dataType: DataType { get }
@@ -27,7 +25,6 @@ public protocol Scalar {
   func asNSNumber() -> NSNumber
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 extension UInt8: Scalar {
   /// The `DataType` corresponding to `UInt8`, which is `.byte`.
   public static var dataType: DataType { .byte }
@@ -35,7 +32,6 @@ extension UInt8: Scalar {
   public func asNSNumber() -> NSNumber { NSNumber(value: self) }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 extension Int8: Scalar {
   /// The `DataType` corresponding to `Int8`, which is `.char`.
   public static var dataType: DataType { .char }
@@ -43,7 +39,6 @@ extension Int8: Scalar {
   public func asNSNumber() -> NSNumber { NSNumber(value: self) }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 extension Int16: Scalar {
   /// The `DataType` corresponding to `Int16`, which is `.short`.
   public static var dataType: DataType { .short }
@@ -51,7 +46,6 @@ extension Int16: Scalar {
   public func asNSNumber() -> NSNumber { NSNumber(value: self) }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 extension Int32: Scalar {
   /// The `DataType` corresponding to `Int32`, which is `.int`.
   public static var dataType: DataType { .int }
@@ -59,7 +53,6 @@ extension Int32: Scalar {
   public func asNSNumber() -> NSNumber { NSNumber(value: self) }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 extension Int64: Scalar {
   /// The `DataType` corresponding to `Int64`, which is `.long`.
   public static var dataType: DataType { .long }
@@ -67,7 +60,6 @@ extension Int64: Scalar {
   public func asNSNumber() -> NSNumber { NSNumber(value: self) }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 extension Int: Scalar {
   /// The `DataType` corresponding to `Int`, which is `.long`.
   public static var dataType: DataType { .long }
@@ -75,7 +67,6 @@ extension Int: Scalar {
   public func asNSNumber() -> NSNumber { NSNumber(value: self) }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 extension Float: Scalar {
   /// The `DataType` corresponding to `Float`, which is `.float`.
   public static var dataType: DataType { .float }
@@ -83,7 +74,6 @@ extension Float: Scalar {
   public func asNSNumber() -> NSNumber { NSNumber(value: self) }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 extension Double: Scalar {
   /// The `DataType` corresponding to `Double`, which is `.double`.
   public static var dataType: DataType { .double }
@@ -91,7 +81,6 @@ extension Double: Scalar {
   public func asNSNumber() -> NSNumber { NSNumber(value: self) }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 extension Bool: Scalar {
   /// The `DataType` corresponding to `Bool`, which is `.bool`.
   public static var dataType: DataType { .bool }
@@ -99,7 +88,6 @@ extension Bool: Scalar {
   public func asNSNumber() -> NSNumber { NSNumber(value: self) }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 extension UInt16: Scalar {
   /// The `DataType` corresponding to `UInt16`.
   public static var dataType: DataType { .uInt16 }
@@ -107,7 +95,6 @@ extension UInt16: Scalar {
   public func asNSNumber() -> NSNumber { NSNumber(value: self) }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 extension UInt32: Scalar {
   /// The `DataType` corresponding to `UInt32`.
   public static var dataType: DataType { .uInt32 }
@@ -115,7 +102,6 @@ extension UInt32: Scalar {
   public func asNSNumber() -> NSNumber { NSNumber(value: self) }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 extension UInt64: Scalar {
   /// The `DataType` corresponding to `UInt64`.
   public static var dataType: DataType { .uInt64 }
@@ -123,7 +109,6 @@ extension UInt64: Scalar {
   public func asNSNumber() -> NSNumber { NSNumber(value: self) }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 extension UInt: Scalar {
   /// The `DataType` corresponding to `UInt`.
   public static var dataType: DataType { .uInt64 }
@@ -132,7 +117,6 @@ extension UInt: Scalar {
 }
 
 /// A type-erasing tensor class for ExecuTorch operations.
-@available(*, deprecated, message: "This API is experimental.")
 public extension AnyTensor {
   /// The shape of the tensor.
   var shape: [Int] { __shape.map(\.intValue) }
@@ -258,7 +242,6 @@ public extension AnyTensor {
   }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 public extension AnyTensor {
   /// Creates an empty tensor with the specified properties.
   ///
@@ -302,7 +285,6 @@ public extension AnyTensor {
   }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 public extension AnyTensor {
   /// Creates a tensor filled with the specified scalar value.
   ///
@@ -348,7 +330,6 @@ public extension AnyTensor {
   }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 public extension AnyTensor {
   /// Creates a tensor filled with ones.
   ///
@@ -390,7 +371,6 @@ public extension AnyTensor {
   }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 public extension AnyTensor {
   /// Creates a tensor filled with zeros.
   ///
@@ -433,7 +413,6 @@ public extension AnyTensor {
   }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 public extension AnyTensor {
   /// Creates a tensor with random values uniformly distributed in `[0, 1)`.
   ///
@@ -477,7 +456,6 @@ public extension AnyTensor {
   }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 public extension AnyTensor {
   /// Creates a tensor with random values from a normal distribution with mean `0` and variance `1`.
   ///
@@ -521,7 +499,6 @@ public extension AnyTensor {
   }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 public extension AnyTensor {
   /// Creates a tensor with random integers from `low` (inclusive) to `high` (exclusive).
   ///
@@ -581,7 +558,6 @@ public extension AnyTensor {
 ///
 /// This class encapsulates a type-erasing `AnyTensor` instance and provides a variety of
 /// initializers and utility methods to work with tensor data.
-@available(*, deprecated, message: "This API is experimental.")
 public final class Tensor<T: Scalar>: Equatable {
   /// The data type of the tensor's elements.
   public var dataType: DataType { anyTensor.dataType }
@@ -819,7 +795,6 @@ public final class Tensor<T: Scalar>: Equatable {
   public let anyTensor: AnyTensor
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 public extension Tensor {
   /// Returns the tensor's elements as an array of scalars.
   ///
@@ -829,7 +804,6 @@ public extension Tensor {
   }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 public extension Tensor {
   /// Creates an empty tensor with the specified properties.
   ///
@@ -868,7 +842,6 @@ public extension Tensor {
   }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 public extension Tensor {
   /// Creates a tensor filled with the specified scalar value.
   ///
@@ -912,7 +885,6 @@ public extension Tensor {
   }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 public extension Tensor {
   /// Creates a tensor filled with ones.
   ///
@@ -950,7 +922,6 @@ public extension Tensor {
   }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 public extension Tensor {
   /// Creates a tensor filled with zeros.
   ///
@@ -988,7 +959,6 @@ public extension Tensor {
   }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 public extension Tensor {
   /// Creates a tensor with random values uniformly distributed in `[0, 1)`.
   ///
@@ -1027,7 +997,6 @@ public extension Tensor {
   }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 public extension Tensor {
   /// Creates a tensor with random values from a normal distribution with mean `0` and variance `1`.
   ///
@@ -1066,7 +1035,6 @@ public extension Tensor {
   }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 public extension Tensor {
   /// Creates a tensor with random integers from `low` (inclusive) to `high` (exclusive).
   ///
@@ -1117,7 +1085,6 @@ public extension Tensor {
   }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 extension Tensor: CustomStringConvertible {
   public var description: String {
     self.anyTensor.description

--- a/extension/apple/ExecuTorch/Exported/ExecuTorch+Value.swift
+++ b/extension/apple/ExecuTorch/Exported/ExecuTorch+Value.swift
@@ -8,7 +8,6 @@
 
 @_exported import ExecuTorch
 
-@available(*, deprecated, message: "This API is experimental.")
 public extension Value {
   /// Creates a `Value` instance encapsulating a `Tensor`.
   ///
@@ -35,20 +34,17 @@ public extension Value {
 
 /// A protocol that provides a uniform way to convert different Swift types
 /// into a `Value`.
-@available(*, deprecated, message: "This API is experimental.")
 public protocol ValueConvertible {
   /// Converts the instance into a `Value`.
   func asValue() -> Value
 }
 
 /// A protocol that provides a uniform way to create an instance from a `Value`.
-@available(*, deprecated, message: "This API is experimental.")
 public protocol ValueConstructible {
   /// Constructs the instance from a `Value`.
   static func from(_ value: Value) throws -> Self
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 public extension ValueConstructible {
   /// Sugar on top of `decode(from:)`
   init(_ value: Value) throws {
@@ -57,13 +53,11 @@ public extension ValueConstructible {
 }
 
 /// A protocol that provides a uniform way to create an instance from an array of `Value`.
-@available(*, deprecated, message: "This API is experimental.")
 public protocol ValueSequenceConstructible {
   /// Constructs the instance from a `Value` array.
   static func from(_ values: [Value]) throws -> Self
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 extension ValueSequenceConstructible where Self: ValueConstructible {
   public static func from(_ values: [Value]) throws -> Self {
     guard values.count == 1 else { throw Error(code: .invalidType) }
@@ -71,7 +65,6 @@ extension ValueSequenceConstructible where Self: ValueConstructible {
   }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 public extension ValueSequenceConstructible {
   /// Sugar on top of `decode(from:)`
   init(_ values: [Value]) throws {
@@ -81,109 +74,91 @@ public extension ValueSequenceConstructible {
 
 // MARK: - ValueConvertible Conformances
 
-@available(*, deprecated, message: "This API is experimental.")
 extension Value: ValueConvertible {
   /// Returns the `Value` itself.
   public func asValue() -> Value { self }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 extension AnyTensor: ValueConvertible {
   /// Converts the `Tensor` into a `Value`.
   public func asValue() -> Value { Value(self) }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 extension Tensor: ValueConvertible {
   /// Converts the `Tensor` into a `Value`.
   public func asValue() -> Value { Value(self) }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 extension String: ValueConvertible {
   /// Converts the `String` into a `Value`.
   public func asValue() -> Value { Value(self) }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 extension NSNumber: ValueConvertible {
   /// Converts the `NSNumber` into a `Value`.
   public func asValue() -> Value { Value(self) }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 extension UInt8: ValueConvertible {
   /// Converts the `UInt8` into a `Value`.
   public func asValue() -> Value { Value(NSNumber(value: Int(self))) }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 extension Int8: ValueConvertible {
   /// Converts the `Int8` into a `Value`.
   public func asValue() -> Value { Value(NSNumber(value: Int(self))) }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 extension Int16: ValueConvertible {
   /// Converts the `Int16` into a `Value`.
   public func asValue() -> Value { Value(NSNumber(value: self)) }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 extension Int32: ValueConvertible {
   /// Converts the `Int32` into a `Value`.
   public func asValue() -> Value { Value(NSNumber(value: self)) }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 extension Int64: ValueConvertible {
   /// Converts the `Int64` into a `Value`.
   public func asValue() -> Value { Value(NSNumber(value: self)) }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 extension Int: ValueConvertible {
   /// Converts the `Int` into a `Value`.
   public func asValue() -> Value { Value(self) }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 extension Float: ValueConvertible {
   /// Converts the `Float` into a `Value`.
   public func asValue() -> Value { Value(self) }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 extension Double: ValueConvertible {
   /// Converts the `Double` into a `Value`.
   public func asValue() -> Value { Value(self) }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 extension Bool: ValueConvertible {
   /// Converts the `Bool` into a `Value`.
   public func asValue() -> Value { Value(self) }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 extension UInt16: ValueConvertible {
   /// Converts the `UInt16` into a `Value`.
   public func asValue() -> Value { Value(NSNumber(value: self)) }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 extension UInt32: ValueConvertible {
   /// Converts the `UInt32` into a `Value`.
   public func asValue() -> Value { Value(NSNumber(value: self)) }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 extension UInt64: ValueConvertible {
   /// Converts the `UInt64` into a `Value`.
   public func asValue() -> Value { Value(NSNumber(value: self)) }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 extension UInt: ValueConvertible {
   /// Converts the `UInt` into a `Value`.
   public func asValue() -> Value { Value(NSNumber(value: self)) }
@@ -191,14 +166,12 @@ extension UInt: ValueConvertible {
 
 // MARK: - ValueConstructible Conformances
 
-@available(*, deprecated, message: "This API is experimental.")
 extension Value: ValueConstructible, ValueSequenceConstructible {
   public static func from(_ value: Value) throws -> Self {
     value as! Self
   }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 extension AnyTensor: ValueConstructible, ValueSequenceConstructible {
   public static func from(_ value: Value) throws -> Self {
     guard let tensor = value.anyTensor else {
@@ -208,7 +181,6 @@ extension AnyTensor: ValueConstructible, ValueSequenceConstructible {
   }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 extension Tensor: ValueConstructible, ValueSequenceConstructible {
   public static func from(_ value: Value) throws -> Self {
     guard let anyTensor = value.anyTensor else {
@@ -221,7 +193,6 @@ extension Tensor: ValueConstructible, ValueSequenceConstructible {
   }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 extension String: ValueConstructible, ValueSequenceConstructible {
   public static func from(_ value: Value) throws -> Self {
     guard let string = value.string else {
@@ -231,7 +202,6 @@ extension String: ValueConstructible, ValueSequenceConstructible {
   }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 extension NSNumber: ValueConstructible, ValueSequenceConstructible {
   public static func from(_ value: Value) throws -> Self {
     guard let scalar = value.scalar as? Self else {
@@ -241,7 +211,6 @@ extension NSNumber: ValueConstructible, ValueSequenceConstructible {
   }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 extension UInt8: ValueConstructible, ValueSequenceConstructible {
   public static func from(_ value: Value) throws -> Self {
     guard let scalar = value.scalar else {
@@ -254,7 +223,6 @@ extension UInt8: ValueConstructible, ValueSequenceConstructible {
   }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 extension Int8: ValueConstructible, ValueSequenceConstructible {
   public static func from(_ value: Value) throws -> Self {
     guard let scalar = value.scalar else {
@@ -267,7 +235,6 @@ extension Int8: ValueConstructible, ValueSequenceConstructible {
   }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 extension Int16: ValueConstructible, ValueSequenceConstructible {
   public static func from(_ value: Value) throws -> Self {
     guard let scalar = value.scalar else {
@@ -280,7 +247,6 @@ extension Int16: ValueConstructible, ValueSequenceConstructible {
   }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 extension Int32: ValueConstructible, ValueSequenceConstructible {
   public static func from(_ value: Value) throws -> Self {
     guard let scalar = value.scalar else {
@@ -293,7 +259,6 @@ extension Int32: ValueConstructible, ValueSequenceConstructible {
   }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 extension Int64: ValueConstructible, ValueSequenceConstructible {
   public static func from(_ value: Value) throws -> Self {
     guard let scalar = value.scalar else {
@@ -306,7 +271,6 @@ extension Int64: ValueConstructible, ValueSequenceConstructible {
   }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 extension Int: ValueConstructible, ValueSequenceConstructible {
   public static func from(_ value: Value) throws -> Self {
     guard let scalar = value.scalar else {
@@ -319,7 +283,6 @@ extension Int: ValueConstructible, ValueSequenceConstructible {
   }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 extension Float: ValueConstructible, ValueSequenceConstructible {
   public static func from(_ value: Value) throws -> Self {
     guard value.isFloat else {
@@ -329,7 +292,6 @@ extension Float: ValueConstructible, ValueSequenceConstructible {
   }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 extension Double: ValueConstructible, ValueSequenceConstructible {
   public static func from(_ value: Value) throws -> Self {
     guard value.isDouble else {
@@ -339,7 +301,6 @@ extension Double: ValueConstructible, ValueSequenceConstructible {
   }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 extension Bool: ValueConstructible, ValueSequenceConstructible {
   public static func from(_ value: Value) throws -> Self {
     guard value.isBoolean else {
@@ -349,7 +310,6 @@ extension Bool: ValueConstructible, ValueSequenceConstructible {
   }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 extension UInt16: ValueConstructible, ValueSequenceConstructible {
   public static func from(_ value: Value) throws -> Self {
     guard let scalar = value.scalar else {
@@ -362,7 +322,6 @@ extension UInt16: ValueConstructible, ValueSequenceConstructible {
   }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 extension UInt32: ValueConstructible, ValueSequenceConstructible {
   public static func from(_ value: Value) throws -> Self {
     guard let scalar = value.scalar else {
@@ -375,7 +334,6 @@ extension UInt32: ValueConstructible, ValueSequenceConstructible {
   }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 extension UInt64: ValueConstructible, ValueSequenceConstructible {
   public static func from(_ value: Value) throws -> Self {
     guard let scalar = value.scalar else {
@@ -388,7 +346,6 @@ extension UInt64: ValueConstructible, ValueSequenceConstructible {
   }
 }
 
-@available(*, deprecated, message: "This API is experimental.")
 extension UInt: ValueConstructible, ValueSequenceConstructible {
   public static func from(_ value: Value) throws -> Self {
     guard let scalar = value.scalar else {
@@ -403,7 +360,6 @@ extension UInt: ValueConstructible, ValueSequenceConstructible {
 
 // MARK: - ValueSequenceConstructible Conformances
 
-@available(*, deprecated, message: "This API is experimental.")
 extension Array: ValueSequenceConstructible where Element: ValueConstructible {
   public static func from(_ values: [Value]) throws -> [Element] {
     return try values.map { try Element.from($0) }

--- a/extension/apple/ExecuTorch/Exported/ExecuTorchError.h
+++ b/extension/apple/ExecuTorch/Exported/ExecuTorchError.h
@@ -56,7 +56,7 @@ typedef NS_ERROR_ENUM(ExecuTorchErrorDomain, ExecuTorchErrorCode) {
  * @return An NSString containing the error description.
  */
 FOUNDATION_EXPORT
-__attribute__((deprecated("This API is experimental.")))
+NS_RETURNS_RETAINED
 NSString *ExecuTorchErrorDescription(ExecuTorchErrorCode code)
     NS_SWIFT_NAME(ErrorDescription(_:));
 
@@ -68,7 +68,6 @@ NSString *ExecuTorchErrorDescription(ExecuTorchErrorCode code)
  */
 FOUNDATION_EXPORT
 NS_RETURNS_RETAINED
-__attribute__((deprecated("This API is experimental.")))
 NSError *ExecuTorchErrorWithCode(ExecuTorchErrorCode code)
     NS_SWIFT_NAME(Error(code:));
 
@@ -81,7 +80,6 @@ NSError *ExecuTorchErrorWithCode(ExecuTorchErrorCode code)
  */
  FOUNDATION_EXPORT
  NS_RETURNS_RETAINED
- __attribute__((deprecated("This API is experimental.")))
  NSError *ExecuTorchErrorWithCodeAndDescription(ExecuTorchErrorCode code, NSString * __nullable description)
      NS_SWIFT_NAME(Error(code:description:));
 

--- a/extension/apple/ExecuTorch/Exported/ExecuTorchModule.h
+++ b/extension/apple/ExecuTorch/Exported/ExecuTorchModule.h
@@ -16,7 +16,6 @@ NS_ASSUME_NONNULL_BEGIN
  * and its debug name.
  */
 NS_SWIFT_NAME(TensorMetadata)
-__attribute__((deprecated("This API is experimental.")))
 @interface ExecuTorchTensorMetadata : NSObject
 
 /** The size of each dimension. */
@@ -47,7 +46,6 @@ __attribute__((deprecated("This API is experimental.")))
  * per-tensor metadata, buffer sizes, backends, and instruction count.
  */
 NS_SWIFT_NAME(MethodMetadata)
-__attribute__((deprecated("This API is experimental.")))
 @interface ExecuTorchMethodMetadata : NSObject
 
 /** The method’s name. */
@@ -120,7 +118,6 @@ typedef NS_ENUM(uint8_t, ExecuTorchVerification) {
  * This class is a facade for loading programs and executing methods within them.
  */
 NS_SWIFT_NAME(Module)
-__attribute__((deprecated("This API is experimental.")))
 @interface ExecuTorchModule : NSObject
 
 /**

--- a/extension/apple/ExecuTorch/Exported/ExecuTorchTensor.h
+++ b/extension/apple/ExecuTorch/Exported/ExecuTorchTensor.h
@@ -68,7 +68,6 @@ typedef NS_ENUM(uint8_t, ExecuTorchShapeDynamism) {
  * @return An NSInteger indicating the size in bytes.
  */
 FOUNDATION_EXPORT
-__attribute__((deprecated("This API is experimental.")))
 NSInteger ExecuTorchSizeOfDataType(ExecuTorchDataType dataType)
     NS_SWIFT_NAME(size(ofDataType:));
 
@@ -79,7 +78,6 @@ NSInteger ExecuTorchSizeOfDataType(ExecuTorchDataType dataType)
  * @return An NSInteger equal to the product of the sizes of all dimensions.
  */
 FOUNDATION_EXPORT
-__attribute__((deprecated("This API is experimental.")))
 NSInteger ExecuTorchElementCountOfShape(NSArray<NSNumber *> *shape)
     NS_REFINED_FOR_SWIFT;
 
@@ -90,7 +88,6 @@ NSInteger ExecuTorchElementCountOfShape(NSArray<NSNumber *> *shape)
  * initializers and utility methods to work with tensor data.
  */
  NS_SWIFT_NAME(AnyTensor)
-__attribute__((deprecated("This API is experimental.")))
 __attribute__((objc_subclassing_restricted))
 @interface ExecuTorchTensor : NSObject<NSCopying>
 

--- a/extension/apple/ExecuTorch/Exported/ExecuTorchValue.h
+++ b/extension/apple/ExecuTorch/Exported/ExecuTorchValue.h
@@ -43,7 +43,6 @@ typedef float ExecuTorchFloatValue
  * a tensor or a scalar. The value’s type is indicated by its tag.
  */
 NS_SWIFT_NAME(Value)
-__attribute__((deprecated("This API is experimental.")))
 __attribute__((objc_subclassing_restricted))
 @interface ExecuTorchValue : NSObject <NSCopying>
 


### PR DESCRIPTION
Summary: .

Differential Revision: D83283835


