### PR TITLE
Support case when cache_len == 0

### DIFF
--- a/examples/models/llama/static_attention.py
+++ b/examples/models/llama/static_attention.py
@@ -632,6 +632,8 @@ class StaticAttentionIOManager:
         return y, attn_updates
 
     def _update_states(self, attn_updates, update_pos, update_len):
+        if attn_updates["out_cache_state"] is None:
+            return
         for mask in self._masks.values():
             mask.unmask(update_len)
         k_cache_updates, v_cache_updates = attn_updates["out_cache_state"]


### PR DESCRIPTION
Summary: There's a discrepancy in the SDPA impl when computing w/wo paddings as invalid cache, even it's masked out. For verification purposes, we need to test eager model without paddings to match results with QAT model. The change is to handle cases where `cache_len == 0`, preventing crashes in cache updates.

Differential Revision: D90526985


