### PR TITLE
Arm backend: Move FuseConstantArgsPass

### DIFF
--- a/backends/arm/_passes/arm_pass_manager.py
+++ b/backends/arm/_passes/arm_pass_manager.py
@@ -243,7 +243,6 @@ class ArmPassManager(PassManager):
                 # passes. Ticket: MLETORCH-1540
                 DecomposeNotEqualPass(),
                 MatchArgRanksPass(exported_program),
-                FuseConstantArgsPass(exported_program),
             ]
         )
 
@@ -265,6 +264,7 @@ class ArmPassManager(PassManager):
                 DecomposeAvgPool2dPass(),
                 DecorateFp32toInt32CastingPass(),
                 ComputeConstantOpsAOTPass(exported_program),
+                FuseConstantArgsPass(exported_program),
                 ConvertExpandCopyToRepeatPass(),
                 UnsqueezeBeforeRepeatPass(),
                 DecomposeCumsumPass(exported_program),

--- a/backends/arm/_passes/fuse_constant_ops_pass.py
+++ b/backends/arm/_passes/fuse_constant_ops_pass.py
@@ -178,7 +178,10 @@ class ComputeConstantOpsAOTPass(ArmPass):
             return node_name_pre_computed
     """
 
-    _passes_required_after: Set[Type[ExportPass]] = {FuseEqualPlaceholdersPass}
+    _passes_required_after: Set[Type[ExportPass]] = {
+        FuseEqualPlaceholdersPass,
+        FuseConstantArgsPass,
+    }
 
     targeted_ops = [
         exir_ops.edge.aten.full.default,

--- a/backends/arm/test/models/test_torch_functions.py
+++ b/backends/arm/test/models/test_torch_functions.py
@@ -126,8 +126,6 @@ def test_torch_fns_FP(test_data):
     xfails={
         "nonzero": "torch.fx.experimental.symbolic_shapes.GuardOnDataDependentSymNode: Could not guard on data-dependent expression Eq(u4, 0). "
         "Requires dynamic output shape.",
-        "eye": "ValueError: Failed processing buffer placeholder: aten_arange_start_step_1_pre_computed_common. "
-        "Is the original torch function supported?",
         "topk": "NotImplementedError: No registered serialization name for <class 'torch.return_types.topk'> found",
         "sort": "NotImplementedError: No registered serialization name for <class 'torch.return_types.sort'> found",
     },


### PR DESCRIPTION
Move FuseConstantArgsPass to run after ComputeConstantOpsAOTPass to make sure that ops without input nodes are pre-computed first.

cc @freddan80 @per @zingo @digantdesai