### PR TITLE
Arm backend: Replace squeeze with view in DecomposeAnyPass

### DIFF
--- a/backends/arm/_passes/__init__.py
+++ b/backends/arm/_passes/__init__.py
@@ -13,7 +13,6 @@ from .cast_bool_to_int8_pass import CastBoolToInt8Pass  # noqa
 from .cast_int64_pass import CastInt64BuffersToInt32Pass  # noqa
 from .cast_to_int32_pass import CastToInt32Pass  # noqa
 from .conv1d_unsqueeze_pass import Conv1dUnsqueezePass  # noqa
-from .convert_any_default_dim_dims_pass import ConvertAnyDefaultDimDimsPass  # noqa
 from .convert_elu_params import ConvertELUParamsPass  # noqa
 from .convert_expand_copy_to_repeat import ConvertExpandCopyToRepeatPass  # noqa
 from .convert_full_like_to_full_pass import ConvertFullLikeToFullPass  # noqa
@@ -31,6 +30,7 @@ from .decompose_acosh_pass import DecomposeAcoshPass  # noqa
 from .decompose_adaptive_avg_pool2d_pass import DecomposeAdaptiveAvgPool2dPass  # noqa
 from .decompose_add_sub_alpha_pass import DecomposeAddSubAlphaPass  # noqa
 from .decompose_addmm_pass import DecomposeAddmmPass  # noqa
+from .decompose_any_pass import DecomposeAnyPass  # noqa
 from .decompose_asin_and_acos_pass import DecomposeAsinAndAcosPass  # noqa
 from .decompose_asinh_pass import DecomposeAsinhPass  # noqa
 from .decompose_atan_pass import DecomposeAtanPass  # noqa

--- a/backends/arm/_passes/arm_pass_manager.py
+++ b/backends/arm/_passes/arm_pass_manager.py
@@ -18,7 +18,6 @@ from executorch.backends.arm._passes import (
     CastToInt32Pass,
     ComputeConstantOpsAOT,
     Conv1dUnsqueezePass,
-    ConvertAnyDefaultDimDimsPass,
     ConvertELUParamsPass,
     ConvertExpandCopyToRepeatPass,
     ConvertFullLikeToFullPass,
@@ -35,6 +34,7 @@ from executorch.backends.arm._passes import (
     DecomposeAdaptiveAvgPool2dPass,
     DecomposeAddmmPass,
     DecomposeAddSubAlphaPass,
+    DecomposeAnyPass,
     DecomposeAsinAndAcosPass,
     DecomposeAsinhPass,
     DecomposeAtanhPass,
@@ -241,7 +241,7 @@ class ArmPassManager(PassManager):
         self.add_pass(DecomposeDivPass())
         self.add_pass(DecomposeSoftmaxPass())
         self.add_pass(ConvertMinMaxPass())
-        self.add_pass(ConvertAnyDefaultDimDimsPass())
+        self.add_pass(DecomposeAnyPass())
         self.add_pass(DecomposeAdaptiveAvgPool2dPass())
         self.add_pass(DecomposeAvgPool2d())
         self.add_pass(

--- a/backends/arm/operators/op_any.py
+++ b/backends/arm/operators/op_any.py
@@ -46,7 +46,7 @@ class AnyVisitor(NodeVisitor):
         )  # process the negative index
         keep_dim = cast(bool, inputs[2].number if len(inputs) > 2 else False)
         if not keep_dim:
-            raise ValueError("This case should be handled by ConvertAnyDimDimsPass")
+            raise ValueError("This case should be handled by DecomposeAnyPass")
 
         attr = ts.TosaSerializerAttribute()
         attr.ReduceAnyAttribute(inputs[0].dim_order.index(dim))


### PR DESCRIPTION
Rename ConvertAnyDefaultDimDimsPass to DecomposeAnyPass because, in practice, it does same thing for the any op as DecomposeSumPass does for sum.

When keepdim=False, create a single view_copy to the reduced shape instead of inserting squeeze_copy. This eliminates the chronological dependency of ConvertSqueezesToViewPass.

cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai