### PR TITLE
[RELEASE ONLY CHANGES] Use torchao 0.15.0

### DIFF
--- a/.ci/docker/common/install_pytorch.sh
+++ b/.ci/docker/common/install_pytorch.sh
@@ -17,7 +17,7 @@ install_domains() {
 }
 
 install_pytorch_and_domains() {
-  pip_install --force-reinstall torch==2.10.0 torchvision==0.25.0 torchaudio==2.10.0 --index-url https://download.pytorch.org/whl/test/cpu
+  pip_install --force-reinstall torch==2.10.0 torchvision==0.25.0 torchaudio==2.10.0 torchao==0.15.0 --index-url https://download.pytorch.org/whl/test/cpu
 }
 
 install_pytorch_and_domains

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ dependencies=[
   "scikit-learn==1.7.1",
   "hydra-core>=1.3.0",
   "omegaconf>=2.3.0",
+  "torchao==0.15.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
### Summary
AO has officially released 0.15.0 (see https://pypi.org/project/torchao/#history). Update the pyproject.toml and pins to use 0.15. Also bumps the submodule to the v0.15.0 tag.

### Test plan
CI