### PR TITLE
[ET-VK] Move operator specific quantize/dequantize ops to QuantizeDequantize.cpp

### DIFF
--- a/backends/vulkan/runtime/graph/ops/impl/QuantizeDequantize.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/QuantizeDequantize.cpp
@@ -1,0 +1,426 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/vulkan/runtime/graph/ops/OperatorRegistry.h>
+
+#include <executorch/backends/vulkan/runtime/graph/ops/impl/Common.h>
+#include <executorch/backends/vulkan/runtime/graph/ops/impl/QuantizeDequantize.h>
+#include <executorch/backends/vulkan/runtime/graph/ops/utils/ShaderNameUtils.h>
+
+namespace vkcompute {
+
+//
+// General utilities
+//
+
+bool is_gemv(ComputeGraph* graph, const ValueRef& fp_input) {
+  return graph->size_at<uint32_t>(-2, fp_input) == 1;
+}
+
+//
+// Dispatch utilities (Linear)
+//
+
+std::tuple<int64_t, int64_t> get_quantized_input_num_blocks(
+    ComputeGraph& graph,
+    const ValueRef input) {
+  std::vector<int64_t> input_sizes = graph.sizes_of(input);
+  const int64_t ndim = graph.dim_of(input);
+
+  const int64_t M = input_sizes.at(ndim - 2);
+  const int64_t K = input_sizes.at(ndim - 1);
+
+  const int64_t num_blocks_M = utils::div_up(M, int64_t(4));
+  const int64_t num_blocks_K = utils::div_up(K, int64_t(4));
+
+  return std::make_tuple(num_blocks_M, num_blocks_K);
+}
+
+utils::uvec3 quant_pack_input_global_wg_size(
+    ComputeGraph* graph,
+    const vkapi::ShaderInfo& shader,
+    const std::vector<ArgGroup>& args,
+    const std::vector<ValueRef>& resize_args) {
+  const ValueRef input = args.at(1).refs.at(0);
+  int64_t num_blocks_M, num_blocks_K;
+  std::tie(num_blocks_M, num_blocks_K) =
+      get_quantized_input_num_blocks(*graph, input);
+
+  return {
+      utils::safe_downcast<uint32_t>(num_blocks_K),
+      utils::safe_downcast<uint32_t>(num_blocks_M),
+      1u};
+}
+
+vkapi::ShaderInfo pick_quantize_and_pack_input_with_sums_shader(
+    ComputeGraph* graph,
+    const std::vector<ArgGroup>& args,
+    const std::vector<ValueRef>& resize_args) {
+  const ValueRef packed_int_input = args.at(0).refs.at(0);
+  const ValueRef fp_input = args.at(1).refs.at(0);
+  const ValueRef group_size = resize_args.at(0);
+
+  const int64_t group_size_val = graph->extract_scalar<int64_t>(group_size);
+
+  std::string shader_name = "quantize_and_pack_linear_input_with_sums";
+  if (group_size_val >= 128) {
+    shader_name += "_o2w32";
+  } else {
+    shader_name += "_o4w16";
+  }
+
+  add_storage_type_suffix(
+      shader_name, graph->storage_type_of(packed_int_input));
+  add_storage_type_suffix(shader_name, graph->storage_type_of(fp_input));
+  add_dtype_suffix(shader_name, graph->dtype_of(fp_input));
+
+  return VK_KERNEL_FROM_STR(shader_name);
+}
+
+utils::uvec3 pick_quantize_and_pack_input_with_sums_global_wg_size(
+    ComputeGraph* graph,
+    const vkapi::ShaderInfo& shader,
+    const std::vector<ArgGroup>& args,
+    const std::vector<ValueRef>& resize_args) {
+  const ValueRef fp_input = args.at(1).refs.at(0);
+  // For gemv cases, skip the quantize and pack input step in favor of computing
+  // the quantized linear as a weight only quantized linear operation. The
+  // rationale for this is that gemv is a memory bound operation and may not
+  // necessarily benefit from quantizing the input and computing with integer
+  // accumulation.
+  if (is_gemv(graph, fp_input)) {
+    return {0u, 0u, 0u};
+  }
+
+  const ValueRef group_size = resize_args.at(0);
+  int64_t num_blocks_M, num_blocks_K;
+  std::tie(num_blocks_M, num_blocks_K) =
+      get_quantized_input_num_blocks(*graph, fp_input);
+
+  const int64_t group_size_val = graph->extract_scalar<int64_t>(group_size);
+  const int64_t blocks_per_group = group_size_val / 4;
+
+  const int64_t num_groups = num_blocks_K / blocks_per_group;
+
+  return {
+      utils::safe_downcast<uint32_t>(num_groups),
+      utils::safe_downcast<uint32_t>(num_blocks_M),
+      1u};
+}
+
+utils::uvec3 pick_quantize_and_pack_input_with_sums_local_wg_size(
+    ComputeGraph* graph,
+    const vkapi::ShaderInfo& shader,
+    const utils::uvec3& global_workgroup_size,
+    const std::vector<ArgGroup>& args,
+    const std::vector<ValueRef>& resize_args) {
+  (void)shader;
+  (void)resize_args;
+
+  const ValueRef fp_input = args.at(1).refs.at(0);
+  // For gemv, skip the quantize input step since the quantized linear is
+  // computed as a weight only quantized linear operation.
+  if (is_gemv(graph, fp_input)) {
+    return {1u, 1u, 1u};
+  }
+
+  uint32_t groups_per_wg = 2u;
+  uint32_t workers_per_group = 32u;
+
+  if (shader.kernel_name.find("o4w16") != std::string::npos) {
+    groups_per_wg = 4u;
+    workers_per_group = 16u;
+  }
+
+  return {groups_per_wg, 1u, workers_per_group};
+}
+
+//
+// Dispatch logic (Linear)
+//
+
+void add_quantize_and_pack_linear_input_node(
+    ComputeGraph& graph,
+    const QuantizationConfig& input_quant_config,
+    const ValueRef fp_input,
+    const ValueRef packed_input_scale,
+    const ValueRef packed_input_zp,
+    const ValueRef input_scale_data,
+    const ValueRef input_zp_data,
+    const ValueRef packed_int_input,
+    const ValueRef group_size) {
+  // Only certain quantization types supported at the moment
+  VK_CHECK_COND(input_quant_config.granularity == kPerTensor);
+
+  int64_t num_blocks_M, num_blocks_K;
+  std::tie(num_blocks_M, num_blocks_K) =
+      get_quantized_input_num_blocks(graph, fp_input);
+
+  float inv_scale = 1.0f / graph.extract_scalar<float>(input_scale_data);
+  int32_t zp = graph.extract_scalar<int32_t>(input_zp_data);
+
+  std::string shader_name = "quantize_and_pack_linear_input_per_tensor";
+  add_storage_type_suffix(shader_name, graph.storage_type_of(packed_int_input));
+  add_storage_type_suffix(shader_name, graph.storage_type_of(fp_input));
+  add_dtype_suffix(shader_name, graph.dtype_of(fp_input));
+
+  vkapi::ParamsBindList param_buffers = {graph.sizes_ubo(fp_input)};
+
+  std::vector<PushConstantDataInfo> push_constants = {
+      PushConstantDataInfo(&inv_scale, sizeof(inv_scale)),
+      PushConstantDataInfo(&zp, sizeof(zp)),
+  };
+
+  graph.execute_nodes().emplace_back(new DynamicDispatchNode(
+      graph,
+      VK_KERNEL_FROM_STR(shader_name),
+      quant_pack_input_global_wg_size,
+      default_pick_local_wg_size,
+      // Inputs and Outputs
+      {{packed_int_input, vkapi::kWrite}, {fp_input, vkapi::kRead}},
+      // Shader params buffers
+      param_buffers,
+      // Push Constants
+      push_constants,
+      // Specialization Constants
+      {},
+      // Resize args
+      {}));
+}
+
+void add_quantize_and_pack_linear_input_with_sums_node(
+    ComputeGraph& graph,
+    const QuantizationConfig& input_quant_config,
+    const ValueRef fp_input,
+    const ValueRef int_input_sums,
+    const ValueRef packed_input_scales,
+    const ValueRef packed_input_zps,
+    const ValueRef packed_int_input,
+    const ValueRef group_size) {
+  // Only certain quantization types supported at the moment
+  VK_CHECK_COND(input_quant_config.granularity == kPerChannel);
+
+  int64_t num_blocks_M, num_blocks_K;
+  std::tie(num_blocks_M, num_blocks_K) =
+      get_quantized_input_num_blocks(graph, fp_input);
+
+  vkapi::ParamsBindList param_buffers = {graph.sizes_ubo(fp_input)};
+
+  const int32_t group_size_val = graph.extract_scalar<int32_t>(group_size);
+  const int32_t blocks_per_group = utils::div_up(group_size_val, int32_t(4));
+
+  graph.execute_nodes().emplace_back(new DynamicDispatchNode(
+      graph,
+      pick_quantize_and_pack_input_with_sums_shader,
+      pick_quantize_and_pack_input_with_sums_global_wg_size,
+      pick_quantize_and_pack_input_with_sums_local_wg_size,
+      // Inputs and Outputs
+      {{{packed_int_input, int_input_sums}, vkapi::kWrite},
+       {{fp_input, packed_input_scales, packed_input_zps}, vkapi::kRead}},
+      // Shader params buffers
+      param_buffers,
+      // Push Constants
+      {},
+      // Specialization Constants
+      {blocks_per_group},
+      // Resize args
+      {group_size}));
+}
+
+//
+// Dispatch utilities (Conv2d)
+//
+
+utils::uvec3 pick_quantize_and_pack_conv2d_input_global_wg_size(
+    ComputeGraph* graph,
+    const vkapi::ShaderInfo& shader,
+    const std::vector<ArgGroup>& args,
+    const std::vector<ValueRef>& resize_args) {
+  const ValueRef fp_input = args.at(1).refs.at(0);
+
+  const uint32_t W = graph->size_at<uint32_t>(-1, fp_input);
+  const uint32_t H = graph->size_at<uint32_t>(-2, fp_input);
+  const uint32_t C = graph->size_at<uint32_t>(-3, fp_input);
+
+  const uint32_t W4 = utils::div_up_4(W);
+  const uint32_t C4 = utils::div_up_4(C);
+
+  return {W4, H, C4};
+}
+
+utils::uvec3 pick_unpack_and_dequantize_conv2d_output_global_wg_size(
+    ComputeGraph* graph,
+    const vkapi::ShaderInfo& shader,
+    const std::vector<ArgGroup>& args,
+    const std::vector<ValueRef>& resize_args) {
+  const ValueRef fp_output = args.at(0).refs.at(0);
+
+  const uint32_t W = graph->size_at<uint32_t>(-1, fp_output);
+  const uint32_t H = graph->size_at<uint32_t>(-2, fp_output);
+  const uint32_t C = graph->size_at<uint32_t>(-3, fp_output);
+
+  const uint32_t W4 = utils::div_up_4(W);
+  const uint32_t C4 = utils::div_up_4(C);
+
+  return {W4, H, C4};
+}
+
+//
+// Dispatch logic (Conv2d)
+//
+
+void add_quantize_and_pack_q8ta_conv2d_input_node(
+    ComputeGraph& graph,
+    const ValueRef fp_input,
+    const ValueRef input_scale,
+    const ValueRef input_zp,
+    const ValueRef packed_int8_input) {
+  float inv_scale = 1.0f / graph.extract_scalar<float>(input_scale);
+  int32_t zp = graph.extract_scalar<int32_t>(input_zp);
+
+  // Get shader for quantized conv2d linear tiled
+  std::string kernel_name = "quantize_and_pack_q8ta_conv2d_input";
+  add_storage_type_suffix(
+      kernel_name, graph.storage_type_of(packed_int8_input));
+  add_storage_type_suffix(kernel_name, graph.storage_type_of(fp_input));
+  add_dtype_suffix(kernel_name, graph.dtype_of(fp_input));
+
+  vkapi::ShaderInfo shader = VK_KERNEL_FROM_STR(kernel_name);
+
+  vkapi::ParamsBindList param_buffers = {graph.sizes_ubo(fp_input)};
+
+  std::vector<PushConstantDataInfo> push_constants = {
+      PushConstantDataInfo(&inv_scale, sizeof(inv_scale)),
+      PushConstantDataInfo(&zp, sizeof(zp)),
+  };
+
+  graph.execute_nodes().emplace_back(new DynamicDispatchNode(
+      graph,
+      VK_KERNEL_FROM_STR(kernel_name),
+      pick_quantize_and_pack_conv2d_input_global_wg_size,
+      pick_wc_square_wg_size,
+      // Inputs and Outputs
+      {{packed_int8_input, vkapi::kWrite}, {fp_input, vkapi::kRead}},
+      // Shader params buffers
+      param_buffers,
+      // Push Constants
+      push_constants,
+      // Specialization Constants
+      {},
+      // Resize args
+      {},
+      // Resizing Logic
+      nullptr));
+}
+
+void add_unpack_and_dequantize_q8ta_conv2d_output_node(
+    ComputeGraph& graph,
+    const ValueRef packed_int8_output,
+    const ValueRef output_scale,
+    const ValueRef output_zp,
+    const ValueRef fp_output) {
+  float scale = graph.extract_scalar<float>(output_scale);
+  int32_t zp = graph.extract_scalar<int32_t>(output_zp);
+
+  // Get shader for quantized conv2d linear tiled
+  std::string kernel_name = "unpack_and_dequantize_q8ta_conv2d_output";
+  add_storage_type_suffix(kernel_name, graph.storage_type_of(fp_output));
+  add_storage_type_suffix(
+      kernel_name, graph.storage_type_of(packed_int8_output));
+  add_dtype_suffix(kernel_name, graph.dtype_of(fp_output));
+
+  vkapi::ShaderInfo shader = VK_KERNEL_FROM_STR(kernel_name);
+
+  vkapi::ParamsBindList param_buffers = {graph.sizes_ubo(fp_output)};
+
+  std::vector<PushConstantDataInfo> push_constants = {
+      PushConstantDataInfo(&scale, sizeof(scale)),
+      PushConstantDataInfo(&zp, sizeof(zp)),
+  };
+
+  graph.execute_nodes().emplace_back(new DynamicDispatchNode(
+      graph,
+      VK_KERNEL_FROM_STR(kernel_name),
+      pick_unpack_and_dequantize_conv2d_output_global_wg_size,
+      default_pick_local_wg_size,
+      // Inputs and Outputs
+      {{fp_output, vkapi::kWrite}, {packed_int8_output, vkapi::kRead}},
+      // Shader params buffers
+      param_buffers,
+      // Push Constants
+      push_constants,
+      // Specialization Constants
+      {},
+      // Resize args
+      {},
+      // Resizing Logic
+      nullptr));
+}
+
+//
+// Operator Entrypoints
+//
+
+void quantize_q8ta_for_conv2d(
+    ComputeGraph& graph,
+    const std::vector<ValueRef>& args) {
+  int32_t idx = 0;
+  const ValueRef fp_input = args.at(idx++);
+  const ValueRef scale = args.at(idx++);
+  const ValueRef zero_point = args.at(idx++);
+  const ValueRef packed_int8_input = args.at(idx++);
+
+  add_quantize_and_pack_q8ta_conv2d_input_node(
+      graph, fp_input, scale, zero_point, packed_int8_input);
+}
+
+void dequantize_q8to_from_conv2d(
+    ComputeGraph& graph,
+    const std::vector<ValueRef>& args) {
+  int32_t idx = 0;
+  const ValueRef packed_int8_output = args.at(idx++);
+  const ValueRef scale = args.at(idx++);
+  const ValueRef zero_point = args.at(idx++);
+  const ValueRef fp_output = args.at(idx++);
+
+  add_unpack_and_dequantize_q8ta_conv2d_output_node(
+      graph, packed_int8_output, scale, zero_point, fp_output);
+}
+
+void qdq8ta_conv2d_input(
+    ComputeGraph& graph,
+    const std::vector<ValueRef>& args) {
+  int32_t idx = 0;
+  const ValueRef fp_input = args.at(idx++);
+  const ValueRef scale = args.at(idx++);
+  const ValueRef zero_point = args.at(idx++);
+  const ValueRef fp_output = args.at(idx++);
+
+  TmpTensor packed_int8_input(
+      &graph,
+      graph.sizes_of(fp_input),
+      vkapi::kInt8x4,
+      utils::kBuffer,
+      utils::kPackedInt8_4W4C);
+
+  add_quantize_and_pack_q8ta_conv2d_input_node(
+      graph, fp_input, scale, zero_point, packed_int8_input);
+
+  add_unpack_and_dequantize_q8ta_conv2d_output_node(
+      graph, packed_int8_input, scale, zero_point, fp_output);
+}
+
+REGISTER_OPERATORS {
+  VK_REGISTER_OP(etvk.qdq8ta_conv2d_input.default, qdq8ta_conv2d_input);
+  VK_REGISTER_OP(
+      et_vk.quantize_q8ta_for_conv2d.default, quantize_q8ta_for_conv2d);
+  VK_REGISTER_OP(
+      et_vk.dequantize_q8to_from_conv2d.default, dequantize_q8to_from_conv2d);
+}
+
+} // namespace vkcompute

--- a/backends/vulkan/runtime/graph/ops/impl/QuantizeDequantize.h
+++ b/backends/vulkan/runtime/graph/ops/impl/QuantizeDequantize.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <executorch/backends/vulkan/runtime/graph/ComputeGraph.h>
+#include <executorch/backends/vulkan/runtime/graph/ops/impl/utils/QuantizationConfig.h>
+
+namespace vkcompute {
+
+//
+// General utils
+//
+
+bool is_gemv(ComputeGraph* graph, const ValueRef& fp_input);
+
+//
+// Quantize, Dequantize for Linear/Matmul
+//
+
+void add_quantize_and_pack_linear_input_node(
+    ComputeGraph& graph,
+    const QuantizationConfig& input_quant_config,
+    const ValueRef fp_input,
+    const ValueRef packed_input_scale,
+    const ValueRef packed_input_zp,
+    const ValueRef input_scale_data,
+    const ValueRef input_zp_data,
+    const ValueRef packed_int_input,
+    const ValueRef group_size);
+
+void add_quantize_and_pack_linear_input_with_sums_node(
+    ComputeGraph& graph,
+    const QuantizationConfig& input_quant_config,
+    const ValueRef fp_input,
+    const ValueRef int_input_sums,
+    const ValueRef packed_input_scales,
+    const ValueRef packed_input_zps,
+    const ValueRef packed_int_input,
+    const ValueRef group_size);
+
+//
+// Quantize, Dequantize for Convolution
+//
+
+void add_quantize_and_pack_q8ta_conv2d_input_node(
+    ComputeGraph& graph,
+    const ValueRef fp_input,
+    const ValueRef input_scale,
+    const ValueRef input_zp,
+    const ValueRef packed_int8_input);
+
+void add_unpack_and_dequantize_q8ta_conv2d_output_node(
+    ComputeGraph& graph,
+    const ValueRef packed_int8_output,
+    const ValueRef output_scale,
+    const ValueRef output_zp,
+    const ValueRef fp_output);
+
+} // namespace vkcompute

--- a/backends/vulkan/runtime/graph/ops/impl/QuantizedBinary.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/QuantizedBinary.cpp
@@ -9,7 +9,7 @@
 #include <executorch/backends/vulkan/runtime/graph/ops/OperatorRegistry.h>
 
 #include <executorch/backends/vulkan/runtime/graph/ops/impl/Common.h>
-#include <executorch/backends/vulkan/runtime/graph/ops/impl/QuantizedConvolution.h>
+#include <executorch/backends/vulkan/runtime/graph/ops/impl/QuantizeDequantize.h>
 #include <executorch/backends/vulkan/runtime/graph/ops/impl/Staging.h>
 #include <executorch/backends/vulkan/runtime/graph/ops/utils/ShaderNameUtils.h>
 

--- a/backends/vulkan/runtime/graph/ops/impl/QuantizedConvolution.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/QuantizedConvolution.cpp
@@ -9,6 +9,7 @@
 #include <executorch/backends/vulkan/runtime/graph/ops/OperatorRegistry.h>
 
 #include <executorch/backends/vulkan/runtime/graph/ops/impl/Common.h>
+#include <executorch/backends/vulkan/runtime/graph/ops/impl/QuantizeDequantize.h>
 #include <executorch/backends/vulkan/runtime/graph/ops/impl/QuantizedConvolution.h>
 #include <executorch/backends/vulkan/runtime/graph/ops/impl/QuantizedLinear.h>
 #include <executorch/backends/vulkan/runtime/graph/ops/impl/Staging.h>
@@ -273,40 +274,6 @@ std::vector<int64_t> calculate_output_im2col_sizes(
 //
 // Shader dispatch utilities
 //
-
-utils::uvec3 pick_quantize_and_pack_conv2d_input_global_wg_size(
-    ComputeGraph* graph,
-    const vkapi::ShaderInfo& shader,
-    const std::vector<ArgGroup>& args,
-    const std::vector<ValueRef>& resize_args) {
-  const ValueRef fp_input = args.at(1).refs.at(0);
-
-  const uint32_t W = graph->size_at<uint32_t>(-1, fp_input);
-  const uint32_t H = graph->size_at<uint32_t>(-2, fp_input);
-  const uint32_t C = graph->size_at<uint32_t>(-3, fp_input);
-
-  const uint32_t W4 = utils::div_up_4(W);
-  const uint32_t C4 = utils::div_up_4(C);
-
-  return {W4, H, C4};
-}
-
-utils::uvec3 pick_unpack_and_dequantize_conv2d_output_global_wg_size(
-    ComputeGraph* graph,
-    const vkapi::ShaderInfo& shader,
-    const std::vector<ArgGroup>& args,
-    const std::vector<ValueRef>& resize_args) {
-  const ValueRef fp_output = args.at(0).refs.at(0);
-
-  const uint32_t W = graph->size_at<uint32_t>(-1, fp_output);
-  const uint32_t H = graph->size_at<uint32_t>(-2, fp_output);
-  const uint32_t C = graph->size_at<uint32_t>(-3, fp_output);
-
-  const uint32_t W4 = utils::div_up_4(W);
-  const uint32_t C4 = utils::div_up_4(C);
-
-  return {W4, H, C4};
-}
 
 utils::uvec3 im2col_global_wg_size(
     ComputeGraph* graph,
@@ -692,94 +659,6 @@ void add_input_im2col_packed_int8_node(
       im2col_packed_int8_local_wg_size,
       // Inputs and Outputs
       {{input_im2col, vkapi::kWrite}, {input, vkapi::kRead}},
-      // Shader params buffers
-      param_buffers,
-      // Push Constants
-      push_constants,
-      // Specialization Constants
-      {},
-      // Resize args
-      {},
-      // Resizing Logic
-      nullptr));
-}
-
-void add_quantize_and_pack_q8ta_conv2d_input_node(
-    ComputeGraph& graph,
-    const ValueRef fp_input,
-    const ValueRef input_scale,
-    const ValueRef input_zp,
-    const ValueRef packed_int8_input) {
-  float inv_scale = 1.0f / graph.extract_scalar<float>(input_scale);
-  int32_t zp = graph.extract_scalar<int32_t>(input_zp);
-
-  // Get shader for quantized conv2d linear tiled
-  std::string kernel_name = "quantize_and_pack_q8ta_conv2d_input";
-  add_storage_type_suffix(
-      kernel_name, graph.storage_type_of(packed_int8_input));
-  add_storage_type_suffix(kernel_name, graph.storage_type_of(fp_input));
-  add_dtype_suffix(kernel_name, graph.dtype_of(fp_input));
-
-  vkapi::ShaderInfo shader = VK_KERNEL_FROM_STR(kernel_name);
-
-  vkapi::ParamsBindList param_buffers = {graph.sizes_ubo(fp_input)};
-
-  std::vector<PushConstantDataInfo> push_constants = {
-      PushConstantDataInfo(&inv_scale, sizeof(inv_scale)),
-      PushConstantDataInfo(&zp, sizeof(zp)),
-  };
-
-  graph.execute_nodes().emplace_back(new DynamicDispatchNode(
-      graph,
-      VK_KERNEL_FROM_STR(kernel_name),
-      pick_quantize_and_pack_conv2d_input_global_wg_size,
-      pick_wc_square_wg_size,
-      // Inputs and Outputs
-      {{packed_int8_input, vkapi::kWrite}, {fp_input, vkapi::kRead}},
-      // Shader params buffers
-      param_buffers,
-      // Push Constants
-      push_constants,
-      // Specialization Constants
-      {},
-      // Resize args
-      {},
-      // Resizing Logic
-      nullptr));
-}
-
-void add_unpack_and_dequantize_q8ta_conv2d_output_node(
-    ComputeGraph& graph,
-    const ValueRef packed_int8_output,
-    const ValueRef output_scale,
-    const ValueRef output_zp,
-    const ValueRef fp_output) {
-  float scale = graph.extract_scalar<float>(output_scale);
-  int32_t zp = graph.extract_scalar<int32_t>(output_zp);
-
-  // Get shader for quantized conv2d linear tiled
-  std::string kernel_name = "unpack_and_dequantize_q8ta_conv2d_output";
-  add_storage_type_suffix(kernel_name, graph.storage_type_of(fp_output));
-  add_storage_type_suffix(
-      kernel_name, graph.storage_type_of(packed_int8_output));
-  add_dtype_suffix(kernel_name, graph.dtype_of(fp_output));
-
-  vkapi::ShaderInfo shader = VK_KERNEL_FROM_STR(kernel_name);
-
-  vkapi::ParamsBindList param_buffers = {graph.sizes_ubo(fp_output)};
-
-  std::vector<PushConstantDataInfo> push_constants = {
-      PushConstantDataInfo(&scale, sizeof(scale)),
-      PushConstantDataInfo(&zp, sizeof(zp)),
-  };
-
-  graph.execute_nodes().emplace_back(new DynamicDispatchNode(
-      graph,
-      VK_KERNEL_FROM_STR(kernel_name),
-      pick_unpack_and_dequantize_conv2d_output_global_wg_size,
-      default_pick_local_wg_size,
-      // Inputs and Outputs
-      {{fp_output, vkapi::kWrite}, {packed_int8_output, vkapi::kRead}},
       // Shader params buffers
       param_buffers,
       // Push Constants
@@ -1608,59 +1487,6 @@ void conv2d_q8ta_q8csw_q8to(
 }
 
 //
-// Quantize and dequantize operators
-//
-
-void quantize_q8ta_for_conv2d(
-    ComputeGraph& graph,
-    const std::vector<ValueRef>& args) {
-  int32_t idx = 0;
-  const ValueRef fp_input = args.at(idx++);
-  const ValueRef scale = args.at(idx++);
-  const ValueRef zero_point = args.at(idx++);
-  const ValueRef packed_int8_input = args.at(idx++);
-
-  add_quantize_and_pack_q8ta_conv2d_input_node(
-      graph, fp_input, scale, zero_point, packed_int8_input);
-}
-
-void dequantize_q8to_from_conv2d(
-    ComputeGraph& graph,
-    const std::vector<ValueRef>& args) {
-  int32_t idx = 0;
-  const ValueRef packed_int8_output = args.at(idx++);
-  const ValueRef scale = args.at(idx++);
-  const ValueRef zero_point = args.at(idx++);
-  const ValueRef fp_output = args.at(idx++);
-
-  add_unpack_and_dequantize_q8ta_conv2d_output_node(
-      graph, packed_int8_output, scale, zero_point, fp_output);
-}
-
-void qdq8ta_conv2d_input(
-    ComputeGraph& graph,
-    const std::vector<ValueRef>& args) {
-  int32_t idx = 0;
-  const ValueRef fp_input = args.at(idx++);
-  const ValueRef scale = args.at(idx++);
-  const ValueRef zero_point = args.at(idx++);
-  const ValueRef fp_output = args.at(idx++);
-
-  TmpTensor packed_int8_input(
-      &graph,
-      graph.sizes_of(fp_input),
-      vkapi::kInt8x4,
-      utils::kBuffer,
-      utils::kPackedInt8_4W4C);
-
-  add_quantize_and_pack_q8ta_conv2d_input_node(
-      graph, fp_input, scale, zero_point, packed_int8_input);
-
-  add_unpack_and_dequantize_q8ta_conv2d_output_node(
-      graph, packed_int8_input, scale, zero_point, fp_output);
-}
-
-//
 // Test operators
 //
 
@@ -1727,12 +1553,7 @@ void conv2d_q8ta_q8csw_q8to_test(
 REGISTER_OPERATORS {
   VK_REGISTER_OP(et_vk.conv2d_q8ta_q8csw.default, conv2d_q8ta_q8csw);
   VK_REGISTER_OP(et_vk.conv2d_q8csw.default, conv2d_q8csw);
-  VK_REGISTER_OP(etvk.qdq8ta_conv2d_input.default, qdq8ta_conv2d_input);
   VK_REGISTER_OP(etvk.conv2d_q8ta_q8csw_q8to.test, conv2d_q8ta_q8csw_q8to_test);
-  VK_REGISTER_OP(
-      et_vk.quantize_q8ta_for_conv2d.default, quantize_q8ta_for_conv2d);
-  VK_REGISTER_OP(
-      et_vk.dequantize_q8to_from_conv2d.default, dequantize_q8to_from_conv2d);
   VK_REGISTER_OP(et_vk.conv2d_q8ta_q8csw_q8to.default, conv2d_q8ta_q8csw_q8to);
   VK_REGISTER_OP(
       et_vk.conv2d_q8ta_q8csw_q8to_dw.default, conv2d_q8ta_q8csw_q8to);

--- a/backends/vulkan/runtime/graph/ops/impl/QuantizedConvolution.h
+++ b/backends/vulkan/runtime/graph/ops/impl/QuantizedConvolution.h
@@ -12,31 +12,7 @@
 
 namespace vkcompute {
 
-//
-// Quantize and dequantize functions for conv2d that can be reused by other
-// operations
-//
-
-/**
- * Add a dispatch node to quantize a floating-point input tensor to a packed
- * int8 tensor for use in quantized operations.
- */
-void add_quantize_and_pack_q8ta_conv2d_input_node(
-    ComputeGraph& graph,
-    const ValueRef fp_input,
-    const ValueRef input_scale,
-    const ValueRef input_zp,
-    const ValueRef packed_int8_input);
-
-/**
- * Add a dispatch node to unpack and dequantize a packed int8 output tensor back
- * to a floating-point tensor.
- */
-void add_unpack_and_dequantize_q8ta_conv2d_output_node(
-    ComputeGraph& graph,
-    const ValueRef packed_int8_output,
-    const ValueRef output_scale,
-    const ValueRef output_zp,
-    const ValueRef fp_output);
+// This header is intentionally empty as all quantize/dequantize functions
+// have been moved to QuantizeDequantize.h
 
 } // namespace vkcompute

--- a/backends/vulkan/runtime/graph/ops/impl/QuantizedLinear.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/QuantizedLinear.cpp
@@ -9,6 +9,7 @@
 #include <executorch/backends/vulkan/runtime/graph/ops/OperatorRegistry.h>
 
 #include <executorch/backends/vulkan/runtime/graph/ops/impl/Common.h>
+#include <executorch/backends/vulkan/runtime/graph/ops/impl/QuantizeDequantize.h>
 #include <executorch/backends/vulkan/runtime/graph/ops/impl/QuantizedLinear.h>
 #include <executorch/backends/vulkan/runtime/graph/ops/impl/Staging.h>
 #include <executorch/backends/vulkan/runtime/graph/ops/utils/ShaderNameUtils.h>
@@ -18,10 +19,6 @@ namespace vkcompute {
 //
 // Shader dispatch utilities
 //
-
-bool is_gemv(ComputeGraph* graph, const ValueRef& fp_input) {
-  return graph->size_at<uint32_t>(-2, fp_input) == 1;
-}
 
 void resize_linear_qw_node(
     ComputeGraph* graph,
@@ -103,120 +100,6 @@ utils::uvec3 quantized_linear_local_wg_size(
     return pick_hw_square_wg_size(
         graph, shader, global_workgroup_size, args, resize_args);
   }
-}
-
-std::tuple<int64_t, int64_t> get_quantized_input_num_blocks(
-    ComputeGraph& graph,
-    const ValueRef input) {
-  std::vector<int64_t> input_sizes = graph.sizes_of(input);
-  const int64_t ndim = graph.dim_of(input);
-
-  const int64_t M = input_sizes.at(ndim - 2);
-  const int64_t K = input_sizes.at(ndim - 1);
-
-  const int64_t num_blocks_M = utils::div_up(M, int64_t(4));
-  const int64_t num_blocks_K = utils::div_up(K, int64_t(4));
-
-  return std::make_tuple(num_blocks_M, num_blocks_K);
-}
-
-utils::uvec3 quant_pack_input_global_wg_size(
-    ComputeGraph* graph,
-    const vkapi::ShaderInfo& shader,
-    const std::vector<ArgGroup>& args,
-    const std::vector<ValueRef>& resize_args) {
-  const ValueRef input = args.at(1).refs.at(0);
-  int64_t num_blocks_M, num_blocks_K;
-  std::tie(num_blocks_M, num_blocks_K) =
-      get_quantized_input_num_blocks(*graph, input);
-
-  return {
-      utils::safe_downcast<uint32_t>(num_blocks_K),
-      utils::safe_downcast<uint32_t>(num_blocks_M),
-      1u};
-}
-
-vkapi::ShaderInfo pick_quantize_and_pack_input_with_sums_shader(
-    ComputeGraph* graph,
-    const std::vector<ArgGroup>& args,
-    const std::vector<ValueRef>& resize_args) {
-  const ValueRef packed_int_input = args.at(0).refs.at(0);
-  const ValueRef fp_input = args.at(1).refs.at(0);
-  const ValueRef group_size = resize_args.at(0);
-
-  const int64_t group_size_val = graph->extract_scalar<int64_t>(group_size);
-
-  std::string shader_name = "quantize_and_pack_linear_input_with_sums";
-  if (group_size_val >= 128) {
-    shader_name += "_o2w32";
-  } else {
-    shader_name += "_o4w16";
-  }
-
-  add_storage_type_suffix(
-      shader_name, graph->storage_type_of(packed_int_input));
-  add_storage_type_suffix(shader_name, graph->storage_type_of(fp_input));
-  add_dtype_suffix(shader_name, graph->dtype_of(fp_input));
-
-  return VK_KERNEL_FROM_STR(shader_name);
-}
-
-utils::uvec3 pick_quantize_and_pack_input_with_sums_global_wg_size(
-    ComputeGraph* graph,
-    const vkapi::ShaderInfo& shader,
-    const std::vector<ArgGroup>& args,
-    const std::vector<ValueRef>& resize_args) {
-  const ValueRef fp_input = args.at(1).refs.at(0);
-  // For gemv cases, skip the quantize and pack input step in favor of computing
-  // the quantized linear as a weight only quantized linear operation. The
-  // rationale for this is that gemv is a memory bound operation and may not
-  // necessarily benefit from quantizing the input and computing with integer
-  // accumulation.
-  if (is_gemv(graph, fp_input)) {
-    return {0u, 0u, 0u};
-  }
-
-  const ValueRef group_size = resize_args.at(0);
-  int64_t num_blocks_M, num_blocks_K;
-  std::tie(num_blocks_M, num_blocks_K) =
-      get_quantized_input_num_blocks(*graph, fp_input);
-
-  const int64_t group_size_val = graph->extract_scalar<int64_t>(group_size);
-  const int64_t blocks_per_group = group_size_val / 4;
-
-  const int64_t num_groups = num_blocks_K / blocks_per_group;
-
-  return {
-      utils::safe_downcast<uint32_t>(num_groups),
-      utils::safe_downcast<uint32_t>(num_blocks_M),
-      1u};
-}
-
-utils::uvec3 pick_quantize_and_pack_input_with_sums_local_wg_size(
-    ComputeGraph* graph,
-    const vkapi::ShaderInfo& shader,
-    const utils::uvec3& global_workgroup_size,
-    const std::vector<ArgGroup>& args,
-    const std::vector<ValueRef>& resize_args) {
-  (void)shader;
-  (void)resize_args;
-
-  const ValueRef fp_input = args.at(1).refs.at(0);
-  // For gemv, skip the quantize input step since the quantized linear is
-  // computed as a weight only quantized linear operation.
-  if (is_gemv(graph, fp_input)) {
-    return {1u, 1u, 1u};
-  }
-
-  uint32_t groups_per_wg = 2u;
-  uint32_t workers_per_group = 32u;
-
-  if (shader.kernel_name.find("o4w16") != std::string::npos) {
-    groups_per_wg = 4u;
-    workers_per_group = 16u;
-  }
-
-  return {groups_per_wg, 1u, workers_per_group};
 }
 
 vkapi::ShaderInfo pick_linear_qw_shader(
@@ -421,7 +304,7 @@ ValueRef prepack_quantized_linear_weight(
 /*
  * Shader dispatch for linear with quantized weight but fp activations.
  */
-DynamicDispatchNode make_linear_qw_node(
+void add_linear_qw_node(
     ComputeGraph& graph,
     const QuantizationConfig& weight_quant_config,
     const ValueRef fp_input,
@@ -458,7 +341,7 @@ DynamicDispatchNode make_linear_qw_node(
   const ValueRef is_4bit_flag =
       weight_quant_config.nbits == 4 ? group_size : kDummyValueRef;
 
-  return DynamicDispatchNode(
+  graph.execute_nodes().emplace_back(new DynamicDispatchNode(
       graph,
       pick_linear_qw_shader,
       quantized_linear_global_wg_size,
@@ -476,98 +359,10 @@ DynamicDispatchNode make_linear_qw_node(
       // Resize args
       {is_4bit_flag, weight_data},
       // Resizing Logic
-      resize_linear_qw_node);
+      resize_linear_qw_node));
 }
 
-DynamicDispatchNode make_quantize_and_pack_linear_input_node(
-    ComputeGraph& graph,
-    const QuantizationConfig& input_quant_config,
-    const ValueRef fp_input,
-    const ValueRef packed_input_scale,
-    const ValueRef packed_input_zp,
-    const ValueRef input_scale_data,
-    const ValueRef input_zp_data,
-    const ValueRef packed_int_input,
-    const ValueRef group_size) {
-  // Only certain quantization types supported at the moment
-  VK_CHECK_COND(input_quant_config.granularity == kPerTensor);
-
-  int64_t num_blocks_M, num_blocks_K;
-  std::tie(num_blocks_M, num_blocks_K) =
-      get_quantized_input_num_blocks(graph, fp_input);
-
-  float inv_scale = 1.0f / graph.extract_scalar<float>(input_scale_data);
-  int32_t zp = graph.extract_scalar<int32_t>(input_zp_data);
-
-  std::string shader_name = "quantize_and_pack_linear_input_per_tensor";
-  add_storage_type_suffix(shader_name, graph.storage_type_of(packed_int_input));
-  add_storage_type_suffix(shader_name, graph.storage_type_of(fp_input));
-  add_dtype_suffix(shader_name, graph.dtype_of(fp_input));
-
-  vkapi::ParamsBindList param_buffers = {graph.sizes_ubo(fp_input)};
-
-  std::vector<PushConstantDataInfo> push_constants = {
-      PushConstantDataInfo(&inv_scale, sizeof(inv_scale)),
-      PushConstantDataInfo(&zp, sizeof(zp)),
-  };
-
-  return DynamicDispatchNode(
-      graph,
-      VK_KERNEL_FROM_STR(shader_name),
-      quant_pack_input_global_wg_size,
-      default_pick_local_wg_size,
-      // Inputs and Outputs
-      {{packed_int_input, vkapi::kWrite}, {fp_input, vkapi::kRead}},
-      // Shader params buffers
-      param_buffers,
-      // Push Constants
-      push_constants,
-      // Specialization Constants
-      {},
-      // Resize args
-      {});
-}
-
-DynamicDispatchNode make_quantize_and_pack_linear_input_with_sums_node(
-    ComputeGraph& graph,
-    const QuantizationConfig& input_quant_config,
-    const ValueRef fp_input,
-    const ValueRef int_input_sums,
-    const ValueRef packed_input_scales,
-    const ValueRef packed_input_zps,
-    const ValueRef packed_int_input,
-    const ValueRef group_size) {
-  // Only certain quantization types supported at the moment
-  VK_CHECK_COND(input_quant_config.granularity == kPerChannel);
-
-  int64_t num_blocks_M, num_blocks_K;
-  std::tie(num_blocks_M, num_blocks_K) =
-      get_quantized_input_num_blocks(graph, fp_input);
-
-  vkapi::ParamsBindList param_buffers = {graph.sizes_ubo(fp_input)};
-
-  const int32_t group_size_val = graph.extract_scalar<int32_t>(group_size);
-  const int32_t blocks_per_group = utils::div_up(group_size_val, int32_t(4));
-
-  return DynamicDispatchNode(
-      graph,
-      pick_quantize_and_pack_input_with_sums_shader,
-      pick_quantize_and_pack_input_with_sums_global_wg_size,
-      pick_quantize_and_pack_input_with_sums_local_wg_size,
-      // Inputs and Outputs
-      {{{packed_int_input, int_input_sums}, vkapi::kWrite},
-       {{fp_input, packed_input_scales, packed_input_zps}, vkapi::kRead}},
-      // Shader params buffers
-      param_buffers,
-      // Push Constants
-      {},
-      // Specialization Constants
-      {blocks_per_group},
-      // Resize args
-      {group_size});
-}
-
-DynamicDispatchNode make_linear_qa_qw_node(
+void add_linear_qa_qw_node(
     ComputeGraph& graph,
     const QuantizationConfig& input_quant_config,
     const QuantizationConfig& weight_quant_config,
@@ -615,8 +410,7 @@ DynamicDispatchNode make_linear_qa_qw_node(
     apply_bias = 0;
   }
 
-  // Add the compute node
-  return DynamicDispatchNode(
+  graph.execute_nodes().emplace_back(new DynamicDispatchNode(
       graph,
       VK_KERNEL_FROM_STR(kernel_name),
       quantized_linear_global_wg_size,
@@ -638,10 +432,10 @@ DynamicDispatchNode make_linear_qa_qw_node(
       // Resize args
       {fp_input},
       // Resizing Logic
-      nullptr);
+      nullptr));
 }
 
-DynamicDispatchNode make_linear_dqa_qw_node(
+void add_linear_dqa_qw_node(
     ComputeGraph& graph,
     const QuantizationConfig& input_quant_config,
     const QuantizationConfig& weight_quant_config,
@@ -685,8 +479,7 @@ DynamicDispatchNode make_linear_dqa_qw_node(
   const ValueRef is_4bit_flag =
       weight_quant_config.nbits == 4 ? group_size : kDummyValueRef;
 
-  // Add the compute node
-  return DynamicDispatchNode(
+  graph.execute_nodes().emplace_back(new DynamicDispatchNode(
       graph,
       pick_linear_dqa_qw_shader,
       quantized_linear_global_wg_size,
@@ -712,7 +505,7 @@ DynamicDispatchNode make_linear_dqa_qw_node(
       // Resize args
       {is_4bit_flag, weight_data},
       // Resizing Logic
-      resize_linear_qw_node);
+      resize_linear_qw_node));
 }
 
 //
@@ -770,7 +563,7 @@ void quantized_linear_impl(
   // 2. Input is not quantized
   if (!graph.can_use_int8_dot_product() ||
       input_quant_config.granularity == kNoQuantization) {
-    DynamicDispatchNode linear_qw_node(make_linear_qw_node(
+    add_linear_qw_node(
         graph,
         weight_quant_config,
         fp_input,
@@ -781,9 +574,8 @@ void quantized_linear_impl(
         group_size,
         bias_data,
         packed_bias,
-        output));
+        output);
 
-    graph.execute_nodes().emplace_back(new DynamicDispatchNode(linear_qw_node));
     return;
   }
   // Otherwise, use input and weight quantized linear computed with integer
@@ -815,22 +607,18 @@ void quantized_linear_impl(
 
   // Non dynamically quantized input case
   if (!input_quant_config.is_dynamic) {
-    DynamicDispatchNode quantize_and_pack_linear_node(
-        make_quantize_and_pack_linear_input_node(
-            graph,
-            input_quant_config,
-            fp_input,
-            packed_input_scale,
-            packed_input_zp,
-            input_scale,
-            input_zp,
-            packed_int_input,
-            group_size));
+    add_quantize_and_pack_linear_input_node(
+        graph,
+        input_quant_config,
+        fp_input,
+        packed_input_scale,
+        packed_input_zp,
+        input_scale,
+        input_zp,
+        packed_int_input,
+        group_size);
 
-    graph.execute_nodes().emplace_back(
-        new DynamicDispatchNode(quantize_and_pack_linear_node));
-
-    DynamicDispatchNode linear_qa_qw_node(make_linear_qa_qw_node(
+    add_linear_qa_qw_node(
         graph,
         input_quant_config,
         weight_quant_config,
@@ -847,10 +635,7 @@ void quantized_linear_impl(
         group_size,
         bias_data,
         packed_bias,
-        output));
-
-    graph.execute_nodes().emplace_back(
-        new DynamicDispatchNode(linear_qa_qw_node));
+        output);
 
     return;
   }
@@ -871,21 +656,17 @@ void quantized_linear_impl(
       utils::kBuffer,
       utils::kWidthPacked);
 
-  DynamicDispatchNode quantize_and_pack_input_with_sums_node(
-      make_quantize_and_pack_linear_input_with_sums_node(
-          graph,
-          input_quant_config,
-          fp_input,
-          int_input_sums,
-          packed_input_scale,
-          packed_input_zp,
-          packed_int_input,
-          group_size));
+  add_quantize_and_pack_linear_input_with_sums_node(
+      graph,
+      input_quant_config,
+      fp_input,
+      int_input_sums,
+      packed_input_scale,
+      packed_input_zp,
+      packed_int_input,
+      group_size);
 
-  graph.execute_nodes().emplace_back(
-      new DynamicDispatchNode(quantize_and_pack_input_with_sums_node));
-
-  DynamicDispatchNode linear_dqa_qw_node(make_linear_dqa_qw_node(
+  add_linear_dqa_qw_node(
       graph,
       input_quant_config,
       weight_quant_config,
@@ -903,10 +684,7 @@ void quantized_linear_impl(
       group_size,
       bias_data,
       packed_bias,
-      output));
-
-  graph.execute_nodes().emplace_back(
-      new DynamicDispatchNode(linear_dqa_qw_node));
+      output);
 }
 
 void linear_q8ta_q8csw(ComputeGraph& graph, const std::vector<ValueRef>& args) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #15721
* #15720
* __->__ #15707
* #15706
* #15705
* #15704
* #15703
* #15702

Title says it all! This diff is mostly just moving code around for better organization. Specifically, functions that handle quantizing / dequantizing tensors are placed in a new file `QuantizeDequantize.cpp`.

Differential Revision: [D86674168](https://our.internmc.facebook.com/intern/diff/D86674168/)