### PR TITLE
[executorch] Remove EXECUTORCH_CLIENTS visibility gating - Devtools, Examples & More

### DIFF
--- a/codegen/targets.bzl
+++ b/codegen/targets.bzl
@@ -15,10 +15,7 @@ def define_common_targets():
             "templates/**/*.ini",
             "templates/**/*.h",
         ]),
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_library(
@@ -26,11 +23,7 @@ def define_common_targets():
         exported_headers = [
             "macros.h",
         ],
-        visibility = [
-            "//executorch/runtime/kernel/...",
-            "//executorch/kernels/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     runtime.python_library(
@@ -61,10 +54,7 @@ def define_common_targets():
         deps = [
             ":api",
         ],
-        visibility = [
-            "@EXECUTORCH_CLIENTS",
-            "//executorch/codegen/...",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     runtime.python_binary(

--- a/codegen/tools/targets.bzl
+++ b/codegen/tools/targets.bzl
@@ -29,10 +29,7 @@ def define_common_targets(is_fbcode = False):
         ],
         preload_deps = ["//executorch/codegen/tools:selective_build"],
         package_style = "inplace",
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     runtime.python_library(
@@ -72,10 +69,7 @@ def define_common_targets(is_fbcode = False):
             ":gen_oplist_lib",
         ],
         package_style = "inplace",
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     runtime.python_library(
@@ -224,10 +218,7 @@ def define_common_targets(is_fbcode = False):
             srcs = ["gen_ops_def.py"],
             main_module = "executorch.codegen.tools.gen_ops_def",
             package_style = "inplace",
-            visibility = [
-                "//executorch/...",
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
             deps = [
                 "fbsource//third-party/pypi/pyyaml:pyyaml",
                 ":yaml_util",

--- a/configurations/targets.bzl
+++ b/configurations/targets.bzl
@@ -22,10 +22,7 @@ def define_common_targets():
         exported_deps = [
             "//executorch/extension/threadpool:threadpool",
         ] + get_all_cpu_backend_targets(),
-        visibility = [
-            "//executorch/test/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     # Add a common configuration of cpu optimized operators. This adds a bit of confusion
@@ -45,8 +42,5 @@ def define_common_targets():
         functions_yaml_target = "//executorch/kernels/optimized:optimized.yaml",
         fallback_yaml_target = "//executorch/kernels/portable:functions.yaml",
         define_static_targets = True,
-        visibility = [
-            "//executorch/examples/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )

--- a/devtools/backend_debug/TARGETS
+++ b/devtools/backend_debug/TARGETS
@@ -8,12 +8,7 @@ runtime.python_library(
         "__init__.py",
         "delegation_info.py",
     ],
-    visibility = [
-        "//executorch/...",
-        "//executorch/exir/backend/...",
-        "//executorch/test/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         "fbsource//third-party/pypi/pandas:pandas",
         "//caffe2:torch",

--- a/devtools/bundled_program/TARGETS
+++ b/devtools/bundled_program/TARGETS
@@ -10,10 +10,7 @@ runtime.python_library(
     srcs = [
         "core.py",
     ],
-    visibility = [
-        "//executorch/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         ":config",
         ":version",
@@ -29,10 +26,7 @@ runtime.python_library(
     srcs = [
         "config.py",
     ],
-    visibility = [
-        "//executorch/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         "fbsource//third-party/pypi/typing-extensions:typing-extensions",
         "//caffe2:torch",

--- a/devtools/bundled_program/serialize/TARGETS
+++ b/devtools/bundled_program/serialize/TARGETS
@@ -16,19 +16,7 @@ runtime.python_library(
     # Currently serialization API should only be used in some dedicated targets,
     # to avoid ODR violation when linking with another Flatbuffers library.
     # Please ask before changing this.
-    visibility = [
-        "//executorch/bacends/...",
-        "//executorch/backends/xnnpack/test/...",
-        "//executorch/codegen/...",
-        "//executorch/devtools/bundled_program/tests/...",
-        "//executorch/examples/async_exec:emit_program_lib",
-        "//executorch/exir:lib",
-        "//executorch/extension/pybindings/test:test",
-        "//executorch/extension/pybindings/test:test-library",
-        "//executorch/profiler/...",
-        "//executorch/test/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         "fbsource//third-party/pypi/setuptools:setuptools",
         "//executorch/devtools/bundled_program/schema:bundled_program_schema_py",

--- a/devtools/bundled_program/targets.bzl
+++ b/devtools/bundled_program/targets.bzl
@@ -13,10 +13,7 @@ def define_common_targets():
             name = "runtime" + aten_suffix,
             srcs = ["bundled_program.cpp"],
             exported_headers = ["bundled_program.h"],
-            visibility = [
-                "//executorch/...",
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
             deps = [
                 "//executorch/runtime/core/exec_aten/util:dim_order_util" + aten_suffix,
                 "//executorch/devtools/bundled_program/schema:bundled_program_schema_fbs",

--- a/devtools/etdump/data_sinks/targets.bzl
+++ b/devtools/etdump/data_sinks/targets.bzl
@@ -17,10 +17,7 @@ def define_data_sink_target(data_sink_name, aten_suffix):
                 "//executorch/runtime/core/exec_aten:lib" + aten_suffix,
                 ":data_sink_base" + aten_suffix,
             ],
-            visibility = [
-                "//executorch/...",
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
         )
 
 def define_common_targets():
@@ -40,10 +37,7 @@ def define_common_targets():
             exported_deps = [
                 "//executorch/runtime/core/exec_aten/util:scalar_type_util" + aten_suffix,
             ],
-            visibility = [
-                "//executorch/...",
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
         )
 
         define_data_sink_target("buffer_data_sink", aten_suffix)

--- a/devtools/etdump/targets.bzl
+++ b/devtools/etdump/targets.bzl
@@ -47,7 +47,7 @@ def define_common_targets():
     """
     runtime.export_file(
         name = ETDUMP_SCHEMA_FLATCC,
-        visibility = ["@EXECUTORCH_CLIENTS"],
+        visibility = ["PUBLIC"],
     )
 
     generate_schema_header_flatcc(
@@ -73,7 +73,7 @@ def define_common_targets():
     runtime.cxx_library(
         name = ETDUMP_STEM_FLATCC,
         srcs = [],
-        visibility = ["//executorch/...", "@EXECUTORCH_CLIENTS"],
+        visibility = ["PUBLIC"],
         exported_headers = {
             ETDUMP_SCHEMA_FLATCC_BUILDER: ":{}[{}]".format(ETDUMP_GEN_RULE_NAME_FLATCC, ETDUMP_SCHEMA_FLATCC_BUILDER),
             ETDUMP_SCHEMA_FLATCC_READER: ":{}[{}]".format(ETDUMP_GEN_RULE_NAME_FLATCC, ETDUMP_SCHEMA_FLATCC_READER),
@@ -116,10 +116,7 @@ def define_common_targets():
                 "fbsource//third-party/re2:re2",
                 "//executorch/runtime/core:event_tracer" + aten_suffix,
             ],
-            visibility = [
-                "//executorch/...",
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
         )
 
         runtime.cxx_library(
@@ -145,8 +142,5 @@ def define_common_targets():
                 "//executorch/runtime/core:event_tracer" + aten_suffix,
                 "//executorch/runtime/core/exec_aten/util:scalar_type_util" + aten_suffix,
             ],
-            visibility = [
-                "//executorch/...",
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
         )

--- a/devtools/visualization/TARGETS
+++ b/devtools/visualization/TARGETS
@@ -10,10 +10,7 @@ runtime.python_library(
         "__init__.py",
         "visualization_utils.py",
     ],
-    visibility = [
-        "//executorch/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         "//caffe2:torch",
         "//executorch/exir:lib",

--- a/examples/apple/coreml/llama/TARGETS
+++ b/examples/apple/coreml/llama/TARGETS
@@ -10,10 +10,7 @@ runtime.python_library(
     ],
     _is_external_target = True,
     base_module = "executorch.examples.apple.coreml.llama",
-    visibility = [
-        "//executorch/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         "//caffe2:torch",
         "//executorch/examples/models/llama:llama_transformer",
@@ -27,10 +24,7 @@ runtime.python_library(
     ],
     _is_external_target = True,
     base_module = "executorch.examples.apple.coreml.llama",
-    visibility = [
-        "//executorch/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         "//caffe2:torch",
     ],
@@ -42,10 +36,7 @@ runtime.python_binary(
         "export.py",
     ],
     main_function = "executorch.examples.apple.coreml.llama.export.main",
-    visibility = [
-        "//executorch/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         "fbsource//third-party/pypi/coremltools:coremltools",
         ":llama_transformer",

--- a/examples/models/llama/TARGETS
+++ b/examples/models/llama/TARGETS
@@ -16,10 +16,7 @@ runtime.python_library(
     ],
     _is_external_target = True,
     base_module = "executorch.examples.models.llama",
-    visibility = [
-        "//executorch/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         ":transformer_modules",
         "//caffe2:torch",
@@ -39,10 +36,7 @@ runtime.python_library(
     ],
     _is_external_target = True,
     base_module = "executorch.examples.models.llama",
-    visibility = [
-        "//executorch/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
 )
 
 runtime.python_library(
@@ -52,10 +46,7 @@ runtime.python_library(
     ],
     _is_external_target = True,
     base_module = "executorch.examples.models.llama",
-    visibility = [
-        "//executorch/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         ":llama_transformer",
         "//caffe2:torch",
@@ -116,10 +107,7 @@ runtime.command_alias(
 
 runtime.python_library(
     name = "source_transformation",
-    visibility = [
-        "//executorch/examples/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     srcs = [
         "source_transformation/apply_spin_quant_r1_r2.py",
         "source_transformation/attention.py",
@@ -155,12 +143,7 @@ runtime.python_library(
     ],
     _is_external_target = True,
     base_module = "executorch.examples.models.llama",
-    visibility = [
-        "//bento/...",
-        "//bento_kernels/...",
-        "//executorch/examples/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         ":hf_download",
         ":source_transformation",
@@ -207,12 +190,7 @@ runtime.python_library(
     ],
     _is_external_target = True,
     base_module = "executorch.examples.models.llama",
-    visibility = [
-        "//bento/...",
-        "//bento_kernels/...",
-        "//executorch/examples/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         "fbsource//third-party/pypi/tqdm:tqdm",
         "fbsource//third-party/pypi/datasets:datasets",

--- a/examples/models/llama/runner/TARGETS
+++ b/examples/models/llama/runner/TARGETS
@@ -16,12 +16,7 @@ runtime.python_library(
     ],
     _is_external_target = True,
     base_module = "executorch.examples.models.llama.runner",
-    visibility = [
-        "//bento/...",
-        "//bento_kernels/...",
-        "//executorch/examples/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         "//executorch/examples/models/llama:export_library",
     ],

--- a/examples/models/llama/runner/targets.bzl
+++ b/examples/models/llama/runner/targets.bzl
@@ -34,9 +34,7 @@ def define_common_targets():
             preprocessor_flags = [
                 "-DUSE_ATEN_LIB",
             ] if aten else [],
-            visibility = [
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
             compiler_flags = [
                 "-Wno-missing-prototypes",
             ],
@@ -64,9 +62,7 @@ def define_common_targets():
         exported_headers = [
             "static_attention_io_manager.h",
         ],
-        visibility = [
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         exported_deps = [
             "//executorch/runtime/executor:program",
         ]

--- a/examples/models/llama/tokenizer/targets.bzl
+++ b/examples/models/llama/tokenizer/targets.bzl
@@ -17,9 +17,7 @@ def define_common_targets():
         exported_deps = [
             "//pytorch/tokenizers:tiktoken",
         ],
-        visibility = [
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     runtime.python_library(

--- a/examples/portable/custom_ops/targets.bzl
+++ b/examples/portable/custom_ops/targets.bzl
@@ -9,10 +9,7 @@ def define_common_targets():
     """
     runtime.export_file(
         name = "custom_ops.yaml",
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     # ~~~ START of custom ops 1 `my_ops::mul3` library definitions ~~~
@@ -22,10 +19,7 @@ def define_common_targets():
             "my_ops::mul3.out",
         ],
         define_static_targets = True,
-        visibility = [
-            "//executorch/codegen/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_library(
@@ -34,10 +28,7 @@ def define_common_targets():
         deps = [
             "//executorch/runtime/kernel:kernel_includes",
         ],
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     executorch_generated_lib(
@@ -47,10 +38,7 @@ def define_common_targets():
             ":custom_ops_1",
         ],
         custom_ops_yaml_target = ":custom_ops.yaml",
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     # ~~~ END of custom ops 1 `my_ops::mul3` library definitions ~~~
@@ -62,10 +50,7 @@ def define_common_targets():
             "my_ops::mul4.out",
         ],
         define_static_targets = True,
-        visibility = [
-            "//executorch/codegen/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_library(
@@ -74,10 +59,7 @@ def define_common_targets():
         deps = [
             "//executorch/runtime/kernel:kernel_includes",
         ],
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_library(
@@ -89,10 +71,7 @@ def define_common_targets():
         deps = [
             "//executorch/runtime/kernel:kernel_includes_aten",
         ],
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         external_deps = ["libtorch"],
         # @lint-ignore BUCKLINT link_whole
         link_whole = True,
@@ -120,9 +99,6 @@ def define_common_targets():
             ":custom_ops_2",
         ],
         custom_ops_yaml_target = ":custom_ops.yaml",
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
     # ~~~ END of custom ops 2 `my_ops::mul4` library definitions ~~~

--- a/examples/xnnpack/targets.bzl
+++ b/examples/xnnpack/targets.bzl
@@ -46,9 +46,7 @@ def define_common_targets():
         deps = [
             ":xnnpack_aot_lib",
         ],
-        visibility = [
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )
 
     # executor_runner for XNNPACK Backend and portable kernels.

--- a/exir/_serialize/TARGETS
+++ b/exir/_serialize/TARGETS
@@ -44,23 +44,7 @@ runtime.python_library(
     # Currently serialization API should only be used in some dedicated targets,
     # to avoid ODR violation when linking with another Flatbuffers library.
     # Please ask before changing this.
-    visibility = [
-        "//executorch/backends/...",
-        "//executorch/codegen/...",
-        "//executorch/devtools:lib",
-        "//executorch/devtools/bundled_program/serialize:lib",
-        "//executorch/devtools/bundled_program/tests/...",
-        "//executorch/devtools/experimental/...",
-        "//executorch/examples/async_exec:emit_program_lib",
-        "//executorch/exir/...",
-        "//executorch/exir/tests/...",
-        "//executorch/extension/...",
-        "//executorch/extension/pybindings/test:test",
-        "//executorch/extension/pybindings/test:test-library",
-        "//executorch/profiler/...",
-        "//executorch/test/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         "//executorch/exir:schema",
         "//executorch/exir:tensor",

--- a/exir/backend/TARGETS
+++ b/exir/backend/TARGETS
@@ -16,11 +16,7 @@ runtime.python_library(
     srcs = [
         "backend_api.py",
     ],
-    visibility = [
-        "//executorch/...",
-        "//executorch/test/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         ":backend_details",
         ":compile_spec_schema",
@@ -35,11 +31,7 @@ runtime.python_library(
     srcs = [
         "compile_spec_schema.py",
     ],
-    visibility = [
-        "//executorch/...",
-        "//executorch/test/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
 )
 
 runtime.python_library(
@@ -47,11 +39,7 @@ runtime.python_library(
     srcs = [
         "operator_support.py",
     ],
-    visibility = [
-        "//executorch/...",
-        "//executorch/test/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
 )
 
 runtime.python_library(
@@ -59,11 +47,7 @@ runtime.python_library(
     srcs = [
         "partitioner.py",
     ],
-    visibility = [
-        "//executorch/...",
-        "//executorch/test/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         ":compile_spec_schema",
         "//caffe2:torch",
@@ -75,11 +59,7 @@ runtime.python_library(
     srcs = [
         "backend_details.py",
     ],
-    visibility = [
-        "//executorch/...",
-        "//executorch/test/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         ":compile_spec_schema",
         ":partitioner",
@@ -93,11 +73,7 @@ runtime.python_library(
 # it's supposed to be only used on server side and not for production on device.
 runtime.python_library(
     name = "backend_lib",
-    visibility = [
-        "//executorch/...",
-        "//executorch/test/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         ":backend_api",
         ":backend_details",
@@ -111,12 +87,7 @@ runtime.python_library(
     srcs = [
         "utils.py",
     ],
-    visibility = [
-        "//executorch/...",
-        "//executorch/exir/backend/...",
-        "//executorch/test/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         "fbsource//third-party/pypi/pandas:pandas",
         "//caffe2:torch",

--- a/exir/backend/canonical_partitioners/TARGETS
+++ b/exir/backend/canonical_partitioners/TARGETS
@@ -9,12 +9,7 @@ runtime.python_library(
         "pattern_op_partitioner.py",
         "all_node_partitioner.py",
     ],
-    visibility = [
-        "//executorch/...",
-        "//executorch/exir/backend/...",
-        "//executorch/test/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         "//caffe2:torch",
         "//executorch/exir/backend:partitioner",
@@ -27,12 +22,7 @@ runtime.python_library(
     srcs = [
         "duplicate_constant_node_pass.py",
     ],
-    visibility = [
-        "//executorch/...",
-        "//executorch/exir/backend/...",
-        "//executorch/test/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         "//caffe2:torch",
         "//executorch/exir/backend:partitioner",
@@ -44,12 +34,7 @@ runtime.python_library(
     srcs = [
         "config_partitioner.py",
     ],
-    visibility = [
-        "//executorch/...",
-        "//executorch/exir/backend/...",
-        "//executorch/test/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         "//caffe2:torch",
         "//executorch/exir/backend:partitioner",
@@ -61,12 +46,7 @@ runtime.python_library(
     srcs = [
         "group_partitioner.py",
     ],
-    visibility = [
-        "//executorch/...",
-        "//executorch/exir/backend/...",
-        "//executorch/test/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         "//caffe2:torch",
         "//executorch/exir/backend:partitioner",

--- a/export/TARGETS
+++ b/export/TARGETS
@@ -7,10 +7,7 @@ runtime.python_library(
     srcs = [
         "recipe.py",
     ],
-    visibility = [
-        "//executorch/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         "//caffe2:torch",
         "//executorch/exir/backend:backend_api",
@@ -24,10 +21,7 @@ runtime.python_library(
     srcs = [
         "export.py",
     ],
-    visibility = [
-        "//executorch/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         ":recipe",
         ":stages",
@@ -42,10 +36,7 @@ runtime.python_library(
     srcs = [
         "stages.py",
     ],
-    visibility = [
-        "//executorch/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         ":recipe",
         ":types",
@@ -63,10 +54,7 @@ runtime.python_library(
     srcs = [
         "__init__.py",
     ],
-    visibility = [
-        "//executorch/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         ":export",
         ":recipe",
@@ -82,10 +70,7 @@ runtime.python_library(
     srcs = [
         "recipe_registry.py",
     ],
-    visibility = [
-        "//executorch/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         ":recipe",
         ":recipe_provider"

--- a/profiler/TARGETS
+++ b/profiler/TARGETS
@@ -12,7 +12,7 @@ runtime.python_library(
         "profiler_results_cli.py",
     ],
     base_module = "executorch.profiler",
-    visibility = ["@EXECUTORCH_CLIENTS"],
+    visibility = ["PUBLIC"],
     external_deps = ["prettytable"],
 )
 

--- a/shim_et/xplat/executorch/codegen/codegen.bzl
+++ b/shim_et/xplat/executorch/codegen/codegen.bzl
@@ -573,7 +573,7 @@ def build_portable_lib(
         portable_header_lib = None,
         feature = None,
         expose_operator_symbols = False,
-        visibility = ["@EXECUTORCH_CLIENTS"],
+        visibility = ["PUBLIC"],
         platforms = get_default_executorch_platforms()):
     """
     WARNING: Before using this, please consider using executorch_generated_lib instead. This

--- a/shim_et/xplat/executorch/kernels/optimized/lib_defs.bzl
+++ b/shim_et/xplat/executorch/kernels/optimized/lib_defs.bzl
@@ -82,10 +82,7 @@ def define_libs():
             "vec/**/*.h",
         ]),
         header_namespace = "executorch/kernels/optimized",
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         deps = select({
             "ovr_config//os:linux": [
                 "fbsource//third-party/sleef:sleef",
@@ -104,10 +101,7 @@ def define_libs():
             "utils/**/*.h",
         ]),
         header_namespace = "executorch/kernels/optimized",
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         exported_deps = [
             # Needed to access the ET_INLINE macro
             "//executorch/runtime/platform:compiler",
@@ -123,10 +117,7 @@ def define_libs():
             "blas/**/*.h",
         ]),
         header_namespace = "executorch/kernels/optimized",
-        visibility = [
-            "//executorch/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         preprocessor_flags = select({
             "ovr_config//os:android-arm64": [
                 "-DET_BUILD_WITH_BLAS",

--- a/test/models/targets.bzl
+++ b/test/models/targets.bzl
@@ -206,12 +206,7 @@ def define_common_targets():
             for fname in DELEGATED_MODULES_TO_EXPORT
         },
         default_outs = ["."],
-        visibility = [
-            "//executorch/runtime/executor/test/...",
-            "//executorch/backends/test/...",
-            "//executorch/test/...",
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
         env = {"PYTORCH_DISABLE_JUSTKNOBS": "1",},
     )
 

--- a/test/targets.bzl
+++ b/test/targets.bzl
@@ -45,7 +45,5 @@ def define_common_targets():
 
     runtime.export_file(
         name = "size_test.cpp",
-        visibility = [
-            "@EXECUTORCH_CLIENTS",
-        ],
+        visibility = ["PUBLIC"],
     )

--- a/test/utils/targets.bzl
+++ b/test/utils/targets.bzl
@@ -19,11 +19,7 @@ def define_common_targets():
                 "alignment.h",
                 "DeathTest.h",
             ],
-            visibility = [
-                "//executorch/...",
-                "//pytorch/tokenizers/...",
-                "@EXECUTORCH_CLIENTS",
-            ],
+            visibility = ["PUBLIC"],
             deps = [
                 "//executorch/runtime/platform:platform",
                 "//executorch/runtime/core:core",

--- a/third-party/flatcc_defs.bzl
+++ b/third-party/flatcc_defs.bzl
@@ -85,7 +85,7 @@ def define_flatcc_targets():
             "include",
         ],
         headers = PUBLIC_HEADERS,
-        visibility = ["@EXECUTORCH_CLIENTS"],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_library(
@@ -166,7 +166,7 @@ def define_flatcc_targets():
             "flatcc/src/compiler/keywords.h",
             "flatcc/src/compiler/codegen_c_sort.h",
         ],
-        visibility = ["@EXECUTORCH_CLIENTS"],
+        visibility = ["PUBLIC"],
         deps = [":flatccrt"],
     )
 
@@ -249,7 +249,7 @@ def define_flatcc_targets():
             "flatcc/src/compiler/keywords.h",
             "flatcc/src/compiler/codegen_c_sort.h",
         ]),
-        visibility = ["@EXECUTORCH_CLIENTS"],
+        visibility = ["PUBLIC"],
     )
 
     # FlatCC CLI
@@ -266,5 +266,5 @@ def define_flatcc_targets():
             "flatcc/config",
         ],
         deps = [":flatcc-host"],
-        visibility = ["@EXECUTORCH_CLIENTS"],
+        visibility = ["PUBLIC"],
     )

--- a/util/TARGETS
+++ b/util/TARGETS
@@ -14,10 +14,7 @@ runtime.python_library(
         "activation_memory_profiler.py",
     ],
     _is_external_target = True,
-    visibility = [
-        "//executorch/...",
-        "@EXECUTORCH_CLIENTS",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         "//caffe2:torch",
         "//executorch/exir:lib",

--- a/util/targets.bzl
+++ b/util/targets.bzl
@@ -17,6 +17,6 @@ def define_common_targets():
                 "fbsource//third-party/pypi/snakeviz:snakeviz",
                 "fbsource//third-party/pypi/tornado:tornado",
             ],
-            visibility = ["@EXECUTORCH_CLIENTS"],
+            visibility = ["PUBLIC"],
             _is_external_target = True,
         )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #16480
* #16479
* #16478
* #16477
* #16476
* #16475
* #16474

Remove the EXECUTORCH_CLIENTS buck client list visibility gating from remaining
targets. This replaces all visibility blocks containing @EXECUTORCH_CLIENTS
with explicit PUBLIC visibility.

This is part 7 of a multi-diff stack to remove visibility gating across all of executorch.
This diff covers:
- codegen
- configurations
- devtools
- examples
- exir
- export
- profiler
- shim_et
- test
- third-party
- util

Differential Revision: [D89902031](https://our.internmc.facebook.com/intern/diff/D89902031/)