### PR TITLE
Arm backend: Relax pre-push header checks

### DIFF
--- a/backends/arm/scripts/pre-push
+++ b/backends/arm/scripts/pre-push
@@ -33,7 +33,7 @@ VERBS="Add|Fix|Update|Refactor|Improve|Remove|Change|Implement|Create|Modify|"\
 "Handle|Ignore|Interpret|Instantiate|Invoke|Limit|Load|Modify|Permit|Print|"\
 "Profile|Recalculate|Reconstruct|Redefine|Redesign|Reevaluate|Relocate|Remap|"\
 "Render|Reposition|Request|Revert|Sanitize|Specify|Strengthen|Stub|Substitute|"\
-"Tag|Tweak|Unify|Unlock|Unset|Use|Validate|Verify|Rename"
+"Tag|Tweak|Unify|Unlock|Unset|Use|Validate|Verify|Rename|Relax"
 
 # Remote branch
 REMOTE=$(git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null)
@@ -68,6 +68,11 @@ if [ -z "$COMMITS" ]; then
 fi
 
 for COMMIT in ${COMMITS}; do
+    if [ -n "$REMOTE" ] && git merge-base --is-ancestor "$COMMIT" "$REMOTE"; then
+        echo -e "${INFO} Skipping commit ${COMMIT} (already on $REMOTE)"
+        continue
+    fi
+
     # If commit header contains WIP, everything is ok
     git rev-list --format=%s --max-count=1 ${COMMIT} | grep -q WIP && \
          continue
@@ -95,8 +100,14 @@ for COMMIT in ${COMMITS}; do
     commit_files=$(git diff-tree --no-commit-id --name-only \
         --diff-filter=ACMR ${COMMIT} -r)
     for commited_file in $commit_files; do
-        head $commited_file | grep -q "$current_year Arm"
-        if [[ $? != 0 ]]; then
+        file_header=$(head "$commited_file")
+        if ! echo "$file_header" | grep -qi "Arm"; then
+            echo -e "${WARNING} No Arm copyright header in ${commited_file}"\
+            " (skipping license year check)"
+            continue
+        fi
+
+        if ! echo "$file_header" | grep -q "$current_year Arm"; then
             echo -e "${ERROR} Header in $commited_file did not contain"\
             "'$current_year Arm'"
             failed_license_check=true


### PR DESCRIPTION
* Warn when files lack Arm headers instead of failing license check
* Keep year enforcement when an Arm header is present
* Skip commits already on upstream to avoid rebase noise


cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai