### PR TITLE
[RELEASE ONLY] Use torchao 0.14.0

### DIFF
--- a/.ci/docker/common/install_pytorch.sh
+++ b/.ci/docker/common/install_pytorch.sh
@@ -17,7 +17,7 @@ install_domains() {
 }
 
 install_pytorch_and_domains() {
-  pip_install torch==2.9.0 torchvision torchaudio torchao=0.14.0 --index-url https://download.pytorch.org/whl/test/cpu
+  pip_install torch==2.9.0 torchvision torchaudio torchao==0.14.0 --index-url https://download.pytorch.org/whl/test/cpu
 }
 
 install_pytorch_and_domains

--- a/.ci/docker/common/install_pytorch.sh
+++ b/.ci/docker/common/install_pytorch.sh
@@ -17,7 +17,7 @@ install_domains() {
 }
 
 install_pytorch_and_domains() {
-  pip_install torch==2.9.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/test/cpu
+  pip_install torch==2.9.0 torchvision torchaudio torchao=0.14.0 --index-url https://download.pytorch.org/whl/test/cpu
 }
 
 install_pytorch_and_domains

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -111,6 +111,7 @@ def install_requirements(use_pytorch_nightly):
     )
 
     LOCAL_REQUIREMENTS = [
+        "third-party/ao",  # We need the latest kernels for fast iteration, so not relying on pypi.
     ] + (
         [
             "extension/llm/tokenizers",  # TODO(larryliu0820): Setup a pypi package for this.

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -111,7 +111,6 @@ def install_requirements(use_pytorch_nightly):
     )
 
     LOCAL_REQUIREMENTS = [
-        "third-party/ao",  # We need the latest kernels for fast iteration, so not relying on pypi.
     ] + (
         [
             "extension/llm/tokenizers",  # TODO(larryliu0820): Setup a pypi package for this.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ dependencies=[
   "scikit-learn==1.7.1",
   "hydra-core>=1.3.0",
   "omegaconf>=2.3.0",
-  "torchao=0.14.0",
+  "torchao==0.14.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ dependencies=[
   "scikit-learn==1.7.1",
   "hydra-core>=1.3.0",
   "omegaconf>=2.3.0",
+  "torchao=0.14.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
### Summary
AO has officially released 0.14.0 (see https://pypi.org/project/torchao/#history). Update the pyproject.toml and pins to use 0.14. I also bumped the submodule to the latest release/0.14.0 head, though this only picks up a minor GH actions workflow change.

Fixes https://github.com/pytorch/executorch/issues/14419.

### Test plan
CI