### PR TITLE
Qualcomm AI Engine Direct - support multi-core lowering

### DIFF
--- a/backends/qualcomm/runtime/CMakeLists.txt
+++ b/backends/qualcomm/runtime/CMakeLists.txt
@@ -27,6 +27,9 @@ target_sources(
   INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/QnnManager.h>
   PRIVATE ${CMAKE_CURRENT_LIST_DIR}/QnnManager.cpp
 )
+target_include_directories(
+  qnn_manager PRIVATE ${EXECUTORCH_SOURCE_DIR}/third-party/json/single_include
+)
 
 # qnn_backend_options
 target_sources(

--- a/backends/qualcomm/runtime/QnnExecuTorch.h
+++ b/backends/qualcomm/runtime/QnnExecuTorch.h
@@ -72,6 +72,11 @@ void QnnExecuTorchAddCustomMemTensorAddr(void* tensor_addr, void* custom_mem);
 /// Free the allocated shared memory.
 void QnnExecuTorchFreeCustomMem(void* buffer_ptr);
 
+/// Dump platform information
+void QnnExecuTorchDumpPlatformInfo(
+    const char* backend_lib_path,
+    const char* platform_info_path);
+
 #ifdef __cplusplus
 }
 #endif // __cplusplus

--- a/backends/qualcomm/runtime/backends/QnnFunctionInterface.h
+++ b/backends/qualcomm/runtime/backends/QnnFunctionInterface.h
@@ -50,6 +50,9 @@ class QnnInterface {
   DEFINE_SHIM_FUNCTION_INTERFACE(
       device_get_platform_info,
       deviceGetPlatformInfo);
+  DEFINE_SHIM_FUNCTION_INTERFACE(
+      device_free_platform_info,
+      deviceFreePlatformInfo);
   // DEFINE_SHIM_FUNCTION_INTERFACE(device_get_info, deviceGetInfo);
   // --------- QnnContext ---------
   DEFINE_SHIM_FUNCTION_INTERFACE(context_create, contextCreate);

--- a/backends/qualcomm/runtime/backends/htp/HtpDevice.h
+++ b/backends/qualcomm/runtime/backends/htp/HtpDevice.h
@@ -32,7 +32,8 @@ class HtpDevice : public QnnDevice {
         qcom_target_soc_info_(soc_info),
         htp_options_(htp_options) {
     htp_device_platform_info_config_ =
-        std::make_unique<HtpDevicePlatformInfoConfig>(htp_options);
+        std::make_unique<HtpDevicePlatformInfoConfig>(
+            htp_options, implementation, logger);
     htp_device_custom_config_ =
         std::make_unique<HtpDeviceCustomConfig>(htp_options);
   }

--- a/backends/qualcomm/runtime/backends/htp/HtpDevicePlatformInfoConfig.h
+++ b/backends/qualcomm/runtime/backends/htp/HtpDevicePlatformInfoConfig.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <executorch/backends/qualcomm/qc_compiler_spec_generated.h>
+#include <executorch/backends/qualcomm/runtime/backends/QnnDeviceCommon.h>
 
 #include <memory>
 #include <vector>
@@ -20,8 +21,22 @@ using namespace qnn_delegate;
 class HtpDevicePlatformInfoConfig {
  public:
   explicit HtpDevicePlatformInfoConfig(
-      const QnnExecuTorchHtpBackendOptions* htp_options)
-      : htp_options_(htp_options) {}
+      const QnnExecuTorchHtpBackendOptions* htp_options,
+      QnnImplementation* implementation,
+      QnnLogger* logger)
+      : htp_options_(htp_options),
+        implementation_(implementation),
+        logger_(logger) {}
+
+  ~HtpDevicePlatformInfoConfig() {
+    // to prevent misleading error message: e.g. <E> Invalid platform info (nil)
+    // check if platform_info_ has been queried first
+    if (platform_info_) {
+      implementation_->GetQnnInterface().qnn_device_free_platform_info(
+          logger_->GetHandle(), platform_info_);
+    }
+  }
+
   std::vector<QnnDevice_PlatformInfo_t*> CreateDevicePlatformInfo(
       const SocInfo* qcom_target_soc_info);
 
@@ -43,9 +58,9 @@ class HtpDevicePlatformInfoConfig {
   }
 
   QnnDevice_CoreInfo_t* AllocCoreInfo() {
-    htp_core_info_.emplace_back(std::make_unique<QnnDevice_CoreInfo_t>());
-    htp_core_info_.back()->version = QNN_DEVICE_CORE_INFO_VERSION_UNDEFINED;
-    return htp_core_info_.back().get();
+    htp_core_info_.emplace_back(QnnDevice_CoreInfo_t());
+    htp_core_info_.back().version = QNN_DEVICE_CORE_INFO_VERSION_UNDEFINED;
+    return &htp_core_info_.back();
   }
 
   QnnHtpDevice_DeviceInfoExtension_t* AllocDeviceInfoExtension() {
@@ -60,9 +75,12 @@ class HtpDevicePlatformInfoConfig {
   std::vector<std::unique_ptr<QnnDevice_PlatformInfo_t>> htp_platform_info_;
   std::vector<std::unique_ptr<QnnDevice_HardwareDeviceInfo_t>>
       htp_hw_device_info_;
-  std::vector<std::unique_ptr<QnnDevice_CoreInfo_t>> htp_core_info_;
+  std::vector<QnnDevice_CoreInfo_t> htp_core_info_;
   std::vector<std::unique_ptr<QnnHtpDevice_DeviceInfoExtension_t>>
       htp_device_info_extension_;
+  const QnnDevice_PlatformInfo_t* platform_info_{nullptr};
+  QnnImplementation* implementation_;
+  QnnLogger* logger_;
 };
 } // namespace qnn
 } // namespace backends

--- a/backends/qualcomm/runtime/backends/htp/HtpGraphCustomConfig.cpp
+++ b/backends/qualcomm/runtime/backends/htp/HtpGraphCustomConfig.cpp
@@ -70,6 +70,11 @@ HtpGraphCustomConfig::CreateGraphCustomConfigCommon(
       htp_options_->use_dlbc() ? 1.0 : 0.0;
   ret.push_back(static_cast<QnnGraph_CustomConfig_t>(p_custom_config));
 
+  p_custom_config = AllocGraphCustomConfig();
+  p_custom_config->option = QNN_HTP_GRAPH_CONFIG_OPTION_NUM_CORES;
+  p_custom_config->numCores = htp_options_->core_ids()->size();
+  ret.push_back(static_cast<QnnGraph_CustomConfig_t>(p_custom_config));
+
   return ret;
 }
 } // namespace qnn

--- a/backends/qualcomm/runtime/backends/htp/aarch64/HtpDevicePlatformInfoConfig.cpp
+++ b/backends/qualcomm/runtime/backends/htp/aarch64/HtpDevicePlatformInfoConfig.cpp
@@ -12,7 +12,63 @@ namespace qnn {
 std::vector<QnnDevice_PlatformInfo_t*>
 HtpDevicePlatformInfoConfig::CreateDevicePlatformInfo(
     const SocInfo* /*qcom_target_soc_info*/) {
-  return {};
+  std::vector<QnnDevice_PlatformInfo_t*> ret;
+  auto error = implementation_->GetQnnInterface().qnn_device_get_platform_info(
+      logger_->GetHandle(), &platform_info_);
+  if (error != QNN_SUCCESS) {
+    QNN_EXECUTORCH_LOG_ERROR(
+        "Failed to get platform info via QNN with error %lu",
+        QNN_GET_ERROR_CODE(error));
+    return ret;
+  }
+  if (platform_info_->v1.numHwDevices <= htp_options_->device_id()) {
+    QNN_EXECUTORCH_LOG_ERROR(
+        "Device id (%d) exceeds current hardware capability: %d",
+        htp_options_->device_id(),
+        platform_info_->v1.numHwDevices);
+    return ret;
+  }
+  size_t num_device_cores =
+      platform_info_->v1.hwDevices[htp_options_->device_id()].v1.numCores;
+  if (htp_options_->core_ids()->size() >= num_device_cores) {
+    QNN_EXECUTORCH_LOG_ERROR(
+        "Number of cores (%d) exceeds current hardware capability: %d",
+        htp_options_->core_ids()->size(),
+        num_device_cores);
+    return ret;
+  }
+
+  QnnDevice_PlatformInfo_t* p_platform_info = AllocDevicePlatformInfo();
+  p_platform_info->version = QNN_DEVICE_PLATFORM_INFO_VERSION_1;
+  p_platform_info->v1.numHwDevices = 1;
+
+  QnnDevice_HardwareDeviceInfo_t* p_hw_device_info = AllocHwDeviceInfo();
+  p_hw_device_info->version = QNN_DEVICE_HARDWARE_DEVICE_INFO_VERSION_1;
+  p_hw_device_info->v1.deviceId = htp_options_->device_id();
+  // TODO: support off-chip device type if necessary
+  p_hw_device_info->v1.deviceType = 0;
+  p_hw_device_info->v1.numCores = htp_options_->core_ids()->size();
+
+  for (size_t i = 0; i < p_hw_device_info->v1.numCores; ++i) {
+    QnnDevice_CoreInfo_t* p_core_info = AllocCoreInfo();
+    // memory of core info is maintained by QNN, should be safe to use it
+    // directly
+    if (htp_options_->core_ids()->data()[i] >= num_device_cores) {
+      QNN_EXECUTORCH_LOG_ERROR(
+          "Core id (%d) exceeds current hardware capability: %d",
+          htp_options_->core_ids()->data()[i],
+          num_device_cores);
+      return ret;
+    }
+    *p_core_info = platform_info_->v1.hwDevices[htp_options_->device_id()]
+                       .v1.cores[htp_options_->core_ids()->data()[i]];
+  }
+  p_hw_device_info->v1.cores = htp_core_info_.data();
+
+  p_platform_info->v1.hwDevices = p_hw_device_info;
+  ret.push_back(p_platform_info);
+
+  return ret;
 }
 } // namespace qnn
 } // namespace backends

--- a/backends/qualcomm/runtime/backends/htp/x86_64/HtpDevicePlatformInfoConfig.cpp
+++ b/backends/qualcomm/runtime/backends/htp/x86_64/HtpDevicePlatformInfoConfig.cpp
@@ -17,7 +17,6 @@ HtpDevicePlatformInfoConfig::CreateDevicePlatformInfo(
   QnnDevice_PlatformInfo_t* p_platform_info = nullptr;
   QnnDevice_HardwareDeviceInfo_t* p_hw_device_info = nullptr;
   QnnHtpDevice_DeviceInfoExtension_t* p_device_info_extension = nullptr;
-  QnnDevice_CoreInfo_t* p_core_info = nullptr;
 
   p_platform_info = AllocDevicePlatformInfo();
   p_platform_info->version = QNN_DEVICE_PLATFORM_INFO_VERSION_1;
@@ -44,12 +43,12 @@ HtpDevicePlatformInfoConfig::CreateDevicePlatformInfo(
   p_device_info_extension->onChipDevice.dlbcSupport = true;
   p_hw_device_info->v1.deviceInfoExtension = p_device_info_extension;
 
-  p_core_info = AllocCoreInfo();
+  QnnDevice_CoreInfo_t* p_core_info = AllocCoreInfo();
   p_core_info->version = QNN_DEVICE_CORE_INFO_VERSION_1;
   p_core_info->v1.coreId = 0;
   p_core_info->v1.coreType = 0;
   p_core_info->v1.coreInfoExtension = nullptr;
-  p_hw_device_info->v1.cores = p_core_info;
+  p_hw_device_info->v1.cores = htp_core_info_.data();
 
   p_platform_info->v1.hwDevices = p_hw_device_info;
   ret.push_back(p_platform_info);

--- a/backends/qualcomm/serialization/qc_compiler_spec.fbs
+++ b/backends/qualcomm/serialization/qc_compiler_spec.fbs
@@ -181,6 +181,14 @@ table QnnExecuTorchHtpBackendOptions {
   /// When multiple graphs appear inside the same context,
   /// weights could be reused across all graphs.
   use_weight_sharing:bool;
+
+  /// When multiple devices appear in the same platform
+  /// specify device id for preparing graphs
+  device_id:int;
+
+  /// When multiple cores appear in the same device
+  /// specify core ids for preparing graphs
+  core_ids:[int];
 }
 
 /// Logging level of the delegate and QNN backend.

--- a/backends/qualcomm/serialization/qc_schema.py
+++ b/backends/qualcomm/serialization/qc_schema.py
@@ -166,6 +166,8 @@ class QnnExecuTorchHtpBackendOptions:
     use_fold_relu: bool = True
     use_multi_contexts: bool = False
     use_weight_sharing: bool = False
+    device_id: int = 0
+    core_ids: tuple[int] = (0,)
 
 
 @unique

--- a/backends/qualcomm/tests/utils.py
+++ b/backends/qualcomm/tests/utils.py
@@ -29,6 +29,7 @@ from executorch.backends.qualcomm.utils.constants import (
     QCOM_ZERO_POINT,
 )
 from executorch.backends.qualcomm.utils.utils import (
+    get_backend_type,
     get_soc_to_chipset_map,
     to_edge_transform_and_lower_to_qnn,
 )
@@ -36,7 +37,6 @@ from executorch.devtools import Inspector
 from executorch.devtools.inspector._inspector_utils import TimeScale
 from executorch.examples.qualcomm.utils import (
     generate_inputs,
-    get_backend_type,
     make_output_dir,
     make_quantizer,
     SimpleADB,

--- a/examples/qualcomm/executor_runner/qnn_executor_runner.cpp
+++ b/examples/qualcomm/executor_runner/qnn_executor_runner.cpp
@@ -109,6 +109,15 @@ DEFINE_int32(
     "This is a runtime option and will override the profile level set during AOT. "
     "Refer to QnnExecuTorchProfileLevel under qc_compiler_spec.fbs for more info.");
 
+DEFINE_bool(
+    dump_platform_info,
+    false,
+    "Dump platform information to json file.");
+DEFINE_string(
+    backend_lib_path,
+    "",
+    "Specify backend library path for dumping platform info.");
+
 using executorch::aten::Tensor;
 using executorch::aten::TensorImpl;
 using executorch::etdump::ETDumpGen;
@@ -176,6 +185,17 @@ int main(int argc, char** argv) {
     }
     ET_LOG(Error, "%s", msg.c_str());
     return 1;
+  }
+
+  if (FLAGS_dump_platform_info) {
+    ET_CHECK_MSG(
+        !FLAGS_backend_lib_path.empty(),
+        "Please specify backend library path for dumping platform info.",
+        QNN_RUNTIME_LOG_LEVEL);
+    std::string output_path = FLAGS_output_folder_path + "/platform_info.json";
+    QnnExecuTorchDumpPlatformInfo(
+        FLAGS_backend_lib_path.c_str(), output_path.c_str());
+    return 0;
   }
 
   // Set runtime options

--- a/examples/qualcomm/utils.py
+++ b/examples/qualcomm/utils.py
@@ -15,7 +15,6 @@ import shutil
 import subprocess
 import sys
 import tempfile
-from pathlib import Path
 
 from typing import Callable, Dict, List, Optional, Tuple
 
@@ -98,7 +97,6 @@ class SimpleADB:
         self.workspace = workspace
         self.device_id = device_id
         self.host_id = host_id
-        self.working_dir = Path(self.pte_path[0]).parent.absolute()
         self.input_list_filename = "input_list.txt"
         self.etdump_path = f"{self.workspace}/etdump.etdp"
         self.dump_intermediate_outputs = dump_intermediate_outputs
@@ -131,7 +129,7 @@ class SimpleADB:
                 cmds, stdout=subprocess.DEVNULL if self.error_only else sys.stdout
             )
 
-    def push(self, inputs=None, input_list=None, files=None, init_env=True):
+    def push(self, inputs=None, files=None, init_env=True):
         artifacts = []
         if init_env:
             self._adb(["shell", f"rm -rf {self.workspace}"])
@@ -175,7 +173,8 @@ class SimpleADB:
                 artifacts.append(input_list_file)
 
             for artifact in artifacts:
-                self._adb(["push", artifact, self.workspace])
+                if artifact is not None:
+                    self._adb(["push", artifact, self.workspace])
 
             # input data
             for file_name in input_files:
@@ -609,10 +608,6 @@ def evaluate_squad(predicted_texts: List[str], target_texts: List[str]):
     results["f1"] /= 100
     results["exact_match"] /= 100
     return results
-
-
-def get_backend_type(backend: str):
-    return getattr(QnnExecuTorchBackendType, f"k{backend.title()}Backend")
 
 
 def get_imagenet_dataset(


### PR DESCRIPTION
### Summary
- utility for device / core id query
- backend & compile spec support for specifying cores
- unit tests

### Test plan
1. Use `from executorch.backends.qualcomm.utils.utils import get_platform_info` for querying device / core ids. Please check `TestQNNQuantizedUtils.test_qnn_backend_platform_info` in `backends/qualcomm/tests/test_qnn_delegate.py` for more information.
2. Specify designated cores for lowering & inference. Please check `TestQNNQuantizedUtils.test_qnn_backend_multi_core` in `backends/qualcomm/tests/test_qnn_delegate.py` for more information.
