### PR TITLE
Relax verification on flat tensor

### DIFF
--- a/extension/flat_tensor/flat_tensor_data_map.cpp
+++ b/extension/flat_tensor/flat_tensor_data_map.cpp
@@ -218,7 +218,7 @@ ET_NODISCARD Result<const char*> FlatTensorDataMap::get_key(
   size_t expected_size = fh->segment_base_offset + fh->segment_data_size;
   size_t actual_size = loader->size().get();
   ET_CHECK_OR_RETURN_ERROR(
-      expected_size == actual_size,
+      expected_size <= actual_size,
       InvalidExternalData,
       "File size is too small; file may be corrupted or truncated. Expected %zu from flat_tensor header, received %zu from data loader",
       expected_size,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #15313

Enforce that the data loader size must be at least as large as the header size, not exactly.

We are introducing a dual address data loader, which takes in two loaders, one for flatbuffer-only, and one for the full PTD file. The DualAddressDataLoader returns size as the combined size of both loaders. This will end up being larger than the PTD file size in the header.

The new data loader allows users to address int64 and int32 at the same time.

Differential Revision: [D85169688](https://our.internmc.facebook.com/intern/diff/D85169688/)