### PR TITLE
[executorch] Remove EXECUTORCH_CLIENTS visibility gating - Core

### DIFF
--- a/runtime/core/exec_aten/targets.bzl
+++ b/runtime/core/exec_aten/targets.bzl
@@ -15,10 +15,7 @@ def define_common_targets():
             name = "lib" + aten_suffix,
             exported_headers = ["exec_aten.h"],
             exported_preprocessor_flags = ["-DUSE_ATEN_LIB"] if aten_mode else [],
-            visibility = [
-                "//executorch/...",
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
             exported_deps = ["//executorch/runtime/core:tensor_shape_dynamism"] + ([] if aten_mode else ["//executorch/runtime/core/portable_type:portable_type"]),
             exported_external_deps = ["libtorch"] if aten_mode else [],
         )

--- a/runtime/core/exec_aten/testing_util/targets.bzl
+++ b/runtime/core/exec_aten/testing_util/targets.bzl
@@ -16,26 +16,7 @@ def define_common_targets():
                 "tensor_util.h",
                 "tensor_factory.h",
             ],
-            visibility = [
-                # Be strict with the visibility so that operator implementations
-                # under //executorch/kernels/... can't depend on this test-only
-                # target. It's ok to add any //executorch/*/test/... path to this
-                # list.
-                "//executorch/runtime/core/exec_aten/util/test/...",
-                "//executorch/runtime/core/exec_aten/testing_util/test/...",
-                "//executorch/runtime/core/portable_type/test/...",
-                "//executorch/kernels/prim_ops/test/...",
-                "//executorch/kernels/portable/test/...",
-                "//executorch/kernels/portable/cpu/util/test/...",
-                "//executorch/kernels/quantized/test/...",
-                "//executorch/kernels/optimized/test/...",
-                "//executorch/kernels/test/...",
-                "//executorch/kernels/fb/custom_ops/...",
-                "//executorch/runtime/core/test/...",
-                "//executorch/test/...",
-                "//executorch/extension/kernel_util/test/...",
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
             compiler_flags = ["-Wno-unneeded-internal-declaration"],
             exported_preprocessor_flags = ["-DUSE_ATEN_LIB"] if aten_mode else [],
             exported_deps = [

--- a/runtime/core/exec_aten/util/targets.bzl
+++ b/runtime/core/exec_aten/util/targets.bzl
@@ -23,10 +23,7 @@ def define_common_targets():
             exported_headers = [
                 "scalar_type_util.h",
             ],
-            visibility = [
-                "//executorch/...",
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
             exported_preprocessor_flags = exported_preprocessor_flags_,
             exported_deps = exported_deps_,
             exported_external_deps = ["libtorch"] if aten_mode else [],
@@ -42,10 +39,7 @@ def define_common_targets():
                 "//executorch/runtime/core:core",
                 "//executorch/runtime/core/portable_type/c10/c10:c10",
             ],
-            visibility = [
-                "//executorch/...",
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
             exported_preprocessor_flags = ["-DUSE_ATEN_LIB"] if aten_mode else [],
         )
 
@@ -55,10 +49,7 @@ def define_common_targets():
             exported_headers = [
                 "tensor_util.h",
             ],
-            visibility = [
-                "//executorch/...",
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
             exported_preprocessor_flags = ["-DUSE_ATEN_LIB"] if aten_mode else [],
             exported_deps = [
                 ":tensor_dimension_limit",
@@ -84,17 +75,11 @@ def define_common_targets():
                 "//executorch/runtime/core/exec_aten/util:tensor_dimension_limit",
             ],
             exported_headers = ["tensor_shape_to_c_string.h"],
-            visibility = [
-                "//executorch/...",
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
         )
 
     runtime.cxx_library(
         name = "tensor_dimension_limit",
         exported_headers = ["tensor_dimension_limit.h"],
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )

--- a/runtime/core/portable_type/c10/c10/targets.bzl
+++ b/runtime/core/portable_type/c10/c10/targets.bzl
@@ -61,11 +61,7 @@ def define_common_targets():
     runtime.cxx_library(
         name = "aten_headers_for_executorch",
         srcs = [],
-        visibility = [
-            "//executorch/kernels/optimized/...",
-            "//executorch/kernels/portable/cpu/util/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         # select() on ovr_config//runtime:fbcode does not work
         # properly in all cases. I have seen
         # //xplat/executorch/runtime/core/portable_type/c10/c10:aten_headers_for_executorch
@@ -124,10 +120,7 @@ def define_common_targets():
                 "-DC10_USE_GLOG",
                 "-DC10_USE_MINIMAL_GLOG",
             ]),
-            visibility = [
-                "//executorch/...",
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
             exported_deps = [
                 "//executorch/runtime/core/portable_type/c10/torch/headeronly:torch_headeronly",
             ] + select({
@@ -142,8 +135,5 @@ def define_common_targets():
         runtime.cxx_library(
             name = "c10",
             exported_deps = [":aten_headers_for_executorch"],
-            visibility = [
-                "//executorch/...",
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
         )

--- a/runtime/core/targets.bzl
+++ b/runtime/core/targets.bzl
@@ -50,10 +50,7 @@ def define_common_targets():
             "result.h",
             "span.h",
         ],
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         exported_preprocessor_flags = get_core_flags(),
         exported_deps = [
             "//executorch/runtime/core/portable_type/c10/c10:c10",
@@ -82,10 +79,7 @@ def define_common_targets():
             ":core",
             "//executorch/runtime/core/portable_type/c10/c10:c10",
         ],
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     for aten_mode in get_aten_mode_options():
@@ -96,10 +90,7 @@ def define_common_targets():
                 "evalue.h",
             ],
             srcs = ["evalue.cpp"],
-            visibility = [
-                "//executorch/...",
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
             exported_deps = [
                 ":core",
                 ":tag",
@@ -114,10 +105,7 @@ def define_common_targets():
                 "event_tracer_hooks.h",
                 "event_tracer_hooks_delegate.h",
             ],
-            visibility = [
-                "//executorch/...",
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
             exported_preprocessor_flags = get_event_tracer_flags() + get_sdk_flags(),
             exported_deps = [
                 "//executorch/runtime/platform:platform",
@@ -130,10 +118,7 @@ def define_common_targets():
             exported_headers = [
                 "named_data_map.h",
             ],
-            visibility = [
-                "//executorch/...",
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
             exported_deps = [
                 ":tensor_layout" + aten_suffix,
                 "//executorch/runtime/core/exec_aten:lib" + aten_suffix,

--- a/runtime/core/testing_util/targets.bzl
+++ b/runtime/core/testing_util/targets.bzl
@@ -15,10 +15,7 @@ def define_common_targets():
         exported_headers = [
             "error_matchers.h",
         ],
-        visibility = [
-            "//executorch/runtime/core/testing_util/test/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         exported_external_deps = [
             "gmock",
         ],

--- a/runtime/platform/targets.bzl
+++ b/runtime/platform/targets.bzl
@@ -81,10 +81,7 @@ def define_common_targets():
             ":compiler",
             ":platform_private",
         ],
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         # WARNING: using a deprecated API to avoid being built into a shared
         # library. In the case of dynamically loading so library we don't want
         # it to depend on other so libraries because that way we have to
@@ -110,10 +107,7 @@ def define_common_targets():
                 "ovr_config//os:macos": ["-DET_USE_LIBDL"],
             },
         ),
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     # Common compiler directives such as 'unlikely' or 'deprecated'
@@ -122,8 +116,5 @@ def define_common_targets():
         exported_headers = [
             "compiler.h",
         ],
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )

--- a/shim_et/xplat/executorch/build/runtime_wrapper.bzl
+++ b/shim_et/xplat/executorch/build/runtime_wrapper.bzl
@@ -184,17 +184,7 @@ def _patch_kwargs_common(kwargs):
     """
     env.remove_unsupported_kwargs(kwargs)
 
-    # Be careful about dependencies on executorch targets for now, so that we
-    # don't pick up unexpected clients while things are still in flux.
-    if not kwargs.pop("_is_external_target", False):
-        for target in kwargs.get("visibility", []):
-            if not (target == "PUBLIC" or target.startswith("//executorch") or target.startswith("//pytorch/tokenizers") or target.startswith("@")):
-                fail("Please manage all external visibility using the " +
-                     "EXECUTORCH_CLIENTS list in " +
-                     "//executorch/build/fb/clients.bzl. " +
-                     "Found external visibility target \"{}\".".format(target))
-    else:
-        kwargs.pop("_is_external_target", None)
+    kwargs.pop("_is_external_target", False)
 
     # Convert `[exported_]external_deps` entries into real deps if necessary.
     _resolve_external_deps(kwargs)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #16480
* #16479
* #16478
* #16477
* #16476
* #16475
* __->__ #16474

Remove the EXECUTORCH_CLIENTS buck client list that gates visibility on core infrastructure
targets. This removes the gating rule in runtime_wrapper.bzl and replaces all visibility
blocks containing @EXECUTORCH_CLIENTS with explicit PUBLIC visibility.

This is part 1 of a multi-diff stack to remove visibility gating across all of executorch.
This diff covers:
- build/runtime_wrapper.bzl (removes the gating rule)
- runtime/core/* targets
- runtime/platform targets

Differential Revision: [D89902032](https://our.internmc.facebook.com/intern/diff/D89902032/)