### PR TITLE
Support tuple outputs in aten bridge

### DIFF
--- a/extension/aten_util/make_aten_functor_from_et_functor.h
+++ b/extension/aten_util/make_aten_functor_from_et_functor.h
@@ -82,6 +82,17 @@ struct type_map<torch::executor::ArrayRef<T>> final {
   using type = at::ArrayRef<typename type_map<T>::type>;
 };
 
+// Tuple.
+template <class... Args>
+struct type_map<std::tuple<Args...>> final {
+  using type = std::tuple<typename type_map<Args>::type...>;
+};
+
+template <class... Args>
+struct type_map<std::tuple<Args...>&> final {
+  using type = std::tuple<typename type_map<Args>::type...>&;
+};
+
 template <typename T>
 struct remove_const_ref final {
   using type = std::remove_const_t<std::remove_reference_t<T>>;
@@ -232,6 +243,73 @@ struct type_convert<torch::executor::ArrayRef<F>, c10::ArrayRef<T>> final {
   }
 };
 
+// Tuples: birdirectional.
+template <class... F, class... T>
+struct type_convert<std::tuple<F...>, std::tuple<T...>> final {
+ public:
+  // We need to remove references from the output type because converters expect
+  // to return by value. For example, the tensor converter creates a temporary
+  // tensor and returns it by value - so we can't return an lvalue reference to it.
+  using InType = std::tuple<F...>;
+  using OutType = std::tuple<std::remove_reference_t<T>...>;
+
+  std::tuple<type_convert<F, std::remove_reference_t<T>>...> converters;
+
+  explicit type_convert(std::tuple<F...> value) :
+    converters(make_converters(value, std::index_sequence_for<F...>{})) {}
+
+  template <size_t... Is>
+  static decltype(converters) make_converters(
+    std::tuple<F...> value,
+    std::index_sequence<Is...>) {
+    return std::make_tuple(
+      // For each element in the input/output tuple, create a type_convert struct.
+      type_convert<
+        // Get the type of Ith element of the input and output.
+        std::tuple_element_t<Is, InType>,
+        std::tuple_element_t<Is, OutType>
+        // Instantiate the converter with the Ith element of the input.
+      >(std::get<Is>(value))...
+    );
+  }
+
+  template <size_t... Is>
+  OutType call_impl(std::index_sequence<Is...>) {
+    // Invoke the converter on each element of the tuple.
+    return std::make_tuple(std::get<Is>(converters).call()...);
+  }
+  OutType call() {
+    return call_impl(std::make_index_sequence<sizeof...(F)>{});
+  }
+};
+
+template <class T>
+struct is_tuple : std::false_type {};
+
+template <class... Args>
+struct is_tuple<std::tuple<Args...>> : std::true_type {};
+
+// A utility struct to extract the out arguments from a function.
+// Returns a tuple of Args[N...], where N is the index of the first out argument.
+template <size_t N, typename... Args>
+struct extract_out_args;
+
+template <size_t N, typename... Args>
+struct extract_out_args {
+  static_assert(sizeof...(Args) >= N, "Output index out of range.");
+  static constexpr size_t n_out = sizeof...(Args) - N;
+  using tuple_type = std::tuple<Args...>;
+
+  template <size_t... I>
+  static auto get_impl(tuple_type&& t, std::index_sequence<I...>) {
+    return std::forward_as_tuple(std::get<N + I>(std::forward<tuple_type>(t))...);
+  }
+
+  static auto get(tuple_type&& t) {
+    return get_impl(std::forward<tuple_type>(t), std::make_index_sequence<n_out>{});
+  }
+};
+
 template <class F, F f, typename N = int, N index = N(-1)>
 struct wrapper_impl;
 
@@ -244,17 +322,20 @@ struct wrapper_impl<R (*)(Args...), f, int, N> {
   using TupleConvertsType =
       std::tuple<type_convert<typename type_map<Args>::type, Args>...>;
   using TupleArgsType = std::tuple<typename type_map<Args>::type...>;
+
   static constexpr size_t num_args = sizeof...(Args);
+  static constexpr size_t num_out_args = sizeof...(Args) - N;
+  static constexpr bool is_output_tuple = is_tuple<ReturnType>::value;
+  static_assert(N < num_args, "The index of the out tensor can't be greater or equal to num_args.");
   static_assert(
-      (N < num_args &&
+       is_output_tuple ||
        std::is_same_v<
            executorch::extension::kernel_util_internal::element_t<
                N,
                executorch::extension::kernel_util_internal::typelist<Args...>>,
-           R>) ||
+           R> ||
           N == -1,
-      "The index of the out tensor can't be greater or equal to num_args and "
-      "the Nth argument type has to be the same as the return type.");
+      "The Nth argument type has to be the same as the return type.");
 
   static ReturnType wrap(typename type_map<Args>::type... args) {
     // The wrapped function that takes ATen argument types, convert them into
@@ -265,20 +346,24 @@ struct wrapper_impl<R (*)(Args...), f, int, N> {
         type_convert<typename type_map<Args>::type, Args>(args)...);
     R result =
         call_functor_with_args(converts, std::make_index_sequence<num_args>());
-    typename std::remove_reference<ReturnType>::type converted_result =
-        type_convert<R, ReturnType>(result).call();
+    auto converted_result = type_convert<R, ReturnType>(result).call();
     if constexpr (N == -1) {
       return converted_result;
-    } else {
+    } else if constexpr (is_output_tuple) {
+      auto out_args = extract_out_args<N, typename type_map<Args>::type...>::get(std::move(args_tuple));
+
+       return resize_and_copy_outputs(
+        std::move(converted_result),
+        std::move(out_args),
+        std::make_index_sequence<num_out_args>{});
+    } else { // Non-tuple return type.
       static_assert(
           std::is_same_v<
               typename std::remove_reference<ReturnType>::type,
               at::Tensor>,
           "Only support at::Tensor-like return");
       ReturnType out = std::get<N>(args_tuple);
-      at::native::resize_output(out, converted_result.sizes());
-      out.copy_(converted_result);
-      return out;
+      return resize_and_copy_output(converted_result, out);
     }
   }
 
@@ -288,6 +373,30 @@ struct wrapper_impl<R (*)(Args...), f, int, N> {
       TupleConvertsType& converts,
       std::index_sequence<indices...>) {
     return f(std::get<indices>(converts).call()...);
+  }
+
+  template <class A>
+  static at::Tensor& resize_and_copy_output(
+    A converted_result,
+    at::Tensor& out
+  ) {
+    at::native::resize_output(out, converted_result.sizes());
+    out.copy_(converted_result);
+    return out;
+  }
+
+  template <class A, class B, size_t... Is>
+  static ReturnType resize_and_copy_outputs(
+    A&& converted_result,
+    B&& out,
+    std::index_sequence<Is...>
+  ) {
+    return std::forward_as_tuple(
+      resize_and_copy_output(
+        std::get<Is>(std::forward<A>(converted_result)),
+        std::get<Is>(std::forward<B>(out))
+      )...
+    );
   }
 };
 

--- a/extension/aten_util/test/make_aten_functor_from_et_functor_test.cpp
+++ b/extension/aten_util/test/make_aten_functor_from_et_functor_test.cpp
@@ -90,10 +90,8 @@ Tensor& sum_arrayref_optional_tensor_out(
   return out;
 }
 
-std::tuple<Tensor&, Tensor&> add_constant_tuple_out(
-  const Tensor& a,
-  Tensor& out1,
-  Tensor& out2) {
+std::tuple<Tensor&, Tensor&>
+add_constant_tuple_out(const Tensor& a, Tensor& out1, Tensor& out2) {
   auto a_data = a.const_data_ptr<int32_t>();
   auto out1_data = out1.mutable_data_ptr<int32_t>();
   auto out2_data = out2.mutable_data_ptr<int32_t>();
@@ -103,7 +101,7 @@ std::tuple<Tensor&, Tensor&> add_constant_tuple_out(
     out2_data[i] = a_data[i] + 2;
   }
 
-  return { out1, out2 };
+  return {out1, out2};
 }
 
 Tensor& quantized_embedding_byte_out(
@@ -153,17 +151,19 @@ TEST_F(MakeATenFunctorFromETFunctorTest, TestTypeMap_Tensor) {
 TEST_F(MakeATenFunctorFromETFunctorTest, TestTypeMap_Tuple_Tensor2x) {
   EXPECT_TRUE(
       (std::is_same<
-        type_map<std::tuple<torch::executor::Tensor, torch::executor::Tensor>>::type,
-        std::tuple<at::Tensor, at::Tensor>
-        >::value));
+          type_map<
+              std::tuple<torch::executor::Tensor, torch::executor::Tensor>>::
+              type,
+          std::tuple<at::Tensor, at::Tensor>>::value));
 }
 
 TEST_F(MakeATenFunctorFromETFunctorTest, TestTypeMap_Tuple_TensorRef3x) {
-  EXPECT_TRUE(
-      (std::is_same<
-        type_map<std::tuple<torch::executor::Tensor&, torch::executor::Tensor&, torch::executor::Tensor&>>::type,
-        std::tuple<at::Tensor&, at::Tensor&, at::Tensor&>
-        >::value));
+  EXPECT_TRUE((std::is_same<
+               type_map<std::tuple<
+                   torch::executor::Tensor&,
+                   torch::executor::Tensor&,
+                   torch::executor::Tensor&>>::type,
+               std::tuple<at::Tensor&, at::Tensor&, at::Tensor&>>::value));
 }
 
 TEST_F(MakeATenFunctorFromETFunctorTest, TestTypeMap_Optionals) {
@@ -226,23 +226,24 @@ TEST_F(MakeATenFunctorFromETFunctorTest, TestConvert_TupleTensor) {
   at::Tensor at_in1 = torch::tensor({1});
   at::Tensor at_in2 = torch::tensor({2});
   auto et = type_convert<
-      std::tuple<at::Tensor, at::Tensor>,
-      std::tuple<torch::executor::Tensor, torch::executor::Tensor>>(
-      std::make_tuple(at_in1, at_in2))
-          .call();
-  EXPECT_TRUE(
-      (std::is_same<
-          decltype(et),
-          std::tuple<torch::executor::Tensor, torch::executor::Tensor>>::value));
+                std::tuple<at::Tensor, at::Tensor>,
+                std::tuple<torch::executor::Tensor, torch::executor::Tensor>>(
+                std::make_tuple(at_in1, at_in2))
+                .call();
+  EXPECT_TRUE((std::is_same<
+               decltype(et),
+               std::tuple<torch::executor::Tensor, torch::executor::Tensor>>::
+                   value));
 
   // Convert et to at.
   torch::executor::testing::TensorFactory<ScalarType::Int> tf;
   torch::executor::Tensor et_in1 = tf.ones({3});
   torch::executor::Tensor et_in2 = tf.ones({4});
-  auto at_out = type_convert<
-      std::tuple<torch::executor::Tensor, torch::executor::Tensor>,
-      std::tuple<at::Tensor, at::Tensor>>(std::make_tuple(et_in1, et_in2))
-                    .call();
+  auto at_out =
+      type_convert<
+          std::tuple<torch::executor::Tensor, torch::executor::Tensor>,
+          std::tuple<at::Tensor, at::Tensor>>(std::make_tuple(et_in1, et_in2))
+          .call();
   EXPECT_TRUE(
       (std::is_same<decltype(at_out), std::tuple<at::Tensor, at::Tensor>>::
            value));


### PR DESCRIPTION
Summary: Update the aten bridge logic in make_aten_functor_from_et... to handle kernels that return tuples of tensors. This motivating use case is the box_with_nms_limit custom op, which returns a tuple of 6 output tensors.

Differential Revision: D91375148


