### PR TITLE
Add platforms for all operator library sub-targets.

### DIFF
--- a/shim_et/xplat/executorch/kernels/prim_ops/selective_build.bzl
+++ b/shim_et/xplat/executorch/kernels/prim_ops/selective_build.bzl
@@ -28,6 +28,7 @@ def prim_ops_registry_selective(name, selected_prim_ops_header_target, aten_suff
             header_name: [header_name],
             "selected_prim_ops.h": ["selected_prim_ops.h"]
         },
+        platforms = kwargs.get("platforms", "CXX"),
         default_outs = ["."],
     )
     runtime.cxx_library(


### PR DESCRIPTION
Summary: Fixes meta-internal build errors. The `platforms` buck arg wasn't propagated everywhere.

Differential Revision: D83680406


