### PR TITLE
Fix left nav TOC for backends overview page in main

### DIFF
--- a/docs/source/backends-overview.md
+++ b/docs/source/backends-overview.md
@@ -51,16 +51,16 @@ Backends are the bridge between your exported model and the hardware it runs on.
 :hidden:
 :caption: Backend Overview
 
-backends-xnnpack
+backends/xnnpack/xnnpack-overview
 backends/cuda/cuda-overview
 backends/coreml/coreml-overview
-backends-mps
-backends-vulkan
+backends/mps/mps-overview
+backends/vulkan/vulkan-overview
 backends-qualcomm
 backends-mediatek
-backends-arm-ethos-u
-backends-arm-vgf
+backends/arm-ethos-u/arm-ethos-u-overview
+backends/arm-vgf/arm-vgf-overview
 build-run-openvino
-backends-nxp
+backends/nxp/nxp-overview
 backends-cadence
-backends-samsung-exynos
+backends/samsung/samsung-overview

--- a/docs/source/backends/nxp/nxp-dim-order.md
+++ b/docs/source/backends/nxp/nxp-dim-order.md
@@ -90,10 +90,3 @@ python -m examples.nxp.aot_neutron_compile --quantize \
     --delegate --neutron_converter_flavor SDK_25_12 -m cifar10 \
     --use_channels_last_dim_order
 ```
-
-```{toctree}
-:hidden:
-:maxdepth: 2
-
-nxp-overview
-```


### PR DESCRIPTION
The backends-overview page was only showing 6 backends instead of 13. This regression was introduced in commit cdc2701acb (NXP Backend: Update documentation to the new scheme #15219) which inadvertently reverted correct toctree paths to incorrect ones during a table reformatting.


- Toctree entries used old flat paths (e.g., backends-xnnpack) instead of the new subdirectory paths (e.g., backends/xnnpack/xnnpack-overview)
- A circular toctree dependency between nxp-overview.md and nxp-dim-order.md caused Sphinx build failures


Test Plan: Built sphinx locally and rendered page


https://docs-preview.pytorch.org/pytorch/executorch/16861/backends-section.html