### PR TITLE
Fix custom op example

### DIFF
--- a/examples/qualcomm/custom_op/custom_ops_1.py
+++ b/examples/qualcomm/custom_op/custom_ops_1.py
@@ -69,16 +69,13 @@ def annotate_custom(gm: torch.fx.GraphModule) -> None:
     This function is specific for custom op.
     The source_fn of the rewritten nn module turns out to be "my_ops.mul3.default"
     """
-    from executorch.backends.qualcomm.quantizer.annotators import (
-        _is_annotated,
-        QUANT_ANNOTATION_KEY,
-    )
-
+    from executorch.backends.qualcomm.quantizer.annotators import _is_annotated
     from executorch.backends.qualcomm.quantizer.qconfig import (
         get_ptq_per_channel_quant_config,
     )
     from torch.fx import Node
     from torchao.quantization.pt2e.quantizer import QuantizationAnnotation
+    from torchao.quantization.pt2e.quantizer.quantizer import Q_ANNOTATION_KEY
 
     quantization_config = get_ptq_per_channel_quant_config()
     for node in gm.graph.nodes:
@@ -95,7 +92,7 @@ def annotate_custom(gm: torch.fx.GraphModule) -> None:
         input_spec = quantization_config.input_activation
         input_qspec_map[input_act] = input_spec
 
-        node.meta[QUANT_ANNOTATION_KEY] = QuantizationAnnotation(
+        node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
             input_qspec_map=input_qspec_map,
             output_qspec=quantization_config.output_activation,
             _annotated=True,
@@ -235,6 +232,7 @@ def main(args):
                 f"--output_folder_path {output_data_folder}",
             ]
         )
+        print(f"Running command: {runner_cmd}")
         subprocess.run(
             runner_cmd,
             # stdout=subprocess.PIPE,
@@ -258,8 +256,6 @@ def main(args):
             device_id=args.device,
             host_id=args.host,
             soc_model=args.model,
-            shared_buffer=args.shared_buffer,
-            target=args.target,
         )
         adb.push(inputs=sample_input, files=op_package_paths)
         adb.execute()

--- a/examples/qualcomm/custom_op/custom_ops_1.py
+++ b/examples/qualcomm/custom_op/custom_ops_1.py
@@ -79,7 +79,7 @@ def annotate_custom(gm: torch.fx.GraphModule) -> None:
 
     quantization_config = get_ptq_per_channel_quant_config()
     for node in gm.graph.nodes:
-        if node.target != torch.ops.my_ops.mul3.default: g
+        if node.target != torch.ops.my_ops.mul3.default:
             continue
 
         # skip annotation if it is already annotated
@@ -257,6 +257,7 @@ def main(args):
             host_id=args.host,
             soc_model=args.model,
             shared_buffer=args.shared_buffer,
+            target=args.target,
         )
         adb.push(inputs=sample_input, files=op_package_paths)
         adb.execute()

--- a/examples/qualcomm/custom_op/custom_ops_1.py
+++ b/examples/qualcomm/custom_op/custom_ops_1.py
@@ -256,6 +256,7 @@ def main(args):
             device_id=args.device,
             host_id=args.host,
             soc_model=args.model,
+            shared_buffer=args.shared_buffer,
         )
         adb.push(inputs=sample_input, files=op_package_paths)
         adb.execute()

--- a/examples/qualcomm/custom_op/custom_ops_1.py
+++ b/examples/qualcomm/custom_op/custom_ops_1.py
@@ -79,7 +79,7 @@ def annotate_custom(gm: torch.fx.GraphModule) -> None:
 
     quantization_config = get_ptq_per_channel_quant_config()
     for node in gm.graph.nodes:
-        if node.target != torch.ops.my_ops.mul3.default:
+        if node.target != torch.ops.my_ops.mul3.default: g
             continue
 
         # skip annotation if it is already annotated
@@ -232,7 +232,7 @@ def main(args):
                 f"--output_folder_path {output_data_folder}",
             ]
         )
-        print(f"Running command: {runner_cmd}")
+
         subprocess.run(
             runner_cmd,
             # stdout=subprocess.PIPE,


### PR DESCRIPTION
There were some refactor and looks like the custom example was not covered in CI

Run
```
python3 examples/qualcomm/custom_op/custom_ops_1.py --build_folder build-android -s R3CY50HEGYM -m SM8750 --op_package_dir examples/qualcomm/custom_op/example_op_package_htp/ExampleOpPackage --build_op_package 
```
and output is

<details>
<summary>Output log</summary>

```
Quantizing(PTQ) the model...
WARNING:root:Op aten.unbind.int was requested for preservation by partitioner.  This request is ignored because it is in a blocklist.
WARNING:root:Op aten.unbind.int was requested for preservation by partitioner.  This request is ignored because it is in a blocklist.
[INFO] [Qnn ExecuTorch]: create QNN Logger with log_level 1
[INFO] [Qnn ExecuTorch]: Initialize Qnn backend parameters for Qnn executorch backend type 2
[INFO] [Qnn ExecuTorch]: Caching: Caching is in SAVE MODE.
[INFO] [Qnn ExecuTorch]: Running level=3 optimization.
[QNN Partitioner Op Support]: my_ops.mul3.default | True
[INFO] [Qnn ExecuTorch]: Destroy Qnn backend parameters
[INFO] [Qnn ExecuTorch]: Destroy Qnn context
[INFO] [Qnn ExecuTorch]: Destroy Qnn device
[INFO] [Qnn ExecuTorch]: Destroy Qnn backend
[INFO] [Qnn ExecuTorch]: Destroy Qnn backend parameters
INFO:executorch.backends.qualcomm.partition.qnn_partitioner:Qnn partitioner will delegate torch mutable buffer with the same I/O address during the runtime, so if your model contains mutable buffer, then you can get the better performance with skip_mutable_buffer=False. If you encounter accuracy issue during the runtime, then please set `skip_mutable_buffer=True` and try again.
[INFO] [Qnn ExecuTorch]: create QNN Logger with log_level 1
[INFO] [Qnn ExecuTorch]: Initialize Qnn backend parameters for Qnn executorch backend type 2
[INFO] [Qnn ExecuTorch]: Caching: Caching is in SAVE MODE.
</details>
[INFO] [Qnn ExecuTorch]: Running level=3 optimization.
INFO:executorch.backends.qualcomm.qnn_preprocess:Processing Method(0): (1/1)
INFO:executorch.backends.qualcomm.qnn_preprocess:Visiting: quantized_decomposed_quantize_per_tensor_default, quantized_decomposed.quantize_per_tensor.default
INFO:executorch.backends.qualcomm.qnn_preprocess:Visiting: my_ops_mul3_default, my_ops.mul3.default
INFO:executorch.backends.qualcomm.qnn_preprocess:Visiting: quantized_decomposed_dequantize_per_tensor_tensor, quantized_decomposed.dequantize_per_tensor.tensor

====== DDR bandwidth summary ======
spill_bytes=0
fill_bytes=0
write_total_bytes=131584
read_total_bytes=125440

[INFO] [Qnn ExecuTorch]: Destroy Qnn backend parameters
[INFO] [Qnn ExecuTorch]: Destroy Qnn context
[INFO] [Qnn ExecuTorch]: Destroy Qnn device
[INFO] [Qnn ExecuTorch]: Destroy Qnn backend
[INFO] [Qnn ExecuTorch]: Destroy Qnn backend parameters
WARNING:root:Op aten.unbind.int was requested for preservation by partitioner.  This request is ignored because it is in a blocklist.
./custom_op/custom_qnn.pte: 1 file pushed, 0 skipped. 166.7 MB/s (31652 bytes in 0.000s)
/home/chenlai/fbsource/third-party/qualcomm/qnn/qnn-2.34/lib/aarch64-android/libQnnHtp.so: 1 file pushed, 0 skipped. 302.9 MB/s (2193976 bytes in 0.007s)
/home/chenlai/fbsource/third-party/qualcomm/qnn/qnn-2.34/lib/hexagon-v79/unsigned/libQnnHtpV79Skel.so: 1 file pushed, 0 skipped. 384.9 MB/s (9087648 bytes in 0.023s)
/home/chenlai/fbsource/third-party/qualcomm/qnn/qnn-2.34/lib/aarch64-android/libQnnHtpV79Stub.so: 1 file pushed, 0 skipped. 263.7 MB/s (477208 bytes in 0.002s)
/home/chenlai/fbsource/third-party/qualcomm/qnn/qnn-2.34/lib/aarch64-android/libQnnHtpPrepare.so: 1 file pushed, 0 skipped. 373.1 MB/s (52389040 bytes in 0.134s)
/home/chenlai/fbsource/third-party/qualcomm/qnn/qnn-2.34/lib/aarch64-android/libQnnSystem.so: 1 file pushed, 0 skipped. 266.2 MB/s (2497656 bytes in 0.009s)
build-android/examples/qualcomm/executor_runner/qnn_executor_runner: 1 file pushed, 0 skipped. 444.4 MB/s (45963304 bytes in 0.099s)
build-android/backends/qualcomm/libqnn_executorch_backend.so: 1 file pushed, 0 skipped. 240.5 MB/s (646624 bytes in 0.003s)
/home/chenlai/fbsource/third-party/qualcomm/qnn/qnn-2.34/lib/aarch64-android/libQnnModelDlc.so: 1 file pushed, 0 skipped. 303.0 MB/s (2430512 bytes in 0.008s)
/data/users/chenlai/executorch/custom_op/input_list.txt: 1 file pushed, 0 skipped. 0.1 MB/s (14 bytes in 0.000s)
/data/users/chenlai/executorch/custom_op/input_0_0.raw: 1 file pushed, 0 skipped. 288.0 MB/s (100352 bytes in 0.000s)
examples/qualcomm/custom_op/example_op_package_htp/ExampleOpPackage/build/hexagon-v79/libQnnExampleOpPackage_HTP.so: 1 file pushed, 0 skipped. 110.0 MB/s (177136 bytes in 0.002s)
examples/qualcomm/custom_op/example_op_package_htp/ExampleOpPackage/build/aarch64-android/libQnnExampleOpPackage.so: 1 file pushed, 0 skipped. 340.1 MB/s (874888 bytes in 0.002s)
I 00:00:00.000608 executorch:qnn_executor_runner.cpp:232] Model file custom_qnn.pte is loaded.
I 00:00:00.000707 executorch:qnn_executor_runner.cpp:242] Using method forward
I 00:00:00.000718 executorch:qnn_executor_runner.cpp:289] Setting up planned buffer 0, size 200704.
[INFO] [Qnn ExecuTorch]: Deserializing processed data using QnnContextCustomProtocol
[INFO] [Qnn ExecuTorch]: create QNN Logger with log_level 1
[INFO] [Qnn ExecuTorch]: Initialize Qnn backend parameters for Qnn executorch backend type 2
[INFO] [Qnn ExecuTorch]: Caching: Caching is in RESTORE MODE.
[INFO] [Qnn ExecuTorch]: QnnContextCustomProtocol expected magic number: 0x5678abcd but get: 0x2000000
[INFO] [Qnn ExecuTorch]: Running level=1 optimization.
I 00:00:00.283815 executorch:qnn_executor_runner.cpp:313] Method loaded.
E 00:00:00.284038 executorch:method.cpp:1274] Output 0 is memory planned, or is a constant. Cannot override the existing data pointer.
I 00:00:00.284055 executorch:qnn_executor_runner.cpp:373] ignoring error from set_output_data_ptr(): 0x2
I 00:00:00.284061 executorch:qnn_executor_runner.cpp:376] Inputs prepared.
I 00:00:00.284115 executorch:qnn_executor_runner.cpp:382] Number of inputs: 1
I 00:00:00.284290 executorch:qnn_executor_runner.cpp:490] Perform 10 inference for warming up
I 00:00:04.366009 executorch:qnn_executor_runner.cpp:496] Start inference (0)
I 00:00:04.781286 executorch:qnn_executor_runner.cpp:514] 1 inference took 415.036000 ms, avg 415.036000 ms
I 00:00:04.782228 executorch:qnn_executor_runner.cpp:550] Total 1 inference took 415.036000 ms, avg 415.036000 ms
I 00:00:04.782429 executorch:qnn_executor_runner.cpp:615] Write etdump to /data/local/tmp/executorch/custom_qnn/etdump.etdp, Size = 1984
[INFO] [Qnn ExecuTorch]: Destroy Qnn backend parameters
[INFO] [Qnn ExecuTorch]: Destroy Qnn context
[INFO] [Qnn ExecuTorch]: Destroy Qnn device
[INFO] [Qnn ExecuTorch]: Destroy Qnn backend
[WARNING] [Qnn ExecuTorch]: QnnDsp <W> Function not called, PrepareLib isn't loaded!

/data/local/tmp/executorch/custom_qnn/outputs/: 1 file pulled, 0 skipped. 0.9 MB/s (100352 bytes in 0.104s)
is_close? True
```