### PR TITLE
Make ARM backend import optional in llama export tests

### DIFF
--- a/examples/models/llama/tests/test_export_llama_lib.py
+++ b/examples/models/llama/tests/test_export_llama_lib.py
@@ -7,9 +7,15 @@
 
 import unittest
 
-from executorch.backends.arm.quantizer.arm_quantizer import TOSAQuantizer
-
 from executorch.devtools.backend_debug import get_delegation_info
+
+try:
+    from executorch.backends.arm.quantizer.arm_quantizer import TOSAQuantizer
+
+    HAS_ARM_BACKEND = True
+except ImportError:
+    HAS_ARM_BACKEND = False
+    TOSAQuantizer = None
 from executorch.examples.models.llama.export_llama_lib import (
     _export_llama,
     build_args_parser,
@@ -53,6 +59,7 @@ class ExportLlamaLibTest(unittest.TestCase):
         for op, _op_info in delegation_info.delegation_by_operator.items():
             self.assertTrue(op not in UNWANTED_OPS)
 
+    @unittest.skipUnless(HAS_ARM_BACKEND, "ARM backend not available")
     def test_get_quantizer_and_quant_params_returns_tosa_quantizer(self):
         llm_config = LlmConfig()
         llm_config.backend.tosa.enabled = True


### PR DESCRIPTION
The test file had a top-level import of TOSAQuantizer from the ARM
backend, which transitively requires the tosa_serializer module. This
caused the entire test file to fail to load when the ARM backend
dependencies were not installed.

The TOSAQuantizer import is now wrapped in a try/except block, and
the test that depends on it is skipped when the ARM backend is not
available. This allows the other tests in the file to run regardless
of whether ARM dependencies are installed.

Co-authored-by: Claude <noreply@anthropic.com>
