### PR TITLE
Enable int16 for op permute

### DIFF
--- a/backends/arm/operators/op_permute.py
+++ b/backends/arm/operators/op_permute.py
@@ -117,7 +117,7 @@ class PermuteVisitor(NodeVisitor):
         validate_valid_dtype(
             self.target,
             [inputs[0], output],
-            [ts.DType.INT8, ts.DType.INT32, ts.DType.FP32],
+            [ts.DType.INT8, ts.DType.INT16, ts.DType.INT32, ts.DType.FP32],
             output.tosa_spec,
         )
 

--- a/backends/arm/test/targets.bzl
+++ b/backends/arm/test/targets.bzl
@@ -20,6 +20,7 @@ def define_arm_tests():
         "ops/test_cat.py",
         "ops/test_linear.py", 
         "ops/test_mul.py",
+        "ops/test_permute.py",
         "ops/test_slice.py",
         "ops/test_sigmoid.py",
         "ops/test_sub.py",


### PR DESCRIPTION
Summary: Enable int16 for op permute

Reviewed By: Ninja91

Differential Revision: D84948536


