### PR TITLE
Summary: ARM backend: Add skip markers for 16A8W quantization known t…

### DIFF
--- a/backends/arm/test/common.py
+++ b/backends/arm/test/common.py
@@ -237,6 +237,7 @@ def parametrize(
     arg_name: str,
     test_data: dict[str, Any],
     xfails: dict[str, xfail_type] | None = None,
+    skips: dict[str, str] | None = None,
     strict: bool = True,
     flakies: dict[str, int] | None = None,
 ) -> Decorator:
@@ -249,6 +250,8 @@ def parametrize(
     """
     if xfails is None:
         xfails = {}
+    if skips is None:
+        skips = {}
     if flakies is None:
         flakies = {}
 
@@ -259,6 +262,9 @@ def parametrize(
             if id in flakies:
                 # Mark this parameter as flaky with given reruns
                 marker = (pytest.mark.flaky(reruns=flakies[id]),)
+            elif id in skips:
+                # fail markers do not work with 'buck' based ci, so use skip instead
+                marker = (pytest.mark.skip(reason=skips[id]),)
             elif id in xfails:
                 xfail_info = xfails[id]
                 reason = ""

--- a/backends/arm/test/ops/test_linear.py
+++ b/backends/arm/test/ops/test_linear.py
@@ -308,18 +308,24 @@ def test_linear_16a8w_tosa_INT(test_data: torch.Tensor):
 
 
 x_fails = {}
+x_skips = {}
+
 for test_name in [
     "model_linear_rank4_zeros",
     "model_linear_rank4_negative_ones",
     "model_linear_rank4_negative_large_rand",
 ]:
     for set_per_chan in ["True", "False"]:
-        x_fails[test_name + ",per_channel_quant={}".format(set_per_chan)] = (
+        key = test_name + ",per_channel_quant={}".format(set_per_chan)
+        reason = (
             "MLETORCH-1452: AssertionError: Output 0 does not match reference output."
         )
+        x_fails[key] = reason
+        # TODO: Check why xfail doesn't work for this buck target. In the interim rely on skip
+        x_skips[key] = reason
 
 
-@common.parametrize("test_data", test_data_all_16a8w, x_fails)
+@common.parametrize("test_data", test_data_all_16a8w, xfails=x_fails, skips=x_skips)
 @common.XfailIfNoCorstone300
 def test_linear_16a8w_u55_INT16(test_data: torch.Tensor):
     """Test linear operation with 16A8W quantization on U55 (16-bit activations, 8-bit weights)"""


### PR DESCRIPTION
…est failures

Added skip functionality (because buck based targets do not seem to comply with xfail marker) to the test parametrize framework to handle known failing tests in ARM backend 16A8W quantization. The model_linear_rank4_zeros, model_linear_rank4_negative_ones, and model_linear_rank4_negative_large_rand test cases are now skipped due to bias quantization accuracy issues tracked in MLETORCH-1452. This prevents buck based CI from blocking while maintaining visibility of the known issues through proper test annotations.

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags:

### Summary
[PLEASE REMOVE] See [CONTRIBUTING.md's Pull Requests](https://github.com/pytorch/executorch/blob/main/CONTRIBUTING.md#pull-requests) for ExecuTorch PR guidelines.

[PLEASE REMOVE] If this PR closes an issue, please add a `Fixes #<issue-id>` line.

[PLEASE REMOVE] If this PR introduces a fix or feature that should be the upcoming release notes, please add a "Release notes: <area>" label. For a list of available release notes labels, check out [CONTRIBUTING.md's Pull Requests](https://github.com/pytorch/executorch/blob/main/CONTRIBUTING.md#pull-requests).

### Test plan
[PLEASE REMOVE] How did you test this PR? Please write down any manual commands you used and note down tests that you have written if applicable.
