### PR TITLE
Qualcomm AI Engine Direct - fix optrace demo script and remove redundant flags from QNN tool

### DIFF
--- a/backends/qualcomm/debugger/README.md
+++ b/backends/qualcomm/debugger/README.md
@@ -13,7 +13,7 @@ pip install qairt-visualizer
 ## Quick start
 This command launches an interactive GUI interface to visualize the `optrace` and `QHAS` results.
 ```
-python -m examples.qualcomm.util_scripts.qairt_visualizer_demo -H ${host} -s {device} -b build-android -a ${path_to_output_folder} --online_prepare
+python -m examples.qualcomm.util_scripts.qairt_visualizer_demo -H ${host} -s {device} -m ${SOC_MODEL} -b build-android -a ${path_to_output_folder} --online_prepare
 ```
 - If online prepare mode is `enabled`, the following artifacts will be generated:
     - `model`.dlc

--- a/backends/qualcomm/debugger/utils.py
+++ b/backends/qualcomm/debugger/utils.py
@@ -5,7 +5,7 @@ import shutil
 import subprocess
 import tempfile
 from pathlib import Path
-from typing import Tuple
+from typing import Sequence, Tuple
 
 import executorch.backends.qualcomm.python.PyQnnManagerAdaptor as PyQnnManager
 import pandas as pd
@@ -217,9 +217,6 @@ class QnnTool:
                 "backend_extensions": {
                     "config_file_path": "config.json",
                 },
-                "features": {
-                    "qhas_json": True,
-                },
             },
             "config": {
                 "devices": [
@@ -316,9 +313,6 @@ class QnnTool:
         ), f"Error: qnn-profiling-data_0.log not found in {self.tmp_dir}"
 
     def qnn_profile_viewer(self, graph_name="forward_schematic", graph_idx=0):
-        self.config["backend_extension_config"]["backend_extensions"][
-            "shared_library_path"
-        ] = "./libQnnHtpNetRunExtensions.so"
         self.config["backend_extension_config"] = {"features": {"qhas_json": True}}
         for file_name, data in self.config.items():
             with open(f"{self.tmp_dir}/{file_name}.json", "w") as json_file:
@@ -398,7 +392,11 @@ class QnnTool:
 
 
 def generate_optrace(
-    artifact, soc_id: QcomChipset, adb, pte_path: str, inputs: Tuple[torch.Tensor]
+    artifact,
+    soc_id: QcomChipset,
+    adb,
+    pte_path: str,
+    inputs: Sequence[Tuple[torch.Tensor]],
 ):
     """
     Generate optrace and QHAS (QNN HTP Analysis Summary) JSON files.
@@ -407,7 +405,7 @@ def generate_optrace(
         artifact (str): Path to the artifact folder.
         adb (SimpleADB): An object for communicating with Android device
         pte_path (str): The path to the generated PTE file, including the file extension (e.g., model.pte).
-        inputs (Tuple[torch.Tensor]): The input tensors for the model.
+        inputs Sequence((Tuple[torch.Tensor])): The input tensors for the model.
 
 
     Returns:

--- a/backends/qualcomm/tests/test_qnn_delegate.py
+++ b/backends/qualcomm/tests/test_qnn_delegate.py
@@ -8765,7 +8765,17 @@ class TestUtilsScript(TestQNN):
                 for _, (optrace, qhas) in msg["binaries_trace"].items():
                     with open(optrace, "r") as optrace_file:
                         optrace_data = json.load(optrace_file)
-                        for row in optrace_data:
+                        # {
+                        #  header:
+                        #    {
+                        #     'header_version': {'major': x, 'minor': y, 'patch': z},
+                        #     'version': {'major': x, 'minor': y, 'patch': z},
+                        #     'artifact_type': 'OP_TRACE'
+                        #    }
+                        #  traceEvents:
+                        #    {...}
+                        # }
+                        for row in optrace_data["traceEvents"]:
                             self.assertIn("pid", row)
                     with open(qhas, "r") as qhas_file:
                         qhas_data = json.load(qhas_file)

--- a/examples/qualcomm/util_scripts/qairt_visualizer_demo.py
+++ b/examples/qualcomm/util_scripts/qairt_visualizer_demo.py
@@ -23,7 +23,7 @@ from executorch.examples.qualcomm.utils import (
 
 def main(args) -> None:
     model = SimpleModel()
-    example_input = (torch.ones(1, 32, 28, 28), torch.ones(1, 32, 28, 28))
+    example_inputs = [(torch.ones(1, 32, 28, 28), torch.ones(1, 32, 28, 28))]
 
     pte_filename = "qnn_simple_model"
     os.makedirs(args.artifact, exist_ok=True)
@@ -31,10 +31,10 @@ def main(args) -> None:
     # lower to QNN
     build_executorch_binary(
         model,
-        example_input,
+        example_inputs[0],
         args.model,
         f"{args.artifact}/{pte_filename}",
-        [example_input],
+        example_inputs,
         quant_dtype=QuantDtype.use_8a8w,
         online_prepare=args.online_prepare,
         optrace=True,
@@ -56,7 +56,7 @@ def main(args) -> None:
         get_soc_to_chipset_map()[args.model],
         adb,
         f"{args.artifact}/{pte_filename}.pte",
-        example_input,
+        example_inputs,
     )
 
     if args.ip and args.port != -1:


### PR DESCRIPTION
Qualcomm AI Engine Direct - Fix OpTrace Profiling demo script

### Summary
 - Fix OpTrace Profiling demo script
 - remove redundant flags from QNN tool
 
### Test plan
``` bash
python -m examples.qualcomm.util_scripts.qairt_visualizer_demo -s {SERIAL_NUM} -m ${SOC_MODEL} -b build-android -a ${path_to_output_folder}
```

``` bash
python -m examples.qualcomm.util_scripts.qairt_visualizer_demo -s {SERIAL_NUM} -m ${SOC_MODEL} -b build-android -a ${path_to_output_folder} --online_prepare
```

``` bash
python -m backends.qualcomm.tests.test_qnn_delegate.TestUtilsScript.test_debugger_generate_optrace  -s {SERIAL_NUM} -m ${SOC_MODEL} -b build-android --executorch_root . -a .
```