### PR TITLE
Introduce CMake workflow

### DIFF
--- a/.ci/scripts/test_llama_lora.sh
+++ b/.ci/scripts/test_llama_lora.sh
@@ -12,10 +12,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/utils.sh"
 cmake_install_executorch_libraries() {
     echo "Installing libexecutorch.a, libextension_module.so, libportable_ops_lib.a"
     rm -rf cmake-out
-    retry cmake --preset llm \
-        -DCMAKE_INSTALL_PREFIX=cmake-out \
-        -DCMAKE_BUILD_TYPE=Release
-    cmake --build cmake-out -j9 --target install --config Release
+    cmake --workflow llm-release
 }
 
 cmake_build_llama_runner() {

--- a/.ci/scripts/test_model_e2e.sh
+++ b/.ci/scripts/test_model_e2e.sh
@@ -157,20 +157,17 @@ echo "::endgroup::"
 echo "::group::Build $MODEL_NAME Runner"
 
 if [ "$DEVICE" = "cuda" ]; then
+  WORKFLOW="llm-release-cuda"
   BUILD_BACKEND="EXECUTORCH_BUILD_CUDA"
 elif [ "$DEVICE" = "metal" ]; then
+  WORKFLOW="llm-release-metal"
   BUILD_BACKEND="EXECUTORCH_BUILD_METAL"
 else
   echo "Error: Unsupported device '$DEVICE'. Must be 'cuda' or 'metal'."
   exit 1
 fi
 
-cmake --preset llm \
-      -D${BUILD_BACKEND}=ON \
-      -DCMAKE_INSTALL_PREFIX=cmake-out \
-      -DCMAKE_BUILD_TYPE=Release \
-      -Bcmake-out -S.
-cmake --build cmake-out -j$(nproc) --target install --config Release
+cmake --workflow $WORKFLOW
 
 cmake -D${BUILD_BACKEND}=ON \
       -DCMAKE_BUILD_TYPE=Release \

--- a/.ci/scripts/test_phi_3_mini.sh
+++ b/.ci/scripts/test_phi_3_mini.sh
@@ -23,8 +23,16 @@ if hash nproc &> /dev/null; then NPROC=$(nproc); fi
 
 cmake_install_executorch_libraries() {
   rm -rf cmake-out
-  cmake --preset llm -DCMAKE_INSTALL_PREFIX=cmake-out -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
-  cmake --build cmake-out -j16 --target install --config ${BUILD_TYPE}
+
+  # Select workflow preset based on BUILD_TYPE
+  if [[ "${BUILD_TYPE}" == "Debug" ]]; then
+    WORKFLOW_PRESET="llm-debug"
+  else
+    WORKFLOW_PRESET="llm-release"
+  fi
+
+  echo "Using workflow preset: ${WORKFLOW_PRESET}"
+  cmake --workflow --preset ${WORKFLOW_PRESET}
 }
 
 cmake_build_phi_3_mini() {

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -340,6 +340,7 @@ jobs:
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout: 90
       script: |
+        set -eux
         # The generic Linux job chooses to use base env, not the one setup by the image
         CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
         conda activate "${CONDA_ENV}"

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -119,38 +119,118 @@
       }
     },
     {
-        "name": "llm",
-        "displayName": "Build LLM libraries",
-        "inherits": ["common"],
-        "cacheVariables": {
-            "EXECUTORCH_BUILD_PRESET_FILE": "${sourceDir}/tools/cmake/preset/llm.cmake",
-            "CMAKE_OSX_DEPLOYMENT_TARGET": "12.0"
-        },
-        "condition": {
-            "type": "inList",
-            "string": "${hostSystemName}",
-            "list": ["Darwin", "Linux", "Windows"]
-        }
+      "name": "llm",
+      "displayName": "Build LLM libraries",
+      "inherits": [
+        "common"
+      ],
+      "cacheVariables": {
+        "EXECUTORCH_BUILD_PRESET_FILE": "${sourceDir}/tools/cmake/preset/llm.cmake",
+        "CMAKE_OSX_DEPLOYMENT_TARGET": "12.0"
+      },
+      "condition": {
+        "type": "inList",
+        "string": "${hostSystemName}",
+        "list": ["Darwin", "Linux", "Windows"]
+      }
     },
     {
-        "name": "profiling",
-        "displayName": "Build ExecuTorch with Profiling Enabled",
-        "inherits": [
-            "common"
-        ],
-        "cacheVariables": {
-            "EXECUTORCH_BUILD_PRESET_FILE": "${sourceDir}/tools/cmake/preset/profiling.cmake",
-            "CMAKE_OSX_DEPLOYMENT_TARGET": "12.0"
-        },
-        "condition": {
-            "type": "inList",
-            "string": "${hostSystemName}",
-            "list": [
-                "Darwin",
-                "Linux",
-                "Windows"
-            ]
-        }
+      "name": "llm-release",
+      "displayName": "LLM release build",
+      "inherits": [
+        "llm"
+      ],
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_INSTALL_PREFIX": "${sourceDir}/cmake-out"
+      }
+    },
+    {
+      "name": "llm-release-cuda",
+      "displayName": "LLM release build with CUDA",
+      "inherits": [
+        "llm-release"
+      ],
+      "cacheVariables": {
+        "EXECUTORCH_BUILD_CUDA": "ON"
+      },
+      "condition": {
+        "lhs": "${hostSystemName}",
+        "type": "equals",
+        "rhs": "Linux"
+      }
+    },
+    {
+      "name": "llm-release-metal",
+      "displayName": "LLM release build with Metal",
+      "inherits": [
+        "llm-release"
+      ],
+      "cacheVariables": {
+        "EXECUTORCH_BUILD_METAL": "ON"
+      },
+      "condition": {
+        "lhs": "${hostSystemName}",
+        "type": "equals",
+        "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "llm-debug",
+      "displayName": "LLM debug build",
+      "inherits": [
+        "llm"
+      ],
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_INSTALL_PREFIX": "${sourceDir}/cmake-out"
+      }
+    },
+    {
+      "name": "llm-debug-cuda",
+      "displayName": "LLM debug build with CUDA",
+      "inherits": [
+        "llm-debug"
+      ],
+      "cacheVariables": {
+        "EXECUTORCH_BUILD_CUDA": "ON"
+      },
+      "condition": {
+        "lhs": "${hostSystemName}",
+        "type": "equals",
+        "rhs": "Linux"
+      }
+    },
+    {
+      "name": "llm-debug-metal",
+      "displayName": "LLM debug build with Metal",
+      "inherits": [
+        "llm-debug"
+      ],
+      "cacheVariables": {
+        "EXECUTORCH_BUILD_METAL": "ON"
+      },
+      "condition": {
+        "lhs": "${hostSystemName}",
+        "type": "equals",
+        "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "profiling",
+      "displayName": "Build ExecuTorch with Profiling Enabled",
+      "inherits": [
+        "common"
+      ],
+      "cacheVariables": {
+        "EXECUTORCH_BUILD_PRESET_FILE": "${sourceDir}/tools/cmake/preset/profiling.cmake",
+        "CMAKE_OSX_DEPLOYMENT_TARGET": "12.0"
+      },
+      "condition": {
+        "type": "inList",
+        "string": "${hostSystemName}",
+        "list": ["Darwin", "Linux", "Windows"]
+      }
     },
     {
       "name": "windows",
@@ -177,13 +257,155 @@
         }
     },
     {
-        "name": "arm-baremetal",
-        "displayName": "Build ExecuTorch for Arm baremetal",
-        "inherits": ["common"],
-        "cacheVariables": {
-            "EXECUTORCH_BUILD_PRESET_FILE": "${sourceDir}/tools/cmake/preset/arm_baremetal.cmake",
-            "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/examples/arm/ethos-u-setup/arm-none-eabi-gcc.cmake"
-          }
+      "name": "arm-baremetal",
+      "displayName": "Build ExecuTorch for Arm baremetal",
+      "inherits": ["common"],
+      "cacheVariables": {
+        "EXECUTORCH_BUILD_PRESET_FILE": "${sourceDir}/tools/cmake/preset/arm_baremetal.cmake",
+        "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/examples/arm/ethos-u-setup/arm-none-eabi-gcc.cmake"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "llm-release-install",
+      "displayName": "Build and install LLM extension release artifacts",
+      "configurePreset": "llm-release",
+      "targets": [
+        "install"
+      ],
+      "jobs": 0
+    },
+    {
+      "name": "llm-release-cuda-install",
+      "displayName": "Build and install LLM extension release artifacts (CUDA)",
+      "configurePreset": "llm-release-cuda",
+      "targets": [
+        "install"
+      ],
+      "jobs": 0
+    },
+    {
+      "name": "llm-release-metal-install",
+      "displayName": "Build and install LLM extension release artifacts (Metal)",
+      "configurePreset": "llm-release-metal",
+      "targets": [
+        "install"
+      ],
+      "jobs": 0
+    },
+    {
+      "name": "llm-debug-install",
+      "displayName": "Build and install LLM extension debug artifacts",
+      "configurePreset": "llm-debug",
+      "targets": [
+        "install"
+      ],
+      "jobs": 0
+    },
+    {
+      "name": "llm-debug-cuda-install",
+      "displayName": "Build and install LLM extension debug artifacts (CUDA)",
+      "configurePreset": "llm-debug-cuda",
+      "targets": [
+        "install"
+      ],
+      "jobs": 0
+    },
+    {
+      "name": "llm-debug-metal-install",
+      "displayName": "Build and install LLM extension debug artifacts (Metal)",
+      "configurePreset": "llm-debug-metal",
+      "targets": [
+        "install"
+      ],
+      "jobs": 0
+    }
+  ],
+  "workflowPresets": [
+    {
+      "name": "llm-release",
+      "displayName": "Configure, build and install ExecuTorch LLM extension with default CPU backend",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "llm-release"
+        },
+        {
+          "type": "build",
+          "name": "llm-release-install"
+        }
+      ]
+    },
+    {
+      "name": "llm-release-cuda",
+      "displayName": "Configure, build and install ExecuTorch LLM extension with CUDA enabled",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "llm-release-cuda"
+        },
+        {
+          "type": "build",
+          "name": "llm-release-cuda-install"
+        }
+      ]
+    },
+    {
+      "name": "llm-release-metal",
+      "displayName": "Configure, build and install ExecuTorch LLM extension with Metal enabled",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "llm-release-metal"
+        },
+        {
+          "type": "build",
+          "name": "llm-release-metal-install"
+        }
+      ]
+    },
+    {
+      "name": "llm-debug",
+      "displayName": "Configure, build and install ExecuTorch LLM extension with default CPU backend (Debug)",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "llm-debug"
+        },
+        {
+          "type": "build",
+          "name": "llm-debug-install"
+        }
+      ]
+    },
+    {
+      "name": "llm-debug-cuda",
+      "displayName": "Configure, build and install ExecuTorch LLM extension with CUDA enabled (Debug)",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "llm-debug-cuda"
+        },
+        {
+          "type": "build",
+          "name": "llm-debug-cuda-install"
+        }
+      ]
+    },
+    {
+      "name": "llm-debug-metal",
+      "displayName": "Configure, build and install ExecuTorch LLM extension with Metal enabled (Debug)",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "llm-debug-metal"
+        },
+        {
+          "type": "build",
+          "name": "llm-debug-metal-install"
+        }
+      ]
     }
   ]
 }

--- a/examples/models/gemma3/README.md
+++ b/examples/models/gemma3/README.md
@@ -82,12 +82,7 @@ Ensure you have a CUDA-capable GPU and CUDA toolkit installed on your system.
 ./install_executorch.sh
 
 # Build the multimodal runner with CUDA
-cmake --preset llm \
-      -DEXECUTORCH_BUILD_CUDA=ON \
-      -DCMAKE_INSTALL_PREFIX=cmake-out \
-      -DCMAKE_BUILD_TYPE=Release \
-      -Bcmake-out -S.
-cmake --build cmake-out -j$(nproc) --target install --config Release
+cmake --workflow llm-release-cuda
 
 # Build the Gemma3 runner
 cmake -DEXECUTORCH_BUILD_CUDA=ON \

--- a/examples/models/llama/README.md
+++ b/examples/models/llama/README.md
@@ -235,11 +235,9 @@ If you're interested in deploying on non-CPU backends, [please refer the non-cpu
 ## Step 3: Run on your computer to validate
 
 1. Build executorch with optimized CPU performance as follows. Build options available [here](https://github.com/pytorch/executorch/blob/main/CMakeLists.txt#L59).
-    ```
-    cmake --preset llm -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=cmake-out
-
-    cmake --build cmake-out -j16 --target install --config Release
-    ```
+```
+cmake --workflow llm-release
+```
 Note for Mac users: There's a known linking issue with Xcode 15.1. Refer to the section of Common Issues and Mitigations below for solutions.
 
 2. Build llama runner.

--- a/examples/models/moshi/mimi/install_requirements.sh
+++ b/examples/models/moshi/mimi/install_requirements.sh
@@ -7,7 +7,7 @@
 
 set -x
 
-sudo apt install ffmpeg
+sudo apt install ffmpeg -y
 pip install torchcodec==0.7.0.dev20251012 --extra-index-url https://download.pytorch.org/whl/nightly/cpu
 pip install moshi==0.2.11
 pip install bitsandbytes soundfile einops

--- a/examples/models/moshi/mimi/install_requirements.sh
+++ b/examples/models/moshi/mimi/install_requirements.sh
@@ -7,7 +7,7 @@
 
 set -x
 
-conda install -c conda-forge "ffmpeg<8" -y
+sudo apt install ffmpeg
 pip install torchcodec==0.7.0.dev20251012 --extra-index-url https://download.pytorch.org/whl/nightly/cpu
 pip install moshi==0.2.11
 pip install bitsandbytes soundfile einops

--- a/examples/models/phi-3-mini/README.md
+++ b/examples/models/phi-3-mini/README.md
@@ -30,9 +30,7 @@ The model artifact `model.pte` size is about 2.0GB.
 3. Build and run the model.
 - Build executorch with LLM preset:
 ```
-cmake --preset llm -DCMAKE_INSTALL_PREFIX=cmake-out
-
-cmake --build cmake-out -j16 --target install --config Release
+cmake --workflow llm-release
 ```
 - Build Phi-3-mini runner.
 ```

--- a/examples/models/voxtral/README.md
+++ b/examples/models/voxtral/README.md
@@ -123,7 +123,7 @@ python -m executorch.extension.audio.mel_spectrogram \
 ### Building for CPU (XNNPack)
 ```
 # Build and install ExecuTorch
-cmake --preset llm -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=cmake-out -DEXECUTORCH_ENABLE_LOGGING=ON && cmake --build cmake-out -j16 --target install --config Release
+cmake --workflow llm-release
 
 # Build and install Voxtral runner
 cmake -DCMAKE_INSTALL_PREFIX=cmake-out -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release -Bcmake-out/examples/models/voxtral examples/models/voxtral && cmake --build cmake-out/examples/models/voxtral -j16 --config Release
@@ -135,12 +135,7 @@ cmake -DCMAKE_INSTALL_PREFIX=cmake-out -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Re
 ./install_executorch.sh
 
 # Build the multimodal runner with CUDA
-cmake --preset llm \
-      -DEXECUTORCH_BUILD_CUDA=ON \
-      -DCMAKE_INSTALL_PREFIX=cmake-out \
-      -DCMAKE_BUILD_TYPE=Release \
-      -Bcmake-out -S.
-cmake --build cmake-out -j16 --target install --config Release
+cmake --workflow llm-release-cuda
 
 cmake -DEXECUTORCH_BUILD_CUDA=ON \
       -DCMAKE_BUILD_TYPE=Release \
@@ -155,12 +150,7 @@ cmake --build cmake-out/examples/models/voxtral --target voxtral_runner --config
 CMAKE_ARGS="-DEXECUTORCH_BUILD_METAL=ON" ./install_executorch.sh
 
 # Build the multimodal runner with Metal
-cmake --preset llm \
-      -DEXECUTORCH_BUILD_METAL=ON \
-      -DCMAKE_INSTALL_PREFIX=cmake-out \
-      -DCMAKE_BUILD_TYPE=Release \
-      -Bcmake-out -S.
-cmake --build cmake-out -j16 --target install --config Release
+cmake --workflow llm-release-metal
 
 cmake -DEXECUTORCH_BUILD_METAL=ON \
       -DCMAKE_BUILD_TYPE=Release \

--- a/examples/models/whisper/README.md
+++ b/examples/models/whisper/README.md
@@ -24,22 +24,17 @@ Currently we have CUDA and Metal build support. CPU is WIP.
 
 For CUDA:
 ```
-BUILD_BACKEND="EXECUTORCH_BUILD_CUDA"
+WORKFLOW="llm-release-cuda"
 ```
 
 For Metal:
 ```
-BUILD_BACKEND="EXECUTORCH_BUILD_METAL"
+WORKFLOW="llm-release-metal"
 ```
 
 ```bash
 # Install ExecuTorch libraries:
-cmake --preset llm \
-      -D${BUILD_BACKEND}=ON \
-      -DCMAKE_INSTALL_PREFIX=cmake-out \
-      -DCMAKE_BUILD_TYPE=Release \
-      -Bcmake-out -S.
-cmake --build cmake-out -j$(nproc) --target install --config Release
+cmake --workflow $WORKFLOW
 
 # Build the runner:
 cmake \

--- a/tools/cmake/preset/README.md
+++ b/tools/cmake/preset/README.md
@@ -77,6 +77,12 @@ For example, `llm-release` workflow:
 - Uses `llm-release-install` build preset (builds the `install` target with parallel jobs)
 - Installs artifacts to `cmake-out/` directory
 
+#### Add a new workflow
+To add a new workflow:
+1. Add a configure preset, e.g. `new-workflow`
+2. Add a build preset that depends on (1), e.g. `new-workflow-install`
+3. You should be able to run `cmake --workflow new-workflow-install`
+
 
 ### Including ExecuTorch as Third-party Library
 

--- a/tools/cmake/preset/README.md
+++ b/tools/cmake/preset/README.md
@@ -37,6 +37,47 @@ $ cmake -DEXECUTORCH_BUILD_MPS=OFF --preset llm
 
 The cmake presets roughly map to the ExecuTorch presets and are explicitly listed in [CMakePresets.json](../../../CMakePresets.json). Note that you are encouraged to rely on presets when build locally and adding build/tests in CI — CI should do what a developer would do and nothing more!
 
+### Using Workflows
+
+CMake workflow presets combine configure, build, and test steps into a single command. This is the recommended way to build ExecuTorch as it automates the entire build process.
+
+#### List available workflows
+
+```bash
+$ cmake --workflow --list-presets
+```
+
+#### Run a complete workflow
+
+```bash
+# Configure, build, and install LLM extension (CPU)
+$ cmake --workflow --preset llm-release
+
+# Configure, build, and install LLM extension with CUDA (Linux only)
+$ cmake --workflow --preset llm-release-cuda
+
+# Configure, build, and install LLM extension with Metal (macOS only)
+$ cmake --workflow --preset llm-release-metal
+
+# Debug builds are also available
+$ cmake --workflow --preset llm-debug
+$ cmake --workflow --preset llm-debug-cuda
+$ cmake --workflow --preset llm-debug-metal
+```
+
+#### Understanding workflow components
+
+A workflow preset typically consists of:
+1. **Configure preset**: Defines CMake cache variables and build settings
+2. **Build preset**: Specifies targets to build and parallel job count
+3. **Workflow preset**: Orchestrates the configure and build steps
+
+For example, `llm-release` workflow:
+- Uses `llm-release` configure preset (sets `CMAKE_BUILD_TYPE=Release`)
+- Uses `llm-release-install` build preset (builds the `install` target with parallel jobs)
+- Installs artifacts to `cmake-out/` directory
+
+
 ### Including ExecuTorch as Third-party Library
 
 #### Choose a built-in preset


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #15804

CMake workflow combines configure and build into 1 command. Instead of
doing:

```
cmake --preset llm \
      -DEXECUTORCH_BUILD_CUDA=ON \
      -DCMAKE_INSTALL_PREFIX=cmake-out \
      -DCMAKE_BUILD_TYPE=Release \
      -Bcmake-out -S.
cmake --build cmake-out -j$(nproc) --target install --config Release
```

We can simply do `cmake --workflow llm-release-cuda`. This largely
reduces the burden of running these cmake commands.

Next step I'm going to create workflow for the popular runners (llama,
whisper, voxtral etc) and further simplify the build command