### PR TITLE
Fix buck cell for xplat builds.

### DIFF
--- a/runtime/core/portable_type/c10/c10/targets.bzl
+++ b/runtime/core/portable_type/c10/c10/targets.bzl
@@ -78,11 +78,11 @@ def define_common_targets():
             ] if not runtime.is_oss else [],
         }),
         xplat_exported_deps = [
-            "//xplat/caffe2:aten_header",
-            "//xplat/caffe2/c10:c10_headers",
+            "fbsource//xplat/caffe2:aten_header",
+            "fbsource//xplat/caffe2/c10:c10_headers",
         ] + select({
-            "DEFAULT": ["//xplat/caffe2:generated_aten_config_header"],
-            "ovr_config//build_mode:arvr_mode": ["//xplat/caffe2:ovrsource_aten_Config.h"],
+            "DEFAULT": ["fbsource//xplat/caffe2:generated_aten_config_header"],
+            "ovr_config//build_mode:arvr_mode": ["fbsource//xplat/caffe2:ovrsource_aten_Config.h"],
         }) + get_sleef_deps(),
         fbcode_exported_deps = ([
             "//caffe2:aten-headers-cpu",

--- a/shim_et/xplat/executorch/backends/xnnpack/third-party/third_party_libs.bzl
+++ b/shim_et/xplat/executorch/backends/xnnpack/third-party/third_party_libs.bzl
@@ -5,12 +5,12 @@ load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 # second element is the OSS dep
 _THIRD_PARTY_LIBS = {
     "FP16": ["fbsource//xplat/third-party/FP16:FP16Fbcode", "//backends/xnnpack/third-party:FP16"],
-    "FXdiv": ["//xplat/third-party/FXdiv:FXdiv", "//backends/xnnpack/third-party:FXdiv"],
-    "XNNPACK": ["//xplat/third-party/XNNPACK:XNNPACK", "//backends/xnnpack/third-party:XNNPACK"],
-    "clog": ["//xplat/third-party/clog:clog", "//backends/xnnpack/third-party:clog"],
+    "FXdiv": ["fbsource//xplat/third-party/FXdiv:FXdiv", "//backends/xnnpack/third-party:FXdiv"],
+    "XNNPACK": ["fbsource//xplat/third-party/XNNPACK:XNNPACK", "//backends/xnnpack/third-party:XNNPACK"],
+    "clog": ["fbsource//xplat/third-party/clog:clog", "//backends/xnnpack/third-party:clog"],
     "cpuinfo": ["fbsource//third-party/cpuinfo:cpuinfo", "//backends/xnnpack/third-party:cpuinfo"],
-    "pthreadpool": ["//xplat/third-party/pthreadpool:pthreadpool", "//backends/xnnpack/third-party:pthreadpool"],
-    "pthreadpool_header": ["//xplat/third-party/pthreadpool:pthreadpool_header", "//backends/xnnpack/third-party:pthreadpool_header"],
+    "pthreadpool": ["fbsource//xplat/third-party/pthreadpool:pthreadpool", "//backends/xnnpack/third-party:pthreadpool"],
+    "pthreadpool_header": ["fbsource//xplat/third-party/pthreadpool:pthreadpool_header", "//backends/xnnpack/third-party:pthreadpool_header"],
 }
 
 def third_party_dep(name):


### PR DESCRIPTION
Summary: Explicitly use fbsource cell when building for xplat.

Differential Revision: D83441105


