### PR TITLE
Add missing custom_ops_aot_lib preload dep to test_update_cross_attn_cache

### DIFF
--- a/extension/llm/custom_ops/TARGETS
+++ b/extension/llm/custom_ops/TARGETS
@@ -70,6 +70,7 @@ runtime.python_test(
         "test_update_cross_attn_cache.py",
     ],
     preload_deps = [
+        ":custom_ops_aot_lib",
         ":custom_ops_aot_py",
     ],
     deps = [


### PR DESCRIPTION
Summary: The test was failing with ModuleNotFoundError because the custom ops weren't registered when the test ran. The C++ library that registers the llama ops needs to be preloaded before the Python module tries to access them.

Differential Revision: D90205347


