### PR TITLE
Arm backend: Remove `# type: ignore` from tosa_serializer import

### DIFF
--- a/backends/arm/common/debug.py
+++ b/backends/arm/common/debug.py
@@ -7,7 +7,7 @@ import logging
 import os
 from typing import Optional
 
-import serializer.tosa_serializer as ts  # type: ignore
+import serializer.tosa_serializer as ts
 import torch
 from executorch.exir.print_program import inspect_node
 

--- a/backends/arm/debug/schema.py
+++ b/backends/arm/debug/schema.py
@@ -10,7 +10,7 @@ import json
 from dataclasses import asdict, dataclass
 from typing import Any, Optional
 
-import serializer.tosa_serializer as ts  # type: ignore
+import serializer.tosa_serializer as ts
 import torch
 
 from executorch.backends.arm.common.arm_compile_spec import ArmCompileSpec

--- a/backends/arm/operators/op_abs.py
+++ b/backends/arm/operators/op_abs.py
@@ -6,6 +6,8 @@
 # pyre-unsafe
 from typing import Any, List
 
+import serializer.tosa_serializer as ts
+
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
     register_node_visitor,
@@ -36,9 +38,6 @@ class AbsVisitor(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-
-        import serializer.tosa_serializer as ts  # type: ignore
-
         validate_num_inputs(self.target, inputs, 1)
         validate_same_dtype(self.target, [*inputs, output], ts)
 

--- a/backends/arm/operators/op_add.py
+++ b/backends/arm/operators/op_add.py
@@ -9,6 +9,7 @@ from typing import Any, List
 
 import executorch.backends.arm.tosa.quant_utils as tqutils
 import executorch.backends.arm.tosa.utils as tutils
+import serializer.tosa_serializer as ts
 
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
@@ -42,9 +43,6 @@ class AddVisitor_INT(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-
-        import serializer.tosa_serializer as ts  # type: ignore
-
         validate_num_inputs(self.target, inputs, 2)
         validate_same_dtype(self.target, [*inputs, output], ts)
         valid_dtypes = []
@@ -132,9 +130,6 @@ class AddVisitor_FP(AddVisitor_INT):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-
-        import serializer.tosa_serializer as ts  # type: ignore
-
         validate_num_inputs(self.target, inputs, 2)
         validate_same_dtype(self.target, [*inputs, output], ts)
 

--- a/backends/arm/operators/op_amax.py
+++ b/backends/arm/operators/op_amax.py
@@ -4,6 +4,8 @@
 # LICENSE file in the root directory of this source tree.
 from typing import Any, List
 
+import serializer.tosa_serializer as ts
+
 from executorch.backends.arm._passes.arm_pass_utils import get_first_fake_tensor
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
@@ -34,8 +36,6 @@ class MaxVisitor(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-        import serializer.tosa_serializer as ts
-
         validate_num_inputs(self.target, inputs, 3)
         validate_same_dtype(self.target, [inputs[0], output], ts)
         validate_valid_dtype(

--- a/backends/arm/operators/op_amin.py
+++ b/backends/arm/operators/op_amin.py
@@ -4,6 +4,8 @@
 # LICENSE file in the root directory of this source tree.
 from typing import Any, List
 
+import serializer.tosa_serializer as ts
+
 from executorch.backends.arm._passes.arm_pass_utils import get_first_fake_tensor
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
@@ -34,8 +36,6 @@ class MinVisitor(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-        import serializer.tosa_serializer as ts
-
         validate_num_inputs(self.target, inputs, 3)
         validate_same_dtype(self.target, [inputs[0], output], ts)
         validate_valid_dtype(

--- a/backends/arm/operators/op_any.py
+++ b/backends/arm/operators/op_any.py
@@ -6,6 +6,8 @@
 # pyre-unsafe
 from typing import Any, cast, List
 
+import serializer.tosa_serializer as ts
+
 from executorch.backends.arm.operators.node_visitor import (  # type: ignore
     NodeVisitor,
     register_node_visitor,
@@ -33,8 +35,6 @@ class AnyVisitor(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-        import serializer.tosa_serializer as ts
-
         validate_num_inputs(self.target, inputs, 3)
         validate_same_dtype(self.target, [inputs[0], output], ts)
         validate_valid_dtype(

--- a/backends/arm/operators/op_avg_pool2d.py
+++ b/backends/arm/operators/op_avg_pool2d.py
@@ -6,6 +6,8 @@
 # pyre-unsafe
 from typing import Any, List
 
+import serializer.tosa_serializer as ts
+
 import torch
 
 from executorch.backends.arm._passes.fold_qdq_with_annotated_qparams_pass import (
@@ -47,8 +49,6 @@ class AvgPool2dVisitor(NodeVisitor):
         output_zp: int,
         accumulator_type: Any,
     ) -> None:
-
-        import serializer.tosa_serializer as ts  # type: ignore
 
         input_tensor = inputs[0]
         kernel_size_list = inputs[1].special
@@ -116,8 +116,6 @@ class AvgPool2dVisitor(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-        import serializer.tosa_serializer as ts  # type: ignore
-
         validate_num_inputs(self.target, inputs, [3, 4, 5, 6, 7])
         validate_same_dtype(self.target, [inputs[0], output], ts)
         validate_valid_dtype(
@@ -155,8 +153,6 @@ class AvgPool2dVisitor_FP(AvgPool2dVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-        import serializer.tosa_serializer as ts  # type: ignore
-
         validate_num_inputs(self.target, inputs, [3, 4, 5, 6, 7])
         validate_same_dtype(self.target, [inputs[0], output], ts)
         validate_valid_dtype(

--- a/backends/arm/operators/op_bitwise_not.py
+++ b/backends/arm/operators/op_bitwise_not.py
@@ -5,6 +5,8 @@
 
 from typing import Any, List
 
+import serializer.tosa_serializer as ts
+
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
     register_node_visitor,
@@ -38,9 +40,6 @@ class BitwiseNotVisitor(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-
-        import serializer.tosa_serializer as ts  # type: ignore
-
         validate_num_inputs(self.target, inputs, 1)
         validate_same_dtype(self.target, [*inputs, output], ts)
         validate_valid_dtype(

--- a/backends/arm/operators/op_cat.py
+++ b/backends/arm/operators/op_cat.py
@@ -7,6 +7,8 @@
 
 from typing import Any, List
 
+import serializer.tosa_serializer as ts
+
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
     register_node_visitor,
@@ -34,8 +36,6 @@ class CatVisitor(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-        import serializer.tosa_serializer as ts
-
         validate_num_inputs(self.target, inputs, [1, 2])
 
         tensors = inputs[0].special

--- a/backends/arm/operators/op_ceil.py
+++ b/backends/arm/operators/op_ceil.py
@@ -5,6 +5,8 @@
 
 from typing import Any, List
 
+import serializer.tosa_serializer as ts
+
 import torch.fx
 
 from executorch.backends.arm.operators.node_visitor import (
@@ -38,8 +40,6 @@ class CeilVisitor(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-        import serializer.tosa_serializer as ts  # type: ignore  # noqa: F401
-
         validate_num_inputs(self.target, inputs, 1)
         validate_same_dtype(self.target, [*inputs, output], ts)
         validate_valid_dtype(

--- a/backends/arm/operators/op_clamp.py
+++ b/backends/arm/operators/op_clamp.py
@@ -9,6 +9,7 @@
 from typing import Any, List, Tuple
 
 import numpy as np
+import serializer.tosa_serializer as ts
 import torch
 
 from executorch.backends.arm.operators.node_visitor import (
@@ -67,8 +68,6 @@ class ClampVisitor_INT(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-        import serializer.tosa_serializer as ts  # type: ignore
-
         validate_num_inputs(self.target, inputs, [2, 3])
         validate_same_dtype(self.target, [inputs[0], output], ts)
         validate_valid_dtype(
@@ -118,8 +117,6 @@ class ClampVisitor_FP(ClampVisitor_INT):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-        import serializer.tosa_serializer as ts  # type: ignore
-
         validate_num_inputs(self.target, inputs, [2, 3])
         validate_same_dtype(self.target, [inputs[0], output], ts)
         validate_valid_dtype(

--- a/backends/arm/operators/op_constant_pad_nd.py
+++ b/backends/arm/operators/op_constant_pad_nd.py
@@ -7,6 +7,8 @@
 
 from typing import Any, List
 
+import serializer.tosa_serializer as ts
+
 import torch
 
 from executorch.backends.arm._passes.fold_qdq_with_annotated_qparams_pass import (
@@ -42,8 +44,6 @@ class ConstantPadNDVisitor(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-        import serializer.tosa_serializer as ts  # type: ignore
-
         validate_num_inputs(self.target, inputs, 3)
         validate_same_dtype(self.target, [inputs[0], output], ts)
         validate_valid_dtype(

--- a/backends/arm/operators/op_cos.py
+++ b/backends/arm/operators/op_cos.py
@@ -6,7 +6,7 @@
 # pyre-unsafe
 from typing import List
 
-import serializer.tosa_serializer as ts  # type: ignore
+import serializer.tosa_serializer as ts
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
     register_node_visitor,

--- a/backends/arm/operators/op_eq.py
+++ b/backends/arm/operators/op_eq.py
@@ -7,6 +7,8 @@
 
 from typing import Any, List
 
+import serializer.tosa_serializer as ts
+
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
     register_node_visitor,
@@ -41,9 +43,6 @@ class EqualVisitor(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-
-        import serializer.tosa_serializer as ts  # type: ignore
-
         validate_num_inputs(self.target, inputs, 2)
         validate_same_dtype(self.target, inputs, ts)
         validate_valid_dtype(

--- a/backends/arm/operators/op_erf.py
+++ b/backends/arm/operators/op_erf.py
@@ -5,6 +5,8 @@
 # pyre-unsafe
 from typing import Any, List
 
+import serializer.tosa_serializer as ts
+
 import torch.fx
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
@@ -36,8 +38,6 @@ class ERFVisitor(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-        import serializer.tosa_serializer as ts
-
         validate_num_inputs(self.target, inputs, 1)
         validate_same_dtype(self.target, [*inputs, output], ts)
         validate_valid_dtype(

--- a/backends/arm/operators/op_exp.py
+++ b/backends/arm/operators/op_exp.py
@@ -6,6 +6,8 @@
 # pyre-unsafe
 from typing import Any, List
 
+import serializer.tosa_serializer as ts
+
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
     register_node_visitor,
@@ -37,8 +39,6 @@ class ExpVisitor(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-        import serializer.tosa_serializer as ts
-
         validate_num_inputs(self.target, inputs, 1)
         validate_same_dtype(self.target, [*inputs, output], ts)
         validate_valid_dtype(

--- a/backends/arm/operators/op_floor.py
+++ b/backends/arm/operators/op_floor.py
@@ -5,6 +5,8 @@
 
 from typing import Any, List
 
+import serializer.tosa_serializer as ts
+
 import torch.fx
 
 from executorch.backends.arm.operators.node_visitor import (
@@ -38,8 +40,6 @@ class FloorVisitor(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-        import serializer.tosa_serializer as ts  # type: ignore  # noqa: F401
-
         validate_num_inputs(self.target, inputs, 1)
         validate_same_dtype(self.target, [*inputs, output], ts)
         validate_valid_dtype(

--- a/backends/arm/operators/op_ge.py
+++ b/backends/arm/operators/op_ge.py
@@ -7,6 +7,8 @@
 
 from typing import Any, List
 
+import serializer.tosa_serializer as ts
+
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
     register_node_visitor,
@@ -41,9 +43,6 @@ class GreaterEqualVisitor(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-
-        import serializer.tosa_serializer as ts  # type: ignore
-
         validate_num_inputs(self.target, inputs, 2)
         validate_same_dtype(self.target, inputs, ts)
         validate_valid_dtype(

--- a/backends/arm/operators/op_gt.py
+++ b/backends/arm/operators/op_gt.py
@@ -7,6 +7,8 @@
 
 from typing import Any, List
 
+import serializer.tosa_serializer as ts
+
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
     register_node_visitor,
@@ -41,9 +43,6 @@ class GreaterThanVisitor(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-
-        import serializer.tosa_serializer as ts  # type: ignore
-
         validate_num_inputs(self.target, inputs, 2)
         validate_same_dtype(self.target, inputs, ts)
         validate_valid_dtype(

--- a/backends/arm/operators/op_index_select.py
+++ b/backends/arm/operators/op_index_select.py
@@ -8,6 +8,7 @@
 from typing import Any, List
 
 import executorch.backends.arm.tosa.quant_utils as tqutils  # noqa: F401
+import serializer.tosa_serializer as ts
 
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
@@ -46,9 +47,6 @@ class IndexSelectVisitor(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-
-        import serializer.tosa_serializer as ts  # type: ignore
-
         if len(inputs) != 3:
             raise ValueError(f"Number of inputs are not 3: {len(inputs)}")
 

--- a/backends/arm/operators/op_index_tensor.py
+++ b/backends/arm/operators/op_index_tensor.py
@@ -11,6 +11,7 @@ from typing import Any, List
 import executorch.backends.arm.tosa.utils as tutils
 
 import numpy as np
+import serializer.tosa_serializer as ts
 
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
@@ -127,7 +128,6 @@ class IndexTensorVisitor(CommonIndexTensorVisitor):
         If the number of total elements in the values tensor exceeds int32 limits
         then this approach falls apart.
         """
-        import serializer.tosa_serializer as ts
 
         validate_same_dtype(self.target, [inputs[0], output])
 

--- a/backends/arm/operators/op_le.py
+++ b/backends/arm/operators/op_le.py
@@ -7,6 +7,8 @@
 
 from typing import Any, List
 
+import serializer.tosa_serializer as ts
+
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
     register_node_visitor,
@@ -41,9 +43,6 @@ class LessEqualVisitor(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-
-        import serializer.tosa_serializer as ts  # type: ignore
-
         validate_num_inputs(self.target, inputs, 2)
         validate_same_dtype(self.target, inputs, ts)
         validate_valid_dtype(

--- a/backends/arm/operators/op_log.py
+++ b/backends/arm/operators/op_log.py
@@ -6,6 +6,8 @@
 # pyre-unsafe
 from typing import Any, List
 
+import serializer.tosa_serializer as ts
+
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
     register_node_visitor,
@@ -37,8 +39,6 @@ class LogVisitor(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-        import serializer.tosa_serializer as ts
-
         validate_num_inputs(self.target, inputs, 1)
         validate_same_dtype(self.target, [*inputs, output], ts)
         validate_valid_dtype(

--- a/backends/arm/operators/op_logical_not.py
+++ b/backends/arm/operators/op_logical_not.py
@@ -5,6 +5,8 @@
 
 from typing import Any, List
 
+import serializer.tosa_serializer as ts
+
 import torch.fx
 
 from executorch.backends.arm.operators.node_visitor import (
@@ -39,8 +41,6 @@ class LogicalNotVisitor(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-        import serializer.tosa_serializer as ts  # type: ignore  # noqa: F401
-
         validate_num_inputs(self.target, inputs, 1)
         validate_same_dtype(self.target, [*inputs, output], ts)
         validate_valid_dtype(

--- a/backends/arm/operators/op_lt.py
+++ b/backends/arm/operators/op_lt.py
@@ -7,6 +7,8 @@
 
 from typing import Any, List
 
+import serializer.tosa_serializer as ts
+
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
     register_node_visitor,
@@ -41,9 +43,6 @@ class LessThanVisitor(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-
-        import serializer.tosa_serializer as ts  # type: ignore
-
         validate_num_inputs(self.target, inputs, 2)
         validate_same_dtype(self.target, inputs, ts)
         validate_valid_dtype(

--- a/backends/arm/operators/op_max_pool2d.py
+++ b/backends/arm/operators/op_max_pool2d.py
@@ -6,6 +6,8 @@
 # pyre-unsafe
 from typing import Any, List
 
+import serializer.tosa_serializer as ts
+
 import torch
 
 from executorch.backends.arm.operators.node_visitor import (
@@ -41,9 +43,6 @@ class MaxPool2dVisitor(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-
-        import serializer.tosa_serializer as ts  # type: ignore
-
         validate_num_inputs(self.target, inputs, [3, 4, 5, 6])
         validate_same_dtype(self.target, [inputs[0], output], ts)
         validate_valid_dtype(

--- a/backends/arm/operators/op_maximum.py
+++ b/backends/arm/operators/op_maximum.py
@@ -7,6 +7,8 @@
 
 from typing import Any, List
 
+import serializer.tosa_serializer as ts
+
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
     register_node_visitor,
@@ -40,8 +42,6 @@ class MaxVisitor(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-
-        import serializer.tosa_serializer as ts  # type: ignore
         from tosa.NanPropagationMode import NanPropagationMode  # type: ignore
 
         validate_num_inputs(self.target, inputs, 2)

--- a/backends/arm/operators/op_minimum.py
+++ b/backends/arm/operators/op_minimum.py
@@ -7,6 +7,8 @@
 
 from typing import Any, List
 
+import serializer.tosa_serializer as ts
+
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
     register_node_visitor,
@@ -40,8 +42,6 @@ class MinVisitor(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-
-        import serializer.tosa_serializer as ts  # type: ignore
         from tosa.NanPropagationMode import NanPropagationMode  # type: ignore
 
         validate_num_inputs(self.target, inputs, 2)

--- a/backends/arm/operators/op_mul.py
+++ b/backends/arm/operators/op_mul.py
@@ -7,6 +7,7 @@
 
 from typing import Any, List
 
+import serializer.tosa_serializer as ts
 import torch
 
 from executorch.backends.arm.operators.node_visitor import (
@@ -38,9 +39,6 @@ class MulVisitor(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-
-        import serializer.tosa_serializer as ts  # type: ignore
-
         validate_num_inputs(self.target, inputs, 2)
         validate_same_dtype(self.target, [*inputs, output], ts)
         validate_valid_dtype(

--- a/backends/arm/operators/op_neg.py
+++ b/backends/arm/operators/op_neg.py
@@ -6,6 +6,8 @@
 # pyre-unsafe
 from typing import Any, List
 
+import serializer.tosa_serializer as ts
+
 import torch.fx
 
 from executorch.backends.arm._passes.fold_qdq_with_annotated_qparams_pass import (
@@ -53,8 +55,6 @@ class NegVisitor(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-        import serializer.tosa_serializer as ts  # type: ignore
-
         supported_dtypes = [
             ts.DType.INT8,
             ts.DType.INT16,

--- a/backends/arm/operators/op_permute.py
+++ b/backends/arm/operators/op_permute.py
@@ -7,6 +7,8 @@
 
 from typing import Any, List
 
+import serializer.tosa_serializer as ts
+
 import torch
 
 from executorch.backends.arm.operators.node_visitor import (
@@ -110,8 +112,6 @@ class PermuteVisitor(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-        import serializer.tosa_serializer as ts
-
         validate_num_inputs(self.target, inputs, 2)
         validate_same_dtype(self.target, [inputs[0], output], ts)
         validate_valid_dtype(

--- a/backends/arm/operators/op_pow.py
+++ b/backends/arm/operators/op_pow.py
@@ -7,6 +7,8 @@
 
 from typing import Any, List
 
+import serializer.tosa_serializer as ts
+
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
     register_node_visitor,
@@ -39,8 +41,6 @@ class PowVisitor(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-        import serializer.tosa_serializer as ts
-
         validate_num_inputs(self.target, inputs, 2)
         validate_same_dtype(self.target, [*inputs, output], ts)
         validate_valid_dtype(

--- a/backends/arm/operators/op_reciprocal.py
+++ b/backends/arm/operators/op_reciprocal.py
@@ -6,6 +6,8 @@
 # pyre-unsafe
 from typing import Any, List
 
+import serializer.tosa_serializer as ts
+
 import torch
 
 from executorch.backends.arm.operators.node_visitor import (
@@ -38,8 +40,6 @@ class ReciprocalVisitor(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-        import serializer.tosa_serializer as ts
-
         validate_num_inputs(self.target, inputs, 1)
         validate_same_dtype(self.target, [*inputs, output], ts)
         validate_valid_dtype(

--- a/backends/arm/operators/op_repeat.py
+++ b/backends/arm/operators/op_repeat.py
@@ -7,6 +7,8 @@
 
 from typing import Any
 
+import serializer.tosa_serializer as ts
+
 import torch
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
@@ -37,8 +39,6 @@ class RepeatVisitor(NodeVisitor):
         inputs: list[TosaArg],
         output: TosaArg,
     ) -> None:
-        import serializer.tosa_serializer as ts  # type: ignore
-
         validate_num_inputs(self.target, inputs, 2)
         validate_same_dtype(self.target, [inputs[0], output], ts)
         validate_valid_dtype(

--- a/backends/arm/operators/op_rshift_tensor.py
+++ b/backends/arm/operators/op_rshift_tensor.py
@@ -7,6 +7,8 @@
 
 from typing import Any, List
 
+import serializer.tosa_serializer as ts
+
 import torch
 
 from executorch.backends.arm.operators.node_visitor import (
@@ -34,8 +36,6 @@ class RshiftVisitor(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-        import serializer.tosa_serializer as ts
-
         validate_num_inputs(self.target, inputs, 2)
         validate_same_dtype(self.target, [*inputs, output], ts)
         validate_valid_dtype(

--- a/backends/arm/operators/op_rsqrt.py
+++ b/backends/arm/operators/op_rsqrt.py
@@ -6,6 +6,8 @@
 # pyre-unsafe
 from typing import Any, List
 
+import serializer.tosa_serializer as ts
+
 import torch
 
 from executorch.backends.arm.operators.node_visitor import (
@@ -38,8 +40,6 @@ class RsqrtVisitor(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-        import serializer.tosa_serializer as ts
-
         validate_num_inputs(self.target, inputs, 1)
         validate_same_dtype(self.target, [*inputs, output], ts)
         validate_valid_dtype(

--- a/backends/arm/operators/op_sigmoid.py
+++ b/backends/arm/operators/op_sigmoid.py
@@ -6,6 +6,8 @@
 # pyre-unsafe
 from typing import Any, List
 
+import serializer.tosa_serializer as ts
+
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
     register_node_visitor,
@@ -37,8 +39,6 @@ class SigmoidVisitor(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-        import serializer.tosa_serializer as ts
-
         validate_num_inputs(self.target, inputs, 1)
         validate_same_dtype(self.target, [*inputs, output], ts)
         validate_valid_dtype(

--- a/backends/arm/operators/op_sin.py
+++ b/backends/arm/operators/op_sin.py
@@ -6,7 +6,7 @@
 # pyre-unsafe
 from typing import List
 
-import serializer.tosa_serializer as ts  # type: ignore
+import serializer.tosa_serializer as ts
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
     register_node_visitor,

--- a/backends/arm/operators/op_slice.py
+++ b/backends/arm/operators/op_slice.py
@@ -7,6 +7,8 @@
 
 from typing import Any, List
 
+import serializer.tosa_serializer as ts
+
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
     register_node_visitor,
@@ -50,8 +52,6 @@ class SliceVisitor(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-        import serializer.tosa_serializer as ts  # type: ignore
-
         validate_num_inputs(self.target, inputs, [4, 5])
         validate_same_dtype(self.target, [inputs[0], output], ts)
         validate_valid_dtype(

--- a/backends/arm/operators/op_sub.py
+++ b/backends/arm/operators/op_sub.py
@@ -9,6 +9,7 @@ from typing import Any, List
 
 import executorch.backends.arm.tosa.quant_utils as tqutils
 import executorch.backends.arm.tosa.utils as tutils
+import serializer.tosa_serializer as ts
 
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
@@ -42,9 +43,6 @@ class SubVisitor_INT(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-
-        import serializer.tosa_serializer as ts  # type: ignore
-
         validate_num_inputs(self.target, inputs, 2)
         validate_same_dtype(self.target, [*inputs, output], ts)
         validate_valid_dtype(
@@ -128,9 +126,6 @@ class SubVisitor_FP(SubVisitor_INT):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-
-        import serializer.tosa_serializer as ts  # type: ignore
-
         validate_num_inputs(self.target, inputs, 2)
         validate_same_dtype(self.target, [*inputs, output], ts)
 

--- a/backends/arm/operators/op_sum.py
+++ b/backends/arm/operators/op_sum.py
@@ -9,6 +9,7 @@ from typing import Any, List
 
 import executorch.backends.arm.tosa.quant_utils as tqutils
 import executorch.backends.arm.tosa.utils as tutils
+import serializer.tosa_serializer as ts
 
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
@@ -41,9 +42,6 @@ class SumVisitor_INT(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-
-        import serializer.tosa_serializer as ts  # type: ignore
-
         validate_num_inputs(self.target, inputs, 3)
         validate_same_dtype(self.target, [inputs[0], output], ts)
 
@@ -97,9 +95,6 @@ class SumVisitor_FP(SumVisitor_INT):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-
-        import serializer.tosa_serializer as ts  # type: ignore
-
         validate_num_inputs(self.target, inputs, 3)
         validate_same_dtype(self.target, [inputs[0], output], ts)
 

--- a/backends/arm/operators/op_tanh.py
+++ b/backends/arm/operators/op_tanh.py
@@ -6,6 +6,8 @@
 # pyre-unsafe
 from typing import Any, List
 
+import serializer.tosa_serializer as ts
+
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
     register_node_visitor,
@@ -38,8 +40,6 @@ class TanhVisitor(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-        import serializer.tosa_serializer as ts
-
         validate_num_inputs(self.target, inputs, 1)
         validate_same_dtype(self.target, [*inputs, output], ts)
         validate_valid_dtype(

--- a/backends/arm/operators/op_to_dim_order_copy.py
+++ b/backends/arm/operators/op_to_dim_order_copy.py
@@ -6,6 +6,8 @@
 # pyre-unsafe
 from typing import Any, List
 
+import serializer.tosa_serializer as ts
+
 import torch
 
 from executorch.backends.arm.operators.node_visitor import (
@@ -40,8 +42,6 @@ class ToDimOrderCopyVisitor(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-        import serializer.tosa_serializer as ts  # type: ignore
-
         validate_num_inputs(self.target, inputs, 1)
 
         self._serialize_operator(

--- a/backends/arm/operators/op_tosa_conv2d.py
+++ b/backends/arm/operators/op_tosa_conv2d.py
@@ -4,6 +4,8 @@
 # LICENSE file in the root directory of this source tree.
 
 # pyre-unsafe
+import serializer.tosa_serializer as ts
+
 """Provide a visitor for lowering 2D convolution to TOSA (INT/FP)."""
 
 import itertools
@@ -59,7 +61,6 @@ class Conv2dVisitor(NodeVisitor):
         output: TosaArg,
     ) -> None:
         """Define the TOSA CONV2D/DEPTHWISE_CONV2D operator and post-rescale."""
-        import serializer.tosa_serializer as ts  # type: ignore
         from tosa.RoundingMode import RoundingMode  # type: ignore
 
         input, weight, bias, stride, pad, dilation, _, _, group = inputs

--- a/backends/arm/operators/op_tosa_rescale.py
+++ b/backends/arm/operators/op_tosa_rescale.py
@@ -7,6 +7,8 @@
 
 from typing import Any, cast, List
 
+import serializer.tosa_serializer as ts
+
 import torch
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
@@ -35,7 +37,6 @@ class RescaleVisitor(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-        import serializer.tosa_serializer as ts  # type: ignore
         from tosa.RoundingMode import RoundingMode  # type: ignore
 
         validate_num_inputs(self.target, inputs, 5)

--- a/backends/arm/operators/op_tosa_resize.py
+++ b/backends/arm/operators/op_tosa_resize.py
@@ -6,6 +6,8 @@
 # pyre-unsafe
 from typing import Any, List
 
+import serializer.tosa_serializer as ts
+
 import torch
 
 from executorch.backends.arm.operators.node_visitor import (
@@ -39,8 +41,6 @@ class ResizeVisitor(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-        import serializer.tosa_serializer as ts
-
         validate_num_inputs(self.target, inputs, [3, 4])
         if node.kwargs.get("resize_mode") == "bilinear":
             resize_mode = ResizeMode.BILINEAR

--- a/backends/arm/operators/op_tosa_table.py
+++ b/backends/arm/operators/op_tosa_table.py
@@ -7,6 +7,8 @@
 
 from typing import Any, List
 
+import serializer.tosa_serializer as ts
+
 import torch
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
@@ -34,8 +36,6 @@ class TableVisitor(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-        import serializer.tosa_serializer as ts  # type: ignore
-
         validate_num_inputs(self.target, inputs, 2)
         validate_valid_dtype(
             self.target, inputs, [ts.DType.INT8, ts.DType.INT16], output.tosa_spec

--- a/backends/arm/operators/op_tosa_transpose.py
+++ b/backends/arm/operators/op_tosa_transpose.py
@@ -7,6 +7,8 @@
 
 from typing import Any, List
 
+import serializer.tosa_serializer as ts
+
 import torch
 
 from executorch.backends.arm.operators.node_visitor import (
@@ -40,8 +42,6 @@ class TransposeVisitor(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-        import serializer.tosa_serializer as ts  # type: ignore
-
         validate_num_inputs(self.target, inputs, 2)
         validate_same_dtype(self.target, [inputs[0], output], ts)
         validate_valid_dtype(

--- a/backends/arm/operators/op_view.py
+++ b/backends/arm/operators/op_view.py
@@ -6,6 +6,8 @@
 # pyre-unsafe
 from typing import Any, cast, List
 
+import serializer.tosa_serializer as ts
+
 import torch
 
 from executorch.backends.arm.operators.node_visitor import (
@@ -37,8 +39,6 @@ class ViewVisitor(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-        import serializer.tosa_serializer as ts
-
         validate_num_inputs(self.target, inputs, 2)
         validate_same_dtype(self.target, [inputs[0], output], ts)
         validate_valid_dtype(

--- a/backends/arm/operators/op_where.py
+++ b/backends/arm/operators/op_where.py
@@ -5,6 +5,8 @@
 
 from typing import Any, List, Sequence
 
+import serializer.tosa_serializer as ts
+
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
     register_node_visitor,
@@ -39,7 +41,6 @@ class WhereVisitor_INT(NodeVisitor):
         output: TosaArg,
         supported_dtypes: Sequence,
     ) -> None:
-        import serializer.tosa_serializer as ts
 
         validate_num_inputs(self.target, inputs, 3)
         # Not first input, which is condition tensor.
@@ -68,8 +69,6 @@ class WhereVisitor_INT(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-        import serializer.tosa_serializer as ts
-
         bi_supported_dtypes = [
             ts.DType.INT8,
             ts.DType.INT16,
@@ -98,8 +97,6 @@ class WhereVisitor_FP(WhereVisitor_INT):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-        import serializer.tosa_serializer as ts
-
         mi_supported_dtypes = [
             ts.DType.FP16,
             ts.DType.FP32,

--- a/backends/arm/operators/operator_validation_utils.py
+++ b/backends/arm/operators/operator_validation_utils.py
@@ -148,7 +148,6 @@ def validate_valid_dtype(
         validate_valid_dtype,
     )
 
-    import serializer.tosa_serializer as ts
 
     validate_valid_dtype(
         self.target,

--- a/backends/arm/operators/ops_binary.py
+++ b/backends/arm/operators/ops_binary.py
@@ -7,6 +7,8 @@
 
 from typing import Any, List
 
+import serializer.tosa_serializer as ts
+
 import torch
 import torch.fx
 
@@ -36,8 +38,6 @@ def binary_operator_factory(bw_target: str, tosa_op):
             inputs: List[TosaArg],
             output: TosaArg,
         ) -> None:
-            import serializer.tosa_serializer as ts  # type: ignore  # noqa: F401
-
             validate_num_inputs(self.target, inputs, 2)
             validate_same_dtype(self.target, [*inputs, output], ts)
 
@@ -75,8 +75,6 @@ def binary_operator_factory(bw_target: str, tosa_op):
 
     register_node_visitor(BinaryOperator)
 
-
-import serializer.tosa_serializer as ts  # type: ignore
 
 binary_operator_factory("aten.bitwise_and.Tensor", ts.TosaOp.Op().BITWISE_AND)
 binary_operator_factory("aten.bitwise_xor.Tensor", ts.TosaOp.Op().BITWISE_XOR)

--- a/backends/arm/operators/ops_identity.py
+++ b/backends/arm/operators/ops_identity.py
@@ -7,6 +7,8 @@
 
 from typing import Any, List
 
+import serializer.tosa_serializer as ts
+
 import torch
 import torch.fx
 
@@ -39,8 +41,6 @@ def identity_operator_factory(identity_target: str):
             inputs: List[TosaArg],
             output: TosaArg,
         ) -> None:
-            import serializer.tosa_serializer as ts
-
             validate_num_inputs(self.target, inputs, 1)
             validate_same_dtype(self.target, [*inputs, output], ts)
 

--- a/backends/arm/test/tester/arm_tester.py
+++ b/backends/arm/test/tester/arm_tester.py
@@ -24,7 +24,7 @@ from typing import (
 
 import executorch.backends.xnnpack.test.tester.tester as tester
 
-import serializer.tosa_serializer as ts  # type: ignore[import-untyped]
+import serializer.tosa_serializer as ts
 
 import torch.fx
 import torch.utils._pytree as pytree

--- a/backends/arm/tosa/backend.py
+++ b/backends/arm/tosa/backend.py
@@ -15,7 +15,7 @@ from collections import deque
 from itertools import count
 from typing import cast, Dict, final, List, Set
 
-import serializer.tosa_serializer as ts  # type: ignore
+import serializer.tosa_serializer as ts
 from executorch.backends.arm.common.arm_compile_spec import ArmCompileSpec
 from executorch.backends.arm.common.debug import debug_fail, debug_tosa_dump
 from executorch.backends.arm.debug.schema import DebugHook

--- a/backends/arm/tosa/mapping.py
+++ b/backends/arm/tosa/mapping.py
@@ -14,7 +14,7 @@ the TOSA serializer types and shapes used during initial compilation.
 from enum import Enum
 from typing import Any, Optional, Sequence
 
-import serializer.tosa_serializer as ts  # type: ignore
+import serializer.tosa_serializer as ts
 
 import torch
 from executorch.backends.arm.tosa.specification import TosaSpecification

--- a/backends/arm/tosa/quant_utils.py
+++ b/backends/arm/tosa/quant_utils.py
@@ -11,7 +11,7 @@ import math
 
 from typing import Any, Tuple
 
-import serializer.tosa_serializer as ts  # type: ignore
+import serializer.tosa_serializer as ts
 
 from executorch.backends.arm._passes.fold_qdq_with_annotated_qparams_pass import (
     get_input_qparams,
@@ -374,7 +374,6 @@ def build_rescale(
     rounding_mode: RoundingMode,
     per_channel=False,
 ):
-    import serializer.tosa_serializer as ts  # type: ignore
 
     import tosa.Op as TosaOp  # type: ignore
 

--- a/backends/arm/tosa/utils.py
+++ b/backends/arm/tosa/utils.py
@@ -9,7 +9,7 @@ import logging
 from typing import Any
 
 import numpy as np
-import serializer.tosa_serializer as ts  # type: ignore
+import serializer.tosa_serializer as ts
 
 import sympy  # type: ignore
 


### PR DESCRIPTION
A leftover from TOSA 0.80 was the need for `# type: ignore` after the tosa serializer import. This ignore is now removed, along with moving the imports to the top of the file instead of having it as a dynamic import.


cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai