### PR TITLE
Add missing Buck build targets and module exports for the cortex_m quantizer package

### DIFF
--- a/backends/cortex_m/ops/TARGETS
+++ b/backends/cortex_m/ops/TARGETS
@@ -17,6 +17,7 @@ runtime.python_library(
     deps = [
         "fbcode//caffe2:torch",
         "//executorch/backends/cortex_m/passes:passes_utils",
+        "//executorch/backends/cortex_m/quantizer:quantization_configs",
     ],
 )
 

--- a/backends/cortex_m/quantizer/TARGETS
+++ b/backends/cortex_m/quantizer/TARGETS
@@ -1,0 +1,36 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+load("@fbcode_macros//build_defs:python_library.bzl", "python_library")
+
+oncall("executorch")
+
+python_library(
+    name = "quantizer",
+    srcs = [
+        "__init__.py",
+        "operator_configs.py",
+        "quantization_configs.py",
+        "quantizer.py",
+    ],
+    deps = [
+        "//caffe2:torch",
+        "//executorch/backends/arm/quantizer:quantization_config",
+        "//pytorch/ao:torchao",
+    ],
+)
+
+python_library(
+    name = "quantization_configs",
+    srcs = [
+        "quantization_configs.py",
+    ],
+    deps = [
+        "//caffe2:torch",
+        "//executorch/backends/arm/quantizer:quantization_config",
+        "//pytorch/ao:torchao",
+    ],
+)

--- a/backends/cortex_m/quantizer/__init__.py
+++ b/backends/cortex_m/quantizer/__init__.py
@@ -1,0 +1,19 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from .quantization_configs import (  # noqa
+    CMSIS_SOFTMAX_SCALE,
+    CMSIS_SOFTMAX_ZERO_POINT,
+    INT8_ACTIVATION_PER_CHANNEL_QSPEC,
+    INT8_ACTIVATION_PER_TENSOR_QSPEC,
+    INT8_PER_CHANNEL_CONFIG,
+    INT8_PER_TENSOR_CONFIG,
+    INT8_WEIGHT_PER_CHANNEL_QSPEC,
+    INT8_WEIGHT_PER_TENSOR_QSPEC,
+    SOFTMAX_OUTPUT_FIXED_QSPEC,
+    SOFTMAX_PER_TENSOR_CONFIG,
+)
+from .quantizer import CortexMQuantizer, SharedQspecQuantizer  # noqa


### PR DESCRIPTION
Summary:
This diff adds missing Buck build targets and module exports for the cortex_m quantizer package 

## Rationale

The recent diff-train commit D89549367 added softmax support to the cortex_m backend, which introduced new quantizer files (operator_configs.py, quantization_configs.py, quantizer.py). However, the following were missing:

1. **TARGETS files**: No Buck build targets existed for the quantizer package, making it impossible to depend on these modules from other targets
2. **__init__.py files**: No module exports existed, preventing proper Python package imports
3. **Dependency in ops/TARGETS**: The ops target was missing the quantization_configs dependency needed for the operators module

## Changes

- Add `quantizer` and `quantization_configs` Buck targets 
- Add `__init__.py` with proper exports for quantizer classes and config constants
- Add missing `quantization_configs` dependency to `ops/TARGETS`
- Use appropriate build macros: `runtime.python_library` for xplat, `python_library` 

Reviewed By: digantdesai

Differential Revision: D89688088


