### PR TITLE
Initial PowerVR GPU support for Vulkan backend

### DIFF
--- a/backends/vulkan/runtime/api/Context.cpp
+++ b/backends/vulkan/runtime/api/Context.cpp
@@ -46,7 +46,11 @@ Context::Context(vkapi::Adapter* adapter, const ContextConfig& config)
       image_clearlist_mutex_{},
       images_to_clear_{},
       preferred_image_tiling_{VK_IMAGE_TILING_OPTIMAL} {
-  if (adapter_p_->linear_tiling_3d_enabled()) {
+  // PowerVR GPUs may report linear tiling support for 3D images but not
+  // handle it correctly in compute shaders (e.g., imageStore may produce
+  // incorrect results). Force optimal tiling on PowerVR for correctness.
+  if (adapter_p_->linear_tiling_3d_enabled() &&
+      adapter_p_->device_type() != vkapi::DeviceType::POWERVR) {
     preferred_image_tiling_ = VK_IMAGE_TILING_LINEAR;
   }
 }

--- a/backends/vulkan/runtime/api/containers/StagingBuffer.h
+++ b/backends/vulkan/runtime/api/containers/StagingBuffer.h
@@ -88,6 +88,11 @@ class StagingBuffer final {
     for (size_t i = 0; i < numel; ++i) {
       dst[i] = static_cast<DST_T>(src[i]);
     }
+    vmaFlushAllocation(
+        vulkan_buffer_.vma_allocator(),
+        vulkan_buffer_.allocation(),
+        0u,
+        VK_WHOLE_SIZE);
   }
 
   void cast_half_to_float_and_copy_from(
@@ -117,6 +122,11 @@ class StagingBuffer final {
 
   inline void set_staging_zeros() {
     memset(data(), 0, nbytes());
+    vmaFlushAllocation(
+        vulkan_buffer_.vma_allocator(),
+        vulkan_buffer_.allocation(),
+        0u,
+        VK_WHOLE_SIZE);
   }
 
   template <typename T>

--- a/backends/vulkan/runtime/api/containers/StagingBuffer.h
+++ b/backends/vulkan/runtime/api/containers/StagingBuffer.h
@@ -88,11 +88,6 @@ class StagingBuffer final {
     for (size_t i = 0; i < numel; ++i) {
       dst[i] = static_cast<DST_T>(src[i]);
     }
-    vmaFlushAllocation(
-        vulkan_buffer_.vma_allocator(),
-        vulkan_buffer_.allocation(),
-        0u,
-        VK_WHOLE_SIZE);
   }
 
   void cast_half_to_float_and_copy_from(
@@ -122,11 +117,6 @@ class StagingBuffer final {
 
   inline void set_staging_zeros() {
     memset(data(), 0, nbytes());
-    vmaFlushAllocation(
-        vulkan_buffer_.vma_allocator(),
-        vulkan_buffer_.allocation(),
-        0u,
-        VK_WHOLE_SIZE);
   }
 
   template <typename T>

--- a/backends/vulkan/runtime/graph/ComputeGraph.h
+++ b/backends/vulkan/runtime/graph/ComputeGraph.h
@@ -661,6 +661,9 @@ class ComputeGraph final {
   inline bool device_is_adreno() {
     return context_->adapter_ptr()->device_type() == vkapi::DeviceType::ADRENO;
   }
+  inline bool device_is_powervr() {
+    return context_->adapter_ptr()->device_type() == vkapi::DeviceType::POWERVR;
+  }
   const std::string& device_name() {
     return context()->adapter_ptr()->device_name();
   }

--- a/backends/vulkan/runtime/graph/ops/impl/Convolution.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Convolution.cpp
@@ -534,13 +534,6 @@ void add_conv2d_node(
       stride_equals_dilation,
       stride_1_padding_0);
 
-  utils::uvec3 wg_size = create_conv2d_global_wg_size(
-      graph, method, out, weight_data, stride_equals_dilation);
-
-  if (method == Conv2dMethod::Depthwise || method == Conv2dMethod::Pointwise) {
-    wg_size = {wg_size[0] * wg_size[1], wg_size[2], 1};
-  }
-
   vkapi::ParamsBindList param_buffers;
   std::vector<PushConstantDataInfo> push_constants;
   if (method == Conv2dMethod::Pointwise) {

--- a/backends/vulkan/runtime/graph/ops/impl/Convolution.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Convolution.cpp
@@ -18,6 +18,8 @@
 
 #include <executorch/backends/vulkan/runtime/graph/ops/utils/ShaderNameUtils.h>
 
+#include <iostream>
+
 namespace vkcompute {
 
 enum class Conv2dMethod : uint8_t {
@@ -401,6 +403,25 @@ utils::uvec3 conv2d_local_wg_size(
     method = Conv2dMethod::SlidingWindow;
   }
 
+  // PowerVR GPUs may not handle large workgroup sizes well. Use smaller,
+  // more conservative workgroup sizes to avoid potential hardware issues
+  // with the TBDR architecture.
+  if (graph->device_is_powervr()) {
+    if (method == Conv2dMethod::Pointwise) {
+      uint32_t local_wg_size_y = 1;
+      if (global_workgroup_size[1] % 4 == 0) {
+        local_wg_size_y = 4;
+      } else if (global_workgroup_size[1] % 2 == 0) {
+        local_wg_size_y = 2;
+      }
+      return {32 / local_wg_size_y, local_wg_size_y, 1};
+    } else if (method == Conv2dMethod::Depthwise) {
+      return {32, 1, 1};
+    } else {
+      return graph->create_local_wg_size(global_workgroup_size);
+    }
+  }
+
   if (method == Conv2dMethod::Pointwise) {
     uint32_t local_wg_size_y = 1;
     if (global_workgroup_size[1] % 8 == 0) {
@@ -523,18 +544,21 @@ void add_conv2d_node(
     wg_size = {wg_size[0] * wg_size[1], wg_size[2], 1};
   }
 
+  // Use smaller workgroup sizes on PowerVR to avoid potential hardware issues
+  const uint32_t max_local_size = graph.device_is_powervr() ? 32u : 64u;
+
   if (method == Conv2dMethod::Pointwise) {
     uint32_t local_wg_size_y = 1;
-    if (wg_size[1] % 8 == 0) {
+    if (!graph.device_is_powervr() && wg_size[1] % 8 == 0) {
       local_wg_size_y = 8;
     } else if (wg_size[1] % 4 == 0) {
       local_wg_size_y = 4;
     } else if (wg_size[1] % 2 == 0) {
       local_wg_size_y = 2;
     }
-    local_wg_size = {64 / local_wg_size_y, local_wg_size_y, 1};
+    local_wg_size = {max_local_size / local_wg_size_y, local_wg_size_y, 1};
   } else if (method == Conv2dMethod::Depthwise) {
-    local_wg_size = {64, 1, 1};
+    local_wg_size = {max_local_size, 1, 1};
   } else {
     local_wg_size = graph.create_local_wg_size(wg_size);
   }
@@ -594,6 +618,34 @@ void add_conv2d_node(
         graph.create_params_buffer(out_params),
     };
   }
+
+  // Diagnostic logging for PowerVR devices to help debug conv2d issues
+#ifndef NDEBUG
+  if (graph.device_is_powervr()) {
+    const auto weight_sizes = graph.sizes_of(weight_data);
+    const auto out_sizes = graph.sizes_of(out);
+    const auto in_sizes_dbg = graph.sizes_of(in);
+    const char* method_str =
+        method == Conv2dMethod::Depthwise    ? "Depthwise"
+        : method == Conv2dMethod::Pointwise  ? "Pointwise"
+        : method == Conv2dMethod::Transposed ? "Transposed"
+                                             : "SlidingWindow";
+    std::cerr << "[PowerVR conv2d] method=" << method_str
+              << " shader=" << shader.kernel_name
+              << " in=[" << in_sizes_dbg[0] << "," << in_sizes_dbg[1] << ","
+              << in_sizes_dbg[2] << "," << in_sizes_dbg[3] << "]"
+              << " weight=[" << weight_sizes[0] << "," << weight_sizes[1] << ","
+              << weight_sizes[2] << "," << weight_sizes[3] << "]"
+              << " out=[" << out_sizes[0] << "," << out_sizes[1] << ","
+              << out_sizes[2] << "," << out_sizes[3] << "]"
+              << " groups=" << groups_val
+              << " global_wg=[" << wg_size[0] << "," << wg_size[1] << ","
+              << wg_size[2] << "]"
+              << " local_wg=[" << local_wg_size[0] << "," << local_wg_size[1]
+              << "," << local_wg_size[2] << "]"
+              << std::endl;
+  }
+#endif
 
   graph.execute_nodes().emplace_back(new DynamicDispatchNode(
       graph,

--- a/backends/vulkan/runtime/graph/ops/impl/Convolution.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Convolution.cpp
@@ -18,8 +18,6 @@
 
 #include <executorch/backends/vulkan/runtime/graph/ops/utils/ShaderNameUtils.h>
 
-#include <iostream>
-
 namespace vkcompute {
 
 enum class Conv2dMethod : uint8_t {
@@ -618,34 +616,6 @@ void add_conv2d_node(
         graph.create_params_buffer(out_params),
     };
   }
-
-  // Diagnostic logging for PowerVR devices to help debug conv2d issues
-#ifndef NDEBUG
-  if (graph.device_is_powervr()) {
-    const auto weight_sizes = graph.sizes_of(weight_data);
-    const auto out_sizes = graph.sizes_of(out);
-    const auto in_sizes_dbg = graph.sizes_of(in);
-    const char* method_str =
-        method == Conv2dMethod::Depthwise    ? "Depthwise"
-        : method == Conv2dMethod::Pointwise  ? "Pointwise"
-        : method == Conv2dMethod::Transposed ? "Transposed"
-                                             : "SlidingWindow";
-    std::cerr << "[PowerVR conv2d] method=" << method_str
-              << " shader=" << shader.kernel_name
-              << " in=[" << in_sizes_dbg[0] << "," << in_sizes_dbg[1] << ","
-              << in_sizes_dbg[2] << "," << in_sizes_dbg[3] << "]"
-              << " weight=[" << weight_sizes[0] << "," << weight_sizes[1] << ","
-              << weight_sizes[2] << "," << weight_sizes[3] << "]"
-              << " out=[" << out_sizes[0] << "," << out_sizes[1] << ","
-              << out_sizes[2] << "," << out_sizes[3] << "]"
-              << " groups=" << groups_val
-              << " global_wg=[" << wg_size[0] << "," << wg_size[1] << ","
-              << wg_size[2] << "]"
-              << " local_wg=[" << local_wg_size[0] << "," << local_wg_size[1]
-              << "," << local_wg_size[2] << "]"
-              << std::endl;
-  }
-#endif
 
   graph.execute_nodes().emplace_back(new DynamicDispatchNode(
       graph,

--- a/backends/vulkan/runtime/graph/ops/impl/Convolution.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Convolution.cpp
@@ -18,6 +18,8 @@
 
 #include <executorch/backends/vulkan/runtime/graph/ops/utils/ShaderNameUtils.h>
 
+#include <iostream>
+
 namespace vkcompute {
 
 enum class Conv2dMethod : uint8_t {
@@ -616,6 +618,34 @@ void add_conv2d_node(
         graph.create_params_buffer(out_params),
     };
   }
+
+  // Diagnostic logging for PowerVR devices to help debug conv2d issues
+#ifndef NDEBUG
+  if (graph.device_is_powervr()) {
+    const auto weight_sizes = graph.sizes_of(weight_data);
+    const auto out_sizes = graph.sizes_of(out);
+    const auto in_sizes_dbg = graph.sizes_of(in);
+    const char* method_str =
+        method == Conv2dMethod::Depthwise    ? "Depthwise"
+        : method == Conv2dMethod::Pointwise  ? "Pointwise"
+        : method == Conv2dMethod::Transposed ? "Transposed"
+                                             : "SlidingWindow";
+    std::cerr << "[PowerVR conv2d] method=" << method_str
+              << " shader=" << shader.kernel_name
+              << " in=[" << in_sizes_dbg[0] << "," << in_sizes_dbg[1] << ","
+              << in_sizes_dbg[2] << "," << in_sizes_dbg[3] << "]"
+              << " weight=[" << weight_sizes[0] << "," << weight_sizes[1] << ","
+              << weight_sizes[2] << "," << weight_sizes[3] << "]"
+              << " out=[" << out_sizes[0] << "," << out_sizes[1] << ","
+              << out_sizes[2] << "," << out_sizes[3] << "]"
+              << " groups=" << groups_val
+              << " global_wg=[" << wg_size[0] << "," << wg_size[1] << ","
+              << wg_size[2] << "]"
+              << " local_wg=[" << local_wg_size[0] << "," << local_wg_size[1]
+              << "," << local_wg_size[2] << "]"
+              << std::endl;
+  }
+#endif
 
   graph.execute_nodes().emplace_back(new DynamicDispatchNode(
       graph,

--- a/backends/vulkan/runtime/vk_api/Adapter.cpp
+++ b/backends/vulkan/runtime/vk_api/Adapter.cpp
@@ -131,6 +131,15 @@ VkDevice create_logical_device(
       enabled_device_extensions,
       requested_device_extensions);
 
+  // Enable robustBufferAccess on PowerVR devices to ensure well-defined
+  // behavior for out-of-bounds buffer/image accesses. Without this, PowerVR
+  // drivers may return zeros or undefined values for edge cases in compute
+  // shaders. This has a minor performance cost but improves correctness.
+  VkPhysicalDeviceFeatures enabled_features{};
+  if (physical_device.device_type == DeviceType::POWERVR) {
+    enabled_features.robustBufferAccess = VK_TRUE;
+  }
+
   VkDeviceCreateInfo device_create_info{
       VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO, // sType
       nullptr, // pNext
@@ -142,7 +151,9 @@ VkDevice create_logical_device(
       static_cast<uint32_t>(
           enabled_device_extensions.size()), // enabledExtensionCount
       enabled_device_extensions.data(), // ppEnabledExtensionNames
-      nullptr, // pEnabledFeatures
+      physical_device.device_type == DeviceType::POWERVR
+          ? &enabled_features
+          : nullptr, // pEnabledFeatures
   };
 
   void* extension_list_top = nullptr;

--- a/backends/vulkan/runtime/vk_api/Adapter.cpp
+++ b/backends/vulkan/runtime/vk_api/Adapter.cpp
@@ -131,13 +131,18 @@ VkDevice create_logical_device(
       enabled_device_extensions,
       requested_device_extensions);
 
-  // Enable robustBufferAccess on PowerVR devices to ensure well-defined
-  // behavior for out-of-bounds buffer/image accesses. Without this, PowerVR
-  // drivers may return zeros or undefined values for edge cases in compute
-  // shaders. This has a minor performance cost but improves correctness.
+  // Enable robustBufferAccess on PowerVR devices to provide more well-defined
+  // behavior for out-of-bounds buffer descriptor accesses. Without this,
+  // PowerVR drivers may return zeros or undefined values for some edge cases
+  // in compute shaders. This has a minor performance cost but improves
+  // correctness.
   VkPhysicalDeviceFeatures enabled_features{};
   if (physical_device.device_type == DeviceType::POWERVR) {
-    enabled_features.robustBufferAccess = VK_TRUE;
+    VkPhysicalDeviceFeatures supported_features{};
+    vkGetPhysicalDeviceFeatures(physical_device.handle, &supported_features);
+    if (supported_features.robustBufferAccess == VK_TRUE) {
+      enabled_features.robustBufferAccess = VK_TRUE;
+    }
   }
 
   VkDeviceCreateInfo device_create_info{

--- a/backends/vulkan/runtime/vk_api/Device.cpp
+++ b/backends/vulkan/runtime/vk_api/Device.cpp
@@ -126,6 +126,8 @@ PhysicalDevice::PhysicalDevice(
     device_type = DeviceType::NVIDIA;
   } else if (device_name.find("mali") != std::string::npos) {
     device_type = DeviceType::MALI;
+  } else if (device_name.find("powervr") != std::string::npos) {
+    device_type = DeviceType::POWERVR;
   }
 }
 

--- a/backends/vulkan/runtime/vk_api/Device.h
+++ b/backends/vulkan/runtime/vk_api/Device.h
@@ -24,6 +24,7 @@ enum class DeviceType : uint32_t {
   MALI,
   ADRENO,
   SWIFTSHADER,
+  POWERVR,
 };
 
 struct PhysicalDevice final {


### PR DESCRIPTION
## Summary

Initial work to add PowerVR GPU support to the Vulkan backend. This PR adds device detection, workgroup tuning, and correctness fixes needed for PowerVR's TBDR architecture.

FP32 inference works correctly with these changes. FP16 has a known issue (see below).

## Motivation

The Vulkan backend currently has no awareness of PowerVR GPUs. Testing on Pixel 10 Pro (PowerVR D-Series DXT-48-1536 MC1) showed that without explicit PowerVR handling, inference produces incorrect results. This PR adds the foundational support needed to run models on PowerVR hardware.

## Changes

### Device Detection (`vk_api/Device.h`, `vk_api/Device.cpp`)

- Added `POWERVR` to `DeviceType` enum
- Added PowerVR string detection in `PhysicalDevice` constructor

### Compute Graph (`graph/ComputeGraph.h`)

- Added `device_is_powervr()` convenience method

### Convolution Optimization (`graph/ops/impl/Convolution.cpp`)

- Added PowerVR-specific workgroup sizes (32 instead of 64) for convolution dispatch via `conv2d_local_wg_size` callback
- PowerVR GPUs have different execution unit configurations than Adreno/Mali

### Tiling Fix (`api/Context.cpp`)

- Force optimal tiling on PowerVR (linear tiling may produce incorrect results in compute shaders on TBDR architecture)

### Buffer Access (`vk_api/Adapter.cpp`)

- Enable `robustBufferAccess` on PowerVR for well-defined out-of-bounds behavior

## Test Results (Pixel 10 Pro)

I tested 13 minimal single-operator models to isolate behavior:

| Test | Type | Expected | Actual | Status |
|------|------|----------|--------|--------|
| bare_add (x+1.0) | FP16 | 2.0 | 2.0 | PASS |
| bare_half (x*0.5) | FP16 | 0.5 | 0.5 | PASS |
| zero_conv (all-zero weights, no bias) | FP16 | 0.0 | 0.5 | FAIL (+0.5) |
| identity_conv (1x1, input=5.0) | FP16 | 5.0 | 5.5 | FAIL (+0.5) |
| bare_conv2d (3->4, 3x3, no bias) | FP16 | 0.8403 | 1.3400 | FAIL (+0.5) |
| bare_linear (16->4) | FP16 | 1.6 | 2.0996 | FAIL (+0.5) |
| **bare_conv2d_fp32** (3->4, 3x3, no bias) | **FP32** | **0.8403** | **0.8403** | **PASS** |
| bare_conv2d_xnnpack (CPU reference) | FP32 | 0.8403 | 0.8403 | PASS |

**Key observations:**
- **FP32 works correctly** on PowerVR with these changes
- **FP16 conv/linear ops have a deterministic +0.5 offset** (same every run, not random)
- **Non-conv FP16 ops work** (bare_add, bare_half produce correct results)
- **All conv variants affected** — regular, depthwise, pointwise, and linear

MobileNet progressive slices all produce NaN, likely cascading from the +0.5 offset through batch normalization.

## Known Issues

### FP16 +0.5 Offset (Unresolved)

All FP16 convolution and linear operations on PowerVR show a constant +0.5 added to the output. This is deterministic and affects all conv variants. The root cause has not been identified yet.

What I've ruled out:
- **Not uninitialized memory**: The offset is deterministic (+0.5 every run), not random
- **Not a convolution algorithm bug**: FP32 convolution produces correct results
- **Not specific to conv size/type**: Affects regular, depthwise, pointwise, and linear

The issue likely lives somewhere in the FP16 prepack or texture path, but I haven't pinpointed it yet. Help from the Vulkan team would be appreciated.

## Test Plan

- [x] Tested 13 minimal single-operator models on Pixel 10 Pro (PowerVR)
- [x] FP32 convolution passes all tests
- [x] Non-conv FP16 ops (add, multiply) pass all tests
- [x] FP16 conv/linear has known +0.5 offset (unresolved)
- [ ] Run existing Vulkan test suite on Adreno/Mali to verify no regressions

## Related Issues

- #17299 - Vulkan backend issues on PowerVR GPUs
- #17341 - StagingBuffer vmaFlushAllocation fixes (separate PR)

cc @SS-JIA @manuelcandales @digantdesai @cbilgin