### PR TITLE
Add `aoti_torch_item_bool` and `aoti_torch_new_tensor_handle` in AOTI…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,21 +87,22 @@
 #
 # ==============================================================================
 
-.PHONY: voxtral-cuda voxtral-cpu voxtral-metal whisper-cuda whisper-cpu whisper-metal llama-cpu llava-cpu gemma3-cuda gemma3-cpu clean help
+.PHONY: voxtral-cuda voxtral-cpu voxtral-metal whisper-cuda whisper-debug-cuda whisper-cpu whisper-metal llama-cpu llava-cpu gemma3-cuda gemma3-cpu clean help
 
 help:
-	@echo "This Makefile adds targets to build runners for various models on various backends. Run using `make <target>`. Available targets:"
-	@echo "  voxtral-cuda   - Build Voxtral runner with CUDA backend"
-	@echo "  voxtral-cpu    - Build Voxtral runner with CPU backend"
-	@echo "  voxtral-metal  - Build Voxtral runner with Metal backend (macOS only)"
-	@echo "  whisper-cuda   - Build Whisper runner with CUDA backend"
-	@echo "  whisper-cpu    - Build Whisper runner with CPU backend"
-	@echo "  whisper-metal  - Build Whisper runner with Metal backend (macOS only)"
-	@echo "  llama-cpu      - Build Llama runner with CPU backend"
-	@echo "  llava-cpu      - Build Llava runner with CPU backend"
-	@echo "  gemma3-cuda    - Build Gemma3 runner with CUDA backend"
-	@echo "  gemma3-cpu     - Build Gemma3 runner with CPU backend"
-	@echo "  clean          - Clean build artifacts"
+	@echo "This Makefile adds targets to build runners for various models on various backends. Run using \`make <target>\`. Available targets:"
+	@echo "  voxtral-cuda            - Build Voxtral runner with CUDA backend"
+	@echo "  voxtral-cpu             - Build Voxtral runner with CPU backend"
+	@echo "  voxtral-metal           - Build Voxtral runner with Metal backend (macOS only)"
+	@echo "  whisper-cuda            - Build Whisper runner with CUDA backend"
+	@echo "  whisper-debug-cuda      - Build Whisper runner with CUDA backend (debug mode)"
+	@echo "  whisper-cpu             - Build Whisper runner with CPU backend"
+	@echo "  whisper-metal           - Build Whisper runner with Metal backend (macOS only)"
+	@echo "  llama-cpu               - Build Llama runner with CPU backend"
+	@echo "  llava-cpu               - Build Llava runner with CPU backend"
+	@echo "  gemma3-cuda             - Build Gemma3 runner with CUDA backend"
+	@echo "  gemma3-cpu              - Build Gemma3 runner with CPU backend"
+	@echo "  clean                   - Clean build artifacts"
 
 voxtral-cuda:
 	@echo "==> Building and installing ExecuTorch with CUDA..."
@@ -135,6 +136,15 @@ whisper-cuda:
 	cmake --workflow --preset llm-release-cuda
 	@echo "==> Building Whisper runner with CUDA..."
 	cd examples/models/whisper && cmake --workflow --preset whisper-cuda
+	@echo ""
+	@echo "✓ Build complete!"
+	@echo "  Binary: cmake-out/examples/models/whisper/whisper_runner"
+
+whisper-debug-cuda:
+	@echo "==> Building and installing ExecuTorch with CUDA (debug mode)..."
+	cmake --workflow --preset llm-debug-cuda
+	@echo "==> Building Whisper runner with CUDA (debug mode)..."
+	cd examples/models/whisper && cmake --workflow --preset whisper-debug-cuda
 	@echo ""
 	@echo "✓ Build complete!"
 	@echo "  Binary: cmake-out/examples/models/whisper/whisper_runner"

--- a/backends/aoti/common_shims.h
+++ b/backends/aoti/common_shims.h
@@ -59,11 +59,18 @@ aoti_torch_get_device_index(Tensor* tensor, int32_t* ret_device_index);
 AOTI_SHIM_EXPORT AOTITorchError
 aoti_torch_get_dim(Tensor* tensor, int64_t* ret_dim);
 
+// Device type query (optional; backends may implement this to return device
+// type constants such as CUDA). Declared here so common shims can dispatch
+// appropriately.
+AOTI_SHIM_EXPORT AOTITorchError
+aoti_torch_get_device_type(Tensor* tensor, int32_t* ret_device_type);
+
 // Utility functions for device and layout information
 AOTI_SHIM_EXPORT int32_t aoti_torch_device_type_cpu();
 AOTI_SHIM_EXPORT int32_t aoti_torch_layout_strided();
 AOTI_SHIM_EXPORT int32_t aoti_torch_dtype_float32();
 AOTI_SHIM_EXPORT int32_t aoti_torch_dtype_bfloat16();
+AOTI_SHIM_EXPORT int32_t aoti_torch_dtype_bool();
 AOTI_SHIM_EXPORT int32_t aoti_torch_dtype_int8();
 AOTI_SHIM_EXPORT int32_t aoti_torch_dtype_int16();
 AOTI_SHIM_EXPORT int32_t aoti_torch_dtype_int32();

--- a/backends/cuda/runtime/shims/memory.h
+++ b/backends/cuda/runtime/shims/memory.h
@@ -161,9 +161,30 @@ aoti_torch_copy_(Tensor* self, Tensor* src, int32_t non_blocking);
  * @return Error::Ok on success, appropriate error code on failure:
  *         - Error::InvalidArgument: null pointers or invalid parameters
  */
-AOTITorchError aoti_torch_new_tensor_handle(
-    Tensor* orig_handle,
-    Tensor** new_handle);
+AOTI_SHIM_EXPORT AOTITorchError
+aoti_torch_new_tensor_handle(Tensor* orig_handle, Tensor** new_handle);
+
+// Function to retrieve boolean value from a 0D boolean tensor
+AOTI_SHIM_EXPORT AOTITorchError
+aoti_torch_item_bool(Tensor* tensor, bool* ret_value);
+
+/**
+ * Reinterprets the destination tensor to be a view of the source tensor's
+ * data.
+ *
+ * This function makes the destination tensor a view of the source tensor's
+ * underlying data, but with the destination tensor's original shape and
+ * strides. The number of elements in both tensors must match. The destination
+ * tensor handle will be updated to point to a new tensor view.
+ *
+ * @param src The source tensor providing the data.
+ * @param ret_dst On input, a pointer to the destination tensor. On output,
+ * this will be updated to point to the new tensor view.
+ *
+ * @return Error::Ok on success, appropriate error code on failure.
+ */
+AOTI_SHIM_EXPORT AOTITorchError
+aoti_torch_assign_tensors_out(Tensor* src, Tensor** ret_dst);
 
 // Function to clear all tensors from internal storage
 AOTI_SHIM_EXPORT void clear_all_tensors();

--- a/examples/models/whisper/CMakePresets.json
+++ b/examples/models/whisper/CMakePresets.json
@@ -29,6 +29,20 @@
             }
         },
         {
+            "name": "whisper-debug-cuda",
+            "displayName": "Whisper runner (CUDA Debug)",
+            "inherits": ["whisper-base"],
+            "cacheVariables": {
+                "EXECUTORCH_BUILD_CUDA": "ON",
+                "CMAKE_BUILD_TYPE": "Debug"
+            },
+            "condition": {
+                "lhs": "${hostSystemName}",
+                "type": "equals",
+                "rhs": "Linux"
+            }
+        },
+        {
             "name": "whisper-metal",
             "displayName": "Whisper runner (Metal)",
             "inherits": ["whisper-base"],
@@ -53,6 +67,12 @@
             "name": "whisper-cuda",
             "displayName": "Build Whisper runner (CUDA)",
             "configurePreset": "whisper-cuda",
+            "targets": ["whisper_runner"]
+        },
+        {
+            "name": "whisper-debug-cuda",
+            "displayName": "Build Whisper runner (CUDA Debug)",
+            "configurePreset": "whisper-debug-cuda",
             "targets": ["whisper_runner"]
         },
         {
@@ -88,6 +108,20 @@
                 {
                     "type": "build",
                     "name": "whisper-cuda"
+                }
+            ]
+        },
+        {
+            "name": "whisper-debug-cuda",
+            "displayName": "Configure and build Whisper runner (CUDA Debug)",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "whisper-debug-cuda"
+                },
+                {
+                    "type": "build",
+                    "name": "whisper-debug-cuda"
                 }
             ]
         },


### PR DESCRIPTION
… CUDA shim

As titled. This PR adds `aoti_torch_item_bool` implementation and `aoti_torch_new_tensor_handle` implementation.

`aoti_torch_item_bool` will be used when the model does: `scalar_tensor.item()` and expect to receive a bool.

`aoti_torch_new_tensor_handle` returns a tensor handle that share the same data pointer as another tensor.

### Summary
[PLEASE REMOVE] See [CONTRIBUTING.md's Pull Requests](https://github.com/pytorch/executorch/blob/main/CONTRIBUTING.md#pull-requests) for ExecuTorch PR guidelines.

[PLEASE REMOVE] If this PR closes an issue, please add a `Fixes #<issue-id>` line.

[PLEASE REMOVE] If this PR introduces a fix or feature that should be the upcoming release notes, please add a "Release notes: <area>" label. For a list of available release notes labels, check out [CONTRIBUTING.md's Pull Requests](https://github.com/pytorch/executorch/blob/main/CONTRIBUTING.md#pull-requests).

### Test plan
[PLEASE REMOVE] How did you test this PR? Please write down any manual commands you used and note down tests that you have written if applicable.
