### PR TITLE
[RELEASE ONLY] Update QNN wheel build job torch pin to 2.9.0 release

### DIFF
--- a/.ci/scripts/test_wheel_package_qnn.sh
+++ b/.ci/scripts/test_wheel_package_qnn.sh
@@ -139,7 +139,7 @@ run_core_tests () {
   echo "=== [$LABEL] Installing wheel & deps ==="
   "$PIPBIN" install --upgrade pip
   "$PIPBIN" install "$WHEEL_FILE"
-  "$PIPBIN" install torch=="2.9.0.dev20250906" --index-url "https://download.pytorch.org/whl/nightly/cpu"
+  "$PIPBIN" install torch=="2.9.0"
   "$PIPBIN" install --pre torchao --index-url "https://download.pytorch.org/whl/nightly/cpu"
 
   echo "=== [$LABEL] Import smoke tests ==="


### PR DESCRIPTION
### Summary
QNN wheel build test jobs are failing on CI due to the pinned torch nightly build going out of retention. I believe there were some pinning changes + centralization on main that haven't all been merged into release (conflicts on the picks?). To ensure that release/1.0 CI stays healthy long-term, I'm just updating the pin in the script to point to release torch 2.9.0.

### Test Plan
test-qnn-wheel-packages-linux jobs are passing in CI on this PR.