### PR TITLE
Add dependency for RemoveCatFromSliceCopyPass.

### DIFF
--- a/backends/cadence/aot/TARGETS
+++ b/backends/cadence/aot/TARGETS
@@ -268,6 +268,7 @@ runtime.python_library(
     ],
     typing = True,
     deps = [
+        ":ops_registrations",
         "//caffe2:torch",
         "//executorch/backends/cadence/aot:pass_utils",
         "//executorch/backends/cadence/aot:simplify_ops",

--- a/backends/cadence/aot/remove_ops.py
+++ b/backends/cadence/aot/remove_ops.py
@@ -11,6 +11,9 @@ import logging
 from dataclasses import dataclass, field
 from typing import cast, List, Optional, Sequence, Set, Type
 
+# Import these for the cadence function signatures.
+import executorch.backends.cadence.aot.ops_registrations  # noqa: F401
+
 import torch
 import torch.fx
 from executorch.backends.cadence.aot.pass_utils import (


### PR DESCRIPTION
Summary:
This diff moves RemoveCatFromSliceCopyPass after MovePermuteAfterConcat because the latter pass may introduce the new cat-slice pairs.

With this diff in, the unwanted cat ops described in task, get optimized:
 {F1982857385}

Reviewed By: hsharma35

Differential Revision: D85087930


