### PR TITLE
Expose get_num_threads via pybind

### DIFF
--- a/extension/pybindings/portable_lib.py
+++ b/extension/pybindings/portable_lib.py
@@ -65,6 +65,7 @@ from executorch.extension.pybindings._portable_lib import (  # noqa: F401
     _load_program,  # noqa: F401
     _load_program_from_buffer,  # noqa: F401
     _reset_profile_results,  # noqa: F401
+    _threadpool_get_thread_count,  # noqa: F401
     _unsafe_reset_threadpool,  # noqa: F401
     BundledModule,  # noqa: F401
     ExecuTorchMethod,  # noqa: F401

--- a/extension/pybindings/pybindings.cpp
+++ b/extension/pybindings/pybindings.cpp
@@ -1558,6 +1558,13 @@ PYBIND11_MODULE(EXECUTORCH_PYTHON_MODULE_NAME, m) {
       },
       py::arg("num_threads"),
       call_guard);
+  m.def(
+      "_threadpool_get_thread_count",
+      []() {
+        return ::executorch::extension::threadpool::get_threadpool()
+            ->get_thread_count();
+      },
+      call_guard);
 
   py::class_<PyModule>(m, "ExecuTorchModule")
       .def(

--- a/extension/pybindings/pybindings.pyi
+++ b/extension/pybindings/pybindings.pyi
@@ -288,3 +288,12 @@ def _unsafe_reset_threadpool(num_threads: int) -> None:
         This API is experimental and subject to change without notice.
     """
     ...
+
+@experimental("This API is experimental and subject to change without notice.")
+def _threadpool_get_thread_count() -> int:
+    """
+    .. warning::
+
+        This API is experimental and subject to change without notice.
+    """
+    ...


### PR DESCRIPTION
Summary:
Main objective is to allow querying number of threads being used from python.

Later diff uses this mainly for testing.

Reviewed By: larryliu0820

Differential Revision: D87510750


