### PR TITLE
Relax XNN quantized conv1d test tolerances

### DIFF
--- a/backends/xnnpack/test/ops/test_conv1d.py
+++ b/backends/xnnpack/test/ops/test_conv1d.py
@@ -126,7 +126,9 @@ class TestConv1d(unittest.TestCase):
         # quantized operators to be loaded and we don't want to do that in the test.
         if not skip_to_executorch:
             tester.to_executorch().serialize().run_method_and_compare_outputs(
-                num_runs=10, atol=0.02, rtol=0.02
+                num_runs=10,
+                atol=0.04 if quantized else 1e-03,
+                rtol=0.02 if quantized else 1e-03,
             )
 
     def test_fp16_conv1d(self):


### PR DESCRIPTION
### Summary
The test_qs8_conv1d_batchnorm_seq test is periodically failing in CI due to being out of tolerance. From looking at the numbers, I believe this is due to an overly tight tolerance when quantizing. The error reported in https://github.com/pytorch/executorch/actions/runs/19147331216/job/54728231147#step:9:19945, for example, is 0.03, which seems large, but given that the output range is 6, that's roughly 1/200th. With 8-bit quant, that's not unreasonable. I've updated the tolerance in the test to reflect this.
