### PR TITLE
Disable nxp tests

### DIFF
--- a/backends/nxp/tests/TARGETS
+++ b/backends/nxp/tests/TARGETS
@@ -1,3 +1,4 @@
+load("@fbsource//tools/target_determinator/macros:ci.bzl", "ci")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 load("@fbcode_macros//build_defs:python_pytest.bzl", "python_pytest")
 
@@ -50,5 +51,9 @@ python_pytest(
         "//executorch/backends/nxp:neutron_backend",
         ":executorch_pipeline",
         ":models",
-    ]
+    ],
+    labels = [
+        "local_only",
+        ci.skip_test(),
+    ],
 )


### PR DESCRIPTION
Summary: Disabling nxp tests due to sdk 25 09 unavailability: context: https://fb.workplace.com/groups/python.thirdparty/posts/1393985928266913/?comment_id=1545241046474733&reply_comment_id=1545266799805491&notif_id=1759353502709709&notif_t=work_group_comment_mention

Differential Revision: D83693629


