### PR TITLE
Fix broken IR spec link in Export IR docs

### DIFF
--- a/docs/source/ir-exir.md
+++ b/docs/source/ir-exir.md
@@ -2,7 +2,7 @@
 
 Export IR is an intermediate representation (IR) for the result of
 `torch.export`. To read more on the details of Export IR, please read this
-[document](https://pytorch.org/docs/main/export/ir_spec.html).
+[document](https://pytorch.org/docs/stable/export/ir_spec.html).
 
 The Exported IR is a specification that consists of the following parts:
 

--- a/docs/source/ir-exir.md
+++ b/docs/source/ir-exir.md
@@ -2,7 +2,7 @@
 
 Export IR is an intermediate representation (IR) for the result of
 `torch.export`. To read more on the details of Export IR, please read this
-[document](https://pytorch.org/docs/main/export.ir_spec.html).
+[document](https://pytorch.org/docs/main/export/ir_spec.html).
 
 The Exported IR is a specification that consists of the following parts:
 


### PR DESCRIPTION
This PR fixes a broken link to the IR spec documentation from the Export IR documentation. 

cc @mergennachin @AlannaBurke