### PR TITLE
Cortex_M backend: Fuse clamp + hardswish decompostion

### DIFF
--- a/backends/cortex_m/ops/cortex_m_ops_common.h
+++ b/backends/cortex_m/ops/cortex_m_ops_common.h
@@ -69,11 +69,7 @@ inline void validate_cmsis_nn_tensor_requirements(
         "Output must have the same sizes as inputs");
   }
 
-  // Dim order consistency
-  ET_CHECK_MSG(
-      executorch::runtime::tensors_have_same_dim_order(input1, input2, output),
-      "Tensors must have same dimension order");
-
+  // TBD: Validate dim_order
   // TBD: Validate memory alignment (CMSIS-NN requirement)
 }
 

--- a/backends/cortex_m/ops/cortex_m_ops_common.h
+++ b/backends/cortex_m/ops/cortex_m_ops_common.h
@@ -69,7 +69,7 @@ inline void validate_cmsis_nn_tensor_requirements(
         "Output must have the same sizes as inputs");
   }
 
-  // TBD: Validate dim_order
+  // TBD (#16032): Validate dim_order
   // TBD: Validate memory alignment (CMSIS-NN requirement)
 }
 

--- a/backends/cortex_m/passes/__init__.py
+++ b/backends/cortex_m/passes/__init__.py
@@ -4,7 +4,9 @@
 # LICENSE file in the root directory of this source tree.
 
 from .activation_fusion_pass import ActivationFusionPass  # noqa
+from .clamp_hardswish_pass import ClampHardswishPass  # noqa
 from .convert_to_cortex_m_pass import ConvertToCortexMPass  # noqa
+from .decompose_hardswish_pass import DecomposeHardswishPass  # noqa
 from .quantized_op_fusion_pass import QuantizedOpFusionPass  # noqa
 from .replace_quant_nodes_pass import ReplaceQuantNodesPass  # noqa
 from .cortex_m_pass_manager import CortexMPassManager  # noqa  # usort: skip

--- a/backends/cortex_m/passes/clamp_hardswish_pass.py
+++ b/backends/cortex_m/passes/clamp_hardswish_pass.py
@@ -1,0 +1,37 @@
+# Copyright 2025 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Dict
+
+import torch
+
+from executorch.exir.dialects.edge._ops import EdgeOpOverload
+from executorch.exir.pass_base import ExportPass, NodeMetadata, ProxyValue
+from torch.fx.node import Argument
+
+
+class ClampHardswishPass(ExportPass):
+    """
+    Adds a clamp operation before hardswish to ensure input is in the range [-3, inf).
+
+    By doing this before quantization the output range of the preceeding op is minimized,
+    potentially improving accuracy.
+    """
+
+    def call_operator(
+        self,
+        op: EdgeOpOverload,
+        args: tuple[Argument, ...],
+        kwargs: Dict[str, Argument],
+        meta: NodeMetadata,
+    ) -> ProxyValue:
+        if op == torch.ops.aten.hardswish.default:
+            clamped_args = (args[0], -3)
+            clamped_input = super().call_operator(
+                torch.ops.aten.clamp.default, clamped_args, {}, meta
+            )
+            args = (clamped_input,)
+
+        return super().call_operator(op, args, kwargs, meta)

--- a/backends/cortex_m/passes/convert_to_cortex_m_pass.py
+++ b/backends/cortex_m/passes/convert_to_cortex_m_pass.py
@@ -10,6 +10,7 @@ import executorch.backends.cortex_m.ops.operators  # noqa
 
 import torch
 import torch.fx
+from executorch.backends.arm._passes.arm_pass_utils import get_first_fake_tensor
 from executorch.backends.cortex_m.passes.passes_utils import quantize_multiplier_aot
 
 from executorch.backends.transforms.utils import (
@@ -137,7 +138,8 @@ class ConvertToCortexMPass(XNNPACKPass):
         input_zero_point = node.meta["input_qparams"][0].zp
         weight_scales = node.meta["input_qparams"][1].scale
         if not isinstance(weight_scales, list):
-            weight_scales = [weight_scales] * weight.data.shape[0]
+            weight_tensor = get_first_fake_tensor(weight)
+            weight_scales = [weight_scales] * weight_tensor.shape[0]
 
         output_qparams = node.meta["output_qparams"][0]
         output_scale = output_qparams.scale

--- a/backends/cortex_m/passes/cortex_m_pass_manager.py
+++ b/backends/cortex_m/passes/cortex_m_pass_manager.py
@@ -12,7 +12,9 @@ from executorch.backends.arm._passes import (
 )
 from executorch.backends.cortex_m.passes import (
     ActivationFusionPass,
+    ClampHardswishPass,
     ConvertToCortexMPass,
+    DecomposeHardswishPass,
     QuantizedOpFusionPass,
     ReplaceQuantNodesPass,
 )
@@ -31,14 +33,16 @@ class CortexMPassManager(PassManager):
         FoldAndAnnotateQParamsPass,
         ReplaceScalarWithTensorArgPass,
         ReplaceQuantNodesPass,
-        QuantizedOpFusionPass,
         ActivationFusionPass,
+        DecomposeHardswishPass,
+        QuantizedOpFusionPass,
         ConvertToCortexMPass,
     ]
 
     pass_list_transform_for_annotation: list[ExportPass] = [
         ScalarsToAttributePass,
         ReplaceScalarWithTensorArgPass,
+        ClampHardswishPass,
     ]
 
     def __init__(self, exported_program, passes=None):

--- a/backends/cortex_m/passes/decompose_hardswish_pass.py
+++ b/backends/cortex_m/passes/decompose_hardswish_pass.py
@@ -1,0 +1,127 @@
+# Copyright 2025 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import logging
+
+import executorch.backends.cortex_m.ops.operators  # noqa: F401
+
+import torch
+from executorch.backends.arm._passes.quant_args import QuantArgs
+
+from executorch.backends.cortex_m.passes.passes_utils import quantize_val
+
+from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import ExportPass
+from torch.fx import GraphModule, Node
+from torch.fx.passes.infra.pass_manager import PassResult
+
+logger = logging.getLogger(__name__)
+
+
+class DecomposeHardswishPass(ExportPass):
+    """
+    Decomposes hardswish like
+
+        hardswish(x) = x * (clamp(x, -3, 3) + 3)/6
+
+    where the add and division is implemented by modifying the quantization parameters similar
+    to hardsigmoid in the activation_fusion_pass. Note that this pass assumes
+    that the output range of the preceding op is already clamped to [-3, inf] during
+    quantization by the clamp_hardswish_pass, removing the need for the negative clamp.
+    """
+
+    TARGETS = {
+        exir_ops.edge.aten.hardswish.default,
+    }
+
+    FUSE_OPS = {
+        exir_ops.edge.aten.linear.default,
+        exir_ops.edge.aten.convolution.default,
+    }
+
+    def call(self, graph_module: GraphModule) -> PassResult:
+        modified = False
+        nodes_to_erase: list[Node] = []
+
+        for node in list(graph_module.graph.nodes):
+            if node.op != "call_function" or node.target not in self.TARGETS:
+                continue
+
+            input_node = node.args[0]
+            if (
+                input_node.op != "call_function"
+                or input_node.target not in self.FUSE_OPS
+            ):
+                logger.warning(
+                    f"Cannot fuse activation {node.name} as input node {input_node.name} is not a supported fused activation op."
+                )
+                continue
+            if len(input_node.users.values()) > 1:
+                logger.warning(
+                    f"Cannot fuse activation {node.name} as input node {input_node.name} has multiple users."
+                )
+                continue
+
+            input_quant_dict = input_node.meta.get("output_qparams", [None])[
+                0
+            ]._asdict()
+            scale = input_quant_dict["scale"]
+            zero_point = input_quant_dict["zp"]
+            qmin = input_quant_dict["qmin"]
+            qmax = input_quant_dict["qmax"]
+
+            # Create min node
+            with graph_module.graph.inserting_after(input_node):
+                clamp_node = graph_module.graph.create_node(
+                    "call_function",
+                    target=exir_ops.edge.aten.minimum.default,
+                    args=(
+                        input_node,
+                        torch.tensor(
+                            quantize_val(3, scale, zero_point, qmin, qmax),
+                            dtype=torch.int8,
+                        ),
+                    ),
+                    kwargs={},
+                )
+                clamp_node.meta = input_node.meta.copy()
+
+            # Create mul node
+            with graph_module.graph.inserting_after(clamp_node):
+                mul_node = graph_module.graph.create_node(
+                    "call_function",
+                    target=exir_ops.edge.aten.mul.Tensor,
+                    args=(input_node, clamp_node),
+                    kwargs={},
+                )
+                mul_node.meta = node.meta.copy()
+
+            mul_quant_dict = node.meta["input_qparams"][0]._asdict()
+
+            mul_quant_dict_shifted = mul_quant_dict.copy()
+            mul_quant_dict_shifted["zp"] = mul_quant_dict_shifted["zp"] - round(
+                3 / (mul_quant_dict_shifted["scale"])
+            )
+
+            output_quant_dict = node.meta["output_qparams"][0]._asdict()
+            output_quant_dict["scale"] = output_quant_dict["scale"] * 6
+
+            node.meta["input_qparams"][0] = QuantArgs(**mul_quant_dict)
+            mul_node.meta["input_qparams"][1] = QuantArgs(**mul_quant_dict_shifted)
+            mul_node.meta["output_qparams"][0] = QuantArgs(**output_quant_dict)
+
+            node.replace_all_uses_with(mul_node)
+            nodes_to_erase.append(node)
+            modified = True
+
+        for node in nodes_to_erase:
+            graph_module.graph.erase_node(node)
+
+        if modified:
+            graph_module.graph.eliminate_dead_code()
+            graph_module.recompile()
+
+        return PassResult(graph_module, modified)

--- a/backends/cortex_m/passes/passes_utils.py
+++ b/backends/cortex_m/passes/passes_utils.py
@@ -17,6 +17,10 @@ from torch.fx import Node
 SHIFT_INT8 = 20
 
 
+def quantize_val(val, scale, zp, qmin, qmax):
+    return min(max(round(val / scale + zp), qmin), qmax)
+
+
 def dequantize_per_tensor_cmsis(
     qtensor: torch.Tensor, zero_point: int, multiplier: int, shift: int
 ) -> torch.Tensor:

--- a/backends/cortex_m/quantizer/operator_configs.py
+++ b/backends/cortex_m/quantizer/operator_configs.py
@@ -19,6 +19,8 @@ from torchao.quantization.pt2e.quantizer import OperatorConfig
 BINARY_OP_PATTERNS = [
     [torch.ops.aten.add.Tensor],
     [torch.ops.aten.mul.Tensor],
+    [torch.ops.aten.hardswish.default],
+    [torch.ops.aten.hardswish_.default],
 ]
 
 LINEAR_OP_PATTERNS = [
@@ -29,6 +31,8 @@ LINEAR_OP_PATTERNS = [
     [torch.ops.aten.linear.default, torch.ops.aten.hardtanh_.default],
     [torch.ops.aten.linear.default, torch.ops.aten.hardsigmoid.default],
     [torch.ops.aten.linear.default, torch.ops.aten.hardsigmoid_.default],
+    [torch.ops.aten.linear.default, torch.ops.aten.clamp.default],
+    [torch.ops.aten.linear.default, torch.ops.aten.clamp_.default],
 ]
 
 CONV_OP_PATTERNS = [
@@ -39,6 +43,8 @@ CONV_OP_PATTERNS = [
     [torch.ops.aten.conv2d.default, torch.ops.aten.hardtanh_.default],
     [torch.ops.aten.conv2d.default, torch.ops.aten.hardsigmoid.default],
     [torch.ops.aten.conv2d.default, torch.ops.aten.hardsigmoid_.default],
+    [torch.ops.aten.conv2d.default, torch.ops.aten.clamp.default],
+    [torch.ops.aten.conv2d.default, torch.ops.aten.clamp_.default],
 ]
 
 # ----------------- OPERATOR CONFIG PRESETS -----------------

--- a/backends/cortex_m/test/ops/test_activation.py
+++ b/backends/cortex_m/test/ops/test_activation.py
@@ -3,7 +3,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-
 import torch
 from executorch.backends.arm.test.common import parametrize
 from executorch.backends.cortex_m.test.tester import (
@@ -153,6 +152,32 @@ class CortexMLinearHardsigmoid(torch.nn.Module):
         return self.act(self.linear(x))
 
 
+class CortexMLinearHardswish(torch.nn.Module):
+    ops_before_transforms = {
+        "executorch_exir_dialects_edge__ops_aten_linear_default": 1,
+        "executorch_exir_dialects_edge__ops_aten_clamp_default": 1,
+        "executorch_exir_dialects_edge__ops_aten_hardswish_default": 1,
+        "executorch_exir_dialects_edge__ops_quantized_decomposed_quantize_per_tensor_default": 3,
+        "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_tensor_default": 4,
+    }
+
+    ops_after_transforms = {
+        "executorch_exir_dialects_edge__ops_cortex_m_quantized_linear_default": 1,
+        "executorch_exir_dialects_edge__ops_cortex_m_quantize_per_tensor_default": 1,
+        "executorch_exir_dialects_edge__ops_cortex_m_minimum_default": 1,
+        "executorch_exir_dialects_edge__ops_cortex_m_quantized_mul_default": 1,
+        "executorch_exir_dialects_edge__ops_cortex_m_dequantize_per_tensor_default": 1,
+    }
+
+    def __init__(self, in_features=8, out_features=8):
+        super().__init__()
+        self.linear = torch.nn.Linear(in_features, out_features, bias=False)
+        self.act = torch.nn.Hardswish()
+
+    def forward(self, x):
+        return self.act(self.linear(x))
+
+
 class CortexMConv2DReLU(torch.nn.Module):
     ops_before_transforms = {
         "executorch_exir_dialects_edge__ops_aten_convolution_default": 1,
@@ -220,6 +245,34 @@ class CortexMConv2DHardtanh(torch.nn.Module):
         super().__init__()
         self.conv = torch.nn.Conv2d(4, 8, 3, padding=1, bias=True)
         self.act = torch.nn.Hardtanh(min_val=min_val, max_val=max_val)
+
+    def forward(self, x):
+        return self.act(self.conv(x))
+
+
+class CortexMConv2DHardswish(torch.nn.Module):
+    ops_before_transforms = {
+        "executorch_exir_dialects_edge__ops_aten_convolution_default": 1,
+        "executorch_exir_dialects_edge__ops_aten_clamp_default": 1,
+        "executorch_exir_dialects_edge__ops_aten_hardswish_default": 1,
+        "executorch_exir_dialects_edge__ops_quantized_decomposed_quantize_per_tensor_default": 3,
+        "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_tensor_default": 3,
+        "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_channel_default": 1,
+    }
+
+    ops_after_transforms = {
+        "executorch_exir_dialects_edge__ops_cortex_m_quantized_conv2d_default": 1,
+        "executorch_exir_dialects_edge__ops_cortex_m_quantize_per_tensor_default": 1,
+        "executorch_exir_dialects_edge__ops_cortex_m_minimum_default": 1,
+        "executorch_exir_dialects_edge__ops_cortex_m_quantized_mul_default": 1,
+        "executorch_exir_dialects_edge__ops_cortex_m_dequantize_per_tensor_default": 1,
+    }
+
+    def __init__(self, in_channels=1, out_channels=1):
+        super().__init__()
+        self.conv = torch.nn.Conv2d(1, 1, 1, padding=0, bias=False)
+        self.act = torch.nn.Hardswish()
+        self.conv.weight.data.fill_(1)
 
     def forward(self, x):
         return self.act(self.conv(x))
@@ -297,6 +350,52 @@ class CortexMConv2DHardsigmoid(torch.nn.Module):
 
     def forward(self, x):
         return self.act(self.conv(x))
+
+
+class CortexMConv2DClampInplace(torch.nn.Module):
+    ops_before_transforms = {
+        "executorch_exir_dialects_edge__ops_aten_convolution_default": 1,
+        "executorch_exir_dialects_edge__ops_aten_clamp_default": 1,
+        "executorch_exir_dialects_edge__ops_quantized_decomposed_quantize_per_tensor_default": 2,
+        "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_tensor_default": 2,
+        "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_channel_default": 1,
+    }
+
+    ops_after_transforms = {
+        "executorch_exir_dialects_edge__ops_cortex_m_quantized_conv2d_default": 1,
+        "executorch_exir_dialects_edge__ops_cortex_m_quantize_per_tensor_default": 1,
+        "executorch_exir_dialects_edge__ops_cortex_m_dequantize_per_tensor_default": 1,
+    }
+
+    def __init__(self):
+        super().__init__()
+        self.conv = torch.nn.Conv2d(1, 1, 1, bias=False)
+        self.conv.weight.data.fill_(1)
+
+    def forward(self, x):
+        return torch.clamp_(self.conv(x), min=0.0, max=None)
+
+
+class CortexMLinearClamp(torch.nn.Module):
+    ops_before_transforms = {
+        "executorch_exir_dialects_edge__ops_aten_linear_default": 1,
+        "executorch_exir_dialects_edge__ops_aten_clamp_default": 1,
+        "executorch_exir_dialects_edge__ops_quantized_decomposed_quantize_per_tensor_default": 2,
+        "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_tensor_default": 3,
+    }
+
+    ops_after_transforms = {
+        "executorch_exir_dialects_edge__ops_cortex_m_quantized_linear_default": 1,
+        "executorch_exir_dialects_edge__ops_cortex_m_quantize_per_tensor_default": 1,
+        "executorch_exir_dialects_edge__ops_cortex_m_dequantize_per_tensor_default": 1,
+    }
+
+    def __init__(self, in_features=4, out_features=3):
+        super().__init__()
+        self.linear = torch.nn.Linear(in_features, out_features, bias=False)
+
+    def forward(self, x):
+        return torch.clamp(self.linear(x), min=None, max=6.0)
 
 
 test_cases = {
@@ -384,11 +483,31 @@ test_cases = {
         model=CortexMLinearHardsigmoid(in_features=6, out_features=4),
         example_inputs=(ramp_tensor(-8, 8, (2, 6)),),
     ),
+    "linear_hardswish": McuTestCase(
+        model=CortexMLinearHardswish(in_features=12, out_features=6),
+        example_inputs=(ramp_tensor(-12, 12, (1, 12)),),
+    ),
     "conv2d_hardsigmoid_inplace": McuTestCase(
         model=CortexMConv2DHardsigmoid(),
         example_inputs=(
             ramp_tensor(-4, 4, (1, 1, 6, 6)).to(memory_format=torch.channels_last),
         ),
+    ),
+    "conv2d_hardswish": McuTestCase(
+        model=CortexMConv2DHardswish(in_channels=1, out_channels=1),
+        example_inputs=(
+            ramp_tensor(-3, 0, (1, 1, 1, 100)).to(memory_format=torch.channels_last),
+        ),
+    ),
+    "conv2d_clamp_inplace": McuTestCase(
+        model=CortexMConv2DClampInplace(),
+        example_inputs=(
+            ramp_tensor(-4, 4, (1, 1, 1, 10)).to(memory_format=torch.channels_last),
+        ),
+    ),
+    "linear_clamp": McuTestCase(
+        model=CortexMLinearClamp(in_features=4, out_features=3),
+        example_inputs=(ramp_tensor(-10, 10, (1, 4)),),
     ),
 }
 

--- a/backends/cortex_m/test/tester.py
+++ b/backends/cortex_m/test/tester.py
@@ -39,6 +39,8 @@ class CortexMToEdge(ToEdge):
                 torch.ops.aten.linear.default,
                 torch.ops.aten.hardsigmoid.default,
                 torch.ops.aten.hardsigmoid_.default,
+                torch.ops.aten.hardswish.default,
+                torch.ops.aten.hardswish_.default,
             ]
         )
         super().__init__(config)


### PR DESCRIPTION
Adds quantization and fusion of clamp.

This is in turn used to decompose the hardswish operator in two passes, one clamping the dynamic range before quantization, and one decomposing the reminder of the operation into a maximum and mul op.

The tests in this patch exposes an issue in the runtime dim_order check as it cannot differ between channels_last/channels_first for tensors with C=1 or H=W=1. Therefore the check is removed and added as a TBD instead.

Additionally fixes per_tensor quantization for conv2d.