### PR TITLE
llm/custom_ops: follow test code conventions

### DIFF
--- a/extension/llm/custom_ops/test_sdpa_with_kv_cache.py
+++ b/extension/llm/custom_ops/test_sdpa_with_kv_cache.py
@@ -282,7 +282,7 @@ class SDPAWithCausalTest(SDPATest):
         self.is_causal = True
 
 
-class SDPAWithDynamicShape(unittest.TestCase):
+class SDPAWithDynamicShapeTest(unittest.TestCase):
 
     def setUp(self):
         torch.manual_seed(42)


### PR DESCRIPTION
Summary:
Rename Test Suites in `test_sdpa_with_kv_cache` to follow internal tooling conventions and make test target static listable.

Previously, some of the Test Suites in the modified test file did not satisfy the condition:
* Test Suite's name must contain `Test`

This diff makes it so that the Test Suites follow the expected conventions.

### Benefits
Following the conventions grants the test targets:
* Faster test listing
* Better dev experience in VSCode

Differential Revision: D85428922


