### PR TITLE
NXP backend: Improve `view_copy` delegation

### DIFF
--- a/backends/nxp/backend/ir/converter/node_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converter.py
@@ -125,7 +125,9 @@ class NodeConverter(ABC):
         node: Node,
         partition_list: list[Partition],
         custom_delegation_options: CustomDelegationOptions,
-    ):
+        neutron_target_spec: NeutronTargetSpec,
+        parameters_mapping: dict[str, Parameter],
+    ) -> bool:
         """Check if the given `node` supports the assigned partitioning, which is stored  the `partition_list`. Child
             classes can overwrite this method in case they have delegation restrictions based on the context defined by
             the partitioning result.
@@ -133,6 +135,9 @@ class NodeConverter(ABC):
         :param node: torch.Node to check.
         :param partition_list: List of proposed partitions.
         :param custom_delegation_options: Custom user options which affect node delegation.
+        :param neutron_target_spec: NeutronTargetSpec instance.
+        :param parameters_mapping: Dictionary mapping tensor names to their static data.
+        :return: Boolean indicating whether the node supports the current partitioning.
         """
         return True
 

--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/cat_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/cat_converter.py
@@ -156,7 +156,9 @@ class CatConverter(NodeConverter):
         node: Node,
         partition_list: list[Partition],
         custom_delegation_options: CustomDelegationOptions,
-    ):
+        neutron_target_spec: NeutronTargetSpec,
+        parameters_mapping: dict[str, Parameter],
+    ) -> bool:
         # There is a bug in the NeutronConverter, where if none of the input dimensions before the one referenced by
         #  `dim` are `!= 1`, the `Concat` is not delegated.
         # This only happens when the inputs to the `Concat` are model inputs, and not outputs of other

--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/view_copy_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/view_copy_converter.py
@@ -6,12 +6,18 @@
 import numpy as np
 
 from executorch.backends.nxp.backend.edge_helper import (
+    get_non_qdq_users,
     input_tensor,
     output_tensor,
     tensor_rank,
 )
 from executorch.backends.nxp.backend.ir.converter import quantization_utils
 from executorch.backends.nxp.backend.ir.converter.conversion.common import OpsList
+from executorch.backends.nxp.backend.ir.converter.conversion.translator import (
+    apply_permutation_to,
+    create_channels_first_to_channels_last_permutation,
+    create_channels_last_to_channels_first_permutation,
+)
 from executorch.backends.nxp.backend.ir.converter.node_converter import (
     CustomDelegationOptions,
     is_not_qdq_node,
@@ -23,6 +29,12 @@ from executorch.backends.nxp.backend.ir.converter.node_converters.shared.reshape
 from executorch.backends.nxp.backend.ir.tflite_generator.builtin_options import (
     reshape_options,
 )
+from executorch.backends.nxp.backend.neutron_operator_support import (
+    transposition_is_supported_on_neutron,
+)
+from executorch.backends.nxp.backend.neutron_target_spec import NeutronTargetSpec
+from executorch.backends.nxp.backend.node_format import NXP_NODE_FORMAT
+from executorch.exir.dialects._ops import ops as exir_ops
 from torch.fx import Node
 from torch.fx.passes.infra.partitioner import Partition
 from torch.nn import Parameter
@@ -53,6 +65,8 @@ class ViewCopyConverter(NodeConverter):
         node: Node,
         partition_list: list[Partition],
         custom_delegation_options: CustomDelegationOptions,
+        neutron_target_spec: NeutronTargetSpec,
+        parameters_mapping: dict[str, Parameter],
     ):
         view_copy_partitions = [
             partition for partition in partition_list if node in partition.nodes
@@ -65,6 +79,76 @@ class ViewCopyConverter(NodeConverter):
         if len(non_q_dq_partition_nodes) == 1:
             # The `view_copy` cannot be the only node in a partition.
             return False
+
+        input_format = node.args[0].meta[NXP_NODE_FORMAT]
+        output_format = node.meta[NXP_NODE_FORMAT]
+        input_shape = list(node.args[0].meta["val"].shape)
+        output_shape = list(node.meta["val"].shape)
+        to_nchw_perm = create_channels_last_to_channels_first_permutation(
+            len(input_shape), True
+        )
+        to_nhwc_perm = create_channels_first_to_channels_last_permutation(
+            len(output_shape), True
+        )
+        channels_last_input_shape = apply_permutation_to(
+            input_shape,
+            create_channels_first_to_channels_last_permutation(len(input_shape), True),
+        )
+
+        if input_format.is_channels_first() and (not output_format.is_channels_first()):
+            # The `view_copy` removes node format. Conversion will require the addition of a `Transpose` operator.
+            # Make sure the `Transpose` will be supported.
+
+            if not transposition_is_supported_on_neutron(
+                channels_last_input_shape, to_nchw_perm, neutron_target_spec
+            ):
+                # The `Transpose` would have to be removed by the `PermuteFullyConnectedWeightsAfterReshape` pass.
+                # Make sure it will be applied.
+                users = get_non_qdq_users(node)
+                if len(users) != 1 or (linear_node := users[0]).target not in [
+                    exir_ops.edge.aten.addmm.default,
+                    exir_ops.edge.aten.mm.default,
+                ]:
+                    return False
+
+                if linear_node not in view_copy_partitions[0].nodes:
+                    # The `mm` / `addmm` node will not be delegated within this partition.
+                    return False
+
+                # Make sure the specific requirements of the `PermuteFullyConnectedWeightsAfterReshape` are satisfied.
+                weights_index = (
+                    2 if linear_node.target == exir_ops.edge.aten.addmm.default else 1
+                )
+                if not (
+                    input_shape[0] == output_shape[0]  # Preserve batch.
+                    and len(output_shape) == 2
+                    and output_shape[1]
+                    == linear_node.args[weights_index].meta["val"].shape[0]
+                ):
+                    return False
+
+        elif (
+            not input_format.is_channels_first()
+        ) and output_format.is_channels_first():
+            # The `view_copy` introduces node format. Conversion will require the addition of a `Transpose` operator.
+            # Make sure the `Transpose` will be supported.
+            if not transposition_is_supported_on_neutron(
+                output_shape, to_nhwc_perm, neutron_target_spec
+            ):
+                return False
+
+        elif input_format.is_channels_first() and output_format.is_channels_first():
+            # The `view_copy` works with the channels first format, so both tensors will end up being transposed.
+            # Make sure these transpositions are supported.
+            if not (
+                transposition_is_supported_on_neutron(
+                    channels_last_input_shape, to_nchw_perm, neutron_target_spec
+                )
+                and transposition_is_supported_on_neutron(
+                    output_shape, to_nhwc_perm, neutron_target_spec
+                )
+            ):
+                return False
 
         return True
 

--- a/backends/nxp/neutron_partitioner.py
+++ b/backends/nxp/neutron_partitioner.py
@@ -317,11 +317,12 @@ class NeutronPartitioner(Partitioner):
         )
         self.neutron_target_spec = neutron_target_spec
 
-    @staticmethod
     def validate_partitioning_result(
+        self,
         graph: Graph,
         partition_list: list[Partition],
         custom_delegation_options: CustomDelegationOptions,
+        parameters_mapping: dict[str, Parameter],
     ) -> bool:
         all_delegated_nodes = {
             node for partition in partition_list for node in partition.nodes
@@ -334,7 +335,11 @@ class NeutronPartitioner(Partitioner):
                 and node.target in supported_ops
             ):
                 if not supported_ops[node.target].supports_partitioning_result(
-                    node, partition_list, custom_delegation_options
+                    node,
+                    partition_list,
+                    custom_delegation_options,
+                    self.neutron_target_spec,
+                    parameters_mapping,
                 ):
                     # This node is not supported within its partition. Exclude it from delegation in the future.
                     partitioning_valid = False
@@ -379,6 +384,10 @@ class NeutronPartitioner(Partitioner):
         # This format will be used by the `CapabilityBasedPartitioner` to determine which nodes will be delegated.
         NodeFormatInference(exported_program).identify_node_formats()
 
+        parameters_mapping = EdgeProgramToIRConverter.map_inputs_to_parameters(
+            exported_program
+        )
+
         iteration_limit = len(exported_program.graph.nodes)
         for _ in range(iteration_limit):
             # Run the partitioning.
@@ -386,7 +395,10 @@ class NeutronPartitioner(Partitioner):
 
             # Check if the nodes support the partitioning result. Mark the problematic nodes with `NXP_DO_NOT_DELEGATE`.
             partitioning_valid = self.validate_partitioning_result(
-                exported_program.graph, partition_list, self.custom_delegation_options
+                exported_program.graph,
+                partition_list,
+                self.custom_delegation_options,
+                parameters_mapping,
             )
             if partitioning_valid:
                 # The result of the partitioning is fine

--- a/backends/nxp/tests/ir/converter/node_converter/test_view_copy_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_view_copy_converter.py
@@ -1,4 +1,4 @@
-# Copyright 2024 NXP
+# Copyright 2024-2025 NXP
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -12,7 +12,6 @@ import torch
 from executorch.backends.nxp.backend.edge_program_converter import (
     EdgeProgramToIRConverter,
 )
-
 from executorch.backends.nxp.backend.ir.conversion_config import ConversionConfig
 from executorch.backends.nxp.backend.ir.converter.builder.model_builder import (
     ModelBuilder,
@@ -32,9 +31,11 @@ from executorch.backends.nxp.tests.executorch_pipeline import (
 )
 from executorch.backends.nxp.tests.executors import (
     convert_run_compare,
-    ToNCHWPreprocess,
-    ToNHWCPreprocess,
+    graph_contains_any_of_ops,
+    ToChannelFirstPreprocess,
+    ToChannelLastPreprocess,
 )
+from executorch.exir.dialects._ops import ops as exir_ops
 from torch import nn
 from torch.export import ExportedProgram
 
@@ -109,7 +110,35 @@ class ConvLinearViewModule(torch.nn.Module):
         return x
 
 
-def test__channels_first_to_2d(mocker):
+class ConvViewLinearModule(torch.nn.Module):
+    def __init__(self, view_new_shape: list[int], channels: int, bias: bool):
+        super().__init__()
+        self.view_new_shape = view_new_shape
+        self.conv = nn.Conv2d(channels, channels, 1, 1)
+        self.linear = nn.Linear(view_new_shape[1], 8, bias=bias)
+
+    def forward(self, x):
+        x = self.conv(x)
+        x = x.view(self.view_new_shape)
+        x = self.linear(x)
+        return x
+
+
+class ConvViewConvModule(torch.nn.Module):
+    def __init__(self, view_new_shape: list[int], channels: int):
+        super().__init__()
+        self.view_new_shape = view_new_shape
+        self.conv1 = nn.Conv2d(channels, channels, 1, 1)
+        self.conv2 = nn.Conv2d(channels, channels, 1, 1)
+
+    def forward(self, x):
+        x = self.conv1(x)
+        x = x.view(self.view_new_shape)
+        x = self.conv2(x)
+        return x
+
+
+def test__view_copy__channels_first_to_2d(mocker):
     input_shape = (1, 4, 7, 9)
     new_shape = (6, 32)  # Mix up the dimensions for a thorough test.
 
@@ -121,7 +150,7 @@ def test__channels_first_to_2d(mocker):
     converter_spy = mocker.spy(ModelBuilder, "finish")
 
     convert_run_compare(
-        edge_program, input_data, tflite_input_preprocess=ToNHWCPreprocess()
+        edge_program, input_data, tflite_input_preprocess=ToChannelLastPreprocess()
     )
 
     tflite_model = converter_spy.spy_return
@@ -132,7 +161,7 @@ def test__channels_first_to_2d(mocker):
     assert isinstance(ops[2].builtin_options, Reshape)
 
 
-def test__channels_first_to_4d(mocker):
+def test__view_copy__channels_first_to_4d(mocker):
     input_shape = (1, 8, 6, 8)
     new_shape = (7, 4, 2, 5)
 
@@ -146,7 +175,7 @@ def test__channels_first_to_4d(mocker):
     convert_run_compare(
         edge_program,
         input_data,
-        tflite_input_preprocess=ToNHWCPreprocess(),
+        tflite_input_preprocess=ToChannelLastPreprocess(),
         atol=2.0e-7,
         conversion_config=ConversionConfig(
             {"use_neutron_for_format_conversion": False}
@@ -161,7 +190,7 @@ def test__channels_first_to_4d(mocker):
     assert isinstance(ops[2].builtin_options, Reshape)
 
 
-def test__formatless_to_channels_first(mocker):
+def test__view_copy__formatless_to_channels_first(mocker):
     input_shape = (12, 32)
     new_shape = (1, 4, 12, 8)  # Mix up the dimensions for a thorough test.
 
@@ -177,7 +206,7 @@ def test__formatless_to_channels_first(mocker):
     convert_run_compare(
         edge_program,
         input_data,
-        tflite_output_preprocess=ToNCHWPreprocess(),
+        tflite_output_preprocess=ToChannelFirstPreprocess(),
         atol=2.0e-7,
     )
 
@@ -189,7 +218,7 @@ def test__formatless_to_channels_first(mocker):
     assert isinstance(ops[2].builtin_options, Conv2D)
 
 
-def test__formatless_to_formatless(mocker):
+def test__view_copy__formatless_to_formatless(mocker):
     input_shape = (12, 32)
     new_shape = (1, 4, 6, 16)
 
@@ -262,7 +291,213 @@ def test_view_w_conv_linear_quant_conversion(mocker, input_shape, channels_view_
     convert_run_compare(
         edge_program,
         input_data,
-        tflite_input_preprocess=ToNHWCPreprocess(),
+        tflite_input_preprocess=ToChannelLastPreprocess(),
         tfl_model=tflite_flatbuffers_model,
         atol=1.0,
+    )
+
+
+@pytest.mark.parametrize(
+    "bias",
+    [True, False],
+)
+def test__view_copy__context_dependent__channels_first_to_formatless__transpose_fused(
+    bias, mocker
+):
+    input_shape = (1, 2, 3, 4)
+    new_shape = [1, 2 * 3 * 4]
+    module = ConvViewLinearModule(new_shape, 2, bias)
+
+    converter_spy = mocker.spy(EdgeProgramToIRConverter, "convert_program")
+
+    ep = to_quantized_edge_program(
+        module,
+        input_shape,
+        use_neutron_for_format_conversion=False,
+    ).exported_program()
+
+    # Make sure all 3 nodes were delegated
+    assert any(n.name == "executorch_call_delegate" for n in ep.graph.nodes)
+    assert not graph_contains_any_of_ops(
+        ep.graph,
+        [
+            exir_ops.edge.aten.convolution.default,
+            exir_ops.edge.aten.mm.default,
+            exir_ops.edge.aten.addmm.default,
+            exir_ops.edge.aten.view_copy.default,
+        ],
+    )
+
+    input_data = (np.random.random(input_shape).astype(np.float32) * 50).astype(np.int8)
+
+    converted_edge_program = converter_spy.call_args.args[1]
+    neutron_ir_model = converter_spy.spy_return[0]
+    convert_run_compare(
+        converted_edge_program,
+        input_data,
+        tfl_model=neutron_ir_model,
+        tflite_input_preprocess=ToChannelLastPreprocess(),
+    )
+
+
+@pytest.mark.parametrize(
+    "bias",
+    [True, False],
+)
+def test__view_copy__context_dependent__channels_first_to_formatless__transpose_not_fusable(
+    bias,
+):
+    input_shape = (1, 2, 3, 4)
+    new_shape = [
+        2,
+        3 * 4,
+    ]  # The batch size changes, which makes the optimization not applicable.
+    module = ConvViewLinearModule(new_shape, 2, bias)
+
+    ep = to_quantized_edge_program(
+        module,
+        input_shape,
+        use_neutron_for_format_conversion=False,
+    ).exported_program()
+
+    # Make sure the convolution and the linear were delegated, but not the view_copy.
+    assert any(n.name == "executorch_call_delegate" for n in ep.graph.nodes)
+    assert not graph_contains_any_of_ops(
+        ep.graph,
+        [
+            exir_ops.edge.aten.convolution.default,
+            exir_ops.edge.aten.mm.default,
+            exir_ops.edge.aten.addmm.default,
+        ],
+    )
+    assert graph_contains_any_of_ops(
+        ep.graph,
+        [
+            exir_ops.edge.aten.view_copy.default,
+        ],
+    )
+
+
+def test__view_copy__formatless_to_channels_first__transpose_supported(mocker):
+    input_shape = (1, 8 * 3 * 8)
+    new_shape = [1, 8, 3, 8]
+    module = FormatlessToChannelsFirstModule(8, new_shape)
+
+    converter_spy = mocker.spy(EdgeProgramToIRConverter, "convert_program")
+
+    ep = to_quantized_edge_program(
+        module,
+        input_shape,
+        use_neutron_for_format_conversion=False,
+    ).exported_program()
+
+    # Make sure both nodes were delegated
+    assert any(n.name == "executorch_call_delegate" for n in ep.graph.nodes)
+    assert not graph_contains_any_of_ops(
+        ep.graph,
+        [
+            exir_ops.edge.aten.convolution.default,
+            exir_ops.edge.aten.view_copy.default,
+        ],
+    )
+
+    input_data = (np.random.random(input_shape).astype(np.float32) * 50).astype(np.int8)
+
+    converted_edge_program = converter_spy.call_args.args[1]
+    neutron_ir_model = converter_spy.spy_return[0]
+    convert_run_compare(
+        converted_edge_program,
+        input_data,
+        tfl_model=neutron_ir_model,
+        tflite_output_preprocess=ToChannelFirstPreprocess(),
+    )
+
+
+def test__view_copy__formatless_to_channels_first__transpose_not_supported():
+    input_shape = (1, 8 * 3 * 4)
+    new_shape = [1, 8, 3, 4]  # The last dim is not a multiple of num_macs.
+    module = FormatlessToChannelsFirstModule(8, new_shape)
+
+    ep = to_quantized_edge_program(
+        module,
+        input_shape,
+        use_neutron_for_format_conversion=False,
+    ).exported_program()
+
+    # Make sure the view_copy was not delegated.
+    assert any(n.name == "executorch_call_delegate" for n in ep.graph.nodes)
+    assert not graph_contains_any_of_ops(
+        ep.graph,
+        [
+            exir_ops.edge.aten.convolution.default,
+        ],
+    )
+    assert graph_contains_any_of_ops(
+        ep.graph,
+        [
+            exir_ops.edge.aten.view_copy.default,
+        ],
+    )
+
+
+def test__view_copy__channels_first_to_channels_first__transpose_supported(mocker):
+    input_shape = (1, 8, 3, 8)
+    new_shape = [1, 8, 1, 24]
+    module = ConvViewConvModule(new_shape, 8)
+
+    converter_spy = mocker.spy(EdgeProgramToIRConverter, "convert_program")
+
+    ep = to_quantized_edge_program(
+        module,
+        input_shape,
+        use_neutron_for_format_conversion=False,
+    ).exported_program()
+
+    # Make sure all nodes were delegated
+    assert any(n.name == "executorch_call_delegate" for n in ep.graph.nodes)
+    assert not graph_contains_any_of_ops(
+        ep.graph,
+        [
+            exir_ops.edge.aten.convolution.default,
+            exir_ops.edge.aten.view_copy.default,
+        ],
+    )
+
+    input_data = (np.random.random(input_shape).astype(np.float32) * 50).astype(np.int8)
+
+    converted_edge_program = converter_spy.call_args.args[1]
+    neutron_ir_model = converter_spy.spy_return[0]
+    convert_run_compare(
+        converted_edge_program,
+        input_data,
+        tfl_model=neutron_ir_model,
+        tflite_input_preprocess=ToChannelLastPreprocess(),
+        tflite_output_preprocess=ToChannelFirstPreprocess(),
+    )
+
+
+def test__view_copy__channels_first_to_channels_first__transpose_not_supported():
+    input_shape = (1, 8, 3, 5)  # The last dimension is not a multiple of num_macs.
+    new_shape = [1, 8, 1, 15]
+    module = ConvViewConvModule(new_shape, 8)
+
+    ep = to_quantized_edge_program(
+        module,
+        input_shape,
+        use_neutron_for_format_conversion=False,
+    ).exported_program()
+
+    # Make sure the view_copy was NOT delegated
+    assert any(n.name == "executorch_call_delegate" for n in ep.graph.nodes)
+    assert not graph_contains_any_of_ops(
+        ep.graph,
+        [
+            exir_ops.edge.aten.convolution.default,
+        ],
+    )
+    assert graph_contains_any_of_ops(
+        ep.graph,
+        [
+            exir_ops.edge.aten.view_copy.default,
+        ],
     )


### PR DESCRIPTION
### Summary
The conversion of `aten.view_copy` to NeutronIR may require the insertion of extra `Transpose` operations, which may not be supported. This PR makes sure the `view_copy` is only delegated if the extra operations are supported too.

### Test plan
Unit tests provided.


cc @robert-kalmar