### PR TITLE
Follow up for D86436435

### DIFF
--- a/kernels/portable/cpu/op_constant_pad_nd.cpp
+++ b/kernels/portable/cpu/op_constant_pad_nd.cpp
@@ -7,7 +7,7 @@
  */
 
 #include <c10/util/irange.h>
-#include <cmath>
+#include <c10/util/safe_numerics.h>
 #include <cstring>
 
 #include <executorch/runtime/kernel/kernel_includes.h>
@@ -64,9 +64,16 @@ void apply_padding_to_dim(
     for (ET_UNUSED const auto i : c10::irange(out_sizes.size())) {
       numel *= out_sizes[i];
     }
+    uint64_t required_size = 0;
     ET_KERNEL_CHECK_MSG(
         ctx,
-        numel >= pad_before * out_step_len,
+        !c10::mul_overflows(static_cast<uint64_t>(pad_before), static_cast<uint64_t>(out_step_len), &required_size),
+        InvalidArgument,
+        /* void */,
+        "Integer overflow when computing required padding size.");
+    ET_KERNEL_CHECK_MSG(
+        ctx,
+        numel >= required_size,
         InvalidArgument,
         /* void */,
         "Out tensor is too small for the requested padding.");
@@ -116,9 +123,17 @@ void apply_padding_to_dim(
     for (ET_UNUSED const auto i : c10::irange(out_sizes.size())) {
       numel *= out_sizes[i];
     }
+    // Safely compute required_size to avoid overflow
+    uint64_t required_size = 0;
     ET_KERNEL_CHECK_MSG(
         ctx,
-        numel >= pad_after * out_step_len,
+        !c10::mul_overflows(static_cast<uint64_t>(pad_after), static_cast<uint64_t>(out_step_len), &required_size),
+        InvalidArgument,
+        /* void */,
+        "Integer overflow when computing required padding size.");
+    ET_KERNEL_CHECK_MSG(
+        ctx,
+        numel >= required_size,
         InvalidArgument,
         /* void */,
         "Out tensor is too small for the requested padding.");


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/pytorch/pull/168033

D86436435 is the patch for T235095990, but it is insufficient when overflow happenes.

Differential Revision: D87115901


