### PR TITLE
QNN Backend: Add SM8350 Support

### DIFF
--- a/backends/qualcomm/serialization/qc_compiler_spec.fbs
+++ b/backends/qualcomm/serialization/qc_compiler_spec.fbs
@@ -34,6 +34,7 @@ table HtpInfo {
 enum QcomChipset: int {
   UNKNOWN_SM = 0,
   SA8295 = 39,
+  SM8350 = 35,
   SM8450 = 36,
   SM8475 = 42,
   SM8550 = 43,

--- a/backends/qualcomm/serialization/qc_schema.py
+++ b/backends/qualcomm/serialization/qc_schema.py
@@ -40,6 +40,7 @@ class HtpInfo:
 class QcomChipset(IntEnum):
     UNKNOWN_SM = 0
     SA8295 = 39  # v68
+    SM8350 = 35  # v68
     SM8450 = 36  # v69
     SM8475 = 42  # v69
     SM8550 = 43  # v73
@@ -63,6 +64,7 @@ class SocInfo:
 
 _soc_info_table = {
     QcomChipset.SA8295: SocInfo(QcomChipset.SA8295, HtpInfo(HtpArch.V68, 8)),
+    QcomChipset.SM8350: SocInfo(QcomChipset.SM8350, HtpInfo(HtpArch.V68, 4)),
     QcomChipset.SM8450: SocInfo(QcomChipset.SM8450, HtpInfo(HtpArch.V69, 8)),
     QcomChipset.SM8475: SocInfo(QcomChipset.SM8475, HtpInfo(HtpArch.V69, 8)),
     QcomChipset.SM8550: SocInfo(QcomChipset.SM8550, HtpInfo(HtpArch.V73, 8)),

--- a/backends/qualcomm/utils/utils.py
+++ b/backends/qualcomm/utils/utils.py
@@ -1089,6 +1089,7 @@ def generate_qnn_executorch_compiler_spec(
 def get_soc_to_arch_map():
     return {
         "SA8295": HtpArch.V68,
+        "SM8350": HtpArch.V68,
         "SM8450": HtpArch.V69,
         "SM8475": HtpArch.V69,
         "SM8550": HtpArch.V73,
@@ -1108,6 +1109,7 @@ def get_soc_to_arch_map():
 def get_soc_to_chipset_map():
     return {
         "SA8295": QcomChipset.SA8295,
+        "SM8350": QcomChipset.SM8350,
         "SM8450": QcomChipset.SM8450,
         "SM8475": QcomChipset.SM8475,
         "SM8550": QcomChipset.SM8550,


### PR DESCRIPTION
### Summary
Add support for Qualcomm Snapdragon 888 (SM8350) chipset to the QNN backend.
This PR adds SM8350 to the list of supported Qualcomm SoCs for ExecuTorch's Qualcomm AI Engine Direct backend. 
The SM8350 uses HTP Architecture V68 with 4 cores, similar to the SA8295 but with fewer cores.
- Added SM8350 = 35 to the QcomChipset enum in both FlatBuffer schema and Python definitions
- Registered SM8350 with HTP V68 architecture and 4 cores in the SoC info table
- Added SM8350 to the SoC-to-architecture and SoC-to-chipset mapping functions
This enables users to compile and deploy ExecuTorch models on devices with Snapdragon 888 chipsets.


### Test plan
Manually tested model compilation and execution on SM8350 device:
` python -m examples.qualcomm.scripts.deeplab_v3 -b build-android -m SM8350 --compile_only --ci
`
The model compiled successfully and generated a valid .pte file for SM8350 target.

Tested on:
- Device: SM8350 (Snapdragon 888)
- Model: DeepLabV3 ResNet101
- Quantization: INT8 (8a8w)
- Build: Android (build-android)