### PR TITLE
Removing one shift op from quantized linear shader to improve perf.

### DIFF
--- a/backends/vulkan/runtime/graph/ops/glsl/linear_qcsnw_tiled.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/linear_qcsnw_tiled.glsl
@@ -114,7 +114,7 @@ void main() {
             const uvec4 packed_weight_tex = texelFetch(
               t_weight, u16vec2(weight_txcol + ${c}, pos + r), 0);
 
-          qmat2[${c}] = (VEC4_T((packed_weight_tex & 0xF0) >> 4) - 8.0);
+          qmat2[${c}] = (VEC4_T(packed_weight_tex >> 4) - 8.0);
           qmat2[${c + 1}] = (VEC4_T(packed_weight_tex & 0x0F) - 8.0);
       $else:
         $for c in range(TILE_TXCOLS):


### PR DESCRIPTION
Summary: This diff removes a redundant mask op from 4 bit quantized linear shader to improve performance.

Reviewed By: SS-JIA

Differential Revision: D84679388


