### PR TITLE
Arm backend: Fix mypy warnings in test_dim_order.py

### DIFF
--- a/backends/arm/test/misc/test_dim_order.py
+++ b/backends/arm/test/misc/test_dim_order.py
@@ -17,7 +17,7 @@ from executorch.backends.arm.test.tester.test_pipeline import (
 )
 
 
-input_t1 = Tuple[torch.Tensor]  # Input x
+input_t1 = Tuple[torch.Tensor, ...]  # Input x
 
 
 class ChannelsLastInput(torch.nn.Module):


### PR DESCRIPTION
Add a missing fix for test_dim_order.py

Signed-off-by: per.held@arm.com
Change-Id: Iadafe078c7957215babf05a3d60ed102df97226d

