### PR TITLE
[executorch] Remove EXECUTORCH_CLIENTS visibility gating - XNNPACK & Vulkan Backends

### DIFF
--- a/backends/vulkan/partitioner/TARGETS
+++ b/backends/vulkan/partitioner/TARGETS
@@ -7,10 +7,7 @@ runtime.python_library(
     srcs = [
         "vulkan_partitioner.py",
     ],
-    visibility = [
-        "//executorch/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         "//executorch/backends/vulkan:op_registry",
         "//executorch/backends/vulkan:utils_lib",

--- a/backends/vulkan/serialization/targets.bzl
+++ b/backends/vulkan/serialization/targets.bzl
@@ -47,11 +47,7 @@ def define_common_targets(is_fbcode = False):
             resources = [
                 "schema.fbs",
             ],
-            visibility = [
-                "//executorch/...",
-                "//executorch/vulkan/...",
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
             deps = [
                 "//executorch/exir:graph_module",
                 "//executorch/exir/_serialize:_bindings",

--- a/backends/vulkan/targets.bzl
+++ b/backends/vulkan/targets.bzl
@@ -158,10 +158,7 @@ def define_common_targets(is_fbcode = False):
     runtime.python_binary(
         name = "gen_vulkan_spv_bin",
         main_module = "runtime.gen_vulkan_spv",
-        visibility = [
-            "//executorch/backends/vulkan/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         deps = [
             ":gen_vulkan_spv_lib",
         ],
@@ -241,10 +238,7 @@ def define_common_targets(is_fbcode = False):
             ]),
             labels = get_labels(no_volk),
             platforms = get_platforms(),
-            visibility = [
-                "//executorch/backends/vulkan/...",
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
             fbobjc_frameworks = select({
                 "DEFAULT": [],
                 "ovr_config//os:macos": [
@@ -270,12 +264,7 @@ def define_common_targets(is_fbcode = False):
             ]),
             labels = get_labels(no_volk),
             platforms = get_platforms(),
-            visibility = [
-                "//executorch/backends/...",
-                "//executorch/extension/pybindings/...",
-                "//executorch/test/...",
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
             exported_deps = [
                 ":vulkan_graph_runtime_shaderlib{}".format(suffix),
                 "//executorch/runtime/backend:interface",
@@ -309,12 +298,7 @@ def define_common_targets(is_fbcode = False):
             ]),
             labels = get_labels(no_volk),
             platforms = get_platforms(),
-            visibility = [
-                "//executorch/backends/...",
-                "//executorch/extension/pybindings/...",
-                "//executorch/test/...",
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
             deps = [
                 ":vulkan_graph_runtime{}".format(suffix),
                 "//executorch/backends/vulkan/serialization:vk_delegate_schema",
@@ -353,11 +337,7 @@ def define_common_targets(is_fbcode = False):
             srcs = [
                 "custom_ops_lib.py"
             ],
-            visibility = [
-                "//executorch/...",
-                "//executorch/vulkan/...",
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
             deps = [
                 "//caffe2:torch",
                 "//executorch/backends/vulkan/patterns:vulkan_patterns",
@@ -369,11 +349,7 @@ def define_common_targets(is_fbcode = False):
             srcs = [
                 "op_registry.py",
             ],
-            visibility = [
-                "//executorch/...",
-                "//executorch/vulkan/...",
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
             deps = [
                 ":custom_ops_lib",
                 ":utils_lib",
@@ -388,11 +364,7 @@ def define_common_targets(is_fbcode = False):
             srcs = [
                 "vulkan_preprocess.py",
             ],
-            visibility = [
-                "//executorch/...",
-                "//executorch/vulkan/...",
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
             deps = [
                 "//executorch/backends/transforms:addmm_mm_to_linear",
                 "//executorch/backends/transforms:fuse_batch_norm_with_conv",

--- a/backends/vulkan/test/custom_ops/targets.bzl
+++ b/backends/vulkan/test/custom_ops/targets.bzl
@@ -38,10 +38,7 @@ def define_common_targets(is_fbcode = False):
             "glsl/*.glsl",
             "glsl/*.yaml",
         ]),
-        visibility = [
-            "//executorch/backends/vulkan/test/custom_ops/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     vulkan_spv_shader_lib(
@@ -71,10 +68,7 @@ def define_common_targets(is_fbcode = False):
         deps = [
             "//executorch/backends/vulkan:vulkan_graph_runtime",
         ],
-        visibility = [
-            "//executorch/backends/vulkan/test/custom_ops/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     # Operator implementations library
@@ -88,10 +82,7 @@ def define_common_targets(is_fbcode = False):
             "//executorch/backends/vulkan:vulkan_graph_runtime",
             ":custom_ops_shaderlib",
         ],
-        visibility = [
-            "//executorch/backends/vulkan/test/custom_ops/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         link_whole = True,
     )
 

--- a/backends/vulkan/test/op_tests/targets.bzl
+++ b/backends/vulkan/test/op_tests/targets.bzl
@@ -158,10 +158,7 @@ def define_common_targets(is_fbcode = False):
             "//executorch/runtime/core/exec_aten:lib",
             runtime.external_dep_location("libtorch"),
         ],
-        visibility = [
-            "//executorch/backends/vulkan/test/op_tests/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     define_test_targets(

--- a/backends/xnnpack/TARGETS
+++ b/backends/xnnpack/TARGETS
@@ -10,10 +10,7 @@ runtime.python_library(
     srcs = [
         "xnnpack_preprocess.py",
     ],
-    visibility = [
-        "//executorch/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         "//executorch/backends/transforms:lib",
         "//executorch/backends/transforms:remove_getitem_op",
@@ -30,10 +27,7 @@ runtime.python_library(
     srcs = [
         "__init__.py",
     ],
-    visibility = [
-        "//executorch/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         ":xnnpack_preprocess",
         "//executorch/backends/xnnpack/partition:xnnpack_partitioner",

--- a/backends/xnnpack/operators/TARGETS
+++ b/backends/xnnpack/operators/TARGETS
@@ -5,10 +5,7 @@ oncall("executorch")
 runtime.python_library(
     name = "operators",
     srcs = glob(["*.py"]),
-    visibility = [
-        "//executorch/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         "//executorch/backends/xnnpack/utils:xnnpack_utils",
         "//executorch/exir:graph_module",

--- a/backends/xnnpack/partition/TARGETS
+++ b/backends/xnnpack/partition/TARGETS
@@ -7,10 +7,7 @@ runtime.python_library(
     srcs = [
         "xnnpack_partitioner.py",
     ],
-    visibility = [
-        "//executorch/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         ":partitioner_graphs",
         "//executorch/backends/xnnpack:xnnpack_preprocess",
@@ -28,10 +25,7 @@ runtime.python_library(
     srcs = glob([
         "graphs/*.py",
     ]),
-    visibility = [
-        "//executorch/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         "//executorch/exir:lib",
     ],

--- a/backends/xnnpack/partition/config/TARGETS
+++ b/backends/xnnpack/partition/config/TARGETS
@@ -7,10 +7,7 @@ runtime.python_library(
     srcs = glob([
         "*.py",
     ]),
-    visibility = [
-        "//executorch/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         "//executorch/exir:lib",
         "//executorch/exir/backend:partitioner",

--- a/backends/xnnpack/recipes/TARGETS
+++ b/backends/xnnpack/recipes/TARGETS
@@ -7,10 +7,7 @@ runtime.python_library(
     srcs = [
         "__init__.py",
     ],
-    visibility = [
-        "//executorch/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         "//executorch/export:recipe_registry",
         ":xnnpack_recipe_provider",
@@ -23,10 +20,7 @@ runtime.python_library(
     srcs = [
         "xnnpack_recipe_provider.py",
     ],
-    visibility = [
-        "//executorch/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         "//caffe2:torch",
         "//executorch/export:lib",
@@ -42,10 +36,7 @@ runtime.python_library(
     srcs = [
         "xnnpack_recipe_types.py",
     ],
-    visibility = [
-        "//executorch/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         "//executorch/export:recipe",
     ],

--- a/backends/xnnpack/serialization/TARGETS
+++ b/backends/xnnpack/serialization/TARGETS
@@ -10,10 +10,7 @@ runtime.python_library(
     srcs = [
         "xnnpack_graph_schema.py",
     ],
-    visibility = [
-        "//executorch/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
 )
 
 runtime.python_library(
@@ -24,10 +21,7 @@ runtime.python_library(
     resources = [
         "schema.fbs",
     ],
-    visibility = [
-        "//executorch/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         ":xnnpack_schema",
         "//executorch/exir/_serialize:lib",

--- a/backends/xnnpack/targets.bzl
+++ b/backends/xnnpack/targets.bzl
@@ -28,10 +28,7 @@ def define_common_targets():
             "//executorch/runtime/core/exec_aten:lib",
             "//executorch/runtime/backend:interface",
         ],
-        visibility = [
-            "//executorch/backends/xnnpack/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     for aten_mode in get_aten_mode_options():
@@ -43,13 +40,7 @@ def define_common_targets():
                 "runtime/*.h",
                 "runtime/profiling/*.h",
             ]),
-            visibility = [
-                "//executorch/exir/backend:backend_lib",
-                "//executorch/exir/backend/test/...",
-                "//executorch/backends/xnnpack/test/...",
-                "//executorch/extension/pybindings/...",
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
             preprocessor_flags = [
                 # Uncomment to enable per operator timings
                 # "-DENABLE_XNNPACK_PROFILING",
@@ -76,9 +67,7 @@ def define_common_targets():
     
     runtime.cxx_library(
         name = "xnnpack_interface",
-        visibility = [
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         exported_headers = [
             "runtime/XNNPACKBackend.h",
         ],

--- a/backends/xnnpack/test/tester/TARGETS
+++ b/backends/xnnpack/test/tester/TARGETS
@@ -9,10 +9,7 @@ runtime.python_library(
         "tester.py",
     ],
     base_module = "executorch.backends.xnnpack.test.tester",
-    visibility = [
-        "//executorch/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         "//caffe2:torch",
         "//executorch/backends/test/harness:tester",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #16480
* #16479
* #16478
* __->__ #16477
* #16476
* #16475
* #16474

Remove the EXECUTORCH_CLIENTS buck client list visibility gating from XNNPACK
and Vulkan backend targets. This replaces all visibility blocks containing
@EXECUTORCH_CLIENTS with explicit PUBLIC visibility.

This is part 4 of a multi-diff stack to remove visibility gating across all of executorch.
This diff covers:
- backends/xnnpack/*
- backends/vulkan/*

Differential Revision: [D89902028](https://our.internmc.facebook.com/intern/diff/D89902028/)

cc @SS-JIA @manuelcandales @digantdesai @cbilgin