### PR TITLE
remove useless warnings in kernel util

### DIFF
--- a/extension/kernel_util/make_boxed_from_unboxed_functor.h
+++ b/extension/kernel_util/make_boxed_from_unboxed_functor.h
@@ -34,9 +34,6 @@
 //===----------------------------------------------------------------------===//
 
 #pragma once
-#if __cplusplus < 201703L
-#error "This header requires C++17"
-#endif
 
 #include <executorch/extension/kernel_util/meta_programming.h>
 #include <executorch/extension/kernel_util/type_list.h>

--- a/extension/kernel_util/meta_programming.h
+++ b/extension/kernel_util/meta_programming.h
@@ -7,9 +7,6 @@
  */
 
 #pragma once
-#if __cplusplus < 201703L
-#error "This header requires C++17"
-#endif
 
 #include <executorch/extension/kernel_util/type_list.h>
 #include <cstdlib>

--- a/extension/kernel_util/type_list.h
+++ b/extension/kernel_util/type_list.h
@@ -11,9 +11,6 @@
 /// Forked from pytorch/c10/util/TypeList.h
 /// \brief Utilities for working with type lists.
 #pragma once
-#if __cplusplus < 201703L
-#error "This header requires C++17"
-#endif
 
 #include <algorithm>
 #include <cstddef>


### PR DESCRIPTION
Everything is pinned to cpp17 now
