### PR TITLE
Fix null pointer dereference in get_execution_plan

### DIFF
--- a/runtime/executor/program.cpp
+++ b/runtime/executor/program.cpp
@@ -49,7 +49,8 @@ Result<executorch_flatbuffer::ExecutionPlan*> get_execution_plan(
   auto execution_plans = program->execution_plan();
   for (size_t i = 0; i < execution_plans->size(); i++) {
     auto plan = execution_plans->GetMutableObject(i);
-    if (std::strcmp(plan->name()->c_str(), method_name) == 0) {
+    if (plan != nullptr && plan->name() != nullptr &&
+        std::strcmp(plan->name()->c_str(), method_name) == 0) {
       return plan;
     }
   }


### PR DESCRIPTION
### Summary
Add null ptr check in program.get_execution_plan. Not sure if the test is really necessary but have it here just in case.

### Test plan
```
cmake .. -DEXECUTORCH_BUILD_TESTS=ON
cmake --build . --target program_test
ctest -R program_test -V
```