### PR TITLE
[Do not land] Static numeric experiment

### DIFF
--- a/examples/apple/coreml/llama/export.py
+++ b/examples/apple/coreml/llama/export.py
@@ -10,13 +10,17 @@ import coremltools as ct
 import torch
 from executorch.backends.apple.coreml.compiler import CoreMLBackend  # pyre-ignore
 from executorch.backends.apple.coreml.partition import CoreMLPartitioner  # pyre-ignore
+import os
 
 from executorch.examples.apple.coreml.llama.llama_transformer import (
     InputManager,
     load_model,
+    load_model_in_pieces_ITO,
+    load_model_in_pieces_IAFO,
 )
 from executorch.examples.apple.coreml.llama.utils import (
     replace_linear_with_split_linear,
+    SplitLinearModule,
 )
 
 from executorch.exir import to_edge_transform_and_lower
@@ -103,97 +107,65 @@ def main() -> None:
         type=str,
         default="fp16",
     )
-
-    export_args = parser.parse_args()
-    model = load_model(
-        export_args.checkpoint,
-        export_args.params,
-        max_seq_length=export_args.max_seq_length,
-        use_cache_list=export_args.use_cache_list,
+    parser.add_argument(
+        "--export_in_pieces_mode",
+        type=int,
+        default=0,
     )
 
+    export_args = parser.parse_args()
+    
     float_dtype = {"fp16": torch.float16, "fp32": torch.float32}[
         export_args.dtype
     ]  # dtype for model/inputs
 
-    model.eval()
-    model.to(float_dtype)
+    def maybe_split_model(model):
+        if export_args.target_split_size is not None:
+            replace_linear_with_split_linear(
+                model,
+                out_target_split_size=export_args.target_split_size,
+                out_max_splits=export_args.max_splits,
+                # I have not found splitting on in_features to be beneficial,
+                # and it often leads to OOM so I set in_max_splits to 1
+                in_target_split_size=1,
+                in_max_splits=1,
+            )
+    
+    def maybe_quantize_model(model):
+        if export_args.embedding_quantize:
+            bitwidth, group_size = export_args.embedding_quantize.split(",")
+            bitwidth = int(bitwidth)
+            assert bitwidth in [4, 8], "CoreML only supports 4-bit and 8-bit quantization"
+            group_size = int(group_size)
+            if group_size == 0:
+                granularity = PerAxis(0)
+            else:
+                granularity = PerGroup(group_size)
+            weight_dtype = getattr(torch, f"int{bitwidth}")
 
-    print("MODEL", model)
+            quantize_(
+                model,
+                IntxWeightOnlyConfig(weight_dtype=weight_dtype, granularity=granularity),
+                lambda m, fqn: isinstance(m, torch.nn.Embedding),
+            )
 
-    if export_args.target_split_size is not None:
-        replace_linear_with_split_linear(
-            model,
-            out_target_split_size=export_args.target_split_size,
-            out_max_splits=export_args.max_splits,
-            # I have not found splitting on in_features to be beneficial,
-            # and it often leads to OOM so I set in_max_splits to 1
-            in_target_split_size=1,
-            in_max_splits=1,
-        )
+        if export_args.coreml_quantize == "b4w":
+            quantize_(
+                model,
+                IntxWeightOnlyConfig(
+                    weight_dtype=torch.int4,
+                    granularity=PerGroup(32),
+                ),
+            )
+        elif export_args.coreml_quantize == "c4w":
+            quantize_(
+                model,
+                IntxWeightOnlyConfig(
+                    weight_dtype=torch.int4,
+                    granularity=PerAxis(0),
+                ),
+            )
 
-    # Quantization
-    if export_args.embedding_quantize:
-        bitwidth, group_size = export_args.embedding_quantize.split(",")
-        bitwidth = int(bitwidth)
-        assert bitwidth in [4, 8], "CoreML only supports 4-bit and 8-bit quantization"
-        group_size = int(group_size)
-        if group_size == 0:
-            granularity = PerAxis(0)
-        else:
-            granularity = PerGroup(group_size)
-        weight_dtype = getattr(torch, f"int{bitwidth}")
-
-        quantize_(
-            model,
-            IntxWeightOnlyConfig(weight_dtype=weight_dtype, granularity=granularity),
-            lambda m, fqn: isinstance(m, torch.nn.Embedding),
-        )
-
-    if export_args.coreml_quantize == "b4w":
-        quantize_(
-            model,
-            IntxWeightOnlyConfig(
-                weight_dtype=torch.int4,
-                granularity=PerGroup(32),
-            ),
-        )
-    elif export_args.coreml_quantize == "c4w":
-        quantize_(
-            model,
-            IntxWeightOnlyConfig(
-                weight_dtype=torch.int4,
-                granularity=PerAxis(0),
-            ),
-        )
-    elif export_args.coreml_quantize == "custom":
-        replace_linear_with_split_linear(
-            model,
-            out_target_split_size=2048,
-            out_max_splits=4,
-            in_target_split_size=1,
-            in_max_splits=1,
-            fqn_filer=lambda fqn: any(fqn.endswith(suffix) for suffix in ["w1", "w3"])
-        )
-        replace_linear_with_split_linear(
-            model,
-            out_target_split_size=2048,
-            out_max_splits=1,
-            in_target_split_size=2048,
-            in_max_splits=4,
-            fqn_filer=lambda fqn: any(fqn.endswith(suffix) for suffix in ["w2"])
-        )
-        quantize_(
-            model,
-            IntxWeightOnlyConfig(
-                weight_dtype=torch.int4,
-                granularity=PerAxis(0),
-            ),
-            lambda m, fqn: (
-                isinstance(m, torch.nn.Linear) 
-                and any(fqn.endswith(suffix) for suffix in ["wq", "wk", "wv", "wo", "output", "w1", "w3", "w2"])
-            ),
-        )
 
     compile_specs = CoreMLBackend.generate_compile_specs(  # pyre-fixme[16]
         minimum_deployment_target=ct.target.iOS18,
@@ -210,50 +182,165 @@ def main() -> None:
         skip_ops_for_coreml_delegation=[],
     )
 
-    input_manager = InputManager(
-        n_layers=model.params.n_layers,
-        max_batch_size=model.params.max_batch_size,
-        n_kv_heads=model.params.n_kv_heads,
-        max_seq_length=model.params.max_seq_len,
-        head_dim=model.params.head_dim,
-        use_cache_list=export_args.use_cache_list,
-        seq_length=export_args.seq_length,
-        dtype=float_dtype,
-        minus_infinity=-30000,
-        cache_size=export_args.cache_size,
-    )
-    example_inputs = input_manager.get_inputs(tokens=[0])
-
-    model = unwrap_tensor_subclass(model)
-
-    ep = torch.export.export(model, example_inputs, strict=True)
-    print("Exported program")
-    print(ep)
-
-    # ep = ep.run_decompositions({})
-    # mlprogram = ct.convert(ep, minimum_deployment_target=ct.target.iOS18)
-    # mlprogram.save("model.mlpackage")
-
-    edge_manager = to_edge_transform_and_lower(
-        ep,
-        partitioner=[partitioner],
+    executorch_config = ExecutorchBackendConfig(
+        extract_delegate_segments=True,
+        do_quant_fusion_and_const_prop=True,
+        memory_planning_pass=MemoryPlanningPass(alloc_graph_input=False),
+        sym_shape_eval_pass=ConstraintBasedSymShapeEvalPass(),
     )
 
-    print("Delegated program")
-    print(format_delegated_graph(edge_manager.exported_program().graph_module))
+    def strip_pte(name):
+        if name.endswith(".pte"):
+            return name[:-4]
+        else:
+            return name
 
-    executorch_program = edge_manager.to_executorch(
-        ExecutorchBackendConfig(
-            extract_delegate_segments=True,
-            do_quant_fusion_and_const_prop=True,
-            memory_planning_pass=MemoryPlanningPass(alloc_graph_input=False),
-            sym_shape_eval_pass=ConstraintBasedSymShapeEvalPass(),
+
+    if export_args.export_in_pieces_mode == 0:
+        model = load_model(
+            export_args.checkpoint,
+            export_args.params,
+            max_seq_length=export_args.max_seq_length,
+            use_cache_list=export_args.use_cache_list,
         )
-    )
+        input_manager = InputManager(
+            n_layers=model.params.n_layers,
+            max_batch_size=model.params.max_batch_size,
+            n_kv_heads=model.params.n_kv_heads,
+            max_seq_length=model.params.max_seq_len,
+            head_dim=model.params.head_dim,
+            use_cache_list=export_args.use_cache_list,
+            seq_length=export_args.seq_length,
+            dtype=float_dtype,
+            minus_infinity=-30000,
+            cache_size=export_args.cache_size,
+        )
+        example_inputs = input_manager.get_inputs(tokens=[0])
+        model.eval()
+        model = model.to(float_dtype)
+        print("Model", model)   
+        maybe_split_model(model)
+        print("Model after split", model)
+        maybe_quantize_model(model)
+        print("Model after quantize", model)
 
-    filename = save_pte_program(executorch_program, export_args.output_name)
-    print(f"Saved Executorch program to local {filename}")
+        ep = torch.export.export(model, example_inputs, strict=True)
+        ep = ep.run_decompositions({})
+        print("Exported program")
+        print(ep)
 
+        edge_manager = to_edge_transform_and_lower(
+            ep,
+            partitioner=[partitioner],
+        )
+
+        print("Delegated program")
+        print(format_delegated_graph(edge_manager.exported_program().graph_module))
+
+        executorch_program = edge_manager.to_executorch(executorch_config)
+        filename = save_pte_program(executorch_program, export_args.output_name)
+        print(f"Saved Executorch program to local {filename}")
+
+    else:
+        if export_args.export_in_pieces_mode == 1:
+            models, example_inputs = load_model_in_pieces_ITO(
+                export_args.checkpoint,
+                export_args.params,
+                max_seq_length=export_args.max_seq_length,
+                seq_length=export_args.seq_length,
+                float_dtype=float_dtype,
+            )
+
+            for i, model in enumerate(models):
+                if i == 0:
+                    ex_inputs = example_inputs[i]
+                    suffix = "input_block"
+                elif i == len(models) - 1:
+                    ex_inputs = example_inputs[-1]
+                    suffix = "output_block"
+                else:
+                    ex_inputs = example_inputs[1]
+                    suffix = f"transformer_block_{i-1}"
+                
+                model.eval()
+                model = model.to(float_dtype)
+                print(f"Model {i}", model)
+                maybe_split_model(model)
+                print(f"Model {i} after split", model)
+                maybe_quantize_model(model)
+                print(f"Model {i} after quantize", model)
+                ep = torch.export.export(model, ex_inputs, strict=True)
+                ep = ep.run_decompositions({})
+                print(f"Exported program for model {i}", ep)
+
+                edge_manager = to_edge_transform_and_lower(
+                    ep,
+                    partitioner=[partitioner],
+                )
+
+                print(f"Delegated program for model {i}")
+                print(format_delegated_graph(edge_manager.exported_program().graph_module))
+
+                executorch_program = edge_manager.to_executorch(executorch_config)
+                os.makedirs(f"{strip_pte(export_args.output_name)}", exist_ok=True)
+                filename = save_pte_program(executorch_program, f"{strip_pte(export_args.output_name)}/{suffix}.pte")
+                print(f"Saved Executorch program to local {filename}")
+
+
+
+        elif export_args.export_in_pieces_mode == 2:
+            models, example_inputs = load_model_in_pieces_IAFO(
+                export_args.checkpoint,
+                export_args.params,
+                max_seq_length=export_args.max_seq_length,
+                seq_length=export_args.seq_length,
+                float_dtype=float_dtype,
+            )
+
+            for i, model in enumerate(models):
+                if i == 0:
+                    ex_inputs = example_inputs[i]
+                    suffix = "input_block"
+                elif i == len(models) - 1:
+                    ex_inputs = example_inputs[-1]
+                    suffix = "output_block"
+                else:
+                    if i % 2 == 1:
+                        # AttentionBlock
+                        ex_inputs = example_inputs[1]
+                    else:
+                        # FeedForwardBlock
+                        ex_inputs = example_inputs[2]
+                    suffix = f"transformer_block_{i-1}"
+                
+
+                model.eval()
+                model = model.to(float_dtype)
+                print(f"Model {i}", model)
+                maybe_split_model(model)
+                print(f"Model {i} after split", model)
+                maybe_quantize_model(model)
+                print(f"Model {i} after quantize", model)
+                ep = torch.export.export(model, ex_inputs, strict=True)
+                ep = ep.run_decompositions({})
+                print(f"Exported program for model {i}", ep)
+
+                edge_manager = to_edge_transform_and_lower(
+                    ep,
+                    partitioner=[partitioner],
+                )
+
+                print(f"Delegated program for model {i}")
+                print(format_delegated_graph(edge_manager.exported_program().graph_module))
+
+                executorch_program = edge_manager.to_executorch(executorch_config)
+                os.makedirs(f"{strip_pte(export_args.output_name)}", exist_ok=True)
+                filename = save_pte_program(executorch_program, f"{strip_pte(export_args.output_name)}/{suffix}.pte")
+                print(f"Saved Executorch program to local {filename}")
+
+        else:
+            raise ValueError(f"Unknown export_in_pieces_mode {export_args.export_in_pieces_mode}")
+        
 
 if __name__ == "__main__":
     main()  # pragma: no cover

--- a/examples/apple/coreml/llama/llama_transformer.py
+++ b/examples/apple/coreml/llama/llama_transformer.py
@@ -34,6 +34,14 @@ def find_multiple(n: int, k: int) -> int:
     return n + k - (n % k)
 
 
+def silu_approx(x):
+    x = x.clamp(-3, 3)
+    x2 = x * x
+    x4 = x2 * x2
+    x6 = x4 * x2
+    res = 0.0017 + 0.5 * x + 0.2423  * x2 -0.0153 * x4 + 0.00057 * x6
+    return res
+
 @dataclass
 class ModelArgs:
     dim: int = 2048
@@ -108,6 +116,15 @@ class ModelArgs:
         if self.head_dim is None:
             self.head_dim = self.dim // self.n_heads
 
+def rms_norm_fp16_stable(x, eps=1e-5, min_scale=1e-3):
+    amax = x.abs().amax(dim=-1, keepdim=True)
+    scale = amax.clamp(min=min_scale)
+    x_scaled = x / scale
+
+    var = torch.square(x_scaled).mean(dim=-1, keepdim=True)
+    rms = torch.sqrt(var + eps)
+    y = x_scaled / rms
+    return y
 
 class CoreMLRMSNorm(torch.nn.Module):
     def __init__(self, dim: int, eps: float = 1e-6):
@@ -146,10 +163,11 @@ class CoreMLRMSNorm(torch.nn.Module):
         # In future, we want to add CoreML support for the functional RMSNorm op
         # We have yet to do large scale evaluations on the numeric stability of this solution, but note that
         # it appears better than what exists currently (removing FP32 casts and using FP16)
+        norm = torch.linalg.vector_norm(x, dim=-1, keepdim=True)
         rms_norm_eps0 = (
             x
-            * torch.sqrt(torch.tensor(self.dim, dtype=x.dtype))
-            * torch.reciprocal(torch.linalg.vector_norm(x, dim=-1, keepdim=True))
+            * (torch.sqrt(torch.tensor(self.dim, dtype=x.dtype)) / norm)
+            # * torch.reciprocal(torch.linalg.vector_norm(x, dim=-1, keepdim=True))
         )
         return rms_norm_eps0
 
@@ -167,40 +185,10 @@ class CoreMLRMSNorm(torch.nn.Module):
         output = self._norm(x)
         return output * self.weight
 
-class CoreMLRMSNormV2(torch.nn.Module):
-    def __init__(self, dim: int, eps: float = 1e-6):
-        """
-        Initialize the RMSNorm normalization layer.
-
-        Args:
-            dim (int): The dimension of the input tensor.
-            eps (float, optional): A small value added to the denominator for numerical stability. Default is 1e-6.
-
-        Attributes:
-            eps (float): A small value added to the denominator for numerical stability.
-            weight (nn.Parameter): Learnable scaling parameter.
-
-        """
-        super().__init__()
-        self.dim = dim
-        self.eps = eps
-        self.weight = nn.Parameter(torch.ones(dim))
-
-    def forward(self, x):
-        """
-        Apply the RMSNorm normalization to the input tensor.
-
-        Args:
-            x (torch.Tensor): The input tensor.
-
-        Returns:
-            torch.Tensor: The normalized tensor.
-
-        """
-
-        return torch.nn.functional.rms_norm(x, normalized_shape=[self.dim], weight=self.weight, eps=None)
-
 _RMS_NORM = CoreMLRMSNorm
+_DECOMPOSE_SDPA = True
+_USE_SOFTMAX = True
+_USE_SILU_APPROX = False
 
 class Rope(torch.nn.Module):
     def __init__(self, params: ModelArgs):
@@ -283,8 +271,15 @@ class FeedForward(nn.Module):
         self.w3 = nn.Linear(args.dim, hidden_dim, bias=False)
 
     def forward(self, x):
-        return self.w2(F.silu(self.w1(x)) * self.w3(x))
-
+        t1 = self.w1(x)
+        if _USE_SILU_APPROX:
+            t1 = silu_approx(t1)
+        else:
+            t1 = F.silu(t1)
+        t2 = self.w3(x)
+        out = t1 * t2
+        out = self.w2(out)
+        return out
 
 class ConditionalFeedForward(nn.Module):
     def __init__(self, args: ModelArgs):
@@ -404,9 +399,40 @@ class Attention(nn.Module):
             k = k.repeat_interleave(self.n_rep, dim=1)
             v = v.repeat_interleave(self.n_rep, dim=1)
 
-        output = torch.ops.aten.scaled_dot_product_attention.default(
-            q, k, v, attn_mask=attn_mask
-        )
+        if not _DECOMPOSE_SDPA:
+            output = torch.ops.aten.scaled_dot_product_attention.default(
+                q, k, v, attn_mask=attn_mask
+            )
+        else:
+
+            # ------------------------------
+            # Manual SDPA: matmuls + softmax
+            # q: (B, H, T_q, D)
+            # k: (B, H, T_k, D)
+            # v: (B, H, T_k, D)
+            # attn_mask: broadcastable to (B, H, T_q, T_k)
+            # ------------------------------
+            d = q.size(-1)
+            # (B, H, T_q, T_k)
+            scores = torch.matmul(q, k.transpose(-2, -1)) / (d ** 0.5)
+
+            if attn_mask is not None:
+                # attn_mask is already used this way with SDPA, keep same semantics:
+                # 0.0 for allowed, -inf for disallowed, added to scores.
+                scores = scores + attn_mask
+
+            if _USE_SOFTMAX:
+                # (B, H, T_q, T_k)
+                attn_weights = torch.softmax(scores, dim=-1)
+            else:
+                scores = scores.clamp(min=-60.0, max=60.0)
+                scores_max, _ = scores.max(dim=-1, keepdim=True)          # (B, H, T_q, 1)
+                scores_exp = torch.exp(scores - scores_max)
+                attn_weights = scores_exp / scores_exp.sum(dim=-1, keepdim=True)
+
+            # (B, H, T_q, D)
+            output = torch.matmul(attn_weights, v)
+
         output = output.transpose(1, 2).contiguous().view(bsz, seqlen, -1)
         output = self.wo(output)
         return output, new_k, new_v
@@ -439,10 +465,87 @@ class TransformerBlock(nn.Module):
         h, new_k, new_v = self.attention.forward(
             norm_emb, freqs_cos, freqs_sin, k_cache, v_cache, attn_mask
         )
-
         h = x + h
-        out = h + self.feed_forward(self.ffn_norm(h))
+        tmp = self.feed_forward(self.ffn_norm(h))
+        out = h + tmp
         return out, new_k, new_v
+
+
+
+class AttentionBlock(nn.Module):
+    def __init__(self, layer_id: int, args: ModelArgs, rope: Rope):
+        super().__init__()
+        self.n_heads = args.n_heads
+        self.dim = args.dim
+        self.head_dim = args.head_dim
+        self.attention = Attention(args, layer_id, rope)
+        self.attention_norm = _RMS_NORM(args.dim, eps=args.norm_eps)
+
+    def forward(
+        self,
+        x,
+        freqs_cos,
+        freqs_sin,
+        k_cache,
+        v_cache,
+        attn_mask,
+    ):  # x: 1xN
+        norm_emb = self.attention_norm(x)
+        h, new_k, new_v = self.attention.forward(
+            norm_emb, freqs_cos, freqs_sin, k_cache, v_cache, attn_mask
+        )
+        h = x + h
+        return h, new_k, new_v
+
+
+class FeedForwardBlock(nn.Module):
+    def __init__(self, layer_id: int, args: ModelArgs, rope: Rope):
+        super().__init__()
+        self.n_heads = args.n_heads
+        self.dim = args.dim
+        self.head_dim = args.head_dim
+        if args.moe:
+            self.block_sparse_moe = MOEFeedForward(args)
+        else:
+            self.feed_forward = FeedForward(args)
+        self.ffn_norm = _RMS_NORM(args.dim, eps=args.norm_eps)
+
+    def forward(
+        self,
+        h,
+    ):  # x: 1xN
+        tmp = self.feed_forward(self.ffn_norm(h))
+        out = h + tmp
+        return out
+
+
+
+class InputBlock(nn.Module):
+    def __init__(self, params: ModelArgs):
+        super().__init__()
+        self.rope = Rope(params)
+        self.tok_embeddings = nn.Embedding(params.vocab_size, params.dim)
+    
+    def forward(self, tokens: torch.LongTensor, input_pos: torch.LongTensor):
+        h = self.tok_embeddings(tokens)
+        seqlen = h.shape[1]
+        freqs_cos, freqs_sin = self.rope.get_freqs(input_pos, seqlen)
+        return h, freqs_cos, freqs_sin 
+
+class OutputBlock(nn.Module):
+    def __init__(self, params: ModelArgs):
+        super().__init__()
+        self.generate_full_logits = params.generate_full_logits
+        self.norm = _RMS_NORM(params.dim, eps=params.norm_eps)
+        self.output = nn.Linear(params.dim, params.vocab_size, bias=False)
+    
+    def forward(self, h, input_length: torch.LongTensor):
+        if not self.generate_full_logits:
+            # Only the last logit is used for the new generated token
+            h = h[:, input_length - 1, :].squeeze(1)
+        h = self.norm(h)
+        logits = self.output(h)
+        return logits
 
 
 class Transformer(nn.Module):
@@ -543,6 +646,166 @@ def load_model(checkpoint_path, params_path, max_seq_length, use_cache_list):
     print("Unexpected keys: ", unexpected)
 
     return model
+
+def load_model_in_pieces_ITO(checkpoint_path, params_path, max_seq_length, seq_length, float_dtype: torch.dtype = torch.float16):
+    """
+    Loads model in pieces: input, [repeating transformer], output
+    """
+    import json
+
+    with open(params_path, "r") as f:
+        params = json.loads(f.read())
+
+    args = ModelArgs(
+        max_seq_len=max_seq_length,
+        generate_full_logits=False,
+        **params,
+    )
+
+    with torch.device("meta"):
+        rope = Rope(args)
+        in_block = InputBlock(args)
+        out_block = OutputBlock(args)
+        transformer_blocks = []
+        for layer_id in range(args.n_layers):
+            transformer_blocks.append(TransformerBlock(layer_id, args, rope))
+    
+    checkpoint = torch.load(
+        checkpoint_path, map_location="cpu", mmap=True, weights_only=True
+    )
+    if "model" in checkpoint:
+        checkpoint = checkpoint["model"]
+
+    for model in [in_block, out_block]:
+        missing, unexpected = model.load_state_dict(
+            checkpoint,
+            strict=False,
+            assign=True,
+        )
+        assert len(missing) == 0
+        
+    for i, model in enumerate(transformer_blocks):
+        layer_prefix = f"layers.{i}."
+        layer_checkpoint = {k[len(layer_prefix):]:v for k, v in checkpoint.items() if k.startswith(layer_prefix)}
+        missing, unexpected = model.load_state_dict(
+            layer_checkpoint,
+            strict=False,
+            assign=True,
+        )
+        assert len(missing) == 0
+
+    cache_shape = (1, args.n_kv_heads, max_seq_length - seq_length, args.head_dim)
+    attn_mask_shape = (seq_length, max_seq_length)
+    freqs_shape = (seq_length, args.head_dim // 2)
+    h_shape = (1, seq_length, args.dim)
+
+    example_inputs = [
+        (torch.zeros(1, seq_length, dtype=torch.int64), torch.tensor([0], dtype=torch.long),), # InputBlock
+        ( # TransformerBlock
+            torch.zeros(h_shape, dtype=float_dtype), # h
+            torch.zeros(freqs_shape, dtype=float_dtype), # freqs_cos
+            torch.zeros(freqs_shape, dtype=float_dtype), # freqs_sin
+            torch.zeros(cache_shape, dtype=float_dtype), # k_cache
+            torch.zeros(cache_shape, dtype=float_dtype), # v_cache
+            torch.zeros(attn_mask_shape, dtype=float_dtype),
+        ),
+        ( # OutputBlock
+            torch.zeros(h_shape, dtype=float_dtype), # h
+            torch.tensor([0], dtype=torch.long), # input_length
+        ),
+    ]
+
+    models = [in_block] + transformer_blocks + [out_block]
+    for i in range(len(models)):
+        models[i] = models[i].to(float_dtype)
+
+    return models, example_inputs
+
+def load_model_in_pieces_IAFO(checkpoint_path, params_path, max_seq_length, seq_length, float_dtype: torch.dtype = torch.float16):
+    """
+    Loads model in pieces: input, [repeating attention, feedforward], output
+    """
+    import json
+
+    with open(params_path, "r") as f:
+        params = json.loads(f.read())
+
+    args = ModelArgs(
+        max_seq_len=max_seq_length,
+        generate_full_logits=False,
+        **params,
+    )
+
+    with torch.device("meta"):
+        rope = Rope(args)
+        in_block = InputBlock(args)
+        out_block = OutputBlock(args)
+        transformer_blocks = []
+        for layer_id in range(args.n_layers):
+            transformer_blocks.append(AttentionBlock(layer_id, args, rope))
+            transformer_blocks.append(FeedForwardBlock(layer_id, args, rope))
+
+    checkpoint = torch.load(
+        checkpoint_path, map_location="cpu", mmap=True, weights_only=True
+    )
+    if "model" in checkpoint:
+        checkpoint = checkpoint["model"]
+
+
+    for model in [in_block, out_block]:
+        missing, unexpected = model.load_state_dict(
+            checkpoint,
+            strict=False,
+            assign=True,
+        )
+        assert len(missing) == 0
+        
+
+    for i in range(len(transformer_blocks) // 2):
+        layer_prefix = f"layers.{i}."
+        layer_checkpoint = {k[len(layer_prefix):]:v for k, v in checkpoint.items() if k.startswith(layer_prefix)}
+        missing, unexpected = transformer_blocks[2*i].load_state_dict(
+            layer_checkpoint,
+            strict=False,
+            assign=True,
+        )
+        assert len(missing) == 0
+        missing, unexpected = transformer_blocks[2*i+1].load_state_dict(
+            layer_checkpoint,
+            strict=False,
+            assign=True,
+        )
+        assert len(missing) == 0
+
+    cache_shape = (1, args.n_kv_heads, max_seq_length - seq_length, args.head_dim)
+    attn_mask_shape = (seq_length, max_seq_length)
+    freqs_shape = (seq_length, args.head_dim // 2)
+    h_shape = (1, seq_length, args.dim)
+
+    example_inputs = [
+        (torch.zeros(1, seq_length, dtype=torch.int64), torch.tensor([0], dtype=torch.long),), # InputBlock
+        ( # AttentionBlock
+            torch.zeros(h_shape, dtype=float_dtype), # h
+            torch.zeros(freqs_shape, dtype=float_dtype), # freqs_cos
+            torch.zeros(freqs_shape, dtype=float_dtype), # freqs_sin
+            torch.zeros(cache_shape, dtype=float_dtype), # k_cache
+            torch.zeros(cache_shape, dtype=float_dtype), # v_cache
+            torch.zeros(attn_mask_shape, dtype=float_dtype),
+        ),
+        ( # FeedForwardBlock
+            torch.zeros(h_shape, dtype=float_dtype), # h
+        ),
+        ( # OutputBlock
+            torch.zeros(h_shape, dtype=float_dtype), # h
+            torch.tensor([0], dtype=torch.long), # input_length
+        ),
+    ]
+
+    models = [in_block] + transformer_blocks + [out_block]
+    for i in range(len(models)):
+        models[i] = models[i].to(float_dtype)
+
+    return models, example_inputs
 
 
 class InputManager:

--- a/examples/apple/coreml/llama/run.py
+++ b/examples/apple/coreml/llama/run.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import argparse
+import os
 
 import sentencepiece as spm
 
@@ -20,6 +21,139 @@ from executorch.examples.models.llama.tokenizer import tiktoken
 from executorch.runtime import Runtime
 
 
+class ModelPieceManager:
+    def __init__(self, runtime, model: str, n_layers: int, eager_model_pieces=None, use_eager=False):
+        self.use_eager = use_eager
+        self.n_layers = n_layers
+        self.input_proj_method = runtime.load_program(f"{model}/input_block.pte").load_method("forward")
+        self.output_proj_method = runtime.load_program(f"{model}/output_block.pte").load_method("forward")
+        self.layer_methods = []
+
+        max_batch_size = None
+        n_kv_heads = None
+        cache_size = None
+        head_dim = None
+        seq_length = None
+        max_seq_length = None
+        float_dtype = None
+
+        for i in range(n_layers):
+            method = runtime.load_program(f"{model}/transformer_block_{i}.pte").load_method("forward")
+            self.layer_methods.append(method)
+            if i == 0:
+                metadata = method.metadata
+                print("Method metadata (piece 0): ", metadata, "\n\n")
+                assert metadata.num_inputs() == 6
+
+                # k_cache input
+                max_batch_size, n_kv_heads, cache_size, head_dim = metadata.input_tensor_meta(3).sizes()
+                float_dtype = {5: torch.float16, 6: torch.float32}[metadata.input_tensor_meta(3).dtype()]
+
+                # mask input
+                seq_length, max_seq_length = metadata.input_tensor_meta(5).sizes()
+
+        self.max_batch_size = max_batch_size
+        self.n_kv_heads = n_kv_heads
+        self.head_dim = head_dim
+        self.cache_size = cache_size
+        self.seq_length = seq_length
+        self.max_seq_length = max_seq_length
+        self.float_dtype = float_dtype
+        self.eager_model_pieces = eager_model_pieces
+
+    def run(self, runtime, inputs):
+        """
+        Run the piecewise model.
+
+        inputs: (tokens, input_pos, input_length, k_caches, v_caches, attn_mask)
+        returns: (logits, new_k_caches, new_v_caches)
+        """
+        tokens, input_pos, input_length, k_caches, v_caches, attn_mask = inputs
+
+        # Input block
+        h, freqs_cos, freqs_sin = self.input_proj_method.execute((tokens, input_pos))
+
+        if self.eager_model_pieces is not None:
+            h_eager, freqs_cos_eager, freqs_sin_eager = self.eager_model_pieces[0].forward(tokens, input_pos)
+            assert torch.allclose(h, h_eager, atol=1e-4)
+            assert torch.allclose(freqs_cos, freqs_cos_eager, atol=1e-4)
+            assert torch.allclose(freqs_sin, freqs_sin_eager, atol=1e-4)
+            rmse = torch.sqrt(torch.mean((h - h_eager) ** 2))
+            print("RMSE h (input_block)", rmse)
+            rmse = torch.sqrt(torch.mean((freqs_cos - freqs_cos_eager) ** 2))
+            print("RMSE freqs_cos (input_block)", rmse)
+            rmse = torch.sqrt(torch.mean((freqs_sin - freqs_sin_eager) ** 2))
+            print("RMSE freqs_sin (input_block)", rmse)
+
+            if self.use_eager:
+                h = h_eager
+                freqs_cos = freqs_cos_eager
+                freqs_sin = freqs_sin_eager
+
+        new_ks = []
+        new_vs = []
+
+        # Transformer blocks
+        for i in range(self.n_layers):
+            method = self.layer_methods[i]
+            h_new, new_k, new_v = method.execute((h, freqs_cos, freqs_sin, k_caches[i], v_caches[i], attn_mask))
+
+            if self.eager_model_pieces is not None:
+                print("CHECK LAYER", i)
+                h_eager, new_k_eager, new_v_eager = self.eager_model_pieces[i + 1].forward(
+                    h, freqs_cos, freqs_sin, k_caches[i], v_caches[i], attn_mask
+                )
+
+                rmse_h = torch.sqrt(torch.mean((h_new - h_eager) ** 2))
+                print(
+                    "RMSE h",
+                    rmse_h,
+                    torch.max(h_eager),
+                    torch.min(h_eager),
+                    torch.quantile(h_eager.to(torch.float32), torch.tensor([0.1, 0.25, 0.5, 0.74, 0.9])),
+                )
+
+                rmse_k = torch.sqrt(torch.mean((new_k - new_k_eager) ** 2))
+                print(
+                    "RMSE new_k",
+                    rmse_k,
+                    torch.quantile(new_k_eager.to(torch.float32), torch.tensor([0.1, 0.25, 0.5, 0.74, 0.9])),
+                )
+
+                rmse_v = torch.sqrt(torch.mean((new_v - new_v_eager) ** 2))
+                print(
+                    "RMSE new_v",
+                    rmse_v,
+                    torch.quantile(new_v_eager.to(torch.float32), torch.tensor([0.1, 0.25, 0.5, 0.74, 0.9])),
+                )
+
+                if self.use_eager:
+                    h_new = h_eager
+                    new_k = new_k_eager
+                    new_v = new_v_eager
+
+            h = h_new
+            new_ks.append(new_k)
+            new_vs.append(new_v)
+
+        # Output block – this should return logits
+        logits, = self.output_proj_method.execute((h, input_length))
+
+        if self.eager_model_pieces is not None:
+            logits_eager = self.eager_model_pieces[-1].forward(h, input_length)
+            rmse_out = torch.sqrt(torch.mean((logits - logits_eager) ** 2))
+            print(
+                "RMSE logits OUT",
+                rmse_out,
+                torch.max(logits_eager),
+                torch.min(logits_eager),
+            )
+            if self.use_eager:
+                logits = logits_eager
+
+        return logits, new_ks, new_vs
+
+
 class Tokenizer:
     def __init__(self, model_path: str):
         # Try sentence piece
@@ -28,7 +162,7 @@ class Tokenizer:
             sp = spm.SentencePieceProcessor()
             sp.load(model_path)
             self.tokenizer = sp
-        except:
+        except Exception:
             print("Trying to load tiktoken")
             self.tokenizer = tiktoken.Tokenizer(model_path)
 
@@ -55,7 +189,7 @@ def main() -> None:
     parser.add_argument(
         "-m",
         "--model",
-        help="model.pte",
+        help="Either a single model.pte OR a directory containing input_block.pte / transformer_block_*.pte / output_block.pte",
     )
     parser.add_argument(
         "-t",
@@ -115,60 +249,98 @@ def main() -> None:
     tokenizer = Tokenizer(args.tokenizer)
 
     runtime = Runtime.get()
-    if args.use_eager:
-        assert args.params is not None
-        assert args.checkpoint is not None
-        assert args.dtype is not None
-        assert args.max_seq_length is not None
-        assert args.seq_length is not None
 
-        max_seq_length = args.max_seq_length
-        seq_length = args.seq_length
-        model = load_model(
-            args.checkpoint,
-            args.params,
-            max_seq_length=max_seq_length,
-            use_cache_list=False,
+    # These will be set depending on monolithic vs pieces
+    model = None
+    method = None
+    piece_manager = None
+
+    n_layers = None
+    max_batch_size = None
+    n_kv_heads = None
+    cache_size = args.cache_size
+    head_dim = None
+    seq_length = None
+    max_seq_length = None
+    float_dtype = None
+
+    ### PIECES: detect directory of piecewise exports
+    if os.path.isdir(args.model):
+        # Infer number of layers from transformer_block_*.pte files
+        n_layers = 0
+        while os.path.exists(os.path.join(args.model, f"transformer_block_{n_layers}.pte")):
+            n_layers += 1
+        if n_layers == 0:
+            raise RuntimeError(f"No transformer_block_*.pte found in directory: {args.model}")
+
+        print(f"Detected piecewise model with {n_layers} layers")
+
+        piece_manager = ModelPieceManager(
+            runtime=runtime,
+            model=args.model,
+            n_layers=n_layers,
+            eager_model_pieces=None,  # wire in eager pieces if/when you want debugging
+            use_eager=args.use_eager,
         )
-        n_layers = model.params.n_layers
-        max_batch_size = model.params.max_batch_size
-        n_kv_heads = model.params.n_kv_heads
-        head_dim = model.params.head_dim
-        cache_size = args.cache_size
 
-        float_dtype = {"fp16": torch.float16, "fp32": torch.float32}[
-            args.dtype
-        ]  # dtype for model/inputs
-        model.eval()
-        model.to(float_dtype)
+        # Pull shapes/dtype from piece manager
+        max_batch_size = piece_manager.max_batch_size
+        n_kv_heads = piece_manager.n_kv_heads
+        cache_size = piece_manager.cache_size
+        head_dim = piece_manager.head_dim
+        seq_length = piece_manager.seq_length
+        max_seq_length = piece_manager.max_seq_length
+        float_dtype = piece_manager.float_dtype
+
     else:
-        program = runtime.load_program(args.model)
-        method = program.load_method("forward")
+        # Original monolithic path
+        if args.use_eager:
+            assert args.params is not None
+            assert args.checkpoint is not None
+            assert args.dtype is not None
+            assert args.max_seq_length is not None
+            assert args.seq_length is not None
 
-        metadata = method.metadata
-        print("Method metadata: ", metadata, "\n\n")
+            max_seq_length = args.max_seq_length
+            seq_length = args.seq_length
+            model = load_model(
+                args.checkpoint,
+                args.params,
+                max_seq_length=max_seq_length,
+                use_cache_list=False,
+            )
+            n_layers = model.params.n_layers
+            max_batch_size = model.params.max_batch_size
+            n_kv_heads = model.params.n_kv_heads
+            head_dim = model.params.head_dim
 
-        assert (
-            metadata.num_inputs() == 6
-        ), "Do not export with --use_cache_list for use in pybindings"
-        # k_cache input
-        n_layers, max_batch_size, n_kv_heads, cache_size, head_dim = (
-            metadata.input_tensor_meta(3).sizes()
-        )
-        float_dtype = {5: torch.float16, 6: torch.float32}[
-            metadata.input_tensor_meta(3).dtype()
-        ]
+            float_dtype = {"fp16": torch.float16, "fp32": torch.float32}[args.dtype]
+            model.eval()
+            model.to(float_dtype)
+        else:
+            program = runtime.load_program(args.model)
+            method = program.load_method("forward")
 
-        # mask input
-        seq_length, max_seq_length = metadata.input_tensor_meta(5).sizes()
+            metadata = method.metadata
+            print("Method metadata: ", metadata, "\n\n")
 
+            assert metadata.num_inputs() == 6, "Do not export with --use_cache_list for use in pybindings"
+
+            # k_cache input
+            n_layers, max_batch_size, n_kv_heads, cache_size, head_dim = metadata.input_tensor_meta(3).sizes()
+            float_dtype = {5: torch.float16, 6: torch.float32}[metadata.input_tensor_meta(3).dtype()]
+
+            # mask input
+            seq_length, max_seq_length = metadata.input_tensor_meta(5).sizes()
+
+    # Common InputManager setup
     input_manager = InputManager(
         n_layers=n_layers,
         max_batch_size=max_batch_size,
         n_kv_heads=n_kv_heads,
         max_seq_length=max_seq_length,
         head_dim=head_dim,
-        use_cache_list=False,
+        use_cache_list=piece_manager is not None,
         seq_length=seq_length,
         dtype=float_dtype,
         minus_infinity=-30000.0,
@@ -178,21 +350,19 @@ def main() -> None:
     print(args.prompt, end="")
     tokens = tokenizer.encode(args.prompt, bos=True, eos=False)
     while input_manager.input_pos + seq_length < max_seq_length:
-        while len(tokens) > 0 and (
-            input_manager.input_pos + seq_length < max_seq_length
-        ):
-            inputs, remaining_tokens = input_manager.get_inputs_and_remaining_tokens(
-                tokens
-            )
+        while len(tokens) > 0 and (input_manager.input_pos + seq_length < max_seq_length):
+            inputs, remaining_tokens = input_manager.get_inputs_and_remaining_tokens(tokens)
             processed_tokens = len(tokens) - len(remaining_tokens)
-            if args.use_eager:
+
+            ### PIECES: choose correct execution path
+            if piece_manager is not None:
+                logits, k, v = piece_manager.run(runtime, inputs)
+            elif args.use_eager:
                 logits, k, v = model(*inputs)
             else:
                 logits, k, v = method.execute(inputs)
 
-            input_manager.update(
-                input_length=processed_tokens, new_k_caches=k, new_v_caches=v
-            )
+            input_manager.update(input_length=processed_tokens, new_k_caches=k, new_v_caches=v)
             tokens = remaining_tokens
 
         tokens = [next_token(logits, args.temperature, args.top_p)]

--- a/examples/apple/coreml/llama/utils.py
+++ b/examples/apple/coreml/llama/utils.py
@@ -91,10 +91,15 @@ class SplitLinearModule(torch.nn.Module):
 
 
 def replace_linear_with_split_linear(
-    model, out_target_split_size, out_max_splits, in_target_split_size, in_max_splits=1
+    model, out_target_split_size, out_max_splits, in_target_split_size, in_max_splits=1, fqn_filer=None,
 ):
+    if fqn_filer is None:
+        fqn_filer = lambda fqn: True
+
     for name, module in model.named_children():
-        if isinstance(module, torch.nn.Linear):
+        should_split = isinstance(module, torch.nn.Linear) and fqn_filer(name)
+        print("TESTING", name, "WILL SPLIT", should_split)
+        if should_split:
             assert module.bias is None, "SplitLinearModule does not support bias"
             new_module = SplitLinearModule(
                 module.in_features,
@@ -113,4 +118,5 @@ def replace_linear_with_split_linear(
                 out_max_splits,
                 in_target_split_size,
                 in_max_splits,
+                fqn_filer,
             )

--- a/examples/apple/coreml/scripts/extract_coreml_models.py
+++ b/examples/apple/coreml/scripts/extract_coreml_models.py
@@ -21,7 +21,7 @@ from executorch.exir.schema import (
 
 
 def extract_coreml_models(pte_data: bytes):
-    program = deserialize_pte_binary(pte_data)
+    program = deserialize_pte_binary(pte_data).program
     delegates: List[BackendDelegate] = sum(
         [execution_plan.delegates for execution_plan in program.execution_plan], []
     )


### PR DESCRIPTION
Here we do experiments to see why iOS26 produces bad numerics (see https://github.com/pytorch/executorch/issues/15833).

Export with:

```
 python export.py -n model2.pte -p $HOME/models/llama1b/params.json -c $HOME/models/llama1b/llama1b.pth --seq_length 16 --max_seq_length 512 --dtype fp16 --coreml-quantize custom &> log.txt
```

Run with:
```
python run.py -m model2.pte -t $HOME/models/llama1b/tokenizer.model --prompt "Once upon a time,"
```

What we've found:
* Quantizing embeddings seems to lead to bad results on iOS26
* Using CoreMLRMSNorm instead of RMSNorm produces better numerics in FP16 on iOS26
* Quantizing q, k, v, o, and lm_head on iOS26 seems OK
* Quantizing w1, w1, or w3 on iOS26 leads to bad numerics.  It seems to be related to the 8096 matrix size.  If we use in/out feature splitting on those linear layers, we can recover good numerics.


Even after all of the above changes, on my mac CoreML is scheduling this model to run on CPU.  Have yet to try on iPhone.


**Update:**

We can quantize everything with somewhat OK text generation if we decompose SDPA into matmuls + softmax.  So the key changes are the following settings in llama_transformer.py:
```
_RMS_NORM = CoreMLRMSNorm
_DECOMPOSE_SDPA = True
_USE_SOFTMAX = True
_USE_SILU_APPROX = False
```


Repro commands:

Export as one model:

```
python export.py -n model2.pte -p $HOME/models/llama1b/params.json -c $HOME/models/llama1b/llama1b.pth --seq_length 16 --max_seq_length 512 --dtype fp16 --coreml-quantize c4w -E "8,0" --target_split_size 1024 --max_splits 8 --export_in_pieces_mode 0 &> log.txt
python run.py -m model2.pte -t $HOME/models/llama1b/tokenizer.model --prompt "Once upon a time,"
```

Export as collection of models:
```
python export.py -n model2.pte -p $HOME/models/llama1b/params.json -c $HOME/models/llama1b/llama1b.pth --seq_length 16 --max_seq_length 512 --dtype fp16 --coreml-quantize c4w -E "8,0" --export_in_pieces_mode 1 &> log.txt
python run.py -m model2 -t $HOME/models/llama1b/tokenizer.model --prompt "Once upon a time,"
```
