### PR TITLE
[Release only] Install torch, vision, and audio RC in the release branch

### DIFF
--- a/.ci/docker/common/install_pytorch.sh
+++ b/.ci/docker/common/install_pytorch.sh
@@ -12,39 +12,12 @@ source "$(dirname "${BASH_SOURCE[0]}")/utils.sh"
 
 install_domains() {
   echo "Install torchvision and torchaudio"
-  pip install --no-use-pep517 --user "git+https://github.com/pytorch/audio.git@release/2.9"
-  pip install --no-use-pep517 --user "git+https://github.com/pytorch/vision.git@release/0.24"
+  pip install --no-use-pep517 --user "git+https://github.com/pytorch/audio.git@${TORCHAUDIO_VERSION}"
+  pip install --no-use-pep517 --user "git+https://github.com/pytorch/vision.git@${TORCHVISION_VERSION}"
 }
 
 install_pytorch_and_domains() {
-  git clone https://github.com/pytorch/pytorch.git
-
-  # Fetch the target commit
-  pushd pytorch || true
-  git checkout "${TORCH_VERSION}"
-  git submodule update --init --recursive
-
-  chown -R ci-user .
-
-  export _GLIBCXX_USE_CXX11_ABI=1
-  # Then build and install PyTorch
-  conda_run python setup.py bdist_wheel
-  pip_install "$(echo dist/*.whl)"
-
-  # Grab the pinned audio and vision commits from PyTorch
-  TORCHAUDIO_VERSION=release/2.9
-  export TORCHAUDIO_VERSION
-  TORCHVISION_VERSION=release/0.24
-  export TORCHVISION_VERSION
-
-  install_domains
-
-  popd || true
-  # Clean up the cloned PyTorch repo to reduce the Docker image size
-  rm -rf pytorch
-
-  # Print sccache stats for debugging
-  as_ci_user sccache --show-stats
+  pip install torch==2.9.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/test/cpu
 }
 
 install_pytorch_and_domains

--- a/.ci/docker/common/install_pytorch.sh
+++ b/.ci/docker/common/install_pytorch.sh
@@ -12,12 +12,12 @@ source "$(dirname "${BASH_SOURCE[0]}")/utils.sh"
 
 install_domains() {
   echo "Install torchvision and torchaudio"
-  pip install --no-use-pep517 --user "git+https://github.com/pytorch/audio.git@${TORCHAUDIO_VERSION}"
-  pip install --no-use-pep517 --user "git+https://github.com/pytorch/vision.git@${TORCHVISION_VERSION}"
+  pip_install --no-use-pep517 --user "git+https://github.com/pytorch/audio.git@${TORCHAUDIO_VERSION}"
+  pip_install --no-use-pep517 --user "git+https://github.com/pytorch/vision.git@${TORCHVISION_VERSION}"
 }
 
 install_pytorch_and_domains() {
-  pip install torch==2.9.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/test/cpu
+  pip_install torch==2.9.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/test/cpu
 }
 
 install_pytorch_and_domains

--- a/.ci/docker/common/install_pytorch.sh
+++ b/.ci/docker/common/install_pytorch.sh
@@ -12,8 +12,8 @@ source "$(dirname "${BASH_SOURCE[0]}")/utils.sh"
 
 install_domains() {
   echo "Install torchvision and torchaudio"
-  pip_install --no-use-pep517 --user "git+https://github.com/pytorch/audio.git@${TORCHAUDIO_VERSION}"
-  pip_install --no-use-pep517 --user "git+https://github.com/pytorch/vision.git@${TORCHVISION_VERSION}"
+  pip install --no-use-pep517 --user "git+https://github.com/pytorch/audio.git@release/2.9"
+  pip install --no-use-pep517 --user "git+https://github.com/pytorch/vision.git@release/0.24"
 }
 
 install_pytorch_and_domains() {

--- a/.ci/scripts/utils.sh
+++ b/.ci/scripts/utils.sh
@@ -46,8 +46,8 @@ install_pip_dependencies() {
 
 install_domains() {
   echo "Install torchvision and torchaudio"
-  pip install --no-use-pep517 --user "git+https://github.com/pytorch/audio.git@${TORCHAUDIO_VERSION}"
-  pip install --no-use-pep517 --user "git+https://github.com/pytorch/vision.git@${TORCHVISION_VERSION}"
+  pip install --no-use-pep517 --user "git+https://github.com/pytorch/audio.git@release/2.9"
+  pip install --no-use-pep517 --user "git+https://github.com/pytorch/vision.git@release/0.24"
 }
 
 install_pytorch_and_domains() {


### PR DESCRIPTION
It's wrong to build torch, vision, and audio during release, we should just use their release candidates instead.  Not only we could avoid the need to rebuild these packages, it's also the correct setup to test against RC during release