### PR TITLE
Arm backend: Add function to help linker force include backend

### DIFF
--- a/backends/arm/runtime/EthosUBackend.cpp
+++ b/backends/arm/runtime/EthosUBackend.cpp
@@ -540,9 +540,33 @@ class EthosUBackend final : public ::executorch::runtime::BackendInterface {
 };
 
 namespace {
-auto backend = EthosUBackend();
-Backend backend_id{"EthosUBackend", &backend};
-static auto registered = register_backend(backend_id);
+auto EthosUBackend_backend = EthosUBackend();
+Backend EthosUBackend_id{"EthosUBackend", &EthosUBackend_backend};
+static executorch::runtime::Error EthosUBackend_registered =
+    register_backend(EthosUBackend_id);
+
+#ifdef __ZEPHYR__
+/**
+ * This function serves as a linker force-include mechanism to ensure the
+ * EthosU backend module gets properly linked into the final executable,
+ * even when it might otherwise be optimized out by the linker due to
+ * linker options that remove unused code or data for example
+ * if you link with --gc-sections
+ * This function can be called from your runner to force the inclusion of
+ * the EthosU backend module. As a bonus it will return the status of the
+ * backend registration, so you can also check if the registration was
+ * successful.
+ */
+
+// Warning: This should not be considered to be an API and might get removed
+// without notice in a future release if a better way to solve this is
+// implemented.
+extern "C" executorch::runtime::Error
+executorch_delegate_EthosUBackend_registered() {
+  return EthosUBackend_registered;
+}
+#endif
+
 } // namespace
 
 } // namespace arm


### PR DESCRIPTION
### Summary
Add a function that serves as a linker force-include mechanism to
ensure the EthosU backend module gets properly linked into the final
executable, even when it might otherwise be optimized out by the
linker. This is needed when you use linker options that remove unused
code or data then this function can be called from your runner to
force the inclusion of the EthosU backend module.

This might be the case when build Executorch in other projects like
in ZephyrOS when you have an other set of compilers and linker flags.

### Test plan

Tested by invoking the project from ZephyrOS and check if the backend get installed or not.

cc @freddan80 @per @oscarandersson8218 @digantdesai