### PR TITLE
Arm backend: Add FP16 support to operators pt.4-6

### DIFF
--- a/backends/arm/_passes/rewrite_matmul.py
+++ b/backends/arm/_passes/rewrite_matmul.py
@@ -92,17 +92,17 @@ class RewriteMatmulPass(ArmPass):
                         TosaSpecialDtype.INT48
                     )
             elif (
-                x1_fake_tensor.dtype == torch.bfloat16
-                and x2_fake_tensor.dtype == torch.bfloat16
-                and output_fake_tensor.dtype != torch.bfloat16
+                x1_fake_tensor.dtype in [torch.float16, torch.bfloat16]
+                and x2_fake_tensor.dtype in [torch.float16, torch.bfloat16]
+                and output_fake_tensor.dtype not in [torch.float16, torch.bfloat16]
             ):
-                # A TOSA BF16 MATMUL outputs FP32 wheras pytorch outputs BF16.
-                # Cast back to BF16 to get matching semantics.
+                # A TOSA BF16/FP16 MATMUL outputs FP32 whereas pytorch outputs BF16/FP16.
+                # Cast back to BF16/FP16 to get matching semantics.
                 with graph_module.graph.inserting_after(tosa_matmul_node):
                     cast_node = create_node(
                         graph_module.graph,
                         op_target=exir_ops.edge.dim_order_ops._to_dim_order_copy.default,
-                        kwargs={"dtype": torch.bfloat16},
+                        kwargs={"dtype": x1_fake_tensor.dtype},
                         from_node=tosa_matmul_node,
                     )
                     tosa_matmul_node.replace_all_uses_with(cast_node)

--- a/backends/arm/operators/op_ge.py
+++ b/backends/arm/operators/op_ge.py
@@ -41,7 +41,7 @@ class GreaterEqualVisitor(NodeVisitor):
         validate_valid_dtype(
             self.target,
             inputs,
-            [ts.DType.INT32, ts.DType.FP32, ts.DType.BF16],
+            [ts.DType.INT32, ts.DType.FP32, ts.DType.BF16, ts.DType.FP16],
             self.tosa_spec,
         )
         validate_valid_dtype(self.target, output, ts.DType.BOOL, self.tosa_spec)

--- a/backends/arm/operators/op_gt.py
+++ b/backends/arm/operators/op_gt.py
@@ -41,7 +41,7 @@ class GreaterThanVisitor(NodeVisitor):
         validate_valid_dtype(
             self.target,
             inputs,
-            [ts.DType.INT32, ts.DType.FP32, ts.DType.BF16],
+            [ts.DType.INT32, ts.DType.FP32, ts.DType.BF16, ts.DType.FP16],
             self.tosa_spec,
         )
         validate_valid_dtype(self.target, output, ts.DType.BOOL, self.tosa_spec)

--- a/backends/arm/operators/op_log.py
+++ b/backends/arm/operators/op_log.py
@@ -43,7 +43,7 @@ class LogVisitor(NodeVisitor):
         validate_valid_dtype(
             self.target,
             [*inputs, output],
-            [ts.DType.FP32, ts.DType.BF16],
+            [ts.DType.FP32, ts.DType.FP16, ts.DType.BF16],
             self.tosa_spec,
         )
         attr = ts.TosaSerializerAttribute()

--- a/backends/arm/operators/op_max_pool2d.py
+++ b/backends/arm/operators/op_max_pool2d.py
@@ -38,7 +38,7 @@ class MaxPool2dVisitor(NodeVisitor):
     ) -> None:
         validate_num_inputs(self.target, inputs, [3, 4, 5, 6])
         validate_same_dtype(self.target, [inputs[0], output], ts)
-        supported_dtypes = [ts.DType.INT8, ts.DType.FP32, ts.DType.BF16]
+        supported_dtypes = [ts.DType.INT8, ts.DType.FP16, ts.DType.FP32, ts.DType.BF16]
         if self.tosa_spec.support_extension("int16"):
             supported_dtypes.append(ts.DType.INT16)
         validate_valid_dtype(

--- a/backends/arm/operators/op_mul.py
+++ b/backends/arm/operators/op_mul.py
@@ -44,6 +44,7 @@ class MulVisitor(NodeVisitor):
                 ts.DType.INT32,
                 ts.DType.FP32,
                 ts.DType.BF16,
+                ts.DType.FP16,
             ],
             self.tosa_spec,
         )

--- a/backends/arm/operators/op_reciprocal.py
+++ b/backends/arm/operators/op_reciprocal.py
@@ -44,7 +44,7 @@ class ReciprocalVisitor(NodeVisitor):
         validate_valid_dtype(
             self.target,
             [*inputs, output],
-            [ts.DType.FP32, ts.DType.BF16],
+            [ts.DType.FP16, ts.DType.FP32, ts.DType.BF16],
             self.tosa_spec,
         )
         attr = ts.TosaSerializerAttribute()

--- a/backends/arm/operators/op_rsqrt.py
+++ b/backends/arm/operators/op_rsqrt.py
@@ -44,7 +44,7 @@ class RsqrtVisitor(NodeVisitor):
         validate_valid_dtype(
             self.target,
             [*inputs, output],
-            [ts.DType.FP32, ts.DType.BF16],
+            [ts.DType.FP16, ts.DType.FP32, ts.DType.BF16],
             self.tosa_spec,
         )
         attr = ts.TosaSerializerAttribute()

--- a/backends/arm/operators/op_sigmoid.py
+++ b/backends/arm/operators/op_sigmoid.py
@@ -43,7 +43,7 @@ class SigmoidVisitor(NodeVisitor):
         validate_valid_dtype(
             self.target,
             [*inputs, output],
-            [ts.DType.FP32, ts.DType.BF16],
+            [ts.DType.FP16, ts.DType.FP32, ts.DType.BF16],
             self.tosa_spec,
         )
         attr = ts.TosaSerializerAttribute()

--- a/backends/arm/operators/op_tosa_matmul.py
+++ b/backends/arm/operators/op_tosa_matmul.py
@@ -44,24 +44,23 @@ class MatmulVisitor(NodeVisitor):
         """Define the TOSA ``MATMUL`` operator."""
         validate_num_inputs(self.target, inputs, 2)
         validate_same_dtype(self.target, [*inputs], ts)
-        supported_input_dtypes = [ts.DType.INT8, ts.DType.INT32, ts.DType.FP32]
-        if self.tosa_spec.support_extension("bf16"):
-            supported_input_dtypes.append(ts.DType.BF16)
-        if self.tosa_spec.support_extension("int16"):
-            supported_input_dtypes.append(ts.DType.INT16)
         validate_valid_dtype(
             self.target,
             [*inputs],
-            supported_input_dtypes,
+            [
+                ts.DType.INT8,
+                ts.DType.INT16,
+                ts.DType.INT32,
+                ts.DType.FP16,
+                ts.DType.FP32,
+                ts.DType.BF16,
+            ],
             self.tosa_spec,
         )
-        supported_output_dtypes = [ts.DType.INT32, ts.DType.FP32]
-        if self.tosa_spec.support_extension("int16"):
-            supported_output_dtypes.append(ts.DType.INT48)
         validate_valid_dtype(
             self.target,
             [output],
-            supported_output_dtypes,
+            [ts.DType.INT32, ts.DType.INT48, ts.DType.FP32],
             self.tosa_spec,
         )
 

--- a/backends/arm/operators/op_view.py
+++ b/backends/arm/operators/op_view.py
@@ -45,6 +45,7 @@ class ViewVisitor(NodeVisitor):
                 ts.DType.INT8,
                 ts.DType.INT16,
                 ts.DType.INT32,
+                ts.DType.FP16,
                 ts.DType.FP32,
                 ts.DType.BF16,
                 ts.DType.BOOL,

--- a/backends/arm/test/ops/test_alias_copy.py
+++ b/backends/arm/test/ops/test_alias_copy.py
@@ -39,6 +39,9 @@ class AliasCopy(torch.nn.Module):
     test_data_bf16 = {
         "3d_rand_bf16": lambda: (torch.rand(3, 5, 2, dtype=torch.bfloat16),)
     }
+    test_data_fp16 = {
+        "3d_rand_fp16": lambda: (torch.rand(3, 5, 2, dtype=torch.float16),),
+    }
 
     def __init__(self):
         super().__init__()
@@ -49,7 +52,10 @@ class AliasCopy(torch.nn.Module):
         )  # Multiply by one to make sure it is partitioned.
 
 
-@common.parametrize("test_data", AliasCopy.test_data | AliasCopy.test_data_bf16)
+@common.parametrize(
+    "test_data",
+    AliasCopy.test_data | AliasCopy.test_data_bf16 | AliasCopy.test_data_fp16,
+)
 def test_alias_tosa_FP(test_data: input_t1):
     TosaPipelineFP[input_t1](
         AliasCopy(),
@@ -92,7 +98,7 @@ def test_alias_u85_INT(test_data: input_t1):
     ).run()
 
 
-@common.parametrize("test_data", AliasCopy.test_data)
+@common.parametrize("test_data", AliasCopy.test_data | AliasCopy.test_data_fp16)
 @common.SkipIfNoModelConverter
 def test_alias_vgf_no_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](

--- a/backends/arm/test/ops/test_ge.py
+++ b/backends/arm/test/ops/test_ge.py
@@ -68,7 +68,16 @@ test_data_tensor = {
     "ge_tensor_rank3_randn": lambda: op_ge_tensor_rank3_randn,
     "ge_tensor_rank4_randn": lambda: op_ge_tensor_rank4_randn,
 }
-
+test_data_tensor_fp16 = {
+    "ge_tensor_rank2_rand_fp16": lambda: GreaterEqual(
+        torch.rand(4, 5, dtype=torch.float16),
+        torch.rand(1, 5, dtype=torch.float16),
+    ),
+    "ge_tensor_rank4_randn_fp16": lambda: GreaterEqual(
+        torch.randn(2, 3, 4, 2, dtype=torch.float16),
+        torch.randn(2, 3, 4, 1, dtype=torch.float16),
+    ),
+}
 test_data_tensor_bf16 = {
     "ge_tensor_rank2_rand_bf16": lambda: GreaterEqual(
         torch.rand(4, 5, dtype=torch.bfloat16),
@@ -86,7 +95,14 @@ test_data_scalar = {
     "ge_scalar_rank3_randn": lambda: op_ge_scalar_rank3_randn,
     "ge_scalar_rank4_randn": lambda: op_ge_scalar_rank4_randn,
 }
-
+test_data_scalar_fp16 = {
+    "ge_scalar_rank2_rand_fp16": lambda: GreaterEqual(
+        torch.rand(4, 5, dtype=torch.float16), 0.2
+    ),
+    "ge_scalar_rank3_randn_fp16": lambda: GreaterEqual(
+        torch.randn(2, 3, 4, dtype=torch.float16), -0.1
+    ),
+}
 test_data_scalar_bf16 = {
     "ge_scalar_rank2_rand_bf16": lambda: GreaterEqual(
         torch.rand(4, 5, dtype=torch.bfloat16), 0.2
@@ -97,7 +113,9 @@ test_data_scalar_bf16 = {
 }
 
 
-@common.parametrize("test_module", test_data_tensor | test_data_tensor_bf16)
+@common.parametrize(
+    "test_module", test_data_tensor | test_data_tensor_bf16 | test_data_tensor_fp16
+)
 def test_ge_tensor_tosa_FP(test_module):
     pipeline = TosaPipelineFP[input_t](
         test_module(),
@@ -109,7 +127,9 @@ def test_ge_tensor_tosa_FP(test_module):
     pipeline.run()
 
 
-@common.parametrize("test_module", test_data_scalar | test_data_scalar_bf16)
+@common.parametrize(
+    "test_module", test_data_scalar | test_data_scalar_bf16 | test_data_scalar_fp16
+)
 def test_ge_scalar_tosa_FP(test_module):
     pipeline = TosaPipelineFP[input_t](
         test_module(),
@@ -262,7 +282,7 @@ def test_ge_scalar_16a8w_u85_INT(test_module):
     pipeline.run()
 
 
-@common.parametrize("test_module", test_data_tensor)
+@common.parametrize("test_module", test_data_tensor | test_data_tensor_fp16)
 @common.SkipIfNoModelConverter
 def test_ge_tensor_vgf_no_quant(test_module):
     pipeline = VgfPipeline[input_t](
@@ -288,7 +308,7 @@ def test_ge_tensor_vgf_quant(test_module):
     pipeline.run()
 
 
-@common.parametrize("test_module", test_data_scalar)
+@common.parametrize("test_module", test_data_scalar | test_data_scalar_fp16)
 @common.SkipIfNoModelConverter
 def test_ge_scalar_vgf_no_quant(test_module):
     pipeline = VgfPipeline[input_t](

--- a/backends/arm/test/ops/test_gt.py
+++ b/backends/arm/test/ops/test_gt.py
@@ -69,7 +69,16 @@ test_data_tensor = {
     "gt_tensor_rank3_randn": lambda: op_gt_tensor_rank3_randn,
     "gt_tensor_rank4_randn": lambda: op_gt_tensor_rank4_randn,
 }
-
+test_data_tensor_fp16 = {
+    "gt_tensor_rank2_rand_fp16": lambda: Greater(
+        torch.rand(4, 5, dtype=torch.float16),
+        torch.rand(1, 5, dtype=torch.float16),
+    ),
+    "gt_tensor_rank3_randn_fp16": lambda: Greater(
+        torch.randn(2, 3, 4, dtype=torch.float16),
+        torch.randn(2, 3, 4, dtype=torch.float16),
+    ),
+}
 test_data_tensor_bf16 = {
     "gt_tensor_rank2_rand_bf16": lambda: Greater(
         torch.rand(4, 5, dtype=torch.bfloat16),
@@ -87,7 +96,14 @@ test_data_scalar = {
     "gt_scalar_rank3_randn": lambda: op_gt_scalar_rank3_randn,
     "gt_scalar_rank4_randn": lambda: op_gt_scalar_rank4_randn,
 }
-
+test_data_scalar_fp16 = {
+    "gt_scalar_rank2_rand_fp16": lambda: Greater(
+        torch.rand(4, 5, dtype=torch.float16), 0.2
+    ),
+    "gt_scalar_rank3_randn_fp16": lambda: Greater(
+        torch.randn(2, 3, 4, dtype=torch.float16), -0.1
+    ),
+}
 test_data_scalar_bf16 = {
     "gt_scalar_rank2_rand_bf16": lambda: Greater(
         torch.rand(4, 5, dtype=torch.bfloat16), 0.2
@@ -98,7 +114,9 @@ test_data_scalar_bf16 = {
 }
 
 
-@common.parametrize("test_module", test_data_tensor | test_data_tensor_bf16)
+@common.parametrize(
+    "test_module", test_data_tensor | test_data_tensor_bf16 | test_data_tensor_fp16
+)
 def test_gt_tensor_tosa_FP(test_module):
     pipeline = TosaPipelineFP[input_t](
         test_module(),
@@ -110,7 +128,9 @@ def test_gt_tensor_tosa_FP(test_module):
     pipeline.run()
 
 
-@common.parametrize("test_module", test_data_scalar | test_data_scalar_bf16)
+@common.parametrize(
+    "test_module", test_data_scalar | test_data_scalar_bf16 | test_data_scalar_fp16
+)
 def test_gt_scalar_tosa_FP(test_module):
     pipeline = TosaPipelineFP[input_t](
         test_module(),
@@ -263,7 +283,7 @@ def test_gt_scalar_16a8w_u85_INT(test_module):
     pipeline.run()
 
 
-@common.parametrize("test_module", test_data_tensor)
+@common.parametrize("test_module", test_data_tensor | test_data_tensor_fp16)
 @common.SkipIfNoModelConverter
 def test_gt_tensor_vgf_no_quant(test_module):
     pipeline = VgfPipeline[input_t](
@@ -276,7 +296,7 @@ def test_gt_tensor_vgf_no_quant(test_module):
     pipeline.run()
 
 
-@common.parametrize("test_module", test_data_scalar)
+@common.parametrize("test_module", test_data_scalar | test_data_scalar_fp16)
 @common.SkipIfNoModelConverter
 def test_gt_scalar_vgf_no_quant(test_module):
     pipeline = VgfPipeline[input_t](

--- a/backends/arm/test/ops/test_index_tensor.py
+++ b/backends/arm/test/ops/test_index_tensor.py
@@ -327,6 +327,12 @@ class IndexTensor(torch.nn.Module):
             (torch.arange(2, dtype=torch.int32),),
         ),
     }
+    test_data_fp16: dict[input_params] = {
+        "test_2d_1_idx_fp16": (
+            torch.rand(3, 4, dtype=torch.float16),
+            (torch.arange(2, dtype=torch.int32),),
+        ),
+    }
 
     # xfail - None (unsqueeze) unsupported
     test_data_none: dict[input_params] = {
@@ -378,7 +384,10 @@ class IndexTensor(torch.nn.Module):
         return input_[indices]
 
 
-@common.parametrize("test_data", IndexTensor.test_data | IndexTensor.test_data_bf16)
+@common.parametrize(
+    "test_data",
+    IndexTensor.test_data | IndexTensor.test_data_bf16 | IndexTensor.test_data_fp16,
+)
 def test_index_tensor_tosa_FP(test_data: input_params):
     test_input = test_data
     with torch.no_grad():

--- a/backends/arm/test/ops/test_matmul.py
+++ b/backends/arm/test/ops/test_matmul.py
@@ -22,44 +22,127 @@ exir_op_mm = "executorch_exir_dialects_edge__ops_aten_matmul_default"
 
 input_t = Tuple[torch.Tensor, ...]
 input_factory_t = Callable[[], input_t]
-test_case_t = Tuple[torch.nn.Module, input_factory_t]
+test_case_t = Callable[[], Tuple[torch.nn.Module, input_factory_t]]
 
 
 class MatMulDoubleInput(torch.nn.Module):
     test_data = {
-        "randn_rand_1d_1d": lambda: (torch.randn(5), torch.rand(5)),
-        "randn_rand_2d_2d": lambda: ((1 << 30) * torch.randn(5, 5), torch.rand(5, 2)),
-        "randn_rand_2d_1d": lambda: (torch.randn(5, 5), torch.rand(5)),
-        "randn_rand_1d_2d": lambda: (torch.randn(5), torch.rand(5, 2)),
-        "randn_rand_3d_3d": lambda: (torch.randn(2, 3, 5), torch.rand(2, 5, 2)),
-        "randn_rand_3d_1d": lambda: (torch.randn(2, 3, 5), torch.rand(5)),
-        "randn_rand_3d_2d": lambda: (
-            (1 << 30) * torch.randn(2, 3, 5),
-            torch.rand(5, 2),
+        "double_input_randn_rand_1d_1d": lambda: (
+            MatMulDoubleInput(),
+            lambda: (torch.randn(5), torch.rand(5)),
         ),
-        "randn_rand_1d_3d": lambda: (torch.randn(5), torch.rand(2, 5, 3)),
-        "randn_rand_2d_3d": lambda: (torch.randn(3, 5), torch.rand(2, 5, 3)),
-        "randn_rand_4d_4d": lambda: (torch.randn(1, 2, 3, 5), torch.rand(1, 2, 5, 2)),
-        "randn_rand_4d_1d": lambda: (torch.randn(1, 2, 3, 5), torch.rand(5)),
-        "randn_rand_4d_2d": lambda: (torch.randn(1, 2, 3, 5), torch.rand(5, 3)),
-        "randn_rand_4d_3d": lambda: (
-            (1 << 30) * torch.randn(1, 2, 3, 5),
-            torch.rand(2, 5, 3),
-        ),
-        "randn_rand_3d_4d": lambda: (torch.randn(4, 3, 5), torch.rand(2, 4, 5, 3)),
-        "randn_rand_2d_4d": lambda: (torch.randn(3, 5), torch.rand(2, 4, 5, 3)),
-        "randn_rand_1d_4d": lambda: (
-            torch.randn(
-                5,
+        "double_input_randn_rand_2d_2d": lambda: (
+            MatMulDoubleInput(),
+            lambda: (
+                (1 << 30) * torch.randn(5, 5),
+                torch.rand(5, 2),
             ),
-            torch.rand(2, 4, 5, 3),
+        ),
+        "double_input_randn_rand_2d_1d": lambda: (
+            MatMulDoubleInput(),
+            lambda: (torch.randn(5, 5), torch.rand(5)),
+        ),
+        "double_input_randn_rand_1d_2d": lambda: (
+            MatMulDoubleInput(),
+            lambda: (torch.randn(5), torch.rand(5, 2)),
+        ),
+        "double_input_randn_rand_3d_3d": lambda: (
+            MatMulDoubleInput(),
+            lambda: (
+                torch.randn(2, 3, 5),
+                torch.rand(2, 5, 2),
+            ),
+        ),
+        "double_input_randn_rand_3d_1d": lambda: (
+            MatMulDoubleInput(),
+            lambda: (torch.randn(2, 3, 5), torch.rand(5)),
+        ),
+        "double_input_randn_rand_3d_2d": lambda: (
+            MatMulDoubleInput(),
+            lambda: (
+                (1 << 30) * torch.randn(2, 3, 5),
+                torch.rand(5, 2),
+            ),
+        ),
+        "double_input_randn_rand_1d_3d": lambda: (
+            MatMulDoubleInput(),
+            lambda: (torch.randn(5), torch.rand(2, 5, 3)),
+        ),
+        "double_input_randn_rand_2d_3d": lambda: (
+            MatMulDoubleInput(),
+            lambda: (
+                torch.randn(3, 5),
+                torch.rand(2, 5, 3),
+            ),
+        ),
+        "double_input_randn_rand_4d_4d": lambda: (
+            MatMulDoubleInput(),
+            lambda: (
+                torch.randn(1, 2, 3, 5),
+                torch.rand(1, 2, 5, 2),
+            ),
+        ),
+        "double_input_randn_rand_4d_1d": lambda: (
+            MatMulDoubleInput(),
+            lambda: (
+                torch.randn(1, 2, 3, 5),
+                torch.rand(5),
+            ),
+        ),
+        "double_input_randn_rand_4d_2d": lambda: (
+            MatMulDoubleInput(),
+            lambda: (
+                torch.randn(1, 2, 3, 5),
+                torch.rand(5, 3),
+            ),
+        ),
+        "double_input_randn_rand_4d_3d": lambda: (
+            MatMulDoubleInput(),
+            lambda: (
+                (1 << 30) * torch.randn(1, 2, 3, 5),
+                torch.rand(2, 5, 3),
+            ),
+        ),
+        "double_input_randn_rand_3d_4d": lambda: (
+            MatMulDoubleInput(),
+            lambda: (
+                torch.randn(4, 3, 5),
+                torch.rand(2, 4, 5, 3),
+            ),
+        ),
+        "double_input_randn_rand_2d_4d": lambda: (
+            MatMulDoubleInput(),
+            lambda: (
+                torch.randn(3, 5),
+                torch.rand(2, 4, 5, 3),
+            ),
+        ),
+        "double_input_randn_rand_1d_4d": lambda: (
+            MatMulDoubleInput(),
+            lambda: (
+                torch.randn(5),
+                torch.rand(2, 4, 5, 3),
+            ),
+        ),
+    }
+
+    test_data_fp16 = {
+        "double_input_rand_rand_2d_fp16": lambda: (
+            MatMulDoubleInput(),
+            lambda: (
+                torch.rand(4, 4, dtype=torch.float16),
+                torch.rand(4, 3, dtype=torch.float16),
+            ),
         ),
     }
 
     test_data_bf16 = {
-        "rand_rand_2d_bf16": lambda: (
-            torch.rand(4, 4, dtype=torch.bfloat16),
-            torch.rand(4, 3, dtype=torch.bfloat16),
+        "double_input_rand_rand_2d_bf16": lambda: (
+            MatMulDoubleInput(),
+            lambda: (
+                torch.rand(4, 4, dtype=torch.bfloat16),
+                torch.rand(4, 3, dtype=torch.bfloat16),
+            ),
         ),
     }
 
@@ -69,14 +152,36 @@ class MatMulDoubleInput(torch.nn.Module):
 
 class MatMulSingleInput(torch.nn.Module):
     test_data = {
-        "randn_1d": lambda: (torch.randn(5),),
-        "randn_2d": lambda: (torch.randn(5, 5),),
-        "randn_3d": lambda: (torch.randn(2, 5, 5),),
-        "randn_4d": lambda: (torch.randn(1, 2, 5, 5),),
+        "single_input_randn_1d": lambda: (
+            MatMulSingleInput(),
+            lambda: (torch.randn(5),),
+        ),
+        "single_input_randn_2d": lambda: (
+            MatMulSingleInput(),
+            lambda: (torch.randn(5, 5),),
+        ),
+        "single_input_randn_3d": lambda: (
+            MatMulSingleInput(),
+            lambda: (torch.randn(2, 5, 5),),
+        ),
+        "single_input_randn_4d": lambda: (
+            MatMulSingleInput(),
+            lambda: (torch.randn(1, 2, 5, 5),),
+        ),
+    }
+
+    test_data_fp16 = {
+        "single_input_rand_2d_fp16": lambda: (
+            MatMulSingleInput(),
+            lambda: (torch.rand(4, 4, dtype=torch.float16),),
+        ),
     }
 
     test_data_bf16 = {
-        "rand_2d_bf16": lambda: (torch.rand(4, 4, dtype=torch.bfloat16),),
+        "single_input_rand_2d_bf16": lambda: (
+            MatMulSingleInput(),
+            lambda: (torch.rand(4, 4, dtype=torch.bfloat16),),
+        ),
     }
 
     def forward(self, x: torch.Tensor):
@@ -85,28 +190,51 @@ class MatMulSingleInput(torch.nn.Module):
 
 class MatMulCombo(torch.nn.Module):
     test_data = {
-        "rand_randn_rand_2d": lambda: (
-            torch.rand(5, 5),
-            10e8 * torch.randn(5, 2),
-            torch.rand(2, 5),
+        "combo_rand_randn_rand_2d": lambda: (
+            MatMulCombo(),
+            lambda: (
+                torch.rand(5, 5),
+                10e8 * torch.randn(5, 2),
+                torch.rand(2, 5),
+            ),
         ),
-        "rand_randn_rand_3d": lambda: (
-            torch.rand(2, 5, 5),
-            10e12 * torch.randn(2, 5, 2),
-            torch.rand(2, 2, 5),
+        "combo_rand_randn_rand_3d": lambda: (
+            MatMulCombo(),
+            lambda: (
+                torch.rand(2, 5, 5),
+                10e12 * torch.randn(2, 5, 2),
+                torch.rand(2, 2, 5),
+            ),
         ),
-        "rand_randn_rand_4d": lambda: (
-            torch.rand(1, 2, 5, 5),
-            torch.randn(1, 2, 5, 2),
-            torch.rand(1, 2, 2, 5),
+        "combo_rand_randn_rand_4d": lambda: (
+            MatMulCombo(),
+            lambda: (
+                torch.rand(1, 2, 5, 5),
+                torch.randn(1, 2, 5, 2),
+                torch.rand(1, 2, 2, 5),
+            ),
+        ),
+    }
+
+    test_data_fp16 = {
+        "combo_rand_rand_rand_2d_fp16": lambda: (
+            MatMulCombo(),
+            lambda: (
+                torch.rand(4, 4, dtype=torch.float16),
+                torch.rand(4, 3, dtype=torch.float16),
+                torch.rand(3, 4, dtype=torch.float16),
+            ),
         ),
     }
 
     test_data_bf16 = {
-        "rand_rand_rand_2d_bf16": lambda: (
-            torch.rand(4, 4, dtype=torch.bfloat16),
-            torch.rand(4, 3, dtype=torch.bfloat16),
-            torch.rand(3, 4, dtype=torch.bfloat16),
+        "combo_rand_rand_rand_2d_bf16": lambda: (
+            MatMulCombo(),
+            lambda: (
+                torch.rand(4, 4, dtype=torch.bfloat16),
+                torch.rand(4, 3, dtype=torch.bfloat16),
+                torch.rand(3, 4, dtype=torch.bfloat16),
+            ),
         ),
     }
 
@@ -115,33 +243,18 @@ class MatMulCombo(torch.nn.Module):
         return torch.matmul(y1, x3)
 
 
-test_suite_double_input = {
-    f"double_input_{name}": (MatMulDoubleInput(), inputs)
-    for name, inputs in MatMulDoubleInput.test_data.items()
-}
-test_suite_bf16_double_input = {
-    f"double_input_bf16_{name}": (MatMulDoubleInput(), inputs)
-    for name, inputs in MatMulDoubleInput.test_data_bf16.items()
-}
-test_suite_single_input = {
-    f"single_input_{name}": (MatMulSingleInput(), inputs)
-    for name, inputs in MatMulSingleInput.test_data.items()
-}
-test_suite_bf16_single_input = {
-    f"single_input_bf16_{name}": (MatMulSingleInput(), inputs)
-    for name, inputs in MatMulSingleInput.test_data_bf16.items()
-}
-test_suite_combo = {
-    f"combo_{name}": (MatMulCombo(), inputs)
-    for name, inputs in MatMulCombo.test_data.items()
-}
-test_suite_bf16_combo = {
-    f"combo_bf16_{name}": (MatMulCombo(), inputs)
-    for name, inputs in MatMulCombo.test_data_bf16.items()
-}
-test_suite = test_suite_double_input | test_suite_single_input | test_suite_combo
+test_suite = (
+    MatMulDoubleInput.test_data | MatMulSingleInput.test_data | MatMulCombo.test_data
+)
+test_suite_fp16 = (
+    MatMulDoubleInput.test_data_fp16
+    | MatMulSingleInput.test_data_fp16
+    | MatMulCombo.test_data_fp16
+)
 test_suite_bf16 = (
-    test_suite_bf16_double_input | test_suite_bf16_single_input | test_suite_bf16_combo
+    MatMulDoubleInput.test_data_bf16
+    | MatMulSingleInput.test_data_bf16
+    | MatMulCombo.test_data_bf16
 )
 xfails = {
     "double_input_randn_rand_1d_1d": "aten.dot.default is not supported",
@@ -152,9 +265,9 @@ xfails = {
 }
 
 
-@common.parametrize("test_case", test_suite | test_suite_bf16)
+@common.parametrize("test_case", test_suite | test_suite_fp16 | test_suite_bf16)
 def test_matmul_tosa_FP(test_case: test_case_t):
-    model, inputs = test_case
+    model, inputs = test_case()
     pipeline = TosaPipelineFP[input_t](
         model, inputs(), aten_op_mm, exir_op_mm, tosa_extensions=["bf16"]
     )
@@ -163,7 +276,7 @@ def test_matmul_tosa_FP(test_case: test_case_t):
 
 @common.parametrize("test_case", test_suite, xfails=xfails)
 def test_matmul_tosa_INT(test_case: test_case_t):
-    model, inputs = test_case
+    model, inputs = test_case()
     pipeline = TosaPipelineINT[input_t](
         model,
         inputs(),
@@ -177,7 +290,7 @@ def test_matmul_tosa_INT(test_case: test_case_t):
 @common.parametrize("test_case", test_suite, xfails=xfails)
 @common.XfailIfNoCorstone300
 def test_matmul_u55_INT(test_case: test_case_t):
-    model, inputs = test_case
+    model, inputs = test_case()
     pipeline = EthosU55PipelineINT[input_t](
         model,
         inputs(),
@@ -190,7 +303,7 @@ def test_matmul_u55_INT(test_case: test_case_t):
 @common.parametrize("test_case", test_suite, xfails=xfails)
 @common.XfailIfNoCorstone320
 def test_matmul_u85_INT(test_case: test_case_t):
-    model, inputs = test_case
+    model, inputs = test_case()
     pipeline = EthosU85PipelineINT[input_t](
         model,
         inputs(),
@@ -200,10 +313,10 @@ def test_matmul_u85_INT(test_case: test_case_t):
     pipeline.run()
 
 
-@common.parametrize("test_case", test_suite)
+@common.parametrize("test_case", test_suite | test_suite_fp16)
 @common.SkipIfNoModelConverter
 def test_matmul_vgf_no_quant(test_case: test_case_t):
-    model, inputs = test_case
+    model, inputs = test_case()
     pipeline = VgfPipeline[input_t](
         model,
         inputs(),
@@ -217,7 +330,7 @@ def test_matmul_vgf_no_quant(test_case: test_case_t):
 @common.parametrize("test_case", test_suite, xfails=xfails)
 @common.SkipIfNoModelConverter
 def test_matmul_vgf_quant(test_case: test_case_t):
-    model, inputs = test_case
+    model, inputs = test_case()
     pipeline = VgfPipeline[input_t](
         model, inputs(), [], exir_op_mm, quantize=True, run_on_vulkan_runtime=False
     )
@@ -227,7 +340,7 @@ def test_matmul_vgf_quant(test_case: test_case_t):
 @common.parametrize("test_case", test_suite, xfails=xfails)
 def test_matmul_tosa_INT_a16w8(test_case: test_case_t):
     """Test matmul with 16A8W quantization for TOSA INT."""
-    model, inputs = test_case
+    model, inputs = test_case()
     pipeline = TosaPipelineINT[input_t](
         model,
         inputs(),
@@ -245,7 +358,7 @@ def test_matmul_tosa_INT_a16w8(test_case: test_case_t):
 @common.XfailIfNoCorstone300
 def test_matmul_u55_INT_a16w8(test_case: test_case_t):
     """Test matmul with 16A8W quantization on U55 (16-bit activations, 8-bit weights)"""
-    model, inputs = test_case
+    model, inputs = test_case()
     pipeline = EthosU55PipelineINT[input_t](
         model,
         inputs(),
@@ -260,7 +373,7 @@ def test_matmul_u55_INT_a16w8(test_case: test_case_t):
 @common.XfailIfNoCorstone320
 def test_matmul_u85_INT_a16w8(test_case: test_case_t):
     """Test matmul with 16A8W quantization on U85 (16-bit activations, 8-bit weights)"""
-    model, inputs = test_case
+    model, inputs = test_case()
     pipeline = EthosU85PipelineINT[input_t](
         model,
         inputs(),

--- a/backends/arm/test/ops/test_max_pool.py
+++ b/backends/arm/test/ops/test_max_pool.py
@@ -69,6 +69,10 @@ test_data_suite = {
     "randn": lambda: (torch.randn(5, 16, 50, 32), [4, 2, 0]),
 }
 
+test_data_suite_fp16 = {
+    "rand_fp16": lambda: (torch.rand(1, 8, 20, 20, dtype=torch.float16), [3, 2, 1]),
+}
+
 test_data_suite_bf16 = {
     "rand_bf16": lambda: (
         torch.rand(1, 8, 20, 20, dtype=torch.bfloat16),
@@ -135,7 +139,9 @@ class MaxPool2d(torch.nn.Module):
         return self.max_pool_2d(x)
 
 
-@common.parametrize("test_data", test_data_suite | test_data_suite_bf16)
+@common.parametrize(
+    "test_data", test_data_suite | test_data_suite_fp16 | test_data_suite_bf16
+)
 def test_max_pool2d_tosa_FP(test_data: torch.Tensor):
     test_data, model_params = test_data()
     pipeline = TosaPipelineFP[input_t1](
@@ -263,7 +269,7 @@ dilation_test_data = {
 
 
 @common.parametrize("test_data", test_data_suite_unsupported_dilation)
-def test_max_pool2d_dilation_not_supported(test_data):
+def test_max_pool2d_tosa_FP_not_delegated_with_dilation(test_data):
     """
     Test that dilation cases not supported by TOSA are rejected.
     """
@@ -311,7 +317,7 @@ def test_max_pool2d_tosa_INT_dilation(test_data):
 
 
 # VGF tests
-@common.parametrize("test_data", test_data_suite)
+@common.parametrize("test_data", test_data_suite | test_data_suite_fp16)
 @common.SkipIfNoModelConverter
 def test_max_pool2d_vgf_no_quant(test_data: torch.Tensor):
     test_data, model_params = test_data()

--- a/backends/arm/test/ops/test_mul.py
+++ b/backends/arm/test/ops/test_mul.py
@@ -90,6 +90,16 @@ test_data_suite_bf16 = {
     ),
 }
 
+test_data_suite_fp16 = {
+    "op_mul_rank2_rand_fp16": lambda: (
+        torch.rand(4, 5, dtype=torch.float16),
+        torch.rand(1, 5, dtype=torch.float16),
+    ),
+    "op_mul_rank3_randn_fp16": lambda: (
+        torch.randn(3, 2, 4, dtype=torch.float16),
+        torch.randn(1, 2, 4, dtype=torch.float16),
+    ),
+}
 
 test_data_suite_int32 = {
     # (test_name, input, other,) See torch.mul() for info
@@ -118,7 +128,9 @@ class Mul(torch.nn.Module):
         return input_ * other_
 
 
-@common.parametrize("test_data", test_data_suite | test_data_suite_bf16)
+@common.parametrize(
+    "test_data", test_data_suite | test_data_suite_bf16 | test_data_suite_fp16
+)
 def test_mul_tensor_tosa_FP(test_data: torch.Tensor):
     pipeline = TosaPipelineFP[input_t1](
         Mul(),
@@ -250,7 +262,10 @@ def test_mul_tensor_u85_INT_int32(test_data: torch.Tensor):
 
 @common.parametrize(
     "test_data",
-    test_data_suite | test_data_suite_2 | test_data_int32_without_broadcasting,
+    test_data_suite
+    | test_data_suite_fp16
+    | test_data_suite_2
+    | test_data_int32_without_broadcasting,
 )
 @common.SkipIfNoModelConverter
 def test_mul_tensor_vgf_no_quant(test_data: torch.Tensor):

--- a/backends/arm/test/ops/test_reciprocal.py
+++ b/backends/arm/test/ops/test_reciprocal.py
@@ -34,6 +34,10 @@ test_data_suite = {
     "op_reciprocal_rank4_large_randn": lambda: 200 * torch.randn(1, 10, 25, 20) + 1,
 }
 
+test_data_suite_fp16 = {
+    "op_reciprocal_rank2_fp16": lambda: torch.rand(3, 4, dtype=torch.float16),
+}
+
 test_data_suite_bf16 = {
     "op_reciprocal_rank2_bf16": lambda: torch.rand(3, 4, dtype=torch.bfloat16),
 }
@@ -45,7 +49,9 @@ class Reciprocal(torch.nn.Module):
         return input_.reciprocal()
 
 
-@common.parametrize("test_data", test_data_suite | test_data_suite_bf16)
+@common.parametrize(
+    "test_data", test_data_suite | test_data_suite_fp16 | test_data_suite_bf16
+)
 def test_reciprocal_tosa_FP(test_data: torch.Tensor):
     pipeline = TosaPipelineFP[input_t1](
         Reciprocal(),
@@ -93,7 +99,7 @@ def test_reciprocal_u85_INT(test_data: torch.Tensor):
     pipeline.run()
 
 
-@common.parametrize("test_data", test_data_suite)
+@common.parametrize("test_data", test_data_suite | test_data_suite_fp16)
 @common.SkipIfNoModelConverter
 def test_reciprocal_vgf_no_quant(test_data: torch.Tensor):
     pipeline = VgfPipeline[input_t1](

--- a/backends/arm/test/ops/test_rsqrt.py
+++ b/backends/arm/test/ops/test_rsqrt.py
@@ -31,6 +31,9 @@ class Rsqrt(torch.nn.Module):
         "rand_4d_2": lambda: (torch.rand(1, 5, 10, 20),),
         "rand_3d": lambda: (torch.rand(5, 10, 20),),
     }
+    test_parameters_fp16 = {
+        "rand_3d_fp16": lambda: (torch.rand(3, 4, 5, dtype=torch.float16),),
+    }
 
     test_parameters_bf16 = {
         "rand_3d_bf16": lambda: (torch.rand(3, 4, 5, dtype=torch.bfloat16),),
@@ -40,7 +43,10 @@ class Rsqrt(torch.nn.Module):
         return x.rsqrt()
 
 
-@common.parametrize("test_tensor", Rsqrt.test_parameters | Rsqrt.test_parameters_bf16)
+@common.parametrize(
+    "test_tensor",
+    Rsqrt.test_parameters | Rsqrt.test_parameters_fp16 | Rsqrt.test_parameters_bf16,
+)
 def test_rsqrt_tosa_FP(test_tensor: torch.Tensor):
     test_data = test_tensor()
     match test_data[0].dtype:
@@ -98,7 +104,7 @@ def test_rsqrt_u85_INT(test_tensor: torch.Tensor):
     pipeline.run()
 
 
-@common.parametrize("test_tensor", Rsqrt.test_parameters)
+@common.parametrize("test_tensor", Rsqrt.test_parameters | Rsqrt.test_parameters_fp16)
 @common.SkipIfNoModelConverter
 def test_rsqrt_vgf_no_quant(test_tensor: torch.Tensor):
     pipeline = VgfPipeline[input_t1](

--- a/backends/arm/test/ops/test_sigmoid.py
+++ b/backends/arm/test/ops/test_sigmoid.py
@@ -35,6 +35,9 @@ test_data_suite = {
     "randn_neg": lambda: torch.randn(10) - 10,
     "ramp": lambda: torch.arange(-16, 16, 0.2),
 }
+test_data_suite_fp16 = {
+    "rand_fp16": lambda: torch.rand(4, 4, dtype=torch.float16) - 0.2,
+}
 
 test_data_suite_bf16 = {
     "rand_bf16": lambda: torch.rand(4, 4, dtype=torch.bfloat16) - 0.2,
@@ -77,7 +80,9 @@ class SigmoidAddSigmoid(torch.nn.Module):
         return self.sigmoid((self.sigmoid(y) + self.sigmoid(x)))
 
 
-@common.parametrize("test_data", test_data_suite | test_data_suite_bf16)
+@common.parametrize(
+    "test_data", test_data_suite | test_data_suite_fp16 | test_data_suite_bf16
+)
 def test_sigmoid_tosa_FP(test_data: torch.Tensor):
     TosaPipelineFP[input_t1](
         Sigmoid(),
@@ -171,7 +176,7 @@ def test_sigmoid_u85_INT(test_data: Tuple):
     pipeline.run()
 
 
-@common.parametrize("test_data", test_data_suite)
+@common.parametrize("test_data", test_data_suite | test_data_suite_fp16)
 @common.SkipIfNoModelConverter
 def test_sigmoid_vgf_no_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](


### PR DESCRIPTION
Add FP16 support for operators:
 - ge
 - gt
 - alias_copy
 - index_tensor
 - identity
 - mul
 - matmul
 - log
 - max_pool2d
 - view
 - pow
 - reciprocal
 - rsqrt
 - sigmoid

Update op tests to cover the new datatype.

The index_tensor node visitor (in op_index_tensor.py) was missing dtype
validation. Add such validation while including the new fp16 dtype.

Clean up defining of test suites in test_matmul.py.

cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai