### PR TITLE
Fix conv2d nchw sharding bug

### DIFF
--- a/backends/cadence/aot/ops_registrations.py
+++ b/backends/cadence/aot/ops_registrations.py
@@ -1113,6 +1113,13 @@ def quantized_conv2d_nchw_per_tensor_meta(
     assert len(in_size) > 2
     assert len(in_size) < 6
 
+    in_channels = input.shape[1]
+    if (in_channels % groups) != 0:
+        raise ValueError("`in_channels` must be divisible by `groups`")
+
+    if (out_channels % groups) != 0:
+        raise ValueError("`out_channels` must be divisible by `groups`")
+
     # Compute the output tensor size
     output_size = (
         get_conv1d_output_size(


### PR DESCRIPTION
Summary:
We were seeing a case where we were getting a numerical mismatch which graph bisect isolated to a single cadence quantized_conv_nchw

The bug was that the sharded version was outputting all 0s. This was isolated to the fact that the sharding logic did not correctly scale down the groups (aka each shard was seeing the number of groups for the original unsharded op). This should have, but was not, caught in a meta kernel. This is fixed now.

Additionally, the sharding padding logic for convolution assumes that there is a key by the name of 'zero_point', but this is not true for the cadence conv, which has the key 'input_zero_point'. Added a temporary fix to select the correct key, however a TODO was created to make this more robust.

Differential Revision: D87293004


