### PR TITLE
PoC Cortex_m backend: Add support for CMSIS-NN scratch buffers

### DIFF
--- a/backends/cortex_m/ops/operators.py
+++ b/backends/cortex_m/ops/operators.py
@@ -1,6 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -494,6 +494,7 @@ def transpose_impl(input: torch.Tensor, perm) -> torch.Tensor:
 lib.define(
     "quantized_conv2d("
     "Tensor input, "
+    "Tensor scratch, "
     "Tensor weight, "
     "Tensor? bias, "
     "int[] stride, "
@@ -512,6 +513,7 @@ lib.define(
 lib.define(
     "quantized_conv2d.out("
     "Tensor input, "
+    "Tensor scratch, "
     "Tensor weight, "
     "Tensor? bias, "
     "int[] stride, "
@@ -588,6 +590,7 @@ def _compute_depthwise_conv2d_output_shape(
 @register_fake("cortex_m::quantized_conv2d")
 def quantized_conv2d_meta(
     input: torch.Tensor,
+    scratch: torch.Tensor,
     weight: torch.Tensor,
     bias: torch.Tensor | None,
     stride: Sequence[int],
@@ -617,6 +620,7 @@ def quantized_conv2d_meta(
 @impl(lib, "quantized_conv2d", "CompositeExplicitAutograd")
 def quantized_conv2d_impl(
     input: torch.Tensor,
+    scratch: torch.Tensor,
     weight: torch.Tensor,
     bias: torch.Tensor | None,
     stride: Sequence[int],
@@ -683,6 +687,7 @@ def quantized_conv2d_impl(
 lib.define(
     "quantized_depthwise_conv2d("
     "Tensor input, "
+    "Tensor scratch, "
     "Tensor weight, "
     "Tensor? bias, "
     "int[] stride, "
@@ -702,6 +707,7 @@ lib.define(
 lib.define(
     "quantized_depthwise_conv2d.out("
     "Tensor input, "
+    "Tensor scratch, "
     "Tensor weight, "
     "Tensor? bias, "
     "int[] stride, "
@@ -722,6 +728,7 @@ lib.define(
 @register_fake("cortex_m::quantized_depthwise_conv2d")
 def quantized_depthwise_conv2d_meta(
     input: torch.Tensor,
+    scratch: torch.Tensor,
     weight: torch.Tensor,
     bias: torch.Tensor | None,
     stride: Sequence[int],
@@ -752,6 +759,7 @@ def quantized_depthwise_conv2d_meta(
 @impl(lib, "quantized_depthwise_conv2d", "CompositeExplicitAutograd")
 def quantized_depthwise_conv2d_impl(
     input: torch.Tensor,
+    scratch: torch.Tensor,
     weight: torch.Tensor,
     bias: torch.Tensor | None,
     stride: Sequence[int],

--- a/backends/cortex_m/ops/operators.yaml
+++ b/backends/cortex_m/ops/operators.yaml
@@ -1,6 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -59,13 +59,14 @@
     - arg_meta: null
       kernel_name: cortex_m::transpose_out
 
-- func: cortex_m::quantized_conv2d.out(Tensor input, Tensor weight, Tensor? bias, int[] stride, int[] padding, int[] dilation, int input_offset, int output_offset, Tensor requantize_multipliers, Tensor requantize_shifts, int activation_min, int activation_max, *, Tensor(a!) out) -> Tensor(a!)
+- func: cortex_m::quantized_conv2d.out(Tensor input, Tensor scratch, Tensor weight, Tensor? bias, int[] stride, int[] padding, int[] dilation, int input_offset, int output_offset, Tensor requantize_multipliers, Tensor requantize_shifts, int activation_min, int activation_max, *, Tensor(a!) out) -> Tensor(a!)
   variants: function
   kernels:
     - arg_meta: null
       kernel_name: cortex_m::quantized_conv2d_out
 
-- func: cortex_m::quantized_depthwise_conv2d.out(Tensor input, Tensor weight, Tensor? bias, int[] stride, int[] padding, int[] dilation, int depth_multiplier, int input_offset, int output_offset, Tensor requantize_multipliers, Tensor requantize_shifts, int activation_min, int activation_max, *, Tensor(a!) out) -> Tensor(a!)
+
+- func: cortex_m::quantized_depthwise_conv2d.out(Tensor input, Tensor scratch, Tensor weight, Tensor? bias, int[] stride, int[] padding, int[] dilation, int depth_multiplier, int input_offset, int output_offset, Tensor requantize_multipliers, Tensor requantize_shifts, int activation_min, int activation_max, *, Tensor(a!) out) -> Tensor(a!)
   variants: function
   kernels:
     - arg_meta: null

--- a/examples/arm/executor_runner/arm_executor_runner.cpp
+++ b/examples/arm/executor_runner/arm_executor_runner.cpp
@@ -1,6 +1,6 @@
 /* Copyright (c) Meta Platforms, Inc. and affiliates.
  * All rights reserved.
- * Copyright 2023-2025 Arm Limited and/or its affiliates.
+ * Copyright 2023-2026 Arm Limited and/or its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
@@ -256,11 +256,12 @@ const int num_inferences = 1;
  * ET_ARM_BAREMETAL_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE and
  * ET_ARM_BAREMETAL_FAST_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE
  */
-const size_t temp_allocation_pool_size =
-    ET_ARM_BAREMETAL_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE;
-unsigned char __attribute__((
-    section(".bss.tensor_arena"),
-    aligned(16))) temp_allocation_pool[temp_allocation_pool_size];
+constexpr size_t temp_allocation_pool_size = 0;
+//    ET_ARM_BAREMETAL_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE;
+unsigned char* temp_allocation_pool = nullptr;
+// unsigned char __attribute__((
+//     section(".bss.tensor_arena"),
+//     aligned(16))) temp_allocation_pool[temp_allocation_pool_size];
 #if defined(ET_ARM_BAREMETAL_FAST_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE)
 extern "C" {
 size_t ethosu_fast_scratch_size =
@@ -637,7 +638,10 @@ void runner_init(
   size_t num_memory_planned_buffers = method_meta->num_memory_planned_buffers();
   ctx.planned_spans.reserve(num_memory_planned_buffers);
   size_t planned_buffer_membase = ctx.method_allocator->used_size();
-
+  ET_LOG(
+      Info,
+      "Method meta, has %zu instructions",
+      method_meta->num_instructions());
   for (size_t id = 0; id < num_memory_planned_buffers; ++id) {
     size_t buffer_size =
         static_cast<size_t>(method_meta->memory_planned_buffer_size(id).get());


### PR DESCRIPTION
Use exir.memory.alloc for CMSIS-NN scratch buffers, which is ideal since it has a TensorSpec and gets memory planned but creates no additional operator overhead.
Use CMSIS-NN pybind wrapper to get correct buffer size.

Improves: https://github.com/pytorch/executorch/issues/16041

Comparing w/wo patch memory consumption for conv2d_x3 unit test case. Without patch:

I [executorch:arm_executor_runner.cpp:842 log_mem_status()] model_pte_program_size: 10208 bytes.
I [executorch:arm_executor_runner.cpp:843 log_mem_status()] model_pte_loaded_size: 10208 bytes.
I [executorch:arm_executor_runner.cpp:848 log_mem_status()] input_file_allocator_used: 10976 / 62914560 free: 62903584 ( used: 0 % )
I [executorch:arm_executor_runner.cpp:860 log_mem_status()] method_allocator_used: 5433 / 62914560 free: 62909127 ( used: 0 % )
I [executorch:arm_executor_runner.cpp:867 log_mem_status()] method_allocator_planned: 2560 bytes
I [executorch:arm_executor_runner.cpp:871 log_mem_status()] method_allocator_loaded: 2857 bytes
I [executorch:arm_executor_runner.cpp:875 log_mem_status()] method_allocator_input: 16 bytes
I [executorch:arm_executor_runner.cpp:876 log_mem_status()] method_allocator_executor: 0 bytes
I [executorch:arm_executor_runner.cpp:879 log_mem_status()] temp_allocator: 2097152

With patch:
I [executorch:arm_executor_runner.cpp:846 log_mem_status()] model_pte_program_size: 10336 bytes.
I [executorch:arm_executor_runner.cpp:847 log_mem_status()] model_pte_loaded_size: 10336 bytes.
I [executorch:arm_executor_runner.cpp:852 log_mem_status()] input_file_allocator_used: 11104 / 62914560 free: 62903456 ( used: 0 % )
I [executorch:arm_executor_runner.cpp:864 log_mem_status()] method_allocator_used: 6414 / 62914560 free: 62908146 ( used: 0 % )
I [executorch:arm_executor_runner.cpp:871 log_mem_status()] method_allocator_planned: 2560 bytes
I [executorch:arm_executor_runner.cpp:875 log_mem_status()] method_allocator_loaded: 3838 bytes
I [executorch:arm_executor_runner.cpp:879 log_mem_status()] method_allocator_input: 16 bytes
I [executorch:arm_executor_runner.cpp:880 log_mem_status()] method_allocator_executor: 0 bytes

Summary:
* The big temp_allocator used for scratch is removed in patch and no longer used except for Linear/FC but this is a PoC/Draft-PR anway
* method_allocator_planned: 2560 bytes is the same in both cases => This means there is 100% reuse of the scratch buffers
 *  increased model size and method_allocator_loaded delta => This can be explained by increased number of planned objects that describe scratch reuse (more meta data). This meta data should stay consistent if scratch buffer sizes increased so I think this acceptable


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @Sebastian-Larsson @robell