### PR TITLE
Add FlatTensorDataMap to low-level pybindings

### DIFF
--- a/extension/pybindings/portable_lib.py
+++ b/extension/pybindings/portable_lib.py
@@ -59,6 +59,8 @@ from executorch.extension.pybindings._portable_lib import (  # noqa: F401
     _get_registered_backend_names,  # noqa: F401
     _is_available,  # noqa: F401
     _load_bundled_program_from_buffer,  # noqa: F401
+    _load_flat_tensor_data_map,  # noqa: F401
+    _load_flat_tensor_data_map_from_buffer,  # noqa: F401
     _load_for_executorch,  # noqa: F401
     _load_for_executorch_from_buffer,  # noqa: F401
     _load_for_executorch_from_bundled_program,  # noqa: F401
@@ -71,6 +73,7 @@ from executorch.extension.pybindings._portable_lib import (  # noqa: F401
     ExecuTorchMethod,  # noqa: F401
     ExecuTorchModule,  # noqa: F401
     ExecuTorchProgram,  # noqa: F401
+    FlatTensorDataMap,  # noqa: F401
     MethodMeta,  # noqa: F401
     Verification,  # noqa: F401
 )

--- a/extension/pybindings/pybindings.pyi
+++ b/extension/pybindings/pybindings.pyi
@@ -297,3 +297,60 @@ def _threadpool_get_thread_count() -> int:
         This API is experimental and subject to change without notice.
     """
     ...
+
+@experimental("This API is experimental and subject to change without notice.")
+class FlatTensorDataMap:
+    """FlatTensorDataMap loads external data from a .ptd file.
+
+    .. warning::
+
+        This API is experimental and subject to change without notice.
+    """
+
+    def get_named_data_map(self) -> Any:
+        """Get a pointer to the underlying NamedDataMap.
+
+        Returns:
+            A capsule containing a pointer to the internal NamedDataMap
+            that can be passed to ExecuTorchProgram.load_method().
+
+        Warning:
+            The FlatTensorDataMap instance must outlive the returned capsule.
+        """
+        ...
+
+@experimental("This API is experimental and subject to change without notice.")
+def _load_flat_tensor_data_map(
+    data_path: str,
+) -> FlatTensorDataMap:
+    """Load a flat tensor data map from a file.
+
+    .. warning::
+
+        This API is experimental and subject to change without notice.
+
+    Args:
+        data_path: Path to the .ptd file with external data.
+
+    Returns:
+        A FlatTensorDataMap instance that can be used with ExecuTorchProgram.load_method().
+    """
+    ...
+
+@experimental("This API is experimental and subject to change without notice.")
+def _load_flat_tensor_data_map_from_buffer(
+    data_buffer: bytes,
+) -> FlatTensorDataMap:
+    """Load a flat tensor data map from a buffer.
+
+    .. warning::
+
+        This API is experimental and subject to change without notice.
+
+    Args:
+        data_buffer: Buffer holding a .ptd file with external data.
+
+    Returns:
+        A FlatTensorDataMap instance that can be used with ExecuTorchProgram.load_method().
+    """
+    ...

--- a/shim_et/xplat/executorch/extension/pybindings/pybindings.bzl
+++ b/shim_et/xplat/executorch/extension/pybindings/pybindings.bzl
@@ -8,35 +8,37 @@ MODELS_ATEN_OPS_LEAN_MODE_GENERATED_LIB = [
 ]
 
 PORTABLE_MODULE_DEPS = [
-    "//executorch/runtime/kernel:operator_registry",
-    "//executorch/runtime/executor:program",
     "//executorch/devtools/bundled_program/schema:bundled_program_schema_fbs",
-    "//executorch/extension/aten_util:aten_bridge",
     "//executorch/devtools/bundled_program:runtime",
+    "//executorch/devtools/etdump:etdump_flatcc",
+    "//executorch/extension/aten_util:aten_bridge",
     "//executorch/extension/data_loader:buffer_data_loader",
     "//executorch/extension/data_loader:mmap_data_loader",
+    "//executorch/extension/flat_tensor:flat_tensor_data_map",
     "//executorch/extension/memory_allocator:malloc_memory_allocator",
     "//executorch/extension/module:bundled_module",
     "//executorch/extension/module:module",
     "//executorch/extension/tensor:tensor",
+    "//executorch/runtime/executor:program",
     "//executorch/runtime/executor/test:test_backend_compiler_lib",
-    "//executorch/devtools/etdump:etdump_flatcc",
+    "//executorch/runtime/kernel:operator_registry",
 ] + get_all_cpu_backend_targets()
 
 ATEN_MODULE_DEPS = [
-    "//executorch/runtime/kernel:operator_registry_aten",
-    "//executorch/runtime/executor:program_aten",
     "//executorch/runtime/core/exec_aten:lib_aten",
     "//executorch/devtools/bundled_program/schema:bundled_program_schema_fbs",
+    "//executorch/devtools/bundled_program:runtime_aten",
+    "//executorch/devtools/etdump:etdump_flatcc",
     "//executorch/extension/data_loader:buffer_data_loader",
     "//executorch/extension/data_loader:mmap_data_loader",
+    "//executorch/extension/flat_tensor:flat_tensor_data_map_aten",
     "//executorch/extension/memory_allocator:malloc_memory_allocator",
     "//executorch/extension/module:bundled_module_aten",
     "//executorch/extension/module:module_aten",
     "//executorch/extension/tensor:tensor_aten",
-    "//executorch/devtools/bundled_program:runtime_aten",
     "//executorch/runtime/executor/test:test_backend_compiler_lib_aten",
-    "//executorch/devtools/etdump:etdump_flatcc",
+    "//executorch/runtime/executor:program_aten",
+    "//executorch/runtime/kernel:operator_registry_aten",
 ]
 
 # Generated lib for all ATen ops with aten kernel used by models in model inventory


### PR DESCRIPTION
Summary:
Create pybindings around the FlatTensorDataMap::load function

This allows us to use the low-level program data separation APIs in pybindings, through program/method as well as Module.

Use `py::capsule` to capture the type `const NamedDataMap*` that is passed into method_load.

Example usage:
```
 >>> inputs = (torch.randn(3),)
 >>> program = _load_program_from_buffer(program_buffer)
 >>> data_map = _load_flat_tensor_data_map("model.ptd")
 >>> method = program.load_method("forward", data_map.get_named_data_map())
 >>> outputs = method(inputs)[0]
```

Differential Revision: D87461455


