### PR TITLE
[ET-VK][testing] Fix on-device tests

### DIFF
--- a/backends/vulkan/test/op_tests/utils/gen_benchmark_vk.py
+++ b/backends/vulkan/test/op_tests/utils/gen_benchmark_vk.py
@@ -31,6 +31,7 @@ class GeneratedOpBenchmark_{op_name} : public ::benchmark::Fixture {{
   {arg_valuerefs}
 
   void SetUp(::benchmark::State& state) override {{
+    torch::manual_seed(42);
     GraphConfig config;
     config.descriptor_pool_safety_factor = 2.0;
     test_dtype = at::ScalarType(state.range(0));
@@ -199,10 +200,12 @@ vkapi::ScalarType from_at_scalartype(c10::ScalarType at_scalartype) {{
 at::Tensor make_casted_randint_tensor(
     std::vector<int64_t> sizes,
     at::ScalarType dtype = at::kFloat,
-    int low = 0,
-    int high = 10) {{
+    int64_t low = 1,
+    int64_t high = 20) {{
 
-  return at::randint(high, sizes, at::device(at::kCPU).dtype(dtype));
+  // For some reason range needs to be passed in as explicit variables
+  // otherwise 0s will be generated.
+  return at::randint(1, 20, sizes, at::device(at::kCPU).dtype(dtype));
 }}
 
 at::Tensor make_rand_tensor(
@@ -234,7 +237,7 @@ at::Tensor make_seq_tensor(
 
   std::vector<float> values(n);
   for (int i=0;i<n;i++) {{
-    values[i] = (float) i;
+    values[i] = (float) (i + 1);
   }}
 
   // Clone as original data will be deallocated upon return.

--- a/backends/vulkan/test/op_tests/utils/gen_correctness_base.py
+++ b/backends/vulkan/test/op_tests/utils/gen_correctness_base.py
@@ -286,10 +286,12 @@ cpp_test_template = """
 at::Tensor make_casted_randint_tensor(
     std::vector<int64_t> sizes,
     at::ScalarType dtype = at::kFloat,
-    int low = 0,
-    int high = 10) {{
+    int64_t low = 1,
+    int64_t high = 20) {{
 
-  return at::randint(high, sizes, at::device(at::kCPU).dtype(dtype));
+  // For some reason range needs to be passed in as explicit variables
+  // otherwise 0s will be generated.
+  return at::randint(1, 20, sizes, at::device(at::kCPU).dtype(dtype));
 }}
 
 at::Tensor make_rand_tensor(
@@ -341,7 +343,7 @@ at::Tensor make_seq_tensor(
 
   std::vector<float> values(n);
   for (int i=0;i<n;i++) {{
-    values[i] = (float) i;
+    values[i] = (float) (i + 1);
   }}
 
   // Clone as original data will be deallocated upon return.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #16412

The Malibu on-device tests have been failing for a while because the export script is trying to access a manifold asset that seems to no longer exist.

Since our team does not own the export process, it is unclear how to resolve the export issue. Therefore, remove the export step from the testing flow. The production model is still tested as part of the flow.

Additionally, start running basic test binary and the full ATen operator test suite as part of the android arm64 on device tests for better test coverage.

Also add some improvements to the generated operator tests
1. Use seed locking for consistent inputs
2. Make sure generate functions that generate integers cannot generate 0
3. Fix issue with generate_casted_randint function - before, it was producing a tensor with all zeros.

Differential Revision: [D89901783](https://our.internmc.facebook.com/intern/diff/D89901783/)