### PR TITLE
executorch | Use Vulkan headers only through `version-selector`

### DIFF
--- a/backends/vulkan/targets.bzl
+++ b/backends/vulkan/targets.bzl
@@ -188,7 +188,7 @@ def define_common_targets(is_fbcode = False):
         if no_volk:
             for deps in [default_deps, android_deps]:
                 deps.append("fbsource//third-party/toolchains:vulkan")
-                deps.append("fbsource//third-party/khronos:vulkan-headers")
+                deps.append("fbsource//third-party/khronos/version-selector:vulkan-headers")
         else:
             for deps in [default_deps, android_deps]:
                 deps.append("fbsource//third-party/volk:volk-header")


### PR DESCRIPTION
Summary: Use Vulkan headers only through `version-selector`.

Differential Revision: D91003972




cc @SS-JIA @manuelcandales @digantdesai @cbilgin