### PR TITLE
[android] Add support for float16 tensor

### DIFF
--- a/extension/android/executorch_android/src/test/java/org/pytorch/executorch/TensorTest.kt
+++ b/extension/android/executorch_android/src/test/java/org/pytorch/executorch/TensorTest.kt
@@ -7,8 +7,11 @@
  */
 package org.pytorch.executorch
 
+import java.nio.ByteOrder
 import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -182,6 +185,65 @@ class TensorTest {
     assertEquals(data[1].toLong(), tensor.dataAsUnsignedByteArray[1].toLong())
     assertEquals(data[2].toLong(), tensor.dataAsUnsignedByteArray[2].toLong())
     assertEquals(data[3].toLong(), tensor.dataAsUnsignedByteArray[3].toLong())
+  }
+
+  @Test
+  fun testHalfTensorFromShortArrayAndBuffer() {
+    val data =
+        shortArrayOf(
+            0x3C00.toShort(), // 1.0
+            0xC000.toShort(), // -2.0
+            0x0000.toShort(), // 0.0
+            0x7C00.toShort() // +inf
+            )
+    val shape = longArrayOf(2, 2)
+    var tensor = Tensor.fromBlob(data, shape)
+    assertEquals(DType.HALF, tensor.dtype())
+    assertEquals(shape[0], tensor.shape()[0])
+    assertEquals(shape[1], tensor.shape()[1])
+    assertEquals(4, tensor.numel())
+    assertArrayEquals(data, tensor.dataAsShortArray)
+    val floats = tensor.dataAsFloatArray
+    assertEquals(1.0f.toDouble(), floats[0].toDouble(), 1e-6)
+    assertEquals((-2.0f).toDouble(), floats[1].toDouble(), 1e-6)
+    assertEquals(0.0f.toDouble(), floats[2].toDouble(), 1e-6)
+    assertEquals(Float.POSITIVE_INFINITY.toDouble(), floats[3].toDouble(), 0.0)
+
+    val buffer = Tensor.allocateHalfBuffer(data.size)
+    assertTrue(buffer.isDirect)
+    assertEquals(ByteOrder.nativeOrder(), buffer.order())
+    buffer.put(data)
+    buffer.rewind()
+
+    tensor = Tensor.fromBlob(buffer, longArrayOf(data.size.toLong()))
+    assertEquals(DType.HALF, tensor.dtype())
+    assertEquals(data.size.toLong(), tensor.shape()[0])
+    assertEquals(data.size.toLong(), tensor.numel())
+    assertArrayEquals(data, tensor.dataAsShortArray)
+    val raw = tensor.rawDataBuffer as java.nio.ShortBuffer
+    assertTrue(raw === buffer)
+  }
+
+  @Test
+  fun testHalfTensorSerializationRoundTrip() {
+    val data =
+        shortArrayOf(
+            0x0000.toShort(),
+            0x0400.toShort(),
+            0x3C00.toShort(),
+            0x7BFF.toShort(),
+        )
+    val shape = longArrayOf(2, 2)
+    val tensor = Tensor.fromBlob(data, shape)
+    val serialized = tensor.toByteArray()
+    val deserialized = Tensor.fromByteArray(serialized)
+
+    assertEquals(DType.HALF, deserialized.dtype())
+    assertEquals(shape[0], deserialized.shape()[0])
+    assertEquals(shape[1], deserialized.shape()[1])
+    assertEquals(4, deserialized.numel())
+    assertArrayEquals(data, deserialized.dataAsShortArray)
+    assertEquals(1.0f.toDouble(), deserialized.dataAsFloatArray[2].toDouble(), 1e-6)
   }
 
   @Test

--- a/extension/android/executorch_android/src/test/java/org/pytorch/executorch/TensorTest.kt
+++ b/extension/android/executorch_android/src/test/java/org/pytorch/executorch/TensorTest.kt
@@ -194,8 +194,8 @@ class TensorTest {
             0x3C00.toShort(), // 1.0
             0xC000.toShort(), // -2.0
             0x0000.toShort(), // 0.0
-            0x7C00.toShort() // +inf
-            )
+            0x7C00.toShort(), // +inf
+        )
     val shape = longArrayOf(2, 2)
     var tensor = Tensor.fromBlob(data, shape)
     assertEquals(DType.HALF, tensor.dtype())

--- a/extension/android/jni/jni_layer.cpp
+++ b/extension/android/jni/jni_layer.cpp
@@ -14,6 +14,7 @@
 #include <executorch/extension/runner_util/inputs.h>
 #include <executorch/extension/tensor/tensor.h>
 #include <executorch/runtime/core/portable_type/tensor_impl.h>
+#include <executorch/runtime/core/exec_aten/util/scalar_type_util.h>
 #include <executorch/runtime/platform/log.h>
 #include <executorch/runtime/platform/platform.h>
 #include <executorch/runtime/platform/runtime.h>
@@ -117,7 +118,7 @@ class TensorHybrid : public facebook::jni::HybridClass<TensorHybrid> {
     std::vector<executorch::aten::SizesType> shape_vec;
     shape_vec.reserve(rank);
 
-    auto numel = 1;
+    int64_t numel = 1;
     for (int i = 0; i < rank; i++) {
       shape_vec.push_back(shapeArr[i]);
     }
@@ -132,11 +133,24 @@ class TensorHybrid : public facebook::jni::HybridClass<TensorHybrid> {
           static_cast<uint32_t>(Error::InvalidArgument), ss.str().c_str());
     }
     ScalarType scalar_type = java_dtype_to_scalar_type.at(jdtype);
-    const auto dataCapacity = jni->GetDirectBufferCapacity(jbuffer.get());
-    if (dataCapacity != numel) {
+    const jlong dataCapacity = jni->GetDirectBufferCapacity(jbuffer.get());
+    if (dataCapacity < 0) {
+      std::stringstream ss;
+      ss << "Tensor buffer is not direct or has invalid capacity";
+      jni_helper::throwExecutorchException(
+          static_cast<uint32_t>(Error::InvalidArgument), ss.str().c_str());
+    }
+    const size_t elementSize = executorch::runtime::elementSize(scalar_type);
+    const jlong expectedElements = static_cast<jlong>(numel);
+    const jlong expectedBytes =
+        expectedElements * static_cast<jlong>(elementSize);
+    const bool matchesElements = dataCapacity == expectedElements;
+    const bool matchesBytes = dataCapacity == expectedBytes;
+    if (!matchesElements && !matchesBytes) {
       std::stringstream ss;
       ss << "Tensor dimensions(elements number: " << numel
-         << "inconsistent with buffer capacity " << dataCapacity << "]";
+         << ") inconsistent with buffer capacity " << dataCapacity
+         << " (element size bytes: " << elementSize << ")";
       jni_helper::throwExecutorchException(
           static_cast<uint32_t>(Error::InvalidArgument), ss.str().c_str());
     }

--- a/extension/android/jni/jni_layer.cpp
+++ b/extension/android/jni/jni_layer.cpp
@@ -13,8 +13,8 @@
 #include <executorch/extension/module/module.h>
 #include <executorch/extension/runner_util/inputs.h>
 #include <executorch/extension/tensor/tensor.h>
-#include <executorch/runtime/core/portable_type/tensor_impl.h>
 #include <executorch/runtime/core/exec_aten/util/scalar_type_util.h>
+#include <executorch/runtime/core/portable_type/tensor_impl.h>
 #include <executorch/runtime/platform/log.h>
 #include <executorch/runtime/platform/platform.h>
 #include <executorch/runtime/platform/runtime.h>


### PR DESCRIPTION
The Android binding exposes helpers for feeding IEEE-754 half-precision (FP16) inputs directly.
Use `Tensor.fromBlob(shortArray, shape)` or reuse a direct `ShortBuffer` created via
`Tensor.allocateHalfBuffer(numElements)` to avoid extra copies:

```kotlin
val shape = longArrayOf(24, 4096)
val halfData: ShortArray = buildHalfEncodedData()
val tensor = Tensor.fromBlob(halfData, shape)

val buffer = Tensor.allocateHalfBuffer(halfData.size)
buffer.put(halfData)
buffer.rewind()
val tensorNoCopy = Tensor.fromBlob(buffer, shape)
```

All buffers must be direct and use the native byte order; the helper above takes care of this.