### PR TITLE
Runner logs

### DIFF
--- a/extension/llm/runner/text_llm_runner.cpp
+++ b/extension/llm/runner/text_llm_runner.cpp
@@ -169,6 +169,11 @@ Error TextLLMRunner::generate(
   stats_->first_token_ms = time_in_ms();
   stats_->prompt_eval_end_ms = time_in_ms();
 
+  RUNNER_ET_LOG(
+      config.warming,
+      "RSS after prompt prefill: %f MiB (0 if unsupported)",
+      get_rss_bytes() / 1024.0 / 1024.0);
+
   // print the first token from prefill. No prev_token so use cur_token for it.
   auto decode_result = tokenizer_->decode(cur_token, cur_token);
   if (!decode_result.ok()) {
@@ -179,10 +184,6 @@ Error TextLLMRunner::generate(
     return ::executorch::runtime::Error::InvalidArgument;
   }
   wrapped_callback(std::move(*decode_result));
-  RUNNER_ET_LOG(
-      config.warming,
-      "RSS after prompt prefill: %f MiB (0 if unsupported)",
-      get_rss_bytes() / 1024.0 / 1024.0);
 
   // start the main loop
   prompt_tokens.push_back(cur_token);

--- a/extension/llm/runner/text_token_generator.h
+++ b/extension/llm/runner/text_token_generator.h
@@ -128,9 +128,13 @@ class ET_EXPERIMENTAL TextTokenGenerator {
       if (eos_ids_->find(cur_token) != eos_ids_->end()) {
         printf("\n");
         ET_LOG(Info, "\nReached to the end of generation");
-        break;
+        return pos - start_pos;
       }
     }
+    ET_LOG(
+        Info,
+        "\nFinished generation. Generated %" PRIi32 " tokens.",
+        start_pos + max_new_tokens);
     return pos - start_pos;
   }
 


### PR DESCRIPTION
### Summary
Move some runner logs around.
1. Move the stats so it doesn't interfere with generation
2. Add a different message to end of generation to indicate we cut off because tokens, not because of eos

### Test plan
lora demo
