### PR TITLE
[ET-VK] Add storage_type parameter to define_required_extensions

### DIFF
--- a/backends/vulkan/runtime/graph/ops/glsl/addmm_naive_buffer.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/addmm_naive_buffer.glsl
@@ -8,14 +8,14 @@
 
 #version 450 core
 
+${define_required_extensions("buffer", DTYPE)}
+
 #define PRECISION ${PRECISION}
 
 $if HAS_BIAS:
   #define HAS_BIAS
 
 #define T ${buffer_scalar_type(DTYPE)}
-
-${define_required_extensions(DTYPE)}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/binary_op.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/binary_op.glsl
@@ -6,12 +6,16 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#version 450 core
-
-#define PRECISION ${PRECISION}
-
 // Binary comparison ops require that the output is boolean and not the same as input.
 $IS_COMPARISON_OP = (any([name in VARIANT_NAME for name in ["binary_eq",  "binary_lt", "binary_le", "binary_gt", "binary_ge"]]))
+
+#version 450 core
+
+${define_required_extensions(STORAGE, DTYPE)}
+$if IS_COMPARISON_OP:
+  ${define_required_extensions(STORAGE, "uint8")}
+
+#define PRECISION ${PRECISION}
 
 #define NAME ${VARIANT_NAME}
 
@@ -26,11 +30,6 @@ $else:
 #define op(X, Y, A) ${OPERATOR}
 
 ${define_active_storage_type(STORAGE)}
-${define_required_extensions(DTYPE)}
-
-
-$if IS_COMPARISON_OP:
-  ${define_required_extensions("uint8")}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/binary_q8ta_q8ta_q8to.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/binary_q8ta_q8ta_q8to.glsl
@@ -8,6 +8,8 @@
 
 #version 450 core
 
+${define_required_extensions("buffer", DTYPE)}
+
 #define PRECISION ${PRECISION}
 
 #define NAME ${VARIANT_NAME}
@@ -20,8 +22,6 @@ $if IO_STORAGE == "buffer":
   #define PACKED_INT8_INPUT_BUFFER
 
 #define op(X, Y) ${OPERATOR}
-
-${define_required_extensions(DTYPE)}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/binary_scalar_buffer.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/binary_scalar_buffer.glsl
@@ -8,6 +8,8 @@
 
 #version 450 core
 
+${define_required_extensions(STORAGE, DTYPE)}
+
 #define PRECISION ${PRECISION}
 
 #define NAME ${VARIANT_NAME}
@@ -17,7 +19,6 @@
 #define op(X, Y) ${OPERATOR}
 
 ${define_active_storage_type(STORAGE)}
-${define_required_extensions(DTYPE)}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/binary_scalar_texture.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/binary_scalar_texture.glsl
@@ -8,6 +8,8 @@
 
 #version 450 core
 
+${define_required_extensions(STORAGE, DTYPE)}
+
 #define PRECISION ${PRECISION}
 
 #define NAME ${VARIANT_NAME}
@@ -18,7 +20,6 @@
 #define op(X, Y) ${OPERATOR}
 
 ${define_active_storage_type(STORAGE)}
-${define_required_extensions(DTYPE)}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/buffer_to_buffer.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/buffer_to_buffer.glsl
@@ -1,10 +1,10 @@
 #version 450 core
 
+${define_required_extensions(STORAGE, DTYPE)}
+
 #define PRECISION ${PRECISION}
 
 #define T ${buffer_scalar_type(DTYPE)}
-
-${define_required_extensions(DTYPE)}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/buffer_to_nchw.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/buffer_to_nchw.glsl
@@ -1,12 +1,12 @@
 #version 450 core
 
+${define_required_extensions(STORAGE, DTYPE)}
+${define_required_extensions("buffer", BUF_DTYPE)}
+
 #define PRECISION ${PRECISION}
 
 #define T ${buffer_scalar_type(DTYPE)}
 #define DST_T ${buffer_scalar_type(BUF_DTYPE)}
-
-${define_required_extensions(DTYPE)}
-${define_required_extensions(BUF_DTYPE)}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/choose_qparams_per_row.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/choose_qparams_per_row.glsl
@@ -8,6 +8,11 @@
 
 #version 450 core
 
+${define_required_extensions(STORAGE, DTYPE)}
+${define_required_extensions("texture3d", "int8")}
+
+#extension GL_EXT_control_flow_attributes : require
+
 #define PRECISION ${PRECISION}
 #define VEC4_T ${texel_load_type(DTYPE, STORAGE)}
 #define T ${texel_load_component_type(DTYPE, STORAGE)}
@@ -19,11 +24,6 @@
 #define MAX_THREADS 256
 
 ${define_active_storage_type(STORAGE)}
-
-${define_required_extensions(DTYPE)}
-${define_required_extensions("int8")}
-
-#extension GL_EXT_control_flow_attributes : require
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/col2im.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/col2im.glsl
@@ -8,6 +8,9 @@
 
 #version 450 core
 
+${define_required_extensions(OUTPUT_STORAGE, DTYPE)}
+${define_required_extensions(INPUT_STORAGE, DTYPE)}
+
 #define PRECISION ${PRECISION}
 #define VEC4_T ${texel_load_type(DTYPE, OUTPUT_STORAGE)}
 #define T ${texel_load_component_type(DTYPE, OUTPUT_STORAGE)}
@@ -24,8 +27,6 @@ $if INPUT_STORAGE == "buffer":
 #define TILE_M 4
 #define TILE_N 4
 #define TILE_K 4
-
-${define_required_extensions(DTYPE)}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/concat_buffer.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/concat_buffer.glsl
@@ -8,13 +8,14 @@
 
 #version 450 core
 
+${define_required_extensions("buffer", DTYPE)}
+
 #define PRECISION ${PRECISION}
 
 #define VEC4_T ${texel_type(DTYPE)}
 #define T ${buffer_scalar_type(DTYPE)}
 
 ${define_active_storage_type("buffer")}
-${define_required_extensions(DTYPE)}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/conv2d_dw_q8ta_q8csw_q8to.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/conv2d_dw_q8ta_q8csw_q8to.glsl
@@ -8,6 +8,8 @@
 
 #version 450 core
 
+${define_required_extensions("buffer", DTYPE)}
+
 #define PRECISION ${PRECISION}
 #define VEC4_T ${texel_load_type(DTYPE, "buffer")}
 #define T ${texel_load_component_type(DTYPE, "buffer")}
@@ -20,8 +22,6 @@ $if WEIGHT_STORAGE == "buffer":
 
 #define MAX_WINDOW_WIDTH 12
 #define MAX_KERNEL_WIDTH 5
-
-${define_required_extensions(DTYPE)}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/conv2d_pw_q8ta_q8csw_q8to_tiled.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/conv2d_pw_q8ta_q8csw_q8to_tiled.glsl
@@ -8,6 +8,8 @@
 
 #version 450 core
 
+${define_required_extensions("buffer", DTYPE)}
+
 #define PRECISION ${PRECISION}
 #define VEC4_T ${texel_load_type(DTYPE, "buffer")}
 #define T ${texel_load_component_type(DTYPE, "buffer")}
@@ -28,8 +30,6 @@ $if WEIGHT_STORAGE == "buffer":
 #define TILE_M 4
 #define TILE_K 4
 #define TILE_N 8
-
-${define_required_extensions(DTYPE)}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/conv2d_q8csw_linear_tiled.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/conv2d_q8csw_linear_tiled.glsl
@@ -8,6 +8,8 @@
 
 #version 450 core
 
+${define_required_extensions(OUTPUT_STORAGE, DTYPE)}
+
 #define PRECISION ${PRECISION}
 #define VEC4_T ${texel_load_type(DTYPE, OUTPUT_STORAGE)}
 #define T ${texel_load_component_type(DTYPE, OUTPUT_STORAGE)}
@@ -26,8 +28,6 @@ $if WEIGHT_STORAGE == "buffer":
 #define TILE_M ${TILE_M4 * 4}
 #define TILE_K ${TILE_K4 * 4}
 #define TILE_N ${TILE_N4 * 4}
-
-${define_required_extensions(DTYPE)}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/conv2d_q8ta_q8csw_linear_tiled.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/conv2d_q8ta_q8csw_linear_tiled.glsl
@@ -8,6 +8,8 @@
 
 #version 450 core
 
+${define_required_extensions(OUTPUT_STORAGE, DTYPE)}
+
 #define PRECISION ${PRECISION}
 #define VEC4_T ${texel_load_type(DTYPE, OUTPUT_STORAGE)}
 #define T ${texel_load_component_type(DTYPE, OUTPUT_STORAGE)}
@@ -26,8 +28,6 @@ $if WEIGHT_STORAGE == "buffer":
 #define TILE_M ${TILE_M4 * 4}
 #define TILE_K ${TILE_K4 * 4}
 #define TILE_N ${TILE_N4 * 4}
-
-${define_required_extensions(DTYPE)}
 
 #extension GL_EXT_integer_dot_product : require
 

--- a/backends/vulkan/runtime/graph/ops/glsl/conv2d_q8ta_q8csw_q8to.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/conv2d_q8ta_q8csw_q8to.glsl
@@ -8,6 +8,8 @@
 
 #version 450 core
 
+${define_required_extensions("buffer", DTYPE)}
+
 #define PRECISION ${PRECISION}
 #define VEC4_T ${texel_load_type(DTYPE, "buffer")}
 #define T ${texel_load_component_type(DTYPE, "buffer")}
@@ -30,8 +32,6 @@ $if WEIGHT_STORAGE == "buffer":
 #define TILE_M 4
 #define TILE_K 4
 #define TILE_N 4
-
-${define_required_extensions(DTYPE)}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/conv2d_q8ta_q8csw_q8to_linear_tiled.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/conv2d_q8ta_q8csw_q8to_linear_tiled.glsl
@@ -8,6 +8,8 @@
 
 #version 450 core
 
+${define_required_extensions("buffer", DTYPE)}
+
 #define PRECISION ${PRECISION}
 #define VEC4_T ${texel_load_type(DTYPE, "buffer")}
 #define T ${texel_load_component_type(DTYPE, "buffer")}
@@ -28,8 +30,6 @@ $if WEIGHT_STORAGE == "buffer":
 #define TILE_M 4
 #define TILE_K 4
 #define TILE_N 8
-
-${define_required_extensions(DTYPE)}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/embedding_buffer.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/embedding_buffer.glsl
@@ -8,12 +8,13 @@
 
 #version 450 core
 
+${define_required_extensions("buffer", DTYPE)}
+
 #define PRECISION ${PRECISION}
 
 #define T ${buffer_scalar_type(DTYPE)}
 
 ${define_active_storage_type("buffer")}
-${define_required_extensions(DTYPE)}
 
 #extension GL_EXT_control_flow_attributes : require
 

--- a/backends/vulkan/runtime/graph/ops/glsl/embedding_texture.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/embedding_texture.glsl
@@ -8,13 +8,15 @@
 
 #version 450 core
 
+${define_required_extensions("texture3d", DTYPE)}
+${define_required_extensions("buffer", DTYPE)}
+
 #define PRECISION ${PRECISION}
 
 #define VEC4_T ${texel_load_type(DTYPE, "texture3d")}
 #define T ${texel_load_component_type(DTYPE, "texture3d")}
 
 ${define_active_storage_type("texture3d")}
-${define_required_extensions(DTYPE)}
 
 #extension GL_EXT_control_flow_attributes : require
 

--- a/backends/vulkan/runtime/graph/ops/glsl/expand_buffer.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/expand_buffer.glsl
@@ -8,12 +8,12 @@
 
 #version 450 core
 
+${define_required_extensions("buffer", DTYPE)}
+
 #define PRECISION ${PRECISION}
 
 #define VEC4_T ${texel_type(DTYPE)}
 #define T ${buffer_scalar_type(DTYPE)}
-
-${define_required_extensions(DTYPE)}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/gather_buffer.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/gather_buffer.glsl
@@ -8,12 +8,13 @@
 
 #version 450 core
 
+${define_required_extensions("buffer", DTYPE)}
+
 #define PRECISION ${PRECISION}
 
 #define T ${buffer_scalar_type(DTYPE)}
 
 ${define_active_storage_type("buffer")}
-${define_required_extensions(DTYPE)}
 
 #extension GL_EXT_control_flow_attributes : require
 

--- a/backends/vulkan/runtime/graph/ops/glsl/gather_texture.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/gather_texture.glsl
@@ -8,13 +8,14 @@
 
 #version 450 core
 
+${define_required_extensions("texture3d", DTYPE)}
+
 #define PRECISION ${PRECISION}
 
 #define VEC4_T ${texel_load_type(DTYPE, "texture3d")}
 #define T ${texel_load_component_type(DTYPE, "texture3d")}
 
 ${define_active_storage_type("texture3d")}
-${define_required_extensions(DTYPE)}
 
 #extension GL_EXT_control_flow_attributes : require
 

--- a/backends/vulkan/runtime/graph/ops/glsl/group_norm_reduce_texture.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/group_norm_reduce_texture.glsl
@@ -8,14 +8,14 @@
 
 #version 450 core
 
+${define_required_extensions("buffer", DTYPE)}
+
 #include "broadcasting_utils.h"
 #include "indexing_utils.h"
 
 #define PRECISION ${PRECISION}
 
 #define BUF_T ${buffer_scalar_type(DTYPE)}
-
-${define_required_extensions(DTYPE)}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/group_norm_texture.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/group_norm_texture.glsl
@@ -8,12 +8,13 @@
 
 #version 450 core
 
+${define_required_extensions("texture3d", DTYPE)}
+${define_required_extensions("buffer", DTYPE)}
+
 #include "broadcasting_utils.h"
 #include "indexing_utils.h"
 
 #define PRECISION ${PRECISION}
-
-${define_required_extensions(DTYPE)}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/im2col.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/im2col.glsl
@@ -8,6 +8,8 @@
 
 #version 450 core
 
+${define_required_extensions(INPUT_STORAGE, DTYPE)}
+
 #define PRECISION ${PRECISION}
 #define VEC4_T ${texel_load_type(DTYPE, INPUT_STORAGE)}
 #define T ${texel_load_component_type(DTYPE, INPUT_STORAGE)}
@@ -24,8 +26,6 @@ $if INPUT_STORAGE == "buffer":
 #define TILE_M 4
 #define TILE_N 4
 #define TILE_K 4
-
-${define_required_extensions(DTYPE)}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/image_to_nchw.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/image_to_nchw.glsl
@@ -8,15 +8,16 @@
 
 #version 450 core
 
+${define_required_extensions(STORAGE, DTYPE)}
+${define_required_extensions("buffer", BUF_DTYPE)}
+${define_explicit_type_extensions(DTYPE)}
+
 #define PRECISION ${PRECISION}
 
 #define BUF_T ${buffer_scalar_type(DTYPE)}
 #define VEC4_T ${texel_load_type(DTYPE, STORAGE)}
 
 ${define_active_storage_type(STORAGE)}
-
-${define_required_extensions(DTYPE)}
-${define_required_extensions(BUF_DTYPE)}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/linear_dq8ca_q4gsw_tiled.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/linear_dq8ca_q4gsw_tiled.glsl
@@ -8,6 +8,13 @@
 
 #version 450 core
 
+// For input/output tensors
+${define_required_extensions(IO_STORAGE, DTYPE)}
+// For int8 input scales/zps
+${define_required_extensions("texture3d", "int8")}
+// For weight scales and bias
+${define_required_extensions("buffer", DTYPE)}
+
 #define PRECISION ${PRECISION}
 #define VEC4_T ${texel_load_type(DTYPE, IO_STORAGE)}
 #define T ${texel_load_component_type(DTYPE, IO_STORAGE)}
@@ -29,9 +36,6 @@ $if WEIGHT_STORAGE == "buffer":
 #define TILE_M ${TILE_M4 * 4}
 #define TILE_K ${TILE_K4 * 4}
 #define TILE_N ${TILE_N8 * 8}
-
-${define_required_extensions(DTYPE)}
-${define_required_extensions("int8")}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/linear_q4gsw_coop.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/linear_q4gsw_coop.glsl
@@ -8,6 +8,9 @@
 
 #version 450 core
 
+${define_required_extensions(IO_STORAGE, DTYPE)}
+${define_required_extensions("buffer", DTYPE)}
+
 #define PRECISION ${PRECISION}
 #define VEC4_T ${texel_load_type(DTYPE, IO_STORAGE)}
 #define T ${texel_load_component_type(DTYPE, IO_STORAGE)}
@@ -28,8 +31,6 @@ $if WEIGHT_STORAGE == "buffer":
 #define TILE_N ${TILE_N8 * 8}
 
 #define WGS ${WGS}
-
-${define_required_extensions(DTYPE)}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/linear_q4gsw_tiled.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/linear_q4gsw_tiled.glsl
@@ -8,6 +8,9 @@
 
 #version 450 core
 
+${define_required_extensions(IO_STORAGE, DTYPE)}
+${define_required_extensions("buffer", DTYPE)}
+
 #define PRECISION ${PRECISION}
 #define VEC4_T ${texel_load_type(DTYPE, IO_STORAGE)}
 #define T ${texel_load_component_type(DTYPE, IO_STORAGE)}
@@ -27,8 +30,6 @@ $if WEIGHT_STORAGE == "buffer":
 #define TILE_M ${TILE_M4 * 4}
 #define TILE_K ${TILE_K4 * 4}
 #define TILE_N ${TILE_N8 * 8}
-
-${define_required_extensions(DTYPE)}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/linear_q8csw_tiled.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/linear_q8csw_tiled.glsl
@@ -8,6 +8,9 @@
 
 #version 450 core
 
+${define_required_extensions(IO_STORAGE, DTYPE)}
+${define_required_extensions("buffer", DTYPE)}
+
 #define PRECISION ${PRECISION}
 #define VEC4_T ${texel_load_type(DTYPE, IO_STORAGE)}
 #define T ${texel_load_component_type(DTYPE, IO_STORAGE)}
@@ -25,8 +28,6 @@ $if WEIGHT_STORAGE == "buffer":
 #define TILE_M ${TILE_M4 * 4}
 #define TILE_K ${TILE_K4 * 4}
 #define TILE_N ${TILE_N4 * 4}
-
-${define_required_extensions(DTYPE)}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/linear_q8ta_q8csw_tiled.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/linear_q8ta_q8csw_tiled.glsl
@@ -8,6 +8,8 @@
 
 #version 450 core
 
+${define_required_extensions(OUTPUT_STORAGE, DTYPE)}
+
 #define PRECISION ${PRECISION}
 #define VEC4_T ${texel_load_type(DTYPE, OUTPUT_STORAGE)}
 #define T int
@@ -26,8 +28,6 @@ $if WEIGHT_STORAGE == "buffer":
 #define TILE_M ${TILE_M4 * 4}
 #define TILE_K ${TILE_K4 * 4}
 #define TILE_N ${TILE_N4 * 4}
-
-${define_required_extensions(DTYPE)}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/linear_qcsnw.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/linear_qcsnw.glsl
@@ -8,16 +8,16 @@
 
 #version 450 core
 
+${define_required_extensions(STORAGE, DTYPE)}
+$if STORAGE == "buffer":
+  ${define_required_extensions("buffer", "int8")}
+
 #define PRECISION ${PRECISION}
 
 #define VEC4_T ${texel_load_type(DTYPE, STORAGE)}
 #define FLOAT_T ${buffer_scalar_type(DTYPE)}
 
 ${define_active_storage_type(STORAGE)}
-
-${define_required_extensions(DTYPE)}
-$if STORAGE == "buffer":
-  ${define_required_extensions("int8")}
 
 #include "indexing_utils.h"
 

--- a/backends/vulkan/runtime/graph/ops/glsl/linear_qcsnw_coop.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/linear_qcsnw_coop.glsl
@@ -8,6 +8,11 @@
 
 #version 450 core
 
+${define_required_extensions(OUT_STORAGE, DTYPE)}
+
+$if WEIGHT_STORAGE == "buffer":
+  ${define_required_extensions("buffer", "int8")}
+
 #define PRECISION ${PRECISION}
 
 #define T ${buffer_scalar_type(DTYPE)}
@@ -18,11 +23,6 @@
 
 #define NGROUPS 8
 #define NWORKERS 8
-
-${define_required_extensions(DTYPE)}
-
-$if WEIGHT_STORAGE == "buffer":
-  ${define_required_extensions("int8")}
 
 #extension GL_EXT_control_flow_attributes : require
 

--- a/backends/vulkan/runtime/graph/ops/glsl/linear_qcsnw_tiled.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/linear_qcsnw_tiled.glsl
@@ -8,6 +8,8 @@
 
 #version 450 core
 
+${define_required_extensions(OUT_STORAGE, DTYPE)}
+
 #define PRECISION ${PRECISION}
 
 #define T ${buffer_scalar_type(DTYPE)}
@@ -15,8 +17,6 @@
 
 #define TILE_ROWS ${TILE_ROWS}
 #define TILE_TXCOLS ${TILE_TXCOLS}
-
-${define_required_extensions(DTYPE)}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/nchw_to_buffer.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/nchw_to_buffer.glsl
@@ -1,11 +1,11 @@
 #version 450 core
 
+${define_required_extensions(STORAGE, DTYPE)}
+${define_required_extensions("buffer", BUF_DTYPE)}
+
 #define PRECISION ${PRECISION}
 
 #define T ${buffer_scalar_type(DTYPE)}
-
-${define_required_extensions(DTYPE)}
-${define_required_extensions(BUF_DTYPE)}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/nchw_to_image.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/nchw_to_image.glsl
@@ -8,15 +8,15 @@
 
 #version 450 core
 
+${define_required_extensions(STORAGE, DTYPE)}
+${define_required_extensions("buffer", BUF_DTYPE)}
+
 #define PRECISION ${PRECISION}
 
 #define VEC4_T ${texel_load_type(DTYPE, STORAGE)}
 #define SCALAR_T ${texel_load_component_type(DTYPE, STORAGE)}
 
 ${define_active_storage_type(STORAGE)}
-
-${define_required_extensions(DTYPE)}
-${define_required_extensions(BUF_DTYPE)}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/no_op.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/no_op.glsl
@@ -8,9 +8,9 @@
 
 #version 450 core
 
-#define PRECISION ${PRECISION}
+${define_required_extensions(STORAGE, DTYPE)}
 
-${define_required_extensions(DTYPE)}
+#define PRECISION ${PRECISION}
 
 #include "broadcasting_utils.h"
 #include "indexing_utils.h"

--- a/backends/vulkan/runtime/graph/ops/glsl/pack_int4_linear_weight_transposed_interleaved.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/pack_int4_linear_weight_transposed_interleaved.glsl
@@ -8,10 +8,10 @@
 
 #version 450 core
 
-#define PRECISION ${PRECISION}
-
 $if not NO_INT8_BUFFERS:
-  ${define_required_extensions("uint8")}
+  ${define_required_extensions("buffer", "uint8")}
+
+#define PRECISION ${PRECISION}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/pack_q8_conv2d_weights.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/pack_q8_conv2d_weights.glsl
@@ -8,13 +8,13 @@
 
 #version 450 core
 
+${define_required_extensions("buffer", "int8")}
+
 #define PRECISION ${PRECISION}
 
 ${define_active_storage_type(STORAGE)}
 
 #extension GL_EXT_control_flow_attributes : require
-
-${define_required_extensions("int8")}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/permute_buffer.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/permute_buffer.glsl
@@ -8,13 +8,14 @@
 
 #version 450 core
 
+${define_required_extensions("buffer", DTYPE)}
+
 #define PRECISION ${PRECISION}
 
 #define VEC4_T ${texel_type(DTYPE)}
 #define T ${buffer_scalar_type(DTYPE)}
 
 ${define_active_storage_type("buffer")}
-${define_required_extensions(DTYPE)}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/permute_texture.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/permute_texture.glsl
@@ -8,13 +8,15 @@
 
 #version 450 core
 
+${define_required_extensions("texture3d", DTYPE)}
+${define_explicit_type_extensions(DTYPE)}
+
 #define PRECISION ${PRECISION}
 
 #define VEC4_T ${texel_type(DTYPE)}
 #define T ${buffer_scalar_type(DTYPE)}
 
 ${define_active_storage_type("texture3d")}
-${define_required_extensions(DTYPE)}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/quantize_and_pack_4h4w.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/quantize_and_pack_4h4w.glsl
@@ -8,6 +8,8 @@
 
 #version 450 core
 
+${define_required_extensions(INPUT_STORAGE, DTYPE)}
+
 #define PRECISION ${PRECISION}
 #define VEC4_T ${texel_load_type(DTYPE, INPUT_STORAGE)}
 #define T ${texel_load_component_type(DTYPE, INPUT_STORAGE)}
@@ -16,8 +18,6 @@ $if OUTPUT_STORAGE == "buffer":
   #define OUTPUT_BUFFER
 $if INPUT_STORAGE == "buffer":
   #define INPUT_BUFFER
-
-${define_required_extensions(DTYPE)}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/quantize_and_pack_4h4w_with_group_sums.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/quantize_and_pack_4h4w_with_group_sums.glsl
@@ -8,6 +8,9 @@
 
 #version 450 core
 
+${define_required_extensions(INPUT_STORAGE, DTYPE)}
+${define_required_extensions("texture3d", "int8")}
+
 #define PRECISION ${PRECISION}
 #define VEC4_T ${texel_load_type(DTYPE, INPUT_STORAGE)}
 #define T ${texel_load_component_type(DTYPE, INPUT_STORAGE)}
@@ -16,9 +19,6 @@ $if OUTPUT_STORAGE == "buffer":
   #define OUTPUT_BUFFER
 $if INPUT_STORAGE == "buffer":
   #define INPUT_BUFFER
-
-${define_required_extensions(DTYPE)}
-${define_required_extensions("int8")}
 
 #extension GL_EXT_integer_dot_product : require
 

--- a/backends/vulkan/runtime/graph/ops/glsl/quantize_and_pack_4w4c.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/quantize_and_pack_4w4c.glsl
@@ -8,6 +8,8 @@
 
 #version 450 core
 
+${define_required_extensions(INPUT_STORAGE, DTYPE)}
+
 #define PRECISION ${PRECISION}
 #define VEC4_T ${texel_load_type(DTYPE, INPUT_STORAGE)}
 #define T ${texel_load_component_type(DTYPE, INPUT_STORAGE)}
@@ -23,8 +25,6 @@ $if OUTPUT_STORAGE == "buffer":
   #define OUTPUT_BUFFER
 $if INPUT_STORAGE == "buffer":
   #define INPUT_BUFFER
-
-${define_required_extensions(DTYPE)}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/quantize_and_pack_im2col.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/quantize_and_pack_im2col.glsl
@@ -8,6 +8,8 @@
 
 #version 450 core
 
+${define_required_extensions(INPUT_STORAGE, DTYPE)}
+
 #define PRECISION ${PRECISION}
 #define VEC4_T ${texel_load_type(DTYPE, INPUT_STORAGE)}
 #define T ${texel_load_component_type(DTYPE, INPUT_STORAGE)}
@@ -24,8 +26,6 @@ $if INPUT_STORAGE == "buffer":
 #define TILE_M 4
 #define TILE_N 4
 #define TILE_K 4
-
-${define_required_extensions(DTYPE)}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/reduce_per_row_buffer.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/reduce_per_row_buffer.glsl
@@ -8,6 +8,8 @@
 
 #version 450 core
 
+${define_required_extensions("buffer", DTYPE)}
+
 #define PRECISION ${PRECISION}
 
 #define ACCUM_T ${accum_scalar_type(DTYPE)}
@@ -17,7 +19,6 @@
 #define NUM_WORKERS_PER_OUTPUT 64
 
 ${define_active_storage_type("buffer")}
-${define_required_extensions(DTYPE)}
 
 #extension GL_EXT_control_flow_attributes : require
 

--- a/backends/vulkan/runtime/graph/ops/glsl/repeat_interleave.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/repeat_interleave.glsl
@@ -8,11 +8,11 @@
 
 #version 450 core
 
+${define_required_extensions(STORAGE, DTYPE)}
+
 #define PRECISION ${PRECISION}
 
 #define VEC4_T ${texel_load_type(DTYPE, STORAGE)}
-
-${define_required_extensions(DTYPE)}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/rotary_embedding.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/rotary_embedding.glsl
@@ -8,11 +8,12 @@
 
 #version 450 core
 
+${define_required_extensions(STORAGE, DTYPE)}
+
 #define PRECISION ${PRECISION}
 
 #define VEC4_T ${texel_load_type(DTYPE, STORAGE)}
 
-${define_required_extensions(DTYPE)}
 ${define_active_storage_type(STORAGE)}
 
 layout(std430) buffer;

--- a/backends/vulkan/runtime/graph/ops/glsl/scalar_tensor.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/scalar_tensor.glsl
@@ -8,14 +8,15 @@
 
 #version 450 core
 
+${define_required_extensions(STORAGE, DTYPE)}
+${define_explicit_type_extensions(SCALAR_VALUE_TYPE)}
+
 #define PRECISION ${PRECISION}
 
 #define BUF_T ${buffer_scalar_type(DTYPE)}
 #define VEC4_T ${texel_type(DTYPE)}
 
 ${define_active_storage_type(STORAGE)}
-${define_required_extensions(DTYPE)}
-${define_required_extensions(SCALAR_VALUE_TYPE)}
 
 #include "indexing_utils.h"
 

--- a/backends/vulkan/runtime/graph/ops/glsl/sdpa_attn_weights_softmax.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/sdpa_attn_weights_softmax.glsl
@@ -16,7 +16,7 @@
 
 ${define_active_storage_type(STORAGE)}
 
-${define_required_extensions(DTYPE)}
+${define_required_extensions(STORAGE, DTYPE)}
 
 #extension GL_EXT_control_flow_attributes : require
 

--- a/backends/vulkan/runtime/graph/ops/glsl/sdpa_compute_attn_weights_coop.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/sdpa_compute_attn_weights_coop.glsl
@@ -27,7 +27,7 @@ $if K_CACHE_STORAGE == "buffer":
 
 #define NUM_WORKERS_PER_OUT 64
 
-${define_required_extensions(DTYPE)}
+${define_required_extensions(IO_STORAGE, DTYPE)}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/sdpa_compute_attn_weights_tiled.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/sdpa_compute_attn_weights_tiled.glsl
@@ -26,7 +26,7 @@ $if K_CACHE_STORAGE == "buffer":
 #define TILE_K ${TILE_K4 * 4}
 #define TILE_N ${TILE_N4 * 4}
 
-${define_required_extensions(DTYPE)}
+${define_required_extensions(IO_STORAGE, DTYPE)}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/sdpa_compute_out_coop.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/sdpa_compute_out_coop.glsl
@@ -27,7 +27,7 @@ $if V_CACHE_STORAGE == "buffer":
 
 #define NUM_WORKERS_PER_OUT 64
 
-${define_required_extensions(DTYPE)}
+${define_required_extensions(IO_STORAGE, DTYPE)}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/sdpa_compute_out_tiled.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/sdpa_compute_out_tiled.glsl
@@ -28,7 +28,7 @@ $if V_CACHE_STORAGE == "buffer":
 #define TILE_K ${TILE_K4 * 4}
 #define TILE_N ${TILE_N4 * 4}
 
-${define_required_extensions(DTYPE)}
+${define_required_extensions(IO_STORAGE, DTYPE)}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/sdpa_kv_cache_update.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/sdpa_kv_cache_update.glsl
@@ -10,7 +10,7 @@ $if OUTPUT_STORAGE == "buffer":
 $if INPUT_STORAGE == "buffer":
   #define INPUT_BUFFER
 
-${define_required_extensions(DTYPE)}
+${define_required_extensions(INPUT_STORAGE, DTYPE)}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/set_zero.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/set_zero.glsl
@@ -8,12 +8,13 @@
 
 #version 450 core
 
+${define_required_extensions("buffer", DTYPE)}
+
 #define PRECISION ${PRECISION}
 
 #define T ${buffer_scalar_type(DTYPE)}
 
 ${define_active_storage_type("buffer")}
-${define_required_extensions(DTYPE)}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/split_buffer.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/split_buffer.glsl
@@ -8,14 +8,14 @@
 
 #version 450 core
 
+${define_required_extensions("buffer", DTYPE)}
+#extension GL_EXT_control_flow_attributes : require
+
 #define PRECISION ${PRECISION}
 
 #define T ${buffer_scalar_type(DTYPE)}
 
 ${define_active_storage_type("buffer")}
-${define_required_extensions(DTYPE)}
-
-#extension GL_EXT_control_flow_attributes : require
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/split_texture.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/split_texture.glsl
@@ -8,15 +8,15 @@
 
 #version 450 core
 
+${define_required_extensions("texture3d", DTYPE)}
+#extension GL_EXT_control_flow_attributes : require
+
 #define PRECISION ${PRECISION}
 
 #define VEC4_T ${texel_load_type(DTYPE, "texture3d")}
 #define T ${texel_load_component_type(DTYPE, "texture3d")}
 
 ${define_active_storage_type("texture3d")}
-${define_required_extensions(DTYPE)}
-
-#extension GL_EXT_control_flow_attributes : require
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/tan.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/tan.glsl
@@ -8,6 +8,8 @@
 
 #version 450 core
 
+${define_required_extensions(STORAGE, DTYPE)}
+
 #define PRECISION ${PRECISION}
 
 #define VEC4_T ${texel_load_type(DTYPE, STORAGE)}
@@ -16,8 +18,6 @@
 ${define_active_storage_type(STORAGE)}
 
 #include "indexing_utils.h"
-
-${define_required_extensions(DTYPE)}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/transfer_buffer.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/transfer_buffer.glsl
@@ -8,15 +8,15 @@
 
 #version 450 core
 
+${define_required_extensions("buffer", DTYPE)}
+#extension GL_EXT_control_flow_attributes : require
+
 #define PRECISION ${PRECISION}
 #define UBO_PARAMS ${UBO_PARAMS}
 
 #define T ${buffer_scalar_type(DTYPE)}
 
 ${define_active_storage_type("buffer")}
-${define_required_extensions(DTYPE)}
-
-#extension GL_EXT_control_flow_attributes : require
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/transfer_texture.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/transfer_texture.glsl
@@ -8,6 +8,9 @@
 
 #version 450 core
 
+${define_required_extensions("texture3d", DTYPE)}
+#extension GL_EXT_control_flow_attributes : require
+
 #define PRECISION ${PRECISION}
 #define UBO_PARAMS ${UBO_PARAMS}
 
@@ -15,9 +18,6 @@
 #define T ${texel_load_component_type(DTYPE, "texture3d")}
 
 ${define_active_storage_type("texture3d")}
-${define_required_extensions(DTYPE)}
-
-#extension GL_EXT_control_flow_attributes : require
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/unary_op.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/unary_op.glsl
@@ -8,6 +8,8 @@
 
 #version 450 core
 
+${define_required_extensions(STORAGE, DTYPE)}
+
 #define PRECISION ${PRECISION}
 
 #define VEC4_T ${texel_load_type(DTYPE, STORAGE)}
@@ -18,8 +20,6 @@
 ${define_active_storage_type(STORAGE)}
 
 #include "indexing_utils.h"
-
-${define_required_extensions(DTYPE)}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/unpack_4w4c_and_dequantize.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/unpack_4w4c_and_dequantize.glsl
@@ -8,6 +8,8 @@
 
 #version 450 core
 
+${define_required_extensions(INPUT_STORAGE, DTYPE)}
+
 #define PRECISION ${PRECISION}
 #define VEC4_T ${texel_load_type(DTYPE, INPUT_STORAGE)}
 #define T ${texel_load_component_type(DTYPE, INPUT_STORAGE)}
@@ -23,8 +25,6 @@ $if OUTPUT_STORAGE == "buffer":
   #define OUTPUT_BUFFER
 $if INPUT_STORAGE == "buffer":
   #define INPUT_BUFFER
-
-${define_required_extensions(DTYPE)}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/update_concat_offset.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/update_concat_offset.glsl
@@ -8,12 +8,13 @@
 
 #version 450 core
 
+${define_required_extensions("buffer", DTYPE)}
+
 #define PRECISION ${PRECISION}
 
 #define T ${buffer_scalar_type(DTYPE)}
 
 ${define_active_storage_type("buffer")}
-${define_required_extensions(DTYPE)}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/var_buffer.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/var_buffer.glsl
@@ -8,10 +8,10 @@
 
 #version 450 core
 
+${define_required_extensions(STORAGE, DTYPE)}
+
 #define PRECISION ${PRECISION}
 #define T ${buffer_scalar_type(DTYPE)}
-
-${define_required_extensions(DTYPE)}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/view_buffer.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/view_buffer.glsl
@@ -4,7 +4,7 @@
 
 #define T ${buffer_scalar_type(DTYPE)}
 
-${define_required_extensions(DTYPE)}
+${define_required_extensions(STORAGE, DTYPE)}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/view_convert_buffer.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/view_convert_buffer.glsl
@@ -5,8 +5,8 @@
 #define IN_T ${buffer_scalar_type(IN_DTYPE)}
 #define OUT_T ${buffer_scalar_type(OUT_DTYPE)}
 
-${define_required_extensions(IN_DTYPE)}
-${define_required_extensions(OUT_DTYPE)}
+${define_required_extensions("buffer", IN_DTYPE)}
+${define_required_extensions("buffer", OUT_DTYPE)}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/where.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/where.glsl
@@ -11,6 +11,9 @@
 
 #version 450 core
 
+${define_required_extensions(STORAGE, DTYPE)}
+${define_required_extensions(STORAGE, "bool")}
+
 #define PRECISION ${PRECISION}
 
 #define VEC4_T ${texel_load_type(DTYPE, STORAGE)}
@@ -18,8 +21,6 @@
 #define COND_T ${buffer_scalar_type("bool")}
 
 ${define_active_storage_type(STORAGE)}
-${define_required_extensions(DTYPE)}
-${define_required_extensions("bool")}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/test/custom_ops/glsl/add_buffer.glsl
+++ b/backends/vulkan/test/custom_ops/glsl/add_buffer.glsl
@@ -14,7 +14,7 @@
 #define T ${buffer_scalar_type(DTYPE)}
 
 ${define_active_storage_type("buffer")}
-${define_required_extensions(DTYPE)}
+${define_required_extensions("buffer", DTYPE)}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/test/custom_ops/glsl/add_texture.glsl
+++ b/backends/vulkan/test/custom_ops/glsl/add_texture.glsl
@@ -13,7 +13,7 @@
 #define VEC4_T ${texel_type(DTYPE)}
 
 ${define_active_storage_type("texture3d")}
-${define_required_extensions(DTYPE)}
+${define_required_extensions("texture3d", DTYPE)}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/test/glsl/idx_fill_buffer.glsl
+++ b/backends/vulkan/test/glsl/idx_fill_buffer.glsl
@@ -8,13 +8,13 @@
 
 #version 450 core
 
+${define_required_extensions("buffer", DTYPE)}
+
 #define PRECISION ${PRECISION}
 
 #define T ${buffer_scalar_type(DTYPE)}
 
 #include "indexing_utils.h"
-
-${define_required_extensions(DTYPE)}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/test/glsl/scalar_add_buffer.glsl
+++ b/backends/vulkan/test/glsl/scalar_add_buffer.glsl
@@ -10,7 +10,7 @@
 
 #define PRECISION ${PRECISION}
 
-${define_required_extensions(DTYPE)}
+${define_required_extensions("buffer", DTYPE)}
 
 #define T ${buffer_scalar_type(DTYPE)}
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #16818
* #16817
* #16816
* #16815
* __->__ #16814

Update the `define_required_extensions` function in gen_vulkan_spv.py to
accept a `storage_type` argument as the first parameter. This allows the
function to generate appropriate GLSL extensions based on both the storage
type and data type, enabling more precise extension requirements for
different shader configurations.

Also add a new `define_explicit_type_extensions` helper function for cases
where only explicit arithmetic type extensions are needed without the
storage-related image format extensions.

Updated all 72 GLSL shader files across:
- runtime/graph/ops/glsl/ (67 files)
- test/glsl/ (2 files)
- test/custom_ops/glsl/ (2 files)

Fixed shaders that need extensions for multiple storage types:
- linear_q4gsw_coop.glsl, linear_q4gsw_tiled.glsl, linear_q8csw_tiled.glsl:
  Added buffer extensions for shaders using both texture and buffer storage
- image_to_nchw.glsl, permute_texture.glsl: Added explicit type extensions
- scalar_tensor.glsl: Use explicit type extensions for SCALAR_VALUE_TYPE

Differential Revision: [D91281385](https://our.internmc.facebook.com/intern/diff/D91281385/)