### PR TITLE
Add BC wrapper for generate() with temperature parameter

### DIFF
--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmModule.java
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmModule.java
@@ -150,6 +150,18 @@ public class LlmModule {
    * @param seqLen sequence length
    * @param llmCallback callback object to receive results
    * @param echo indicate whether to echo the input prompt or not (text completion vs chat)
+   */
+  public int generate(String prompt, int seqLen, LlmCallback llmCallback, boolean echo) {
+    return generate(prompt, seqLen, llmCallback, echo, DEFAULT_TEMPERATURE);
+  }
+
+  /**
+   * Start generating tokens from the module.
+   *
+   * @param prompt Input prompt
+   * @param seqLen sequence length
+   * @param llmCallback callback object to receive results
+   * @param echo indicate whether to echo the input prompt or not (text completion vs chat)
    * @param temperature temperature for sampling (use negative value to use module default)
    */
   public native int generate(


### PR DESCRIPTION
Fixes backwards compatibility break from commit 015c9ac6 which changed the native generate() signature to add a temperature parameter. This adds a wrapper that preserves the old 4-parameter public API.
