### PR TITLE
Fix uninitialized aggregate_sampling_time_ms in Stats struct

### DIFF
--- a/examples/qualcomm/qaihub_scripts/llama/runner/runner.h
+++ b/examples/qualcomm/qaihub_scripts/llama/runner/runner.h
@@ -55,7 +55,7 @@ class Runner {
     // inference_end_ms: End of inference/generation.
     long inference_end_ms;
     // Keep a running total of the time spent in sampling.
-    long aggregate_sampling_time_ms;
+    long aggregate_sampling_time_ms = 0;
     // Token count from prompt
     int64_t num_prompt_tokens;
     // Token count from generated (total - prompt)

--- a/extension/llm/runner/stats.h
+++ b/extension/llm/runner/stats.h
@@ -44,7 +44,7 @@ struct ET_EXPERIMENTAL Stats {
   // inference_end_ms: End of inference/generation.
   long inference_end_ms;
   // Keep a running total of the time spent in sampling.
-  long aggregate_sampling_time_ms;
+  long aggregate_sampling_time_ms = 0;
   // Token count from prompt
   int64_t num_prompt_tokens;
   // Token count from generated (total - prompt)


### PR DESCRIPTION
## Summary
Fixes a critical bug where `aggregate_sampling_time_ms` in the `Stats` struct was not initialized, causing it to contain garbage data from uninitialized memory.

## Problem
The `aggregate_sampling_time_ms` member variable was declared without initialization:
```cpp
long aggregate_sampling_time_ms;  // uninitialized!
```
This resulted in absurd sampling time reports like:

```
Sampling time over 68 tokens: 8433599.048000 (seconds)  // ~97.5 days!
```

The actual sampling time should have been milliseconds, not millions of seconds. Since the code accumulates timing data onto this variable (`stats_.aggregate_sampling_time_ms += ...`), the garbage initial value propagated through all calculations.

## Solution

Initialize the variable to zero in both locations:

`long aggregate_sampling_time_ms = 0;`

## Impact

After this fix, sampling time metrics will report realistic values (e.g., 0.010-0.100 seconds for typical token generation) instead of garbage values.