### PR TITLE
Fix circular dep in flat tensor import

### DIFF
--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -79,7 +79,6 @@ from executorch.exir.verification.verifier import (
     EXIREdgeDialectVerifier,
     get_aten_verifier,
 )
-from executorch.extension.flat_tensor.serialize.serialize import FlatTensorSerializer
 from torch._export.passes import ReplaceViewOpsWithViewCopyOpsPass
 from torch._export.verifier import Verifier
 from torch.export import ExportedProgram
@@ -590,6 +589,10 @@ class ExecutorchProgram:
         self._segment_alignment: int = segment_alignment
         self._constant_tensor_alignment: Optional[int] = constant_tensor_alignment
         self._delegate_alignment: Optional[int] = delegate_alignment
+        from executorch.extension.flat_tensor.serialize.serialize import (
+            FlatTensorSerializer,
+        )
+
         self._data_serializer: DataSerializer = FlatTensorSerializer()
 
     def _get_emitter_output(self) -> EmitterOutput:
@@ -1839,6 +1842,10 @@ class ExecutorchProgramManager:
         )
 
         # Serialize emitter output, ready to be written to a file.
+        from executorch.extension.flat_tensor.serialize.serialize import (
+            FlatTensorSerializer,
+        )
+
         self._data_serializer = FlatTensorSerializer()
         self._pte_data, self._tensor_data = serialize_for_executorch(
             self._emitter_output,


### PR DESCRIPTION
Seeing error when important flat tensor deserializer
```
(executorch) [lfq@devvm311.ldc0 /data/users/lfq/executorch (aff5086f)]$ python debug-lora.py 
Traceback (most recent call last):
  File "/data/users/lfq/executorch/debug-lora.py", line 1, in <module>
    from executorch.extension.flat_tensor.serialize.serialize import _deserialize_to_flat_tensor
  File "/data/users/lfq/executorch/src/executorch/extension/flat_tensor/serialize/serialize.py", line 20, in <module>
    from executorch.exir._serialize._cord import Cord
  File "/data/users/lfq/executorch/src/executorch/exir/__init__.py", line 9, in <module>
    from executorch.exir.capture import (
  File "/data/users/lfq/executorch/src/executorch/exir/capture/__init__.py", line 9, in <module>
    from executorch.exir.capture._capture import (
  File "/data/users/lfq/executorch/src/executorch/exir/capture/_capture.py", line 17, in <module>
    from executorch.exir.program import ExirExportedProgram
  File "/data/users/lfq/executorch/src/executorch/exir/program/__init__.py", line 10, in <module>
    from executorch.exir.program._program import (
  File "/data/users/lfq/executorch/src/executorch/exir/program/_program.py", line 82, in <module>
    from executorch.extension.flat_tensor.serialize.serialize import FlatTensorSerializer
ImportError: cannot import name 'FlatTensorSerializer' from partially initialized module 'executorch.extension.flat_tensor.serialize.serialize' (most likely due to a circular import) (/data/users/lfq/executorch/src/executorch/extension/flat_tensor/serialize/serialize.py)
```
Previously, the import happened at module load time, causing the circular dependency. Now, the import happens at runtime, and we do not hit the circular dep. 
