### PR TITLE
Fix precommit hook to extract commit hash from nightly commit title

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -8,7 +8,11 @@ if git diff --cached --name-only | grep -q "^torch_pin.py$"; then
     echo "📝 Updating PyTorch commit pin..."
 
     # Run the update script
-    if python .github/scripts/update_pytorch_pin.py; then
+    hook_output=$(python .github/scripts/update_pytorch_pin.py 2>&1)
+    hook_status=$?
+    echo "$hook_output"
+
+    if [ $hook_status -eq 0 ]; then
         # Check if pytorch.txt was modified
         if ! git diff --quiet .ci/docker/ci_commit_pins/pytorch.txt; then
             echo "✅ PyTorch commit pin updated successfully"
@@ -19,9 +23,14 @@ if git diff --cached --name-only | grep -q "^torch_pin.py$"; then
             echo "ℹ️  PyTorch commit pin unchanged"
         fi
     else
-        echo "❌ Failed to update PyTorch commit pin"
-        echo "Please run: python .github/scripts/update_pytorch_pin.py"
-        exit 1
+        if echo "$hook_output" | grep -qi "rate limit exceeded"; then
+            echo "⚠️  PyTorch commit pin not updated due to GitHub API rate limiting."
+            echo "   Please manually update .ci/docker/ci_commit_pins/pytorch.txt if needed."
+        else
+            echo "❌ Failed to update PyTorch commit pin"
+            echo "Please run: python .github/scripts/update_pytorch_pin.py"
+            exit 1
+        fi
     fi
 fi
 

--- a/.github/scripts/update_pytorch_pin.py
+++ b/.github/scripts/update_pytorch_pin.py
@@ -4,7 +4,6 @@ import json
 import re
 import sys
 import urllib.request
-from datetime import datetime
 
 
 def parse_nightly_version(nightly_version):
@@ -75,11 +74,18 @@ def get_commit_hash_for_nightly(date_str):
         # Check if the first line of commit message matches
         first_line = commit_msg.split("\n")[0].strip()
         if first_line == target_title or first_line.startswith(f"{date_str} nightly"):
-            return commit["sha"]
+            return extract_hash_from_title(first_line)
 
     raise ValueError(
         f"Could not find commit with title matching '{target_title}' in nightly branch"
     )
+
+
+def extract_hash_from_title(title):
+    match = re.search(r"\(([0-9a-fA-F]{7,40})\)", title)
+    if not match:
+        raise ValueError(f"Could not extract commit hash from title '{title}'")
+    return match.group(1)
 
 
 def update_pytorch_pin(commit_hash):

--- a/.github/scripts/update_pytorch_pin.py
+++ b/.github/scripts/update_pytorch_pin.py
@@ -52,7 +52,7 @@ def get_commit_hash_for_nightly(date_str):
         Commit hash string
     """
     api_url = "https://api.github.com/repos/pytorch/pytorch/commits"
-    params = f"?sha=nightly&per_page=100"
+    params = f"?sha=nightly&per_page=50"
     url = api_url + params
 
     req = urllib.request.Request(url)
@@ -73,7 +73,7 @@ def get_commit_hash_for_nightly(date_str):
         commit_msg = commit.get("commit", {}).get("message", "")
         # Check if the first line of commit message matches
         first_line = commit_msg.split("\n")[0].strip()
-        if first_line == target_title or first_line.startswith(f"{date_str} nightly"):
+        if first_line.startswith(f"{date_str} nightly"):
             return extract_hash_from_title(first_line)
 
     raise ValueError(


### PR DESCRIPTION
Instead of using the nightly commit hash

As titled.

