### PR TITLE
Fix nxp unittests

### DIFF
--- a/backends/nxp/tests/test_batch_norm_fusion.py
+++ b/backends/nxp/tests/test_batch_norm_fusion.py
@@ -105,7 +105,10 @@ def test_batch_norm_conv_fusing(bias: bool, input_shape: list[int]):
     og_nodes = list(program.graph.nodes)
     transformed_nodes = list(graph_module_out.graph.nodes)
 
-    assert any(node.target.__name__ == "batch_norm.default" for node in og_nodes)
+    assert any(
+        node.op == "call_function" and node.target.__name__ == "batch_norm.default"
+        for node in og_nodes
+    )
 
     assert not any(
         node.op == "call_function" and "batch_norm" in node.target.__name__
@@ -137,7 +140,10 @@ def test_batch_norm_linear_fusing(bias: bool):
     og_nodes = list(og_module.graph.nodes)
     transformed_nodes = list(graph_module_out.graph.nodes)
 
-    assert any(node.target.__name__ == "linear.default" for node in og_nodes)
+    assert any(
+        node.op == "call_function" and node.target.__name__ == "linear.default"
+        for node in og_nodes
+    )
 
     assert not any(
         node.op == "call_function" and "batch_norm" in node.target.__name__

--- a/backends/nxp/tests/test_batch_norm_fusion.py
+++ b/backends/nxp/tests/test_batch_norm_fusion.py
@@ -105,10 +105,8 @@ def test_batch_norm_conv_fusing(bias: bool, input_shape: list[int]):
     og_nodes = list(program.graph.nodes)
     transformed_nodes = list(graph_module_out.graph.nodes)
 
-    assert len(og_nodes) == (11 if bias else 10)
-    assert og_nodes[9 if bias else 8].target.__name__ == "batch_norm.default"
+    assert any(node.target.__name__ == "batch_norm.default" for node in og_nodes)
 
-    assert len(transformed_nodes) == 5
     assert not any(
         node.op == "call_function" and "batch_norm" in node.target.__name__
         for node in transformed_nodes
@@ -118,7 +116,7 @@ def test_batch_norm_conv_fusing(bias: bool, input_shape: list[int]):
     input_data = torch.randn(input_shape, dtype=torch.float32)
     out1 = og_module(input_data).detach().numpy()
     out2 = graph_module_out(input_data).detach().numpy()
-    assert np.allclose(out1, out2, atol=3.0e-7)
+    torch.testing.assert_close(out1, out2)
 
 
 @pytest.mark.parametrize(
@@ -139,10 +137,8 @@ def test_batch_norm_linear_fusing(bias: bool):
     og_nodes = list(og_module.graph.nodes)
     transformed_nodes = list(graph_module_out.graph.nodes)
 
-    assert len(og_nodes) == (11 if bias else 10)
-    assert og_nodes[8 if bias else 7].target.__name__ == "linear.default"
+    assert any(node.target.__name__ == "linear.default" for node in og_nodes)
 
-    assert len(transformed_nodes) == 5
     assert not any(
         node.op == "call_function" and "batch_norm" in node.target.__name__
         for node in transformed_nodes
@@ -152,7 +148,7 @@ def test_batch_norm_linear_fusing(bias: bool):
     input_data = torch.randn(input_shape, dtype=torch.float32)
     out1 = og_module(input_data).detach().numpy()
     out2 = graph_module_out(input_data).detach().numpy()
-    assert np.allclose(out1, out2, atol=1.2e-7)
+    torch.testing.assert_close(out1, out2)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Let's not hard code the number of nodes in the graph.

The graph of batch norm + conv looks like this after torch nightly 1015:

```
graph():
    %p_conv_weight : [num_users=1] = placeholder[target=p_conv_weight]
    %p_conv_bias : [num_users=1] = placeholder[target=p_conv_bias]
    %p_batch_norm_batch_norm_weight : [num_users=1] = placeholder[target=p_batch_norm_batch_norm_weight]
    %p_batch_norm_batch_norm_bias : [num_users=1] = placeholder[target=p_batch_norm_batch_norm_bias]
    %b_batch_norm_batch_norm_running_mean : [num_users=1] = placeholder[target=b_batch_norm_batch_norm_running_mean]
    %b_batch_norm_batch_norm_running_var : [num_users=1] = placeholder[target=b_batch_norm_batch_norm_running_var]
    %x : [num_users=1] = placeholder[target=x]
    %conv2d : [num_users=1] = call_function[target=torch.ops.aten.conv2d.default](args = (%x, %p_conv_weight, %p_conv_bias), kwargs = {})
    %batch_norm : [num_users=1] = call_function[target=torch.ops.aten.batch_norm.default](args = (%conv2d, %p_batch_norm_batch_norm_weight, %p_batch_norm_batch_norm_bias, %b_batch_norm_batch_norm_running_mean, %b_batch_norm_batch_norm_running_var, False, 0.1, 1e-05, True), kwargs = {})
    return (batch_norm,)
```
