### PR TITLE
enable gpu test in internal ci

### DIFF
--- a/backends/cuda/runtime/shims/tests/targets.bzl
+++ b/backends/cuda/runtime/shims/tests/targets.bzl
@@ -19,6 +19,10 @@ def cuda_shim_cpp_unittest(name):
         external_deps = [
             ("cuda", None, "cuda-lazy"),
         ],
+        keep_gpu_sections = True,
+        remote_execution = re_test_utils.remote_execution(
+            platform = "gpu-remote-execution",
+        ),
     )
 
 def define_common_targets():

--- a/backends/cuda/runtime/tests/targets.bzl
+++ b/backends/cuda/runtime/tests/targets.bzl
@@ -1,4 +1,5 @@
 load("@fbcode_macros//build_defs:cpp_unittest.bzl", "cpp_unittest")
+load("@fbcode_macros//build_defs/lib:re_test_utils.bzl", "re_test_utils")
 
 def cuda_runtime_cpp_unittest(name):
     cpp_unittest(
@@ -15,6 +16,10 @@ def cuda_runtime_cpp_unittest(name):
         external_deps = [
             ("cuda", None, "cuda-lazy"),
         ],
+        keep_gpu_sections = True,
+        remote_execution = re_test_utils.remote_execution(
+            platform = "gpu-remote-execution",
+        ),
     )
 
 def define_common_targets():


### PR DESCRIPTION
Summary: This diff adds RE settings and buck ci package label to make sure gpu cis for cuda backend runtime can be run internally

Differential Revision: D89829958


