### PR TITLE
Add torch.tensor to named_data_store

### DIFF
--- a/exir/TARGETS
+++ b/exir/TARGETS
@@ -86,6 +86,7 @@ runtime.python_library(
     ],
     deps = [
         ":scalar_type",
+        ":tensor",
     ]
 )
 


### PR DESCRIPTION
Summary: Allow adding torch.Tensor to named_data_store, and infer the TensorLayout.

Differential Revision: D85992938


