### PR TITLE
Fix the llm module e2e test

### DIFF
--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmModule.java
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmModule.java
@@ -182,8 +182,10 @@ public class LlmModule {
       LlmCallback llmCallback,
       boolean echo) {
     prefillPrompt(prompt);
-    prefillImages(image, width, height, channels);
-    return generate("", llmCallback, echo);
+    if (image != null) {
+      prefillImages(image, width, height, channels);
+    }
+    return generate(prompt, seqLen, llmCallback, echo);
   }
 
   /**


### PR DESCRIPTION
The generate API for llm has two issues.
- The input image could be null, but prefillImages assume non-null, this cause prefillImages return Error::EndOfMethod, this can be fixed by adding a null check on the java layer
- The generate didn't pass prompt which caused stack overflow



Test plan
Run all e2e test on the local emulator and run via CI 