### PR TITLE
Restore backend tests

### DIFF
--- a/backends/nxp/tests/TARGETS
+++ b/backends/nxp/tests/TARGETS
@@ -1,4 +1,3 @@
-load("@fbsource//tools/target_determinator/macros:ci.bzl", "ci")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 load("@fbcode_macros//build_defs:python_pytest.bzl", "python_pytest")
 
@@ -51,9 +50,5 @@ python_pytest(
         "//executorch/backends/nxp:neutron_backend",
         ":executorch_pipeline",
         ":models",
-    ],
-    labels = [
-        "local_only",
-        ci.skip_test(),
-    ],
+    ]
 )


### PR DESCRIPTION
Summary: Now that the SDK update has been ingested, CI tests pass again.

Differential Revision: D83849826


