### PR TITLE
updated cmake and doc for bundled program

### DIFF
--- a/docs/source/bundled-io.md
+++ b/docs/source/bundled-io.md
@@ -199,13 +199,13 @@ This stage mainly focuses on executing the model with the bundled inputs and com
 
 ### Get ExecuTorch Program Pointer from `BundledProgram` Buffer
 We need the pointer to ExecuTorch program to do the execution. To unify the process of loading and executing `BundledProgram` and Program flatbuffer, we create an API for this
-`executorch::bundled_program::get_program_data`. Check out an [example usage](https://github.com/pytorch/executorch/blob/release/0.6/examples/devtools/example_runner/example_runner.cpp#L128-L137) of this API.
+`executorch::bundled_program::get_program_data`. Check out an [example usage](https://github.com/pytorch/executorch/blob/release/1.0/examples/devtools/example_runner/example_runner.cpp#L128-L137) of this API.
 
 ### Load Bundled Input to Method
-To execute the program on the bundled input, we need to load the bundled input into the method. Here we provided an API called `executorch::bundled_program::load_bundled_input`.  Check out an [example usage](https://github.com/pytorch/executorch/blob/release/0.6/examples/devtools/example_runner/example_runner.cpp#L253-L259) of this API.
+To execute the program on the bundled input, we need to load the bundled input into the method. Here we provided an API called `executorch::bundled_program::load_bundled_input`.  Check out an [example usage](https://github.com/pytorch/executorch/blob/release/1.0/examples/devtools/example_runner/example_runner.cpp#L253-L259) of this API.
 
 ### Verify the Method's Output.
-We call `executorch::bundled_program::verify_method_outputs` to verify the method's output with bundled expected outputs. Check out an [example usage](https://github.com/pytorch/executorch/blob/release/0.6/examples/devtools/example_runner/example_runner.cpp#L300-L311) of this API.
+We call `executorch::bundled_program::verify_method_outputs` to verify the method's output with bundled expected outputs. Check out an [example usage](https://github.com/pytorch/executorch/blob/release/1.0/examples/devtools/example_runner/example_runner.cpp#L301-L307) of this API.
 
 ### Runtime Example
 
@@ -213,13 +213,29 @@ Please checkout our [example runner](https://github.com/pytorch/executorch/blob/
 
 ```bash
 cd executorch
-   ./examples/devtools/build_example_runner.sh
-   ./cmake-out/examples/devtools/example_runner --bundled_program_path {your-bpte-file} --output_verification
+./examples/devtools/build_example_runner.sh
+./cmake-out/examples/devtools/example_runner --bundled_program_path {your-bpte-file} --output_verification
 ```
 
 It is expected to see no output from running the above mentioned snippet.
+For a detailed example of how the runner should be like, please refer to our [example runner](https://github.com/pytorch/executorch/blob/release/1.0/examples/devtools/example_runner/example_runner.cpp).
 
-For a detailed example of how the runner should be like, please refer to our [example runner](https://github.com/pytorch/executorch/blob/release/0.6/examples/devtools/example_runner/example_runner.cpp).
+
+### Try the Complete Workflow
+
+To test the entire end-to-end workflow including building the example runner, exporting a model, and verifying the bundled program execution, you can use the test script:
+
+```bash
+cd executorch
+./examples/devtools/test_example_runner.sh
+```
+
+This script will:
+1. Build the example runner using `build_example_runner.sh`
+2. Export a MobileNetV2 model as a bundled program
+3. Run the example runner with the bundled program to verify correctness
+
+This is a great way to ensure your environment is set up correctly and to see the complete BundledProgram workflow in action.
 
 ## Common Errors
 

--- a/examples/devtools/build_example_runner.sh
+++ b/examples/devtools/build_example_runner.sh
@@ -61,7 +61,15 @@ main() {
 
   local example_dir=examples/devtools
   local build_dir="cmake-out/${example_dir}"
-  local cmake_prefix_path="${PWD}/cmake-out/lib/cmake/ExecuTorch;${PWD}/cmake-out/third-party/gflags"
+
+  # Check for both lib and lib64 directories
+  local executorch_dir="${PWD}/cmake-out/lib/cmake/ExecuTorch"
+  if [[ ! -d "${executorch_dir}" ]]; then
+    executorch_dir="${PWD}/cmake-out/lib64/cmake/ExecuTorch"
+  fi
+
+  local cmake_prefix_path="${executorch_dir};${PWD}/cmake-out/third-party/gflags"
+
   rm -rf ${build_dir}
   cmake -DCMAKE_PREFIX_PATH="${cmake_prefix_path}" \
       -DCMAKE_BUILD_TYPE=Release \


### PR DESCRIPTION
Summary:
**CMake and Doc Updates for Bundled Program**
==============================================

This diff includes the following changes:

### Doc Updates

* Updated `bundled-io.md` to reflect changes in the `getting-started` and `export-to-executorch-tutorial` links.

### CMake Updates

* Updated `build_example_runner.sh` to simplify the build process and fix the pipefail issue.
* Updated `test_example_runner.sh` to use the same build script as `build_example_runner.sh` and remove redundant code.

Reviewed By: larryliu0820, lucylq

Differential Revision: D84526104
