### PR TITLE
Cortex-M backend: Enable MVE in Zephyr build

### DIFF
--- a/examples/arm/zephyr/prj.conf
+++ b/examples/arm/zephyr/prj.conf
@@ -1,6 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -34,3 +34,7 @@ CONFIG_ETHOS_U=y
 CONFIG_EXECUTORCH_METHOD_ALLOCATOR_POOL_SIZE=262144
 # Ethos-U scratch memory requirements scale with the compiled network.
 CONFIG_EXECUTORCH_TEMP_ALLOCATOR_POOL_SIZE=1572864
+
+# Enable Helium (MVE) builds of CMSIS-NN by selecting the FPU and hard-float ABI.
+CONFIG_FPU=y
+CONFIG_FP_HARDABI=y


### PR DESCRIPTION
Before CMSIS-NN was built for zephyr w/o MVE enabled.

cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai