### PR TITLE
Arm backend: Fix mypy warnings in test/models

### DIFF
--- a/backends/arm/test/models/test_conformer.py
+++ b/backends/arm/test/models/test_conformer.py
@@ -18,7 +18,7 @@ from executorch.backends.arm.test.tester.test_pipeline import (
     VgfPipeline,
 )
 
-from torchaudio.models import Conformer
+from torchaudio.models import Conformer  # type: ignore[import-untyped]
 
 input_t = Tuple[torch.Tensor, torch.IntTensor]  # Input x, y
 

--- a/backends/arm/test/models/test_deit_tiny_arm.py
+++ b/backends/arm/test/models/test_deit_tiny_arm.py
@@ -7,7 +7,7 @@ import logging
 
 from typing import Tuple
 
-import timm
+import timm  # type: ignore[import-untyped]
 
 import torch
 
@@ -19,8 +19,11 @@ from executorch.backends.arm.test.tester.test_pipeline import (
     VgfPipeline,
 )
 
-from timm.data import IMAGENET_INCEPTION_MEAN, IMAGENET_INCEPTION_STD
-from torchvision import transforms
+from timm.data import (  # type: ignore[import-untyped]
+    IMAGENET_INCEPTION_MEAN,
+    IMAGENET_INCEPTION_STD,
+)
+from torchvision import transforms  # type: ignore[import-untyped]
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)

--- a/backends/arm/test/models/test_inception_v3_arm.py
+++ b/backends/arm/test/models/test_inception_v3_arm.py
@@ -5,10 +5,11 @@
 
 from typing import Tuple
 
-import common
 import pytest
 
 import torch
+
+from executorch.backends.arm.test import common
 
 from executorch.backends.arm.test.tester.test_pipeline import (
     EthosU55PipelineINT,
@@ -18,7 +19,7 @@ from executorch.backends.arm.test.tester.test_pipeline import (
     VgfPipeline,
 )
 
-from torchvision import models, transforms
+from torchvision import models, transforms  # type: ignore[import-untyped]
 
 ic3 = models.inception_v3(weights=models.Inception_V3_Weights)
 ic3 = ic3.eval()

--- a/backends/arm/test/models/test_mobilenet_v3_arm.py
+++ b/backends/arm/test/models/test_mobilenet_v3_arm.py
@@ -5,10 +5,11 @@
 
 from typing import Tuple
 
-import common
 import pytest
 
 import torch
+
+from executorch.backends.arm.test import common
 
 from executorch.backends.arm.test.tester.test_pipeline import (
     EthosU55PipelineINT,
@@ -18,7 +19,7 @@ from executorch.backends.arm.test.tester.test_pipeline import (
     VgfPipeline,
 )
 
-from torchvision import models, transforms
+from torchvision import models, transforms  # type: ignore[import-untyped]
 
 mv3 = models.mobilenet_v3_small(weights=models.MobileNet_V3_Small_Weights)
 mv3 = mv3.eval()

--- a/backends/arm/test/models/test_resnet18.py
+++ b/backends/arm/test/models/test_resnet18.py
@@ -17,7 +17,10 @@ from executorch.backends.arm.test.tester.test_pipeline import (
 )
 
 from torchvision import transforms  # type: ignore[import-untyped]
-from torchvision.models import resnet18, ResNet18_Weights
+from torchvision.models import (  # type: ignore[import-untyped]
+    resnet18,
+    ResNet18_Weights,
+)
 
 model = resnet18(weights=ResNet18_Weights)
 model = model.eval()

--- a/backends/arm/test/models/test_w2l_arm.py
+++ b/backends/arm/test/models/test_w2l_arm.py
@@ -20,7 +20,7 @@ from executorch.backends.arm.test.tester.test_pipeline import (
     VgfPipeline,
 )
 
-from torchaudio import models
+from torchaudio import models  # type: ignore[import-untyped]
 
 input_t = Tuple[torch.Tensor]  # Input x
 


### PR DESCRIPTION
Add ignores for third-party modules and change import common into using the correct path.

Signed-off-by: per.held@arm.com
Change-Id: I0b1cfa4c5b7a1625b72c6cfa59da8f427a25a204
