### PR TITLE
Parakeet: Enable xnnpack by default

### DIFF
--- a/examples/models/parakeet/README.md
+++ b/examples/models/parakeet/README.md
@@ -25,7 +25,7 @@ python export_parakeet_tdt.py --audio /path/to/audio.wav
 | Argument | Description |
 |----------|-------------|
 | `--output-dir` | Output directory for exports (default: `./parakeet_tdt_exports`) |
-| `--backend` | Backend for acceleration: `portable`, `xnnpack`, `metal`, `cuda`, `cuda-windows` (default: `portable`) |
+| `--backend` | Backend for acceleration: `portable`, `xnnpack`, `metal`, `cuda`, `cuda-windows` (default: `xnnpack`) |
 | `--dtype` | Data type: `fp32`, `bf16`, `fp16` (default: `fp32`). Metal backend supports `fp32` and `bf16` only (no `fp16`). |
 | `--audio` | Path to audio file for transcription test |
 

--- a/examples/models/parakeet/export_parakeet_tdt.py
+++ b/examples/models/parakeet/export_parakeet_tdt.py
@@ -598,9 +598,9 @@ def main():
     parser.add_argument(
         "--backend",
         type=str,
-        default="portable",
+        default="xnnpack",
         choices=["portable", "xnnpack", "metal", "cuda", "cuda-windows"],
-        help="Backend for acceleration (default: portable)",
+        help="Backend for acceleration (default: xnnpack)",
     )
     parser.add_argument(
         "--dtype",


### PR DESCRIPTION
Now that https://github.com/pytorch/executorch/pull/17166 is landed, we can enable by default