### PR TITLE
Remove old CMSIS Add op related tests as the new refactor for Add / Linear ops fundamentally changes the way we decompose the Ops and match them

### DIFF
--- a/backends/cortex_m/test/TARGETS
+++ b/backends/cortex_m/test/TARGETS
@@ -8,13 +8,11 @@ load("@fbcode_macros//build_defs:python_unittest.bzl", "python_unittest")
 load("targets.bzl", "define_common_targets")
 
 oncall("executorch")
-
 python_unittest(
     name="test_replace_quant_nodes",
     srcs=[
         "test_helpers_passes_utils.py",
         "test_replace_quant_nodes.py",
-        "test_quantize_op_fusion_pass.py",
     ],
     deps=[
         "//pytorch/ao:torchao",  # @manual


### PR DESCRIPTION
Summary:
^^^

Note that there are new dedicated CortexM tests to rely on for the new flow

Differential Revision: D86469035


