### PR TITLE
Move ReplaceScalarWithTensorArgPass, to the common section.

### DIFF
--- a/backends/cadence/aot/replace_ops.py
+++ b/backends/cadence/aot/replace_ops.py
@@ -2106,6 +2106,7 @@ class ReplaceTorchQuantizedEmbeddingWithCadenceQuantizedEmbedding(ExportPass):
 
 class CommonReplacePasses:
     passes = [
+        ReplaceScalarWithTensorArgPass,
         ReplaceSqueezeAndUnsqueezeWithViewPass,
         ReplaceSplitWithSlicePass,
         ReplaceSelectWithViewOpPass,
@@ -2143,7 +2144,6 @@ class CadenceReplaceOpsInGraph:
         ReplaceEmptyTensorsWithFullPass,
         ReplaceFunctionallyEquivalentOpTargets,
         ReplacePermuteWithTransposePass,
-        ReplaceScalarWithTensorArgPass,
         ReplaceConvolutionOptionalArgsWithConcreteArgsPass,
         ReplaceAddMMWithLinearPass,
         RemoveNopSelectOpPass,


### PR DESCRIPTION
Summary:
This diff reverts D83184528 by moving the ReplaceScalarWithTensorArgPass to the common section between helios and jarvis.

The mul.Scalar op is used in MTL models and Michael Maitland  caught a performance degradation:
With mul.Scalar: P2003182852
vs without mul.Scalar P2003196850

Reviewed By: michaelmaitland, mcremon-meta

Differential Revision: D85256050


