### PR TITLE
Fix Android emulator CI test file permission error

### DIFF
--- a/extension/android/executorch_android/src/androidTest/AndroidManifest.xml
+++ b/extension/android/executorch_android/src/androidTest/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <application>
     </application>
     <instrumentation

--- a/extension/android/executorch_android/src/androidTest/java/org/pytorch/executorch/LlmModuleInstrumentationTest.kt
+++ b/extension/android/executorch_android/src/androidTest/java/org/pytorch/executorch/LlmModuleInstrumentationTest.kt
@@ -7,9 +7,7 @@
  */
 package org.pytorch.executorch
 
-import android.Manifest
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.test.rule.GrantPermissionRule
 import java.io.File
 import java.io.IOException
 import java.net.URISyntaxException
@@ -19,7 +17,6 @@ import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.pytorch.executorch.TestFileUtils.getTestFilePath
@@ -50,10 +47,6 @@ class LlmModuleInstrumentationTest : LlmCallback {
     llmModule =
         LlmModule(getTestFilePath(TEST_FILE_NAME), getTestFilePath(TOKENIZER_FILE_NAME), 0.0f)
   }
-
-  @get:Rule
-  var runtimePermissionRule: GrantPermissionRule =
-      GrantPermissionRule.grant(Manifest.permission.READ_EXTERNAL_STORAGE)
 
   @Test
   @Throws(IOException::class, URISyntaxException::class)

--- a/extension/android/executorch_android/src/androidTest/java/org/pytorch/executorch/ModuleE2ETest.kt
+++ b/extension/android/executorch_android/src/androidTest/java/org/pytorch/executorch/ModuleE2ETest.kt
@@ -7,18 +7,15 @@
  */
 package org.pytorch.executorch
 
-import android.Manifest
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.test.rule.GrantPermissionRule
 import java.io.File
 import java.io.IOException
 import java.net.URISyntaxException
 import org.apache.commons.io.FileUtils
 import org.junit.Assert
 import org.junit.Assert.assertArrayEquals
-import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.pytorch.executorch.TensorImageUtils.bitmapToFloat32Tensor
@@ -27,9 +24,6 @@ import org.pytorch.executorch.TestFileUtils.getTestFilePath
 /** Unit tests for [Module]. */
 @RunWith(AndroidJUnit4::class)
 class ModuleE2ETest {
-  @get:Rule
-  var runtimePermissionRule: GrantPermissionRule =
-      GrantPermissionRule.grant(Manifest.permission.READ_EXTERNAL_STORAGE)
 
   @Throws(IOException::class, URISyntaxException::class)
   fun testClassification(filePath: String) {

--- a/extension/android/executorch_android/src/androidTest/java/org/pytorch/executorch/ModuleInstrumentationTest.kt
+++ b/extension/android/executorch_android/src/androidTest/java/org/pytorch/executorch/ModuleInstrumentationTest.kt
@@ -7,9 +7,7 @@
  */
 package org.pytorch.executorch
 
-import android.Manifest
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.test.rule.GrantPermissionRule
 import java.io.File
 import java.io.IOException
 import java.net.URISyntaxException
@@ -20,7 +18,6 @@ import org.apache.commons.io.FileUtils
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Ignore
-import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.pytorch.executorch.TestFileUtils.getTestFilePath
@@ -42,10 +39,6 @@ class ModuleInstrumentationTest {
     FileUtils.copyInputStreamToFile(inputStream, nonPteFile)
     inputStream.close()
   }
-
-  @get:Rule
-  var runtimePermissionRule: GrantPermissionRule =
-      GrantPermissionRule.grant(Manifest.permission.READ_EXTERNAL_STORAGE)
 
   @Ignore(
       "The forward has failure that needs to be fixed before enabling this test: [Executorch Error 0x12] Invalid argument: Execution failed for method: forward "

--- a/extension/android/executorch_android/src/androidTest/java/org/pytorch/executorch/TestFileUtils.kt
+++ b/extension/android/executorch_android/src/androidTest/java/org/pytorch/executorch/TestFileUtils.kt
@@ -6,7 +6,6 @@ import androidx.test.InstrumentationRegistry
 object TestFileUtils {
 
   fun getTestFilePath(fileName: String): String {
-    return InstrumentationRegistry.getInstrumentation().targetContext.externalCacheDir.toString() +
-        fileName
+    return InstrumentationRegistry.getInstrumentation().targetContext.cacheDir.toString() + fileName
   }
 }

--- a/extension/android/executorch_android/src/androidTest/java/org/pytorch/executorch/training/TrainingModuleE2ETest.kt
+++ b/extension/android/executorch_android/src/androidTest/java/org/pytorch/executorch/training/TrainingModuleE2ETest.kt
@@ -8,10 +8,8 @@
 
 package org.pytorch.executorch.training
 
-import android.Manifest
 import android.util.Log
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.test.rule.GrantPermissionRule
 import java.io.File
 import java.io.IOException
 import java.net.URISyntaxException
@@ -19,7 +17,6 @@ import kotlin.random.Random
 import kotlin.test.assertContains
 import org.apache.commons.io.FileUtils
 import org.junit.Assert
-import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.pytorch.executorch.EValue
@@ -29,9 +26,6 @@ import org.pytorch.executorch.TestFileUtils
 /** Unit tests for [TrainingModule]. */
 @RunWith(AndroidJUnit4::class)
 class TrainingModuleE2ETest {
-  @get:Rule
-  var runtimePermissionRule: GrantPermissionRule =
-      GrantPermissionRule.grant(Manifest.permission.READ_EXTERNAL_STORAGE)
 
   @Test
   @Throws(IOException::class, URISyntaxException::class)


### PR DESCRIPTION
This test has been failing for a while: https://hud.pytorch.org/hud/pytorch/executorch/main/1?per_page=50&name_filter=android%20%2F%20run-emulator

Use internal cache directory instead of external cache directory for
Android instrumentation tests. On Android API 34, scoped storage
restrictions prevent writing to external storage even for app-specific
directories. Internal storage (cacheDir) requires no permissions and
works reliably on all API levels.

- Change externalCacheDir to cacheDir in TestFileUtils
- Remove unnecessary READ_EXTERNAL_STORAGE permission from manifest
- Remove GrantPermissionRule from all test files


Test Plan: 

https://github.com/pytorch/executorch/actions/runs/21071703747
