### PR TITLE
Add Python 3.13 to windows wheel build CI

### DIFF
--- a/.github/workflows/build-wheels-windows.yml
+++ b/.github/workflows/build-wheels-windows.yml
@@ -27,7 +27,7 @@ jobs:
       test-infra-ref: main
       with-cuda: disabled
       with-rocm: disabled
-      python-versions: '["3.10", "3.11", "3.12"]'
+      python-versions: '["3.10", "3.11", "3.12", "3.13"]'
 
   build:
     needs: generate-matrix

--- a/.github/workflows/build-wheels-windows.yml
+++ b/.github/workflows/build-wheels-windows.yml
@@ -2,15 +2,23 @@ name: Build Windows Wheels
 
 on:
   pull_request:
+    paths:
+      - .ci/**/*
+      - .github/workflows/build-wheels-macos.yml
+      - examples/**/*
+      - pyproject.toml
+      - setup.py
+    tags:
+      - ciflow/binaries/*
   push:
     branches:
       - nightly
-      - main
       - release/*
     tags:
-        # NOTE: Binary build pipelines should only get triggered on release candidate builds
-        # Release candidate tags look like: v1.11.0-rc1
-        - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
+      # NOTE: Binary build pipelines should only get triggered on release candidate builds
+      # Release candidate tags look like: v1.11.0-rc1
+      - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
+      - ciflow/binaries/*
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
As titled. It was disabled because `pytorch_tokenizers` wheels are missing for python3.13, see https://github.com/meta-pytorch/tokenizers/issues/160. This has been fixed so re-enabling the CI

