### PR TITLE
[etrecord] Implement generic fallback for  `GraphModuleSerializer.handle_call_function`

### DIFF
--- a/exir/serde/export_serialize.py
+++ b/exir/serde/export_serialize.py
@@ -546,7 +546,13 @@ class GraphModuleSerializer:
                 metadata=self.serialize_metadata(node),
             )
         else:
-            raise SerializeError(f"Serializing {node.target} is not supported")
+            ex_node = Node(
+                name=node.name,
+                target=node._pretty_print_target(node.target),
+                inputs=self.serialize_hoo_inputs(node.args, node.kwargs),
+                outputs=self.serialize_hoo_outputs(node),
+                metadata=self.serialize_metadata(node),
+            )
 
         self.graph_state.nodes.append(ex_node)
 

--- a/exir/tests/test_serde.py
+++ b/exir/tests/test_serde.py
@@ -335,3 +335,18 @@ class TestSerde(unittest.TestCase):
                     node.meta.get("from_node"), node_new.meta.get("from_node")
                 ):
                     self.assertEqual(node_source.to_dict(), node_source_new.to_dict())
+
+    def test_memory_ops(self) -> None:
+        class MemoryOpsModule(nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x, y):
+                x = exir.memory.view(x, (10, 10))
+                return x + y
+
+        inputs = (
+            torch.randn(100),
+            torch.randn(10, 10),
+        )
+        self.check_serde(MemoryOpsModule(), inputs)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #16059

Title says it all!

Implement the case where `node.target` is neither `torch._ops.OpOverload` or `torch._ops.HigherOrderOperator`, instead of throwing an exception.

Differential Revision: [D88216198](https://our.internmc.facebook.com/intern/diff/D88216198/)