### PR TITLE
Speed up named data map + add uint32 support

### DIFF
--- a/exir/tensor.py
+++ b/exir/tensor.py
@@ -289,6 +289,7 @@ scalar_type_table: Dict[torch.dtype, ScalarType] = {
     torch.bfloat16: ScalarType.BFLOAT16,
     torch.quint4x2: ScalarType.QUINT4x2,
     torch.uint16: ScalarType.UINT16,
+    torch.uint32: ScalarType.UINT32,
 }
 
 


### PR DESCRIPTION
Summary:
his diff significantly speeds up named data map insertion by switching from bytes(tensor.untyped_storage()) to tensor.numpy().tobytes() for converting tensors to bytes. The new _tensor_to_bytes() helper function provides a much faster conversion path, which should noticeably improve XNNPACK and Vulkan lowering times since these backends heavily use the named data store during serialization.

Additionally, this diff adds torch.uint32 to the ScalarType mapping, enabling support for unsigned 32-bit integer tensors in ExecuTorch.

Changes:
_named_data_store.py: Added _tensor_to_bytes() helper that uses numpy().tobytes() for fast tensor-to-bytes conversion, with special handling for bfloat16 (which numpy doesn't support natively)
tensor.py: Added torch.uint32 → ScalarType.UINT32 mapping

Differential Revision: D92447071


