### PR TITLE
aoti_torch__reinterpret_tensor

### DIFF
--- a/backends/aoti/utils.h
+++ b/backends/aoti/utils.h
@@ -73,6 +73,23 @@ inline AOTITorchError validate_storage_offset(int64_t storage_offset) {
   return Error::Ok;
 }
 
+// Check if tensor is in contiguous memory format (NCHW for 4D tensors)
+// Contiguous format means strides decrease from left to right:
+// For NCHW: strides = [C*H*W, H*W, W, 1]
+inline bool is_tensor_contiguous(
+    int64_t ndim,
+    const int64_t* sizes,
+    const int64_t* strides) {
+  int64_t expected_stride = 1;
+  for (int64_t i = ndim - 1; i >= 0; i--) {
+    if (strides[i] != expected_stride) {
+      return false;
+    }
+    expected_stride *= sizes[i];
+  }
+  return true;
+}
+
 } // extern "C"
 
 } // namespace aoti

--- a/backends/aoti/utils.h
+++ b/backends/aoti/utils.h
@@ -36,6 +36,8 @@ inline executorch::aten::ScalarType dtype_to_scalar_type(int32_t dtype) {
   switch (dtype) {
     case 6: // PyTorch's float32 dtype code
       return executorch::aten::ScalarType::Float;
+    case 15: // PyTorch's bfloat16 dtype code
+      return executorch::aten::ScalarType::BFloat16;
     // Future support for additional dtypes can be added here
     default:
       ET_LOG(Error, "Unsupported dtype: %d for ScalarType conversion", dtype);

--- a/backends/cuda/runtime/TARGETS
+++ b/backends/cuda/runtime/TARGETS
@@ -1,0 +1,32 @@
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+
+oncall("executorch")
+
+runtime.cxx_library(
+    name = "runtime_shims",
+    srcs = [
+        "shims/memory.cpp",
+        "shims/tensor_attribute.cpp",
+    ],
+    headers = [
+        "shims/memory.h",
+        "shims/tensor_attribute.h",
+        "shims/utils.h",
+    ],
+    # @lint-ignore BUCKLINT: Avoid `link_whole=True` (https://fburl.com/avoid-link-whole)
+    link_whole = True,
+    supports_python_dlopen = True,
+    # Constructor needed for backend registration.
+    compiler_flags = ["-Wno-global-constructors"],
+    visibility = ["@EXECUTORCH_CLIENTS"],
+    deps = [
+        "//executorch/backends/aoti:common_shims",
+        "//executorch/extension/tensor:tensor",
+        "//executorch/runtime/core:core",
+        "//executorch/runtime/core/exec_aten:lib",
+        "//executorch/runtime/platform:platform",
+    ],
+    external_deps = [
+        ("cuda", None, "cuda-lazy"),
+    ],
+)

--- a/backends/cuda/runtime/shims/memory.cpp
+++ b/backends/cuda/runtime/shims/memory.cpp
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/aoti/common_shims.h>
+#include <executorch/backends/aoti/utils.h>
+#include <executorch/backends/cuda/runtime/shims/memory.h>
+#include <executorch/backends/cuda/runtime/shims/tensor_attribute.h>
+#include <executorch/backends/cuda/runtime/shims/utils.h>
+#include <executorch/runtime/platform/log.h>
+#include <cstdint>
+#include <cstdlib> // For posix_memalign
+#include <memory>
+#include <unordered_set>
+#include <vector>
+
+// CUDA error checking macro
+#define ET_CUDA_CHECK_OR_RETURN_ERROR(EXPR) \
+  do {                                      \
+    const cudaError_t err = EXPR;           \
+    if (err == cudaSuccess) {               \
+      break;                                \
+    }                                       \
+    ET_LOG(                                 \
+        Error,                              \
+        "%s:%d CUDA error: %s",             \
+        __FILE__,                           \
+        __LINE__,                           \
+        cudaGetErrorString(err));           \
+    return Error::Internal;                 \
+  } while (0)
+
+// Kernel launch check macro
+#define ET_CUDA_KERNEL_LAUNCH_CHECK_OR_RETURN_ERROR() \
+  ET_CUDA_CHECK_OR_RETURN_ERROR(cudaGetLastError())
+
+namespace executorch {
+namespace backends {
+namespace cuda {
+
+using executorch::aten::SizesType;
+using executorch::aten::StridesType;
+using executorch::backends::aoti::dtype_to_element_size;
+using executorch::backends::aoti::dtype_to_scalar_type;
+
+// Global storage for tensors and their metadata
+std::unordered_set<std::shared_ptr<Tensor>> tensors;
+
+extern "C" {
+
+AOTITorchError aoti_torch_empty_strided(
+    int64_t ndim,
+    const int64_t* sizes_ptr,
+    const int64_t* strides_ptr,
+    int32_t dtype,
+    int32_t device_type,
+    int32_t device_index,
+    Tensor** ret_new_tensor) {
+  // Check that device_index is always 0
+  if (device_index != 0) {
+    ET_LOG(Error, "device_index must be 0, got: %d", device_index);
+    return Error::InvalidArgument;
+  }
+
+  // This requires us to reserve CUDA memory and put it into a ETensor
+  void* ptr;
+  int64_t numel = 1;
+  for (int64_t i = 0; i < ndim; i++) {
+    numel *= sizes_ptr[i];
+  }
+
+  AOTITorchError dtype_error = validate_dtype(dtype);
+  if (dtype_error != Error::Ok) {
+    return dtype_error;
+  }
+
+  size_t element_size = dtype_to_element_size(dtype);
+  if (element_size == 0) {
+    ET_LOG(Error, "Invalid element size for dtype: %d", dtype);
+    return Error::InvalidArgument;
+  }
+  int64_t nbytes = numel * element_size;
+
+  if (device_type == 1) { // cuda
+    ET_CUDA_CHECK_OR_RETURN_ERROR(cudaMallocManaged(&ptr, nbytes));
+  } else if (device_type == 0) { // cpu
+    // Ensure 16-byte alignment for CPU memory to match CUDA requirements
+    int result = posix_memalign(&ptr, 16, nbytes);
+    if (result != 0) {
+      ET_LOG(Error, "Failed to allocate aligned CPU memory");
+      return Error::MemoryAllocationFailed;
+    }
+    if (ptr == nullptr) {
+      ET_LOG(Error, "Failed to call posix_memalign");
+      return Error::MemoryAllocationFailed;
+    }
+  } else {
+    ET_LOG(
+        Error,
+        "Need to implement empty_strided for non-CUDA non-CPU device type %d",
+        device_type);
+    return Error::NotImplemented;
+  }
+
+  // ETensor sizes
+  auto sizes = convert_sizes_to_vector(ndim, sizes_ptr);
+
+  // ETensor strides
+  auto strides = convert_strides_to_vector(ndim, sizes_ptr, strides_ptr);
+
+  // ETensor creation with dynamic shape support for edge cases
+  auto tensor = executorch::extension::from_blob(
+      ptr, sizes, strides, dtype_to_scalar_type(dtype));
+
+  // Store the tensor so it doesn't get destroyed
+  tensors.insert(tensor);
+  *ret_new_tensor = tensor.get();
+
+  return Error::Ok;
+}
+
+// TODO(gasoonjia): reuse aoti_torch_delete_tensor_object to destory tensors
+void clear_all_tensors() {
+  tensors.clear();
+}
+
+} // extern "C"
+
+} // namespace cuda
+} // namespace backends
+} // namespace executorch

--- a/backends/cuda/runtime/shims/memory.cpp
+++ b/backends/cuda/runtime/shims/memory.cpp
@@ -15,28 +15,9 @@
 #include <cstdint>
 #include <cstdlib> // For posix_memalign
 #include <memory>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
-
-// CUDA error checking macro
-#define ET_CUDA_CHECK_OR_RETURN_ERROR(EXPR) \
-  do {                                      \
-    const cudaError_t err = EXPR;           \
-    if (err == cudaSuccess) {               \
-      break;                                \
-    }                                       \
-    ET_LOG(                                 \
-        Error,                              \
-        "%s:%d CUDA error: %s",             \
-        __FILE__,                           \
-        __LINE__,                           \
-        cudaGetErrorString(err));           \
-    return Error::Internal;                 \
-  } while (0)
-
-// Kernel launch check macro
-#define ET_CUDA_KERNEL_LAUNCH_CHECK_OR_RETURN_ERROR() \
-  ET_CUDA_CHECK_OR_RETURN_ERROR(cudaGetLastError())
 
 namespace executorch {
 namespace backends {
@@ -46,11 +27,121 @@ using executorch::aten::SizesType;
 using executorch::aten::StridesType;
 using executorch::backends::aoti::dtype_to_element_size;
 using executorch::backends::aoti::dtype_to_scalar_type;
+using executorch::backends::aoti::validate_storage_offset;
 
 // Global storage for tensors and their metadata
 std::unordered_set<std::shared_ptr<Tensor>> tensors;
 
+// Reference counting for memory addresses
+// Maps memory address to number of tensors using it
+// Special value: NOT_OWN (-1) means tensor never owns the memory
+constexpr int32_t NOT_OWN = -1;
+std::unordered_map<void*, int32_t> memory_to_n_tensor;
+
 extern "C" {
+
+AOTITorchError aoti_torch_create_tensor_from_blob_v2(
+    void* data,
+    int64_t ndim,
+    const int64_t* sizes_ptr,
+    const int64_t* strides_ptr,
+    int64_t storage_offset,
+    int32_t dtype,
+    int32_t device_type,
+    int32_t device_index,
+    Tensor** ret_new_tensor,
+    int32_t layout,
+    const uint8_t* opaque_metadata,
+    int64_t opaque_metadata_size) {
+  // TODO(gasoonjia): verify given data is on the target device
+  (void)device_type;
+  (void)opaque_metadata;
+  (void)layout;
+  (void)opaque_metadata_size;
+
+  // Validate input parameters first
+  if (data == nullptr) {
+    ET_LOG(
+        Error,
+        "aoti_torch_create_tensor_from_blob_v2 failed: data pointer is null");
+    return Error::InvalidArgument;
+  }
+
+  if (sizes_ptr == nullptr && ndim > 0) {
+    ET_LOG(
+        Error,
+        "aoti_torch_create_tensor_from_blob_v2 failed: sizes_ptr is null");
+    return Error::InvalidArgument;
+  }
+
+  if (ret_new_tensor == nullptr) {
+    ET_LOG(
+        Error,
+        "aoti_torch_create_tensor_from_blob_v2 failed: ret_new_tensor is null");
+    return Error::InvalidArgument;
+  }
+
+  // Check that device_index is always 0
+  if (device_index != 0) {
+    ET_LOG(Error, "device_index must be 0, got: %d", device_index);
+    return Error::InvalidArgument;
+  }
+
+  // Validate dtype using SupportedDTypes from utils.h
+  AOTITorchError dtype_error = validate_dtype(dtype);
+  if (dtype_error != Error::Ok) {
+    return dtype_error;
+  }
+
+  // Storage offset must be 0 since from_blob cannot handle different offsets
+  AOTITorchError storage_offset_error = validate_storage_offset(storage_offset);
+  if (storage_offset_error != Error::Ok) {
+    return storage_offset_error;
+  }
+
+  // Convert sizes to the format expected by ExecutorTorch using SizesType
+  std::vector<executorch::aten::SizesType> sizes =
+      convert_sizes_to_vector(ndim, sizes_ptr);
+
+  // Convert strides using the common helper function with StridesType
+  std::vector<executorch::aten::StridesType> strides =
+      convert_strides_to_vector(ndim, sizes_ptr, strides_ptr);
+
+  // Create ExecutorTorch tensor that wraps the existing memory
+  // Note: We're NOT copying the data, just wrapping it
+  auto tensor = executorch::extension::from_blob(
+      data, // existing memory (don't copy!)
+      sizes, // tensor dimensions
+      strides, // tensor strides (allows different strides)
+      dtype_to_scalar_type(dtype) // map int32_t dtype to ScalarType
+  );
+
+  if (!tensor) {
+    ET_LOG(Error, "Failed to create tensor from blob");
+    return Error::InvalidArgument;
+  }
+
+  // Store the tensor so it doesn't get destroyed
+  tensors.insert(tensor);
+
+  *ret_new_tensor = tensor.get();
+
+  // Check if this memory address is already being tracked
+  auto memory_it = memory_to_n_tensor.find(data);
+  if (memory_it != memory_to_n_tensor.end()) {
+    ET_LOG(
+        Error,
+        "Memory address %p is already being tracked by another tensor",
+        data);
+    return Error::InvalidArgument;
+  }
+
+  // Mark this memory as NOT_OWN since tensor created from blob never owns
+  // memory
+  memory_to_n_tensor[data] = NOT_OWN;
+
+  return Error::Ok;
+}
 
 AOTITorchError aoti_torch_empty_strided(
     int64_t ndim,
@@ -120,6 +211,9 @@ AOTITorchError aoti_torch_empty_strided(
   tensors.insert(tensor);
   *ret_new_tensor = tensor.get();
 
+  // This tensor owns the memory it allocated, set reference count to 1
+  memory_to_n_tensor[ptr] = 1;
+
   return Error::Ok;
 }
 
@@ -164,26 +258,47 @@ AOTITorchError aoti_torch_delete_tensor_object(Tensor* tensor) {
     if (it->get() == tensor) {
       // Get the tensor before erasing
       auto tensor_ptr = *it;
-
       void* data_ptr = tensor_ptr->mutable_data_ptr();
 
-      // Determine if it's GPU memory
-      cudaPointerAttributes attributes{};
-      ET_CUDA_CHECK_OR_RETURN_ERROR(
-          cudaPointerGetAttributes(&attributes, data_ptr));
+      // Find the reference count for this memory address
+      auto memory_it = memory_to_n_tensor.find(data_ptr);
+      if (memory_it != memory_to_n_tensor.end()) {
+        int32_t ref_count = memory_it->second;
 
-      // et tensor does not own data; need to free them manually.
-      if (attributes.type == cudaMemoryTypeManaged) {
-        // This is CUDA managed memory - free with proper synchronization
-        ET_CUDA_CHECK_OR_RETURN_ERROR(
-            cudaDeviceSynchronize()); // Wait for all operations to complete
-                                      // BEFORE freeing
-        ET_CUDA_CHECK_OR_RETURN_ERROR(cudaFree(data_ptr));
+        if (ref_count == NOT_OWN) {
+          // Tensor never owned the memory, skip freeing
+          // Just remove tensor from tracking
+          tensors.erase(it);
+          return Error::Ok;
+        } else if (ref_count == 1) {
+          // Only current tensor using this memory, free it
+          // Determine if it's GPU memory
+          cudaPointerAttributes attributes{};
+          ET_CUDA_CHECK_OR_RETURN_ERROR(
+              cudaPointerGetAttributes(&attributes, data_ptr));
+
+          if (attributes.type == cudaMemoryTypeManaged) {
+            // This is CUDA managed memory - free with proper synchronization
+            ET_CUDA_CHECK_OR_RETURN_ERROR(cudaDeviceSynchronize());
+            ET_CUDA_CHECK_OR_RETURN_ERROR(cudaFree(data_ptr));
+          } else {
+            // This is CPU memory - free immediately
+            free(data_ptr);
+            data_ptr = nullptr;
+          }
+
+          // Remove from memory tracking
+          memory_to_n_tensor.erase(memory_it);
+        } else if (ref_count > 1) {
+          // Other tensors still using this memory, just decrement count
+          memory_to_n_tensor[data_ptr] = ref_count - 1;
+        }
       } else {
-        // This is CPU memory - free immediately
-        free(data_ptr);
+        ET_LOG(Error, "Internal error: memory not found during deletion");
+        return Error::Internal;
       }
-      // Remove from set (this will call the destructor if it's the last
+
+      // Remove tensor from set (this will call the destructor if it's the last
       // reference)
       tensors.erase(it);
       return Error::Ok;

--- a/backends/cuda/runtime/shims/memory.h
+++ b/backends/cuda/runtime/shims/memory.h
@@ -44,8 +44,16 @@ AOTITorchError aoti_torch_empty_strided(
     int32_t device_index,
     Tensor** ret_new_tensor);
 
+/**
+ * Deletes a tensor object and frees its associated memory.
+ *
+ * @param tensor Pointer to the tensor object to be deleted
+ * @return AOTITorchError error code (Error::Ok on success, or an error code on
+ * failure)
+ */
+AOTITorchError aoti_torch_delete_tensor_object(Tensor* tensor);
+
 // Function to clear all tensors from internal storage
-// TODO(gasoonjia): reuse aoti_torch_delete_tensor_object to destory tensors
 void clear_all_tensors();
 
 } // extern "C"

--- a/backends/cuda/runtime/shims/memory.h
+++ b/backends/cuda/runtime/shims/memory.h
@@ -91,6 +91,31 @@ AOTITorchError aoti_torch_empty_strided(
  */
 AOTITorchError aoti_torch_delete_tensor_object(Tensor* tensor);
 
+/**
+ * Creates a tensor view that reinterprets the same underlying memory with
+ * different shape and strides without copying data.
+ *
+ * Note that the new tensor will not have the ownership of the underlying
+ * memory.
+ *
+ * @param self Input tensor whose memory will be reinterpreted
+ * @param ndim Number of dimensions for the new tensor view
+ * @param sizes_ptr Array of sizes for each dimension
+ * @param strides_ptr Array of strides for each dimension (or nullptr for
+ * contiguous)
+ * @param storage_offset Storage offset (must be 0)
+ * @param ret_new_tensor Output pointer to store the new tensor view
+ *
+ * @return Error::Ok on success, appropriate error code on failure
+ */
+AOTITorchError aoti_torch__reinterpret_tensor(
+    Tensor* self,
+    int64_t ndim,
+    const int64_t* sizes_ptr,
+    const int64_t* strides_ptr,
+    int64_t storage_offset,
+    Tensor** ret_new_tensor);
+
 // Function to clear all tensors from internal storage
 void clear_all_tensors();
 } // extern "C"

--- a/backends/cuda/runtime/shims/memory.h
+++ b/backends/cuda/runtime/shims/memory.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cuda_runtime.h>
+#include <executorch/backends/aoti/common_shims.h>
+#include <cstdint>
+
+namespace executorch {
+namespace backends {
+namespace cuda {
+
+using executorch::backends::aoti::AOTITorchError;
+using executorch::backends::aoti::Tensor;
+
+extern "C" {
+
+/**
+ * Creates an uninitialized tensor with specified dimensions, strides, and
+ * dtyper on either CPU or CUDA device.
+ *
+ * @param ndim Number of dimensions in the tensor
+ * @param sizes_ptr Pointer to array of dimension sizes
+ * @param strides_ptr Pointer to array of strides for each dimension
+ * @param dtype Data type identifier (matches PyTorch scalar types)
+ * @param device_type Device type (0=CPU, 1=CUDA)
+ * @param device_index Device index (must be 0 for current implementation)
+ * @param ret_new_tensor Output parameter for the created tensor
+ * @return AOTITorchError error code (Error::Ok on success, or an error code on
+ * failure)
+ */
+AOTITorchError aoti_torch_empty_strided(
+    int64_t ndim,
+    const int64_t* sizes_ptr,
+    const int64_t* strides_ptr,
+    int32_t dtype,
+    int32_t device_type,
+    int32_t device_index,
+    Tensor** ret_new_tensor);
+
+// Function to clear all tensors from internal storage
+// TODO(gasoonjia): reuse aoti_torch_delete_tensor_object to destory tensors
+void clear_all_tensors();
+
+} // extern "C"
+
+} // namespace cuda
+} // namespace backends
+} // namespace executorch

--- a/backends/cuda/runtime/shims/memory.h
+++ b/backends/cuda/runtime/shims/memory.h
@@ -22,6 +22,44 @@ using executorch::backends::aoti::Tensor;
 extern "C" {
 
 /**
+ * Creates a tensor object from an existing memory blob without copying the
+ * data. The tensor will wrap the provided memory and will not take ownership of
+ * it. When the tensor is deleted, the original memory will remain valid and
+ * must be freed by the caller.
+ *
+ * @param data Pointer to the memory blob to wrap (must not be null)
+ * @param ndim Number of dimensions in the tensor
+ * @param sizes_ptr Pointer to array of dimension sizes (using SizesType)
+ * @param strides_ptr Pointer to array of strides for each dimension (using
+ * StridesType, can be null for contiguous)
+ * @param storage_offset Storage offset (must be 0 for current implementation)
+ * @param dtype Data type identifier (supports FLOAT32 and BFLOAT16 from
+ * SupportedDTypes)
+ * @param device_type Device type (CPU=0, CUDA=1 from SupportedDevices)
+ * @param device_index Device index (must be 0 for current implementation)
+ * @param ret_new_tensor Output parameter for the created tensor (must not be
+ * null)
+ * @param layout Tensor layout identifier (0=strided)
+ * @param opaque_metadata Optional metadata pointer (can be null)
+ * @param opaque_metadata_size Size of opaque metadata in bytes
+ * @return AOTITorchError error code (Error::Ok on success, or an error code on
+ * failure)
+ */
+AOTITorchError aoti_torch_create_tensor_from_blob_v2(
+    void* data,
+    int64_t ndim,
+    const int64_t* sizes_ptr,
+    const int64_t* strides_ptr,
+    int64_t storage_offset,
+    int32_t dtype,
+    int32_t device_type,
+    int32_t device_index,
+    Tensor** ret_new_tensor,
+    int32_t layout,
+    const uint8_t* opaque_metadata,
+    int64_t opaque_metadata_size);
+
+/**
  * Creates an uninitialized tensor with specified dimensions, strides, and
  * dtyper on either CPU or CUDA device.
  *
@@ -55,7 +93,6 @@ AOTITorchError aoti_torch_delete_tensor_object(Tensor* tensor);
 
 // Function to clear all tensors from internal storage
 void clear_all_tensors();
-
 } // extern "C"
 
 } // namespace cuda

--- a/backends/cuda/runtime/shims/tests/TARGETS
+++ b/backends/cuda/runtime/shims/tests/TARGETS
@@ -1,0 +1,6 @@
+load("@fbcode_macros//build_defs:cpp_unittest.bzl", "cpp_unittest")
+load(":targets.bzl", "define_common_targets")
+
+oncall("executorch")
+
+define_common_targets()

--- a/backends/cuda/runtime/shims/tests/targets.bzl
+++ b/backends/cuda/runtime/shims/tests/targets.bzl
@@ -30,3 +30,4 @@ def define_common_targets():
     cuda_shim_cpp_unittest("aoti_torch_empty_strided")
     cuda_shim_cpp_unittest("aoti_torch_delete_tensor_object")
     cuda_shim_cpp_unittest("aoti_torch_create_tensor_from_blob_v2")
+    cuda_shim_cpp_unittest("aoti_torch__reinterpret_tensor")

--- a/backends/cuda/runtime/shims/tests/targets.bzl
+++ b/backends/cuda/runtime/shims/tests/targets.bzl
@@ -29,3 +29,4 @@ def define_common_targets():
     """
     cuda_shim_cpp_unittest("aoti_torch_empty_strided")
     cuda_shim_cpp_unittest("aoti_torch_delete_tensor_object")
+    cuda_shim_cpp_unittest("aoti_torch_create_tensor_from_blob_v2")

--- a/backends/cuda/runtime/shims/tests/targets.bzl
+++ b/backends/cuda/runtime/shims/tests/targets.bzl
@@ -28,3 +28,4 @@ def define_common_targets():
     TARGETS and BUCK files that call this function.
     """
     cuda_shim_cpp_unittest("aoti_torch_empty_strided")
+    cuda_shim_cpp_unittest("aoti_torch_delete_tensor_object")

--- a/backends/cuda/runtime/shims/tests/targets.bzl
+++ b/backends/cuda/runtime/shims/tests/targets.bzl
@@ -1,0 +1,30 @@
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+load("@fbcode_macros//build_defs:cpp_unittest.bzl", "cpp_unittest")
+load("@fbcode_macros//build_defs/lib:re_test_utils.bzl", "re_test_utils")
+
+def cuda_shim_cpp_unittest(name):
+    cpp_unittest(
+        name = "test_" + name,
+        srcs = [
+            "test_" + name + ".cpp",
+        ],
+        deps = [
+            "//executorch/backends/aoti:common_shims",
+            "//executorch/backends/cuda/runtime:runtime_shims",
+            "//executorch/extension/tensor:tensor",
+            "//executorch/runtime/core:core",
+            "//executorch/runtime/platform:platform",
+            "//executorch/runtime/core/exec_aten:lib",
+        ],
+        external_deps = [
+            ("cuda", None, "cuda-lazy"),
+        ],
+    )
+
+def define_common_targets():
+    """Defines targets that should be shared between fbcode and xplat.
+
+    The directory containing this targets.bzl file should also contain both
+    TARGETS and BUCK files that call this function.
+    """
+    cuda_shim_cpp_unittest("aoti_torch_empty_strided")

--- a/backends/cuda/runtime/shims/tests/test_aoti_torch__reinterpret_tensor.cpp
+++ b/backends/cuda/runtime/shims/tests/test_aoti_torch__reinterpret_tensor.cpp
@@ -1,0 +1,810 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <cuda_runtime.h>
+#include <executorch/backends/aoti/common_shims.h>
+#include <executorch/backends/cuda/runtime/shims/memory.h>
+#include <executorch/backends/cuda/runtime/shims/tensor_attribute.h>
+#include <executorch/backends/cuda/runtime/shims/utils.h>
+#include <executorch/runtime/core/error.h>
+#include <executorch/runtime/platform/platform.h>
+#include <gtest/gtest.h>
+#include <vector>
+
+using namespace executorch::backends::aoti;
+using namespace executorch::backends::cuda;
+using namespace executorch::runtime;
+using executorch::runtime::etensor::Tensor;
+
+// Test fixture for aoti_torch__reinterpret_tensor tests
+class AOTITorchReinterpretTensorTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // Initialize ExecuTorch Platform Abstraction Layer
+    et_pal_init();
+
+    // Check if CUDA is available
+    int device_count = 0;
+    cudaError_t err = cudaGetDeviceCount(&device_count);
+    if (err != cudaSuccess || device_count == 0) {
+      GTEST_SKIP() << "CUDA not available, skipping CUDA tests";
+    }
+
+    // Clean up any existing cached metadata before each test
+    cleanup_tensor_metadata();
+
+    // Clear any remaining tensors from previous tests
+    clear_all_tensors();
+  }
+
+  void TearDown() override {
+    // Clean up metadata
+    cleanup_tensor_metadata();
+
+    // Clear the global tensor storage using the provided function
+    clear_all_tensors();
+  }
+
+  // Helper to calculate number of elements from sizes
+  int64_t calculate_numel(const std::vector<int64_t>& sizes) {
+    int64_t numel = 1;
+    for (int64_t size : sizes) {
+      numel *= size;
+    }
+    return numel;
+  }
+
+  // Helper to calculate contiguous strides from sizes
+  std::vector<int64_t> calculate_contiguous_strides(
+      const std::vector<int64_t>& sizes) {
+    std::vector<int64_t> strides(sizes.size());
+    if (sizes.empty()) {
+      return strides;
+    }
+
+    strides[sizes.size() - 1] = 1;
+    for (int64_t i = static_cast<int64_t>(sizes.size()) - 2; i >= 0; i--) {
+      strides[i] = strides[i + 1] * sizes[i + 1];
+    }
+    return strides;
+  }
+
+  // Helper to create a source tensor using empty_strided (which allocates new
+  // memory)
+  Tensor* create_source_tensor(
+      const std::vector<int64_t>& sizes,
+      int32_t dtype = 6, // float32
+      int32_t device_type = 1, // CUDA
+      int32_t device_index = 0) {
+    std::vector<int64_t> strides = calculate_contiguous_strides(sizes);
+
+    Tensor* tensor;
+    AOTITorchError error = aoti_torch_empty_strided(
+        sizes.size(),
+        sizes.data(),
+        strides.data(),
+        dtype,
+        device_type,
+        device_index,
+        &tensor);
+
+    if (error != Error::Ok) {
+      return nullptr;
+    }
+
+    return tensor;
+  }
+
+ private:
+  std::vector<void*> cuda_memory_buffers_;
+  std::vector<void*> cpu_memory_buffers_;
+};
+
+// Test basic functionality: reinterpret tensor with different shapes
+TEST_F(AOTITorchReinterpretTensorTest, BasicReinterpretation) {
+  // Create a source tensor with shape [12] (1D with 12 elements)
+  std::vector<int64_t> source_sizes = {12};
+  Tensor* source_tensor = create_source_tensor(source_sizes);
+  ASSERT_NE(source_tensor, nullptr);
+
+  // Store the original data pointer
+  void* original_data_ptr = source_tensor->mutable_data_ptr();
+  ASSERT_NE(original_data_ptr, nullptr);
+
+  // Reinterpret as [3, 4] (2D with same number of elements)
+  std::vector<int64_t> new_sizes = {3, 4};
+  std::vector<int64_t> new_strides = calculate_contiguous_strides(new_sizes);
+
+  Tensor* reinterpreted_tensor;
+  AOTITorchError error = aoti_torch__reinterpret_tensor(
+      source_tensor,
+      new_sizes.size(),
+      new_sizes.data(),
+      new_strides.data(),
+      0, // storage_offset
+      &reinterpreted_tensor);
+
+  EXPECT_EQ(error, Error::Ok);
+  ASSERT_NE(reinterpreted_tensor, nullptr);
+
+  // Check that the reinterpreted tensor has the new shape
+  EXPECT_EQ(reinterpreted_tensor->dim(), 2);
+  EXPECT_EQ(reinterpreted_tensor->size(0), 3);
+  EXPECT_EQ(reinterpreted_tensor->size(1), 4);
+
+  // CRITICAL: Check that the reinterpreted tensor uses the SAME memory
+  void* reinterpreted_data_ptr = reinterpreted_tensor->mutable_data_ptr();
+  EXPECT_EQ(reinterpreted_data_ptr, original_data_ptr)
+      << "Reinterpreted tensor should use the same memory as the source tensor";
+
+  // Write data through the original tensor and verify it's visible through the
+  // reinterpreted tensor
+  std::vector<float> test_data = {
+      1.0f,
+      2.0f,
+      3.0f,
+      4.0f,
+      5.0f,
+      6.0f,
+      7.0f,
+      8.0f,
+      9.0f,
+      10.0f,
+      11.0f,
+      12.0f};
+  cudaError_t cuda_err = cudaMemcpy(
+      original_data_ptr,
+      test_data.data(),
+      test_data.size() * sizeof(float),
+      cudaMemcpyHostToDevice);
+  EXPECT_EQ(cuda_err, cudaSuccess);
+
+  // Read back through the reinterpreted tensor
+  std::vector<float> readback_data(12);
+  cuda_err = cudaMemcpy(
+      readback_data.data(),
+      reinterpreted_data_ptr,
+      readback_data.size() * sizeof(float),
+      cudaMemcpyDeviceToHost);
+  EXPECT_EQ(cuda_err, cudaSuccess);
+
+  // Verify the data matches
+  for (size_t i = 0; i < test_data.size(); i++) {
+    EXPECT_EQ(readback_data[i], test_data[i])
+        << "Data should be the same through both tensors at index " << i;
+  }
+}
+
+// Test reinterpreting with different strides
+TEST_F(AOTITorchReinterpretTensorTest, ReinterpretWithCustomStrides) {
+  // Create a source tensor with shape [2, 6] (contiguous)
+  std::vector<int64_t> source_sizes = {2, 6};
+  Tensor* source_tensor = create_source_tensor(source_sizes);
+  ASSERT_NE(source_tensor, nullptr);
+
+  void* original_data_ptr = source_tensor->mutable_data_ptr();
+  ASSERT_NE(original_data_ptr, nullptr);
+
+  // Reinterpret as [3, 4] with custom strides (still valid for the same memory)
+  std::vector<int64_t> new_sizes = {3, 4};
+  std::vector<int64_t> new_strides = {4, 1}; // Row-major strides for [3, 4]
+
+  Tensor* reinterpreted_tensor;
+  AOTITorchError error = aoti_torch__reinterpret_tensor(
+      source_tensor,
+      new_sizes.size(),
+      new_sizes.data(),
+      new_strides.data(),
+      0, // storage_offset
+      &reinterpreted_tensor);
+
+  EXPECT_EQ(error, Error::Ok);
+  ASSERT_NE(reinterpreted_tensor, nullptr);
+
+  // Check shape
+  EXPECT_EQ(reinterpreted_tensor->dim(), 2);
+  EXPECT_EQ(reinterpreted_tensor->size(0), 3);
+  EXPECT_EQ(reinterpreted_tensor->size(1), 4);
+
+  // CRITICAL: Check that the reinterpreted tensor uses the SAME memory
+  void* reinterpreted_data_ptr = reinterpreted_tensor->mutable_data_ptr();
+  EXPECT_EQ(reinterpreted_data_ptr, original_data_ptr)
+      << "Reinterpreted tensor should use the same memory as the source tensor";
+
+  // Verify strides were set correctly
+  int64_t* tensor_strides;
+  error = aoti_torch_get_strides(reinterpreted_tensor, &tensor_strides);
+  EXPECT_EQ(error, Error::Ok);
+  EXPECT_EQ(tensor_strides[0], 4);
+  EXPECT_EQ(tensor_strides[1], 1);
+}
+
+// Test error cases: null input tensor
+TEST_F(AOTITorchReinterpretTensorTest, NullInputTensor) {
+  std::vector<int64_t> new_sizes = {2, 3};
+  std::vector<int64_t> new_strides = calculate_contiguous_strides(new_sizes);
+
+  Tensor* reinterpreted_tensor;
+  AOTITorchError error = aoti_torch__reinterpret_tensor(
+      nullptr, // null input tensor
+      new_sizes.size(),
+      new_sizes.data(),
+      new_strides.data(),
+      0, // storage_offset
+      &reinterpreted_tensor);
+
+  EXPECT_EQ(error, Error::InvalidArgument);
+}
+
+// Test error cases: null sizes pointer
+TEST_F(AOTITorchReinterpretTensorTest, NullSizesPointer) {
+  std::vector<int64_t> source_sizes = {6};
+  Tensor* source_tensor = create_source_tensor(source_sizes);
+  ASSERT_NE(source_tensor, nullptr);
+
+  std::vector<int64_t> new_strides = {2, 1};
+
+  Tensor* reinterpreted_tensor;
+  AOTITorchError error = aoti_torch__reinterpret_tensor(
+      source_tensor,
+      2, // ndim > 0
+      nullptr, // null sizes pointer
+      new_strides.data(),
+      0, // storage_offset
+      &reinterpreted_tensor);
+
+  EXPECT_EQ(error, Error::InvalidArgument);
+}
+
+// Test error cases: null return tensor pointer
+TEST_F(AOTITorchReinterpretTensorTest, NullReturnTensorPointer) {
+  std::vector<int64_t> source_sizes = {6};
+  Tensor* source_tensor = create_source_tensor(source_sizes);
+  ASSERT_NE(source_tensor, nullptr);
+
+  std::vector<int64_t> new_sizes = {2, 3};
+  std::vector<int64_t> new_strides = calculate_contiguous_strides(new_sizes);
+
+  AOTITorchError error = aoti_torch__reinterpret_tensor(
+      source_tensor,
+      new_sizes.size(),
+      new_sizes.data(),
+      new_strides.data(),
+      0, // storage_offset
+      nullptr); // null return tensor pointer
+
+  EXPECT_EQ(error, Error::InvalidArgument);
+}
+
+// Test error cases: non-zero storage offset (should fail)
+TEST_F(AOTITorchReinterpretTensorTest, NonZeroStorageOffset) {
+  std::vector<int64_t> source_sizes = {6};
+  Tensor* source_tensor = create_source_tensor(source_sizes);
+  ASSERT_NE(source_tensor, nullptr);
+
+  std::vector<int64_t> new_sizes = {2, 3};
+  std::vector<int64_t> new_strides = calculate_contiguous_strides(new_sizes);
+
+  Tensor* reinterpreted_tensor;
+  AOTITorchError error = aoti_torch__reinterpret_tensor(
+      source_tensor,
+      new_sizes.size(),
+      new_sizes.data(),
+      new_strides.data(),
+      1, // non-zero storage_offset (should fail)
+      &reinterpreted_tensor);
+
+  EXPECT_EQ(error, Error::InvalidArgument);
+}
+
+// Test reinterpreting CPU tensor
+TEST_F(AOTITorchReinterpretTensorTest, ReinterpretCPUTensor) {
+  // Create a CPU tensor with shape [8]
+  std::vector<int64_t> source_sizes = {8};
+  Tensor* source_tensor = create_source_tensor(
+      source_sizes,
+      6, // float32
+      0, // CPU device
+      0);
+  ASSERT_NE(source_tensor, nullptr);
+
+  void* original_data_ptr = source_tensor->mutable_data_ptr();
+  ASSERT_NE(original_data_ptr, nullptr);
+
+  // Reinterpret as [2, 4]
+  std::vector<int64_t> new_sizes = {2, 4};
+  std::vector<int64_t> new_strides = calculate_contiguous_strides(new_sizes);
+
+  Tensor* reinterpreted_tensor;
+  AOTITorchError error = aoti_torch__reinterpret_tensor(
+      source_tensor,
+      new_sizes.size(),
+      new_sizes.data(),
+      new_strides.data(),
+      0, // storage_offset
+      &reinterpreted_tensor);
+
+  EXPECT_EQ(error, Error::Ok);
+  ASSERT_NE(reinterpreted_tensor, nullptr);
+
+  // Check that the reinterpreted tensor uses the SAME memory
+  void* reinterpreted_data_ptr = reinterpreted_tensor->mutable_data_ptr();
+  EXPECT_EQ(reinterpreted_data_ptr, original_data_ptr)
+      << "Reinterpreted CPU tensor should use the same memory as the source tensor";
+
+  // Test direct memory access for CPU tensors
+  float* original_float_ptr = reinterpret_cast<float*>(original_data_ptr);
+  float* reinterpreted_float_ptr =
+      reinterpret_cast<float*>(reinterpreted_data_ptr);
+
+  // Write through original and read through reinterpreted
+  original_float_ptr[0] = 42.0f;
+  EXPECT_EQ(reinterpreted_float_ptr[0], 42.0f)
+      << "Changes through original tensor should be visible through reinterpreted tensor";
+}
+
+// Test that deleting source tensor doesn't affect reinterpreted tensor (they
+// share memory)
+TEST_F(AOTITorchReinterpretTensorTest, DeletionBehavior) {
+  std::vector<int64_t> source_sizes = {6};
+  Tensor* source_tensor = create_source_tensor(source_sizes);
+  ASSERT_NE(source_tensor, nullptr);
+
+  void* shared_data_ptr = source_tensor->mutable_data_ptr();
+
+  // Reinterpret as [2, 3]
+  std::vector<int64_t> new_sizes = {2, 3};
+  std::vector<int64_t> new_strides = calculate_contiguous_strides(new_sizes);
+
+  Tensor* reinterpreted_tensor;
+  AOTITorchError error = aoti_torch__reinterpret_tensor(
+      source_tensor,
+      new_sizes.size(),
+      new_sizes.data(),
+      new_strides.data(),
+      0,
+      &reinterpreted_tensor);
+
+  EXPECT_EQ(error, Error::Ok);
+  ASSERT_NE(reinterpreted_tensor, nullptr);
+
+  // Verify they share the same memory
+  EXPECT_EQ(reinterpreted_tensor->mutable_data_ptr(), shared_data_ptr);
+
+  // Delete the source tensor (which owns the memory)
+  error = aoti_torch_delete_tensor_object(source_tensor);
+  EXPECT_EQ(error, Error::Ok);
+
+  // The reinterpreted tensor should still be valid but the memory might be
+  // freed Since the source tensor owned the memory, the reinterpreted tensor
+  // becomes invalid This is expected behavior - the user needs to manage the
+  // lifecycle properly
+
+  // Clean up the reinterpreted tensor
+  error = aoti_torch_delete_tensor_object(reinterpreted_tensor);
+  EXPECT_EQ(error, Error::Ok);
+}
+
+// Test scalar tensor reinterpretation
+TEST_F(AOTITorchReinterpretTensorTest, ReinterpretScalarTensor) {
+  // Create a scalar tensor (0D)
+  std::vector<int64_t> source_sizes = {};
+  Tensor* source_tensor = create_source_tensor(source_sizes);
+  ASSERT_NE(source_tensor, nullptr);
+
+  void* original_data_ptr = source_tensor->mutable_data_ptr();
+
+  // Try to reinterpret scalar as [1] (1D with 1 element)
+  std::vector<int64_t> new_sizes = {1};
+  std::vector<int64_t> new_strides = {1};
+
+  Tensor* reinterpreted_tensor;
+  AOTITorchError error = aoti_torch__reinterpret_tensor(
+      source_tensor,
+      new_sizes.size(),
+      new_sizes.data(),
+      new_strides.data(),
+      0,
+      &reinterpreted_tensor);
+
+  EXPECT_EQ(error, Error::Ok);
+  ASSERT_NE(reinterpreted_tensor, nullptr);
+
+  // Check that the reinterpreted tensor uses the SAME memory
+  EXPECT_EQ(reinterpreted_tensor->mutable_data_ptr(), original_data_ptr);
+
+  // Check new shape
+  EXPECT_EQ(reinterpreted_tensor->dim(), 1);
+  EXPECT_EQ(reinterpreted_tensor->size(0), 1);
+}
+
+// Test reinterpreting tensor with zero-sized dimension
+// TODO: This test is disabled because zero-sized tensors have complex stride
+// validation requirements that need further investigation
+TEST_F(AOTITorchReinterpretTensorTest, DISABLED_ReinterpretZeroSizedTensor) {
+  // Create a tensor with shape [0, 5] (zero elements)
+  std::vector<int64_t> source_sizes = {0, 5};
+  Tensor* source_tensor = create_source_tensor(source_sizes);
+  ASSERT_NE(source_tensor, nullptr);
+
+  void* original_data_ptr = source_tensor->mutable_data_ptr();
+
+  // Reinterpret as [5, 0] (still zero elements)
+  std::vector<int64_t> new_sizes = {5, 0};
+  std::vector<int64_t> new_strides = calculate_contiguous_strides(new_sizes);
+
+  Tensor* reinterpreted_tensor;
+  AOTITorchError error = aoti_torch__reinterpret_tensor(
+      source_tensor,
+      new_sizes.size(),
+      new_sizes.data(),
+      new_strides.data(),
+      0,
+      &reinterpreted_tensor);
+
+  EXPECT_EQ(error, Error::Ok);
+  ASSERT_NE(reinterpreted_tensor, nullptr);
+
+  // Check that the reinterpreted tensor uses the SAME memory
+  EXPECT_EQ(reinterpreted_tensor->mutable_data_ptr(), original_data_ptr);
+
+  // Check new shape
+  EXPECT_EQ(reinterpreted_tensor->dim(), 2);
+  EXPECT_EQ(reinterpreted_tensor->size(0), 5);
+  EXPECT_EQ(reinterpreted_tensor->size(1), 0);
+}
+
+// Test with nullptr strides (should use contiguous strides)
+TEST_F(AOTITorchReinterpretTensorTest, NullStridesPointer) {
+  std::vector<int64_t> source_sizes = {12};
+  Tensor* source_tensor = create_source_tensor(source_sizes);
+  ASSERT_NE(source_tensor, nullptr);
+
+  void* original_data_ptr = source_tensor->mutable_data_ptr();
+
+  // Reinterpret as [3, 4] with null strides (should calculate contiguous
+  // strides)
+  std::vector<int64_t> new_sizes = {3, 4};
+
+  Tensor* reinterpreted_tensor;
+  AOTITorchError error = aoti_torch__reinterpret_tensor(
+      source_tensor,
+      new_sizes.size(),
+      new_sizes.data(),
+      nullptr, // null strides - should calculate contiguous strides
+      0,
+      &reinterpreted_tensor);
+
+  EXPECT_EQ(error, Error::Ok);
+  ASSERT_NE(reinterpreted_tensor, nullptr);
+
+  // Check that the reinterpreted tensor uses the SAME memory
+  EXPECT_EQ(reinterpreted_tensor->mutable_data_ptr(), original_data_ptr);
+
+  // Check that contiguous strides were calculated correctly
+  int64_t* tensor_strides;
+  error = aoti_torch_get_strides(reinterpreted_tensor, &tensor_strides);
+  EXPECT_EQ(error, Error::Ok);
+  EXPECT_EQ(tensor_strides[0], 4); // stride for dimension 0 should be 4
+  EXPECT_EQ(tensor_strides[1], 1); // stride for dimension 1 should be 1
+}
+
+// Test bf16 tensor reinterpretation
+TEST_F(AOTITorchReinterpretTensorTest, ReinterpretBF16Tensor) {
+  // Create a bf16 source tensor with shape [6]
+  std::vector<int64_t> source_sizes = {6};
+  Tensor* source_tensor = create_source_tensor(
+      source_sizes,
+      static_cast<int32_t>(
+          SupportedDTypes::BFLOAT16), // bf16 dtype from SupportedDTypes
+      static_cast<int32_t>(
+          SupportedDevices::CUDA), // CUDA device from SupportedDevices
+      0); // device_index must be 0
+  ASSERT_NE(source_tensor, nullptr);
+
+  void* original_data_ptr = source_tensor->mutable_data_ptr();
+  ASSERT_NE(original_data_ptr, nullptr);
+
+  // Verify the tensor is actually bf16
+  int32_t actual_dtype = 0;
+  AOTITorchError dtype_check_error =
+      aoti_torch_get_dtype(source_tensor, &actual_dtype);
+  EXPECT_EQ(dtype_check_error, Error::Ok);
+  EXPECT_EQ(actual_dtype, static_cast<int32_t>(SupportedDTypes::BFLOAT16))
+      << "Source tensor should have bfloat16 dtype";
+
+  // Reinterpret as [2, 3] (same number of elements)
+  std::vector<int64_t> new_sizes = {2, 3};
+  std::vector<int64_t> new_strides = calculate_contiguous_strides(new_sizes);
+
+  Tensor* reinterpreted_tensor;
+  AOTITorchError error = aoti_torch__reinterpret_tensor(
+      source_tensor,
+      new_sizes.size(),
+      new_sizes.data(),
+      new_strides.data(),
+      0, // storage_offset
+      &reinterpreted_tensor);
+
+  EXPECT_EQ(error, Error::Ok);
+  ASSERT_NE(reinterpreted_tensor, nullptr);
+
+  // Check that the reinterpreted tensor has the new shape
+  EXPECT_EQ(reinterpreted_tensor->dim(), 2);
+  EXPECT_EQ(reinterpreted_tensor->size(0), 2);
+  EXPECT_EQ(reinterpreted_tensor->size(1), 3);
+
+  // Verify the dtype is preserved as bf16
+  int32_t reinterpreted_dtype = 0;
+  dtype_check_error =
+      aoti_torch_get_dtype(reinterpreted_tensor, &reinterpreted_dtype);
+  EXPECT_EQ(dtype_check_error, Error::Ok);
+  EXPECT_EQ(
+      reinterpreted_dtype, static_cast<int32_t>(SupportedDTypes::BFLOAT16))
+      << "Reinterpreted tensor should preserve bfloat16 dtype";
+
+  // CRITICAL: Check that the reinterpreted tensor uses the SAME memory
+  void* reinterpreted_data_ptr = reinterpreted_tensor->mutable_data_ptr();
+  EXPECT_EQ(reinterpreted_data_ptr, original_data_ptr)
+      << "Reinterpreted tensor should use the same memory as the source tensor";
+
+  // Test memory sharing by writing data through the original tensor
+  // and verifying it's visible through the reinterpreted tensor
+  // Note: bf16 has 2 bytes per element
+  std::vector<uint16_t> test_data_bf16 = {
+      0x3F80, 0x4000, 0x4040, 0x4080, 0x40A0, 0x40C0}; // bf16 values
+  cudaError_t cuda_err = cudaMemcpy(
+      original_data_ptr,
+      test_data_bf16.data(),
+      test_data_bf16.size() * sizeof(uint16_t),
+      cudaMemcpyHostToDevice);
+  EXPECT_EQ(cuda_err, cudaSuccess);
+
+  // Read back through the reinterpreted tensor
+  std::vector<uint16_t> readback_data_bf16(6);
+  cuda_err = cudaMemcpy(
+      readback_data_bf16.data(),
+      reinterpreted_data_ptr,
+      readback_data_bf16.size() * sizeof(uint16_t),
+      cudaMemcpyDeviceToHost);
+  EXPECT_EQ(cuda_err, cudaSuccess);
+
+  // Verify the data matches
+  for (size_t i = 0; i < test_data_bf16.size(); i++) {
+    EXPECT_EQ(readback_data_bf16[i], test_data_bf16[i])
+        << "BF16 data should be the same through both tensors at index " << i;
+  }
+}
+
+// Test reference counting behavior - memory not in map should fail
+TEST_F(AOTITorchReinterpretTensorTest, MemoryNotInMapShouldFail) {
+  // Create a tensor directly without using our allocation functions
+  // This should NOT be in the reference counting map
+  void* external_memory;
+  ASSERT_EQ(
+      cudaMallocManaged(&external_memory, 12 * sizeof(float)), cudaSuccess);
+
+  // Create a tensor by manually wrapping this memory without going through our
+  // APIs
+  std::vector<int64_t> sizes = {12};
+  std::vector<int64_t> strides = calculate_contiguous_strides(sizes);
+
+  // Create the tensor directly using ExecutorTorch extension
+  auto tensor_shared = executorch::extension::from_blob(
+      external_memory,
+      convert_sizes_to_vector(sizes.size(), sizes.data()),
+      convert_strides_to_vector(sizes.size(), sizes.data(), strides.data()),
+      executorch::runtime::etensor::ScalarType::Float);
+
+  ASSERT_TRUE(tensor_shared);
+  Tensor* external_tensor = tensor_shared.get();
+
+  // Try to reinterpret this tensor - should fail because memory is not in map
+  std::vector<int64_t> new_sizes = {3, 4};
+  std::vector<int64_t> new_strides = calculate_contiguous_strides(new_sizes);
+
+  Tensor* reinterpreted_tensor;
+  AOTITorchError error = aoti_torch__reinterpret_tensor(
+      external_tensor,
+      new_sizes.size(),
+      new_sizes.data(),
+      new_strides.data(),
+      0, // storage_offset
+      &reinterpreted_tensor);
+
+  // Should fail because memory is not being tracked by reference counting
+  // system
+  EXPECT_EQ(error, Error::InvalidArgument);
+
+  // Clean up the external memory
+  ASSERT_EQ(cudaFree(external_memory), cudaSuccess);
+}
+
+// Test reference counting behavior - creating view increments reference count
+TEST_F(AOTITorchReinterpretTensorTest, ViewCreationIncrementsReferenceCount) {
+  // Create a source tensor that owns memory (reference count = 1)
+  std::vector<int64_t> source_sizes = {12};
+  Tensor* source_tensor = create_source_tensor(source_sizes);
+  ASSERT_NE(source_tensor, nullptr);
+
+  void* shared_data_ptr = source_tensor->mutable_data_ptr();
+  ASSERT_NE(shared_data_ptr, nullptr);
+
+  // Create first view - should increment reference count to 2
+  std::vector<int64_t> view1_sizes = {3, 4};
+  std::vector<int64_t> view1_strides =
+      calculate_contiguous_strides(view1_sizes);
+
+  Tensor* view1_tensor;
+  AOTITorchError error = aoti_torch__reinterpret_tensor(
+      source_tensor,
+      view1_sizes.size(),
+      view1_sizes.data(),
+      view1_strides.data(),
+      0,
+      &view1_tensor);
+
+  EXPECT_EQ(error, Error::Ok);
+  ASSERT_NE(view1_tensor, nullptr);
+  EXPECT_EQ(view1_tensor->mutable_data_ptr(), shared_data_ptr);
+
+  // Create second view - should increment reference count to 3
+  std::vector<int64_t> view2_sizes = {2, 6};
+  std::vector<int64_t> view2_strides =
+      calculate_contiguous_strides(view2_sizes);
+
+  Tensor* view2_tensor;
+  error = aoti_torch__reinterpret_tensor(
+      source_tensor,
+      view2_sizes.size(),
+      view2_sizes.data(),
+      view2_strides.data(),
+      0,
+      &view2_tensor);
+
+  EXPECT_EQ(error, Error::Ok);
+  ASSERT_NE(view2_tensor, nullptr);
+  EXPECT_EQ(view2_tensor->mutable_data_ptr(), shared_data_ptr);
+
+  // Now delete the source tensor - memory should NOT be freed (reference count
+  // = 2)
+  error = aoti_torch_delete_tensor_object(source_tensor);
+  EXPECT_EQ(error, Error::Ok);
+
+  // Both views should still be valid - test by accessing memory
+  float test_value = 42.0f;
+  cudaError_t cuda_err = cudaMemcpy(
+      shared_data_ptr, &test_value, sizeof(float), cudaMemcpyHostToDevice);
+  EXPECT_EQ(cuda_err, cudaSuccess);
+
+  float readback_value = 0.0f;
+  cuda_err = cudaMemcpy(
+      &readback_value,
+      view1_tensor->mutable_data_ptr(),
+      sizeof(float),
+      cudaMemcpyDeviceToHost);
+  EXPECT_EQ(cuda_err, cudaSuccess);
+  EXPECT_EQ(readback_value, test_value);
+
+  // Delete first view - memory should still NOT be freed (reference count = 1)
+  error = aoti_torch_delete_tensor_object(view1_tensor);
+  EXPECT_EQ(error, Error::Ok);
+
+  // Second view should still be valid
+  readback_value = 0.0f;
+  cuda_err = cudaMemcpy(
+      &readback_value,
+      view2_tensor->mutable_data_ptr(),
+      sizeof(float),
+      cudaMemcpyDeviceToHost);
+  EXPECT_EQ(cuda_err, cudaSuccess);
+  EXPECT_EQ(readback_value, test_value);
+
+  // Delete second view - NOW memory should be freed (reference count = 0)
+  error = aoti_torch_delete_tensor_object(view2_tensor);
+  EXPECT_EQ(error, Error::Ok);
+}
+
+// Test reference counting behavior with NOT_OWN memory (from blob) - should
+// SUCCEED and keep NOT_OWN
+TEST_F(AOTITorchReinterpretTensorTest, ViewOfNotOwnMemoryKeepsNotOwnStatus) {
+  // Allocate external memory
+  void* external_memory;
+  cudaError_t cuda_err =
+      cudaMallocManaged(&external_memory, 12 * sizeof(float));
+  ASSERT_EQ(cuda_err, cudaSuccess);
+
+  // Create tensor from blob (which marks memory as NOT_OWN)
+  std::vector<int64_t> blob_sizes = {12};
+  std::vector<int64_t> blob_strides = calculate_contiguous_strides(blob_sizes);
+
+  Tensor* blob_tensor;
+  AOTITorchError error = aoti_torch_create_tensor_from_blob_v2(
+      external_memory,
+      blob_sizes.size(),
+      blob_sizes.data(),
+      blob_strides.data(),
+      0, // storage_offset
+      static_cast<int32_t>(SupportedDTypes::FLOAT32),
+      static_cast<int32_t>(SupportedDevices::CUDA),
+      0, // device_index
+      &blob_tensor,
+      0, // layout
+      nullptr, // opaque_metadata
+      0); // opaque_metadata_size
+
+  EXPECT_EQ(error, Error::Ok);
+  ASSERT_NE(blob_tensor, nullptr);
+
+  // Create view of NOT_OWN memory - should SUCCEED and keep NOT_OWN status
+  std::vector<int64_t> view_sizes = {3, 4};
+  std::vector<int64_t> view_strides = calculate_contiguous_strides(view_sizes);
+
+  Tensor* view_tensor;
+  error = aoti_torch__reinterpret_tensor(
+      blob_tensor,
+      view_sizes.size(),
+      view_sizes.data(),
+      view_strides.data(),
+      0,
+      &view_tensor);
+
+  // Should succeed - NOT_OWN memory can be reinterpreted but stays NOT_OWN
+  EXPECT_EQ(error, Error::Ok);
+  ASSERT_NE(view_tensor, nullptr);
+  EXPECT_EQ(view_tensor->mutable_data_ptr(), external_memory);
+
+  // Verify both tensors share the same memory
+  EXPECT_EQ(blob_tensor->mutable_data_ptr(), view_tensor->mutable_data_ptr());
+
+  // Test memory sharing by writing data through one tensor and reading through
+  // the other
+  float test_value = 42.0f;
+  cuda_err = cudaMemcpy(
+      external_memory, &test_value, sizeof(float), cudaMemcpyHostToDevice);
+  EXPECT_EQ(cuda_err, cudaSuccess);
+
+  float readback_value = 0.0f;
+  cuda_err = cudaMemcpy(
+      &readback_value,
+      view_tensor->mutable_data_ptr(),
+      sizeof(float),
+      cudaMemcpyDeviceToHost);
+  EXPECT_EQ(cuda_err, cudaSuccess);
+  EXPECT_EQ(readback_value, test_value);
+
+  // Delete the blob tensor - external memory should NOT be freed (NOT_OWN
+  // behavior)
+  error = aoti_torch_delete_tensor_object(blob_tensor);
+  EXPECT_EQ(error, Error::Ok);
+
+  // View tensor should still be valid - test by accessing memory
+  readback_value = 0.0f;
+  cuda_err = cudaMemcpy(
+      &readback_value,
+      view_tensor->mutable_data_ptr(),
+      sizeof(float),
+      cudaMemcpyDeviceToHost);
+  EXPECT_EQ(cuda_err, cudaSuccess);
+  EXPECT_EQ(readback_value, test_value);
+
+  // Delete view tensor - external memory should still NOT be freed (NOT_OWN
+  // behavior)
+  error = aoti_torch_delete_tensor_object(view_tensor);
+  EXPECT_EQ(error, Error::Ok);
+
+  // External memory should still be accessible (proves neither tensor freed it)
+  readback_value = 0.0f;
+  cuda_err = cudaMemcpy(
+      &readback_value, external_memory, sizeof(float), cudaMemcpyDeviceToHost);
+  EXPECT_EQ(cuda_err, cudaSuccess);
+  EXPECT_EQ(readback_value, test_value);
+
+  // Clean up external memory manually (as expected for NOT_OWN memory)
+  ASSERT_EQ(cudaFree(external_memory), cudaSuccess);
+}

--- a/backends/cuda/runtime/shims/tests/test_aoti_torch_create_tensor_from_blob_v2.cpp
+++ b/backends/cuda/runtime/shims/tests/test_aoti_torch_create_tensor_from_blob_v2.cpp
@@ -1,0 +1,754 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <cuda_runtime.h>
+#include <executorch/backends/aoti/common_shims.h>
+#include <executorch/backends/cuda/runtime/shims/memory.h>
+#include <executorch/backends/cuda/runtime/shims/tensor_attribute.h>
+#include <executorch/backends/cuda/runtime/shims/utils.h>
+#include <executorch/runtime/core/error.h>
+#include <executorch/runtime/platform/platform.h>
+#include <gtest/gtest.h>
+#include <vector>
+
+using namespace executorch::backends::aoti;
+using namespace executorch::backends::cuda;
+using namespace executorch::runtime;
+using executorch::runtime::etensor::Tensor;
+
+// Test fixture for aoti_torch_create_tensor_from_blob_v2 tests
+class AOTITorchCreateTensorFromBlobV2Test : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // Initialize ExecuTorch Platform Abstraction Layer
+    et_pal_init();
+
+    // Check if CUDA is available
+    int device_count = 0;
+    cudaError_t err = cudaGetDeviceCount(&device_count);
+    if (err != cudaSuccess || device_count == 0) {
+      GTEST_SKIP() << "CUDA not available, skipping CUDA tests";
+    }
+
+    // Clean up any existing cached metadata before each test
+    cleanup_tensor_metadata();
+
+    // Clear any remaining tensors from previous tests
+    clear_all_tensors();
+  }
+
+  void TearDown() override {
+    // Clean up metadata
+    cleanup_tensor_metadata();
+
+    // Clear the global tensor storage using the provided function
+    clear_all_tensors();
+
+    // Clean up any allocated memory buffers
+    for (void* ptr : cuda_memory_buffers_) {
+      if (ptr) {
+        cudaError_t cuda_err = cudaFree(ptr);
+        EXPECT_EQ(cuda_err, cudaSuccess)
+            << "Failed to free CUDA memory: " << cudaGetErrorString(cuda_err);
+      }
+    }
+    cuda_memory_buffers_.clear();
+
+    for (void* ptr : cpu_memory_buffers_) {
+      if (ptr) {
+        free(ptr);
+      }
+    }
+    cpu_memory_buffers_.clear();
+  }
+
+  // Helper to allocate CUDA memory and track it for cleanup
+  void* allocate_cuda_memory(size_t bytes) {
+    void* ptr;
+    cudaError_t err = cudaMallocManaged(&ptr, bytes);
+    if (err == cudaSuccess) {
+      cuda_memory_buffers_.push_back(ptr);
+      return ptr;
+    }
+    return nullptr;
+  }
+
+  // Helper to allocate CPU memory and track it for cleanup
+  void* allocate_cpu_memory(size_t bytes) {
+    void* ptr;
+    int result = posix_memalign(&ptr, 16, bytes); // 16-byte aligned
+    if (result == 0 && ptr != nullptr) {
+      cpu_memory_buffers_.push_back(ptr);
+      return ptr;
+    }
+    return nullptr;
+  }
+
+  // Helper to calculate number of elements from sizes
+  int64_t calculate_numel(const std::vector<int64_t>& sizes) {
+    int64_t numel = 1;
+    for (int64_t size : sizes) {
+      numel *= size;
+    }
+    return numel;
+  }
+
+  // Helper to calculate contiguous strides from sizes
+  std::vector<int64_t> calculate_contiguous_strides(
+      const std::vector<int64_t>& sizes) {
+    std::vector<int64_t> strides(sizes.size());
+    if (sizes.empty()) {
+      return strides;
+    }
+
+    strides[sizes.size() - 1] = 1;
+    // Use int64_t and check for underflow to avoid unsigned integer wraparound
+    for (int64_t i = static_cast<int64_t>(sizes.size()) - 2; i >= 0; i--) {
+      strides[i] = strides[i + 1] * sizes[i + 1];
+    }
+    return strides;
+  }
+
+ private:
+  std::vector<void*> cuda_memory_buffers_;
+  std::vector<void*> cpu_memory_buffers_;
+};
+
+// Test basic functionality with CUDA memory
+TEST_F(AOTITorchCreateTensorFromBlobV2Test, BasicFunctionalityCUDA) {
+  // Test 1D tensor
+  std::vector<int64_t> sizes_1d = {5};
+  std::vector<int64_t> strides_1d = calculate_contiguous_strides(sizes_1d);
+
+  // Allocate CUDA memory
+  size_t bytes = calculate_numel(sizes_1d) * sizeof(float);
+  void* cuda_data = allocate_cuda_memory(bytes);
+  ASSERT_NE(cuda_data, nullptr);
+
+  Tensor* tensor_1d;
+  AOTITorchError error = aoti_torch_create_tensor_from_blob_v2(
+      cuda_data,
+      sizes_1d.size(),
+      sizes_1d.data(),
+      strides_1d.data(),
+      0, // storage_offset
+      static_cast<int32_t>(SupportedDTypes::FLOAT32),
+      static_cast<int32_t>(SupportedDevices::CUDA),
+      0, // device index
+      &tensor_1d,
+      0, // layout (strided)
+      nullptr, // opaque_metadata
+      0); // opaque_metadata_size
+
+  EXPECT_EQ(error, Error::Ok);
+  EXPECT_NE(tensor_1d, nullptr);
+
+  // Check tensor properties
+  EXPECT_EQ(tensor_1d->dim(), 1);
+  EXPECT_EQ(tensor_1d->size(0), 5);
+
+  // Verify the tensor uses the same data pointer
+  void* tensor_data = tensor_1d->mutable_data_ptr();
+  EXPECT_EQ(tensor_data, cuda_data);
+
+  // Delete the tensor - this should NOT free the original memory
+  error = aoti_torch_delete_tensor_object(tensor_1d);
+  EXPECT_EQ(error, Error::Ok);
+
+  // Test that the original memory is still accessible (proves tensor didn't own
+  // it) For CUDA memory, check that we can still access it (synchronously)
+  // after tensor deletion
+  float pattern_value = 42.0f;
+  cudaError_t cuda_err = cudaMemcpy(
+      cuda_data, &pattern_value, sizeof(float), cudaMemcpyHostToDevice);
+  EXPECT_EQ(cuda_err, cudaSuccess)
+      << "Should be able to write to original CUDA memory after tensor deletion";
+
+  float readback_value = 0.0f;
+  cuda_err = cudaMemcpy(
+      &readback_value, cuda_data, sizeof(float), cudaMemcpyDeviceToHost);
+  EXPECT_EQ(cuda_err, cudaSuccess)
+      << "Should be able to read from original CUDA memory after tensor deletion";
+  EXPECT_EQ(readback_value, pattern_value)
+      << "Original CUDA memory should still contain our test pattern";
+}
+
+// Test basic functionality with CPU memory
+TEST_F(AOTITorchCreateTensorFromBlobV2Test, BasicFunctionalityCPU) {
+  // Test 2D tensor
+  std::vector<int64_t> sizes_2d = {3, 4};
+  std::vector<int64_t> strides_2d = calculate_contiguous_strides(sizes_2d);
+
+  // Allocate CPU memory
+  size_t bytes = calculate_numel(sizes_2d) * sizeof(float);
+  void* cpu_data = allocate_cpu_memory(bytes);
+  ASSERT_NE(cpu_data, nullptr);
+
+  Tensor* tensor_2d;
+  AOTITorchError error = aoti_torch_create_tensor_from_blob_v2(
+      cpu_data,
+      sizes_2d.size(),
+      sizes_2d.data(),
+      strides_2d.data(),
+      0, // storage_offset
+      static_cast<int32_t>(SupportedDTypes::FLOAT32),
+      static_cast<int32_t>(SupportedDevices::CPU),
+      0, // device index
+      &tensor_2d,
+      0, // layout (strided)
+      nullptr, // opaque_metadata
+      0); // opaque_metadata_size
+
+  EXPECT_EQ(error, Error::Ok);
+  EXPECT_NE(tensor_2d, nullptr);
+
+  // Check tensor properties
+  EXPECT_EQ(tensor_2d->dim(), 2);
+  EXPECT_EQ(tensor_2d->size(0), 3);
+  EXPECT_EQ(tensor_2d->size(1), 4);
+
+  // Verify the tensor uses the same data pointer
+  void* tensor_data = tensor_2d->mutable_data_ptr();
+  EXPECT_EQ(tensor_data, cpu_data);
+
+  // Delete the tensor - this should NOT free the original memory
+  error = aoti_torch_delete_tensor_object(tensor_2d);
+  EXPECT_EQ(error, Error::Ok);
+
+  // Test that the original memory is still accessible (proves tensor didn't own
+  // it) For CPU memory, directly write and read to verify accessibility
+  float* float_ptr = reinterpret_cast<float*>(cpu_data);
+  float pattern_value = 42.0f;
+  *float_ptr = pattern_value;
+  EXPECT_EQ(*float_ptr, pattern_value)
+      << "Original CPU memory should still be accessible after tensor deletion";
+}
+
+// Test with invalid dtype
+TEST_F(AOTITorchCreateTensorFromBlobV2Test, InvalidDtype) {
+  std::vector<int64_t> sizes = {2, 3};
+  std::vector<int64_t> strides = calculate_contiguous_strides(sizes);
+
+  size_t bytes = calculate_numel(sizes) * sizeof(float);
+  void* data = allocate_cuda_memory(bytes);
+  ASSERT_NE(data, nullptr);
+
+  Tensor* tensor;
+  AOTITorchError error = aoti_torch_create_tensor_from_blob_v2(
+      data,
+      sizes.size(),
+      sizes.data(),
+      strides.data(),
+      0, // storage_offset
+      999, // invalid dtype
+      static_cast<int32_t>(SupportedDevices::CUDA),
+      0, // device index
+      &tensor,
+      0, // layout
+      nullptr, // opaque_metadata
+      0); // opaque_metadata_size
+
+  EXPECT_EQ(error, Error::InvalidArgument);
+}
+
+// Test with non-zero storage offset (should fail since from_blob cannot handle
+// offsets)
+TEST_F(AOTITorchCreateTensorFromBlobV2Test, NonZeroStorageOffset) {
+  std::vector<int64_t> sizes = {2, 3};
+  std::vector<int64_t> strides = calculate_contiguous_strides(sizes);
+
+  size_t bytes = calculate_numel(sizes) * sizeof(float);
+  void* data = allocate_cuda_memory(bytes);
+  ASSERT_NE(data, nullptr);
+
+  Tensor* tensor;
+  AOTITorchError error = aoti_torch_create_tensor_from_blob_v2(
+      data,
+      sizes.size(),
+      sizes.data(),
+      strides.data(),
+      1, // non-zero storage_offset (should fail since from_blob cannot handle
+         // offsets)
+      static_cast<int32_t>(SupportedDTypes::FLOAT32),
+      static_cast<int32_t>(SupportedDevices::CUDA),
+      0, // device index
+      &tensor,
+      0, // layout
+      nullptr, // opaque_metadata
+      0); // opaque_metadata_size
+
+  EXPECT_EQ(error, Error::InvalidArgument);
+}
+
+// Test with custom strides (using stride parameter but still contiguous)
+TEST_F(AOTITorchCreateTensorFromBlobV2Test, CustomContiguousStrides) {
+  std::vector<int64_t> sizes = {2, 3};
+  // Use the correct contiguous strides but pass them explicitly
+  std::vector<int64_t> contiguous_strides = {3, 1}; // Proper contiguous strides
+
+  size_t bytes = calculate_numel(sizes) * sizeof(float);
+  void* data = allocate_cuda_memory(bytes);
+  ASSERT_NE(data, nullptr);
+
+  Tensor* tensor;
+  AOTITorchError error = aoti_torch_create_tensor_from_blob_v2(
+      data,
+      sizes.size(),
+      sizes.data(),
+      contiguous_strides.data(), // Explicitly pass contiguous strides
+      0, // storage_offset
+      static_cast<int32_t>(SupportedDTypes::FLOAT32),
+      static_cast<int32_t>(SupportedDevices::CUDA),
+      0, // device index
+      &tensor,
+      0, // layout
+      nullptr, // opaque_metadata
+      0); // opaque_metadata_size
+
+  EXPECT_EQ(error, Error::Ok);
+  EXPECT_NE(tensor, nullptr);
+
+  // Check tensor properties
+  EXPECT_EQ(tensor->dim(), 2);
+  EXPECT_EQ(tensor->size(0), 2);
+  EXPECT_EQ(tensor->size(1), 3);
+
+  // Verify the tensor uses the same data pointer
+  void* tensor_data = tensor->mutable_data_ptr();
+  EXPECT_EQ(tensor_data, data);
+
+  // Verify strides were properly set (we can check via aoti_torch_get_strides)
+  int64_t* tensor_strides;
+  error = aoti_torch_get_strides(tensor, &tensor_strides);
+  EXPECT_EQ(error, Error::Ok);
+  EXPECT_EQ(tensor_strides[0], 3);
+  EXPECT_EQ(tensor_strides[1], 1);
+
+  // Delete the tensor - this should NOT free the original memory
+  error = aoti_torch_delete_tensor_object(tensor);
+  EXPECT_EQ(error, Error::Ok);
+
+  // Test that the original memory is still accessible (proves tensor didn't own
+  // it)
+  float pattern_value = 42.0f;
+  cudaError_t cuda_err =
+      cudaMemcpy(data, &pattern_value, sizeof(float), cudaMemcpyHostToDevice);
+  EXPECT_EQ(cuda_err, cudaSuccess)
+      << "Should be able to write to original CUDA memory after tensor deletion";
+
+  float readback_value = 0.0f;
+  cuda_err =
+      cudaMemcpy(&readback_value, data, sizeof(float), cudaMemcpyDeviceToHost);
+  EXPECT_EQ(cuda_err, cudaSuccess)
+      << "Should be able to read from original CUDA memory after tensor deletion";
+  EXPECT_EQ(readback_value, pattern_value)
+      << "Original CUDA memory should still contain our test pattern";
+}
+
+// Test with null data pointer
+TEST_F(AOTITorchCreateTensorFromBlobV2Test, NullDataPointer) {
+  std::vector<int64_t> sizes = {2, 3};
+  std::vector<int64_t> strides = calculate_contiguous_strides(sizes);
+
+  Tensor* tensor;
+  AOTITorchError error = aoti_torch_create_tensor_from_blob_v2(
+      nullptr, // null data pointer
+      sizes.size(),
+      sizes.data(),
+      strides.data(),
+      0, // storage_offset
+      static_cast<int32_t>(SupportedDTypes::FLOAT32),
+      static_cast<int32_t>(SupportedDevices::CUDA),
+      0, // device index
+      &tensor,
+      0, // layout
+      nullptr, // opaque_metadata
+      0); // opaque_metadata_size
+
+  EXPECT_EQ(error, Error::InvalidArgument);
+}
+
+// Test scalar tensor (0D)
+TEST_F(AOTITorchCreateTensorFromBlobV2Test, ScalarTensor) {
+  std::vector<int64_t> sizes = {}; // 0D tensor
+  std::vector<int64_t> strides = {}; // Empty strides for scalar
+
+  size_t bytes = sizeof(float); // Single element
+  void* data = allocate_cuda_memory(bytes);
+  ASSERT_NE(data, nullptr);
+
+  Tensor* tensor = nullptr;
+  AOTITorchError error = aoti_torch_create_tensor_from_blob_v2(
+      data,
+      sizes.size(),
+      sizes.data(),
+      strides.data(),
+      0, // storage_offset
+      static_cast<int32_t>(SupportedDTypes::FLOAT32),
+      static_cast<int32_t>(SupportedDevices::CUDA),
+      0, // device index
+      &tensor,
+      0, // layout
+      nullptr, // opaque_metadata
+      0); // opaque_metadata_size
+
+  EXPECT_EQ(error, Error::Ok);
+  ASSERT_NE(tensor, nullptr);
+
+  // Check tensor properties
+  EXPECT_EQ(tensor->dim(), 0);
+
+  // Verify the tensor uses the same data pointer
+  void* tensor_data = tensor->mutable_data_ptr();
+  EXPECT_EQ(tensor_data, data);
+
+  // Delete the tensor - this should NOT free the original memory
+  error = aoti_torch_delete_tensor_object(tensor);
+  EXPECT_EQ(error, Error::Ok);
+
+  // Test that the original memory is still accessible (proves tensor didn't own
+  // it)
+  float pattern_value = 42.0f;
+  cudaError_t cuda_err =
+      cudaMemcpy(data, &pattern_value, sizeof(float), cudaMemcpyHostToDevice);
+  EXPECT_EQ(cuda_err, cudaSuccess)
+      << "Should be able to write to original CUDA memory after tensor deletion";
+
+  float readback_value = 0.0f;
+  cuda_err =
+      cudaMemcpy(&readback_value, data, sizeof(float), cudaMemcpyDeviceToHost);
+  EXPECT_EQ(cuda_err, cudaSuccess)
+      << "Should be able to read from original CUDA memory after tensor deletion";
+  EXPECT_EQ(readback_value, pattern_value)
+      << "Original CUDA memory should still contain our test pattern";
+}
+
+// Test zero-sized tensor
+TEST_F(AOTITorchCreateTensorFromBlobV2Test, ZeroSizedTensor) {
+  std::vector<int64_t> sizes = {0, 5}; // Zero elements
+  std::vector<int64_t> strides = calculate_contiguous_strides(sizes);
+
+  // Even for zero-sized tensor, we need some memory allocated
+  size_t bytes = sizeof(float); // Minimum allocation
+  void* data = allocate_cuda_memory(bytes);
+  ASSERT_NE(data, nullptr);
+
+  Tensor* tensor;
+  AOTITorchError error = aoti_torch_create_tensor_from_blob_v2(
+      data,
+      sizes.size(),
+      sizes.data(),
+      strides.data(),
+      0, // storage_offset
+      static_cast<int32_t>(SupportedDTypes::FLOAT32),
+      static_cast<int32_t>(SupportedDevices::CUDA),
+      0, // device index
+      &tensor,
+      0, // layout
+      nullptr, // opaque_metadata
+      0); // opaque_metadata_size
+
+  EXPECT_EQ(error, Error::Ok);
+  EXPECT_NE(tensor, nullptr);
+
+  // Check tensor properties
+  EXPECT_EQ(tensor->dim(), 2);
+  EXPECT_EQ(tensor->size(0), 0);
+  EXPECT_EQ(tensor->size(1), 5);
+
+  // Verify the tensor uses the same data pointer
+  void* tensor_data = tensor->mutable_data_ptr();
+  EXPECT_EQ(tensor_data, data);
+
+  // Delete the tensor - this should NOT free the original memory
+  error = aoti_torch_delete_tensor_object(tensor);
+  EXPECT_EQ(error, Error::Ok);
+
+  // Test that the original memory is still accessible (proves tensor didn't own
+  // it)
+  float pattern_value = 42.0f;
+  cudaError_t cuda_err =
+      cudaMemcpy(data, &pattern_value, sizeof(float), cudaMemcpyHostToDevice);
+  EXPECT_EQ(cuda_err, cudaSuccess)
+      << "Should be able to write to original CUDA memory after tensor deletion";
+
+  float readback_value = 0.0f;
+  cuda_err =
+      cudaMemcpy(&readback_value, data, sizeof(float), cudaMemcpyDeviceToHost);
+  EXPECT_EQ(cuda_err, cudaSuccess)
+      << "Should be able to read from original CUDA memory after tensor deletion";
+  EXPECT_EQ(readback_value, pattern_value)
+      << "Original CUDA memory should still contain our test pattern";
+}
+
+// Test multi-dimensional tensors
+TEST_F(AOTITorchCreateTensorFromBlobV2Test, MultiDimensionalTensors) {
+  // Test 3D tensor
+  std::vector<int64_t> sizes_3d = {2, 3, 4};
+  std::vector<int64_t> strides_3d = calculate_contiguous_strides(sizes_3d);
+
+  size_t bytes_3d = calculate_numel(sizes_3d) * sizeof(float);
+  void* data_3d = allocate_cuda_memory(bytes_3d);
+  ASSERT_NE(data_3d, nullptr);
+
+  Tensor* tensor_3d;
+  AOTITorchError error = aoti_torch_create_tensor_from_blob_v2(
+      data_3d,
+      sizes_3d.size(),
+      sizes_3d.data(),
+      strides_3d.data(),
+      0, // storage_offset
+      static_cast<int32_t>(SupportedDTypes::FLOAT32),
+      static_cast<int32_t>(SupportedDevices::CUDA),
+      0, // device index
+      &tensor_3d,
+      0, // layout
+      nullptr, // opaque_metadata
+      0); // opaque_metadata_size
+
+  EXPECT_EQ(error, Error::Ok);
+  EXPECT_NE(tensor_3d, nullptr);
+  EXPECT_EQ(tensor_3d->dim(), 3);
+  EXPECT_EQ(tensor_3d->size(0), 2);
+  EXPECT_EQ(tensor_3d->size(1), 3);
+  EXPECT_EQ(tensor_3d->size(2), 4);
+
+  // Test 4D tensor
+  std::vector<int64_t> sizes_4d = {2, 3, 4, 5};
+  std::vector<int64_t> strides_4d = calculate_contiguous_strides(sizes_4d);
+
+  size_t bytes_4d = calculate_numel(sizes_4d) * sizeof(float);
+  void* data_4d = allocate_cuda_memory(bytes_4d);
+  ASSERT_NE(data_4d, nullptr);
+
+  Tensor* tensor_4d;
+  error = aoti_torch_create_tensor_from_blob_v2(
+      data_4d,
+      sizes_4d.size(),
+      sizes_4d.data(),
+      strides_4d.data(),
+      0, // storage_offset
+      static_cast<int32_t>(SupportedDTypes::FLOAT32),
+      static_cast<int32_t>(SupportedDevices::CUDA),
+      0, // device index
+      &tensor_4d,
+      0, // layout
+      nullptr, // opaque_metadata
+      0); // opaque_metadata_size
+
+  EXPECT_EQ(error, Error::Ok);
+  EXPECT_NE(tensor_4d, nullptr);
+  EXPECT_EQ(tensor_4d->dim(), 4);
+  EXPECT_EQ(tensor_4d->size(0), 2);
+  EXPECT_EQ(tensor_4d->size(1), 3);
+  EXPECT_EQ(tensor_4d->size(2), 4);
+  EXPECT_EQ(tensor_4d->size(3), 5);
+}
+
+// Test tensor data pointer consistency
+TEST_F(AOTITorchCreateTensorFromBlobV2Test, DataPointerConsistency) {
+  std::vector<int64_t> sizes = {2, 3};
+  std::vector<int64_t> strides = calculate_contiguous_strides(sizes);
+
+  size_t bytes = calculate_numel(sizes) * sizeof(float);
+  void* original_data = allocate_cuda_memory(bytes);
+  ASSERT_NE(original_data, nullptr);
+
+  Tensor* tensor;
+  AOTITorchError error = aoti_torch_create_tensor_from_blob_v2(
+      original_data,
+      sizes.size(),
+      sizes.data(),
+      strides.data(),
+      0, // storage_offset
+      static_cast<int32_t>(SupportedDTypes::FLOAT32),
+      static_cast<int32_t>(SupportedDevices::CUDA),
+      0, // device index
+      &tensor,
+      0, // layout
+      nullptr, // opaque_metadata
+      0); // opaque_metadata_size
+
+  EXPECT_EQ(error, Error::Ok);
+  EXPECT_NE(tensor, nullptr);
+
+  // Check that the tensor uses the same data pointer
+  void* tensor_data = tensor->mutable_data_ptr();
+  EXPECT_EQ(tensor_data, original_data);
+}
+
+// Test creating multiple tensors from different blobs
+TEST_F(AOTITorchCreateTensorFromBlobV2Test, MultipleTensorsFromBlobs) {
+  const int num_tensors = 5;
+  std::vector<Tensor*> tensors;
+  std::vector<void*> data_ptrs;
+
+  for (int i = 0; i < num_tensors; i++) {
+    std::vector<int64_t> sizes = {i + 1, i + 2};
+    std::vector<int64_t> strides = calculate_contiguous_strides(sizes);
+
+    size_t bytes = calculate_numel(sizes) * sizeof(float);
+    void* data = allocate_cuda_memory(bytes);
+    ASSERT_NE(data, nullptr);
+    data_ptrs.push_back(data);
+
+    Tensor* tensor;
+    AOTITorchError error = aoti_torch_create_tensor_from_blob_v2(
+        data,
+        sizes.size(),
+        sizes.data(),
+        strides.data(),
+        0, // storage_offset
+        static_cast<int32_t>(SupportedDTypes::FLOAT32),
+        static_cast<int32_t>(SupportedDevices::CUDA),
+        0, // device index
+        &tensor,
+        0, // layout
+        nullptr, // opaque_metadata
+        0); // opaque_metadata_size
+
+    EXPECT_EQ(error, Error::Ok);
+    EXPECT_NE(tensor, nullptr);
+    tensors.push_back(tensor);
+
+    // Verify dimensions
+    EXPECT_EQ(tensor->dim(), 2);
+    EXPECT_EQ(tensor->size(0), i + 1);
+    EXPECT_EQ(tensor->size(1), i + 2);
+
+    // Verify the tensor uses the correct data pointer
+    EXPECT_EQ(tensor->mutable_data_ptr(), data);
+  }
+
+  // Verify all tensors have different data pointers
+  for (int i = 0; i < num_tensors; i++) {
+    EXPECT_EQ(tensors[i]->mutable_data_ptr(), data_ptrs[i]);
+    for (int j = i + 1; j < num_tensors; j++) {
+      EXPECT_NE(tensors[i]->mutable_data_ptr(), tensors[j]->mutable_data_ptr());
+    }
+  }
+}
+
+// Test deletion of tensor created from blob (should not free the original
+// memory)
+TEST_F(AOTITorchCreateTensorFromBlobV2Test, DeletionDoesNotFreeOriginalMemory) {
+  std::vector<int64_t> sizes = {2, 3};
+  std::vector<int64_t> strides = calculate_contiguous_strides(sizes);
+
+  size_t bytes = calculate_numel(sizes) * sizeof(float);
+  void* data = allocate_cuda_memory(bytes);
+  ASSERT_NE(data, nullptr);
+
+  Tensor* tensor;
+  AOTITorchError error = aoti_torch_create_tensor_from_blob_v2(
+      data,
+      sizes.size(),
+      sizes.data(),
+      strides.data(),
+      0, // storage_offset
+      static_cast<int32_t>(SupportedDTypes::FLOAT32),
+      static_cast<int32_t>(SupportedDevices::CUDA),
+      0, // device index
+      &tensor,
+      0, // layout
+      nullptr, // opaque_metadata
+      0); // opaque_metadata_size
+
+  EXPECT_EQ(error, Error::Ok);
+  EXPECT_NE(tensor, nullptr);
+
+  // Delete the tensor - this should NOT free the original memory
+  error = aoti_torch_delete_tensor_object(tensor);
+  EXPECT_EQ(error, Error::Ok);
+
+  // The original memory should still be valid (we'll free it in teardown)
+  // We can't easily test if the memory is still valid without risking crashes,
+  // but the test should pass without issues if memory management is correct
+}
+
+// Test with opaque metadata
+TEST_F(AOTITorchCreateTensorFromBlobV2Test, WithOpaqueMetadata) {
+  std::vector<int64_t> sizes = {2, 3};
+  std::vector<int64_t> strides = calculate_contiguous_strides(sizes);
+
+  size_t bytes = calculate_numel(sizes) * sizeof(float);
+  void* data = allocate_cuda_memory(bytes);
+  ASSERT_NE(data, nullptr);
+
+  // Create some opaque metadata
+  std::vector<uint8_t> metadata = {0x01, 0x02, 0x03, 0x04};
+
+  Tensor* tensor;
+  AOTITorchError error = aoti_torch_create_tensor_from_blob_v2(
+      data,
+      sizes.size(),
+      sizes.data(),
+      strides.data(),
+      0, // storage_offset
+      static_cast<int32_t>(SupportedDTypes::FLOAT32),
+      static_cast<int32_t>(SupportedDevices::CUDA),
+      0, // device index
+      &tensor,
+      0, // layout
+      metadata.data(), // opaque_metadata
+      metadata.size()); // opaque_metadata_size
+
+  EXPECT_EQ(error, Error::Ok);
+  EXPECT_NE(tensor, nullptr);
+
+  // Check tensor properties
+  EXPECT_EQ(tensor->dim(), 2);
+  EXPECT_EQ(tensor->size(0), 2);
+  EXPECT_EQ(tensor->size(1), 3);
+}
+
+// Test stress test with many small tensors from blobs
+TEST_F(AOTITorchCreateTensorFromBlobV2Test, StressTestManySmallTensors) {
+  const int num_tensors = 50; // Reduced for reasonable test time
+  std::vector<Tensor*> tensors;
+
+  for (int i = 0; i < num_tensors; i++) {
+    std::vector<int64_t> sizes = {1, 1}; // Minimal size
+    std::vector<int64_t> strides = calculate_contiguous_strides(sizes);
+
+    size_t bytes = calculate_numel(sizes) * sizeof(float);
+    void* data = allocate_cuda_memory(bytes);
+    if (data == nullptr) {
+      // Skip if we run out of memory
+      continue;
+    }
+
+    Tensor* tensor;
+    AOTITorchError error = aoti_torch_create_tensor_from_blob_v2(
+        data,
+        sizes.size(),
+        sizes.data(),
+        strides.data(),
+        0, // storage_offset
+        static_cast<int32_t>(SupportedDTypes::FLOAT32),
+        static_cast<int32_t>(SupportedDevices::CUDA),
+        0, // device index
+        &tensor,
+        0, // layout
+        nullptr, // opaque_metadata
+        0); // opaque_metadata_size
+
+    if (error == Error::Ok && tensor != nullptr) {
+      tensors.push_back(tensor);
+
+      // Verify the tensor uses the correct data pointer
+      EXPECT_EQ(tensor->mutable_data_ptr(), data);
+    }
+  }
+
+  // Delete all created tensors
+  for (Tensor* tensor : tensors) {
+    AOTITorchError error = aoti_torch_delete_tensor_object(tensor);
+    EXPECT_EQ(error, Error::Ok);
+  }
+}

--- a/backends/cuda/runtime/shims/tests/test_aoti_torch_delete_tensor_object.cpp
+++ b/backends/cuda/runtime/shims/tests/test_aoti_torch_delete_tensor_object.cpp
@@ -1,0 +1,454 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <cuda_runtime.h>
+#include <executorch/backends/aoti/common_shims.h>
+#include <executorch/backends/cuda/runtime/shims/memory.h>
+#include <executorch/backends/cuda/runtime/shims/tensor_attribute.h>
+#include <executorch/backends/cuda/runtime/shims/utils.h>
+#include <executorch/runtime/core/error.h>
+#include <executorch/runtime/platform/platform.h>
+#include <gtest/gtest.h>
+#include <vector>
+
+using namespace executorch::backends::aoti;
+using namespace executorch::backends::cuda;
+using namespace executorch::runtime;
+using executorch::runtime::etensor::Tensor;
+
+// Test fixture for aoti_torch_delete_tensor_object tests
+class AOTITorchDeleteTensorObjectTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // Initialize ExecuTorch Platform Abstraction Layer
+    et_pal_init();
+
+    // Check if CUDA is available
+    int device_count = 0;
+    cudaError_t err = cudaGetDeviceCount(&device_count);
+    if (err != cudaSuccess || device_count == 0) {
+      GTEST_SKIP() << "CUDA not available, skipping CUDA tests";
+    }
+
+    // Clean up any existing cached metadata before each test
+    cleanup_tensor_metadata();
+
+    // Clear any remaining tensors from previous tests
+    clear_all_tensors();
+  }
+
+  void TearDown() override {
+    // Clean up metadata
+    cleanup_tensor_metadata();
+
+    // Clear the global tensor storage using the provided function
+    clear_all_tensors();
+  }
+
+  // Helper to create test tensors
+  Tensor* create_test_tensor(
+      const std::vector<int64_t>& sizes,
+      const std::vector<int64_t>& strides = {},
+      int32_t dtype = 6, // float32
+      int32_t device_type = 1, // CUDA
+      int32_t device_index = 0) {
+    Tensor* tensor;
+
+    const int64_t* strides_ptr = strides.empty() ? nullptr : strides.data();
+
+    AOTITorchError error = aoti_torch_empty_strided(
+        sizes.size(),
+        sizes.data(),
+        strides_ptr,
+        dtype,
+        device_type,
+        device_index,
+        &tensor);
+
+    return (error == Error::Ok) ? tensor : nullptr;
+  }
+};
+
+// Test basic deletion of CUDA tensor
+TEST_F(AOTITorchDeleteTensorObjectTest, DeleteCudaTensorBasic) {
+  // Create a CUDA tensor
+  std::vector<int64_t> sizes = {2, 3};
+  Tensor* tensor = create_test_tensor(sizes, {}, 6, 1, 0); // CUDA device
+  ASSERT_NE(tensor, nullptr);
+
+  // Verify tensor properties before deletion
+  EXPECT_EQ(tensor->dim(), 2);
+  EXPECT_EQ(tensor->size(0), 2);
+  EXPECT_EQ(tensor->size(1), 3);
+
+  // Delete the tensor
+  AOTITorchError error = aoti_torch_delete_tensor_object(tensor);
+  EXPECT_EQ(error, Error::Ok);
+}
+
+// Test basic deletion of CPU tensor
+TEST_F(AOTITorchDeleteTensorObjectTest, DeleteCpuTensorBasic) {
+  // Create a CPU tensor
+  std::vector<int64_t> sizes = {3, 4};
+  Tensor* tensor = create_test_tensor(sizes, {}, 6, 0, 0); // CPU device
+  ASSERT_NE(tensor, nullptr);
+
+  // Verify tensor properties before deletion
+  EXPECT_EQ(tensor->dim(), 2);
+  EXPECT_EQ(tensor->size(0), 3);
+  EXPECT_EQ(tensor->size(1), 4);
+
+  // Delete the tensor
+  AOTITorchError error = aoti_torch_delete_tensor_object(tensor);
+  EXPECT_EQ(error, Error::Ok);
+}
+
+// Test deletion of null tensor pointer
+TEST_F(AOTITorchDeleteTensorObjectTest, DeleteNullTensor) {
+  AOTITorchError error = aoti_torch_delete_tensor_object(nullptr);
+  EXPECT_EQ(error, Error::InvalidArgument);
+}
+
+// Test deletion of tensor not in tracking system
+TEST_F(AOTITorchDeleteTensorObjectTest, DeleteUntrackedTensor) {
+  // Create a tensor and then clear the tracking system
+  std::vector<int64_t> sizes = {2, 3};
+  Tensor* tensor = create_test_tensor(sizes);
+  ASSERT_NE(tensor, nullptr);
+
+  // Clear the tracking system (simulating an untracked tensor)
+  clear_all_tensors();
+
+  // Try to delete the tensor - should fail
+  AOTITorchError error = aoti_torch_delete_tensor_object(tensor);
+  EXPECT_EQ(error, Error::InvalidArgument);
+}
+
+// Test deletion of multiple tensors
+TEST_F(AOTITorchDeleteTensorObjectTest, DeleteMultipleTensors) {
+  // Create multiple tensors
+  std::vector<Tensor*> tensors;
+
+  for (int i = 1; i <= 5; i++) {
+    std::vector<int64_t> sizes = {i, i + 1};
+    Tensor* tensor = create_test_tensor(sizes);
+    ASSERT_NE(tensor, nullptr);
+    tensors.push_back(tensor);
+  }
+
+  // Delete all tensors
+  for (Tensor* tensor : tensors) {
+    AOTITorchError error = aoti_torch_delete_tensor_object(tensor);
+    EXPECT_EQ(error, Error::Ok);
+  }
+}
+
+// Test deletion of zero-sized tensors
+TEST_F(AOTITorchDeleteTensorObjectTest, DeleteZeroSizedTensor) {
+  // Create a zero-sized tensor
+  std::vector<int64_t> sizes = {0, 5};
+  Tensor* tensor = create_test_tensor(sizes);
+  ASSERT_NE(tensor, nullptr);
+
+  // Verify tensor properties
+  EXPECT_EQ(tensor->dim(), 2);
+  EXPECT_EQ(tensor->size(0), 0);
+  EXPECT_EQ(tensor->size(1), 5);
+
+  // Delete the tensor
+  AOTITorchError error = aoti_torch_delete_tensor_object(tensor);
+  EXPECT_EQ(error, Error::Ok);
+}
+
+// Test deletion of scalar (0D) tensors
+TEST_F(AOTITorchDeleteTensorObjectTest, DeleteScalarTensor) {
+  // Create a scalar tensor
+  std::vector<int64_t> sizes = {};
+  Tensor* tensor = create_test_tensor(sizes);
+  ASSERT_NE(tensor, nullptr);
+
+  // Verify tensor properties
+  EXPECT_EQ(tensor->dim(), 0);
+
+  // Delete the tensor
+  AOTITorchError error = aoti_torch_delete_tensor_object(tensor);
+  EXPECT_EQ(error, Error::Ok);
+}
+
+// Test deletion of large multi-dimensional tensors
+TEST_F(AOTITorchDeleteTensorObjectTest, DeleteLargeTensor) {
+  // Create a large multi-dimensional tensor
+  std::vector<int64_t> sizes = {10, 20, 30};
+  Tensor* tensor = create_test_tensor(sizes);
+  ASSERT_NE(tensor, nullptr);
+
+  // Verify tensor properties
+  EXPECT_EQ(tensor->dim(), 3);
+  EXPECT_EQ(tensor->size(0), 10);
+  EXPECT_EQ(tensor->size(1), 20);
+  EXPECT_EQ(tensor->size(2), 30);
+
+  // Delete the tensor
+  AOTITorchError error = aoti_torch_delete_tensor_object(tensor);
+  EXPECT_EQ(error, Error::Ok);
+}
+
+// Test deletion of tensors with custom strides
+TEST_F(AOTITorchDeleteTensorObjectTest, DeleteTensorWithCustomStrides) {
+  // Create tensor with custom strides
+  std::vector<int64_t> sizes = {3, 4};
+  std::vector<int64_t> strides = {4, 1}; // Row-major strides
+  Tensor* tensor = create_test_tensor(sizes, strides);
+  ASSERT_NE(tensor, nullptr);
+
+  // Verify tensor properties
+  EXPECT_EQ(tensor->dim(), 2);
+  EXPECT_EQ(tensor->size(0), 3);
+  EXPECT_EQ(tensor->size(1), 4);
+
+  // Delete the tensor
+  AOTITorchError error = aoti_torch_delete_tensor_object(tensor);
+  EXPECT_EQ(error, Error::Ok);
+}
+
+// Test deletion after accessing tensor data
+TEST_F(AOTITorchDeleteTensorObjectTest, DeleteAfterDataAccess) {
+  // Create a tensor
+  std::vector<int64_t> sizes = {2, 3};
+  Tensor* tensor = create_test_tensor(sizes);
+  ASSERT_NE(tensor, nullptr);
+
+  // Access tensor data (this should not prevent deletion)
+  void* data_ptr = tensor->mutable_data_ptr();
+  EXPECT_NE(data_ptr, nullptr);
+
+  // Delete the tensor
+  AOTITorchError error = aoti_torch_delete_tensor_object(tensor);
+  EXPECT_EQ(error, Error::Ok);
+}
+
+// Test double deletion (should fail on second attempt)
+TEST_F(AOTITorchDeleteTensorObjectTest, DoubleDeletion) {
+  // Create a tensor
+  std::vector<int64_t> sizes = {2, 3};
+  Tensor* tensor = create_test_tensor(sizes);
+  ASSERT_NE(tensor, nullptr);
+
+  // First deletion should succeed
+  AOTITorchError error1 = aoti_torch_delete_tensor_object(tensor);
+  EXPECT_EQ(error1, Error::Ok);
+
+  // Second deletion should fail (tensor no longer tracked)
+  AOTITorchError error2 = aoti_torch_delete_tensor_object(tensor);
+  EXPECT_EQ(error2, Error::InvalidArgument);
+}
+
+// Test deletion of tensors on both CUDA and CPU devices
+TEST_F(AOTITorchDeleteTensorObjectTest, DeleteMixedDeviceTensors) {
+  // Create CUDA tensor
+  std::vector<int64_t> sizes = {2, 3};
+  Tensor* cuda_tensor = create_test_tensor(sizes, {}, 6, 1, 0);
+  ASSERT_NE(cuda_tensor, nullptr);
+
+  // Create CPU tensor
+  Tensor* cpu_tensor = create_test_tensor(sizes, {}, 6, 0, 0);
+  ASSERT_NE(cpu_tensor, nullptr);
+
+  // Delete both tensors
+  AOTITorchError cuda_error = aoti_torch_delete_tensor_object(cuda_tensor);
+  EXPECT_EQ(cuda_error, Error::Ok);
+
+  AOTITorchError cpu_error = aoti_torch_delete_tensor_object(cpu_tensor);
+  EXPECT_EQ(cpu_error, Error::Ok);
+}
+
+// Test memory consistency after deletion
+TEST_F(AOTITorchDeleteTensorObjectTest, MemoryConsistencyAfterDeletion) {
+  // Create multiple tensors
+  std::vector<Tensor*> tensors;
+  const int num_tensors = 10;
+
+  for (int i = 0; i < num_tensors; i++) {
+    std::vector<int64_t> sizes = {i + 1, i + 2};
+    Tensor* tensor = create_test_tensor(sizes);
+    ASSERT_NE(tensor, nullptr);
+    tensors.push_back(tensor);
+  }
+
+  // Delete every other tensor
+  for (int i = 0; i < num_tensors; i += 2) {
+    AOTITorchError error = aoti_torch_delete_tensor_object(tensors[i]);
+    EXPECT_EQ(error, Error::Ok);
+  }
+
+  // Delete remaining tensors
+  for (int i = 1; i < num_tensors; i += 2) {
+    AOTITorchError error = aoti_torch_delete_tensor_object(tensors[i]);
+    EXPECT_EQ(error, Error::Ok);
+  }
+}
+
+// Test stress deletion with many small tensors
+TEST_F(AOTITorchDeleteTensorObjectTest, StressDeletionManySmallTensors) {
+  const int num_tensors = 100;
+  std::vector<Tensor*> tensors;
+
+  // Create many small tensors
+  for (int i = 0; i < num_tensors; i++) {
+    std::vector<int64_t> sizes = {1, 1}; // Minimal size
+    Tensor* tensor = create_test_tensor(sizes);
+    if (tensor != nullptr) {
+      tensors.push_back(tensor);
+    }
+  }
+
+  // Delete all created tensors
+  for (Tensor* tensor : tensors) {
+    AOTITorchError error = aoti_torch_delete_tensor_object(tensor);
+    EXPECT_EQ(error, Error::Ok);
+  }
+}
+
+// Test CUDA synchronization during deletion
+TEST_F(AOTITorchDeleteTensorObjectTest, CudaSynchronizationDuringDeletion) {
+  // Create a larger CUDA tensor to ensure memory allocation
+  std::vector<int64_t> sizes = {100, 100};
+  Tensor* tensor = create_test_tensor(sizes, {}, 6, 1, 0); // CUDA device
+  ASSERT_NE(tensor, nullptr);
+
+  // Delete the tensor (should handle synchronization internally)
+  AOTITorchError error = aoti_torch_delete_tensor_object(tensor);
+  EXPECT_EQ(error, Error::Ok);
+
+  // Verify CUDA state is still good
+  cudaError_t cuda_error = cudaGetLastError();
+  EXPECT_EQ(cuda_error, cudaSuccess);
+}
+
+// Test specific deletion of bfloat16 tensors
+TEST_F(AOTITorchDeleteTensorObjectTest, DeleteBFloat16Tensor) {
+  // Test 1D bfloat16 tensor deletion
+  std::vector<int64_t> sizes_1d = {10};
+  Tensor* tensor_bf16_1d = create_test_tensor(
+      sizes_1d,
+      {},
+      static_cast<int32_t>(SupportedDTypes::BFLOAT16),
+      1, // CUDA device
+      0);
+  ASSERT_NE(tensor_bf16_1d, nullptr);
+
+  // Verify it's bfloat16 before deletion
+  int32_t actual_dtype;
+  EXPECT_EQ(aoti_torch_get_dtype(tensor_bf16_1d, &actual_dtype), Error::Ok);
+  EXPECT_EQ(actual_dtype, static_cast<int32_t>(SupportedDTypes::BFLOAT16))
+      << "Expected bfloat16 dtype ("
+      << static_cast<int32_t>(SupportedDTypes::BFLOAT16) << "), got "
+      << actual_dtype;
+
+  // Verify element size (bfloat16 should be 2 bytes per element)
+  EXPECT_EQ(tensor_bf16_1d->element_size(), 2);
+
+  // Delete the bfloat16 tensor
+  AOTITorchError error = aoti_torch_delete_tensor_object(tensor_bf16_1d);
+  EXPECT_EQ(error, Error::Ok);
+
+  // Test 2D bfloat16 tensor deletion with custom strides
+  std::vector<int64_t> sizes_2d = {4, 6};
+  std::vector<int64_t> strides_2d = {6, 1}; // Row-major strides
+  Tensor* tensor_bf16_2d = create_test_tensor(
+      sizes_2d,
+      strides_2d,
+      static_cast<int32_t>(SupportedDTypes::BFLOAT16),
+      1, // CUDA device
+      0);
+  ASSERT_NE(tensor_bf16_2d, nullptr);
+
+  // Verify tensor properties
+  EXPECT_EQ(tensor_bf16_2d->dim(), 2);
+  EXPECT_EQ(tensor_bf16_2d->size(0), 4);
+  EXPECT_EQ(tensor_bf16_2d->size(1), 6);
+  EXPECT_EQ(tensor_bf16_2d->element_size(), 2);
+
+  // Verify it's bfloat16
+  int32_t dtype_2d;
+  EXPECT_EQ(aoti_torch_get_dtype(tensor_bf16_2d, &dtype_2d), Error::Ok);
+  EXPECT_EQ(dtype_2d, static_cast<int32_t>(SupportedDTypes::BFLOAT16));
+
+  // Delete the 2D bfloat16 tensor
+  error = aoti_torch_delete_tensor_object(tensor_bf16_2d);
+  EXPECT_EQ(error, Error::Ok);
+
+  // Test 3D bfloat16 tensor deletion
+  std::vector<int64_t> sizes_3d = {2, 3, 4};
+  Tensor* tensor_bf16_3d = create_test_tensor(
+      sizes_3d,
+      {},
+      static_cast<int32_t>(SupportedDTypes::BFLOAT16),
+      1, // CUDA device
+      0);
+  ASSERT_NE(tensor_bf16_3d, nullptr);
+
+  // Verify tensor properties
+  EXPECT_EQ(tensor_bf16_3d->dim(), 3);
+  EXPECT_EQ(tensor_bf16_3d->size(0), 2);
+  EXPECT_EQ(tensor_bf16_3d->size(1), 3);
+  EXPECT_EQ(tensor_bf16_3d->size(2), 4);
+  EXPECT_EQ(tensor_bf16_3d->element_size(), 2);
+
+  // Verify memory size (2 * 3 * 4 * 2 bytes = 48 bytes)
+  size_t expected_memory = 2 * 3 * 4 * 2;
+  size_t actual_memory =
+      tensor_bf16_3d->numel() * tensor_bf16_3d->element_size();
+  EXPECT_EQ(actual_memory, expected_memory);
+
+  // Delete the 3D bfloat16 tensor
+  error = aoti_torch_delete_tensor_object(tensor_bf16_3d);
+  EXPECT_EQ(error, Error::Ok);
+
+  // Test bfloat16 scalar tensor (0D) deletion
+  std::vector<int64_t> scalar_sizes = {};
+  Tensor* tensor_bf16_scalar = create_test_tensor(
+      scalar_sizes,
+      {},
+      static_cast<int32_t>(SupportedDTypes::BFLOAT16),
+      1, // CUDA device
+      0);
+  ASSERT_NE(tensor_bf16_scalar, nullptr);
+
+  // Verify scalar tensor properties
+  EXPECT_EQ(tensor_bf16_scalar->dim(), 0);
+  EXPECT_EQ(tensor_bf16_scalar->numel(), 1);
+  EXPECT_EQ(tensor_bf16_scalar->element_size(), 2);
+
+  // Delete the scalar bfloat16 tensor
+  error = aoti_torch_delete_tensor_object(tensor_bf16_scalar);
+  EXPECT_EQ(error, Error::Ok);
+
+  // Test zero-element bfloat16 tensor deletion
+  std::vector<int64_t> zero_sizes = {0, 5};
+  Tensor* tensor_bf16_zero = create_test_tensor(
+      zero_sizes,
+      {},
+      static_cast<int32_t>(SupportedDTypes::BFLOAT16),
+      1, // CUDA device
+      0);
+  ASSERT_NE(tensor_bf16_zero, nullptr);
+
+  // Verify zero-element tensor properties
+  EXPECT_EQ(tensor_bf16_zero->dim(), 2);
+  EXPECT_EQ(tensor_bf16_zero->size(0), 0);
+  EXPECT_EQ(tensor_bf16_zero->size(1), 5);
+  EXPECT_EQ(tensor_bf16_zero->numel(), 0);
+  EXPECT_EQ(tensor_bf16_zero->element_size(), 2);
+
+  // Delete the zero-element bfloat16 tensor
+  error = aoti_torch_delete_tensor_object(tensor_bf16_zero);
+  EXPECT_EQ(error, Error::Ok);
+}
+
+// Test deletion of mixed dtype tensors (float32 and bfloat16)

--- a/backends/cuda/runtime/shims/tests/test_aoti_torch_empty_strided.cpp
+++ b/backends/cuda/runtime/shims/tests/test_aoti_torch_empty_strided.cpp
@@ -1,0 +1,588 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <cuda_runtime.h>
+#include <executorch/backends/aoti/common_shims.h>
+#include <executorch/backends/cuda/runtime/shims/memory.h>
+#include <executorch/backends/cuda/runtime/shims/tensor_attribute.h>
+#include <executorch/backends/cuda/runtime/shims/utils.h>
+#include <executorch/runtime/core/error.h>
+#include <executorch/runtime/platform/platform.h>
+#include <gtest/gtest.h>
+#include <vector>
+
+using namespace executorch::backends::cuda;
+using namespace executorch::backends::aoti;
+using namespace executorch::runtime;
+using executorch::runtime::etensor::Tensor;
+
+// Test fixture for aoti_torch_empty_strided tests
+class AOTITorchEmptyStridedTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // Initialize ExecuTorch Platform Abstraction Layer
+    et_pal_init();
+
+    // Check if CUDA is available
+    int device_count = 0;
+    cudaError_t err = cudaGetDeviceCount(&device_count);
+    if (err != cudaSuccess || device_count == 0) {
+      GTEST_SKIP() << "CUDA not available, skipping CUDA tests";
+    }
+
+    // Clean up any existing cached metadata before each test
+    cleanup_tensor_metadata();
+
+    // Clear any remaining tensors from previous tests
+    clear_all_tensors();
+  }
+
+  void TearDown() override {
+    // Clean up metadata
+    cleanup_tensor_metadata();
+
+    // Clear the global tensor storage using the provided function
+    clear_all_tensors();
+  }
+
+  // Helper to create test tensors
+  Tensor* create_tracked_tensor(
+      const std::vector<int64_t>& sizes,
+      const std::vector<int64_t>& strides = {},
+      int32_t dtype = static_cast<int32_t>(SupportedDTypes::FLOAT32),
+      int32_t device_type = static_cast<int32_t>(SupportedDevices::CUDA),
+      int32_t device_index = 0) {
+    Tensor* tensor;
+
+    const int64_t* strides_ptr = strides.empty() ? nullptr : strides.data();
+
+    AOTITorchError error = aoti_torch_empty_strided(
+        sizes.size(),
+        sizes.data(),
+        strides_ptr,
+        dtype,
+        device_type,
+        device_index,
+        &tensor);
+
+    return (error == Error::Ok) ? tensor : nullptr;
+  }
+};
+
+// Test aoti_torch_empty_strided basic functionality
+TEST_F(AOTITorchEmptyStridedTest, BasicFunctionality) {
+  // Test 1D tensor
+  std::vector<int64_t> sizes_1d = {5};
+  Tensor* tensor_1d;
+  AOTITorchError error = aoti_torch_empty_strided(
+      sizes_1d.size(),
+      sizes_1d.data(),
+      nullptr, // Let function compute strides
+      static_cast<int32_t>(SupportedDTypes::FLOAT32),
+      static_cast<int32_t>(SupportedDevices::CUDA),
+      0, // device index
+      &tensor_1d);
+
+  EXPECT_EQ(error, Error::Ok);
+  EXPECT_NE(tensor_1d, nullptr);
+
+  // CRITICAL: Verify the tensor is actually float32
+  int32_t actual_dtype;
+  EXPECT_EQ(aoti_torch_get_dtype(tensor_1d, &actual_dtype), Error::Ok);
+  EXPECT_EQ(actual_dtype, static_cast<int32_t>(SupportedDTypes::FLOAT32))
+      << "Expected float32 dtype ("
+      << static_cast<int32_t>(SupportedDTypes::FLOAT32) << "), got "
+      << actual_dtype;
+
+  // Verify element size (float32 should be 4 bytes per element)
+  size_t element_size = tensor_1d->element_size();
+  EXPECT_EQ(element_size, 4)
+      << "Expected float32 element size to be 4 bytes, got " << element_size;
+
+  // Verify total number of elements and memory usage
+  int64_t expected_numel = 5; // 5 elements
+  EXPECT_EQ(tensor_1d->numel(), expected_numel)
+      << "Expected " << expected_numel << " elements, got "
+      << tensor_1d->numel();
+
+  // Verify total memory size (numel * element_size)
+  size_t expected_memory_size = expected_numel * 4; // 5 * 4 = 20 bytes
+  size_t actual_memory_size = tensor_1d->numel() * tensor_1d->element_size();
+  EXPECT_EQ(actual_memory_size, expected_memory_size)
+      << "Expected " << expected_memory_size << " bytes, got "
+      << actual_memory_size;
+
+  // Check tensor properties
+  EXPECT_EQ(tensor_1d->dim(), 1);
+  EXPECT_EQ(tensor_1d->size(0), 5);
+
+  // Test 2D tensor with explicit strides
+  std::vector<int64_t> sizes_2d = {3, 4};
+  std::vector<int64_t> strides_2d = {4, 1};
+  Tensor* tensor_2d;
+  error = aoti_torch_empty_strided(
+      sizes_2d.size(),
+      sizes_2d.data(),
+      strides_2d.data(),
+      static_cast<int32_t>(SupportedDTypes::FLOAT32),
+      static_cast<int32_t>(SupportedDevices::CUDA),
+      0, // device index
+      &tensor_2d);
+
+  EXPECT_EQ(error, Error::Ok);
+  EXPECT_NE(tensor_2d, nullptr);
+
+  // Verify 2D tensor is also float32
+  int32_t dtype_2d;
+  EXPECT_EQ(aoti_torch_get_dtype(tensor_2d, &dtype_2d), Error::Ok);
+  EXPECT_EQ(dtype_2d, static_cast<int32_t>(SupportedDTypes::FLOAT32))
+      << "Expected float32 dtype ("
+      << static_cast<int32_t>(SupportedDTypes::FLOAT32) << "), got "
+      << dtype_2d;
+
+  // Verify element size for 2D tensor
+  EXPECT_EQ(tensor_2d->element_size(), 4);
+
+  // Check tensor properties
+  EXPECT_EQ(tensor_2d->dim(), 2);
+  EXPECT_EQ(tensor_2d->size(0), 3);
+  EXPECT_EQ(tensor_2d->size(1), 4);
+
+  // Verify memory size for 2D tensor
+  int64_t expected_numel_2d = 3 * 4; // 12 elements
+  size_t expected_memory_2d = expected_numel_2d * 4; // 12 * 4 = 48 bytes
+  EXPECT_EQ(tensor_2d->numel() * tensor_2d->element_size(), expected_memory_2d);
+}
+
+// Test aoti_torch_empty_strided with CPU device
+TEST_F(AOTITorchEmptyStridedTest, CPUDevice) {
+  std::vector<int64_t> sizes = {2, 3};
+  Tensor* tensor;
+  AOTITorchError error = aoti_torch_empty_strided(
+      sizes.size(),
+      sizes.data(),
+      nullptr, // Let function compute strides
+      static_cast<int32_t>(SupportedDTypes::FLOAT32),
+      static_cast<int32_t>(SupportedDevices::CPU),
+      0, // device index
+      &tensor);
+
+  EXPECT_EQ(error, Error::Ok);
+  EXPECT_NE(tensor, nullptr);
+
+  // Check tensor properties
+  EXPECT_EQ(tensor->dim(), 2);
+  EXPECT_EQ(tensor->size(0), 2);
+  EXPECT_EQ(tensor->size(1), 3);
+}
+
+// Test aoti_torch_empty_strided with invalid dtype
+TEST_F(AOTITorchEmptyStridedTest, InvalidDtype) {
+  std::vector<int64_t> sizes = {2, 3};
+  Tensor* tensor;
+  AOTITorchError error = aoti_torch_empty_strided(
+      sizes.size(),
+      sizes.data(),
+      nullptr,
+      999, // invalid dtype
+      1, // CUDA device
+      0, // device index
+      &tensor);
+
+  EXPECT_EQ(error, Error::InvalidArgument);
+}
+
+// Test aoti_torch_empty_strided with unsupported device
+TEST_F(AOTITorchEmptyStridedTest, UnsupportedDevice) {
+  std::vector<int64_t> sizes = {2, 3};
+  Tensor* tensor;
+  AOTITorchError error = aoti_torch_empty_strided(
+      sizes.size(),
+      sizes.data(),
+      nullptr,
+      6, // float32
+      2, // unsupported device type
+      0, // device index
+      &tensor);
+
+  EXPECT_EQ(error, Error::NotImplemented);
+}
+
+// Test aoti_torch_empty_strided with zero-sized tensor
+TEST_F(AOTITorchEmptyStridedTest, ZeroSized) {
+  std::vector<int64_t> sizes = {0, 5};
+  Tensor* tensor;
+  AOTITorchError error = aoti_torch_empty_strided(
+      sizes.size(),
+      sizes.data(),
+      nullptr,
+      6, // float32
+      1, // CUDA device
+      0, // device index
+      &tensor);
+
+  EXPECT_EQ(error, Error::Ok);
+  EXPECT_NE(tensor, nullptr);
+
+  // Check tensor properties
+  EXPECT_EQ(tensor->dim(), 2);
+  EXPECT_EQ(tensor->size(0), 0);
+  EXPECT_EQ(tensor->size(1), 5);
+}
+
+// Test aoti_torch_empty_strided scalar tensor (0D)
+TEST_F(AOTITorchEmptyStridedTest, Scalar) {
+  std::vector<int64_t> sizes = {};
+  Tensor* tensor;
+  AOTITorchError error = aoti_torch_empty_strided(
+      sizes.size(),
+      sizes.data(),
+      nullptr,
+      6, // float32
+      1, // CUDA device
+      0, // device index
+      &tensor);
+
+  EXPECT_EQ(error, Error::Ok);
+  EXPECT_NE(tensor, nullptr);
+
+  // Check tensor properties
+  EXPECT_EQ(tensor->dim(), 0);
+}
+
+// Test aoti_torch_empty_strided with large tensor
+TEST_F(AOTITorchEmptyStridedTest, LargeTensor) {
+  std::vector<int64_t> sizes = {100, 200, 50};
+  Tensor* tensor;
+  AOTITorchError error = aoti_torch_empty_strided(
+      sizes.size(),
+      sizes.data(),
+      nullptr,
+      6, // float32
+      1, // CUDA device
+      0, // device index
+      &tensor);
+
+  EXPECT_EQ(error, Error::Ok);
+  EXPECT_NE(tensor, nullptr);
+
+  // Check tensor properties
+  EXPECT_EQ(tensor->dim(), 3);
+  EXPECT_EQ(tensor->size(0), 100);
+  EXPECT_EQ(tensor->size(1), 200);
+  EXPECT_EQ(tensor->size(2), 50);
+}
+
+// Test error handling with memory allocation failures
+TEST_F(AOTITorchEmptyStridedTest, MemoryAllocationStress) {
+  // Try to create a very large tensor that might cause allocation failure
+  // (This test may pass or fail depending on available memory)
+  std::vector<int64_t> huge_sizes = {10000, 10000, 100}; // ~38GB for float32
+  Tensor* tensor;
+
+  AOTITorchError error = aoti_torch_empty_strided(
+      huge_sizes.size(),
+      huge_sizes.data(),
+      nullptr,
+      6, // float32
+      1, // CUDA device
+      0, // device index
+      &tensor);
+
+  // Either succeed or fail with memory allocation error
+  if (error == Error::Ok) {
+    EXPECT_NE(tensor, nullptr);
+  } else {
+    EXPECT_EQ(error, Error::MemoryAllocationFailed);
+  }
+}
+
+// Test aoti_torch_empty_strided with bfloat16 dtype
+TEST_F(AOTITorchEmptyStridedTest, BFloat16Tensor) {
+  // Test creating bfloat16 tensor on CUDA
+  std::vector<int64_t> sizes = {2, 3, 4};
+  Tensor* tensor_bf16;
+  AOTITorchError error = aoti_torch_empty_strided(
+      sizes.size(),
+      sizes.data(),
+      nullptr, // Let function compute strides
+      static_cast<int32_t>(SupportedDTypes::BFLOAT16),
+      static_cast<int32_t>(SupportedDevices::CUDA),
+      0, // device index
+      &tensor_bf16);
+
+  EXPECT_EQ(error, Error::Ok);
+  EXPECT_NE(tensor_bf16, nullptr);
+
+  // CRITICAL: Verify the tensor is actually bfloat16
+  int32_t actual_dtype;
+  EXPECT_EQ(aoti_torch_get_dtype(tensor_bf16, &actual_dtype), Error::Ok);
+  EXPECT_EQ(actual_dtype, static_cast<int32_t>(SupportedDTypes::BFLOAT16))
+      << "Expected bfloat16 dtype ("
+      << static_cast<int32_t>(SupportedDTypes::BFLOAT16) << "), got "
+      << actual_dtype;
+
+  // Verify element size (bfloat16 should be 2 bytes per element)
+  size_t element_size = tensor_bf16->element_size();
+  EXPECT_EQ(element_size, 2)
+      << "Expected bfloat16 element size to be 2 bytes, got " << element_size;
+
+  // Verify total number of elements and memory usage
+  int64_t expected_numel = 2 * 3 * 4; // 24 elements
+  EXPECT_EQ(tensor_bf16->numel(), expected_numel)
+      << "Expected " << expected_numel << " elements, got "
+      << tensor_bf16->numel();
+
+  // Verify total memory size (numel * element_size)
+  size_t expected_memory_size = expected_numel * 2; // 24 * 2 = 48 bytes
+  size_t actual_memory_size =
+      tensor_bf16->numel() * tensor_bf16->element_size();
+  EXPECT_EQ(actual_memory_size, expected_memory_size)
+      << "Expected " << expected_memory_size << " bytes, got "
+      << actual_memory_size;
+
+  // Check tensor properties
+  EXPECT_EQ(tensor_bf16->dim(), 3);
+  EXPECT_EQ(tensor_bf16->size(0), 2);
+  EXPECT_EQ(tensor_bf16->size(1), 3);
+  EXPECT_EQ(tensor_bf16->size(2), 4);
+
+  // Verify we can get tensor metadata
+  int64_t* sizes_ptr;
+  int64_t* strides_ptr;
+  EXPECT_EQ(aoti_torch_get_sizes(tensor_bf16, &sizes_ptr), Error::Ok);
+  EXPECT_EQ(aoti_torch_get_strides(tensor_bf16, &strides_ptr), Error::Ok);
+
+  // Check sizes match
+  EXPECT_EQ(sizes_ptr[0], 2);
+  EXPECT_EQ(sizes_ptr[1], 3);
+  EXPECT_EQ(sizes_ptr[2], 4);
+
+  // Check that strides are computed correctly (row-major order)
+  EXPECT_EQ(strides_ptr[0], 12); // 3 * 4
+  EXPECT_EQ(strides_ptr[1], 4); // 4
+  EXPECT_EQ(strides_ptr[2], 1); // 1
+
+  // Test bfloat16 tensor with custom strides
+  std::vector<int64_t> sizes_2d = {3, 2};
+  std::vector<int64_t> strides_2d = {2, 1}; // Row-major strides
+  Tensor* tensor_bf16_custom;
+  error = aoti_torch_empty_strided(
+      sizes_2d.size(),
+      sizes_2d.data(),
+      strides_2d.data(),
+      static_cast<int32_t>(SupportedDTypes::BFLOAT16),
+      static_cast<int32_t>(SupportedDevices::CUDA),
+      0, // device index
+      &tensor_bf16_custom);
+
+  EXPECT_EQ(error, Error::Ok);
+  EXPECT_NE(tensor_bf16_custom, nullptr);
+
+  // Verify custom stride tensor is also bfloat16
+  int32_t custom_dtype;
+  EXPECT_EQ(aoti_torch_get_dtype(tensor_bf16_custom, &custom_dtype), Error::Ok);
+  EXPECT_EQ(custom_dtype, static_cast<int32_t>(SupportedDTypes::BFLOAT16))
+      << "Expected bfloat16 dtype ("
+      << static_cast<int32_t>(SupportedDTypes::BFLOAT16) << "), got "
+      << custom_dtype;
+
+  // Verify element size for custom stride tensor
+  EXPECT_EQ(tensor_bf16_custom->element_size(), 2);
+
+  // Check tensor properties
+  EXPECT_EQ(tensor_bf16_custom->dim(), 2);
+  EXPECT_EQ(tensor_bf16_custom->size(0), 3);
+  EXPECT_EQ(tensor_bf16_custom->size(1), 2);
+
+  // Verify memory size for custom stride tensor
+  int64_t custom_expected_numel = 3 * 2; // 6 elements
+  size_t custom_expected_memory = custom_expected_numel * 2; // 6 * 2 = 12 bytes
+  EXPECT_EQ(
+      tensor_bf16_custom->numel() * tensor_bf16_custom->element_size(),
+      custom_expected_memory);
+
+  // Check custom strides
+  int64_t* custom_strides_ptr;
+  EXPECT_EQ(
+      aoti_torch_get_strides(tensor_bf16_custom, &custom_strides_ptr),
+      Error::Ok);
+  EXPECT_EQ(custom_strides_ptr[0], 2);
+  EXPECT_EQ(custom_strides_ptr[1], 1);
+
+  // Test bfloat16 scalar tensor (0D)
+  std::vector<int64_t> scalar_sizes = {};
+  Tensor* tensor_bf16_scalar;
+  error = aoti_torch_empty_strided(
+      scalar_sizes.size(),
+      scalar_sizes.data(),
+      nullptr,
+      static_cast<int32_t>(SupportedDTypes::BFLOAT16),
+      static_cast<int32_t>(SupportedDevices::CUDA),
+      0, // device index
+      &tensor_bf16_scalar);
+
+  EXPECT_EQ(error, Error::Ok);
+  EXPECT_NE(tensor_bf16_scalar, nullptr);
+  EXPECT_EQ(tensor_bf16_scalar->dim(), 0);
+
+  // Verify scalar tensor is also bfloat16
+  int32_t scalar_dtype;
+  EXPECT_EQ(aoti_torch_get_dtype(tensor_bf16_scalar, &scalar_dtype), Error::Ok);
+  EXPECT_EQ(scalar_dtype, static_cast<int32_t>(SupportedDTypes::BFLOAT16))
+      << "Expected bfloat16 dtype ("
+      << static_cast<int32_t>(SupportedDTypes::BFLOAT16) << "), got "
+      << scalar_dtype;
+
+  // Verify scalar tensor properties
+  EXPECT_EQ(tensor_bf16_scalar->element_size(), 2);
+  EXPECT_EQ(tensor_bf16_scalar->numel(), 1); // Scalar tensor has 1 element
+  EXPECT_EQ(
+      tensor_bf16_scalar->numel() * tensor_bf16_scalar->element_size(),
+      2); // 1 * 2 = 2 bytes
+}
+
+// Test custom strides functionality
+TEST_F(AOTITorchEmptyStridedTest, CustomStrides) {
+  // Create tensor with valid custom strides (contiguous layout)
+  std::vector<int64_t> sizes = {2, 3};
+  std::vector<int64_t> strides = {3, 1}; // Standard row-major strides
+
+  Tensor* tensor = create_tracked_tensor(sizes, strides);
+  EXPECT_NE(tensor, nullptr);
+
+  // Verify the tensor was created correctly
+  EXPECT_EQ(tensor->dim(), 2);
+  EXPECT_EQ(tensor->size(0), 2);
+  EXPECT_EQ(tensor->size(1), 3);
+
+  // Check strides through AOTI interface
+  int64_t* strides_ptr;
+  EXPECT_EQ(aoti_torch_get_strides(tensor, &strides_ptr), Error::Ok);
+  EXPECT_EQ(strides_ptr[0], 3);
+  EXPECT_EQ(strides_ptr[1], 1);
+
+  // Test another valid stride pattern - transpose-like
+  std::vector<int64_t> sizes_2 = {3, 2};
+  std::vector<int64_t> strides_2 = {1, 3}; // Column-major strides
+
+  Tensor* tensor_2 = create_tracked_tensor(sizes_2, strides_2);
+  EXPECT_NE(tensor_2, nullptr);
+
+  // Verify the tensor properties
+  EXPECT_EQ(tensor_2->dim(), 2);
+  EXPECT_EQ(tensor_2->size(0), 3);
+  EXPECT_EQ(tensor_2->size(1), 2);
+
+  // Check strides
+  int64_t* strides_ptr_2;
+  EXPECT_EQ(aoti_torch_get_strides(tensor_2, &strides_ptr_2), Error::Ok);
+  EXPECT_EQ(strides_ptr_2[0], 1);
+  EXPECT_EQ(strides_ptr_2[1], 3);
+}
+
+// Test edge case: zero-element tensor with non-zero dimensions
+TEST_F(AOTITorchEmptyStridedTest, ZeroElementTensor) {
+  std::vector<int64_t> sizes = {2, 0, 3}; // Total elements = 0
+  Tensor* tensor = create_tracked_tensor(sizes);
+  EXPECT_NE(tensor, nullptr);
+
+  // Verify the tensor properties
+  EXPECT_EQ(tensor->dim(), 3);
+  EXPECT_EQ(tensor->size(0), 2);
+  EXPECT_EQ(tensor->size(1), 0);
+  EXPECT_EQ(tensor->size(2), 3);
+
+  // Should be able to get metadata
+  int64_t* sizes_ptr;
+  int64_t* strides_ptr;
+  EXPECT_EQ(aoti_torch_get_sizes(tensor, &sizes_ptr), Error::Ok);
+  EXPECT_EQ(aoti_torch_get_strides(tensor, &strides_ptr), Error::Ok);
+
+  EXPECT_EQ(sizes_ptr[0], 2);
+  EXPECT_EQ(sizes_ptr[1], 0);
+  EXPECT_EQ(sizes_ptr[2], 3);
+}
+
+// Test different data types (only float32 is currently supported)
+TEST_F(AOTITorchEmptyStridedTest, DifferentDataTypes) {
+  std::vector<int64_t> sizes = {2, 3};
+
+  // Test float32 (dtype 6) - currently the only supported type
+  Tensor* tensor_float32;
+  AOTITorchError error = aoti_torch_empty_strided(
+      sizes.size(),
+      sizes.data(),
+      nullptr,
+      6, // float32
+      1, // CUDA device
+      0, // device index
+      &tensor_float32);
+
+  EXPECT_EQ(error, Error::Ok);
+  EXPECT_NE(tensor_float32, nullptr);
+
+  // Test unsupported data types should return error
+  Tensor* tensor_int32;
+  error = aoti_torch_empty_strided(
+      sizes.size(),
+      sizes.data(),
+      nullptr,
+      3, // int32 - unsupported
+      1, // CUDA device
+      0, // device index
+      &tensor_int32);
+
+  EXPECT_EQ(error, Error::InvalidArgument); // Should fail for unsupported dtype
+
+  // Test another unsupported data type
+  Tensor* tensor_float64;
+  error = aoti_torch_empty_strided(
+      sizes.size(),
+      sizes.data(),
+      nullptr,
+      7, // float64 - unsupported
+      1, // CUDA device
+      0, // device index
+      &tensor_float64);
+
+  EXPECT_EQ(error, Error::InvalidArgument); // Should fail for unsupported dtype
+}
+
+// Test multi-dimensional tensors with various shapes
+TEST_F(AOTITorchEmptyStridedTest, MultiDimensionalTensors) {
+  // Test 3D tensor
+  std::vector<int64_t> sizes_3d = {2, 3, 4};
+  Tensor* tensor_3d = create_tracked_tensor(sizes_3d);
+  EXPECT_NE(tensor_3d, nullptr);
+  EXPECT_EQ(tensor_3d->dim(), 3);
+  EXPECT_EQ(tensor_3d->size(0), 2);
+  EXPECT_EQ(tensor_3d->size(1), 3);
+  EXPECT_EQ(tensor_3d->size(2), 4);
+
+  // Test 4D tensor
+  std::vector<int64_t> sizes_4d = {2, 3, 4, 5};
+  Tensor* tensor_4d = create_tracked_tensor(sizes_4d);
+  EXPECT_NE(tensor_4d, nullptr);
+  EXPECT_EQ(tensor_4d->dim(), 4);
+  EXPECT_EQ(tensor_4d->size(0), 2);
+  EXPECT_EQ(tensor_4d->size(1), 3);
+  EXPECT_EQ(tensor_4d->size(2), 4);
+  EXPECT_EQ(tensor_4d->size(3), 5);
+
+  // Test 5D tensor
+  std::vector<int64_t> sizes_5d = {1, 2, 3, 4, 5};
+  Tensor* tensor_5d = create_tracked_tensor(sizes_5d);
+  EXPECT_NE(tensor_5d, nullptr);
+  EXPECT_EQ(tensor_5d->dim(), 5);
+  EXPECT_EQ(tensor_5d->size(0), 1);
+  EXPECT_EQ(tensor_5d->size(1), 2);
+  EXPECT_EQ(tensor_5d->size(2), 3);
+  EXPECT_EQ(tensor_5d->size(3), 4);
+  EXPECT_EQ(tensor_5d->size(4), 5);
+}

--- a/backends/cuda/runtime/shims/utils.h
+++ b/backends/cuda/runtime/shims/utils.h
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cuda_runtime.h>
+#include <executorch/runtime/core/error.h>
+#include <executorch/runtime/core/exec_aten/exec_aten.h>
+#include <cstdint>
+#include <vector>
+
+namespace executorch {
+namespace backends {
+namespace cuda {
+
+// Enum for supported data types in et-cuda backend
+enum class SupportedDTypes : int32_t {
+  FLOAT32 = 6, // PyTorch's float32 dtype code
+  BFLOAT16 = 15, // PyTorch's bfloat16 dtype code
+};
+
+// Enum for supported device types in et-cuda backend
+enum class SupportedDevices : int32_t {
+  CPU = 0, // CPU device
+  CUDA = 1, // CUDA device
+};
+
+// Utility function to convert sizes pointer to vector
+inline std::vector<executorch::aten::SizesType> convert_sizes_to_vector(
+    int64_t ndim,
+    const int64_t* sizes_ptr) {
+  std::vector<executorch::aten::SizesType> sizes(ndim);
+  for (int i = 0; i < ndim; i++) {
+    sizes[i] = static_cast<executorch::aten::SizesType>(sizes_ptr[i]);
+  }
+  return sizes;
+}
+
+// Utility function to convert strides pointer to vector or calculate from sizes
+inline std::vector<executorch::aten::StridesType> convert_strides_to_vector(
+    int64_t ndim,
+    const int64_t* sizes_ptr,
+    const int64_t* strides_ptr) {
+  std::vector<executorch::aten::StridesType> strides(ndim);
+
+  if (strides_ptr != nullptr) {
+    // Use provided strides. it is ok if provided strides here is not contiguous
+    // strides since it will be used internally in CUDA delegate.
+    for (int64_t i = 0; i < ndim; i++) {
+      strides[i] = static_cast<executorch::aten::StridesType>(strides_ptr[i]);
+    }
+  } else {
+    // Calculate strides from sizes using ExecutorTorch's algorithm
+    if (ndim > 0) {
+      strides[ndim - 1] = static_cast<executorch::aten::StridesType>(
+          1); // Last dimension has stride 1
+      for (int64_t i = ndim - 2; i >= 0; i--) {
+        if (sizes_ptr[i + 1] == 0) {
+          strides[i] = strides[i + 1]; // Copy stride when size is 0
+        } else {
+          strides[i] = static_cast<executorch::aten::StridesType>(
+              static_cast<int64_t>(strides[i + 1]) * sizes_ptr[i + 1]);
+        }
+      }
+    }
+  }
+  return strides;
+}
+
+extern "C" {
+using executorch::runtime::Error;
+// Common AOTI type aliases
+using AOTITorchError = Error;
+
+// Helper function to check if a dtype is supported in ET CUDA backend
+inline bool is_dtype_supported_in_et_cuda(int32_t dtype) {
+  switch (dtype) {
+    case static_cast<int32_t>(SupportedDTypes::FLOAT32):
+    case static_cast<int32_t>(SupportedDTypes::BFLOAT16):
+      return true;
+    default:
+      return false;
+  }
+}
+
+// Dtype validation utility function
+inline AOTITorchError validate_dtype(int32_t dtype) {
+  if (is_dtype_supported_in_et_cuda(dtype)) {
+    return Error::Ok;
+  }
+
+  ET_LOG(
+      Error,
+      "Unsupported dtype: %d. Supported dtypes: %d (float32), %d (bfloat16)",
+      dtype,
+      static_cast<int32_t>(SupportedDTypes::FLOAT32),
+      static_cast<int32_t>(SupportedDTypes::BFLOAT16));
+  return Error::InvalidArgument;
+}
+} // extern "C"
+
+} // namespace cuda
+} // namespace backends
+} // namespace executorch

--- a/backends/cuda/runtime/shims/utils.h
+++ b/backends/cuda/runtime/shims/utils.h
@@ -14,6 +14,26 @@
 #include <cstdint>
 #include <vector>
 
+// CUDA error checking macro
+#define ET_CUDA_CHECK_OR_RETURN_ERROR(EXPR) \
+  do {                                      \
+    const cudaError_t err = EXPR;           \
+    if (err == cudaSuccess) {               \
+      break;                                \
+    }                                       \
+    ET_LOG(                                 \
+        Error,                              \
+        "%s:%d CUDA error: %s",             \
+        __FILE__,                           \
+        __LINE__,                           \
+        cudaGetErrorString(err));           \
+    return Error::Internal;                 \
+  } while (0)
+
+// Kernel launch check macro
+#define ET_CUDA_KERNEL_LAUNCH_CHECK_OR_RETURN_ERROR() \
+  ET_CUDA_CHECK_OR_RETURN_ERROR(cudaGetLastError())
+
 namespace executorch {
 namespace backends {
 namespace cuda {


### PR DESCRIPTION
Summary: Introduced aoti_torch__reinterpret_tensor, which creates a new tensor view that reinterprets the same underlying memory with custom shape and strides.

Differential Revision: D83094603
