### PR TITLE
Use torch.median for error stats

### DIFF
--- a/backends/test/harness/error_statistics.py
+++ b/backends/test/harness/error_statistics.py
@@ -33,7 +33,7 @@ class TensorStatistics:
         return cls(
             shape=tensor.shape,
             numel=tensor.numel(),
-            median=torch.quantile(flattened, q=0.5).item(),
+            median=torch.median(flattened).item(),
             mean=flattened.mean().item(),
             max=flattened.max().item(),
             min=flattened.min().item(),

--- a/backends/test/harness/tests/test_error_statistics.py
+++ b/backends/test/harness/tests/test_error_statistics.py
@@ -14,7 +14,9 @@ class ErrorStatisticsTests(unittest.TestCase):
         # Check actual tensor statistics
         self.assertEqual(error_stats.actual_stats.shape, torch.Size([4]))
         self.assertEqual(error_stats.actual_stats.numel, 4)
-        self.assertEqual(error_stats.actual_stats.median, 2.5)
+        self.assertEqual(
+            error_stats.actual_stats.median, 2
+        )  # torch.median takes the lower median
         self.assertEqual(error_stats.actual_stats.mean, 2.5)
         self.assertEqual(error_stats.actual_stats.max, 4)
         self.assertEqual(error_stats.actual_stats.min, 1)
@@ -44,7 +46,7 @@ class ErrorStatisticsTests(unittest.TestCase):
         # Check actual tensor statistics
         self.assertEqual(error_stats.actual_stats.shape, torch.Size([4]))
         self.assertEqual(error_stats.actual_stats.numel, 4)
-        self.assertEqual(error_stats.actual_stats.median, 2.5)
+        self.assertEqual(error_stats.actual_stats.median, 2)
         self.assertEqual(error_stats.actual_stats.mean, 2.5)
         self.assertEqual(error_stats.actual_stats.max, 4)
         self.assertEqual(error_stats.actual_stats.min, 1)
@@ -52,7 +54,7 @@ class ErrorStatisticsTests(unittest.TestCase):
         # Check reference tensor statistics
         self.assertEqual(error_stats.reference_stats.shape, torch.Size([2, 2]))
         self.assertEqual(error_stats.reference_stats.numel, 4)
-        self.assertEqual(error_stats.reference_stats.median, 3.5)
+        self.assertEqual(error_stats.reference_stats.median, 3)
         self.assertEqual(error_stats.reference_stats.mean, 3.5)
         self.assertEqual(error_stats.reference_stats.max, 5)
         self.assertEqual(error_stats.reference_stats.min, 2)


### PR DESCRIPTION
### Summary
This is a re-land of https://github.com/pytorch/executorch/pull/16673 with updated test data. Previously, the error stats logic would throw when a large tensor is passed in due to size limitations of torch.quantile. The above PR switched it to use torch.median, but this has differing behavior for tensors with an even number of elements.

Quantile will return the mean of the two medians, but torch.median takes the lower. Either is fine for this use case - we just need to update the test logic accordingly. I verified that the error stats unit tests pass with this change.