### PR TITLE
Fix dynamic shape missing Symbol errors

### DIFF
--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -149,9 +149,7 @@ def _get_updated_range_constraints(gm):
     if shape_env is None:
         return {}
     range_constraints = {
-        k: v
-        for k, v in shape_env.var_to_range.items()
-        if k not in shape_env.replacements
+        shape_env.replacements.get(k, k): v for k, v in shape_env.var_to_range.items()
     }
     # Only when we have an unbacked symint, and it's used as constructor inputs,
     # runtime_var_to_range will make a difference compated to var_to_range.


### PR DESCRIPTION
Handle edge case of the range constraints of mixed Symbol + int where the replacement does not have the key.
E.g. {s11: VR[2, 32], s11 + 2048: VR[2050, 2080]}
The replacements only have key "s11" due to "s11 + 2048" is merged to s11. This is needed to the StaticAttention attention class that the attention mask append the dynamic seq_len at the last dimension.
Dynamic shapes and mixed symbol are required for the CoreML enumerated shapes as the precursor for ET enabled CoreML enumerated shape

Differential Revision: D89754133


