### PR TITLE
reorganize VOLK_IMPLEMENTATION usage

### DIFF
--- a/backends/vulkan/runtime/vk_api/Runtime.cpp
+++ b/backends/vulkan/runtime/vk_api/Runtime.cpp
@@ -14,12 +14,6 @@
 #include <iostream>
 #include <sstream>
 
-#ifdef USE_VOLK_HEADER_ONLY
-// For volk.h, define this before including volk.h in exactly one CPP file.
-#define VOLK_IMPLEMENTATION
-#include <volk.h>
-#endif /* USE_VOLK_HEADER_ONLY */
-
 namespace vkcompute {
 namespace vkapi {
 

--- a/backends/vulkan/targets.bzl
+++ b/backends/vulkan/targets.bzl
@@ -192,6 +192,7 @@ def define_common_targets(is_fbcode = False):
         else:
             for deps in [default_deps, android_deps]:
                 deps.append("fbsource//third-party/volk:volk-header")
+                deps.append("fbsource//third-party/volk:volk-implementation")
 
         if is_fbcode:
             VK_API_DEPS += [


### PR DESCRIPTION
Summary: when using ETVK with volk, Runtime.cpp should not define VOLK_IMPLEMENTATION, but should instead leave its definition up to clients.  this makes combining multiple volk-dependent libraries easier

Differential Revision: D87851728


