### PR TITLE
In place zero fill for Devserver FSIM debug buffer

### DIFF
--- a/devtools/etdump/data_sinks/tests/file_data_sink_test.cpp
+++ b/devtools/etdump/data_sinks/tests/file_data_sink_test.cpp
@@ -137,3 +137,88 @@ TEST_F(FileDataSinkTest, WriteMultipleDataAndCheckOffsets) {
   EXPECT_EQ(
       std::memcmp(file_content.data() + offset3.get(), data3, data3_size), 0);
 }
+
+TEST_F(FileDataSinkTest, WriteInPlaceTensorZeroFill) {
+  // Test writing with nullptr ptr and non-zero length (in-place tensor case)
+  // This should zero-fill the file
+  size_t length = 16;
+
+  // Create a FileDataSink instance
+  Result<FileDataSink> result = FileDataSink::create(file_path_.c_str());
+  ASSERT_TRUE(result.ok());
+  FileDataSink* data_sink = &result.get();
+
+  // Write nullptr with non-zero length
+  Result<size_t> write_result = data_sink->write(nullptr, length);
+  ASSERT_TRUE(write_result.ok());
+  EXPECT_EQ(write_result.get(), 0);
+
+  size_t used_bytes = data_sink->get_used_bytes();
+  EXPECT_EQ(used_bytes, length);
+
+  data_sink->close();
+
+  // Verify the file contents are zero-filled
+  std::ifstream file(file_path_, std::ios::binary);
+  file.seekg(0, std::ios::end);
+  size_t file_size = file.tellg();
+  file.seekg(0, std::ios::beg);
+  EXPECT_EQ(file_size, length);
+
+  // Read the file content and verify it's all zeros
+  std::vector<uint8_t> file_content(file_size);
+  file.read(reinterpret_cast<char*>(file_content.data()), file_size);
+  file.close();
+
+  for (size_t i = 0; i < length; ++i) {
+    EXPECT_EQ(file_content[i], 0);
+  }
+}
+
+TEST_F(FileDataSinkTest, WriteZeroLengthReturnsCurrentOffset) {
+  // Create a FileDataSink instance
+  Result<FileDataSink> result = FileDataSink::create(file_path_.c_str());
+  ASSERT_TRUE(result.ok());
+  FileDataSink* data_sink = &result.get();
+
+  // Zero length write should return current offset (0)
+  Result<size_t> ret = data_sink->write(nullptr, 0);
+  ASSERT_TRUE(ret.ok());
+  EXPECT_EQ(ret.get(), 0);
+
+  // Write some data first
+  const char* data = "Hello";
+  size_t data_size = strlen(data);
+  Result<size_t> write_ret = data_sink->write(data, data_size);
+  ASSERT_TRUE(write_ret.ok());
+
+  // Zero length write should return current offset
+  size_t current_used = data_sink->get_used_bytes();
+  Result<size_t> ret2 = data_sink->write(nullptr, 0);
+  ASSERT_TRUE(ret2.ok());
+  EXPECT_EQ(ret2.get(), current_used);
+
+  data_sink->close();
+}
+
+TEST_F(FileDataSinkTest, WriteNullptrWithZeroLengthReturnsCurrentOffset) {
+  // Create a FileDataSink instance
+  Result<FileDataSink> result = FileDataSink::create(file_path_.c_str());
+  ASSERT_TRUE(result.ok());
+  FileDataSink* data_sink = &result.get();
+
+  // Write some data first to advance the offset
+  const char* data = "Test data";
+  size_t data_size = strlen(data);
+  Result<size_t> write_ret = data_sink->write(data, data_size);
+  ASSERT_TRUE(write_ret.ok());
+
+  size_t current_used = data_sink->get_used_bytes();
+
+  // Writing nullptr with zero length should return current offset
+  Result<size_t> ret = data_sink->write(nullptr, 0);
+  ASSERT_TRUE(ret.ok());
+  EXPECT_EQ(ret.get(), current_used);
+
+  data_sink->close();
+}


### PR DESCRIPTION
Summary: Some ops are in place (`index_put_` or `aten_copy_`). This diff makes the debug buffer flow support these cases.

Differential Revision: D86346763


