### PR TITLE
Metal backend: use HQQ in Parakeet quantization

### DIFF
--- a/examples/models/parakeet/quantize.py
+++ b/examples/models/parakeet/quantize.py
@@ -37,6 +37,7 @@ def quantize_model_(  # noqa: C901
         config = UIntxWeightOnlyConfig(
             group_size=qlinear_group_size,
             bitwidth=4,
+            uintx_choose_qparams_algorithm="hqq",
         )
 
         def linear_filter(m, fqn):


### PR DESCRIPTION
Bump ao pin to get https://github.com/pytorch/ao/pull/3829, and use HQQ in Parakeet quantization

