### PR TITLE
Adjust 'test_quantize_op_fusion_pass' test to account for SHIFT_INT8 value (2^20)

### DIFF
--- a/backends/cortex_m/test/test_quantize_op_fusion_pass.py
+++ b/backends/cortex_m/test/test_quantize_op_fusion_pass.py
@@ -298,7 +298,7 @@ class TestQuantizedOpFusionPass(unittest.TestCase):
 
         # Output multiplier should be close to 2^30 (for 1.0 scale)
         self.assertAlmostEqual(output_mult, 2**30, delta=1000)
-        self.assertEqual(output_shift, -1)
+        self.assertEqual(output_shift, -18)
 
     def test_executorch_program_generation(self):
         """Verify ExecuTorch program generation with fused ops"""


### PR DESCRIPTION
Summary: The test should expect -18 because that's the mathematically correct result when you include the ÷ 2^20 (SHIFT_INT8) factor that ARM chips need for their quantization.

Reviewed By: GregoryComer

Differential Revision: D85986326


