### PR TITLE
Arm backend: Add FP16 support to operators pt.3

### DIFF
--- a/backends/arm/operators/op_eq.py
+++ b/backends/arm/operators/op_eq.py
@@ -41,7 +41,7 @@ class EqualVisitor(NodeVisitor):
         validate_valid_dtype(
             self.target,
             inputs,
-            [ts.DType.INT32, ts.DType.FP32, ts.DType.BF16],
+            [ts.DType.INT32, ts.DType.FP16, ts.DType.FP32, ts.DType.BF16],
             self.tosa_spec,
         )
         validate_valid_dtype(self.target, output, ts.DType.BOOL, self.tosa_spec)

--- a/backends/arm/operators/op_erf.py
+++ b/backends/arm/operators/op_erf.py
@@ -42,7 +42,7 @@ class ERFVisitor(NodeVisitor):
         validate_valid_dtype(
             self.target,
             [*inputs, output],
-            [ts.DType.FP32, ts.DType.BF16],
+            [ts.DType.FP16, ts.DType.FP32, ts.DType.BF16],
             self.tosa_spec,
         )
 

--- a/backends/arm/operators/op_exp.py
+++ b/backends/arm/operators/op_exp.py
@@ -43,7 +43,7 @@ class ExpVisitor(NodeVisitor):
         validate_valid_dtype(
             self.target,
             [*inputs, output],
-            [ts.DType.FP32, ts.DType.BF16],
+            [ts.DType.FP16, ts.DType.FP32, ts.DType.BF16],
             self.tosa_spec,
         )
 

--- a/backends/arm/operators/op_floor.py
+++ b/backends/arm/operators/op_floor.py
@@ -45,7 +45,7 @@ class FloorVisitor(NodeVisitor):
         validate_valid_dtype(
             self.target,
             inputs[0],
-            [ts.DType.FP32, ts.DType.BF16],
+            [ts.DType.FP16, ts.DType.FP32, ts.DType.BF16],
             self.tosa_spec,
         )
 

--- a/backends/arm/test/ops/test_depthwise_conv.py
+++ b/backends/arm/test/ops/test_depthwise_conv.py
@@ -181,6 +181,20 @@ test_data_conv2d_FP_bf16 = {
         dtype=torch.bfloat16,
     ),
 }
+test_data_conv2d_FP_fp16 = {
+    "fp16_3x3_gp3_fp16": lambda: Conv2d(
+        in_channels=3,
+        out_channels=3,
+        kernel_size=(3, 3),
+        stride=(1, 1),
+        groups=3,
+        padding=2,
+        width=16,
+        height=16,
+        batches=1,
+        dtype=torch.float16,
+    ),
+}
 
 # Generate a new test set paired with per_channel_quant=True/False.
 test_data_conv2d_INT = {
@@ -226,7 +240,11 @@ def _get_dtype_count(model: torch.nn.Module):
 
 
 @common.parametrize(
-    "test_data", test_data_conv1d_FP | test_data_conv2d_FP | test_data_conv2d_FP_bf16
+    "test_data",
+    test_data_conv1d_FP
+    | test_data_conv2d_FP
+    | test_data_conv2d_FP_bf16
+    | test_data_conv2d_FP_fp16,
 )
 def test_convolution_2d_tosa_FP_depthwise(test_data: torch.nn.Module):
     pipeline = TosaPipelineFP[input_t](
@@ -274,7 +292,9 @@ def test_convolution_2d_tosa_INT_a8w4_depthwise(test_data):
     pipeline.run()
 
 
-@common.parametrize("test_data", test_data_conv1d_FP | test_data_conv2d_FP)
+@common.parametrize(
+    "test_data", test_data_conv1d_FP | test_data_conv2d_FP | test_data_conv2d_FP_fp16
+)
 @common.SkipIfNoModelConverter
 def test_convolution_2d_vgf_no_quant_depthwise(test_data: torch.nn.Module):
     model = test_data()

--- a/backends/arm/test/ops/test_eq.py
+++ b/backends/arm/test/ops/test_eq.py
@@ -79,6 +79,16 @@ test_data_tensor_bf16 = {
         torch.randn(2, 3, 4, dtype=torch.bfloat16),
     ),
 }
+test_data_tensor_fp16 = {
+    "eq_tensor_rank2_rand_fp16": lambda: Equal(
+        torch.rand(4, 5, dtype=torch.float16),
+        torch.rand(1, 5, dtype=torch.float16),
+    ),
+    "eq_tensor_rank3_randn_fp16": lambda: Equal(
+        torch.randn(2, 3, 4, dtype=torch.float16),
+        torch.randn(2, 3, 4, dtype=torch.float16),
+    ),
+}
 
 test_data_scalar = {
     "eq_scalar_rank1_ones": lambda: op_eq_scalar_rank1_ones,
@@ -93,9 +103,17 @@ test_data_scalar_bf16 = {
         torch.randn(2, 3, 4, dtype=torch.bfloat16), -0.1
     ),
 }
+test_data_scalar_fp16 = {
+    "eq_scalar_rank2_fp16": lambda: Equal(torch.rand(4, 5, dtype=torch.float16), 0.2),
+    "eq_scalar_rank3_fp16": lambda: Equal(
+        torch.randn(2, 3, 4, dtype=torch.float16), -0.1
+    ),
+}
 
 
-@common.parametrize("test_module", test_data_tensor | test_data_tensor_bf16)
+@common.parametrize(
+    "test_module", test_data_tensor | test_data_tensor_bf16 | test_data_tensor_fp16
+)
 def test_eq_scalar_tosa_FP_tensor(test_module):
     pipeline = TosaPipelineFP[input_t](
         test_module(),
@@ -107,7 +125,9 @@ def test_eq_scalar_tosa_FP_tensor(test_module):
     pipeline.run()
 
 
-@common.parametrize("test_module", test_data_scalar | test_data_scalar_bf16)
+@common.parametrize(
+    "test_module", test_data_scalar | test_data_scalar_bf16 | test_data_scalar_fp16
+)
 def test_eq_scalar_tosa_FP(test_module):
     pipeline = TosaPipelineFP[input_t](
         test_module(),
@@ -254,7 +274,7 @@ def test_eq_scalar_u85_INT_16a8w(test_module):
     pipeline.run()
 
 
-@common.parametrize("test_module", test_data_tensor)
+@common.parametrize("test_module", test_data_tensor | test_data_tensor_fp16)
 @common.SkipIfNoModelConverter
 def test_eq_scalar_vgf_no_quant_tensor(test_module):
     pipeline = VgfPipeline[input_t](
@@ -267,7 +287,7 @@ def test_eq_scalar_vgf_no_quant_tensor(test_module):
     pipeline.run()
 
 
-@common.parametrize("test_module", test_data_scalar)
+@common.parametrize("test_module", test_data_scalar | test_data_scalar_fp16)
 @common.SkipIfNoModelConverter
 def test_eq_scalar_vgf_no_quant(test_module):
     pipeline = VgfPipeline[input_t](

--- a/backends/arm/test/ops/test_erf.py
+++ b/backends/arm/test/ops/test_erf.py
@@ -37,9 +37,15 @@ class Erf(torch.nn.Module):
         "rand_bf16": lambda: ((torch.rand(8, 8, dtype=torch.bfloat16) - 0.5),),
         "ramp_bf16": lambda: (torch.arange(-8, 8, 0.5, dtype=torch.bfloat16),),
     }
+    test_data_fp16: dict[str, input_t1] = {
+        "rand_fp16": lambda: ((torch.rand(8, 8, dtype=torch.float16) - 0.5),),
+        "ramp_fp16": lambda: (torch.arange(-8, 8, 0.5, dtype=torch.float16),),
+    }
 
 
-@common.parametrize("test_data", Erf.test_data | Erf.test_data_bf16)
+@common.parametrize(
+    "test_data", Erf.test_data | Erf.test_data_bf16 | Erf.test_data_fp16
+)
 def test_erf_tosa_FP(test_data: input_t1):
     pipeline = TosaPipelineFP[input_t1](
         Erf(), test_data(), aten_op, exir_op, tosa_extensions=["bf16"]
@@ -77,7 +83,7 @@ def test_erf_u85_INT(test_data: input_t1):
     pipeline.run()
 
 
-@common.parametrize("test_data", Erf.test_data)
+@common.parametrize("test_data", Erf.test_data | Erf.test_data_fp16)
 @common.SkipIfNoModelConverter
 def test_erf_vgf_no_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](

--- a/backends/arm/test/ops/test_exp.py
+++ b/backends/arm/test/ops/test_exp.py
@@ -33,6 +33,10 @@ test_data_suite_bf16 = {
     "rand_bf16": lambda: torch.rand(6, 6, dtype=torch.bfloat16) - 0.5,
     "ramp_bf16": lambda: torch.arange(-8, 8, 0.5, dtype=torch.bfloat16),
 }
+test_data_suite_fp16 = {
+    "rand_fp16": lambda: torch.rand(6, 6, dtype=torch.float16) - 0.5,
+    "ramp_fp16": lambda: torch.arange(-8, 8, 0.5, dtype=torch.float16),
+}
 
 aten_op = "torch.ops.aten.exp.default"
 input_t1 = Tuple[torch.Tensor]  # Input x
@@ -43,7 +47,9 @@ class Exp(torch.nn.Module):
         return torch.exp(x)
 
 
-@common.parametrize("test_data", test_data_suite | test_data_suite_bf16)
+@common.parametrize(
+    "test_data", test_data_suite | test_data_suite_bf16 | test_data_suite_fp16
+)
 def test_exp_tosa_FP(test_data: Tuple):
     pipeline = TosaPipelineFP[input_t1](
         Exp(),
@@ -90,15 +96,24 @@ def test_exp_u85_INT(test_data: Tuple):
     pipeline.run()
 
 
-@common.parametrize("test_data", test_data_suite)
+@common.parametrize("test_data", test_data_suite | test_data_suite_fp16)
 @common.SkipIfNoModelConverter
 def test_exp_vgf_no_quant(test_data: Tuple):
+    data = test_data()
+    if data.dtype == torch.float16:
+        atol = 2e-2
+        rtol = 2e-2
+    else:
+        atol = 1e-3
+        rtol = 1e-3
     pipeline = VgfPipeline[input_t1](
         Exp(),
-        (test_data(),),
+        (data,),
         aten_op,
         exir_op=[],
         quantize=False,
+        atol=atol,
+        rtol=rtol,
     )
     pipeline.run()
 

--- a/backends/arm/test/ops/test_floor.py
+++ b/backends/arm/test/ops/test_floor.py
@@ -52,9 +52,19 @@ test_data_bf16 = {
         torch.arange(-8, 8, 0.5, dtype=torch.bfloat16),
     ),
 }
+test_data_fp16 = {
+    "floor_rand_fp16": lambda: (
+        Floor(),
+        torch.rand(4, 4, dtype=torch.float16) - 0.5,
+    ),
+    "floor_ramp_fp16": lambda: (
+        Floor(),
+        torch.arange(-8, 8, 0.5, dtype=torch.float16),
+    ),
+}
 
 
-@common.parametrize("test_data", test_data | test_data_bf16)
+@common.parametrize("test_data", test_data | test_data_bf16 | test_data_fp16)
 def test_floor_tosa_FP(test_data: input_t1):
     module, data = test_data()
     pipeline = TosaPipelineFP[input_t1](
@@ -107,7 +117,7 @@ def test_floor_u85_INT(test_data: input_t1):
     pipeline.run()
 
 
-@common.parametrize("test_data", test_data)
+@common.parametrize("test_data", test_data | test_data_fp16)
 @common.SkipIfNoModelConverter
 def test_floor_vgf_no_quant(test_data: input_t1):
     module, data = test_data()


### PR DESCRIPTION
Add FP16 support for operators:
 - eq
 - erf
 - exp
 - floor
 - depthwise conv

Update op tests to cover the new datatype.


cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai