### PR TITLE
Arm backend: Use .module() in minimal examples

### DIFF
--- a/backends/arm/scripts/TOSA_minimal_example.ipynb
+++ b/backends/arm/scripts/TOSA_minimal_example.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Copyright 2025 Arm Limited and/or its affiliates.\n",
+    "# Copyright 2025-2026 Arm Limited and/or its affiliates.\n",
     "#\n",
     "# This source code is licensed under the BSD-style license found in the\n",
     "# LICENSE file in the root directory of this source tree."
@@ -62,7 +62,7 @@
     "model = Add()\n",
     "model = model.eval()\n",
     "exported_program = torch.export.export(model, example_inputs)\n",
-    "graph_module = exported_program.graph_module\n",
+    "graph_module = exported_program.module(check_guards=False)\n",
     "\n",
     "_ = graph_module.print_readable()"
    ]

--- a/docs/source/backends/arm-ethos-u/tutorials/ethos-u-getting-started.md
+++ b/docs/source/backends/arm-ethos-u/tutorials/ethos-u-getting-started.md
@@ -78,7 +78,7 @@ example_inputs = (torch.ones(1,1,1,1),torch.ones(1,1,1,1))
 model = Add()
 model = model.eval()
 exported_program = torch.export.export(model, example_inputs)
-graph_module = exported_program.graph_module
+graph_module = exported_program.module(check_guards=False)
 
 
 from executorch.backends.arm.ethosu import EthosUCompileSpec

--- a/docs/source/backends/arm-vgf/tutorials/vgf-getting-started.md
+++ b/docs/source/backends/arm-vgf/tutorials/vgf-getting-started.md
@@ -91,7 +91,7 @@ example_inputs = (torch.ones(1,1,1,1),torch.ones(1,1,1,1))
 model = AddSigmoid()
 model = model.eval()
 exported_program = torch.export.export(model, example_inputs)
-graph_module = exported_program.graph_module
+graph_module = exported_program.module(check_guards=False)
 
 
 from executorch.backends.arm.quantizer import (

--- a/examples/arm/ethos_u_minimal_example.ipynb
+++ b/examples/arm/ethos_u_minimal_example.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Copyright 2025 Arm Limited and/or its affiliates.\n",
+    "# Copyright 2025-2026 Arm Limited and/or its affiliates.\n",
     "#\n",
     "# This source code is licensed under the BSD-style license found in the\n",
     "# LICENSE file in the root directory of this source tree."
@@ -58,7 +58,7 @@
     "model = Add()\n",
     "model = model.eval()\n",
     "exported_program = torch.export.export(model, example_inputs)\n",
-    "graph_module = exported_program.graph_module\n",
+    "graph_module = exported_program.module(check_guards=False)\n",
     "\n",
     "_ = graph_module.print_readable()"
    ]
@@ -160,7 +160,7 @@
     "            config=ExecutorchBackendConfig(extract_delegate_segments=False)\n",
     "        )\n",
     "\n",
-    "_ = executorch_program_manager.exported_program().graph_module.print_readable()\n",
+    "_ = executorch_program_manager.exported_program().module(check_guards=False).print_readable()\n",
     "\n",
     "# Save pte file\n",
     "save_pte_program(executorch_program_manager, \"ethos_u_minimal_example.pte\")"

--- a/examples/arm/vgf_minimal_example.ipynb
+++ b/examples/arm/vgf_minimal_example.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Copyright 2025 Arm Limited and/or its affiliates.\n",
+    "# Copyright 2025-2026 Arm Limited and/or its affiliates.\n",
     "#\n",
     "# This source code is licensed under the BSD-style license found in the\n",
     "# LICENSE file in the root directory of this source tree."
@@ -61,7 +61,7 @@
     "model = AddSigmoid()\n",
     "model = model.eval()\n",
     "exported_program = torch.export.export(model, example_inputs)\n",
-    "graph_module = exported_program.graph_module\n",
+    "graph_module = exported_program.module(check_guards=False)\n",
     "\n",
     "_ = graph_module.print_readable()"
    ]
@@ -210,7 +210,7 @@
     "            config=ExecutorchBackendConfig(extract_delegate_segments=False)\n",
     ")\n",
     "\n",
-    "executorch_program_manager.exported_program().graph_module.print_readable()\n",
+    "executorch_program_manager.exported_program().module(check_guards=False).print_readable()\n",
     "\n",
     "# Save pte file\n",
     "cwd_dir = os.getcwd()\n",


### PR DESCRIPTION
.graph_module doesn't work for models with weights. Also set check_guards=False, guards don't work well with et. This is addressed in et in a rather hacky way, see https://github.com/pytorch/pytorch/blob/19d8ad08cd8c6ee15c34117daaaea04d929778e4/torch/export/_unlift.py#L734

cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai