### PR TITLE
Update supported Python versions in windows build

### DIFF
--- a/.github/workflows/build-wheels-windows.yml
+++ b/.github/workflows/build-wheels-windows.yml
@@ -27,7 +27,7 @@ jobs:
       test-infra-ref: main
       with-cuda: disabled
       with-rocm: disabled
-      python-versions: '["3.10", "3.11", "3.12", "3.13"]'
+      python-versions: '["3.10", "3.11", "3.12"]'
 
   build:
     needs: generate-matrix


### PR DESCRIPTION

### Summary
Removed Python 3.13 from the list of supported versions for windows for now. It's causing issue.

### Test plan
CI