### PR TITLE
Add check for negative index in cpu kernel op_index

### DIFF
--- a/kernels/portable/cpu/op_index.cpp
+++ b/kernels/portable/cpu/op_index.cpp
@@ -1,11 +1,13 @@
 /*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  * All rights reserved.
+ * Copyright 2025 Arm Limited and/or its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <algorithm>
 #include <cinttypes>
 #include <cstdint>
 #include <cstring>
@@ -46,6 +48,23 @@ bool check_fast_path_conditions(
       // Fast path only supports a 1-dimensional index tensor
       if (index.dim() != 1) {
         return false;
+      }
+
+      // Fast path only supports non-negative indices.
+      if (ix_type == ScalarType::Int) {
+        const int32_t* const data = index.const_data_ptr<int32_t>();
+        if (std::any_of(data, data + index.numel(), [](const auto x) {
+              return x < 0;
+            })) {
+          return false;
+        }
+      } else { // ScalarType::Long
+        const int64_t* const data = index.const_data_ptr<int64_t>();
+        if (std::any_of(data, data + index.numel(), [](const auto x) {
+              return x < 0;
+            })) {
+          return false;
+        }
       }
     }
   }

--- a/kernels/test/op_index_test.cpp
+++ b/kernels/test/op_index_test.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  * All rights reserved.
+ * Copyright 2025 Arm Limited and/or its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
@@ -478,6 +479,36 @@ TEST_F(OpIndexTensorOutTest, AllDtypesSupportedForInput) {
 TEST_F(OpIndexTensorOutTest, AllDtypesSupportedForIndex) {
   test_dtype<ScalarType::Double, ScalarType::Long, ScalarType::Double>();
   test_dtype<ScalarType::Double, ScalarType::Int, ScalarType::Double>();
+}
+
+TEST_F(OpIndexTensorOutTest, NegativeIndexSupportedForLong) {
+  TensorFactory<ScalarType::Float> tf;
+  TensorFactory<ScalarType::Long> tfl;
+
+  Tensor x = tf.make({3}, {1., 2., 3.});
+  Tensor out = tf.zeros({1});
+  Tensor expected = tf.make({1}, {3.});
+
+  std::array<optional<Tensor>, 1> indices = {
+      optional<Tensor>(tfl.make({1}, {-1}))};
+
+  Tensor ret = op_index_tensor_out(x, indices, out);
+  EXPECT_TENSOR_EQ(ret, expected);
+}
+
+TEST_F(OpIndexTensorOutTest, NegativeIndexSupportedForInt) {
+  TensorFactory<ScalarType::Float> tf;
+  TensorFactory<ScalarType::Int> tfi;
+
+  Tensor x = tf.make({3}, {1., 2., 3.});
+  Tensor out = tf.zeros({1});
+  Tensor expected = tf.make({1}, {3.});
+
+  std::array<optional<Tensor>, 1> indices = {
+      optional<Tensor>(tfi.make({1}, {-1}))};
+
+  Tensor ret = op_index_tensor_out(x, indices, out);
+  EXPECT_TENSOR_EQ(ret, expected);
 }
 
 //


### PR DESCRIPTION
Fast path cannot be taken when the index is negative in op_index. It results in a failure in `check_fast_path_args`. Add a check to `check_fast_path_conditions` for negative index and return `false` if one is encountered.

cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai