### PR TITLE
Arm backend: Improve support for multiple output ops

### DIFF
--- a/backends/arm/operators/op_cond_if.py
+++ b/backends/arm/operators/op_cond_if.py
@@ -56,6 +56,6 @@ class CondVisitor(NodeVisitor):
                 inputs[0].name,
                 *(subgraph_input.name for subgraph_input in inputs[-1].special),
             ],
-            [output.name],
+            output.multiple_output_names,
             attr,
         )

--- a/backends/arm/operators/ops_identity.py
+++ b/backends/arm/operators/ops_identity.py
@@ -40,7 +40,7 @@ def identity_operator_factory(identity_target: str):
             inputs: List[TosaArg],
             output: TosaArg,
         ) -> None:
-            validate_num_inputs(self.target, inputs, [1, 2])
+            validate_num_inputs(self.target, inputs, 1)
             validate_same_dtype(self.target, [inputs[0], output], ts)
 
             # Simply add an identityOp
@@ -58,5 +58,4 @@ def identity_operator_factory(identity_target: str):
     register_node_visitor(IdentityOperatorVisitor)
 
 
-identity_operator_factory("getitem")
 identity_operator_factory("aten.alias_copy.default")

--- a/backends/arm/process_node.py
+++ b/backends/arm/process_node.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 #
 
+import operator
 from typing import Any, cast, Dict
 
 import numpy as np
@@ -45,9 +46,15 @@ def process_call_function(
             f"Failed processing call_function: {node.name}. "
             "Is the original torch function supported?"
         ) from e
-    tosa_graph.currRegion.currBasicBlock.addTensor(
-        output.name, tosa_shape(output.shape, output.dim_order), output.dtype
-    )
+
+    if not output.multiple_output_names:
+        tosa_graph.currRegion.currBasicBlock.addTensor(
+            output.name, tosa_shape(output.shape, output.dim_order), output.dtype
+        )
+
+    # Get item nodes just add tensors, no node visitor is needed.
+    if node.target == operator.getitem:
+        return
 
     # Visiting each Node
     # pyre-ignore[16]: Undefined attribute.

--- a/backends/arm/test/ops/test_cond.py
+++ b/backends/arm/test/ops/test_cond.py
@@ -174,9 +174,7 @@ test_cases: dict[str, Callable[[], tuple[torch.nn.Module, tuple]]] = {
     "case",
     test_cases,
     xfails={
-        "one_arg_two_outputs": "Multiple outputs is not supported.",
         "one_arg_and_scalar_one_output": "Scalars become get_attr nodes that are not supported.",
-        "two_args_two_outputs": "Nodes with multiple outputs are not properly supported.",
         "multiple_one_arg_one_output": "Scalars become get_attr nodes that are not supported.",
     },
 )


### PR DESCRIPTION
The pattern of using .name from the TosaArg output is used in essentially all node visitors. Refactoring output to possibly be a list of TosaArgs would be very cumbersome. Instead, use a new multiple_output_names field to provide the names of all getitem tensors. This also means that we don't have to insert identity ops for getitem operators, they just need to insert a tensor.

cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai