### PR TITLE
[ET-VK][testing] Fix qdq8ta_conv2d_activations test failures via configurable shader filtering

### DIFF
--- a/backends/vulkan/test/custom_ops/qdq8ta_conv2d_activations.cpp
+++ b/backends/vulkan/test/custom_ops/qdq8ta_conv2d_activations.cpp
@@ -82,6 +82,10 @@ TestCase create_test_case_from_config(
 
   test_case.set_abs_tolerance(scale_val + 1e-4);
 
+  // Use layout-only filter for this test since quantize/dequantize ARE the
+  // operations being tested, not overhead
+  test_case.set_shader_filter(kLayoutOnlyShaderFilter);
+
   return test_case;
 }
 

--- a/backends/vulkan/test/custom_ops/utils.h
+++ b/backends/vulkan/test/custom_ops/utils.h
@@ -40,6 +40,24 @@ bool debugging();
 void set_debugging(bool enable_debugging);
 
 //
+// Shader filter defaults
+//
+
+// Default shader filter: excludes layout conversions and quantization overhead
+// This is used for tests where quantize/dequantize are overhead operations
+inline const std::vector<std::string> kDefaultShaderFilter = {
+    "nchw_to",
+    "to_nchw",
+    "quantize_and_pack_4w4c",
+    "unpack_4w4c_and_dequantize"};
+
+// Layout-only filter: only excludes layout conversions
+// Use this for tests where quantize/dequantize ARE the operations being tested
+inline const std::vector<std::string> kLayoutOnlyShaderFilter = {
+    "nchw_to",
+    "to_nchw"};
+
+//
 // ValueSpec class
 //
 
@@ -332,9 +350,15 @@ struct ValueSpec {
 
 class TestCase {
  public:
-  TestCase() : abs_tolerance_(2e-3f), rel_tolerance_(1e-3f) {}
+  TestCase()
+      : abs_tolerance_(2e-3f),
+        rel_tolerance_(1e-3f),
+        shader_filter_(kDefaultShaderFilter) {}
   TestCase(const std::string& name)
-      : name_(name), abs_tolerance_(2e-3f), rel_tolerance_(1e-3f) {}
+      : name_(name),
+        abs_tolerance_(2e-3f),
+        rel_tolerance_(1e-3f),
+        shader_filter_(kDefaultShaderFilter) {}
 
   void set_name(const std::string& name) {
     name_ = name;
@@ -363,6 +387,15 @@ class TestCase {
   }
   float get_rel_tolerance() const {
     return rel_tolerance_;
+  }
+
+  // Shader filter settings - list of shader name patterns to exclude from
+  // timing
+  void set_shader_filter(const std::vector<std::string>& filter) {
+    shader_filter_ = filter;
+  }
+  const std::vector<std::string>& get_shader_filter() const {
+    return shader_filter_;
   }
 
   void add_input_spec(const ValueSpec& spec) {
@@ -407,6 +440,7 @@ class TestCase {
     operator_name_.clear();
     abs_tolerance_ = 2e-3f;
     rel_tolerance_ = 1e-3f;
+    shader_filter_ = kDefaultShaderFilter;
   }
 
  private:
@@ -416,6 +450,7 @@ class TestCase {
   std::vector<ValueSpec> outputs_;
   float abs_tolerance_;
   float rel_tolerance_;
+  std::vector<std::string> shader_filter_;
 };
 
 //


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #16403
* __->__ #16402

The qdq8ta_conv2d_activations correctness tests were failing because the GPU timing collection function was filtering out quantize_and_pack_4w4c and unpack_4w4c_and_dequantize shaders from timing measurements. For these tests, these shaders ARE the operations being tested, not overhead.

This change refactors shader filtering to be configurable per test case:
- Added shader_filter member to TestCase class with getter/setter methods
- Created kDefaultShaderFilter (filters layout conversions + quantization) for backward compatibility
- Created kLayoutOnlyShaderFilter (filters only layout conversions) for tests where quantization is the primary operation
- Updated collect_gpu_timing_us() to accept shader_filter parameter
- Updated qdq8ta_conv2d_activations to use kLayoutOnlyShaderFilter

This allows tests to control what shaders are excluded from timing measurements based on what they're actually testing, while maintaining backward compatibility for all existing tests.

Differential Revision: [D89832383](https://our.internmc.facebook.com/intern/diff/D89832383/)