### PR TITLE
Arm backend: Add partial 3d support for gather

### DIFF
--- a/backends/arm/_passes/canonicalize_gather_pass.py
+++ b/backends/arm/_passes/canonicalize_gather_pass.py
@@ -3,16 +3,12 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-
-import logging
 from typing import Set, Type
 
 import torch
 from executorch.backends.arm._passes import ArmPass
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass
-
-logger = logging.getLogger(__name__)
 
 
 class CanonicalizeGatherPass(ArmPass):
@@ -21,14 +17,24 @@ class CanonicalizeGatherPass(ArmPass):
 
     This pass is intended to run only for nodes already gated by GatherSupported.
 
-    Behavior:
-      - Reshape x from [N,K] to [N,K,1] so values matches TOSA gather's [N,K,C].
-      - Keep indices as [N,W]
-      - Lower using tosa.GATHER.default, producing [N,W,1].
-      - Reshape output to [N,W].
-      - Only insert bool<->int8 casts when x is bool:
+    Generic behavior:
+    - Only insert bool<->int8 casts when x is bool:
         * If x is bool: gather runs on int8 and output is cast back to bool.
         * If x is not bool: gather runs on original dtype and output keeps dtype.
+
+    2D behavior:
+    - Reshape x from [N,K] to [N,K,1] so values matches TOSA gather's [N,K,C].
+    - Reshape indices to [N,W].
+    - Lower using tosa.GATHER.default, producing [N,W,1].
+    - Reshape output to [N,W].
+
+    3D behavior:
+    - Permute and reshape x from [N,K,C] to [N*C,K,1].
+    - Permute and reshape indices from [N,W,C] to [N*C,W].
+    - Lower using tosa.GATHER.default, producing [N*C,W,1].
+    - Reshape and permute output to [N,W,C].
+    - Note that this decomposition requires the channel size of the indices to be the same as the channel
+    size of the input, which is not guaranteed in Pytorch. We reject nodes not fulfilling this when partitioning.
     """
 
     _passes_required_after: Set[Type[ExportPass]] = set()
@@ -45,15 +51,17 @@ class CanonicalizeGatherPass(ArmPass):
         # GatherSupported should have gated this already; treat violations as errors.
         x_shape = x.data.shape
         index_shape = index.data.shape
+        dim = dim % len(x_shape)
         if not (
-            dim in (1, -1)
-            and len(x_shape) == 2
-            and len(index_shape) == 2
+            dim in (1,)
+            and len(x_shape) in (2, 3)
+            and len(index_shape) in (2, 3)
             and index_shape[0] == x_shape[0]
         ):
             raise RuntimeError(
-                f"[{op}] Unexpected gather pattern; expected "
-                f"x:[N,K], index:[N,W], dim in {{1,-1}}, matching N. "
+                f"[{op}] Unexpected gather pattern; expected one of: "
+                f"x:[N,K], index:[N,W], dim in {{1,}}, matching N, "
+                f"x:[N,K,C], index:[N,W,C], dim in {{1,}}, matching N. "
                 f"Got dim={dim}, x.shape={x_shape}, index.shape={index_shape}."
             )
 
@@ -62,6 +70,7 @@ class CanonicalizeGatherPass(ArmPass):
 
         view_op = exir_ops.edge.aten.view_copy.default
         to_copy_op = exir_ops.edge.dim_order_ops._to_dim_order_copy.default
+        permute_copy_op = exir_ops.edge.aten.permute_copy.default
 
         # Use backend dialect gather:
         # values:  [N,K,C]
@@ -83,40 +92,111 @@ class CanonicalizeGatherPass(ArmPass):
             )
 
         # [N,K] -> [N,K,1]
-        values_3d = super().call_operator(
-            view_op,
-            (values_in, [N, K, 1]),
-            {},
-            meta,
-            updated=True,
-        )
+        if len(x_shape) < 3:
+            values_3d = super().call_operator(
+                view_op,
+                (values_in, [N, K, 1]),
+                {},
+                meta,
+                updated=True,
+            )
 
-        # indices stays [N,W]
-        gathered_3d = super().call_operator(
-            tosa_gather_op,
-            (values_3d, index),
-            {},
-            meta,
-            updated=True,
-        )
+            # indices stays [N,W]
+            gathered_3d = super().call_operator(
+                tosa_gather_op,
+                (values_3d, index),
+                {},
+                meta,
+                updated=True,
+            )
+        else:
+            # For 3D inputs we need to reshuffle both input and indices so that
+            # the payload is accessed from the batch rather than the channels
+            # since torch allows for accessing of different indices across channels
+            # while TOSA does not.
+            # 1. Permute input [N,K,C] to [N,C,K].
+            # 2. Rehsape input [N,K,C] to [N*C,K,1].
+            # 3. Permute indices [N,W,C] to [N,C,W].
+            # 4. Reshape indices [N,C,W] to [N*C,W].
+            # 5. Gather using tosa.GATHER with reshaped inputs and indices.
+            # 6. Reshape output [N*C,W,1] to [N,C,W].
+            # 7. Permute output [N,C,W] to [N,W,C].
 
-        # [N,W,1] -> [N,W]
-        gathered_2d = super().call_operator(
-            view_op,
-            (gathered_3d, [N, W]),
-            {},
-            meta,
-            updated=True,
-        )
+            # TODO if index input is a repeat across last dim with C repeats
+            # we can remove the repeat and directly lower to tosa.GATHER.
+            values_3d = values_in
+            N, K, C = x_shape
+            _, W, _ = index_shape
+            values_3d_permuted = super().call_operator(
+                permute_copy_op,
+                (values_3d, [0, 2, 1]),
+                {},
+                meta,
+                updated=True,
+            )  # [N,C,K]
+            values_3d_reshaped = super().call_operator(
+                view_op,
+                (values_3d_permuted, [N * C, K, 1]),
+                {},
+                meta,
+                updated=True,
+            )  # [N*C,K,1]
+            indices_permuted = super().call_operator(
+                permute_copy_op,
+                (index, [0, 2, 1]),
+                {},
+                meta,
+                updated=True,
+            )  # [N,L,W]
+            indices_reshaped = super().call_operator(
+                view_op,
+                (indices_permuted, [N * C, W]),
+                {},
+                meta,
+                updated=True,
+            )  # [N*L,W]
+            gathered = super().call_operator(
+                tosa_gather_op,
+                (values_3d_reshaped, indices_reshaped),
+                {},
+                meta,
+                updated=True,
+            )  # [N*L,W,1]
+            gathered_reshaped = super().call_operator(
+                view_op,
+                (gathered, [N, C, W]),
+                {},
+                meta,
+                updated=True,
+            )  # [N,L,W]
+            gathered_3d = super().call_operator(
+                permute_copy_op,
+                (gathered_reshaped, [0, 2, 1]),
+                {},
+                meta,
+                updated=True,
+            )  # [N,W,L]
+
+        if len(x_shape) == 2:
+            # [N,W,1] -> [N,W]
+            gathered = super().call_operator(
+                view_op,
+                (gathered_3d, [N, W]),
+                {},
+                meta,
+                updated=True,
+            )
+        else:
+            gathered = gathered_3d
 
         # int8 -> bool (only if needed)
         if needs_bool_cast:
             return super().call_operator(
                 to_copy_op,
-                (gathered_2d,),
+                (gathered,),
                 {"dtype": torch.bool},
                 meta,
                 updated=True,
             )
 
-        return gathered_2d
+        return gathered

--- a/backends/arm/test/ops/test_gather.py
+++ b/backends/arm/test/ops/test_gather.py
@@ -32,7 +32,7 @@ input_params = Tuple[torch.Tensor, int, torch.Tensor]
 
 # FP profile: only float inputs.
 test_data_fp: dict[str, input_params] = {
-    "test_fp32": (
+    "test_fp32_2d": (
         torch.tensor(
             [[0.1, 0.2, 0.3], [1.1, 1.2, 1.3], [2.1, 2.2, 2.3], [3.1, 3.2, 3.3]],
             dtype=torch.float32,
@@ -43,13 +43,32 @@ test_data_fp: dict[str, input_params] = {
             dtype=torch.int64,
         ),  # Shape: [N=4, W=2]
     ),
+    "test_fp32_3d": (
+        torch.tensor(
+            [
+                [[0.1, 0.2, 0.3], [1.1, 1.2, 1.3], [2.1, 2.2, 2.3]],
+                [[3.1, 3.2, 3.1], [4.1, 4.2, 4.3], [5.1, 5.2, 5.3]],
+                [[6.1, 6.2, 6.3], [7.1, 7.2, 7.3], [8.1, 8.2, 8.3]],
+            ],
+            dtype=torch.float32,
+        ),  # Shape: [N=3, K=3, C=3]
+        1,
+        torch.tensor(
+            [
+                [[0, 1, 2], [1, 2, 1], [2, 0, 1]],
+                [[1, 1, 2], [2, 2, 1], [0, 0, 1]],
+                [[2, 1, 2], [0, 2, 1], [1, 0, 1]],
+            ],
+            dtype=torch.int64,
+        ),  # Shape: [N=3, W=3, C=3]
+    ),
 }
 
 
 # INT profile: integer inputs + bool (bool is supported via casts in
 # CanonicalizeGatherPass: bool -> int8 -> bool).
 test_data_int: dict[str, input_params] = {
-    "test_int32": (
+    "test_int32_2d": (
         torch.tensor(
             [[1, 2, 3], [11, 12, 13], [21, 22, 23], [31, 32, 33]],
             dtype=torch.int32,
@@ -60,7 +79,7 @@ test_data_int: dict[str, input_params] = {
             dtype=torch.int64,
         ),  # Shape: [N=4, W=2]
     ),
-    "test_int8": (
+    "test_int8_2d": (
         torch.randint(5, size=(5, 10), dtype=torch.int8),  # Shape: [N=5, K=10]
         1,
         torch.tensor(
@@ -68,7 +87,7 @@ test_data_int: dict[str, input_params] = {
             dtype=torch.int64,
         ),  # Shape: [N=5, W=3]
     ),
-    "test_bool": (
+    "test_bool_2d": (
         torch.tensor(
             [
                 [True, False, True],


### PR DESCRIPTION
Add support for 3D gathers when input_size[-1] == index_size[-1]. In this case we can permute and reshape input [N,K,C] and index [N,W,C] to [N*C,K,1] and [N*C,W], apply a tosa.GATHER, and then reshape and permute back to [N,W,C].

cc @freddan80 @per @zingo @digantdesai