### PR TITLE
Fix 50% perf reduction in model

### DIFF
--- a/backends/cadence/aot/memory_constraints.py
+++ b/backends/cadence/aot/memory_constraints.py
@@ -484,13 +484,6 @@ class GenerateCatNopConstraints(PassBase):
         # If any of the tensors to be concatenated is slice_nop or cat_nop, bail
         if any(self.is_slice_view(arg) for arg in cat_tensors):
             return False
-
-        # If any of the tensors already has a relative placement constraint,
-        # we cannot add a new constraint for this cat without conflicting.
-        # This can happen when a tensor is used in multiple cat operations.
-        if any(self.has_relative_placement_constraint(arg) for arg in cat_tensors):
-            return False
-
         # If the same tensor appears multiple times in the cat inputs,
         # we cannot place it at multiple different offsets relative to the output.
         if len(cat_tensors) != len(set(cat_tensors)):

--- a/backends/cadence/aot/replace_ops.py
+++ b/backends/cadence/aot/replace_ops.py
@@ -1678,8 +1678,15 @@ class ReplaceLinearWithFullyConnectedOpPass(RemoveOrReplacePassInterface):
     """
 
     linear_to_fc_op: Dict[EdgeOpOverload, EdgeOpOverload] = {
+        # Default variants
         exir_ops.edge.aten.linear.default: exir_ops.edge.cadence.fully_connected.default,
         exir_ops.edge.cadence.quantized_linear.default: exir_ops.edge.cadence.quantized_fully_connected.default,
+        # Per-tensor variants
+        exir_ops.edge.cadence.quantized_linear.per_tensor: exir_ops.edge.cadence.quantized_fully_connected.per_tensor,
+        # Type-specialized variants (int8)
+        exir_ops.edge.cadence.quantized_linear_asym8sxasym8s_asym8s.per_tensor: exir_ops.edge.cadence.quantized_fully_connected_asym8sxasym8s_asym8s.per_tensor,
+        # Type-specialized variants (uint8)
+        exir_ops.edge.cadence.quantized_linear_asym8uxasym8u_asym8u.per_tensor: exir_ops.edge.cadence.quantized_fully_connected_asym8uxasym8u_asym8u.per_tensor,
     }
 
     @property
@@ -1915,7 +1922,10 @@ class ReplaceIm2RowWithViewPass(RemoveOrReplacePassInterface):
 
     @property
     def targets(self) -> list[EdgeOpOverload]:
-        return [exir_ops.edge.cadence.im2row.default]
+        return [
+            exir_ops.edge.cadence.im2row.default,
+            exir_ops.edge.cadence.im2row.per_tensor,
+        ]
 
     def maybe_remove_or_replace(self, node: torch.fx.Node) -> bool:
         # Check if im2row applies padding. If yes, we cannot replace it with view.


### PR DESCRIPTION
Summary:
One source of slowness was cat nops became real cats and fully_connected (which is high perf) became linear. Also, was not replacing eligible im2row per tensor variants with views, just the default variants. And finally, needed to run a last cleanup step of removing cascade of views and then removing nop views/slices

Reviewed By: ethansfng

Differential Revision: D90145865


