### PR TITLE
Arm backend: Update docs to mention partial quantization

### DIFF
--- a/docs/source/backends/arm-ethos-u/arm-ethos-u-quantization.md
+++ b/docs/source/backends/arm-ethos-u/arm-ethos-u-quantization.md
@@ -10,6 +10,7 @@ The Arm Ethos-U delegate supports the following quantization schemes:
 
 - 8-bit symmetric weights with 8-bit asymmetric activations (via the PT2E quantization flow).
 - Limited support for 16-bit quantization with 16-bit activations and 8-bit weights (a.k.a 16x8 quantization). This is under development.
+- Partial quantization is *not* supported on the Ethos-U backend. The entire model must be quantized.
 
 ### Quantization API
 

--- a/docs/source/backends/arm-vgf/arm-vgf-overview.md
+++ b/docs/source/backends/arm-vgf/arm-vgf-overview.md
@@ -84,6 +84,8 @@ See [Partitioner API](arm-vgf-partitioner.md) for more information of the Partit
 The VGF quantizer supports [Post Training Quantization (PT2E)](https://docs.pytorch.org/ao/main/tutorials_source/pt2e_quant_ptq.html)
 and [Quantization-Aware Training (QAT)](https://docs.pytorch.org/ao/main/tutorials_source/pt2e_quant_qat.html).
 
+Partial quantization is supported, allowing users to quantize only specific parts of the model while leaving others in floating-point.
+
 For more information on quantization, see [Quantization](arm-vgf-quantization.md).
 
 ## Runtime Integration

--- a/docs/source/backends/arm-vgf/arm-vgf-quantization.md
+++ b/docs/source/backends/arm-vgf/arm-vgf-quantization.md
@@ -13,6 +13,25 @@ The quantization schemes supported by the VGF Backend are:
 
 Weight-only quantization is not currently supported on the VGF backend.
 
+### Partial Quantization
+
+The VGF backend supports partial quantization, where only parts of the model
+are quantized while others remain in floating-point. This can be useful for
+models where certain layers are not well-suited for quantization or when a
+balance between performance and accuracy is desired.
+
+For every node (op) in the graph, the quantizer looks at the *quantization
+configuration* set for that specific node. If the configuration is set to
+`None`, the node is left in floating-point; if it is provided (not `None`), the
+node is quantized according to that configuration.
+
+With the [Quantization API](#quantization-api), users can specify the
+quantization configurations for specific layers or submodules of the model. The
+`set_global` method is first used to set a default quantization configuration
+(could be `None` as explained above) for all nodes in the model. Then,
+configurations for specific layers or submodules can override the global
+setting using the `set_module_name` or `set_module_type` methods.
+
 ### Quantization API
 
 ```python


### PR DESCRIPTION
VGF has now support for partial quantization, i.e., having the model run in mixed numerical precision. Update the markdown documentation to include and explain this feature.

cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai