### PR TITLE
Arm backend: Add STABLE softmax decomposition config for Ethos-U

### DIFF
--- a/backends/arm/common/pipeline_config.py
+++ b/backends/arm/common/pipeline_config.py
@@ -12,8 +12,9 @@ from executorch.exir._warnings import deprecated
 
 
 class SoftmaxDecompositionConfig(Enum):
-    MASKED = auto()
-    UNSTABLE = auto()
+    MASKED = auto()  # Stable softmax + masked fill decomposition
+    UNSTABLE = auto()  # Unstable softmax, no masked fill decomposition
+    STABLE = auto()  # Stable softmax, no masked fill decomposition
 
 
 class FuseDuplicateUsersConfig(Enum):
@@ -36,7 +37,7 @@ class ArmPassPipelineConfig:
         The stable softmax decomposition is now supported by all arm targets and will be made default in a future release. Overwrite the default config using `compile_spec.set_pass_pipeline_config(ArmPassPipelineConfig())` to use the stable algorithm and avoid this error."
         """
 
-        self.softmax = SoftmaxDecompositionConfig.UNSTABLE
+        self.softmax = SoftmaxDecompositionConfig.STABLE
 
     def disable_fuse_duplicate_users(self) -> None:
         self.fuse_duplicate_users = FuseDuplicateUsersConfig.DISABLED

--- a/backends/arm/test/misc/test_compile_spec.py
+++ b/backends/arm/test/misc/test_compile_spec.py
@@ -3,6 +3,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from executorch.backends.arm.common.pipeline_config import SoftmaxDecompositionConfig
 from executorch.backends.arm.ethosu import EthosUCompileSpec
 from executorch.backends.arm.tosa.compile_spec import TosaCompileSpec
 from executorch.backends.arm.vgf import VgfCompileSpec
@@ -26,6 +27,20 @@ def test_ethos_u_compile_spec_no_target():
     spec_list.pop(0)
     with raises(ValueError, match="No tosa_spec in compile spec."):
         EthosUCompileSpec.from_list(spec_list)
+
+
+def test_ethos_u55_defaults_to_stable_softmax():
+    """Test that EthosUCompileSpec for U55 defaults to STABLE softmax config."""
+    compile_spec = EthosUCompileSpec("ethos-u55-128")
+    pipeline_config = compile_spec.get_pass_pipeline_config()
+    assert pipeline_config.softmax == SoftmaxDecompositionConfig.STABLE
+
+
+def test_ethos_u85_defaults_to_stable_softmax():
+    """Test that EthosUCompileSpec for U85 defaults to MASKED softmax config."""
+    compile_spec = EthosUCompileSpec("ethos-u85-256")
+    pipeline_config = compile_spec.get_pass_pipeline_config()
+    assert pipeline_config.softmax == SoftmaxDecompositionConfig.MASKED
 
 
 def test_vgf_compile_spec_no_target():

--- a/backends/arm/test/misc/test_pass_pipeline_config.py
+++ b/backends/arm/test/misc/test_pass_pipeline_config.py
@@ -4,11 +4,16 @@
 # LICENSE file in the root directory of this source tree.
 
 from executorch.backends.arm._passes import (
+    DecomposeMaskedFillPass,
+    DecomposeSoftmaxPass,
     DecomposeSoftmaxUnstablePass,
     FuseDuplicateUsersPass,
 )
 from executorch.backends.arm._passes.arm_pass_manager import ArmPassManager
-from executorch.backends.arm.common.pipeline_config import ArmPassPipelineConfig
+from executorch.backends.arm.common.pipeline_config import (
+    ArmPassPipelineConfig,
+    SoftmaxDecompositionConfig,
+)
 from executorch.backends.arm.tosa.compile_spec import TosaCompileSpec
 from executorch.backends.arm.tosa.specification import TosaSpecification
 
@@ -33,3 +38,54 @@ def test_pipeline_config_override_outside_compile_spec_no_target():
 
     assert FuseDuplicateUsersPass in skip_passes
     assert DecomposeSoftmaxUnstablePass in skip_passes
+
+
+def test_softmax_config_masked():
+    """Test MASKED config: stable softmax, masked fill decomposition enabled."""
+    compile_spec = TosaCompileSpec(
+        TosaSpecification.create_from_string("TOSA-1.00+INT")
+    )
+    config = ArmPassPipelineConfig(softmax=SoftmaxDecompositionConfig.MASKED)
+    compile_spec.set_pass_pipeline_config(config)
+    manager = ArmPassManager(compile_spec)
+    skip_passes = manager._skip_pass_types
+
+    # MASKED: skip unstable softmax, use stable softmax
+    assert DecomposeSoftmaxUnstablePass in skip_passes
+    assert DecomposeSoftmaxPass not in skip_passes
+    # MASKED: masked fill decomposition is enabled (not skipped)
+    assert DecomposeMaskedFillPass not in skip_passes
+
+
+def test_softmax_config_unstable():
+    """Test UNSTABLE config: unstable softmax, no masked fill decomposition."""
+    compile_spec = TosaCompileSpec(
+        TosaSpecification.create_from_string("TOSA-1.00+INT")
+    )
+    config = ArmPassPipelineConfig(softmax=SoftmaxDecompositionConfig.UNSTABLE)
+    compile_spec.set_pass_pipeline_config(config)
+    manager = ArmPassManager(compile_spec)
+    skip_passes = manager._skip_pass_types
+
+    # UNSTABLE: skip stable softmax, use unstable softmax
+    assert DecomposeSoftmaxPass in skip_passes
+    assert DecomposeSoftmaxUnstablePass not in skip_passes
+    # UNSTABLE: masked fill decomposition is disabled (skipped)
+    assert DecomposeMaskedFillPass in skip_passes
+
+
+def test_softmax_config_stable():
+    """Test STABLE config: stable softmax, no masked fill decomposition."""
+    compile_spec = TosaCompileSpec(
+        TosaSpecification.create_from_string("TOSA-1.00+INT")
+    )
+    config = ArmPassPipelineConfig(softmax=SoftmaxDecompositionConfig.STABLE)
+    compile_spec.set_pass_pipeline_config(config)
+    manager = ArmPassManager(compile_spec)
+    skip_passes = manager._skip_pass_types
+
+    # STABLE: skip unstable softmax, use stable softmax
+    assert DecomposeSoftmaxUnstablePass in skip_passes
+    assert DecomposeSoftmaxPass not in skip_passes
+    # STABLE: masked fill decomposition is disabled (skipped)
+    assert DecomposeMaskedFillPass in skip_passes

--- a/backends/arm/test/targets.bzl
+++ b/backends/arm/test/targets.bzl
@@ -41,6 +41,7 @@ def define_arm_tests():
     # Misc tests
     test_files += [
         "misc/test_compile_spec.py",
+        "misc/test_pass_pipeline_config.py",
         "misc/test_tosa_spec.py",
         "misc/test_bn_relu_folding_qat.py",
         "misc/test_custom_partition.py",


### PR DESCRIPTION
Summary:
Current behavior for U55 defaults to UNSTABLE. It seems like this is because mask is not supported on U55, but there does not seem to be an inherent need to couple this. Defaulting to UNSTABLE negatively impacts quantization performance.

This PR adds a new `STABLE` option to `SoftmaxDecompositionConfig` that provides numerically stable softmax decomposition without masked fill decomposition.

The three softmax configs now behave as follows:
- `MASKED`: Stable softmax (with amax subtraction) + masked fill decomposition
- `UNSTABLE`: Unstable softmax (no amax subtraction), no masked fill decomposition
- `STABLE`: Stable softmax (with amax subtraction), no masked fill decomposition

For Ethos-U55 targets, `disable_masked_softmax()` now sets the config to `STABLE` instead of `UNSTABLE`, providing numerically stable softmax while avoiding masked fill decomposition which is not needed for these targets.

Differential Revision: D92058235




cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai