### PR TITLE
Arm backend: Shorten input names passed to the FVP

### DIFF
--- a/backends/arm/test/ops/test_slice.py
+++ b/backends/arm/test/ops/test_slice.py
@@ -76,13 +76,7 @@ def test_slice_tensor_tosa_INT_nhwc(test_data: torch.Tensor):
     pipeline.run()
 
 
-x_fails = {
-    "ones_slice_3": "MLETORCH-1402: Compiler limitation when passing more than 255 char as argument to FVP.",
-    "ones_slice_4": "MLETORCH-1402: Compiler limitation when passing more than 255 char as argument to FVP.",
-}
-
-
-@common.parametrize("test_data", test_data_suite, x_fails)
+@common.parametrize("test_data", test_data_suite)
 @common.XfailIfNoCorstone300
 def test_slice_tensor_u55_INT(test_data: torch.Tensor):
     pipeline = EthosU55PipelineINT[input_t1](
@@ -94,7 +88,7 @@ def test_slice_tensor_u55_INT(test_data: torch.Tensor):
     pipeline.run()
 
 
-@common.parametrize("test_data", test_data_suite, x_fails)
+@common.parametrize("test_data", test_data_suite)
 @common.XfailIfNoCorstone320
 def test_slice_tensor_u85_INT(test_data: torch.Tensor):
     pipeline = EthosU85PipelineINT[input_t1](
@@ -175,7 +169,7 @@ def test_slice_tensor_16a8w_tosa_INT(test_data: torch.Tensor):
     pipeline.run()
 
 
-@common.parametrize("test_data", test_data_suite, x_fails)
+@common.parametrize("test_data", test_data_suite)
 @common.XfailIfNoCorstone300
 def test_slice_tensor_16a8w_u55_INT16(test_data: torch.Tensor):
     """Test slice operation with 16A8W quantization on U55 (16-bit activations, 8-bit weights)"""
@@ -199,7 +193,7 @@ def test_slice_tensor_16a8w_u55_INT16(test_data: torch.Tensor):
     pipeline.run()
 
 
-@common.parametrize("test_data", test_data_suite, x_fails)
+@common.parametrize("test_data", test_data_suite)
 @common.XfailIfNoCorstone320
 def test_slice_tensor_16a8w_u85_INT16(test_data: torch.Tensor):
     """Test slice operation with 16A8W quantization on U85 (16-bit activations, 8-bit weights)"""

--- a/backends/arm/test/ops/test_split.py
+++ b/backends/arm/test/ops/test_split.py
@@ -139,17 +139,7 @@ def test_split_with_sizes_tosa_INT(test_data: input_t1):
     pipeline.run()
 
 
-x_fails = {
-    "split_3d_2_sizes_dim": "MLETORCH-1403: Split operator is running out of memory when reading input file",
-    "split_4d_2_sizes_dim_neg": "MLETORCH-1403: Split operator is running out of memory when reading input file",
-}
-
-
-@common.parametrize(
-    "test_data",
-    (Split.test_data | Split.test_data_list),
-    x_fails,
-)
+@common.parametrize("test_data", (Split.test_data | Split.test_data_list))
 @common.XfailIfNoCorstone300
 def test_split_with_sizes_u55_INT(test_data: input_t1):
     pipeline = EthosU55PipelineINT[input_t1](
@@ -161,11 +151,7 @@ def test_split_with_sizes_u55_INT(test_data: input_t1):
     pipeline.run()
 
 
-@common.parametrize(
-    "test_data",
-    (Split.test_data | Split.test_data_list),
-    x_fails,
-)
+@common.parametrize("test_data", (Split.test_data | Split.test_data_list))
 @common.XfailIfNoCorstone320
 def test_split_with_sizes_u85_INT(test_data: input_t1):
     pipeline = EthosU85PipelineINT[input_t1](


### PR DESCRIPTION
Modify the backends/arm/test/runner_utils.py so that we pass relative paths to the FVP. This is to allow us get around the 256 char limit on the FVP and enables testing of the slice operator for 16x8. Solves internal ticket MLETORCH-1403.

cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai