### PR TITLE
Neutron backend: Add NXP Executor Runner

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -966,15 +966,17 @@ jobs:
         # The generic Linux job chooses to use base env, not the one setup by the image
         CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
         conda activate "${CONDA_ENV}"
+        
+        # Install eIQ packages
+        pip install -r backends/nxp/requirements-eiq.txt
 
         # Build and install Executorch
         PYTHON_EXECUTABLE=python \
-        CMAKE_ARGS="-DEXECUTORCH_BUILD_NXP_NEUTRON=ON" \
+        CMAKE_ARGS="-DEXECUTORCH_BUILD_NXP_NEUTRON=ON -DEXECUTORCH_BUILD_NXP_NEUTRON_RUNNER=ON " \
         .ci/scripts/setup-linux.sh --build-tool "cmake"
 
         # Install test requirements
         pip install -r backends/nxp/requirements-tests-pypi.txt
-        pip install -r backends/nxp/requirements-tests-eiq.txt
         PYTHON_EXECUTABLE=python bash examples/nxp/setup.sh
 
         # Run pytest
@@ -983,6 +985,9 @@ jobs:
         # Run aot examples:
         PYTHON_EXECUTABLE=python bash examples/nxp/run_aot_example.sh cifar10
         PYTHON_EXECUTABLE=python bash examples/nxp/run_aot_example.sh mobilenetv2
+        
+        # Run e2e example with Simulator:
+        PYTHON_EXECUTABLE=python bash examples/nxp/run.sh cifar10
 
   test-samsung-quantmodels-linux:
     name: test-samsung-quantmodels-linux

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -628,6 +628,10 @@ if(EXECUTORCH_BUILD_NXP_NEUTRON)
   list(APPEND _executorch_backends executorch_delegate_neutron)
 endif()
 
+if(EXECUTORCH_BUILD_NXP_NEUTRON_RUNNER)
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/examples/nxp/executor_runner)
+endif()
+
 if(EXECUTORCH_BUILD_COREML)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/backends/apple/coreml)
   list(APPEND _executorch_backends coremldelegate)

--- a/backends/nxp/requirements-eiq.txt
+++ b/backends/nxp/requirements-eiq.txt
@@ -1,2 +1,4 @@
 --index-url https://eiq.nxp.com/repository
 neutron_converter_SDK_25_12
+eiq_neutron_sdk==2.2.2
+eiq_nsys

--- a/docs/source/backends/nxp/nxp-overview.md
+++ b/docs/source/backends/nxp/nxp-overview.md
@@ -37,17 +37,14 @@ $ ./examples/nxp/setup.sh
 
 ## Using NXP eIQ Backend
 
-To test converting a neural network model for inference on NXP eIQ Neutron backend, you can use our example script:
-
-```shell
-# cd to the root of executorch repository
-./examples/nxp/aot_neutron_compile.sh [model (cifar10 or mobilenetv2)]
-```
+To test the eIQ Neutron Backend, both AoT flow for model preparation and Runtime for execution, refer to the [Getting started with eIQ Neutron NPU ExecuTorch backend](tutorials/nxp-basic-tutorial.md)
 
 For a quick overview how to convert a custom PyTorch model, take a look at our [example python script](https://github.com/pytorch/executorch/tree/release/1.0/examples/nxp/aot_neutron_compile.py).
 
 
 ## Runtime Integration
+
+An example runtime application using the eIQ NSYS (eIQ Neutron Simulator) is available [examples/nxp/executor_runner](https://github.com/pytorch/executorch/blob/main/examples/nxp/executor_runner/), described in the tutorial [Getting started with eIQ Neutron NPU ExecuTorch backend](tutorials/nxp-basic-tutorial.md)
 
 To learn how to run the converted model on the NXP hardware, use one of our example projects on using ExecuTorch runtime from MCUXpresso IDE example projects list.
 For more finegrained tutorial, visit [this manual page](https://mcuxpresso.nxp.com/mcuxsdk/latest/html/middleware/eiq/executorch/docs/nxp/topics/example_applications.html).

--- a/docs/source/backends/nxp/tutorials/nxp-basic-tutorial.md
+++ b/docs/source/backends/nxp/tutorials/nxp-basic-tutorial.md
@@ -1,9 +1,35 @@
-# Preparing a Model for NXP eIQ Neutron Backend
+# Getting started with eIQ Neutron NPU ExecuTorch backend
+
+## Prerequisities
+
+### Hardware
+For this tutorial, you will need a Linux machine with x86_64 processor architecture. 
+This tutorial demonstrates the use of the eIQ Neutron backend with the Neutron behavioral simulator, called NSYS. You don't need any specific development board for this tutorial. 
+
+### Software
+First you need to have Python 3.10 - 3.12 installed. 
+
+You need to install the ExecuTorch. Please follow the tutorial to install the ExecuTorch [Setting Up ExecuTorch](../../../getting-started-setup.rst)
+
+
+In addition to this, you will need to install the eIQ Neutron Simulator, called NSYS,
+and the Neutron Converter for generating the byte-code for the eIQ Neutron NPU, 
+during the model conversion in ExecuTorch AoT flow. 
+To install the eIQ Neutron dependencies, run:
+```bash
+examples/nxp/setup.sh
+```
+This will install: 
+* Neutron Converter, for converting the Neutron IR to Neutron byte-code 
+* eIQ Neutron SDK, containing the eIQ Neutron runtimes (driver and firmware) for various NXP SoC and simulator 
+* eIQ NSYS, the Neutron behavioral simulator
+
+## Preparing a Model for NXP eIQ Neutron Backend
 
 This guide demonstrating the use of ExecuTorch AoT flow to convert a PyTorch model to ExecuTorch
 format and delegate the model computation to eIQ Neutron NPU using the eIQ Neutron Backend.
 
-## Step 1: Environment Setup
+### Step 1: Environment Setup
 
 This tutorial is intended to be run from a Linux and uses Conda or Virtual Env for Python environment management. For full setup details and system requirements, see [Getting Started with ExecuTorch](/getting-started).
 
@@ -11,14 +37,107 @@ Create a Conda environment and install the ExecuTorch Python package.
 ```bash
 conda create -y --name executorch python=3.12
 conda activate executorch
+```
+and install the ExecuTorch Python package, either a prebuilt one: 
+```bash
 conda install executorch
 ```
+or build from source: 
+```bash
+./install_executorch.sh
+```
 
-Run the setup.sh script to install the neutron-converter:
-```commandline
+Also run the `setup.sh` script to install the eIQ Neutron dependencies:
+```bash
 $ ./examples/nxp/setup.sh
 ```
 
-## Step 2: Model Preparation and Running the Model on Target
+### Step 2: Model Preparation and Running the Model on Target
 
-See the example `aot_neutron_compile.py` and its [README](https://github.com/pytorch/executorch/blob/release/1.0/examples/nxp/README.md) file. 
+See the example `aot_neutron_compile.py` and its [README](https://github.com/pytorch/executorch/blob/main/examples/nxp/README.md) file.
+
+For the purpose of this tutorial we will use a simple image classification model CifarNet10.
+```bash
+python -m examples.nxp.aot_neutron_compile --quantize \
+    --delegate --neutron_converter_flavor SDK_25_12 -m "cifar10"
+```
+
+Also, we will dump few of the images from the Cifar 10 dataset to a folder: 
+```bash
+python -m examples.nxp.experimental.cifar_net.cifar_net --store-test-data
+```
+The destination folder is `./cifar10_test_data`.
+
+## Runtime with NSYS
+### nxp_executor_runner example
+The end-to-end example illustrating the use of the eIQ Neutron NPU is located in `examples/nxp/executor_runner`. 
+Before we proceed with the build and execution, let's stop to briefly introduce the example. 
+
+The application runs the executorch on a particular model. 
+If a delegated model is provided to the runner, as in this tutorial, the instruction `DelegateCall` having the `NeutronBackend` ID is present in the model. 
+This instruction is recognized by ExecuTorch runtime and handed over to the NeutronBackend.
+NeutronBackend runs it on the eIQ Neutron NPU, simulated by NSYS. 
+
+The NeutronDriver's API (`NeutronDriver.h` and `NeutronErrors.h`) is the same, regardless of whether it is a physical IP or NSYS. 
+What is specific, is the API provided by the `NeutronEnvConfig.h`, to set up the paths to:
+* the NSYS,
+* the Neutron Firmware to run and
+* the NSYS configuration (.ini file): 
+```c++
+    storeNsysConfigPath(FLAGS_nsys_config.c_str());
+    storeFirmwarePath(FLAGS_firmware.c_str());
+    storeNsysPath(FLAGS_nsys.c_str());
+```
+
+What corresponds to nxp_executor_runner CLI options, `--firmware`, `--nsys`, `--nsys_config` or provided by environmental variable:
+
+| CLI Option      | Environmental variable | Description | 
+|-----------------|------------------------|-------------|
+| `--firmware`    | NSYS_FIRMWARE_PATH     | Path to the NSYS firmware. The NSYS firmware for each supported platform is provided by the eIQ Neutron SDK package. |
+| `--nsys_config` | NSYS_CONFIG_PATH       | Path to the NSYS configuration. For i.MXRT700 SoC available in `examples/nxp/exector_runner/neutron-imxrt700.ini`. For other platform not required. 
+| `--nsys` | N/A | Path to the eIQ NSYS simulator executable (`which nsys`) | 
+
+For further details about `eiq_nsys` refer for the provided user guide in the python package. 
+
+### Build the nxp_executor_runner
+Use the provided `examples/nxp/executor_runner/CMakeLists.txt`. It can be build separately: 
+```bash
+mkdir ./examples/nxp/executor_runner/build 
+pushd ./examples/nxp/executor_runner/build
+cmake ..
+make nxp_executor_runner
+popd
+```
+or as part of the ExecuTorch build:
+```bash
+cd <executorch_root_dir>
+mkdir build
+cmake .. \
+  -DEXECUTORCH_BUILD_NXP_NEUTRON=ON \
+  -DEXECUTORCH_BUILD_NXP_NEUTRON_RUNNER=ON \
+  -DEXECUTORCH_BUILD_KERNELS_QUANTIZED=ON \
+  -DEXECUTORCH_BUILD_KERNELS_QUANTIZED_AOT=ON \
+make nxp_executorch_runner
+```
+
+### Run the nxp_executor_runner
+
+```bash
+./examples/nxp/executor_runner/build/nxp_executor_runner \
+    --firmware `make -C ./examples/nxp/executor_runner/build locate_neutron_firmware | grep "NeutronFirmware.elf" ` \
+    --nsys `which nsys` \
+    --nsys_config ./examples/nxp/executor_runner/neutron-imxrt700.ini \
+    --model ./cifar10_nxp_delegate.pte \
+    --dataset ./cifar10_test_data \
+    --output ./cifar10_test_output
+```
+
+## Takeways 
+For the convenience, you can run the provided utility script doing all the above-mentioned steps for detailed inspection: 
+```bash
+cd <executorch-root>
+./examples/nxp/run.sh
+```
+
+## FAQs
+If you encounter any bugs or issues following this tutorial please file a bug/issue here on [Github](https://github.com/pytorch/executorch/issues/new) and label as `module: nxp`.  

--- a/examples/nxp/aot_neutron_compile.py
+++ b/examples/nxp/aot_neutron_compile.py
@@ -48,8 +48,8 @@ from torchao.quantization.pt2e.quantize_pt2e import convert_pt2e, prepare_qat_pt
 
 from .experimental.cifar_net.cifar_net import (
     CifarNet,
-    test_cifarnet_model,
     train_cifarnet_model,
+    verify_cifarnet_model,
 )
 from .models.mobilenet_v2 import MobilenetV2
 
@@ -282,7 +282,7 @@ if __name__ == "__main__":  # noqa C901
     if args.test:
         match args.model_name:
             case "cifar10":
-                accuracy = test_cifarnet_model(module)
+                accuracy = verify_cifarnet_model(module)
 
             case _:
                 raise NotImplementedError(

--- a/examples/nxp/executor_runner/CMakeLists.txt
+++ b/examples/nxp/executor_runner/CMakeLists.txt
@@ -1,0 +1,122 @@
+# Copyright 2026 NXP
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+cmake_minimum_required(VERSION 3.16)
+project(nxp_executor_runner C CXX)
+
+set(EIQ_NEUTRON_TARGET
+    "imxrt700"
+    CACHE STRING "Neutron Target to build the executor_runner"
+)
+set(EXECUTORCH_PATH ${CMAKE_CURRENT_LIST_DIR}/../../../)
+
+find_package(
+  Python
+  COMPONENTS Interpreter
+  REQUIRED
+)
+
+message(STATUS "Looking for Neutron Driver")
+if(NOT TARGET nd)
+  message(STATUS "Looking for Neutron Driver -- not found")
+
+  message(STATUS "Looking for eIQ Neutron SDK")
+  execute_process(
+    COMMAND
+      ${Python_EXECUTABLE} -c
+      "import eiq_neutron_sdk, os; print(os.path.dirname(eiq_neutron_sdk.__file__))"
+    OUTPUT_VARIABLE EIQ_NEUTRON_SDK_PATH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  message(
+    STATUS "Looking for eIQ Neutron SDK -- found: ${EIQ_NEUTRON_SDK_PATH}"
+  )
+  message(STATUS "Looking for Neutron target $CACHE{EIQ_NEUTRON_TARGET}")
+  set(EIQ_NEUTRON_TARGET_DIR
+      "${EIQ_NEUTRON_SDK_PATH}/target/$CACHE{EIQ_NEUTRON_TARGET}"
+  )
+  if(NOT EXISTS ${EIQ_NEUTRON_TARGET_DIR})
+    message(
+      FATAL_ERROR
+        "Looking for Neutron target $CACHE{EIQ_NEUTRON_TARGET} -- not found"
+    )
+  else()
+    message(
+      STATUS
+        "Looking for Neutron target $CACHE{EIQ_NEUTRON_TARGET} -- found: ${EIQ_NEUTRON_TARGET_DIR}"
+    )
+  endif()
+
+  set(EIQ_NEUTRON_TARGET_INCLUDE_DIR "${EIQ_NEUTRON_TARGET_DIR}/common/include"
+                                     "${EIQ_NEUTRON_TARGET_DIR}/driver/include"
+  )
+  set(EIQ_NEUTRON_TARGET_DRIVER
+      "${EIQ_NEUTRON_TARGET_DIR}/cmodel/libNeutronDriver.a"
+  )
+  set(EIQ_NEUTRON_TARGET_FIRMWARE
+      "${EIQ_NEUTRON_TARGET_DIR}/cmodel/NeutronFirmware.elf"
+  )
+
+  add_library(nd STATIC IMPORTED GLOBAL)
+  set_target_properties(
+    nd PROPERTIES IMPORTED_LOCATION ${EIQ_NEUTRON_TARGET_DRIVER}
+  )
+  set_target_properties(
+    nd PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
+                  "${EIQ_NEUTRON_TARGET_INCLUDE_DIR}"
+  )
+
+  # Add a virtual target to dump the path to corresponding neutron_firmware
+  add_custom_target(locate_neutron_firmware echo ${EIQ_NEUTRON_TARGET_FIRMWARE})
+else()
+  message(STATUS "Neutron Driver -- found")
+endif()
+
+# Check if the ExecuTorch Target is aleady defined, what indicate this
+# CMakeLists.txt is involved as subproject:
+message(STATUS "Looking for executorch target")
+if(NOT TARGET executorch)
+  message(STATUS "Looking for executorch target -- not found, adding")
+  set(EXECUTORCH_BUILD_NXP_NEUTRON ON)
+  set(EXECUTORCH_BUILD_KERNELS_QUANTIZED ON)
+  set(EXECUTORCH_BUILD_KERNELS_QUANTIZED_AOT ON)
+  add_subdirectory(
+    "${EXECUTORCH_PATH}" "${CMAKE_CURRENT_BINARY_DIR}/executorch"
+    EXCLUDE_FROM_ALL
+  )
+else()
+  message(STATUS "Looking for executorch target -- found")
+endif()
+
+message(STATUS "Looking for gflags")
+if(NOT TARGET gflags::gflags)
+  message(STATUS "Looking for gflags -- not found, adding")
+  add_subdirectory(
+    "${EXECUTORCH_PATH}/third-party/gflags"
+    "${CMAKE_CURRENT_BINARY_DIR}/gflags" EXCLUDE_FROM_ALL
+  )
+else()
+  message(STATUS "Looking for gflags -- found")
+endif()
+
+set(CMAKE_CXX_STANDARD 17)
+add_executable(
+  nxp_executor_runner
+  nxp_executor_runner.cpp
+  ${EXECUTORCH_PATH}/extension/data_loader/file_data_loader.cpp
+)
+
+target_compile_options(nxp_executor_runner PRIVATE -DNEUTRON_CMODEL)
+
+target_link_libraries(
+  nxp_executor_runner
+  PRIVATE executorch
+          executorch_kernels
+          nd
+          gflags::gflags
+          "-Wl,--whole-archive"
+          executorch_delegate_neutron
+          "-Wl,--no-whole-archive"
+)

--- a/examples/nxp/executor_runner/neutron-imxrt700.ini
+++ b/examples/nxp/executor_runner/neutron-imxrt700.ini
@@ -1,0 +1,3 @@
+[neutron2]
+num_pipelines = 8
+num_macs = 8

--- a/examples/nxp/executor_runner/nxp_executor_runner.cpp
+++ b/examples/nxp/executor_runner/nxp_executor_runner.cpp
@@ -1,0 +1,500 @@
+/*
+ * Copyright 2024-2026 NXP
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+
+ * Example script to compile the model for the NXP Neutron NPU
+ */
+
+/*
+ * This is an example ExecuTorch runner running on host CPU and Neutron
+ * simulator - NSYS. Example illustrates how to use the ExecuTorch with the
+ * Neutron Backend.
+ */
+
+#include <executorch/extension/data_loader/file_data_loader.h>
+#include <executorch/runtime/executor/method.h>
+#include <executorch/runtime/executor/program.h>
+#include <executorch/runtime/platform/runtime.h>
+
+using torch::executor::Error;
+using torch::executor::Result;
+using torch::executor::util::FileDataLoader;
+
+static uint8_t __attribute__((
+    aligned(16))) method_allocator_pool[512 * 1024 * 1024U]; // 512 MB
+static uint8_t __attribute__((
+    aligned(16))) tmp_allocator_pool[512 * 1024 * 1024U]; // 512 MB
+
+#include <executorch/backends/nxp/runtime/NeutronDriver.h>
+#include <executorch/backends/nxp/runtime/NeutronErrors.h>
+
+#ifdef NEUTRON_CMODEL
+// The following header is needed only for NSYS backend.
+#include "NeutronEnvConfig.h"
+#endif
+
+#include <dirent.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <algorithm>
+#include <cstring>
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include <vector>
+
+#include <gflags/gflags.h>
+
+DEFINE_string(model, "", "Path to serialized model.");
+DEFINE_string(dataset, "", "Path to model dataset folder.");
+DEFINE_string(
+    inputs,
+    "",
+    "Path to inputs. Usage: "
+    "/path/to/inputdata1,/path/to/inputdata2");
+DEFINE_string(output, "", "Path to folder where output tensors are saved.");
+
+#ifdef NEUTRON_CMODEL
+DEFINE_string(firmware, "", "Relative path to firmware *.elf file.");
+DEFINE_string(nsys, "", "Relative path to nsys.");
+DEFINE_string(nsys_config, "", "Relative path to nsys config *.ini file");
+#endif
+
+#define DEFAULT_OUTPUT_DIR "results"
+
+void processInputs(std::vector<std::string>& inputsData, std::string& inputs) {
+  std::string segment;
+  std::stringstream ss(inputs);
+
+  while (std::getline(ss, segment, ',')) {
+    inputsData.push_back(segment);
+  }
+}
+
+bool isDirectory(std::string path) {
+  struct stat sb;
+  if (stat(path.c_str(), &sb) == -1) {
+    fprintf(stderr, "Unable to determine stats of a path!\n");
+    exit(-1);
+  }
+  return S_ISDIR(sb.st_mode);
+}
+
+void setInputs(
+    torch::executor::Method& method,
+    std::vector<std::string>& inputFiles) {
+  if (method.inputs_size() != inputFiles.size()) {
+    fprintf(
+        stderr,
+        "Mismatch: method has %ld inputs, whereas the loaded data contains %ld entries!\n",
+        method.inputs_size(),
+        inputFiles.size());
+    exit(-1);
+  }
+  std::vector<torch::executor::EValue> values(method.inputs_size());
+  Error status = method.get_inputs(values.data(), values.size());
+  if (status != Error::Ok) {
+    fprintf(stderr, "Failed to get_inputs...\n");
+    exit(-1);
+  }
+  for (size_t i = 0; i < values.size(); i++) {
+    fprintf(stderr, "Loading file %s\n", inputFiles[i].c_str());
+    FILE* datasetFile = fopen(inputFiles[i].c_str(), "r");
+    fseek(datasetFile, 0, SEEK_END);
+    size_t inputSize = ftell(datasetFile);
+    fseek(datasetFile, 0, SEEK_SET);
+    if (inputSize == values[i].toTensor().nbytes()) {
+      // Input is in floats
+      fread(values[i].toTensor().mutable_data_ptr(), 1, inputSize, datasetFile);
+    } else if (
+        (inputSize == values[i].toTensor().numel()) &&
+        (values[i].toTensor().scalar_type() ==
+         torch::executor::ScalarType::Float)) {
+      // Input is in bytes, convert to floats
+      printf("Converting inputs to floats...\n");
+      uint8_t* ptr = (uint8_t*)malloc(inputSize);
+      fread(ptr, 1, inputSize, datasetFile);
+      for (size_t j = 0; j < inputSize; j++) {
+        values[i].toTensor().mutable_data_ptr<float>()[j] = ptr[j];
+      }
+      free(ptr);
+    } else {
+      // Input mismatch
+      fprintf(
+          stderr,
+          "Mismatch in the %ld-th input tensor: expected %ld elements x %ld bytes each, loaded %ld bytes!\n",
+          i,
+          values[i].toTensor().numel(),
+          values[i].toTensor().element_size(),
+          inputSize);
+      fclose(datasetFile);
+      exit(-1);
+    }
+    fclose(datasetFile);
+  }
+}
+
+void saveOutputs(
+    torch::executor::Method& method,
+    std::string& outputPath,
+    const std::string& runPathPrefix = ".") {
+  struct stat st;
+  if (stat(outputPath.c_str(), &st) == -1) {
+    mkdir(outputPath.c_str(), 0700);
+  }
+  if (stat((outputPath + "/" + runPathPrefix).c_str(), &st) == -1) {
+    mkdir((outputPath + "/" + runPathPrefix).c_str(), 0700);
+  }
+  std::vector<torch::executor::EValue> values(method.outputs_size());
+  Error status = method.get_outputs(values.data(), values.size());
+  if (status != Error::Ok) {
+    fprintf(stderr, "Failed to get_outputs...\n");
+    exit(-1);
+  }
+  for (size_t i = 0; i < values.size(); i++) {
+    int precision = 4 - std::to_string(i).size();
+    std::string fileName = outputPath + "/" + runPathPrefix + "/" +
+        std::to_string(i).insert(0, precision, '0') + ".bin";
+    printf("Saving file %s\n", fileName.c_str());
+    FILE* datasetFile = fopen(fileName.c_str(), "w");
+    fwrite(
+        values[i].toTensor().data_ptr(),
+        1,
+        values[i].toTensor().nbytes(),
+        datasetFile);
+    fclose(datasetFile);
+  }
+}
+
+template <typename T>
+void printClassificationOutput(
+    const torch::executor::EValue& value,
+    std::string& outputPath,
+    const std::string& runPathPrefix) {
+  T maxVal = value.toTensor().mutable_data_ptr<T>()[0];
+  size_t maxIdx = 0;
+  for (size_t j = 1; j < value.toTensor().numel(); j++) {
+    T val = value.toTensor().mutable_data_ptr<T>()[j];
+    if (val > maxVal) {
+      maxVal = val;
+      maxIdx = j;
+    }
+  }
+  struct stat st;
+  std::string resultsFile{outputPath + "/results.txt"};
+  if (stat(outputPath.c_str(), &st) == -1) {
+    mkdir(outputPath.c_str(), 0700);
+  }
+  FILE* results = fopen(resultsFile.c_str(), "a+");
+  // Print classification results and save to results.txt.
+  std::cout << "Top1 class " << runPathPrefix << " = " << maxIdx << std::endl;
+  fprintf(results, "%s %d ", runPathPrefix.c_str(), maxIdx);
+  std::cout << "Confidence = " << static_cast<float_t>(maxVal) << std::endl;
+  fprintf(results, "%f ", static_cast<float_t>(maxVal));
+  fprintf(results, "\n");
+  fclose(results);
+}
+
+void printOutput(
+    torch::executor::Method& method,
+    std::string& outputPath,
+    const std::string& runPathPrefix = ".") {
+  // The single tensor is considered to be a classification result.
+  if (method.outputs_size() == 1) {
+    std::vector<torch::executor::EValue> values(method.outputs_size());
+    Error status = method.get_outputs(values.data(), values.size());
+    if (status != Error::Ok) {
+      fprintf(stderr, "Failed to get_outputs...\n");
+      exit(-1);
+    }
+    switch (values[0].toTensor().scalar_type()) {
+      case torch::executor::ScalarType::Byte:
+        printClassificationOutput<uint8_t>(
+            values[0], outputPath, runPathPrefix);
+        break;
+      case torch::executor::ScalarType::Char:
+        printClassificationOutput<int8_t>(values[0], outputPath, runPathPrefix);
+        break;
+      case torch::executor::ScalarType::Short:
+        printClassificationOutput<int16_t>(
+            values[0], outputPath, runPathPrefix);
+        break;
+      case torch::executor::ScalarType::Int:
+        printClassificationOutput<int32_t>(
+            values[0], outputPath, runPathPrefix);
+        break;
+      case torch::executor::ScalarType::Long:
+        printClassificationOutput<int64_t>(
+            values[0], outputPath, runPathPrefix);
+        break;
+      case torch::executor::ScalarType::Float:
+        printClassificationOutput<float>(values[0], outputPath, runPathPrefix);
+        break;
+      case torch::executor::ScalarType::Double:
+        printClassificationOutput<double>(values[0], outputPath, runPathPrefix);
+        break;
+      default:
+        fprintf(
+            stderr,
+            "Unsupported tensor data type: %d\n",
+            values[0].toTensor().scalar_type());
+        exit(-1);
+    }
+  }
+}
+
+int main(int argc, char* argv[]) {
+  DIR* datasetDir = nullptr;
+  struct dirent* dataset = nullptr;
+
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+  // Check that model name and inputs have been specified.
+  if (FLAGS_model.empty()) {
+    std::cout << "Please specify path to model using the --model option.\n";
+    exit(-1);
+  }
+  if (FLAGS_dataset.empty() && FLAGS_inputs.empty()) {
+    std::cout << "Please specify path to dataset using the --dataset option or "
+                 "inputs using --inputs option\n";
+    exit(-1);
+  }
+  if (!FLAGS_dataset.empty() && !FLAGS_inputs.empty()) {
+    std::cout << "Cannot specify both inputs list and dataset directory\n";
+    exit(-1);
+  }
+  if (!FLAGS_dataset.empty()) {
+    datasetDir = opendir(FLAGS_dataset.c_str());
+    if (!datasetDir) {
+      std::cout << "Dataset path is not valid\n";
+      exit(-1);
+    }
+  }
+  if (FLAGS_output.empty()) {
+    FLAGS_output = DEFAULT_OUTPUT_DIR;
+  }
+
+#ifdef NEUTRON_CMODEL
+  if (!FLAGS_nsys_config.empty()) {
+    storeNsysConfigPath(FLAGS_nsys_config.c_str());
+  } else if (getenv("NSYS_CONFIG_PATH")) {
+    storeNsysConfigPath(getenv("NSYS_CONFIG_PATH"));
+  } else {
+    std::cout << "ERROR: missing --nsys_config argument\n";
+    exit(-1);
+  }
+
+  if (!FLAGS_firmware.empty()) {
+    storeFirmwarePath(FLAGS_firmware.c_str());
+  } else if (getenv("NSYS_FIRMWARE_PATH")) {
+    storeFirmwarePath(getenv("NSYS_FIRMWARE_PATH"));
+  } else {
+    std::cout << "ERROR: missing --firmware argument\n";
+    exit(-1);
+  }
+
+  if (!FLAGS_nsys.empty()) {
+    storeNsysPath(FLAGS_nsys.c_str());
+  } else if (getenv("NSYS_PATH")) {
+    storeNsysPath(getenv("NSYS_PATH"));
+  } else {
+    std::cout << "ERROR: missing --nsys argument\n";
+    exit(-1);
+  }
+#endif
+
+  NeutronError error = ENONE;
+  error = neutronInit();
+  if (error != ENONE) {
+    fprintf(stderr, "Internal Neutron NPU driver error %x in init!\n", error);
+    exit(-1);
+  }
+
+  torch::executor::runtime_init();
+
+  printf("Started..\n");
+
+  Result<FileDataLoader> loader = FileDataLoader::from(FLAGS_model.c_str());
+  if (!loader.ok()) {
+    fprintf(stderr, "Model PTE loading failed\n");
+    exit(-1);
+  } else {
+    printf("Model file %s loaded\n", FLAGS_model.c_str());
+  }
+
+  Result<torch::executor::Program> program =
+      torch::executor::Program::load(&loader.get());
+  if (!program.ok()) {
+    fprintf(stderr, "Program loading failed\n");
+    exit(-1);
+  } else {
+    printf("Program loaded\n");
+  }
+
+  const char* method_name = nullptr;
+  {
+    const auto method_name_result = program->get_method_name(0);
+    if (!method_name_result.ok()) {
+      fprintf(stderr, "Program has no methods...\n");
+      exit(-1);
+    }
+    method_name = *method_name_result;
+  }
+  printf("Using method (%s)...\n", method_name);
+
+  Result<torch::executor::MethodMeta> method_meta =
+      program->method_meta(method_name);
+  if (!method_meta.ok()) {
+    fprintf(
+        stderr,
+        "Failed to get method_meta for (%s): %" PRIu32,
+        method_name,
+        (unsigned int)method_meta.error());
+    exit(-1);
+  }
+
+  printf("Creating MemoryAllocator...\n");
+  torch::executor::MemoryAllocator method_allocator{
+      torch::executor::MemoryAllocator(
+          sizeof(method_allocator_pool), method_allocator_pool)};
+  torch::executor::MemoryAllocator tmp_allocator{
+      torch::executor::MemoryAllocator(
+          sizeof(tmp_allocator_pool), tmp_allocator_pool)};
+
+  std::vector<std::unique_ptr<uint8_t[]>> planned_buffers; // Owns the memory
+  std::vector<torch::executor::Span<uint8_t>>
+      planned_spans; // Passed to the allocator
+  size_t num_memory_planned_buffers = method_meta->num_memory_planned_buffers();
+
+  for (size_t id = 0; id < num_memory_planned_buffers; ++id) {
+    size_t buffer_size =
+        static_cast<size_t>(method_meta->memory_planned_buffer_size(id).get());
+    printf("Setting up planned buffer %lu, size %lu...\n", id, buffer_size);
+
+    planned_buffers.push_back(std::make_unique<uint8_t[]>(buffer_size));
+    planned_spans.push_back({planned_buffers.back().get(), buffer_size});
+  }
+
+  printf("Creating HierarchicalAllocator....\n");
+  torch::executor::HierarchicalAllocator planned_memory(
+      {planned_spans.data(), planned_spans.size()});
+
+  torch::executor::MemoryManager memory_manager(
+      &method_allocator, &planned_memory, &tmp_allocator);
+
+  Result<torch::executor::Method> method =
+      program->load_method(method_name, &memory_manager);
+  if (!method.ok()) {
+    fprintf(
+        stderr,
+        "Loading of method (%s) failed with status %" PRIu32 "...\n",
+        method_name,
+        (unsigned int)method.error());
+    exit(-1);
+  }
+  printf("Method loaded...\n");
+
+  Error status = Error::Ok;
+  if (!FLAGS_dataset.empty()) {
+    // Go through entire dataset for this model.
+    FLAGS_dataset += "/";
+    while (dataset = readdir(datasetDir)) {
+      if (!strcmp(dataset->d_name, ".") || !strcmp(dataset->d_name, ".."))
+        continue;
+
+      std::vector<std::string> inputsData;
+      inputsData.push_back(FLAGS_dataset + dataset->d_name);
+      // Set input and call inferrence.
+      setInputs(method.get(), inputsData);
+
+      status = method->execute();
+      if (status != Error::Ok) {
+        fprintf(
+            stderr,
+            "Execution of method %s failed with status %" PRIu32 "...\n",
+            method_name,
+            (unsigned int)status);
+        exit(-1);
+      } else {
+        printf("Method executed successfully...\n");
+      }
+
+      // Save outputs in binary files.
+      saveOutputs(method.get(), FLAGS_output, dataset->d_name);
+      // Print result with highest confidence.
+      printOutput(method.get(), FLAGS_output, dataset->d_name);
+    }
+    closedir(datasetDir);
+  } else if (!FLAGS_inputs.empty()) {
+    std::vector<std::string> inputPaths;
+
+    // Validate and process inputs and separate into two lists.
+    processInputs(inputPaths, FLAGS_inputs);
+
+    if (std::all_of(inputPaths.begin(), inputPaths.end(), isDirectory)) {
+      // Inputs are in directories - use files in each directory as the inputs.
+      std::vector<std::string> inputsData;
+      for (std::string& inputDir : inputPaths) {
+        datasetDir = opendir(inputDir.c_str());
+        while (dataset = readdir(datasetDir)) {
+          if (!strcmp(dataset->d_name, ".") || !strcmp(dataset->d_name, ".."))
+            continue;
+
+          inputsData.push_back(inputDir + "/" + dataset->d_name);
+        }
+        closedir(datasetDir);
+
+        setInputs(method.get(), inputsData);
+
+        status = method->execute();
+        if (status != Error::Ok) {
+          fprintf(
+              stderr,
+              "Execution of method %s failed with status %" PRIu32 "...\n",
+              method_name,
+              (unsigned int)status);
+          exit(-1);
+        } else {
+          printf("Method executed successfully...\n");
+        }
+
+        if (inputDir.back() == '/')
+          inputDir.pop_back();
+
+        auto pos = inputDir.find_last_of('/');
+        if (pos != std::string::npos)
+          inputDir = inputDir.substr(pos + 1);
+
+        // Save outputs in binary files.
+        saveOutputs(method.get(), FLAGS_output, inputDir.c_str());
+        inputsData.clear();
+      }
+    } else {
+      // Inputs are files.
+      setInputs(method.get(), inputPaths);
+
+      status = method->execute();
+      if (status != Error::Ok) {
+        fprintf(
+            stderr,
+            "Execution of method %s failed with status %" PRIu32 "...\n",
+            method_name,
+            (unsigned int)status);
+        exit(-1);
+      } else {
+        printf("Method executed successfully...\n");
+      }
+
+      // Save outputs in binary files.
+      saveOutputs(method.get(), FLAGS_output);
+    }
+  }
+
+  printf("Finished...\n");
+
+  error = neutronDeinit();
+
+  return 0;
+}

--- a/examples/nxp/run.sh
+++ b/examples/nxp/run.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Copyright 2026 NXP
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+set -eux
+
+SCRIPT_DIR=$(dirname $(readlink -fm $0))
+EXECUTORCH_DIR=$(dirname $(dirname $SCRIPT_DIR))
+MODEL=${1:-"cifar10"}
+
+cd ${EXECUTORCH_DIR}
+
+echo "** Build nxp_executor_runner"
+if [ ! -d ${SCRIPT_DIR}/executor_runner/build ] ; then
+  mkdir ${SCRIPT_DIR}/executor_runner/build
+fi
+rm -rf ${SCRIPT_DIR}/executor_runner/build/*
+
+pushd ${SCRIPT_DIR}/executor_runner/build
+cmake -DCMAKE_BUILD_TYPE=Release ..
+make -j8 nxp_executor_runner
+popd
+
+echo "** Export cifar10 model to executorch"
+# Run the AoT example
+python -m examples.nxp.aot_neutron_compile --quantize \
+    --delegate --neutron_converter_flavor SDK_25_12 -m "cifar10"
+test -f cifar10_nxp_delegate.pte
+
+echo "** Generate test dataset"
+python -m examples.nxp.experimental.cifar_net.cifar_net --store-test-data
+
+echo "** Run nxp_executor_runner"
+${SCRIPT_DIR}/executor_runner/build/nxp_executor_runner \
+    --firmware `make -C ${SCRIPT_DIR}/executor_runner/build locate_neutron_firmware | grep "NeutronFirmware.elf" ` \
+    --nsys `which nsys` \
+    --nsys_config ${SCRIPT_DIR}/executor_runner/neutron-imxrt700.ini \
+    --model cifar10_nxp_delegate.pte \
+    --dataset ./cifar10_test_data \
+    --output ./cifar10_test_output

--- a/examples/nxp/setup.sh
+++ b/examples/nxp/setup.sh
@@ -5,11 +5,12 @@
 # LICENSE file in the root directory of this source tree.
 
 set -u
-EIQ_PYPI_URL=https://eiq.nxp.com/repository
-
+EIQ_PYPI_URL="${EIQ_PYPI_URL:-https://eiq.nxp.com/repository}"
 
 # Install neutron-converter
 pip install --index-url ${EIQ_PYPI_URL} neutron_converter_SDK_25_12
+
+pip install --index-url ${EIQ_PYPI_URL} eiq_neutron_sdk==2.2.2 eiq_nsys
 
 # Get the directory of the current script
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/tools/cmake/preset/default.cmake
+++ b/tools/cmake/preset/default.cmake
@@ -125,6 +125,9 @@ define_overridable_option(
   EXECUTORCH_BUILD_QNN "Build the Qualcomm backend" BOOL OFF
 )
 define_overridable_option(
+  EXECUTORCH_BUILD_NXP_NEUTRON "Build the NXP eIQ Neutron backend"  BOOL OFF
+)
+define_overridable_option(
   EXECUTORCH_BUILD_KERNELS_OPTIMIZED "Build the optimized kernels" BOOL OFF
 )
 define_overridable_option(

--- a/tools/cmake/preset/default.cmake
+++ b/tools/cmake/preset/default.cmake
@@ -1,6 +1,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
 # Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2026 NXP
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -125,7 +126,11 @@ define_overridable_option(
   EXECUTORCH_BUILD_QNN "Build the Qualcomm backend" BOOL OFF
 )
 define_overridable_option(
-  EXECUTORCH_BUILD_NXP_NEUTRON "Build the NXP eIQ Neutron backend"  BOOL OFF
+  EXECUTORCH_BUILD_NXP_NEUTRON "Build the NXP eIQ Neutron backend" BOOL OFF
+)
+define_overridable_option(
+  EXECUTORCH_BUILD_NXP_NEUTRON_RUNNER "Build the NXP eIQ Neutron runner" BOOL
+  OFF
 )
 define_overridable_option(
   EXECUTORCH_BUILD_KERNELS_OPTIMIZED "Build the optimized kernels" BOOL OFF


### PR DESCRIPTION
### Summary
Add NXP executor runner demonstrating the use of Neutron Backend in executorch on eIQ Neutron NPU Simulator (eIQ NSYS). 


### Test plan
The `run.sh` e2e example is part of the unittest-nxp-neutron job. 


cc @JakeStevens @digantdesai