### PR TITLE
Change runner to linux.24xlarge.memory in workflow

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -301,7 +301,7 @@ jobs:
         model: ["gemma3-4b"]  # llava gives segfault so not covering.
     with:
       secrets-env: EXECUTORCH_HF_TOKEN
-      runner: linux.24xlarge
+      runner: linux.24xlarge.memory
       docker-image: ci-image:executorch-ubuntu-22.04-clang12
       submodules: 'recursive'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}


### PR DESCRIPTION
Found this runner option in pytorch/test-infra. Let's see if it helps with the segfault similar to https://github.com/pytorch/executorch/actions/runs/21274414400/job/61231179223
