### PR TITLE
Cadence ops: Add in singleton tensor default variants

### DIFF
--- a/backends/cadence/aot/ops_registrations.py
+++ b/backends/cadence/aot/ops_registrations.py
@@ -53,16 +53,10 @@ def _validate_ref_impl_exists() -> None:
     # 1. be removed
     # 2. have a reference implementation added to ref_implementations.py
     _WARN_ONLY = {
-        "cadence::quantized_add",  # We should only support per_tensor variant, should remove
         "cadence::_softmax_f32_f32",
-        "cadence::requantize",  # We should only support per_tensor variant, should remove
         "cadence::quantized_softmax.per_tensor",
-        "cadence::quantized_conv2d_nchw",  # We should only support per_tensor variant, should remove
-        "cadence::quantized_relu",  # We should only support per_tensor variant, should remove
-        "cadence::quantized_conv2d_nhwc",  # We should only support per_tensor variant, should remove
         "cadence::quantized_softmax",
         "cadence::quantized_w8a32_gru",
-        "cadence::quantized_layer_norm",  # We should only support per_tensor variant, should remove
     }
 
     ref_impls = get_registered_ref_implementations()


### PR DESCRIPTION
Summary:
- Cleaned up decorator so we don't need to keep asserting that outs are tensors
- Added default variants which just call per_tensor_variants.
- Test which just ensures that they all run

Differential Revision: D84842582
