### PR TITLE
[RELEASE ONLY] Use release torchao version for OpenVINO

### DIFF
--- a/backends/openvino/scripts/openvino_build.sh
+++ b/backends/openvino/scripts/openvino_build.sh
@@ -54,9 +54,6 @@ main() {
         # Build the package
         ./install_executorch.sh --minimal
 
-        # Install torchao
-        pip install third-party/ao
-
     else
         echo "Error: Argument is not valid: $build_type"
         exit 1  # Exit the script with an error code


### PR DESCRIPTION
### Summary
OpenVINO CI is failing on the release branch. We can avoid the build from source by just using the release ao version installed with pyproject.toml.

### Test Plan
The [test-openvino-linux / linux-job](https://github.com/pytorch/executorch/actions/runs/19485963505/job/55768329507?pr=15880#logs) run is passing on this PR (failing on trunk).