### PR TITLE
Print non-zero error code returned by nnlib calls.

### DIFF
--- a/backends/cadence/common/xt_macros.h
+++ b/backends/cadence/common/xt_macros.h
@@ -10,13 +10,15 @@
 
 #include <executorch/runtime/core/exec_aten/util/tensor_util.h>
 
-#define XT_KERNEL_CHECK(ctx, out, kernel, ...)                  \
-  {                                                             \
-    const auto ret = kernel(__VA_ARGS__);                       \
-    ET_KERNEL_CHECK_MSG(                                        \
-        ctx,                                                    \
-        ret == 0,                                               \
-        InvalidArgument,                                        \
-        out,                                                    \
-        "Failed to run kernel: " #kernel "(" #__VA_ARGS__ ")"); \
+#define XT_KERNEL_CHECK(ctx, out, kernel, ...)            \
+  {                                                       \
+    const auto ret = kernel(__VA_ARGS__);                 \
+    ET_KERNEL_CHECK_MSG(                                  \
+        ctx,                                              \
+        ret == 0,                                         \
+        InvalidArgument,                                  \
+        out,                                              \
+        "Failed to run kernel: " #kernel "(" #__VA_ARGS__ \
+        "). Returned code %d",                            \
+        static_cast<int>(ret));                           \
   }


### PR DESCRIPTION
Summary: Print the actual returned code for debugging.

Differential Revision: D85720366


