### PR TITLE
Fix heap-buffer-overflow vulnerability in WAV file loader

### DIFF
--- a/test/utils/DeathTest.h
+++ b/test/utils/DeathTest.h
@@ -15,6 +15,8 @@
 
 #include <gtest/gtest.h>
 
+#include <executorch/runtime/platform/log.h>
+
 #ifndef ET_BUILD_MODE_COV
 #define ET_BUILD_MODE_COV 0
 #endif // ET_BUILD_MODE_COV
@@ -28,6 +30,17 @@
  * tests.
  */
 #define ET_EXPECT_DEATH(_statement, _matcher) ((void)0)
+
+#elif defined(_WIN32) || !ET_LOG_ENABLED
+
+/**
+ * On Windows, death test stderr matching is unreliable.
+ * When logging is disabled, ET_CHECK_MSG doesn't output error messages.
+ * In both cases, we ignore the matcher and only verify that the statement
+ * causes the process to terminate.
+ */
+#define ET_EXPECT_DEATH(_statement, _matcher) \
+  EXPECT_DEATH_IF_SUPPORTED(_statement, "")
 
 #else // ET_BUILD_MODE_COV
 


### PR DESCRIPTION
This PR fixes a security vulnerability in the WAV file loader where a malicious WAV file could trigger an out-of-bounds heap read by providing an inflated `Subchunk2Size` value in the file header.

The `load_wav_audio_data` function in `extension/llm/runner/wav_loader.h` reads `data_offset` and `data_size` directly from the WAV file header without validating that the claimed data size falls within the bounds of the actual file buffer. When `Subchunk2Size` exceeds the actual file size, the copy operation reads beyond the allocated heap buffer, potentially exposing sensitive data.

This vulnerability affects all code paths that process user-supplied WAV files through the ExecuTorch audio loading API, including the Whisper, Parakeet, and Voxtral example applications.

Added bounds validation in two locations:

1. **`load_wav_header`**: Validates that the data chunk header can be safely read before accessing `Subchunk2Size`
2. **`load_wav_audio_data`**: Validates that `data_offset + data_size <= buffer.size()` before performing any copy operations

Malicious WAV files with inflated size values are now rejected with a clear error message before any memory access beyond the buffer bounds can occur.

Added three new test cases:
- `LoadAudioDataRejectsInflatedSubchunk2Size`: Tests rejection of a WAV file claiming 1MB of data but containing only 4 bytes
- `LoadAudioDataRejectsDataOffsetBeyondBounds`: Tests rejection when data offset points beyond file bounds
- `LoadAudioDataAcceptsExactSizeMatch`: Verifies legitimate WAV files continue to work

Also updated `ET_EXPECT_DEATH` macro in `test/utils/DeathTest.h` to handle builds with logging disabled (`!ET_LOG_ENABLED`).

- `extension/llm/runner/wav_loader.h` - Added bounds validation
- `extension/llm/runner/test/test_wav_loader.cpp` - Added security tests
- `test/utils/DeathTest.h` - Updated macro to handle logging-disabled builds

