### PR TITLE
Using push constants for clone op parameters.

### DIFF
--- a/backends/vulkan/runtime/graph/ops/glsl/clone.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/clone.glsl
@@ -16,7 +16,10 @@ layout(std430) buffer;
 
 ${layout_declare_tensor(B, "w", "t_out", DTYPE, STORAGE)}
 ${layout_declare_tensor(B, "r", "t_in", DTYPE, STORAGE)}
-${layout_declare_ubo(B, "ivec3", "out_limits")}
+
+layout(push_constant) uniform restrict Block {
+  ivec3 out_limits;
+};
 
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
 

--- a/backends/vulkan/runtime/graph/ops/impl/Clone.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Clone.cpp
@@ -48,9 +48,9 @@ void add_clone_node(
       // Inputs and Outputs
       {{out, vkapi::kWrite}, {in, vkapi::kRead}},
       // Parameter Buffers
-      {graph.logical_limits_ubo(out)},
-      // Push Constants
       {},
+      // Push Constants
+      {graph.logical_limits_pc_of(out)},
       // Specialization Constants
       {},
       // Resize Args


### PR DESCRIPTION
Summary: This diff modifies the clone operation in the Executorch Vulkan backend to use push constants instead of a uniform buffer for storing the output limits.

Differential Revision: D88097604


