### PR TITLE
Introduce Makefile and some runner targets

### DIFF
--- a/.ci/scripts/test_llama.sh
+++ b/.ci/scripts/test_llama.sh
@@ -171,15 +171,14 @@ cmake_build_llama_runner() {
     git submodule update --init
     popd
     dir="examples/models/llama"
-    retry cmake \
-        -DEXECUTORCH_BUILD_TESTS=ON \
-        -DBUILD_TESTING=OFF \
-        -DCMAKE_INSTALL_PREFIX=cmake-out \
-        -DCMAKE_BUILD_TYPE="$CMAKE_BUILD_TYPE" \
-        -Bcmake-out/${dir} \
-        ${dir}
-    cmake --build cmake-out/${dir} -j9 --config "$CMAKE_BUILD_TYPE"
-
+    if [[ "$CMAKE_BUILD_TYPE" == "Debug" ]]; then
+        PRESET="llama-debug"
+    else
+        PRESET="llama-release"
+    fi
+    pushd "${dir}"
+    cmake --workflow --preset "${PRESET}"
+    popd
 }
 
 cleanup_files() {

--- a/.ci/scripts/test_model_e2e.sh
+++ b/.ci/scripts/test_model_e2e.sh
@@ -156,24 +156,13 @@ echo "::endgroup::"
 
 echo "::group::Build $MODEL_NAME Runner"
 
-if [ "$DEVICE" = "cuda" ]; then
-  WORKFLOW="llm-release-cuda"
-  BUILD_BACKEND="EXECUTORCH_BUILD_CUDA"
-elif [ "$DEVICE" = "metal" ]; then
-  WORKFLOW="llm-release-metal"
-  BUILD_BACKEND="EXECUTORCH_BUILD_METAL"
-else
+if [ "$DEVICE" != "cuda" ] && [ "$DEVICE" != "metal" ]; then
   echo "Error: Unsupported device '$DEVICE'. Must be 'cuda' or 'metal'."
   exit 1
 fi
 
-cmake --workflow $WORKFLOW
-
-cmake -D${BUILD_BACKEND}=ON \
-      -DCMAKE_BUILD_TYPE=Release \
-      -Sexamples/models/$RUNNER_PATH \
-      -Bcmake-out/examples/models/$RUNNER_PATH/
-cmake --build cmake-out/examples/models/$RUNNER_PATH --target $RUNNER_TARGET --config Release
+MAKE_TARGET="${RUNNER_PATH}-${$DEVICE}"
+make "${MAKE_TARGET}"
 echo "::endgroup::"
 
 echo "::group::Run $MODEL_NAME Runner"

--- a/.ci/scripts/test_model_e2e.sh
+++ b/.ci/scripts/test_model_e2e.sh
@@ -161,7 +161,7 @@ if [ "$DEVICE" != "cuda" ] && [ "$DEVICE" != "metal" ]; then
   exit 1
 fi
 
-MAKE_TARGET="${RUNNER_PATH}-${$DEVICE}"
+MAKE_TARGET="${RUNNER_PATH}-${DEVICE}"
 make "${MAKE_TARGET}"
 echo "::endgroup::"
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,96 @@
+# ==============================================================================
+# ExecuTorch Targets Makefile
+# ==============================================================================
+#
+# This Makefile provides convenient targets for building ExecuTorch model runners
+# with different backend configurations (CPU, CUDA, Metal), as well as other
+# binary targets.
+#
+# WHAT THIS BUILDS:
+# -----------------
+# Each target builds:
+# 1. ExecuTorch core libraries with the specified backend (CPU, CUDA, or Metal)
+# 2. The model-specific runner executable in cmake-out/examples/models/<model>/
+#
+# SUPPORTED MODELS:
+# -----------------
+# - voxtral:  Multimodal voice + text model (CPU, CUDA, Metal)
+# - whisper:  Speech recognition model (CPU, CUDA, Metal)
+# - llama:    Text generation model (CPU)
+# - llava:    Vision + language model (CPU)
+# - gemma3:   Text generation model (CPU, CUDA)
+#
+# USAGE:
+# ------
+# make <model>-<backend>    # Build a specific model with a backend
+# make help                  # Show all available targets
+# make clean                 # Remove all build artifacts
+#
+# Examples:
+#   make voxtral-cuda        # Build Voxtral with CUDA backend
+#   make llama-cpu           # Build Llama with CPU backend
+#   make whisper-metal       # Build Whisper with Metal backend (macOS)
+#
+# HOW TO ADD A NEW MODEL:
+# -----------------------
+# To add a new model (e.g., "mymodel"), follow these steps:
+#
+# 1. Create a CMakePresets.json in examples/models/mymodel/:
+#    - Define configurePresets for each backend (base, cpu, cuda, metal)
+#    - Define buildPresets with the target name from CMakeLists.txt
+#    - Define workflowPresets that combine configure + build steps
+#    - See examples/models/voxtral/CMakePresets.json for multi-backend reference
+#    - Or see examples/models/llama/CMakePresets.json for simple single-preset reference
+#
+# 2. Add targets to this Makefile:
+#    a) Add to .PHONY declaration: mymodel-cuda mymodel-cpu mymodel-metal
+#    b) Add help text in the help target
+#    c) Add target implementations following this pattern:
+#
+#       mymodel-cuda:
+#           @echo "==> Building and installing ExecuTorch with CUDA..."
+#           cmake --workflow --preset llm-release-cuda
+#           @echo "==> Building MyModel runner with CUDA..."
+#           cd examples/models/mymodel && cmake --workflow --preset mymodel-cuda
+#           @echo ""
+#           @echo "✓ Build complete!"
+#           @echo "  Binary: cmake-out/examples/models/mymodel/mymodel_runner"
+#
+#       mymodel-cpu:
+#           @echo "==> Building and installing ExecuTorch..."
+#           cmake --workflow --preset llm-release
+#           @echo "==> Building MyModel runner (CPU)..."
+#           cd examples/models/mymodel && cmake --workflow --preset mymodel-cpu
+#           @echo ""
+#           @echo "✓ Build complete!"
+#           @echo "  Binary: cmake-out/examples/models/mymodel/mymodel_runner"
+#
+#       mymodel-metal:
+#           @echo "==> Building and installing ExecuTorch with Metal..."
+#           cmake --workflow --preset llm-release-metal
+#           @echo "==> Building MyModel runner with Metal..."
+#           cd examples/models/mymodel && cmake --workflow --preset mymodel-metal
+#           @echo ""
+#           @echo "✓ Build complete!"
+#           @echo "  Binary: cmake-out/examples/models/mymodel/mymodel_runner"
+#
+# 3. Test your new targets:
+#    make mymodel-cpu     # or mymodel-cuda, mymodel-metal
+#
+# NOTES:
+# ------
+# - CUDA backend is only available on Linux systems
+# - Metal backend is only available on macOS (Darwin) systems
+# - Some models may not support all backends (check model documentation)
+# - Binary outputs are located in cmake-out/examples/models/<model>/
+# - The preset names in CMakePresets.json must match the names used in Makefile
+#
+# ==============================================================================
+
 .PHONY: voxtral-cuda voxtral-cpu voxtral-metal whisper-cuda whisper-cpu whisper-metal llama-cpu llava-cpu gemma3-cuda gemma3-cpu clean help
 
 help:
-	@echo "Available targets:"
+	@echo "This Makefile adds targets to build runners for various models on various backends. Run using `make <target>`. Available targets:"
 	@echo "  voxtral-cuda   - Build Voxtral runner with CUDA backend"
 	@echo "  voxtral-cpu    - Build Voxtral runner with CPU backend"
 	@echo "  voxtral-metal  - Build Voxtral runner with Metal backend (macOS only)"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,108 @@
+.PHONY: voxtral-cuda voxtral-cpu voxtral-metal whisper-cuda whisper-cpu whisper-metal llama-cpu llava-cpu gemma3-cuda gemma3-cpu clean help
+
+help:
+	@echo "Available targets:"
+	@echo "  voxtral-cuda   - Build Voxtral runner with CUDA backend"
+	@echo "  voxtral-cpu    - Build Voxtral runner with CPU backend"
+	@echo "  voxtral-metal  - Build Voxtral runner with Metal backend (macOS only)"
+	@echo "  whisper-cuda   - Build Whisper runner with CUDA backend"
+	@echo "  whisper-cpu    - Build Whisper runner with CPU backend"
+	@echo "  whisper-metal  - Build Whisper runner with Metal backend (macOS only)"
+	@echo "  llama-cpu      - Build Llama runner with CPU backend"
+	@echo "  llava-cpu      - Build Llava runner with CPU backend"
+	@echo "  gemma3-cuda    - Build Gemma3 runner with CUDA backend"
+	@echo "  gemma3-cpu     - Build Gemma3 runner with CPU backend"
+	@echo "  clean          - Clean build artifacts"
+
+voxtral-cuda:
+	@echo "==> Building and installing ExecuTorch with CUDA..."
+	cmake --workflow --preset llm-release-cuda
+	@echo "==> Building Voxtral runner with CUDA..."
+	cd examples/models/voxtral && cmake --workflow --preset voxtral-cuda
+	@echo ""
+	@echo "✓ Build complete!"
+	@echo "  Binary: cmake-out/examples/models/voxtral/voxtral_runner"
+
+voxtral-cpu:
+	@echo "==> Building and installing ExecuTorch..."
+	cmake --workflow --preset llm-release
+	@echo "==> Building Voxtral runner (CPU)..."
+	cd examples/models/voxtral && cmake --workflow --preset voxtral-cpu
+	@echo ""
+	@echo "✓ Build complete!"
+	@echo "  Binary: cmake-out/examples/models/voxtral/voxtral_runner"
+
+voxtral-metal:
+	@echo "==> Building and installing ExecuTorch with Metal..."
+	cmake --workflow --preset llm-release-metal
+	@echo "==> Building Voxtral runner with Metal..."
+	cd examples/models/voxtral && cmake --workflow --preset voxtral-metal
+	@echo ""
+	@echo "✓ Build complete!"
+	@echo "  Binary: cmake-out/examples/models/voxtral/voxtral_runner"
+
+whisper-cuda:
+	@echo "==> Building and installing ExecuTorch with CUDA..."
+	cmake --workflow --preset llm-release-cuda
+	@echo "==> Building Whisper runner with CUDA..."
+	cd examples/models/whisper && cmake --workflow --preset whisper-cuda
+	@echo ""
+	@echo "✓ Build complete!"
+	@echo "  Binary: cmake-out/examples/models/whisper/whisper_runner"
+
+whisper-cpu:
+	@echo "==> Building and installing ExecuTorch..."
+	cmake --workflow --preset llm-release
+	@echo "==> Building Whisper runner (CPU)..."
+	cd examples/models/whisper && cmake --workflow --preset whisper-cpu
+	@echo ""
+	@echo "✓ Build complete!"
+	@echo "  Binary: cmake-out/examples/models/whisper/whisper_runner"
+
+whisper-metal:
+	@echo "==> Building and installing ExecuTorch with Metal..."
+	cmake --workflow --preset llm-release-metal
+	@echo "==> Building Whisper runner with Metal..."
+	cd examples/models/whisper && cmake --workflow --preset whisper-metal
+	@echo ""
+	@echo "✓ Build complete!"
+	@echo "  Binary: cmake-out/examples/models/whisper/whisper_runner"
+
+llama-cpu:
+	@echo "==> Building and installing ExecuTorch..."
+	cmake --workflow --preset llm-release
+	@echo "==> Building Llama runner (CPU)..."
+	cd examples/models/llama && cmake --workflow --preset llama-release
+	@echo ""
+	@echo "✓ Build complete!"
+	@echo "  Binary: cmake-out/examples/models/llama/llama_main"
+
+llava-cpu:
+	@echo "==> Building and installing ExecuTorch..."
+	cmake --workflow --preset llm-release
+	@echo "==> Building Llava runner (CPU)..."
+	cd examples/models/llava && cmake --workflow --preset llava
+	@echo ""
+	@echo "✓ Build complete!"
+	@echo "  Binary: cmake-out/examples/models/llava/llava_main"
+
+gemma3-cuda:
+	@echo "==> Building and installing ExecuTorch with CUDA..."
+	cmake --workflow --preset llm-release-cuda
+	@echo "==> Building Gemma3 runner with CUDA..."
+	cd examples/models/gemma3 && cmake --workflow --preset gemma3-cuda
+	@echo ""
+	@echo "✓ Build complete!"
+	@echo "  Binary: cmake-out/examples/models/gemma3/gemma3_e2e_runner"
+
+gemma3-cpu:
+	@echo "==> Building and installing ExecuTorch..."
+	cmake --workflow --preset llm-release
+	@echo "==> Building Gemma3 runner (CPU)..."
+	cd examples/models/gemma3 && cmake --workflow --preset gemma3-cpu
+	@echo ""
+	@echo "✓ Build complete!"
+	@echo "  Binary: cmake-out/examples/models/gemma3/gemma3_e2e_runner"
+
+clean:
+	rm -rf cmake-out

--- a/examples/models/gemma3/CMakePresets.json
+++ b/examples/models/gemma3/CMakePresets.json
@@ -1,0 +1,76 @@
+{
+    "version": 6,
+    "configurePresets": [
+        {
+            "name": "gemma3-base",
+            "hidden": true,
+            "binaryDir": "${sourceDir}/../../../cmake-out/examples/models/gemma3",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release",
+                "CMAKE_FIND_ROOT_PATH": "${sourceDir}/../../../cmake-out"
+            }
+        },
+        {
+            "name": "gemma3-cpu",
+            "displayName": "Gemma3 runner (CPU)",
+            "inherits": ["gemma3-base"]
+        },
+        {
+            "name": "gemma3-cuda",
+            "displayName": "Gemma3 runner (CUDA)",
+            "inherits": ["gemma3-base"],
+            "cacheVariables": {
+                "EXECUTORCH_BUILD_CUDA": "ON"
+            },
+            "condition": {
+                "lhs": "${hostSystemName}",
+                "type": "equals",
+                "rhs": "Linux"
+            }
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "gemma3-cpu",
+            "displayName": "Build Gemma3 runner (CPU)",
+            "configurePreset": "gemma3-cpu",
+            "targets": ["gemma3_e2e_runner"]
+        },
+        {
+            "name": "gemma3-cuda",
+            "displayName": "Build Gemma3 runner (CUDA)",
+            "configurePreset": "gemma3-cuda",
+            "targets": ["gemma3_e2e_runner"]
+        }
+    ],
+    "workflowPresets": [
+        {
+            "name": "gemma3-cpu",
+            "displayName": "Configure and build Gemma3 runner (CPU)",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "gemma3-cpu"
+                },
+                {
+                    "type": "build",
+                    "name": "gemma3-cpu"
+                }
+            ]
+        },
+        {
+            "name": "gemma3-cuda",
+            "displayName": "Configure and build Gemma3 runner (CUDA)",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "gemma3-cuda"
+                },
+                {
+                    "type": "build",
+                    "name": "gemma3-cuda"
+                }
+            ]
+        }
+    ]
+}

--- a/examples/models/gemma3/README.md
+++ b/examples/models/gemma3/README.md
@@ -78,18 +78,11 @@ Ensure you have a CUDA-capable GPU and CUDA toolkit installed on your system.
 
 ### Building for CUDA
 ```bash
-# Install ExecuTorch.
-./install_executorch.sh
+# Build the Gemma3 runner with CUDA enabled
+make gemma3-cuda
 
-# Build the multimodal runner with CUDA
-cmake --workflow llm-release-cuda
-
-# Build the Gemma3 runner
-cmake -DEXECUTORCH_BUILD_CUDA=ON \
-      -DCMAKE_BUILD_TYPE=Release \
-      -Sexamples/models/gemma3 \
-      -Bcmake-out/examples/models/gemma3/
-cmake --build cmake-out/examples/models/gemma3 --target gemma3_e2e_runner --config Release
+# Build the Gemma3 runner with CPU enabled
+make gemma3-cpu
 ```
 
 ## Running the model

--- a/examples/models/llama/CMakePresets.json
+++ b/examples/models/llama/CMakePresets.json
@@ -1,0 +1,67 @@
+{
+    "version": 6,
+    "configurePresets": [
+        {
+            "name": "llama-release",
+            "displayName": "Llama runner in Release mode",
+            "binaryDir": "${sourceDir}/../../../cmake-out/examples/models/llama",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release",
+                "CMAKE_FIND_ROOT_PATH": "${sourceDir}/../../../cmake-out"
+            }
+        },
+        {
+            "name": "llama-debug",
+            "displayName": "Llama runner in Debug mode",
+            "binaryDir": "${sourceDir}/../../../cmake-out/examples/models/llama",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "CMAKE_FIND_ROOT_PATH": "${sourceDir}/../../../cmake-out"
+            }
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "llama-release",
+            "displayName": "Build Llama runner in Release mode",
+            "configurePreset": "llama-release",
+            "targets": ["llama_main"]
+        },
+        {
+            "name": "llama-debug",
+            "displayName": "Build Llama runner in Debug mode",
+            "configurePreset": "llama-debug",
+            "targets": ["llama_main"]
+        }
+    ],
+    "workflowPresets": [
+        {
+            "name": "llama-release",
+            "displayName": "Configure and build Llama runner in Release mode",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "llama-release"
+                },
+                {
+                    "type": "build",
+                    "name": "llama-release"
+                }
+            ]
+        },
+        {
+            "name": "llama-debug",
+            "displayName": "Configure and build Llama runner in Debug mode",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "llama-debug"
+                },
+                {
+                    "type": "build",
+                    "name": "llama-debug"
+                }
+            ]
+        }
+    ]
+}

--- a/examples/models/llama/README.md
+++ b/examples/models/llama/README.md
@@ -242,12 +242,9 @@ Note for Mac users: There's a known linking issue with Xcode 15.1. Refer to the 
 
 2. Build llama runner.
 ```
-cmake -DCMAKE_INSTALL_PREFIX=cmake-out \
-	-DCMAKE_BUILD_TYPE=Release \
-	-Bcmake-out/examples/models/llama \
-	examples/models/llama
-
-cmake --build cmake-out/examples/models/llama -j16 --config Release
+pushd examples/models/llama
+cmake --workflow --preset llama-release
+popd
 ```
 
 3. Run model. Run options available [here](https://github.com/pytorch/executorch/blob/main/examples/models/llama/main.cpp#L18-L40).

--- a/examples/models/llava/CMakePresets.json
+++ b/examples/models/llava/CMakePresets.json
@@ -1,0 +1,38 @@
+{
+    "version": 6,
+    "configurePresets": [
+        {
+            "name": "llava",
+            "displayName": "Llava runner",
+            "binaryDir": "${sourceDir}/../../../cmake-out/examples/models/llava",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release",
+                "CMAKE_FIND_ROOT_PATH": "${sourceDir}/../../../cmake-out"
+            }
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "llava",
+            "displayName": "Build Llava runner",
+            "configurePreset": "llava",
+            "targets": ["llava_main"]
+        }
+    ],
+    "workflowPresets": [
+        {
+            "name": "llava",
+            "displayName": "Configure and build Llava runner",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "llava"
+                },
+                {
+                    "type": "build",
+                    "name": "llava"
+                }
+            ]
+        }
+    ]
+}

--- a/examples/models/voxtral/CMakePresets.json
+++ b/examples/models/voxtral/CMakePresets.json
@@ -1,0 +1,109 @@
+{
+    "version": 6,
+    "configurePresets": [
+        {
+            "name": "voxtral-base",
+            "hidden": true,
+            "binaryDir": "${sourceDir}/../../../cmake-out/examples/models/voxtral",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release",
+                "CMAKE_FIND_ROOT_PATH": "${sourceDir}/../../../cmake-out"
+            }
+        },
+        {
+            "name": "voxtral-cpu",
+            "displayName": "Voxtral runner (CPU)",
+            "inherits": ["voxtral-base"]
+        },
+        {
+            "name": "voxtral-cuda",
+            "displayName": "Voxtral runner (CUDA)",
+            "inherits": ["voxtral-base"],
+            "cacheVariables": {
+                "EXECUTORCH_BUILD_CUDA": "ON"
+            },
+            "condition": {
+                "lhs": "${hostSystemName}",
+                "type": "equals",
+                "rhs": "Linux"
+            }
+        },
+        {
+            "name": "voxtral-metal",
+            "displayName": "Voxtral runner (Metal)",
+            "inherits": ["voxtral-base"],
+            "cacheVariables": {
+                "EXECUTORCH_BUILD_METAL": "ON"
+            },
+            "condition": {
+                "lhs": "${hostSystemName}",
+                "type": "equals",
+                "rhs": "Darwin"
+            }
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "voxtral-cpu",
+            "displayName": "Build Voxtral runner (CPU)",
+            "configurePreset": "voxtral-cpu",
+            "targets": ["voxtral_runner"]
+        },
+        {
+            "name": "voxtral-cuda",
+            "displayName": "Build Voxtral runner (CUDA)",
+            "configurePreset": "voxtral-cuda",
+            "targets": ["voxtral_runner"]
+        },
+        {
+            "name": "voxtral-metal",
+            "displayName": "Build Voxtral runner (Metal)",
+            "configurePreset": "voxtral-metal",
+            "targets": ["voxtral_runner"]
+        }
+    ],
+    "workflowPresets": [
+        {
+            "name": "voxtral-cpu",
+            "displayName": "Configure and build Voxtral runner (CPU)",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "voxtral-cpu"
+                },
+                {
+                    "type": "build",
+                    "name": "voxtral-cpu"
+                }
+            ]
+        },
+        {
+            "name": "voxtral-cuda",
+            "displayName": "Configure and build Voxtral runner (CUDA)",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "voxtral-cuda"
+                },
+                {
+                    "type": "build",
+                    "name": "voxtral-cuda"
+                }
+            ]
+        },
+        {
+            "name": "voxtral-metal",
+            "displayName": "Configure and build Voxtral runner (Metal)",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "voxtral-metal"
+                },
+                {
+                    "type": "build",
+                    "name": "voxtral-metal"
+                }
+            ]
+        }
+    ]
+}

--- a/examples/models/voxtral/README.md
+++ b/examples/models/voxtral/README.md
@@ -122,41 +122,20 @@ python -m executorch.extension.audio.mel_spectrogram \
 
 ### Building for CPU (XNNPack)
 ```
-# Build and install ExecuTorch
-cmake --workflow llm-release
-
 # Build and install Voxtral runner
-cmake -DCMAKE_INSTALL_PREFIX=cmake-out -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release -Bcmake-out/examples/models/voxtral examples/models/voxtral && cmake --build cmake-out/examples/models/voxtral -j16 --config Release
+make voxtral-cpu
 ```
 
 ### Building for CUDA
 ```
-# Install ExecuTorch with CUDA support
-./install_executorch.sh
-
-# Build the multimodal runner with CUDA
-cmake --workflow llm-release-cuda
-
-cmake -DEXECUTORCH_BUILD_CUDA=ON \
-      -DCMAKE_BUILD_TYPE=Release \
-      -Sexamples/models/voxtral \
-      -Bcmake-out/examples/models/voxtral/
-cmake --build cmake-out/examples/models/voxtral --target voxtral_runner --config Release
+# Build Voxtral runner with CUDA
+make voxtral-cuda
 ```
 
 ### Building for Metal
 ```
-# Install ExecuTorch with Metal support
-CMAKE_ARGS="-DEXECUTORCH_BUILD_METAL=ON" ./install_executorch.sh
-
-# Build the multimodal runner with Metal
-cmake --workflow llm-release-metal
-
-cmake -DEXECUTORCH_BUILD_METAL=ON \
-      -DCMAKE_BUILD_TYPE=Release \
-      -Sexamples/models/voxtral \
-      -Bcmake-out/examples/models/voxtral/
-cmake --build cmake-out/examples/models/voxtral --target voxtral_runner --config Release
+# Build Voxtral runner with Metal
+make voxtral-metal
 ```
 
 ## Running the model

--- a/examples/models/whisper/CMakePresets.json
+++ b/examples/models/whisper/CMakePresets.json
@@ -1,0 +1,109 @@
+{
+    "version": 6,
+    "configurePresets": [
+        {
+            "name": "whisper-base",
+            "hidden": true,
+            "binaryDir": "${sourceDir}/../../../cmake-out/examples/models/whisper",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release",
+                "CMAKE_FIND_ROOT_PATH": "${sourceDir}/../../../cmake-out"
+            }
+        },
+        {
+            "name": "whisper-cpu",
+            "displayName": "Whisper runner (CPU)",
+            "inherits": ["whisper-base"]
+        },
+        {
+            "name": "whisper-cuda",
+            "displayName": "Whisper runner (CUDA)",
+            "inherits": ["whisper-base"],
+            "cacheVariables": {
+                "EXECUTORCH_BUILD_CUDA": "ON"
+            },
+            "condition": {
+                "lhs": "${hostSystemName}",
+                "type": "equals",
+                "rhs": "Linux"
+            }
+        },
+        {
+            "name": "whisper-metal",
+            "displayName": "Whisper runner (Metal)",
+            "inherits": ["whisper-base"],
+            "cacheVariables": {
+                "EXECUTORCH_BUILD_METAL": "ON"
+            },
+            "condition": {
+                "lhs": "${hostSystemName}",
+                "type": "equals",
+                "rhs": "Darwin"
+            }
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "whisper-cpu",
+            "displayName": "Build Whisper runner (CPU)",
+            "configurePreset": "whisper-cpu",
+            "targets": ["whisper_runner"]
+        },
+        {
+            "name": "whisper-cuda",
+            "displayName": "Build Whisper runner (CUDA)",
+            "configurePreset": "whisper-cuda",
+            "targets": ["whisper_runner"]
+        },
+        {
+            "name": "whisper-metal",
+            "displayName": "Build Whisper runner (Metal)",
+            "configurePreset": "whisper-metal",
+            "targets": ["whisper_runner"]
+        }
+    ],
+    "workflowPresets": [
+        {
+            "name": "whisper-cpu",
+            "displayName": "Configure and build Whisper runner (CPU)",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "whisper-cpu"
+                },
+                {
+                    "type": "build",
+                    "name": "whisper-cpu"
+                }
+            ]
+        },
+        {
+            "name": "whisper-cuda",
+            "displayName": "Configure and build Whisper runner (CUDA)",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "whisper-cuda"
+                },
+                {
+                    "type": "build",
+                    "name": "whisper-cuda"
+                }
+            ]
+        },
+        {
+            "name": "whisper-metal",
+            "displayName": "Configure and build Whisper runner (Metal)",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "whisper-metal"
+                },
+                {
+                    "type": "build",
+                    "name": "whisper-metal"
+                }
+            ]
+        }
+    ]
+}

--- a/examples/models/whisper/README.md
+++ b/examples/models/whisper/README.md
@@ -20,32 +20,22 @@ module to generate the spectrogram tensor.
 
 ## Build
 
-Currently we have CUDA and Metal build support. CPU is WIP.
+Currently we have CUDA and Metal build support.
+
+For CPU:
+```
+make whisper-cpu
+```
 
 For CUDA:
 ```
-WORKFLOW="llm-release-cuda"
+make whisper-cuda
 ```
 
 For Metal:
 ```
-WORKFLOW="llm-release-metal"
+make whisper-metal
 ```
-
-```bash
-# Install ExecuTorch libraries:
-cmake --workflow $WORKFLOW
-
-# Build the runner:
-cmake \
-  -B cmake-out/examples/models/whisper \
-  -S examples/models/whisper
-cmake --build cmake-out/examples/models/whisper -j$(nproc)
-```
-
-The first cmake command build produces a static library named `extension_asr_runner`. The second cmake command links it into your
-application together with the standard ExecuTorch runtime libraries and the
-tokenizer target (`tokenizers::tokenizers`).
 
 ## Usage
 


### PR DESCRIPTION
This way we can do

```
make llama-cpu
```
to build llama runner with CPU backend, instead of the original:

```
cmake --preset llm -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=cmake-out

cmake --build cmake-out -j16 --target install --config Release

cmake -DCMAKE_INSTALL_PREFIX=cmake-out \
	-DCMAKE_BUILD_TYPE=Release \
	-Bcmake-out/examples/models/llama \
	examples/models/llama

cmake --build cmake-out/examples/models/llama -j16 --config Release
```

I added a bunch of runners such as whisper, gemma3, voxtral and llava.

Another good thing about `Makefile` is that it supports tab completion.


### Test plan
Manually tested a few of them. Changed CI job to use these commands.
