### PR TITLE
Fix const prop pass when a const prop tensor has zero stride, make it contiguous

### DIFF
--- a/exir/passes/constant_prop_pass.py
+++ b/exir/passes/constant_prop_pass.py
@@ -164,6 +164,14 @@ def get_propagated_const_tensor_dict(
         with torch.no_grad():
             # Execute the `node.target` and create a new propagated constant tensor.
             prop_constant_tensor = node.target(*args_data, **kwargs_data)
+
+            # ExecuTorch doesn't support zero strides, so we need to ensure the tensor is contiguous
+            # if it has any zero strides from broadcasting/expansion operations
+            if (
+                isinstance(prop_constant_tensor, torch.Tensor)
+                and 0 in prop_constant_tensor.stride()
+            ):
+                prop_constant_tensor = prop_constant_tensor.contiguous()
         const_node_to_tensor[node] = prop_constant_tensor
 
     return const_node_to_tensor


### PR DESCRIPTION
Summary:
Found out that xnnpack lowering fails due to rejecting a zero stride tensor by executorch during to_backend phase. The fix is to identify such tensors and make them contiguous.

For context: https://fb.workplace.com/groups/764610762549390/permalink/1868907967337731/

Differential Revision: D83631522


