### PR TITLE
Set GIT_TERMINAL_PROMPT=0 in doc-build.yml

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -112,6 +112,9 @@ jobs:
         # refs/tags/v1.12.0 convert to 1.12
         export GITHUB_REF=${{ github.ref }}
 
+        # Fail immediately instead of prompting for input.
+        export GIT_TERMINAL_PROMPT=0
+
         # Convert refs/tags/v1.12.0rc3 into 1.12.
         # Adopted from https://github.com/pytorch/pytorch/blob/main/.github/workflows/_docs.yml#L150C11-L155C13
         if [[ "${GITHUB_REF}" =~ ^refs/tags/v([0-9]+\.[0-9]+) ]]; then


### PR DESCRIPTION
### Summary
I believe that the git commit call in the doc build job is failing due to missing credentials and prompting - thus hanging. We never want git to request terminal input in the CI job, so setting GIT_TERMINAL_PROMPT=0 will cause it to fail fast and leave clear errors in the logs.