### PR TITLE
Add whisper-cuda-debug build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,21 +87,22 @@
 #
 # ==============================================================================
 
-.PHONY: voxtral-cuda voxtral-cpu voxtral-metal whisper-cuda whisper-cpu whisper-metal llama-cpu llava-cpu gemma3-cuda gemma3-cpu clean help
+.PHONY: voxtral-cuda voxtral-cpu voxtral-metal whisper-cuda whisper-cuda-debug whisper-cpu whisper-metal llama-cpu llava-cpu gemma3-cuda gemma3-cpu clean help
 
 help:
-	@echo "This Makefile adds targets to build runners for various models on various backends. Run using `make <target>`. Available targets:"
-	@echo "  voxtral-cuda   - Build Voxtral runner with CUDA backend"
-	@echo "  voxtral-cpu    - Build Voxtral runner with CPU backend"
-	@echo "  voxtral-metal  - Build Voxtral runner with Metal backend (macOS only)"
-	@echo "  whisper-cuda   - Build Whisper runner with CUDA backend"
-	@echo "  whisper-cpu    - Build Whisper runner with CPU backend"
-	@echo "  whisper-metal  - Build Whisper runner with Metal backend (macOS only)"
-	@echo "  llama-cpu      - Build Llama runner with CPU backend"
-	@echo "  llava-cpu      - Build Llava runner with CPU backend"
-	@echo "  gemma3-cuda    - Build Gemma3 runner with CUDA backend"
-	@echo "  gemma3-cpu     - Build Gemma3 runner with CPU backend"
-	@echo "  clean          - Clean build artifacts"
+	@echo "This Makefile adds targets to build runners for various models on various backends. Run using \`make <target>\`. Available targets:"
+	@echo "  voxtral-cuda        - Build Voxtral runner with CUDA backend"
+	@echo "  voxtral-cpu         - Build Voxtral runner with CPU backend"
+	@echo "  voxtral-metal       - Build Voxtral runner with Metal backend (macOS only)"
+	@echo "  whisper-cuda        - Build Whisper runner with CUDA backend"
+	@echo "  whisper-cuda-debug  - Build Whisper runner with CUDA backend (debug mode)"
+	@echo "  whisper-cpu         - Build Whisper runner with CPU backend"
+	@echo "  whisper-metal       - Build Whisper runner with Metal backend (macOS only)"
+	@echo "  llama-cpu           - Build Llama runner with CPU backend"
+	@echo "  llava-cpu           - Build Llava runner with CPU backend"
+	@echo "  gemma3-cuda         - Build Gemma3 runner with CUDA backend"
+	@echo "  gemma3-cpu          - Build Gemma3 runner with CPU backend"
+	@echo "  clean               - Clean build artifacts"
 
 voxtral-cuda:
 	@echo "==> Building and installing ExecuTorch with CUDA..."
@@ -135,6 +136,15 @@ whisper-cuda:
 	cmake --workflow --preset llm-release-cuda
 	@echo "==> Building Whisper runner with CUDA..."
 	cd examples/models/whisper && cmake --workflow --preset whisper-cuda
+	@echo ""
+	@echo "✓ Build complete!"
+	@echo "  Binary: cmake-out/examples/models/whisper/whisper_runner"
+
+whisper-cuda-debug:
+	@echo "==> Building and installing ExecuTorch with CUDA (debug mode)..."
+	cmake --workflow --preset llm-debug-cuda
+	@echo "==> Building Whisper runner with CUDA (debug mode)..."
+	cd examples/models/whisper && cmake --workflow --preset whisper-cuda-debug
 	@echo ""
 	@echo "✓ Build complete!"
 	@echo "  Binary: cmake-out/examples/models/whisper/whisper_runner"

--- a/examples/models/whisper/CMakePresets.json
+++ b/examples/models/whisper/CMakePresets.json
@@ -30,6 +30,20 @@
             }
         },
         {
+            "name": "whisper-cuda-debug",
+            "displayName": "Whisper runner (CUDA Debug)",
+            "inherits": ["whisper-base"],
+            "cacheVariables": {
+                "EXECUTORCH_BUILD_CUDA": "ON",
+                "CMAKE_BUILD_TYPE": "Debug"
+            },
+            "condition": {
+                "type": "inList",
+                "string": "${hostSystemName}",
+                "list": ["Linux", "Windows"]
+            }
+        },
+        {
             "name": "whisper-metal",
             "displayName": "Whisper runner (Metal)",
             "inherits": ["whisper-base"],
@@ -54,6 +68,12 @@
             "name": "whisper-cuda",
             "displayName": "Build Whisper runner (CUDA)",
             "configurePreset": "whisper-cuda",
+            "targets": ["whisper_runner"]
+        },
+        {
+            "name": "whisper-cuda-debug",
+            "displayName": "Build Whisper runner (CUDA Debug)",
+            "configurePreset": "whisper-cuda-debug",
             "targets": ["whisper_runner"]
         },
         {
@@ -89,6 +109,20 @@
                 {
                     "type": "build",
                     "name": "whisper-cuda"
+                }
+            ]
+        },
+        {
+            "name": "whisper-cuda-debug",
+            "displayName": "Configure and build Whisper runner (CUDA Debug)",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "whisper-cuda-debug"
+                },
+                {
+                    "type": "build",
+                    "name": "whisper-cuda-debug"
                 }
             ]
         },


### PR DESCRIPTION
Add a debug build target for Whisper with CUDA backend. This allows
building the Whisper runner with debug symbols for easier debugging.

Changes:
- Add whisper-cuda-debug target to Makefile
- Add whisper-cuda-debug presets to CMakePresets.json