### PR TITLE
Pin MacOS runners to MacOS 14

### DIFF
--- a/.ci/scripts/gather_test_models.py
+++ b/.ci/scripts/gather_test_models.py
@@ -18,7 +18,7 @@ from examples.xnnpack import MODEL_NAME_TO_OPTIONS, QuantType
 
 DEFAULT_RUNNERS = {
     "linux": "linux.2xlarge",
-    "macos": "macos-m1-stable",
+    "macos": "macos-m1-14",
 }
 CUSTOM_RUNNERS = {
     "linux": {

--- a/.github/workflows/_test_backend.yml
+++ b/.github/workflows/_test_backend.yml
@@ -70,7 +70,7 @@ jobs:
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@release/2.9
     with:
       ref: ${{ inputs.ref }}
-      runner: macos-m1-stable
+      runner: macos-m1-14
       python-version: "3.12"
       submodules: recursive
       timeout: ${{ inputs.timeout }}

--- a/.github/workflows/_unittest.yml
+++ b/.github/workflows/_unittest.yml
@@ -44,7 +44,7 @@ jobs:
   macos:
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@release/2.9
     with:
-      runner: macos-m1-stable
+      runner: macos-m1-14
       python-version: '3.11'
       submodules: 'recursive'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/apple-perf.yml
+++ b/.github/workflows/apple-perf.yml
@@ -167,7 +167,7 @@ jobs:
       fail-fast: false
     with:
       # NB: Need to use our AWS MacOS runner to upload large models to S3
-      runner: macos-m1-stable
+      runner: macos-m1-14
       python-version: '3.11'
       submodules: 'recursive'
       timeout: 60

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -39,7 +39,7 @@ jobs:
             backend: portable
       fail-fast: false
     with:
-      runner: macos-m1-stable
+      runner: macos-m1-14
       python-version: '3.11'
       submodules: 'recursive'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
@@ -211,7 +211,7 @@ jobs:
           - build-tool: cmake
       fail-fast: false
     with:
-      runner: macos-m1-stable
+      runner: macos-m1-14
       python-version: '3.11'
       submodules: 'recursive'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
@@ -233,7 +233,7 @@ jobs:
           - build-tool: cmake
       fail-fast: false
     with:
-      runner: macos-m1-stable
+      runner: macos-m1-14
       python-version: '3.11'
       submodules: 'recursive'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
@@ -453,7 +453,7 @@ jobs:
     name: test-static-llama-ane
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@release/2.9
     with:
-      runner: macos-m1-stable
+      runner: macos-m1-14
       python-version: '3.11'
       submodules: 'recursive'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
@@ -475,7 +475,7 @@ jobs:
     name: test-llama-torchao-lowbit
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@release/2.9
     with:
-      runner: macos-m1-stable
+      runner: macos-m1-14
       python-version: '3.11'
       submodules: 'recursive'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
@@ -559,7 +559,7 @@ jobs:
         mode: [mps, coreml, xnnpack+custom+quantize_kv]
       fail-fast: false
     with:
-      runner: macos-m1-stable
+      runner: macos-m1-14
       python-version: '3.11'
       submodules: 'recursive'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
@@ -705,7 +705,7 @@ jobs:
         model: [dl3, edsr, efficient_sam, emformer_join, emformer_transcribe, ic3, ic4, mobilebert, mv2, mv3, resnet50, vit, w2l]
       fail-fast: false
     with:
-      runner: macos-m1-stable
+      runner: macos-m1-14
       python-version: '3.11'
       submodules: 'recursive'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
@@ -744,7 +744,7 @@ jobs:
     strategy:
       fail-fast: false
     with:
-      runner: macos-m1-stable
+      runner: macos-m1-14
       python-version: '3.11'
       submodules: 'recursive'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}


### PR DESCRIPTION
### Summary
A recent change seems to have updated macos-m1-stable to OS 15 and broken many ET jobs due to an issue building torchaudio with Clang 16 (see https://github.com/pytorch/executorch/actions/runs/18023896317/job/51287146415#step:9:46287). This appears to be unique to the release branch. Perhaps the issue was fixed on the development branch of torchaudio or somewhere upstream.

To unbreak the release branch, I'm trying pinning the runner version to "macos-m1-14" instead of "macos-m1-stable".

### Test plan
I'm running trunk CI on this job. If all the MacOS jobs pass, then we're good.