### PR TITLE
Enable 16-bit activations in Cadence Quantizer For fully_connected and linear

### DIFF
--- a/backends/cadence/aot/quantizer/quantizer.py
+++ b/backends/cadence/aot/quantizer/quantizer.py
@@ -342,3 +342,16 @@ class CadenceWithSoftmaxQuantizer(CadenceQuantizer):
             quantizers = get_cadence_default_quantizers()
         quantizers.append(CadenceAtenQuantizer(SoftmaxPattern(), qconfig_A16))
         super().__init__(quantizers)
+
+
+class CadenceWith16BitLinearActivationsQuantizer(CadenceQuantizer):
+    """
+    Quantizer including A16 fully_connected
+    """
+
+    def __init__(self, quantizers: Optional[list[Quantizer]] = None) -> None:
+        if quantizers is None:
+            quantizers = []
+        # Add 16-bit quantizers for LinearPattern
+        quantizers.append(CadenceAtenQuantizer(LinearPattern(), qconfig_A16))
+        super().__init__(quantizers)

--- a/backends/cadence/aot/ref_implementations.py
+++ b/backends/cadence/aot/ref_implementations.py
@@ -261,7 +261,7 @@ def quantized_linear_common(
     src = src.view(-1, K)
 
     dtype = src.dtype
-    supported_dtypes = [torch.int8, torch.uint8, torch.int32]
+    supported_dtypes = [torch.int8, torch.uint8, torch.int16, torch.int32]
     if dtype not in supported_dtypes:
         raise ValueError(
             f"Unsupported dtype to quantize to {dtype}. Supported dtypes must be one of {supported_dtypes}"

--- a/backends/cadence/aot/tests/test_ref_implementations.py
+++ b/backends/cadence/aot/tests/test_ref_implementations.py
@@ -183,6 +183,8 @@ class TestRefImplementations(unittest.TestCase):
                     (False, torch.int8),
                     (True, torch.int8),
                     (True, torch.uint8),
+                    (True, torch.int16),
+                    (False, torch.int16),
                 )
             ],
             # Test case 2: 1x3 input, 2x3 weight (2 output features)
@@ -207,6 +209,8 @@ class TestRefImplementations(unittest.TestCase):
                 for (per_tensor, dtype) in (
                     (False, torch.int8),
                     (True, torch.int8),
+                    (False, torch.int16),
+                    (True, torch.int16),
                 )
             ],
             *[
@@ -256,6 +260,8 @@ class TestRefImplementations(unittest.TestCase):
                 for (per_tensor, dtype) in (
                     (False, torch.int8),
                     (True, torch.int8),
+                    (False, torch.int16),
+                    (True, torch.int16),
                 )
             ],
             # Test case 4: Non-zero zero points
@@ -280,6 +286,8 @@ class TestRefImplementations(unittest.TestCase):
                 for (per_tensor, dtype) in (
                     (False, torch.int8),
                     (True, torch.int8),
+                    (False, torch.int16),
+                    (True, torch.int16),
                     # (True, torch.uint8),
                 )
             ],
@@ -302,7 +310,10 @@ class TestRefImplementations(unittest.TestCase):
                     False,
                     False,
                 )
-                for dtype in (torch.int8,)
+                for dtype in (
+                    torch.int8,
+                    torch.int16,
+                )
             ],
             # Test case 6: Non-zero out_shift (shift=1)
             *[
@@ -325,7 +336,12 @@ class TestRefImplementations(unittest.TestCase):
                     False,
                     False,
                 )
-                for (per_tensor, dtype) in ((False, torch.int8), (True, torch.int8))
+                for (per_tensor, dtype) in (
+                    (False, torch.int8),
+                    (True, torch.int8),
+                    (False, torch.int16),
+                    (True, torch.int16),
+                )
             ],
             *[
                 (
@@ -348,7 +364,7 @@ class TestRefImplementations(unittest.TestCase):
                     transposed_matmul,
                 )
                 for (matmul, transposed_matmul) in ((True, False), (True, True))
-                for (per_tensor, dtype) in ((True, torch.int8),)
+                for (per_tensor, dtype) in ((True, torch.int8), (True, torch.int16))
             ],
             *[
                 (


### PR DESCRIPTION
Summary:
# Context
We currently only support 8-bit for most operators. We would like to add generic ops for 16-bit activations, for the following ops:
- quantized_fully_connected
- quantized_linear
- quantized_conv (all flavors)
- quantized_matmul



# This Diff


Here, we add support for `quantized_linear` and `quantized_fully_connected`. We need to do the following: 
1. Allow 16-bit activations in `quantized_fully_connected_out.cpp` and `quantized_linear_out.cpp`. 
2. Allow 16-bit activations in `ref_implementations.py`, so tests can run with 16-bit activations to validate the quantization is correct. 
3. Add a quantizer(`CadenceWith16BitLinearActivationsQuantizer`) for checking this works and create a unit test.

Differential Revision: D84284794


