### PR TITLE
Fixing issues with using buffers for quantized linear weights.

### DIFF
--- a/backends/vulkan/runtime/graph/ops/glsl/linear_qcsnw_tiled.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/linear_qcsnw_tiled.yaml
@@ -35,8 +35,18 @@ linear_qcsnw_tiled:
     - NAME: linear_qcs4w_tiled_texture3d_texture3d_texture2d_texture2d_float
       TILE_TXCOLS: 2
       QUANT_NBITS: 4
+    - NAME: linear_qcs4w_tiled_texture3d_texture3d_buffer_texture2d_float
+      TILE_TXCOLS: 2
+      QUANT_NBITS: 4
+      WEIGHT_STORAGE: buffer
     - NAME: linear_qcs4w_tiled_buffer_buffer_texture2d_texture2d_float
       IN_STORAGE: buffer
       OUT_STORAGE: buffer
+      TILE_TXCOLS: 2
+      QUANT_NBITS: 4
+    - NAME: linear_qcs4w_tiled_buffer_buffer_buffer_texture2d_float
+      IN_STORAGE: buffer
+      OUT_STORAGE: buffer
+      WEIGHT_STORAGE: buffer
       TILE_TXCOLS: 2
       QUANT_NBITS: 4

--- a/backends/vulkan/runtime/graph/ops/glsl/pack_int4_linear_weight_transposed_interleaved.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/pack_int4_linear_weight_transposed_interleaved.yaml
@@ -14,3 +14,6 @@ pack_int4_linear_weight_transposed_interleaved:
       STORAGE: buffer
     - NAME: pack_int4_linear_weight_transposed_interleaved_nobitw8buffer_texture2d
       NO_INT8_BUFFERS: true
+    - NAME: pack_int4_linear_weight_transposed_interleaved_nobitw8buffer_buffer
+      STORAGE: buffer
+      NO_INT8_BUFFERS: true

--- a/backends/vulkan/runtime/graph/ops/impl/QuantizedLinearQCSNW.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/QuantizedLinearQCSNW.cpp
@@ -225,7 +225,8 @@ void add_linear_qcs8w_node(
   } else {
     pcs = {
         graph.logical_limits_pc_of(out_W_packed),
-        graph.sizes_pc_of(mat1_W_packed)};
+        graph.sizes_pc_of(mat1_W_packed),
+        graph.sizes_pc_of(q_mat2)};
   }
 
   const utils::uvec3 global_wg = {
@@ -351,7 +352,9 @@ void add_linear_qcsnw_tiled_node(
       // Shader params buffers
       {},
       // Push Constants
-      {{graph.sizes_pc_of(out), graph.sizes_pc_of(mat1)}},
+      {{graph.sizes_pc_of(out),
+        graph.sizes_pc_of(mat1),
+        graph.sizes_pc_of(q_mat2)}},
       // Specialization Constants
       {},
       // Resize Args


### PR DESCRIPTION
Summary:
This diff issues related to using buffers for quantized linear weights in the Executorch Vulkan backend.

The changes include:
* Using uint for buffer weight storage instead of uint8 and packing / unpacking integer values accordingly.
* Updating the shader parameters in `QuantizedLinearQCSNW.cpp` to include the correct sizes for the packed weights.

Differential Revision: D84870681


