### PR TITLE
[ET-VK] Improve `PackedDimInfo` semantics

### DIFF
--- a/backends/vulkan/runtime/api/containers/Tensor.h
+++ b/backends/vulkan/runtime/api/containers/Tensor.h
@@ -22,39 +22,81 @@ namespace api {
 static constexpr size_t kTensorDimLimit = 8;
 
 /*
- * PackedDimInfo encapsulates metadata about packed dimensions in GPU tensors.
- * This includes information about which dimension is packed, whether it's
- * padded, and block packing information for special layouts like 4W4C and 4H4W.
+ * PackedDimInfo describes how tensor data is organized in physical memory.
+ * Specifically, it describes which dimensions are kept adjacent in memory, and
+ * which dimensions may be aligned to accomodate minimum load/store granularity
+ * of a selected storage type + memory layout combination.
+ *
+ * For non-quantized tensors that use GPU buffers, the tensor data is arranged
+ * as a linear array of data, and each data element can be loaded/stored
+ * individually. The PackedDimInfo describes which dimension of the tensor
+ * is kept contiguous in memory.
+ *
+ * For non-quantized tensors that use GPU textures, the tensor data is arranged
+ * as a 3D cube, where each "texel" in the cube contains 4 elements. The minimum
+ * load/store granularity is therefore 4 elements; the 4 elements in the texel
+ * will be adjacent elements along particular dimension specified by the
+ * PackedDimInfo.
+ *
+ * Quantized tensors will use the buffer storage type and the kInt8x4 dtype.
+ * Although the buffer storage type is used, the kInt8x4 dtype means that the
+ * minimum load/store granularity is still 1 texel int32 = 4x int8). Some
+ * memory layouts for quantized tensors will use block packing; this means that
+ * 4 adjacent texels loads a 4x4 square block of data composed of two dimensions
+ * rather than 16 elements from a single dimension.
+ *
+ * A generalization of all the above is to partition the tensor into a MxN block
+ * composed of 2 tensor dimensions. For non-quantized buffer tensors, the block
+ * size will be 1x1; for non-quantized texture tensors, the block size will be
+ * 4x1; for block-packed tensor layouts, the block size will be 4x4. For buffer
+ * backed tensors, the blocks are then arranged linearly in memory with the
+ * inner dimension of the block having the lowest stride and the outer dimension
+ * of the block having the next lowest stride.
+ *
+ * Note that all dimension indices contained in the struct use WHCN ordering
+ * (0 for width, 1 for height, 2 for channels, etc.) which is the ordering
+ * expected in GLSL compute shaders.
  */
 struct PackedDimInfo {
-  // Describes which dimension is "tightly packed" using WHCN index (i.e. 0 for
-  // width, 1 for height, etc.). For texture backed tensors, this describes
-  // which dimension is packed along a texel. For buffer backed tensors, this
-  // describes which dimension has a stride of 1 (i.e. is last in the dim
-  // order).
+  // Describes which dimension (WHCN index) is kept adjacent in physical memory.
+  // When doing a load/store for a texel/block, the first 4 elements of the data
+  // will be adjacent elements along the packed dimension.
   int32_t packed_dim;
-  // Describes if the packed dimension is padded to a multiple of 4. This will
-  // be true for all tensors that use texture storage, and will also be true
-  // for the PACKED_PADDED memory layouts.
-  bool packed_dim_padded;
-  // Describes a second level of packing, if applicable (which will only apply
-  // to the 4W4C and 4H4W layouts). If there is no second level of packing,
-  // then this will be equal to packed_dim. Otherwise, it will represent the
-  // outer dim used to construct block packing. For example, 4W4C will have
-  // packed_dim = 2 and outer_packed_dim = 0.
+  // The alignment size for the packed dimension. This value reflects the
+  // minimum load/store granularity of the storage type + memory layout config.
+  // In physical memory, the size of the packed dim is aligned to this size to
+  // ensure that data for the packed dim aligns with texel/block boundaries.
+  int32_t packed_dim_block_size;
+  // For block-packed layouts, represents the second tensor dimension that forms
+  // the "width" dimension of the MxN square that is kept contiguous in memory.
+  // For non block-packed layouts, represent the dimension with the next lowest
+  // stride after the contiguous/packed dim (i.e. second last in the dim order).
   int32_t outer_packed_dim;
-  // Whether the outer packed dim is padded to the next multiple of 4. This is
-  // true only for block-packed layouts.
-  bool outer_packed_dim_padded;
-  // True if this layout uses block packing (i.e., outer_packed_dim !=
-  // packed_dim). Block packing is used for layouts like 4W4C and 4H4W.
-  bool is_block_packed;
+  // The alignment size for the outer packed dimension. For non-block-packed
+  // layouts, this is 1 (no padding). For block-packed layouts like 4W4C and
+  // 4H4W, represents the "height" of the square block that is kept contiguous
+  // in memory.
+  int32_t outer_packed_dim_block_size;
+  // Typically the blocks of the tensor will be arranged such that the inner
+  // dim of the block (i.e. the packed dim) has the lowest stride, and the
+  // outer dim of the block (i.e. the outer packed dim) has the next lowest
+  // stride. However if this flag is set to true, then instead the outer packed
+  // dim will have the lowest stride, and the packed dim will have the next
+  // lowest stride.
+  bool block_transposed;
+  // The total number of elements in a packed block, computed as
+  // packed_dim_block_size * outer_packed_dim_block_size. For standard texture
+  // layouts, this is 4 (1 texel = 4 elements). For block-packed int8 layouts
+  // like 4W4C and 4H4W, this is 16 (4 elements along each of two dimensions).
+  // For contiguous buffer layouts, this is 1.
+  int32_t block_numel;
 
   PackedDimInfo(
-      int32_t dim,
-      bool dim_padded,
-      int32_t outer_dim,
-      bool outer_dim_padded);
+      const int32_t dim,
+      const int32_t dim_block_size,
+      const int32_t outer_dim,
+      const int32_t outer_dim_block_size,
+      const bool is_block_transposed);
 };
 
 struct LastAccess {
@@ -290,10 +332,10 @@ class vTensor final {
    * to construct a tensor.
    */
 
-  // Information about packed dimension padding and block packing
-  PackedDimInfo packed_dim_info_;
   // Whether the tensor has elements of type float, int, etc.
   vkapi::ScalarType dtype_;
+  // Information about packed dimension padding and block packing
+  PackedDimInfo packed_dim_info_;
   // sizes of the tensor in NCHW dimension order
   std::vector<int64_t> sizes_;
   // padded sizes of the tensor (pre-computed to avoid recalculation)

--- a/backends/vulkan/runtime/graph/ops/glsl/indexing.glslh
+++ b/backends/vulkan/runtime/graph/ops/glsl/indexing.glslh
@@ -27,11 +27,16 @@
  * to select optimized code paths suited for a particular memory layout.
  *
  * Currently the following information is packed into the layout integer:
- * - bits 0-15: first 4 elements of the dim order array
- *   - bits 0-3: dim_order[0]
- *   - bits 4-7: dim_order[1]
- *   - bits 8-11: dim_order[2]
- *   - bits 12-15: dim_order[3]
+ * - bits  0-15: layout_id: dim order (buffer) or axis_map (texture)
+ *   - bits  0- 3: dim_order[0] / axis_map[0]
+ *   - bits  4- 7: dim_order[1] / axis_map[1]
+ *   - bits  8-11: dim_order[2] / axis_map[2]
+ *   - bits 12-15: dim_order[3] / axis_map[3]
+ * - bits 16-31: packed_dim_info
+ *   - bits 16-19: packed_dim
+ *   - bits 20-23: outer_packed_dim
+ *   - bits 24-27: packed_dim_block_size
+ *   - bits 28-31: outer_packed_dim_block_size
  */
 
 // Extracts the 4-bit packed value at the given position (0..7) from a 32-bit
@@ -43,13 +48,13 @@ int extract_4b(const int packed, const int pos) {
 
 
 // Corresponds to dim_order[:4] = [0, 1, 2, 3]
-#define CONTIGUOUS_BUFFER_LAYOUT_ID 12816
+#define CONTIGUOUS_BUFFER_LAYOUT_ID 0x3210
 // Corresponds to dim_order[:4] = [2, 0, 1, 3]
-#define CHANNELS_LAST_BUFFER_LAYOUT_ID 12546
+#define CHANNELS_LAST_BUFFER_LAYOUT_ID 0x3102
 
 // Used as a default value for hashed layout ints, representing the most common
 // layout used for buffer-backed tensors (i.e. contiguous buffers)
-#define CONTIG_LAYOUT_INT 12816
+#define CONTIG_LAYOUT_INT 0x11103210
 
 int layout_id(const int hashed_layout) {
   // Extract the first 16 bits

--- a/backends/vulkan/runtime/utils/StorageUtils.cpp
+++ b/backends/vulkan/runtime/utils/StorageUtils.cpp
@@ -24,5 +24,9 @@ bool is_packed_int8_layout(const GPUMemoryLayout layout) {
   }
 }
 
+bool is_block_transposed_layout(const GPUMemoryLayout layout) {
+  return false;
+}
+
 } // namespace utils
 } // namespace vkcompute

--- a/backends/vulkan/runtime/utils/StorageUtils.h
+++ b/backends/vulkan/runtime/utils/StorageUtils.h
@@ -161,6 +161,82 @@ T to_packed_dim(const GPUMemoryLayout layout) {
   return 0;
 }
 
+template <typename T>
+T to_outer_packed_dim(const GPUMemoryLayout layout) {
+  switch (layout) {
+    case kWidthPacked:
+      return 1;
+    case kHeightPacked:
+      return 0;
+    case kChannelsPacked:
+      return 0;
+    case kPackedInt8_4W:
+      return 1;
+    case kPackedInt8_4C:
+      return 0;
+    case kPackedInt8_4H:
+      return 0;
+    case kPackedInt8_4W4C:
+      return 0;
+    case kPackedInt8_4H4W:
+      return 1;
+  };
+  // Should be unreachable
+  return 1;
+}
+
+template <typename T>
+T to_packed_dim_block_size(
+    const GPUMemoryLayout layout,
+    const StorageType storage) {
+  switch (layout) {
+    case kWidthPacked:
+      return storage == kBuffer ? 1 : 4;
+    case kHeightPacked:
+      return storage == kBuffer ? 1 : 4;
+    case kChannelsPacked:
+      return storage == kBuffer ? 1 : 4;
+    case kPackedInt8_4W:
+      return storage == kBuffer ? 4 : 16;
+    case kPackedInt8_4C:
+      return storage == kBuffer ? 4 : 16;
+    case kPackedInt8_4H:
+      return storage == kBuffer ? 4 : 16;
+    case kPackedInt8_4W4C:
+      return 4;
+    case kPackedInt8_4H4W:
+      return 4;
+  };
+  // Should be unreachable
+  return 1;
+}
+
+template <typename T>
+T to_outer_packed_dim_block_size(const GPUMemoryLayout layout) {
+  switch (layout) {
+    case kWidthPacked:
+      return 1;
+    case kHeightPacked:
+      return 1;
+    case kChannelsPacked:
+      return 1;
+    case kPackedInt8_4W:
+      return 1;
+    case kPackedInt8_4C:
+      return 1;
+    case kPackedInt8_4H:
+      return 1;
+    case kPackedInt8_4W4C:
+      return 4;
+    case kPackedInt8_4H4W:
+      return 4;
+  };
+  // Should be unreachable
+  return 1;
+}
+
+bool is_block_transposed_layout(const GPUMemoryLayout layout);
+
 bool is_packed_int8_layout(const GPUMemoryLayout layout);
 
 inline std::ostream& operator<<(

--- a/backends/vulkan/test/vulkan_compute_api_test.cpp
+++ b/backends/vulkan/test/vulkan_compute_api_test.cpp
@@ -62,6 +62,10 @@ std::vector<float> compute_reference_matmul(
 }
 
 std::vector<std::vector<int64_t>> standard_sizes_to_test = {
+    // 1D
+    {7},
+    {13},
+    {24},
     // 2D
     {7, 11},
     {13, 6},
@@ -114,25 +118,59 @@ TEST_F(VulkanComputeAPITest, print_shader_executable_properties) {
 
 std::vector<int64_t> get_reference_dim_order(
     const size_t ndim,
-    const int32_t packed_dim) {
+    const int32_t packed_dim,
+    const int32_t outer_packed_dim,
+    const bool block_transposed) {
   // Special case for zero dim tensors
   if (ndim == 0) {
     return {0};
   }
-  std::vector<int64_t> dim_order(ndim);
-  // Explicitly convert ndim to signed to prevent underflow
-  int64_t last_dim = int64_t(ndim) - 1 - packed_dim;
 
-  int64_t cur_dim = 0;
-  for (int d = 0; d < ndim; ++d) {
-    if (d == last_dim) {
-      cur_dim++;
-    }
-    dim_order[d] = cur_dim;
-    cur_dim++;
+  // Initialize dim_order as {0, 1, 2, ..., ndim-1}
+  std::vector<int64_t> dim_order(ndim);
+  for (size_t i = 0; i < ndim; ++i) {
+    dim_order[i] = static_cast<int64_t>(i);
   }
-  if (last_dim >= 0) {
-    dim_order[ndim - 1] = last_dim;
+
+  int64_t ndim_signed = static_cast<int64_t>(ndim);
+
+  // Convert WHCN indices to NCHW indices
+  // packed_dim and outer_packed_dim are in WHCN order (0=W, 1=H, 2=C, 3=N)
+  // NCHW index = ndim - 1 - WHCN index
+  int64_t last_dim_nchw = ndim_signed - 1 - packed_dim;
+  int64_t second_last_dim_nchw = ndim_signed - 1 - outer_packed_dim;
+  if (block_transposed) {
+    std::swap(last_dim_nchw, second_last_dim_nchw);
+  }
+
+  // Move last_dim_nchw to the back (if valid)
+  bool last_dim_valid = last_dim_nchw >= 0 && last_dim_nchw < ndim_signed;
+  if (last_dim_valid) {
+    auto it = std::find(dim_order.begin(), dim_order.end(), last_dim_nchw);
+    if (it != dim_order.end()) {
+      dim_order.erase(it);
+      dim_order.push_back(last_dim_nchw);
+    }
+  }
+
+  // Move second_last_dim_nchw to:
+  // a) second last position if last_dim_nchw is valid
+  // b) last position if last_dim_nchw was not valid
+  bool second_last_dim_valid =
+      second_last_dim_nchw >= 0 && second_last_dim_nchw < ndim_signed;
+  if (second_last_dim_valid) {
+    auto it =
+        std::find(dim_order.begin(), dim_order.end(), second_last_dim_nchw);
+    if (it != dim_order.end()) {
+      dim_order.erase(it);
+      if (last_dim_valid && ndim >= 2) {
+        // Insert at second last position
+        dim_order.insert(dim_order.end() - 1, second_last_dim_nchw);
+      } else {
+        // Insert at last position
+        dim_order.push_back(second_last_dim_nchw);
+      }
+    }
   }
 
   return dim_order;
@@ -141,9 +179,9 @@ std::vector<int64_t> get_reference_dim_order(
 std::vector<int64_t> get_reference_padded_sizes(
     const std::vector<int64_t>& sizes,
     const int32_t packed_dim,
-    const bool packed_dim_padded,
+    const int32_t packed_dim_block_size,
     const int32_t outer_packed_dim = -1,
-    const bool outer_packed_dim_padded = false) {
+    const int32_t outer_packed_dim_block_size = 1) {
   int64_t ndim = sizes.size();
   if (ndim == 0) {
     ndim = 1;
@@ -156,21 +194,23 @@ std::vector<int64_t> get_reference_padded_sizes(
     padded_sizes.at(i) = utils::val_at(i - ndim_up4, sizes);
   }
 
-  // Pad the packed dim to the next multiple of 4 if specified
-  if (packed_dim_padded) {
+  // Pad the packed dim to the next multiple of the block size if > 1
+  if (packed_dim_block_size > 1) {
     const int64_t dim_offset = packed_dim + 1;
     const int64_t padded_dim_size = utils::val_at(-dim_offset, sizes);
-    padded_sizes.at(ndim_up4 - dim_offset) = utils::align_up_4(padded_dim_size);
+    padded_sizes.at(ndim_up4 - dim_offset) = utils::align_up(
+        padded_dim_size, static_cast<int64_t>(packed_dim_block_size));
   }
 
-  // For block-packed layouts, also pad the outer packed dimension if specified
+  // For block-packed layouts, also pad the outer packed dimension if > 1
   if (outer_packed_dim >= 0 && outer_packed_dim != packed_dim &&
-      outer_packed_dim_padded) {
+      outer_packed_dim_block_size > 1) {
     const int64_t outer_dim_offset = outer_packed_dim + 1;
     const int64_t outer_padded_dim_size =
         utils::val_at(-outer_dim_offset, sizes);
-    padded_sizes.at(ndim_up4 - outer_dim_offset) =
-        utils::align_up_4(outer_padded_dim_size);
+    padded_sizes.at(ndim_up4 - outer_dim_offset) = utils::align_up(
+        outer_padded_dim_size,
+        static_cast<int64_t>(outer_packed_dim_block_size));
   }
 
   return padded_sizes;
@@ -386,24 +426,29 @@ TEST_F(VulkanComputeAPITest, tensor_layout_metadata_test) {
     int32_t packed_dim;
     int32_t outer_packed_dim;
     bool is_block_packed;
+    bool block_transposed;
   };
 
   std::vector<LayoutTestConfig> layout_configs = {
       // Standard layouts with float dtype
+      // For non-block-packed: outer_packed_dim = (packed_dim == 0) ? 1 : 0
       {utils::kWidthPacked,
        vkapi::kFloat,
        WHCN::kWidthDim,
-       WHCN::kWidthDim,
+       WHCN::kHeightDim,
+       false,
        false},
       {utils::kHeightPacked,
        vkapi::kFloat,
        WHCN::kHeightDim,
-       WHCN::kHeightDim,
+       WHCN::kWidthDim,
+       false,
        false},
       {utils::kChannelsPacked,
        vkapi::kFloat,
        WHCN::kChannelsDim,
-       WHCN::kChannelsDim,
+       WHCN::kWidthDim,
+       false,
        false},
 
       // Packed int8 vector layouts (single-dimension packed)
@@ -411,17 +456,14 @@ TEST_F(VulkanComputeAPITest, tensor_layout_metadata_test) {
       {utils::kPackedInt8_4W,
        vkapi::kChar,
        WHCN::kWidthDim,
-       WHCN::kWidthDim,
+       WHCN::kHeightDim,
+       false,
        false},
       {utils::kPackedInt8_4C,
        vkapi::kChar,
        WHCN::kChannelsDim,
-       WHCN::kChannelsDim,
-       false},
-      {utils::kPackedInt8_4H,
-       vkapi::kChar,
-       WHCN::kHeightDim,
-       WHCN::kHeightDim,
+       WHCN::kWidthDim,
+       false,
        false},
 
       // Packed int8 block layouts (two-dimension packed)
@@ -430,12 +472,14 @@ TEST_F(VulkanComputeAPITest, tensor_layout_metadata_test) {
        vkapi::kChar,
        WHCN::kChannelsDim,
        WHCN::kWidthDim,
-       true},
+       true,
+       false},
       {utils::kPackedInt8_4H4W,
        vkapi::kChar,
        WHCN::kWidthDim,
        WHCN::kHeightDim,
-       true},
+       true,
+       false},
   };
 
   std::vector<utils::StorageType> storage_types = {
@@ -478,39 +522,64 @@ TEST_F(VulkanComputeAPITest, tensor_layout_metadata_test) {
             << ", expected=" << static_cast<int>(expected_dtype)
             << ", got=" << static_cast<int>(tensor.dtype());
 
-        // Determine if packed_dim should be padded
-        // For packed int8 layouts (using kChar which converts to kInt8x4),
-        // always padded For texture storage, always padded For buffer storage
-        // with standard layouts, not padded
-        const bool expected_packed_dim_padded =
-            (config.dtype == vkapi::kChar) || (storage_type != utils::kBuffer);
+        // Determine packed_dim_block_size based on layout and storage type
+        // - kInt8 non-block-packed + texture: 16 (16 values per texel)
+        // - kInt8 non-block-packed + buffer: 4 (alignment)
+        // - kInt8 block-packed: 4 (4 values per dim per texel)
+        // - Standard texture: 4 (4 values per texel)
+        // - Contiguous buffer: 1 (no padding)
+        const bool is_non_block_packed_int8 =
+            config.dtype == vkapi::kChar && !config.is_block_packed;
+        int32_t expected_packed_dim_block_size;
+        if (is_non_block_packed_int8 && storage_type != utils::kBuffer) {
+          expected_packed_dim_block_size = 16;
+        } else if (config.dtype == vkapi::kChar) {
+          expected_packed_dim_block_size = 4;
+        } else if (storage_type != utils::kBuffer) {
+          expected_packed_dim_block_size = 4;
+        } else {
+          expected_packed_dim_block_size = 1;
+        }
 
         // For block-packed layouts, outer_packed_dim is also padded
-        const bool expected_outer_packed_dim_padded = config.is_block_packed;
+        const int32_t expected_outer_packed_dim_block_size =
+            config.is_block_packed ? 4 : 1;
+
+        // Expected block_numel is the product of the two block sizes
+        const int32_t expected_block_numel = expected_packed_dim_block_size *
+            expected_outer_packed_dim_block_size;
 
         // Verify packed_dim_info
         const auto& packed_dim_info = tensor.packed_dim_info();
         ASSERT_EQ(packed_dim_info.packed_dim, config.packed_dim)
             << "packed_dim mismatch for layout="
             << static_cast<int>(config.layout);
-        ASSERT_EQ(packed_dim_info.packed_dim_padded, expected_packed_dim_padded)
-            << "packed_dim_padded mismatch for layout="
+        ASSERT_EQ(
+            packed_dim_info.packed_dim_block_size,
+            expected_packed_dim_block_size)
+            << "packed_dim_block_size mismatch for layout="
             << static_cast<int>(config.layout);
         ASSERT_EQ(packed_dim_info.outer_packed_dim, config.outer_packed_dim)
             << "outer_packed_dim mismatch for layout="
             << static_cast<int>(config.layout);
         ASSERT_EQ(
-            packed_dim_info.outer_packed_dim_padded,
-            expected_outer_packed_dim_padded)
-            << "outer_packed_dim_padded mismatch for layout="
+            packed_dim_info.outer_packed_dim_block_size,
+            expected_outer_packed_dim_block_size)
+            << "outer_packed_dim_block_size mismatch for layout="
             << static_cast<int>(config.layout);
-        ASSERT_EQ(packed_dim_info.is_block_packed, config.is_block_packed)
-            << "is_block_packed mismatch for layout="
+        ASSERT_EQ(packed_dim_info.block_numel, expected_block_numel)
+            << "block_numel mismatch for layout="
+            << static_cast<int>(config.layout);
+        ASSERT_EQ(packed_dim_info.block_transposed, config.block_transposed)
+            << "block_transposed mismatch for layout="
             << static_cast<int>(config.layout);
 
         // Verify dim_order
-        std::vector<int64_t> ref_dim_order =
-            get_reference_dim_order(sizes.size(), config.packed_dim);
+        std::vector<int64_t> ref_dim_order = get_reference_dim_order(
+            sizes.size(),
+            config.packed_dim,
+            config.outer_packed_dim,
+            config.block_transposed);
         ASSERT_TRUE(tensor.dim_order() == ref_dim_order)
             << "Dim order mismatch for layout="
             << static_cast<int>(config.layout);
@@ -519,9 +588,9 @@ TEST_F(VulkanComputeAPITest, tensor_layout_metadata_test) {
         std::vector<int64_t> ref_padded_sizes = get_reference_padded_sizes(
             sizes,
             config.packed_dim,
-            expected_packed_dim_padded,
+            expected_packed_dim_block_size,
             config.outer_packed_dim,
-            expected_outer_packed_dim_padded);
+            expected_outer_packed_dim_block_size);
         ASSERT_TRUE(tensor.padded_sizes() == ref_padded_sizes)
             << "Padded sizes mismatch for layout="
             << static_cast<int>(config.layout);
@@ -598,6 +667,43 @@ TEST_F(VulkanComputeAPITest, tensor_layout_metadata_test_against_golden) {
   };
 
   std::vector<TestCase> test_cases = {
+      // 1D tensor [7] with width packed, float dtype
+      {/* sizes */ {7},
+       /* dtype */ vkapi::kFloat,
+       /* layout */ utils::kWidthPacked,
+       /* expected_dim_order */ {0},
+       /* expected_padded_sizes_buffer */ {1, 1, 1, 7},
+       /* expected_padded_sizes_texture */ {1, 1, 1, 8},
+       /* expected_strides_buffer */ {1},
+       /* expected_physical_numel_buffer */ 7,
+       /* expected_physical_numel_texture */ 8,
+       /* expected_image_extents */ {2, 1, 1}},
+
+      // 1D tensor [13] with width packed, float dtype
+      {/* sizes */ {13},
+       /* dtype */ vkapi::kFloat,
+       /* layout */ utils::kWidthPacked,
+       /* expected_dim_order */ {0},
+       /* expected_padded_sizes_buffer */ {1, 1, 1, 13},
+       /* expected_padded_sizes_texture */ {1, 1, 1, 16},
+       /* expected_strides_buffer */ {1},
+       /* expected_physical_numel_buffer */ 13,
+       /* expected_physical_numel_texture */ 16,
+       /* expected_image_extents */ {4, 1, 1}},
+
+      // 1D tensor [7] with channels packed, float dtype
+      // C dimension (implicit, size 1) is padded to 4
+      {/* sizes */ {7},
+       /* dtype */ vkapi::kFloat,
+       /* layout */ utils::kChannelsPacked,
+       /* expected_dim_order */ {0},
+       /* expected_padded_sizes_buffer */ {1, 1, 1, 7},
+       /* expected_padded_sizes_texture */ {1, 4, 1, 7},
+       /* expected_strides_buffer */ {1},
+       /* expected_physical_numel_buffer */ 7,
+       /* expected_physical_numel_texture */ 28,
+       /* expected_image_extents */ {7, 1, 1}},
+
       // 2D tensor [5, 7] with width packed, float dtype
       {/* sizes */ {5, 7},
        /* dtype */ vkapi::kFloat,
@@ -659,15 +765,16 @@ TEST_F(VulkanComputeAPITest, tensor_layout_metadata_test_against_golden) {
        /* expected_image_extents */ {4, 12, 2}},
 
       // 3D tensor [9, 13, 17] with packed int8 4C layout (odd sizes)
+      // For texture, packed_dim (channels) is padded to multiple of 16
       {/* sizes */ {9, 13, 17},
        /* dtype */ vkapi::kChar,
        /* layout */ utils::kPackedInt8_4C,
        /* expected_dim_order */ {1, 2, 0},
        /* expected_padded_sizes_buffer */ {1, 12, 13, 17},
-       /* expected_padded_sizes_texture */ {1, 12, 13, 17},
+       /* expected_padded_sizes_texture */ {1, 16, 13, 17},
        /* expected_strides_buffer */ {},
        /* expected_physical_numel_buffer */ 663,
-       /* expected_physical_numel_texture */ 663,
+       /* expected_physical_numel_texture */ 884,
        /* expected_image_extents */ {17, 13, 1}},
 
       // 3D tensor [9, 13, 17] with packed int8 4H4W block layout (odd sizes)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #16818
* #16817
* __->__ #16816
* #16815
* #16814

Refactor `PackedDimInfo` to use explicit block sizes instead of boolean flags.
This makes the packing semantics clearer and more flexible:

- Replace `packed_dim_padded` (bool) with `packed_dim_block_size` (int32_t)
- Replace `outer_packed_dim_padded` (bool) with `outer_packed_dim_block_size` (int32_t)
- Remove `is_block_packed` - now derived from `outer_packed_dim_block_size > 1`
- Add `block_numel` field (product of the two block sizes) for convenience
- Add `block_transposed` field to allow swapping the stride ordering of packed_dim
  and outer_packed_dim (outer_packed_dim gets lowest stride when true)
- Ensure `outer_packed_dim` is always distinct from `packed_dim`
- Add `operator<<` overload for printing `PackedDimInfo` via `std::cout`

The block size values now explicitly represent the alignment requirements:
- Contiguous buffer: block_size = 1 (no padding)
- Standard texture: block_size = 4 (4 values per texel)
- Int8 non-block-packed texture: packed_dim_block_size = 16
- Int8 block-packed texture: both block sizes = 4 (4x4 = 16 values)

Also adds helper functions `to_outer_packed_dim()`, `to_packed_dim_block_size()`,
`to_outer_packed_dim_block_size()`, and `is_block_transposed_layout()` to
StorageUtils.h, and updates `calculate_dim_order()` and `calculate_strides()` to
account for both packed dimensions and the block_transposed flag.

Differential Revision: [D91281386](https://our.internmc.facebook.com/intern/diff/D91281386/)