### PR TITLE
[ET-VK][ez] Fix NaN propagation in binary div operations for padded texels

### DIFF
--- a/backends/vulkan/runtime/graph/ops/glsl/binary_op.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/binary_op.yaml
@@ -10,6 +10,7 @@ binary_op:
     NDIM: 3
     DTYPE: float
     PACKING: C_packed
+    MASK_PADDING: 0
   generate_variant_forall:
     STORAGE:
       - VALUE: texture3d
@@ -26,10 +27,12 @@ binary_op:
       OPERATOR: X * Y
     - NAME: binary_div
       OPERATOR: X / Y
+      MASK_PADDING: 1
     - NAME: binary_pow
       OPERATOR: pow(X, Y)
     - NAME: binary_floor_divide
       OPERATOR: floor(X / Y)
+      MASK_PADDING: 1
     - NAME: binary_minimum
       OPERATOR: min(X, Y)
     - NAME: binary_eq_int32


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #16420
* __->__ #16419

When the packed dimension size is not a multiple of 4, texture-backed
tensors have padding elements in the last texel. For division operations,
these padding regions contain 0/0 = NaN, which propagates through
subsequent reduction operations and corrupts results.

This fix adds conditional padding masking logic to binary_op shaders:
- Introduced MASK_PADDING codegen variable to binary_op.yaml
- Enabled MASK_PADDING=1 for binary_div and binary_floor_divide ops
- Added GLSL preprocessor macro definition in binary_op.glsl
- Implemented padding masking logic using modulo arithmetic to correctly
  identify last texels in batch concatenation scenarios
- Padding elements are explicitly zeroed out to prevent NaN propagation

The implementation follows GLSL best practices by using Python
preprocessing only for macro definition, keeping core shader logic
as pure GLSL with standard #ifdef directives.

Differential Revision: [D89935220](https://our.internmc.facebook.com/intern/diff/D89935220/)