### PR TITLE
[RELEASE ONLY CHANGES] Use prebuilt torch + domain libraries for MacOS jobs

### DIFF
--- a/.ci/scripts/utils.sh
+++ b/.ci/scripts/utils.sh
@@ -107,7 +107,7 @@ install_pytorch_and_domains() {
   TORCHVISION_VERSION=$(cat .github/ci_commit_pins/vision.txt)
   export TORCHVISION_VERSION
 
-  install_domains
+  #install_domains
 
   popd || return
   # Print sccache stats for debugging

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -877,6 +877,11 @@ if(EXECUTORCH_BUILD_PYBIND)
       portable_lib PROPERTIES BUILD_RPATH "@loader_path/../../../torch/lib"
                               INSTALL_RPATH "@loader_path/../../../torch/lib"
     )
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+      if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "16.0")
+        target_link_options(portable_lib PRIVATE -Wl,-ld_classic)
+      endif()
+    endif()
   else()
     set_target_properties(
       portable_lib PROPERTIES BUILD_RPATH "$ORIGIN/../../../torch/lib"

--- a/extension/training/CMakeLists.txt
+++ b/extension/training/CMakeLists.txt
@@ -74,6 +74,12 @@ if(EXECUTORCH_BUILD_PYBIND)
   )
   target_link_libraries(_training_lib PRIVATE ${_pybind_training_dep_libs})
 
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "16.0")
+      target_link_options(_training_lib PRIVATE -Wl,-ld_classic)
+    endif()
+  endif()
+
   install(TARGETS _training_lib
           LIBRARY DESTINATION executorch/extension/training/pybindings
   )


### PR DESCRIPTION
### Summary
Skip building torch, torchvision, and torchaudio from source on the release branch. We install the pinned versions in install_requirements.py. This is an attempt to fix the broken CI on the release/1.0 branch, which is failing to install torchaudio from source. There seems to be an upstream incompatibility with torchaudio's current release/2.9 branch head and AppleClang 16+. Since we don't actually need to build from source on the release branch (we're pinning the versions), we can just skip the build from source.

### Test plan
CI, including trunk
