### PR TITLE
Fix XNNWorkspaceManager cleanup tests by using unique IDs instead of raw pointers

### DIFF
--- a/backends/xnnpack/test/runtime/test_workspace_manager.cpp
+++ b/backends/xnnpack/test/runtime/test_workspace_manager.cpp
@@ -166,7 +166,7 @@ TEST_F(XNNWorkspaceManagerTest, PerModelModeCleanup) {
   workspace_manager_->set_sharing_mode(WorkspaceSharingMode::PerModel);
 
   uintptr_t program_id = 12345;
-  xnn_workspace_t raw_workspace1 = nullptr;
+  uint64_t workspace1_id = 0;
 
   // Create a scope to control the lifetime of workspace1
   {
@@ -175,8 +175,8 @@ TEST_F(XNNWorkspaceManagerTest, PerModelModeCleanup) {
     ASSERT_TRUE(workspace1_result.ok());
     auto workspace1 = workspace1_result.get();
 
-    // Store the raw pointer for later comparison
-    raw_workspace1 = workspace1->unsafe_get_workspace();
+    // Store the unique ID for later comparison
+    workspace1_id = workspace1->id();
 
     // Let workspace1 go out of scope and be destroyed
   }
@@ -188,7 +188,9 @@ TEST_F(XNNWorkspaceManagerTest, PerModelModeCleanup) {
   auto workspace2 = workspace2_result.get();
 
   // Since the previous workspace was destroyed, we should get a new one.
-  EXPECT_NE(workspace2->unsafe_get_workspace(), raw_workspace1);
+  // We compare IDs instead of raw pointers because memory allocators may
+  // reuse addresses after deallocation.
+  EXPECT_NE(workspace2->id(), workspace1_id);
 }
 
 TEST_F(XNNWorkspaceManagerTest, GlobalModeCleanup) {
@@ -197,7 +199,7 @@ TEST_F(XNNWorkspaceManagerTest, GlobalModeCleanup) {
   workspace_manager_->set_sharing_mode(WorkspaceSharingMode::Global);
 
   uintptr_t program_id = 12345;
-  xnn_workspace_t raw_workspace1 = nullptr;
+  uint64_t workspace1_id = 0;
 
   // Create a scope to control the lifetime of workspace1
   {
@@ -206,8 +208,8 @@ TEST_F(XNNWorkspaceManagerTest, GlobalModeCleanup) {
     ASSERT_TRUE(workspace1_result.ok());
     auto workspace1 = workspace1_result.get();
 
-    // Store the raw pointer for later comparison
-    raw_workspace1 = workspace1->unsafe_get_workspace();
+    // Store the unique ID for later comparison
+    workspace1_id = workspace1->id();
 
     // Let workspace1 go out of scope and be destroyed
   }
@@ -219,7 +221,9 @@ TEST_F(XNNWorkspaceManagerTest, GlobalModeCleanup) {
   auto workspace2 = workspace2_result.get();
 
   // Since the previous workspace was destroyed, we should get a new one.
-  EXPECT_NE(workspace2->unsafe_get_workspace(), raw_workspace1);
+  // We compare IDs instead of raw pointers because memory allocators may
+  // reuse addresses after deallocation.
+  EXPECT_NE(workspace2->id(), workspace1_id);
 }
 
 TEST_F(XNNWorkspaceManagerTest, SwitchingModes) {


### PR DESCRIPTION
Summary:
The PerModelModeCleanup and GlobalModeCleanup tests were failing because they
compared raw xnn_workspace_t pointers to verify cleanup behavior. However,
memory allocators commonly reuse addresses after deallocation - when
xnn_release_workspace frees memory and xnn_create_workspace immediately
allocates the same size, the allocator may return the same address.

This fix:
1. Adds a unique instance ID (uint64_t) to XNNWorkspace using an atomic counter
2. Adds an id() method to retrieve this unique ID
3. Modifies both cleanup tests to compare IDs instead of raw pointers

This correctly verifies that new workspace objects are created after cleanup,
regardless of memory address reuse by the allocator.

Differential Revision: D90897333


