### PR TITLE
Remove download progress reporting

### DIFF
--- a/backends/qualcomm/scripts/download_qnn_sdk.py
+++ b/backends/qualcomm/scripts/download_qnn_sdk.py
@@ -143,7 +143,6 @@ def _download_archive(url: str, archive_path: pathlib.Path) -> bool:
                     if chunk:
                         f.write(chunk)
                         downloaded += len(chunk)
-                        _make_report_progress()(downloaded, downloaded, total)
 
         logger.info("Download completed!")
 
@@ -159,26 +158,6 @@ def _download_archive(url: str, archive_path: pathlib.Path) -> bool:
         return False
 
     return True
-
-
-def _make_report_progress():
-    """Return a callback to report download progress."""
-    last_reported = 0
-
-    def report_progress(block_num, block_size, total_size):
-        nonlocal last_reported
-        try:
-            downloaded = block_num * block_size
-            percent = downloaded / total_size * 100 if total_size else 100.0
-        except Exception:
-            percent, downloaded, total_size = 0.0, block_num * block_size, 0
-        if percent - last_reported >= 20 or percent >= 100:
-            logger.info(
-                "Downloaded: %d/%d bytes (%.2f%%)", downloaded, total_size, percent
-            )
-            last_reported = percent
-
-    return report_progress
 
 
 def _extract_archive(

--- a/backends/qualcomm/scripts/download_qnn_sdk.py
+++ b/backends/qualcomm/scripts/download_qnn_sdk.py
@@ -134,7 +134,6 @@ def _download_archive(url: str, archive_path: pathlib.Path) -> bool:
         with session.get(url, stream=True) as r:
             r.raise_for_status()
 
-            total = int(r.headers.get("content-length", 0))
             downloaded = 0
             chunk_size = 1024 * 1024  # 1MB
 


### PR DESCRIPTION
It's not compatible with https://github.com/pytorch/executorch/pull/15933 which cause 2^70+ byte counters like
```
Downloaded: 839890544179019776 / 1354151797 bytes (62023367397.93%)
Downloaded: 841813590016000000 / 1354151797 bytes (62165378496.04%)
```

