### PR TITLE
examples/qwen3: match config with optimum flow

### DIFF
--- a/examples/models/qwen3/config/qwen3_xnnpack_q8da4w.yaml
+++ b/examples/models/qwen3/config/qwen3_xnnpack_q8da4w.yaml
@@ -8,6 +8,11 @@ model:
 
 quantization:
   qmode: 8da4w
+  embedding_quantize: 8,0
+
+export:
+  max_seq_length: 2048
+  max_context_length: 2048
 
 backend:
   xnnpack:


### PR DESCRIPTION
Sanity checked both flows on 1.0-rc3 and S24
