### PR TITLE
Refactor cadence.convolution

### DIFF
--- a/backends/cadence/aot/ref_implementations.py
+++ b/backends/cadence/aot/ref_implementations.py
@@ -1334,8 +1334,25 @@ def quantized_conv1d_nlc_asym8sxsym8s_asym8s_per_tensor() -> torch.Tensor: ...
 def quantized_conv1d_nlc_asym8uxsym8u_asym8u_per_tensor() -> torch.Tensor: ...
 
 
-@impl_tracked(m, "convolution")
-def convolution(
+@impl_tracked(m, "conv1d")
+def conv1d(
+    input_tensor: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor,
+    stride: tuple[int],
+    padding: tuple[int],
+    dilation: tuple[int],
+    groups: int,
+) -> torch.Tensor:
+    conv_out = torch.nn.functional.conv1d(
+        input_tensor, weight, bias, stride[0], padding[0], dilation[0], groups
+    )
+
+    return conv_out
+
+
+@impl_tracked(m, "conv2d")
+def conv2d(
     input_tensor: torch.Tensor,
     weight: torch.Tensor,
     bias: torch.Tensor,
@@ -1343,39 +1360,27 @@ def convolution(
     padding: tuple[int, int],
     dilation: tuple[int, int],
     groups: int,
-    channel_last: bool = False,
 ) -> torch.Tensor:
-    conv_is_1d = len(input_tensor.shape) == 3
-    if channel_last:
-        if conv_is_1d:
-            input_tensor = input_tensor.movedim(-1, 1).contiguous()
-            if len(weight.shape) != 3:
-                raise ValueError("Weight tensor must be 3D if input is 3D")
-            weight = weight.movedim(-1, 1).contiguous()
-        else:
-            input_tensor = input_tensor.movedim(-1, -3)
-            if len(weight.shape) != 4:
-                raise ValueError("Weight tensor must be 4D if input is nd > 3")
-            weight = torch.permute(weight, (0, -1, 1, 2)).contiguous()
+    conv_out = torch.nn.functional.conv2d(
+        input_tensor, weight, bias, stride, padding, dilation, groups
+    )
 
-    _stride: tuple[int, int] | int = stride
-    _padding: tuple[int, int] | int = padding
-    _dilation: tuple[int, int] | int = dilation
+    return conv_out
 
-    if conv_is_1d:
-        conv = torch.nn.functional.conv1d
-        _stride = stride[0]
-        _padding = padding[0]
-        _dilation = dilation[0]
-    else:
-        conv = torch.nn.functional.conv2d
 
-    conv_out = conv(input_tensor, weight, bias, _stride, _padding, _dilation, groups)
-    if channel_last:
-        if conv_is_1d:
-            conv_out = conv_out.movedim(1, -1).contiguous()
-        else:
-            conv_out = conv_out.movedim(-3, -1).contiguous()
+@impl_tracked(m, "conv3d")
+def conv3d(
+    input_tensor: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor,
+    stride: tuple[int, int, int],
+    padding: tuple[int, int, int],
+    dilation: tuple[int, int, int],
+    groups: int,
+) -> torch.Tensor:
+    conv_out = torch.nn.functional.conv3d(
+        input_tensor, weight, bias, stride, padding, dilation, groups
+    )
 
     return conv_out
 

--- a/backends/cadence/aot/tests/test_ref_implementations.py
+++ b/backends/cadence/aot/tests/test_ref_implementations.py
@@ -1572,25 +1572,6 @@ class TestRefImplementations(unittest.TestCase):
                     [[[[5.0]]]], dtype=torch.float32
                 ),  # expected: 1*1 + 4*1 = 5
             ),
-            # Test case 2: Basic 2D convolution (NHWC format)
-            (
-                "basic_2d_nhwc",
-                torch.tensor(
-                    [[[[1.0], [2.0]], [[3.0], [4.0]]]], dtype=torch.float32
-                ),  # input: 1x2x2x1 (NHWC)
-                torch.tensor(
-                    [[[[1.0], [0.0]], [[0.0], [1.0]]]], dtype=torch.float32
-                ),  # weight: 1x2x2x1 (NHWC format)
-                torch.tensor([0.0], dtype=torch.float32),  # bias
-                (1, 1),  # stride
-                (0, 0),  # padding
-                (1, 1),  # dilation
-                1,  # groups
-                True,  # channel_last
-                torch.tensor(
-                    [[[[5.0]]]], dtype=torch.float32
-                ),  # expected: 1*1 + 4*1 = 5
-            ),
             # Test case 3: 2D convolution with stride=2
             (
                 "conv2d_stride2",
@@ -1709,23 +1690,6 @@ class TestRefImplementations(unittest.TestCase):
                     [[[3.0, 5.0, 7.0]]], dtype=torch.float32
                 ),  # expected: [1+2, 2+3, 3+4]
             ),
-            # Test case 8: 1D convolution (NLC format)
-            (
-                "conv1d_nlc",
-                torch.tensor(
-                    [[[1.0], [2.0], [3.0], [4.0]]], dtype=torch.float32
-                ),  # input: 1x4x1 (NLC)
-                torch.tensor(
-                    [[[1.0], [1.0]]], dtype=torch.float32
-                ),  # weight: 1x2x1 (NLC)
-                torch.tensor([0.0], dtype=torch.float32),  # bias
-                (1, 1),  # stride
-                (0, 0),  # padding
-                (1, 1),  # dilation
-                1,  # groups
-                True,  # channel_last
-                torch.tensor([[[3.0], [5.0], [7.0]]], dtype=torch.float32),
-            ),
             # Test case 9: Multi-channel input and output
             (
                 "multi_channel",
@@ -1796,19 +1760,31 @@ class TestRefImplementations(unittest.TestCase):
         padding: tuple[int, int],
         dilation: tuple[int, int],
         groups: int,
-        channel_last: bool,
+        channel_last: bool,  # Keep for backward compatibility with test data, but won't use
         expected_output: torch.Tensor,
     ) -> None:
-        output = torch.ops.cadence.convolution(
-            input_tensor,
-            weight,
-            bias,
-            stride,
-            padding,
-            dilation,
-            groups,
-            channel_last,
-        )
+        # Determine if 1D or 2D based on input shape
+        is_conv1d = len(input_tensor.shape) == 3
+        if is_conv1d:
+            output = torch.ops.cadence.conv1d(
+                input_tensor,
+                weight,
+                bias,
+                (stride[0],),
+                (padding[0],),
+                (dilation[0],),
+                groups,
+            )
+        else:
+            output = torch.ops.cadence.conv2d(
+                input_tensor,
+                weight,
+                bias,
+                stride,
+                padding,
+                dilation,
+                groups,
+            )
 
         # Verify output properties
         self.assertEqual(
@@ -1830,7 +1806,6 @@ class TestRefImplementations(unittest.TestCase):
 
     @expand(
         [
-            # Basic 2D transposed convolution with stride=1 (current test case - corrected name)
             (
                 "basic_2d_stride1",
                 torch.tensor(
@@ -1848,33 +1823,6 @@ class TestRefImplementations(unittest.TestCase):
                 False,  # channel_last
                 torch.tensor(
                     [[[[1.0, 3.0, 2.0], [4.0, 10.0, 6.0], [3.0, 7.0, 4.0]]]],
-                    dtype=torch.float32,
-                ),
-            ),
-            # 2D transposed convolution with channel_last=True (NHWC format)
-            (
-                "channel_last_nhwc",
-                torch.tensor(
-                    [[[[1.0], [2.0]], [[3.0], [4.0]]]], dtype=torch.float32
-                ),  # input: 1x2x2x1 (NHWC)
-                torch.tensor(
-                    [[[[1.0], [1.0]], [[1.0], [1.0]]]], dtype=torch.float32
-                ),  # weight: 1x2x2x1 (NHWC)
-                torch.tensor([0.0], dtype=torch.float32),  # bias
-                (1, 1),  # stride
-                (0, 0),  # padding
-                (1, 1),  # dilation
-                1,  # groups
-                (0, 0),  # output_padding
-                True,  # channel_last=True
-                torch.tensor(
-                    [
-                        [
-                            [[1.0], [3.0], [2.0]],
-                            [[4.0], [10.0], [6.0]],
-                            [[3.0], [7.0], [4.0]],
-                        ]
-                    ],
                     dtype=torch.float32,
                 ),
             ),
@@ -1897,26 +1845,6 @@ class TestRefImplementations(unittest.TestCase):
                 torch.tensor(
                     [[[[6.0, 7.0, 5.0], [8.0, 10.0, 7.0], [5.0, 8.0, 9.0]]]],
                     dtype=torch.float32,
-                ),
-            ),
-            # 1D transposed convolution (3D tensor, NLC format)
-            (
-                "conv1d_nlc",
-                torch.tensor(
-                    [[[1.0], [2.0], [3.0]]], dtype=torch.float32
-                ),  # input: 1x3x1 (NLC)
-                torch.tensor(
-                    [[[1.0], [0.5]]], dtype=torch.float32
-                ),  # weight: 1x2x1 (NLC)
-                torch.tensor([0.0], dtype=torch.float32),  # bias
-                (2, 0),  # stride
-                (0, 0),  # padding
-                (1, 1),  # dilation
-                1,  # groups
-                (0, 0),  # output_padding
-                True,  # channel_last=True
-                torch.tensor(
-                    [[[1.0], [0.5], [2.0], [1.0], [3.0], [1.5]]], dtype=torch.float32
                 ),
             ),
         ]


### PR DESCRIPTION
Summary:
We will then replace them with the native aten versions.
- Replace `cadence.convolution` with `cadence.conv1d` and `cadence.conv2d`. Add `cadence.conv3d`.
- Removes the channel_last arg

Differential Revision: D86473542
