### PR TITLE
[ET-VK] Update vulkan gpuinfo code for staging buffer changes

### DIFF
--- a/backends/vulkan/tools/gpuinfo/include/architecture.h
+++ b/backends/vulkan/tools/gpuinfo/include/architecture.h
@@ -166,7 +166,10 @@ void warp_size(const App& app, const bool verbose = false) {
 
   auto bench = [&](uint32_t nthread) {
     StagingBuffer out_buf(
-        context(), vkapi::kInt, app.nthread_logic, vkapi::CopyDirection::DEVICE_TO_HOST);
+        context(),
+        vkapi::kInt,
+        app.nthread_logic,
+        vkapi::CopyDirection::DEVICE_TO_HOST);
     vkapi::PipelineBarrier pipeline_barrier{};
 
     auto shader_name = "warp_size_physical";
@@ -227,7 +230,10 @@ void warp_size(const App& app, const bool verbose = false) {
   // inaccuracy.
   auto bench_sm = [&](uint32_t nthread) {
     StagingBuffer out_buf(
-        context(), vkapi::kInt, app.nthread_logic, vkapi::CopyDirection::DEVICE_TO_HOST);
+        context(),
+        vkapi::kInt,
+        app.nthread_logic,
+        vkapi::CopyDirection::DEVICE_TO_HOST);
     vkapi::PipelineBarrier pipeline_barrier{};
 
     auto shader_name = "warp_size_scheduler";

--- a/backends/vulkan/tools/gpuinfo/include/architecture.h
+++ b/backends/vulkan/tools/gpuinfo/include/architecture.h
@@ -40,7 +40,8 @@ void reg_count(const App& app) {
   uint32_t NITER;
 
   auto bench = [&](uint32_t ngrp, uint32_t nreg) {
-    StagingBuffer buffer(context(), vkapi::kFloat, 1);
+    StagingBuffer buffer(
+        context(), vkapi::kFloat, 1, vkapi::CopyDirection::DEVICE_TO_HOST);
     vkapi::PipelineBarrier pipeline_barrier{};
 
     auto shader_name = "reg_count_" + std::to_string(nreg);
@@ -164,7 +165,8 @@ void warp_size(const App& app, const bool verbose = false) {
   uint32_t NITER;
 
   auto bench = [&](uint32_t nthread) {
-    StagingBuffer out_buf(context(), vkapi::kInt, app.nthread_logic);
+    StagingBuffer out_buf(
+        context(), vkapi::kInt, app.nthread_logic, vkapi::CopyDirection::DEVICE_TO_HOST);
     vkapi::PipelineBarrier pipeline_barrier{};
 
     auto shader_name = "warp_size_physical";
@@ -224,7 +226,8 @@ void warp_size(const App& app, const bool verbose = false) {
   // doesn't depend on kernel timing, so the extra wait time doesn't lead to
   // inaccuracy.
   auto bench_sm = [&](uint32_t nthread) {
-    StagingBuffer out_buf(context(), vkapi::kInt, app.nthread_logic);
+    StagingBuffer out_buf(
+        context(), vkapi::kInt, app.nthread_logic, vkapi::CopyDirection::DEVICE_TO_HOST);
     vkapi::PipelineBarrier pipeline_barrier{};
 
     auto shader_name = "warp_size_scheduler";

--- a/backends/vulkan/tools/gpuinfo/include/buffers.h
+++ b/backends/vulkan/tools/gpuinfo/include/buffers.h
@@ -36,7 +36,10 @@ void buf_cacheline_size(const App& app) {
 
   auto bench = [&](int stride) {
     StagingBuffer in_buf(
-        context(), vkapi::kFloat, BUF_SIZE, vkapi::CopyDirection::HOST_TO_DEVICE);
+        context(),
+        vkapi::kFloat,
+        BUF_SIZE,
+        vkapi::CopyDirection::HOST_TO_DEVICE);
     StagingBuffer out_buf(
         context(), vkapi::kFloat, 1, vkapi::CopyDirection::DEVICE_TO_HOST);
     vkapi::PipelineBarrier pipeline_barrier{};
@@ -135,9 +138,15 @@ void _bandwidth(
     const uint32_t workgroup_width = local_x * NITER * NUNROLL;
 
     StagingBuffer in_buf(
-        context(), vkapi::kFloat, range / sizeof(float), vkapi::CopyDirection::HOST_TO_DEVICE);
+        context(),
+        vkapi::kFloat,
+        range / sizeof(float),
+        vkapi::CopyDirection::HOST_TO_DEVICE);
     StagingBuffer out_buf(
-        context(), vkapi::kFloat, VEC_WIDTH * app.nthread_logic, vkapi::CopyDirection::DEVICE_TO_HOST);
+        context(),
+        vkapi::kFloat,
+        VEC_WIDTH * app.nthread_logic,
+        vkapi::CopyDirection::DEVICE_TO_HOST);
     vkapi::PipelineBarrier pipeline_barrier{};
 
     auto shader_name = "buf_bandwidth_" + memtype_lower;

--- a/backends/vulkan/tools/gpuinfo/include/buffers.h
+++ b/backends/vulkan/tools/gpuinfo/include/buffers.h
@@ -35,8 +35,10 @@ void buf_cacheline_size(const App& app) {
   uint32_t NITER;
 
   auto bench = [&](int stride) {
-    StagingBuffer in_buf(context(), vkapi::kFloat, BUF_SIZE);
-    StagingBuffer out_buf(context(), vkapi::kFloat, 1);
+    StagingBuffer in_buf(
+        context(), vkapi::kFloat, BUF_SIZE, vkapi::CopyDirection::HOST_TO_DEVICE);
+    StagingBuffer out_buf(
+        context(), vkapi::kFloat, 1, vkapi::CopyDirection::DEVICE_TO_HOST);
     vkapi::PipelineBarrier pipeline_barrier{};
 
     auto shader_name = "buf_cacheline_size";
@@ -132,9 +134,10 @@ void _bandwidth(
     // workgroups, once the size of the access excedes the workgroup width.
     const uint32_t workgroup_width = local_x * NITER * NUNROLL;
 
-    StagingBuffer in_buf(context(), vkapi::kFloat, range / sizeof(float));
+    StagingBuffer in_buf(
+        context(), vkapi::kFloat, range / sizeof(float), vkapi::CopyDirection::HOST_TO_DEVICE);
     StagingBuffer out_buf(
-        context(), vkapi::kFloat, VEC_WIDTH * app.nthread_logic);
+        context(), vkapi::kFloat, VEC_WIDTH * app.nthread_logic, vkapi::CopyDirection::DEVICE_TO_HOST);
     vkapi::PipelineBarrier pipeline_barrier{};
 
     auto shader_name = "buf_bandwidth_" + memtype_lower;

--- a/backends/vulkan/tools/gpuinfo/include/textures.h
+++ b/backends/vulkan/tools/gpuinfo/include/textures.h
@@ -61,7 +61,8 @@ void tex_cacheline_concurr(const App& app) {
       vTensor in_tensor =
           api::vTensor(api::context(), sizes_nchw, vkapi::kFloat);
 
-      StagingBuffer out_buf(context(), vkapi::kFloat, TEXEL_WIDTH);
+      StagingBuffer out_buf(
+          context(), vkapi::kFloat, TEXEL_WIDTH, vkapi::CopyDirection::DEVICE_TO_HOST);
 
       vkapi::PipelineBarrier pipeline_barrier{};
 
@@ -174,7 +175,7 @@ void tex_bandwidth(const App& app) {
       const uint32_t workgroup_width = local_x * NITER * NUNROLL;
 
       StagingBuffer out_buf(
-          context(), vkapi::kFloat, VEC_WIDTH * app.nthread_logic);
+          context(), vkapi::kFloat, VEC_WIDTH * app.nthread_logic, vkapi::CopyDirection::DEVICE_TO_HOST);
       vkapi::PipelineBarrier pipeline_barrier{};
 
       auto time = benchmark_on_gpu(shader_name, 10, [&]() {

--- a/backends/vulkan/tools/gpuinfo/include/textures.h
+++ b/backends/vulkan/tools/gpuinfo/include/textures.h
@@ -62,7 +62,10 @@ void tex_cacheline_concurr(const App& app) {
           api::vTensor(api::context(), sizes_nchw, vkapi::kFloat);
 
       StagingBuffer out_buf(
-          context(), vkapi::kFloat, TEXEL_WIDTH, vkapi::CopyDirection::DEVICE_TO_HOST);
+          context(),
+          vkapi::kFloat,
+          TEXEL_WIDTH,
+          vkapi::CopyDirection::DEVICE_TO_HOST);
 
       vkapi::PipelineBarrier pipeline_barrier{};
 
@@ -175,7 +178,10 @@ void tex_bandwidth(const App& app) {
       const uint32_t workgroup_width = local_x * NITER * NUNROLL;
 
       StagingBuffer out_buf(
-          context(), vkapi::kFloat, VEC_WIDTH * app.nthread_logic, vkapi::CopyDirection::DEVICE_TO_HOST);
+          context(),
+          vkapi::kFloat,
+          VEC_WIDTH * app.nthread_logic,
+          vkapi::CopyDirection::DEVICE_TO_HOST);
       vkapi::PipelineBarrier pipeline_barrier{};
 
       auto time = benchmark_on_gpu(shader_name, 10, [&]() {


### PR DESCRIPTION
Summary: In D89086669, we updated StagingBuffer to take a flag specifying transfer direction (CPU->GPU or GPU->CPU). I missed the call sites under tools/gpuinfo. This PR updates these call sites to make the tool buildable again.

Differential Revision: D90888995




cc @SS-JIA @manuelcandales @digantdesai @cbilgin