### PR TITLE
Cortex_m backend: Add SharedQspecQuantizer + maximum/minimum

### DIFF
--- a/backends/cortex_m/CMakeLists.txt
+++ b/backends/cortex_m/CMakeLists.txt
@@ -58,6 +58,8 @@ set(_cortex_m_kernels__srcs
     ${CMAKE_CURRENT_SOURCE_DIR}/ops/op_quantized_add.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ops/op_quantized_linear.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ops/op_quantized_mul.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/ops/op_minimum.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/ops/op_maximum.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ops/op_transpose.cpp
 )
 

--- a/backends/cortex_m/ops/op_maximum.cpp
+++ b/backends/cortex_m/ops/op_maximum.cpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2025 Arm Limited and/or its affiliates.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "cortex_m_ops_common.h"
+
+// Include CMSIS-NN headers with C linkage
+extern "C" {
+#include "arm_nnfunctions.h"
+}
+
+namespace cortex_m {
+namespace native {
+
+using KernelRuntimeContext = torch::executor::KernelRuntimeContext;
+
+Tensor& maximum_out(
+    KernelRuntimeContext& context,
+    const Tensor& input1,
+    const Tensor& input2,
+    Tensor& out) {
+  validate_cmsis_nn_tensor_requirements(
+      input1,
+      input2,
+      out,
+      ScalarType::Char,
+      /*require_channels_last=*/false,
+      /*require_same_sizes=*/false);
+
+  auto resize_error = resize_to_broadcast_target_size(input1, input2, out);
+  if (resize_error != Error::Ok) {
+    ET_LOG(Error, "maximum_out: broadcast shape mismatch between inputs");
+    context.fail(resize_error);
+    return out;
+  }
+
+  const int8_t* input1_data = input1.const_data_ptr<int8_t>();
+  const int8_t* input2_data = input2.const_data_ptr<int8_t>();
+  int8_t* output_data = out.mutable_data_ptr<int8_t>();
+
+  // Create CMSIS-NN dims directly from tensor sizes
+  const auto input1_rank = input1.dim();
+  const auto input1_sizes = input1.sizes();
+  const cmsis_nn_dims input1_dims{
+      static_cast<int32_t>(
+          input1_rank >= 4 ? input1_sizes[input1_rank - 4] : 1),
+      static_cast<int32_t>(
+          input1_rank >= 3 ? input1_sizes[input1_rank - 3] : 1),
+      static_cast<int32_t>(
+          input1_rank >= 2 ? input1_sizes[input1_rank - 2] : 1),
+      static_cast<int32_t>(
+          input1_rank >= 1 ? input1_sizes[input1_rank - 1] : 1)};
+
+  const auto input2_rank = input2.dim();
+  const auto input2_sizes = input2.sizes();
+  const cmsis_nn_dims input2_dims{
+      static_cast<int32_t>(
+          input2_rank >= 4 ? input2_sizes[input2_rank - 4] : 1),
+      static_cast<int32_t>(
+          input2_rank >= 3 ? input2_sizes[input2_rank - 3] : 1),
+      static_cast<int32_t>(
+          input2_rank >= 2 ? input2_sizes[input2_rank - 2] : 1),
+      static_cast<int32_t>(
+          input2_rank >= 1 ? input2_sizes[input2_rank - 1] : 1)};
+
+  const auto output_rank = out.dim();
+  const auto output_sizes = out.sizes();
+  const cmsis_nn_dims output_dims{
+      static_cast<int32_t>(
+          output_rank >= 4 ? output_sizes[output_rank - 4] : 1),
+      static_cast<int32_t>(
+          output_rank >= 3 ? output_sizes[output_rank - 3] : 1),
+      static_cast<int32_t>(
+          output_rank >= 2 ? output_sizes[output_rank - 2] : 1),
+      static_cast<int32_t>(
+          output_rank >= 1 ? output_sizes[output_rank - 1] : 1)};
+
+  const arm_cmsis_nn_status status = arm_maximum_s8(
+      /* ctx */ nullptr,
+      input1_data,
+      &input1_dims,
+      input2_data,
+      &input2_dims,
+      output_data,
+      &output_dims);
+
+  if (status != ARM_CMSIS_NN_SUCCESS) {
+    ET_LOG(
+        Error,
+        "maximum_out: arm_maximum_s8 failed with status [%d]",
+        static_cast<int>(status));
+    context.fail(Error::Internal);
+  }
+
+  return out;
+}
+
+} // namespace native
+} // namespace cortex_m

--- a/backends/cortex_m/ops/op_minimum.cpp
+++ b/backends/cortex_m/ops/op_minimum.cpp
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ * Copyright 2025 Arm Limited and/or its affiliates.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "cortex_m_ops_common.h"
+
+// Include CMSIS-NN headers with C linkage
+extern "C" {
+#include "arm_nnfunctions.h"
+}
+
+namespace cortex_m {
+namespace native {
+
+using KernelRuntimeContext = torch::executor::KernelRuntimeContext;
+
+Tensor& minimum_out(
+    KernelRuntimeContext& context,
+    const Tensor& input1,
+    const Tensor& input2,
+    Tensor& out) {
+  validate_cmsis_nn_tensor_requirements(
+      input1,
+      input2,
+      out,
+      ScalarType::Char,
+      /*require_channels_last=*/false,
+      /*require_same_sizes=*/false);
+
+  auto resize_error = resize_to_broadcast_target_size(input1, input2, out);
+  if (resize_error != Error::Ok) {
+    ET_LOG(Error, "minimum_out: broadcast shape mismatch between inputs");
+    context.fail(resize_error);
+    return out;
+  }
+
+  const int8_t* input1_data = input1.const_data_ptr<int8_t>();
+  const int8_t* input2_data = input2.const_data_ptr<int8_t>();
+  int8_t* output_data = out.mutable_data_ptr<int8_t>();
+
+  // Create CMSIS-NN dims directly from tensor sizes
+  const auto input1_rank = input1.dim();
+  const auto input1_sizes = input1.sizes();
+  const cmsis_nn_dims input1_dims{
+      static_cast<int32_t>(
+          input1_rank >= 4 ? input1_sizes[input1_rank - 4] : 1),
+      static_cast<int32_t>(
+          input1_rank >= 3 ? input1_sizes[input1_rank - 3] : 1),
+      static_cast<int32_t>(
+          input1_rank >= 2 ? input1_sizes[input1_rank - 2] : 1),
+      static_cast<int32_t>(
+          input1_rank >= 1 ? input1_sizes[input1_rank - 1] : 1)};
+
+  const auto input2_rank = input2.dim();
+  const auto input2_sizes = input2.sizes();
+  const cmsis_nn_dims input2_dims{
+      static_cast<int32_t>(
+          input2_rank >= 4 ? input2_sizes[input2_rank - 4] : 1),
+      static_cast<int32_t>(
+          input2_rank >= 3 ? input2_sizes[input2_rank - 3] : 1),
+      static_cast<int32_t>(
+          input2_rank >= 2 ? input2_sizes[input2_rank - 2] : 1),
+      static_cast<int32_t>(
+          input2_rank >= 1 ? input2_sizes[input2_rank - 1] : 1)};
+
+  const auto output_rank = out.dim();
+  const auto output_sizes = out.sizes();
+  const cmsis_nn_dims output_dims{
+      static_cast<int32_t>(
+          output_rank >= 4 ? output_sizes[output_rank - 4] : 1),
+      static_cast<int32_t>(
+          output_rank >= 3 ? output_sizes[output_rank - 3] : 1),
+      static_cast<int32_t>(
+          output_rank >= 2 ? output_sizes[output_rank - 2] : 1),
+      static_cast<int32_t>(
+          output_rank >= 1 ? output_sizes[output_rank - 1] : 1)};
+
+  const arm_cmsis_nn_status status = arm_minimum_s8(
+      /* ctx */ nullptr,
+      input1_data,
+      &input1_dims,
+      input2_data,
+      &input2_dims,
+      output_data,
+      &output_dims);
+
+  if (status != ARM_CMSIS_NN_SUCCESS) {
+    ET_LOG(
+        Error,
+        "minimum_out: arm_minimum_s8 failed with status [%d]",
+        static_cast<int>(status));
+    context.fail(Error::Internal);
+  }
+
+  return out;
+}
+
+} // namespace native
+} // namespace cortex_m

--- a/backends/cortex_m/ops/operators.py
+++ b/backends/cortex_m/ops/operators.py
@@ -239,6 +239,47 @@ def quantized_mul_impl(
 
 
 # ===================================================================
+# MINIMUM/MAXIMUM OPERATION DEFINITIONS
+# ===================================================================
+lib.define("minimum(Tensor self, Tensor other) -> Tensor")
+lib.define("minimum.out(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)")
+
+
+@register_fake("cortex_m::minimum")
+def minimum_meta(self: torch.Tensor, other: torch.Tensor) -> torch.Tensor:
+    assert self.dtype == other.dtype, (
+        "Cortex-M minimum: dtype mismatch — "
+        f"got self.dtype={self.dtype}, other.dtype={other.dtype}"
+    )
+    broadcasted_shape = torch.broadcast_shapes(self.shape, other.shape)
+    return torch.empty(broadcasted_shape, dtype=self.dtype, device=self.device)
+
+
+@impl(lib, "minimum", "CompositeExplicitAutograd")
+def minimum_impl(self: torch.Tensor, other: torch.Tensor) -> torch.Tensor:
+    return torch.minimum(self, other)
+
+
+lib.define("maximum(Tensor self, Tensor other) -> Tensor")
+lib.define("maximum.out(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)")
+
+
+@register_fake("cortex_m::maximum")
+def maximum_meta(self: torch.Tensor, other: torch.Tensor) -> torch.Tensor:
+    assert self.dtype == other.dtype, (
+        "Cortex-M maximum: dtype mismatch — "
+        f"got self.dtype={self.dtype}, other.dtype={other.dtype}"
+    )
+    broadcasted_shape = torch.broadcast_shapes(self.shape, other.shape)
+    return torch.empty(broadcasted_shape, dtype=self.dtype, device=self.device)
+
+
+@impl(lib, "maximum", "CompositeExplicitAutograd")
+def maximum_impl(self: torch.Tensor, other: torch.Tensor) -> torch.Tensor:
+    return torch.maximum(self, other)
+
+
+# ===================================================================
 # QUANTIZED LINEAR OPERATION DEFINITION
 # ===================================================================
 

--- a/backends/cortex_m/ops/operators.yaml
+++ b/backends/cortex_m/ops/operators.yaml
@@ -29,6 +29,18 @@
     - arg_meta: null
       kernel_name: cortex_m::quantized_mul_out
 
+- func: cortex_m::minimum.out(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
+  variants: function
+  kernels:
+    - arg_meta: null
+      kernel_name: cortex_m::minimum_out
+
+- func: cortex_m::maximum.out(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
+  variants: function
+  kernels:
+    - arg_meta: null
+      kernel_name: cortex_m::maximum_out
+
 - func: cortex_m::quantized_linear.out(Tensor input, Tensor weights, Tensor? bias, Tensor? kernel_sum, Scalar input_offset, Scalar filter_offset, Scalar output_offset, int[] requantize_multipliers, int[] requantize_shifts, Scalar activation_max, Scalar activation_min, *, Tensor(a!) out) -> Tensor(a!)
   variants: function
   kernels:

--- a/backends/cortex_m/passes/quantized_op_fusion_pass.py
+++ b/backends/cortex_m/passes/quantized_op_fusion_pass.py
@@ -101,6 +101,18 @@ class QuantizedOpFusionPass(ExportPass):
 
         return exir_ops.edge.cortex_m.quantized_mul.default, args
 
+    def _get_minimum_replacement(self, args, meta):
+        if args[0].data.dtype != torch.int8:
+            return exir_ops.edge.aten.minimum.default, args
+
+        return exir_ops.edge.cortex_m.minimum.default, args
+
+    def _get_maximum_replacement(self, args, meta):
+        if args[0].data.dtype != torch.int8:
+            return exir_ops.edge.aten.maximum.default, args
+
+        return exir_ops.edge.cortex_m.maximum.default, args
+
     def _get_permute_replacement(self, args, meta):
         if args[0].data.dtype != torch.int8:
             return exir_ops.edge.aten.permute_copy.default, args
@@ -123,6 +135,10 @@ class QuantizedOpFusionPass(ExportPass):
                 op, args = self._get_add_replacement(args, meta)
             case exir_ops.edge.aten.mul.Tensor:
                 op, args = self._get_mul_replacement(args, meta)
+            case exir_ops.edge.aten.minimum.default:
+                op, args = self._get_minimum_replacement(args, meta)
+            case exir_ops.edge.aten.maximum.default:
+                op, args = self._get_maximum_replacement(args, meta)
             case exir_ops.edge.aten.permute_copy.default:
                 op, args = self._get_permute_replacement(args, meta)
             case _:

--- a/backends/cortex_m/test/misc/test_quantization.py
+++ b/backends/cortex_m/test/misc/test_quantization.py
@@ -4,7 +4,6 @@
 # LICENSE file in the root directory of this source tree.
 
 
-import pytest
 import torch
 from executorch.backends.arm._passes.arm_pass_utils import get_first_fake_tensor
 from executorch.backends.arm.test.common import parametrize
@@ -16,105 +15,331 @@ from executorch.backends.cortex_m.test.tester import (
 from executorch.exir.dialects._ops import ops as exir_ops
 
 
-class CortexMInheritAllOps(torch.nn.Module):
-    ops_before_transforms = {
-        "executorch_exir_dialects_edge__ops_quantized_decomposed_quantize_per_tensor_default": 3,
-        "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_tensor_default": 3,
-    }
+class SharedQspecMulipleClusters(torch.nn.Module):
+    """Three linear shared qspec clusters."""
 
+    ops_before_transforms = {
+        "executorch_exir_dialects_edge__ops_aten_add_Tensor": 2,
+        "executorch_exir_dialects_edge__ops_aten_permute_copy_default": 1,
+        "executorch_exir_dialects_edge__ops_dim_order_ops__clone_dim_order_default": 4,
+        "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_tensor_default": 8,
+        "executorch_exir_dialects_edge__ops_quantized_decomposed_quantize_per_tensor_default": 8,
+    }
     ops_after_transforms = {
-        "executorch_exir_dialects_edge__ops_cortex_m_quantize_per_tensor_default": 1,
         "executorch_exir_dialects_edge__ops_cortex_m_dequantize_per_tensor_default": 1,
+        "executorch_exir_dialects_edge__ops_cortex_m_quantize_per_tensor_default": 1,
+        "executorch_exir_dialects_edge__ops_cortex_m_quantized_add_default": 2,
+        "executorch_exir_dialects_edge__ops_cortex_m_transpose_default": 1,
+        "executorch_exir_dialects_edge__ops_dim_order_ops__clone_dim_order_default": 4,
     }
 
     def forward(self, x):
-        # x shape: (1, 3, 4, 5)
-        x = x + x
-        x = torch.ops.aten.squeeze.default(x)  # Remove dim 0: (3, 4, 5)
-        x = torch.ops.aten.unsqueeze.default(x, 0)  # Add dim at 0: (1, 3, 4, 5)
-        x = torch.ops.aten.squeeze_copy.default(x)  # (3, 4, 5)
-        x = torch.ops.aten.unsqueeze_copy.default(x, 0)  # (1, 3, 4, 5)
-        x = torch.ops.aten.squeeze.dims(x, [0])  # (3, 4, 5)
-        x = torch.ops.aten.squeeze_copy.dim(
-            x, 0
-        )  # Remove first dim if size 1, otherwise same
-        x = torch.ops.aten.squeeze.dim(x, 0)  # Same
-        x = torch.ops.aten.unbind.int(x, 0)[0]  # Unbind and take first: (4, 5)
-        x = torch.ops.aten.reshape.default(x, (1, 4, 5, 1))  # (1, 4, 5, 1)
-        x = torch.ops.aten.repeat.default(x, [1, 1, 1, 2])  # (1, 4, 5, 2)
-        x = torch.ops.aten.view.default(x, (1, 4, 10))  # (1, 4, 10)
-        target_shape = torch.zeros(1, 4, 10)
-        x = torch.ops.aten.view_as.default(x, target_shape)  # (1, 4, 10)
-        x = torch.ops.aten.view_copy.default(x, (1, 2, 20))  # (1, 2, 20)
-        x = torch.ops.aten.unflatten.int(x, 2, [4, 5])  # (1, 2, 4, 5)
-        x = torch.ops.aten.flatten.using_ints(x, 1, 3)  # (1, 40)
-        x = torch.ops.aten.repeat_interleave.self_int(x, 2, 1)  # (1, 80)
-        x = torch.ops.aten.expand_copy.default(x, (2, 80))  # (2, 80)
-        x = torch.ops.aten.expand.default(x, (2, 80))  # (2, 80)
-        x = torch.ops.aten.tile.default(x, [1, 1])  # (2, 80)
-        x = torch.ops.aten.split.Tensor(x, 40, 1)[0]  # (2, 40)
-        x = torch.ops.aten.split_with_sizes.default(x, [20, 20], 1)[0]  # (2, 20)
-        x = torch.ops.aten.split_copy.Tensor(x, 10, 1)[0]  # (2, 10)
-        x = torch.ops.aten.chunk.default(x, 2, 1)[0]  # (2, 5)
-        x = torch.ops.aten.pad.default(x, [1, 1, 0, 0], "constant", 0.0)  # (2, 7)
-        x = torch.ops.aten.select.int(x, 1, 0)  # (2,)
-        x = torch.ops.aten.select_copy.int(x, 0, 0)  # scalar -> need to reshape
-        x = torch.ops.aten.unsqueeze.default(x, 0)  # (1,)
-        x = torch.ops.aten.unsqueeze.default(x, 1)  # (1, 1)
-        x = torch.ops.aten.slice.Tensor(x, 0, 0, 1)  # (1, 1)
-        x = torch.ops.aten.slice_copy.Tensor(x, 1, 0, 1)  # (1, 1)
-        x = torch.ops.aten.reshape.default(x, (1, 1))  # Ensure shape for transpose
-        x = torch.ops.aten.transpose.int(x, 0, 1)  # (1, 1)
-        x = torch.ops.aten.transpose_copy.int(x, 0, 1)  # (1, 1)
-        x = torch.ops.aten.t_copy.default(x)  # (1, 1)
-        x = torch.ops.aten.contiguous.default(x)  # (1, 1)
-        x = torch.ops.aten.permute.default(x, [1, 0])  # (1, 1)
-        x = torch.ops.aten.permute_copy.default(x, [0, 1])  # (1, 1)
-        x = torch.ops.aten.flip.default(x, [0])  # (1, 1)
-        y = torch.zeros_like(x)
-        x = torch.ops.aten.copy_.default(y, x)  # (1, 1)
-        x = torch.ops.aten.clone.default(x)  # (1, 1)
-        return x
+        x1 = torch.clone(x)
+        x2 = x1 + x1
+        x3 = torch.clone(x2)
+        x3 = torch.clone(x3)
+        x3 = torch.clone(x3)
+        x4 = x3 + x3
+        x5 = torch.transpose(x4, 2, 1)
+        return x5
 
 
-class CortexMOnlyInheritOps(torch.nn.Module):
+class SharedQspecInputForkNonShared(torch.nn.Module):
+    """Shared qspec cluster with an input fork with both inputs as non-shared qspecs."""
+
     ops_before_transforms = {
-        "executorch_exir_dialects_edge__ops_quantized_decomposed_quantize_per_tensor_default": 2,
-        "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_tensor_default": 2,
+        "executorch_exir_dialects_edge__ops_aten_maximum_default": 1,
+        "executorch_exir_dialects_edge__ops_aten_view_copy_default": 1,
+        "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_tensor_default": 4,
+        "executorch_exir_dialects_edge__ops_quantized_decomposed_quantize_per_tensor_default": 4,
     }
-
     ops_after_transforms = {
-        "executorch_exir_dialects_edge__ops_cortex_m_quantize_per_tensor_default": 1,
+        "executorch_exir_dialects_edge__ops_aten_view_copy_default": 1,
         "executorch_exir_dialects_edge__ops_cortex_m_dequantize_per_tensor_default": 1,
+        "executorch_exir_dialects_edge__ops_cortex_m_maximum_default": 1,
+        "executorch_exir_dialects_edge__ops_cortex_m_quantize_per_tensor_default": 2,
     }
 
-    def forward(self, x):
-        return torch.permute(torch.clone(x), (0, 1, 3, 2))
+    def forward(self, x, y):
+        z = torch.maximum(x, y)
+        return torch.flatten(z)
 
 
-class CortexMQuantizeNonSupportedSub(torch.nn.Module):
+class SharedQspecInputForkShared(torch.nn.Module):
+    """Shared qspec cluster with an input fork with both inputs as shared qspecs."""
+
+    ops_before_transforms = {
+        "executorch_exir_dialects_edge__ops_aten_minimum_default": 1,
+        "executorch_exir_dialects_edge__ops_aten_permute_copy_default": 1,
+        "executorch_exir_dialects_edge__ops_dim_order_ops__clone_dim_order_default": 1,
+        "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_tensor_default": 5,
+        "executorch_exir_dialects_edge__ops_quantized_decomposed_quantize_per_tensor_default": 5,
+    }
+    ops_after_transforms = {
+        "executorch_exir_dialects_edge__ops_cortex_m_dequantize_per_tensor_default": 1,
+        "executorch_exir_dialects_edge__ops_cortex_m_minimum_default": 1,
+        "executorch_exir_dialects_edge__ops_cortex_m_quantize_per_tensor_default": 2,
+        "executorch_exir_dialects_edge__ops_cortex_m_transpose_default": 1,
+        "executorch_exir_dialects_edge__ops_dim_order_ops__clone_dim_order_default": 1,
+    }
+
+    def forward(self, x, y):
+        x = torch.clone(x)
+        y = torch.permute(y, (0, 1, 3, 2))
+        z = torch.minimum(x, y)
+        return z
+
+
+class SharedQspecInputForkXShared(torch.nn.Module):
+    """Shared qspec cluster with an input fork with left input as shared qspec."""
+
+    ops_before_transforms = {
+        "executorch_exir_dialects_edge__ops_aten_maximum_default": 1,
+        "executorch_exir_dialects_edge__ops_aten_permute_copy_default": 1,
+        "executorch_exir_dialects_edge__ops_dim_order_ops__clone_dim_order_default": 1,
+        "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_tensor_default": 4,
+        "executorch_exir_dialects_edge__ops_quantized_decomposed_quantize_per_tensor_default": 4,
+    }
+    ops_after_transforms = {
+        "executorch_exir_dialects_edge__ops_cortex_m_dequantize_per_tensor_default": 1,
+        "executorch_exir_dialects_edge__ops_cortex_m_maximum_default": 1,
+        "executorch_exir_dialects_edge__ops_cortex_m_quantize_per_tensor_default": 2,
+        "executorch_exir_dialects_edge__ops_cortex_m_transpose_default": 1,
+        "executorch_exir_dialects_edge__ops_dim_order_ops__clone_dim_order_default": 1,
+    }
+
+    def forward(self, x, y):
+        x = torch.t_copy(x)
+        z = torch.maximum(x, y)
+        return z
+
+
+class SharedQspecInputForkYShared(torch.nn.Module):
+    """Shared qspec cluster with an input fork with right input as shared qspec."""
+
+    ops_before_transforms = {
+        "executorch_exir_dialects_edge__ops_aten_minimum_default": 1,
+        "executorch_exir_dialects_edge__ops_aten_squeeze_copy_dims": 1,
+        "executorch_exir_dialects_edge__ops_dim_order_ops__clone_dim_order_default": 1,
+        "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_tensor_default": 5,
+        "executorch_exir_dialects_edge__ops_quantized_decomposed_quantize_per_tensor_default": 5,
+    }
+    ops_after_transforms = {
+        "executorch_exir_dialects_edge__ops_aten_squeeze_copy_dims": 1,
+        "executorch_exir_dialects_edge__ops_cortex_m_dequantize_per_tensor_default": 1,
+        "executorch_exir_dialects_edge__ops_cortex_m_minimum_default": 1,
+        "executorch_exir_dialects_edge__ops_cortex_m_quantize_per_tensor_default": 2,
+        "executorch_exir_dialects_edge__ops_dim_order_ops__clone_dim_order_default": 1,
+    }
+
+    def forward(self, x, y):
+        y = torch.clone(y)
+        z = torch.minimum(x, y)
+        return torch.squeeze(z)
+
+
+class SharedQspecInputForkXConstant(torch.nn.Module):
+    """Shared qspec cluster with an input fork with left input as global constant."""
+
     ops_before_transforms = {}
+    ops_after_transforms = {}
+    constant = torch.tensor(5.0)
 
+    def forward(self, x):
+        return torch.minimum(self.constant, x)
+
+
+class SharedQspecInputForkYConstant(torch.nn.Module):
+    """Shared qspec cluster with an input fork with left input as local constant."""
+
+    ops_before_transforms = {}
+    ops_after_transforms = {}
+
+    def forward(self, x):
+        return torch.maximum(x, torch.tensor(5.0))
+
+
+class SharedQspecOutputForkNonShared(torch.nn.Module):
+    """Shared qspec cluster with an output fork with both outputs as non-shared qspecs."""
+
+    ops_before_transforms = {
+        "executorch_exir_dialects_edge__ops_aten_add_Tensor": 1,
+        "executorch_exir_dialects_edge__ops_aten_unsqueeze_copy_default": 1,
+        "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_tensor_default": 4,
+        "executorch_exir_dialects_edge__ops_quantized_decomposed_quantize_per_tensor_default": 3,
+    }
+    ops_after_transforms = {
+        "executorch_exir_dialects_edge__ops_aten_unsqueeze_copy_default": 1,
+        "executorch_exir_dialects_edge__ops_cortex_m_dequantize_per_tensor_default": 2,
+        "executorch_exir_dialects_edge__ops_cortex_m_quantize_per_tensor_default": 1,
+        "executorch_exir_dialects_edge__ops_cortex_m_quantized_add_default": 1,
+    }
+
+    def forward(self, x):
+        x = torch.unsqueeze(x, 0)
+        y = x + x
+        return x, y
+
+
+class SharedQspecOutputForkShared(torch.nn.Module):
+    """Shared qspec cluster with an output fork with both outputs as shared qspecs."""
+
+    ops_before_transforms = {
+        "executorch_exir_dialects_edge__ops_aten_permute_copy_default": 1,
+        "executorch_exir_dialects_edge__ops_aten_unsqueeze_copy_default": 1,
+        "executorch_exir_dialects_edge__ops_dim_order_ops__clone_dim_order_default": 1,
+        "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_tensor_default": 6,
+        "executorch_exir_dialects_edge__ops_quantized_decomposed_quantize_per_tensor_default": 4,
+    }
+    ops_after_transforms = {
+        "executorch_exir_dialects_edge__ops_aten_unsqueeze_copy_default": 1,
+        "executorch_exir_dialects_edge__ops_cortex_m_dequantize_per_tensor_default": 3,
+        "executorch_exir_dialects_edge__ops_cortex_m_quantize_per_tensor_default": 1,
+        "executorch_exir_dialects_edge__ops_cortex_m_transpose_default": 1,
+        "executorch_exir_dialects_edge__ops_dim_order_ops__clone_dim_order_default": 1,
+    }
+
+    def forward(self, x):
+        x = torch.unsqueeze(x, 0)
+        y = torch.clone(x)
+        z = torch.permute_copy(x, (0, 2, 1, 3))
+        return y, z, x
+
+
+class SharedQspecManyForks(torch.nn.Module):
+    """Shared qspec cluster with a number of forks to testmore complex structures."""
+
+    ops_before_transforms = {
+        "executorch_exir_dialects_edge__ops_aten_maximum_default": 2,
+        "executorch_exir_dialects_edge__ops_aten_minimum_default": 1,
+        "executorch_exir_dialects_edge__ops_aten_permute_copy_default": 1,
+        "executorch_exir_dialects_edge__ops_dim_order_ops__clone_dim_order_default": 1,
+        "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_tensor_default": 9,
+        "executorch_exir_dialects_edge__ops_quantized_decomposed_quantize_per_tensor_default": 6,
+    }
+    ops_after_transforms = {
+        "executorch_exir_dialects_edge__ops_cortex_m_dequantize_per_tensor_default": 1,
+        "executorch_exir_dialects_edge__ops_cortex_m_maximum_default": 2,
+        "executorch_exir_dialects_edge__ops_cortex_m_minimum_default": 1,
+        "executorch_exir_dialects_edge__ops_cortex_m_quantize_per_tensor_default": 1,
+        "executorch_exir_dialects_edge__ops_cortex_m_transpose_default": 1,
+        "executorch_exir_dialects_edge__ops_dim_order_ops__clone_dim_order_default": 1,
+    }
+
+    def forward(self, x):
+        x1 = torch.clone(x)
+        x2 = torch.maximum(x, x1)
+        x3 = torch.maximum(x, torch.t(x2))
+        x4 = torch.minimum(x2, x3)
+
+        return x4
+
+
+class SharedQspecSurroundedQuantizedOp(torch.nn.Module):
+    ops_before_transforms = {
+        "executorch_exir_dialects_edge__ops_aten_add_Tensor": 1,
+        "executorch_exir_dialects_edge__ops_aten_maximum_default": 1,
+        "executorch_exir_dialects_edge__ops_dim_order_ops__clone_dim_order_default": 1,
+        "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_tensor_default": 5,
+        "executorch_exir_dialects_edge__ops_quantized_decomposed_quantize_per_tensor_default": 4,
+    }
+    ops_after_transforms = {
+        "executorch_exir_dialects_edge__ops_cortex_m_dequantize_per_tensor_default": 1,
+        "executorch_exir_dialects_edge__ops_cortex_m_maximum_default": 1,
+        "executorch_exir_dialects_edge__ops_cortex_m_quantize_per_tensor_default": 1,
+        "executorch_exir_dialects_edge__ops_cortex_m_quantized_add_default": 1,
+        "executorch_exir_dialects_edge__ops_dim_order_ops__clone_dim_order_default": 1,
+    }
+
+    def forward(self, x):
+        x1 = torch.clone(x)
+        x2 = torch.add(x1, x1)
+        x3 = torch.maximum(x1, x2)
+        return x3
+
+
+class SharedQspecSurroundedQuantizedOpConstant(torch.nn.Module):
+    ops_before_transforms = {}
+    ops_after_transforms = {}
+
+    def forward(self, x):
+        x1 = torch.clone(x)
+        x2 = torch.add(x1, torch.ones(2, 2))
+        x3 = torch.maximum(x1, x2)
+        return x3
+
+
+class SharedQspecSub(torch.nn.Module):
+    ops_before_transforms = {}
     ops_after_transforms = {}
 
     def forward(self, x, y):
-        return y - x
+        return torch.clone(x - y)
 
 
 test_cases = {
-    "all_ops": McuTestCase(
-        CortexMInheritAllOps(),
-        (ramp_tensor(0, 10, (1, 3, 4, 5)),),
+    "multiple_clusters": McuTestCase(
+        SharedQspecMulipleClusters(),
+        (ramp_tensor(-2, 2, (2, 3, 4)),),
     ),
-    "only_inherit_ops": McuTestCase(
-        CortexMOnlyInheritOps(),
-        (ramp_tensor(0, 10, (1, 3, 4, 5)),),
+    "input_fork_non_shared": McuTestCase(
+        SharedQspecInputForkNonShared(),
+        (ramp_tensor(-2, 2, (2, 3, 4)), ramp_tensor(-1, 3, (2, 3, 4))),
+    ),
+    "input_fork_shared": McuTestCase(
+        SharedQspecInputForkShared(),
+        (ramp_tensor(-2, 2, (2, 3, 4, 5)), ramp_tensor(-1, 3, (2, 3, 5, 4))),
+    ),
+    "input_fork_x_shared": McuTestCase(
+        SharedQspecInputForkXShared(),
+        (ramp_tensor(-2, 2, (3, 4)), ramp_tensor(-1, 3, (4, 3))),
+    ),
+    "input_fork_y_shared": McuTestCase(
+        SharedQspecInputForkYShared(),
+        (ramp_tensor(-2, 2, (2, 3, 4)), ramp_tensor(-1, 3, (2, 3, 4))),
+    ),
+    "input_fork_x_constant": McuTestCase(
+        SharedQspecInputForkXConstant(),
+        (ramp_tensor(-2, 2, (2, 3, 4)),),
+    ),
+    "input_fork_y_constant": McuTestCase(
+        SharedQspecInputForkYConstant(),
+        (ramp_tensor(-2, 2, (2, 3, 4)),),
+    ),
+    "surrounded_quantized_op": McuTestCase(
+        SharedQspecSurroundedQuantizedOp(),
+        (ramp_tensor(-128, 2, (2, 3, 4)),),
+    ),
+    "surrounded_quantized_op_constant": McuTestCase(
+        SharedQspecSurroundedQuantizedOpConstant(),
+        (ramp_tensor(-2, 2, (2, 2)),),
+    ),
+    "output_fork_non_shared": McuTestCase(
+        SharedQspecOutputForkNonShared(),
+        (ramp_tensor(-2, 2, (2, 3, 4)),),
+    ),
+    "output_fork_shared": McuTestCase(
+        SharedQspecOutputForkShared(),
+        (ramp_tensor(-2, 2, (2, 3, 4)),),
+    ),
+    "many_forks": McuTestCase(
+        SharedQspecManyForks(),
+        (ramp_tensor(-20, 2, (4, 4)),),
+    ),
+    "non-quantized_op": McuTestCase(
+        SharedQspecSub(),
+        (ramp_tensor(0, 10, (5, 5)), ramp_tensor(0, 1, (5, 5))),
     ),
 }
 
+xfails = {
+    "surrounded_quantized_op_constant": "Numerical error since the add is forced to have non-correct qparams.",
+    "non-quantized_op": "Non-quantized ops are not currently supported in SharedQspecQuantizer.",
+}
 
-@parametrize("test_case", test_cases)
-def test_inherit_int8_dtype(test_case):
+
+@parametrize("test_case", test_cases, xfails=xfails)
+def test_shared_qspec_quantizer(test_case):
     """
     Test that ops which does not change dynamic range are able to use int8 portable kernels.
     """
@@ -132,25 +357,3 @@ def test_inherit_int8_dtype(test_case):
             continue
 
         assert get_first_fake_tensor(node).dtype == torch.int8, f"{node.name}"
-
-
-test_cases = {
-    "sub": McuTestCase(
-        CortexMQuantizeNonSupportedSub(),
-        (ramp_tensor(0, 10, (1, 3, 4, 5)), ramp_tensor(0, 1, (1, 3, 4, 5))),
-    ),
-}
-
-
-@pytest.mark.xfail(
-    reason="Non handled ops which change dynamic range currently not supported."
-)
-@parametrize("test_case", test_cases)
-def test_quantize_unsupported_op(test_case):
-    """
-    Test an op which does change dynamic range and which is not suported by CMSIS-NN. Currently not supported.
-    """
-    tester = CortexMTester(test_case.model, test_case.example_inputs)
-    tester.test_dialect(
-        test_case.model.ops_before_transforms, test_case.model.ops_after_transforms
-    )

--- a/backends/cortex_m/test/ops/test_maximum.py
+++ b/backends/cortex_m/test/ops/test_maximum.py
@@ -1,0 +1,83 @@
+# Copyright 2025 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import torch
+from executorch.backends.arm.test.common import parametrize
+from executorch.backends.cortex_m.test.tester import (
+    CortexMTester,
+    McuTestCase,
+    ramp_tensor,
+)
+
+
+class CortexMTensorMaximum(torch.nn.Module):
+    ops_before_transforms = {
+        "executorch_exir_dialects_edge__ops_aten_maximum_default": 1,
+        "executorch_exir_dialects_edge__ops_quantized_decomposed_quantize_per_tensor_default": 3,
+        "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_tensor_default": 3,
+    }
+
+    ops_after_transforms = {
+        "executorch_exir_dialects_edge__ops_cortex_m_maximum_default": 1,
+        "executorch_exir_dialects_edge__ops_cortex_m_quantize_per_tensor_default": 2,
+        "executorch_exir_dialects_edge__ops_cortex_m_dequantize_per_tensor_default": 1,
+    }
+
+    def forward(self, x, y):
+        return torch.maximum(x, y)
+
+
+test_cases = {
+    "tensor_small": McuTestCase(
+        CortexMTensorMaximum(),
+        (
+            torch.tensor([[1.0, -2.0], [3.5, -4.5]]),
+            torch.tensor([[0.5, -1.0], [4.0, -3.5]]),
+        ),
+    ),
+    "tensor_rand": McuTestCase(
+        CortexMTensorMaximum(),
+        (
+            torch.rand(2, 2, 2) * 4 - 2,
+            torch.rand(2, 2, 2) * 4 - 2,
+        ),
+    ),
+    "broadcast": McuTestCase(
+        CortexMTensorMaximum(),
+        (
+            ramp_tensor(-2, 2, (2, 1, 2)),
+            ramp_tensor(-3, 3, (1, 2, 1)),
+        ),
+    ),
+    "broadcast_rank4": McuTestCase(
+        CortexMTensorMaximum(),
+        (
+            ramp_tensor(-4, 4, (1, 2, 3, 1)),
+            ramp_tensor(-6, 6, (4, 1, 1, 3)),
+        ),
+    ),
+    "broadcast_scalar": McuTestCase(
+        CortexMTensorMaximum(),
+        (
+            torch.tensor(1.0),
+            ramp_tensor(-6, 6, (4, 1, 1, 3)),
+        ),
+    ),
+}
+
+
+@parametrize("test_case", test_cases)
+def test_dialect_maximum(test_case):
+    tester = CortexMTester(test_case.model, test_case.example_inputs)
+    tester.test_dialect(
+        test_case.model.ops_before_transforms, test_case.model.ops_after_transforms
+    )
+
+
+@parametrize("test_case", test_cases)
+def test_implementation_maximum(test_case):
+    tester = CortexMTester(test_case.model, test_case.example_inputs)
+    tester.test_implementation()

--- a/backends/cortex_m/test/ops/test_minimum.py
+++ b/backends/cortex_m/test/ops/test_minimum.py
@@ -1,0 +1,104 @@
+# Copyright 2025 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import torch
+from executorch.backends.arm.test.common import parametrize
+from executorch.backends.cortex_m.test.tester import (
+    CortexMTester,
+    McuTestCase,
+    ramp_tensor,
+)
+
+
+class CortexMSelfMinimum(torch.nn.Module):
+    ops_before_transforms = {
+        "executorch_exir_dialects_edge__ops_aten_minimum_default": 1,
+        "executorch_exir_dialects_edge__ops_quantized_decomposed_quantize_per_tensor_default": 2,
+        "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_tensor_default": 2,
+    }
+
+    ops_after_transforms = {
+        "executorch_exir_dialects_edge__ops_cortex_m_minimum_default": 1,
+        "executorch_exir_dialects_edge__ops_cortex_m_quantize_per_tensor_default": 1,
+        "executorch_exir_dialects_edge__ops_cortex_m_dequantize_per_tensor_default": 1,
+    }
+
+    def forward(self, x):
+        return torch.minimum(x, x)
+
+
+class CortexMTensorMinimum(torch.nn.Module):
+    ops_before_transforms = {
+        "executorch_exir_dialects_edge__ops_aten_minimum_default": 1,
+        "executorch_exir_dialects_edge__ops_quantized_decomposed_quantize_per_tensor_default": 3,
+        "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_tensor_default": 3,
+    }
+
+    ops_after_transforms = {
+        "executorch_exir_dialects_edge__ops_cortex_m_minimum_default": 1,
+        "executorch_exir_dialects_edge__ops_cortex_m_quantize_per_tensor_default": 2,
+        "executorch_exir_dialects_edge__ops_cortex_m_dequantize_per_tensor_default": 1,
+    }
+
+    def forward(self, x, y):
+        return torch.minimum(x, y)
+
+
+test_cases = {
+    "self_rank_1": McuTestCase(
+        CortexMSelfMinimum(),
+        (ramp_tensor(-5, 5, (10,)),),
+    ),
+    "self_rank_3": McuTestCase(
+        CortexMSelfMinimum(),
+        (ramp_tensor(-10, 10, (2, 3, 4)),),
+    ),
+    "tensor_small": McuTestCase(
+        CortexMTensorMinimum(),
+        (
+            torch.tensor([[1.0, -2.0], [3.5, -4.5]]),
+            torch.tensor([[0.5, -3.0], [3.0, -4.0]]),
+        ),
+    ),
+    "tensor_rand": McuTestCase(
+        CortexMTensorMinimum(),
+        (
+            torch.rand(2, 2, 2) * 4 - 2,
+            torch.rand(2, 2, 2) * 4 - 2,
+        ),
+    ),
+    "broadcast": McuTestCase(
+        CortexMTensorMinimum(),
+        (
+            ramp_tensor(-2, 2, (2, 1, 2)),
+            ramp_tensor(-3, 3, (1, 2, 1)),
+        ),
+    ),
+    "broadcast_rank4": McuTestCase(
+        CortexMTensorMinimum(),
+        (
+            ramp_tensor(-4, 4, (1, 2, 3, 1)),
+            ramp_tensor(-6, 6, (4, 1, 1, 3)),
+        ),
+    ),
+}
+
+
+xfails = {}
+
+
+@parametrize("test_case", test_cases, xfails=xfails)
+def test_dialect_minimum(test_case):
+    tester = CortexMTester(test_case.model, test_case.example_inputs)
+    tester.test_dialect(
+        test_case.model.ops_before_transforms, test_case.model.ops_after_transforms
+    )
+
+
+@parametrize("test_case", test_cases, xfails=xfails)
+def test_implementation_minimum(test_case):
+    tester = CortexMTester(test_case.model, test_case.example_inputs)
+    tester.test_implementation()


### PR DESCRIPTION
This patch reworks how ops w/o rescaling are handled. Instead of not annotating them and counting on the retracing to make them get correct dtype, they must now be annotated by the SharedQspecQuantizer.

The reason for this is that it simplifies ensuring that non-rescaling with multiple inputs has the same scale on both inputs. It also becomes easier to tell which dtype each op will receive before folding.


cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai