### PR TITLE
Use std::isfinite() instead of isfinite() in portable ops.

### DIFF
--- a/examples/arm/zephyr/prj.conf
+++ b/examples/arm/zephyr/prj.conf
@@ -11,10 +11,6 @@ CONFIG_EXECUTORCH=y
 CONFIG_CPP=y
 CONFIG_STD_CPP17=y
 
-# Needed as kernels/portable/cpu/op_allclose.cpp uses isfinite() instead of std::isfinite()
-# If you fully delegated your model to Ethos-U you could remove this and save some space
-CONFIG_NEWLIB_LIBC=y
-
 # Config - increased for ExecuTorch memory requirements
 CONFIG_MAIN_STACK_SIZE=8192
 CONFIG_HEAP_MEM_POOL_SIZE=32768

--- a/kernels/portable/cpu/op_allclose.cpp
+++ b/kernels/portable/cpu/op_allclose.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  * All rights reserved.
+ * Copyright 2025 Arm Limited and/or its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
@@ -8,8 +9,8 @@
 
 #include <executorch/runtime/kernel/kernel_includes.h>
 #include <executorch/runtime/platform/compiler.h>
-#include <math.h>
 #include <string.h>
+#include <cmath>
 
 namespace torch {
 namespace executor {
@@ -42,7 +43,7 @@ bool data_is_close(
     } else {
       auto allowed_error = atol + fabs(rtol * b[i]);
       auto actual_error = fabs(a[i] - b[i]);
-      if (!isfinite(actual_error) || actual_error > allowed_error) {
+      if (!std::isfinite(actual_error) || actual_error > allowed_error) {
         return false;
       }
     }


### PR DESCRIPTION
### Summary
This make it possible to build with a simpler libc and saves some flash space. When moving from NEWLIB_LIBC in ZephyrOS to the default one we saved almost 60 Kb in the flash memory (with a simple add model, larger models/code might save less as more libc stuff are probably used).

### Test plan
Test by building ExecuTorch from ZephyrOS with and without NEWLIB_LIBC by hand.

cc @freddan80 @per @oscarandersson8218 @digantdesai