### PR TITLE
Cortex_M backend: Remove int8 requirement for zero_points

### DIFF
--- a/backends/cortex_m/ops/cortex_m_ops_common.h
+++ b/backends/cortex_m/ops/cortex_m_ops_common.h
@@ -83,13 +83,6 @@ inline void validate_single_quant_params(
   int64_t shift_val = shift.to<int64_t>();
 
   ET_CHECK_MSG(
-      zp_val >= std::numeric_limits<int8_t>::min() &&
-          zp_val <= std::numeric_limits<int8_t>::max(),
-      "%s zero point must be in int8 range [Value: %d]",
-      param_name,
-      zp_val);
-
-  ET_CHECK_MSG(
       mult_val >= std::numeric_limits<int32_t>::min() &&
           mult_val <= std::numeric_limits<int32_t>::max(),
       "%s multiplier must be in int32 range [Value: %d]",

--- a/backends/cortex_m/test/ops/test_activation.py
+++ b/backends/cortex_m/test/ops/test_activation.py
@@ -485,7 +485,7 @@ test_cases = {
     ),
     "linear_hardswish": McuTestCase(
         model=CortexMLinearHardswish(in_features=12, out_features=6),
-        example_inputs=(ramp_tensor(-12, 12, (1, 12)),),
+        example_inputs=(ramp_tensor(-2, 0, (1, 12)),),
     ),
     "conv2d_hardsigmoid_inplace": McuTestCase(
         model=CortexMConv2DHardsigmoid(),


### PR DESCRIPTION
The zero point would sometimes get out of range in the hardswish decomposition (depending on the range of the quantized output) as it adjusts the zero point. Since the zero_point is applied in int32 accumulation there is no actual reason for the limitation, so we can just remove it.

Additionally change the input to linear_hardswish to reliably trigger the behaviour causing the crash before the fix was introduced to catch future regressions.

cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai