### PR TITLE
Manually pick moshi requirements update from #15180

### DIFF
--- a/examples/models/moshi/mimi/install_requirements.sh
+++ b/examples/models/moshi/mimi/install_requirements.sh
@@ -7,10 +7,10 @@
 
 set -x
 
-conda install -c conda-forge "ffmpeg<8" -y
-pip install torchcodec==0.7.0.dev20250906 --extra-index-url https://download.pytorch.org/whl/nightly/cpu
-pip install moshi==0.2.4
-pip install bitsandbytes soundfile
+sudo apt install ffmpeg -y
+pip install torchcodec==0.7.0.dev20251012 --extra-index-url https://download.pytorch.org/whl/nightly/cpu
+pip install moshi==0.2.11
+pip install bitsandbytes soundfile einops
 # Run llama2/install requirements for torchao deps
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 bash "$SCRIPT_DIR"/../../llama/install_requirements.sh

--- a/examples/models/moshi/mimi/test_mimi.py
+++ b/examples/models/moshi/mimi/test_mimi.py
@@ -189,8 +189,7 @@ class TestMimiModel(unittest.TestCase):
                 x = self.mimi_model.upsample(x)
                 (emb,) = self.mimi_model.decoder_transformer(x)
                 emb.transpose(1, 2)
-                with self.mimi_model._context_for_encoder_decoder:
-                    out = self.mimi_model.decoder(emb)
+                out = self.mimi_model.decoder(emb)
                 return out
 
         emb_input = torch.rand(1, 1, 512, device="cpu")


### PR DESCRIPTION
### Summary
The torchcodec nightly version we are pinning is out of retention. It was updated on main as part of #15180. This PR picks just that change to the requirements file to avoid picking up all of the other large changes in the PR. The follow-up change to the ffmpeg install in #15821 is also picked here, since it's needed for the previous change to work.