### PR TITLE
Reland 17206

### DIFF
--- a/backends/arm/test/common.py
+++ b/backends/arm/test/common.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 Arm Limited and/or its affiliates.
+# Copyright 2024-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -6,7 +6,6 @@
 
 import os
 
-import tempfile
 from datetime import datetime
 
 from pathlib import Path
@@ -95,9 +94,8 @@ def get_u55_compile_spec(
     """Default compile spec for Ethos-U55 tests."""
     if not custom_path:
         custom_path = maybe_get_tosa_collate_path()
-    artifact_path = custom_path or tempfile.mkdtemp(prefix="arm_u55_")
-    if not os.path.exists(artifact_path):
-        os.makedirs(artifact_path, exist_ok=True)
+    if custom_path is not None:
+        os.makedirs(custom_path, exist_ok=True)
 
     # https://gitlab.arm.com/artificial-intelligence/ethos-u/ethos-u-vela/-/blob/main/OPTIONS.md
     assert macs in [32, 64, 128, 256], "Unsupported MACs value"
@@ -114,7 +112,7 @@ def get_u55_compile_spec(
             extra_flags=extra_flags_list,
             config_ini=config,
         )
-        .dump_intermediate_artifacts_to(artifact_path)
+        .dump_intermediate_artifacts_to(custom_path)
         .dump_debug_info(tosa_debug_mode)
     )
     return compile_spec
@@ -133,9 +131,8 @@ def get_u85_compile_spec(
 
     if not custom_path:
         custom_path = maybe_get_tosa_collate_path()
-    artifact_path = custom_path or tempfile.mkdtemp(prefix="arm_u85_")
-    if not os.path.exists(artifact_path):
-        os.makedirs(artifact_path, exist_ok=True)
+    if custom_path is not None:
+        os.makedirs(custom_path, exist_ok=True)
 
     assert macs in [128, 256, 512, 1024, 2048], "Unsupported MACs value"
 
@@ -152,7 +149,7 @@ def get_u85_compile_spec(
             extra_flags=extra_flags_list,
             config_ini=config,
         )
-        .dump_intermediate_artifacts_to(artifact_path)
+        .dump_intermediate_artifacts_to(custom_path)
         .dump_debug_info(tosa_debug_mode)
     )
     return compile_spec  # type: ignore[return-value]
@@ -178,17 +175,8 @@ def get_vgf_compile_spec(
     if len(profiles) == 0:
         raise ValueError(f"Unsupported vgf compile_spec: {repr(tosa_spec)}")
 
-    if custom_path is None:
-        artifact_path = "arm_vgf_"
-        for profile in profiles:
-            artifact_path = artifact_path + f"_{profile}"
-        artifact_path = tempfile.mkdtemp(artifact_path)
-    else:
-        artifact_path = custom_path
-
-    if not os.path.exists(artifact_path):
-        os.makedirs(artifact_path, exist_ok=True)
-
+    if custom_path is not None:
+        os.makedirs(custom_path, exist_ok=True)
     if compiler_flags is not None:
         compiler_flags_list = compiler_flags.split(" ")
     else:
@@ -196,7 +184,7 @@ def get_vgf_compile_spec(
 
     compile_spec = (
         VgfCompileSpec(tosa_spec, compiler_flags_list)
-        .dump_intermediate_artifacts_to(artifact_path)
+        .dump_intermediate_artifacts_to(custom_path)
         .dump_debug_info(tosa_debug_mode)
     )
 

--- a/backends/arm/test/tester/arm_tester.py
+++ b/backends/arm/test/tester/arm_tester.py
@@ -6,8 +6,6 @@
 import copy
 
 import logging
-import shutil
-import tempfile
 
 from collections import Counter, defaultdict
 from pprint import pformat
@@ -412,10 +410,6 @@ class ArmTester(Tester):
                 use_portable_ops=self.use_portable_ops,
                 timeout=self.timeout,
             )
-        assert (
-            self.compile_spec.get_intermediate_path() is not None
-        ), "Can't dump serialized file when compile specs do not contain an artifact path."
-
         return super().serialize(serialize_stage)
 
     def is_quantized(self) -> bool:
@@ -992,14 +986,6 @@ class ArmTester(Tester):
                     qtol=0,
                 )
             raise e
-
-    def __del__(self):
-        intermediate_path = self.compile_spec.get_intermediate_path()
-        if not intermediate_path:
-            return
-        if len(tempdir := tempfile.gettempdir()) > 0:
-            if intermediate_path.startswith(tempdir):
-                shutil.rmtree(intermediate_path, ignore_errors=True)
 
     def check_dtype_count(self, dtype_dict: Dict[str, Dict[str, int]]):
         if self.cur in (

--- a/backends/arm/test/tester/serialize.py
+++ b/backends/arm/test/tester/serialize.py
@@ -1,10 +1,11 @@
-# Copyright 2024-2025 Arm Limited and/or its affiliates.
+# Copyright 2024-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
 import logging
 import os
+import tempfile
 from typing import Optional
 
 import executorch.backends.xnnpack.test.tester.tester as tester
@@ -68,7 +69,12 @@ class Serialize(tester.Serialize):
                 f"Did not find build arm_executor_runner in path {elf_path}, run setup_testing.sh?"
             )
 
-        return run_target(
+        tempdir_context = None
+        if intermediate_path is None:
+            tempdir_context = tempfile.TemporaryDirectory()
+            intermediate_path = tempdir_context.name
+
+        result = run_target(
             self.executorch_program_manager,
             inputs_flattened,
             intermediate_path,
@@ -76,3 +82,8 @@ class Serialize(tester.Serialize):
             elf_path,
             self.timeout,
         )
+
+        if tempdir_context:
+            tempdir_context.cleanup()
+
+        return result

--- a/backends/arm/tosa/backend.py
+++ b/backends/arm/tosa/backend.py
@@ -16,7 +16,6 @@ subsequent stages (for example, JIT or hardware-specific compilers) consume.
 """
 
 import logging
-import tempfile
 from itertools import count
 from typing import cast, Dict, final, List
 
@@ -247,16 +246,11 @@ class TOSABackend(BackendDetails):
 
         if artifact_path:
             tag = arm_get_first_delegation_tag(edge_program.graph_module)
-
-            # Only dump TOSA if we are not saving to temporary folder.
-            if len(
-                tempdir := tempfile.gettempdir()
-            ) > 0 and not artifact_path.startswith(tempdir):
-                debug_tosa_dump(
-                    binary,
-                    artifact_path,
-                    suffix="{}".format(f"_{tag}" if tag else "") + (f"_{tosa_spec}"),
-                )
+            debug_tosa_dump(
+                binary,
+                artifact_path,
+                suffix="{}".format(f"_{tag}" if tag else "") + (f"_{tosa_spec}"),
+            )
 
             if debug_hook is not None:
                 if debug_hook.mode == ArmCompileSpec.DebugMode.JSON:


### PR DESCRIPTION
### Summary
git revert 78237921f2          

```
78237921f2 Revert "Arm backend: Make setting artifact_path optional for tests" (#17288)
```

Reland https://github.com/pytorch/executorch/pull/17206

After reverting: https://github.com/pytorch/executorch/pull/17288

Reason - we have a fwd fix in internal now.
