### PR TITLE
Arm backend: Add ng_model_gym test deps

### DIFF
--- a/backends/arm/requirements-arm-models-test.txt
+++ b/backends/arm/requirements-arm-models-test.txt
@@ -4,3 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 diffusers[torch] @ git+https://github.com/huggingface/diffusers.git@a7cb14efbe4b255f4c8721c91a04f0ef40f4a05a
+# ng_model_gym deps needed by NSS model tests
+pydantic
+slangtorch
+rich


### PR DESCRIPTION
ng_model_gym is installed with --no-deps, so add explicit deps (pydantic, slangtorch) to avoid import errors in model tests.

cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai