### PR TITLE
Fix missing enum values in switch statements

### DIFF
--- a/extension/apple/ExecuTorch/Exported/ExecuTorchLog.mm
+++ b/extension/apple/ExecuTorch/Exported/ExecuTorchLog.mm
@@ -151,6 +151,7 @@ void et_pal_emit_log_message(et_timestamp_t timestamp,
   case kFatal:
     logType = OS_LOG_TYPE_FAULT;
     break;
+  case kUnknown:
   default:
     logType = OS_LOG_TYPE_DEFAULT;
     break;

--- a/extension/tensor/tensor_ptr.h
+++ b/extension/tensor/tensor_ptr.h
@@ -13,9 +13,12 @@
 #include <memory>
 #include <vector>
 
+#include <c10/macros/Macros.h>
 #include <executorch/runtime/core/error.h>
 #include <executorch/runtime/core/exec_aten/exec_aten.h>
 #include <executorch/runtime/core/exec_aten/util/scalar_type_util.h>
+
+C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wswitch-enum")
 
 namespace executorch {
 namespace extension {
@@ -478,3 +481,5 @@ runtime::Error resize_tensor_ptr(
 
 } // namespace extension
 } // namespace executorch
+
+C10_DIAGNOSTIC_POP()

--- a/runtime/core/exec_aten/util/scalar_type_util.h
+++ b/runtime/core/exec_aten/util/scalar_type_util.h
@@ -27,7 +27,10 @@
 #include <limits>
 #include <type_traits>
 
+#include <c10/macros/Macros.h>
 #include <executorch/runtime/platform/assert.h>
+
+C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wswitch-enum")
 
 #ifdef USE_ATEN_LIB
 // Note that a lot of the macros/functions defined in this ScalarTypeUtil.h file
@@ -1421,3 +1424,5 @@ using ::executorch::runtime::internal::U1;
 } // namespace internal
 } // namespace executor
 } // namespace torch
+
+C10_DIAGNOSTIC_POP()


### PR DESCRIPTION
Summary:
`-Wswitch-enum` was introduced in 2024 and is beneficial because it will err when switch statement is missing a case for an enum, even with `default:` present.  This helps alert developers when they add an enum value of all the switch statements that need updating.

These diffs are to help progress the codebase so that we can enable `-Wswitch-enum` by default in `fbobjc`

Differential Revision: D85956878


