### PR TITLE
Skip test-samsung-models-linux on fork PRs

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -909,6 +909,8 @@ jobs:
 
   test-samsung-models-linux:
     name: test-samsung-models-linux
+    # Skip this job if the pull request is from a fork (secrets are not available)
+    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     permissions:
       id-token: write


### PR DESCRIPTION
### Summary
Similar to #15401, skip test-samsung-models-linux on forked PRs as it requires secrets and thus fails. This should reduce false-negatives / noise on contributor PRs.

Example failure (from https://github.com/pytorch/executorch/actions/runs/18856230366/job/53804732612):
```
Failed to extract download URL
{"success":false,"data":null,"msg":"API key is required","page":0,"total":0}
exit 1
```

### Test Plan
Verified that test-samsung-models-linux is skipped on this PR.