### PR TITLE
Cortex-M backend: Add quantized s8 pad operator via CMSIS-NN

### DIFF
--- a/backends/cortex_m/CMakeLists.txt
+++ b/backends/cortex_m/CMakeLists.txt
@@ -67,6 +67,7 @@ set(_cortex_m_kernels__srcs
     ${CMAKE_CURRENT_SOURCE_DIR}/ops/op_maximum.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ops/op_softmax.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ops/op_transpose.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/ops/op_pad.cpp
 )
 
 # Generate C++ bindings to register kernels into Executorch

--- a/backends/cortex_m/ops/op_pad.cpp
+++ b/backends/cortex_m/ops/op_pad.cpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2025-2026 Arm Limited and/or its affiliates.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "cortex_m_ops_common.h"
+
+extern "C" {
+#include "arm_nnfunctions.h"
+}
+
+namespace cortex_m {
+namespace native {
+
+using KernelRuntimeContext = torch::executor::KernelRuntimeContext;
+
+namespace {
+
+constexpr size_t kMaxSupportedDims = 4;
+
+} // namespace
+
+Tensor& pad_out(
+    KernelRuntimeContext& context,
+    const Tensor& input,
+    const Int64ArrayRef pre_pad,
+    const Int64ArrayRef post_pad,
+    int64_t pad_value,
+    Tensor& out) {
+  if (input.scalar_type() != ScalarType::Char ||
+      out.scalar_type() != ScalarType::Char) {
+    ET_LOG(
+        Error,
+        "pad_out: only int8 tensors are supported (input=%d, out=%d)",
+        static_cast<int>(input.scalar_type()),
+        static_cast<int>(out.scalar_type()));
+    context.fail(Error::InvalidArgument);
+    return out;
+  }
+
+  const size_t rank = input.dim();
+  if (rank == 0 || rank > kMaxSupportedDims) {
+    ET_LOG(
+        Error,
+        "pad_out: expected tensor rank in [1, %zu], got %zu",
+        kMaxSupportedDims,
+        rank);
+    context.fail(Error::InvalidArgument);
+    return out;
+  }
+
+  const size_t offset = kMaxSupportedDims - rank;
+
+  cmsis_nn_dims input_dims = {1, 1, 1, 1};
+  int32_t* d = &input_dims.n;
+  for (size_t i = 0; i < rank; ++i) {
+    d[offset + i] = static_cast<int32_t>(input.size(i));
+  }
+
+  cmsis_nn_dims cmsis_pre_pad = {
+      static_cast<int32_t>(pre_pad[0]),
+      static_cast<int32_t>(pre_pad[1]),
+      static_cast<int32_t>(pre_pad[2]),
+      static_cast<int32_t>(pre_pad[3])};
+  cmsis_nn_dims cmsis_post_pad = {
+      static_cast<int32_t>(post_pad[0]),
+      static_cast<int32_t>(post_pad[1]),
+      static_cast<int32_t>(post_pad[2]),
+      static_cast<int32_t>(post_pad[3])};
+
+  const int8_t* input_data = input.const_data_ptr<int8_t>();
+  int8_t* output_data = out.mutable_data_ptr<int8_t>();
+
+  const arm_cmsis_nn_status status = arm_pad_s8(
+      input_data,
+      output_data,
+      static_cast<int8_t>(pad_value),
+      &input_dims,
+      &cmsis_pre_pad,
+      &cmsis_post_pad);
+
+  if (status != ARM_CMSIS_NN_SUCCESS) {
+    ET_LOG(
+        Error,
+        "pad_out: arm_pad_s8 failed with status [%d]",
+        static_cast<int>(status));
+    context.fail(Error::Internal);
+    return out;
+  }
+
+  return out;
+}
+
+} // namespace native
+} // namespace cortex_m

--- a/backends/cortex_m/ops/op_pad.cpp
+++ b/backends/cortex_m/ops/op_pad.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright 2025-2026 Arm Limited and/or its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.

--- a/backends/cortex_m/ops/operators.yaml
+++ b/backends/cortex_m/ops/operators.yaml
@@ -59,6 +59,12 @@
     - arg_meta: null
       kernel_name: cortex_m::transpose_out
 
+- func: cortex_m::pad.out(Tensor input, int[] pre_pad, int[] post_pad, int pad_value, *, Tensor(a!) out) -> Tensor(a!)
+  variants: function
+  kernels:
+    - arg_meta: null
+      kernel_name: cortex_m::pad_out
+
 - func: cortex_m::quantized_conv2d.out(Tensor input, Tensor weight, Tensor? bias, int[] stride, int[] padding, int[] dilation, int input_offset, int output_offset, Tensor requantize_multipliers, Tensor requantize_shifts, int activation_min, int activation_max, *, Tensor(a!) out) -> Tensor(a!)
   variants: function
   kernels:

--- a/backends/cortex_m/passes/quantized_op_fusion_pass.py
+++ b/backends/cortex_m/passes/quantized_op_fusion_pass.py
@@ -11,6 +11,7 @@ from typing import Dict, Sequence
 import torch
 from executorch.backends.cortex_m.passes.passes_utils import (
     quantize_multiplier_aot,
+    quantize_val,
     SHIFT_INT8,
 )
 from executorch.backends.cortex_m.quantizer.quantization_configs import (
@@ -386,8 +387,8 @@ class QuantizedOpFusionPass(ExportPass):
         pad_value_raw = self._unwrap_argument(args[2]) if len(args) > 2 else 0
         pad_value_float = float(pad_value_raw)
 
-        quantized_pad_value = max(
-            -128, min(127, round(pad_value_float / scale + zero_point))
+        quantized_pad_value = int(
+            quantize_val(pad_value_float, scale, zero_point, -128, 127)
         )
 
         rank = len(args[0].data.shape)

--- a/backends/cortex_m/quantizer/quantizer.py
+++ b/backends/cortex_m/quantizer/quantizer.py
@@ -256,6 +256,9 @@ class SharedQspecQuantizer(Quantizer):
         torch.ops.aten._unsafe_view.default,
         torch.ops.aten.unflatten.int,
         torch.ops.aten.flatten.using_ints,
+        # Padding
+        torch.ops.aten.pad.default,
+        torch.ops.aten.constant_pad_nd.default,
     ]
 
     def __init__(self, targets: Optional[List[OpOverload]] = None) -> None:

--- a/backends/cortex_m/test/ops/test_pad.py
+++ b/backends/cortex_m/test/ops/test_pad.py
@@ -1,0 +1,87 @@
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import torch
+import torch.nn.functional as F
+from executorch.backends.arm.test.common import parametrize
+from executorch.backends.cortex_m.test.tester import (
+    CortexMTester,
+    McuTestCase,
+    ramp_tensor,
+)
+
+OPS_BEFORE_PASSES = {
+    "executorch_exir_dialects_edge__ops_quantized_decomposed_quantize_per_tensor_default": 2,
+    "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_tensor_default": 2,
+    "executorch_exir_dialects_edge__ops_aten_constant_pad_nd_default": 1,
+}
+
+OPS_AFTER_PASSES = {
+    "executorch_exir_dialects_edge__ops_cortex_m_quantize_per_tensor_default": 1,
+    "executorch_exir_dialects_edge__ops_cortex_m_pad_default": 1,
+    "executorch_exir_dialects_edge__ops_cortex_m_dequantize_per_tensor_default": 1,
+}
+
+
+class CortexMPad(torch.nn.Module):
+    ops_before_transforms = OPS_BEFORE_PASSES
+    ops_after_transforms = OPS_AFTER_PASSES
+
+    def __init__(self, padding, value=0.0):
+        super().__init__()
+        self.padding = padding
+        self.value = value
+
+    def forward(self, x):
+        return F.pad(x, self.padding, mode="constant", value=self.value)
+
+
+test_cases = {
+    "pad_rank4_all_dims": McuTestCase(
+        CortexMPad((1, 1, 2, 2, 1, 0, 0, 1)),
+        (ramp_tensor(-0.5, 0.5, (1, 2, 3, 4)),),
+    ),
+    "pad_rank4_last_two_dims": McuTestCase(
+        CortexMPad((1, 2, 3, 4)),
+        (ramp_tensor(-1.0, 1.0, (1, 3, 4, 5)),),
+    ),
+    "pad_rank3": McuTestCase(
+        CortexMPad((1, 1, 2, 2)),
+        (ramp_tensor(-0.5, 0.5, (2, 3, 4)),),
+    ),
+    "pad_rank2": McuTestCase(
+        CortexMPad((1, 2, 3, 4)),
+        (ramp_tensor(-1.0, 1.0, (3, 5)),),
+    ),
+    "pad_rank1": McuTestCase(
+        CortexMPad((2, 3)),
+        (ramp_tensor(0.0, 1.0, (6,)),),
+    ),
+    "pad_nonzero_value": McuTestCase(
+        CortexMPad((1, 1), value=0.5),
+        (ramp_tensor(-1.0, 1.0, (2, 4)),),
+    ),
+    "pad_zero_padding": McuTestCase(
+        CortexMPad((0, 0, 0, 0)),
+        (ramp_tensor(-0.5, 0.5, (2, 3, 4, 5)),),
+    ),
+}
+
+
+@parametrize("test_case", test_cases)
+def test_dialect_pad(test_case):
+    tester = CortexMTester(test_case.model, test_case.example_inputs)
+    tester.test_dialect(
+        test_case.model.ops_before_transforms,
+        test_case.model.ops_after_transforms,
+        qtol=1,
+    )
+
+
+@parametrize("test_case", test_cases)
+def test_implementation_pad(test_case):
+    tester = CortexMTester(test_case.model, test_case.example_inputs)
+    tester.test_implementation(qtol=1)

--- a/backends/cortex_m/test/ops/test_pad.py
+++ b/backends/cortex_m/test/ops/test_pad.py
@@ -1,4 +1,5 @@
-# Copyright 2025-2026 Arm Limited and/or its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -77,11 +78,11 @@ def test_dialect_pad(test_case):
     tester.test_dialect(
         test_case.model.ops_before_transforms,
         test_case.model.ops_after_transforms,
-        qtol=1,
+        qtol=0,
     )
 
 
 @parametrize("test_case", test_cases)
 def test_implementation_pad(test_case):
     tester = CortexMTester(test_case.model, test_case.example_inputs)
-    tester.test_implementation(qtol=1)
+    tester.test_implementation(qtol=0)


### PR DESCRIPTION
### Summary
Add cortex_m::pad that delegates to arm_pad_s8. The operator takes pre_pad/post_pad arrays in CMSIS-NN 4D format — the AoT fusion pass converts from PyTorch's constant_pad_nd padding format, validates rank/padding constraints, and quantizes the float pad value to int8.

Pad is a shared-qspec op (input/output share quantization parameters).

Fixes #16111

### Test plan
```
source examples/arm/arm-scratch/setup_path.sh
backends/cortex_m/test/build_test_runner.sh
pytest --config-file=backends/arm/test/pytest.ini backends/cortex_m/test/ops/test_pad.py
```