### PR TITLE
Fix a typo in logging

### DIFF
--- a/extension/asr/runner/runner.cpp
+++ b/extension/asr/runner/runner.cpp
@@ -120,7 +120,7 @@ Error AsrRunner::load() {
       executorch::runtime::set_option("CudaBackend", backend_options.view());
   if (opt_err != ::executorch::runtime::Error::Ok) {
     ET_LOG(
-        Warning,
+        Error,
         "Failed to set CUDA backend options: %d",
         static_cast<int>(opt_err));
   }


### PR DESCRIPTION
CI didn't catch it because we completely turn off logging.
