### PR TITLE
Arm backend: Support quantized cond and while

### DIFF
--- a/backends/arm/_passes/__init__.py
+++ b/backends/arm/_passes/__init__.py
@@ -88,7 +88,11 @@ from .fuse_view_copy_transform_pass import FuseViewCopyTransformPass  # noqa
 from .insert_int32_casts_after_int64_placeholders import (  # noqa
     InsertInt32CastsAfterInt64PlaceholdersPass,
 )
-from .insert_rescales_pass import InsertRescaleInt32Pass, InsertRescalePass  # noqa
+from .insert_rescales_pass import (  # noqa
+    InsertCondRescalesPass,
+    InsertRescaleInt32Pass,
+    InsertRescalePass,
+)
 from .insert_table_ops import InsertTableOpsPass  # noqa
 from .match_arg_dtype_pass import MatchArgDtypePass  # noqa
 from .match_arg_ranks_pass import MatchArgRanksPass  # noqa

--- a/backends/arm/_passes/__init__.py
+++ b/backends/arm/_passes/__init__.py
@@ -89,7 +89,7 @@ from .insert_int32_casts_after_int64_placeholders import (  # noqa
     InsertInt32CastsAfterInt64PlaceholdersPass,
 )
 from .insert_rescales_pass import (  # noqa
-    InsertCondRescalesPass,
+    InsertControlFlowRescalesPass,
     InsertRescaleInt32Pass,
     InsertRescalePass,
 )

--- a/backends/arm/_passes/arm_pass_manager.py
+++ b/backends/arm/_passes/arm_pass_manager.py
@@ -85,6 +85,7 @@ from executorch.backends.arm._passes import (
     FuseEqualPlaceholdersPass,
     FuseQuantizedActivationPass,
     FuseViewCopyTransformPass,
+    InsertCondRescalesPass,
     InsertInt32CastsAfterInt64PlaceholdersPass,
     InsertRescaleInt32Pass,
     InsertRescalePass,
@@ -195,6 +196,7 @@ class ArmPassManager(PassManager):
                 # Ticket: MLETORCH-1539
                 DecomposeLinearPass(),
                 InsertRescaleInt32Pass(),
+                InsertCondRescalesPass(),
             ]
         )
 

--- a/backends/arm/_passes/arm_pass_manager.py
+++ b/backends/arm/_passes/arm_pass_manager.py
@@ -85,7 +85,7 @@ from executorch.backends.arm._passes import (
     FuseEqualPlaceholdersPass,
     FuseQuantizedActivationPass,
     FuseViewCopyTransformPass,
-    InsertCondRescalesPass,
+    InsertControlFlowRescalesPass,
     InsertInt32CastsAfterInt64PlaceholdersPass,
     InsertRescaleInt32Pass,
     InsertRescalePass,
@@ -196,7 +196,7 @@ class ArmPassManager(PassManager):
                 # Ticket: MLETORCH-1539
                 DecomposeLinearPass(),
                 InsertRescaleInt32Pass(),
-                InsertCondRescalesPass(),
+                InsertControlFlowRescalesPass(),
             ]
         )
 

--- a/backends/arm/_passes/insert_rescales_pass.py
+++ b/backends/arm/_passes/insert_rescales_pass.py
@@ -471,7 +471,7 @@ class InsertControlFlowRescalesPass(ArmPass):
 
         The dq->q qparam pair we want to convert to a rescale is:
         (input qparam of output_node, output qparam of getitem)
-        And the rescale is inserted between op and output. Note that the output qparam of op is qalled input_qargs,
+        And the rescale is inserted between op and output. Note that the output qparam of op is called input_qargs,
         since the it is the input to the dq-q pair.
 
         Args:

--- a/backends/arm/_passes/insert_rescales_pass.py
+++ b/backends/arm/_passes/insert_rescales_pass.py
@@ -369,3 +369,185 @@ class InsertRescaleInt32Pass(ArmPass):
             graph_module.recompile()
 
         return PassResult(graph_module, modified)
+
+
+class InsertCondRescalesPass(ArmPass):
+    """The quantization parameters for tensors going into and coming out of a submodule are not guaranteed to
+    match the quantization parameters for the corresponding tensors inside the submodule. For example, cond has
+    different annotation on input and output, while the entire graph inside the submodule could be using shared
+    annotation. This pass solves this by inserting rescales in the beginning and end of the submodule
+    that transform the tensor from one set of quantization parameters to another.
+
+    The pass is run by the graph_module containing the control flow operator, but requires that the affected nodes
+    inside the submodule have been q-dq folded and have input/output_qparams meta.
+    """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
+
+    def _get_input_nodes(self, graph_module: GraphModule):
+        return [node for node in graph_module.graph.nodes if node.op == "placeholder"]
+
+    def _insert_rescale(
+        self,
+        in_qparams: QuantArgs,
+        out_qparams: QuantArgs,
+        from_node: Node,
+        graph_module: GraphModule,
+    ):
+        """Insert a rescale into the graph, inheriting meta from `from_node`.
+        The node is not connected to anything, that is up to the user."""
+
+        new_scales = [
+            in_qparams.get_scale_per_tensor() / out_qparams.get_scale_per_tensor()
+        ]
+
+        rescale_node = create_node(
+            graph_module.graph,
+            exir_ops.backend.tosa.RESCALE.default,
+            (
+                None,
+                out_qparams.dtype,
+                new_scales,
+                in_qparams.get_zp_per_tensor(),  # Old zero point
+                out_qparams.get_zp_per_tensor(),  # New zero point
+            ),
+            from_node=from_node,
+        )
+        return rescale_node
+
+    def _rescale_submodule_inputs(
+        self, submodule: GraphModule, input_qparams_map: Dict[int, QuantArgs]
+    ) -> bool:
+        """Insert rescales at the inputs of `submodule` to match the qparams outside the submodule.
+        Matching the correct qparams gets a bit tricky:
+        Containing module: | submodule:
+              ops => cond  | => placeholders => ...
+
+        The dq->q qparam pair we want to convert to a rescale is:
+        (input qparams of op, output qparams of placeholder)
+        And the rescale is inserted after the placeholder.
+
+        Args:
+            submodule: GraphModule: the GraphModule in which to rescale the inputs.
+            input_qparams_map: A map of input indexes mapping to QuantArgs. Not guaranteed to contain a mapping
+                for every submodule input.
+        Returns:
+            True if at least one rescale was inserted, False otherwise.
+        """
+
+        modified = False
+        input_nodes = self._get_input_nodes(submodule)
+        for qargs_index in input_qparams_map:
+            input_node = input_nodes[qargs_index]
+            if len(out_qparams_map := input_node.meta.get("output_qparams", {})) != 1:
+                raise ValueError(
+                    f"Expected submodule input {input_node} to have exactly one output qparam, got {out_qparams_map}"
+                )
+            in_qparams = input_qparams_map[qargs_index]
+            out_qparams = cast(QuantArgs, out_qparams_map[0])
+
+            # Remove qparam meta to not confuse folding pass.
+            del input_node.meta["output_qparams"]
+            if in_qparams == out_qparams:
+                continue
+            with submodule.graph.inserting_after(input_node):
+                modified = True
+                rescale_node = self._insert_rescale(
+                    in_qparams, out_qparams, input_node, submodule
+                )
+                input_node.replace_all_uses_with(replace_with=rescale_node)
+                rescale_node.update_arg(0, input_node)
+        return modified
+
+    def _rescale_submodule_outputs(
+        self, submodule: GraphModule, output_qparams_map: Dict[int, QuantArgs]
+    ) -> bool:
+        """Insert rescales at the outputs of `submodule` to match the qparams outside the submodule.
+        Matching the correct qparams gets a bit tricky:
+        Submodule:             | Containing module:
+        output_nodes => output |=> getitems => ...
+
+        The dq->q qparam pair we want to convert to a rescale is:
+        (input qparam of output_node, output qparam of getitem)
+        And the rescale is inserted between op and output. Note that the output qparam of op is qalled input_qargs,
+        since the it is the input to the dq-q pair.
+
+        Args:
+            submodule: GraphModule: the GraphModule in which to rescale the outputs.
+            output_qparams_map: A map of output indexes mapping to QuantArgs. Not guaranteed to contain a mapping
+                for every submodule output.
+        Returns:
+            True if at least one rescale was inserted, False otherwise.
+        """
+
+        modified = False
+        output_node = submodule.graph.output_node()
+        output_args = list(cast(tuple[Node], output_node.args[0]))
+        input_qparams_map = cast(
+            dict[int, QuantArgs], output_node.meta["input_qparams"]
+        )
+        for qargs_index in output_qparams_map:
+            output_arg_node = output_args[qargs_index]
+            in_qparams = input_qparams_map[qargs_index]
+            out_qparams = output_qparams_map[qargs_index]
+            if in_qparams == out_qparams:
+                continue
+            with submodule.graph.inserting_before(output_node):
+                modified = True
+                rescale_node = self._insert_rescale(
+                    in_qparams, out_qparams, output_arg_node, submodule
+                )
+                output_args[qargs_index] = rescale_node
+                rescale_node.update_arg(0, output_arg_node)
+        output_node.update_arg(0, tuple(output_args))
+        # Remove qparam meta to not confuse folding pass.
+        del output_node.meta["input_qparams"]
+        return modified
+
+    def _rescale_control_flow(self, node: Node, graph_module: GraphModule) -> bool:
+        modified = False
+        if_graph: GraphModule = cast(GraphModule, graph_module.get_submodule(node.args[1].target))  # type: ignore
+        else_graph: GraphModule = cast(GraphModule, graph_module.get_submodule(node.args[2].target))  # type: ignore
+        input_qparams_meta = cast(
+            dict[int, QuantArgs], node.meta.get("input_qparams", None)
+        )
+        if input_qparams_meta:
+            input_qparams = cast(QuantArgs, input_qparams_meta.get(3, None))
+            if not input_qparams:
+                raise ValueError(
+                    f"Expected entry with key 3 in input_qparams meta, got {input_qparams_meta}"
+                )
+            num_inputs = len(cast(list, node.args[3]))
+
+            # Currently, infra only supports one set of qparams for a list of inputs
+            # Map all inputs to the same qparams.
+            input_qparams_map = {i: input_qparams for i in range(num_inputs)}
+            modified |= self._rescale_submodule_inputs(if_graph, input_qparams_map)
+            modified |= self._rescale_submodule_inputs(else_graph, input_qparams_map)
+
+        output_qparams_map: dict[int, QuantArgs] = {}
+        for getitem_node in node.users:
+            idx = cast(int, getitem_node.args[1])
+            qparam = getitem_node.meta.get("output_qparams", None)
+            if qparam:
+                output_qparams_map[idx] = cast(QuantArgs, qparam[0])
+        modified |= self._rescale_submodule_outputs(if_graph, output_qparams_map)
+        modified |= self._rescale_submodule_outputs(else_graph, output_qparams_map)
+        return modified
+
+    def call(self, graph_module: GraphModule) -> PassResult:
+        modified = False
+
+        for node in list(graph_module.graph.nodes):
+            node = cast(Node, node)
+            if node.op != "call_function" or node.target != torch.ops.higher_order.cond:
+                continue
+
+            modified = self._rescale_control_flow(node, graph_module)
+
+        if modified:
+            # Retrace the graph to update the fake tensor types
+            graph_module = super().call(graph_module).graph_module
+            graph_module.recompile()
+
+        return PassResult(graph_module, modified)

--- a/backends/arm/operator_support/__init__.py
+++ b/backends/arm/operator_support/__init__.py
@@ -6,6 +6,7 @@
 
 from . import (  # noqa
     clone_dim_order_support,
+    control_flow_support,
     convolution_support,
     embedding_support,
     ethos_u55_support,

--- a/backends/arm/operator_support/control_flow_support.py
+++ b/backends/arm/operator_support/control_flow_support.py
@@ -1,0 +1,162 @@
+# Copyright 2025 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import typing
+from typing import cast
+
+import torch
+import torch.fx as fx
+
+from executorch.backends.arm._passes.arm_pass_utils import is_submodule_node
+from executorch.backends.arm.constants import DQ_OPS, Q_OPS
+from executorch.backends.arm.tosa import TosaSpecification
+from executorch.backends.arm.tosa.specification import Tosa_1_00
+from executorch.exir import ExportedProgram
+from executorch.exir.backend.utils import WhyNoPartitionReporter
+
+from torch.fx.passes.operator_support import OperatorSupportBase
+
+
+def _fully_partitioned(submodule: fx.GraphModule) -> bool:
+    partition_tag = None
+    for submodule_node in submodule.graph.nodes:
+        if submodule_node.op == "call_function":
+            # Input Q ops and output DQ ops will be de-tagged even if the submodule is fully supported.
+            if (
+                submodule_node.target in Q_OPS
+                and list(submodule_node.all_input_nodes)[0].op == "placeholder"
+            ):
+                continue
+            if (
+                submodule_node.target in DQ_OPS
+                and list(submodule_node.users)[0].op == "output"
+            ):
+                continue
+            if "delegation_tag" not in submodule_node.meta:
+                return False
+            if partition_tag is None:
+                partition_tag = submodule_node.meta["delegation_tag"]
+            elif submodule_node.meta["delegation_tag"] != partition_tag:
+                return False
+    return True
+
+
+def _submodules_fully_partitioned(
+    node: fx.Node, exported_program: ExportedProgram
+) -> bool:
+    """Returns whether the submodule arguments to a cond node were fully partitioned.
+    Updates "val" meta of the submodules if they are.
+    """
+    match node.target:
+        case torch.ops.higher_order.cond:
+            submodule_args = node.args[1:3]
+        case torch.ops.higher_order.while_loop:
+            submodule_args = node.args[0:2]
+        case _:
+            raise ValueError(f"Unexpected target: {node.target}")
+    cond_submodules = (
+        (
+            exported_program.graph_module.get_submodule(
+                str(cast(torch.fx.Node, submodule_node).target)
+            ),
+            cast(torch.fx.Node, submodule_node),
+        )
+        for submodule_node in submodule_args
+    )
+    for submodule, submodule_node in cond_submodules:
+        submodule = cast(torch.fx.GraphModule, submodule)
+
+        if _fully_partitioned(submodule):
+            submodule_node.meta["val"] = submodule.graph.output_node().meta["val"]
+        else:
+            return False
+    return True
+
+
+def _tosa_spec_supports_cf(tosa_spec: TosaSpecification) -> bool:
+    if not isinstance(tosa_spec, Tosa_1_00):
+        return False
+    return tosa_spec.support_extension("cf")
+
+
+class ControlFlowSubmoduleSupported(OperatorSupportBase):
+    """Check whether control flow submodule args should be partitioned.
+    Applies control-flow extension constraints before allowing delegation."""
+
+    def __init__(
+        self,
+        exported_program: ExportedProgram,
+        tosa_spec: TosaSpecification,
+        reporter: WhyNoPartitionReporter,
+    ):
+        self.exported_program = exported_program
+        self.reporter = reporter
+        self.tosa_spec = tosa_spec
+        super().__init__()
+
+    def is_node_supported(
+        self, submodules: typing.Mapping[str, torch.nn.Module], node: fx.Node
+    ) -> bool:
+        if is_submodule_node(node):
+            if not _tosa_spec_supports_cf(self.tosa_spec):
+                self.reporter.report_reject(
+                    node,
+                    f"TOSA spec {self.tosa_spec} does not support control flow extension.",
+                )
+                return False
+            for user in node.users:
+                if user.target not in ControlFlowOpSupported._targeted_ops:
+                    self.reporter.report_reject(
+                        node, f"Submodule had unsupported user {user}"
+                    )
+                    return False
+                if not _submodules_fully_partitioned(user, self.exported_program):
+                    self.reporter.report_reject(
+                        node, "One submodule was not fully partitioned"
+                    )
+                    return False
+            return True
+        return False
+
+
+class ControlFlowOpSupported(OperatorSupportBase):
+    """Check whether control flow ops should be partitioned.
+    Applies control-flow extension constraints before allowing delegation."""
+
+    _targeted_ops = {
+        torch.ops.higher_order.cond,
+        torch.ops.higher_order.while_loop,
+    }
+
+    def __init__(
+        self,
+        exported_program: ExportedProgram,
+        tosa_spec: TosaSpecification,
+        reporter: WhyNoPartitionReporter,
+    ):
+        self.exported_program = exported_program
+        self.reporter = reporter
+        self.tosa_spec = tosa_spec
+        super().__init__()
+
+    def is_node_supported(
+        self, submodules: typing.Mapping[str, torch.nn.Module], node: fx.Node
+    ) -> bool:
+        if node.target in self._targeted_ops:
+            if not _tosa_spec_supports_cf(self.tosa_spec):
+                self.reporter.report_reject(
+                    node,
+                    f"TOSA spec {self.tosa_spec} does not support control flow extension.",
+                )
+                return False
+
+            if not _submodules_fully_partitioned(node, self.exported_program):
+                self.reporter.report_reject(
+                    node, "Submodule was not fully partitioned."
+                )
+                return False
+            return True
+
+        return False

--- a/backends/arm/operator_support/tosa_supported_operators.py
+++ b/backends/arm/operator_support/tosa_supported_operators.py
@@ -13,7 +13,7 @@ used by the TOSA partitioner to decide if FX nodes are eligible for delegation.
 import itertools
 import operator
 import typing
-from typing import cast, final, Optional, Sequence, Type
+from typing import final, Optional, Sequence, Type
 
 import torch
 import torch.fx as fx
@@ -29,6 +29,10 @@ from executorch.backends.arm._passes.fuse_quantized_activation_pass import (
 from executorch.backends.arm._passes.insert_table_ops import TableOps
 from executorch.backends.arm.common.annotation_meta import ArmAnnotationInfo
 from executorch.backends.arm.constants import DQ_OPS, MAX_RANK, Q_OPS
+from executorch.backends.arm.operator_support.control_flow_support import (
+    ControlFlowOpSupported,
+    ControlFlowSubmoduleSupported,
+)
 from executorch.backends.arm.operator_support.ethos_u55_support import (
     EthosU55CastCheck,
     EthosU55DtypeSupport,
@@ -41,7 +45,6 @@ from executorch.backends.arm.operator_support.tosa_profile_supported_op_lists im
     TOSA_PRO_INT_SupportList,
 )
 from executorch.backends.arm.tosa.specification import (
-    Tosa_1_00,
     TosaSpecification,
     TosaSpecMapping,
 )
@@ -185,7 +188,8 @@ def tosa_support_factory(
     """
     # Postive checks: Add nodes to partitioning
     positive_checks: list[OperatorSupportBase] = [
-        CondSupported(exported_program, tosa_spec, reporter)
+        ControlFlowSubmoduleSupported(exported_program, tosa_spec, reporter),
+        ControlFlowOpSupported(exported_program, tosa_spec, reporter),
     ]
 
     if tosa_spec.support_integer():
@@ -688,131 +692,3 @@ class RankCheck(OperatorSupportBase):
                 )
                 return False
         return True
-
-
-class CondSupported(OperatorSupportBase):
-    """Check whether cond operator and submodule args should be partitioned.
-
-    Applies control-flow extension constraints before allowing delegation.
-
-    """
-
-    def __init__(
-        self,
-        exported_program: ExportedProgram,
-        tosa_spec: TosaSpecification,
-        reporter: WhyNoPartitionReporter,
-    ):
-        """Initialize conditional support checks for TOSA delegation.
-
-        Args:
-            exported_program (ExportedProgram): Program containing the cond
-                submodules to inspect.
-            tosa_spec (TosaSpecification): TOSA specification used to validate
-                supported operators.
-            reporter (WhyNoPartitionReporter): Reporter that records rejection
-                reasons for unsupported nodes.
-
-        """
-        self.exported_program = exported_program
-        self.reporter = reporter
-        self.tosa_spec = tosa_spec
-        super().__init__()
-
-    def _fully_partitioned(self, submodule: fx.GraphModule) -> bool:
-        """Check whether all call_function nodes share one delegation tag."""
-        partition_tag = None
-        for submodule_node in submodule.graph.nodes:
-            if submodule_node.op == "call_function":
-                # Input Q ops and output DQ ops will be de-tagged even if the submodule is fully supported.
-                if (
-                    submodule_node.target in Q_OPS
-                    and list(submodule_node.all_input_nodes)[0].op == "placeholder"
-                ):
-                    continue
-                if (
-                    submodule_node.target in DQ_OPS
-                    and list(submodule_node.users)[0].op == "output"
-                ):
-                    continue
-                if "delegation_tag" not in submodule_node.meta:
-                    return False
-                if partition_tag is None:
-                    partition_tag = submodule_node.meta["delegation_tag"]
-                elif submodule_node.meta["delegation_tag"] != partition_tag:
-                    return False
-        return True
-
-    def _cond_submodules_fully_partitioned(self, node: fx.Node) -> bool:
-        """Determine whether cond submodules were fully partitioned.
-
-        Update the "val" meta of the submodules when they are partitioned.
-
-        """
-        cond_submodules = (
-            (
-                self.exported_program.graph_module.get_submodule(
-                    str(cast(torch.fx.Node, submodule_node).target)
-                ),
-                cast(torch.fx.Node, submodule_node),
-            )
-            for submodule_node in node.args[1:3]
-        )
-        for submodule, submodule_node in cond_submodules:
-            submodule = cast(torch.fx.GraphModule, submodule)
-
-            if self._fully_partitioned(submodule):
-                submodule_node.meta["val"] = submodule.graph.output_node().meta["val"]
-            else:
-                return False
-        return True
-
-    def is_node_supported(  # noqa: C901
-        self, submodules: typing.Mapping[str, torch.nn.Module], node: fx.Node
-    ) -> bool:
-        """Check whether a cond node and its submodules are partitionable."""
-        if is_submodule_node(node):
-            if not isinstance(self.tosa_spec, Tosa_1_00):
-                self.reporter.report_reject(
-                    node, "Control flow extension not supported for TOSA version <1.0"
-                )
-                return False
-            if not self.tosa_spec.support_extension("cf"):
-                self.reporter.report_reject(
-                    node,
-                    f"TOSA spec {self.tosa_spec} does not support control flow extension.",
-                )
-                return False
-            for user in node.users:
-                if user.target != torch.ops.higher_order.cond:
-                    self.reporter.report_reject(
-                        node, f"Submodule had unsupported user {user}"
-                    )
-                    return False
-                if not self._cond_submodules_fully_partitioned(user):
-                    self.reporter.report_reject(
-                        node, "One submodule was not fully partitioned"
-                    )
-                    return False
-            return True
-        if node.target == torch.ops.higher_order.cond:
-            if not isinstance(self.tosa_spec, Tosa_1_00):
-                self.reporter.report_reject(
-                    node, "Control flow extension not supported for TOSA version <1.0"
-                )
-                return False
-            if not self.tosa_spec.support_extension("cf"):
-                self.reporter.report_reject(
-                    node,
-                    f"TOSA spec {self.tosa_spec} does not support control flow extension.",
-                )
-                return False
-
-            if not self._cond_submodules_fully_partitioned(node):
-                self.reporter.report_reject(
-                    node, "Submodule was not fully partitioned."
-                )
-                return False
-            return True
-
-        return False

--- a/backends/arm/operator_support/tosa_supported_operators.py
+++ b/backends/arm/operator_support/tosa_supported_operators.py
@@ -321,8 +321,6 @@ class CheckArmQuantized(OperatorSupportBase):
     def is_node_supported(
         self, submodules: typing.Mapping[str, torch.nn.Module], node: fx.Node
     ) -> bool:
-        if node.op != "call_function":
-            return False
 
         if node.target in (*DQ_OPS, *Q_OPS):
             return True

--- a/backends/arm/operators/__init__.py
+++ b/backends/arm/operators/__init__.py
@@ -64,6 +64,7 @@ from . import (  # noqa
     op_tosa_transpose,
     op_view,
     op_where,
+    op_while,
     ops_binary,
     ops_identity,
 )

--- a/backends/arm/operators/op_cond_if.py
+++ b/backends/arm/operators/op_cond_if.py
@@ -13,11 +13,11 @@ from executorch.backends.arm.operators.node_visitor import (  # type: ignore
     register_node_visitor,
 )
 from executorch.backends.arm.operators.operator_validation_utils import (
+    validate_cf_extension,
     validate_num_inputs,
     validate_valid_dtype,
 )
 from executorch.backends.arm.tosa.mapping import TosaArg  # type: ignore
-from executorch.backends.arm.tosa.specification import Tosa_1_00
 from torch.fx import Node
 
 
@@ -37,12 +37,7 @@ class CondVisitor(NodeVisitor):
 
         validate_num_inputs(self.target, inputs, 4)
         validate_valid_dtype(self.target, [inputs[0]], ts.DType.BOOL, self.tosa_spec)
-        if not isinstance(self.tosa_spec, Tosa_1_00):
-            raise ValueError("Trying to lower cond, but TOSA version is <1.0.")
-        if not self.tosa_spec.support_extension("cf"):
-            raise ValueError(
-                f"Trying to lower cond, but TOSA specification {self.tosa_spec} does not support the cf extension."
-            )
+        validate_cf_extension(self.target, self.tosa_spec)
 
         attr = ts.TosaSerializerAttribute()
         if_graph, else_graph = (cast(Node, arg).target for arg in node.args[1:3])

--- a/backends/arm/operators/op_while.py
+++ b/backends/arm/operators/op_while.py
@@ -60,8 +60,8 @@ class WhileLoopVisitor(NodeVisitor):
 
         if len(input_names) != len(output.multiple_output_names):
             raise ValueError(
-                f"TOSA specifies that the number of inputs,{input_names}, need to be the"
-                "same as the number of outputs, {output.multiple_output_names}."
+                f"TOSA specifies that the number of inputs, {input_names}, need to be the "
+                f"same as the number of outputs, {output.multiple_output_names}."
             )
 
         self._serialize_operator(

--- a/backends/arm/operators/op_while.py
+++ b/backends/arm/operators/op_while.py
@@ -1,0 +1,74 @@
+# Copyright 2025 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, cast, List
+
+import tosa_serializer as ts
+
+from executorch.backends.arm.operators.node_visitor import (
+    NodeVisitor,
+    register_node_visitor,
+)
+from executorch.backends.arm.operators.operator_validation_utils import (
+    validate_cf_extension,
+    validate_num_inputs,
+)
+from executorch.backends.arm.tosa.mapping import TosaArg
+from torch.fx import Node
+
+
+@register_node_visitor
+class WhileLoopVisitor(NodeVisitor):
+    target = "while_loop"
+
+    tosa_specs = NodeVisitor.tosa_specs
+
+    def define_node(
+        self,
+        node: Node,
+        tosa_graph: Any,
+        inputs: List[TosaArg],
+        output: TosaArg,
+    ) -> None:
+
+        validate_num_inputs(self.target, inputs, 4)
+        validate_cf_extension(self.target, self.tosa_spec)
+
+        carried_inputs = inputs[2].special if hasattr(inputs[2], "special") else None
+        if carried_inputs is None:
+            raise ValueError(f"{self.target}: Expected loop input arguments to be set.")
+
+        additional_inputs = inputs[3].special if hasattr(inputs[3], "special") else None
+        if additional_inputs:
+            raise ValueError(
+                "Additional inputs is not supported, use carried inputs instead."
+            )
+
+        attr = ts.TosaSerializerAttribute()
+        cond_graph, body_graph = (cast(Node, arg).target for arg in node.args[:2])
+        attr.WhileLoopAttribute(cond_graph, body_graph)
+
+        input_names: list[str] = []
+        for loop_input in carried_inputs:
+            if not isinstance(loop_input, Node):
+                raise ValueError(
+                    f"{self.target}: Unsupported carried input type {type(loop_input)}."
+                )
+            input_names.append(loop_input.name)
+
+        if len(input_names) != len(output.multiple_output_names):
+            raise ValueError(
+                f"TOSA specifies that the number of inputs,{input_names}, need to be the"
+                "same as the number of outputs, {output.multiple_output_names}."
+            )
+
+        self._serialize_operator(
+            node,
+            tosa_graph,
+            ts.Op.WHILE_LOOP,
+            input_names,
+            output.multiple_output_names,
+            attr,
+        )

--- a/backends/arm/process_node.py
+++ b/backends/arm/process_node.py
@@ -246,7 +246,6 @@ def process_placeholder(
 ):
     """Wrapper for processing and serializing all types of placeholders"""
     if node.name != node.target:
-        pass
         raise ValueError(
             f"Placeholder name '{node.name}' does not match target '{node.target}'"
         )
@@ -272,7 +271,7 @@ def process_placeholder(
     elif containing_graph_module and _submodule_has_user_input(
         containing_graph_module, edge_program
     ):
-        # If we are in a submodule and it has
+        # If we are in a submodule and it has user input, process as regular input.
         process_inputs(node, tosa_graph, tosa_spec)
     else:
         raise RuntimeError(f"Placeholder '{node.name}' is of unknown type.")

--- a/backends/arm/process_node.py
+++ b/backends/arm/process_node.py
@@ -15,6 +15,7 @@ from executorch.backends.arm.operators.node_visitor import NodeVisitor
 from executorch.backends.arm.tosa.mapping import TosaArg, TosaSpecialDtype
 from executorch.backends.arm.tosa.specification import TosaSpecification
 from executorch.backends.arm.tosa.utils import tosa_shape
+from executorch.exir.graph_module import get_control_flow_submodules
 from torch._export.utils import (
     get_buffer,
     get_lifted_tensor_constant,
@@ -188,14 +189,53 @@ def process_inputs_to_lifted_tensor_constants(
     )
 
 
+def _is_submodule_input(
+    node: torch.fx.Node, containing_graph_module: torch.fx.GraphModule
+) -> bool:
+    """Determines whether 'node' is an input to a submodule of 'containing_graph_module'."""
+    if node.op != "placeholder":
+        return False
+
+    for _, _, submodule_node in get_control_flow_submodules(containing_graph_module):
+        args = cast(list[torch.fx.Node], submodule_node.args[-1])
+        for arg in args:
+            if isinstance(arg.target, str):
+                # If argument is a buffer or similar, we can match exactly.
+                if arg.target == node.name:
+                    return True
+            # If argument target has a name, the submodule input is operator name + number to avoid duplication.
+            # For example: cond input namespace::my_op -> submodule input my_op_1
+            if (name_fn := (getattr(arg.target, "name", None))) is not None:
+                op_name = name_fn().split(":")[-1]
+                if op_name in node.name:
+                    return True
+    return False
+
+
+def _submodule_has_user_input(
+    containing_graph_module: torch.fx.GraphModule, edge_program: ExportedProgram
+):
+    # If argument is a user input, there is no such guarantee. We need to to a heuristic match.
+    for _, _, submodule_node in get_control_flow_submodules(containing_graph_module):
+        args = cast(list[torch.fx.Node], submodule_node.args[-1])
+        for arg in args:
+            if (
+                isinstance(arg.target, str)
+                and arg.target in edge_program.graph_signature.user_inputs
+            ):
+                return True
+
+
 def process_placeholder(
     node: torch.fx.Node,
     tosa_graph: Any,
     edge_program: ExportedProgram,
+    containing_graph_module: torch.fx.GraphModule | None,
     tosa_spec: TosaSpecification,
 ):
     """Wrapper for processing and serializing all types of placeholders"""
     if node.name != node.target:
+        pass
         raise ValueError(
             f"Placeholder name '{node.name}' does not match target '{node.target}'"
         )
@@ -203,6 +243,8 @@ def process_placeholder(
         raise ValueError(f"Placeholder '{node.name}' must not have default values")
 
     if node.name in edge_program.graph_signature.user_inputs:
+        process_inputs(node, tosa_graph, tosa_spec)
+    elif containing_graph_module and _is_submodule_input(node, containing_graph_module):
         process_inputs(node, tosa_graph, tosa_spec)
     elif is_param(edge_program, node):
         process_inputs_to_parameters(node, tosa_graph, edge_program, tosa_spec)
@@ -216,6 +258,11 @@ def process_placeholder(
         raise NotImplementedError(
             "Placeholder is of type 'lifted custom object' which is not supported."
         )
+    elif containing_graph_module and _submodule_has_user_input(
+        containing_graph_module, edge_program
+    ):
+        # If we are in a submodule and it has
+        process_inputs(node, tosa_graph, tosa_spec)
     else:
         raise RuntimeError(f"Placeholder '{node.name}' is of unknown type.")
 

--- a/backends/arm/quantizer/arm_quantizer.py
+++ b/backends/arm/quantizer/arm_quantizer.py
@@ -24,6 +24,7 @@ from executorch.backends.arm.common.arm_compile_spec import (
     ArmCompileSpec,
 )  # isort: skip
 from executorch.backends.arm.vgf import VgfCompileSpec
+from executorch.exir.graph_module import get_control_flow_submodules
 
 from torch.fx import GraphModule, Node
 from torchao.quantization.pt2e import (
@@ -35,6 +36,11 @@ from torchao.quantization.pt2e import (
     ObserverOrFakeQuantizeConstructor,
     PerChannelMinMaxObserver,
     PlaceholderObserver,
+)
+from torchao.quantization.pt2e.quantize_pt2e import (
+    convert_pt2e,
+    prepare_pt2e,
+    prepare_qat_pt2e,
 )
 
 from torchao.quantization.pt2e.quantizer import (
@@ -481,14 +487,40 @@ class TOSAQuantizer(Quantizer):
                 )
                 mark_node_as_annotated(node)
             if node.op == "output":
-                parent = node.all_input_nodes[0]
-                annotate_input_qspec_map(
-                    node, parent, quantization_config.get_input_act_qspec()
-                )
+                for parent in node.all_input_nodes:
+                    annotate_input_qspec_map(
+                        node, parent, quantization_config.get_input_act_qspec()
+                    )
                 mark_node_as_annotated(node)
 
     def validate(self, model: GraphModule) -> None:
         pass
+
+    def quantize_with_submodules(
+        self,
+        model: GraphModule,
+        calibration_samples: list[tuple],
+        is_qat: bool = False,
+    ):
+        """Quantizes a GraphModule in a way such that conditional submodules are handled properly.
+        Args:
+            model: GraphModule, the model to quantize.
+        calibration_samples: list[tuple], a list of inputs to used to calibrate the model during quantization.
+            To properly calibrate a model with submodules, at least one sample per code path is needed.
+        is_qat: bool, whether to do quantization aware training or not.
+        """
+        prepare_fn = prepare_qat_pt2e if is_qat else prepare_pt2e
+
+        prepared = prepare_fn(model, self)
+        for name, submodule, _ in get_control_flow_submodules(prepared):
+            prepared.set_submodule(name, prepare_fn(submodule, self), strict=True)
+        for inp in calibration_samples:
+            prepared(*inp)
+
+        for name, submodule, _ in get_control_flow_submodules(prepared):
+            prepared.set_submodule(name, convert_pt2e(submodule), strict=True)
+        converted = convert_pt2e(prepared)
+        return converted
 
 
 class EthosUQuantizer(TOSAQuantizer):

--- a/backends/arm/quantizer/arm_quantizer.py
+++ b/backends/arm/quantizer/arm_quantizer.py
@@ -503,11 +503,12 @@ class TOSAQuantizer(Quantizer):
         is_qat: bool = False,
     ):
         """Quantizes a GraphModule in a way such that conditional submodules are handled properly.
+
         Args:
             model: GraphModule, the model to quantize.
-        calibration_samples: list[tuple], a list of inputs to used to calibrate the model during quantization.
+            calibration_samples: list[tuple], a list of inputs to used to calibrate the model during quantization.
             To properly calibrate a model with submodules, at least one sample per code path is needed.
-        is_qat: bool, whether to do quantization aware training or not.
+            is_qat: bool, whether to do quantization aware training or not.
         """
         prepare_fn = prepare_qat_pt2e if is_qat else prepare_pt2e
 

--- a/backends/arm/quantizer/arm_quantizer.py
+++ b/backends/arm/quantizer/arm_quantizer.py
@@ -24,7 +24,7 @@ from executorch.backends.arm.common.arm_compile_spec import (
     ArmCompileSpec,
 )  # isort: skip
 from executorch.backends.arm.vgf import VgfCompileSpec
-from executorch.exir.graph_module import get_control_flow_submodules
+from executorch.exir.graph_module import get_cond_while_submodules
 
 from torch.fx import GraphModule, Node
 from torchao.quantization.pt2e import (
@@ -512,12 +512,12 @@ class TOSAQuantizer(Quantizer):
         prepare_fn = prepare_qat_pt2e if is_qat else prepare_pt2e
 
         prepared = prepare_fn(model, self)
-        for name, submodule, _ in get_control_flow_submodules(prepared):
+        for name, submodule, _ in get_cond_while_submodules(prepared):
             prepared.set_submodule(name, prepare_fn(submodule, self), strict=True)
         for inp in calibration_samples:
             prepared(*inp)
 
-        for name, submodule, _ in get_control_flow_submodules(prepared):
+        for name, submodule, _ in get_cond_while_submodules(prepared):
             prepared.set_submodule(name, convert_pt2e(submodule), strict=True)
         converted = convert_pt2e(prepared)
         return converted

--- a/backends/arm/quantizer/quantization_annotator.py
+++ b/backends/arm/quantizer/quantization_annotator.py
@@ -724,7 +724,13 @@ def get_quant_properties(  # noqa: C901
                 (cast(list[Node], submodule_args)[0], node)
             )
             quant_properties.quant_inputs = [
-                _QuantProperty(submodule_args_pos, [input_act_qspec, *([shared_qspec] * (len(submodule_args) - 1))])  # type: ignore[arg-type]
+                _QuantProperty(
+                    submodule_args_pos,
+                    [
+                        input_act_qspec,
+                        *([shared_qspec] * (len(submodule_args) - 1)),  # type: ignore[arg-type]
+                    ],
+                )
             ]
         quant_properties.quant_output = _QuantProperty(0, output_act_qspec)
     else:

--- a/backends/arm/scripts/parse_test_names.py
+++ b/backends/arm/scripts/parse_test_names.py
@@ -33,6 +33,7 @@ CUSTOM_EDGE_OPS = [
     "alias_copy.default",
     "pixel_shuffle.default",
     "pixel_unshuffle.default",
+    "while_loop.default",
 ]
 ALL_EDGE_OPS = SAMPLE_INPUT.keys() | CUSTOM_EDGE_OPS
 

--- a/backends/arm/test/ops/test_cond.py
+++ b/backends/arm/test/ops/test_cond.py
@@ -5,10 +5,9 @@
 
 from typing import Callable, Tuple
 
-import pytest
-
 import torch
 from executorch.backends.arm.test import common
+from executorch.backends.arm.test.tester.arm_tester import ArmTester
 from executorch.backends.arm.test.tester.test_pipeline import (
     TosaPipelineFP,
     TosaPipelineINT,
@@ -45,6 +44,22 @@ class CondOneArgOneOutput(torch.nn.Module):
         return torch.cond(predicate, true_branch, false_branch, [x])
 
 
+class CondOneArgBufferOneOutput(torch.nn.Module):
+    def __init__(self, *args: common.Any, **kwargs: common.Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.buffer = torch.rand(2, 3)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        def true_branch(arg: torch.Tensor, buffer: torch.Tensor) -> torch.Tensor:
+            return torch.sin(arg) + buffer
+
+        def false_branch(arg: torch.Tensor, buffer: torch.Tensor) -> torch.Tensor:
+            return torch.cos(arg) + buffer
+
+        predicate = x.sum() > 0
+        return torch.cond(predicate, true_branch, false_branch, [x, self.buffer])
+
+
 class CondOneArgAndScalarOneOutput(torch.nn.Module):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         def true_branch(arg: torch.Tensor) -> torch.Tensor:
@@ -72,17 +87,17 @@ class CondOneArgTwoOutputs(torch.nn.Module):
 class CondNestedOneArgOneOutput(torch.nn.Module):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         def inner_true(arg: torch.Tensor) -> torch.Tensor:
-            return arg + 1.0
+            return arg + torch.full((1,), (1.0))
 
         def inner_false(arg: torch.Tensor) -> torch.Tensor:
-            return arg - 1.0
+            return arg - torch.full((1,), (1.0))
 
         def outer_true(arg: torch.Tensor) -> torch.Tensor:
             inner_predicate = arg.mean() > 0
             return torch.cond(inner_predicate, inner_true, inner_false, [arg])
 
         def outer_false(arg: torch.Tensor) -> torch.Tensor:
-            return arg * 0.5
+            return arg * torch.full((1,), (1.0))
 
         predicate = x.sum() > 0
         return torch.cond(predicate, outer_true, outer_false, [x])
@@ -91,19 +106,19 @@ class CondNestedOneArgOneOutput(torch.nn.Module):
 class CondMultipleOneArgOneOutput(torch.nn.Module):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         def first_true(arg: torch.Tensor) -> torch.Tensor:
-            return arg + 2.0
+            return arg.sigmoid()
 
         def first_false(arg: torch.Tensor) -> torch.Tensor:
-            return arg - 2.0
+            return arg.relu()
 
         first_predicate = x.sum() > 0
         intermediate = torch.cond(first_predicate, first_true, first_false, [x])
 
         def second_true(arg: torch.Tensor) -> torch.Tensor:
-            return arg * 3.0
+            return arg.sin()
 
         def second_false(arg: torch.Tensor) -> torch.Tensor:
-            return arg / 3.0
+            return arg.cos()
 
         second_predicate = intermediate.mean() > 0
         return torch.cond(second_predicate, second_true, second_false, [intermediate])
@@ -161,6 +176,7 @@ def _dual_input_case(
 test_cases: dict[str, Callable[[], tuple[torch.nn.Module, tuple]]] = {
     "zero_args_one_output": _single_input_case(CondZeroArgsOneOutput),
     "one_arg_one_output": _single_input_case(CondOneArgOneOutput),
+    "one_arg_const_one_output": _single_input_case(CondOneArgBufferOneOutput),
     "one_arg_and_scalar_one_output": _single_input_case(CondOneArgAndScalarOneOutput),
     "one_arg_two_outputs": _single_input_case(CondOneArgTwoOutputs),
     "two_args_one_output": _dual_input_case(CondTwoArgsOneOutput),
@@ -170,12 +186,36 @@ test_cases: dict[str, Callable[[], tuple[torch.nn.Module, tuple]]] = {
 }
 
 
+def _make_calibration_samples(
+    module: torch.nn.Module, example_inputs: tuple
+) -> tuple[tuple[torch.Tensor, ...], ...]:
+    """Return one example input that triggers the if branch, and one that triggers the else branch."""
+
+    if isinstance(module, CondTwoArgsOneOutput):
+        # Predicate is sum(lhs-rhs) > 0
+        lhs, rhs = example_inputs
+        if_example_inputs = (lhs, rhs)
+        else_example_inputs = (rhs, lhs)
+    elif isinstance(module, CondTwoArgsTwoOutputs):
+        # Predicate is sum(lhs*rhs) > 0
+        lhs, rhs = example_inputs
+        if_example_inputs = (lhs, rhs)
+        else_example_inputs = (lhs, -rhs)
+    else:
+        # Predicate is sum(x) > 0
+        (x,) = example_inputs
+        if_example_inputs = (x,)
+        else_example_inputs = (-x,)
+
+    return (if_example_inputs, else_example_inputs)
+
+
 @common.parametrize(
     "case",
     test_cases,
     xfails={
         "one_arg_and_scalar_one_output": "Scalars become get_attr nodes that are not supported.",
-        "multiple_one_arg_one_output": "Scalars become get_attr nodes that are not supported.",
+        "nested_one_arg_one_output": "Not fully delegated.",
     },
 )
 def test_cond_tosa_FP(case: Callable[[], tuple[torch.nn.Module, tuple]]):
@@ -183,17 +223,41 @@ def test_cond_tosa_FP(case: Callable[[], tuple[torch.nn.Module, tuple]]):
     pipeline = TosaPipelineFP[tuple](
         module, example_inputs, aten_op, tosa_extensions=["cf"]
     )
+    # Make sure no cond ops are left after partitioning.
+    pipeline.add_stage_after(
+        "to_edge_transform_and_lower",
+        ArmTester.check_not,
+        pipeline.tester,
+        ["torch.ops.higher_order.cond"],
+    )
     pipeline.run()
 
 
-@pytest.mark.skip("Quantization on submodules is not implemented yet.")
 @common.parametrize(
     "case",
     test_cases,
+    xfails={
+        "zero_args_one_output": "Since the submodules have no input, the tracer fails finding a fake tensor mode,"
+        " and traces the graph with real tensors, which tosa.RESCALE can't handle.",
+        "one_arg_and_scalar_one_output": "Incorrect quantization on the scalar.",
+        "nested_one_arg_one_output": "Node submodule_0 target submodule_0 references nonexistent attribute submodule_0",
+    },
 )
 def test_cond_tosa_INT(case: Callable[[], tuple[torch.nn.Module, tuple]]):
     module, example_inputs = case()
     pipeline = TosaPipelineINT[tuple](
         module, example_inputs, aten_op, tosa_extensions=["cf"]
+    )
+    calibration_samples = _make_calibration_samples(module, example_inputs)
+    quant_stage_pos = pipeline.find_pos("quantize")
+    quant_stage = pipeline._stages[quant_stage_pos].args[0]
+    quant_stage.calibration_samples = calibration_samples
+
+    # Make sure no cond ops are left after partitioning.
+    pipeline.add_stage_after(
+        "to_edge_transform_and_lower",
+        ArmTester.check_not,
+        pipeline.tester,
+        ["torch.ops.higher_order.cond"],
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_while.py
+++ b/backends/arm/test/ops/test_while.py
@@ -1,0 +1,185 @@
+# Copyright 2025 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Callable, Tuple
+
+import torch
+import torch.fx
+
+from executorch.backends.arm.test import common
+from executorch.backends.arm.test.tester.arm_tester import ArmTester
+from executorch.backends.arm.test.tester.test_pipeline import (
+    TosaPipelineFP,
+    TosaPipelineINT,
+)
+
+input_single = Tuple[torch.Tensor]
+input_double = Tuple[torch.Tensor, torch.Tensor]
+
+
+class WhileTwoInputsTwoOutputs(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+
+    def forward(
+        self, lhs: torch.Tensor, rhs: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        def cond_fn(
+            lhs_val: torch.Tensor, rhs_val: torch.Tensor
+        ) -> Tuple[torch.Tensor]:
+            total = torch.sum(rhs_val)
+            zero = torch.zeros_like(total)
+            return torch.gt(total, zero).squeeze()
+
+        def body_fn(
+            lhs_val: torch.Tensor, rhs_val: torch.Tensor
+        ) -> Tuple[torch.Tensor, torch.Tensor]:
+            next_lhs = torch.add(lhs_val, rhs_val)
+            next_rhs = torch.sub(rhs_val, torch.full((1,), 1.0))
+            return (next_lhs, next_rhs)
+
+        result = torch.ops.higher_order.while_loop(
+            cond_fn,
+            body_fn,
+            (lhs, rhs),
+            (),
+        )
+        return result
+
+
+class WhileOneInputOneBufferTwoOutputs(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.register_buffer("threshold", torch.tensor((30.0,)))
+
+    def forward(self, value: torch.Tensor) -> torch.Tensor:
+        def cond_fn(value: torch.Tensor, limit: torch.Tensor) -> torch.Tensor:
+            total = value.sum()
+            return torch.lt(total, limit).squeeze()
+
+        def body_fn(value: torch.Tensor, limit: torch.Tensor) -> Tuple[torch.Tensor]:
+            return (torch.add(value, value), limit.clone())
+
+        result = torch.ops.higher_order.while_loop(
+            cond_fn,
+            body_fn,
+            (value, self.threshold),
+            (),
+        )
+        return result
+
+
+class WhileAdditionalArg(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.register_buffer("threshold", torch.tensor((30.0,)))
+
+    def forward(self, value: torch.Tensor) -> torch.Tensor:
+        def cond_fn(value: torch.Tensor, limit: torch.Tensor) -> torch.Tensor:
+            total = value.sum()
+            return torch.lt(total, limit).squeeze()
+
+        def body_fn(value: torch.Tensor, limit: torch.Tensor) -> Tuple[torch.Tensor]:
+            return torch.add(value, value)
+
+        result = torch.ops.higher_order.while_loop(
+            cond_fn,
+            body_fn,
+            (value,),
+            (self.threshold,),
+        )
+        return result
+
+
+class WhileSingleCapturedOutput(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.register_buffer("threshold", torch.tensor((30.0,)))
+
+    def forward(self, value: torch.Tensor) -> torch.Tensor:
+        def cond_fn(value: torch.Tensor, limit: torch.Tensor) -> torch.Tensor:
+            total = value.sum()
+            return torch.lt(total, limit).squeeze()
+
+        def body_fn(value: torch.Tensor, limit: torch.Tensor) -> Tuple[torch.Tensor]:
+            return (torch.add(value, value), limit.clone())
+
+        result = torch.ops.higher_order.while_loop(
+            cond_fn,
+            body_fn,
+            (value, self.threshold),
+            (),
+        )
+        return result[0]
+
+
+def _single_input_case(
+    module_factory: Callable[[], torch.nn.Module],
+) -> Callable[[], Tuple[torch.nn.Module, input_single]]:
+    def _create() -> Tuple[torch.nn.Module, input_single]:
+        return module_factory(), (torch.ones(2, 3),)
+
+    return _create
+
+
+def _dual_input_case(
+    module_factory: Callable[[], torch.nn.Module],
+) -> Callable[[], Tuple[torch.nn.Module, input_double]]:
+    def _create() -> Tuple[torch.nn.Module, input_double]:
+        return module_factory(), (torch.zeros(2, 3), torch.full((2, 3), 2.0))
+
+    return _create
+
+
+test_cases: dict[str, Callable[[], Tuple[torch.nn.Module, Tuple]]] = {
+    "two_in_two_out": _dual_input_case(WhileTwoInputsTwoOutputs),
+    "one_in_one_buffer_two_out": _single_input_case(WhileOneInputOneBufferTwoOutputs),
+    "additional_arg": _single_input_case(WhileAdditionalArg),
+    "two_in_one_captured_out": _single_input_case(WhileSingleCapturedOutput),
+}
+
+
+@common.parametrize(
+    "case",
+    test_cases,
+    xfails={
+        "additional_arg": "Support not implemented.",
+        "two_in_one_captured_out": "When only one output is used, the second one is removed, which is not allowed in TOSA.",
+    },
+)
+def test_while_loop_tosa_FP(case: Callable[[], Tuple[torch.nn.Module, Tuple]]):
+    module, example_inputs = case()
+    pipeline = TosaPipelineFP[tuple](
+        module,
+        example_inputs,
+        "torch.ops.higher_order.while_loop",
+        tosa_extensions=["cf"],
+        custom_path="tosa/while",
+    )
+    pipeline.run()
+
+
+@common.parametrize(
+    "case",
+    test_cases,
+    xfails={
+        name: "Quantization not implemented for while_loop." for name in test_cases
+    },
+)
+def test_while_loop_tosa_INT(case: Callable[[], Tuple[torch.nn.Module, Tuple]]):
+    module, example_inputs = case()
+    pipeline = TosaPipelineINT[tuple](
+        module,
+        example_inputs,
+        "torch.ops.higher_order.while_loop",
+        tosa_extensions=["cf"],
+    )
+    pipeline.add_stage_after(
+        "to_edge_transform_and_lower",
+        ArmTester.check_not,
+        pipeline.tester,
+        ["torch.ops.higher_order.while_loop"],
+    )
+    pipeline.run()

--- a/backends/arm/test/ops/test_while.py
+++ b/backends/arm/test/ops/test_while.py
@@ -128,7 +128,7 @@ def _dual_input_case(
     module_factory: Callable[[], torch.nn.Module],
 ) -> Callable[[], Tuple[torch.nn.Module, input_double]]:
     def _create() -> Tuple[torch.nn.Module, input_double]:
-        return module_factory(), (torch.zeros(2, 3), torch.full((2, 3), 2.0))
+        return module_factory(), (torch.zeros(2, 3), torch.full((2, 3), -2.0))
 
     return _create
 
@@ -156,7 +156,6 @@ def test_while_loop_tosa_FP(case: Callable[[], Tuple[torch.nn.Module, Tuple]]):
         example_inputs,
         "torch.ops.higher_order.while_loop",
         tosa_extensions=["cf"],
-        custom_path="tosa/while",
     )
     pipeline.run()
 
@@ -165,7 +164,8 @@ def test_while_loop_tosa_FP(case: Callable[[], Tuple[torch.nn.Module, Tuple]]):
     "case",
     test_cases,
     xfails={
-        name: "Quantization not implemented for while_loop." for name in test_cases
+        "additional_arg": "Support not implemented.",
+        "two_in_one_captured_out": "When only one output is used, the second one is removed, which is not allowed in TOSA.",
     },
 )
 def test_while_loop_tosa_INT(case: Callable[[], Tuple[torch.nn.Module, Tuple]]):

--- a/backends/arm/test/ops/test_while.py
+++ b/backends/arm/test/ops/test_while.py
@@ -26,9 +26,7 @@ class WhileTwoInputsTwoOutputs(torch.nn.Module):
     def forward(
         self, lhs: torch.Tensor, rhs: torch.Tensor
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        def cond_fn(
-            lhs_val: torch.Tensor, rhs_val: torch.Tensor
-        ) -> Tuple[torch.Tensor]:
+        def cond_fn(lhs_val: torch.Tensor, rhs_val: torch.Tensor) -> torch.Tensor:
             total = torch.sum(rhs_val)
             zero = torch.zeros_like(total)
             return torch.gt(total, zero).squeeze()
@@ -46,7 +44,7 @@ class WhileTwoInputsTwoOutputs(torch.nn.Module):
             (lhs, rhs),
             (),
         )
-        return result
+        return result  # type: ignore
 
 
 class WhileOneInputOneBufferTwoOutputs(torch.nn.Module):
@@ -59,7 +57,9 @@ class WhileOneInputOneBufferTwoOutputs(torch.nn.Module):
             total = value.sum()
             return torch.lt(total, limit).squeeze()
 
-        def body_fn(value: torch.Tensor, limit: torch.Tensor) -> Tuple[torch.Tensor]:
+        def body_fn(
+            value: torch.Tensor, limit: torch.Tensor
+        ) -> Tuple[torch.Tensor, torch.Tensor]:
             return (torch.add(value, value), limit.clone())
 
         result = torch.ops.higher_order.while_loop(
@@ -68,7 +68,7 @@ class WhileOneInputOneBufferTwoOutputs(torch.nn.Module):
             (value, self.threshold),
             (),
         )
-        return result
+        return result  # type: ignore
 
 
 class WhileAdditionalArg(torch.nn.Module):
@@ -81,7 +81,7 @@ class WhileAdditionalArg(torch.nn.Module):
             total = value.sum()
             return torch.lt(total, limit).squeeze()
 
-        def body_fn(value: torch.Tensor, limit: torch.Tensor) -> Tuple[torch.Tensor]:
+        def body_fn(value: torch.Tensor, limit: torch.Tensor) -> torch.Tensor:
             return torch.add(value, value)
 
         result = torch.ops.higher_order.while_loop(
@@ -90,7 +90,7 @@ class WhileAdditionalArg(torch.nn.Module):
             (value,),
             (self.threshold,),
         )
-        return result
+        return result  # type: ignore
 
 
 class WhileSingleCapturedOutput(torch.nn.Module):
@@ -103,7 +103,9 @@ class WhileSingleCapturedOutput(torch.nn.Module):
             total = value.sum()
             return torch.lt(total, limit).squeeze()
 
-        def body_fn(value: torch.Tensor, limit: torch.Tensor) -> Tuple[torch.Tensor]:
+        def body_fn(
+            value: torch.Tensor, limit: torch.Tensor
+        ) -> Tuple[torch.Tensor, torch.Tensor]:
             return (torch.add(value, value), limit.clone())
 
         result = torch.ops.higher_order.while_loop(
@@ -112,7 +114,7 @@ class WhileSingleCapturedOutput(torch.nn.Module):
             (value, self.threshold),
             (),
         )
-        return result[0]
+        return result[0]  # type: ignore
 
 
 def _single_input_case(

--- a/backends/arm/test/tester/arm_tester.py
+++ b/backends/arm/test/tester/arm_tester.py
@@ -48,7 +48,9 @@ from executorch.backends.arm.test.tester.analyze_output_utils import (
     dump_error_output,
     print_error_diffs,
 )
+from executorch.backends.arm.test.tester.quantize import ArmQuantize as Quantize
 from executorch.backends.arm.test.tester.serialize import Serialize
+
 from executorch.backends.arm.tosa import TosaSpecification
 from executorch.backends.arm.tosa.compile_spec import TosaCompileSpec
 from executorch.backends.arm.tosa.mapping import extract_tensor_meta
@@ -313,7 +315,7 @@ class ArmTester(Tester):
         # Same stage type as parent but exposed via module alias
         if quantize_stage is None:
             quantizer = create_quantizer(self.compile_spec)
-            quantize_stage = tester.Quantize(
+            quantize_stage = Quantize(
                 quantizer,
                 get_symmetric_quantization_config(),
             )

--- a/backends/arm/test/tester/quantize.py
+++ b/backends/arm/test/tester/quantize.py
@@ -1,0 +1,43 @@
+# Copyright 2025 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Optional, Tuple
+
+import torch
+from executorch.backends.arm.quantizer import TOSAQuantizer
+from executorch.backends.test.harness.stages.quantize import Quantize
+
+from executorch.backends.transforms.duplicate_dynamic_quant_chain import (
+    DuplicateDynamicQuantChainPass,
+)
+
+from torch.export import export
+
+
+class ArmQuantize(Quantize):
+
+    def run(
+        self, artifact: torch.nn.Module, inputs: Optional[Tuple[torch.Tensor]]
+    ) -> None:
+        assert inputs is not None
+        if self.is_qat:
+            artifact.train()
+        captured_graph = export(artifact, inputs, strict=True).module()
+
+        if not isinstance(self.quantizer, TOSAQuantizer):
+            raise ValueError("ArmQuantizer can only run with TOSAQuantizer.")
+
+        if self.calibration_samples is not None:
+            converted = self.quantizer.quantize_with_submodules(
+                captured_graph, self.calibration_samples, bool(self.is_qat)  # type: ignore
+            )
+        else:
+            converted = self.quantizer.quantize_with_submodules(
+                captured_graph, [inputs], bool(self.is_qat)
+            )
+
+        DuplicateDynamicQuantChainPass()(converted)
+
+        self.converted_graph = converted

--- a/backends/arm/test/tester/test_pipeline.py
+++ b/backends/arm/test/tester/test_pipeline.py
@@ -32,12 +32,12 @@ from executorch.backends.arm.quantizer import (
 )
 from executorch.backends.arm.test import common, conftest
 from executorch.backends.arm.test.tester.arm_tester import ArmTester, RunPasses
+
+from executorch.backends.arm.test.tester.quantize import ArmQuantize as Quantize
 from executorch.backends.arm.tosa.specification import (
     TosaLoweringContext,
     TosaSpecification,
 )
-
-from executorch.backends.xnnpack.test.tester.tester import Quantize
 from executorch.exir.pass_base import ExportPass
 from torch._export.pass_base import PassType
 

--- a/backends/arm/tosa/backend.py
+++ b/backends/arm/tosa/backend.py
@@ -261,6 +261,7 @@ class TOSABackend(BackendDetails):
         tosa_graph: ts.TosaSerializer,
         debug_hook: DebugHook | None,
         submodule_name: str | None = None,
+        containing_graph_module: GraphModule | None = None,
     ):
         """Convert an FX ``graph_module`` to TOSA serializer calls.
 
@@ -308,7 +309,13 @@ class TOSABackend(BackendDetails):
                 elif node.op == "placeholder":
                     if len(node.users) == 0:
                         continue
-                    process_placeholder(node, tosa_graph, edge_program, tosa_spec)
+                    process_placeholder(
+                        node,
+                        tosa_graph,
+                        edge_program,
+                        containing_graph_module,
+                        tosa_spec,
+                    )
                 elif node.op == "output":
                     process_output(node, tosa_graph, tosa_spec)
                 elif node.op == "get_attr":
@@ -341,6 +348,7 @@ class TOSABackend(BackendDetails):
                 tosa_graph,
                 debug_hook,
                 submodule_name=name,
+                containing_graph_module=graph_module,
             )
 
     @staticmethod

--- a/backends/arm/tosa/partitioner.py
+++ b/backends/arm/tosa/partitioner.py
@@ -37,7 +37,7 @@ from executorch.exir.backend.partitioner import (
 )
 from executorch.exir.backend.utils import tag_constant_data, WhyNoPartitionReporter
 from executorch.exir.dialects._ops import ops as exir_ops
-from executorch.exir.graph_module import get_control_flow_submodules
+from executorch.exir.graph_module import get_cond_while_submodules
 from torch.export.exported_program import ExportedProgram
 from torch.fx import GraphModule
 from torch.fx.passes.infra.partitioner import CapabilityBasedPartitioner, Partition
@@ -207,7 +207,7 @@ class TOSAPartitioner(Partitioner):
         tags: set[str] = set()
         if tag_iterator is None:
             tag_iterator = count(0)
-        for _, submodule, _ in get_control_flow_submodules(module):
+        for _, submodule, _ in get_cond_while_submodules(module):
             submodule_tags = self._tag_module(
                 submodule, containing_program, reporter, tag_iterator
             )


### PR DESCRIPTION
    Arm backend: Support quantized while_loop
    
    - Add annotation logic.
    - Extend cond handling in q-dq folding to while
    - Extend InsertCondRescale pass to handle while.
    
----------------------------------------------------
    Arm backend: Add initial while_loop support.
    
    - Refactor CondSupported to also test while, move to own file
      and split into one check for submodule nodes, and one for ops.
    - Add node visitor
    - Add tests
-----------------------------------------------------
    Arm backend: Initial quantization support for conditional
    
    The standard prepare/convert_pt2 does not seem to support
    quantization out of the box. Instead, a quantization call
    is introduced in the TOSAQuantizer, that does the neccessary
    steps to get correct quantization on submodules. A custom
    Quantize step is needed in the ArmTester to make this work
    in testing.
    
    Additionally, getting correct quantization parameters needs
    some delicate handling. The model is calibrated twice,
    once for each code path. Because of this, the observers outside
    the if/else submodules see different data than the observers
    inside the submodules. Rescales need to be inserted to handle
    this. To get a correctly traced graph at all times, we
      1. Fold the outmost quant ops in the submodules at the same
         time as the cond is folded. Add qparam meta to folded
         nodes inside submodule.
      2. Use this meta in the InsertCondRescale pass to
         insert a tosa.RESCALE to handle the different qparams.
      3. After this, the submodule's q-dq nodes can be folded normally.


cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai