### PR TITLE
Add CentOS to the supported host OS

### DIFF
--- a/docs/source/backends-qualcomm.md
+++ b/docs/source/backends-qualcomm.md
@@ -36,17 +36,23 @@ Currently, this ExecuTorch Backend can delegate AI computations to Hexagon proce
 
 ### Host OS
 
-The Linux host operating system that QNN Backend is verified with is Ubuntu 22.04 LTS x64
-at the moment of updating this tutorial.
-In addition, it is also confirmed to work on Windows Subsystem for Linux (WSL) with Ubuntu 22.04.
-Usually, we verified the backend on the same OS version which QNN is verified with.
-The version is documented in QNN SDK.
+The QNN Backend is currently verified on the following Linux host operating systems:
+
+- **Ubuntu 22.04 LTS (x64)**
+- **CentOS Stream 9**
+- **Windows Subsystem for Linux (WSL)** with Ubuntu 22.04
+
+In general, we verify the backend on the same OS versions that the QNN SDK is officially validated against.  
+The exact supported versions are documented in the QNN SDK.
 
 #### Windows (WSL) Setup
+
 To install Ubuntu 22.04 on WSL, run the following command in PowerShell or Windows Terminal:
-``` bash
+
+```bash
 wsl --install -d ubuntu 22.04
 ```
+
 This command will install WSL and set up Ubuntu 22.04 as the default Linux distribution.
 
 For more details and troubleshooting, refer to the official Microsoft WSL installation guide:


### PR DESCRIPTION
Updated the prerequisites section to include additional supported Linux distributions for the QNN Backend.

