### PR TITLE
Call prepare_traced_pt2 instead of prepare_pt2 in get_fake_quant_model

### DIFF
--- a/backends/cadence/aot/compiler.py
+++ b/backends/cadence/aot/compiler.py
@@ -183,7 +183,7 @@ def get_fake_quant_model(
         logging.info(program.graph.print_tabular())
 
     # Get prepared graph module
-    prepared_gm = prepare_pt2(model, inputs, quantizer, dump_graphs=dump_graphs)
+    prepared_gm = prepare_traced_pt2(program, quantizer, dump_graphs=dump_graphs)
 
     # Calibrate
     # If no calibration data is provided, use the inputs


### PR DESCRIPTION
Summary: avoids tracing twice

Differential Revision: D88103722


