### PR TITLE
XNNPACK: Assert on unsupported pass through tensor args

### DIFF
--- a/backends/xnnpack/xnnpack_preprocess.py
+++ b/backends/xnnpack/xnnpack_preprocess.py
@@ -71,6 +71,11 @@ def generate_node_to_external_map(
         if node.op == "output":
             for output_nodes in node.args:
                 for output_node in output_nodes:
+                    if output_node in node_to_external_map:
+                        raise RuntimeError(
+                            f"Output node '{output_node}' is already in the inputs. "
+                            "This is likely due to pass through arguments, which are not supported in XNNPACK Delegate."
+                        )
                     node_to_external_map[output_node] = ExternalMeta(
                         external_id=len(node_to_external_map),
                         io_type=XNN_VALUE_FLAG_EXTERNAL_OUTPUT,


### PR DESCRIPTION
Summary:
Partitioned original graph,
```
forward(t1, t2, t3):
   t4 = some_op_to_be_removed(t1)
   t5 = add(t2, t3)
   return [t4, t5]
```
can become after transformations inside XNNPACK.
```
forward(t1, t2, t3):
   t5 = add(t2, t3)
   return [t1, t5]
```

pass through t1 isn't something we handle well today.

The asserts stop us AoT before running into weird runtime issues.

This is temporary until we allow passthrough args in the delegate at runtime.

Differential Revision: D83872407


