### PR TITLE
Add missing sliding window param into ModelArgs

### DIFF
--- a/examples/models/gemma2/config/2b_config.json
+++ b/examples/models/gemma2/config/2b_config.json
@@ -12,6 +12,7 @@
   "post_attention_norm": true,
   "post_ffn_norm": true,
   "rope_theta": 10000.0,
+  "local_rope_theta": 10000.0,
   "use_scaled_rope": false,
   "apply_embedding": true,
   "embedding_scale_factor": 48.0,
@@ -21,6 +22,5 @@
   "attn_logit_softcapping": 50.0,
   "final_logit_softcapping": 30.0,
   "sliding_window": 4096,
-  "layer_types": ["local", "global", "local", "global", "local", "global", "local", "global", "local", "global", "local", "global", "local", "global", "local", "global", "local", "global", "local", "global", "local", "global", "local", "global", "local", "global"],
-  "rope_local_base_freq": 10000.0
+  "layer_types": ["sliding_attention", "full_attention", "sliding_attention", "full_attention", "sliding_attention", "full_attention", "sliding_attention", "full_attention", "sliding_attention", "full_attention", "sliding_attention", "full_attention", "sliding_attention", "full_attention", "sliding_attention", "full_attention", "sliding_attention", "full_attention", "sliding_attention", "full_attention", "sliding_attention", "full_attention", "sliding_attention", "full_attention", "sliding_attention", "full_attention"]
 }

--- a/examples/models/gemma3/config/1b_config.json
+++ b/examples/models/gemma3/config/1b_config.json
@@ -12,6 +12,7 @@
   "post_attention_norm": true,
   "post_ffn_norm": true,
   "rope_theta": 1000000.0,
+  "local_rope_theta": 10000.0,
   "use_scaled_rope": false,
   "apply_embedding": true,
   "embedding_scale_factor": 33.941125497,
@@ -19,5 +20,7 @@
   "use_hf_rope": true,
   "attention_qkv_bias": false,
   "use_qk_norm": true,
-  "qk_norm_before_rope": true
+  "qk_norm_before_rope": true,
+  "layer_types": ["sliding_attention","sliding_attention", "sliding_attention", "sliding_attention", "sliding_attention", "full_attention", "sliding_attention","sliding_attention", "sliding_attention", "sliding_attention", "sliding_attention", "full_attention", "sliding_attention","sliding_attention", "sliding_attention", "sliding_attention", "sliding_attention", "full_attention", "sliding_attention","sliding_attention", "sliding_attention", "sliding_attention", "sliding_attention", "full_attention", "sliding_attention","sliding_attention"],
+  "sliding_window": 512
 }

--- a/examples/models/llama/model_args.py
+++ b/examples/models/llama/model_args.py
@@ -102,6 +102,9 @@ class ModelArgs:
     rope_theta: Optional[float] = (
         None  # The official name to override self.rope_freq_base.
     )
+    local_rope_theta: Optional[float] = (
+        None  # For sliding window attention. e.g., gemma3-1b
+    )
     rope_freq_base: float = 10000.0  # The base frequency for RoPE. Keep it for BC.
     use_scaled_rope: bool = False  # Use scaled RoPE, introduced in llama3.1.
     rope_scale_factor: int = 8
@@ -133,6 +136,9 @@ class ModelArgs:
     layer_types: Optional[list] = None
     model_architecture: Optional[str] = (
         None  # Architecture of model. For HF models, please refer to the HF model.config.architectures. This is used in QNN backend only for now.
+    )
+    sliding_window: Optional[int] = (
+        None  # sliding window size for sliding window attention
     )
     # gemma2 attn and output soft capping
     final_logit_softcapping: Optional[float] = None

--- a/examples/qualcomm/oss_scripts/llama/wrappers.py
+++ b/examples/qualcomm/oss_scripts/llama/wrappers.py
@@ -407,37 +407,6 @@ class TextDecoder(Component):
                 "Audio encoder modality is not currently supported. "
                 "Please provide a valid modality_placeholder_token_id in kwargs."
             )
-        # Language-only Model (LLM) configuration
-        # Handle architecture-specific parameters for models that require special configurations
-        # beyond the general Static LLaMA architecture
-        else:
-            match self.control_args.decoder_model:
-                case "gemma3-1b":
-                    # Gemma3 requires additional configuration parameters:
-                    # - layer_types: Specifies the type of each layer (e.g., casual vs. sliding window attention)
-                    # - rope_local_base_freq: Base frequency for local RoPE
-                    # - sliding_window: Size of the sliding attention window for efficient long-context processing
-                    from transformers import Gemma3Config
-
-                    hf_config = Gemma3Config.from_pretrained(self.config.repo_id)
-                    kwargs["layer_types"] = hf_config.text_config.layer_types
-                    kwargs["rope_local_base_freq"] = (
-                        hf_config.text_config.rope_local_base_freq
-                    )
-                    kwargs["sliding_window"] = hf_config.sliding_window
-                case "gemma2-2b":
-                    from transformers import Gemma2Config
-
-                    hf_config = Gemma2Config.from_pretrained(self.config.repo_id)
-                    kwargs["layer_types"] = hf_config.layer_types
-                    kwargs["rope_local_base_freq"] = hf_config.rope_parameters[
-                        "rope_theta"
-                    ]
-                    kwargs["sliding_window"] = hf_config.sliding_window
-                    kwargs["final_logit_softcapping"] = (
-                        hf_config.final_logit_softcapping
-                    )
-                    kwargs["attn_logit_softcapping"] = hf_config.attn_logit_softcapping
 
         return kwargs
 


### PR DESCRIPTION
### Summary

Fix follow-up to:  https://github.com/pytorch/executorch/pull/16684
 - add the `sliding_window` and `local_rope_theta` parameters to `ModelArgs` so Gemma2 configs load correctly in static llama flow.
 - integrate all local attention related config under `ModelArgs` for consistency.

### Test plan
``` bash 
python backends/qualcomm/tests/test_qnn_delegate.py TestExampleLLMScript.test_static_llm_model -m SM8750 -s ${SERIAL_NUM} -b build-android -a . --executorch_root . --model_name gemma2-2b
```

