### PR TITLE
add the target file for model export

### DIFF
--- a/examples/qualcomm/oss_scripts/llama/TARGETS
+++ b/examples/qualcomm/oss_scripts/llama/TARGETS
@@ -10,9 +10,11 @@ runtime.python_library(
     srcs = [
         "model/__init__.py",
         "model/apply_rope.py",
+        "model/embedding.py",
         "model/feed_forward.py",
         "model/layernorm.py",
         "model/static_llama.py",
+        "model/vision_encoder.py",
     ],
     deps = [
         "//caffe2:torch",
@@ -50,12 +52,84 @@ runtime.python_library(
 )
 
 runtime.python_library(
+    name = "encoder",
+    srcs = [
+        "encoder/__init__.py",
+        "encoder/encoder_config.py",
+        "encoder/encoder_quant_recipe.py",
+    ],
+    deps = [
+        ":static_llama",
+        "//caffe2:torch",
+    ],
+)
+
+runtime.python_library(
+    name = "static_llm_quant_recipe",
+    srcs = [
+        "static_llm_quant_recipe.py",
+    ],
+    deps = [
+        "//caffe2:torch",
+        "//executorch/backends/qualcomm/quantizer:quantizer",
+        "//pytorch/ao:torchao",
+    ],
+)
+
+runtime.python_library(
+    name = "tokenizer",
+    srcs = [
+        "tokenizer.py",
+    ],
+    deps = [
+        "//caffe2:torch",
+    ],
+)
+
+runtime.python_library(
+    name = "dataset",
+    srcs = [
+        "dataset.py",
+    ],
+    deps = [
+        ":tokenizer",
+        "//caffe2:torch",
+    ],
+)
+
+runtime.python_library(
+    name = "wrappers",
+    srcs = [
+        "wrappers.py",
+    ],
+    deps = [
+        ":decoder_constants",
+        ":encoder",
+        ":static_llama",
+        ":static_llm_quant_recipe",
+        "//caffe2:torch",
+        "//executorch/backends/qualcomm/_passes:passes",
+        "//executorch/backends/qualcomm/quantizer:quantizer",
+        "//executorch/backends/qualcomm/utils:utils",
+        "//executorch/devtools/backend_debug:delegation_info",
+        "//executorch/examples/models/llama:hf_download",
+        "//executorch/examples/models/llama:source_transformation",
+        "//pytorch/ao:torchao",
+        "fbsource//third-party/pypi/transformers:transformers",
+    ],
+)
+
+runtime.python_library(
     name = "llama_lib",
     srcs = ["__init__.py", "llama.py"],
     deps = [
+        ":dataset",
         ":decoder_constants",
         ":decoder_utils",
+        ":encoder",
         ":masking_utils",
+        ":static_llm_quant_recipe",
+        ":wrappers",
         "//executorch/examples/models/llama:source_transformation",
         "//caffe2:torch",
         "//executorch/backends/qualcomm/partition:partition",
@@ -63,6 +137,13 @@ runtime.python_library(
         "//executorch/devtools/backend_debug:delegation_info",
         "//executorch/devtools:lib",
         "//executorch/examples/models:models",
+        "//executorch/examples/models/codegen:codegen",
+        "//executorch/examples/models/gemma:gemma",
+        "//executorch/examples/models/gemma2:gemma2",
+        "//executorch/examples/models/glm:glm",
+        "//executorch/examples/models/granite:granite",
+        "//executorch/examples/models/internvl3:internvl3",
+        "//executorch/examples/models/smolvlm:smolvlm",
         "//executorch/examples/models/llama:hf_download",
         "//executorch/examples/qualcomm/oss_scripts/llama:range_setting_pt2e",
         "//executorch/examples/qualcomm/oss_scripts/llama:static_llama",

--- a/examples/qualcomm/oss_scripts/llama/encoder/__init__.py
+++ b/examples/qualcomm/oss_scripts/llama/encoder/__init__.py
@@ -1,0 +1,27 @@
+# Copyright (c) Qualcomm Innovation Center, Inc.
+# All rights reserved
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from executorch.examples.qualcomm.oss_scripts.llama.encoder.encoder_config import (
+    InternVL3Encoder,
+    LateFusionModalityConfig,
+    SmolVLMEncoder,
+    VisionModalityConfig,
+)
+from executorch.examples.qualcomm.oss_scripts.llama.encoder.encoder_quant_recipe import (
+    EncoderQuantRecipe,
+    InternVL3_Encoder_QuantRecipe,
+    SmolVLM_Encoder_QuantRecipe,
+)
+
+__all__ = [
+    "EncoderQuantRecipe",
+    "InternVL3Encoder",
+    "InternVL3_Encoder_QuantRecipe",
+    "LateFusionModalityConfig",
+    "SmolVLMEncoder",
+    "SmolVLM_Encoder_QuantRecipe",
+    "VisionModalityConfig",
+]


### PR DESCRIPTION
Summary: To reuse OSS QNN, need buckify oss llama.py for internal verfication

Differential Revision: D91147403


