### PR TITLE
Adding compile option warmup_execute_after_compile to optionally run execute rigtht after compilation to create command buffers.

### DIFF
--- a/backends/vulkan/runtime/VulkanBackend.cpp
+++ b/backends/vulkan/runtime/VulkanBackend.cpp
@@ -179,6 +179,12 @@ GraphConfig get_graph_config(ArrayRef<CompileSpec>& compile_specs) {
         config.expect_dynamic_shapes = true;
       }
     }
+    if (strcmp(spec.key, "warmup_execute_after_compile") == 0) {
+      ET_CHECK_MSG(value_size == sizeof(uint8_t), "Unexpected value size!");
+      bool value = getBool(value_data);
+
+      config.warmup_execute_after_compile = value;
+    }
   }
 #ifdef ET_EVENT_TRACER_ENABLED
   config.enable_querypool = true;
@@ -578,6 +584,8 @@ class VulkanBackend final : public ::executorch::runtime::BackendInterface {
     compute_graph->prepare_pipelines();
 
     compute_graph->prepack();
+
+    compute_graph->optional_warmup_execute();
 
     return Error::Ok;
   }

--- a/backends/vulkan/runtime/graph/ComputeGraph.cpp
+++ b/backends/vulkan/runtime/graph/ComputeGraph.cpp
@@ -1107,6 +1107,12 @@ void ComputeGraph::prepack() {
   }
 }
 
+void ComputeGraph::optional_warmup_execute() {
+  if (config_.warmup_execute_after_compile) {
+    execute();
+  }
+}
+
 void ComputeGraph::execute() {
   if (deferred_cmd_list_.empty()) {
     context_->flush();

--- a/backends/vulkan/runtime/graph/ComputeGraph.h
+++ b/backends/vulkan/runtime/graph/ComputeGraph.h
@@ -1034,6 +1034,12 @@ class ComputeGraph final {
   void prepack();
 
   //
+  // Optional Graph Execution
+  //
+
+  void optional_warmup_execute();
+
+  //
   // Graph Execution
   //
 

--- a/backends/vulkan/runtime/graph/GraphConfig.h
+++ b/backends/vulkan/runtime/graph/GraphConfig.h
@@ -71,6 +71,10 @@ struct GraphConfig final {
   // many command buffers.
   size_t execute_max_cmds = 0;
 
+  // If true, then the graph will be executed once immediately after it is
+  // compiled.
+  bool warmup_execute_after_compile = false;
+
   vkapi::Adapter* external_adapter;
 
   // Generate a default graph config with pre-configured settings


### PR DESCRIPTION
Summary: This diff introduces a new compile option, `warmup_execute_after_compile`, which allows the graph to be executed once immediately after it is compiled. This option is disabled by default and can be enabled by setting the `warmup_execute_after_compile` flag to `true` in the `GraphConfig` object. When enabled, the `optional_warmup_execute` method makes a dummy call to `execute` function after the graph is prepacked.

Differential Revision: D87781471


