### PR TITLE
NXP Backend: Add option for prefetching weights from external memory

### DIFF
--- a/backends/nxp/backend/neutron_converter_manager.py
+++ b/backends/nxp/backend/neutron_converter_manager.py
@@ -72,7 +72,19 @@ class NeutronConverterManager:
                 f"Target `{target}` is not a valid target. Must be one of `{valid_targets}`."
             )
 
-    def convert(self, tflite_model: bytes, target: str) -> bytes:
+    def convert(
+        self, tflite_model: bytes, target: str, fetch_constants_to_sram: bool = False
+    ) -> bytes:
+        """
+        Call Neutron Converter.
+
+        :param tflite_model: A generic TFLite model to be converted.
+        :param target: The target platform.
+        :param fetch_constants_to_sram: Add microcode that fetches weights from external memory.
+        This allows running models which do not fit into SRAM. Applies to Neutron-C only (microcontrollers).
+
+        :return: TFLite model with Neutron microcode as bytes.
+        """
         # Neutron converter crashes if we provide invalid target -> verify.
         self.verify_target(target)
 
@@ -82,6 +94,7 @@ class NeutronConverterManager:
         cctx.compilationOpts.excludeGraphPasses = (
             "HoistSliceAboveTranspose,MergeTranspose"
         )
+        cctx.compilationOpts.fetchConstantsToSRAM = fetch_constants_to_sram
 
         # Try to use multiprocessing for isolation, but fall back to direct execution
         # if the environment doesn't support it (e.g., in sandcastle/build environments)

--- a/backends/nxp/tests/executorch_pipeline.py
+++ b/backends/nxp/tests/executorch_pipeline.py
@@ -99,6 +99,7 @@ def to_quantized_edge_program(
     get_quantizer_fn=None,
     use_neutron_for_format_conversion=True,
     use_quant_state_dict=True,
+    fetch_constants_to_sram=False,
 ) -> EdgeProgramManager:
     _neutron_target_spec = NeutronTargetSpec(target, neutron_converter_flavor)
     if get_quantizer_fn is None:
@@ -128,6 +129,7 @@ def to_quantized_edge_program(
         operators_not_to_delegate=operators_not_to_delegate,
         neutron_converter_flavor=neutron_converter_flavor,
         use_neutron_for_format_conversion=use_neutron_for_format_conversion,
+        fetch_constants_to_sram=fetch_constants_to_sram,
     )
     post_quant_state_dict = (
         exir_program_aten__module_quant.state_dict() if use_quant_state_dict else None

--- a/backends/nxp/tests/test_neutron_converter_manager.py
+++ b/backends/nxp/tests/test_neutron_converter_manager.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 NXP
+# Copyright 2024-2026 NXP
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -14,7 +14,8 @@ from executorch.backends.nxp.backend.neutron_converter_manager import (
     NeutronConverterManager,
 )
 from executorch.backends.nxp.backend.node_format_inference import NodeFormatInference
-from executorch.backends.nxp.tests.models import Conv2dModule
+from executorch.backends.nxp.tests.executorch_pipeline import to_quantized_edge_program
+from executorch.backends.nxp.tests.models import Conv2dModule, LinearModule
 
 
 def test_conv2d_neutron_conversion__default_flavor():
@@ -31,7 +32,7 @@ def test_conv2d_neutron_conversion__default_flavor():
     )
 
     neutron_converter_manager = NeutronConverterManager()
-    neutron_model = neutron_converter_manager.convert(tflite_model, "imxrt700")
+    neutron_model = neutron_converter_manager.convert(tflite_model, "imxrt700", False)
 
     assert len(
         neutron_model
@@ -52,8 +53,30 @@ def test__conv2d_neutron_conversion__invalid_flavor():
     )
 
     with pytest.raises(RuntimeError) as excinfo:
-        _ = NeutronConverterManager("bad_flavor").convert(tflite_model, "imxrt700")
+        _ = NeutronConverterManager("bad_flavor").convert(
+            tflite_model, "imxrt700", False
+        )
 
     assert "Neutron Converter module with flavor 'bad_flavor' not found." in str(
         excinfo
     )
+
+
+def test_conv2d_neutron_conversion__prefetching(mocker):
+    model = LinearModule(True)
+    input_shape = (1, 1, 32, 32)
+
+    converter_spy = mocker.spy(NeutronConverterManager, "convert")
+    _ = to_quantized_edge_program(
+        model, input_shape, fetch_constants_to_sram=True
+    ).exported_program()
+    neutron_model_prefetch = converter_spy.spy_return
+
+    _ = to_quantized_edge_program(
+        model, input_shape, fetch_constants_to_sram=False
+    ).exported_program()
+    neutron_model_regular = converter_spy.spy_return
+
+    assert len(neutron_model_prefetch) != len(
+        neutron_model_regular
+    ), "The weight prefetching flag does not make a difference!"

--- a/examples/nxp/aot_neutron_compile.py
+++ b/examples/nxp/aot_neutron_compile.py
@@ -229,6 +229,13 @@ if __name__ == "__main__":  # noqa C901
         action="store_true",
         help="The calibration and testing datasets will be generated randomly instead of being downloaded.",
     )
+    parser.add_argument(
+        "--fetch_constants_to_sram",
+        required=False,
+        default=False,
+        action="store_true",
+        help="This feature allows running models which do not fit into SRAM by offloading them to an external memory.",
+    )
 
     args = parser.parse_args()
 
@@ -313,6 +320,7 @@ if __name__ == "__main__":  # noqa C901
         args.target,
         operators_not_to_delegate=args.operators_not_to_delegate,
         neutron_converter_flavor=args.neutron_converter_flavor,
+        fetch_constants_to_sram=args.fetch_constants_to_sram,
     )
     partitioners = (
         [


### PR DESCRIPTION
### Summary
Models that do not fit into SRAM can be placed into external memory. Since the Neutron has no access to external FLASH, the firmware needs to prefetch the weights from FLASH to SRAM in advance. This commit instructs the Neutron Converter to create extra instructions for such prefetching. Each prefetching is started in parallel with the compute, but can take longer, so this feature needs to be used only when necessary. 

This commit changes both the AoT part and runtime.

### Test plan
Unit test added to backends/nxp/tests/test_neutron_converter_manager.py

cc @robert-kalmar @JakeStevens @digantdesai