### PR TITLE
Arm backend: Add support for aten.unfold_copy

### DIFF
--- a/backends/arm/_passes/__init__.py
+++ b/backends/arm/_passes/__init__.py
@@ -81,6 +81,7 @@ from .decompose_tan_pass import DecomposeTanPass  # noqa
 from .decompose_tosa_unsupported_clamp_pass import (  # noqa
     DecomposeTOSAUnsupportedClampPass,
 )
+from .decompose_unfold_to_gather_pass import DecomposeUnfoldToGatherPass  # noqa
 from .decompose_var_pass import DecomposeVarPass  # noqa
 from .decorate_fp32_to_int32_casting_pass import DecorateFp32toInt32CastingPass  # noqa
 from .fold_qdq_with_annotated_qparams_pass import (  # noqa

--- a/backends/arm/_passes/arm_pass_manager.py
+++ b/backends/arm/_passes/arm_pass_manager.py
@@ -82,6 +82,7 @@ from executorch.backends.arm._passes import (
     DecomposeSumPass,
     DecomposeTanPass,
     DecomposeTOSAUnsupportedClampPass,
+    DecomposeUnfoldToGatherPass,
     DecomposeVarPass,
     DecorateFp32toInt32CastingPass,
     FoldAndAnnotateQParamsPass,
@@ -287,6 +288,7 @@ class ArmPassManager(PassManager):
                 DecomposeGeluPass(),
                 DecomposeAddSubAlphaPass(),
                 DecomposeGroupedConvPass(),
+                DecomposeUnfoldToGatherPass(),
                 Conv1dUnsqueezePass(),
             ]
         )

--- a/backends/arm/_passes/decompose_unfold_to_gather_pass.py
+++ b/backends/arm/_passes/decompose_unfold_to_gather_pass.py
@@ -1,0 +1,372 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import math
+from typing import Set, Type
+
+import torch
+
+from executorch.backends.arm._passes import ArmPass
+from executorch.backends.arm._passes.replace_scalar_with_tensor_pass import (
+    ReplaceScalarWithTensorByProfilePass,
+)
+from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import ExportPass
+
+
+def _get_unfold_copy_decomposition(op) -> tuple:
+    """
+    Returns the decomposition of the given aten.unfold_copy operation into
+    its equivalent TOSA-supported operations
+
+    Returns:
+        A tuple of operator overloads used by the decomposition.
+
+    Raises:
+        RuntimeError: If the provided operator is not supported by this pass.
+    """
+
+    if op in DecomposeUnfoldToGatherPass._TARGET_OPS:
+        return (
+            exir_ops.edge.dim_order_ops._to_dim_order_copy.default,
+            exir_ops.edge.aten.view_copy.default,
+            exir_ops.edge.aten.arange.start_step,
+            exir_ops.edge.aten.mul.Scalar,
+            exir_ops.edge.aten.unsqueeze_copy.default,
+            exir_ops.edge.aten.add.Tensor,
+            exir_ops.edge.aten.expand_copy.default,
+            exir_ops.backend.tosa.GATHER.default,
+            exir_ops.edge.aten.permute_copy.default,
+        )
+
+    raise RuntimeError(f"Can't get unfold_copy decomposition for op {op}")
+
+
+class DecomposeUnfoldToGatherPass(ArmPass):
+    """
+    Decompose unfold_copy with backend tosa.GATHER as the core op, plus other
+    TOSA-supported ops to build indices and materialize the output layout.
+
+    Supported op:
+      y = x.unfold_copy(dimension=dim, size=C, step=S)
+
+    Requirements:
+      - size > 0, step > 0
+      - input rank >= 1
+      - dim may be negative (normalized against rank)
+      - the selected dimension length K must satisfy K >= size
+      - shape must be static enough to compute:
+          U = floor((K - C) / S) + 1
+        (i.e. K, C, S known at export time)
+
+    Input / Output (PyTorch semantics):
+      - Input:  x has shape [d0, d1, ..., d{r-1}]  (rank r)
+      - Output: y has shape:
+          [d0, ..., d{dim-1}, U, d{dim+1}, ..., d{r-1}, C]
+        where U = floor((K - C) / S) + 1 and K = x.size(dim)
+
+    Strategy (single gather):
+      - If x is bool: cast to int8 for TOSA gather and cast back at the end.
+      - Normalize dimension and reshape x to the 3D "values" tensor expected by
+        TOSA gather:
+            pre  = x.shape[:dim]
+            post = x.shape[dim+1:]
+            P = prod(pre)  (or 1 if empty)
+            Q = prod(post) (or 1 if empty)
+            K = x.shape[dim]
+            values = reshape(x, [P, K, Q])
+      - Build a 1D index vector of length U*C:
+            idx2d[u,c] = u*S + c   for u in [0..U-1], c in [0..C-1]
+            idx1d = reshape(idx2d, [U*C])
+        Then expand across P:
+            indices = expand(idx1d[None, :], [P, U*C])
+      - Call backend gather:
+            tosa.GATHER(values=[P,K,Q], indices=[P,U*C]) -> [P,U*C,Q]
+      - Reshape and permute to match PyTorch unfold layout:
+            [P,U*C,Q] -> [*pre, U, *post, C]
+    """
+
+    _passes_required_after: Set[Type[ExportPass]] = {
+        ReplaceScalarWithTensorByProfilePass,
+    }
+
+    _TARGET_OPS = {
+        exir_ops.edge.aten.unfold_copy.default,
+    }
+
+    _UnfoldCopyInfo = tuple[
+        torch.Tensor,  # x_val (FakeTensor)
+        int,  # C
+        int,  # S
+        int,  # K
+        int,  # U
+        int,  # UC
+        list[int],  # pre
+        list[int],  # post
+        int,  # P
+        int,  # Q
+        bool,  # needs_bool_cast
+    ]
+
+    def _compute_unfold_copy_params(
+        self,
+        x: torch.Tensor,
+        dim: int,
+        size: int,
+        step: int,
+    ) -> _UnfoldCopyInfo:
+        x_val = x.data  # FakeTensor
+        x_shape = tuple(x_val.shape)
+        rank = len(x_shape)
+
+        # Checked by UnfoldCopySupported (programmer error if hit here).
+        assert rank >= 1, "unfold_copy requires rank >= 1"
+        assert size > 0 and step > 0, "unfold_copy requires size/step > 0"
+
+        dim_norm = dim % rank
+        C = size
+        S = step
+
+        K = x_shape[dim_norm]
+        assert K >= C, f"unfold_copy requires K>=C (K={K}, C={C})"
+
+        U = (K - C) // S + 1
+        UC = U * C
+
+        pre = list(x_shape[:dim_norm])
+        post = list(x_shape[dim_norm + 1 :])
+
+        P = math.prod(pre) if pre else 1
+        Q = math.prod(post) if post else 1
+
+        needs_bool_cast = x_val.dtype == torch.bool
+
+        return (x_val, C, S, K, U, UC, pre, post, P, Q, needs_bool_cast)
+
+    def call_operator(self, op, args, kwargs, meta):
+        if op not in self._TARGET_OPS:
+            return super().call_operator(op, args, kwargs, meta)
+
+        x, dim, size, step = args
+
+        (
+            x_val,
+            C,
+            S,
+            K,
+            U,
+            UC,
+            pre,
+            post,
+            P,
+            Q,
+            needs_bool_cast,
+        ) = self._compute_unfold_copy_params(x, dim, size, step)
+
+        (
+            to_copy_op,
+            view_op,
+            arange_op,
+            mul_scalar_op,
+            unsqueeze_op,
+            add_tensor_op,
+            expand_op,
+            tosa_gather_op,
+            permute_op,
+        ) = _get_unfold_copy_decomposition(op)
+
+        # Note:
+        #   bool unfolding (and the bool<->int8 casts) are INT-profile only;
+        #   FP profile should reject these via the UnfoldCopySupported check.
+        # ---- optional bool -> int8 ----
+        x_for_gather = x
+        if needs_bool_cast:
+            x_for_gather = super().call_operator(
+                to_copy_op,
+                (x,),
+                {"dtype": torch.int8},
+                meta,
+                updated=True,
+            )
+
+        # ---- values: [P, K, Q] ----
+        values_pkq = super().call_operator(
+            view_op,
+            (x_for_gather, [P, K, Q]),
+            {},
+            meta,
+            updated=True,
+        )
+
+        # ---- build idx1d of length U*C ----
+        # idx_u: [U]
+        idx_u = super().call_operator(
+            arange_op,
+            (0, U),
+            {
+                "dtype": torch.int32,
+                "device": x_val.device,
+            },
+            meta,
+            updated=True,
+        )
+        # idx_u_scaled: [U] = idx_u * S
+        idx_u_scaled = super().call_operator(
+            mul_scalar_op,
+            (idx_u, S),
+            {},
+            meta,
+            updated=True,
+        )
+        # idx_u2d: [U,1]
+        idx_u2d = super().call_operator(
+            unsqueeze_op,
+            (idx_u_scaled, 1),
+            {},
+            meta,
+            updated=True,
+        )
+
+        # idx_c: [C]
+        idx_c = super().call_operator(
+            arange_op,
+            (0, C),
+            {
+                "dtype": torch.int32,
+                "device": x_val.device,
+            },
+            meta,
+            updated=True,
+        )
+        # idx_c2d: [1,C]
+        idx_c2d = super().call_operator(
+            unsqueeze_op,
+            (idx_c, 0),
+            {},
+            meta,
+            updated=True,
+        )
+
+        # idx2d: [U,C] = idx_u2d + idx_c2d
+        idx2d = super().call_operator(
+            add_tensor_op,
+            (idx_u2d, idx_c2d),
+            {},
+            meta,
+            updated=True,
+        )
+
+        # idx1d: [U*C]
+        idx1d = super().call_operator(
+            view_op,
+            (idx2d, [UC]),
+            {},
+            meta,
+            updated=True,
+        )
+
+        # indices: [P, U*C] by expanding from [1, U*C]
+        idx_1xUC = super().call_operator(
+            unsqueeze_op,
+            (idx1d, 0),
+            {},
+            meta,
+            updated=True,
+        )
+        indices_puc = super().call_operator(
+            expand_op,
+            (idx_1xUC, [P, UC]),
+            {},
+            meta,
+            updated=True,
+        )
+
+        # ---- backend tosa gather ----
+        # tosa.GATHER(values=[P,K,Q], indices=[P,UC]) -> [P,UC,Q]
+        gathered_pucq = super().call_operator(
+            tosa_gather_op,
+            (values_pkq, indices_puc),
+            {},
+            meta,
+            updated=True,
+        )
+
+        # [P,UC,Q] -> [P,U,C,Q]
+        pucq = super().call_operator(
+            view_op,
+            (gathered_pucq, [P, U, C, Q]),
+            {},
+            meta,
+            updated=True,
+        )
+
+        # Unflatten Q back to post, and P back to pre:
+        # current logical layout: [*pre_flat=P, U, C, *post_flat=Q]
+        if post:
+            # [P,U,C,Q] -> [P,U,C,*post]
+            shaped = super().call_operator(
+                view_op,
+                (pucq, [P, U, C, *post]),
+                {},
+                meta,
+                updated=True,
+            )
+        else:
+            # [P,U,C,Q(=1)] -> [P,U,C]
+            shaped = super().call_operator(
+                view_op,
+                (pucq, [P, U, C]),
+                {},
+                meta,
+                updated=True,
+            )
+
+        if pre:
+            # [P,U,C,*post] -> [*pre, U, C, *post]
+            shaped = super().call_operator(
+                view_op,
+                (shaped, [*pre, U, C, *post]),
+                {},
+                meta,
+                updated=True,
+            )
+        else:
+            # drop P(=1): [P,U,C,*post] -> [U, C, *post]
+            shaped = super().call_operator(
+                view_op,
+                (shaped, [U, C, *post]),
+                {},
+                meta,
+                updated=True,
+            )
+
+        # Move C to the last dimension:
+        # from [*pre, U, C, *post] -> [*pre, U, *post, C]
+        pre_len = len(pre)
+        post_len = len(post)
+        rank_cur = pre_len + 1 + 1 + post_len  # pre + U + C + post
+        c_idx = pre_len + 1
+
+        perm = list(range(0, pre_len + 1)) + list(range(c_idx + 1, rank_cur)) + [c_idx]
+        out = super().call_operator(
+            permute_op,
+            (shaped, perm),
+            {},
+            meta,
+            updated=True,
+        )
+
+        # ---- optional int8 -> bool ----
+        if needs_bool_cast:
+            out = super().call_operator(
+                to_copy_op,
+                (out,),
+                {"dtype": torch.bool},
+                meta,
+                updated=True,
+            )
+
+        return out

--- a/backends/arm/operator_support/__init__.py
+++ b/backends/arm/operator_support/__init__.py
@@ -20,5 +20,6 @@ from . import (  # noqa
     slice_copy_support,
     to_dim_order_copy_support,
     tosa_supported_operators,
+    unfold_copy_support,
     where_support,
 )

--- a/backends/arm/operator_support/ethos_u55_support.py
+++ b/backends/arm/operator_support/ethos_u55_support.py
@@ -214,6 +214,7 @@ class EthosU55NotSupported(OperatorSupportBase):
         exir_ops.edge.aten.select_scatter.default,
         exir_ops.edge.aten.scatter_reduce.two,
         exir_ops.edge.aten.scatter_add.default,
+        exir_ops.edge.aten.unfold_copy.default,  # GATHER
         exir_ops.edge.aten.upsample_nearest2d.vec,  # RESIZE
         exir_ops.edge.aten.upsample_bilinear2d.vec,  # RESIZE
         exir_ops.edge.aten.reflection_pad1d.default,  # REVERSE

--- a/backends/arm/operator_support/unfold_copy_support.py
+++ b/backends/arm/operator_support/unfold_copy_support.py
@@ -1,0 +1,121 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Declare operator support for ``edge.aten.unfold_copy`` in TOSA.
+
+This support check matches the subset intended to be handled by the Arm
+unfold lowering (e.g. DecomposeUnfoldToGatherPass), similar to how
+GatherSupported gates CanonicalizeGatherPass.
+
+Supported pattern:
+
+- target: exir_ops.edge.aten.unfold_copy.default
+- args: exactly (x, dimension, size, step)  (i.e. len(node.args) == 4)
+- x must be rank >= 1 (e.g. [T], [B,T], [B,T,F], ...)
+- dimension may be negative (normalized against rank)
+- size and step must be > 0
+- the selected dimension length must satisfy D >= size
+
+Notes:
+- Dtype/profile constraints apply (see dtype checks below).
+- This check assumes static shapes and constant dim/size/step.
+"""
+
+import torch
+import torch.fx as fx
+
+from executorch.backends.arm.operator_support.tosa_supported_operators import (
+    register_tosa_support_check,
+    SupportedTOSAOperatorCheck,
+)
+from executorch.backends.arm.tosa import TosaSpecification
+from executorch.exir.dialects._ops import ops as exir_ops
+
+
+@register_tosa_support_check
+class UnfoldCopySupported(SupportedTOSAOperatorCheck):
+    """Provide TOSA support check for ``edge.aten.unfold_copy``."""
+
+    targets = [exir_ops.edge.aten.unfold_copy.default]
+
+    tosa_specs = [
+        TosaSpecification.create_from_string("TOSA-1.0+INT"),
+        TosaSpecification.create_from_string("TOSA-1.0+FP"),
+    ]
+
+    def is_node_tosa_supported(
+        self, node: fx.Node, tosa_spec: TosaSpecification
+    ) -> bool:  # type: ignore[override, misc]
+        """Return True if the node is supported by TOSA."""
+
+        if len(node.args) != 4:
+            self.reporter.report_reject(
+                node,
+                f"{node.target}: expected 4 args (x, dimension, size, step), "
+                f"got {len(node.args)}.",
+            )
+            return False
+
+        x_arg, dim, size, step = node.args
+
+        if size <= 0 or step <= 0:  # type: ignore[operator]
+            self.reporter.report_reject(
+                node,
+                f"{node.target}: size and step must be > 0, got size={size} "
+                f"step={step}.",
+            )
+            return False
+
+        x_val = x_arg.meta["val"]  # type: ignore[union-attr]
+        x_shape = tuple(x_val.shape)
+        x_rank = len(x_shape)
+
+        if x_rank < 1:
+            self.reporter.report_reject(
+                node,
+                f"{node.target}: input must be rank>=1, got shape={x_shape}.",
+            )
+            return False
+
+        # Values dtype validation
+        values_dtype = x_val.dtype
+        # ints (and bool via casts) require INT profile
+        if values_dtype in (torch.bool, torch.int8, torch.int16, torch.int32):
+            if not tosa_spec.support_integer():
+                self.reporter.report_reject(
+                    node,
+                    f"{node.target}: dtype {values_dtype} requires INT profile.",
+                )
+                return False
+        # fp16/fp32: either FP profile, or INT profile (via quantization)
+        elif values_dtype in (torch.float16, torch.float32):
+            if not (tosa_spec.support_float() or tosa_spec.support_integer()):
+                self.reporter.report_reject(
+                    node,
+                    f"{node.target}: dtype {values_dtype} requires FP profile or "
+                    "INT profile (with quantization).",
+                )
+                return False
+        else:
+            self.reporter.report_reject(
+                node,
+                f"{node.target}: unsupported values dtype {values_dtype}; "
+                "expected bool/int8/int16/int32/float16/float32.",
+            )
+            return False
+
+        # Basic validity on unfolded dimension
+        dim_norm = dim % x_rank  # type: ignore[operator]
+        D = x_shape[dim_norm]  # type: ignore[index]
+        if D < size:
+            self.reporter.report_reject(
+                node,
+                f"{node.target}: invalid unfold (x.shape[{dim_norm}]={D} < "
+                f"size={size}) for shape={x_shape}.",
+            )
+            return False
+
+        return True

--- a/backends/arm/quantizer/quantization_annotator.py
+++ b/backends/arm/quantizer/quantization_annotator.py
@@ -429,6 +429,7 @@ _one_to_one_shared_input_qspec = [
     torch.ops.aten.clamp.Tensor,
     torch.ops.aten.unflatten.int,
     torch.ops.aten.gather.default,
+    torch.ops.aten.unfold_copy.default,
     torch.ops.aten.index_select.default,
     torch.ops.aten.index.Tensor,
     # Neg operator flips the range, but keps the magnitude the same.

--- a/backends/arm/scripts/collect_testname_resources.py
+++ b/backends/arm/scripts/collect_testname_resources.py
@@ -47,6 +47,7 @@ _CUSTOM_EDGE_OPS = [
     "sum.default",
     "unbind.int",
     "unflatten.int",
+    "unfold_copy.default",
     "_native_batch_norm_legit_no_training.default",
     "_native_batch_norm_legit.no_stats",
     "alias_copy.default",

--- a/backends/arm/test/ops/test_unfold_copy.py
+++ b/backends/arm/test/ops/test_unfold_copy.py
@@ -1,0 +1,205 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Tuple
+
+import torch
+
+from executorch.backends.arm.test import common
+from executorch.backends.arm.test.tester.test_pipeline import (
+    EthosU85PipelineINT,
+    OpNotSupportedPipeline,
+    TosaPipelineFP,
+    TosaPipelineINT,
+    VgfPipeline,
+)
+
+
+class UnfoldCopy(torch.nn.Module):
+    aten_op = "torch.ops.aten.unfold_copy.default"
+    exir_op = "executorch_exir_dialects_edge__ops_aten_unfold_copy_default"
+
+    def forward(self, input_: torch.Tensor, dim_: int, size_: int, step_: int):
+        return torch.ops.aten.unfold_copy.default(input_, dim_, size_, step_)
+
+
+input_params = Tuple[torch.Tensor, int, int, int]
+
+# ---- FP profile: only float inputs ----
+test_data_fp: dict[str, input_params] = {
+    # 1D: [T] -> unfold dim=0 => [U, C]
+    "test_fp32_1d_dim0": (
+        torch.tensor([0.1, 0.2, 0.3, 0.4, 0.5], dtype=torch.float32),  # [T=5]
+        0,
+        3,
+        2,  # U=(5-3)//2+1=2 -> [U=2, C=3]
+    ),
+    # 2D: [B, T] -> unfold dim=1 => [B, U, C]
+    "test_fp32_2d_dim1": (
+        torch.tensor(
+            [[0.1, 0.2, 0.3, 0.4, 0.5], [1.1, 1.2, 1.3, 1.4, 1.5]],
+            dtype=torch.float32,
+        ),  # [B=2, T=5]
+        1,
+        3,
+        2,  # U=(5-3)//2+1=2 -> [B=2, U=2, C=3]
+    ),
+    # 3D: [B, T, F] -> unfold dim=-1 => [B, T, U, C]
+    "test_fp32_3d_dim_neg1": (
+        torch.randn(2, 6, 4, dtype=torch.float32),  # [B=2, T=6, F=4]
+        -1,
+        3,
+        1,  # U=(4-3)//1+1=2 -> [B=2, T=6, U=2, C=3]
+    ),
+    # 4D: [B, T, N, H] -> unfold dim=1 => [B, U, N, H, C]
+    "test_fp32_4d_dim1": (
+        torch.randn(2, 6, 3, 4, dtype=torch.float32),  # [B=2, T=6, N=3, H=4]
+        1,
+        3,
+        2,  # U=(6-3)//2+1=2 -> [B=2, U=2, N=3, H=4, C=3]
+    ),
+    # 4D: [B, T, N, H] -> unfold dim=-1 => [B, T, N, U, C]
+    "test_fp32_4d_dim_neg1": (
+        torch.randn(2, 6, 3, 4, dtype=torch.float32),  # [B=2, T=6, N=3, H=4]
+        -1,
+        3,
+        1,  # U=(4-3)//1+1=2 -> [B=2, T=6, N=3, U=2, C=3]
+    ),
+}
+
+# ---- INT profile: integer inputs + bool ----
+test_data_int: dict[str, input_params] = {
+    # int8 1D: [T] -> unfold dim=0 => [U, C]
+    "test_int8_1d_dim0": (
+        torch.randint(-5, 5, size=(10,), dtype=torch.int8),  # [T=10]
+        0,
+        4,
+        3,  # U=(10-4)//3+1=3 -> [U=3, C=4]
+    ),
+    # bool 1D: [T] -> unfold dim=-1 => [U, C]
+    "test_bool_1d_dim_neg1": (
+        torch.tensor([True, False, True, True], dtype=torch.bool),  # [T=4]
+        -1,
+        3,
+        1,  # U=(4-3)//1+1=2 -> [U=2, C=3]
+    ),
+    # bool 2D: [B, T] -> unfold dim=0 => [U, T, C]
+    "test_bool_2d_dim0": (
+        torch.tensor(
+            [[True, False, True], [False, True, False]],
+            dtype=torch.bool,
+        ),  # [B=2, T=3]
+        0,
+        2,
+        1,  # U=(2-2)//1+1=1 -> [U=1, T=3, C=2]
+    ),
+    # int8 3D: [B, T, F] -> unfold dim=1 => [B, U, F, C]
+    "test_int8_3d_dim1": (
+        torch.randint(-5, 5, size=(2, 8, 5), dtype=torch.int8),  # [B=2, T=8, F=5]
+        1,
+        4,
+        2,  # U=(8-4)//2+1=3 -> [B=2, U=3, F=5, C=4]
+    ),
+    # int8 3D: [B, T, F] -> unfold dim=-1 => [B, T, U, C]
+    "test_int8_3d_dim_neg1": (
+        torch.randint(-5, 5, size=(2, 8, 5), dtype=torch.int8),  # [B=2, T=8, F=5]
+        -1,
+        3,
+        2,  # U=(5-3)//2+1=2 -> [B=2, T=8, U=2, C=3]
+    ),
+    # int32 4D: [B, T, N, H] -> unfold dim=-1 => [B, T, N, U, C]
+    "test_int32_4d_dim_neg1": (
+        torch.randint(
+            -50, 50, size=(2, 7, 2, 3), dtype=torch.int32
+        ),  # [B=2, T=7, N=2, H=3]
+        -1,
+        2,
+        1,  # U=(3-2)//1+1=2 -> [B=2, T=7, N=2, U=2, C=2]
+    ),
+}
+
+
+@common.parametrize("test_data", test_data_fp)
+def test_unfold_copy_tosa_FP(test_data: input_params):
+    pipeline = TosaPipelineFP[input_params](
+        UnfoldCopy(),
+        test_data,
+        aten_op=UnfoldCopy.aten_op,
+        exir_op=UnfoldCopy.exir_op,
+    )
+    pipeline.run()
+
+
+@common.parametrize("test_data", test_data_int | test_data_fp)
+def test_unfold_copy_tosa_INT(test_data: input_params):
+    pipeline = TosaPipelineINT[input_params](
+        UnfoldCopy(),
+        test_data,
+        aten_op=UnfoldCopy.aten_op,
+        exir_op=UnfoldCopy.exir_op,
+    )
+    pipeline.run()
+
+
+@common.parametrize("test_data", test_data_int | test_data_fp)
+@common.XfailIfNoCorstone300
+def test_unfold_copy_u55_INT(test_data: input_params):
+    # Gather op is not supported on U55
+    pipeline = OpNotSupportedPipeline[input_params](
+        UnfoldCopy(),
+        test_data,
+        {UnfoldCopy.exir_op: 1},
+        quantize=True,
+        u55_subset=True,
+        n_expected_delegates=0,
+    )
+    pipeline.run()
+
+
+@common.parametrize(
+    "test_data",
+    test_data_int | test_data_fp,
+    xfails={
+        "test_int8_3d_dim_neg1": "MLETORCH-1732: rand test fails",
+        "test_int32_4d_dim_neg1": "MLETORCH-1732: rand test fails",
+        "test_fp32_3d_dim_neg1": "MLETORCH-1732: rand test fails",
+        "test_fp32_4d_dim_neg1": "MLETORCH-1732: rand test fails",
+    },
+)
+@common.XfailIfNoCorstone320
+def test_unfold_copy_u85_INT(test_data: input_params):
+    pipeline = EthosU85PipelineINT[input_params](
+        UnfoldCopy(),
+        test_data,
+        aten_ops=UnfoldCopy.aten_op,
+        exir_ops=UnfoldCopy.exir_op,
+    )
+    pipeline.run()
+
+
+@common.parametrize("test_data", test_data_fp | test_data_int)
+@common.SkipIfNoModelConverter
+def test_unfold_copy_vgf_no_quant(test_data: input_params):
+    pipeline = VgfPipeline[input_params](
+        UnfoldCopy(),
+        test_data,
+        aten_op=UnfoldCopy.aten_op,
+        exir_op=UnfoldCopy.exir_op,
+        quantize=False,
+    )
+    pipeline.run()
+
+
+@common.parametrize("test_data", test_data_fp | test_data_int)
+@common.SkipIfNoModelConverter
+def test_unfold_copy_vgf_quant(test_data: input_params):
+    pipeline = VgfPipeline[input_params](
+        UnfoldCopy(),
+        test_data,
+        aten_op=UnfoldCopy.aten_op,
+        exir_op=UnfoldCopy.exir_op,
+        quantize=True,
+    )
+    pipeline.run()


### PR DESCRIPTION
- Decompose edge.aten.unfold_copy via backend tosa.GATHER + shape ops
- Add UnfoldCopySupported TOSA support check for the supported pattern
- Add unfold_copy tests covering 1D-4D inputs and dim={0,1,-1} for FP and INT pipelines; add U85 INT xfails

Change-Id: I0a4b96e8c307f2a638e68f6d137cde489b1261c9


cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai