### PR TITLE
Bump linux unittest runner to linux.2xlarge.memory

### DIFF
--- a/.github/workflows/_unittest.yml
+++ b/.github/workflows/_unittest.yml
@@ -32,7 +32,7 @@ jobs:
       id-token: write
       contents: read
     with:
-      runner: linux.2xlarge
+      runner: linux.2xlarge.memory
       docker-image: ${{ inputs.docker-image }}
       submodules: 'recursive'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}


### PR DESCRIPTION
### Summary
Unittest jobs are dying since https://github.com/pytorch/executorch/pull/15180. I'm not entirely sure why the jobs passed on the PR, but they are failing consistently since on trunk. Testing a runner size bump (2xlarge -> 2xlarge.memory) to see if that resolves it.

Example logs (from another [PR](https://github.com/pytorch/executorch/pull/15397)). Note that the exit code (137 / SIGKILL) likely means OOM kill.
```
The runner has received a shutdown signal. This can happen when the runner service is stopped, or a manually started runner is canceled.
...
Process completed with exit code 137.
```