### PR TITLE
Fix incorrect kernel mappings in Cadence HiFi functions.yaml

### DIFF
--- a/backends/cadence/aot/functions_hifi.yaml
+++ b/backends/cadence/aot/functions_hifi.yaml
@@ -306,7 +306,7 @@
   variants: function
   kernels:
     - arg_meta: null
-      kernel_name: impl::HiFi::quantize_per_tensor_asym16s_out
+      kernel_name: impl::HiFi::quantize_per_tensor_asym16u_out
 
 - func: cadence::quantize_per_tensor_asym32s.out(Tensor input, float scale, int zero_point, int quant_min, int quant_max, ScalarType dtype, *, Tensor(a!) out) -> Tensor(a!)
   variants: function
@@ -348,7 +348,7 @@
   variants: function
   kernels:
     - arg_meta: null
-      kernel_name: impl::HiFi::dequantize_per_tensor_asym16s_out
+      kernel_name: impl::HiFi::dequantize_per_tensor_asym32s_out
 
 - func: cadence::quantized_conv2d_nchw.out(Tensor input, Tensor weight, Tensor bias, int[] stride, SymInt[] padding, int[] dilation, int groups, int input_zero_point, Tensor weight_zero_point, Tensor bias_scale, float out_scale, int out_zero_point, Tensor out_multiplier, Tensor out_shift, *, Tensor(a!) out) -> Tensor(a!)
   kernels:


### PR DESCRIPTION
Summary:
Fixed two bugs in fbcode/executorch/backends/cadence/aot/functions_hifi.yaml:
  1. cadence::quantize_per_tensor_asym16u was incorrectly mapped to impl::HiFi::quantize_per_tensor_asym16s_out instead of asym16u_out
  2. cadence::dequantize_per_tensor_asym32s was incorrectly mapped to impl::HiFi::dequantize_per_tensor_asym16s_out instead of asym32s_out

Differential Revision: D84865463


