### PR TITLE
NXP backend: Add support for optimizing Conv+BN during QAT

### DIFF
--- a/backends/nxp/aten_passes/neutron_aten_pass_manager.py
+++ b/backends/nxp/aten_passes/neutron_aten_pass_manager.py
@@ -42,23 +42,32 @@ from torch.fx.passes.infra.pass_base import PassResult
 PassType = type[Callable[[torch.fx.GraphModule], PassResult]]
 
 
+def _get_default_passes(neutron_target_spec, qat_mode: bool = False) -> list[PassType]:
+    passes = [
+        DecomposeSplitToSlicesPass(),
+        SplitGroupConvolution(),
+        SplitGRUBasedOnNumLayers(),
+        RemoveNodesWithKnownOutputs(),
+        FuseLinearAndAddPass(),
+        MoveActivationBeforeConcat(neutron_target_spec),
+        ConvertUnsqueezeToViewPass(),
+    ]
+
+    if not qat_mode:
+        # In QAT mode, the fusing should happen after the training
+        # to preserve batch norm stats updating mechanism.
+        passes.append(FuseBatchNormWithConvPass())
+        passes.append(FuseBatchNormWithLinearPass())
+
+    return passes
+
+
 class NeutronAtenPassManager(PassManager):
 
     def __init__(
         self, neutron_target_spec: NeutronTargetSpec, passes: list[PassType] = None
     ):
-        passes: list[PassType] = passes or [
-            DecomposeSplitToSlicesPass(),
-            FuseBatchNormWithConvPass(),
-            FuseBatchNormWithLinearPass(),
-            SplitGroupConvolution(),
-            SplitGRUBasedOnNumLayers(),
-            RemoveNodesWithKnownOutputs(),
-            FuseLinearAndAddPass(),
-            MoveActivationBeforeConcat(neutron_target_spec),
-            ConvertUnsqueezeToViewPass(),
-        ]
-
+        passes: list[PassType] = passes or _get_default_passes(neutron_target_spec)
         super().__init__(passes)
 
     def __call__(self, module: nn.Module) -> PassResult:

--- a/backends/nxp/quantizer/neutron_quantizer.py
+++ b/backends/nxp/quantizer/neutron_quantizer.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# Copyright 2024-2025 NXP
+# Copyright 2024-2026 NXP
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -17,6 +17,7 @@ from executorch.backends.nxp.quantizer.patterns import (
     AddmmPattern,
     AddTensorPattern,
     AvgPoolPattern,
+    BatchNormPattern,
     CatPattern,
     Conv1dPattern,
     Conv2dPattern,
@@ -245,6 +246,7 @@ class NeutronQuantizer(ComposableQuantizer):
                 OpQuantizer(AddTensorPattern(is_qat=is_qat), static_qconfig),
                 OpQuantizer(AddmmPattern(self, is_qat=is_qat), static_fc_qconfig),
                 OpQuantizer(AvgPoolPattern(is_qat=is_qat), static_qconfig),
+                OpQuantizer(BatchNormPattern(is_qat=is_qat), static_qconfig),
                 OpQuantizer(CatPattern(is_qat=is_qat), static_qconfig),
                 OpQuantizer(Conv1dPattern(is_qat=is_qat), static_qconfig),
                 OpQuantizer(Conv2dPattern(self, is_qat=is_qat), static_qconfig),

--- a/backends/nxp/quantizer/neutron_quantizer.py
+++ b/backends/nxp/quantizer/neutron_quantizer.py
@@ -6,6 +6,7 @@
 
 import torch
 from executorch.backends.nxp.aten_passes.neutron_aten_pass_manager import (
+    _get_default_passes,
     NeutronAtenPassManager,
 )
 
@@ -295,7 +296,12 @@ class NeutronQuantizer(ComposableQuantizer):
     ) -> torch.fx.GraphModule:
         model.graph.eliminate_dead_code()  # Remove dead code to simplify the graph for the passes.
 
-        model = NeutronAtenPassManager(self.neutron_target_spec)(model).graph_module
+        pass_manager = NeutronAtenPassManager(
+            self.neutron_target_spec,
+            _get_default_passes(self.neutron_target_spec, self.is_qat),
+        )
+
+        model = pass_manager(model).graph_module
 
         model.graph.eliminate_dead_code()  # Remove dead code again, in case it was created by the passes.
 

--- a/backends/nxp/quantizer/patterns.py
+++ b/backends/nxp/quantizer/patterns.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# Copyright 2025 NXP
+# Copyright 2025-2026 NXP
 # All rights reserved.
 #
 # This source code is licensed under the BSD-style license found in the
@@ -147,6 +147,27 @@ class SingleInputBasicPattern(QuantizationPattern):
 
         return PartitionAnchors(
             inputs=[(node, NodeArgsIdx(0))],
+            weights=[],
+            biases=[],
+            output=[(node,)],
+        )
+
+
+class BatchNormPattern(QuantizationPattern):
+    def __init__(self, is_qat: bool):
+        super().__init__(is_qat=is_qat)
+
+    def partition_types(self) -> list[OpOverload]:
+        # BatchNorm quantization is needed only when in QAT mode
+        return [torch.ops.aten.batch_norm.default] if self.is_qat else []
+
+    def get_anchors(
+        self, gm: fx.GraphModule, fused_partition: list[fx.GraphModule]
+    ) -> PartitionAnchors | None:
+        node = fused_partition[0].nodes[-1]
+
+        return PartitionAnchors(
+            inputs=[],
             weights=[],
             biases=[],
             output=[(node,)],

--- a/backends/nxp/tests/models.py
+++ b/backends/nxp/tests/models.py
@@ -457,6 +457,30 @@ class Conv2dReLUMaxPoolModule(torch.nn.Module):
         return self.pool(x)
 
 
+class ConvBNModule(torch.nn.Module):
+    def __init__(self, conv_module, conv_bias, bn_affine):
+        super().__init__()
+
+        if conv_module == "conv1d":
+            self.conv = torch.nn.Conv1d(3, 64, 3, padding=1, bias=conv_bias)
+            self.bn = torch.nn.BatchNorm1d(64, affine=bn_affine)
+        elif conv_module == "conv2d":
+            self.conv = torch.nn.Conv2d(3, 64, 3, padding=1, bias=conv_bias)
+            self.bn = torch.nn.BatchNorm2d(64, affine=bn_affine)
+        elif conv_module == "conv1d_t":
+            self.conv = torch.nn.ConvTranspose1d(3, 64, 3, padding=1, bias=conv_bias)
+            self.bn = torch.nn.BatchNorm1d(64, affine=bn_affine)
+        elif conv_module == "conv2d_t":
+            self.conv = torch.nn.ConvTranspose2d(3, 64, 3, padding=1, bias=conv_bias)
+            self.bn = torch.nn.BatchNorm2d(64, affine=bn_affine)
+        else:
+            raise ValueError(f"Unknown conv_module: {conv_module}")
+
+    def forward(self, x):
+        x = self.conv(x)
+        return self.bn(x)
+
+
 class MulTensorModule(torch.nn.Module):
     def __init__(self):
         super().__init__()

--- a/examples/nxp/aot_neutron_compile.py
+++ b/examples/nxp/aot_neutron_compile.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 NXP
+# Copyright 2024-2026 NXP
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -150,6 +150,13 @@ if __name__ == "__main__":  # noqa C901
         help="Produce a quantized model",
     )
     parser.add_argument(
+        "--use_qat",
+        action="store_true",
+        required=False,
+        default=False,
+        help="Use QAT mode for quantization (does not include QAT training)",
+    )
+    parser.add_argument(
         "-s",
         "--so_library",
         required=False,
@@ -235,8 +242,10 @@ if __name__ == "__main__":  # noqa C901
                 "No calibration inputs available, using the example inputs instead"
             )
             calibration_inputs = example_inputs
-        quantizer = NeutronQuantizer(neutron_target_spec)
-        module = calibrate_and_quantize(module, calibration_inputs, quantizer)
+        quantizer = NeutronQuantizer(neutron_target_spec, args.use_qat)
+        module = calibrate_and_quantize(
+            module, calibration_inputs, quantizer, is_qat=args.use_qat
+        )
 
     if args.so_library is not None:
         logging.debug(f"Loading libraries: {args.so_library}")

--- a/examples/nxp/experimental/cifar_net/cifar_net.py
+++ b/examples/nxp/experimental/cifar_net/cifar_net.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 NXP
+# Copyright 2024-2026 NXP
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -145,34 +145,11 @@ def get_model(
         cifar_net.load_state_dict(torch.load(state_dict_file, weights_only=True))
 
     if train:
-        # Train the model.
-        criterion = nn.CrossEntropyLoss()
-        optimizer = optim.SGD(cifar_net.parameters(), lr=0.0005, momentum=0.6)
-        train_loader = get_train_loader(batch_size)
+        cifar_net = train_cifarnet_model(
+            cifar_net=cifar_net, batch_size=batch_size, num_epochs=num_epochs
+        )
 
-        for epoch in range(num_epochs):
-            running_loss = 0.0
-            for i, data in enumerate(train_loader, 0):
-                # get the inputs; data is a list of [inputs, labels]
-                inputs, labels = data
-
-                # zero the parameter gradients
-                optimizer.zero_grad()
-
-                # forward + backward + optimize
-                outputs = cifar_net(inputs)
-                loss = criterion(outputs, labels)
-                loss.backward()
-                optimizer.step()
-
-                # print statistics
-                running_loss += loss.item()
-                if i % 2000 == 1999:  # print every 2000 mini-batches
-                    print(f"[{epoch + 1}, {i + 1:5d}] loss: {running_loss / 2000:.3f}")
-                    running_loss = 0.0
-
-        logger.info("Finished training.")
-        if state_dict_file is not None and train:
+        if state_dict_file is not None:
             logger.info(f"Saving the trained weights in `{state_dict_file}`.")
             torch.save(cifar_net.state_dict(), state_dict_file)
 
@@ -187,6 +164,40 @@ def get_cifarnet_calibration_data(num_images: int = 100) -> tuple[torch.Tensor]:
     images = [image for image, _ in itertools.islice(loader, num_images)]
     tensor = torch.vstack(images)
     return (tensor,)
+
+
+def train_cifarnet_model(
+    cifar_net: nn.Module | torch.fx.GraphModule,
+    batch_size: int = 1,
+    num_epochs: int = 1,
+) -> nn.Module:
+    criterion = nn.CrossEntropyLoss()
+    optimizer = optim.SGD(cifar_net.parameters(), lr=0.0001, momentum=0.6)
+    train_loader = get_train_loader(batch_size)
+
+    for epoch in range(num_epochs):
+        running_loss = 0.0
+        for i, data in enumerate(train_loader, 0):
+            # get the inputs; data is a list of [inputs, labels]
+            inputs, labels = data
+
+            # zero the parameter gradients
+            optimizer.zero_grad()
+
+            # forward + backward + optimize
+            outputs = cifar_net(inputs)
+            loss = criterion(outputs, labels)
+            loss.backward()
+            optimizer.step()
+
+            # print statistics
+            running_loss += loss.item()
+            if i % 2000 == 1999:  # print every 2000 mini-batches
+                print(f"[{epoch + 1}, {i + 1:5d}] loss: {running_loss / 2000:.3f}")
+                running_loss = 0.0
+
+    logger.info("Finished training.")
+    return cifar_net
 
 
 def test_cifarnet_model(cifar_net: nn.Module, batch_size: int = 1) -> float:


### PR DESCRIPTION
### Summary
Enables optimization of Conv+BatchNorm during QAT. This involves:
- Enabling TorchAO native batch norm and conv fusing (by disabling our `FuseBatchNormWithConvPass` when in QAT mode)
- Removing output quantization of convolution (for native conv+bn fusing to properly match the pattern to be replaced)
- Adding BatchNorm quantization output pattern implementation

### Test plan
Test cases for Conv+BatchNorm fusion and quantization were added.


cc @robert-kalmar @JakeStevens @digantdesai