### PR TITLE
[slimtensor migration 6/n] add copyright headers

### DIFF
--- a/backends/aoti/slim/c10/core/Contiguity.h
+++ b/backends/aoti/slim/c10/core/Contiguity.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <executorch/backends/aoti/slim/c10/util/irange.h>

--- a/backends/aoti/slim/c10/core/Device.h
+++ b/backends/aoti/slim/c10/core/Device.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <executorch/backends/aoti/slim/c10/core/DeviceType.h>

--- a/backends/aoti/slim/c10/core/DeviceType.h
+++ b/backends/aoti/slim/c10/core/DeviceType.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 // Copied from c10/core/DeviceType.h with some modifications:

--- a/backends/aoti/slim/c10/core/Layout.h
+++ b/backends/aoti/slim/c10/core/Layout.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <executorch/runtime/platform/assert.h>

--- a/backends/aoti/slim/c10/core/MemoryFormat.h
+++ b/backends/aoti/slim/c10/core/MemoryFormat.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <executorch/runtime/core/array_ref.h>

--- a/backends/aoti/slim/c10/core/Scalar.h
+++ b/backends/aoti/slim/c10/core/Scalar.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <cstdint>

--- a/backends/aoti/slim/c10/core/ScalarType.h
+++ b/backends/aoti/slim/c10/core/ScalarType.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <executorch/backends/aoti/slim/c10/util/Array.h>

--- a/backends/aoti/slim/c10/core/SizesAndStrides.h
+++ b/backends/aoti/slim/c10/core/SizesAndStrides.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <algorithm>

--- a/backends/aoti/slim/c10/core/WrapDimMinimal.h
+++ b/backends/aoti/slim/c10/core/WrapDimMinimal.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <cstdint>

--- a/backends/aoti/slim/c10/cuda/Exception.h
+++ b/backends/aoti/slim/c10/cuda/Exception.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 #ifdef USE_CUDA
 

--- a/backends/aoti/slim/c10/macros/Macros.h
+++ b/backends/aoti/slim/c10/macros/Macros.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 // SlimTensor Macros Header

--- a/backends/aoti/slim/c10/util/Array.h
+++ b/backends/aoti/slim/c10/util/Array.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <array>

--- a/backends/aoti/slim/c10/util/BFloat16-inl.h
+++ b/backends/aoti/slim/c10/util/BFloat16-inl.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <executorch/backends/aoti/slim/c10/macros/Macros.h>

--- a/backends/aoti/slim/c10/util/BFloat16-math.h
+++ b/backends/aoti/slim/c10/util/BFloat16-math.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <executorch/backends/aoti/slim/c10/util/BFloat16.h>

--- a/backends/aoti/slim/c10/util/BFloat16.h
+++ b/backends/aoti/slim/c10/util/BFloat16.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 // Defines the bloat16 type (brain floating-point). This representation uses

--- a/backends/aoti/slim/c10/util/Float4_e2m1fn_x2.h
+++ b/backends/aoti/slim/c10/util/Float4_e2m1fn_x2.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 #include <cstdint>
 

--- a/backends/aoti/slim/c10/util/Float8_e4m3fn-inl.h
+++ b/backends/aoti/slim/c10/util/Float8_e4m3fn-inl.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <executorch/backends/aoti/slim/c10/macros/Macros.h>

--- a/backends/aoti/slim/c10/util/Float8_e4m3fn.h
+++ b/backends/aoti/slim/c10/util/Float8_e4m3fn.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 /// Defines the Float8_e4m3fn type (8-bit floating-point) including conversions

--- a/backends/aoti/slim/c10/util/Float8_e4m3fnuz-inl.h
+++ b/backends/aoti/slim/c10/util/Float8_e4m3fnuz-inl.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <executorch/backends/aoti/slim/c10/macros/Macros.h>

--- a/backends/aoti/slim/c10/util/Float8_e4m3fnuz.h
+++ b/backends/aoti/slim/c10/util/Float8_e4m3fnuz.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 /// Defines the Float8_e4m3fnuz type (8-bit floating-point) including

--- a/backends/aoti/slim/c10/util/Float8_e5m2-inl.h
+++ b/backends/aoti/slim/c10/util/Float8_e5m2-inl.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <executorch/backends/aoti/slim/c10/macros/Macros.h>

--- a/backends/aoti/slim/c10/util/Float8_e5m2.h
+++ b/backends/aoti/slim/c10/util/Float8_e5m2.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 /// Defines the Float8_e5m2 type (8-bit floating-point) including conversions

--- a/backends/aoti/slim/c10/util/Float8_e5m2fnuz-inl.h
+++ b/backends/aoti/slim/c10/util/Float8_e5m2fnuz-inl.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <executorch/backends/aoti/slim/c10/macros/Macros.h>

--- a/backends/aoti/slim/c10/util/Float8_e5m2fnuz.h
+++ b/backends/aoti/slim/c10/util/Float8_e5m2fnuz.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 /// Defines the Float8_e5m2fnuz type (8-bit floating-point) including

--- a/backends/aoti/slim/c10/util/Float8_e8m0fnu-inl.h
+++ b/backends/aoti/slim/c10/util/Float8_e8m0fnu-inl.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <executorch/backends/aoti/slim/c10/macros/Macros.h>

--- a/backends/aoti/slim/c10/util/Float8_e8m0fnu.h
+++ b/backends/aoti/slim/c10/util/Float8_e8m0fnu.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 /// Defines the Float8_e8m0fnu type (8-bit floating-point) including

--- a/backends/aoti/slim/c10/util/Float8_fnuz_cvt.h
+++ b/backends/aoti/slim/c10/util/Float8_fnuz_cvt.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <executorch/backends/aoti/slim/c10/util/floating_point_utils.h>

--- a/backends/aoti/slim/c10/util/Half-inl.h
+++ b/backends/aoti/slim/c10/util/Half-inl.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <executorch/backends/aoti/slim/c10/macros/Macros.h>

--- a/backends/aoti/slim/c10/util/Half.h
+++ b/backends/aoti/slim/c10/util/Half.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 /// Defines the Half type (half-precision floating-point) including conversions

--- a/backends/aoti/slim/c10/util/StringUtil.h
+++ b/backends/aoti/slim/c10/util/StringUtil.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <sstream>

--- a/backends/aoti/slim/c10/util/TypeCast.h
+++ b/backends/aoti/slim/c10/util/TypeCast.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 #include <executorch/backends/aoti/slim/c10/macros/Macros.h>
 #include <executorch/backends/aoti/slim/c10/util/BFloat16.h>

--- a/backends/aoti/slim/c10/util/TypeSafeSignMath.h
+++ b/backends/aoti/slim/c10/util/TypeSafeSignMath.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 // Thin wrapper to reuse ExecuTorch's c10 TypeSafeSignMath implementation.

--- a/backends/aoti/slim/c10/util/accumulate.h
+++ b/backends/aoti/slim/c10/util/accumulate.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 #pragma once

--- a/backends/aoti/slim/c10/util/bit_cast.h
+++ b/backends/aoti/slim/c10/util/bit_cast.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 // Thin wrapper to reuse ExecuTorch's c10::bit_cast implementation.

--- a/backends/aoti/slim/c10/util/bits.h
+++ b/backends/aoti/slim/c10/util/bits.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 #include <cstdint>
 

--- a/backends/aoti/slim/c10/util/complex.h
+++ b/backends/aoti/slim/c10/util/complex.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <complex>

--- a/backends/aoti/slim/c10/util/complex_math.h
+++ b/backends/aoti/slim/c10/util/complex_math.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #if !defined(STANDALONE_INTERNAL_INCLUDE_COMPLEX_REMAINING_H)
 #error \
     "standalone/c10/util/complex_math.h is not meant to be individually included. Include standalone/c10/util/complex.h instead."

--- a/backends/aoti/slim/c10/util/complex_utils.h
+++ b/backends/aoti/slim/c10/util/complex_utils.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #if !defined(STANDALONE_INTERNAL_INCLUDE_COMPLEX_REMAINING_H)
 #error \
     "standalone/c10/util/complex_utils.h is not meant to be individually included. Include standalone/c10/util/complex.h instead."

--- a/backends/aoti/slim/c10/util/copysign.h
+++ b/backends/aoti/slim/c10/util/copysign.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <executorch/backends/aoti/slim/c10/util/BFloat16.h>

--- a/backends/aoti/slim/c10/util/floating_point_utils.h
+++ b/backends/aoti/slim/c10/util/floating_point_utils.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 // Thin wrapper to reuse ExecuTorch's c10 floating_point_utils implementation.

--- a/backends/aoti/slim/c10/util/generic_math.h
+++ b/backends/aoti/slim/c10/util/generic_math.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <executorch/backends/aoti/slim/c10/macros/Macros.h>

--- a/backends/aoti/slim/c10/util/irange.h
+++ b/backends/aoti/slim/c10/util/irange.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 // Thin wrapper to reuse ExecuTorch's c10::irange implementation.

--- a/backends/aoti/slim/c10/util/llvmMathExtras.h
+++ b/backends/aoti/slim/c10/util/llvmMathExtras.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 // Thin wrapper to reuse ExecuTorch's c10 llvmMathExtras implementation.

--- a/backends/aoti/slim/c10/util/overflows.h
+++ b/backends/aoti/slim/c10/util/overflows.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <executorch/backends/aoti/slim/c10/macros/Macros.h>

--- a/backends/aoti/slim/c10/util/qint32.h
+++ b/backends/aoti/slim/c10/util/qint32.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 #include <cstdint>
 

--- a/backends/aoti/slim/c10/util/qint8.h
+++ b/backends/aoti/slim/c10/util/qint8.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 #include <cstdint>
 

--- a/backends/aoti/slim/c10/util/quint2x4.h
+++ b/backends/aoti/slim/c10/util/quint2x4.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 #include <cstdint>
 

--- a/backends/aoti/slim/c10/util/quint4x2.h
+++ b/backends/aoti/slim/c10/util/quint4x2.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 #include <cstdint>
 

--- a/backends/aoti/slim/c10/util/quint8.h
+++ b/backends/aoti/slim/c10/util/quint8.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 #include <cstdint>
 

--- a/backends/aoti/slim/c10/util/safe_numerics.h
+++ b/backends/aoti/slim/c10/util/safe_numerics.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 // Thin wrapper to reuse ExecuTorch's c10 safe_numerics implementation.

--- a/backends/aoti/slim/core/SlimTensor.h
+++ b/backends/aoti/slim/core/SlimTensor.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <cassert>

--- a/backends/aoti/slim/core/SlimTensorResize-incl.h
+++ b/backends/aoti/slim/core/SlimTensorResize-incl.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <vector>

--- a/backends/aoti/slim/core/SlimTensorView-incl.h
+++ b/backends/aoti/slim/core/SlimTensorView-incl.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <vector>

--- a/backends/aoti/slim/core/Storage.h
+++ b/backends/aoti/slim/core/Storage.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 #include <cstdint>
 #include <cstring>

--- a/backends/aoti/slim/cuda/Guard.h
+++ b/backends/aoti/slim/cuda/Guard.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <cuda.h>

--- a/backends/aoti/slim/factory/Empty.h
+++ b/backends/aoti/slim/factory/Empty.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <cstdint>

--- a/backends/aoti/slim/factory/Factory.h
+++ b/backends/aoti/slim/factory/Factory.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <executorch/backends/aoti/slim/factory/Empty.h>

--- a/backends/aoti/slim/factory/FromBlob.h
+++ b/backends/aoti/slim/factory/FromBlob.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <executorch/backends/aoti/slim/core/SlimTensor.h>

--- a/backends/aoti/slim/factory/FromScalar.h
+++ b/backends/aoti/slim/factory/FromScalar.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <executorch/backends/aoti/slim/factory/Empty.h>

--- a/backends/aoti/slim/factory/Pad.h
+++ b/backends/aoti/slim/factory/Pad.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <executorch/backends/aoti/slim/factory/Empty.h>

--- a/backends/aoti/slim/util/ArrayRefUtil.h
+++ b/backends/aoti/slim/util/ArrayRefUtil.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 // Utilities for working with ExecuTorch's ArrayRef in SlimTensor code.

--- a/backends/aoti/slim/util/SharedPtr.h
+++ b/backends/aoti/slim/util/SharedPtr.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <algorithm>

--- a/backends/aoti/slim/util/SizeUtil.h
+++ b/backends/aoti/slim/util/SizeUtil.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <cstdint>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #16330
* #16329
* #16327
* #16314
* #16313
* #16304

This stack aims to migrate slim tensor into ExecuTorch stack to make it as internal tensor representation of cudabackend.

This diff makes every slimtensor file has copyright headers.

After this diff slimtensor class should be good to go.

Differential Revision: [D89507718](https://our.internmc.facebook.com/intern/diff/D89507718/)