### PR TITLE
Qualcomm AI Engine Direct - fix miss layernorm registry

### DIFF
--- a/examples/qualcomm/oss_scripts/llama/model/layernorm.py
+++ b/examples/qualcomm/oss_scripts/llama/model/layernorm.py
@@ -42,6 +42,7 @@ class LayerNorm(torch.nn.LayerNorm, Norm):
         super().__init__(hidden_size, eps=eps)
 
 
+@register_norm("gemma3")
 @register_norm("rmsnorm")
 class RMSNorm(torch.nn.RMSNorm, Norm):
     def __init__(self, hidden_size: int, eps=1e-5):


### PR DESCRIPTION
### Summary
 - fix miss layernorm registry for gemma.

### Test Plan
```bash
python examples/qualcomm/oss_scripts/llama/llama.py -b build-android -s ${SERIAL_NUM} -m ${SOC_MODEL} --temperature 0 --model_mode hybrid --max_seq_len 1024 --prefill_ar_len 128 --decoder_model gemma-2b --prompt "I would like to learn python, could you teach me with a simple example?" --tasks wikitext --limit 1
```
