### PR TITLE
Use runtime::FunctionRef in threadpool.h itself

### DIFF
--- a/extension/threadpool/threadpool.cpp
+++ b/extension/threadpool/threadpool.cpp
@@ -76,7 +76,7 @@ bool ThreadPool::_unsafe_reset_threadpool(uint32_t new_thread_count) {
 }
 
 void ThreadPool::run(
-    const std::function<void(size_t)>& fn,
+    runtime::FunctionRef<void(size_t)> fn,
     const size_t range) {
   // Run on same thread if NoThreadPoolGuard guard is enabled
   if (NoThreadPoolGuard::is_enabled()) {

--- a/extension/threadpool/threadpool.h
+++ b/extension/threadpool/threadpool.h
@@ -14,6 +14,8 @@
 
 #include <pthreadpool.h>
 
+#include <executorch/runtime/core/function_ref.h>
+
 /*
  * Threadpool Options:
  *
@@ -74,7 +76,7 @@ class ThreadPool final {
    * multiple threads with the scope of the guard When NoThreadPoolGuard is not
    * used all calls to run method are serialized.
    */
-  void run(const std::function<void(size_t)>& fn, size_t range);
+  void run(runtime::FunctionRef<void(size_t)> fn, size_t range);
 
  private:
   friend pthreadpool_t get_pthreadpool();


### PR DESCRIPTION
I previously added runtime::FunctionRef and used it in parallel_for to save code size, but didn't carry that through to the Threadpool wrapper. Profiling showed that we were doing heap allocations on each parallel_for invocation, so let's fix that.