### PR TITLE
[executorch] Remove EXECUTORCH_CLIENTS visibility gating - Extensions

### DIFF
--- a/extension/android/jni/BUCK
+++ b/extension/android/jni/BUCK
@@ -131,7 +131,7 @@ non_fbcode_target(_kind = runtime.cxx_library,
     deps = [
         "//executorch/runtime/core:core",
     ],
-    visibility = ["@EXECUTORCH_CLIENTS"],
+    visibility = ["PUBLIC"],
 )
 
 runtime.export_file(

--- a/extension/aten_util/targets.bzl
+++ b/extension/aten_util/targets.bzl
@@ -21,10 +21,7 @@ def define_common_targets():
             "-Wno-global-constructors",
             "-Wno-unused-function",
         ],
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         exported_deps = [
             "//executorch/extension/kernel_util:kernel_util",
             "//executorch/extension/tensor:tensor",

--- a/extension/data_loader/targets.bzl
+++ b/extension/data_loader/targets.bzl
@@ -11,14 +11,7 @@ def define_common_targets():
         name = "buffer_data_loader",
         srcs = [],
         exported_headers = ["buffer_data_loader.h"],
-        visibility = [
-            "//executorch/exir/backend/test/...",
-            "//executorch/runtime/executor/test/...",
-            "//executorch/extension/pybindings/...",
-            "//executorch/test/...",
-            "//executorch/extension/data_loader/test/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         exported_deps = [
             "//executorch/runtime/core:core",
         ],
@@ -28,10 +21,7 @@ def define_common_targets():
         name = "shared_ptr_data_loader",
         srcs = [],
         exported_headers = ["shared_ptr_data_loader.h"],
-        visibility = [
-            "@EXECUTORCH_CLIENTS",
-            "//executorch/extension/data_loader/test/...",
-        ],
+        visibility = ["PUBLIC"],
         exported_deps = [
             "//executorch/runtime/core:core",
         ],
@@ -41,12 +31,7 @@ def define_common_targets():
         name = "file_data_loader",
         srcs = ["file_data_loader.cpp"],
         exported_headers = ["file_data_loader.h"],
-        visibility = [
-            "//executorch/test/...",
-            "//executorch/runtime/executor/test/...",
-            "//executorch/extension/data_loader/test/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         exported_deps = [
             "//executorch/runtime/core:core",
         ],
@@ -56,12 +41,7 @@ def define_common_targets():
         name = "file_descriptor_data_loader",
         srcs = ["file_descriptor_data_loader.cpp"],
         exported_headers = ["file_descriptor_data_loader.h"],
-        visibility = [
-            "//executorch/test/...",
-            "//executorch/runtime/executor/test/...",
-            "//executorch/extension/data_loader/test/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         exported_deps = [
             "//executorch/runtime/core:core",
         ],
@@ -83,13 +63,7 @@ def define_common_targets():
             "mman.h",
             "mmap_data_loader.h"
         ],
-        visibility = [
-            "//executorch/test/...",
-            "//executorch/extension/pybindings/...",
-            "//executorch/runtime/executor/test/...",
-            "//executorch/extension/data_loader/test/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         exported_deps = [
             "//executorch/runtime/core:core",
         ],

--- a/extension/evalue_util/targets.bzl
+++ b/extension/evalue_util/targets.bzl
@@ -14,7 +14,7 @@ def define_common_targets():
             name = "print_evalue" + aten_suffix,
             srcs = ["print_evalue.cpp"],
             exported_headers = ["print_evalue.h"],
-            visibility = ["@EXECUTORCH_CLIENTS"],
+            visibility = ["PUBLIC"],
             exported_deps = [
                 "//executorch/runtime/core:evalue" + aten_suffix,
             ],

--- a/extension/export_util/TARGETS
+++ b/extension/export_util/TARGETS
@@ -8,12 +8,7 @@ runtime.python_library(
         "utils.py",
     ],
     _is_external_target = True,
-    visibility = [
-        "//bento/...",
-        "//bento_kernels/...",
-        "//executorch/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         "//caffe2:torch",
         "//executorch/exir:lib",

--- a/extension/flat_tensor/serialize/TARGETS
+++ b/extension/flat_tensor/serialize/TARGETS
@@ -27,10 +27,7 @@ runtime.python_library(
         "flat_tensor.fbs",
         "scalar_type.fbs",
     ],
-    visibility = [
-        "//executorch/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         ":schema",
         "//executorch/exir/_serialize:lib",

--- a/extension/flat_tensor/serialize/targets.bzl
+++ b/extension/flat_tensor/serialize/targets.bzl
@@ -54,9 +54,6 @@ def define_common_targets():
             "//executorch/runtime/core/exec_aten:lib",
         ],
         exported_headers = ["serialize.h"],
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         exported_external_deps = ["flatbuffers-api"],
     )

--- a/extension/flat_tensor/targets.bzl
+++ b/extension/flat_tensor/targets.bzl
@@ -20,7 +20,5 @@ def define_common_targets():
                 "//executorch/extension/flat_tensor/serialize:flat_tensor_header",
                 "//executorch/extension/flat_tensor/serialize:generated_headers",
             ],
-            visibility = [
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
         )

--- a/extension/kernel_util/targets.bzl
+++ b/extension/kernel_util/targets.bzl
@@ -15,10 +15,7 @@ def define_common_targets():
             "meta_programming.h",
             "type_list.h",
         ],
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         exported_deps = [
             "//executorch/runtime/core:core",
             "//executorch/runtime/core:evalue",

--- a/extension/llm/custom_ops/spinquant/targets.bzl
+++ b/extension/llm/custom_ops/spinquant/targets.bzl
@@ -18,5 +18,5 @@ def define_common_targets():
         exported_deps = [
             "//executorch/extension/llm/custom_ops/spinquant/third-party/FFHT:fht",
         ],
-        visibility = ["@EXECUTORCH_CLIENTS"],
+        visibility = ["PUBLIC"],
     )

--- a/extension/llm/custom_ops/spinquant/third-party/FFHT/targets.bzl
+++ b/extension/llm/custom_ops/spinquant/third-party/FFHT/targets.bzl
@@ -10,7 +10,7 @@ def define_common_targets():
         name = "dumb_fht",
         srcs = ["dumb_fht.c"],
         exported_headers = ["dumb_fht.h"],
-        visibility = ["@EXECUTORCH_CLIENTS"],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_library(
@@ -21,7 +21,7 @@ def define_common_targets():
             "ovr_config//cpu:x86_64": ["fht_avx.c"],
         }),
         exported_headers = ["fht.h"],
-        visibility = ["@EXECUTORCH_CLIENTS"],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_binary(

--- a/extension/llm/custom_ops/targets.bzl
+++ b/extension/llm/custom_ops/targets.bzl
@@ -60,11 +60,7 @@ def define_common_targets():
                 "DEFAULT": [],
                 "ovr_config//cpu:arm64": ["-march=armv8.2-a+dotprod"],
             }),
-            visibility = [
-                "//executorch/...",
-                "//executorch/extension/llm/custom_ops/...",
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
             # @lint-ignore BUCKLINT link_whole
             link_whole = True,
             force_static = True,
@@ -80,10 +76,7 @@ def define_common_targets():
             ],
             headers = ["op_tile_crop.h"],
             compiler_flags = ["-Wno-global-constructors"],
-            visibility = [
-                "//executorch/...",
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
             external_deps = [
                 "libtorch",
             ],
@@ -98,10 +91,7 @@ def define_common_targets():
         srcs = [
             "custom_ops.py",
         ],
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         deps = [
             "//caffe2:torch",
         ],
@@ -141,10 +131,7 @@ def define_common_targets():
         srcs = [
             "preprocess_custom_ops.py",
         ],
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         deps = [
             "//caffe2:torch",
         ],
@@ -155,10 +142,7 @@ def define_common_targets():
         srcs = [
             "model_sharding.py",
         ],
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         deps = [
             "//caffe2:torch",
         ],
@@ -173,10 +157,7 @@ def define_common_targets():
             "//executorch/extension/kernel_util:kernel_util",
         ],
         compiler_flags = ["-Wno-missing-prototypes", "-Wno-global-constructors"],
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         # @lint-ignore BUCKLINT link_whole
         link_whole = True,
         force_static = True,

--- a/extension/llm/export/config/targets.bzl
+++ b/extension/llm/export/config/targets.bzl
@@ -8,8 +8,5 @@ def define_common_targets():
         ],
         _is_external_target = True,
         base_module = "executorch.extension.llm.export.config",
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )

--- a/extension/llm/runner/io_manager/targets.bzl
+++ b/extension/llm/runner/io_manager/targets.bzl
@@ -15,7 +15,5 @@ def define_common_targets():
                 "//executorch/extension/tensor:tensor" + aten_suffix,
                 "//executorch/extension/module:module" + aten_suffix,
             ],
-            visibility = [
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
         )

--- a/extension/llm/runner/targets.bzl
+++ b/extension/llm/runner/targets.bzl
@@ -6,9 +6,7 @@ def define_common_targets():
         exported_headers = [
             "irunner.h",
         ],
-        visibility = [
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_library(
@@ -16,9 +14,7 @@ def define_common_targets():
         exported_headers = [
             "constants.h",
         ],
-        visibility = [
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     for aten in get_aten_mode_options():
@@ -30,9 +26,7 @@ def define_common_targets():
                 "stats.h",
                 "util.h",
             ],
-            visibility = [
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
             exported_deps = [
                 ":constants",
                  "//executorch/extension/module:module" + aten_suffix,
@@ -44,9 +38,7 @@ def define_common_targets():
             name = "text_decoder_runner" + aten_suffix,
             exported_headers = ["text_decoder_runner.h"],
             srcs = ["text_decoder_runner.cpp"],
-            visibility = [
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
             exported_deps = [
                 ":stats" + aten_suffix,
                 "//executorch/kernels/portable/cpu/util:arange_util" + aten_suffix,
@@ -61,9 +53,7 @@ def define_common_targets():
             name = "text_prefiller" + aten_suffix,
             exported_headers = ["text_prefiller.h"],
             srcs = ["text_prefiller.cpp"],
-            visibility = [
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
             exported_deps = [
                 ":text_decoder_runner" + aten_suffix,
                 "//pytorch/tokenizers:headers",
@@ -75,9 +65,7 @@ def define_common_targets():
         runtime.cxx_library(
             name = "text_token_generator" + aten_suffix,
             exported_headers = ["text_token_generator.h"],
-            visibility = [
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
             exported_deps = [
                 ":text_decoder_runner" + aten_suffix,
                 "//pytorch/tokenizers:headers",
@@ -89,9 +77,7 @@ def define_common_targets():
         runtime.cxx_library(
             name = "image_prefiller" + aten_suffix,
             exported_headers = ["image_prefiller.h", "image.h"],
-            visibility = [
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
             exported_deps = [
                 ":constants",
                 "//executorch/extension/module:module" + aten_suffix,
@@ -134,9 +120,7 @@ def define_common_targets():
                 "llm_runner_helper.cpp",
                 "multimodal_runner.cpp",
             ],
-            visibility = [
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
             compiler_flags = [
                 "-Wno-missing-prototypes",
             ],

--- a/extension/llm/sampler/targets.bzl
+++ b/extension/llm/sampler/targets.bzl
@@ -16,9 +16,7 @@ def define_common_targets():
             srcs = [
                 "sampler.cpp",
             ],
-            visibility = [
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
             external_deps = [
                 "libtorch",
             ] if aten else [],

--- a/extension/memory_allocator/targets.bzl
+++ b/extension/memory_allocator/targets.bzl
@@ -16,10 +16,7 @@ def define_common_targets():
         exported_deps = [
             "//executorch/runtime/core:memory_allocator",
         ],
-        visibility = [
-            "//executorch/extension/memory_allocator/test/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_library(
@@ -34,8 +31,5 @@ def define_common_targets():
         exported_deps = [
             "//executorch/runtime/core:memory_allocator",
         ],
-        visibility = [
-            "//executorch/extension/memory_allocator/test/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )

--- a/extension/module/targets.bzl
+++ b/extension/module/targets.bzl
@@ -18,9 +18,7 @@ def define_common_targets():
             exported_headers = [
                 "module.h",
             ],
-            visibility = [
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
             deps = [
                 "//executorch/extension/memory_allocator:malloc_memory_allocator",
                 "//executorch/extension/data_loader:file_data_loader",
@@ -41,9 +39,7 @@ def define_common_targets():
             exported_headers = [
                 "bundled_module.h",
             ],
-            visibility = [
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
             deps = [
                 "//executorch/extension/data_loader:buffer_data_loader",
                 "//executorch/extension/data_loader:file_data_loader",

--- a/extension/named_data_map/targets.bzl
+++ b/extension/named_data_map/targets.bzl
@@ -11,9 +11,7 @@ def define_common_targets():
             exported_headers = [
                 "merged_data_map.h",
             ],
-            visibility = [
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
             deps = [
                 "//executorch/runtime/core:named_data_map" + aten_suffix,
                 "//executorch/runtime/core:core",

--- a/extension/parallel/targets.bzl
+++ b/extension/parallel/targets.bzl
@@ -12,10 +12,7 @@ def define_common_targets():
         exported_headers = [
             "thread_parallel.h",
         ],
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         deps = [
             "//executorch/extension/threadpool:threadpool",
         ],

--- a/extension/pybindings/TARGETS
+++ b/extension/pybindings/TARGETS
@@ -65,11 +65,7 @@ executorch_pybindings(
 runtime.python_library(
     name = "portable_lib",
     srcs = ["portable_lib.py"],
-    visibility = [
-        "//executorch/exir/...",
-        "//executorch/runtime/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         ":_portable_lib",
         "//executorch/exir:_warnings",

--- a/extension/pytree/aten_util/targets.bzl
+++ b/extension/pytree/aten_util/targets.bzl
@@ -11,10 +11,7 @@ def define_common_targets():
         name = "ivalue_util",
         srcs = ["ivalue_util.cpp"],
         exported_headers = ["ivalue_util.h"],
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         exported_deps = [
             "//executorch/extension/pytree:pytree",
             "//executorch/runtime/platform:platform",

--- a/extension/pytree/targets.bzl
+++ b/extension/pytree/targets.bzl
@@ -14,8 +14,5 @@ def define_common_targets():
         exported_deps = [
             "//executorch/runtime/core:core",
         ],
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )

--- a/extension/runner_util/targets.bzl
+++ b/extension/runner_util/targets.bzl
@@ -17,10 +17,7 @@ def define_common_targets():
                 "inputs{}.cpp".format("_aten" if aten_mode else "_portable"),
             ],
             exported_headers = ["inputs.h"],
-            visibility = [
-                "//executorch/...",
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
             exported_deps = [
                 "//executorch/runtime/core/exec_aten:lib" + aten_suffix,
                 "//executorch/runtime/executor:program_no_prim_ops" + aten_suffix,

--- a/extension/tensor/targets.bzl
+++ b/extension/tensor/targets.bzl
@@ -22,9 +22,7 @@ def define_common_targets():
                 "tensor_ptr.h",
                 "tensor_ptr_maker.h",
             ],
-            visibility = [
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
             deps = [
                 "//executorch/runtime/core/exec_aten/util:dim_order_util" + aten_suffix,
                 "//executorch/runtime/core/exec_aten/util:tensor_util" + aten_suffix,

--- a/extension/threadpool/targets.bzl
+++ b/extension/threadpool/targets.bzl
@@ -36,13 +36,7 @@ def define_common_targets():
         exported_preprocessor_flags = [
             "-DET_USE_THREADPOOL",
         ],
-        visibility = [
-            "//executorch/...",
-            "//executorch/backends/...",
-            "//executorch/runtime/backend/...",
-            "//executorch/extension/threadpool/test/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_library(
@@ -71,10 +65,7 @@ def define_common_targets():
             # If we don't know what it is, disable threadpool out of caution.
             "DEFAULT": ["//executorch/runtime/kernel:thread_parallel_interface"],
         })),
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_library(
@@ -92,11 +83,5 @@ def define_common_targets():
             third_party_dep("pthreadpool"),
             third_party_dep("cpuinfo"),
         ],
-        visibility = [
-            "//executorch/...",
-            "//executorch/backends/...",
-            "//executorch/runtime/backend/...",
-            "//executorch/extension/threadpool/test/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )

--- a/extension/training/module/targets.bzl
+++ b/extension/training/module/targets.bzl
@@ -15,9 +15,7 @@ def define_common_targets():
         exported_headers = [
             "state_dict_util.h",
         ],
-        visibility = [
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         exported_deps = [
             "//executorch/runtime/core:named_data_map",
             "//executorch/extension/tensor:tensor",
@@ -36,9 +34,7 @@ def define_common_targets():
             exported_headers = [
                 "training_module.h",
             ],
-            visibility = [
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
             exported_deps = [
                 "//executorch/extension/module:module" + aten_suffix,
                 "//executorch/runtime/core:evalue" + aten_suffix,

--- a/extension/training/optimizer/targets.bzl
+++ b/extension/training/optimizer/targets.bzl
@@ -36,7 +36,5 @@ def define_common_targets():
                 "//executorch/runtime/core:core",
                 "//executorch/runtime/core/exec_aten:lib" + aten_suffix,
             ],  # + kernel_deps,
-            visibility = [
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
         )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #16480
* __->__ #16479
* #16478
* #16477
* #16476
* #16475
* #16474

Remove the EXECUTORCH_CLIENTS buck client list visibility gating from extension
targets. This replaces all visibility blocks containing @EXECUTORCH_CLIENTS
with explicit PUBLIC visibility.

This is part 6 of a multi-diff stack to remove visibility gating across all of executorch.
This diff covers all extension/*:
- extension/android
- extension/aten_util
- extension/data_loader
- extension/fb (dynamic_shim, ptez)
- extension/flat_tensor
- extension/kernel_util
- extension/llm
- extension/memory_allocator
- extension/module
- extension/pybindings
- extension/tensor
- extension/threadpool
- extension/training

Differential Revision: [D89902030](https://our.internmc.facebook.com/intern/diff/D89902030/)