### PR TITLE
Update first token time calculation in cuda benchmark

### DIFF
--- a/.ci/scripts/cuda_benchmark.py
+++ b/.ci/scripts/cuda_benchmark.py
@@ -73,7 +73,13 @@ def parse_pytorch_observer_log(log_line: str) -> Optional[RunMetrics]:
             else 0
         )
         model_load_time_ms = model_load_end_ms - model_load_start_ms
-        first_token_latency_ms = first_token_ms - prompt_eval_end_ms
+
+        # First token latency (TTFT): time from inference start to first token
+        # For multimodal models (e.g., whisper, voxtral, gemma3), this includes:
+        # 1. Encoding time (image/audio processing)
+        # 2. Prefill time (decoder processing encoder outputs)
+        # This represents the end-to-end user experience of waiting for the first token
+        first_token_latency_ms = first_token_ms - inference_start_ms
 
         return RunMetrics(
             generated_tokens=generated_tokens,


### PR DESCRIPTION

previously we onlu calculate the prefill time as first token time. However we should calculate the time from the model start, to the time we get the first token.

this pr updates the calculation to solve the issue