### PR TITLE
[executorch] Remove EXECUTORCH_CLIENTS visibility gating - Runtime (backend/executor/kernel)

### DIFF
--- a/runtime/TARGETS
+++ b/runtime/TARGETS
@@ -8,8 +8,5 @@ runtime.python_library(
     deps = [
         "//executorch/extension/pybindings:portable_lib",
     ],
-    visibility = [
-        "//executorch/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
 )

--- a/runtime/backend/targets.bzl
+++ b/runtime/backend/targets.bzl
@@ -22,10 +22,7 @@ def define_common_targets():
                 "interface.h",
             ],
             preprocessor_flags = ["-DUSE_ATEN_LIB"] if aten_mode else [],
-            visibility = [
-                "//executorch/...",
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
             exported_deps = [
                 "//executorch/runtime/core:core",
                 "//executorch/runtime/core:evalue" + aten_suffix,

--- a/runtime/executor/targets.bzl
+++ b/runtime/executor/targets.bzl
@@ -37,10 +37,7 @@ def define_common_targets():
         exported_deps = [
             "//executorch/runtime/core:memory_allocator",
         ],
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
 
@@ -55,10 +52,7 @@ def define_common_targets():
             exported_headers = [
                 "pte_data_map.h",
             ],
-            visibility = [
-                "//executorch/runtime/executor/...",
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
             exported_deps = [
                 "//executorch/runtime/core:core",
                 "//executorch/runtime/core:named_data_map" + aten_suffix,
@@ -86,10 +80,7 @@ def define_common_targets():
                 ":program_no_prim_ops" + aten_suffix,
                 "//executorch/kernels/prim_ops:prim_ops_registry" + aten_suffix,
             ],
-            visibility = [
-                "//executorch/runtime/executor/...",
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
         )
 
         runtime.cxx_library(
@@ -132,8 +123,5 @@ def define_common_targets():
                 "//executorch/schema:program",
                 "//executorch/runtime/core/exec_aten/util:tensor_dimension_limit"
             ],
-            visibility = [
-                "//executorch/runtime/executor/...",
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
         )

--- a/runtime/executor/test/targets.bzl
+++ b/runtime/executor/test/targets.bzl
@@ -81,11 +81,7 @@ def define_common_targets(is_fbcode = False):
         exported_headers = [
             "managed_memory_manager.h",
         ],
-        visibility = [
-            "//executorch/runtime/executor/test/...",
-            "//executorch/test/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         deps = [
             "//executorch/runtime/core:memory_allocator",
             "//executorch/runtime/executor:memory_manager",

--- a/runtime/kernel/targets.bzl
+++ b/runtime/kernel/targets.bzl
@@ -28,10 +28,7 @@ def define_common_targets():
         name = "operator_registry_MAX_NUM_KERNELS_TEST_ONLY",
         srcs = ["operator_registry.cpp"],
         exported_headers = ["operator_registry.h"],
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         exported_deps = [
             "//executorch/runtime/core:core",
             "//executorch/runtime/core:evalue",
@@ -60,10 +57,7 @@ def define_common_targets():
             name = "operator_registry" + aten_suffix,
             srcs = ["operator_registry.cpp"],
             exported_headers = ["operator_registry.h"],
-            visibility = [
-                "//executorch/...",
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
             exported_deps = [
                 "//executorch/runtime/core:core",
                 "//executorch/runtime/core:evalue" + aten_suffix,
@@ -76,12 +70,7 @@ def define_common_targets():
             exported_headers = [
                 "kernel_runtime_context.h",
             ],
-            visibility = [
-                "//executorch/kernels/...",
-                "//executorch/runtime/executor/...",
-                "//executorch/runtime/kernel/...",
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
             exported_deps = [
                 "//executorch/runtime/core:core",
                 "//executorch/runtime/platform:platform",
@@ -98,12 +87,7 @@ def define_common_targets():
             exported_headers = [
                 "kernel_includes.h",
             ],
-            visibility = [
-                "//executorch/runtime/kernel/...",
-                "//executorch/kernels/...",
-                "//executorch/kernels/prim_ops/...",  # Prim kernels
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
             exported_deps = [
                 ":kernel_runtime_context" + aten_suffix,
                 "//executorch/runtime/core/exec_aten:lib" + aten_suffix,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #16480
* #16479
* #16478
* #16477
* #16476
* __->__ #16475
* #16474

Remove the EXECUTORCH_CLIENTS buck client list visibility gating from runtime
targets outside of core. This replaces all visibility blocks containing
@EXECUTORCH_CLIENTS with explicit PUBLIC visibility.

This is part 2 of a multi-diff stack to remove visibility gating across all of executorch.
This diff covers:
- runtime/backend targets
- runtime/executor targets
- runtime/kernel targets

Differential Revision: [D89902033](https://our.internmc.facebook.com/intern/diff/D89902033/)