### PR TITLE
Add extension_llm_runner library to executorch-config.cmake

### DIFF
--- a/examples/models/llama/README.md
+++ b/examples/models/llama/README.md
@@ -245,7 +245,6 @@ Note for Mac users: There's a known linking issue with Xcode 15.1. Refer to the 
 2. Build llama runner.
 ```
 cmake -DCMAKE_INSTALL_PREFIX=cmake-out \
-	-DBUILD_TESTING=OFF \
 	-DCMAKE_BUILD_TYPE=Release \
 	-Bcmake-out/examples/models/llama \
 	examples/models/llama

--- a/tools/cmake/executorch-config.cmake
+++ b/tools/cmake/executorch-config.cmake
@@ -68,6 +68,7 @@ set(optional_lib_list
     portable_ops_lib
     custom_ops
     extension_evalue_util
+    extension_llm_runner
     extension_module
     extension_module_static
     extension_runner_util


### PR DESCRIPTION
So that we can find it in `CMAKE_INSTALL_PREFIX`.

