### PR TITLE
[ET-VK] Refactor Context::flush() and make ComputeGraph destructor exception-safe

### DIFF
--- a/backends/vulkan/runtime/api/Context.cpp
+++ b/backends/vulkan/runtime/api/Context.cpp
@@ -226,13 +226,14 @@ void Context::submit_cmd_to_gpu(VkFence fence_handle, const bool final_use) {
   }
 }
 
-void Context::flush() {
+void Context::wait_for_queue() {
   VK_CHECK(vkQueueWaitIdle(queue().handle));
+}
 
+void Context::clear_resources() {
   command_pool_.flush();
   descriptor_pool_.flush();
 
-  // If there is an existing command buffer, invalidate it
   if (cmd_) {
     cmd_.invalidate();
   }
@@ -241,6 +242,11 @@ void Context::flush() {
   std::lock_guard<std::mutex> imagelist_lock(image_clearlist_mutex_);
   buffers_to_clear_.clear();
   images_to_clear_.clear();
+}
+
+void Context::flush() {
+  wait_for_queue();
+  clear_resources();
 }
 
 bool available() {

--- a/backends/vulkan/runtime/api/Context.h
+++ b/backends/vulkan/runtime/api/Context.h
@@ -232,6 +232,10 @@ class Context final {
     return cmd_;
   }
 
+  void wait_for_queue();
+
+  void clear_resources();
+
   void flush();
 
 #if defined(VK_KHR_pipeline_executable_properties) && \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #17160
* #17159
* __->__ #17158

Refactored Context::flush() by extracting two new public functions:
- wait_for_queue(): blocks until the GPU queue is idle
- clear_resources(): clears command/descriptor pools and cleanup lists

This allows callers to use these operations independently. ComputeGraph's
destructor now uses these functions directly and wraps them in try/catch
blocks to ensure it never throws exceptions, following C++ best practices
for destructors.

Authored with Claude.

Differential Revision: [D92171362](https://our.internmc.facebook.com/intern/diff/D92171362/)