### PR TITLE
Metal backend: compile metal with precise and safe flags on

### DIFF
--- a/backends/apple/metal/runtime/shims/et_metal.mm
+++ b/backends/apple/metal/runtime/shims/et_metal.mm
@@ -234,7 +234,13 @@ void ETMetalShaderLibrary::compileLibrary() {
         NSString* sourceString = [NSString stringWithUTF8String:shaderSource_.c_str()];
         NSError* error = nil;
 
-        library_ = [device newLibraryWithSource:sourceString options:nil error:&error];
+        MTLCompileOptions* options = [[MTLCompileOptions alloc] init];
+        if (@available(macOS 15.0, iOS 18.0, *)) {
+            options.mathMode = MTLMathModeSafe;
+            options.mathFloatingPointFunctions = MTLMathFloatingPointFunctionsPrecise;
+        }
+
+        library_ = [device newLibraryWithSource:sourceString options:options error:&error];
         if (!library_ || error) {
             ET_LOG(Error, "ETMetalShaderLibrary: Failed to compile shader library: %s",
                    error ? [[error localizedDescription] UTF8String] : "unknown error");

--- a/backends/apple/metal/runtime/shims/et_metal.mm
+++ b/backends/apple/metal/runtime/shims/et_metal.mm
@@ -234,8 +234,8 @@ void ETMetalShaderLibrary::compileLibrary() {
         NSString* sourceString = [NSString stringWithUTF8String:shaderSource_.c_str()];
         NSError* error = nil;
 
-        MTLCompileOptions* options = [[MTLCompileOptions alloc] init];
-        if (@available(macOS 15.0, iOS 18.0, *)) {
+        MTLCompileOptions* options = [[MTLCompileOptions new] autorelease];
+        if (@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, *)) {
             options.mathMode = MTLMathModeSafe;
             options.mathFloatingPointFunctions = MTLMathFloatingPointFunctionsPrecise;
         }


### PR DESCRIPTION
This pull request updates the Metal shader compilation process to improve numerical accuracy and safety when compiling shaders on newer versions of macOS and iOS. The main change is the introduction of specific compile options for math operations when supported by the operating system.

In the compileLibrary() function, added `MTLCompileOptions` when running on macOS 15.0, iOS 18.0, or newer, to ensure safer and more precise math operations during shader compilation:
  * `mathMode` set to `MTLMathModeSafe` (equivalent to -fmetal-math-mode=safe)
  * `mathFloatingPointFunctions` set to `MTLMathFloatingPointFunctionsPrecise` (equivalent to -fmetal-math-fp32-functions=precise)
  
