### PR TITLE
Use custom rmsnorm in static attention

### DIFF
--- a/examples/models/llama/static_attention.py
+++ b/examples/models/llama/static_attention.py
@@ -14,6 +14,7 @@ from executorch.examples.models.llama.attention import (
     register_attention,
 )
 from executorch.examples.models.llama.model_args import ModelArgs
+from executorch.examples.models.llama.norm import RMSNorm
 from executorch.examples.models.llama.rope import Rope
 
 
@@ -847,8 +848,8 @@ class StaticAttention(Attention):
         self.layer_id = layer_id
 
         if self.use_qk_norm:
-            self.q_norm = torch.nn.RMSNorm(self.head_dim, config.norm_eps)
-            self.k_norm = torch.nn.RMSNorm(self.head_dim, config.norm_eps)
+            self.q_norm = RMSNorm(self.head_dim, eps=config.norm_eps)
+            self.k_norm = RMSNorm(self.head_dim, eps=config.norm_eps)
         else:
             self.q_norm = torch.nn.Identity()
             self.k_norm = torch.nn.Identity()


### PR DESCRIPTION
### Summary
Use custom RMSNorm for static attention. This is what's used in mha attention as well.

https://github.com/pytorch/executorch/blob/9cbe754f6ea66d99e9a7977c956faec686a96f03/examples/models/llama/attention.py#L365-L366



### Test plan
Exporting qwen with coreml. Qwen config sets `use_qk_norm` to true in the config, and then fails because of CoreML fp16 conversion error. Looks like the custom RMSNorm explicitly casts to fp32. 

https://github.com/pytorch/executorch/blob/9cbe754f6ea66d99e9a7977c956faec686a96f03/examples/models/llama/norm.py#L54
