### PR TITLE
NXP backend: Fix Neutron IR node support check.

### DIFF
--- a/backends/nxp/backend/ir/converter/node_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converter.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 NXP
+# Copyright 2024-2026 NXP
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -170,16 +170,25 @@ class NodeConverter(ABC):
         return True
 
     def assert_convertible(self, node):
-        """Assert that the call `_is_supported_in_IR()` returns `True`. Otherwise, raise an exception and print an
+        """Assert that the call `is_supported()` returns `True`. Otherwise, raise an exception and print an
         error message.
         """
-        assert self._is_supported_in_IR(
+        supported_in_ir = self._is_supported_in_IR(
             node,
             self.context.parameters_mapping,
             self.context.custom_delegation_options,
-        ), (
-            f"Node `{node}` is not convertible to the intermediate representation. "
-            "There is an error in the partitioner."
+        )
+
+        supported_on_target = self._is_supported_on_target(
+            node,
+            self.neutron_target_spec,
+            self.context.parameters_mapping,
+            self.context.custom_delegation_options,
+        )
+
+        assert supported_in_ir and supported_on_target, (
+            f"Node `{node}` was selected for delegation to Neutron, but it is not convertible to the intermediate "
+            "representation. There is an error in the Neutron partitioner. Please report this."
         )
 
     @property

--- a/backends/nxp/tests/executors.py
+++ b/backends/nxp/tests/executors.py
@@ -1,7 +1,8 @@
-# Copyright 2023-2025 NXP
+# Copyright 2023-2026 NXP
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+
 import warnings
 from typing import Callable, Dict, Union
 
@@ -9,6 +10,9 @@ import numpy
 import numpy as np
 import torch
 
+from executorch.backends.nxp.backend.custom_delegation_options import (
+    CustomDelegationOptions,
+)
 from executorch.backends.nxp.backend.edge_program_converter import (
     EdgeProgramToIRConverter,
 )
@@ -25,6 +29,7 @@ from executorch.backends.nxp.backend.node_format_inference import NodeFormatInfe
 from torch.export import ExportedProgram
 from torch.fx import Node
 from torch.fx.graph import Graph
+from torch.nn import Parameter
 
 # If executed on i.MX platform, there is no tensorflow module. And typically the intention is to use the tflite python
 # interpreter available in tflite_runtime
@@ -379,10 +384,13 @@ def graph_contains_any(graph: Graph, condition: Callable[[Node], bool]) -> bool:
     return any(map(condition, graph.nodes))
 
 
-target_support_check_function = Callable[[Node, NeutronTargetSpec], bool]
+target_support_check_function = Callable[
+    [Node, NeutronTargetSpec, dict[str, Parameter], CustomDelegationOptions], bool
+]
 
 
 class OverrideTargetSupportCheck:
+    """Temporarily override the static method `_is_supported_on_target` on a NodeConverter subclass."""
 
     def __init__(
         self,
@@ -392,10 +400,24 @@ class OverrideTargetSupportCheck:
     ):
         self._converter_class = converter_class
         self.new_target_support_check = new_target_support_check
-        self.old_target_support_check = converter_class._is_supported_on_target
+
+        # Retrieve the method exactly as defined in the class, not the bound attribute.
+        # This preserves the `staticmethod` wrapper.
+        self.old_target_support_check = converter_class.__dict__.get(
+            "_is_supported_on_target", None
+        )
+        if self.old_target_support_check is None:
+            # The class doesn't override the method, so retrieve it from the parent class.
+            self.old_target_support_check = NodeConverter.__dict__[
+                "_is_supported_on_target"
+            ]
 
     def __enter__(self):
-        self._converter_class._is_supported_on_target = self.new_target_support_check
+        # Replace the target check with the mock method converted to a `staticmethod`.
+        self._converter_class._is_supported_on_target = staticmethod(
+            self.new_target_support_check
+        )
 
     def __exit__(self, exc_type, exc_val, exc_tb):
+        # Restore the original method, exactly as it was in the class dictionary.
         self._converter_class._is_supported_on_target = self.old_target_support_check

--- a/backends/nxp/tests/ir/converter/node_converter/test_constant_pad_nd_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_constant_pad_nd_converter.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 NXP
+# Copyright 2024-2026 NXP
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -6,8 +6,10 @@
 import numpy as np
 import pytest
 import torch
-
 from executorch.backends.nxp.backend.ir.conversion_config import ConversionConfig
+from executorch.backends.nxp.backend.ir.converter.node_converters.ops_converters.constant_pad_nd_converter import (
+    ConstantPadNDConverter,
+)
 from executorch.backends.nxp.tests.executorch_pipeline import (
     to_edge_program,
     to_quantized_edge_program,
@@ -23,6 +25,7 @@ from executorch.backends.nxp.tests.models import (
     ConstantPadNDModule,
 )
 from executorch.backends.nxp.tests.use_qat import *  # noqa F403
+from executorch.backends.nxp.tests.executors import OverrideTargetSupportCheck
 from executorch.exir.dialects._ops import ops as exir_ops
 
 
@@ -43,7 +46,14 @@ def test_constant_pad_nd_conversion__specific_constant(constant):
 
     input_data = np.random.random(input_shape).astype(np.float32)
 
-    convert_run_compare(edge_program, input_data)
+    # Ignore the target requirement, as this test is target agnostic.
+    def supported_target(*_):
+        return True
+
+    with OverrideTargetSupportCheck(
+        ConstantPadNDConverter, new_target_support_check=supported_target
+    ):
+        convert_run_compare(edge_program, input_data)
 
 
 def test_constant_pad_nd_conversion__default_constant():
@@ -56,7 +66,14 @@ def test_constant_pad_nd_conversion__default_constant():
 
     input_data = np.random.random(input_shape).astype(np.float32)
 
-    convert_run_compare(edge_program, input_data)
+    # Ignore the target requirement, as this test is target agnostic.
+    def supported_target(*_):
+        return True
+
+    with OverrideTargetSupportCheck(
+        ConstantPadNDConverter, new_target_support_check=supported_target
+    ):
+        convert_run_compare(edge_program, input_data)
 
 
 @pytest.mark.parametrize(
@@ -80,7 +97,14 @@ def test_constant_pad_nd_conversion__format_less(input_shape, paddings):
 
     input_data = np.random.random(input_shape).astype(np.float32)
 
-    convert_run_compare(edge_program, input_data)
+    # Ignore the target requirement, as this test is target agnostic.
+    def supported_target(*_):
+        return True
+
+    with OverrideTargetSupportCheck(
+        ConstantPadNDConverter, new_target_support_check=supported_target
+    ):
+        convert_run_compare(edge_program, input_data)
 
 
 @pytest.mark.parametrize(
@@ -98,15 +122,22 @@ def test_constant_pad_nd_conversion__channels_first(input_shape, paddings):
 
     input_data = np.random.random(input_shape).astype(np.float32)
 
-    convert_run_compare(
-        edge_program,
-        input_data,
-        tflite_input_preprocess=ToNHWCPreprocess(),
-        tflite_output_preprocess=ToNCHWPreprocess(),
-        conversion_config=ConversionConfig(
-            {"use_neutron_for_format_conversion": False}
-        ),
-    )
+    # Ignore the target requirement, as this test is target agnostic.
+    def supported_target(*_):
+        return True
+
+    with OverrideTargetSupportCheck(
+        ConstantPadNDConverter, new_target_support_check=supported_target
+    ):
+        convert_run_compare(
+            edge_program,
+            input_data,
+            tflite_input_preprocess=ToNHWCPreprocess(),
+            tflite_output_preprocess=ToNCHWPreprocess(),
+            conversion_config=ConversionConfig(
+                {"use_neutron_for_format_conversion": False}
+            ),
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Summary
The check to make sure a node is supported in Neutron IR was incomplete, so potential partitioning issues could have gone unnoticed. Now, this check is complete.

### Test plan
Tested by most of the existing tests.


cc @robert-kalmar @JakeStevens @digantdesai