### PR TITLE
[ET-VK][1/n] Remove dynamic array indexing in shaders

### DIFF
--- a/backends/vulkan/runtime/graph/ops/glsl/binary_op.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/binary_op.glsl
@@ -94,8 +94,7 @@ void main() {
     return;
   }
 
-  TensorIndex outp_tidx;
-  linear_idx_to_tensor_idx(outp, out_bufi, outp_tidx);
+  TensorIndex outp_tidx = linear_idx_to_tensor_idx(outp, out_bufi);
 
   TensorIndex inp_tidx = outp_tidx;
   clamp_tensor_idx(inp, inp_tidx);

--- a/backends/vulkan/runtime/graph/ops/glsl/buffer_to_nchw.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/buffer_to_nchw.glsl
@@ -29,8 +29,7 @@ void main() {
     return;
   }
 
-  TensorIndex inp_tidx;
-  linear_idx_to_tensor_idx(inp, inp_bufi, inp_tidx);
+  TensorIndex inp_tidx = linear_idx_to_tensor_idx(inp, inp_bufi);
 
   uint nchwi = tensor_idx_to_contiguous_idx(inp, inp_tidx);
 

--- a/backends/vulkan/runtime/graph/ops/glsl/expand_buffer.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/expand_buffer.glsl
@@ -33,13 +33,12 @@ void main() {
     return;
   }
 
-  TensorIndex outp_tidx;
-  linear_idx_to_tensor_idx(outp, outp_bufi, outp_tidx);
+  TensorIndex outp_tidx = linear_idx_to_tensor_idx(outp, outp_bufi);
 
   // Map output tensor index to input tensor index by taking modulo
   // with input tensor sizes for each dimension
   TensorIndex inp_tidx = outp_tidx;
-  for (int d = 0; d < ndim(inp); ++d) {
+  for (int d = 0; d < ndim(outp); ++d) {
     uint inp_size = size_at(inp, d);
     uint outp_idx = idx_at(outp_tidx, d);
     inp_tidx.data[div_4(d)][mod_4(d)] = outp_idx % inp_size;

--- a/backends/vulkan/runtime/graph/ops/glsl/indexing.glslh
+++ b/backends/vulkan/runtime/graph/ops/glsl/indexing.glslh
@@ -11,8 +11,51 @@
 
 #include "common.glslh"
 
+#extension GL_EXT_control_flow_attributes : require
+
 #define DIMLIMIT 8
 #define DIMLIMIT_DIV4 2
+
+//
+// Hashed layout utils
+//
+
+/*
+ * The hashed layout is a packed int32 where each group of 4 bits contain some
+ * information about the memory layout of a tensor buffer or texture. It is
+ * passed into shaders as a specialization constant and allows shader compilers
+ * to select optimized code paths suited for a particular memory layout.
+ *
+ * Currently the following information is packed into the layout integer:
+ * - bits 0-15: first 4 elements of the dim order array
+ *   - bits 0-3: dim_order[0]
+ *   - bits 4-7: dim_order[1]
+ *   - bits 8-11: dim_order[2]
+ *   - bits 12-15: dim_order[3]
+ */
+
+
+// Corresponds to dim_order[:4] = [0, 1, 2, 3]
+#define CONTIGUOUS_BUFFER_LAYOUT_ID 12816
+// Corresponds to dim_order[:4] = [2, 0, 1, 3]
+#define CHANNELS_LAST_BUFFER_LAYOUT_ID 12546
+
+// Used as a default value for hashed layout ints, representing the most common
+// layout used for buffer-backed tensors (i.e. contiguous buffers)
+#define CONTIG_LAYOUT_INT 12816
+
+int layout_id(const int hashed_layout) {
+  // Extract the first 16 bits
+  return hashed_layout & 0xFFFF;
+}
+
+bool is_contiguous(const int hashed_layout) {
+  return layout_id(hashed_layout) == CONTIGUOUS_BUFFER_LAYOUT_ID;
+}
+
+bool is_channels_last(const int hashed_layout) {
+  return layout_id(hashed_layout) == CHANNELS_LAST_BUFFER_LAYOUT_ID;
+}
 
 //
 // BufferMetadata
@@ -174,33 +217,44 @@ struct TextureElementIndex {
 // Index Conversions
 //
 
-void contiguous_idx_to_tensor_idx(
-    const BufferMetadata meta,
-    uint contiguous_idx,
-    out TensorIndex tidx) {
-  initialize(tidx);
-  int dim = int_ndim(meta);
-  int i = 0;
-
-  uint contiguous_strides[DIMLIMIT];
-  contiguous_strides[0] = 1;
-  for (int d = 1; d < DIMLIMIT; ++d) {
-    contiguous_strides[d] = size_at(meta, d - 1) * contiguous_strides[d - 1];
-  }
-
-  for (int d = max(dim - 1, 0); d >= 0; d--) {
-    uint dim_stride = contiguous_strides[d];
-
-    tidx.data[div_4(d)][mod_4(d)] = contiguous_idx / dim_stride;
-    contiguous_idx = contiguous_idx % dim_stride;
-  }
-}
-
 TensorIndex contiguous_idx_to_tensor_idx(
     const BufferMetadata meta,
     uint contiguous_idx) {
   TensorIndex tidx;
-  contiguous_idx_to_tensor_idx(meta, contiguous_idx, tidx);
+
+  uint contiguous_strides[DIMLIMIT];
+
+  // Manual loop unrolling to avoid dynamic array accesses, which may cause
+  // severe performance issues on some GPUs
+
+  contiguous_strides[0] = 1;
+  contiguous_strides[1] = meta.sizes[0][0] * contiguous_strides[0];
+  contiguous_strides[2] = meta.sizes[0][1] * contiguous_strides[1];
+  contiguous_strides[3] = meta.sizes[0][2] * contiguous_strides[2];
+
+  contiguous_strides[4] = meta.sizes[0][3] * contiguous_strides[3];
+  contiguous_strides[5] = meta.sizes[1][0] * contiguous_strides[4];
+  contiguous_strides[6] = meta.sizes[1][1] * contiguous_strides[5];
+  contiguous_strides[7] = meta.sizes[1][2] * contiguous_strides[6];
+
+  tidx.data[1][3] = contiguous_idx / contiguous_strides[7];
+  contiguous_idx = contiguous_idx % contiguous_strides[7];
+  tidx.data[1][2] = contiguous_idx / contiguous_strides[6];
+  contiguous_idx = contiguous_idx % contiguous_strides[6];
+  tidx.data[1][1] = contiguous_idx / contiguous_strides[5];
+  contiguous_idx = contiguous_idx % contiguous_strides[5];
+  tidx.data[1][0] = contiguous_idx / contiguous_strides[4];
+  contiguous_idx = contiguous_idx % contiguous_strides[4];
+
+  tidx.data[0][3] = contiguous_idx / contiguous_strides[3];
+  contiguous_idx = contiguous_idx % contiguous_strides[3];
+  tidx.data[0][2] = contiguous_idx / contiguous_strides[2];
+  contiguous_idx = contiguous_idx % contiguous_strides[2];
+  tidx.data[0][1] = contiguous_idx / contiguous_strides[1];
+  contiguous_idx = contiguous_idx % contiguous_strides[1];
+  tidx.data[0][0] = contiguous_idx / contiguous_strides[0];
+  contiguous_idx = contiguous_idx % contiguous_strides[0];
+
   return tidx;
 }
 
@@ -208,49 +262,136 @@ uint tensor_idx_to_contiguous_idx(
     const BufferMetadata meta,
     const TensorIndex tidx) {
   uint contiguous_strides[DIMLIMIT];
+
+  // Manual loop unrolling to avoid dynamic array accesses, which may cause
+  // severe performance issues on some GPUs
+
   contiguous_strides[0] = 1;
-  for (int d = 1; d < DIMLIMIT; ++d) {
-    contiguous_strides[d] = size_at(meta, d - 1) * contiguous_strides[d - 1];
-  }
+  contiguous_strides[1] = meta.sizes[0][0] * contiguous_strides[0];
+  contiguous_strides[2] = meta.sizes[0][1] * contiguous_strides[1];
+  contiguous_strides[3] = meta.sizes[0][2] * contiguous_strides[2];
 
-  uint contig_idx = 0;
-  for (int d = 0; d < ndim(meta); ++d) {
-    contig_idx += contiguous_strides[d] * idx_at(tidx, d);
-  }
+  contiguous_strides[4] = meta.sizes[0][3] * contiguous_strides[3];
+  contiguous_strides[5] = meta.sizes[1][0] * contiguous_strides[4];
+  contiguous_strides[6] = meta.sizes[1][1] * contiguous_strides[5];
+  contiguous_strides[7] = meta.sizes[1][2] * contiguous_strides[6];
+
+  uint contig_idx = contiguous_strides[0] * tidx.data[0][0];
+  contig_idx += contiguous_strides[1] * tidx.data[0][1];
+  contig_idx += contiguous_strides[2] * tidx.data[0][2];
+  contig_idx += contiguous_strides[3] * tidx.data[0][3];
+
+  contig_idx += contiguous_strides[4] * tidx.data[1][0];
+  contig_idx += contiguous_strides[5] * tidx.data[1][1];
+  contig_idx += contiguous_strides[6] * tidx.data[1][2];
+  contig_idx += contiguous_strides[7] * tidx.data[1][3];
+
   return contig_idx;
-}
-
-void linear_idx_to_tensor_idx(
-    const BufferMetadata meta,
-    uint linear_idx,
-    out TensorIndex tidx) {
-  initialize(tidx);
-  int dim = int_ndim(meta);
-  int i = 0;
-  for (int d = max(dim - 1, 0); d >= 0; d--) {
-    uint dim_idx = dim_order_at(meta, d);
-    uint dim_stride = stride_at(meta, dim_idx);
-
-    tidx.data[div_4(dim_idx)][mod_4(dim_idx)] = linear_idx / dim_stride;
-    linear_idx = linear_idx % dim_stride;
-  }
 }
 
 TensorIndex linear_idx_to_tensor_idx(
     const BufferMetadata meta,
     uint linear_idx) {
   TensorIndex tidx;
-  linear_idx_to_tensor_idx(meta, linear_idx, tidx);
+  initialize(tidx);
+  int dim = int_ndim(meta);
+  int i = 0;
+  for (int d = max(dim - 1, 0); d >= 0; d--) {
+    uint dim_idx = meta.dim_order[div_4(d)][mod_4(d)];
+    uint dim_stride = meta.strides[div_4(dim_idx)][mod_4(dim_idx)];
+
+    tidx.data[div_4(dim_idx)][mod_4(dim_idx)] = linear_idx / dim_stride;
+    linear_idx = linear_idx % dim_stride;
+  }
   return tidx;
+}
+
+TensorIndex linear_idx_to_tensor_idx_contig_case(
+    const BufferMetadata meta,
+    uint linear_idx) {
+  TensorIndex tidx;
+
+  // Manual loop unrolling to avoid dynamic array accesses, which may cause
+  // severe performance issues on some GPUs
+
+  tidx.data[1][3] = linear_idx / meta.strides[1][3];
+  linear_idx = linear_idx % meta.strides[1][3];
+  tidx.data[1][2] = linear_idx / meta.strides[1][2];
+  linear_idx = linear_idx % meta.strides[1][2];
+  tidx.data[1][1] = linear_idx / meta.strides[1][1];
+  linear_idx = linear_idx % meta.strides[1][1];
+  tidx.data[1][0] = linear_idx / meta.strides[1][0];
+  linear_idx = linear_idx % meta.strides[1][0];
+
+  tidx.data[0][3] = linear_idx / meta.strides[0][3];
+  linear_idx = linear_idx % meta.strides[0][3];
+  tidx.data[0][2] = linear_idx / meta.strides[0][2];
+  linear_idx = linear_idx % meta.strides[0][2];
+  tidx.data[0][1] = linear_idx / meta.strides[0][1];
+  linear_idx = linear_idx % meta.strides[0][1];
+  tidx.data[0][0] = linear_idx / meta.strides[0][0];
+  linear_idx = linear_idx % meta.strides[0][0];
+
+  return tidx;
+}
+
+TensorIndex linear_idx_to_tensor_idx_channelslast_case(
+    const BufferMetadata meta,
+    uint linear_idx) {
+  TensorIndex tidx;
+
+  // Manual loop unrolling to avoid dynamic array accesses, which may cause
+  // severe performance issues on some GPUs
+
+  tidx.data[1][3] = linear_idx / meta.strides[1][3];
+  linear_idx = linear_idx % meta.strides[1][3];
+  tidx.data[1][2] = linear_idx / meta.strides[1][2];
+  linear_idx = linear_idx % meta.strides[1][2];
+  tidx.data[1][1] = linear_idx / meta.strides[1][1];
+  linear_idx = linear_idx % meta.strides[1][1];
+  tidx.data[1][0] = linear_idx / meta.strides[1][0];
+  linear_idx = linear_idx % meta.strides[1][0];
+
+  tidx.data[0][3] = linear_idx / meta.strides[0][3];
+  linear_idx = linear_idx % meta.strides[0][3];
+  tidx.data[0][1] = linear_idx / meta.strides[0][1];
+  linear_idx = linear_idx % meta.strides[0][1];
+  tidx.data[0][0] = linear_idx / meta.strides[0][0];
+  linear_idx = linear_idx % meta.strides[0][0];
+  tidx.data[0][2] = linear_idx / meta.strides[0][2];
+  linear_idx = linear_idx % meta.strides[0][2];
+
+  return tidx;
+}
+
+TensorIndex linear_idx_to_tensor_idx(
+    const BufferMetadata meta,
+    uint linear_idx,
+    int hashed_layout) {
+  if (is_contiguous(hashed_layout)) {
+    return linear_idx_to_tensor_idx_contig_case(meta, linear_idx);
+  } else if (is_channels_last(hashed_layout)) {
+    return linear_idx_to_tensor_idx_channelslast_case(meta, linear_idx);
+  }
+  return linear_idx_to_tensor_idx(meta, linear_idx);
 }
 
 uint tensor_idx_to_linear_idx(
     const BufferMetadata meta,
     const TensorIndex tidx) {
-  uint lin_idx = 0;
-  for (int d = 0; d < ndim(meta); ++d) {
-    lin_idx += stride_at(meta, d) * idx_at(tidx, d);
-  }
+  // Manual loop unrolling to avoid dynamic array accesses, which may cause
+  // severe performance issues on some GPUs
+
+  uint lin_idx = meta.strides[0][0] * tidx.data[0][0];
+  lin_idx += meta.strides[0][1] * tidx.data[0][1];
+  lin_idx += meta.strides[0][2] * tidx.data[0][2];
+  lin_idx += meta.strides[0][3] * tidx.data[0][3];
+
+  lin_idx += meta.strides[1][0] * tidx.data[1][0];
+  lin_idx += meta.strides[1][1] * tidx.data[1][1];
+  lin_idx += meta.strides[1][2] * tidx.data[1][2];
+  lin_idx += meta.strides[1][3] * tidx.data[1][3];
+
   return lin_idx;
 }
 

--- a/backends/vulkan/runtime/graph/ops/glsl/nchw_to_buffer.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/nchw_to_buffer.glsl
@@ -29,10 +29,8 @@ void main() {
     return;
   }
 
-  TensorIndex outp_tidx;
+  TensorIndex outp_tidx = linear_idx_to_tensor_idx(outp, outp_bufi);
   uint nchwi;
-
-  linear_idx_to_tensor_idx(outp, outp_bufi, outp_tidx);
 
   if (transpose_hw == 1) {
     BufferMetadata transposed_meta = outp;

--- a/backends/vulkan/runtime/graph/ops/glsl/permute_buffer.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/permute_buffer.glsl
@@ -36,8 +36,7 @@ void main() {
     return;
   }
 
-  TensorIndex inp_tidx;
-  linear_idx_to_tensor_idx(inp, inp_bufi, inp_tidx);
+  TensorIndex inp_tidx = linear_idx_to_tensor_idx(inp, inp_bufi);
 
   TensorIndex outp_tidx = inp_tidx;
   permute(outp_tidx, permute_order);

--- a/backends/vulkan/runtime/graph/ops/glsl/view_buffer.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/view_buffer.glsl
@@ -18,7 +18,8 @@ ${layout_declare_ubo(B, "BufferMetadata", "inp")}
 
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
 
-${layout_declare_spec_const(C, "int", "all_contiguous", "0")}
+${layout_declare_spec_const(C, "int", "outp_layout", "CONTIG_LAYOUT_INT")}
+${layout_declare_spec_const(C, "int", "inp_layout", "CONTIG_LAYOUT_INT")}
 
 /*
  * The insight behind the view operation is that the contiguous index of each
@@ -31,16 +32,15 @@ void main() {
   }
 
   uint inp_bufi = outp_bufi;
-  if (all_contiguous == 0) {
-    TensorIndex outp_tidx;
-    linear_idx_to_tensor_idx(outp, outp_bufi, outp_tidx);
+  if (!is_contiguous(outp_layout) || !is_contiguous(inp_layout)) {
+    TensorIndex outp_tidx = linear_idx_to_tensor_idx(
+        outp, outp_bufi, outp_layout);
 
     // To map the output to the input, find the input element that has the same
     // contiguous index as the output element.
     const uint contig_idx = tensor_idx_to_contiguous_idx(outp, outp_tidx);
 
-    TensorIndex inp_tidx;
-    contiguous_idx_to_tensor_idx(inp, contig_idx, inp_tidx);
+    TensorIndex inp_tidx = contiguous_idx_to_tensor_idx(inp, contig_idx);
 
     inp_bufi = tensor_idx_to_linear_idx(inp, inp_tidx);
   }

--- a/backends/vulkan/runtime/graph/ops/glsl/view_convert_buffer.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/view_convert_buffer.glsl
@@ -20,7 +20,8 @@ ${layout_declare_ubo(B, "BufferMetadata", "inp")}
 
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
 
-${layout_declare_spec_const(C, "int", "all_contiguous", "0")}
+${layout_declare_spec_const(C, "int", "outp_layout", "0")}
+${layout_declare_spec_const(C, "int", "inp_layout", "0")}
 
 /*
  * The insight behind the view_convert operation is that the contiguous index of each
@@ -35,16 +36,15 @@ void main() {
 
   uint inp_bufi = outp_bufi;
 
-  if (all_contiguous == 0) {
-    TensorIndex outp_tidx;
-    linear_idx_to_tensor_idx(outp, outp_bufi, outp_tidx);
+  if (!is_contiguous(outp_layout) || !is_contiguous(inp_layout)) {
+    TensorIndex outp_tidx = linear_idx_to_tensor_idx(
+        outp, outp_bufi, outp_layout);
 
     // To map the output to the input, find the input element that has the same
     // contiguous index as the output element.
     const uint contig_idx = tensor_idx_to_contiguous_idx(outp, outp_tidx);
 
-    TensorIndex inp_tidx;
-    contiguous_idx_to_tensor_idx(inp, contig_idx, inp_tidx);
+    TensorIndex inp_tidx = contiguous_idx_to_tensor_idx(inp, contig_idx);
 
     inp_bufi = tensor_idx_to_linear_idx(inp, inp_tidx);
   }

--- a/backends/vulkan/runtime/graph/ops/impl/View.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/View.cpp
@@ -108,11 +108,6 @@ void add_view_copy_buffer_node(
   std::string kernel_name = "view_buffer";
   add_dtype_suffix(kernel_name, graph.dtype_of(out));
 
-  bool all_contiguous = graph.is_contiguous_buffer_tensor(in) &&
-      graph.is_contiguous_buffer_tensor(out);
-
-  int32_t all_contiguous_int = all_contiguous ? 1 : 0;
-
   graph.execute_nodes().emplace_back(new DynamicDispatchNode(
       graph,
       VK_KERNEL_FROM_STR(kernel_name),
@@ -125,7 +120,7 @@ void add_view_copy_buffer_node(
       // Push Constants
       {},
       // Specialization Constants
-      {all_contiguous_int},
+      {graph.hashed_layout_of(out), graph.hashed_layout_of(in)},
       // Resize Args
       resize_args,
       // Resizing Logic
@@ -142,11 +137,6 @@ void add_view_copy_convert_buffer_node(
   add_dtype_suffix(kernel_name, graph.dtype_of(in));
   add_dtype_suffix(kernel_name, graph.dtype_of(out));
 
-  bool all_contiguous = graph.is_contiguous_buffer_tensor(in) &&
-      graph.is_contiguous_buffer_tensor(out);
-
-  int32_t all_contiguous_int = all_contiguous ? 1 : 0;
-
   graph.execute_nodes().emplace_back(new DynamicDispatchNode(
       graph,
       VK_KERNEL_FROM_STR(kernel_name),
@@ -159,7 +149,7 @@ void add_view_copy_convert_buffer_node(
       // Push Constants
       {},
       // Specialization Constants
-      {all_contiguous_int},
+      {graph.hashed_layout_of(out), graph.hashed_layout_of(in)},
       // Resize Args
       resize_args,
       // Resizing Logic


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #16307
* __->__ #16306
* #16305

## Context

Recent investigations into poor performance of certain shaders on Arm GPUs revealed that dynamically indexing into temporary arrays results in severe performance issues, i.e.

```c++
int arr[4];
arr[some_variable] = ...
```

However, array indexing does not cause any issues if a specialization constant is used, or if done in a loop with predictable bounds.

The cause seems to be that when the compiler cannot predict what array elements are being accessed, it will allocate the array on the "stack" instead of registers. From the [Mali offline compiler docs](https://developer.arm.com/documentation/101863/8-8/Using-Mali-Offline-Compiler/Performance-analysis/Resource-usage), the stack is:

> Stack is a form of thread local storage that is used by compiler-generated memory allocations and register spills. The stack size metric in the report shows the size of the stack memory for a single shader thread. Later compilers generate additional sub-metrics that show the split between regions used for spilling and compiler-generated allocations.

> You can reduce the size of your stack in the following ways:

> Avoid coding patterns that require the compiler to allocate on the stack, such as dynamically indexing into temporary arrays.
> Reduce register pressure to avoid stack spilling.

Stack usage can be detected by the Mali offline compiler, for example:

```
view_buffer_float
~~~~~~~~~~~~~~~~~~~~~~~~~~

Mali Offline Compiler v8.8.0 (Build 888cd7)
Copyright (c) 2007-2025 Arm Limited. All rights reserved.

Configuration
=============

Hardware: Mali-G1 r0p1
Architecture: Arm 5th Generation
Driver: r55p0-00rel0
Shader type: Vulkan Compute

Main shader
===========

Work registers: 49 (76% used at 50% occupancy)
Uniform registers: 76 (59% used)
Shared storage size: 0 bytes
Stack use: 544 bytes
 - Alloca region: 504 bytes
16-bit arithmetic: 0%
```

Currently, dynamic array indexing is coming primarily from indexing logic, i.e. converting between n-dimensional tensor coordinates to physical buffer indices or texture coordinates. The goal of this diff stack is to eliminate dynamic indexing of arrays whenever possible by:

1. Manually unrolling loops
2. Using specialization constants to pass in dim data instead of UBOs
3. Using specialization constants (primarily the hashed layout integer) to optimize for common cases whenever dynamic array indexing is unavoidable (i.e. converting between buffer index to tensor index, since the dim order needs to be respected)

## Changes in this diff/PR

1. Manually unroll most of the tensor index conversion functions in indexing.glslh to avoid dynamic indexing
2. For `linear_idx_to_tensor_idx`, introduce an overload that accepts the hashed layout spec constant that can invoke special cases for common layouts which do not use dynamic array indexing
3. Update view ops to use the new `linear_idx_to_tensor_idx` overload
4. Get rid of some unnecessary operator overloads in indexing.glslh

Differential Revision: [D89226115](https://our.internmc.facebook.com/intern/diff/D89226115/)