### PR TITLE
Adding Test For CadenceWith16BitLinearActivationsQuantizer

### DIFF
--- a/backends/cadence/aot/TARGETS
+++ b/backends/cadence/aot/TARGETS
@@ -641,6 +641,9 @@ python_unittest(
     typing = True,
     deps = [
         "//caffe2:torch",
+        "//executorch/backends/cadence/aot:graph_builder",
         "//executorch/backends/cadence/aot/quantizer:quantizer",
+        "//executorch/exir:pass_base",
+        "//pytorch/ao:torchao",
     ],
 )


### PR DESCRIPTION
Summary:
We test the CadenceWith16BitLinearActivationQuantizer. 

We use the graph builder to build the graph with metadata(that's needed for quantizer.annotate to recognize the nodes), and we ensure that the quantization params are as expected.

Reviewed By: hsharma35

Differential Revision: D88054651


