### PR TITLE
Arm backend: Updated how generic evaluator is handled

### DIFF
--- a/examples/arm/aot_arm_compiler.py
+++ b/examples/arm/aot_arm_compiler.py
@@ -285,7 +285,9 @@ def get_calibration_data(
 ):
     # Firstly, if the model is being evaluated, take the evaluators calibration function if it has one
     if evaluator_name is not None:
-        return evaluator_calibration_data(evaluator_name, evaluator_config)
+        evaluator_data = evaluator_calibration_data(evaluator_name, evaluator_config)
+        if evaluator_data is not None:
+            return evaluator_data
 
     # If the model is in the calibration_data dictionary, get the data from there
     # This is used for the simple model examples provided


### PR DESCRIPTION
Currently using the generic evaluator leads to a dataset of "None" being used. This patch reverts the dataset to being defaulted to example inputs for the generic evaluator.

Change-Id: I7bdb3161d6339eadc50a1d3a73d592119fa87587

cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai