### PR TITLE
StaticAttetnion runtime support for generate_full_logits=False

### DIFF
--- a/examples/models/llama/tests/test_static_attention.py
+++ b/examples/models/llama/tests/test_static_attention.py
@@ -248,7 +248,9 @@ class StaticAttentionTest(unittest.TestCase):
                 )
                 ys.append(y_i)
 
-            self.assertTrue(torch.isclose(ys[-1], expected, rtol=1e-3).all())
+            self.assertTrue(
+                torch.isclose(ys[-1].flatten(), expected.flatten(), rtol=1e-3).all()
+            )
 
         for args in itertools.product(
             ["shift_pointer", "smart_mask"], ["static", "static_mha"]


### PR DESCRIPTION
Summary: Prefill will produce the logits at position 0 when not generating full logits. Lookahead decoding requires full logits.

Differential Revision: D88790445


