### PR TITLE
Pin pytest<9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ dependencies=[
   "packaging",
   "pandas>=2.2.2; python_version >= '3.10'",
   "parameterized",
-  "pytest",
+  "pytest<9.0",
   "pytest-xdist",
   "pytest-rerunfailures==15.1",
   "pytest-json-report",


### PR DESCRIPTION
### Summary
Trying to fix failing CI. Seems like something is up with our subtests that causes a failure deep cloning in the pytest code. I'm going to pin pytest<9 for now.