### PR TITLE
[ET-VK][ez] Add lint rule to check no debug mode in shaders + clean up debug mode usage

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -449,3 +449,24 @@ command = [
   "--",
   "@{{PATHSFILE}}",
 ]
+
+[[linter]]
+code = 'ETVKNODEBUG'
+include_patterns = [
+    "backends/vulkan/**/*.glsl",
+]
+command = [
+    'python',
+    '-m',
+    'lintrunner_adapters',
+    'run',
+    'grep_linter',
+    '--pattern=((DEBUG_MODE)|(GL_EXT_debug_printf))',
+    '--linter-name=ETVKNODEBUG',
+    '--error-name=Using DEBUG_MODE or GL_EXT_debug_printf in Vulkan shader',
+    """--error-description=\
+        #define DEBUG_MODE or #extension GL_EXT_debug_printf should only be used during development!
+    """,
+    '--',
+    '@{{PATHSFILE}}',
+]

--- a/backends/vulkan/runtime/graph/ops/glsl/binary_q8ta_q8ta_q8to.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/binary_q8ta_q8ta_q8to.glsl
@@ -25,8 +25,6 @@ ${define_required_extensions(DTYPE)}
 
 layout(std430) buffer;
 
-#extension GL_EXT_debug_printf : enable
-#define DEBUG_MODE
 #include "indexing.glslh"
 #include "common.glslh"
 

--- a/backends/vulkan/runtime/graph/ops/glsl/binary_scalar_texture.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/binary_scalar_texture.glsl
@@ -22,7 +22,6 @@ ${define_required_extensions(DTYPE)}
 
 layout(std430) buffer;
 
-#define DEBUG_MODE
 #include "indexing.glslh"
 
 ${layout_declare_tensor(B, "w", "t_out", DTYPE, STORAGE)}

--- a/backends/vulkan/runtime/graph/ops/glsl/common.glslh
+++ b/backends/vulkan/runtime/graph/ops/glsl/common.glslh
@@ -9,6 +9,10 @@
 #ifndef COMMON_GLSLH
 #define COMMON_GLSLH
 
+#ifdef DEBUG_MODE
+#extension GL_EXT_debug_printf : enable
+#endif
+
 #define mul_2(x) ((x) << 1)
 #define mul_4(x) ((x) << 2)
 #define mul_8(x) ((x) << 3)

--- a/backends/vulkan/runtime/graph/ops/glsl/embedding_buffer.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/embedding_buffer.glsl
@@ -19,7 +19,6 @@ ${define_required_extensions(DTYPE)}
 
 layout(std430) buffer;
 
-#define DEBUG_MODE
 #include "indexing.glslh"
 
 ${layout_declare_tensor(B, "w", "t_out", DTYPE, "buffer")}

--- a/backends/vulkan/runtime/graph/ops/glsl/embedding_texture.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/embedding_texture.glsl
@@ -20,7 +20,6 @@ ${define_required_extensions(DTYPE)}
 
 layout(std430) buffer;
 
-#define DEBUG_MODE
 #include "common.glslh"
 #include "indexing.glslh"
 

--- a/backends/vulkan/runtime/graph/ops/glsl/indexing.glslh
+++ b/backends/vulkan/runtime/graph/ops/glsl/indexing.glslh
@@ -278,8 +278,6 @@ TextureElementIndex tensor_idx_to_texture_element_idx_simple(
 
 #ifdef DEBUG_MODE
 
-#extension GL_EXT_debug_printf : enable
-
 void printTensorIndex(const TensorIndex tidx) {
     debugPrintfEXT(
         "TensorIndex: tidx=[%u %u %u %u %u %u %u %u]\\n",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #15620
* #15619
* #15618
* #15617
* __->__ #15616

Title says it all!

Differential Revision: [D86340342](https://our.internmc.facebook.com/intern/diff/D86340342/)