### PR TITLE
Expose fuse_view_copy to PySpeech

### DIFF
--- a/backends/transforms/targets.bzl
+++ b/backends/transforms/targets.bzl
@@ -96,6 +96,7 @@ def define_common_targets():
         srcs = ["fuse_view_copy.py"],
         visibility = [
             "//executorch/backends/...",
+            "@EXECUTORCH_CLIENTS",
         ],
         deps = [
             "//caffe2:torch",


### PR DESCRIPTION
Summary: As title. We expose the fuse_view_copy transform to EXECUTORCH_CLIENTS so that we can use it in PySpeech.

Differential Revision: D86140700


