### PR TITLE
[ET-VK][ez] Add support for auto_functionalized_v2

### DIFF
--- a/backends/vulkan/partitioner/vulkan_partitioner.py
+++ b/backends/vulkan/partitioner/vulkan_partitioner.py
@@ -97,7 +97,10 @@ class VulkanSupportedOperators(OperatorSupportBase):
         """
         target = node.target
         # Account for custom operators
-        if node.target == torch.ops.higher_order.auto_functionalized:
+        if (
+            node.target == torch.ops.higher_order.auto_functionalized
+            or node.target == torch.ops.higher_order.auto_functionalized_v2
+        ):
             first_arg = node.args[0]
             assert isinstance(first_arg, torch._ops.OpOverload)
             target = first_arg.name()
@@ -223,7 +226,10 @@ class VulkanSupportedOperators(OperatorSupportBase):
                 return True
 
         target = node.target
-        if node.target == torch.ops.higher_order.auto_functionalized:
+        if (
+            node.target == torch.ops.higher_order.auto_functionalized
+            or node.target == torch.ops.higher_order.auto_functionalized_v2
+        ):
             first_arg = node.args[0]
             assert isinstance(first_arg, torch._ops.OpOverload)
             target = first_arg.name()

--- a/backends/vulkan/test/utils.py
+++ b/backends/vulkan/test/utils.py
@@ -819,7 +819,10 @@ def print_occurrences(edge_program, operator_list: List):
         if utils.is_torch_op_node(node):
             target = node.target
             # Handle auto_functionalized nodes
-            if node.target == torch.ops.higher_order.auto_functionalized:
+            if (
+                node.target == torch.ops.higher_order.auto_functionalized
+                or node.target == torch.ops.higher_order.auto_functionalized_v2
+            ):
                 first_arg = node.args[0]
                 if hasattr(first_arg, "name"):
                     target = first_arg.name()
@@ -907,7 +910,10 @@ def op_ablation_test(  # noqa: C901
         if utils.is_torch_op_node(node):
             target = node.target
             # Handle auto_functionalized nodes
-            if node.target == torch.ops.higher_order.auto_functionalized:
+            if (
+                node.target == torch.ops.higher_order.auto_functionalized
+                or node.target == torch.ops.higher_order.auto_functionalized_v2
+            ):
                 first_arg = node.args[0]
                 if hasattr(first_arg, "name"):
                     target = first_arg.name()


### PR DESCRIPTION

Summary:
Update the Vulkan partitioner to recognize torch.ops.higher_order.auto_functionalized_v2
in addition to the existing auto_functionalized op when determining operator support
and extracting target names for custom operators.
