### PR TITLE
OOB read in as_strided_copy

### DIFF
--- a/kernels/portable/cpu/util/targets.bzl
+++ b/kernels/portable/cpu/util/targets.bzl
@@ -155,7 +155,7 @@ def define_common_targets():
         deps = [
             "//executorch/runtime/kernel:kernel_includes",
         ],
-        visibility = ["//executorch/kernels/portable/cpu/...", "//executorch/kernels/optimized/cpu/..."],
+        visibility = ["//executorch/kernels/portable/cpu/...", "//executorch/kernels/optimized/cpu/...", "//executorch/kernels/test/..."],
     )
 
     runtime.cxx_library(

--- a/kernels/test/targets.bzl
+++ b/kernels/test/targets.bzl
@@ -1,13 +1,19 @@
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 load("@fbsource//xplat/executorch/kernels/test:util.bzl", "codegen_function_header_wrapper", "op_test")
 
-def _common_op_test(name, kernels):
+def _common_op_test(name, kernels, extra_deps = []):
     """
     Defines test targets in format of <kernel>_op_<op-name>_test
     For ATen kernel testing, let's use portable functions.yaml for tested ops.
+
+    Args:
+        name: The test name (e.g., "op_add_test").
+        kernels: List of kernel names to test (e.g., ["aten", "portable"]).
+        extra_deps: Optional list of additional dependencies to add to all
+            kernel variants of this test.
     """
     for kernel in kernels:
-        deps = [":function_header_wrapper_{}".format(kernel)]
+        deps = [":function_header_wrapper_{}".format(kernel)] + extra_deps
         op_test(name, kernel_name = kernel, use_kernel_prefix = True, deps = deps)
 
 def define_common_targets():
@@ -178,7 +184,10 @@ def define_common_targets():
     _common_op_test("op_arange_test", ["aten", "portable"])
     _common_op_test("op_argmax_test", ["aten", "portable"])
     _common_op_test("op_argmin_test", ["aten", "portable"])
-    _common_op_test("op_as_strided_copy_test", ["aten", "portable"])
+    _common_op_test("op_as_strided_copy_test", ["aten", "portable"], extra_deps = [
+        "//executorch/kernels/portable/cpu/util:copy_ops_util",
+        "//executorch/test/utils:utils",
+    ])
     _common_op_test("op_asin_test", ["aten", "portable"])
     _common_op_test("op_asinh_test", ["aten", "portable"])
     _common_op_test("op_atan_test", ["aten", "portable"])


### PR DESCRIPTION
Summary:
Make sure the last element requested by the output tensor does not exceed the size of the input tensor.

e.g. if we have input tensor with 100 elements, and requested offset = 2, output size of [5, 2] and strides [50, 10], then the last element would be

offset + ((size[0] - 1) * strides[0]) + ((size[1] - 1)*strides[1])

2 + 4 * 50 + 1 * 10 =  212

which is out of bounds for tensor with 100 elements.

Differential Revision: D91723375


