### PR TITLE
Qwen lora quantize test

### DIFF
--- a/.ci/scripts/test_lora.sh
+++ b/.ci/scripts/test_lora.sh
@@ -53,7 +53,11 @@ $PYTHON_EXECUTABLE -m extension.llm.export.export_llm \
 HF_QWEN_PATH=$(python -c "from huggingface_hub import snapshot_download; print(snapshot_download('unsloth/Qwen3-0.6B'))")
 echo "Model downloaded to: $HF_QWEN_PATH"
 
+<<<<<<< HEAD
 ### BUILD LLAMA RUNNER.
+=======
+# Build llama runner.
+>>>>>>> 3c0898753d (qwen lora test)
 cmake_install_executorch_libraries
 cmake_build_llama_runner
 


### PR DESCRIPTION
Add test for quantized lora. Expected file sizes:
```
full file:
-rw-r--r-- 1 lfq users 3051988096 Dec 10 11:34 qwen_lora_math_full.pte

program-data separated:
-rw-r--r-- 1 lfq users 2388436736 Dec  9 12:20 qwen_foundation.ptd
-rw-r--r-- 1 lfq users   40430544 Dec  9 12:20 qwen_lora_math.ptd
-rw-r--r-- 1 lfq users     810064 Dec  9 12:20 qwen_lora_math.pte

quantized:
-rw-r--r-- 1 lfq users  962094448 Dec 10 14:16 qwen_foundation_lora_q.ptd
-rw-r--r-- 1 lfq users   40430544 Dec 10 14:16 qwen_lora_math_q.ptd
-rw-r--r-- 1 lfq users     874912 Dec 10 14:16 qwen_lora_math_q.pte

quantized, no lora adapter:
-rw-r--r-- 1 lfq users  962094448 Dec 10 13:52 qwen_foundation_q.ptd
-rw-r--r-- 1 lfq users     635552 Dec 10 13:52 qwen_q.pte
```

Quantized lora weights are the same as non-quantized, as the rank is 16, and quantization for xnnpack works for group_size >= 32