### PR TITLE
Arm backend: Fix VGF backend calling

### DIFF
--- a/backends/arm/vgf/backend.py
+++ b/backends/arm/vgf/backend.py
@@ -156,8 +156,8 @@ def vgf_compile(
             vgf_path,
         ]
         try:
-            subprocess.run(  # nosec B602 - shell invocation constrained to trusted converter binary
-                conversion_command, shell=True, check=True, capture_output=True
+            subprocess.run(  # nosec B602, B603 - shell invocation constrained to trusted converter binary with trusted inputs
+                conversion_command, shell=False, check=True, capture_output=True
             )
         except subprocess.CalledProcessError as process_error:
             conversion_command_str = " ".join(conversion_command)


### PR DESCRIPTION
### Summary
Setting shell=True, makes run only use the first command in the list, causing model-converter to read from stdin instead of the supplied flatbuffer argument. Switch to shell=False to run the commands as expected.

### Test plan
Tested through ci tests.

cc @freddan80 @zingo @oscarandersson8218 @digantdesai