### PR TITLE
CI: Fix doc-build gh-pages push authentication

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -99,11 +99,13 @@ jobs:
       id-token: write
       contents: write
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    secrets: inherit
     with:
       repository: pytorch/executorch
       download-artifact: docs
       ref: gh-pages
       timeout: 90
+      secrets-env: GITHUB_TOKEN
       script: |
         set -euo pipefail
 
@@ -114,6 +116,8 @@ jobs:
 
         # Fail immediately instead of prompting for input.
         export GIT_TERMINAL_PROMPT=0
+        # Configure git to use the token for authentication
+        git remote set-url origin https://x-access-token:${SECRET_GITHUB_TOKEN}@github.com/pytorch/executorch.git
 
         # Convert refs/tags/v1.12.0rc3 into 1.12.
         # Adopted from https://github.com/pytorch/pytorch/blob/main/.github/workflows/_docs.yml#L150C11-L155C13


### PR DESCRIPTION
The upload-gh-pages job was failing with:
  fatal: could not read Username for 'https://github.com': terminal prompts disabled

The issue was that the script runs inside a Docker container which
doesn't have access to git credentials configured during checkout.

Fix by:
- Adding secrets: inherit to pass secrets to the reusable workflow
- Adding secrets-env: GITHUB_TOKEN to expose token inside container
- Configuring git remote URL with the token for authentication
