### PR TITLE
[RELEASE ONLY CHANGES] Pin tokenizers to v1.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ dependencies=[
   "pytest-xdist",
   "pytest-rerunfailures==15.1",
   "pytest-json-report",
-  "pytorch-tokenizers",
+  "pytorch-tokenizers>=1.1",
   "pyyaml",
   "ruamel.yaml",
   "sympy",


### PR DESCRIPTION
### Summary

This change moves the tokenizers dependency to >=1.1.