### PR TITLE
Arm backend: Add missing attribute in VisualizePass

### DIFF
--- a/backends/arm/_passes/_debug_passes.py
+++ b/backends/arm/_passes/_debug_passes.py
@@ -3,6 +3,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Set, Type
+
 import torch
 from executorch.devtools.visualization.visualization_utils import visualize_graph
 from executorch.exir import ExportedProgram
@@ -13,6 +15,8 @@ class VisualizePass(ExportPass):
     """
     This pass visualizes the graph at the point of insertion in the pass manager
     """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
 
     def __init__(self, exported_program: ExportedProgram) -> None:
         super().__init__()


### PR DESCRIPTION
VisualizePass was missing _passes_required_after and could therefore not be initialized. Define this attribute to fix the problem.

cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai