### PR TITLE
Optimize Parakeet export by combining components to reduce CPU-GPU round trips

### DIFF
--- a/examples/models/parakeet/main.cpp
+++ b/examples/models/parakeet/main.cpp
@@ -110,7 +110,6 @@ std::vector<Token> greedy_decode_executorch(
     const ::executorch::aten::Tensor& f_proj,
     int64_t encoder_len,
     int64_t blank_id,
-    int64_t vocab_size,
     int64_t num_rnn_layers = 2,
     int64_t pred_hidden = 640,
     int64_t max_symbols_per_step = 10) {
@@ -396,13 +395,7 @@ int main(int argc, char** argv) {
 
   ET_LOG(Info, "Running TDT greedy decode...");
   auto decoded_tokens = greedy_decode_executorch(
-      *model,
-      f_proj,
-      encoded_len,
-      blank_id,
-      vocab_size,
-      num_rnn_layers,
-      pred_hidden);
+      *model, f_proj, encoded_len, blank_id, num_rnn_layers, pred_hidden);
 
   ET_LOG(Info, "Decoded %zu tokens", decoded_tokens.size());
 


### PR DESCRIPTION
Summary:

Reduces CPU↔GPU data transfer overhead in Parakeet TDT inference by combining related neural network components into fewer ExecuTorch methods.

Previously, the encoder output required a separate joint_project_encoder call, and each token emission required separate decoder_predict and joint_project_decoder calls. This caused unnecessary round trips between CPU and GPU memory.

Now, encoder includes the transpose and projection operations, and decoder_step combines the RNN step with projection. This reduces exported methods from 6 to 4 and eliminates ~51 CPU↔GPU round trips per utterance (~1 for encoder, ~50 for decoder tokens).

Also do argmax in directly in GPU

Test plan

 - Export with --backend metal succeeds
 - C++ runner produces correct transcription
 - Timestamps match expected output
 - Optimized the whole inference from 650 downto 550ms. Thanks @manuelcandales for helping with the profiling.
