### PR TITLE
Arm Backend: Enable Pybindings for tosa_serialization lib

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -83,6 +83,12 @@ ignore_missing_imports = True
 [mypy-tosa_tools.*]
 ignore_missing_imports = True
 
+[mypy-tosa_serializer]
+ignore_missing_imports = True
+
+[mypy-tosa_serializer.*]
+ignore_missing_imports = True
+
 [mypy-setuptools.*]
 ignore_missing_imports = True
 

--- a/backends/arm/common/debug.py
+++ b/backends/arm/common/debug.py
@@ -7,8 +7,9 @@ import logging
 import os
 from typing import Optional
 
-import serializer.tosa_serializer as ts
 import torch
+
+import tosa_serializer as ts
 from executorch.exir.print_program import inspect_node
 
 logger = logging.getLogger(__name__)
@@ -50,28 +51,19 @@ def get_node_debug_info(
     return output
 
 
-# Output TOSA flatbuffer and test harness file
-def debug_tosa_dump(tosa_graph: ts.TosaSerializer, path: str, suffix: str = ""):
+# Output TOSA flatbuffer for debugging
+def debug_tosa_dump(tosa_graph: bytes, path: str, suffix: str = ""):
     filename = f"output{suffix}.tosa"
 
     logger.info(f"Emitting debug output to: {path=}, {suffix=}")
 
     os.makedirs(path, exist_ok=True)
 
-    fb = tosa_graph.serialize()
-    js = tosa_graph.writeJson(filename)
-
     filepath_tosa_fb = os.path.join(path, filename)
     with open(filepath_tosa_fb, "wb") as f:
-        f.write(fb)
+        f.write(tosa_graph)
     if not os.path.exists(filepath_tosa_fb):
         raise IOError("Failed to write TOSA flatbuffer")
-
-    filepath_desc_json = os.path.join(path, f"desc{suffix}.json")
-    with open(filepath_desc_json, "w") as f:
-        f.write(js)
-    if not os.path.exists(filepath_desc_json):
-        raise IOError("Failed to write TOSA JSON")
 
 
 def debug_fail(
@@ -81,7 +73,7 @@ def debug_fail(
     path: Optional[str] = None,
 ):
     logger.warning("Internal error due to poorly handled node:")
-    if tosa_graph is not None and path is not None:
-        debug_tosa_dump(tosa_graph, path)
+    if tosa_graph is not None and path:
+        debug_tosa_dump(tosa_graph.serialize(), path)
         logger.warning(f"Debug output captured in '{path}'.")
     debug_node(node, graph_module)

--- a/backends/arm/ethosu/backend.py
+++ b/backends/arm/ethosu/backend.py
@@ -51,6 +51,15 @@ class EthosUBackend(BackendDetails):
                 "compile_flags are required in the CompileSpec list for EthosUBackend"
             )
 
+        # Vela tooling only supports flatbuffers up to 2 GiB.
+        max_flatbuffer_size = 2 * 1024 * 1024 * 1024
+        flatbuffer_size = len(tosa_flatbuffer)
+        if flatbuffer_size > max_flatbuffer_size:
+            raise RuntimeError(
+                "TOSA flatbuffer is too large for Vela "
+                f"({flatbuffer_size} bytes > {max_flatbuffer_size} bytes limit)."
+            )
+
         # Pass on the TOSA flatbuffer to the vela compiler.
         binary = vela_compile(
             tosa_flatbuffer,

--- a/backends/arm/operators/node_visitor.py
+++ b/backends/arm/operators/node_visitor.py
@@ -9,6 +9,7 @@ import json
 from typing import Any, Dict, List, Optional
 
 import torch
+import tosa_serializer as ts
 
 from executorch.backends.arm.common.arm_compile_spec import ArmCompileSpec
 from executorch.backends.arm.debug.schema import DebugHook
@@ -46,12 +47,12 @@ class NodeVisitor:
         self,
         node: torch.fx.Node,
         tosa_graph: Any,
-        tosa_op: Any,
+        tosa_op: ts.Op,
         inputs: List[str],
         outputs: List[str],
         attributes: Optional[Any] = None,
     ) -> None:
-        op_location = ""
+        op_location = ts.TosaOpLocation()
         if self.debug_hook:
             debug_info = self.debug_hook.add(
                 node,
@@ -60,7 +61,7 @@ class NodeVisitor:
             )
 
             if self.debug_hook.mode == ArmCompileSpec.DebugMode.TOSA:
-                op_location = json.dumps(debug_info.to_dict())
+                op_location.text = json.dumps(debug_info.to_dict())
 
         tosa_graph.addOperator(
             tosa_op,

--- a/backends/arm/operators/op_abs.py
+++ b/backends/arm/operators/op_abs.py
@@ -6,7 +6,7 @@
 # pyre-unsafe
 from typing import Any, List
 
-import serializer.tosa_serializer as ts
+import tosa_serializer as ts
 
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
@@ -48,11 +48,13 @@ class AbsVisitor(NodeVisitor):
             output.tosa_spec,
         )
 
-        tosa_graph.addOperator(
-            ts.TosaOp.Op().ABS,
-            [
-                inputs[0].name,
-            ],
+        attr = ts.TosaSerializerAttribute()
+        attr.AbsAttribute()
+        self._serialize_operator(
+            node,
+            tosa_graph,
+            ts.Op.ABS,
+            [inputs[0].name],
             [output.name],
-            None,
+            attr,
         )

--- a/backends/arm/operators/op_add.py
+++ b/backends/arm/operators/op_add.py
@@ -9,7 +9,7 @@ from typing import Any, List
 
 import executorch.backends.arm.tosa.quant_utils as tqutils
 import executorch.backends.arm.tosa.utils as tutils
-import serializer.tosa_serializer as ts
+import tosa_serializer as ts
 
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
@@ -81,15 +81,16 @@ class AddVisitor_INT(NodeVisitor):
             add_output = output
 
         input1, input2 = rescaled_inputs
-
+        attr = ts.TosaSerializerAttribute()
+        attr.AddAttribute()
         # Do the INT32 Add
         self._serialize_operator(
             node,
             tosa_graph,
-            ts.TosaOp.Op().ADD,
+            ts.Op.ADD,
             [input1.name, input2.name],
             [add_output.name],
-            None,
+            attr,
         )
 
         if output.dtype == ts.DType.INT8:
@@ -143,13 +144,14 @@ class AddVisitor_FP(AddVisitor_INT):
             )
 
             input1, input2 = inputs
-
+            attr = ts.TosaSerializerAttribute()
+            attr.AddAttribute()
             # FP lowering
             self._serialize_operator(
                 node,
                 tosa_graph,
-                ts.TosaOp.Op().ADD,
+                ts.Op.ADD,
                 [input1.name, input2.name],
                 [output.name],
-                None,
+                attr,
             )

--- a/backends/arm/operators/op_amax.py
+++ b/backends/arm/operators/op_amax.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 from typing import Any, List
 
-import serializer.tosa_serializer as ts
+import tosa_serializer as ts
 
 from executorch.backends.arm._passes.arm_pass_utils import get_first_fake_tensor
 from executorch.backends.arm.operators.node_visitor import (
@@ -60,11 +60,12 @@ class MaxVisitor(NodeVisitor):
             )
 
         attr = ts.TosaSerializerAttribute()
-        attr.ReduceMaxAttribute(axis=input.dim_order.index(dim), nan_mode=1)
+        nan_mode = ts.NanPropagationMode.PROPAGATE
+        attr.ReduceMaxAttribute(axis=input.dim_order.index(dim), nan_mode=nan_mode)
         self._serialize_operator(
             node,
             tosa_graph,
-            ts.TosaOp.Op().REDUCE_MAX,
+            ts.Op.REDUCE_MAX,
             [input.name],
             [output.name],
             attr,

--- a/backends/arm/operators/op_amin.py
+++ b/backends/arm/operators/op_amin.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 from typing import Any, List
 
-import serializer.tosa_serializer as ts
+import tosa_serializer as ts
 
 from executorch.backends.arm._passes.arm_pass_utils import get_first_fake_tensor
 from executorch.backends.arm.operators.node_visitor import (
@@ -60,11 +60,13 @@ class MinVisitor(NodeVisitor):
             )
 
         attr = ts.TosaSerializerAttribute()
-        attr.ReduceMinAttribute(axis=input.dim_order.index(dim), nan_mode=1)
+        attr.ReduceMinAttribute(
+            axis=input.dim_order.index(dim), nan_mode=ts.NanPropagationMode.PROPAGATE
+        )
         self._serialize_operator(
             node,
             tosa_graph,
-            ts.TosaOp.Op().REDUCE_MIN,
+            ts.Op.REDUCE_MIN,
             [input.name],
             [output.name],
             attr,

--- a/backends/arm/operators/op_any.py
+++ b/backends/arm/operators/op_any.py
@@ -6,7 +6,7 @@
 # pyre-unsafe
 from typing import Any, cast, List
 
-import serializer.tosa_serializer as ts
+import tosa_serializer as ts
 
 from executorch.backends.arm.operators.node_visitor import (  # type: ignore
     NodeVisitor,
@@ -55,7 +55,7 @@ class AnyVisitor(NodeVisitor):
         self._serialize_operator(
             node,
             tosa_graph,
-            ts.TosaOp.Op().REDUCE_ANY,
+            ts.Op.REDUCE_ANY,
             [inputs[0].name],
             [output.name],
             attr,

--- a/backends/arm/operators/op_avg_pool2d.py
+++ b/backends/arm/operators/op_avg_pool2d.py
@@ -6,9 +6,9 @@
 # pyre-unsafe
 from typing import Any, List
 
-import serializer.tosa_serializer as ts
-
 import torch
+
+import tosa_serializer as ts
 
 from executorch.backends.arm._passes.fold_qdq_with_annotated_qparams_pass import (
     get_input_qparams,
@@ -93,17 +93,14 @@ class AvgPool2dVisitor(NodeVisitor):
             pad=pad_size_list,
             acc_type=accumulator_type,
         )
-        input_zp_tensor = tosa_graph.addConst(
-            shape=[1], dtype=output.dtype, vals=[input_zp]
-        )
-        output_zp_tensor = tosa_graph.addConst(
-            shape=[1], dtype=output.dtype, vals=[output_zp]
-        )
+        dt: ts.DType = output.dtype
+        input_zp_tensor = tosa_graph.addConst(shape=[1], dtype=dt, vals=[input_zp])
+        output_zp_tensor = tosa_graph.addConst(shape=[1], dtype=dt, vals=[output_zp])
 
         self._serialize_operator(
             node,
             tosa_graph,
-            ts.TosaOp.Op().AVG_POOL2D,
+            ts.Op.AVG_POOL2D,
             [input_tensor.name, input_zp_tensor.name, output_zp_tensor.name],
             [output.name],
             attr,

--- a/backends/arm/operators/op_bitwise_not.py
+++ b/backends/arm/operators/op_bitwise_not.py
@@ -5,7 +5,7 @@
 
 from typing import Any, List
 
-import serializer.tosa_serializer as ts
+import tosa_serializer as ts
 
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
@@ -49,10 +49,14 @@ class BitwiseNotVisitor(NodeVisitor):
             output.tosa_spec,
         )
 
+        attr = ts.TosaSerializerAttribute()
+        attr.BitwiseNotAttribute()
+
         self._serialize_operator(
             node,
             tosa_graph,
-            ts.TosaOp.Op().BITWISE_NOT,
+            ts.Op.BITWISE_NOT,
             [inputs[0].name],
             [output.name],
+            attr,
         )

--- a/backends/arm/operators/op_cat.py
+++ b/backends/arm/operators/op_cat.py
@@ -7,7 +7,7 @@
 
 from typing import Any, List
 
-import serializer.tosa_serializer as ts
+import tosa_serializer as ts
 
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
@@ -50,7 +50,7 @@ class CatVisitor(NodeVisitor):
         self._serialize_operator(
             node,
             tosa_graph,
-            ts.TosaOp.Op().CONCAT,
+            ts.Op.CONCAT,
             [tensor.name for tensor in tensors],
             [output.name],
             attr,

--- a/backends/arm/operators/op_ceil.py
+++ b/backends/arm/operators/op_ceil.py
@@ -5,9 +5,9 @@
 
 from typing import Any, List
 
-import serializer.tosa_serializer as ts
-
 import torch.fx
+
+import tosa_serializer as ts
 
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
@@ -49,6 +49,8 @@ class CeilVisitor(NodeVisitor):
             output.tosa_spec,
         )
 
+        attr = ts.TosaSerializerAttribute()
+        attr.CeilAttribute()
         self._serialize_operator(
-            node, tosa_graph, ts.TosaOp.Op().CEIL, [inputs[0].name], [output.name]
+            node, tosa_graph, ts.Op.CEIL, [inputs[0].name], [output.name], attr
         )

--- a/backends/arm/operators/op_constant_pad_nd.py
+++ b/backends/arm/operators/op_constant_pad_nd.py
@@ -7,9 +7,9 @@
 
 from typing import Any, List
 
-import serializer.tosa_serializer as ts
-
 import torch
+
+import tosa_serializer as ts
 
 from executorch.backends.arm._passes.fold_qdq_with_annotated_qparams_pass import (
     get_input_qparams,
@@ -100,10 +100,13 @@ class ConstantPadNDVisitor(NodeVisitor):
             shape=[1], dtype=pad_const_dtype, vals=[pad_const_val]
         )
 
+        attr = ts.TosaSerializerAttribute()
+        attr.PadAttribute()
         self._serialize_operator(
             node,
             tosa_graph,
-            ts.TosaOp.Op().PAD,
+            ts.Op.PAD,
             [inputs[0].name, padding.name, pad_const.name],
             [output.name],
+            attr,
         )

--- a/backends/arm/operators/op_cos.py
+++ b/backends/arm/operators/op_cos.py
@@ -6,7 +6,7 @@
 # pyre-unsafe
 from typing import List
 
-import serializer.tosa_serializer as ts
+import tosa_serializer as ts
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
     register_node_visitor,
@@ -43,7 +43,8 @@ class CosVisitor(NodeVisitor):
         validate_valid_dtype(
             self.target, [*inputs, output], ts.DType.FP32, output.tosa_spec
         )
-
+        attr = ts.TosaSerializerAttribute()
+        attr.CosAttribute()
         self._serialize_operator(
-            node, tosa_graph, ts.TosaOp.Op().COS, [inputs[0].name], [output.name]
+            node, tosa_graph, ts.Op.COS, [inputs[0].name], [output.name], attr
         )

--- a/backends/arm/operators/op_eq.py
+++ b/backends/arm/operators/op_eq.py
@@ -7,7 +7,7 @@
 
 from typing import Any, List
 
-import serializer.tosa_serializer as ts
+import tosa_serializer as ts
 
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
@@ -53,12 +53,13 @@ class EqualVisitor(NodeVisitor):
         )
         validate_valid_dtype(self.target, output, ts.DType.BOOL, output.tosa_spec)
 
-        # Do the equal comparison
+        attr = ts.TosaSerializerAttribute()
+        attr.EqualAttribute()
         self._serialize_operator(
             node,
             tosa_graph,
-            ts.TosaOp.Op().EQUAL,
+            ts.Op.EQUAL,
             [inputs[0].name, inputs[1].name],
             [output.name],
-            None,
+            attr,
         )

--- a/backends/arm/operators/op_erf.py
+++ b/backends/arm/operators/op_erf.py
@@ -5,9 +5,9 @@
 # pyre-unsafe
 from typing import Any, List
 
-import serializer.tosa_serializer as ts
-
 import torch.fx
+
+import tosa_serializer as ts
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
     register_node_visitor,
@@ -48,6 +48,8 @@ class ERFVisitor(NodeVisitor):
         )
 
         # MI lowering
+        attr = ts.TosaSerializerAttribute()
+        attr.ErfAttribute()
         self._serialize_operator(
-            node, tosa_graph, ts.TosaOp.Op().ERF, [inputs[0].name], [output.name]
+            node, tosa_graph, ts.Op.ERF, [inputs[0].name], [output.name], attr
         )

--- a/backends/arm/operators/op_exp.py
+++ b/backends/arm/operators/op_exp.py
@@ -6,7 +6,7 @@
 # pyre-unsafe
 from typing import Any, List
 
-import serializer.tosa_serializer as ts
+import tosa_serializer as ts
 
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
@@ -48,6 +48,8 @@ class ExpVisitor(NodeVisitor):
             output.tosa_spec,
         )
 
+        attr = ts.TosaSerializerAttribute()
+        attr.ExpAttribute()
         self._serialize_operator(
-            node, tosa_graph, ts.TosaOp.Op().EXP, [inputs[0].name], [output.name]
+            node, tosa_graph, ts.Op.EXP, [inputs[0].name], [output.name], attr
         )

--- a/backends/arm/operators/op_floor.py
+++ b/backends/arm/operators/op_floor.py
@@ -5,9 +5,9 @@
 
 from typing import Any, List
 
-import serializer.tosa_serializer as ts
-
 import torch.fx
+
+import tosa_serializer as ts
 
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
@@ -49,6 +49,8 @@ class FloorVisitor(NodeVisitor):
             output.tosa_spec,
         )
 
+        attr = ts.TosaSerializerAttribute()
+        attr.FloorAttribute()
         self._serialize_operator(
-            node, tosa_graph, ts.TosaOp.Op().FLOOR, [inputs[0].name], [output.name]
+            node, tosa_graph, ts.Op.FLOOR, [inputs[0].name], [output.name], attr
         )

--- a/backends/arm/operators/op_ge.py
+++ b/backends/arm/operators/op_ge.py
@@ -7,7 +7,7 @@
 
 from typing import Any, List
 
-import serializer.tosa_serializer as ts
+import tosa_serializer as ts
 
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
@@ -53,11 +53,13 @@ class GreaterEqualVisitor(NodeVisitor):
         )
         validate_valid_dtype(self.target, output, ts.DType.BOOL, output.tosa_spec)
 
+        attr = ts.TosaSerializerAttribute()
+        attr.GreaterEqualAttribute()
         self._serialize_operator(
             node,
             tosa_graph,
-            ts.TosaOp.Op().GREATER_EQUAL,
+            ts.Op.GREATER_EQUAL,
             [inputs[0].name, inputs[1].name],
             [output.name],
-            None,
+            attr,
         )

--- a/backends/arm/operators/op_gt.py
+++ b/backends/arm/operators/op_gt.py
@@ -7,7 +7,7 @@
 
 from typing import Any, List
 
-import serializer.tosa_serializer as ts
+import tosa_serializer as ts
 
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
@@ -53,11 +53,13 @@ class GreaterThanVisitor(NodeVisitor):
         )
         validate_valid_dtype(self.target, output, ts.DType.BOOL, output.tosa_spec)
 
+        attr = ts.TosaSerializerAttribute()
+        attr.GreaterAttribute()
         self._serialize_operator(
             node,
             tosa_graph,
-            ts.TosaOp.Op().GREATER,
+            ts.Op.GREATER,
             [inputs[0].name, inputs[1].name],
             [output.name],
-            None,
+            attr,
         )

--- a/backends/arm/operators/op_index_select.py
+++ b/backends/arm/operators/op_index_select.py
@@ -8,7 +8,7 @@
 from typing import Any, List
 
 import executorch.backends.arm.tosa.quant_utils as tqutils  # noqa: F401
-import serializer.tosa_serializer as ts
+import tosa_serializer as ts
 
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
@@ -84,13 +84,15 @@ class IndexSelectVisitor(NodeVisitor):
             tosa_graph, indices.name, indices_new_shape, indices_reshaped.name
         )
 
+        attr = ts.TosaSerializerAttribute()
+        attr.GatherAttribute()
         self._serialize_operator(
             node,
             tosa_graph,
-            ts.TosaOp.Op().GATHER,
+            ts.Op.GATHER,
             [weights_reshaped.name, indices_reshaped.name],
             [output_name],
-            None,
+            attr,
         )
 
         if len(weights.shape) == 2:

--- a/backends/arm/operators/op_le.py
+++ b/backends/arm/operators/op_le.py
@@ -7,7 +7,7 @@
 
 from typing import Any, List
 
-import serializer.tosa_serializer as ts
+import tosa_serializer as ts
 
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
@@ -53,11 +53,13 @@ class LessEqualVisitor(NodeVisitor):
         )
         validate_valid_dtype(self.target, output, ts.DType.BOOL, output.tosa_spec)
 
+        attr = ts.TosaSerializerAttribute()
+        attr.GreaterEqualAttribute()
         self._serialize_operator(
             node,
             tosa_graph,
-            ts.TosaOp.Op().GREATER_EQUAL,
+            ts.Op.GREATER_EQUAL,
             [inputs[1].name, inputs[0].name],
             [output.name],
-            None,
+            attr,
         )

--- a/backends/arm/operators/op_log.py
+++ b/backends/arm/operators/op_log.py
@@ -6,7 +6,7 @@
 # pyre-unsafe
 from typing import Any, List
 
-import serializer.tosa_serializer as ts
+import tosa_serializer as ts
 
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
@@ -44,7 +44,8 @@ class LogVisitor(NodeVisitor):
         validate_valid_dtype(
             self.target, [*inputs, output], ts.DType.FP32, output.tosa_spec
         )
-
+        attr = ts.TosaSerializerAttribute()
+        attr.LogAttribute()
         self._serialize_operator(
-            node, tosa_graph, ts.TosaOp.Op().LOG, [inputs[0].name], [output.name]
+            node, tosa_graph, ts.Op.LOG, [inputs[0].name], [output.name], attr
         )

--- a/backends/arm/operators/op_logical_not.py
+++ b/backends/arm/operators/op_logical_not.py
@@ -5,9 +5,9 @@
 
 from typing import Any, List
 
-import serializer.tosa_serializer as ts
-
 import torch.fx
+
+import tosa_serializer as ts
 
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
@@ -50,10 +50,13 @@ class LogicalNotVisitor(NodeVisitor):
             output.tosa_spec,
         )
 
+        attr = ts.TosaSerializerAttribute()
+        attr.LogicalNotAttribute()
         self._serialize_operator(
             node,
             tosa_graph,
-            ts.TosaOp.Op().LOGICAL_NOT,
+            ts.Op.LOGICAL_NOT,
             [inputs[0].name],
             [output.name],
+            attr,
         )

--- a/backends/arm/operators/op_lt.py
+++ b/backends/arm/operators/op_lt.py
@@ -7,7 +7,7 @@
 
 from typing import Any, List
 
-import serializer.tosa_serializer as ts
+import tosa_serializer as ts
 
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
@@ -53,11 +53,13 @@ class LessThanVisitor(NodeVisitor):
         )
         validate_valid_dtype(self.target, output, ts.DType.BOOL, output.tosa_spec)
 
+        attr = ts.TosaSerializerAttribute()
+        attr.GreaterAttribute()
         self._serialize_operator(
             node,
             tosa_graph,
-            ts.TosaOp.Op().GREATER,
+            ts.Op.GREATER,
             [inputs[1].name, inputs[0].name],
             [output.name],
-            None,
+            attr,
         )

--- a/backends/arm/operators/op_max_pool2d.py
+++ b/backends/arm/operators/op_max_pool2d.py
@@ -6,9 +6,9 @@
 # pyre-unsafe
 from typing import Any, List
 
-import serializer.tosa_serializer as ts
-
 import torch
+
+import tosa_serializer as ts
 
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
@@ -90,13 +90,16 @@ class MaxPool2dVisitor(NodeVisitor):
 
         attr = ts.TosaSerializerAttribute()
         attr.MaxPool2dAttribute(
-            kernel=kernel_size, stride=stride, pad=pad_size_list, nan_mode=1
+            kernel=kernel_size,
+            stride=stride,
+            pad=pad_size_list,
+            nan_mode=ts.NanPropagationMode.PROPAGATE,
         )
 
         self._serialize_operator(
             node,
             tosa_graph,
-            ts.TosaOp.Op().MAX_POOL2D,
+            ts.Op.MAX_POOL2D,
             [input_tensor.name],
             [output.name],
             attr,

--- a/backends/arm/operators/op_maximum.py
+++ b/backends/arm/operators/op_maximum.py
@@ -7,7 +7,7 @@
 
 from typing import Any, List
 
-import serializer.tosa_serializer as ts
+import tosa_serializer as ts
 
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
@@ -42,8 +42,6 @@ class MaxVisitor(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-        from tosa.NanPropagationMode import NanPropagationMode  # type: ignore
-
         validate_num_inputs(self.target, inputs, 2)
         validate_same_dtype(self.target, [*inputs, output], ts)
         validate_valid_dtype(
@@ -54,13 +52,12 @@ class MaxVisitor(NodeVisitor):
         )
 
         attr_maximum = ts.TosaSerializerAttribute()
-        # Set to PROPAGATE as default
-        attr_maximum.MaximumAttribute(nan_mode=NanPropagationMode.PROPAGATE)
+        attr_maximum.MaximumAttribute(nan_mode=ts.NanPropagationMode.PROPAGATE)
 
         self._serialize_operator(
             node,
             tosa_graph,
-            ts.TosaOp.Op().MAXIMUM,
+            ts.Op.MAXIMUM,
             [
                 inputs[0].name,
                 inputs[1].name,

--- a/backends/arm/operators/op_minimum.py
+++ b/backends/arm/operators/op_minimum.py
@@ -7,7 +7,7 @@
 
 from typing import Any, List
 
-import serializer.tosa_serializer as ts
+import tosa_serializer as ts
 
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
@@ -42,7 +42,6 @@ class MinVisitor(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-        from tosa.NanPropagationMode import NanPropagationMode  # type: ignore
 
         validate_num_inputs(self.target, inputs, 2)
         validate_same_dtype(self.target, [*inputs, output], ts)
@@ -54,13 +53,12 @@ class MinVisitor(NodeVisitor):
         )
 
         attr_minimum = ts.TosaSerializerAttribute()
-        # Set to PROPAGATE as default
-        attr_minimum.MinimumAttribute(nan_mode=NanPropagationMode.PROPAGATE)
+        attr_minimum.MinimumAttribute(nan_mode=ts.NanPropagationMode.PROPAGATE)
 
         self._serialize_operator(
             node,
             tosa_graph,
-            ts.TosaOp.Op().MINIMUM,
+            ts.Op.MINIMUM,
             [
                 inputs[0].name,
                 inputs[1].name,

--- a/backends/arm/operators/op_mul.py
+++ b/backends/arm/operators/op_mul.py
@@ -7,8 +7,9 @@
 
 from typing import Any, List
 
-import serializer.tosa_serializer as ts
 import torch
+
+import tosa_serializer as ts
 
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
@@ -49,8 +50,13 @@ class MulVisitor(NodeVisitor):
         )
 
         tosa_graph.addConst([1], ts.DType.INT8, 0, name=f"{node.name}_shift")
-        tosa_graph.addOperator(
-            ts.TosaOp.Op().MUL,
+        attr = ts.TosaSerializerAttribute()
+        attr.MulAttribute()
+        self._serialize_operator(
+            node,
+            tosa_graph,
+            ts.Op.MUL,
             [inputs[0].name, inputs[1].name, f"{node.name}_shift"],
             [output.name],
+            attr,
         )

--- a/backends/arm/operators/op_neg.py
+++ b/backends/arm/operators/op_neg.py
@@ -6,9 +6,9 @@
 # pyre-unsafe
 from typing import Any, List
 
-import serializer.tosa_serializer as ts
-
 import torch.fx
+
+import tosa_serializer as ts
 
 from executorch.backends.arm._passes.fold_qdq_with_annotated_qparams_pass import (
     get_input_qparams,
@@ -81,11 +81,13 @@ class NegVisitor(NodeVisitor):
         output_zp_tensor = tosa_graph.addConst(
             (1,), output.dtype, [output_zp], name=output.name + "_output_zp"
         )
-
+        attr = ts.TosaSerializerAttribute()
+        attr.NegateAttribute()
         self._serialize_operator(
             node,
             tosa_graph,
-            ts.TosaOp.Op().NEGATE,
+            ts.Op.NEGATE,
             [inputs[0].name, input_zp_tensor.name, output_zp_tensor.name],
             [output.name],
+            attr,
         )

--- a/backends/arm/operators/op_permute.py
+++ b/backends/arm/operators/op_permute.py
@@ -7,9 +7,9 @@
 
 from typing import Any, List
 
-import serializer.tosa_serializer as ts
-
 import torch
+
+import tosa_serializer as ts
 
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
@@ -138,7 +138,7 @@ class PermuteVisitor(NodeVisitor):
         self._serialize_operator(
             node,
             tosa_graph,
-            ts.TosaOp.Op().TRANSPOSE,
+            ts.Op.TRANSPOSE,
             [inputs[0].name],
             [output.name],
             attr,

--- a/backends/arm/operators/op_pow.py
+++ b/backends/arm/operators/op_pow.py
@@ -7,7 +7,7 @@
 
 from typing import Any, List
 
-import serializer.tosa_serializer as ts
+import tosa_serializer as ts
 
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
@@ -49,15 +49,16 @@ class PowVisitor(NodeVisitor):
             [ts.DType.FP16, ts.DType.FP32],
             output.tosa_spec,
         )
-
+        attr = ts.TosaSerializerAttribute()
+        attr.PowAttribute()
         self._serialize_operator(
             node,
             tosa_graph,
-            ts.TosaOp.Op().POW,
+            ts.Op.POW,
             [
                 inputs[0].name,
                 inputs[1].name,
             ],
             [output.name],
-            None,
+            attr,
         )

--- a/backends/arm/operators/op_reciprocal.py
+++ b/backends/arm/operators/op_reciprocal.py
@@ -6,9 +6,9 @@
 # pyre-unsafe
 from typing import Any, List
 
-import serializer.tosa_serializer as ts
-
 import torch
+
+import tosa_serializer as ts
 
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
@@ -45,7 +45,8 @@ class ReciprocalVisitor(NodeVisitor):
         validate_valid_dtype(
             self.target, [*inputs, output], ts.DType.FP32, output.tosa_spec
         )
-
+        attr = ts.TosaSerializerAttribute()
+        attr.ReciprocalAttribute()
         self._serialize_operator(
-            node, tosa_graph, ts.TosaOp.Op().RECIPROCAL, [inputs[0].name], [output.name]
+            node, tosa_graph, ts.Op.RECIPROCAL, [inputs[0].name], [output.name], attr
         )

--- a/backends/arm/operators/op_repeat.py
+++ b/backends/arm/operators/op_repeat.py
@@ -7,9 +7,9 @@
 
 from typing import Any
 
-import serializer.tosa_serializer as ts
-
 import torch
+
+import tosa_serializer as ts
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
     register_node_visitor,
@@ -60,11 +60,13 @@ class RepeatVisitor(NodeVisitor):
             name=node.name + "_multiples",
         )
 
+        attr = ts.TosaSerializerAttribute()
+        attr.TileAttribute()
         self._serialize_operator(
             node,
             tosa_graph,
-            ts.TosaOp.Op().TILE,
+            ts.Op.TILE,
             [inputs[0].name, multiple_shapes.name],
             [output.name],
-            None,
+            attr,
         )

--- a/backends/arm/operators/op_rshift_tensor.py
+++ b/backends/arm/operators/op_rshift_tensor.py
@@ -7,9 +7,9 @@
 
 from typing import Any, List
 
-import serializer.tosa_serializer as ts
-
 import torch
+
+import tosa_serializer as ts
 
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
@@ -56,7 +56,7 @@ class RshiftVisitor(NodeVisitor):
         self._serialize_operator(
             node,
             tosa_graph,
-            ts.TosaOp.Op().ARITHMETIC_RIGHT_SHIFT,
+            ts.Op.ARITHMETIC_RIGHT_SHIFT,
             [inputs[0].name, inputs[1].name],
             [output.name],
             attr,

--- a/backends/arm/operators/op_rsqrt.py
+++ b/backends/arm/operators/op_rsqrt.py
@@ -6,9 +6,9 @@
 # pyre-unsafe
 from typing import Any, List
 
-import serializer.tosa_serializer as ts
-
 import torch
+
+import tosa_serializer as ts
 
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
@@ -45,7 +45,8 @@ class RsqrtVisitor(NodeVisitor):
         validate_valid_dtype(
             self.target, [*inputs, output], ts.DType.FP32, output.tosa_spec
         )
-
+        attr = ts.TosaSerializerAttribute()
+        attr.RsqrtAttribute()
         self._serialize_operator(
-            node, tosa_graph, ts.TosaOp.Op().RSQRT, [inputs[0].name], [output.name]
+            node, tosa_graph, ts.Op.RSQRT, [inputs[0].name], [output.name], attr
         )

--- a/backends/arm/operators/op_sigmoid.py
+++ b/backends/arm/operators/op_sigmoid.py
@@ -6,7 +6,7 @@
 # pyre-unsafe
 from typing import Any, List
 
-import serializer.tosa_serializer as ts
+import tosa_serializer as ts
 
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
@@ -44,7 +44,8 @@ class SigmoidVisitor(NodeVisitor):
         validate_valid_dtype(
             self.target, [*inputs, output], ts.DType.FP32, output.tosa_spec
         )
-
+        attr = ts.TosaSerializerAttribute()
+        attr.SigmoidAttribute()
         self._serialize_operator(
-            node, tosa_graph, ts.TosaOp.Op().SIGMOID, [inputs[0].name], [output.name]
+            node, tosa_graph, ts.Op.SIGMOID, [inputs[0].name], [output.name], attr
         )

--- a/backends/arm/operators/op_sin.py
+++ b/backends/arm/operators/op_sin.py
@@ -6,7 +6,7 @@
 # pyre-unsafe
 from typing import List
 
-import serializer.tosa_serializer as ts
+import tosa_serializer as ts
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
     register_node_visitor,
@@ -43,7 +43,8 @@ class SinVisitor(NodeVisitor):
         validate_valid_dtype(
             self.target, [*inputs, output], ts.DType.FP32, output.tosa_spec
         )
-
+        attr = ts.TosaSerializerAttribute()
+        attr.SinAttribute()
         self._serialize_operator(
-            node, tosa_graph, ts.TosaOp.Op().SIN, [inputs[0].name], [output.name]
+            node, tosa_graph, ts.Op.SIN, [inputs[0].name], [output.name], attr
         )

--- a/backends/arm/operators/op_sub.py
+++ b/backends/arm/operators/op_sub.py
@@ -9,7 +9,7 @@ from typing import Any, List
 
 import executorch.backends.arm.tosa.quant_utils as tqutils
 import executorch.backends.arm.tosa.utils as tutils
-import serializer.tosa_serializer as ts
+import tosa_serializer as ts
 
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
@@ -76,16 +76,18 @@ class SubVisitor_INT(NodeVisitor):
             sub_output = output
 
         # Do the INT32 Sub
+        attr = ts.TosaSerializerAttribute()
+        attr.SubAttribute()
         self._serialize_operator(
             node,
             tosa_graph,
-            ts.TosaOp.Op().SUB,
+            ts.Op.SUB,
             [
                 rescaled_inputs[0].name,
                 rescaled_inputs[1].name,
             ],
             [sub_output.name],
-            None,
+            attr,
         )
 
         if output.dtype == ts.DType.INT8:
@@ -139,11 +141,13 @@ class SubVisitor_FP(SubVisitor_INT):
             )
 
             # MI lowering
+            attr = ts.TosaSerializerAttribute()
+            attr.SubAttribute()
             self._serialize_operator(
                 node,
                 tosa_graph,
-                ts.TosaOp.Op().SUB,
+                ts.Op.SUB,
                 [inputs[0].name, inputs[1].name],
                 [output.name],
-                None,
+                attr,
             )

--- a/backends/arm/operators/op_sum.py
+++ b/backends/arm/operators/op_sum.py
@@ -9,7 +9,7 @@ from typing import Any, List
 
 import executorch.backends.arm.tosa.quant_utils as tqutils
 import executorch.backends.arm.tosa.utils as tutils
-import serializer.tosa_serializer as ts
+import tosa_serializer as ts
 
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
@@ -68,7 +68,7 @@ class SumVisitor_INT(NodeVisitor):
         self._serialize_operator(
             node,
             tosa_graph,
-            ts.TosaOp.Op().REDUCE_SUM,
+            ts.Op.REDUCE_SUM,
             [rescaled_inputs[0].name],
             [intermediate.name],
             attr,
@@ -111,7 +111,7 @@ class SumVisitor_FP(SumVisitor_INT):
         self._serialize_operator(
             node,
             tosa_graph,
-            ts.TosaOp.Op().REDUCE_SUM,
+            ts.Op.REDUCE_SUM,
             [tensor.name],
             [output.name],
             attr,

--- a/backends/arm/operators/op_tanh.py
+++ b/backends/arm/operators/op_tanh.py
@@ -6,7 +6,7 @@
 # pyre-unsafe
 from typing import Any, List
 
-import serializer.tosa_serializer as ts
+import tosa_serializer as ts
 
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
@@ -45,7 +45,8 @@ class TanhVisitor(NodeVisitor):
         validate_valid_dtype(
             self.target, [*inputs, output], ts.DType.FP32, output.tosa_spec
         )
-
+        attr = ts.TosaSerializerAttribute()
+        attr.TanhAttribute()
         self._serialize_operator(
-            node, tosa_graph, ts.TosaOp.Op().TANH, [inputs[0].name], [output.name]
+            node, tosa_graph, ts.Op.TANH, [inputs[0].name], [output.name], attr
         )

--- a/backends/arm/operators/op_to_dim_order_copy.py
+++ b/backends/arm/operators/op_to_dim_order_copy.py
@@ -6,9 +6,9 @@
 # pyre-unsafe
 from typing import Any, List
 
-import serializer.tosa_serializer as ts
-
 import torch
+
+import tosa_serializer as ts
 
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
@@ -43,7 +43,8 @@ class ToDimOrderCopyVisitor(NodeVisitor):
         output: TosaArg,
     ) -> None:
         validate_num_inputs(self.target, inputs, 1)
-
+        attr = ts.TosaSerializerAttribute()
+        attr.CastAttribute()
         self._serialize_operator(
-            node, tosa_graph, ts.TosaOp.Op().CAST, [inputs[0].name], [output.name]
+            node, tosa_graph, ts.Op.CAST, [inputs[0].name], [output.name], attr
         )

--- a/backends/arm/operators/op_tosa_conv2d.py
+++ b/backends/arm/operators/op_tosa_conv2d.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 # pyre-unsafe
-import serializer.tosa_serializer as ts
+import tosa_serializer as ts
 
 """Provide a visitor for lowering 2D convolution to TOSA (INT/FP)."""
 
@@ -46,9 +46,7 @@ class Conv2dVisitor(NodeVisitor):
         super().__init__(*args)
 
     def _get_tosa_op(self):
-        import serializer.tosa_serializer as ts  # type: ignore
-
-        return ts.TosaOp.Op().CONV2D
+        return ts.Op.CONV2D
 
     def _get_attr_func(self, attr):
         return attr.Conv2dAttribute
@@ -61,8 +59,6 @@ class Conv2dVisitor(NodeVisitor):
         output: TosaArg,
     ) -> None:
         """Define the TOSA CONV2D/DEPTHWISE_CONV2D operator and post-rescale."""
-        from tosa.RoundingMode import RoundingMode  # type: ignore
-
         input, weight, bias, stride, pad, dilation, _, _, group = inputs
         validate_num_inputs(self.target, inputs, 9)
 
@@ -193,5 +189,5 @@ class Conv2dVisitor(NodeVisitor):
                 input_zp=[0],
                 output_zp=[output_qargs[0].get_zp_per_tensor()],
                 per_channel=per_channel_quant,
-                rounding_mode=RoundingMode.SINGLE_ROUND,
+                rounding_mode=ts.RoundingMode.SINGLE_ROUND,
             )

--- a/backends/arm/operators/op_tosa_depthwise_conv2d.py
+++ b/backends/arm/operators/op_tosa_depthwise_conv2d.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 # pyre-unsafe
+import tosa_serializer as ts
 from executorch.backends.arm.operators.node_visitor import register_node_visitor
 from executorch.backends.arm.operators.op_tosa_conv2d import Conv2dVisitor
 from executorch.backends.arm.tosa import TosaSpecification
@@ -21,9 +22,7 @@ class DepthwiseConv2dVisitor(Conv2dVisitor):
     ]
 
     def _get_tosa_op(self):
-        import serializer.tosa_serializer as ts  # type: ignore
-
-        return ts.TosaOp.Op().DEPTHWISE_CONV2D
+        return ts.Op.DEPTHWISE_CONV2D
 
     def _get_attr_func(self, attr):
         return attr.DepthwiseConv2dAttribute

--- a/backends/arm/operators/op_tosa_rescale.py
+++ b/backends/arm/operators/op_tosa_rescale.py
@@ -7,9 +7,9 @@
 
 from typing import Any, cast, List
 
-import serializer.tosa_serializer as ts
-
 import torch
+
+import tosa_serializer as ts
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
     register_node_visitor,
@@ -37,8 +37,6 @@ class RescaleVisitor(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-        from tosa.RoundingMode import RoundingMode  # type: ignore
-
         validate_num_inputs(self.target, inputs, 5)
 
         input_dtype = inputs[0].dtype
@@ -71,6 +69,6 @@ class RescaleVisitor(NodeVisitor):
             output_type=output.dtype,
             input_zp=[input_zp],
             output_zp=[output_zp],
-            rounding_mode=RoundingMode.SINGLE_ROUND,
+            rounding_mode=ts.RoundingMode.SINGLE_ROUND,
             per_channel=False,
         )

--- a/backends/arm/operators/op_tosa_resize.py
+++ b/backends/arm/operators/op_tosa_resize.py
@@ -6,9 +6,9 @@
 # pyre-unsafe
 from typing import Any, List
 
-import serializer.tosa_serializer as ts
-
 import torch
+
+import tosa_serializer as ts
 
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
@@ -21,8 +21,6 @@ from executorch.backends.arm.operators.operator_validation_utils import (
 )
 from executorch.backends.arm.tosa.mapping import TosaArg
 from executorch.backends.arm.tosa.utils import get_resize_parameters
-
-from tosa.ResizeMode import ResizeMode  # type: ignore
 
 
 @register_node_visitor
@@ -43,10 +41,10 @@ class ResizeVisitor(NodeVisitor):
     ) -> None:
         validate_num_inputs(self.target, inputs, [3, 4])
         if node.kwargs.get("resize_mode") == "bilinear":
-            resize_mode = ResizeMode.BILINEAR
+            resize_mode = ts.ResizeMode.BILINEAR
             align_corners = bool(node.args[2])
         else:
-            resize_mode = ResizeMode.NEAREST
+            resize_mode = ts.ResizeMode.NEAREST
             align_corners = False
             validate_same_dtype(self.target, [inputs[0], output], ts)
         validate_valid_dtype(
@@ -78,27 +76,32 @@ class ResizeVisitor(NodeVisitor):
         if not in_int16_range(border_yx):
             raise ValueError("border_yx is out of the int16 range")
 
-        scales = [scale_n_yx[0], scale_d_yx[0], scale_n_yx[1], scale_d_yx[1]]
+        scale_n_vals = [int(v) for v in scale_n_yx.tolist()]
+        scale_d_vals = [int(v) for v in scale_d_yx.tolist()]
+        scales = [
+            scale_n_vals[0],
+            scale_d_vals[0],
+            scale_n_vals[1],
+            scale_d_vals[1],
+        ]
         scales_tensor = tosa_graph.addConst(
             [len(scales)], ts.DType.SHAPE, scales, node.name + "_scales"
         )
-        offset = offset_yx.tolist()
+        offset = [int(v) for v in offset_yx.tolist()]
         offset_tensor = tosa_graph.addConst(
             [len(offset)], ts.DType.SHAPE, offset, node.name + "_offset"
         )
-        border = border_yx.tolist()
+        border = [int(v) for v in border_yx.tolist()]
         border_tensor = tosa_graph.addConst(
             [len(border)], ts.DType.SHAPE, border, node.name + "_border"
         )
         attr = ts.TosaSerializerAttribute()
-        attr.ResizeAttribute(
-            mode=resize_mode,
-        )
+        attr.ResizeAttribute(resize_mode)
 
         self._serialize_operator(
             node,
             tosa_graph,
-            ts.TosaOp.Op().RESIZE,
+            ts.Op.RESIZE,
             [
                 inputs[0].name,
                 scales_tensor.name,

--- a/backends/arm/operators/op_tosa_table.py
+++ b/backends/arm/operators/op_tosa_table.py
@@ -7,9 +7,9 @@
 
 from typing import Any, List
 
-import serializer.tosa_serializer as ts
-
 import torch
+
+import tosa_serializer as ts
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
     register_node_visitor,
@@ -59,12 +59,13 @@ class TableVisitor(NodeVisitor):
             table.detach().numpy(),
             name=table_tensor_name,
         )
-
+        attr = ts.TosaSerializerAttribute()
+        attr.TableAttribute()
         self._serialize_operator(
             node,
             tosa_graph,
-            ts.TosaOp.Op().TABLE,
+            ts.Op.TABLE,
             [inputs[0].name, table_tensor_name],
             [output.name],
-            None,
+            attr,
         )

--- a/backends/arm/operators/op_tosa_transpose.py
+++ b/backends/arm/operators/op_tosa_transpose.py
@@ -7,9 +7,9 @@
 
 from typing import Any, List
 
-import serializer.tosa_serializer as ts
-
 import torch
+
+import tosa_serializer as ts
 
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
@@ -65,7 +65,7 @@ class TransposeVisitor(NodeVisitor):
         self._serialize_operator(
             node,
             tosa_graph,
-            ts.TosaOp.Op().TRANSPOSE,
+            ts.Op.TRANSPOSE,
             [inputs[0].name],
             [output.name],
             attr,

--- a/backends/arm/operators/op_view.py
+++ b/backends/arm/operators/op_view.py
@@ -6,9 +6,9 @@
 # pyre-unsafe
 from typing import Any, cast, List
 
-import serializer.tosa_serializer as ts
-
 import torch
+
+import tosa_serializer as ts
 
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
@@ -75,7 +75,7 @@ class ViewVisitor(NodeVisitor):
         self._serialize_operator(
             node,
             tosa_graph,
-            ts.TosaOp.Op().RESHAPE,
+            ts.Op.RESHAPE,
             [inputs[0].name, shape.name],
             [output.name],
             attr,

--- a/backends/arm/operators/op_where.py
+++ b/backends/arm/operators/op_where.py
@@ -5,7 +5,7 @@
 
 from typing import Any, List, Sequence
 
-import serializer.tosa_serializer as ts
+import tosa_serializer as ts
 
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
@@ -53,13 +53,15 @@ class WhereVisitor_INT(NodeVisitor):
             output.tosa_spec,
         )
 
+        attr = ts.TosaSerializerAttribute()
+        attr.SelectAttribute()
         self._serialize_operator(
             node,
             tosa_graph,
-            ts.TosaOp.Op().SELECT,
+            ts.Op.SELECT,
             [inputs[0].name, inputs[1].name, inputs[2].name],
             [output.name],
-            None,
+            attr,
         )
 
     def define_node(

--- a/backends/arm/operators/operator_validation_utils.py
+++ b/backends/arm/operators/operator_validation_utils.py
@@ -6,8 +6,6 @@
 from math import ceil, floor
 from typing import Any, List, Optional
 
-import serializer.tosa_serializer as ts
-
 
 def validate_num_inputs(op_name: str, inputs: List[Any], expected: int | List[int]):
     """
@@ -98,18 +96,14 @@ def validate_same_dtype(op_name: str, tensors: List[Any], ts: Optional[Any] = No
 
     # Get dtype of the first tensor to reference for comparison
     reference_dtype = tensors[0].dtype
+    reference_dtype_name = str(reference_dtype)
 
     for tensor in tensors:
-        ref_dtype_name = (
-            ts.DTypeNames[reference_dtype] if ts is not None else str(reference_dtype)
-        )
-        inconsistent_dtype_name = (
-            ts.DTypeNames[tensor.dtype] if ts is not None else str(tensor.dtype)
-        )
         if tensor.dtype != reference_dtype:
+            inconsistent_dtype_name = str(tensor.dtype)
             raise ValueError(
-                f"{op_name}: Expected all tensors to have dtype {ref_dtype_name}, but "
-                f"found inconsistent dtype {inconsistent_dtype_name}."
+                f"{op_name}: Expected all tensors to have dtype {reference_dtype_name}, "
+                f"but found inconsistent dtype {inconsistent_dtype_name}."
             )
 
 
@@ -171,10 +165,11 @@ def validate_valid_dtype(
 
     for tensor in tensors:
         if tensor.dtype not in valid_dtypes:
+            valid_names = [str(dtype) for dtype in valid_dtypes]
+            got_name = str(tensor.dtype)
             raise ValueError(
                 f"Expected tensor {tensor.name} in {op_name} to have one of the "
-                f"following dtypes: {[ts.DTypeNames[i] for i in valid_dtypes]}, "
-                f"got: {ts.DTypeNames[tensor.dtype]}"
+                f"following dtypes: {valid_names}, got: {got_name}"
             )
 
 

--- a/backends/arm/operators/ops_identity.py
+++ b/backends/arm/operators/ops_identity.py
@@ -7,10 +7,10 @@
 
 from typing import Any, List
 
-import serializer.tosa_serializer as ts
-
 import torch
 import torch.fx
+
+import tosa_serializer as ts
 
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
@@ -45,12 +45,15 @@ def identity_operator_factory(identity_target: str):
             validate_same_dtype(self.target, [*inputs, output], ts)
 
             # Simply add an identityOp
+            attr = ts.TosaSerializerAttribute()
+            attr.IdentityAttribute()
             self._serialize_operator(
                 node,
                 tosa_graph,
-                ts.TosaOp.Op().IDENTITY,
+                ts.Op.IDENTITY,
                 [inputs[0].name],
                 [output.name],
+                attr,
             )
 
     register_node_visitor(IdentityOperatorVisitor)

--- a/backends/arm/process_node.py
+++ b/backends/arm/process_node.py
@@ -8,9 +8,9 @@
 from typing import Any, cast, Dict
 
 import numpy as np
-import serializer.tosa_serializer as ts
 import torch
 import torch.fx
+import tosa_serializer as ts
 from executorch.backends.arm.operators.node_visitor import NodeVisitor
 from executorch.backends.arm.tosa.mapping import TosaArg, TosaSpecialDtype
 from executorch.backends.arm.tosa.specification import TosaSpecification
@@ -85,7 +85,6 @@ def process_inputs(
         tosa_shape(input_shape, input_dim_order),
         tosa_arg.dtype,
         data=None,
-        placeholderFilename=tosa_arg.name + ".npy",
     )
     tosa_graph.addInputTensor(tensor)
 

--- a/backends/arm/requirements-arm-tosa.txt
+++ b/backends/arm/requirements-arm-tosa.txt
@@ -7,5 +7,3 @@ ml_dtypes == 0.5.1
 flatbuffers == 24.3.25
 tosa-adapter-model-explorer == 0.0.1
 ai-edge-model-explorer >= 0.1.16
-
-tosa-tools @ git+https://git.gitlab.arm.com/tosa/tosa-reference-model.git@v2025.07.1

--- a/backends/arm/test/models/test_llama.py
+++ b/backends/arm/test/models/test_llama.py
@@ -111,9 +111,12 @@ def test_llama_tosa_FP():
             llama_inputs,
             aten_op=[],
             exir_op=[],
+            custom_path="llama_tosa_fb",
+            run_on_tosa_ref_model=False,  # Just want to write TOSA FB to disk
             use_to_edge_transform_and_lower=True,
             transform_passes=[InsertInt32CastsAfterInt64PlaceholdersPass()],
         )
+        pipeline.add_stage_after("to_executorch", pipeline.tester.serialize)
         pipeline.run()
 
 
@@ -129,8 +132,11 @@ def test_llama_tosa_INT():
             llama_inputs,
             aten_op=[],
             exir_op=[],
+            custom_path="llama_tosa_fb_int",
+            run_on_tosa_ref_model=False,  # Just want to write TOSA FB to disk
             use_to_edge_transform_and_lower=True,
         )
+        pipeline.add_stage_after("to_executorch", pipeline.tester.serialize)
         pipeline.run()
 
 
@@ -150,6 +156,7 @@ def test_llama_vgf_FP():
             tosa_version="TOSA-1.0+FP",
             use_to_edge_transform_and_lower=True,
             transform_passes=[InsertInt32CastsAfterInt64PlaceholdersPass()],
+            run_on_vulkan_runtime=True,
         )
         pipeline.run()
 
@@ -169,5 +176,6 @@ def test_llama_vgf_INT():
             exir_op=[],
             tosa_version="TOSA-1.0+INT",
             use_to_edge_transform_and_lower=True,
+            run_on_vulkan_runtime=True,
         )
         pipeline.run()

--- a/backends/arm/test/tester/arm_tester.py
+++ b/backends/arm/test/tester/arm_tester.py
@@ -24,10 +24,11 @@ from typing import (
 
 import executorch.backends.xnnpack.test.tester.tester as tester
 
-import serializer.tosa_serializer as ts
-
 import torch.fx
 import torch.utils._pytree as pytree
+
+import tosa_serializer as ts
+
 from executorch.backends.arm._passes.arm_pass_manager import ArmPassManager
 
 from executorch.backends.arm.common.arm_compile_spec import ArmCompileSpec

--- a/backends/arm/tosa/mapping.py
+++ b/backends/arm/tosa/mapping.py
@@ -14,9 +14,8 @@ the TOSA serializer types and shapes used during initial compilation.
 from enum import Enum
 from typing import Any, Optional, Sequence
 
-import serializer.tosa_serializer as ts
-
 import torch
+import tosa_serializer as ts
 from executorch.backends.arm.tosa.specification import TosaSpecification
 
 UNSUPPORTED_DTYPES = (
@@ -40,7 +39,7 @@ class TosaSpecialDtype(Enum):
 
     INT48 = ts.DType.INT48
 
-    def get_tosa_dtype(self) -> ts.TosaDType.DType:
+    def get_tosa_dtype(self) -> ts.DType:
         return self.value
 
     @staticmethod

--- a/backends/arm/tosa/quant_utils.py
+++ b/backends/arm/tosa/quant_utils.py
@@ -11,8 +11,7 @@ import math
 
 from typing import Any, Tuple
 
-import serializer.tosa_serializer as ts
-
+import tosa_serializer as ts
 from executorch.backends.arm._passes.fold_qdq_with_annotated_qparams_pass import (
     get_input_qparams,
     get_output_qparams,
@@ -20,8 +19,6 @@ from executorch.backends.arm._passes.fold_qdq_with_annotated_qparams_pass import
 
 from executorch.backends.arm.tosa.mapping import TosaArg
 from torch.fx import Node
-
-from tosa.RoundingMode import RoundingMode  # type: ignore
 
 
 def insert_rescale_ops_to_int32_maxscale(
@@ -371,12 +368,10 @@ def build_rescale(
     output_type: Any,
     input_zp: list[int],
     output_zp: list[int],
-    rounding_mode: RoundingMode,
-    per_channel=False,
+    rounding_mode: ts.RoundingMode,
+    per_channel: bool = False,
+    is_scale32: bool = True,
 ):
-
-    import tosa.Op as TosaOp  # type: ignore
-
     scaleWidth = 16 if input_node.dtype == ts.DType.INT48 else 32
     is_scale32 = False if input_node.dtype == ts.DType.INT48 else True
     multipliers, shifts = compute_multiplier_and_shift(scale, scaleWidth)
@@ -402,7 +397,7 @@ def build_rescale(
     )
 
     tosa_fb.addOperator(
-        TosaOp.Op().RESCALE,
+        ts.Op.RESCALE,
         [input_node.name, *rescale_inputs],
         [output_name],
         attr_rescale,
@@ -433,7 +428,7 @@ def build_rescale_to_int32(
         ts.DType.INT32,
         [input_zp],
         [0],
-        rounding_mode=RoundingMode.SINGLE_ROUND,
+        rounding_mode=ts.RoundingMode.SINGLE_ROUND,
     )  # type: ignore[call-arg]
 
     return input_A_rescaled_to_int32
@@ -501,7 +496,7 @@ def build_rescale_from_int32_to_dtype(
         output_type=output_dtype,
         input_zp=[0],
         output_zp=[output_zp],
-        rounding_mode=RoundingMode.SINGLE_ROUND,
+        rounding_mode=ts.RoundingMode.SINGLE_ROUND,
     )  # type: ignore[call-arg]
 
     return

--- a/backends/arm/tosa/utils.py
+++ b/backends/arm/tosa/utils.py
@@ -9,11 +9,11 @@ import logging
 from typing import Any
 
 import numpy as np
-import serializer.tosa_serializer as ts
 
 import sympy  # type: ignore
 
 import torch
+import tosa_serializer as ts
 
 from executorch.backends.arm.tosa.mapping import extract_tensor_meta
 from executorch.backends.arm.tosa.specification import TosaSpecification
@@ -121,11 +121,13 @@ def broadcast_tensors(
             name=f"{node.name}_multiples",
         )
 
+        attr = ts.TosaSerializerAttribute()
+        attr.TileAttribute()
         tosa_fb.addOperator(
-            ts.TosaOp.Op().TILE,
+            ts.Op.TILE,
             [reshaped.name, multiple_shapes.name],
             [tiled.name],
-            None,
+            attr,
         )
 
         broadcast_tensors.append(tiled)
@@ -146,7 +148,7 @@ def build_reshape_tosa_1_0(
     attr = ts.TosaSerializerAttribute()
     attr.ReshapeAttribute()
     tosa_graph.addOperator(
-        ts.TosaOp.Op().RESHAPE,
+        ts.Op.RESHAPE,
         [input_name, shape.name],
         [output_name],
         attr,
@@ -160,7 +162,7 @@ def tosa_shape(shape, dim_order):
     removed_symints = tuple(
         [-1 if isinstance(d, torch.SymInt) else d for d in reordered]
     )
-    return removed_symints
+    return list(removed_symints)
 
 
 def get_resize_parameters_1d(

--- a/backends/arm/vgf/backend.py
+++ b/backends/arm/vgf/backend.py
@@ -112,7 +112,7 @@ def vgf_compile(
                 Stdout:\n{process_error.stdout.decode()}"
             )
 
-        if artifact_path is not None:
+        if artifact_path:
             logger.info(f"Emitting debug output to: {vgf_path=}")
             os.makedirs(artifact_path, exist_ok=True)
             cp = f"cp {vgf_path} {artifact_path}"


### PR DESCRIPTION
 These bindings should drastically increase serialization
 performance, both speed wise and memory usage wise.

 This patch also enables serialization of tosa flatbuffers
 that are over 2GB in size.

 - Ensure each tosa operator has an attribute.
 - Replace TosaOp.Op() calls with Op enum
 - Convert tosa clamp data to numpy int8 to allow c++ byte serialization
 - Replace "import tosa_serializer.serializer" with "import tosa_serializer" for pybind
 - Remove serialize to json.
 - Remove Darwin support workaround in mlsdk dependencies
 - Update mlsdk to latest tag, but overwrite the tosa_mlir_translator to a version that supports offset buffers
 - Update tosa-tools to the monorepo
 - Update slice to clamp end and start dim. This avoids the object not having a number field from being too large or small.

Change-Id: Id03582b6b7b9eef296480f9ea3a4744a08b22603

cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai