### PR TITLE
Error out if git symlink not enabled on Windows

### DIFF
--- a/install_executorch.bat
+++ b/install_executorch.bat
@@ -1,4 +1,5 @@
 @ECHO OFF
+setlocal EnableDelayedExpansion
 
 rem Copyright (c) Meta Platforms, Inc. and affiliates.
 rem All rights reserved.
@@ -7,9 +8,24 @@ rem This batch file provides a basic functionality similar to the bash script.
 
 cd /d "%~dp0"
 
+rem Verify that Git checked out symlinks correctly. Without this the Python install
+rem will fail when attempting to copy files from src\executorch.
+where git >NUL 2>&1
+if not errorlevel 1 (
+    set "GIT_SYMLINKS="
+    for /f "usebackq delims=" %%i in (`git config --get core.symlinks 2^>nul`) do set "GIT_SYMLINKS=%%i"
+    if /I not "!GIT_SYMLINKS!"=="true" (
+        echo ExecuTorch requires Git symlink support on Windows.
+        echo Enable Developer Mode and run: git config --global core.symlinks true
+        echo Re-clone the repository after enabling symlinks, then rerun install_executorch.bat.
+        exit /b 1
+    )
+)
+
 rem Under windows, it's always python
 set PYTHON_EXECUTABLE=python
 
 "%PYTHON_EXECUTABLE%" install_executorch.py %*
 
-exit /b %ERRORLEVEL%
+set "EXIT_CODE=%ERRORLEVEL%"
+endlocal & exit /b %EXIT_CODE%

--- a/setup.py
+++ b/setup.py
@@ -635,6 +635,9 @@ class CustomBuildPy(build_py):
             dst_root = self.get_package_dir(".")
         else:
             dst_root = os.path.join(self.build_lib, "executorch")
+            # On Windows the package directory might not exist yet when building from a
+            # clean tree. Ensure it is created before we attempt to write version.py.
+            self.mkpath(dst_root)
         # Create the version file.
         Version.write_to_python_file(os.path.join(dst_root, "version.py"))
 

--- a/setup.py
+++ b/setup.py
@@ -635,9 +635,6 @@ class CustomBuildPy(build_py):
             dst_root = self.get_package_dir(".")
         else:
             dst_root = os.path.join(self.build_lib, "executorch")
-            # On Windows the package directory might not exist yet when building from a
-            # clean tree. Ensure it is created before we attempt to write version.py.
-            self.mkpath(dst_root)
         # Create the version file.
         Version.write_to_python_file(os.path.join(dst_root, "version.py"))
 


### PR DESCRIPTION
When I install executorch on windows I run into this error:   error:
[Errno 2] No such file or directory:
'pip-out\\lib.win-amd64-cpython-312\\executorch\\version.py'

This is because we are not enabling symlink in git.

Need to run:

```
 git config --global core.symlinks true
```

and reclone the repo.

This PR fails the installation when that happens.