### PR TITLE
Arm backend: Add TOSA-dtype validation to tester

### DIFF
--- a/backends/arm/test/misc/test_debug_feats.py
+++ b/backends/arm/test/misc/test_debug_feats.py
@@ -311,8 +311,6 @@ def test_fail_dump_tosa_ops(capsys, test_data: input_t1):
         Add(), test_data, aten_ops, exir_ops, use_to_edge_transform_and_lower=True
     )
     pipeline.dump_operator_distribution("to_edge_transform_and_lower")
-    pipeline.run()
-    assert (
-        "Can not get operator distribution for Vela command stream."
-        in capsys.readouterr().out
-    )
+    error_msg = "Can not get operator distribution for Vela command stream."
+    with pytest.raises(NotImplementedError, match=error_msg):
+        pipeline.run()

--- a/backends/arm/test/misc/test_mixed_type_lowering.py
+++ b/backends/arm/test/misc/test_mixed_type_lowering.py
@@ -1,0 +1,72 @@
+# Copyright 2025 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from collections import Counter, defaultdict
+
+import torch
+from executorch.backends.arm.test.tester.test_pipeline import TosaPipelineINT
+
+
+def combine_op_dicts(*dicts):
+    merged = defaultdict(Counter)
+    for d in dicts:
+        for op, dtypes in d.items():
+            merged[op].update(dtypes)
+    return {op: dict(counts) for op, counts in merged.items()}
+
+
+# TODO Figure out how to handle multiple dq/q nodes properly
+# See backends/arm/_passes/decompose_quant_nodes.py for details
+dq_tosa_ops = {
+    "CAST": {"FP32": 1, "INT32": 1},
+    "SUB": {"INT32": 1},  # zero-point subtraction
+    "MUL": {"FP32": 1},  # scale multiplication
+}
+q_tosa_ops = {
+    "CAST": {"INT8": 1},
+    "MUL": {"FP32": 1},  # scale multiplication
+    "ADD": {"FP32": 2},  # zero-point addition, rounding
+    "SUB": {"FP32": 1},  # for rounding
+    "CLAMP": {"FP32": 1},  # clamp
+    "GREATER_EQUAL": {"BOOL": 1},  # for rounding
+    "SELECT": {"FP32": 1},  # for rounding
+    "CEIL": {"FP32": 1},  # for rounding
+    "FLOOR": {"FP32": 1},  # for rounding
+}
+q_dq_tosa_ops = combine_op_dicts(dq_tosa_ops, q_tosa_ops)
+
+
+class AddSigmoidMul(torch.nn.Module):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.sigmoid = torch.nn.Sigmoid()
+
+    def forward(self, x, y):
+        return self.sigmoid(x + y) * x
+
+
+def test_mixed_type_lowering():
+    model = AddSigmoidMul()
+    input_data = (torch.randn(1, 16, 16, 16), torch.randn(1, 16, 16, 16))
+
+    pipeline = TosaPipelineINT[type(input_data)](
+        model, input_data, [], [], qtol=1, tosa_extensions=["FP"]
+    )
+    pipeline.quantizer.set_module_type(torch.nn.Sigmoid, None)
+    expected_tosa_dtype_counts = combine_op_dicts(
+        {
+            "SIGMOID": {"FP32": 1},  # SIGMOID should be executed in FP32
+            "ADD": {"INT32": 1},  # ADD should be executed in INT32
+            "MUL": {"INT32": 1},  # MUL should be executed in INT32
+        },
+        q_dq_tosa_ops,
+    )
+
+    pipeline.add_stage_after(
+        "to_edge_transform_and_lower",
+        pipeline.tester.check_dtype_count,
+        expected_tosa_dtype_counts,
+    )
+    pipeline.run()

--- a/backends/arm/test/tester/test_pipeline.py
+++ b/backends/arm/test/tester/test_pipeline.py
@@ -280,10 +280,15 @@ class BasePipelineMaker(Generic[T]):
         self.add_stage_after(stage_id, self.tester.dump_artifact, suffix=suffix)
         return self
 
-    def dump_operator_distribution(self, stage_id: str, suffix: str | None = None):
+    def dump_operator_distribution(
+        self, stage_id: str, suffix: str | None = None, include_dtypes: bool = False
+    ):
         """Adds a dump_operator_distribution stage after the given stage id."""
         self.add_stage_after(
-            stage_id, self.tester.dump_operator_distribution, suffix=suffix
+            stage_id,
+            self.tester.dump_operator_distribution,
+            suffix=suffix,
+            include_dtypes=include_dtypes,
         )
         return self
 


### PR DESCRIPTION
Add method to verify dtypes of TOSA-operators in ArmTester.


cc @freddan80 @per @zingo @digantdesai