### PR TITLE
Fix build isolation and editable install issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,8 @@ readme = "README-wheel.md"
 authors = [
   {name="PyTorch Team", email="packages@pytorch.org"},
 ]
-license = "BSD-3-Clause"
-license-files = ["LICENSE"]
+license = {text = "BSD-3-Clause"}
+
 keywords = ["pytorch", "machine learning"]
 # PyPI package information.
 classifiers = [
@@ -97,6 +97,9 @@ flatc = "executorch.data.bin:flatc"
 # TODO(dbort): Could use py_modules to restrict the set of modules we
 # package, and package_data to restrict the set up non-python files we
 # include. See also setuptools/discovery.py for custom finders.
+[tool.setuptools]
+license-files = ["LICENSE"]
+
 [tool.setuptools.package-dir]
 # Tell setuptools to follow the symlink: src/executorch/* -> * for all first level
 # modules such as src/executorch/exir -> exir. This helps us to semi-compliant with

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,6 @@ import shutil
 import site
 import subprocess
 import sys
-
 from distutils import log  # type: ignore[import-not-found]
 from distutils.sysconfig import get_python_lib  # type: ignore[import-not-found]
 from pathlib import Path
@@ -552,7 +551,7 @@ class CustomBuildPy(build_py):
         # package subdirectory.
         if self.editable_mode:
             # In editable mode, the package directory is the original source directory
-            dst_root = self.get_package_dir(".")
+            dst_root = self.get_package_dir("executorch")
         else:
             dst_root = os.path.join(self.build_lib, "executorch")
         # Create the version file.


### PR DESCRIPTION
Summary:
This PR fixes two issues affecting the build and installation process:

1.  **pyproject.toml configuration**: Fixed invalid `license` and `license-files` fields that were causing build failures with newer versions of `setuptools` and `pip` build isolation. The `license` field now uses the table format `{text = ...}` and `license-files` was moved to `[tool.setuptools]`.

2.  **Editable install version.py**: Fixed an issue where `version.py` was being written to the project root instead of the package directory (`src/executorch`) during editable installs. This was causing `ImportError: cannot import name 'version'` when importing `executorch`.

Test Plan:
- Verified `pip install . --no-build-isolation` works (metadata generation succeeds).
- Verified `pip install -e . --no-build-isolation` works and `from executorch import version` succeeds.

### Summary
[PLEASE REMOVE] See [CONTRIBUTING.md's Pull Requests](https://github.com/pytorch/executorch/blob/main/CONTRIBUTING.md#pull-requests) for ExecuTorch PR guidelines.

[PLEASE REMOVE] If this PR closes an issue, please add a `Fixes #<issue-id>` line.

[PLEASE REMOVE] If this PR introduces a fix or feature that should be the upcoming release notes, please add a "Release notes: <area>" label. For a list of available release notes labels, check out [CONTRIBUTING.md's Pull Requests](https://github.com/pytorch/executorch/blob/main/CONTRIBUTING.md#pull-requests).

### Test plan
[PLEASE REMOVE] How did you test this PR? Please write down any manual commands you used and note down tests that you have written if applicable.


cc @GregoryComer