### PR TITLE
Arm backend: Allow log1p in test naming

### DIFF
--- a/backends/arm/scripts/collect_testname_resources.py
+++ b/backends/arm/scripts/collect_testname_resources.py
@@ -35,6 +35,7 @@ _CUSTOM_EDGE_OPS = [
     "linear.default",
     "maximum.default",
     "mean.default",
+    "log1p.default",
     "multihead_attention.default",
     "adaptive_avg_pool2d.default",
     "bitwise_right_shift.Tensor",


### PR DESCRIPTION
The pre-push hook rejected test_log1p_* because log1p was missing from the allowed op list. Add log1p.default to the custom edge ops set so naming validation accepts log1p tests.


cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai