### PR TITLE
Expose convert_dtype_pass

### DIFF
--- a/backends/transforms/targets.bzl
+++ b/backends/transforms/targets.bzl
@@ -182,6 +182,7 @@ def define_common_targets():
         ],
         visibility = [
             "//executorch/backends/...",
+            "@EXECUTORCH_CLIENTS",
         ],
         deps = [
             "//caffe2:torch",


### PR DESCRIPTION
Summary: Add support for Vulkan lowering along with HTP. This ensures that we use the same optimizations for all backends.

Differential Revision: D85087953




cc @SS-JIA @manuelcandales @digantdesai @cbilgin