### PR TITLE
Arm backend: Make INT+FP default for vgf-backend

### DIFF
--- a/backends/arm/quantizer/quantization_annotator.py
+++ b/backends/arm/quantizer/quantization_annotator.py
@@ -356,6 +356,7 @@ _one_to_one = [
     torch.ops.aten.hardswish.default,
     torch.ops.aten.hardswish_.default,
     torch.ops.aten.full_like.default,
+    torch.ops.aten.zeros_like.default,
     torch.ops.aten.pow.Tensor_Scalar,
     torch.ops.aten.gelu.default,
     torch.ops.aten.sinh.default,

--- a/backends/arm/test/common.py
+++ b/backends/arm/test/common.py
@@ -170,12 +170,21 @@ def get_vgf_compile_spec(
 
     if not custom_path:
         custom_path = maybe_get_tosa_collate_path()
+    profiles = []
     if "FP" in repr(tosa_spec):
-        artifact_path = custom_path or tempfile.mkdtemp(prefix="arm_vgf_fp_")
-    elif "INT" in repr(tosa_spec):
-        artifact_path = custom_path or tempfile.mkdtemp(prefix="arm_vgf_int_")
-    else:
+        profiles.append("fp")
+    if "INT" in repr(tosa_spec):
+        profiles.append("int")
+    if len(profiles) == 0:
         raise ValueError(f"Unsupported vgf compile_spec: {repr(tosa_spec)}")
+
+    if custom_path is None:
+        artifact_path = "arm_vgf_"
+        for profile in profiles:
+            artifact_path = artifact_path + f"_{profile}"
+        artifact_path = tempfile.mkdtemp(artifact_path)
+    else:
+        artifact_path = custom_path
 
     if not os.path.exists(artifact_path):
         os.makedirs(artifact_path, exist_ok=True)

--- a/backends/arm/test/ops/test_eq.py
+++ b/backends/arm/test/ops/test_eq.py
@@ -122,7 +122,7 @@ def test_eq_scalar_tosa_INT(test_module):
 
 
 @common.parametrize("test_module", test_data_tensor)
-def test_eq_tensor_tosa_INT_a16w8(test_module):
+def test_eq_tensor_tosa_INT_16a8w(test_module):
     pipeline = TosaPipelineINT[input_t](
         test_module(),
         test_module().get_inputs(),
@@ -134,7 +134,7 @@ def test_eq_tensor_tosa_INT_a16w8(test_module):
 
 
 @common.parametrize("test_module", test_data_scalar)
-def test_eq_scalar_tosa_INT_a16w8(test_module):
+def test_eq_scalar_tosa_INT_16a8w(test_module):
     pipeline = TosaPipelineINT[input_t](
         test_module(),
         test_module().get_inputs(),
@@ -238,7 +238,11 @@ def test_eq_scalar_16a8w_u85_INT16(test_module):
 @common.SkipIfNoModelConverter
 def test_eq_scalar_vgf_FP_tensor(test_module):
     pipeline = VgfPipeline[input_t](
-        test_module(), test_module().get_inputs(), Equal.aten_op_Tensor, Equal.exir_op
+        test_module(),
+        test_module().get_inputs(),
+        Equal.aten_op_Tensor,
+        Equal.exir_op,
+        tosa_version="TOSA-1.0+FP",
     )
     pipeline.run()
 
@@ -247,7 +251,11 @@ def test_eq_scalar_vgf_FP_tensor(test_module):
 @common.SkipIfNoModelConverter
 def test_eq_scalar_vgf_FP(test_module):
     pipeline = VgfPipeline[input_t](
-        test_module(), test_module().get_inputs(), Equal.aten_op_Scalar, Equal.exir_op
+        test_module(),
+        test_module().get_inputs(),
+        Equal.aten_op_Scalar,
+        Equal.exir_op,
+        tosa_version="TOSA-1.0+FP",
     )
     pipeline.run()
 

--- a/backends/arm/test/tester/test_pipeline.py
+++ b/backends/arm/test/tester/test_pipeline.py
@@ -990,7 +990,7 @@ class VgfPipeline(BasePipelineMaker, Generic[T]):
         exir_op: Optional[str | List[str]] = None,
         run_on_vulkan_runtime: bool = True,
         vgf_compiler_flags: Optional[str] = "",
-        tosa_version: str = "TOSA-1.0+FP",
+        tosa_version: str = "TOSA-1.0+INT+FP",
         symmetric_io_quantization: bool = False,
         per_channel_quantization: bool = True,
         use_to_edge_transform_and_lower: bool = True,

--- a/backends/arm/vgf/compile_spec.py
+++ b/backends/arm/vgf/compile_spec.py
@@ -28,13 +28,12 @@ class VgfCompileSpec(ArmCompileSpec):
             tosa_spec (TosaSpecification | str | None): TOSA specification to
                 target. Strings are parsed via
                 :meth:`TosaSpecification.create_from_string`. Defaults to
-                ``"TOSA-1.0+FP"``.
+                ``"TOSA-1.0+FP+INT"``.
             compiler_flags (list[str] | None): Optional converter-backend flags.
-
         """
         if tosa_spec is None:
-            tosa_spec = "TOSA-1.0+FP"
-        if isinstance(tosa_spec, str):
+            tosa_spec = TosaSpecification.create_from_string("TOSA-1.0+FP+INT")
+        elif isinstance(tosa_spec, str):
             tosa_spec = TosaSpecification.create_from_string(tosa_spec)
 
         if compiler_flags is None:
@@ -55,13 +54,7 @@ class VgfCompileSpec(ArmCompileSpec):
 
         if "FP" not in tosa_profiles and "INT" not in tosa_profiles:
             raise ValueError(
-                "Arm backend only supports converter-backend for FP or INT. "
-                f"Invalid TOSA profile: {tosa_profiles}"
-            )
-
-        if len(tosa_profiles) != 1:
-            raise ValueError(
-                "For now Arm backend only supports converter-backend for either FP or INT. "
+                "Arm backend only supports converter-backend for FP and/or INT. "
                 f"Invalid TOSA profile: {tosa_profiles}"
             )
 


### PR DESCRIPTION
### Summary
Make INT+FP default for vgf. With INT+FP supported, the following issues were solved:
- Make sure that pow.Tensor_Scalar is not replaced by pow.Tensor_Tensor during transform_for_annotation.
- Make sure that Scalar-ops that also maps to table ops are not replaced by Tensor ops when quantized.
- Fix a bug in tosa_supported_operators where nodes with integer outputs were considered ok for partitioning when they shouldn't be.

### Test plan
The plan is to move most of the vgf-tests to lower with both INT and FP support. We can then test both the quantized and non-quantized flows.


cc @freddan80 @per @zingo @digantdesai