### PR TITLE
[ET-VK][2/n] Remove dynamic array indexing in permute

### DIFF
--- a/backends/vulkan/runtime/graph/ops/glsl/indexing.glslh
+++ b/backends/vulkan/runtime/graph/ops/glsl/indexing.glslh
@@ -34,6 +34,13 @@
  *   - bits 12-15: dim_order[3]
  */
 
+// Extracts the 4-bit packed value at the given position (0..7) from a 32-bit
+// int. Position 0 corresponds to the least-significant 4 bits; position 7 to
+// the most-significant.
+int extract_4b(const int packed, const int pos) {
+  return (packed >> (pos * 4)) & 0xF;
+}
+
 
 // Corresponds to dim_order[:4] = [0, 1, 2, 3]
 #define CONTIGUOUS_BUFFER_LAYOUT_ID 12816
@@ -167,15 +174,6 @@ uint idx_at(const TensorIndex tidx, const int dim) {
 
 uint idx_at(const TensorIndex tidx, const uint dim) {
   return tidx.data[div_4(dim)][mod_4(dim)];
-}
-
-void permute(inout TensorIndex tidx, const ivec4 permute_order[DIMLIMIT_DIV4]) {
-  TensorIndex new_tidx = tidx;
-  for (int d = 0; d < DIMLIMIT; ++d) {
-    int src_dim = permute_order[div_4(d)][mod_4(d)];
-    new_tidx.data[div_4(d)][mod_4(d)] = idx_at(tidx, src_dim);
-  }
-  tidx = new_tidx;
 }
 
 uint x(const TensorIndex tidx) {

--- a/backends/vulkan/runtime/graph/ops/glsl/permute_buffer.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/permute_buffer.glsl
@@ -26,9 +26,27 @@ ${layout_declare_tensor(B, "r", "t_inp", DTYPE, "buffer")}
 ${layout_declare_ubo(B, "BufferMetadata", "outp")}
 ${layout_declare_ubo(B, "BufferMetadata", "inp")}
 
-${layout_declare_ubo(B, "ivec4[DIMLIMIT_DIV4]", "permute_order")}
+${layout_declare_spec_const(C, "int", "outp_layout", "CONTIG_LAYOUT_INT")}
+${layout_declare_spec_const(C, "int", "inp_layout", "CONTIG_LAYOUT_INT")}
+${layout_declare_spec_const(C, "int", "permute_order", "0")}
 
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+TensorIndex permute(TensorIndex tidx) {
+  TensorIndex new_tidx = tidx;
+
+  new_tidx.data[0][0] = idx_at(tidx, extract_4b(permute_order, 0));
+  new_tidx.data[0][1] = idx_at(tidx, extract_4b(permute_order, 1));
+  new_tidx.data[0][2] = idx_at(tidx, extract_4b(permute_order, 2));
+  new_tidx.data[0][3] = idx_at(tidx, extract_4b(permute_order, 3));
+
+  new_tidx.data[1][0] = idx_at(tidx, extract_4b(permute_order, 4));
+  new_tidx.data[1][1] = idx_at(tidx, extract_4b(permute_order, 5));
+  new_tidx.data[1][2] = idx_at(tidx, extract_4b(permute_order, 6));
+  new_tidx.data[1][3] = idx_at(tidx, extract_4b(permute_order, 7));
+
+  return new_tidx;
+}
 
 void main() {
   const uint inp_bufi = gl_GlobalInvocationID.x;
@@ -36,12 +54,10 @@ void main() {
     return;
   }
 
-  TensorIndex inp_tidx = linear_idx_to_tensor_idx(inp, inp_bufi);
-
-  TensorIndex outp_tidx = inp_tidx;
-  permute(outp_tidx, permute_order);
-
+  TensorIndex inp_tidx = linear_idx_to_tensor_idx(inp, inp_bufi, inp_layout);
+  TensorIndex outp_tidx = permute(inp_tidx);
   const uint outp_bufi = tensor_idx_to_linear_idx(outp, outp_tidx);
+
   // Copy data from input to output
   t_outp[outp_bufi] = t_inp[inp_bufi];
 }

--- a/backends/vulkan/runtime/graph/ops/impl/Permute.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Permute.cpp
@@ -187,6 +187,19 @@ struct WHCNPermuteDims {
       whcn_permute_dims[whcn_i] = whcn_i;
     }
   }
+
+  int32_t pack_into_int32() const {
+    // If kTensorDimLimit is increased, we will need to send in an additional
+    // int.
+    VK_CHECK_COND(api::kTensorDimLimit <= 8);
+    // Packs the 8 elements in whcn_permute_dims into a single int32_t. Each
+    // element is packed into 4 bits.
+    int32_t packed = 0;
+    for (int32_t i = 0; i < api::kTensorDimLimit; i++) {
+      packed |= (whcn_permute_dims[i] & 0x0F) << (i * 4);
+    }
+    return packed;
+  }
 };
 
 void add_permute_buffer_node(
@@ -199,7 +212,7 @@ void add_permute_buffer_node(
   WHCNPermuteDims whcn_permute_dims;
   // Convert the permute dims to WHCN dimension order, which is the standard in
   // our compute shaders. The following transformations are applied.
-  // 1. Change dimension index values from NCHW order valueto WHCN order value
+  // 1. Change dimension index values from NCHW order value to WHCN order value
   // 2. Extend the permute array to kTensorDimLimit
   {
     IntListPtr permute_dims_ptr = graph.get_int_list(permute_dims);
@@ -214,7 +227,6 @@ void add_permute_buffer_node(
   vkapi::ParamsBindList param_buffers = {
       graph.buffer_meta_ubo(out),
       graph.buffer_meta_ubo(in),
-      graph.create_params_buffer(whcn_permute_dims),
   };
 
   graph.execute_nodes().emplace_back(new DynamicDispatchNode(
@@ -228,7 +240,9 @@ void add_permute_buffer_node(
       // Push Constants
       {},
       // Specialization Constants
-      {},
+      {graph.hashed_layout_of(out),
+       graph.hashed_layout_of(in),
+       whcn_permute_dims.pack_into_int32()},
       // Resize Args
       {permute_dims},
       // Resizing Logic


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #16307
* #16306
* #16305

## Context

See D89226115

## Changes

Removes dynamic array access from the permute shader by doing the following:

1. Passing in permute order via specialization constant
2. Using the hashed layout specialization constant to convert between linear index and tensor index

Differential Revision: [D89421393](https://our.internmc.facebook.com/intern/diff/D89421393/)