### PR TITLE
Title: Fix OOB heap read in bundled program tensor deserialization

### DIFF
--- a/devtools/bundled_program/bundled_program.cpp
+++ b/devtools/bundled_program/bundled_program.cpp
@@ -54,6 +54,15 @@ at::Tensor tensor_like(bundled_program_flatbuffer::Tensor* bundled_tensor) {
   at::Tensor ret_tensor = at::zeros(
       {ret_t_sizes, bundled_tensor->sizes()->size()},
       at::dtype(static_cast<ScalarType>(bundled_tensor->scalar_type())));
+
+  // Validate data buffer exists and has sufficient size
+  ET_CHECK(bundled_tensor->data() != nullptr);
+  ET_CHECK_MSG(
+      bundled_tensor->data()->size() >= ret_tensor.nbytes(),
+      "Tensor data buffer too small: got %zu bytes, need %zu bytes",
+      static_cast<size_t>(bundled_tensor->data()->size()),
+      static_cast<size_t>(ret_tensor.nbytes()));
+
   memcpy(
       ret_tensor.mutable_data_ptr(),
       static_cast<const void*>(bundled_tensor->data()->Data()),


### PR DESCRIPTION
Summary:
This diff addresses a security vulnerability (TOB-EXECUTORCH-9) in the bundled program tensor parsing code.

Problem:
tensor_like() in bundled_program.cpp copies tensor data using ret_tensor.nbytes() derived from the sizes[] field No validation that data[] buffer actually contains that many bytes A malicious .bpte file could claim large dimensions with minimal data, causing heap over-read

Fix:
Added null check for bundled_tensor->data()
Added size validation: data()->size() >= ret_tensor.nbytes() Memcpy only proceeds if source buffer is sufficiently sized
