### PR TITLE
Qualcomm AI Engine Direct - Remove the workaround used to clean the kwargs for the constant operation

### DIFF
--- a/backends/qualcomm/quantizer/annotators.py
+++ b/backends/qualcomm/quantizer/annotators.py
@@ -410,8 +410,6 @@ def annotate_arange(node: Node, quantization_config: QuantizationConfig) -> None
         return
 
     if _is_float_tensor(node):
-        # workaround for node with kwargs could not be correctly annotated
-        node.kwargs = {}
         node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
             input_qspec_map={},
             output_qspec=quantization_config.output_activation,
@@ -491,8 +489,6 @@ def annotate_scalar_tensor(node: Node, quantization_config: QuantizationConfig) 
     if _is_annotated([node]):
         return
     if _is_float_tensor(node):
-        # workaround for node with kwargs could not be correctly annotated
-        node.kwargs = {}
         node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
             input_qspec_map={},
             output_qspec=quantization_config.output_activation,
@@ -547,8 +543,6 @@ def annotate_full(node: Node, quantization_config: QuantizationConfig) -> None:
         return
 
     if _is_float_tensor(node):
-        # workaround for node with kwargs could not be correctly annotated
-        node.kwargs = {}
         node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
             input_qspec_map={},
             output_qspec=quantization_config.output_activation,
@@ -1492,8 +1486,6 @@ def annotate_zeros(node: Node, quantization_config: QuantizationConfig) -> None:
     if _is_annotated([node]) or not _is_float_tensor(node):
         return
 
-    # workaround for node with kwargs could not be correctly annotated
-    node.kwargs = {}
     node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
         input_qspec_map={},
         output_qspec=quantization_config.output_activation,


### PR DESCRIPTION
This issue appears to be resolved by the PR below, so it should be fine to remove it from the annotation logic now.
[Allow non-tensor kwargs in prepare_pt2e (#3642) · pytorch/ao@79d1eca](https://github.com/pytorch/ao/commit/79d1eca8557658b67d2abc62fa51d8ae875f562c#diff-021ab2e7f5848c2dabf45478f6d3477d4f5c678ce9c444dcebc23b2d2dd0d39f)