### PR TITLE
make partial export failure not stop cuda benchmark

### DIFF
--- a/.github/workflows/cuda-perf.yml
+++ b/.github/workflows/cuda-perf.yml
@@ -179,6 +179,7 @@ jobs:
     needs:
       - set-parameters
       - export-models
+    if: always()
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     permissions:
       id-token: write


### PR DESCRIPTION
Before:
When running CUDA benchmarks on multiple models, any model export failure would halt the entire benchmark job.

After:
With the new configuration, the benchmark job will continue for models that export successfully, even if some models fail to export.