### PR TITLE
Fix UnboundLocalError: local variable 'qnn_compile_spec_buffer' refer…

### DIFF
--- a/backends/qualcomm/partition/utils.py
+++ b/backends/qualcomm/partition/utils.py
@@ -28,7 +28,7 @@ def generate_qnn_executorch_option(
         raise ValueError(
             f"QNN compile spec (key={QCOM_QNN_COMPILE_SPEC}) not found in compiler_specs"
         )
-        
+
     return qnn_compile_spec_buffer
 
 

--- a/backends/qualcomm/partition/utils.py
+++ b/backends/qualcomm/partition/utils.py
@@ -16,11 +16,19 @@ from executorch.exir.backend.compile_spec_schema import CompileSpec
 def generate_qnn_executorch_option(
     compiler_specs: List[CompileSpec],
 ) -> bytes:
+    qnn_compile_spec_buffer = None
+
     for compiler_spec in compiler_specs:
         if compiler_spec.key == QCOM_QNN_COMPILE_SPEC:
             qnn_compile_spec_buffer = compiler_spec.value
         else:
             raise ValueError(f"unknown compiler spec key value: {compiler_spec.key}")
+
+    if qnn_compile_spec_buffer is None:
+        raise ValueError(
+            f"QNN compile spec (key={QCOM_QNN_COMPILE_SPEC}) not found in compiler_specs"
+        )
+        
     return qnn_compile_spec_buffer
 
 


### PR DESCRIPTION


As title, addressed issues exposed from https://github.com/pytorch/pytorch/pull/168098
```
FAILED exir/backend/test/test_debug_handle_map.py::TestBackendDebugHandle::test_lowered_the_whole_model - UnboundLocalError: local variable 'qnn_compile_spec_buffer' referenced before assignment
Falsifying example: test_lowered_the_whole_model(
    unlift=False,
    self=<test_debug_handle_map.TestBackendDebugHandle testMethod=test_lowered_the_whole_model>,
)

```
