### PR TITLE
[parakeet] Fix tokenizer API compatibility after library update

### DIFF
--- a/examples/models/parakeet/timestamp_utils.cpp
+++ b/examples/models/parakeet/timestamp_utils.cpp
@@ -17,22 +17,20 @@ std::vector<TokenWithTextInfo> get_tokens_with_text_info(
   tokens_with_text.reserve(tokens.size());
 
   for (const auto& token : tokens) {
-    auto piece_result = tokenizer.id_to_piece(token.id);
-    if (!piece_result.ok()) {
-      throw std::runtime_error(
-          "id_to_piece failed for token=" + std::to_string(token.id));
-    }
-
     auto text_result = tokenizer.decode(tokenizer.bos_tok(), token.id);
     if (!text_result.ok()) {
       throw std::runtime_error(
           "decode failed for token=" + std::to_string(token.id));
     }
 
+    // Use decoded text for both piece and text since id_to_piece is not available
+    // in the current tokenizer interface
+    const std::string decoded_text = text_result.get();
+    
     tokens_with_text.push_back(
         {token.id,
-         piece_result.get(),
-         text_result.get(),
+         decoded_text, // using decoded text as piece
+         decoded_text,
          token.start_offset,
          token.start_offset + token.duration});
   }

--- a/examples/models/parakeet/tokenizer_utils.cpp
+++ b/examples/models/parakeet/tokenizer_utils.cpp
@@ -55,11 +55,12 @@ std::unordered_set<std::string> derive_supported_punctuation(
 
   const int32_t vocab_size = tokenizer.vocab_size();
   for (int32_t id = 0; id < vocab_size; id++) {
-    const auto piece_result = tokenizer.id_to_piece(static_cast<TokenId>(id));
-    if (!piece_result.ok()) {
+    // Use decode to get token text since id_to_piece is not available
+    const auto text_result = tokenizer.decode(tokenizer.bos_tok(), static_cast<TokenId>(id));
+    if (!text_result.ok()) {
       continue;
     }
-    const std::string& piece = piece_result.get();
+    const std::string& piece = text_result.get();
     if (is_special_token(piece)) {
       continue;
     }


### PR DESCRIPTION
## Summary

I found that the Parakeet build didn't work with the new tokenizer submodule.

The tokenizer library submodule was updated from commit `37e1c7ed` to `3aada3fe`, which removed/changed the tokenizer API. The base `tokenizers::Tokenizer` interface no longer provides an `id_to_piece()` method, causing compilation failures in the parakeet example.

Updated `timestamp_utils.cpp` and `tokenizer_utils.cpp` to use the available `decode()` method instead of the removed `id_to_piece()` method to retrieve token text for a given token ID.

### Error message

```shell
cmake --workflow --preset parakeet-metal

...
Executing workflow step 2 of 2: build preset "parakeet-metal"

[ 25%] Building CXX object CMakeFiles/parakeet_runner.dir/main.cpp.o
[ 50%] Building CXX object CMakeFiles/parakeet_runner.dir/timestamp_utils.cpp.o
/Users/younghan/project/executorch/examples/models/parakeet/timestamp_utils.cpp:20:35: error: no member named 'id_to_piece' in 'tokenizers::Tokenizer'
   20 |     auto piece_result = tokenizer.id_to_piece(token.id);
      |                         ~~~~~~~~~ ^
1 error generated.
make[3]: *** [CMakeFiles/parakeet_runner.dir/timestamp_utils.cpp.o] Error 1
make[2]: *** [CMakeFiles/parakeet_runner.dir/all] Error 2
make[1]: *** [CMakeFiles/parakeet_runner.dir/rule] Error 2
make: *** [parakeet_runner] Error 2
```

## Resolved

```shell
cmake --workflow --preset parakeet-metal

...
/Users/younghan/project/executorch/cmake-out/examples/models/parakeet

Executing workflow step 2 of 2: build preset "parakeet-metal"

[ 25%] Building CXX object CMakeFiles/parakeet_runner.dir/main.cpp.o
[ 50%] Building CXX object CMakeFiles/parakeet_runner.dir/timestamp_utils.cpp.o
[ 75%] Building CXX object CMakeFiles/parakeet_runner.dir/tokenizer_utils.cpp.o
[100%] Linking CXX executable parakeet_runner
ld: warning: ignoring duplicate libraries: '/Users/younghan/project/executorch/cmake-out/lib/libcpublas.a', '/Users/younghan/project/executorch/cmake-out/lib/libeigen_blas.a', '/Users/younghan/project/executorch/cmake-out/lib/libextension_tensor.a', '/Users/younghan/project/executorch/cmake-out/lib/libkleidiai.a'
[100%] Built target parakeet_runner
```

## Environment

```shell
PyTorch version: 2.11.0.dev20251222
Is debug build: False
CUDA used to build PyTorch: None
ROCM used to build PyTorch: N/A

OS: macOS 26.2 (arm64)
GCC version: Could not collect
Clang version: 17.0.0 (clang-1700.6.3.2)
CMake version: version 3.31.6
Libc version: N/A

Python version: 3.11.14 (main, Oct 21 2025, 18:27:30) [Clang 20.1.8 ] (64-bit runtime)
Python platform: macOS-26.2-arm64-arm-64bit
Is CUDA available: False
CUDA runtime version: No CUDA
CUDA_MODULE_LOADING set to: N/A
GPU models and configuration: No CUDA
Nvidia driver version: No CUDA
cuDNN version: No CUDA
HIP runtime version: N/A
MIOpen runtime version: N/A
Is XNNPACK available: True

CPU:
Apple M3 Pro

Versions of relevant libraries:
[pip3] executorch==1.2.0a0+f39016d
[pip3] mypy_extensions==1.1.0
[pip3] numpy==2.3.4
[pip3] nv-one-logger-pytorch-lightning-integration==2.3.1
[pip3] onnx==1.20.1
[pip3] onnxruntime==1.23.2
[pip3] optimum-executorch==0.2.0.dev0
[pip3] pytorch-lightning==2.6.0
[pip3] pytorch_tokenizers==1.0.1
[pip3] torch==2.11.0.dev20251222
[pip3] torchao==0.14.0+git01849b2b1
[pip3] torchaudio==2.10.0.dev20251222
[pip3] torchdata==0.11.0
[pip3] torchmetrics==1.8.2
[pip3] torchsr==1.0.4
[pip3] torchtune==0.6.1
[pip3] torchvision==0.25.0.dev20251222
[conda] executorch                1.2.0a0+f39016d          pypi_0    pypi
[conda] numpy                     2.3.4                    pypi_0    pypi
[conda] nv-one-logger-pytorch-lightning-integration 2.3.1                    pypi_0    pypi
[conda] optimum-executorch        0.2.0.dev0               pypi_0    pypi
[conda] pytorch-lightning         2.6.0                    pypi_0    pypi
[conda] pytorch-tokenizers        1.0.1                    pypi_0    pypi
[conda] torch                     2.11.0.dev20251222          pypi_0    pypi
[conda] torchao                   0.14.0+git01849b2b1          pypi_0    pypi
[conda] torchaudio                2.10.0.dev20251222          pypi_0    pypi
[conda] torchdata                 0.11.0                   pypi_0    pypi
[conda] torchmetrics              1.8.2                    pypi_0    pypi
[conda] torchsr                   1.0.4                    pypi_0    pypi
[conda] torchtune                 0.6.1                    pypi_0    pypi
[conda] torchvision               0.25.0.dev20251222          pypi_0    pypi
```