### PR TITLE
Revert "Arm backend: Make setting artifact_path optional for tests"

### DIFF
--- a/backends/arm/test/common.py
+++ b/backends/arm/test/common.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2026 Arm Limited and/or its affiliates.
+# Copyright 2024-2025 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -6,6 +6,7 @@
 
 import os
 
+import tempfile
 from datetime import datetime
 
 from pathlib import Path
@@ -94,8 +95,9 @@ def get_u55_compile_spec(
     """Default compile spec for Ethos-U55 tests."""
     if not custom_path:
         custom_path = maybe_get_tosa_collate_path()
-    if custom_path is not None:
-        os.makedirs(custom_path, exist_ok=True)
+    artifact_path = custom_path or tempfile.mkdtemp(prefix="arm_u55_")
+    if not os.path.exists(artifact_path):
+        os.makedirs(artifact_path, exist_ok=True)
 
     # https://gitlab.arm.com/artificial-intelligence/ethos-u/ethos-u-vela/-/blob/main/OPTIONS.md
     assert macs in [32, 64, 128, 256], "Unsupported MACs value"
@@ -112,7 +114,7 @@ def get_u55_compile_spec(
             extra_flags=extra_flags_list,
             config_ini=config,
         )
-        .dump_intermediate_artifacts_to(custom_path)
+        .dump_intermediate_artifacts_to(artifact_path)
         .dump_debug_info(tosa_debug_mode)
     )
     return compile_spec
@@ -131,8 +133,9 @@ def get_u85_compile_spec(
 
     if not custom_path:
         custom_path = maybe_get_tosa_collate_path()
-    if custom_path is not None:
-        os.makedirs(custom_path, exist_ok=True)
+    artifact_path = custom_path or tempfile.mkdtemp(prefix="arm_u85_")
+    if not os.path.exists(artifact_path):
+        os.makedirs(artifact_path, exist_ok=True)
 
     assert macs in [128, 256, 512, 1024, 2048], "Unsupported MACs value"
 
@@ -149,7 +152,7 @@ def get_u85_compile_spec(
             extra_flags=extra_flags_list,
             config_ini=config,
         )
-        .dump_intermediate_artifacts_to(custom_path)
+        .dump_intermediate_artifacts_to(artifact_path)
         .dump_debug_info(tosa_debug_mode)
     )
     return compile_spec  # type: ignore[return-value]
@@ -175,8 +178,17 @@ def get_vgf_compile_spec(
     if len(profiles) == 0:
         raise ValueError(f"Unsupported vgf compile_spec: {repr(tosa_spec)}")
 
-    if custom_path is not None:
-        os.makedirs(custom_path, exist_ok=True)
+    if custom_path is None:
+        artifact_path = "arm_vgf_"
+        for profile in profiles:
+            artifact_path = artifact_path + f"_{profile}"
+        artifact_path = tempfile.mkdtemp(artifact_path)
+    else:
+        artifact_path = custom_path
+
+    if not os.path.exists(artifact_path):
+        os.makedirs(artifact_path, exist_ok=True)
+
     if compiler_flags is not None:
         compiler_flags_list = compiler_flags.split(" ")
     else:
@@ -184,7 +196,7 @@ def get_vgf_compile_spec(
 
     compile_spec = (
         VgfCompileSpec(tosa_spec, compiler_flags_list)
-        .dump_intermediate_artifacts_to(custom_path)
+        .dump_intermediate_artifacts_to(artifact_path)
         .dump_debug_info(tosa_debug_mode)
     )
 

--- a/backends/arm/test/tester/serialize.py
+++ b/backends/arm/test/tester/serialize.py
@@ -1,11 +1,10 @@
-# Copyright 2024-2026 Arm Limited and/or its affiliates.
+# Copyright 2024-2025 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
 import logging
 import os
-import tempfile
 from typing import Optional
 
 import executorch.backends.xnnpack.test.tester.tester as tester
@@ -69,12 +68,7 @@ class Serialize(tester.Serialize):
                 f"Did not find build arm_executor_runner in path {elf_path}, run setup_testing.sh?"
             )
 
-        tempdir_context = None
-        if intermediate_path is None:
-            tempdir_context = tempfile.TemporaryDirectory()
-            intermediate_path = tempdir_context.name
-
-        result = run_target(
+        return run_target(
             self.executorch_program_manager,
             inputs_flattened,
             intermediate_path,
@@ -82,8 +76,3 @@ class Serialize(tester.Serialize):
             elf_path,
             self.timeout,
         )
-
-        if tempdir_context:
-            tempdir_context.cleanup()
-
-        return result

--- a/backends/arm/tosa/backend.py
+++ b/backends/arm/tosa/backend.py
@@ -16,6 +16,7 @@ subsequent stages (for example, JIT or hardware-specific compilers) consume.
 """
 
 import logging
+import tempfile
 from itertools import count
 from typing import cast, Dict, final, List
 
@@ -246,11 +247,16 @@ class TOSABackend(BackendDetails):
 
         if artifact_path:
             tag = arm_get_first_delegation_tag(edge_program.graph_module)
-            debug_tosa_dump(
-                binary,
-                artifact_path,
-                suffix="{}".format(f"_{tag}" if tag else "") + (f"_{tosa_spec}"),
-            )
+
+            # Only dump TOSA if we are not saving to temporary folder.
+            if len(
+                tempdir := tempfile.gettempdir()
+            ) > 0 and not artifact_path.startswith(tempdir):
+                debug_tosa_dump(
+                    binary,
+                    artifact_path,
+                    suffix="{}".format(f"_{tag}" if tag else "") + (f"_{tosa_spec}"),
+                )
 
             if debug_hook is not None:
                 if debug_hook.mode == ArmCompileSpec.DebugMode.JSON:


### PR DESCRIPTION
This reverts commit 52bdacc16b40448a9f2993229474f4cf665347b2.

### Summary
This is breaking internal CI in https://www.internalfb.com/diff/D92366066

Specifically, breaking CI for all the _INT variant tests across multiple ops (avg_pool2d, tanh, rsqrt, conv2d, cat, addmm, add).

cc @psiddh 