### PR TITLE
Arm backend: Use correct log-level in tests

### DIFF
--- a/backends/arm/_passes/decompose_embedding_pass.py
+++ b/backends/arm/_passes/decompose_embedding_pass.py
@@ -17,7 +17,6 @@ from executorch.exir.pass_base import ExportPass, PassResult
 from .arm_pass_utils import create_node, get_first_fake_tensor
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.WARNING)
 
 
 class DecomposeEmbeddingPass(ArmPass):

--- a/backends/arm/ethosu/backend.py
+++ b/backends/arm/ethosu/backend.py
@@ -63,7 +63,7 @@ class EthosUBackend(BackendDetails):
         binary = vela_compile(
             tosa_flatbuffer,
             compile_flags,
-            verbose=logger.getEffectiveLevel() == logging.INFO,
+            verbose=logger.getEffectiveLevel() <= logging.INFO,
             intermediate_path=compile_spec.get_intermediate_path(),
         )
         return binary

--- a/backends/arm/operator_support/right_shift_support.py
+++ b/backends/arm/operator_support/right_shift_support.py
@@ -48,5 +48,5 @@ class RightShiftSupported(SupportedTOSAOperatorCheck):
         """
         # TODO MLETORCH-525 Remove warning
         if tosa_spec.is_U55_subset:
-            logging.warning(f"{node.target} may introduce one-off errors.")
+            logger.warning(f"{node.target} may introduce one-off errors.")
         return True

--- a/backends/arm/operator_support/slice_copy_support.py
+++ b/backends/arm/operator_support/slice_copy_support.py
@@ -32,6 +32,6 @@ class SliceCopySupported(SupportedTOSAOperatorCheck):
 
         args = node.args
         if len(args) == 5 and (step := args[4]) != 1:
-            logging.warning(f"{node.target} with step size of {step} not supported.")
+            logger.warning(f"{node.target} with step size of {step} not supported.")
             return False
         return True

--- a/backends/arm/test/conftest.py
+++ b/backends/arm/test/conftest.py
@@ -6,10 +6,11 @@
 import logging
 import os
 import random
-import sys
 from typing import Any
 
 import pytest
+
+logger = logging.getLogger(__name__)
 
 """
 This file contains the pytest hooks, fixtures etc. for the Arm test suite.
@@ -28,8 +29,6 @@ def pytest_configure(config):
     pytest._test_options["tosa_version"] = "1.0"  # type: ignore[attr-defined]
     if config.option.arm_run_tosa_version:
         pytest._test_options["tosa_version"] = config.option.arm_run_tosa_version
-
-    logging.basicConfig(level=logging.INFO, stream=sys.stdout)
 
 
 def pytest_collection_modifyitems(config, items):
@@ -98,7 +97,7 @@ def set_random_seed():
                 "ARM_TEST_SEED env variable must be integers or the string RANDOM"
             )
 
-    print(f" ARM_TEST_SEED={seed} ", end=" ")
+    logger.info(f"ARM_TEST_SEED={seed}")
 
 
 # ==== End of Pytest fixtures =====

--- a/backends/arm/test/conftest.py
+++ b/backends/arm/test/conftest.py
@@ -3,14 +3,11 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import logging
 import os
 import random
 from typing import Any
 
 import pytest
-
-logger = logging.getLogger(__name__)
 
 """
 This file contains the pytest hooks, fixtures etc. for the Arm test suite.
@@ -97,7 +94,7 @@ def set_random_seed():
                 "ARM_TEST_SEED env variable must be integers or the string RANDOM"
             )
 
-    logger.info(f"ARM_TEST_SEED={seed}")
+    print(f" ARM_TEST_SEED={seed} ", end=" ")
 
 
 # ==== End of Pytest fixtures =====

--- a/backends/arm/test/misc/test_debug_feats.py
+++ b/backends/arm/test/misc/test_debug_feats.py
@@ -23,7 +23,6 @@ from executorch.backends.arm.test.tester.test_pipeline import (
 )
 from executorch.backends.test.harness.stages import StageType
 
-
 input_t1 = Tuple[torch.Tensor]  # Input x
 
 
@@ -261,14 +260,14 @@ def test_dump_tosa_debug_tosa(test_data: input_t1):
 
 
 @common.parametrize("test_data", Linear.inputs)
-def test_dump_tosa_ops(caplog, test_data: input_t1):
+def test_dump_tosa_ops(capsys, test_data: input_t1):
     aten_ops: list[str] = []
     exir_ops: list[str] = []
     pipeline = TosaPipelineINT[input_t1](Linear(), test_data, aten_ops, exir_ops)
     pipeline.pop_stage("run_method_and_compare_outputs")
     pipeline.dump_operator_distribution("to_edge_transform_and_lower")
     pipeline.run()
-    assert "TOSA operators:" in caplog.text
+    assert "TOSA operators:" in capsys.readouterr().out
 
 
 class Add(torch.nn.Module):
@@ -282,7 +281,7 @@ class Add(torch.nn.Module):
 
 @common.parametrize("test_data", Add.inputs)
 @common.XfailIfNoCorstone300
-def test_fail_dump_tosa_ops(caplog, test_data: input_t1):
+def test_fail_dump_tosa_ops(capsys, test_data: input_t1):
     aten_ops: list[str] = []
     exir_ops: list[str] = []
     pipeline = EthosU55PipelineINT[input_t1](
@@ -290,4 +289,7 @@ def test_fail_dump_tosa_ops(caplog, test_data: input_t1):
     )
     pipeline.dump_operator_distribution("to_edge_transform_and_lower")
     pipeline.run()
-    assert "Can not get operator distribution for Vela command stream." in caplog.text
+    assert (
+        "Can not get operator distribution for Vela command stream."
+        in capsys.readouterr().out
+    )

--- a/backends/arm/test/models/test_deit_tiny_arm.py
+++ b/backends/arm/test/models/test_deit_tiny_arm.py
@@ -23,7 +23,6 @@ from timm.data import IMAGENET_INCEPTION_MEAN, IMAGENET_INCEPTION_STD
 from torchvision import transforms
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 deit_tiny = timm.models.deit.deit_tiny_patch16_224(pretrained=True)

--- a/backends/arm/test/runner_utils.py
+++ b/backends/arm/test/runner_utils.py
@@ -763,11 +763,11 @@ def run_tosa_graph(
     if isinstance(tosa_version, Tosa_1_00):
         import tosa_reference_model as reference_model  # type: ignore[import-untyped]
 
-        debug_mode = "ALL" if logger.level <= logging.DEBUG else None
+        debug_mode = "ALL" if logger.getEffectiveLevel() <= logging.DEBUG else None
         outputs_np, status = reference_model.run(
             graph,
             inputs_np,
-            verbosity=_tosa_refmodel_loglevel(logger.level),
+            verbosity=_tosa_refmodel_loglevel(logger.getEffectiveLevel()),
             initialize_variable_tensor_from_numpy=True,
             debug_mode=debug_mode,
         )

--- a/backends/arm/test/tester/analyze_output_utils.py
+++ b/backends/arm/test/tester/analyze_output_utils.py
@@ -312,11 +312,8 @@ def dump_error_output(
 
 
 if __name__ == "__main__":
-    import sys
 
-    logging.basicConfig(stream=sys.stdout, level=logging.INFO)
-
-    """ This is expected to produce the example output of print_diff"""
+    """This is expected to produce the example output of print_diff"""
     torch.manual_seed(0)
     a = torch.rand(3, 3, 2, 2) * 0.01
     b = a.clone().detach()

--- a/backends/arm/test/tester/arm_tester.py
+++ b/backends/arm/test/tester/arm_tester.py
@@ -832,7 +832,7 @@ def _dump_str(to_print: str, path_to_dump: Optional[str] = None):
         with open(path_to_dump, "a") as fp:
             fp.write(to_print)
     else:
-        logger.info(to_print)
+        print(to_print)
 
 
 def _format_dict(to_print: dict, print_table: bool = True) -> str:


### PR DESCRIPTION
Arm tests logged too much as comparisons with logger.level were used instead of logger.getEffectiveLevel(). logger.level will always be logging.NOTSET unless explicitly set with logger.setLevel() which we want to avoid. Instead, we should use logger.getEffectiveLevel() which will inherit the level from its parent.


cc @freddan80 @per @zingo @digantdesai