### PR TITLE
Arm backend: Update vgf ops tests [Part 1]

### DIFF
--- a/backends/arm/test/ops/test_abs.py
+++ b/backends/arm/test/ops/test_abs.py
@@ -77,21 +77,25 @@ def test_abs_u85_INT(test_data: torch.Tensor):
 
 @common.parametrize("test_data", Abs.test_parameters)
 @common.SkipIfNoModelConverter
-def test_abs_vgf_FP(test_data: input_t1):
+def test_abs_vgf_no_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
-        Abs(), test_data(), aten_op, exir_op, tosa_version="TOSA-1.0+FP"
+        Abs(),
+        test_data(),
+        aten_op,
+        exir_op,
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", Abs.test_parameters)
 @common.SkipIfNoModelConverter
-def test_abs_vgf_INT(test_data: input_t1):
+def test_abs_vgf_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         Abs(),
         test_data(),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_acos.py
+++ b/backends/arm/test/ops/test_acos.py
@@ -95,27 +95,27 @@ def test_acos_u85_INT(test_data: Tuple):
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_acos_vgf_FP(test_data: Tuple):
+def test_acos_vgf_no_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t](
         Acos(),
         (test_data(),),
         [],
         [],
-        tosa_version="TOSA-1.0+FP",
         run_on_vulkan_runtime=True,
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_acos_vgf_INT(test_data: Tuple):
+def test_acos_vgf_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t](
         Acos(),
         (test_data(),),
         [],
         [],
-        tosa_version="TOSA-1.0+INT",
         run_on_vulkan_runtime=True,
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_acosh.py
+++ b/backends/arm/test/ops/test_acosh.py
@@ -115,23 +115,23 @@ def test_acosh_u85_INT_xfail(test_data: Tuple):
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_acosh_vgf_FP(test_data: Tuple):
+def test_acosh_vgf_no_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t](
         Acosh(),
         (test_data(),),
         aten_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_acosh_vgf_INT(test_data: Tuple):
+def test_acosh_vgf_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t](
         Acosh(),
         (test_data(),),
         aten_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_adaptive_avg_pool2d.py
+++ b/backends/arm/test/ops/test_adaptive_avg_pool2d.py
@@ -216,27 +216,27 @@ def test_adaptive_avg_pool2d_16a8w_u85_INT16(test_module):
 
 @common.parametrize("test_module", test_modules)
 @common.SkipIfNoModelConverter
-def test_adaptive_avg_pool2d_vgf_FP(test_module):
+def test_adaptive_avg_pool2d_vgf_no_quant(test_module):
     model, input_tensor = test_module()
     pipeline = VgfPipeline[input_t](
         model,
         input_tensor,
         [],
         exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_module", test_modules)
 @common.SkipIfNoModelConverter
-def test_adaptive_avg_pool2d_vgf_INT(test_module):
+def test_adaptive_avg_pool2d_vgf_quant(test_module):
     model, input_tensor = test_module()
     pipeline = VgfPipeline[input_t](
         model,
         input_tensor,
         [],
         exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_add.py
+++ b/backends/arm/test/ops/test_add.py
@@ -202,28 +202,28 @@ def test_add_tensor_u85_INT_2(test_data: input_t2):
 
 @common.parametrize("test_data", Add.test_data)
 @common.SkipIfNoModelConverter
-def test_add_tensor_vgf_FP(test_data: input_t1):
+def test_add_tensor_vgf_no_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         Add(),
         test_data(),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+FP",
         run_on_vulkan_runtime=True,
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", Add.test_data)
 @common.SkipIfNoModelConverter
-def test_add_tensor_vgf_INT(test_data: input_t1):
+def test_add_tensor_vgf_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         Add(),
         test_data(),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+INT",
         run_on_vulkan_runtime=True,
+        quantize=True,
     )
     pipeline.run()
 

--- a/backends/arm/test/ops/test_addmm.py
+++ b/backends/arm/test/ops/test_addmm.py
@@ -167,26 +167,26 @@ def test_addmm_u85_INT(test_data: Tuple):
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_addmm_vgf_FP(test_data: input_t1):
+def test_addmm_vgf_no_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         Addmm(),
         (*test_data,),
         aten_op=aten_op,
         exir_op=exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_addmm_vgf_INT(test_data: input_t1):
+def test_addmm_vgf_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         Addmm(),
         (*test_data,),
         aten_op=[],
         exir_op=exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 

--- a/backends/arm/test/ops/test_alias_copy.py
+++ b/backends/arm/test/ops/test_alias_copy.py
@@ -90,25 +90,25 @@ def test_alias_u85_INT(test_data: input_t1):
 
 @common.parametrize("test_data", AliasCopy.test_data)
 @common.SkipIfNoModelConverter
-def test_alias_vgf_FP(test_data: input_t1):
+def test_alias_vgf_no_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         AliasCopy(),
         test_data(),
         AliasCopy.aten_op,
         AliasCopy.exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", AliasCopy.test_data)
 @common.SkipIfNoModelConverter
-def test_alias_vgf_INT(test_data: input_t1):
+def test_alias_vgf_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         AliasCopy(),
         test_data(),
         AliasCopy.aten_op,
         AliasCopy.exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_amax.py
+++ b/backends/arm/test/ops/test_amax.py
@@ -139,53 +139,53 @@ def test_max_dim_tosa_FP_not_delegated():
 
 @common.parametrize("test_data", Amax.test_data)
 @common.SkipIfNoModelConverter
-def test_amax_vgf_FP(test_data: Amax.input_t):
+def test_amax_vgf_no_quant(test_data: Amax.input_t):
     data, dim, keep_dims = test_data()
     module = Amax(dim, keep_dims)
     pipeline = VgfPipeline[Amax.input_t](
         module,
         data,
         Amax.aten_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", Amax.test_data)
 @common.SkipIfNoModelConverter
-def test_amax_vgf_INT(test_data: Amax.input_t):
+def test_amax_vgf_quant(test_data: Amax.input_t):
     data, dim, keep_dims = test_data()
     module = Amax(dim, keep_dims)
     pipeline = VgfPipeline[Amax.input_t](
         module,
         data,
         Amax.aten_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", Max.test_data)
 @common.SkipIfNoModelConverter
-def test_max_dim_vgf_FP_to_amax(test_data: Max.input_t):
+def test_max_dim_to_amax_vgf_no_quant(test_data: Max.input_t):
     data, dim = test_data()
     pipeline = VgfPipeline[Max.input_t](
         Max(dim),
         data,
         "torch.ops.aten.max",
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", Max.test_data)
 @common.SkipIfNoModelConverter
-def test_max_dim_vgf_INT_to_amax(test_data: Max.input_t):
+def test_max_dim_to_amax_vgf_quant(test_data: Max.input_t):
     data, dim = test_data()
     pipeline = VgfPipeline[Max.input_t](
         Max(dim),
         data,
         "torch.ops.aten.amax",
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_amin.py
+++ b/backends/arm/test/ops/test_amin.py
@@ -155,48 +155,51 @@ def test_min_dim_tosa_FP_not_delegated():
 
 @common.parametrize("test_data", Amin.test_data)
 @common.SkipIfNoModelConverter
-def test_amin_vgf_FP(test_data: Amin.input_t):
+def test_amin_vgf_no_quant(test_data: Amin.input_t):
     data, dim, keep_dims = test_data()
     pipeline = VgfPipeline[Amin.input_t](
-        Amin(dim, keep_dims), data, Amin.aten_op, tosa_version="TOSA-1.0+FP"
+        Amin(dim, keep_dims),
+        data,
+        Amin.aten_op,
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", Amin.test_data)
 @common.SkipIfNoModelConverter
-def test_amin_vgf_INT(test_data: Amin.input_t):
+def test_amin_vgf_quant(test_data: Amin.input_t):
     data, dim, keep_dims = test_data()
     pipeline = VgfPipeline[Amin.input_t](
         Amin(dim, keep_dims),
         data,
         Amin.aten_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", Min.test_data)
 @common.SkipIfNoModelConverter
-def test_min_dim_vgf_FP_to_amin(test_data: Min.input_t):
+def test_min_dim_to_amin_vgf_no_quant(test_data: Min.input_t):
     data, dim = test_data()
     pipeline = VgfPipeline[Min.input_t](
         Min(dim),
         data,
         "torch.ops.aten.min",
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", Min.test_data)
 @common.SkipIfNoModelConverter
-def test_min_dim_vgf_INT_to_amin(test_data: Min.input_t):
+def test_min_dim_to_amin_vgf_quant(test_data: Min.input_t):
     data, dim = test_data()
     pipeline = VgfPipeline[Min.input_t](
         Min(dim),
         data,
         "torch.ops.aten.amin",
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_any.py
+++ b/backends/arm/test/ops/test_any.py
@@ -184,27 +184,27 @@ def test_any_u85_INT(test_data: input_t1):
 
 @common.parametrize("test_data", test_data)
 @common.SkipIfNoModelConverter
-def test_any_vgf_FP(test_data: input_t1):
+def test_any_vgf_no_quant(test_data: input_t1):
     op, data_fn = test_data()
     pipeline = VgfPipeline[input_t1](
         op,
         data_fn(),
         op.aten_op,
         op.exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data)
 @common.SkipIfNoModelConverter
-def test_any_vgf_INT(test_data: input_t1):
+def test_any_vgf_quant(test_data: input_t1):
     op, data_fn = test_data()
     pipeline = VgfPipeline[input_t1](
         op,
         data_fn(),
         op.aten_op,
         op.exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_arange.py
+++ b/backends/arm/test/ops/test_arange.py
@@ -127,7 +127,7 @@ def test_arange_start_step_u85_INT(test_data: test_data_t):
 
 @common.parametrize("test_data", ArangeAdd.test_data)
 @common.SkipIfNoModelConverter
-def test_arange_start_step_vgf_FP(test_data: test_data_t):
+def test_arange_start_step_vgf_no_quant(test_data: test_data_t):
     input_data, init_data = test_data
     module = ArangeAdd(*init_data)
     pipeline = VgfPipeline[input_t](
@@ -135,14 +135,14 @@ def test_arange_start_step_vgf_FP(test_data: test_data_t):
         input_data(),
         module.aten_op,
         module.exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", ArangeAdd.test_data)
 @common.SkipIfNoModelConverter
-def test_arange_start_step_vgf_INT(test_data: test_data_t):
+def test_arange_start_step_vgf_quant(test_data: test_data_t):
     input_data, init_data = test_data
     module = ArangeAdd(*init_data)
     pipeline = VgfPipeline[input_t](
@@ -150,7 +150,7 @@ def test_arange_start_step_vgf_INT(test_data: test_data_t):
         input_data(),
         module.aten_op,
         module.exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 
@@ -199,28 +199,28 @@ def test_linspace_tosa_INT(test_data: test_data_t):
 
 @common.parametrize("test_data", LinspaceAdd.test_data)
 @common.SkipIfNoModelConverter
-def test_linspace_vgf_FP(test_data: test_data_t):
+def test_linspace_vgf_no_quant(test_data: test_data_t):
     input_data, init_data = test_data
     pipeline = VgfPipeline[input_t](
         LinspaceAdd(*init_data),
         input_data(),
         LinspaceAdd.aten_op,
         LinspaceAdd.exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", LinspaceAdd.test_data)
 @common.SkipIfNoModelConverter
-def test_linspace_vgf_INT(test_data: test_data_t):
+def test_linspace_vgf_quant(test_data: test_data_t):
     input_data, init_data = test_data
     pipeline = VgfPipeline[input_t](
         LinspaceAdd(*init_data),
         input_data(),
         LinspaceAdd.aten_op,
         LinspaceAdd.exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 
@@ -249,10 +249,10 @@ def test_arange_u85_INT():
 
 
 @pytest.mark.skip(reason=skip_str)
-def test_arange_vgf_FP():
+def test_arange_vgf_no_quant():
     pass
 
 
 @pytest.mark.skip(reason=skip_str)
-def test_arange_vgf_INT():
+def test_arange_vgf_quant():
     pass

--- a/backends/arm/test/ops/test_asin.py
+++ b/backends/arm/test/ops/test_asin.py
@@ -83,23 +83,23 @@ def test_asin_u85_INT(test_data: Tuple):
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_asin_vgf_FP(test_data: Tuple):
+def test_asin_vgf_no_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t](
         Asin(),
         (test_data(),),
         aten_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_asin_vgf_INT(test_data: Tuple):
+def test_asin_vgf_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t](
         Asin(),
         (test_data(),),
         aten_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_asinh.py
+++ b/backends/arm/test/ops/test_asinh.py
@@ -82,23 +82,23 @@ def test_asinh_u85_INT(test_data: Tuple):
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_asinh_vgf_FP(test_data: Tuple):
+def test_asinh_vgf_no_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t](
         Asinh(),
         (test_data(),),
         aten_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_asinh_vgf_INT(test_data: Tuple):
+def test_asinh_vgf_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t](
         Asinh(),
         (test_data(),),
         aten_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_at.py
+++ b/backends/arm/test/ops/test_at.py
@@ -152,105 +152,105 @@ def test_atmatmul_mixed_pattern2_tosa_INT(test_data: input_t1):
 
 @common.parametrize("test_data", AtMatMulSingleInput.test_data_generators)
 @common.SkipIfNoModelConverter
-def test_atmatmul_single_input_vgf_FP(test_data: input_t1):
+def test_atmatmul_single_input_vgf_no_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         AtMatMulSingleInput(),
         test_data(),
         aten_op_mm,
         exir_op_mm,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", AtMatMulDoubleInput.test_data_generators)
 @common.SkipIfNoModelConverter
-def test_atmatmul_double_input_vgf_FP(test_data: input_t1):
+def test_atmatmul_double_input_vgf_no_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         AtMatMulDoubleInput(),
         test_data(),
         aten_op_mm,
         exir_op_mm,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", AtMatMulMixedPattern1.test_data_generators)
 @common.SkipIfNoModelConverter
-def test_atmatmul_mixed_pattern1_vgf_FP(test_data: input_t1):
+def test_atmatmul_mixed_pattern1_vgf_no_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         AtMatMulMixedPattern1(),
         test_data(),
         aten_op_mm,
         exir_op_mm,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", AtMatMulMixedPattern2.test_data_generators)
 @common.SkipIfNoModelConverter
-def test_atmatmul_mixed_pattern2_vgf_FP(test_data: input_t1):
+def test_atmatmul_mixed_pattern2_vgf_no_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         AtMatMulMixedPattern2(),
         test_data(),
         aten_op_mm,
         exir_op_mm,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", AtMatMulSingleInput.test_data_generators)
 @common.SkipIfNoModelConverter
-def test_atmatmul_single_input_vgf_INT(test_data: input_t1):
+def test_atmatmul_single_input_vgf_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         AtMatMulSingleInput(),
         test_data(),
         aten_op_mm,
         exir_op_mm,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", AtMatMulDoubleInput.test_data_generators)
 @common.SkipIfNoModelConverter
-def test_atmatmul_double_input_vgf_INT(test_data: input_t1):
+def test_atmatmul_double_input_vgf_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         AtMatMulDoubleInput(),
         test_data(),
         aten_op_mm,
         exir_op_mm,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", AtMatMulMixedPattern1.test_data_generators)
 @common.SkipIfNoModelConverter
-def test_atmatmul_mixed_pattern1_vgf_INT(test_data: input_t1):
+def test_atmatmul_mixed_pattern1_vgf_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         AtMatMulMixedPattern1(),
         test_data(),
         aten_op_mm,
         exir_op_mm,
         qtol=1,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", AtMatMulMixedPattern2.test_data_generators)
 @common.SkipIfNoModelConverter
-def test_atmatmul_mixed_pattern2_vgf_INT(test_data: input_t1):
+def test_atmatmul_mixed_pattern2_vgf_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         AtMatMulMixedPattern2(),
         test_data(),
         aten_op_mm,
         exir_op_mm,
         qtol=1,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_atan.py
+++ b/backends/arm/test/ops/test_atan.py
@@ -87,25 +87,25 @@ def test_atan_u85_INT(test_data: Tuple):
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_atan_vgf_FP(test_data: Tuple):
+def test_atan_vgf_no_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         Atan(),
         (test_data,),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_atan_vgf_INT(test_data: Tuple):
+def test_atan_vgf_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         Atan(),
         (test_data,),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_atanh.py
+++ b/backends/arm/test/ops/test_atanh.py
@@ -88,25 +88,25 @@ def test_atanh_u85_INT(test_data: Tuple):
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_atanh_vgf_FP(test_data: input_t1):
+def test_atanh_vgf_no_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         Atanh(),
         (test_data,),
         aten_op=aten_op,
         exir_op=exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_atanh_vgf_INT(test_data: input_t1):
+def test_atanh_vgf_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         Atanh(),
         (test_data,),
         aten_op=aten_op,
         exir_op=exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_avg_pool2d.py
+++ b/backends/arm/test/ops/test_avg_pool2d.py
@@ -232,28 +232,28 @@ def test_avg_pool2d_16a8w_u85_INT16(test_module):
 
 @common.parametrize("test_module", test_modules)
 @common.SkipIfNoModelConverter
-def test_avg_pool2d_vgf_FP(test_module):
+def test_avg_pool2d_vgf_no_quant(test_module):
     model, input_tensor = test_module()
     pipeline = VgfPipeline[input_t](
         model,
         input_tensor,
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_module", test_modules)
 @common.SkipIfNoModelConverter
-def test_avg_pool2d_vgf_INT(test_module):
+def test_avg_pool2d_vgf_quant(test_module):
     model, input_tensor = test_module()
     pipeline = VgfPipeline[input_t](
         model,
         input_tensor,
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 

--- a/backends/arm/test/ops/test_batch_norm.py
+++ b/backends/arm/test/ops/test_batch_norm.py
@@ -102,20 +102,20 @@ def test_native_batch_norm_legit_no_training_tosa_INT_not_delegated():
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_native_batch_norm_legit_no_training_vgf_FP(test_data: Tuple):
+def test_native_batch_norm_legit_no_training_vgf_no_quant(test_data: Tuple):
     inp, model_params = test_data()
     pipeline = VgfPipeline[input_t1](
         BatchNorm2d(*model_params),
         (inp,),
         aten_op=BatchNorm2d.aten_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_native_batch_norm_legit_no_training_vgf_INT(test_data: Tuple):
+def test_native_batch_norm_legit_no_training_vgf_quant(test_data: Tuple):
     # TODO(MLETORCH-100: Quantized stand-alone batch norms)
     pass
 
@@ -240,27 +240,27 @@ def test_native_batch_norm_legit_no_training_u85_INT_conv(test_data: Tuple):
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_native_batch_norm_legit_no_training_vgf_FP_conv(test_data: Tuple):
+def test_native_batch_norm_legit_no_training_conv_vgf_no_quant(test_data: Tuple):
     test_data, model_params = test_data()
     pipeline = VgfPipeline[input_t1](
         BatchNorm2dConv(*model_params),
         (test_data,),
         aten_op=BatchNorm2dConv.aten_ops,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_native_batch_norm_legit_no_training_vgf_INT_conv(test_data: Tuple):
+def test_native_batch_norm_legit_no_training_conv_vgf_quant(test_data: Tuple):
     test_data, model_params = test_data()
     pipeline = VgfPipeline[input_t1](
         BatchNorm2dConv(*model_params),
         (test_data,),
-        aten_op=BatchNorm2dConv.aten_ops[0],  # Bn is removed before check
+        aten_op=BatchNorm2dConv.aten_ops[0],
         qtol=1,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 
@@ -357,13 +357,13 @@ def test_native_batch_norm_legit_no_stats_u85_INT(test_data: Tuple):
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_native_batch_norm_legit_no_stats_vgf_FP(test_data: Tuple):
+def test_native_batch_norm_legit_no_stats_vgf_no_quant(test_data: Tuple):
     test_data, model_params = test_data()
     pipeline = VgfPipeline[input_t1](
         BatchNorm2dNoStats(*model_params),
         (test_data,),
         aten_op=BatchNorm2dNoStats.aten_ops,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
@@ -373,13 +373,13 @@ def test_native_batch_norm_legit_no_stats_vgf_FP(test_data: Tuple):
 )
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_native_batch_norm_legit_no_stats_vgf_INT(test_data: Tuple):
+def test_native_batch_norm_legit_no_stats_vgf_quant(test_data: Tuple):
     test_data, model_params = test_data()
     pipeline = VgfPipeline[input_t1](
         BatchNorm2dNoStats(*model_params),
         (test_data,),
         aten_op=BatchNorm2dNoStats.aten_ops,
         qtol=1,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_bitwise.py
+++ b/backends/arm/test/ops/test_bitwise.py
@@ -255,7 +255,7 @@ def test_bitwise_and_tensor_u85_INT(test_data: input_t2):
 
 @common.parametrize("test_data", And().test_data)
 @common.SkipIfNoModelConverter
-def test_bitwise_and_tensor_vgf_FP(test_data: input_t2):
+def test_bitwise_and_tensor_vgf_no_quant(test_data: input_t2):
     pipeline = OpNotSupportedPipeline[input_t2](
         And(),
         test_data(),
@@ -266,7 +266,7 @@ def test_bitwise_and_tensor_vgf_FP(test_data: input_t2):
 
 @common.parametrize("test_data", AndScalar().test_data)
 @common.SkipIfNoModelConverter
-def test_bitwise_and_scalar_vgf_FP(test_data: input_t2):
+def test_bitwise_and_scalar_vgf_no_quant(test_data: input_t2):
     pipeline = OpNotSupportedPipeline[input_t2](
         AndScalar(),
         test_data(),
@@ -277,7 +277,7 @@ def test_bitwise_and_scalar_vgf_FP(test_data: input_t2):
 
 @common.parametrize("test_data", And().test_data)
 @common.SkipIfNoModelConverter
-def test_bitwise_and_tensor_vgf_INT(test_data: input_t2):
+def test_bitwise_and_tensor_vgf_quant(test_data: input_t2):
     pipeline = VgfPipeline[input_t2](
         And(),
         test_data(),
@@ -286,14 +286,14 @@ def test_bitwise_and_tensor_vgf_INT(test_data: input_t2):
         atol=0,
         rtol=0,
         qtol=0,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", AndScalar().test_data)
 @common.SkipIfNoModelConverter
-def test_bitwise_and_scalar_vgf_INT(test_data: input_t2):
+def test_bitwise_and_scalar_vgf_quant(test_data: input_t2):
     pipeline = VgfPipeline[input_t2](
         AndScalar(),
         test_data(),
@@ -302,7 +302,7 @@ def test_bitwise_and_scalar_vgf_INT(test_data: input_t2):
         atol=0,
         rtol=0,
         qtol=0,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 
@@ -424,7 +424,7 @@ def test_bitwise_xor_scalar_u85_INT(test_data: input_t2):
 
 @common.parametrize("test_data", Xor().test_data)
 @common.SkipIfNoModelConverter
-def test_bitwise_xor_tensor_vgf_FP(test_data: input_t2):
+def test_bitwise_xor_tensor_vgf_no_quant(test_data: input_t2):
     pipeline = OpNotSupportedPipeline[input_t2](
         Xor(),
         test_data(),
@@ -435,7 +435,7 @@ def test_bitwise_xor_tensor_vgf_FP(test_data: input_t2):
 
 @common.parametrize("test_data", XorScalar().test_data)
 @common.SkipIfNoModelConverter
-def test_bitwise_xor_scalar_vgf_FP(test_data: input_t2):
+def test_bitwise_xor_scalar_vgf_no_quant(test_data: input_t2):
     pipeline = OpNotSupportedPipeline[input_t2](
         XorScalar(),
         test_data(),
@@ -446,7 +446,7 @@ def test_bitwise_xor_scalar_vgf_FP(test_data: input_t2):
 
 @common.parametrize("test_data", Xor().test_data)
 @common.SkipIfNoModelConverter
-def test_bitwise_xor_tensor_vgf_INT(test_data: input_t2):
+def test_bitwise_xor_tensor_vgf_quant(test_data: input_t2):
     pipeline = VgfPipeline[input_t2](
         Xor(),
         test_data(),
@@ -455,14 +455,14 @@ def test_bitwise_xor_tensor_vgf_INT(test_data: input_t2):
         atol=0,
         rtol=0,
         qtol=0,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", XorScalar().test_data)
 @common.SkipIfNoModelConverter
-def test_bitwise_xor_scalar_vgf_INT(test_data: input_t2):
+def test_bitwise_xor_scalar_vgf_quant(test_data: input_t2):
     pipeline = VgfPipeline[input_t2](
         XorScalar(),
         test_data(),
@@ -471,7 +471,7 @@ def test_bitwise_xor_scalar_vgf_INT(test_data: input_t2):
         atol=0,
         rtol=0,
         qtol=0,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 
@@ -593,7 +593,7 @@ def test_bitwise_or_scalar_u85_INT(test_data: input_t2):
 
 @common.parametrize("test_data", Or().test_data)
 @common.SkipIfNoModelConverter
-def test_bitwise_or_tensor_vgf_FP(test_data: input_t2):
+def test_bitwise_or_tensor_vgf_no_quant(test_data: input_t2):
     pipeline = OpNotSupportedPipeline[input_t2](
         Or(),
         test_data(),
@@ -604,7 +604,7 @@ def test_bitwise_or_tensor_vgf_FP(test_data: input_t2):
 
 @common.parametrize("test_data", OrScalar().test_data)
 @common.SkipIfNoModelConverter
-def test_bitwise_or_scalar_vgf_FP(test_data: input_t2):
+def test_bitwise_or_scalar_vgf_no_quant(test_data: input_t2):
     pipeline = OpNotSupportedPipeline[input_t2](
         OrScalar(),
         test_data(),
@@ -615,7 +615,7 @@ def test_bitwise_or_scalar_vgf_FP(test_data: input_t2):
 
 @common.parametrize("test_data", Or().test_data)
 @common.SkipIfNoModelConverter
-def test_bitwise_or_tensor_vgf_INT(test_data: input_t2):
+def test_bitwise_or_tensor_vgf_quant(test_data: input_t2):
     pipeline = VgfPipeline[input_t2](
         Or(),
         test_data(),
@@ -624,14 +624,14 @@ def test_bitwise_or_tensor_vgf_INT(test_data: input_t2):
         atol=0,
         rtol=0,
         qtol=0,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", OrScalar().test_data)
 @common.SkipIfNoModelConverter
-def test_bitwise_or_scalar_vgf_INT(test_data: input_t2):
+def test_bitwise_or_scalar_vgf_quant(test_data: input_t2):
     pipeline = VgfPipeline[input_t2](
         OrScalar(),
         test_data(),
@@ -640,7 +640,7 @@ def test_bitwise_or_scalar_vgf_INT(test_data: input_t2):
         atol=0,
         rtol=0,
         qtol=0,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 

--- a/backends/arm/test/ops/test_bitwise_not.py
+++ b/backends/arm/test/ops/test_bitwise_not.py
@@ -90,7 +90,7 @@ def test_bitwise_not_u85_INT(test_data: Tuple):
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_bitwise_not_vgf_FP(test_data: Tuple):
+def test_bitwise_not_vgf_no_quant(test_data: Tuple):
     # We don't delegate bitwise_not since it is not supported on the FP profile.
     pipeline = OpNotSupportedPipeline[input_t1](
         BitwiseNot(),
@@ -103,12 +103,12 @@ def test_bitwise_not_vgf_FP(test_data: Tuple):
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_bitwise_not_vgf_INT(test_data: Tuple):
+def test_bitwise_not_vgf_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         BitwiseNot(),
         (test_data,),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_bmm.py
+++ b/backends/arm/test/ops/test_bmm.py
@@ -139,9 +139,13 @@ def test_bmm_u85_INT_single_input(test_data: input_t1):
 
 @common.parametrize("test_data", BMM.test_data_generators)
 @common.SkipIfNoModelConverter
-def test_bmm_vgf_FP(test_data: input_t1):
+def test_bmm_vgf_no_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
-        BMM(), test_data(), aten_op_bmm, exir_op_bmm, tosa_version="TOSA-1.0+FP"
+        BMM(),
+        test_data(),
+        aten_op_bmm,
+        exir_op_bmm,
+        quantize=False,
     )
     pipeline.run()
 
@@ -152,38 +156,38 @@ def test_bmm_vgf_FP(test_data: input_t1):
     flakies={"rand_big_1": 3},
 )
 @common.SkipIfNoModelConverter
-def test_bmm_vgf_FP_single_input(test_data: input_t1):
+def test_bmm_single_input_vgf_no_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         BMMSingleInput(),
         test_data(),
         aten_op_bmm,
         exir_op_bmm,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", BMM.test_data_generators)
 @common.SkipIfNoModelConverter
-def test_bmm_vgf_INT(test_data: input_t1):
+def test_bmm_vgf_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         BMM(),
         test_data(),
         aten_op_bmm,
         exir_op_bmm,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", BMMSingleInput.test_data_generators)
 @common.SkipIfNoModelConverter
-def test_bmm_vgf_INT_single_input(test_data: input_t1):
+def test_bmm_single_input_vgf_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         BMMSingleInput(),
         test_data(),
         aten_op_bmm,
         exir_op_bmm,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_cat.py
+++ b/backends/arm/test/ops/test_cat.py
@@ -134,22 +134,26 @@ def test_cat_u85_INT(test_data: Tuple):
 
 @common.parametrize("test_data", Cat.test_parameters)
 @common.SkipIfNoModelConverter
-def test_cat_vgf_FP(test_data: Tuple):
+def test_cat_vgf_no_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
-        Cat(), test_data(), aten_op, exir_op, tosa_version="TOSA-1.0+FP"
+        Cat(),
+        test_data(),
+        aten_op,
+        exir_op,
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", Cat.test_parameters)
 @common.SkipIfNoModelConverter
-def test_cat_vgf_INT(test_data: Tuple):
+def test_cat_vgf_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         Cat(),
         test_data(),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 

--- a/backends/arm/test/ops/test_ceil.py
+++ b/backends/arm/test/ops/test_ceil.py
@@ -97,21 +97,21 @@ def test_ceil_u85_INT(test_data: input_t1):
 
 @common.parametrize("test_data", test_data)
 @common.SkipIfNoModelConverter
-def test_ceil_vgf_FP(test_data: input_t1):
+def test_ceil_vgf_no_quant(test_data: input_t1):
     module, data = test_data()
     pipeline = VgfPipeline[input_t1](
         module,
         (data,),
         module.aten_op,
         module.exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data)
 @common.SkipIfNoModelConverter
-def test_ceil_vgf_INT(test_data: input_t1):
+def test_ceil_vgf_quant(test_data: input_t1):
     module, data = test_data()
     pipeline = VgfPipeline[input_t1](
         module,
@@ -120,6 +120,6 @@ def test_ceil_vgf_INT(test_data: input_t1):
         module.exir_op,
         atol=0.06,
         rtol=0.01,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_clamp.py
+++ b/backends/arm/test/ops/test_clamp.py
@@ -207,7 +207,7 @@ def test_clamp_16a8w_u85_INT16(test_data):
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_clamp_vgf_FP(test_data):
+def test_clamp_vgf_no_quant(test_data):
     input_tensor, min_val, max_val = test_data()
     model = Clamp(min_val, max_val)
     pipeline = VgfPipeline[input_t](
@@ -215,14 +215,14 @@ def test_clamp_vgf_FP(test_data):
         (input_tensor,),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_clamp_vgf_INT(test_data):
+def test_clamp_vgf_quant(test_data):
     input_tensor, min_val, max_val = test_data()
     model = Clamp(min_val, max_val)
     pipeline = VgfPipeline[input_t](
@@ -230,6 +230,6 @@ def test_clamp_vgf_INT(test_data):
         (input_tensor,),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_clone.py
+++ b/backends/arm/test/ops/test_clone.py
@@ -124,23 +124,27 @@ def test_clone_u85_INT(input_data):
 
 @common.parametrize("test_data", delegated_clones)
 @common.SkipIfNoModelConverter
-def test_clone_vgf_FP(test_data):
-    module, input_tensor = test_data()
-    pipeline = VgfPipeline[input_t](
-        module(), input_tensor, aten_op, exir_op, tosa_version="TOSA-1.0+FP"
-    )
-    pipeline.run()
-
-
-@common.parametrize("test_data", delegated_clones)
-@common.SkipIfNoModelConverter
-def test_clone_vgf_INT(test_data):
+def test_clone_vgf_no_quant(test_data):
     module, input_tensor = test_data()
     pipeline = VgfPipeline[input_t](
         module(),
         input_tensor,
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=False,
+    )
+    pipeline.run()
+
+
+@common.parametrize("test_data", delegated_clones)
+@common.SkipIfNoModelConverter
+def test_clone_vgf_quant(test_data):
+    module, input_tensor = test_data()
+    pipeline = VgfPipeline[input_t](
+        module(),
+        input_tensor,
+        aten_op,
+        exir_op,
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_constant_pad_nd.py
+++ b/backends/arm/test/ops/test_constant_pad_nd.py
@@ -93,27 +93,27 @@ def test_constant_pad_nd_tosa_INT_a16w8(test_data: Tuple):
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_constant_pad_nd_vgf_FP(test_data: Tuple):
+def test_constant_pad_nd_vgf_no_quant(test_data: Tuple):
     inp, padding, value = test_data()
     pipeline = VgfPipeline[input_t1](
         ConstantPadND(padding, value),
         (inp,),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_constant_pad_nd_vgf_INT(test_data: Tuple):
+def test_constant_pad_nd_vgf_quant(test_data: Tuple):
     inp, padding, value = test_data()
     pipeline = VgfPipeline[input_t1](
         ConstantPadND(padding, value),
         (inp,),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_conv1d.py
+++ b/backends/arm/test/ops/test_conv1d.py
@@ -330,27 +330,27 @@ def test_convolution_1d_u85_INT(test_data):
 
 @common.parametrize("test_data", test_data_FP)
 @common.SkipIfNoModelConverter
-def test_convolution_1d_vgf_FP(test_data):
+def test_convolution_1d_vgf_no_quant(test_data):
     pipeline = VgfPipeline[input_t](
         test_data(),
         test_data().get_inputs(),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data_INT)
 @common.SkipIfNoModelConverter
-def test_convolution_1d_vgf_INT(test_data):
+def test_convolution_1d_vgf_quant(test_data):
     model, per_channel_quantization = test_data()
     pipeline = VgfPipeline[input_t](
         model,
         model.get_inputs(),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+INT",
         per_channel_quantization=per_channel_quantization,
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_conv2d.py
+++ b/backends/arm/test/ops/test_conv2d.py
@@ -447,29 +447,29 @@ def test_convolution_u85_INT(test_data):
 
 @common.parametrize("test_data", test_data_FP)
 @common.SkipIfNoModelConverter
-def test_convolution_2d_vgf_FP(test_data):
+def test_convolution_2d_vgf_no_quant(test_data):
     model = test_data()
     pipeline = VgfPipeline[input_t](
         model,
         model.get_inputs(),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data_INT)
 @common.SkipIfNoModelConverter
-def test_convolution_2d_vgf_INT(test_data):
+def test_convolution_2d_vgf_quant(test_data):
     model, per_channel_quantization = test_data()
     pipeline = VgfPipeline[input_t](
         model,
         model.get_inputs(),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+INT",
         per_channel_quantization=per_channel_quantization,
+        quantize=True,
     )
     pipeline.run()
 

--- a/backends/arm/test/ops/test_conv3d.py
+++ b/backends/arm/test/ops/test_conv3d.py
@@ -585,7 +585,7 @@ def test_convolution_3d_vgf_quant(test_data):
 
 
 @common.SkipIfNoModelConverter
-def test_convolution_3d_vgf_FP_multi_op():
+def test_convolution_3d_vgf_no_quant_multi_op():
     """Ensure mixed Conv3d/Conv2d graphs keep correct spatial annotations."""
     model = Conv3dMultiOp()
     pipeline = VgfPipeline[input_t](
@@ -593,13 +593,13 @@ def test_convolution_3d_vgf_FP_multi_op():
         model.get_inputs(),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.SkipIfNoModelConverter
-def test_convolution_3d_vgf_INT_multi_op():
+def test_convolution_3d_vgf_quant_multi_op():
     """Ensure mixed Conv3d/Conv2d graphs keep correct spatial annotations."""
     model = Conv3dMultiOp()
     pipeline = VgfPipeline[input_t](
@@ -607,7 +607,7 @@ def test_convolution_3d_vgf_INT_multi_op():
         model.get_inputs(),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 

--- a/backends/arm/test/ops/test_conv3d.py
+++ b/backends/arm/test/ops/test_conv3d.py
@@ -559,27 +559,27 @@ def test_convolution_3d_u85_INT(test_data):
 
 @common.parametrize("test_data", test_data_FP)
 @common.SkipIfNoModelConverter
-def test_convolution_3d_vgf_FP(test_data):
+def test_convolution_3d_vgf_no_quant(test_data):
     pipeline = VgfPipeline[input_t](
         test_data(),
         test_data().get_inputs(),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data_INT)
 @common.SkipIfNoModelConverter
-def test_convolution_3d_vgf_INT(test_data):
+def test_convolution_3d_vgf_quant(test_data):
     model, per_channel_quantization = test_data()
     pipeline = VgfPipeline[input_t](
         model,
         model.get_inputs(),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 

--- a/backends/arm/test/ops/test_conv_combos.py
+++ b/backends/arm/test/ops/test_conv_combos.py
@@ -275,27 +275,27 @@ def test_convolution_2d_u85_INT_meandim():
 
 
 @common.SkipIfNoModelConverter
-def test_convolution_2d_vgf_FP_meandim():
+def test_convolution_2d_meandim_vgf_no_quant():
     model = ComboConv2dMeandim()
     pipeline = VgfPipeline[input_t1](
         model,
         model.get_inputs(),
         aten_op=[],
         exir_op=ComboConv2dMeandim.edge_op_list,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.SkipIfNoModelConverter
-def test_convolution_2d_vgf_INT_meandim():
+def test_convolution_2d_meandim_vgf_quant():
     model = ComboConv2dMeandim()
     pipeline = VgfPipeline[input_t1](
         model,
         model.get_inputs(),
         aten_op=[],
         exir_op=ComboConv2dMeandim.edge_op_list,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 
@@ -366,7 +366,7 @@ def test_convolution_2d_u85_INT_batchnorm_relu6(test_data):
 
 @common.parametrize("test_data", ComboConvBatchnormRelu6.test_data_FP)
 @common.SkipIfNoModelConverter
-def test_convolution_2d_vgf_FP_batchnorm_relu6(test_data):
+def test_convolution_2d_batchnorm_relu6_vgf_no_quant(test_data):
     affine = test_data
     model = ComboConvBatchnormRelu6(affine)
     pipeline = VgfPipeline[input_t1](
@@ -374,14 +374,14 @@ def test_convolution_2d_vgf_FP_batchnorm_relu6(test_data):
         model.get_inputs(),
         aten_op=[],
         exir_op=ComboConvBatchnormRelu6.edge_op_list,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", ComboConvBatchnormRelu6.test_data_INT)
 @common.SkipIfNoModelConverter
-def test_convolution_2d_vgf_INT_batchnorm_relu6(test_data):
+def test_convolution_2d_batchnorm_relu6_vgf_quant(test_data):
     affine, per_channel_quantization = test_data
     model = ComboConvBatchnormRelu6(affine)
     pipeline = VgfPipeline[input_t1](
@@ -389,8 +389,8 @@ def test_convolution_2d_vgf_INT_batchnorm_relu6(test_data):
         model.get_inputs(),
         aten_op=[],
         exir_op=ComboConvBatchnormRelu6.edge_op_list,
-        tosa_version="TOSA-1.0+INT",
         per_channel_quantization=per_channel_quantization,
+        quantize=True,
     )
     pipeline.run()
 
@@ -459,21 +459,21 @@ def test_convolution_2d_u85_INT_relu6(test_data):
 
 @common.parametrize("test_data", ComboConvRelu6.test_data_FP)
 @common.SkipIfNoModelConverter
-def test_convolution_2d_vgf_FP_relu6(test_data):
+def test_convolution_2d_relu6_vgf_no_quant(test_data):
     model = ComboConvRelu6()
     pipeline = VgfPipeline[input_t1](
         model,
         test_data(),
         aten_op=[],
         exir_op=ComboConvRelu6.edge_op_list,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", ComboConvRelu6.test_data_INT)
 @common.SkipIfNoModelConverter
-def test_convolution_2d_vgf_INT_relu6(test_data):
+def test_convolution_2d_relu6_vgf_quant(test_data):
     input, per_channel_quantization = test_data()
     model = ComboConvRelu6()
     pipeline = VgfPipeline[input_t1](
@@ -481,8 +481,8 @@ def test_convolution_2d_vgf_INT_relu6(test_data):
         input,
         aten_op=[],
         exir_op=ComboConvRelu6.edge_op_list,
-        tosa_version="TOSA-1.0+INT",
         per_channel_quantization=per_channel_quantization,
+        quantize=True,
     )
     pipeline.run()
 
@@ -548,21 +548,21 @@ def test_convolution_2d_u85_INT_block_bottleneck(test_data):
 
 
 @common.SkipIfNoModelConverter
-def test_convolution_2d_vgf_FP_block_bottleneck():
+def test_convolution_2d_block_bottleneck_vgf_no_quant():
     model = ComboBlockBottleneckResidual()
     pipeline = VgfPipeline[input_t1](
         model,
         model.get_inputs(),
         aten_op=[],
         exir_op=ComboBlockBottleneckResidual.edge_op_list,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", ComboBlockBottleneckResidual.test_data_INT)
 @common.SkipIfNoModelConverter
-def test_convolution_2d_vgf_INT_block_bottleneck(test_data):
+def test_convolution_2d_block_bottleneck_vgf_quant(test_data):
     per_channel_quantization = test_data
     model = ComboBlockBottleneckResidual()
     pipeline = VgfPipeline[input_t1](
@@ -570,8 +570,8 @@ def test_convolution_2d_vgf_INT_block_bottleneck(test_data):
         model.get_inputs(),
         aten_op=[],
         exir_op=ComboBlockBottleneckResidual.edge_op_list,
-        tosa_version="TOSA-1.0+INT",
         per_channel_quantization=per_channel_quantization,
+        quantize=True,
     )
     pipeline.run()
 
@@ -640,21 +640,21 @@ def test_convolution_2d_u85_INT_avgpool2d(test_data):
 
 @common.parametrize("test_data", ComboConvAvgPool2d.test_data_FP)
 @common.SkipIfNoModelConverter
-def test_convolution_2d_vgf_FP_avgpool2d(test_data):
+def test_convolution_2d_avgpool2d_vgf_no_quant(test_data):
     model = ComboConvAvgPool2d()
     pipeline = VgfPipeline[input_t1](
         model,
         test_data(),
         aten_op=[],
         exir_op=ComboConvAvgPool2d.edge_op_list,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", ComboConvAvgPool2d.test_data_INT)
 @common.SkipIfNoModelConverter
-def test_convolution_2d_vgf_INT_avgpool2d(test_data):
+def test_convolution_2d_avgpool2d_vgf_quant(test_data):
     input, per_channel_quantization = test_data()
     model = ComboConvAvgPool2d()
     pipeline = VgfPipeline[input_t1](
@@ -662,7 +662,7 @@ def test_convolution_2d_vgf_INT_avgpool2d(test_data):
         input,
         aten_op=[],
         exir_op=ComboConvAvgPool2d.edge_op_list,
-        tosa_version="TOSA-1.0+INT",
         per_channel_quantization=per_channel_quantization,
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_conv_constant_pad_nd.py
+++ b/backends/arm/test/ops/test_conv_constant_pad_nd.py
@@ -119,27 +119,27 @@ def test_constant_pad_nd_tosa_INT(test_data: Tuple):
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_constant_pad_nd_vgf_FP(test_data: Tuple):
+def test_constant_pad_nd_vgf_no_quant(test_data: Tuple):
     test_data, padding, value = test_data
     pipeline = VgfPipeline[input_t1](
         ConstantPadND(padding, value),
         (test_data,),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_constant_pad_nd_vgf_INT(test_data: Tuple):
+def test_constant_pad_nd_vgf_quant(test_data: Tuple):
     test_data, padding, value = test_data
     pipeline = VgfPipeline[input_t1](
         ConstantPadND(padding, value),
         (test_data,),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_copy.py
+++ b/backends/arm/test/ops/test_copy.py
@@ -145,27 +145,27 @@ def test_copy_u85_INT(input_data):
 
 @common.parametrize("test_data", test_suite)
 @common.SkipIfNoModelConverter
-def test_copy_vgf_FP(test_data):
+def test_copy_vgf_no_quant(test_data):
     module, input_tensor = test_data()
     pipeline = VgfPipeline[input_t](
         module(),
         input_tensor,
         aten_op=aten_op,
         exir_op=exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_suite)
 @common.SkipIfNoModelConverter
-def test_copy_vgf_INT(test_data):
+def test_copy_vgf_quant(test_data):
     module, input_tensor = test_data()
     pipeline = VgfPipeline[input_t](
         module(),
         input_tensor,
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_cos.py
+++ b/backends/arm/test/ops/test_cos.py
@@ -91,25 +91,25 @@ def test_cos_u85_INT(test_data: Tuple):
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_cos_vgf_FP(test_data: Tuple):
+def test_cos_vgf_no_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         Cos(),
         (test_data,),
         aten_op,
         exir_op=[],
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_cos_vgf_INT(test_data: Tuple):
+def test_cos_vgf_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         Cos(),
         (test_data,),
         aten_op,
         exir_op=[],
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_cosh.py
+++ b/backends/arm/test/ops/test_cosh.py
@@ -87,25 +87,25 @@ def test_cosh_u85_INT(test_data: Tuple):
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_cosh_vgf_FP(test_data: Tuple):
+def test_cosh_vgf_no_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         Cosh(),
         (test_data,),
         [],
         [],
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_cosh_vgf_INT(test_data: Tuple):
+def test_cosh_vgf_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         Cosh(),
         (test_data,),
         [],
         [],
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_cumsum.py
+++ b/backends/arm/test/ops/test_cumsum.py
@@ -68,28 +68,28 @@ def test_cumsum_tosa_INT(test_data: input_t1):
 
 @common.parametrize("test_data", CumsumModule.test_parameters)
 @common.SkipIfNoModelConverter
-def test_cumsum_vgf_FP(test_data: input_t1):
+def test_cumsum_vgf_no_quant(test_data: input_t1):
     module = CumsumModule()
     args = test_data()
     pipeline = VgfPipeline[input_t1](
         module,
         args,
         aten_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", CumsumModule.test_parameters)
 @common.SkipIfNoModelConverter
-def test_cumsum_vgf_INT(test_data: input_t1):
+def test_cumsum_vgf_quant(test_data: input_t1):
     module = CumsumModule()
     args = test_data()
     pipeline = VgfPipeline[input_t1](
         module,
         args,
         aten_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 

--- a/backends/arm/test/ops/test_depthwise_conv.py
+++ b/backends/arm/test/ops/test_depthwise_conv.py
@@ -225,28 +225,28 @@ def test_convolution_2d_tosa_INT_depthwise(test_data):
 
 @common.parametrize("test_data", test_data_conv1d_FP | test_data_conv2d_FP)
 @common.SkipIfNoModelConverter
-def test_convolution_2d_vgf_FP_depthwise(test_data: torch.nn.Module):
+def test_convolution_2d_depthwise_vgf_no_quant(test_data: torch.nn.Module):
     model = test_data()
     pipeline = VgfPipeline[input_t](
         model,
         model.get_inputs(),
         aten_op=[],
         exir_op=exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data_conv1d_INT | test_data_conv2d_INT)
 @common.SkipIfNoModelConverter
-def test_convolution_2d_vgf_INT_depthwise(test_data):
+def test_convolution_2d_depthwise_vgf_quant(test_data):
     model, per_channel_quantization = test_data()
     pipeline = VgfPipeline[input_t](
         model,
         model.get_inputs(),
         aten_op=[],
         exir_op=exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 

--- a/backends/arm/test/ops/test_div.py
+++ b/backends/arm/test/ops/test_div.py
@@ -127,21 +127,25 @@ def test_div_tensor_u85_INT(test_data: Tuple):
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_div_tensor_vgf_FP(test_data: Tuple):
+def test_div_tensor_vgf_no_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
-        Div(), test_data(), aten_op, exir_op, tosa_version="TOSA-1.0+FP"
+        Div(),
+        test_data(),
+        aten_op,
+        exir_op,
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_div_tensor_vgf_INT(test_data: Tuple):
+def test_div_tensor_vgf_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         Div(),
         test_data(),
         aten_op=[],
         exir_op=[],
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_div_tensor_mode.py
+++ b/backends/arm/test/ops/test_div_tensor_mode.py
@@ -118,7 +118,7 @@ def test_div_tensor_mode_u85_INT(data):
 
 @common.SkipIfNoModelConverter
 @common.parametrize("data", test_data)
-def test_div_tensor_mode_vgf_INT(data):
+def test_div_tensor_mode_vgf_quant(data):
     mode, inputs = data()
     model = DivTensorModeFloat(mode)
 
@@ -127,8 +127,8 @@ def test_div_tensor_mode_vgf_INT(data):
         inputs,
         aten_op=model.aten_ops_int,
         exir_op=[],
-        tosa_version="TOSA-1.0+INT",
         use_to_edge_transform_and_lower=True,
+        quantize=True,
     )
     pipeline.pop_stage("check_count.exir")
     pipeline.run()
@@ -136,7 +136,7 @@ def test_div_tensor_mode_vgf_INT(data):
 
 @common.SkipIfNoModelConverter
 @common.parametrize("data", test_data)
-def test_div_tensor_mode_vgf_FP(data):
+def test_div_tensor_mode_vgf_no_quant(data):
     mode, inputs = data()
     model = DivTensorModeFloat(mode)
 
@@ -145,7 +145,7 @@ def test_div_tensor_mode_vgf_FP(data):
         inputs,
         aten_op=model.aten_ops,
         exir_op=[],
-        tosa_version="TOSA-1.0+FP",
         use_to_edge_transform_and_lower=True,
+        quantize=False,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_elu.py
+++ b/backends/arm/test/ops/test_elu.py
@@ -107,27 +107,27 @@ def test_elu_u85_INT(test_module: input_t1):
 
 @common.SkipIfNoModelConverter
 @common.parametrize("test_module", test_data_suite)
-def test_elu_vgf_FP(test_module: input_t1):
+def test_elu_vgf_no_quant(test_module: input_t1):
     alpha, test_data = test_module()
     pipeline = VgfPipeline[input_t1](
         Elu(alpha),
         (test_data,),
         aten_op=Elu.aten_op,
         exir_op=Elu.exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.SkipIfNoModelConverter
 @common.parametrize("test_module", test_data_suite)
-def test_elu_vgf_INT(test_module: input_t1):
+def test_elu_vgf_quant(test_module: input_t1):
     alpha, test_data = test_module()
     pipeline = VgfPipeline[input_t1](
         Elu(alpha),
         (test_data,),
         aten_op=Elu.aten_op,
         exir_op=Elu.exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_embedding.py
+++ b/backends/arm/test/ops/test_embedding.py
@@ -114,31 +114,31 @@ def test_expand_embedding_tosa_INT():
 @pytest.mark.skip("reason=MLETORCH-1274 Improve data type checks during partitioning")
 @common.parametrize("test_input", test_input)
 @common.SkipIfNoModelConverter
-def test_embedding_vgf_FP(test_input: input_params):
+def test_embedding_vgf_no_quant(test_input: input_params):
     op = Embedding()
     pipeline = VgfPipeline[input_params](
         op,
         test_input,
         op.aten_op,
         op.exir_op,
-        tosa_version="TOSA-1.0+FP",
         use_to_edge_transform_and_lower=True,
         transform_passes=[InsertInt32CastsAfterInt64PlaceholdersPass()],
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_input", test_input)
 @common.SkipIfNoModelConverter
-def test_embedding_vgf_INT(test_input: input_params):
+def test_embedding_vgf_quant(test_input: input_params):
     op = Embedding()
     pipeline = VgfPipeline[input_params](
         op,
         test_input,
         op.aten_op,
         op.exir_op,
-        tosa_version="TOSA-1.0+INT",
         use_to_edge_transform_and_lower=True,
+        quantize=True,
     )
     pipeline.pop_stage("check.aten")
     pipeline.pop_stage("check_count.exir")

--- a/backends/arm/test/ops/test_eq.py
+++ b/backends/arm/test/ops/test_eq.py
@@ -242,20 +242,20 @@ def test_eq_scalar_vgf_FP_tensor(test_module):
         test_module().get_inputs(),
         Equal.aten_op_Tensor,
         Equal.exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_module", test_data_scalar)
 @common.SkipIfNoModelConverter
-def test_eq_scalar_vgf_FP(test_module):
+def test_eq_scalar_vgf_no_quant(test_module):
     pipeline = VgfPipeline[input_t](
         test_module(),
         test_module().get_inputs(),
         Equal.aten_op_Scalar,
         Equal.exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
@@ -268,19 +268,19 @@ def test_eq_scalar_vgf_INT_tensor(test_module):
         test_module().get_inputs(),
         Equal.aten_op_Tensor,
         Equal.exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 
 
 @common.parametrize("test_module", test_data_scalar)
 @common.SkipIfNoModelConverter
-def test_eq_scalar_vgf_INT(test_module):
+def test_eq_scalar_vgf_quant(test_module):
     pipeline = VgfPipeline[input_t](
         test_module(),
         test_module().get_inputs(),
         Equal.aten_op_Tensor,
         Equal.exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_eq.py
+++ b/backends/arm/test/ops/test_eq.py
@@ -122,7 +122,7 @@ def test_eq_scalar_tosa_INT(test_module):
 
 
 @common.parametrize("test_module", test_data_tensor)
-def test_eq_tensor_tosa_INT_16a8w(test_module):
+def test_eq_tensor_16a8w_tosa_INT(test_module):
     pipeline = TosaPipelineINT[input_t](
         test_module(),
         test_module().get_inputs(),
@@ -200,7 +200,7 @@ def test_eq_scalar_u85_INT(test_module):
 
 @common.parametrize("test_module", test_data_tensor)
 @common.XfailIfNoCorstone320
-def test_eq_tensor_16a8w_u85_INT16(test_module):
+def test_eq_tensor_16a8w_u85_INT(test_module):
     """Test eq operation with 16A8W quantization on U85 (16-bit activations, 8-bit weights)"""
     per_channel_quantization = False
 
@@ -218,7 +218,7 @@ def test_eq_tensor_16a8w_u85_INT16(test_module):
 
 @common.parametrize("test_module", test_data_scalar)
 @common.XfailIfNoCorstone320
-def test_eq_scalar_16a8w_u85_INT16(test_module):
+def test_eq_scalar_16a8w_u85_INT(test_module):
     """Test eq operation (scalar) with 16A8W quantization on U85 (16-bit activations, 8-bit weights)"""
     per_channel_quantization = False
 
@@ -236,7 +236,7 @@ def test_eq_scalar_16a8w_u85_INT16(test_module):
 
 @common.parametrize("test_module", test_data_tensor)
 @common.SkipIfNoModelConverter
-def test_eq_scalar_vgf_FP_tensor(test_module):
+def test_eq_scalar_vgf_no_quant_tensor(test_module):
     pipeline = VgfPipeline[input_t](
         test_module(),
         test_module().get_inputs(),
@@ -262,7 +262,7 @@ def test_eq_scalar_vgf_no_quant(test_module):
 
 @common.parametrize("test_module", test_data_tensor)
 @common.SkipIfNoModelConverter
-def test_eq_scalar_vgf_INT_tensor(test_module):
+def test_eq_scalar_vgf_quant_tensor(test_module):
     pipeline = VgfPipeline[input_t](
         test_module(),
         test_module().get_inputs(),

--- a/backends/arm/test/ops/test_erf.py
+++ b/backends/arm/test/ops/test_erf.py
@@ -72,21 +72,25 @@ def test_erf_u85_INT(test_data: input_t1):
 
 @common.parametrize("test_data", Erf.test_data)
 @common.SkipIfNoModelConverter
-def test_erf_vgf_FP(test_data: input_t1):
+def test_erf_vgf_no_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
-        Erf(), test_data(), aten_op, exir_op, tosa_version="TOSA-1.0+FP"
+        Erf(),
+        test_data(),
+        aten_op,
+        exir_op,
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", Erf.test_data)
 @common.SkipIfNoModelConverter
-def test_erf_vgf_INT(test_data: input_t1):
+def test_erf_vgf_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         Erf(),
         test_data(),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_exp.py
+++ b/backends/arm/test/ops/test_exp.py
@@ -86,25 +86,25 @@ def test_exp_u85_INT(test_data: Tuple):
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_exp_vgf_FP(test_data: Tuple):
+def test_exp_vgf_no_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         Exp(),
         (test_data(),),
         aten_op,
         exir_op=[],
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_exp_vgf_INT(test_data: Tuple):
+def test_exp_vgf_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         Exp(),
         (test_data(),),
         aten_op,
         exir_op=[],
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_expand.py
+++ b/backends/arm/test/ops/test_expand.py
@@ -108,26 +108,26 @@ def test_expand_u85_INT(test_data: Tuple):
 
 @common.parametrize("test_data", Expand.test_parameters)
 @common.SkipIfNoModelConverter
-def test_expand_vgf_FP(test_data: Tuple):
+def test_expand_vgf_no_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         Expand(),
         test_data(),
         aten_op,
         exir_op=[],
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", Expand.test_parameters)
 @common.SkipIfNoModelConverter
-def test_expand_vgf_INT(test_data: Tuple):
+def test_expand_vgf_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         Expand(),
         test_data(),
         aten_op,
         exir_op=[],
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 

--- a/backends/arm/test/ops/test_expm1.py
+++ b/backends/arm/test/ops/test_expm1.py
@@ -89,25 +89,25 @@ def test_expm1_u85_INT(test_data: Tuple):
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_expm1_vgf_FP(test_data: Tuple):
+def test_expm1_vgf_no_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         Expm1(),
         (test_data,),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_expm1_vgf_INT(test_data: Tuple):
+def test_expm1_vgf_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         Expm1(),
         (test_data,),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_eye.py
+++ b/backends/arm/test/ops/test_eye.py
@@ -111,13 +111,13 @@ def test_eye_u85_INT(test_data: test_data_t):
     EyeAdd.test_data,
 )
 @common.SkipIfNoModelConverter
-def test_eye_vgf_FP(test_data: test_data_t):
+def test_eye_vgf_no_quant(test_data: test_data_t):
     input_data, init_data = test_data
     pipeline = VgfPipeline[input_t](
         EyeAdd(*init_data),
         input_data(),
         EyeAdd.aten_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
@@ -127,13 +127,13 @@ def test_eye_vgf_FP(test_data: test_data_t):
     EyeAdd.test_data,
 )
 @common.SkipIfNoModelConverter
-def test_eye_vgf_INT(test_data: test_data_t):
+def test_eye_vgf_quant(test_data: test_data_t):
     input_data, init_data = test_data
     pipeline = VgfPipeline[input_t](
         EyeAdd(*init_data),
         input_data(),
         EyeAdd.aten_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     if pipeline.has_stage("check.quant_nodes"):
         pipeline.pop_stage("check.quant_nodes")

--- a/backends/arm/test/ops/test_fill_scalar.py
+++ b/backends/arm/test/ops/test_fill_scalar.py
@@ -84,25 +84,25 @@ def test_fill_scalar_u85_INT(test_data: Tuple):
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_fill_scalar_vgf_FP(test_data: input_t1):
+def test_fill_scalar_vgf_no_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         FillScalar(),
         (*test_data,),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_fill_scalar_vgf_INT(test_data: input_t1):
+def test_fill_scalar_vgf_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         FillScalar(),
         (*test_data,),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_floor.py
+++ b/backends/arm/test/ops/test_floor.py
@@ -97,21 +97,21 @@ def test_floor_u85_INT(test_data: input_t1):
 
 @common.parametrize("test_data", test_data)
 @common.SkipIfNoModelConverter
-def test_floor_vgf_FP(test_data: input_t1):
+def test_floor_vgf_no_quant(test_data: input_t1):
     module, data = test_data()
     pipeline = VgfPipeline[input_t1](
         module,
         (data,),
         module.aten_op,
         module.exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data)
 @common.SkipIfNoModelConverter
-def test_floor_vgf_INT(test_data: input_t1):
+def test_floor_vgf_quant(test_data: input_t1):
     module, data = test_data()
     pipeline = VgfPipeline[input_t1](
         module,
@@ -120,6 +120,6 @@ def test_floor_vgf_INT(test_data: input_t1):
         module.exir_op,
         atol=0.06,
         rtol=0.01,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_floor_div.py
+++ b/backends/arm/test/ops/test_floor_div.py
@@ -129,28 +129,28 @@ def test_floor_divide_u85_INT(test_data: input_t1):
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_floor_divide_vgf_FP(test_data: input_t1):
+def test_floor_divide_vgf_no_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         FloorDivide(),
         test_data(),
         FloorDivide.aten_op,
         FloorDivide.exir_op,
-        tosa_version="TOSA-1.0+FP",
         use_to_edge_transform_and_lower=False,
         rtol=0.06,
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_floor_divide_vgf_INT(test_data: input_t1):
+def test_floor_divide_vgf_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         FloorDivide(),
         test_data(),
         aten_op=FloorDivide.aten_ops_int,
         exir_op=FloorDivide.exir_ops_int,
-        tosa_version="TOSA-1.0+INT",
         use_to_edge_transform_and_lower=False,
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_full.py
+++ b/backends/arm/test/ops/test_full.py
@@ -143,52 +143,52 @@ def test_full_tosa_INT(test_data: Tuple):
 
 
 @common.SkipIfNoModelConverter
-def test_full_vgf_FP_only():
+def test_full_only_vgf_no_quant():
     pipeline = VgfPipeline[input_t1](
         Full(),
         (),
         aten_op=[],
         exir_op=exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.SkipIfNoModelConverter
-def test_full_vgf_FP_const():
+def test_full_const_vgf_no_quant():
     test_data = (torch.rand((2, 2, 3, 3)) * 10,)
     pipeline = VgfPipeline[input_t1](
         AddConstFull(),
         test_data,
         aten_op=[],
         exir_op=exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", AddVariableFull.test_parameters)
 @common.SkipIfNoModelConverter
-def test_full_vgf_FP(test_data: Tuple):
+def test_full_vgf_no_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         AddVariableFull(),
         test_data,
         aten_op=[],
         exir_op=exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", AddVariableFull.test_parameters)
 @common.SkipIfNoModelConverter
-def test_full_vgf_INT(test_data: Tuple):
+def test_full_vgf_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         AddVariableFull(),
         test_data,
         aten_op=[],
         exir_op=exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 

--- a/backends/arm/test/ops/test_ge.py
+++ b/backends/arm/test/ops/test_ge.py
@@ -242,51 +242,51 @@ def test_ge_scalar_16a8w_u85_INT16(test_module):
 
 @common.parametrize("test_module", test_data_tensor)
 @common.SkipIfNoModelConverter
-def test_ge_tensor_vgf_FP(test_module):
+def test_ge_tensor_vgf_no_quant(test_module):
     pipeline = VgfPipeline[input_t](
         test_module(),
         test_module().get_inputs(),
         GreaterEqual.aten_op_tensor,
         GreaterEqual.exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_module", test_data_tensor)
 @common.SkipIfNoModelConverter
-def test_ge_tensor_vgf_INT(test_module):
+def test_ge_tensor_vgf_quant(test_module):
     pipeline = VgfPipeline[input_t](
         test_module(),
         test_module().get_inputs(),
         GreaterEqual.aten_op_tensor,
         GreaterEqual.exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 
 
 @common.parametrize("test_module", test_data_scalar)
 @common.SkipIfNoModelConverter
-def test_ge_scalar_vgf_FP(test_module):
+def test_ge_scalar_vgf_no_quant(test_module):
     pipeline = VgfPipeline[input_t](
         test_module(),
         test_module().get_inputs(),
         GreaterEqual.aten_op_scalar,
         GreaterEqual.exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_module", test_data_scalar)
 @common.SkipIfNoModelConverter
-def test_ge_scalar_vgf_INT(test_module):
+def test_ge_scalar_vgf_quant(test_module):
     pipeline = VgfPipeline[input_t](
         test_module(),
         test_module().get_inputs(),
         GreaterEqual.aten_op_tensor,
         GreaterEqual.exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_gelu.py
+++ b/backends/arm/test/ops/test_gelu.py
@@ -130,27 +130,27 @@ def test_gelu_u85_INT(test_data: input_t1):
 
 @common.parametrize("test_data", Gelu.test_data)
 @common.SkipIfNoModelConverter
-def test_gelu_vgf_FP(test_data: input_t1):
+def test_gelu_vgf_no_quant(test_data: input_t1):
     approximate, data = test_data()
     pipeline = VgfPipeline[input_t1](
         Gelu(approximate),
         (data,),
         Gelu.aten_op,
         Gelu.exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", Gelu.test_data)
 @common.SkipIfNoModelConverter
-def test_gelu_vgf_INT(test_data: input_t1):
+def test_gelu_vgf_quant(test_data: input_t1):
     approximate, data = test_data()
     pipeline = VgfPipeline[input_t1](
         Gelu(approximate),
         (data,),
         Gelu.aten_op,
         Gelu.exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_glu.py
+++ b/backends/arm/test/ops/test_glu.py
@@ -103,13 +103,13 @@ def test_glu_u85_INT(test_data: Tuple):
     test_data_suite,
 )
 @common.SkipIfNoModelConverter
-def test_glu_vgf_FP(test_data: input_t1):
+def test_glu_vgf_no_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         Glu(),
         (*test_data,),
         [],
         [],
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
@@ -119,12 +119,12 @@ def test_glu_vgf_FP(test_data: input_t1):
     test_data_suite,
 )
 @common.SkipIfNoModelConverter
-def test_glu_vgf_INT(test_data: input_t1):
+def test_glu_vgf_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         Glu(),
         (*test_data,),
         [],
         [],
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_group_norm.py
+++ b/backends/arm/test/ops/test_group_norm.py
@@ -159,7 +159,7 @@ def test_native_group_norm_u85_INT(test_data):
     strict=False,
 )
 @common.SkipIfNoModelConverter
-def test_native_group_norm_vgf_FP(test_data):
+def test_native_group_norm_vgf_no_quant(test_data):
     aten_op = "torch.ops.aten.group_norm.default"
     exir_op = "executorch_exir_dialects_edge__ops_aten_native_group_norm_default"
     model, inp = test_data
@@ -168,7 +168,7 @@ def test_native_group_norm_vgf_FP(test_data):
         model,
         aten_op=aten_op,
         exir_op=exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
@@ -185,7 +185,7 @@ def test_native_group_norm_vgf_FP(test_data):
     strict=False,
 )
 @common.SkipIfNoModelConverter
-def test_native_group_norm_vgf_INT(test_data):
+def test_native_group_norm_vgf_quant(test_data):
     aten_op = "torch.ops.aten.sub.Tensor"
     exir_op = "executorch_exir_dialects_edge__ops_aten_native_group_norm_default"
     model, inp = test_data
@@ -194,7 +194,7 @@ def test_native_group_norm_vgf_INT(test_data):
         model,
         aten_op=aten_op,
         exir_op=exir_op,
-        tosa_version="TOSA-1.0+INT",
-        atol=0.1,  # TODO: "MLETORCH-925: Fix numerical issue for aten.native_group_norm"
+        atol=0.1,
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_gt.py
+++ b/backends/arm/test/ops/test_gt.py
@@ -243,51 +243,51 @@ def test_gt_scalar_16a8w_u85_INT16(test_module):
 
 @common.parametrize("test_module", test_data_tensor)
 @common.SkipIfNoModelConverter
-def test_gt_tensor_vgf_FP(test_module):
+def test_gt_tensor_vgf_no_quant(test_module):
     pipeline = VgfPipeline[input_t](
         test_module(),
         test_module().get_inputs(),
         Greater.aten_op_tensor,
         Greater.exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_module", test_data_scalar)
 @common.SkipIfNoModelConverter
-def test_gt_scalar_vgf_FP(test_module):
+def test_gt_scalar_vgf_no_quant(test_module):
     pipeline = VgfPipeline[input_t](
         test_module(),
         test_module().get_inputs(),
         Greater.aten_op_scalar,
         Greater.exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_module", test_data_tensor)
 @common.SkipIfNoModelConverter
-def test_gt_tensor_vgf_INT(test_module):
+def test_gt_tensor_vgf_quant(test_module):
     pipeline = VgfPipeline[input_t](
         test_module(),
         test_module().get_inputs(),
         Greater.aten_op_tensor,
         Greater.exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 
 
 @common.parametrize("test_module", test_data_scalar)
 @common.SkipIfNoModelConverter
-def test_gt_scalar_vgf_INT(test_module):
+def test_gt_scalar_vgf_quant(test_module):
     pipeline = VgfPipeline[input_t](
         test_module(),
         test_module().get_inputs(),
         Greater.aten_op_tensor,
         Greater.exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()


### PR DESCRIPTION
Updates the the first half of vgf op tests to use the quantize flag to VgfTestPipeline instead of passing a tosa_version.

cc @freddan80 @per @zingo @digantdesai