### PR TITLE
Arm backend: Avoid not decomposing linears we reject

### DIFF
--- a/backends/arm/test/models/test_nn_modules.py
+++ b/backends/arm/test/models/test_nn_modules.py
@@ -137,8 +137,6 @@ def test_nn_Modules_FP(test_data):
     "test_data",
     test_parameters,
     xfails={
-        "GRUModule": "RuntimeError: Node aten_linear_default with op <EdgeOpOverload: aten.linear[...]> was not decomposed or delegated.",
-        "PReLUModule": "RuntimeError: mul(): functions with out=... arguments don't support automatic differentiation, but one of the arguments requires grad.",
         "TransformerModule": "AssertionError: Output 0 does not match reference output.",
     },
 )

--- a/backends/arm/test/tester/arm_tester.py
+++ b/backends/arm/test/tester/arm_tester.py
@@ -266,6 +266,7 @@ class ArmTester(Tester):
             StageType.QUANTIZE,
             StageType.EXPORT,
         ]
+        self.original_module.requires_grad_(False)
 
         # Initial model needs to be set as a *possible* but not yet added Stage, therefore add None entry.
         self.stages[StageType.INITIAL_MODEL] = None


### PR DESCRIPTION
If a linear is not quantized properly, we will reject it when partitioning. However, if we tell Executorch to _not_ not decompose an op, we are required to partition it. We thus need to figure out if we will partition the linear or not in the ops_not_to_decompose filter function.

Also turn off grad in the arm tester to solve an error that popped up in the GRU model. Since we only do inference, grad is never relevant.

cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai