### PR TITLE
Skip Voxtral metal job on fork PRs (secrets are not available)

### DIFF
--- a/.github/workflows/metal.yml
+++ b/.github/workflows/metal.yml
@@ -30,6 +30,8 @@ jobs:
 
   export-voxtral-metal-artifact:
     name: export-voxtral-metal-artifact
+      # Skip this job if the pull request is from a fork (HuggingFace secrets are not available)
+    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
     secrets: inherit
     with:


### PR DESCRIPTION
### Summary
Similar to https://github.com/pytorch/executorch/pull/15385, skip export-voxtral-metal-artifact / macos-job when running on fork PRs. It will fail as secrets are not available (see [export-voxtral-metal-artifact / macos-job](https://github.com/pytorch/executorch/actions/runs/18855906121/job/53803670641?pr=15400#logs)).

### Test Plan
I verified that export-voxtral-metal-artifact / macos-job is skipped on this PR.