### PR TITLE
Arm backend: Expand docformatter scope and format operator_support/

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -517,6 +517,7 @@ include_patterns = [
     'backends/arm/quantizer/**/*.py',
     'backends/arm/debug/**/*.py',
     'backends/arm/scripts/**/*.py',
+    'backends/arm/operator_support/**/*.py',
     'backends/arm/*.py',
 ]
 exclude_patterns = ['third-party/**', '**/third-party/**']

--- a/backends/arm/operator_support/control_flow_support.py
+++ b/backends/arm/operator_support/control_flow_support.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -46,8 +46,11 @@ def _fully_partitioned(submodule: fx.GraphModule) -> bool:
 def _submodules_fully_partitioned(
     node: fx.Node, exported_program: ExportedProgram
 ) -> bool:
-    """Returns whether the submodule arguments to a cond node were fully partitioned.
+    """Returns whether the submodule arguments to a cond node were fully
+    partitioned.
+
     Updates "val" meta of the submodules if they are.
+
     """
     match node.target:
         case torch.ops.higher_order.cond:
@@ -83,7 +86,10 @@ def _tosa_spec_supports_cf(tosa_spec: TosaSpecification) -> bool:
 
 class ControlFlowSubmoduleSupported(OperatorSupportBase):
     """Check whether control flow submodule args should be partitioned.
-    Applies control-flow extension constraints before allowing delegation."""
+
+    Applies control-flow extension constraints before allowing delegation.
+
+    """
 
     def __init__(
         self,
@@ -123,7 +129,10 @@ class ControlFlowSubmoduleSupported(OperatorSupportBase):
 
 class ControlFlowOpSupported(OperatorSupportBase):
     """Check whether control flow ops should be partitioned.
-    Applies control-flow extension constraints before allowing delegation."""
+
+    Applies control-flow extension constraints before allowing delegation.
+
+    """
 
     _targeted_ops = {
         torch.ops.higher_order.cond,

--- a/backends/arm/operator_support/gather_support.py
+++ b/backends/arm/operator_support/gather_support.py
@@ -2,8 +2,7 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
-"""
-Declare operator support for ``edge.aten.gather`` in TOSA.
+"""Declare operator support for ``edge.aten.gather`` in TOSA.
 
 This support check matches the subset accepted by CanonicalizeGatherPass:
 
@@ -28,6 +27,7 @@ Note:
   indices as [N, W],then lowers via the TOSA gather dialect.
 - For 3D inputs CanonicalizeGatherPass permutes and reshapes values and indices
   to [N*C, K, 1] and [N*C, W] respectively, then lowers via the TOSA gather dialect.
+
 """
 
 from typing import cast

--- a/backends/arm/operator_support/index_select_support.py
+++ b/backends/arm/operator_support/index_select_support.py
@@ -12,6 +12,7 @@ Constraints:
 - args: exactly (input, dim, index)
 - input rank must be >= 1 and dtype compatible with the active TOSA spec
 - index must be rank-1 and dtype int32
+
 """
 
 import torch

--- a/backends/arm/operator_support/pool_2d_support.py
+++ b/backends/arm/operator_support/pool_2d_support.py
@@ -93,6 +93,7 @@ def dilation_check(
         dilation (tuple[int,int]): Vertical and horizontal dilation.
     Returns:
         bool: True if dilation constraints are met.
+
     """
 
     pad_h, pad_w = padding
@@ -197,12 +198,14 @@ class AvgPool2dSupported(SupportedTOSAOperatorCheck):
 
 @register_tosa_support_check
 class MaxPool2dSupported(SupportedTOSAOperatorCheck):
-    """Provide TOSA support checks for ``aten.max_pool2d_with_indices`` and ``aten.max_pool2d``.
+    """Provide TOSA support checks for ``aten.max_pool2d_with_indices`` and
+    ``aten.max_pool2d``.
 
     Checks that dilation constraints are met for both ops.
 
-    Applies additional constraints to the aten.max_pool2d_with_indices op when targeting the U55 subset, including
-    limits on kernel size, stride, and tensor ranks.
+    Applies additional constraints to the aten.max_pool2d_with_indices op when
+    targeting the U55 subset, including limits on kernel size, stride, and
+    tensor ranks.
 
     """
 
@@ -212,9 +215,10 @@ class MaxPool2dSupported(SupportedTOSAOperatorCheck):
     ]
 
     def is_node_tosa_supported(self, node: fx.Node, tosa_spec: TosaSpecification):
-        """
-        Return True if ``max_pool2d`` satisfies dilation constraints.
+        """Return True if ``max_pool2d`` satisfies dilation constraints.
+
         Return True if ``max_pool2d_with_indices`` satisfies both dilation constraints and U55 constraints.
+
         """
 
         shape = cast(torch.Tensor, node.all_input_nodes[0].meta["val"]).shape

--- a/backends/arm/operator_support/tosa_supported_operators.py
+++ b/backends/arm/operator_support/tosa_supported_operators.py
@@ -184,6 +184,7 @@ def is_quantized(node: torch.fx.Node) -> bool:
 
     Returns:
         bool: True if the node is quantized, False otherwise.
+
     """
 
     try:
@@ -371,10 +372,11 @@ class TOSAProINTFPSupportList(OperatorSupportBase):
 
 
 class CheckArmQuantized(OperatorSupportBase):
-    """
-    Check if the node was marked as quantized in the Arm backend.
-    This is used to ensure that nodes that were quantized in the Arm backend
-    are only partitioned if they are supported by the TOSA backend.
+    """Check if the node was marked as quantized in the Arm backend.
+
+    This is used to ensure that nodes that were quantized in the Arm backend are
+    only partitioned if they are supported by the TOSA backend.
+
     """
 
     def __init__(self, reporter: WhyNoPartitionReporter):
@@ -610,7 +612,9 @@ class CheckDtypeInputsAndOutputs(OperatorSupportBase):
     def is_node_supported(
         self, submodules: typing.Mapping[str, torch.nn.Module], node: fx.Node
     ) -> bool:
-        """Return True if no disallowed dtypes are present on inputs or outputs."""
+        """Return True if no disallowed dtypes are present on inputs or
+        outputs.
+        """
         if is_submodule_node(node):
             return True
         for input_node in (

--- a/backends/arm/operator_support/unfold_copy_support.py
+++ b/backends/arm/operator_support/unfold_copy_support.py
@@ -2,9 +2,7 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
-
-"""
-Declare operator support for ``edge.aten.unfold_copy`` in TOSA.
+"""Declare operator support for ``edge.aten.unfold_copy`` in TOSA.
 
 This support check matches the subset intended to be handled by the Arm
 unfold lowering (e.g. DecomposeUnfoldToGatherPass), similar to how
@@ -22,6 +20,7 @@ Supported pattern:
 Notes:
 - Dtype/profile constraints apply (see dtype checks below).
 - This check assumes static shapes and constant dim/size/step.
+
 """
 
 import torch


### PR DESCRIPTION
Add operator_support to the docformatter include list and reformat docstrings in the updated operator_support files.

cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai