### PR TITLE
Choosing ops_to_preserve by delegating to quantizer

### DIFF
--- a/backends/cadence/aot/TARGETS
+++ b/backends/cadence/aot/TARGETS
@@ -631,3 +631,15 @@ python_unittest(
         "//caffe2:torch",
     ]
 )
+
+python_unittest(
+    name = "test_quantizer_ops",
+    srcs = [
+        "tests/test_quantizer_ops.py",
+    ],
+    typing = True,
+    deps = [
+        "//caffe2:torch",
+        "//executorch/backends/cadence/aot/quantizer:quantizer",
+    ],
+)

--- a/backends/cadence/aot/compiler.py
+++ b/backends/cadence/aot/compiler.py
@@ -65,22 +65,10 @@ def trace(
     """
     Trace the model with export and return an ExportedProgram.
     """
+    if quantizer is None:
+        quantizer = default_quantizer
 
-    ops_to_keep = [
-        torch.ops.aten.conv1d.default,
-        torch.ops.aten.conv2d.default,
-        torch.ops.aten.layer_norm.default,
-        torch.ops.aten.linear.default,
-        torch.ops.aten.matmul.default,
-        torch.ops.aten.rms_norm.default,
-    ]
-
-    if isinstance(quantizer, CadenceW8A32MixedQuantizer):
-        ops_to_keep += [
-            torch.ops.aten.gru.input,
-            torch.ops.aten.gru.data,
-        ]
-
+    ops_to_keep = quantizer.get_ops_to_preserve_from_decomposition()
     program = trace_fn(
         model, inputs, is_qat=False, strict=True, ops_to_keep=ops_to_keep
     )

--- a/backends/cadence/aot/tests/test_quantizer_ops.py
+++ b/backends/cadence/aot/tests/test_quantizer_ops.py
@@ -1,0 +1,66 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+
+import torch
+
+from executorch.backends.cadence.aot.quantizer.quantizer import (
+    CadenceW8A32MixedQuantizer,
+    CadenceDefaultQuantizer,
+    get_cadence_default_ops,
+)
+
+
+class DerivedMixedQuantizer(CadenceW8A32MixedQuantizer):
+    """
+    Test-only subclass to validate MRO aggregation:
+    contributes one additional op beyond CadenceW8A32MixedQuantizer.
+    """
+
+    ADDITIONAL_OPS_TO_PRESERVE: tuple[torch._ops.OpOverload, ...] = (
+        torch.ops.aten.batch_norm.default,
+    )
+
+
+class QuantizerOpsPreserveTest(unittest.TestCase):
+    def test_mixed_w8a32_ops_to_preserve(self) -> None:
+        q = CadenceW8A32MixedQuantizer()
+        actual = q.get_ops_to_preserve_from_decomposition()
+        expected = get_cadence_default_ops()
+        expected += [
+            torch.ops.aten.gru.input,
+            torch.ops.aten.gru.data,
+        ]
+        self.assertCountEqual(actual, expected)
+
+    def test_default_quantizer_ops_to_preserve(self) -> None:
+        q = CadenceDefaultQuantizer()
+        actual = q.get_ops_to_preserve_from_decomposition()
+        expected = get_cadence_default_ops()
+        self.assertCountEqual(actual, expected)
+
+    def test_mro_aggregation_includes_subclass_ops(self) -> None:
+        """
+        Validate MRO aggregation: DerivedMixedQuantizer should include
+        base Cadence ops, GRU ops from CadenceW8A32MixedQuantizer, and
+        the subclass-contributed batch_norm op.
+        """
+        q = DerivedMixedQuantizer()
+        actual = q.get_ops_to_preserve_from_decomposition()
+        expected = get_cadence_default_ops()
+        expected += [
+            torch.ops.aten.gru.input,
+            torch.ops.aten.gru.data,
+            torch.ops.aten.batch_norm.default,
+        ]
+        self.assertCountEqual(actual, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
# Context
The `trace` function in `compiler.py` returns the static graph representation of the model. Because certain hardwares are very optimized for certain operations, we don't want to decompose those operations in our graph. 

Thus, currently, the function passes in `ops_to_keep` to `trace_fn` 

https://www.internalfb.com/code/fbsource/[ada71b37b46a898065851182cd48b48b321a5d12]/fbcode/executorch/backends/cadence/aot/compiler.py?lines=59-86

which then removes these operations before decomposing the graph:
https://www.internalfb.com/code/fbsource/[ada71b37b46a898065851182cd48b48b321a5d12]/fbcode/executorch/backends/cadence/aot/compiler_funcs.py?lines=33-36

# Issue
Right now, the `ops_to_keep` is hardcoded, and there's no easy way to customize which ops to keep. View [this comment thread](https://www.internalfb.com/diff/D81703253?dst_version_fbid=1326590512174768&transaction_fbid=728299956948640) for more details. 

The tl;dr is that there should be stricter separation of concerns between the compiler and the hardware -- the compiler shouldn't need to know what ops to keep or not. 


# Possible Solutions

|  Solution | Pros  | Cons  |
| -- |
| Delegate `ops_to_keep` to `QuantizationPattern`  | Clear separation of concerns, semantically correct, works well with current composition structure of classes, easily extensible  | Changes existing behavior. i.e, `CadenceFusedConvReluQuantizer` doesn't have all patterns, but current behavior is that compiler is actually keeping all default ops. Also, `QuantizationPattern` isn't owned by us, so we might have to create a wrapper, etc. so could be not worth long-term maintenence.  |
| Delegate `ops_to_keep` to `CadenceQuantizer`[**chosen solution**]  | Keeps existing behavior, simple for users(just add additional ops to keep)   | Doesn't work well with more complex compositions(none exist), making inheritance additive is somewhat complicated,  not sure if it makes sense semantically, harder to customize   |


# This Diff
For now, we delegate `ops_to_keep` to `CadenceQuantizer`(second solution). We
1. Create a method `get_ops_to_preserve_from_decomposition`,  in `CadenceQuantizer` and fill it with the default ops that's currently set for everything, and create a method `_collect_additional_ops` that goes through the inheritance chain to add all additional ops to keep, and finally, create the class attribute `ADDITIONAL_OPS_TO_PRESERVE` for subclasses to override. 
2. Port over current logic into the correct quantizer
3. Update the `trace` function in `compiler.py` to use our method rather than the hardcoding.
4. Add unit tests to validate changes 

Now, if someone has some ops they would like to keep for a quantizer, they just need to update that quantizer's `ADDITIONAL_OPS_TO_PRESERVE`.

Differential Revision: D84461403


