### PR TITLE
Arm backend: Test partial quantization of models on VGF

### DIFF
--- a/backends/arm/test/models/test_llama.py
+++ b/backends/arm/test/models/test_llama.py
@@ -206,3 +206,22 @@ def test_llama_partial_quant_tosa_INT_FP():
         )
         _use_partial_quantizer(pipeline)
         pipeline.run()
+
+
+@common.SkipIfNoModelConverter
+def test_llama_partial_quant_vgf_quant():
+    llama_model, llama_inputs, llama_meta = TestLlama().prepare_model()
+
+    if llama_model is None or llama_inputs is None:
+        pytest.skip("Missing model and/or input files")
+
+    with torch.no_grad():
+        pipeline = VgfPipeline[input_t](
+            llama_model,
+            llama_inputs,
+            aten_op=[],
+            exir_op=[],
+            quantize=True,
+        )
+        _use_partial_quantizer(pipeline)
+        pipeline.run()

--- a/backends/arm/test/models/test_mobilenet_v2_arm.py
+++ b/backends/arm/test/models/test_mobilenet_v2_arm.py
@@ -163,3 +163,17 @@ def test_mv2_partial_quant_tosa_INT_FP():
     )
     _use_partial_quantizer(pipeline)
     pipeline.run()
+
+
+@common.SkipIfNoModelConverter
+def test_mv2_partial_quant_vgf_quant():
+    pipeline = VgfPipeline[input_t](
+        mv2,
+        model_inputs,
+        aten_op=[],
+        exir_op=[],
+        quantize=True,
+        atol=0.10,
+    )
+    _use_partial_quantizer(pipeline)
+    pipeline.run()


### PR DESCRIPTION
Run tests of partial quantization on the MobileNetV2 and Llama models using the VGF backend (INT+FP profile).

cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai