### PR TITLE
Adding Test for CadenceWith16BitMatmulActivationsQuantizer

### DIFF
--- a/backends/cadence/aot/TARGETS
+++ b/backends/cadence/aot/TARGETS
@@ -641,6 +641,9 @@ python_unittest(
     typing = True,
     deps = [
         "//caffe2:torch",
+        "//executorch/backends/cadence/aot:graph_builder",
         "//executorch/backends/cadence/aot/quantizer:quantizer",
+        "//executorch/exir:pass_base",
+        "//pytorch/ao:torchao",
     ],
 )


### PR DESCRIPTION
Summary:
We test the quantizer we added in D87996796 correctly annotates the graph. 

We use the graph builder to build the graph with metadata(that's needed for quantizer.annotate to recognize the nodes), and we ensure that the quantization params are as expected.

Reviewed By: hsharma35

Differential Revision: D88053808


