### PR TITLE
Move several edge passes to the iterative section.

### DIFF
--- a/backends/cadence/aot/replace_ops.py
+++ b/backends/cadence/aot/replace_ops.py
@@ -554,9 +554,9 @@ class ReplaceRepeatWithCatPass(RemoveOrReplacePassInterface):
         # the output of repeat will be a higher-dimensional tensor. We reshape
         # the input so that it has the same dimensionality as the output tensor.
         diff = len(repeats) - len(in_shape)
-        assert (
-            diff >= 0
-        ), "Repeat arg malformed: expected a repeat along each dimension of input tensor"
+        assert diff >= 0, (
+            "Repeat arg malformed: expected a repeat along each dimension of input tensor"
+        )
 
         graph = node.graph
         result_node = in_tensor
@@ -1662,16 +1662,6 @@ class ReplaceNopTransposeOrPermuteWithViewPass(RemoveOrReplacePassInterface):
 
         return False
 
-    def call(self, graph_module: torch.fx.GraphModule) -> PassResult:
-        result = super().call(graph_module)
-
-        # TODO: I tried conditionally running this only if the above made any modifications,
-        # but for whatever reason was getting numerical failures in
-        # test_mtl_e2e_test_a16w8_two_layers_turing_3_1_1k. Always running this pass
-        # resolved that issue.
-        fuse_cascaded_result = FuseCascadedViewOps().call(result.graph_module)
-        return PassResult(fuse_cascaded_result.graph_module, True)
-
 
 @register_cadence_pass(CadencePassAttribute(opt_level=2))
 class ReplaceLinearWithFullyConnectedOpPass(RemoveOrReplacePassInterface):
@@ -1792,7 +1782,6 @@ class ReplaceInfArgInFullWithValuePass(RemoveOrReplacePassInterface):
         return [exir_ops.edge.aten.full.default]
 
     def maybe_remove_or_replace(self, node: torch.fx.Node) -> bool:
-
         new_args = list(node.args)
         fill_value = node.args[1]
         if fill_value == float("-inf"):


### PR DESCRIPTION
Summary:
Removing the inline call to FuseCascadedViewOps from ReplaceNopTransposeOrPermuteWithViewPass entirely. It breaks the modified flag of the pass.

Reviewed By: DrJessop

Differential Revision: D91521344


