### PR TITLE
Enhance get_arg with generic type checking and refactor all usages

### DIFF
--- a/backends/cadence/aot/BUCK
+++ b/backends/cadence/aot/BUCK
@@ -81,6 +81,7 @@ fbcode_target(_kind = runtime.python_library,
         "pass_utils.py",
     ],
     deps = [
+        "fbsource//third-party/pypi/beartype:beartype",
         ":utils",
         "//caffe2:torch",
         "//executorch/exir:pass_base",
@@ -172,6 +173,19 @@ fbcode_target(_kind = python_unittest,
     deps = [
         ":pass_utils",
         "//executorch/exir:pass_base",
+    ],
+)
+
+fbcode_target(_kind = python_unittest,
+    name = "test_pass_utils",
+    srcs = [
+        "tests/test_pass_utils.py",
+    ],
+    typing = True,
+    deps = [
+        "fbsource//third-party/pypi/beartype:beartype",
+        ":pass_utils",
+        "//caffe2:torch",
     ],
 )
 

--- a/backends/cadence/aot/pass_utils.py
+++ b/backends/cadence/aot/pass_utils.py
@@ -8,16 +8,18 @@
 
 from abc import abstractmethod
 from dataclasses import dataclass
-from typing import Callable, List, Optional, Set, Type, Union
+from typing import Callable, List, Optional, Set, Type, TypeVar, Union
 
 import torch
+from beartype.door import die_if_unbearable
 from executorch.backends.cadence.aot.utils import get_edge_overload_packet
-
 from executorch.exir.dialects.edge._ops import EdgeOpOverload, EdgeOpOverloadPacket
 from executorch.exir.pass_base import ExportPass, PassBase, PassResult
-
 from torch._ops import OpOverloadPacket
 from torch.fx import Node
+from torch.fx.node import Argument
+
+T = TypeVar("T")
 
 
 # Is an overlap in tensor lifetime and storage allowed at the current opt level?
@@ -177,24 +179,50 @@ def nodes_not_adjacent_in_gm(
 def get_arg(
     node: torch.fx.Node,
     kwarg_name: str,
-) -> torch.fx.node.Argument:
+    expected_type: Type[T] = Argument,
+) -> T:
     """
     Get the arg with arg_name of the node, returns default value if not set.
+
+    Args:
+        node: The FX node to extract the argument from
+        kwarg_name: The name of the argument to extract
+        expected_type: Optional type to validate and cast the argument to.
+                      If provided, asserts the argument is an instance of this type.
+
+    Returns:
+        The argument value, optionally type-checked and cast to expected_type
+
+    Example:
+        # Get a node argument with type checking
+        conv_weight_node = get_arg(node, "weight", torch.fx.Node)
+
+        # Get a float argument with type checking
+        eps = get_arg(node, "eps", float)
+
+        # Get an argument without type checking (returns Argument)
+        value = get_arg(node, "some_arg")
     """
     # Try to get the arg from kwargs first since this is faster
     if kwarg_name in node.kwargs:
-        return node.kwargs[kwarg_name]
-
-    # If it's not found in kwargs, try to normalize the args
-    normalized_args = node.normalized_arguments(
-        node.graph.owning_module, normalize_to_only_use_kwargs=True
-    )
-    if not normalized_args:
-        raise RuntimeError(
-            f"get_arg: Node {node} does not support normalization of arguments"
+        value = node.kwargs[kwarg_name]
+    else:
+        # If it's not found in kwargs, try to normalize the args
+        normalized_args = node.normalized_arguments(
+            node.graph.owning_module, normalize_to_only_use_kwargs=True
         )
+        if not normalized_args:
+            raise RuntimeError(
+                f"get_arg: Node {node} does not support normalization of arguments"
+            )
+        value = normalized_args.kwargs[kwarg_name]
 
-    return normalized_args.kwargs[kwarg_name]
+    # Validate type using beartype's runtime type checker when a specific
+    # type is requested (not the default Argument type alias, which contains
+    # recursive forward references that beartype cannot resolve).
+    if expected_type is not Argument:
+        die_if_unbearable(value, expected_type)
+    return value  # type: ignore[return-value]
 
 
 def set_arg(

--- a/backends/cadence/aot/tests/test_pass_utils.py
+++ b/backends/cadence/aot/tests/test_pass_utils.py
@@ -1,0 +1,85 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+from typing import List
+
+import torch
+from beartype.roar import BeartypeDoorHintViolation
+from executorch.backends.cadence.aot.pass_utils import get_arg
+
+
+class TestGetArg(unittest.TestCase):
+    def _create_add_graph(self) -> torch.fx.GraphModule:
+        """Create a simple graph: output = input + 1."""
+
+        class AddModule(torch.nn.Module):
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return x + 1
+
+        m = AddModule()
+        gm = torch.fx.symbolic_trace(m)
+        return gm
+
+    def _create_graph_with_kwargs(
+        self, **kwargs: torch.fx.node.Argument
+    ) -> tuple[torch.fx.GraphModule, torch.fx.Node]:
+        """Create a graph with a node that has specific kwargs."""
+        graph = torch.fx.Graph()
+        node = graph.create_node("call_function", torch.add, kwargs=kwargs)
+        graph.output(node)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+        return gm, node
+
+    def test_get_arg_with_int_type(self) -> None:
+        """Test get_arg returns the value and validates int type."""
+        _, node = self._create_graph_with_kwargs(input=1, other=2)
+        result = get_arg(node, "input", int)
+        self.assertEqual(result, 1)
+
+    def test_get_arg_with_float_type(self) -> None:
+        """Test get_arg returns the value and validates float type."""
+        _, node = self._create_graph_with_kwargs(input=3.14, other=2)
+        result = get_arg(node, "input", float)
+        self.assertAlmostEqual(result, 3.14)
+
+    def test_get_arg_with_str_type(self) -> None:
+        """Test get_arg returns the value and validates str type."""
+        _, node = self._create_graph_with_kwargs(input="hello", other=2)
+        result = get_arg(node, "input", str)
+        self.assertEqual(result, "hello")
+
+    def test_get_arg_with_list_type(self) -> None:
+        """Test get_arg returns the value and validates list type."""
+        _, node = self._create_graph_with_kwargs(input=[1, 2, 3], other=2)
+        result = get_arg(node, "input", list)
+        self.assertEqual(result, [1, 2, 3])
+
+    def test_get_arg_with_list_int_type(self) -> None:
+        """Test get_arg validates parameterized List[int] type."""
+        _, node = self._create_graph_with_kwargs(input=[1, 2, 3], other=2)
+        result = get_arg(node, "input", List[int])
+        self.assertEqual(result, [1, 2, 3])
+
+    def test_get_arg_without_type_returns_value(self) -> None:
+        """Test get_arg without expected_type (default Argument) returns value."""
+        _, node = self._create_graph_with_kwargs(input=42, other=2)
+        result = get_arg(node, "input")
+        self.assertEqual(result, 42)
+
+    def test_get_arg_type_mismatch_raises(self) -> None:
+        """Test get_arg raises BeartypeDoorHintViolation on type mismatch."""
+        _, node = self._create_graph_with_kwargs(input="not_an_int", other=2)
+        with self.assertRaises(BeartypeDoorHintViolation):
+            get_arg(node, "input", int)
+
+    def test_get_arg_list_type_mismatch_raises(self) -> None:
+        """Test get_arg raises BeartypeDoorHintViolation when list elements mismatch."""
+        _, node = self._create_graph_with_kwargs(input=["a", "b"], other=2)
+        with self.assertRaises(BeartypeDoorHintViolation):
+            get_arg(node, "input", List[int])


### PR DESCRIPTION
Summary:
Enhanced the get_arg utility in pass_utils.py to support generic type checking using TypeVar and overload decorators. When an expected_type is provided, the function now asserts the type instead of requiring manual casting, providing better type safety and cleaner code.

Replaced all cast(..., get_arg(...)) patterns across the codebase with the new type-checked API:
- executorch/backends/cadence/aot: 14 patterns in fuse_ops.py and remove_ops.py
- on_device_ai/helios: 7 patterns across roi_align_sampled_points.py, merge_split_concat_chain.py, emulate_non_unitary_depthwise_convolution_pass.py, and et_dump_debugger.py

Benefits:
- Type Safety: Assertions catch type errors explicitly instead of silent casts
- Cleaner Code: Eliminated 21 cast patterns, removed 4 unused cast imports
- Better API: Single generic function replaces type-specific helper functions
- Maintainability: Centralized type validation logic

Examples:
- cast(Node, get_arg(node, "weight")) → get_arg(node, "weight", Node)
- cast(int, get_arg(node, "dim")) → get_arg(node, "dim", int)
- cast(float, get_arg(node, "eps")) → get_arg(node, "eps", float)

Reviewed By: DrJessop

Differential Revision: D92884254


