### PR TITLE
[Vulkan] Fix Ninja build failure by removing wildcard dependencies

### DIFF
--- a/backends/vulkan/cmake/ShaderLibrary.cmake
+++ b/backends/vulkan/cmake/ShaderLibrary.cmake
@@ -61,7 +61,12 @@ function(gen_vulkan_shader_lib_cpp shaders_path)
   endif()
 
   # Ninja cannot expand wildcards (*) in DEPENDS lists.
-  file(GLOB VULKAN_SHADERS "${shaders_path}/*.glsl")
+  file(GLOB VULKAN_SHADERS
+      "${shaders_path}/*.glsl"
+      "${shaders_path}/*.glslh"
+      "${shaders_path}/*.yaml"
+      "${shaders_path}/*.h"
+  )
 
   add_custom_command(
     COMMENT "Generating Vulkan Compute Shaders"

--- a/backends/vulkan/cmake/ShaderLibrary.cmake
+++ b/backends/vulkan/cmake/ShaderLibrary.cmake
@@ -61,11 +61,8 @@ function(gen_vulkan_shader_lib_cpp shaders_path)
   endif()
 
   # Ninja cannot expand wildcards (*) in DEPENDS lists.
-  file(GLOB VULKAN_SHADERS
-      "${shaders_path}/*.glsl"
-      "${shaders_path}/*.glslh"
-      "${shaders_path}/*.yaml"
-      "${shaders_path}/*.h"
+  file(GLOB VULKAN_SHADERS "${shaders_path}/*.glsl" "${shaders_path}/*.glslh"
+       "${shaders_path}/*.yaml" "${shaders_path}/*.h"
   )
 
   add_custom_command(

--- a/backends/vulkan/cmake/ShaderLibrary.cmake
+++ b/backends/vulkan/cmake/ShaderLibrary.cmake
@@ -60,6 +60,9 @@ function(gen_vulkan_shader_lib_cpp shaders_path)
     )
   endif()
 
+  # Ninja cannot expand wildcards (*) in DEPENDS lists.
+  file(GLOB VULKAN_SHADERS "${shaders_path}/*.glsl")
+
   add_custom_command(
     COMMENT "Generating Vulkan Compute Shaders"
     OUTPUT ${VULKAN_SHADERGEN_OUT_PATH}/spv.cpp
@@ -70,7 +73,7 @@ function(gen_vulkan_shader_lib_cpp shaders_path)
       --glslc-path=${GLSLC_PATH}
       --tmp-dir-path=${VULKAN_SHADERGEN_OUT_PATH}/shader_cache/ --env
       ${VULKAN_GEN_ARG_ENV} ${GEN_SPV_ARGS}
-    DEPENDS ${shaders_path}/*
+    DEPENDS ${VULKAN_SHADERS}
             ${EXECUTORCH_ROOT}/backends/vulkan/runtime/gen_vulkan_spv.py
   )
 


### PR DESCRIPTION
### Summary
Fixes Ninja build support for the Vulkan backend by removing wildcard usage in `DEPENDS`.

Fixes #16354
Fixes #14984

The [backends/vulkan/cmake/ShaderLibrary.cmake](cci:7://file:///Users/srirambharadwaj/Documents/iiitb/moonlight/executorch/backends/vulkan/cmake/ShaderLibrary.cmake:0:0-0:0) file previously used a wildcard (`${shaders_path}/*`) in the `DEPENDS` clause of a custom command. Ninja does not support wildcard expansion in dependencies, which caused the build to fail with:
`ninja: error: '.../glsl/*', needed by 'vk_compute_shaders/spv.cpp', missing and no known rule to make it`.

This PR replaces the wildcard usage with an explicit [file(GLOB ...)](cci:1://file:///Users/srirambharadwaj/Documents/iiitb/moonlight/executorch/examples/portable/executor_runner/executor_runner.cpp:165:0-180:1) command to resolve the source files before passing them to `DEPENDS`, making the build compatible with the Ninja generator.

### Test plan
Verified the fix by rebuilding the Android `executor_runner` using Ninja:

1.  **Clean Build:** `rm -rf cmake-out-android`
2.  **Configure:**
    ```bash
    cmake . -G Ninja -DCMAKE_INSTALL_PREFIX=cmake-out-android \
      -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake \
      -DANDROID_ABI=arm64-v8a \
      -DANDROID_PLATFORM=android-26 \
      -DEXECUTORCH_BUILD_VULKAN=ON \
      -DEXECUTORCH_BUILD_EXTENSION_DATA_LOADER=ON \
      -DEXECUTORCH_BUILD_EXTENSION_MODULE=ON \
      -DEXECUTORCH_BUILD_EXTENSION_TENSOR=ON \
      -DEXECUTORCH_BUILD_EXTENSION_NAMED_DATA_MAP=ON \
      -DEXECUTORCH_BUILD_EXTENSION_LLM=OFF \
      -DPYTHON_EXECUTABLE=$(which python) \
      -Bcmake-out-android
    ```
3.  **Build:** `ninja -C cmake-out-android` -> **Success** (previously failed).
4.  **Runtime Verification:** Pushed the built `executor_runner` to an Android device and executed a MobileNetV2 model to ensure the binary loads and runs (confirmed same runtime behavior as the Make build).

cc @SS-JIA @manuelcandales @digantdesai @cbilgin