### PR TITLE
lpai e2e & minimum inference runtime support

### DIFF
--- a/backends/qualcomm/CMakeLists.txt
+++ b/backends/qualcomm/CMakeLists.txt
@@ -239,11 +239,28 @@ target_link_libraries(
           shared_buffer
           qnn_dlc_manager
 )
-target_link_libraries(
-  qnn_executorch_backend
-  PRIVATE qnn_executorch_header qnn_schema qnn_manager executorch_core
-          extension_tensor qnn_backend_options
-)
+if(${CMAKE_SYSTEM_PROCESSOR} MATCHES Hexagon)
+  link_directories(
+    $ENV{HEXAGON_TOOLS_ROOT}/Tools/target/hexagon/lib/$ENV{HEXAGON_ARCH}/G0/pic
+  )
+  target_link_libraries(
+    qnn_executorch_backend
+    PRIVATE qnn_executorch_header
+            qnn_schema
+            qnn_manager
+            executorch_core
+            extension_tensor
+            qnn_backend_options
+            c
+            c++
+  )
+else()
+  target_link_libraries(
+    qnn_executorch_backend
+    PRIVATE qnn_executorch_header qnn_schema qnn_manager executorch_core
+            extension_tensor qnn_backend_options
+  )
+endif()
 set_target_properties(
   qnn_executorch_backend PROPERTIES LINK_FLAGS "-Wl,-rpath='$ORIGIN'"
 )
@@ -277,6 +294,13 @@ install(
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/executorch/backends/qualcomm
   RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR}/executorch/backends/qualcomm
 )
+
+if(DEFINED ENV{HEXAGON_SDK_ROOT})
+  add_subdirectory(
+    ${QNN_EXECUTORCH_ROOT_DIR}/fastrpc
+    ${CMAKE_CURRENT_BINARY_DIR}/qnn_executorch/fastrpc
+  )
+endif()
 
 # QNN pybind
 if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64")

--- a/backends/qualcomm/fastrpc/CMakeLists.txt
+++ b/backends/qualcomm/fastrpc/CMakeLists.txt
@@ -1,0 +1,78 @@
+# Copyright (c) Qualcomm Innovation Center, Inc.
+# Copyright 2025 Arm Limited and/or its affiliates.
+# All rights reserved
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+set(_qnn_fastrpc__dir ${CMAKE_BINARY_DIR}/backends/qualcomm/fastrpc)
+set(_qnn_fastrpc__srcs ${CMAKE_CURRENT_LIST_DIR}/qnn_executorch.idl)
+set(_qnn_fastrpc__outputs
+    ${_qnn_fastrpc__dir}/qnn_executorch.h
+    ${_qnn_fastrpc__dir}/qnn_executorch_stub.c
+    ${_qnn_fastrpc__dir}/qnn_executorch_skel.c
+)
+
+if(DEFINED ENV{HEXAGON_SDK_ROOT})
+  add_custom_command(
+    OUTPUT ${_qnn_fastrpc__outputs}
+    COMMAND mkdir -p ${_qnn_fastrpc__dir}
+    COMMAND
+      $ENV{HEXAGON_SDK_ROOT}/ipc/fastrpc/qaic/bin/qaic -I
+      $ENV{HEXAGON_SDK_ROOT}/incs -I $ENV{HEXAGON_SDK_ROOT}/incs/stddef -o
+      ${_qnn_fastrpc__dir} ${_qnn_fastrpc__srcs}
+    WORKING_DIRECTORY ${EXECUTORCH_SOURCE_DIR}
+    DEPENDS qnn_executorch_backend
+    COMMENT "Codegen for fastrpc files"
+  )
+  add_custom_target(
+    fastrpc_codegen
+    DEPENDS ${_qnn_fastrpc__outputs}
+    COMMENT "Codegen for fastrpc files"
+  )
+
+endif()
+
+if(${CMAKE_SYSTEM_PROCESSOR} MATCHES Hexagon)
+  add_library(
+    qnn_executorch_skel SHARED
+    ${_qnn_fastrpc__dir}/qnn_executorch.h
+    ${_qnn_fastrpc__dir}/qnn_executorch_skel.c qnn_executorch_impl.cpp
+  )
+  target_include_directories(qnn_executorch_skel PRIVATE ${_qnn_fastrpc__dir})
+  target_link_libraries(
+    qnn_executorch_skel PRIVATE extension_data_loader qnn_executorch_backend
+                                c++ c
+  )
+  add_dependencies(qnn_executorch_skel fastrpc_codegen)
+endif()
+
+if(${CMAKE_SYSTEM_PROCESSOR} MATCHES aarch64)
+  include_directories(
+    $ENV{HEXAGON_SDK_ROOT}/incs $ENV{HEXAGON_SDK_ROOT}/incs/stddef
+    ${_qnn_fastrpc__dir}
+  )
+  link_directories(
+    $ENV{HEXAGON_SDK_ROOT}/ipc/fastrpc/remote/ship/android_aarch64
+  )
+  add_library(
+    qnn_executorch_stub SHARED ${_qnn_fastrpc__dir}/qnn_executorch.h
+                               ${_qnn_fastrpc__dir}/qnn_executorch_stub.c
+  )
+  # TODO: support cdsp if necessary
+  target_link_libraries(qnn_executorch_stub PRIVATE adsprpc)
+  add_dependencies(qnn_executorch_stub fastrpc_codegen)
+
+  # build minimum example app
+  add_executable(qnn_executor_runner qnn_executor_runner.cpp)
+  target_link_libraries(
+    qnn_executor_runner PRIVATE executorch_core gflags qnn_executorch_stub
+                                adsprpc
+  )
+  # TODO: support cdsp if necessary
+  target_link_libraries(qnn_executor_runner PRIVATE adsprpc)
+endif()

--- a/backends/qualcomm/fastrpc/qnn_executor_runner.cpp
+++ b/backends/qualcomm/fastrpc/qnn_executor_runner.cpp
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) Qualcomm Innovation Center, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <chrono>
+#include <fstream>
+#include <memory>
+#include <numeric>
+
+#include <executorch/runtime/platform/assert.h>
+#include <gflags/gflags.h>
+
+#include "qnn_executorch.h"
+
+DEFINE_string(
+    model_path,
+    "model.pte",
+    "Model serialized in flatbuffer format.");
+DEFINE_string(
+    output_folder_path,
+    ".",
+    "Executorch inference data output path.");
+DEFINE_string(input_list_path, "input_list.txt", "Model input list path.");
+
+int main(int argc, char** argv) {
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  if (argc != 1) {
+    std::string msg = "extra commandline args:";
+    for (int i = 1 /* skip argv[0] (program name) */; i < argc; i++) {
+      msg += std::string(" ") + argv[i];
+    }
+    ET_LOG(Error, "%s", msg.c_str());
+    return 1;
+  }
+
+  // fastrpc related
+  // adsp
+  const int adsp_domain_id = 0;
+  // signed PD
+  const int enable_unsigned_pd = 0;
+  // domain uri
+  std::string domain_uri(qnn_executorch_URI);
+  domain_uri += "&_dom=adsp";
+  // init session
+  struct remote_rpc_control_unsigned_module data;
+  data.domain = adsp_domain_id;
+  data.enable = enable_unsigned_pd;
+  int err = AEE_SUCCESS;
+  ET_CHECK_MSG(
+      AEE_SUCCESS ==
+          (err = remote_session_control(
+               DSPRPC_CONTROL_UNSIGNED_MODULE, (void*)&data, sizeof(data))),
+      "remote_session_control failed: 0x%x",
+      err);
+  // start session
+  remote_handle64 handle = -1;
+  ET_CHECK_MSG(
+      AEE_SUCCESS == (err = qnn_executorch_open(domain_uri.data(), &handle)),
+      "qnn_executorch_open failed: 0x%x",
+      err);
+  // load model
+  const char* model_path = FLAGS_model_path.c_str();
+  qnn_executorch_load(handle, model_path);
+
+  // prepare io
+  std::vector<std::vector<uint8_t>> input_data, output_data;
+  std::vector<tensor> input_tensor, output_tensor;
+  for (int i = 0;; ++i) {
+    int nbytes = 0;
+    qnn_executorch_get_input_size(handle, model_path, i, &nbytes);
+    if (nbytes == -1) {
+      break;
+    }
+    input_data.emplace_back(std::vector<uint8_t>(nbytes));
+    input_tensor.emplace_back(
+        tensor({input_data.back().data(), (int)input_data.back().size()}));
+  }
+  for (int i = 0;; ++i) {
+    int nbytes = 0;
+    qnn_executorch_get_output_size(handle, model_path, i, &nbytes);
+    if (nbytes == -1) {
+      break;
+    }
+    output_data.emplace_back(std::vector<uint8_t>(nbytes));
+    output_tensor.emplace_back(
+        tensor({output_data.back().data(), (int)output_data.back().size()}));
+  }
+
+  // prepare input data
+  std::ifstream input_list(FLAGS_input_list_path);
+  // TODO: should check IO info via fastrpc first
+  if (input_list.is_open()) {
+    auto split = [](std::string s, std::string delimiter) {
+      size_t pos_start = 0, pos_end, delim_len = delimiter.length();
+      std::string token;
+      std::vector<std::string> res;
+
+      while ((pos_end = s.find(delimiter, pos_start)) != std::string::npos) {
+        token = s.substr(pos_start, pos_end - pos_start);
+        pos_start = pos_end + delim_len;
+        res.push_back(token);
+      }
+      res.push_back(s.substr(pos_start));
+      return res;
+    };
+
+    std::string file_path;
+    int inference_index = 0;
+    while (std::getline(input_list, file_path)) {
+      auto input_files = split(file_path, " ");
+      if (input_files.size() == 0) {
+        break;
+      }
+      size_t num_inputs = input_files.size();
+      for (int i = 0; i < num_inputs; ++i) {
+        std::ifstream fin(input_files[i], std::ios::binary);
+        fin.seekg(0, fin.end);
+        size_t file_size = fin.tellg();
+        fin.seekg(0, fin.beg);
+        fin.read((char*)input_data[i].data(), file_size);
+        fin.close();
+      }
+      qnn_executorch_set_input(
+          handle, model_path, input_tensor.data(), input_tensor.size());
+      qnn_executorch_execute(handle, model_path);
+      qnn_executorch_get_output(
+          handle, model_path, output_tensor.data(), output_tensor.size());
+      for (size_t i = 0; i < output_tensor.size(); i++) {
+        auto output_file_name = FLAGS_output_folder_path + "/output_" +
+            std::to_string(inference_index) + "_" + std::to_string(i) + ".raw";
+        std::ofstream fout(output_file_name.c_str(), std::ios::binary);
+        fout.write(
+            (const char*)output_tensor[i].data, output_tensor[i].dataLen);
+        fout.close();
+      }
+    }
+  }
+
+  // unload model
+  qnn_executorch_unload(handle, model_path);
+  // tear down
+  qnn_executorch_close(handle);
+  return 0;
+}

--- a/backends/qualcomm/fastrpc/qnn_executorch.idl
+++ b/backends/qualcomm/fastrpc/qnn_executorch.idl
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Qualcomm Innovation Center, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "AEEStdDef.idl"
+#include "remote.idl"
+
+/// Enabling stub-skel mismatch check feature in the auto-gen files.
+/// Please refer to the IDL documentation for more details on the feature.
+/// It is fully supported only on Kailua and later targets.
+const string IDL_VERSION = "0.0.0";
+
+typedef sequence<uint8> tensor;
+
+interface qnn_executorch : remote_handle64 {
+   long load(in string pte_path);
+   long get_input_size(in string pte_path, in long index, rout long nbytes);
+   long set_input(in string pte_path, in sequence<tensor> tensors);
+   long execute(in string pte_path);
+   long get_output_size(in string pte_path, in long index, rout long nbytes);
+   long get_output(in string pte_path, rout sequence<tensor> tensors);
+   long unload(in string pte_path);
+};

--- a/backends/qualcomm/fastrpc/qnn_executorch_impl.cpp
+++ b/backends/qualcomm/fastrpc/qnn_executorch_impl.cpp
@@ -1,0 +1,314 @@
+#include <chrono>
+#include <fstream>
+#include <memory>
+#include <unordered_map>
+
+#include <executorch/extension/data_loader/file_data_loader.h>
+#include <executorch/runtime/core/memory_allocator.h>
+#include <executorch/runtime/executor/method.h>
+#include <executorch/runtime/executor/program.h>
+#include <executorch/runtime/platform/log.h>
+#include <executorch/runtime/platform/runtime.h>
+
+#include <dlfcn.h>
+#include "System/QnnSystemInterface.h"
+#include "qnn_executorch.h"
+
+#include "HAP_farf.h"
+
+using executorch::aten::Tensor;
+using executorch::aten::TensorImpl;
+using executorch::extension::FileDataLoader;
+using executorch::runtime::Error;
+using executorch::runtime::HierarchicalAllocator;
+using executorch::runtime::MemoryAllocator;
+using executorch::runtime::MemoryManager;
+using executorch::runtime::Method;
+using executorch::runtime::MethodMeta;
+using executorch::runtime::Program;
+using executorch::runtime::Result;
+using executorch::runtime::Span;
+
+class SimpleWrapper {
+ public:
+  SimpleWrapper(const char* pte_path) {
+    auto loader = FileDataLoader::from(pte_path, 256);
+    if (!loader.ok()) {
+      FARF(
+          RUNTIME_ERROR,
+          "FileDataLoader::from() failed: 0x%x",
+          (int)loader.error());
+      return;
+    }
+    loader_ = std::make_unique<FileDataLoader>(std::move(loader.get()));
+
+    auto program = Program::load(loader_.get());
+    if (!program.ok()) {
+      FARF(RUNTIME_ERROR, "failed to parse model file %s", pte_path);
+      return;
+    }
+    program_ = std::make_unique<Program>(std::move(program.get()));
+
+    auto method_name = program_->get_method_name(0);
+    if (!method_name.ok()) {
+      FARF(RUNTIME_ERROR, "program has no methods");
+      return;
+    }
+    FARF(RUNTIME_HIGH, "using method %s", *method_name);
+
+    auto method_meta = program_->method_meta(*method_name);
+    if (!method_meta.ok()) {
+      FARF(
+          RUNTIME_ERROR,
+          "failed to get method_meta for %s: 0x%x",
+          *method_name,
+          (unsigned int)method_meta.error());
+      return;
+    }
+    method_meta_ = std::make_unique<MethodMeta>(std::move(method_meta.get()));
+
+    method_allocator_ = std::make_unique<MemoryAllocator>(
+        sizeof(method_allocator_pool_), method_allocator_pool_);
+
+    for (size_t id = 0; id < method_meta_->num_memory_planned_buffers(); ++id) {
+      size_t buffer_size = static_cast<size_t>(
+          method_meta->memory_planned_buffer_size(id).get());
+      planned_buffers_.push_back(std::make_unique<uint8_t[]>(buffer_size));
+      planned_spans_.push_back({planned_buffers_.back().get(), buffer_size});
+    }
+    planned_memory_ = std::make_unique<HierarchicalAllocator>(
+        Span<Span<uint8_t>>{planned_spans_.data(), planned_spans_.size()});
+
+    memory_manager_ = std::make_unique<MemoryManager>(
+        method_allocator_.get(), planned_memory_.get());
+
+    auto method = program_->load_method(*method_name, memory_manager_.get());
+    if (!method.ok()) {
+      FARF(
+          RUNTIME_ERROR,
+          "loading of method %s failed with status 0x%x",
+          *method_name,
+          (int)method.error());
+    }
+    method_ = std::make_unique<Method>(std::move(method.get()));
+
+    input_tensors_.resize(method_->inputs_size());
+    for (int i = 0; i < input_tensors_.size(); ++i) {
+      auto tensor_meta = method_meta_->input_tensor_meta(i);
+      input_tensors_[i].resize(padded_size(tensor_meta->nbytes()));
+      input_tensor_impls_.emplace_back(TensorImpl(
+          tensor_meta->scalar_type(),
+          tensor_meta->sizes().size(),
+          const_cast<TensorImpl::SizesType*>(tensor_meta->sizes().data()),
+          align_ptr(input_tensors_[i].data()),
+          const_cast<TensorImpl::DimOrderType*>(
+              tensor_meta->dim_order().data())));
+      Error ret = method_->set_input(Tensor(&input_tensor_impls_.back()), i);
+      if (ret != Error::Ok) {
+        FARF(RUNTIME_ERROR, "failed to set input tensor: %d", (int)ret);
+        return;
+      }
+    }
+    output_tensors_.resize(method_->outputs_size());
+    for (int i = 0; i < output_tensors_.size(); ++i) {
+      auto tensor_meta = method_meta_->output_tensor_meta(i);
+      output_tensors_[i].resize(padded_size(tensor_meta->nbytes()));
+      Error ret = method_->set_output_data_ptr(
+          align_ptr(output_tensors_[i].data()), tensor_meta->nbytes(), i);
+      if (ret != Error::Ok) {
+        FARF(RUNTIME_ERROR, "failed to set output tensor: %d", (int)ret);
+        return;
+      }
+    }
+  }
+
+  size_t padded_size(size_t sz) {
+    size_t new_sz = alignment_ + sz;
+    return new_sz;
+  }
+
+  void* align_ptr(void* ptr) {
+    void* addr = reinterpret_cast<void*>(
+        ((size_t)ptr + (alignment_ - 1)) & ~(alignment_ - 1));
+    return addr;
+  }
+
+  int get_input_size(const int index) {
+    if (index < input_tensors_.size()) {
+      auto tensor_meta = method_meta_->input_tensor_meta(index);
+      return tensor_meta.ok() ? tensor_meta->nbytes() : -1;
+    }
+    return -1;
+  }
+
+  void set_input(int index, const tensor& t) {
+    if (padded_size(t.dataLen) > input_tensors_[index].size()) {
+      FARF(
+          RUNTIME_ERROR,
+          "input tensor %d size mismatched: %d vs %d",
+          index,
+          input_tensors_[index].size(),
+          t.dataLen);
+      return;
+    }
+    std::memcpy(align_ptr(input_tensors_[index].data()), t.data, t.dataLen);
+  }
+
+  int get_output_size(const int index) {
+    if (index < output_tensors_.size()) {
+      auto tensor_meta = method_meta_->output_tensor_meta(index);
+      return tensor_meta.ok() ? tensor_meta->nbytes() : -1;
+    }
+    return -1;
+  }
+
+  void get_output(int index, tensor& t) {
+    if (padded_size(t.dataLen) > output_tensors_[index].size()) {
+      FARF(
+          RUNTIME_ERROR,
+          "output tensor %d size mismatched: %d vs %d",
+          index,
+          output_tensors_[index].size(),
+          t.dataLen);
+      return;
+    }
+    std::memcpy(t.data, align_ptr(output_tensors_[index].data()), t.dataLen);
+  }
+
+  void execute() {
+    Error status = method_->execute();
+    if (status != Error::Ok) {
+      FARF(
+          RUNTIME_ERROR,
+          "Execution of method failed with status 0x%x",
+          (int)status);
+    }
+  }
+
+ private:
+  uint8_t method_allocator_pool_[4 * 1024U];
+  const size_t alignment_ = 64;
+  std::unique_ptr<FileDataLoader> loader_;
+  std::unique_ptr<HierarchicalAllocator> planned_memory_;
+  std::unique_ptr<MethodMeta> method_meta_;
+  std::unique_ptr<MemoryAllocator> method_allocator_;
+  std::unique_ptr<MemoryManager> memory_manager_;
+  std::unique_ptr<Method> method_;
+  std::unique_ptr<Program> program_;
+  std::vector<std::unique_ptr<uint8_t[]>> planned_buffers_;
+  std::vector<Span<uint8_t>> planned_spans_;
+  std::vector<std::vector<uint8_t>> input_tensors_;
+  std::vector<std::vector<uint8_t>> output_tensors_;
+  std::vector<TensorImpl> input_tensor_impls_;
+  std::vector<TensorImpl> output_tensor_impls_;
+};
+
+std::unordered_map<std::string, std::unique_ptr<SimpleWrapper>>
+    g_cached_request;
+
+AEEResult qnn_executorch_open(const char* uri, remote_handle64* h) {
+  FARF(RUNTIME_HIGH, __func__);
+  executorch::runtime::runtime_init();
+  return 0;
+}
+
+AEEResult qnn_executorch_close(remote_handle64 h) {
+  FARF(RUNTIME_HIGH, __func__);
+  g_cached_request.clear();
+  return 0;
+}
+
+AEEResult qnn_executorch_load(remote_handle64 _h, const char* pte_path) {
+  FARF(RUNTIME_HIGH, __func__);
+  std::string key(pte_path);
+  if (!g_cached_request.count(key)) {
+    g_cached_request[key] = std::make_unique<SimpleWrapper>(pte_path);
+  }
+  return 0;
+}
+
+AEEResult qnn_executorch_get_input_size(
+    remote_handle64 _h,
+    const char* pte_path,
+    const int index,
+    int* nbytes) {
+  FARF(RUNTIME_HIGH, __func__);
+  std::string key(pte_path);
+  *nbytes = -1;
+  if (g_cached_request.count(key)) {
+    *nbytes = g_cached_request[key]->get_input_size(index);
+  }
+  return 0;
+}
+
+AEEResult qnn_executorch_set_input(
+    remote_handle64 _h,
+    const char* pte_path,
+    const tensor* tensors,
+    int tensorsLen) {
+  FARF(RUNTIME_HIGH, __func__);
+  std::string key(pte_path);
+  if (g_cached_request.count(key)) {
+    auto& wrapper = g_cached_request[key];
+    for (int i = 0; i < tensorsLen; ++i) {
+      wrapper->set_input(i, tensors[i]);
+    }
+  }
+  return 0;
+}
+
+AEEResult qnn_executorch_execute(remote_handle64 _h, const char* pte_path) {
+  FARF(RUNTIME_HIGH, __func__);
+  std::string key(pte_path);
+  if (g_cached_request.count(key)) {
+    auto before_exec = std::chrono::high_resolution_clock::now();
+    g_cached_request[key]->execute();
+    auto after_exec = std::chrono::high_resolution_clock::now();
+    double interval_infs =
+        std::chrono::duration_cast<std::chrono::microseconds>(
+            after_exec - before_exec)
+            .count() /
+        1000.0;
+    FARF(RUNTIME_HIGH, "inferences took %f ms", interval_infs);
+  }
+  return 0;
+}
+
+AEEResult qnn_executorch_get_output_size(
+    remote_handle64 _h,
+    const char* pte_path,
+    const int index,
+    int* nbytes) {
+  FARF(RUNTIME_HIGH, __func__);
+  std::string key(pte_path);
+  *nbytes = -1;
+  if (g_cached_request.count(key)) {
+    *nbytes = g_cached_request[key]->get_output_size(index);
+  }
+  return 0;
+}
+
+AEEResult qnn_executorch_get_output(
+    remote_handle64 _h,
+    const char* pte_path,
+    tensor* tensors,
+    int tensorsLen) {
+  FARF(RUNTIME_HIGH, __func__);
+  std::string key(pte_path);
+  if (g_cached_request.count(key)) {
+    auto& wrapper = g_cached_request[key];
+    for (int i = 0; i < tensorsLen; ++i) {
+      wrapper->get_output(i, tensors[i]);
+    }
+  }
+  return 0;
+}
+
+AEEResult qnn_executorch_unload(remote_handle64 _h, const char* pte_path) {
+  FARF(RUNTIME_HIGH, __func__);
+  std::string key(pte_path);
+  if (g_cached_request.count(key)) {
+    g_cached_request.erase(key);
+  }
+  return 0;
+}

--- a/backends/qualcomm/runtime/Logging.cpp
+++ b/backends/qualcomm/runtime/Logging.cpp
@@ -11,6 +11,9 @@
 #ifdef __ANDROID__
 #include <android/log.h>
 #endif
+#ifdef __hexagon__
+#include "HAP_farf.h"
+#endif
 namespace executorch {
 namespace backends {
 namespace qnn {
@@ -58,10 +61,17 @@ void Log(QnnExecuTorchLogLevel log_level, const char* format, ...) {
   }
   __android_log_vprint(android_severity, "[Qnn ExecuTorch]", format, args);
 #endif
+#ifndef __hexagon__
   fprintf(stderr, "[%s] [Qnn ExecuTorch]: ", serverity_name);
   vfprintf(stderr, format, args);
   va_end(args);
   fputc('\n', stderr);
+#else
+  char buf[128] = {0};
+  vsprintf(buf, format, args);
+  va_end(args);
+  FARF(RUNTIME_HIGH, "[%s] [Qnn ExecuTorch]: %s\n", serverity_name, buf);
+#endif
 }
 } // namespace qnn
 } // namespace backends

--- a/backends/qualcomm/runtime/QnnExecuTorchBackend.cpp
+++ b/backends/qualcomm/runtime/QnnExecuTorchBackend.cpp
@@ -113,7 +113,9 @@ Result<DelegateHandle*> QnnExecuTorchBackend::init(
   }
   add_cached_delegate(signature, qnn_manager);
   // This backend does not need its processed data after Init.
+#ifndef __hexagon__
   processed->Free();
+#endif
   return qnn_manager;
 }
 

--- a/backends/qualcomm/runtime/Utils.cpp
+++ b/backends/qualcomm/runtime/Utils.cpp
@@ -13,6 +13,7 @@ namespace backends {
 namespace qnn {
 
 void CreateDirectory(const std::string& path) {
+#ifndef __hexagon__
   // Create any recursive directory
   if (path.empty()) {
     QNN_EXECUTORCH_LOG_ERROR("Create folder shouldn't be empty");
@@ -29,6 +30,7 @@ void CreateDirectory(const std::string& path) {
     std::string err_msg = "Failed to create " + subdir + " folder\n";
     QNN_EXECUTORCH_LOG_ERROR(err_msg.c_str());
   }
+#endif
 }
 
 } // namespace qnn

--- a/backends/qualcomm/runtime/backends/CMakeLists.txt
+++ b/backends/qualcomm/runtime/backends/CMakeLists.txt
@@ -43,13 +43,16 @@ target_sources(
                        ${CMAKE_CURRENT_LIST_DIR}/QnnProfiler.cpp
 )
 
-set(HOST_ARCHITECTURE_GPU
-    ${CMAKE_CURRENT_LIST_DIR}/gpu/${CMAKE_SYSTEM_PROCESSOR}
-)
-set(HOST_ARCHITECTURE_HTP
-    ${CMAKE_CURRENT_LIST_DIR}/htp/${CMAKE_SYSTEM_PROCESSOR}
-)
-set(HOST_ARCHITECTURE_IR ${CMAKE_CURRENT_LIST_DIR}/ir/${CMAKE_SYSTEM_PROCESSOR})
+# quick workaround for hexagon target
+set(target_platform aarch64)
+if(${CMAKE_SYSTEM_PROCESSOR} MATCHES x86_64)
+  set(target_platform x86_64)
+endif()
+
+set(HOST_ARCHITECTURE_GPU ${CMAKE_CURRENT_LIST_DIR}/gpu/${target_platform})
+set(HOST_ARCHITECTURE_HTP ${CMAKE_CURRENT_LIST_DIR}/htp/${target_platform})
+set(HOST_ARCHITECTURE_IR ${CMAKE_CURRENT_LIST_DIR}/ir/${target_platform})
+set(HOST_ARCHITECTURE_LPAI ${CMAKE_CURRENT_LIST_DIR}/lpai/${target_platform})
 
 # qnn_device
 target_sources(
@@ -57,6 +60,7 @@ target_sources(
   PUBLIC ${CMAKE_CURRENT_LIST_DIR}/QnnDeviceCommon.h
          ${CMAKE_CURRENT_LIST_DIR}/gpu/GpuDevice.h
          ${CMAKE_CURRENT_LIST_DIR}/htp/HtpDevice.h
+         ${CMAKE_CURRENT_LIST_DIR}/lpai/LpaiDevice.h
   PRIVATE ${CMAKE_CURRENT_LIST_DIR}/QnnDeviceCommon.cpp
           ${CMAKE_CURRENT_LIST_DIR}/htp/HtpDevice.cpp
           ${CMAKE_CURRENT_LIST_DIR}/htp/HtpDevicePlatformInfoConfig.h
@@ -65,6 +69,7 @@ target_sources(
           # platform infomation and SocModel to Qnn
           ${HOST_ARCHITECTURE_HTP}/HtpDevicePlatformInfoConfig.cpp
           ${HOST_ARCHITECTURE_HTP}/HtpDeviceCustomConfig.cpp
+          ${HOST_ARCHITECTURE_LPAI}/LpaiDevice.cpp
 )
 
 # qnn_context
@@ -74,13 +79,17 @@ target_sources(
          ${CMAKE_CURRENT_LIST_DIR}/htp/HtpContext.h
          ${CMAKE_CURRENT_LIST_DIR}/ir/IrContext.h
          ${CMAKE_CURRENT_LIST_DIR}/gpu/GpuContext.h
+         ${CMAKE_CURRENT_LIST_DIR}/lpai/LpaiContext.h
   PRIVATE ${CMAKE_CURRENT_LIST_DIR}/QnnContextCommon.cpp
-          ${CMAKE_CURRENT_LIST_DIR}/htp/HtpContext.cpp
-          ${CMAKE_CURRENT_LIST_DIR}/htp/HtpContextCustomConfig.h
           ${CMAKE_CURRENT_LIST_DIR}/gpu/GpuContext.cpp
           ${CMAKE_CURRENT_LIST_DIR}/gpu/GpuContextCustomConfig.h
+          ${CMAKE_CURRENT_LIST_DIR}/htp/HtpContext.cpp
+          ${CMAKE_CURRENT_LIST_DIR}/htp/HtpContextCustomConfig.h
+          ${CMAKE_CURRENT_LIST_DIR}/lpai/LpaiContext.cpp
+          ${CMAKE_CURRENT_LIST_DIR}/lpai/LpaiContextCustomConfig.h
           ${HOST_ARCHITECTURE_GPU}/GpuContextCustomConfig.cpp
           ${HOST_ARCHITECTURE_HTP}/HtpContextCustomConfig.cpp
+          ${HOST_ARCHITECTURE_LPAI}/LpaiContextCustomConfig.cpp
           ${HOST_ARCHITECTURE_IR}/IrContext.cpp
 )
 
@@ -99,6 +108,7 @@ target_sources(
   PUBLIC ${CMAKE_CURRENT_LIST_DIR}/QnnGraphCommon.h
          ${CMAKE_CURRENT_LIST_DIR}/gpu/GpuGraph.h
          ${CMAKE_CURRENT_LIST_DIR}/htp/HtpGraph.h
+         ${CMAKE_CURRENT_LIST_DIR}/lpai/LpaiGraph.h
   PRIVATE ${CMAKE_CURRENT_LIST_DIR}/QnnGraphCommon.cpp
           ${CMAKE_CURRENT_LIST_DIR}/gpu/GpuGraph.cpp
           ${CMAKE_CURRENT_LIST_DIR}/gpu/GpuGraphCustomConfig.h
@@ -107,6 +117,9 @@ target_sources(
           ${CMAKE_CURRENT_LIST_DIR}/htp/HtpGraphCustomConfig.h
           ${CMAKE_CURRENT_LIST_DIR}/htp/HtpGraphCustomConfig.cpp
           ${HOST_ARCHITECTURE_HTP}/HtpGraphCustomConfig.cpp
+          ${CMAKE_CURRENT_LIST_DIR}/lpai/LpaiGraphCustomConfig.h
+          ${HOST_ARCHITECTURE_LPAI}/LpaiGraph.cpp
+          ${HOST_ARCHITECTURE_LPAI}/LpaiGraphCustomConfig.cpp
 )
 
 # qnn_op_package_manager
@@ -123,10 +136,14 @@ target_sources(
          ${CMAKE_CURRENT_LIST_DIR}/gpu/GpuBackend.h
          ${CMAKE_CURRENT_LIST_DIR}/htp/HtpBackend.h
          ${CMAKE_CURRENT_LIST_DIR}/ir/IrBackend.h
+         ${CMAKE_CURRENT_LIST_DIR}/lpai/LpaiBackend.h
   PRIVATE ${CMAKE_CURRENT_LIST_DIR}/QnnBackendCommon.cpp
           ${CMAKE_CURRENT_LIST_DIR}/gpu/GpuBackend.cpp
           ${CMAKE_CURRENT_LIST_DIR}/gpu/GpuBackendCustomConfig.h
           ${CMAKE_CURRENT_LIST_DIR}/gpu/GpuBackendCustomConfig.cpp
+          ${CMAKE_CURRENT_LIST_DIR}/lpai/LpaiBackend.cpp
+          ${CMAKE_CURRENT_LIST_DIR}/lpai/LpaiBackendCustomConfig.h
+          ${CMAKE_CURRENT_LIST_DIR}/lpai/LpaiBackendCustomConfig.cpp
 )
 
 # qnn_mem_manager

--- a/backends/qualcomm/runtime/backends/QnnBackendCache.cpp
+++ b/backends/qualcomm/runtime/backends/QnnBackendCache.cpp
@@ -22,11 +22,10 @@ Error QnnBackendCache::GetQnnGraphInfoFromBinary(
   std::uint32_t num_graphs;
   QnnSystemContext_GraphInfo_t* graphs = nullptr;
   const QnnSystemContext_BinaryInfo_t* binaryinfo{nullptr};
-  Qnn_ContextBinarySize_t binaryinfo_size = 0;
   Qnn_ErrorHandle_t error = QNN_SUCCESS;
 
   error = qnn_sys_interface.qnn_system_context_get_binary_info(
-      sys_context_handle_, buffer, nbytes, &binaryinfo, &binaryinfo_size);
+      sys_context_handle_, buffer, nbytes, &binaryinfo);
 
   if (error != QNN_SUCCESS) {
     QNN_EXECUTORCH_LOG_WARN(

--- a/backends/qualcomm/runtime/backends/QnnBackendFactory.h
+++ b/backends/qualcomm/runtime/backends/QnnBackendFactory.h
@@ -22,6 +22,8 @@
 #include <executorch/backends/qualcomm/runtime/backends/htp/HtpBackendCache.h>
 #include <executorch/backends/qualcomm/runtime/backends/htp/HtpContext.h>
 #include <executorch/backends/qualcomm/runtime/backends/htp/HtpGraph.h>
+#include <executorch/backends/qualcomm/runtime/backends/lpai/LpaiContext.h>
+#include <executorch/backends/qualcomm/runtime/backends/lpai/LpaiGraph.h>
 
 #include <memory>
 namespace executorch {

--- a/backends/qualcomm/runtime/backends/QnnBackendUnifiedRegistry.cpp
+++ b/backends/qualcomm/runtime/backends/QnnBackendUnifiedRegistry.cpp
@@ -13,6 +13,8 @@
 #include <executorch/backends/qualcomm/runtime/backends/gpu/GpuDevice.h>
 #include <executorch/backends/qualcomm/runtime/backends/htp/HtpBackend.h>
 #include <executorch/backends/qualcomm/runtime/backends/htp/HtpDevice.h>
+#include <executorch/backends/qualcomm/runtime/backends/lpai/LpaiBackend.h>
+#include <executorch/backends/qualcomm/runtime/backends/lpai/LpaiDevice.h>
 
 #include <string>
 
@@ -56,7 +58,10 @@ Error QnnBackendUnifiedRegistry::GetOrCreateBackendBundle(
         current_lib_path = gpu_library_name_;
         break;
       }
-      case QnnExecuTorchBackendType::kDspBackend:
+      case QnnExecuTorchBackendType::kLpaiBackend: {
+        current_lib_path = lpai_library_name_;
+        break;
+      }
       case QnnExecuTorchBackendType::kUndefinedBackend:
       default:
         QNN_EXECUTORCH_LOG_ERROR(
@@ -118,7 +123,12 @@ Error QnnBackendUnifiedRegistry::GetOrCreateBackendBundle(
       device = std::make_unique<GpuDevice>(implementation.get(), logger.get());
       break;
     }
-    case QnnExecuTorchBackendType::kDspBackend:
+    case QnnExecuTorchBackendType::kLpaiBackend: {
+      backend = std::make_unique<LpaiBackend>(
+          implementation.get(), logger.get(), options->soc_info());
+      device = std::make_unique<LpaiDevice>(implementation.get(), logger.get());
+      break;
+    }
     case QnnExecuTorchBackendType::kUndefinedBackend:
     default:
       return Error::NotFound;

--- a/backends/qualcomm/runtime/backends/QnnBackendUnifiedRegistry.h
+++ b/backends/qualcomm/runtime/backends/QnnBackendUnifiedRegistry.h
@@ -73,7 +73,7 @@ class QnnBackendUnifiedRegistry {
 
   static constexpr const char* htp_library_name_ = "libQnnHtp.so";
   static constexpr const char* gpu_library_name_ = "libQnnGpu.so";
-  static constexpr const char* dsp_library_name_ = "libQnnDsp.so";
+  static constexpr const char* lpai_library_name_ = "libQnnLpai.so";
 
   std::unique_ptr<const QnnSaver_Config_t*[]> GetImplementationConfig(
       const QnnExecuTorchOptions* options) {

--- a/backends/qualcomm/runtime/backends/QnnCustomProtocol.cpp
+++ b/backends/qualcomm/runtime/backends/QnnCustomProtocol.cpp
@@ -20,8 +20,7 @@ void QnnContextCustomProtocol::BuildContextCustomBuffer() {
     uint8_t magic_number_proto_size = sizeof(magic_number_);
     uint8_t binary_proto_size = sizeof(binary_size_);
     uint8_t signature_proto_size = sizeof(signature_);
-    uint64_t buffer_size = magic_number_proto_size + signature_proto_size +
-        binary_proto_size + binary_size_;
+    uint64_t buffer_size = alignment_ + binary_size_;
     qnn_custom_buffer_.resize(buffer_size, 0);
 
     size_t pos = 0;
@@ -62,6 +61,8 @@ QnnContextCustomProtocol::DeserializeContextCustomBuffer(void* processed_data) {
   uint8_t magic_number_proto_size = sizeof(magic_number_);
   uint8_t binary_proto_size = sizeof(binary_size_);
   uint8_t signature_proto_size = sizeof(signature_);
+  uint32_t padding_size = alignment_ - magic_number_proto_size -
+      binary_proto_size - signature_proto_size;
 
   uint32_t magic_number;
   std::memcpy(&magic_number, ptr, magic_number_proto_size);
@@ -80,13 +81,13 @@ QnnContextCustomProtocol::DeserializeContextCustomBuffer(void* processed_data) {
 
   uint64_t binary_size;
   std::memcpy(&binary_size, ptr, binary_proto_size);
-  ptr += binary_proto_size;
+  ptr += binary_proto_size + padding_size;
 
   return {status, signature_, binary_size, static_cast<void*>(ptr)};
 }
 
 uint64_t QnnContextCustomProtocol::GetContextBinaryOffset() {
-  return sizeof(magic_number_) + sizeof(signature_) + sizeof(binary_size_);
+  return alignment_;
 }
 
 } // namespace qnn

--- a/backends/qualcomm/runtime/backends/QnnCustomProtocol.h
+++ b/backends/qualcomm/runtime/backends/QnnCustomProtocol.h
@@ -83,6 +83,7 @@ class QnnContextCustomProtocol : public QnnCustomProtocol {
   static constexpr uint32_t magic_number_ = 0x5678ABCD;
   int64_t signature_{0};
   uint64_t binary_size_{0};
+  uint32_t alignment_{256};
 };
 
 } // namespace qnn

--- a/backends/qualcomm/runtime/backends/QnnFunctionInterface.h
+++ b/backends/qualcomm/runtime/backends/QnnFunctionInterface.h
@@ -65,6 +65,8 @@ class QnnInterface {
   DEFINE_SHIM_FUNCTION_INTERFACE(graph_finalize, graphFinalize);
   DEFINE_SHIM_FUNCTION_INTERFACE(graph_execute, graphExecute);
   DEFINE_SHIM_FUNCTION_INTERFACE(graph_retrieve, graphRetrieve);
+  DEFINE_SHIM_FUNCTION_INTERFACE(graph_set_config, graphSetConfig);
+  DEFINE_SHIM_FUNCTION_INTERFACE(graph_get_property, graphGetProperty);
   // --------- QnnLog ---------
   DEFINE_SHIM_FUNCTION_INTERFACE(log_create, logCreate);
   DEFINE_SHIM_FUNCTION_INTERFACE(log_free, logFree);

--- a/backends/qualcomm/runtime/backends/QnnGraphCommon.h
+++ b/backends/qualcomm/runtime/backends/QnnGraphCommon.h
@@ -34,7 +34,7 @@ class QnnGraph {
 
   virtual ~QnnGraph(){};
 
-  executorch::runtime::Error Configure(const std::string& graph_name);
+  virtual executorch::runtime::Error Configure(const std::string& graph_name);
 
   Qnn_ErrorHandle_t GraphExecute(
       const std::string& graph_name,
@@ -81,10 +81,10 @@ class QnnGraph {
       std::vector<const QnnGraph_Config_t*>& config) {
     return executorch::runtime::Error::Ok;
   };
-
- private:
   std::unordered_map<std::string, Qnn_GraphHandle_t> handle_;
   QnnImplementation* implementation_;
+
+ private:
   QnnBackend* backend_;
   QnnContext* context_;
   QnnExecuTorchProfileLevel profile_level_;

--- a/backends/qualcomm/runtime/backends/QnnSysFunctionInterface.h
+++ b/backends/qualcomm/runtime/backends/QnnSysFunctionInterface.h
@@ -40,7 +40,7 @@ class QnnSystemInterface {
       systemContextCreate);
   DEFINE_SHIM_FUNCTION_SYS_INTERFACE(
       system_context_get_binary_info,
-      systemContextGetBinaryInfo);
+      systemContextGetMetaData);
   DEFINE_SHIM_FUNCTION_SYS_INTERFACE(system_context_free, systemContextFree);
 
  private:

--- a/backends/qualcomm/runtime/backends/lpai/LpaiBackend.cpp
+++ b/backends/qualcomm/runtime/backends/lpai/LpaiBackend.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Qualcomm Innovation Center, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/qualcomm/runtime/backends/lpai/LpaiBackend.h>
+
+#include "LPAI/QnnLpaiCommon.h"
+
+namespace executorch {
+namespace backends {
+namespace qnn {
+
+using executorch::runtime::Error;
+
+LpaiBackend::LpaiBackend(
+    QnnImplementation* implementation,
+    QnnLogger* logger,
+    const SocInfo* soc_info)
+    : QnnBackend(implementation, logger) {
+  lpai_backend_custom_config_ =
+      std::make_unique<LpaiBackendCustomConfig>(soc_info);
+}
+
+Qnn_Version_t LpaiBackend::GetExpectedBackendVersion() const {
+  Qnn_Version_t backend_version;
+  backend_version.major = QNN_LPAI_API_VERSION_MAJOR;
+  backend_version.minor = QNN_LPAI_API_VERSION_MINOR;
+  backend_version.patch = QNN_LPAI_API_VERSION_PATCH;
+  return backend_version;
+}
+
+bool LpaiBackend::IsProfileEventTypeParentOfNodeTime(
+    QnnProfile_EventType_t event_type) {
+  return (event_type == QNN_PROFILE_EVENTTYPE_EXECUTE);
+}
+
+Error LpaiBackend::MakeConfig(std::vector<const QnnBackend_Config_t*>& config) {
+  const std::vector<QnnBackend_CustomConfig_t>& backend_custom_config =
+      lpai_backend_custom_config_->CreateBackendCustomConfig();
+
+  uint32_t num_custom_configs = backend_custom_config.size();
+  backend_config_.resize(num_custom_configs);
+  // +1 for null terminated
+  config.reserve(num_custom_configs + 1);
+
+  for (std::size_t i = 0; i < num_custom_configs; ++i) {
+    backend_config_[i].option = QNN_BACKEND_CONFIG_OPTION_CUSTOM;
+    backend_config_[i].customConfig = backend_custom_config[i];
+    config.push_back(&backend_config_[i]);
+  }
+
+  config.push_back(nullptr);
+  return Error::Ok;
+}
+
+} // namespace qnn
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/lpai/LpaiBackend.h
+++ b/backends/qualcomm/runtime/backends/lpai/LpaiBackend.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Qualcomm Innovation Center, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <executorch/backends/qualcomm/runtime/backends/lpai/LpaiBackendCustomConfig.h>
+
+namespace executorch {
+namespace backends {
+namespace qnn {
+
+class LpaiBackend : public QnnBackend {
+ public:
+  LpaiBackend(
+      QnnImplementation* implementation,
+      QnnLogger* logger,
+      const SocInfo* soc_info);
+
+  Qnn_Version_t GetExpectedBackendVersion() const override;
+
+  bool IsProfileEventTypeParentOfNodeTime(
+      QnnProfile_EventType_t event_type) override;
+
+ protected:
+  executorch::runtime::Error MakeConfig(
+      std::vector<const QnnBackend_Config_t*>& config) override;
+
+ private:
+  std::vector<QnnBackend_Config_t> backend_config_;
+  std::unique_ptr<LpaiBackendCustomConfig> lpai_backend_custom_config_;
+};
+
+} // namespace qnn
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/lpai/LpaiBackendCustomConfig.cpp
+++ b/backends/qualcomm/runtime/backends/lpai/LpaiBackendCustomConfig.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Qualcomm Innovation Center, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/qualcomm/runtime/backends/lpai/LpaiBackendCustomConfig.h>
+
+namespace executorch {
+namespace backends {
+namespace qnn {
+
+LpaiBackendCustomConfig::LpaiBackendCustomConfig(const SocInfo* soc_info)
+    : soc_info_(soc_info) {}
+
+QnnLpaiBackend_CustomConfig_t*
+LpaiBackendCustomConfig::AllocBackendCustomConfig() {
+  lpai_backend_config_.emplace_back(
+      std::make_unique<QnnLpaiBackend_CustomConfig_t>());
+  lpai_backend_config_.back()->option = QNN_LPAI_BACKEND_CUSTOM_CFG_UNDEFINED;
+  return lpai_backend_config_.back().get();
+}
+
+QnnLpaiBackend_CustomConfigHwInfo_t* LpaiBackendCustomConfig::AllocHwInfo() {
+  lpai_hw_info_.emplace_back(
+      std::make_unique<QnnLpaiBackend_CustomConfigHwInfo_t>());
+  lpai_hw_info_.back()->hwVersion = QNN_LPAI_BACKEND_HW_VERSION_UNKNOWN;
+  lpai_hw_info_.back()->lpaiTarget = QNN_LPAI_BACKEND_TARGET_UNKNOWN;
+  return lpai_hw_info_.back().get();
+}
+
+std::vector<QnnBackend_CustomConfig_t>
+LpaiBackendCustomConfig::CreateBackendCustomConfig() {
+  std::vector<QnnBackend_CustomConfig_t> ret;
+  QnnLpaiBackend_CustomConfig_t* p_custom_config = nullptr;
+
+  std::unordered_map<LpaiHardwareVersion, QnnLpaiBackend_HwVersion_t>
+      lpai_hw_ver = {
+          {LpaiHardwareVersion::V1, QNN_LPAI_BACKEND_HW_VERSION_V1},
+          {LpaiHardwareVersion::V2, QNN_LPAI_BACKEND_HW_VERSION_V2},
+          {LpaiHardwareVersion::V3, QNN_LPAI_BACKEND_HW_VERSION_V3},
+          {LpaiHardwareVersion::V4, QNN_LPAI_BACKEND_HW_VERSION_V4},
+          {LpaiHardwareVersion::V5, QNN_LPAI_BACKEND_HW_VERSION_V5},
+          {LpaiHardwareVersion::V5_1, QNN_LPAI_BACKEND_HW_VERSION_V5_1},
+          {LpaiHardwareVersion::V6, QNN_LPAI_BACKEND_HW_VERSION_V6},
+          {LpaiHardwareVersion::V7, QNN_LPAI_BACKEND_HW_VERSION_V7},
+      };
+
+  p_custom_config = AllocBackendCustomConfig();
+  auto p_hw_info = AllocHwInfo();
+  p_custom_config->option = QNN_LPAI_BACKEND_CUSTOM_CFG_HW_INFO;
+  auto lpai_info = soc_info_->lpai_info();
+  if (lpai_info && lpai_hw_ver.count(lpai_info->lpai_hardware_version())) {
+    p_hw_info->hwVersion = lpai_hw_ver[lpai_info->lpai_hardware_version()];
+  }
+  p_hw_info->lpaiTarget = QNN_LPAI_BACKEND_TARGET_ADSP;
+  p_custom_config->config = p_hw_info;
+  ret.push_back(static_cast<QnnBackend_CustomConfig_t>(p_custom_config));
+  return ret;
+}
+
+} // namespace qnn
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/lpai/LpaiBackendCustomConfig.h
+++ b/backends/qualcomm/runtime/backends/lpai/LpaiBackendCustomConfig.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Qualcomm Innovation Center, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <executorch/backends/qualcomm/qc_compiler_spec_generated.h>
+#include <executorch/backends/qualcomm/runtime/backends/QnnBackendCommon.h>
+
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+#include "LPAI/QnnLpaiBackend.h"
+
+namespace executorch {
+namespace backends {
+namespace qnn {
+
+using namespace qnn_delegate;
+
+class LpaiBackendCustomConfig {
+ public:
+  explicit LpaiBackendCustomConfig(const SocInfo* soc_info);
+
+  std::vector<QnnBackend_CustomConfig_t> CreateBackendCustomConfig();
+
+ private:
+  QnnLpaiBackend_CustomConfig_t* AllocBackendCustomConfig();
+  std::vector<std::unique_ptr<QnnLpaiBackend_CustomConfig_t>>
+      lpai_backend_config_;
+  const SocInfo* soc_info_;
+
+  std::vector<std::unique_ptr<QnnLpaiBackend_CustomConfigHwInfo_t>>
+      lpai_hw_info_;
+  QnnLpaiBackend_CustomConfigHwInfo_t* AllocHwInfo();
+};
+
+} // namespace qnn
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/lpai/LpaiContext.cpp
+++ b/backends/qualcomm/runtime/backends/lpai/LpaiContext.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Qualcomm Innovation Center, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/qualcomm/runtime/backends/lpai/LpaiContext.h>
+
+namespace executorch {
+namespace backends {
+namespace qnn {
+
+using executorch::runtime::Error;
+
+LpaiContext::LpaiContext(
+    QnnImplementation* implementation,
+    QnnBackend* backend,
+    QnnDevice* device,
+    QnnBackendCache* cache,
+    QnnDlcManager* qnn_dlc_manager)
+    : QnnContext(implementation, backend, device, cache, qnn_dlc_manager) {
+  lpai_context_custom_config_ = std::make_unique<LpaiContextCustomConfig>();
+}
+
+Error LpaiContext::MakeConfig(std::vector<const QnnContext_Config_t*>& config) {
+  const std::vector<QnnContext_CustomConfig_t>& context_custom_config =
+      lpai_context_custom_config_->CreateContextCustomConfig();
+
+  uint32_t num_custom_configs = context_custom_config.size();
+  context_config_.resize(num_custom_configs);
+  // +1 for null terminated
+  config.reserve(num_custom_configs + 1);
+
+  for (std::size_t i = 0; i < num_custom_configs; ++i) {
+    context_config_[i].option = QNN_CONTEXT_CONFIG_OPTION_CUSTOM;
+    context_config_[i].customConfig = context_custom_config[i];
+    config.push_back(&context_config_[i]);
+  }
+
+#ifdef __hexagon__
+  QnnContext_Config_t adsp_context_config;
+  adsp_context_config.option = QNN_CONTEXT_CONFIG_PERSISTENT_BINARY;
+  adsp_context_config.isPersistentBinary = 1;
+  context_config_.push_back(adsp_context_config);
+  config.push_back(&context_config_.back());
+#endif
+
+  config.push_back(nullptr);
+  return Error::Ok;
+}
+
+} // namespace qnn
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/lpai/LpaiContext.h
+++ b/backends/qualcomm/runtime/backends/lpai/LpaiContext.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Qualcomm Innovation Center, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <executorch/backends/qualcomm/runtime/backends/lpai/LpaiContextCustomConfig.h>
+
+namespace executorch {
+namespace backends {
+namespace qnn {
+
+class QnnDlcManager;
+class LpaiContext : public QnnContext {
+ public:
+  LpaiContext(
+      QnnImplementation* implementation,
+      QnnBackend* backend,
+      QnnDevice* device,
+      QnnBackendCache* cache,
+      QnnDlcManager* qnn_dlc_manager);
+
+ protected:
+  executorch::runtime::Error MakeConfig(
+      std::vector<const QnnContext_Config_t*>& config) override;
+
+ private:
+  std::vector<QnnContext_Config_t> context_config_;
+  std::unique_ptr<LpaiContextCustomConfig> lpai_context_custom_config_;
+};
+
+} // namespace qnn
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/lpai/LpaiContextCustomConfig.h
+++ b/backends/qualcomm/runtime/backends/lpai/LpaiContextCustomConfig.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Qualcomm Innovation Center, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <executorch/backends/qualcomm/qc_compiler_spec_generated.h>
+#include <executorch/backends/qualcomm/runtime/backends/QnnContextCommon.h>
+
+#include <memory>
+#include <vector>
+
+#include "LPAI/QnnLpaiContext.h"
+
+namespace executorch {
+namespace backends {
+namespace qnn {
+
+using namespace qnn_delegate;
+
+class LpaiContextCustomConfig {
+ public:
+  explicit LpaiContextCustomConfig() {}
+
+  std::vector<QnnContext_CustomConfig_t> CreateContextCustomConfig();
+
+ private:
+  QnnLpaiContext_CustomConfig_t* AllocContextCustomConfig() {
+    lpai_context_config_.emplace_back(
+        std::make_unique<QnnLpaiContext_CustomConfig_t>());
+    lpai_context_config_.back()->option = QNN_LPAI_CONTEXT_SET_CFG_UNDEFINED;
+    return lpai_context_config_.back().get();
+  }
+  std::vector<std::unique_ptr<QnnLpaiContext_CustomConfig_t>>
+      lpai_context_config_;
+};
+
+} // namespace qnn
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/lpai/LpaiDevice.h
+++ b/backends/qualcomm/runtime/backends/lpai/LpaiDevice.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Qualcomm Innovation Center, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#pragma once
+
+#include <executorch/backends/qualcomm/runtime/backends/QnnDeviceCommon.h>
+
+namespace executorch {
+namespace backends {
+namespace qnn {
+
+using executorch::runtime::Error;
+
+class LpaiDevice : public QnnDevice {
+ public:
+  LpaiDevice(QnnImplementation* implementation, QnnLogger* logger)
+      : QnnDevice(implementation, logger){};
+
+  executorch::runtime::Error Configure() override;
+
+ private:
+  std::vector<QnnDevice_Config_t> device_config_;
+};
+
+} // namespace qnn
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/lpai/LpaiGraph.h
+++ b/backends/qualcomm/runtime/backends/lpai/LpaiGraph.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) Qualcomm Innovation Center, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <executorch/backends/qualcomm/runtime/backends/lpai/LpaiGraphCustomConfig.h>
+
+namespace executorch {
+namespace backends {
+namespace qnn {
+
+class LpaiGraph : public QnnGraph {
+ public:
+  LpaiGraph(
+      QnnImplementation* implementation,
+      QnnBackend* backend,
+      QnnContext* context,
+      const QnnExecuTorchProfileLevel& profile_level,
+      const QnnExecuTorchLpaiBackendOptions* lpai_options)
+      : QnnGraph(implementation, backend, context, profile_level) {
+    lpai_graph_custom_config_ =
+        std::make_unique<LpaiGraphCustomConfig>(lpai_options, this);
+  };
+
+  executorch::runtime::Error Configure(const std::string& graph_name) override {
+    Error configure_status = QnnGraph::Configure(graph_name);
+    if (configure_status != Error::Ok) {
+      return configure_status;
+    }
+    const std::vector<QnnGraph_CustomConfig_t>& graph_custom_config =
+        lpai_graph_custom_config_->CreateGraphCustomConfig(graph_name);
+
+    std::vector<const QnnGraph_Config_t*> config;
+    uint32_t num_custom_configs = graph_custom_config.size();
+    graph_config_.resize(num_custom_configs);
+    // +1 for null terminated
+    config.reserve(num_custom_configs + 1);
+
+    for (std::size_t i = 0; i < num_custom_configs; ++i) {
+      graph_config_[i].option = QNN_GRAPH_CONFIG_OPTION_CUSTOM;
+      graph_config_[i].customConfig = graph_custom_config[i];
+      config.push_back(&graph_config_[i]);
+    }
+    config.push_back(nullptr);
+
+    // LPAI specific > configs can only be set after graph create
+    const QnnInterface& qnn_interface = implementation_->GetQnnInterface();
+    Qnn_ErrorHandle_t error =
+        qnn_interface.qnn_graph_set_config(handle_[graph_name], config.data());
+    if (error != QNN_SUCCESS) {
+      QNN_EXECUTORCH_LOG_ERROR(
+          "qnn_graph_set_config failed. Error  %d", QNN_GET_ERROR_CODE(error));
+      return Error::Internal;
+    }
+
+    // platform specific behavior
+    return AfterConfigure(graph_name);
+  }
+
+  friend LpaiGraphCustomConfig;
+
+ protected:
+  executorch::runtime::Error MakeConfig(
+      std::vector<const QnnGraph_Config_t*>& config) override {
+    return {};
+  }
+
+ private:
+  executorch::runtime::Error AfterConfigure(const std::string& graph_name);
+  std::vector<QnnGraph_Config_t> graph_config_;
+  std::unique_ptr<LpaiGraphCustomConfig> lpai_graph_custom_config_;
+};
+
+} // namespace qnn
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/lpai/LpaiGraphCustomConfig.h
+++ b/backends/qualcomm/runtime/backends/lpai/LpaiGraphCustomConfig.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) Qualcomm Innovation Center, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <executorch/backends/qualcomm/qc_compiler_spec_generated.h>
+#include <executorch/backends/qualcomm/runtime/backends/QnnGraphCommon.h>
+
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+#include "LPAI/QnnLpaiGraph.h"
+#include "LPAI/QnnLpaiGraphPrepare.h"
+
+namespace executorch {
+namespace backends {
+namespace qnn {
+
+using namespace qnn_delegate;
+
+class LpaiGraph;
+class LpaiGraphCustomConfig {
+ public:
+  explicit LpaiGraphCustomConfig(
+      const QnnExecuTorchLpaiBackendOptions* lpai_options,
+      LpaiGraph* graph)
+      : graph_(graph), lpai_options_(lpai_options){};
+
+  std::vector<QnnGraph_CustomConfig_t> CreateGraphCustomConfig(
+      const std::string& graph_name);
+
+ private:
+  [[maybe_unused]] LpaiGraph* graph_;
+  [[maybe_unused]] const QnnExecuTorchLpaiBackendOptions* lpai_options_;
+
+  std::vector<std::unique_ptr<QnnLpaiGraph_Mem_t>> lpai_mem_;
+  QnnLpaiGraph_Mem_t* AllocMem() {
+    lpai_mem_.emplace_back(std::make_unique<QnnLpaiGraph_Mem_t>());
+    lpai_mem_.back()->memType = QNN_LPAI_MEM_TYPE_UNDEFINED;
+    lpai_mem_.back()->size = 0;
+    lpai_mem_.back()->addr = nullptr;
+    return lpai_mem_.back().get();
+  }
+
+  std::vector<std::unique_ptr<QnnLpaiGraph_CustomConfig_t>> lpai_graph_config_;
+  QnnLpaiGraph_CustomConfig_t* AllocGraphCustomConfig() {
+    lpai_graph_config_.emplace_back(
+        std::make_unique<QnnLpaiGraph_CustomConfig_t>());
+    lpai_graph_config_.back()->option = QNN_LPAI_GRAPH_SET_CFG_UNDEFINED;
+    return lpai_graph_config_.back().get();
+  }
+
+  std::vector<std::unique_ptr<QnnLpaiGraph_PerfCfg_t>> lpai_perf_cfg_;
+  QnnLpaiGraph_PerfCfg_t* AllocPerfCfg() {
+    lpai_perf_cfg_.emplace_back(std::make_unique<QnnLpaiGraph_PerfCfg_t>());
+    lpai_perf_cfg_.back()->fps = 0;
+    lpai_perf_cfg_.back()->ftrtRatio = 0;
+    lpai_perf_cfg_.back()->clientType =
+        QNN_LPAI_GRAPH_CLIENT_PERF_TYPE_UNDEFINED;
+    return lpai_perf_cfg_.back().get();
+  }
+
+  std::vector<std::unique_ptr<QnnLpaiGraph_CoreAffinity_t>> lpai_core_affinity_;
+  QnnLpaiGraph_CoreAffinity_t* AllocCoreAffinity() {
+    lpai_core_affinity_.emplace_back(
+        std::make_unique<QnnLpaiGraph_CoreAffinity_t>());
+    lpai_core_affinity_.back()->affinity =
+        QNN_LPAI_GRAPH_CORE_AFFINITY_UNDEFINED;
+    lpai_core_affinity_.back()->coreSelection = 0;
+    return lpai_core_affinity_.back().get();
+  }
+
+  std::vector<std::unique_ptr<QnnLpaiGraph_CustomConfigPrepare_t>>
+      lpai_prepare_;
+  QnnLpaiGraph_CustomConfigPrepare_t* AllocPrepare() {
+    lpai_prepare_.emplace_back(
+        std::make_unique<QnnLpaiGraph_CustomConfigPrepare_t>());
+    lpai_prepare_.back()->enablePerLayer = 0;
+    lpai_prepare_.back()->enableCoreSelection = nullptr;
+    return lpai_prepare_.back().get();
+  }
+
+  std::vector<uint8_t> scratch_buf_, persistent_buf_;
+};
+
+} // namespace qnn
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/lpai/aarch64/LpaiContextCustomConfig.cpp
+++ b/backends/qualcomm/runtime/backends/lpai/aarch64/LpaiContextCustomConfig.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Qualcomm Innovation Center, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/qualcomm/runtime/backends/lpai/LpaiContextCustomConfig.h>
+
+namespace executorch {
+namespace backends {
+namespace qnn {
+
+std::vector<QnnContext_CustomConfig_t>
+LpaiContextCustomConfig::CreateContextCustomConfig() {
+  std::vector<QnnContext_CustomConfig_t> ret;
+#ifndef __hexagon__
+  QnnLpaiContext_CustomConfig_t* p_custom_config = nullptr;
+
+  // TODO: support graph based execution
+  p_custom_config = AllocContextCustomConfig();
+  p_custom_config->option = QNN_LPAI_CONTEXT_SET_CFG_ENABLE_ISLAND;
+  p_custom_config->config = nullptr;
+  ret.push_back(static_cast<QnnContext_CustomConfig_t>(p_custom_config));
+#endif
+  return ret;
+}
+
+} // namespace qnn
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/lpai/aarch64/LpaiDevice.cpp
+++ b/backends/qualcomm/runtime/backends/lpai/aarch64/LpaiDevice.cpp
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Qualcomm Innovation Center, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/qualcomm/runtime/backends/lpai/LpaiDevice.h>
+
+namespace executorch {
+namespace backends {
+namespace qnn {
+
+Error LpaiDevice::Configure() {
+#ifndef __hexagon__
+  return QnnDevice::Configure();
+#else
+  return Error::Ok;
+#endif
+}
+
+} // namespace qnn
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/lpai/aarch64/LpaiGraph.cpp
+++ b/backends/qualcomm/runtime/backends/lpai/aarch64/LpaiGraph.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Qualcomm Innovation Center, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/qualcomm/runtime/backends/lpai/LpaiGraph.h>
+
+namespace executorch {
+namespace backends {
+namespace qnn {
+
+Error LpaiGraph::AfterConfigure(const std::string& graph_name) {
+  // LPAI does not support online prepare and require graph to be finalized
+  // again
+  Qnn_ErrorHandle_t error = GraphFinalize(graph_name);
+  if (error != QNN_SUCCESS) {
+    QNN_EXECUTORCH_LOG_ERROR(
+        "Failed to finalize Qnn Graph with error: %d",
+        QNN_GET_ERROR_CODE(error));
+    return Error::Internal;
+  }
+  return Error::Ok;
+}
+
+} // namespace qnn
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/lpai/aarch64/LpaiGraphCustomConfig.cpp
+++ b/backends/qualcomm/runtime/backends/lpai/aarch64/LpaiGraphCustomConfig.cpp
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) Qualcomm Innovation Center, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/qualcomm/runtime/backends/lpai/LpaiGraph.h>
+
+namespace executorch {
+namespace backends {
+namespace qnn {
+
+std::vector<QnnGraph_CustomConfig_t>
+LpaiGraphCustomConfig::CreateGraphCustomConfig(const std::string& graph_name) {
+  std::vector<QnnGraph_CustomConfig_t> configs;
+  QnnLpaiGraph_CustomConfig_t* p_custom_config = nullptr;
+
+#ifdef __hexagon__
+  uint32_t scratch_size = 0;
+  uint32_t persistent_size = 0;
+  QnnLpaiGraph_CustomProperty_t custom_props[2];
+  custom_props[0].option = QNN_LPAI_GRAPH_GET_PROP_SCRATCH_MEM_SIZE;
+  custom_props[0].property = &scratch_size;
+  custom_props[1].option = QNN_LPAI_GRAPH_GET_PROP_PERSISTENT_MEM_SIZE;
+  custom_props[1].property = &persistent_size;
+
+  QnnGraph_Property_t graph_props[2];
+  graph_props[0].option = QNN_GRAPH_PROPERTY_OPTION_CUSTOM;
+  graph_props[0].customProperty = &custom_props[0];
+  graph_props[1].option = QNN_GRAPH_PROPERTY_OPTION_CUSTOM;
+  graph_props[1].customProperty = &custom_props[1];
+  QnnGraph_Property_t* graph_prop_ptrs[3] = {0};
+  graph_prop_ptrs[0] = &graph_props[0];
+  graph_prop_ptrs[1] = &graph_props[1];
+
+  const QnnInterface& qnn_interface =
+      graph_->implementation_->GetQnnInterface();
+  Qnn_ErrorHandle_t error = qnn_interface.qnn_graph_get_property(
+      graph_->handle_[graph_name], graph_prop_ptrs);
+
+  if (error != QNN_SUCCESS) {
+    QNN_EXECUTORCH_LOG_ERROR(
+        "failed to get graph property: %d", QNN_GET_ERROR_CODE(error));
+    return {};
+  }
+
+  scratch_buf_.resize(scratch_size);
+  p_custom_config = AllocGraphCustomConfig();
+  p_custom_config->option = QNN_LPAI_GRAPH_SET_CFG_SCRATCH_MEM;
+  auto p_scratch_config = AllocMem();
+  p_scratch_config->memType = QNN_LPAI_MEM_TYPE_DDR;
+  p_scratch_config->size = scratch_size;
+  p_scratch_config->addr = scratch_buf_.data();
+  p_custom_config->config = p_scratch_config;
+  configs.push_back(p_custom_config);
+
+  persistent_buf_.resize(persistent_size);
+  p_custom_config = AllocGraphCustomConfig();
+  p_custom_config->option = QNN_LPAI_GRAPH_SET_CFG_PERSISTENT_MEM_DEFAULT;
+  auto p_persistent_config = AllocMem();
+  p_persistent_config->memType = QNN_LPAI_MEM_TYPE_DDR;
+  p_persistent_config->size = persistent_size;
+  p_persistent_config->addr = persistent_buf_.data();
+  p_custom_config->config = p_persistent_config;
+  configs.push_back(p_custom_config);
+  // TODO: figure out how to add perf control (internal enum required)
+  //       e.g. QNN_LPAI_GRAPH_SET_ENPU_CLOCK
+#endif
+  // perf config
+  p_custom_config = AllocGraphCustomConfig();
+  auto p_perf_cfg = AllocPerfCfg();
+  p_custom_config->option = QNN_LPAI_GRAPH_SET_CFG_PERF_CFG;
+  p_perf_cfg->fps = lpai_options_->fps();
+  p_perf_cfg->ftrtRatio = lpai_options_->ftrt_ratio();
+  p_perf_cfg->clientType = static_cast<QnnLpaiGraph_ClientPerfType_t>(
+      lpai_options_->client_perf_type());
+  p_custom_config->config = p_perf_cfg;
+  configs.push_back(p_custom_config);
+  // core affinity
+  p_custom_config = AllocGraphCustomConfig();
+  auto p_core_affinity = AllocCoreAffinity();
+  p_custom_config->option = QNN_LPAI_GRAPH_SET_CFG_CORE_AFFINITY;
+  p_core_affinity->affinity =
+      static_cast<QnnLpaiGraph_CoreAffinityType_t>(lpai_options_->affinity());
+  p_core_affinity->coreSelection = lpai_options_->core_selection();
+  p_custom_config->config = p_core_affinity;
+  configs.push_back(p_custom_config);
+  return configs;
+}
+
+} // namespace qnn
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/lpai/x86_64/LpaiContextCustomConfig.cpp
+++ b/backends/qualcomm/runtime/backends/lpai/x86_64/LpaiContextCustomConfig.cpp
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Qualcomm Innovation Center, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/qualcomm/runtime/backends/lpai/LpaiContextCustomConfig.h>
+
+namespace executorch {
+namespace backends {
+namespace qnn {
+
+std::vector<QnnContext_CustomConfig_t>
+LpaiContextCustomConfig::CreateContextCustomConfig() {
+  return {};
+}
+
+} // namespace qnn
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/lpai/x86_64/LpaiDevice.cpp
+++ b/backends/qualcomm/runtime/backends/lpai/x86_64/LpaiDevice.cpp
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) Qualcomm Innovation Center, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/qualcomm/runtime/backends/lpai/LpaiDevice.h>
+
+namespace executorch {
+namespace backends {
+namespace qnn {
+
+Error LpaiDevice::Configure() {
+  return Error::Ok;
+}
+
+} // namespace qnn
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/lpai/x86_64/LpaiGraph.cpp
+++ b/backends/qualcomm/runtime/backends/lpai/x86_64/LpaiGraph.cpp
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) Qualcomm Innovation Center, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/qualcomm/runtime/backends/lpai/LpaiGraph.h>
+
+namespace executorch {
+namespace backends {
+namespace qnn {
+
+Error LpaiGraph::AfterConfigure(const std::string& graph_name) {
+  return Error::Ok;
+}
+
+} // namespace qnn
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/runtime/backends/lpai/x86_64/LpaiGraphCustomConfig.cpp
+++ b/backends/qualcomm/runtime/backends/lpai/x86_64/LpaiGraphCustomConfig.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Qualcomm Innovation Center, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/qualcomm/runtime/backends/lpai/LpaiGraphCustomConfig.h>
+
+namespace executorch {
+namespace backends {
+namespace qnn {
+
+std::vector<QnnGraph_CustomConfig_t>
+LpaiGraphCustomConfig::CreateGraphCustomConfig(const std::string& graph_name) {
+  std::vector<QnnGraph_CustomConfig_t> configs;
+  QnnLpaiGraph_CustomConfig_t* p_custom_config = nullptr;
+
+  p_custom_config = AllocGraphCustomConfig();
+  auto p_core_prepare = AllocPrepare();
+  static char core_selection = lpai_options_->core_selection() + '0';
+  p_custom_config->option = QNN_LPAI_GRAPH_SET_CFG_PREPARE;
+  p_core_prepare->enableCoreSelection = &core_selection;
+  p_custom_config->config = p_core_prepare;
+  configs.push_back(static_cast<QnnBackend_CustomConfig_t>(p_custom_config));
+  return configs;
+}
+
+} // namespace qnn
+} // namespace backends
+} // namespace executorch

--- a/backends/qualcomm/scripts/lpai_utils.sh
+++ b/backends/qualcomm/scripts/lpai_utils.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# Copyright (c) Qualcomm Innovation Center, Inc.
+# All rights reserved
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+if [[ -z $HEXAGON_SDK_ROOT || -z $QNN_SDK_ROOT ]]; then
+  echo "please export HEXAGON_SDK_ROOT and QNN_SDK_ROOT"
+  exit -1
+fi
+
+usage() { echo "usage: $0 [--serial abc] [--workspace /data/tmp/local/xxx] [--direct] [--lpai v6] [--hexagon v81] [--artifact /path/to/artifacts]" 1>&2; exit 1; }
+
+short=H:,s:,w:,l:,x:,a:,d,h,
+long=host:,serial:,workspace:,lpai:,hexagon:,artifact:,direct,help
+args=$(getopt -a -o $short -l $long -n $0 -- $@)
+eval set -- $args
+
+host=""
+serial=""
+workspace=""
+mode="hlos"
+lpai=""
+hexagon=""
+artifact=""
+while true; do
+  case $1 in
+    -H | --host) host=$2; shift 2;;
+    -s | --serial) serial=$2; shift 2;;
+    -w | --workspace) workspace=$2; shift 2;;
+    -l | --lpai) lpai=$2; shift 2;;
+    -x | --hexagon) hexagon=$2; shift 2;;
+    -a | --artifact) artifact=$2; shift 2;;
+    -d | --direct) mode="direct"; shift;;
+    -h | --help) usage;;
+    --) shift; break;;
+    *) echo "unknown keyword: $1"; usage;;
+  esac
+done
+
+if [[ -z $lpai ]]; then
+  echo "please specify lpai version"
+  usage
+elif [[ $mode == "direct" && -z $workspace ]]; then
+  echo "please provide device serial and workspace while using direct mode"
+  usage
+fi
+
+signed_folder=$QNN_SDK_ROOT/lib/lpai-$lpai/signed
+signer=$HEXAGON_SDK_ROOT/tools/elfsigner/elfsigner.py
+mkdir -p $signed_folder
+
+if [[ $mode == "hlos" ]]; then
+  yes 2>/dev/null | python $signer -i $QNN_SDK_ROOT/lib/lpai-$lpai/unsigned/libQnnLpaiSkel.so -o $signed_folder
+else
+  if [[ -z $hexagon ]]; then
+    echo "please specify hexagon arch"
+  fi
+  adb_args=""
+  if [[ ! -z $host ]]; then
+    adb_args="$adb_args -H $host"
+  fi
+  if [[ ! -z $serial ]]; then
+    adb_args="$adb_args -s $serial"
+  fi
+  adb $adb_args shell mkdir -p $workspace
+  yes 2>/dev/null | python $signer -i $QNN_SDK_ROOT/lib/lpai-$lpai/unsigned/libQnnLpai.so -o $signed_folder
+  yes 2>/dev/null | python $signer -i $QNN_SDK_ROOT/lib/hexagon-$hexagon/unsigned/libQnnSystem.so -o $signed_folder
+  yes 2>/dev/null | python $signer -i $HEXAGON_TOOLS_ROOT/Tools/target/hexagon/lib/$hexagon/G0/pic/libc++.so.1.0 -o $signed_folder
+  yes 2>/dev/null | python $signer -i build-hexagon/backends/qualcomm/qnn_executorch/fastrpc/libqnn_executorch_skel.so -o $signed_folder
+  yes 2>/dev/null | python $signer -i build-hexagon/backends/qualcomm/libqnn_executorch_backend.so -o $signed_folder
+  if [[ ! -z $artifact ]]; then
+    adb $adb_args push $(find $QNN_SDK_ROOT/lib/lpai-$lpai/signed/ -name 'lib*' ! -name '*LpaiSkel*') $workspace
+    adb $adb_args push build-android/backends/qualcomm/qnn_executorch/fastrpc/libqnn_executorch_stub.so $workspace
+    adb $adb_args push build-android/backends/qualcomm/qnn_executorch/fastrpc/qnn_executor_runner $workspace
+    adb $adb_args shell "cd $workspace && rm -f libc++.so.1 && ln -s libc++.so.1.0 libc++.so.1"
+    pte=$(find $artifact -type f -name "*.pte")
+    input_list=$(find $artifact -type f -name "input*.txt")
+    input_data=$(find $artifact -type f -name "input*.raw")
+    output_folder=output_direct
+    adb $adb_args shell "rm -rf $workspace/$output_folder && mkdir -p $workspace/$output_folder"
+    adb $adb_args push $pte $input_list $input_data $workspace
+    adb $adb_args shell "cd $workspace && \
+      export LD_LIBRARY_PATH=. && export ADSP_LIBRARY_PATH=. \
+      && echo 0x0C > qnn_executor_runner.farf && logcat -c \
+      && ./qnn_executor_runner --model_path $(basename $pte) --output_folder_path $output_folder"
+    adb $adb_args pull $workspace/$output_folder $artifact
+  fi
+fi

--- a/backends/qualcomm/scripts/sqnr_verifier.py
+++ b/backends/qualcomm/scripts/sqnr_verifier.py
@@ -1,0 +1,38 @@
+import argparse
+
+import numpy as np
+import torch
+from torchao.quantization.utils import compute_error
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "-g",
+    "--golden",
+    nargs="+",
+    type=str,
+)
+parser.add_argument(
+    "-o",
+    "--output",
+    nargs="+",
+    type=str,
+)
+parser.add_argument(
+    "-d",
+    "--dtype",
+    type=str,
+)
+parser.add_argument(
+    "-e",
+    "--encoding",
+    type=str,
+)
+args = parser.parse_args()
+golden = [np.fromfile(f, dtype=np.float32) for f in args.golden]
+output = [np.fromfile(f, dtype=eval(f"np.{args.dtype}")) for f in args.output]
+
+with open(args.encoding, "r") as f:
+    for i, g in enumerate(golden):
+        enc = [float(x) for x in f.readline().split()]
+        o = torch.from_numpy(output[i]).to(torch.float).sub(enc[1]).mul(enc[0])
+        print(f"SQNR_{i}: {compute_error(torch.from_numpy(g), o)}")

--- a/backends/qualcomm/serialization/qc_compiler_spec.fbs
+++ b/backends/qualcomm/serialization/qc_compiler_spec.fbs
@@ -29,6 +29,24 @@ table HtpInfo {
   vtcm_size_in_mb:uint;
 }
 
+/// Defines the LPAI hardware architecture available for LPAI backend.
+enum LpaiHardwareVersion: int {
+  NONE = 0,
+  V1,
+  V2,
+  V3,
+  V4,
+  V5,
+  V5_1 = 0x10005,
+  V6 = 6,
+  V7,
+}
+
+table LpaiInfo {
+  /// Represent the LPAI hardware version
+  lpai_hardware_version:LpaiHardwareVersion;
+}
+
 /// You could refer to Qualcomm AI Engine Direct SDK
 /// to get SoC Model in supported snapdragon devices
 enum QcomChipset: int {
@@ -61,6 +79,9 @@ table SocInfo {
 
   /// Identifies the htp information of the specified SoC.
   htp_info:HtpInfo;
+
+  /// Identifies the lpai information of the specified SoC.
+  lpai_info:LpaiInfo;
 }
 
 /// Defines performance modes available for GPU backend.
@@ -134,7 +155,7 @@ enum QnnExecuTorchBackendType: int {
   kUndefinedBackend = 0,
   kGpuBackend,
   kHtpBackend,
-  kDspBackend,
+  kLpaiBackend,
 }
 
 /// Defines pd sessions available for HTP backend.
@@ -182,7 +203,43 @@ table QnnExecuTorchHtpBackendOptions {
   use_weight_sharing:bool;
 }
 
-/// Logging level of the delegate and QNN backend.
+/// Real-time: Indicates that the model is intended for real-time use cases, where a specific performance threshold must be met.
+/// Non-real-time: Refers to models without strict performance requirements.
+enum QnnExecuTorchLpaiClientPerf: int {
+  /// this is the limit of old version flatbuffer
+  kUndefined = 0,
+  kRealTime,
+  kNonRealTime,
+}
+
+/// Offloaded Ops shall be executed on core with affinity specified.
+enum QnnExecuTorchLpaiCoreAffinity: int {
+  /// this is the limit of old version flatbuffer
+  kUndefined = 0,
+  kSoft,
+  kHard,
+}
+
+/// Specifies the backend options for the LPAI backend.
+table QnnExecuTorchLpaiBackendOptions {
+  /// Specifies how frequently inference must be completed.
+  fps:int;
+
+  /// Determines the hardware configuration to meet the latency requirement for inference.
+  ftrt_ratio:int;
+
+  /// Refers to models w/wo strict performance requirements.
+  client_perf_type:QnnExecuTorchLpaiClientPerf;
+
+  /// Offloaded Ops shall be executed on core with affinity specified.
+  affinity:QnnExecuTorchLpaiCoreAffinity;
+
+  /// Select which core for execution
+  core_selection:int;
+}
+
+/// Determines the hardware configuration to meet the latency requirement for inference.
+/// To ensure inference completes within this reduced time window, the eNPU must be boosted.
 enum QnnExecuTorchLogLevel: int {
   kLogOff = 0,
   kLogLevelError,
@@ -252,6 +309,8 @@ table QnnExecuTorchBackendOptions {
   htp_options:QnnExecuTorchHtpBackendOptions;
 
   gpu_options:QnnExecuTorchGpuBackendOptions;
+
+  lpai_options:QnnExecuTorchLpaiBackendOptions;
 }
 
 table QnnExecuTorchOptions {

--- a/examples/qualcomm/executor_runner/qnn_executor_runner.cpp
+++ b/examples/qualcomm/executor_runner/qnn_executor_runner.cpp
@@ -465,7 +465,8 @@ int main(int argc, char** argv) {
 
         if (expected_input_shapes.empty()) {
           ET_CHECK_MSG(
-              file_size == tensor_meta->nbytes(),
+              // workaround for LPAI (== → <=), should figure out root cause of graph without io QDQ
+              file_size <= tensor_meta->nbytes(),
               "Input(%d) size mismatch. file bytes: %zu, tensor bytes: %zu",
               input_index,
               file_size,

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -6,7 +6,10 @@
 
 set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
 add_subdirectory(json)
-add_subdirectory(gflags)
+# [workaround]: mkdir was not supported in hexagon
+if(NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES Hexagon)
+  add_subdirectory(gflags)
+endif()
 
 if(EXECUTORCH_BUILD_PYBIND)
   add_subdirectory(pybind11)


### PR DESCRIPTION
### Test plan
Tested with QNN version 2.41.0.251128

[Initialization]
- Build hexagon & aarch64 target
```bash
# e.g.
export HEXAGON_SDK_ROOT=$WORKSPACE/aisw-tools/avante-tools/prebuilt/dsp/hexagon-sdk-6.4.0
export HEXAGON_TOOLS_ROOT=$HEXAGON_SDK_ROOT/tools/HEXAGON_Tools/21.0.0
export HEXAGON_ARCH=v81
# QNN_SDK_ROOT & ANDROID_NDK_ROOT are required as well
cd path/to/executorch
backends/qualcomm/scripts/build.sh --enable_hexagon
```

[aarch64-android]
- Sign artifact
```bash
# e.g.
cd path/to/executorch
backends/qualcomm/scripts/lpai_utils.sh --lpai v6
```
- Run e2e test
```bash
cd path/to/executorch
mkdir lpai_artifacts
python backends/qualcomm/tests/test_qnn_delegate.py TestQNNQuantizedOperator.test_qnn_backend_lpai -b build-android -s f3c0531 -m SM8850 --backend lpai -a lpai_artifacts
```

[hexagon direct]
- Sign & push artifacts + execution
```bash
cd path/to/executorch
backends/qualcomm/scripts/lpai_utils.sh --direct --lpai v6 --hexagon v81 --workspace /data/local/tmp/lpai_direct --artifact lpai_artifacts/ --serial f3c0531
```
- Verify
```bash
cd path/to/executorch
python backends/qualcomm/scripts/sqnr_verifier.py -g lpai_artifacts/golden_0* -o lpai_artifacts/output_direct/output_0* -e lpai_artifacts/encoding.txt -d uint8
# should have SQNR number for each output
```
