### PR TITLE
Arm backend: Remove pyre-unsafe from tosa/, vgf/ and ethosu/

### DIFF
--- a/backends/arm/ethosu/__init__.py
+++ b/backends/arm/ethosu/__init__.py
@@ -3,7 +3,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 #
-# pyre-unsafe
 
 from .backend import EthosUBackend  # noqa: F401
 from .compile_spec import EthosUCompileSpec  # noqa: F401

--- a/backends/arm/ethosu/backend.py
+++ b/backends/arm/ethosu/backend.py
@@ -3,7 +3,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# pyre-unsafe
 
 #
 # Main implementation of AoT flow to partition and preprocess for Arm target

--- a/backends/arm/ethosu/partitioner.py
+++ b/backends/arm/ethosu/partitioner.py
@@ -3,7 +3,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# pyre-unsafe
 
 from typing import final, Optional, Sequence
 

--- a/backends/arm/tosa/__init__.py
+++ b/backends/arm/tosa/__init__.py
@@ -3,7 +3,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 #
-# pyre-unsafe
 
 from .specification import TosaSpecification
 

--- a/backends/arm/tosa/backend.py
+++ b/backends/arm/tosa/backend.py
@@ -3,7 +3,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# pyre-unsafe
 
 #
 # Main implementation of AoT flow to partition and preprocess for Arm target

--- a/backends/arm/tosa/mapping.py
+++ b/backends/arm/tosa/mapping.py
@@ -3,7 +3,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# pyre-unsafe
 """Provide PyTorch-to-TOSA mapping helpers.
 
 Use these utilities to translate PyTorch dtypes and FX node metadata into

--- a/backends/arm/tosa/partitioner.py
+++ b/backends/arm/tosa/partitioner.py
@@ -3,7 +3,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# pyre-unsafe
 """Provide a partitioner for delegating subgraphs to the TOSA backend.
 
 Implement logic to identify and tag regions of an ``ExportedProgram`` that can

--- a/backends/arm/tosa/quant_utils.py
+++ b/backends/arm/tosa/quant_utils.py
@@ -3,7 +3,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# pyre-unsafe
 
 # Utility functions for TOSA quantized lowerings
 

--- a/backends/arm/tosa/specification.py
+++ b/backends/arm/tosa/specification.py
@@ -3,7 +3,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# pyre-unsafe
 """Provide TOSA specification parsing and context utilities.
 
 Use these helpers to parse and validate TOSA profile/extension strings and to

--- a/backends/arm/tosa/utils.py
+++ b/backends/arm/tosa/utils.py
@@ -3,7 +3,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# pyre-unsafe
 
 import logging
 from typing import Any

--- a/backends/arm/vgf/__init__.py
+++ b/backends/arm/vgf/__init__.py
@@ -3,7 +3,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 #
-# pyre-unsafe
 
 from .backend import VgfBackend  # noqa: F401
 from .compile_spec import VgfCompileSpec  # noqa: F401

--- a/backends/arm/vgf/backend.py
+++ b/backends/arm/vgf/backend.py
@@ -3,7 +3,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# pyre-unsafe
 
 #
 # Main implementation of AoT flow to partition and preprocess for VGF target

--- a/backends/arm/vgf/partitioner.py
+++ b/backends/arm/vgf/partitioner.py
@@ -3,7 +3,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# pyre-unsafe
 
 from typing import final, Optional, Sequence
 


### PR DESCRIPTION
Pyre is no longer used.


cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai