### PR TITLE
Arm backend: Ignore _debug_passes.py for code coverage

### DIFF
--- a/backends/arm/test/.coveragerc
+++ b/backends/arm/test/.coveragerc
@@ -1,6 +1,7 @@
 [run]
 omit =
     *__init__.py*
+    *_debug_passes.py
 
 [report]
 skip_covered = true


### PR DESCRIPTION
_debug_passes.py does not contain production code and is therefore not relevant to measure as a part of overall test coverage. For this reason, ignore this file for code coverage reports.

cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai