### PR TITLE
Add checks for compute_slice

### DIFF
--- a/backends/cadence/fusion_g3/operators/op_slice_copy.cpp
+++ b/backends/cadence/fusion_g3/operators/op_slice_copy.cpp
@@ -123,7 +123,7 @@ Tensor& slice_copy_Tensor_out(
         InvalidArgument,
         out);
 
-    torch::executor::compute_slice(in, dim, start, length, step, out);
+    torch::executor::compute_slice(ctx, in, dim, start, length, step, out);
   }
 
   return out;

--- a/backends/cadence/hifi/operators/op_slice_copy.cpp
+++ b/backends/cadence/hifi/operators/op_slice_copy.cpp
@@ -64,7 +64,7 @@ Tensor& slice_copy_Tensor_out(
       InvalidArgument,
       out);
 
-  compute_slice(in, dim, start, length, step, out);
+  compute_slice(ctx, in, dim, start, length, step, out);
 
   return out;
 }

--- a/kernels/portable/cpu/op_narrow_copy.cpp
+++ b/kernels/portable/cpu/op_narrow_copy.cpp
@@ -46,7 +46,7 @@ Tensor& narrow_copy_out(
       out);
 
   if (length != 0) {
-    compute_slice(in, dim, start, length, 1, out);
+    compute_slice(ctx, in, dim, start, length, 1, out);
   }
 
   return out;

--- a/kernels/portable/cpu/op_slice_copy.cpp
+++ b/kernels/portable/cpu/op_slice_copy.cpp
@@ -55,7 +55,7 @@ Tensor& slice_copy_Tensor_out(
       InvalidArgument,
       out);
 
-  compute_slice(in, dim, start, length, step, out);
+  compute_slice(ctx, in, dim, start, length, step, out);
 
   return out;
 }

--- a/kernels/portable/cpu/util/slice_util.h
+++ b/kernels/portable/cpu/util/slice_util.h
@@ -55,6 +55,7 @@ int64_t adjust_slice_indices(
     int64_t step);
 
 void compute_slice(
+    KernelRuntimeContext& ctx,
     const Tensor& in,
     int64_t dim,
     int64_t start,


### PR DESCRIPTION
Summary:
Add safety checks to compute_slice, to ensure that we:

1. Do not read outside of the src tensor bounds
2. Do not write outside of the output tensor bounds

Differential Revision: D86433966


