### PR TITLE
Arm backend: Update docformatter scope and format Arm base modules

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -511,6 +511,13 @@ include_patterns = [
     'backends/arm/tosa/**/*.py',
     'backends/arm/ethosu/**/*.py',
     'backends/arm/operators/**/*.py',
+    'backends/arm/common/**/*.py',
+    'backends/arm/util/**/*.py',
+    'backends/arm/runtime/**/*.py',
+    'backends/arm/quantizer/**/*.py',
+    'backends/arm/debug/**/*.py',
+    'backends/arm/scripts/**/*.py',
+    'backends/arm/*.py',
 ]
 exclude_patterns = ['third-party/**', '**/third-party/**']
 command = [

--- a/backends/arm/arm_vela.py
+++ b/backends/arm/arm_vela.py
@@ -1,4 +1,4 @@
-# Copyright 2023-2025 Arm Limited and/or its affiliates.
+# Copyright 2023-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -54,8 +54,8 @@ def vela_compile(
     verbose: bool = False,
     intermediate_path: str | None = None,
 ):
-    """
-    Compile a TOSA graph to a binary stream for ArmBackendEthosU using Vela.
+    """Compile a TOSA graph to a binary stream for ArmBackendEthosU using
+    Vela.
     """
     if not has_vela:
         raise RuntimeError(

--- a/backends/arm/common/annotation_meta.py
+++ b/backends/arm/common/annotation_meta.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -11,9 +11,9 @@ from typing import Any, Mapping, Optional
 
 @dataclass(frozen=True, init=False)
 class ArmAnnotationInfo(dict):
-    """
-    Dataclass wrapper that behaves like a dict so serialization can treat it as
-    a plain mapping, while still exposing a typed attribute for convenience.
+    """Dataclass wrapper that behaves like a dict so serialization can treat it
+    as a plain mapping, while still exposing a typed attribute for
+    convenience.
     """
 
     quantized: bool

--- a/backends/arm/common/arm_compile_spec.py
+++ b/backends/arm/common/arm_compile_spec.py
@@ -212,21 +212,23 @@ class ArmCompileSpec(ABC):
         return compile_spec
 
     def get_pass_pipeline_config(self) -> ArmPassPipelineConfig:
-        """
-        Returns configuration that controls how the Arm pass pipeline should behave.
+        """Returns configuration that controls how the Arm pass pipeline should
+        behave.
+
         Subclasses may override to tweak defaults for specific targets.
+
         """
         if self._pipeline_config is None:
             self._pipeline_config = self._create_default_pipeline_config()
         return self._pipeline_config
 
     def set_pass_pipeline_config(self, config: ArmPassPipelineConfig) -> None:
-        """
-        Sets the configuration that controls how the Arm pass pipeline should behave.
-        Subclasses may override to tweak defaults for specific targets.
+        """Sets the configuration that controls how the Arm pass pipeline should
+        behave. Subclasses may override to tweak defaults for specific targets.
 
         Args:
             config: The custom ArmPassPipelineConfig to set.
+
         """
         self._pipeline_config = config
 
@@ -237,48 +239,48 @@ class ArmCompileSpec(ABC):
         return config
 
     def get_intermediate_path(self) -> str | None:
-        """
-        Gets the path used for dumping intermediate results such as tosa and pte.
+        """Gets the path used for dumping intermediate results such as tosa and
+        pte.
 
         Returns:
             Path where intermediate results are saved.
+
         """
         return self.path_for_intermediates
 
     def dump_intermediate_artifacts_to(self, output_path: str | None):
-        """
-        Sets a path for dumping intermediate results during such as tosa and pte.
+        """Sets a path for dumping intermediate results during such as tosa and
+        pte.
 
         Args:
             output_path: Path to dump intermediate results to.
+
         """
         self.path_for_intermediates = output_path
         return self
 
     def dump_debug_info(self, debug_mode: DebugMode | None):
-        """
-        Dump debugging information into the intermediates path.
+        """Dump debugging information into the intermediates path.
 
         Args:
             debug_mode: The debug mode to use for dumping debug information.
+
         """
         self.tosa_debug_mode = debug_mode
         return self
 
     def set_output_order_workaround(self, output_order_workaround: bool):
-        """
-        Sets whether to apply the output order workaround.
+        """Sets whether to apply the output order workaround.
 
         Args:
             output_order_workaround: Boolean indicating whether to apply the workaround.
+
         """
         self.output_order_workaround = output_order_workaround
         return self
 
     def get_output_order_workaround(self) -> bool:
-        """
-        Gets whether the output order workaround is being applied.
-        """
+        """Gets whether the output order workaround is being applied."""
         return self.output_order_workaround
 
     @classmethod

--- a/backends/arm/common/as_strided_utils.py
+++ b/backends/arm/common/as_strided_utils.py
@@ -25,12 +25,12 @@ def to_int(value: object) -> Optional[int]:
 
 
 def maybe_static_sequence(value: object) -> Optional[Sequence]:
-    """
-    Return a Python sequence for literal or FX-constant values.
+    """Return a Python sequence for literal or FX-constant values.
 
     FX exporters often wrap constant lists in nodes where the materialised
     value is stored in ``node.meta["val"]``. This helper unwraps that so the
     rest of the logic can treat them uniformly.
+
     """
     if isinstance(value, (str, bytes)):
         return None
@@ -45,7 +45,9 @@ def maybe_static_sequence(value: object) -> Optional[Sequence]:
 
 
 def to_int_tuple(value: object) -> Optional[Tuple[int, ...]]:
-    """Best-effort conversion of a sequence of integers/SymInts to a tuple[int, ...]."""
+    """Best-effort conversion of a sequence of integers/SymInts to a tuple[int,
+    ...].
+    """
     seq = maybe_static_sequence(value)
     if seq is None:
         return None

--- a/backends/arm/process_node.py
+++ b/backends/arm/process_node.py
@@ -91,7 +91,7 @@ def process_inputs(
     tosa_graph: Any,
     tosa_spec: TosaSpecification,
 ):
-    """Serialize an input node"""
+    """Serialize an input node."""
     try:
         tosa_arg = TosaArg(node, tosa_spec)
     except ValueError as e:
@@ -117,7 +117,7 @@ def process_inputs_to_parameters(
     edge_program: ExportedProgram,
     tosa_spec: TosaSpecification,
 ):
-    """Serialize bias and non-quantized weights"""
+    """Serialize bias and non-quantized weights."""
     try:
         tosa_arg = TosaArg(node, tosa_spec)
     except ValueError as e:
@@ -147,7 +147,7 @@ def process_inputs_to_buffers(
     edge_program: ExportedProgram,
     tosa_spec: TosaSpecification,
 ):
-    """Serialize quantized weights"""
+    """Serialize quantized weights."""
     try:
         tosa_arg = TosaArg(node, tosa_spec)
     except ValueError as e:
@@ -196,7 +196,9 @@ def process_inputs_to_lifted_tensor_constants(
 def _is_submodule_input(
     node: torch.fx.Node, containing_graph_module: torch.fx.GraphModule
 ) -> bool:
-    """Determines whether 'node' is an input to a submodule of 'containing_graph_module'."""
+    """Determines whether 'node' is an input to a submodule of
+    'containing_graph_module'.
+    """
     if node.op != "placeholder":
         return False
     return node.meta.get("is_input", False)
@@ -209,7 +211,7 @@ def process_placeholder(
     containing_graph_module: torch.fx.GraphModule | None,
     tosa_spec: TosaSpecification,
 ):
-    """Wrapper for processing and serializing all types of placeholders"""
+    """Wrapper for processing and serializing all types of placeholders."""
     if node.name != node.target:
         raise ValueError(
             f"Placeholder name '{node.name}' does not match target '{node.target}'"

--- a/backends/arm/quantizer/__init__.py
+++ b/backends/arm/quantizer/__init__.py
@@ -1,12 +1,13 @@
-# Copyright 2024-2025 Arm Limited and/or its affiliates.
+# Copyright 2024-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 """Expose quantizer APIs and load optional quantized kernels.
 
-Import the public quantizer classes and configuration helpers for Arm
-backends. Attempt to load portable and quantized libraries; fall back to a
-log message if unavailable.
+Import the public quantizer classes and configuration helpers for Arm backends.
+Attempt to load portable and quantized libraries; fall back to a log message if
+unavailable.
+
 """
 
 from .quantization_config import QuantizationConfig  # noqa  # usort: skip

--- a/backends/arm/quantizer/arm_quantizer.py
+++ b/backends/arm/quantizer/arm_quantizer.py
@@ -442,10 +442,11 @@ class TOSAQuantizer(Quantizer):
     def _set_disallow_tfa_for_nodes(self, model: GraphModule) -> None:
         """Populate `disallow_tfa` metadata for each FX node.
 
-        Transform-for-annotation passes inspect this flag to decide whether
-        they may transform a node. Typically, a node should not be transformed
-        in case it is not to be quantized, which is relevant for partially
+        Transform-for-annotation passes inspect this flag to decide whether they
+        may transform a node. Typically, a node should not be transformed in
+        case it is not to be quantized, which is relevant for partially
         quantized models.
+
         """
 
         # First, set all nodes according to global config
@@ -644,7 +645,8 @@ class TOSAQuantizer(Quantizer):
         calibration_samples: list[tuple],
         is_qat: bool = False,
     ):
-        """Quantizes a GraphModule in a way such that conditional submodules are handled properly.
+        """Quantizes a GraphModule in a way such that conditional submodules are
+        handled properly.
 
         Args:
             model (GraphModule): The model to quantize.

--- a/backends/arm/quantizer/arm_quantizer_utils.py
+++ b/backends/arm/quantizer/arm_quantizer_utils.py
@@ -1,10 +1,9 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
-# Copyright 2024-2025 Arm Limited and/or its affiliates.
+# Copyright 2024-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
-
 """Provide utilities for quantization annotations.
 
 Use these helpers to check and mark annotation state when working with

--- a/backends/arm/scripts/docgen/docgen.py
+++ b/backends/arm/scripts/docgen/docgen.py
@@ -23,9 +23,8 @@ class DocumentationJob:
 
 
 def get_docstring(obj) -> str:
-    """
-    Returns the docstring of an object, formatted in markdown to resemble pytorch-style
-    docs, e.g. an argument list like:
+    """Returns the docstring of an object, formatted in markdown to resemble
+    pytorch-style docs, e.g. an argument list like:
 
     Args:
         arg1: description
@@ -35,6 +34,7 @@ def get_docstring(obj) -> str:
     Args:
     - **arg1**: description
     - **arg2**: description
+
     """
 
     docstring = inspect.getdoc(obj)
@@ -56,16 +56,14 @@ def get_docstring(obj) -> str:
 
 
 def get_function_docstring(cls, func) -> str:
-    """
-    Returns a function's signature and docstring formatted in markdown.
-    """
+    """Returns a function's signature and docstring formatted in markdown."""
     return f"```python\ndef {cls.__name__}.{func.__name__}{inspect.signature(func)}:\n```\n{get_docstring(func)}\n\n"
 
 
 def get_class_docstring(cls, filter_funcs=()) -> str:
-    """
-    Returns a class signature and docstring, as well as documentation for all its public
-    methods with names not matching strings listed in filter_funcs.
+    """Returns a class signature and docstring, as well as documentation for all
+    its public methods with names not matching strings listed in
+    filter_funcs.
     """
     header = f"```python\nclass {cls.__name__}{inspect.signature(cls)}\n```\n{get_docstring(cls)}\n\n"
 
@@ -85,10 +83,12 @@ def get_class_docstring(cls, filter_funcs=()) -> str:
 
 
 def get_jupyter_code(path, get_bash, which_cells: list[int] | None = None) -> str:
-    """
-    Returns all code cells from the jupyter notebook at 'path'. If get_bash is True,
-    only bash cells are returned, otherwise only python cells are returned.
-    which_cells lets you supply a list of cell indicies to return.
+    """Returns all code cells from the jupyter notebook at 'path'.
+
+    If get_bash is True, only bash cells are returned, otherwise only python
+    cells are returned. which_cells lets you supply a list of cell indicies to
+    return.
+
     """
     output = f"```{'bash' if get_bash else 'python'}\n"
     with open(path, "r") as f:

--- a/backends/arm/scripts/parse_test_names.py
+++ b/backends/arm/scripts/parse_test_names.py
@@ -91,16 +91,16 @@ def collect_tests(file_paths: list[pathlib.Path]) -> list[str]:
 
 
 def _match_allowed_op_prefix(test_name: str) -> tuple[str, str, bool]:
-    """
-    Parses a test name on the form
-        test_OP_TARGET_<not_delegated>_<any_other_info>
-    where OP must match a key in op_name_map and TARGET one string in TARGETS. The
-    "not_delegated" suffix indicates that the test tests that the op is not delegated.
+    """Parses a test name on the form
+    test_OP_TARGET_<not_delegated>_<any_other_info> where OP must match a key in
+    op_name_map and TARGET one string in TARGETS. The "not_delegated" suffix
+    indicates that the test tests that the op is not delegated.
 
     Examples of valid names: "test_mm_u55_INT_not_delegated" and
     "test_add_scalar_tosa_FP_two_inputs".
 
     Returns a tuple (OP, TARGET, IS_DELEGATED) if valid.
+
     """
     test_name = test_name.removeprefix("test_")
     is_delegated = "not_delegated" not in test_name

--- a/backends/arm/util/arm_model_evaluator.py
+++ b/backends/arm/util/arm_model_evaluator.py
@@ -45,10 +45,12 @@ def _get_imagenet_224_transforms():
 def _build_calibration_loader(
     dataset: datasets.ImageFolder, max_items: int
 ) -> DataLoader:
-    """Return a DataLoader over a deterministic, shuffled subset of size <= max_items.
+    """Return a DataLoader over a deterministic, shuffled subset of size <=
+    max_items.
 
     Shuffles with seed: ARM_EVAL_CALIB_SEED (int) or default 1337; then selects first k and
     sorts indices to keep enumeration order stable while content depends on seed.
+
     """
     k = min(max_items, len(dataset))
     seed_env = os.getenv("ARM_EVAL_CALIB_SEED")
@@ -80,6 +82,7 @@ def _load_imagenet_folder(directory: str) -> datasets.ImageFolder:
     """Shared helper to load an ImageNet-layout folder.
 
     Raises FileNotFoundError for a missing directory early to aid debugging.
+
     """
     directory_path = Path(directory)
     if not directory_path.exists():
@@ -89,10 +92,12 @@ def _load_imagenet_folder(directory: str) -> datasets.ImageFolder:
 
 
 class GenericModelEvaluator:
-    """Base evaluator computing quantization error metrics and optional compression ratio.
+    """Base evaluator computing quantization error metrics and optional
+    compression ratio.
 
     Subclasses can extend: provide calibration (get_calibrator) and override evaluate()
     to add domain specific metrics (e.g. top-1 / top-5 accuracy).
+
     """
 
     @staticmethod
@@ -113,6 +118,7 @@ class GenericModelEvaluator:
             log_every: Log running accuracy every N batches.
         Returns:
             (top1_accuracy, topk_accuracy)
+
         """
         # Some exported / quantized models (torchao PT2E) disallow direct eval()/train().
         # Try to switch to eval mode, but degrade gracefully if unsupported.
@@ -188,10 +194,11 @@ class GenericModelEvaluator:
         """Return per-output quantization error statistics.
 
         Metrics (lists per output tensor):
-            max_error
-            max_absolute_error
-            max_percentage_error (safe-divided; zero fp32 elements -> 0%)
-            mean_absolute_error
+            * max_error
+            * max_absolute_error
+            * max_percentage_error (safe-divided; zero fp32 elements -> 0%)
+            * mean_absolute_error
+
         """
         fp32_outputs, _ = tree_flatten(self.fp32_model(*self.example_input))
         quant_outputs, _ = tree_flatten(self.quant_model(*self.example_input))
@@ -252,6 +259,7 @@ class ImageNetEvaluator(GenericModelEvaluator):
 
     Provides dataset loading, calibration loader and a standard `evaluate` that
     computes top-1/top-5 accuracy.
+
     """
 
     REQUIRES_CONFIG = True


### PR DESCRIPTION
Limit docformatter to the newly supported Arm paths and apply docstring formatting to common/util/runtime/quantizer/debug/scripts and root Arm Python files.

cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai