### PR TITLE
[llama] Add chat format support for Llama 3 Instruct models

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,7 @@ include(${PROJECT_SOURCE_DIR}/tools/cmake/Codegen.cmake)
 include(${PROJECT_SOURCE_DIR}/tools/cmake/Utils.cmake)
 include(CMakeDependentOption)
 include(ExternalProject)
+include(FetchContent)
 include(GNUInstallDirs)
 
 if(NOT CMAKE_CXX_STANDARD)
@@ -379,6 +380,14 @@ set(_common_include_directories
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/executorch/runtime/core/portable_type/c10>
 )
+
+if(TARGET jinja2cpp)
+  install(
+    TARGETS jinja2cpp
+    EXPORT ExecuTorchTargets
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  )
+endif()
 
 #
 # The `_<target>_srcs` lists are defined by executorch_load_build_variables.
@@ -744,7 +753,7 @@ endif()
 
 if(EXECUTORCH_BUILD_EXTENSION_LLM)
   if(EXECUTORCH_BUILD_EXTENSION_LLM_RUNNER)
-    set(SUPPORT_REGEX_LOOKAHEAD ON)
+    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/extension/llm/chat_template)
     # llama/runner/CMakeLists.txt builds a shared library libllama_runner.so
     # that transitively depends on tokenizers. Need to build tokenizers with
     # -fPIC.

--- a/examples/models/llama/CMakeLists.txt
+++ b/examples/models/llama/CMakeLists.txt
@@ -48,6 +48,31 @@ set(TORCH_ROOT ${EXECUTORCH_ROOT}/third-party/pytorch)
 
 include(${EXECUTORCH_ROOT}/tools/cmake/Utils.cmake)
 
+include(FetchContent)
+cmake_policy(SET CMP0077 NEW)
+FetchContent_Declare(
+  jinja2cpp
+  GIT_REPOSITORY https://github.com/jinja2cpp/Jinja2Cpp.git
+  GIT_TAG 1.3.2
+  GIT_SUBMODULES_RECURSE TRUE
+)
+set(JINJA2CPP_BUILD_TESTS
+    OFF
+    CACHE BOOL ""
+          FORCE
+)
+set(JINJA2CPP_BUILD_SHARED
+    OFF
+    CACHE BOOL ""
+          FORCE
+)
+set(JINJA2CPP_INSTALL
+    OFF
+    CACHE BOOL ""
+          FORCE
+)
+FetchContent_MakeAvailable(jinja2cpp)
+
 if(NOT PYTHON_EXECUTABLE)
   resolve_python_executable()
 endif()

--- a/examples/models/llama/runner/CMakeLists.txt
+++ b/examples/models/llama/runner/CMakeLists.txt
@@ -53,6 +53,7 @@ set(llama_runner_deps
 
 target_link_libraries(llama_runner PUBLIC ${llama_runner_deps})
 target_link_libraries(llama_runner PUBLIC tokenizers::tokenizers)
+target_link_libraries(llama_runner PRIVATE jinja2cpp)
 
 target_include_directories(
   llama_runner PUBLIC ${EXECUTORCH_ROOT}/extension/llm/tokenizers/include

--- a/examples/models/llama/runner/chat_formatter.h
+++ b/examples/models/llama/runner/chat_formatter.h
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+#include <executorch/extension/llm/runner/jinja_chat_formatter.h>
+
+namespace example {
+
+/**
+ * Supported chat template formats for different model families.
+ */
+enum class ChatFormat {
+  None,   // No formatting (pass-through)
+  Llama3, // Llama 3.x Instruct models
+  Gemma3, // Gemma 3 Instruct models
+  Jinja,  // Custom Jinja template from file
+};
+
+/**
+ * Abstract base class for chat formatters.
+ * Implementations format user prompts into model-specific chat templates.
+ */
+class ChatFormatter {
+ public:
+  virtual ~ChatFormatter() = default;
+
+  /**
+   * Format a user prompt into the model's expected chat template.
+   *
+   * @param prompt The user's input message
+   * @param system_prompt Optional system prompt to set model behavior
+   * @return Formatted string ready for tokenization
+   */
+  virtual std::string format(
+      const std::string& prompt,
+      const std::string& system_prompt = "") const = 0;
+
+  /**
+   * Whether this formatter includes BOS token in the template.
+   * If true, the runner should not prepend additional BOS tokens.
+   */
+  virtual bool includes_bos() const = 0;
+};
+
+/**
+ * No formatting (pass-through).
+ * Use when the prompt is already formatted or for base models.
+ */
+class NoChatFormatter : public ChatFormatter {
+ public:
+  std::string format(
+      const std::string& prompt,
+      const std::string& system_prompt = "") const override {
+    (void)system_prompt; // Unused in pass-through mode
+    return prompt;
+  }
+
+  bool includes_bos() const override {
+    return false; // User controls BOS token
+  }
+};
+
+class JinjaChatFormatterAdapter : public ChatFormatter {
+ public:
+  explicit JinjaChatFormatterAdapter(
+      std::unique_ptr<executorch::extension::llm::JinjaChatFormatter> formatter)
+      : formatter_(std::move(formatter)) {}
+
+  std::string format(
+      const std::string& prompt,
+      const std::string& system_prompt = "") const override {
+    return formatter_->format(prompt, system_prompt);
+  }
+
+  bool includes_bos() const override {
+    return formatter_->includesBos();
+  }
+
+ private:
+  std::unique_ptr<executorch::extension::llm::JinjaChatFormatter> formatter_;
+};
+
+/**
+ * Parse a chat format string into the corresponding enum value.
+ *
+ * @param format_str String identifier (e.g., "llama3", "none")
+ * @return ChatFormat enum value, defaults to None for unknown formats
+ */
+inline ChatFormat parse_chat_format(const std::string& format_str) {
+  static const std::unordered_map<std::string, ChatFormat> format_map = {
+      {"none", ChatFormat::None},
+      {"llama3", ChatFormat::Llama3},
+      {"llama3.2", ChatFormat::Llama3},
+      {"llama32", ChatFormat::Llama3},
+      {"llama3_2", ChatFormat::Llama3},
+      {"gemma3", ChatFormat::Gemma3},
+      {"jinja", ChatFormat::Jinja},
+  };
+  auto it = format_map.find(format_str);
+  if (it != format_map.end()) {
+    return it->second;
+  }
+  return ChatFormat::None;
+}
+
+/**
+ * Get a human-readable list of supported chat formats.
+ */
+inline std::string get_supported_formats() {
+  return "llama3, gemma3, jinja, none";
+}
+
+/**
+ * Factory function to create the appropriate ChatFormatter instance.
+ *
+ * @param format The chat format to use
+ * @return Unique pointer to a ChatFormatter instance
+ */
+inline std::unique_ptr<ChatFormatter> create_chat_formatter(
+    ChatFormat format,
+    const std::string& template_file = "") {
+  using executorch::extension::llm::ChatTemplateType;
+  using executorch::extension::llm::JinjaChatFormatter;
+
+  if (!template_file.empty()) {
+    return std::make_unique<JinjaChatFormatterAdapter>(
+        JinjaChatFormatter::fromFile(template_file));
+  }
+
+  switch (format) {
+    case ChatFormat::Llama3:
+      return std::make_unique<JinjaChatFormatterAdapter>(
+          JinjaChatFormatter::fromTemplate(ChatTemplateType::Llama3));
+    case ChatFormat::Gemma3:
+      return std::make_unique<JinjaChatFormatterAdapter>(
+          JinjaChatFormatter::fromTemplate(ChatTemplateType::Gemma3));
+    case ChatFormat::Jinja:
+      return std::make_unique<NoChatFormatter>();
+    case ChatFormat::None:
+    default:
+      return std::make_unique<NoChatFormatter>();
+  }
+}
+
+} // namespace example

--- a/examples/models/llama/runner/eager.py
+++ b/examples/models/llama/runner/eager.py
@@ -83,6 +83,20 @@ def build_args_parser() -> argparse.ArgumentParser:
     )
 
     parser.add_argument(
+        "--system_prompt",
+        type=str,
+        default="",
+        help="System prompt for chat formatting (optional).",
+    )
+
+    parser.add_argument(
+        "--chat_template_file",
+        type=str,
+        default="",
+        help="Path to a custom Jinja2 chat template file for chat mode.",
+    )
+
+    parser.add_argument(
         "--tokenizer_config_path",
         type=str,
         default=None,
@@ -104,6 +118,8 @@ def execute_runner(runner_class: Type[LlamaRunner]) -> None:
     temperature = args.temperature
     show_tokens = args.show_tokens
     chat_mode = args.chat
+    system_prompt = args.system_prompt
+    chat_template_file = args.chat_template_file
     tokenizer_config_path = args.tokenizer_config_path
     use_attention_sink = args.use_attention_sink
 
@@ -113,6 +129,8 @@ def execute_runner(runner_class: Type[LlamaRunner]) -> None:
             llm_config=llm_config,
             tokenizer_config_path=tokenizer_config_path,
             use_attention_sink=use_attention_sink,
+            system_prompt=system_prompt,
+            chat_template_file=chat_template_file or None,
         )
 
         generated_tokens = (

--- a/examples/models/llama/runner/targets.bzl
+++ b/examples/models/llama/runner/targets.bzl
@@ -26,6 +26,7 @@ def define_common_targets():
                 "runner.cpp",
             ],
             exported_headers = [
+                "chat_formatter.h",
                 "runner.h",
             ],
             deps = [

--- a/extension/llm/chat_template/BUCK
+++ b/extension/llm/chat_template/BUCK
@@ -1,0 +1,18 @@
+load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target", "non_fbcode_target")
+oncall("executorch")
+
+# Any targets that should be shared between fbcode and xplat must be defined in
+# targets.bzl. This file can contain fbcode-only targets.
+
+load(":targets.bzl", "define_common_targets")
+
+non_fbcode_target(_kind = define_common_targets,)
+
+# !!!! fbcode/executorch/extension/llm/chat_template/TARGETS was merged into this file, see https://fburl.com/workplace/xl8l9yuo for more info !!!!
+
+# Any targets that should be shared between fbcode and xplat must be defined in
+# targets.bzl. This file can contain fbcode-only targets.
+
+load(":targets.bzl", "define_common_targets")
+
+fbcode_target(_kind = define_common_targets,)

--- a/extension/llm/chat_template/CMakeLists.txt
+++ b/extension/llm/chat_template/CMakeLists.txt
@@ -1,0 +1,106 @@
+if(NOT EXECUTORCH_BUILD_EXTENSION_LLM_RUNNER)
+  return()
+endif()
+
+include(FetchContent)
+cmake_policy(SET CMP0077 NEW)
+
+FetchContent_Declare(
+  jinja2cpp
+  GIT_REPOSITORY https://github.com/jinja2cpp/Jinja2Cpp.git
+  GIT_TAG 1.3.2
+  GIT_SUBMODULES_RECURSE TRUE
+)
+
+set(JINJA2CPP_BUILD_TESTS
+    OFF
+    CACHE BOOL ""
+          FORCE
+)
+set(JINJA2CPP_BUILD_SHARED
+    OFF
+    CACHE BOOL ""
+          FORCE
+)
+set(JINJA2CPP_INSTALL
+    OFF
+    CACHE BOOL ""
+          FORCE
+)
+
+FetchContent_MakeAvailable(jinja2cpp)
+if(NOT TARGET jinja2cpp)
+  message(FATAL_ERROR "Jinja2Cpp target not found after FetchContent.")
+endif()
+
+if(DEFINED jinja2cpp_SOURCE_DIR)
+  function(executorch_copy_nonstd_header dep_name target header_name dest_root)
+    set(_copied FALSE)
+    if(TARGET ${target})
+      get_target_property(_aliased ${target} ALIASED_TARGET)
+      if(_aliased)
+        set(_resolved_target ${_aliased})
+      else()
+        set(_resolved_target ${target})
+      endif()
+      get_target_property(
+        _include_dirs ${_resolved_target} INTERFACE_INCLUDE_DIRECTORIES
+      )
+      foreach(_dir IN LISTS _include_dirs)
+        if(EXISTS "${_dir}/nonstd/${header_name}")
+          file(MAKE_DIRECTORY "${dest_root}/nonstd")
+          file(
+            COPY "${_dir}/nonstd/${header_name}"
+            DESTINATION "${dest_root}/nonstd"
+          )
+          set(_copied TRUE)
+          break()
+        endif()
+      endforeach()
+    endif()
+    if(NOT _copied)
+      set(
+        _fallback_path
+        "${CMAKE_BINARY_DIR}/_deps/${dep_name}-src/include/nonstd/${header_name}"
+      )
+      if(EXISTS "${_fallback_path}")
+        file(MAKE_DIRECTORY "${dest_root}/nonstd")
+        file(COPY "${_fallback_path}" DESTINATION "${dest_root}/nonstd")
+      endif()
+    endif()
+  endfunction()
+
+  set(_jinja2cpp_nonstd_root
+      "${jinja2cpp_SOURCE_DIR}/thirdparty/nonstd"
+  )
+  executorch_copy_nonstd_header(
+    expected-lite
+    nonstd::expected-lite
+    expected.hpp
+    "${_jinja2cpp_nonstd_root}/expected-lite/include"
+  )
+  executorch_copy_nonstd_header(
+    variant-lite
+    nonstd::variant-lite
+    variant.hpp
+    "${_jinja2cpp_nonstd_root}/variant-lite/include"
+  )
+  executorch_copy_nonstd_header(
+    optional-lite
+    nonstd::optional-lite
+    optional.hpp
+    "${_jinja2cpp_nonstd_root}/optional-lite/include"
+  )
+  executorch_copy_nonstd_header(
+    string-view-lite
+    nonstd::string-view-lite
+    string_view.hpp
+    "${_jinja2cpp_nonstd_root}/string-view-lite/include"
+  )
+endif()
+
+set(SUPPORT_REGEX_LOOKAHEAD
+    ON
+    CACHE BOOL ""
+          FORCE
+)

--- a/extension/llm/chat_template/chat_templates.h
+++ b/extension/llm/chat_template/chat_templates.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+namespace executorch::extension::llm {
+
+enum class ChatTemplateType {
+  None,
+  Llama3,
+  Llama32,
+  Gemma3,
+  Custom,
+};
+
+constexpr std::string_view kLlama3Template = R"({{ bos_token }}{%- for message in messages -%}<|start_header_id|>{{ message.role }}<|end_header_id|>
+
+{{ message.content }}<|eot_id|>{%- endfor -%}{%- if add_generation_prompt -%}<|start_header_id|>assistant<|end_header_id|>
+
+{%- endif -%})";
+
+constexpr std::string_view kGemma3Template = R"({{ bos_token }}{%- for message in messages -%}{%- if message.role == 'assistant' -%}<start_of_turn>model
+{%- else -%}<start_of_turn>{{ message.role }}
+{%- endif -%}{{ message.content }}<end_of_turn>{%- endfor -%}{%- if add_generation_prompt -%}<start_of_turn>model
+{%- endif -%})";
+
+inline const std::unordered_map<ChatTemplateType, std::string_view>
+    kEmbeddedTemplates = {
+        {ChatTemplateType::Llama3, kLlama3Template},
+        {ChatTemplateType::Llama32, kLlama3Template},
+        {ChatTemplateType::Gemma3, kGemma3Template},
+    };
+
+struct ModelTokens {
+  std::string bos_token;
+  std::string eos_token;
+  std::vector<std::string> stop_tokens;
+};
+
+inline const std::unordered_map<ChatTemplateType, ModelTokens> kModelTokens = {
+    {ChatTemplateType::Llama3,
+     {"<|begin_of_text|>", "<|eot_id|>", {"<|eot_id|>", "<|end_of_text|>"}}},
+    {ChatTemplateType::Llama32,
+     {"<|begin_of_text|>", "<|eot_id|>", {"<|eot_id|>", "<|end_of_text|>"}}},
+    {ChatTemplateType::Gemma3,
+     {"<bos>", "<end_of_turn>", {"<end_of_turn>", "<eos>"}}},
+};
+
+} // namespace executorch::extension::llm

--- a/extension/llm/chat_template/targets.bzl
+++ b/extension/llm/chat_template/targets.bzl
@@ -1,0 +1,16 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+
+def define_common_targets():
+    runtime.cxx_library(
+        name = "chat_templates",
+        exported_headers = [
+            "chat_templates.h",
+        ],
+        visibility = ["PUBLIC"],
+    )

--- a/extension/llm/runner/CMakeLists.txt
+++ b/extension/llm/runner/CMakeLists.txt
@@ -53,6 +53,14 @@ endif()
 list(APPEND runner_deps kernels_util_all_deps)
 
 target_link_libraries(extension_llm_runner PUBLIC ${runner_deps})
+target_link_libraries(extension_llm_runner PRIVATE $<LINK_ONLY:jinja2cpp>)
+target_include_directories(
+  extension_llm_runner PRIVATE
+  $<TARGET_PROPERTY:jinja2cpp,INTERFACE_INCLUDE_DIRECTORIES>
+)
+target_compile_definitions(
+  extension_llm_runner PUBLIC EXECUTORCH_USE_JINJA2CPP
+)
 set_target_properties(
   extension_llm_runner PROPERTIES POSITION_INDEPENDENT_CODE ON
 )

--- a/extension/llm/runner/README.md
+++ b/extension/llm/runner/README.md
@@ -89,6 +89,24 @@ MultimodalRunner Supported Model Architecture:
 
 ## Quick Start
 
+## Chat Templates (Jinja2)
+
+The runner supports Jinja2 chat templates. For local testing with `llama_main`,
+sample templates are stored in `extension/llm/runner/templates/`. Use
+`--chat_template_file` to point to a template file, for example:
+
+```bash
+cmake-out/examples/models/llama/llama_main \
+  --model_path=<model.pte> \
+  --tokenizer_path=<tokenizer.model> \
+  --chat_template_file=extension/llm/runner/templates/tool_chat_template_llama3.2_pythonic.jinja \
+  --prompt="Hello"
+```
+
+Notes:
+- Match the template to the model family (e.g., Llama templates for Llama models).
+- For clean text output, pass `--echo=false` so prompt formatting tokens are not printed.
+
 ### TextLLMRunner Example
 
 ```cpp

--- a/extension/llm/runner/__init__.py
+++ b/extension/llm/runner/__init__.py
@@ -14,8 +14,12 @@ enabling processing of mixed inputs (text, images, audio) and text generation.
 try:
     # Import shared components from the compiled C++ extension
     from executorch.extension.llm.runner._llm_runner import (  # noqa: F401
+        ChatConversation,
+        ChatMessage,
+        ChatTemplateType,
         GenerationConfig,
         Image,
+        JinjaChatFormatter,
         make_audio_input,
         make_image_input,
         make_raw_audio_input,
@@ -222,8 +226,12 @@ setattr(MultimodalRunner, "generate_text_hf", generate_text_hf)  # noqa B010
 
 
 __all__ = [
+    "ChatConversation",
+    "ChatMessage",
+    "ChatTemplateType",
     "GenerationConfig",
     "Image",
+    "JinjaChatFormatter",
     "make_audio_input",
     "make_image_input",
     "make_raw_audio_input",

--- a/extension/llm/runner/_llm_runner.pyi
+++ b/extension/llm/runner/_llm_runner.pyi
@@ -4,6 +4,7 @@ Type stubs for _llm_runner module.
 This file provides type annotations for the ExecuTorch LLM Runner Python bindings.
 """
 
+from enum import Enum
 from typing import Callable, List, Optional, overload
 
 import torch
@@ -62,6 +63,45 @@ class GenerationConfig:
         ...
 
     def __repr__(self) -> str: ...
+
+class ChatTemplateType(Enum):
+    None_ = 0
+    Llama3 = 1
+    Llama32 = 2
+    Gemma3 = 3
+    Custom = 4
+
+class ChatMessage:
+    role: str
+    content: str
+
+    def __init__(self, role: str, content: str) -> None: ...
+
+    def __repr__(self) -> str: ...
+
+class ChatConversation:
+    messages: List[ChatMessage]
+    bos_token: str
+    eos_token: str
+    add_generation_prompt: bool
+
+    def __init__(self) -> None: ...
+
+class JinjaChatFormatter:
+    @staticmethod
+    def from_template(template_type: ChatTemplateType) -> "JinjaChatFormatter": ...
+
+    @staticmethod
+    def from_string(template_str: str) -> "JinjaChatFormatter": ...
+
+    @staticmethod
+    def from_file(path: str) -> "JinjaChatFormatter": ...
+
+    def format(self, prompt: str, system_prompt: str = "") -> str: ...
+
+    def format_conversation(self, conversation: ChatConversation) -> str: ...
+
+    def includes_bos(self) -> bool: ...
 
 class Stats:
     """Statistics for LLM generation performance."""

--- a/extension/llm/runner/chat_types.h
+++ b/extension/llm/runner/chat_types.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace executorch::extension::llm {
+
+struct ChatMessage {
+  std::string role;
+  std::string content;
+};
+
+struct ChatConversation {
+  std::vector<ChatMessage> messages;
+  std::string bos_token;
+  std::string eos_token;
+  bool add_generation_prompt = true;
+};
+
+} // namespace executorch::extension::llm

--- a/extension/llm/runner/jinja_chat_formatter.cpp
+++ b/extension/llm/runner/jinja_chat_formatter.cpp
@@ -1,0 +1,222 @@
+#include <executorch/extension/llm/runner/jinja_chat_formatter.h>
+
+#include <jinja2cpp/reflected_value.h>
+#include <jinja2cpp/template.h>
+#include <jinja2cpp/value.h>
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <fstream>
+#include <sstream>
+#include <stdexcept>
+#include <unordered_map>
+
+namespace executorch::extension::llm {
+namespace {
+
+std::string readFileToString(const std::filesystem::path& path) {
+  std::ifstream file(path);
+  if (!file) {
+    throw std::runtime_error("Failed to open template file: " + path.string());
+  }
+  std::ostringstream buffer;
+  buffer << file.rdbuf();
+  return buffer.str();
+}
+
+bool templateIncludesBos(
+    const std::string& template_str,
+    const ModelTokens& model_tokens) {
+  if (!model_tokens.bos_token.empty() &&
+      template_str.find(model_tokens.bos_token) != std::string::npos) {
+    return true;
+  }
+  return template_str.find("bos_token") != std::string::npos;
+}
+
+std::string normalizeTemplate(std::string input) {
+  constexpr std::array<std::pair<std::string_view, std::string_view>, 10>
+      replacements = {{
+          {"tools = none", "tools = []"},
+          {"tools = None", "tools = []"},
+          {"tools is not none", "tools"},
+          {"tools is not None", "tools"},
+          {"not tools is none", "not tools"},
+          {"not tools is None", "not tools"},
+          {"tools is none", "not tools"},
+          {"tools is None", "not tools"},
+          {"messages[1:]", "messages_tail"},
+          {"{ \"output\": message.content } | tojson", "message.content | tojson"},
+      }};
+  // Handle special case that can't be constexpr due to escape sequence
+  const std::pair<std::string, std::string> gemmaReplacement = {
+      "{{'<start_of_turn>model\\n'}}", "{{ '<start_of_turn>model\\n' }}"};
+  for (const auto& replacement : replacements) {
+    size_t pos = 0;
+    while ((pos = input.find(replacement.first, pos)) != std::string::npos) {
+      input.replace(pos, replacement.first.size(), replacement.second);
+      pos += replacement.second.size();
+    }
+  }
+  // Apply the gemma replacement separately
+  size_t pos = 0;
+  while ((pos = input.find(gemmaReplacement.first, pos)) != std::string::npos) {
+    input.replace(pos, gemmaReplacement.first.size(), gemmaReplacement.second);
+    pos += gemmaReplacement.second.size();
+  }
+  return input;
+}
+
+ChatTemplateType detectTemplateType(const std::string& template_str) {
+  if (template_str.find("<start_of_turn>") != std::string::npos) {
+    return ChatTemplateType::Gemma3;
+  }
+  if (template_str.find("<|start_header_id|>") != std::string::npos) {
+    return ChatTemplateType::Llama3;
+  }
+  return ChatTemplateType::Custom;
+}
+
+std::string toLower(std::string value) {
+  std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) {
+    return static_cast<char>(std::tolower(c));
+  });
+  return value;
+}
+
+} // namespace
+
+} // namespace executorch::extension::llm
+
+namespace jinja2 {
+
+// NOLINTBEGIN(facebook-hte-MisplacedTemplateSpecialization,facebook-hte-ShadowingClass)
+// This template specialization must be in the jinja2 namespace for the library
+// to find it via ADL during template instantiation.
+template <>
+struct TypeReflection<executorch::extension::llm::ChatMessage>
+    : TypeReflected<executorch::extension::llm::ChatMessage> {
+  static auto& GetAccessors() {
+    static std::unordered_map<std::string, FieldAccessor> accessors = {
+        {"role",
+         [](const executorch::extension::llm::ChatMessage& msg) {
+           return jinja2::Reflect(msg.role);
+         }},
+        {"content",
+         [](const executorch::extension::llm::ChatMessage& msg) {
+           return jinja2::Reflect(msg.content);
+         }},
+    };
+    return accessors;
+  }
+};
+// NOLINTEND(facebook-hte-MisplacedTemplateSpecialization,facebook-hte-ShadowingClass)
+
+} // namespace jinja2
+
+namespace executorch::extension::llm {
+
+JinjaChatFormatter::JinjaChatFormatter(
+    const std::string& template_str,
+    ChatTemplateType type)
+    : template_str_(template_str), type_(type) {
+  auto tokens_it = kModelTokens.find(type_);
+  if (tokens_it != kModelTokens.end()) {
+    model_tokens_ = tokens_it->second;
+  }
+  includes_bos_ = templateIncludesBos(template_str_, model_tokens_);
+  const std::string normalized_template = normalizeTemplate(template_str_);
+  compiled_template_ = std::make_unique<jinja2::Template>();
+  auto load_result = compiled_template_->Load(normalized_template);
+  if (!load_result) {
+    throw std::runtime_error(
+        "Failed to parse chat template: " +
+        load_result.error().ToString());
+  }
+}
+
+JinjaChatFormatter::~JinjaChatFormatter() = default;
+
+std::unique_ptr<JinjaChatFormatter> JinjaChatFormatter::fromTemplate(
+    ChatTemplateType type) {
+  auto it = kEmbeddedTemplates.find(type);
+  if (it == kEmbeddedTemplates.end()) {
+    throw std::runtime_error("Unsupported embedded chat template type.");
+  }
+  return std::unique_ptr<JinjaChatFormatter>(
+      new JinjaChatFormatter(std::string(it->second), type));
+}
+
+std::unique_ptr<JinjaChatFormatter> JinjaChatFormatter::fromString(
+    const std::string& template_str) {
+  const ChatTemplateType inferred_type = detectTemplateType(template_str);
+  return std::unique_ptr<JinjaChatFormatter>(
+      new JinjaChatFormatter(template_str, inferred_type));
+}
+
+std::unique_ptr<JinjaChatFormatter> JinjaChatFormatter::fromFile(
+    const std::filesystem::path& path) {
+  return fromString(readFileToString(path));
+}
+
+std::string JinjaChatFormatter::format(
+    const std::string& prompt,
+    const std::string& system_prompt) const {
+  ChatConversation conversation;
+  if (!system_prompt.empty()) {
+    conversation.messages.push_back({"system", system_prompt});
+  }
+  conversation.messages.push_back({"user", prompt});
+  conversation.bos_token = model_tokens_.bos_token;
+  conversation.eos_token = model_tokens_.eos_token;
+  conversation.add_generation_prompt = true;
+  return formatConversation(conversation);
+}
+
+std::string JinjaChatFormatter::formatConversation(
+    const ChatConversation& conversation) const {
+  jinja2::ValuesMap params;
+  params["messages"] = jinja2::ValuesList();
+  params["messages_tail"] = jinja2::ValuesList();
+  bool is_first = true;
+  for (const auto& msg : conversation.messages) {
+    params["messages"].asList().push_back(jinja2::Reflect(msg));
+    if (!is_first) {
+      params["messages_tail"].asList().push_back(jinja2::Reflect(msg));
+    }
+    is_first = false;
+  }
+  params["bos_token"] = conversation.bos_token;
+  params["eos_token"] = conversation.eos_token;
+  params["add_generation_prompt"] = conversation.add_generation_prompt;
+
+  auto rendered = compiled_template_->RenderAsString(params);
+  if (!rendered) {
+    throw std::runtime_error(
+        "Failed to render chat template: " + rendered.error().ToString());
+  }
+  return rendered.value();
+}
+
+ChatTemplateType parseChatTemplateType(const std::string& type_str) {
+  const std::string lower = toLower(type_str);
+  if (lower == "none") {
+    return ChatTemplateType::None;
+  }
+  if (lower == "llama3") {
+    return ChatTemplateType::Llama3;
+  }
+  if (lower == "llama3.2" || lower == "llama32" || lower == "llama3_2") {
+    return ChatTemplateType::Llama32;
+  }
+  if (lower == "gemma3") {
+    return ChatTemplateType::Gemma3;
+  }
+  if (lower == "custom" || lower == "jinja") {
+    return ChatTemplateType::Custom;
+  }
+  return ChatTemplateType::None;
+}
+
+} // namespace executorch::extension::llm

--- a/extension/llm/runner/jinja_chat_formatter.h
+++ b/extension/llm/runner/jinja_chat_formatter.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <executorch/extension/llm/chat_template/chat_templates.h>
+#include <executorch/extension/llm/runner/chat_types.h>
+
+#include <filesystem>
+#include <memory>
+#include <string>
+
+namespace jinja2 {
+class Template;
+}
+
+namespace executorch::extension::llm {
+
+class JinjaChatFormatter {
+ public:
+  static std::unique_ptr<JinjaChatFormatter> fromTemplate(ChatTemplateType type);
+  static std::unique_ptr<JinjaChatFormatter> fromString(
+      const std::string& template_str);
+  static std::unique_ptr<JinjaChatFormatter> fromFile(
+      const std::filesystem::path& path);
+
+  ~JinjaChatFormatter();
+
+  std::string format(
+      const std::string& prompt,
+      const std::string& system_prompt = "") const;
+  std::string formatConversation(const ChatConversation& conversation) const;
+
+  bool includesBos() const {
+    return includes_bos_;
+  }
+
+  const ModelTokens& getModelTokens() const {
+    return model_tokens_;
+  }
+
+ private:
+  JinjaChatFormatter(const std::string& template_str, ChatTemplateType type);
+
+  std::string template_str_;
+  ChatTemplateType type_;
+  ModelTokens model_tokens_;
+  bool includes_bos_ = false;
+  std::unique_ptr<jinja2::Template> compiled_template_;
+};
+
+ChatTemplateType parseChatTemplateType(const std::string& type_str);
+
+} // namespace executorch::extension::llm

--- a/extension/llm/runner/targets.bzl
+++ b/extension/llm/runner/targets.bzl
@@ -111,11 +111,14 @@ def define_common_targets():
         runtime.cxx_library(
             name = "runner_lib" + aten_suffix,
             exported_headers = [
+                "chat_types.h",
+                "jinja_chat_formatter.h",
                 "text_llm_runner.h",
                 "llm_runner_helper.h",
                 "constants.h",
             ],
             srcs = [
+                "jinja_chat_formatter.cpp",
                 "text_llm_runner.cpp",
                 "llm_runner_helper.cpp",
                 "multimodal_runner.cpp",
@@ -131,11 +134,13 @@ def define_common_targets():
                 ":text_decoder_runner" + aten_suffix,
                 ":text_prefiller" + aten_suffix,
                 ":text_token_generator" + aten_suffix,
+                "//executorch/extension/llm/chat_template:chat_templates",
                 "//executorch/extension/llm/runner/io_manager:io_manager" + aten_suffix,
                 "//pytorch/tokenizers:hf_tokenizer",
                 "//pytorch/tokenizers:llama2c_tokenizer",
                 "//pytorch/tokenizers:sentencepiece",
                 "//pytorch/tokenizers:tekken",
                 "//pytorch/tokenizers:tiktoken",
+                "@fbsource//third-party/jinja2cpp:jinja2cpp",
             ],
         )

--- a/extension/llm/runner/templates/tool_chat_template_gemma3_pythonic.jinja
+++ b/extension/llm/runner/templates/tool_chat_template_gemma3_pythonic.jinja
@@ -1,0 +1,123 @@
+{#- Begin-of-sequence token to start the model prompt -#}
+{{ bos_token }}
+{#- Extracts the system message. Gemma does not support system messages so it will be prepended to first user message. -#}
+{%- if messages[0]['role'] == 'system' -%}
+    {%- if messages[0]['content'] is string -%}
+        {%- set first_user_prefix = messages[0]['content'] + '\n\n' -%}
+    {%- else -%}
+        {%- set first_user_prefix = messages[0]['content'][0]['text'] + '\n\n' -%}
+    {%- endif -%}
+    {%- set loop_messages = messages[1:] -%}
+{%- else -%}
+    {%- set first_user_prefix = "" -%}
+    {%- set loop_messages = messages -%}
+{%- endif -%}
+{#- Set tools to none if not defined for this ChatCompletion request (helps avoid errors later) -#}
+{%- if not tools is defined %}
+    {%- set tools = none %}
+{%- endif %}
+{#- Validate alternating user/assistant messages (excluding 'tool' messages and ones with tool_calls) -#}
+{%- for message in loop_messages | rejectattr("role", "equalto", "tool") | selectattr("tool_calls", "undefined") -%}
+    {%- if (message['role'] == 'user') != (loop.index0 % 2 == 0) %}
+        {{ raise_exception("Conversation roles must alternate user/assistant/user/assistant/...") }}
+    {%- endif -%}
+{%- endfor -%}
+
+{#- Main loop over all messages in the conversation history -#}
+{%- for message in loop_messages -%}
+    {#- Normalize roles for model prompt formatting -#}
+    {%- if (message['role'] == 'assistant') -%}
+        {%- set role = "model" -%}
+    {%- elif (message['role'] == 'tool') -%}
+        {%- set role = "user" -%}
+    {%- else -%}
+        {%- set role = message['role'] -%}
+    {%- endif -%}
+    {#- Mark the start of a message block with the appropriate role -#}
+    {{ '<start_of_turn>' + role + '\n' -}}
+
+    {#- Insert system message content (if present) at the beginning of the first message. -#}
+    {%- if loop.first -%}
+        {{ first_user_prefix }}
+        {#- Append system message with tool information if using tools in message request. -#}
+        {%- if tools is not none -%}
+            {{- "Tools (functions) are available. If you decide to invoke one or more of the tools, you must respond with a python list of the function calls.\n" -}}
+            {{- "Example Format: [func_name1(params_name1=params_value1, params_name2=params_value2...), func_name2(params)] \n" -}}
+            {{- "Do not use variables. DO NOT USE MARKDOWN SYNTAX. You SHOULD NOT include any other text in the response if you call a function. If none of the functions can be used, point it out. If you lack the parameters required by the function, also point it out.\n" -}}
+            {{- "Here is a list of functions in JSON format that you can invoke.\n" -}}
+            {{- tools | tojson(indent=4) -}}
+            {{- "\n\n" -}}
+        {%- endif -%}
+    {%- endif -%}
+
+    {#- Format model tool calls (turns where model indicates they want to call a tool) -#}
+    {%- if 'tool_calls' in message -%}
+        {#- Opening bracket for tool call list. -#}
+        {{- '[' -}}
+        {#- For each tool call -#}
+        {%- for tool_call in message.tool_calls -%}
+            {#- Get tool call function. -#}
+            {%- if tool_call.function is defined -%}
+                {%- set tool_call = tool_call.function -%}
+            {%- endif -%}
+            {#- Function name & opening parenthesis. -#}
+            {{- tool_call.name + '(' -}}
+
+            {#-- Handle arguments as list (positional) or dict (named) --#}
+            {#-- Named arguments (dict) --#}
+            {%- if tool_call.arguments is iterable and tool_call.arguments is mapping -%}
+                {%- set first = true -%}
+                {%- for key, val in tool_call.arguments.items() -%}
+                    {%- if not first %}, {% endif -%}
+                    {{ key }}={{ val | tojson }}
+                    {%- set first = false -%}
+                {%- endfor -%}
+            {#-- Positional arguments (list) --#}
+            {%- elif tool_call.arguments is iterable -%}
+                {{- tool_call.arguments | map('tojson') | join(', ') -}}
+            {#-- Fallback: single positional value --#}
+            {%- else -%}
+                {{- tool_call.arguments | tojson -}}
+            {#-- Closing parenthesis. --#}
+            {%- endif -%}
+                {{- ')' -}}
+            {#-- If more than one tool call, place comma and move to formatting next tool call --#}
+            {%- if not loop.last -%}, {% endif -%}
+        {%- endfor -%}
+        {#- Closing bracket for tool call list. -#}
+        {{- ']' -}}
+    {%- endif -%}
+    
+    {#- Tool response start tag (for messages from a tool) -#}
+    {%- if (message['role'] == 'tool') -%}
+        {{ '<tool_response>\n' -}}
+    {%- endif -%}
+
+    {#- Render the message content: handle plain string or multimodal content like image/text -#}
+    {%- if message['content'] is string -%}
+        {{ message['content'] | trim }}
+    {%- elif message['content'] is iterable -%}
+        {%- for item in message['content'] -%}
+            {%- if item['type'] == 'image' -%}
+                {{ '<start_of_image>' }}
+            {%- elif item['type'] == 'text' -%}
+                {{ item['text'] | trim }}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- else -%}
+        {{ raise_exception("Invalid content type") }}
+    {%- endif -%}
+
+    {#- Tool response end tag -#}
+    {%- if (message['role'] == 'tool') -%}
+        {{ '</tool_response>' -}}
+    {%- endif -%}
+
+    {#- Mark end of a single turn -#}
+    {{ '<end_of_turn>\n' }}
+{%- endfor -%}
+
+{#- If generation is to be triggered, add model prompt prefix -#}
+{%- if add_generation_prompt -%}
+    {{'<start_of_turn>model\n'}}
+{%- endif -%}

--- a/extension/llm/runner/templates/tool_chat_template_llama3.2_pythonic.jinja
+++ b/extension/llm/runner/templates/tool_chat_template_llama3.2_pythonic.jinja
@@ -1,0 +1,98 @@
+{{- bos_token }}
+{%- if custom_tools is defined %}
+    {%- set tools = custom_tools %}
+{%- endif %}
+{%- if not tools_in_user_message is defined %}
+    {%- set tools_in_user_message = false %}
+{%- endif %}
+{%- if not date_string is defined %}
+    {%- if strftime_now is defined %}
+        {%- set date_string = strftime_now("%d %b %Y") %}
+    {%- else %}
+        {%- set date_string = "26 Jul 2024" %}
+    {%- endif %}
+{%- endif %}
+{%- if not tools is defined %}
+    {%- set tools = none %}
+{%- endif %}
+
+{#- This block extracts the system message, so we can slot it into the right place. #}
+{%- if messages[0]['role'] == 'system' %}
+    {%- set system_message = messages[0]['content']|trim %}
+    {%- set messages = messages[1:] %}
+{%- else %}
+    {%- set system_message = "You are a helpful assistant with tool calling capabilities. Only reply with a tool call if the function exists in the library provided by the user. If it doesn't exist, just reply directly in natural language. When you receive a tool call response, use the output to format an answer to the original user question." %}
+{%- endif %}
+
+{#- System message #}
+{{- "<|start_header_id|>system<|end_header_id|>\n\n" }}
+{%- if tools is not none %}
+    {{- "Environment: ipython\n" }}
+{%- endif %}
+{{- "Cutting Knowledge Date: December 2023\n" }}
+{{- "Today Date: " + date_string + "\n\n" }}
+{%- if tools is not none and not tools_in_user_message %}
+    {{- "You have access to the following functions. To call functions, please respond with a python list of the calls. " }}
+    {{- 'Respond in the format [func_name1(params_name1=params_value1, params_name2=params_value2...), func_name2(params)] ' }}
+    {{- "Do not use variables.\n\n" }}
+    {%- for t in tools %}
+        {{- t | tojson(indent=4) }}
+        {{- "\n\n" }}
+    {%- endfor %}
+{%- endif %}
+{{- system_message }}
+{{- "<|eot_id|>" }}
+
+{#- Custom tools are passed in a user message with some extra guidance #}
+{%- if tools_in_user_message and not tools is none %}
+    {#- Extract the first user message so we can plug it in here #}
+    {%- if messages | length != 0 %}
+        {%- set first_user_message = messages[0]['content']|trim %}
+        {%- set messages = messages[1:] %}
+    {%- else %}
+        {{- raise_exception("Cannot put tools in the first user message when there's no first user message!") }}
+    {%- endif %}
+    {{- '<|start_header_id|>user<|end_header_id|>\n\n' -}}
+    {{- "Given the following functions, please respond with a python list for function calls " }}
+    {{- "with their proper arguments to best answer the given prompt.\n\n" }}
+    {{- 'Respond in the format [func_name1(params_name1=params_value1, params_name2=params_value2...), func_name2(params)] ' }}
+    {{- "Do not use variables.\n\n" }}
+    {%- for t in tools %}
+        {{- t | tojson(indent=4) }}
+        {{- "\n\n" }}
+    {%- endfor %}
+    {{- first_user_message + "<|eot_id|>"}}
+{%- endif %}
+
+{%- for message in messages %}
+    {%- if not (message.role == 'ipython' or message.role == 'tool' or 'tool_calls' in message) %}
+        {{- '<|start_header_id|>' + message['role'] + '<|end_header_id|>\n\n'+ message['content'] | trim + '<|eot_id|>' }}
+    {%- elif 'tool_calls' in message %}
+        {{- '<|start_header_id|>assistant<|end_header_id|>\n\n[' -}}
+        {%- for tool_call in message.tool_calls %}
+            {%- if tool_call.function is defined %}
+                {%- set tool_call = tool_call.function %}
+            {%- endif %}
+            {{- tool_call.name + '(' -}}
+            {%- for param in tool_call.arguments %}
+                {{- param + '=' -}}
+                {{- "%s" | format(tool_call.arguments[param]) -}}
+                {% if not loop.last %}, {% endif %}
+            {%- endfor %}
+            {{- ')' -}}
+            {% if not loop.last %}, {% endif %}
+        {%- endfor %}
+        {{- ']<|eot_id|>' -}}
+    {%- elif message.role == "tool" or message.role == "ipython" %}
+        {{- "<|start_header_id|>ipython<|end_header_id|>\n\n" }}
+        {%- if message.content is mapping %}
+            {{- message.content | tojson }}
+        {%- else %}
+            {{- { "output": message.content } | tojson }}
+        {%- endif %}
+        {{- "<|eot_id|>" }}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|start_header_id|>assistant<|end_header_id|>\n\n' }}
+{%- endif %}

--- a/extension/llm/runner/test/BUCK
+++ b/extension/llm/runner/test/BUCK
@@ -10,32 +10,21 @@ oncall("executorch")
 # targets.bzl. This file can contain fbcode-only targets.
 
 load(":targets.bzl", "define_common_targets")
-
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
 non_fbcode_target(_kind = define_common_targets,)
 
-# !!!! fbcode/executorch/extension/llm/runner/test/TARGETS was merged into this file, see https://fburl.com/workplace/xl8l9yuo for more info !!!!
-
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
-
-# Any targets that should be shared between fbcode and xplat must be defined in
-# targets.bzl. This file can contain fbcode-only targets.
-
-load(":targets.bzl", "define_common_targets")
-load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
-
 fbcode_target(_kind = define_common_targets,)
 
+# fbcode-only test that requires access to fbcode//executorch/test/models
 fbcode_target(_kind = runtime.cxx_test,
     name = "test_text_decoder_runner",
     srcs = ["test_text_decoder_runner.cpp"],
     deps = [
-        "//executorch/extension/llm/runner:runner_lib",
         "//executorch/extension/llm/runner/io_manager:io_manager",
+        "//executorch/extension/llm/runner:text_decoder_runner",
+        "//executorch/extension/module:module",
+        "//executorch/extension/tensor:tensor",
         "//executorch/kernels/portable:generated_lib",
         "//executorch/runtime/core/exec_aten/testing_util:tensor_util",
     ],
@@ -43,5 +32,5 @@ fbcode_target(_kind = runtime.cxx_test,
         "KVCACHE_CACHE_POS": "$(location fbcode//executorch/test/models:exported_programs[ModuleKVCacheCachePos.pte])",
         "KVCACHE_INPUT_POS": "$(location fbcode//executorch/test/models:exported_programs[ModuleKVCacheInputPos.pte])",
         "NO_KVCACHE": "$(location fbcode//executorch/test/models:exported_programs[ModuleNoKVCache.pte])",
-    }
+    },
 )

--- a/extension/llm/runner/test/CMakeLists.txt
+++ b/extension/llm/runner/test/CMakeLists.txt
@@ -19,6 +19,7 @@ include(${EXECUTORCH_ROOT}/tools/cmake/Test.cmake)
 
 set(_test_srcs
     test_generation_config.cpp
+    test_jinja_chat_formatter.cpp
     test_text_llm_runner.cpp
     test_text_prefiller.cpp
     test_text_decoder_runner.cpp

--- a/extension/llm/runner/test/targets.bzl
+++ b/extension/llm/runner/test/targets.bzl
@@ -18,6 +18,14 @@ def define_common_targets():
     )
 
     runtime.cxx_test(
+        name = "test_jinja_chat_formatter",
+        srcs = ["test_jinja_chat_formatter.cpp"],
+        deps = [
+            "//executorch/extension/llm/runner:runner_lib",
+        ],
+    )
+
+    runtime.cxx_test(
         name = "test_text_llm_runner",
         srcs = ["test_text_llm_runner.cpp"],
         deps = [

--- a/extension/llm/runner/test/test_jinja_chat_formatter.cpp
+++ b/extension/llm/runner/test/test_jinja_chat_formatter.cpp
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/extension/llm/runner/jinja_chat_formatter.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+using executorch::extension::llm::ChatConversation;
+using executorch::extension::llm::ChatMessage;
+using executorch::extension::llm::ChatTemplateType;
+using executorch::extension::llm::JinjaChatFormatter;
+using executorch::extension::llm::parseChatTemplateType;
+using testing::HasSubstr;
+
+TEST(JinjaChatFormatter, Llama3SingleMessage) {
+  auto formatter = JinjaChatFormatter::fromTemplate(ChatTemplateType::Llama3);
+  const std::string prompt = "Test prompt";
+  const std::string system_prompt = "You are a helpful assistant.";
+  // Note: The Jinja template uses {%- ... -%} which strips whitespace,
+  // so the output has \n\n after each <|end_header_id|> and content,
+  // but no trailing \n\n at the end due to the {%- endif -%} stripping.
+  const std::string expected =
+      "<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n\n" +
+      system_prompt +
+      "<|eot_id|><|start_header_id|>user<|end_header_id|>\n\n" + prompt +
+      "<|eot_id|><|start_header_id|>assistant<|end_header_id|>";
+
+  EXPECT_EQ(formatter->format(prompt, system_prompt), expected);
+}
+
+TEST(JinjaChatFormatter, Gemma3SingleMessage) {
+  auto formatter = JinjaChatFormatter::fromTemplate(ChatTemplateType::Gemma3);
+  const std::string result = formatter->format("Hello!");
+
+  EXPECT_THAT(result, HasSubstr("<bos>"));
+  EXPECT_THAT(result, HasSubstr("<start_of_turn>user"));
+  EXPECT_THAT(result, HasSubstr("Hello!"));
+  EXPECT_THAT(result, HasSubstr("<start_of_turn>model"));
+}
+
+TEST(JinjaChatFormatter, Llama3WithoutSystemPrompt) {
+  auto formatter = JinjaChatFormatter::fromTemplate(ChatTemplateType::Llama3);
+  const std::string result = formatter->format("Hello!");
+
+  EXPECT_THAT(result, HasSubstr("<|begin_of_text|>"));
+  EXPECT_THAT(result, HasSubstr("<|start_header_id|>user<|end_header_id|>"));
+  EXPECT_THAT(result, HasSubstr("Hello!"));
+  EXPECT_THAT(result, HasSubstr("<|start_header_id|>assistant<|end_header_id|>"));
+  // Should not contain system header when no system prompt
+  EXPECT_THAT(result, ::testing::Not(HasSubstr("<|start_header_id|>system")));
+}
+
+TEST(JinjaChatFormatter, Llama3IncludesBos) {
+  auto formatter = JinjaChatFormatter::fromTemplate(ChatTemplateType::Llama3);
+  EXPECT_TRUE(formatter->includesBos());
+}
+
+TEST(JinjaChatFormatter, Gemma3IncludesBos) {
+  auto formatter = JinjaChatFormatter::fromTemplate(ChatTemplateType::Gemma3);
+  EXPECT_TRUE(formatter->includesBos());
+}
+
+TEST(JinjaChatFormatter, Llama3ModelTokens) {
+  auto formatter = JinjaChatFormatter::fromTemplate(ChatTemplateType::Llama3);
+  const auto& tokens = formatter->getModelTokens();
+
+  EXPECT_EQ(tokens.bos_token, "<|begin_of_text|>");
+  EXPECT_EQ(tokens.eos_token, "<|eot_id|>");
+  EXPECT_EQ(tokens.stop_tokens.size(), 2);
+}
+
+TEST(JinjaChatFormatter, Gemma3ModelTokens) {
+  auto formatter = JinjaChatFormatter::fromTemplate(ChatTemplateType::Gemma3);
+  const auto& tokens = formatter->getModelTokens();
+
+  EXPECT_EQ(tokens.bos_token, "<bos>");
+  EXPECT_EQ(tokens.eos_token, "<end_of_turn>");
+  EXPECT_EQ(tokens.stop_tokens.size(), 2);
+}
+
+TEST(JinjaChatFormatter, FormatConversationMultiTurn) {
+  auto formatter = JinjaChatFormatter::fromTemplate(ChatTemplateType::Llama3);
+
+  ChatConversation conversation;
+  conversation.bos_token = "<|begin_of_text|>";
+  conversation.eos_token = "<|eot_id|>";
+  conversation.add_generation_prompt = true;
+  conversation.messages = {
+      {"user", "Hello"},
+      {"assistant", "Hi there!"},
+      {"user", "How are you?"},
+  };
+
+  const std::string result = formatter->formatConversation(conversation);
+
+  EXPECT_THAT(result, HasSubstr("Hello"));
+  EXPECT_THAT(result, HasSubstr("Hi there!"));
+  EXPECT_THAT(result, HasSubstr("How are you?"));
+  EXPECT_THAT(result, HasSubstr("<|start_header_id|>assistant<|end_header_id|>"));
+}
+
+TEST(JinjaChatFormatter, FromStringLlama3Template) {
+  const std::string llama_template =
+      "{{ bos_token }}<|start_header_id|>user<|end_header_id|>\n\n"
+      "{{ messages[0].content }}<|eot_id|>";
+
+  auto formatter = JinjaChatFormatter::fromString(llama_template);
+
+  // Should detect Llama3 type from the template content
+  const std::string result = formatter->format("Test");
+  EXPECT_THAT(result, HasSubstr("Test"));
+}
+
+TEST(JinjaChatFormatter, FromStringGemma3Template) {
+  const std::string gemma_template =
+      "{{ bos_token }}<start_of_turn>user\n"
+      "{{ messages[0].content }}<end_of_turn>";
+
+  auto formatter = JinjaChatFormatter::fromString(gemma_template);
+
+  const std::string result = formatter->format("Test");
+  EXPECT_THAT(result, HasSubstr("Test"));
+}
+
+TEST(JinjaChatFormatter, UnsupportedTemplateTypeThrows) {
+  EXPECT_THROW(
+      JinjaChatFormatter::fromTemplate(ChatTemplateType::None),
+      std::runtime_error);
+}
+
+// Tests for parseChatTemplateType
+TEST(ParseChatTemplateType, ParseNone) {
+  EXPECT_EQ(parseChatTemplateType("none"), ChatTemplateType::None);
+  EXPECT_EQ(parseChatTemplateType("None"), ChatTemplateType::None);
+  EXPECT_EQ(parseChatTemplateType("NONE"), ChatTemplateType::None);
+}
+
+TEST(ParseChatTemplateType, ParseLlama3) {
+  EXPECT_EQ(parseChatTemplateType("llama3"), ChatTemplateType::Llama3);
+  EXPECT_EQ(parseChatTemplateType("LLAMA3"), ChatTemplateType::Llama3);
+  EXPECT_EQ(parseChatTemplateType("Llama3"), ChatTemplateType::Llama3);
+}
+
+TEST(ParseChatTemplateType, ParseLlama32Variants) {
+  EXPECT_EQ(parseChatTemplateType("llama3.2"), ChatTemplateType::Llama32);
+  EXPECT_EQ(parseChatTemplateType("llama32"), ChatTemplateType::Llama32);
+  EXPECT_EQ(parseChatTemplateType("llama3_2"), ChatTemplateType::Llama32);
+  EXPECT_EQ(parseChatTemplateType("LLAMA3.2"), ChatTemplateType::Llama32);
+}
+
+TEST(ParseChatTemplateType, ParseGemma3) {
+  EXPECT_EQ(parseChatTemplateType("gemma3"), ChatTemplateType::Gemma3);
+  EXPECT_EQ(parseChatTemplateType("GEMMA3"), ChatTemplateType::Gemma3);
+  EXPECT_EQ(parseChatTemplateType("Gemma3"), ChatTemplateType::Gemma3);
+}
+
+TEST(ParseChatTemplateType, ParseCustom) {
+  EXPECT_EQ(parseChatTemplateType("custom"), ChatTemplateType::Custom);
+  EXPECT_EQ(parseChatTemplateType("jinja"), ChatTemplateType::Custom);
+  EXPECT_EQ(parseChatTemplateType("CUSTOM"), ChatTemplateType::Custom);
+}
+
+TEST(ParseChatTemplateType, ParseUnknownReturnsNone) {
+  EXPECT_EQ(parseChatTemplateType("unknown"), ChatTemplateType::None);
+  EXPECT_EQ(parseChatTemplateType(""), ChatTemplateType::None);
+  EXPECT_EQ(parseChatTemplateType("invalid"), ChatTemplateType::None);
+}
+
+TEST(JinjaChatFormatter, Llama32SingleMessage) {
+  auto formatter = JinjaChatFormatter::fromTemplate(ChatTemplateType::Llama32);
+  const std::string result = formatter->format("Hello!");
+
+  // Llama32 uses the same template as Llama3
+  EXPECT_THAT(result, HasSubstr("<|begin_of_text|>"));
+  EXPECT_THAT(result, HasSubstr("<|start_header_id|>user<|end_header_id|>"));
+  EXPECT_THAT(result, HasSubstr("Hello!"));
+  EXPECT_THAT(result, HasSubstr("<|start_header_id|>assistant<|end_header_id|>"));
+}
+
+TEST(JinjaChatFormatter, Llama32IncludesBos) {
+  auto formatter = JinjaChatFormatter::fromTemplate(ChatTemplateType::Llama32);
+  EXPECT_TRUE(formatter->includesBos());
+}
+
+TEST(JinjaChatFormatter, Llama32ModelTokens) {
+  auto formatter = JinjaChatFormatter::fromTemplate(ChatTemplateType::Llama32);
+  const auto& tokens = formatter->getModelTokens();
+
+  EXPECT_EQ(tokens.bos_token, "<|begin_of_text|>");
+  EXPECT_EQ(tokens.eos_token, "<|eot_id|>");
+  EXPECT_EQ(tokens.stop_tokens.size(), 2);
+}

--- a/shim_et/xplat/executorch/build/build_variables.bzl
+++ b/shim_et/xplat/executorch/build/build_variables.bzl
@@ -354,6 +354,7 @@ EXTENSION_RUNNER_UTIL_SRCS = [
 ]
 
 EXTENSION_LLM_RUNNER_SRCS = [
+    "extension/llm/runner/jinja_chat_formatter.cpp",
     "extension/llm/runner/llm_runner_helper.cpp",
     "extension/llm/runner/multimodal_prefiller.cpp",
     "extension/llm/runner/multimodal_runner.cpp",


### PR DESCRIPTION
### Summary

Without chat formatting, Instruct models behave like base models and never generate end-of-turn tokens. 

So, I added chat template support to the `llama_main` runner for Llama 3 Instruct models.

## Problem

When running Llama 3 Instruct models without proper chat formatting:

```bash
cmake-out/examples/models/llama/llama_main \    
    --model_path="llama/Llama-3.2-1B-Instruct/model.pte" \
    --tokenizer_path="llama/original/tokenizer.model" \
    --prompt="What's the capital of France?"

Paris is incorrect answer so was stated so some major tech companies may choose the other city, and for instance the CEO of Apple is Tim Cook and he is from California, and the CEO of Google is Sundar Pichai and he is from India.
```
==>  Only max_tokens limit

### Solution

New CLI flags enable proper Instruct model behavior:

| Flag | Description | Default |
|------|-------------|---------|
| `--chat_format` | Chat template (llama3, none) | `none` |
| `--system_prompt` | System prompt for assistant behavior | (empty) |
| `--echo` | Echo input prompt in output | `true` |

### Examples

#### Basic Usage
```bash
cmake-out/examples/models/llama/llama_main \
    --model_path="llama/Llama-3.2-1B-Instruct/model.pte" \
    --tokenizer_path="llama/original/tokenizer.model" \
    --chat_format="llama3" \
    --prompt="What's the capital of France?"
```

**Output:**
```
<|begin_of_text|><|start_header_id|>user<|end_header_id|>

What's the capital of France?<|eot_id|><|start_header_id|>assistant<|end_header_id|>

The capital of France is Paris.
```

#### Clean Output (Recommended for Apps)
```bash
cmake-out/examples/models/llama/llama_main \
    --model_path="llama/Llama-3.2-1B-Instruct/model.pte" \
    --tokenizer_path="llama/original/tokenizer.model" \
    --chat_format="llama3" \
    --echo=false \
    --prompt="What's the capital of France?"
```

**Output:**
```
The capital of France is Paris.
```

#### With System Prompt
```bash
cmake-out/examples/models/llama/llama_main \
    --model_path="llama/Llama-3.2-1B-Instruct/model.pte" \
    --tokenizer_path="llama/original/tokenizer.model" \
    --chat_format="llama3" \
    --system_prompt="You are a helpful assistant. Be concise and respond in one sentence." \
    --echo=false \
    --prompt="Explain quantum computing"
```

**Output:**
```
Quantum computing uses quantum bits (qubits) that can exist in multiple states simultaneously to solve complex problems faster than classical computers.
```

#### Backward Compatible (No Chat Format)
```bash
# For base models or pre-formatted prompts
cmake-out/examples/models/llama/llama_main \
    --model_path="llama/Llama-3.2-1B/model.pte" \
    --tokenizer_path="llama/original/tokenizer.model" \
    --chat_format="none" \
    --prompt="Once upon a time"
```

### Files Changed

| File | Description |
|------|-------------|
| `examples/models/llama/runner/chat_formatter.h` | **NEW** - ChatFormatter for Llama 3 |
| `examples/models/llama/main.cpp` | Added CLI flags |
| `examples/models/llama/README.md` | Documentation with examples |
| `extension/llm/runner/text_llm_runner.cpp` | Special token filtering |
| `extension/llm/runner/llm_runner_helper.cpp` | EOS token merge logic |

### Before/After Comparison

| Metric | Before (no chat format) | After (--chat_format=llama3 --echo=false) |
|--------|------------------------|------------------------------------------|
| Tokens generated | 120 (max limit) | 7 (stops at EOS) |
| Output | Rambling continuation | Clean answer |
| Special tokens | Visible in output | Filtered out |

### Test Plan
- [x] Build with `make llama-cpu`
- [x] Test `--chat_format=llama3` with Llama-3.2-1B-Instruct
- [x] Verify generation stops at `<|eot_id|>` token
- [x] Test `--echo=false` produces clean output without special tokens
- [x] Test `--system_prompt` affects model behavior
- [x] Backward compatible with `--chat_format=none` (default)
