### PR TITLE
Arm backend: Add int4 VGF quant tests for conv and linear ops

### DIFF
--- a/backends/arm/test/ops/test_conv1d.py
+++ b/backends/arm/test/ops/test_conv1d.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 Arm Limited and/or its affiliates.
+# Copyright 2024-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -7,6 +7,9 @@
 from typing import List, Tuple, Union
 
 import torch
+from executorch.backends.arm.quantizer.arm_quantizer import (
+    get_symmetric_a8w4_quantization_config,
+)
 from executorch.backends.arm.test import common
 from executorch.backends.arm.test.tester.test_pipeline import (
     EthosU55PipelineINT,
@@ -352,5 +355,21 @@ def test_convolution_1d_vgf_quant(test_data):
         exir_op,
         per_channel_quantization=per_channel_quantization,
         quantize=True,
+    )
+    pipeline.run()
+
+
+@common.parametrize("test_data", test_data_INT)
+@common.SkipIfNoModelConverter
+def test_convolution_1d_vgf_quant_a8w4(test_data):
+    model, per_channel_quantization = test_data()
+    pipeline = VgfPipeline[input_t](
+        model,
+        model.get_inputs(),
+        aten_op,
+        exir_op,
+    )
+    pipeline.quantizer.set_global(
+        get_symmetric_a8w4_quantization_config(is_per_channel=per_channel_quantization)
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_conv2d.py
+++ b/backends/arm/test/ops/test_conv2d.py
@@ -455,6 +455,24 @@ def _get_dtype_count(model: torch.nn.Module):
     }
 
 
+@common.parametrize(
+    "test_data",
+    test_data_INT,
+)
+def test_convolution_2d_vgf_quant_a8w4(test_data):
+    model, per_channel_quantization = test_data()
+    pipeline = VgfPipeline[input_t](
+        model,
+        model.get_inputs(),
+        aten_op,
+        exir_op,
+    )
+    pipeline.quantizer.set_global(
+        get_symmetric_a8w4_quantization_config(is_per_channel=per_channel_quantization)
+    )
+    pipeline.run()
+
+
 @common.parametrize("test_data", test_data_FP | test_data_FP_bf16 | test_data_FP_fp16)
 def test_convolution_2d_tosa_FP(test_data):
     model = test_data()

--- a/backends/arm/test/ops/test_conv3d.py
+++ b/backends/arm/test/ops/test_conv3d.py
@@ -678,6 +678,22 @@ def test_convolution_3d_vgf_quant(test_data):
     pipeline.run()
 
 
+@common.parametrize("test_data", test_data_INT)
+@common.SkipIfNoModelConverter
+def test_convolution_3d_vgf_quant_a8w4(test_data):
+    model, per_channel_quantization = test_data()
+    pipeline = VgfPipeline[input_t](
+        model,
+        model.get_inputs(),
+        aten_op,
+        exir_op,
+    )
+    pipeline.quantizer.set_global(
+        get_symmetric_a8w4_quantization_config(is_per_channel=per_channel_quantization)
+    )
+    pipeline.run()
+
+
 @common.SkipIfNoModelConverter
 def test_convolution_3d_vgf_no_quant_multi_op():
     """Ensure mixed Conv3d/Conv2d graphs keep correct spatial annotations."""

--- a/backends/arm/test/ops/test_depthwise_conv.py
+++ b/backends/arm/test/ops/test_depthwise_conv.py
@@ -322,6 +322,22 @@ def test_convolution_2d_vgf_quant_depthwise(test_data):
     pipeline.run()
 
 
+@common.parametrize("test_data", test_data_conv1d_INT | test_data_conv2d_INT)
+@common.SkipIfNoModelConverter
+def test_convolution_2d_vgf_quant_a8w4_depthwise(test_data):
+    model, per_channel_quantization = test_data()
+    pipeline = VgfPipeline[input_t](
+        model,
+        model.get_inputs(),
+        aten_op=[],
+        exir_op=exir_op,
+    )
+    pipeline.quantizer.set_global(
+        get_symmetric_a8w4_quantization_config(is_per_channel=per_channel_quantization)
+    )
+    pipeline.run()
+
+
 @common.XfailIfNoCorstone300
 @common.parametrize("test_data", test_data_conv2d_INT)
 def test_convolution_2d_u55_INT_depthwise(test_data):

--- a/backends/arm/test/ops/test_linear.py
+++ b/backends/arm/test/ops/test_linear.py
@@ -264,6 +264,23 @@ def test_linear_vgf_quant(test_data: torch.Tensor):
     pipeline.run()
 
 
+@common.parametrize("test_data", test_data_rank1_INT | test_data_rank4_INT)
+@common.SkipIfNoModelConverter
+def test_linear_vgf_quant_a8w4(test_data: torch.Tensor):
+    test_data, out_features, has_bias, per_channel_quantization = test_data()
+    in_features = test_data.shape[-1]
+    pipeline = VgfPipeline[input_t1](
+        Linear(in_features=in_features, out_features=out_features, bias=has_bias),
+        (test_data,),
+        aten_op=aten_op,
+        exir_op=[],
+    )
+    pipeline.quantizer.set_global(
+        get_symmetric_a8w4_quantization_config(is_per_channel=per_channel_quantization)
+    )
+    pipeline.run()
+
+
 test_data_all_16a8w = test_data_rank1_INT | test_data_rank4_INT
 
 

--- a/backends/arm/test/ops/test_transpose_conv2d.py
+++ b/backends/arm/test/ops/test_transpose_conv2d.py
@@ -198,6 +198,22 @@ def test_conv_transpose2d_vgf_quant(test_data):
     pipeline.run()
 
 
+@common.parametrize("test_data", test_data_INT, xfails=_a8w4_transpose_conv_xfails)
+@common.SkipIfNoModelConverter
+def test_conv_transpose2d_vgf_quant_a8w4(test_data):
+    model, per_channel_quantization = test_data()
+    pipeline = VgfPipeline[input_t](
+        model,
+        model.get_inputs(),
+        aten_op,
+        exir_op,
+    )
+    pipeline.quantizer.set_global(
+        get_symmetric_a8w4_quantization_config(is_per_channel=per_channel_quantization)
+    )
+    pipeline.run()
+
+
 @common.parametrize("test_data", test_data_INT16)
 @common.SkipIfNoModelConverter
 def test_conv_transpose2d_vgf_INT_int16(test_data):

--- a/backends/arm/vgf/compile_spec.py
+++ b/backends/arm/vgf/compile_spec.py
@@ -23,7 +23,7 @@ class VgfCompileSpec(ArmCompileSpec):
     Args:
         tosa_spec (TosaSpecification | str | None): TOSA specification to
             target. Strings are parsed via ``TosaSpecification.create_from_string``.
-            Defaults to ``"TOSA-1.0+FP+INT"``.
+            Defaults to ``"TOSA-1.0+FP+INT+int4+int16"``.
         compiler_flags (list[str] | None): Optional converter-backend flags.
 
     """
@@ -34,7 +34,9 @@ class VgfCompileSpec(ArmCompileSpec):
         compiler_flags: list[str] | None = None,
     ):
         if tosa_spec is None:
-            tosa_spec = TosaSpecification.create_from_string("TOSA-1.0+FP+INT")
+            tosa_spec = TosaSpecification.create_from_string(
+                "TOSA-1.0+FP+INT+int4+int16"
+            )
         elif isinstance(tosa_spec, str):
             tosa_spec = TosaSpecification.create_from_string(tosa_spec)
 


### PR DESCRIPTION
Add A8W4 VGF coverage for conv1d, conv2d, conv3d, depthwise, transpose_conv2d and linear paths using the int4 TOSA extension.

Make VgfPipeline default to VgfCompileSpec TOSA settings unless a tosa_spec or version is provided. VgfCompileSpec now includes int4 by default.

cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai