### PR TITLE
Remove set -x for viable/strict job

### DIFF
--- a/.github/workflows/update-viablestrict.yml
+++ b/.github/workflows/update-viablestrict.yml
@@ -34,7 +34,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          set -x  # Show commands in logs
           echo "## ❌ No green commit found" >> $GITHUB_STEP_SUMMARY
           echo "No green commit found"
           echo "" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
set -x which enables command tracing, causing every command to be echoed before execution. This makes the logs very noisy.
