### PR TITLE
Rm platform args executorch

### DIFF
--- a/kernels/optimized/lib_defs.bzl
+++ b/kernels/optimized/lib_defs.bzl
@@ -1,4 +1,3 @@
-load("@fbsource//tools/build_defs:default_platform_defs.bzl", "DEVSERVER_PLATFORM_REGEX")
 load("@fbsource//tools/build_defs:fb_native_wrapper.bzl", "fb_native")
 load("@fbsource//xplat/executorch/backends/xnnpack/third-party:third_party_libs.bzl", "third_party_dep")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
@@ -51,14 +50,12 @@ def get_vec_deps():
     return []
 
 def get_vec_cxx_preprocessor_flags():
-    preprocessor_flags = [
-        (
-            DEVSERVER_PLATFORM_REGEX,
-            [
-                "-DCPU_CAPABILITY_AVX2",
-            ],
-        ),
-    ]
+    preprocessor_flags = select({
+        "DEFAULT": [],
+        "ovr_config//os:linux": [
+            "-DCPU_CAPABILITY_AVX2",
+        ],
+    })
     return preprocessor_flags
 
 def get_vec_fbcode_preprocessor_flags():
@@ -126,33 +123,15 @@ def define_libs(is_fbcode=False):
         ],
         exported_deps = [
             "//executorch/runtime/core/portable_type/c10/c10:aten_headers_for_executorch",
-        ],
-        cxx_platform_deps = select({
-            "DEFAULT": [
-                (
-                    DEVSERVER_PLATFORM_REGEX,
-                    [
-                        "fbsource//third-party/sleef:sleef",
-                    ],
-                ),
+        ] + select({
+            "DEFAULT": [],
+            "ovr_config//os:linux": [
+                "fbsource//third-party/sleef:sleef",
             ],
-            "ovr_config//cpu:arm64": [
-                (
-                    DEVSERVER_PLATFORM_REGEX,
-                    [
-                        "fbsource//third-party/sleef:sleef",
-                    ],
-                ),
+            "ovr_config//os:android-arm64": [
+                "fbsource//third-party/sleef:sleef",
             ],
         }),
-        fbandroid_platform_deps = [
-            (
-                "^android-arm64.*$",
-                [
-                    "fbsource//third-party/sleef:sleef",
-                ],
-            ),
-        ],
     )
 
     runtime.cxx_library(
@@ -187,6 +166,24 @@ def define_libs(is_fbcode=False):
     ]
 
     for libblas_name, mkl_dep in [("libblas", "fbsource//third-party/mkl:mkl_lp64_omp"), ("libblas_mkl_noomp", "fbsource//third-party/mkl:mkl")]:
+        # Merge platform-specific kwargs
+        platform_kwargs = get_apple_framework_deps_kwargs(is_fbcode)
+        if not is_fbcode:
+            platform_kwargs.update({
+                "fbandroid_preprocessor_flags": select({
+                    "DEFAULT": [],
+                    "ovr_config//os:android-arm64": [
+                        "-DET_BUILD_WITH_BLAS",
+                    ],
+                }),
+                "fbandroid_deps": select({
+                    "DEFAULT": [],
+                    "ovr_config//os:android-arm64": [
+                        "fbsource//arvr/third-party/eigen:eigen3_blas",
+                    ],
+                }),
+            })
+
         runtime.cxx_library(
             name = libblas_name,
             srcs = native.glob([
@@ -207,22 +204,6 @@ def define_libs(is_fbcode=False):
                 "@EXECUTORCH_CLIENTS",
             ],
             preprocessor_flags = get_preprocessor_flags(),
-            fbandroid_platform_preprocessor_flags = [
-                (
-                    "^android-arm64.*$",
-                    [
-                        "-DET_BUILD_WITH_BLAS",
-                    ],
-                ),
-            ],
-            fbandroid_platform_deps = [
-                (
-                    "^android-arm64.*$",
-                    [
-                        "fbsource//arvr/third-party/eigen:eigen3_blas",
-                    ],
-                ),
-            ],
             fbobjc_exported_preprocessor_flags = [
                 "-DET_BUILD_WITH_BLAS",
                 "-DET_BUILD_FOR_APPLE",
@@ -237,5 +218,5 @@ def define_libs(is_fbcode=False):
                 "//executorch/runtime/core/exec_aten:lib",
                 "//executorch/runtime/core/portable_type/c10/c10:aten_headers_for_executorch",
             ],
-            **get_apple_framework_deps_kwargs(is_fbcode),
+            **platform_kwargs,
         )

--- a/kernels/optimized/test/targets.bzl
+++ b/kernels/optimized/test/targets.bzl
@@ -26,8 +26,7 @@ def _lib_test_bin(name, extra_deps = [], in_cpu = False):
             "//executorch/test/utils:utils",
             "//executorch/kernels/optimized{}:{}".format(cpu_path, lib_root),
         ] + extra_deps,
-        cxx_platform_preprocessor_flags = get_vec_cxx_preprocessor_flags(),
-        preprocessor_flags = get_vec_preprocessor_flags(),
+        preprocessor_flags = get_vec_preprocessor_flags() + get_vec_cxx_preprocessor_flags(),
     )
 
 def define_common_targets():


### PR DESCRIPTION
Summary:
Get rid of platform args around the repo to unblock modernization with platforms.
Platform args were only needed in buck1

Reviewed By: rexzhang123

Differential Revision: D86467457


