### PR TITLE
Arm backend: Fix ubsan warning in example runner

### DIFF
--- a/backends/arm/test/test_arm_baremetal.sh
+++ b/backends/arm/test/test_arm_baremetal.sh
@@ -390,7 +390,7 @@ test_memory_allocation() {
             --require "model_pte_program_size" "<= 3000 B" \
             --require "method_allocator_planned" "<= 64 B" \
             --require "method_allocator_loaded" "<= 1024 B" \
-            --require "method_allocator_input" "<= 4 B" \
+            --require "method_allocator_input" "<= 16 B" \
             --require "Total DRAM used" "<= 0.06 KiB"
     echo "${TEST_SUITE_NAME}: PASS"
 }

--- a/examples/arm/executor_runner/arm_executor_runner.cpp
+++ b/examples/arm/executor_runner/arm_executor_runner.cpp
@@ -410,8 +410,7 @@ Error prepare_input_tensors(
       "Wrong number of inputs allocated compared to method");
 #endif
 
-  EValue* input_evalues =
-      static_cast<EValue*>(allocator.allocate(num_inputs * sizeof(EValue*)));
+  EValue* input_evalues = allocator.allocateList<EValue>(num_inputs);
   ET_CHECK_OR_RETURN_ERROR(
       input_evalues != nullptr,
       MemoryAllocationFailed,


### PR DESCRIPTION
Avoid dangerous pointer arithmetic by making sure EValue lands at its natural alignment (8 bytes on this target).

Signed-off-by: per.held@arm.com
Change-Id: I3efee39f5c36ea76e08373fccc5ff10c01cbc588
