### PR TITLE
Arm backend: Initialize basicConfig for logging

### DIFF
--- a/backends/arm/test/conftest.py
+++ b/backends/arm/test/conftest.py
@@ -3,8 +3,10 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import logging
 import os
 import random
+import sys
 from typing import Any
 
 import pytest
@@ -26,6 +28,8 @@ def pytest_configure(config):
     pytest._test_options["tosa_version"] = "1.0"  # type: ignore[attr-defined]
     if config.option.arm_run_tosa_version:
         pytest._test_options["tosa_version"] = config.option.arm_run_tosa_version
+
+    logging.basicConfig(stream=sys.stdout)
 
 
 def pytest_collection_modifyitems(config, items):


### PR DESCRIPTION
In a previous patch, the basicConfig for the logging was removed which led to log-prints not being displayed when running the tests. This patch adds it back, but without a default log-level.

cc @freddan80 @per @zingo @digantdesai