### PR TITLE
Fix data pointer const-correctness in executorch kernels

### DIFF
--- a/kernels/optimized/cpu/fft_utils.h
+++ b/kernels/optimized/cpu/fft_utils.h
@@ -38,7 +38,7 @@ inline pocketfft::shape_t shape_from_tensor(const Tensor& t) {
 template <typename T>
 inline std::complex<T>* tensor_cdata(Tensor& t) {
   return reinterpret_cast<std::complex<T>*>(
-      t.data_ptr<executorch::runtime::etensor::complex<T>>());
+      t.mutable_data_ptr<executorch::runtime::etensor::complex<T>>());
 }
 
 template <typename T>

--- a/kernels/optimized/cpu/op_where.cpp
+++ b/kernels/optimized/cpu/op_where.cpp
@@ -51,7 +51,7 @@ Tensor& opt_where_out(
       const CTYPE_COMPUTE* const data_a = a.const_data_ptr<CTYPE_COMPUTE>();
       const CTYPE_COMPUTE* const data_b = b.const_data_ptr<CTYPE_COMPUTE>();
       const bool* const data_cond = cond.const_data_ptr<bool>();
-      CTYPE_COMPUTE* const data_out = out.data_ptr<CTYPE_COMPUTE>();
+      CTYPE_COMPUTE* const data_out = out.mutable_data_ptr<CTYPE_COMPUTE>();
       executorch::extension::parallel_for(
           0,
           out_numel,

--- a/kernels/portable/cpu/op_native_dropout.cpp
+++ b/kernels/portable/cpu/op_native_dropout.cpp
@@ -76,7 +76,7 @@ std::tuple<Tensor&, Tensor&> native_dropout_out(
               out);
         });
   } else if (input.numel() > 0) {
-    std::memcpy(out.mutable_data_ptr(), input.data_ptr(), input.nbytes());
+    std::memcpy(out.mutable_data_ptr(), input.const_data_ptr(), input.nbytes());
     std::memset(mask.mutable_data_ptr(), true, mask.nbytes());
   }
   return ret;


### PR DESCRIPTION
Summary: This diff fixes const-correctness issues in executorch kernel implementations by using the appropriate data pointer methods based on whether the tensor data is being read or written.

Reviewed By: krishnakapil

Differential Revision: D88495144


