### PR TITLE
Cortex-M backend: Introduce QuantizerReporter

### DIFF
--- a/backends/cortex_m/quantizer/quantization_configs.py
+++ b/backends/cortex_m/quantizer/quantization_configs.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -84,7 +84,7 @@ def _derive_bias_qparams_fn(
 
 def _get_int32_bias_qspec(node):
     return DerivedQuantizationSpec(
-        derived_from=[(node.args[0], node), (node.args[1], node)],  # type: ignore[list-item]
+        derived_from=((node.args[0], node), (node.args[1], node)),  # type: ignore[list-item]
         derive_qparams_fn=_derive_bias_qparams_fn,
         dtype=torch.int32,
         quant_min=torch.iinfo(torch.int32).min,
@@ -94,7 +94,7 @@ def _get_int32_bias_qspec(node):
 
 def _get_int32_per_channel_bias_qspec(node):
     return DerivedQuantizationSpec(
-        derived_from=[(node.args[0], node), (node.args[1], node)],  # type: ignore[list-item]
+        derived_from=((node.args[0], node), (node.args[1], node)),  # type: ignore[list-item]
         derive_qparams_fn=_derive_bias_qparams_fn,
         dtype=torch.int32,
         quant_min=torch.iinfo(torch.int32).min,

--- a/backends/cortex_m/quantizer/quantizer_reporter.py
+++ b/backends/cortex_m/quantizer/quantizer_reporter.py
@@ -1,0 +1,441 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+"""
+Contains classes for reporting quantization decisions made by Quantizers.
+
+Basic useage:
+1. Implement the QuantizerReporterUser API for all quantizers intending to use the reporter.
+2. Instantiate the QuantizerReporter with a list of quantizers to be reported.
+3. After annotation, log the report using QuantizerReporter.log_quantizer_report(model).
+
+Logs a summary report at INFO level, and a detailed node-per-node report at DEBUG level.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, List, NamedTuple, Optional
+
+from executorch.backends.cortex_m.quantizer.quantization_configs import (
+    __name__ as quantization_configs_module,
+    INT8_ACTIVATION_PER_CHANNEL_QSPEC,
+    INT8_ACTIVATION_PER_TENSOR_QSPEC,
+    INT8_PER_CHANNEL_CONFIG,
+    INT8_PER_CHANNEL_TRANSPOSE_CONFIG,
+    INT8_PER_TENSOR_CONFIG,
+    INT8_WEIGHT_PER_CHANNEL_QSPEC,
+    INT8_WEIGHT_PER_CHANNEL_TRANSPOSE_QSPEC,
+    INT8_WEIGHT_PER_TENSOR_QSPEC,
+    SOFTMAX_OUTPUT_FIXED_QSPEC,
+    SOFTMAX_PER_TENSOR_CONFIG,
+)
+from tabulate import tabulate
+from torch.fx import GraphModule, Node
+from torchao.quantization.pt2e.quantizer import Quantizer
+from torchao.quantization.pt2e.quantizer.quantizer import Q_ANNOTATION_KEY
+
+logger = logging.getLogger(__name__)
+
+# Look-up dicts used to get human readable names for supported quantization configs and specs
+SUPPORTED_QCONFIGS = {
+    INT8_PER_CHANNEL_CONFIG: f"{quantization_configs_module}.INT8_PER_CHANNEL_QCONFIG",
+    INT8_PER_CHANNEL_TRANSPOSE_CONFIG: f"{quantization_configs_module}.INT8_PER_CHANNEL_TRANSPOSE_QCONFIG",
+    INT8_PER_TENSOR_CONFIG: f"{quantization_configs_module}.INT8_PER_TENSOR_QCONFIG",
+    SOFTMAX_PER_TENSOR_CONFIG: f"{quantization_configs_module}.SOFTMAX_PER_TENSOR_QCONFIG",
+}
+
+
+SUPPORTED_QSPECS = {
+    INT8_ACTIVATION_PER_TENSOR_QSPEC: "INT8_ACTIVATION_PER_TENSOR_QSPEC",
+    INT8_ACTIVATION_PER_CHANNEL_QSPEC: "INT8_ACTIVATION_PER_CHANNEL_QSPEC",
+    INT8_WEIGHT_PER_TENSOR_QSPEC: "INT8_WEIGHT_PER_TENSOR_QSPEC",
+    INT8_WEIGHT_PER_CHANNEL_QSPEC: "INT8_WEIGHT_PER_CHANNEL_QSPEC",
+    INT8_WEIGHT_PER_CHANNEL_TRANSPOSE_QSPEC: "INT8_WEIGHT_PER_CHANNEL_TRANSPOSE_QSPEC",
+    SOFTMAX_OUTPUT_FIXED_QSPEC: "SOFTMAX_OUTPUT_FIXED_QSPEC",
+    None: "None",
+}
+
+
+def _qspec_repr(qspec):
+    return SUPPORTED_QSPECS.get(qspec, "CUSTOM_QSPEC")
+
+
+class QuantizerInfo(NamedTuple):
+    """
+    NamedTuple storing information about a Quantizer.
+    """
+
+    name: str
+    targeted_nodes_description: str
+    quantization_config_path: str
+    support_config_path: str
+
+
+class NodeQSpecReport(NamedTuple):
+    """
+    NamedTuple storing annotation info for a single node.
+    """
+
+    name: str
+    qspec_input_map_lines: List[str]
+    qspec_output: str
+
+
+class AnnotatedPatternReport(NamedTuple):
+    """
+    NamedTuple storing annotation info for a pattern of nodes.
+    """
+
+    nodes: List[NodeQSpecReport]
+
+
+class RejectedPatternReport(NamedTuple):
+    """
+    NamedTuple storing rejection info for a pattern of nodes.
+    """
+
+    node_names: List[str]
+    rejection_reason: str
+
+
+class QuantizerReport:
+    """
+    Reporter class for collecting and generating quantization reports from a single Quantizer.
+    Used by the QuantizerReporter to aggregate reports from multiple Quantizers.
+    """
+
+    _PREVIOUS_ANNOTATION_REJECT_REASON = "Tried annotating already quantized node."
+
+    def __init__(self, quantizer):
+        self.quantizer = quantizer.get_quantizer_info()
+        self.accepted_patterns: List[AnnotatedPatternReport] = []
+        self.rejected_patterns: List[RejectedPatternReport] = []
+
+    @property
+    def accepted_node_count(self) -> int:
+        return sum(len(report.nodes) for report in self.accepted_patterns)
+
+    @property
+    def rejected_node_count(self) -> int:
+        return sum(
+            len(report.node_names)
+            for report in self.rejected_patterns
+            if report.rejection_reason != self._PREVIOUS_ANNOTATION_REJECT_REASON
+        )
+
+    @property
+    def rejected_previous_annotation_count(self) -> int:
+        return sum(
+            len(report.node_names)
+            for report in self.rejected_patterns
+            if report.rejection_reason == self._PREVIOUS_ANNOTATION_REJECT_REASON
+        )
+
+    def report_accept(self, pattern: List[Node]) -> None:
+        """
+        Stores an AnnotatedPatternReport containing info about the accepted pattern.
+        """
+        node_reports = []
+        for node in pattern:
+            if Q_ANNOTATION_KEY not in node.meta:
+                raise ValueError(
+                    "Node {node.name} reported as annotated but has no quantization annotation."
+                )
+            annotation = node.meta.get(Q_ANNOTATION_KEY)
+            qspec_input_map_lines = [
+                f"{node.name}: {_qspec_repr(qspec)}"
+                for node, qspec in annotation.input_qspec_map.items()
+            ]
+
+            node_reports.append(
+                NodeQSpecReport(
+                    node.name,
+                    qspec_input_map_lines,
+                    _qspec_repr(annotation.output_qspec),
+                )
+            )
+
+        self.accepted_patterns.append(AnnotatedPatternReport(node_reports))
+
+    def report_reject(self, pattern, reason):
+        """
+        Stores an RejectedPatternReport containing info about the rejected pattern.
+        """
+        self.rejected_patterns.append(
+            RejectedPatternReport([node.name for node in pattern], reason)
+        )
+
+    def get_quantizer_info_rows(self) -> List[str]:
+        rows = []
+        rows.append(
+            f"{self.quantizer.name} using {self.quantizer.targeted_nodes_description}"
+        )
+        rows.append(f"Annotating with {self.quantizer.quantization_config_path}")
+        rows.append(
+            f"Supported operators and patterns defined by {self.quantizer.support_config_path}"
+        )
+
+        if (
+            self.accepted_node_count
+            or self.rejected_node_count
+            or self.rejected_previous_annotation_count
+        ):
+            rows.append(f"   Accepted nodes: {self.accepted_node_count}")
+            rows.append(
+                f"   Rejected due to previous annotation: {self.rejected_previous_annotation_count}"
+            )
+            rows.append(f"   Rejected nodes: {self.rejected_node_count}")
+        else:
+            rows.append("   No patterns accepted or rejected.")
+
+        rows.append("")
+        return rows
+
+    def quantizer_report(self, include_table: bool) -> List[str]:
+        report_rows = []
+        report_rows.extend(self.get_quantizer_info_rows())
+
+        if include_table:
+            table = self._format_qspec_table()
+            if table:
+                report_rows.append(self._indent_block(table, "   "))
+        return report_rows
+
+    def _format_qspec_table(self) -> str:
+        include_prefix = self._has_multi_node_pattern()
+        rows = self._pattern_rows(include_prefix)
+        if not rows:
+            return ""
+        if include_prefix:
+            headers = ["", "NODE NAME", "INPUT QSPEC MAP", "OUTPUT QSPEC MAP"]
+        else:
+            headers = ["NODE NAME", "INPUT QSPEC MAP", "OUTPUT QSPEC MAP"]
+        return tabulate(
+            rows,
+            headers=headers,
+            tablefmt="simple",
+        )
+
+    def _pattern_rows(self, include_prefix: bool) -> List[List[str]]:
+        rows: List[List[str]] = []
+        for accepted in self.accepted_patterns:
+            if not accepted.nodes:
+                continue
+            total_lines = sum(
+                max(1, len(node.qspec_input_map_lines)) for node in accepted.nodes
+            )
+            line_index = 0
+            for node in accepted.nodes:
+                entries = node.qspec_input_map_lines or [""]
+                for entry_index, entry in enumerate(entries):
+                    prefix = self._pattern_prefix(
+                        line_index, total_lines, len(accepted.nodes)
+                    )
+                    node_name = node.name if entry_index == 0 else ""
+                    output = node.qspec_output if entry_index == 0 else ""
+                    if include_prefix:
+                        rows.append([prefix, node_name, entry, output])
+                    else:
+                        rows.append([node_name, entry, output])
+                    line_index += 1
+
+        for rejected in self.rejected_patterns:
+            if not self._should_report_rejection(rejected):
+                continue
+            node_name = self._rejected_pattern_label(rejected)
+            input_qspec = f"Rejected: {rejected.rejection_reason}"
+            output_qspec = ""
+            if include_prefix:
+                rows.append([" ", node_name, input_qspec, output_qspec])
+            else:
+                rows.append([node_name, input_qspec, output_qspec])
+        return rows
+
+    def _has_multi_node_pattern(self) -> bool:
+        return any(len(report.nodes) > 1 for report in self.accepted_patterns) or any(
+            len(report.node_names) > 1
+            for report in self.rejected_patterns
+            if self._should_report_rejection(report)
+        )
+
+    def _should_report_rejection(self, rejected: RejectedPatternReport) -> bool:
+        return rejected.rejection_reason != self._PREVIOUS_ANNOTATION_REJECT_REASON
+
+    def _indent_block(self, text: str, prefix: str) -> str:
+        return "\n".join(f"{prefix}{line}" for line in text.splitlines())
+
+    def _pattern_prefix(self, index: int, total: int, pattern_size: int) -> str:
+        if pattern_size == 1:
+            return " "
+        if index == 0:
+            return "╒"
+        if index == total - 1:
+            return "╘"
+        return "|"
+
+    def _rejected_pattern_label(self, rejected: RejectedPatternReport) -> str:
+        if len(rejected.node_names) == 1:
+            return rejected.node_names[0]
+        return "(" + ", ".join(rejected.node_names) + ")"
+
+
+class QuantizerReporter:
+    """
+    Reporter class for collecting and generating quantization reports from Quantizers
+    inheriting from QuantizerReporterUser.
+    """
+
+    def __init__(self, quantizers: List[QuantizerReporterUser]):
+        self.quantizers: Dict[Quantizer, QuantizerReport] = {}
+        self.set_quantizers(quantizers)
+
+    def set_quantizers(self, quantizers: List[QuantizerReporterUser]) -> None:
+        """
+        Registers quantizers to report their quantization decisions.
+        """
+
+        self.quantizers = {}
+        for quantizer in quantizers:
+            try:
+                quantizer.register_reporter(self)
+            except AttributeError:
+                logger.warning(
+                    f"Quantizer {quantizer.__class__.__name__} does not implement QuantizerReporterUser interface and will not report quantization decisions."
+                )
+
+            self.quantizers[quantizer] = QuantizerReport(quantizer)
+
+    def report_reject(
+        self, quantizer: QuantizerReporterUser, pattern: List[Node], reason: str
+    ):
+        """
+        Reports a node pattern rejected by a quantizer with a given reason.
+        """
+        quantizer_entry = self.quantizers.get(quantizer, None)
+        if quantizer_entry is not None:
+            quantizer_entry.report_reject(pattern, reason)
+        else:
+            raise ValueError(
+                f"Quantizer {quantizer.__class__.__name__} not registred in reporter."
+            )
+
+    def report_accept(
+        self,
+        quantizer: QuantizerReporterUser,
+        pattern: List[Node],
+    ):
+        """
+        Reports a node pattern accepted by a quantizer.
+        """
+        quantizer_entry = self.quantizers.get(quantizer, None)
+        if quantizer_entry is not None:
+            quantizer_entry.report_accept(pattern)
+        else:
+            raise ValueError(
+                f"Quantizer {quantizer.__class__.__name__} not registred in reporter."
+            )
+
+    def log_quantizer_report(self, model: Optional[GraphModule] = None):
+        """
+        Logs the quantization report for all registered quantizers.
+
+        If the logger is set to DEBUG level, a node-per-node report is generated and
+        logged at DEBUG level. Otherwise, a summary report is logged at INFO level.
+        """
+        extended_report = logger.isEnabledFor(logging.DEBUG)
+
+        report = self.get_quantization_report(model, extended_report)
+        if extended_report:
+            logger.debug(report)
+        else:
+            logger.info(report)
+
+    def get_quantization_report(
+        self, model: Optional[GraphModule], extended_report: bool
+    ) -> str:
+        """
+        Generates the quantization report for all registered quantizers
+        """
+        report_rows: List[str] = []
+        separator = "-" * 100
+        report_rows.append(separator)
+        report_rows.append(" " * 39 + " QUANTIZATION REPORT " + " " * 40)
+        report_rows.append(separator)
+
+        for report in self.quantizers.values():
+            report_rows.extend(report.quantizer_report(extended_report))
+            report_rows.append(separator)
+
+        report_rows.extend(self.unannotated_nodes_report(model, extended_report))
+        report_rows.append(separator)
+
+        report = "\n" + "\n".join(report_rows)
+        return report
+
+    def unannotated_nodes_report(
+        self, model: Optional[GraphModule], extended_report: bool
+    ) -> List[str]:
+        """
+        Generates the quantization report for all non-annotated nodes in the model.
+        """
+        non_quantized_nodes = [
+            node for node in model.graph.nodes if Q_ANNOTATION_KEY not in node.meta
+        ]
+
+        rows = []
+        if extended_report:
+            rows.append("Non annotated nodes:")
+            if non_quantized_nodes:
+                for node in non_quantized_nodes:
+                    rows.append(f"    {self._pattern_repr([node])}")
+            else:
+                rows.append("    None")
+        else:
+            rows.append(f"Non annotated nodes: {len(non_quantized_nodes)}")
+        return rows
+
+    def _pattern_repr(self, nodes: List[Node]) -> str:
+        names = [n.name for n in nodes]
+        if len(names) == 1:
+            return f"{names[0]}"
+        return "(" + ", ".join(names) + ")"
+
+
+class QuantizerReporterUser:
+    """
+    Mixin class for Quantizers, to be used with QuantizerReporter.
+
+    Handles reporter registration and ensures that that the quantizer does not crash
+    without a reporter registred
+    """
+
+    def __init__(self):
+        self.reporter: QuantizerReporter = None
+
+    def register_reporter(self, reporter: QuantizerReporter) -> None:
+        """
+        Used by QuantizerReporter to register itself with the Quantizer.
+        """
+        self.reporter = reporter
+
+    def report_reject(self, pattern: List[Node], reason: str) -> None:
+        """
+        Reports a node pattern rejected by a quantizer, if a reporter is registered.
+        """
+        if self.reporter is not None:
+            self.reporter.report_reject(self, pattern, reason)
+
+    def report_accept(self, pattern: List[Node]) -> None:
+        """
+        Reports a node pattern accepted by a quantizer, if a reporter is registered.
+        """
+        if self.reporter is not None:
+            self.reporter.report_accept(self, pattern)
+
+    def get_quantizer_info(self) -> "QuantizerInfo":
+        """
+        Returns a QuantizerInfo NamedTuple with information about the quantizer.
+        """
+        raise NotImplementedError("Quantizer must implement get_quantizer_info method.")

--- a/backends/cortex_m/test/misc/test_node_finders.py
+++ b/backends/cortex_m/test/misc/test_node_finders.py
@@ -34,6 +34,7 @@ def test_node_name_finder_single_name():
     nodes = list(node_finder.find_nodes(graph_module))
     assert len(nodes) == 1
     assert nodes[0].name == "add"
+    assert str(node_finder) == "NodeNameNodeFinder targeting names: add"
 
 
 def test_node_name_finder_multiple_names():
@@ -44,6 +45,7 @@ def test_node_name_finder_multiple_names():
     nodes = list(node_finder.find_nodes(graph_module))
     node_names = {n.name for n in nodes}
     assert node_names == {"add", "sub"}
+    assert str(node_finder) == "NodeNameNodeFinder targeting names: add, sub"
 
 
 def test_node_name_finder_missing_name():
@@ -53,6 +55,7 @@ def test_node_name_finder_missing_name():
     node_finder = node_finders.NodeNameNodeFinder("not_in_graph")
     nodes = list(node_finder.find_nodes(graph_module))
     assert nodes == []
+    assert str(node_finder) == "NodeNameNodeFinder targeting names: not_in_graph"
 
 
 def test_node_target_finder_single_target():
@@ -63,6 +66,10 @@ def test_node_target_finder_single_target():
     nodes = list(node_finder.find_nodes(graph_module))
     assert len(nodes) == 1
     assert nodes[0].target == torch.ops.aten.add.Tensor
+    assert (
+        str(node_finder)
+        == "NodeTargetNodeFinder targeting node targets: aten::add.Tensor"
+    )
 
 
 def test_node_target_finder_multiple_targets():
@@ -84,6 +91,7 @@ def test_node_target_finder_missing_target():
     node_finder = node_finders.NodeTargetNodeFinder(torch.ops.aten.relu.default)
     nodes = list(node_finder.find_nodes(graph_module))
     assert nodes == []
+    assert str(node_finder) == "NodeTargetNodeFinder targeting node targets: aten::relu"
 
 
 def test_global_node_finder():
@@ -104,6 +112,7 @@ def test_global_node_finder():
         "mul",
         "output",
     ]
+    assert str(node_finder) == "GlobalNodeFinder targeting all nodes"
 
 
 def test_input_node_finder():
@@ -116,6 +125,7 @@ def test_input_node_finder():
     node_names = [node.name for node in nodes]
     assert node_names == ["p_linear_weight", "p_linear_bias", "x"]
     assert all(node.op == "placeholder" for node in nodes)
+    assert str(node_finder) == "InputNodeFinder targeting all placeholder nodes"
 
 
 def test_output_node_finder():
@@ -127,6 +137,7 @@ def test_output_node_finder():
 
     assert len(nodes) == 1
     assert nodes[0].op == "output"
+    assert str(node_finder) == "OutputNodeFinder targeting the output node"
 
 
 def test_module_name_finder():
@@ -138,6 +149,7 @@ def test_module_name_finder():
 
     assert len(nodes) == 1
     assert nodes[0].target == torch.ops.aten.linear.default
+    assert str(node_finder) == "ModuleNameNodeFinder targeting module names: linear"
 
 
 def test_module_name_finder_missing_name():
@@ -147,6 +159,9 @@ def test_module_name_finder_missing_name():
     node_finder = node_finders.ModuleNameNodeFinder("not_in_graph")
     nodes = list(node_finder.find_nodes(graph_module))
     assert nodes == []
+    assert (
+        str(node_finder) == "ModuleNameNodeFinder targeting module names: not_in_graph"
+    )
 
 
 def test_module_type_finder():
@@ -158,6 +173,7 @@ def test_module_type_finder():
 
     assert len(nodes) == 1
     assert nodes[0].target == torch.ops.aten.linear.default
+    assert str(node_finder) == "ModuleTypeNodeFinder targeting module types: Linear"
 
 
 def test_module_type_finder_missing_type():
@@ -167,3 +183,4 @@ def test_module_type_finder_missing_type():
     node_finder = node_finders.ModuleTypeNodeFinder(torch.nn.Conv2d)
     nodes = list(node_finder.find_nodes(graph_module))
     assert nodes == []
+    assert str(node_finder) == "ModuleTypeNodeFinder targeting module types: Conv2d"

--- a/backends/cortex_m/test/misc/test_quantizer_reporter.py
+++ b/backends/cortex_m/test/misc/test_quantizer_reporter.py
@@ -1,0 +1,158 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+
+import torch
+from executorch.backends.cortex_m.quantizer.quantization_configs import (
+    INT8_ACTIVATION_PER_CHANNEL_QSPEC,
+    INT8_WEIGHT_PER_TENSOR_QSPEC,
+)
+from executorch.backends.cortex_m.quantizer.quantizer import mark_node_as_annotated
+from executorch.backends.cortex_m.quantizer.quantizer_reporter import (
+    logger as quantizer_logger,
+    QuantizerInfo,
+    QuantizerReport,
+    QuantizerReporter,
+    QuantizerReporterUser,
+)
+from torch.export import export
+
+
+class _TwoOpModule(torch.nn.Module):
+    def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
+        return torch.relu(x + y)
+
+
+def _export_two_op_graph_module():
+    return export(_TwoOpModule(), (torch.ones(2, 2), torch.ones(2, 2))).graph_module
+
+
+class _DummyQuantizer(QuantizerReporterUser):
+    def __init__(self):
+        super().__init__()
+
+    def get_quantizer_info(self) -> QuantizerInfo:
+        return QuantizerInfo(
+            name="DummyQuantizer",
+            targeted_nodes_description="dummy nodes",
+            quantization_config_path="dummy.config",
+            support_config_path="dummy.support",
+        )
+
+
+def test_warning_log_level(caplog):
+    graph_module = _export_two_op_graph_module()
+
+    reporter = QuantizerReporter([])
+    with caplog.at_level(logging.WARNING, logger=quantizer_logger.name):
+        reporter.log_quantizer_report(graph_module)
+
+    unexpected_string = """----------------------------------------------------------------------------------------------------
+                                    QUANTIZATION REPORT                                         
+----------------------------------------------------------------------------------------------------
+Non annotated nodes: 5
+----------------------------------------------------------------------------------------------------"""
+
+    assert unexpected_string not in caplog.text
+
+
+def test_info_log_level(caplog):
+    """Ensure report generation does not fail when INFO/DEBUG is disabled."""
+    graph_module = _export_two_op_graph_module()
+
+    reporter = QuantizerReporter([])
+    with caplog.at_level(logging.INFO, logger=quantizer_logger.name):
+        reporter.log_quantizer_report(graph_module)
+
+    expected_string = """----------------------------------------------------------------------------------------------------
+                                        QUANTIZATION REPORT                                         
+----------------------------------------------------------------------------------------------------
+Non annotated nodes: 5
+----------------------------------------------------------------------------------------------------"""
+
+    assert expected_string in caplog.text
+
+
+def test_debug_log_level(caplog):
+    """Ensure report generation does not fail when INFO/DEBUG is disabled."""
+    graph_module = _export_two_op_graph_module()
+
+    add_node = next(
+        node
+        for node in graph_module.graph.nodes
+        if node.target == torch.ops.aten.add.Tensor
+    )
+    relu_node = next(
+        node
+        for node in graph_module.graph.nodes
+        if node.target == torch.ops.aten.relu.default
+    )
+
+    quantizer1 = _DummyQuantizer()
+    quantizer2 = _DummyQuantizer()
+    quantizer3 = _DummyQuantizer()
+
+    reporter = QuantizerReporter([quantizer1, quantizer2, quantizer3])
+
+    mark_node_as_annotated(
+        add_node,
+        {add_node.args[0]: INT8_WEIGHT_PER_TENSOR_QSPEC, add_node.args[1]: None},
+        None,
+    )
+    mark_node_as_annotated(
+        relu_node,
+        {},
+        INT8_ACTIVATION_PER_CHANNEL_QSPEC,
+    )
+    quantizer1.report_accept([add_node, relu_node])
+    quantizer2.report_reject(
+        [add_node], QuantizerReport._PREVIOUS_ANNOTATION_REJECT_REASON
+    )
+    quantizer2.report_reject([relu_node], "Dummy rejection message")
+
+    with caplog.at_level(logging.DEBUG, logger=quantizer_logger.name):
+        reporter.log_quantizer_report(graph_module)
+
+    expected_string = """----------------------------------------------------------------------------------------------------
+                                        QUANTIZATION REPORT                                         
+----------------------------------------------------------------------------------------------------
+DummyQuantizer using dummy nodes
+Annotating with dummy.config
+Supported operators and patterns defined by dummy.support
+   Accepted nodes: 2
+   Rejected due to previous annotation: 0
+   Rejected nodes: 0
+
+       NODE NAME    INPUT QSPEC MAP                  OUTPUT QSPEC MAP
+   --  -----------  -------------------------------  ---------------------------------
+   ╒   add          x: INT8_WEIGHT_PER_TENSOR_QSPEC  None
+   |                y: None
+   ╘   relu                                          INT8_ACTIVATION_PER_CHANNEL_QSPEC
+----------------------------------------------------------------------------------------------------
+DummyQuantizer using dummy nodes
+Annotating with dummy.config
+Supported operators and patterns defined by dummy.support
+   Accepted nodes: 0
+   Rejected due to previous annotation: 1
+   Rejected nodes: 1
+
+   NODE NAME    INPUT QSPEC MAP                    OUTPUT QSPEC MAP
+   -----------  ---------------------------------  ------------------
+   relu         Rejected: Dummy rejection message
+----------------------------------------------------------------------------------------------------
+DummyQuantizer using dummy nodes
+Annotating with dummy.config
+Supported operators and patterns defined by dummy.support
+   No patterns accepted or rejected.
+
+----------------------------------------------------------------------------------------------------
+Non annotated nodes:
+    x
+    y
+    output
+----------------------------------------------------------------------------------------------------"""
+
+    assert expected_string in caplog.text


### PR DESCRIPTION
The QuantizerReporter logs how a graph is annotated.

Basic useage:
1. Implement the QuantizerReporterUser API for all quantizers intending to use the reporter.
2. Instantiate the QuantizerReporter with a list of quantizers to be reported.
3. After annotation, log the report using QuantizerReporter.log_quantizer_report(model).

Logs a summary report at INFO level, and a detailed node-per-node report at DEBUG level. See the added test for example output.

cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai