### PR TITLE
Metal backend: compute init/execute times

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -167,7 +167,8 @@
         "llm-release"
       ],
       "cacheVariables": {
-        "EXECUTORCH_BUILD_METAL": "ON"
+        "EXECUTORCH_BUILD_METAL": "ON",
+        "EXECUTORCH_METAL_COLLECT_STATS": "OFF"
       },
       "condition": {
         "lhs": "${hostSystemName}",
@@ -209,6 +210,23 @@
       ],
       "cacheVariables": {
         "EXECUTORCH_BUILD_METAL": "ON"
+      },
+      "condition": {
+        "lhs": "${hostSystemName}",
+        "type": "equals",
+        "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "llm-metal-stats",
+      "displayName": "LLM Metal build with stats collection and logging",
+      "inherits": [
+        "llm-release-metal"
+      ],
+      "cacheVariables": {
+        "EXECUTORCH_METAL_COLLECT_STATS": "ON",
+        "EXECUTORCH_ENABLE_LOGGING": "ON",
+        "EXECUTORCH_LOG_LEVEL": "Info"
       },
       "condition": {
         "lhs": "${hostSystemName}",
@@ -320,6 +338,15 @@
         "install"
       ],
       "jobs": 0
+    },
+    {
+      "name": "llm-metal-stats-install",
+      "displayName": "Build and install LLM extension artifacts with Metal stats",
+      "configurePreset": "llm-metal-stats",
+      "targets": [
+        "install"
+      ],
+      "jobs": 0
     }
   ],
   "workflowPresets": [
@@ -404,6 +431,20 @@
         {
           "type": "build",
           "name": "llm-debug-metal-install"
+        }
+      ]
+    },
+    {
+      "name": "llm-metal-stats",
+      "displayName": "Configure, build and install ExecuTorch LLM extension with Metal stats and logging",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "llm-metal-stats"
+        },
+        {
+          "type": "build",
+          "name": "llm-metal-stats-install"
         }
       ]
     }

--- a/backends/apple/metal/CMakeLists.txt
+++ b/backends/apple/metal/CMakeLists.txt
@@ -74,7 +74,9 @@ target_compile_definitions(metal_backend PUBLIC ET_BUILD_METAL)
 
 # Define macro for stats collection if enabled
 if(EXECUTORCH_METAL_COLLECT_STATS)
-  target_compile_definitions(metal_backend PUBLIC EXECUTORCH_METAL_COLLECT_STATS)
+  target_compile_definitions(
+    metal_backend PUBLIC EXECUTORCH_METAL_COLLECT_STATS
+  )
   message(STATUS "Metal backend stats collection enabled")
 endif()
 

--- a/backends/apple/metal/CMakeLists.txt
+++ b/backends/apple/metal/CMakeLists.txt
@@ -69,6 +69,9 @@ target_link_libraries(
 
 target_compile_options(metal_backend PUBLIC -fexceptions -frtti -fPIC)
 
+# Define C++ preprocessor macro for Metal backend availability
+target_compile_definitions(metal_backend PUBLIC ET_BUILD_METAL)
+
 target_link_options(metal_backend PUBLIC -Wl,-export_dynamic)
 
 # Find PyTorch's OpenMP library specifically for libtorch-less AOTI

--- a/backends/apple/metal/CMakeLists.txt
+++ b/backends/apple/metal/CMakeLists.txt
@@ -36,6 +36,7 @@ find_package_torch()
 
 set(_aoti_metal_sources
     runtime/metal_backend.cpp
+    runtime/stats.cpp
     runtime/shims/memory.cpp
     runtime/shims/et_metal.mm
     runtime/shims/et_metal_ops.mm

--- a/backends/apple/metal/CMakeLists.txt
+++ b/backends/apple/metal/CMakeLists.txt
@@ -72,6 +72,12 @@ target_compile_options(metal_backend PUBLIC -fexceptions -frtti -fPIC)
 # Define C++ preprocessor macro for Metal backend availability
 target_compile_definitions(metal_backend PUBLIC ET_BUILD_METAL)
 
+# Define macro for stats collection if enabled
+if(EXECUTORCH_METAL_COLLECT_STATS)
+  target_compile_definitions(metal_backend PUBLIC EXECUTORCH_METAL_COLLECT_STATS)
+  message(STATUS "Metal backend stats collection enabled")
+endif()
+
 target_link_options(metal_backend PUBLIC -Wl,-export_dynamic)
 
 # Find PyTorch's OpenMP library specifically for libtorch-less AOTI

--- a/backends/apple/metal/runtime/metal_backend.cpp
+++ b/backends/apple/metal/runtime/metal_backend.cpp
@@ -37,14 +37,19 @@ namespace executorch::backends::metal {
 static double g_execute_total_ms = 0.0;
 static int64_t g_execute_call_count = 0;
 
-// Per-method timing statistics
+// Timing statistics for init() calls
+static double g_init_total_ms = 0.0;
+static int64_t g_init_call_count = 0;
+
+// Per-method timing statistics (for both init and execute)
 struct MethodStats {
   double total_ms = 0.0;
   int64_t call_count = 0;
 };
 static std::unordered_map<std::string, MethodStats> g_method_stats;
+static std::unordered_map<std::string, MethodStats> g_init_method_stats;
 
-// Accessor functions for timing statistics
+// Accessor functions for execute timing statistics
 double get_metal_backend_execute_total_ms() {
   return g_execute_total_ms;
 }
@@ -53,16 +58,37 @@ int64_t get_metal_backend_execute_call_count() {
   return g_execute_call_count;
 }
 
+// Accessor functions for init timing statistics
+double get_metal_backend_init_total_ms() {
+  return g_init_total_ms;
+}
+
+int64_t get_metal_backend_init_call_count() {
+  return g_init_call_count;
+}
+
 void reset_metal_backend_execute_stats() {
   g_execute_total_ms = 0.0;
   g_execute_call_count = 0;
+  g_init_total_ms = 0.0;
+  g_init_call_count = 0;
   g_method_stats.clear();
+  g_init_method_stats.clear();
 }
 
 std::unordered_map<std::string, std::pair<double, int64_t>>
 get_metal_backend_per_method_stats() {
   std::unordered_map<std::string, std::pair<double, int64_t>> result;
   for (const auto& entry : g_method_stats) {
+    result[entry.first] = {entry.second.total_ms, entry.second.call_count};
+  }
+  return result;
+}
+
+std::unordered_map<std::string, std::pair<double, int64_t>>
+get_metal_backend_init_per_method_stats() {
+  std::unordered_map<std::string, std::pair<double, int64_t>> result;
+  for (const auto& entry : g_init_method_stats) {
     result[entry.first] = {entry.second.total_ms, entry.second.call_count};
   }
   return result;
@@ -173,6 +199,7 @@ class ET_EXPERIMENTAL MetalBackend final
       FreeableBuffer* processed, // This will be a empty buffer
       ArrayRef<CompileSpec> compile_specs // This will be my empty list
   ) const override {
+    auto init_start = std::chrono::high_resolution_clock::now();
     ET_LOG(Info, "MetalBackend::init - Starting initialization");
 
     std::string method_name;
@@ -297,6 +324,22 @@ class ET_EXPERIMENTAL MetalBackend final
     }
 
     ET_LOG(Info, "MetalBackend::init - Initialization completed successfully");
+
+    // Accumulate init timing statistics
+    auto init_end = std::chrono::high_resolution_clock::now();
+    double elapsed_ms =
+        std::chrono::duration<double, std::milli>(init_end - init_start)
+            .count();
+    g_init_total_ms += elapsed_ms;
+    g_init_call_count++;
+
+    // Track per-method init timing
+    if (!method_name.empty()) {
+      auto& stats = g_init_method_stats[method_name];
+      stats.total_ms += elapsed_ms;
+      stats.call_count++;
+    }
+
     return (DelegateHandle*)handle; // Return the handle post-processing
   }
 

--- a/backends/apple/metal/runtime/metal_backend.cpp
+++ b/backends/apple/metal/runtime/metal_backend.cpp
@@ -76,7 +76,7 @@ int64_t get_metal_backend_init_call_count() {
   return g_init_call_count;
 }
 
-void reset_metal_backend_execute_stats() {
+void reset_metal_backend_stats() {
   std::lock_guard<std::mutex> lock(g_stats_mutex);
   g_execute_total_ms = 0.0;
   g_execute_call_count = 0;

--- a/backends/apple/metal/runtime/metal_backend.cpp
+++ b/backends/apple/metal/runtime/metal_backend.cpp
@@ -30,6 +30,7 @@
 #include <executorch/backends/apple/metal/runtime/shims/shim_mps.h>
 #include <executorch/backends/apple/metal/runtime/shims/tensor_attribute.h>
 #include <executorch/backends/apple/metal/runtime/shims/utils.h>
+#include <executorch/backends/apple/metal/runtime/stats.h>
 
 namespace executorch::backends::metal {
 

--- a/backends/apple/metal/runtime/metal_backend.cpp
+++ b/backends/apple/metal/runtime/metal_backend.cpp
@@ -35,6 +35,8 @@
 
 namespace executorch::backends::metal {
 
+#ifdef EXECUTORCH_METAL_COLLECT_STATS
+
 // Per-method timing statistics
 struct MethodStats {
   double total_ms = 0.0;
@@ -116,6 +118,8 @@ get_metal_backend_init_per_method_stats() {
   }
   return result;
 }
+
+#endif // EXECUTORCH_METAL_COLLECT_STATS
 
 #define LOAD_SYMBOL(handle, member, name, so_handle)                        \
   do {                                                                      \
@@ -222,7 +226,9 @@ class ET_EXPERIMENTAL MetalBackend final
       FreeableBuffer* processed, // This will be a empty buffer
       ArrayRef<CompileSpec> compile_specs // This will be my empty list
   ) const override {
+#ifdef EXECUTORCH_METAL_COLLECT_STATS
     auto init_start = std::chrono::high_resolution_clock::now();
+#endif
     ET_LOG(Info, "MetalBackend::init - Starting initialization");
 
     std::string method_name;
@@ -348,6 +354,7 @@ class ET_EXPERIMENTAL MetalBackend final
 
     ET_LOG(Info, "MetalBackend::init - Initialization completed successfully");
 
+#ifdef EXECUTORCH_METAL_COLLECT_STATS
     // Accumulate init timing statistics
     auto init_end = std::chrono::high_resolution_clock::now();
     double elapsed_ms =
@@ -367,6 +374,7 @@ class ET_EXPERIMENTAL MetalBackend final
         method_stats.call_count++;
       }
     }
+#endif
 
     return (DelegateHandle*)handle; // Return the handle post-processing
   }
@@ -376,7 +384,9 @@ class ET_EXPERIMENTAL MetalBackend final
       BackendExecutionContext& context,
       DelegateHandle* handle_,
       Span<EValue*> args) const override {
+#ifdef EXECUTORCH_METAL_COLLECT_STATS
     auto execute_start = std::chrono::high_resolution_clock::now();
+#endif
     ET_LOG(Debug, "MetalBackend execute");
 
     AOTIDelegateHandle* handle = (AOTIDelegateHandle*)handle_;
@@ -622,6 +632,7 @@ class ET_EXPERIMENTAL MetalBackend final
 
     ET_LOG(Debug, "MetalBackend execution completed successfully");
 
+#ifdef EXECUTORCH_METAL_COLLECT_STATS
     // Accumulate timing statistics
     auto execute_end = std::chrono::high_resolution_clock::now();
     double elapsed_ms =
@@ -642,6 +653,7 @@ class ET_EXPERIMENTAL MetalBackend final
         method_stats.call_count++;
       }
     }
+#endif
 
     return Error::Ok;
   }

--- a/backends/apple/metal/runtime/shims/et_metal.h
+++ b/backends/apple/metal/runtime/shims/et_metal.h
@@ -367,6 +367,9 @@ void synchronize_metal_stream_with_type(int sync_type);
 double get_metal_backend_execute_total_ms();
 int64_t get_metal_backend_execute_call_count();
 void reset_metal_backend_execute_stats();
+// Returns map of method_name -> (total_ms, call_count)
+std::unordered_map<std::string, std::pair<double, int64_t>>
+get_metal_backend_per_method_stats();
 
 // =======================
 // Metal helper functions (C interface)

--- a/backends/apple/metal/runtime/shims/et_metal.h
+++ b/backends/apple/metal/runtime/shims/et_metal.h
@@ -364,12 +364,22 @@ void synchronize_metal_stream_with_type(int sync_type);
 // =======================
 // Metal backend timing statistics
 // =======================
+// Execute timing
 double get_metal_backend_execute_total_ms();
 int64_t get_metal_backend_execute_call_count();
-void reset_metal_backend_execute_stats();
 // Returns map of method_name -> (total_ms, call_count)
 std::unordered_map<std::string, std::pair<double, int64_t>>
 get_metal_backend_per_method_stats();
+
+// Init timing
+double get_metal_backend_init_total_ms();
+int64_t get_metal_backend_init_call_count();
+// Returns map of method_name -> (total_ms, call_count) for init
+std::unordered_map<std::string, std::pair<double, int64_t>>
+get_metal_backend_init_per_method_stats();
+
+// Reset all timing stats
+void reset_metal_backend_execute_stats();
 
 // =======================
 // Metal helper functions (C interface)

--- a/backends/apple/metal/runtime/shims/et_metal.h
+++ b/backends/apple/metal/runtime/shims/et_metal.h
@@ -362,6 +362,13 @@ void synchronize_metal_stream();
 void synchronize_metal_stream_with_type(int sync_type);
 
 // =======================
+// Metal backend timing statistics
+// =======================
+double get_metal_backend_execute_total_ms();
+int64_t get_metal_backend_execute_call_count();
+void reset_metal_backend_execute_stats();
+
+// =======================
 // Metal helper functions (C interface)
 // =======================
 #ifdef __cplusplus

--- a/backends/apple/metal/runtime/shims/et_metal.h
+++ b/backends/apple/metal/runtime/shims/et_metal.h
@@ -362,26 +362,6 @@ void synchronize_metal_stream();
 void synchronize_metal_stream_with_type(int sync_type);
 
 // =======================
-// Metal backend timing statistics
-// =======================
-// Execute timing
-double get_metal_backend_execute_total_ms();
-int64_t get_metal_backend_execute_call_count();
-// Returns map of method_name -> (total_ms, call_count)
-std::unordered_map<std::string, std::pair<double, int64_t>>
-get_metal_backend_per_method_stats();
-
-// Init timing
-double get_metal_backend_init_total_ms();
-int64_t get_metal_backend_init_call_count();
-// Returns map of method_name -> (total_ms, call_count) for init
-std::unordered_map<std::string, std::pair<double, int64_t>>
-get_metal_backend_init_per_method_stats();
-
-// Reset all timing stats
-void reset_metal_backend_execute_stats();
-
-// =======================
 // Metal helper functions (C interface)
 // =======================
 #ifdef __cplusplus

--- a/backends/apple/metal/runtime/stats.cpp
+++ b/backends/apple/metal/runtime/stats.cpp
@@ -7,6 +7,9 @@
  */
 
 #include <executorch/backends/apple/metal/runtime/stats.h>
+
+#ifdef EXECUTORCH_METAL_COLLECT_STATS
+
 #include <iostream>
 
 namespace executorch {
@@ -79,3 +82,5 @@ void print_metal_backend_stats() {
 } // namespace metal
 } // namespace backends
 } // namespace executorch
+
+#endif // EXECUTORCH_METAL_COLLECT_STATS

--- a/backends/apple/metal/runtime/stats.cpp
+++ b/backends/apple/metal/runtime/stats.cpp
@@ -14,7 +14,7 @@ namespace backends {
 namespace metal {
 
 void print_metal_backend_stats() {
-  std::cout << "\n--- Metal Backend ---" << std::endl;
+  std::cout << "\n--- Metal Backend Performance Statistics ---" << std::endl;
 
   // Init stats
   double metal_init_total_ms = get_metal_backend_init_total_ms();
@@ -72,6 +72,8 @@ void print_metal_backend_stats() {
       std::cout << std::endl;
     }
   }
+
+  std::cout << "\n--------------------------------------------" << std::endl;
 }
 
 } // namespace metal

--- a/backends/apple/metal/runtime/stats.cpp
+++ b/backends/apple/metal/runtime/stats.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/apple/metal/runtime/stats.h>
+#include <iostream>
+
+namespace executorch {
+namespace backends {
+namespace metal {
+
+void print_metal_backend_stats() {
+  std::cout << "\n--- Metal Backend ---" << std::endl;
+
+  // Init stats
+  double metal_init_total_ms = get_metal_backend_init_total_ms();
+  int64_t metal_init_call_count = get_metal_backend_init_call_count();
+  std::cout << "Metal init() total: " << metal_init_total_ms << " ms ("
+            << metal_init_call_count << " calls)";
+  if (metal_init_call_count > 0) {
+    std::cout << " (avg: " << metal_init_total_ms / metal_init_call_count
+              << " ms/call)";
+  }
+  std::cout << std::endl;
+
+  // Per-method init breakdown
+  auto init_per_method_stats = get_metal_backend_init_per_method_stats();
+  if (!init_per_method_stats.empty()) {
+    std::cout << "  Per-method init breakdown:" << std::endl;
+    for (const auto& entry : init_per_method_stats) {
+      const std::string& method_name = entry.first;
+      double method_total_ms = entry.second.first;
+      int64_t method_call_count = entry.second.second;
+      std::cout << "    " << method_name << ": " << method_total_ms << " ms ("
+                << method_call_count << " calls)";
+      if (method_call_count > 0) {
+        std::cout << " (avg: " << method_total_ms / method_call_count
+                  << " ms/call)";
+      }
+      std::cout << std::endl;
+    }
+  }
+
+  // Execute stats
+  double metal_total_ms = get_metal_backend_execute_total_ms();
+  int64_t metal_call_count = get_metal_backend_execute_call_count();
+  std::cout << "\nMetal execute() total: " << metal_total_ms << " ms ("
+            << metal_call_count << " calls)";
+  if (metal_call_count > 0) {
+    std::cout << " (avg: " << metal_total_ms / metal_call_count << " ms/call)";
+  }
+  std::cout << std::endl;
+
+  // Per-method execute breakdown
+  auto per_method_stats = get_metal_backend_per_method_stats();
+  if (!per_method_stats.empty()) {
+    std::cout << "  Per-method execute breakdown:" << std::endl;
+    for (const auto& entry : per_method_stats) {
+      const std::string& method_name = entry.first;
+      double method_total_ms = entry.second.first;
+      int64_t method_call_count = entry.second.second;
+      std::cout << "    " << method_name << ": " << method_total_ms << " ms ("
+                << method_call_count << " calls)";
+      if (method_call_count > 0) {
+        std::cout << " (avg: " << method_total_ms / method_call_count
+                  << " ms/call)";
+      }
+      std::cout << std::endl;
+    }
+  }
+}
+
+} // namespace metal
+} // namespace backends
+} // namespace executorch

--- a/backends/apple/metal/runtime/stats.cpp
+++ b/backends/apple/metal/runtime/stats.cpp
@@ -73,7 +73,7 @@ void print_metal_backend_stats() {
     }
   }
 
-  std::cout << "\n--------------------------------------------" << std::endl;
+  std::cout << "--------------------------------------------\n" << std::endl;
 }
 
 } // namespace metal

--- a/backends/apple/metal/runtime/stats.h
+++ b/backends/apple/metal/runtime/stats.h
@@ -13,6 +13,8 @@
 #include <unordered_map>
 #include <utility>
 
+#include <executorch/runtime/platform/log.h>
+
 namespace executorch {
 namespace backends {
 namespace metal {
@@ -67,7 +69,12 @@ get_metal_backend_init_per_method_stats() {
   return {};
 }
 inline void reset_metal_backend_stats() {}
-inline void print_metal_backend_stats() {}
+inline void print_metal_backend_stats() {
+  ET_LOG(
+      Info,
+      "Metal backend stats collection is disabled. "
+      "Set EXECUTORCH_METAL_COLLECT_STATS=ON to collect stats.");
+}
 
 #endif // EXECUTORCH_METAL_COLLECT_STATS
 

--- a/backends/apple/metal/runtime/stats.h
+++ b/backends/apple/metal/runtime/stats.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+namespace executorch {
+namespace backends {
+namespace metal {
+
+// =======================
+// Metal backend timing statistics
+// =======================
+
+// Execute timing
+double get_metal_backend_execute_total_ms();
+int64_t get_metal_backend_execute_call_count();
+// Returns map of method_name -> (total_ms, call_count)
+std::unordered_map<std::string, std::pair<double, int64_t>>
+get_metal_backend_per_method_stats();
+
+// Init timing
+double get_metal_backend_init_total_ms();
+int64_t get_metal_backend_init_call_count();
+// Returns map of method_name -> (total_ms, call_count) for init
+std::unordered_map<std::string, std::pair<double, int64_t>>
+get_metal_backend_init_per_method_stats();
+
+// Reset all timing stats
+void reset_metal_backend_execute_stats();
+
+// Print all timing stats to stdout
+void print_metal_backend_stats();
+
+} // namespace metal
+} // namespace backends
+} // namespace executorch

--- a/backends/apple/metal/runtime/stats.h
+++ b/backends/apple/metal/runtime/stats.h
@@ -36,7 +36,7 @@ std::unordered_map<std::string, std::pair<double, int64_t>>
 get_metal_backend_init_per_method_stats();
 
 // Reset all timing stats
-void reset_metal_backend_execute_stats();
+void reset_metal_backend_stats();
 
 // Print all timing stats to stdout
 void print_metal_backend_stats();

--- a/backends/apple/metal/runtime/stats.h
+++ b/backends/apple/metal/runtime/stats.h
@@ -21,6 +21,8 @@ namespace metal {
 // Metal backend timing statistics
 // =======================
 
+#ifdef EXECUTORCH_METAL_COLLECT_STATS
+
 // Execute timing
 double get_metal_backend_execute_total_ms();
 int64_t get_metal_backend_execute_call_count();
@@ -40,6 +42,34 @@ void reset_metal_backend_stats();
 
 // Print all timing stats to stdout
 void print_metal_backend_stats();
+
+#else // !EXECUTORCH_METAL_COLLECT_STATS
+
+// No-op stubs when stats collection is disabled
+inline double get_metal_backend_execute_total_ms() {
+  return 0.0;
+}
+inline int64_t get_metal_backend_execute_call_count() {
+  return 0;
+}
+inline std::unordered_map<std::string, std::pair<double, int64_t>>
+get_metal_backend_per_method_stats() {
+  return {};
+}
+inline double get_metal_backend_init_total_ms() {
+  return 0.0;
+}
+inline int64_t get_metal_backend_init_call_count() {
+  return 0;
+}
+inline std::unordered_map<std::string, std::pair<double, int64_t>>
+get_metal_backend_init_per_method_stats() {
+  return {};
+}
+inline void reset_metal_backend_stats() {}
+inline void print_metal_backend_stats() {}
+
+#endif // EXECUTORCH_METAL_COLLECT_STATS
 
 } // namespace metal
 } // namespace backends

--- a/examples/models/parakeet/main.cpp
+++ b/examples/models/parakeet/main.cpp
@@ -7,7 +7,6 @@
  */
 
 #include <algorithm>
-#include <chrono>
 #include <cmath>
 #include <cstdint>
 #include <cstring>
@@ -420,22 +419,9 @@ int main(int argc, char** argv) {
       decoded_tokens, *tokenizer);
   std::cout << "Transcribed text: " << text << std::endl;
 
-  // Print performance statistics
-  std::cout << "\n=== Performance Statistics ===" << std::endl;
-
-  // Calculate audio duration in seconds
-  double audio_duration_sec =
-      static_cast<double>(audio_data.size()) / static_cast<double>(sample_rate);
-
-  std::cout << "\nAudio duration: " << audio_duration_sec << " seconds"
-            << std::endl;
-  std::cout << "Tokens decoded: " << decoded_tokens.size() << std::endl;
-
 #ifdef ET_BUILD_METAL
   executorch::backends::metal::print_metal_backend_stats();
 #endif // ET_BUILD_METAL
-
-  std::cout << "==============================\n" << std::endl;
 
   if (!timestamp_mode.enabled()) {
     return 0;

--- a/examples/models/parakeet/main.cpp
+++ b/examples/models/parakeet/main.cpp
@@ -33,7 +33,7 @@
 #include <executorch/extension/tensor/tensor_ptr_maker.h>
 #include <executorch/runtime/core/evalue.h>
 #include <executorch/runtime/platform/log.h>
-#ifdef EXECUTORCH_BUILD_METAL
+#ifdef ET_BUILD_METAL
 #include <executorch/backends/apple/metal/runtime/stats.h>
 #endif
 
@@ -431,9 +431,9 @@ int main(int argc, char** argv) {
             << std::endl;
   std::cout << "Tokens decoded: " << decoded_tokens.size() << std::endl;
 
-#ifdef EXECUTORCH_BUILD_METAL
+#ifdef ET_BUILD_METAL
   executorch::backends::metal::print_metal_backend_stats();
-#endif // EXECUTORCH_BUILD_METAL
+#endif // ET_BUILD_METAL
 
   std::cout << "==============================\n" << std::endl;
 

--- a/examples/models/parakeet/main.cpp
+++ b/examples/models/parakeet/main.cpp
@@ -442,6 +442,25 @@ int main(int argc, char** argv) {
   }
   std::cout << std::endl;
 
+  // Per-method breakdown
+  auto per_method_stats =
+      executorch::backends::metal::get_metal_backend_per_method_stats();
+  if (!per_method_stats.empty()) {
+    std::cout << "\nPer-method breakdown:" << std::endl;
+    for (const auto& entry : per_method_stats) {
+      const std::string& method_name = entry.first;
+      double method_total_ms = entry.second.first;
+      int64_t method_call_count = entry.second.second;
+      std::cout << "  " << method_name << ": " << method_total_ms << " ms ("
+                << method_call_count << " calls)";
+      if (method_call_count > 0) {
+        std::cout << " (avg: " << method_total_ms / method_call_count
+                  << " ms/call)";
+      }
+      std::cout << std::endl;
+    }
+  }
+
   std::cout << "==============================\n" << std::endl;
 
   if (!timestamp_mode.enabled()) {

--- a/examples/models/parakeet/main.cpp
+++ b/examples/models/parakeet/main.cpp
@@ -33,7 +33,9 @@
 #include <executorch/extension/tensor/tensor_ptr_maker.h>
 #include <executorch/runtime/core/evalue.h>
 #include <executorch/runtime/platform/log.h>
+#ifdef EXECUTORCH_BUILD_METAL
 #include <executorch/backends/apple/metal/runtime/shims/et_metal.h>
+#endif
 
 DEFINE_string(model_path, "parakeet.pte", "Path to Parakeet model (.pte).");
 DEFINE_string(audio_path, "", "Path to input audio file (.wav).");
@@ -429,6 +431,7 @@ int main(int argc, char** argv) {
             << std::endl;
   std::cout << "Tokens decoded: " << decoded_tokens.size() << std::endl;
 
+#ifdef EXECUTORCH_BUILD_METAL
   // Metal backend statistics
   std::cout << "\n--- Metal Backend ---" << std::endl;
 
@@ -494,6 +497,7 @@ int main(int argc, char** argv) {
       std::cout << std::endl;
     }
   }
+#endif // EXECUTORCH_BUILD_METAL
 
   std::cout << "==============================\n" << std::endl;
 

--- a/examples/models/parakeet/main.cpp
+++ b/examples/models/parakeet/main.cpp
@@ -34,7 +34,7 @@
 #include <executorch/runtime/core/evalue.h>
 #include <executorch/runtime/platform/log.h>
 #ifdef EXECUTORCH_BUILD_METAL
-#include <executorch/backends/apple/metal/runtime/shims/et_metal.h>
+#include <executorch/backends/apple/metal/runtime/stats.h>
 #endif
 
 DEFINE_string(model_path, "parakeet.pte", "Path to Parakeet model (.pte).");
@@ -432,71 +432,7 @@ int main(int argc, char** argv) {
   std::cout << "Tokens decoded: " << decoded_tokens.size() << std::endl;
 
 #ifdef EXECUTORCH_BUILD_METAL
-  // Metal backend statistics
-  std::cout << "\n--- Metal Backend ---" << std::endl;
-
-  // Init stats
-  double metal_init_total_ms =
-      executorch::backends::metal::get_metal_backend_init_total_ms();
-  int64_t metal_init_call_count =
-      executorch::backends::metal::get_metal_backend_init_call_count();
-  std::cout << "Metal init() total: " << metal_init_total_ms << " ms ("
-            << metal_init_call_count << " calls)";
-  if (metal_init_call_count > 0) {
-    std::cout << " (avg: " << metal_init_total_ms / metal_init_call_count
-              << " ms/call)";
-  }
-  std::cout << std::endl;
-
-  // Per-method init breakdown
-  auto init_per_method_stats =
-      executorch::backends::metal::get_metal_backend_init_per_method_stats();
-  if (!init_per_method_stats.empty()) {
-    std::cout << "  Per-method init breakdown:" << std::endl;
-    for (const auto& entry : init_per_method_stats) {
-      const std::string& method_name = entry.first;
-      double method_total_ms = entry.second.first;
-      int64_t method_call_count = entry.second.second;
-      std::cout << "    " << method_name << ": " << method_total_ms << " ms ("
-                << method_call_count << " calls)";
-      if (method_call_count > 0) {
-        std::cout << " (avg: " << method_total_ms / method_call_count
-                  << " ms/call)";
-      }
-      std::cout << std::endl;
-    }
-  }
-
-  // Execute stats
-  double metal_total_ms =
-      executorch::backends::metal::get_metal_backend_execute_total_ms();
-  int64_t metal_call_count =
-      executorch::backends::metal::get_metal_backend_execute_call_count();
-  std::cout << "\nMetal execute() total: " << metal_total_ms << " ms ("
-            << metal_call_count << " calls)";
-  if (metal_call_count > 0) {
-    std::cout << " (avg: " << metal_total_ms / metal_call_count << " ms/call)";
-  }
-  std::cout << std::endl;
-
-  // Per-method execute breakdown
-  auto per_method_stats =
-      executorch::backends::metal::get_metal_backend_per_method_stats();
-  if (!per_method_stats.empty()) {
-    std::cout << "  Per-method execute breakdown:" << std::endl;
-    for (const auto& entry : per_method_stats) {
-      const std::string& method_name = entry.first;
-      double method_total_ms = entry.second.first;
-      int64_t method_call_count = entry.second.second;
-      std::cout << "    " << method_name << ": " << method_total_ms << " ms ("
-                << method_call_count << " calls)";
-      if (method_call_count > 0) {
-        std::cout << " (avg: " << method_total_ms / method_call_count
-                  << " ms/call)";
-      }
-      std::cout << std::endl;
-    }
-  }
+  executorch::backends::metal::print_metal_backend_stats();
 #endif // EXECUTORCH_BUILD_METAL
 
   std::cout << "==============================\n" << std::endl;

--- a/examples/models/parakeet/main.cpp
+++ b/examples/models/parakeet/main.cpp
@@ -431,27 +431,61 @@ int main(int argc, char** argv) {
 
   // Metal backend statistics
   std::cout << "\n--- Metal Backend ---" << std::endl;
+
+  // Init stats
+  double metal_init_total_ms =
+      executorch::backends::metal::get_metal_backend_init_total_ms();
+  int64_t metal_init_call_count =
+      executorch::backends::metal::get_metal_backend_init_call_count();
+  std::cout << "Metal init() total: " << metal_init_total_ms << " ms ("
+            << metal_init_call_count << " calls)";
+  if (metal_init_call_count > 0) {
+    std::cout << " (avg: " << metal_init_total_ms / metal_init_call_count
+              << " ms/call)";
+  }
+  std::cout << std::endl;
+
+  // Per-method init breakdown
+  auto init_per_method_stats =
+      executorch::backends::metal::get_metal_backend_init_per_method_stats();
+  if (!init_per_method_stats.empty()) {
+    std::cout << "  Per-method init breakdown:" << std::endl;
+    for (const auto& entry : init_per_method_stats) {
+      const std::string& method_name = entry.first;
+      double method_total_ms = entry.second.first;
+      int64_t method_call_count = entry.second.second;
+      std::cout << "    " << method_name << ": " << method_total_ms << " ms ("
+                << method_call_count << " calls)";
+      if (method_call_count > 0) {
+        std::cout << " (avg: " << method_total_ms / method_call_count
+                  << " ms/call)";
+      }
+      std::cout << std::endl;
+    }
+  }
+
+  // Execute stats
   double metal_total_ms =
       executorch::backends::metal::get_metal_backend_execute_total_ms();
   int64_t metal_call_count =
       executorch::backends::metal::get_metal_backend_execute_call_count();
-  std::cout << "Metal execute() total: " << metal_total_ms << " ms ("
+  std::cout << "\nMetal execute() total: " << metal_total_ms << " ms ("
             << metal_call_count << " calls)";
   if (metal_call_count > 0) {
     std::cout << " (avg: " << metal_total_ms / metal_call_count << " ms/call)";
   }
   std::cout << std::endl;
 
-  // Per-method breakdown
+  // Per-method execute breakdown
   auto per_method_stats =
       executorch::backends::metal::get_metal_backend_per_method_stats();
   if (!per_method_stats.empty()) {
-    std::cout << "\nPer-method breakdown:" << std::endl;
+    std::cout << "  Per-method execute breakdown:" << std::endl;
     for (const auto& entry : per_method_stats) {
       const std::string& method_name = entry.first;
       double method_total_ms = entry.second.first;
       int64_t method_call_count = entry.second.second;
-      std::cout << "  " << method_name << ": " << method_total_ms << " ms ("
+      std::cout << "    " << method_name << ": " << method_total_ms << " ms ("
                 << method_call_count << " calls)";
       if (method_call_count > 0) {
         std::cout << " (avg: " << method_total_ms / method_call_count

--- a/tools/cmake/preset/default.cmake
+++ b/tools/cmake/preset/default.cmake
@@ -164,6 +164,10 @@ define_overridable_option(
   EXECUTORCH_BUILD_METAL "Build the Metal backend" BOOL OFF
 )
 define_overridable_option(
+  EXECUTORCH_METAL_COLLECT_STATS
+  "Enable Metal backend performance statistics collection" BOOL OFF
+)
+define_overridable_option(
   EXECUTORCH_BUILD_VGF "Build the Arm VGF backend" BOOL OFF
 )
 define_overridable_option(


### PR DESCRIPTION
This pull request introduces detailed performance tracking and reporting for the Metal backend, focusing on timing statistics for both initialization and execution phases. It adds infrastructure to collect, reset, and print timing data, and integrates statistics output into the Parakeet model example. Additionally, a preprocessor macro is defined to signal Metal backend availability.

**Metal Backend Performance Statistics:**

* Added timing statistics collection for `init()` and `execute()` calls in the Metal backend, including total time, call count, and per-method breakdowns. Accessor and reset functions are provided in `stats.h` and implemented in `metal_backend.cpp`.
* Introduced a new `stats.cpp` file with a function to print all collected Metal backend statistics, including per-method breakdowns for both initialization and execution.

**Build and Integration Improvements:**

* Added `runtime/stats.cpp` to the Metal backend build sources and defined the `ET_BUILD_METAL` preprocessor macro to indicate Metal backend support.

**Example Model Enhancements:**

* Updated the Parakeet example (`main.cpp`) to show Metal backend timing stats after model execution if Metal is enabled.

These changes provide better visibility into Metal backend performance and make it easier to profile and optimize model execution on Apple devices.
