### PR TITLE
Reduce log noise

### DIFF
--- a/extension/named_data_map/merged_data_map.cpp
+++ b/extension/named_data_map/merged_data_map.cpp
@@ -59,12 +59,10 @@ namespace ET_MERGED_DATA_MAP_NAMESPACE {
 ET_NODISCARD Result<const TensorLayout> MergedDataMap::get_tensor_layout(
     string_view key) const {
   const auto it = key_to_map_index_.find(key.data());
-  ET_CHECK_OR_RETURN_ERROR(
-      it != key_to_map_index_.end(),
-      NotFound,
-      "Key %s not found in named data maps",
-      key.data());
-
+  if (it == key_to_map_index_.end()) {
+    ET_LOG(Debug, "Key %s not found in named data maps.", key.data());
+    return Error::NotFound;
+  }
   return named_data_maps_.at(it->second)->get_tensor_layout(key);
 }
 


### PR DESCRIPTION
Usually this is combined with another data map, and the `NotFound` is not an error. Making it a debug log.

e.g seeing logs like this:

```
E 00:00:06.073735 executorch:merged_data_map.cpp:74] Key 537ca242d86c910ebd95cd37a7dcad7f3ab83a5f98c9dea2b9aa37e22791462d not found in named data maps
E 00:00:06.108011 executorch:merged_data_map.cpp:74] Key 2c7ee820b43b1ba6fa25e689481224853b62082fb6e39926097d1aa3c8f064ad not found in named data maps
E 00:00:06.108094 executorch:merged_data_map.cpp:74] Key 02734750baa46cc2ffa7bfaa4e21d1504f4f6de2966be9106a15614384687163 not found in named data maps
E 00:00:06.108245 executorch:merged_data_map.cpp:74] Key e4e8398664617f6e50439c7f7f775bc5a88675dbc14092eb79d0d077c7e2af1e not found in named data maps
E 00:00:06.243662 executorch:merged_data_map.cpp:74] Key c5efb5589c3685c5b2d130fcd5ad1ef80a9914b24319695d440558c6f00e091f not found in named data maps
E 00:00:06.243909 executorch:merged_data_map.cpp:74] Key e54e83719155dbe8a54b21f981e07173c9ebb6979e2666d73c25789279faea61 not found in named data maps
E 00:00:06.309820 executorch:merged_data_map.cpp:74] Key c54d4180cfe222db1671f533c988ecc8fe0aed0c9b6b76e0a955ed20ef840b8e not found in named data maps
E 00:00:06.311046 executorch:merged_data_map.cpp:74] Key c7db292d5b0c06ecc05778fbf7844794825945b457f27b388c30dd10683aa46e not found in named data maps
E 00:00:06.313533 executorch:merged_data_map.cpp:74] Key 5baeac61a83d17e6d1a9f366441de869323cdffc6d9c2706a8e7debf97f5e5e0 not found in named data maps
E 00:00:06.313617 executorch:merged_data_map.cpp:74] Key 0f2c6e4f38d5896883f9f78d9bc3d302c45c4de10dad90f6a812674ef9eb8c3c not found in named data maps
E 00:00:06.313682 executorch:merged_data_map.cpp:74] Key 113ec195bb508aabfeddb085c650355a3f38c001c1283e3bb2a49218e0d72649 not found in named data maps
E 00:00:06.313718 executorch:merged_data_map.cpp:74] Key 25bd797342fa9c2b6596a54442f19b7104e52e8365734f349b19380168a7322d not found in named data maps
E 00:00:06.337360 executorch:merged_data_map.cpp:74] Key 5ccd23b17c19c6b68863bc29d2d8cbc144150b4bfea5ec40ef003d70bc24f99f not found in named data maps
E 00:00:06.337446 executorch:merged_data_map.cpp:74] Key e07f63db3a921001de2138151dca82c0d44cbf415010ce586f19cbfe879313a5 not found in named data maps
E 00:00:06.381035 executorch:merged_data_map.cpp:74] Key b5a51f8d7182166eef839c3b7e50925dce4b2884d600851f3111ae36e792139e not found in named data maps
E 00:00:06.412047 executorch:merged_data_map.cpp:74] Key 7fb59d1866755d0039a26c6ac13401e0ac9bcbd0ad3257f4d1666676a30921d9 not found in named data maps
E 00:00:06.412139 executorch:merged_data_map.cpp:74] Key 6ac27c95d6622fd7f5728c32382564c1d584a72b788f989dcc1fab781fa8516e not found in named data maps
E 00:00:06.412338 executorch:merged_data_map.cpp:74] Key 073079336d970475e2cbbec34c0ebc13812d3c0ed5a2272eb9a8c582a7fe2fb6 not found in named data maps
E 00:00:06.544362 executorch:merged_data_map.cpp:74] Key 265dd831d9a0d6a488b0868db842e93f4b0fbc439d0ced4e6d39b70bf5ff2bd8 not found in named data maps
E 00:00:06.544612 executorch:merged_data_map.cpp:74] Key 32cc7db65b168913a369a09d9b6236e1d116e444ab507582d6721b12f7f7cbc2 not found in named data maps
I 00:00:07.869628 executorch:text_llm_runner.cpp:89] Doing a warmup run...
```
except it runs well.
