### PR TITLE
[Cria][Lllama runner] Use caching temp allocator

### DIFF
--- a/extension/llm/runner/llm_runner_helper.cpp
+++ b/extension/llm/runner/llm_runner_helper.cpp
@@ -226,7 +226,6 @@ std::unique_ptr<TextLLMRunner> create_text_llm_runner(
   } else {
     module = std::make_unique<Module>(
         model_path,
-        model_path,
         Module::LoadMode::File,
         std::move(event_tracer), // event tracer
         nullptr, // memory allocator


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #15830
* __->__ #16080
* #15730
* #15729
* #15728
* #15611
* #15610

Use of caching allocator improves TITO model performance by 6+ %.

Will add repro instructions here but requires next diff to see the impact

Differential Revision: [D85532078](https://our.internmc.facebook.com/intern/diff/D85532078/)