### PR TITLE
[ET-VK] Add missing VMA flush/invalidate calls in StagingBuffer copy methods

### DIFF
--- a/backends/vulkan/runtime/api/containers/StagingBuffer.cpp
+++ b/backends/vulkan/runtime/api/containers/StagingBuffer.cpp
@@ -159,6 +159,11 @@ void StagingBuffer::cast_half_to_float_and_copy_from(
   for (size_t i = 0; i < numel; ++i) {
     dst[i] = half_to_float(src[i]);
   }
+  vmaFlushAllocation(
+      vulkan_buffer_.vma_allocator(),
+      vulkan_buffer_.allocation(),
+      0u,
+      VK_WHOLE_SIZE);
 }
 
 void StagingBuffer::cast_float_to_half_and_copy_to(

--- a/backends/vulkan/runtime/api/containers/StagingBuffer.h
+++ b/backends/vulkan/runtime/api/containers/StagingBuffer.h
@@ -88,6 +88,11 @@ class StagingBuffer final {
     for (size_t i = 0; i < numel; ++i) {
       dst[i] = static_cast<DST_T>(src[i]);
     }
+    vmaFlushAllocation(
+        vulkan_buffer_.vma_allocator(),
+        vulkan_buffer_.allocation(),
+        0u,
+        VK_WHOLE_SIZE);
   }
 
   void cast_half_to_float_and_copy_from(
@@ -109,6 +114,11 @@ class StagingBuffer final {
   template <typename SRC_T, typename DST_T>
   void cast_and_copy_to(DST_T* dst, const size_t numel) {
     VK_CHECK_COND(numel <= this->numel());
+    vmaInvalidateAllocation(
+        vulkan_buffer_.vma_allocator(),
+        vulkan_buffer_.allocation(),
+        0u,
+        VK_WHOLE_SIZE);
     const SRC_T* src = reinterpret_cast<const SRC_T*>(data());
     for (size_t i = 0; i < numel; ++i) {
       dst[i] = static_cast<DST_T>(src[i]);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #17341

`copy_from` correctly calls `vmaFlushAllocation` after writing to the staging buffer, and `copy_to` correctly calls `vmaInvalidateAllocation` before reading, but the cast-and-copy variants were missing these calls. On devices with non-coherent memory, this could cause the GPU to read stale data (missing flush) or the CPU to read stale data (missing invalidate). This change adds the missing `vmaFlushAllocation` to `cast_and_copy_from` and `cast_half_to_float_and_copy_from`, and the missing `vmaInvalidateAllocation` to `cast_and_copy_to`. `cast_float_to_half_and_copy_to` already had the invalidate call and was not changed.

Authored with Claude.

Differential Revision: [D92843801](https://our.internmc.facebook.com/intern/diff/D92843801/)