### PR TITLE
Read max context length from the correct ModelArgs field

### DIFF
--- a/examples/models/llama/static_attention.py
+++ b/examples/models/llama/static_attention.py
@@ -259,7 +259,7 @@ class StaticAttentionIOManager:
         }
 
         rope = Rope(config)
-        freqs = rope.get_freqs(None, config.max_seq_len)
+        freqs = rope.get_freqs(None, config.max_context_len)
         self.freqs_cos = freqs[0].to(dtype)
         self.freqs_sin = freqs[1].to(dtype)
 


### PR DESCRIPTION
Summary: We should read from `max_context_len` for RoPE, `max_seq_len` represents input sequence length.

Differential Revision: D84182698


