### PR TITLE
[samsung][ci] Pass with warnings if no device could be reserved

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -945,6 +945,12 @@ jobs:
         export SAMSUNG_AI_LITECORE_KEY=$SECRET_SAMSUNG_AI_LITECORE_KEY
         source .ci/scripts/setup-samsung-linux-deps.sh
 
+        # Check if device was reserved
+        if [[ "${DEVICE_RESERVED:-0}" != "1" ]]; then
+          echo "::warning::Skipping tests - no Samsung device available"
+          exit 0
+        fi
+
         # Test quant models
         model_scripts="deeplab_v3 edsr inception_v3 inception_v4 mobilenet_v2 mobilenet_v3 resnet18 resnet50 vit wav2letter"
         for m_script in $model_scripts; do
@@ -980,6 +986,12 @@ jobs:
         # Setup Samsung SDK (AI Lite Core) and install enn backend
         export SAMSUNG_AI_LITECORE_KEY=$SECRET_SAMSUNG_AI_LITECORE_KEY
         source .ci/scripts/setup-samsung-linux-deps.sh
+
+        # Check if device was reserved
+        if [[ "${DEVICE_RESERVED:-0}" != "1" ]]; then
+          echo "::warning::Skipping tests - no Samsung device available"
+          exit 0
+        fi
 
         # Test models
         python -m unittest discover -s backends/samsung/test/models -p "test_*.py"


### PR DESCRIPTION

Summary:

Previously, the Samsung CI jobs would fail when no device could be
reserved from the device farm. This caused the entire CI run to fail
even though the issue was transient device availability rather than
a code problem.

This commit updates the device reservation logic to:
- Set DEVICE_RESERVED=0 by default, and 1 when successfully reserved
- Catch devicefarm-cli reservation failures and emit GitHub warnings
- Allow the setup script to complete successfully even without a device
- Skip actual tests with a warning when no device is available
