### PR TITLE
Increase emulator boot timeout to 1800 seconds

### DIFF
--- a/.github/workflows/_android.yml
+++ b/.github/workflows/_android.yml
@@ -126,4 +126,4 @@ jobs:
           disable-animations: true
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           # This is to make sure that the job doesn't fail flakily
-          emulator-boot-timeout: 900
+          emulator-boot-timeout: 1800


### PR DESCRIPTION
### Summary

### Test plan
CI