### PR TITLE
[llm_patch] Fix out-of-bounds access in pad2d function

### DIFF
--- a/kernels/portable/cpu/util/padding_util.h
+++ b/kernels/portable/cpu/util/padding_util.h
@@ -56,6 +56,8 @@ void pad1d(
     size_t out_i_base = i * out_width;
     size_t in_i_base = i * in_width;
     for (const auto w : c10::irange(out_width)) {
+      size_t in_w_idx = padding_ix(w, in_width, pad_left);
+      ET_CHECK(in_w_idx < in_width);
       out_data[out_i_base + w] =
           in_data[in_i_base + padding_ix(w, in_width, pad_left)];
     }
@@ -85,11 +87,13 @@ void pad2d(
     size_t in_i_base = i * in_height * in_width;
     for (const auto h : c10::irange(out_height)) {
       size_t out_h_base = out_i_base + h * out_width;
-      size_t in_h_base =
-          in_i_base + padding_ix(h, in_height, pad_top) * in_width;
+      size_t in_h_idx = padding_ix(h, in_height, pad_top);
+      ET_CHECK(in_h_idx < in_height);
+      size_t in_h_base = in_i_base + in_h_idx * in_width;
       for (const auto w : c10::irange(out_width)) {
-        out_data[out_h_base + w] =
-            in_data[in_h_base + padding_ix(w, in_width, pad_left)];
+        size_t in_w_idx = padding_ix(w, in_width, pad_left);
+        ET_CHECK(in_w_idx < in_width);
+        out_data[out_h_base + w] = in_data[in_h_base + in_w_idx];
       }
     }
   }
@@ -121,15 +125,18 @@ void pad3d(
     size_t in_i_base = i * in_depth * in_height * in_width;
     for (const auto d : c10::irange(out_depth)) {
       size_t out_d_base = out_i_base + d * out_height * out_width;
-      size_t in_d_base =
-          in_i_base + padding_ix(d, in_depth, pad_front) * in_height * in_width;
+      size_t in_d_base_padding = padding_ix(d, in_depth, pad_front);
+      ET_CHECK(in_d_base_padding < in_depth);
+      size_t in_d_base = in_i_base + in_d_base_padding * in_height * in_width;
       for (const auto h : c10::irange(out_height)) {
         size_t out_h_base = out_d_base + h * out_width;
-        size_t in_h_base =
-            in_d_base + padding_ix(h, in_height, pad_top) * in_width;
+        size_t in_h_base_padding = padding_ix(h, in_height, pad_top);
+        ET_CHECK(in_h_base_padding < in_height);
+        size_t in_h_base = in_d_base + in_h_base_padding * in_width;
         for (const auto w : c10::irange(out_width)) {
-          out_data[out_h_base + w] =
-              in_data[in_h_base + padding_ix(w, in_width, pad_left)];
+          size_t in_w_base_padding = padding_ix(w, in_width, pad_left);
+          ET_CHECK(in_w_base_padding < in_width);
+          out_data[out_h_base + w] = in_data[in_h_base + in_w_base_padding];
         }
       }
     }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #15623

Add checks for pad1d and pad3d, as well as pad2d.

I think what happens is, we 'broadcast' the input tensor into the padded regions, depending on the pad algorithm (replication, reflection).
The pad algorithm takes an output tensor index, and returns an input tensor index. We need to check that this index is valid/within bounds of the input tensor.

---
The crash is a "wild-addr-read" that occurs in the `pad2d` function, which is part of the Executorch library. This type of crash typically indicates that the program is attempting to read from an invalid or uninitialized memory address.

The root cause of the crash is an out-of-bounds access in the `pad2d` function. The function uses a `padding_ix` function to calculate indices for the input tensor `in`, but it does not perform sufficient bounds checking to ensure that these indices are valid. As a result, the program may attempt to read from memory outside the bounds of the `in` tensor, leading to the crash.

The patch fixes the crash by adding bounds checking to the `pad2d` function. Specifically, it adds two `ET_CHECK` statements to verify that the indices calculated by `padding_ix` are within the valid range of the `in` tensor. The checks are performed using the following code: `ET_CHECK(in_h_idx < in_height)` and `ET_CHECK(in_w_idx < in_width)`. By adding these checks, the patch ensures that the program will not attempt to read from invalid memory addresses, preventing the "wild-addr-read" crash.

Other considerations that reviewers should take into account when validating the patch include the potential impact on performance. The added `ET_CHECK` statements may introduce a small performance overhead, particularly if the `pad2d` function is called frequently. Reviewers should verify that the performance impact is acceptable and that the patch does not introduce any other unintended consequences. Additionally, reviewers should test the patch with a variety of input tensors and padding configurations to ensure that it correctly handles different edge cases. They should also verify that the `ET_CHECK` statements are triggered correctly when invalid indices are encountered, and that the program behaves as expected in these cases.

NOTE: This diff is entirely auto-generated by LLM-based patch generator.
Reviewer should carefully examine this diff as Lionhead does not guarrantee the
correctnesss of the patch beyond fixing the crash and passing existing tests.
Please commandeer this diff and revise as needed. Our bot does not respond to
comments or revision requests (yet).

Differential Revision: [D80831697](https://our.internmc.facebook.com/intern/diff/D80831697/)