### PR TITLE
[ET-VK][ez] Add padded_numel_ member to vTensor for shader bounds checking

### DIFF
--- a/backends/vulkan/runtime/api/containers/Tensor.h
+++ b/backends/vulkan/runtime/api/containers/Tensor.h
@@ -331,6 +331,9 @@ class vTensor final {
   // number of elements based on the canonical sizes
   size_t numel_;
 
+  // number of elements based on the padded sizes (before packing)
+  size_t padded_numel_;
+
   // number of elements required for GPU buffer storage (with padding/packing)
   // This is pre-computed to avoid recomputing calculate_gpu_buffer_numel
   int64_t physical_numel_;
@@ -506,6 +509,10 @@ class vTensor final {
 
   inline size_t numel() const {
     return numel_;
+  }
+
+  inline size_t padded_numel() const {
+    return padded_numel_;
   }
 
   inline int64_t physical_numel() const {

--- a/backends/vulkan/runtime/graph/ComputeGraph.cpp
+++ b/backends/vulkan/runtime/graph/ComputeGraph.cpp
@@ -296,6 +296,14 @@ std::vector<int64_t> ComputeGraph::sizes_of(const ValueRef idx) const {
   VK_THROW("Could not get sizes of value with type ", val.type());
 }
 
+std::vector<int64_t> ComputeGraph::padded_sizes_of(const ValueRef idx) const {
+  const Value& val = values_.at(idx);
+  if (val.isTensor()) {
+    return val.toConstTensor().padded_sizes();
+  }
+  VK_THROW("Could not get padded sizes of value with type ", val.type());
+}
+
 int64_t ComputeGraph::dim_of(const ValueRef idx) const {
   const Value& val = values_.at(idx);
   if (val.isTensor()) {

--- a/backends/vulkan/runtime/graph/ComputeGraph.h
+++ b/backends/vulkan/runtime/graph/ComputeGraph.h
@@ -327,6 +327,8 @@ class ComputeGraph final {
 
   std::vector<int64_t> sizes_of(const ValueRef idx) const;
 
+  std::vector<int64_t> padded_sizes_of(const ValueRef idx) const;
+
   /*
    * Returns the size of the tensor at `idx` along the specified dimension.
    * Negative indexing is allowed.
@@ -355,7 +357,13 @@ class ComputeGraph final {
   }
 
   inline int32_t numel_of(const ValueRef idx) const {
-    return values_.at(idx).toConstTensor().numel();
+    return utils::safe_downcast<int32_t>(
+        values_.at(idx).toConstTensor().numel());
+  }
+
+  inline int32_t padded_numel_of(const ValueRef idx) const {
+    return utils::safe_downcast<int32_t>(
+        values_.at(idx).toConstTensor().padded_numel());
   }
 
   inline size_t staging_buffer_numel_of(const ValueRef idx) const {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #16818
* #16817
* #16816
* __->__ #16815
* #16814

Introduce a new padded_numel_ member to the vTensor class that stores the total number of elements based on padded sizes (before packing). This value is useful for bounds checking in shader code, as it represents the logical size of the padded tensor before any int8 packing is applied. The padded_numel_ is computed as utils::multiply_integers(padded_sizes_) and is maintained alongside numel_ (based on original sizes) and physical_numel_ (after packing). Also adds corresponding accessor functions padded_sizes_of() and padded_numel_of() to ComputeGraph for convenient access to these values from ValueRefs.

Differential Revision: [D91281383](https://our.internmc.facebook.com/intern/diff/D91281383/)