### PR TITLE
Integrate CUDA sampler into ASR runner and enable skip_copy for decoder

### DIFF
--- a/backends/cuda/runtime/cuda_backend.cpp
+++ b/backends/cuda/runtime/cuda_backend.cpp
@@ -83,7 +83,36 @@ class ET_EXPERIMENTAL CudaBackend final
       return false;
     }
     std::lock_guard<std::mutex> guard(skip_copy_method_mutex_);
-    return method_name == skip_copy_method_;
+    // Support comma-separated list of method names
+    if (skip_copy_method_.empty()) {
+      return false;
+    }
+    // Check if method_name matches any entry in the comma-separated list
+    size_t start = 0;
+    size_t end = skip_copy_method_.find(',');
+    while (end != std::string::npos) {
+      std::string entry = skip_copy_method_.substr(start, end - start);
+      // Trim whitespace
+      size_t entry_start = entry.find_first_not_of(" \t");
+      size_t entry_end = entry.find_last_not_of(" \t");
+      if (entry_start != std::string::npos) {
+        entry = entry.substr(entry_start, entry_end - entry_start + 1);
+        if (entry == method_name) {
+          return true;
+        }
+      }
+      start = end + 1;
+      end = skip_copy_method_.find(',', start);
+    }
+    // Check last (or only) entry
+    std::string entry = skip_copy_method_.substr(start);
+    size_t entry_start = entry.find_first_not_of(" \t");
+    size_t entry_end = entry.find_last_not_of(" \t");
+    if (entry_start != std::string::npos) {
+      entry = entry.substr(entry_start, entry_end - entry_start + 1);
+      return entry == method_name;
+    }
+    return false;
   }
 
   Error load_function_pointers_into_handle(

--- a/extension/asr/runner/CMakeLists.txt
+++ b/extension/asr/runner/CMakeLists.txt
@@ -42,6 +42,15 @@ if(EXECUTORCH_BUILD_CUDA)
   find_package(CUDAToolkit QUIET)
   if(CUDAToolkit_FOUND)
     target_compile_definitions(extension_asr_runner PUBLIC CUDA_AVAILABLE)
+    target_include_directories(
+      extension_asr_runner PUBLIC ${CUDAToolkit_INCLUDE_DIRS}
+    )
+    # Link against the CUDA sampler library from extension/llm/sampler
+    if(TARGET extension_llm_sampler_cuda)
+      target_link_libraries(extension_asr_runner PUBLIC extension_llm_sampler_cuda)
+    else()
+      target_link_libraries(extension_asr_runner PUBLIC CUDA::cudart)
+    endif()
     message(STATUS "CUDAToolkit found; defining CUDA_AVAILABLE for ASR runner")
   else()
     message(

--- a/extension/llm/runner/CMakeLists.txt
+++ b/extension/llm/runner/CMakeLists.txt
@@ -66,6 +66,17 @@ if(EXECUTORCH_BUILD_CUDA)
     target_compile_definitions(extension_llm_runner PUBLIC CUDA_AVAILABLE)
     target_link_libraries(extension_llm_runner PUBLIC CUDA::cudart)
     message(STATUS "CUDAToolkit found; defining CUDA_AVAILABLE")
+
+    # Build the CUDA sampler library
+    if(NOT TARGET extension_llm_sampler_cuda)
+      add_subdirectory(
+        ${EXECUTORCH_ROOT}/extension/llm/sampler
+        ${CMAKE_CURRENT_BINARY_DIR}/sampler
+      )
+    endif()
+    if(TARGET extension_llm_sampler_cuda)
+      target_link_libraries(extension_llm_runner PUBLIC extension_llm_sampler_cuda)
+    endif()
   else()
     message(
       STATUS


### PR DESCRIPTION
- cuda_backend.cpp: Support comma-separated method names in
  skip_copy_output_to_cpu_for_method backend option.
- runner.cpp: Use CudaSampler for argmax when CUDA is available and
  temperature==0. Skip copy to CPU for both encoder and decoder methods.
- CMakeLists.txt updates: Link against extension_llm_sampler_cuda library
  and include the sampler subdirectory.

This optimization keeps decoder logits on GPU and performs argmax directly
on GPU memory, avoiding unnecessary device-to-host copies in the decode loop.