### PR TITLE
Upgrade Python from 3.10 to 3.12

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -52,7 +52,7 @@ To build the documentation locally:
    Or a Conda environment:
 
    ```bash
-   conda create -yn executorch python=3.10.0 && conda activate executorch
+   conda create -yn executorch python=3.12.0 && conda activate executorch
    ```
 
 1. Install dependencies:

--- a/docs/source/raspberry_pi_llama_tutorial.md
+++ b/docs/source/raspberry_pi_llama_tutorial.md
@@ -65,7 +65,7 @@ cd executorch
 
 ```bash
 # Create conda environment
-conda create -yn executorch python=3.10.0
+conda create -yn executorch python=3.12.0
 conda activate executorch
 
 # Upgrade pip

--- a/docs/source/using-executorch-building-from-source.md
+++ b/docs/source/using-executorch-building-from-source.md
@@ -45,7 +45,7 @@ portability details.
    ```bash
    git clone -b viable/strict https://github.com/pytorch/executorch.git
    cd executorch
-   conda create -yn executorch python=3.10.0
+   conda create -yn executorch python=3.12.0
    conda activate executorch
    ```
 

--- a/examples/raspberry_pi/setup.sh
+++ b/examples/raspberry_pi/setup.sh
@@ -245,7 +245,7 @@ setup_environment() {
         # Check if conda is available
         if command -v conda &> /dev/null; then
             log_info "Creating conda environment..."
-            conda create -yn executorch python=3.10.0
+            conda create -yn executorch python=3.12.0
             eval "$(conda shell.bash hook)"
             conda activate executorch
             log_success "Created and activated conda environment: executorch"


### PR DESCRIPTION
Summary:
This diff upgrades all Python 3.10 pins in the ExecutorTorch codebase to Python 3.12, completing task T236697147.

Changes include:
- Updated PACKAGE files in devtools/fb and exir/backend directories to use Python 3.12
- Created new PACKAGE files in subdirectories (benchmark, tests, visualizer/tests) to ensure consistent Python 3.12 usage
- Updated documentation examples to recommend Python 3.12 instead of 3.10 for new environments
- Updated setup.sh scripts to use Python 3.12

Note: References to "Python 3.10+" or "Python 3.10-3.13" in documentation are intentionally preserved as they indicate minimum version requirements, not pins.

Differential Revision: D92073272


