### PR TITLE
Support NVidia Nemo Sortformer Diarization model on XNNPACK

### DIFF
--- a/.claude/skills/export/SKILL.md
+++ b/.claude/skills/export/SKILL.md
@@ -26,3 +26,6 @@ with open("model.pte", "wb") as f:
 ## Debugging
 - Draft export: `export(model, inputs, strict=False)`
 - tlparse: `TORCH_LOGS="+dynamo,+export" python script.py 2>&1 | tlparse`
+
+## Guides
+- [torch.export basics](guides/torch-export.md) — `torch.export.export()`, dynamic shapes, strict mode, debugging

--- a/.claude/skills/export/guides/torch-export.md
+++ b/.claude/skills/export/guides/torch-export.md
@@ -1,0 +1,619 @@
+# torch.export.export()
+
+Captures a PyTorch `nn.Module` into an `ExportedProgram` — a fully traced
+ATen-dialect graph with no Python runtime dependency.
+
+```python
+from torch.export import export
+exported = export(model.eval(), (example_input,))
+```
+
+## How export works
+
+### The tracing mechanism
+
+`torch.export` traces `forward()` by replacing real tensors with **fake
+tensors** — objects that carry shapes, dtypes, and device metadata but no data.
+These are wrapped in proxy objects that record every ATen operation into a graph.
+The result is a fixed DAG of operations that can be executed without Python.
+
+Fake tensors are implemented as meta-device tensor subclasses that lie about
+their device. Each operator has a **fake implementation** (meta kernel) that
+computes output shapes and metadata from input shapes — without touching data.
+For example, `torch.cat`'s fake kernel sums input sizes along the cat dimension.
+When you see `UnsupportedOperatorException`, it means an operator is missing
+its fake implementation.
+
+Two tracing modes:
+
+- **Non-strict** (`strict=False`, recommended): the Python interpreter runs
+  normally with fake tensors. Most Python patterns work. Conditions on tensor
+  shapes are captured as guards.
+- **Strict** (`strict=True`, current default): TorchDynamo analyzes Python
+  bytecode symbolically without executing it. More restrictive — some Python
+  patterns are unsupported. Will stop being the default.
+
+### Static vs dynamic values
+
+Every value encountered during tracing is classified as either **static** (fixed
+at export time, burned into the graph as a constant) or **dynamic** (variable
+across runs, tracked symbolically in the graph).
+
+| Value | Classification |
+|-------|---------------|
+| Tensor data | Always dynamic |
+| Tensor shapes | Static by default; dynamic via `dynamic_shapes` |
+| Tensor metadata (dtype, device, layout) | Always static |
+| Python primitives (int, float, bool, str, None) | Always static |
+| Container structure (list length, dict keys) | Always static |
+| Module parameters and buffers | Dynamic data, always-static shapes |
+| Module attributes of primitive type | Always static |
+
+**Static values are constant-folded.** If `y = 3` is a static input and the
+model computes `x + y + 7`, the graph contains `x + 10`. The graph is
+*specialized* to that value — passing a different one at runtime raises an
+error. Loops over static values are unrolled; branches on static values are
+resolved to a single path.
+
+**Dynamic values flow through the graph as symbolic variables.** The tracer
+must prove that all operations on them are valid for all possible runtime
+values.
+
+This classification is the single concept from which all export behavior
+follows. Control flow, shape constraints, and failure modes are all
+consequences of how the tracer handles static vs dynamic values.
+
+### Symbolic shapes
+
+When a dimension is marked dynamic, the tracer assigns it a **symbol** (e.g.,
+`s0`). As operations transform tensors, output shapes become **symbolic
+expressions** computed by fake implementations: `torch.cat([x, x], dim=0)`
+produces shape `[2*s0, ...]`; a stride-2 conv on length `L` produces
+`1 + ((L - 1) // 2)`.
+
+Symbols are either **backed** or **unbacked**:
+
+- **Backed symbols** come from input dimensions marked as dynamic. They have
+  **hint values** — the concrete sizes from the example inputs. The tracer uses
+  hints to evaluate conditions, pick branches, and emit guards.
+
+- **Unbacked symbols** come from operations whose output shape depends on
+  tensor *data*, not tensor shapes (e.g., `torch.nonzero()`, `.item()`). They
+  have no hint value, so the tracer can't evaluate conditions involving them
+  without explicit help (see `torch._check` below).
+
+### Guards
+
+When the tracer encounters a condition on a backed dynamic shape, it uses
+the hint to evaluate it, picks a branch, and records a **guard** — a symbolic
+boolean expression asserting that the branch choice is correct. For example,
+`if x.size(0) > 4` with hint `s0 = 8` produces the guard `s0 > 4`.
+
+After tracing, all guards must be **provable** from the `Dim` specification
+(the `min`/`max` ranges). If the solver can't prove a guard, export fails with
+`ConstraintViolationError` and suggests how to fix the `Dim` spec.
+
+The solver uses algebraic reasoning over the `Dim` ranges. It handles **linear
+arithmetic well** (addition, multiplication, comparison) but is **weak at
+integer division (`//`) and modular arithmetic (`%`)**. Any shape expression
+involving these operators is likely to produce guards the solver can't prove.
+This is the root cause of the most difficult export failures.
+
+## API
+
+```python
+torch.export.export(
+    model,          # nn.Module in eval mode
+    args=(),        # tuple of example positional inputs
+    kwargs=None,    # dict of example keyword inputs
+    dynamic_shapes=None,  # shape dynamism specification
+    strict=True,    # True: strict tracing. False: non-strict (recommended)
+)
+```
+
+### Dynamic shapes
+
+By default, every dimension is static. `dynamic_shapes` maps inputs to symbolic
+dimension specs. Dynamic rank (changing the number of dimensions) is not
+supported.
+
+```python
+from torch.export import Dim, export
+
+batch = Dim("batch", min=1, max=32)
+seq_len = Dim("seq_len", min=1, max=2048)
+
+exported = export(
+    model.eval(),
+    (example_input,),
+    dynamic_shapes={"x": {0: batch, 1: seq_len}},
+)
+```
+
+Rules:
+- Keys match kwarg names or positional index
+- Values map dimension indices → `Dim` objects
+- Unspecified dimensions remain static
+- `{}` for an input means all dims are static
+- Same `Dim` object across inputs asserts equal size
+- Linear relationships between dims: `{0: dx}`, `{0: 2 * dx}`
+
+#### Dim.DYNAMIC and Dim.AUTO
+
+Instead of explicit `Dim("name", min=, max=)`:
+
+- **`Dim.DYNAMIC`**: infer range automatically. **Errors** if the dimension
+  turns out to be static (i.e., requires it to truly be dynamic).
+- **`Dim.AUTO`**: infer range automatically. **Does not error** if the dimension
+  is static. "Best effort" — marks dynamic if possible, keeps static otherwise.
+
+Both often produce unbounded ranges (`int_oo` upper bound). Downstream
+consumers that need concrete upper bounds for memory planning will fail. Always
+prefer explicit `Dim(min=, max=)`.
+
+#### ShapesCollection
+
+For complex nested inputs (dicts, dataclasses), `ShapesCollection` lets you
+assign dynamic shapes directly to tensor objects instead of mirroring the input
+structure:
+
+```python
+sc = torch.export.ShapesCollection()
+sc[tensor_x] = (dim, dim + 1, 8)     # tuple: per-dimension specs
+sc[tensor_y] = {0: dim * 2}          # dict: only specified dims are dynamic
+ep = export(M(), (args,), dynamic_shapes=sc)
+```
+
+#### 0/1 specialization
+
+By default, the system specializes on dimensions of size 0 or 1. This avoids
+complex guards for broadcasting and contiguity edge cases. Dynamic symbols
+start with an implicit range of `[2, int_oo]` unless the `Dim` spec explicitly
+includes 0 or 1.
+
+This means: if your `Dim(min=1)` and the example input has size 1 on that
+dimension, export may specialize it as static. Use `min=2` or larger, or
+provide an example input with size > 1.
+
+## The ExportedProgram
+
+```python
+exported = export(model.eval(), (x,))
+
+print(exported.graph)            # torch.fx.Graph — the traced DAG
+gm = exported.graph_module       # torch.fx.GraphModule wrapping the graph
+out = exported.module()(x)       # run eagerly for correctness testing
+```
+
+### Key attributes
+
+- `exported.graph_signature` — describes which graph inputs are user inputs,
+  parameters, or buffers, and which outputs are buffer mutations
+- `exported.range_constraints` — maps symbols (`s0`, `s1`) to their proven
+  value ranges, reflecting guards from tracing
+- `exported.state_dict` — parameters and buffers
+
+### Unflattening
+
+Export produces a flattened graph (all submodules inlined). To reconstruct the
+original module hierarchy:
+
+```python
+from torch.export import unflatten
+unflat = unflatten(exported)  # returns UnflattenedModule with original hierarchy
+```
+
+Module swaps on the unflattened module won't work unless you set
+`preserve_module_call_signature` during export:
+
+```python
+ep = export(model, args, preserve_module_call_signature=("encoder",))
+```
+
+### Node metadata
+
+Every `call_function` node has:
+- `node.meta["val"]` — a `FakeTensor` or `SymInt` describing the output shape
+  and dtype. This is the source of truth for shape information in the graph.
+- `node.meta["stack_trace"]` — Python source location
+- `node.meta["nn_module_stack"]` — which `nn.Module` the op came from
+- `node.meta["source_fn_stack"]` — the original torch function before
+  decomposition
+
+### IR levels
+
+Export produces three IR levels via `run_decompositions`:
+
+| IR | How | Properties | Op count |
+|----|-----|-----------|----------|
+| Training IR | `export()` (default) | May contain mutations | ~3000 |
+| Inference IR | `ep.run_decompositions(decomp_table={})` | Purely functional | ~2000 |
+| Core ATen IR | `ep.run_decompositions(decomp_table=None)` | Highly decomposed | ~180 |
+
+Training IR preserves in-place ops (`aten.add_`) for autograd compatibility.
+Inference IR functionalizes them (`aten.add`). Core ATen IR decomposes further
+(e.g., `conv2d` → `convolution`). Most deployment backends use Core ATen IR.
+
+Use `torch.no_grad()` when producing inference or Core ATen IR:
+```python
+with torch.no_grad():
+    inference_ep = exported.run_decompositions(decomp_table={})
+```
+
+Custom decompositions: start from the default table and override specific ops:
+```python
+decomp_table = torch.export.default_decompositions()
+
+def _linear_decomp(input, weight, bias=None):
+    out = input @ weight.T
+    return out + bias if bias is not None else out
+
+decomp_table[torch.ops.aten.linear.default] = _linear_decomp
+
+with torch.no_grad():
+    exported = exported.run_decompositions(decomp_table)
+```
+
+### Serialization
+
+```python
+torch.export.save(exported, "model.pt2")
+loaded = torch.export.load("model.pt2")
+```
+
+The `.pt2` file is a zipfile containing the graph, state dict, and metadata.
+
+## Control flow
+
+How control flow is handled follows directly from the static/dynamic
+classification of the condition:
+
+### Static control flow
+
+Branches on static values (Python primitives, static shapes) are resolved at
+trace time. The taken branch is traced; the other is discarded. Loops over
+static ranges are unrolled. This is transparent — no special handling needed.
+
+### Shape-dependent control flow
+
+When a condition involves **backed** dynamic shapes, the tracer uses the hint
+value to evaluate it, traces the taken branch, and emits a **guard**. The guard
+must be provable from the `Dim` spec.
+
+```python
+def forward(self, x):
+    if x.size(0) > 4:      # guard: s0 > 4
+        return x.sin()
+    return x.cos()
+```
+
+If `Dim("batch", min=2, max=32)`, the solver proves `s0 > 4` is not always
+true → `ConstraintViolationError`. Fix: use `min=5`, or restructure to
+avoid the branch, or use `torch.cond`.
+
+### Data-dependent control flow
+
+When a condition involves **unbacked** dynamic shapes (from `.item()`,
+`.nonzero()`, etc.), the tracer has no hint to evaluate it →
+`GuardOnDataDependentSymNode`.
+
+Two solutions:
+
+**`torch._check`** — assert a fact about the unbacked symbol so the tracer can
+continue on one branch. Creates a runtime assertion in the graph.
+
+```python
+nz = x.nonzero()
+torch._check(nz.shape[0] > 0)    # refines u0 range to [1, inf]
+if nz.shape[0] > 0:               # tracer now picks True
+    return x.sin()
+```
+
+**`torch.cond`** — trace both branches. The graph contains both subgraphs and
+selects at runtime. Use when you genuinely need both paths.
+
+```python
+return torch.cond(
+    pred=x.sum() > 0,
+    true_fn=lambda x: x.sin(),
+    false_fn=lambda x: x.cos(),
+    operands=(x,),
+)
+```
+
+`torch.cond` lowers to `torch.ops.higher_order.cond` — a special node with two
+`GraphModule` attributes for the branches. No closures; all captured values
+become explicit operands. No mutations allowed in branches.
+
+**`torch.map`** — trace a loop body over a dynamic number of iterations. Use for
+data-dependent loops where unrolling isn't possible:
+
+```python
+return torch.map(
+    f=lambda x_i: x_i.sin(),
+    xs=(x,),  # map over first dim of each tensor
+)
+```
+
+**`torch._check_is_size`** — like `torch._check`, but additionally marks the
+unbacked symbol as "size-like." Size-like symbols are assumed to never be 0 or
+1 under `guard_size_oblivious` checks, which eliminates many framework-internal
+guards. Use when passing an unbacked symbol to a function that expects a tensor
+dimension.
+
+## Module state
+
+Rules for module state during tracing:
+
+- **Parameters**: read freely, **cannot be updated** during forward. Export with
+  `torch.no_grad()` to avoid autograd-related updates.
+- **Buffers**: read freely, **can be updated** (in-place or reassignment).
+  Updated buffers are lifted as additional graph outputs.
+- **Attributes of primitive type**: static — read freely, updates are burned in
+  (no graph instructions emitted for gets/sets).
+- **Attributes of Tensor type**: can be read but **cannot be updated** during
+  forward. Register as a buffer if updates are needed.
+- **All module state shapes are static** — parameter and buffer shapes cannot be
+  dynamic.
+
+## When export fails
+
+Every failure traces back to the tracer encountering something the static graph
+contract can't represent. Diagnose by asking: **is this a control flow problem,
+a shape constraint problem, a side effect, or a missing kernel?**
+
+### Shape constraint failures
+
+The most common and subtle failures. When a dimension is symbolic, every
+downstream shape operation generates guards. The solver must prove each guard
+from the `Dim` min/max bounds. Most difficult failures involve `//` or `%` in
+symbolic expressions (see Guards above).
+
+When export raises `ConstraintViolationError`, the error message includes
+suggested fixes. Apply them automatically:
+
+```python
+from torch.export.dynamic_shapes import refine_dynamic_shapes_from_suggested_fixes
+
+try:
+    ep = export(model, args, dynamic_shapes=ds)
+except Exception as e:
+    ds = refine_dynamic_shapes_from_suggested_fixes(str(e), ds)
+    ep = export(model, args, dynamic_shapes=ds)
+```
+
+**Modular branches from padding/alignment logic.**
+```
+Not all values of seq_len satisfy ((1 + (seq_len // S)) % N) != 0
+```
+Models that pad or align to multiples of N create guards like
+`if frames % N == 0`. The solver can't prove modular conditions for arbitrary
+`Dim` values.
+Fix: disable the alignment logic before export (e.g., set the pad-to-multiple
+config to 0, or override the padding method to be a no-op). Alternatively,
+constrain the `Dim` so the condition is always true.
+
+**reshape with `-1` inference on symbolic dimensions.**
+```
+(D + D*(((-1) + L) // S)) == (1 + (((-1) + L) // S))
+```
+`reshape(b, t, -1)` needs the solver to prove `numel / (b*t)` is a whole
+number. When `t` involves `//`, the solver can't.
+Fix: `flatten(start_dim)` on *static* dimensions instead of `reshape`.
+`x.permute(0, 2, 1, 3).flatten(2)` flattens dims 2+3 (both static) without
+generating guards on the dynamic dimension.
+
+**Linear/matmul on conv-derived symbolic expressions.**
+```
+(1 % (1 + (((-1) + L) // S))) != 0
+```
+After strided convolutions, the output dimension becomes
+`1 + ((L-1)//S)`. Applying `nn.Linear` triggers a contiguity/divisibility
+guard the solver can't prove. Known limitation — `torch._check`,
+`.contiguous()`, `.clone()` don't help. The `//` in the symbolic expression is
+the root cause. A plain `Dim` works fine with `Linear`; the issue is
+specifically expressions produced by strided convolutions.
+
+**view/reshape mixing two correlated dynamic dimensions.**
+```
+(((-1) + ((2*T*T) // T)) % T) != 0
+```
+`view(b, h, -1, T)` on a `(b, h, T, 2T)` tensor creates numel `2*T*T`.
+The `-1` resolves to `(2*T*T)//T` which the solver can't simplify to `2*T`.
+This arises in relative position attention where pad+view is used to shift
+position scores across two sequence-length-dependent dimensions.
+Fix: replace the pad+reshape+slice pattern with `torch.gather` using
+explicitly computed indices:
+```python
+arange = torch.arange(seq_len, device=x.device)
+idx = arange.unsqueeze(0) - arange.unsqueeze(1) + (seq_len - 1)
+idx = idx.unsqueeze(0).unsqueeze(0).expand(b, h, -1, -1)
+result = torch.gather(x, 3, idx)  # (b, h, T, T) — no view needed
+```
+The gather operates element-wise without view guards. Using explicit
+dimensions in `reshape` (no `-1`) doesn't help because the stride
+computation in the view algorithm also generates unprovable guards.
+
+### Side effect failures
+
+The graph captures a pure function. Conditional buffer mutations, distributed
+calls, or in-place state updates during `forward()` break this contract.
+
+```python
+def forward(self, x):
+    if x.size(1) > self.max_len:
+        self.pos_enc = make_pos_enc(x.size(1))   # conditional mutation
+```
+
+Fix: pre-compute state at maximum size before export, then no-op the updater
+so `forward()` is pure. Note that *unconditional* buffer updates are supported
+— the graph lifts them as additional outputs.
+
+### Missing fake kernels
+
+Custom operators need a fake (meta) implementation that computes output shapes
+without data:
+
+```python
+@torch.library.register_fake("mylib::custom_op")
+def _(x):
+    return torch.empty_like(x)
+
+# For data-dependent output shapes:
+@torch.library.register_fake("mylib::custom_nonzero")
+def _(x):
+    nnz = torch.library.get_ctx().new_dynamic_size()  # unbacked symbol
+    return x.new_empty([nnz, x.dim()], dtype=torch.int64)
+```
+
+### Making untraceable code traceable
+
+When the problematic code is in a module you can't modify:
+
+**Wrapper modules** — present a traceable `forward()` around a subgraph:
+
+```python
+class EncoderWrapper(nn.Module):
+    def __init__(self, model):
+        super().__init__()
+        self.encoder = model.encoder
+        self.proj = model.projection
+
+    def forward(self, x, length):
+        enc_out, _ = self.encoder(x=x, length=length)
+        return self.proj(enc_out)
+```
+
+**Re-implementing untraceable layers** — when a layer's `forward()` has
+data-dependent masking, generator-based loops, or other untraceable patterns,
+re-implement the forward logic in the wrapper. Extract sub-modules as
+`nn.ModuleList` so weights remain in the graph:
+
+```python
+class ConvWrapper(nn.Module):
+    def __init__(self, conv_block):
+        super().__init__()
+        self.conv_layers = nn.ModuleList(list(conv_block.layers))
+        self.out = conv_block.out
+
+    def forward(self, x):
+        x = x.unsqueeze(1)
+        for layer in self.conv_layers:
+            x = layer(x)
+        x = x.permute(0, 2, 1, 3).flatten(2)
+        return self.out(x)
+```
+
+The key question: *which operations in the original forward() actually matter
+for inference?* Training-only logic (masking for batched inputs, dynamic
+padding for variable batches, gradient checkpointing) can be dropped for
+single-sample inference.
+
+**Monkey-patching individual methods** — when the problem is a single method
+buried deep in a module hierarchy, wrapping the outer module doesn't help.
+Use `types.MethodType` to surgically replace just that method on each
+affected sub-module:
+
+```python
+import types
+
+def _fixed_method(self, x):
+    # export-safe reimplementation
+    ...
+
+for layer in model.encoder.layers:
+    layer.attn.problematic_method = types.MethodType(
+        _fixed_method, layer.attn
+    )
+```
+
+This preserves the module hierarchy and all weights — only the forward logic
+of the targeted method changes. Useful when the same problematic pattern
+repeats across many layers (e.g., attention layers in a transformer stack).
+
+**Overriding device-dependent branches** — some models
+have `if torch.cuda.is_available():` branches that route to CUDA-specific
+code paths. During tracing on CPU, these branches can still cause issues if
+the tracer sees both paths. Override before export:
+
+```python
+old = torch.cuda.is_available
+torch.cuda.is_available = lambda: False
+ep = export(wrapper, args, strict=False)
+torch.cuda.is_available = old
+```
+
+## Debugging
+
+### draft_export
+
+When export fails repeatedly and you want to see all issues at once instead of
+fixing them one by one:
+
+```python
+ep = torch.export.draft_export(model, args)
+print(ep._report)    # detailed report with per-issue debug info
+```
+
+`draft_export` always produces a graph, even with soundness issues. It uses
+**real tensor tracing** alongside fake tensors — when the fake tracer can't
+evaluate a condition, it falls back to the real tensor value and emits a runtime
+assert. It also catches missing fake kernels (using real kernels as fallback)
+and incorrect fake kernels (by comparing real vs fake outputs). Not for
+production — for diagnosis.
+
+### TORCH_LOGS and tlparse
+
+Enable verbose logging and parse into an HTML report:
+```bash
+TORCH_LOGS="+dynamo,+export" python export_script.py 2>&1 | tlparse
+```
+
+The report shows guard failures, graph breaks, symbol creation, and the traced
+graph. Key log patterns:
+- `create_symbol s0 = 5 for L['x'].size()[0]` — symbol allocated with hint
+- `eval Eq(s0, 5) [guard added]` — guard generated from a condition
+- `GuardOnDataDependentSymNode` — unbacked symbol hit a branch
+
+For deeper debugging:
+- `TORCHDYNAMO_EXTENDED_DEBUG_CREATE_SYMBOL="s0"` — full trace for one symbol
+- `TORCHDYNAMO_EXTENDED_DEBUG_GUARD_ADDED="Eq(s0, 5)"` — trace a specific guard
+- `TORCHDYNAMO_EXTENDED_DEBUG_CPP=1` — C++ backtraces for guards from kernels
+
+### Incremental testing
+
+Isolate failures by controlling one variable at a time:
+
+1. **Static shapes first** (no `dynamic_shapes`). If this fails, the problem is
+   control flow or side effects — not shape constraints.
+2. **Add one dynamic dimension at a time**. The dimension that causes failure
+   tells you which downstream shape expression is unprovable.
+3. **Test each wrapper independently** before combining them.
+
+```python
+# Step 1: catches control flow + side effects
+ep = export(wrapper, args, strict=False)
+
+# Step 2: catches shape constraint violations
+ep = export(wrapper, args, dynamic_shapes=ds, strict=False)
+```
+
+### Static shapes as deliberate fallback
+
+When a dimension is fundamentally blocked from being dynamic — typically due
+to `//` or `%` in the symbolic expression (e.g., conv-derived `1+((L-1)//S)`
+hitting `nn.Linear`) — keeping that dimension static is a valid strategy, not
+a failure.
+
+Design the export around it: use a fixed input size for the affected method
+and have the caller handle variable-length inputs via padding/truncation or
+chunking. This is practical when the model already operates on fixed-size
+chunks (e.g., streaming models with fixed chunk sizes per config).
+
+```python
+# Dynamic shapes blocked → use static shapes, caller pads to fixed size
+ep = export(
+    wrapper, (fixed_size_input, length),
+    strict=False,   # no dynamic_shapes
+)
+```

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@
 # - voxtral:  Multimodal voice + text model (CPU, CUDA, Metal)
 # - whisper:  Speech recognition model (CPU, CUDA, Metal)
 # - parakeet: Speech recognition model (CPU, CUDA, Metal)
+# - sortformer: Speaker diarization model (CPU)
 # - llama:    Text generation model (CPU)
 # - llava:    Vision + language model (CPU)
 # - gemma3:   Text generation model (CPU, CUDA)
@@ -88,7 +89,7 @@
 #
 # ==============================================================================
 
-.PHONY: voxtral-cuda voxtral-cpu voxtral-metal whisper-cuda whisper-cuda-debug whisper-cpu whisper-metal parakeet-cuda parakeet-cuda-debug parakeet-cpu parakeet-metal llama-cpu llava-cpu gemma3-cuda gemma3-cpu clean help
+.PHONY: voxtral-cuda voxtral-cpu voxtral-metal whisper-cuda whisper-cuda-debug whisper-cpu whisper-metal parakeet-cuda parakeet-cuda-debug parakeet-cpu parakeet-metal sortformer-cpu llama-cpu llava-cpu gemma3-cuda gemma3-cpu clean help
 
 help:
 	@echo "This Makefile adds targets to build runners for various models on various backends. Run using \`make <target>\`. Available targets:"
@@ -103,6 +104,7 @@ help:
 	@echo "  parakeet-cuda-debug - Build Parakeet runner with CUDA backend (debug mode)"
 	@echo "  parakeet-cpu        - Build Parakeet runner with CPU backend"
 	@echo "  parakeet-metal      - Build Parakeet runner with Metal backend (macOS only)"
+	@echo "  sortformer-cpu      - Build Sortformer runner with CPU backend"
 	@echo "  llama-cpu           - Build Llama runner with CPU backend"
 	@echo "  llava-cpu           - Build Llava runner with CPU backend"
 	@echo "  gemma3-cuda         - Build Gemma3 runner with CUDA backend"
@@ -207,6 +209,15 @@ parakeet-metal:
 	@echo ""
 	@echo "✓ Build complete!"
 	@echo "  Binary: cmake-out/examples/models/parakeet/parakeet_runner"
+
+sortformer-cpu:
+	@echo "==> Building and installing ExecuTorch..."
+	cmake --workflow --preset llm-release
+	@echo "==> Building Sortformer runner (CPU)..."
+	cd examples/models/sortformer && cmake --workflow --preset sortformer-cpu
+	@echo ""
+	@echo "✓ Build complete!"
+	@echo "  Binary: cmake-out/examples/models/sortformer/sortformer_runner"
 
 llama-cpu:
 	@echo "==> Building and installing ExecuTorch..."

--- a/examples/models/sortformer/CMakeLists.txt
+++ b/examples/models/sortformer/CMakeLists.txt
@@ -1,0 +1,116 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+cmake_minimum_required(VERSION 3.24)
+project(sortformer_runner)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
+
+include(${EXECUTORCH_ROOT}/tools/cmake/Utils.cmake)
+
+# Let files say "include <executorch/path/to/header.h>"
+set(_common_include_directories ${EXECUTORCH_ROOT}/..)
+
+# Need this for gflags
+set(gflags_DIR ${CMAKE_CURRENT_BINARY_DIR}/../../../third-party/gflags)
+find_package(gflags REQUIRED)
+
+# Find executorch libraries
+list(APPEND CMAKE_FIND_ROOT_PATH ${CMAKE_CURRENT_BINARY_DIR}/../../..)
+find_package(executorch CONFIG REQUIRED FIND_ROOT_PATH_BOTH)
+get_target_property(_executorch_imported executorch IMPORTED)
+if(NOT _executorch_imported)
+  executorch_target_link_options_shared_lib(executorch)
+endif()
+
+set(link_libraries executorch gflags)
+
+# Common ops for all builds
+if(TARGET optimized_native_cpu_ops_lib)
+  list(APPEND link_libraries optimized_native_cpu_ops_lib cpublas eigen_blas)
+  get_target_property(_is_imported optimized_native_cpu_ops_lib IMPORTED)
+  if(NOT _is_imported)
+    executorch_target_link_options_shared_lib(optimized_native_cpu_ops_lib)
+  endif()
+endif()
+
+# CPU-only builds need quantized and custom ops
+if(NOT EXECUTORCH_BUILD_CUDA AND MSVC)
+  list(APPEND link_libraries quantized_ops_lib custom_ops)
+  executorch_target_link_options_shared_lib(quantized_ops_lib)
+  executorch_target_link_options_shared_lib(custom_ops)
+endif()
+
+# XNNPACK
+if(TARGET xnnpack_backend)
+  set(xnnpack_backend_libs xnnpack_backend XNNPACK xnnpack-microkernels-prod)
+  if(TARGET kleidiai)
+    list(APPEND xnnpack_backend_libs kleidiai)
+  endif()
+  list(APPEND link_libraries ${xnnpack_backend_libs})
+  get_target_property(_xnnpack_imported xnnpack_backend IMPORTED)
+  if(NOT _xnnpack_imported)
+    executorch_target_link_options_shared_lib(xnnpack_backend)
+  endif()
+endif()
+
+# Needed for cpuinfo where it uses android specific log lib
+if(ANDROID)
+  list(APPEND link_libraries log)
+endif()
+
+# Add the required ExecuTorch extensions
+list(
+  APPEND
+  link_libraries
+  extension_llm_runner
+  extension_module
+  extension_data_loader
+  extension_tensor
+  extension_flat_tensor
+)
+
+# Link CUDA backend
+if(EXECUTORCH_BUILD_CUDA)
+  find_package(CUDAToolkit REQUIRED)
+  list(APPEND link_libraries aoti_cuda_backend)
+  if(NOT MSVC)
+    executorch_target_link_options_shared_lib(aoti_cuda_backend)
+  endif()
+endif()
+
+if(EXECUTORCH_BUILD_METAL)
+  list(APPEND link_libraries metal_backend)
+  executorch_target_link_options_shared_lib(metal_backend)
+endif()
+
+add_executable(sortformer_runner main.cpp sortformer_runner.cpp)
+if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+  target_link_options_gc_sections(sortformer_runner)
+  if(NOT APPLE AND NOT MSVC)
+    target_link_options(sortformer_runner PRIVATE "LINKER:-s")
+  endif()
+endif()
+
+target_include_directories(
+  sortformer_runner PUBLIC ${_common_include_directories}
+)
+target_link_libraries(sortformer_runner PUBLIC ${link_libraries})
+target_compile_options(sortformer_runner PUBLIC ${_common_compile_options})
+
+# On Windows, copy required DLLs to the executable directory
+if(MSVC AND EXECUTORCH_BUILD_CUDA)
+  add_custom_command(
+    TARGET sortformer_runner
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:aoti_cuda_shims>
+            $<TARGET_FILE_DIR:sortformer_runner>
+    COMMENT "Copying aoti_cuda_shims.dll to sortformer_runner directory"
+  )
+endif()

--- a/examples/models/sortformer/CMakePresets.json
+++ b/examples/models/sortformer/CMakePresets.json
@@ -1,0 +1,44 @@
+{
+    "version": 6,
+    "configurePresets": [
+        {
+            "name": "sortformer-base",
+            "hidden": true,
+            "binaryDir": "${sourceDir}/../../../cmake-out/examples/models/sortformer",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release",
+                "CMAKE_FIND_ROOT_PATH": "${sourceDir}/../../../cmake-out",
+                "CMAKE_PREFIX_PATH": "${sourceDir}/../../../cmake-out"
+            }
+        },
+        {
+            "name": "sortformer-cpu",
+            "displayName": "Sortformer runner (CPU)",
+            "inherits": ["sortformer-base"]
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "sortformer-cpu",
+            "displayName": "Build Sortformer runner (CPU)",
+            "configurePreset": "sortformer-cpu",
+            "targets": ["sortformer_runner"]
+        }
+    ],
+    "workflowPresets": [
+        {
+            "name": "sortformer-cpu",
+            "displayName": "Configure and build Sortformer runner (CPU)",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "sortformer-cpu"
+                },
+                {
+                    "type": "build",
+                    "name": "sortformer-cpu"
+                }
+            ]
+        }
+    ]
+}

--- a/examples/models/sortformer/README.md
+++ b/examples/models/sortformer/README.md
@@ -1,0 +1,147 @@
+# Streaming Sortformer Diarizer for ExecuTorch
+
+Export and run [nvidia/diar_streaming_sortformer_4spk-v2](https://huggingface.co/nvidia/diar_streaming_sortformer_4spk-v2) (117M params) on ExecuTorch for native C++ speaker diarization. Tested with both [v2](https://huggingface.co/nvidia/diar_streaming_sortformer_4spk-v2) and [v2.1](https://huggingface.co/nvidia/diar_streaming_sortformer_4spk-v2.1).
+
+Speaker diarization answers "who spoke when" — the model outputs per-frame activity probabilities for up to 4 speakers. This is not ASR; there is no text output.
+
+## Quick Start
+
+```bash
+# Install Python dependencies
+pip install -r install_requirements.txt
+
+# Export to .pte
+cd examples/models/sortformer
+python export_sortformer.py --nemo-path /path/to/model.nemo --backend xnnpack
+
+# Build the C++ runner (from repo root)
+make sortformer-cpu
+
+# Run diarization
+./cmake-out/examples/models/sortformer/sortformer_runner \
+    --model_path examples/models/sortformer/sortformer_exports/sortformer.pte \
+    --audio_path /path/to/audio.wav
+```
+
+Output:
+
+```
+Diarization results (440 segments, 13117 frames, 1049.4s):
+  0.480 1.760 speaker_0
+  10.960 11.760 speaker_1
+  12.000 14.640 speaker_1
+  ...
+
+Speaker 0: 3649/13117 frames active (27.8%)
+Speaker 1: 2040/13117 frames active (15.6%)
+Speaker 2: 2597/13117 frames active (19.8%)
+Speaker 3: 606/13117 frames active (4.6%)
+```
+
+Each line is `start_seconds end_seconds speaker_N`. Each output frame covers 80ms of audio (10ms stride x 8x subsampling).
+
+## Export
+
+```bash
+python export_sortformer.py --nemo-path /path/to/model.nemo --backend xnnpack
+```
+
+| Argument | Description |
+|----------|-------------|
+| `--nemo-path` | Path to `.nemo` model file |
+| `--hf-model` | HuggingFace model ID (default: `nvidia/diar_streaming_sortformer_4spk-v2`) |
+| `--backend` | `portable` or `xnnpack` (default: `xnnpack`) |
+| `--output-dir` | Output directory (default: `./sortformer_exports`) |
+
+Output: `sortformer_exports/sortformer.pte` (~470 MB unquantized). The preprocessor is always lowered with the portable backend regardless of `--backend`.
+
+## Validate
+
+Compare `.pte` output against NeMo's `diarize()` reference on real audio:
+
+```bash
+python validate_pte.py \
+    --nemo-path /path/to/model.nemo \
+    --pte-path ./sortformer_exports/sortformer.pte \
+    --wav /path/to/audio.wav
+```
+
+A passing result shows `decision agreement > 95%`.
+
+## C++ Runner
+
+### Build
+
+From the repository root:
+
+```bash
+make sortformer-cpu
+```
+
+Binary: `cmake-out/examples/models/sortformer/sortformer_runner`
+
+### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `--model_path` | Path to `.pte` file (default: `sortformer.pte`) |
+| `--audio_path` | Path to input WAV file (16kHz mono, required) |
+| `--threshold` | Speaker activity threshold, 0.0–1.0 (default: `0.5`) |
+| `--chunk_len` | Encode chunk size in 80ms frames (default: `124`) |
+| `--fifo_len` | FIFO buffer size in 80ms frames (default: `124`) |
+
+### How Streaming Works
+
+The runner handles audio of any length through a three-stage pipeline:
+
+1. **Preprocessor**: converts raw audio to mel spectrograms (up to 120s per call, chunked automatically for longer audio).
+2. **Pre_encode**: 8x convolutional downsampling from mel frames to 512-dim embeddings (4000 mel frames per call, ~40s each).
+3. **Encode**: conformer + transformer that produces per-frame speaker probabilities.
+
+The encode method has a 1000-frame input limit, so long audio must be processed in chunks. Each encode step sees three concatenated buffers:
+
+```
+[speaker_cache | FIFO | current_chunk]  →  encode  →  predictions
+```
+
+- **Current chunk** (`--chunk_len`): the new embedding frames being processed.
+- **FIFO** (`--fifo_len`): a sliding window of recent embeddings providing short-term context. As new chunks arrive, the oldest FIFO frames are pushed to the speaker cache.
+- **Speaker cache** (188 frames max): long-term memory. When it overflows, the least speaker-discriminative frames are dropped (ranked by max speaker probability — a simplification of NeMo's log-odds scoring).
+
+Only the current chunk's predictions are kept as output. The cache and FIFO exist purely to give the model context from earlier in the audio.
+
+### Streaming Configurations
+
+The defaults match the model's "High" config. The model was trained and evaluated with these specific configs, so matching one gives best results:
+
+| Config | `--chunk_len` | `--fifo_len` | Context per step |
+|--------|---------------|--------------|------------------|
+| Very high | 340 | 40 | 188 + 40 + 340 = 568 |
+| **High (default)** | **124** | **124** | **188 + 124 + 124 = 436** |
+| Low | 6 | 188 | 188 + 188 + 6 = 382 |
+| Ultra low | 3 | 188 | 188 + 188 + 3 = 379 |
+
+For offline processing, larger chunks generally give better predictions since the model sees more new audio per step. The "High" config is a good default.
+
+### Limitations
+
+- Input must be 16kHz mono WAV.
+- Memory scales linearly with audio length (~1.5 MB per minute) since all embeddings are collected before the streaming encode loop.
+
+## Exported Methods
+
+The `.pte` contains three methods, split along streaming boundaries so the caller manages chunking and cache state:
+
+| Method | Backend | Input | Output |
+|--------|---------|-------|--------|
+| `preprocessor` | portable | `audio` (N,) float, `length` (1,) int64 | `mel` (1, 128, T) float, `mel_len` (1,) int64 |
+| `pre_encode` | XNNPACK | `chunk` (1, 4000, 128) float, `chunk_len` (1,) int64 | `embs` (1, 500, 512) float, `emb_len` (1,) int64 |
+| `encode` | XNNPACK | `embs` (1, T, 512) float, `emb_len` (1,) int64 | `preds` (1, T, 4) float |
+
+- `preprocessor`: dynamic audio length (min=1600, max=1,920,000 samples).
+- `pre_encode`: static shapes (4000 mel frames).
+- `encode`: dynamic sequence length (min=2, max=1000 frames).
+
+**Metadata** via `constant_methods`: `sample_rate`, `window_stride`, `subsampling_factor`, `fc_d_model`, `tf_d_model`, `max_num_of_spks`, `spkcache_len`.
+
+The mel output from `preprocessor` is `(1, 128, T)` channels-first. `pre_encode` expects `(1, T, 128)` channels-last. The caller must transpose and pad to 4000 frames between stages. See `model.md` for architecture details.

--- a/examples/models/sortformer/export_sortformer.py
+++ b/examples/models/sortformer/export_sortformer.py
@@ -1,0 +1,382 @@
+"""Export streaming Sortformer diarizer components to ExecuTorch.
+
+Exports nvidia/diar_streaming_sortformer_4spk-v2 (117M param speaker diarization)
+as a multi-method .pte with three methods: preprocessor, pre_encode, encode.
+
+Usage:
+    python export_sortformer.py --nemo-path /path/to/model.nemo
+    python export_sortformer.py --hf-model nvidia/diar_streaming_sortformer_4spk-v2
+"""
+
+import argparse
+import os
+from typing import Optional
+
+import torch
+
+from executorch.exir import (
+    EdgeCompileConfig,
+    ExecutorchBackendConfig,
+    to_edge_transform_and_lower,
+)
+from executorch.exir.passes import MemoryPlanningPass
+from torch import nn
+from torch.export import Dim, export
+
+
+class PreprocessorWrapper(torch.nn.Module):
+    """Wraps NeMo's AudioToMelSpectrogramPreprocessor for single-sample export.
+
+    Input: 1D audio waveform (N,) and length (1,) int64.
+    Output: mel spectrogram (1, 128, T_mel) and mel_len (1,) int64.
+    """
+
+    def __init__(self, preprocessor):
+        super().__init__()
+        self.preprocessor = preprocessor
+
+    def forward(
+        self, audio: torch.Tensor, length: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        audio_signal = audio.unsqueeze(0)
+        mel, mel_len = self.preprocessor(input_signal=audio_signal, length=length)
+        return mel, mel_len
+
+
+class PreEncodeWrapper(torch.nn.Module):
+    """Wraps ConvSubsampling (8x downsampling) for per-chunk export.
+
+    Input: chunk (1, T_mel_chunk, 128) float, chunk_len (1,) int64.
+    Output: embs (1, T_sub, 512) float, emb_len (1,) int64.
+
+    Re-implements ConvSubsampling.forward without MaskedConvSequential's
+    masking logic, which creates data-dependent guards that block torch.export.
+    Masking is unnecessary for single-sample inference with valid-length chunks.
+    """
+
+    def __init__(self, pre_encode):
+        super().__init__()
+        self.conv_layers = nn.ModuleList(list(pre_encode.conv))
+        self.out = pre_encode.out
+        self._left_padding = pre_encode._left_padding
+        self._right_padding = pre_encode._right_padding
+        self._kernel_size = pre_encode._kernel_size
+        self._stride = pre_encode._stride
+        self._ceil_mode = pre_encode._ceil_mode
+        self._sampling_num = pre_encode._sampling_num
+
+    def forward(
+        self, chunk: torch.Tensor, chunk_len: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        from nemo.collections.asr.parts.submodules.subsampling import calc_length
+
+        out_lengths = calc_length(
+            chunk_len,
+            all_paddings=self._left_padding + self._right_padding,
+            kernel_size=self._kernel_size,
+            stride=self._stride,
+            ceil_mode=self._ceil_mode,
+            repeat_num=self._sampling_num,
+        )
+        x = chunk.unsqueeze(1)  # (B, 1, T, feat_in)
+        for layer in self.conv_layers:
+            x = layer(x)
+        # flatten static dims C and F (not dynamic T) to avoid symbolic guards
+        x = x.permute(0, 2, 1, 3).flatten(2)  # (B, T_sub, C*F)
+        x = self.out(x)
+        return x, out_lengths.to(torch.int64)
+
+
+class EncodeWrapper(torch.nn.Module):
+    """Wraps conformer + encoder_proj + transformer + speaker head.
+
+    Input: embs (1, T_total, 512) float, emb_len (1,) int64.
+    Output: preds (1, T_total, 4) float — per-frame speaker probabilities.
+
+    The C++ runner concatenates [spkcache, fifo, chunk_embs] into a single
+    contiguous tensor and passes it here. Calls encoder with bypass_pre_encode=True
+    to skip ConvSubsampling (already run separately).
+    """
+
+    def __init__(self, encoder, encoder_proj, transformer_encoder, sortformer_modules):
+        super().__init__()
+        self.encoder = encoder
+        self.encoder_proj = encoder_proj if encoder_proj is not None else nn.Identity()
+        self.transformer_encoder = transformer_encoder
+        self.sortformer_modules = sortformer_modules
+
+    def forward(self, embs: torch.Tensor, emb_len: torch.Tensor) -> torch.Tensor:
+        # Conformer layers (skip pre_encode since input is already subsampled)
+        encoded, enc_len = self.encoder(
+            audio_signal=embs, length=emb_len, bypass_pre_encode=True
+        )
+        # encoded shape: (B, d_model, T) — transpose to (B, T, d_model)
+        encoded = encoded.transpose(1, 2)
+
+        # Project from conformer dim to transformer dim: (B, T, 512) -> (B, T, 192)
+        encoded = self.encoder_proj(encoded)
+
+        # Transformer encoder
+        encoder_mask = self.sortformer_modules.length_to_mask(enc_len, encoded.shape[1])
+        trans_out = self.transformer_encoder(
+            encoder_states=encoded, encoder_mask=encoder_mask
+        )
+
+        # Speaker head: Linear(192->192) -> ReLU -> Linear(192->4) -> Sigmoid
+        preds = self.sortformer_modules.forward_speaker_sigmoids(trans_out)
+        preds = preds * encoder_mask.unsqueeze(-1)
+        return preds
+
+
+def load_model(nemo_path: Optional[str] = None, hf_model: Optional[str] = None):
+    """Load SortformerEncLabelModel from .nemo file or HuggingFace."""
+    from nemo.collections.asr.models import SortformerEncLabelModel
+
+    if nemo_path:
+        model = SortformerEncLabelModel.restore_from(
+            nemo_path, map_location="cpu", strict=False
+        )
+    elif hf_model:
+        model = SortformerEncLabelModel.from_pretrained(hf_model, map_location="cpu")
+    else:
+        model = SortformerEncLabelModel.from_pretrained(
+            "nvidia/diar_streaming_sortformer_4spk-v2", map_location="cpu"
+        )
+
+    model.eval()
+    model.cpu()
+    return model
+
+
+def _rel_shift_export(self, x):
+    """Export-safe rel_shift using gather instead of pad+view.
+
+    The original rel_shift does pad → view(b,h,-1,T) → slice → view(b,h,T,2T-1).
+    The view ops mix two T-dependent dimensions, creating a (2*T*T)//T guard that
+    the symbolic solver can't simplify. This replaces the entire operation with a
+    single gather that directly produces the shifted+trimmed output (b,h,T,T).
+    """
+    b, h, qlen, pos_len = x.size()
+    arange = torch.arange(qlen, device=x.device)
+    # output[i,j] = input[i, j - i + qlen - 1]
+    idx = arange.unsqueeze(0) - arange.unsqueeze(1) + (qlen - 1)
+    idx = idx.unsqueeze(0).unsqueeze(0).expand(b, h, -1, -1)
+    return torch.gather(x, 3, idx)
+
+
+def prepare_for_export(model):
+    """Patch model to remove torch.export blockers.
+
+    1. Preprocessor pad_to creates a data-dependent branch on frame count % 16.
+    2. ConformerEncoder.update_max_seq_length dynamically extends positional
+       encoding buffers based on input size.
+    3. RelPositionMultiHeadAttention.rel_shift uses pad+view that creates
+       unsolvable (2*T*T)//T guards — replaced with gather-based version.
+    """
+    model.preprocessor.featurizer.pad_to = 0
+    model.encoder.set_max_audio_length(5000)
+    model.encoder.update_max_seq_length = lambda seq_length, device: None
+
+    import types
+
+    from nemo.collections.asr.parts.submodules.multi_head_attention import (
+        RelPositionMultiHeadAttention,
+    )
+
+    for layer in model.encoder.layers:
+        if isinstance(layer.self_attn, RelPositionMultiHeadAttention):
+            layer.self_attn.rel_shift = types.MethodType(
+                _rel_shift_export, layer.self_attn
+            )
+
+
+def export_all(model, backend: Optional[str] = None):
+    """Export preprocessor, pre_encode, and encode methods.
+
+    Args:
+        model: The SortformerEncLabelModel to export.
+        backend: Target backend ("xnnpack" or "portable").
+    """
+    programs = {}
+
+    sample_rate = model.preprocessor._cfg.sample_rate
+    window_stride = float(model.preprocessor._cfg.window_stride)
+    subsampling_factor = int(model.encoder.subsampling_factor)
+
+    prepare_for_export(model)
+
+    # --- Method 1: preprocessor ---
+    preprocessor_wrapper = PreprocessorWrapper(model.preprocessor)
+    preprocessor_wrapper.eval()
+
+    max_audio_samples = int(sample_rate * 120)  # 120 seconds max
+    sample_audio = torch.randn(max_audio_samples, dtype=torch.float)
+    sample_length = torch.tensor([sample_audio.shape[0]], dtype=torch.int64)
+
+    # Force CPU path to avoid data-dependent CUDA conditionals in preprocessor
+    old_cuda_is_available = torch.cuda.is_available
+    torch.cuda.is_available = lambda: False
+
+    print("  Exporting preprocessor...")
+    programs["preprocessor"] = export(
+        preprocessor_wrapper,
+        (sample_audio, sample_length),
+        dynamic_shapes={
+            "audio": {0: Dim("audio_len", min=1600, max=max_audio_samples)},
+            "length": {},
+        },
+        strict=False,
+    )
+
+    torch.cuda.is_available = old_cuda_is_available
+
+    # --- Method 2: pre_encode ---
+    pre_encode_wrapper = PreEncodeWrapper(model.encoder.pre_encode)
+    pre_encode_wrapper.eval()
+
+    feat_in = getattr(model.encoder, "_feat_in", 128)
+    max_chunk_mel = 4000
+    sample_chunk = torch.randn(1, max_chunk_mel, feat_in, dtype=torch.float)
+    sample_chunk_len = torch.tensor([max_chunk_mel], dtype=torch.int64)
+
+    print("  Exporting pre_encode...")
+    programs["pre_encode"] = export(
+        pre_encode_wrapper,
+        (sample_chunk, sample_chunk_len),
+        # Static shapes: conv-derived symbolic expression 1+((L-1)//8) creates
+        # an unsolvable guard when hitting nn.Linear. Static shapes are practical
+        # since streaming chunk sizes are fixed per config.
+        strict=False,
+    )
+
+    # --- Method 3: encode ---
+
+    encoder_proj = model.sortformer_modules.encoder_proj
+    encode_wrapper = EncodeWrapper(
+        encoder=model.encoder,
+        encoder_proj=encoder_proj,
+        transformer_encoder=model.transformer_encoder,
+        sortformer_modules=model.sortformer_modules,
+    )
+    encode_wrapper.eval()
+
+    d_model = model.encoder.d_model
+    max_total_frames = 1000
+    sample_embs = torch.randn(1, max_total_frames, d_model, dtype=torch.float)
+    sample_emb_len = torch.tensor([max_total_frames], dtype=torch.int64)
+
+    print("  Exporting encode...")
+    programs["encode"] = export(
+        encode_wrapper,
+        (sample_embs, sample_emb_len),
+        dynamic_shapes={
+            # min=2: attention mask logic requires T>1
+            "embs": {1: Dim("total_frames", min=2, max=max_total_frames)},
+            "emb_len": {},
+        },
+        strict=False,
+    )
+
+    # --- Metadata ---
+    fc_d_model = int(model._cfg.encoder.d_model)
+    tf_d_model = int(model._cfg.model_defaults.tf_d_model)
+    max_num_of_spks = int(model._cfg.max_num_of_spks)
+    spkcache_len = int(model.sortformer_modules.spkcache_len)
+
+    metadata = {
+        "sample_rate": int(sample_rate),
+        "window_stride": window_stride,
+        "subsampling_factor": subsampling_factor,
+        "fc_d_model": fc_d_model,
+        "tf_d_model": tf_d_model,
+        "max_num_of_spks": max_num_of_spks,
+        "spkcache_len": spkcache_len,
+    }
+
+    return programs, metadata
+
+
+def lower_to_executorch(programs, metadata=None, backend="portable"):
+    if backend == "xnnpack":
+        from executorch.backends.xnnpack.partition.xnnpack_partitioner import (
+            XnnpackPartitioner,
+        )
+
+        print("\nLowering to ExecuTorch with XNNPACK...")
+        partitioner = {}
+        for key in programs.keys():
+            if key == "preprocessor":
+                partitioner[key] = []
+            else:
+                partitioner[key] = [XnnpackPartitioner()]
+    else:
+        print("\nLowering to ExecuTorch...")
+        partitioner = []
+
+    constant_methods = {}
+    if metadata:
+        for key, value in metadata.items():
+            constant_methods[key] = value
+
+    et_prog = to_edge_transform_and_lower(
+        programs,
+        partitioner=partitioner,
+        compile_config=EdgeCompileConfig(
+            _check_ir_validity=False,
+            _skip_dim_order=True,
+        ),
+        constant_methods=constant_methods if constant_methods else None,
+    )
+    return et_prog.to_executorch(
+        config=ExecutorchBackendConfig(
+            extract_delegate_segments=True,
+            memory_planning_pass=MemoryPlanningPass(alloc_graph_input=False),
+        ),
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Export streaming Sortformer diarizer to ExecuTorch"
+    )
+    parser.add_argument("--output-dir", default="./sortformer_exports")
+    parser.add_argument(
+        "--nemo-path",
+        type=str,
+        help="Path to .nemo model file",
+    )
+    parser.add_argument(
+        "--hf-model",
+        type=str,
+        help="HuggingFace model ID (default: nvidia/diar_streaming_sortformer_4spk-v2)",
+    )
+    parser.add_argument(
+        "--backend",
+        type=str,
+        default="xnnpack",
+        choices=["portable", "xnnpack"],
+        help="Backend for acceleration (default: xnnpack)",
+    )
+
+    args = parser.parse_args()
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    print("Loading model...")
+    model = load_model(nemo_path=args.nemo_path, hf_model=args.hf_model)
+
+    print("\nExporting components...")
+    programs, metadata = export_all(model, backend=args.backend)
+
+    et = lower_to_executorch(programs, metadata=metadata, backend=args.backend)
+
+    pte_path = os.path.join(args.output_dir, "sortformer.pte")
+    print(f"\nSaving ExecuTorch program to: {pte_path}")
+    with open(pte_path, "wb") as f:
+        et.write_to_file(f)
+    print(f"Saved {os.path.getsize(pte_path) / (1024 * 1024):.1f} MB")
+
+    print("\nDone!")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/models/sortformer/install_requirements.txt
+++ b/examples/models/sortformer/install_requirements.txt
@@ -1,0 +1,1 @@
+nemo_toolkit[asr]

--- a/examples/models/sortformer/main.cpp
+++ b/examples/models/sortformer/main.cpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// CLI entry point for the Sortformer diarizer.
+//
+// Loads a .pte model and a 16kHz mono WAV file, runs the three-stage
+// diarization pipeline (preprocessor → pre_encode → streaming encode), and
+// prints "start end speaker_N" segments. See README.md for usage.
+
+#include <iomanip>
+#include <iostream>
+
+#include <gflags/gflags.h>
+
+#include <executorch/extension/llm/runner/stats.h>
+#include <executorch/extension/llm/runner/util.h>
+#include <executorch/extension/llm/runner/wav_loader.h>
+#include <executorch/runtime/platform/log.h>
+
+#include "sortformer_runner.h"
+
+DEFINE_string(model_path, "sortformer.pte", "Path to Sortformer model (.pte).");
+DEFINE_string(audio_path, "", "Path to input audio file (.wav).");
+DEFINE_double(threshold, 0.5, "Speaker activity threshold (0.0 - 1.0).");
+DEFINE_int32(chunk_len, 124, "Streaming chunk length in 80ms frames.");
+DEFINE_int32(fifo_len, 124, "FIFO buffer length in 80ms frames.");
+
+int main(int argc, char** argv) {
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+  if (FLAGS_audio_path.empty()) {
+    ET_LOG(Error, "audio_path flag must be provided.");
+    return 1;
+  }
+
+  ::executorch::extension::llm::Stats stats;
+  stats.model_load_start_ms = ::executorch::extension::llm::time_in_ms();
+
+  sortformer::SortformerRunner runner(FLAGS_model_path);
+
+  stats.model_load_end_ms = ::executorch::extension::llm::time_in_ms();
+  stats.inference_start_ms = ::executorch::extension::llm::time_in_ms();
+
+  ET_LOG(Info, "Loading audio from: %s", FLAGS_audio_path.c_str());
+  auto audio_data =
+      ::executorch::extension::llm::load_wav_audio_data(FLAGS_audio_path);
+
+  sortformer::StreamingConfig config;
+  config.chunk_len = static_cast<int64_t>(FLAGS_chunk_len);
+  config.fifo_len = static_cast<int64_t>(FLAGS_fifo_len);
+
+  std::cout << std::fixed << std::setprecision(3);
+
+  auto result = runner.diarize(
+      audio_data.data(),
+      static_cast<int64_t>(audio_data.size()),
+      static_cast<float>(FLAGS_threshold),
+      config,
+      [](const sortformer::Segment& seg) {
+        std::cout << "  " << seg.start << " " << seg.end << " speaker_"
+                  << seg.speaker << std::endl;
+      });
+
+  stats.inference_end_ms = ::executorch::extension::llm::time_in_ms();
+
+  // Summary
+  std::cout << "\n"
+            << result.num_segments << " segments, " << result.num_frames
+            << " frames, " << std::setprecision(1)
+            << result.num_frames * runner.frame_duration() << "s\n";
+
+  for (int spk = 0; spk < static_cast<int>(runner.max_spks()); spk++) {
+    auto active = result.speaker_active_frames[static_cast<size_t>(spk)];
+    if (active > 0) {
+      double pct = 100.0 * active / static_cast<double>(result.num_frames);
+      std::cout << "Speaker " << spk << ": " << active << "/"
+                << result.num_frames << " frames active ("
+                << std::setprecision(1) << pct << "%)\n";
+    }
+  }
+
+  ::executorch::extension::llm::print_report(stats);
+
+  return 0;
+}

--- a/examples/models/sortformer/model.md
+++ b/examples/models/sortformer/model.md
@@ -1,0 +1,209 @@
+# Streaming Sortformer Diarizer
+
+Speaker diarization model (117M params) that outputs per-frame speaker activity
+probabilities for up to 4 speakers. Based on NVIDIA NeMo's
+`SortformerEncLabelModel`. Not ASR — no text output.
+
+Source: `nvidia/diar_streaming_sortformer_4spk-v2` (HuggingFace, CC-BY-4.0).
+Tested with both [v2](https://huggingface.co/nvidia/diar_streaming_sortformer_4spk-v2) and [v2.1](https://huggingface.co/nvidia/diar_streaming_sortformer_4spk-v2.1) (same architecture, v2.1 adds speaker cache scoring parameters).
+
+Paper: [Sortformer](https://arxiv.org/abs/2409.06656),
+[Streaming Sortformer](https://arxiv.org/abs/2507.18446)
+
+## Pipeline
+
+```
+Raw audio (B, num_samples) @ 16kHz
+  → Preprocessor (mel spectrogram: 128 bins, 25ms window, 10ms stride)
+(B, 128, T)
+  → ConformerEncoder (FastConformer, 17 layers, d_model=512)
+    └─ pre_encode: ConvSubsampling 8x → (B, T/8, 512)
+    └─ 17× ConformerLayer (rel-pos self-attn + conv + FFN)
+(B, T/8, 512)
+  → encoder_proj: Linear(512 → 192)
+(B, T/8, 192)
+  → TransformerEncoder (18 layers, hidden=192, 8 heads)
+(B, T/8, 192)
+  → Speaker head: Linear(192→192) → ReLU → Linear(192→4) → Sigmoid
+(B, T/8, 4)
+```
+
+Each output frame = 80ms of audio (10ms stride × 8x subsampling).
+
+## Streaming Architecture
+
+Audio is processed in chunks. Before running the conformer + transformer,
+three sequences are concatenated:
+
+```
+[speaker_cache | FIFO | current_chunk]  →  encoder  →  transformer  →  head
+                                                        ↓
+                                              extract chunk predictions
+```
+
+- **Speaker cache** (188 frames max): Long-term memory of the most
+  speaker-discriminative frames — frames where a single speaker is clearly
+  dominant (non-overlapped speech), selected via log-odds importance scoring.
+  Compressed when it overflows by keeping the highest-scoring frames per
+  speaker plus silence placeholders.
+
+- **FIFO** (configurable): Short-term sliding window of recent embeddings.
+  Oldest frames are popped into the speaker cache when the FIFO fills up.
+
+- **Current chunk**: Fresh audio. Only this chunk's `pre_encode`
+  (ConvSubsampling) runs; cache and FIFO reuse previously computed embeddings
+  via `bypass_pre_encode=True`.
+
+### Streaming Configurations
+
+| Config           | Latency | chunk_len | right_context | fifo_len | update_period | spkcache_len |
+|------------------|---------|-----------|---------------|----------|---------------|--------------|
+| Very high        | 30.4s   | 340       | 40            | 40       | 300           | 188          |
+| High             | 10.0s   | 124       | 1             | 124      | 124           | 188          |
+| Low              | 1.04s   | 6         | 7             | 188      | 144           | 188          |
+| Ultra low        | 0.32s   | 3         | 1             | 188      | 144           | 188          |
+
+All values in 80ms frames. Latency = (chunk_len + right_context) × 80ms.
+
+## Model Parameters
+
+| Parameter              | Value |
+|------------------------|-------|
+| sample_rate            | 16000 |
+| mel features           | 128   |
+| window_size            | 0.025s (25ms) |
+| window_stride          | 0.01s (10ms) |
+| subsampling_factor     | 8     |
+| fc_d_model (conformer) | 512   |
+| tf_d_model (transformer)| 192  |
+| conformer_layers       | 17    |
+| transformer_layers     | 18    |
+| attention_heads        | 8     |
+| max_num_of_spks        | 4     |
+| spkcache_len           | 188   |
+
+## NeMo Classes
+
+| Class | File | Role |
+|-------|------|------|
+| `SortformerEncLabelModel` | `sortformer_diar_models.py` | Top-level model, forward/diarize |
+| `SortformerModules` | `sortformer_modules.py` | Streaming state, encoder_proj, speaker head, cache compression |
+| `ConformerEncoder` | `conformer_encoder.py` | FastConformer with pre_encode subsampling |
+| `TransformerEncoder` | `transformer_encoders.py` | Standard transformer encoder |
+| `AudioToMelSpectrogramPreprocessor` | ASR modules | Mel spectrogram extraction |
+
+## Output
+
+Raw output is `(B, T/8, 4)` sigmoid probabilities. The `diarize()` method
+post-processes with VAD-style thresholding and smoothing to produce segments:
+`[start_seconds, end_seconds, speaker_index]`.
+
+## Loading
+
+```python
+from nemo.collections.asr.models import SortformerEncLabelModel
+
+# From HuggingFace
+model = SortformerEncLabelModel.from_pretrained("nvidia/diar_streaming_sortformer_4spk-v2")
+
+# From local .nemo file
+model = SortformerEncLabelModel.restore_from("path/to/model.nemo", map_location="cpu", strict=False)
+
+model.eval()
+```
+
+## ExecuTorch Export
+
+### Usage
+
+```bash
+cd examples/models/sortformer
+
+# Export
+python export_sortformer.py --nemo-path /path/to/model.nemo --backend xnnpack
+
+# Validate
+python validate_pte.py \
+    --nemo-path /path/to/model.nemo \
+    --pte-path ./sortformer_exports/sortformer.pte \
+    --wav /path/to/audio.wav
+```
+
+Output: `sortformer_exports/sortformer.pte` (~470 MB unquantized).
+
+### Exported Methods
+
+Three methods, splitting along streaming boundaries so the C++ runner
+manages chunking and cache state:
+
+**`preprocessor`** — portable (no XNNPACK)
+- Input: `audio` (N,) float, `length` (1,) int64
+- Output: `mel` (1, 128, T_mel) float, `mel_len` (1,) int64
+- Dynamic shapes: `audio` dim 0, min=1600, max=1,920,000 (120s)
+
+**`pre_encode`** — XNNPACK
+- Input: `chunk` (1, 4000, 128) float, `chunk_len` (1,) int64
+- Output: `embs` (1, 500, 512) float, `emb_len` (1,) int64
+- Static shapes: conv-derived symbolic expression `1+((L-1)//8)` creates
+  an unsolvable guard with `nn.Linear`, so chunk size is fixed at 4000 mel
+  frames (~40s). Streaming chunk sizes are fixed per config, so this is not
+  a practical limitation.
+
+**`encode`** — XNNPACK
+- Input: `embs` (1, T_total, 512) float, `emb_len` (1,) int64
+- Output: `preds` (1, T_total, 4) float
+- Dynamic shapes: `embs` dim 1, min=2, max=1000
+
+**Metadata** (constant_methods): `sample_rate`, `window_stride`,
+`subsampling_factor`, `fc_d_model`, `tf_d_model`, `max_num_of_spks`,
+`spkcache_len`.
+
+### Caller Responsibilities
+
+The mel output from `preprocessor` is `(1, 128, T)` (channels-first).
+`pre_encode` expects `(1, T, 128)` (channels-last). The caller must
+transpose and pad/truncate to 4000 frames between stages. See
+`validate_pte.py` for the exact sequence.
+
+## torch.export Fixes
+
+All fixes are in `prepare_for_export()` and the wrapper classes.
+
+### 1. Preprocessor `pad_to=16`
+Pads frame count to multiples of 16, creating a data-dependent branch.
+Fix: `model.preprocessor.featurizer.pad_to = 0`.
+
+### 2. ConformerEncoder `update_max_seq_length`
+Conditionally extends positional encoding buffers. Involves distributed
+calls and buffer mutation.
+Fix: pre-allocate to max length, then no-op:
+```python
+model.encoder.set_max_audio_length(5000)
+model.encoder.update_max_seq_length = lambda seq_length, device: None
+```
+
+### 3. ConvSubsampling MaskedConvSequential
+`MaskedConvSequential` uses data-dependent masking that creates export
+guards. Masking is unnecessary for single-sample inference.
+Fix: `PreEncodeWrapper` runs conv layers directly via `nn.ModuleList`,
+bypassing `MaskedConvSequential`.
+
+### 4. `reshape(b, t, -1)` on conv output
+`reshape` with `-1` generates an unsolvable guard when the time dim is
+symbolic.
+Fix: `x.permute(0, 2, 1, 3).flatten(2)` — flattens static dims C and F
+without generating guards on the dynamic time dimension.
+
+### 5. Conv-derived expression + Linear
+After strided convolutions, the time dim becomes `1+((L-1)//8)`. Applying
+`nn.Linear` triggers a guard the solver can't prove. No code-level fix
+exists.
+Fix: use static shapes for `pre_encode`.
+
+### 6. RelPositionMultiHeadAttention `rel_shift`
+The conformer's `rel_shift` uses `pad → view(b,h,-1,T) → slice → view`
+to shift relative position scores. The `view` mixes two T-dependent
+dimensions, creating a `(2*T*T)//T` guard the solver can't simplify.
+Fix: `_rel_shift_export` replaces pad+view with `torch.gather` using
+explicitly computed indices. Monkey-patched onto all conformer attention
+layers in `prepare_for_export`.

--- a/examples/models/sortformer/sortformer_runner.cpp
+++ b/examples/models/sortformer/sortformer_runner.cpp
@@ -1,0 +1,474 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "sortformer_runner.h"
+
+#include <algorithm>
+#include <cstring>
+#include <vector>
+
+#include <executorch/extension/tensor/tensor_ptr_maker.h>
+#include <executorch/runtime/core/evalue.h>
+#include <executorch/runtime/core/exec_aten/util/scalar_type_util.h>
+#include <executorch/runtime/platform/log.h>
+
+using ::executorch::extension::from_blob;
+using ::executorch::extension::Module;
+using ::executorch::runtime::Error;
+using ::executorch::runtime::EValue;
+
+namespace sortformer {
+namespace {
+
+constexpr int64_t kMaxMelFrames = 4000; // pre_encode static input shape
+constexpr int kMelBins = 128; // Mel spectrogram frequency bins
+constexpr int64_t kSampleRate = 16000;
+constexpr int64_t kMaxAudioSamples = kSampleRate * 120; // 120s preprocessor max
+
+// Compress the speaker cache when it exceeds max_size frames.
+//
+// Scores each frame by its max speaker probability and keeps the top max_size
+// frames (sorted by original time order). This is a simplification of NeMo's
+// log-odds importance scoring, which uses per-speaker AOSC (Average Online
+// Speaker Confusion) scores. The simplified version works well in practice
+// because high max-probability frames tend to be the same ones NeMo would keep.
+void compress_cache(
+    std::vector<float>& embs,
+    std::vector<float>& preds,
+    int64_t& size,
+    int64_t max_size,
+    int64_t d_model,
+    int64_t max_spks) {
+  if (size <= max_size)
+    return;
+
+  std::vector<std::pair<float, int64_t>> scored;
+  scored.reserve(static_cast<size_t>(size));
+  for (int64_t i = 0; i < size; i++) {
+    float max_p = 0.0f;
+    for (int64_t s = 0; s < max_spks; s++) {
+      max_p = std::max(max_p, preds[static_cast<size_t>(i * max_spks + s)]);
+    }
+    scored.push_back({max_p, i});
+  }
+
+  std::sort(scored.begin(), scored.end(), [](const auto& a, const auto& b) {
+    return a.first > b.first;
+  });
+
+  std::vector<int64_t> keep;
+  keep.reserve(static_cast<size_t>(max_size));
+  for (int64_t i = 0; i < max_size; i++) {
+    keep.push_back(scored[static_cast<size_t>(i)].second);
+  }
+  std::sort(keep.begin(), keep.end());
+
+  std::vector<float> new_embs(static_cast<size_t>(max_size * d_model));
+  std::vector<float> new_preds(static_cast<size_t>(max_size * max_spks));
+  for (int64_t i = 0; i < max_size; i++) {
+    int64_t src = keep[static_cast<size_t>(i)];
+    std::memcpy(
+        &new_embs[static_cast<size_t>(i * d_model)],
+        &embs[static_cast<size_t>(src * d_model)],
+        static_cast<size_t>(d_model) * sizeof(float));
+    std::memcpy(
+        &new_preds[static_cast<size_t>(i * max_spks)],
+        &preds[static_cast<size_t>(src * max_spks)],
+        static_cast<size_t>(max_spks) * sizeof(float));
+  }
+
+  embs = std::move(new_embs);
+  preds = std::move(new_preds);
+  size = max_size;
+}
+
+} // namespace
+
+// Read model parameters from .pte constant_methods. These are baked into the
+// exported model by export_sortformer.py and describe the preprocessing config
+// and architecture dimensions needed to set up the streaming pipeline.
+SortformerRunner::SortformerRunner(const std::string& model_path) {
+  ET_LOG(Info, "Loading model from: %s", model_path.c_str());
+  model_ = std::make_unique<Module>(model_path, Module::LoadMode::Mmap);
+  auto load_error = model_->load();
+  if (load_error != Error::Ok) {
+    ET_LOG(Error, "Failed to load model.");
+    return;
+  }
+
+  std::vector<EValue> empty;
+  auto ws = model_->execute("window_stride", empty);
+  auto ss = model_->execute("subsampling_factor", empty);
+  auto sc = model_->execute("spkcache_len", empty);
+  auto ms = model_->execute("max_num_of_spks", empty);
+
+  window_stride_ = ws.ok() ? ws.get()[0].toDouble() : 0.01;
+  subsampling_factor_ = ss.ok() ? ss.get()[0].toInt() : 8;
+  spkcache_len_ = sc.ok() ? sc.get()[0].toInt() : 188;
+  max_spks_ = ms.ok() ? ms.get()[0].toInt() : 4;
+  frame_duration_ = window_stride_ * static_cast<double>(subsampling_factor_);
+}
+
+std::pair<std::vector<float>, int64_t> SortformerRunner::run_preprocessor(
+    const float* audio,
+    int64_t num_samples) {
+  auto audio_tensor = from_blob(
+      const_cast<float*>(audio),
+      {static_cast<::executorch::aten::SizesType>(num_samples)},
+      ::executorch::aten::ScalarType::Float);
+  std::vector<int64_t> len_data = {num_samples};
+  auto len_tensor =
+      from_blob(len_data.data(), {1}, ::executorch::aten::ScalarType::Long);
+
+  auto result = model_->execute(
+      "preprocessor", std::vector<EValue>{audio_tensor, len_tensor});
+  if (!result.ok()) {
+    ET_LOG(Error, "Preprocessor failed.");
+    return {{}, 0};
+  }
+
+  auto& outputs = result.get();
+  auto mel = outputs[0].toTensor();
+  int64_t mel_len = outputs[1].toTensor().const_data_ptr<int64_t>()[0];
+  int64_t mel_T = mel.sizes()[2]; // (1, 128, T_mel)
+  int64_t valid_mel = std::min(mel_T, mel_len);
+
+  // Transpose from (1, 128, T) channels-first to (T, 128) channels-last.
+  // The preprocessor outputs channels-first but pre_encode expects
+  // channels-last.
+  const float* mel_ptr = mel.const_data_ptr<float>();
+  std::vector<float> transposed(static_cast<size_t>(valid_mel) * kMelBins);
+  for (int64_t t = 0; t < valid_mel; t++) {
+    for (int f = 0; f < kMelBins; f++) {
+      transposed[static_cast<size_t>(t * kMelBins + f)] =
+          mel_ptr[static_cast<size_t>(f * mel_T + t)];
+    }
+  }
+
+  return {std::move(transposed), valid_mel};
+}
+
+int64_t SortformerRunner::run_pre_encode(
+    const float* mel_transposed,
+    int64_t valid_mel_len,
+    std::vector<float>& all_embs) {
+  // Pad to kMaxMelFrames — pre_encode requires a static input shape because
+  // the conv-derived time expression 1+((L-1)//8) creates a guard that
+  // torch.export's solver can't prove against nn.Linear (see model.md #5).
+  std::vector<float> padded(
+      static_cast<size_t>(kMaxMelFrames) * kMelBins, 0.0f);
+  int64_t copy_len = std::min(valid_mel_len, kMaxMelFrames);
+  std::memcpy(
+      padded.data(),
+      mel_transposed,
+      static_cast<size_t>(copy_len * kMelBins) * sizeof(float));
+
+  auto chunk_tensor = from_blob(
+      padded.data(),
+      {1,
+       static_cast<::executorch::aten::SizesType>(kMaxMelFrames),
+       static_cast<::executorch::aten::SizesType>(kMelBins)},
+      ::executorch::aten::ScalarType::Float);
+  std::vector<int64_t> len_data = {copy_len};
+  auto len_tensor =
+      from_blob(len_data.data(), {1}, ::executorch::aten::ScalarType::Long);
+
+  auto result = model_->execute(
+      "pre_encode", std::vector<EValue>{chunk_tensor, len_tensor});
+  if (!result.ok()) {
+    ET_LOG(Error, "pre_encode failed.");
+    return 0;
+  }
+
+  auto& outputs = result.get();
+  auto embs = outputs[0].toTensor();
+  int64_t emb_len = outputs[1].toTensor().const_data_ptr<int64_t>()[0];
+
+  if (d_model_ == 0) {
+    d_model_ = embs.sizes()[2]; // 512
+  }
+
+  const float* emb_ptr = embs.const_data_ptr<float>();
+  all_embs.insert(
+      all_embs.end(),
+      emb_ptr,
+      emb_ptr + static_cast<size_t>(emb_len * d_model_));
+  return emb_len;
+}
+
+// Streaming encode loop. For each chunk of embeddings:
+//   1. Concatenate [speaker_cache | FIFO | current_chunk] → encode →
+//   predictions
+//   2. Extract only the current chunk's predictions as output
+//   3. Update FIFO (push oldest frames to speaker cache when it overflows)
+//   4. Compress speaker cache if it exceeds spkcache_len_ (188 frames)
+//
+// The cache and FIFO exist purely to give the conformer+transformer context
+// from earlier audio. The model itself is stateless per call.
+SortformerRunner::Result SortformerRunner::run_streaming_encode(
+    const std::vector<float>& all_embs,
+    int64_t total_emb_len,
+    float threshold,
+    const StreamingConfig& config,
+    SegmentCallback segment_cb) {
+  // Speaker cache: long-term memory of the most speaker-discriminative frames.
+  std::vector<float> cache_embs;
+  std::vector<float> cache_preds;
+  int64_t cache_size = 0;
+
+  // FIFO: short-term sliding window of recent embeddings.
+  std::vector<float> fifo_embs;
+  int64_t fifo_size = 0;
+
+  // Per-speaker activity state for segment emission.
+  std::vector<bool> spk_active(static_cast<size_t>(max_spks_), false);
+  std::vector<int64_t> spk_start_frame(static_cast<size_t>(max_spks_), 0);
+  std::vector<int64_t> spk_active_frames(static_cast<size_t>(max_spks_), 0);
+  int64_t num_output_frames = 0;
+  int num_segments = 0;
+
+  for (int64_t offset = 0; offset < total_emb_len; offset += config.chunk_len) {
+    int64_t cur_chunk_len = std::min(config.chunk_len, total_emb_len - offset);
+    int64_t total_len = cache_size + fifo_size + cur_chunk_len;
+
+    // Build [cache | fifo | chunk]
+    std::vector<float> concat(static_cast<size_t>(total_len * d_model_));
+    size_t dst = 0;
+    if (cache_size > 0) {
+      std::memcpy(
+          concat.data() + dst,
+          cache_embs.data(),
+          static_cast<size_t>(cache_size * d_model_) * sizeof(float));
+      dst += static_cast<size_t>(cache_size * d_model_);
+    }
+    if (fifo_size > 0) {
+      std::memcpy(
+          concat.data() + dst,
+          fifo_embs.data(),
+          static_cast<size_t>(fifo_size * d_model_) * sizeof(float));
+      dst += static_cast<size_t>(fifo_size * d_model_);
+    }
+    std::memcpy(
+        concat.data() + dst,
+        all_embs.data() + static_cast<size_t>(offset * d_model_),
+        static_cast<size_t>(cur_chunk_len * d_model_) * sizeof(float));
+
+    auto enc_tensor = from_blob(
+        concat.data(),
+        {1,
+         static_cast<::executorch::aten::SizesType>(total_len),
+         static_cast<::executorch::aten::SizesType>(d_model_)},
+        ::executorch::aten::ScalarType::Float);
+    std::vector<int64_t> enc_len_data = {total_len};
+    auto enc_len_tensor = from_blob(
+        enc_len_data.data(), {1}, ::executorch::aten::ScalarType::Long);
+
+    auto enc_result = model_->execute(
+        "encode", std::vector<EValue>{enc_tensor, enc_len_tensor});
+    if (!enc_result.ok()) {
+      ET_LOG(Error, "encode failed.");
+      break;
+    }
+    auto enc_preds = enc_result.get()[0].toTensor();
+    const float* preds_ptr = enc_preds.const_data_ptr<float>();
+
+    // Extract the cache region's predictions from the encode output. Because
+    // the cache frames were encoded alongside the new chunk, their predictions
+    // now reflect updated context. These are used as scoring input for
+    // compress_cache.
+    if (cache_size > 0) {
+      cache_preds.resize(static_cast<size_t>(cache_size * max_spks_));
+      std::memcpy(
+          cache_preds.data(),
+          preds_ptr,
+          static_cast<size_t>(cache_size * max_spks_) * sizeof(float));
+    }
+
+    // Extract chunk predictions (skip cache and FIFO regions) and emit
+    // segments via threshold-based activity detection. Each speaker slot's
+    // probability is compared against the threshold independently.
+    size_t chunk_pred_start =
+        static_cast<size_t>((cache_size + fifo_size) * max_spks_);
+    for (int64_t t = 0; t < cur_chunk_len; t++) {
+      int64_t global_frame = num_output_frames + t;
+      for (int spk = 0; spk < static_cast<int>(max_spks_); spk++) {
+        float prob = preds_ptr
+            [chunk_pred_start + static_cast<size_t>(t * max_spks_ + spk)];
+        size_t si = static_cast<size_t>(spk);
+        if (prob > threshold) {
+          spk_active_frames[si]++;
+          if (!spk_active[si]) {
+            spk_active[si] = true;
+            spk_start_frame[si] = global_frame;
+          }
+        } else if (spk_active[si]) {
+          spk_active[si] = false;
+          segment_cb(
+              {spk_start_frame[si] * frame_duration_,
+               global_frame * frame_duration_,
+               spk});
+          num_segments++;
+        }
+      }
+    }
+    num_output_frames += cur_chunk_len;
+
+    // Update FIFO: append current chunk's embeddings. When the FIFO exceeds
+    // its configured size, the oldest frames overflow into the speaker cache.
+    int64_t combined = fifo_size + cur_chunk_len;
+    int64_t overflow = std::max(int64_t(0), combined - config.fifo_len);
+
+    if (overflow > 0) {
+      int64_t from_fifo = std::min(overflow, fifo_size);
+      int64_t from_chunk = overflow - from_fifo;
+
+      if (from_fifo > 0) {
+        cache_embs.insert(
+            cache_embs.end(),
+            fifo_embs.begin(),
+            fifo_embs.begin() + static_cast<ptrdiff_t>(from_fifo * d_model_));
+        size_t fifo_pred_start = static_cast<size_t>(cache_size * max_spks_);
+        cache_preds.insert(
+            cache_preds.end(),
+            preds_ptr + fifo_pred_start,
+            preds_ptr + fifo_pred_start +
+                static_cast<size_t>(from_fifo * max_spks_));
+        cache_size += from_fifo;
+
+        fifo_embs.erase(
+            fifo_embs.begin(),
+            fifo_embs.begin() + static_cast<ptrdiff_t>(from_fifo * d_model_));
+        fifo_size -= from_fifo;
+      }
+
+      if (from_chunk > 0) {
+        size_t chunk_emb_start = static_cast<size_t>(offset * d_model_);
+        cache_embs.insert(
+            cache_embs.end(),
+            all_embs.data() + chunk_emb_start,
+            all_embs.data() + chunk_emb_start +
+                static_cast<size_t>(from_chunk * d_model_));
+        size_t orig_chunk_pred_start = chunk_pred_start;
+        cache_preds.insert(
+            cache_preds.end(),
+            preds_ptr + orig_chunk_pred_start,
+            preds_ptr + orig_chunk_pred_start +
+                static_cast<size_t>(from_chunk * max_spks_));
+        cache_size += from_chunk;
+      }
+
+      int64_t chunk_keep = cur_chunk_len - from_chunk;
+      if (chunk_keep > 0) {
+        size_t keep_start =
+            static_cast<size_t>((offset + from_chunk) * d_model_);
+        fifo_embs.insert(
+            fifo_embs.end(),
+            all_embs.data() + keep_start,
+            all_embs.data() + keep_start +
+                static_cast<size_t>(chunk_keep * d_model_));
+        fifo_size += chunk_keep;
+      }
+    } else {
+      size_t emb_start = static_cast<size_t>(offset * d_model_);
+      fifo_embs.insert(
+          fifo_embs.end(),
+          all_embs.data() + emb_start,
+          all_embs.data() + emb_start +
+              static_cast<size_t>(cur_chunk_len * d_model_));
+      fifo_size += cur_chunk_len;
+    }
+
+    // Compress speaker cache if it exceeds the limit (188 frames). Keeps the
+    // most speaker-discriminative frames ranked by max speaker probability.
+    if (cache_size > spkcache_len_) {
+      compress_cache(
+          cache_embs,
+          cache_preds,
+          cache_size,
+          spkcache_len_,
+          d_model_,
+          max_spks_);
+    }
+  }
+
+  // Close any still-active segments
+  for (int spk = 0; spk < static_cast<int>(max_spks_); spk++) {
+    size_t si = static_cast<size_t>(spk);
+    if (spk_active[si]) {
+      segment_cb(
+          {spk_start_frame[si] * frame_duration_,
+           num_output_frames * frame_duration_,
+           spk});
+      num_segments++;
+    }
+  }
+
+  return {num_output_frames, num_segments, std::move(spk_active_frames)};
+}
+
+// Orchestrates the full diarization pipeline for arbitrary-length audio.
+// Stages 1-2 (preprocessor → pre_encode) run first to collect all embeddings,
+// then stage 3 (streaming encode) processes them in chunks with cache/FIFO
+// context. Audio longer than 120s is automatically chunked for the
+// preprocessor.
+SortformerRunner::Result SortformerRunner::diarize(
+    const float* audio_data,
+    int64_t num_samples,
+    float threshold,
+    const StreamingConfig& config,
+    SegmentCallback segment_cb) {
+  // Stages 1-2: preprocessor → pre_encode, chunked for arbitrary length
+  std::vector<float> all_embs;
+  int64_t total_emb_len = 0;
+
+  for (int64_t audio_offset = 0; audio_offset < num_samples;
+       audio_offset += kMaxAudioSamples) {
+    int64_t chunk_samples =
+        std::min(kMaxAudioSamples, num_samples - audio_offset);
+
+    ET_LOG(
+        Info,
+        "Running preprocessor (%.1fs-%.1fs)...",
+        static_cast<double>(audio_offset) / kSampleRate,
+        static_cast<double>(audio_offset + chunk_samples) / kSampleRate);
+
+    auto [mel_transposed, valid_mel] =
+        run_preprocessor(audio_data + audio_offset, chunk_samples);
+
+    // Run pre_encode in sub-chunks of kMaxMelFrames
+    for (int64_t mel_offset = 0; mel_offset < valid_mel;
+         mel_offset += kMaxMelFrames) {
+      int64_t sub_len = std::min(kMaxMelFrames, valid_mel - mel_offset);
+      int64_t added = run_pre_encode(
+          mel_transposed.data() + static_cast<size_t>(mel_offset * kMelBins),
+          sub_len,
+          all_embs);
+      total_emb_len += added;
+    }
+  }
+
+  ET_LOG(
+      Info,
+      "Total embeddings: %lld frames x %lld dims",
+      static_cast<long long>(total_emb_len),
+      static_cast<long long>(d_model_));
+
+  ET_LOG(
+      Info,
+      "Streaming: chunk=%lld, fifo=%lld, cache=%lld, frame=%.3fs",
+      static_cast<long long>(config.chunk_len),
+      static_cast<long long>(config.fifo_len),
+      static_cast<long long>(spkcache_len_),
+      frame_duration_);
+
+  // Stage 3: streaming encode
+  return run_streaming_encode(
+      all_embs, total_emb_len, threshold, config, std::move(segment_cb));
+}
+
+} // namespace sortformer

--- a/examples/models/sortformer/sortformer_runner.h
+++ b/examples/models/sortformer/sortformer_runner.h
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Streaming Sortformer diarizer runner.
+//
+// Runs a three-stage pipeline exported from NeMo's SortformerEncLabelModel:
+//   1. preprocessor:  raw audio → mel spectrogram (128 bins, 10ms stride)
+//   2. pre_encode:    mel → 512-dim embeddings (8x convolutional downsampling)
+//   3. encode:        embeddings → per-frame speaker probabilities (up to 4
+//   spks)
+//
+// The .pte model is stateless — all streaming state (speaker cache, FIFO) is
+// managed here. Each output frame covers 80ms of audio (10ms stride × 8x
+// subsampling). See model.md for architecture details.
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <executorch/extension/module/module.h>
+
+namespace sortformer {
+
+// Streaming chunk/FIFO sizes in 80ms frames. Defaults match the "High" config.
+// See README.md § Streaming Configurations for all presets.
+struct StreamingConfig {
+  int64_t chunk_len = 124;
+  int64_t fifo_len = 124;
+};
+
+// A diarization output segment: [start, end) in seconds for a speaker slot.
+// Speaker indices are fixed output slots (0–3), not cluster IDs — identity is
+// maintained across chunks because the speaker cache feeds
+// speaker-discriminative embeddings from earlier audio into each encode call,
+// giving the model context to assign the same slot to the same physical
+// speaker.
+struct Segment {
+  double start;
+  double end;
+  int speaker;
+};
+
+using SegmentCallback = std::function<void(const Segment&)>;
+
+class SortformerRunner {
+ public:
+  explicit SortformerRunner(const std::string& model_path);
+
+  struct Result {
+    int64_t num_frames;
+    int num_segments;
+    std::vector<int64_t> speaker_active_frames;
+  };
+
+  Result diarize(
+      const float* audio_data,
+      int64_t num_samples,
+      float threshold,
+      const StreamingConfig& config,
+      SegmentCallback segment_cb);
+
+  double frame_duration() const {
+    return frame_duration_;
+  }
+  int64_t max_spks() const {
+    return max_spks_;
+  }
+
+ private:
+  std::unique_ptr<::executorch::extension::Module> model_;
+
+  // Model parameters. window_stride_, subsampling_factor_, spkcache_len_, and
+  // max_spks_ are read from .pte constant_methods at load time. d_model_ is
+  // inferred from the first pre_encode output. frame_duration_ is computed.
+  double window_stride_;
+  int64_t subsampling_factor_;
+  int64_t spkcache_len_; // Max speaker cache frames (188)
+  int64_t max_spks_; // Fixed speaker output slots (4)
+  int64_t d_model_ = 0; // Conformer hidden dim (512), set on first pre_encode
+  double frame_duration_; // window_stride * subsampling_factor = 80ms
+
+  // Stage 1: audio → mel spectrogram.
+  // Output is transposed from the model's (1, 128, T) channels-first to
+  // (T, 128) channels-last, which is what pre_encode expects.
+  std::pair<std::vector<float>, int64_t> run_preprocessor(
+      const float* audio,
+      int64_t num_samples);
+
+  // Stage 2: mel → 512-dim embeddings via 8x convolutional downsampling.
+  // Input is padded to 4000 mel frames (static shape required by the exported
+  // model — see model.md § torch.export Fixes #5).
+  int64_t run_pre_encode(
+      const float* mel_transposed,
+      int64_t valid_mel_len,
+      std::vector<float>& all_embs);
+
+  // Stage 3: streaming encode with cache/FIFO state management.
+  // Processes embeddings in chunks, concatenating [cache | FIFO | chunk] for
+  // each encode call. Only the current chunk's predictions are kept as output.
+  // The speaker cache provides long-term context (most speaker-discriminative
+  // frames), the FIFO provides short-term sliding window context.
+  Result run_streaming_encode(
+      const std::vector<float>& all_embs,
+      int64_t total_emb_len,
+      float threshold,
+      const StreamingConfig& config,
+      SegmentCallback segment_cb);
+};
+
+} // namespace sortformer

--- a/examples/models/sortformer/validate_pte.py
+++ b/examples/models/sortformer/validate_pte.py
@@ -1,0 +1,136 @@
+"""Validate sortformer .pte against NeMo reference diarize() on audio.
+
+Usage:
+    python validate_pte.py \
+        --nemo-path /path/to/model.nemo \
+        --pte-path ./sortformer_exports/sortformer.pte \
+        --wav /path/to/audio.wav
+"""
+
+import argparse
+import os
+import tempfile
+
+import numpy as np
+import soundfile as sf
+import torch
+
+from executorch.runtime import Runtime
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--nemo-path", type=str, required=True)
+    parser.add_argument("--pte-path", type=str, required=True)
+    parser.add_argument("--wav", type=str, required=True)
+    args = parser.parse_args()
+
+    # --- Load audio ---
+    audio_np, sr = sf.read(args.wav, dtype="float32")
+    if audio_np.ndim > 1:
+        audio_np = audio_np.mean(axis=1)
+    if sr != 16000:
+        target_len = int(len(audio_np) * 16000 / sr)
+        audio_np = np.interp(
+            np.linspace(0, len(audio_np) - 1, target_len),
+            np.arange(len(audio_np)),
+            audio_np,
+        )
+        sr = 16000
+    # pre_encode static shape = 4000 mel frames ≈ 40s
+    audio_np = audio_np[: sr * 40]
+    audio = torch.from_numpy(audio_np).float()
+    length = torch.tensor([audio.shape[0]], dtype=torch.int64)
+    print(f"Audio: {audio.shape[0]/sr:.1f}s, {sr}Hz")
+
+    # Save truncated audio so NeMo diarize() processes the same segment
+    tmp_wav = os.path.join(tempfile.gettempdir(), "validate_pte_truncated.wav")
+    sf.write(tmp_wav, audio_np, sr)
+
+    # --- Run NeMo reference ---
+    print("Loading NeMo model...")
+    from nemo.collections.asr.models import SortformerEncLabelModel
+
+    if args.nemo_path.endswith(".nemo"):
+        model = SortformerEncLabelModel.restore_from(
+            args.nemo_path, map_location="cpu", strict=False
+        )
+    else:
+        model = SortformerEncLabelModel.from_pretrained(
+            args.nemo_path, map_location="cpu"
+        )
+    model.eval()
+
+    # Very high latency config — single chunk for ≤27s audio
+    model.sortformer_modules.chunk_len = 340
+    model.sortformer_modules.chunk_right_context = 40
+    model.sortformer_modules.fifo_len = 40
+    model.sortformer_modules.spkcache_update_period = 300
+
+    print("Running NeMo diarize()...")
+    nemo_segments, nemo_probs = model.diarize(
+        audio=[tmp_wav], batch_size=1, include_tensor_outputs=True
+    )
+
+    nemo_preds = nemo_probs[0]  # first audio from list
+    if nemo_preds.dim() == 3:
+        nemo_preds = nemo_preds.squeeze(0)  # remove batch dim
+    print(f"  NeMo segments: {len(nemo_segments[0])}")
+    print(f"  NeMo preds: {nemo_preds.shape}")
+
+    # --- Run .pte ---
+    print("Loading .pte...")
+    runtime = Runtime.get()
+    program = runtime.load_program(args.pte_path)
+    pte_pre = program.load_method("preprocessor")
+    pte_penc = program.load_method("pre_encode")
+    pte_enc = program.load_method("encode")
+
+    print("Running .pte...")
+    mel, mel_len = pte_pre.execute([audio, length])
+
+    mel_t = mel.transpose(1, 2).contiguous()
+    valid_mel = min(mel_t.shape[1], 4000)
+    if mel_t.shape[1] < 4000:
+        padded = torch.zeros(1, 4000, 128)
+        padded[:, : mel_t.shape[1], :] = mel_t
+        mel_t = padded
+    else:
+        mel_t = mel_t[:, :4000, :].contiguous()
+    chunk_len = torch.tensor([valid_mel], dtype=torch.int64)
+
+    embs, emb_len = pte_penc.execute([mel_t, chunk_len])
+    embs = embs[:, : emb_len.item(), :].contiguous()
+    pte_preds = pte_enc.execute([embs, emb_len])[0]
+    pte_preds = pte_preds.squeeze(0)  # (T, 4)
+    print(f"  PTE preds: {pte_preds.shape}")
+
+    # --- Compare ---
+    min_t = min(nemo_preds.shape[0], pte_preds.shape[0])
+    nemo_aligned = nemo_preds[:min_t]
+    pte_aligned = pte_preds[:min_t]
+
+    max_diff = torch.abs(nemo_aligned - pte_aligned).max().item()
+    mean_diff = torch.abs(nemo_aligned - pte_aligned).mean().item()
+    agree = ((nemo_aligned > 0.5) == (pte_aligned > 0.5)).float().mean().item()
+
+    print(f"\nFrames compared:    {min_t}")
+    print(f"Max abs diff:       {max_diff:.6f}")
+    print(f"Mean abs diff:      {mean_diff:.6f}")
+    print(f"Decision agreement: {agree*100:.1f}%")
+    # NeMo diarize() uses streaming (chunked processing with speaker cache/FIFO),
+    # while .pte runs single-pass, so raw probabilities differ at chunk boundaries.
+    # Decision agreement is the meaningful metric.
+    print(f"Result:             {'PASS' if agree > 0.95 else 'FAIL'}")
+
+    # Show NeMo reference segments
+    print("\nNeMo diarization segments:")
+    for seg in nemo_segments[0]:
+        print(f"  {seg}")
+
+    # Cleanup
+    os.remove(tmp_wav)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Test on both https://huggingface.co/nvidia/diar_streaming_sortformer_4spk-v2 and https://huggingface.co/nvidia/diar_streaming_sortformer_4spk-v2.1 (since the architecture is the same)

Tested on https://groups.inf.ed.ac.uk/ami/AMICorpusMirror/amicorpus/ES2004a/audio/ES2004a.Mix-Headset.wav

Also as part of the exercise, populate torch-export guide for how to resolve common errors (which was in turn used to export softformer)


```
(executorch_dev) mnachin@mnachin-mbp executorch % cmake-out/examples/models/softformer/softformer_runner --model_path examples/models/softformer/softformer_exports/softformer.pte --audio_path /tmp/meeting.wav
I tokenizers:regex.cpp:27] Registering override fallback regex
  0.480 1.760 speaker_0
  10.960 11.760 speaker_1
  12.000 14.640 speaker_1
  17.920 18.320 speaker_0
  18.880 19.360 speaker_1
  19.760 20.400 speaker_1
  22.400 23.840 speaker_1
  25.200 26.560 speaker_2
  29.920 30.400 speaker_0
  29.200 30.400 speaker_2
  30.960 31.600 speaker_0
  31.200 32.240 speaker_2
  34.320 34.720 speaker_0
  50.400 51.840 speaker_2
  52.240 52.800 speaker_2
  63.920 64.000 speaker_3
  80.560 80.960 speaker_0
  81.920 83.200 speaker_0
  83.280 83.520 speaker_1
  83.920 84.320 speaker_0
  84.560 87.200 speaker_0
  88.000 89.920 speaker_0
  90.560 91.360 speaker_0
  92.080 93.440 speaker_0
  95.840 96.480 speaker_0
  96.720 97.200 speaker_0
  97.760 99.200 speaker_0
  99.200 101.360 speaker_1
  102.160 103.760 speaker_1
  104.240 105.440 speaker_1
  106.320 107.520 speaker_1
  108.160 109.920 speaker_1
  112.080 115.840 speaker_1
  117.680 119.040 speaker_1
  119.040 121.120 speaker_0
  122.400 125.440 speaker_0
  126.080 128.080 speaker_0
  128.880 132.400 speaker_0
  133.280 134.960 speaker_0
  135.600 138.240 speaker_0
  139.360 141.200 speaker_0
  142.720 143.440 speaker_0
  143.840 148.960 speaker_0
  149.680 150.160 speaker_0
  150.400 153.360 speaker_0
  154.080 156.080 speaker_0
  156.720 158.720 speaker_0
  159.440 160.960 speaker_0
  162.400 167.760 speaker_0
  170.400 174.000 speaker_0
  174.560 179.040 speaker_0
  179.920 183.440 speaker_0
  184.160 184.800 speaker_0
  188.880 189.520 speaker_0
```