### PR TITLE
Doc upload token fix

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -101,11 +101,11 @@ jobs:
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     secrets: inherit
     with:
+      secrets-env: DOC_BUILD_GITHUB_TOKEN
       repository: pytorch/executorch
       download-artifact: docs
       ref: gh-pages
       timeout: 90
-      secrets-env: GITHUB_TOKEN
       script: |
         set -euo pipefail
 
@@ -116,8 +116,6 @@ jobs:
 
         # Fail immediately instead of prompting for input.
         export GIT_TERMINAL_PROMPT=0
-        # Configure git to use the token for authentication
-        git remote set-url origin https://x-access-token:${SECRET_GITHUB_TOKEN}@github.com/pytorch/executorch.git
 
         # Convert refs/tags/v1.12.0rc3 into 1.12.
         # Adopted from https://github.com/pytorch/pytorch/blob/main/.github/workflows/_docs.yml#L150C11-L155C13
@@ -136,6 +134,9 @@ jobs:
         mkdir -p "${TARGET_FOLDER}"
         mv "${RUNNER_ARTIFACT_DIR}"/html/* "${TARGET_FOLDER}"
         git add "${TARGET_FOLDER}" || true
+
+        echo "::add-mask::$SECRET_DOC_BUILD_GITHUB_TOKEN" # Mask the secret in GH logs
+        git remote set-url origin https://x-access-token:$SECRET_DOC_BUILD_GITHUB_TOKEN@github.com/pytorch/executorch.git
 
         git config user.name 'pytorchbot'
         git config user.email 'soumith+bot@pytorch.org'


### PR DESCRIPTION
### Summary
Unblock the doc upload job by using an explicit access token secret. I verified this works in https://github.com/pytorch/executorch/pull/16989.