### PR TITLE
Arm backend: Update vgf ops tests [Part 2]

### DIFF
--- a/backends/arm/test/models/test_nss.py
+++ b/backends/arm/test/models/test_nss.py
@@ -110,7 +110,7 @@ def test_nss_u85_INT():
     reason="[MLETORCH-1430]: Double types are not supported in buffers in MSL"
 )
 @common.SkipIfNoModelConverter
-def test_nss_vgf_no_quant():
+def test_nss_vgf_FP():
     pipeline = VgfPipeline[input_t](
         nss().eval(),
         example_inputs(),
@@ -119,12 +119,14 @@ def test_nss_vgf_no_quant():
         use_to_edge_transform_and_lower=True,
         run_on_vulkan_runtime=True,
         quantize=False,
+        # Override tosa version to test FP-only path
+        tosa_version="TOSA-1.0+FP",
     )
     pipeline.run()
 
 
 @common.SkipIfNoModelConverter
-def test_nss_vgf_quant():
+def test_nss_vgf_INT():
     pipeline = VgfPipeline[input_t](
         nss().eval(),
         example_inputs(),
@@ -134,6 +136,8 @@ def test_nss_vgf_quant():
         use_to_edge_transform_and_lower=True,
         run_on_vulkan_runtime=True,
         quantize=True,
+        # Override tosa version to test INT-only path
+        tosa_version="TOSA-1.0+INT",
     )
     pipeline.run()
 

--- a/backends/arm/test/ops/test_hardsigmoid.py
+++ b/backends/arm/test/ops/test_hardsigmoid.py
@@ -90,21 +90,25 @@ def test_hardsigmoid_u85_INT(test_data: torch.Tensor):
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_hardsigmoid_vgf_FP(test_data: torch.Tensor):
+def test_hardsigmoid_vgf_no_quant(test_data: torch.Tensor):
     pipeline = VgfPipeline[input_t1](
-        Hardsigmoid(), (test_data(),), aten_op, exir_op=[], tosa_version="TOSA-1.0+FP"
+        Hardsigmoid(),
+        (test_data(),),
+        aten_op,
+        exir_op=[],
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_hardsigmoid_vgf_INT(test_data: torch.Tensor):
+def test_hardsigmoid_vgf_quant(test_data: torch.Tensor):
     pipeline = VgfPipeline[input_t1](
         Hardsigmoid(),
         (test_data(),),
         aten_op,
         exir_op=[],
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_hardswish.py
+++ b/backends/arm/test/ops/test_hardswish.py
@@ -80,21 +80,25 @@ def test_hardswish_u85_INT(test_data):
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_hardswish_vgf_FP(test_data):
+def test_hardswish_vgf_no_quant(test_data):
     pipeline = VgfPipeline[input_t1](
-        Hardswish(), (test_data(),), aten_op, exir_op, tosa_version="TOSA-1.0+FP"
+        Hardswish(),
+        (test_data(),),
+        aten_op,
+        exir_op,
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_hardswish_vgf_INT(test_data):
+def test_hardswish_vgf_quant(test_data):
     pipeline = VgfPipeline[input_t1](
         Hardswish(),
         (test_data(),),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_hardtanh.py
+++ b/backends/arm/test/ops/test_hardtanh.py
@@ -89,21 +89,25 @@ def test_hardtanh_u85_INT(test_data: torch.Tensor):
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_hardtanh_vgf_FP(test_data: torch.Tensor):
+def test_hardtanh_vgf_no_quant(test_data: torch.Tensor):
     pipeline = VgfPipeline[input_t](
-        HardTanh(), (test_data(),), aten_op, exir_op, tosa_version="TOSA-1.0+FP"
+        HardTanh(),
+        (test_data(),),
+        aten_op,
+        exir_op,
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_hardtanh_vgf_INT(test_data: torch.Tensor):
+def test_hardtanh_vgf_quant(test_data: torch.Tensor):
     pipeline = VgfPipeline[input_t](
         HardTanh(),
         (test_data(),),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_index_select.py
+++ b/backends/arm/test/ops/test_index_select.py
@@ -137,41 +137,41 @@ def test_index_select_u55_INT_not_delegated(test_data: input_params):
 
 @pytest.mark.parametrize("test_data", list(test_data.values()))
 @common.SkipIfNoModelConverter
-def test_index_select_vgf_FP(test_data: input_params):
+def test_index_select_vgf_no_quant(test_data: input_params):
     op, inp = test_data
     pipeline = VgfPipeline[input_params](
         op,
         inp,
         op.aten_op,
         op.exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @pytest.mark.parametrize("test_data", list(test_data.values())[:-1])
 @common.SkipIfNoModelConverter
-def test_index_select_vgf_INT(test_data: input_params):
+def test_index_select_vgf_quant(test_data: input_params):
     op, inp = test_data
     pipeline = VgfPipeline[input_params](
         op,
         inp,
         op.aten_op,
         op.exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 
 
 @pytest.mark.parametrize("test_data", list(test_data.values())[-1:])
 @common.SkipIfNoModelConverter
-def test_index_select_vgf_INT_rand(test_data: input_params):
+def test_index_select_vgf_quant_rand(test_data: input_params):
     op, inp = test_data
     pipeline = VgfPipeline[input_params](
         op,
         inp,
         op.aten_op,
         op.exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_layer_norm.py
+++ b/backends/arm/test/ops/test_layer_norm.py
@@ -115,26 +115,26 @@ def test_native_layer_norm_u85_INT(test_data):
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_native_layer_norm_vgf_FP(test_data):
+def test_native_layer_norm_vgf_no_quant(test_data):
     test_input, model = test_data()
     pipeline = VgfPipeline[input_t](
         model,
         test_input,
         "torch.ops.aten.layer_norm.default",
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_native_layer_norm_vgf_INT(test_data):
+def test_native_layer_norm_vgf_quant(test_data):
     test_input, model = test_data()
     pipeline = VgfPipeline[input_t](
         model,
         test_input,
         "torch.ops.aten.sub.Tensor",
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 

--- a/backends/arm/test/ops/test_le.py
+++ b/backends/arm/test/ops/test_le.py
@@ -246,51 +246,51 @@ def test_le_scalar_16a8w_u85_INT16(test_module):
 
 @common.parametrize("test_module", test_data_tensor)
 @common.SkipIfNoModelConverter
-def test_le_tensor_vgf_FP(test_module):
+def test_le_tensor_vgf_no_quant(test_module):
     pipeline = VgfPipeline[input_t](
         test_module(),
         test_module().get_inputs(),
         LessEqual.aten_op_tensor,
         LessEqual.exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_module", test_data_tensor)
 @common.SkipIfNoModelConverter
-def test_le_tensor_vgf_INT(test_module):
+def test_le_tensor_vgf_quant(test_module):
     pipeline = VgfPipeline[input_t](
         test_module(),
         test_module().get_inputs(),
         LessEqual.aten_op_tensor,
         LessEqual.exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 
 
 @common.parametrize("test_module", test_data_scalar)
 @common.SkipIfNoModelConverter
-def test_le_scalar_vgf_FP(test_module):
+def test_le_scalar_vgf_no_quant(test_module):
     pipeline = VgfPipeline[input_t](
         test_module(),
         test_module().get_inputs(),
         LessEqual.aten_op_scalar,
         LessEqual.exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_module", test_data_scalar)
 @common.SkipIfNoModelConverter
-def test_le_scalar_vgf_INT(test_module):
+def test_le_scalar_vgf_quant(test_module):
     pipeline = VgfPipeline[input_t](
         test_module(),
         test_module().get_inputs(),
         LessEqual.aten_op_tensor,
         LessEqual.exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_leaky_relu.py
+++ b/backends/arm/test/ops/test_leaky_relu.py
@@ -95,14 +95,14 @@ def test_leaky_relu_u85_INT(test_data):
 
 @common.parametrize("test_data", LeakyReLU.test_data)
 @common.SkipIfNoModelConverter
-def test_leaky_relu_vgf_FP(test_data):
+def test_leaky_relu_vgf_no_quant(test_data):
     data, slope = test_data()
     pipeline = VgfPipeline[input_t1](
         LeakyReLU(slope),
         data,
         [],
         use_to_edge_transform_and_lower=True,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.add_stage_after(
         "to_edge_transform_and_lower", pipeline.tester.check_not, [aten_op]
@@ -112,14 +112,14 @@ def test_leaky_relu_vgf_FP(test_data):
 
 @common.parametrize("test_data", LeakyReLU.test_data)
 @common.SkipIfNoModelConverter
-def test_leaky_relu_vgf_INT(test_data):
+def test_leaky_relu_vgf_quant(test_data):
     data, slope = test_data()
     pipeline = VgfPipeline[input_t1](
         LeakyReLU(slope),
         data,
         [],
         use_to_edge_transform_and_lower=True,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.add_stage_after("quantize", pipeline.tester.check_not, [aten_op])
     pipeline.run()

--- a/backends/arm/test/ops/test_linalg_vector_norm.py
+++ b/backends/arm/test/ops/test_linalg_vector_norm.py
@@ -128,7 +128,7 @@ def test_vector_norm_u85_INT_fvp(test_module):
 
 @common.parametrize("test_module", test_modules)
 @common.SkipIfNoModelConverter
-def test_vector_norm_vgf_FP(test_module):
+def test_vector_norm_vgf_no_quant(test_module):
     model, input_tensor = test_module
     # FP VGF
     aten_op = "torch.ops.aten.linalg_vector_norm.default"
@@ -138,14 +138,14 @@ def test_vector_norm_vgf_FP(test_module):
         input_tensor,
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_module", test_modules)
 @common.SkipIfNoModelConverter
-def test_vector_norm_vgf_INT(test_module):
+def test_vector_norm_vgf_quant(test_module):
     model, input_tensor = test_module
     # Should not found this op
     exir_op = "executorch_exir_dialects_edge__ops_aten_linalg_vector_norm_default"
@@ -155,6 +155,6 @@ def test_vector_norm_vgf_INT(test_module):
         input_tensor,
         aten_op_q_decomposed_q,
         exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_linear.py
+++ b/backends/arm/test/ops/test_linear.py
@@ -209,39 +209,31 @@ def test_linear_u85_INT(test_data: torch.Tensor):
 
 @common.parametrize("test_data", test_data_rank1_FP | test_data_rank4_FP)
 @common.SkipIfNoModelConverter
-def test_linear_vgf_FP(test_data: torch.Tensor):
+def test_linear_vgf_no_quant(test_data: torch.Tensor):
     test_data, out_features, has_bias = test_data()
     in_features = test_data.shape[-1]
     pipeline = VgfPipeline[input_t1](
-        Linear(
-            in_features=in_features,
-            out_features=out_features,
-            bias=has_bias,
-        ),
+        Linear(in_features=in_features, out_features=out_features, bias=has_bias),
         (test_data,),
         aten_op=aten_op,
         exir_op=[],
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data_rank1_INT | test_data_rank4_INT)
 @common.SkipIfNoModelConverter
-def test_linear_vgf_INT(test_data: torch.Tensor):
+def test_linear_vgf_quant(test_data: torch.Tensor):
     test_data, out_features, has_bias, per_channel_quantization = test_data()
     in_features = test_data.shape[-1]
     pipeline = VgfPipeline[input_t1](
-        Linear(
-            in_features=in_features,
-            out_features=out_features,
-            bias=has_bias,
-        ),
+        Linear(in_features=in_features, out_features=out_features, bias=has_bias),
         (test_data,),
         aten_op=aten_op,
         exir_op=[],
-        tosa_version="TOSA-1.0+INT",
         per_channel_quantization=per_channel_quantization,
+        quantize=True,
     )
     pipeline.run()
 

--- a/backends/arm/test/ops/test_log.py
+++ b/backends/arm/test/ops/test_log.py
@@ -76,25 +76,25 @@ def test_log_u85_INT(test_data: input_t1):
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_log_vgf_FP(test_data: input_t1):
+def test_log_vgf_no_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         Log(),
         (test_data(),),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_log_vgf_INT(test_data: input_t1):
+def test_log_vgf_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         Log(),
         (test_data(),),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_logical.py
+++ b/backends/arm/test/ops/test_logical.py
@@ -144,26 +144,26 @@ def test_logical_and_u85_INT(test_data: input_t2):
 
 @common.parametrize("test_data", And().test_data)
 @common.SkipIfNoModelConverter
-def test_logical_and_vgf_FP(test_data: input_t2):
+def test_logical_and_vgf_no_quant(test_data: input_t2):
     pipeline = VgfPipeline[input_t2](
         And(),
         test_data(),
         And().aten_op,
         And().exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", And().test_data)
 @common.SkipIfNoModelConverter
-def test_logical_and_vgf_INT(test_data: input_t2):
+def test_logical_and_vgf_quant(test_data: input_t2):
     pipeline = VgfPipeline[input_t2](
         And(),
         test_data(),
         And().aten_op,
         And().exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 
@@ -231,26 +231,26 @@ def test_logical_xor_u85_INT(test_data: input_t2):
 
 @common.parametrize("test_data", Xor().test_data)
 @common.SkipIfNoModelConverter
-def test_logical_xor_vgf_FP(test_data: input_t2):
+def test_logical_xor_vgf_no_quant(test_data: input_t2):
     pipeline = VgfPipeline[input_t2](
         Xor(),
         test_data(),
         Xor().aten_op,
         Xor().exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", Xor().test_data)
 @common.SkipIfNoModelConverter
-def test_logical_xor_vgf_INT(test_data: input_t2):
+def test_logical_xor_vgf_quant(test_data: input_t2):
     pipeline = VgfPipeline[input_t2](
         Xor(),
         test_data(),
         Xor().aten_op,
         Xor().exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 
@@ -318,26 +318,26 @@ def test_logical_or_u85_INT(test_data: input_t2):
 
 @common.parametrize("test_data", Or().test_data)
 @common.SkipIfNoModelConverter
-def test_logical_or_vgf_FP(test_data: input_t2):
+def test_logical_or_vgf_no_quant(test_data: input_t2):
     pipeline = VgfPipeline[input_t2](
         Or(),
         test_data(),
         Or().aten_op,
         Or().exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", Or().test_data)
 @common.SkipIfNoModelConverter
-def test_logical_or_vgf_INT(test_data: input_t2):
+def test_logical_or_vgf_quant(test_data: input_t2):
     pipeline = VgfPipeline[input_t2](
         Or(),
         test_data(),
         Or().aten_op,
         Or().exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 
@@ -405,25 +405,25 @@ def test_logical_not_u85_INT(test_data: input_t2):
 
 @common.parametrize("test_data", Not().test_data)
 @common.SkipIfNoModelConverter
-def test_logical_not_vgf_FP(test_data: input_t2):
+def test_logical_not_vgf_no_quant(test_data: input_t2):
     pipeline = VgfPipeline[input_t2](
         Not(),
         test_data(),
         Not().aten_op,
         Not().exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", Not().test_data)
 @common.SkipIfNoModelConverter
-def test_logical_not_vgf_INT(test_data: input_t2):
+def test_logical_not_vgf_quant(test_data: input_t2):
     pipeline = VgfPipeline[input_t2](
         Not(),
         test_data(),
         Not().aten_op,
         Not().exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_logit.py
+++ b/backends/arm/test/ops/test_logit.py
@@ -92,13 +92,13 @@ def test_logit_u85_INT(test_data: Tuple):
     test_data_suite,
 )
 @common.SkipIfNoModelConverter
-def test_logit_vgf_FP(test_data: input_t1):
+def test_logit_vgf_no_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         Logit(),
         (*test_data,),
         [],
         [],
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
@@ -108,12 +108,12 @@ def test_logit_vgf_FP(test_data: input_t1):
     test_data_suite,
 )
 @common.SkipIfNoModelConverter
-def test_logit_vgf_INT(test_data: input_t1):
+def test_logit_vgf_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         Logit(),
         (*test_data,),
         [],
         [],
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_logsoftmax.py
+++ b/backends/arm/test/ops/test_logsoftmax.py
@@ -94,10 +94,14 @@ def test_log_softmax_u85_INT(test_data):
 
 @common.parametrize("test_data", LogSoftmax.test_data)
 @common.SkipIfNoModelConverter
-def test_log_softmax_vgf_FP(test_data):
+def test_log_softmax_vgf_no_quant(test_data):
     data, dim = test_data()
     pipeline = VgfPipeline[input_t1](
-        LogSoftmax(dim), data, [], [], tosa_version="TOSA-1.0+FP"
+        LogSoftmax(dim),
+        data,
+        [],
+        [],
+        quantize=False,
     )
     pipeline.add_stage_after(
         "to_edge_transform_and_lower", pipeline.tester.check_not, [aten_op]
@@ -107,14 +111,14 @@ def test_log_softmax_vgf_FP(test_data):
 
 @common.parametrize("test_data", LogSoftmax.test_data)
 @common.SkipIfNoModelConverter
-def test_log_softmax_vgf_INT(test_data):
+def test_log_softmax_vgf_quant(test_data):
     data, dim = test_data()
     pipeline = VgfPipeline[input_t1](
         LogSoftmax(dim),
         data,
         [],
         [],
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.add_stage_after("quantize", pipeline.tester.check_not, [aten_op])
     pipeline.run()

--- a/backends/arm/test/ops/test_lshift.py
+++ b/backends/arm/test/ops/test_lshift.py
@@ -120,26 +120,26 @@ def test_bitwise_left_shift_tensor_u85_INT_scalar(test_data):
 
 @common.parametrize("test_data", LshiftScalar.test_data)
 @common.SkipIfNoModelConverter
-def test_bitwise_left_shift_scalar_vgf_FP_scalar(test_data: scalar_input_t):
+def test_bitwise_left_shift_scalar_scalar_vgf_no_quant(test_data: scalar_input_t):
     pipeline = VgfPipeline[scalar_input_t](
         LshiftScalar(),
         test_data,
         LshiftScalar.torch_op_FP,
         LshiftScalar.exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", LshiftScalar.test_data)
 @common.SkipIfNoModelConverter
-def test_bitwise_left_shift_tensor_vgf_INT_scalar(test_data: scalar_input_t):
+def test_bitwise_left_shift_tensor_scalar_vgf_quant(test_data: scalar_input_t):
     pipeline = VgfPipeline[scalar_input_t](
         LshiftScalar(),
         test_data,
         LshiftScalar.torch_op_INT,
         LshiftScalar.exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 
@@ -196,25 +196,25 @@ def test_bitwise_left_shift_tensor_u85_INT(test_data):
 
 @common.parametrize("test_data", LshiftTensor.test_data)
 @common.SkipIfNoModelConverter
-def test_bitwise_left_shift_tensor_vgf_FP(test_data: tensor_input_t):
+def test_bitwise_left_shift_tensor_vgf_no_quant(test_data: tensor_input_t):
     pipeline = VgfPipeline[tensor_input_t](
         LshiftTensor(),
         test_data,
         LshiftTensor.torch_op,
         LshiftTensor.exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", LshiftTensor.test_data)
 @common.SkipIfNoModelConverter
-def test_bitwise_left_shift_tensor_vgf_INT(test_data: tensor_input_t):
+def test_bitwise_left_shift_tensor_vgf_quant(test_data: tensor_input_t):
     pipeline = VgfPipeline[tensor_input_t](
         LshiftTensor(),
         test_data,
         LshiftTensor.torch_op,
         LshiftTensor.exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_lt.py
+++ b/backends/arm/test/ops/test_lt.py
@@ -243,51 +243,51 @@ def test_lt_scalar_16a8w_u85_INT16(test_module):
 
 @common.parametrize("test_module", test_data_tensor)
 @common.SkipIfNoModelConverter
-def test_lt_tensor_vgf_FP(test_module):
+def test_lt_tensor_vgf_no_quant(test_module):
     pipeline = VgfPipeline[input_t](
         test_module(),
         test_module().get_inputs(),
         LessThan.aten_op_tensor,
         LessThan.exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_module", test_data_scalar)
 @common.SkipIfNoModelConverter
-def test_lt_scalar_vgf_FP(test_module):
+def test_lt_scalar_vgf_no_quant(test_module):
     pipeline = VgfPipeline[input_t](
         test_module(),
         test_module().get_inputs(),
         LessThan.aten_op_scalar,
         LessThan.exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_module", test_data_tensor)
 @common.SkipIfNoModelConverter
-def test_lt_tensor_vgf_INT(test_module):
+def test_lt_tensor_vgf_quant(test_module):
     pipeline = VgfPipeline[input_t](
         test_module(),
         test_module().get_inputs(),
         LessThan.aten_op_tensor,
         LessThan.exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 
 
 @common.parametrize("test_module", test_data_scalar)
 @common.SkipIfNoModelConverter
-def test_lt_scalar_vgf_INT(test_module):
+def test_lt_scalar_vgf_quant(test_module):
     pipeline = VgfPipeline[input_t](
         test_module(),
         test_module().get_inputs(),
         LessThan.aten_op_tensor,
         LessThan.exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_masked_fill.py
+++ b/backends/arm/test/ops/test_masked_fill.py
@@ -147,19 +147,25 @@ def test_masked_fill_scalar_u85_INT(test_module):
 
 @common.parametrize("test_module", test_modules)
 @common.SkipIfNoModelConverter
-def test_masked_fill_scalar_vgf_FP(test_module):
+def test_masked_fill_scalar_vgf_no_quant(test_module):
     module, inputs = test_module()
     pipeline = VgfPipeline[input_t](
-        module, inputs, aten_op=[], tosa_version="TOSA-1.0+FP"
+        module,
+        inputs,
+        aten_op=[],
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_module", test_modules)
 @common.SkipIfNoModelConverter
-def test_masked_fill_scalar_vgf_INT(test_module):
+def test_masked_fill_scalar_vgf_quant(test_module):
     module, inputs = test_module()
     pipeline = VgfPipeline[input_t](
-        module, inputs, aten_op=[], tosa_version="TOSA-1.0+INT"
+        module,
+        inputs,
+        aten_op=[],
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_matmul.py
+++ b/backends/arm/test/ops/test_matmul.py
@@ -225,69 +225,77 @@ def test_matmul_combo_u85_INT(test_data: input_t1):
 
 @common.parametrize("test_data", MatMul.test_data_generators)
 @common.SkipIfNoModelConverter
-def test_matmul_vgf_FP(test_data: input_t1):
+def test_matmul_vgf_no_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
-        MatMul(), test_data(), aten_op_mm, exir_op_mm, tosa_version="TOSA-1.0+FP"
+        MatMul(),
+        test_data(),
+        aten_op_mm,
+        exir_op_mm,
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", MatMulSingleInput.test_data_generators)
 @common.SkipIfNoModelConverter
-def test_matmul_single_input_vgf_FP(test_data: input_t1):
+def test_matmul_single_input_vgf_no_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         MatMulSingleInput(),
         test_data(),
         aten_op_mm,
         exir_op_mm,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", MatMulCombo.test_data_generators)
 @common.SkipIfNoModelConverter
-def test_matmul_combo_vgf_FP(test_data: input_t1):
+def test_matmul_combo_vgf_no_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
-        MatMulCombo(), test_data(), aten_op_mm, exir_op_mm, tosa_version="TOSA-1.0+FP"
+        MatMulCombo(),
+        test_data(),
+        aten_op_mm,
+        exir_op_mm,
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", MatMul.test_data_generators)
 @common.SkipIfNoModelConverter
-def test_matmul_vgf_INT(test_data: input_t1):
+def test_matmul_vgf_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         MatMul(),
         test_data(),
         aten_op_mm,
         exir_op_mm,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", MatMulSingleInput.test_data_generators)
 @common.SkipIfNoModelConverter
-def test_matmul_single_input_vgf_INT(test_data: input_t1):
+def test_matmul_single_input_vgf_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         MatMulSingleInput(),
         test_data(),
         aten_op_mm,
         exir_op_mm,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", MatMulCombo.test_data_generators)
 @common.SkipIfNoModelConverter
-def test_matmul_combo_vgf_INT(test_data: input_t1):
+def test_matmul_combo_vgf_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         MatMulCombo(),
         test_data(),
         aten_op_mm,
         exir_op_mm,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_max_pool.py
+++ b/backends/arm/test/ops/test_max_pool.py
@@ -269,35 +269,35 @@ def test_max_pool2d_tosa_INT_dilation(test_data):
 # VGF tests
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_max_pool2d_vgf_FP(test_data: torch.Tensor):
+def test_max_pool2d_vgf_no_quant(test_data: torch.Tensor):
     test_data, model_params = test_data()
     pipeline = VgfPipeline[input_t1](
         MaxPool2d(*model_params),
         (test_data,),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_max_pool2d_vgf_INT(test_data: torch.Tensor):
+def test_max_pool2d_vgf_quant(test_data: torch.Tensor):
     test_data, model_params = test_data()
     pipeline = VgfPipeline[input_t1](
         MaxPool2d(*model_params),
         (test_data,),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", dilation_test_data)
 @common.SkipIfNoModelConverter
-def test_max_pool2d_vgf_FP_dilation(test_data: torch.Tensor):
+def test_max_pool2d_dilation_vgf_no_quant(test_data: torch.Tensor):
     """
     VGF FP pipeline with dilation > 1 (and dilation=1 sanity cases).
     """
@@ -307,14 +307,14 @@ def test_max_pool2d_vgf_FP_dilation(test_data: torch.Tensor):
         (test_data,),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", dilation_test_data)
 @common.SkipIfNoModelConverter
-def test_max_pool2d_vgf_INT_dilation(test_data: torch.Tensor):
+def test_max_pool2d_dilation_vgf_quant(test_data: torch.Tensor):
     """
     VGF INT pipeline with dilation > 1 (and dilation=1 sanity cases).
     """
@@ -324,6 +324,6 @@ def test_max_pool2d_vgf_INT_dilation(test_data: torch.Tensor):
         (test_data,),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_maximum.py
+++ b/backends/arm/test/ops/test_maximum.py
@@ -76,23 +76,23 @@ def test_maximum_u85_INT(test_data: Tuple):
 
 @common.parametrize("test_data", Maximum.test_parameters)
 @common.SkipIfNoModelConverter
-def test_maximum_vgf_FP(test_data: Tuple):
+def test_maximum_vgf_no_quant(test_data: Tuple):
     pipeline = VgfPipeline[test_t](
         Maximum(),
         test_data(),
         aten_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", Maximum.test_parameters)
 @common.SkipIfNoModelConverter
-def test_maximum_vgf_INT(test_data: Tuple):
+def test_maximum_vgf_quant(test_data: Tuple):
     pipeline = VgfPipeline[test_t](
         Maximum(),
         test_data(),
         aten_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_mean_dim.py
+++ b/backends/arm/test/ops/test_mean_dim.py
@@ -85,27 +85,27 @@ def test_adaptive_avg_pool2d_u85_INT(test_data):
 
 @common.parametrize("test_data", AdaptiveAveragePool2d.test_data_suite)
 @common.SkipIfNoModelConverter
-def test_adaptive_avg_pool2d_vgf_FP(test_data):
+def test_adaptive_avg_pool2d_vgf_no_quant(test_data):
     pipeline = VgfPipeline[input_t](
         AdaptiveAveragePool2d(),
         test_data(),
         AdaptiveAveragePool2d.aten_op,
         AdaptiveAveragePool2d.exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", AdaptiveAveragePool2d.test_data_suite)
 @common.SkipIfNoModelConverter
-def test_adaptive_avg_pool2d_vgf_INT(test_data):
+def test_adaptive_avg_pool2d_vgf_quant(test_data):
     pipeline = VgfPipeline[input_t](
         AdaptiveAveragePool2d(),
         test_data(),
         AdaptiveAveragePool2d.aten_op,
         AdaptiveAveragePool2d.exir_op,
         symmetric_io_quantization=True,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 
@@ -322,28 +322,28 @@ def test_mean_dim_u85_INT(test_data):
 
 @common.parametrize("test_data", MeanDim.test_data_suite)
 @common.SkipIfNoModelConverter
-def test_mean_dim_vgf_FP(test_data):
+def test_mean_dim_vgf_no_quant(test_data):
     test_data_val, dim, keep_dim = test_data()
     pipeline = VgfPipeline[input_t](
         MeanDim(dim, keep_dim),
         (test_data_val,),
         MeanDim.torch_op,
         MeanDim.exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", MeanDim.test_data_suite)
 @common.SkipIfNoModelConverter
-def test_mean_dim_vgf_INT(test_data):
+def test_mean_dim_vgf_quant(test_data):
     test_data_val, dim, keep_dim = test_data()
     pipeline = VgfPipeline[input_t](
         MeanDim(dim, keep_dim),
         (test_data_val,),
-        [],  # Might be sum, avgpool, or both
+        [],
         symmetric_io_quantization=True,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 

--- a/backends/arm/test/ops/test_minimum.py
+++ b/backends/arm/test/ops/test_minimum.py
@@ -76,18 +76,23 @@ def test_minimum_u85_INT(test_data: Tuple):
 
 @common.parametrize("test_data", Minimum.test_parameters)
 @common.SkipIfNoModelConverter
-def test_minimum_vgf_FP(test_data: test_t):
-    pipeline = VgfPipeline[test_t](Minimum(), test_data(), aten_op)
+def test_minimum_vgf_no_quant(test_data: test_t):
+    pipeline = VgfPipeline[test_t](
+        Minimum(),
+        test_data(),
+        aten_op,
+        quantize=False,
+    )
     pipeline.run()
 
 
 @common.parametrize("test_data", Minimum.test_parameters)
 @common.SkipIfNoModelConverter
-def test_minimum_vgf_INT(test_data: test_t):
+def test_minimum_vgf_quant(test_data: test_t):
     pipeline = VgfPipeline[test_t](
         Minimum(),
         test_data(),
         aten_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_mm.py
+++ b/backends/arm/test/ops/test_mm.py
@@ -69,21 +69,25 @@ def test_mm_u85_INT(test_data: Tuple):
 
 @common.parametrize("test_data", MM.test_data_generators)
 @common.SkipIfNoModelConverter
-def test_mm_vgf_FP(test_data: Tuple):
+def test_mm_vgf_no_quant(test_data: Tuple):
     pipeline = VgfPipeline[test_t](
-        MM(), test_data(), MM.aten_op, MM.exir_op, tosa_version="TOSA-1.0+FP"
+        MM(),
+        test_data(),
+        MM.aten_op,
+        MM.exir_op,
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", MM.test_data_generators)
 @common.SkipIfNoModelConverter
-def test_mm_vgf_INT(test_data: Tuple):
+def test_mm_vgf_quant(test_data: Tuple):
     pipeline = VgfPipeline[test_t](
         MM(),
         test_data(),
         MM.aten_op,
         MM.exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_mul.py
+++ b/backends/arm/test/ops/test_mul.py
@@ -248,39 +248,39 @@ def test_mul_tensor_u85_INT_int32(test_data: torch.Tensor):
     test_data_suite | test_data_suite_2 | test_data_int32_without_broadcasting,
 )
 @common.SkipIfNoModelConverter
-def test_mul_tensor_vgf_FP(test_data: torch.Tensor):
+def test_mul_tensor_vgf_no_quant(test_data: torch.Tensor):
     pipeline = VgfPipeline[input_t1](
         Mul(),
         test_data(),
         aten_op,
         exir_op=[],
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data_suite | test_data_suite_2)
 @common.SkipIfNoModelConverter
-def test_mul_tensor_vgf_INT(test_data: torch.Tensor):
+def test_mul_tensor_vgf_quant(test_data: torch.Tensor):
     pipeline = VgfPipeline[input_t1](
         Mul(),
         test_data(),
         aten_op,
         exir_op=[],
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data_suite_int32)
 @common.SkipIfNoModelConverter
-def test_mul_tensor_vgf_INT_int32(test_data: torch.Tensor):
+def test_mul_tensor_int32_vgf_quant(test_data: torch.Tensor):
     pipeline = VgfPipeline[input_t1](
         Mul(),
         test_data(),
         aten_op,
         exir_op=[],
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 

--- a/backends/arm/test/ops/test_multihead_attention.py
+++ b/backends/arm/test/ops/test_multihead_attention.py
@@ -108,14 +108,14 @@ def test_multihead_attention_u85_INT(test_data: input_t1):
     test_suite,
 )
 @common.SkipIfNoModelConverter
-def test_multihead_attention_vgf_FP(test_data: input_t1):
+def test_multihead_attention_vgf_no_quant(test_data: input_t1):
     test_data_vals, module = test_data()
     pipeline = VgfPipeline[input_t1](
         module,
         (*test_data_vals, *test_data_vals, *test_data_vals),
         [],
         [],
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
@@ -125,15 +125,14 @@ def test_multihead_attention_vgf_FP(test_data: input_t1):
     test_suite,
 )
 @common.SkipIfNoModelConverter
-def test_multihead_attention_vgf_INT(test_data: input_t1):
+def test_multihead_attention_vgf_quant(test_data: input_t1):
     test_data_vals, module = test_data()
     pipeline = VgfPipeline[input_t1](
         module,
         (*test_data_vals, *test_data_vals, *test_data_vals),
         [],
         [],
-        tosa_version="TOSA-1.0+INT",
-        # TODO: Per-channel quantization is broken (MLETORCH-1144)
         per_channel_quantization=False,
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_ne.py
+++ b/backends/arm/test/ops/test_ne.py
@@ -193,51 +193,51 @@ def test_ne_scalar_u85_INT(test_module):
 
 @common.parametrize("test_module", test_data_tensor)
 @common.SkipIfNoModelConverter
-def test_ne_tensor_vgf_FP(test_module):
+def test_ne_tensor_vgf_no_quant(test_module):
     pipeline = VgfPipeline[input_t](
         test_module,
         test_module.get_inputs(),
         NotEqual.aten_op_Tensor,
         NotEqual.exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_module", test_data_tensor)
 @common.SkipIfNoModelConverter
-def test_ne_tensor_vgf_INT(test_module):
+def test_ne_tensor_vgf_quant(test_module):
     pipeline = VgfPipeline[input_t](
         test_module,
         test_module.get_inputs(),
         NotEqual.decomposed_ops,
         NotEqual.exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 
 
 @common.parametrize("test_module", test_data_scalar)
 @common.SkipIfNoModelConverter
-def test_ne_scalar_vgf_FP(test_module):
+def test_ne_scalar_vgf_no_quant(test_module):
     pipeline = VgfPipeline[input_t](
         test_module,
         test_module.get_inputs(),
         NotEqual.aten_op_Scalar,
         NotEqual.exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_module", test_data_scalar)
 @common.SkipIfNoModelConverter
-def test_ne_scalar_vgf_INT(test_module):
+def test_ne_scalar_vgf_quant(test_module):
     pipeline = VgfPipeline[input_t](
         test_module,
         test_module.get_inputs(),
         NotEqual.decomposed_ops,
         NotEqual.exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_neg.py
+++ b/backends/arm/test/ops/test_neg.py
@@ -75,21 +75,25 @@ def test_neg_u85_INT(test_data: input_t1):
 
 @common.parametrize("test_data", Neg.test_data)
 @common.SkipIfNoModelConverter
-def test_neg_vgf_FP(test_data: input_t1):
+def test_neg_vgf_no_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
-        Neg(), test_data, Neg.aten_op, Neg.exir_op, tosa_version="TOSA-1.0+FP"
+        Neg(),
+        test_data,
+        Neg.aten_op,
+        Neg.exir_op,
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", Neg.test_data)
 @common.SkipIfNoModelConverter
-def test_neg_vgf_INT(test_data: input_t1):
+def test_neg_vgf_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         Neg(),
         test_data,
         Neg.aten_op,
         Neg.exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_ones.py
+++ b/backends/arm/test/ops/test_ones.py
@@ -124,23 +124,26 @@ def test_ones_tosa_INT_not_delegated(test_data: test_data_t):
 
 @common.parametrize("test_data", OnesAdd.test_data)
 @common.SkipIfNoModelConverter
-def test_ones_vgf_FP(test_data: test_data_t):
+def test_ones_vgf_no_quant(test_data: test_data_t):
     input_data, init_data = test_data
     pipeline = VgfPipeline[input_t](
-        OnesAdd(*init_data), input_data(), OnesAdd.aten_op, tosa_version="TOSA-1.0+FP"
+        OnesAdd(*init_data),
+        input_data(),
+        OnesAdd.aten_op,
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", OnesAdd.test_data)
 @common.SkipIfNoModelConverter
-def test_ones_vgf_INT(test_data: test_data_t):
+def test_ones_vgf_quant(test_data: test_data_t):
     input_data, init_data = test_data
     pipeline = VgfPipeline[input_t](
         OnesAdd(*init_data),
         input_data(),
         OnesAdd.aten_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     # Pop the quantization check stage if it exists as no
     # quantization nodes will be present for int + fp inputs.

--- a/backends/arm/test/ops/test_permute.py
+++ b/backends/arm/test/ops/test_permute.py
@@ -130,28 +130,28 @@ def test_permute_u85_INT(test_data: torch.Tensor):
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_permute_vgf_FP(test_data):
+def test_permute_vgf_no_quant(test_data):
     test_data, dims = test_data()
     pipeline = VgfPipeline[input_t1](
         SimplePermute(dims=dims),
         (test_data,),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_permute_vgf_INT(test_data):
+def test_permute_vgf_quant(test_data):
     test_data, dims = test_data()
     pipeline = VgfPipeline[input_t1](
         SimplePermute(dims=dims),
         (test_data,),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 

--- a/backends/arm/test/ops/test_pixel_shuffling.py
+++ b/backends/arm/test/ops/test_pixel_shuffling.py
@@ -123,56 +123,56 @@ def test_pixel_shuffle_tosa_INT(test_data: input_t1):
 
 @common.parametrize("test_data", PixelUnShuffle.test_data_generators)
 @common.SkipIfNoModelConverter
-def test_pixel_unshuffle_vgf_FP(test_data: input_t1):
+def test_pixel_unshuffle_vgf_no_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         PixelUnShuffle(),
         test_data(),
         aten_op_pixel_unshuffle,
         exir_op_pixel_unshuffle,
-        tosa_version="TOSA-1.0+FP",
         run_on_vulkan_runtime=True,
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", PixelUnShuffle.test_data_generators)
 @common.SkipIfNoModelConverter
-def test_pixel_unshuffle_vgf_INT(test_data: input_t1):
+def test_pixel_unshuffle_vgf_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         PixelUnShuffle(),
         test_data(),
         aten_op_pixel_unshuffle,
         exir_op_pixel_unshuffle,
-        tosa_version="TOSA-1.0+INT",
         run_on_vulkan_runtime=True,
+        quantize=True,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", PixelShuffle.test_data_generators)
 @common.SkipIfNoModelConverter
-def test_pixel_shuffle_vgf_FP(test_data: input_t1):
+def test_pixel_shuffle_vgf_no_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         PixelShuffle(),
         test_data(),
         aten_op_pixel_shuffle,
         exir_op_pixel_shuffle,
-        tosa_version="TOSA-1.0+FP",
         run_on_vulkan_runtime=True,
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", PixelShuffle.test_data_generators)
 @common.SkipIfNoModelConverter
-def test_pixel_shuffle_vgf_INT(test_data: input_t1):
+def test_pixel_shuffle_vgf_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         PixelShuffle(),
         test_data(),
         aten_op_pixel_shuffle,
         exir_op_pixel_shuffle,
-        tosa_version="TOSA-1.0+INT",
         run_on_vulkan_runtime=True,
+        quantize=True,
     )
     pipeline.run()
 

--- a/backends/arm/test/ops/test_pow.py
+++ b/backends/arm/test/ops/test_pow.py
@@ -105,13 +105,13 @@ def test_pow_tensor_tensor_tosa_FP(test_data: Pow_TensorTensor.input_t):
 
 @common.parametrize("test_data", Pow_TensorTensor.test_data, x_fail, strict=False)
 @common.SkipIfNoModelConverter
-def test_pow_tensor_tensor_vgf_FP(test_data: Pow_TensorTensor.input_t):
+def test_pow_tensor_tensor_vgf_no_quant(test_data: Pow_TensorTensor.input_t):
     pipeline = VgfPipeline[Pow_TensorTensor.input_t](
         Pow_TensorTensor(),
         test_data(),
         Pow_TensorTensor.aten_op,
         Pow_TensorTensor.exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
@@ -175,14 +175,14 @@ def test_pow_tensor_scalar_u85_INT(test_data: Pow_TensorScalar.input_t):
 
 @common.parametrize("test_data", Pow_TensorScalar.test_data, x_fail, strict=False)
 @common.SkipIfNoModelConverter
-def test_pow_tensor_scalar_vgf_FP(test_data: Pow_TensorScalar.input_t):
+def test_pow_tensor_scalar_vgf_no_quant(test_data: Pow_TensorScalar.input_t):
     base, exp = test_data()
     pipeline = VgfPipeline[Pow_TensorScalar.input_t](
         Pow_TensorScalar(exp),
         (base,),
         Pow_TensorScalar.aten_op,
         Pow_TensorScalar.exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
@@ -192,13 +192,13 @@ def test_pow_tensor_scalar_vgf_FP(test_data: Pow_TensorScalar.input_t):
     Pow_TensorScalar.test_data,
 )
 @common.SkipIfNoModelConverter
-def test_pow_tensor_scalar_vgf_INT(test_data: Pow_TensorScalar.input_t):
+def test_pow_tensor_scalar_vgf_quant(test_data: Pow_TensorScalar.input_t):
     base, exp = test_data()
     pipeline = VgfPipeline[Pow_TensorScalar.input_t](
         Pow_TensorScalar(exp),
         (base,),
         Pow_TensorScalar.aten_op,
         Pow_TensorScalar.exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_reciprocal.py
+++ b/backends/arm/test/ops/test_reciprocal.py
@@ -90,23 +90,23 @@ def test_reciprocal_u85_INT(test_data: torch.Tensor):
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_reciprocal_vgf_FP(test_data: torch.Tensor):
+def test_reciprocal_vgf_no_quant(test_data: torch.Tensor):
     pipeline = VgfPipeline[input_t1](
         Reciprocal(),
         (test_data(),),
         aten_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_reciprocal_vgf_INT(test_data: torch.Tensor):
+def test_reciprocal_vgf_quant(test_data: torch.Tensor):
     pipeline = VgfPipeline[input_t1](
         Reciprocal(),
         (test_data(),),
         aten_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_relu.py
+++ b/backends/arm/test/ops/test_relu.py
@@ -142,25 +142,25 @@ def test_relu_u85_INT(test_data: torch.Tensor):
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_relu_vgf_FP(test_data: torch.Tensor):
+def test_relu_vgf_no_quant(test_data: torch.Tensor):
     pipeline = VgfPipeline[input_t1](
         Relu(),
         (test_data(),),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_relu_vgf_INT(test_data: torch.Tensor):
+def test_relu_vgf_quant(test_data: torch.Tensor):
     pipeline = VgfPipeline[input_t1](
         Relu(),
         (test_data(),),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_remainder.py
+++ b/backends/arm/test/ops/test_remainder.py
@@ -149,51 +149,51 @@ def test_remainder_scalar_u85_INT(test_data):
 
 @common.parametrize("test_data", Remainder.test_cases_tensor)
 @common.SkipIfNoModelConverter
-def test_remainder_tensor_vgf_FP(test_data):
+def test_remainder_tensor_vgf_no_quant(test_data):
     data = test_data()
     pipeline = VgfPipeline[Remainder.input_t](
         Remainder(),
         data,
         Remainder.aten_op_tensor,
         Remainder.exir_op_tensor,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", Remainder.test_cases_scalar)
 @common.SkipIfNoModelConverter
-def test_remainder_scalar_vgf_FP(test_data):
+def test_remainder_scalar_vgf_no_quant(test_data):
     data = test_data()
     pipeline = VgfPipeline[Remainder.input_t](
         Remainder(),
         data,
         Remainder.aten_op_scalar,
         Remainder.exir_op_scalar,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", Remainder.test_cases_tensor)
 @common.SkipIfNoModelConverter
-def test_remainder_tensor_vgf_INT(test_data):
+def test_remainder_tensor_vgf_quant(test_data):
     pipeline = VgfPipeline[Remainder.input_t](
         Remainder(),
         test_data(),
         [],
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", Remainder.test_cases_scalar)
 @common.SkipIfNoModelConverter
-def test_remainder_scalar_vgf_INT(test_data):
+def test_remainder_scalar_vgf_quant(test_data):
     pipeline = VgfPipeline[Remainder.input_t](
         Remainder(),
         test_data(),
         [],
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_repeat.py
+++ b/backends/arm/test/ops/test_repeat.py
@@ -138,25 +138,25 @@ def test_repeat_u85_INT(test_data: Tuple):
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_repeat_vgf_FP(test_data: Tuple):
+def test_repeat_vgf_no_quant(test_data: Tuple):
     module, args = test_data()
     pipeline = VgfPipeline[input_t1](
         module,
         args,
         module.aten_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_repeat_vgf_INT(test_data: Tuple):
+def test_repeat_vgf_quant(test_data: Tuple):
     module, args = test_data()
     pipeline = VgfPipeline[input_t1](
         module,
         args,
         module.aten_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_round.py
+++ b/backends/arm/test/ops/test_round.py
@@ -87,25 +87,25 @@ def test_round_u85_INT(test_data: torch.Tensor):
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_round_vgf_FP(test_data: torch.Tensor):
+def test_round_vgf_no_quant(test_data: torch.Tensor):
     pipeline = VgfPipeline[input_t1](
         Round(),
         (test_data(),),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_round_vgf_INT(test_data: torch.Tensor):
+def test_round_vgf_quant(test_data: torch.Tensor):
     pipeline = VgfPipeline[input_t1](
         Round(),
         (test_data(),),
         [],
         exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_rshift.py
+++ b/backends/arm/test/ops/test_rshift.py
@@ -123,26 +123,26 @@ def test_bitwise_right_shift_tensor_u85_INT_scalar(test_data):
 
 @common.parametrize("test_data", RshiftScalar.test_data)
 @common.SkipIfNoModelConverter
-def test_bitwise_right_shift_scalar_vgf_FP_scalar(test_data):
+def test_bitwise_right_shift_tensor_vgf_no_quant_scalar(test_data):
     pipeline = VgfPipeline[scalar_input_t](
         RshiftScalar(),
         test_data(),
         RshiftScalar.torch_op_FP,
         RshiftScalar.exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", RshiftScalar.test_data)
 @common.SkipIfNoModelConverter
-def test_bitwise_right_shift_tensor_vgf_INT_scalar(test_data):
+def test_bitwise_right_shift_tensor_vgf_quant_scalar(test_data):
     pipeline = VgfPipeline[scalar_input_t](
         RshiftScalar(),
         test_data(),
         RshiftScalar.torch_op_INT,
         RshiftScalar.exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 
@@ -202,25 +202,25 @@ def test_bitwise_right_shift_tensor_u85_INT(test_data):
 
 @common.parametrize("test_data", RshiftTensor.test_data)
 @common.SkipIfNoModelConverter
-def test_bitwise_right_shift_tensor_vgf_FP(test_data):
+def test_bitwise_right_shift_tensor_vgf_no_quant(test_data):
     pipeline = VgfPipeline[tensor_input_t](
         RshiftTensor(),
         test_data(),
         RshiftTensor.torch_op,
         RshiftTensor.exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", RshiftTensor.test_data)
 @common.SkipIfNoModelConverter
-def test_bitwise_right_shift_tensor_vgf_INT(test_data):
+def test_bitwise_right_shift_tensor_vgf_quant(test_data):
     pipeline = VgfPipeline[tensor_input_t](
         RshiftTensor(),
         test_data(),
         RshiftTensor.torch_op,
         RshiftTensor.exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_rsqrt.py
+++ b/backends/arm/test/ops/test_rsqrt.py
@@ -85,24 +85,24 @@ def test_rsqrt_u85_INT(test_tensor: torch.Tensor):
 
 @common.parametrize("test_tensor", Rsqrt.test_parameters)
 @common.SkipIfNoModelConverter
-def test_rsqrt_vgf_FP(test_tensor: torch.Tensor):
+def test_rsqrt_vgf_no_quant(test_tensor: torch.Tensor):
     pipeline = VgfPipeline[input_t1](
         Rsqrt(),
         test_tensor(),
         aten_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_tensor", Rsqrt.test_parameters)
 @common.SkipIfNoModelConverter
-def test_rsqrt_vgf_INT(test_tensor: torch.Tensor):
+def test_rsqrt_vgf_quant(test_tensor: torch.Tensor):
     pipeline = VgfPipeline[input_t1](
         Rsqrt(),
         test_tensor(),
         aten_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 

--- a/backends/arm/test/ops/test_rsub.py
+++ b/backends/arm/test/ops/test_rsub.py
@@ -98,29 +98,29 @@ def test_rsub_scalar_u85_INT(test_data):
 
 @common.parametrize("test_data", rsub_test_data)
 @common.SkipIfNoModelConverter
-def test_rsub_scalar_vgf_FP(test_data: Tuple[torch.Tensor]):
+def test_rsub_scalar_vgf_no_quant(test_data: Tuple[torch.Tensor]):
     """Test Subtraction (VGF FP)"""
     pipeline = VgfPipeline[input_t1](
         Rsub(),
         test_data(),
         Rsub.aten_op,
         Rsub.exir_op,
-        tosa_version="TOSA-1.0+FP",
         use_to_edge_transform_and_lower=False,
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", rsub_test_data)
 @common.SkipIfNoModelConverter
-def test_rsub_scalar_vgf_INT(test_data: Tuple[torch.Tensor]):
+def test_rsub_scalar_vgf_quant(test_data: Tuple[torch.Tensor]):
     """Test Subtraction (VGF INT)"""
     pipeline = VgfPipeline[input_t1](
         Rsub(),
         test_data(),
         aten_op="torch.ops.aten.sub.Tensor",
         exir_op=Rsub.exir_op,
-        tosa_version="TOSA-1.0+INT",
         use_to_edge_transform_and_lower=False,
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_scalar_tensor.py
+++ b/backends/arm/test/ops/test_scalar_tensor.py
@@ -104,13 +104,13 @@ def test_scalar_tensor_u85_INT(test_data):
 
 @common.parametrize("test_data", float_test_data_suite)
 @common.SkipIfNoModelConverter
-def test_scalar_tensor_vgf_FP(test_data):
+def test_scalar_tensor_vgf_no_quant(test_data):
     scalar, dtype, data = test_data()
     pipeline = VgfPipeline(
         ScalarTensor(scalar, dtype),
         tuple(data),
         ScalarTensor.aten_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
@@ -120,13 +120,13 @@ def test_scalar_tensor_vgf_FP(test_data):
     int_test_data_suite,
 )
 @common.SkipIfNoModelConverter
-def test_scalar_tensor_vgf_INT(test_data):
+def test_scalar_tensor_vgf_quant(test_data):
     scalar, dtype, data = test_data()
     pipeline = VgfPipeline(
         ScalarTensor(scalar, dtype),
         tuple(data),
         ScalarTensor.aten_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     # Pop the quantization check stage if it exists as no
     # quantization nodes will be present for int + fp inputs.

--- a/backends/arm/test/ops/test_sdpa.py
+++ b/backends/arm/test/ops/test_sdpa.py
@@ -48,22 +48,26 @@ def test_sdpa_tosa_INT():
 
 
 @common.SkipIfNoModelConverter
-def test_sdpa_vgf_FP():
-    test_input = tuple(torch.randn(1, 3, 197, 64) for _ in range(3))
-    pipeline = VgfPipeline[input_t](
-        SDPA(), test_input, [], [], tosa_version="TOSA-1.0+FP"
-    )
-    pipeline.run()
-
-
-@common.SkipIfNoModelConverter
-def test_sdpa_vgf_INT():
+def test_sdpa_vgf_no_quant():
     test_input = tuple(torch.randn(1, 3, 197, 64) for _ in range(3))
     pipeline = VgfPipeline[input_t](
         SDPA(),
         test_input,
         [],
         [],
-        tosa_version="TOSA-1.0+INT",
+        quantize=False,
+    )
+    pipeline.run()
+
+
+@common.SkipIfNoModelConverter
+def test_sdpa_vgf_quant():
+    test_input = tuple(torch.randn(1, 3, 197, 64) for _ in range(3))
+    pipeline = VgfPipeline[input_t](
+        SDPA(),
+        test_input,
+        [],
+        [],
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_select.py
+++ b/backends/arm/test/ops/test_select.py
@@ -169,43 +169,51 @@ def test_select_int_u85_INT(test_data: Tuple):
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_select_int_vgf_FP_copy(test_data: Tuple):
-    pipeline = VgfPipeline[input_t1](
-        SelectCopy(), test_data(), aten_op_copy, [], tosa_version="TOSA-1.0+FP"
-    )
-    pipeline.run()
-
-
-@common.parametrize("test_data", test_data_suite)
-@common.SkipIfNoModelConverter
-def test_select_int_vgf_FP(test_data: Tuple):
-    pipeline = VgfPipeline[input_t1](
-        SelectInt(), test_data(), aten_op_int, [], tosa_version="TOSA-1.0+FP"
-    )
-    pipeline.run()
-
-
-@common.parametrize("test_data", test_data_suite)
-@common.SkipIfNoModelConverter
-def test_select_int_vgf_INT_copy(test_data: Tuple):
+def test_select_int_copy_vgf_no_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         SelectCopy(),
         test_data(),
         aten_op_copy,
         [],
-        tosa_version="TOSA-1.0+INT",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_select_int_vgf_INT(test_data: Tuple):
+def test_select_int_vgf_no_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         SelectInt(),
         test_data(),
         aten_op_int,
         [],
-        tosa_version="TOSA-1.0+INT",
+        quantize=False,
+    )
+    pipeline.run()
+
+
+@common.parametrize("test_data", test_data_suite)
+@common.SkipIfNoModelConverter
+def test_select_int_copy_vgf_quant(test_data: Tuple):
+    pipeline = VgfPipeline[input_t1](
+        SelectCopy(),
+        test_data(),
+        aten_op_copy,
+        [],
+        quantize=True,
+    )
+    pipeline.run()
+
+
+@common.parametrize("test_data", test_data_suite)
+@common.SkipIfNoModelConverter
+def test_select_int_vgf_quant(test_data: Tuple):
+    pipeline = VgfPipeline[input_t1](
+        SelectInt(),
+        test_data(),
+        aten_op_int,
+        [],
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_select_scatter.py
+++ b/backends/arm/test/ops/test_select_scatter.py
@@ -149,25 +149,25 @@ def test_select_scatter_u85_INT(test_module: input_t):
 
 @common.SkipIfNoModelConverter
 @common.parametrize("test_module", test_data_suite)
-def test_select_scatter_vgf_FP(test_module: input_t):
+def test_select_scatter_vgf_no_quant(test_module: input_t):
     pipeline = VgfPipeline[input_t](
         SelectScatter(),
         test_module(),
         aten_op=SelectScatter.fp_aten_op,
         exir_op=SelectScatter.fp_exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.SkipIfNoModelConverter
 @common.parametrize("test_module", test_data_suite)
-def test_select_scatter_vgf_INT(test_module: input_t):
+def test_select_scatter_vgf_quant(test_module: input_t):
     pipeline = VgfPipeline[input_t](
         SelectScatter(),
         test_module(),
         aten_op=SelectScatter.int_aten_ops,
         exir_op=SelectScatter.int_exir_ops,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_sigmoid.py
+++ b/backends/arm/test/ops/test_sigmoid.py
@@ -167,98 +167,98 @@ def test_sigmoid_u85_INT(test_data: Tuple):
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_sigmoid_vgf_FP(test_data: Tuple):
+def test_sigmoid_vgf_no_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         Sigmoid(),
         (test_data(),),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_sigmoid_vgf_INT(test_data: Tuple):
+def test_sigmoid_vgf_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         Sigmoid(),
         (test_data(),),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 
 
 @common.SkipIfNoModelConverter
-def test_sigmoid_vgf_FP_add():
+def test_sigmoid_add_vgf_no_quant():
     pipeline = VgfPipeline[input_t1](
         AddSigmoid(),
         (test_data_suite["zeros"](),),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.SkipIfNoModelConverter
-def test_sigmoid_vgf_INT_add():
+def test_sigmoid_add_vgf_quant():
     pipeline = VgfPipeline[input_t1](
         AddSigmoid(),
         (test_data_suite["ramp"](),),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 
 
 @common.SkipIfNoModelConverter
-def test_sigmoid_vgf_FP_add_2():
+def test_sigmoid_add_2_vgf_no_quant():
     pipeline = VgfPipeline[input_t1](
         SigmoidAdd(),
         (test_data_suite["zeros"](),),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.SkipIfNoModelConverter
-def test_sigmoid_vgf_INT_add_2():
+def test_sigmoid_add_2_vgf_quant():
     pipeline = VgfPipeline[input_t1](
         SigmoidAdd(),
         (test_data_suite["zeros"](),),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 
 
 @common.SkipIfNoModelConverter
-def test_sigmoid_vgf_FP_add_3():
+def test_sigmoid_add_3_vgf_no_quant():
     pipeline = VgfPipeline[input_t1](
         SigmoidAddSigmoid(),
         (test_data_suite["randn_neg"](), test_data_suite["randn_pos"]()),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.SkipIfNoModelConverter
-def test_sigmoid_vgf_INT_add_3():
+def test_sigmoid_add_3_vgf_quant():
     pipeline = VgfPipeline[input_t1](
         SigmoidAddSigmoid(),
         (test_data_suite["randn_neg"](), test_data_suite["randn_pos"]()),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 

--- a/backends/arm/test/ops/test_sign.py
+++ b/backends/arm/test/ops/test_sign.py
@@ -89,25 +89,25 @@ def test_sign_u85_INT(test_data: Tuple):
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_sign_vgf_FP(test_data: Tuple):
+def test_sign_vgf_no_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         Sign(),
         (test_data,),
         aten_op=aten_op,
         exir_op=exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_sign_vgf_INT(test_data: Tuple):
+def test_sign_vgf_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         Sign(),
         (test_data,),
         aten_op=[],
         exir_op=exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_silu.py
+++ b/backends/arm/test/ops/test_silu.py
@@ -124,45 +124,51 @@ def test_silu_u85_INT_inplace(test_data: input_t):
 
 @common.parametrize("test_data", Silu.test_data)
 @common.SkipIfNoModelConverter
-def test_silu_vgf_FP(test_data: input_t):
+def test_silu_vgf_no_quant(test_data: input_t):
     silu_data = (test_data(), False)
     pipeline = VgfPipeline[input_t](
-        Silu(), silu_data, Silu.aten_op_FP, tosa_version="TOSA-1.0+FP"
+        Silu(),
+        silu_data,
+        Silu.aten_op_FP,
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", Silu.test_data)
 @common.SkipIfNoModelConverter
-def test_silu_vgf_FP_inplace(test_data: input_t):
+def test_silu_inplace_vgf_no_quant(test_data: input_t):
     silu_data = (test_data(), True)
     pipeline = VgfPipeline[input_t](
-        Silu(), silu_data, Silu.aten_op_inplace_FP, tosa_version="TOSA-1.0+FP"
+        Silu(),
+        silu_data,
+        Silu.aten_op_inplace_FP,
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", Silu.test_data)
 @common.SkipIfNoModelConverter
-def test_silu_vgf_INT(test_data: input_t):
+def test_silu_vgf_quant(test_data: input_t):
     silu_data = (test_data(), False)
     pipeline = VgfPipeline[input_t](
         Silu(),
         silu_data,
         Silu.aten_op_INT,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", Silu.test_data)
 @common.SkipIfNoModelConverter
-def test_silu_vgf_INT_inplace(test_data: input_t):
+def test_silu_inplace_vgf_quant(test_data: input_t):
     silu_data = (test_data(), True)
     pipeline = VgfPipeline[input_t](
         Silu(),
         silu_data,
         Silu.aten_op_INT,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_sin.py
+++ b/backends/arm/test/ops/test_sin.py
@@ -86,20 +86,23 @@ def test_sin_u85_INT(test_data: Tuple):
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_sin_vgf_FP(test_data: Tuple):
+def test_sin_vgf_no_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
-        Sin(), (test_data,), aten_op, tosa_version="TOSA-1.0+FP"
+        Sin(),
+        (test_data,),
+        aten_op,
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_sin_vgf_INT(test_data: Tuple):
+def test_sin_vgf_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         Sin(),
         (test_data,),
         aten_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_sinh.py
+++ b/backends/arm/test/ops/test_sinh.py
@@ -81,20 +81,23 @@ def test_sinh_u85_INT(test_data: Tuple):
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_sinh_vgf_FP(test_data: Tuple):
+def test_sinh_vgf_no_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
-        Sinh(), (test_data,), aten_op, tosa_version="TOSA-1.0+FP"
+        Sinh(),
+        (test_data,),
+        aten_op,
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_sinh_vgf_INT(test_data: Tuple):
+def test_sinh_vgf_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         Sinh(),
         (test_data,),
         aten_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_slice.py
+++ b/backends/arm/test/ops/test_slice.py
@@ -102,26 +102,26 @@ def test_slice_tensor_u85_INT(test_data: torch.Tensor):
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_slice_tensor_vgf_FP(test_data: torch.Tensor):
+def test_slice_tensor_vgf_no_quant(test_data: torch.Tensor):
     pipeline = VgfPipeline[input_t1](
         Slice(),
         test_data(),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_slice_tensor_vgf_INT(test_data: torch.Tensor):
+def test_slice_tensor_vgf_quant(test_data: torch.Tensor):
     pipeline = VgfPipeline[input_t1](
         Slice(),
         test_data(),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 

--- a/backends/arm/test/ops/test_softmax.py
+++ b/backends/arm/test/ops/test_softmax.py
@@ -91,13 +91,13 @@ def test_softmax_u85_INT(test_data):
 
 @common.parametrize("test_data", Softmax.test_data)
 @common.SkipIfNoModelConverter
-def test_softmax_vgf_FP(test_data):
+def test_softmax_vgf_no_quant(test_data):
     data, dim = test_data()
     pipeline = VgfPipeline[input_t1](
         Softmax(dim),
         data,
         [],
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.add_stage_after(
         "to_edge_transform_and_lower", pipeline.tester.check_not, [exir_op]
@@ -107,13 +107,13 @@ def test_softmax_vgf_FP(test_data):
 
 @common.parametrize("test_data", Softmax.test_data)
 @common.SkipIfNoModelConverter
-def test_softmax_vgf_INT(test_data):
+def test_softmax_vgf_quant(test_data):
     data, dim = test_data()
     pipeline = VgfPipeline[input_t1](
         Softmax(dim),
         data,
         [],
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.add_stage_after("quantize", pipeline.tester.check_not, [aten_op])
     # TODO: MLETORCH-1136 Change args of run_method_and_compare_outputs of the vgf tests

--- a/backends/arm/test/ops/test_split.py
+++ b/backends/arm/test/ops/test_split.py
@@ -168,26 +168,26 @@ def test_split_with_sizes_u85_INT(test_data: input_t1):
     (Split.test_data | Split.test_data_list),
 )
 @common.SkipIfNoModelConverter
-def test_split_with_sizes_vgf_FP(test_data: input_t1):
+def test_split_with_sizes_vgf_no_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         Split(),
         test_data(),
         aten_op=[],
         exir_op=exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", Split.test_data_list)
 @common.SkipIfNoModelConverter
-def test_split_with_sizes_vgf_FP_2(test_data: input_t1):
+def test_split_with_sizes_2_vgf_no_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         SplitWithSizes(),
         test_data(),
         aten_op=[],
         exir_op=exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
@@ -197,13 +197,13 @@ def test_split_with_sizes_vgf_FP_2(test_data: input_t1):
     (Split.test_data | Split.test_data_list),
 )
 @common.SkipIfNoModelConverter
-def test_split_with_sizes_vgf_FP_one_out(test_data: input_t1):
+def test_split_with_sizes_one_out_vgf_no_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         SplitSingleOut(),
         test_data(),
         aten_op=[],
         exir_op=exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
@@ -213,13 +213,13 @@ def test_split_with_sizes_vgf_FP_one_out(test_data: input_t1):
     (Split.test_data | Split.test_data_list),
 )
 @common.SkipIfNoModelConverter
-def test_split_with_sizes_vgf_FP_two_out(test_data: input_t1):
+def test_split_with_sizes_two_out_vgf_no_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         SplitTwoOut(),
         test_data(),
         aten_op=[],
         exir_op=exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
@@ -229,13 +229,13 @@ def test_split_with_sizes_vgf_FP_two_out(test_data: input_t1):
     (Split.test_data | Split.test_data_list),
 )
 @common.SkipIfNoModelConverter
-def test_split_with_sizes_vgf_INT(test_data: input_t1):
+def test_split_with_sizes_vgf_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         Split(),
         test_data(),
         aten_op=[],
         exir_op=exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 
@@ -288,25 +288,25 @@ def test_split_tensor_u85_INT(test_data: Tuple):
 
 @common.parametrize("test_data", Split.test_data)
 @common.SkipIfNoModelConverter
-def test_split_tensor_vgf_FP(test_data: Tuple):
+def test_split_tensor_vgf_no_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         SplitCopy(),
         test_data(),
         aten_op=SplitCopy.aten_op,
         exir_op=SplitCopy.exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", Split.test_data)
 @common.SkipIfNoModelConverter
-def test_split_tensor_vgf_INT(test_data: Tuple):
+def test_split_tensor_vgf_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         SplitCopy(),
         test_data(),
         aten_op=SplitCopy.aten_op,
         exir_op=SplitCopy.exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_sqrt.py
+++ b/backends/arm/test/ops/test_sqrt.py
@@ -88,25 +88,25 @@ def test_sqrt_u85_INT(test_data: Sqrt.input_t):
 
 @common.parametrize("test_data", Sqrt.test_data)
 @common.SkipIfNoModelConverter
-def test_sqrt_vgf_FP(test_data: Sqrt.input_t):
+def test_sqrt_vgf_no_quant(test_data: Sqrt.input_t):
     pipeline = VgfPipeline[Sqrt.input_t](
         Sqrt(),
         test_data(),
         Sqrt.aten_op_FP,
         Sqrt.exir_op_FP,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", Sqrt.test_data)
 @common.SkipIfNoModelConverter
-def test_sqrt_vgf_INT(test_data: Sqrt.input_t):
+def test_sqrt_vgf_quant(test_data: Sqrt.input_t):
     pipeline = VgfPipeline[Sqrt.input_t](
         Sqrt(),
         test_data(),
         Sqrt.aten_op_INT,
         Sqrt.exir_op_INT,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_squeeze.py
+++ b/backends/arm/test/ops/test_squeeze.py
@@ -113,26 +113,26 @@ def test_squeeze_dim_u85_INT(test_data: Tuple):
 
 @common.parametrize("test_data", Squeeze.test_parameters)
 @common.SkipIfNoModelConverter
-def test_squeeze_dim_vgf_FP(test_data: Tuple):
+def test_squeeze_dim_vgf_no_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         Squeeze(),
         test_data(),
         "torch.ops.aten.squeeze.default",
         [],
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", Squeeze.test_parameters)
 @common.SkipIfNoModelConverter
-def test_squeeze_dim_vgf_INT(test_data: Tuple):
+def test_squeeze_dim_vgf_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         Squeeze(),
         test_data(),
         "torch.ops.aten.squeeze.default",
         [],
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 
@@ -190,26 +190,26 @@ def test_squeeze_dim_u85_INT_2(test_data: Tuple):
 
 @common.parametrize("test_data", SqueezeDim.test_parameters)
 @common.SkipIfNoModelConverter
-def test_squeeze_dim_vgf_FP_2(test_data: Tuple):
+def test_squeeze_dim_2_vgf_no_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         SqueezeDim(),
         test_data(),
         "torch.ops.aten.squeeze.dim",
         [],
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", SqueezeDim.test_parameters)
 @common.SkipIfNoModelConverter
-def test_squeeze_dim_vgf_INT_2(test_data: Tuple):
+def test_squeeze_dim_2_vgf_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         SqueezeDim(),
         test_data(),
         "torch.ops.aten.squeeze.dim",
         [],
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 
@@ -267,25 +267,25 @@ def test_squeeze_dims_u85_INT(test_data: Tuple):
 
 @common.parametrize("test_data", SqueezeDims.test_parameters)
 @common.SkipIfNoModelConverter
-def test_squeeze_dims_vgf_FP(test_data: Tuple):
+def test_squeeze_dims_vgf_no_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         SqueezeDims(),
         test_data(),
         "torch.ops.aten.squeeze.dims",
         [],
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", SqueezeDims.test_parameters)
 @common.SkipIfNoModelConverter
-def test_squeeze_dims_vgf_INT(test_data: Tuple):
+def test_squeeze_dims_vgf_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         SqueezeDims(),
         test_data(),
         "torch.ops.aten.squeeze.dims",
         [],
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_stack.py
+++ b/backends/arm/test/ops/test_stack.py
@@ -122,29 +122,29 @@ def test_stack_u85_INT(test_module: input_t1):
 
 @common.SkipIfNoModelConverter
 @common.parametrize("test_module", test_data_suite)
-def test_stack_vgf_FP(test_module: input_t1):
+def test_stack_vgf_no_quant(test_module: input_t1):
     test_data = test_module()
     pipeline = VgfPipeline[input_t1](
         Stack(),
         test_data,
         aten_op=Stack.aten_op,
         exir_op=Stack.exir_op,
-        tosa_version="TOSA-1.0+FP",
         use_to_edge_transform_and_lower=False,
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.SkipIfNoModelConverter
 @common.parametrize("test_module", test_data_suite)
-def test_stack_vgf_INT(test_module: input_t1):
+def test_stack_vgf_quant(test_module: input_t1):
     test_data = test_module()
     pipeline = VgfPipeline[input_t1](
         Stack(),
         test_data,
         aten_op=Stack.aten_op,
         exir_op=Stack.exir_op,
-        tosa_version="TOSA-1.0+INT",
         use_to_edge_transform_and_lower=False,
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_sub.py
+++ b/backends/arm/test/ops/test_sub.py
@@ -219,56 +219,56 @@ def test_sub_tensor_u85_INT(test_data: Tuple[torch.Tensor, torch.Tensor]):
 
 @common.parametrize("test_data", sub_test_data)
 @common.SkipIfNoModelConverter
-def test_sub_tensor_vgf_FP(test_data: Tuple[torch.Tensor]):
+def test_sub_tensor_vgf_no_quant(test_data: Tuple[torch.Tensor]):
     """Test Subtraction (VGF FP)"""
     pipeline = VgfPipeline[input_t1](
         Sub(),
         test_data(),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", sub2_test_data)
 @common.SkipIfNoModelConverter
-def test_sub_tensor_vgf_FP_2(test_data: Tuple[torch.Tensor, torch.Tensor]):
+def test_sub_tensor_2_vgf_no_quant(test_data: Tuple[torch.Tensor, torch.Tensor]):
     """Test Two-Operand Subtraction (VGF FP)"""
     pipeline = VgfPipeline[input_t2](
         Sub2(),
         test_data(),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", sub_test_data)
 @common.SkipIfNoModelConverter
-def test_sub_tensor_vgf_INT(test_data: Tuple[torch.Tensor]):
+def test_sub_tensor_vgf_quant(test_data: Tuple[torch.Tensor]):
     """Test Subtraction (VGF INT)"""
     pipeline = VgfPipeline[input_t1](
         Sub(),
         test_data(),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", sub2_test_data)
 @common.SkipIfNoModelConverter
-def test_sub_tensor_vgf_INT_2(test_data: Tuple[torch.Tensor, torch.Tensor]):
+def test_sub_tensor_2_vgf_quant(test_data: Tuple[torch.Tensor, torch.Tensor]):
     """Test Two-Operand Subtraction (VGF INT)"""
     pipeline = VgfPipeline[input_t2](
         Sub2(),
         test_data(),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 

--- a/backends/arm/test/ops/test_sum.py
+++ b/backends/arm/test/ops/test_sum.py
@@ -90,26 +90,26 @@ def test_view_u85_INT_1_0(test_data: Tuple):
 
 @common.parametrize("test_data", Sum.test_parameters)
 @common.SkipIfNoModelConverter
-def test_sum_dim_intlist_vgf_FP(test_data: input_t1):
+def test_sum_dim_intlist_vgf_no_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         Sum(),
         test_data(),
         aten_op,
-        tosa_version="TOSA-1.0+FP",
         run_on_vulkan_runtime=True,
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", Sum.test_parameters)
 @common.SkipIfNoModelConverter
-def test_sum_dim_intlist_vgf_INT(test_data: input_t1):
+def test_sum_dim_intlist_vgf_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         Sum(),
         test_data(),
         aten_op,
-        tosa_version="TOSA-1.0+INT",
         run_on_vulkan_runtime=True,
+        quantize=True,
     )
     pipeline.run()
 

--- a/backends/arm/test/ops/test_t_copy.py
+++ b/backends/arm/test/ops/test_t_copy.py
@@ -89,27 +89,27 @@ def test_t_u85_INT(test_data: Tuple):
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_t_vgf_FP(test_data: Tuple):
+def test_t_vgf_no_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         TCopy(),
         test_data(),
         aten_op=TCopy.aten_op,
         exir_op=TCopy.exir_op,
-        tosa_version="TOSA-1.0+FP",
         use_to_edge_transform_and_lower=False,
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_t_vgf_INT(test_data: Tuple):
+def test_t_vgf_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         TCopy(),
         test_data(),
         aten_op=TCopy.aten_op,
         exir_op=TCopy.exir_op,
-        tosa_version="TOSA-1.0+INT",
         use_to_edge_transform_and_lower=False,
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_tanh.py
+++ b/backends/arm/test/ops/test_tanh.py
@@ -89,21 +89,24 @@ def test_tanh_u85_INT(test_data: Tuple):
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_tanh_vgf_FP(test_data: Tuple):
+def test_tanh_vgf_no_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
-        Tanh(), (test_data(),), aten_op, tosa_version="TOSA-1.0+FP"
+        Tanh(),
+        (test_data(),),
+        aten_op,
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_tanh_vgf_INT(test_data: Tuple):
+def test_tanh_vgf_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         Tanh(),
         (test_data(),),
         aten_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 

--- a/backends/arm/test/ops/test_to_copy.py
+++ b/backends/arm/test/ops/test_to_copy.py
@@ -95,24 +95,15 @@ def test_to_tosa_FP(test_data: Tuple):
 
 @common.parametrize("test_data", _TO_COPY_TEST_DATA_FP)
 @common.SkipIfNoModelConverter
-def test_to_vgf_FP(test_data: Tuple):
+def test_to_vgf_no_quant(test_data: Tuple):
     test_tensor, new_dtype = test_data()
     pipeline = VgfPipeline[input_t1](
         Cast(new_dtype),
         (test_tensor,),
         aten_op=[],
         exir_op=[],
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
-    # int to int cast is not supported in TOSA+FP profile
-    if not new_dtype.is_floating_point and not torch.is_floating_point(test_tensor):
-        pipeline.change_args(
-            "check_count.exir",
-            {
-                "torch.ops.higher_order.executorch_call_delegate": 0,
-                "executorch_exir_dialects_edge__ops_dim_order_ops__to_dim_order_copy_default": 1,
-            },
-        )
     pipeline.run()
 
 
@@ -164,7 +155,7 @@ def test_to_tosa_INT_not_delegated(test_data: Tuple):
 
 @common.parametrize("test_data", _TO_COPY_TEST_DATA_INT)
 @common.SkipIfNoModelConverter
-def test_to_vgf_INT(test_data: Tuple):
+def test_to_vgf_quant(test_data: Tuple):
     # Op not supported
     pass
 

--- a/backends/arm/test/ops/test_transpose_copy.py
+++ b/backends/arm/test/ops/test_transpose_copy.py
@@ -88,27 +88,27 @@ def test_transpose_int_u85_INT(test_data: Tuple):
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_transpose_int_vgf_FP(test_data: Tuple):
+def test_transpose_int_vgf_no_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         TransposeCopy(),
         test_data(),
         aten_op=TransposeCopy.aten_op,
         exir_op=TransposeCopy.exir_op,
-        tosa_version="TOSA-1.0+FP",
         use_to_edge_transform_and_lower=False,
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_transpose_int_vgf_INT(test_data: Tuple):
+def test_transpose_int_vgf_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         TransposeCopy(),
         test_data(),
         aten_op=TransposeCopy.aten_op,
         exir_op=TransposeCopy.exir_op,
-        tosa_version="TOSA-1.0+INT",
         use_to_edge_transform_and_lower=False,
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_unary_combos.py
+++ b/backends/arm/test/ops/test_unary_combos.py
@@ -132,9 +132,13 @@ def test_unary_combos_u85_INT(model_cls):
 
 @common.SkipIfNoModelConverter
 @pytest.mark.parametrize("model_cls", MODELS, ids=lambda c: c.__name__)
-def test_unary_combos_vgf_INT(model_cls):
+def test_unary_combos_vgf_quant(model_cls):
     m, inputs, exir = _build(model_cls)
     p = VgfPipeline[Tensor1](
-        m, inputs, aten_op=[], exir_op=exir, tosa_version="TOSA-1.0+INT"
+        m,
+        inputs,
+        aten_op=[],
+        exir_op=exir,
+        quantize=True,
     )
     p.run()

--- a/backends/arm/test/ops/test_unbind.py
+++ b/backends/arm/test/ops/test_unbind.py
@@ -58,25 +58,25 @@ def test_unbind_int_tosa_INT(test_data: test_data_t):
 
 @common.parametrize("test_data", Unbind.test_data)
 @common.SkipIfNoModelConverter
-def test_unbind_int_vgf_FP(test_data: test_data_t):
+def test_unbind_int_vgf_no_quant(test_data: test_data_t):
     input_data, init_data = test_data
     pipeline = VgfPipeline[input_t](
         Unbind(*init_data),
         input_data(),
         Unbind.aten_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", Unbind.test_data)
 @common.SkipIfNoModelConverter
-def test_unbind_int_vgf_INT(test_data: test_data_t):
+def test_unbind_int_vgf_quant(test_data: test_data_t):
     input_data, init_data = test_data
     pipeline = VgfPipeline[input_t](
         Unbind(*init_data),
         input_data(),
         Unbind.aten_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_unflatten.py
+++ b/backends/arm/test/ops/test_unflatten.py
@@ -83,25 +83,25 @@ def test_unflatten_int_u85_INT(test_data: test_data_t):
 
 @common.parametrize("test_data", Unflatten.test_data)
 @common.SkipIfNoModelConverter
-def test_unflatten_int_vgf_FP(test_data: test_data_t):
+def test_unflatten_int_vgf_no_quant(test_data: test_data_t):
     module, inputs = test_data()
     pipeline = VgfPipeline[input_t](
         module,
         inputs,
         Unflatten.aten_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", Unflatten.test_data)
 @common.SkipIfNoModelConverter
-def test_unflatten_int_vgf_INT(test_data: test_data_t):
+def test_unflatten_int_vgf_quant(test_data: test_data_t):
     module, inputs = test_data()
     pipeline = VgfPipeline[input_t](
         module,
         inputs,
         Unflatten.aten_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_unsqueeze.py
+++ b/backends/arm/test/ops/test_unsqueeze.py
@@ -83,22 +83,25 @@ def test_unsqueeze_u85_INT(test_tensor: torch.Tensor):
 
 @common.parametrize("test_tensor", Unsqueeze.test_parameters)
 @common.SkipIfNoModelConverter
-def test_unsqueeze_vgf_FP(test_tensor: torch.Tensor):
+def test_unsqueeze_vgf_no_quant(test_tensor: torch.Tensor):
     for i in range(-test_tensor[0].dim() - 1, test_tensor[0].dim() + 1):
         pipeline = VgfPipeline[input_t1](
-            Unsqueeze(), (*test_tensor, i), aten_op, tosa_version="TOSA-1.0+FP"
+            Unsqueeze(),
+            (*test_tensor, i),
+            aten_op,
+            quantize=False,
         )
         pipeline.run()
 
 
 @common.parametrize("test_tensor", Unsqueeze.test_parameters)
 @common.SkipIfNoModelConverter
-def test_unsqueeze_vgf_INT(test_tensor: torch.Tensor):
+def test_unsqueeze_vgf_quant(test_tensor: torch.Tensor):
     for i in range(-test_tensor[0].dim() - 1, test_tensor[0].dim() + 1):
         pipeline = VgfPipeline[input_t1](
             Unsqueeze(),
             (*test_tensor, i),
             aten_op,
-            tosa_version="TOSA-1.0+INT",
+            quantize=True,
         )
         pipeline.run()

--- a/backends/arm/test/ops/test_upsample_bilinear2d.py
+++ b/backends/arm/test/ops/test_upsample_bilinear2d.py
@@ -345,14 +345,16 @@ def test_upsample_bilinear2d_vec_U85_INT_a16w8(
 
 @common.parametrize("test_data", test_data_suite_tosa)
 @common.SkipIfNoModelConverter
-def test_upsample_bilinear2d_vgf_FP_UpsamplingBilinear2d(test_data: torch.Tensor):
+def test_upsample_bilinear2d_UpsamplingBilinear2d_vgf_no_quant(
+    test_data: torch.Tensor,
+):
     data, size, scale_factor, compare = test_data
     pipeline = VgfPipeline[input_t1](
         UpsamplingBilinear2d(size, scale_factor),
         (data,),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     if not compare:
         pipeline.pop_stage(-1)
@@ -361,14 +363,14 @@ def test_upsample_bilinear2d_vgf_FP_UpsamplingBilinear2d(test_data: torch.Tensor
 
 @common.parametrize("test_data", test_data_suite_tosa)
 @common.SkipIfNoModelConverter
-def test_upsample_bilinear2d_vgf_FP_Upsample(test_data: torch.Tensor):
+def test_upsample_bilinear2d_Upsample_vgf_no_quant(test_data: torch.Tensor):
     data, size, scale_factor, compare = test_data
     pipeline = VgfPipeline[input_t1](
         Upsample(size, scale_factor),
         (data,),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     if not compare:
         pipeline.pop_stage(-1)
@@ -377,14 +379,14 @@ def test_upsample_bilinear2d_vgf_FP_Upsample(test_data: torch.Tensor):
 
 @common.parametrize("test_data", test_data_suite_tosa)
 @common.SkipIfNoModelConverter
-def test_upsample_bilinear2d_vgf_FP_Interpolate(test_data: torch.Tensor):
+def test_upsample_bilinear2d_Interpolate_vgf_no_quant(test_data: torch.Tensor):
     data, size, scale_factor, compare = test_data
     pipeline = VgfPipeline[input_t1](
         Interpolate(size, scale_factor),
         (data,),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     if not compare:
         pipeline.pop_stage(-1)
@@ -393,14 +395,16 @@ def test_upsample_bilinear2d_vgf_FP_Interpolate(test_data: torch.Tensor):
 
 @common.parametrize("test_data", test_data_suite_tosa)
 @common.SkipIfNoModelConverter
-def test_upsample_bilinear2d_vgf_INT_UpsamplingBilinear2d(test_data: torch.Tensor):
+def test_upsample_bilinear2d_UpsamplingBilinear2d_vgf_quant(
+    test_data: torch.Tensor,
+):
     data, size, scale_factor, compare = test_data
     pipeline = VgfPipeline[input_t1](
         UpsamplingBilinear2d(size, scale_factor),
         (data,),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     if not compare:
         pipeline.pop_stage(-1)
@@ -409,14 +413,14 @@ def test_upsample_bilinear2d_vgf_INT_UpsamplingBilinear2d(test_data: torch.Tenso
 
 @common.parametrize("test_data", test_data_suite_tosa)
 @common.SkipIfNoModelConverter
-def test_upsample_bilinear2d_vgf_INT_Upsample(test_data: torch.Tensor):
+def test_upsample_bilinear2d_Upsample_vgf_quant(test_data: torch.Tensor):
     data, size, scale_factor, compare = test_data
     pipeline = VgfPipeline[input_t1](
         Upsample(size, scale_factor),
         (data,),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     if not compare:
         pipeline.pop_stage(-1)
@@ -425,14 +429,14 @@ def test_upsample_bilinear2d_vgf_INT_Upsample(test_data: torch.Tensor):
 
 @common.parametrize("test_data", test_data_suite_tosa)
 @common.SkipIfNoModelConverter
-def test_upsample_bilinear2d_vgf_INT_Interpolate(test_data: torch.Tensor):
+def test_upsample_bilinear2d_Interpolate_vgf_quant(test_data: torch.Tensor):
     data, size, scale_factor, compare = test_data
     pipeline = VgfPipeline[input_t1](
         Interpolate(size, scale_factor),
         (data,),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     if not compare:
         pipeline.pop_stage(-1)

--- a/backends/arm/test/ops/test_upsample_nearest2d.py
+++ b/backends/arm/test/ops/test_upsample_nearest2d.py
@@ -245,7 +245,7 @@ def test_upsample_nearest2d_nearest_vgf_no_quant(test_data: torch.Tensor):
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_upsample_nearest2d_interpolate_vgf_no_quant(test_data: torch.Tensor):
+def test_upsample_nearest2d_interpolate_vgf_FP(test_data: torch.Tensor):
     data, size, scale_factor, compare = test_data()
     pipeline = VgfPipeline[input_t1](
         Interpolate(size, scale_factor),
@@ -253,6 +253,8 @@ def test_upsample_nearest2d_interpolate_vgf_no_quant(test_data: torch.Tensor):
         aten_op,
         exir_op,
         quantize=False,
+        # Override tosa version to test FP-only path
+        tosa_version="TOSA-1.0+FP",
     )
     if not compare:
         pipeline.pop_stage(-1)
@@ -293,7 +295,7 @@ def test_upsample_nearest2d_nearest_vgf_quant(test_data: torch.Tensor):
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_upsample_nearest2d_interpolate_vgf_quant(test_data: torch.Tensor):
+def test_upsample_nearest2d_interpolate_vgf_INT(test_data: torch.Tensor):
     data, size, scale_factor, compare = test_data()
     pipeline = VgfPipeline[input_t1](
         Interpolate(size, scale_factor),
@@ -301,6 +303,8 @@ def test_upsample_nearest2d_interpolate_vgf_quant(test_data: torch.Tensor):
         aten_op,
         exir_op,
         quantize=True,
+        # Override tosa version to test INT-only path
+        tosa_version="TOSA-1.0+INT",
     )
     if not compare:
         pipeline.pop_stage(-1)

--- a/backends/arm/test/ops/test_upsample_nearest2d.py
+++ b/backends/arm/test/ops/test_upsample_nearest2d.py
@@ -213,14 +213,14 @@ def test_upsample_nearest2d_vec_tosa_INT_a16w8(test_data: torch.Tensor):
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_upsample_nearest2d_vgf_FP(test_data: torch.Tensor):
+def test_upsample_nearest2d_vgf_no_quant(test_data: torch.Tensor):
     data, size, scale_factor, compare = test_data()
     pipeline = VgfPipeline[input_t1](
         UpsamplingNearest2d(size, scale_factor),
         (data,),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     if not compare:
         pipeline.pop_stage(-1)
@@ -229,14 +229,14 @@ def test_upsample_nearest2d_vgf_FP(test_data: torch.Tensor):
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_upsample_nearest2d_vgf_FP_nearest(test_data: torch.Tensor):
+def test_upsample_nearest2d_nearest_vgf_no_quant(test_data: torch.Tensor):
     data, size, scale_factor, compare = test_data()
     pipeline = VgfPipeline[input_t1](
         Upsample(size, scale_factor),
         (data,),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     if not compare:
         pipeline.pop_stage(-1)
@@ -245,14 +245,14 @@ def test_upsample_nearest2d_vgf_FP_nearest(test_data: torch.Tensor):
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_upsample_nearest2d_vgf_FP_interpolate(test_data: torch.Tensor):
+def test_upsample_nearest2d_interpolate_vgf_no_quant(test_data: torch.Tensor):
     data, size, scale_factor, compare = test_data()
     pipeline = VgfPipeline[input_t1](
         Interpolate(size, scale_factor),
         (data,),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     if not compare:
         pipeline.pop_stage(-1)
@@ -261,14 +261,14 @@ def test_upsample_nearest2d_vgf_FP_interpolate(test_data: torch.Tensor):
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_upsample_nearest2d_vgf_INT(test_data: torch.Tensor):
+def test_upsample_nearest2d_vgf_quant(test_data: torch.Tensor):
     data, size, scale_factor, compare = test_data()
     pipeline = VgfPipeline[input_t1](
         UpsamplingNearest2d(size, scale_factor),
         (data,),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     if not compare:
         pipeline.pop_stage(-1)
@@ -277,14 +277,14 @@ def test_upsample_nearest2d_vgf_INT(test_data: torch.Tensor):
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_upsample_nearest2d_vgf_INT_nearest(test_data: torch.Tensor):
+def test_upsample_nearest2d_nearest_vgf_quant(test_data: torch.Tensor):
     data, size, scale_factor, compare = test_data()
     pipeline = VgfPipeline[input_t1](
         Upsample(size, scale_factor),
         (data,),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     if not compare:
         pipeline.pop_stage(-1)
@@ -293,14 +293,14 @@ def test_upsample_nearest2d_vgf_INT_nearest(test_data: torch.Tensor):
 
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
-def test_upsample_nearest2d_vgf_INT_interpolate(test_data: torch.Tensor):
+def test_upsample_nearest2d_interpolate_vgf_quant(test_data: torch.Tensor):
     data, size, scale_factor, compare = test_data()
     pipeline = VgfPipeline[input_t1](
         Interpolate(size, scale_factor),
         (data,),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     if not compare:
         pipeline.pop_stage(-1)

--- a/backends/arm/test/ops/test_var.py
+++ b/backends/arm/test/ops/test_var.py
@@ -213,24 +213,28 @@ def test_var_dim_u85_INT_no_dim(test_data: Tuple):
 
 @common.parametrize("test_data", Var.test_parameters)
 @common.SkipIfNoModelConverter
-def test_var_dim_vgf_FP_no_dim(test_data: Tuple):
-    data, keepdim, correction = test_data()
-    pipeline = VgfPipeline[input_t1](
-        Var(keepdim, correction), (data,), [], [], tosa_version="TOSA-1.0+FP"
-    )
-    pipeline.run()
-
-
-@common.parametrize("test_data", Var.test_parameters)
-@common.SkipIfNoModelConverter
-def test_var_dim_vgf_INT_no_dim(test_data: Tuple):
+def test_var_dim_no_dim_vgf_no_quant(test_data: Tuple):
     data, keepdim, correction = test_data()
     pipeline = VgfPipeline[input_t1](
         Var(keepdim, correction),
         (data,),
         [],
         [],
-        tosa_version="TOSA-1.0+INT",
+        quantize=False,
+    )
+    pipeline.run()
+
+
+@common.parametrize("test_data", Var.test_parameters)
+@common.SkipIfNoModelConverter
+def test_var_dim_no_dim_vgf_quant(test_data: Tuple):
+    data, keepdim, correction = test_data()
+    pipeline = VgfPipeline[input_t1](
+        Var(keepdim, correction),
+        (data,),
+        [],
+        [],
+        quantize=True,
     )
     pipeline.run()
 
@@ -293,24 +297,28 @@ def test_var_dim_u85_INT(test_data: Tuple):
 
 @common.parametrize("test_data", VarDim.test_parameters)
 @common.SkipIfNoModelConverter
-def test_var_dim_vgf_FP(test_data: Tuple):
-    data, dim, keepdim, unbiased = test_data()
-    pipeline = VgfPipeline[input_t1](
-        VarDim(dim, keepdim, unbiased), (data,), [], [], tosa_version="TOSA-1.0+FP"
-    )
-    pipeline.run()
-
-
-@common.parametrize("test_data", VarDim.test_parameters)
-@common.SkipIfNoModelConverter
-def test_var_dim_vgf_INT(test_data: Tuple):
+def test_var_dim_vgf_no_quant(test_data: Tuple):
     data, dim, keepdim, unbiased = test_data()
     pipeline = VgfPipeline[input_t1](
         VarDim(dim, keepdim, unbiased),
         (data,),
         [],
         [],
-        tosa_version="TOSA-1.0+INT",
+        quantize=False,
+    )
+    pipeline.run()
+
+
+@common.parametrize("test_data", VarDim.test_parameters)
+@common.SkipIfNoModelConverter
+def test_var_dim_vgf_quant(test_data: Tuple):
+    data, dim, keepdim, unbiased = test_data()
+    pipeline = VgfPipeline[input_t1](
+        VarDim(dim, keepdim, unbiased),
+        (data,),
+        [],
+        [],
+        quantize=True,
     )
     pipeline.run()
 
@@ -382,23 +390,27 @@ def test_var_dim_u85_INT_correction(test_data: Tuple):
 
 @common.parametrize("test_data", VarCorrection.test_parameters)
 @common.SkipIfNoModelConverter
-def test_var_dim_vgf_FP_correction(test_data: Tuple):
-    data, dim, keepdim, corr = test_data()
-    pipeline = VgfPipeline[input_t1](
-        VarCorrection(dim, keepdim, corr), (data,), [], [], tosa_version="TOSA-1.0+FP"
-    )
-    pipeline.run()
-
-
-@common.parametrize("test_data", VarCorrection.test_parameters)
-@common.SkipIfNoModelConverter
-def test_var_dim_vgf_INT_correction(test_data: Tuple):
+def test_var_dim_correction_vgf_no_quant(test_data: Tuple):
     data, dim, keepdim, corr = test_data()
     pipeline = VgfPipeline[input_t1](
         VarCorrection(dim, keepdim, corr),
         (data,),
         [],
         [],
-        tosa_version="TOSA-1.0+INT",
+        quantize=False,
+    )
+    pipeline.run()
+
+
+@common.parametrize("test_data", VarCorrection.test_parameters)
+@common.SkipIfNoModelConverter
+def test_var_dim_correction_vgf_quant(test_data: Tuple):
+    data, dim, keepdim, corr = test_data()
+    pipeline = VgfPipeline[input_t1](
+        VarCorrection(dim, keepdim, corr),
+        (data,),
+        [],
+        [],
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_view.py
+++ b/backends/arm/test/ops/test_view.py
@@ -107,26 +107,26 @@ def test_view_u55_INT(test_data: Tuple):
 
 @common.parametrize("test_data", View.needs_transpose_tests)
 @common.SkipIfNoModelConverter
-def test_view_vgf_FP(test_data: Tuple):
+def test_view_vgf_no_quant(test_data: Tuple):
     test_tensor, new_shape = test_data()
     pipeline = VgfPipeline[input_t1](
         View(new_shape),
         (test_tensor,),
         aten_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_data", View.needs_transpose_tests)
 @common.SkipIfNoModelConverter
-def test_view_vgf_INT(test_data: Tuple):
+def test_view_vgf_quant(test_data: Tuple):
     test_tensor, new_shape = test_data()
     pipeline = VgfPipeline[input_t1](
         View(new_shape),
         (test_tensor,),
         aten_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()
 

--- a/backends/arm/test/ops/test_where.py
+++ b/backends/arm/test/ops/test_where.py
@@ -261,25 +261,25 @@ def test_where_self_u85_INT(test_module):
 
 @common.parametrize("test_module", test_modules_FP)
 @common.SkipIfNoModelConverter
-def test_where_self_vgf_FP(test_module):
+def test_where_self_vgf_no_quant(test_module):
     pipeline = VgfPipeline[input_t](
         test_module(),
         test_module().get_inputs(),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+FP",
+        quantize=False,
     )
     pipeline.run()
 
 
 @common.parametrize("test_module", test_modules_INT)
 @common.SkipIfNoModelConverter
-def test_where_self_vgf_INT(test_module):
+def test_where_self_vgf_quant(test_module):
     pipeline = VgfPipeline[input_t](
         test_module(),
         test_module().get_inputs(),
         aten_op,
         exir_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_zeros.py
+++ b/backends/arm/test/ops/test_zeros.py
@@ -127,10 +127,13 @@ def test_zeros_tosa_INT_not_delegated(test_data: test_data_t):
     ZerosAdd.test_data,
 )
 @common.SkipIfNoModelConverter
-def test_zeros_vgf_FP(test_data: test_data_t):
+def test_zeros_vgf_no_quant(test_data: test_data_t):
     input_data, init_data = test_data
     pipeline = VgfPipeline[input_t](
-        ZerosAdd(*init_data), input_data(), ZerosAdd.aten_op, tosa_version="TOSA-1.0+FP"
+        ZerosAdd(*init_data),
+        input_data(),
+        ZerosAdd.aten_op,
+        quantize=False,
     )
     pipeline.run()
 
@@ -140,13 +143,13 @@ def test_zeros_vgf_FP(test_data: test_data_t):
     ZerosAdd.test_data,
 )
 @common.SkipIfNoModelConverter
-def test_zeros_vgf_INT(test_data: test_data_t):
+def test_zeros_vgf_quant(test_data: test_data_t):
     input_data, init_data = test_data
     pipeline = VgfPipeline[input_t](
         ZerosAdd(*init_data),
         input_data(),
         ZerosAdd.aten_op,
-        tosa_version="TOSA-1.0+INT",
+        quantize=True,
     )
     # Pop the quantization check stage if it exists as no
     # quantization nodes will be present for int + fp inputs.

--- a/backends/arm/test/tester/test_pipeline.py
+++ b/backends/arm/test/tester/test_pipeline.py
@@ -1088,7 +1088,7 @@ class VgfPipeline(BasePipelineMaker, Generic[T]):
             transform_passes=transform_passes,
         )
 
-        if quantize and tosa_spec.support_integer():
+        if quantize:
             quantizer = VgfQuantizer(compile_spec)
             quantization_config = get_symmetric_quantization_config(
                 is_per_channel=per_channel_quantization


### PR DESCRIPTION
### Summary
Updates the remaining vgf op tests to use the quantize flag to VgfTestPipeline
instead of passing a tosa_version. Also adds a few vgf tests where we override
the default INT+FP TOSA specification to test INT or FP only lowering to vgf.


cc @freddan80 @per @zingo @digantdesai