### PR TITLE
Automate documentation branch updates for releases

### DIFF
--- a/scripts/release/apply-release-changes.sh
+++ b/scripts/release/apply-release-changes.sh
@@ -45,9 +45,19 @@ for i in .github/workflows/*.yml; do
   fi
 done
 
+# Update documentation to use release branch instead of viable/strict
+echo "Updating documentation branch references"
+for doc in $(grep -rl "viable/strict" docs/); do
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i '' -e "s#-b viable/strict#-b ${RELEASE_BRANCH}#g" "$doc"
+  else
+    sed -i -e "s#-b viable/strict#-b ${RELEASE_BRANCH}#g" "$doc"
+  fi
+done
+
 echo "You'll need to manually commit the changes and create a PR. Here are the steps:"
-echo "1. Stage the changes to the workflow files:"
-echo "   git add ./github/workflows/*.yml"
+echo "1. Stage the changes:"
+echo "   git add .github/workflows/*.yml docs/"
 echo "2. Commit the changes:"
 echo "   git commit -m \"[RELEASE-ONLY CHANGES] Branch Cut for Release ${RELEASE_VERSION}\""
 echo "3. After committing, create a pull request to merge the changes."


### PR DESCRIPTION
### Summary

As part of the release process, all of the `viable/strict` branch references in documentation are updated to point at the new release branch. This was done manually for `release/1.1` in #16722. This change automates this process by adding the replacement to the `apply-release-changes.sh` script.

Authored with Claude.

### Test plan
```
./scripts/release/apply-release-changes.sh
# Manually verify that docs are updated with release branch.
```