### PR TITLE
CI: Add permissions for viable/strict update workflow

### DIFF
--- a/.github/workflows/update-viablestrict.yml
+++ b/.github/workflows/update-viablestrict.yml
@@ -11,6 +11,8 @@ concurrency:
 
 jobs:
   do_update_viablestrict:
+    permissions:
+      id-token: write
     if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: ubuntu-22.04
     environment: ${{ (github.event_name == 'schedule') && 'update-viable-strict' || '' }}


### PR DESCRIPTION
Add permissions: id-token: write to match pytorch/pytorch workflow.
This is needed for the update-viablestrict action to push to the
viable/strict branch.


https://github.com/pytorch/executorch/actions/runs/21489966446/job/61909548514 is failing with

```
Checking 019c0876ae304ff9c4df9b2d2de35fd3d51046a0
RED: Build documentation was not successful, Build documentation / upload-gh-pages / linux-job failed
Checking 16a80dec452470e8d3af895ba4aaaa1e6aae4a02
RED: Build documentation was not successful, Build documentation / upload-gh-pages / linux-job failed
Checking 8f9e0b201b71b870888805bb86c52e7fa052689d
RED: Build documentation was not successful, Build documentation / upload-gh-pages / linux-job failed
Checking 20680c6211e6be0590bf05782baa79bee422512e
RED: Build documentation was not successful, Build documentation / upload-gh-pages / linux-job failed
Checking 4ee6ca4a55b8414a0c33b44e239fefe8d5da72a2
RED: Build documentation was not successful, Build documentation / upload-gh-pages / linux-job failed
Checking 3b162950a516242da722c790cb466feb05cb299e
GREEN
+ output=3b162950a516242da722c790cb466feb05cb299e
+ echo latest_viable_sha=3b162950a516242da722c790cb466feb05cb299e
+ echo 3b162950a516242da722c790cb466feb05cb299e
3b162950a516242da722c790cb466feb05cb299e
Run git config --global user.email "pytorchmergebot@users.noreply.github.com"
Set the latest sha variable to be 3b162950a516242da722c790cb466feb05cb299e
remote: Permission to pytorch/executorch.git denied to pytorchupdatebot.
fatal: unable to access 'https://github.com/pytorch/executorch/': The requested URL returned error: 403
```