### PR TITLE
Add null pointer check in XNNWeightsCache::look_up_or_insert

### DIFF
--- a/backends/xnnpack/runtime/XNNWeightsCache.cpp
+++ b/backends/xnnpack/runtime/XNNWeightsCache.cpp
@@ -208,6 +208,11 @@ size_t XNNWeightsCache::look_up_or_insert(
 
   if (offset != SIZE_MAX) {
     void* saved_ptr = context->offset_to_addr(context, offset);
+    // Check for null pointers before calling memcmp
+    if (ptr == nullptr || saved_ptr == nullptr) {
+      // If either pointer is null, cache is invalid
+      return SIZE_MAX;
+    }
     if (0 == memcmp(ptr, saved_ptr, size)) {
       return offset;
     }

--- a/backends/xnnpack/runtime/XNNWeightsCache.cpp
+++ b/backends/xnnpack/runtime/XNNWeightsCache.cpp
@@ -210,7 +210,8 @@ size_t XNNWeightsCache::look_up_or_insert(
     void* saved_ptr = context->offset_to_addr(context, offset);
     // Check for null pointers before calling memcmp
     if (ptr == nullptr || saved_ptr == nullptr) {
-      // If either pointer is null, cache is invalid
+      // If either pointer is null (due to deleted data or allocation failure), treat as cache miss
+      // and return SIZE_MAX to trigger reinsertion.
       return SIZE_MAX;
     }
     if (0 == memcmp(ptr, saved_ptr, size)) {


### PR DESCRIPTION

### Summary
This PR fixes a critical null pointer dereference crash (SIGSEGV) in the XNNPACK weights cache implementation that occurs when `look_up_or_insert` attempts to compare cached data with null pointers.

### Problem
The crash occurs in `XNNWeightsCache::look_up_or_insert` at line 211 (original) when `memcmp` is called without validating that the input pointers are non-null. This can happen in the following scenarios:

1. When `saved_ptr` is null because packed data was previously deleted (set to nullptr at line 118 in `delete_packed_data`)
2. When XNNPACK passes a null `ptr` parameter to the function
3. When there's a race condition or cache invalidation between lookup and comparison

The crash manifests as:
```
signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x0000000000000000
Cause: null pointer dereference
```

### Solution
Added a null pointer check before calling `memcmp` to validate both `ptr` and `saved_ptr`. When either pointer is null, the function returns `SIZE_MAX` to indicate the cache entry is invalid, allowing the normal insertion path to proceed instead of crashing.

Fixes https://github.com/pytorch/executorch/issues/16241

### Test plan
I Was not able to test the changes due to not having enough knowledge to integrate the direct build into android build. 

### Release Notes
Category: **Release notes: backends**

Fixed critical null pointer dereference crash in XNNPACK weights cache when comparing cached data. The fix adds null pointer validation before memory comparison, preventing SIGSEGV crashes during model loading and runtime creation.



cc @GregoryComer @digantdesai @cbilgin