### PR TITLE
Add ThreadSanitizer CI jobs for detecting threading bugs

### DIFF
--- a/.ci/scripts/unittest-linux.sh
+++ b/.ci/scripts/unittest-linux.sh
@@ -22,7 +22,7 @@ if [[ "$BUILD_TOOL" == "cmake" ]]; then
 
     # Enable sanitizers for Debug builds
     if [[ "$BUILD_MODE" == "Debug" ]]; then
-        export EXECUTORCH_USE_SANITIZER=ON
+        export EXECUTORCH_USE_SANITIZER="${EXECUTORCH_USE_SANITIZER:-asan}"
     fi
 
     # We need the runner to test the built library.

--- a/.ci/scripts/unittest-macos.sh
+++ b/.ci/scripts/unittest-macos.sh
@@ -21,7 +21,7 @@ trap 'rm -rfv ${TMP_DIR}' EXIT
 
 # Enable sanitizers for Debug builds
 if [[ "$BUILD_MODE" == "Debug" ]]; then
-    export EXECUTORCH_USE_SANITIZER=ON
+    export EXECUTORCH_USE_SANITIZER="${EXECUTORCH_USE_SANITIZER:-asan}"
 fi
 
 # Setup MacOS dependencies as there is no Docker support on MacOS atm

--- a/.ci/scripts/utils.sh
+++ b/.ci/scripts/utils.sh
@@ -167,8 +167,8 @@ build_executorch_runner_cmake() {
   local build_type="${1:-Release}"
   local sanitizer_flag=""
 
-  if [[ "${EXECUTORCH_USE_SANITIZER:-OFF}" == "ON" ]]; then
-      sanitizer_flag="-DEXECUTORCH_USE_SANITIZER=ON"
+  if [[ "${EXECUTORCH_USE_SANITIZER:-OFF}" != "OFF" ]]; then
+      sanitizer_flag="-DEXECUTORCH_USE_SANITIZER=${EXECUTORCH_USE_SANITIZER}"
   fi
 
   retry cmake \

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -18,6 +18,40 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  unittest-linux-tsan:
+    name: unittest-linux-tsan
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      runner: linux.2xlarge.memory
+      docker-image: ci-image:executorch-ubuntu-22.04-clang12
+      submodules: 'recursive'
+      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      timeout: 120
+      script: |
+        set -eux
+        export EXECUTORCH_USE_SANITIZER=tsan
+        .ci/scripts/unittest-linux.sh --build-tool cmake --build-mode Debug
+
+  unittest-linux-aarch64-tsan:
+    name: unittest-linux-aarch64-tsan
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      runner: linux.arm64.2xlarge
+      docker-image: ci-image:executorch-ubuntu-22.04-gcc11-aarch64
+      submodules: 'recursive'
+      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      timeout: 120
+      script: |
+        set -eux
+        export EXECUTORCH_USE_SANITIZER=tsan
+        .ci/scripts/unittest-linux.sh --build-tool cmake --build-mode Debug
+
   test-models-macos-cpu:
     name: test-models-macos-cpu
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,21 +111,52 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 announce_configured_options(CMAKE_BUILD_TYPE)
 
-# Sanitizer support (ASAN + UBSAN)
-if(EXECUTORCH_USE_SANITIZER)
+# Sanitizer support: OFF, asan, tsan - asan: AddressSanitizer +
+# UndefinedBehaviorSanitizer - tsan: ThreadSanitizer (for detecting data races)
+# Can be set via environment variable or -D flag
+if(DEFINED ENV{EXECUTORCH_USE_SANITIZER} AND NOT DEFINED
+                                             EXECUTORCH_USE_SANITIZER
+)
+  set(EXECUTORCH_USE_SANITIZER
+      "$ENV{EXECUTORCH_USE_SANITIZER}"
+      CACHE STRING "Sanitizer to use: OFF, asan, tsan"
+  )
+else()
+  set(EXECUTORCH_USE_SANITIZER
+      "OFF"
+      CACHE STRING "Sanitizer to use: OFF, asan, tsan"
+  )
+endif()
+set_property(CACHE EXECUTORCH_USE_SANITIZER PROPERTY STRINGS OFF asan tsan)
+
+if(NOT EXECUTORCH_USE_SANITIZER STREQUAL "OFF")
   if(MSVC)
     message(WARNING "Sanitizers are not fully supported on MSVC, skipping")
   else()
-    set(EXECUTORCH_SANITIZER_FLAGS
-        "-fsanitize=address,undefined -fno-omit-frame-pointer"
-    )
-    # Suppress deprecation warnings on macOS (third-party code like flatcc uses
-    # deprecated sprintf)
-    if(APPLE)
+    if(EXECUTORCH_USE_SANITIZER STREQUAL "asan")
       set(EXECUTORCH_SANITIZER_FLAGS
-          "${EXECUTORCH_SANITIZER_FLAGS} -Wno-deprecated-declarations"
+          "-fsanitize=address,undefined -fno-omit-frame-pointer"
+      )
+      # Suppress deprecation warnings on macOS (third-party code like flatcc
+      # uses deprecated sprintf)
+      if(APPLE)
+        set(EXECUTORCH_SANITIZER_FLAGS
+            "${EXECUTORCH_SANITIZER_FLAGS} -Wno-deprecated-declarations"
+        )
+      endif()
+      message(STATUS "Sanitizers enabled: address, undefined")
+    elseif(EXECUTORCH_USE_SANITIZER STREQUAL "tsan")
+      set(EXECUTORCH_SANITIZER_FLAGS
+          "-fsanitize=thread -fno-omit-frame-pointer"
+      )
+      message(STATUS "Sanitizers enabled: thread")
+    else()
+      message(
+        FATAL_ERROR
+          "Unknown sanitizer: ${EXECUTORCH_USE_SANITIZER}. Use: OFF, asan, tsan"
       )
     endif()
+
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${EXECUTORCH_SANITIZER_FLAGS}")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${EXECUTORCH_SANITIZER_FLAGS}")
     set(CMAKE_EXE_LINKER_FLAGS
@@ -134,7 +165,11 @@ if(EXECUTORCH_USE_SANITIZER)
     set(CMAKE_SHARED_LINKER_FLAGS
         "${CMAKE_SHARED_LINKER_FLAGS} ${EXECUTORCH_SANITIZER_FLAGS}"
     )
-    message(STATUS "Sanitizers enabled: address, undefined")
+    # MODULE libraries (e.g., Python extensions built with pybind11) use
+    # CMAKE_MODULE_LINKER_FLAGS, not CMAKE_SHARED_LINKER_FLAGS
+    set(CMAKE_MODULE_LINKER_FLAGS
+        "${CMAKE_MODULE_LINKER_FLAGS} ${EXECUTORCH_SANITIZER_FLAGS}"
+    )
   endif()
 endif()
 announce_configured_options(EXECUTORCH_USE_SANITIZER)

--- a/kernels/test/op_convolution_backward_test.cpp
+++ b/kernels/test/op_convolution_backward_test.cpp
@@ -23,6 +23,15 @@ using IntArrayRef = executorch::aten::ArrayRef<int64_t>;
 using OptIntArrayRef = executorch::aten::OptionalArrayRef<int64_t>;
 using torch::executor::testing::TensorFactory;
 
+namespace {
+// Helper to convert integer initializer list to vector of target type.
+// Avoids narrowing conversion errors with float16_t on strict compilers.
+template <typename T>
+std::vector<T> make_data(std::initializer_list<int> values) {
+  return std::vector<T>(values.begin(), values.end());
+}
+} // namespace
+
 class OpConvolutionBackwardOutTest : public OperatorTest {
  protected:
   std::tuple<Tensor&, Tensor&, Tensor&> op_convolution_backward_out(
@@ -68,11 +77,12 @@ class OpConvolutionBackwardOutTest : public OperatorTest {
     TensorFactory<DTYPE> tf;
 
     using CTYPE = typename decltype(tf)::ctype;
-    std::vector<CTYPE> grad_output_data = {
+    // clang-format off
+    auto grad_output_data = make_data<CTYPE>({
         10, 12, 87, 13, 34, 87, 55, 22, 48, 33, 29, 38, 60, 49, 88, 30,
         99, 19, 42, 37, 61, 31, 33, 58, 38, 23, 2,  33, 3,  21, 32, 2,
-        30, 72, 10, 67, 92, 19, 11, 16, 65, 37, 60, 74, 4,  19, 45, 37};
-    std::vector<CTYPE> input_data = {
+        30, 72, 10, 67, 92, 19, 11, 16, 65, 37, 60, 74, 4,  19, 45, 37});
+    auto input_data = make_data<CTYPE>({
         9,  89, 45, 39, 25, 2,  97, 55, 80, 24, 18, 33, 28, 89, 19, 16, 19, 33,
         69, 61, 34, 84, 58, 30, 33, 18, 75, 30, 6,  33, 42, 10, 80, 41, 66, 64,
         47, 51, 67, 62, 58, 10, 97, 71, 24, 44, 84, 34, 33, 54, 8,  73, 90, 15,
@@ -96,15 +106,15 @@ class OpConvolutionBackwardOutTest : public OperatorTest {
         45, 64, 58, 92, 44, 42, 7,  28, 94, 4,  8,  22, 22, 31, 75, 44, 3,  70,
         83, 72, 87, 12, 20, 55, 84, 31, 50, 34, 25, 49, 29, 71, 57, 97, 25, 82,
         84, 42, 86, 41, 54, 92, 34, 30, 52, 34, 84, 25, 54, 37, 38, 26, 76, 82,
-        34, 14, 85, 28, 93, 9};
-    std::vector<CTYPE> weight_data = {
+        34, 14, 85, 28, 93, 9});
+    auto weight_data = make_data<CTYPE>({
         2,  54, 9,  37, 0,  47, 70, 9,  84,  69, 56, 79, 25, 35, 54, 13,
         65, 46, 38, 28, 74, 27, 66, 61, 20,  60, 62, 58, 15, 44, 75, 55,
         7,  52, 13, 36, 39, 64, 62, 45, 100, 6,  79, 63, 63, 52, 37, 60,
         78, 12, 69, 2,  74, 56, 93, 39, 62,  22, 55, 67, 68, 74, 12, 69,
         15, 73, 28, 70, 86, 20, 90, 49, 52,  26, 58, 2,  82, 17, 70, 55,
-        54, 83, 70, 11, 27, 9,  5,  42, 34,  62, 29, 94, 69, 81, 54, 4};
-    std::vector<CTYPE> expected_grad_input_data = {
+        54, 83, 70, 11, 27, 9,  5,  42, 34,  62, 29, 94, 69, 81, 54, 4});
+    auto expected_grad_input_data = make_data<CTYPE>({
         1134,  7578,  686,   2682,  0, 4148,  7136,  2406,  8698, 0,
         3759,  6003,  2163,  2395,  0, 2929,  5830,  3469,  6955, 0,
         720,   6201,  495,   2063,  0, 5260,  5989,  3060,  7079, 0,
@@ -146,8 +156,8 @@ class OpConvolutionBackwardOutTest : public OperatorTest {
         152,   927,   287,   1902,  0, 301,   1051,  886,   2346, 0,
         6821,  19615, 4491,  13281, 0, 424,   1146,  999,   2906, 0,
         15177, 15480, 8849,  12442, 0, 1222,  544,   2687,  1859, 0,
-        20215, 9693,  11441, 4964,  0, 1206,  555,   2466,  860,  0};
-    std::vector<CTYPE> expected_grad_weight_data = {
+        20215, 9693,  11441, 4964,  0, 1206,  555,   2466,  860,  0});
+    auto expected_grad_weight_data = make_data<CTYPE>({
         9246,  22073, 12431, 19714, 11179, 19032, 8458,  6495,  18707, 13830,
         20445, 17089, 17124, 18710, 11827, 17236, 16824, 9008,  14086, 18834,
         17419, 16759, 13152, 9339,  13801, 20888, 13976, 27277, 13010, 23949,
@@ -157,8 +167,9 @@ class OpConvolutionBackwardOutTest : public OperatorTest {
         24188, 23619, 13752, 16251, 18741, 19368, 24517, 34261, 27054, 31257,
         21238, 18909, 15776, 16881, 34604, 22534, 28101, 23834, 18479, 16469,
         12852, 16551, 14204, 29983, 20167, 24150, 14281, 17501, 15897, 16019,
-        21661, 32765, 23874, 26527, 20463, 18661};
-    std::vector<CTYPE> expected_grad_bias_data = {363, 438, 585, 501};
+        21661, 32765, 23874, 26527, 20463, 18661});
+    auto expected_grad_bias_data = make_data<CTYPE>({363, 438, 585, 501});
+    // clang-format on
 
     auto grad_output = tf.make({2, 4, 3, 2}, grad_output_data);
     auto input = tf.make({2, 6, 7, 5}, input_data);

--- a/kernels/test/op_max_test.cpp
+++ b/kernels/test/op_max_test.cpp
@@ -254,7 +254,7 @@ class OpMaxUnaryOutTest : public OperatorTest {
     TensorFactory<IN_DTYPE> tf_in;
     Tensor input = tf_in.make({2, 0}, {});
     Tensor out = tf_in.zeros({});
-    Tensor expected = tf_in.make({}, {-INFINITY});
+    Tensor expected = tf_in.make({}, {static_cast<CTYPE>(-INFINITY)});
     op_max_unary_out(input, out);
     EXPECT_TENSOR_CLOSE(out, expected);
   }

--- a/kernels/test/op_unsqueeze_copy_test.cpp
+++ b/kernels/test/op_unsqueeze_copy_test.cpp
@@ -177,7 +177,7 @@ TEST_F(OpUnsqueezeTest, DimOutOfRangeDies) {
   }
 
   for (auto dim : illegal_dims) {
-    ET_LOG(Info, "Checking dim %ld", dim);
+    ET_LOG(Info, "Checking dim %lld", (long long)dim);
     ET_EXPECT_KERNEL_FAILURE(context_, op_unsqueeze_copy_out(input, dim, out));
   }
 }

--- a/test/run_oss_cpp_tests.sh
+++ b/test/run_oss_cpp_tests.sh
@@ -34,8 +34,8 @@ build_executorch() {
   fi
 
   SANITIZER_FLAG=""
-  if [[ "${EXECUTORCH_USE_SANITIZER:-OFF}" == "ON" ]]; then
-    SANITIZER_FLAG="-DEXECUTORCH_USE_SANITIZER=ON"
+  if [[ "${EXECUTORCH_USE_SANITIZER:-OFF}" != "OFF" ]]; then
+    SANITIZER_FLAG="-DEXECUTORCH_USE_SANITIZER=${EXECUTORCH_USE_SANITIZER}"
   fi
 
   cmake . \

--- a/tools/cmake/preset/default.cmake
+++ b/tools/cmake/preset/default.cmake
@@ -56,8 +56,7 @@ define_overridable_option(
   "Build executorch runtime optimizing for binary size" BOOL OFF
 )
 define_overridable_option(
-  EXECUTORCH_USE_SANITIZER
-  "Build with AddressSanitizer and UndefinedBehaviorSanitizer enabled" BOOL OFF
+  EXECUTORCH_USE_SANITIZER "Sanitizer to use: OFF, asan, tsan" STRING "OFF"
 )
 define_overridable_option(
   EXECUTORCH_BUILD_ARM_BAREMETAL


### PR DESCRIPTION
Unify sanitizer support under EXECUTORCH_USE_SANITIZER which now accepts
"asan", "tsan", or "OFF" instead of being a boolean. This provides a
single mechanism for all sanitizers with proper CMake linker flag handling.

Changes:
- EXECUTORCH_USE_SANITIZER accepts: OFF, asan, tsan
- Can be set via environment variable or -D flag
- TSAN jobs added to trunk.yml (not pull.yml to limit CI cost)
- Shell script defaults to asan for Debug builds

TSAN is valuable for ExecuTorch due to XNNPACK's thread pool usage
and parallel kernel execution.

CI:

https://github.com/pytorch/executorch/actions/runs/21642534747/job/62386030637?pr=17165
https://github.com/pytorch/executorch/actions/runs/21642534747/job/62386030575?pr=17165
