### PR TITLE
Temporarily disable Samsung test jobs

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -961,8 +961,10 @@ jobs:
 
   test-samsung-models-linux:
     name: test-samsung-models-linux
-    # Skip this job if the pull request is from a fork (secrets are not available)
-    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
+    # Temporarily disabled - edb (Exynos device bridge) failures and device reservation issues
+    # See: https://github.com/pytorch/executorch/issues/16678
+    if: false
+    # if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     permissions:
       id-token: write


### PR DESCRIPTION
Disable test-samsung-models-linux due to edb (Exynos device bridge) failures and device reservation issues.

Root causes:
- Device reservation not always successful
- edb command execution failures
- Path mismatches in runtime_executor.py

These jobs were blocking viable/strict from advancing.

Here's the history

https://hud.pytorch.org/hud/pytorch/executorch/main/1?per_page=50&name_filter=samsung