### PR TITLE
NXP backend: Update neutron-converter flavor to SDK_25_12

### DIFF
--- a/backends/nxp/backend/edge_program_converter.py
+++ b/backends/nxp/backend/edge_program_converter.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 NXP
+# Copyright 2024-2026 NXP
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -56,7 +56,7 @@ class EdgeProgramToIRConverter:
     """
 
     _default_conversion_config = ConversionConfig()
-    _default_target_spec = NeutronTargetSpec("imxrt700", "SDK_25_09")
+    _default_target_spec = NeutronTargetSpec("imxrt700", "SDK_25_12")
     _default_delegation_options = CustomDelegationOptions()
 
     def convert_program(

--- a/backends/nxp/backend/neutron_converter_manager.py
+++ b/backends/nxp/backend/neutron_converter_manager.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 NXP
+# Copyright 2024-2026 NXP
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -28,7 +28,7 @@ class NeutronConverterManager:
 
     def __init__(
         self,
-        neutron_converter_flavor: str = "SDK_25_09",
+        neutron_converter_flavor: str = "SDK_25_12",
     ):
 
         neutron_converter_modules = [

--- a/backends/nxp/nxp_backend.py
+++ b/backends/nxp/nxp_backend.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 NXP
+# Copyright 2024-2026 NXP
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -67,7 +67,7 @@ class NeutronCompileSpecBuilder:
         Args:
             config: Neutron accelerator configuration, e.g. "imxrt700"
             neutron_converter_flavor: Flavor of the neutron-converter module to use. Neutron-converter module named "
-             "'neutron_converter_SDK_25_09' has flavor 'SDK_25_09'.
+             "'neutron_converter_SDK_25_12' has flavor 'SDK_25_12'.
             extra_flags: Extra flags for the Neutron compiler
             operators_not_to_delegate: List of operators that should not be delegated
             use_neutron_for_format_conversion: If True, the EdgeProgramToIRConverter will insert `Transpose` ops to

--- a/backends/nxp/requirements-tests-eiq.txt
+++ b/backends/nxp/requirements-tests-eiq.txt
@@ -1,2 +1,2 @@
 --index-url https://eiq.nxp.com/repository
-neutron_converter_SDK_25_09
+neutron_converter_SDK_25_12

--- a/backends/nxp/tests/executorch_pipeline.py
+++ b/backends/nxp/tests/executorch_pipeline.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 NXP
+# Copyright 2024-2026 NXP
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -38,7 +38,7 @@ from torch import nn
 from torch.export import export
 from torchao.quantization.pt2e.quantizer import Quantizer
 
-neutron_converter_flavor = "SDK_25_09"
+neutron_converter_flavor = "SDK_25_12"
 neutron_target_spec = NeutronTargetSpec(
     target="imxrt700", neutron_converter_flavor=neutron_converter_flavor
 )

--- a/backends/nxp/tests/ir/converter/node_converter/test_cat_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_cat_converter.py
@@ -1,4 +1,4 @@
-# Copyright 2025 NXP
+# Copyright 2025-2026 NXP
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -363,7 +363,7 @@ def test_cat__same_shapes_converter_padding_last_dimension(use_qat):
         CatModule(2),
         [input_shape, input_shape],
         target=target,
-        neutron_converter_flavor="SDK_25_09",
+        neutron_converter_flavor="SDK_25_12",
         custom_delegation_options=CustomDelegationOptions(),
         use_qat=use_qat,
     ).exported_program()
@@ -385,7 +385,7 @@ def test_cat__same_shapes__channels_first__padding_channels(use_qat):
         CatConvModule(1),
         [input_shape, input_shape],
         target=target,
-        neutron_converter_flavor="SDK_25_09",
+        neutron_converter_flavor="SDK_25_12",
         custom_delegation_options=CustomDelegationOptions(),
         use_qat=use_qat,
     ).exported_program()

--- a/backends/nxp/tests/ir/converter/node_converter/test_slice_tensor_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_slice_tensor_converter.py
@@ -1,4 +1,4 @@
-# Copyright 2025 NXP
+# Copyright 2025-2026 NXP
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -46,9 +46,21 @@ def reseed_model_per_test_run():
             (24, 32, 64, 48),
             id="4D, no transpose",
         ),
-        pytest.param((24, 32), (0, 1), (8, 0), (24, 32), id="2D, one transpose"),
         pytest.param(
-            (24, 32, 64), (0, 1, 2), (0, 8, 0), (24, 32, 64), id="3D, one transpose"
+            (24, 32),
+            (0, 1),
+            (8, 0),
+            (24, 32),
+            id="2D, one transpose",
+            marks=pytest.mark.xfail(reason="EIEX-649", strict=True),
+        ),
+        pytest.param(
+            (24, 32, 64),
+            (0, 1, 2),
+            (0, 8, 0),
+            (24, 32, 64),
+            id="3D, one transpose",
+            marks=pytest.mark.xfail(reason="EIEX-649", strict=True),
         ),
         pytest.param(
             (24, 32, 64, 48),
@@ -56,9 +68,15 @@ def reseed_model_per_test_run():
             (0, 0, 8, 0),
             (24, 32, 64, 48),
             id="4D, one transpose",
+            marks=pytest.mark.xfail(reason="EIEX-649", strict=True),
         ),
         pytest.param(
-            (24, 32, 64), (0, 1, 2), (8, 8, 0), (24, 32, 64), id="3D, two transposes"
+            (24, 32, 64),
+            (0, 1, 2),
+            (8, 8, 0),
+            (24, 32, 64),
+            id="3D, two transposes",
+            marks=pytest.mark.xfail(reason="EIEX-649", strict=True),
         ),
         # bug in neutron-converter will not properly convert models in these test cases
         # pytest.param((24, 32, 64, 48), (0, 1, 2, 3), (16, 0, 8, 0), (24, 32, 64, 48), id="4D, two transposes"),
@@ -127,6 +145,7 @@ def test_slice_tensor_quant_conversion(mocker, x_input_shape, dims, starts, ends
             (0, 0, 8, 0),
             (1, 8, 32, 32),
             id="4D, handle channel order swap",
+            marks=pytest.mark.xfail(reason="EIEX-649", strict=True),
         )
     ],
 )

--- a/backends/nxp/tests/test_edge_passes.py
+++ b/backends/nxp/tests/test_edge_passes.py
@@ -1,4 +1,4 @@
-# Copyright 2025 NXP
+# Copyright 2025-2026 NXP
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -319,7 +319,7 @@ class TestEdgePasses(unittest.TestCase):
 
         edge_program_manager = edge_program_manager.transform(NeutronEdgePassManager())
 
-        compile_spec = generate_neutron_compile_spec(target, "SDK_25_09")
+        compile_spec = generate_neutron_compile_spec(target, "SDK_25_12")
         partitioner = NeutronPartitioner(
             compile_spec, neutron_target_spec, custom_delegation_options
         )

--- a/backends/nxp/tests/test_neutron_backend_executor.py
+++ b/backends/nxp/tests/test_neutron_backend_executor.py
@@ -1,4 +1,4 @@
-# Copyright 2024 NXP
+# Copyright 2024-2026 NXP
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -165,7 +165,7 @@ def test_delegating_format_related_transpose_operators__supported_case(mocker):
     # Make sure the output channels (channels for the trailing Transpose), and the last input dimension (channels for
     #  the leading Transpose) are multiples of `num_macs``.
 
-    num_macs = NeutronTargetSpec("imxrt700", "SDK_25_09").get_num_macs()
+    num_macs = NeutronTargetSpec("imxrt700", "SDK_25_12").get_num_macs()
     model = Conv2dModule(
         in_channels=num_macs, out_channels=num_macs, padding=1, stride=1
     )
@@ -222,7 +222,7 @@ def test_delegating_format_related_transpose_operators__supported_case(mocker):
 def test_delegating_format_related_transpose_operators__supported_output__unsupported_input(
     mocker,
 ):
-    num_macs = NeutronTargetSpec("imxrt700", "SDK_25_09").get_num_macs()
+    num_macs = NeutronTargetSpec("imxrt700", "SDK_25_12").get_num_macs()
     model = Conv2dModule(
         in_channels=num_macs,
         out_channels=num_macs,  # The output `Transpose` will be supported.
@@ -278,7 +278,7 @@ def test_delegating_format_related_transpose_operators__supported_output__unsupp
 def test_delegating_format_related_transpose_operators__supported_input__unsupported_output(
     mocker,
 ):
-    num_macs = NeutronTargetSpec("imxrt700", "SDK_25_09").get_num_macs()
+    num_macs = NeutronTargetSpec("imxrt700", "SDK_25_12").get_num_macs()
     model = Conv2dModule(
         in_channels=num_macs,
         out_channels=3,  # The output `Transpose` will NOT be supported.

--- a/backends/nxp/tests/test_split_group_convolution.py
+++ b/backends/nxp/tests/test_split_group_convolution.py
@@ -56,7 +56,7 @@ def _quantize_and_lower_module(
         edge_compile_config=edge_compile_config,
     )
 
-    compile_spec = generate_neutron_compile_spec(target, "SDK_25_09")
+    compile_spec = generate_neutron_compile_spec(target, "SDK_25_12")
     partitioner = NeutronPartitioner(compile_spec, neutron_target_spec)
     return edge_program_manager.to_backend(partitioner)
 

--- a/docs/source/backends/nxp/nxp-dim-order.md
+++ b/docs/source/backends/nxp/nxp-dim-order.md
@@ -87,7 +87,7 @@ installation see {doc}`nxp-overview`.
 
 ```
 python -m examples.nxp.aot_neutron_compile --quantize \
-    --delegate --neutron_converter_flavor SDK_25_09 -m cifar10 \
+    --delegate --neutron_converter_flavor SDK_25_12 -m cifar10 \
     --use_channels_last_dim_order
 ```
 

--- a/docs/source/backends/nxp/nxp-quantization.md
+++ b/docs/source/backends/nxp/nxp-quantization.md
@@ -64,7 +64,7 @@ from torchao.quantization.pt2e.quantize_pt2e import convert_pt2e, prepare_pt2e
 model = models.mobilenetv2.mobilenet_v2(weights=MobileNet_V2_Weights.DEFAULT).eval()
 sample_inputs = (torch.randn(1, 3, 224, 224), )
 
-target_spec = NeutronTargetSpec(target="imxrt700", converter_flavor="SDK_25_09")
+target_spec = NeutronTargetSpec(target="imxrt700", converter_flavor="SDK_25_12")
 quantizer = NeutronQuantizer(neutron_target_spec) # (1)
 
 training_ep = torch.export.export(model, sample_inputs).module() # (2)
@@ -78,7 +78,7 @@ quantized_model = convert_pt2e(prepared_model) # (5)
 compile_spec = generate_neutron_compile_spec(
     "imxrt700",
     operators_not_to_delegate=None,
-    neutron_converter_flavor="SDK_25_06",
+    neutron_converter_flavor="SDK_25_12",
 )
 
 et_program = to_edge_transform_and_lower( # (6)
@@ -95,7 +95,7 @@ from executorch.backends.nxp.quantizer.utils import calibrate_and_quantize
 
 ...
 
-target_spec = NeutronTargetSpec(target="imxrt700", converter_flavor="SDK_25_09")
+target_spec = NeutronTargetSpec(target="imxrt700", converter_flavor="SDK_25_12")
 quantized_graph_module = calibrate_and_quantize(
     aten_model,
     calibration_inputs,

--- a/examples/nxp/README.md
+++ b/examples/nxp/README.md
@@ -36,11 +36,11 @@ The steps are expected to be executed from the `executorch` root folder.
 1. Run the `aot_neutron_compile.py` example with the `cifar10` model 
     ```commandline
     $ python -m examples.nxp.aot_neutron_compile --quantize \
-        --delegate --neutron_converter_flavor SDK_25_09 -m cifar10 
+        --delegate --neutron_converter_flavor SDK_25_12 -m cifar10 
     ```
 
 2. It will generate you `cifar10_nxp_delegate.pte` file which can be used with the MCUXpresso SDK `cifarnet_example` 
 project, presented [here](https://mcuxpresso.nxp.com/mcuxsdk/latest/html/middleware/eiq/executorch/docs/nxp/topics/example_applications.html#how-to-build-and-run-executorch-cifarnet-example).
 This project will guide you through the process of deploying your PTE model to the device.
 To get the MCUXpresso SDK follow this [guide](https://mcuxpresso.nxp.com/mcuxsdk/latest/html/middleware/eiq/executorch/docs/nxp/topics/getting_mcuxpresso.html),
-use the MCUXpresso SDK v25.09.00. 
+use the MCUXpresso SDK v25.12.00. 

--- a/examples/nxp/aot_neutron_compile.py
+++ b/examples/nxp/aot_neutron_compile.py
@@ -146,9 +146,9 @@ if __name__ == "__main__":  # noqa C901
         "-c",
         "--neutron_converter_flavor",
         required=False,
-        default="SDK_25_09",
+        default="SDK_25_12",
         help="Flavor of installed neutron-converter module. Neutron-converter module named "
-        "'neutron_converter_SDK_25_09' has flavor 'SDK_25_09'.",
+        "'neutron_converter_SDK_25_12' has flavor 'SDK_25_12'.",
     )
     parser.add_argument(
         "-q",

--- a/examples/nxp/run_aot_example.sh
+++ b/examples/nxp/run_aot_example.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2025 NXP
+# Copyright 2025-2026 NXP
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -13,6 +13,6 @@ cd $EXECUTORCH_DIR
 
 # Run the AoT example
 python -m examples.nxp.aot_neutron_compile --quantize \
-    --delegate --neutron_converter_flavor SDK_25_09 -m ${MODEL}
+    --delegate --neutron_converter_flavor SDK_25_12 -m ${MODEL}
 # verify file exists
 test -f ${MODEL}_nxp_delegate.pte

--- a/examples/nxp/setup.sh
+++ b/examples/nxp/setup.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
-# Copyright 2025 NXP
+# Copyright 2025-2026 NXP
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
 set -u
+EIQ_PYPI_URL=https://eiq.nxp.com/repository
+
 
 # Install neutron-converter
-pip install --index-url https://eiq.nxp.com/repository neutron_converter_SDK_25_09
+pip install --index-url ${EIQ_PYPI_URL} neutron_converter_SDK_25_12
 
 # Get the directory of the current script
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
### Summary
Update the neutron-converter to SDK_25.12
### Test plan
Using existing unittest

cc @JakeStevens @digantdesai