### PR TITLE
[ET-VK] Add int and bool tensor support for many operators

### DIFF
--- a/backends/vulkan/runtime/graph/ops/glsl/clone.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/clone.yaml
@@ -7,5 +7,7 @@ clone:
     DTYPE:
       - VALUE: half
       - VALUE: float
+      - VALUE: int32
+      - VALUE: uint8
   shader_variants:
     - NAME: clone

--- a/backends/vulkan/runtime/graph/ops/glsl/concat_buffer.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/concat_buffer.yaml
@@ -6,6 +6,7 @@ concat_buffer:
     DTYPE:
       - VALUE: half
       - VALUE: float
+      - VALUE: int32
   shader_variants:
     - NAME: concat_1_buffer
       NUM_INPUTS: 1

--- a/backends/vulkan/runtime/graph/ops/glsl/concat_texture.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/concat_texture.glsl
@@ -113,8 +113,6 @@ void main() {
 
   VEC4_T out_texel = imageLoad(t_out, out_pos);
 
-  VEC4_T test_texel = VEC4_T(-1.0);
-
   for (int comp = 0; comp < 4; ++comp) {
     ivec4 out_tidx = out_read_start_tidx;
     out_tidx[out_packed_dim] += comp;
@@ -124,7 +122,6 @@ void main() {
     // of the previous input batch; if so, then don't overwrite this texel
     // element
     if (out_tidx[concat_dim] < concat_offset) {
-      test_texel[comp] = -5.0;
       continue;
     }
 
@@ -164,7 +161,6 @@ void main() {
             inp${i}_packed_dim);
 
         out_texel[comp] = texelFetch(t_inp${i}, in_posi.xyz, 0)[in_posi.w];
-        test_texel[comp] = out_texel[comp];
         continue;
       }
       else {

--- a/backends/vulkan/runtime/graph/ops/glsl/concat_texture.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/concat_texture.yaml
@@ -6,6 +6,7 @@ concat_texture:
     DTYPE:
       - VALUE: half
       - VALUE: float
+      - VALUE: int32
   shader_variants:
     - NAME: concat_1_texture3d
       NUM_INPUTS: 1

--- a/backends/vulkan/runtime/graph/ops/glsl/expand_buffer.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/expand_buffer.yaml
@@ -6,5 +6,6 @@ expand_buffer:
       - VALUE: half
       - VALUE: float
       - VALUE: int32
+      - VALUE: uint8
   shader_variants:
     - NAME: expand_buffer

--- a/backends/vulkan/runtime/graph/ops/glsl/full.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/full.yaml
@@ -15,5 +15,6 @@ full:
       - VALUE: half
       - VALUE: float
       - VALUE: int32
+      - VALUE: uint8
   shader_variants:
     - NAME: full

--- a/backends/vulkan/runtime/graph/ops/glsl/gather_buffer.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/gather_buffer.yaml
@@ -12,5 +12,7 @@ gather_buffer:
     DTYPE:
       - VALUE: half
       - VALUE: float
+      - VALUE: int32
+      - VALUE: uint8
   shader_variants:
     - NAME: gather_buffer

--- a/backends/vulkan/runtime/graph/ops/glsl/gather_texture.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/gather_texture.yaml
@@ -11,5 +11,7 @@ gather_texture:
     DTYPE:
       - VALUE: half
       - VALUE: float
+      - VALUE: int32
+      - VALUE: uint8
   shader_variants:
     - NAME: gather_texture3d

--- a/backends/vulkan/runtime/graph/ops/glsl/index_select.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/index_select.yaml
@@ -8,5 +8,6 @@ index_select:
       - VALUE: half
       - VALUE: float
       - VALUE: int32
+      - VALUE: uint8
   shader_variants:
     - NAME: index_select

--- a/backends/vulkan/runtime/graph/ops/glsl/index_select_channel.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/index_select_channel.yaml
@@ -8,5 +8,6 @@ index_select_channel:
       - VALUE: half
       - VALUE: float
       - VALUE: int32
+      - VALUE: uint8
   shader_variants:
     - NAME: index_select_channel

--- a/backends/vulkan/runtime/graph/ops/glsl/pad_channel.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/pad_channel.yaml
@@ -8,5 +8,7 @@ pad_channel:
     DTYPE:
       - VALUE: float
       - VALUE: half
+      - VALUE: int32
+      - VALUE: uint8
   shader_variants:
     - NAME: pad_channel

--- a/backends/vulkan/runtime/graph/ops/glsl/pad_height_width.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/pad_height_width.yaml
@@ -8,5 +8,7 @@ pad_height_width:
     DTYPE:
       - VALUE: float
       - VALUE: half
+      - VALUE: int32
+      - VALUE: uint8
   shader_variants:
     - NAME: pad_height_width

--- a/backends/vulkan/runtime/graph/ops/glsl/repeat_channel.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/repeat_channel.yaml
@@ -6,5 +6,7 @@ repeat_channel:
     DTYPE:
       - VALUE: half
       - VALUE: float
+      - VALUE: int32
+      - VALUE: uint8
   shader_variants:
     - NAME: repeat_channel

--- a/backends/vulkan/runtime/graph/ops/glsl/repeat_interleave.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/repeat_interleave.yaml
@@ -6,5 +6,7 @@ repeat_interleave:
     DTYPE:
       - VALUE: half
       - VALUE: float
+      - VALUE: int32
+      - VALUE: uint8
   shader_variants:
     - NAME: repeat_interleave

--- a/backends/vulkan/runtime/graph/ops/glsl/split_buffer.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/split_buffer.yaml
@@ -12,5 +12,7 @@ split_buffer:
     DTYPE:
       - VALUE: half
       - VALUE: float
+      - VALUE: int32
+      - VALUE: uint8
   shader_variants:
     - NAME: split_buffer

--- a/backends/vulkan/runtime/graph/ops/glsl/split_texture.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/split_texture.yaml
@@ -11,5 +11,7 @@ split_texture:
     DTYPE:
       - VALUE: half
       - VALUE: float
+      - VALUE: int32
+      - VALUE: uint8
   shader_variants:
     - NAME: split_texture3d


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #15829
* #15796
* #15795
* #15794
* #15793

Title says it all!

Adds `int32` and `uint8` shader variants to a bunch of operators that don't currently have variants for these dtypes, but should.

This should prevent folks from running into dtype crashes at runtime when using the Vulkan delegate.

Differential Revision: [D87082724](https://our.internmc.facebook.com/intern/diff/D87082724/)