### PR TITLE
Update import path for prepare_image function, fixes #15178

### DIFF
--- a/examples/models/llava/test/test_pte.py
+++ b/examples/models/llava/test/test_pte.py
@@ -8,7 +8,7 @@ import logging
 import sys
 
 import torch
-from executorch.examples.models.llava.image_util import prepare_image
+from executorch.examples.models.llava.model import prepare_image
 from executorch.examples.models.llava.model import LlavaModel
 from executorch.extension.pybindings.portable_lib import _load_for_executorch
 from PIL import Image

--- a/examples/models/llava/test/test_pte.py
+++ b/examples/models/llava/test/test_pte.py
@@ -8,8 +8,7 @@ import logging
 import sys
 
 import torch
-from executorch.examples.models.llava.model import prepare_image
-from executorch.examples.models.llava.model import LlavaModel
+from executorch.examples.models.llava.model import LlavaModel, prepare_image
 from executorch.extension.pybindings.portable_lib import _load_for_executorch
 from PIL import Image
 


### PR DESCRIPTION
Earlier, prepare_image() was in 'executorch.examples.models.llava.image_util', which does not exist anymore. Currently, the function exists in 'executorch.examples.models.llava.model'. Updated the import statement accordingly

Fixes #15178 


cc @mergennachin @byjlw @iseeyuan @lucylq @helunwencser @tarun292 @kimishpatel @jackzhxng @larryliu0820 @cccclai