### PR TITLE
Fix test_aoti_torch_cuda__weight_int4pack_mm

### DIFF
--- a/backends/cuda/runtime/shims/tests/test_aoti_torch_cuda__weight_int4pack_mm.cpp
+++ b/backends/cuda/runtime/shims/tests/test_aoti_torch_cuda__weight_int4pack_mm.cpp
@@ -264,15 +264,6 @@ TEST_F(AOTITorchInt4MMTest, NullInputHandling) {
     EXPECT_EQ(error, Error::InvalidArgument)
         << "Should fail with null output pointer";
   }
-
-  // Test null output tensor (ret0 points to null)
-  {
-    Tensor* null_output = nullptr;
-    AOTITorchError error = aoti_torch_cuda__weight_int4pack_mm(
-        A, B, qGroupSize, qScaleAndZeros, &null_output);
-    EXPECT_EQ(error, Error::InvalidArgument)
-        << "Should fail with null output tensor";
-  }
 }
 
 // Test with larger batch size


### PR DESCRIPTION
Summary: Remove out-dated unit test. Code logic was changed, since the output tensor ptr can point to null,  but I forgot to update the corresponding unit test.

Reviewed By: Gasoonjia

Differential Revision: D85156554


