### PR TITLE
NXP backend: Update documetnation for neutron converter flavor update to SDK_25_12

### DIFF
--- a/docs/source/backends/nxp/nxp-overview.md
+++ b/docs/source/backends/nxp/nxp-overview.md
@@ -23,11 +23,11 @@ Among currently supported machine learning models are:
 ## Development Requirements
 
 - [MCUXpresso IDE](https://www.nxp.com/design/design-center/software/development-software/mcuxpresso-software-and-tools-/mcuxpresso-integrated-development-environment-ide:MCUXpresso-IDE) or [MCUXpresso Visual Studio Code extension](https://www.nxp.com/design/design-center/software/development-software/mcuxpresso-software-and-tools-/mcuxpresso-for-visual-studio-code:MCUXPRESSO-VSC)
-- [MCUXpresso SDK 25.06](https://mcuxpresso.nxp.com/mcuxsdk/25.06.00/html/index.html)
-- eIQ Neutron Converter for MCUXPresso SDK 25.06, what you can download from eIQ PyPI: 
+- [MCUXpresso SDK 25.12](https://mcuxpresso.nxp.com/mcuxsdk/25.12.00/html/index.html)
+- eIQ Neutron Converter for MCUXPresso SDK 25.12, what you can download from eIQ PyPI:
 
 ```commandline
-$ pip install --index-url https://eiq.nxp.com/repository neutron_converter_SDK_25_06
+$ pip install --index-url https://eiq.nxp.com/repository neutron_converter_SDK_25_12
 ```
 
 Instead of manually installing requirements, except MCUXpresso IDE and SDK, you can use the setup script: 

--- a/docs/source/backends/nxp/nxp-partitioner.rst
+++ b/docs/source/backends/nxp/nxp-partitioner.rst
@@ -16,7 +16,7 @@ To generate the Compile Spec for Neutron backend, you can use the `generate_neut
 Following fields can be set:
 
 * `config` - NXP platform defining the Neutron NPU configuration, e.g. "imxrt700".
-* `neutron_converter_flavor` - Flavor of the neutron-converter module to use. Neutron-converter module named neutron_converter_SDK_25_06' has flavor 'SDK_25_06'. You shall set the flavour to the MCUXpresso SDK version you will use.
+* `neutron_converter_flavor` - Flavor of the neutron-converter module to use. Neutron-converter module named neutron_converter_SDK_25_12' has flavor 'SDK_25_12'. You shall set the flavour to the MCUXpresso SDK version you will use.
 * `extra_flags` - Extra flags for the Neutron compiler.
 * `operators_not_to_delegate` - List of operators that will not be delegated.
 


### PR DESCRIPTION
Align documentation to code

### Test plan
The unit tests are in place to test the new converter.

cc @robert-kalmar @JakeStevens @digantdesai