### PR TITLE
[ET-VK][ez] Add a setting to disable multithreading when compiler shaders during build

### DIFF
--- a/backends/vulkan/cmake/ShaderLibrary.cmake
+++ b/backends/vulkan/cmake/ShaderLibrary.cmake
@@ -53,6 +53,13 @@ function(gen_vulkan_shader_lib_cpp shaders_path)
     endif()
   endif()
 
+  # Add nthreads argument for shader compilation
+  if(DEFINED EXECUTORCH_VULKAN_SHADER_COMPILE_NTHREADS)
+    list(APPEND GEN_SPV_ARGS "--nthreads"
+         "${EXECUTORCH_VULKAN_SHADER_COMPILE_NTHREADS}"
+    )
+  endif()
+
   add_custom_command(
     COMMENT "Generating Vulkan Compute Shaders"
     OUTPUT ${VULKAN_SHADERGEN_OUT_PATH}/spv.cpp

--- a/backends/vulkan/targets.bzl
+++ b/backends/vulkan/targets.bzl
@@ -93,12 +93,15 @@ def vulkan_spv_shader_lib(name, spv_filegroups, is_fbcode = False, no_volk = Fal
     for target, subpath in spv_filegroups.items():
         glsl_paths.append("$(location {})/{}".format(target, subpath))
 
+    nthreads = read_config("etvk", "shader_compile_nthreads", "-1")
+
     genrule_cmd = (
         "$(exe {}) ".format(gen_vulkan_spv_target) +
         "--glsl-paths {} ".format(" ".join(glsl_paths)) +
         "--output-path $OUT " +
         "--glslc-path=$(exe {}) ".format(glslc_path) +
         "--tmp-dir-path=shader_cache " +
+        "--nthreads {} ".format(nthreads) +
         ("-f " if read_config("etvk", "force_shader_rebuild", "0") == "1" else " ") +
         select({
             "DEFAULT": "",


### PR DESCRIPTION

Summary:
## Context

Currently, the `gen_vulkan_spv.py` script which orchestrates compute shader compilation for the Vulkan backend uses a thread pool to help parallelize shader compilation.

However, when Claude Code is instructed to build ExecuTorch via CMake, it runs into permission issues when trying to launch threads.

As a workaround, this PR adds a setting to control the number of threads that is used during shader compilation. 1 will result in serial compilation and -1 will result in querying the number of processors available.
