### PR TITLE
Arm backend: Delete temporary folders in ArmTester

### DIFF
--- a/backends/arm/test/misc/test_outputs_order.py
+++ b/backends/arm/test/misc/test_outputs_order.py
@@ -79,7 +79,7 @@ def _read_tosa_outputs(tosa_path: Path):
 
 
 @pytest.mark.parametrize("batch_size", [1, 4])
-def test_network_output_order_and_restore(tmp_path, batch_size):
+def test_network_output_order_and_restore(batch_size):
     model = Network(batch_norm=True).eval()
     # Prepare spec
     spec = TosaSpecification.create_from_string("TOSA-1.0+INT")
@@ -97,7 +97,7 @@ def test_network_output_order_and_restore(tmp_path, batch_size):
     model = convert_pt2e(model)
     # Export to aten dialect
     aten_gm = torch.export.export(model, args=(dummy,), strict=True)
-    with tempfile.TemporaryDirectory() as tmpdir:
+    with tempfile.TemporaryDirectory(dir="") as tmpdir:
         art_dir = Path(tmpdir)
         part = TOSAPartitioner(
             TosaCompileSpec(spec).dump_intermediate_artifacts_to(str(art_dir))

--- a/backends/arm/test/tester/arm_tester.py
+++ b/backends/arm/test/tester/arm_tester.py
@@ -6,6 +6,8 @@
 import copy
 
 import logging
+import shutil
+import tempfile
 
 from collections import Counter
 from pprint import pformat
@@ -86,7 +88,6 @@ from tabulate import tabulate
 
 from torch.export.graph_signature import ExportGraphSignature, InputSpec, OutputSpec
 from torch.fx import Graph
-
 
 logger = logging.getLogger(__name__)
 
@@ -667,6 +668,14 @@ class ArmTester(Tester):
                     qtol=0,
                 )
             raise e
+
+    def __del__(self):
+        intermediate_path = self.compile_spec.get_intermediate_path()
+        if not intermediate_path:
+            return
+        if len(tempdir := tempfile.gettempdir()) > 0:
+            if intermediate_path.startswith(tempdir):
+                shutil.rmtree(intermediate_path, ignore_errors=True)
 
 
 def _get_dtype_distribution(


### PR DESCRIPTION
To save disk space, we assume that files are unwanted if they are saved to a folder in the temporary directory. To save artifacts you can set the path for tests using the TOSA_TESTCASES_BASE_PATH environment variable.

Also, don't dump a debug TOSA file if we are in a
temporary folder.

cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai