### PR TITLE
Creating Paramaterized Test For Quantizers For Easier Testing

### DIFF
--- a/backends/cadence/aot/TARGETS
+++ b/backends/cadence/aot/TARGETS
@@ -641,6 +641,9 @@ python_unittest(
     typing = True,
     deps = [
         "//caffe2:torch",
+        "//executorch/backends/cadence/aot:graph_builder",
         "//executorch/backends/cadence/aot/quantizer:quantizer",
+        "//executorch/exir:pass_base",
+        "//pytorch/ao:torchao",
     ],
 )

--- a/backends/cadence/aot/TARGETS
+++ b/backends/cadence/aot/TARGETS
@@ -640,6 +640,7 @@ python_unittest(
     ],
     typing = True,
     deps = [
+        "fbsource//third-party/pypi/parameterized:parameterized",
         "//caffe2:torch",
         "//executorch/backends/cadence/aot:graph_builder",
         "//executorch/backends/cadence/aot/quantizer:quantizer",


### PR DESCRIPTION
Summary:
We consolidate the two tests we created into a single testing function using parameterization. 

This will make testing future Quantizers much easier, and there will be a lot less code duplication.

Reviewed By: hsharma35

Differential Revision: D88054917


