### PR TITLE
Qualcomm AI Engine Direct - Update value cache for all heads in lookahead mode

### DIFF
--- a/backends/qualcomm/serialization/qc_compiler_spec.fbs
+++ b/backends/qualcomm/serialization/qc_compiler_spec.fbs
@@ -34,7 +34,7 @@ table HtpInfo {
 enum QcomChipset: int {
   UNKNOWN_SM = 0,
   SA8295 = 39,
-  SM8350 = 35,
+  SM8350 = 30,
   SM8450 = 36,
   SM8475 = 42,
   SM8550 = 43,

--- a/backends/qualcomm/serialization/qc_schema.py
+++ b/backends/qualcomm/serialization/qc_schema.py
@@ -40,7 +40,7 @@ class HtpInfo:
 class QcomChipset(IntEnum):
     UNKNOWN_SM = 0
     SA8295 = 39  # v68
-    SM8350 = 35  # v68
+    SM8350 = 30  # v68
     SM8450 = 36  # v69
     SM8475 = 42  # v69
     SM8550 = 43  # v73

--- a/examples/qualcomm/oss_scripts/llama/runner/kv_manager.cpp
+++ b/examples/qualcomm/oss_scripts/llama/runner/kv_manager.cpp
@@ -348,16 +348,20 @@ void KVManager<T>::update_value(
     }
   } else {
     int32_t update_times = n_update;
-    auto wp = write_ptr, rp = read_ptr;
-    for (auto sel : selected) {
-      if (sel) {
-        std::memcpy(wp, rp, metadata_.head_dim * sizeof(T));
-        wp += metadata_.head_dim;
-        update_times--;
-        if (update_times == 0)
-          break;
+    for (int i = 0; i < n_iter; ++i) {
+      auto wp = write_ptr, rp = read_ptr;
+      for (auto sel : selected) {
+        if (sel) {
+          std::memcpy(wp, rp, metadata_.head_dim * sizeof(T));
+          wp += metadata_.head_dim;
+          update_times--;
+          if (update_times == 0)
+            break;
+        }
+        rp += metadata_.head_dim;
       }
-      rp += metadata_.head_dim;
+      write_ptr += iter_size;
+      read_ptr += out_size;
     }
   }
 }


### PR DESCRIPTION
### Summary
- As mentioned in the title, it  currently only updates once, but it should update for each num_heads.
- Fixed soc_model of SM8350
<img width="730" height="241" alt="image" src="https://github.com/user-attachments/assets/372a6ff1-4f6b-44f8-91a3-0852758a6e36" />

### Test Plan
```
python examples/qualcomm/oss_scripts/llama/llama.py -b build-android -H <host> -s <device id> -m SM8750 --temperature 0 --checkpoint consolidated.00.pth --params params.json --tokenizer_model   tokenizer.model --decoder_model llama3_2-1b_instruct --model_mode lookahead --prefill_ar_len 64 --ngram 9 --window 4 --gcap 4 --max_seq_len 1024 --prompt "I would like to learn python, could you teach me with a simple example?" --artifact test_llama321b_lookahead944/ 
```