### PR TITLE
Disable smollm2 on ethos-u

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -315,7 +315,6 @@ jobs:
           - test_arm_baremetal: test_run_ethos_u85
           - test_arm_baremetal: test_smaller_stories_llama
           - test_arm_baremetal: test_memory_allocation
-          - test_arm_baremetal: test_model_smollm2-135M
       fail-fast: false
     with:
       runner: linux.2xlarge.memory


### PR DESCRIPTION
### Summary
This model is too large to fit on Ethos-U. After discussion with @psiddh, sounds like the best call is to disable it for now. It was previously working only because the weights were all zeros, allowing it to be compressed and fit. With recent changes to not zero weights, the job is failing on trunk.
