### PR TITLE
Increase constructTuple max inputs to 12

### DIFF
--- a/extension/pytree/aten_util/ivalue_util.cpp
+++ b/extension/pytree/aten_util/ivalue_util.cpp
@@ -89,8 +89,12 @@ IValue constructTuple(const std::vector<IValue>& ivalues) {
       return create_tuple<9>(ivalues);
     case 10:
       return create_tuple<10>(ivalues);
+    case 11:
+      return create_tuple<11>(ivalues);
+    case 12:
+      return create_tuple<12>(ivalues);
   }
-  ET_ASSERT_UNREACHABLE_MSG("Supports at most 10 inputs");
+  ET_ASSERT_UNREACHABLE_MSG("Supports at most 12 inputs");
   return {};
 }
 


### PR DESCRIPTION
Summary: Currently, `constructTuple` supports at most 10 inputs. This diff increases that maximum to 12 inputs.

Differential Revision: D90297949


