### PR TITLE
[multimodal] Fix pybind in nightly wheel build

### DIFF
--- a/extension/llm/runner/CMakeLists.txt
+++ b/extension/llm/runner/CMakeLists.txt
@@ -106,10 +106,19 @@ if(EXECUTORCH_BUILD_PYBIND)
   )
   if(APPLE)
     set(RPATH "@loader_path/../../pybindings")
+    set(TORCH_RPATH "@loader_path/../../../../torch/lib")
   else()
     set(RPATH "$ORIGIN/../../pybindings")
+    set(TORCH_RPATH "$ORIGIN/../../../../torch/lib")
   endif()
-  set_target_properties(_llm_runner PROPERTIES INSTALL_RPATH ${RPATH})
+  # Set RPATH to find PyTorch libraries relative to the installation location
+  # This goes from executorch/extension/pybindings up to site-packages, then to
+  # torch/lib. This is copied from root level CMakeLists.txt
+  set_target_properties(
+    _llm_runner PROPERTIES BUILD_RPATH "${TORCH_RPATH}"
+                            INSTALL_RPATH "${RPATH};${TORCH_RPATH}"
+  )
+
   # Add include directories
   target_include_directories(
     _llm_runner PRIVATE ${_common_include_directories} ${TORCH_INCLUDE_DIRS}

--- a/tools/cmake/Utils.cmake
+++ b/tools/cmake/Utils.cmake
@@ -121,7 +121,7 @@ function(get_torch_base_path outVar)
   execute_process(
     COMMAND
       "${PYTHON_EXECUTABLE}" -c
-      "import importlib.util; print(importlib.util.find_spec('torch').submodule_search_locations[0])"
+      "\"import importlib.util; print(importlib.util.find_spec('torch').submodule_search_locations[0])\""
     OUTPUT_VARIABLE _tmp_torch_path
     ERROR_VARIABLE _tmp_torch_path_error
     RESULT_VARIABLE _tmp_torch_path_result COMMAND_ECHO STDERR

--- a/tools/cmake/Utils.cmake
+++ b/tools/cmake/Utils.cmake
@@ -121,7 +121,7 @@ function(get_torch_base_path outVar)
   execute_process(
     COMMAND
       "${PYTHON_EXECUTABLE}" -c
-      "\"import importlib.util; print(importlib.util.find_spec('torch').submodule_search_locations[0])\""
+      "import importlib.util; print(importlib.util.find_spec('torch').submodule_search_locations[0])"
     OUTPUT_VARIABLE _tmp_torch_path
     ERROR_VARIABLE _tmp_torch_path_error
     RESULT_VARIABLE _tmp_torch_path_result COMMAND_ECHO STDERR


### PR DESCRIPTION
Right now after
```
pip install executorch==1.1.0.dev20251001 --extra-index-url
https://download.pytorch.org/whl/nightly
```

Then run

```
python -c "from executorch.extension.llm.runner import MultimodalRunner"
```

I'm getting this error:

```
(executorch) [larryliu@devvm121.ldc0 /data/users/larryliu/executorch (main)]$ python -c "from executorch.extension.llm.runner import MultimodalRunner"
Traceback (most recent call last):
  File "/home/larryliu/.conda/envs/executorch/lib/python3.11/site-packages/executorch/extension/llm/runner/__init__.py", line 16, in <module>
    from executorch.extension.llm.runner._llm_runner import (  # noqa: F401
ImportError: libtorch_python.so: cannot open shared object file: No such file or directory

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/larryliu/.conda/envs/executorch/lib/python3.11/site-packages/executorch/extension/llm/runner/__init__.py", line 29, in <module>
    raise RuntimeError(
RuntimeError: LLM runner is not installed. Please build ExecuTorch from source with EXECUTORCH_BUILD_PYBIND=ON
```

This PR should fix it by properly point to the installation path of pytorch.

### Summary
[PLEASE REMOVE] See [CONTRIBUTING.md's Pull Requests](https://github.com/pytorch/executorch/blob/main/CONTRIBUTING.md#pull-requests) for ExecuTorch PR guidelines.

[PLEASE REMOVE] If this PR closes an issue, please add a `Fixes #<issue-id>` line.

[PLEASE REMOVE] If this PR introduces a fix or feature that should be the upcoming release notes, please add a "Release notes: <area>" label. For a list of available release notes labels, check out [CONTRIBUTING.md's Pull Requests](https://github.com/pytorch/executorch/blob/main/CONTRIBUTING.md#pull-requests).

### Test plan
[PLEASE REMOVE] How did you test this PR? Please write down any manual commands you used and note down tests that you have written if applicable.
