### PR TITLE
Fix circular import in cortex_m passes using relative imports

### DIFF
--- a/backends/cortex_m/passes/cortex_m_pass_manager.py
+++ b/backends/cortex_m/passes/cortex_m_pass_manager.py
@@ -10,14 +10,6 @@ from executorch.backends.arm._passes import (
     FoldAndAnnotateQParamsPass,
     ScalarsToAttributePass,
 )
-from executorch.backends.cortex_m.passes import (
-    ActivationFusionPass,
-    ClampHardswishPass,
-    ConvertToCortexMPass,
-    DecomposeHardswishPass,
-    QuantizedOpFusionPass,
-    ReplaceQuantNodesPass,
-)
 from executorch.backends.transforms.replace_scalar_with_tensor import (
     ReplaceScalarWithTensorArgPass,
 )
@@ -25,6 +17,13 @@ from executorch.exir.pass_base import ExportPass
 from executorch.exir.pass_manager import PassManager
 from executorch.exir.program._program import _transform
 from torch.export import ExportedProgram
+
+from .activation_fusion_pass import ActivationFusionPass
+from .clamp_hardswish_pass import ClampHardswishPass
+from .convert_to_cortex_m_pass import ConvertToCortexMPass
+from .decompose_hardswish_pass import DecomposeHardswishPass
+from .quantized_op_fusion_pass import QuantizedOpFusionPass
+from .replace_quant_nodes_pass import ReplaceQuantNodesPass
 
 
 class CortexMPassManager(PassManager):

--- a/backends/cortex_m/quantizer/__init__.py
+++ b/backends/cortex_m/quantizer/__init__.py
@@ -16,4 +16,3 @@ from .quantization_configs import (  # noqa
     SOFTMAX_OUTPUT_FIXED_QSPEC,
     SOFTMAX_PER_TENSOR_CONFIG,
 )
-from .quantizer import CortexMQuantizer, SharedQspecQuantizer  # noqa


### PR DESCRIPTION
Changed cortex_m_pass_manager.py to use relative imports (from .activation_fusion_pass) instead of absolute imports (from executorch.backends.cortex_m.passes) for intra-package references. This breaks the circular import chain: __init__.py → cortex_m_pass_manager.py → __init__.py

Resolves: ImportError: cannot import name 'ActivationFusionPass' from partially initialized module 'executorch.backends.cortex_m.passes'

### Summary
[PLEASE REMOVE] See [CONTRIBUTING.md's Pull Requests](https://github.com/pytorch/executorch/blob/main/CONTRIBUTING.md#pull-requests) for ExecuTorch PR guidelines.

[PLEASE REMOVE] If this PR closes an issue, please add a `Fixes #<issue-id>` line.

[PLEASE REMOVE] If this PR introduces a fix or feature that should be the upcoming release notes, please add a "Release notes: <area>" label. For a list of available release notes labels, check out [CONTRIBUTING.md's Pull Requests](https://github.com/pytorch/executorch/blob/main/CONTRIBUTING.md#pull-requests).

### Test plan
[PLEASE REMOVE] How did you test this PR? Please write down any manual commands you used and note down tests that you have written if applicable.
