### PR TITLE
Cortex_m backend: Support channels-broadcasting for ADD/MUL

### DIFF
--- a/backends/cortex_m/ops/op_quantized_add.cpp
+++ b/backends/cortex_m/ops/op_quantized_add.cpp
@@ -33,7 +33,14 @@ Tensor& quantized_add_out(
     const Scalar& output_shift,
     Tensor& out) {
   // Validate tensor types and dim order
-  validate_cmsis_nn_tensor_requirements(input1_int8, input2_int8, out);
+  bool channel_broadcast = is_channel_broadcast(input1_int8, input2_int8);
+  validate_cmsis_nn_tensor_requirements(
+      input1_int8,
+      input2_int8,
+      out,
+      ScalarType::Char,
+      /*require_channels_last=*/channel_broadcast,
+      /*require_same_sizes=*/!channel_broadcast);
 
   // Validate quantization parameters
   validate_quantization_params(
@@ -62,6 +69,8 @@ Tensor& quantized_add_out(
   int32_t out_zp = extractScalarToInt32(output_zero_point);
   int32_t output_mult = extractScalarToInt32(output_multiplier);
   int output_shift_val = extractScalarToInt(output_shift);
+  int8_t* input1_ptr = input1_int8.data_ptr<int8_t>();
+  int8_t* input2_ptr = input2_int8.data_ptr<int8_t>();
 
   // Left shift to maximize precision
   const int32_t left_shift = 20;
@@ -87,33 +96,49 @@ Tensor& quantized_add_out(
   // addition. To preserve precision when rescaling the inputs, they are first
   // upscaled as much as possible, Hence the left_shift parameter required here.
 
-  // Call CMSIS-NN kernel with precomputed parameters
-  arm_cmsis_nn_status status = arm_elementwise_add_s8(
-      input1_int8.const_data_ptr<int8_t>(),
-      input2_int8.const_data_ptr<int8_t>(),
-      -static_cast<int32_t>(zp1),
-      input1_mult,
-      input1_shift_val,
-      -static_cast<int32_t>(zp2),
-      input2_mult,
-      input2_shift_val,
-      left_shift,
-      out.mutable_data_ptr<int8_t>(),
-      static_cast<int32_t>(out_zp),
-      output_mult,
-      output_shift_val,
-      activation_min,
-      activation_max,
-      static_cast<int32_t>(out.numel()));
+  int32_t adds_per_loop = 0;
+  if (channel_broadcast) {
+    if (input1_int8.numel() < input2_int8.numel()) {
+      std::swap<int32_t>(zp1, zp2);
+      std::swap<int32_t>(input1_mult, input2_mult);
+      std::swap<int>(input1_shift_val, input2_shift_val);
+      std::swap<int8_t*>(input1_ptr, input2_ptr);
+    }
+    adds_per_loop = input1_int8.size(1);
+  } else {
+    adds_per_loop = out.numel();
+  }
 
-  if (status != ARM_CMSIS_NN_SUCCESS) {
-    ET_LOG(
-        Error,
-        "quantized_add_out: arm_elementwise_add_s8 failed with status [%d]",
-        status);
+  for (int32_t broadcast_offset = 0; broadcast_offset < out.numel();
+       broadcast_offset += adds_per_loop) {
+    // Call CMSIS-NN kernel with precomputed parameters
+    arm_cmsis_nn_status status = arm_elementwise_add_s8(
+        input1_ptr + broadcast_offset,
+        input2_ptr,
+        -static_cast<int32_t>(zp1),
+        input1_mult,
+        input1_shift_val,
+        -static_cast<int32_t>(zp2),
+        input2_mult,
+        input2_shift_val,
+        left_shift,
+        out.mutable_data_ptr<int8_t>() + broadcast_offset,
+        static_cast<int32_t>(out_zp),
+        output_mult,
+        output_shift_val,
+        activation_min,
+        activation_max,
+        adds_per_loop);
 
-    context.fail(Error::Internal); // Fail the execution context
-    return out;
+    if (status != ARM_CMSIS_NN_SUCCESS) {
+      ET_LOG(
+          Error,
+          "quantized_add_out: arm_elementwise_add_s8 failed with status [%d]",
+          status);
+
+      context.fail(Error::Internal); // Fail the execution context
+      return out;
+    }
   }
   ET_LOG(
       Info,

--- a/backends/cortex_m/test/ops/test_add.py
+++ b/backends/cortex_m/test/ops/test_add.py
@@ -121,6 +121,27 @@ test_cases = {
             ramp_tensor(-5, 5, (1, 2, 1, 2)),
         ),
     ),
+    "broadcast_channels_1": McuTestCase(
+        CortexMTensorAdd(),
+        (
+            ramp_tensor(-2, 2, (1, 8, 1, 1)).to(memory_format=torch.channels_last),
+            ramp_tensor(-5, 5, (1, 8, 5, 5)).to(memory_format=torch.channels_last),
+        ),
+    ),
+    "broadcast_channels_2": McuTestCase(
+        CortexMTensorAdd(),
+        (
+            ramp_tensor(-5, 5, (2, 8, 5, 5)).to(memory_format=torch.channels_last),
+            ramp_tensor(-2, 2, (1, 8, 1, 1)).to(memory_format=torch.channels_last),
+        ),
+    ),
+    "broadcast_channels_continous": McuTestCase(
+        CortexMTensorAdd(),
+        (
+            ramp_tensor(-5, 5, (2, 8, 5, 5)),
+            ramp_tensor(-2, 2, (1, 8, 1, 1)),
+        ),
+    ),
     "alpha": McuTestCase(
         CortexMAlphaAdd(0.5),
         (
@@ -143,6 +164,7 @@ xfails_dialect = xfails_implementation | {
     "broadcast_1": "Broadcasting is not supported in Cortex-M backend",
     "broadcast_2": "Broadcasting is not supported in Cortex-M backend",
     "broadcast_3": "Broadcasting is not supported in Cortex-M backend",
+    "broadcast_channels_continous": "Broadcasting channels is not supported in continous memory_format in Cortex-M backend.",
 }
 
 

--- a/backends/cortex_m/test/ops/test_mul.py
+++ b/backends/cortex_m/test/ops/test_mul.py
@@ -103,6 +103,27 @@ test_cases = {
             ramp_tensor(-5, 5, (1, 2, 1, 2)),
         ),
     ),
+    "broadcast_channels_1": McuTestCase(
+        CortexMTensorMul(),
+        (
+            ramp_tensor(-2, 2, (1, 8, 1, 1)).to(memory_format=torch.channels_last),
+            ramp_tensor(-5, 5, (1, 8, 5, 5)).to(memory_format=torch.channels_last),
+        ),
+    ),
+    "broadcast_channels_2": McuTestCase(
+        CortexMTensorMul(),
+        (
+            ramp_tensor(-5, 5, (2, 8, 5, 5)).to(memory_format=torch.channels_last),
+            ramp_tensor(-2, 2, (1, 8, 1, 1)).to(memory_format=torch.channels_last),
+        ),
+    ),
+    "broadcast_channels_continous": McuTestCase(
+        CortexMTensorMul(),
+        (
+            ramp_tensor(-5, 5, (2, 8, 5, 5)),
+            ramp_tensor(-2, 2, (1, 8, 1, 1)),
+        ),
+    ),
 }
 
 
@@ -112,6 +133,7 @@ xfail_cases_dialect = {
     "broadcast_1": "Broadcasting is not supported in Cortex-M backend",
     "broadcast_2": "Broadcasting is not supported in Cortex-M backend",
     "broadcast_3": "Broadcasting is not supported in Cortex-M backend",
+    "broadcast_channels_continous": "Broadcasting channels is not supported in continous memory_format in Cortex-M backend.",
 }
 
 


### PR DESCRIPTION
Adds support for broadcasting in the special case where one input contains only channels which are broadcasted onto every spatial element of the other tensor, e.g. [1,C,1,1] + [N, C, H, W] for channel-last tensors.

This is a needed for mobilenet_v3.

cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai