### PR TITLE
[executorch] Remove EXECUTORCH_CLIENTS visibility gating - Other Backends

### DIFF
--- a/backends/aoti/targets.bzl
+++ b/backends/aoti/targets.bzl
@@ -49,7 +49,7 @@ def define_common_targets():
         supports_python_dlopen = True,
         # Constructor needed for backend registration.
         compiler_flags = ["-Wno-global-constructors"],
-        visibility = ["@EXECUTORCH_CLIENTS"],
+        visibility = ["PUBLIC"],
         deps = [
             "//executorch/runtime/core:core",
             "//executorch/runtime/core/exec_aten:lib",
@@ -67,7 +67,7 @@ def define_common_targets():
         supports_python_dlopen = True,
         # Constructor needed for backend registration.
         compiler_flags = ["-Wno-global-constructors"],
-        visibility = ["@EXECUTORCH_CLIENTS"],
+        visibility = ["PUBLIC"],
         deps = [
             "//executorch/runtime/backend:interface",
             "//executorch/runtime/core:core",
@@ -80,7 +80,7 @@ def define_common_targets():
         # @lint-ignore BUCKLINT: Avoid `link_whole=True` (https://fburl.com/avoid-link-whole)
         link_whole = True,
         supports_python_dlopen = True,
-        visibility = ["@EXECUTORCH_CLIENTS"],
+        visibility = ["PUBLIC"],
         exported_deps = [
             ":common_shims",
             ":delegate_handle",

--- a/backends/apple/coreml/TARGETS
+++ b/backends/apple/coreml/TARGETS
@@ -8,9 +8,7 @@ oncall("executorch")
 # TODO: this is a placeholder to support internal fbcode build. We should add the coreml backend target properly.
 runtime.python_library(
     name = "coreml",
-    visibility = [
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
 )
 
 runtime.python_library(
@@ -19,9 +17,7 @@ runtime.python_library(
         "compiler/*.py",
         "logging.py",
     ]),
-    visibility = [
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         "fbsource//third-party/pypi/coremltools:coremltools",
         ":executorchcoreml",
@@ -36,9 +32,7 @@ runtime.python_library(
         "partition/*.py",
         "logging.py",
     ]),
-    visibility = [
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         "fbsource//third-party/pypi/coremltools:coremltools",
         ":backend",
@@ -55,9 +49,7 @@ runtime.python_library(
     srcs = glob([
         "quantizer/*.py",
     ]),
-    visibility = [
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
 )
 
 runtime.python_library(
@@ -66,10 +58,7 @@ runtime.python_library(
         "recipes/__init__.py",
         "recipes/coreml_recipe_provider.py"
     ],
-    visibility = [
-        "@EXECUTORCH_CLIENTS",
-        "//executorch/export/...",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         "fbsource//third-party/pypi/coremltools:coremltools",
         ":coreml_recipe_types",
@@ -91,10 +80,7 @@ runtime.python_library(
     srcs = [
         "recipes/coreml_recipe_types.py",
     ],
-    visibility = [
-        "@EXECUTORCH_CLIENTS",
-        "//executorch/export/...",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         "//executorch/export:recipe",
     ],
@@ -124,10 +110,7 @@ runtime.cxx_python_extension(
     types = [
         "executorchcoreml.pyi",
     ],
-    visibility = [
-        "//executorch/examples/apple/coreml/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         "fbsource//third-party/nlohmann-json:nlohmann-json",
         "fbsource//third-party/pybind11:pybind11",

--- a/backends/apple/mps/TARGETS
+++ b/backends/apple/mps/TARGETS
@@ -19,9 +19,7 @@ runtime.python_library(
         "__init__.py",
         "mps_preprocess.py",
     ],
-    visibility = [
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         ":operators",
         ":serialization",
@@ -49,9 +47,7 @@ runtime.python_library(
     srcs = glob([
         "partition/*.py",
     ]),
-    visibility = [
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         ":backend",
         "//caffe2:torch",

--- a/backends/apple/mps/targets.bzl
+++ b/backends/apple/mps/targets.bzl
@@ -39,16 +39,7 @@ def define_common_targets(is_xplat = False, platforms = []):
             "runtime/operations/*.h",
         ]),
         "srcs": MPS_BACKEND_BUCK_SRCS,
-        "visibility": [
-            "//executorch/backends/apple/...",
-            "//executorch/examples/...",
-            "//executorch/exir/backend:backend_lib",
-            "//executorch/extension/pybindings/...",
-            "//executorch/runtime/backend/...",
-            "//executorch/devtools/runners/...",
-            "//executorch/test/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        "visibility": ["PUBLIC"],
         "link_whole": True,
     }
 

--- a/backends/arm/runtime/targets.bzl
+++ b/backends/arm/runtime/targets.bzl
@@ -5,7 +5,7 @@ def define_common_targets():
         name = "vela_bin_stream",
         srcs = ["VelaBinStream.cpp"],
         exported_headers = ["VelaBinStream.h"],
-        visibility = ["@EXECUTORCH_CLIENTS"],
+        visibility = ["PUBLIC"],
         deps = [
             "//executorch/runtime/core:core",
         ],
@@ -21,7 +21,7 @@ def define_common_targets():
         supports_python_dlopen = True,
         # Constructor needed for backend registration.
         compiler_flags = ["-Wno-global-constructors"],
-        visibility = ["@EXECUTORCH_CLIENTS"],
+        visibility = ["PUBLIC"],
         deps = [
             "//executorch/runtime/backend:interface",
             ":vela_bin_stream",

--- a/backends/cadence/fusion_g3/operators/targets.bzl
+++ b/backends/cadence/fusion_g3/operators/targets.bzl
@@ -23,10 +23,7 @@ def define_operator(name: str, deps: list[str] | None = None) -> None:
         name = op_name,
         srcs = [op_name + ".cpp"],
         platforms = CXX,
-        visibility = [
-            "//executorch/backends/cadence/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         compatible_with = ["ovr_config//cpu:xtensa"],
         deps = deps + common_deps,
     )

--- a/backends/cadence/generic/kernels/targets.bzl
+++ b/backends/cadence/generic/kernels/targets.bzl
@@ -8,9 +8,6 @@ def define_common_targets():
         exported_headers = [
             "kernels.h",
         ],
-        visibility = [
-            "//executorch/backends/cadence/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         platforms = CXX,
     )

--- a/backends/cadence/generic/operators/targets.bzl
+++ b/backends/cadence/generic/operators/targets.bzl
@@ -38,10 +38,7 @@ def define_common_targets():
             "//executorch/runtime/kernel:kernel_includes",
             "//executorch/backends/cadence/generic/kernels:cadence_kernels",
         ],
-        visibility = [
-            "//executorch/backends/cadence/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_library(
@@ -53,10 +50,7 @@ def define_common_targets():
             "//executorch/runtime/kernel:kernel_includes",
             "//executorch/backends/cadence/generic/kernels:cadence_kernels",
         ],
-        visibility = [
-            "//executorch/backends/cadence/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_library(
@@ -69,10 +63,7 @@ def define_common_targets():
             "//executorch/runtime/core/exec_aten:lib",
             "//executorch/runtime/kernel:kernel_runtime_context",
         ],
-        visibility = [
-            "//executorch/backends/cadence/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_library(
@@ -85,10 +76,7 @@ def define_common_targets():
             "//executorch/runtime/core/exec_aten:lib",
             "//executorch/runtime/kernel:kernel_runtime_context",
         ],
-        visibility = [
-            "//executorch/backends/cadence/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_library(
@@ -102,10 +90,7 @@ def define_common_targets():
             "//executorch/runtime/core/exec_aten/util:tensor_util",
             "//executorch/runtime/kernel:kernel_runtime_context",
         ],
-        visibility = [
-            "//executorch/backends/cadence/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_library(
@@ -118,10 +103,7 @@ def define_common_targets():
             "//executorch/runtime/core/exec_aten:lib",
             "//executorch/runtime/kernel:kernel_runtime_context",
         ],
-        visibility = [
-            "//executorch/backends/cadence/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_library(
@@ -135,10 +117,7 @@ def define_common_targets():
             "//executorch/runtime/kernel:kernel_includes",
             ":quantized_op_macros",
         ],
-        visibility = [
-            "//executorch/backends/cadence/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_library(
@@ -151,10 +130,7 @@ def define_common_targets():
             "//executorch/backends/cadence/generic/kernels:cadence_kernels",
             "//executorch/runtime/kernel:kernel_includes",
         ],
-        visibility = [
-            "//executorch/backends/cadence/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_library(
@@ -167,10 +143,7 @@ def define_common_targets():
             "//executorch/backends/cadence/generic/kernels:cadence_kernels",
             "//executorch/runtime/kernel:kernel_includes",
         ],
-        visibility = [
-            "//executorch/backends/cadence/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_library(
@@ -184,10 +157,7 @@ def define_common_targets():
             ":quantized_linear",
             ":quantized_op_macros",
         ],
-        visibility = [
-            "//executorch/backends/cadence/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_library(
@@ -200,10 +170,7 @@ def define_common_targets():
             "//executorch/runtime/kernel:kernel_includes",
             ":quantized_op_macros",
         ],
-        visibility = [
-            "//executorch/backends/cadence/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_library(
@@ -217,10 +184,7 @@ def define_common_targets():
             ":quantized_op_macros",
             ":quantized_linear",
         ],
-        visibility = [
-            "//executorch/backends/cadence/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_library(
@@ -233,10 +197,7 @@ def define_common_targets():
             "//executorch/runtime/kernel:kernel_includes",
             ":quantized_op_macros",
         ],
-        visibility = [
-            "//executorch/backends/cadence/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_library(
@@ -249,10 +210,7 @@ def define_common_targets():
             "//executorch/runtime/kernel:kernel_includes",
             ":quantized_op_macros",
         ],
-        visibility = [
-            "//executorch/backends/cadence/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_library(
@@ -266,10 +224,7 @@ def define_common_targets():
             "//executorch/kernels/portable/cpu:scalar_utils",
             ":quantized_op_macros",
         ],
-        visibility = [
-            "//executorch/backends/cadence/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_library(
@@ -284,10 +239,7 @@ def define_common_targets():
             "//executorch/runtime/kernel:kernel_includes",
             ":quantized_op_macros",
         ],
-        visibility = [
-            "//executorch/backends/cadence/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_library(
@@ -299,10 +251,7 @@ def define_common_targets():
             "//executorch/runtime/kernel:kernel_includes",
             ":quantized_op_macros",
         ],
-        visibility = [
-            "//executorch/backends/cadence/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_library(
@@ -315,10 +264,7 @@ def define_common_targets():
             "//executorch/runtime/kernel:kernel_includes",
             ":quantized_op_macros",
         ],
-        visibility = [
-            "//executorch/backends/cadence/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
 
@@ -334,10 +280,7 @@ def define_common_targets():
             "//executorch/runtime/core/exec_aten:lib",
             "//executorch/runtime/kernel:kernel_runtime_context",
         ],
-        visibility = [
-            "//executorch/backends/cadence/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_library(
@@ -348,10 +291,7 @@ def define_common_targets():
         deps = [
             "//executorch/runtime/kernel:kernel_includes",
         ],
-        visibility = [
-            "//executorch/backends/cadence/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_library(
@@ -362,10 +302,7 @@ def define_common_targets():
         deps = [
             "//executorch/runtime/kernel:kernel_includes",
         ],
-        visibility = [
-            "//executorch/backends/cadence/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_library(
@@ -376,10 +313,7 @@ def define_common_targets():
         deps = [
             "//executorch/runtime/kernel:kernel_includes",
         ],
-        visibility = [
-            "//executorch/backends/cadence/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_library(
@@ -392,10 +326,7 @@ def define_common_targets():
             "//executorch/runtime/core/exec_aten:lib",
             "//executorch/runtime/kernel:kernel_runtime_context",
         ],
-        visibility = [
-            "//executorch/backends/cadence/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_library(
@@ -406,10 +337,7 @@ def define_common_targets():
         deps = [
             "//executorch/runtime/kernel:kernel_includes",
         ],
-        visibility = [
-            "//executorch/backends/cadence/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_library(
@@ -422,10 +350,7 @@ def define_common_targets():
             "//executorch/runtime/core/exec_aten:lib",
             "//executorch/runtime/kernel:kernel_runtime_context",
         ],
-        visibility = [
-            "//executorch/backends/cadence/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_library(
@@ -438,10 +363,7 @@ def define_common_targets():
             "//executorch/runtime/core/exec_aten:lib",
             "//executorch/runtime/kernel:kernel_runtime_context",
         ],
-        visibility = [
-            "//executorch/backends/cadence/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_library(
@@ -457,10 +379,7 @@ def define_common_targets():
         exported_deps = [
             "//executorch/runtime/kernel:kernel_includes",
         ],
-        visibility = [
-            "//executorch/backends/cadence/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_library(
@@ -476,10 +395,7 @@ def define_common_targets():
         exported_deps = [
             "//executorch/runtime/kernel:kernel_includes",
         ],
-        visibility = [
-            "//executorch/backends/cadence/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_library(
@@ -493,8 +409,5 @@ def define_common_targets():
         exported_deps = [
             "//executorch/runtime/kernel:kernel_includes",
         ],
-        visibility = [
-            "//executorch/backends/cadence/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )

--- a/backends/cadence/hifi/kernels/targets.bzl
+++ b/backends/cadence/hifi/kernels/targets.bzl
@@ -14,10 +14,7 @@ def define_common_targets():
         ],
         deps = common_deps,
         compatible_with = ["ovr_config//cpu:xtensa"],
-        visibility = [
-            "//executorch/backends/cadence/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         exported_deps = [
             "fbsource//third-party/nnlib-hifi4/xa_nnlib:libxa_nnlib_common",
         ],

--- a/backends/cadence/hifi/operators/targets.bzl
+++ b/backends/cadence/hifi/operators/targets.bzl
@@ -28,10 +28,7 @@ def define_operator(name: str, deps: list[str] | None = None, exported_headers: 
         name = op_name,
         srcs = [op_name + ".cpp"],
         platforms = CXX,
-        visibility = [
-            "//executorch/backends/cadence/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         compatible_with = ["ovr_config//cpu:xtensa"],
         deps = deps + common_deps,
         exported_headers = exported_headers,

--- a/backends/cadence/hifi/third-party/nnlib/targets.bzl
+++ b/backends/cadence/hifi/third-party/nnlib/targets.bzl
@@ -8,10 +8,7 @@ def define_common_targets():
         name = "nnlib-extensions",
         srcs = native.glob(["*.c", "*.cpp"]),
         exported_headers = glob(["*.h"]),
-        visibility = [
-            "//executorch/backends/cadence/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         compatible_with = ["ovr_config//cpu:xtensa"],
         compiler_flags = [
             "-Wno-pointer-sign",

--- a/backends/cadence/runtime/targets.bzl
+++ b/backends/cadence/runtime/targets.bzl
@@ -5,10 +5,7 @@ def define_common_targets():
         name = "et_pal",
         srcs = ["et_pal.cpp"],
         link_whole = True,
-        visibility = [
-            "//executorch/backends/cadence/...",
-            "@EXECUTORCH_CLIENTS"
-        ],
+        visibility = ["PUBLIC"],
         exported_deps = [
             "//executorch/runtime/platform:platform",
         ],
@@ -17,10 +14,7 @@ def define_common_targets():
     runtime.python_library(
         name = "etdump",
         srcs = ["etdump.py"],
-        visibility = [
-            "//executorch/backends/cadence/...",
-            "@EXECUTORCH_CLIENTS"
-        ],
+        visibility = ["PUBLIC"],
         deps = [
             "fbcode//executorch/devtools:lib",
             "fbcode//executorch/devtools/inspector:inspector_utils",

--- a/backends/cadence/vision/kernels/targets.bzl
+++ b/backends/cadence/vision/kernels/targets.bzl
@@ -8,10 +8,7 @@ def define_common_targets():
         exported_headers = [
             "kernels.h",
         ],
-        visibility = [
-            "//executorch/backends/cadence/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         platforms = CXX,
         compatible_with = select({
             "DEFAULT": [],

--- a/backends/cadence/vision/operators/targets.bzl
+++ b/backends/cadence/vision/operators/targets.bzl
@@ -44,10 +44,7 @@ def define_operator(name: str, deps: list[str] | None = None) -> None:
         name = op_name,
         srcs = [op_name + ".cpp"],
         platforms = CXX,
-        visibility = [
-            "//executorch/backends/cadence/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         compatible_with = ["ovr_config//cpu:xtensa"],
         deps = deps + common_deps,
         exported_headers = exported_headers,

--- a/backends/cadence/vision/third-party/targets.bzl
+++ b/backends/cadence/vision/third-party/targets.bzl
@@ -17,10 +17,7 @@ def define_common_targets():
             "include_private/*.h"
         ]),
         header_namespace = "",
-        visibility = [
-            "//executorch/backends/cadence/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         platforms = CXX,
         compatible_with = select({
             "DEFAULT": [],

--- a/backends/cortex_m/ops/targets.bzl
+++ b/backends/cortex_m/ops/targets.bzl
@@ -41,10 +41,7 @@ def define_common_targets():
     runtime.cxx_library(
         name = "cortex_m_operators",
         srcs = [],
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         platforms = CXX,
         exported_deps = all_op_targets,
     )

--- a/backends/cuda/runtime/TARGETS
+++ b/backends/cuda/runtime/TARGETS
@@ -14,7 +14,7 @@ runtime.cxx_library(
     # @lint-ignore BUCKLINT: Avoid `link_whole=True` (https://fburl.com/avoid-link-whole)
     link_whole = True,
     supports_python_dlopen = True,
-    visibility = ["@EXECUTORCH_CLIENTS"],
+    visibility = ["PUBLIC"],
     deps = [
         "//executorch/runtime/core:core",
     ],
@@ -38,7 +38,7 @@ runtime.cxx_library(
     # @lint-ignore BUCKLINT: Avoid `link_whole=True` (https://fburl.com/avoid-link-whole)
     link_whole = True,
     supports_python_dlopen = True,
-    visibility = ["@EXECUTORCH_CLIENTS"],
+    visibility = ["PUBLIC"],
     deps = [
         "//executorch/runtime/core:core",
         "//executorch/runtime/core/exec_aten:lib",
@@ -69,7 +69,7 @@ runtime.cxx_library(
     supports_python_dlopen = True,
     # Constructor needed for backend registration.
     compiler_flags = ["-Wno-global-constructors"],
-    visibility = ["@EXECUTORCH_CLIENTS"],
+    visibility = ["PUBLIC"],
     deps = [
         ":tensor_maker",
         "//executorch/backends/aoti:common_shims",
@@ -97,7 +97,7 @@ runtime.cxx_library(
     supports_python_dlopen = True,
     # Constructor needed for backend registration.
     compiler_flags = ["-Wno-global-constructors"],
-    visibility = ["@EXECUTORCH_CLIENTS"],
+    visibility = ["PUBLIC"],
     deps = [
         ":runtime_shims",
         "//executorch/backends/aoti:aoti_common",

--- a/backends/nxp/runtime/targets.bzl
+++ b/backends/nxp/runtime/targets.bzl
@@ -13,11 +13,7 @@ def define_common_targets():
         # Constructor needed for backend registration.
         compiler_flags = ["-Wno-global-constructors", "-fno-rtti", "-DNO_HEAP_USAGE"],
         labels = [ci.skip_target()],
-        visibility = [
-            "//executorch/backends/nxp/runtime/fb:nxp_fb_backend",
-            "//executorch/backends/nxp/runtime/fb:nxp_hifi_fb_backend",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         deps = [
             "//executorch/runtime/backend:interface",
             "//executorch/runtime/core:core",

--- a/backends/qualcomm/TARGETS
+++ b/backends/qualcomm/TARGETS
@@ -8,10 +8,7 @@ define_common_targets()
 runtime.python_library(
     name = "preprocess",
     srcs = ["qnn_preprocess.py"],
-    visibility = [
-        "//executorch/backends/qualcomm/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         "//executorch/backends/qualcomm/_passes:passes",
     ],

--- a/backends/qualcomm/_passes/TARGETS
+++ b/backends/qualcomm/_passes/TARGETS
@@ -7,9 +7,7 @@ runtime.python_library(
     srcs = glob([
         "*.py",
     ]),
-    visibility = [
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         "//executorch/backends/transforms:addmm_mm_to_linear",
         "//executorch/backends/transforms:decompose_sdpa",

--- a/backends/qualcomm/aot/python/targets.bzl
+++ b/backends/qualcomm/aot/python/targets.bzl
@@ -55,7 +55,7 @@ def define_common_targets():
             "*.h",
         ]),
         platforms = (CXX),
-        visibility = ["@EXECUTORCH_CLIENTS"],
+        visibility = ["PUBLIC"],
         deps = [
             "//executorch/backends/qualcomm/aot/wrappers:wrappers",
             "//executorch/backends/qualcomm/runtime:logging",

--- a/backends/qualcomm/aot/wrappers/targets.bzl
+++ b/backends/qualcomm/aot/wrappers/targets.bzl
@@ -21,7 +21,7 @@ def define_common_targets():
         ]),
         define_static_target = True,
         platforms = [ANDROID],
-        visibility = ["@EXECUTORCH_CLIENTS"],
+        visibility = ["PUBLIC"],
         deps = [
             "fbsource//third-party/qualcomm/qnn/qnn-{0}:api".format(get_qnn_library_version()),
             "fbsource//third-party/qualcomm/qnn/qnn-{0}:app_sources".format(get_qnn_library_version()),

--- a/backends/qualcomm/builders/targets.bzl
+++ b/backends/qualcomm/builders/targets.bzl
@@ -11,9 +11,7 @@ def define_common_targets():
         srcs = glob([
             "*.py",
         ]),
-        visibility = [
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         deps = [
             "//executorch/exir/backend:backend_details",
             "//executorch/exir/backend:compile_spec_schema",

--- a/backends/qualcomm/partition/targets.bzl
+++ b/backends/qualcomm/partition/targets.bzl
@@ -11,9 +11,7 @@ def define_common_targets():
         srcs = glob([
             "*.py",
         ]),
-        visibility = [
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         deps = [
             "//executorch/exir/backend:backend_details",
             "//executorch/exir/backend:compile_spec_schema",

--- a/backends/qualcomm/quantizer/targets.bzl
+++ b/backends/qualcomm/quantizer/targets.bzl
@@ -12,9 +12,7 @@ def define_common_targets():
             "*.py",
             "*/*.py",
         ]),
-        visibility = [
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         deps = [
             "//executorch/backends/transforms:decompose_sdpa",
         ],

--- a/backends/qualcomm/recipes/TARGETS
+++ b/backends/qualcomm/recipes/TARGETS
@@ -7,10 +7,7 @@ runtime.python_library(
     srcs = [
         "__init__.py",
     ],
-    visibility = [
-        "//executorch/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         "//executorch/export:recipe_registry",
         ":qnn_recipe_provider",
@@ -23,10 +20,7 @@ runtime.python_library(
     srcs = [
         "qnn_recipe_provider.py",
     ],
-    visibility = [
-        "//executorch/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         "//caffe2:torch",
         "//executorch/export:lib",
@@ -44,10 +38,7 @@ runtime.python_library(
     srcs = [
         "qnn_recipe_types.py",
     ],
-    visibility = [
-        "//executorch/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         "//executorch/export:lib",
     ],

--- a/backends/qualcomm/runtime/targets.bzl
+++ b/backends/qualcomm/runtime/targets.bzl
@@ -22,7 +22,7 @@ def define_common_targets():
         ],
         define_static_target = True,
         platforms = [ANDROID],
-        visibility = ["@EXECUTORCH_CLIENTS"],
+        visibility = ["PUBLIC"],
         deps = [
             "fbsource//third-party/qualcomm/qnn/qnn-{0}:api".format(get_qnn_library_version()),
             "fbsource//third-party/qualcomm/qnn/qnn-{0}:app_sources".format(get_qnn_library_version()),
@@ -66,7 +66,7 @@ def define_common_targets():
             define_static_target = True,
             link_whole = True,  # needed for executorch/examples/models/llama:main to register QnnBackend
             platforms = [ANDROID],
-            visibility = ["@EXECUTORCH_CLIENTS"],
+            visibility = ["PUBLIC"],
             resources = ({
                 "qnn_lib": "fbsource//third-party/qualcomm/qnn/qnn-{0}:qnn_offline_compile_libs".format(get_qnn_library_version()),
                 } if include_aot_qnn_lib else {

--- a/backends/qualcomm/serialization/targets.bzl
+++ b/backends/qualcomm/serialization/targets.bzl
@@ -21,9 +21,7 @@ def define_common_targets():
         resources = {
             ":qc_compiler_spec_schema": "qc_compiler_spec.fbs",
         },
-        visibility = [
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         deps = [
             "//executorch/exir/backend:backend_details",
             "//executorch/exir/backend:compile_spec_schema",

--- a/backends/qualcomm/targets.bzl
+++ b/backends/qualcomm/targets.bzl
@@ -82,7 +82,7 @@ def define_common_targets():
         srcs = [],
         headers = [],
         define_static_target = True,
-        visibility = ["@EXECUTORCH_CLIENTS"],
+        visibility = ["PUBLIC"],
         deps = [
             "fbsource//third-party/qualcomm/qnn/qnn-{0}:api".format(get_qnn_library_version()),
             "//executorch/runtime/backend:interface",

--- a/backends/qualcomm/utils/targets.bzl
+++ b/backends/qualcomm/utils/targets.bzl
@@ -11,9 +11,7 @@ def define_common_targets():
         srcs = glob([
             "*.py",
         ]),
-        visibility = [
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         deps = [
             "//executorch/exir/backend:backend_details",
             "//executorch/exir/backend:compile_spec_schema",

--- a/backends/test/harness/TARGETS
+++ b/backends/test/harness/TARGETS
@@ -5,10 +5,7 @@ oncall("executorch")
 runtime.python_library(
     name = "tester",
     srcs = native.glob(["*.py", "stages/*.py"]),
-    visibility = [
-        "//executorch/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         "//executorch/exir:graph_module",
     ],

--- a/backends/transforms/targets.bzl
+++ b/backends/transforms/targets.bzl
@@ -36,10 +36,7 @@ def define_common_targets():
     runtime.python_library(
         name = "decompose_sdpa",
         srcs = ["decompose_sdpa.py"],
-        visibility = [
-            "//executorch/backends/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         deps = [
             "//caffe2:torch",
             "//executorch/exir:pass_base",
@@ -107,10 +104,7 @@ def define_common_targets():
     runtime.python_library(
         name = "remove_clone_ops",
         srcs = ["remove_clone_ops.py"],
-        visibility = [
-            "//executorch/backends/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         deps = [
             "//caffe2:torch",
             "//executorch/exir:pass_base",
@@ -164,12 +158,7 @@ def define_common_targets():
     runtime.python_library(
         name = "duplicate_dynamic_quant_chain",
         srcs = ["duplicate_dynamic_quant_chain.py"],
-        visibility = [
-            "//executorch/backends/...",
-            "//executorch/examples/...",
-            "//executorch/extension/llm/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         deps = [
             "//caffe2:torch",
         ],
@@ -180,10 +169,7 @@ def define_common_targets():
         srcs = [
             "convert_dtype_pass.py",
         ],
-        visibility = [
-            "//executorch/backends/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         deps = [
             "//caffe2:torch",
             "//executorch/exir:pass_base",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #16480
* #16479
* __->__ #16478
* #16477
* #16476
* #16475
* #16474

Remove the EXECUTORCH_CLIENTS buck client list visibility gating from additional
backend targets. This replaces all visibility blocks containing @EXECUTORCH_CLIENTS
with explicit PUBLIC visibility.

This is part 5 of a multi-diff stack to remove visibility gating across all of executorch.
This diff covers:
- backends/aoti
- backends/apple (coreml, mps)
- backends/arm
- backends/cadence
- backends/cortex_m
- backends/cuda
- backends/nxp
- backends/qualcomm
- backends/test
- backends/transforms

Differential Revision: [D89902029](https://our.internmc.facebook.com/intern/diff/D89902029/)