### PR TITLE
Fix openvino torchao build

### DIFF
--- a/backends/openvino/scripts/openvino_build.sh
+++ b/backends/openvino/scripts/openvino_build.sh
@@ -81,7 +81,9 @@ build_python_enabled() {
     ./install_executorch.sh --minimal
 
     # Install torchao
-    pip install third-party/ao
+    # Note: --no-build-isolation is required because torchao's setup.py imports torch
+    # See comment in torchao's pyproject.toml for more details
+    pip install third-party/ao --no-build-isolation
 }
 
 main() {


### PR DESCRIPTION
When building torchao, `--no-build-isolation` is required because torchao's setup.py imports torch
See [comment](https://github.com/pytorch/ao/blob/b9e5780b56088daaf01d4fa3d4828efc4868cbed/pyproject.toml#L5-L8) in torchao's pyproject.toml for more details
