### PR TITLE
Move user-defined passes after SpecPropPass

### DIFF
--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -839,13 +839,11 @@ def edge_to_executorch_passes(
     Get the pre memory planning passes based on the method name, if the pass is not in the dict, use the default pass.
     """
     passes: List[PassType] = [
-        SpecPropPass(),
         # ExecuTorch backend ops are unable to handle unbacked symints. So after
         # this pass, passes cannot be Interpreter-based, because it will fail if
         # there exists an unbacked symint operation.
         *config.passes,
-        # config.passes may contain external_constants_pass. This pass has to
-        # run after SpecPropPass, which populates tensor names.
+        SpecPropPass(),
         EdgeToBackendOpsPass(),
         RemoveGraphAssertsPass(),
     ] + pre_memory_planning_passes(config, name)

--- a/extension/llm/export/builder.py
+++ b/extension/llm/export/builder.py
@@ -473,7 +473,11 @@ class LLMEdgeManager:
         return self
 
     def to_executorch(
-        self, passes: Optional[List[ExportPass]] = None
+        self,
+        passes: Optional[List[ExportPass]] = None,
+        external_constants_tag: Optional[
+            Callable[[torch.fx.Node], Optional[str]]
+        ] = None,
     ) -> "LLMEdgeManager":
         """
         Lower the model to executorch and get an ExecutorchProgram.
@@ -506,6 +510,7 @@ class LLMEdgeManager:
                 do_quant_fusion_and_const_prop=True,
                 memory_planning_pass=MemoryPlanningPass(alloc_graph_input=False),
                 sym_shape_eval_pass=ConstraintBasedSymShapeEvalPass(),
+                external_constants=external_constants_tag,
             )
         )
         logging.info(


### PR DESCRIPTION
Summary:
1. Use `ExecutorchBackendConfig` instead of inserting the pass.
2. Move SpecPropPass after user-defined passes. It was originally swapped here: D80840528. cc ethansfng, who has a pass that should run before SpecPropPass

Differential Revision: D87576772


