### PR TITLE
Arm backend: Remove old CI workaround

### DIFF
--- a/backends/arm/test/ops/test_mean_dim.py
+++ b/backends/arm/test/ops/test_mean_dim.py
@@ -1,6 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
-# Copyright 2024-2025 Arm Limited and/or its affiliates.
+# Copyright 2024-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -247,6 +247,8 @@ class MeanDim(torch.nn.Module):
             (2),
             False,
         ),
+    }
+    u55_test_data_suite = {
         "u55_avg_pool_not_supported": lambda: (
             torch.rand(1, 1, 1, 257),
             (0, 1, 2, 3),
@@ -288,7 +290,9 @@ def test_mean_dim_tosa_INT(test_data):
     pipeline.run()
 
 
-@common.parametrize("test_data", MeanDim.test_data_suite)
+@common.parametrize(
+    "test_data", {**MeanDim.test_data_suite, **MeanDim.u55_test_data_suite}
+)
 @common.XfailIfNoCorstone300
 def test_mean_dim_u55_INT(test_data):
     test_data, dim, keep_dim = test_data()

--- a/backends/arm/test/tester/test_pipeline.py
+++ b/backends/arm/test/tester/test_pipeline.py
@@ -1176,15 +1176,3 @@ class VgfPipeline(BasePipeline, Generic[T]):
                 inputs=self.test_data,
             )
         self.run_on_vulkan_runtime = run_on_vulkan_runtime
-
-    # TODO: Remove once CI fully working
-    def run(self):
-        import pytest
-
-        if self.run_on_vulkan_runtime:
-            try:
-                super().run()
-            except FileNotFoundError as e:
-                pytest.skip(f"VKML executor_runner not found - not built - skip {e}")
-        else:
-            super().run()


### PR DESCRIPTION
Also run only "u55_avg_pool_not_supported" with
EthosU55PipelineINT. This is related to CI and the workaround removal, in that it avoid mixing u55 and vgf tests that could e.g. run with different setups.

Signed-off-by: Måns Nilsson <mans.nilsson@arm.com>


cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai