### PR TITLE
[RELEASE ONLY CHANGES] Update torch pins to 2.10

### DIFF
--- a/.ci/docker/ci_commit_pins/pytorch.txt
+++ b/.ci/docker/ci_commit_pins/pytorch.txt
@@ -1,1 +1,1 @@
-7a79b41e29a790ebb4b530eb98a89381e2d7de29
+release/2.10

--- a/.ci/docker/common/install_pytorch.sh
+++ b/.ci/docker/common/install_pytorch.sh
@@ -32,9 +32,9 @@ install_pytorch_and_domains() {
   pip_install "$(echo dist/*.whl)"
 
   # Grab the pinned audio and vision commits from PyTorch
-  TORCHAUDIO_VERSION=$(cat .github/ci_commit_pins/audio.txt)
+  TORCHAUDIO_VERSION=release/2.10
   export TORCHAUDIO_VERSION
-  TORCHVISION_VERSION=$(cat .github/ci_commit_pins/vision.txt)
+  TORCHVISION_VERSION=release/0.25
   export TORCHVISION_VERSION
 
   install_domains

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -14,9 +14,9 @@ from install_utils import determine_torch_url, is_intel_mac_os, python_is_compat
 
 from torch_pin import NIGHTLY_VERSION, TORCH_VERSION
 
-# The pip repository that hosts nightly torch packages.
+# The pip repository that hosts torch packages.
 # This will be dynamically set based on CUDA availability and CUDA backend enabled/disabled.
-TORCH_NIGHTLY_URL_BASE = "https://download.pytorch.org/whl/nightly"
+TORCH_URL_BASE = "https://download.pytorch.org/whl/test"
 
 # Supported CUDA versions - modify this to add/remove supported versions
 # Format: tuple of (major, minor) version numbers
@@ -53,18 +53,14 @@ def install_requirements(use_pytorch_nightly):
         sys.exit(1)
 
     # Determine the appropriate PyTorch URL based on CUDA delegate status
-    torch_url = determine_torch_url(TORCH_NIGHTLY_URL_BASE, SUPPORTED_CUDA_VERSIONS)
+    torch_url = determine_torch_url(TORCH_URL_BASE, SUPPORTED_CUDA_VERSIONS)
 
     # pip packages needed by exir.
     TORCH_PACKAGE = [
         # Setting use_pytorch_nightly to false to test the pinned PyTorch commit. Note
         # that we don't need to set any version number there because they have already
         # been installed on CI before this step, so pip won't reinstall them
-        (
-            f"torch=={TORCH_VERSION}.{NIGHTLY_VERSION}"
-            if use_pytorch_nightly
-            else "torch"
-        ),
+        ("torch==2.10.0" if use_pytorch_nightly else "torch"),
     ]
 
     # Install the requirements for core ExecuTorch package.
@@ -123,20 +119,12 @@ def install_requirements(use_pytorch_nightly):
 
 def install_optional_example_requirements(use_pytorch_nightly):
     # Determine the appropriate PyTorch URL based on CUDA delegate status
-    torch_url = determine_torch_url(TORCH_NIGHTLY_URL_BASE, SUPPORTED_CUDA_VERSIONS)
+    torch_url = determine_torch_url(TORCH_URL_BASE, SUPPORTED_CUDA_VERSIONS)
 
     print("Installing torch domain libraries")
     DOMAIN_LIBRARIES = [
-        (
-            f"torchvision==0.25.0.{NIGHTLY_VERSION}"
-            if use_pytorch_nightly
-            else "torchvision"
-        ),
-        (
-            f"torchaudio==2.10.0.{NIGHTLY_VERSION}"
-            if use_pytorch_nightly
-            else "torchaudio"
-        ),
+        ("torchvision==0.25.0" if use_pytorch_nightly else "torchvision"),
+        ("torchaudio==2.10.0" if use_pytorch_nightly else "torchaudio"),
     ]
     # Then install domain libraries
     subprocess.run(

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -12,8 +12,6 @@ import sys
 
 from install_utils import determine_torch_url, is_intel_mac_os, python_is_compatible
 
-from torch_pin import NIGHTLY_VERSION, TORCH_VERSION
-
 # The pip repository that hosts torch packages.
 # This will be dynamically set based on CUDA availability and CUDA backend enabled/disabled.
 TORCH_URL_BASE = "https://download.pytorch.org/whl/test"


### PR DESCRIPTION
### Summary
As described in the release manual, update torch pins to 2.10.0 for pytorch and torchaudio, 0.25.0 for torchvision. This follows the same pattern as #14393.