### PR TITLE
Switch ruamel-yaml default from 0.17.x to 0.18.15

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -1,7 +1,7 @@
 mpmath==1.3.0
 numpy>=2.0.0; python_version >= '3.10'
 PyYAML==6.0.1
-ruamel.yaml==0.17.32
+ruamel.yaml==0.18.15
 sympy==1.12
 timm==0.6.13
 tomli==2.0.1

--- a/exir/dialects/edge/_ops.py
+++ b/exir/dialects/edge/_ops.py
@@ -16,7 +16,6 @@ from executorch.exir.dialects.edge.dtype.supported import regular_tensor_str_to_
 from executorch.exir.dialects.edge.op.api import to_variant
 from executorch.exir.dialects.edge.spec.utils import get_tensor_variable_names
 
-# pyre-ignore
 from ruamel.yaml import YAML
 from torchgen.model import SchemaKind
 
@@ -166,7 +165,6 @@ class FunctionDtypeConstraint:
 
 
 def _load_edge_dialect_info() -> Dict[str, Dict[str, Any]]:
-    # pyre-ignore
     yaml = YAML(typ="safe")
     edge_yaml = resources.read_text(edge_package, "edge.yaml", encoding="utf-8")
     edge_dialect_yaml_info = yaml.load(edge_yaml)

--- a/exir/dialects/edge/spec/gen.py
+++ b/exir/dialects/edge/spec/gen.py
@@ -34,7 +34,6 @@ name_to_opinfo = {
     op.aten_name if op.aten_name is not None else op.name: op for op in op_db
 }
 
-# pyre-ignore
 yaml = ruamel.yaml.YAML()
 
 dtr = DtypeRunner()


### PR DESCRIPTION
Summary: Change the default version of ruamel-yaml from 0.17.10 to 0.18.15 everywhere.

Reviewed By: parulgupta1004

Differential Revision: D83863515


