### PR TITLE
[ET-VK] Add float16 to float32 fallback for devices without 16-bit buffer support

### DIFF
--- a/backends/vulkan/runtime/api/containers/StagingBuffer.cpp
+++ b/backends/vulkan/runtime/api/containers/StagingBuffer.cpp
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/vulkan/runtime/api/containers/StagingBuffer.h>
+
+namespace vkcompute {
+namespace api {
+
+namespace {
+
+// Convert IEEE 16-bit half to IEEE 32-bit float
+float half_to_float(uint16_t h) {
+  const uint32_t sign = (h >> 15) & 0x1;
+  const uint32_t exp = (h >> 10) & 0x1F;
+  const uint32_t mant = h & 0x3FF;
+
+  uint32_t f;
+  if (exp == 0) {
+    if (mant == 0) {
+      // Signed zero
+      f = sign << 31;
+    } else {
+      // Subnormal half -> normalized float
+      uint32_t e = 0;
+      uint32_t m = mant;
+      while ((m & 0x400) == 0) {
+        m <<= 1;
+        e++;
+      }
+      f = (sign << 31) | ((127 - 15 - e) << 23) | ((m & 0x3FF) << 13);
+    }
+  } else if (exp == 31) {
+    // Inf or NaN
+    f = (sign << 31) | 0x7F800000 | (mant << 13);
+  } else {
+    // Normalized
+    f = (sign << 31) | ((exp - 15 + 127) << 23) | (mant << 13);
+  }
+
+  float result;
+  memcpy(&result, &f, sizeof(float));
+  return result;
+}
+
+// Convert IEEE 32-bit float to IEEE 16-bit half
+int16_t float_to_half(float val) {
+  uint32_t f;
+  memcpy(&f, &val, sizeof(float));
+  const uint32_t sign = (f >> 31) & 0x1;
+  const int32_t exp = ((f >> 23) & 0xFF) - 127 + 15; // Rebias exponent
+  const uint32_t mant = f & 0x7FFFFF;
+
+  uint16_t h;
+  if ((f & 0x7FFFFFFF) == 0) {
+    // Signed zero
+    h = static_cast<uint16_t>(sign << 15);
+  } else if (exp <= 0) {
+    // Underflow to zero or subnormal
+    if (exp < -10) {
+      // Too small, flush to zero
+      h = static_cast<uint16_t>(sign << 15);
+    } else {
+      // Subnormal half
+      const uint32_t m = (mant | 0x800000) >> (1 - exp);
+      h = static_cast<uint16_t>((sign << 15) | (m >> 13));
+    }
+  } else if (exp >= 31) {
+    // Overflow to infinity, or preserve NaN
+    if (exp == 143 && mant != 0) {
+      // NaN - preserve some mantissa bits
+      h = static_cast<uint16_t>((sign << 15) | 0x7C00 | (mant >> 13));
+      // Ensure NaN mantissa is non-zero
+      if ((h & 0x03FF) == 0) {
+        h |= 0x0001;
+      }
+    } else {
+      // Infinity
+      h = static_cast<uint16_t>((sign << 15) | 0x7C00);
+    }
+  } else {
+    // Normalized
+    h = static_cast<uint16_t>((sign << 15) | (exp << 10) | (mant >> 13));
+  }
+
+  return static_cast<int16_t>(h);
+}
+
+} // namespace
+
+StagingBuffer::StagingBuffer(
+    Context* context_p,
+    const vkapi::ScalarType dtype,
+    const size_t numel,
+    const vkapi::CopyDirection direction)
+    : context_p_(context_p),
+      dtype_(get_staging_dtype(context_p, dtype)),
+      vulkan_buffer_(context_p_->adapter_ptr()->vma().create_staging_buffer(
+          element_size(dtype_) * numel,
+          direction)),
+      mapped_data_(nullptr) {}
+
+vkapi::ScalarType get_staging_dtype(
+    Context* context_p,
+    vkapi::ScalarType dtype) {
+  if (dtype == vkapi::kHalf &&
+      !context_p->adapter_ptr()->has_full_float16_buffers_support()) {
+    return vkapi::kFloat;
+  }
+  return dtype;
+}
+
+void StagingBuffer::cast_half_to_float_and_copy_from(
+    const int16_t* src,
+    const size_t numel) {
+  VK_CHECK_COND(numel <= this->numel());
+  float* dst = reinterpret_cast<float*>(data());
+  for (size_t i = 0; i < numel; ++i) {
+    dst[i] = half_to_float(static_cast<uint16_t>(src[i]));
+  }
+}
+
+void StagingBuffer::cast_float_to_half_and_copy_to(
+    int16_t* dst,
+    const size_t numel) {
+  VK_CHECK_COND(numel <= this->numel());
+  vmaInvalidateAllocation(
+      vulkan_buffer_.vma_allocator(),
+      vulkan_buffer_.allocation(),
+      0u,
+      VK_WHOLE_SIZE);
+  const float* src = reinterpret_cast<const float*>(data());
+  for (size_t i = 0; i < numel; ++i) {
+    dst[i] = float_to_half(src[i]);
+  }
+}
+
+} // namespace api
+} // namespace vkcompute

--- a/backends/vulkan/runtime/api/containers/StagingBuffer.h
+++ b/backends/vulkan/runtime/api/containers/StagingBuffer.h
@@ -19,6 +19,10 @@
 namespace vkcompute {
 namespace api {
 
+vkapi::ScalarType get_staging_dtype(
+    Context* context_p,
+    vkapi::ScalarType dtype);
+
 class StagingBuffer final {
  private:
   Context* context_p_;
@@ -32,13 +36,7 @@ class StagingBuffer final {
       Context* context_p,
       const vkapi::ScalarType dtype,
       const size_t numel,
-      const vkapi::CopyDirection direction)
-      : context_p_(context_p),
-        dtype_(dtype),
-        vulkan_buffer_(context_p_->adapter_ptr()->vma().create_staging_buffer(
-            element_size(dtype_) * numel,
-            direction)),
-        mapped_data_(nullptr) {}
+      const vkapi::CopyDirection direction);
 
   StagingBuffer(const StagingBuffer&) = delete;
   StagingBuffer& operator=(const StagingBuffer&) = delete;
@@ -91,6 +89,10 @@ class StagingBuffer final {
       dst[i] = static_cast<DST_T>(src[i]);
     }
   }
+
+  void cast_half_to_float_and_copy_from(const int16_t* src, const size_t numel);
+
+  void cast_float_to_half_and_copy_to(int16_t* dst, const size_t numel);
 
   inline void copy_to(void* dst, const size_t nbytes) {
     VK_CHECK_COND(nbytes <= this->nbytes());

--- a/backends/vulkan/runtime/graph/ComputeGraph.cpp
+++ b/backends/vulkan/runtime/graph/ComputeGraph.cpp
@@ -11,6 +11,8 @@
 
 #include <executorch/backends/vulkan/runtime/graph/ComputeGraph.h>
 
+#include <executorch/backends/vulkan/runtime/api/containers/StagingBuffer.h>
+
 #include <executorch/backends/vulkan/runtime/graph/ops/impl/Staging.h>
 
 #include <executorch/backends/vulkan/runtime/graph/ops/utils/StagingUtils.h>
@@ -348,6 +350,11 @@ vkapi::ScalarType ComputeGraph::dtype_of(const ValueRef idx) const {
     return vkapi::ScalarType::Int;
   }
   VK_THROW("Could not get dtype of value with type ", val.type());
+}
+
+vkapi::ScalarType ComputeGraph::get_staging_dtype_for(
+    const ValueRef idx) const {
+  return api::get_staging_dtype(context_.get(), dtype_of(idx));
 }
 
 bool ComputeGraph::is_contiguous_buffer_tensor(const ValueRef idx) const {
@@ -923,6 +930,10 @@ void ComputeGraph::maybe_cast_and_copy_into_staging(
         src_data_dtype == vkapi::kDouble && staging_dtype == vkapi::kFloat) {
       const double* casted_data = reinterpret_cast<const double*>(data);
       staging->cast_and_copy_from<double, float>(casted_data, numel);
+    } else if (
+        src_data_dtype == vkapi::kHalf && staging_dtype == vkapi::kFloat) {
+      const int16_t* casted_data = reinterpret_cast<const int16_t*>(data);
+      staging->cast_half_to_float_and_copy_from(casted_data, numel);
     } else {
       VK_THROW(
           "Unsupported type conversion from ",
@@ -962,6 +973,10 @@ void ComputeGraph::maybe_cast_and_copy_from_staging(
         dst_data_dtype == vkapi::kDouble && staging_dtype == vkapi::kFloat) {
       double* casted_data = reinterpret_cast<double*>(data);
       staging->cast_and_copy_to<float, double>(casted_data, numel);
+    } else if (
+        dst_data_dtype == vkapi::kHalf && staging_dtype == vkapi::kFloat) {
+      int16_t* casted_data = reinterpret_cast<int16_t*>(data);
+      staging->cast_float_to_half_and_copy_to(casted_data, numel);
     } else {
       VK_THROW(
           "Unsupported type conversion from staging dtype ",

--- a/backends/vulkan/runtime/graph/ComputeGraph.h
+++ b/backends/vulkan/runtime/graph/ComputeGraph.h
@@ -352,6 +352,8 @@ class ComputeGraph final {
 
   vkapi::ScalarType dtype_of(const ValueRef idx) const;
 
+  vkapi::ScalarType get_staging_dtype_for(const ValueRef idx) const;
+
   inline const utils::ivec3& logical_limits_of(const ValueRef idx) const {
     return values_.at(idx).toConstTensor().logical_limits();
   }
@@ -997,16 +999,18 @@ class ComputeGraph final {
   // Input/Output
   //
 
+ private:
   void
   copy_into_staging(const ValueRef idx, const void* data, const size_t numel);
 
+  void copy_from_staging(const ValueRef idx, void* data, const size_t numel);
+
+ public:
   void maybe_cast_and_copy_into_staging(
       const ValueRef idx,
       const void* data,
       const size_t numel,
       const vkapi::ScalarType src_data_dtype);
-
-  void copy_from_staging(const ValueRef idx, void* data, const size_t numel);
 
   void maybe_cast_and_copy_from_staging(
       const ValueRef idx,
@@ -1108,6 +1112,10 @@ class ComputeGraph final {
 
   inline bool int16_shader_types_enabled() const {
     return context_->adapter_ptr()->supports_int16_shader_types();
+  }
+
+  inline bool float16_buffers_enabled() const {
+    return context_->adapter_ptr()->has_full_float16_buffers_support();
   }
 
   inline size_t execute_count() const {

--- a/backends/vulkan/runtime/graph/ops/PrepackNode.cpp
+++ b/backends/vulkan/runtime/graph/ops/PrepackNode.cpp
@@ -70,7 +70,35 @@ api::StagingBuffer PrepackNode::create_staging_buffer(ComputeGraph* graph) {
       vkapi::CopyDirection::HOST_TO_DEVICE);
   graph->update_staging_nbytes_in_cmd(staging.buffer().mem_size_as_size_t());
   size_t nbytes = numel * vkapi::element_size(tref->dtype);
-  staging.copy_from(tref->data, nbytes);
+
+  // In some cases the staging dtype will diverge from the TensorRef dtype. The
+  // most common case for this is when the tensor data is float16, but the GPU
+  // does not support 16-bit storage buffers. In these cases, the tensor data
+  // is manually casted to the staging dtype.
+  vkapi::ScalarType staging_dtype = staging.dtype();
+  vkapi::ScalarType tref_dtype = tref->dtype;
+  if (staging_dtype == tref_dtype) {
+    staging.copy_from(tref->data, nbytes);
+  } else {
+    // Hard-coded type conversion cases
+    if (tref_dtype == vkapi::kHalf && staging_dtype == vkapi::kFloat) {
+      const int16_t* casted_data = reinterpret_cast<const int16_t*>(tref->data);
+      staging.cast_half_to_float_and_copy_from(casted_data, numel);
+    } else if (tref_dtype == vkapi::kLong && staging_dtype == vkapi::kInt) {
+      const int64_t* casted_data = reinterpret_cast<const int64_t*>(tref->data);
+      staging.cast_and_copy_from<int64_t, int32_t>(casted_data, numel);
+    } else if (tref_dtype == vkapi::kDouble && staging_dtype == vkapi::kFloat) {
+      const double* casted_data = reinterpret_cast<const double*>(tref->data);
+      staging.cast_and_copy_from<double, float>(casted_data, numel);
+    } else {
+      VK_THROW(
+          "Unsupported type conversion from ",
+          tref_dtype,
+          " to staging dtype ",
+          staging_dtype);
+    }
+  }
+
   // Once the staging buffer is copied, if the TensorRef owns a FreeableBuffer,
   // it can be freed.
   tref->free_buffer();

--- a/backends/vulkan/runtime/graph/ops/glsl/conv2d_dw_prepack_weights.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/conv2d_dw_prepack_weights.glsl
@@ -8,16 +8,16 @@
 
 #version 450 core
 
+${define_required_extensions("texture3d", DTYPE)}
+${define_required_extensions("buffer", BUF_DTYPE)}
+
 #define PRECISION ${PRECISION}
 
-#define BUF_T ${buffer_scalar_type(DTYPE)}
+#define BUF_T ${buffer_scalar_type(BUF_DTYPE)}
 #define VEC4_T ${texel_type(DTYPE)}
 #define SCALAR_T ${texel_component_type(DTYPE)}
 
 #include "indexing_utils.h"
-
-$if DTYPE == "half":
-  #extension GL_EXT_shader_16bit_storage : require
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/conv2d_dw_prepack_weights.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/conv2d_dw_prepack_weights.yaml
@@ -7,9 +7,13 @@
 conv2d_dw_prepack_weights:
   parameter_names_with_default_values:
     DTYPE: float
+    BUF_DTYPE: float
   generate_variant_forall:
-    DTYPE:
-      - VALUE: half
-      - VALUE: float
+    combination:
+      parameter_names: [DTYPE, BUF_DTYPE]
+      combos:
+        - parameter_values: [float, float]
+        - parameter_values: [half, float]
+        - parameter_values: [half, half]
   shader_variants:
     - NAME: conv2d_dw_prepack_weights

--- a/backends/vulkan/runtime/graph/ops/glsl/conv2d_prepack_weights.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/conv2d_prepack_weights.glsl
@@ -8,16 +8,16 @@
 
 #version 450 core
 
+${define_required_extensions("texture3d", DTYPE)}
+${define_required_extensions("buffer", BUF_DTYPE)}
+
 #define PRECISION ${PRECISION}
 
-#define BUF_T ${buffer_scalar_type(DTYPE)}
+#define BUF_T ${buffer_scalar_type(BUF_DTYPE)}
 #define VEC4_T ${texel_type(DTYPE)}
 #define SCALAR_T ${texel_component_type(DTYPE)}
 
 #include "indexing_utils.h"
-
-$if DTYPE == "half":
-  #extension GL_EXT_shader_16bit_storage : require
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/conv2d_prepack_weights.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/conv2d_prepack_weights.yaml
@@ -7,9 +7,13 @@
 conv2d_prepack_weights:
   parameter_names_with_default_values:
     DTYPE: float
+    BUF_DTYPE: float
   generate_variant_forall:
-    DTYPE:
-      - VALUE: half
-      - VALUE: float
+    combination:
+      parameter_names: [DTYPE, BUF_DTYPE]
+      combos:
+        - parameter_values: [float, float]
+        - parameter_values: [half, float]
+        - parameter_values: [half, half]
   shader_variants:
     - NAME: conv2d_prepack_weights

--- a/backends/vulkan/runtime/graph/ops/glsl/conv_transpose2d_prepack_weights.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/conv_transpose2d_prepack_weights.glsl
@@ -8,16 +8,16 @@
 
 #version 450 core
 
+${define_required_extensions("texture3d", DTYPE)}
+${define_required_extensions("buffer", BUF_DTYPE)}
+
 #define PRECISION ${PRECISION}
 
-#define BUF_T ${buffer_scalar_type(DTYPE)}
+#define BUF_T ${buffer_scalar_type(BUF_DTYPE)}
 #define VEC4_T ${texel_type(DTYPE)}
 #define SCALAR_T ${texel_component_type(DTYPE)}
 
 #include "indexing_utils.h"
-
-$if DTYPE == "half":
-  #extension GL_EXT_shader_16bit_storage : require
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/conv_transpose2d_prepack_weights.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/conv_transpose2d_prepack_weights.yaml
@@ -8,9 +8,13 @@ conv_transpose2d_prepack_weights:
   parameter_names_with_default_values:
     NDIM: 3
     DTYPE: float
+    BUF_DTYPE: float
   generate_variant_forall:
-    DTYPE:
-      - VALUE: half
-      - VALUE: float
+    combination:
+      parameter_names: [DTYPE, BUF_DTYPE]
+      combos:
+        - parameter_values: [float, float]
+        - parameter_values: [half, float]
+        - parameter_values: [half, half]
   shader_variants:
     - NAME: conv_transpose2d_prepack_weights

--- a/backends/vulkan/runtime/graph/ops/impl/Convolution.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Convolution.cpp
@@ -106,7 +106,7 @@ ValueRef prepack_biases(
       {out_channels}, graph.dtype_of(weight), storage_type, memory_layout);
 
   vkapi::ShaderInfo shader =
-      get_nchw_to_tensor_shader(graph, v, graph.dtype_of(weight));
+      get_nchw_to_tensor_shader(graph, v, graph.get_staging_dtype_for(weight));
 
   graph.prepack_nodes().emplace_back(new PrepackNode(
       graph,
@@ -170,6 +170,10 @@ vkapi::ShaderInfo get_conv2d_shader(
     kernel_name += "_clamp";
   }
   add_dtype_suffix(kernel_name, graph.dtype_of(out));
+
+  if (prepack_weights) {
+    add_dtype_suffix(kernel_name, graph.get_staging_dtype_for(weight));
+  }
 
   return VK_KERNEL_FROM_STR(kernel_name);
 }

--- a/backends/vulkan/runtime/graph/ops/impl/Staging.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Staging.cpp
@@ -148,7 +148,10 @@ void add_prepack_standard_node(
     const ValueRef tensor,
     const bool transpose_hw = false) {
   vkapi::ShaderInfo shader = get_nchw_to_tensor_shader(
-      graph, tensor, graph.dtype_of(tensor_data), graph.int8_buffers_enabled());
+      graph,
+      tensor,
+      graph.get_staging_dtype_for(tensor_data),
+      graph.int8_buffers_enabled());
 
   vkapi::ParamsBindList param_buffers = {};
   if (graph.is_buffer_storage(tensor)) {

--- a/backends/vulkan/test/custom_ops/utils.cpp
+++ b/backends/vulkan/test/custom_ops/utils.cpp
@@ -1175,7 +1175,8 @@ execute_test_case(TestCase& test_case, int warmup_runs, int benchmark_runs) {
       }
 
       // Copy data into staging buffer
-      graph.copy_into_staging(input_ref.staging, data_ptr, data_numel);
+      graph.maybe_cast_and_copy_into_staging(
+          input_ref.staging, data_ptr, data_numel, input_spec.dtype);
     }
   }
 
@@ -1242,7 +1243,8 @@ execute_test_case(TestCase& test_case, int warmup_runs, int benchmark_runs) {
 
       if (data_ptr != nullptr) {
         // Copy data from staging buffer to output spec
-        graph.copy_from_staging(output_ref.staging, data_ptr, data_numel);
+        graph.maybe_cast_and_copy_from_staging(
+            output_ref.staging, data_ptr, data_numel, output_spec.dtype);
       }
 
       // Print output tensor data if output printing is enabled

--- a/backends/vulkan/test/op_tests/quantize_affine_test.cpp
+++ b/backends/vulkan/test/op_tests/quantize_affine_test.cpp
@@ -493,26 +493,36 @@ void test_vulkan_quantize_affine_impl(
   graph.prepack();
 
   // Copy input data to GPU
-  graph.copy_into_staging(
-      r_input.staging, input.const_data_ptr(), input.numel());
+  graph.maybe_cast_and_copy_into_staging(
+      r_input.staging,
+      input.const_data_ptr(),
+      input.numel(),
+      from_at_scalartype(input.scalar_type()));
 
   // Copy scale tensor to GPU
-  graph.copy_into_staging(
-      r_scale.staging, scale_tensor.const_data_ptr(), scale_tensor.numel());
+  graph.maybe_cast_and_copy_into_staging(
+      r_scale.staging,
+      scale_tensor.const_data_ptr(),
+      scale_tensor.numel(),
+      from_at_scalartype(scale_tensor.scalar_type()));
 
   // Copy zero_point tensor to GPU
-  graph.copy_into_staging(
+  graph.maybe_cast_and_copy_into_staging(
       r_zero_point.staging,
       zero_point_tensor.const_data_ptr(),
-      zero_point_tensor.numel());
+      zero_point_tensor.numel(),
+      from_at_scalartype(zero_point_tensor.scalar_type()));
 
   // Execute the graph
   graph.execute();
 
   // Copy output data back to CPU
   at::Tensor vk_out = at::empty_like(reference_out).contiguous();
-  graph.copy_from_staging(
-      staging_out, vk_out.mutable_data_ptr(), vk_out.numel());
+  graph.maybe_cast_and_copy_from_staging(
+      staging_out,
+      vk_out.mutable_data_ptr(),
+      vk_out.numel(),
+      from_at_scalartype(vk_out.scalar_type()));
 
   // Compare outputs
   at::Tensor reference_int = reference_out.to(at::kInt);
@@ -790,26 +800,36 @@ void test_vulkan_dequantize_affine_impl(
   graph.prepack();
 
   // Copy input data to GPU
-  graph.copy_into_staging(
-      r_input.staging, input.const_data_ptr(), input.numel());
+  graph.maybe_cast_and_copy_into_staging(
+      r_input.staging,
+      input.const_data_ptr(),
+      input.numel(),
+      from_at_scalartype(input.scalar_type()));
 
   // Copy scale tensor to GPU
-  graph.copy_into_staging(
-      r_scale.staging, scale_tensor.const_data_ptr(), scale_tensor.numel());
+  graph.maybe_cast_and_copy_into_staging(
+      r_scale.staging,
+      scale_tensor.const_data_ptr(),
+      scale_tensor.numel(),
+      from_at_scalartype(scale_tensor.scalar_type()));
 
   // Copy zero_point tensor to GPU
-  graph.copy_into_staging(
+  graph.maybe_cast_and_copy_into_staging(
       r_zero_point.staging,
       zero_point_tensor.const_data_ptr(),
-      zero_point_tensor.numel());
+      zero_point_tensor.numel(),
+      from_at_scalartype(zero_point_tensor.scalar_type()));
 
   // Execute the graph
   graph.execute();
 
   // Copy output data back to CPU
   at::Tensor vk_out = at::empty_like(reference_out).contiguous();
-  graph.copy_from_staging(
-      staging_out, vk_out.mutable_data_ptr(), vk_out.numel());
+  graph.maybe_cast_and_copy_from_staging(
+      staging_out,
+      vk_out.mutable_data_ptr(),
+      vk_out.numel(),
+      from_at_scalartype(vk_out.scalar_type()));
 
   // Compare outputs
   const bool output_correct =
@@ -1079,8 +1099,11 @@ void test_vulkan_choose_qparams_affine_impl(
   graph.prepack();
 
   // Copy input data to GPU
-  graph.copy_into_staging(
-      r_input.staging, input.const_data_ptr(), input.numel());
+  graph.maybe_cast_and_copy_into_staging(
+      r_input.staging,
+      input.const_data_ptr(),
+      input.numel(),
+      from_at_scalartype(input.scalar_type()));
 
   // Execute the graph
   graph.execute();
@@ -1089,12 +1112,16 @@ void test_vulkan_choose_qparams_affine_impl(
   at::Tensor vk_scale = at::empty_like(reference_scale).contiguous();
   at::Tensor vk_zero_point = at::empty_like(reference_zero_point).contiguous();
 
-  graph.copy_from_staging(
-      staging_scale, vk_scale.mutable_data_ptr(), vk_scale.numel());
-  graph.copy_from_staging(
+  graph.maybe_cast_and_copy_from_staging(
+      staging_scale,
+      vk_scale.mutable_data_ptr(),
+      vk_scale.numel(),
+      from_at_scalartype(vk_scale.scalar_type()));
+  graph.maybe_cast_and_copy_from_staging(
       staging_zero_point,
       vk_zero_point.mutable_data_ptr(),
-      vk_zero_point.numel());
+      vk_zero_point.numel(),
+      from_at_scalartype(vk_zero_point.scalar_type()));
 
   // Compare outputs
   const bool scale_correct =

--- a/backends/vulkan/test/op_tests/quantized_linear_test.cpp
+++ b/backends/vulkan/test/op_tests/quantized_linear_test.cpp
@@ -189,13 +189,20 @@ void test_vulkan_linear_qcs4w_impl(
   //
 
   graph.propagate_resize();
-  graph.copy_into_staging(r_x.staging, x.const_data_ptr(), x.numel());
+  graph.maybe_cast_and_copy_into_staging(
+      r_x.staging,
+      x.const_data_ptr(),
+      x.numel(),
+      from_at_scalartype(x.scalar_type()));
 
   graph.execute();
 
   at::Tensor vk_out = at::empty_like(out_ref);
-  graph.copy_from_staging(
-      staging_out, vk_out.mutable_data_ptr(), vk_out.numel());
+  graph.maybe_cast_and_copy_from_staging(
+      staging_out,
+      vk_out.mutable_data_ptr(),
+      vk_out.numel(),
+      from_at_scalartype(vk_out.scalar_type()));
 
   ASSERT_TRUE(at::allclose(vk_out, out_ref, 1e-4, 1e-4));
 }

--- a/backends/vulkan/test/op_tests/rotary_embedding_test.cpp
+++ b/backends/vulkan/test/op_tests/rotary_embedding_test.cpp
@@ -120,22 +120,42 @@ void test_reference(
   //
 
   graph.propagate_resize();
-  graph.copy_into_staging(r_xq.staging, xq.const_data_ptr(), xq.numel());
-  graph.copy_into_staging(r_xk.staging, xk.const_data_ptr(), xk.numel());
-  graph.copy_into_staging(
-      r_freqs_cos.staging, freqs_cos.const_data_ptr(), freqs_cos.numel());
-  graph.copy_into_staging(
-      r_freqs_sin.staging, freqs_sin.const_data_ptr(), freqs_sin.numel());
+  graph.maybe_cast_and_copy_into_staging(
+      r_xq.staging,
+      xq.const_data_ptr(),
+      xq.numel(),
+      from_at_scalartype(xq.scalar_type()));
+  graph.maybe_cast_and_copy_into_staging(
+      r_xk.staging,
+      xk.const_data_ptr(),
+      xk.numel(),
+      from_at_scalartype(xk.scalar_type()));
+  graph.maybe_cast_and_copy_into_staging(
+      r_freqs_cos.staging,
+      freqs_cos.const_data_ptr(),
+      freqs_cos.numel(),
+      from_at_scalartype(freqs_cos.scalar_type()));
+  graph.maybe_cast_and_copy_into_staging(
+      r_freqs_sin.staging,
+      freqs_sin.const_data_ptr(),
+      freqs_sin.numel(),
+      from_at_scalartype(freqs_sin.scalar_type()));
 
   graph.execute();
 
   at::Tensor vk_xq_out = at::empty_like(xq_out);
-  graph.copy_from_staging(
-      staging_xq_out, vk_xq_out.mutable_data_ptr(), vk_xq_out.numel());
+  graph.maybe_cast_and_copy_from_staging(
+      staging_xq_out,
+      vk_xq_out.mutable_data_ptr(),
+      vk_xq_out.numel(),
+      from_at_scalartype(vk_xq_out.scalar_type()));
 
   at::Tensor vk_xk_out = at::empty_like(xk_out);
-  graph.copy_from_staging(
-      staging_xk_out, vk_xk_out.mutable_data_ptr(), vk_xk_out.numel());
+  graph.maybe_cast_and_copy_from_staging(
+      staging_xk_out,
+      vk_xk_out.mutable_data_ptr(),
+      vk_xk_out.numel(),
+      from_at_scalartype(vk_xk_out.scalar_type()));
 
   EXPECT_TRUE(at::allclose(xq_out, vk_xq_out, 1e-4, 1e-4));
   EXPECT_TRUE(at::allclose(xk_out, vk_xk_out, 1e-4, 1e-4));

--- a/backends/vulkan/test/op_tests/sdpa_test.cpp
+++ b/backends/vulkan/test/op_tests/sdpa_test.cpp
@@ -449,13 +449,20 @@ void test_vulkan_sdpa(
   // Run model
   //
 
-#define COPY_INPUT(x) \
-  graph.copy_into_staging(r_##x.staging, x.const_data_ptr(), x.numel());
+#define COPY_INPUT(x)                     \
+  graph.maybe_cast_and_copy_into_staging( \
+      r_##x.staging,                      \
+      x.const_data_ptr(),                 \
+      x.numel(),                          \
+      from_at_scalartype(x.scalar_type()));
 
 #define EXTRACT_TENSOR(x)                             \
   at::Tensor vk_##x = at::zeros_like(x).contiguous(); \
-  graph.copy_from_staging(                            \
-      staging_##x, vk_##x.mutable_data_ptr(), vk_##x.numel());
+  graph.maybe_cast_and_copy_from_staging(             \
+      staging_##x,                                    \
+      vk_##x.mutable_data_ptr(),                      \
+      vk_##x.numel(),                                 \
+      from_at_scalartype(vk_##x.scalar_type()));
 
   torch::manual_seed(0);
 

--- a/backends/vulkan/test/utils/test_utils.cpp
+++ b/backends/vulkan/test/utils/test_utils.cpp
@@ -528,7 +528,8 @@ void fill_vtensor(
     std::fill(data.begin(), data.end(), val);
   }
 
-  graph.copy_into_staging(idx.staging, data.data(), data.size());
+  graph.maybe_cast_and_copy_into_staging(
+      idx.staging, data.data(), data.size(), vkapi::kFloat);
 }
 
 void extract_vtensor(api::vTensor& vten, std::vector<float>& data) {
@@ -613,8 +614,11 @@ void execute_graph_and_check_output(
     IOValueRef out_ioval = graph.outputs().at(i);
     std::vector<float> output_data(
         graph.staging_buffer_numel_of(out_ioval.value));
-    graph.copy_from_staging(
-        out_ioval.staging, output_data.data(), output_data.size());
+    graph.maybe_cast_and_copy_from_staging(
+        out_ioval.staging,
+        output_data.data(),
+        output_data.size(),
+        vkapi::kFloat);
 
     for (size_t j = 0; j < graph.numel_of(out_ioval.value); ++j) {
       CHECK_VALUE(output_data, j, expected_outputs.at(i));


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #16842
* #16817
* #16816
* #16815
* #16814

Some Vulkan devices do not support 16-bit storage buffers (the
VK_KHR_16bit_storage extension with storageBuffer16BitAccess). Previously,
attempting to run models with fp16 buffer-backed tensors on such devices would
crash because the shaders require 16-bit buffer access.

This diff adds transparent fallback behavior: when a device lacks float16
buffer support, fp16 data is automatically converted to fp32 when copying
between CPU memory and staging buffers, and the GPU tensors/buffers use fp32
storage internally.

Key changes:

1. StagingBuffer dtype aliasing:
   - Added `get_staging_dtype()` which returns kFloat when kHalf is requested
     but the device lacks float16 buffer support
   - Moved StagingBuffer constructor to cpp file to apply this aliasing

2. Half<->Float conversion utilities:
   - Added `half_to_float()` and `float_to_half()` for IEEE 754 compliant
     conversion between 16-bit and 32-bit floats
   - Added `cast_half_to_float_and_copy_from()` and
     `cast_float_to_half_and_copy_to()` methods to StagingBuffer

3. vTensor dtype aliasing:
   - Modified `get_effective_scalar_type()` in Tensor.cpp to alias kHalf to
     kFloat when float16 buffers are not supported

4. Data transfer dtype handling:
   - Updated `create_staging_buffer()` in PrepackNode.cpp to handle dtype
     conversion when staging dtype differs from TensorRef dtype
   - Updated `maybe_cast_and_copy_into_staging()` and
     `maybe_cast_and_copy_from_staging()` in ComputeGraph.cpp to handle
     kHalf<->kFloat conversion

5. Shader updates for conv2d weight prepacking:
   - Modified conv2d_prepack_weights.glsl/yaml and
     conv2d_dw_prepack_weights.glsl/yaml to support separate buffer dtype
     (BUF_DTYPE) from texture dtype (DTYPE)
   - Added shader variant combinations: [float,float], [half,float], [half,half]
   - Updated Convolution.cpp and Staging.cpp to select correct shader variant
     based on staging dtype

6. Make copy_into_staging/copy_from_staging private:
   - Made `copy_into_staging()` and `copy_from_staging()` private methods in
     ComputeGraph
   - Migrated all callsites to use `maybe_cast_and_copy_into_staging()` and
     `maybe_cast_and_copy_from_staging()` instead
   - These new APIs require an explicit dtype parameter specifying the source/
     destination data type, ensuring staging buffers always receive data of
     the correct type and enabling automatic dtype conversion when needed

Differential Revision: [D91281381](https://our.internmc.facebook.com/intern/diff/D91281381/)