### PR TITLE
remove invalid arg in qualcomm llama export

### DIFF
--- a/examples/qualcomm/oss_scripts/llama/eval_llama_qnn.py
+++ b/examples/qualcomm/oss_scripts/llama/eval_llama_qnn.py
@@ -212,7 +212,7 @@ def prepare_model(args):
 def prequant_algorithm(model, prefill_config, args):
     # TODO: use dtype of model checkpoint
     model = model.to(device=args.device, dtype=torch.float)
-    inputs = model.get_example_inputs(use_kv_cache=False)
+    inputs = model.get_example_inputs()
     tokens, atten_mask = inputs
     tokens.to(args.device)
     for mask in atten_mask.masks:


### PR DESCRIPTION
The LlamaModel.get_example_inputs() in model.py doesn't accept a use_kv_cache parameter. The method internally checks self.use_kv_cache instead.

