### PR TITLE
Tensor view keeps original tensor alive.

### DIFF
--- a/extension/apple/ExecuTorch/Exported/ExecuTorchTensor.mm
+++ b/extension/apple/ExecuTorch/Exported/ExecuTorchTensor.mm
@@ -129,7 +129,7 @@ NSInteger ExecuTorchElementCountOfShape(NSArray<NSNumber *> *shape) {
 - (instancetype)initWithTensor:(ExecuTorchTensor *)otherTensor {
   ET_CHECK(otherTensor);
   auto tensor = make_tensor_ptr(
-    **reinterpret_cast<TensorPtr *>(otherTensor.nativeInstance)
+    *reinterpret_cast<TensorPtr *>(otherTensor.nativeInstance)
   );
   return [self initWithNativeInstance:&tensor];
 }

--- a/extension/tensor/tensor_ptr.h
+++ b/extension/tensor/tensor_ptr.h
@@ -338,13 +338,16 @@ inline TensorPtr make_tensor_ptr(
  * @param sizes Optional sizes override.
  * @param dim_order Optional dimension order override.
  * @param strides Optional strides override.
+ * @param deleter A custom deleter function for managing the lifetime of the
+ * original Tensor.
  * @return A TensorPtr aliasing the same storage with requested metadata.
  */
 inline TensorPtr make_tensor_ptr(
     const executorch::aten::Tensor& tensor,
     std::vector<executorch::aten::SizesType> sizes = {},
     std::vector<executorch::aten::DimOrderType> dim_order = {},
-    std::vector<executorch::aten::StridesType> strides = {}) {
+    std::vector<executorch::aten::StridesType> strides = {},
+    std::function<void(void*)> deleter = nullptr) {
   if (sizes.empty()) {
     sizes.assign(tensor.sizes().begin(), tensor.sizes().end());
   }
@@ -372,16 +375,18 @@ inline TensorPtr make_tensor_ptr(
       tensor.mutable_data_ptr(),
       std::move(dim_order),
       std::move(strides),
-      tensor.scalar_type()
+      tensor.scalar_type(),
 #ifndef USE_ATEN_LIB
-          ,
-      tensor.shape_dynamism()
+      tensor.shape_dynamism(),
+#else // USE_ATEN_LIB
+      executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND,
 #endif // USE_ATEN_LIB
-  );
+      std::move(deleter));
 }
 
 /**
  * Convenience overload identical to make_tensor_ptr(*tensor_ptr, ...).
+ * Keeps the original TensorPtr alive until the returned TensorPtr is destroyed.
  *
  * @param tensor_ptr The source tensor pointer to alias.
  * @param sizes Optional sizes override.
@@ -395,7 +400,11 @@ inline TensorPtr make_tensor_ptr(
     std::vector<executorch::aten::DimOrderType> dim_order = {},
     std::vector<executorch::aten::StridesType> strides = {}) {
   return make_tensor_ptr(
-      *tensor_ptr, std::move(sizes), std::move(dim_order), std::move(strides));
+      *tensor_ptr,
+      std::move(sizes),
+      std::move(dim_order),
+      std::move(strides),
+      [tensor_ptr](void*) {});
 }
 
 /**


### PR DESCRIPTION
Summary: TensorPtr view created with TensorPtr should keep it alive to match ATen behavior.

Differential Revision: D84512176


