### PR TITLE
Remove unused exception parameter from executorch/backends/vulkan/test/custom_ops/utils.cpp

### DIFF
--- a/backends/vulkan/test/custom_ops/utils.cpp
+++ b/backends/vulkan/test/custom_ops/utils.cpp
@@ -1288,7 +1288,7 @@ TestResult execute_test_cases(
     try {
       result = execute_test_case(test_case, warmup_runs, benchmark_runs);
       result.set_operator_name(test_case.operator_name());
-    } catch (const vkcompute::vkapi::ShaderNotSupportedError& e) {
+    } catch (const vkcompute::vkapi::ShaderNotSupportedError&) {
       result = BenchmarkResult(
           test_case.name().empty() ? "unnamed_test_case" : test_case.name(),
           test_case.operator_name());


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Reviewed By: dtolnay

Differential Revision: D89014357




cc @SS-JIA @digantdesai @cbilgin