### PR TITLE
add support for Qualcomm QCM6490

### DIFF
--- a/backends/qualcomm/serialization/qc_compiler_spec.fbs
+++ b/backends/qualcomm/serialization/qc_compiler_spec.fbs
@@ -50,6 +50,7 @@ enum QcomChipset: int {
   SAR2230P = 95,
   SA8255 = 52,
   SW6100 = 96,
+  QCS6490 = 35,
 }
 
 /// Indicate the information of the specified SoC.

--- a/backends/qualcomm/serialization/qc_compiler_spec.fbs
+++ b/backends/qualcomm/serialization/qc_compiler_spec.fbs
@@ -50,7 +50,7 @@ enum QcomChipset: int {
   SAR2230P = 95,
   SA8255 = 52,
   SW6100 = 96,
-  QCM6490 = 35,
+  QCM6490 = 93,
 }
 
 /// Indicate the information of the specified SoC.

--- a/backends/qualcomm/serialization/qc_compiler_spec.fbs
+++ b/backends/qualcomm/serialization/qc_compiler_spec.fbs
@@ -50,7 +50,7 @@ enum QcomChipset: int {
   SAR2230P = 95,
   SA8255 = 52,
   SW6100 = 96,
-  QCS6490 = 35,
+  QCM6490 = 35,
 }
 
 /// Indicate the information of the specified SoC.

--- a/backends/qualcomm/serialization/qc_schema.py
+++ b/backends/qualcomm/serialization/qc_schema.py
@@ -56,6 +56,7 @@ class QcomChipset(IntEnum):
     SAR2230P = 95  # v81
     SA8255 = 52  # v73
     SW6100 = 96  # v81
+    QCS6490 = 35  # v68
 
 
 @dataclass
@@ -82,6 +83,7 @@ _soc_info_table = {
     QcomChipset.QCS9100: SocInfo(QcomChipset.QCS9100, HtpInfo(HtpArch.V73, 8)),
     QcomChipset.SAR2230P: SocInfo(QcomChipset.SAR2230P, HtpInfo(HtpArch.V81, 4)),
     QcomChipset.SW6100: SocInfo(QcomChipset.SW6100, HtpInfo(HtpArch.V81, 4)),
+    QcomChipset.QCS6490: SocInfo(QcomChipset.QCS6490, HtpInfo(HtpArch.V68, 2)),
 }
 
 

--- a/backends/qualcomm/serialization/qc_schema.py
+++ b/backends/qualcomm/serialization/qc_schema.py
@@ -56,7 +56,7 @@ class QcomChipset(IntEnum):
     SAR2230P = 95  # v81
     SA8255 = 52  # v73
     SW6100 = 96  # v81
-    QCM6490 = 35  # v68
+    QCM6490 = 93  # v68
 
 
 @dataclass

--- a/backends/qualcomm/serialization/qc_schema.py
+++ b/backends/qualcomm/serialization/qc_schema.py
@@ -56,7 +56,7 @@ class QcomChipset(IntEnum):
     SAR2230P = 95  # v81
     SA8255 = 52  # v73
     SW6100 = 96  # v81
-    QCS6490 = 35  # v68
+    QCM6490 = 35  # v68
 
 
 @dataclass
@@ -83,7 +83,7 @@ _soc_info_table = {
     QcomChipset.QCS9100: SocInfo(QcomChipset.QCS9100, HtpInfo(HtpArch.V73, 8)),
     QcomChipset.SAR2230P: SocInfo(QcomChipset.SAR2230P, HtpInfo(HtpArch.V81, 4)),
     QcomChipset.SW6100: SocInfo(QcomChipset.SW6100, HtpInfo(HtpArch.V81, 4)),
-    QcomChipset.QCS6490: SocInfo(QcomChipset.QCS6490, HtpInfo(HtpArch.V68, 2)),
+    QcomChipset.QCM6490: SocInfo(QcomChipset.QCM6490, HtpInfo(HtpArch.V68, 2)),
 }
 
 

--- a/backends/qualcomm/utils/utils.py
+++ b/backends/qualcomm/utils/utils.py
@@ -1145,6 +1145,7 @@ def get_soc_to_arch_map():
         "QCS9100": HtpArch.V73,
         "SAR2230P": HtpArch.V81,
         "SW6100": HtpArch.V81,
+        "QCS6490": HtpArch.V68,
     }
 
 
@@ -1167,6 +1168,7 @@ def get_soc_to_chipset_map():
         "QCS9100": QcomChipset.QCS9100,
         "SAR2230P": QcomChipset.SAR2230P,
         "SW6100": QcomChipset.SW6100,
+        "QCS6490": QcomChipset.QCS6490,
     }
 
 

--- a/backends/qualcomm/utils/utils.py
+++ b/backends/qualcomm/utils/utils.py
@@ -1145,7 +1145,7 @@ def get_soc_to_arch_map():
         "QCS9100": HtpArch.V73,
         "SAR2230P": HtpArch.V81,
         "SW6100": HtpArch.V81,
-        "QCS6490": HtpArch.V68,
+        "QCM6490": HtpArch.V68,
     }
 
 
@@ -1168,7 +1168,7 @@ def get_soc_to_chipset_map():
         "QCS9100": QcomChipset.QCS9100,
         "SAR2230P": QcomChipset.SAR2230P,
         "SW6100": QcomChipset.SW6100,
-        "QCS6490": QcomChipset.QCS6490,
+        "QCM6490": QcomChipset.QCM6490,
     }
 
 

--- a/docs/source/backends-qualcomm.md
+++ b/docs/source/backends-qualcomm.md
@@ -71,6 +71,7 @@ You will need an Android / Linux device with adb-connected running on one of bel
  - SXR1230P (Linux Embedded)
  - SXR2230P
  - SXR2330P
+ - QCS6490
 
 This example is verified with SM8550 and SM8450.
 

--- a/docs/source/backends-qualcomm.md
+++ b/docs/source/backends-qualcomm.md
@@ -71,7 +71,7 @@ You will need an Android / Linux device with adb-connected running on one of bel
  - SXR1230P (Linux Embedded)
  - SXR2230P
  - SXR2330P
- - QCS6490
+ - QCM6490
 
 This example is verified with SM8550 and SM8450.
 


### PR DESCRIPTION
### Summary
This PR adds support for Qualcomm QCM6490, which has been discussed in issue #7356.

### Fixes
Fixes #7356.

### Test plan
The changes in this PR have been tested with the [official Llama example](https://github.com/pytorch/executorch/blob/v0.7.0/examples/qualcomm/oss_scripts/llama/runner/runner.cpp).