### PR TITLE
Use torch 2.9 release packages

### DIFF
--- a/.ci/docker/common/install_pytorch.sh
+++ b/.ci/docker/common/install_pytorch.sh
@@ -12,11 +12,11 @@ source "$(dirname "${BASH_SOURCE[0]}")/utils.sh"
 
 install_domains() {
   echo "Install torchvision and torchaudio"
-  pip install torchvision==0.24.0 torchaudio==2.9.0
+  pip install torchvision==0.24.0 torchaudio==2.9.0 --index-url https://download.pytorch.org/whl/cpu
 }
 
 install_pytorch_and_domains() {
-  pip_install torch==2.9.0 torchvision==0.24.0 torchaudio==2.9.0 torchao==0.14.0
+  pip_install torch==2.9.0 torchvision==0.24.0 torchaudio==2.9.0 torchao==0.14.0 --index-url https://download.pytorch.org/whl/cpu
 }
 
 install_pytorch_and_domains

--- a/.ci/docker/common/install_pytorch.sh
+++ b/.ci/docker/common/install_pytorch.sh
@@ -12,12 +12,11 @@ source "$(dirname "${BASH_SOURCE[0]}")/utils.sh"
 
 install_domains() {
   echo "Install torchvision and torchaudio"
-  pip_install --no-use-pep517 --user "git+https://github.com/pytorch/audio.git@${TORCHAUDIO_VERSION}"
-  pip_install --no-use-pep517 --user "git+https://github.com/pytorch/vision.git@${TORCHVISION_VERSION}"
+  pip install torchvision==0.24.0 torchaudio==2.9.0
 }
 
 install_pytorch_and_domains() {
-  pip_install torch==2.9.0 torchvision torchaudio torchao==0.14.0 --index-url https://download.pytorch.org/whl/test/cpu
+  pip_install torch==2.9.0 torchvision=0.24.0 torchaudio=2.9.0 torchao==0.14.0
 }
 
 install_pytorch_and_domains

--- a/.ci/docker/common/install_pytorch.sh
+++ b/.ci/docker/common/install_pytorch.sh
@@ -16,7 +16,7 @@ install_domains() {
 }
 
 install_pytorch_and_domains() {
-  pip_install torch==2.9.0 torchvision=0.24.0 torchaudio=2.9.0 torchao==0.14.0
+  pip_install torch==2.9.0 torchvision==0.24.0 torchaudio==2.9.0 torchao==0.14.0
 }
 
 install_pytorch_and_domains

--- a/.ci/scripts/setup-linux.sh
+++ b/.ci/scripts/setup-linux.sh
@@ -17,9 +17,9 @@ echo "Build tool: $BUILD_TOOL, Mode: $BUILD_MODE"
 # have already been installed, so we use PyTorch build from source here instead
 # of nightly. This allows CI to test against latest commits from PyTorch
 if [[ "${EDITABLE:-false}" == "true" ]]; then
-  install_executorch --use-pt-pinned-commit --editable
+  install_executorch --editable
 else
-  install_executorch --use-pt-pinned-commit
+  install_executorch
 fi
 build_executorch_runner "${BUILD_TOOL}" "${BUILD_MODE}"
 
@@ -27,8 +27,4 @@ build_executorch_runner "${BUILD_TOOL}" "${BUILD_MODE}"
 # Tracking in https://github.com/pytorch/executorch/issues/14679.
 if [ "$(uname -m)" == "aarch64" ]; then
   conda install -y -c conda-forge libstdcxx-ng
-fi
-
-if [[ "${GITHUB_BASE_REF:-}" == *main* || "${GITHUB_BASE_REF:-}" == *gh* ]]; then
-  do_not_use_nightly_on_ci
 fi

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -147,25 +147,6 @@ def install_requirements(use_pytorch_nightly):
 
 
 def install_optional_example_requirements(use_pytorch_nightly):
-    print("Installing torch domain libraries")
-    DOMAIN_LIBRARIES = [
-        ("torchvision==0.24.0" if use_pytorch_nightly else "torchvision"),
-        "torchaudio==2.9.0" if use_pytorch_nightly else "torchaudio",
-    ]
-    # Then install domain libraries
-    subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "pip",
-            "install",
-            *DOMAIN_LIBRARIES,
-            "--extra-index-url",
-            TORCH_URL,
-        ],
-        check=True,
-    )
-
     print("Installing packages in requirements-examples.txt")
     subprocess.run(
         [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ dependencies=[
   "hydra-core>=1.3.0",
   "omegaconf>=2.3.0",
   "torchao==0.14.0",
+  "torch>=2.9.0,<2.10.0",
 ]
 
 [project.urls]

--- a/requirements-examples.txt
+++ b/requirements-examples.txt
@@ -5,3 +5,5 @@ timm == 1.0.7
 torchsr == 1.0.4
 torchtune >= 0.6.1
 transformers == 4.53.1
+torchaudio == 2.9.0
+torchvision == 0.24.0


### PR DESCRIPTION
### Summary
Use release 2.9 packages for pytorch and domain libraries in preparation for the final 1.0 release. I'm following the pattern from https://github.com/pytorch/executorch/pull/13248.