### PR TITLE
Arm backend: Add missing bool case in prepare_input_tensors

### DIFF
--- a/examples/arm/executor_runner/arm_executor_runner.cpp
+++ b/examples/arm/executor_runner/arm_executor_runner.cpp
@@ -470,6 +470,12 @@ Error prepare_input_tensors(
                 tensor.mutable_data_ptr<int8_t>() + tensor.numel(),
                 1);
             break;
+          case ScalarType::Bool:
+            std::fill(
+                tensor.mutable_data_ptr<int8_t>(),
+                tensor.mutable_data_ptr<int8_t>() + tensor.numel(),
+                1);
+            break;
           default:
             ET_LOG(Error, "Unhandled ScalarType");
             err = Error::InvalidArgument;


### PR DESCRIPTION
Before the commit that added a default case, booleans where never handled and set to 1 instead they just passed through gracefully.

Now there is a case to handle booleans and set them to 1.

Signed-off-by: per.held@arm.com
Change-Id: I64d4cae231a258d0f732c7a12e2f0d1c3be521cf



cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai