### PR TITLE
Add QCS9100 to supported Qualcomm SoCs list

### DIFF
--- a/docs/source/backends-qualcomm.md
+++ b/docs/source/backends-qualcomm.md
@@ -72,6 +72,7 @@ You will need an Android / Linux device with adb-connected running on one of bel
  - SXR2230P
  - SXR2330P
  - QCM6490
+ - QCS9100
 
 This example is verified with SM8550 and SM8450.
 


### PR DESCRIPTION
### Summary
As support for QCS9100 has been added, updated the documentation to include QCS9100 in the list of supported hardware.

cc @cccclai @winskuo-quic @shewu-quic @haowhsu-quic @DannyYuyang-quic @cbilgin