### PR TITLE
FlatTensor alignment tests

### DIFF
--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -592,10 +592,13 @@ class ExecutorchProgram:
         self._constant_tensor_alignment: Optional[int] = constant_tensor_alignment
         self._delegate_alignment: Optional[int] = delegate_alignment
         from executorch.extension.flat_tensor.serialize.serialize import (
+            FlatTensorConfig,
             FlatTensorSerializer,
         )
 
-        self._data_serializer: DataSerializer = FlatTensorSerializer()
+        self._data_serializer: DataSerializer = FlatTensorSerializer(
+            FlatTensorConfig(self._segment_alignment)
+        )
 
     def _get_emitter_output(self) -> EmitterOutput:
         if self._emitter_output is None:
@@ -1851,10 +1854,13 @@ class ExecutorchProgramManager:
 
         # Serialize emitter output, ready to be written to a file.
         from executorch.extension.flat_tensor.serialize.serialize import (
+            FlatTensorConfig,
             FlatTensorSerializer,
         )
 
-        self._data_serializer = FlatTensorSerializer()
+        self._data_serializer = FlatTensorSerializer(
+            FlatTensorConfig(segment_alignment=backend_config.segment_alignment)
+        )
         self._pte_data, self._tensor_data = serialize_for_executorch(
             self._emitter_output,
             backend_config,

--- a/extension/flat_tensor/serialize/serialize.py
+++ b/extension/flat_tensor/serialize/serialize.py
@@ -39,6 +39,9 @@ from executorch.extension.flat_tensor.serialize.flat_tensor_schema import (
 # endian.
 _HEADER_BYTEORDER: Literal["little"] = "little"
 
+# Alignment of the flatbuffer (after the header).
+_FLATBUFFER_ALIGNMENT: int = 16
+
 # Current version. Keep in sync with c++ version number in serialize.
 _FLAT_TENSOR_VERSION: int = 0
 
@@ -95,8 +98,7 @@ def _deserialize_to_flat_tensor(flatbuffer: bytes) -> FlatTensor:
 
 @dataclass
 class FlatTensorConfig:
-    tensor_alignment: int = 16
-    segment_alignment: int = 16
+    segment_alignment: int = 128
 
 
 @dataclass
@@ -334,18 +336,13 @@ class FlatTensorSerializer(DataSerializer):
         )
 
         flatbuffer_payload = _serialize_to_flatbuffer(flat_tensor)
-        padded_flatbuffer_length: int = aligned_size(
-            input_size=len(flatbuffer_payload),
-            alignment=self.config.tensor_alignment,
-        )
-
         padded_header_length: int = aligned_size(
             input_size=FlatTensorHeader.EXPECTED_LENGTH,
-            alignment=self.config.tensor_alignment,
+            alignment=_FLATBUFFER_ALIGNMENT,
         )
 
         segment_base_offset = aligned_size(
-            padded_flatbuffer_length + padded_header_length,
+            len(flatbuffer_payload) + padded_header_length,
             self.config.segment_alignment,
         )
 
@@ -360,19 +357,16 @@ class FlatTensorSerializer(DataSerializer):
 
         # Pad header and payload to segment alignment.
         header_data = pad_to(header_data, padded_header_length)
-        original_flatbuffer_payload_size = len(flatbuffer_payload)
-        flatbuffer_payload.append(
-            b"\x00" * (padded_flatbuffer_length - len(flatbuffer_payload))
-        )
         injected_flatbuffer_data: bytes = _insert_flatbuffer_header(
             flatbuffer_data=flatbuffer_payload.__bytes__(),
             magic_regex=r"FT[0-9a-zA-Z][0-9a-zA-Z]",
             header_data=header_data,
         )
+        injected_flatbuffer_data = pad_to(injected_flatbuffer_data, segment_base_offset)
 
         eh = _get_extended_header(injected_flatbuffer_data)
         assert eh is not None
-        assert eh.flatbuffer_size == original_flatbuffer_payload_size
+        assert eh.flatbuffer_size == len(flatbuffer_payload)
         assert eh.segment_base_offset == segment_base_offset
         assert eh.flatbuffer_offset == padded_header_length
         assert eh.segment_data_size == len(aggregated_segment_data)


### PR DESCRIPTION
Summary:
1. Pass segment_alignment from ExecutorchBackendConfig to flat tensor serializer
2. Set segment_alignment=128 as default to match ExecutorchBackendConfig
3. Remove tensor_alignment from the config (do not have multiple tensors per segment)
4. Additional tests for varying segment alignment.

Differential Revision: D89422691


