### PR TITLE
Validate dim_order is a permutation in dim_order_to_stride

### DIFF
--- a/runtime/core/exec_aten/util/test/dim_order_util_test.cpp
+++ b/runtime/core/exec_aten/util/test/dim_order_util_test.cpp
@@ -335,7 +335,8 @@ TEST_F(DimOrderUtilTest, DimOrderWithOutOfBoundsValueReturnsError) {
 }
 
 TEST_F(DimOrderUtilTest, TooManyDimsReturnsError) {
-  constexpr size_t kTooManyDims = executorch::runtime::kTensorDimensionLimit + 1;
+  constexpr size_t kTooManyDims =
+      executorch::runtime::kTensorDimensionLimit + 1;
   std::vector<executorch::aten::SizesType> sizes(kTooManyDims, 1);
   std::vector<executorch::aten::SizesType> dim_order(kTooManyDims);
   std::iota(dim_order.begin(), dim_order.end(), 0);


### PR DESCRIPTION
### Summary
The validate_dim_order function only checked that values were in bounds, allowing invalid inputs like {0, 0, 0} to pass. This caused uninitialized memory access in dim_order_to_stride_nocheck.

Fix by using a bitmask to detect duplicates. Also adds test fixture with runtime_init() for error logging and removes duplicate include.

### Test plan
```
./test/run_oss_cpp_tests.sh
```