### PR TITLE
Manually cherry-pick "Pin huggingface_hub<1.0"

### DIFF
--- a/.ci/scripts/test_wheel_package_qnn.sh
+++ b/.ci/scripts/test_wheel_package_qnn.sh
@@ -136,7 +136,7 @@ run_core_tests () {
   local PIPBIN="$2"     # path to pip
   local LABEL="$3"      # label to print (conda/venv)
 
- 
+  echo "=== [$LABEL] Installing wheel & deps ==="
   "$PIPBIN" install --upgrade pip
   "$PIPBIN" install "$WHEEL_FILE"
   "$PIPBIN" install torch=="2.9.1"

--- a/.ci/scripts/test_wheel_package_qnn.sh
+++ b/.ci/scripts/test_wheel_package_qnn.sh
@@ -136,10 +136,10 @@ run_core_tests () {
   local PIPBIN="$2"     # path to pip
   local LABEL="$3"      # label to print (conda/venv)
 
-  echo "=== [$LABEL] Installing wheel & deps ==="
+ 
   "$PIPBIN" install --upgrade pip
   "$PIPBIN" install "$WHEEL_FILE"
-  "$PIPBIN" install torch=="2.9.0"
+  "$PIPBIN" install torch=="2.9.1"
   "$PIPBIN" install --pre torchao --index-url "https://download.pytorch.org/whl/nightly/cpu"
 
   echo "=== [$LABEL] Import smoke tests ==="

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -307,9 +307,12 @@ jobs:
 
         PYTHON_EXECUTABLE=python bash .ci/scripts/setup-linux.sh --build-tool "cmake"
 
-        # install Llava requirements
-        bash examples/models/llama/install_requirements.sh
-        bash examples/models/llava/install_requirements.sh
+        echo "::group::Setup Huggingface"
+        pip install -U "huggingface_hub[cli]<1.0" accelerate
+        huggingface-cli login --token $SECRET_EXECUTORCH_HF_TOKEN
+        OPTIMUM_ET_VERSION=$(cat .ci/docker/ci_commit_pins/optimum-executorch.txt)
+        pip install git+https://github.com/huggingface/optimum-executorch.git@${OPTIMUM_ET_VERSION}
+        echo "::endgroup::"
 
         # run python unittest
         python -m unittest examples.models.llava.test.test_llava
@@ -625,7 +628,9 @@ jobs:
         conda activate "${CONDA_ENV}"
 
         PYTHON_EXECUTABLE=python bash .ci/scripts/setup-linux.sh --build-tool "cmake"
+        echo "::endgroup::"
 
+        echo "::group::Setup requirements"
         # install phi-3-mini requirements
         bash examples/models/phi-3-mini/install_requirements.sh
 

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -307,12 +307,9 @@ jobs:
 
         PYTHON_EXECUTABLE=python bash .ci/scripts/setup-linux.sh --build-tool "cmake"
 
-        echo "::group::Setup Huggingface"
-        pip install -U "huggingface_hub[cli]<1.0" accelerate
-        huggingface-cli login --token $SECRET_EXECUTORCH_HF_TOKEN
-        OPTIMUM_ET_VERSION=$(cat .ci/docker/ci_commit_pins/optimum-executorch.txt)
-        pip install git+https://github.com/huggingface/optimum-executorch.git@${OPTIMUM_ET_VERSION}
-        echo "::endgroup::"
+        # install Llava requirements
+        bash examples/models/llama/install_requirements.sh
+        bash examples/models/llava/install_requirements.sh
 
         # run python unittest
         python -m unittest examples.models.llava.test.test_llava
@@ -628,9 +625,7 @@ jobs:
         conda activate "${CONDA_ENV}"
 
         PYTHON_EXECUTABLE=python bash .ci/scripts/setup-linux.sh --build-tool "cmake"
-        echo "::endgroup::"
 
-        echo "::group::Setup requirements"
         # install phi-3-mini requirements
         bash examples/models/phi-3-mini/install_requirements.sh
 

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -809,7 +809,7 @@ jobs:
         echo "::endgroup::"
 
         echo "::group::Setup Huggingface"
-        pip install -U "huggingface_hub[cli]" accelerate
+        pip install -U "huggingface_hub[cli]<1.0" accelerate
         huggingface-cli login --token $SECRET_EXECUTORCH_HF_TOKEN
         OPTIMUM_ET_VERSION=$(cat .ci/docker/ci_commit_pins/optimum-executorch.txt)
         pip install git+https://github.com/huggingface/optimum-executorch.git@${OPTIMUM_ET_VERSION}

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -612,7 +612,7 @@ jobs:
         conda activate "${CONDA_ENV}"
 
         PYTHON_EXECUTABLE=python bash .ci/scripts/setup-linux.sh --build-tool cmake
-        pip install -U "huggingface_hub[cli]"
+        pip install -U "huggingface_hub[cli]<1.0"
 
         bash .ci/scripts/test_torchao_huggingface_checkpoints.sh ${{ matrix.model }} ${{ matrix.test_with_runner && '--test_with_runner' || '' }}
 
@@ -905,7 +905,7 @@ jobs:
         echo "::endgroup::"
 
         echo "::group::Set up Huggingface"
-        ${CONDA_RUN} pip install -U "huggingface_hub[cli]" accelerate
+        ${CONDA_RUN} pip install -U "huggingface_hub[cli]<1.0" accelerate
         ${CONDA_RUN} huggingface-cli login --token $SECRET_EXECUTORCH_HF_TOKEN
         OPTIMUM_ET_VERSION=$(cat .ci/docker/ci_commit_pins/optimum-executorch.txt)
         ${CONDA_RUN} pip install git+https://github.com/huggingface/optimum-executorch.git@${OPTIMUM_ET_VERSION}

--- a/examples/models/llama/install_requirements.sh
+++ b/examples/models/llama/install_requirements.sh
@@ -10,7 +10,7 @@
 # Install tokenizers for hf .json tokenizer.
 # Install snakeviz for cProfile flamegraph
 # Install lm-eval for Model Evaluation with lm-evalution-harness.
-pip install hydra-core huggingface_hub tiktoken torchtune sentencepiece tokenizers snakeviz lm_eval==0.4.5 blobfile
+pip install hydra-core "huggingface_hub<1.0" tiktoken torchtune sentencepiece tokenizers snakeviz lm_eval==0.4.5 blobfile
 
 # Call the install helper for further setup
 python examples/models/llama/install_requirement_helper.py


### PR DESCRIPTION
### Summary
This is a manual cherry-pick of https://github.com/pytorch/executorch/pull/15399 and https://github.com/pytorch/executorch/pull/15403 to resolve CI failures caused by an incompatibility between the newly released huggingface_hub package and our pinned version of transformers. Due to differences between main and release/1.0, the automated cherry-pick failed, so I've reverted to a manual pick and some small manual edits to examples/models/llama/install_requirements.sh.

### Test Plan
This PR is running trunk CI.