### PR TITLE
Fix ARM test resource loading for TOSA schema and flatc binary

### DIFF
--- a/backends/arm/test/TARGETS
+++ b/backends/arm/test/TARGETS
@@ -22,11 +22,15 @@ runtime.python_library(
 runtime.python_library(
     name = "runner_utils",
     srcs = ["runner_utils.py"],
+    resources = {
+        "fbsource//third-party/flatbuffers:flatc-host": "flatbuffers-flatc",
+    },
     deps = [
         ":conftest",
         "//executorch/backends/arm:arm_compile_spec",
         "//executorch/backends/arm:ethosu",
         "//executorch/backends/arm/tosa:compile_spec",
+        "//executorch/backends/arm/tosa:schemas",
         "//executorch/backends/arm:vgf",
         "//executorch/backends/arm/tosa:specification",
         "//executorch/exir:lib",

--- a/backends/arm/test/runner_utils.py
+++ b/backends/arm/test/runner_utils.py
@@ -11,13 +11,13 @@ import re
 import shutil
 import subprocess  # nosec B404 - invoked only for trusted toolchain binaries
 import tempfile
-
-import executorch.backends.arm.test as arm_test_package
-import executorch.backends.arm.tosa.schemas as tosa_schemas_package
 from pathlib import Path
 
 from types import NoneType
 from typing import Any, cast, Dict, List, Optional, Tuple
+
+import executorch.backends.arm.test as arm_test_package
+import executorch.backends.arm.tosa.schemas as tosa_schemas_package
 
 import numpy as np
 import torch
@@ -605,16 +605,16 @@ def _run_flatc(args: List[str]) -> None:
             )
     else:
         # Expect the `flatc` tool to be on the system path or set as an env var.
-        flatc_path = os.getenv("FLATC_EXECUTABLE")
-        if not flatc_path:
-            flatc_path = shutil.which("flatc")
-        if not flatc_path:
+        flatc_executable: str | None = os.getenv("FLATC_EXECUTABLE")
+        if not flatc_executable:
+            flatc_executable = shutil.which("flatc")
+        if not flatc_executable:
             raise RuntimeError(
                 "flatc not found. Either add it to PATH, set FLATC_EXECUTABLE env var, "
                 "or ensure the flatbuffers-flatc resource is available."
             )
         subprocess.run(  # nosec B603 - cmd constructed from trusted inputs
-            [flatc_path] + args, check=True
+            [flatc_executable] + args, check=True
         )
 
 

--- a/backends/arm/test/runner_utils.py
+++ b/backends/arm/test/runner_utils.py
@@ -3,6 +3,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import importlib.resources as _resources
 import json
 import logging
 import os
@@ -11,6 +12,8 @@ import shutil
 import subprocess  # nosec B404 - invoked only for trusted toolchain binaries
 import tempfile
 
+import executorch.backends.arm.test as arm_test_package
+import executorch.backends.arm.tosa.schemas as tosa_schemas_package
 from pathlib import Path
 
 from types import NoneType
@@ -583,6 +586,38 @@ def _run_cmd(cmd: List[str], check=True) -> subprocess.CompletedProcess[bytes]:
         )
 
 
+# Name of an optional resource containing the `flatc` executable.
+_FLATC_RESOURCE_NAME: str = "flatbuffers-flatc"
+
+
+def _run_flatc(args: List[str]) -> None:
+    """Runs the `flatc` command with the provided args.
+
+    If a resource matching _FLATC_RESOURCE_NAME exists, uses that executable.
+    Otherwise, expects the `flatc` tool to be available on the system path.
+    """
+    flatc_resource = _resources.files(arm_test_package).joinpath(_FLATC_RESOURCE_NAME)
+    if flatc_resource.is_file():
+        # Use the provided flatc binary from resources.
+        with _resources.as_file(flatc_resource) as flatc_path:
+            subprocess.run(  # nosec B603 - cmd constructed from trusted inputs
+                [str(flatc_path)] + args, check=True
+            )
+    else:
+        # Expect the `flatc` tool to be on the system path or set as an env var.
+        flatc_path = os.getenv("FLATC_EXECUTABLE")
+        if not flatc_path:
+            flatc_path = shutil.which("flatc")
+        if not flatc_path:
+            raise RuntimeError(
+                "flatc not found. Either add it to PATH, set FLATC_EXECUTABLE env var, "
+                "or ensure the flatbuffers-flatc resource is available."
+            )
+        subprocess.run(  # nosec B603 - cmd constructed from trusted inputs
+            [flatc_path] + args, check=True
+        )
+
+
 def dbg_tosa_fb_to_json(tosa_fb: bytes) -> Dict:
     """
     This function is used to dump the TOSA flatbuffer to a human readable
@@ -603,16 +638,14 @@ def dbg_tosa_fb_to_json(tosa_fb: bytes) -> Dict:
             f"Unsupported version in TOSA flatbuffer: version={major}.{minor}.{patch}"
         )
 
-    arm_backend_path = os.path.realpath(os.path.dirname(__file__) + "/..")
-    tosa_schema_file = os.path.join(
-        arm_backend_path, f"tosa/schemas/tosa_{major}.{minor}.fbs"
-    )
-    assert os.path.exists(
-        tosa_schema_file
-    ), f"tosa_schema_file: {tosa_schema_file} does not exist"
-    assert shutil.which("flatc") is not None
-    cmd_flatc = [
-        "flatc",
+    # Write schema file to temp directory using importlib.resources
+    tosa_schema_file = os.path.join(tmp, f"tosa_{major}.{minor}.fbs")
+    with open(tosa_schema_file, "wb") as schema_file:
+        schema_file.write(
+            _resources.read_binary(tosa_schemas_package, f"tosa_{major}.{minor}.fbs")
+        )
+
+    flatc_args = [
         "--json",
         "--strict-json",
         "-o",
@@ -623,7 +656,7 @@ def dbg_tosa_fb_to_json(tosa_fb: bytes) -> Dict:
         "--",
         tosa_input_file,
     ]
-    _run_cmd(cmd_flatc)
+    _run_flatc(flatc_args)
     with open(os.path.join(tmp, "output.json"), "r") as f:
         json_out = json.load(f)
 

--- a/backends/arm/tosa/TARGETS
+++ b/backends/arm/tosa/TARGETS
@@ -1,6 +1,15 @@
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
 runtime.python_library(
+    name = "schemas",
+    srcs = ["schemas/__init__.py"],
+    resources = [
+        "schemas/tosa_1.0.fbs",
+    ],
+    visibility = ["PUBLIC"],
+)
+
+runtime.python_library(
     name = "mapping",
     srcs = [
         "mapping.py",

--- a/backends/arm/tosa/schemas/__init__.py
+++ b/backends/arm/tosa/schemas/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2025 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.


### PR DESCRIPTION
Summary:
The `dbg_tosa_fb_to_json` function was failing in buck tests because it relied on `__file__`-relative paths to find the TOSA schema file, which doesn't work in buck-out link-trees. Additionally, the `flatc` binary wasn't available in the test environment.

This fix uses `importlib.resources` to properly load the schema file and flatc binary as buck resources, following the same pattern used in `executorch/exir/_serialize/`.

Differential Revision: D90879503




cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai