### PR TITLE
Clean up various leftover platform arg usage around the repo that never hit validation

### DIFF
--- a/shim_et/xplat/executorch/codegen/codegen.bzl
+++ b/shim_et/xplat/executorch/codegen/codegen.bzl
@@ -687,21 +687,18 @@ def build_optimized_lib(name, oplist_header_name, portable_header_lib, feature =
         name = name,
         srcs = optimized_source_files,
         exported_preprocessor_flags = ["-DEXECUTORCH_SELECTIVE_BUILD_DTYPE"],
-        deps = get_portable_lib_deps() + get_optimized_lib_deps() + [":" + portable_header_lib],
         compiler_flags = compiler_flags,
         platforms = platforms,
         preprocessor_flags = get_vec_preprocessor_flags(),
         # sleef needs to be added as a direct dependency of the operator target when building for Android,
-        # or a linker error may occur. Not sure why this happens; it seems that fbandroid_platform_deps of
+        # or a linker error may occur. Not sure why this happens; it seems that platform deps of
         # dependencies are not transitive
-        fbandroid_platform_deps = [
-            (
-                "^android-arm64.*$",
-                [
-                    "fbsource//third-party/sleef:sleef",
-                ],
-            ),
-        ],
+        deps = get_portable_lib_deps() + get_optimized_lib_deps() + [":" + portable_header_lib] + select({
+            "ovr_config//os:android-arm64": [
+                "fbsource//third-party/sleef:sleef",
+            ],
+            "DEFAULT": [],
+        }),
         # WARNING: using a deprecated API to avoid being built into a shared
         # library. In the case of dynamically loading so library we don't want
         # it to depend on other so libraries because that way we have to

--- a/shim_et/xplat/executorch/kernels/optimized/op_registration_util.bzl
+++ b/shim_et/xplat/executorch/kernels/optimized/op_registration_util.bzl
@@ -107,21 +107,18 @@ def define_op_library(name, compiler_flags, deps):
             # fail Werror builds; see https://godbolt.org/z/zvf85vTsr
             "-Wno-pass-failed",
         ] + compiler_flags + get_compiler_optimization_flags(),
-        deps = [
-            "//executorch/runtime/kernel:kernel_includes",
-        ] + augmented_deps + get_vec_deps(),
-        preprocessor_flags = get_vec_preprocessor_flags(),
         # sleef needs to be added as a direct dependency of the operator target when building for Android,
         # or a linker error may occur. Not sure why this happens; it seems that fbandroid_platform_deps of
         # dependencies are not transitive
-        fbandroid_platform_deps = [
-            (
-                "^android-arm64.*$",
-                [
-                    "fbsource//third-party/sleef:sleef",
-                ],
-            ),
-        ],
+        deps = [
+            "//executorch/runtime/kernel:kernel_includes",
+        ] + augmented_deps + get_vec_deps() + select({
+            "DEFAULT": [],
+            "ovr_config//os:android-arm64": [
+                "fbsource//third-party/sleef:sleef",
+            ],
+        }),
+        preprocessor_flags = get_vec_preprocessor_flags(),
         # link_whole is necessary because the operators register themselves
         # via static initializers that run at program startup.
         # @lint-ignore BUCKLINT link_whole

--- a/shim_et/xplat/executorch/kernels/portable/op_registration_util.bzl
+++ b/shim_et/xplat/executorch/kernels/portable/op_registration_util.bzl
@@ -98,7 +98,7 @@ def define_op_library(name, deps, android_deps, aten_target, _allow_third_party_
     Args:
         name: The name of the target; e.g., "op_add"
         deps: List of deps for the target.
-        android_deps: List of fbandroid_platform_deps for the target.
+        android_deps: List of deps for Android platform.
         aten_target: If True, define a "<name>_aten" target that uses
             `:kernel_types_aten`, compatible with host PyTorch. If False, define
             a "<name>" target that uses `:kernel_types`, compatible with the
@@ -123,7 +123,6 @@ def define_op_library(name, deps, android_deps, aten_target, _allow_third_party_
             "//executorch/kernels/test/...",
             "@EXECUTORCH_CLIENTS",
         ],
-        fbandroid_platform_deps = android_deps,
         # kernels often have helpers with no prototypes just disabling the warning here as the headers
         # are codegend and linked in later
         compiler_flags = select({
@@ -142,7 +141,10 @@ def define_op_library(name, deps, android_deps, aten_target, _allow_third_party_
         ) + get_compiler_optimization_flags(),
         deps = [
             "//executorch/runtime/kernel:kernel_includes" + aten_suffix,
-        ] + deps,
+        ] + deps + select({
+            "ovr_config//os:android": android_deps,
+            "DEFAULT": [],
+        }),
         # WARNING: using a deprecated API to avoid being built into a shared
         # library. In the case of dynamically loading so library we don't want
         # it to depend on other so libraries because that way we have to


### PR DESCRIPTION
Summary:
Cleaning up platform args before the whole feature gets deleted. These missed our validation.

---
These are to force android builds of mwa for xplat diffs

Reviewed By: mzlee

Differential Revision: D89322661


