### PR TITLE
Pin huggingface_hub in more places

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -626,7 +626,7 @@ jobs:
           BUILD_TORCHAO_EXPERIMENTAL=1 TORCHAO_BUILD_CPU_AARCH64=1 TORCHAO_BUILD_KLEIDIAI=1 TORCHAO_ENABLE_ARM_NEON_DOT=1 TORCHAO_PARALLEL_BACKEND=OPENMP pip install third-party/ao
         fi
 
-        pip install -U "huggingface_hub[cli]"
+        pip install -U "huggingface_hub[cli]<1.0"
 
         bash .ci/scripts/test_torchao_huggingface_checkpoints.sh ${{ matrix.model }} ${{ matrix.model != 'phi_4_mini' && '--test_with_runner' || '' }}  ${{ matrix.backend == 'torchao' && '--use_torchao_kernels' || '' }}
 
@@ -659,7 +659,7 @@ jobs:
         echo "::endgroup::"
 
         echo "::group::Set up Huggingface"
-        ${CONDA_RUN} pip install -U "huggingface_hub[cli]" accelerate
+        ${CONDA_RUN} pip install -U "huggingface_hub[cli]<1.0" accelerate
         ${CONDA_RUN} huggingface-cli login --token $SECRET_EXECUTORCH_HF_TOKEN
         OPTIMUM_ET_VERSION=$(cat .ci/docker/ci_commit_pins/optimum-executorch.txt)
         ${CONDA_RUN} pip install git+https://github.com/huggingface/optimum-executorch.git@${OPTIMUM_ET_VERSION}
@@ -930,7 +930,7 @@ jobs:
         echo "::endgroup::"
 
         echo "::group::Set up Huggingface"
-        ${CONDA_RUN} pip install -U "huggingface_hub[cli]" accelerate
+        ${CONDA_RUN} pip install -U "huggingface_hub[cli]<1.0" accelerate
         ${CONDA_RUN} huggingface-cli login --token $SECRET_EXECUTORCH_HF_TOKEN
         OPTIMUM_ET_VERSION=$(cat .ci/docker/ci_commit_pins/optimum-executorch.txt)
         ${CONDA_RUN} pip install git+https://github.com/huggingface/optimum-executorch.git@${OPTIMUM_ET_VERSION}


### PR DESCRIPTION
### Summary
We need to pin huggingface_hub in CI to avoid an incompatibility with our pinned version of transformers. See https://github.com/pytorch/executorch/pull/15399 for more context - I missed a few places on trunk jobs. Cleaning these up here.

### Test Plan
Running with ciflow/trunk. I verified that the test-huggingface-transformers-macos / * and gemma3-4b macos jobs pass on this PR. They are failing on trunk (see https://hud.pytorch.org/pytorch/executorch/commit/4c30da308ee811bdfa44fd4bea3bc439bfd303d4 for an example).

