### PR TITLE
Arm backend: Increase tolerance on Tanh int16 test

### DIFF
--- a/backends/arm/test/ops/test_tanh.py
+++ b/backends/arm/test/ops/test_tanh.py
@@ -8,12 +8,8 @@ from typing import Tuple
 
 import pytest
 import torch
-from executorch.backends.arm.quantizer.arm_quantizer import (
-    get_symmetric_a16w8_quantization_config,
-    TOSAQuantizer,
-)
 
-from executorch.backends.arm.test import common, conftest
+from executorch.backends.arm.test import common
 from executorch.backends.arm.test.tester.test_pipeline import (
     EthosU55PipelineINT,
     EthosU85PipelineINT,
@@ -21,8 +17,6 @@ from executorch.backends.arm.test.tester.test_pipeline import (
     TosaPipelineINT,
     VgfPipeline,
 )
-from executorch.backends.arm.tosa.specification import TosaSpecification
-from executorch.backends.xnnpack.test.tester import Quantize
 
 aten_op = "torch.ops.aten.tanh.default"
 input_t1 = Tuple[torch.Tensor]  # Input x
@@ -114,29 +108,6 @@ def test_tanh_vgf_INT(test_data: Tuple):
     pipeline.run()
 
 
-def get_symmetric_a16w8_tanh_quantizer(per_channel_quantization=False):
-    tosa_version = conftest.get_option("tosa_version")
-    tosa_profiles = {
-        "1.0": TosaSpecification.create_from_string("TOSA-1.0+INT+int16"),
-    }
-
-    quantizer = TOSAQuantizer(tosa_profiles[tosa_version])
-
-    # Use a smaller episilon value to not greatly inflate [qmin, qmax]
-    quantizer.set_global(
-        get_symmetric_a16w8_quantization_config(
-            is_per_channel=per_channel_quantization, epsilon=2**-16
-        )
-    )
-
-    return Quantize(
-        quantizer,
-        get_symmetric_a16w8_quantization_config(
-            is_per_channel=per_channel_quantization, epsilon=2**-16
-        ),
-    )
-
-
 @common.parametrize("test_data", test_data_suite)
 def test_tanh_16a8w_tosa_INT(test_data: torch.Tensor):
     """Test tanh operation with 16A8W quantization (16-bit activations, 8-bit weights)"""
@@ -150,13 +121,8 @@ def test_tanh_16a8w_tosa_INT(test_data: torch.Tensor):
         per_channel_quantization=per_channel_quantization,
         use_to_edge_transform_and_lower=True,
         tosa_extensions=["int16"],
-    )
-
-    pipeline.change_args(
-        "quantize",
-        get_symmetric_a16w8_tanh_quantizer(
-            per_channel_quantization=per_channel_quantization
-        ),
+        epsilon=2**-16,
+        rtol=2e-03,
     )
     pipeline.run()
 
@@ -177,13 +143,9 @@ def test_tanh_16a8w_u55_INT16(test_data: torch.Tensor):
         exir_ops=[],
         per_channel_quantization=per_channel_quantization,
         use_to_edge_transform_and_lower=True,
-    )
-
-    pipeline.change_args(
-        "quantize",
-        get_symmetric_a16w8_tanh_quantizer(
-            per_channel_quantization=per_channel_quantization
-        ),
+        a16w8_quantization=True,
+        epsilon=2**-16,
+        rtol=2e-03,
     )
     pipeline.run()
 
@@ -201,12 +163,8 @@ def test_tanh_16a8w_u85_INT16(test_data: torch.Tensor):
         exir_ops=[],
         per_channel_quantization=per_channel_quantization,
         use_to_edge_transform_and_lower=True,
-    )
-
-    pipeline.change_args(
-        "quantize",
-        get_symmetric_a16w8_tanh_quantizer(
-            per_channel_quantization=per_channel_quantization
-        ),
+        a16w8_quantization=True,
+        epsilon=2**-16,
+        rtol=2e-03,
     )
     pipeline.run()


### PR DESCRIPTION
### Summary

- Updates the tolerance on Tanh int16 which intermittently fails.
- Refactored test case to use int16 test pipeline


cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai