### PR TITLE
Qualcomm AI Engine Direct - Support SLC allocator feature

### DIFF
--- a/backends/qualcomm/aot/python/PyQnnManagerAdaptor.cpp
+++ b/backends/qualcomm/aot/python/PyQnnManagerAdaptor.cpp
@@ -207,6 +207,7 @@ PYBIND11_MODULE(PyQnnManagerAdaptor, m) {
       .def("Init", &PyQnnManager::Init)
       .def("InitBackend", &PyQnnManager::InitBackend)
       .def("InitContext", &PyQnnManager::InitContext)
+      .def("InitContextCache", &PyQnnManager::InitContextCache)
       .def("IsNodeSupportedByBackend", &PyQnnManager::IsNodeSupportedByBackend)
       .def(
           "Compile",

--- a/backends/qualcomm/aot/python/PyQnnManagerAdaptor.h
+++ b/backends/qualcomm/aot/python/PyQnnManagerAdaptor.h
@@ -236,6 +236,10 @@ class PyQnnManager {
     return qnn_manager_->InitContext(std::optional{graph_names});
   }
 
+  executorch::runtime::Error InitContextCache() {
+    return qnn_manager_->InitContextCache();
+  }
+
   bool IsNodeSupportedByBackend(
       std::vector<std::shared_ptr<OpWrapper>>& op_wrappers) {
     return qnn_manager_->IsNodeSupportedByBackend(op_wrappers);

--- a/backends/qualcomm/quantizer/qconfig.py
+++ b/backends/qualcomm/quantizer/qconfig.py
@@ -114,14 +114,21 @@ def get_8a8w_qnn_ptq_config(
     # the smallest scale defaults to DEFAULT_EPS_8BIT
     extra_args: Dict[str, Any] = {"eps": eps if eps else DEFAULT_EPS_8BIT}
 
-    act_quantization_spec = QuantizationSpec(
-        dtype=torch.uint8,
-        qscheme=(
-            torch.per_tensor_symmetric if act_symmetric else torch.per_tensor_affine
-        ),
-        ch_axis=0,
-        observer_or_fake_quant_ctr=act_observer.with_args(**extra_args),
-    )
+    if act_symmetric:
+        act_quantization_spec = QuantizationSpec(
+            dtype=torch.uint8,
+            qscheme=(torch.per_tensor_symmetric),
+            ch_axis=0,
+            observer_or_fake_quant_ctr=act_observer.with_args(**extra_args),
+        )
+    else:
+        act_quantization_spec = QuantizationSpec(
+            dtype=torch.uint8,
+            quant_min=torch.iinfo(torch.uint8).min,
+            quant_max=torch.iinfo(torch.uint8).max,
+            qscheme=(torch.per_tensor_affine),
+            observer_or_fake_quant_ctr=act_observer.with_args(**extra_args),
+        )
 
     weight_quantization_spec = QuantizationSpec(
         dtype=torch.int8,

--- a/backends/qualcomm/runtime/QnnManager.h
+++ b/backends/qualcomm/runtime/QnnManager.h
@@ -38,6 +38,9 @@ class QnnManager {
   // graph name will be obtained from the binary.
   executorch::runtime::Error InitContext(
       std::optional<std::vector<std::string>> graph_names = std::nullopt);
+  // This function only initialize the context cache to get spill fill buffer
+  // size
+  executorch::runtime::Error InitContextCache();
   executorch::runtime::Error AllocateTensor(const std::string& graph_name);
   executorch::runtime::Error AllocateTensor(
       const std::string& graph_name,

--- a/backends/qualcomm/runtime/backends/QnnBackendFactory.cpp
+++ b/backends/qualcomm/runtime/backends/QnnBackendFactory.cpp
@@ -52,6 +52,9 @@ std::unique_ptr<BackendConfigParameters> QnnBackendFactory::Create(
         QNN_EXECUTORCH_LOG_INFO(
             "use_fold_relu in htp_options: %d", htp_options->use_fold_relu());
         QNN_EXECUTORCH_LOG_INFO(
+            "use_slc_allocator in htp_options: %d",
+            htp_options->use_slc_allocator());
+        QNN_EXECUTORCH_LOG_INFO(
             "use_multi_contexts in htp_options: %d",
             htp_options->use_multi_contexts());
         QNN_EXECUTORCH_LOG_INFO(

--- a/backends/qualcomm/runtime/backends/htp/HtpGraphCustomConfig.cpp
+++ b/backends/qualcomm/runtime/backends/htp/HtpGraphCustomConfig.cpp
@@ -70,6 +70,14 @@ HtpGraphCustomConfig::CreateGraphCustomConfigCommon(
       htp_options_->use_dlbc() ? 1.0 : 0.0;
   ret.push_back(static_cast<QnnGraph_CustomConfig_t>(p_custom_config));
 
+  p_custom_config = AllocGraphCustomConfig();
+  p_custom_config->option = QNN_HTP_GRAPH_CONFIG_OPTION_OPTIMIZATION;
+  p_custom_config->optimizationOption.type =
+      QNN_HTP_GRAPH_OPTIMIZATION_TYPE_ENABLE_SLC_ALLOCATOR;
+  p_custom_config->optimizationOption.floatValue =
+      htp_options_->use_slc_allocator() ? 1.0 : 0.0;
+  ret.push_back(static_cast<QnnGraph_CustomConfig_t>(p_custom_config));
+
   return ret;
 }
 } // namespace qnn

--- a/backends/qualcomm/serialization/qc_compiler_spec.fbs
+++ b/backends/qualcomm/serialization/qc_compiler_spec.fbs
@@ -181,6 +181,11 @@ table QnnExecuTorchHtpBackendOptions {
   /// When multiple graphs appear inside the same context,
   /// weights could be reused across all graphs.
   use_weight_sharing:bool;
+
+  /// Allows user to enable the usage of the System Level Cache Allocator for a given graph. 
+  /// It will help the by reducing overall bandwith on the use case.
+  /// The feature is only supported by specific SOCs.
+  use_slc_allocator:bool;
 }
 
 /// Logging level of the delegate and QNN backend.

--- a/backends/qualcomm/serialization/qc_schema.py
+++ b/backends/qualcomm/serialization/qc_schema.py
@@ -166,6 +166,7 @@ class QnnExecuTorchHtpBackendOptions:
     use_fold_relu: bool = True
     use_multi_contexts: bool = False
     use_weight_sharing: bool = False
+    use_slc_allocator: bool = False
 
 
 @unique

--- a/examples/qualcomm/oss_scripts/llama/eval_llama_qnn.py
+++ b/examples/qualcomm/oss_scripts/llama/eval_llama_qnn.py
@@ -418,7 +418,7 @@ def eval_llama_with_attention_sink(args):
             layer.feed_forward.prepare_feedfoward_conv()
     model = convert_linear_to_conv2d(model)
 
-    _, atten_mask, _, k_caches, v_caches = model.get_example_inputs(use_kv_cache=True)
+    _, atten_mask, _, k_caches, v_caches = model.get_example_inputs()
     eval_data = load_dataset("wikitext", "wikitext-2-raw-v1", split="test")
 
     neg_log_likelihoods = []

--- a/examples/qualcomm/oss_scripts/llama/wrappers/llm_wrappers.py
+++ b/examples/qualcomm/oss_scripts/llama/wrappers/llm_wrappers.py
@@ -824,9 +824,9 @@ class HybridTextDecoder(Component):
             skip_node_op_set={"llama.fallback.default"},
         )
 
-        if self.config.num_sharding > 1 and self.control_args.model_mode == "kv":
-            # weight-sharing based context binaries cannot be opened in x86 host
-            update_spill_fill_size(edge_prog_mgr.exported_program("kv_forward"))
+        if self.config.num_sharding > 1:
+            for graph_name in graph_names:
+                update_spill_fill_size(edge_prog_mgr.exported_program(graph_name))
 
         if self.control_args.verbose:
             for ep in edge_prog_mgr._edge_programs.values():


### PR DESCRIPTION
Summary:
- Support SLC allocator feature setting
- Support spill-fill buffer for hybrid mode
- Fixed redundant convert_op in 8w8a quantization config

Test Plan:
- Check  the debug log to confirm if the SLC allocator is enabled.
```
 I [Qnn ExecuTorch]: QnnDsp <V> SLC_ALLOCATOR is set to 1 for graph 0
```
- Check the debug log whether the spill-fill buffer is configured for the LLM in hybrid mode.
```
 python examples/qualcomm/oss_scripts/llama/llama.py -b build-android -H ${HOST} -s ${DEVICE} -m SM8750 --temperature 0 --model_mode hybrid --max_seq_len 128 --prefill_ar_len 32 --decoder_model smollm2_135m --prompt "I would like to learn python, could you teach me with a simple example?"  --artifact {ARTIFACTS}
```
