### PR TITLE
Arm backend: Partition boundary Q/DQ nodes for INT+FP

### DIFF
--- a/backends/arm/_passes/decorate_fp32_to_int32_casting_pass.py
+++ b/backends/arm/_passes/decorate_fp32_to_int32_casting_pass.py
@@ -58,6 +58,14 @@ class DecorateFp32toInt32CastingPass(ArmPass):
         if not (input_dtype == torch.float32 and output_dtype == torch.int32):
             return super().call_operator(op, args, kwargs, meta)
 
+        # For some ops, qparams dtype is inconsistent with fake tensor's dtype.
+        # Skip decorating if the input is quantized and thus not floating point.
+        if (
+            "output_qparams" in input.node.meta
+            and len(input.node.meta["output_qparams"]) > 0
+        ):
+            return super().call_operator(op, args, kwargs, meta)
+
         op_full, op_ge, op_floor, op_ceil, op_where = _get_decorated_ops(op)
 
         zero = super().call_operator(

--- a/backends/arm/test/tester/test_pipeline.py
+++ b/backends/arm/test/tester/test_pipeline.py
@@ -390,14 +390,15 @@ class TosaPipelineINT(TOSAPipelineMaker, Generic[T]):
             ),
         }
         tosa_version = _require_tosa_version()
+        tosa_spec: TosaSpecification = tosa_profiles[tosa_version]
 
         compile_spec = common.get_tosa_compile_spec(
-            tosa_profiles[tosa_version],
+            tosa_spec,
             custom_path=custom_path,
             tosa_debug_mode=tosa_debug_mode,
         )
 
-        quantizer = TOSAQuantizer(tosa_profiles[tosa_version])
+        quantizer = TOSAQuantizer(tosa_spec)
         # choose 16A8W quantization config when int16 extension is requested
         if "int16" in tosa_extensions:
             quantization_config = get_symmetric_a16w8_quantization_config(
@@ -422,7 +423,7 @@ class TosaPipelineINT(TOSAPipelineMaker, Generic[T]):
         )
         self.add_stage(self.tester.quantize, quant_stage, pos=0)
 
-        remove_quant_nodes_stage = (
+        remove_torch_quant_nodes_stage = (
             "to_edge_transform_and_lower"
             if use_to_edge_transform_and_lower
             else "partition"
@@ -440,13 +441,28 @@ class TosaPipelineINT(TOSAPipelineMaker, Generic[T]):
                 suffix="quant_nodes",
             )
             self.add_stage_after(
-                remove_quant_nodes_stage,
+                remove_torch_quant_nodes_stage,
                 self.tester.check_not,
                 [
                     "torch.ops.quantized_decomposed.dequantize_per_tensor.default",
                     "torch.ops.quantized_decomposed.quantize_per_tensor.default",
                 ],
                 suffix="quant_nodes",
+            )
+
+        # For pure INT lowering, outer exir Q/DQ nodes remain in the graph because we can't partition them.
+        # In INT+FP lowering, we partition these nodes, so a check is added to verify that.
+        if tosa_spec.support_integer() and tosa_spec.support_float():
+            self.add_stage_after(
+                remove_torch_quant_nodes_stage,
+                self.tester.check_not,
+                [
+                    "executorch_exir_dialects_edge__ops_quantized_decomposed_quantize_per_tensor_default",
+                    "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_tensor_default",
+                    "executorch_exir_dialects_edge__ops_quantized_decomposed_quantize_per_channel_default",
+                    "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_channel_default",
+                ],
+                suffix="exir_quant_nodes",
             )
 
         if run_on_tosa_ref_model:
@@ -1093,6 +1109,12 @@ class VgfPipeline(BasePipelineMaker, Generic[T]):
             transform_passes=transform_passes,
         )
 
+        remove_torch_quant_nodes_stage = (
+            "to_edge_transform_and_lower"
+            if use_to_edge_transform_and_lower
+            else "partition"
+        )
+
         if quantize:
             quantizer = VgfQuantizer(compile_spec)
             quantization_config = get_symmetric_quantization_config(
@@ -1103,12 +1125,6 @@ class VgfPipeline(BasePipelineMaker, Generic[T]):
             quant_stage = Quantize(quantizer, quantization_config)
 
             self.add_stage(self.tester.quantize, quant_stage, pos=0)
-
-            remove_quant_nodes_stage = (
-                "to_edge_transform_and_lower"
-                if use_to_edge_transform_and_lower
-                else "partition"
-            )
 
             if _has_quantizable_inputs(test_data):
                 # only add stages if we have quantizable input
@@ -1122,7 +1138,7 @@ class VgfPipeline(BasePipelineMaker, Generic[T]):
                     suffix="quant_nodes",
                 )
                 self.add_stage_after(
-                    remove_quant_nodes_stage,
+                    remove_torch_quant_nodes_stage,
                     self.tester.check_not,
                     [
                         "torch.ops.quantized_decomposed.dequantize_per_tensor.default",
@@ -1139,6 +1155,21 @@ class VgfPipeline(BasePipelineMaker, Generic[T]):
                     "torch.ops.quantized_decomposed.quantize_per_tensor.default",
                 ],
                 suffix="quant_nodes",
+            )
+
+        # For pure INT lowering, outer exir Q/DQ nodes remain in the graph because we can't partition them.
+        # In INT+FP lowering, we partition these these nodes, so a check is added to verify that.
+        if tosa_spec.support_integer() and tosa_spec.support_float():
+            self.add_stage_after(
+                remove_torch_quant_nodes_stage,
+                self.tester.check_not,
+                [
+                    "executorch_exir_dialects_edge__ops_quantized_decomposed_quantize_per_tensor_default",
+                    "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_tensor_default",
+                    "executorch_exir_dialects_edge__ops_quantized_decomposed_quantize_per_channel_default",
+                    "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_channel_default",
+                ],
+                suffix="exir_quant_nodes",
             )
 
         if run_on_vulkan_runtime:


### PR DESCRIPTION
For full INT lowering without FP support, Q/DQ nodes that are on the boundary of a partition are not included in the partition. With INT+FP support, the backend is able to handle them properly. Therefore, include these boundary nodes in that setting.

To add test coverage for this new feature, a new stage called "check_not.exir_quant_nodes" is added for TosaPipelineINT and VgfPipeline in case both FP and INT profiles are enabled. This stage verifies that no exir Q/DQ remains in the graph after "to_edge_transform_and_lower" (or "partition" if
"to_edge_transform_and_lower" is omitted). In case a test fails to partition the boundary Q/DQ nodes in INT+FP lowering, it will be detected in "check_not.exir_quant_nodes". Tests in test_quant_custom_meta.py will run this new check.


cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai