### PR TITLE
Apple CI: Automate version and release branch detection

### DIFF
--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -33,15 +33,42 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       version: ${{ steps.set_version.outputs.version }}
+      release_branch: ${{ steps.set_version.outputs.release_branch }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       - name: Set VERSION variable
         id: set_version
         shell: bash
         run: |
-          VERSION="1.1.0.$(TZ='PST8PDT' date +%Y%m%d)"
+          set -eux  # Enable strict mode and command tracing
+          # Read base version from version.txt, extract only X.Y.Z (first match)
+          BASE_VERSION=$(grep -oE '^[0-9]+\.[0-9]+\.[0-9]+' version.txt | head -1)
+          if [[ -z "${BASE_VERSION}" ]]; then
+            echo "ERROR: Could not extract base version from version.txt"
+            echo "Expected format: X.Y.Z (e.g., 1.2.0 or 1.2.0a0)"
+            exit 1
+          fi
+          # Extract major.minor for release branch matching
+          MAJOR_MINOR=$(echo "${BASE_VERSION}" | grep -oE '^[0-9]+\.[0-9]+')
+          RELEASE_BRANCH="refs/heads/release/${MAJOR_MINOR}"
+          echo "release_branch=${RELEASE_BRANCH}" >> "$GITHUB_OUTPUT"
+          # For release branch matching version.txt (release/X.Y), use base version without date suffix
+          # For all other branches, append date for nightly builds
+          if [[ "${GITHUB_REF}" == "${RELEASE_BRANCH}" ]]; then
+            VERSION="${BASE_VERSION}"
+          else
+            VERSION="${BASE_VERSION}.$(TZ='PST8PDT' date +%Y%m%d)"
+          fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "BASE_VERSION=${BASE_VERSION}"
+          echo "RELEASE_BRANCH=${RELEASE_BRANCH}"
+          echo "GITHUB_REF=${GITHUB_REF}"
+          echo "VERSION=${VERSION}"
       - name: Guardrail
-        if: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main' }}
+        if: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && (github.ref == 'refs/heads/main' || github.ref == steps.set_version.outputs.release_branch) }}
         shell: bash
         run: |
           VERSION="${{ steps.set_version.outputs.version }}"
@@ -198,7 +225,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [build-frameworks-ios, set-version]
     timeout-minutes: 30
-    environment: ${{ github.ref == 'refs/heads/main' && 'cherry-pick-bot' || '' }}
+    environment: ${{ (github.ref == 'refs/heads/main' || github.ref == needs.set-version.outputs.release_branch) && 'cherry-pick-bot' || '' }}
     permissions:
       id-token: write
       contents: write
@@ -222,8 +249,8 @@ jobs:
           # NB: The name here needs to match the upload-artifact name from build-frameworks-ios job
           name: executorch-frameworks-ios
           path: ${{ runner.temp }}/frameworks-ios/
-      - name: Only push to S3 when running the workflow manually from main branch
-        if: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main' }}
+      - name: Only push to S3 when running the workflow manually from main or release branch
+        if: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && (github.ref == 'refs/heads/main' || github.ref == needs.set-version.outputs.release_branch) }}
         shell: bash
         run: |
           echo "UPLOAD_ON_MAIN=1" >> "${GITHUB_ENV}"


### PR DESCRIPTION
Previously, the Apple workflow required a manual cherry-pick for each
release branch to:
1. Change hardcoded version from "X.Y.Z.YYYYMMDD" to "X.Y.Z"
2. Update branch conditions from main to release/X.Y

See e5e49b6dd0e7 as an example of this manual cherry-pick for release/1.1.

This change automates all of that by:
- Reading the base version from version.txt (single source of truth)
- Deriving the expected release branch from version (e.g., 1.2.0 → release/1.2)
- Automatically using release versioning when on the matching release branch
- Updating Guardrail, environment, and S3 upload conditions to work for
  both main and the version-matched release branch

Behavior:
- main branch: produces 1.2.0.YYYYMMDD (nightly)
- release/1.2 (with version.txt=1.2.0): produces 1.2.0 (release)
- release/1.1 (with version.txt=1.1.0): produces 1.1.0 (release)
- Mismatched branch/version: produces nightly (fail-safe)

No cherry-pick required for release branches.

Test Plan:
- Tested version extraction logic locally without CI:
  - version.txt=1.2.0a0 → BASE_VERSION=1.2.0, MAJOR_MINOR=1.2
  - Simulated main branch → VERSION=1.2.0.YYYYMMDD
  - Simulated release/1.2 → VERSION=1.2.0
  - Simulated release/1.1 → VERSION=1.2.0.YYYYMMDD (fail-safe)
  
PR Apple job: https://github.com/pytorch/executorch/actions/runs/21487890216