### PR TITLE
Add AlannaBurke as a codeowner for docs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -18,7 +18,7 @@
 
 /devtools @Gasoonjia
 
-/docs @mergennachin
+/docs @mergennachin @AlannaBurke
 
 /examples/apple @shoumikhin
 /examples/apple/coreml @cccclai @metascroy @cymbalrush @YifanShenSZ


### PR DESCRIPTION
### Summary
Add @AlannaBurke to the CODEOWNERS file for docs. This will request her review on any documentation PRs.
