### PR TITLE
Fix quantizer documentation link in XNNPACK section

### DIFF
--- a/docs/source/backends/xnnpack/xnnpack-arch-internals.md
+++ b/docs/source/backends/xnnpack/xnnpack-arch-internals.md
@@ -75,7 +75,7 @@ We have enabled basic profiling for the XNNPACK delegate that can be enabled wit
 
 [comment]: <> (TODO: Refactor quantizer to a more official quantization doc)
 ## Quantization
-The XNNPACK delegate can also be used as a backend to execute symmetrically quantized models. For quantized model delegation, we quantize models using the `XNNPACKQuantizer`. `Quantizers` are backend specific, which means the `XNNPACKQuantizer` is configured to quantize models to leverage the quantized operators offered by the XNNPACK Library. We will not go over the details of how to implement your custom quantizer, you can follow the docs [here](https://pytorch.org/tutorials/prototype/pt2e_quantizer.html) to do so. However, we will provide a brief overview of how to quantize the model to leverage quantized execution of the XNNPACK delegate.
+The XNNPACK delegate can also be used as a backend to execute symmetrically quantized models. For quantized model delegation, we quantize models using the `XNNPACKQuantizer`. `Quantizers` are backend specific, which means the `XNNPACKQuantizer` is configured to quantize models to leverage the quantized operators offered by the XNNPACK Library. We will not go over the details of how to implement your custom quantizer, you can follow the docs [here](https://docs.pytorch.org/ao/main/pt2e_quantization/index.html) to do so. However, we will provide a brief overview of how to quantize the model to leverage quantized execution of the XNNPACK delegate.
 
 ### Configuring the XNNPACKQuantizer
 


### PR DESCRIPTION
The old link 404'd. Updated the link for custom quantizer documentation to the official PyTorch quantization docs.

https://docs.pytorch.org/executorch/stable/backends/xnnpack/xnnpack-arch-internals.html#quantization