### PR TITLE
Add prefill/decode multifunction support in ET

### DIFF
--- a/backends/apple/coreml/runtime/delegate/ETCoreMLModelManager.h
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLModelManager.h
@@ -50,6 +50,27 @@ __attribute__((objc_subclassing_restricted))
                        configuration:(MLModelConfiguration*)configuration
                                error:(NSError* __autoreleasing*)error;
 
+/// Loads the model from the AOT data with an optional method name for multifunction model support.
+///
+/// The data is the AOT blob stored in the executorch Program. The method first parses the model
+/// metadata stored in the blob and extracts the identifier. For multifunction CoreML models,
+/// the methodName is used to populate the correct input/output names from the method's metadata,
+/// while functionName specifies the CoreML function to invoke (via MLModelConfiguration.functionName).
+/// The method/function names are NOT included in the cache key since the multifunction
+/// model contains all functions and should only be compiled once.
+///
+/// @param data The AOT blob data.
+/// @param configuration The model configuration that will be used to load the model.
+/// @param methodName Optional method name (e.g., "forward", "prefill") for metadata lookup.
+/// @param functionName Optional CoreML function name to invoke. If nil, methodName is used.
+/// @param error   On failure, error is filled with the failure information.
+/// @retval An opaque handle that points to the loaded model.
+- (ModelHandle*)loadModelFromAOTData:(NSData*)data
+                       configuration:(MLModelConfiguration*)configuration
+                          methodName:(nullable NSString*)methodName
+                        functionName:(nullable NSString*)functionName
+                               error:(NSError* __autoreleasing*)error;
+
 /// Executes the loaded model.
 ///
 /// @param handle The handle to the loaded model.

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLStrings.mm
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLStrings.mm
@@ -112,7 +112,7 @@
                 result = [paths.lastObject stringByAppendingPathComponent:self.productName];
             }
         });
-        
+
         return result;
     #endif
 }
@@ -126,7 +126,7 @@
         dispatch_once(&onceToken, ^{
             result = [NSTemporaryDirectory() stringByAppendingPathComponent:self.productName];
         });
-        
+
         return result;
     #endif
 }

--- a/backends/apple/coreml/runtime/delegate/backend_delegate.h
+++ b/backends/apple/coreml/runtime/delegate/backend_delegate.h
@@ -72,9 +72,15 @@ public:
     ///
     /// @param processed The AOT blob.
     /// @param specs The specs at the time of compilation.
+    /// @param method_name The ExecuTorch method name for metadata lookup (optional, may be nullptr).
+    /// @param function_name The CoreML function name to invoke (optional, may be nullptr).
+    ///                      If nullptr, method_name is used as the function name.
     /// @retval An opaque handle to the initialized blob or `nullptr` if the
     /// initialization failed.
-    virtual Handle* init(Buffer processed, const std::unordered_map<std::string, Buffer>& specs) const noexcept = 0;
+    virtual Handle* init(Buffer processed,
+                         const std::unordered_map<std::string, Buffer>& specs,
+                         const char* method_name = nullptr,
+                         const char* function_name = nullptr) const noexcept = 0;
 
     /// Must execute the CoreML model with the specified handle.
     ///

--- a/backends/apple/coreml/runtime/delegate/model_metadata.h
+++ b/backends/apple/coreml/runtime/delegate/model_metadata.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#import <map>
 #import <string>
 #import <vector>
 
@@ -14,9 +15,25 @@
 
 namespace executorchcoreml {
 
+/// A struct representing per-method metadata (for multifunction models).
+struct MethodMetadata {
+    /// Constructs a `MethodMetadata` instance.
+    /// @param input_names The input names for the method.
+    /// @param output_names The output names for the method.
+    inline MethodMetadata(std::vector<std::string> input_names, std::vector<std::string> output_names) noexcept
+        : input_names(std::move(input_names)), output_names(std::move(output_names)) { }
+
+    inline MethodMetadata() noexcept { }
+
+    /// Input names of the method.
+    std::vector<std::string> input_names;
+    /// Output names of the method.
+    std::vector<std::string> output_names;
+};
+
 /// A struct representing a model's metadata.
 struct ModelMetadata {
-    /// Constructs a `ModelMetada` instance.
+    /// Constructs a `ModelMetada` instance (for single-method models).
     /// @param identifier The unique identifier.
     /// @param input_names The input names for the model.
     /// @param output_names   The output names for the model.
@@ -29,7 +46,37 @@ struct ModelMetadata {
     inline ModelMetadata() noexcept { }
 
     /// Returns `true` if the metadata is valid otherwise `false`.
-    inline bool is_valid() const noexcept { return !identifier.empty() && !output_names.empty(); }
+    inline bool is_valid() const noexcept {
+        if (identifier.empty()) {
+            return false;
+        }
+
+        if (is_multifunction()) {
+            // For multifunction models, every method must have outputs
+            for (const auto& [name, method]: methods) {
+                if (method.output_names.empty()) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        // For single-method models, check output_names directly
+        return !output_names.empty();
+    }
+
+    /// Returns `true` if this is multifunction metadata (has methods).
+    inline bool is_multifunction() const noexcept { return !methods.empty(); }
+
+    /// Get metadata for a specific method. Returns nullptr if method not found.
+    /// For single-method models, returns nullptr (use input_names/output_names directly).
+    inline const MethodMetadata* get_method_metadata(const std::string& method_name) const noexcept {
+        auto it = methods.find(method_name);
+        if (it != methods.end()) {
+            return &it->second;
+        }
+        return nullptr;
+    }
 
     inline std::string to_json_string() const noexcept { return executorchcoreml::serde::json::to_json_string(*this); }
 
@@ -39,9 +86,11 @@ struct ModelMetadata {
 
     /// Unique identifier.
     std::string identifier;
-    /// Input names of the model.
+    /// Input names of the model (for single-method models).
     std::vector<std::string> input_names;
-    /// Output names of the model.
+    /// Output names of the model (for single-method models).
     std::vector<std::string> output_names;
+    /// Per-method metadata (for multifunction models).
+    std::map<std::string, MethodMetadata> methods;
 };
 } // namespace executorchcoreml

--- a/backends/apple/coreml/test/test_coreml_multifunction.py
+++ b/backends/apple/coreml/test/test_coreml_multifunction.py
@@ -1,0 +1,334 @@
+# Copyright © 2024 Apple Inc. All rights reserved.
+#
+# Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+import platform
+import sys
+import unittest
+
+import coremltools as ct
+import torch
+
+from executorch.backends.apple.coreml.compiler.coreml_preprocess import (
+    CoreMLBackend,
+    MULTIMETHOD_WEIGHT_SHARING_STRATEGY,
+)
+from executorch.backends.apple.coreml.partition import CoreMLPartitioner
+from executorch.exir import EdgeCompileConfig, to_edge_transform_and_lower
+
+
+def is_fbcode():
+    return not hasattr(torch.version, "git_version")
+
+
+def _macos_version_at_least(major: int, minor: int = 0) -> bool:
+    """Check if the current macOS version is at least major.minor."""
+    if sys.platform != "darwin":
+        return False
+    try:
+        version = platform.mac_ver()[0]
+        if not version:
+            return False
+        parts = version.split(".")
+        current_major = int(parts[0])
+        current_minor = int(parts[1]) if len(parts) > 1 else 0
+        return (current_major, current_minor) >= (major, minor)
+    except (ValueError, IndexError):
+        return False
+
+
+# Multifunction CoreML models require macOS 15+ / iOS 18+
+_TEST_RUNTIME = (
+    sys.platform == "darwin" and not is_fbcode() and _macos_version_at_least(15, 0)
+)
+if _TEST_RUNTIME:
+    from executorch.runtime import Runtime
+
+
+class TestCoreMLMultifunction(unittest.TestCase):
+    """Tests for multifunction (multi-method) CoreML model export."""
+
+    edge_compile_config = EdgeCompileConfig(_check_ir_validity=False)
+
+    def _get_compile_specs(self, weight_sharing: bool = True):
+        """Get compile specs for multifunction models."""
+        compile_specs = CoreMLBackend.generate_compile_specs(
+            minimum_deployment_target=ct.target.iOS18,
+            compute_precision=ct.precision.FLOAT32,
+            compute_unit=ct.ComputeUnit.CPU_ONLY,
+            model_type=CoreMLBackend.MODEL_TYPE.MODEL,
+        )
+        if weight_sharing:
+            compile_specs.append(
+                CoreMLBackend.generate_multimethod_weight_sharing_strategy_compile_spec(
+                    MULTIMETHOD_WEIGHT_SHARING_STRATEGY.POSITIONAL
+                )
+            )
+        return compile_specs
+
+    def test_multifunction_simple_model(self):
+        """Test exporting a simple model with multiple methods (forward and prefill)."""
+
+        class SimpleModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(16, 16)
+
+            def forward(self, x):
+                return self.linear(x)
+
+        model = SimpleModel()
+        model.eval()
+
+        # Create example inputs for two different sequence lengths
+        decode_inputs = (torch.randn(1, 1, 16),)  # seqlen=1
+        prefill_inputs = (torch.randn(1, 8, 16),)  # seqlen=8
+
+        # Export both methods
+        decode_ep = torch.export.export(model, decode_inputs)
+        prefill_ep = torch.export.export(model, prefill_inputs)
+
+        # Create partitioner with multifunction support
+        partitioner = CoreMLPartitioner(
+            compile_specs=self._get_compile_specs(weight_sharing=True),
+        )
+
+        # Lower to edge with multiple methods
+        edge_manager = to_edge_transform_and_lower(
+            {"forward": decode_ep, "prefill": prefill_ep},
+            partitioner=[partitioner],
+            compile_config=self.edge_compile_config,
+        )
+
+        # Verify both methods exist
+        method_names = edge_manager.methods
+        self.assertIn("forward", method_names)
+        self.assertIn("prefill", method_names)
+
+        # Convert to ExecuTorch
+        et_program = edge_manager.to_executorch()
+
+        if _TEST_RUNTIME:
+            # Test runtime execution
+            runtime = Runtime.get()
+            program = runtime.load_program(et_program.buffer)
+
+            # Check both methods are available
+            available_methods = program.method_names
+            self.assertIn("forward", available_methods)
+            self.assertIn("prefill", available_methods)
+
+            # Test forward (decode) method
+            forward_method = program.load_method("forward")
+            decode_output = forward_method.execute(decode_inputs)
+            expected_decode = model(*decode_inputs)
+            self.assertTrue(
+                torch.allclose(decode_output[0], expected_decode, atol=1e-4, rtol=1e-4)
+            )
+
+            # Test prefill method
+            prefill_method = program.load_method("prefill")
+            prefill_output = prefill_method.execute(prefill_inputs)
+            expected_prefill = model(*prefill_inputs)
+            self.assertTrue(
+                torch.allclose(
+                    prefill_output[0], expected_prefill, atol=1e-4, rtol=1e-4
+                )
+            )
+
+    def test_multifunction_with_kv_cache(self):
+        """Test multifunction export with KV cache-like buffers."""
+
+        class ModelWithCache(torch.nn.Module):
+            def __init__(self, hidden_dim: int, cache_len: int):
+                super().__init__()
+                self.linear = torch.nn.Linear(hidden_dim, hidden_dim)
+                self.hidden_dim = hidden_dim
+                self.cache_len = cache_len
+
+            def forward(self, x, cache):
+                # x: [batch, seqlen, hidden_dim]
+                # cache: [batch, cache_len, hidden_dim]
+                out = self.linear(x)
+                # Simple cache update simulation
+                new_cache = torch.cat([cache[:, 1:, :], out[:, -1:, :]], dim=1)
+                return out, new_cache
+
+        hidden_dim = 16
+        cache_len = 32
+        model = ModelWithCache(hidden_dim, cache_len)
+        model.eval()
+
+        # Decode: seqlen=1
+        decode_inputs = (
+            torch.randn(1, 1, hidden_dim),
+            torch.randn(1, cache_len, hidden_dim),
+        )
+
+        # Prefill: seqlen=8
+        prefill_inputs = (
+            torch.randn(1, 8, hidden_dim),
+            torch.randn(1, cache_len, hidden_dim),
+        )
+
+        decode_ep = torch.export.export(model, decode_inputs)
+        prefill_ep = torch.export.export(model, prefill_inputs)
+
+        partitioner = CoreMLPartitioner(
+            compile_specs=self._get_compile_specs(weight_sharing=True),
+        )
+
+        edge_manager = to_edge_transform_and_lower(
+            {"forward": decode_ep, "prefill": prefill_ep},
+            partitioner=[partitioner],
+            compile_config=self.edge_compile_config,
+        )
+
+        et_program = edge_manager.to_executorch()
+
+        if _TEST_RUNTIME:
+            runtime = Runtime.get()
+            program = runtime.load_program(et_program.buffer)
+
+            # Test decode
+            forward_method = program.load_method("forward")
+            decode_output = forward_method.execute(decode_inputs)
+            expected_out, expected_cache = model(*decode_inputs)
+            self.assertTrue(
+                torch.allclose(decode_output[0], expected_out, atol=1e-4, rtol=1e-4)
+            )
+            self.assertTrue(
+                torch.allclose(decode_output[1], expected_cache, atol=1e-4, rtol=1e-4)
+            )
+
+            # Test prefill
+            prefill_method = program.load_method("prefill")
+            prefill_output = prefill_method.execute(prefill_inputs)
+            expected_out, expected_cache = model(*prefill_inputs)
+            self.assertTrue(
+                torch.allclose(prefill_output[0], expected_out, atol=1e-4, rtol=1e-4)
+            )
+            self.assertTrue(
+                torch.allclose(prefill_output[1], expected_cache, atol=1e-4, rtol=1e-4)
+            )
+
+    def test_multifunction_without_weight_sharing(self):
+        """Test multifunction export without weight sharing."""
+
+        class SimpleModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(16, 16)
+
+            def forward(self, x):
+                return self.linear(x)
+
+        model = SimpleModel()
+        model.eval()
+
+        decode_inputs = (torch.randn(1, 1, 16),)
+        prefill_inputs = (torch.randn(1, 8, 16),)
+
+        decode_ep = torch.export.export(model, decode_inputs)
+        prefill_ep = torch.export.export(model, prefill_inputs)
+
+        # Create partitioner without weight sharing
+        compile_specs = CoreMLBackend.generate_compile_specs(
+            minimum_deployment_target=ct.target.iOS18,
+            compute_precision=ct.precision.FLOAT32,
+            compute_unit=ct.ComputeUnit.CPU_ONLY,
+            model_type=CoreMLBackend.MODEL_TYPE.MODEL,
+        )
+        compile_specs.append(
+            CoreMLBackend.generate_multimethod_weight_sharing_strategy_compile_spec(
+                MULTIMETHOD_WEIGHT_SHARING_STRATEGY.DISABLED
+            )
+        )
+
+        partitioner = CoreMLPartitioner(compile_specs=compile_specs)
+
+        edge_manager = to_edge_transform_and_lower(
+            {"forward": decode_ep, "prefill": prefill_ep},
+            partitioner=[partitioner],
+            compile_config=self.edge_compile_config,
+        )
+
+        method_names = edge_manager.methods
+        self.assertIn("forward", method_names)
+        self.assertIn("prefill", method_names)
+
+        et_program = edge_manager.to_executorch()
+
+        if _TEST_RUNTIME:
+            runtime = Runtime.get()
+            program = runtime.load_program(et_program.buffer)
+
+            forward_method = program.load_method("forward")
+            decode_output = forward_method.execute(decode_inputs)
+            expected_decode = model(*decode_inputs)
+            self.assertTrue(
+                torch.allclose(decode_output[0], expected_decode, atol=1e-4, rtol=1e-4)
+            )
+
+    def test_multifunction_with_constant_methods(self):
+        """Test multifunction export with constant methods (metadata)."""
+
+        class SimpleModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(16, 16)
+
+            def forward(self, x):
+                return self.linear(x)
+
+        model = SimpleModel()
+        model.eval()
+
+        decode_inputs = (torch.randn(1, 1, 16),)
+        prefill_inputs = (torch.randn(1, 8, 16),)
+
+        decode_ep = torch.export.export(model, decode_inputs)
+        prefill_ep = torch.export.export(model, prefill_inputs)
+
+        partitioner = CoreMLPartitioner(
+            compile_specs=self._get_compile_specs(weight_sharing=True),
+        )
+
+        # Add constant methods (metadata)
+        constant_methods = {
+            "vocab_size": 32000,
+            "hidden_dim": 16,
+            "decode_seqlen": 1,
+            "prefill_seqlen": 8,
+        }
+
+        edge_manager = to_edge_transform_and_lower(
+            {"forward": decode_ep, "prefill": prefill_ep},
+            partitioner=[partitioner],
+            constant_methods=constant_methods,
+            compile_config=self.edge_compile_config,
+        )
+
+        et_program = edge_manager.to_executorch()
+
+        if _TEST_RUNTIME:
+            runtime = Runtime.get()
+            program = runtime.load_program(et_program.buffer)
+
+            # Check all methods are available (executable + constant)
+            available_methods = program.method_names
+            self.assertIn("forward", available_methods)
+            self.assertIn("prefill", available_methods)
+            self.assertIn("vocab_size", available_methods)
+            self.assertIn("hidden_dim", available_methods)
+            self.assertIn("decode_seqlen", available_methods)
+            self.assertIn("prefill_seqlen", available_methods)
+
+
+if __name__ == "__main__":
+    test_runner = TestCoreMLMultifunction()
+    test_runner.test_multifunction_simple_model()
+    test_runner.test_multifunction_with_kv_cache()
+    test_runner.test_multifunction_without_weight_sharing()
+    test_runner.test_multifunction_with_constant_methods()
+    print("All tests passed!")

--- a/examples/apple/coreml/llama/export_static_llm_coreml.py
+++ b/examples/apple/coreml/llama/export_static_llm_coreml.py
@@ -27,7 +27,10 @@ import torch
 import torch.nn as nn
 import torch.utils._pytree as pytree
 
-from executorch.backends.apple.coreml.compiler import CoreMLBackend
+from executorch.backends.apple.coreml.compiler.coreml_preprocess import (
+    CoreMLBackend,
+    MULTIMETHOD_WEIGHT_SHARING_STRATEGY,
+)
 from executorch.backends.apple.coreml.partition import CoreMLPartitioner
 from executorch.examples.apple.coreml.llama.utils import (
     replace_linear_with_split_linear,
@@ -90,26 +93,41 @@ class BlockWithGraphBreak(nn.Module):
 
 
 def remove_graph_break_(edge_manager):
+    """Remove graph break ops from all methods in the edge manager."""
     from executorch.exir.dialects._ops import ops as exir_ops
 
-    for n in edge_manager.exported_program().graph_module.graph.nodes:
-        if n.target == exir_ops.edge.executorch_utils.graph_break.Tensor:
-            n.replace_all_uses_with(n.args[0])
-    edge_manager.exported_program().graph_module.graph.eliminate_dead_code()
+    # Get all method names
+    method_names = edge_manager.methods
+    for method_name in method_names:
+        ep = edge_manager.exported_program(method_name)
+        for n in ep.graph_module.graph.nodes:
+            if n.target == exir_ops.edge.executorch_utils.graph_break.Tensor:
+                n.replace_all_uses_with(n.args[0])
+        ep.graph_module.graph.eliminate_dead_code()
 
 
-def load_model(checkpoint_path: str, params_path: str, max_context_len: int):
-    """Load the model from checkpoint with static_mha attention type."""
+def load_model(
+    checkpoint_path: str,
+    params_path: str,
+    max_context_len: int,
+    generate_full_logits: bool = True,
+):
+    """Load the model from checkpoint with static_mha attention type.
+
+    Args:
+        checkpoint_path: Path to the model checkpoint (.pth)
+        params_path: Path to params.json
+        max_context_len: Maximum context length
+        generate_full_logits: If True, output logits for all tokens (needed for
+            lookahead decoding). If False, only output logits for the last token
+            (more efficient for standard autoregressive generation).
+    """
     with open(params_path, "r") as f:
         params = json.loads(f.read())
 
-    # TODO: to support lookahead decoding, the static model outputs
-    # full logits, but if we are not using lookahead decoding, we can have a
-    # more efficient model by setting generate_full_logits=False and supplying the last
-    # valid token
     args = ModelArgs(
         max_context_len=max_context_len,
-        generate_full_logits=True,
+        generate_full_logits=generate_full_logits,
         **params,
     )
     args.attention_type = "static_mha"
@@ -150,6 +168,59 @@ def load_model(checkpoint_path: str, params_path: str, max_context_len: int):
         print(f"Unexpected keys: {unexpected}")
 
     return model, args
+
+
+def _create_example_inputs(
+    model_args, input_len, max_context_len, float_dtype, cache_len=None
+):
+    """
+    Create example inputs for a given input length.
+
+    Args:
+        model_args: Model configuration arguments
+        input_len: Sequence length for this forward pass
+        max_context_len: Maximum context length
+        float_dtype: Float dtype (torch.float16 or torch.float32)
+        cache_len: Optional cache length override. If None, uses max_context_len - input_len.
+
+    Returns:
+        Tuple of (example_inputs, cache_len) where example_inputs is the tuple
+        expected by the model's forward method.
+    """
+    if cache_len is None:
+        cache_len = max_context_len - input_len
+
+    mgr = StaticAttentionIOManager(
+        model_args,
+        input_len=input_len,
+        cache_lens=cache_len,
+        batch_size=1,
+        dtype=float_dtype,
+        style="smart_mask",
+        mask_val=float("-inf"),
+    )
+
+    options = {
+        "masks": mgr.masks,
+        "freqs_cos_override": mgr.freqs_cos[:input_len],
+        "freqs_sin_override": mgr.freqs_sin[:input_len],
+        "in_cache_state": (mgr.k_caches, mgr.v_caches),
+    }
+
+    # When generate_full_logits=False, we need to pass last_valid_token_pos
+    # to tell the model which position's logits to output.
+    # This is the index of the last real token (before any padding).
+    if not model_args.generate_full_logits:
+        options["last_valid_token_pos"] = torch.tensor(
+            [input_len - 1], dtype=torch.long
+        )
+
+    example_inputs = (
+        torch.zeros(1, input_len, dtype=torch.int32),
+        options,
+    )
+
+    return example_inputs, cache_len
 
 
 def _get_metadata(model_args, example_inputs, input_len, cache_len, float_dtype):
@@ -320,11 +391,29 @@ def main():
         help="Disable graph breaks between transformer blocks",
     )
 
+    # Export mode options
+    parser.add_argument(
+        "--multifunction",
+        action="store_true",
+        help="Export as multifunction model with separate prefill (seqlen=input_len) "
+        "and decode (seqlen=1) methods. Weight sharing is enabled across methods. "
+        "When disabled, exports a single-method model with fixed seqlen=input_len "
+        "and generate_full_logits=True for lookahead decoding support.",
+    )
+
     args = parser.parse_args()
 
     # Compute cache length
 
-    print("Quantization and datatype:")
+    print("Export mode:")
+    if args.multifunction:
+        print(
+            "\tMultifunction: separate prefill/decode graphs, generate_full_logits=False"
+        )
+    else:
+        print("\tSingle method: fixed seqlen, generate_full_logits=True (lookahead)")
+
+    print("\nQuantization and datatype:")
     print(f"\tEmbedding quantize: {args.embedding_quantize}")
     print(f"\tLinear quantize: {args.linear_quantize}")
     print(f"\tDtype: {args.dtype}")
@@ -340,11 +429,15 @@ def main():
     print(f"\tMax splits: {args.max_splits}")
 
     # Load model
+    # For multifunction: generate_full_logits=False (efficient, only last token)
+    # For single method: generate_full_logits=True (needed for lookahead decoding)
+    generate_full_logits = not args.multifunction
     print(f"\nLoading model from {args.checkpoint}...")
     model, model_args = load_model(
         args.checkpoint,
         args.params,
         args.max_context_len,
+        generate_full_logits=generate_full_logits,
     )
     print(f"Model loaded: {model_args.n_layers} layers, {model_args.dim} dim")
 
@@ -413,73 +506,192 @@ def main():
             model.layers[n_layers - 1], break_before=False
         )
 
-    # Create IO manager and example inputs
-    mgr = StaticAttentionIOManager(
-        model_args,
-        input_len=args.input_len,
-        cache_lens=cache_len,
-        batch_size=1,
-        dtype=float_dtype,
-        style="smart_mask",  # Use smart_mask to match C++ StaticTransformerRunner
-        mask_val=float("-inf"),
-    )
-    example_inputs = (
-        torch.zeros(1, args.input_len, dtype=torch.int32),
-        {
-            "masks": mgr.masks,
-            "freqs_cos_override": mgr.freqs_cos[: args.input_len],
-            "freqs_sin_override": mgr.freqs_sin[: args.input_len],
-            "in_cache_state": (mgr.k_caches, mgr.v_caches),
-        },
-    )
+    if args.multifunction:
+        # Multifunction mode: separate prefill and decode graphs with weight sharing
+        # Both methods use the same cache_len (decode's cache size) so they can share
+        # the same cache buffer at runtime without any copying.
+        decode_input_len = 1
+        prefill_input_len = args.input_len  # default 32
+        shared_cache_len = (
+            args.max_context_len - decode_input_len
+        )  # Use decode's cache size for both
 
-    # Test eager execution
-    print("\nTesting eager execution...")
-    with torch.no_grad():
-        model(*example_inputs)
-    print("Eager execution successful!")
+        print(f"\nShared cache length for prefill/decode: {shared_cache_len}")
 
-    # Export the model
-    print("\nExporting model...")
-    ep = torch.export.export(model, example_inputs)
-    print("Export successful!")
-    print(ep)
+        print(f"\nCreating example inputs for decode (seqlen={decode_input_len})...")
+        decode_inputs, decode_cache_len = _create_example_inputs(
+            model_args,
+            decode_input_len,
+            args.max_context_len,
+            float_dtype,
+            cache_len=shared_cache_len,
+        )
 
-    # Generate metadata for C++ runner
-    print("\nGenerating metadata for C++ runner...")
-    constant_methods = _get_metadata(
-        model_args, example_inputs, args.input_len, cache_len, float_dtype
-    )
+        print(f"Creating example inputs for prefill (seqlen={prefill_input_len})...")
+        prefill_inputs, prefill_cache_len = _create_example_inputs(
+            model_args,
+            prefill_input_len,
+            args.max_context_len,
+            float_dtype,
+            cache_len=shared_cache_len,
+        )
 
-    # Setup CoreML partitioner
-    print("\nSetting up CoreML partitioner...")
-    compile_specs = CoreMLBackend.generate_compile_specs(
-        minimum_deployment_target=ct.target.iOS18,
-        compute_precision={
-            torch.float16: ct.precision.FLOAT16,
-            torch.float32: ct.precision.FLOAT32,
-        }[float_dtype],
-        compute_unit=ct.ComputeUnit.CPU_AND_NE,
-        model_type=CoreMLBackend.MODEL_TYPE.MODEL,
-    )
-    partitioner = CoreMLPartitioner(
-        compile_specs=compile_specs,
-        take_over_mutable_buffer=False,
-        skip_ops_for_coreml_delegation=[],
-    )
+        # Test eager execution for both
+        print("\nTesting eager execution (decode, seqlen=1)...")
+        with torch.no_grad():
+            model(*decode_inputs)
+        print("Decode eager execution successful!")
 
-    # Lower to edge with constant methods for C++ runner
-    print("\nLowering to edge...")
-    edge_compile_config = EdgeCompileConfig(_check_ir_validity=False)
-    edge_manager = to_edge_transform_and_lower(
-        ep,
-        partitioner=[partitioner],
-        constant_methods=constant_methods,
-        compile_config=edge_compile_config,
-    )
+        print(f"\nTesting eager execution (prefill, seqlen={prefill_input_len})...")
+        with torch.no_grad():
+            model(*prefill_inputs)
+        print("Prefill eager execution successful!")
 
-    print("\nDelegated program:")
-    print(format_delegated_graph(edge_manager.exported_program().graph_module))
+        # Export both graphs
+        print("\nExporting decode model (seqlen=1)...")
+        decode_ep = torch.export.export(model, decode_inputs)
+        print("Decode export successful!")
+        print(decode_ep)
+
+        print(f"\nExporting prefill model (seqlen={prefill_input_len})...")
+        prefill_ep = torch.export.export(model, prefill_inputs)
+        print("Prefill export successful!")
+        print(prefill_ep)
+
+        # Generate metadata for C++ runner
+        # constant_methods are shared across all methods, so we prefix method-specific
+        # metadata with the method name
+        print("\nGenerating metadata for C++ runner...")
+        decode_metadata = _get_metadata(
+            model_args, decode_inputs, decode_input_len, decode_cache_len, float_dtype
+        )
+        prefill_metadata = _get_metadata(
+            model_args,
+            prefill_inputs,
+            prefill_input_len,
+            prefill_cache_len,
+            float_dtype,
+        )
+
+        # Combine metadata - shared values go without prefix, method-specific values get prefixed
+        constant_methods = {
+            # Shared metadata (same for both methods)
+            "vocab_size": decode_metadata["vocab_size"],
+            "head_dim": decode_metadata["head_dim"],
+            "n_heads_per_cache": decode_metadata["n_heads_per_cache"],
+            "freqs_cos": decode_metadata["freqs_cos"],
+            "freqs_sin": decode_metadata["freqs_sin"],
+            # Decode-specific metadata (forward method)
+            "decode_input_len": decode_metadata["forward_input_len"],
+            "decode_freqs_cos_input_index": decode_metadata["freqs_cos_input_index"],
+            "decode_freqs_sin_input_index": decode_metadata["freqs_sin_input_index"],
+            "decode_mask_specs": decode_metadata["mask_specs"],
+            "decode_kv_cache_specs": decode_metadata["kv_cache_specs"],
+            # Prefill-specific metadata
+            "prefill_input_len": prefill_metadata["forward_input_len"],
+            "prefill_freqs_cos_input_index": prefill_metadata["freqs_cos_input_index"],
+            "prefill_freqs_sin_input_index": prefill_metadata["freqs_sin_input_index"],
+            "prefill_mask_specs": prefill_metadata["mask_specs"],
+            "prefill_kv_cache_specs": prefill_metadata["kv_cache_specs"],
+        }
+
+        # Setup CoreML partitioner with multimethod weight sharing
+        print("\nSetting up CoreML partitioner (multifunction with weight sharing)...")
+        compile_specs = CoreMLBackend.generate_compile_specs(
+            minimum_deployment_target=ct.target.iOS18,
+            compute_precision={
+                torch.float16: ct.precision.FLOAT16,
+                torch.float32: ct.precision.FLOAT32,
+            }[float_dtype],
+            compute_unit=ct.ComputeUnit.CPU_AND_NE,
+            model_type=CoreMLBackend.MODEL_TYPE.MODEL,
+        )
+        compile_specs.append(
+            CoreMLBackend.generate_multimethod_weight_sharing_strategy_compile_spec(
+                MULTIMETHOD_WEIGHT_SHARING_STRATEGY.POSITIONAL
+            )
+        )
+        partitioner = CoreMLPartitioner(
+            compile_specs=compile_specs,
+            take_over_mutable_buffer=False,
+            skip_ops_for_coreml_delegation=[],
+        )
+
+        # Lower to edge with both decode and prefill methods
+        print("\nLowering to edge (multi-method: decode + prefill)...")
+        edge_compile_config = EdgeCompileConfig(_check_ir_validity=False)
+
+        # Create multi-method edge manager with decode as "forward" and prefill as "prefill"
+        edge_manager = to_edge_transform_and_lower(
+            {"forward": decode_ep, "prefill": prefill_ep},
+            partitioner=[partitioner],
+            constant_methods=constant_methods,
+            compile_config=edge_compile_config,
+        )
+
+        print("\nDelegated program (decode/forward):")
+        print(format_delegated_graph(edge_manager.exported_program().graph_module))
+
+        print("\nDelegated program (prefill):")
+        print(
+            format_delegated_graph(
+                edge_manager.exported_program("prefill").graph_module
+            )
+        )
+    else:
+        # Single method mode: fixed seqlen with generate_full_logits=True for lookahead
+        print(f"\nCreating example inputs (seqlen={args.input_len})...")
+        example_inputs, example_cache_len = _create_example_inputs(
+            model_args, args.input_len, args.max_context_len, float_dtype
+        )
+
+        # Test eager execution
+        print("\nTesting eager execution...")
+        with torch.no_grad():
+            model(*example_inputs)
+        print("Eager execution successful!")
+
+        # Export the model
+        print("\nExporting model...")
+        ep = torch.export.export(model, example_inputs)
+        print("Export successful!")
+        print(ep)
+
+        # Generate metadata for C++ runner
+        print("\nGenerating metadata for C++ runner...")
+        constant_methods = _get_metadata(
+            model_args, example_inputs, args.input_len, example_cache_len, float_dtype
+        )
+
+        # Setup CoreML partitioner
+        print("\nSetting up CoreML partitioner...")
+        compile_specs = CoreMLBackend.generate_compile_specs(
+            minimum_deployment_target=ct.target.iOS18,
+            compute_precision={
+                torch.float16: ct.precision.FLOAT16,
+                torch.float32: ct.precision.FLOAT32,
+            }[float_dtype],
+            compute_unit=ct.ComputeUnit.CPU_AND_NE,
+            model_type=CoreMLBackend.MODEL_TYPE.MODEL,
+        )
+        partitioner = CoreMLPartitioner(
+            compile_specs=compile_specs,
+            take_over_mutable_buffer=False,
+            skip_ops_for_coreml_delegation=[],
+        )
+
+        # Lower to edge with constant methods for C++ runner
+        print("\nLowering to edge...")
+        edge_compile_config = EdgeCompileConfig(_check_ir_validity=False)
+        edge_manager = to_edge_transform_and_lower(
+            ep,
+            partitioner=[partitioner],
+            constant_methods=constant_methods,
+            compile_config=edge_compile_config,
+        )
+
+        print("\nDelegated program:")
+        print(format_delegated_graph(edge_manager.exported_program().graph_module))
 
     # Convert to ExecuTorch
     print("\nConverting to ExecuTorch...")

--- a/examples/apple/coreml/llama/readme.md
+++ b/examples/apple/coreml/llama/readme.md
@@ -1,6 +1,10 @@
 # ANE-friendly Llama models
 
-To export a static, ANE-friendly model use:
+The export script supports two modes: **single method** (default) and **multifunction**.
+
+## Single Method Export (Default)
+
+Exports a model with a fixed sequence length and `generate_full_logits=True`, which is required for lookahead decoding:
 
 ```
 python export_static_llm_coreml.py \
@@ -23,11 +27,73 @@ python run_static_llm.py \
 
 (Enabling lookahead decoding is optional, but does improve performance.)
 
+## Multifunction Export
+
+Exports a model with separate prefill (seqlen=input_len) and decode (seqlen=1) methods. This mode enables weight sharing across methods and uses `generate_full_logits=False` for more efficient autoregressive generation:
+
+```
+python export_static_llm_coreml.py \
+    --checkpoint /path/to/model.pth \
+    --params /path/to/params.json \
+    --output static_llm_coreml_multifunction.pte \
+    --multifunction
+```
+
+To test the multifunction model in python:
+
+```
+python run_static_llm_multifunction.py \
+    --model static_llm_coreml_multifunction.pte \
+    --params /path/to/params.json \
+    --tokenizer /path/to/tokenizer.model \
+    --prompt "Once upon a time" \
+    --max_new_tokens 100
+```
+
+Key differences between the two modes:
+* **Single method**: Uses fixed seqlen for both prefill and decode, outputs full logits (supports lookahead decoding)
+* **Multifunction**: Separate optimized graphs for prefill (seqlen=input_len) and decode (seqlen=1), outputs only last token logits (more efficient for standard generation), enables CoreML multifunction weight sharing
+
+## Export Options
+
+### Model Paths
+| Option | Default | Description |
+|--------|---------|-------------|
+| `-c`, `--checkpoint` | (required) | Path to model checkpoint (.pth) |
+| `-p`, `--params` | (required) | Path to params.json |
+| `-o`, `--output` | `model.pte` | Output filename for the .pte model |
+
+### Model Configuration
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--max_context_len` | 1024 | Maximum context length |
+| `--input_len` | 32 | Input sequence length per forward pass. In multifunction mode, this is the prefill sequence length. |
+| `--dtype` | `fp16` | Model dtype (`fp16` or `fp32`). The ANE requires fp16. |
+
+### Quantization Options
+| Option | Default | Description |
+|--------|---------|-------------|
+| `-E`, `--embedding_quantize` | `8,0` | Embedding quantization: `<bitwidth>,<groupsize>`, e.g., `4,32` for 4-bit with group size 32, or `8,0` for 8-bit per-channel |
+| `--linear_quantize` | `c4w` | CoreML linear quantization: `b4w` (blockwise 4-bit) or `c4w` (channelwise 4-bit). The ANE requires channelwise. |
+
+### Linear Splitting Options
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--target_split_size` | 1024 | Split linear layers into chunks of this size (helps with ANE performance) |
+| `--max_splits` | 8 | Maximum number of splits for linear layers |
+
+### Export Mode Options
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--multifunction` | disabled | Export as multifunction model with separate prefill (seqlen=input_len) and decode (seqlen=1) methods. Enables weight sharing across methods. |
+| `--no_graph_breaks` | disabled | Disable graph breaks between transformer blocks. Graph breaks help improve ANE performance by keeping model pieces smaller. |
+
+## ANE Optimizations
+
 The static model has several ANE optimizations, including:
 * Splitting linear layers for improved performance (controlled by target_split_size and max_splits args)
 * Splitting the pte into multiple Core ML pieces for improved performance (can be disabled with no_graph_breaks)
-* Re-writing SDPA to avoid 5-D tensors to imporve performance.  This also fixes an accuracy bug that was introduced in iOS 26 (addresses this: https://github.com/pytorch/executorch/issues/15833)
-
+* Re-writing SDPA to avoid 5-D tensors to improve performance.  This also fixes an accuracy bug that was introduced in iOS 26 (addresses this: https://github.com/pytorch/executorch/issues/15833)
 
 We are working on adding a C++ runner as well.
 

--- a/examples/apple/coreml/llama/run_static_llm_multifunction.py
+++ b/examples/apple/coreml/llama/run_static_llm_multifunction.py
@@ -1,0 +1,507 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Run script for multifunction static attention Llama models exported with coreml_static_llama.py.
+
+This script tests multifunction CoreML models that have separate "forward" (decode) and
+"prefill" methods sharing weights.
+
+Usage:
+    python run_static_llm_multifunction.py \
+        --model $HOME/Desktop/multifunction_test.pte \
+        --params $HOME/models/llama1b/params.json \
+        --tokenizer $HOME/models/llama1b/tokenizer.model \
+        --prompt "Once upon a time" \
+        --max_new_tokens 100
+"""
+
+import argparse
+import json
+import time
+from typing import Any, Dict, List, Tuple
+
+import torch
+import torch.utils._pytree as pytree
+
+from executorch.examples.models.llama.model_args import ModelArgs
+from executorch.examples.models.llama.runner.generation import next_token
+from executorch.examples.models.llama.static_attention import StaticAttentionIOManager
+from executorch.runtime import Runtime
+from pytorch_tokenizers import get_tokenizer
+
+
+def get_stop_tokens(tokenizer) -> List[int]:
+    """Get stop tokens from tokenizer, falling back to eos_id if not available."""
+    if hasattr(tokenizer, "stop_tokens"):
+        return tokenizer.stop_tokens
+    return [tokenizer.eos_id]
+
+
+def create_pte_wrapper(
+    decode_method,
+    prefill_method,
+    mgr: "StaticAttentionIOManager",
+    prefill_seq_len: int,
+    prefill_mask: Dict[str, torch.Tensor],
+):
+    """
+    Create a wrapper function that adapts PTE execution to the interface
+    expected by StaticAttentionIOManager.
+
+    This multifunction version selects between prefill and decode methods
+    based on the input sequence length. Both methods use the SAME cache_len,
+    so the cache buffer is shared directly without any slicing or copying.
+
+    The wrapper:
+    - Takes (tokens, options_dict) like the eager model
+    - Selects prefill or decode method based on token count
+    - Uses the same cache buffer for both methods (no slicing needed)
+    - Flattens inputs using pytree
+    - Executes the appropriate PTE method
+    - Reconstructs outputs to match eager model format: (logits, {"out_cache_state": (k_dict, v_dict)})
+
+    Args:
+        decode_method: The PTE method for decode (seqlen=1)
+        prefill_method: The PTE method for prefill (seqlen=input_len)
+        mgr: StaticAttentionIOManager with caches sized for shared cache_len
+        prefill_seq_len: The sequence length for prefill
+        prefill_mask: Pre-computed mask tensor for prefill method
+    """
+
+    k_cache_keys = list(mgr.k_caches.keys())
+    v_cache_keys = list(mgr.v_caches.keys())
+
+    timing_stats = {
+        "flatten_time": 0.0,
+        "execute_time": 0.0,
+        "reconstruct_time": 0.0,
+        "detection_time": 0.0,
+        "options_build_time": 0.0,
+        "call_count": 0,
+    }
+
+    def wrapper(
+        tokens: torch.Tensor, options: Dict[str, Any]
+    ) -> Tuple[torch.Tensor, Dict[str, Any]]:
+        import time as time_module
+
+        timing_stats["call_count"] += 1
+
+        t0 = time_module.perf_counter()
+
+        # Detect actual sequence length.
+        # StaticAttentionIOManager._run_once pads tokens with zeros on the right.
+        # For decode (1 actual token), positions 1+ are all zeros.
+        padded_seq_len = tokens.shape[1]
+        if padded_seq_len > 1 and (tokens[0, 1:] == 0).all():
+            actual_seq_len = 1
+        else:
+            actual_seq_len = padded_seq_len
+
+        is_prefill = actual_seq_len == prefill_seq_len
+
+        t1 = time_module.perf_counter()
+        timing_stats["detection_time"] += t1 - t0
+
+        t0 = time_module.perf_counter()
+
+        # Get the input cache state from options
+        in_k_caches, in_v_caches = options["in_cache_state"]
+
+        # Both prefill and decode use the same cache_len, so no slicing needed!
+        # Just select the appropriate method and mask.
+        if is_prefill:
+            method = prefill_method
+            adapted_mask = prefill_mask
+        else:
+            method = decode_method
+            adapted_mask = mgr.masks
+
+        adapted_options = {
+            "masks": adapted_mask,
+            "freqs_cos_override": options["freqs_cos_override"],
+            "freqs_sin_override": options["freqs_sin_override"],
+            "in_cache_state": (in_k_caches, in_v_caches),  # Same cache for both!
+        }
+
+        if "last_valid_token_pos" in options:
+            adapted_options["last_valid_token_pos"] = options["last_valid_token_pos"]
+
+        inputs = (tokens, adapted_options)
+
+        t1 = time_module.perf_counter()
+        timing_stats["options_build_time"] += t1 - t0
+
+        t0 = time_module.perf_counter()
+        flat_inputs, _ = pytree.tree_flatten(inputs)
+        t1 = time_module.perf_counter()
+        timing_stats["flatten_time"] += t1 - t0
+
+        t0 = time_module.perf_counter()
+        outputs = method.execute(flat_inputs)
+        t1 = time_module.perf_counter()
+        timing_stats["execute_time"] += t1 - t0
+
+        t0 = time_module.perf_counter()
+
+        logits = outputs[0]
+
+        num_layers = len(k_cache_keys)
+        k_updates = outputs[1 : 1 + num_layers]
+        v_updates = outputs[1 + num_layers : 1 + 2 * num_layers]
+
+        k_cache_dict = dict(zip(k_cache_keys, k_updates))
+        v_cache_dict = dict(zip(v_cache_keys, v_updates))
+
+        attn_updates = {"out_cache_state": (k_cache_dict, v_cache_dict)}
+
+        t1 = time_module.perf_counter()
+        timing_stats["reconstruct_time"] += t1 - t0
+
+        return logits, attn_updates
+
+    def print_timing_stats():
+        n = timing_stats["call_count"]
+        if n > 0:
+            print(f"\n=== Wrapper Timing Stats ({n} calls) ===")
+            print(
+                f"  Detection time:   {timing_stats['detection_time']*1000:.2f}ms total, {timing_stats['detection_time']/n*1000:.4f}ms avg"
+            )
+            print(
+                f"  Options build:    {timing_stats['options_build_time']*1000:.2f}ms total, {timing_stats['options_build_time']/n*1000:.4f}ms avg"
+            )
+            print(
+                f"  Flatten time:     {timing_stats['flatten_time']*1000:.2f}ms total, {timing_stats['flatten_time']/n*1000:.4f}ms avg"
+            )
+            print(
+                f"  Execute time:     {timing_stats['execute_time']*1000:.2f}ms total, {timing_stats['execute_time']/n*1000:.3f}ms avg"
+            )
+            print(
+                f"  Reconstruct time: {timing_stats['reconstruct_time']*1000:.2f}ms total, {timing_stats['reconstruct_time']/n*1000:.4f}ms avg"
+            )
+            total = (
+                timing_stats["detection_time"]
+                + timing_stats["options_build_time"]
+                + timing_stats["flatten_time"]
+                + timing_stats["execute_time"]
+                + timing_stats["reconstruct_time"]
+            )
+            print(
+                f"  Total wrapper:    {total*1000:.2f}ms total, {total/n*1000:.3f}ms avg"
+            )
+            print(
+                f"  Execute is {timing_stats['execute_time']/total*100:.1f}% of wrapper time"
+            )
+            expected_tps = 1000 / (timing_stats["execute_time"] / n * 1000)
+            print(f"  Expected tok/s from execute alone: {expected_tps:.1f}")
+
+    wrapper.print_timing_stats = print_timing_stats
+    wrapper.timing_stats = timing_stats
+
+    return wrapper
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Run multifunction static attention Llama model"
+    )
+
+    parser.add_argument(
+        "-m",
+        "--model",
+        required=True,
+        help="Path to exported .pte model",
+    )
+    parser.add_argument(
+        "-p",
+        "--params",
+        required=True,
+        help="Path to params.json",
+    )
+    parser.add_argument(
+        "-t",
+        "--tokenizer",
+        required=True,
+        help="Path to tokenizer model",
+    )
+    parser.add_argument(
+        "--tokenizer_config",
+        type=str,
+        default=None,
+        help="Path to tokenizer config (required for HuggingFace tokenizers)",
+    )
+    parser.add_argument(
+        "--prompt",
+        type=str,
+        default="Once upon a time,",
+        help="Input prompt",
+    )
+    parser.add_argument(
+        "--max_new_tokens",
+        type=int,
+        default=100,
+        help="Maximum number of tokens to generate",
+    )
+    parser.add_argument(
+        "--temperature",
+        type=float,
+        default=0.6,
+        help="Sampling temperature",
+    )
+    parser.add_argument(
+        "--top_p",
+        type=float,
+        default=0.9,
+        help="Top-p (nucleus) sampling threshold",
+    )
+    parser.add_argument(
+        "--input_len",
+        type=int,
+        default=32,
+        help="Input sequence length for prefill (must match export)",
+    )
+    parser.add_argument(
+        "--max_context_len",
+        type=int,
+        default=1024,
+        help="Maximum context length (must match export)",
+    )
+    parser.add_argument(
+        "--lookahead",
+        action="store_true",
+        help="Enable lookahead (speculative) decoding",
+    )
+    parser.add_argument(
+        "--ngram_size",
+        type=int,
+        default=5,
+        help="N-gram size for lookahead decoding",
+    )
+    parser.add_argument(
+        "--window_size",
+        type=int,
+        default=4,
+        help="Window size for lookahead decoding",
+    )
+    parser.add_argument(
+        "--n_verifications",
+        type=int,
+        default=4,
+        help="Number of verification branches for lookahead decoding",
+    )
+
+    args = parser.parse_args()
+
+    # Load tokenizer
+    tokenizer = get_tokenizer(args.tokenizer, args.tokenizer_config)
+    stop_tokens = get_stop_tokens(tokenizer)
+
+    # Load model params
+    with open(args.params, "r") as f:
+        params = json.loads(f.read())
+
+    # Create model args
+    # Multifunction models use generate_full_logits=False (only last token logits)
+    model_args = ModelArgs(
+        max_context_len=args.max_context_len,
+        generate_full_logits=False,
+        **params,
+    )
+    model_args.attention_type = "static_mha"
+
+    print(f"Model config: {model_args.n_layers} layers, dim={model_args.dim}")
+    print(f"Max context length: {args.max_context_len}, Input length: {args.input_len}")
+
+    # Both prefill and decode use the same cache_len (decode's cache size).
+    # This allows them to share the same cache buffer without any copying.
+    # The export script exports both methods with cache_len = max_context_len - 1.
+    prefill_input_len = args.input_len  # e.g., 64
+    decode_input_len = 1
+    shared_cache_len = args.max_context_len - decode_input_len  # e.g., 1023
+
+    print(f"Prefill: input_len={prefill_input_len}, cache_len={shared_cache_len}")
+    print(f"Decode: input_len={decode_input_len}, cache_len={shared_cache_len}")
+
+    # Create decode manager (input_len=1) - used for decode phase
+    mgr = StaticAttentionIOManager(
+        model_args,
+        input_len=decode_input_len,
+        cache_lens=shared_cache_len,
+        batch_size=1,
+        dtype=torch.float16,
+        style="smart_mask",
+        mask_val=float("-inf"),
+    )
+
+    # Create prefill manager (input_len=64) with the SAME cache_len.
+    # Since both use the same cache_len, we can share the cache buffer directly.
+    prefill_mgr = StaticAttentionIOManager(
+        model_args,
+        input_len=prefill_input_len,
+        cache_lens=shared_cache_len,  # Same cache_len as decode!
+        batch_size=1,
+        dtype=torch.float16,
+        style="smart_mask",
+        mask_val=float("-inf"),
+    )
+
+    # Share cache buffers: point prefill_mgr's caches to mgr's caches.
+    # No copying needed since both managers use the same cache_len!
+    prefill_mgr.k_caches = mgr.k_caches
+    prefill_mgr.v_caches = mgr.v_caches
+
+    prefill_mask = prefill_mgr.masks
+
+    # Load PTE model with multifunction support
+    print(f"Loading multifunction model from {args.model}...")
+    runtime = Runtime.get()
+    program = runtime.load_program(args.model)
+
+    # List available methods
+    method_names = program.method_names
+    # Separate executable methods from constant methods (metadata)
+    executable_methods = {"forward", "prefill"}
+    actual_methods = executable_methods & method_names
+    constant_methods = method_names - executable_methods
+    print(f"Executable methods: {actual_methods}")
+    print(f"Metadata methods: {constant_methods}")
+
+    # Check for expected multifunction methods
+    if "forward" not in method_names or "prefill" not in method_names:
+        print(
+            f"Warning: Expected 'forward' and 'prefill' methods, found: {method_names}"
+        )
+        print("Falling back to single 'forward' method...")
+        decode_method = program.load_method("forward")
+        prefill_method = decode_method
+    else:
+        # Load both methods
+        print("Loading 'forward' (decode) method...")
+        decode_method = program.load_method("forward")
+        print("Loading 'prefill' method...")
+        prefill_method = program.load_method("prefill")
+
+    decode_metadata = decode_method.metadata
+    print(
+        f"Decode method metadata: num_inputs={decode_metadata.num_inputs()}, num_outputs={decode_metadata.num_outputs()}"
+    )
+
+    prefill_metadata = prefill_method.metadata
+    print(
+        f"Prefill method metadata: num_inputs={prefill_metadata.num_inputs()}, num_outputs={prefill_metadata.num_outputs()}"
+    )
+
+    # Get cache keys in insertion order (NOT sorted alphabetically!)
+    # Pytree preserves dict insertion order in Python 3.7+
+    # The caches are created in layer order (0, 1, 2, ..., n_layers-1)
+    # Note: cache keys are obtained inside create_pte_wrapper
+
+    # Create wrapper function that adapts PTE to eager interface
+    # This wrapper will select between prefill and decode based on seq_len
+    model_fn = create_pte_wrapper(
+        decode_method,
+        prefill_method,
+        mgr,
+        prefill_input_len,
+        prefill_mask,
+    )
+
+    # Encode prompt
+    prompt_tokens = tokenizer.encode(args.prompt, bos=True, eos=False)
+    print(f"\nPrompt: {args.prompt}")
+    print(f"Prompt tokens: {len(prompt_tokens)}")
+    print("-" * 50)
+
+    # Reset both managers
+    mgr.reset()
+    prefill_mgr.reset()
+
+    # Prefill using prefill_mgr which has the correct input_len and mask shapes
+    # This will call model_fn with seq_len=input_len, which selects the prefill method
+    print("Prefilling (using 'prefill' method)...", end=" ", flush=True)
+    start_time = time.time()
+
+    # Use prefill_mgr for prefill since it has the correct input_len=64 and mask shapes
+    logits = prefill_mgr.prefill(model_fn, prompt_tokens)
+
+    prefill_time = time.time() - start_time
+    print(f"done in {prefill_time:.2f}s")
+
+    # Get first token from prefill logits
+    # With generate_full_logits=False, logits is 2D [batch, vocab]
+    # With generate_full_logits=True, logits is 3D [batch, seq_len, vocab]
+    if logits.dim() == 2:
+        first_token = next_token(logits, args.temperature, args.top_p)
+    else:
+        first_token = next_token(logits[:, -1, :], args.temperature, args.top_p)
+
+    # No cache copying needed! prefill_mgr and mgr share the same cache buffers
+    # because both use the same cache_len (shared_cache_len).
+
+    # Sync position from prefill manager to decode manager
+    mgr.pos = prefill_mgr.pos
+
+    # Update decode manager's masks to reflect current position after prefill
+    for mask in mgr._masks.values():
+        mask.reset()
+        mask.unmask(mgr.pos)
+
+    # Decode using mgr.decode() which will call model_fn
+    # The wrapper will detect seq_len=1 and route to decode method
+    print(f"\n{args.prompt}", end="", flush=True)
+    print(tokenizer.decode_token(first_token), end="", flush=True)
+
+    decode_start = time.time()
+
+    if args.lookahead:
+        # Use lookahead (speculative) decoding
+        print(
+            f"\n[Using lookahead decoding: ngram={args.ngram_size}, window={args.window_size}, verifications={args.n_verifications}]"
+        )
+        generated_tokens = mgr.lookahead_decode(
+            model_fn,
+            first_token,
+            n=args.max_new_tokens - 1,  # -1 because first_token counts
+            ngram_size=args.ngram_size,
+            window_size=args.window_size,
+            n_verifications=args.n_verifications,
+            stop_tokens=stop_tokens,
+        )
+    else:
+        # Use standard autoregressive decoding (uses 'forward' method)
+        print("\n[Using 'forward' (decode) method for generation]")
+        generated_tokens = mgr.decode(
+            model_fn,
+            first_token,
+            n=args.max_new_tokens - 1,  # -1 because first_token counts
+            stop_tokens=stop_tokens,
+        )
+
+    # Print generated tokens (skip first as it's the init_token we already printed)
+    for token in generated_tokens[1:]:
+        if token in stop_tokens:
+            break
+        print(tokenizer.decode_token(token), end="", flush=True)
+
+    decode_time = time.time() - decode_start
+    total_generated = len(generated_tokens)
+    tokens_per_sec = total_generated / decode_time if decode_time > 0 else 0
+
+    print("\n" + "-" * 50)
+    print(f"Prefill: {len(prompt_tokens)} tokens in {prefill_time:.2f}s")
+    print(
+        f"Decode: {total_generated} tokens in {decode_time:.2f}s ({tokens_per_sec:.2f} tok/s)"
+    )
+
+    # Print detailed timing breakdown
+    model_fn.print_timing_stats()
+
+    print("\nMultifunction model test completed successfully!")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/apple/coreml/scripts/extract_coreml_models.py
+++ b/examples/apple/coreml/scripts/extract_coreml_models.py
@@ -4,11 +4,12 @@
 # LICENSE file in the root directory of this source tree.
 
 import argparse
+import json
 import os
 import shutil
 from pathlib import Path
 
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from executorch.backends.apple.coreml import executorchcoreml
 from executorch.backends.apple.coreml.compiler import CoreMLBackend
@@ -21,27 +22,78 @@ from executorch.exir.schema import (
 
 
 def extract_coreml_models(pte_data: bytes):
-    program = deserialize_pte_binary(pte_data).program
+    pte_file = deserialize_pte_binary(pte_data)
+    program = pte_file.program
+
+    # Build a map from named_data keys to their data for multifunction model support.
+    # Multifunction models store a JSON reference in processed_bytes that points to
+    # the actual model data in named_data.
+    # After deserialization, pte_file.named_data is a NamedDataStoreOutput containing
+    # buffers and pte_data (key -> DataEntry mapping).
+    named_data_map: Dict[str, bytes] = {}
+    if pte_file.named_data is not None:
+        for key, data_entry in pte_file.named_data.pte_data.items():
+            named_data_map[key] = pte_file.named_data.buffers[data_entry.buffer_index]
+
     delegates: List[BackendDelegate] = sum(
         [execution_plan.delegates for execution_plan in program.execution_plan], []
     )
     coreml_delegates: List[BackendDelegate] = [
         delegate for delegate in delegates if delegate.id == CoreMLBackend.__name__
     ]
+
+    # Track extracted models to avoid duplicates (multifunction models share partitions)
+    extracted_keys: set = set()
     model_index: int = 1
+
     for coreml_delegate in coreml_delegates:
         coreml_delegate_data: BackendDelegateDataReference = coreml_delegate.processed
         coreml_processed_bytes: Optional[bytes] = None
+        model_name: Optional[str] = None
+
         match coreml_delegate_data.location:
             case DataLocation.INLINE:
-                coreml_processed_bytes = program.backend_delegate_data[
+                raw_bytes = program.backend_delegate_data[
                     coreml_delegate_data.index
                 ].data
+
+                # Check if this is a JSON reference to named_data (multifunction models)
+                # JSON references are prefixed with "CMJR" magic number
+                MAGIC_NUMBER = b"CMJR"
+                if raw_bytes.startswith(MAGIC_NUMBER):
+                    # Strip magic number and parse JSON
+                    json_bytes = raw_bytes[len(MAGIC_NUMBER) :]
+                    try:
+                        reference = json.loads(json_bytes.decode("utf-8"))
+                        key = reference.get("key")
+                        if key in extracted_keys:
+                            # Already extracted this partition, skip
+                            continue
+                        if key in named_data_map:
+                            coreml_processed_bytes = named_data_map[key]
+                            model_name = key  # Use the key as model name
+                            extracted_keys.add(key)
+                        else:
+                            print(
+                                f"Warning: Named data key '{key}' not found in program"
+                            )
+                            continue
+                    except (json.JSONDecodeError, UnicodeDecodeError) as e:
+                        print(f"Warning: Failed to parse JSON reference: {e}")
+                        continue
+                else:
+                    # Not a JSON reference, treat as raw model data (legacy format)
+                    coreml_processed_bytes = raw_bytes
 
             case _:
                 AssertionError("The loaded Program must have inline data.")
 
-        model_name: str = f"model_{model_index}"
+        if coreml_processed_bytes is None:
+            continue
+
+        if model_name is None:
+            model_name = f"model_{model_index}"
+
         model_path: Path = Path() / "extracted_coreml_models" / model_name
         if model_path.exists():
             shutil.rmtree(model_path.absolute())


### PR DESCRIPTION
## Summary

This diff adds multifunction export support for static Llama models on CoreML. Multifunction models export separate prefill and decode graphs with weight sharing, enabling more efficient autoregressive generation compared to the single-method approach.

### Key Changes

**CoreML Backend Compiler (`coreml_preprocess.py`)**
- Added `MULTIMETHOD_WEIGHT_SHARING_STRATEGY` enum with `NONE` and `POSITIONAL` strategies
- Added `generate_multimethod_weight_sharing_strategy_compile_spec()` to enable weight sharing across methods
- Implemented multifunction CoreML model compilation using `ct.utils.MultiFunctionDescriptor`
- When weight sharing is enabled, weights from the first method are shared positionally with subsequent methods

**Model Metadata (`model_metadata.h`, `serde_json.mm`)**
- Added `MethodMetadata` struct to store per-method input/output names for multifunction models
- Extended `ModelMetadata` with `methods` map and `default_method` field
- Added `is_multifunction()` helper to detect multifunction models
- Updated JSON serialization to handle the new multifunction metadata format

**Runtime Changes (`ETCoreMLModelManager.mm`, `backend_delegate.mm`, `coreml_backend_delegate.mm`)**
- Updated `ETCoreMLModelManager` to set `functionName` on `MLModelConfiguration` only for multifunction models (based on `metadata.is_multifunction()`)
- Legacy single-function models continue to work with `functionName=nil`
- Added method name propagation through the delegate initialization path
- Updated model loading to use per-method input/output names when available

**Export Script (`export_static_llm_coreml.py`)**
- Added `--multifunction` flag to export models with separate prefill (seqlen=input_len) and decode (seqlen=1) methods
- Multifunction mode uses `generate_full_logits=False` for efficiency (only outputs last token logits)
- Single method mode (default) retains `generate_full_logits=True` for lookahead decoding support
- Generates combined metadata with method-specific prefixes (e.g., `decode_input_len`, `prefill_input_len`)

**New Runner (`run_static_llm_multifunction.py`)**
- Added dedicated runner for multifunction models
- Handles separate prefill and decode method execution
- Manages cache state transfer between prefill and decode phases
- Supports both 2D (generate_full_logits=False) and 3D (generate_full_logits=True) logits output

**Build System (`CMakeLists.txt`)**
- Fixed installation of CoreML backend headers

**Utilities (`extract_coreml_models.py`)**
- Updated model extraction script to handle multifunction models

**Documentation (`README.md`)**
- Added documentation for both export modes (single method and multifunction)
- Added comprehensive export options reference table
- Added usage examples for both modes

### Usage Examples

**Single Method Export (for lookahead decoding):**
```bash
python examples/apple/coreml/llama/export_static_llm_coreml.py \
    --checkpoint $HOME/models/llama1b/llama1b.pth \
    --params $HOME/models/llama1b/params.json \
    --output static_llm_coreml_model.pte \
    --input_len 32 \
    --max_context_len 1024
```

**Multifunction Export (separate prefill/decode):**
```bash
python examples/apple/coreml/llama/export_static_llm_coreml.py \
    --checkpoint $HOME/models/llama1b/llama1b.pth \
    --params $HOME/models/llama1b/params.json \
    --output static_llm_coreml_multifunction.pte \
    --input_len 64 \
    --max_context_len 1024 \
    --multifunction
```

**Run Single Method Model (with lookahead):**
```bash
python examples/apple/coreml/llama/run_static_llm.py \
    --model static_llm_coreml_model.pte \
    --params $HOME/models/llama1b/params.json \
    --tokenizer $HOME/models/llama1b/tokenizer.model \
    --prompt "Once upon a time" \
    --max_new_tokens 100 \
    --lookahead
```

**Run Multifunction Model:**
```bash
python examples/apple/coreml/llama/run_static_llm_multifunction.py \
    --model static_llm_coreml_multifunction.pte \
    --params $HOME/models/llama1b/params.json \
    --tokenizer $HOME/models/llama1b/tokenizer.model \
    --prompt "Once upon a time" \
    --max_new_tokens 100 \
    --input_len 64 \
    --max_context_len 1024
```

### Mode Comparison

| Feature | Single Method | Multifunction |
|---------|---------------|---------------|
| Sequence length | Fixed (input_len for both prefill & decode) | Separate (input_len for prefill, 1 for decode) |
| Logits output | Full (all tokens) | Last token only |
| Lookahead decoding | ✅ Supported | ❌ Not supported |
| Weight sharing | N/A | ✅ Enabled |
| Generation efficiency | Good with lookahead | Optimized decode step |

## Test Plan
New unit test +

Tested both export modes on Llama 1B:
1. Exported single method model with `--input_len 32 --max_context_len 1024`
2. Exported multifunction model with `--input_len 64 --max_context_len 1024 --multifunction`
3. Ran single method model with `--lookahead` flag
4. Ran multifunction model with matching input_len and max_context_len
5. Verified text generation produces coherent output for both modes
