### PR TITLE
Kernel util warnings

### DIFF
--- a/extension/data_loader/mman.h
+++ b/extension/data_loader/mman.h
@@ -13,6 +13,7 @@
 
 #include <executorch/runtime/platform/compiler.h>
 #include <sys/stat.h>
+#include <cstdint>
 
 #ifndef _WIN32
 
@@ -75,8 +76,8 @@ ET_INLINE int get_file_stat(int fd, size_t* out_size) {
 /**
  * Platform-specific mmap offset type conversion.
  */
-ET_INLINE std::uint64_t get_mmap_offset(size_t offset) {
-  return static_cast<std::uint64_t>(offset);
+ET_INLINE uint64_t get_mmap_offset(size_t offset) {
+  return static_cast<uint64_t>(offset);
 }
 
 #endif

--- a/extension/data_loader/mman.h
+++ b/extension/data_loader/mman.h
@@ -12,11 +12,11 @@
 #pragma once
 
 #include <executorch/runtime/platform/compiler.h>
+#include <sys/stat.h>
 
 #ifndef _WIN32
 
 #include <sys/mman.h>
-#include <sys/stat.h>
 #include <unistd.h>
 
 ET_INLINE size_t get_os_page_size() {
@@ -48,7 +48,6 @@ ET_INLINE off_t get_mmap_offset(size_t offset) {
 #include <windows.h>
 #undef NOMINMAX
 #include <io.h>
-#include <sys/stat.h>
 
 #include <executorch/extension/data_loader/mman_windows.h>
 

--- a/extension/data_loader/mman.h
+++ b/extension/data_loader/mman.h
@@ -19,7 +19,6 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-
 ET_INLINE size_t get_os_page_size() {
   return sysconf(_SC_PAGESIZE);
 }
@@ -50,7 +49,6 @@ ET_INLINE off_t get_mmap_offset(size_t offset) {
 #undef NOMINMAX
 #include <io.h>
 #include <sys/stat.h>
-
 
 #include <executorch/extension/data_loader/mman_windows.h>
 

--- a/extension/data_loader/mman_windows.cpp
+++ b/extension/data_loader/mman_windows.cpp
@@ -21,8 +21,8 @@
 
 #include <errno.h>
 #include <io.h>
-#include <limits>
 #include <cstdint>
+#include <limits>
 #define NOMINMAX
 #include <windows.h>
 #undef NOMINMAX
@@ -162,12 +162,14 @@ void* mmap(
   const std::uint64_t maxSize = off + static_cast<std::uint64_t>(len);
 
   const DWORD dwFileOffsetLow = static_cast<DWORD>(off & 0xFFFFFFFFULL);
-  const DWORD dwFileOffsetHigh = static_cast<DWORD>((off >> 32) & 0xFFFFFFFFULL);
+  const DWORD dwFileOffsetHigh =
+      static_cast<DWORD>((off >> 32) & 0xFFFFFFFFULL);
   const DWORD protect = __map_mmap_prot_page(prot);
   const DWORD desiredAccess = __map_mmap_prot_file(prot);
 
   const DWORD dwMaxSizeLow = static_cast<DWORD>(maxSize & 0xFFFFFFFFULL);
-  const DWORD dwMaxSizeHigh = static_cast<DWORD>((maxSize >> 32) & 0xFFFFFFFFULL);
+  const DWORD dwMaxSizeHigh =
+      static_cast<DWORD>((maxSize >> 32) & 0xFFFFFFFFULL);
 
   h = ((flags & MAP_ANONYMOUS) == 0) ? (HANDLE)_get_osfhandle(fildes)
                                      : INVALID_HANDLE_VALUE;

--- a/extension/data_loader/mman_windows.cpp
+++ b/extension/data_loader/mman_windows.cpp
@@ -23,7 +23,9 @@
 #include <io.h>
 #include <limits>
 #include <cstdint>
+#define NOMINMAX
 #include <windows.h>
+#undef NOMINMAX
 
 #ifndef STATUS_SECTION_TOO_BIG
 #define STATUS_SECTION_TOO_BIG 0xC0000040L

--- a/extension/data_loader/mman_windows.cpp
+++ b/extension/data_loader/mman_windows.cpp
@@ -139,7 +139,7 @@ void* mmap(
     int prot,
     int flags,
     int fildes,
-    std::uint64_t off) {
+    uint64_t off) {
   HANDLE fm, h;
   void* map = MAP_FAILED;
 

--- a/extension/data_loader/mman_windows.cpp
+++ b/extension/data_loader/mman_windows.cpp
@@ -21,6 +21,8 @@
 
 #include <errno.h>
 #include <io.h>
+#include <limits>
+#include <cstdint>
 #include <windows.h>
 
 #ifndef STATUS_SECTION_TOO_BIG
@@ -129,48 +131,41 @@ static DWORD __map_mmap_prot_file(const int prot) {
 
 } // namespace
 
-void* mmap(void* addr, size_t len, int prot, int flags, int fildes, off_t off) {
+void* mmap(
+    void* addr,
+    size_t len,
+    int prot,
+    int flags,
+    int fildes,
+    std::uint64_t off) {
   HANDLE fm, h;
-
   void* map = MAP_FAILED;
-
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4293)
-#endif
-
-  const DWORD dwFileOffsetLow = (sizeof(off_t) <= sizeof(DWORD))
-      ? (DWORD)off
-      : (DWORD)(off & 0xFFFFFFFFL);
-  const DWORD dwFileOffsetHigh = (sizeof(off_t) <= sizeof(DWORD))
-      ? (DWORD)0
-      : (DWORD)((off >> 32) & 0xFFFFFFFFL);
-  const DWORD protect = __map_mmap_prot_page(prot);
-  const DWORD desiredAccess = __map_mmap_prot_file(prot);
-
-  const off_t maxSize = off + (off_t)len;
-
-  const DWORD dwMaxSizeLow = (sizeof(off_t) <= sizeof(DWORD))
-      ? (DWORD)maxSize
-      : (DWORD)(maxSize & 0xFFFFFFFFL);
-  const DWORD dwMaxSizeHigh = (sizeof(off_t) <= sizeof(DWORD))
-      ? (DWORD)0
-      : (DWORD)((maxSize >> 32) & 0xFFFFFFFFL);
-
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 
   errno = 0;
 
   if (len == 0
       /* Unsupported flag combinations */
       || (flags & MAP_FIXED) != 0
-      /* Usupported protection combinations */
+      /* Unsupported protection combinations */
       || prot == PROT_EXEC) {
     errno = EINVAL;
     return MAP_FAILED;
   }
+
+  if (off > std::numeric_limits<std::uint64_t>::max() - len) {
+    errno = EINVAL;
+    return MAP_FAILED;
+  }
+
+  const std::uint64_t maxSize = off + static_cast<std::uint64_t>(len);
+
+  const DWORD dwFileOffsetLow = static_cast<DWORD>(off & 0xFFFFFFFFULL);
+  const DWORD dwFileOffsetHigh = static_cast<DWORD>((off >> 32) & 0xFFFFFFFFULL);
+  const DWORD protect = __map_mmap_prot_page(prot);
+  const DWORD desiredAccess = __map_mmap_prot_file(prot);
+
+  const DWORD dwMaxSizeLow = static_cast<DWORD>(maxSize & 0xFFFFFFFFULL);
+  const DWORD dwMaxSizeHigh = static_cast<DWORD>((maxSize >> 32) & 0xFFFFFFFFULL);
 
   h = ((flags & MAP_ANONYMOUS) == 0) ? (HANDLE)_get_osfhandle(fildes)
                                      : INVALID_HANDLE_VALUE;

--- a/extension/data_loader/mman_windows.h
+++ b/extension/data_loader/mman_windows.h
@@ -31,6 +31,7 @@
 #endif
 
 #include <sys/types.h>
+#include <cstdint>
 
 #ifdef __cplusplus
 extern "C" {
@@ -56,7 +57,13 @@ extern "C" {
 #define MS_SYNC 2
 #define MS_INVALIDATE 4
 
-void* mmap(void* addr, size_t len, int prot, int flags, int fildes, off_t off);
+void* mmap(
+    void* addr,
+    size_t len,
+    int prot,
+    int flags,
+    int fildes,
+    std::uint64_t off);
 int munmap(void* addr, size_t len);
 int mprotect(void* addr, size_t len, int prot);
 int msync(void* addr, size_t len, int flags);

--- a/extension/data_loader/mman_windows.h
+++ b/extension/data_loader/mman_windows.h
@@ -63,7 +63,7 @@ void* mmap(
     int prot,
     int flags,
     int fildes,
-    std::uint64_t off);
+    uint64_t off);
 int munmap(void* addr, size_t len);
 int mprotect(void* addr, size_t len, int prot);
 int msync(void* addr, size_t len, int flags);

--- a/extension/data_loader/mmap_data_loader.cpp
+++ b/extension/data_loader/mmap_data_loader.cpp
@@ -9,9 +9,9 @@
 #include <executorch/extension/data_loader/mmap_data_loader.h>
 
 #include <cerrno>
+#include <cstdint>
 #include <cstring>
 #include <limits>
-#include <cstdint>
 
 #include <fcntl.h>
 #include <sys/stat.h>
@@ -203,13 +203,8 @@ Result<FreeableBuffer> MmapDataLoader::load(
   // can also map the same pages and share the same memory.
   const auto map_offset = get_mmap_offset(range.start);
 
-  void* pages = ::mmap(
-      nullptr,
-      map_size,
-      PROT_READ,
-      MAP_SHARED,
-      fd_,
-      map_offset);
+  void* pages =
+      ::mmap(nullptr, map_size, PROT_READ, MAP_SHARED, fd_, map_offset);
   ET_CHECK_OR_RETURN_ERROR(
       pages != MAP_FAILED,
       AccessFailed,
@@ -313,13 +308,8 @@ Error MmapDataLoader::load_into(
   // modifying the file.
   const auto map_offset = get_mmap_offset(range.start);
 
-  void* pages = ::mmap(
-      nullptr,
-      map_size,
-      PROT_READ,
-      MAP_PRIVATE,
-      fd_,
-      map_offset);
+  void* pages =
+      ::mmap(nullptr, map_size, PROT_READ, MAP_PRIVATE, fd_, map_offset);
   ET_CHECK_OR_RETURN_ERROR(
       pages != MAP_FAILED,
       AccessFailed,

--- a/extension/data_loader/test/mmap_data_loader_test.cpp
+++ b/extension/data_loader/test/mmap_data_loader_test.cpp
@@ -435,6 +435,13 @@ TEST_F(MmapDataLoaderTest, LoadIntoCopiesOffsetCorrectly) {
 // This test verifies that offsets and sizes beyond 32-bit limits are handled
 // correctly by creating a sparse file with data at a large offset.
 TEST_F(MmapDataLoaderTest, LargeFileOffsetSupport) {
+// We run some 32 bit tests on Linux so we need to skip this
+// test.
+#ifndef _WIN32
+  if (sizeof(off_t) <= 8) {
+    return;
+  }
+#endif
   // Create a sparse file with a marker at an offset beyond 2GB (32-bit limit).
   // We use 3GB to ensure we're testing 64-bit offset handling.
   const size_t large_offset = 3ULL * 1024 * 1024 * 1024; // 3GB

--- a/extension/data_loader/test/mmap_data_loader_test.cpp
+++ b/extension/data_loader/test/mmap_data_loader_test.cpp
@@ -9,6 +9,7 @@
 #include <executorch/extension/data_loader/mmap_data_loader.h>
 
 #include <cstring>
+#include <vector>
 
 #include <gtest/gtest.h>
 
@@ -428,4 +429,54 @@ TEST_F(MmapDataLoaderTest, LoadIntoCopiesOffsetCorrectly) {
 
   // Verify memory copied correctly.
   EXPECT_EQ(0, std::memcmp(dst, contents + offset, size));
+}
+
+// Tests that the loader can handle files requiring 64-bit file systems.
+// This test verifies that offsets and sizes beyond 32-bit limits are handled
+// correctly by creating a sparse file with data at a large offset.
+TEST_F(MmapDataLoaderTest, LargeFileOffsetSupport) {
+  // Create a sparse file with a marker at an offset beyond 2GB (32-bit limit).
+  // We use 3GB to ensure we're testing 64-bit offset handling.
+  const size_t large_offset = 3ULL * 1024 * 1024 * 1024; // 3GB
+  const std::string test_marker = "TEST_MARKER_AT_LARGE_OFFSET";
+
+  // Use TempFile sparse file API to create a 3GB+ file
+  TempFile tf(large_offset, test_marker, large_offset + test_marker.size());
+
+  // Now try to load the data using MmapDataLoader.
+  Result<MmapDataLoader> mdl = MmapDataLoader::from(tf.path().c_str());
+  ASSERT_EQ(mdl.error(), Error::Ok)
+      << "Failed to create MmapDataLoader for large sparse file";
+
+  // Verify the file size is reported correctly (should be > 3GB).
+  Result<size_t> file_size = mdl->size();
+  ASSERT_EQ(file_size.error(), Error::Ok);
+  EXPECT_GT(*file_size, large_offset)
+      << "File size should be larger than the large offset";
+  EXPECT_EQ(*file_size, large_offset + test_marker.size())
+      << "File size should match offset + marker size";
+
+  // Try to load the marker data from the large offset.
+  Result<FreeableBuffer> fb = mdl->load(
+      large_offset,
+      test_marker.size(),
+      DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program));
+  ASSERT_EQ(fb.error(), Error::Ok)
+      << "Failed to load data from large offset";
+
+  EXPECT_EQ(fb->size(), test_marker.size());
+  EXPECT_EQ(0, std::memcmp(fb->data(), test_marker.data(), test_marker.size()))
+      << "Data at large offset does not match expected marker";
+
+  // Test load_into as well.
+  std::vector<uint8_t> buffer(test_marker.size());
+  Error err = mdl->load_into(
+      large_offset,
+      test_marker.size(),
+      DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program),
+      buffer.data());
+  ASSERT_EQ(err, Error::Ok) << "load_into failed for large offset";
+
+  EXPECT_EQ(0, std::memcmp(buffer.data(), test_marker.data(), test_marker.size()))
+      << "load_into data at large offset does not match expected marker";
 }

--- a/extension/data_loader/test/mmap_data_loader_test.cpp
+++ b/extension/data_loader/test/mmap_data_loader_test.cpp
@@ -461,8 +461,7 @@ TEST_F(MmapDataLoaderTest, LargeFileOffsetSupport) {
       large_offset,
       test_marker.size(),
       DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program));
-  ASSERT_EQ(fb.error(), Error::Ok)
-      << "Failed to load data from large offset";
+  ASSERT_EQ(fb.error(), Error::Ok) << "Failed to load data from large offset";
 
   EXPECT_EQ(fb->size(), test_marker.size());
   EXPECT_EQ(0, std::memcmp(fb->data(), test_marker.data(), test_marker.size()))
@@ -477,6 +476,7 @@ TEST_F(MmapDataLoaderTest, LargeFileOffsetSupport) {
       buffer.data());
   ASSERT_EQ(err, Error::Ok) << "load_into failed for large offset";
 
-  EXPECT_EQ(0, std::memcmp(buffer.data(), test_marker.data(), test_marker.size()))
+  EXPECT_EQ(
+      0, std::memcmp(buffer.data(), test_marker.data(), test_marker.size()))
       << "load_into data at large offset does not match expected marker";
 }

--- a/extension/kernel_util/make_boxed_from_unboxed_functor.h
+++ b/extension/kernel_util/make_boxed_from_unboxed_functor.h
@@ -34,9 +34,6 @@
 //===----------------------------------------------------------------------===//
 
 #pragma once
-#if __cplusplus < 201703L
-#error "This header requires C++17"
-#endif
 
 #include <executorch/extension/kernel_util/meta_programming.h>
 #include <executorch/extension/kernel_util/type_list.h>

--- a/extension/kernel_util/meta_programming.h
+++ b/extension/kernel_util/meta_programming.h
@@ -7,9 +7,6 @@
  */
 
 #pragma once
-#if __cplusplus < 201703L
-#error "This header requires C++17"
-#endif
 
 #include <executorch/extension/kernel_util/type_list.h>
 #include <cstdlib>

--- a/extension/kernel_util/type_list.h
+++ b/extension/kernel_util/type_list.h
@@ -11,9 +11,6 @@
 /// Forked from pytorch/c10/util/TypeList.h
 /// \brief Utilities for working with type lists.
 #pragma once
-#if __cplusplus < 201703L
-#error "This header requires C++17"
-#endif
 
 #include <algorithm>
 #include <cstddef>

--- a/extension/testing_util/temp_file.h
+++ b/extension/testing_util/temp_file.h
@@ -12,8 +12,8 @@
 #include <fstream>
 #include <memory>
 #include <string>
+#include <vector>
 
-#include <fcntl.h> // open()
 #include <gtest/gtest.h>
 
 namespace executorch {
@@ -40,6 +40,27 @@ class TempFile {
    */
   TempFile(const void* data, size_t size) {
     CreateFile(data, size, &path_);
+  }
+
+  /**
+   * Creates a sparse temporary file with a string at a specific offset.
+   * The file will have the specified total size, but only the data at the
+   * given offset will be written, creating a sparse file that doesn't
+   * allocate all the disk space.
+   *
+   * Example:
+   *   // Create a 3GB file with "DATA_AT_3GB" at 3GB offset
+   *   size_t offset = 3ULL * 1024 * 1024 * 1024;
+   *   std::string data = "DATA_AT_3GB";
+   *   TempFile tf(offset, data, offset + data.size());
+   *
+   * @param offset Byte offset where the string should be written
+   * @param data String to write at the specified offset
+   * @param file_size Total size of the sparse file (must be >= offset +
+   * data.size())
+   */
+  TempFile(size_t offset, const std::string& data, size_t file_size) {
+    CreateSparseFile(offset, data, file_size, &path_);
   }
 
   ~TempFile() {
@@ -77,6 +98,49 @@ class TempFile {
     file.write((const char*)data, size);
     ASSERT_TRUE(file.good())
         << "Failed to write " << size << " bytes: " << strerror(errno);
+
+    *out_path = path;
+  }
+
+  void CreateSparseFile(
+      size_t offset,
+      const std::string& data,
+      size_t file_size,
+      std::string* out_path) {
+    ASSERT_GE(file_size, offset + data.size())
+        << "file_size must be >= offset + data.size()";
+
+    // Find a unique temporary file name.
+    std::string path;
+    {
+      std::array<char, L_tmpnam> buf;
+      const char* ret = std::tmpnam(buf.data());
+      ASSERT_NE(ret, nullptr) << "Could not generate temp file";
+      buf[L_tmpnam - 1] = '\0';
+      path = std::string(buf.data()) + "-executorch-testing";
+    }
+
+    // Open file in binary mode for writing.
+    std::ofstream file(path, std::ios::out | std::ios::binary);
+    ASSERT_TRUE(file.is_open())
+        << "open(" << path << ") failed: " << strerror(errno);
+
+    // Seek to the offset.
+    file.seekp(offset, std::ios::beg);
+    ASSERT_TRUE(file.good()) << "Failed to seek to offset " << offset;
+
+    // Write the data.
+    file.write(data.data(), data.size());
+    ASSERT_TRUE(file.good()) << "Failed to write " << data.size()
+                             << " bytes at offset " << offset;
+
+    // Ensure file is the specified size by seeking to the end.
+    file.seekp(file_size - 1, std::ios::beg);
+
+    // Write a single byte to ensure file has the correct size.
+    file.write("\0", 1);
+    file.close();
+    ASSERT_TRUE(file.good() || file.eof()) << "Error closing file: " << path;
 
     *out_path = path;
   }

--- a/extension/testing_util/temp_file.h
+++ b/extension/testing_util/temp_file.h
@@ -131,8 +131,8 @@ class TempFile {
 
     // Write the data.
     file.write(data.data(), data.size());
-    ASSERT_TRUE(file.good()) << "Failed to write " << data.size()
-                             << " bytes at offset " << offset;
+    ASSERT_TRUE(file.good())
+        << "Failed to write " << data.size() << " bytes at offset " << offset;
 
     // Ensure file is the specified size by seeking to the end.
     file.seekp(file_size - 1, std::ios::beg);

--- a/extension/testing_util/temp_file.h
+++ b/extension/testing_util/temp_file.h
@@ -134,11 +134,20 @@ class TempFile {
     ASSERT_TRUE(file.good())
         << "Failed to write " << data.size() << " bytes at offset " << offset;
 
-    // Ensure file is the specified size by seeking to the end.
-    file.seekp(file_size - 1, std::ios::beg);
+    // Ensure file is the specified size by seeking to the end and writing a
+    // byte, but only if the file needs to be extended beyond the data we just
+    // wrote.
+    if (file_size > offset + data.size()) {
+      file.seekp(file_size - 1, std::ios::beg);
+      ASSERT_TRUE(file.good())
+          << "Failed to seek to file_size - 1: " << file_size - 1;
 
-    // Write a single byte to ensure file has the correct size.
-    file.write("\0", 1);
+      // Write a single byte to ensure file has the correct size.
+      file.write("\0", 1);
+      ASSERT_TRUE(file.good())
+          << "Failed to write final byte at position " << file_size - 1;
+    }
+
     file.close();
     ASSERT_TRUE(file.good() || file.eof()) << "Error closing file: " << path;
 


### PR DESCRIPTION
Everything in ET is cpp17 now so these warnings are useless and also seem to break on msvc
