### PR TITLE
[ET-VK][ez][debug-tools] Fix json serialization of value list

### DIFF
--- a/backends/vulkan/runtime/graph/Logging.cpp
+++ b/backends/vulkan/runtime/graph/Logging.cpp
@@ -52,8 +52,11 @@ std::string make_arg_json(ComputeGraph* const compute_graph, ValueRef arg) {
   } else if (compute_graph->val_is_value_list(arg)) {
     ValueListPtr val_list = compute_graph->get_value_list(arg);
     ss << ", \"values\": [";
-    for (const ValueRef& value : *val_list) {
-      ss << value << ", ";
+    for (size_t i = 0; i < val_list->size(); ++i) {
+      ss << val_list->at(i);
+      if (i + 1 < val_list->size()) {
+        ss << ", ";
+      }
     }
     ss << "]";
   } else if (compute_graph->val_is_int_list(arg)) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #16307
* #16306
* __->__ #16305

Title says it all! Make sure not to add a trailing comma when serializing a value list into a json, otherwise json compilation will fail.

Differential Revision: [D89421394](https://our.internmc.facebook.com/intern/diff/D89421394/)