### PR TITLE
[executorch] Remove EXECUTORCH_CLIENTS visibility gating - Kernels

### DIFF
--- a/kernels/aten/targets.bzl
+++ b/kernels/aten/targets.bzl
@@ -10,18 +10,12 @@ def define_common_targets():
 
     runtime.export_file(
         name = "functions.yaml",
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     runtime.export_file(
         name = "edge_dialect_aten_op.yaml",
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     et_operator_library(
@@ -33,10 +27,7 @@ def define_common_targets():
     runtime.cxx_library(
         name = "operators_edge_dialect_aten",
         srcs = [],
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         exported_deps = [
             "//executorch/kernels/aten/cpu:cpu",
         ],
@@ -61,8 +52,5 @@ def define_common_targets():
         custom_ops_yaml_target = "//executorch/kernels/aten:edge_dialect_aten_op.yaml",
         define_static_targets = True,
         custom_ops_requires_aot_registration = False,
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )

--- a/kernels/optimized/cpu/targets.bzl
+++ b/kernels/optimized/cpu/targets.bzl
@@ -25,7 +25,7 @@ def define_common_targets():
         name = "add_sub_impl",
         srcs = [],
         exported_headers = ["op_add_sub_impl.h"],
-        visibility = ["//executorch/kernels/optimized/cpu/...", "@EXECUTORCH_CLIENTS",],
+        visibility = ["PUBLIC"],
         exported_deps = [
             "//executorch/runtime/core:core",
             "//executorch/kernels/portable/cpu/util:broadcast_indexes_range",
@@ -39,7 +39,7 @@ def define_common_targets():
         name = "fft_utils",
         srcs = [],
         exported_headers = ["fft_utils.h"],
-        visibility = ["//executorch/kernels/optimized/cpu/...", "@EXECUTORCH_CLIENTS",],
+        visibility = ["PUBLIC"],
         exported_deps = [] if runtime.is_oss else ["fbsource//third-party/pocket_fft:pocketfft"],
     )
 
@@ -47,7 +47,7 @@ def define_common_targets():
         name = "binary_ops",
         srcs = ["binary_ops.cpp"],
         exported_headers = ["binary_ops.h"],
-        visibility = ["//executorch/kernels/optimized/cpu/...", "@EXECUTORCH_CLIENTS",],
+        visibility = ["PUBLIC"],
         exported_deps = [
             "//executorch/runtime/core/exec_aten:lib",
             "//executorch/runtime/kernel:kernel_includes",
@@ -68,7 +68,7 @@ def define_common_targets():
         name = "moments_utils",
         srcs = [],
         exported_headers = ["moments_utils.h"],
-        visibility = ["//executorch/kernels/optimized/...", "@EXECUTORCH_CLIENTS",],
+        visibility = ["PUBLIC"],
         exported_deps = [
             "//executorch/runtime/core/portable_type/c10/c10:aten_headers_for_executorch",
             "//executorch/kernels/optimized:libvec",
@@ -80,11 +80,11 @@ def define_common_targets():
     runtime.filegroup(
         name = "optimized_source_files",
         srcs = native.glob(["*.cpp"]),
-        visibility = ["//executorch/...", "@EXECUTORCH_CLIENTS"],
+        visibility = ["PUBLIC"],
     )
 
     runtime.filegroup(
         name = "optimized_header_files",
         srcs = native.glob(["*.h"]),
-        visibility = ["//executorch/...", "@EXECUTORCH_CLIENTS"],
+        visibility = ["PUBLIC"],
     )

--- a/kernels/optimized/lib_defs.bzl
+++ b/kernels/optimized/lib_defs.bzl
@@ -127,10 +127,7 @@ def define_libs(is_fbcode=False):
             "vec/**/*.h",
         ]),
         header_namespace = "executorch/kernels/optimized",
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         exported_deps = [
             "//executorch/runtime/core/portable_type/c10/c10:aten_headers_for_executorch",
         ],
@@ -157,10 +154,7 @@ def define_libs(is_fbcode=False):
             "utils/**/*.h",
         ]),
         header_namespace = "executorch/kernels/optimized",
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         exported_deps = [
             # Needed to access the ET_INLINE macro
             "//executorch/runtime/platform:compiler",
@@ -222,10 +216,7 @@ def define_libs(is_fbcode=False):
                 "DEFAULT": ["-Os"],
             }),
             header_namespace = "executorch/kernels/optimized",
-            visibility = [
-                "//executorch/...",
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
             preprocessor_flags = get_preprocessor_flags(),
             fbobjc_exported_preprocessor_flags = [
                 "-DET_BUILD_WITH_BLAS",

--- a/kernels/optimized/targets.bzl
+++ b/kernels/optimized/targets.bzl
@@ -13,19 +13,13 @@ def define_common_targets(is_fbcode=False):
 
     runtime.export_file(
         name = "optimized.yaml",
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_library(
         name = "optimized_operators",
         srcs = [],
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         exported_deps = [
             "//executorch/kernels/optimized/cpu:cpu_optimized",
         ],
@@ -34,9 +28,7 @@ def define_common_targets(is_fbcode=False):
     et_operator_library(
         name = "optimized_oplist",
         ops_schema_yaml_target = ":optimized.yaml",
-        visibility = [
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     # Used mainly for operator testing. In practice, a generated lib specific
@@ -50,8 +42,5 @@ def define_common_targets(is_fbcode=False):
         ],
         functions_yaml_target = ":optimized.yaml",
         define_static_targets = True,
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )

--- a/kernels/portable/cpu/pattern/targets.bzl
+++ b/kernels/portable/cpu/pattern/targets.bzl
@@ -18,7 +18,7 @@ def define_common_targets():
             "//executorch/kernels/portable/cpu/pattern:comparison_op",
             "//executorch/kernels/portable/cpu/pattern:logical_op"
         ],
-        visibility = ["//executorch/...", "@EXECUTORCH_CLIENTS"],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_library(

--- a/kernels/portable/cpu/targets.bzl
+++ b/kernels/portable/cpu/targets.bzl
@@ -47,11 +47,7 @@ def define_common_targets():
         ],
         srcs = [],
         exported_headers = ["vec_ops.h"],
-        visibility = [
-            "//executorch/kernels/portable/...",
-            "//executorch/kernels/quantized/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     # Only for use by targets in this directory. Defines constants like M_PI
@@ -62,9 +58,7 @@ def define_common_targets():
         exported_headers = [
             "math_constants.h",
         ],
-        visibility = [
-            "//executorch/kernels/portable/...", "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     # Only for use by targets in this directory.
@@ -72,13 +66,7 @@ def define_common_targets():
         name = "scalar_utils",
         srcs = [],
         exported_headers = ["scalar_utils.h", "selective_build.h"],
-        visibility = [
-            "//executorch/kernels/fb/...",
-            "//executorch/kernels/optimized/cpu/...",
-            "//executorch/kernels/portable/cpu/...",
-            "//executorch/kernels/portable/test/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         deps = [
             "//executorch/runtime/core/exec_aten/util:scalar_type_util",
         ],
@@ -91,11 +79,11 @@ def define_common_targets():
     runtime.filegroup(
         name = "portable_source_files",
         srcs = native.glob(["*.cpp"]),
-        visibility = ["//executorch/...", "@EXECUTORCH_CLIENTS"],
+        visibility = ["PUBLIC"],
     )
 
     runtime.filegroup(
         name = "portable_header_files",
         srcs = native.glob(["*.h"]),
-        visibility = ["//executorch/...", "@EXECUTORCH_CLIENTS"],
+        visibility = ["PUBLIC"],
     )

--- a/kernels/portable/cpu/util/targets.bzl
+++ b/kernels/portable/cpu/util/targets.bzl
@@ -38,7 +38,7 @@ def define_common_targets():
             "//executorch/kernels/portable/cpu/util:vectorized_math",
             "//executorch/kernels/portable/cpu/util:grid_sampler_2d_util",
         ],
-        visibility = ["//executorch/...", "@EXECUTORCH_CLIENTS"],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_library(
@@ -88,7 +88,7 @@ def define_common_targets():
             "//executorch/runtime/core/exec_aten/util:tensor_shape_to_c_string",
             "//executorch/runtime/core/exec_aten/util:tensor_util",
         ],
-        visibility = ["//executorch/kernels/portable/cpu/...", "//executorch/kernels/optimized/cpu/...", "@EXECUTORCH_CLIENTS"],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_library(
@@ -101,7 +101,7 @@ def define_common_targets():
         deps = [
             "//executorch/runtime/kernel:kernel_includes",
         ],
-        visibility = ["//executorch/kernels/portable/cpu/...", "//executorch/kernels/optimized/cpu/...", "@EXECUTORCH_CLIENTS"],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_library(
@@ -124,7 +124,7 @@ def define_common_targets():
         deps = [
             "//executorch/runtime/kernel:kernel_includes",
         ],
-        visibility = ["//executorch/kernels/portable/cpu/...", "//executorch/kernels/optimized/cpu/...", "@EXECUTORCH_CLIENTS"],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_library(
@@ -139,7 +139,7 @@ def define_common_targets():
             "//executorch/runtime/core/exec_aten/util:tensor_shape_to_c_string",
             "//executorch/runtime/kernel:kernel_includes",
         ],
-        visibility = ["//executorch/kernels/portable/cpu/...", "//executorch/kernels/optimized/cpu/...", "@EXECUTORCH_CLIENTS"],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_library(
@@ -262,7 +262,7 @@ def define_common_targets():
             "//executorch/runtime/core/exec_aten/util:tensor_util",
             ":broadcast_util",
         ],
-        visibility = ["//executorch/kernels/portable/cpu/...", "//executorch/kernels/quantized/...", "@EXECUTORCH_CLIENTS"],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_library(
@@ -308,7 +308,7 @@ def define_common_targets():
         exported_deps = [
             "//executorch/runtime/kernel:kernel_includes",
         ],
-        visibility = ["//executorch/kernels/portable/cpu/...", "@EXECUTORCH_CLIENTS"],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_library(
@@ -328,10 +328,7 @@ def define_common_targets():
             "//executorch/runtime/core/exec_aten:lib",
             "//executorch/runtime/core/exec_aten/util:tensor_dimension_limit",
         ],
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_library(
@@ -369,12 +366,7 @@ def define_common_targets():
                 "//executorch/extension/threadpool:threadpool",
             ],
             exported_preprocessor_flags = ["-DUSE_ATEN_LIB"] if aten_mode else [],
-            visibility = [
-                "//executorch/extension/llm/custom_ops/...",
-                "//executorch/kernels/portable/cpu/...",
-                "//executorch/kernels/quantized/...",
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
         )
 
         runtime.cxx_library(

--- a/kernels/portable/targets.bzl
+++ b/kernels/portable/targets.bzl
@@ -11,10 +11,7 @@ def define_common_targets():
     runtime.cxx_library(
         name = "operators",
         srcs = [],
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         exported_deps = [
             "//executorch/kernels/portable/cpu:cpu",
         ],
@@ -24,10 +21,7 @@ def define_common_targets():
         runtime.cxx_library(
             name = "operators_aten",
             srcs = [],
-            visibility = [
-                "//executorch/...",
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
             exported_deps = [
                 "//executorch/kernels/portable/cpu:cpu_aten",
             ],
@@ -35,48 +29,33 @@ def define_common_targets():
 
     runtime.export_file(
         name = "functions.yaml",
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     runtime.export_file(
         name = "custom_ops.yaml",
-        visibility = [
-            "//executorch/codegen/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     et_operator_library(
         name = "executorch_all_ops",
         include_all_operators = True,
         define_static_targets = True,
-        visibility = [
-            "//executorch/codegen/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     et_operator_library(
         name = "executorch_aten_ops",
         ops_schema_yaml_target = "//executorch/kernels/portable:functions.yaml",
         define_static_targets = True,
-        visibility = [
-            "//executorch/codegen/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     et_operator_library(
         name = "executorch_custom_ops",
         ops_schema_yaml_target = "//executorch/kernels/portable:custom_ops.yaml",
         define_static_targets = True,
-        visibility = [
-            "//executorch/codegen/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     generated_lib_common_args = {
@@ -84,10 +63,7 @@ def define_common_targets():
         # size_test expects _static targets to be available for these libraries.
         "define_static_targets": True,
         "functions_yaml_target": "//executorch/kernels/portable:functions.yaml",
-        "visibility": [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        "visibility": ["PUBLIC"],
     }
 
     executorch_generated_lib(
@@ -113,9 +89,6 @@ def define_common_targets():
             ],
             custom_ops_yaml_target = "//executorch/kernels/portable:custom_ops.yaml",
             aten_mode = True,
-            visibility = [
-                "//executorch/...",
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
             define_static_targets = True,
         )

--- a/kernels/portable/test/TARGETS
+++ b/kernels/portable/test/TARGETS
@@ -13,10 +13,7 @@ runtime.cxx_library(
     srcs = [
         "register_ops_aot_for_test.cpp",
     ],
-    visibility = [
-        "//executorch/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         "//executorch/extension/aten_util:aten_bridge",
         "//executorch/kernels/portable/cpu:op_grid_sampler_2d",

--- a/kernels/prim_ops/targets.bzl
+++ b/kernels/prim_ops/targets.bzl
@@ -11,13 +11,13 @@ def define_common_targets():
     runtime.filegroup(
         name = "prim_ops_sources",
         srcs = ["register_prim_ops.cpp"],
-        visibility = ["//executorch/...", "@EXECUTORCH_CLIENTS"],
+        visibility = ["PUBLIC"],
     )
 
     runtime.filegroup(
         name = "selective_build_prim_ops.h",
         srcs = ["selective_build_prim_ops.h"],
-        visibility = ["//executorch/...", "@EXECUTORCH_CLIENTS"],
+        visibility = ["PUBLIC"],
     )
 
     for aten_mode in get_aten_mode_options():
@@ -28,10 +28,7 @@ def define_common_targets():
             srcs = ["et_copy_index.cpp"],
             # To allow for selective prim ops to depend on this library.
             # Used by selective_build.bzl
-            visibility = [
-                "//executorch/...",
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
             exported_headers = ["et_copy_index.h"],
             deps = [
                 "//executorch/runtime/kernel:kernel_includes" + aten_suffix,
@@ -48,10 +45,7 @@ def define_common_targets():
             srcs = ["et_view.cpp"],
             # To allow for selective prim ops to depend on this library.
             # Used by selective_build.bzl
-            visibility = [
-                "//executorch/...",
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
             exported_headers = ["et_view.h"],
             deps = [
                 "//executorch/runtime/kernel:kernel_includes" + aten_suffix,
@@ -66,10 +60,7 @@ def define_common_targets():
         runtime.cxx_library(
             name = "prim_ops_registry" + aten_suffix,
             srcs = ["register_prim_ops.cpp"],
-            visibility = [
-                "//executorch/...",
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
             # @lint-ignore BUCKLINT link_whole, need this to register prim ops.
             link_whole = True,
             # prim ops are registered through a global table so the ctor needs to be allowed

--- a/kernels/quantized/targets.bzl
+++ b/kernels/quantized/targets.bzl
@@ -4,9 +4,7 @@ load("@fbsource//xplat/executorch/codegen:codegen.bzl", "et_operator_library", "
 def define_common_targets():
     runtime.export_file(
         name = "quantized.yaml",
-        visibility = [
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     # Excluding embedding_byte ops because we choose to define them
@@ -35,7 +33,7 @@ def define_common_targets():
     exir_custom_ops_aot_lib(
         name = "custom_ops_generated_lib",
         yaml_target = ":quantized.yaml",
-        visibility = ["//executorch/...", "@EXECUTORCH_CLIENTS"],
+        visibility = ["PUBLIC"],
         kernels = [":quantized_operators_aten"],
         deps = [
             ":quantized_ops_need_aot_registration",
@@ -47,10 +45,7 @@ def define_common_targets():
     exir_custom_ops_aot_lib(
         name = "aot_lib",
         yaml_target = ":quantized.yaml",
-        visibility = [
-                "//executorch/...",
-                "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         kernels = [":quantized_operators_aten"],
         deps = [
             ":quantized_ops_need_aot_registration",
@@ -61,10 +56,7 @@ def define_common_targets():
         name = "all_quantized_ops",
         ops_schema_yaml_target = ":quantized.yaml",
         define_static_targets = True,
-        visibility = [
-                "//executorch/...",
-                "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     # On Windows we can only compile these two ops currently, so adding a
@@ -87,10 +79,7 @@ def define_common_targets():
         runtime.cxx_library(
             name = "quantized_operators" + aten_suffix,
             srcs = [],
-            visibility = [
-                "//executorch/...",
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
             exported_deps = [
                 "//executorch/kernels/quantized/cpu:quantized_cpu" + aten_suffix,
             ],
@@ -110,10 +99,7 @@ def define_common_targets():
                 custom_ops_requires_aot_registration = False,
                 aten_mode = aten_mode,
                 support_exceptions = support_exceptions,
-                visibility = [
-                    "//executorch/...",
-                    "@EXECUTORCH_CLIENTS",
-                ],
+                visibility = ["PUBLIC"],
                 define_static_targets = True,
             )
 
@@ -131,10 +117,7 @@ def define_common_targets():
                     ":q_dq_ops",
                 ],
                 support_exceptions = support_exceptions,
-                visibility = [
-                    "//executorch/...",
-                    "@EXECUTORCH_CLIENTS",
-                ],
+                visibility = ["PUBLIC"],
             )
 
     runtime.python_library(
@@ -143,8 +126,5 @@ def define_common_targets():
         deps = [
             "//caffe2:torch",
         ],
-        visibility = [
-            "//executorch/kernels/quantized/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )

--- a/kernels/quantized/test/TARGETS
+++ b/kernels/quantized/test/TARGETS
@@ -25,10 +25,7 @@ runtime.cxx_library(
     srcs = [
         "quantized_ops_aot_register.cpp",
     ],
-    visibility = [
-        "//executorch/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         "//executorch/extension/aten_util:aten_bridge",
         "//executorch/kernels/quantized/cpu:op_dequantize",

--- a/kernels/test/custom_kernel_example/targets.bzl
+++ b/kernels/test/custom_kernel_example/targets.bzl
@@ -26,10 +26,7 @@ def define_common_targets():
     runtime.cxx_library(
         name = "my_operators",
         srcs = [],
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         exported_deps = all_op_targets,
     )
 

--- a/kernels/test/targets.bzl
+++ b/kernels/test/targets.bzl
@@ -24,10 +24,7 @@ def define_common_targets():
             exported_headers=[
                 "TestUtil.h",
             ],
-            visibility = [
-                "//executorch/kernels/...",
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
             preprocessor_flags = ["-DUSE_ATEN_LIB"] if aten_kernel else [],
             exported_deps = [
                 "//executorch/runtime/core:core",
@@ -53,10 +50,7 @@ def define_common_targets():
                 "ScalarOverflowTestMacros.h",
                 "UnaryUfuncRealHBBF16ToFloatHBF16Test.h",
             ],
-            visibility = [
-                "//executorch/kernels/...",
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
             preprocessor_flags = ["-DUSE_ATEN_LIB"] if aten_kernel else [],
             exported_deps = [
                 ":supported_features_header",
@@ -151,10 +145,7 @@ def define_common_targets():
     runtime.filegroup(
         name = "test_srcs",
         srcs = TEST_SRCS,
-        visibility = [
-            "//executorch/kernels/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     runtime.genrule(
@@ -163,10 +154,7 @@ def define_common_targets():
         cmd = "cp $(location :test_srcs)/* $OUT",
         outs = {f: [f] for f in TEST_SRCS},
         default_outs = ["."],
-        visibility = [
-            "//executorch/kernels/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     codegen_function_header_wrapper("executorch/kernels/aten", "aten")

--- a/shim_et/xplat/executorch/kernels/optimized/op_registration_util.bzl
+++ b/shim_et/xplat/executorch/kernels/optimized/op_registration_util.bzl
@@ -92,13 +92,7 @@ def define_op_library(name, compiler_flags, deps):
         srcs = [
             "{}.cpp".format(name),
         ],
-        visibility = [
-            "//executorch/kernels/portable/test/...",
-            "//executorch/kernels/quantized/test/...",
-            "//executorch/kernels/optimized/test/...",
-            "//executorch/kernels/test/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         compiler_flags = [
             # kernels often have helpers with no prototypes just disabling the warning here as the headers
             # are codegend and linked in later

--- a/shim_et/xplat/executorch/kernels/portable/op_registration_util.bzl
+++ b/shim_et/xplat/executorch/kernels/portable/op_registration_util.bzl
@@ -116,13 +116,7 @@ def define_op_library(name, deps, android_deps, aten_target, _allow_third_party_
         srcs = [
             "{}.cpp".format(name),
         ],
-        visibility = [
-            "//executorch/kernels/portable/test/...",
-            "//executorch/kernels/quantized/...",
-            "//executorch/kernels/optimized/test/...",
-            "//executorch/kernels/test/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         # kernels often have helpers with no prototypes just disabling the warning here as the headers
         # are codegend and linked in later
         compiler_flags = select({

--- a/shim_et/xplat/executorch/kernels/prim_ops/selective_build.bzl
+++ b/shim_et/xplat/executorch/kernels/prim_ops/selective_build.bzl
@@ -38,10 +38,7 @@ def prim_ops_registry_selective(name, selected_prim_ops_header_target, aten_suff
             "selective_build_prim_ops.h": ":" + genrule_dep_name + "[selective_build_prim_ops.h]",
             "selected_prim_ops.h": ":" + genrule_dep_name + "[selected_prim_ops.h]"
         },
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         # @lint-ignore BUCKLINT link_whole, need this to register prim ops.
         link_whole = True,
         # prim ops are registered through a global table so the ctor needs to be allowed


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #16480
* #16479
* #16478
* #16477
* __->__ #16476
* #16475
* #16474

Remove the EXECUTORCH_CLIENTS buck client list visibility gating from kernel
targets. This replaces all visibility blocks containing @EXECUTORCH_CLIENTS
with explicit PUBLIC visibility.

This is part 3 of a multi-diff stack to remove visibility gating across all of executorch.
This diff covers all kernels/*:
- kernels/aten
- kernels/fb/custom_ops
- kernels/optimized
- kernels/portable
- kernels/prim_ops
- kernels/quantized
- kernels/test

Differential Revision: [D89902027](https://our.internmc.facebook.com/intern/diff/D89902027/)