### PR TITLE
NXP backend: added aten.split support 

### DIFF
--- a/backends/nxp/aten_passes/decompose_split_to_slices_pass.py
+++ b/backends/nxp/aten_passes/decompose_split_to_slices_pass.py
@@ -1,0 +1,193 @@
+# Copyright 2026 NXP
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+from typing import Optional, TypeAlias
+
+import torch
+from torch._subclasses import FakeTensor, FakeTensorMode
+from torch.fx import GraphModule, Node
+from torch.fx.passes.infra.pass_base import PassBase, PassResult
+
+
+class DecomposeSplitToSlicesPass(PassBase):
+    """
+      The `split` operator returns multiple tensors by partitioning `x` along `dim`. Each partitioning can be done
+      using one `slice` operator. Replacing the `split` operator with multiple `slice` operators will yield the same results.
+
+
+                                  │
+                    ┌─────────────▼─────────────┐
+                    │             x             │
+                    └─────────────┬─────────────┘
+                                  │
+            ┌─────────────────────▼─────────────────────┐
+            │     aten.split / aten.split_with_sizes    │
+            └─────────────────────┬─────────────────────┘
+                                  │
+             ┌────────────────────┼─────────────────────────┐
+             │                    │                         │
+    ┌────────▼────────┐  ┌────────▼────────┐       ┌────────▼────────┐
+    │    getitem(0)   │  │    getitem(1)   │  ...  │   getitem(N-1)  │
+    └────────┬────────┘  └────────┬────────┘       └────────┬────────┘
+             │                    │                         │
+             ▼                    ▼                         ▼
+            out0                 out1                    out(N-1)
+
+
+                                  |
+                                  |
+                             replace with
+                                  |
+                                  |
+                                  ▼
+
+
+                                  │
+                    ┌─────────────▼─────────────┐
+                    │             x             │
+                    └─────────────┬─────────────┘
+                                  │
+             ┌────────────────────┼─────────────────────────┐
+             │                    │                         │
+    ┌────────▼────────┐  ┌────────▼────────┐       ┌────────▼────────┐
+    │  aten.slice(x,  │  │  aten.slice(x,  │  ...  │  (more slices)  │
+    │    dim,s0,e0    │  │   dim,s1,e1)    │  ...  │                 │
+    └────────┬────────┘  └────────┬────────┘       └────────┬────────┘
+             │                    │                         │
+             │                    │                         │
+             ▼                    ▼                         ▼
+            out0                 out1                     outN-1
+
+    """
+
+    graph_module: GraphModule
+
+    @staticmethod
+    def _is_split_with_sizes(node: Node) -> bool:
+        return (
+            node.op == "call_function"
+            and node.target == torch.ops.aten.split_with_sizes.default
+        )
+
+    @staticmethod
+    def _is_regular_split(node: Node) -> bool:
+        is_split_tensor = (
+            node.op == "call_function" and node.target == torch.ops.aten.split.Tensor
+        )
+
+        is_split_default = (
+            node.op == "call_function" and node.target == torch.ops.aten.split.default
+        )
+
+        return is_split_tensor or is_split_default
+
+    def _create_slice_node(self, *slice_args) -> Node:
+        slice_target = torch.ops.aten.slice.Tensor
+        slice_node = self.graph_module.graph.call_function(slice_target, slice_args)
+
+        slice_node.meta["source_fn_stack"] = [
+            (slice_node.name, torch.ops.aten.slice.Tensor)
+        ]
+
+        with FakeTensorMode() as mode:
+            input_ = slice_args[0].meta["val"]
+
+            fake_input = FakeTensor.from_tensor(
+                torch.empty(input_.shape, dtype=input_.dtype), mode
+            )
+            output = slice_target(fake_input, *slice_args[1:])
+            slice_node.meta["val"] = FakeTensor.from_tensor(
+                torch.empty(output.shape, dtype=output.dtype), mode
+            )
+
+        return slice_node
+
+    SlicesArgs: TypeAlias = tuple[list[int], list[int], int]
+
+    def _get_slices_args(self, split_node: Node) -> SlicesArgs:
+        split_nodes_chunks = split_node.meta["val"]
+        dim = 0 if len(split_node.args) < 3 else split_node.args[2]
+
+        # Sometimes chunks are in tuples
+        if isinstance(split_nodes_chunks, tuple):
+            split_nodes_chunks = list(split_nodes_chunks)
+
+        if not isinstance(split_nodes_chunks, list):
+            raise RuntimeError("Faulty split chunks")
+
+        # Get slices start, end params
+        starts = []
+        ends = []
+
+        curr_start = 0
+        for s in split_nodes_chunks:
+            starts.append(curr_start)
+            ends.append(curr_start + s.shape[dim])
+            curr_start += s.shape[dim]
+
+        return starts, ends, dim
+
+    def _replace_split_with_slices(self, input_node, split_node, starts, ends, dim):
+        # Replace getitem nodes after split with slices
+        getitem_nodes = list(split_node.users.keys())
+        slice_nodes = []
+        for i in range(len(starts)):
+            slice_arguments = (input_node, dim, starts[i], ends[i])
+            with self.graph_module.graph.inserting_after(split_node):
+                slice_node = self._create_slice_node(*slice_arguments)
+                slice_nodes.append(slice_node)
+
+                getitem_node = getitem_nodes[i]
+                getitem_node.replace_all_uses_with(slice_node)
+
+                self.graph_module.graph.erase_node(getitem_node)
+
+        # Wire split node correctly to the input node
+        split_node.replace_all_uses_with(input_node)
+        self.graph_module.graph.erase_node(split_node)
+
+    def call(self, graph_module: GraphModule) -> Optional[PassResult]:
+        self.graph_module = graph_module
+        made_changes = False
+
+        if not any(map(self._is_regular_split, graph_module.graph.nodes)) and not any(
+            map(self._is_split_with_sizes, graph_module.graph.nodes)
+        ):
+            return PassResult(graph_module, made_changes)
+
+        for node in graph_module.graph.nodes:
+            # Skip if not split
+            is_split_with_sizes = self._is_split_with_sizes(node)
+            is_regular_split = self._is_regular_split(node)
+
+            if not is_split_with_sizes and not is_regular_split:
+                continue
+
+            # Get split args
+            split_node = node
+            input_node = split_node.all_input_nodes[0]
+            split_nodes_chunks = split_node.meta["val"]
+
+            # Check if split is even necessary - if not, remove it
+            if len(split_nodes_chunks) == 1:
+                getitem_node = list(split_node.users)[0]
+                getitem_node.replace_all_uses_with(input_node)
+
+                self.graph_module.graph.erase_node(getitem_node)
+                self.graph_module.graph.erase_node(split_node)
+
+                made_changes = True
+                continue
+
+            # Get arguments for the new slices
+            starts, ends, dim = self._get_slices_args(split_node)
+
+            # Replace split with slices and restructure the graph
+            self._replace_split_with_slices(input_node, split_node, starts, ends, dim)
+            made_changes = True
+
+        self.graph_module.recompile()
+        self.graph_module.graph.eliminate_dead_code()
+
+        return PassResult(self.graph_module, made_changes)

--- a/backends/nxp/aten_passes/neutron_aten_pass_manager.py
+++ b/backends/nxp/aten_passes/neutron_aten_pass_manager.py
@@ -1,4 +1,4 @@
-# Copyright 2026 NXP
+# Copyright 2025-2026 NXP
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -9,6 +9,9 @@ import torch
 
 from executorch.backends.nxp.aten_passes.convert_unsqueeze_to_view import (
     ConvertUnsqueezeToViewPass,
+)
+from executorch.backends.nxp.aten_passes.decompose_split_to_slices_pass import (
+    DecomposeSplitToSlicesPass,
 )
 from executorch.backends.nxp.aten_passes.fuse_batch_norm_with_conv_pass import (
     FuseBatchNormWithConvPass,
@@ -45,6 +48,7 @@ class NeutronAtenPassManager(PassManager):
         self, neutron_target_spec: NeutronTargetSpec, passes: list[PassType] = None
     ):
         passes: list[PassType] = passes or [
+            DecomposeSplitToSlicesPass(),
             FuseBatchNormWithConvPass(),
             FuseBatchNormWithLinearPass(),
             SplitGroupConvolution(),

--- a/backends/nxp/tests/models.py
+++ b/backends/nxp/tests/models.py
@@ -633,6 +633,38 @@ class ConvActivationModule(torch.nn.Module):
         return self.activation(x)
 
 
+class GRUModel(nn.Module):
+    def __init__(self, num_layers=1):
+        super().__init__()
+        self.gru = torch.nn.GRU(8, 8, num_layers=num_layers)
+
+    def forward(self, input_):
+        # `input_` has shape [sequence_length, batch_size, input_size] ([8, 1, 8])
+        return self.gru(
+            input_, None
+        )  # The initial hidden is `None`, which will result in a `Zeros` node being added.
+
+
+class SplitWithSize(torch.nn.Module):
+    def __init__(self, split_size, dim):
+        super().__init__()
+        self.split_size = split_size
+        self.dim = dim
+
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor]:
+        return torch.split(x, self.split_size, self.dim)
+
+
+class SplitWithSections(torch.nn.Module):
+    def __init__(self, sections, dim):
+        super().__init__()
+        self.sections = sections
+        self.dim = dim
+
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor]:
+        return torch.split(x, self.sections, self.dim)
+
+
 class MiniConvNetWithRegressionHead(torch.nn.Module):
     def __init__(self):
         super().__init__()

--- a/backends/nxp/tests/test_decompose_split_to_slices.py
+++ b/backends/nxp/tests/test_decompose_split_to_slices.py
@@ -1,0 +1,315 @@
+# Copyright 2026 NXP
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import numpy as np
+import pytest
+import torch
+from executorch.backends.nxp.aten_passes.neutron_aten_pass_manager import (
+    DecomposeSplitToSlicesPass,
+    NeutronAtenPassManager,
+    SplitGRUBasedOnNumLayers,
+)
+
+from executorch.backends.nxp.backend.edge_program_converter import (
+    EdgeProgramToIRConverter,
+)
+from executorch.backends.nxp.tests.executorch_pipeline import (
+    neutron_converter_flavor,
+    neutron_target_spec,
+    to_quantized_edge_program,
+)
+from executorch.backends.nxp.tests.executors import (
+    convert_run_compare,
+    graph_contains_any_of_ops,
+)
+from executorch.backends.nxp.tests.models import (
+    GRUModel,
+    SplitWithSections,
+    SplitWithSize,
+)
+from executorch.exir.dialects._ops import ops as exir_ops
+from torch.export import ExportedProgram
+
+
+@pytest.fixture(autouse=True)
+def reseed_model_per_test_run():
+    torch.manual_seed(23)
+    np.random.seed(23)
+
+
+@pytest.mark.parametrize(
+    "input_shape, split_size, dim",
+    [
+        pytest.param((8,), 3, 0, id="1D."),
+        pytest.param((4, 8), 5, 1, id="2D."),
+    ],
+)
+def test_decompose_split_with_size(mocker, input_shape, split_size, dim):
+    model = SplitWithSize(split_size, dim)
+    example_input = torch.rand(input_shape)
+
+    exir_program_aten = torch.export.export(model, (example_input,)).module()
+
+    # Check "aten.split.Tensor" is present
+    assert graph_contains_any_of_ops(
+        exir_program_aten.graph, [torch.ops.aten.split.Tensor]
+    )
+    outputs_before = [o.detach().numpy() for o in exir_program_aten(example_input)]
+
+    # Apply the optimization.
+    NeutronAtenPassManager(neutron_target_spec, [DecomposeSplitToSlicesPass()])(
+        exir_program_aten
+    )
+
+    # Make sure no "Split" is in the model.
+    assert not graph_contains_any_of_ops(
+        exir_program_aten.graph,
+        [
+            torch.ops.aten.split.Tensor,
+            torch.ops.aten.split.default,
+            torch.ops.aten.split_with_sizes.default,
+        ],
+    )
+
+    # Check correct placement of slices
+    nodes = list(exir_program_aten.graph.nodes)
+    slices_count = input_shape[dim] // split_size
+    # Slice nodes start appearing at index 1
+    slices_start_idx = 1
+
+    for i in range(0, slices_count):
+        assert nodes[slices_start_idx + i].target == torch.ops.aten.slice.Tensor
+
+    outputs_after = [o.detach().numpy() for o in exir_program_aten(example_input)]
+
+    # Make sure the model still produces the exact same output.
+    assert len(outputs_before) == len(outputs_after)
+
+    for i in range(len(outputs_before)):
+        assert np.allclose(outputs_before[i], outputs_after[i])
+
+
+@pytest.mark.parametrize(
+    "input_shape, sections, dim",
+    [
+        pytest.param((8,), [5, 3], 0, id="1D."),
+        pytest.param((4, 8), [3, 3, 2], 1, id="2D."),
+    ],
+)
+def test_decompose_split_with_section(mocker, input_shape, sections, dim):
+    model = SplitWithSections(sections, dim)
+    example_input = torch.rand(input_shape)
+
+    exir_program_aten = torch.export.export(model, (example_input,)).module()
+
+    # Check "aten.split_with_sizes" is present
+    assert graph_contains_any_of_ops(
+        exir_program_aten.graph, [torch.ops.aten.split_with_sizes.default]
+    )
+    outputs_before = [o.detach().numpy() for o in exir_program_aten(example_input)]
+
+    # Apply the optimization.
+    NeutronAtenPassManager(neutron_target_spec, [DecomposeSplitToSlicesPass()])(
+        exir_program_aten
+    )
+
+    # Make sure no "Split" is in the model.
+    assert not graph_contains_any_of_ops(
+        exir_program_aten.graph,
+        [
+            torch.ops.aten.split.Tensor,
+            torch.ops.aten.split.default,
+            torch.ops.aten.split_with_sizes.default,
+        ],
+    )
+
+    # Check correct placement of slices
+    nodes = list(exir_program_aten.graph.nodes)
+    slices_count = len(sections)
+    # Slice nodes start appearing at index 1
+    slices_start_idx = 1
+
+    for i in range(0, slices_count):
+        assert nodes[slices_start_idx + i].target == torch.ops.aten.slice.Tensor
+
+    outputs_after = [o.detach().numpy() for o in exir_program_aten(example_input)]
+
+    # Make sure the model still produces the exact same output.
+    assert len(outputs_before) == len(outputs_after)
+
+    for i in range(len(outputs_before)):
+        assert np.allclose(outputs_before[i], outputs_after[i])
+
+
+@pytest.mark.parametrize(
+    "gru_layers",
+    [
+        pytest.param(2, id="2 GRU layers"),
+    ],
+)
+def test_decompose_gru_with_split(mocker, gru_layers):
+    model = GRUModel(gru_layers).eval()
+
+    input_shape = (8, 1, 8)
+    example_input = (torch.ones(input_shape),)
+
+    exir_program_aten = torch.export.export(model, example_input).module()
+
+    # Apply the pass to split the `aten.gru.input` into multiple instances, which adds a split operator
+    NeutronAtenPassManager(neutron_target_spec, [SplitGRUBasedOnNumLayers()])(
+        exir_program_aten
+    )
+
+    # Check "aten.split.default" is present
+    assert graph_contains_any_of_ops(
+        exir_program_aten.graph, [torch.ops.aten.split.default]
+    )
+
+    outputs_before = [o.detach().numpy() for o in exir_program_aten(*example_input)]
+
+    # Apply the optimization.
+    NeutronAtenPassManager(neutron_target_spec, [DecomposeSplitToSlicesPass()])(
+        exir_program_aten
+    )
+
+    # Make sure no "Split" is in the model.
+    assert not graph_contains_any_of_ops(
+        exir_program_aten.graph,
+        [
+            torch.ops.aten.split.Tensor,
+            torch.ops.aten.split.default,
+            torch.ops.aten.split_with_sizes.default,
+        ],
+    )
+
+    # Check correct placement of slices
+    nodes = list(exir_program_aten.graph.nodes)
+    slices_count = gru_layers
+    # Slice nodes start appearing at index 10 for gru_layer=2, for gru_layer=3 they start at index 14...
+    slices_start_idx = 4 * gru_layers + 2
+
+    for i in range(0, slices_count):
+        assert nodes[slices_start_idx + i].target == torch.ops.aten.slice.Tensor
+
+    outputs_after = [o.detach().numpy() for o in exir_program_aten(*example_input)]
+
+    # Make sure the model still produces the exact same output.
+    assert len(outputs_before) == len(outputs_after)
+
+    for i in range(len(outputs_before)):
+        assert np.allclose(outputs_before[i], outputs_after[i])
+
+
+@pytest.mark.parametrize(
+    "input_shape, size_or_sections, dim",
+    [
+        pytest.param((8, 4), 4, 1, id="2D, one chunk using split size."),
+        pytest.param(
+            (8, 4),
+            5,
+            1,
+            id="2D, one chunk using split size, chunk size over the limit.",
+        ),
+        pytest.param((8, 4), [4], 1, id="2D, one chunk using sections."),
+    ],
+)
+def test_decompose_split_with_one_chunk(mocker, input_shape, size_or_sections, dim):
+    if isinstance(size_or_sections, list):
+        model = SplitWithSections(size_or_sections, dim)
+    else:
+        model = SplitWithSize(size_or_sections, dim)
+    example_input = torch.rand(input_shape)
+
+    exir_program_aten = torch.export.export(model, (example_input,)).module()
+
+    # Check "aten.split" is present
+    assert graph_contains_any_of_ops(
+        exir_program_aten.graph,
+        [torch.ops.aten.split.Tensor, torch.ops.aten.split_with_sizes.default],
+    )
+    outputs_before = [o.detach().numpy() for o in exir_program_aten(example_input)]
+
+    # Apply the optimization.
+    NeutronAtenPassManager(neutron_target_spec, [DecomposeSplitToSlicesPass()])(
+        exir_program_aten
+    )
+
+    # Make sure no "Split" is in the model.
+    assert not graph_contains_any_of_ops(
+        exir_program_aten.graph,
+        [
+            torch.ops.aten.split.Tensor,
+            torch.ops.aten.split.default,
+            torch.ops.aten.split_with_sizes.default,
+        ],
+    )
+
+    # Make sure there are no "aten.slice.Tensor" either. Since the split was done using one chunk,
+    # slicing is unnecessary
+    assert not graph_contains_any_of_ops(
+        exir_program_aten.graph, [torch.ops.aten.slice.Tensor]
+    )
+
+    outputs_after = [o.detach().numpy() for o in exir_program_aten(example_input)]
+
+    # Make sure the model still produces the exact same output.
+    assert len(outputs_before) == len(outputs_after)
+
+    for i in range(len(outputs_before)):
+        assert np.allclose(outputs_before[i], outputs_after[i])
+
+
+@pytest.mark.parametrize(
+    "input_shape, size_or_sections, dim",
+    [
+        pytest.param((8, 24), [16, 8], 1, id="2D, with sections."),
+        pytest.param((8, 24), 3, 1, id="2D, with sizes."),
+    ],
+)
+def test_decompose_gru_with_split_full_pipeline(
+    mocker, input_shape, size_or_sections, dim
+):
+    # The delegation of slices will not work in older versions, thus making the tests fail.
+    if neutron_converter_flavor == "SDK_25_09":
+        pytest.skip("Neutron Software must be version 2.2.1 or higher.")
+
+    converter_spy = mocker.spy(EdgeProgramToIRConverter, "convert_program")
+
+    if isinstance(size_or_sections, list):
+        model = SplitWithSections(size_or_sections, dim)
+    else:
+        model = SplitWithSize(size_or_sections, dim)
+
+    # Run conversion
+    edge_program = to_quantized_edge_program(model, input_shape).exported_program()
+
+    # Make sure no "Split" is in the model.
+    assert not graph_contains_any_of_ops(
+        edge_program.graph,
+        [
+            torch.ops.aten.split.Tensor,
+            torch.ops.aten.split.default,
+            torch.ops.aten.split_with_sizes.default,
+        ],
+    )
+
+    # Capture generated model
+    neutron_ir_model = converter_spy.spy_return[0]
+    exported_program: ExportedProgram = converter_spy.call_args.args[1]
+
+    # Make sure "edge.aten.slice_copy.Tensor" is in the model.
+    assert graph_contains_any_of_ops(
+        exported_program.graph,
+        [exir_ops.edge.aten.slice_copy.Tensor],
+    )
+
+    example_input = (np.random.random(input_shape).astype(np.float32) * 50).astype(
+        np.int8
+    )
+    convert_run_compare(
+        exported_program,
+        input_data=example_input,
+        tfl_model=neutron_ir_model,
+    )

--- a/backends/nxp/tests/test_split_group_convolution.py
+++ b/backends/nxp/tests/test_split_group_convolution.py
@@ -1,4 +1,4 @@
-# Copyright 2025 NXP
+# Copyright 2025-2026 NXP
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -246,7 +246,15 @@ class TestSplitGroupConvolution(unittest.TestCase):
         graph_module = torch.export.export(module, example_input).module()
         original_module = deepcopy(graph_module)
 
-        modified_module = NeutronAtenPassManager(neutron_target_spec)(
+        neutron_pass_manager = NeutronAtenPassManager(neutron_target_spec)
+        # The pass is removed for testing purposes, keeping the `split` operators and improving clarity
+        neutron_pass_manager.passes = [
+            a_pass
+            for a_pass in neutron_pass_manager.passes
+            if a_pass.__name__ != "DecomposeSplitToSlicesPass"
+        ]
+
+        modified_module = neutron_pass_manager(
             graph_module
         ).graph_module  # Default passes.
 


### PR DESCRIPTION
### Summary

adds support for aten.split operator

### Test plan

tests can be manually run using `pytest -c /dev/null backends/nxp/tests/`

cc @robert-kalmar @JakeStevens @digantdesai @MartinPavella 