### PR TITLE
Remove copy python packages files in build.sh

### DIFF
--- a/backends/qualcomm/scripts/build.sh
+++ b/backends/qualcomm/scripts/build.sh
@@ -270,7 +270,6 @@ if [ "$BUILD_X86_64" = true ]; then
     cmake --build $BUILD_ROOT -j$BUILD_JOB_NUMBER --target install
 
     rm -f $PRJ_ROOT/backends/qualcomm/python/*
-    cp -fv $BUILD_ROOT/backends/qualcomm/Py* "$PRJ_ROOT/backends/qualcomm/python"
     cp -fv "$PRJ_ROOT/schema/program.fbs" "$PRJ_ROOT/exir/_serialize/program.fbs"
     cp -fv "$PRJ_ROOT/schema/scalar_type.fbs" "$PRJ_ROOT/exir/_serialize/scalar_type.fbs"
 


### PR DESCRIPTION
In a recent PR, we set the target destination for these files so we don't need to manually copy it https://github.com/pytorch/executorch/blob/main/backends/qualcomm/CMakeLists.txt#L322-L328

Test manually and rely on CI. This script is widely used so should be well tested