### PR TITLE
CI: Remove docker-builds from viable/strict requirements and add debugging

### DIFF
--- a/.github/workflows/update-viablestrict.yml
+++ b/.github/workflows/update-viablestrict.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           repository: pytorch/executorch
           stable-branch: viable/strict
-          requires: '[\"pull\", \"lint\", \"trunk\", \"Build documentation\", \"^Apple$\", \"docker-builds\"]'
+          requires: '[\"pull\", \"lint\", \"trunk\", \"Build documentation\", \"^Apple$\"]'
           secret-bot-token: ${{ secrets.UPDATEBOT_TOKEN }}
           clickhouse-url: ${{ secrets.CLICKHOUSE_URL }}
           clickhouse-username: ${{ secrets.CLICKHOUSE_VIABLESTRICT_USERNAME }}
@@ -32,7 +32,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -x  # Show commands in logs
           echo "## ❌ No green commit found" >> $GITHUB_STEP_SUMMARY
+          echo "No green commit found"
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "viable/strict branch was not updated because no commit passed all required checks." >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
- Remove docker-builds from the required jobs for viable/strict
  - docker is run only once a week so it's too restrictive to have this as part of the viable/strict movement
- Add set -x and stdout logging to "Summarize CI failures" step for
  better debugging visibility

