### PR TITLE
Arm backend: Conv + INT16: check DTYPE with qparams rather than runtime's DTYPE

### DIFF
--- a/backends/arm/test/passes/test_decompose_int16_activation_conv_pass.py
+++ b/backends/arm/test/passes/test_decompose_int16_activation_conv_pass.py
@@ -1,0 +1,202 @@
+# Copyright 2025 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Tests for DecomposeConvWithInt16ActivationPass.
+
+This pass decomposes convolution with int16 activation and bias into:
+- A convolution without bias
+- A rescale to int32
+- An add with the reshaped bias
+- A rescale back to the output dtype
+"""
+
+from typing import Tuple
+
+import torch
+from executorch.backends.arm._passes import DecomposeConvWithInt16ActivationPass
+from executorch.backends.arm.test.tester.test_pipeline import (
+    PassPipeline,
+    TosaPipelineINT,
+)
+
+input_t = Tuple[torch.Tensor]
+
+
+class Conv2dWithBias(torch.nn.Module):
+    """Conv2d with bias - should be decomposed for INT16 activations."""
+
+    def __init__(
+        self,
+        in_channels: int = 3,
+        out_channels: int = 8,
+        kernel_size: Tuple[int, int] = (3, 3),
+        stride: int = 1,
+        padding: int = 1,
+    ):
+        super().__init__()
+        self.conv = torch.nn.Conv2d(
+            in_channels=in_channels,
+            out_channels=out_channels,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=padding,
+            bias=True,
+        )
+
+    def get_inputs(self) -> input_t:
+        return (torch.randn(1, 3, 8, 8),)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.conv(x)
+
+
+class Conv2dWithoutBias(torch.nn.Module):
+    """Conv2d without bias - should NOT be decomposed."""
+
+    def __init__(
+        self,
+        in_channels: int = 3,
+        out_channels: int = 8,
+        kernel_size: Tuple[int, int] = (3, 3),
+        stride: int = 1,
+        padding: int = 1,
+    ):
+        super().__init__()
+        self.conv = torch.nn.Conv2d(
+            in_channels=in_channels,
+            out_channels=out_channels,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=padding,
+            bias=False,
+        )
+
+    def get_inputs(self) -> input_t:
+        return (torch.randn(1, 3, 8, 8),)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.conv(x)
+
+
+class Conv2dMultipleConvs(torch.nn.Module):
+    """Multiple Conv2d layers with bias - all should be decomposed for INT16."""
+
+    def __init__(self):
+        super().__init__()
+        self.conv1 = torch.nn.Conv2d(
+            in_channels=3, out_channels=8, kernel_size=3, stride=1, padding=1, bias=True
+        )
+        self.conv2 = torch.nn.Conv2d(
+            in_channels=8,
+            out_channels=16,
+            kernel_size=3,
+            stride=1,
+            padding=1,
+            bias=True,
+        )
+
+    def get_inputs(self) -> input_t:
+        return (torch.randn(1, 3, 8, 8),)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.conv1(x)
+        x = self.conv2(x)
+        return x
+
+
+def test_decompose_int16_conv_pass_fp32_no_decomposition() -> None:
+    """
+    Test that DecomposeConvWithInt16ActivationPass does NOT decompose
+    convolution when using FP32 (no quantization).
+    """
+    module = Conv2dWithBias()
+    pipeline = PassPipeline[input_t](
+        module,
+        module.get_inputs(),
+        quantize=False,
+        ops_before_pass={
+            "executorch_exir_dialects_edge__ops_aten_convolution_default": 1,
+        },
+        ops_after_pass={
+            "executorch_exir_dialects_edge__ops_aten_convolution_default": 1,
+        },
+        ops_not_after_pass=[
+            "executorch_exir_dialects_edge__ops_aten_add_Tensor",
+            "executorch_exir_dialects_backend__ops_tosa_RESCALE_default",
+        ],
+        pass_list=[DecomposeConvWithInt16ActivationPass],
+    )
+    pipeline.pop_stage("run_method_and_compare_outputs")
+    pipeline.run()
+
+
+aten_op = "torch.ops.aten.conv2d.default"
+exir_op = "executorch_exir_dialects_edge__ops_aten_convolution_default"
+
+
+def test_conv2d_int16_e2e_tosa_single_conv() -> None:
+    """
+    End-to-end test for conv2d with INT16 quantization using TOSA pipeline.
+    This validates the full lowering path including the decomposition pass
+    for a single convolution with bias.
+    """
+    module = Conv2dWithBias()
+    pipeline = TosaPipelineINT[input_t](
+        module,
+        module.get_inputs(),
+        aten_op,
+        exir_op,
+        tosa_extensions=["int16"],
+    )
+    pipeline.run()
+
+
+def test_conv2d_int16_e2e_tosa_multiple_convs() -> None:
+    """
+    End-to-end test for conv2d with INT16 quantization using TOSA pipeline.
+    This validates the full lowering path including the decomposition pass
+    for multiple convolutions with bias.
+    """
+    module = Conv2dMultipleConvs()
+    pipeline = TosaPipelineINT[input_t](
+        module,
+        module.get_inputs(),
+        aten_op,
+        exir_op,
+        tosa_extensions=["int16"],
+    )
+    pipeline.run()
+
+
+def test_conv2d_int16_e2e_tosa_without_bias() -> None:
+    """
+    End-to-end test for conv2d without bias with INT16 quantization.
+    This validates that convolutions without bias don't get decomposed.
+    """
+    module = Conv2dWithoutBias()
+    pipeline = TosaPipelineINT[input_t](
+        module,
+        module.get_inputs(),
+        aten_op,
+        exir_op,
+        tosa_extensions=["int16"],
+    )
+    pipeline.run()
+
+
+def test_conv2d_int8_e2e_tosa() -> None:
+    """
+    End-to-end test for conv2d with INT8 quantization using TOSA pipeline.
+    This validates that INT8 activations don't trigger the decomposition.
+    """
+    module = Conv2dWithBias()
+    pipeline = TosaPipelineINT[input_t](
+        module,
+        module.get_inputs(),
+        aten_op,
+        exir_op,
+    )
+    pipeline.run()


### PR DESCRIPTION
Summary:
## Overview

- Modifying `DecomposeConvWithInt16ActivationPass` to check the quantization parameters' dtype (meta.data['input_qparams'][0].dtype) instead of the raw tensor dtype (args[0].data.dtype).

## Problem before this PULL request
- The original code checked args[0].data.dtype (the FakeTensor's runtime dtype), which may differ from the quantization target.

Specifically:
- Added a lookup for input_qparams from meta.data
- Added a guard to return early if input qparams are not present (index 0 not in qparams)
- Changed the dtype check from activation_tensor.dtype != torch.int16 to activation_dtype != torch.int16 where activation_dtype comes from the quantization parameters
- Added tests.

## Note:
- Other passes (`insert_rescales_pass.py`) use the same approach to check for INT16 activations. ```shift_bits = 12 if input_qparams[keys[0]].dtype == torch.int16 else 20```

Differential Revision: D92054367




cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai