### PR TITLE
Timestamps in `parakeet_runner`

### DIFF
--- a/examples/models/parakeet/CMakeLists.txt
+++ b/examples/models/parakeet/CMakeLists.txt
@@ -80,7 +80,12 @@ if(EXECUTORCH_BUILD_METAL)
   executorch_target_link_options_shared_lib(metal_backend)
 endif()
 
-add_executable(parakeet_runner main.cpp)
+add_executable(
+  parakeet_runner
+  main.cpp
+  timestamp_utils.cpp
+  tokenizer_utils.cpp
+)
 if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
   target_link_options_gc_sections(parakeet_runner)
   if(NOT APPLE AND NOT MSVC)

--- a/examples/models/parakeet/CMakeLists.txt
+++ b/examples/models/parakeet/CMakeLists.txt
@@ -80,12 +80,7 @@ if(EXECUTORCH_BUILD_METAL)
   executorch_target_link_options_shared_lib(metal_backend)
 endif()
 
-add_executable(
-  parakeet_runner
-  main.cpp
-  timestamp_utils.cpp
-  tokenizer_utils.cpp
-)
+add_executable(parakeet_runner main.cpp timestamp_utils.cpp tokenizer_utils.cpp)
 if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
   target_link_options_gc_sections(parakeet_runner)
   if(NOT APPLE AND NOT MSVC)

--- a/examples/models/parakeet/README.md
+++ b/examples/models/parakeet/README.md
@@ -71,3 +71,4 @@ From the executorch root directory:
 | `--audio_path` | Path to input audio file (.wav) |
 | `--tokenizer_path` | Path to tokenizer file (default: `tokenizer.json`) |
 | `--data_path` | Path to data file (.ptd) for delegate data (optional, required for CUDA) |
+| `--timestamps`     | Timestamp output mode: `none\|token\|word\|segment\|all` |

--- a/examples/models/parakeet/README.md
+++ b/examples/models/parakeet/README.md
@@ -71,4 +71,4 @@ From the executorch root directory:
 | `--audio_path` | Path to input audio file (.wav) |
 | `--tokenizer_path` | Path to tokenizer file (default: `tokenizer.json`) |
 | `--data_path` | Path to data file (.ptd) for delegate data (optional, required for CUDA) |
-| `--timestamps`     | Timestamp output mode: `none\|token\|word\|segment\|all` |
+| `--timestamps`     | Timestamp output mode: `none\|token\|word\|segment\|all` (default: `segment`) |

--- a/examples/models/parakeet/export_parakeet_tdt.py
+++ b/examples/models/parakeet/export_parakeet_tdt.py
@@ -2,9 +2,11 @@
 
 import argparse
 import os
+import re
 import shutil
 import tarfile
 import tempfile
+import unicodedata
 
 import torch
 import torchaudio
@@ -15,6 +17,29 @@ from executorch.exir import (
 )
 from executorch.exir.passes import MemoryPlanningPass
 from torch.export import Dim, export
+
+
+_SPECIAL_TOKEN_PATTERNS = [
+    re.compile(r"^\[.*\]$"),
+    re.compile(r"^<.*>$"),
+    re.compile(r"^##"),
+    re.compile(r"^▁"),
+    re.compile(r"^\s*$"),
+]
+
+
+def _extract_punctuation_from_vocab(vocab: list[str]) -> list[str]:
+    def is_special_token(token: str) -> bool:
+        return any(pattern.match(token) for pattern in _SPECIAL_TOKEN_PATTERNS)
+
+    punctuation: set[str] = set()
+    for token in vocab:
+        if is_special_token(token):
+            continue
+        for char in token:
+            if unicodedata.category(char).startswith("P"):
+                punctuation.add(char)
+    return sorted(punctuation)
 
 
 def load_audio(audio_path: str, sample_rate: int = 16000) -> torch.Tensor:
@@ -351,6 +376,15 @@ def export_all(model):
     )
 
     sample_rate = model.preprocessor._cfg.sample_rate
+    window_stride = float(model.preprocessor._cfg.window_stride)
+    encoder_subsampling_factor = int(getattr(model.encoder, "subsampling_factor", 8))
+
+    tokenizer_vocab = getattr(model.tokenizer, "vocab", None)
+    supported_punctuation = (
+        _extract_punctuation_from_vocab(tokenizer_vocab)
+        if isinstance(tokenizer_vocab, list)
+        else []
+    )
     metadata = {
         "num_rnn_layers": num_layers,
         "pred_hidden": pred_hidden,
@@ -358,6 +392,9 @@ def export_all(model):
         "vocab_size": model.tokenizer.vocab_size,
         "blank_id": model.tokenizer.vocab_size,
         "sample_rate": sample_rate,
+        "window_stride": window_stride,
+        "encoder_subsampling_factor": encoder_subsampling_factor,
+        "supported_punctuation": supported_punctuation,
     }
 
     return programs, metadata

--- a/examples/models/parakeet/main.cpp
+++ b/examples/models/parakeet/main.cpp
@@ -873,8 +873,14 @@ int main(int argc, char** argv) {
       supported_punctuation.size());
 
   // for simplicity, compute all levels of timestamps regardless of mode
-  const auto tokens_with_text_info = get_tokens_with_text_info(
+  std::vector<TokenWithTextInfo> tokens_with_text_info;
+  try {
+    tokens_with_text_info = get_tokens_with_text_info(
       decoded_tokens, *tokenizer, supported_punctuation);
+  } catch (const std::exception& e) {
+    ET_LOG(Error, "Failed to get tokens with text info: %s", e.what());
+    return 1;
+  }
   const auto word_offsets = get_words_offsets(
       tokens_with_text_info, *tokenizer, supported_punctuation);
   const auto segment_offsets = get_segment_offsets(word_offsets);

--- a/examples/models/parakeet/main.cpp
+++ b/examples/models/parakeet/main.cpp
@@ -45,7 +45,7 @@ DEFINE_string(
     "Path to data file (.ptd) for delegate data (optional, required for CUDA).");
 DEFINE_string(
     timestamps,
-    "none",
+    "segment",
     "Timestamp output mode: none|token|word|segment|all");
 
 using ::executorch::extension::from_blob;

--- a/examples/models/parakeet/main.cpp
+++ b/examples/models/parakeet/main.cpp
@@ -21,6 +21,10 @@
 
 #include <gflags/gflags.h>
 
+#include "timestamp_utils.h"
+#include "tokenizer_utils.h"
+#include "types.h"
+
 #include <executorch/extension/llm/runner/llm_runner_helper.h>
 #include <executorch/extension/llm/runner/wav_loader.h>
 #include <executorch/extension/llm/tokenizers/third-party/llama.cpp-unicode/include/unicode.h>
@@ -49,10 +53,12 @@ using ::executorch::extension::Module;
 using ::executorch::runtime::Error;
 using ::executorch::runtime::EValue;
 
-namespace {
-// Matches output type of tokenizers::Tokenizer methods
-using TokenId = uint64_t;
+using ::parakeet::TextWithOffsets;
+using ::parakeet::Token;
+using ::parakeet::TokenId;
+using ::parakeet::TokenWithTextInfo;
 
+namespace {
 // TDT duration values
 const std::vector<int> DURATIONS = {0, 1, 2, 3, 4};
 
@@ -64,28 +70,6 @@ struct TimestampOutputMode {
   bool enabled() const {
     return token || word || segment;
   }
-};
-
-struct Token {
-  TokenId id;
-  int64_t start_offset;
-  int64_t duration;
-};
-
-struct TokenWithTextInfo {
-  TokenId id;
-  // Raw vocabulary piece for the token_id (i.e., "##ing", "▁hello")
-  std::string raw_piece;
-  // Decoded text for the token_id (i.e., "ing", " hello")
-  std::string decoded_text;
-  int64_t start_offset;
-  int64_t end_offset;
-};
-
-struct TextWithOffsets {
-  std::string text;
-  int64_t start_offset;
-  int64_t end_offset;
 };
 
 std::string to_lower_ascii(std::string s) {
@@ -119,356 +103,6 @@ TimestampOutputMode parse_timestamp_output_mode(const std::string& raw_arg) {
   throw std::invalid_argument(
       "Invalid --timestamps value '" + raw_arg +
       "'. Expected: token, word, segment, all.");
-}
-
-bool is_whitespace_only(const std::string& token) {
-  if (token.empty()) {
-    return true;
-  }
-
-  try {
-    const auto codepoints = unicode_cpts_from_utf8(token);
-    for (const auto cp : codepoints) {
-      if (!unicode_cpt_flags(cp).is_whitespace) {
-        return false;
-      }
-    }
-    return true;
-  } catch (const std::exception&) {
-    return false;
-  }
-}
-
-bool is_special_token(const std::string& token) {
-  if (token.size() >= 2 && token.front() == '[' && token.back() == ']') {
-    return true;
-  }
-  if (token.size() >= 2 && token.front() == '<' && token.back() == '>') {
-    return true;
-  }
-  if (token.rfind("##", 0) == 0) {
-    return true;
-  }
-  if (token.rfind(u8"▁", 0) == 0) {
-    return true;
-  }
-  if (is_whitespace_only(token)) {
-    return true;
-  }
-  return false;
-}
-
-// Matches NeMo extract_punctuation_from_vocab method
-// https://github.com/NVIDIA-NeMo/NeMo/blob/b90a528/nemo/collections/asr/parts/utils/tokenizer_utils.py#L20
-std::unordered_set<std::string> derive_supported_punctuation(
-    const tokenizers::Tokenizer& tokenizer) {
-  std::unordered_set<std::string> punctuation;
-
-  const int32_t vocab_size = tokenizer.vocab_size();
-  for (int32_t id = 0; id < vocab_size; id++) {
-    const auto piece_result = tokenizer.id_to_piece(static_cast<TokenId>(id));
-    if (!piece_result.ok()) {
-      continue;
-    }
-    const std::string& piece = piece_result.get();
-    if (is_special_token(piece)) {
-      continue;
-    }
-
-    try {
-      const auto codepoints = unicode_cpts_from_utf8(piece);
-      for (const auto cp : codepoints) {
-        if (unicode_cpt_flags(cp).is_punctuation) {
-          punctuation.insert(unicode_cpt_to_utf8(cp));
-        }
-      }
-    } catch (const std::exception&) {
-      ET_LOG(
-          Error,
-          "Failed to decode token piece '%s' to codepoints",
-          piece.c_str());
-    }
-  }
-
-  return punctuation;
-}
-
-std::string decode_token_sequence(
-    const std::vector<TokenId>& tokens,
-    const tokenizers::Tokenizer& tokenizer) {
-  std::string result;
-  TokenId prev_token = tokenizer.bos_tok();
-  for (const TokenId token : tokens) {
-    auto decode_result = tokenizer.decode(prev_token, token);
-    if (decode_result.ok()) {
-      result += decode_result.get();
-    }
-    prev_token = token;
-  }
-  return result;
-}
-
-// convenience overload
-std::string decode_token_sequence(
-    const std::vector<Token>& decoded_tokens,
-    const tokenizers::Tokenizer& tokenizer) {
-  std::vector<TokenId> token_ids;
-  token_ids.reserve(decoded_tokens.size());
-  for (const auto& tok : decoded_tokens) {
-    token_ids.push_back(tok.id);
-  }
-  return decode_token_sequence(token_ids, tokenizer);
-}
-
-// throws if any tokenizer calls fail
-std::vector<TokenWithTextInfo> get_tokens_with_text_info(
-    const std::vector<Token>& tokens,
-    const tokenizers::Tokenizer& tokenizer,
-    const std::unordered_set<std::string>& supported_punctuation) {
-  std::vector<TokenWithTextInfo> tokens_with_text;
-  tokens_with_text.reserve(tokens.size());
-
-  for (const auto& token : tokens) {
-    auto piece_result = tokenizer.id_to_piece(token.id);
-    if (!piece_result.ok()) {
-      throw std::runtime_error(
-          "id_to_piece failed for token=" + std::to_string(token.id));
-    }
-
-    auto text_result = tokenizer.decode(tokenizer.bos_tok(), token.id);
-    if (!text_result.ok()) {
-      throw std::runtime_error(
-          "decode failed for token=" + std::to_string(token.id));
-    }
-
-    tokens_with_text.push_back(
-        {token.id,
-         piece_result.get(),
-         text_result.get(),
-         token.start_offset,
-         token.start_offset + token.duration});
-  }
-
-  // NeMo TDT punctuation refinement pass: snap punctuation to the end of the
-  // previous token.
-  // https://github.com/NVIDIA-NeMo/NeMo/blob/bf583c9/nemo/collections/asr/parts/submodules/rnnt_decoding.py#L1169-L1189
-  for (size_t i = 1; i < tokens_with_text.size(); i++) {
-    if (supported_punctuation.count(tokens_with_text[i].decoded_text) > 0) {
-      tokens_with_text[i].start_offset = tokens_with_text[i - 1].end_offset;
-      tokens_with_text[i].end_offset = tokens_with_text[i].start_offset;
-    }
-  }
-
-  return tokens_with_text;
-}
-
-// ref:
-// https://github.com/NVIDIA-NeMo/NeMo/blob/bf583c9/nemo/collections/asr/parts/utils/timestamp_utils.py#L54
-// assumes BPE tokenizer type
-std::vector<TextWithOffsets> get_words_offsets(
-    const std::vector<TokenWithTextInfo>& tokens,
-    const tokenizers::Tokenizer& tokenizer,
-    const std::unordered_set<std::string>& supported_punctuation,
-    const std::string& word_delimiter_char = " ") {
-  std::vector<TextWithOffsets> word_offsets;
-  if (tokens.empty()) {
-    return word_offsets;
-  }
-
-  size_t previous_token_index = 0;
-  std::vector<size_t> build_token_indices;
-
-  auto is_curr_punctuation = [&](const std::string& token_text) {
-    return token_text != word_delimiter_char &&
-        supported_punctuation.count(token_text) > 0;
-  };
-
-  auto is_word_start = [&](const std::string& token_piece,
-                           const std::string& token_text,
-                           const std::string& next_non_delim_token) {
-    const bool next_is_punctuation =
-        supported_punctuation.count(next_non_delim_token) > 0;
-    return token_piece != token_text ||
-        (token_text == word_delimiter_char && !next_is_punctuation);
-  };
-
-  for (size_t i = 0; i < tokens.size(); i++) {
-    const auto& token = tokens[i];
-
-    const bool curr_punctuation = is_curr_punctuation(token.decoded_text);
-
-    std::string next_non_delim_token;
-    for (size_t j = i + 1; j < tokens.size(); j++) {
-      if (tokens[j].decoded_text != word_delimiter_char) {
-        next_non_delim_token = tokens[j].decoded_text;
-        break;
-      }
-    }
-
-    if (is_word_start(
-            token.raw_piece, token.decoded_text, next_non_delim_token) &&
-        !curr_punctuation) {
-      if (!build_token_indices.empty()) {
-        std::vector<TokenId> built_ids;
-        built_ids.reserve(build_token_indices.size());
-        for (size_t idx : build_token_indices) {
-          built_ids.push_back(tokens[idx].id);
-        }
-        word_offsets.push_back(
-            {decode_token_sequence(built_ids, tokenizer),
-             tokens[previous_token_index].start_offset,
-             tokens[i - 1].end_offset});
-      }
-
-      build_token_indices.clear();
-
-      if (token.decoded_text != word_delimiter_char) {
-        build_token_indices.push_back(i);
-        previous_token_index = i;
-      }
-    } else if (
-        curr_punctuation && build_token_indices.empty() &&
-        !word_offsets.empty()) {
-      auto& last_built_word = word_offsets.back();
-      last_built_word.end_offset = token.end_offset;
-      if (!last_built_word.text.empty() && last_built_word.text.back() == ' ') {
-        last_built_word.text.pop_back();
-      }
-      last_built_word.text += token.decoded_text;
-    } else if (curr_punctuation && !build_token_indices.empty()) {
-      const auto& last = tokens[build_token_indices.back()].raw_piece;
-      if (last == " " || last == "_" || last == "▁") {
-        build_token_indices.pop_back();
-      }
-      build_token_indices.push_back(i);
-    } else {
-      if (build_token_indices.empty()) {
-        previous_token_index = i;
-      }
-      build_token_indices.push_back(i);
-    }
-  }
-
-  // Match NeMo behavior: inject first start_offset and append any remaining
-  // built tokens as the final word.
-  if (word_offsets.empty()) {
-    if (!build_token_indices.empty()) {
-      std::vector<TokenId> built_ids;
-      built_ids.reserve(build_token_indices.size());
-      for (const size_t idx : build_token_indices) {
-        built_ids.push_back(tokens[idx].id);
-      }
-      word_offsets.push_back(
-          {decode_token_sequence(built_ids, tokenizer),
-           tokens[0].start_offset,
-           tokens.back().end_offset});
-    }
-  } else {
-    word_offsets[0].start_offset = tokens[0].start_offset;
-
-    if (!build_token_indices.empty()) {
-      std::vector<TokenId> built_ids;
-      built_ids.reserve(build_token_indices.size());
-      for (size_t idx : build_token_indices) {
-        built_ids.push_back(tokens[idx].id);
-      }
-      word_offsets.push_back(
-          {decode_token_sequence(built_ids, tokenizer),
-           tokens[previous_token_index].start_offset,
-           tokens.back().end_offset});
-    }
-  }
-
-  return word_offsets;
-}
-
-// ref
-// https://github.com/NVIDIA-NeMo/NeMo/blob/bf583c9/nemo/collections/asr/parts/utils/timestamp_utils.py#L227
-std::vector<TextWithOffsets> get_segment_offsets(
-    const std::vector<TextWithOffsets>& word_offsets,
-    const std::vector<std::string>& segment_delimiters = {".", "?", "!"},
-    const std::optional<int64_t>& segment_gap_threshold = std::nullopt) {
-  std::vector<TextWithOffsets> segment_offsets;
-  if (word_offsets.empty()) {
-    return segment_offsets;
-  }
-
-  std::vector<std::string> segment_words;
-  size_t previous_word_index = 0;
-
-  for (size_t i = 0; i < word_offsets.size(); i++) {
-    const auto& offset = word_offsets[i];
-    const auto& word = offset.text;
-
-    if (segment_gap_threshold.has_value() && !segment_words.empty()) {
-      const int64_t gap_between_words =
-          offset.start_offset - word_offsets[i - 1].end_offset;
-      if (gap_between_words >= segment_gap_threshold.value()) {
-        std::string segment;
-        for (size_t j = 0; j < segment_words.size(); j++) {
-          if (j > 0) {
-            segment += " ";
-          }
-          segment += segment_words[j];
-        }
-        segment_offsets.push_back(
-            {segment,
-             word_offsets[previous_word_index].start_offset,
-             word_offsets[i - 1].end_offset});
-        segment_words = {word};
-        previous_word_index = i;
-        continue;
-      }
-    }
-
-    const bool is_delimiter_word =
-        std::find(segment_delimiters.begin(), segment_delimiters.end(), word) !=
-        segment_delimiters.end();
-
-    const bool ends_with_delimiter = !word.empty() &&
-        std::find(
-            segment_delimiters.begin(),
-            segment_delimiters.end(),
-            std::string(1, word.back())) != segment_delimiters.end();
-
-    if (!word.empty() && (ends_with_delimiter || is_delimiter_word)) {
-      segment_words.push_back(word);
-      if (!segment_words.empty()) {
-        std::string segment;
-        for (size_t j = 0; j < segment_words.size(); j++) {
-          if (j > 0) {
-            segment += " ";
-          }
-          segment += segment_words[j];
-        }
-        segment_offsets.push_back(
-            {segment,
-             word_offsets[previous_word_index].start_offset,
-             offset.end_offset});
-      }
-      segment_words.clear();
-      previous_word_index = i + 1;
-      continue;
-    }
-
-    segment_words.push_back(word);
-  }
-
-  if (!segment_words.empty()) {
-    std::string segment;
-    for (size_t j = 0; j < segment_words.size(); j++) {
-      if (j > 0) {
-        segment += " ";
-      }
-      segment += segment_words[j];
-    }
-    segment_offsets.push_back(
-        {segment,
-         word_offsets[previous_word_index].start_offset,
-         word_offsets.back().end_offset});
-  }
-
-  return segment_offsets;
 }
 
 std::vector<Token> greedy_decode_executorch(
@@ -857,7 +491,8 @@ int main(int argc, char** argv) {
   }
 
   // Convert tokens to text
-  std::string text = decode_token_sequence(decoded_tokens, *tokenizer);
+  std::string text = parakeet::tokenizer_utils::decode_token_sequence(
+      decoded_tokens, *tokenizer);
   std::cout << "Transcribed text: " << text << std::endl;
 
   if (!timestamp_mode.enabled()) {
@@ -866,7 +501,7 @@ int main(int argc, char** argv) {
 
   ET_LOG(Info, "Computing timestamps...");
   std::unordered_set<std::string> supported_punctuation =
-      derive_supported_punctuation(*tokenizer);
+      parakeet::tokenizer_utils::derive_supported_punctuation(*tokenizer);
   ET_LOG(
       Info,
       "Derived supported_punctuation size=%zu",
@@ -875,15 +510,17 @@ int main(int argc, char** argv) {
   // for simplicity, compute all levels of timestamps regardless of mode
   std::vector<TokenWithTextInfo> tokens_with_text_info;
   try {
-    tokens_with_text_info = get_tokens_with_text_info(
-      decoded_tokens, *tokenizer, supported_punctuation);
+    tokens_with_text_info =
+        parakeet::timestamp_utils::get_tokens_with_text_info(
+            decoded_tokens, *tokenizer, supported_punctuation);
   } catch (const std::exception& e) {
     ET_LOG(Error, "Failed to get tokens with text info: %s", e.what());
     return 1;
   }
-  const auto word_offsets = get_words_offsets(
+  const auto word_offsets = parakeet::timestamp_utils::get_words_offsets(
       tokens_with_text_info, *tokenizer, supported_punctuation);
-  const auto segment_offsets = get_segment_offsets(word_offsets);
+  const auto segment_offsets =
+      parakeet::timestamp_utils::get_segment_offsets(word_offsets);
 
   const double frame_to_seconds =
       window_stride * static_cast<double>(encoder_subsampling_factor);

--- a/examples/models/parakeet/timestamp_utils.cpp
+++ b/examples/models/parakeet/timestamp_utils.cpp
@@ -1,0 +1,257 @@
+#include "timestamp_utils.h"
+
+#include "tokenizer_utils.h"
+
+#include <algorithm>
+#include <stdexcept>
+
+#include <pytorch/tokenizers/tokenizer.h>
+
+namespace parakeet::timestamp_utils {
+
+std::vector<TokenWithTextInfo> get_tokens_with_text_info(
+    const std::vector<Token>& tokens,
+    const tokenizers::Tokenizer& tokenizer,
+    const std::unordered_set<std::string>& supported_punctuation) {
+  std::vector<TokenWithTextInfo> tokens_with_text;
+  tokens_with_text.reserve(tokens.size());
+
+  for (const auto& token : tokens) {
+    auto piece_result = tokenizer.id_to_piece(token.id);
+    if (!piece_result.ok()) {
+      throw std::runtime_error(
+          "id_to_piece failed for token=" + std::to_string(token.id));
+    }
+
+    auto text_result = tokenizer.decode(tokenizer.bos_tok(), token.id);
+    if (!text_result.ok()) {
+      throw std::runtime_error(
+          "decode failed for token=" + std::to_string(token.id));
+    }
+
+    tokens_with_text.push_back(
+        {token.id,
+         piece_result.get(),
+         text_result.get(),
+         token.start_offset,
+         token.start_offset + token.duration});
+  }
+
+  // NeMo TDT punctuation refinement pass: snap punctuation to the end of the
+  // previous token.
+  // https://github.com/NVIDIA-NeMo/NeMo/blob/bf583c9/nemo/collections/asr/parts/submodules/rnnt_decoding.py#L1169-L1189
+  for (size_t i = 1; i < tokens_with_text.size(); i++) {
+    if (supported_punctuation.count(tokens_with_text[i].decoded_text) > 0) {
+      tokens_with_text[i].start_offset = tokens_with_text[i - 1].end_offset;
+      tokens_with_text[i].end_offset = tokens_with_text[i].start_offset;
+    }
+  }
+
+  return tokens_with_text;
+}
+
+std::vector<TextWithOffsets> get_words_offsets(
+    const std::vector<TokenWithTextInfo>& tokens,
+    const tokenizers::Tokenizer& tokenizer,
+    const std::unordered_set<std::string>& supported_punctuation,
+    const std::string& word_delimiter_char) {
+  std::vector<TextWithOffsets> word_offsets;
+  if (tokens.empty()) {
+    return word_offsets;
+  }
+
+  size_t previous_token_index = 0;
+  std::vector<size_t> build_token_indices;
+
+  auto is_curr_punctuation = [&](const std::string& token_text) {
+    return token_text != word_delimiter_char &&
+        supported_punctuation.count(token_text) > 0;
+  };
+
+  auto is_word_start = [&](const std::string& token_piece,
+                           const std::string& token_text,
+                           const std::string& next_non_delim_token) {
+    const bool next_is_punctuation =
+        supported_punctuation.count(next_non_delim_token) > 0;
+    return token_piece != token_text ||
+        (token_text == word_delimiter_char && !next_is_punctuation);
+  };
+
+  for (size_t i = 0; i < tokens.size(); i++) {
+    const auto& token = tokens[i];
+
+    const bool curr_punctuation = is_curr_punctuation(token.decoded_text);
+
+    std::string next_non_delim_token;
+    for (size_t j = i + 1; j < tokens.size(); j++) {
+      if (tokens[j].decoded_text != word_delimiter_char) {
+        next_non_delim_token = tokens[j].decoded_text;
+        break;
+      }
+    }
+
+    if (is_word_start(
+            token.raw_piece, token.decoded_text, next_non_delim_token) &&
+        !curr_punctuation) {
+      if (!build_token_indices.empty()) {
+        std::vector<TokenId> built_ids;
+        built_ids.reserve(build_token_indices.size());
+        for (size_t idx : build_token_indices) {
+          built_ids.push_back(tokens[idx].id);
+        }
+        word_offsets.push_back(
+            {tokenizer_utils::decode_token_sequence(built_ids, tokenizer),
+             tokens[previous_token_index].start_offset,
+             tokens[i - 1].end_offset});
+      }
+
+      build_token_indices.clear();
+
+      if (token.decoded_text != word_delimiter_char) {
+        build_token_indices.push_back(i);
+        previous_token_index = i;
+      }
+    } else if (
+        curr_punctuation && build_token_indices.empty() &&
+        !word_offsets.empty()) {
+      auto& last_built_word = word_offsets.back();
+      last_built_word.end_offset = token.end_offset;
+      if (!last_built_word.text.empty() && last_built_word.text.back() == ' ') {
+        last_built_word.text.pop_back();
+      }
+      last_built_word.text += token.decoded_text;
+    } else if (curr_punctuation && !build_token_indices.empty()) {
+      const auto& last = tokens[build_token_indices.back()].raw_piece;
+      if (last == " " || last == "_" || last == "▁") {
+        build_token_indices.pop_back();
+      }
+      build_token_indices.push_back(i);
+    } else {
+      if (build_token_indices.empty()) {
+        previous_token_index = i;
+      }
+      build_token_indices.push_back(i);
+    }
+  }
+
+  // Match NeMo behavior: inject first start_offset and append any remaining
+  // built tokens as the final word.
+  if (word_offsets.empty()) {
+    if (!build_token_indices.empty()) {
+      std::vector<TokenId> built_ids;
+      built_ids.reserve(build_token_indices.size());
+      for (const size_t idx : build_token_indices) {
+        built_ids.push_back(tokens[idx].id);
+      }
+      word_offsets.push_back(
+          {tokenizer_utils::decode_token_sequence(built_ids, tokenizer),
+           tokens[0].start_offset,
+           tokens.back().end_offset});
+    }
+  } else {
+    word_offsets[0].start_offset = tokens[0].start_offset;
+
+    if (!build_token_indices.empty()) {
+      std::vector<TokenId> built_ids;
+      built_ids.reserve(build_token_indices.size());
+      for (size_t idx : build_token_indices) {
+        built_ids.push_back(tokens[idx].id);
+      }
+      word_offsets.push_back(
+          {tokenizer_utils::decode_token_sequence(built_ids, tokenizer),
+           tokens[previous_token_index].start_offset,
+           tokens.back().end_offset});
+    }
+  }
+
+  return word_offsets;
+}
+
+std::vector<TextWithOffsets> get_segment_offsets(
+    const std::vector<TextWithOffsets>& word_offsets,
+    const std::vector<std::string>& segment_delimiters,
+    const std::optional<int64_t>& segment_gap_threshold) {
+  std::vector<TextWithOffsets> segment_offsets;
+  if (word_offsets.empty()) {
+    return segment_offsets;
+  }
+
+  std::vector<std::string> segment_words;
+  size_t previous_word_index = 0;
+
+  for (size_t i = 0; i < word_offsets.size(); i++) {
+    const auto& offset = word_offsets[i];
+    const auto& word = offset.text;
+
+    if (segment_gap_threshold.has_value() && !segment_words.empty()) {
+      const int64_t gap_between_words =
+          offset.start_offset - word_offsets[i - 1].end_offset;
+      if (gap_between_words >= segment_gap_threshold.value()) {
+        std::string segment;
+        for (size_t j = 0; j < segment_words.size(); j++) {
+          if (j > 0) {
+            segment += " ";
+          }
+          segment += segment_words[j];
+        }
+        segment_offsets.push_back(
+            {segment,
+             word_offsets[previous_word_index].start_offset,
+             word_offsets[i - 1].end_offset});
+        segment_words = {word};
+        previous_word_index = i;
+        continue;
+      }
+    }
+
+    const bool is_delimiter_word =
+        std::find(segment_delimiters.begin(), segment_delimiters.end(), word) !=
+        segment_delimiters.end();
+
+    const bool ends_with_delimiter = !word.empty() &&
+        std::find(
+            segment_delimiters.begin(),
+            segment_delimiters.end(),
+            std::string(1, word.back())) != segment_delimiters.end();
+
+    if (!word.empty() && (ends_with_delimiter || is_delimiter_word)) {
+      segment_words.push_back(word);
+      if (!segment_words.empty()) {
+        std::string segment;
+        for (size_t j = 0; j < segment_words.size(); j++) {
+          if (j > 0) {
+            segment += " ";
+          }
+          segment += segment_words[j];
+        }
+        segment_offsets.push_back(
+            {segment,
+             word_offsets[previous_word_index].start_offset,
+             offset.end_offset});
+      }
+      segment_words.clear();
+      previous_word_index = i + 1;
+      continue;
+    }
+
+    segment_words.push_back(word);
+  }
+
+  if (!segment_words.empty()) {
+    std::string segment;
+    for (size_t j = 0; j < segment_words.size(); j++) {
+      if (j > 0) {
+        segment += " ";
+      }
+      segment += segment_words[j];
+    }
+    segment_offsets.push_back(
+        {segment,
+         word_offsets[previous_word_index].start_offset,
+         word_offsets.back().end_offset});
+  }
+
+  return segment_offsets;
+}
+
+} // namespace parakeet::timestamp_utils

--- a/examples/models/parakeet/timestamp_utils.cpp
+++ b/examples/models/parakeet/timestamp_utils.cpp
@@ -216,19 +216,17 @@ std::vector<TextWithOffsets> get_segment_offsets(
 
     if (!word.empty() && (ends_with_delimiter || is_delimiter_word)) {
       segment_words.push_back(word);
-      if (!segment_words.empty()) {
-        std::string segment;
-        for (size_t j = 0; j < segment_words.size(); j++) {
-          if (j > 0) {
-            segment += " ";
-          }
-          segment += segment_words[j];
+      std::string segment;
+      for (size_t j = 0; j < segment_words.size(); j++) {
+        if (j > 0) {
+          segment += " ";
         }
-        segment_offsets.push_back(
-            {segment,
-             word_offsets[previous_word_index].start_offset,
-             offset.end_offset});
+        segment += segment_words[j];
       }
+      segment_offsets.push_back(
+          {segment,
+           word_offsets[previous_word_index].start_offset,
+           offset.end_offset});
       segment_words.clear();
       previous_word_index = i + 1;
       continue;

--- a/examples/models/parakeet/timestamp_utils.h
+++ b/examples/models/parakeet/timestamp_utils.h
@@ -7,7 +7,7 @@
 #include <unordered_set>
 #include <vector>
 
-#include <tokenizer.h>
+#include <pytorch/tokenizers/tokenizer.h>
 
 namespace parakeet::timestamp_utils {
 

--- a/examples/models/parakeet/timestamp_utils.h
+++ b/examples/models/parakeet/timestamp_utils.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "types.h"
+
+#include <optional>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include <tokenizer.h>
+
+namespace parakeet::timestamp_utils {
+
+// throws if any tokenizer calls fail
+std::vector<TokenWithTextInfo> get_tokens_with_text_info(
+    const std::vector<Token>& tokens,
+    const tokenizers::Tokenizer& tokenizer,
+    const std::unordered_set<std::string>& supported_punctuation);
+
+// ref:
+// https://github.com/NVIDIA-NeMo/NeMo/blob/bf583c9/nemo/collections/asr/parts/utils/timestamp_utils.py#L54
+// assumes BPE tokenizer type
+std::vector<TextWithOffsets> get_words_offsets(
+    const std::vector<TokenWithTextInfo>& tokens,
+    const tokenizers::Tokenizer& tokenizer,
+    const std::unordered_set<std::string>& supported_punctuation,
+    const std::string& word_delimiter_char = " ");
+
+// ref
+// https://github.com/NVIDIA-NeMo/NeMo/blob/bf583c9/nemo/collections/asr/parts/utils/timestamp_utils.py#L227
+std::vector<TextWithOffsets> get_segment_offsets(
+    const std::vector<TextWithOffsets>& word_offsets,
+    const std::vector<std::string>& segment_delimiters = {".", "?", "!"},
+    const std::optional<int64_t>& segment_gap_threshold = std::nullopt);
+
+} // namespace parakeet::timestamp_utils

--- a/examples/models/parakeet/tokenizer_utils.cpp
+++ b/examples/models/parakeet/tokenizer_utils.cpp
@@ -1,0 +1,111 @@
+#include "tokenizer_utils.h"
+
+#include <exception>
+
+#include <executorch/extension/llm/tokenizers/third-party/llama.cpp-unicode/include/unicode.h>
+#include <executorch/runtime/platform/log.h>
+#include <pytorch/tokenizers/tokenizer.h>
+
+namespace {
+
+bool is_whitespace_only(const std::string& token) {
+  if (token.empty()) {
+    return true;
+  }
+
+  try {
+    const auto codepoints = unicode_cpts_from_utf8(token);
+    for (const auto cp : codepoints) {
+      if (!unicode_cpt_flags(cp).is_whitespace) {
+        return false;
+      }
+    }
+    return true;
+  } catch (const std::exception&) {
+    return false;
+  }
+}
+
+bool is_special_token(const std::string& token) {
+  if (token.size() >= 2 && token.front() == '[' && token.back() == ']') {
+    return true;
+  }
+  if (token.size() >= 2 && token.front() == '<' && token.back() == '>') {
+    return true;
+  }
+  if (token.rfind("##", 0) == 0) {
+    return true;
+  }
+  if (token.rfind(u8"▁", 0) == 0) {
+    return true;
+  }
+  if (is_whitespace_only(token)) {
+    return true;
+  }
+  return false;
+}
+
+} // namespace
+
+namespace parakeet::tokenizer_utils {
+
+std::unordered_set<std::string> derive_supported_punctuation(
+    const tokenizers::Tokenizer& tokenizer) {
+  std::unordered_set<std::string> punctuation;
+
+  const int32_t vocab_size = tokenizer.vocab_size();
+  for (int32_t id = 0; id < vocab_size; id++) {
+    const auto piece_result = tokenizer.id_to_piece(static_cast<TokenId>(id));
+    if (!piece_result.ok()) {
+      continue;
+    }
+    const std::string& piece = piece_result.get();
+    if (is_special_token(piece)) {
+      continue;
+    }
+
+    try {
+      const auto codepoints = unicode_cpts_from_utf8(piece);
+      for (const auto cp : codepoints) {
+        if (unicode_cpt_flags(cp).is_punctuation) {
+          punctuation.insert(unicode_cpt_to_utf8(cp));
+        }
+      }
+    } catch (const std::exception&) {
+      ET_LOG(
+          Error,
+          "Failed to decode token piece '%s' to codepoints",
+          piece.c_str());
+    }
+  }
+
+  return punctuation;
+}
+
+std::string decode_token_sequence(
+    const std::vector<TokenId>& tokens,
+    const tokenizers::Tokenizer& tokenizer) {
+  std::string result;
+  TokenId prev_token = tokenizer.bos_tok();
+  for (const TokenId token : tokens) {
+    auto decode_result = tokenizer.decode(prev_token, token);
+    if (decode_result.ok()) {
+      result += decode_result.get();
+    }
+    prev_token = token;
+  }
+  return result;
+}
+
+std::string decode_token_sequence(
+    const std::vector<Token>& decoded_tokens,
+    const tokenizers::Tokenizer& tokenizer) {
+  std::vector<TokenId> token_ids;
+  token_ids.reserve(decoded_tokens.size());
+  for (const auto& tok : decoded_tokens) {
+    token_ids.push_back(tok.id);
+  }
+  return decode_token_sequence(token_ids, tokenizer);
+}
+
+} // namespace parakeet::tokenizer_utils

--- a/examples/models/parakeet/tokenizer_utils.h
+++ b/examples/models/parakeet/tokenizer_utils.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "types.h"
+
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include <tokenizer.h>
+
+namespace parakeet::tokenizer_utils {
+
+// Matches NeMo extract_punctuation_from_vocab method
+// https://github.com/NVIDIA-NeMo/NeMo/blob/b90a528/nemo/collections/asr/parts/utils/tokenizer_utils.py#L20
+std::unordered_set<std::string> derive_supported_punctuation(
+    const tokenizers::Tokenizer& tokenizer);
+
+std::string decode_token_sequence(
+    const std::vector<TokenId>& tokens,
+    const tokenizers::Tokenizer& tokenizer);
+
+// convenience overload
+std::string decode_token_sequence(
+    const std::vector<Token>& decoded_tokens,
+    const tokenizers::Tokenizer& tokenizer);
+
+} // namespace parakeet::tokenizer_utils

--- a/examples/models/parakeet/tokenizer_utils.h
+++ b/examples/models/parakeet/tokenizer_utils.h
@@ -6,7 +6,7 @@
 #include <unordered_set>
 #include <vector>
 
-#include <tokenizer.h>
+#include <pytorch/tokenizers/tokenizer.h>
 
 namespace parakeet::tokenizer_utils {
 

--- a/examples/models/parakeet/types.h
+++ b/examples/models/parakeet/types.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace parakeet {
+
+// Matches output type of tokenizers::Tokenizer methods
+using TokenId = uint64_t;
+
+struct Token {
+  TokenId id;
+  int64_t start_offset;
+  int64_t duration;
+};
+
+struct TokenWithTextInfo {
+  TokenId id;
+  // Raw vocabulary piece for the token_id (i.e., "##ing", "▁hello")
+  std::string raw_piece;
+  // Decoded text for the token_id (i.e., "ing", " hello")
+  std::string decoded_text;
+  int64_t start_offset;
+  int64_t end_offset;
+};
+
+struct TextWithOffsets {
+  std::string text;
+  int64_t start_offset;
+  int64_t end_offset;
+};
+
+} // namespace parakeet

--- a/extension/llm/runner/test/test_text_llm_runner.cpp
+++ b/extension/llm/runner/test/test_text_llm_runner.cpp
@@ -40,11 +40,6 @@ class MockTokenizer : public ::tokenizers::Tokenizer {
       (const));
   MOCK_METHOD(
       ::tokenizers::Result<std::string>,
-      id_to_piece,
-      (uint64_t),
-      (const));
-  MOCK_METHOD(
-      ::tokenizers::Result<std::string>,
       decode,
       (uint64_t, uint64_t),
       (const));

--- a/extension/llm/runner/test/test_text_llm_runner.cpp
+++ b/extension/llm/runner/test/test_text_llm_runner.cpp
@@ -40,6 +40,11 @@ class MockTokenizer : public ::tokenizers::Tokenizer {
       (const));
   MOCK_METHOD(
       ::tokenizers::Result<std::string>,
+      id_to_piece,
+      (uint64_t),
+      (const));
+  MOCK_METHOD(
+      ::tokenizers::Result<std::string>,
       decode,
       (uint64_t, uint64_t),
       (const));


### PR DESCRIPTION
### Summary
Enable computation of timestamps within `parakeet_runner` through a `--timestamps` flag (`none|token|word|segment|all`). Followed reference implementation from [NVIDIA-NeMo/NeMo](https://github.com/NVIDIA-NeMo/NeMo/tree/bf583c980b70cecc184fa8a083a9c3ddb87f905e), which is cited as the way to run parakeet and compute timestamps for [nvidia/parakeet-tdt-0.6b-v3 on HF](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3#transcribing-with-timestamps).

Requires https://github.com/meta-pytorch/tokenizers/pull/163 for the `id_to_piece` method on `Tokenizers`.

### Test plan
Outputs the exact same transcription/timestamps as [NVIDIA-NeMo/NeMo](https://github.com/NVIDIA-NeMo/NeMo/tree/bf583c980b70cecc184fa8a083a9c3ddb87f905e) for audio files [basketball.wav](https://github.com/user-attachments/files/24569675/basketball.wav) and [audio.wav](https://github.com/user-attachments/files/24569979/audio.wav)


#### NeMo (basketball.wav)

```
import nemo.collections.asr as nemo_asr

asr_model = nemo_asr.models.ASRModel.from_pretrained(model_name="nvidia/parakeet-tdt-0.6b-v3")

output = asr_model.transcribe(['basketball.wav'], timestamps=True)

# by default, timestamps are enabled for char, word and segment level
word_timestamps = output[0].timestamp['word'] # word level timestamps for first sample
segment_timestamps = output[0].timestamp['segment'] # segment level timestamps
char_timestamps = output[0].timestamp['char'] # char level timestamps

for stamp in segment_timestamps:
    print(f"{stamp['start']}s - {stamp['end']}s : {stamp['segment']}")

for stamp in word_timestamps:
    print(f"{stamp['start']}s - {stamp['end']}s : {stamp['word']}")

for stamp in char_timestamps:
    print(f"{stamp['start']}s - {stamp['end']}s : {stamp['char']}")
```

<details>
<summary>Click to see output</summary>

```
Transcribing: 1it [00:01,  1.82s/it]
0.56s - 2.88s : All right, ballerina for the Nuggets and Mavs tonight.
2.96s - 3.6s : Late fourth quarter.
3.68s - 4.88s : Joker to MPJ.
4.96s - 5.68s : Back to you.
5.92s - 7.92s : Joker spins, fakes, scores.
8.08s - 10.24s : Was tied at 118 with two minutes to go.
10.32s - 11.52s : Then the Mavs by two.
11.6s - 12.48s : Joker drives.
12.56s - 14.64s : He'll miss but clean up his own mess.
14.8s - 16.080000000000002s : Tied at 120.
16.240000000000002s - 17.44s : Then time running out.
17.68s - 19.44s : Jamal to MPJ.
20.0s - 22.080000000000002s : He drives, stops, and pops.
22.16s - 23.04s : He had 17.
23.12s - 25.44s : The Nuggets had the lead with 6.5 to go.
25.6s - 26.8s : Mavs had a last chance.
26.88s - 31.28s : Kyrie Irving scored 43 points, but didn't hit the game winner.
31.44s - 32.24s : Joker got it.
32.32s - 34.56s : The Nuggets win at 122-120.
34.800000000000004s - 36.480000000000004s : Incredible stat line for Jokic.
36.72s - 37.36s : One of a kind.
37.6s - 40.88s : 37 points, 18 rebounds, 15 assists.
41.04s - 42.24s : He is simply the best.
42.4s - 45.92s : And the Nuggets have won four in a row and six of their last seven.
0.56s - 0.72s : All
0.72s - 0.8s : right,
0.96s - 1.76s : ballerina
1.76s - 1.84s : for
1.84s - 1.92s : the
1.92s - 2.24s : Nuggets
2.24s - 2.32s : and
2.32s - 2.64s : Mavs
2.64s - 2.88s : tonight.
2.96s - 3.2s : Late
3.2s - 3.44s : fourth
3.44s - 3.6s : quarter.
3.68s - 4.16s : Joker
4.16s - 4.32s : to
4.32s - 4.88s : MPJ.
4.96s - 5.2s : Back
5.2s - 5.44s : to
5.44s - 5.68s : you.
5.92s - 6.48s : Joker
6.48s - 6.88s : spins,
6.96s - 7.36s : fakes,
7.5200000000000005s - 7.92s : scores.
8.08s - 8.32s : Was
8.32s - 8.64s : tied
8.64s - 8.72s : at
8.72s - 9.36s : 118
9.36s - 9.52s : with
9.52s - 9.68s : two
9.68s - 9.92s : minutes
9.92s - 10.0s : to
10.0s - 10.24s : go.
10.32s - 10.56s : Then
10.56s - 10.64s : the
10.64s - 11.120000000000001s : Mavs
11.120000000000001s - 11.200000000000001s : by
11.28s - 11.52s : two.
11.6s - 12.16s : Joker
12.16s - 12.48s : drives.
12.56s - 12.96s : He'll
12.96s - 13.200000000000001s : miss
13.280000000000001s - 13.44s : but
13.44s - 13.68s : clean
13.84s - 13.92s : up
13.92s - 14.08s : his
14.08s - 14.32s : own
14.32s - 14.64s : mess.
14.8s - 15.200000000000001s : Tied
15.200000000000001s - 15.36s : at
15.36s - 16.080000000000002s : 120.
16.240000000000002s - 16.48s : Then
16.48s - 16.72s : time
16.88s - 17.28s : running
17.28s - 17.44s : out.
17.68s - 18.400000000000002s : Jamal
18.400000000000002s - 18.72s : to
18.72s - 19.44s : MPJ.
20.0s - 20.240000000000002s : He
20.240000000000002s - 20.72s : drives,
20.96s - 21.28s : stops,
21.36s - 21.6s : and
21.6s - 22.080000000000002s : pops.
22.16s - 22.32s : He
22.400000000000002s - 22.64s : had
22.64s - 23.04s : 17.
23.12s - 23.28s : The
23.28s - 23.68s : Nuggets
23.68s - 23.84s : had
23.84s - 23.92s : the
23.92s - 24.240000000000002s : lead
24.240000000000002s - 24.400000000000002s : with
24.400000000000002s - 25.12s : 6.5
25.12s - 25.28s : to
25.28s - 25.44s : go.
25.6s - 26.16s : Mavs
26.16s - 26.32s : had
26.32s - 26.400000000000002s : a
26.400000000000002s - 26.560000000000002s : last
26.560000000000002s - 26.8s : chance.
26.88s - 27.36s : Kyrie
27.52s - 28.0s : Irving
28.16s - 28.560000000000002s : scored
28.560000000000002s - 29.2s : 43
29.2s - 29.6s : points,
29.76s - 30.080000000000002s : but
30.080000000000002s - 30.48s : didn't
30.48s - 30.64s : hit
30.64s - 30.72s : the
30.72s - 30.96s : game
30.96s - 31.28s : winner.
31.44s - 32.0s : Joker
32.0s - 32.160000000000004s : got
32.160000000000004s - 32.24s : it.
32.32s - 32.480000000000004s : The
32.480000000000004s - 32.88s : Nuggets
32.88s - 33.12s : win
33.12s - 33.28s : at
33.28s - 34.56s : 122-120.
34.800000000000004s - 35.36s : Incredible
35.36s - 35.6s : stat
35.6s - 35.84s : line
35.84s - 36.0s : for
36.0s - 36.480000000000004s : Jokic.
36.72s - 36.88s : One
36.88s - 37.04s : of
37.04s - 37.12s : a
37.12s - 37.36s : kind.
37.6s - 38.160000000000004s : 37
38.160000000000004s - 38.56s : points,
38.72s - 39.2s : 18
39.2s - 39.68s : rebounds,
39.84s - 40.32s : 15
40.32s - 40.88s : assists.
41.04s - 41.2s : He
41.2s - 41.44s : is
41.44s - 41.76s : simply
41.76s - 42.0s : the
42.0s - 42.24s : best.
42.4s - 42.56s : And
42.56s - 42.64s : the
42.64s - 43.12s : Nuggets
43.12s - 43.28s : have
43.28s - 43.52s : won
43.52s - 43.76s : four
43.76s - 43.92s : in
43.92s - 44.0s : a
44.0s - 44.24s : row
44.24s - 44.56s : and
44.56s - 44.96s : six
44.96s - 45.2s : of
45.2s - 45.36s : their
45.36s - 45.6s : last
45.6s - 45.92s : seven.
0.56s - 0.72s : ['All']
0.72s - 0.8s : ['right']
0.8s - 0.8s : [',']
0.96s - 1.12s : ['b']
1.12s - 1.28s : ['all']
1.28s - 1.36s : ['er']
1.6s - 1.76s : ['ina']
1.76s - 1.84s : ['for']
1.84s - 1.92s : ['the']
1.92s - 2.0s : ['N']
2.0s - 2.08s : ['ug']
2.08s - 2.16s : ['g']
2.16s - 2.24s : ['ets']
2.24s - 2.32s : ['and']
2.32s - 2.4s : ['M']
2.4s - 2.48s : ['av']
2.48s - 2.64s : ['s']
2.64s - 2.72s : ['ton']
2.72s - 2.88s : ['ight']
2.88s - 2.88s : ['.']
2.96s - 3.04s : ['L']
3.04s - 3.2s : ['ate']
3.2s - 3.2800000000000002s : ['fo']
3.2800000000000002s - 3.36s : ['urt']
3.36s - 3.44s : ['h']
3.44s - 3.52s : ['quar']
3.52s - 3.6s : ['ter']
3.6s - 3.6s : ['.']
3.68s - 3.84s : ['J']
3.84s - 4.0s : ['ok']
4.0s - 4.16s : ['er']
4.16s - 4.32s : ['to']
4.32s - 4.48s : ['M']
4.48s - 4.64s : ['P']
4.64s - 4.88s : ['J']
4.88s - 4.88s : ['.']
4.96s - 5.04s : ['B']
5.04s - 5.2s : ['ack']
5.2s - 5.44s : ['to']
5.44s - 5.68s : ['you']
5.68s - 5.68s : ['.']
5.92s - 6.16s : ['J']
6.16s - 6.32s : ['ok']
6.32s - 6.48s : ['er']
6.48s - 6.72s : ['sp']
6.72s - 6.88s : ['ins']
6.88s - 6.88s : [',']
6.96s - 7.12s : ['fak']
7.28s - 7.36s : ['es']
7.36s - 7.36s : [',']
7.5200000000000005s - 7.76s : ['sc']
7.76s - 7.92s : ['ores']
7.92s - 7.92s : ['.']
8.08s - 8.32s : ['Was']
8.32s - 8.64s : ['tied']
8.64s - 8.72s : ['at']
8.72s - 8.8s : ['']
8.8s - 8.88s : ['1']
8.96s - 9.040000000000001s : ['1']
9.120000000000001s - 9.36s : ['8']
9.36s - 9.52s : ['with']
9.52s - 9.68s : ['two']
9.68s - 9.76s : ['minut']
9.76s - 9.92s : ['es']
9.92s - 10.0s : ['to']
10.0s - 10.24s : ['go']
10.24s - 10.24s : ['.']
10.32s - 10.4s : ['T']
10.4s - 10.56s : ['hen']
10.56s - 10.64s : ['the']
10.64s - 10.8s : ['M']
10.8s - 10.96s : ['av']
10.96s - 11.120000000000001s : ['s']
11.120000000000001s - 11.200000000000001s : ['by']
11.28s - 11.52s : ['two']
11.52s - 11.52s : ['.']
11.6s - 11.76s : ['J']
11.76s - 12.0s : ['ok']
12.0s - 12.16s : ['er']
12.16s - 12.24s : ['d']
12.24s - 12.32s : ['ri']
12.32s - 12.48s : ['ves']
12.48s - 12.48s : ['.']
12.56s - 12.72s : ['He']
12.72s - 12.72s : ["'"]
12.8s - 12.96s : ['ll']
12.96s - 13.200000000000001s : ['miss']
13.280000000000001s - 13.44s : ['but']
13.44s - 13.52s : ['c']
13.52s - 13.6s : ['le']
13.6s - 13.68s : ['an']
13.84s - 13.92s : ['up']
13.92s - 14.08s : ['his']
14.08s - 14.16s : ['o']
14.16s - 14.32s : ['wn']
14.32s - 14.48s : ['m']
14.48s - 14.64s : ['ess']
14.64s - 14.64s : ['.']
14.8s - 14.96s : ['T']
14.96s - 15.200000000000001s : ['ied']
15.200000000000001s - 15.36s : ['at']
15.36s - 15.44s : ['']
15.44s - 15.6s : ['1']
15.68s - 15.92s : ['2']
15.92s - 16.080000000000002s : ['0']
16.080000000000002s - 16.080000000000002s : ['.']
16.240000000000002s - 16.32s : ['T']
16.32s - 16.48s : ['hen']
16.48s - 16.72s : ['time']
16.88s - 17.04s : ['run']
17.04s - 17.28s : ['ning']
17.28s - 17.44s : ['out']
17.44s - 17.44s : ['.']
17.68s - 17.84s : ['J']
17.84s - 18.080000000000002s : ['am']
18.080000000000002s - 18.400000000000002s : ['al']
18.400000000000002s - 18.72s : ['to']
18.72s - 18.88s : ['M']
18.88s - 19.04s : ['P']
19.2s - 19.44s : ['J']
19.44s - 19.44s : ['.']
20.0s - 20.240000000000002s : ['He']
20.240000000000002s - 20.400000000000002s : ['d']
20.400000000000002s - 20.64s : ['ri']
20.64s - 20.72s : ['ves']
20.72s - 20.72s : [',']
20.96s - 21.12s : ['stop']
21.12s - 21.28s : ['s']
21.28s - 21.28s : [',']
21.36s - 21.6s : ['and']
21.6s - 21.84s : ['po']
21.84s - 22.080000000000002s : ['ps']
22.080000000000002s - 22.080000000000002s : ['.']
22.16s - 22.32s : ['He']
22.400000000000002s - 22.64s : ['had']
22.64s - 22.72s : ['']
22.72s - 22.88s : ['1']
22.88s - 23.04s : ['7']
23.04s - 23.04s : ['.']
23.12s - 23.28s : ['The']
23.28s - 23.36s : ['N']
23.36s - 23.44s : ['ug']
23.44s - 23.6s : ['g']
23.6s - 23.68s : ['ets']
23.68s - 23.84s : ['had']
23.84s - 23.92s : ['the']
23.92s - 24.080000000000002s : ['le']
24.080000000000002s - 24.240000000000002s : ['ad']
24.240000000000002s - 24.400000000000002s : ['with']
24.400000000000002s - 24.48s : ['']
24.48s - 24.72s : ['6']
24.72s - 24.72s : ['.']
24.88s - 25.12s : ['5']
25.12s - 25.28s : ['to']
25.28s - 25.44s : ['go']
25.44s - 25.44s : ['.']
25.6s - 25.76s : ['M']
25.76s - 26.0s : ['av']
26.0s - 26.16s : ['s']
26.16s - 26.32s : ['had']
26.32s - 26.400000000000002s : ['a']
26.400000000000002s - 26.560000000000002s : ['last']
26.560000000000002s - 26.64s : ['ch']
26.64s - 26.8s : ['ance']
26.8s - 26.8s : ['.']
26.88s - 27.04s : ['K']
27.04s - 27.28s : ['y']
27.28s - 27.36s : ['rie']
27.52s - 27.76s : ['Ir']
27.76s - 27.92s : ['v']
27.92s - 28.0s : ['ing']
28.16s - 28.32s : ['sc']
28.32s - 28.400000000000002s : ['or']
28.400000000000002s - 28.560000000000002s : ['ed']
28.560000000000002s - 28.72s : ['']
28.72s - 28.88s : ['4']
28.88s - 29.2s : ['3']
29.2s - 29.28s : ['po']
29.28s - 29.44s : ['in']
29.44s - 29.6s : ['ts']
29.6s - 29.6s : [',']
29.76s - 30.080000000000002s : ['but']
30.080000000000002s - 30.240000000000002s : ['did']
30.240000000000002s - 30.32s : ['n']
30.32s - 30.32s : ["'"]
30.48s - 30.48s : ['t']
30.48s - 30.64s : ['hit']
30.64s - 30.72s : ['the']
30.72s - 30.8s : ['g']
30.8s - 30.96s : ['ame']
30.96s - 31.04s : ['w']
31.04s - 31.2s : ['inn']
31.2s - 31.28s : ['er']
31.28s - 31.28s : ['.']
31.44s - 31.68s : ['J']
31.68s - 31.84s : ['ok']
31.84s - 32.0s : ['er']
32.0s - 32.160000000000004s : ['got']
32.160000000000004s - 32.24s : ['it']
32.24s - 32.24s : ['.']
32.32s - 32.480000000000004s : ['The']
32.480000000000004s - 32.56s : ['N']
32.56s - 32.64s : ['ug']
32.64s - 32.8s : ['g']
32.8s - 32.88s : ['ets']
32.88s - 32.96s : ['w']
32.96s - 33.12s : ['in']
33.12s - 33.28s : ['at']
33.28s - 33.36s : ['']
33.36s - 33.52s : ['1']
33.52s - 33.76s : ['2']
33.76s - 33.92s : ['2']
33.92s - 33.92s : ['-']
34.0s - 34.08s : ['1']
34.24s - 34.4s : ['2']
34.4s - 34.56s : ['0']
34.56s - 34.56s : ['.']
34.800000000000004s - 34.88s : ['In']
34.88s - 34.96s : ['c']
34.96s - 35.04s : ['re']
35.04s - 35.12s : ['di']
35.12s - 35.36s : ['ble']
35.36s - 35.6s : ['stat']
35.6s - 35.68s : ['l']
35.68s - 35.84s : ['ine']
35.84s - 36.0s : ['for']
36.0s - 36.160000000000004s : ['J']
36.160000000000004s - 36.32s : ['ok']
36.32s - 36.480000000000004s : ['ic']
36.480000000000004s - 36.480000000000004s : ['.']
36.72s - 36.800000000000004s : ['O']
36.800000000000004s - 36.88s : ['ne']
36.88s - 37.04s : ['of']
37.04s - 37.12s : ['a']
37.12s - 37.36s : ['kind']
37.36s - 37.36s : ['.']
37.6s - 37.68s : ['']
37.68s - 37.84s : ['3']
37.92s - 38.160000000000004s : ['7']
38.160000000000004s - 38.32s : ['po']
38.32s - 38.4s : ['in']
38.4s - 38.56s : ['ts']
38.56s - 38.56s : [',']
38.72s - 38.800000000000004s : ['']
38.800000000000004s - 38.96s : ['1']
38.96s - 39.2s : ['8']
39.2s - 39.36s : ['re']
39.36s - 39.44s : ['bo']
39.44s - 39.6s : ['und']
39.6s - 39.68s : ['s']
39.68s - 39.68s : [',']
39.84s - 39.92s : ['']
39.92s - 40.08s : ['1']
40.08s - 40.32s : ['5']
40.32s - 40.480000000000004s : ['ass']
40.480000000000004s - 40.64s : ['ist']
40.64s - 40.88s : ['s']
40.88s - 40.88s : ['.']
41.04s - 41.2s : ['He']
41.2s - 41.44s : ['is']
41.44s - 41.6s : ['simpl']
41.6s - 41.76s : ['y']
41.76s - 42.0s : ['the']
42.0s - 42.24s : ['best']
42.24s - 42.24s : ['.']
42.4s - 42.56s : ['And']
42.56s - 42.64s : ['the']
42.64s - 42.72s : ['N']
42.72s - 42.88s : ['ug']
42.88s - 43.04s : ['g']
43.04s - 43.12s : ['ets']
43.12s - 43.28s : ['have']
43.28s - 43.36s : ['w']
43.36s - 43.52s : ['on']
43.52s - 43.6s : ['fo']
43.6s - 43.76s : ['ur']
43.76s - 43.92s : ['in']
43.92s - 44.0s : ['a']
44.0s - 44.08s : ['ro']
44.08s - 44.24s : ['w']
44.24s - 44.56s : ['and']
44.56s - 44.72s : ['si']
44.72s - 44.96s : ['x']
44.96s - 45.2s : ['of']
45.2s - 45.36s : ['their']
45.36s - 45.6s : ['last']
45.6s - 45.76s : ['se']
45.76s - 45.92s : ['ven']
45.92s - 45.92s : ['.']
```

</details>

#### `parakeet_runner` (basketball.wav)
```
./cmake-out/examples/models/parakeet/parakeet_runner --model_path examples/models/parakeet/parakeet_tdt_exports/parakeet_tdt.pte --tokenizer_path /Users/matt/Workspace/executorch/examples/models/parakeet/parakeet_tdt_exports/tokenizer.model --audio_path basketball.wav --timestamps all
```

<details>
<summary>Click to see output</summary>

```
-> % ./cmake-out/examples/models/parakeet/parakeet_runner --model_path examples/models/parakeet/parakeet_tdt_exports/parakeet_tdt.pte --tokenizer_path /Users/matt/Workspace/executorch/examples/models/parakeet/parakeet_tdt_exports/tokenizer.model --audio_path /Users/matt/Documents/parakeet_test_audio/basketball.wav --timestamps all
I tokenizers:regex.cpp:27] Registering override fallback regex
I 00:00:00.005332 executorch:main.cpp:717] Loading model from: examples/models/parakeet/parakeet_tdt_exports/parakeet_tdt.pte
I 00:00:00.005729 executorch:main.cpp:733] Loading audio from: /Users/matt/Documents/parakeet_test_audio/basketball.wav
I 00:00:00.008822 executorch:wav_loader.h:98] WAV header detected, getting raw audio data.
I 00:00:00.008832 executorch:wav_loader.h:105] RIFF Header: RIFF
I 00:00:00.008835 executorch:wav_loader.h:106] Chunk Size: 1476488
I 00:00:00.008836 executorch:wav_loader.h:113] WAVE Header: WAVE
I 00:00:00.008840 executorch:wav_loader.h:120] Format Header: fmt 
I 00:00:00.008841 executorch:wav_loader.h:121] Format Chunk Size: 16
I 00:00:00.008843 executorch:wav_loader.h:122] Audio Format: 1
I 00:00:00.008845 executorch:wav_loader.h:123] Number of Channels: 1
I 00:00:00.008846 executorch:wav_loader.h:124] Sample Rate: 16000
I 00:00:00.008848 executorch:wav_loader.h:125] Byte Rate: 32000
I 00:00:00.008849 executorch:wav_loader.h:126] Block Align: 2
I 00:00:00.008851 executorch:wav_loader.h:127] Bits per Sample: 16
I 00:00:00.008852 executorch:wav_loader.h:132] Subchunk2Size: 1476418
I 00:00:00.009391 executorch:wav_loader.h:226] Loaded 738209 audio samples from WAV file: /Users/matt/Documents/parakeet_test_audio/basketball.wav
I 00:00:00.009403 executorch:main.cpp:736] Loaded 738209 audio samples
I 00:00:00.009432 executorch:main.cpp:747] Running preprocessor...
I 00:00:00.033216 executorch:cpuinfo_utils.cpp:71] Reading file /sys/devices/soc0/image_version
I 00:00:00.033243 executorch:cpuinfo_utils.cpp:87] Failed to open midr file /sys/devices/soc0/image_version
I 00:00:00.065268 executorch:main.cpp:772] Mel spectrogram shape: [1, 128, 4614], mel_len: 4613
I 00:00:00.065280 executorch:main.cpp:775] Running encoder...
I 00:01:19.425587 executorch:main.cpp:792] Encoder output shape: [1, 1024, 577], len=577
I 00:01:19.425620 executorch:main.cpp:833] Model metadata: vocab_size=8192, blank_id=8192, num_rnn_layers=2, pred_hidden=640, sample_rate=16000, window_stride=0.010000, encoder_subsampling_factor=8
I 00:01:19.425627 executorch:main.cpp:835] Running TDT greedy decode...
I 00:01:32.149805 executorch:main.cpp:845] Decoded 289 tokens
I 00:01:32.149823 executorch:main.cpp:848] Loading tokenizer from: /Users/matt/Workspace/executorch/examples/models/parakeet/parakeet_tdt_exports/tokenizer.model
E tokenizers:hf_tokenizer.cpp:82] Error parsing json file: [json.exception.parse_error.101] parse error at line 2, column 1: syntax error while parsing value - invalid literal; last read: '<U+000A><U+000E>'
E tokenizers:tiktoken.cpp:59] invalid tiktoken line: 
I 00:01:32.154983 executorch:llm_runner_helper.cpp:77] Loaded Sentencepiece tokenizer
Transcribed text: All right, ballerina for the Nuggets and Mavs tonight. Late fourth quarter. Joker to MPJ. Back to you. Joker spins, fakes, scores. Was tied at 118 with two minutes to go. Then the Mavs by two. Joker drives. He'll miss but clean up his own mess. Tied at 120. Then time running out. Jamal to MPJ. He drives, stops, and pops. He had 17. The Nuggets had the lead with 6.5 to go. Mavs had a last chance. Kyrie Irving scored 43 points, but didn't hit the game winner. Joker got it. The Nuggets win at 122-120. Incredible stat line for Jokic. One of a kind. 37 points, 18 rebounds, 15 assists. He is simply the best. And the Nuggets have won four in a row and six of their last seven.
I 00:01:32.155043 executorch:main.cpp:867] Computing timestamps...
I 00:01:32.155828 executorch:main.cpp:873] Derived supported_punctuation size=11

Segment timestamps:
0.56s - 2.88s : All right, ballerina for the Nuggets and Mavs tonight.
2.96s - 3.6s : Late fourth quarter.
3.68s - 4.88s : Joker to MPJ.
4.96s - 5.68s : Back to you.
5.92s - 7.92s : Joker spins, fakes, scores.
8.08s - 10.24s : Was tied at 118 with two minutes to go.
10.32s - 11.52s : Then the Mavs by two.
11.6s - 12.48s : Joker drives.
12.56s - 14.64s : He'll miss but clean up his own mess.
14.8s - 16.08s : Tied at 120.
16.24s - 17.44s : Then time running out.
17.68s - 19.44s : Jamal to MPJ.
20s - 22.08s : He drives, stops, and pops.
22.16s - 23.04s : He had 17.
23.12s - 25.44s : The Nuggets had the lead with 6.5 to go.
25.6s - 26.8s : Mavs had a last chance.
26.88s - 31.28s : Kyrie Irving scored 43 points, but didn't hit the game winner.
31.44s - 32.24s : Joker got it.
32.32s - 34.56s : The Nuggets win at 122-120.
34.8s - 36.48s : Incredible stat line for Jokic.
36.72s - 37.36s : One of a kind.
37.6s - 40.88s : 37 points, 18 rebounds, 15 assists.
41.04s - 42.24s : He is simply the best.
42.4s - 45.92s : And the Nuggets have won four in a row and six of their last seven.

Word timestamps:
0.56s - 0.72s : All
0.72s - 0.8s : right,
0.96s - 1.76s : ballerina
1.76s - 1.84s : for
1.84s - 1.92s : the
1.92s - 2.24s : Nuggets
2.24s - 2.32s : and
2.32s - 2.64s : Mavs
2.64s - 2.88s : tonight.
2.96s - 3.2s : Late
3.2s - 3.44s : fourth
3.44s - 3.6s : quarter.
3.68s - 4.16s : Joker
4.16s - 4.32s : to
4.32s - 4.88s : MPJ.
4.96s - 5.2s : Back
5.2s - 5.44s : to
5.44s - 5.68s : you.
5.92s - 6.48s : Joker
6.48s - 6.88s : spins,
6.96s - 7.36s : fakes,
7.52s - 7.92s : scores.
8.08s - 8.32s : Was
8.32s - 8.64s : tied
8.64s - 8.72s : at
8.72s - 9.36s : 118
9.36s - 9.52s : with
9.52s - 9.68s : two
9.68s - 9.92s : minutes
9.92s - 10s : to
10s - 10.24s : go.
10.32s - 10.56s : Then
10.56s - 10.64s : the
10.64s - 11.12s : Mavs
11.12s - 11.2s : by
11.28s - 11.52s : two.
11.6s - 12.16s : Joker
12.16s - 12.48s : drives.
12.56s - 12.96s : He'll
12.96s - 13.2s : miss
13.28s - 13.44s : but
13.44s - 13.68s : clean
13.84s - 13.92s : up
13.92s - 14.08s : his
14.08s - 14.32s : own
14.32s - 14.64s : mess.
14.8s - 15.2s : Tied
15.2s - 15.36s : at
15.36s - 16.08s : 120.
16.24s - 16.48s : Then
16.48s - 16.72s : time
16.88s - 17.28s : running
17.28s - 17.44s : out.
17.68s - 18.4s : Jamal
18.4s - 18.72s : to
18.72s - 19.44s : MPJ.
20s - 20.24s : He
20.24s - 20.72s : drives,
20.96s - 21.28s : stops,
21.36s - 21.6s : and
21.6s - 22.08s : pops.
22.16s - 22.32s : He
22.4s - 22.64s : had
22.64s - 23.04s : 17.
23.12s - 23.28s : The
23.28s - 23.68s : Nuggets
23.68s - 23.84s : had
23.84s - 23.92s : the
23.92s - 24.24s : lead
24.24s - 24.4s : with
24.4s - 25.12s : 6.5
25.12s - 25.28s : to
25.28s - 25.44s : go.
25.6s - 26.16s : Mavs
26.16s - 26.32s : had
26.32s - 26.4s : a
26.4s - 26.56s : last
26.56s - 26.8s : chance.
26.88s - 27.36s : Kyrie
27.52s - 28s : Irving
28.16s - 28.56s : scored
28.56s - 29.2s : 43
29.2s - 29.6s : points,
29.76s - 30.08s : but
30.08s - 30.48s : didn't
30.48s - 30.64s : hit
30.64s - 30.72s : the
30.72s - 30.96s : game
30.96s - 31.28s : winner.
31.44s - 32s : Joker
32s - 32.16s : got
32.16s - 32.24s : it.
32.32s - 32.48s : The
32.48s - 32.88s : Nuggets
32.88s - 33.12s : win
33.12s - 33.28s : at
33.28s - 34.56s : 122-120.
34.8s - 35.36s : Incredible
35.36s - 35.6s : stat
35.6s - 35.84s : line
35.84s - 36s : for
36s - 36.48s : Jokic.
36.72s - 36.88s : One
36.88s - 37.04s : of
37.04s - 37.12s : a
37.12s - 37.36s : kind.
37.6s - 38.16s : 37
38.16s - 38.56s : points,
38.72s - 39.2s : 18
39.2s - 39.68s : rebounds,
39.84s - 40.32s : 15
40.32s - 40.88s : assists.
41.04s - 41.2s : He
41.2s - 41.44s : is
41.44s - 41.76s : simply
41.76s - 42s : the
42s - 42.24s : best.
42.4s - 42.56s : And
42.56s - 42.64s : the
42.64s - 43.12s : Nuggets
43.12s - 43.28s : have
43.28s - 43.52s : won
43.52s - 43.76s : four
43.76s - 43.92s : in
43.92s - 44s : a
44s - 44.24s : row
44.24s - 44.56s : and
44.56s - 44.96s : six
44.96s - 45.2s : of
45.2s - 45.36s : their
45.36s - 45.6s : last
45.6s - 45.92s : seven.

Token timestamps:
0.56s - 0.72s : All
0.72s - 0.8s : right
0.8s - 0.8s : ,
0.96s - 1.12s : b
1.12s - 1.28s : all
1.28s - 1.36s : er
1.6s - 1.76s : ina
1.76s - 1.84s : for
1.84s - 1.92s : the
1.92s - 2s : N
2s - 2.08s : ug
2.08s - 2.16s : g
2.16s - 2.24s : ets
2.24s - 2.32s : and
2.32s - 2.4s : M
2.4s - 2.48s : av
2.48s - 2.64s : s
2.64s - 2.72s : ton
2.72s - 2.88s : ight
2.88s - 2.88s : .
2.96s - 3.04s : L
3.04s - 3.2s : ate
3.2s - 3.28s : fo
3.28s - 3.36s : urt
3.36s - 3.44s : h
3.44s - 3.52s : quar
3.52s - 3.6s : ter
3.6s - 3.6s : .
3.68s - 3.84s : J
3.84s - 4s : ok
4s - 4.16s : er
4.16s - 4.32s : to
4.32s - 4.48s : M
4.48s - 4.64s : P
4.64s - 4.88s : J
4.88s - 4.88s : .
4.96s - 5.04s : B
5.04s - 5.2s : ack
5.2s - 5.44s : to
5.44s - 5.68s : you
5.68s - 5.68s : .
5.92s - 6.16s : J
6.16s - 6.32s : ok
6.32s - 6.48s : er
6.48s - 6.72s : sp
6.72s - 6.88s : ins
6.88s - 6.88s : ,
6.96s - 7.12s : fak
7.28s - 7.36s : es
7.36s - 7.36s : ,
7.52s - 7.76s : sc
7.76s - 7.92s : ores
7.92s - 7.92s : .
8.08s - 8.32s : Was
8.32s - 8.64s : tied
8.64s - 8.72s : at
8.72s - 8.8s : 
8.8s - 8.88s : 1
8.96s - 9.04s : 1
9.12s - 9.36s : 8
9.36s - 9.52s : with
9.52s - 9.68s : two
9.68s - 9.76s : minut
9.76s - 9.92s : es
9.92s - 10s : to
10s - 10.24s : go
10.24s - 10.24s : .
10.32s - 10.4s : T
10.4s - 10.56s : hen
10.56s - 10.64s : the
10.64s - 10.8s : M
10.8s - 10.96s : av
10.96s - 11.12s : s
11.12s - 11.2s : by
11.28s - 11.52s : two
11.52s - 11.52s : .
11.6s - 11.76s : J
11.76s - 12s : ok
12s - 12.16s : er
12.16s - 12.24s : d
12.24s - 12.32s : ri
12.32s - 12.48s : ves
12.48s - 12.48s : .
12.56s - 12.72s : He
12.72s - 12.72s : '
12.8s - 12.96s : ll
12.96s - 13.2s : miss
13.28s - 13.44s : but
13.44s - 13.52s : c
13.52s - 13.6s : le
13.6s - 13.68s : an
13.84s - 13.92s : up
13.92s - 14.08s : his
14.08s - 14.16s : o
14.16s - 14.32s : wn
14.32s - 14.48s : m
14.48s - 14.64s : ess
14.64s - 14.64s : .
14.8s - 14.96s : T
14.96s - 15.2s : ied
15.2s - 15.36s : at
15.36s - 15.44s : 
15.44s - 15.6s : 1
15.68s - 15.92s : 2
15.92s - 16.08s : 0
16.08s - 16.08s : .
16.24s - 16.32s : T
16.32s - 16.48s : hen
16.48s - 16.72s : time
16.88s - 17.04s : run
17.04s - 17.28s : ning
17.28s - 17.44s : out
17.44s - 17.44s : .
17.68s - 17.84s : J
17.84s - 18.08s : am
18.08s - 18.4s : al
18.4s - 18.72s : to
18.72s - 18.88s : M
18.88s - 19.04s : P
19.2s - 19.44s : J
19.44s - 19.44s : .
20s - 20.24s : He
20.24s - 20.4s : d
20.4s - 20.64s : ri
20.64s - 20.72s : ves
20.72s - 20.72s : ,
20.96s - 21.12s : stop
21.12s - 21.28s : s
21.28s - 21.28s : ,
21.36s - 21.6s : and
21.6s - 21.84s : po
21.84s - 22.08s : ps
22.08s - 22.08s : .
22.16s - 22.32s : He
22.4s - 22.64s : had
22.64s - 22.72s : 
22.72s - 22.88s : 1
22.88s - 23.04s : 7
23.04s - 23.04s : .
23.12s - 23.28s : The
23.28s - 23.36s : N
23.36s - 23.44s : ug
23.44s - 23.6s : g
23.6s - 23.68s : ets
23.68s - 23.84s : had
23.84s - 23.92s : the
23.92s - 24.08s : le
24.08s - 24.24s : ad
24.24s - 24.4s : with
24.4s - 24.48s : 
24.48s - 24.72s : 6
24.72s - 24.72s : .
24.88s - 25.12s : 5
25.12s - 25.28s : to
25.28s - 25.44s : go
25.44s - 25.44s : .
25.6s - 25.76s : M
25.76s - 26s : av
26s - 26.16s : s
26.16s - 26.32s : had
26.32s - 26.4s : a
26.4s - 26.56s : last
26.56s - 26.64s : ch
26.64s - 26.8s : ance
26.8s - 26.8s : .
26.88s - 27.04s : K
27.04s - 27.28s : y
27.28s - 27.36s : rie
27.52s - 27.76s : Ir
27.76s - 27.92s : v
27.92s - 28s : ing
28.16s - 28.32s : sc
28.32s - 28.4s : or
28.4s - 28.56s : ed
28.56s - 28.72s : 
28.72s - 28.88s : 4
28.88s - 29.2s : 3
29.2s - 29.28s : po
29.28s - 29.44s : in
29.44s - 29.6s : ts
29.6s - 29.6s : ,
29.76s - 30.08s : but
30.08s - 30.24s : did
30.24s - 30.32s : n
30.32s - 30.32s : '
30.48s - 30.48s : t
30.48s - 30.64s : hit
30.64s - 30.72s : the
30.72s - 30.8s : g
30.8s - 30.96s : ame
30.96s - 31.04s : w
31.04s - 31.2s : inn
31.2s - 31.28s : er
31.28s - 31.28s : .
31.44s - 31.68s : J
31.68s - 31.84s : ok
31.84s - 32s : er
32s - 32.16s : got
32.16s - 32.24s : it
32.24s - 32.24s : .
32.32s - 32.48s : The
32.48s - 32.56s : N
32.56s - 32.64s : ug
32.64s - 32.8s : g
32.8s - 32.88s : ets
32.88s - 32.96s : w
32.96s - 33.12s : in
33.12s - 33.28s : at
33.28s - 33.36s : 
33.36s - 33.52s : 1
33.52s - 33.76s : 2
33.76s - 33.92s : 2
33.92s - 33.92s : -
34s - 34.08s : 1
34.24s - 34.4s : 2
34.4s - 34.56s : 0
34.56s - 34.56s : .
34.8s - 34.88s : In
34.88s - 34.96s : c
34.96s - 35.04s : re
35.04s - 35.12s : di
35.12s - 35.36s : ble
35.36s - 35.6s : stat
35.6s - 35.68s : l
35.68s - 35.84s : ine
35.84s - 36s : for
36s - 36.16s : J
36.16s - 36.32s : ok
36.32s - 36.48s : ic
36.48s - 36.48s : .
36.72s - 36.8s : O
36.8s - 36.88s : ne
36.88s - 37.04s : of
37.04s - 37.12s : a
37.12s - 37.36s : kind
37.36s - 37.36s : .
37.6s - 37.68s : 
37.68s - 37.84s : 3
37.92s - 38.16s : 7
38.16s - 38.32s : po
38.32s - 38.4s : in
38.4s - 38.56s : ts
38.56s - 38.56s : ,
38.72s - 38.8s : 
38.8s - 38.96s : 1
38.96s - 39.2s : 8
39.2s - 39.36s : re
39.36s - 39.44s : bo
39.44s - 39.6s : und
39.6s - 39.68s : s
39.68s - 39.68s : ,
39.84s - 39.92s : 
39.92s - 40.08s : 1
40.08s - 40.32s : 5
40.32s - 40.48s : ass
40.48s - 40.64s : ist
40.64s - 40.88s : s
40.88s - 40.88s : .
41.04s - 41.2s : He
41.2s - 41.44s : is
41.44s - 41.6s : simpl
41.6s - 41.76s : y
41.76s - 42s : the
42s - 42.24s : best
42.24s - 42.24s : .
42.4s - 42.56s : And
42.56s - 42.64s : the
42.64s - 42.72s : N
42.72s - 42.88s : ug
42.88s - 43.04s : g
43.04s - 43.12s : ets
43.12s - 43.28s : have
43.28s - 43.36s : w
43.36s - 43.52s : on
43.52s - 43.6s : fo
43.6s - 43.76s : ur
43.76s - 43.92s : in
43.92s - 44s : a
44s - 44.08s : ro
44.08s - 44.24s : w
44.24s - 44.56s : and
44.56s - 44.72s : si
44.72s - 44.96s : x
44.96s - 45.2s : of
45.2s - 45.36s : their
45.36s - 45.6s : last
45.6s - 45.76s : se
45.76s - 45.92s : ven
45.92s - 45.92s : .
```

</details>

