### PR TITLE
Fix text prefiller start pos being updated twice

### DIFF
--- a/extension/llm/runner/text_llm_runner.cpp
+++ b/extension/llm/runner/text_llm_runner.cpp
@@ -247,7 +247,7 @@ Error TextLLMRunner::warmup(const std::string& prompt, int32_t max_new_tokens) {
   Error err = generate(prompt, config);
 
   // Reset stats after warmup, not resetting the std::unique_ptr!
-  stats_->reset();
+  reset();
   return err;
 }
 

--- a/extension/llm/runner/text_prefiller.cpp
+++ b/extension/llm/runner/text_prefiller.cpp
@@ -59,7 +59,6 @@ TextPrefiller::TextPrefiller(
       ET_CHECK_OK_OR_RETURN_ERROR(chunk_result.error());
       cur_token = chunk_result.get();
 
-      start_pos += num_tokens_to_prefill_with;
       num_tokens_to_process += num_tokens_to_prefill_with;
     }
 


### PR DESCRIPTION
In `text_prefiller.cpp` `prefill()` we are updating the `start_pos` inside `prefillChunk()` as well as outside. This PR fixes this issue. Also updating llama `main.cpp` to take `max_new_tokens`.
