### PR TITLE
Remove .forward for call to attention block

### DIFF
--- a/examples/models/llama/llama_transformer.py
+++ b/examples/models/llama/llama_transformer.py
@@ -127,7 +127,7 @@ class TransformerBlock(nn.Module):
         return TransformerBlock(args, attention)
 
     def forward(self, x, freqs_cos, freqs_sin, attn_options: ForwardOptions):  # x: 1xN
-        h, attn_options_update = self.attention.forward(
+        h, attn_options_update = self.attention(
             self.attention_norm(x), freqs_cos, freqs_sin, **attn_options
         )
         if not isinstance(self.attention, AttentionSkip):


### PR DESCRIPTION
Summary: We have been explicitly calling forward method on attention block from transformer block. This prevents use from registering various hooks on the attention module. I found this out while trying to implement hook that records the input to the attention block.

Differential Revision: D90126170


