### PR TITLE
NXP backend: Update partitioning to avoid delegating no-op partitions.

### DIFF
--- a/backends/nxp/backend/custom_delegation_options.py
+++ b/backends/nxp/backend/custom_delegation_options.py
@@ -1,4 +1,4 @@
-# Copyright 2025 NXP
+# Copyright 2025-2026 NXP
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -17,3 +17,8 @@ class CustomDelegationOptions:
     #  of `num_macs`. The `force_delegate_cat` allows the user to turn off the defensive check if from the model design
     #  it is known this constraint will be satisfied.
     force_delegate_cat: bool = False
+
+    # Proposed partitions which only contain Neutron no-ops are normally not delegated, as the NeutronConverter would
+    #  not create any NeutronGraph that can be called. This is done by the partitioner itself, and is not handled by
+    #  the individual node converters.
+    allow_no_op_partitions: bool = False

--- a/backends/nxp/backend/edge_helper.py
+++ b/backends/nxp/backend/edge_helper.py
@@ -1,7 +1,9 @@
-# Copyright 2024-2025 NXP
+# Copyright 2024-2026 NXP
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+
+import logging
 
 import torch
 
@@ -18,6 +20,14 @@ DEQUANTIZE_OPERATORS = [
     exir_ops.edge.quantized_decomposed.dequantize_per_channel.default,
     exir_ops.edge.quantized_decomposed.dequantize_per_tensor.default,
 ]
+
+# A set of operators which could possibly be no-ops in certain conditions. The operators in this set will be proclaimed
+#  as no-ops (and potentially not delegated), if their input and output tensors are equal (when run on random data).
+no_op_candidates = {
+    exir_ops.edge.aten.add.Tensor,
+    exir_ops.edge.aten.mul.Tensor,
+    exir_ops.edge.aten.sub.Tensor,
+}
 
 
 def input_tensor(node: Node, input_index: int) -> torch.Tensor:
@@ -220,3 +230,127 @@ def get_non_qdq_parent(node: Node, input_index: int = 0) -> Node | None:
         return None
 
     return quant_node.args[0]
+
+
+def try_get_dequantized_data(
+    dequantize_node: Node, parameters_mapping: dict[str, Parameter]
+) -> Parameter | None:
+    """Get the dequantized data from the following pattern. The dequantization formula is `r = (q - Z) * S`, where `q`
+        represents the static quantized data.
+
+         ┌─────────────────────────┐
+         │ <static_quantized_data> │
+         └────────────┬────────────┘
+                      │
+                ┌─────▼──────┐
+                │ Dequantize │
+                └─────┬──────┘
+                      ▼
+
+
+    :param dequantize_node: The Dequantize node from the pattern, which dequantizes the static quantized data.
+    :param parameters_mapping: Dict mapping tensor names to their static data. Should be inferred from the
+                                `state_dict` attribute of an edge program.
+    :return: The dequantized static parameter, or `None` if the data is not available.
+    """
+    if not _is_dequantize(dequantize_node):
+        return None
+
+    if not node_is_static_tensor(param := dequantize_node.args[0], parameters_mapping):
+        return None
+
+    # The pattern is correct. Dequantize the static data and return it.
+    scale, zp = get_quantization_parameters_for(dequantize_node)
+    quantized_data = parameters_mapping[param.name]
+
+    dequantized_data = (quantized_data - zp) * scale
+    return dequantized_data
+
+
+def is_no_op_on_neutron(node: Node, parameters_mapping: dict[str, Parameter]) -> bool:
+    """Check if a node is a no-op operation from the perspective of Neutron."""
+    if node.op != "call_function":
+        raise ValueError(
+            f"is_no_op_on_neutron(): Expected call_function node, got {node.op}."
+        )
+
+    if node.target in [
+        exir_ops.edge.aten.view_copy.default,
+        exir_ops.edge.dim_order_ops._clone_dim_order.default,
+        exir_ops.edge.aten.clone.default,
+    ]:
+        # Known operators which are always no-ops on Neutron.
+        return True
+
+    if node.target == exir_ops.edge.aten.cat.default and len(node.args[0]) == 1:
+        # Concatenation with 1 input is a no-op.
+        return True
+
+    # For any other operators, run them with random data and see if the output is identical to the input.
+    torch.manual_seed(42)
+    # noinspection PyBroadException
+    try:
+        input_data = None
+        args_with_random_data = []
+        for arg in node.args:
+            match arg:
+                case Node():
+                    # `arg` is either another operator, a model input, or a static parameter.
+
+                    if (
+                        data := try_get_dequantized_data(arg, parameters_mapping)
+                    ) is not None:
+                        # The `arg` is a static parameter. Use it's actual static data during the no-op test.
+                        args_with_random_data.append(data)
+
+                    else:
+                        # The `arg` is a compute node or a model input. Replace it with random data for the no-op test.
+                        if input_data is not None:
+                            # Some random input data for `node` has already been stored, which means that the node has
+                            #  more than 1 dynamic input node. Therefore, it cannot be a no-op.
+                            return False
+
+                        # Generate the random data. Use the range [-5, 5) to avoid proclaiming operations like Relu as
+                        #  no-ops.
+                        val = arg.meta["val"]
+                        input_data = torch.rand(val.shape, dtype=val.dtype) * 10 - 5
+                        args_with_random_data.append(input_data)
+
+                case list():
+                    # Lists of input nodes are not supported to keep the code simple. It is not crucial to support this
+                    #  case as the affected operators are either not supported on Neutron, or are extremely unlikely to
+                    #  be no-ops (e.g. GRU). One exception is `aten.cat`, which is explicitly supported above.
+                    return False
+
+                case _:
+                    # Generic argument (value). Not an input from a previous node. Store it in the arguments for the
+                    #  no-op test.
+                    args_with_random_data.append(arg)
+
+        # Run the operator with the random data. If the input equals the output, the node is considered a no-op.
+        output_data = node.target(*args_with_random_data)
+
+        val = node.meta["val"]
+        if (
+            output_data.dtype == val.dtype
+            and output_data.shape == val.shape
+            and torch.all(input_data == output_data)
+        ):
+            # The operator preserves the shape, data type, and data. Therefore, it is a no-op from the perspective of
+            #  Neutron.
+            if node.target in no_op_candidates:
+                return True
+            else:
+                logging.info(
+                    f"Found the operator `{node.target}`, which appears to be a no-op, but is not in the "
+                    "known no-op list. Please report this issue."
+                )
+                return False
+
+        else:
+            # Type, shape, or data doesn't match.
+            return False
+
+    except Exception:
+        # If execution fails, assume it's not a no-op.
+        return False

--- a/backends/nxp/backend/edge_program_converter.py
+++ b/backends/nxp/backend/edge_program_converter.py
@@ -13,6 +13,7 @@ from executorch.backends.nxp.backend.ir.converter.builder.aten_model_builder_dir
 from executorch.backends.nxp.backend.ir.converter.node_converter import (
     CustomDelegationOptions,
 )
+from torch._subclasses import FakeTensor
 from torch.export import ExportedProgram
 from torch.export.graph_signature import InputKind
 from torch.fx import Node
@@ -161,20 +162,49 @@ class EdgeProgramToIRConverter:
                     )
 
     @staticmethod
-    def map_inputs_to_parameters(edge_program: ExportedProgram) -> dict[str, Parameter]:
+    def map_inputs_to_parameters(
+        edge_program: ExportedProgram,
+        post_quantization_state_dict: dict[str, Parameter] | None = None,
+    ) -> dict[str, Parameter]:
         """
         Create mapping between program parameters (input nodes & static data nodes) and their names.
 
         :param edge_program: EdgeProgram instance.
+        :param post_quantization_state_dict: State-dict of the model right after quantization. During partitioning, the
+                                              `edge_program` only contains fake tensors without any data. In this case,
+                                              this state dict is used instead (if provided). Notice: It may potentially
+                                              contain outdated data,
         :return: Mapping from parameter name to parameter instance.
         """
         result_map = {}
 
         for input_spec in edge_program.graph_signature.input_specs:
             if input_spec.kind in [InputKind.PARAMETER, InputKind.BUFFER]:
-                result_map[input_spec.arg.name] = edge_program.state_dict[
-                    input_spec.target
-                ]
+
+                # First, try to load the static data from the model.
+                param = edge_program.state_dict[input_spec.target]
+
+                if not isinstance(param, FakeTensor):
+                    # Use the data from the model.
+                    result_map[input_spec.arg.name] = param
+
+                else:
+                    # It is the partitioning stage, which uses a FakeModel with FakeTensors (without the actual data).
+                    # Try to load the data from the post-quantization state dict.
+                    if (
+                        post_quantization_state_dict is not None
+                        and (
+                            param := post_quantization_state_dict.get(
+                                input_spec.target, None
+                            )
+                        )
+                        is not None
+                    ):
+                        result_map[input_spec.arg.name] = param
+
+                    else:
+                        # There is no data available.
+                        continue
 
         return result_map
 

--- a/backends/nxp/backend/ir/converter/node_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converter.py
@@ -75,7 +75,10 @@ class NodeConverter(ABC):
             Classes which implement conversion for individual operators must overwrite this method.
 
         :param node: torch.Node to check.
-        :param parameters_mapping: Dictionary mapping tensor names to their static data (if they have it).
+        :param parameters_mapping: Dictionary mapping static parameter names to Parameter objects containing their data
+                                    (if they have any). During partitioning, this data is extracted from the model right
+                                    after quantization and before edge dialect passes. Therefore, it could potentially
+                                    be outdated.
         :param custom_delegation_options: Custom options which affect delegation.
         """
         pass
@@ -93,7 +96,10 @@ class NodeConverter(ABC):
 
         :param node: The node (edge operator) to check.
         :param neutron_target_spec: Object for querying the target platform to retrieve its properties.
-        :param parameters_mapping: Dictionary mapping tensor names to their static data (if they have it).
+        :param parameters_mapping: Dictionary mapping static parameter names to Parameter objects containing their data
+                                    (if they have any). During partitioning, this data is extracted from the model right
+                                    after quantization and before edge dialect passes. Therefore, it could potentially
+                                    be outdated.
         :param custom_delegation_options: Custom options which affect delegation.
         """
         return True
@@ -110,7 +116,10 @@ class NodeConverter(ABC):
 
         :param node: torch.Node to check.
         :param neutron_target_spec: Object for querying the target platform to retrieve its properties.
-        :param parameters_mapping: Dict mapping tensor names to their data.
+        :param parameters_mapping: Dictionary mapping static parameter names to Parameter objects containing their data
+                                    (if they have any). During partitioning, this data is extracted from the model right
+                                    after quantization and before edge dialect passes. Therefore, it could potentially
+                                    be outdated.
         :param custom_delegation_options: Custom user options which affect node delegation.
         """
         return cls._is_supported_in_IR(
@@ -136,7 +145,10 @@ class NodeConverter(ABC):
         :param partition_list: List of proposed partitions.
         :param custom_delegation_options: Custom user options which affect node delegation.
         :param neutron_target_spec: NeutronTargetSpec instance.
-        :param parameters_mapping: Dictionary mapping tensor names to their static data.
+        :param parameters_mapping: Dictionary mapping static parameter names to Parameter objects containing their data
+                                    (if they have any). During partitioning, this data is extracted from the model right
+                                    after quantization and before edge dialect passes. Therefore, it could potentially
+                                    be outdated.
         :return: Boolean indicating whether the node supports the current partitioning.
         """
         return True

--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/view_copy_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/view_copy_converter.py
@@ -21,7 +21,6 @@ from executorch.backends.nxp.backend.ir.converter.conversion.translator import (
 )
 from executorch.backends.nxp.backend.ir.converter.node_converter import (
     CustomDelegationOptions,
-    is_not_qdq_node,
     NodeConverter,
 )
 from executorch.backends.nxp.backend.ir.converter.node_converters.shared.reshape_transposition import (
@@ -60,24 +59,6 @@ class ViewCopyConverter(NodeConverter):
         return True
 
     @classmethod
-    def _partition_contains_compute_nodes(cls, view_copy_partition: Partition) -> bool:
-        non_q_dq_partition_nodes = list(
-            filter(is_not_qdq_node, view_copy_partition.nodes)
-        )
-
-        if len(non_q_dq_partition_nodes) == 1:
-            # The `view_copy` cannot be the only node in a partition.
-            return False
-
-        # It is common for a `clone` node to come before the `view_copy`. Make sure these are not the only two nodes
-        #  in the partition.
-        if any("clone" in n.name for n in non_q_dq_partition_nodes):
-            if len(non_q_dq_partition_nodes) <= 2:
-                return False
-
-        return True
-
-    @classmethod
     def supports_partitioning_result(
         cls,
         node: Node,
@@ -90,9 +71,6 @@ class ViewCopyConverter(NodeConverter):
             partition for partition in partition_list if node in partition.nodes
         ]
         assert len(view_copy_partitions) == 1
-
-        if not cls._partition_contains_compute_nodes(view_copy_partitions[0]):
-            return False
 
         input_format = node.args[0].meta[NXP_NODE_FORMAT]
         output_format = node.meta[NXP_NODE_FORMAT]

--- a/backends/nxp/neutron_partitioner.py
+++ b/backends/nxp/neutron_partitioner.py
@@ -366,6 +366,10 @@ class NeutronPartitioner(Partitioner):
                                    `state_dict` attribute of an edge program.
         :return: True, if the partitioning result is valid.
         """
+        if len(partition_list) == 0:
+            # If there are no partitions, the partitioning is trivially valid.
+            return True
+
         partitioning_valid = True
 
         if not custom_delegation_options.allow_no_op_partitions:

--- a/backends/nxp/neutron_partitioner.py
+++ b/backends/nxp/neutron_partitioner.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 NXP
+# Copyright 2024-2026 NXP
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -17,11 +17,13 @@ from executorch.backends.nxp.backend.custom_delegation_options import (
 )
 from executorch.backends.nxp.backend.edge_helper import (
     DEQUANTIZE_OPERATORS,
+    is_no_op_on_neutron,
     QUANTIZE_OPERATORS,
 )
 from executorch.backends.nxp.backend.edge_program_converter import (
     EdgeProgramToIRConverter,
 )
+from executorch.backends.nxp.backend.ir.converter.node_converter import is_not_qdq_node
 from torch.export.exported_program import ExportedProgram
 from torch.fx import Graph
 from torch.fx.passes.infra.partitioner import CapabilityBasedPartitioner, Partition
@@ -268,12 +270,11 @@ class NeutronSupportedOperators(OperatorSupportBase):
             # There is no `NodeConverter` for this `node`.
             return False
 
+        # noinspection PyUnresolvedReferences
         return (
             self._is_node_call_function(node)
             and self._is_node_quantized(node)
-            and
-            # TODO: `view_copy` node should be delegated only if it's not the only operator in the cluster.
-            node_converter.is_supported(
+            and node_converter.is_supported(
                 node,
                 self.neutron_target_spec,
                 self.parameters_mapping,
@@ -314,12 +315,40 @@ class NeutronPartitioner(Partitioner):
         compile_spec: list[CompileSpec],
         neutron_target_spec: NeutronTargetSpec,
         custom_delegation_options: CustomDelegationOptions | None = None,
+        post_quantization_state_dict: dict[str, Parameter] | None = None,
     ) -> None:
+        """Class responsible for identifying partitions suited for delegation to the eIQ Neutron NPU.
+
+        :param compile_spec: A list of compile specifications for Neutron.
+        :param neutron_target_spec: Object for querying the target platform to retrieve its properties.
+        :param custom_delegation_options: Custom user options which affect node delegation.
+        :param post_quantization_state_dict: State-dict of the model right after quantization. During partitioning, the
+                                              `edge_program` only contains fake tensors without any data. In this case,
+                                              this state dict is used instead (if provided). Notice: It may potentially
+                                              contain outdated data,
+        """
+        super().__init__()
         self.delegation_spec = DelegationSpec(NeutronBackend.__name__, compile_spec)
         self.custom_delegation_options = (
             custom_delegation_options or CustomDelegationOptions()
         )
         self.neutron_target_spec = neutron_target_spec
+        self.post_quantization_state_dict = post_quantization_state_dict
+
+    @staticmethod
+    def _partition_contains_compute_nodes(
+        partition: Partition, parameters_mapping: dict[str, Parameter]
+    ) -> bool:
+        non_q_dq_partition_nodes = list(filter(is_not_qdq_node, partition.nodes))
+
+        if all(
+            is_no_op_on_neutron(node, parameters_mapping)
+            for node in non_q_dq_partition_nodes
+        ):
+            # All operators in the partition are no-ops from the perspective of Neutron.
+            return False
+
+        return True
 
     def validate_partitioning_result(
         self,
@@ -328,10 +357,33 @@ class NeutronPartitioner(Partitioner):
         custom_delegation_options: CustomDelegationOptions,
         parameters_mapping: dict[str, Parameter],
     ) -> bool:
+        """Verify that the result of the partitioning can be safely used for delegation.
+
+        :param graph: Original graph that was partitioned.
+        :param partition_list: List of the resulting partitions.
+        :param custom_delegation_options: Custom user options which affect node delegation.
+        :param parameters_mapping: Dict mapping tensor names to their static data. Should be inferred from the
+                                   `state_dict` attribute of an edge program.
+        :return: True, if the partitioning result is valid.
+        """
+        partitioning_valid = True
+
+        if not custom_delegation_options.allow_no_op_partitions:
+            # Make sure all every partition contains at least 1 compute node. A partition with just no-op nodes will
+            #  result in an empty Neutron delegated partition, causing an exception.
+            for partition in partition_list:
+                if not self._partition_contains_compute_nodes(
+                    partition, parameters_mapping
+                ):
+                    # None of the nodes in this partition are compute nodes. Make sure they will not be delegated.
+                    partitioning_valid = False
+                    for node in partition.nodes:
+                        node.meta[NXP_DO_NOT_DELEGATE] = True
+
+        # Verify that all node-specific partitioning requirements are satisfied.
         all_delegated_nodes = {
             node for partition in partition_list for node in partition.nodes
         }
-        partitioning_valid = True
         for node in graph.nodes:
             if (
                 node in all_delegated_nodes
@@ -370,7 +422,7 @@ class NeutronPartitioner(Partitioner):
         logging.info(f"Operators not to delegate: {operators_not_to_delegate}")
 
         parameters_mapping = EdgeProgramToIRConverter.map_inputs_to_parameters(
-            exported_program
+            exported_program, self.post_quantization_state_dict
         )
         capability_partitioner = CapabilityBasedPartitioner(
             exported_program.graph_module,
@@ -389,7 +441,7 @@ class NeutronPartitioner(Partitioner):
         NodeFormatInference(exported_program).identify_node_formats()
 
         parameters_mapping = EdgeProgramToIRConverter.map_inputs_to_parameters(
-            exported_program
+            exported_program, self.post_quantization_state_dict
         )
 
         iteration_limit = len(exported_program.graph.nodes)

--- a/backends/nxp/quantizer/patterns.py
+++ b/backends/nxp/quantizer/patterns.py
@@ -787,7 +787,8 @@ class MulTensorPattern(QuantizationPattern):
         # which didn't take the requirements of "Mul" into account, we need to overwrite
         # the existing "quantization_annotation".
         for input_node in input_nodes:
-            input_node.meta["quantization_annotation"].output_qspec = qspec
+            if "quantization_annotation" in input_node.meta:
+                input_node.meta["quantization_annotation"].output_qspec = qspec
 
         return PartitionAnchors(
             inputs=[(node, NodeArgsIdx(0), qspec), (node, NodeArgsIdx(1), qspec)],

--- a/backends/nxp/tests/executorch_pipeline.py
+++ b/backends/nxp/tests/executorch_pipeline.py
@@ -128,7 +128,10 @@ def to_quantized_edge_program(
     )
     partitioners = [
         NeutronPartitioner(
-            compile_spec, _neutron_target_spec, custom_delegation_options
+            compile_spec,
+            _neutron_target_spec,
+            custom_delegation_options,
+            exir_program_aten__module_quant.state_dict(),
         )
     ]
 

--- a/backends/nxp/tests/ir/converter/node_converter/test_view_copy_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_view_copy_converter.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 NXP
+# Copyright 2024-2026 NXP
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -35,10 +35,10 @@ from executorch.backends.nxp.tests.executors import (
     ToChannelFirstPreprocess,
     ToChannelLastPreprocess,
 )
-from executorch.exir.dialects._ops import ops as exir_ops
 from torch import nn
 from torch.export import ExportedProgram
 from executorch.backends.nxp.tests.use_qat import *  # noqa F403
+from executorch.exir.dialects._ops import ops as exir_ops
 
 
 @pytest.fixture(autouse=True)
@@ -323,7 +323,10 @@ def test__view_copy__context_dependent__channels_first_to_formatless__transpose_
     ).exported_program()
 
     # Make sure all 3 nodes were delegated
-    assert any(n.name == "executorch_call_delegate" for n in ep.graph.nodes)
+    assert any(
+        n.target == torch._higher_order_ops.executorch_call_delegate
+        for n in ep.graph.nodes
+    )
     assert not graph_contains_any_of_ops(
         ep.graph,
         [
@@ -367,7 +370,10 @@ def test__view_copy__context_dependent__channels_first_to_formatless__transpose_
     ).exported_program()
 
     # Make sure the convolution and the linear were delegated, but not the view_copy.
-    assert any(n.name == "executorch_call_delegate" for n in ep.graph.nodes)
+    assert any(
+        n.target == torch._higher_order_ops.executorch_call_delegate
+        for n in ep.graph.nodes
+    )
     assert not graph_contains_any_of_ops(
         ep.graph,
         [
@@ -398,7 +404,10 @@ def test__view_copy__formatless_to_channels_first__transpose_supported(mocker):
     ).exported_program()
 
     # Make sure both nodes were delegated
-    assert any(n.name == "executorch_call_delegate" for n in ep.graph.nodes)
+    assert any(
+        n.target == torch._higher_order_ops.executorch_call_delegate
+        for n in ep.graph.nodes
+    )
     assert not graph_contains_any_of_ops(
         ep.graph,
         [
@@ -431,7 +440,10 @@ def test__view_copy__formatless_to_channels_first__transpose_not_supported():
     ).exported_program()
 
     # Make sure the view_copy was not delegated.
-    assert any(n.name == "executorch_call_delegate" for n in ep.graph.nodes)
+    assert any(
+        n.target == torch._higher_order_ops.executorch_call_delegate
+        for n in ep.graph.nodes
+    )
     assert not graph_contains_any_of_ops(
         ep.graph,
         [
@@ -460,7 +472,10 @@ def test__view_copy__channels_first_to_channels_first__transpose_supported(mocke
     ).exported_program()
 
     # Make sure all nodes were delegated
-    assert any(n.name == "executorch_call_delegate" for n in ep.graph.nodes)
+    assert any(
+        n.target == torch._higher_order_ops.executorch_call_delegate
+        for n in ep.graph.nodes
+    )
     assert not graph_contains_any_of_ops(
         ep.graph,
         [
@@ -494,7 +509,10 @@ def test__view_copy__channels_first_to_channels_first__transpose_not_supported()
     ).exported_program()
 
     # Make sure the view_copy was NOT delegated
-    assert any(n.name == "executorch_call_delegate" for n in ep.graph.nodes)
+    assert any(
+        n.target == torch._higher_order_ops.executorch_call_delegate
+        for n in ep.graph.nodes
+    )
     assert not graph_contains_any_of_ops(
         ep.graph,
         [
@@ -504,6 +522,76 @@ def test__view_copy__channels_first_to_channels_first__transpose_not_supported()
     assert graph_contains_any_of_ops(
         ep.graph,
         [
+            exir_ops.edge.aten.view_copy.default,
+        ],
+    )
+
+
+class ViewViewModel(nn.Module):
+    def __init__(self, new_shape_1: list[int], new_shape_2: list[int]):
+        super().__init__()
+        self.new_shape_1 = new_shape_1
+        self.new_shape_2 = new_shape_2
+
+    def forward(self, x):
+        x = x.view(self.new_shape_1)
+        return x.view(self.new_shape_2)
+
+
+class ViewAddZeroModel(nn.Module):
+    def __init__(self, new_shape: list[int]):
+        super().__init__()
+        self.new_shape = new_shape
+
+    def forward(self, x):
+        x = x.view(self.new_shape)
+        zero = torch.zeros(self.new_shape)
+        return x + zero
+
+
+def test__view_copy__noop_partitions__second_view():
+    input_shape = (1, 2, 3, 4)
+    new_shape1 = [2, 12]
+    new_shape2 = [6, 4]
+    module = ViewViewModel(new_shape1, new_shape2)
+
+    ep = to_quantized_edge_program(
+        module,
+        input_shape,
+    ).exported_program()
+
+    # Make sure neither `view_copy` was delegated.
+    assert not any(
+        n.target == torch._higher_order_ops.executorch_call_delegate
+        for n in ep.graph.nodes
+    )
+    assert graph_contains_any_of_ops(
+        ep.graph,
+        [
+            exir_ops.edge.aten.view_copy.default,
+        ],
+    )
+
+
+def test__view_copy__noop_partitions__add_zeros():
+    input_shape = (1, 2, 3, 4)
+    new_shape = [2, 12]
+    module = ViewAddZeroModel(new_shape)
+
+    ep = to_quantized_edge_program(
+        module,
+        input_shape,
+    ).exported_program()
+
+    # Make sure neither the `view` nor the `add` was delegated
+    assert not any(
+        n.target == torch._higher_order_ops.executorch_call_delegate
+        for n in ep.graph.nodes
+    )
+    assert graph_contains_any_of_ops(
+        ep.graph,
+        [
+            exir_ops.edge.aten.add.Tensor,
             exir_ops.edge.aten.view_copy.default,
         ],
     )

--- a/backends/nxp/tests/test_context_sensitive_delegation.py
+++ b/backends/nxp/tests/test_context_sensitive_delegation.py
@@ -1,19 +1,24 @@
-# Copyright 2025 NXP
+# Copyright 2025-2026 NXP
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import unittest
-
 import numpy as np
+import pytest
 import torch
 
+from executorch.backends.nxp.backend.custom_delegation_options import (
+    CustomDelegationOptions,
+)
 from executorch.backends.nxp.backend.ir.converter.node_converters.ops_converters import (
     ViewCopyConverter,
 )
 from executorch.backends.nxp.tests.executorch_pipeline import to_quantized_edge_program
 from executorch.backends.nxp.tests.executors import graph_contains_any_of_ops
 from executorch.exir.dialects._ops import ops as exir_ops
+
+# noinspection PyProtectedMember
+ExecutorchDelegateCall = torch._higher_order_ops.executorch_call_delegate
 
 
 class SingleViewCopyModule(torch.nn.Module):
@@ -25,47 +30,156 @@ class SingleViewCopyModule(torch.nn.Module):
         return torch.reshape(x, self.new_shape)
 
 
-class TestContextSensitiveDelegation(unittest.TestCase):
-    __test__ = False  # Prevent interfering with PyTest tests.
+class ConcatAddNoOpModel(torch.nn.Module):
+    def __init__(self, shape: tuple[int, ...]):
+        super().__init__()
+        self.shape = shape
 
-    @classmethod
-    def setUpClass(cls):
-        torch.manual_seed(23)
-        np.random.seed(42)
+    def forward(self, x):
+        # Concatenate 1 tensor and add 0. Both operations are no-ops.
+        x = torch.concat((x,), dim=0)
+        zeros = torch.zeros(self.shape)
+        return x + zeros
 
-    def test_single_view_copy_partition(self):
-        input_shape = (2, 10)
-        module = SingleViewCopyModule([1, 20])
 
-        ep = to_quantized_edge_program(module, input_shape).exported_program()
+class AddMulSubNoOpModel(torch.nn.Module):
+    def __init__(self, shape: tuple[int, ...]):
+        super().__init__()
+        self.shape = shape
 
-        # Make sure the `view_copy` was not delegated.
-        assert graph_contains_any_of_ops(
-            ep.graph, [exir_ops.edge.aten.view_copy.default]
-        )
-        assert not any("delegate" in n.name for n in ep.graph.nodes)
+    def forward(self, x):
+        zero1 = torch.zeros(self.shape)
+        zero2 = torch.zeros(self.shape)
+        one = torch.ones(self.shape)
 
-    def test_single_view_copy_partition__forced_delegation(self):
-        input_shape = (2, 10)
-        module = SingleViewCopyModule([1, 20])
+        x = zero1 + x
+        x = one * x
+        x = x - zero2
 
-        def _supported_partitioning(*_):
-            return True
+        return x
 
-        # Replace the partition support check function, to accept anything.
-        original_supports_partitioning_result = (
-            ViewCopyConverter.supports_partitioning_result
-        )
-        ViewCopyConverter.supports_partitioning_result = _supported_partitioning
 
-        with self.assertRaises(RuntimeError) as e:
-            to_quantized_edge_program(module, input_shape).exported_program()
-        assert (
-            str(e.exception)
-            == "Model converted with neutron-converter does not contain a NeutronGraph node."
-        )
+@pytest.fixture(autouse=True)
+def reseed_model_per_test_run():
+    torch.manual_seed(23)
+    np.random.seed(23)
 
-        # Return to the original partition support check function.
-        ViewCopyConverter.supports_partitioning_result = (
-            original_supports_partitioning_result
-        )
+
+def test_single_view_copy_partition():
+    input_shape = (2, 10)
+    module = SingleViewCopyModule([1, 20])
+
+    ep = to_quantized_edge_program(module, input_shape).exported_program()
+
+    # Make sure the `view_copy` was not delegated.
+    assert graph_contains_any_of_ops(ep.graph, [exir_ops.edge.aten.view_copy.default])
+    assert not graph_contains_any_of_ops(ep.graph, [ExecutorchDelegateCall])
+
+
+def test_single_view_copy_partition__forced_delegation():
+    input_shape = (2, 10)
+    module = SingleViewCopyModule([1, 20])
+
+    def _supported_partitioning(*_):
+        return True
+
+    # Replace the partition support check function, to accept anything.
+    original_supports_partitioning_result = (
+        ViewCopyConverter.supports_partitioning_result
+    )
+    ViewCopyConverter.supports_partitioning_result = _supported_partitioning
+
+    # Force the partitioner to delegate the node.
+    cdo = CustomDelegationOptions(allow_no_op_partitions=True)
+
+    with pytest.raises(
+        RuntimeError,
+        match="Model converted with neutron-converter does not contain a NeutronGraph node.",
+    ):
+        to_quantized_edge_program(
+            module, input_shape, custom_delegation_options=cdo
+        ).exported_program()
+
+    # Return to the original partition support check function.
+    ViewCopyConverter.supports_partitioning_result = (
+        original_supports_partitioning_result
+    )
+
+
+def test_noop_partitions__concatenate_one_tensor_and_add_zeros():
+    input_shape = (1, 2, 3, 4)
+    module = ConcatAddNoOpModel(input_shape)
+
+    ep = to_quantized_edge_program(
+        module,
+        input_shape,
+    ).exported_program()
+
+    # Make sure neither the `cat` nor the `add` was delegated
+    assert not any(
+        n.target == torch._higher_order_ops.executorch_call_delegate
+        for n in ep.graph.nodes
+    )
+    assert graph_contains_any_of_ops(
+        ep.graph,
+        [
+            exir_ops.edge.aten.cat.default,
+            exir_ops.edge.aten.add.Tensor,
+        ],
+    )
+
+
+def test_noop_partitions__concatenate_one_tensor_and_add_zeros__forced_delegation():
+    input_shape = (1, 2, 3, 4)
+    module = ConcatAddNoOpModel(input_shape)
+
+    # Force the partitioner to delegate the node.
+    cdo = CustomDelegationOptions(allow_no_op_partitions=True)
+
+    with pytest.raises(
+        RuntimeError,
+        match="Model converted with neutron-converter does not contain a NeutronGraph node.",
+    ):
+        to_quantized_edge_program(
+            module, input_shape, custom_delegation_options=cdo
+        ).exported_program()
+
+
+def test_noop_partitions__add_mul_sub_div():
+    input_shape = (6, 7)
+    module = AddMulSubNoOpModel(input_shape)
+
+    ep = to_quantized_edge_program(
+        module,
+        input_shape,
+    ).exported_program()
+
+    # Make sure nothing was delegated.
+    assert not any(
+        n.target == torch._higher_order_ops.executorch_call_delegate
+        for n in ep.graph.nodes
+    )
+    assert graph_contains_any_of_ops(
+        ep.graph,
+        [
+            exir_ops.edge.aten.add.Tensor,
+            exir_ops.edge.aten.mul.Tensor,
+            exir_ops.edge.aten.sub.Tensor,
+        ],
+    )
+
+
+def test_noop_partitions__add_mul_sub_div__forced_delegation():
+    input_shape = (6, 7)
+    module = AddMulSubNoOpModel(input_shape)
+
+    # Force the partitioner to delegate the node.
+    cdo = CustomDelegationOptions(allow_no_op_partitions=True)
+
+    with pytest.raises(
+        RuntimeError,
+        match="Model converted with neutron-converter does not contain a NeutronGraph node.",
+    ):
+        to_quantized_edge_program(
+            module, input_shape, custom_delegation_options=cdo
+        ).exported_program()


### PR DESCRIPTION
### Summary
If a partition delegated no Neutron only contained no-ops, it would cause a crash. This PR identifies such cases and prohibits their delegation.

### Test plan
Unit-tests provided.