### PR TITLE
Arm backend: Fix tosa_spec issue in op_gather

### DIFF
--- a/backends/arm/operators/op_tosa_gather.py
+++ b/backends/arm/operators/op_tosa_gather.py
@@ -52,7 +52,7 @@ class GatherVisitor(NodeVisitor):
             self.target,
             [indices],
             [ts.DType.INT32],
-            output.tosa_spec,
+            self.tosa_spec,
         )
         validate_valid_dtype(
             self.target,
@@ -64,7 +64,7 @@ class GatherVisitor(NodeVisitor):
                 ts.DType.FP16,
                 ts.DType.FP32,
             ],
-            output.tosa_spec,
+            self.tosa_spec,
         )
 
         attr = ts.TosaSerializerAttribute()


### PR DESCRIPTION
A recent commit removed it from TosaArg, preferring instead to use the node_visitors self.tosa_spec.

cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai