### PR TITLE
[Release Only] Fix llama-runner jobs on ARM linux

### DIFF
--- a/.ci/scripts/setup-linux.sh
+++ b/.ci/scripts/setup-linux.sh
@@ -23,6 +23,12 @@ else
 fi
 build_executorch_runner "${BUILD_TOOL}" "${BUILD_MODE}"
 
+# Fix for libcxx version issues with PyTorch prebuilts.
+# Tracking in https://github.com/pytorch/executorch/issues/14679.
+if [ "$(uname -m)" == "aarch64" ]; then
+  conda install -y -c conda-forge libstdcxx-ng
+fi
+
 if [[ "${GITHUB_BASE_REF:-}" == *main* || "${GITHUB_BASE_REF:-}" == *gh* ]]; then
   do_not_use_nightly_on_ci
 fi


### PR DESCRIPTION
The libcxx version is too old on the ARM linux runners. Install a newer version with Conda as a band-aid fix. See https://github.com/pytorch/executorch/issues/14679 for details and to track the long-term fix.

Note that this is intentionally done on the release branch, as the issue only affects the jobs using the rc wheels. We'll want to solve it more generally, but the fix needs to be tested here. See the tracking task.