### PR TITLE
Arm backend: Fix bug in ConvertExpandToRepeat pass

### DIFF
--- a/backends/arm/tosa/partitioner.py
+++ b/backends/arm/tosa/partitioner.py
@@ -110,8 +110,8 @@ def is_noop_expand(node: torch.fx.node.Node) -> bool:
     if node.target != exir_ops.edge.aten.expand_copy.default:
         return False
     else:
-        multiples = calculate_multiples(node.args)
-    return all(m == 1 for m in multiples)
+        multiples, changes_rank = calculate_multiples(node.args)
+    return all(m == 1 for m in multiples) and not changes_rank
 
 
 def is_partitioned(


### PR DESCRIPTION
The pass assumed that if all repeat multiples are one, the op is a no-op. However, it can still change the rank.

cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai