### PR TITLE
Prohibit nested backends

### DIFF
--- a/exir/backend/backend_details.py
+++ b/exir/backend/backend_details.py
@@ -57,6 +57,22 @@ class BackendDetails(ABC):
 
     """
 
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+
+        # Allow direct subclasses of BackendDetails
+        if cls.__bases__ == (BackendDetails,):
+            return
+
+        # Forbid subclasses whose ANY parent is already a child of BackendDetails
+        for base in cls.__bases__:
+            if issubclass(base, BackendDetails) and base is not BackendDetails:
+                raise TypeError(
+                    f"ExecuTorch delegate doesn't support nested backend, '{base.__name__}' "
+                    " should be a final backend implementation and should not be subclassed "
+                    f"(attempted by '{cls.__name__}')."
+                )
+
     @staticmethod
     # all backends need to implement this method
     @enforcedmethod


### PR DESCRIPTION
Summary: https://github.com/pytorch/executorch/pull/15528 initially wanted to subclass a backend.. It was currently already guarded by https://github.com/pytorch/executorch/blob/main/exir/backend/backend_api.py#L111-L112 meaning that subclass will not show up.  However it's not super obvious so we want to guard by disallowing subclass at all

Differential Revision: D87105211


