### PR TITLE
Qualcomm AI Engine Direct - Optimize UT execution time

### DIFF
--- a/backends/qualcomm/tests/test_qnn_delegate.py
+++ b/backends/qualcomm/tests/test_qnn_delegate.py
@@ -8131,8 +8131,15 @@ class TestUtilsScript(TestQNN):
                 self.build_folder,
                 "--input_list",
                 f"{tmp_dir}/input_list",
+                "--model",
+                self.model,
+                "--host",
+                self.host,
+                "--target",
+                self.target,
+                "--device",
+                self.device,
             ]
-            self.add_default_cmds(cmds)
             subprocess.run(cmds, stdout=subprocess.DEVNULL)
             self.assertTrue(os.path.isfile(f"{tmp_dir}/e_out/Result_0/output_0.pt"))
 

--- a/backends/qualcomm/tests/utils.py
+++ b/backends/qualcomm/tests/utils.py
@@ -185,6 +185,25 @@ class TestQNN(unittest.TestCase):
     inference_speed: float = 0.0
     inference_speed_output_path = "outputs/inference_speed.txt"
 
+    @classmethod
+    def setUpClass(cls):
+        if not cls.enable_x86_64 and not cls.compile_only:
+            # init device once
+            adb = SimpleADB(
+                qnn_sdk=os.getenv("QNN_SDK_ROOT"),
+                build_path=cls.build_folder,
+                pte_path=[],
+                workspace="/data/local/tmp/qnn_executorch_test",
+                device_id=cls.device,
+                host_id=cls.host,
+                soc_model=cls.model,
+                error_only=cls.error_only,
+                target=cls.target,
+            )
+            adb.push(
+                init_env=True,
+            )
+
     def _assert_outputs_equal(self, model_output, ref_output):
         self.assertTrue(len(ref_output) == len(model_output))
         for i in range(len(ref_output)):
@@ -489,6 +508,7 @@ class TestQNN(unittest.TestCase):
                 adb.push(
                     inputs=[processed_inputs],
                     files=op_package_paths,
+                    init_env=False,
                 )
                 adb.extra_cmds += extra_cmds
                 if save_inference_speed:


### PR DESCRIPTION
### Summary
- Currently all tests will push same libs, which is redundant. With this PR it only push once, and reduce execution time from two to three times for operator's tests.

### Test plan
```
python backends/qualcomm/tests/test_qnn_delegate.py -k TestQNNFloatingPointOperator --device <device> --host <host> --model SM8650 --build_folder build-android --executorch_root . --artifact all_artifact
```
without optimization
<img width="429" height="136" alt="image" src="https://github.com/user-attachments/assets/a0a6d40a-6876-469d-af46-c8e4ebfa7cb8" />


with optimization
<img width="442" height="130" alt="image" src="https://github.com/user-attachments/assets/9249b3eb-c85f-4d64-99c2-12fafdd7ae77" />



cc @cccclai @cbilgin