### PR TITLE
Move RemovePermutesAroundElementwiseOps and RemoveSqueezeViewBeforeElementwiseOps to the common section.

### DIFF
--- a/backends/cadence/aot/remove_ops.py
+++ b/backends/cadence/aot/remove_ops.py
@@ -935,6 +935,8 @@ class CommonRemovePasses:
         RemoveNopSelectOpPass,
         RemoveToOpsPass,
         RemoveZeroSizedCatArgsPass,
+        RemovePermutesAroundElementwiseOps,
+        RemoveSqueezeViewBeforeElementwiseOps,
     ]
 
 


### PR DESCRIPTION
Differential Revision: D83793229


