### PR TITLE
Update usages of DataLoader::SegmentInfo::Type::External

### DIFF
--- a/extension/flat_tensor/flat_tensor_data_map.cpp
+++ b/extension/flat_tensor/flat_tensor_data_map.cpp
@@ -135,7 +135,7 @@ ET_NODISCARD Result<FreeableBuffer> FlatTensorDataMap::get_data(
   return loader_->load(
       /*offset=*/header_.segment_base_offset + segment_offset,
       segment_size,
-      DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::External));
+      DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Constant));
 }
 
 ET_NODISCARD Error FlatTensorDataMap::load_data_into(
@@ -201,7 +201,7 @@ ET_NODISCARD Result<const char*> FlatTensorDataMap::get_key(
   Result<FreeableBuffer> header = loader->load(
       /*offset=*/0,
       FlatTensorHeader::kNumHeadBytes,
-      DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::External));
+      DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program));
   if (!header.ok()) {
     ET_LOG(Error, "Failed to load header.");
     return header.error();
@@ -228,7 +228,7 @@ ET_NODISCARD Result<const char*> FlatTensorDataMap::get_key(
   Result<FreeableBuffer> flat_tensor_data = loader->load(
       /*offset=*/0,
       fh->flatbuffer_offset + fh->flatbuffer_size,
-      DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::External));
+      DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program));
   if (!flat_tensor_data.ok()) {
     ET_LOG(Error, "Failed to load flat_tensor data.");
     return flat_tensor_data.error();

--- a/extension/flat_tensor/test/flat_tensor_data_map_test.cpp
+++ b/extension/flat_tensor/test/flat_tensor_data_map_test.cpp
@@ -173,7 +173,7 @@ TEST_F(FlatTensorDataMapTest, LoadAndCheckSize) {
   Result<FreeableBuffer> truncated_file = data_map_loader_->load(
       0,
       trunc_size,
-      DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::External));
+      DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Constant));
   ASSERT_EQ(truncated_file.error(), Error::Ok);
 
   BufferDataLoader truncated_loader =

--- a/extension/training/module/test/state_dict_util_test.cpp
+++ b/extension/training/module/test/state_dict_util_test.cpp
@@ -44,7 +44,7 @@ class LoadStateDictTest : public ::testing::Test {
         /*offset=*/0,
         FlatTensorHeader::kNumHeadBytes,
         /*segment_info=*/
-        DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::External));
+        DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program));
 
     ASSERT_EQ(header.error(), Error::Ok);
 

--- a/runtime/executor/pte_data_map.cpp
+++ b/runtime/executor/pte_data_map.cpp
@@ -57,7 +57,7 @@ Result<FreeableBuffer> PteDataMap::get_data(
       return loader_->load(
           /*offset=*/segment_base_offset_ + segment_offset,
           segment_size,
-          DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::External));
+          DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Constant));
     }
   }
   return Error::NotFound;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #15195

Update usages of `SegmentInfo::Type::External` to reflect the same segments that PTE uses, instead of using `External` for any part of the PTD . Specifically:

1. Program: PTD header and flatbuffer portion
2. Constant: when loading items using the `get_data` API
3. Mutable: when loading items using the `load_data_into` API

Differential Revision: [D83671426](https://our.internmc.facebook.com/intern/diff/D83671426/)