### PR TITLE
Rename the qnn demo backend

### DIFF
--- a/exir/backend/test/TARGETS
+++ b/exir/backend/test/TARGETS
@@ -95,9 +95,9 @@ python_unittest(
 )
 
 runtime.python_library(
-    name = "qnn_backend_demo",
+    name = "demo_backend",
     srcs = [
-        "qnn_backend_demo.py",
+        "demo_backend.py",
     ],
     visibility = [
         "//executorch/...",
@@ -119,7 +119,7 @@ runtime.python_library(
         "//executorch/test/...",
     ],
     deps = [
-        ":qnn_backend_demo",
+        ":demo_backend",
         "//caffe2:torch",
         "//executorch/exir:lib",
         "//executorch/exir/backend:partitioner",
@@ -153,7 +153,7 @@ runtime.python_library(
     name = "example_backends",
     deps = [
         ":backend_with_compiler_demo",
-        ":qnn_backend_demo",
+        ":demo_backend",
     ],
 )
 
@@ -171,7 +171,7 @@ python_unittest(
         ":backend_with_compiler_demo",
         ":hta_partitioner_demo",
         ":op_partitioner_demo",
-        ":qnn_backend_demo",
+        ":demo_backend",
         "//caffe2:torch",
         "//caffe2/functorch:functorch_src",
         "//executorch/exir:delegate",
@@ -250,7 +250,7 @@ python_unittest(
     deps = [
         "fbsource//third-party/pypi/hypothesis:hypothesis",
         ":op_partitioner_demo",
-        ":qnn_backend_demo",
+        ":demo_backend",
         "//caffe2:torch",
         "//executorch/exir:delegate",
         "//executorch/exir:lib",
@@ -273,7 +273,7 @@ python_unittest(
         ":backend_with_compiler_demo",
         ":hta_partitioner_demo",
         ":op_partitioner_demo",
-        ":qnn_backend_demo",
+        ":demo_backend",
         "//caffe2:torch",
         "//caffe2/functorch:functorch_src",
         "//executorch/exir:delegate",
@@ -303,7 +303,7 @@ python_unittest(
     deps = [
         "fbsource//third-party/pypi/hypothesis:hypothesis",
         ":backend_with_compiler_demo",
-        ":qnn_backend_demo",
+        ":demo_backend",
         "//caffe2:torch",
         "//executorch/exir:lib",
         "//executorch/exir:schema",

--- a/exir/backend/test/demo_backend.py
+++ b/exir/backend/test/demo_backend.py
@@ -16,7 +16,7 @@ from executorch.exir.backend.compile_spec_schema import CompileSpec
 
 
 @final
-class QnnBackend(BackendDetails):
+class DemoBackend(BackendDetails):
     @staticmethod
     def preprocess(
         edge_program: ExportedProgram,

--- a/exir/backend/test/hta_partitioner_demo.py
+++ b/exir/backend/test/hta_partitioner_demo.py
@@ -18,7 +18,7 @@ from executorch.exir.backend.partitioner import (
     Partitioner,
     PartitionResult,
 )
-from executorch.exir.backend.test.qnn_backend_demo import QnnBackend
+from executorch.exir.backend.test.demo_backend import DemoBackend
 from executorch.exir.backend.utils import tag_constant_data
 from torch.export import ExportedProgram
 from torch.fx.passes.infra.partitioner import Partition
@@ -28,7 +28,7 @@ from torch.fx.passes.infra.partitioner import Partition
 class HTAPartitionerMultiplePatternsDemo(Partitioner):
     """
     An example implementation to partition graph for HTA, in this example, the backend
-    associate with this partitioner is QnnBackend. With QnnBackend, the two lowerable
+    associate with this partitioner is DemoBackend. With DemoBackend, the two lowerable
     patterns are: (lstm + conv) and (sub). backend is a class member instead of instance
     members, as it is a properties of HTAPartitionerMultiplePatternsDemo, and won't be different for
     different HTAPartitionerMultiplePatternsDemo instances.
@@ -116,7 +116,7 @@ class HTAPartitionerMultiplePatternsDemo(Partitioner):
             pattern_sub.graph,
         ]
 
-        backend_id = QnnBackend.__name__
+        backend_id = DemoBackend.__name__
         self.delegation_spec = DelegationSpec(backend_id, [])
 
     def is_exclusive(self, partition_list_list: List[List[Partition]]) -> bool:
@@ -269,7 +269,7 @@ class HTAPartitionerOnePatternDemo(Partitioner):
         ]
         # Only (lstm + conv) pattern is lowerable
 
-        backend_id = QnnBackend.__name__
+        backend_id = DemoBackend.__name__
         self.delegation_spec = DelegationSpec(backend_id, [])
 
     def partition(self, exported_program: ExportedProgram) -> PartitionResult:

--- a/exir/backend/test/test_backends.py
+++ b/exir/backend/test/test_backends.py
@@ -27,6 +27,7 @@ from executorch.exir.backend.partitioner import (
 from executorch.exir.backend.test.backend_with_compiler_demo import (
     BackendWithCompilerDemo,
 )
+from executorch.exir.backend.test.demo_backend import DemoBackend
 from executorch.exir.backend.test.hta_partitioner_demo import (
     HTAPartitionerMultiplePatternsDemo,
     HTAPartitionerOnePatternDemo,
@@ -35,7 +36,6 @@ from executorch.exir.backend.test.op_partitioner_demo import (
     AddAttributePartitionerDemo,
     AddMulPartitionerDemo,
 )
-from executorch.exir.backend.test.qnn_backend_demo import QnnBackend
 
 from executorch.exir.delegate import executorch_call_delegate
 from executorch.exir.dialects._ops import ops as exir_ops
@@ -643,7 +643,7 @@ class TestBackends(unittest.TestCase):
         self.check_backend_delegate(
             program=program_with_delegates.program,
             delegate=program_with_delegates.program.execution_plan[0].delegates[0],
-            expected_id=QnnBackend.__name__,
+            expected_id=DemoBackend.__name__,
             expected_processed=b"imqnncompiled",
         )
 
@@ -784,7 +784,7 @@ class TestBackends(unittest.TestCase):
         self.check_backend_delegate(
             program=program_with_delegates.program,
             delegate=program_with_delegates.program.execution_plan[0].delegates[0],
-            expected_id=QnnBackend.__name__,
+            expected_id=DemoBackend.__name__,
             expected_processed=b"imqnncompiled",
         )
 

--- a/exir/backend/test/test_backends_lifted.py
+++ b/exir/backend/test/test_backends_lifted.py
@@ -25,6 +25,7 @@ from executorch.exir.backend.partitioner import (
 from executorch.exir.backend.test.backend_with_compiler_demo import (
     BackendWithCompilerDemo,
 )
+from executorch.exir.backend.test.demo_backend import DemoBackend
 from executorch.exir.backend.test.hta_partitioner_demo import (
     HTAPartitionerMultiplePatternsDemo,
     HTAPartitionerOnePatternDemo,
@@ -33,7 +34,6 @@ from executorch.exir.backend.test.op_partitioner_demo import (
     AddAttributePartitionerDemo,
     AddMulPartitionerDemo,
 )
-from executorch.exir.backend.test.qnn_backend_demo import QnnBackend
 
 from executorch.exir.delegate import executorch_call_delegate
 from executorch.exir.dialects._ops import ops as exir_ops
@@ -664,7 +664,7 @@ class TestBackends(unittest.TestCase):
             delegate=program_with_delegates._emitter_output.program.execution_plan[
                 0
             ].delegates[0],
-            expected_id=QnnBackend.__name__,
+            expected_id=DemoBackend.__name__,
             expected_processed=b"imqnncompiled",
         )
 
@@ -803,7 +803,7 @@ class TestBackends(unittest.TestCase):
             delegate=program_with_delegates._emitter_output.program.execution_plan[
                 0
             ].delegates[0],
-            expected_id=QnnBackend.__name__,
+            expected_id=DemoBackend.__name__,
             expected_processed=b"imqnncompiled",
         )
 

--- a/exir/backend/test/test_debug_handle_map.py
+++ b/exir/backend/test/test_debug_handle_map.py
@@ -11,8 +11,8 @@ import executorch.exir.tests.models as models
 import torch
 from executorch import exir
 from executorch.exir.backend.backend_api import to_backend
+from executorch.exir.backend.test.demo_backend import DemoBackend
 from executorch.exir.backend.test.op_partitioner_demo import AddMulPartitionerDemo
-from executorch.exir.backend.test.qnn_backend_demo import QnnBackend
 from executorch.exir.delegate import executorch_call_delegate
 from hypothesis import given, settings, strategies as st
 
@@ -84,10 +84,10 @@ class TestBackendDebugHandle(unittest.TestCase):
                 edge_compile_config
             )
             lowered_model = to_backend(
-                QnnBackend.__name__, edgeir_m.exported_program, []
+                DemoBackend.__name__, edgeir_m.exported_program, []
             )
 
-            # QnnBackend compile all nodes as one node. The debug_handle_map will be like (1: (debug handle from all nodes))
+            # DemoBackend compile all nodes as one node. The debug_handle_map will be like (1: (debug handle from all nodes))
             # Ensure there is only one debug identifier
             self.assertEqual(
                 len(lowered_model.meta["debug_handle_map"].keys()),

--- a/exir/backend/test/test_lowered_backend_module.py
+++ b/exir/backend/test/test_lowered_backend_module.py
@@ -16,7 +16,7 @@ from executorch.exir.backend.compile_spec_schema import CompileSpec
 from executorch.exir.backend.test.backend_with_compiler_demo import (
     BackendWithCompilerDemo,
 )
-from executorch.exir.backend.test.qnn_backend_demo import QnnBackend
+from executorch.exir.backend.test.demo_backend import DemoBackend
 from executorch.exir.schema import DelegateCall, Program
 
 from executorch.extension.pybindings.portable_lib import (  # @manual
@@ -128,7 +128,7 @@ class TestBackendAPI(unittest.TestCase):
                 compile_config=edge_compile_config,
             )
             lowered_model = to_backend(
-                QnnBackend.__name__, edgeir_m.exported_program(), []
+                DemoBackend.__name__, edgeir_m.exported_program(), []
             )
             program = lowered_model.program()
             reference_program = self.get_program_from_wrapped_module(
@@ -181,7 +181,7 @@ class TestBackendAPI(unittest.TestCase):
                 compile_config=edge_compile_config,
             )
             lowered_module = to_backend(
-                QnnBackend.__name__, edgeir_m.exported_program(), []
+                DemoBackend.__name__, edgeir_m.exported_program(), []
             )
 
             # This module will include one operator and two delegate call
@@ -200,7 +200,7 @@ class TestBackendAPI(unittest.TestCase):
             )
 
             nested_lowered_model = to_backend(
-                QnnBackend.__name__, wrapped_module_edge.exported_program(), []
+                DemoBackend.__name__, wrapped_module_edge.exported_program(), []
             )
 
             program = nested_lowered_model.program()


### PR DESCRIPTION
Summary: Suspect the failure https://github.com/pytorch/pytorch/actions/runs/19547462483/job/55989739476 is due to using different QnnBackend implementation. Rename this demo backend to a demo backend name

Differential Revision: D87586567
