### PR TITLE
Arm backend: Add processed module to global scope in aot_arm_compiler

### DIFF
--- a/examples/arm/aot_arm_compiler.py
+++ b/examples/arm/aot_arm_compiler.py
@@ -11,6 +11,7 @@ import argparse
 import copy
 import logging
 import os
+import sys
 
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -161,6 +162,7 @@ def _load_python_module_model(
         raise RuntimeError(f"Unable to load model file {model_name}")
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
+    sys.modules["tmp_model"] = module
     model = module.ModelUnderTest
     inputs = example_inputs if example_inputs is not None else module.ModelInputs
 

--- a/examples/arm/example_modules/add.py
+++ b/examples/arm/example_modules/add.py
@@ -15,13 +15,15 @@
 
 import torch
 
+b = 2
+
 
 class myModelAdd(torch.nn.Module):
     def __init__(self):
         super().__init__()
 
     def forward(self, x):
-        return x + x
+        return x + x + b
 
 
 ModelUnderTest = myModelAdd()


### PR DESCRIPTION
When processing globals, torch._dynamo.symbolic_trace loads them by calling import_lib.import_module. For this to succeed, the module aot_arm_compiler loads from a source file needs to be added to sys.modules.