### PR TITLE
[ET-VK] Reorganize op_registry.py by C++ implementation file

### DIFF
--- a/backends/vulkan/op_registry.py
+++ b/backends/vulkan/op_registry.py
@@ -118,10 +118,15 @@ def update_features(aten_op):
     return features_decorator
 
 
+# =============================================================================
+# Ephemeral Operators (no C++ dispatch - handled symbolically)
+# =============================================================================
+
+
 @update_features(
     [
         operator.getitem,
-        # Symbolic integer ops
+        # Symbolic integer ops (SymIntOps.cpp - symbolic handling)
         torch.ops.aten.sym_size.int,
         operator.add,
         operator.sub,
@@ -135,101 +140,16 @@ def update_features(aten_op):
         torch.ops.aten.sym_constrain_range_for_size.default,
     ]
 )
-def register_ephemeral_op():
+def register_ephemeral_ops():
     return OpFeatures(
         inputs_storage=utils.ANY_STORAGE,
         supports_resize=True,
     )
 
 
-@update_features(
-    [
-        exir_ops.edge.quantized_decomposed.quantize_per_channel.default,
-        exir_ops.edge.quantized_decomposed.quantize_per_token.default,
-        exir_ops.edge.quantized_decomposed.dequantize_per_channel.default,
-        exir_ops.edge.quantized_decomposed.dequantize_per_token.default,
-    ]
-)
-def register_quantization_op():
-    return OpFeatures(
-        inputs_storage=utils.CONTIGUOUS_BUFFER,
-        supports_resize=True,
-    )
-
-
-@update_features(
-    [
-        exir_ops.edge.torchao.quantize_affine.default,
-        exir_ops.edge.torchao.dequantize_affine.default,
-    ]
-)
-def register_affine_quantization_op():
-    return OpFeatures(
-        inputs_storage=utils.CONTIGUOUS_BUFFER,
-        supports_resize=True,
-    )
-
-
-@update_features(
-    [
-        exir_ops.edge.quantized_decomposed.choose_qparams.tensor,
-        exir_ops.edge.quantized_decomposed.choose_qparams_per_token_asymmetric.default,
-    ]
-)
-def register_torchao_quantization_op():
-    return OpFeatures(
-        inputs_storage=utils.CONTIGUOUS_BUFFER,
-        supports_resize=True,
-    )
-
-
-@update_features(
-    exir_ops.edge.torchao.choose_qparams_affine.default,
-)
-def register_torchao_choose_qparams_affine():
-    return OpFeatures(
-        inputs_storage=utils.CONTIGUOUS_ANY,
-        outputs_storage=[
-            utils.WIDTH_PACKED_TEXTURE,  # scales
-            utils.WIDTH_PACKED_TEXTURE,  # zero_points
-        ],
-        supports_resize=True,
-    )
-
-
-@update_features(
-    [
-        exir_ops.edge.aten.add.Tensor,
-        exir_ops.edge.aten.sub.Tensor,
-        exir_ops.edge.aten.minimum.default,
-        exir_ops.edge.aten.mul.Tensor,
-        exir_ops.edge.aten.div.Tensor,
-        exir_ops.edge.aten.div.Tensor_mode,
-        exir_ops.edge.aten.pow.Tensor_Tensor,
-        exir_ops.edge.aten.eq.Tensor,
-        exir_ops.edge.aten.lt.Tensor,
-        exir_ops.edge.aten.le.Tensor,
-        exir_ops.edge.aten.gt.Tensor,
-        exir_ops.edge.aten.ge.Tensor,
-    ]
-)
-def register_binary_op():
-    return OpFeatures(
-        inputs_storage=utils.ANY_STORAGE,
-        supports_resize=True,
-    )
-
-
-@update_features(
-    [
-        exir_ops.edge.aten.pow.Tensor_Scalar,
-    ]
-)
-def register_binary_scalar_op():
-    return OpFeatures(
-        inputs_storage=utils.ANY_STORAGE,
-        supports_resize=True,
-    )
+# =============================================================================
+# UnaryOp.cpp
+# =============================================================================
 
 
 @update_features(
@@ -252,15 +172,61 @@ def register_binary_scalar_op():
         exir_ops.edge.aten.leaky_relu.default,
     ]
 )
-def register_unary_op():
+def register_unaryop_cpp_ops():
     return OpFeatures(
         inputs_storage=utils.ANY_STORAGE,
         supports_resize=True,
     )
 
 
+# =============================================================================
+# BinaryOp.cpp
+# =============================================================================
+
+
+@update_features(
+    [
+        exir_ops.edge.aten.add.Tensor,
+        exir_ops.edge.aten.sub.Tensor,
+        exir_ops.edge.aten.minimum.default,
+        exir_ops.edge.aten.mul.Tensor,
+        exir_ops.edge.aten.div.Tensor,
+        exir_ops.edge.aten.div.Tensor_mode,
+        exir_ops.edge.aten.pow.Tensor_Tensor,
+        exir_ops.edge.aten.eq.Tensor,
+        exir_ops.edge.aten.lt.Tensor,
+        exir_ops.edge.aten.le.Tensor,
+        exir_ops.edge.aten.gt.Tensor,
+        exir_ops.edge.aten.ge.Tensor,
+    ]
+)
+def register_binaryop_cpp_ops():
+    return OpFeatures(
+        inputs_storage=utils.ANY_STORAGE,
+        supports_resize=True,
+    )
+
+
+# =============================================================================
+# BinaryScalarOp.cpp
+# =============================================================================
+
+
+@update_features(exir_ops.edge.aten.pow.Tensor_Scalar)
+def register_pow_tensor_scalar():
+    return OpFeatures(
+        inputs_storage=utils.ANY_STORAGE,
+        supports_resize=True,
+    )
+
+
+# =============================================================================
+# ToCopy.cpp
+# =============================================================================
+
+
 @update_features(exir_ops.edge.aten._to_copy.default)
-def register_to_copy_op():
+def register_to_copy():
     def check_to_copy_node(node: torch.fx.Node) -> bool:
         float_dtypes = [torch.float16, torch.float32]
 
@@ -287,54 +253,65 @@ def register_to_copy_op():
     )
 
 
-@update_features(exir_ops.edge.dim_order_ops._to_dim_order_copy.default)
-def register_to_copy_dim_order_op():
+# =============================================================================
+# Softmax.cpp
+# =============================================================================
+
+
+@update_features(
+    [
+        exir_ops.edge.aten._log_softmax.default,
+        exir_ops.edge.aten._softmax.default,
+    ]
+)
+def register_softmax_cpp_ops():
     return OpFeatures(
-        inputs_storage=utils.ANY_BUFFER,
+        inputs_storage=utils.ANY_TEXTURE,
         supports_resize=True,
     )
 
 
-@update_features(exir_ops.edge.dim_order_ops._clone_dim_order.default)
-def register_clone_dim_order_op():
-    # Similar to to_dim_order_copy, _clone_dim_order can be removed as long as the
-    # operator is not changing the dtype, i.e. the operator call is modifying the dim
-    # order only. Therefore, check that the input and output dtypes are the same, if so
-    # the operator is safe to remove.
-    def check_clone_dim_order_node(node: torch.fx.Node) -> bool:
-        in_arg = node.args[0]
-        if not isinstance(in_arg, torch.fx.Node):
-            return False
-
-        in_tensor = in_arg.meta.get("val", None)
-        out_tensor = node.meta.get("val", None)
-
-        if in_tensor.dtype != out_tensor.dtype:
-            return False
-
-        return True
-
-    return OpFeatures(
-        inputs_storage=utils.ANY_STORAGE,
-        supports_resize=True,
-        are_node_inputs_supported_fn=check_clone_dim_order_node,
-    )
+# =============================================================================
+# MatMul.cpp
+# =============================================================================
 
 
 @update_features(
     [
         exir_ops.edge.aten.bmm.default,
         exir_ops.edge.aten.mm.default,
-        exir_ops.edge.aten.addmm.default,
-        exir_ops.edge.aten.linear.default,
     ]
 )
-def register_mm_op():
+def register_matmul_cpp_ops():
     return OpFeatures(
         inputs_storage=utils.CONTIGUOUS_ANY,
         supports_resize=True,
         supports_prepacking=True,
     )
+
+
+# =============================================================================
+# Linear.cpp
+# =============================================================================
+
+
+@update_features(
+    [
+        exir_ops.edge.aten.addmm.default,
+        exir_ops.edge.aten.linear.default,
+    ]
+)
+def register_linear_cpp_ops():
+    return OpFeatures(
+        inputs_storage=utils.CONTIGUOUS_ANY,
+        supports_resize=True,
+        supports_prepacking=True,
+    )
+
+
+# =============================================================================
+# QuantizedLinearQCSNW.cpp
+# =============================================================================
 
 
 @update_features(
@@ -343,12 +320,17 @@ def register_mm_op():
         exir_ops.edge.et_vk.linear_qcs4w.default,
     ]
 )
-def register_int8_mm_op():
+def register_quantizedlinearqcsnw_cpp_ops():
     return OpFeatures(
         inputs_storage=utils.CONTIGUOUS_ANY,
         supports_resize=True,
         supports_prepacking=True,
     )
+
+
+# =============================================================================
+# QuantizedLinear.cpp
+# =============================================================================
 
 
 @update_features(
@@ -357,7 +339,7 @@ def register_int8_mm_op():
         exir_ops.edge.et_vk.linear_q4gsw.default,
     ]
 )
-def register_quantized_linear_ops():
+def register_quantizedlinear_cpp_ops():
     return OpFeatures(
         inputs_storage=utils.CONTIGUOUS_ANY,
         supports_prepacking=True,
@@ -365,7 +347,7 @@ def register_quantized_linear_ops():
 
 
 @update_features(exir_ops.edge.et_vk.linear_dq8ca_q4gsw.default)
-def register_linear_dqa_qw_ops():
+def register_linear_dq8ca_q4gsw():
     return OpFeatures(
         inputs_storage=[
             utils.CONTIGUOUS_ANY,  # input
@@ -381,16 +363,114 @@ def register_linear_dqa_qw_ops():
     )
 
 
+# =============================================================================
+# QuantizeDequantize.cpp
+# =============================================================================
+
+
 @update_features(
     [
-        exir_ops.edge.aten._log_softmax.default,
-        exir_ops.edge.aten._softmax.default,
+        exir_ops.edge.quantized_decomposed.quantize_per_channel.default,
+        exir_ops.edge.quantized_decomposed.quantize_per_token.default,
+        exir_ops.edge.quantized_decomposed.dequantize_per_channel.default,
+        exir_ops.edge.quantized_decomposed.dequantize_per_token.default,
     ]
 )
-def register_softmax_op():
+def register_quantizedequantize_cpp_ops():
     return OpFeatures(
-        inputs_storage=utils.ANY_TEXTURE,
+        inputs_storage=utils.CONTIGUOUS_BUFFER,
         supports_resize=True,
+    )
+
+
+@update_features(
+    [
+        exir_ops.edge.torchao.quantize_affine.default,
+        exir_ops.edge.torchao.dequantize_affine.default,
+    ]
+)
+def register_torchao_quantize_dequantize():
+    return OpFeatures(
+        inputs_storage=utils.CONTIGUOUS_BUFFER,
+        supports_resize=True,
+    )
+
+
+@update_features(
+    [
+        exir_ops.edge.quantized_decomposed.quantize_per_tensor.default,
+        exir_ops.edge.quantized_decomposed.quantize_per_tensor.tensor,
+    ]
+)
+def register_quantize_per_tensor():
+    return OpFeatures(
+        inputs_storage=[
+            utils.CHANNELS_PACKED_TEXTURE_OR_CONTIGUOUS_BUFFER,
+        ],
+        outputs_storage=[
+            utils.PACKED_INT8_4W4C_BUFFER,
+        ],
+    )
+
+
+@update_features(
+    [
+        exir_ops.edge.quantized_decomposed.dequantize_per_tensor.default,
+        exir_ops.edge.quantized_decomposed.dequantize_per_tensor.tensor,
+    ]
+)
+def register_dequantize_per_tensor():
+    return OpFeatures(
+        inputs_storage=[
+            utils.PACKED_INT8_4W4C_BUFFER,
+        ],
+        outputs_storage=[
+            utils.CHANNELS_PACKED_TEXTURE_OR_CONTIGUOUS_BUFFER,
+        ],
+    )
+
+
+# =============================================================================
+# ChooseQParams.cpp
+# =============================================================================
+
+
+@update_features(
+    [
+        exir_ops.edge.quantized_decomposed.choose_qparams.tensor,
+        exir_ops.edge.quantized_decomposed.choose_qparams_per_token_asymmetric.default,
+    ]
+)
+def register_chooseqparams_cpp_ops():
+    return OpFeatures(
+        inputs_storage=utils.CONTIGUOUS_BUFFER,
+        supports_resize=True,
+    )
+
+
+@update_features(exir_ops.edge.torchao.choose_qparams_affine.default)
+def register_torchao_choose_qparams_affine():
+    return OpFeatures(
+        inputs_storage=utils.CONTIGUOUS_ANY,
+        outputs_storage=[
+            utils.WIDTH_PACKED_TEXTURE,  # scales
+            utils.WIDTH_PACKED_TEXTURE,  # zero_points
+        ],
+        supports_resize=True,
+    )
+
+
+# =============================================================================
+# QuantizedBinary.cpp
+# =============================================================================
+
+
+@update_features(exir_ops.edge.et_vk.add_q8ta_q8ta_q8to.default)
+def register_add_q8ta_q8ta_q8to():
+    return OpFeatures(
+        inputs_storage=utils.PACKED_INT8_4W4C_BUFFER,
+        supports_resize=False,
+        supports_prepacking=True,
     )
 
 
@@ -503,23 +583,51 @@ def pick_storage_for_reduce(node: torch.fx.Node):
     return inputs_storage, outputs_storage
 
 
+# =============================================================================
+# Reduce.cpp
+# =============================================================================
+
+
 @update_features(
     [
         exir_ops.edge.aten.mean.dim,
         exir_ops.edge.aten.sum.dim_IntList,
         exir_ops.edge.aten.amax.default,
         exir_ops.edge.aten.amin.default,
-        exir_ops.edge.aten.argmax.default,
-        exir_ops.edge.aten.argmin.default,
     ]
 )
-def register_reduce_op():
+def register_reduce_cpp_ops():
     return OpFeatures(
         inputs_storage=utils.ANY_TEXTURE,
         supports_resize=True,
         are_node_inputs_supported_fn=is_reduce_node_supported,
         pick_io_storage_fn=pick_storage_for_reduce,
     )
+
+
+# =============================================================================
+# ArgReduce.cpp
+# =============================================================================
+
+
+@update_features(
+    [
+        exir_ops.edge.aten.argmax.default,
+        exir_ops.edge.aten.argmin.default,
+    ]
+)
+def register_argreduce_cpp_ops():
+    return OpFeatures(
+        inputs_storage=utils.ANY_TEXTURE,
+        supports_resize=True,
+        are_node_inputs_supported_fn=is_reduce_node_supported,
+        pick_io_storage_fn=pick_storage_for_reduce,
+    )
+
+
+# =============================================================================
+# Pool.cpp
+# =============================================================================
 
 
 @update_features(
@@ -529,11 +637,16 @@ def register_reduce_op():
         exir_ops.edge.aten.max_pool2d_with_indices.default,
     ]
 )
-def register_2d_pool_op():
+def register_pool_cpp_ops():
     return OpFeatures(
         inputs_storage=utils.CHANNELS_PACKED_TEXTURE,
         supports_resize=True,
     )
+
+
+# =============================================================================
+# Convolution.cpp
+# =============================================================================
 
 
 @update_features(
@@ -542,7 +655,7 @@ def register_2d_pool_op():
         exir_ops.edge.et_vk.conv_with_clamp.default,
     ]
 )
-def register_convolution_op():
+def register_convolution_cpp_ops():
     def check_conv_node(node: torch.fx.Node) -> bool:
         x = node.args[0]
         assert isinstance(x, torch.fx.Node)
@@ -581,13 +694,18 @@ def register_convolution_op():
     )
 
 
+# =============================================================================
+# QuantizedConvolution.cpp
+# =============================================================================
+
+
 @update_features(
     [
         exir_ops.edge.et_vk.conv2d_q8ta_q8csw_q8to.default,
         exir_ops.edge.et_vk.conv2d_q8ta_q8csw_q8to_dw.default,
     ]
 )
-def register_quantized_conv_op():
+def register_quantizedconvolution_cpp_ops():
     return OpFeatures(
         inputs_storage=[
             utils.PACKED_INT8_4W4C_BUFFER,  # input
@@ -611,55 +729,13 @@ def register_quantized_conv_op():
     )
 
 
-@update_features(
-    [
-        exir_ops.edge.et_vk.add_q8ta_q8ta_q8to.default,
-    ]
-)
-def register_quantized_binary_op():
-    return OpFeatures(
-        inputs_storage=utils.PACKED_INT8_4W4C_BUFFER,
-        supports_resize=False,
-        supports_prepacking=True,
-    )
-
-
-@update_features(
-    [
-        exir_ops.edge.quantized_decomposed.quantize_per_tensor.default,
-        exir_ops.edge.quantized_decomposed.quantize_per_tensor.tensor,
-    ]
-)
-def register_quantize_op():
-    return OpFeatures(
-        inputs_storage=[
-            utils.CHANNELS_PACKED_TEXTURE_OR_CONTIGUOUS_BUFFER,
-        ],
-        outputs_storage=[
-            utils.PACKED_INT8_4W4C_BUFFER,
-        ],
-    )
-
-
-@update_features(
-    [
-        exir_ops.edge.quantized_decomposed.dequantize_per_tensor.default,
-        exir_ops.edge.quantized_decomposed.dequantize_per_tensor.tensor,
-    ]
-)
-def register_dequantize_op():
-    return OpFeatures(
-        inputs_storage=[
-            utils.PACKED_INT8_4W4C_BUFFER,
-        ],
-        outputs_storage=[
-            utils.CHANNELS_PACKED_TEXTURE_OR_CONTIGUOUS_BUFFER,
-        ],
-    )
+# =============================================================================
+# SDPA.cpp
+# =============================================================================
 
 
 @update_features("llama::sdpa_with_kv_cache")
-def register_sdpa_with_kv_cache_op():
+def register_sdpa_with_kv_cache():
     return OpFeatures(
         inputs_storage=utils.CONTIGUOUS_ANY,
         supports_resize=True,
@@ -673,128 +749,352 @@ def register_sdpa_with_kv_cache_op():
         "llama::custom_sdpa",
     ]
 )
-def register_sdpa_ops():
+def register_sdpa_cpp_ops():
     return OpFeatures(
         inputs_storage=utils.CONTIGUOUS_ANY,
         supports_resize=True,
     )
+
+
+# =============================================================================
+# RotaryEmbedding.cpp
+# =============================================================================
 
 
 @update_features(exir_ops.edge.et_vk.apply_rotary_emb.default)
-def register_rotary_emb_op():
+def register_apply_rotary_emb():
     return OpFeatures(
         inputs_storage=utils.CONTIGUOUS_ANY,
         supports_resize=True,
     )
 
 
-@update_features(
-    [
-        exir_ops.edge.aten.permute.default,
-    ]
-)
-def register_view_ops():
+# =============================================================================
+# Permute.cpp
+# =============================================================================
+
+
+@update_features(exir_ops.edge.aten.permute.default)
+def register_permute():
     return OpFeatures(
         inputs_storage=utils.ANY_TEXTURE,
         supports_resize=True,
     )
 
 
-@update_features(
-    [
-        exir_ops.edge.aten.view_copy.default,
-        exir_ops.edge.aten.squeeze_copy.dims,
-        exir_ops.edge.aten.unsqueeze_copy.default,
-        exir_ops.edge.aten.clone.default,
-        exir_ops.edge.aten.permute_copy.default,
-        exir_ops.edge.aten.gather.default,
-    ]
-)
-def register_view_ops_with_buffer_meta():
+@update_features(exir_ops.edge.aten.permute_copy.default)
+def register_permute_copy():
     return OpFeatures(
         inputs_storage=utils.ANY_STORAGE,
         supports_resize=True,
     )
+
+
+# =============================================================================
+# View.cpp
+# =============================================================================
+
+
+@update_features(exir_ops.edge.aten.view_copy.default)
+def register_view_copy():
+    return OpFeatures(
+        inputs_storage=utils.ANY_STORAGE,
+        supports_resize=True,
+    )
+
+
+@update_features(exir_ops.edge.dim_order_ops._to_dim_order_copy.default)
+def register_to_dim_order_copy():
+    return OpFeatures(
+        inputs_storage=utils.ANY_BUFFER,
+        supports_resize=True,
+    )
+
+
+# =============================================================================
+# Squeeze.cpp
+# =============================================================================
+
+
+@update_features(exir_ops.edge.aten.squeeze_copy.dims)
+def register_squeeze_copy():
+    return OpFeatures(
+        inputs_storage=utils.ANY_STORAGE,
+        supports_resize=True,
+    )
+
+
+# =============================================================================
+# Unsqueeze.cpp
+# =============================================================================
+
+
+@update_features(exir_ops.edge.aten.unsqueeze_copy.default)
+def register_unsqueeze_copy():
+    return OpFeatures(
+        inputs_storage=utils.ANY_STORAGE,
+        supports_resize=True,
+    )
+
+
+# =============================================================================
+# Clone.cpp
+# =============================================================================
+
+
+@update_features(exir_ops.edge.aten.clone.default)
+def register_clone():
+    return OpFeatures(
+        inputs_storage=utils.ANY_STORAGE,
+        supports_resize=True,
+    )
+
+
+@update_features(exir_ops.edge.dim_order_ops._clone_dim_order.default)
+def register_clone_dim_order():
+    # Similar to to_dim_order_copy, _clone_dim_order can be removed as long as the
+    # operator is not changing the dtype, i.e. the operator call is modifying the dim
+    # order only. Therefore, check that the input and output dtypes are the same, if so
+    # the operator is safe to remove.
+    def check_clone_dim_order_node(node: torch.fx.Node) -> bool:
+        in_arg = node.args[0]
+        if not isinstance(in_arg, torch.fx.Node):
+            return False
+
+        in_tensor = in_arg.meta.get("val", None)
+        out_tensor = node.meta.get("val", None)
+
+        if in_tensor.dtype != out_tensor.dtype:
+            return False
+
+        return True
+
+    return OpFeatures(
+        inputs_storage=utils.ANY_STORAGE,
+        supports_resize=True,
+        are_node_inputs_supported_fn=check_clone_dim_order_node,
+    )
+
+
+# =============================================================================
+# Gather.cpp
+# =============================================================================
+
+
+@update_features(exir_ops.edge.aten.gather.default)
+def register_gather():
+    return OpFeatures(
+        inputs_storage=utils.ANY_STORAGE,
+        supports_resize=True,
+    )
+
+
+# =============================================================================
+# Expand.cpp
+# =============================================================================
 
 
 @update_features(exir_ops.edge.aten.expand_copy.default)
-def register_expand():
-    return OpFeatures(inputs_storage=utils.ANY_BUFFER, supports_resize=False)
+def register_expand_copy():
+    return OpFeatures(
+        inputs_storage=utils.ANY_BUFFER,
+        supports_resize=False,
+    )
 
 
-# Fully featured transfer operators (i.e. operators that copy data from the input
-# tensor(s) to the output tensor(s)), which have memory layout agnostic implementations
-# for both texture and buffer storage types.
+# =============================================================================
+# Concat.cpp
+# =============================================================================
+
+
 @update_features(exir_ops.edge.aten.cat.default)
-def register_cat_op():
+def register_cat():
     return OpFeatures(
         inputs_storage=utils.ANY_STORAGE,
         supports_resize=True,
     )
 
 
-# Fully featured transfer operators (i.e. operators that copy data from the input
-# tensor(s) to the output tensor(s)), which have memory layout agnostic implementations
-# for both texture and buffer storage types.
-@update_features(
-    [
-        exir_ops.edge.aten.select_copy.int,
-        exir_ops.edge.aten.slice_copy.Tensor,
-        exir_ops.edge.aten.split_with_sizes_copy.default,
-    ]
-)
-def register_transfer_ops():
+# =============================================================================
+# Select.cpp
+# =============================================================================
+
+
+@update_features(exir_ops.edge.aten.select_copy.int)
+def register_select_copy():
     return OpFeatures(
         inputs_storage=utils.ANY_STORAGE,
         supports_resize=True,
     )
 
 
-# Ops ported from PyTorch Vulkan backend. These ops commonly support channels
-# packed tensors only and do not have a resize function.
-@update_features(
-    [
-        # Shape Manipulation
-        exir_ops.edge.aten.t_copy.default,
-        # Indexing and lookup
-        exir_ops.edge.aten.flip.default,
-        exir_ops.edge.aten.index_select.default,
-        # Tensor creation
-        exir_ops.edge.aten.arange.start_step,
-        exir_ops.edge.aten.constant_pad_nd.default,
-        exir_ops.edge.aten.full.default,
-        exir_ops.edge.aten.full_like.default,
-        exir_ops.edge.aten.ones.default,
-        exir_ops.edge.aten.ones_like.default,
-        exir_ops.edge.aten.scalar_tensor.default,
-        exir_ops.edge.aten.upsample_nearest2d.vec,
-        exir_ops.edge.aten.upsample_bilinear2d.vec,
-        exir_ops.edge.aten.zeros.default,
-        exir_ops.edge.aten.zeros_like.default,
-        exir_ops.edge.et_vk.grid_priors.default,
-    ]
-)
-def register_ported_op():
+# =============================================================================
+# Slice.cpp
+# =============================================================================
+
+
+@update_features(exir_ops.edge.aten.slice_copy.Tensor)
+def register_slice_copy():
+    return OpFeatures(
+        inputs_storage=utils.ANY_STORAGE,
+        supports_resize=True,
+    )
+
+
+# =============================================================================
+# Split.cpp
+# =============================================================================
+
+
+@update_features(exir_ops.edge.aten.split_with_sizes_copy.default)
+def register_split_with_sizes_copy():
+    return OpFeatures(
+        inputs_storage=utils.ANY_STORAGE,
+        supports_resize=True,
+    )
+
+
+# =============================================================================
+# Transpose.cpp
+# =============================================================================
+
+
+@update_features(exir_ops.edge.aten.t_copy.default)
+def register_t_copy():
     return OpFeatures(
         inputs_storage=utils.CHANNELS_PACKED_TEXTURE,
     )
 
 
-# Ops ported from PyTorch Vulkan backend. These ops are in a separate registry because they support all packed dimensions
+# =============================================================================
+# Flip.cpp
+# =============================================================================
+
+
+@update_features(exir_ops.edge.aten.flip.default)
+def register_flip():
+    return OpFeatures(
+        inputs_storage=utils.CHANNELS_PACKED_TEXTURE,
+    )
+
+
+# =============================================================================
+# IndexSelect.cpp
+# =============================================================================
+
+
+@update_features(exir_ops.edge.aten.index_select.default)
+def register_index_select():
+    return OpFeatures(
+        inputs_storage=utils.CHANNELS_PACKED_TEXTURE,
+    )
+
+
+# =============================================================================
+# Arange.cpp
+# =============================================================================
+
+
+@update_features(exir_ops.edge.aten.arange.start_step)
+def register_arange():
+    return OpFeatures(
+        inputs_storage=utils.CHANNELS_PACKED_TEXTURE,
+    )
+
+
+# =============================================================================
+# Pad.cpp
+# =============================================================================
+
+
+@update_features(exir_ops.edge.aten.constant_pad_nd.default)
+def register_constant_pad_nd():
+    return OpFeatures(
+        inputs_storage=utils.CHANNELS_PACKED_TEXTURE,
+    )
+
+
+# =============================================================================
+# Full.cpp
+# =============================================================================
+
+
 @update_features(
     [
-        exir_ops.edge.aten.repeat.default,
+        exir_ops.edge.aten.full.default,
+        exir_ops.edge.aten.full_like.default,
+        exir_ops.edge.aten.ones.default,
+        exir_ops.edge.aten.ones_like.default,
+        exir_ops.edge.aten.zeros.default,
+        exir_ops.edge.aten.zeros_like.default,
     ]
 )
-def register_ported_op_all_packed_dims():
+def register_full_cpp_ops():
+    return OpFeatures(
+        inputs_storage=utils.CHANNELS_PACKED_TEXTURE,
+    )
+
+
+# =============================================================================
+# ScalarTensor.cpp
+# =============================================================================
+
+
+@update_features(exir_ops.edge.aten.scalar_tensor.default)
+def register_scalar_tensor():
+    return OpFeatures(
+        inputs_storage=utils.CHANNELS_PACKED_TEXTURE,
+    )
+
+
+# =============================================================================
+# Upsample.cpp
+# =============================================================================
+
+
+@update_features(
+    [
+        exir_ops.edge.aten.upsample_nearest2d.vec,
+        exir_ops.edge.aten.upsample_bilinear2d.vec,
+    ]
+)
+def register_upsample_cpp_ops():
+    return OpFeatures(
+        inputs_storage=utils.CHANNELS_PACKED_TEXTURE,
+    )
+
+
+# =============================================================================
+# GridPriors.cpp
+# =============================================================================
+
+
+@update_features(exir_ops.edge.et_vk.grid_priors.default)
+def register_grid_priors():
+    return OpFeatures(
+        inputs_storage=utils.CHANNELS_PACKED_TEXTURE,
+    )
+
+
+# =============================================================================
+# Repeat.cpp
+# =============================================================================
+
+
+@update_features(exir_ops.edge.aten.repeat.default)
+def register_repeat():
     return OpFeatures(
         inputs_storage=utils.ANY_TEXTURE,
     )
 
 
-# Ported ops that support their own prepacking.
+# =============================================================================
+# Embedding.cpp
+# =============================================================================
+
+
 @update_features(exir_ops.edge.aten.embedding.default)
-def register_embedding_op():
+def register_embedding():
     return OpFeatures(
         inputs_storage=utils.CHANNELS_PACKED_TEXTURE,
         supports_prepacking=True,
@@ -802,8 +1102,13 @@ def register_embedding_op():
     )
 
 
+# =============================================================================
+# BatchNorm.cpp
+# =============================================================================
+
+
 @update_features(exir_ops.edge.aten._native_batch_norm_legit_no_training.default)
-def register_batch_norm_op():
+def register_native_batch_norm_legit_no_training():
     def check_batch_norm_node(node: torch.fx.Node) -> bool:
         x = node.args[0]
         if not isinstance(x, torch.fx.Node):
@@ -825,11 +1130,12 @@ def register_batch_norm_op():
     )
 
 
-@update_features(
-    [
-        exir_ops.edge.aten.native_group_norm.default,
-    ]
-)
+# =============================================================================
+# GroupNorm.cpp
+# =============================================================================
+
+
+@update_features(exir_ops.edge.aten.native_group_norm.default)
 def register_native_group_norm():
     return OpFeatures(
         inputs_storage=utils.CHANNELS_PACKED_TEXTURE,
@@ -842,13 +1148,13 @@ def register_native_group_norm():
     )
 
 
-# Ported ops that support their own prepacking.
-@update_features(
-    [
-        exir_ops.edge.aten.native_layer_norm.default,
-    ]
-)
-def register_ported_ops_with_prepacking_all_dims():
+# =============================================================================
+# NativeLayerNorm.cpp
+# =============================================================================
+
+
+@update_features(exir_ops.edge.aten.native_layer_norm.default)
+def register_native_layer_norm():
     return OpFeatures(
         inputs_storage=utils.ANY_TEXTURE,
         supports_prepacking=True,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #17337
* #17336
* __->__ #17335

Previously, operator registrations were grouped by shared OpFeatures
characteristics, which made it difficult to verify that registrations
accurately reflected the capabilities of their C++ implementations. For
example, operators from different C++ files (View.cpp, Squeeze.cpp,
Clone.cpp, Gather.cpp) were grouped together in a single registration
because they happened to share the same storage requirements.

This reorganization groups registrations by their C++ implementation file,
making it straightforward to cross-reference Python registrations with
their corresponding C++ code. When an operator's C++ implementation changes,
the relevant Python registration is now easy to locate and update.

Key changes:
- Added section headers indicating the C++ file for each registration group
- Split registrations where operators mapped to different C++ files (e.g.,
  MatMul.cpp vs Linear.cpp, Reduce.cpp vs ArgReduce.cpp)
- Adopted consistent naming: `register_<cpp_file>_cpp_ops()` for grouped
  registrations, `register_<op_name>()` for single-op registrations
- Kept separate registrations for ops with different characteristics even
  when they share a C++ file (e.g., permute vs permute_copy have different
  storage requirements)

Authored with Claude Code.

Differential Revision: [D92740293](https://our.internmc.facebook.com/intern/diff/D92740293/)