### PR TITLE
Normalize constant and buffer dim order in to_edge

### DIFF
--- a/backends/xnnpack/test/TARGETS
+++ b/backends/xnnpack/test/TARGETS
@@ -28,6 +28,28 @@ runtime.python_test(
 )
 
 runtime.python_test(
+    name = "test_xnnpack_fragments",
+    srcs = glob([
+        "fragments/*.py",
+    ]) + [
+        "test_xnnpack_utils.py",
+    ],
+    deps = [
+        "//executorch/backends/xnnpack/partition:xnnpack_partitioner",
+        "//executorch/backends/xnnpack/quantizer:xnnpack_quantizer",
+        "//executorch/backends/xnnpack/test/tester:tester",
+        "//executorch/devtools:lib",
+        "//executorch/devtools/bundled_program:config",
+        "//executorch/devtools/bundled_program/serialize:lib",
+        "//executorch/exir/passes:constant_prop_pass",
+        "//pytorch/ao:torchao",  # @manual
+    ],
+    external_deps = [
+        "libtorch",
+    ],
+)
+
+runtime.python_test(
     name = "test_xnnpack_ops",
     srcs = glob([
         "ops/*.py",

--- a/backends/xnnpack/test/fragments/test_dim_order.py
+++ b/backends/xnnpack/test/fragments/test_dim_order.py
@@ -26,9 +26,7 @@ class TestDimOrder(unittest.TestCase):
         inputs = (torch.randn(16, 2),)
 
         for quantize in [False, True]:
-            tester = (
-                Tester(Model(), inputs)
-            )
+            tester = Tester(Model(), inputs)
 
             if quantize:
                 tester.quantize()

--- a/backends/xnnpack/test/fragments/test_dim_order.py
+++ b/backends/xnnpack/test/fragments/test_dim_order.py
@@ -1,0 +1,42 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+from executorch.backends.xnnpack.test.tester import Tester
+
+
+class TestDimOrder(unittest.TestCase):
+    def setUp(self):
+        torch._dynamo.reset()
+
+    def test_add_constant_transposed(self):
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.constant = torch.randn(2, 16).transpose(1, 0)
+
+            def forward(self, x):
+                return x + self.constant
+
+        inputs = (torch.randn(16, 2),)
+
+        for quantize in [False, True]:
+            tester = (
+                Tester(Model(), inputs)
+            )
+
+            if quantize:
+                tester.quantize()
+
+            (
+                tester.export()
+                .to_edge_transform_and_lower()
+                .to_executorch()
+                .serialize()
+                .run_method_and_compare_outputs()
+            )

--- a/exir/passes/TARGETS
+++ b/exir/passes/TARGETS
@@ -9,6 +9,7 @@ runtime.python_library(
     ],
     deps = [
         ":const_prop_pass",
+        ":convert_constant_dim_order_pass",
         ":debug_handle_generator_pass",
         ":external_constants_pass",
         ":init_mutable_pass",
@@ -413,5 +414,15 @@ runtime.python_library(
     deps = [
         "//caffe2:torch",
         "//executorch/exir/dialects:lib",
+    ],
+)
+
+runtime.python_library(
+    name = "convert_constant_dim_order_pass",
+    srcs = [
+        "convert_constant_dim_order_pass.py",
+    ],
+    deps = [
+        "//caffe2:torch",
     ],
 )

--- a/exir/passes/convert_constant_dim_order_pass.py
+++ b/exir/passes/convert_constant_dim_order_pass.py
@@ -1,0 +1,86 @@
+import torch
+from torch.export import ExportedProgram
+from torch.export.graph_signature import InputKind
+
+
+def _should_transform(tensor: torch.Tensor) -> bool:
+    """
+    Returns whether the given tensor should be transformed by the pass to
+    contiguous dim order.
+    """
+    return not tensor.is_contiguous() and not tensor.is_contiguous(
+        memory_format=torch.channels_last
+    )
+
+
+def _update_placeholder_meta(
+    exported_program: ExportedProgram,
+    target: str,
+    kind: InputKind,
+):
+    input_spec = next(
+        (
+            spec
+            for spec in exported_program.graph_signature.input_specs
+            if spec.kind == kind and spec.target == target
+        ),
+        None,
+    )
+    if input_spec is None:
+        raise RuntimeError(f"Missing input spec for lifted tensor {target}.")
+
+    placeholder_node = next(
+        (
+            n
+            for n in exported_program.graph.nodes
+            if n.op == "placeholder" and n.name == input_spec.arg.name
+        ),
+        None,
+    )
+    if input_spec is None:
+        raise RuntimeError(f"Missing placeholder for {input_spec.arg.name}.")
+
+    placeholder_node.meta["val"] = placeholder_node.meta["val"].contiguous()
+
+
+def convert_constant_dim_order_pass(
+    exported_program: ExportedProgram,
+) -> ExportedProgram:
+    """
+    Normalize the dim order of constant tensors, ensuring that all constant tensors
+    have either default or channels_last dim order. Tensors with other dim orders or
+    striding are converted to contiguous tensors. This pass acts in-place on the
+    unlifted exported program.
+
+    Args:
+        exported_program: The ExportedProgram to transform.
+
+    Returns:
+        The modified ExportedProgram with normalized constant dim order.
+    """
+
+    for key, const in exported_program.constants.items():
+        if isinstance(const, torch.Tensor) and _should_transform(const):
+            exported_program.constants[key] = const.contiguous()
+
+            # Also update the corresponding placeholder node meta value. This doesn't
+            # get automatically updated during retracing as ExportPass uses the placeholder
+            # meta as the source of truth. TODO(?)
+            _update_placeholder_meta(exported_program, key, InputKind.CONSTANT_TENSOR)
+
+    # Convert buffers.
+    non_persistent_buffer_names = set(
+        exported_program.graph_signature.non_persistent_buffers
+    )
+    for key, buffer in exported_program.named_buffers():
+        if (
+            key not in non_persistent_buffer_names
+            and isinstance(buffer, torch.Tensor)
+            and _should_transform(buffer)
+        ):
+            # Persistent buffers are stored in the state dict.
+            exported_program.state_dict[key] = buffer.contiguous()
+
+            _update_placeholder_meta(exported_program, key, InputKind.BUFFER)
+
+    return exported_program

--- a/exir/program/TARGETS
+++ b/exir/program/TARGETS
@@ -45,6 +45,7 @@ runtime.python_library(
         "//executorch/exir/passes:replace_view_copy_with_view_pass",
         "//executorch/exir/passes:spec_prop_pass",
         "//executorch/exir/passes:weights_to_outputs_pass",
+        "//executorch/exir/passes:convert_constant_dim_order_pass",
         "//executorch/exir/verification:verifier",
         "//executorch/extension/flat_tensor/serialize:serialize",
     ] +  (["//executorch/exir/program/fb:logger"] if not runtime.is_oss else [])

--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -72,9 +72,6 @@ from executorch.exir.passes.replace_view_copy_with_view_pass import (
 )
 from executorch.exir.passes.spec_prop_pass import SpecPropPass
 from executorch.exir.passes.weights_to_outputs_pass import weights_to_outputs_pass
-from executorch.exir.passes.convert_constant_dim_order_pass import (
-    convert_constant_dim_order_pass,
-)
 from executorch.exir.print_program import pretty_print, print_program
 from executorch.exir.schema import Program
 from executorch.exir.tracer import _default_decomposition_table
@@ -919,7 +916,9 @@ def _generate_edge_program(
     edge_program = lift_constant_tensor_pass(edge_program)
 
     # Normalize constant tensor dim order on the unlifted graph
-    edge_program = convert_constant_dim_order_pass(edge_program)
+    edge_program = convert_constant_dim_order_pass.convert_constant_dim_order_pass(
+        edge_program
+    )
 
     edge_program = _transform(edge_program, *post_op_replace_passes)
 

--- a/exir/tests/test_passes.py
+++ b/exir/tests/test_passes.py
@@ -6,6 +6,7 @@
 
 # pyre-strict
 import copy
+import itertools
 import os
 import tempfile
 import unittest
@@ -41,6 +42,7 @@ from executorch.exir.emit import emit_program
 from executorch.exir.graph_module import get_control_flow_submodules
 from executorch.exir.pass_base import ExportPass, PassResult
 from executorch.exir.passes import (
+    convert_constant_dim_order_pass,
     dead_code_elimination_pass,
     DebugPass,
     HintBasedSymShapeEvalPass,
@@ -2330,3 +2332,141 @@ class TestPasses(unittest.TestCase):
             prop_tensor.is_contiguous(),
             f"Propagated tensor is not contiguous: {prop_tensor.stride()}",
         )
+
+    class AddConstant(torch.nn.Module):
+        def __init__(self, constant: torch.Tensor, use_buffer: bool = False):
+            super().__init__()
+            if use_buffer:
+                self.register_buffer("constant", constant)
+            else:
+                self.constant = constant
+
+        def forward(self, x):
+            return x + self.constant
+
+    def test_convert_constant_dim_order_noop(self):
+        """
+        Verify that the convert_constant_dim_order_pass does not modify
+        constant tensors in contiguous or channels last format.
+        """
+
+        memory_formats = [
+            torch.contiguous_format,
+            torch.channels_last,
+        ]
+
+        use_buffer = [False, True]
+
+        for memory_format, use_buffer in itertools.product(memory_formats, use_buffer):
+            constant = torch.randn(2, 3, 4, 5).to(memory_format=memory_format)
+            model = self.AddConstant(constant, use_buffer=use_buffer)
+            inputs = (torch.randn(2, 3, 4, 5).to(memory_format=memory_format),)
+
+            ep = torch.export.export(model, inputs)
+            modified_ep = convert_constant_dim_order_pass.convert_constant_dim_order_pass(copy.deepcopy(ep))
+
+            # Check the outputs - they should match in both data and dim order.
+            original_outputs = ep.module()(*inputs)
+            modified_outputs = modified_ep.module()(*inputs)
+
+            torch.testing.assert_close(original_outputs, modified_outputs, check_stride=True)
+
+            # Verify that the constant/buffer tensor is not modified. The interface for
+            # constants and buffers is just different enough to make it hard to unify the
+            # below logic.
+            if use_buffer:
+                original_buffers = dict(ep.named_buffers())
+                modified_buffers = dict(modified_ep.named_buffers())
+
+                self.assertEqual(len(original_buffers), 1)
+                self.assertEqual(len(modified_buffers), 1)
+
+                buffer_key = next(iter(original_buffers.keys()))
+                original_buffer = original_buffers[buffer_key]
+                modified_buffer = modified_buffers[buffer_key]
+
+                torch.testing.assert_close(original_buffer, modified_buffer, check_stride=True)
+            else:
+                self.assertEqual(len(ep.constants), 1)
+                self.assertEqual(len(modified_ep.constants), 1)
+
+                const_key = next(iter(ep.constants.keys()))
+                original_const = ep.constants[const_key]
+                modified_const = modified_ep.constants[const_key]
+
+                torch.testing.assert_close(original_const, modified_const, check_stride=True)
+
+    def test_convert_constant_dim_order_to_contiguous(self):
+        """
+        Verify that the convert_constant_dim_order_pass converts constant/buffer
+        tensors with dim orders / memory formats outside the allowed list
+        (contiguous and channels_last) to contiguous.
+        """
+
+        # Test cases using transpose/permute to create non-contiguous tensors.
+        # Each case is (base_shape, permutation, description) where we create a
+        # contiguous tensor of base_shape and then permute/transpose it.
+        test_cases = [
+            # Rank 2 - transposed matrix (non-contiguous strides)
+            ((5, 4), (1, 0), "2D transposed"),
+            # Rank 3 - permuted dimensions
+            ((4, 3, 2), (2, 0, 1), "3D permuted"),
+            # Rank 3 - another permutation
+            ((2, 4, 3), (1, 2, 0), "3D permuted v2"),
+            # Rank 4 - permuted (not contiguous, not channels_last)
+            ((5, 4, 3, 2), (3, 1, 0, 2), "4D permuted"),
+            # Rank 5 - permuted
+            ((6, 5, 4, 3, 2), (4, 2, 0, 3, 1), "5D permuted"),
+        ]
+
+        use_buffer_options = [False, True]
+
+        for (base_shape, permutation, description), use_buffer in itertools.product(
+            test_cases, use_buffer_options
+        ):
+            with self.subTest(description=description, use_buffer=use_buffer):
+                # Create a contiguous tensor and permute it to make it non-contiguous
+                base_tensor = torch.randn(base_shape)
+                constant = base_tensor.permute(permutation)
+
+                # Sanity check the tensor construction
+                self.assertFalse(
+                    constant.is_contiguous(),
+                    f"Test setup error: tensor should be non-contiguous",
+                )
+
+                model = self.AddConstant(constant, use_buffer=use_buffer)
+                inputs = (torch.randn(constant.shape),)
+
+                ep = torch.export.export(model, inputs)
+                modified_ep = convert_constant_dim_order_pass.convert_constant_dim_order_pass(
+                    copy.deepcopy(ep)
+                )
+
+                # Check the outputs - they should match in data.
+                original_outputs = ep.module()(*inputs)
+                modified_outputs = modified_ep.module()(*inputs)
+                torch.testing.assert_close(original_outputs, modified_outputs)
+
+                # Verify that the constant/buffer tensor is now contiguous.
+                if use_buffer:
+                    modified_buffers = dict(modified_ep.named_buffers())
+                    self.assertEqual(len(modified_buffers), 1)
+
+                    buffer_key = next(iter(modified_buffers.keys()))
+                    modified_buffer = modified_buffers[buffer_key]
+
+                    self.assertTrue(
+                        modified_buffer.is_contiguous(),
+                        f"Buffer should be contiguous after pass, got strides {modified_buffer.stride()}",
+                    )
+                else:
+                    self.assertEqual(len(modified_ep.constants), 1)
+
+                    const_key = next(iter(modified_ep.constants.keys()))
+                    modified_const = modified_ep.constants[const_key]
+
+                    self.assertTrue(
+                        modified_const.is_contiguous(),
+                        f"Constant should be contiguous after pass, got strides {modified_const.stride()}",
+                    )


### PR DESCRIPTION
Summary:
Add a pass in to_edge to ensure all constant tensors have contiguous or channels-last dim order. Tensors with dim orders not present in this list get converted to contiguous. This solves a class of bugs related to strided constant tensors, such as the one causing https://github.com/pytorch/executorch/issues/14644.

Context for this change:
* Some models, such as Yolo, include strided constant tensors.
* PT2E quantization can convert constant tensors to buffers.
* Prior to @lucylq's fix in https://github.com/pytorch/executorch/pull/16636, we would serialize these with contiguous data layout but strided metadata, causing correctness issues and/or runtime shape mismatch.
* As per discussion with @Gasoonjia, EXIR already assumes that tensors have either contiguous or channels last dim order.
* If we modify tensor dim order in a backend-visible manner, it has to happen before delegation. Otherwise, the backend will see a different dim order at runtime compared to lowering. 
   * Constants and buffers can be passed into delegate subgraphs as inputs. 
   * XNNPACK, for example, will conditionally insert transposes based on input dim order.
* Correspondingly, if we're going to convert dim order in EXIR, we need to do so before delegation.

Test Plan:
I've added tests for constants and buffers with a variety of dim orders and arbitrary strides in test_passes.py. I've also added some end to end test coverage under the XNNPACK backend that also covers the scenario we originally encountered with Yolo and XNNPACK.

Differential Revision: D90898806


