### PR TITLE
Qualcomm AI Engine Direct - Update QnnProfile_Config to generate optrace

### DIFF
--- a/backends/qualcomm/runtime/backends/QnnProfiler.cpp
+++ b/backends/qualcomm/runtime/backends/QnnProfiler.cpp
@@ -54,6 +54,7 @@ QnnProfile::QnnProfile(
 
       QnnProfile_Config_t qnnProfileConfig = QNN_PROFILE_CONFIG_INIT;
       qnnProfileConfig.option = QNN_PROFILE_CONFIG_OPTION_ENABLE_OPTRACE;
+      qnnProfileConfig.enableOptrace = true;
       std::array<const QnnProfile_Config_t*, 2> profileConfigs = {
           &qnnProfileConfig, nullptr};
       error =


### PR DESCRIPTION
### Summary:
- To generate optrace, set `qnnProfileConfig.enableOptrace = true;` for QNN version 2.41 and above.

### Test plan
```
python3 backends/qualcomm/tests/test_qnn_delegate.py TestQNNFloatingPointUtils.test_qnn_backend_generate_optrace -b build-android  -H ${HOST} -s ${DEVICE} -m SM8750 -r /path/to/executorch -a /path/to/unit_test
```
```
python3 backends/qualcomm/tests/test_qnn_delegate.py TestQNNQuantizedUtils.test_qnn_backend_generate_optrace -b build-android  -H ${HOST} -s ${DEVICE} -m SM8750 -r /path/to/executorch -a /path/to/unit_test
```
