### PR TITLE
Add fpu embedded target to EthosUBackend

### DIFF
--- a/backends/arm/runtime/targets.bzl
+++ b/backends/arm/runtime/targets.bzl
@@ -14,7 +14,7 @@ def define_common_targets():
         name = "arm_backend",
         srcs = ["EthosUBackend.cpp"],
         headers = [],
-        compatible_with = ["ovr_config//cpu:arm32-embedded"],
+        compatible_with = ["ovr_config//cpu:arm32-embedded", "ovr_config//cpu:arm32-embedded-fpu"],
         # arm_executor_runner.cpp needs to compile with executor as whole
         # @lint-ignore BUCKLINT: Avoid `link_whole=True` (https://fburl.com/avoid-link-whole)
         link_whole = True,

--- a/kernels/quantized/targets.bzl
+++ b/kernels/quantized/targets.bzl
@@ -96,41 +96,46 @@ def define_common_targets():
             ],
         )
 
-        executorch_generated_lib(
-            name = "generated_lib" + aten_suffix,
-            deps = [
-                ":quantized_operators" + aten_suffix,
-                ":all_quantized_ops",
-            ],
-            custom_ops_yaml_target = ":quantized.yaml",
-            custom_ops_aten_kernel_deps = [":quantized_operators_aten"] if aten_mode else [],
-            custom_ops_requires_aot_registration = False,
-            aten_mode = aten_mode,
-            visibility = [
-                "//executorch/...",
-                "@EXECUTORCH_CLIENTS",
-            ],
-            define_static_targets = True,
-        )
+        for support_exceptions in [True, False]:
+            exception_suffix = "_no_exceptions" if not support_exceptions else ""
 
-        # On Windows we can only compile these two ops currently, so adding a
-        # separate target for this.
-        executorch_generated_lib(
-            name = "q_dq_ops_generated_lib" + aten_suffix,
-            custom_ops_yaml_target = ":quantized.yaml",
-            kernel_deps = [
-                "//executorch/kernels/quantized/cpu:op_quantize" + aten_suffix,
-                "//executorch/kernels/quantized/cpu:op_dequantize" + aten_suffix,
-            ],
-            aten_mode = aten_mode,
-            deps = [
-                ":q_dq_ops",
-            ],
-            visibility = [
-                "//executorch/...",
-                "@EXECUTORCH_CLIENTS",
-            ],
-        )
+            executorch_generated_lib(
+                name = "generated_lib" + aten_suffix + exception_suffix,
+                deps = [
+                    ":quantized_operators" + aten_suffix,
+                    ":all_quantized_ops",
+                ],
+                custom_ops_yaml_target = ":quantized.yaml",
+                custom_ops_aten_kernel_deps = [":quantized_operators_aten"] if aten_mode else [],
+                custom_ops_requires_aot_registration = False,
+                aten_mode = aten_mode,
+                support_exceptions = support_exceptions,
+                visibility = [
+                    "//executorch/...",
+                    "@EXECUTORCH_CLIENTS",
+                ],
+                define_static_targets = True,
+            )
+
+            # On Windows we can only compile these two ops currently, so adding a
+            # separate target for this.
+            executorch_generated_lib(
+                name = "q_dq_ops_generated_lib" + aten_suffix + exception_suffix,
+                custom_ops_yaml_target = ":quantized.yaml",
+                kernel_deps = [
+                    "//executorch/kernels/quantized/cpu:op_quantize" + aten_suffix,
+                    "//executorch/kernels/quantized/cpu:op_dequantize" + aten_suffix,
+                ],
+                aten_mode = aten_mode,
+                deps = [
+                    ":q_dq_ops",
+                ],
+                support_exceptions = support_exceptions,
+                visibility = [
+                    "//executorch/...",
+                    "@EXECUTORCH_CLIENTS",
+                ],
+            )
 
     runtime.python_library(
         name = "quantized_ops_lib",


### PR DESCRIPTION
Summary: We need to add embedded fpu target as well for EthosUBackend as Arm FVP platform can use that for tests for some models.

Differential Revision: D84284543


