### PR TITLE
Disable QNN build option for the default x86 build

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -13,32 +13,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test-qnn-wheel-packages-linux:
-    name: test-qnn-wheel-packages-linux
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
-    permissions:
-      id-token: write
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: [ "3.10", "3.11", "3.12" ]
-    with:
-      runner: linux.2xlarge
-      docker-image: ci-image:executorch-ubuntu-22.04-qnn-sdk
-      submodules: 'recursive'
-      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-      timeout: 180
-      script: |
-        # The generic Linux job chooses to use base env, not the one setup by the image
-        CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
-        conda activate "${CONDA_ENV}"
+  # test-qnn-wheel-packages-linux:
+  #   name: test-qnn-wheel-packages-linux
+  #   uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+  #   permissions:
+  #     id-token: write
+  #     contents: read
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       python-version: [ "3.10", "3.11", "3.12" ]
+  #   with:
+  #     runner: linux.2xlarge
+  #     docker-image: ci-image:executorch-ubuntu-22.04-qnn-sdk
+  #     submodules: 'recursive'
+  #     ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+  #     timeout: 180
+  #     script: |
+  #       # The generic Linux job chooses to use base env, not the one setup by the image
+  #       CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
+  #       conda activate "${CONDA_ENV}"
 
-        # Create a clean env for each python version
-        conda create -y -n test_env_${{ matrix.python-version }} python=${{ matrix.python-version }}
-        conda activate test_env_${{ matrix.python-version }}
+  #       # Create a clean env for each python version
+  #       conda create -y -n test_env_${{ matrix.python-version }} python=${{ matrix.python-version }}
+  #       conda activate test_env_${{ matrix.python-version }}
 
-        PYTHON_EXECUTABLE=python bash .ci/scripts/test_wheel_package_qnn.sh "${{ matrix.python-version }}"
+  #       PYTHON_EXECUTABLE=python bash .ci/scripts/test_wheel_package_qnn.sh "${{ matrix.python-version }}"
 
   test-setup-linux-gcc:
     name: test-setup-linux-gcc

--- a/tools/cmake/preset/pybind.cmake
+++ b/tools/cmake/preset/pybind.cmake
@@ -37,7 +37,7 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   set_overridable_option(EXECUTORCH_BUILD_EXTENSION_LLM_RUNNER ON)
   set_overridable_option(EXECUTORCH_BUILD_EXTENSION_LLM ON)
   if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|amd64|i.86)$")
-    set_overridable_option(EXECUTORCH_BUILD_QNN ON)
+    set_overridable_option(EXECUTORCH_BUILD_QNN OFF)
   endif()
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows" OR CMAKE_SYSTEM_NAME STREQUAL
                                                "WIN32"


### PR DESCRIPTION
seems like qnn download sdk is very unreliable. Trying to fix it then re-enable it
