### PR TITLE
Arm backend: Bug fix decompose-var pass.

### DIFF
--- a/backends/arm/_passes/decompose_var_pass.py
+++ b/backends/arm/_passes/decompose_var_pass.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 Arm Limited and/or its affiliates.
+# Copyright 2024-2026 Arm Limited and/or its affiliates.
 # All rights reserved.
 #
 # This source code is licensed under the BSD-style license found in the
@@ -78,8 +78,12 @@ class DecomposeVarPass(ArmPass):
         dim = get_node_arg(args, key=list, default_value=list(range(len(shape))))
 
         if op == torch.ops.aten.var.dim:
-            keepdim = get_node_arg(args, bool, False)
-            correction = get_node_arg(args, int, 1)
+            keepdim = False
+            correction = 1
+            if len(args) > 2:
+                correction = int(get_node_arg(args, 2, True))
+            if len(args) > 3:
+                keepdim = get_node_arg(args, 3, False)
         else:
             correction = get_node_arg(kwargs, "correction", 1)
             keepdim = get_node_arg(kwargs, "keepdim", False)


### PR DESCRIPTION
Previously, the decompose_var_pass assumed that
"correction" was an integer argument for the
aten.var.dim case, but it is boolean. This meant that 1) get_node_arg() for keepdim actually picked the correction value 2) correction always picked the default value.

Since the error was introduced in transform_for_annotation, it was not detected by tests.

cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai