### PR TITLE
Fail viable/strict update when no green commit found

### DIFF
--- a/.github/workflows/update-viablestrict.yml
+++ b/.github/workflows/update-viablestrict.yml
@@ -48,29 +48,32 @@ jobs:
 
           if [ -n "$VIABLE_SHA" ] && [ -n "$MAIN_SHA" ]; then
             # Get commits between viable/strict and main (up to 20)
-            # Use tab delimiter to avoid issues with pipe in names
+            # Use ASCII unit separator (0x1f) to avoid issues with special chars in names
             COMMITS=$(gh api "repos/pytorch/executorch/compare/${VIABLE_SHA}...${MAIN_SHA}" \
-              --jq '.commits | reverse | .[0:20] | .[] | "\(.sha)\t\(.commit.message | split("\n")[0] | gsub("[\\t\\|]"; " ") | .[0:50])"' 2>/dev/null || echo "")
+              --jq '.commits | reverse | .[0:20] | .[] | "\(.sha)\u001f\(.commit.message | split("\n")[0] | .[0:50])"' 2>/dev/null || echo "")
 
             if [ -n "$COMMITS" ]; then
               echo "| Commit | Title | Failed Job |" >> $GITHUB_STEP_SUMMARY
               echo "|--------|-------|------------|" >> $GITHUB_STEP_SUMMARY
 
-              while IFS=$'\t' read -r sha title; do
+              while IFS=$'\x1f' read -r sha title; do
                 [ -z "$sha" ] && continue
                 short_sha="${sha:0:7}"
+                # Sanitize title for markdown table
+                title=$(echo "$title" | tr '|' '-')
 
-                # Get workflow runs for this commit (use tab delimiter)
+                # Get workflow runs for this commit (use unit separator)
                 failed_run=$(gh api "repos/pytorch/executorch/actions/runs?head_sha=${sha}&per_page=100" \
-                  --jq '.workflow_runs[] | select(.conclusion == "failure" or .conclusion == "cancelled") | "\(.id)\t\(.name | gsub("[\\t\\|]"; " "))"' 2>/dev/null | head -1)
+                  --jq '.workflow_runs[] | select(.conclusion == "failure" or .conclusion == "cancelled") | "\(.id)\u001f\(.name)"' 2>/dev/null | head -1)
 
                 if [ -n "$failed_run" ]; then
-                  run_id=$(echo "$failed_run" | cut -f1)
-                  workflow_name=$(echo "$failed_run" | cut -f2)
+                  IFS=$'\x1f' read -r run_id workflow_name <<< "$failed_run"
+                  # Sanitize workflow name for markdown table
+                  workflow_name=$(echo "$workflow_name" | tr '|' '-')
 
-                  # Get failed job name (sanitize pipe and tab characters)
+                  # Get failed job name
                   failed_job=$(gh api "repos/pytorch/executorch/actions/runs/${run_id}/jobs?per_page=100" \
-                    --jq '.jobs[] | select(.conclusion == "failure" or .conclusion == "cancelled") | .name | gsub("[\\t\\|]"; " ")' 2>/dev/null | head -1)
+                    --jq '.jobs[] | select(.conclusion == "failure" or .conclusion == "cancelled") | .name' 2>/dev/null | head -1 | tr '|' '-')
 
                   echo "| ${short_sha} | ${title} | ${workflow_name} / ${failed_job:-unknown} |" >> $GITHUB_STEP_SUMMARY
                   found_failures=true
@@ -86,12 +89,15 @@ jobs:
             echo "| Commit | Title | Failed Job |" >> $GITHUB_STEP_SUMMARY
             echo "|--------|-------|------------|" >> $GITHUB_STEP_SUMMARY
 
-            # Filter by branch=main and use tab delimiter
+            # Filter by branch=main and use unit separator
             gh api "repos/pytorch/executorch/actions/runs?branch=main&per_page=20" \
-              --jq '.workflow_runs[] | select(.conclusion == "failure") | "\(.id)\t\(.head_sha | .[0:7])\t\(.display_title | gsub("[\\t\\|]"; " ") | .[0:50])\t\(.name | gsub("[\\t\\|]"; " "))"' 2>/dev/null | \
-            while IFS=$'\t' read -r run_id sha title workflow; do
+              --jq '.workflow_runs[] | select(.conclusion == "failure") | "\(.id)\u001f\(.head_sha | .[0:7])\u001f\(.display_title | .[0:50])\u001f\(.name)"' 2>/dev/null | \
+            while IFS=$'\x1f' read -r run_id sha title workflow; do
+              # Sanitize for markdown table
+              title=$(echo "$title" | tr '|' '-')
+              workflow=$(echo "$workflow" | tr '|' '-')
               failed_job=$(gh api "repos/pytorch/executorch/actions/runs/${run_id}/jobs?per_page=100" \
-                --jq '.jobs[] | select(.conclusion == "failure") | .name | gsub("[\\t\\|]"; " ")' 2>/dev/null | head -1)
+                --jq '.jobs[] | select(.conclusion == "failure") | .name' 2>/dev/null | head -1 | tr '|' '-')
               if [ -n "$failed_job" ]; then
                 echo "| ${sha} | ${title} | ${workflow} / ${failed_job} |" >> $GITHUB_STEP_SUMMARY
               fi

--- a/.github/workflows/update-viablestrict.yml
+++ b/.github/workflows/update-viablestrict.yml
@@ -42,17 +42,46 @@ jobs:
           echo "| Commit | Title | Failed Job |" >> $GITHUB_STEP_SUMMARY
           echo "|--------|-------|------------|" >> $GITHUB_STEP_SUMMARY
 
-          # Get failed workflow runs and their failed jobs
-          gh api repos/pytorch/executorch/actions/runs?per_page=50 \
-            --jq '.workflow_runs[] | select(.conclusion == "failure" or .conclusion == "cancelled") | "\(.id)|\(.head_sha | .[0:7])|\(.display_title | gsub("\\|"; "-") | .[0:50])|\(.name)"' 2>/dev/null | \
-          while IFS='|' read -r run_id sha title workflow; do
-            # Get failed or cancelled jobs for this run
-            failed_job=$(gh api "repos/pytorch/executorch/actions/runs/${run_id}/jobs?per_page=100" \
-              --jq '.jobs[] | select(.conclusion == "failure" or .conclusion == "cancelled") | .name' 2>/dev/null | head -1)
-            if [ -n "$failed_job" ]; then
-              echo "| ${sha} | ${title} | ${workflow} / ${failed_job} |" >> $GITHUB_STEP_SUMMARY
-            fi
-          done
+          # Get commits between viable/strict and main using GitHub API
+          VIABLE_SHA=$(gh api repos/pytorch/executorch/git/ref/heads/viable/strict --jq '.object.sha' 2>/dev/null || echo "")
+          MAIN_SHA=$(gh api repos/pytorch/executorch/git/ref/heads/main --jq '.object.sha' 2>/dev/null || echo "")
+
+          if [ -n "$VIABLE_SHA" ] && [ -n "$MAIN_SHA" ]; then
+            # Get commits between viable/strict and main (up to 20)
+            COMMITS=$(gh api "repos/pytorch/executorch/compare/${VIABLE_SHA}...${MAIN_SHA}" \
+              --jq '.commits | reverse | .[0:20] | .[] | "\(.sha)|\(.commit.message | split("\n")[0] | gsub("\\|"; "-") | .[0:50])"' 2>/dev/null || echo "")
+
+            while IFS='|' read -r sha title; do
+              [ -z "$sha" ] && continue
+              short_sha="${sha:0:7}"
+
+              # Get workflow runs for this commit
+              failed_run=$(gh api "repos/pytorch/executorch/actions/runs?head_sha=${sha}&per_page=100" \
+                --jq '.workflow_runs[] | select(.conclusion == "failure" or .conclusion == "cancelled") | "\(.id)|\(.name)"' 2>/dev/null | head -1)
+
+              if [ -n "$failed_run" ]; then
+                run_id=$(echo "$failed_run" | cut -d'|' -f1)
+                workflow_name=$(echo "$failed_run" | cut -d'|' -f2)
+
+                # Get failed job name
+                failed_job=$(gh api "repos/pytorch/executorch/actions/runs/${run_id}/jobs?per_page=100" \
+                  --jq '.jobs[] | select(.conclusion == "failure" or .conclusion == "cancelled") | .name' 2>/dev/null | head -1)
+
+                echo "| ${short_sha} | ${title} | ${workflow_name} / ${failed_job:-unknown} |" >> $GITHUB_STEP_SUMMARY
+              fi
+            done <<< "$COMMITS"
+          else
+            # Fallback: just show recent failed runs globally
+            gh api repos/pytorch/executorch/actions/runs?per_page=20 \
+              --jq '.workflow_runs[] | select(.conclusion == "failure") | "\(.id)|\(.head_sha | .[0:7])|\(.display_title | gsub("\\|"; "-") | .[0:50])|\(.name)"' 2>/dev/null | \
+            while IFS='|' read -r run_id sha title workflow; do
+              failed_job=$(gh api "repos/pytorch/executorch/actions/runs/${run_id}/jobs?per_page=100" \
+                --jq '.jobs[] | select(.conclusion == "failure") | .name' 2>/dev/null | head -1)
+              if [ -n "$failed_job" ]; then
+                echo "| ${sha} | ${title} | ${workflow} / ${failed_job} |" >> $GITHUB_STEP_SUMMARY
+              fi
+            done
+          fi
 
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Summary by job" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/update-viablestrict.yml
+++ b/.github/workflows/update-viablestrict.yml
@@ -50,7 +50,7 @@ jobs:
             # Get commits between viable/strict and main (up to 20)
             # Use ASCII unit separator (0x1f) to avoid issues with special chars in names
             COMMITS=$(gh api "repos/pytorch/executorch/compare/${VIABLE_SHA}...${MAIN_SHA}" \
-              --jq '.commits | reverse | .[0:20] | .[] | "\(.sha)\u001f\(.commit.message | split("\n")[0] | .[0:50])"' 2>/dev/null || echo "")
+              --jq '.commits | reverse | .[:20] | .[] | "\(.sha)\u001f\(.commit.message | split("\n")[0] | .[:50])"' 2>/dev/null || echo "")
 
             if [ -n "$COMMITS" ]; then
               echo "| Commit | Title | Failed Job |" >> $GITHUB_STEP_SUMMARY
@@ -64,7 +64,7 @@ jobs:
 
                 # Get workflow runs for this commit (use unit separator)
                 failed_run=$(gh api "repos/pytorch/executorch/actions/runs?head_sha=${sha}&per_page=100" \
-                  --jq '.workflow_runs[] | select(.conclusion == "failure" or .conclusion == "cancelled") | "\(.id)\u001f\(.name)"' 2>/dev/null | head -1)
+                  --jq '.workflow_runs[] | select(.conclusion == "failure") | "\(.id)\u001f\(.name)"' 2>/dev/null | head -1)
 
                 if [ -n "$failed_run" ]; then
                   IFS=$'\x1f' read -r run_id workflow_name <<< "$failed_run"
@@ -73,7 +73,7 @@ jobs:
 
                   # Get failed job name
                   failed_job=$(gh api "repos/pytorch/executorch/actions/runs/${run_id}/jobs?per_page=100" \
-                    --jq '.jobs[] | select(.conclusion == "failure" or .conclusion == "cancelled") | .name' 2>/dev/null | head -1 | tr '|' '-')
+                    --jq '.jobs[] | select(.conclusion == "failure") | .name' 2>/dev/null | head -1 | tr '|' '-')
 
                   echo "| ${short_sha} | ${title} | ${workflow_name} / ${failed_job:-unknown} |" >> $GITHUB_STEP_SUMMARY
                   found_failures=true
@@ -91,7 +91,7 @@ jobs:
 
             # Filter by branch=main and use unit separator
             gh api "repos/pytorch/executorch/actions/runs?branch=main&per_page=20" \
-              --jq '.workflow_runs[] | select(.conclusion == "failure") | "\(.id)\u001f\(.head_sha | .[0:7])\u001f\(.display_title | .[0:50])\u001f\(.name)"' 2>/dev/null | \
+              --jq '.workflow_runs[] | select(.conclusion == "failure") | "\(.id)\u001f\(.head_sha | .[:7])\u001f\(.display_title | .[:50])\u001f\(.name)"' 2>/dev/null | \
             while IFS=$'\x1f' read -r run_id sha title workflow; do
               # Sanitize for markdown table
               title=$(echo "$title" | tr '|' '-')
@@ -107,8 +107,8 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Summary by job (main branch, last 24h)" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
-          # Filter by main branch and created in last 24 hours
-          yesterday=$(date -u -d '24 hours ago' '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date -u -v-24H '+%Y-%m-%dT%H:%M:%SZ')
+          # Filter by main branch and created in last 24 hours (GNU date syntax for Ubuntu runner)
+          yesterday=$(date -u -d '24 hours ago' '+%Y-%m-%dT%H:%M:%SZ')
           gh api "repos/pytorch/executorch/actions/runs?branch=main&created=>${yesterday}&per_page=100" \
             --jq '.workflow_runs[] | select(.conclusion == "failure") | .name' 2>/dev/null \
             | sort | uniq -c | sort -rn | head -10 >> $GITHUB_STEP_SUMMARY || echo "Failed to fetch data" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/update-viablestrict.yml
+++ b/.github/workflows/update-viablestrict.yml
@@ -39,44 +39,59 @@ jobs:
 
           echo "### Failures by commit (recent)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Commit | Title | Failed Job |" >> $GITHUB_STEP_SUMMARY
-          echo "|--------|-------|------------|" >> $GITHUB_STEP_SUMMARY
 
           # Get commits between viable/strict and main using GitHub API
           VIABLE_SHA=$(gh api repos/pytorch/executorch/git/ref/heads/viable/strict --jq '.object.sha' 2>/dev/null || echo "")
           MAIN_SHA=$(gh api repos/pytorch/executorch/git/ref/heads/main --jq '.object.sha' 2>/dev/null || echo "")
 
+          found_failures=false
+
           if [ -n "$VIABLE_SHA" ] && [ -n "$MAIN_SHA" ]; then
             # Get commits between viable/strict and main (up to 20)
+            # Use tab delimiter to avoid issues with pipe in names
             COMMITS=$(gh api "repos/pytorch/executorch/compare/${VIABLE_SHA}...${MAIN_SHA}" \
-              --jq '.commits | reverse | .[0:20] | .[] | "\(.sha)|\(.commit.message | split("\n")[0] | gsub("\\|"; "-") | .[0:50])"' 2>/dev/null || echo "")
+              --jq '.commits | reverse | .[0:20] | .[] | "\(.sha)\t\(.commit.message | split("\n")[0] | gsub("[\\t\\|]"; " ") | .[0:50])"' 2>/dev/null || echo "")
 
-            while IFS='|' read -r sha title; do
-              [ -z "$sha" ] && continue
-              short_sha="${sha:0:7}"
+            if [ -n "$COMMITS" ]; then
+              echo "| Commit | Title | Failed Job |" >> $GITHUB_STEP_SUMMARY
+              echo "|--------|-------|------------|" >> $GITHUB_STEP_SUMMARY
 
-              # Get workflow runs for this commit
-              failed_run=$(gh api "repos/pytorch/executorch/actions/runs?head_sha=${sha}&per_page=100" \
-                --jq '.workflow_runs[] | select(.conclusion == "failure" or .conclusion == "cancelled") | "\(.id)|\(.name)"' 2>/dev/null | head -1)
+              while IFS=$'\t' read -r sha title; do
+                [ -z "$sha" ] && continue
+                short_sha="${sha:0:7}"
 
-              if [ -n "$failed_run" ]; then
-                run_id=$(echo "$failed_run" | cut -d'|' -f1)
-                workflow_name=$(echo "$failed_run" | cut -d'|' -f2)
+                # Get workflow runs for this commit (use tab delimiter)
+                failed_run=$(gh api "repos/pytorch/executorch/actions/runs?head_sha=${sha}&per_page=100" \
+                  --jq '.workflow_runs[] | select(.conclusion == "failure" or .conclusion == "cancelled") | "\(.id)\t\(.name | gsub("[\\t\\|]"; " "))"' 2>/dev/null | head -1)
 
-                # Get failed job name
-                failed_job=$(gh api "repos/pytorch/executorch/actions/runs/${run_id}/jobs?per_page=100" \
-                  --jq '.jobs[] | select(.conclusion == "failure" or .conclusion == "cancelled") | .name' 2>/dev/null | head -1)
+                if [ -n "$failed_run" ]; then
+                  run_id=$(echo "$failed_run" | cut -f1)
+                  workflow_name=$(echo "$failed_run" | cut -f2)
 
-                echo "| ${short_sha} | ${title} | ${workflow_name} / ${failed_job:-unknown} |" >> $GITHUB_STEP_SUMMARY
-              fi
-            done <<< "$COMMITS"
-          else
-            # Fallback: just show recent failed runs globally
-            gh api repos/pytorch/executorch/actions/runs?per_page=20 \
-              --jq '.workflow_runs[] | select(.conclusion == "failure") | "\(.id)|\(.head_sha | .[0:7])|\(.display_title | gsub("\\|"; "-") | .[0:50])|\(.name)"' 2>/dev/null | \
-            while IFS='|' read -r run_id sha title workflow; do
+                  # Get failed job name (sanitize pipe and tab characters)
+                  failed_job=$(gh api "repos/pytorch/executorch/actions/runs/${run_id}/jobs?per_page=100" \
+                    --jq '.jobs[] | select(.conclusion == "failure" or .conclusion == "cancelled") | .name | gsub("[\\t\\|]"; " ")' 2>/dev/null | head -1)
+
+                  echo "| ${short_sha} | ${title} | ${workflow_name} / ${failed_job:-unknown} |" >> $GITHUB_STEP_SUMMARY
+                  found_failures=true
+                fi
+              done <<< "$COMMITS"
+            fi
+          fi
+
+          if [ "$found_failures" = false ]; then
+            # Fallback: show recent failed runs from main branch only
+            echo "> Note: Could not determine commits between branches. Showing recent failures from main branch." >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "| Commit | Title | Failed Job |" >> $GITHUB_STEP_SUMMARY
+            echo "|--------|-------|------------|" >> $GITHUB_STEP_SUMMARY
+
+            # Filter by branch=main and use tab delimiter
+            gh api "repos/pytorch/executorch/actions/runs?branch=main&per_page=20" \
+              --jq '.workflow_runs[] | select(.conclusion == "failure") | "\(.id)\t\(.head_sha | .[0:7])\t\(.display_title | gsub("[\\t\\|]"; " ") | .[0:50])\t\(.name | gsub("[\\t\\|]"; " "))"' 2>/dev/null | \
+            while IFS=$'\t' read -r run_id sha title workflow; do
               failed_job=$(gh api "repos/pytorch/executorch/actions/runs/${run_id}/jobs?per_page=100" \
-                --jq '.jobs[] | select(.conclusion == "failure") | .name' 2>/dev/null | head -1)
+                --jq '.jobs[] | select(.conclusion == "failure") | .name | gsub("[\\t\\|]"; " ")' 2>/dev/null | head -1)
               if [ -n "$failed_job" ]; then
                 echo "| ${sha} | ${title} | ${workflow} / ${failed_job} |" >> $GITHUB_STEP_SUMMARY
               fi
@@ -84,9 +99,11 @@ jobs:
           fi
 
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Summary by job" >> $GITHUB_STEP_SUMMARY
+          echo "### Summary by job (main branch, last 24h)" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
-          gh api repos/pytorch/executorch/actions/runs?per_page=100 \
+          # Filter by main branch and created in last 24 hours
+          yesterday=$(date -u -d '24 hours ago' '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date -u -v-24H '+%Y-%m-%dT%H:%M:%SZ')
+          gh api "repos/pytorch/executorch/actions/runs?branch=main&created=>${yesterday}&per_page=100" \
             --jq '.workflow_runs[] | select(.conclusion == "failure") | .name' 2>/dev/null \
             | sort | uniq -c | sort -rn | head -10 >> $GITHUB_STEP_SUMMARY || echo "Failed to fetch data" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/update-viablestrict.yml
+++ b/.github/workflows/update-viablestrict.yml
@@ -44,11 +44,11 @@ jobs:
 
           # Get failed workflow runs and their failed jobs
           gh api repos/pytorch/executorch/actions/runs?per_page=50 \
-            --jq '.workflow_runs[] | select(.conclusion == "failure") | "\(.id)|\(.head_sha | .[0:7])|\(.display_title | gsub("\\|"; "-") | .[0:50])|\(.name)"' 2>/dev/null | \
+            --jq '.workflow_runs[] | select(.conclusion == "failure" or .conclusion == "cancelled") | "\(.id)|\(.head_sha | .[0:7])|\(.display_title | gsub("\\|"; "-") | .[0:50])|\(.name)"' 2>/dev/null | \
           while IFS='|' read -r run_id sha title workflow; do
-            # Get failed jobs for this run
-            failed_job=$(gh api "repos/pytorch/executorch/actions/runs/${run_id}/jobs" \
-              --jq '.jobs[] | select(.conclusion == "failure") | .name' 2>/dev/null | head -1)
+            # Get failed or cancelled jobs for this run
+            failed_job=$(gh api "repos/pytorch/executorch/actions/runs/${run_id}/jobs?per_page=100" \
+              --jq '.jobs[] | select(.conclusion == "failure" or .conclusion == "cancelled") | .name' 2>/dev/null | head -1)
             if [ -n "$failed_job" ]; then
               echo "| ${sha} | ${title} | ${workflow} / ${failed_job} |" >> $GITHUB_STEP_SUMMARY
             fi

--- a/.github/workflows/update-viablestrict.yml
+++ b/.github/workflows/update-viablestrict.yml
@@ -16,6 +16,7 @@ jobs:
     environment: ${{ (github.event_name == 'schedule') && 'update-viable-strict' || '' }}
     steps:
       - name: Update viable/strict
+        id: update
         uses: pytorch/test-infra/.github/actions/update-viablestrict@main
         with:
           repository: pytorch/executorch
@@ -25,3 +26,41 @@ jobs:
           clickhouse-url: ${{ secrets.CLICKHOUSE_URL }}
           clickhouse-username: ${{ secrets.CLICKHOUSE_VIABLESTRICT_USERNAME }}
           clickhouse-password: ${{ secrets.CLICKHOUSE_VIABLESTRICT_PASSWORD }}
+
+      - name: Summarize CI failures
+        if: steps.update.outputs.latest_viable_sha == 'None'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "## ❌ No green commit found" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "viable/strict branch was not updated because no commit passed all required checks." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          echo "### Failures by commit (recent)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Commit | Title | Failed Job |" >> $GITHUB_STEP_SUMMARY
+          echo "|--------|-------|------------|" >> $GITHUB_STEP_SUMMARY
+
+          # Get failed workflow runs and their failed jobs
+          gh api repos/pytorch/executorch/actions/runs?per_page=50 \
+            --jq '.workflow_runs[] | select(.conclusion == "failure") | "\(.id)|\(.head_sha | .[0:7])|\(.display_title | gsub("\\|"; "-") | .[0:50])|\(.name)"' 2>/dev/null | \
+          while IFS='|' read -r run_id sha title workflow; do
+            # Get failed jobs for this run
+            failed_job=$(gh api "repos/pytorch/executorch/actions/runs/${run_id}/jobs" \
+              --jq '.jobs[] | select(.conclusion == "failure") | .name' 2>/dev/null | head -1)
+            if [ -n "$failed_job" ]; then
+              echo "| ${sha} | ${title} | ${workflow} / ${failed_job} |" >> $GITHUB_STEP_SUMMARY
+            fi
+          done
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Summary by job" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          gh api repos/pytorch/executorch/actions/runs?per_page=100 \
+            --jq '.workflow_runs[] | select(.conclusion == "failure") | .name' 2>/dev/null \
+            | sort | uniq -c | sort -rn | head -10 >> $GITHUB_STEP_SUMMARY || echo "Failed to fetch data" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+          echo "::error::No green commit found - viable/strict was not updated"
+          exit 1


### PR DESCRIPTION
Add CI failure summary and exit with error when no green commit is
found, making the workflow show as RED in the dashboard instead of
always succeeding silently.

The summary includes:
- Per-commit table showing commit SHA, title, and failed job
- Aggregate count of failures by workflow name

This makes it easier to identify which CI jobs are blocking
viable/strict updates.


Tested locally using this script: 

https://gist.github.com/mergennachin/a3f310d5b718a5279d6af41d836a4dd9

output: 

https://gist.github.com/mergennachin/006dfc4e969d72c378825cb750738151