### PR TITLE
[1.1 Release] Add 1.1 doc link

### DIFF
--- a/versions.html
+++ b/versions.html
@@ -20,6 +20,9 @@
           <a class="reference internal" href="main/">main (unstable)</a>
         </li>
         <li class="toctree-l1">
+          <a class="reference internal" href="1.1">1.1 (release candidate)</a>
+        </li>
+        <li class="toctree-l1">
           <a class="reference internal" href="1.0">1.0 (stable release)</a>
         </li>
         <li class="toctree-l1">


### PR DESCRIPTION
### Summary
Add a dropdown entry / link for 1.1, currently tagged as a release candidate.

### Test plan
Verified that docs are live at https://docs.pytorch.org/executorch/1.1/index.html