### PR TITLE
Cortex_M backend: Remove scalar-scalar tests

### DIFF
--- a/backends/cortex_m/test/ops/test_add.py
+++ b/backends/cortex_m/test/ops/test_add.py
@@ -74,10 +74,6 @@ class CortexMAlphaAdd(ModelAlpha):
 
 
 test_cases = {
-    "self_scalar": McuTestCase(
-        CortexMSelfAdd(),
-        (10.0,),
-    ),
     "self_rank_1": McuTestCase(
         CortexMSelfAdd(),
         (torch.linspace(-5, 5, 10),),
@@ -97,10 +93,6 @@ test_cases = {
     "self_rank_5": McuTestCase(
         CortexMSelfAdd(),
         (ramp_tensor(-5, 5, (2, 2, 2, 2, 2)),),
-    ),
-    "scalar_scalar": McuTestCase(
-        CortexMScalarAdd(),
-        (-0.5, 1.0),
     ),
     "tensor_scalar": McuTestCase(
         CortexMScalarAdd(),
@@ -140,14 +132,6 @@ test_cases = {
 
 
 xfails_implementation = {
-    "self_scalar": (
-        "'float' object has not attribute 'fake_mode' - scalar only ops not supported.",
-        AttributeError,
-    ),
-    "scalar_scalar": (
-        "'float' object has not attribute 'fake_mode' - scalar only ops not supported.",
-        AttributeError,
-    ),
     "alpha": (
         "Expecting kwargs for aten op IR to be empty - alpha arg not supported.",
         AssertionError,

--- a/backends/cortex_m/test/ops/test_mul.py
+++ b/backends/cortex_m/test/ops/test_mul.py
@@ -60,10 +60,6 @@ class CortexMTensorMul(Model):
 
 
 test_cases = {
-    "self_scalar": McuTestCase(
-        CortexMSelfMul(),
-        (10.0,),
-    ),
     "self_rank_1": McuTestCase(
         CortexMSelfMul(),
         (ramp_tensor(-5, 5, (10,)),),
@@ -83,10 +79,6 @@ test_cases = {
     "self_rank_5": McuTestCase(
         CortexMSelfMul(),
         (ramp_tensor(-5, 5, (2, 2, 2, 2, 2)),),
-    ),
-    "scalar_scalar": McuTestCase(
-        CortexMScalarMul(),
-        (-0.5, 1.0),
     ),
     "tensor_scalar": McuTestCase(
         CortexMScalarMul(),
@@ -114,17 +106,7 @@ test_cases = {
 }
 
 
-xfail_cases_implementation = {
-    "self_scalar": (
-        "'float' object has not attribute 'fake_mode' - scalar only ops not supported.",
-        AttributeError,
-    ),
-    "scalar_scalar": (
-        "'float' object has not attribute 'fake_mode' - scalar only ops not supported.",
-        AttributeError,
-    ),
-}
-xfail_cases_dialect = xfail_cases_implementation | {
+xfail_cases_dialect = {
     # Cortex-M quantizer will not quantize multiplicaitons that require broadcasting
     # leading to the mul op not being replaced by a cortex-m specific implementation
     "broadcast_1": "Broadcasting is not supported in Cortex-M backend",
@@ -143,7 +125,10 @@ def test_dialect_mul(test_case):
     )
 
 
-@parametrize("test_case", test_cases, xfails=xfail_cases_implementation)
+@parametrize(
+    "test_case",
+    test_cases,
+)
 def test_implementation_mul(test_case):
     tester = CortexMTester(test_case.model, test_case.example_inputs)
     tester.test_implementation(qtol=1)


### PR DESCRIPTION
Removes scalar-scalar tests for mul and add as scalars are treated as constants, and are pre-computed ahead-of-time, hence making it pointless in testing them in isolation.


cc @freddan80 @per @zingo @digantdesai