### PR TITLE
Fix double-promotion in rsqrt for reduced-precision types

### DIFF
--- a/runtime/core/portable_type/c10/c10/util/BFloat16-math.h
+++ b/runtime/core/portable_type/c10/c10/util/BFloat16-math.h
@@ -1,3 +1,10 @@
+/*
+ * Copyright 2025 Arm Limited and/or its affiliates.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <c10/util/BFloat16.h>
@@ -181,7 +188,7 @@ template <
     typename T,
     typename std::enable_if_t<c10::is_reduced_floating_point_v<T>, int> = 0>
 inline T rsqrt(T a) {
-  return 1.0 / std::sqrt(float(a));
+  return 1.0f / std::sqrt(float(a));
 }
 template <
     typename T,


### PR DESCRIPTION
Keep the bfloat16/fp16 rsqrt helper in float precision so Zephyr’s -Wdouble-promotion (treated as an error) no longer fires when ExecuTorch is built for Cortex-M targets.

Signed-off-by: per.held@arm.com
Change-Id: I8fbcc99d8aebac67c4164f2ad502e9b3081386b4


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell