### PR TITLE
Cover tokenizer build when running install_executorch.sh --clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,4 +194,6 @@ gemma3-cpu:
 	@echo "  Binary: cmake-out/examples/models/gemma3/gemma3_e2e_runner"
 
 clean:
-	rm -rf cmake-out
+	rm -rf cmake-out \
+	       extension/llm/tokenizers/build \
+	       extension/llm/tokenizers/pytorch_tokenizers.egg-info

--- a/install_executorch.py
+++ b/install_executorch.py
@@ -54,6 +54,16 @@ def clean():
     print("Cleaning buck cached state and metadata ...")
     shutil.rmtree(os.path.expanduser("~/.buck/buckd"), ignore_errors=True)
 
+    # tokenizers build cleanup
+    tokenizer_dirs = [
+        "extension/llm/tokenizers/build",
+        "extension/llm/tokenizers/pytorch_tokenizers.egg-info",
+    ]
+
+    for d in tokenizer_dirs:
+        print(f"Cleaning {d}...")
+        shutil.rmtree(d, ignore_errors=True)
+
     # Clean ccache if available
     try:
         result = subprocess.run(["ccache", "--version"], capture_output=True, text=True)


### PR DESCRIPTION
As title, it was erroring out when building tokenizers when running `install_executorch.sh`. Remove the build folder and rebuild fix the issue

