### PR TITLE
Deserialize with named data store

### DIFF
--- a/exir/_serialize/_dataclass.py
+++ b/exir/_serialize/_dataclass.py
@@ -57,7 +57,7 @@ def _get_class_from_union(json_dict: Dict[str, Any], key: str, cls: Any) -> Any:
 
 
 # pyre-ignore
-def _json_to_dataclass(json_dict: Dict[str, Any], cls: Any = None) -> Any:
+def _json_to_dataclass(json_dict: Dict[str, Any], cls: Any = None) -> Any:  # noqa: C901
     """Initializes a dataclass given a dictionary loaded from a json,
     `json_dict`, and the expected class, `cls`, by iterating through the fields
     of the class and retrieving the data for each. If there is a field that is
@@ -139,7 +139,10 @@ def _json_to_dataclass(json_dict: Dict[str, Any], cls: Any = None) -> Any:
         # If T is an enum then lookup the value in the enum otherwise try to
         # cast value to whatever type is required
         if isinstance(T, enum.EnumMeta):
-            data[key] = T[value]
+            if isinstance(value, str):
+                data[key] = T[value]
+            else:
+                data[key] = T(value)
         else:
             data[key] = T(value)
     return cls(**data)


### PR DESCRIPTION
This pull request enhances the deserialization and restoration logic for named data segments in programs, ensuring that named data is reconstructed into a dedicated store and verified in tests. It also includes minor code quality improvements.

**Named Data Segment Restoration:**

* In `_restore_segments` (`exir/_serialize/_program.py`), added logic to reconstruct named data blobs into a `NamedDataStoreOutput` and attach both `named_data_store` and a convenient `named_data_blobs` mapping to the `Program` object. The original `named_data` list is cleared after restoration.
* Updated tests (`test_constant_delegate_and_named_data_segments` and `test_named_data_segments` in `exir/_serialize/test/test_program.py`) to verify that named data is correctly restored, removed from the `Program`, and accessible via the new store and blob mapping. [[1]](diffhunk://#diff-17e38ecaa913e5ec84dbe14e8b49761d7887254ba24543382360fdda013f50a0R896-R912) [[2]](diffhunk://#diff-17e38ecaa913e5ec84dbe14e8b49761d7887254ba24543382360fdda013f50a0R1017-R1031)
