### PR TITLE
Arm backend: Bump tosa version to remove mlplatform dependencies

### DIFF
--- a/backends/arm/requirements-arm-tosa.txt
+++ b/backends/arm/requirements-arm-tosa.txt
@@ -8,4 +8,4 @@ flatbuffers == 24.3.25
 tosa-adapter-model-explorer == 0.0.1
 ai-edge-model-explorer >= 0.1.16
 
-tosa-tools @ git+https://git.gitlab.arm.com/tosa/tosa-reference-model.git@v2025.07.0
+tosa-tools @ git+https://git.gitlab.arm.com/tosa/tosa-reference-model.git@v2025.07.1


### PR DESCRIPTION
 The only change with this version is that submodules will
 no longer point to mlplatform and will instead point to gitlab.


Change-Id: I99e78b9401eaffa2b3e4ae8e840c84bd69ac5ab2


cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai