### PR TITLE
Don't assign ANDROID_HOME if set already

### DIFF
--- a/scripts/build_android_library.sh
+++ b/scripts/build_android_library.sh
@@ -82,9 +82,9 @@ build_aar() {
     find cmake-out-android-so -type f -name "*.so" -exec "$ANDROID_NDK"/toolchains/llvm/prebuilt/*/bin/llvm-strip {} \;
   fi
   pushd extension/android/
-  ANDROID_HOME="${ANDROID_SDK:-/opt/android/sdk}" ./gradlew build
+  ANDROID_HOME="${ANDROID_HOME:-${ANDROID_SDK:-/opt/android/sdk}}"
   # Use java unit test as sanity check
-  ANDROID_HOME="${ANDROID_SDK:-/opt/android/sdk}" ./gradlew :executorch_android:testDebugUnitTest
+  ANDROID_HOME="${ANDROID_HOME:-${ANDROID_SDK:-/opt/android/sdk}}" ./gradlew :executorch_android:testDebugUnitTest
   popd
   if [ ! -z $BUILD_AAR_DIR ]; then
     cp extension/android/executorch_android/build/outputs/aar/executorch_android-debug.aar "${BUILD_AAR_DIR}/executorch.aar"


### PR DESCRIPTION
based on https://github.com/pytorch/executorch/blob/4bf7e12cce28c2a9695bb34a0028f3cf25c9b829/docs/source/using-executorch-android.md users might set up ANDROID_HOME by themselves. However the current script doesn't use that. Fix the script and have it users the one user specified
