### PR TITLE
Fix deprecated importlib.resources and exir.capture() API usage

### DIFF
--- a/backends/xnnpack/serialization/xnnpack_graph_serialize.py
+++ b/backends/xnnpack/serialization/xnnpack_graph_serialize.py
@@ -317,7 +317,9 @@ def convert_to_flatbuffer(xnnpack_graph: XNNGraph) -> bytes:
         schema_path = os.path.join(d, "schema.fbs")
         with open(schema_path, "wb") as schema_file:
             schema_file.write(
-                _resources.read_binary(serialization_package, "schema.fbs")
+                _resources.files(serialization_package)
+                .joinpath("schema.fbs")
+                .read_bytes()
             )
         json_path = os.path.join(d, "schema.json")
         with open(json_path, "wb") as json_file:

--- a/exir/_serialize/_flatbuffer.py
+++ b/exir/_serialize/_flatbuffer.py
@@ -187,9 +187,12 @@ def _run_flatc(args: Sequence[str]) -> None:
     If a resource matching _FLATC_RESOURCE_NAME exists, uses that executable.
     Otherwise, expects the `flatc` tool to be available on the system path.
     """
-    if importlib.resources.is_resource(__package__, _FLATC_RESOURCE_NAME):
+    flatc_resource = importlib.resources.files(__package__).joinpath(
+        _FLATC_RESOURCE_NAME
+    )
+    if flatc_resource.is_file():
         # Use the provided flatc binary.
-        with importlib.resources.path(__package__, _FLATC_RESOURCE_NAME) as flatc_path:
+        with importlib.resources.as_file(flatc_resource) as flatc_path:
             subprocess.run([flatc_path] + list(args), check=True)
     else:
         # Expect the `flatc` tool to be on the system path or set as an env var.


### PR DESCRIPTION
- Replace deprecated `read_binary()` with `files().joinpath().read_bytes()`
  in xnnpack_graph_serialize.py
- Replace deprecated `is_resource()` with `files().joinpath().is_file()`
  in _flatbuffer.py
- Replace deprecated `exir.capture()` with `torch.export.export()` + `to_edge()`
  in bilinear_2d.py
