### PR TITLE
Add CUDA backend to pybind

### DIFF
--- a/.ci/scripts/test_huggingface_optimum_model.py
+++ b/.ci/scripts/test_huggingface_optimum_model.py
@@ -214,15 +214,38 @@ def test_llm_with_image_modality(
         recipe,
         "--output_dir",
         model_dir,
-        "--use_custom_sdpa",
-        "--use_custom_kv_cache",
-        "--qlinear",
-        "8da4w",
-        "--qembedding",
-        "8w",
     ]
+
+    # Recipe-specific configurations
+    if "xnnpack" in recipe:
+        command += ["--use_custom_sdpa", "--use_custom_kv_cache"]
+        if quantize:
+            command += ["--qlinear", "8da4w", "--qembedding", "8w"]
+    elif recipe == "cuda":
+        command += ["--dtype", "bfloat16", "--device", "cuda"]
+        if quantize:
+            command += [
+                "--qlinear",
+                "4w",
+                "--qlinear_encoder",
+                "4w",
+                "--qlinear_packing_format",
+                "tile_packed_to_4d",
+                "--qlinear_encoder_packing_format",
+                "tile_packed_to_4d",
+            ]
+    else:
+        assert not quantize, f"Quantization not supported for {recipe} recipe"
+
     if not run_only:
         cli_export(command, model_dir)
+
+    # CUDA artifact validation
+    if recipe == "cuda":
+        model_path = Path(model_dir) / "model.pte"
+        cuda_blob_path = Path(model_dir) / "aoti_cuda_blob.ptd"
+        assert model_path.exists(), f"Main model file not found: {model_path}"
+        assert cuda_blob_path.exists(), f"CUDA blob not found: {cuda_blob_path}"
 
     tokenizer = AutoTokenizer.from_pretrained(model_id)
     saved_files = tokenizer.save_pretrained(model_dir)
@@ -262,7 +285,14 @@ def test_llm_with_image_modality(
 
     from executorch.extension.llm.runner import GenerationConfig, MultimodalRunner
 
-    runner = MultimodalRunner(f"{model_dir}/model.pte", tokenizer_path)
+    # Recipe-specific MultimodalRunner instantiation
+    if recipe == "cuda":
+        runner = MultimodalRunner(
+            f"{model_dir}/model.pte", tokenizer_path, f"{model_dir}/aoti_cuda_blob.ptd"
+        )
+    else:
+        runner = MultimodalRunner(f"{model_dir}/model.pte", tokenizer_path)
+
     generated_text = runner.generate_text_hf(
         inputs,
         GenerationConfig(max_new_tokens=128, temperature=0, echo=False),

--- a/.github/workflows/cuda-windows.yml
+++ b/.github/workflows/cuda-windows.yml
@@ -66,6 +66,8 @@ jobs:
         echo "::endgroup::"
 
         echo "::group::Setup ExecuTorch"
+        # Disable MKL to avoid duplicate target error when conda has multiple MKL installations
+        export USE_MKL=OFF
         PYTHON_EXECUTABLE=python ./install_executorch.sh
         echo "::endgroup::"
 

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -164,6 +164,8 @@ jobs:
         set -eux
 
         echo "::group::Setup ExecuTorch"
+        # Disable MKL to avoid duplicate target error when conda has multiple MKL installations
+        export USE_MKL=OFF
         ./install_executorch.sh
         echo "::endgroup::"
 
@@ -221,3 +223,68 @@ jobs:
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       script: |
         source .ci/scripts/test_model_e2e.sh cuda "${{ matrix.model.repo }}/${{ matrix.model.name }}" "${{ matrix.quant }}" "${RUNNER_ARTIFACT_DIR}"
+
+  test-cuda-pybind:
+    name: test-cuda-pybind
+    needs: export-model-cuda-artifact
+    # This job downloads models exported by export-model-cuda-artifact and runs them using pybind.
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    permissions:
+      id-token: write
+      contents: read
+    secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        model: ["gemma3-4b"]
+        quantize: ["", "--quantize"]
+    with:
+      timeout: 120
+      secrets-env: EXECUTORCH_HF_TOKEN
+      download-artifact: google-gemma-3-4b-it-cuda-${{ matrix.quantize && 'quantized-int4-tile-packed' || 'non-quantized' }}
+      runner: linux.g5.4xlarge.nvidia.gpu
+      gpu-arch-type: cuda
+      gpu-arch-version: 12.6
+      use-custom-docker-registry: false
+      submodules: recursive
+      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      script: |
+        set -eux
+
+        echo "::group::Setup ExecuTorch"
+        # Disable MKL to avoid duplicate target error when conda has multiple MKL installations
+        export USE_MKL=OFF
+        ./install_executorch.sh
+        echo "::endgroup::"
+
+        echo "::group::Fix libstdc++ GLIBCXX version"
+        # The embedded .so files in the CUDA blob require GLIBCXX_3.4.29
+        # which the default conda libstdc++ doesn't have. Install a newer
+        # libstdc++ from conda-forge and use it via LD_PRELOAD.
+        conda install -y -c conda-forge 'libstdcxx-ng>=12'
+        export LD_LIBRARY_PATH=/opt/conda/lib:$LD_LIBRARY_PATH
+        # Verify the new libstdc++ has GLIBCXX_3.4.29
+        strings /opt/conda/lib/libstdc++.so.6 | grep GLIBCXX_3.4.29 || {
+            echo "Error: GLIBCXX_3.4.29 not found in /opt/conda/lib/libstdc++.so.6"
+            exit 1
+        }
+        echo "::endgroup::"
+
+        echo "::group::Setup Huggingface"
+        pip install -U "huggingface_hub[cli]<1.0"
+        huggingface-cli login --token $SECRET_EXECUTORCH_HF_TOKEN
+        echo "::endgroup::"
+
+        echo "::group::Install optimum-executorch"
+        OPTIMUM_ET_VERSION=$(cat .ci/docker/ci_commit_pins/optimum-executorch.txt)
+        pip install git+https://github.com/huggingface/optimum-executorch.git@${OPTIMUM_ET_VERSION}
+        echo "::endgroup::"
+
+        echo "::group::Test CUDA Multimodal: ${{ matrix.model }} ${{ matrix.quantize }}"
+        python .ci/scripts/test_huggingface_optimum_model.py \
+          --model ${{ matrix.model }} \
+          --recipe cuda \
+          --model_dir "${RUNNER_ARTIFACT_DIR}" \
+          --run_only \
+          ${{ matrix.quantize }}
+        echo "::endgroup::"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -668,6 +668,16 @@ if(EXECUTORCH_BUILD_CORTEX_M)
   list(APPEND _executorch_backends coretex_m_backend)
 endif()
 
+# If CUDA, Metal, or pybind will need Torch, find it at root scope first so that
+# imported targets (e.g. MKL::MKL) aren't created in child directory scopes and
+# then duplicated when found again at root scope.
+if(EXECUTORCH_BUILD_CUDA
+   OR EXECUTORCH_BUILD_METAL
+   OR EXECUTORCH_BUILD_PYBIND
+)
+  find_package_torch()
+endif()
+
 # Build common AOTI functionality if needed by CUDA or Metal backends
 if(EXECUTORCH_BUILD_CUDA OR EXECUTORCH_BUILD_METAL)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/backends/aoti)
@@ -885,6 +895,15 @@ if(EXECUTORCH_BUILD_PYBIND)
       util
       torch
   )
+
+  # Build common AOTI functionality if needed by CUDA or Metal backends
+  if(EXECUTORCH_BUILD_CUDA)
+    # CUDA uses SlimTensor-based shims
+    list(APPEND _dep_libs aoti_cuda_backend)
+  elseif(EXECUTORCH_BUILD_METAL)
+    # Metal still uses ETensor-based shims (for now)
+    list(APPEND _dep_libs aoti_common)
+  endif()
 
   # RPATH for _portable_lib.so
   set(_portable_lib_rpath "$ORIGIN/../../../torch/lib")

--- a/backends/cuda/runtime/platform/platform.cpp
+++ b/backends/cuda/runtime/platform/platform.cpp
@@ -11,6 +11,7 @@
 #include <executorch/runtime/core/error.h>
 #include <executorch/runtime/core/result.h>
 #include <filesystem>
+#include <mutex>
 #include <string>
 
 #ifdef _WIN32
@@ -41,6 +42,28 @@ executorch::runtime::Result<void*> load_library(
   }
 
 #else
+  // Before loading the delegate .so, we need to ensure symbols from the current
+  // process (e.g., _portable_lib.so) are globally visible. Python loads modules
+  // with RTLD_LOCAL by default, so we re-open the current module with
+  // RTLD_GLOBAL | RTLD_NOLOAD to promote its symbols to global visibility.
+  // This allows the delegate .so to resolve symbols like aoti_torch_dtype_*.
+  static std::once_flag symbols_promoted_flag;
+  std::call_once(symbols_promoted_flag, []() {
+    Dl_info info;
+    // Get info about a symbol we know exists in _portable_lib.so
+    if (dladdr((void*)&load_library, &info) && info.dli_fname) {
+      // Re-open with RTLD_GLOBAL | RTLD_NOLOAD to promote symbols
+      void* handle =
+          dlopen(info.dli_fname, RTLD_NOW | RTLD_GLOBAL | RTLD_NOLOAD);
+      if (!handle) {
+        ET_LOG(Error, "Failed to promote symbols: %s", dlerror());
+      } else {
+        // Close the handle after successful promotion
+        dlclose(handle);
+      }
+    }
+  });
+
   std::string path_str = path.string();
   void* lib_handle = dlopen(path_str.c_str(), RTLD_LAZY | RTLD_LOCAL);
   if (lib_handle == nullptr) {

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -18,15 +18,6 @@ from torch_pin import NIGHTLY_VERSION, TORCH_VERSION
 # This will be dynamically set based on CUDA availability and CUDA backend enabled/disabled.
 TORCH_NIGHTLY_URL_BASE = "https://download.pytorch.org/whl/nightly"
 
-# Supported CUDA versions - modify this to add/remove supported versions
-# Format: tuple of (major, minor) version numbers
-SUPPORTED_CUDA_VERSIONS = (
-    (12, 6),
-    (12, 8),
-    (12, 9),
-    (13, 0),
-)
-
 # Since ExecuTorch often uses main-branch features of pytorch, only the nightly
 # pip versions will have the required features.
 #
@@ -39,7 +30,7 @@ SUPPORTED_CUDA_VERSIONS = (
 # https://hud.pytorch.org/hud/pytorch/pytorch/nightly/ @lint-ignore
 #
 # NOTE: If you're changing, make the corresponding supported CUDA versions in
-# SUPPORTED_CUDA_VERSIONS above if needed.
+# SUPPORTED_CUDA_VERSIONS in install_utils.py if needed.
 
 
 def install_requirements(use_pytorch_nightly):
@@ -53,7 +44,7 @@ def install_requirements(use_pytorch_nightly):
         sys.exit(1)
 
     # Determine the appropriate PyTorch URL based on CUDA delegate status
-    torch_url = determine_torch_url(TORCH_NIGHTLY_URL_BASE, SUPPORTED_CUDA_VERSIONS)
+    torch_url = determine_torch_url(TORCH_NIGHTLY_URL_BASE)
 
     # pip packages needed by exir.
     TORCH_PACKAGE = [
@@ -123,7 +114,7 @@ def install_requirements(use_pytorch_nightly):
 
 def install_optional_example_requirements(use_pytorch_nightly):
     # Determine the appropriate PyTorch URL based on CUDA delegate status
-    torch_url = determine_torch_url(TORCH_NIGHTLY_URL_BASE, SUPPORTED_CUDA_VERSIONS)
+    torch_url = determine_torch_url(TORCH_NIGHTLY_URL_BASE)
 
     print("Installing torch domain libraries")
     DOMAIN_LIBRARIES = [

--- a/install_utils.py
+++ b/install_utils.py
@@ -10,30 +10,57 @@ import platform
 import re
 import subprocess
 import sys
+from typing import List, Optional
+
+# Supported CUDA versions - modify this to add/remove supported versions
+# Format: tuple of (major, minor) version numbers
+SUPPORTED_CUDA_VERSIONS = (
+    (12, 6),
+    (12, 8),
+    (12, 9),
+    (13, 0),
+)
 
 
-def _cuda_version_to_pytorch_suffix(major, minor):
+def is_cmake_option_on(
+    cmake_configuration_args: List[str], var_name: str, default: bool
+) -> bool:
     """
-    Generate PyTorch CUDA wheel suffix from CUDA version numbers.
+    Get a boolean CMake variable, from a list of CMake configuration arguments.
+    The var_name should not include the "-D" prefix.
 
     Args:
-        major: CUDA major version (e.g., 12)
-        minor: CUDA minor version (e.g., 6)
+        cmake_configuration_args: List of CMake configuration arguments.
+        var_name: Name of the CMake variable.
+        default: Default boolean value if the variable is not set.
 
     Returns:
-        PyTorch wheel suffix string (e.g., "cu126")
+        Boolean value of the CMake variable.
     """
-    return f"cu{major}{minor}"
+    cmake_define = _extract_cmake_define(cmake_configuration_args, var_name)
+
+    return _normalize_cmake_bool(cmake_define, default)
+
+
+def is_cuda_available() -> bool:
+    """
+    Check if CUDA is available on the system by attempting to get the CUDA version.
+
+    Returns:
+        True if CUDA is available and supported, False otherwise.
+    """
+    try:
+        _get_cuda_version()
+        return True
+    except Exception:
+        return False
 
 
 @functools.lru_cache(maxsize=1)
-def _get_cuda_version(supported_cuda_versions):
+def _get_cuda_version():
     """
     Get the CUDA version installed on the system using nvcc command.
     Returns a tuple (major, minor).
-
-    Args:
-        supported_cuda_versions: List of supported CUDA versions as tuples
 
     Raises:
         RuntimeError: if nvcc is not found or version cannot be parsed
@@ -50,9 +77,9 @@ def _get_cuda_version(supported_cuda_versions):
             major, minor = int(match.group(1)), int(match.group(2))
 
             # Check if the detected version is supported
-            if (major, minor) not in supported_cuda_versions:
+            if (major, minor) not in SUPPORTED_CUDA_VERSIONS:
                 available_versions = ", ".join(
-                    [f"{maj}.{min}" for maj, min in supported_cuda_versions]
+                    [f"{maj}.{min}" for maj, min in SUPPORTED_CUDA_VERSIONS]
                 )
                 raise RuntimeError(
                     f"Detected CUDA version {major}.{minor} is not supported. "
@@ -76,6 +103,39 @@ def _get_cuda_version(supported_cuda_versions):
         )
 
 
+def _extract_cmake_define(args: List[str], name: str) -> Optional[str]:
+    prefix = f"-D{name}="
+    for arg in args:
+        if arg.startswith(prefix):
+            return arg[len(prefix) :]
+    return None
+
+
+def _normalize_cmake_bool(value: Optional[str], default: bool = False) -> bool:
+    if value is None:
+        return default
+    normalized = value.strip().upper()
+    if normalized in {"ON", "1", "TRUE", "YES"}:
+        return True
+    if normalized in {"OFF", "0", "FALSE", "NO"}:
+        return False
+    return default
+
+
+def _cuda_version_to_pytorch_suffix(major, minor):
+    """
+    Generate PyTorch CUDA wheel suffix from CUDA version numbers.
+
+    Args:
+        major: CUDA major version (e.g., 12)
+        minor: CUDA minor version (e.g., 6)
+
+    Returns:
+        PyTorch wheel suffix string (e.g., "cu126")
+    """
+    return f"cu{major}{minor}"
+
+
 def _get_pytorch_cuda_url(cuda_version, torch_nightly_url_base):
     """
     Get the appropriate PyTorch CUDA URL for the given CUDA version.
@@ -95,14 +155,13 @@ def _get_pytorch_cuda_url(cuda_version, torch_nightly_url_base):
 
 
 @functools.lru_cache(maxsize=1)
-def determine_torch_url(torch_nightly_url_base, supported_cuda_versions):
+def determine_torch_url(torch_nightly_url_base):
     """
     Determine the appropriate PyTorch installation URL based on CUDA availability.
     Uses @functools.lru_cache to avoid redundant CUDA detection and print statements.
 
     Args:
         torch_nightly_url_base: Base URL for PyTorch nightly packages
-        supported_cuda_versions: List of supported CUDA versions as tuples
 
     Returns:
         URL string for PyTorch packages
@@ -116,7 +175,7 @@ def determine_torch_url(torch_nightly_url_base, supported_cuda_versions):
     print("Attempting to detect CUDA via nvcc...")
 
     try:
-        cuda_version = _get_cuda_version(supported_cuda_versions)
+        cuda_version = _get_cuda_version()
     except Exception as err:
         print(f"CUDA detection failed ({err}), using CPU-only PyTorch")
         return f"{torch_nightly_url_base}/cpu"

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ import contextlib
 
 # Import this before distutils so that setuptools can intercept the distuils
 # imports.
+import importlib.util
 import logging
 import os
 import re
@@ -61,6 +62,16 @@ from distutils import log  # type: ignore[import-not-found]
 from distutils.sysconfig import get_python_lib  # type: ignore[import-not-found]
 from pathlib import Path
 from typing import List, Optional
+
+# Clean dynamic import using importlib
+_install_utils_path = Path(__file__).parent / "install_utils.py"
+_spec = importlib.util.spec_from_file_location("install_utils", _install_utils_path)
+if _spec is None:
+    raise ImportError(f"Could not create module spec for {_install_utils_path}")
+install_utils = importlib.util.module_from_spec(_spec)
+if _spec.loader is None:
+    raise ImportError(f"Module spec has no loader for {_install_utils_path}")
+_spec.loader.exec_module(install_utils)
 
 from setuptools import Extension, setup
 from setuptools.command.build import build
@@ -688,6 +699,13 @@ class CustomBuild(build):
             item for item in re.split(r"\s+", os.environ.get("CMAKE_ARGS", "")) if item
         ]
 
+        # Check if CUDA is available, and if so, enable building the CUDA
+        # backend by default.
+        if install_utils.is_cuda_available() and install_utils.is_cmake_option_on(
+            cmake_configuration_args, "EXECUTORCH_BUILD_CUDA", default=True
+        ):
+            cmake_configuration_args += ["-DEXECUTORCH_BUILD_CUDA=ON"]
+
         with Buck2EnvironmentFixer():
             # Generate the cmake cache from scratch to ensure that the cache state
             # is predictable.
@@ -742,6 +760,10 @@ class CustomBuild(build):
 
         if cmake_cache.is_enabled("EXECUTORCH_BUILD_EXTENSION_LLM_RUNNER"):
             cmake_build_args += ["--target", "_llm_runner"]
+
+        if cmake_cache.is_enabled("EXECUTORCH_BUILD_CUDA"):
+            cmake_build_args += ["--target", "aoti_cuda_backend"]
+            cmake_build_args += ["--target", "aoti_common_shims_slim"]
 
         if cmake_cache.is_enabled("EXECUTORCH_BUILD_EXTENSION_MODULE"):
             cmake_build_args += ["--target", "extension_module"]


### PR DESCRIPTION
This PR integrates CUDA and AOTI support into the pybind build system. The implementation starts by updating setup.py to automatically detect CUDA availability using install_utils.py functions, replacing the problematic sys.path hack with a clean importlib-based approach. This enables automatic building of CUDA and AOTI targets when CUDA is detected on the system.

The changes then extend to CUDA runtime shims for SlimTensor support, update AOTI build targets and common shims, and enhance CI workflows for CUDA testing. The implementation ensures proper symbol resolution when loading AOTI-produced shared libraries.

## Test Plan

- [x] Verified setup.py imports work correctly without sys.path modifications
- [x] Confirmed CUDA detection functionality works as expected
- [x] Validated that install_utils functions are accessible via importlib approach
- [x] Tested setup.py basic functionality (--help, --version) still works
- [x] Confirmed Python syntax validation passes for all modified files

Co-Authored-By: Claude Sonnet 4 <noreply@anthropic.com>