### PR TITLE
Remove FuseCascadedViewOps from ReplaceNopTransposeOrPermuteWithViewPass.

### DIFF
--- a/backends/cadence/aot/replace_ops.py
+++ b/backends/cadence/aot/replace_ops.py
@@ -20,10 +20,7 @@ from typing import cast, Dict, Optional, Sequence
 import torch
 import torch.fx
 from executorch.backends.cadence.aot.compiler_utils import quantize_tensor_multiplier
-from executorch.backends.cadence.aot.fuse_ops import (
-    FuseCascadedTransposeOrPermuteOps,
-    FuseCascadedViewOps,
-)
+from executorch.backends.cadence.aot.fuse_ops import FuseCascadedTransposeOrPermuteOps
 from executorch.backends.cadence.aot.pass_utils import (
     CadencePassAttribute,
     register_cadence_pass,
@@ -1662,16 +1659,6 @@ class ReplaceNopTransposeOrPermuteWithViewPass(RemoveOrReplacePassInterface):
 
         return False
 
-    def call(self, graph_module: torch.fx.GraphModule) -> PassResult:
-        result = super().call(graph_module)
-
-        # TODO: I tried conditionally running this only if the above made any modifications,
-        # but for whatever reason was getting numerical failures in
-        # test_mtl_e2e_test_a16w8_two_layers_turing_3_1_1k. Always running this pass
-        # resolved that issue.
-        fuse_cascaded_result = FuseCascadedViewOps().call(result.graph_module)
-        return PassResult(fuse_cascaded_result.graph_module, True)
-
 
 @register_cadence_pass(CadencePassAttribute(opt_level=2))
 class ReplaceLinearWithFullyConnectedOpPass(RemoveOrReplacePassInterface):
@@ -1792,7 +1779,6 @@ class ReplaceInfArgInFullWithValuePass(RemoveOrReplacePassInterface):
         return [exir_ops.edge.aten.full.default]
 
     def maybe_remove_or_replace(self, node: torch.fx.Node) -> bool:
-
         new_args = list(node.args)
         fill_value = node.args[1]
         if fill_value == float("-inf"):


### PR DESCRIPTION
Summary: A nested call to the pass breaks the modified flag of the outer pass. Ideally the extra view elimination should be done through either an external pass ordering fix or a greedy optimizer.

Differential Revision: D91738042


