### PR TITLE
overflow in buffer data loader

### DIFF
--- a/extension/data_loader/buffer_data_loader.h
+++ b/extension/data_loader/buffer_data_loader.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <c10/util/safe_numerics.h>
 #include <executorch/runtime/core/data_loader.h>
 #include <executorch/runtime/core/error.h>
 #include <executorch/runtime/core/result.h>
@@ -34,8 +35,10 @@ class BufferDataLoader final : public executorch::runtime::DataLoader {
       size_t offset,
       size_t size,
       ET_UNUSED const DataLoader::SegmentInfo& segment_info) const override {
+    size_t total_size;
+    bool overflow = c10::add_overflows(offset, size, &total_size);
     ET_CHECK_OR_RETURN_ERROR(
-        offset + size <= size_,
+        !overflow && total_size <= size_,
         InvalidArgument,
         "offset %zu + size %zu > size_ %zu",
         offset,


### PR DESCRIPTION
Attack vector here is unlikely, given the buffer data loader is only used in tests or embedded environments where the model file is baked into the firmware, but still good to fix