### PR TITLE
[RELEASE ONLY CHANGES] Use release torchao for OpenVINO

### DIFF
--- a/backends/openvino/scripts/openvino_build.sh
+++ b/backends/openvino/scripts/openvino_build.sh
@@ -79,11 +79,6 @@ build_python_enabled() {
 
     # Build the package
     ./install_executorch.sh --minimal
-
-    # Install torchao
-    # Note: --no-build-isolation is required because torchao's setup.py imports torch
-    # See comment in torchao's pyproject.toml for more details
-    pip install third-party/ao --no-build-isolation
 }
 
 main() {


### PR DESCRIPTION
This change removes the torchao pip install from the openvino_build.sh script for release 1.1. See #15880 as example from 1.0 release.