### PR TITLE
Metal CI: cancel-in-progress=True

### DIFF
--- a/.github/workflows/metal.yml
+++ b/.github/workflows/metal.yml
@@ -9,7 +9,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   test-metal-builds:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configurations to improve CI efficiency by ensuring that only the latest workflow run is active for metal.yml. The main change is enabling the cancellation of in-progress runs when new ones are triggered for the same concurrency group.

Workflow configuration improvements:

* Set `cancel-in-progress: true` in the `concurrency` section of `.github/workflows/metal.yml` to automatically cancel previous Metal workflow runs when a new one is started.
