### PR TITLE
Arm backend: Enable running MV2/DL3/Conformer on MLSDK runtime

### DIFF
--- a/backends/arm/test/models/test_dl3_arm.py
+++ b/backends/arm/test/models/test_dl3_arm.py
@@ -97,8 +97,11 @@ def test_dl3_vgf_INT():
         exir_op=[],
         tosa_version="TOSA-1.0+INT",
         use_to_edge_transform_and_lower=True,
-        run_on_vulkan_runtime=False,  # TODO: run on vulkan runtime
+        run_on_vulkan_runtime=True,  # TODO: run on vulkan runtime
     )
+    pipeline.change_args(
+        "run_method_and_compare_outputs", rtol=0.1, atol=0.1
+    )  # TODO: MLETORCH-1036 decrease tolerance
     pipeline.run()
 
 

--- a/backends/arm/test/models/test_mobilenet_v2_arm.py
+++ b/backends/arm/test/models/test_mobilenet_v2_arm.py
@@ -125,7 +125,6 @@ def test_mv2_vgf_INT(per_channel_quantization):
         per_channel_quantization=per_channel_quantization,
         atol=0.25,
         qtol=1,
-        run_on_vulkan_runtime=False,
     )
     pipeline.run()
 
@@ -139,6 +138,5 @@ def test_mv2_vgf_FP():
         exir_op=[],
         tosa_version="TOSA-1.0+FP",
         use_to_edge_transform_and_lower=True,
-        run_on_vulkan_runtime=False,
     )
     pipeline.run()


### PR DESCRIPTION
Enables model tests for VKML.


cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai