### PR TITLE
Add -fexceptions to quantized kernel generated libs

### DIFF
--- a/kernels/quantized/targets.bzl
+++ b/kernels/quantized/targets.bzl
@@ -96,41 +96,46 @@ def define_common_targets():
             ],
         )
 
-        executorch_generated_lib(
-            name = "generated_lib" + aten_suffix,
-            deps = [
-                ":quantized_operators" + aten_suffix,
-                ":all_quantized_ops",
-            ],
-            custom_ops_yaml_target = ":quantized.yaml",
-            custom_ops_aten_kernel_deps = [":quantized_operators_aten"] if aten_mode else [],
-            custom_ops_requires_aot_registration = False,
-            aten_mode = aten_mode,
-            visibility = [
-                "//executorch/...",
-                "@EXECUTORCH_CLIENTS",
-            ],
-            define_static_targets = True,
-        )
+        for support_exceptions in [True, False]:
+            exception_suffix = "_no_exceptions" if not support_exceptions else ""
 
-        # On Windows we can only compile these two ops currently, so adding a
-        # separate target for this.
-        executorch_generated_lib(
-            name = "q_dq_ops_generated_lib" + aten_suffix,
-            custom_ops_yaml_target = ":quantized.yaml",
-            kernel_deps = [
-                "//executorch/kernels/quantized/cpu:op_quantize" + aten_suffix,
-                "//executorch/kernels/quantized/cpu:op_dequantize" + aten_suffix,
-            ],
-            aten_mode = aten_mode,
-            deps = [
-                ":q_dq_ops",
-            ],
-            visibility = [
-                "//executorch/...",
-                "@EXECUTORCH_CLIENTS",
-            ],
-        )
+            executorch_generated_lib(
+                name = "generated_lib" + aten_suffix + exception_suffix,
+                deps = [
+                    ":quantized_operators" + aten_suffix,
+                    ":all_quantized_ops",
+                ],
+                custom_ops_yaml_target = ":quantized.yaml",
+                custom_ops_aten_kernel_deps = [":quantized_operators_aten"] if aten_mode else [],
+                custom_ops_requires_aot_registration = False,
+                aten_mode = aten_mode,
+                support_exceptions = support_exceptions,
+                visibility = [
+                    "//executorch/...",
+                    "@EXECUTORCH_CLIENTS",
+                ],
+                define_static_targets = True,
+            )
+
+            # On Windows we can only compile these two ops currently, so adding a
+            # separate target for this.
+            executorch_generated_lib(
+                name = "q_dq_ops_generated_lib" + aten_suffix + exception_suffix,
+                custom_ops_yaml_target = ":quantized.yaml",
+                kernel_deps = [
+                    "//executorch/kernels/quantized/cpu:op_quantize" + aten_suffix,
+                    "//executorch/kernels/quantized/cpu:op_dequantize" + aten_suffix,
+                ],
+                aten_mode = aten_mode,
+                deps = [
+                    ":q_dq_ops",
+                ],
+                support_exceptions = support_exceptions,
+                visibility = [
+                    "//executorch/...",
+                    "@EXECUTORCH_CLIENTS",
+                ],
+            )
 
     runtime.python_library(
         name = "quantized_ops_lib",


### PR DESCRIPTION
Summary:
Added compiling with `-fexceptions` since quantized kernels have exception based code in them. Example error:
```
buck-out/ABC/gen/fbsource/6e53edb0a9a0d828/xplat/executorch/kernels/quantized/__generated_lib_combined__/out/RegisterCodegenUnboxedKernelsEverything.cpp:77:44: error: exception handling disabled, use '-fexceptions' to enable
   77 |             } catch (const std::exception& ex) {
      |           
```
This means the generated code uses exceptions in its code, so we should explicitly flag it to the compiler via the relevant BUCK targets.

Differential Revision: D84284541


