### PR TITLE
Custom op to update cache for torch.cond

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -404,6 +404,17 @@ target_compile_definitions(
   executorch_core PUBLIC C10_USING_CUSTOM_GENERATED_MACROS
 )
 target_compile_options(executorch_core PUBLIC ${_common_compile_options})
+
+# Link CUDA runtime when available so core sources (e.g., tensor_utils_portable)
+# can call cuda APIs under CUDA_AVAILABLE.
+if(EXECUTORCH_BUILD_CUDA)
+  find_package(CUDAToolkit QUIET)
+  if(CUDAToolkit_FOUND)
+    target_link_libraries(executorch_core PUBLIC CUDA::cudart)
+    target_compile_definitions(executorch_core PRIVATE CUDA_AVAILABLE)
+  endif()
+endif()
+
 if(MAX_KERNEL_NUM)
   target_compile_definitions(
     executorch_core PRIVATE MAX_KERNEL_NUM=${MAX_KERNEL_NUM}

--- a/Makefile
+++ b/Makefile
@@ -87,21 +87,22 @@
 #
 # ==============================================================================
 
-.PHONY: voxtral-cuda voxtral-cpu voxtral-metal whisper-cuda whisper-cpu whisper-metal llama-cpu llava-cpu gemma3-cuda gemma3-cpu clean help
+.PHONY: voxtral-cuda voxtral-cpu voxtral-metal whisper-cuda whisper-debug-cuda whisper-cpu whisper-metal llama-cpu llava-cpu gemma3-cuda gemma3-cpu clean help
 
 help:
-	@echo "This Makefile adds targets to build runners for various models on various backends. Run using `make <target>`. Available targets:"
-	@echo "  voxtral-cuda   - Build Voxtral runner with CUDA backend"
-	@echo "  voxtral-cpu    - Build Voxtral runner with CPU backend"
-	@echo "  voxtral-metal  - Build Voxtral runner with Metal backend (macOS only)"
-	@echo "  whisper-cuda   - Build Whisper runner with CUDA backend"
-	@echo "  whisper-cpu    - Build Whisper runner with CPU backend"
-	@echo "  whisper-metal  - Build Whisper runner with Metal backend (macOS only)"
-	@echo "  llama-cpu      - Build Llama runner with CPU backend"
-	@echo "  llava-cpu      - Build Llava runner with CPU backend"
-	@echo "  gemma3-cuda    - Build Gemma3 runner with CUDA backend"
-	@echo "  gemma3-cpu     - Build Gemma3 runner with CPU backend"
-	@echo "  clean          - Clean build artifacts"
+	@echo "This Makefile adds targets to build runners for various models on various backends. Run using \`make <target>\`. Available targets:"
+	@echo "  voxtral-cuda            - Build Voxtral runner with CUDA backend"
+	@echo "  voxtral-cpu             - Build Voxtral runner with CPU backend"
+	@echo "  voxtral-metal           - Build Voxtral runner with Metal backend (macOS only)"
+	@echo "  whisper-cuda            - Build Whisper runner with CUDA backend"
+	@echo "  whisper-debug-cuda      - Build Whisper runner with CUDA backend (debug mode)"
+	@echo "  whisper-cpu             - Build Whisper runner with CPU backend"
+	@echo "  whisper-metal           - Build Whisper runner with Metal backend (macOS only)"
+	@echo "  llama-cpu               - Build Llama runner with CPU backend"
+	@echo "  llava-cpu               - Build Llava runner with CPU backend"
+	@echo "  gemma3-cuda             - Build Gemma3 runner with CUDA backend"
+	@echo "  gemma3-cpu              - Build Gemma3 runner with CPU backend"
+	@echo "  clean                   - Clean build artifacts"
 
 voxtral-cuda:
 	@echo "==> Building and installing ExecuTorch with CUDA..."
@@ -135,6 +136,15 @@ whisper-cuda:
 	cmake --workflow --preset llm-release-cuda
 	@echo "==> Building Whisper runner with CUDA..."
 	cd examples/models/whisper && cmake --workflow --preset whisper-cuda
+	@echo ""
+	@echo "✓ Build complete!"
+	@echo "  Binary: cmake-out/examples/models/whisper/whisper_runner"
+
+whisper-debug-cuda:
+	@echo "==> Building and installing ExecuTorch with CUDA (debug mode)..."
+	cmake --workflow --preset llm-debug-cuda
+	@echo "==> Building Whisper runner with CUDA (debug mode)..."
+	cd examples/models/whisper && cmake --workflow --preset whisper-debug-cuda
 	@echo ""
 	@echo "✓ Build complete!"
 	@echo "  Binary: cmake-out/examples/models/whisper/whisper_runner"

--- a/backends/aoti/aoti_delegate_handle.h
+++ b/backends/aoti/aoti_delegate_handle.h
@@ -85,6 +85,7 @@ struct AOTIDelegateHandle {
   AOTInductorModelContainerHandle container_handle;
   void* cuda_stream; // cudaStream_t stored as void* to avoid CUDA header
                      // dependency
+  bool owns_stream{true};
 
   // Function pointers specific to this handle's shared library
   AOTInductorModelContainerCreateWithDeviceFunc create_with_device;

--- a/backends/aoti/common_shims.h
+++ b/backends/aoti/common_shims.h
@@ -59,11 +59,18 @@ aoti_torch_get_device_index(Tensor* tensor, int32_t* ret_device_index);
 AOTI_SHIM_EXPORT AOTITorchError
 aoti_torch_get_dim(Tensor* tensor, int64_t* ret_dim);
 
+// Device type query (optional; backends may implement this to return device
+// type constants such as CUDA). Declared here so common shims can dispatch
+// appropriately.
+AOTI_SHIM_EXPORT AOTITorchError
+aoti_torch_get_device_type(Tensor* tensor, int32_t* ret_device_type);
+
 // Utility functions for device and layout information
 AOTI_SHIM_EXPORT int32_t aoti_torch_device_type_cpu();
 AOTI_SHIM_EXPORT int32_t aoti_torch_layout_strided();
 AOTI_SHIM_EXPORT int32_t aoti_torch_dtype_float32();
 AOTI_SHIM_EXPORT int32_t aoti_torch_dtype_bfloat16();
+AOTI_SHIM_EXPORT int32_t aoti_torch_dtype_bool();
 AOTI_SHIM_EXPORT int32_t aoti_torch_dtype_int8();
 AOTI_SHIM_EXPORT int32_t aoti_torch_dtype_int16();
 AOTI_SHIM_EXPORT int32_t aoti_torch_dtype_int32();

--- a/backends/cuda/cuda_backend.py
+++ b/backends/cuda/cuda_backend.py
@@ -10,6 +10,9 @@ from typing import Any, Dict, final, List
 
 import torch
 from executorch.backends.aoti.aoti_backend import AotiBackend
+from executorch.backends.cuda.passes.keep_cond_predicate_on_cpu import (
+    KeepCondPredicateOnCpuPass,
+)
 from executorch.backends.cuda.triton.replacement_pass import (
     ReplaceEdgeOpWithTritonOpPass,
 )
@@ -49,7 +52,7 @@ class CudaBackend(AotiBackend, BackendDetails):
     @classmethod
     def get_custom_passes(cls) -> List[typing.Any]:
         """Return CUDA-specific passes: ReplaceEdgeOpWithTritonOpPass"""
-        return [ReplaceEdgeOpWithTritonOpPass()]
+        return [KeepCondPredicateOnCpuPass(), ReplaceEdgeOpWithTritonOpPass()]
 
     @classmethod
     def get_aoti_compile_options(

--- a/backends/cuda/passes/keep_cond_predicate_on_cpu.py
+++ b/backends/cuda/passes/keep_cond_predicate_on_cpu.py
@@ -1,0 +1,62 @@
+import torch
+from torch.export import ExportedProgram
+
+
+class KeepCondPredicateOnCpuPass:
+    """
+    A pass that locates torch.cond in the graph and makes sure the predicate stays on CPU
+    if the predicate is a buffer (placeholder).
+    """
+
+    requires_exported_program = True
+
+    def __call__(self, exported_program: ExportedProgram):
+        graph_module = exported_program.graph_module
+        state_dict = exported_program.state_dict
+
+        # Map input names to buffer names
+        inputs_to_buffers = exported_program.graph_signature.inputs_to_buffers
+
+        for node in graph_module.graph.nodes:
+            if (
+                node.op == "call_function"
+                and node.target == torch.ops.higher_order.cond
+            ):
+                pred_node = node.args[0]
+                if pred_node.op == "placeholder":
+                    # Found a placeholder used as predicate
+                    # Check if it corresponds to a buffer
+                    if pred_node.name in inputs_to_buffers:
+                        buffer_name = inputs_to_buffers[pred_node.name]
+
+                        # Move the buffer in state_dict to CPU
+                        if buffer_name in state_dict:
+                            # We modify the tensor in place or replace it?
+                            # Replacing it is safer.
+                            tensor = exported_program.state_dict[buffer_name]
+                            if tensor.device.type != "cpu":
+                                if isinstance(tensor, torch.nn.Parameter):
+                                    exported_program._state_dict[buffer_name] = (
+                                        torch.nn.Parameter(
+                                            tensor.to("cpu"),
+                                            tensor.requires_grad,
+                                        )
+                                    )
+                                else:
+                                    exported_program._state_dict[buffer_name] = (
+                                        tensor.to("cpu")
+                                    )
+
+                        if buffer_name in exported_program.constants:
+                            tensor = exported_program._constants[buffer_name]
+                            if tensor.device.type != "cpu":
+                                exported_program._constants[buffer_name] = tensor.to(
+                                    "cpu"
+                                )
+
+                        # Also update the placeholder metadata
+                        if "val" in pred_node.meta:
+                            fake_tensor = pred_node.meta["val"]
+                            if isinstance(fake_tensor, torch.Tensor):
+                                pred_node.meta["val"] = fake_tensor.to("cpu")
+        exported_program.validate()

--- a/backends/cuda/runtime/shims/memory.h
+++ b/backends/cuda/runtime/shims/memory.h
@@ -161,9 +161,30 @@ aoti_torch_copy_(Tensor* self, Tensor* src, int32_t non_blocking);
  * @return Error::Ok on success, appropriate error code on failure:
  *         - Error::InvalidArgument: null pointers or invalid parameters
  */
-AOTITorchError aoti_torch_new_tensor_handle(
-    Tensor* orig_handle,
-    Tensor** new_handle);
+AOTI_SHIM_EXPORT AOTITorchError
+aoti_torch_new_tensor_handle(Tensor* orig_handle, Tensor** new_handle);
+
+// Function to retrieve boolean value from a 0D boolean tensor
+AOTI_SHIM_EXPORT AOTITorchError
+aoti_torch_item_bool(Tensor* tensor, bool* ret_value);
+
+/**
+ * Reinterprets the destination tensor to be a view of the source tensor's
+ * data.
+ *
+ * This function makes the destination tensor a view of the source tensor's
+ * underlying data, but with the destination tensor's original shape and
+ * strides. The number of elements in both tensors must match. The destination
+ * tensor handle will be updated to point to a new tensor view.
+ *
+ * @param src The source tensor providing the data.
+ * @param ret_dst On input, a pointer to the destination tensor. On output,
+ * this will be updated to point to the new tensor view.
+ *
+ * @return Error::Ok on success, appropriate error code on failure.
+ */
+AOTI_SHIM_EXPORT AOTITorchError
+aoti_torch_assign_tensors_out(Tensor* src, Tensor** ret_dst);
 
 // Function to clear all tensors from internal storage
 AOTI_SHIM_EXPORT void clear_all_tensors();

--- a/backends/cuda/tests/test_keep_cond_predicate_on_cpu.py
+++ b/backends/cuda/tests/test_keep_cond_predicate_on_cpu.py
@@ -1,0 +1,69 @@
+import unittest
+
+import torch
+from executorch.backends.cuda.passes.keep_cond_predicate_on_cpu import (
+    KeepCondPredicateOnCpuPass,
+)
+from torch.export import export
+
+
+class TestKeepCondPredicateOnCpuPass(unittest.TestCase):
+    def test_keep_cond_predicate_on_cpu(self):
+        # Define a simple model using torch.cond
+        class Model(torch.nn.Module):
+            def forward(self, pred, x, y):
+                def true_fn(x, y):
+                    return x + y
+
+                def false_fn(x, y):
+                    return x - y
+
+                return torch.cond(pred, true_fn, false_fn, [x, y])
+
+        model = Model()
+        pred = torch.tensor(True)
+        x = torch.randn(2, 2)
+        y = torch.randn(2, 2)
+
+        # Export the model
+        ep = export(model, (pred, x, y))
+        gm = ep.graph_module
+
+        # Simulate move_to_device_pass by setting all placeholders to cuda using FakeTensorMode
+        # We need to be careful not to trigger CUDA init
+        from unittest.mock import MagicMock
+
+        for node in gm.graph.nodes:
+            if node.op == "placeholder":
+                if "val" in node.meta:
+                    # Use MagicMock to simulate a tensor on cuda
+                    val = MagicMock(spec=torch.Tensor)
+                    val.device = torch.device("cuda")
+
+                    def to_side_effect(device):
+                        new_val = MagicMock(spec=torch.Tensor)
+                        new_val.device = torch.device(device)
+                        return new_val
+
+                    val.to.side_effect = to_side_effect
+                    node.meta["val"] = val
+
+        # Verify that pred is on cuda
+        pred_node = list(gm.graph.nodes)[0]
+        self.assertEqual(pred_node.meta["val"].device.type, "cuda")
+
+        # Run the pass
+        pass_instance = KeepCondPredicateOnCpuPass()
+        pass_instance(gm)
+
+        # Verify that pred is back on cpu
+        self.assertEqual(pred_node.meta["val"].device.type, "cpu")
+
+        # Verify other nodes are still on cuda (if they were)
+        # The second node is x
+        x_node = list(gm.graph.nodes)[1]
+        self.assertEqual(x_node.meta["val"].device.type, "cuda")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/models/whisper/CMakePresets.json
+++ b/examples/models/whisper/CMakePresets.json
@@ -29,6 +29,20 @@
             }
         },
         {
+            "name": "whisper-debug-cuda",
+            "displayName": "Whisper runner (CUDA Debug)",
+            "inherits": ["whisper-base"],
+            "cacheVariables": {
+                "EXECUTORCH_BUILD_CUDA": "ON",
+                "CMAKE_BUILD_TYPE": "Debug"
+            },
+            "condition": {
+                "lhs": "${hostSystemName}",
+                "type": "equals",
+                "rhs": "Linux"
+            }
+        },
+        {
             "name": "whisper-metal",
             "displayName": "Whisper runner (Metal)",
             "inherits": ["whisper-base"],
@@ -53,6 +67,12 @@
             "name": "whisper-cuda",
             "displayName": "Build Whisper runner (CUDA)",
             "configurePreset": "whisper-cuda",
+            "targets": ["whisper_runner"]
+        },
+        {
+            "name": "whisper-debug-cuda",
+            "displayName": "Build Whisper runner (CUDA Debug)",
+            "configurePreset": "whisper-debug-cuda",
             "targets": ["whisper_runner"]
         },
         {
@@ -88,6 +108,20 @@
                 {
                     "type": "build",
                     "name": "whisper-cuda"
+                }
+            ]
+        },
+        {
+            "name": "whisper-debug-cuda",
+            "displayName": "Configure and build Whisper runner (CUDA Debug)",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "whisper-debug-cuda"
+                },
+                {
+                    "type": "build",
+                    "name": "whisper-debug-cuda"
                 }
             ]
         },

--- a/examples/models/whisper/main.cpp
+++ b/examples/models/whisper/main.cpp
@@ -109,6 +109,7 @@ int main(int argc, char** argv) {
   executorch::extension::asr::AsrTranscribeConfig config;
   config.max_new_tokens = FLAGS_max_new_tokens;
   config.temperature = static_cast<float>(FLAGS_temperature);
+  config.use_cuda_sampler = true;
 
   // All Whisper models from HuggingFace now use the v3 tokenizer format
   // where token 50257 = <|endoftext|> and token 50258 = <|startoftranscript|>

--- a/exir/passes/remove_mixed_type_operators.py
+++ b/exir/passes/remove_mixed_type_operators.py
@@ -61,7 +61,7 @@ class RemoveMixedTypeOperators(ExportPass):
             elif isinstance(arg, torch.Tensor):
                 arg_tensor.append(arg)
             else:
-                arg_tensor.append(arg.data)
+                arg_tensor.append(torch.tensor(arg))
         arg_tensor = tuple(arg_tensor)
 
         # Computes type for computation

--- a/extension/asr/runner/CMakeLists.txt
+++ b/extension/asr/runner/CMakeLists.txt
@@ -35,6 +35,15 @@ set_target_properties(
   extension_asr_runner PROPERTIES POSITION_INDEPENDENT_CODE ON
 )
 
+# Propagate CUDA availability to the ASR runner so it can select CUDA paths.
+if(EXECUTORCH_BUILD_CUDA)
+  find_package(CUDAToolkit QUIET)
+  if(CUDAToolkit_FOUND)
+    target_compile_definitions(extension_asr_runner PUBLIC CUDA_AVAILABLE)
+    target_link_libraries(extension_asr_runner PUBLIC CUDA::cudart)
+  endif()
+endif()
+
 install(
   TARGETS extension_asr_runner
   EXPORT ExecuTorchTargets

--- a/extension/llm/custom_ops/custom_ops.py
+++ b/extension/llm/custom_ops/custom_ops.py
@@ -16,6 +16,12 @@ import torch
 
 from torch.library import impl
 
+aten = torch.ops.aten
+
+from typing import Tuple
+
+from torch._inductor.lowering import lowerings as L, register_lowering
+
 try:
     op = torch.ops.llama.sdpa_with_kv_cache.default
     assert op is not None
@@ -387,3 +393,89 @@ def custom_quantized_sdpa_meta(
     )
 
     return torch.empty(query.size(), dtype=torch.float32, device="meta")
+
+
+# 1) Define the custom op in the "executorch" namespace with name "alias"
+@torch.library.custom_op("executorch::alias", mutates_args=())
+def custom_alias(x: torch.Tensor, y: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Runtime implementation: just return the inputs as-is.
+    Works for both CPU and CUDA tensors because we don't do
+    any device-specific work here.
+    """
+    # no copies, just pass-through
+    return x, y
+
+
+# 2) FakeTensor kernel: describes output metadata for compile-time
+@custom_alias.register_fake
+def _(x, y):
+    # For this op, outputs have exactly the same shape/dtype/device as inputs.
+    # We just need *dummy* tensors with that metadata.
+    out_x = torch.empty_like(x)
+    out_y = torch.empty_like(y)
+    return out_x, out_y
+
+
+@register_lowering(torch.ops.executorch.alias.default)
+def lowering_custom_alias(x, y):
+    # x, y here are IR values (Inductor's internal representation).
+    # Alias is logically a no-op – just pass them through.
+    return x, y
+
+
+# Expecting cache shape: (B, H, S_max, D), value shape (B, H, S, D) where S <= S_max
+def _validate_cross_attn_cache_params(value: torch.Tensor, cache: torch.Tensor):
+    torch._assert(value.dim() == 4, "value must be 4D")
+    torch._assert(cache.dim() == 4, "cache must be 4D")
+    # Cache shape: (B, H, S_max, D)
+    # Value shape: (B, H, S, D)
+    torch._assert(
+        value.size(2) <= cache.size(2),
+        f"value sequence length {value.size(2)} exceeds cache size {cache.size(2)}",
+    )
+    torch._assert(value.size(0) == cache.size(0), "batch size mismatch")
+    torch._assert(value.size(1) == cache.size(1), "num heads mismatch")
+    torch._assert(value.size(3) == cache.size(3), "head dim mismatch")
+    torch._assert(value.dtype == cache.dtype, "dtype mismatch")
+
+
+# This is cheating: we delibrately NOT mark `cache` to be mutating so that this
+# custom op can be used in HOP such as `torch.cond`, where `torch.compile` requires
+# no aliasing or mutation in the branches. This is fine because we only care about inference.
+@torch.library.custom_op("executorch::update_cross_attn_cache", mutates_args=[])
+def _update_cross_attn_cache(value: torch.Tensor, cache: torch.Tensor) -> torch.Tensor:
+    # Eager implementation
+    _validate_cross_attn_cache_params(value, cache)
+
+    # Slice the cache to match value's sequence length and copy
+    # cache shape: [B, H, S_max, D]
+    # value shape: [B, H, S, D]
+    cache[:, :, : value.size(2), :].copy_(value)
+    return cache
+
+
+# Register the fake (meta) kernel
+@_update_cross_attn_cache.register_fake
+def _update_cross_attn_cache_fake(
+    value: torch.Tensor, cache: torch.Tensor
+) -> torch.Tensor:
+    _validate_cross_attn_cache_params(value, cache)
+    return torch.empty_like(cache)
+
+
+# Register Inductor lowering
+@register_lowering(torch.ops.executorch.update_cross_attn_cache)
+def _update_cross_attn_cache_lowering(value, cache):
+    # cache shape: [B, H, S_max, D]
+    # value shape: [B, H, S, D]
+
+    # We need to slice the cache along dim 2 (sequence length)
+    # slice(self, dim, start, end, step=1)
+    seq_len = value.get_size()[2]
+    cache_slice = L[aten.slice.Tensor](cache, 2, 0, seq_len, 1)
+
+    # Copy value into the slice
+    L[aten.copy_.default](cache_slice, value)
+
+    return cache

--- a/extension/llm/custom_ops/test_update_cross_attn_cache.py
+++ b/extension/llm/custom_ops/test_update_cross_attn_cache.py
@@ -1,0 +1,178 @@
+import unittest
+
+import torch
+
+# Import the custom ops to ensure they are registered
+from executorch.extension.llm.custom_ops import custom_ops  # noqa: F401
+
+
+class TestUpdateCrossAttnCache(unittest.TestCase):
+    def test_update_cross_attn_cache(self):
+
+        # Create tensors
+        # Cache: [B=2, S_max=4, H=1, D=4]
+        cache = torch.zeros(2, 4, 1, 4, dtype=torch.float32)
+        # Value: [B=2, S=2, H=1, D=4] (S < S_max)
+        value = torch.randn(2, 2, 1, 4, dtype=torch.float32)
+
+        # Compile a function that uses the op
+        @torch.compile
+        def fn(v, c):
+            return torch.ops.executorch.update_cross_attn_cache(v, c)
+
+        # Run it
+        out = fn(value, cache)
+
+        # Check correctness
+        # The first 2 elements in dim 1 should match value
+        torch.testing.assert_close(
+            cache[:, :2, :, :], value, msg="Cache slice not updated correctly"
+        )
+
+        # Make sure out and cache are close. In eager they are the same objects.
+        torch.testing.assert_close(
+            out, cache, msg="Output and cache are different objects"
+        )
+
+        # The rest should be zeros
+        torch.testing.assert_close(
+            cache[:, 2:, :, :],
+            torch.zeros_like(cache[:, 2:, :, :]),
+            msg="Rest of cache was modified",
+        )
+
+    def test_update_cross_attn_cache_in_cond(self):
+        # Create tensors
+
+        # Value: [B=2, S=2, H=1, D=4]
+        value = torch.randn(2, 2, 1, 4, dtype=torch.float32)
+        # Alternative value for false branch
+        value_alt = torch.randn(2, 2, 1, 4, dtype=torch.float32)
+
+        # Define a function that uses the op inside torch.cond
+        def fn_with_cond(pred, v1, v2, c):
+            def true_fn(v, cache):
+                return torch.ops.executorch.update_cross_attn_cache(v, cache)
+
+            def false_fn(v, cache):
+                return torch.ops.executorch.update_cross_attn_cache(v, cache)
+
+            return torch.cond(pred, true_fn, false_fn, (v1, c), (v2, c))
+
+        # Test with true condition
+        pred_true = torch.tensor(True)
+        cache_true = torch.zeros(2, 4, 1, 4, dtype=torch.float32)
+
+        # Compile the function
+        @torch.compile
+        def compiled_fn(pred, v1, v2, c):
+            return fn_with_cond(pred, v1, v2, c)
+
+        # Run with true condition
+        compiled_fn(pred_true, value, value_alt, cache_true)
+
+        # Check that the true branch was executed (value was used)
+        torch.testing.assert_close(
+            cache_true[:, :2, :, :],
+            value,
+            msg="Cache not updated correctly in true branch",
+        )
+
+        # Test with false condition
+        pred_false = torch.tensor(False)
+        cache_false = torch.zeros(2, 4, 1, 4, dtype=torch.float32)
+
+        compiled_fn(pred_false, value, value_alt, cache_false)
+
+        # Check that the false branch was executed (value_alt was used)
+        torch.testing.assert_close(
+            cache_false[:, :2, :, :],
+            value_alt,
+            msg="Cache not updated correctly in false branch",
+        )
+
+    def test_update_cross_attn_cache_export(self):
+
+        # Create tensors
+        # Cache: [B=2, S_max=4, H=1, D=4]
+        cache = torch.zeros(2, 4, 1, 4, dtype=torch.float32)
+        # Value: [B=2, S=2, H=1, D=4]
+        value = torch.randn(2, 2, 1, 4, dtype=torch.float32)
+
+        # Define a function that uses the op
+        class UpdateCacheModule(torch.nn.Module):
+            def forward(self, v, c):
+                return torch.ops.executorch.update_cross_attn_cache(v, c)
+
+        module = UpdateCacheModule()
+
+        # Export the module
+        exported_program = torch.export.export(
+            module,
+            (value, cache),
+        )
+
+        # Run the exported program
+        cache_exported = torch.zeros(2, 4, 1, 4, dtype=torch.float32)
+        exported_program.module()(value, cache_exported)
+
+        # Check correctness
+        torch.testing.assert_close(
+            cache_exported[:, :2, :, :],
+            value,
+            msg="Cache not updated correctly after export",
+        )
+
+    def test_update_cross_attn_cache_different_shapes(self):
+        print("Testing executorch::update_cross_attn_cache with different shapes...")
+
+        # Test with different batch sizes and sequence lengths
+        test_cases = [
+            # (B, S_max, S, H, D)
+            (1, 10, 5, 2, 8),
+            (4, 8, 3, 4, 16),
+            (2, 16, 10, 1, 32),
+        ]
+
+        for B, S_max, S, H, D in test_cases:
+            cache = torch.zeros(B, S_max, H, D, dtype=torch.float32)
+            value = torch.randn(B, S, H, D, dtype=torch.float32)
+
+            @torch.compile
+            def fn(v, c):
+                return torch.ops.executorch.update_cross_attn_cache(v, c)
+
+            fn(value, cache)
+
+            # Check that the first S positions are updated
+            torch.testing.assert_close(
+                cache[:, :S, :, :],
+                value,
+                msg=f"Failed for shape B={B}, S_max={S_max}, S={S}, H={H}, D={D}",
+            )
+
+            # Check that the rest remain zeros
+            if S < S_max:
+                torch.testing.assert_close(
+                    cache[:, S:, :, :],
+                    torch.zeros_like(cache[:, S:, :, :]),
+                    msg=f"Remaining cache modified for shape B={B}, S_max={S_max}, S={S}, H={H}, D={D}",
+                )
+
+    def test_update_cross_attn_cache_full_sequence(self):
+
+        # Cache: [B=2, S_max=4, H=1, D=4]
+        cache = torch.zeros(2, 4, 1, 4, dtype=torch.float32)
+        # Value: [B=2, S=4, H=1, D=4] (S == S_max)
+        value = torch.randn(2, 4, 1, 4, dtype=torch.float32)
+
+        @torch.compile
+        def fn(v, c):
+            return torch.ops.executorch.update_cross_attn_cache(v, c)
+
+        fn(value, cache)
+
+        # The entire cache should match value
+        torch.testing.assert_close(
+            cache, value, msg="Cache not fully updated when S == S_max"
+        )

--- a/extension/llm/runner/CMakeLists.txt
+++ b/extension/llm/runner/CMakeLists.txt
@@ -63,6 +63,20 @@ if(EXECUTORCH_BUILD_CUDA)
   # CUDA runtime library (cudart) if the package isn't available.
   find_package(CUDAToolkit QUIET)
   if(CUDAToolkit_FOUND)
+    # Compile sampler.cpp with a CUDA-capable toolchain so Thrust device paths
+    # are available.
+    enable_language(CUDA)
+    set_target_properties(
+      extension_llm_runner
+      PROPERTIES CUDA_STANDARD 17 CUDA_STANDARD_REQUIRED YES)
+    target_compile_options(
+      extension_llm_runner PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--extended-lambda>)
+    set(sampler_cuda_src "${EXECUTORCH_ROOT}/extension/llm/sampler/sampler_cuda.cpp")
+    if(EXISTS "${sampler_cuda_src}")
+      target_sources(extension_llm_runner PRIVATE ${sampler_cuda_src})
+      set_source_files_properties(
+        ${sampler_cuda_src} PROPERTIES LANGUAGE CUDA LINKER_LANGUAGE CUDA)
+    endif()
     target_compile_definitions(extension_llm_runner PUBLIC CUDA_AVAILABLE)
     target_link_libraries(extension_llm_runner PUBLIC CUDA::cudart)
     message(STATUS "CUDAToolkit found; defining CUDA_AVAILABLE")

--- a/extension/llm/runner/text_decoder_runner.h
+++ b/extension/llm/runner/text_decoder_runner.h
@@ -60,13 +60,15 @@ class ET_EXPERIMENTAL TextDecoderRunner {
    * @param logits_tensor The logits tensor.
    * @param temperature The temperature parameter used to control randomness in
    * sampling.
+   * @param cuda_stream Optional CUDA stream for CUDA sampling path.
    * @return The next token.
    */
   inline int32_t logits_to_token(
       const executorch::aten::Tensor& logits_tensor,
-      const float temperature = 0.0f) {
+      const float temperature = 0.0f,
+      void* cuda_stream = nullptr) {
     return ::executorch::extension::llm::logits_to_token(
-        logits_tensor, temperature);
+        logits_tensor, temperature, cuda_stream);
   }
 
  protected:

--- a/extension/llm/sampler/sampler_cuda.cpp
+++ b/extension/llm/sampler/sampler_cuda.cpp
@@ -1,0 +1,547 @@
+#include <executorch/extension/llm/sampler/sampler_cuda.h>
+
+#ifdef CUDA_AVAILABLE
+
+#include <cuda_runtime.h>
+#include <cub/device/device_reduce.cuh>
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <memory>
+#include <ctime>
+#include <thrust/device_ptr.h>
+#include <thrust/device_vector.h>
+#include <thrust/extrema.h>
+#include <thrust/functional.h>
+#include <thrust/binary_search.h>
+#include <thrust/device_ptr.h>
+#include <thrust/execution_policy.h>
+#include <thrust/iterator/zip_iterator.h>
+#include <thrust/scan.h>
+#include <thrust/sequence.h>
+#include <thrust/sort.h>
+#include <thrust/transform.h>
+#include <thrust/transform_reduce.h>
+#include <thrust/tuple.h>
+
+namespace executorch {
+namespace extension {
+namespace llm {
+
+namespace {
+
+bool is_cuda_pointer(const void* ptr) {
+  if (ptr == nullptr) {
+    return false;
+  }
+  cudaPointerAttributes attributes{};
+  const cudaError_t status = cudaPointerGetAttributes(&attributes, ptr);
+  if (status != cudaSuccess) {
+    return false;
+  }
+#if CUDART_VERSION >= 10000
+  return attributes.type == cudaMemoryTypeDevice ||
+      attributes.type == cudaMemoryTypeManaged;
+#else
+  return attributes.memoryType == cudaMemoryTypeDevice ||
+      attributes.memoryType == cudaMemoryTypeManaged;
+#endif
+}
+
+unsigned int random_u32(unsigned long long* state) {
+  *state ^= *state >> 12;
+  *state ^= *state << 25;
+  *state ^= *state >> 27;
+  return (*state * 0x2545F4914F6CDD1Dull) >> 32;
+}
+
+float random_f32(unsigned long long* state) {
+  return (random_u32(state) >> 8) / 16777216.0f;
+}
+
+template <typename T>
+struct TemperatureScaleExp {
+  float max_val;
+  float inv_temp;
+  __host__ __device__ T operator()(T x) const {
+    float scaled = static_cast<float>(x) * inv_temp - max_val;
+    return static_cast<T>(expf(scaled));
+  }
+};
+
+template <typename T>
+struct ToFloat {
+  __host__ __device__ float operator()(T x) const {
+    return static_cast<float>(x);
+  }
+};
+
+template <typename T>
+struct NormalizeMul {
+  float inv_sum;
+  __host__ __device__ T operator()(T x) const {
+    return static_cast<T>(static_cast<float>(x) * inv_sum);
+  }
+};
+
+struct ProbGreater {
+  __host__ __device__ bool operator()(
+      const thrust::tuple<float, int32_t>& a,
+      const thrust::tuple<float, int32_t>& b) const {
+    return thrust::get<0>(a) > thrust::get<0>(b);
+  }
+};
+
+template <typename T>
+static void softmax_host(T* x, int size) {
+  float max_val = static_cast<float>(x[0]);
+  for (int i = 1; i < size; i++) {
+    const float val = static_cast<float>(x[i]);
+    if (val > max_val) {
+      max_val = val;
+    }
+  }
+  float sum = 0.0f;
+  for (int i = 0; i < size; i++) {
+    float v = expf(static_cast<float>(x[i]) - max_val);
+    x[i] = static_cast<T>(v);
+    sum += v;
+  }
+  for (int i = 0; i < size; i++) {
+    x[i] = static_cast<T>(static_cast<float>(x[i]) / sum);
+  }
+}
+
+template <typename T>
+struct ProbIndexHost {
+  float prob;
+  int32_t index;
+};
+
+} // namespace
+
+CudaSampler::CudaSampler(
+    int32_t vocab_size,
+    float temperature,
+    float topp,
+    unsigned long long rng_seed,
+    void* cuda_stream,
+    SamplerWorkspace* workspace)
+    : vocab_size_(vocab_size),
+      inv_temperature_(
+          static_cast<bool>(temperature) ? 1.0f / temperature : 0.0f),
+      topp_(topp),
+      rng_state_(rng_seed),
+      cuda_stream_(cuda_stream),
+      workspace_(workspace) {}
+
+CudaSampler::CudaSampler(
+    int32_t vocab_size,
+    float temperature,
+    void* cuda_stream,
+    SamplerWorkspace* workspace)
+    : vocab_size_(vocab_size),
+      inv_temperature_(
+          static_cast<bool>(temperature) ? 1.0f / temperature : 0.0f),
+      topp_(kTopp),
+      rng_state_(std::time(nullptr)),
+      cuda_stream_(cuda_stream),
+      workspace_(workspace) {}
+
+template <typename T>
+int32_t CudaSampler::sample(T* logits) {
+  const bool use_cuda = is_cuda_pointer(logits);
+  int32_t next = 0;
+  if (!use_cuda) {
+    if (inv_temperature_ == 0.0f) {
+      next = sample_argmax_host(logits);
+    } else {
+      apply_temperature_and_softmax_host(logits);
+      const float coin = random_f32(&rng_state_);
+      if (topp_ <= 0 || topp_ >= 1) {
+        next = sample_mult_host(logits, coin);
+      } else {
+        next = sample_topp_host(logits, coin);
+      }
+    }
+    return next;
+  }
+
+  if (inv_temperature_ == 0.0f) {
+    next = sample_argmax_cuda(logits);
+  } else {
+    apply_temperature_and_softmax_cuda(logits);
+    const float coin = random_f32(&rng_state_);
+    if (topp_ <= 0 || topp_ >= 1) {
+      next = sample_mult_cuda(logits, coin);
+    } else {
+      next = sample_topp_cuda(logits, coin);
+    }
+  }
+  return next;
+}
+
+template <typename T>
+void CudaSampler::apply_temperature_and_softmax_host(T* logits) {
+  for (int q = 0; q < vocab_size_; q++) {
+    logits[q] = static_cast<T>(static_cast<float>(logits[q]) * inv_temperature_);
+  }
+  softmax_host(logits, vocab_size_);
+}
+
+template <typename T>
+int32_t CudaSampler::sample_argmax_host(T* probabilities) {
+  int max_i = 0;
+  float max_p = static_cast<float>(probabilities[0]);
+  for (int i = 1; i < vocab_size_; i++) {
+    const float val = static_cast<float>(probabilities[i]);
+    if (val > max_p) {
+      max_i = i;
+      max_p = val;
+    }
+  }
+  return max_i;
+}
+
+template <typename T>
+int32_t CudaSampler::sample_mult_host(T* probabilities, float coin) {
+  float cdf = 0.0f;
+  for (int i = 0; i < vocab_size_; i++) {
+    cdf += static_cast<float>(probabilities[i]);
+    if (coin < cdf) {
+      return i;
+    }
+  }
+  return vocab_size_ - 1;
+}
+
+template <typename T>
+int32_t CudaSampler::sample_topp_host(T* probabilities, float coin) {
+  int n = vocab_size_;
+  int n0 = 0;
+  std::unique_ptr<ProbIndexHost<T>[]> probindex =
+      std::make_unique<ProbIndexHost<T>[]>(vocab_size_);
+
+  const float cutoff = (1.0f - topp_) / (n - 1);
+  for (int i = 0; i < n; i++) {
+    const float prob = static_cast<float>(probabilities[i]);
+    if (prob >= cutoff) {
+      probindex[n0].index = i;
+      probindex[n0].prob = prob;
+      n0++;
+    }
+  }
+
+  auto compare = [](const ProbIndexHost<T>& a, const ProbIndexHost<T>& b) {
+    return a.prob > b.prob;
+  };
+  std::sort(probindex.get(), probindex.get() + n0, compare);
+
+  float cumulative_prob = 0.0f;
+  int last_idx = n0 - 1;
+  for (int i = 0; i < n0; i++) {
+    cumulative_prob += probindex[i].prob;
+    if (cumulative_prob > topp_) {
+      last_idx = i;
+      break;
+    }
+  }
+
+  const float r = coin * cumulative_prob;
+  float cdf = 0.0f;
+  for (int i = 0; i <= last_idx; i++) {
+    cdf += probindex[i].prob;
+    if (r < cdf) {
+      return probindex[i].index;
+    }
+  }
+  return probindex[last_idx].index;
+}
+
+template <typename T>
+void CudaSampler::apply_temperature_and_softmax_cuda(T* logits) {
+  thrust::device_ptr<T> logits_ptr(logits);
+  const float max_val = thrust::transform_reduce(
+      thrust::cuda::par.on(static_cast<cudaStream_t>(cuda_stream_)),
+      logits_ptr,
+      logits_ptr + static_cast<size_t>(vocab_size_),
+      ToFloat<T>{},
+      -std::numeric_limits<float>::infinity(),
+      thrust::maximum<float>());
+  const float inv_temp = inv_temperature_;
+
+  thrust::transform(
+      thrust::cuda::par.on(static_cast<cudaStream_t>(cuda_stream_)),
+      logits_ptr,
+      logits_ptr + static_cast<size_t>(vocab_size_),
+      logits_ptr,
+      TemperatureScaleExp<T>{max_val, inv_temp});
+
+  const float sum = thrust::transform_reduce(
+      thrust::cuda::par.on(static_cast<cudaStream_t>(cuda_stream_)),
+      logits_ptr,
+      logits_ptr + static_cast<size_t>(vocab_size_),
+      ToFloat<T>{},
+      0.0f,
+      thrust::plus<float>());
+  if (sum <= 0.0f) {
+    return;
+  }
+  const float inv_sum = 1.0f / sum;
+  thrust::transform(
+      thrust::cuda::par.on(static_cast<cudaStream_t>(cuda_stream_)),
+      logits_ptr,
+      logits_ptr + static_cast<size_t>(vocab_size_),
+      logits_ptr,
+      NormalizeMul<T>{inv_sum});
+}
+
+template <typename T>
+int32_t CudaSampler::sample_argmax_cuda(T* probabilities) {
+  cudaStream_t stream = static_cast<cudaStream_t>(cuda_stream_);
+  thrust::device_ptr<T> probs(probabilities);
+
+  float* prob_data = nullptr;
+  thrust::device_vector<float> local_probs;
+  if (workspace_ != nullptr) {
+    workspace_->reserve(static_cast<size_t>(vocab_size_));
+    prob_data = workspace_->probs;
+  } else {
+    local_probs.resize(static_cast<size_t>(vocab_size_));
+    prob_data = thrust::raw_pointer_cast(local_probs.data());
+  }
+
+  auto exec = thrust::cuda::par.on(stream);
+  thrust::transform(
+      exec,
+      probs,
+      probs + static_cast<size_t>(vocab_size_),
+      prob_data,
+      ToFloat<T>{});
+  auto err = cudaGetLastError();
+  ET_CHECK_MSG(err == cudaSuccess, "CUDA error: %s", cudaGetErrorString(err));
+
+  using Pair = ::cub::KeyValuePair<int, float>;
+  Pair* d_out = nullptr;
+  Pair* local_out = nullptr;
+  if (workspace_ != nullptr) {
+    workspace_->ensure_argmax_capacity(1);
+    d_out = static_cast<Pair*>(workspace_->argmax_out);
+  } else {
+    cudaMalloc(reinterpret_cast<void**>(&local_out), sizeof(Pair));
+    d_out = local_out;
+  }
+
+  size_t temp_bytes = 0;
+  cub::DeviceReduce::ArgMax(
+      nullptr, temp_bytes, prob_data, d_out, vocab_size_, stream);
+
+  uint8_t* temp_storage = nullptr;
+  thrust::device_vector<uint8_t> local_temp;
+  if (workspace_ != nullptr) {
+    workspace_->ensure_temp_bytes(temp_bytes);
+    temp_storage = workspace_->temp_storage;
+  } else {
+    local_temp.resize(temp_bytes);
+    temp_storage = thrust::raw_pointer_cast(local_temp.data());
+  }
+
+  cub::DeviceReduce::ArgMax(
+      temp_storage, temp_bytes, prob_data, d_out, vocab_size_, stream);
+
+  Pair host_out{};
+  cudaMemcpy(
+      &host_out,
+      d_out,
+      sizeof(Pair),
+      cudaMemcpyDeviceToHost);
+  // cudaStreamSynchronize(stream);
+
+  if (local_out != nullptr) {
+    cudaFree(local_out);
+  }
+  return static_cast<int32_t>(host_out.key);
+}
+
+template <typename T>
+int32_t CudaSampler::sample_mult_cuda(T* probabilities, float coin) {
+  thrust::device_ptr<T> probs(probabilities);
+  float* cdf_data = nullptr;
+  thrust::device_vector<float> local_cdf;
+  if (workspace_ != nullptr) {
+    workspace_->reserve(static_cast<size_t>(vocab_size_));
+    cdf_data = workspace_->probs;
+  } else {
+    local_cdf.resize(static_cast<size_t>(vocab_size_));
+    cdf_data = thrust::raw_pointer_cast(local_cdf.data());
+  }
+  thrust::transform(
+      thrust::cuda::par.on(static_cast<cudaStream_t>(cuda_stream_)),
+      probs,
+      probs + static_cast<size_t>(vocab_size_),
+      cdf_data,
+      ToFloat<T>{});
+  thrust::inclusive_scan(
+      thrust::cuda::par.on(static_cast<cudaStream_t>(cuda_stream_)),
+      cdf_data,
+      cdf_data + static_cast<size_t>(vocab_size_),
+      cdf_data);
+  auto it = thrust::upper_bound(
+      thrust::cuda::par.on(static_cast<cudaStream_t>(cuda_stream_)),
+      cdf_data,
+      cdf_data + static_cast<size_t>(vocab_size_),
+      coin);
+  if (it == cdf_data + static_cast<size_t>(vocab_size_)) {
+    return vocab_size_ - 1;
+  }
+  return static_cast<int32_t>(it - cdf_data);
+}
+
+template <typename T>
+int32_t CudaSampler::sample_topp_cuda(T* probabilities, float coin) {
+  thrust::device_ptr<T> probs(probabilities);
+  float* prob_data = nullptr;
+  int32_t* index_data = nullptr;
+  thrust::device_vector<float> local_prob_vec;
+  thrust::device_vector<int32_t> local_indices;
+
+  if (workspace_ != nullptr) {
+    workspace_->reserve(static_cast<size_t>(vocab_size_));
+    prob_data = workspace_->probs;
+    index_data = workspace_->indices;
+  } else {
+    local_prob_vec.resize(static_cast<size_t>(vocab_size_));
+    local_indices.resize(static_cast<size_t>(vocab_size_));
+    prob_data = thrust::raw_pointer_cast(local_prob_vec.data());
+    index_data = thrust::raw_pointer_cast(local_indices.data());
+  }
+  thrust::transform(
+      thrust::cuda::par.on(static_cast<cudaStream_t>(cuda_stream_)),
+      probs,
+      probs + static_cast<size_t>(vocab_size_),
+      prob_data,
+      ToFloat<T>{});
+  thrust::sequence(
+      thrust::cuda::par.on(static_cast<cudaStream_t>(cuda_stream_)),
+      index_data,
+      index_data + static_cast<size_t>(vocab_size_));
+
+  auto zipped_begin = thrust::make_zip_iterator(
+      thrust::make_tuple(prob_data, index_data));
+  auto zipped_end = zipped_begin + static_cast<size_t>(vocab_size_);
+
+  thrust::sort(
+      thrust::cuda::par.on(static_cast<cudaStream_t>(cuda_stream_)),
+      zipped_begin,
+      zipped_end,
+      ProbGreater{});
+
+  thrust::inclusive_scan(
+      thrust::cuda::par.on(static_cast<cudaStream_t>(cuda_stream_)),
+      prob_data,
+      prob_data + static_cast<size_t>(vocab_size_),
+      prob_data);
+  auto cutoff_it = thrust::upper_bound(
+      thrust::cuda::par.on(static_cast<cudaStream_t>(cuda_stream_)),
+      prob_data,
+      prob_data + static_cast<size_t>(vocab_size_),
+      topp_);
+  const int last_idx = cutoff_it == prob_data + static_cast<size_t>(vocab_size_)
+      ? static_cast<int>(vocab_size_ - 1)
+      : static_cast<int>(cutoff_it - prob_data);
+  const float cumulative_prob = prob_data[last_idx];
+  const float target = coin * cumulative_prob;
+
+  auto sample_it = thrust::upper_bound(
+      thrust::cuda::par.on(static_cast<cudaStream_t>(cuda_stream_)),
+      prob_data,
+      prob_data + last_idx + 1,
+      target);
+  const int offset = sample_it == prob_data + last_idx + 1
+      ? last_idx
+      : static_cast<int>(sample_it - prob_data);
+  return index_data[offset];
+}
+
+template int32_t CudaSampler::sample<float>(float*);
+template int32_t CudaSampler::sample<uint16_t>(uint16_t*);
+template int32_t CudaSampler::sample<executorch::aten::Half>(
+    executorch::aten::Half*);
+template int32_t CudaSampler::sample<executorch::aten::BFloat16>(
+    executorch::aten::BFloat16*);
+
+template void CudaSampler::apply_temperature_and_softmax_cuda<float>(float*);
+template void CudaSampler::apply_temperature_and_softmax_cuda<uint16_t>(
+    uint16_t*);
+template void
+CudaSampler::apply_temperature_and_softmax_cuda<executorch::aten::Half>(
+    executorch::aten::Half*);
+template void
+CudaSampler::apply_temperature_and_softmax_cuda<executorch::aten::BFloat16>(
+    executorch::aten::BFloat16*);
+
+template int32_t CudaSampler::sample_argmax_cuda<float>(float*);
+template int32_t CudaSampler::sample_argmax_cuda<uint16_t>(uint16_t*);
+template int32_t CudaSampler::sample_argmax_cuda<executorch::aten::Half>(
+    executorch::aten::Half*);
+template int32_t CudaSampler::sample_argmax_cuda<executorch::aten::BFloat16>(
+    executorch::aten::BFloat16*);
+
+template int32_t CudaSampler::sample_mult_cuda<float>(float*, float);
+template int32_t CudaSampler::sample_mult_cuda<uint16_t>(uint16_t*, float);
+template int32_t CudaSampler::sample_mult_cuda<executorch::aten::Half>(
+    executorch::aten::Half*,
+    float);
+template int32_t CudaSampler::sample_mult_cuda<executorch::aten::BFloat16>(
+    executorch::aten::BFloat16*,
+    float);
+
+template int32_t CudaSampler::sample_topp_cuda<float>(float*, float);
+template int32_t CudaSampler::sample_topp_cuda<uint16_t>(uint16_t*, float);
+template int32_t CudaSampler::sample_topp_cuda<executorch::aten::Half>(
+    executorch::aten::Half*,
+    float);
+template int32_t CudaSampler::sample_topp_cuda<executorch::aten::BFloat16>(
+    executorch::aten::BFloat16*,
+    float);
+
+template void CudaSampler::apply_temperature_and_softmax_host<float>(float*);
+template void CudaSampler::apply_temperature_and_softmax_host<uint16_t>(
+    uint16_t*);
+template void
+CudaSampler::apply_temperature_and_softmax_host<executorch::aten::Half>(
+    executorch::aten::Half*);
+template void
+CudaSampler::apply_temperature_and_softmax_host<executorch::aten::BFloat16>(
+    executorch::aten::BFloat16*);
+
+template int32_t CudaSampler::sample_argmax_host<float>(float*);
+template int32_t CudaSampler::sample_argmax_host<uint16_t>(uint16_t*);
+template int32_t CudaSampler::sample_argmax_host<executorch::aten::Half>(
+    executorch::aten::Half*);
+template int32_t CudaSampler::sample_argmax_host<executorch::aten::BFloat16>(
+    executorch::aten::BFloat16*);
+
+template int32_t CudaSampler::sample_mult_host<float>(float*, float);
+template int32_t CudaSampler::sample_mult_host<uint16_t>(uint16_t*, float);
+template int32_t CudaSampler::sample_mult_host<executorch::aten::Half>(
+    executorch::aten::Half*,
+    float);
+template int32_t CudaSampler::sample_mult_host<executorch::aten::BFloat16>(
+    executorch::aten::BFloat16*,
+    float);
+
+template int32_t CudaSampler::sample_topp_host<float>(float*, float);
+template int32_t CudaSampler::sample_topp_host<uint16_t>(uint16_t*, float);
+template int32_t CudaSampler::sample_topp_host<executorch::aten::Half>(
+    executorch::aten::Half*,
+    float);
+template int32_t CudaSampler::sample_topp_host<executorch::aten::BFloat16>(
+    executorch::aten::BFloat16*,
+    float);
+
+} // namespace llm
+} // namespace extension
+} // namespace executorch
+
+#endif // CUDA_AVAILABLE

--- a/extension/llm/sampler/sampler_cuda.h
+++ b/extension/llm/sampler/sampler_cuda.h
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <executorch/extension/llm/sampler/sampler.h>
+
+#ifdef CUDA_AVAILABLE
+
+#include <cuda_runtime.h>
+#include <cstddef>
+
+namespace executorch {
+namespace extension {
+namespace llm {
+
+struct SamplerWorkspace {
+  SamplerWorkspace() = default;
+  explicit SamplerWorkspace(size_t capacity) {
+    reserve(capacity);
+  }
+  ~SamplerWorkspace() {
+    release();
+  }
+  SamplerWorkspace(const SamplerWorkspace&) = delete;
+  SamplerWorkspace& operator=(const SamplerWorkspace&) = delete;
+  SamplerWorkspace(SamplerWorkspace&& other) noexcept {
+    move_from(std::move(other));
+  }
+  SamplerWorkspace& operator=(SamplerWorkspace&& other) noexcept {
+    if (this != &other) {
+      release();
+      move_from(std::move(other));
+    }
+    return *this;
+  }
+
+  inline void reserve(size_t capacity) {
+    if (capacity > probs_capacity_) {
+      resize_buffer(reinterpret_cast<void**>(&probs), capacity, sizeof(float));
+      resize_buffer(
+          reinterpret_cast<void**>(&indices), capacity, sizeof(int32_t));
+      probs_capacity_ = capacity;
+      indices_capacity_ = capacity;
+    }
+  }
+  inline void ensure_temp_bytes(size_t bytes) {
+    if (bytes > temp_capacity_) {
+      resize_buffer(
+          reinterpret_cast<void**>(&temp_storage), bytes, sizeof(uint8_t));
+      temp_capacity_ = bytes;
+    }
+  }
+  inline void ensure_argmax_capacity(size_t capacity) {
+    if (capacity > argmax_capacity_) {
+      resize_buffer(
+          reinterpret_cast<void**>(&argmax_out), capacity, sizeof(uint64_t));
+      argmax_capacity_ = capacity;
+    }
+  }
+
+  size_t capacity() const {
+    return probs_capacity_;
+  }
+
+  float* probs{nullptr};
+  int32_t* indices{nullptr};
+  uint8_t* temp_storage{nullptr};
+  void* argmax_out{nullptr};
+
+ private:
+  inline void release() {
+    if (probs) {
+      cudaFree(probs);
+      probs = nullptr;
+    }
+    if (indices) {
+      cudaFree(indices);
+      indices = nullptr;
+    }
+    if (temp_storage) {
+      cudaFree(temp_storage);
+      temp_storage = nullptr;
+    }
+    if (argmax_out) {
+      cudaFree(argmax_out);
+      argmax_out = nullptr;
+    }
+    probs_capacity_ = indices_capacity_ = argmax_capacity_ = temp_capacity_ = 0;
+  }
+  inline void move_from(SamplerWorkspace&& other) {
+    probs = other.probs;
+    indices = other.indices;
+    temp_storage = other.temp_storage;
+    argmax_out = other.argmax_out;
+    probs_capacity_ = other.probs_capacity_;
+    indices_capacity_ = other.indices_capacity_;
+    argmax_capacity_ = other.argmax_capacity_;
+    temp_capacity_ = other.temp_capacity_;
+
+    other.probs = nullptr;
+    other.indices = nullptr;
+    other.temp_storage = nullptr;
+    other.argmax_out = nullptr;
+    other.probs_capacity_ = other.indices_capacity_ = other.argmax_capacity_ =
+        other.temp_capacity_ = 0;
+  }
+  inline void resize_buffer(void** ptr, size_t new_cap, size_t elem_size) {
+    if (*ptr) {
+      cudaFree(*ptr);
+      *ptr = nullptr;
+    }
+    cudaMalloc(ptr, new_cap * elem_size);
+  }
+
+  size_t probs_capacity_{0};
+  size_t indices_capacity_{0};
+  size_t argmax_capacity_{0};
+  size_t temp_capacity_{0};
+};
+
+class CudaSampler {
+ public:
+  CudaSampler(
+      int32_t vocab_size,
+      float temperature,
+      float topp,
+      unsigned long long rng_seed,
+      void* cuda_stream = nullptr,
+      SamplerWorkspace* workspace = nullptr);
+
+  CudaSampler(
+      int32_t vocab_size,
+      float temperature,
+      void* cuda_stream = nullptr,
+      SamplerWorkspace* workspace = nullptr);
+
+  template <typename T>
+  int32_t sample(T* logits);
+
+ private:
+  template <typename T>
+  void apply_temperature_and_softmax_cuda(T* logits);
+  template <typename T>
+  int32_t sample_argmax_cuda(T* probabilities);
+  template <typename T>
+  int32_t sample_mult_cuda(T* probabilities, float coin);
+  template <typename T>
+  int32_t sample_topp_cuda(T* probabilities, float coin);
+
+  template <typename T>
+  void apply_temperature_and_softmax_host(T* logits);
+  template <typename T>
+  int32_t sample_argmax_host(T* probabilities);
+  template <typename T>
+  int32_t sample_mult_host(T* probabilities, float coin);
+  template <typename T>
+  int32_t sample_topp_host(T* probabilities, float coin);
+
+  int32_t vocab_size_;
+  float inv_temperature_;
+  float topp_;
+  unsigned long long rng_state_;
+  void* cuda_stream_{nullptr};
+  SamplerWorkspace* workspace_{nullptr};
+};
+
+} // namespace llm
+} // namespace extension
+} // namespace executorch
+
+#endif // CUDA_AVAILABLE

--- a/extension/llm/sampler/util.h
+++ b/extension/llm/sampler/util.h
@@ -8,8 +8,11 @@
 
 #pragma once
 
-#include <executorch/extension/llm/sampler/sampler.h>
 #include <executorch/runtime/core/exec_aten/exec_aten.h>
+#include <executorch/extension/llm/sampler/sampler.h>
+#ifdef CUDA_AVAILABLE
+#include <executorch/extension/llm/sampler/sampler_cuda.h>
+#endif
 
 namespace executorch {
 namespace extension {
@@ -20,11 +23,19 @@ namespace llm {
  * @param logits_tensor The logits tensor.
  * @param temperature The temperature parameter used to control randomness in
  * sampling.
+ * @param cuda_stream Optional CUDA stream to use for device-side sampling.
+ * @param workspace Optional workspace for CUDA sampling to reduce allocations.
  * @return The next token.
  */
 inline int32_t logits_to_token(
     const executorch::aten::Tensor& logits_tensor,
-    const float temperature = 0.0f) {
+    const float temperature = 0.0f,
+    void* cuda_stream = nullptr
+#ifdef CUDA_AVAILABLE
+    ,
+    SamplerWorkspace* workspace = nullptr
+#endif
+) {
   int32_t result = 0;
 
   // Create a minimal context for error handling in ET_SWITCH
@@ -53,7 +64,13 @@ inline int32_t logits_to_token(
           auto num_tokens = logits_tensor.size(1);
           logits += (num_tokens - 1) * vocab_size;
         }
-        // @lint-ignore CLANGTIDY facebook-hte-Deprecated
+#ifdef CUDA_AVAILABLE
+        if (cuda_stream != nullptr) {
+          CudaSampler sampler(vocab_size, temperature, cuda_stream, workspace);
+          result = sampler.sample(logits);
+          return;
+        }
+#endif
         Sampler sampler(vocab_size, temperature);
         result = sampler.sample(logits);
       });

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -23,6 +23,7 @@ TORCH_NIGHTLY_URL_BASE = "https://download.pytorch.org/whl/nightly"
 SUPPORTED_CUDA_VERSIONS = (
     (12, 6),
     (12, 8),
+    (12, 9),
     (13, 0),
 )
 


### PR DESCRIPTION
torch.cond doesn't take aliasing or mutations. Adding 2 ops for supporting conditionally updating kv cache:

* `executorch::alias`: takes 2 tensors and return the same 2 tensors.
* `executorch::update_cross_attn_cache`: takes a tensor `cache` and a tensor `value`, in place copy `value` into `cache`.

With these 2 ops, we can rewrite the model definition from:

```py
if is_cross_attention and past_key_values and is_updated:
    # reuse k,v, cross_attentions
    key_states = past_key_values.layers[self.layer_idx].keys
    value_states = past_key_values.layers[self.layer_idx].values
else:
    key_states = self.k_proj(current_states).view(bsz, -1, self.num_heads, self.head_dim)
    value_states = self.v_proj(current_states).view(bsz, -1, self.num_heads, self.head_dim)
    key_states = key_states.transpose(1, 2).contiguous()
    value_states = value_states.transpose(1, 2).contiguous()
    if past_key_values is not None:
        # save all key/value_states to cache to be re-used for fast auto-regressive generation
        cache_position = cache_position if not is_cross_attention else None
        key_states, value_states = past_key_values.update(
            key_states, value_states, self.layer_idx, {"cache_position": cache_position}
        )
```

Into:

```py
def use_cached_kv(
    cached_keys: Tensor,
    cached_values: Tensor,
    key_value_states: Tensor,
) -> tuple[Tensor, Tensor]:
    # Just reuse cached K/V
    return torch.ops.executorch.alias(cached_keys, cached_values)

def recompute_kv(
    cached_keys: Tensor,  # unused
    cached_values: Tensor,  # unused
    key_value_states: Tensor,
) -> tuple[Tensor, Tensor]:
    # Compute fresh K/V (export-friendly: use custom op to mutate cache)
    key_states = self.k_proj(key_value_states).view(bsz, -1, self.num_heads, self.head_dim)
    value_states = self.v_proj(key_value_states).view(bsz, -1, self.num_heads, self.head_dim)
    key_states = key_states.transpose(1, 2).contiguous()
    value_states = value_states.transpose(1, 2).contiguous()
    k = torch.ops.executorch.update_cross_attn_cache(key_states, cached_keys)
    v = torch.ops.executorch.update_cross_attn_cache(value_states, cached_values)
    return k, v

if past_key_values is not None and self.layer_idx is not None:
    # Grab cached tensors (these are Tensors, so they are OK for export)
    cached_keys = past_key_values.layers[self.layer_idx].keys
    cached_values = past_key_values.layers[self.layer_idx].values

    # Tensor predicate: True if any element is non-zero
    # Result is a 0-dim bool tensor suitable for torch.cond
    cache_is_initialized = (cached_keys != 0).any()

    # Use torch.cond to select branch in a traceable way.
    # All operands must be (nested) tensors or simple Python values.
    key_states, value_states = torch.cond(
        cache_is_initialized,
        use_cached_kv,
        recompute_kv,
        operands=(cached_keys, cached_values, key_value_states),
    )
```

### Summary
[PLEASE REMOVE] See [CONTRIBUTING.md's Pull Requests](https://github.com/pytorch/executorch/blob/main/CONTRIBUTING.md#pull-requests) for ExecuTorch PR guidelines.

[PLEASE REMOVE] If this PR closes an issue, please add a `Fixes #<issue-id>` line.

[PLEASE REMOVE] If this PR introduces a fix or feature that should be the upcoming release notes, please add a "Release notes: <area>" label. For a list of available release notes labels, check out [CONTRIBUTING.md's Pull Requests](https://github.com/pytorch/executorch/blob/main/CONTRIBUTING.md#pull-requests).

### Test plan
[PLEASE REMOVE] How did you test this PR? Please write down any manual commands you used and note down tests that you have written if applicable.
