### PR TITLE
Fix shift overflow warning for 32-bit ARM builds

### DIFF
--- a/runtime/executor/tensor_parser_exec_aten.cpp
+++ b/runtime/executor/tensor_parser_exec_aten.cpp
@@ -55,15 +55,15 @@ ET_NODISCARD Result<void*> getMemPlannedPtr(
   const uint32_t memory_offset_high = allocation_info->memory_offset_high();
 
   size_t memory_offset = memory_offset_low;
-  if ((sizeof(size_t) > sizeof(uint32_t)) && (memory_offset_high > 0)) {
-    // The compiler should remove this always-true check on 64-bit systems.
+  if constexpr (sizeof(size_t) > sizeof(uint32_t)) {
+    memory_offset |= static_cast<size_t>(memory_offset_high) << 32;
+  } else {
     ET_CHECK_OR_RETURN_ERROR(
-        sizeof(size_t) >= sizeof(uint64_t),
+        memory_offset_high == 0,
         NotSupported,
-        "size_t cannot hold memory offset 0x%08" PRIx32 ".%08" PRIx32,
+        "size_t cannot hold memory offset 0x%08" PRIx32 "%08" PRIx32,
         memory_offset_high,
         memory_offset_low);
-    memory_offset |= static_cast<size_t>(memory_offset_high) << 32;
   }
   return allocator->get_offset_address(memory_id, memory_offset, nbytes);
 }


### PR DESCRIPTION
### Summary
Use if constexpr to prevent GCC from compiling the 64-bit memory offset shift on 32-bit systems where size_t is 32 bits. Also add validation that rejects models requiring >32-bit offsets on 32-bit systems.

```
/home/rja/executorch/runtime/executor/tensor_parser_exec_aten.cpp: In
function 'executorch::runtime::Result<void*>
executorch::runtime::deserialization::{anonymous}::getMemPlannedPtr(const
executorch_flatbuffer::AllocationDetails*, size_t,
executorch::runtime::HierarchicalAllocator*)':
/home/rja/executorch/runtime/executor/tensor_parser_exec_aten.cpp:66:62:
warning: left shift count >= width of type [-Wshift-count-overflow]
   66 |     memory_offset |= static_cast<size_t>(memory_offset_high) << 32;
      |
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
```

### Test lan
```
examples/arm/setup.sh --i-agree-to-the-contained-eula
source examples/arm/arm-scratch/setup_path.sh
backends/cortex_m/test/build_test_runner.sh
```
