### PR TITLE
Increase docker time limit

### DIFF
--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -70,6 +70,7 @@ jobs:
 
       - name: Build docker image
         id: build-docker-image
+        timeout-minutes: 45
         uses: pytorch/test-infra/.github/actions/calculate-docker-image@main
         with:
           docker-image-name: ci-image:${{ matrix.docker-image-name }}


### PR DESCRIPTION
docker-build (linux.4xlarge, executorch-ubuntu-22.04-gcc9) is timing out after 30 minutes https://github.com/pytorch/executorch/actions/runs/20146171047/job/57827065017