### PR TITLE
Check flatbuffer offset when verification is minimal

### DIFF
--- a/runtime/executor/program.cpp
+++ b/runtime/executor/program.cpp
@@ -139,7 +139,7 @@ Result<executorch_flatbuffer::ExecutionPlan*> get_execution_plan(
     return Error::InvalidProgram;
   }
 
-  // Do extra verification if requested.
+  // Do verification based on the requested level.
   if (verification == Verification::InternalConsistency) {
 #if ET_ENABLE_PROGRAM_VERIFICATION
     EXECUTORCH_SCOPE_PROF("Program::verify_internal_consistency");
@@ -160,8 +160,22 @@ Result<executorch_flatbuffer::ExecutionPlan*> get_execution_plan(
         "Program validation failed: likely a corrupt file");
 #else
     ET_LOG(
-        Info, "InternalConsistency verification requested but not available");
+        Error,
+        "InternalConsistency verification requested but not available; "
+        "build with ET_ENABLE_PROGRAM_VERIFICATION=1");
+    return Error::NotSupported;
 #endif
+  } else {
+    // Minimal verification: check that the root table offset is within bounds.
+    // The first 4 bytes of the flatbuffer contain an offset to the root table.
+    uint32_t root_offset = flatbuffers::ReadScalar<flatbuffers::uoffset_t>(
+        program_data->data());
+    ET_CHECK_OR_RETURN_ERROR(
+        root_offset < program_data->size(),
+        InvalidProgram,
+        "Root table offset %u >= program size %zu",
+        root_offset,
+        program_data->size());
   }
 
   // The flatbuffer data must start at an aligned address to ensure internal

--- a/runtime/executor/program.cpp
+++ b/runtime/executor/program.cpp
@@ -168,12 +168,19 @@ Result<executorch_flatbuffer::ExecutionPlan*> get_execution_plan(
   } else {
     // Minimal verification: check that the root table offset is within bounds.
     // The first 4 bytes of the flatbuffer contain an offset to the root table.
+    ET_CHECK_OR_RETURN_ERROR(
+        program_data->size() >= sizeof(flatbuffers::uoffset_t),
+        InvalidProgram,
+        "Program data size %zu is too small for flatbuffer header",
+        program_data->size());
     uint32_t root_offset = flatbuffers::ReadScalar<flatbuffers::uoffset_t>(
         program_data->data());
+    // The root table is at buf + root_offset, and must have at least a
+    // vtable offset (soffset_t) at that position.
     ET_CHECK_OR_RETURN_ERROR(
-        root_offset < program_data->size(),
+        root_offset <= program_data->size() - sizeof(flatbuffers::uoffset_t),
         InvalidProgram,
-        "Root table offset %u >= program size %zu",
+        "Root table offset %u exceeds program size %zu",
         root_offset,
         program_data->size());
   }

--- a/runtime/executor/program.cpp
+++ b/runtime/executor/program.cpp
@@ -128,6 +128,16 @@ Result<executorch_flatbuffer::ExecutionPlan*> get_execution_plan(
   }
   EXECUTORCH_END_PROF(prof_tok);
 
+  // Minimum size: 4-byte root offset + 4-byte file identifier.
+  constexpr size_t kMinBufferSize =
+      sizeof(flatbuffers::uoffset_t) + flatbuffers::kFileIdentifierLength;
+  ET_CHECK_OR_RETURN_ERROR(
+      program_data->size() >= kMinBufferSize,
+      InvalidProgram,
+      "Program data size %zu is too small (minimum %zu)",
+      program_data->size(),
+      kMinBufferSize);
+
   // Make sure the magic header matches the expected version.
   if (!executorch_flatbuffer::ProgramBufferHasIdentifier(
           program_data->data())) {
@@ -167,20 +177,18 @@ Result<executorch_flatbuffer::ExecutionPlan*> get_execution_plan(
 #endif
   } else {
     // Minimal verification: check that the root table offset is within bounds.
-    // The first 4 bytes of the flatbuffer contain an offset to the root table.
-    ET_CHECK_OR_RETURN_ERROR(
-        program_data->size() >= sizeof(flatbuffers::uoffset_t),
-        InvalidProgram,
-        "Program data size %zu is too small for flatbuffer header",
-        program_data->size());
+    // The minimum size check above guarantees we can safely read the offset.
     uint32_t root_offset = flatbuffers::ReadScalar<flatbuffers::uoffset_t>(
         program_data->data());
-    // The root table is at buf + root_offset, and must have at least a
-    // vtable offset (soffset_t) at that position.
+    // The root table is at buf + root_offset. It must not point into the
+    // header (offset + file identifier = 8 bytes) and must leave room for
+    // at least a vtable offset (uoffset_t) at its position.
     ET_CHECK_OR_RETURN_ERROR(
-        root_offset <= program_data->size() - sizeof(flatbuffers::uoffset_t),
+        root_offset >= kMinBufferSize &&
+            root_offset <=
+                program_data->size() - sizeof(flatbuffers::uoffset_t),
         InvalidProgram,
-        "Root table offset %u exceeds program size %zu",
+        "Root table offset %u is invalid for program size %zu",
         root_offset,
         program_data->size());
   }

--- a/runtime/executor/test/program_test.cpp
+++ b/runtime/executor/test/program_test.cpp
@@ -266,9 +266,9 @@ TEST_F(ProgramTest, MinimalVerificationCatchesInvalidRootOffset) {
   }
 
   // Corrupt the root offset (first 4 bytes) to point beyond the buffer.
-  // Set it to a value larger than the buffer size.
-  uint32_t invalid_offset = static_cast<uint32_t>(data_len + 1000);
-  memcpy(data.get(), &invalid_offset, sizeof(invalid_offset));
+  // Use WriteScalar for correct little-endian encoding.
+  flatbuffers::WriteScalar<flatbuffers::uoffset_t>(
+      data.get(), static_cast<flatbuffers::uoffset_t>(data_len + 1000));
 
   // Wrap the corrupted data in a loader.
   BufferDataLoader data_loader(data.get(), data_len);


### PR DESCRIPTION
### Summary
Unconditionally verify that the offset is within the flatbuffer bounds. Setting InternalConsistency is a binary size burden (20-30kb), so check this separately when we have minimal verification.

Error out if InternalConsistency is requested, but verification is disabled.

### Test plan
```
cd build
cmake .. -DEXECUTORCH_BUILD_TESTS=ON
cmake --build . --target program_test
ctest -R program_test -V
```