### PR TITLE
Arm backend: Remove xfails on EQ op tests

### DIFF
--- a/backends/arm/test/ops/test_eq.py
+++ b/backends/arm/test/ops/test_eq.py
@@ -174,14 +174,7 @@ def test_eq_scalar_u55_INT(test_module):
     pipeline.run()
 
 
-@common.parametrize(
-    "test_module",
-    test_data_tensor,
-    xfails={
-        "eq_tensor_rank4_randn": "MLETORCH-847: Boolean eq result unstable on U85",
-    },
-    strict=False,
-)
+@common.parametrize("test_module", test_data_tensor)
 @common.XfailIfNoCorstone320
 def test_eq_scalar_u85_INT_tensor(test_module):
     pipeline = EthosU85PipelineINT[input_t](
@@ -193,14 +186,7 @@ def test_eq_scalar_u85_INT_tensor(test_module):
     pipeline.run()
 
 
-@common.parametrize(
-    "test_module",
-    test_data_scalar,
-    xfails={
-        "eq_scalar_rank4_randn": "MLETORCH-847: Boolean eq result unstable on U85",
-    },
-    strict=False,
-)
+@common.parametrize("test_module", test_data_scalar)
 @common.XfailIfNoCorstone320
 def test_eq_scalar_u85_INT(test_module):
     pipeline = EthosU85PipelineINT[input_t](


### PR DESCRIPTION
Some tests in test_eq.py were set to xfail due to a problem with numerical accuracy. The problem appears to have gone away so the xfails are removed with this patch.

cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai