### PR TITLE
[ET-VK] Replace `kPackedInt8_4H` with `kPackedInt8_4C1W`

### DIFF
--- a/backends/vulkan/runtime/utils/StorageUtils.cpp
+++ b/backends/vulkan/runtime/utils/StorageUtils.cpp
@@ -15,9 +15,9 @@ bool is_packed_int8_layout(const GPUMemoryLayout layout) {
   switch (layout) {
     case kPackedInt8_4W:
     case kPackedInt8_4C:
-    case kPackedInt8_4H:
     case kPackedInt8_4W4C:
     case kPackedInt8_4H4W:
+    case kPackedInt8_4C1W:
       return true;
     default:
       return false;
@@ -25,7 +25,12 @@ bool is_packed_int8_layout(const GPUMemoryLayout layout) {
 }
 
 bool is_block_transposed_layout(const GPUMemoryLayout layout) {
-  return false;
+  switch (layout) {
+    case kPackedInt8_4C1W:
+      return true;
+    default:
+      return false;
+  }
 }
 
 } // namespace utils

--- a/backends/vulkan/runtime/utils/StorageUtils.h
+++ b/backends/vulkan/runtime/utils/StorageUtils.h
@@ -101,16 +101,18 @@ enum class GPUMemoryLayout : uint8_t {
    * 16 element block is loaded, rather than 4 elements along one dimension.
    */
 
-  // "vector" packed layouts - single level of packing (4 elements along packed
-  // dim per int32)
-  TENSOR_PACKED_INT8_4W = 5u,
-  TENSOR_PACKED_INT8_4C = 6u,
-  TENSOR_PACKED_INT8_4H = 7u,
-
   // Block packed layouts - two levels of packing (4x4 block composed of
   // elements from two packed dims per ivec4)
   TENSOR_PACKED_INT8_4W4C = 3u,
   TENSOR_PACKED_INT8_4H4W = 4u,
+
+  // "vector" packed layouts - single level of packing (4 elements along packed
+  // dim per int32)
+  TENSOR_PACKED_INT8_4W = 5u,
+  TENSOR_PACKED_INT8_4C = 6u,
+
+  // Block transposed layouts
+  TENSOR_PACKED_INT8_4C1W = 8u,
 };
 
 static constexpr GPUMemoryLayout kWidthPacked =
@@ -128,14 +130,14 @@ static constexpr GPUMemoryLayout kPackedInt8_4W =
 static constexpr GPUMemoryLayout kPackedInt8_4C =
     GPUMemoryLayout::TENSOR_PACKED_INT8_4C;
 
-static constexpr GPUMemoryLayout kPackedInt8_4H =
-    GPUMemoryLayout::TENSOR_PACKED_INT8_4H;
-
 static constexpr GPUMemoryLayout kPackedInt8_4W4C =
     GPUMemoryLayout::TENSOR_PACKED_INT8_4W4C;
 
 static constexpr GPUMemoryLayout kPackedInt8_4H4W =
     GPUMemoryLayout::TENSOR_PACKED_INT8_4H4W;
+
+static constexpr GPUMemoryLayout kPackedInt8_4C1W =
+    GPUMemoryLayout::TENSOR_PACKED_INT8_4C1W;
 
 template <typename T>
 T to_packed_dim(const GPUMemoryLayout layout) {
@@ -150,12 +152,12 @@ T to_packed_dim(const GPUMemoryLayout layout) {
       return 0;
     case kPackedInt8_4C:
       return 2;
-    case kPackedInt8_4H:
-      return 1;
     case kPackedInt8_4W4C:
       return 2;
     case kPackedInt8_4H4W:
       return 0;
+    case kPackedInt8_4C1W:
+      return 2;
   };
   // Should be unreachable
   return 0;
@@ -174,12 +176,12 @@ T to_outer_packed_dim(const GPUMemoryLayout layout) {
       return 1;
     case kPackedInt8_4C:
       return 0;
-    case kPackedInt8_4H:
-      return 0;
     case kPackedInt8_4W4C:
       return 0;
     case kPackedInt8_4H4W:
       return 1;
+    case kPackedInt8_4C1W:
+      return 0;
   };
   // Should be unreachable
   return 1;
@@ -200,12 +202,12 @@ T to_packed_dim_block_size(
       return storage == kBuffer ? 4 : 16;
     case kPackedInt8_4C:
       return storage == kBuffer ? 4 : 16;
-    case kPackedInt8_4H:
-      return storage == kBuffer ? 4 : 16;
     case kPackedInt8_4W4C:
       return 4;
     case kPackedInt8_4H4W:
       return 4;
+    case kPackedInt8_4C1W:
+      return storage == kBuffer ? 4 : 16;
   };
   // Should be unreachable
   return 1;
@@ -224,12 +226,12 @@ T to_outer_packed_dim_block_size(const GPUMemoryLayout layout) {
       return 1;
     case kPackedInt8_4C:
       return 1;
-    case kPackedInt8_4H:
-      return 1;
     case kPackedInt8_4W4C:
       return 4;
     case kPackedInt8_4H4W:
       return 4;
+    case kPackedInt8_4C1W:
+      return 1;
   };
   // Should be unreachable
   return 1;
@@ -275,14 +277,14 @@ inline std::ostream& operator<<(
     case kPackedInt8_4C:
       os << "TENSOR_PACKED_INT8_4C";
       break;
-    case kPackedInt8_4H:
-      os << "TENSOR_PACKED_INT8_4H";
-      break;
     case kPackedInt8_4W4C:
       os << "TENSOR_PACKED_INT8_4W4C";
       break;
     case kPackedInt8_4H4W:
       os << "TENSOR_PACKED_INT8_4H4W";
+      break;
+    case kPackedInt8_4C1W:
+      os << "TENSOR_PACKED_INT8_4C1W";
       break;
   }
   return os;

--- a/backends/vulkan/test/vulkan_compute_api_test.cpp
+++ b/backends/vulkan/test/vulkan_compute_api_test.cpp
@@ -480,6 +480,12 @@ TEST_F(VulkanComputeAPITest, tensor_layout_metadata_test) {
        WHCN::kHeightDim,
        true,
        false},
+      {utils::kPackedInt8_4C1W,
+       vkapi::kChar,
+       WHCN::kChannelsDim,
+       WHCN::kWidthDim,
+       false,
+       true},
   };
 
   std::vector<utils::StorageType> storage_types = {
@@ -788,6 +794,35 @@ TEST_F(VulkanComputeAPITest, tensor_layout_metadata_test_against_golden) {
        /* expected_physical_numel_buffer */ 720,
        /* expected_physical_numel_texture */ 720,
        /* expected_image_extents */ {5, 4, 9}},
+
+      // 3D tensor [9, 13, 17] with packed int8 4C1W block-transposed layout
+      // packed_dim = channels (2), outer_packed_dim = width (0)
+      // block_transposed = true, so dim_order swaps: [1, 0, 2] instead of
+      // [1, 2, 0] Channels padded to 12 (multiple of 4), width padded to 20
+      // (multiple of 4)
+      {/* sizes */ {9, 13, 17},
+       /* dtype */ vkapi::kChar,
+       /* layout */ utils::kPackedInt8_4C1W,
+       /* expected_dim_order */ {1, 0, 2},
+       /* expected_padded_sizes_buffer */ {1, 12, 13, 17},
+       /* expected_padded_sizes_texture */ {1, 16, 13, 17},
+       /* expected_strides_buffer */ {},
+       /* expected_physical_numel_buffer */ 663,
+       /* expected_physical_numel_texture */ 884,
+       /* expected_image_extents */ {17, 13, 1}},
+
+      // 4D tensor [2, 8, 12, 16] with packed int8 4C1W block-transposed layout
+      // Tests 4D case with block_transposed = true
+      {/* sizes */ {2, 8, 12, 16},
+       /* dtype */ vkapi::kChar,
+       /* layout */ utils::kPackedInt8_4C1W,
+       /* expected_dim_order */ {0, 2, 1, 3},
+       /* expected_padded_sizes_buffer */ {2, 8, 12, 16},
+       /* expected_padded_sizes_texture */ {2, 16, 12, 16},
+       /* expected_strides_buffer */ {},
+       /* expected_physical_numel_buffer */ 768,
+       /* expected_physical_numel_texture */ 1536,
+       /* expected_image_extents */ {16, 12, 2}},
   };
 
   for (size_t i = 0; i < test_cases.size(); ++i) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #16818
* __->__ #16817
* #16816
* #16815
* #16814

Replace the unused `kPackedInt8_4H` (height-packed int8) layout with
`kPackedInt8_4C1W`, a block-transposed layout where channels are packed
with width as the outer packed dimension. This layout uses the new
`block_transposed` flag in `PackedDimInfo` to indicate that the stride
ordering of packed_dim and outer_packed_dim should be swapped.

The new layout has:
- packed_dim = 2 (channels)
- outer_packed_dim = 0 (width)
- packed_dim_block_size = 4
- outer_packed_dim_block_size = 4
- block_transposed = true

Updated `estimate_memory_layout()` to use `block_transposed` flag to
distinguish between `kPackedInt8_4C` and `kPackedInt8_4C1W`.

Differential Revision: [D91281382](https://our.internmc.facebook.com/intern/diff/D91281382/)