### PR TITLE
Use pytorch_tokenizer in coreml static runner

### DIFF
--- a/examples/apple/coreml/llama/run_static_llm.py
+++ b/examples/apple/coreml/llama/run_static_llm.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """
-Run script for static attention Llama models exported with coreml_static_llama.py.
+Run script for static attention LLM models exported with export_static_llm_coreml.py.
 
 Usage:
     python run_static_llm.py \
@@ -21,7 +21,6 @@ import json
 import time
 from typing import Any, Dict, List, Tuple
 
-import sentencepiece as spm
 import torch
 import torch.utils._pytree as pytree
 
@@ -29,50 +28,14 @@ from executorch.examples.models.llama.model_args import ModelArgs
 from executorch.examples.models.llama.runner.generation import next_token
 from executorch.examples.models.llama.static_attention import StaticAttentionIOManager
 from executorch.runtime import Runtime
+from pytorch_tokenizers import get_tokenizer
 
 
-class Tokenizer:
-    """Wrapper to support both SentencePiece and Tiktoken tokenizers."""
-
-    def __init__(self, model_path: str):
-        try:
-            print("Trying to load sentencepiece")
-            sp = spm.SentencePieceProcessor()
-            sp.load(model_path)
-            self.tokenizer = sp
-            self._is_sentencepiece = True
-        except Exception:
-            print("Trying to load tiktoken")
-            from executorch.examples.models.llama.tokenizer import tiktoken
-
-            self.tokenizer = tiktoken.Tokenizer(model_path)
-            self._is_sentencepiece = False
-
-    def encode(self, text: str, bos: bool = True, eos: bool = False) -> List[int]:
-        if self._is_sentencepiece:
-            bos_string = "<s>" if bos else ""
-            eos_string = "</s>" if eos else ""
-            return self.tokenizer.encode(f"{bos_string}{text}{eos_string}")
-        return self.tokenizer.encode(text, bos=bos, eos=eos)
-
-    def decode(self, tokens: List[int]) -> str:
-        if self._is_sentencepiece:
-            return self.tokenizer.decode(tokens)
-        return self.tokenizer.decode(tokens)
-
-    def decode_token(self, token: int) -> str:
-        if self._is_sentencepiece:
-            return self.tokenizer.decode([token])
-        try:
-            return self.tokenizer.decode_token(token)
-        except UnicodeDecodeError:
-            return f"<{token}>"
-
-    @property
-    def stop_tokens(self) -> List[int]:
-        if self._is_sentencepiece:
-            return [self.tokenizer.eos_id()]
-        return self.tokenizer.stop_tokens
+def get_stop_tokens(tokenizer) -> List[int]:
+    """Get stop tokens from tokenizer, falling back to eos_id if not available."""
+    if hasattr(tokenizer, "stop_tokens"):
+        return tokenizer.stop_tokens
+    return [tokenizer.eos_id]
 
 
 def create_pte_wrapper(
@@ -144,6 +107,12 @@ def main():
         help="Path to tokenizer model",
     )
     parser.add_argument(
+        "--tokenizer_config",
+        type=str,
+        default=None,
+        help="Path to tokenizer config (required for HuggingFace tokenizers)",
+    )
+    parser.add_argument(
         "--prompt",
         type=str,
         default="Once upon a time,",
@@ -206,7 +175,8 @@ def main():
     args = parser.parse_args()
 
     # Load tokenizer
-    tokenizer = Tokenizer(args.tokenizer)
+    tokenizer = get_tokenizer(args.tokenizer, args.tokenizer_config)
+    stop_tokens = get_stop_tokens(tokenizer)
 
     # Load model params
     with open(args.params, "r") as f:
@@ -291,7 +261,7 @@ def main():
             ngram_size=args.ngram_size,
             window_size=args.window_size,
             n_verifications=args.n_verifications,
-            stop_tokens=tokenizer.stop_tokens,
+            stop_tokens=stop_tokens,
         )
     else:
         # Use standard autoregressive decoding
@@ -299,12 +269,12 @@ def main():
             model_fn,
             first_token,
             n=args.max_new_tokens - 1,  # -1 because first_token counts
-            stop_tokens=tokenizer.stop_tokens,
+            stop_tokens=stop_tokens,
         )
 
     # Print generated tokens (skip first as it's the init_token we already printed)
     for token in generated_tokens[1:]:
-        if token in tokenizer.stop_tokens:
+        if token in stop_tokens:
             break
         print(tokenizer.decode_token(token), end="", flush=True)
 


### PR DESCRIPTION
### Summary
Lora models created with unsloth use HFTokenizer, not supported by the static runner.

### Test plan
Export llama1b lora model
```
python export_static_llm_coreml.py \
      --checkpoint $LLAMA1B/original/consolidated.00.pth  \
      --params $LLAMA1B/original/params.json \
      --adapter_checkpoint $LLAMA1B/lora/adapter_model.safetensors \
      --adapter_config $LLAMA1B/lora/adapter_config.json \
      --output coreml-llama1b-lora.pte \
      --max_context_len 1024
```
Run llama1b lora model 
```
(executorch) lfq@lfq-mbp llama % python run_static_llm.py \
    --model /Users/lfq/executorch/examples/apple/coreml/llama/coreml-llama1b-lora.pte \
    --params $LLAMA1B/original/params.json \
    --tokenizer $LLAMA1B/tokenizer.json \
    --tokenizer_config $LLAMA1B/tokenizer_config.json \
    --prompt "What is 15% of 80?" \
    --max_new_tokens 100 
W0114 16:23:07.644390 81771 site-packages/torch/distributed/elastic/multiprocessing/redirects.py:29] NOTE: Redirects are currently not supported in Windows or MacOs.
W0114 16:23:08.208112 81771 site-packages/torch/utils/flop_counter.py:45] triton not found; flop counting will not work for triton kernels
W0114 16:23:08.208413 81771 site-packages/torch/utils/flop_counter.py:45] triton not found; flop counting will not work for triton kernels
W0114 16:23:08.208502 81771 site-packages/torch/utils/flop_counter.py:45] triton not found; flop counting will not work for triton kernels
W0114 16:23:08.208578 81771 site-packages/torch/utils/flop_counter.py:45] triton not found; flop counting will not work for triton kernels
W0114 16:23:08.208648 81771 site-packages/torch/utils/flop_counter.py:45] triton not found; flop counting will not work for triton kernels
W0114 16:23:08.208904 81771 site-packages/torch/utils/flop_counter.py:45] triton not found; flop counting will not work for triton kernels
W0114 16:23:08.208997 81771 site-packages/torch/utils/flop_counter.py:45] triton not found; flop counting will not work for triton kernels
W0114 16:23:08.209072 81771 site-packages/torch/utils/flop_counter.py:45] triton not found; flop counting will not work for triton kernels
W0114 16:23:08.209149 81771 site-packages/torch/utils/flop_counter.py:45] triton not found; flop counting will not work for triton kernels
W0114 16:23:08.209216 81771 site-packages/torch/utils/flop_counter.py:45] triton not found; flop counting will not work for triton kernels
W0114 16:23:08.209280 81771 site-packages/torch/utils/flop_counter.py:45] triton not found; flop counting will not work for triton kernels
W0114 16:23:08.209353 81771 site-packages/torch/utils/flop_counter.py:45] triton not found; flop counting will not work for triton kernels
W0114 16:23:08.209419 81771 site-packages/torch/utils/flop_counter.py:45] triton not found; flop counting will not work for triton kernels
I tokenizers:regex.cpp:27] Registering override fallback regex
Model config: 16 layers, dim=2048
Input length: 32, Cache length: 992
Loading model from /Users/lfq/executorch/examples/apple/coreml/llama/coreml-llama1b-lora.pte...
[program.cpp:154] InternalConsistency verification requested but not available
[ETCoreMLModelManager.mm:474] Cache Hit: Successfully retrieved compiled model with identifier=executorch_2d7b5a72-14ac-4133-b35d-269dd19a3ed5_cpu_and_ne from the models cache.
[ETCoreMLModelManager.mm:474] Cache Hit: Successfully retrieved compiled model with identifier=executorch_9d2dc1da-5080-4b9c-a49d-031352db1b03_cpu_and_ne from the models cache.
[ETCoreMLModelManager.mm:474] Cache Hit: Successfully retrieved compiled model with identifier=executorch_4dd01157-98ab-4a24-b89b-abd4b98b1f3e_cpu_and_ne from the models cache.
Method metadata: num_inputs=36, num_outputs=33

Prompt: What is 15% of 80?
Prompt tokens: 10
--------------------------------------------------
Prefilling... done in 0.15s

What is 15% of 80? - 15% of 80 is equal to 12. The answer is 0.12. The answer is 0.12. The answer is 0.12. The answer is 0.12. The answer is 0.12. The answer is 0.12. The answer is 0.12. The answer is 0.12. The answer is 0.12. The answer is 0.12. The answer is 0.12
--------------------------------------------------
Prefill: 10 tokens in 0.15s
Decode: 100 tokens in 7.18s (13.92 tok/s)
```