### PR TITLE
Reduce dram buffer size

### DIFF
--- a/backends/cadence/vision/third-party/include_private/idma_init.h
+++ b/backends/cadence/vision/third-party/include_private/idma_init.h
@@ -4,8 +4,8 @@
 #include "../include/dtypes.h"
 #include "common.h"
 
-#define IDMA_BUFF_SIZE \
-  16384 // 16 kb DRAM storage. Assume 4 buffers (2 input and 2 output)
+ // 4 kb x sizeof(float32_t) = 16 kb DRAM storage. Assume 4 buffers (2 input and 2 output)
+#define IDMA_BUFF_SIZE 4096
 
 #ifndef PLACE_IN_DRAM0
 #define PLACE_IN_DRAM0 \


### PR DESCRIPTION
Summary: The idma_init declares two buffers in dram (one in each bank). These are used for iDMA transfers in optimized operators. The comment indicated that the intention was to use 16 KB of dram storage, but because the buffers were arrays of float32_t and not bytes, this actually consumed 64 KB. This diff aligns the size of the buffers with the comment.

Differential Revision: D85269330


