### PR TITLE
QNN Backend: Enable QualComm SM8850 targets

### DIFF
--- a/backends/qualcomm/README.md
+++ b/backends/qualcomm/README.md
@@ -21,6 +21,7 @@ Please check `generate_qnn_executorch_compiler_spec()` in
 - Snapdragon 8 Gen 2
 - Snapdragon 8 Gen 3
 - Snapdragon 8 Elite
+- Snapdragon 8 Elite Gen 5
 - SA8295
 - SA8255
 - SSG2115P

--- a/backends/qualcomm/serialization/qc_compiler_spec.fbs
+++ b/backends/qualcomm/serialization/qc_compiler_spec.fbs
@@ -40,6 +40,7 @@ enum QcomChipset: int {
   SM8550 = 43,
   SM8650 = 57,
   SM8750 = 69,
+  SM8850 = 87,
   SSG2115P = 46,
   SSG2125P = 58,
   SXR1230P = 45,

--- a/backends/qualcomm/serialization/qc_schema.py
+++ b/backends/qualcomm/serialization/qc_schema.py
@@ -46,6 +46,7 @@ class QcomChipset(IntEnum):
     SM8550 = 43  # v73
     SM8650 = 57  # v75
     SM8750 = 69  # v79
+    SM8850 = 87  # v81
     SSG2115P = 46  # v73
     SSG2125P = 58  # v73
     SXR1230P = 45  # v73
@@ -71,6 +72,7 @@ _soc_info_table = {
     QcomChipset.SA8255: SocInfo(QcomChipset.SA8255, HtpInfo(HtpArch.V73, 8)),
     QcomChipset.SM8650: SocInfo(QcomChipset.SM8650, HtpInfo(HtpArch.V75, 8)),
     QcomChipset.SM8750: SocInfo(QcomChipset.SM8750, HtpInfo(HtpArch.V79, 8)),
+    QcomChipset.SM8850: SocInfo(QcomChipset.SM8850, HtpInfo(HtpArch.V81, 8)),
     QcomChipset.SSG2115P: SocInfo(QcomChipset.SSG2115P, HtpInfo(HtpArch.V73, 2)),
     QcomChipset.SSG2125P: SocInfo(QcomChipset.SSG2125P, HtpInfo(HtpArch.V73, 2)),
     QcomChipset.SXR1230P: SocInfo(QcomChipset.SXR1230P, HtpInfo(HtpArch.V73, 2)),

--- a/backends/qualcomm/utils/utils.py
+++ b/backends/qualcomm/utils/utils.py
@@ -1002,6 +1002,7 @@ def generate_qnn_executorch_compiler_spec(
             SM8550(Snapdragon 8 Gen 2)
             SM8650(Snapdragon 8 Gen 3)
             SM8750(Snapdragon 8 Elite)
+            SM8850(Snapdragon 8 Elite Gen 5)
         backend_options: Options required by different backends.
         debug: Enable verbose logging. Disclaimer: this option must change in
             the near future.
@@ -1097,6 +1098,7 @@ def get_soc_to_arch_map():
         "SA8255": HtpArch.V73,
         "SM8650": HtpArch.V75,
         "SM8750": HtpArch.V79,
+        "SM8850": HtpArch.V81,
         "SSG2115P": HtpArch.V73,
         "SSG2125P": HtpArch.V73,
         "SXR1230P": HtpArch.V73,
@@ -1117,6 +1119,7 @@ def get_soc_to_chipset_map():
         "SA8255": QcomChipset.SA8255,
         "SM8650": QcomChipset.SM8650,
         "SM8750": QcomChipset.SM8750,
+        "SM8850": QcomChipset.SM8850,
         "SSG2115P": QcomChipset.SSG2115P,
         "SSG2125P": QcomChipset.SSG2125P,
         "SXR1230P": QcomChipset.SXR1230P,


### PR DESCRIPTION
Add SM8850 for QualComm Snapdragon 8 Elite Gen 5.

### Summary
Fixes #15986


### Test plan
python -m examples.qualcomm.oss_scripts.llama.llama   -b build-android   -m SM8850   --temperature 0   --model_mode kv   --max_seq_len 512   --prefill_ar_len 64   --decoder_model qwen3-0_6b  --prompt "你好，请介绍一 
下人工智能"   --compile_only
