### PR TITLE
Arm backend: Convert ExportPasses to ArmPasses

### DIFF
--- a/backends/arm/_passes/_debug_passes.py
+++ b/backends/arm/_passes/_debug_passes.py
@@ -6,12 +6,13 @@
 from typing import Set, Type
 
 import torch
+from executorch.backends.arm._passes import ArmPass
 from executorch.devtools.visualization.visualization_utils import visualize_graph
 from executorch.exir import ExportedProgram
 from executorch.exir.pass_base import ExportPass, PassResult
 
 
-class VisualizePass(ExportPass):
+class VisualizePass(ArmPass):
     """
     This pass visualizes the graph at the point of insertion in the pass manager
     """

--- a/backends/arm/_passes/add_bias_pass.py
+++ b/backends/arm/_passes/add_bias_pass.py
@@ -10,6 +10,7 @@ from executorch.backends.arm._passes import ArmPass
 from executorch.backends.arm._passes.arm_pass_utils import get_first_fake_tensor
 from executorch.backends.arm.tosa.mapping import TosaSpecialDtype
 from executorch.backends.transforms.utils import create_constant_placeholder
+from executorch.exir import ExportedProgram
 
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass, PassResult
@@ -25,6 +26,10 @@ class AddBiasPass(ArmPass):
     _passes_required_after: Set[Type[ExportPass]] = set()
 
     targeted_ops = (exir_ops.edge.aten.convolution.default,)
+
+    def __init__(self, exported_program: ExportedProgram) -> None:
+        super().__init__()
+        self.exported_program = exported_program
 
     def call(self, graph_module):
         modified = False

--- a/backends/arm/_passes/annotate_decomposed_matmul.py
+++ b/backends/arm/_passes/annotate_decomposed_matmul.py
@@ -10,6 +10,7 @@ import operator
 from typing import cast, List, Set, Type
 
 import torch
+from executorch.backends.arm._passes.arm_pass import ArmPass
 from executorch.backends.arm._passes.arm_pass_utils import create_node
 from executorch.backends.arm._passes.fold_qdq_with_annotated_qparams_pass import (
     FoldAndAnnotateQParamsPass,
@@ -23,7 +24,7 @@ from torch.fx import GraphModule
 from torch.fx.passes.utils.source_matcher_utils import get_source_partitions
 
 
-class AnnotateDecomposedMatmulPass(ExportPass):
+class AnnotateDecomposedMatmulPass(ArmPass):
     """
     torch.matmul and it's equivalent operator @ can be decomposed in many ways, for instance:
     dq -> matmul -> q can become

--- a/backends/arm/_passes/arm_pass.py
+++ b/backends/arm/_passes/arm_pass.py
@@ -9,16 +9,11 @@ import traceback
 from abc import abstractmethod
 from typing import List, Optional, Set, Type
 
-import torch
 from executorch.exir.pass_base import ExportPass, NodeMetadata
 
 
 class ArmPass(ExportPass):
     """Base class for Arm passes"""
-
-    def __init__(self, exported_program: Optional[torch.export.ExportedProgram] = None):
-        super(ArmPass, self).__init__()
-        self.exported_program = exported_program
 
     @property
     @abstractmethod

--- a/backends/arm/_passes/arm_pass_manager.py
+++ b/backends/arm/_passes/arm_pass_manager.py
@@ -210,10 +210,10 @@ class ArmPassManager(PassManager):
         # needs to happen before AddBiasPass, but after the table ops are inserted
         # to be able to validate that conv2d has right dtype arguments.
         self.add_pass(DecomposeConv2dWithInt16ActivationPass())
-        self.add_pass(RewriteUpsamplePass(exported_program))
+        self.add_pass(RewriteUpsamplePass())
         self.add_pass(AddBiasPass(exported_program))
 
-        self.add_pass(RewriteMatmulPass(exported_program))
+        self.add_pass(RewriteMatmulPass())
         self.add_pass(FuseEqualPlaceholdersPass(exported_program))
         self.add_pass(ToTosaMemoryFormatPass(exported_program))
         self.add_pass(RemoveNoopPass())
@@ -298,10 +298,10 @@ class ArmPassManager(PassManager):
         self.add_pass(FuseViewCopyTransform())
         self.add_pass(FuseConstantArgsPass(exported_program))
         self.add_pass(CastInt64BuffersToInt32Pass(exported_program))
-        self.add_pass(RewriteUpsamplePass(exported_program))
+        self.add_pass(RewriteUpsamplePass())
         self.add_pass(AddBiasPass(exported_program))
         self.add_pass(InsertTableOpsPass(exported_program))
-        self.add_pass(RewriteMatmulPass(exported_program))
+        self.add_pass(RewriteMatmulPass())
         self.add_pass(FuseEqualPlaceholdersPass(exported_program))
         self.add_pass(ToTosaMemoryFormatPass(exported_program))
         self.add_pass(RemoveNoopPass())

--- a/backends/arm/_passes/cast_bool_to_int8_pass.py
+++ b/backends/arm/_passes/cast_bool_to_int8_pass.py
@@ -10,11 +10,12 @@ from typing import Set, Type
 
 import torch
 
+from executorch.backends.arm._passes.arm_pass import ArmPass
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass
 
 
-class CastBoolToInt8Pass(ExportPass):
+class CastBoolToInt8Pass(ArmPass):
     """Casts the input to int8 if it is not already and casts back the output to the original input dtype."""
 
     _passes_required_after: Set[Type[ExportPass]] = set()

--- a/backends/arm/_passes/cast_int64_pass.py
+++ b/backends/arm/_passes/cast_int64_pass.py
@@ -9,21 +9,23 @@ import logging
 from typing import Set, Type
 
 import torch
+from executorch.backends.arm._passes.arm_pass import ArmPass
 from executorch.exir.pass_base import ExportPass, PassResult
 from torch._export.utils import is_buffer
+from torch.export import ExportedProgram
 
 logger = logging.getLogger(__name__)
 
 
-class CastInt64BuffersToInt32Pass(ExportPass):
+class CastInt64BuffersToInt32Pass(ArmPass):
     """
     Cast int64 buffers to int32 if the int64 data is in int32 range.
     """
 
     _passes_required_after: Set[Type[ExportPass]] = set()
 
-    def __init__(self, exported_program: torch.export.ExportedProgram):
-        super(CastInt64BuffersToInt32Pass, self).__init__()
+    def __init__(self, exported_program: ExportedProgram):
+        super().__init__()
         self.exported_program = exported_program
 
     def _assert_within_int32(self, tensor: torch.Tensor, node: torch.fx.Node):

--- a/backends/arm/_passes/cast_to_int32_pass.py
+++ b/backends/arm/_passes/cast_to_int32_pass.py
@@ -7,11 +7,12 @@ from typing import Set, Type
 
 import torch
 
+from executorch.backends.arm._passes.arm_pass import ArmPass
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass
 
 
-class CastToInt32Pass(ExportPass):
+class CastToInt32Pass(ArmPass):
     """Casts the input to int32 if it is not already and casts back the output to the original input dtype."""
 
     _passes_required_after: Set[Type[ExportPass]] = set()

--- a/backends/arm/_passes/convert_any_default_dim_dims_pass.py
+++ b/backends/arm/_passes/convert_any_default_dim_dims_pass.py
@@ -6,6 +6,7 @@
 from typing import Set, Type
 
 import torch
+from executorch.backends.arm._passes import ArmPass
 from executorch.backends.arm._passes.convert_squeezes_to_view import (
     ConvertSqueezesToViewPass,
 )
@@ -18,7 +19,7 @@ from executorch.exir.pass_base import (  # type: ignore[import-not-found]
 )
 
 
-class ConvertAnyDefaultDimDimsPass(ExportPass):
+class ConvertAnyDefaultDimDimsPass(ArmPass):
     """
     Converts any.default, any.dim and any.dims to a sequence of any.dim by unrolling multi-dimensional reduction.
     Please refer to KeepDimsFalseToSqueezePass for an explanation of this coversion.

--- a/backends/arm/_passes/convert_elu_params.py
+++ b/backends/arm/_passes/convert_elu_params.py
@@ -3,13 +3,16 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Set, Type
+
 import torch
+from executorch.backends.arm._passes import ArmPass
 from executorch.backends.arm._passes.arm_pass_utils import create_node
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass, PassResult
 
 
-class ConvertELUParamsPass(ExportPass):
+class ConvertELUParamsPass(ArmPass):
     """
     Pass to convert the input_scale kwarg of ELU operator from float to
     int.
@@ -17,6 +20,8 @@ class ConvertELUParamsPass(ExportPass):
     It has been set to 2 as the outputs seem to stay the same regardless of what
     the value of input_scale is, as long as that value is not 1.
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def call(self, graph_module: torch.fx.GraphModule):
         modified_graph = False

--- a/backends/arm/_passes/convert_expand_copy_to_repeat.py
+++ b/backends/arm/_passes/convert_expand_copy_to_repeat.py
@@ -10,6 +10,7 @@ from typing import cast, Set, Type
 
 import torch
 
+from executorch.backends.arm._passes.arm_pass import ArmPass
 from executorch.backends.arm._passes.unsqueeze_before_repeat_pass import (
     UnsqueezeBeforeRepeatPass,
 )
@@ -48,7 +49,7 @@ def calculate_multiples(args):
     return multiples
 
 
-class ConvertExpandCopyToRepeatPass(ExportPass):
+class ConvertExpandCopyToRepeatPass(ArmPass):
     """
     Replace expand copy with repeat since it is a repeat that can only repeat singleton dimensions.
     """

--- a/backends/arm/_passes/convert_int64_const_ops_to_int32.py
+++ b/backends/arm/_passes/convert_int64_const_ops_to_int32.py
@@ -10,6 +10,7 @@ import logging
 from typing import Set, Type
 
 import torch
+from executorch.backends.arm._passes import ArmPass
 from executorch.backends.arm._passes.fuse_constant_ops_pass import ComputeConstantOpsAOT
 from executorch.exir.pass_base import ExportPass, PassResult
 
@@ -19,7 +20,7 @@ INT32_MIN = torch.iinfo(torch.int32).min
 INT32_MAX = torch.iinfo(torch.int32).max
 
 
-class ConvertInt64ConstOpsToInt32Pass(ExportPass):
+class ConvertInt64ConstOpsToInt32Pass(ArmPass):
     """
     Rewrite constant ops that produce int64 to int32 where safe.
 

--- a/backends/arm/_passes/convert_int64_output_ops_to_int32.py
+++ b/backends/arm/_passes/convert_int64_output_ops_to_int32.py
@@ -10,6 +10,7 @@ import logging
 from typing import Set, Type
 
 import torch
+from executorch.backends.arm._passes import ArmPass
 from executorch.backends.arm._passes.arm_pass_utils import (
     create_node,
     get_first_fake_tensor,
@@ -22,7 +23,7 @@ from executorch.exir.pass_base import ExportPass, PassResult
 logger = logging.getLogger(__name__)
 
 
-class ConvertInt64OutputOpsToInt32Pass(ExportPass):
+class ConvertInt64OutputOpsToInt32Pass(ArmPass):
     """
     Rewrites or removes operations that produce int64 outputs, converting them
     to int32 where possible.

--- a/backends/arm/_passes/convert_minmax_pass.py
+++ b/backends/arm/_passes/convert_minmax_pass.py
@@ -6,6 +6,7 @@
 from typing import cast, Set, Type
 
 import torch
+from executorch.backends.arm._passes.arm_pass import ArmPass
 from executorch.backends.arm._passes.arm_pass_utils import get_first_fake_tensor
 from executorch.backends.arm._passes.convert_squeezes_to_view import (
     ConvertSqueezesToViewPass,
@@ -14,7 +15,7 @@ from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass, PassResult
 
 
-class ConvertMinMaxPass(ExportPass):
+class ConvertMinMaxPass(ArmPass):
     """
     Converts min/max to amin/amax and unrolls multi-dimensional reduction and keep-dims arg to be
     TOSA compliant.

--- a/backends/arm/_passes/convert_split_to_slice.py
+++ b/backends/arm/_passes/convert_split_to_slice.py
@@ -8,6 +8,7 @@
 from typing import Set, Type
 
 import torch.fx
+from executorch.backends.arm._passes import ArmPass
 from executorch.backends.arm._passes.arm_pass_utils import (
     create_node,
     get_first_fake_tensor,
@@ -16,7 +17,7 @@ from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass, PassResult
 
 
-class ConvertSplitToSlicePass(ExportPass):
+class ConvertSplitToSlicePass(ArmPass):
     """
     Replace a split operation with many slice operations.
     """

--- a/backends/arm/_passes/convert_squeezes_to_view.py
+++ b/backends/arm/_passes/convert_squeezes_to_view.py
@@ -8,13 +8,15 @@
 
 from typing import Set, Type
 
+from executorch.backends.arm._passes import ArmPass
+
 from executorch.backends.transforms.fuse_view_copy import FuseViewCopyTransform
 
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass
 
 
-class ConvertSqueezesToViewPass(ExportPass):
+class ConvertSqueezesToViewPass(ArmPass):
     """
     Replaces squeeze/unsqueeze operators with view. These are simply special cases of the view op, so removing them gives us less cases to handle in the node visitiors.
     """

--- a/backends/arm/_passes/convert_to_clamp.py
+++ b/backends/arm/_passes/convert_to_clamp.py
@@ -5,6 +5,8 @@
 
 from typing import Set, Tuple, Type
 
+from executorch.backends.arm._passes import ArmPass
+
 from executorch.backends.arm._passes.fold_qdq_with_annotated_qparams_pass import (
     QuantizeOperatorArguments,
 )
@@ -27,7 +29,7 @@ def get_clamp_params(op, args) -> Tuple[float | None, float | None]:
         raise ValueError(f"Getting clamp parameters for op {op} is not implemented.")
 
 
-class ConvertToClampPass(ExportPass):
+class ConvertToClampPass(ArmPass):
     _passes_required_after: Set[Type[ExportPass]] = {QuantizeOperatorArguments}
 
     def call_operator(self, op, args, kwargs, meta):
@@ -39,4 +41,5 @@ class ConvertToClampPass(ExportPass):
             (args[0], *get_clamp_params(op, args)),
             {},
             meta,
+            updated=True,
         )

--- a/backends/arm/_passes/decompose_avg_pool2d.py
+++ b/backends/arm/_passes/decompose_avg_pool2d.py
@@ -7,6 +7,7 @@
 from typing import Set, Type
 
 import torch
+from executorch.backends.arm._passes.arm_pass import ArmPass
 from executorch.backends.arm._passes.fuse_constant_ops_pass import ComputeConstantOpsAOT
 from executorch.backends.arm.operators.operator_validation_utils import (
     adjust_pooling_pad_if_needed,
@@ -36,7 +37,7 @@ def get_decomposition(op) -> tuple:
     raise RuntimeError(f"Can't get avg_pool2d decomposition for op {op}")
 
 
-class DecomposeAvgPool2d(ExportPass):
+class DecomposeAvgPool2d(ArmPass):
     _passes_required_after: Set[Type[ExportPass]] = {ComputeConstantOpsAOT}
 
     def call_operator(self, op, args, kwargs, meta):
@@ -69,7 +70,9 @@ class DecomposeAvgPool2d(ExportPass):
         # Add width padding manually if count_include_pad
         if count_include_pad and pad_w > 0:
             pre_pad_shape = [n, c, h, pad_w]
-            pre_pad = super().call_operator(full_op, (pre_pad_shape, 0.0), kwargs, meta)
+            pre_pad = super().call_operator(
+                full_op, (pre_pad_shape, 0.0), kwargs, meta, updated=True
+            )
 
             if ceil_mode and divisor_override is None:
                 post_pad_w = pad_w
@@ -81,19 +84,23 @@ class DecomposeAvgPool2d(ExportPass):
             if post_pad_w > 0:
                 post_pad_shape = [n, c, h, post_pad_w]
                 post_pad = super().call_operator(
-                    full_op, (post_pad_shape, 0.0), kwargs, meta
+                    full_op, (post_pad_shape, 0.0), kwargs, meta, updated=True
                 )
                 cat_nodes = [pre_pad, x, post_pad]
             else:
                 cat_nodes = [pre_pad, x]
 
-            x = super().call_operator(cat_op, (cat_nodes, 3), kwargs, meta)
+            x = super().call_operator(
+                cat_op, (cat_nodes, 3), kwargs, meta, updated=True
+            )
             new_pad_w = 0
 
         # Add height padding manually if count_include_pad
         if count_include_pad and pad_h > 0:
             pre_pad_shape = [n, c, pad_h, w + pad_w + post_pad_w]
-            pre_pad = super().call_operator(full_op, (pre_pad_shape, 0.0), kwargs, meta)
+            pre_pad = super().call_operator(
+                full_op, (pre_pad_shape, 0.0), kwargs, meta, updated=True
+            )
 
             if ceil_mode and divisor_override is None:
                 post_pad_h = pad_h
@@ -105,13 +112,15 @@ class DecomposeAvgPool2d(ExportPass):
             if post_pad_h > 0:
                 post_pad_shape = [n, c, post_pad_h, w + pad_w + post_pad_w]
                 post_pad = super().call_operator(
-                    full_op, (post_pad_shape, 0.0), kwargs, meta
+                    full_op, (post_pad_shape, 0.0), kwargs, meta, updated=True
                 )
                 cat_nodes = [pre_pad, x, post_pad]
             else:
                 cat_nodes = [pre_pad, x]
 
-            x = super().call_operator(cat_op, (cat_nodes, 2), kwargs, meta)
+            x = super().call_operator(
+                cat_op, (cat_nodes, 2), kwargs, meta, updated=True
+            )
             new_pad_h = 0
 
         avgpool_args = (
@@ -122,13 +131,19 @@ class DecomposeAvgPool2d(ExportPass):
             ceil_mode,
             False,
         )
-        x = super().call_operator(avgpool_op, avgpool_args, kwargs, meta)
+        x = super().call_operator(avgpool_op, avgpool_args, kwargs, meta, updated=True)
 
         # Multiply by factor (kernel_size / divisor_override) if divisor_override
         if divisor_override is not None and divisor_override != kernel_size:
             override_multiplier = super().call_operator(
-                full_op, ([1, 1, 1, 1], kernel_size / divisor_override), kwargs, meta
+                full_op,
+                ([1, 1, 1, 1], kernel_size / divisor_override),
+                kwargs,
+                meta,
+                updated=True,
             )
-            x = super().call_operator(mul_op, (x, override_multiplier), kwargs, meta)
+            x = super().call_operator(
+                mul_op, (x, override_multiplier), kwargs, meta, updated=True
+            )
 
         return x

--- a/backends/arm/_passes/decompose_cosine_similarity_pass.py
+++ b/backends/arm/_passes/decompose_cosine_similarity_pass.py
@@ -6,6 +6,7 @@
 from typing import Set, Type
 
 import torch
+from executorch.backends.arm._passes import ArmPass
 from executorch.backends.arm._passes.convert_full_like_to_full_pass import (
     ConvertFullLikeToFullPass,
 )
@@ -18,7 +19,7 @@ from executorch.exir.pass_base import ExportPass
 torch_cosine_similarity = (torch.ops.aten.cosine_similarity.default,)
 
 
-class DecomposeCosineSimilarityPass(ExportPass):
+class DecomposeCosineSimilarityPass(ArmPass):
     """
     Decomposition of aten.cosine_similarity:
 

--- a/backends/arm/_passes/decompose_cumsum_pass.py
+++ b/backends/arm/_passes/decompose_cumsum_pass.py
@@ -13,6 +13,7 @@ from executorch.backends.arm._passes.arm_pass_utils import create_node
 from executorch.backends.arm._passes.quant_args import QuantArgs
 
 from executorch.backends.transforms.utils import create_constant_placeholder
+from executorch.exir import ExportedProgram
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass, PassResult
 from torch.export.graph_signature import InputKind
@@ -42,6 +43,10 @@ class DecomposeCumsumPass(ArmPass):
     """
 
     _passes_required_after: Set[Type[ExportPass]] = {AddBiasPass}
+
+    def __init__(self, exported_program: ExportedProgram) -> None:
+        super().__init__()
+        self.exported_program = exported_program
 
     def call(self, graph_module):
         graph = graph_module.graph

--- a/backends/arm/_passes/decompose_div_pass.py
+++ b/backends/arm/_passes/decompose_div_pass.py
@@ -9,6 +9,7 @@
 from typing import Set, Type
 
 import torch
+from executorch.backends.arm._passes import ArmPass
 from executorch.backends.arm._passes.insert_table_ops import InsertTableOpsPass
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass
@@ -29,7 +30,7 @@ def get_div_decomposition(op) -> tuple:
     raise RuntimeError(f"Can't get div decomposition for op {op}")
 
 
-class DecomposeDivPass(ExportPass):
+class DecomposeDivPass(ArmPass):
     """
     This pass decomposes div into a mul and a reciprocal node.
 
@@ -50,6 +51,10 @@ class DecomposeDivPass(ExportPass):
 
         numerator = args[0]
         denominator = args[1]
-        reciprocal = super().call_operator(reciprocal_op, (denominator,), {}, meta)
+        reciprocal = super().call_operator(
+            reciprocal_op, (denominator,), {}, meta, updated=True
+        )
 
-        return super().call_operator(mul_op, (numerator, reciprocal), {}, meta)
+        return super().call_operator(
+            mul_op, (numerator, reciprocal), {}, meta, updated=True
+        )

--- a/backends/arm/_passes/decompose_embedding_pass.py
+++ b/backends/arm/_passes/decompose_embedding_pass.py
@@ -11,6 +11,7 @@ from math import prod
 from typing import Set, Type
 
 import torch
+from executorch.backends.arm._passes import ArmPass
 from executorch.backends.transforms.fuse_view_copy import FuseViewCopyTransform
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass, PassResult
@@ -21,7 +22,7 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.WARNING)
 
 
-class DecomposeEmbeddingPass(ExportPass):
+class DecomposeEmbeddingPass(ArmPass):
     """
     This pass decomposes embedding into index_select.
 

--- a/backends/arm/_passes/decompose_gelu_pass.py
+++ b/backends/arm/_passes/decompose_gelu_pass.py
@@ -6,6 +6,7 @@
 from typing import Set, Type
 
 import torch
+from executorch.backends.arm._passes import ArmPass
 from executorch.backends.arm._passes.arm_pass_utils import get_node_arg
 from executorch.backends.arm._passes.fuse_constant_ops_pass import ComputeConstantOpsAOT
 from executorch.backends.arm._passes.insert_table_ops import InsertTableOpsPass
@@ -43,7 +44,7 @@ def _get_gelu_ops(op) -> tuple:
     raise RuntimeError(f"Can't get GeLU decomposition ops for op {op}")
 
 
-class DecomposeGeluPass(ExportPass):
+class DecomposeGeluPass(ArmPass):
     """
     This pass decomposes the GELU operator into primitive ops.
     Aiming to adhere closely to the reference implementations built into

--- a/backends/arm/_passes/decompose_linalg_vector_norm_pass.py
+++ b/backends/arm/_passes/decompose_linalg_vector_norm_pass.py
@@ -6,12 +6,13 @@
 from typing import Set, Type
 
 import torch
+from executorch.backends.arm._passes import ArmPass
 from executorch.backends.arm._passes.decompose_sqrt_pass import DecomposeSqrtPass
 from executorch.backends.arm._passes.decompose_sum_pass import DecomposeSumPass
 from executorch.exir.pass_base import ExportPass
 
 
-class DecomposeLinearVectorNormPass(ExportPass):
+class DecomposeLinearVectorNormPass(ArmPass):
     """
     This pass decomposes aten.linalg_vector_norm.default into more primitive ops.
     We need to add this pass before quantization for graph annotation.

--- a/backends/arm/_passes/decompose_select.py
+++ b/backends/arm/_passes/decompose_select.py
@@ -9,6 +9,7 @@
 from typing import Set, Type
 
 import torch
+from executorch.backends.arm._passes import ArmPass
 from executorch.backends.arm._passes.arm_pass_utils import (
     create_node,
     get_first_fake_tensor,
@@ -20,7 +21,7 @@ from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass, PassResult
 
 
-class DecomposeSelectPass(ExportPass):
+class DecomposeSelectPass(ArmPass):
     """
     This pass decomposes select into slice + squeeze to ensure that Aten and TOSA outputs has the same rank (input rank -1)
     """

--- a/backends/arm/_passes/decompose_silu_pass.py
+++ b/backends/arm/_passes/decompose_silu_pass.py
@@ -8,13 +8,14 @@
 from typing import Set, Type
 
 import torch
+from executorch.backends.arm._passes import ArmPass
 from executorch.backends.arm._passes.insert_table_ops import InsertTableOpsPass
 from executorch.exir.pass_base import ExportPass
 
 aten_silu_ops = (torch.ops.aten.silu.default, torch.ops.aten.silu_.default)
 
 
-class DecomposeSiluPass(ExportPass):
+class DecomposeSiluPass(ArmPass):
     """
     This pass decomposes silu into a mul and a sigmoid node.
 
@@ -34,6 +35,8 @@ class DecomposeSiluPass(ExportPass):
         mul_op = torch.ops.aten.mul.Tensor
 
         original = args[0]
-        sigmoid = super().call_operator(sigmoid_op, (original,), {}, meta)
+        sigmoid = super().call_operator(sigmoid_op, (original,), {}, meta, updated=True)
 
-        return super().call_operator(mul_op, (original, sigmoid), {}, meta)
+        return super().call_operator(
+            mul_op, (original, sigmoid), {}, meta, updated=True
+        )

--- a/backends/arm/_passes/decompose_sqrt_pass.py
+++ b/backends/arm/_passes/decompose_sqrt_pass.py
@@ -7,6 +7,7 @@
 from typing import Set, Tuple, Type, Union
 
 import torch
+from executorch.backends.arm._passes import ArmPass
 from executorch.backends.arm._passes.insert_table_ops import InsertTableOpsPass
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass
@@ -27,7 +28,7 @@ def get_sqrt_decomposition(op) -> Union[Tuple, torch._ops.OpOverload]:
     raise RuntimeError(f"Can't get sqrt decomposition for op {op}")
 
 
-class DecomposeSqrtPass(ExportPass):
+class DecomposeSqrtPass(ArmPass):
     _passes_required_after: Set[Type[ExportPass]] = {InsertTableOpsPass}
 
     def call_operator(self, op, args, kwargs, meta):
@@ -40,4 +41,4 @@ class DecomposeSqrtPass(ExportPass):
 
         pow_op = get_sqrt_decomposition(op)
 
-        return super().call_operator(pow_op, (args[0], 0.5), {}, meta)
+        return super().call_operator(pow_op, (args[0], 0.5), {}, meta, updated=True)

--- a/backends/arm/_passes/decompose_sum_pass.py
+++ b/backends/arm/_passes/decompose_sum_pass.py
@@ -6,6 +6,7 @@
 from typing import Set, Type
 
 import torch
+from executorch.backends.arm._passes import ArmPass
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass
 
@@ -23,7 +24,7 @@ def _get_sum_decomp(op):
             raise RuntimeError("Unvalid op in DecomposeSumPass")
 
 
-class DecomposeSumPass(ExportPass):
+class DecomposeSumPass(ArmPass):
     """
     In Pytorch, the default behaviour of for example Tensor.sum is to squeeze the
     dimension that is summed (keep_dim = False). However, in TOSA, REDUCE_SUM always
@@ -76,13 +77,13 @@ class DecomposeSumPass(ExportPass):
 
         for dim in dims:
             input_node = super().call_operator(
-                sum_op, (input_node, dim, True), kwargs, meta
+                sum_op, (input_node, dim, True), kwargs, meta, updated=True
             )
 
         if not keepdims:
             shape = list(meta["val"].size())
             input_node = super().call_operator(
-                view_op, (input_node, shape), kwargs, meta
+                view_op, (input_node, shape), kwargs, meta, updated=True
             )
 
         return input_node

--- a/backends/arm/_passes/fold_qdq_with_annotated_qparams_pass.py
+++ b/backends/arm/_passes/fold_qdq_with_annotated_qparams_pass.py
@@ -8,7 +8,7 @@
 
 import copy
 
-from typing import cast, Dict, Set, Tuple, Type
+from typing import cast, Optional, Set, Type
 
 from executorch.backends.arm._passes import ArmPass
 from executorch.backends.arm._passes.arm_pass_utils import (
@@ -20,17 +20,12 @@ from executorch.backends.arm._passes.insert_table_ops import InsertTableOpsPass
 from executorch.backends.arm._passes.quant_args import QuantArgs
 from executorch.backends.arm._passes.remove_noop_pass import RemoveNoopPass
 from executorch.backends.arm.constants import DQ_OPS, Q_OPS
+from executorch.exir import ExportedProgram
 
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.dialects.edge._ops import EdgeOpOverload
 
-from executorch.exir.pass_base import (
-    Argument,
-    ExportPass,
-    NodeMetadata,
-    PassResult,
-    ProxyValue,
-)
+from executorch.exir.pass_base import ExportPass, PassResult
 from torch.fx import GraphModule, Node
 
 
@@ -72,7 +67,7 @@ def get_output_qparams(node: Node) -> dict[int, QuantArgs]:
     return output_qparams
 
 
-class RetraceFoldedDtypesPass(ExportPass):
+class RetraceFoldedDtypesPass(ArmPass):
     """
     FoldAndAnnotateQParamsPass folds dq and q nodes. When the graph is retraced
     some operators are retraced to types that cannot be handled by TOSA. One
@@ -90,24 +85,18 @@ class RetraceFoldedDtypesPass(ExportPass):
         exir_ops.edge.aten.sum.dim_IntList,
     }
 
-    def call_operator(
-        self,
-        op,  # pyre-ignore
-        args: Tuple[Argument, ...],
-        kwargs: Dict[str, Argument],
-        meta: NodeMetadata,
-    ) -> ProxyValue:
+    def call_operator(self, op, args, kwargs, meta):
         if op not in self.targeted_ops:
-            return super().call_operator(op, args, kwargs, meta)
+            return super().call_operator(op, args, kwargs, meta, False)
 
         node_kwargs = kwargs.copy()
         output_qparams = meta["output_qparams"]
         if len(output_qparams) == 0:
-            return super().call_operator(op, args, kwargs, meta)
+            return super().call_operator(op, args, kwargs, meta, False)
 
         output_dtype = output_qparams[0].dtype
         node_kwargs["dtype"] = output_dtype
-        return super().call_operator(op, args, node_kwargs, meta)
+        return super().call_operator(op, args, node_kwargs, meta, True)
 
 
 class FoldAndAnnotateQParamsPass(ArmPass):
@@ -145,6 +134,10 @@ class FoldAndAnnotateQParamsPass(ArmPass):
         InsertTableOpsPass,
         RemoveNoopPass,
     }
+
+    def __init__(self, exported_program: Optional[ExportedProgram] = None) -> None:
+        super().__init__()
+        self.exported_program = exported_program
 
     def fold_and_annotate_arg(
         self, graph_module: GraphModule, node: Node, arg_list: list[Node], i: int
@@ -249,7 +242,7 @@ class FoldAndAnnotateQParamsPass(ArmPass):
         return PassResult(graph_module, True)
 
 
-class QuantizeOperatorArguments(ExportPass):
+class QuantizeOperatorArguments(ArmPass):
     """
     This pass makes sure that the arguments to clamp.default are quantized correctly.
     More specifically, this pass:

--- a/backends/arm/_passes/fuse_batchnorm2d_pass.py
+++ b/backends/arm/_passes/fuse_batchnorm2d_pass.py
@@ -8,6 +8,7 @@
 from typing import Set, Type
 
 import torch
+from executorch.backends.arm._passes import ArmPass
 from executorch.backends.arm._passes.arm_pass_utils import (
     create_node,
     get_first_fake_tensor,
@@ -26,7 +27,7 @@ from torch.fx import Node
 from torch.nn.utils.fusion import fuse_conv_bn_weights
 
 
-class FuseBatchnorm2DPass(ExportPass):
+class FuseBatchnorm2DPass(ArmPass):
     """Fuses the pattern convolution -> batchnorm by updating
     the weights and bias of the convolution and removing the batchnorm.
     """
@@ -34,8 +35,8 @@ class FuseBatchnorm2DPass(ExportPass):
     _passes_required_after: Set[Type[ExportPass]] = set()
 
     def __init__(self, exported_program: ExportedProgram):
-        self.exported_program = exported_program
         super().__init__()
+        self.exported_program = exported_program
 
     def get_bias_name(self, weight_node: Node, bias_node: Node | None) -> str:
         if bias_node:

--- a/backends/arm/_passes/fuse_constant_ops_pass.py
+++ b/backends/arm/_passes/fuse_constant_ops_pass.py
@@ -8,6 +8,7 @@ from typing import Set, Type
 
 import torch._export.utils
 import torch.fx
+from executorch.backends.arm._passes.arm_pass import ArmPass
 from executorch.backends.arm._passes.arm_pass_utils import (
     get_constant_placeholder_kind,
     get_first_fake_tensor,
@@ -29,7 +30,7 @@ from torch.export.graph_signature import InputKind
 logger = logging.getLogger(__name__)
 
 
-class FuseConstantArgsPass(ExportPass):
+class FuseConstantArgsPass(ArmPass):
     """
     Fuses ops with only placeholder parameters into one placeholder parameter node with the op
     pre-calulcated on its data.
@@ -162,7 +163,7 @@ class FuseConstantArgsPass(ExportPass):
         return PassResult(graph_module, True)
 
 
-class ComputeConstantOpsAOT(ExportPass):
+class ComputeConstantOpsAOT(ArmPass):
     """
     Evaluates call_functions that produce constant tensor outputs and replaces them with placeholders.
 

--- a/backends/arm/_passes/fuse_equal_placeholders_pass.py
+++ b/backends/arm/_passes/fuse_equal_placeholders_pass.py
@@ -9,6 +9,7 @@ from typing import Set, Type
 
 import torch
 
+from executorch.backends.arm._passes import ArmPass
 from executorch.backends.arm._passes.arm_pass_utils import (
     get_constant_placeholder_kind,
     get_param_tensor,
@@ -23,7 +24,7 @@ from executorch.exir import ExportedProgram
 from executorch.exir.pass_base import ExportPass, PassResult
 
 
-class FuseEqualPlaceholdersPass(ExportPass):
+class FuseEqualPlaceholdersPass(ArmPass):
     """
     This pass optimizes memory usage by finding constant placeholders
     pointing to identical tensors and fusing them to one single placeholder
@@ -33,8 +34,8 @@ class FuseEqualPlaceholdersPass(ExportPass):
     _passes_required_after: Set[Type[ExportPass]] = set()
 
     def __init__(self, exported_program: ExportedProgram):
-        self.exported_program = exported_program
         super().__init__()
+        self.exported_program = exported_program
 
     def call(self, graph_module: torch.fx.GraphModule) -> PassResult:
         modified = False

--- a/backends/arm/_passes/fuse_quantized_activation_pass.py
+++ b/backends/arm/_passes/fuse_quantized_activation_pass.py
@@ -8,6 +8,7 @@
 from typing import Set, Type
 
 import torch
+from executorch.backends.arm._passes import ArmPass
 from executorch.backends.arm._passes.convert_to_clamp import ConvertToClampPass
 from executorch.backends.arm._passes.fold_qdq_with_annotated_qparams_pass import (
     FoldAndAnnotateQParamsPass,
@@ -20,7 +21,7 @@ from executorch.exir.pass_base import ExportPass, PassResult
 from torch.fx import Node
 
 
-class FuseQuantizedActivationPass(ExportPass):
+class FuseQuantizedActivationPass(ArmPass):
     _passes_required_after: Set[Type[ExportPass]] = {
         ConvertToClampPass,
         FoldAndAnnotateQParamsPass,

--- a/backends/arm/_passes/insert_int32_casts_after_int64_placeholders.py
+++ b/backends/arm/_passes/insert_int32_casts_after_int64_placeholders.py
@@ -11,6 +11,7 @@ import logging
 from typing import Set, Type
 
 import torch
+from executorch.backends.arm._passes.arm_pass import ArmPass
 from executorch.backends.arm._passes.arm_pass_utils import create_node
 from executorch.backends.arm._passes.decompose_embedding_pass import (
     DecomposeEmbeddingPass,
@@ -23,7 +24,7 @@ from torch._subclasses.fake_tensor import FakeTensor
 logger = logging.getLogger(__name__)
 
 
-class InsertInt32CastsAfterInt64PlaceholdersPass(ExportPass):
+class InsertInt32CastsAfterInt64PlaceholdersPass(ArmPass):
     """
     Insert an int64->int32 cast after each int64 placeholder.
 

--- a/backends/arm/_passes/insert_rescales_pass.py
+++ b/backends/arm/_passes/insert_rescales_pass.py
@@ -12,6 +12,7 @@ from executorch.backends.arm._passes.arm_pass_utils import create_node, set_node
 from executorch.backends.arm._passes.fold_qdq_with_annotated_qparams_pass import (
     get_output_qparams,
 )
+
 from executorch.backends.arm._passes.quant_args import QuantArgs
 from executorch.backends.arm.constants import DQ_OPS, Q_OPS
 from executorch.exir.dialects._ops import ops as exir_ops
@@ -19,7 +20,7 @@ from executorch.exir.pass_base import ExportPass, PassResult
 from torch.fx import GraphModule, Node
 
 
-class InsertRescalePass(ExportPass):
+class InsertRescalePass(ArmPass):
     """Finds patterns of dq -> q, and replaces them
     with backend dialect tosa::RESCALE op.
 

--- a/backends/arm/_passes/insert_table_ops.py
+++ b/backends/arm/_passes/insert_table_ops.py
@@ -9,6 +9,7 @@ from itertools import chain
 from typing import Callable, cast, Dict, Iterator, Set, Type
 
 import torch
+from executorch.backends.arm._passes import ArmPass
 from executorch.backends.arm._passes.arm_pass_utils import create_node
 from executorch.backends.arm._passes.quant_args import QuantArgs
 from executorch.backends.transforms.utils import create_constant_placeholder
@@ -109,7 +110,7 @@ class TableOps:
         return chain(TableOps.unary_table_ops, TableOps.special_table_ops)
 
 
-class InsertTableOpsPass(ExportPass):
+class InsertTableOpsPass(ArmPass):
     """
     For ops in self.table_ops they need to be serialized as a TOSA TABLE. This pass replaces these
     edge ops with a tosa._table(input: Tensor, target_str: str) where target_str == str(node.target).

--- a/backends/arm/_passes/match_arg_dtype_pass.py
+++ b/backends/arm/_passes/match_arg_dtype_pass.py
@@ -6,6 +6,7 @@
 from typing import Set, Type
 
 import torch
+from executorch.backends.arm._passes import ArmPass
 from executorch.backends.arm._passes.arm_pass_utils import create_node, get_node_arg
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass, PassResult
@@ -28,7 +29,7 @@ def get_largest_dtype(dtype_1, dtype_2):
     return dtype_1 if DTYPE_RANK[dtype_1] > DTYPE_RANK[dtype_2] else dtype_2
 
 
-class MatchArgDtypePass(ExportPass):
+class MatchArgDtypePass(ArmPass):
     """Pass to match data types of non-condition input tensors.
 
     Edge dialect allows different data types for non-condition tensors, while TOSA

--- a/backends/arm/_passes/match_arg_ranks_pass.py
+++ b/backends/arm/_passes/match_arg_ranks_pass.py
@@ -9,10 +9,13 @@
 
 from typing import cast, Set, Type
 
+from executorch.backends.arm._passes import ArmPass
+
 from executorch.backends.arm._passes.arm_pass_utils import (
     create_node,
     get_first_fake_tensor,
 )
+from executorch.exir import ExportedProgram
 
 from executorch.exir.dialects._ops import ops as exir_ops
 
@@ -20,7 +23,7 @@ from executorch.exir.pass_base import ExportPass, PassResult
 from torch.fx import GraphModule, Node
 
 
-class MatchArgRanksPass(ExportPass):
+class MatchArgRanksPass(ArmPass):
     """
     For ops in 'targeted_ops', make sure that the inputs share the same rank.
     New dimensions are inserted from the beginning of the inputs that have a
@@ -38,7 +41,7 @@ class MatchArgRanksPass(ExportPass):
 
     _passes_required_after: Set[Type[ExportPass]] = set()
 
-    def __init__(self, exported_program):
+    def __init__(self, exported_program: ExportedProgram) -> None:
         super().__init__()
         self.exported_program = exported_program
 

--- a/backends/arm/_passes/mm_to_bmm_pass.py
+++ b/backends/arm/_passes/mm_to_bmm_pass.py
@@ -9,6 +9,7 @@
 from typing import Set, Type
 
 import torch
+from executorch.backends.arm._passes import ArmPass
 from executorch.backends.arm._passes.arm_pass_utils import (
     create_node,
     get_first_fake_tensor,
@@ -26,7 +27,7 @@ from executorch.exir.pass_base import ExportPass, PassResult
 from torch.fx import Node
 
 
-class ConvertMmToBmmPass(ExportPass):
+class ConvertMmToBmmPass(ArmPass):
     """
     This pass converts a MM node to a BMM one and turns input and output tensors
     from rank 2 to rank 3. The TOSA specification requires rank 3. The graph is

--- a/backends/arm/_passes/remove_noop_pass.py
+++ b/backends/arm/_passes/remove_noop_pass.py
@@ -9,13 +9,15 @@
 import logging
 from typing import Set, Type
 
+from executorch.backends.arm._passes import ArmPass
+
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass
 
 logger = logging.getLogger(__name__)
 
 
-class RemoveNoopPass(ExportPass):
+class RemoveNoopPass(ArmPass):
     """Remove no-ops from graph_module"""
 
     _passes_required_after: Set[Type[ExportPass]] = set()

--- a/backends/arm/_passes/replace_inf_values_pass.py
+++ b/backends/arm/_passes/replace_inf_values_pass.py
@@ -10,18 +10,16 @@
 from typing import Set, Type
 
 import torch
+from executorch.backends.arm._passes.arm_pass import ArmPass
 from executorch.exir.pass_base import ExportPass, PassResult
 
 
-class ReplaceInfValues(ExportPass):
+class ReplaceInfValues(ArmPass):
     """
     Due to limitation in Quantizer, we need to change inf/-inf to more quantizable values.
     """
 
     _passes_required_after: Set[Type[ExportPass]] = set()
-
-    def __init__(self):
-        super(ReplaceInfValues, self).__init__()
 
     def call(self, graph_module: torch.fx.GraphModule):
         modified = False

--- a/backends/arm/_passes/scalars_to_attribute_pass.py
+++ b/backends/arm/_passes/scalars_to_attribute_pass.py
@@ -9,6 +9,7 @@
 from typing import cast, Set, Type, Union
 
 import torch
+from executorch.backends.arm._passes import ArmPass
 from executorch.backends.arm._passes.arm_pass_utils import get_first_fake_tensor
 from executorch.backends.arm._passes.match_arg_ranks_pass import MatchArgRanksPass
 
@@ -17,7 +18,7 @@ from torch.fx import GraphModule, Node
 from torchao.quantization.pt2e.utils import get_new_attr_name_with_prefix
 
 
-class ScalarsToAttributePass(ExportPass):
+class ScalarsToAttributePass(ArmPass):
     """
     For ops in 'targeted_ops', convert inputs that are scalar values
     to attribute Nodes that output the same value.

--- a/backends/arm/_passes/size_adjust_input_pass.py
+++ b/backends/arm/_passes/size_adjust_input_pass.py
@@ -8,6 +8,7 @@
 from typing import cast, Set, Type, TypeAlias
 
 import torch.fx
+from executorch.backends.arm._passes import ArmPass
 from executorch.backends.arm._passes.arm_pass_utils import create_node
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass, PassResult
@@ -137,7 +138,7 @@ def is_valid_operator(node: torch.fx.Node) -> bool:
     return False
 
 
-class SizeAdjustInputPass(ExportPass):
+class SizeAdjustInputPass(ArmPass):
     """
     Adjusts the input size to Conv2D and Pooling operators. PyTorch allows
     the input and kernel shape to not "match", in which case the remaining

--- a/backends/arm/_passes/to_tosa_memory_format_pass.py
+++ b/backends/arm/_passes/to_tosa_memory_format_pass.py
@@ -10,6 +10,7 @@ import logging
 from typing import Set, Type
 
 import torch
+from executorch.backends.arm._passes import ArmPass
 from executorch.backends.arm._passes.annotate_decomposed_matmul import (
     AnnotateDecomposedMatmulPass,
 )
@@ -44,7 +45,7 @@ def _is_input(node: torch.fx.Node, exported_program: ExportedProgram) -> bool:
     return node.op == "placeholder" and not is_param_node(exported_program, node)
 
 
-class ToTosaMemoryFormatPass(ExportPass):
+class ToTosaMemoryFormatPass(ArmPass):
     """
     Annotates each node with a tosa_dim_order. tosa_dim_order can be seen as a channels-last dim-order
     that in most cases will be (0, 2, 3, 1) for nodes with 4D-shapes. The pass also inserts backend.tosa.TRANSPOSE
@@ -55,8 +56,8 @@ class ToTosaMemoryFormatPass(ExportPass):
     _passes_required_after: Set[Type[ExportPass]] = set()
 
     def __init__(self, exported_program: ExportedProgram) -> None:
-        self.exported_program = exported_program
         super().__init__()
+        self.exported_program = exported_program
 
     @staticmethod
     def _is_consumer_node_depthwise_conv2d(node: torch.fx.Node):

--- a/backends/arm/_passes/unsqueeze_before_repeat_pass.py
+++ b/backends/arm/_passes/unsqueeze_before_repeat_pass.py
@@ -8,6 +8,7 @@ from typing import Set, Type
 
 import torch
 import torch.fx
+from executorch.backends.arm._passes import ArmPass
 from executorch.backends.arm._passes.arm_pass_utils import (
     create_node,
     get_first_fake_tensor,
@@ -16,7 +17,7 @@ from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass, PassResult
 
 
-class UnsqueezeBeforeRepeatPass(ExportPass):
+class UnsqueezeBeforeRepeatPass(ArmPass):
     """
     A TOSA TILE op only supports rank(in) == rank(out).
     To support Pytorch's repeat which can also add dimensions,

--- a/backends/arm/_passes/unsqueeze_scalar_placeholders_pass.py
+++ b/backends/arm/_passes/unsqueeze_scalar_placeholders_pass.py
@@ -8,11 +8,13 @@
 from typing import Set, Type
 
 import torch
+from executorch.backends.arm._passes import ArmPass
+from executorch.exir import ExportedProgram
 from executorch.exir.pass_base import ExportPass, PassResult
 from torch._export.utils import is_buffer, is_param
 
 
-class UnsqueezeScalarPlaceholdersPass(ExportPass):
+class UnsqueezeScalarPlaceholdersPass(ArmPass):
     """
     Placeholders that have node.meta["val"].shape = () cause issues later in the lowering.
     This pass unsqueezes the placeholders to make sure shape is at least (1,).
@@ -20,9 +22,9 @@ class UnsqueezeScalarPlaceholdersPass(ExportPass):
 
     _passes_required_after: Set[Type[ExportPass]] = set()
 
-    def __init__(self, exported_program):
-        self.exported_program = exported_program
+    def __init__(self, exported_program: ExportedProgram) -> None:
         super().__init__()
+        self.exported_program = exported_program
 
     def call(self, graph_module: torch.fx.GraphModule):
         for node in graph_module.graph.nodes:

--- a/backends/arm/test/passes/test_to_tosa_memory_format.py
+++ b/backends/arm/test/passes/test_to_tosa_memory_format.py
@@ -179,11 +179,8 @@ def test_to_tosa_memory_format_tosa_INT(module):
         module.get_inputs(),
         ops_after_pass=module.ops_after_pass,
         ops_not_after_pass=module.ops_not_after_pass,
-        pass_list=[RemoveGetItemPass],
-        passes_with_exported_program=[
-            AnnotateOutputDimOrderPass,
-            ToTosaMemoryFormatPass,
-        ],
+        pass_list=[RemoveGetItemPass, AnnotateOutputDimOrderPass],
+        passes_with_exported_program=[ToTosaMemoryFormatPass],
     )
     pipeline.pop_stage(
         "run_method_and_compare_outputs"


### PR DESCRIPTION
All passes in backends/arm/_passes have been set to inherit from `ArmPass` instead of `ExportPass`.

Furthermore, the attribute `exported_program` in `ArmPass` has been removed to instead let each subclasses set it. The reason is that it was type annotated as an `Optional[ExportedProgram]]` in `ArmPass` and Mypy complained about that when a subclass tried to access it without checking for `None`. By moving the attribute down to each subclass that needs it, the confusion around whether the value is `None` or not is elimininated.

### Test plan
The persistent tests in the Arm backend should cover this change.


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218