### PR TITLE
Qualcomm AI Engine Direct - Optimize UT execution time re-submit

### DIFF
--- a/backends/qualcomm/tests/test_qnn_delegate.py
+++ b/backends/qualcomm/tests/test_qnn_delegate.py
@@ -8183,8 +8183,15 @@ class TestUtilsScript(TestQNN):
                 self.build_folder,
                 "--input_list",
                 f"{tmp_dir}/input_list",
+                "--model",
+                self.model,
+                "--host",
+                self.host,
+                "--target",
+                self.target,
+                "--device",
+                self.device,
             ]
-            self.add_default_cmds(cmds)
             subprocess.run(cmds, stdout=subprocess.DEVNULL)
             self.assertTrue(os.path.isfile(f"{tmp_dir}/e_out/Result_0/output_0.pt"))
 

--- a/backends/qualcomm/tests/utils.py
+++ b/backends/qualcomm/tests/utils.py
@@ -186,6 +186,25 @@ class TestQNN(unittest.TestCase):
     inference_speed_output_path = "outputs/inference_speed.txt"
     static_llm_eval_method = ""
 
+    @classmethod
+    def setUpClass(cls):
+        if not cls.enable_x86_64 and not cls.compile_only:
+            # init device once
+            adb = SimpleADB(
+                qnn_sdk=os.getenv("QNN_SDK_ROOT"),
+                build_path=cls.build_folder,
+                pte_path=[],
+                workspace="/data/local/tmp/qnn_executorch_test",
+                device_id=cls.device,
+                host_id=cls.host,
+                soc_model=cls.model,
+                error_only=cls.error_only,
+                target=cls.target,
+            )
+            adb.push(
+                init_env=True,
+            )
+
     def _assert_outputs_equal(self, model_output, ref_output):
         self.assertTrue(len(ref_output) == len(model_output))
         for i in range(len(ref_output)):
@@ -490,6 +509,7 @@ class TestQNN(unittest.TestCase):
                 adb.push(
                     inputs=[processed_inputs],
                     files=op_package_paths,
+                    init_env=False,
                 )
                 adb.extra_cmds += extra_cmds
                 if save_inference_speed:

--- a/examples/qualcomm/utils.py
+++ b/examples/qualcomm/utils.py
@@ -98,7 +98,10 @@ class SimpleADB:
         self.workspace = workspace
         self.device_id = device_id
         self.host_id = host_id
-        self.working_dir = Path(self.pte_path[0]).parent.absolute()
+        if len(self.pte_path) > 0:
+            self.working_dir = Path(self.pte_path[0]).parent.absolute()
+        else:
+            self.working_dir = Path.cwd()
         self.input_list_filename = "input_list.txt"
         self.etdump_path = f"{self.workspace}/etdump.etdp"
         self.dump_intermediate_outputs = dump_intermediate_outputs
@@ -132,39 +135,42 @@ class SimpleADB:
             )
 
     def push(self, inputs=None, input_list=None, files=None, init_env=True):
-        artifacts = []
+        artifacts = [
+            *self.pte_path,
+        ]
         if init_env:
             self._adb(["shell", f"rm -rf {self.workspace}"])
             self._adb(["shell", f"mkdir -p {self.workspace}"])
 
-        # necessary artifacts
-        artifacts = {
-            QnnExecuTorchBackendType.kHtpBackend: [
-                f"{self.qnn_sdk}/lib/{self.target}/libQnnHtp.so",
-                (
-                    f"{self.qnn_sdk}/lib/hexagon-v{self.htp_arch}/"
-                    f"unsigned/libQnnHtpV{self.htp_arch}Skel.so"
-                ),
-                (
-                    f"{self.qnn_sdk}/lib/{self.target}/"
-                    f"libQnnHtpV{self.htp_arch}Stub.so"
-                ),
-                f"{self.qnn_sdk}/lib/{self.target}/libQnnHtpPrepare.so",
-            ],
-            QnnExecuTorchBackendType.kGpuBackend: [
-                f"{self.qnn_sdk}/lib/{self.target}/libQnnGpu.so",
-            ],
-        }[self.backend]
+            # necessary artifacts
+            artifacts.extend(
+                {
+                    QnnExecuTorchBackendType.kHtpBackend: [
+                        f"{self.qnn_sdk}/lib/{self.target}/libQnnHtp.so",
+                        (
+                            f"{self.qnn_sdk}/lib/hexagon-v{self.htp_arch}/"
+                            f"unsigned/libQnnHtpV{self.htp_arch}Skel.so"
+                        ),
+                        (
+                            f"{self.qnn_sdk}/lib/{self.target}/"
+                            f"libQnnHtpV{self.htp_arch}Stub.so"
+                        ),
+                        f"{self.qnn_sdk}/lib/{self.target}/libQnnHtpPrepare.so",
+                    ],
+                    QnnExecuTorchBackendType.kGpuBackend: [
+                        f"{self.qnn_sdk}/lib/{self.target}/libQnnGpu.so",
+                    ],
+                }[self.backend]
+            )
 
-        artifacts.extend(
-            [
-                *self.pte_path,
-                f"{self.qnn_sdk}/lib/{self.target}/libQnnSystem.so",
-                f"{self.build_path}/{self.runner}",
-                f"{self.build_path}/backends/qualcomm/libqnn_executorch_backend.so",
-                f"{self.qnn_sdk}/lib/{self.target}/libQnnModelDlc.so",
-            ]
-        )
+            artifacts.extend(
+                [
+                    f"{self.qnn_sdk}/lib/{self.target}/libQnnSystem.so",
+                    f"{self.build_path}/{self.runner}",
+                    f"{self.build_path}/backends/qualcomm/libqnn_executorch_backend.so",
+                    f"{self.qnn_sdk}/lib/{self.target}/libQnnModelDlc.so",
+                ]
+            )
         with tempfile.TemporaryDirectory() as tmp_dir:
             input_list_file, input_files = generate_inputs(
                 tmp_dir, self.input_list_filename, inputs
@@ -205,6 +211,7 @@ class SimpleADB:
         method_index=0,
         output_callback: Optional[Callable[[str], None]] = None,
     ):
+        self._adb(["shell", f"rm -rf {self.output_folder}"])
         self._adb(["shell", f"mkdir -p {self.output_folder}"])
         # run the delegation
         if custom_runner_cmd is None:
@@ -474,7 +481,8 @@ def build_executorch_binary(
         else:
             quantizer = custom_quantizer or make_quantizer(quant_dtype=quant_dtype)
             # ptq calibration
-            annotated_model = ptq_calibrate(captured_model, quantizer, dataset)
+            with torch.no_grad():
+                annotated_model = ptq_calibrate(captured_model, quantizer, dataset)
 
         quantized_model = convert_pt2e(annotated_model)
         edge_prog_mgr = to_edge_transform_and_lower_to_qnn(


### PR DESCRIPTION
### Summary
- Currently all tests will push same libs, which is redundant. With this PR it only push once, and reduce execution time from two to three times for operator's tests.

### Test plan
```
python backends/qualcomm/tests/test_qnn_delegate.py -k TestQNNFloatingPointOperator --device <device> --host <host> --model SM8650 --build_folder build-android --executorch_root . --artifact all_artifact
```
without optimization
<img width="429" height="136" alt="image" src="https://github.com/user-attachments/assets/f52a167c-b665-47da-97b2-02f836f4858e" />

with optimization
<img width="442" height="130" alt="image" src="https://github.com/user-attachments/assets/46366237-ec7b-4d38-b577-5677b3dafb36" />



cc @cccclai @cbilgin