### PR TITLE
Fix null pointer dereference in get_output_flattening_encoding

### DIFF
--- a/runtime/executor/program.cpp
+++ b/runtime/executor/program.cpp
@@ -425,7 +425,17 @@ Result<const char*> Program::get_output_flattening_encoding(
   if (!plan.ok()) {
     return plan.error();
   }
-  return plan.get()->container_meta_type()->encoded_out_str()->c_str();
+  auto* container_meta_type = plan.get()->container_meta_type();
+  ET_CHECK_OR_RETURN_ERROR(
+      container_meta_type != nullptr,
+      InvalidProgram,
+      "Missing container_meta_type in execution plan");
+  auto* encoded_out_str = container_meta_type->encoded_out_str();
+  ET_CHECK_OR_RETURN_ERROR(
+      encoded_out_str != nullptr,
+      InvalidProgram,
+      "Missing encoded_out_str in container_meta_type");
+  return encoded_out_str->c_str();
 }
 
 Error Program::get_backend_delegate_data(


### PR DESCRIPTION
Fix null pointer dereference vulnerability in Program::get_output_flattening_encoding()
that could crash when processing malformed PTE files.

The function dereferenced container_meta_type and encoded_out_str without null checks.
Since these fields are optional in the FlatBuffer schema (not marked as required),
a malformed PTE file with missing fields would cause a segfault, enabling
denial-of-service attacks.

Changes:
- Add null checks for container_meta_type and encoded_out_str, returning
  Error::InvalidProgram with descriptive error messages instead of crashing
- Add regression tests that verify malformed PTE files return errors
- Enable program_test target in CMakeLists.txt
