### PR TITLE
Update more passes to use new pass interface/correctly set their modified bits

### DIFF
--- a/backends/cadence/aot/ref_implementations.py
+++ b/backends/cadence/aot/ref_implementations.py
@@ -506,7 +506,9 @@ def quantized_linear_variant(
                     raise ValueError("out_shift must be a scalar")
 
                 if out_shift.dtype != torch.int32:
-                    raise ValueError("out_shift must be an int32")
+                    raise ValueError(
+                        f"out_shift must be an int32. Got {out_shift.dtype} instead"
+                    )
 
                 _out_shift = int(out_shift.item())
                 _out_multiplier = int(out_multiplier[0].item())

--- a/backends/cadence/aot/simplify_ops.py
+++ b/backends/cadence/aot/simplify_ops.py
@@ -10,20 +10,23 @@
 # This file contains all the functions that simplify args of an op
 
 import sys
-from typing import Optional
+from typing import cast, Optional
 
+import torch
 from executorch.backends.cadence.aot.pass_utils import (
     CadencePassAttribute,
     register_cadence_pass,
+    RemoveOrReplacePassInterface,
 )
 from executorch.backends.cadence.aot.utils import rebind
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.dialects.edge._ops import EdgeOpOverload
-from executorch.exir.pass_base import ExportPass
+from executorch.exir.pass_base import ExportPass, PassResult
+from torch.fx import Node
 
 
 @register_cadence_pass(CadencePassAttribute(opt_level=0))
-class SimplifySliceOpPass(ExportPass):
+class SimplifySliceOpPass(RemoveOrReplacePassInterface):
     """
     Simplify the start and end indices of slice and slice_scatter ops.
     """
@@ -62,66 +65,152 @@ class SimplifySliceOpPass(ExportPass):
         # Return the adjusted start and end indices
         return (start_val, end_val)
 
-    def call_operator(self, op, args, kwargs, meta):
-        # We are only interested in slice_copy or slice_scatter ops
-        if op not in {
+    @property
+    def targets(self) -> list[EdgeOpOverload]:
+        return [
             exir_ops.edge.aten.slice_copy.Tensor,
             exir_ops.edge.aten.slice_scatter.default,
-        }:
-            return super().call_operator(op, args, kwargs, meta)
+        ]
 
+    def maybe_remove_or_replace(self, node: Node) -> bool:
         # Check if it is a slice_scatter op or not. The slice_scatter op has
         # an extra src argument at index 1.
-        slice_scatter = op == exir_ops.edge.aten.slice_scatter.default
-        # Parse the arguments
-        # Extract the tensor to be sliced, and the slicing dimension
-        in_tensor = args[0].to_tensor()
-        dim = args[1 + slice_scatter] if len(args) > 1 + slice_scatter else 0
+        slice_scatter = node.target == exir_ops.edge.aten.slice_scatter.default
+
+        # Get input tensor metadata
+        input_node = node.args[0]
+        if not isinstance(input_node, Node) or "val" not in input_node.meta:
+            return False
+
+        in_tensor = input_node.meta["val"]
+
+        # Extract the slicing dimension
+        dim_idx = 1 + (1 if slice_scatter else 0)
+        dim = node.args[dim_idx] if len(node.args) > dim_idx else 0
+        if not isinstance(dim, int):
+            return False
+
         # Make dim non-negative
+        original_dim = dim
         dim = dim if dim >= 0 else dim + in_tensor.dim()
         length = in_tensor.size(dim)
 
         # Get the adjusted start and end indices
-        start_val = args[2 + slice_scatter] if len(args) > 2 + slice_scatter else None
-        end_val = args[3 + slice_scatter] if len(args) > 3 + slice_scatter else None
-        step = args[4 + slice_scatter] if len(args) > 4 + slice_scatter else 1
-        (start_val, end_val) = self.adjust_slice_range(length, start_val, end_val, step)
+        start_idx = 2 + (1 if slice_scatter else 0)
+        end_idx = 3 + (1 if slice_scatter else 0)
+        step_idx = 4 + (1 if slice_scatter else 0)
 
-        # If the start_val is geq end_val, then we can return an empty tensor
-        # for slice op, or input for slice_scatter op.
-        if start_val >= end_val and slice_scatter:
-            return args[0]
-        if start_val >= end_val:
-            empty_shape = [x for x in in_tensor.shape if x != 0]
-            empty_shape[dim] = 0
-            return super().call_operator(
-                exir_ops.edge.aten.full.default,
-                (tuple(empty_shape), 0),
-                {"dtype": in_tensor.dtype},
-                meta,
-            )
+        start_val = node.args[start_idx] if len(node.args) > start_idx else None
+        end_val = node.args[end_idx] if len(node.args) > end_idx else None
+        step = node.args[step_idx] if len(node.args) > step_idx else 1
 
-        # Create new args
-        new_args = (
-            (args[0],)
-            + ((args[1],) if slice_scatter else ())
-            + (dim, start_val, end_val, step)
+        # Validate types
+        if start_val is not None and not isinstance(start_val, int):
+            return False
+        if end_val is not None and not isinstance(end_val, int):
+            return False
+        if not isinstance(step, int):
+            return False
+
+        # Get the adjusted start and end indices
+        original_start = start_val
+        original_end = end_val
+        (adjusted_start, adjusted_end) = self.adjust_slice_range(
+            length, start_val, end_val, step
         )
-        return super().call_operator(op, new_args, kwargs, meta)
+
+        # Check if anything changed
+        nothing_changed = (
+            adjusted_start == original_start
+            and adjusted_end == original_end
+            and dim == original_dim
+        )
+        if nothing_changed:
+            return False
+
+        # Replace the node based on the adjusted range
+        with node.graph.inserting_before(node):
+            if adjusted_start >= adjusted_end and slice_scatter:
+                # For slice_scatter with empty range, return the input
+                node.replace_all_uses_with(input_node)
+            elif adjusted_start >= adjusted_end:
+                # For slice with empty range, create an empty tensor
+                empty_shape = list(in_tensor.shape)
+                empty_shape[dim] = 0
+                new_node = node.graph.call_function(
+                    exir_ops.edge.aten.full.default,
+                    (tuple(empty_shape), 0),
+                    {"dtype": in_tensor.dtype},
+                )
+                new_node.meta = node.meta.copy()
+                node.replace_all_uses_with(new_node)
+            else:
+                # Create new args with simplified indices
+                if slice_scatter:
+                    new_args = (
+                        node.args[0],  # input
+                        node.args[1],  # src
+                        dim,
+                        adjusted_start,
+                        adjusted_end,
+                        step,
+                    )
+                else:
+                    new_args = (
+                        node.args[0],  # input
+                        dim,
+                        adjusted_start,
+                        adjusted_end,
+                        step,
+                    )
+                # Target is guaranteed to be a callable since it's from our targets list
+                target_callable = node.target
+                assert callable(target_callable), "Target must be callable"
+                new_node = node.graph.call_function(target_callable, new_args, {})
+                new_node.meta = node.meta.copy()
+                node.replace_all_uses_with(new_node)
+
+        node.graph.erase_node(node)
+        return True
 
 
 @register_cadence_pass(CadencePassAttribute(opt_level=0))
 class BindOptionalArgsPass(ExportPass):
     """Bind all optional args and kwargs."""
 
-    def call_operator(self, op, args, kwargs, meta):
-        if not isinstance(op, EdgeOpOverload):
-            return super().call_operator(op, args, kwargs, meta)
+    def call(self, graph_module: torch.fx.GraphModule) -> PassResult:
+        """
+        Bind all optional args and kwargs for EdgeOpOverload operations.
+        Only reports modified=True if arguments were actually changed.
+        """
+        modified = False
+        for module in filter(
+            lambda m: isinstance(m, torch.fx.GraphModule), graph_module.modules()
+        ):
+            for node in cast(torch.fx.GraphModule, module).graph.nodes:
+                if node.op != "call_function":
+                    continue
+                if not isinstance(node.target, EdgeOpOverload):
+                    continue
 
-        if (updated_args := rebind(op, args, kwargs)) is not None:
-            args, kwargs = updated_args
+                # Try to rebind the args/kwargs to populate optional arguments
+                updated_args = rebind(node.target, tuple(node.args), dict(node.kwargs))
+                if updated_args is None:
+                    # No schema matched or no changes needed
+                    continue
 
-        return super().call_operator(op, args, kwargs, meta)
+                new_args, new_kwargs = updated_args
+                # Check if anything actually changed
+                if new_args != node.args or new_kwargs != node.kwargs:
+                    node.args = new_args
+                    node.kwargs = new_kwargs
+                    modified = True
+
+        if modified:
+            graph_module.recompile()
+            return super().call(graph_module)
+
+        return PassResult(graph_module, modified)
 
 
 # This class encapsulates all the functions that simplify the op's args


### PR DESCRIPTION
Summary:
Update
- SinkOpsCloserToUsePass
- HoistOpsCloserToDefPass
- PostponePermuteOpBelowSqueezeOrUnsqueezeLikeView
- SimplifySliceOpPass
- BindOptionalArgsPass
- ReplaceConstantPadWithTuringExtendPass

to either use new pass interface (which is more efficient/correctly sets modified bit) or just correctly set modified bit if doesn't fit the interface well.

Differential Revision: D87898571


