### PR TITLE
Expect at least one value in the tensor, to extract scalar from

### DIFF
--- a/kernels/prim_ops/register_prim_ops.cpp
+++ b/kernels/prim_ops/register_prim_ops.cpp
@@ -141,6 +141,12 @@ static Kernel prim_ops[] = {
           EValue& out = *stack[1];
           executorch::aten::Tensor self_tensor =
               self.to<executorch::aten::Tensor>();
+          ET_KERNEL_CHECK_MSG(
+              context,
+              self_tensor.numel() >= 1,
+              InvalidArgument,
+              /* void */,
+              "Expected tensor with at least 1 element");
           ET_SWITCH_REAL_TYPES_AND(
               Bool,
               self_tensor.scalar_type(),


### PR DESCRIPTION
Summary:
local scalar dense extracts a scalar from a tensor.

Check that the tensor has at least one value

Differential Revision: D86363818


