### PR TITLE
Shim LI op defs in OSS

### DIFF
--- a/backends/xnnpack/test/BUCK
+++ b/backends/xnnpack/test/BUCK
@@ -8,6 +8,7 @@ load(
     "@fbsource//xplat/caffe2:pt_defs.bzl",
     "get_pt_ops_deps",
 )
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
 oncall("executorch")
 # As fb_xplat_cxx_test (using target.bzl) fails to compile for
@@ -31,7 +32,7 @@ non_fbcode_target(_kind = fb_xplat_cxx_binary,
         deps = [
             "//xplat/caffe2:torch_mobile_ops_full_dev",
         ],
-    ),
+    ) if not runtime.is_oss else [],
 )
 
 # !!!! fbcode/executorch/backends/xnnpack/test/TARGETS was merged into this file, see https://fburl.com/workplace/xl8l9yuo for more info !!!!

--- a/shim_et/xplat/caffe2/pt_defs.bzl
+++ b/shim_et/xplat/caffe2/pt_defs.bzl
@@ -1,0 +1,2 @@
+def get_pt_ops_deps(name, train, deps):
+    return []


### PR DESCRIPTION
### Summary
Buck unit test jobs are failing since the TARGETS file migration due to xnnpack/buck/test/BUCK referencing an internal target. The specific dependency (ATen quant ops) should be available by default in OSS, so I'm just gating this and adding a no-op definition of get_pt_ops_deps in shim_et.

### Test Plan
Buck tests are passing on OSS CI.