### PR TITLE
link quantized ops on non-cuda builds

### DIFF
--- a/examples/models/parakeet/CMakeLists.txt
+++ b/examples/models/parakeet/CMakeLists.txt
@@ -41,7 +41,7 @@ if(TARGET optimized_native_cpu_ops_lib)
 endif()
 
 # CPU-only builds need quantized and custom ops
-if(NOT EXECUTORCH_BUILD_CUDA AND MSVC)
+if(NOT EXECUTORCH_BUILD_CUDA)
   list(APPEND link_libraries quantized_ops_lib custom_ops)
   executorch_target_link_options_shared_lib(quantized_ops_lib)
   executorch_target_link_options_shared_lib(custom_ops)

--- a/examples/models/voxtral/CMakeLists.txt
+++ b/examples/models/voxtral/CMakeLists.txt
@@ -44,7 +44,7 @@ list(APPEND link_libraries optimized_native_cpu_ops_lib cpublas eigen_blas)
 executorch_target_link_options_shared_lib(optimized_native_cpu_ops_lib)
 
 # CPU-only builds need quantized and custom ops
-if(NOT EXECUTORCH_BUILD_CUDA AND MSVC)
+if(NOT EXECUTORCH_BUILD_CUDA)
   list(APPEND link_libraries quantized_ops_lib custom_ops)
   executorch_target_link_options_shared_lib(quantized_ops_lib)
   executorch_target_link_options_shared_lib(custom_ops)

--- a/examples/models/whisper/CMakeLists.txt
+++ b/examples/models/whisper/CMakeLists.txt
@@ -38,7 +38,7 @@ list(APPEND _link_libraries optimized_native_cpu_ops_lib cpublas eigen_blas)
 executorch_target_link_options_shared_lib(optimized_native_cpu_ops_lib)
 
 # CPU-only builds need quantized and custom ops
-if(NOT EXECUTORCH_BUILD_CUDA AND MSVC)
+if(NOT EXECUTORCH_BUILD_CUDA)
   list(APPEND _link_libraries quantized_ops_lib custom_ops)
   executorch_target_link_options_shared_lib(quantized_ops_lib)
   executorch_target_link_options_shared_lib(custom_ops)


### PR DESCRIPTION
### Summary
enable voxtral on xnnpack (cpu)

### Test plan
make voxtral-cpu

 ./cmake-out/examples/models/voxtral/voxtral_runner \
    --model_path /data/users/lfq/optimum-executorch/voxtral/model.pte \
    --tokenizer_path /home/lfq/.cache/huggingface/hub/models--mistralai--Voxtral-Mini-3B-2507/snapshots/3060fe34b35ba5d44202ce9ff3c097642914f8f3/tekken.json \
    --prompt "What can you tell me about this audio?" \
    --audio_path audio.wav \
    --processor_path /data/users/lfq/optimum-executorch/voxtral/voxtral_preprocessor.pte
