### PR TITLE
Fix cadence test failures after modai migration

### DIFF
--- a/backends/apple/coreml/TARGETS
+++ b/backends/apple/coreml/TARGETS
@@ -82,6 +82,7 @@ runtime.python_library(
         "//executorch/exir/backend:partitioner",
         "//executorch/exir/backend:utils",
         "//executorch/export:lib",
+        "//executorch/runtime:runtime",  # @manual
     ],
 )
 

--- a/backends/qualcomm/recipes/TARGETS
+++ b/backends/qualcomm/recipes/TARGETS
@@ -30,6 +30,7 @@ runtime.python_library(
     deps = [
         "//caffe2:torch",
         "//executorch/export:lib",
+        "//executorch/runtime:runtime",  # @manual
         "//executorch/backends/qualcomm/partition:partition",
         "//executorch/backends/qualcomm/serialization:serialization",
         "//executorch/backends/qualcomm/utils:utils",

--- a/backends/xnnpack/recipes/TARGETS
+++ b/backends/xnnpack/recipes/TARGETS
@@ -30,6 +30,7 @@ runtime.python_library(
     deps = [
         "//caffe2:torch",
         "//executorch/export:lib",
+        "//executorch/runtime:runtime",  # @manual
         "//executorch/backends/xnnpack/quantizer:xnnpack_quantizer",
         "//executorch/backends/xnnpack/partition:xnnpack_partitioner",
         ":xnnpack_recipe_types",

--- a/backends/xnnpack/test/TARGETS
+++ b/backends/xnnpack/test/TARGETS
@@ -107,6 +107,7 @@ runtime.python_test(
     deps = [
        "//executorch/backends/xnnpack/recipes:xnnpack_recipes",
         "//executorch/export:lib",
+        "//executorch/runtime:runtime",  # @manual
         "//pytorch/vision:torchvision",  # @manual
         "//executorch/backends/xnnpack/test/tester:tester",
         "//executorch/examples/models:models",  # @manual

--- a/devtools/etrecord/tests/TARGETS
+++ b/devtools/etrecord/tests/TARGETS
@@ -23,5 +23,6 @@ runtime.python_library(
         "//executorch/exir/tests:models",
         "//executorch/backends/xnnpack/partition:xnnpack_partitioner",
         "//executorch/export:lib",
+        "//executorch/runtime:runtime",  # @manual
     ],
 )

--- a/export/TARGETS
+++ b/export/TARGETS
@@ -32,7 +32,6 @@ runtime.python_library(
         ":recipe",
         ":stages",
         ":types",
-        "//executorch/runtime:runtime",
         ":recipe_registry"
     ]
 )

--- a/export/export.py
+++ b/export/export.py
@@ -631,8 +631,15 @@ class ExportSession:
         Raises:
             RuntimeError: If the method cannot be loaded
         """
-        # Lazy import to avoid forcing portable_lib dependency at module load time
-        from executorch.runtime import Runtime, Verification
+        # Lazy import to avoid forcing portable_lib dependency at module load time.
+        try:
+            from executorch.runtime import Runtime, Verification
+        except ModuleNotFoundError as e:
+            raise ModuleNotFoundError(
+                "executorch.runtime is not available. "
+                "In OSS: Please ensure executorch is properly installed via pip. "
+                "In fbcode: Please add //executorch/runtime:runtime to your dependencies."
+            ) from e
 
         et_runtime = Runtime.get()
         program = et_runtime.load_program(

--- a/export/export.py
+++ b/export/export.py
@@ -6,6 +6,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import logging
+import time
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 import torch
@@ -441,8 +442,13 @@ class ExportSession:
 
             logging.info(f"Executing stage: {stage_type}")
 
+            start = time.perf_counter()
             stage.run(current_artifact)
+            elapsed = (time.perf_counter() - start) * 1000
             current_artifact = stage.get_artifacts()
+            current_artifact.add_context("duration_ms", int(elapsed))
+
+            logging.info(f"Stage {stage_type} execution done")
 
             self._stage_to_artifacts[stage_type] = current_artifact
 

--- a/export/export.py
+++ b/export/export.py
@@ -13,9 +13,10 @@ from executorch.exir._warnings import experimental
 from executorch.exir.program import ExecutorchProgramManager
 from executorch.exir.schema import Program
 from executorch.extension.export_util.utils import save_pte_program
-from executorch.runtime import Runtime, Verification
 from tabulate import tabulate
 from torch import nn
+from torch.export import ExportedProgram
+from torch.fx import GraphModule
 
 from .recipe import ExportRecipe, LoweringRecipe, QuantizationRecipe
 from .stages import (
@@ -36,11 +37,22 @@ from .types import StageType
     "This API and all of its related functionality such as ExportSession and ExportRecipe are experimental."
 )
 def export(
-    model: Union[nn.Module, Dict[str, nn.Module]],
-    example_inputs: Union[
-        List[tuple[torch.Tensor, ...]], Dict[str, List[tuple[torch.Tensor, ...]]]
+    model: Union[
+        nn.Module,
+        Dict[str, nn.Module],
+        GraphModule,
+        Dict[str, GraphModule],
+        ExportedProgram,
+        Dict[str, ExportedProgram],
+        str,
     ],
-    export_recipe: ExportRecipe,
+    example_inputs: Optional[
+        Union[
+            List[tuple[torch.Tensor, ...]],
+            Dict[str, List[tuple[torch.Tensor, ...]]],
+        ]
+    ] = None,
+    export_recipe: ExportRecipe = None,
     name: Optional[str] = None,
     dynamic_shapes: Optional[Union[Any, Dict[str, Any]]] = None,
     constant_methods: Optional[Union[Dict[str, Callable]]] = None,
@@ -54,10 +66,16 @@ def export(
     optionally run the export process in one step.
 
     Args:
-        model: The PyTorch model(s) to export, either a single model or a dictionary
-              mapping method names to models
+        model: The PyTorch model(s) to export. Can be:
+              - nn.Module or Dict[str, nn.Module]: Eager PyTorch model(s)
+              - GraphModule or Dict[str, GraphModule]: Quantized model(s) (e.g., from prepare/convert)
+              - ExportedProgram or Dict[str, ExportedProgram]: Already exported model(s)
+              - str: Path to load an ExportedProgram from disk
         example_inputs: Example inputs for the model(s), either a list of input tuples
-                      or a dictionary mapping method names to lists of input tuples
+                      or a dictionary mapping method names to lists of input tuples.
+                      First sample (index 0) is used for torch.export.export() to export the model.
+                      All samples are used as calibration dataset in PT2E Quantize stage.
+                      Optional when model is ExportedProgram (not needed).
         export_recipe: Contains the configuration for the export process
         name: Optional name for the export
         dynamic_shapes: Optional dynamic shape specifications
@@ -99,11 +117,22 @@ class ExportSession:
 
     def __init__(
         self,
-        model: Union[nn.Module, Dict[str, nn.Module]],
-        example_inputs: Union[
-            List[tuple[torch.Tensor, ...]], Dict[str, List[tuple[torch.Tensor, ...]]]
+        model: Union[
+            nn.Module,
+            Dict[str, nn.Module],
+            GraphModule,
+            Dict[str, GraphModule],
+            ExportedProgram,
+            Dict[str, ExportedProgram],
+            str,
         ],
-        export_recipe: ExportRecipe,
+        example_inputs: Optional[
+            Union[
+                List[tuple[torch.Tensor, ...]],
+                Dict[str, List[tuple[torch.Tensor, ...]]],
+            ]
+        ] = None,
+        export_recipe: ExportRecipe = None,
         name: Optional[str] = None,
         dynamic_shapes: Optional[Union[Any, Dict[str, Any]]] = None,
         constant_methods: Optional[Union[Dict[str, Callable]]] = None,
@@ -114,10 +143,16 @@ class ExportSession:
         Initialize the ExportSession with model, inputs, and recipe.
 
         Args:
-            model: The PyTorch model(s) to export, either a single model or a dictionary
-                  mapping method names to models
+            model: The PyTorch model(s) to export. Can be:
+                  - nn.Module or Dict[str, nn.Module]: Eager PyTorch model(s)
+                  - GraphModule or Dict[str, GraphModule]: Quantized model(s)
+                  - ExportedProgram or Dict[str, ExportedProgram]: Already exported model(s)
+                  - str: Path to load an ExportedProgram from disk
             example_inputs: Example inputs for the model(s), either a list of input tuples
-                          or a dictionary mapping method names to lists of input tuples
+                          or a dictionary mapping method names to lists of input tuples.
+                          First sample (index 0) is used for torch.export.export() to export the model.
+                          All samples are used as calibration dataset in PT2E Quantize stage,
+                          Optional when model is ExportedProgram (not needed).
             export_recipe: Contains the configuration for the export process
             name: Optional name for the export
             dynamic_shapes: Optional dynamic shape specifications
@@ -125,15 +160,35 @@ class ExportSession:
             artifact_dir: Optional directory to store artifacts
             generate_etrecord: Optional flag to generate an etrecord
         """
+        # Load model from file if string path provided
+        if isinstance(model, str):
+            model = torch.export.load(model)
+            logging.info(f"Loaded ExportedProgram from {model}")
+
+        # Detect input model type to determine which stages to skip
+        self._input_model_type = self._detect_model_type(model)
+
         # Standardize model to dictionary format
         self._model = model if isinstance(model, dict) else {"forward": model}
 
-        # Standardize example_inputs to dictionary format
-        self._example_inputs = (
-            example_inputs
-            if isinstance(example_inputs, dict)
-            else {"forward": example_inputs}
-        )
+        # Validate and standardize example_inputs to dictionary format
+        # example_inputs not required for ExportedProgram input
+        if self._input_model_type == "ExportedProgram":
+            self._example_inputs = example_inputs or {}
+            if isinstance(self._example_inputs, list):
+                self._example_inputs = {"forward": self._example_inputs}
+        else:
+            # For nn.Module and GraphModule, example_inputs are required
+            if example_inputs is None:
+                raise ValueError(
+                    f"example_inputs are required when model is {self._input_model_type}. "
+                    f"Only ExportedProgram inputs can omit example_inputs."
+                )
+            self._example_inputs = (
+                example_inputs
+                if isinstance(example_inputs, dict)
+                else {"forward": example_inputs}
+            )
 
         # Standardize dynamic_shapes to dictionary format
         self._dynamic_shapes = {}
@@ -176,14 +231,64 @@ class ExportSession:
 
         self._stage_to_artifacts: Dict[StageType, PipelineArtifact] = {}
 
+    def _detect_model_type(
+        self, model: Union[nn.Module, GraphModule, ExportedProgram, Dict]
+    ) -> str:
+        """
+        Detect the type of input model.
+
+        Args:
+            model: Input model in various formats
+
+        Returns:
+            String indicating the model type: "nn.Module", "GraphModule", or "ExportedProgram"
+        """
+        # Handle dict (multi-method) - check first value
+        if isinstance(model, dict):
+            first_value = next(iter(model.values()))
+            return self._detect_model_type(first_value)
+
+        # Detect single model type
+        if isinstance(model, ExportedProgram):
+            return "ExportedProgram"
+        elif isinstance(model, GraphModule):
+            return "GraphModule"
+        elif isinstance(model, nn.Module):
+            return "nn.Module"
+        else:
+            raise TypeError(f"Unsupported model type: {type(model)}")
+
     def _get_default_pipeline(self) -> List[StageType]:
-        return [
-            StageType.SOURCE_TRANSFORM,  # Optional stage, returns original model if quant recipe is invalid
-            StageType.QUANTIZE,  # Optional stage, returns original model if quant recipe is invalid
-            StageType.TORCH_EXPORT,
-            StageType.TO_EDGE_TRANSFORM_AND_LOWER,
-            StageType.TO_EXECUTORCH,
-        ]
+        """
+        Get default pipeline stages based on input model type.
+
+        Returns:
+            List of stages appropriate for the input model type
+        """
+        stages = []
+
+        # Add quantization stages only for eager nn.Module
+        if self._input_model_type == "nn.Module":
+            stages.extend(
+                [
+                    StageType.SOURCE_TRANSFORM,  # Optional stage, returns original model if quant recipe is invalid
+                    StageType.QUANTIZE,  # Optional stage, returns original model if quant recipe is invalid
+                ]
+            )
+
+        # Add torch export stage if not already exported
+        if self._input_model_type != "ExportedProgram":
+            stages.append(StageType.TORCH_EXPORT)
+
+        # Always include edge and executorch stages
+        stages.extend(
+            [
+                StageType.TO_EDGE_TRANSFORM_AND_LOWER,
+                StageType.TO_EXECUTORCH,
+            ]
+        )
+
+        return stages
 
     def _build_stages(self, stages: List[StageType]) -> Dict[StageType, Stage]:
         """Build the stage registry from the given stages."""
@@ -258,6 +363,34 @@ class ExportSession:
     ) -> None:
         if not stages:
             raise ValueError("Pipeline stages cannot be empty")
+
+        # Validate pipeline compatibility with input model type
+        if self._input_model_type == "GraphModule":
+            # GraphModule input should not run quantization stages
+            incompatible_stages = {StageType.SOURCE_TRANSFORM, StageType.QUANTIZE}
+            found_incompatible = set(stages) & incompatible_stages
+            if found_incompatible:
+                stage_names = ", ".join(s.name for s in found_incompatible)
+                raise ValueError(
+                    f"Cannot run {stage_names} stage(s) with GraphModule input. "
+                    f"GraphModule is already quantized. "
+                    f"Remove {stage_names} from pipeline_stages or use nn.Module input."
+                )
+        elif self._input_model_type == "ExportedProgram":
+            # ExportedProgram input should not run quantization or torch export stages
+            incompatible_stages = {
+                StageType.SOURCE_TRANSFORM,
+                StageType.QUANTIZE,
+                StageType.TORCH_EXPORT,
+            }
+            found_incompatible = set(stages) & incompatible_stages
+            if found_incompatible:
+                stage_names = ", ".join(s.name for s in found_incompatible)
+                raise ValueError(
+                    f"Cannot run {stage_names} stage(s) with ExportedProgram input. "
+                    f"ExportedProgram is already exported. "
+                    f"Remove {stage_names} from pipeline_stages or use nn.Module/GraphModule input."
+                )
 
         # Validate that the first stage can start a pipeline
         first_stage = stages[0]
@@ -436,6 +569,9 @@ class ExportSession:
         Raises:
             RuntimeError: If the method cannot be loaded
         """
+        # Lazy import to avoid forcing portable_lib dependency at module load time
+        from executorch.runtime import Runtime, Verification
+
         et_runtime = Runtime.get()
         program = et_runtime.load_program(
             self.get_pte_buffer(), verification=Verification.Minimal

--- a/export/stages.py
+++ b/export/stages.py
@@ -179,6 +179,7 @@ class EdgeTransformAndLowerStage(Stage):
         ) = None,
         compile_config: Optional[Any] = None,
     ) -> None:
+        super().__init__()
         self._partitioners = partitioners
         self._transform_passes = transform_passes
         self._compile_config = compile_config
@@ -206,7 +207,7 @@ class EdgeTransformAndLowerStage(Stage):
 
     @property
     def can_start_pipeline(self) -> bool:
-        return False
+        return True
 
     def run(self, artifact: PipelineArtifact) -> None:
         """
@@ -271,7 +272,10 @@ class ExecutorchStage(Stage):
 
     @property
     def valid_predecessor_stages(self) -> List["StageType"]:
-        return [StageType.TO_EDGE_TRANSFORM_AND_LOWER, StageType.TO_BACKEND]
+        return [
+            StageType.TO_EDGE_TRANSFORM_AND_LOWER,
+            StageType.TO_BACKEND,
+        ]
 
     @property
     def can_start_pipeline(self) -> bool:
@@ -468,7 +472,7 @@ class ToEdgeStage(Stage):
 
     @property
     def can_start_pipeline(self) -> bool:
-        return False
+        return True
 
     def run(self, artifact: PipelineArtifact) -> None:
         """

--- a/export/stages.py
+++ b/export/stages.py
@@ -13,8 +13,9 @@ from typing import Any, Callable, Dict, List, Optional
 
 import torch
 from executorch.devtools.backend_debug import get_delegation_info
-from executorch.exir import EdgeCompileConfig, ExportedProgram
+from executorch.exir import EdgeCompileConfig, EdgeProgramManager, ExportedProgram
 from executorch.exir.backend.backend_api import validation_disabled
+from executorch.exir.pass_manager import PassManager
 from executorch.exir.program import to_edge, to_edge_transform_and_lower
 from executorch.export.recipe import LoweringRecipe, QuantizationRecipe
 from executorch.export.types import StageType
@@ -175,7 +176,7 @@ class EdgeTransformAndLowerStage(Stage):
         self,
         partitioners: Optional[List[Any]] = None,
         transform_passes: (
-            None | List[Callable[[str, ExportedProgram], List[PassType]]]
+            None | List[Callable[[str, ExportedProgram], List[PassType] | PassManager]]
         ) = None,
         compile_config: Optional[Any] = None,
     ) -> None:
@@ -217,28 +218,33 @@ class EdgeTransformAndLowerStage(Stage):
         constant_methods = artifact.get_context("constant_methods")
         generate_etrecord = artifact.get_context("generate_etrecord", False)
 
-        # per method transform passes
+        # Detect if any callable returns PassManager
+        pass_manager = None
         transform_passes = defaultdict(list)
         for method_name, ep in exported_programs.items():
             # Resolve transform passes from callable
-            for pass_ in self._transform_passes or []:
-                if not callable(pass_):
+            for pass_callable in self._transform_passes or []:
+                if not callable(pass_callable):
                     raise ValueError(
-                        "Transform passes must be a callable that resolves to a list of passes"
+                        "Transform passes must be a callable that resolves to passes"
                     )
-                passes = pass_(method_name, ep)
-                if isinstance(passes, list):
-                    transform_passes[method_name].extend(passes)
+                passes = pass_callable(method_name, ep)
+                if isinstance(passes, PassManager):
+                    pass_manager = passes
+                    break
                 else:
-                    raise ValueError(
-                        "Transform passes must be a callable that resolves to a list of passes"
-                    )
+                    transform_passes[method_name].extend(passes)
+            if pass_manager:
+                break
+
+        # Use PassManager directly if found, otherwise use dict
+        final_passes = pass_manager if pass_manager else transform_passes
 
         with validation_disabled():
             edge_program_manager = to_edge_transform_and_lower(
                 exported_programs,
                 partitioner=self._partitioners,
-                transform_passes=transform_passes,
+                transform_passes=final_passes,
                 constant_methods=constant_methods,
                 compile_config=self._compile_config,
                 generate_etrecord=generate_etrecord,
@@ -275,6 +281,7 @@ class ExecutorchStage(Stage):
         return [
             StageType.TO_EDGE_TRANSFORM_AND_LOWER,
             StageType.TO_BACKEND,
+            StageType.EDGE_PROGRAM_MANAGER_TRANSFORM,  # Added for server model generation (skipping TO_BACKEND)
         ]
 
     @property
@@ -495,21 +502,128 @@ class ToEdgeStage(Stage):
         self._artifact = artifact.copy_with_new_data(edge_program_manager)
 
 
+class EdgeProgramManagerTransformStage(Stage):
+    """
+    Stage: Apply transformation passes that require EdgeProgramManager.
+
+    This stage enables dynamic pass generation where passes need access to the
+    EdgeProgramManager instance. Passes are applied sequentially, allowing
+    to control order and dependencies between pass groups.
+    """
+
+    def __init__(
+        self,
+        edge_transform_passes: (
+            None | List[Callable[[str, ExportedProgram], List[PassType] | PassManager]]
+        ) = None,
+        edge_manager_transform_passes: (
+            None | List[Callable[[EdgeProgramManager], List[PassType] | PassManager]]
+        ) = None,
+    ) -> None:
+        """
+        Initialize the EdgeProgramManagerTransformStage.
+
+        Args:
+            edge_manager_transform_passes: List of callables that take EdgeProgramManager
+                                           and return either List[PassType] or PassManager.
+                                           Each callable is applied sequentially, allowing
+                                           backends to control pass ordering and dependencies.
+        """
+        super().__init__()
+        self._edge_transform_passes = edge_transform_passes or []
+        self._edge_manager_transform_passes = edge_manager_transform_passes or []
+
+    @classmethod
+    def from_recipe(
+        cls, lowering_recipe: Optional[LoweringRecipe]
+    ) -> "EdgeProgramManagerTransformStage":
+        if lowering_recipe is None:
+            return cls()
+
+        return cls(
+            edge_transform_passes=lowering_recipe.edge_transform_passes,
+            edge_manager_transform_passes=lowering_recipe.edge_manager_transform_passes,
+        )
+
+    @property
+    def stage_type(self) -> str:
+        return StageType.EDGE_PROGRAM_MANAGER_TRANSFORM
+
+    @property
+    def valid_predecessor_stages(self) -> List["StageType"]:
+        return [
+            StageType.TO_EDGE,
+            # StageType.TO_EDGE_TRANSFORM_AND_LOWER,  # TODO
+        ]
+
+    @property
+    def can_start_pipeline(self) -> bool:
+        return False
+
+    def run(self, artifact: PipelineArtifact) -> None:
+        """
+        Apply transformation passes sequentially.
+
+        Args:
+            artifact: Pipeline artifact containing EdgeProgramManager
+        """
+        edge_program_manager = artifact.data
+
+        if not isinstance(edge_program_manager, EdgeProgramManager):
+            raise TypeError(
+                f"Expected EdgeProgramManager but got {type(edge_program_manager)}"
+            )
+
+        if not self._edge_transform_passes and not self._edge_manager_transform_passes:
+            self._artifact = artifact
+            return
+
+        # Detect if any callable returns PassManager
+        pass_manager = None
+        transform_passes = defaultdict(list)
+        for method_name in edge_program_manager.methods:
+            # Resolve transform passes if it's a callable
+            ep = edge_program_manager.exported_program(method_name)
+            for pass_callable in self._edge_transform_passes or []:
+                if not callable(pass_callable):
+                    raise ValueError(
+                        "Transform passes must be a callable that resolves to passes"
+                    )
+                passes = pass_callable(method_name, ep)
+                if isinstance(passes, PassManager):
+                    pass_manager = passes
+                    break
+                else:
+                    transform_passes[method_name].extend(passes)
+            if pass_manager:
+                break
+
+        # Use PassManager directly if found, otherwise use dict
+        final_passes = pass_manager if pass_manager else transform_passes
+
+        # Apply edge transform passes
+        edge_program_manager = edge_program_manager.transform(final_passes)
+
+        # Run edge manager transform passes
+        for pass_callable in self._edge_manager_transform_passes:
+            passes = pass_callable(edge_program_manager)
+            if passes:
+                edge_program_manager = edge_program_manager.transform(passes)
+
+        self._artifact = artifact.copy_with_new_data(edge_program_manager)
+
+
 class ToBackendStage(Stage):
     """
-    Stage: Apply transformations and partitioning to EdgeProgramManager.
+    Stage: Apply partitioning to EdgeProgramManager.
     """
 
     def __init__(
         self,
         partitioners: Optional[List[Any]] = None,
-        transform_passes: (
-            None | List[Callable[[str, ExportedProgram], List[PassType]]]
-        ) = None,
     ) -> None:
         super().__init__()
         self._partitioners = partitioners
-        self._transform_passes = transform_passes
 
     @classmethod
     def from_recipe(
@@ -520,7 +634,6 @@ class ToBackendStage(Stage):
 
         return cls(
             partitioners=lowering_recipe.partitioners,
-            transform_passes=lowering_recipe.edge_transform_passes,
         )
 
     @property
@@ -529,7 +642,10 @@ class ToBackendStage(Stage):
 
     @property
     def valid_predecessor_stages(self) -> List["StageType"]:
-        return [StageType.TO_EDGE]
+        return [
+            StageType.TO_EDGE,
+            StageType.EDGE_PROGRAM_MANAGER_TRANSFORM,
+        ]
 
     @property
     def can_start_pipeline(self) -> bool:
@@ -537,7 +653,7 @@ class ToBackendStage(Stage):
 
     def run(self, artifact: PipelineArtifact) -> None:
         """
-        Apply transformations and partitioning to EdgeProgramManager.
+        Apply partitioning to EdgeProgramManager.
 
         Args:
             artifact: Contains edge program manager and context
@@ -546,25 +662,6 @@ class ToBackendStage(Stage):
 
         if edge_program_manager is None:
             raise RuntimeError("Edge program manager is not set.")
-
-        # per method transform passes
-        transform_passes = defaultdict(list)
-        for method_name in edge_program_manager.methods:
-            # Resolve transform passes if it's a callable
-            ep = edge_program_manager.exported_program(method_name)
-            for pass_ in self._transform_passes or []:
-                if not callable(pass_):
-                    raise ValueError(
-                        "Transform passes must be a callable that resolves to a list of passes"
-                    )
-                passes = pass_(method_name, ep)
-                if isinstance(passes, list):
-                    transform_passes[method_name].extend(passes)
-                else:
-                    raise ValueError("Transform passes must return list of passes")
-
-        # Apply transform passes
-        edge_program_manager = edge_program_manager.transform(transform_passes)
 
         # Apply partitioners if available
         if self._partitioners is not None and len(self._partitioners) > 0:

--- a/export/tests/test_export_session.py
+++ b/export/tests/test_export_session.py
@@ -59,8 +59,11 @@ class TestExportSessionCoreFlow(unittest.TestCase):
                 StageType.QUANTIZE,
             ]
             mock_stage.can_start_pipeline = True
-        elif stage_type == StageType.TO_EDGE_TRANSFORM_AND_LOWER:
+        elif stage_type == StageType.ATEN_TRANSFORM:
             mock_stage.valid_predecessor_stages = [StageType.TORCH_EXPORT]
+            mock_stage.can_start_pipeline = True
+        elif stage_type == StageType.TO_EDGE_TRANSFORM_AND_LOWER:
+            mock_stage.valid_predecessor_stages = [StageType.TORCH_EXPORT, StageType.ATEN_TRANSFORM]
             mock_stage.can_start_pipeline = True
         elif stage_type == StageType.TO_EXECUTORCH:
             mock_stage.valid_predecessor_stages = [
@@ -80,6 +83,7 @@ class TestExportSessionCoreFlow(unittest.TestCase):
             StageType.SOURCE_TRANSFORM,
             StageType.QUANTIZE,
             StageType.TORCH_EXPORT,
+            StageType.ATEN_TRANSFORM,
             StageType.TO_EDGE_TRANSFORM_AND_LOWER,
             StageType.TO_EXECUTORCH,
         ]
@@ -104,7 +108,7 @@ class TestExportSessionCoreFlow(unittest.TestCase):
             stage.run.assert_called_once()
 
         # Verify artifacts were stored for each stage
-        self.assertEqual(len(session._stage_to_artifacts), 5)
+        self.assertEqual(len(session._stage_to_artifacts), 6)
         self.assertEqual(set(session._stage_to_artifacts.keys()), set(stage_types))
 
     def test_overriden_pipeline_execution_order(self) -> None:
@@ -490,11 +494,12 @@ class TestExportSessionPipelineBuilding(unittest.TestCase):
 
         registered_stages = session.get_all_registered_stages()
 
-        self.assertEqual(len(registered_stages), 5)
+        self.assertEqual(len(registered_stages), 6)
         expected_types = [
             StageType.SOURCE_TRANSFORM,
             StageType.QUANTIZE,
             StageType.TORCH_EXPORT,
+            StageType.ATEN_TRANSFORM,
             StageType.TO_EDGE_TRANSFORM_AND_LOWER,
             StageType.TO_EXECUTORCH,
         ]

--- a/export/types.py
+++ b/export/types.py
@@ -15,6 +15,7 @@ class StageType(str, Enum):
     SOURCE_TRANSFORM = "source_transform"
     QUANTIZE = "quantize"
     TORCH_EXPORT = "torch_export"
+    ATEN_TRANSFORM = "aten_transform"
     TO_EDGE_TRANSFORM_AND_LOWER = "to_edge_transform_and_lower"
     TO_EDGE = "to_edge"
     EDGE_PROGRAM_MANAGER_TRANSFORM = "edge_program_manager_transform"

--- a/export/types.py
+++ b/export/types.py
@@ -17,5 +17,6 @@ class StageType(str, Enum):
     TORCH_EXPORT = "torch_export"
     TO_EDGE_TRANSFORM_AND_LOWER = "to_edge_transform_and_lower"
     TO_EDGE = "to_edge"
+    EDGE_PROGRAM_MANAGER_TRANSFORM = "edge_program_manager_transform"
     TO_BACKEND = "to_backend"
     TO_EXECUTORCH = "to_executorch"


### PR DESCRIPTION
Summary: Fixing the task T248181571, some tests of cadence backends are failing due to skipping running aten passes. This change makes aten transform as separate stage rather than running as part of torch export stage.

Differential Revision: D88982394
