### PR TITLE
Arm backend: Add "normalized op name" -> "edge op name mapping"

### DIFF
--- a/backends/arm/scripts/collect_testname_resources.py
+++ b/backends/arm/scripts/collect_testname_resources.py
@@ -131,34 +131,19 @@ def _collect_arm_models(models_md: pathlib.Path) -> set[str]:
     return models
 
 
-def _collect_arm_ops() -> set[str]:
-    """
-    Returns a mapping from names on the form to be used in unittests to edge op:
-    1. Names are in lowercase.
-    2. Overload is ignored if 'default', otherwise it's appended with an underscore.
-    3. Overly verbose name are shortened by removing certain prefixes/suffixes.
+def _normalize_op_name(edge_name: str) -> str:
+    op, overload = edge_name.split(".")
 
-    Examples:
-        abs.default -> abs
-        split_copy.Tensor -> split_tensor
-    """
-    ops: set[str] = set()
-    for edge_name in _ALL_EDGE_OPS:
-        op, overload = edge_name.split(".")
+    op = op.lower()
+    op = op.removeprefix("_")
+    op = op.removesuffix("_copy")
+    op = op.removesuffix("_with_indices")
 
-        # Normalize names
-        op = op.lower()
-        op = op.removeprefix("_")
-        op = op.removesuffix("_copy")
-        op = op.removesuffix("_with_indices")
-        overload = overload.lower()
-
-        if overload == "default":
-            ops.add(op)
-        else:
-            ops.add(f"{op}_{overload}")
-
-    return ops
+    overload = overload.lower()
+    if overload == "default":
+        return op
+    else:
+        return f"{op}_{overload}"
 
 
 def _split_model_entry(entry: str) -> tuple[str, str | None, bool]:
@@ -189,7 +174,8 @@ def _camel_to_snake(name: str) -> str:
     return _CAMEL_BOUNDARY.sub("_", name).lower()
 
 
-OP_LIST = sorted(_collect_arm_ops())
+OP_NAME_MAP = {_normalize_op_name(edge_name): edge_name for edge_name in _ALL_EDGE_OPS}
+OP_LIST = sorted({_normalize_op_name(edge_name) for edge_name in _ALL_EDGE_OPS})
 PASS_LIST = sorted(
     _collect_arm_passes(pathlib.Path("backends/arm/_passes/__init__.py"))
 )


### PR DESCRIPTION
To produce exir operator test coverage reports for the Arm backend, it requires mapping from normalized op name to full edge op name. Add this to collect_testname_resources.py.


cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai