### PR TITLE
Fix docs upload job being canceled mid-operation

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -13,6 +13,10 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+concurrency:
+  group: docs-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main


### PR DESCRIPTION
Add workflow-level concurrency that only allows cancellation for PR builds, ensuring push/schedule builds always complete.
