### PR TITLE
[RELEASE ONLY CHANGES] Use torch 2.10 release packages

### DIFF
--- a/.ci/docker/common/install_pytorch.sh
+++ b/.ci/docker/common/install_pytorch.sh
@@ -12,12 +12,11 @@ source "$(dirname "${BASH_SOURCE[0]}")/utils.sh"
 
 install_domains() {
   echo "Install torchvision and torchaudio"
-  pip_install --no-build-isolation --user "git+https://github.com/pytorch/audio.git@${TORCHAUDIO_VERSION}"
-  pip_install --no-build-isolation --user "git+https://github.com/pytorch/vision.git@${TORCHVISION_VERSION}"
+  pip_install --force-reinstall torchvision==0.25.0 torchaudio==2.10.0 --index-url https://download.pytorch.org/whl/cpu
 }
 
 install_pytorch_and_domains() {
-  pip_install --force-reinstall torch==2.10.0 torchvision==0.25.0 torchaudio==2.10.0 torchao==0.15.0 --index-url https://download.pytorch.org/whl/test/cpu
+  pip_install --force-reinstall torch==2.10.0 torchvision==0.25.0 torchaudio==2.10.0 torchao==0.15.0 --index-url https://download.pytorch.org/whl/cpu
 }
 
 install_pytorch_and_domains

--- a/.ci/scripts/setup-linux.sh
+++ b/.ci/scripts/setup-linux.sh
@@ -17,12 +17,8 @@ echo "Build tool: $BUILD_TOOL, Mode: $BUILD_MODE"
 # have already been installed, so we use PyTorch build from source here instead
 # of nightly. This allows CI to test against latest commits from PyTorch
 if [[ "${EDITABLE:-false}" == "true" ]]; then
-  install_executorch --use-pt-pinned-commit --editable
+  install_executorch --editable
 else
-  install_executorch --use-pt-pinned-commit
+  install_executorch
 fi
 build_executorch_runner "${BUILD_TOOL}" "${BUILD_MODE}"
-
-if [[ "${GITHUB_BASE_REF:-}" == *main* || "${GITHUB_BASE_REF:-}" == *gh* ]]; then
-  do_not_use_nightly_on_ci
-fi

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -14,7 +14,7 @@ from install_utils import determine_torch_url, is_intel_mac_os, python_is_compat
 
 # The pip repository that hosts torch packages.
 # This will be dynamically set based on CUDA availability and CUDA backend enabled/disabled.
-TORCH_URL_BASE = "https://download.pytorch.org/whl/test"
+TORCH_URL_BASE = "https://download.pytorch.org/whl/"
 
 # Supported CUDA versions - modify this to add/remove supported versions
 # Format: tuple of (major, minor) version numbers
@@ -118,25 +118,6 @@ def install_requirements(use_pytorch_nightly):
 def install_optional_example_requirements(use_pytorch_nightly):
     # Determine the appropriate PyTorch URL based on CUDA delegate status
     torch_url = determine_torch_url(TORCH_URL_BASE, SUPPORTED_CUDA_VERSIONS)
-
-    print("Installing torch domain libraries")
-    DOMAIN_LIBRARIES = [
-        ("torchvision==0.25.0" if use_pytorch_nightly else "torchvision"),
-        ("torchaudio==2.10.0" if use_pytorch_nightly else "torchaudio"),
-    ]
-    # Then install domain libraries
-    subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "pip",
-            "install",
-            *DOMAIN_LIBRARIES,
-            "--extra-index-url",
-            torch_url,
-        ],
-        check=True,
-    )
 
     print("Installing packages in requirements-examples.txt")
     subprocess.run(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ dependencies=[
   "hydra-core>=1.3.0",
   "omegaconf>=2.3.0",
   "torchao==0.15.0",
+  "torch>=2.10.0",
 ]
 
 [project.urls]

--- a/requirements-examples.txt
+++ b/requirements-examples.txt
@@ -5,3 +5,5 @@ timm == 1.0.7
 torchsr == 1.0.4
 torchtune >= 0.6.1
 transformers == 5.0.0rc1
+torchaudio == 2.10.0
+torchvision == 0.25.0

--- a/requirements-examples.txt
+++ b/requirements-examples.txt
@@ -5,5 +5,5 @@ timm == 1.0.7
 torchsr == 1.0.4
 torchtune >= 0.6.1
 transformers == 5.0.0rc1
-torchaudio == 2.10.0
-torchvision == 0.25.0
+torchaudio >= 2.10.0
+torchvision >= 0.25.0


### PR DESCRIPTION
### Summary
This change switches to torch 2.10 release packages for pytorch and domain libraries for 1.1 release. See #15168 as example from 1.0 release. One notable difference is that we will allow newer versions of torch (ie, 2.11) to be used with 1.1 release.