### PR TITLE
New exported program pass manager and exported program passes (#16986)

### DIFF
--- a/backends/arm/test/tester/test_pipeline.py
+++ b/backends/arm/test/tester/test_pipeline.py
@@ -48,7 +48,7 @@ from executorch.backends.arm.util._factory import create_quantizer
 from executorch.backends.arm.vgf.compile_spec import VgfCompileSpec
 from executorch.backends.test.harness.stages import StageType
 from executorch.exir.pass_base import ExportPass
-from torch._export.pass_base import PassType
+from executorch.exir.pass_manager import PassType
 from torch.export.graph_signature import InputKind, OutputKind
 from torchao.quantization.pt2e.quantizer import QuantizationSpec
 

--- a/backends/qualcomm/_passes/recompose_pad_maxpool2d.py
+++ b/backends/qualcomm/_passes/recompose_pad_maxpool2d.py
@@ -13,12 +13,8 @@ from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass, PassResult
 from executorch.exir.passes import dead_code_elimination_pass
 
-from torch._subclasses.fake_tensor import FakeTensorMode
 
-
-def add_fake_tensor_to_node(padding_node, input_shape, padding_args, dtype):
-    fake_mode = FakeTensorMode()
-
+def add_fake_tensor_to_node(padding_node, input_shape, padding_args, dtype, fake_mode):
     with fake_mode:
         batch, channels, height, width = input_shape
         pad_left, pad_right, pad_top, pad_bottom = padding_args
@@ -114,6 +110,7 @@ class RecomposePadMaxPool2d(ExportPass):
                         input_node.meta["val"].shape,
                         padding,
                         input_node.meta["val"].dtype,
+                        input_node.meta["val"].fake_mode,
                     )
                     if quant_attrs:
                         padding_node.meta["quant_attrs"] = node.meta["quant_attrs"]

--- a/backends/qualcomm/_passes/utils.py
+++ b/backends/qualcomm/_passes/utils.py
@@ -137,7 +137,23 @@ def copy_nn_module_stack(src, target):
         target.meta["nn_module_stack"] = value
 
 
-def merge_decomposed_graph(
+def _unify_fake_mode(node: torch.fx.Node, fake_mode) -> None:
+    val = node.meta.get("val")
+    if val is None:
+        return
+    if isinstance(val, FakeTensor) and val.fake_mode is not fake_mode:
+        node.meta["val"] = fake_mode.from_tensor(val)
+    elif isinstance(val, (list, tuple)):
+        unified = []
+        for v in val:
+            if isinstance(v, FakeTensor) and v.fake_mode is not fake_mode:
+                unified.append(fake_mode.from_tensor(v))
+            else:
+                unified.append(v)
+        node.meta["val"] = type(val)(unified)
+
+
+def merge_decomposed_graph(  # noqa: C901
     remap: Dict[str, torch.fx.Node],
     target_node: torch.fx.Node,
     target_graph: torch.fx.GraphModule,
@@ -148,6 +164,16 @@ def merge_decomposed_graph(
         [torch.fx.Node, torch.fx.Node, Dict[str, torch.fx.Node]], None
     ] = None,
 ) -> None:
+    target_fake_mode = None
+    target_val = target_node.meta.get("val")
+    if isinstance(target_val, FakeTensor):
+        target_fake_mode = target_val.fake_mode
+    elif isinstance(target_val, (list, tuple)):
+        for v in target_val:
+            if isinstance(v, FakeTensor):
+                target_fake_mode = v.fake_mode
+                break
+
     def default_output_process(node):
         for user in node.users.copy():
             # remap
@@ -170,10 +196,13 @@ def merge_decomposed_graph(
                 # replace node map from string to graph node
                 remap[decomposed_node] = remap.pop(decomposed_node.name)
             else:
-                remap[decomposed_node] = target_graph.node_copy(
+                copied = target_graph.node_copy(
                     decomposed_node,
                     arg_transform=lambda x, remap=remap: remap[x],
                 )
+                if target_fake_mode is not None:
+                    _unify_fake_mode(copied, target_fake_mode)
+                remap[decomposed_node] = copied
 
 
 def is_float_tensor(node: torch.fx.Node) -> bool:

--- a/exir/BUCK
+++ b/exir/BUCK
@@ -260,13 +260,25 @@ fbcode_target(_kind = runtime.python_library,
 )
 
 fbcode_target(_kind = runtime.python_library,
+    name = "_program_utils",
+    srcs = [
+        "_program_utils.py",
+    ],
+    deps = [
+        "//caffe2:torch",
+    ],
+)
+
+fbcode_target(_kind = runtime.python_library,
     name = "pass_manager",
     srcs = [
         "pass_manager.py",
     ],
     deps = [
         "fbsource//third-party/pypi/typing-extensions:typing-extensions",
+        ":_program_utils",
         ":error",
+        ":pass_base",
         "//caffe2:torch",
     ],
 )

--- a/exir/_program_utils.py
+++ b/exir/_program_utils.py
@@ -1,0 +1,104 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+import torch
+from torch.export.exported_program import (
+    ConstantArgument,
+    ExportGraphSignature,
+    InputSpec,
+    OutputSpec,
+)
+
+
+def _get_updated_range_constraints(gm):
+    def get_shape_env(gm):
+        vals = [
+            node.meta["val"]
+            for node in gm.graph.nodes
+            if node.meta.get("val", None) is not None
+        ]
+        from torch._guards import detect_fake_mode  # type: ignore[21]
+
+        fake_mode = detect_fake_mode(vals)
+        if fake_mode is not None:
+            return fake_mode.shape_env
+        for v in vals:
+            if isinstance(v, torch.SymInt):
+                return v.node.shape_env
+
+    shape_env = get_shape_env(gm)
+    if shape_env is None:
+        return {}
+    range_constraints = {
+        shape_env.replacements.get(k, k): v for k, v in shape_env.var_to_range.items()
+    }
+    # Only when we have an unbacked symint, and it's used as constructor inputs,
+    # runtime_var_to_range will make a difference compated to var_to_range.
+    # e.g. [2, oo) -> [0, oo)
+    for k, v in shape_env.var_to_range.items():
+        if k not in shape_env.replacements:
+            range_constraints[k] = v
+    return range_constraints
+
+
+def _get_updated_graph_signature(
+    old_signature: ExportGraphSignature,
+    new_gm: torch.fx.GraphModule,
+) -> ExportGraphSignature:
+    """
+    Update the graph signature's user_input/user_outputs.
+    """
+    new_input_specs = []
+    i = 0
+    for node in new_gm.graph.nodes:
+        if node.op != "placeholder":
+            continue
+
+        assert i < len(
+            old_signature.input_specs
+        ), "Number of inputs changed after transformation"
+        old_input_spec = old_signature.input_specs[i]
+        arg = (
+            old_input_spec.arg
+            if isinstance(old_input_spec.arg, ConstantArgument)
+            # pyre-fixme[20]: Argument `class_fqn` expected.
+            else type(old_input_spec.arg)(node.name)
+        )
+        new_input_specs.append(
+            InputSpec(
+                old_input_spec.kind,
+                arg,
+                old_input_spec.target,
+                persistent=old_input_spec.persistent,
+            )
+        )
+        i += 1
+
+    output_node = new_gm.graph.output_node()
+    assert output_node.op == "output"
+
+    new_output_specs = []
+    for i, node in enumerate(output_node.args[0]):
+        assert i < len(
+            old_signature.output_specs
+        ), "Number of outputs changed after transformation"
+        old_output_spec = old_signature.output_specs[i]
+        arg = (
+            old_output_spec.arg
+            if isinstance(old_output_spec.arg, ConstantArgument)
+            # pyre-fixme[20]: Argument `class_fqn` expected.
+            else type(old_output_spec.arg)(node.name)
+        )
+        new_output_specs.append(
+            OutputSpec(old_output_spec.kind, arg, old_output_spec.target)
+        )
+
+    new_signature = ExportGraphSignature(
+        input_specs=new_input_specs, output_specs=new_output_specs
+    )
+    return new_signature

--- a/exir/pass_base.py
+++ b/exir/pass_base.py
@@ -6,10 +6,11 @@
 # LICENSE file in the root directory of this source tree.
 
 # pyre-strict
-
 import operator
 import traceback
+from abc import ABC, abstractmethod
 from contextlib import nullcontext
+from dataclasses import dataclass
 from typing import (
     Any,
     Callable,
@@ -27,9 +28,7 @@ from typing import (
 
 import torch
 from executorch.exir import memory
-
 from executorch.exir.delegate import executorch_call_delegate, is_lowered_module
-
 from executorch.exir.dialects.edge._ops import EdgeOpOverload
 from executorch.exir.error import ExportError, ExportErrorType
 from torch import fx
@@ -37,6 +36,7 @@ from torch._dispatch.python import enable_python_dispatcher
 from torch._subclasses import FakeTensorMode, UnsupportedFakeTensorException
 from torch._subclasses.fake_tensor import FakeTensor
 from torch._subclasses.functional_tensor import FunctionalTensor, FunctionalTensorMode
+from torch.export import ExportedProgram
 from torch.fx import traceback as fx_traceback
 from torch.fx.experimental.proxy_tensor import PythonKeyTracer
 from torch.fx.graph import CodeGen
@@ -180,6 +180,58 @@ class ProxyValue:
 
 class ExportPassBaseError(RuntimeError):
     pass
+
+
+@dataclass(frozen=True)
+class ExportedProgramPassResult:
+    exported_program: ExportedProgram
+    modified: bool
+
+
+class ExportedProgramPassBase(ABC):
+    """
+    Base interface for implementing passes that operate on ExportedProgram.
+    """
+
+    def __call__(self, exported_program: ExportedProgram) -> ExportedProgramPassResult:
+        """
+        Runs the precondition check, the pass itself, and the postcondition check.
+        """
+
+        self.requires(exported_program)
+        res = self.call(exported_program)
+        self.ensures(exported_program)
+        return res
+
+    @abstractmethod
+    def call(self, exported_program: ExportedProgram) -> ExportedProgramPassResult:
+        """
+        The pass that is run through the given exported program. To implement a
+        pass, it is required to implement this function.
+
+        Args:
+            exported_program: The exported program we will run a pass on
+        """
+
+    def requires(self, exported_program: ExportedProgram) -> None:  # noqa: B027
+        """
+        This function will be called before the pass is run and will check that
+        the given exported program contains the preconditions needed to run the
+        pass. It is not required to implement this function.
+
+        Args:
+            exported_program: The exported program we will run checks on
+        """
+
+    def ensures(self, exported_program: ExportedProgram) -> None:  # noqa: B027
+        """
+        This function will be called after the pass is run and will check that
+        the given exported program contains the postconditions needed to run the
+        pass. It is not required to implement this function.
+
+        Args:
+            exported_program: The exported program we will run checks on
+        """
 
 
 class _ExportPassBase(PassBase):

--- a/exir/pass_manager.py
+++ b/exir/pass_manager.py
@@ -5,28 +5,46 @@
 # LICENSE file in the root directory of this source tree.
 
 # pyre-strict
-
-from typing import Callable, List, Optional, Union
+import copy
+import inspect
+import logging
+from typing import Callable, List, Optional, Type, TypeAlias, Union
 
 import torch
 import torch.fx.passes.infra.pass_manager as fx
 import torch.utils._pytree as pytree
+from executorch.exir._program_utils import (
+    _get_updated_graph_signature,
+    _get_updated_range_constraints,
+)
 from executorch.exir.error import ExportError, ExportErrorType
+from executorch.exir.pass_base import ExportedProgramPassBase, ExportedProgramPassResult
+from torch._export.verifier import Verifier
+from torch.export import ExportedProgram
 from torch.fx.passes.infra.pass_base import PassResult
-from typing_extensions import TypeAlias
+from torch.fx.passes.infra.pass_manager import pass_result_wrapper
 
-PassType: TypeAlias = Callable[[torch.fx.GraphModule], Optional[PassResult]]
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.WARNING)
+
+PassType: TypeAlias = Union[
+    ExportedProgramPassBase, Callable[[torch.fx.GraphModule], Optional[PassResult]]
+]
+
+
+def _get_pass_name(fn: PassType) -> str:
+    """Returns a human-readable name for a pass."""
+    return fn.__name__ if inspect.isfunction(fn) else type(fn).__name__
 
 
 class PassManager(fx.PassManager):
     """
-    Class to run multiple passes on a given graph module. The PassManager is
-    callable so to run it, we can just call the PassManager instance.
+    Runs multiple passes on a GraphModule.
 
-    Private Attributes:
-        * **passes**: A list of callable passes
-        * **params**: An instance of PassManagerParams containing the result of the
-            flags set in the constructor.
+    This is the legacy PassManager that extends torch.fx.passes.infra.pass_manager.PassManager.
+    Use this when you need to run passes on a GraphModule directly.
+
+    For running passes on ExportedProgram, use ExportedProgramPassManager instead.
     """
 
     def __init__(
@@ -34,14 +52,11 @@ class PassManager(fx.PassManager):
         passes: Optional[Union[List[PassType], List[List[PassType]]]] = None,
         run_checks_after_each_pass: bool = False,
         suppress_check_failures: bool = False,
+        steps: int = 1,
     ) -> None:
-        r"""
-        Args:
-            passes: A list of passes
-            enable_debug_pass: set to true to enable the debug passes
-            run_checks_after_each_pass: whether to run checks and linting after each pass
-        """
-
+        logger.warning(
+            "PassManager is deprecated. Please use ExportedProgramPassManager instead."
+        )
         # Flatten the passes to a list of callables
         passes = passes if passes else []
         flattened_passes = [
@@ -52,6 +67,7 @@ class PassManager(fx.PassManager):
             flattened_passes,
             run_checks_after_each_pass=run_checks_after_each_pass,
             suppress_check_failures=suppress_check_failures,
+            steps=steps,
         )
 
     def check(self, module: torch.nn.Module) -> None:
@@ -65,10 +81,9 @@ class PassManager(fx.PassManager):
               node's spec field is a tuple)
             - Ensure that the graph module has type torch.fx.GraphModule
         """
-        assert isinstance(module, fx.GraphModule)
+        assert isinstance(module, torch.fx.GraphModule)
         module.recompile()
         module.graph.lint()
-        # TODO(qihan): use verifier.check_is_exir
 
         for node in module.graph.nodes:
             if node.op == "call_method":
@@ -76,3 +91,151 @@ class PassManager(fx.PassManager):
                     ExportErrorType.NOT_SUPPORTED,
                     f"call_method `{node}` is not supported except for backend delegate.",
                 )
+
+
+class ExportedProgramPassManager(fx.PassManager):
+    """
+    Runs multiple passes on an ExportedProgram.
+
+    This PassManager is specifically designed for ExportedProgram and supports
+    both GraphModule-only passes and ExportedProgram-aware passes.
+
+    For running passes on GraphModule directly, use PassManager instead.
+    """
+
+    def __init__(
+        self,
+        passes: Optional[Union[List[PassType], List[List[PassType]]]] = None,
+        constraints: Optional[List[Callable[[Callable, Callable], bool]]] = None,
+        run_checks_after_each_pass: bool = False,
+        suppress_check_failures: bool = False,
+        steps: int = 1,
+    ) -> None:
+        wrapped_passes = (
+            [
+                (
+                    fn
+                    if isinstance(fn, ExportedProgramPassBase)
+                    else pass_result_wrapper(fn)
+                )
+                for fn in pytree.tree_flatten(passes)[0]
+            ]
+            if passes
+            else []
+        )
+
+        super().__init__(
+            wrapped_passes,
+            constraints=constraints,
+            run_checks_after_each_pass=run_checks_after_each_pass,
+            suppress_check_failures=suppress_check_failures,
+            steps=steps,
+        )
+
+    def check(self, exported_program: ExportedProgram) -> None:
+        """Validates graph module invariants."""
+        graph_module = exported_program.graph_module
+        graph_module.recompile()
+        graph_module.graph.lint()
+
+        for node in graph_module.graph.nodes:
+            if node.op == "call_method":
+                raise ExportError(
+                    ExportErrorType.NOT_SUPPORTED,
+                    f"call_method `{node}` is not supported except for backend delegate.",
+                )
+
+        exported_program.validate()
+
+    # pyre-ignore[14]: Intentionally overriding with different signature for ExportedProgram
+    def __call__(  # noqa: C901
+        self,
+        exported_program: ExportedProgram,
+        override_verifiers: Optional[list[Type[Verifier]]] = None,
+    ) -> ExportedProgramPassResult:
+        """
+        Runs passes on an ExportedProgram.
+
+        Handles both GraphModule-only passes and ExportedProgram-aware passes. Will create a shallow copy of the exported program before running passes.
+
+        Args:
+            exported_program: The exported program to transform.
+
+        Returns:
+            ExportedProgramPassResult containing the transformed program.
+        """
+        if not self._validated:
+            self.solve_constraints()
+
+        exported_program = copy.copy(exported_program)
+
+        if override_verifiers:
+            exported_program._verifiers = override_verifiers
+
+        self.check(exported_program)
+
+        overall_modified = False
+
+        for _ in range(self.steps):
+            step_modified = False
+
+            for i, fn in enumerate(self.passes):
+                pass_modified = False
+                try:
+                    if not isinstance(fn, ExportedProgramPassBase):
+                        res = fn(exported_program.graph_module)
+                        if res is None:
+                            raise TypeError(
+                                f"The result of pass {_get_pass_name(fn)} should be type PassResult. "
+                                "Please wrap it with pass_result_wrapper()"
+                            )
+
+                        if res.modified:
+                            # Not running _update_exported_program_graph_module here because it is
+                            # possible that the verifier will fail upon new ExportedProgram construction,
+                            # and we should only run verification after each pass if
+                            # run_checks_after_each_pass is True.
+                            res.graph_module.recompile()
+                            exported_program._graph_module = res.graph_module
+                            exported_program._graph_signature = (
+                                _get_updated_graph_signature(
+                                    exported_program.graph_signature,
+                                    res.graph_module,
+                                )
+                            )
+                            exported_program._range_constraints = (
+                                _get_updated_range_constraints(res.graph_module)
+                            )
+                            pass_modified = True
+
+                    else:
+                        assert isinstance(fn, ExportedProgramPassBase)
+                        ep_res = fn(exported_program)
+                        exported_program = ep_res.exported_program
+
+                        if ep_res.modified:
+                            pass_modified = True
+                            exported_program.graph_module.recompile()
+
+                    if self.run_checks_after_each_pass:
+                        self.check(exported_program)
+
+                    if pass_modified:
+                        step_modified = True
+                        logger.debug(
+                            "Graph after pass '%s': %s",
+                            _get_pass_name(fn),
+                            exported_program.graph_module.graph,
+                        )
+
+                except Exception as e:
+                    prev_names = [_get_pass_name(p) for p in self.passes[:i]]
+                    msg = f"An error occurred when running the '{_get_pass_name(fn)}' pass after the following passes: {prev_names}"
+                    raise Exception(msg) from e  # noqa: TRY002
+
+            overall_modified = overall_modified or step_modified
+            if not step_modified:
+                break
+
+        self.check(exported_program)
+        return ExportedProgramPassResult(exported_program, overall_modified)

--- a/exir/program/BUCK
+++ b/exir/program/BUCK
@@ -22,6 +22,7 @@ fbcode_target(_kind = runtime.python_library,
     ],
     deps = [
         "//caffe2:torch",
+        "//executorch/exir:_program_utils",
         "//executorch/exir:error",
         "//executorch/exir:graph_module",
         "//executorch/exir:pass_base",

--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -5,8 +5,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# pyre-unsafe
-
+# pyre-strict
 import copy
 import io
 import logging
@@ -38,7 +37,8 @@ from executorch.exir.graph_module import get_control_flow_submodules
 from executorch.exir.operator.convert import _pybind_schema_to_native_schema
 from executorch.exir.operator.util import _QUANT_PRIMITIVES
 from executorch.exir.pass_base import PassBase
-from executorch.exir.pass_manager import PassType
+from executorch.exir.pass_manager import ExportedProgramPassManager, PassType
+
 from executorch.exir.passes import (
     base_post_op_replace_passes,
     base_pre_op_replace_passes,
@@ -88,17 +88,11 @@ from torch.export import ExportedProgram
 from torch.export._remove_auto_functionalized_pass import (
     unsafe_remove_auto_functionalized_pass,
 )
-from torch.export.exported_program import (
-    ConstantArgument,
-    ExportGraphSignature,
-    InputKind,
-    InputSpec,
-    OutputSpec,
-    TensorArgument,
-)
+from torch.export.exported_program import InputKind, InputSpec, TensorArgument
 from torch.fx import _pytree as fx_pytree
 from torch.fx._compatibility import compatibility
-from torch.fx.passes.infra.pass_manager import PassManager
+from torch.fx.passes.infra.pass_manager import PassManager as GraphModulePassManager
+
 from torch.utils import _pytree as pytree
 
 Val = Any
@@ -131,93 +125,10 @@ aten_op_to_transform_op = {}
 transform_op_to_aten_op = {}
 
 
-def _get_updated_range_constraints(gm):
-    def get_shape_env(gm):
-        vals = [
-            node.meta["val"]
-            for node in gm.graph.nodes
-            if node.meta.get("val", None) is not None
-        ]
-        from torch._guards import detect_fake_mode  # type: ignore[21]
-
-        fake_mode = detect_fake_mode(vals)
-        if fake_mode is not None:
-            return fake_mode.shape_env
-        for v in vals:
-            if isinstance(v, torch.SymInt):
-                return v.node.shape_env
-
-    shape_env = get_shape_env(gm)
-    if shape_env is None:
-        return {}
-    range_constraints = {
-        shape_env.replacements.get(k, k): v for k, v in shape_env.var_to_range.items()
-    }
-    # Only when we have an unbacked symint, and it's used as constructor inputs,
-    # runtime_var_to_range will make a difference compated to var_to_range.
-    # e.g. [2, oo) -> [0, oo)
-    for k, v in shape_env.var_to_range.items():
-        if k not in shape_env.replacements:
-            range_constraints[k] = v
-    return range_constraints
-
-
-def _get_updated_graph_signature(
-    old_signature: ExportGraphSignature,
-    new_gm: torch.fx.GraphModule,
-) -> ExportGraphSignature:
-    """
-    Update the graph signature's user_input/user_outputs.
-    """
-    new_input_specs = []
-    i = 0
-    for node in new_gm.graph.nodes:
-        if node.op != "placeholder":
-            continue
-
-        assert i < len(
-            old_signature.input_specs
-        ), "Number of inputs changed after transformation"
-        old_input_spec = old_signature.input_specs[i]
-        arg = (
-            old_input_spec.arg
-            if isinstance(old_input_spec.arg, ConstantArgument)
-            # pyre-fixme[20]: Argument `class_fqn` expected.
-            else type(old_input_spec.arg)(node.name)
-        )
-        new_input_specs.append(
-            InputSpec(
-                old_input_spec.kind,
-                arg,
-                old_input_spec.target,
-                persistent=old_input_spec.persistent,
-            )
-        )
-        i += 1
-
-    output_node = new_gm.graph.output_node()
-    assert output_node.op == "output"
-
-    new_output_specs = []
-    for i, node in enumerate(output_node.args[0]):
-        assert i < len(
-            old_signature.output_specs
-        ), "Number of outputs changed after transformation"
-        old_output_spec = old_signature.output_specs[i]
-        arg = (
-            old_output_spec.arg
-            if isinstance(old_output_spec.arg, ConstantArgument)
-            # pyre-fixme[20]: Argument `class_fqn` expected.
-            else type(old_output_spec.arg)(node.name)
-        )
-        new_output_specs.append(
-            OutputSpec(old_output_spec.kind, arg, old_output_spec.target)
-        )
-
-    new_signature = ExportGraphSignature(
-        input_specs=new_input_specs, output_specs=new_output_specs
-    )
-    return new_signature
+from executorch.exir._program_utils import (  # noqa: E402
+    _get_updated_graph_signature,
+    _get_updated_range_constraints,
+)
 
 
 def _transform(
@@ -243,13 +154,13 @@ def _transform(
     ), f"Expected all passes to be of PassType, not list or Verifier. Use override_verifiers kwarg instead. Got: {list(passes)}"
 
     return _transform_with_pass_manager(
-        self, PassManager(list(passes)), override_verifiers
+        self, ExportedProgramPassManager(list(passes)), override_verifiers
     )
 
 
 def _transform_with_pass_manager(
-    self,
-    pass_manager: PassManager,
+    self: ExportedProgram,
+    pass_manager: Union[ExportedProgramPassManager, GraphModulePassManager],
     override_verifiers: None | list[Type[Verifier]] = None,
 ) -> "ExportedProgram":
     """
@@ -258,22 +169,26 @@ def _transform_with_pass_manager(
     Args:
         self: The ExportedProgram instance to transform
         pass_manager: An instance of PassManager to apply transformations.
+            - ExportedProgramPassManager: operates on the full ExportedProgram
+            - GraphModulePassManager: operates on the GraphModule only
         override_verifiers: Optional list of verifier classes to use instead of the default verifiers.
             This is needed if the transforms yields illegal graph that the default verifier cannot handle.
 
     Returns:
         ExportedProgram: A new ExportedProgram with the transformations applied, or self if no changes were made
     """
-    res = pass_manager(self.graph_module)
-    transformed_gm = res.graph_module if res is not None else self.graph_module
-    assert transformed_gm is not None
-
-    if transformed_gm is self.graph_module and not res.modified:
-        return self
-
-    return _update_exported_program_graph_module(
-        self, transformed_gm, override_verifiers
-    )
+    if isinstance(pass_manager, ExportedProgramPassManager):
+        res = pass_manager(self, override_verifiers)
+        if not res.modified:
+            return self
+        return res.exported_program
+    else:
+        res = pass_manager(self.graph_module)
+        if not res.modified:
+            return self
+        return _update_exported_program_graph_module(
+            self, res.graph_module, override_verifiers
+        )
 
 
 def _update_exported_program_graph_module(
@@ -1324,7 +1239,12 @@ def collect_named_data_store_from_exported_program(
 def to_edge_transform_and_lower(  # noqa: C901
     programs: Union[ExportedProgram, Dict[str, ExportedProgram]],
     transform_passes: Optional[
-        Union[Sequence[PassType], Dict[str, Sequence[PassType]], PassManager]
+        Union[
+            Sequence[PassType],
+            Dict[str, Sequence[PassType]],
+            GraphModulePassManager,
+            ExportedProgramPassManager,
+        ]
     ] = None,
     partitioner: Optional[
         Union[List[Partitioner], Dict[str, List[Partitioner]]]
@@ -1359,7 +1279,7 @@ def to_edge_transform_and_lower(  # noqa: C901
             2) a dictionary -
                 only method names specified in the dictionary will be transformed
                 with their corresponding passes
-            3) an instance of a PassManager -
+            3) an instance of a PassManager (either a GraphModulePassManager or an ExportedProgramPassManager) -
                 all methods in the given EdgeProgramManager will be
                 transformed with the given PassManager instance.
 
@@ -1604,7 +1524,12 @@ class EdgeProgramManager:
     @et_logger("transform")
     def transform(
         self,
-        passes: Union[Sequence[PassType], Dict[str, Sequence[PassType]], PassManager],
+        passes: Union[
+            Sequence[PassType],
+            Dict[str, Sequence[PassType]],
+            ExportedProgramPassManager,
+            GraphModulePassManager,
+        ],
         compile_config: Optional[EdgeCompileConfig] = None,
     ) -> "EdgeProgramManager":
         """
@@ -1618,7 +1543,7 @@ class EdgeProgramManager:
                 2) a dictionary mapping method names to lists of passes -
                     only method names specified in the dictionary will be
                     transformed with their corresponding passes.
-                3) a PassManager instance -
+                3) a PassManager (either ExportedProgramPassManager or GraphModulePassManager) instance -
                     all methods in the given EdgeProgramManager will be
                     transformed with the given PassManager instance.
             compile_config: Compile config to use for veriy the correctness of model
@@ -1637,13 +1562,15 @@ class EdgeProgramManager:
         # Cast passes parameter upfront.
         passes_seq: Optional[Sequence[PassType]] = None
         passes_dict: Optional[Dict[str, Sequence[PassType]]] = None
-        pass_manager: Optional[PassManager] = None
+        pass_manager: Optional[
+            Union[ExportedProgramPassManager, GraphModulePassManager]
+        ] = None
 
         if isinstance(passes, Sequence):
             passes_seq = passes
         if isinstance(passes, dict):
             passes_dict = passes
-        if isinstance(passes, PassManager):
+        if isinstance(passes, (ExportedProgramPassManager, GraphModulePassManager)):
             pass_manager = passes
 
         for name, program in self._edge_programs.items():

--- a/exir/tests/test_pass_infra.py
+++ b/exir/tests/test_pass_infra.py
@@ -9,14 +9,22 @@
 
 import unittest
 
+import executorch.exir as exir
 import torch
-from executorch.exir import to_edge
-from executorch.exir.pass_base import ExportPassBaseError, ProxyValue
-from executorch.exir.pass_manager import PassManager
+from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import (
+    ExportedProgramPassBase,
+    ExportedProgramPassResult,
+    ExportPassBaseError,
+    ProxyValue,
+)
+from executorch.exir.pass_manager import ExportedProgramPassManager, PassManager
 from executorch.exir.passes import ScalarToTensorPass
 from executorch.exir.passes.pass_registry import PassRegistry
-from torch.export import Dim, export
-from torch.fx.passes.infra.pass_base import PassBase
+from executorch.exir.program import to_edge
+from torch.export import Dim, export, ExportedProgram
+from torch.export.graph_signature import InputKind, InputSpec, TensorArgument
+from torch.fx.passes.infra.pass_base import PassBase, PassResult
 
 
 class TestPassInfra(unittest.TestCase):
@@ -216,3 +224,228 @@ class TestProxyValueSymbolicCoercions(unittest.TestCase):
 
         with self.assertRaisesRegex(ExportPassBaseError, "converted to float"):
             float(ProxyValue(sym_float, torch.fx.Graph().placeholder("x")))
+
+
+class TestExportedProgramPassManager(unittest.TestCase):
+    def test_runs_graph_module_passes_on_exported_program(self) -> None:
+        """
+        Tests that ExportedProgramPassManager runs GraphModule passes
+        on an ExportedProgram and the graph is correctly modified.
+        """
+
+        def replace_add_with_mul(gm: torch.fx.GraphModule) -> PassResult:
+            modified = False
+            for node in gm.graph.find_nodes(
+                op="call_function", target=exir_ops.edge.aten.add.Tensor
+            ):
+                node.target = exir_ops.edge.aten.mul.Tensor
+                modified = True
+            return PassResult(gm, modified)
+
+        def f(x: torch.Tensor) -> torch.Tensor:
+            y = torch.add(x, x)
+            z = torch.add(y, x)
+            return z
+
+        exported_program = (
+            exir.capture(f, (torch.randn(10),), exir.CaptureConfig())
+            .to_edge()
+            .exported_program
+        )
+
+        pm = ExportedProgramPassManager(passes=[replace_add_with_mul])
+        result = pm(exported_program)
+
+        # Verify return type
+        self.assertIsInstance(result, ExportedProgramPassResult)
+        self.assertTrue(result.modified)
+
+        # Check that all add ops were replaced with mul
+        self.assertEqual(
+            len(
+                result.exported_program.graph.find_nodes(
+                    op="call_function", target=exir_ops.edge.aten.add.Tensor
+                )
+            ),
+            0,
+        )
+
+    def test_updates_constants_on_exported_program(self) -> None:
+        """
+        Tests that ExportedProgramPassManager can update constants
+        in the ExportedProgram using an ExportedProgram-aware pass.
+        """
+
+        class DoubleConstantsPass(ExportedProgramPassBase):
+            """Pass that doubles all constant tensor values in the ExportedProgram."""
+
+            def call(self, ep: ExportedProgram) -> ExportedProgramPassResult:
+                modified = False
+                for key, const in ep.constants.items():
+                    if isinstance(const, torch.Tensor):
+                        ep.constants[key] = const * 2
+                        modified = True
+                return ExportedProgramPassResult(ep, modified)
+
+        class ModuleWithConstant(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.weight = torch.ones(3)
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return x + self.weight
+
+        module = ModuleWithConstant()
+        exported_program = to_edge(
+            torch.export.export(module, (torch.randn(3),))
+        ).exported_program()
+
+        # Verify there are constants in the ExportedProgram
+        self.assertGreater(
+            len(exported_program.constants), 0, "Expected constants in ExportedProgram"
+        )
+
+        # Store original constant values
+        original_values = {
+            key: const.clone()
+            for key, const in exported_program.constants.items()
+            if isinstance(const, torch.Tensor)
+        }
+
+        pm = ExportedProgramPassManager(passes=[DoubleConstantsPass()])
+        result = pm(exported_program)
+
+        self.assertIsInstance(result, ExportedProgramPassResult)
+        self.assertTrue(result.modified)
+
+        # Verify constants were doubled
+        for key, original_const in original_values.items():
+            new_const = result.exported_program.constants[key]
+            self.assertTrue(
+                torch.allclose(new_const, original_const * 2),
+                f"Constant {key} was not doubled correctly",
+            )
+
+    def test_adds_constant_to_exported_program(self) -> None:
+        """
+        Tests that ExportedProgramPassManager can add a new constant
+        to the ExportedProgram, including updating the graph and input specs.
+        """
+
+        class AddConstantPass(ExportedProgramPassBase):
+            """Pass that adds a new constant tensor to the ExportedProgram."""
+
+            def call(self, ep: ExportedProgram) -> ExportedProgramPassResult:
+                graph = ep.graph_module.graph
+                sig = ep.graph_signature
+
+                # Find the first user input to insert before it
+                placeholders = graph.find_nodes(op="placeholder")
+                assert len(placeholders) == 1
+                user_input_node = placeholders[0]
+
+                # Create a new constant tensor
+                new_constant_name = "_test_added_constant"
+                new_constant_tensor = torch.tensor([1.0, 2.0, 3.0])
+
+                # Add placeholder node for the new constant
+                with graph.inserting_before(user_input_node):
+                    new_placeholder = graph.placeholder(new_constant_name)
+                    # Set up meta for the new placeholder
+                    new_placeholder.meta["val"] = new_constant_tensor
+
+                # Add the constant to the constants dict
+                ep.constants[new_constant_name] = new_constant_tensor
+
+                # Update input specs to include the new constant
+                new_input_spec = InputSpec(
+                    kind=InputKind.CONSTANT_TENSOR,
+                    arg=TensorArgument(name=new_placeholder.name),
+                    target=new_constant_name,
+                    persistent=False,
+                )
+                sig.input_specs = (new_input_spec, sig.input_specs[0])
+
+                return ExportedProgramPassResult(ep, modified=True)
+
+        class IdentityModule(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return x
+
+        exported_program = to_edge(
+            torch.export.export(IdentityModule(), (torch.randn(3),))
+        ).exported_program()
+        assert len(exported_program.constants) == 0
+        assert len(exported_program.graph_signature.input_specs) == 1
+
+        pm = ExportedProgramPassManager(passes=[AddConstantPass()])
+        result = pm(exported_program)
+
+        self.assertIsInstance(result, ExportedProgramPassResult)
+        self.assertTrue(result.modified)
+
+        # Verify the new constant was added to constants dict
+        self.assertEqual(len(result.exported_program.constants), 1)
+        self.assertIn("_test_added_constant", result.exported_program.constants)
+        self.assertTrue(
+            torch.allclose(
+                result.exported_program.constants["_test_added_constant"],
+                torch.tensor([1.0, 2.0, 3.0]),
+            )
+        )
+
+        # Verify input_specs was updated
+        self.assertEqual(
+            len(result.exported_program.graph_signature.input_specs),
+            2,
+        )
+
+        # Verify the new placeholder exists in the graph
+        placeholder_names = [
+            node.target
+            for node in result.exported_program.graph_module.graph.find_nodes(
+                op="placeholder"
+            )
+        ]
+        self.assertTrue(len(placeholder_names) == 2)
+
+        # Verify the new input spec has the correct kind
+        new_spec = None
+        for spec in result.exported_program.graph_signature.input_specs:
+            if spec.target == "_test_added_constant":
+                new_spec = spec
+                break
+        self.assertIsNotNone(new_spec)
+        self.assertEqual(new_spec.kind, InputKind.CONSTANT_TENSOR)
+
+    def test_invalid_pass_creates_call_method(self) -> None:
+        """
+        Tests that ExportedProgramPassManager detects invalid passes
+        that introduce call_method nodes.
+        """
+
+        def introduce_call_method(gm: torch.fx.GraphModule) -> PassResult:
+            node = list(gm.graph.nodes)[-2]
+            with gm.graph.inserting_after(node):
+                gm.graph.call_method("torch.ops.relu", (torch.randn(2),))
+            return PassResult(gm, True)
+
+        def f(x: torch.Tensor) -> torch.Tensor:
+            y = torch.add(x, x)
+            return y
+
+        exported_program = (
+            exir.capture(f, (torch.randn(10),), exir.CaptureConfig())
+            .to_edge()
+            .exported_program
+        )
+
+        pm = ExportedProgramPassManager(
+            passes=[introduce_call_method], run_checks_after_each_pass=True
+        )
+
+        with self.assertRaisesRegex(Exception, "call_method"):
+            pm(exported_program)


### PR DESCRIPTION
Summary:

Adds support to run passes on ExportedPrograms, as well as a pass manager for exported programs. Now, users can provide graph module passes or exported program passes as an interleaved list, and the pass manager will run the appropriate logic depending on the pass type. The new pass manager also runs program validation before and after running all passes, and also includes support to run program-level validation after each pass. Users should use this pass manager in favor of the old exir.PassManager.

Reviewed By: angelayi, larryliu0820, ethansfng

Differential Revision: D91725222


