### PR TITLE
Arm backend: Enable mypy for tests

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -367,7 +367,7 @@ exclude_patterns = [
     '**/third-party/**',
     'scripts/check_binary_dependencies.py',
     'profiler/test/test_profiler_e2e.py',
-    'backends/arm/test/**',
+    'backends/arm/test/ops/*.py',
 ]
 command = [
     'python',

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -24,7 +24,7 @@ files =
     test,
     util
 
-mypy_path = executorch
+mypy_path = executorch,src
 
 [mypy-executorch.backends.*]
 follow_untyped_imports = True

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -29,6 +29,9 @@ mypy_path = executorch,src
 [mypy-executorch.backends.*]
 follow_untyped_imports = True
 
+[mypy-backends.arm.*]
+disallow_untyped_decorators = False
+
 [mypy-executorch.codegen.*]
 follow_untyped_imports = True
 

--- a/backends/arm/test/models/stable_diffusion/test_SD3Transformer2DModel.py
+++ b/backends/arm/test/models/stable_diffusion/test_SD3Transformer2DModel.py
@@ -7,7 +7,9 @@
 from typing import Tuple
 
 import torch
-from diffusers.models.transformers import SD3Transformer2DModel
+from diffusers.models.transformers import (  # type: ignore[import-not-found]
+    SD3Transformer2DModel,
+)
 
 from executorch.backends.arm.test import common
 from executorch.backends.arm.test.models.stable_diffusion.stable_diffusion_module_test_configs import (

--- a/backends/arm/test/models/stable_diffusion/test_vae_AutoencoderKL.py
+++ b/backends/arm/test/models/stable_diffusion/test_vae_AutoencoderKL.py
@@ -7,8 +7,12 @@
 from typing import Tuple
 
 import torch
-from diffusers.models.autoencoders import AutoencoderKL
-from diffusers.utils.testing_utils import floats_tensor
+from diffusers.models.autoencoders import (  # type: ignore[import-not-found]
+    AutoencoderKL,
+)
+from diffusers.utils.testing_utils import (  # type: ignore[import-not-found]
+    floats_tensor,
+)
 
 from executorch.backends.arm.test import common
 from executorch.backends.arm.test.models.stable_diffusion.stable_diffusion_module_test_configs import (

--- a/backends/arm/test/models/test_nss.py
+++ b/backends/arm/test/models/test_nss.py
@@ -19,7 +19,9 @@ from executorch.backends.arm.test.tester.test_pipeline import (
 
 from huggingface_hub import hf_hub_download
 
-from ng_model_gym.usecases.nss.model.model_blocks import AutoEncoderV1
+from ng_model_gym.usecases.nss.model.model_blocks import (  # type: ignore[import-not-found,import-untyped]
+    AutoEncoderV1,
+)
 
 input_t = Tuple[torch.Tensor]  # Input x
 

--- a/backends/arm/test/runner_utils.py
+++ b/backends/arm/test/runner_utils.py
@@ -36,7 +36,7 @@ from executorch.exir.lowered_backend_module import LoweredBackendModule
 from torch.fx.node import Node
 
 from torch.overrides import TorchFunctionMode
-from tosa.TosaGraph import TosaGraph  # type: ignore[import-untyped]
+from tosa.TosaGraph import TosaGraph  # type: ignore[import-not-found, import-untyped]
 
 logger = logging.getLogger(__name__)
 
@@ -762,7 +762,7 @@ def run_tosa_graph(
     inputs_np = [torch_tensor_to_numpy(input_tensor) for input_tensor in inputs]
 
     if isinstance(tosa_version, Tosa_1_00):
-        import tosa_reference_model as reference_model  # type: ignore[import-untyped]
+        import tosa_reference_model as reference_model  # type: ignore[import-not-found, import-untyped]
 
         debug_mode = "ALL" if logger.getEffectiveLevel() <= logging.DEBUG else None
         outputs_np, status = reference_model.run(


### PR DESCRIPTION
Add test directory in arm backend to lintrunner. Except the ops directory which has to be fixed later.

About "disallow_untyped_decorators = False":
The only way to make mypy happy seems to be a wrapper around the decorator for each file it is used. I have read numerous of threads about it and there seems to be no good solution. Hence the added ignore for backends/arm.

Signed-off-by: per.held@arm.com
Change-Id: I0430041cb3308b51798d74da61cc4d310966772a


cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai