### PR TITLE
Update constructor args supplying too few parameters

### DIFF
--- a/.ci/docker/ci_commit_pins/pytorch.txt
+++ b/.ci/docker/ci_commit_pins/pytorch.txt
@@ -1,1 +1,1 @@
-53a2908a10f414a2f85caa06703a26a40e873869
+gh/benjaminglass1/106/orig

--- a/backends/apple/mps/test/test_mps.py
+++ b/backends/apple/mps/test/test_mps.py
@@ -1522,7 +1522,7 @@ class TestMPSUnitOpTesting(TestMPS):
         class PadModule(torch.nn.Module):
             def __init__(self):
                 super().__init__()
-                self.constant_pad = torch.nn.ConstantPad2d((1, 2), 0)
+                self.constant_pad = torch.nn.ConstantPad2d((1, 2, 0, 0), 0)
 
             def forward(self, x):
                 return self.constant_pad(x)

--- a/backends/xnnpack/test/ops/test_static_constant_pad.py
+++ b/backends/xnnpack/test/ops/test_static_constant_pad.py
@@ -105,7 +105,7 @@ class TestStaticConstantPad(unittest.TestCase):
     class StaticConstantPad2d(torch.nn.Module):
         def __init__(self):
             super().__init__()
-            self.pad = torch.nn.ConstantPad2d([1, 2, 3, 4], 2.3)
+            self.pad = torch.nn.ConstantPad2d((1, 2, 3, 4), 2.3)
 
         def forward(self, x):
             y = self.pad(x)


### PR DESCRIPTION
This is a prerequisite for https://github.com/pytorch/pytorch/pull/162340. The CI pin will be reverted before merge.
