### PR TITLE
Tensor view keeps original tensor alive.

### DIFF
--- a/extension/apple/ExecuTorch/Exported/ExecuTorchTensor.mm
+++ b/extension/apple/ExecuTorch/Exported/ExecuTorchTensor.mm
@@ -131,7 +131,11 @@ NSInteger ExecuTorchElementCountOfShape(NSArray<NSNumber *> *shape) {
   auto tensor = make_tensor_ptr(
     *reinterpret_cast<TensorPtr *>(otherTensor.nativeInstance)
   );
-  return [self initWithNativeInstance:&tensor];
+  self = [self initWithNativeInstance:&tensor];
+  if (self) {
+    _data = otherTensor->_data;
+  }
+  return self;
 }
 
 - (instancetype)copy {

--- a/extension/apple/ExecuTorch/__tests__/TensorTest.swift
+++ b/extension/apple/ExecuTorch/__tests__/TensorTest.swift
@@ -96,6 +96,19 @@ class TensorTest: XCTestCase {
     XCTAssertEqual(tensor.scalars(), dataArray)
   }
 
+  func testInitDataViewSurvivesSourceScopeEnd() {
+    let dataArray: [Float] = [1.0, 2.0, 3.0, 4.0]
+    var view: Tensor<Float>!
+    autoreleasepool {
+      let data = Data(bytes: dataArray, count: dataArray.count * MemoryLayout<Float>.size)
+      let tensor = Tensor<Float>(data: data, shape: [4])
+      view = Tensor<Float>(tensor)
+      XCTAssertEqual(view.scalars(), dataArray)
+    }
+    XCTAssertEqual(view.count, 4)
+    XCTAssertEqual(view.scalars(), dataArray)
+  }
+
   func testWithCustomStridesAndDimensionOrder() {
     let data: [Float] = [1.0, 2.0, 3.0, 4.0]
     let tensor = Tensor<Float>(


### PR DESCRIPTION
Summary: A view on a tensor created with NSData should keep the data alive

Differential Revision: D84512175


