### PR TITLE
Fix for missing ' executorch.backends.arm.common.type' (See #15367)

### DIFF
--- a/backends/arm/TARGETS
+++ b/backends/arm/TARGETS
@@ -20,6 +20,7 @@ runtime.python_library(
     srcs = [
         "common/__init__.py",
         "common/debug.py",
+        "common/type.py",
     ],
     deps = [
         "fbsource//third-party/tosa_tools:serializer",


### PR DESCRIPTION
Summary: Same as title ^^^

Differential Revision: D85886023


