### PR TITLE
check scalar type and device type supportive

### DIFF
--- a/backends/aoti/slim/c10/core/ScalarType.h
+++ b/backends/aoti/slim/c10/core/ScalarType.h
@@ -133,6 +133,24 @@ inline bool isBoolType(ScalarType t) {
   return t == ScalarType::Bool;
 }
 
+/// Checks if the scalar type is a valid/supported type.
+/// @param t The scalar type to check.
+/// @return true if the scalar type is valid, false otherwise.
+inline bool isValidScalarType(ScalarType t) {
+  switch (t) {
+    case ScalarType::Char:
+    case ScalarType::Short:
+    case ScalarType::Int:
+    case ScalarType::Long:
+    case ScalarType::Float:
+    case ScalarType::Bool:
+    case ScalarType::BFloat16:
+      return true;
+    default:
+      return false;
+  }
+}
+
 inline std::ostream& operator<<(std::ostream& stream, ScalarType scalar_type) {
   return stream << toString(scalar_type);
 }

--- a/backends/aoti/slim/core/slim_tensor.h
+++ b/backends/aoti/slim/core/slim_tensor.h
@@ -52,6 +52,7 @@ class SlimTensor {
         storage_offset_(storage_offset),
         dtype_(dtype) {
     set_sizes_and_strides(sizes, strides);
+    check_supportive();
   }
 
   /**
@@ -65,6 +66,7 @@ class SlimTensor {
         is_contiguous_(true) {
     sizes_and_strides_.set_sizes({0});
     sizes_and_strides_.set_strides({1});
+    check_supportive();
   }
 
   // Default copy/move operations
@@ -554,6 +556,13 @@ class SlimTensor {
         sizes_and_strides_.sizes_arrayref(),
         sizes_and_strides_.strides_arrayref(),
         static_cast<int64_t>(numel_));
+  }
+
+  void check_supportive() const {
+    ET_CHECK_MSG(
+        c10::isValidScalarType(dtype_),
+        "invalid dtype %d",
+        static_cast<int>(dtype_));
   }
 
   Storage storage_;

--- a/backends/aoti/slim/core/storage.h
+++ b/backends/aoti/slim/core/storage.h
@@ -240,7 +240,11 @@ class MaybeOwningStorage {
         data_(data),
         capacity_(nbytes),
         deleter_(detail::noop),
-        is_owning_(false) {}
+        is_owning_(false) {
+    if (!device.is_cuda() && !device.is_cpu()) {
+      ET_CHECK_MSG(false, "Unsupported device type: %s", device.str().c_str());
+    }
+  }
 
   /// Default constructor is deleted - storage must have a device.
   MaybeOwningStorage() = delete;

--- a/backends/aoti/slim/core/test/test_slimtensor_basic.cpp
+++ b/backends/aoti/slim/core/test/test_slimtensor_basic.cpp
@@ -489,4 +489,38 @@ TEST(SlimTensorBasicTest, DataPtrWithOffset) {
   EXPECT_EQ(data, static_cast<char*>(base) + 5 * sizeof(float));
 }
 
+// =============================================================================
+// Dtype and Device Type Validation Tests
+// =============================================================================
+
+TEST(SlimTensorValidationTest, InvalidDtypeUndefined) {
+  std::vector<int64_t> sizes = {2, 3};
+  std::vector<int64_t> strides = {3, 1};
+  size_t nbytes = 6 * sizeof(float);
+  Storage storage = make_cpu_storage(nbytes);
+
+  EXPECT_DEATH(
+      SlimTensor(
+          std::move(storage),
+          makeArrayRef(sizes),
+          makeArrayRef(strides),
+          c10::ScalarType::Undefined),
+      "");
+}
+
+TEST(SlimTensorValidationTest, InvalidDtypeDouble) {
+  std::vector<int64_t> sizes = {2, 3};
+  std::vector<int64_t> strides = {3, 1};
+  size_t nbytes = 6 * sizeof(double);
+  Storage storage = make_cpu_storage(nbytes);
+
+  EXPECT_DEATH(
+      SlimTensor(
+          std::move(storage),
+          makeArrayRef(sizes),
+          makeArrayRef(strides),
+          static_cast<c10::ScalarType>(7)), // Double = 7
+      "");
+}
+
 } // namespace executorch::backends::aoti::slim

--- a/backends/aoti/slim/factory/test/test_empty.cpp
+++ b/backends/aoti/slim/factory/test/test_empty.cpp
@@ -233,6 +233,65 @@ TEST(EmptyTest, CanWriteAndReadData) {
   }
 }
 
+// =============================================================================
+// Dtype and Device Type Validation Tests
+// =============================================================================
+
+TEST(EmptyStridedTest, InvalidDtypeUndefined) {
+  std::vector<int64_t> sizes = {2, 3};
+  std::vector<int64_t> strides = {3, 1};
+
+  EXPECT_DEATH(
+      empty_strided(
+          makeArrayRef(sizes),
+          makeArrayRef(strides),
+          c10::ScalarType::Undefined),
+      "");
+}
+
+TEST(EmptyStridedTest, InvalidDtypeDouble) {
+  std::vector<int64_t> sizes = {2, 3};
+  std::vector<int64_t> strides = {3, 1};
+
+  EXPECT_DEATH(
+      empty_strided(
+          makeArrayRef(sizes),
+          makeArrayRef(strides),
+          static_cast<c10::ScalarType>(7)), // Double = 7
+      "");
+}
+
+TEST(EmptyStridedTest, InvalidDeviceType) {
+  std::vector<int64_t> sizes = {2, 3};
+  std::vector<int64_t> strides = {3, 1};
+
+  c10::Device invalid_device(static_cast<c10::DeviceType>(100), 0);
+
+  EXPECT_DEATH(
+      empty_strided(
+          makeArrayRef(sizes),
+          makeArrayRef(strides),
+          c10::ScalarType::Float,
+          invalid_device),
+      "");
+}
+
+TEST(EmptyTest, InvalidDtypeUndefined) {
+  EXPECT_DEATH(empty({2, 3}, c10::ScalarType::Undefined), "");
+}
+
+TEST(EmptyTest, InvalidDtypeDouble) {
+  EXPECT_DEATH(
+      empty({2, 3}, static_cast<c10::ScalarType>(7)), // Double = 7
+      "");
+}
+
+TEST(EmptyTest, InvalidDeviceType) {
+  c10::Device invalid_device(static_cast<c10::DeviceType>(100), 0);
+
+  EXPECT_DEATH(empty({2, 3}, c10::ScalarType::Float, invalid_device), "");
+}
+
 #ifdef CUDA_AVAILABLE
 
 // =============================================================================

--- a/backends/aoti/slim/factory/test/test_from_blob.cpp
+++ b/backends/aoti/slim/factory/test/test_from_blob.cpp
@@ -316,6 +316,37 @@ TEST(FromBlobTest, WithArrayRef) {
 }
 
 // =============================================================================
+// Dtype and Device Type Validation Tests
+// =============================================================================
+
+TEST(FromBlobTest, InvalidDtypeUndefined) {
+  constexpr size_t kNumFloats = 6;
+  float external_data[kNumFloats];
+
+  EXPECT_DEATH(
+      from_blob(external_data, {2, 3}, c10::ScalarType::Undefined), "");
+}
+
+TEST(FromBlobTest, InvalidDtypeDouble) {
+  constexpr size_t kNumFloats = 6;
+  float external_data[kNumFloats];
+
+  EXPECT_DEATH(
+      from_blob(external_data, {2, 3}, static_cast<c10::ScalarType>(7)), "");
+}
+
+TEST(FromBlobTest, InvalidDeviceType) {
+  constexpr size_t kNumFloats = 6;
+  float external_data[kNumFloats];
+
+  c10::Device invalid_device(static_cast<c10::DeviceType>(100), 0);
+
+  EXPECT_DEATH(
+      from_blob(external_data, {2, 3}, c10::ScalarType::Float, invalid_device),
+      "");
+}
+
+// =============================================================================
 // CUDA from_blob Tests
 // Tests are skipped at runtime if CUDA hardware is not available.
 // =============================================================================


### PR DESCRIPTION
Summary: This diff introduce santiy check in slimtensor for legamity of target dtype and device.

Differential Revision: D91834497


