### PR TITLE
NXP backend: Enable `aten.softmax.default` delegation to Neutron.

### DIFF
--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/softmax_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/softmax_converter.py
@@ -1,12 +1,14 @@
-# Copyright 2024-2025 NXP
+# Copyright 2024-2026 NXP
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import numpy as np
+
 from executorch.backends.nxp.backend.custom_delegation_options import (
     CustomDelegationOptions,
 )
-from executorch.backends.nxp.backend.edge_helper import input_rank
+from executorch.backends.nxp.backend.data_format import NXP_NODE_FORMAT
 from executorch.backends.nxp.backend.ir.converter.node_converter import NodeConverter
 from executorch.backends.nxp.backend.ir.tflite_generator.builtin_options import (
     softmax_options,
@@ -17,6 +19,38 @@ from torch.nn import Parameter
 
 
 class SoftmaxConverter(NodeConverter):
+
+    @staticmethod
+    def _get_channels_dim(node: Node) -> int:
+        """Get the dimension index for channels, based on data format.
+        :return: 1 for the channels_first format (NCHW), rank-1 for the channels_last format (NHWC).
+        """
+        rank = len(node.meta["val"].shape)
+        return 1 if node.meta[NXP_NODE_FORMAT].is_channels_first() else rank - 1
+
+    @staticmethod
+    def _get_spatial_dims(node: Node) -> list[int]:
+        """Extract spatial dimensions from the node's input shape.
+        Returns a list with [N, H, W] (or equivalent for other ranks).
+        """
+        input_shape = list(node.meta["val"].shape)
+        if node.meta[NXP_NODE_FORMAT].is_channels_first():
+            # NCHW: skip the channel dimension at index 1
+            return [input_shape[0]] + input_shape[2:]
+        else:
+            # NHWC: skip the last dimension
+            return input_shape[:-1]
+
+    @staticmethod
+    def _get_total_spatial_size(node: Node) -> int:
+        """Calculate total spatial size (product of all spatial dimensions)."""
+        return int(np.prod(SoftmaxConverter._get_spatial_dims(node)))
+
+    @staticmethod
+    def _get_channels(node: Node) -> int:
+        """Get the number of channels from the node's input shape."""
+        return node.meta["val"].shape[SoftmaxConverter._get_channels_dim(node)]
+
     @staticmethod
     def _is_supported_on_target(
         node: Node,
@@ -24,7 +58,53 @@ class SoftmaxConverter(NodeConverter):
         parameters_mapping: dict[str, Parameter],
         custom_delegation_options: CustomDelegationOptions,
     ) -> bool:
-        return False
+        """Check if the softmax operation can be executed on Neutron hardware.
+
+        Hardware constraints:
+        1. Input rank must be >= 2 (Neutron does not support 1D)
+        2. Channels must be a multiple of num_macs
+        3. Channels < 4096 / num_pipes * 4
+        4. Total spatial size (N*H*W) <= 4096
+        5. (channels * spatial_size) / num_macs <= 65536
+        """
+        input_shape = node.meta["val"].shape
+
+        # Constraint 1: Neutron does not support 1D SoftMax
+        if len(input_shape) == 1:
+            return False
+
+        num_macs = neutron_target_spec.get_num_macs()
+        num_pipes = neutron_target_spec.get_num_pipes()
+        channels = SoftmaxConverter._get_channels(node)
+        total_spatial_size = SoftmaxConverter._get_total_spatial_size(node)
+
+        # Constraint 2: Channels must be a multiple of num_macs
+        if channels % num_macs != 0:
+            return False
+
+        # Constraint 3: Channel size limit
+        if channels >= 4096 / num_pipes * 4:
+            return False
+
+        # Constraint 4: Spatial size limit
+        if total_spatial_size > 4096:
+            return False
+
+        # Constraint 5: Total processing size limit
+        if channels * total_spatial_size / num_macs > 65536:
+            return False
+
+        return True
+
+    @staticmethod
+    def _normalize_dim(dim: int, rank: int) -> int:
+        """Make sure the dimension index `dim` is positive.
+        :arg dim: The dimension index (can be negative)
+        :arg rank: The total number of dimensions
+
+        :return: Positive dimension index
+        """
+        return dim % rank
 
     @staticmethod
     def _is_supported_in_IR(
@@ -32,31 +112,39 @@ class SoftmaxConverter(NodeConverter):
         parameters_mapping: dict[str, Parameter],
         custom_delegation_options: CustomDelegationOptions,
     ) -> bool:
-        # The IR only supports the `dim` as the last dimension. But that depends on the format of the input tensor,
-        #  which is only known after the `Partitioner` has divided the model. So if the input shape can be channels
-        #  first (i.e. is more than 2D), we cannot determine IR support (we assume it's not supported).
-        x_rank = input_rank(node, 0)
-        if x_rank > 2:
+        """Check if the softmax operation is supported in NeutronIR.
+        NeutronIR only supports softmax along the channels dimension.
+        """
+        dim = SoftmaxConverter._normalize_dim(node.args[1], len(node.meta["val"].shape))
+
+        # NeutronIR only supports the `dim` as the channels dimension
+        channels_dim = SoftmaxConverter._get_channels_dim(node)
+        if dim != channels_dim:
             return False
 
-        dim = SoftmaxConverter._normalize_dim(node.args[1], x_rank)
-        if dim != x_rank - 1:
-            return False
+        half_to_float = node.args[2] if len(node.args) > 2 else False
+        if half_to_float:
+            # This argument states that the Softmax has a float16 input and output, but the computation is done in
+            #  float32. Neutron doesn't support float16 quantization, so this case should never happen.
+            raise ValueError(
+                f"Softmax node `{node}` has `half_to_float = True`, which is not supported. "
+                "There is an issue with the NXP backend. Please report this."
+            )
 
         return True
 
-    @staticmethod
-    def _normalize_dim(dim, rank):
-        # convert negative index to positive
-        if dim < 0:
-            dim += rank
-        return dim
-
     def convert(self, node: Node):
+        """Convert `aten._softmax.default` node to NeutronIR.
+        The schema is:
+        aten::_softmax(
+            Tensor self,
+            int dim,
+            bool half_to_float
+        ) -> Tensor
+        """
         self.assert_convertible(node)
 
         t_op = self._create_tflite_op_with_io_tensors(node)
-
         t_op.builtin_options = softmax_options.Softmax(beta=1.0)
 
         self.builder.append_operators([t_op])

--- a/backends/nxp/tests/ir/converter/node_converter/test_softmax_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_softmax_converter.py
@@ -6,20 +6,23 @@
 import numpy as np
 import pytest
 import torch
+
 from executorch.backends.nxp.backend.edge_program_converter import (
     EdgeProgramToIRConverter,
 )
-from executorch.backends.nxp.backend.ir.conversion_config import ConversionConfig
-from executorch.backends.nxp.backend.ir.converter.node_converters.ops_converters.softmax_converter import (
-    SoftmaxConverter,
-)
-from executorch.backends.nxp.backend.node_format_inference import NodeFormatInference
-from executorch.backends.nxp.tests.executorch_pipeline import to_edge_program
+from executorch.backends.nxp.tests.executorch_pipeline import to_quantized_edge_program
 from executorch.backends.nxp.tests.executors import (
     convert_run_compare,
-    OverrideTargetSupportCheck,
+    graph_contains_any_of_ops,
+    ToChannelFirstPreprocess,
+    ToChannelLastPreprocess,
 )
-from executorch.backends.nxp.tests.models import SoftmaxConvModule, SoftmaxModule
+from executorch.backends.nxp.tests.models import SoftmaxModule
+from executorch.exir.dialects._ops import ops as exir_ops
+
+# noinspection PyProtectedMember
+ExecutorchDelegateCall = torch._higher_order_ops.executorch_call_delegate
+Softmax = exir_ops.edge.aten._softmax.default
 
 
 @pytest.fixture(autouse=True)
@@ -28,94 +31,179 @@ def reseed_model_per_test_run():
     np.random.seed(23)
 
 
+class ConvSoftmaxModule(torch.nn.Module):
+    def __init__(self, dim: int, channels: int):
+        super().__init__()
+        self.conv = torch.nn.Conv2d(channels, channels, 1)
+        self.softmax = torch.nn.Softmax(dim=dim)
+
+    def forward(self, x):
+        x = self.conv(x)
+        return self.softmax(x)
+
+
+def assert_softmax_delegated(graph):
+    assert graph_contains_any_of_ops(graph, [ExecutorchDelegateCall])
+    assert not graph_contains_any_of_ops(graph, [Softmax])
+
+
+def assert_softmax_not_delegated(graph):
+    assert not graph_contains_any_of_ops(graph, [ExecutorchDelegateCall])
+    assert graph_contains_any_of_ops(graph, [Softmax])
+
+
+def random_input_data(input_shape):
+    return (np.random.random(input_shape).astype(np.float32) * 256.0 - 128.0).astype(
+        np.int8
+    )
+
+
 @pytest.mark.parametrize(
-    "input_shape,dim",
+    "input_shape, dim",
     [
-        pytest.param((10,), -1, id="1D,dim=-1"),
-        pytest.param((10,), 0, id="1D,dim=0"),
-        pytest.param((10, 32), -1, id="2D,dim=-1"),
-        pytest.param((10, 32), 1, id="2D,dim=1"),
+        # Dim must always be the last dimension, which must be a multiple of 8 (num_macs).
+        pytest.param((4096, 128), -1, id="2D_total_size_limit"),
+        pytest.param((5, 8), -1, id="2D_dim_-1"),
+        pytest.param((5, 8), 1, id="2D_dim_1"),
+        pytest.param((4096, 8), -1, id="2D_WxH_limit"),
+        pytest.param((2, 2048 - 8), -1, id="2D_channels_limit"),
+        pytest.param((5, 4, 8), -1, id="3D_dim_-1"),
+        pytest.param((4096, 1, 8), -1, id="3D_WxH_limit"),
+        pytest.param((5, 4, 3, 8), -1, id="4D_dim_-1"),
+        pytest.param((1, 64, 64, 8), -1, id="4D_WxH_limit"),
+        pytest.param((64, 1, 64, 128), -1, id="4D_total_size_limit"),
+        pytest.param((5, 4, 3, 2, 8), -1, id="5D_dim_-1"),
     ],
 )
-def test_softmax_conversion__formatless_input(input_shape, dim: int):
+def test_softmax_delegation(input_shape, dim: int, mocker):
     model = SoftmaxModule(dim)
 
-    edge_program = to_edge_program(model, input_shape).exported_program()
+    converter_spy = mocker.spy(EdgeProgramToIRConverter, "convert_program")
+    delegated_ep = to_quantized_edge_program(model, input_shape).exported_program()
 
-    input_data = np.random.random(input_shape).astype(np.float32)
+    assert_softmax_delegated(delegated_ep.graph)
 
-    # Ignore the target requirement, as this test is target agnostic.
-    def supported_target(*_):
-        return True
+    # Verify correct behavior of the converted NeutronIR model.
+    intermediate_ep = converter_spy.call_args.args[1]
+    neutron_ir_model, _ = converter_spy.spy_return
+    input_data = random_input_data(input_shape)
 
-    with OverrideTargetSupportCheck(
-        SoftmaxConverter, new_target_support_check=supported_target
-    ):
-        convert_run_compare(edge_program, input_data=input_data)
+    # Make sure the tested program contains the `softmax`, and its input has the expected rank.
+    nodes = list(intermediate_ep.graph.nodes)
+    assert nodes[2].target == Softmax
+    assert len(nodes[2].args[0].meta["val"].shape) == len(input_shape)
+
+    convert_run_compare(
+        intermediate_ep,
+        tfl_model=neutron_ir_model,
+        input_data=input_data,
+    )
 
 
 @pytest.mark.parametrize(
     "input_shape,dim",
     [
-        pytest.param((10, 32, 32), -1, id="3D,dim=-1"),
-        pytest.param((10, 32, 32), 2, id="3D,dim=2"),
-        pytest.param((10, 32, 32, 8), -1, id="4D,dim=-1"),
-        pytest.param((10, 32, 32, 8), 3, id="4D,dim=3"),
-        pytest.param((10, 32, 32, 8, 8), -1, id="5D,dim=-1"),
-        pytest.param((10, 32, 32, 8, 8), 4, id="5D,dim=4"),
+        # `dim` must be the second dimension, which must be a multiple of 8 (num_macs).
+        pytest.param((1, 8, 2, 3), 1, id="4D_dim_1"),
+        pytest.param((1, 8, 64, 64), 1, id="4D_WxH_limit"),
+        pytest.param((64, 128, 1, 64), -3, id="4D_dim_-3_total_size_limit"),
     ],
 )
-def test_softmax_conversion__unknown_input_format(input_shape, dim: int):
+def test_softmax_delegation__channel_first(input_shape, dim: int, mocker):
+    model = ConvSoftmaxModule(dim, input_shape[1])
+
+    converter_spy = mocker.spy(EdgeProgramToIRConverter, "convert_program")
+    delegated_ep = to_quantized_edge_program(
+        model, input_shape, use_neutron_for_format_conversion=False
+    ).exported_program()
+
+    assert_softmax_delegated(delegated_ep.graph)
+
+    # Verify correct behavior of the converted NeutronIR model.
+    intermediate_ep = converter_spy.call_args.args[1]
+    neutron_ir_model, _ = converter_spy.spy_return
+    input_data = random_input_data(input_shape)
+
+    # Make sure the tested program contains the `softmax`.
+    assert graph_contains_any_of_ops(intermediate_ep.graph, [Softmax])
+
+    convert_run_compare(
+        intermediate_ep,
+        tfl_model=neutron_ir_model,
+        input_data=input_data,
+        tflite_input_preprocess=ToChannelLastPreprocess(),
+        tflite_output_preprocess=ToChannelFirstPreprocess(),
+    )
+
+
+@pytest.mark.parametrize(
+    "input_shape,dim",
+    [
+        # `dim` is not the last dimension.
+        pytest.param((10, 32), 0, id="2D_dim_0"),
+        pytest.param((10, 32, 32), 1, id="3D_dim_1"),
+        pytest.param((10, 32, 32, 8), 2, id="4D_dim_2"),
+        pytest.param((10, 32, 32, 8, 8), 3, id="5D_dim_3"),
+        pytest.param((10, 32, 32, 8, 8), 2, id="5D_dim_2"),
+    ],
+)
+def test_softmax_delegation__unsupported_dims(input_shape, dim: int):
     model = SoftmaxModule(dim)
-
-    edge_program = to_edge_program(model, input_shape).exported_program()
-    NodeFormatInference(edge_program).identify_node_formats()
-
-    # Currently this test not pass because the convertibility checker doesn't use tensor formats.
-    with pytest.raises(AssertionError, match="aten__softmax_default.*not convertible"):
-        EdgeProgramToIRConverter().convert_program(edge_program, ConversionConfig())
-
-    # input_data = np.random.random(input_shape).astype(np.float32)
-    # convert_run_compare(edge_program_manager.exported_program(), input_data=input_data, atol=5e-7)
+    delegated_ep = to_quantized_edge_program(model, input_shape).exported_program()
+    assert_softmax_not_delegated(delegated_ep.graph)
 
 
 @pytest.mark.parametrize(
     "input_shape,dim",
     [
-        pytest.param((1, 4, 32, 32), 1, id="4D,dim=1"),
-        pytest.param((1, 4, 16, 16), -3, id="4D,dim=-3"),
+        # `dim` is not the second dimension.
+        pytest.param((10, 32, 32, 8), 2, id="dim_2"),
+        pytest.param((10, 32, 32, 8), -1, id="dim_-1"),
+        pytest.param((10, 32, 32, 8), 3, id="dim_3"),
     ],
 )
-def test_softmax_conversion_channel_last(input_shape, dim: int):
-    model = SoftmaxConvModule(dim)
-
-    edge_program = to_edge_program(model, input_shape).exported_program()
-    NodeFormatInference(edge_program).identify_node_formats()
-
-    # TODO (Robert Kalmar) Currently this test not pass because the convertibility checker doesn't use tensor formats.
-    with pytest.raises(AssertionError, match="aten__softmax_default.*not convertible"):
-        EdgeProgramToIRConverter().convert_program(edge_program, ConversionConfig())
-
-    # input_data = np.random.random(input_shape).astype(np.float32)
-    # convert_run_compare(edge_program_manager.exported_program(), tflite_input_preprocess=ToNHWCPreprocess(),
-    #                     tflite_output_preprocess=ToNCHWPreprocess(), input_data=input_data, atol=5e-7)
-
-
-@pytest.mark.parametrize(
-    "input_shape,dim",
-    [
-        pytest.param((10, 32), 0, id="2D,dim=0"),
-        pytest.param((10, 32, 32), 1, id="3D,dim=1"),
-        pytest.param((10, 32, 32, 8), 2, id="4D,dim=2"),
-        pytest.param((10, 32, 32, 8, 8), 3, id="5D,dim=3"),
-        pytest.param((10, 32, 32, 8, 8), 2, id="5D,dim=2"),
-    ],
-)
-def test_softmax_conversion_unsupported_dims(input_shape, dim: int):
+def test_softmax_delegation__unsupported_dims__channels_first(input_shape, dim: int):
     model = SoftmaxModule(dim)
+    delegated_ep = to_quantized_edge_program(model, input_shape).exported_program()
+    assert_softmax_not_delegated(delegated_ep.graph)
 
-    edge_program = to_edge_program(model, input_shape).exported_program()
-    NodeFormatInference(edge_program).identify_node_formats()
 
-    with pytest.raises(AssertionError, match="aten__softmax_default.*not convertible"):
-        EdgeProgramToIRConverter().convert_program(edge_program, ConversionConfig())
+@pytest.mark.parametrize(
+    "input_shape,dim",
+    [
+        pytest.param((4096 + 1, 8), -1, id="2D_WxH_exceeded"),
+        pytest.param((4096, 2, 8), -1, id="3D_WxH_exceeded"),
+        pytest.param((2, 64, 64, 8), -1, id="4D_WxH_exceeded"),
+        pytest.param((1, 2048), -1, id="2D_channels_exceeded"),
+        pytest.param((4096, 128 + 8), -1, id="2D_total_size_exceeded"),
+        pytest.param((64, 1, 64, 128 + 8), -1, id="4D_total_size_exceeded"),
+    ],
+)
+def test_softmax_delegation__unsupported_dimension_sizes(input_shape, dim: int):
+    model = SoftmaxModule(dim)
+    delegated_ep = to_quantized_edge_program(model, input_shape).exported_program()
+    assert_softmax_not_delegated(delegated_ep.graph)
+
+
+@pytest.mark.parametrize(
+    "input_shape,dim",
+    [
+        pytest.param((2, 8, 64, 64), -1, id="4D_WxH_exceeded"),
+        pytest.param((64, 128 + 8, 1, 64), -1, id="4D_total_size_exceeded"),
+    ],
+)
+def test_softmax_delegation__unsupported_dimension_sizes__channels_first(
+    input_shape, dim: int
+):
+    model = ConvSoftmaxModule(dim, input_shape[1])
+    delegated_ep = to_quantized_edge_program(model, input_shape).exported_program()
+    assert_softmax_not_delegated(delegated_ep.graph)
+
+
+def test_softmax_delegation__1d():
+    input_shape = (8,)
+    dim = 0
+
+    model = SoftmaxModule(dim)
+    delegated_ep = to_quantized_edge_program(model, input_shape).exported_program()
+    assert_softmax_not_delegated(delegated_ep.graph)

--- a/docs/source/backends/nxp/op-support.csv
+++ b/docs/source/backends/nxp/op-support.csv
@@ -18,6 +18,7 @@ aten.neg.default,int8,static int8,
 aten.relu.default,int8,static int8,
 aten.sigmoid.default,int8,static int8,
 aten.slice_copy.Tensor, int8, static int8
+aten.softmax.default, int8, static int8, "rank > 1, channels % 8 = 0, channels < 2048, flat input size / channels <= 4096, flat input size <= 524288"
 aten.tanh.default,int8,static int8,
 aten.upsample_bilinear2d.vec,int8,static int8,"channels % 8 = 0, H_scale = W_scale = 2 or 4"
 aten.upsample_nearest2d.vec,int8,static int8,"channels % 8 = 0, H_scale = W_scale = 2 or 4"


### PR DESCRIPTION
### Summary
This PR enables the delegation of `aten._softmax.default` to Neutron.

### Test plan
Unit-tests provided.


cc @robert-kalmar @JakeStevens @digantdesai