### PR TITLE
Remove internal executorch dependency on torchao.quantization.subclass

### DIFF
--- a/examples/models/llama/experimental/load_gguf_q4_0.py
+++ b/examples/models/llama/experimental/load_gguf_q4_0.py
@@ -26,7 +26,8 @@ from executorch.extension.gguf_util.converters.llama_converter import (
 from executorch.extension.gguf_util.load_gguf import GGUFWeights, load_file
 from gguf import ReaderTensor
 from gguf.constants import GGMLQuantizationType
-from torchao.quantization.subclass import QuantizedLinearWeightBase
+
+from .subclass import QuantizedLinearWeightBase
 
 FORMAT = "[%(levelname)s %(asctime)s %(filename)s:%(lineno)s] %(message)s"
 logging.basicConfig(level=logging.INFO, format=FORMAT)


### PR DESCRIPTION
Summary:
**Summary:** This is a really old quantization API that we
recently removed in torchao (D84842047). No one should be
calling it anymore. For BC, let's just copy the base class
into executorch for now. We should delete this in the future.

**Test Plan:** CI

Differential Revision: D84921134


