### PR TITLE
Annotate oncall for frequent signals

### DIFF
--- a/backends/qualcomm/tests/TARGETS
+++ b/backends/qualcomm/tests/TARGETS
@@ -2,6 +2,8 @@ load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 load("@fbcode_macros//build_defs:python_unittest.bzl", "python_unittest")
 load("@fbsource//xplat/executorch/backends/qualcomm/qnn_version.bzl", "get_qnn_library_version")
 
+oncall("executorch")
+
 runtime.python_library(
     name = "models",
     srcs = ["models.py"],


### PR DESCRIPTION
Summary:
The underlying goal is that all files in fbcode have owners annotated.  This file has been identified as defining builds or tests that are frequently used, but don't have an oncall annotation.

The purpose of the proper oncall is to ensure that the right people are notified on build or test breakages and that automated codemods (e.g. ai diffs) get proper review by the owners of the file or files.

The oncall was determined by looking at other annotations nearby (e.g. the src files, files in the parent folders).

Differential Revision: D87476364


