### PR TITLE
Switch to pnpm for dependency management

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -862,15 +862,17 @@ jobs:
         # Install Node.js and Emscripten
         source .ci/scripts/setup-emscripten.sh
 
+        npm install -g pnpm
+
         # Test selective build
         bash scripts/build_wasm_tests.sh ${{ matrix.enable-etdump }}
 
         # Install Jest
         cd cmake-out-wasm/extension/wasm/test
-        npm install --save-dev jest
+        pnpm add -D jest --ignore-scripts
 
         # Run unit test
-        npm test
+        pnpm test
 
   unittest-nxp-neutron:
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -862,7 +862,12 @@ jobs:
         # Install Node.js and Emscripten
         source .ci/scripts/setup-emscripten.sh
         
-        npm install -g pnpm@10.24.0 --ignore-scripts
+        curl -fsSL https://get.pnpm.io/install.sh | sh -
+
+        export PNPM_HOME="$HOME/.local/share/pnpm"
+        export PATH="$PNPM_HOME:$PATH"
+
+        pnpm --version
 
         # Test selective build
         bash scripts/build_wasm_tests.sh ${{ matrix.enable-etdump }}

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -861,8 +861,8 @@ jobs:
 
         # Install Node.js and Emscripten
         source .ci/scripts/setup-emscripten.sh
-
-        npm install -g pnpm@10.24.0
+        
+        npm install -g pnpm@10.24.0 --ignore-scripts
 
         # Test selective build
         bash scripts/build_wasm_tests.sh ${{ matrix.enable-etdump }}

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -861,8 +861,10 @@ jobs:
 
         # Install Node.js and Emscripten
         source .ci/scripts/setup-emscripten.sh
+
+        export PNPM_VERSION=10.24.0
         
-        curl -fsSL https://get.pnpm.io/install.sh | sh -
+        curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION=$PNPM_VERSION SHELL="$(which bash)" sh -
 
         export PNPM_HOME="$HOME/.local/share/pnpm"
         export PATH="$PNPM_HOME:$PATH"

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -862,14 +862,14 @@ jobs:
         # Install Node.js and Emscripten
         source .ci/scripts/setup-emscripten.sh
 
-        npm install -g pnpm
+        npm install -g pnpm@10.24.0
 
         # Test selective build
         bash scripts/build_wasm_tests.sh ${{ matrix.enable-etdump }}
 
         # Install Jest
         cd cmake-out-wasm/extension/wasm/test
-        pnpm add -D jest --ignore-scripts
+        pnpm add -D jest@30.2.0 --ignore-scripts
 
         # Run unit test
         pnpm test


### PR DESCRIPTION
This PR hardens the executorch WASM test CI pipeline against the [Shai Hulud 2.0 supply chain attack](https://www.wiz.io/blog/shai-hulud-2-0-ongoing-supply-chain-attack) (and similar NPM-based threats) by migrating the test runner environment from npm to pnpm and enforcing strict script blocking.

Implements --ignore-scripts during dependency installation. This ensures that even if a compromised package is downloaded, its malicious payload (usually a script that installs Bun/malware) cannot execute.

Uses curl to install pnpm, bypassing the NPM registry entirely for the tool installation.

Explicitly pins pnpm (v10.24.0) and jest (v30.2.0) versions to prevent "drift" into potentially compromised future releases.

