### PR TITLE
Add pytorch-tokenizers as a dependency of ExecuTorch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ dependencies=[
   "pytest-xdist",
   "pytest-rerunfailures==15.1",
   "pytest-json-report",
+  "pytorch-tokenizers",
   "pyyaml",
   "ruamel.yaml",
   "sympy",


### PR DESCRIPTION
So that we can `pip install executorch` and run python code like `examples/models/llama/runner/generation.py` without installing `pytorch-tokenizers` separately.
