### PR TITLE
[ET-VK][ez] Fix unused variable

### DIFF
--- a/backends/vulkan/CMakeLists.txt
+++ b/backends/vulkan/CMakeLists.txt
@@ -52,6 +52,7 @@ set(COMMON_INCLUDES
 set(VULKAN_CXX_FLAGS "-fexceptions")
 list(APPEND VULKAN_CXX_FLAGS "-DUSE_VULKAN_WRAPPER")
 list(APPEND VULKAN_CXX_FLAGS "-DUSE_VULKAN_VOLK")
+list(APPEND VULKAN_CXX_FLAGS "-Werror=unused-variable")
 
 # vulkan API files
 

--- a/backends/vulkan/runtime/graph/ops/impl/BinaryOp.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/BinaryOp.cpp
@@ -161,7 +161,6 @@ void add_binary_op_buffer_node(
   std::string kernel_name("binary_");
   kernel_name.reserve(kShaderNameReserve);
   std::string op = op_name;
-  int clamp_type = remove_clamp_from_name(op);
   kernel_name += op;
   add_storage_type_suffix(kernel_name, graph.storage_type_of(out));
 


### PR DESCRIPTION

Summary:
Title says it all. Also add `-Werror=unused-variable` to compile flags when building Vulkan to guard against this in the future.
