### PR TITLE
Fix regression with 8 bit quant mat mul.

### DIFF
--- a/backends/vulkan/runtime/graph/ops/glsl/linear_qcsnw_tiled.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/linear_qcsnw_tiled.yaml
@@ -12,7 +12,7 @@ linear_qcsnw_tiled:
     WEIGHT_STORAGE: texture2d
     SCALES_STORAGE: texture2d
     TILE_ROWS: 4
-    TILE_TXCOLS: 2
+    TILE_TXCOLS: 1
     QUANT_NBITS: 8
   generate_variant_forall:
     TILE_ROWS:

--- a/backends/vulkan/runtime/graph/ops/impl/QuantizedLinearQCSNW.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/QuantizedLinearQCSNW.cpp
@@ -73,7 +73,7 @@ utils::uvec3 linear_qcsnw_tiled_global_wg_size(
   }
 
   // Number of output texels in the output tile
-  uint32_t out_tile_ntxcols = 2;
+  uint32_t out_tile_ntxcols = 1;
   if (quant_nbits == 4) {
     out_tile_ntxcols = 2;
   }
@@ -325,7 +325,7 @@ void add_linear_qcsnw_tiled_node(
   }
 
   // Number of output texels in the output tile
-  uint32_t out_tile_ntxcols = 2;
+  uint32_t out_tile_ntxcols = 1;
   if (quant_nbits == 4) {
     out_tile_ntxcols = 2;
   }


### PR DESCRIPTION
Summary: This diff fixes a regression in the 8-bit quantized matrix multiplication operation, by reducing number of columns processed to 1 instead of 2 as before.

Differential Revision: D85767668


