### PR TITLE
NXP backend: Unify quantization function implementations

### DIFF
--- a/backends/nxp/tests/executorch_pipeline.py
+++ b/backends/nxp/tests/executorch_pipeline.py
@@ -23,6 +23,7 @@ from executorch.backends.nxp.edge_passes.remove_io_quant_ops_pass import (
 from executorch.backends.nxp.neutron_partitioner import NeutronPartitioner
 from executorch.backends.nxp.nxp_backend import generate_neutron_compile_spec
 from executorch.backends.nxp.quantizer.neutron_quantizer import NeutronQuantizer
+from executorch.backends.nxp.quantizer.utils import post_training_quantize
 from executorch.exir import (
     EdgeCompileConfig,
     EdgeProgramManager,
@@ -32,12 +33,12 @@ from executorch.exir import (
 )
 from torch import nn
 from torch.export import export
-from torchao.quantization.pt2e.quantize_pt2e import convert_pt2e, prepare_pt2e
 from torchao.quantization.pt2e.quantizer import Quantizer
 
-default_neutron_converter_flavor = "SDK_25_09"
+
+neutron_converter_flavor = "SDK_25_09"
 neutron_target_spec = NeutronTargetSpec(
-    target="imxrt700", neutron_converter_flavor=default_neutron_converter_flavor
+    target="imxrt700", neutron_converter_flavor=neutron_converter_flavor
 )
 
 
@@ -45,17 +46,6 @@ neutron_target_spec = NeutronTargetSpec(
 class ModelInputSpec:
     shape: tuple[int, ...]
     dtype: torch.dtype = torch.float32
-
-
-def _quantize_model(
-    model, quantizer, calibration_inputs: list[tuple[torch.Tensor, ...]]
-):
-    m = prepare_pt2e(model, quantizer)
-    for data in calibration_inputs:
-        m(*data)
-    m = convert_pt2e(m)
-
-    return m
 
 
 def get_random_calibration_inputs(
@@ -101,7 +91,7 @@ def to_quantized_edge_program(
         [tuple[ModelInputSpec, ...]], list[tuple[torch.Tensor, ...]]
     ] = get_random_calibration_inputs,
     target="imxrt700",
-    neutron_converter_flavor=default_neutron_converter_flavor,
+    neutron_converter_flavor=neutron_converter_flavor,
     remove_quant_io_ops=False,
     custom_delegation_options=CustomDelegationOptions(),  # noqa B008
     get_quantizer_fn=None,
@@ -109,7 +99,6 @@ def to_quantized_edge_program(
     _neutron_target_spec = NeutronTargetSpec(target, neutron_converter_flavor)
     if get_quantizer_fn is None:
         get_quantizer_fn = partial(_get_default_quantizer, _neutron_target_spec)
-    quantizer = get_quantizer_fn()
 
     calibration_inputs = get_calibration_inputs_fn(to_model_input_spec(input_spec))
     example_input = calibration_inputs[0]
@@ -119,10 +108,10 @@ def to_quantized_edge_program(
 
     exir_program_aten = torch.export.export(model, example_input, strict=True)
 
-    exir_program_aten__module_quant = _quantize_model(
-        exir_program_aten.module(),
-        quantizer,
+    exir_program_aten__module_quant = post_training_quantize(
+        exir_program_aten,
         calibration_inputs,
+        get_quantizer_fn(),
     )
 
     compile_spec = generate_neutron_compile_spec(

--- a/backends/nxp/tests/test_quantizer.py
+++ b/backends/nxp/tests/test_quantizer.py
@@ -376,7 +376,7 @@ def test_quantizers_order_invariance():
 )
 def test_quantizer__linear_w_activation(mocker, activation, inplace):
     converter_spy = mocker.spy(EdgeProgramToIRConverter, "convert_program")
-    quantizer_spy = mocker.spy(executorch_pipeline, "_quantize_model")
+    quantizer_spy = mocker.spy(executorch_pipeline, "post_training_quantize")
 
     input_shape = (1, 4)
     model = models.LinearActivationModule(
@@ -432,7 +432,7 @@ def test_quantizer__linear_w_activation(mocker, activation, inplace):
 )
 def test_quantizer__addmm_w_activation(mocker, activation, inplace):
     converter_spy = mocker.spy(EdgeProgramToIRConverter, "convert_program")
-    quantizer_spy = mocker.spy(executorch_pipeline, "_quantize_model")
+    quantizer_spy = mocker.spy(executorch_pipeline, "post_training_quantize")
 
     input_shape = (1, 4)
     model = models.LinearActivationModule(
@@ -485,7 +485,7 @@ def test_quantizer__addmm_w_activation(mocker, activation, inplace):
 )
 def test_quantizer__mm_w_activation(mocker, activation, inplace):
     converter_spy = mocker.spy(EdgeProgramToIRConverter, "convert_program")
-    quantizer_spy = mocker.spy(executorch_pipeline, "_quantize_model")
+    quantizer_spy = mocker.spy(executorch_pipeline, "post_training_quantize")
 
     input_shape = (1, 4)
     model = models.LinearActivationModule(
@@ -538,7 +538,7 @@ def test_quantizer__mm_w_activation(mocker, activation, inplace):
 )
 def test_quantizer__conv_w_activation(mocker, activation, inplace):
     converter_spy = mocker.spy(EdgeProgramToIRConverter, "convert_program")
-    quantizer_spy = mocker.spy(executorch_pipeline, "_quantize_model")
+    quantizer_spy = mocker.spy(executorch_pipeline, "post_training_quantize")
 
     input_shape = (1, 4, 8, 8)
     model = models.ConvActivationModule(

--- a/backends/nxp/tests/test_removing_dead_code.py
+++ b/backends/nxp/tests/test_removing_dead_code.py
@@ -10,10 +10,8 @@ import pytest
 import torch
 
 from executorch.backends.nxp.quantizer.neutron_quantizer import NeutronQuantizer
-from executorch.backends.nxp.tests.executorch_pipeline import (
-    _quantize_model,
-    neutron_target_spec,
-)
+from executorch.backends.nxp.quantizer.utils import post_training_quantize
+from executorch.backends.nxp.tests.executorch_pipeline import neutron_target_spec
 from executorch.backends.nxp.tests.executors import graph_contains_any_of_ops
 
 
@@ -55,8 +53,8 @@ class TestRemovingDeadCode(unittest.TestCase):
 
         # The `NeutronQuantizer` should remove the dead code in the `transform_for_annotation()` method.
         quantizer = NeutronQuantizer(neutron_target_spec)
-        exir_program_aten_quant = _quantize_model(
-            exir_program_aten.module(), quantizer, [example_inputs]
+        exir_program_aten_quant = post_training_quantize(
+            exir_program_aten, [example_inputs], quantizer
         )
 
         # Make sure the is no `add` operation in the graph anymore.

--- a/backends/nxp/tests/test_split_group_convolution.py
+++ b/backends/nxp/tests/test_split_group_convolution.py
@@ -18,8 +18,8 @@ from executorch.backends.nxp.aten_passes.split_group_convolution import (
 from executorch.backends.nxp.neutron_partitioner import NeutronPartitioner
 from executorch.backends.nxp.nxp_backend import generate_neutron_compile_spec
 from executorch.backends.nxp.quantizer.neutron_quantizer import NeutronQuantizer
+from executorch.backends.nxp.quantizer.utils import post_training_quantize
 from executorch.backends.nxp.tests.executorch_pipeline import (
-    _quantize_model,
     get_random_calibration_inputs,
     neutron_target_spec,
     to_model_input_spec,
@@ -41,10 +41,11 @@ def _quantize_and_lower_module(
     module: GraphModule, input_shape: tuple[int, ...], target="imxrt700"
 ) -> EdgeProgramManager:
     calibration_inputs = get_random_calibration_inputs(to_model_input_spec(input_shape))
-    quantizer = NeutronQuantizer(neutron_target_spec)
 
-    exir_program_aten__module_quant = _quantize_model(
-        module, quantizer, calibration_inputs
+    exir_program_aten__module_quant = post_training_quantize(
+        module,
+        calibration_inputs,
+        NeutronQuantizer(neutron_target_spec),
     )
 
     edge_compile_config = EdgeCompileConfig(_check_ir_validity=False)

--- a/docs/source/backends-nxp.md
+++ b/docs/source/backends-nxp.md
@@ -56,21 +56,41 @@ List of Aten operators supported by Neutron quantizer:
 `reshape`, `view`, `softmax.int`, `sigmoid`, `tanh`, `tanh_`
 
 #### Example
+
+To quantize your model, you can either use the PT2E workflow:
 ```python
 import torch
 from executorch.backends.nxp.quantizer.neutron_quantizer import NeutronQuantizer
+from executorch.backends.nxp.backend.neutron_target_spec import NeutronTargetSpec
 from torchao.quantization.pt2e.quantize_pt2e import convert_pt2e, prepare_pt2e
 
 # Prepare your model in Aten dialect
 aten_model = get_model_in_aten_dialect()
 # Prepare calibration inputs, each tuple is one example, example tuple has items for each model input
 calibration_inputs: list[tuple[torch.Tensor, ...]] = get_calibration_inputs()
-quantizer = NeutronQuantizer()
+target_spec = NeutronTargetSpec(target="imxrt700", converter_flavor="SDK_25_09")
+quantizer = NeutronQuantizer(neutron_target_spec)
 
 m = prepare_pt2e(aten_model, quantizer)
 for data in calibration_inputs:
     m(*data)
 m = convert_pt2e(m)
+```
+
+Or you can use the predefined function for post training quantization from NXP backend implementation:
+```python
+from executorch.backends.nxp.quantizer.neutron_quantizer import NeutronQuantizer
+from executorch.backends.nxp.backend.neutron_target_spec import NeutronTargetSpec
+from executorch.backends.nxp.quantizer.utils import post_training_quantize
+
+...
+
+target_spec = NeutronTargetSpec(target="imxrt700", converter_flavor="SDK_25_09")
+quantized_graph_module = post_training_quantize(
+    aten_model,
+    calibration_inputs,
+    NeutronQuantizer(neutron_target_spec=target_spec),
+)
 ```
 
 ## Runtime Integration

--- a/examples/nxp/aot_neutron_compile.py
+++ b/examples/nxp/aot_neutron_compile.py
@@ -9,7 +9,6 @@ import argparse
 import io
 import logging
 from collections import defaultdict
-from typing import Iterator
 
 import executorch.extension.pybindings.portable_lib
 import executorch.kernels.quantized  # noqa F401
@@ -25,6 +24,7 @@ from executorch.backends.nxp.edge_passes.remove_io_quant_ops_pass import (
 from executorch.backends.nxp.neutron_partitioner import NeutronPartitioner
 from executorch.backends.nxp.nxp_backend import generate_neutron_compile_spec
 from executorch.backends.nxp.quantizer.neutron_quantizer import NeutronQuantizer
+from executorch.backends.nxp.quantizer.utils import post_training_quantize
 from executorch.devtools.visualization.visualization_utils import (
     visualize_with_clusters,
 )
@@ -37,7 +37,6 @@ from executorch.exir import (
 )
 from executorch.extension.export_util import save_pte_program
 from torch.export import export
-from torchao.quantization.pt2e.quantize_pt2e import convert_pt2e, prepare_pt2e
 
 from .experimental.cifar_net.cifar_net import CifarNet, test_cifarnet_model
 from .models.mobilenet_v2 import MobilenetV2
@@ -107,44 +106,6 @@ models = {
     "cifar10": CifarNet,
     "mobilenetv2": MobilenetV2,
 }
-
-
-def post_training_quantize(
-    model,
-    calibration_inputs: tuple[torch.Tensor] | Iterator[tuple[torch.Tensor]],
-    neutron_target_spec: NeutronTargetSpec,
-):
-    """Quantize the provided model.
-
-    :param model: Aten model to quantize.
-    :param calibration_inputs: Either a tuple of calibration input tensors where each element corresponds to a model
-                                input. Or an iterator over such tuples.
-    :param _neutron_target_spec: The functionality for probing the properties of Neutron Target.
-    """
-    # Based on executorch.examples.arm.aot_amr_compiler.quantize
-    logging.info("Quantizing model")
-    logging.debug(f"---> Original model: {model}")
-    quantizer = NeutronQuantizer(neutron_target_spec)
-
-    m = prepare_pt2e(model, quantizer)
-    # Calibration:
-    logging.debug("Calibrating model")
-
-    def _get_batch_size(data):
-        return data[0].shape[0]
-
-    if not isinstance(
-        calibration_inputs, tuple
-    ):  # Assumption that calibration_inputs is finite.
-        for i, data in enumerate(calibration_inputs):
-            if i % (1000 // _get_batch_size(data)) == 0:
-                logging.debug(f"{i * _get_batch_size(data)} calibration inputs done")
-            m(*data)
-    else:
-        m(*calibration_inputs)
-    m = convert_pt2e(m)
-    logging.debug(f"---> Quantized model: {m}")
-    return m
 
 
 if __name__ == "__main__":  # noqa C901
@@ -254,7 +215,8 @@ if __name__ == "__main__":  # noqa C901
                 "No calibration inputs available, using the example inputs instead"
             )
             calibration_inputs = example_inputs
-        module = post_training_quantize(module, calibration_inputs, neutron_target_spec)
+        quantizer = NeutronQuantizer(neutron_target_spec)
+        module = post_training_quantize(module, calibration_inputs, quantizer)
 
     if args.so_library is not None:
         logging.debug(f"Loading libraries: {args.so_library}")


### PR DESCRIPTION
### Summary
Unifies implementation of model quantization between `executorch_pipeline.py` and example `aot_neutron_compile.py` and introduces documented single function interface.

Includes test fixes in `test_move_activation_before_concatenation.py` related to quantizer function spying.

### Test plan
Should be covered by already existing unit tests.


cc @robert-kalmar @JakeStevens @digantdesai