### PR TITLE
Add torchvision dependency to test_xnnpack_quantizer

### DIFF
--- a/backends/xnnpack/test/TARGETS
+++ b/backends/xnnpack/test/TARGETS
@@ -88,6 +88,7 @@ runtime.python_test(
         "//executorch/backends/xnnpack:xnnpack_preprocess",
         "//executorch/backends/xnnpack/quantizer:xnnpack_quantizer",
         "//pytorch/ao:torchao",  # @manual
+        "//pytorch/vision:torchvision",  # @manual
         "//caffe2:torch",
     ],
     external_deps = [


### PR DESCRIPTION
Summary:
The test_resnet18 test in TestXNNPACKQuantizerModels uses torchvision.models.resnet18()
but the test target was missing torchvision as a dependency. This caused the test to
be skipped with "no torchvision" message due to the skip_if_no_torchvision decorator.

Differential Revision: D90895233


