### PR TITLE
Vulkan Q8 Conv2D: specialize shader on static parameters and tensor s…

### DIFF
--- a/backends/vulkan/runtime/graph/ops/glsl/col2im.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/col2im.glsl
@@ -41,7 +41,23 @@ ${layout_declare_ubo(B, "ivec4", "input_sizes")}
 // Sizes of the im2col matrix of the convolution output
 ${layout_declare_ubo(B, "ivec4", "matrix_sizes")}
 
-${layout_declare_ubo(B, "Conv2DParams", "conv2d_params")}
+${layout_declare_spec_const(C, "int", "apply_bias", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_stride_x", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_stride_y", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_padding_x", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_padding_y", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_dilation_x", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_dilation_y", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_kernel_size_x", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_kernel_size_y", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_in_channels_per_group", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_out_channels_per_group", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_K4_per_group", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_K4", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_K_per_group", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_logical_K", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_logical_K_per_group", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_groups", "1")}
 
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/conv2d_fp_im2col_block.glslh
+++ b/backends/vulkan/runtime/graph/ops/glsl/conv2d_fp_im2col_block.glslh
@@ -63,27 +63,27 @@ void im2col_idx_to_input_tidx(
   TensorIndex4D output_tidx;
   unwrap_m(output_tidx, im2col_idx.row);
 
-  const int in_channels_per_group = conv2d_params.in_channels_per_group;
+  const int in_channels_per_group = conv2d_params_in_channels_per_group;
   // Determine the corresponding position within the convolution window based
   // on the col index (more specifically, the col index within the group)
   const int channel_within_group =
       im2col_idx.col_idx_in_group % in_channels_per_group;
   const int kernel_x = (im2col_idx.col_idx_in_group / in_channels_per_group) %
-      conv2d_params.kernel_size.x;
+      conv2d_params_kernel_size_x;
   const int kernel_y = im2col_idx.col_idx_in_group /
-      (in_channels_per_group * conv2d_params.kernel_size.x);
+      (in_channels_per_group * conv2d_params_kernel_size_x);
 
   // Calculate the actual input channel index
   const int channel_idx =
-      im2col_idx.group_idx * conv2d_params.in_channels_per_group +
+      im2col_idx.group_idx * conv2d_params_in_channels_per_group +
       channel_within_group;
 
   // Calculate corresponding input coordinates based on output position
   // associated with the row index.
-  const int input_y = int(output_tidx.data.y * conv2d_params.stride.y) -
-      int(conv2d_params.padding.y) + int(kernel_y * conv2d_params.dilation.y);
-  const int input_x = int(output_tidx.data.x * conv2d_params.stride.x) -
-      int(conv2d_params.padding.x) + int(kernel_x * conv2d_params.dilation.x);
+  const int input_y = int(output_tidx.data.y * conv2d_params_stride_y) -
+      int(conv2d_params_padding_y) + int(kernel_y * conv2d_params_dilation_y);
+  const int input_x = int(output_tidx.data.x * conv2d_params_stride_x) -
+      int(conv2d_params_padding_x) + int(kernel_x * conv2d_params_dilation_x);
 
   input_tidx.data = ivec4(input_x, input_y, channel_idx, output_tidx.data.w);
 }

--- a/backends/vulkan/runtime/graph/ops/glsl/conv2d_fp_im2col_block_load.glslh
+++ b/backends/vulkan/runtime/graph/ops/glsl/conv2d_fp_im2col_block_load.glslh
@@ -64,8 +64,8 @@ void load_im2col_block_fast(
   // Due to the assumption that in_channels_per_group % 4 == 0, it is
   // guaranteed that the next 4 columns (including this one) is part of the
   // same group.
-  im2col_idx.group_idx = im2col_idx.col / conv2d_params.K_per_group;
-  im2col_idx.col_idx_in_group = im2col_idx.col % conv2d_params.K_per_group;
+  im2col_idx.group_idx = im2col_idx.col / conv2d_params_K_per_group;
+  im2col_idx.col_idx_in_group = im2col_idx.col % conv2d_params_K_per_group;
 
   [[unroll]] for (int m_off = 0; m_off < 4; ++m_off) {
     if (im2col_idx.row >= M) {
@@ -98,9 +98,9 @@ void load_im2col_block_slow(
   im2col_idx_base.col = mul_4(k4);
   im2col_idx_base.row = mul_4(m4);
 
-  im2col_idx_base.group_idx = im2col_idx_base.col / conv2d_params.K_per_group;
+  im2col_idx_base.group_idx = im2col_idx_base.col / conv2d_params_K_per_group;
   im2col_idx_base.col_idx_in_group =
-      im2col_idx_base.col % conv2d_params.K_per_group;
+      im2col_idx_base.col % conv2d_params_K_per_group;
 
   [[unroll]] for (int m_off = 0; m_off < 4; ++m_off) {
     [[unroll]] for (int k_off = 0; k_off < 4; ++k_off) {
@@ -109,7 +109,7 @@ void load_im2col_block_slow(
       im2col_idx.col_idx_in_group += k_off;
 
       // bounds checking
-      if (im2col_idx.col_idx_in_group >= conv2d_params.logical_K_per_group ||
+      if (im2col_idx.col_idx_in_group >= conv2d_params_logical_K_per_group ||
           im2col_idx.row >= M) {
         block.data[m_off][k_off] = T(0);
         continue;
@@ -129,7 +129,7 @@ void load_im2col_block(
     const int m4,
     const int logical_K,
     const int M) {
-  if (mod_4(conv2d_params.in_channels_per_group) == 0) {
+  if (mod_4(conv2d_params_in_channels_per_group) == 0) {
     load_im2col_block_fast(block, k4, m4, logical_K, M);
   } else {
     load_im2col_block_slow(block, k4, m4, logical_K, M);

--- a/backends/vulkan/runtime/graph/ops/glsl/conv2d_pw_q8ta_q8csw_q8to_tiled.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/conv2d_pw_q8ta_q8csw_q8to_tiled.glsl
@@ -44,7 +44,6 @@ ${layout_declare_tensor(B, "r", "t_bias", DTYPE, "buffer", is_scalar_array=False
 
 ${layout_declare_ubo(B, "ivec4", "output_sizes")}
 ${layout_declare_ubo(B, "ivec4", "input_sizes")}
-${layout_declare_ubo(B, "Conv2DParams", "conv2d_params")}
 
 layout(push_constant) uniform restrict Block {
   float input_scale;
@@ -56,6 +55,23 @@ layout(push_constant) uniform restrict Block {
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
 
 ${layout_declare_spec_const(C, "int", "apply_bias", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_stride_x", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_stride_y", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_padding_x", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_padding_y", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_dilation_x", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_dilation_y", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_kernel_size_x", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_kernel_size_y", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_in_channels_per_group", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_out_channels_per_group", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_K4_per_group", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_K4", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_K_per_group", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_logical_K", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_logical_K_per_group", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_groups", "1")}
+
 
 #include "conv2d_int8_input_tile_load.glslh"
 #include "linear_int8_weight_tile_load.glslh"
@@ -88,7 +104,7 @@ void main() {
   Int8InputTileIndex input_idx = make_initial_int8_input_tile_index(
       output_block_idx, input_block_extents);
 
-  for (int k4 = 0; k4 < conv2d_params.K4_per_group; k4++) {
+  for (int k4 = 0; k4 < conv2d_params_K4_per_group; k4++) {
     load_packed_int8_input_tile(int8_input_tile, input_idx);
 
     load_int8_weight_tile(

--- a/backends/vulkan/runtime/graph/ops/glsl/conv2d_q8_utils.glslh
+++ b/backends/vulkan/runtime/graph/ops/glsl/conv2d_q8_utils.glslh
@@ -106,7 +106,7 @@ void perform_conv1d(
     const ivec4 weight_block,
     const int kx) {
   [[unroll]] for (int out_w = 0; out_w < 4; ++out_w) {
-    const int window_i = out_w * conv2d_params.stride.x + kx;
+    const int window_i = out_w * conv2d_params_stride_x + kx;
     [[unroll]] for (int out_c = 0; out_c < 4; ++out_c) {
       accum.data[out_w][0][out_c] = dotPacked4x8AccSatEXT(
           input_window.data[window_i],

--- a/backends/vulkan/runtime/graph/ops/glsl/conv2d_q8csw_linear_tiled.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/conv2d_q8csw_linear_tiled.glsl
@@ -41,11 +41,27 @@ ${layout_declare_tensor(B, "r", "t_bias", DTYPE, "buffer", is_scalar_array=False
 
 ${layout_declare_ubo(B, "ivec4", "output_sizes")}
 ${layout_declare_ubo(B, "ivec4", "input_sizes")}
-${layout_declare_ubo(B, "Conv2DParams", "conv2d_params")}
 
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
 
 ${layout_declare_spec_const(C, "int", "apply_bias", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_stride_x", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_stride_y", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_padding_x", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_padding_y", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_dilation_x", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_dilation_y", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_kernel_size_x", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_kernel_size_y", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_in_channels_per_group", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_out_channels_per_group", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_K4_per_group", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_K4", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_K_per_group", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_logical_K", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_logical_K_per_group", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_groups", "1")}
+
 
 #include "linear_fp_input_tile_load.glslh"
 #include "linear_int8_weight_tile_load.glslh"
@@ -75,10 +91,10 @@ void main() {
     return;
   }
 
-  const int group_idx = n / conv2d_params.out_channels_per_group;
-  const int input_k4_offset = conv2d_params.K4_per_group * group_idx;
+  const int group_idx = n / conv2d_params_out_channels_per_group;
+  const int input_k4_offset = conv2d_params_K4_per_group * group_idx;
 
-  const int K4 = conv2d_params.K4;
+  const int K4 = conv2d_params_K4;
   const int N4 = div_up_4(N);
 
   FPOutTile out_tile;
@@ -90,13 +106,13 @@ void main() {
   const bool dont_check_bounds = (M - m) >= TILE_M;
 
   if (dont_check_bounds) {
-    for (int k4 = 0; k4 < conv2d_params.K4_per_group; k4++) {
+    for (int k4 = 0; k4 < conv2d_params_K4_per_group; k4++) {
       load_input_tile_no_checks(in_tile, k4 + input_k4_offset, m, K4, M);
       load_int8_weight_tile(int8_weight_tile, n4, k4, N4);
       fp_accumulate_with_int8_weight(out_tile, in_tile, int8_weight_tile);
     }
   } else {
-    for (int k4 = 0; k4 < conv2d_params.K4_per_group; k4++) {
+    for (int k4 = 0; k4 < conv2d_params_K4_per_group; k4++) {
       load_input_tile_with_checks(in_tile, k4 + input_k4_offset, m, K4, M);
       load_int8_weight_tile(int8_weight_tile, n4, k4, N4);
       fp_accumulate_with_int8_weight(out_tile, in_tile, int8_weight_tile);

--- a/backends/vulkan/runtime/graph/ops/glsl/conv2d_q8ta_q8csw_linear_tiled.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/conv2d_q8ta_q8csw_linear_tiled.glsl
@@ -44,7 +44,6 @@ ${layout_declare_tensor(B, "r", "t_bias", DTYPE, "buffer", is_scalar_array=False
 
 ${layout_declare_ubo(B, "ivec4", "output_sizes")}
 ${layout_declare_ubo(B, "ivec4", "input_sizes")}
-${layout_declare_ubo(B, "Conv2DParams", "conv2d_params")}
 
 layout(push_constant) uniform restrict Block {
   float input_scale;
@@ -54,6 +53,23 @@ layout(push_constant) uniform restrict Block {
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
 
 ${layout_declare_spec_const(C, "int", "apply_bias", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_stride_x", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_stride_y", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_padding_x", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_padding_y", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_dilation_x", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_dilation_y", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_kernel_size_x", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_kernel_size_y", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_in_channels_per_group", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_out_channels_per_group", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_K4_per_group", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_K4", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_K_per_group", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_logical_K", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_logical_K_per_group", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_groups", "1")}
+
 
 #include "linear_int8_input_tile_load.glslh"
 #include "linear_int8_weight_tile_load.glslh"
@@ -83,10 +99,10 @@ void main() {
     return;
   }
 
-  const int group_idx = n / conv2d_params.out_channels_per_group;
-  const int input_k4_offset = conv2d_params.K4_per_group * group_idx;
+  const int group_idx = n / conv2d_params_out_channels_per_group;
+  const int input_k4_offset = conv2d_params_K4_per_group * group_idx;
 
-  const int K4 = conv2d_params.K4;
+  const int K4 = conv2d_params_K4;
   const int N4 = div_up_4(N);
 
   Int32Accum out_accum;
@@ -95,7 +111,7 @@ void main() {
   Int8InputTile int8_in_tile;
   Int8WeightTile int8_weight_tile;
 
-  for (int k4 = 0; k4 < conv2d_params.K4_per_group; k4++) {
+  for (int k4 = 0; k4 < conv2d_params_K4_per_group; k4++) {
     load_int8_input_tile(int8_in_tile, k4 + input_k4_offset, m4, K4);
     load_int8_weight_tile(int8_weight_tile, n4, k4, N4);
 

--- a/backends/vulkan/runtime/graph/ops/glsl/conv2d_q8ta_q8csw_q8to_linear_tiled.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/conv2d_q8ta_q8csw_q8to_linear_tiled.glsl
@@ -44,7 +44,6 @@ ${layout_declare_tensor(B, "r", "t_bias", DTYPE, "buffer", is_scalar_array=False
 
 ${layout_declare_ubo(B, "ivec4", "output_sizes")}
 ${layout_declare_ubo(B, "ivec4", "im2col_sizes")}
-${layout_declare_ubo(B, "Conv2DParams", "conv2d_params")}
 
 layout(push_constant) uniform restrict Block {
   float input_scale;
@@ -56,6 +55,23 @@ layout(push_constant) uniform restrict Block {
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
 
 ${layout_declare_spec_const(C, "int", "apply_bias", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_stride_x", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_stride_y", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_padding_x", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_padding_y", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_dilation_x", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_dilation_y", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_kernel_size_x", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_kernel_size_y", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_in_channels_per_group", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_out_channels_per_group", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_K4_per_group", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_K4", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_K_per_group", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_logical_K", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_logical_K_per_group", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_groups", "1")}
+
 
 #include "conv2d_int8_input_tile_load.glslh"
 #include "linear_int8_weight_tile_load.glslh"
@@ -79,8 +95,8 @@ void main() {
 
   const int n = mul_4(output_block_idx.data.z);
 
-  const int group_idx = n / conv2d_params.out_channels_per_group;
-  const int group_k4_offset = group_idx * conv2d_params.K4_per_group;
+  const int group_idx = n / conv2d_params_out_channels_per_group;
+  const int group_k4_offset = group_idx * conv2d_params_K4_per_group;
 
   Conv2dBlockExtents input_block_extents = make_block_extents(im2col_sizes);
 
@@ -93,7 +109,7 @@ void main() {
   Int8InputTileIndex input_idx = make_initial_int8_input_tile_index(
       output_block_idx, input_block_extents, group_k4_offset);
 
-  for (int k4 = 0; k4 < conv2d_params.K4_per_group; k4++) {
+  for (int k4 = 0; k4 < conv2d_params_K4_per_group; k4++) {
     load_packed_int8_input_tile(int8_input_tile, input_idx);
 
     load_int8_weight_tile(

--- a/backends/vulkan/runtime/graph/ops/glsl/im2col.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/im2col.glsl
@@ -41,7 +41,23 @@ ${layout_declare_ubo(B, "ivec4", "input_sizes")}
 // Sizes of the output image
 ${layout_declare_ubo(B, "ivec4", "output_sizes")}
 
-${layout_declare_ubo(B, "Conv2DParams", "conv2d_params")}
+${layout_declare_spec_const(C, "int", "apply_bias", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_stride_x", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_stride_y", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_padding_x", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_padding_y", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_dilation_x", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_dilation_y", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_kernel_size_x", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_kernel_size_y", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_in_channels_per_group", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_out_channels_per_group", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_K4_per_group", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_K4", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_K_per_group", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_logical_K", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_logical_K_per_group", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_groups", "1")}
 
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
 
@@ -83,10 +99,10 @@ void main() {
   const int k = mul_4(k4);
   const int m = mul_4(m4);
 
-  const int in_channels_per_group = input_sizes.z / conv2d_params.groups;
+  const int in_channels_per_group = input_sizes.z / conv2d_params_groups;
 
   // Logical K dim size (unpadded)
-  const int logical_K = conv2d_params.logical_K;
+  const int logical_K = conv2d_params_logical_K;
   // Physical K dim, which contains padding elements
   const int K = matrix_sizes.x;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/im2col_packed_int8.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/im2col_packed_int8.glsl
@@ -35,7 +35,23 @@ ${layout_declare_ubo(B, "ivec4", "output_sizes")}
 // Sizes of the input image
 ${layout_declare_ubo(B, "ivec4", "input_sizes")}
 
-${layout_declare_ubo(B, "Conv2DParams", "conv2d_params")}
+${layout_declare_spec_const(C, "int", "apply_bias", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_stride_x", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_stride_y", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_padding_x", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_padding_y", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_dilation_x", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_dilation_y", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_kernel_size_x", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_kernel_size_y", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_in_channels_per_group", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_out_channels_per_group", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_K4_per_group", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_K4", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_K_per_group", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_logical_K", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_logical_K_per_group", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_groups", "1")}
 
 layout(push_constant) uniform restrict Block {
   float inv_scale;
@@ -49,6 +65,7 @@ layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
 
 void main() {
   const int out_buf_idx = int(gl_GlobalInvocationID.x);
+
   Conv2dBlockExtents im2col_block_extents = make_block_extents(im2col_sizes);
 
   Conv2dBlockIndex im2col_block_idx = linear_idx_to_block_idx(

--- a/backends/vulkan/runtime/graph/ops/glsl/im2col_packed_int8_utils.glslh
+++ b/backends/vulkan/runtime/graph/ops/glsl/im2col_packed_int8_utils.glslh
@@ -54,17 +54,17 @@ TensorIndex4D get_input_tensor_tidx(
   TensorIndex4D tidx;
   tidx.data.w = 0;
 
-  const int c_in_group = k_in_group % conv2d_params.in_channels_per_group;
-  const int row = k_in_group / conv2d_params.in_channels_per_group;
-  const int kernel_x = row % conv2d_params.kernel_size.x;
-  const int kernel_y = row / conv2d_params.kernel_size.x;
+  const int c_in_group = k_in_group % conv2d_params_in_channels_per_group;
+  const int row = k_in_group / conv2d_params_in_channels_per_group;
+  const int kernel_x = row % conv2d_params_kernel_size_x;
+  const int kernel_y = row / conv2d_params_kernel_size_x;
 
-  tidx.data.z = group_idx * conv2d_params.in_channels_per_group + c_in_group;
+  tidx.data.z = group_idx * conv2d_params_in_channels_per_group + c_in_group;
 
-  tidx.data.x = (w * conv2d_params.stride.x) - conv2d_params.padding.x +
-      (kernel_x * conv2d_params.dilation.x);
-  tidx.data.y = (h * conv2d_params.stride.y) - conv2d_params.padding.y +
-      (kernel_y * conv2d_params.dilation.y);
+  tidx.data.x = (w * conv2d_params_stride_x) - conv2d_params_padding_x +
+      (kernel_x * conv2d_params_dilation_x);
+  tidx.data.y = (h * conv2d_params_stride_y) - conv2d_params_padding_y +
+      (kernel_y * conv2d_params_dilation_y);
 
   return tidx;
 }
@@ -75,17 +75,17 @@ Im2ColBlockLoadIndices im2col_block_idx_to_load_ixs(
   const int im2col_h = im2col_block_idx.data.y;
   const int im2col_k = mul_4(im2col_block_idx.data.z);
 
-  const int group_idx = im2col_k / conv2d_params.K_per_group;
-  const int k_in_group = im2col_k % conv2d_params.K_per_group;
+  const int group_idx = im2col_k / conv2d_params_K_per_group;
+  const int k_in_group = im2col_k % conv2d_params_K_per_group;
 
   TensorIndex4D input_tidx =
       get_input_tensor_tidx(im2col_w, im2col_h, k_in_group, group_idx);
 
   bool cols_aligned = (mod_4(input_tidx.data.z) == 0) &&
-      (input_tidx.data.z + 3 < conv2d_params.in_channels_per_group);
+      (input_tidx.data.z + 3 < conv2d_params_in_channels_per_group);
 
   bool rows_aligned = mod_4(input_tidx.data.x) == 0;
-  bool rows_contiguous = conv2d_params.stride.x == 1;
+  bool rows_contiguous = conv2d_params_stride_x == 1;
 
   Im2ColBlockLoadIndices load_ixs;
   load_ixs.block_aligned = cols_aligned && rows_aligned && rows_contiguous;
@@ -229,7 +229,7 @@ ivec4 load_im2col_block_no_alignment(
     for (int c = 0; c < 4; c++) {
       const int k_in_group = load_ixs.k_in_group_start + c;
 
-      if (k_in_group >= conv2d_params.logical_K_per_group) {
+      if (k_in_group >= conv2d_params_logical_K_per_group) {
         row_values[c] = input_zp;
         continue;
       }

--- a/backends/vulkan/runtime/graph/ops/glsl/quantize_and_pack_im2col.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/quantize_and_pack_im2col.glsl
@@ -41,7 +41,23 @@ ${layout_declare_ubo(B, "ivec4", "input_sizes")}
 // Sizes of the output image
 ${layout_declare_ubo(B, "ivec4", "output_sizes")}
 
-${layout_declare_ubo(B, "Conv2DParams", "conv2d_params")}
+${layout_declare_spec_const(C, "int", "apply_bias", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_stride_x", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_stride_y", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_padding_x", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_padding_y", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_dilation_x", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_dilation_y", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_kernel_size_x", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_kernel_size_y", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_in_channels_per_group", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_out_channels_per_group", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_K4_per_group", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_K4", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_K_per_group", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_logical_K", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_logical_K_per_group", "1")}
+${layout_declare_spec_const(C, "int", "conv2d_params_groups", "1")}
 
 layout(push_constant) uniform restrict Block {
   float inv_scale;
@@ -68,7 +84,7 @@ void main() {
   const int k = mul_4(k4);
   const int m = mul_4(m4);
 
-  const int logical_K = conv2d_params.logical_K;
+  const int logical_K = conv2d_params_logical_K;
   // Similarly, compute the logical size of the M dim.
   const int logical_M = output_sizes.x * output_sizes.y * output_sizes.w;
 

--- a/backends/vulkan/test/custom_ops/q8ta_q8csw_q8to_conv2d.cpp
+++ b/backends/vulkan/test/custom_ops/q8ta_q8csw_q8to_conv2d.cpp
@@ -456,8 +456,9 @@ void conv2d_q8ta_q8csw_q8to_reference_impl(TestCase& test_case) {
   if (N > kRefDimSizeLimit || C_in > kRefDimSizeLimit ||
       H_in > kRefDimSizeLimit || W_in > kRefDimSizeLimit ||
       C_out > kRefDimSizeLimit) {
-    throw std::invalid_argument(
+      throw std::invalid_argument(
         "One or more dimensions exceed the allowed limit for reference implementation.");
+      std::cout << "Reference implementation: computation may take some time for large tensors..." << std::endl;
   }
 
   if (input_spec.dtype != vkapi::kFloat) {

--- a/backends/vulkan/test/custom_ops/utils.cpp
+++ b/backends/vulkan/test/custom_ops/utils.cpp
@@ -1321,7 +1321,7 @@ TestResult execute_test_cases(
           print_valuespec_data(output_spec, "vulkan output");
           print_valuespec_data(output_spec, "ref output", true);
 
-          throw std::runtime_error("Correctness validation failed");
+            throw std::runtime_error("Correctness validation failed");
         }
       }
 


### PR DESCRIPTION
…izes

This change moves all fixed Conv2D parameters (kernel shape, stride, padding, dilation, groups) and the input/output tensor dimensions into Vulkan specialization constants. By making these values compile-time constants, the backend can generate more optimized pipelines, eliminate generic fallback paths, and reduce dynamic indexing overhead. This significantly improves performance across large and compute-intensive convolution workloads.


Change-Id: I3efe3de80dece91341ae4111bef1254c6779a1db

### Summary
[PLEASE REMOVE] See [CONTRIBUTING.md's Pull Requests](https://github.com/pytorch/executorch/blob/main/CONTRIBUTING.md#pull-requests) for ExecuTorch PR guidelines.

[PLEASE REMOVE] If this PR closes an issue, please add a `Fixes #<issue-id>` line.

[PLEASE REMOVE] If this PR introduces a fix or feature that should be the upcoming release notes, please add a "Release notes: <area>" label. For a list of available release notes labels, check out [CONTRIBUTING.md's Pull Requests](https://github.com/pytorch/executorch/blob/main/CONTRIBUTING.md#pull-requests).

### Test plan
[PLEASE REMOVE] How did you test this PR? Please write down any manual commands you used and note down tests that you have written if applicable.


cc @manuelcandales @digantdesai @cbilgin