### PR TITLE
Fix Vulkan texture tensor UBO budget overflow

### DIFF
--- a/backends/vulkan/runtime/api/containers/Tensor.cpp
+++ b/backends/vulkan/runtime/api/containers/Tensor.cpp
@@ -564,14 +564,19 @@ size_t calculate_max_ubo_nbytes(
     const size_t min_nbytes_per_ubo,
     const utils::StorageType storage_type) {
   size_t ivec4_ubo_nbytes = utils::align_up(size_t(16), min_nbytes_per_ubo);
-  size_t uvec3_ubo_nbytes = utils::align_up(size_t(12), min_nbytes_per_ubo);
+  // TextureLimits has alignas(16) so sizeof(TextureLimits) == 16, not 12.
+  // Use 16 to match the actual sizeof used by metadata_ubo_impl().
+  size_t uvec3_ubo_nbytes = utils::align_up(size_t(16), min_nbytes_per_ubo);
   size_t int32_ubo_nbytes = utils::align_up(size_t(4), min_nbytes_per_ubo);
   if (storage_type == utils::kBuffer) {
     // sizes, strides, dim order, numel
     return 3 * ivec4_ubo_nbytes + int32_ubo_nbytes;
   }
-  // sizes, logical limits
-  return ivec4_ubo_nbytes + uvec3_ubo_nbytes;
+  // sizes, strides, dim_order, numel, logical_limits
+  // Ops like Linear and MatMul unconditionally request strides/numel UBOs on
+  // all tensors regardless of storage type, so texture tensors need the same
+  // metadata budget as buffer tensors plus logical_limits.
+  return 3 * ivec4_ubo_nbytes + int32_ubo_nbytes + uvec3_ubo_nbytes;
 }
 
 //
@@ -1161,9 +1166,10 @@ bool vTensor::is_contiguous() const {
 }
 
 size_t vTensor::get_max_ubo_nbytes(const size_t nbytes_per_ubo) const {
-  // For texture backed tensors, the metadata fields needed are:
-  // sizes, logical limits
-  size_t max_metadata_field_count = 2u;
+  // Ops like Linear and MatMul unconditionally request strides/numel UBOs on
+  // all tensors regardless of storage type, so texture tensors need the same
+  // metadata budget as buffer tensors plus logical_limits (5 fields total).
+  size_t max_metadata_field_count = 5u;
   if (storage_type() == utils::kBuffer) {
     // sizes, strides, dim order, numel
     max_metadata_field_count = 4u;


### PR DESCRIPTION
## Summary

Fixes #17293

Texture-backed tensors had a UBO (Uniform Buffer Object) metadata budget of only 2 fields (sizes + logical_limits), while operators like Linear and MatMul unconditionally request strides, numel, and dim_order UBOs on **all** tensors regardless of storage type. This caused an assertion failure at runtime:

```
Vulkan uniform data allocation has exceeded tensor uniform buffer size
(Tensor.h:579 metadata_ubo_impl)
```

This affected all Vulkan-delegated models on Android (tested on Pixel 10 Pro, Android 16), including simple models like MobileNet V3 Small.

## Changes

**`backends/vulkan/runtime/api/containers/Tensor.cpp`:**

1. **`calculate_max_ubo_nbytes()`** — Increased texture tensor UBO budget from 2 fields (sizes + logical_limits) to 5 fields (sizes + strides + dim_order + numel + logical_limits), matching the buffer budget plus logical_limits.

2. **`get_max_ubo_nbytes()`** — Updated `max_metadata_field_count` for texture tensors from `2u` to `5u`.

**`backends/vulkan/test/vulkan_compute_api_test.cpp`:**

Added `texture_tensor_ubo_metadata_budget_test` regression test that:
- Creates a texture-backed vTensor and requests all 5 metadata UBOs (sizes, logical_limits, strides, numel, dim_order)
- Creates a buffer-backed vTensor and verifies it still works
- Fails without the fix, passes with it

## Test Plan

- [x] Regression test `texture_tensor_ubo_metadata_budget_test` passes
- [x] Full `vulkan_compute_api_test` suite: 50/52 pass (same 2 pre-existing matmul precision failures on MoltenVK/Apple M2 Pro, unrelated to this change)
- [x] Zero regressions introduced

cc @SS-JIA @manuelcandales @digantdesai @cbilgin