### PR TITLE
Arm backend: Remove pyre-unsafe from remaining files

### DIFF
--- a/backends/arm/common/arm_compile_spec.py
+++ b/backends/arm/common/arm_compile_spec.py
@@ -3,7 +3,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# pyre-unsafe
 
 #
 # Main implementation of AoT flow to partition and preprocess for Arm target

--- a/backends/arm/operator_support/__init__.py
+++ b/backends/arm/operator_support/__init__.py
@@ -3,7 +3,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# pyre-unsafe
 
 from . import (  # noqa
     clone_dim_order_support,

--- a/backends/arm/operator_support/ethos_u55_support.py
+++ b/backends/arm/operator_support/ethos_u55_support.py
@@ -10,7 +10,6 @@ Ethos-U55 subset of TOSA.
 
 """
 
-# pyre-unsafe
 
 import typing
 from typing import cast

--- a/backends/arm/operator_support/right_shift_support.py
+++ b/backends/arm/operator_support/right_shift_support.py
@@ -9,8 +9,6 @@ targets across integer and float TOSA profiles.
 
 """
 
-# pyre-unsafe
-
 
 import logging
 

--- a/backends/arm/operator_support/to_dim_order_copy_support.py
+++ b/backends/arm/operator_support/to_dim_order_copy_support.py
@@ -10,7 +10,6 @@ profile (integer and/or float).
 
 """
 
-# pyre-unsafe
 import copy
 import logging
 

--- a/backends/arm/operator_support/tosa_supported_operators.py
+++ b/backends/arm/operator_support/tosa_supported_operators.py
@@ -3,7 +3,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# pyre-unsafe
 
 import itertools
 import operator

--- a/backends/arm/test/misc/test_outputs_order.py
+++ b/backends/arm/test/misc/test_outputs_order.py
@@ -3,7 +3,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 #
-# pyre-unsafe
 import tempfile
 from pathlib import Path
 

--- a/backends/arm/util/arm_model_evaluator.py
+++ b/backends/arm/util/arm_model_evaluator.py
@@ -3,7 +3,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# pyre-unsafe
 
 import json
 import logging


### PR DESCRIPTION
Pyre is no longer used.

cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai