### PR TITLE
Arm backend: Default output_order_workaround=False

### DIFF
--- a/backends/arm/common/arm_compile_spec.py
+++ b/backends/arm/common/arm_compile_spec.py
@@ -46,7 +46,7 @@ class ArmCompileSpec(ABC):
         compiler_flags: list[str],
         path_for_intermediates: str | None = None,
         tosa_debug_mode: DebugMode | None = None,
-        output_order_workaround: bool = True,
+        output_order_workaround: bool = False,
         pipeline_config: ArmPassPipelineConfig | None = None,
     ):
         """Set all values of dataclass directly."""
@@ -198,7 +198,7 @@ class ArmCompileSpec(ABC):
             compile_spec.append(
                 CompileSpec(
                     ArmCompileSpec._OUTPUT_REORDER_KEY,
-                    self.output_order_workaround,
+                    bytes(self.output_order_workaround),
                 )
             )
 

--- a/backends/arm/test/test_arm_baremetal.sh
+++ b/backends/arm/test/test_arm_baremetal.sh
@@ -313,7 +313,7 @@ test_memory_allocation() {
     echo "${TEST_SUITE_NAME}: Test target Ethos-U85"
     examples/arm/run.sh --et_build_root=arm_test/test_run --target=ethos-u85-128 --model_name=examples/arm/example_modules/add.py &> arm_test/test_run/full.log
     python3 backends/arm/test/test_memory_allocator_log.py --log arm_test/test_run/full.log \
-            --require "model_pte_program_size" "<= 3100 B" \
+            --require "model_pte_program_size" "<= 3110 B" \
             --require "method_allocator_planned" "<= 64 B" \
             --require "method_allocator_loaded" "<= 1024 B" \
             --require "method_allocator_input" "<= 16 B" \


### PR DESCRIPTION
output_order_workaround was enabled by default. This can cause failures. Also addresses serialization issue of boolean in compile spec.


cc @freddan80 @per @zingo @digantdesai