### PR TITLE
add support for SA8797/SA8397

### DIFF
--- a/backends/qualcomm/serialization/qc_compiler_spec.fbs
+++ b/backends/qualcomm/serialization/qc_compiler_spec.fbs
@@ -18,6 +18,7 @@ enum HtpArch: int {
   V73 = 73,
   V75 = 75,
   V79 = 79,
+  V81 = 81,
 }
 
 table HtpInfo {
@@ -42,6 +43,7 @@ enum QcomChipset: int {
   SSG2125P = 58,
   SXR1230P = 45,
   SXR2230P = 53,
+  SA8797 = 72,
   SXR2330P = 75,
 }
 

--- a/backends/qualcomm/serialization/qc_schema.py
+++ b/backends/qualcomm/serialization/qc_schema.py
@@ -27,6 +27,7 @@ class HtpArch(IntEnum):
     V73 = 73
     V75 = 75
     V79 = 79
+    V81 = 81
 
 
 @dataclass
@@ -48,6 +49,7 @@ class QcomChipset(IntEnum):
     SSG2125P = 58  # v73
     SXR1230P = 45  # v73
     SXR2230P = 53  # v69
+    SA8797 = 72  # v81
     SXR2330P = 75  # v79
 
 
@@ -69,6 +71,7 @@ _soc_info_table = {
     QcomChipset.SXR1230P: SocInfo(QcomChipset.SXR1230P, HtpInfo(HtpArch.V73, 2)),
     QcomChipset.SXR2230P: SocInfo(QcomChipset.SXR2230P, HtpInfo(HtpArch.V69, 8)),
     QcomChipset.SXR2330P: SocInfo(QcomChipset.SXR2330P, HtpInfo(HtpArch.V79, 8)),
+    QcomChipset.SA8797: SocInfo(QcomChipset.SA8797, HtpInfo(HtpArch.V81, 16)),
 }
 
 

--- a/backends/qualcomm/utils/utils.py
+++ b/backends/qualcomm/utils/utils.py
@@ -1089,6 +1089,7 @@ def generate_qnn_executorch_compiler_spec(
 def get_soc_to_arch_map():
     return {
         "SA8295": HtpArch.V68,
+        "SA8797": HtpArch.V81,
         "SM8450": HtpArch.V69,
         "SM8475": HtpArch.V69,
         "SM8550": HtpArch.V73,
@@ -1105,6 +1106,7 @@ def get_soc_to_arch_map():
 def get_soc_to_chipset_map():
     return {
         "SA8295": QcomChipset.SA8295,
+        "SA8797": QcomChipset.SA8797,
         "SM8450": QcomChipset.SM8450,
         "SM8475": QcomChipset.SM8475,
         "SM8550": QcomChipset.SM8550,


### PR DESCRIPTION
feat(backends/qualcomm): add support for SA8797 chipset and V81 architecture

- Add V81 enum value to HtpArch in qc_compiler_spec.fbs
- Add SA8797 enum value to QcomChipset in qc_compiler_spec.fbs
- Update Python schema definitions with new V81 and SA8797 values
- Add SA8797 to soc info table with V81 architecture and 16 cores
- Include SA8797 in soc to arch and soc to chipset mapping functions
```

cc @cccclai @winskuo-quic @shewu-quic @haowhsu-quic @DannyYuyang-quic @cbilgin