### PR TITLE
Remove no-op clones

### DIFF
--- a/backends/nxp/tests/ir/converter/node_converter/test_clone_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_clone_converter.py
@@ -76,6 +76,7 @@ class KWSFinalBlock(torch.nn.Module):
         return self.block(x)
 
 
+@unittest.skip("Clones are optimized out of the graph.")
 class TestCloneConverter(unittest.TestCase):
     __test__ = False  # Prevent interfering with PyTest tests
 

--- a/backends/transforms/test/test_remove_clone_ops.py
+++ b/backends/transforms/test/test_remove_clone_ops.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-unsafe
+
 import unittest
 
 import torch
@@ -156,34 +158,6 @@ class TestRemoveCloneOpsTransform(TestCase):
             updated_epm = before_epm.transform([RemoveCloneOpsTransform()])
 
             FileCheck().check_count(clone_op_str, 1, exactly=True).run(
-                updated_epm.exported_program().graph_module.code
-            )
-
-            expected = before_epm.exported_program().module()(x)
-            actual = updated_epm.exported_program().module()(x)
-            assert torch.allclose(actual, expected)
-            assert is_channel_last_dim_order(actual)
-
-    def test_clone_identity_removed(self):
-        """Verify identity clone ops are removed by RemoveCloneOpsTransform."""
-
-        for skip_dim_order, clone_op_str in self.CLONE_OP_CASES:
-            model = SimpleCloneChannelsLastModule()
-            x = torch.randn(3, 4, 5, 6).to(memory_format=torch.channels_last)
-
-            exported = export(model.eval(), (x,), strict=True)
-            before_epm = to_edge(
-                exported,
-                compile_config=EdgeCompileConfig(_skip_dim_order=skip_dim_order),
-            )
-
-            FileCheck().check_count(clone_op_str, 1, exactly=True).run(
-                before_epm.exported_program().graph_module.code
-            )
-
-            updated_epm = before_epm.transform([RemoveCloneOpsTransform()])
-
-            FileCheck().check_not(clone_op_str).run(
                 updated_epm.exported_program().graph_module.code
             )
 

--- a/exir/tests/test_passes.py
+++ b/exir/tests/test_passes.py
@@ -2093,3 +2093,35 @@ class TestPasses(unittest.TestCase):
             prop_tensor.is_contiguous(),
             f"Propagated tensor is not contiguous: {prop_tensor.stride()}",
         )
+
+    def test_remove_noop_pass_clone(self) -> None:
+        """
+        Verify the no-op clones are removed from the graph.
+        """
+
+        class CloneModel(torch.nn.Module):
+            def forward(self, x):
+                return x.clone() + x.clone()
+
+        model = CloneModel()
+        inputs = (torch.randn(1, 16),)
+
+        ep = torch.export.export(model, inputs)
+        lowered = to_edge_transform_and_lower(ep)
+
+        # Sanity check the test - we should see clones in the exported program
+        self.assertTrue(
+            any(
+                n.op == "call_function" and n.target == torch.ops.aten.clone.default
+                for n in ep.graph.nodes
+            )
+        )
+
+        # Since the clone ops are no-ops, they should be gone.
+        self.assertFalse(
+            any(
+                n.op == "call_function"
+                and n.target == exir_ops.edge.dim_order_ops._clone_dim_order.default
+                for n in lowered.exported_program().graph.nodes
+            )
+        )


### PR DESCRIPTION
Remove clones that don't change memory layout / dim order. As the graph is assumed to be functional, these are no-ops. We've seen some non-zero performance impact. Some backends optimize them out, but it makes sense to do it at the to_edge level, as the optimization is global.

As this impacts several consumers, I've synced with NXP (see PR comments) and with RL / Jarvis to verify that the change is acceptable.

Differential Revision: D86588171


