### PR TITLE
Use -O2 compilation for Autocorrect only

### DIFF
--- a/shim_et/xplat/executorch/build/runtime_wrapper.bzl
+++ b/shim_et/xplat/executorch/build/runtime_wrapper.bzl
@@ -117,6 +117,12 @@ def _patch_build_mode_flags(kwargs):
             "ovr_config//os:macos": ["-fvisibility=default"],
     })
 
+    # Add -O2 compiler flag when the compiler_flag_O2 config is set
+    kwargs["compiler_flags"] = kwargs["compiler_flags"] + select({
+        "DEFAULT": [],
+        "fbsource//xplat/assistant/oacr/native/scripts:compiler_flag_O2": ["-O2"],
+    })
+
     return kwargs
 
 def _patch_test_compiler_flags(kwargs):


### PR DESCRIPTION
Summary:
Apply -02 compiler flag to make FLLM autocorrect faster

Sheet measuring different scopes of applying -02 and the resulting latency
https://docs.google.com/spreadsheets/d/1ZnxoRwCIiMz3hXyhgb6sm_2UThBUyq-mpp8RzksfJMQ/edit?usp=sharing

Differential Revision: D85152814


