### PR TITLE
Fix mul + ReLU fusion in XNNPACK

### DIFF
--- a/backends/xnnpack/operators/op_multiply.py
+++ b/backends/xnnpack/operators/op_multiply.py
@@ -7,20 +7,19 @@
 from typing import Dict
 
 import torch
+from executorch.backends.xnnpack._passes.fuse_activation_pass import FuseActivationPass
 from executorch.backends.xnnpack.operators.node_visitor import (
     NodeVisitor,
     register_node_visitor,
 )
 from executorch.backends.xnnpack.operators.quant_params import QuantParams
 from executorch.backends.xnnpack.serialization.xnnpack_graph_schema import (
-    OutputMinMax,
     XNNGraph,
     XNNMultiply,
     XNode,
 )
 
-from executorch.backends.xnnpack.utils.utils import get_input_node, get_relu_fused_node
-from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.backends.xnnpack.utils.utils import get_input_node
 
 
 @register_node_visitor
@@ -58,21 +57,15 @@ class MultiplyVisitor(NodeVisitor):
         input2_id = vals_to_ids[input2]
 
         # output
-        output_node = get_relu_fused_node(node) or node
-        output_min_max = None
-        # if fused with relu
-        if output_node.target == exir_ops.edge.aten.relu.default:
-            output_node.meta["XNNPACK_FUSED"] = True
-            output_min_max = OutputMinMax(output_min=0, output_max="+inf")
-
+        output_min_max = FuseActivationPass.get_fused_activation(node)
         self.define_tensor(
-            output_node,
+            node,
             xnn_graph,
             vals_to_ids,
-            quant_params=QuantParams.from_outputs(output_node),
+            quant_params=QuantParams.from_outputs(node),
         )
 
-        output_id = vals_to_ids[output_node]
+        output_id = vals_to_ids[node]
 
         ser_node = XNode(
             xnode_union=XNNMultiply(


### PR DESCRIPTION
Summary: Serialization of fused mul + ReLU was previously broken in XNNPACK. The tests that exist covered graph level but not end to end. I've fixed the code path and updated test coverage.

This resolves the numerical deviation within Parakeet with XNNPACK delegation.

Differential Revision: D92178323


