### PR TITLE
Arm backend: Remove pyre-unsafe from quantizer/ & backends/arm

### DIFF
--- a/backends/arm/arm_vela.py
+++ b/backends/arm/arm_vela.py
@@ -3,7 +3,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# pyre-unsafe
 
 import os
 import struct

--- a/backends/arm/process_node.py
+++ b/backends/arm/process_node.py
@@ -4,7 +4,6 @@
 # LICENSE file in the root directory of this source tree.
 #
 
-# pyre-unsafe
 from typing import Any, cast, Dict
 
 import numpy as np

--- a/backends/arm/quantizer/arm_quantizer.py
+++ b/backends/arm/quantizer/arm_quantizer.py
@@ -5,7 +5,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# pyre-unsafe
 
 #
 # Quantizer for Arm backend

--- a/backends/arm/quantizer/arm_quantizer_utils.py
+++ b/backends/arm/quantizer/arm_quantizer_utils.py
@@ -5,7 +5,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# pyre-unsafe
 """Provide utilities for quantization annotations.
 
 Use these helpers to check and mark annotation state when working with

--- a/backends/arm/quantizer/quantization_config.py
+++ b/backends/arm/quantizer/quantization_config.py
@@ -11,7 +11,6 @@ quantization specs consumed by the annotator.
 
 """
 
-# pyre-unsafe
 
 from dataclasses import dataclass
 


### PR DESCRIPTION
Pyre is no longer used.


cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai