### PR TITLE
Lower cmake minimum version requirement to 3.24

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,9 +45,7 @@
 # ~~~
 #
 
-# TODO Lower to 3.24 when XNNPACK dependency is updated to include
-# https://github.com/google/XNNPACK/commit/c690daa67f883e1b627aadf7684c06797e9a0684
-cmake_minimum_required(VERSION 3.29)
+cmake_minimum_required(VERSION 3.24)
 project(executorch)
 
 set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-  "cmake>=3.29,<4.0.0",  # For building binary targets in the wheel. 4.0.0 breaks third-party CMake build so temporarily pin the version.
+  "cmake>=3.24,<4.0.0",  # For building binary targets in the wheel. 4.0.0 breaks third-party CMake build so temporarily pin the version.
   "packaging>=24.2", # Lower bound required by setuptools
   "pip>=23",  # For building the pip package.
   "pyyaml",  # Imported by the kernel codegen tools.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 # Pip packages needed to build from source. Mainly for development of ExecuTorch.
 
-cmake>=3.29, <4.0.0  # For building binary targets in the wheel.
+cmake>=3.24, <4.0.0  # For building binary targets in the wheel.
 packaging>=24.2 # Lower bound required by setuptools
 pip>=23  # For building the pip package.
 pyyaml  # Imported by the kernel codegen tools.


### PR DESCRIPTION
Lower camke minimum version required to 3.24 as XNNPACK dependency is updated to include https://github.com/google/XNNPACK/commit/c690daa67f883e1b627aadf7684c06797e9a0684



cc @GregoryComer @digantdesai @cbilgin