### PR TITLE
clean unnecessary CMAKE_ARGS="-DEXECUTORCH_BUILD_CUDA=ON" (#15350)

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -255,7 +255,7 @@ jobs:
         set -eux
 
         echo "::group::Setup ExecuTorch Requirements"
-        CMAKE_ARGS="-DEXECUTORCH_BUILD_CUDA=ON" ./install_requirements.sh
+        ./install_requirements.sh
         pip list
         echo "::endgroup::"
 
@@ -305,7 +305,7 @@ jobs:
         set -eux
 
         echo "::group::Setup ExecuTorch Requirements"
-        CMAKE_ARGS="-DEXECUTORCH_BUILD_CUDA=ON" ./install_requirements.sh
+        ./install_requirements.sh
         pip list
         echo "::endgroup::"
 
@@ -363,7 +363,7 @@ jobs:
         set -eux
 
         echo "::group::Setup ExecuTorch Requirements"
-        CMAKE_ARGS="-DEXECUTORCH_BUILD_CUDA=ON" ./install_requirements.sh
+        ./install_requirements.sh
         pip list
         echo "::endgroup::"
 

--- a/examples/models/voxtral/README.md
+++ b/examples/models/voxtral/README.md
@@ -132,7 +132,7 @@ cmake -DCMAKE_INSTALL_PREFIX=cmake-out -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Re
 ### Building for CUDA
 ```
 # Install ExecuTorch with CUDA support
-CMAKE_ARGS="-DEXECUTORCH_BUILD_CUDA=ON" ./install_executorch.sh
+./install_executorch.sh
 
 # Build the multimodal runner with CUDA
 cmake --preset llm \


### PR DESCRIPTION
Summary:

we no longer need this arg for et installation. clean it to avoid misleading.

Reviewed By: larryliu0820

Differential Revision: D85223111
