### PR TITLE
Arm backend: Add FP16 support to operators pt.1

### DIFF
--- a/backends/arm/operators/op_abs.py
+++ b/backends/arm/operators/op_abs.py
@@ -37,7 +37,7 @@ class AbsVisitor(NodeVisitor):
         validate_valid_dtype(
             self.target,
             [*inputs, output],
-            [ts.DType.INT32, ts.DType.FP32, ts.DType.BF16],
+            [ts.DType.INT32, ts.DType.FP16, ts.DType.FP32, ts.DType.BF16],
             self.tosa_spec,
         )
 

--- a/backends/arm/operators/op_avg_pool2d.py
+++ b/backends/arm/operators/op_avg_pool2d.py
@@ -109,7 +109,12 @@ class AvgPool2dVisitor(NodeVisitor):
     ) -> None:
         validate_num_inputs(self.target, inputs, [3, 4, 5, 6, 7])
         validate_same_dtype(self.target, [inputs[0], output], ts)
-        supported_dtypes = [ts.DType.INT8, ts.DType.FP32, ts.DType.BF16]
+        supported_dtypes = [
+            ts.DType.INT8,
+            ts.DType.FP16,
+            ts.DType.FP32,
+            ts.DType.BF16,
+        ]
         if self.tosa_spec.support_extension("int16"):
             supported_dtypes.append(ts.DType.INT16)
         validate_valid_dtype(

--- a/backends/arm/operators/op_cat.py
+++ b/backends/arm/operators/op_cat.py
@@ -39,6 +39,7 @@ class CatVisitor(NodeVisitor):
             ts.DType.BOOL,
             ts.DType.INT8,
             ts.DType.INT32,
+            ts.DType.FP16,
             ts.DType.FP32,
             ts.DType.BF16,
         ]

--- a/backends/arm/operators/op_ceil.py
+++ b/backends/arm/operators/op_ceil.py
@@ -45,7 +45,7 @@ class CeilVisitor(NodeVisitor):
         validate_valid_dtype(
             self.target,
             inputs[0],
-            [ts.DType.FP32, ts.DType.BF16],
+            [ts.DType.FP16, ts.DType.FP32, ts.DType.BF16],
             self.tosa_spec,
         )
 

--- a/backends/arm/operators/op_maximum.py
+++ b/backends/arm/operators/op_maximum.py
@@ -40,7 +40,7 @@ class MaxVisitor(NodeVisitor):
         validate_valid_dtype(
             self.target,
             [*inputs, output],
-            [ts.DType.INT32, ts.DType.FP32, ts.DType.BF16],
+            [ts.DType.INT32, ts.DType.FP16, ts.DType.FP32, ts.DType.BF16],
             self.tosa_spec,
         )
 

--- a/backends/arm/operators/op_minimum.py
+++ b/backends/arm/operators/op_minimum.py
@@ -41,7 +41,7 @@ class MinVisitor(NodeVisitor):
         validate_valid_dtype(
             self.target,
             [*inputs, output],
-            [ts.DType.INT32, ts.DType.FP32, ts.DType.BF16],
+            [ts.DType.INT32, ts.DType.FP16, ts.DType.FP32, ts.DType.BF16],
             self.tosa_spec,
         )
 

--- a/backends/arm/test/ops/test_abs.py
+++ b/backends/arm/test/ops/test_abs.py
@@ -38,12 +38,19 @@ class Abs(torch.nn.Module):
         "randn_1d_bf16": lambda: (torch.randn(8, dtype=torch.bfloat16),),
         "randn_4d_bf16": lambda: (torch.randn(1, 2, 3, 4, dtype=torch.bfloat16),),
     }
+    test_parameters_fp16 = {
+        "randn_1d_fp16": lambda: (torch.randn(8, dtype=torch.float16),),
+        "randn_4d_fp16": lambda: (torch.randn(1, 2, 3, 4, dtype=torch.float16),),
+    }
 
     def forward(self, x):
         return torch.abs(x)
 
 
-@common.parametrize("test_data", Abs.test_parameters | Abs.test_parameters_bf16)
+@common.parametrize(
+    "test_data",
+    Abs.test_parameters | Abs.test_parameters_bf16 | Abs.test_parameters_fp16,
+)
 def test_abs_tosa_FP(test_data: torch.Tensor):
     pipeline = TosaPipelineFP[input_t1](
         Abs(), test_data(), aten_op, exir_op, tosa_extensions=["bf16"]
@@ -81,7 +88,7 @@ def test_abs_u85_INT(test_data: torch.Tensor):
     pipeline.run()
 
 
-@common.parametrize("test_data", Abs.test_parameters)
+@common.parametrize("test_data", Abs.test_parameters | Abs.test_parameters_fp16)
 @common.SkipIfNoModelConverter
 def test_abs_vgf_no_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](

--- a/backends/arm/test/ops/test_avg_pool2d.py
+++ b/backends/arm/test/ops/test_avg_pool2d.py
@@ -134,9 +134,19 @@ test_modules_bf16 = {
         (torch.rand(1, 4, 12, 12, dtype=torch.bfloat16),),
     ),
 }
+test_modules_fp16 = {
+    "rand_fp16": lambda: (
+        AvgPool2d(4, 2, 0, False),
+        (torch.rand(1, 16, 50, 32, dtype=torch.float16),),
+    ),
+    "kernel_3x3_stride_1_pad_1_fp16": lambda: (
+        AvgPool2d((3, 3), (1, 1), 1),
+        (torch.rand(1, 4, 12, 12, dtype=torch.float16),),
+    ),
+}
 
 
-@common.parametrize("test_module", test_modules | test_modules_bf16)
+@common.parametrize("test_module", test_modules | test_modules_bf16 | test_modules_fp16)
 def test_avg_pool2d_tosa_FP(test_module):
     model, input_tensor = test_module()
 
@@ -242,7 +252,7 @@ def test_avg_pool2d_16a8w_u85_INT(test_module):
     pipeline.run()
 
 
-@common.parametrize("test_module", test_modules)
+@common.parametrize("test_module", test_modules | test_modules_fp16)
 @common.SkipIfNoModelConverter
 def test_avg_pool2d_vgf_no_quant(test_module):
     model, input_tensor = test_module()

--- a/backends/arm/test/ops/test_cat.py
+++ b/backends/arm/test/ops/test_cat.py
@@ -82,6 +82,22 @@ class Cat(torch.nn.Module):
             0,
         ),
     }
+    test_parameters_fp16 = {
+        "cat_rand_two_tensors_fp16": lambda: (
+            (
+                torch.randn(1, 2, 4, 4, dtype=torch.float16),
+                torch.randn(1, 2, 4, 1, dtype=torch.float16),
+            ),
+            3,
+        ),
+        "cat_rand_dim0_fp16": lambda: (
+            (
+                torch.randn(1, 2, 4, 4, dtype=torch.float16),
+                torch.randn(1, 2, 4, 4, dtype=torch.float16),
+            ),
+            0,
+        ),
+    }
 
     def __init__(self):
         super().__init__()
@@ -90,7 +106,10 @@ class Cat(torch.nn.Module):
         return torch.cat(t, dim=dim)
 
 
-@common.parametrize("test_data", Cat.test_parameters | Cat.test_parameters_bf16)
+@common.parametrize(
+    "test_data",
+    Cat.test_parameters | Cat.test_parameters_bf16 | Cat.test_parameters_fp16,
+)
 def test_cat_tosa_FP(test_data: Tuple):
     pipeline = TosaPipelineFP[input_t1](
         Cat(),
@@ -151,7 +170,7 @@ def test_cat_u85_INT(test_data: Tuple):
     pipeline.run()
 
 
-@common.parametrize("test_data", Cat.test_parameters)
+@common.parametrize("test_data", Cat.test_parameters | Cat.test_parameters_fp16)
 @common.SkipIfNoModelConverter
 def test_cat_vgf_no_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](

--- a/backends/arm/test/ops/test_ceil.py
+++ b/backends/arm/test/ops/test_ceil.py
@@ -52,9 +52,19 @@ test_data_bf16 = {
         torch.arange(-8, 8, 0.25, dtype=torch.bfloat16),
     ),
 }
+test_data_fp16 = {
+    "ceil_rand_fp16": lambda: (
+        Ceil(),
+        (torch.rand(4, 4, dtype=torch.float16) - 0.5),
+    ),
+    "ceil_ramp_fp16": lambda: (
+        Ceil(),
+        torch.arange(-8, 8, 0.25, dtype=torch.float16),
+    ),
+}
 
 
-@common.parametrize("test_data", test_data | test_data_bf16)
+@common.parametrize("test_data", test_data | test_data_bf16 | test_data_fp16)
 def test_ceil_tosa_FP(test_data: input_t1):
     module, data = test_data()
     pipeline = TosaPipelineFP[input_t1](
@@ -107,7 +117,7 @@ def test_ceil_u85_INT(test_data: input_t1):
     pipeline.run()
 
 
-@common.parametrize("test_data", test_data)
+@common.parametrize("test_data", test_data | test_data_fp16)
 @common.SkipIfNoModelConverter
 def test_ceil_vgf_no_quant(test_data: input_t1):
     module, data = test_data()

--- a/backends/arm/test/ops/test_clamp.py
+++ b/backends/arm/test/ops/test_clamp.py
@@ -47,6 +47,18 @@ test_data_suite_bf16 = {
         None,
     ),
 }
+test_data_suite_fp16 = {
+    "rank_2_fp16": lambda: (
+        torch.rand(1, 35, dtype=torch.float16),
+        0.5,
+        0.8,
+    ),
+    "rank_4_no_max_fp16": lambda: (
+        torch.rand(1, 10, 10, 1, dtype=torch.float16) - 3,
+        -3.3,
+        None,
+    ),
+}
 
 test_data_suite_int32 = {
     "int32_rank2": lambda: (torch.randint(-50, 50, (2, 3), dtype=torch.int32), -10, 10),
@@ -83,7 +95,9 @@ class Clamp(torch.nn.Module):
         return torch.clamp(x, self.clamp_min, self.clamp_max)
 
 
-@common.parametrize("test_data", test_data_suite | test_data_suite_bf16)
+@common.parametrize(
+    "test_data", test_data_suite | test_data_suite_bf16 | test_data_suite_fp16
+)
 def test_clamp_tosa_FP(test_data):
     input_tensor, min_val, max_val = test_data()
     model = Clamp(min_val, max_val)
@@ -209,7 +223,7 @@ def test_clamp_u85_INT_16a8w(test_data):
     pipeline.run()
 
 
-@common.parametrize("test_data", test_data_suite)
+@common.parametrize("test_data", test_data_suite | test_data_suite_fp16)
 @common.SkipIfNoModelConverter
 def test_clamp_vgf_no_quant(test_data):
     input_tensor, min_val, max_val = test_data()
@@ -277,6 +291,18 @@ test_data_suite_tensor_bf16 = {
     "rank_4_no_max_bf16": lambda: (
         torch.rand(10, 20, 30, 40, dtype=torch.bfloat16) - 3,
         torch.tensor(-0.1, dtype=torch.bfloat16),
+        None,
+    ),
+}
+test_data_suite_tensor_fp16 = {
+    "rank_2_fp16": lambda: (
+        torch.rand(1, 35, dtype=torch.float16),
+        torch.tensor(0.5, dtype=torch.float16),
+        torch.tensor(0.8, dtype=torch.float16),
+    ),
+    "rank_4_no_max_fp16": lambda: (
+        torch.rand(10, 20, 30, 40, dtype=torch.float16) - 3,
+        torch.tensor(-0.1, dtype=torch.float16),
         None,
     ),
 }
@@ -356,7 +382,10 @@ test_data_suite_tensor_INT64 = {
 
 
 @common.parametrize(
-    "test_data", test_data_suite_tensor_FP | test_data_suite_tensor_bf16
+    "test_data",
+    test_data_suite_tensor_FP
+    | test_data_suite_tensor_bf16
+    | test_data_suite_tensor_fp16,
 )
 def test_clamp_tosa_FP_tensor(test_data):
     input_tensor, min_val, max_val = test_data()
@@ -472,7 +501,9 @@ def test_clamp_u85_INT_16a8w_tensor(test_data):
     pipeline.run()
 
 
-@common.parametrize("test_data", test_data_suite_tensor_FP)
+@common.parametrize(
+    "test_data", test_data_suite_tensor_FP | test_data_suite_tensor_fp16
+)
 @common.SkipIfNoModelConverter
 def test_clamp_vgf_no_quant_tensor(test_data):
     input_tensor, min_val, max_val = test_data()

--- a/backends/arm/test/ops/test_minimum.py
+++ b/backends/arm/test/ops/test_minimum.py
@@ -20,6 +20,7 @@ from executorch.backends.arm.test.tester.test_pipeline import (
 
 test_t = tuple[torch.Tensor, torch.Tensor]
 aten_op = "torch.ops.aten.minimum.default"
+exir_op = "executorch_exir_dialects_edge__ops_aten_minimum_default"
 
 
 class Minimum(torch.nn.Module):
@@ -36,6 +37,12 @@ class Minimum(torch.nn.Module):
             torch.randn(1, 1, 4, 1),
         ),
     }
+    test_parameters_fp16 = {
+        "fp16_rand": lambda: (
+            torch.randn(1, 3, 4, 4, dtype=torch.float16),
+            torch.randn(1, 3, 4, 4, dtype=torch.float16),
+        ),
+    }
 
     def __init__(self):
         super().__init__()
@@ -44,14 +51,22 @@ class Minimum(torch.nn.Module):
         return torch.minimum(x, y)
 
 
-@common.parametrize("test_data", Minimum.test_parameters)
+@common.parametrize(
+    "test_data",
+    Minimum.test_parameters | Minimum.test_parameters_fp16,
+)
 def test_minimum_tosa_FP(test_data: Tuple):
-    TosaPipelineFP[test_t](Minimum(), test_data(), aten_op).run()
+    TosaPipelineFP[test_t](
+        Minimum(),
+        test_data(),
+        aten_op,
+        exir_op,
+    ).run()
 
 
 @common.parametrize("test_data", Minimum.test_parameters)
 def test_minimum_tosa_INT(test_data: Tuple):
-    TosaPipelineINT[test_t](Minimum(), test_data(), aten_op).run()
+    TosaPipelineINT[test_t](Minimum(), test_data(), aten_op, exir_op).run()
 
 
 @common.parametrize("test_data", Minimum.test_parameters)
@@ -61,6 +76,7 @@ def test_minimum_u55_INT(test_data: Tuple):
         Minimum(),
         test_data(),
         aten_op,
+        exir_op,
     ).run()
 
 
@@ -71,16 +87,18 @@ def test_minimum_u85_INT(test_data: Tuple):
         Minimum(),
         test_data(),
         aten_op,
+        exir_op,
     ).run()
 
 
-@common.parametrize("test_data", Minimum.test_parameters)
+@common.parametrize("test_data", Minimum.test_parameters | Minimum.test_parameters_fp16)
 @common.SkipIfNoModelConverter
 def test_minimum_vgf_no_quant(test_data: test_t):
     pipeline = VgfPipeline[test_t](
         Minimum(),
         test_data(),
         aten_op,
+        exir_op,
         quantize=False,
     )
     pipeline.run()
@@ -93,6 +111,7 @@ def test_minimum_vgf_quant(test_data: test_t):
         Minimum(),
         test_data(),
         aten_op,
+        exir_op,
         quantize=True,
     )
     pipeline.run()
@@ -105,6 +124,7 @@ def test_minimum_tosa_INT_a16w8(test_data: test_t):
         Minimum(),
         test_data(),
         aten_op,
+        exir_op,
         tosa_extensions=["int16"],
     )
     pipeline.run()
@@ -118,6 +138,7 @@ def test_minimum_u55_INT_a16w8(test_data: test_t):
         Minimum(),
         test_data(),
         aten_op,
+        exir_op,
         per_channel_quantization=False,
         a16w8_quantization=True,
         use_to_edge_transform_and_lower=True,
@@ -133,6 +154,7 @@ def test_minimum_u85_INT_a16w8(test_data: test_t):
         Minimum(),
         test_data(),
         aten_op,
+        exir_op,
         per_channel_quantization=False,
         a16w8_quantization=True,
         use_to_edge_transform_and_lower=True,


### PR DESCRIPTION
Add FP16 support for operators:
 - abs
 - average_pool_2d
 - cat
 - ceil
 - clamp

Update op tests to cover the new datatype.

cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai