### PR TITLE
[RELEASE ONLY CHANGES] Remove trailing slash from TORCH_URL_BASE

### DIFF
--- a/install_requirements.py
+++ b/install_requirements.py
@@ -14,7 +14,7 @@ from install_utils import determine_torch_url, is_intel_mac_os, python_is_compat
 
 # The pip repository that hosts torch packages.
 # This will be dynamically set based on CUDA availability and CUDA backend enabled/disabled.
-TORCH_URL_BASE = "https://download.pytorch.org/whl/"
+TORCH_URL_BASE = "https://download.pytorch.org/whl"
 
 # Supported CUDA versions - modify this to add/remove supported versions
 # Format: tuple of (major, minor) version numbers


### PR DESCRIPTION
The trailing slash on TORCH_URL_BASE caused the install_requirements.py to pick up the torchvision from PyPI rather than the pytorch index url.