### PR TITLE
Arm backend: Add Zephyr Cortex-M STM Nucleo n657x0_q example

### DIFF
--- a/examples/arm/zephyr/CMakeLists.txt
+++ b/examples/arm/zephyr/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -84,8 +84,6 @@ else()
     "gen_oplist: No non delagated ops was found in ${ET_PTE_FILE_PATH} no ops added to build"
   )
 endif()
-
-set(CONF_FILE "${CMAKE_CURRENT_SOURCE_DIR}/prj.conf")
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(executorch_executor_runner)

--- a/examples/arm/zephyr/boards/mps3_corstone300_fvp.conf
+++ b/examples/arm/zephyr/boards/mps3_corstone300_fvp.conf
@@ -1,0 +1,9 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Enable the Zephyr Ethos-U driver so executorch_delegate_ethos_u can reserve
+# and use the hardware instance exposed by the board DTS
+# as the board has one available.
+CONFIG_ETHOS_U=y

--- a/examples/arm/zephyr/boards/mps4_corstone320_fvp.conf
+++ b/examples/arm/zephyr/boards/mps4_corstone320_fvp.conf
@@ -1,0 +1,9 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Enable the Zephyr Ethos-U driver so executorch_delegate_ethos_u can reserve
+# and use the hardware instance exposed by the board DTS
+# as the board has one available.
+CONFIG_ETHOS_U=y

--- a/examples/arm/zephyr/prj.conf
+++ b/examples/arm/zephyr/prj.conf
@@ -24,17 +24,20 @@ CONFIG_REQUIRES_FLOAT_PRINTF=y
 # Setting this means you will include all portable ops
 CONFIG_EXECUTORCH_BUILD_PORTABLE_OPS=n
 
-# Enable the Zephyr Ethos-U driver so executorch_delegate_ethos_u can reserve
-# and use the hardware instance exposed by the board DTS.
-CONFIG_ETHOS_U=y
-
-# Add model specific configs
-# The default 1 KB pool is too small even for the tiny sample model;
-# bump to 256 KB so method buffers and inputs fit during setup.
-CONFIG_EXECUTORCH_METHOD_ALLOCATOR_POOL_SIZE=262144
-# Ethos-U scratch memory requirements scale with the compiled network.
-CONFIG_EXECUTORCH_TEMP_ALLOCATOR_POOL_SIZE=1572864
+# To enable the Zephyr Ethos-U driver so executorch_delegate_ethos_u can reserve
+# and use the hardware instance exposed by the board DTS is controlled with
+# CONFIG_ETHOS_U=y
+# This is handled in board specific .conf files, e.g.:
+# examples/arm/zephyr/boards/mps4_corstone320_fvp.conf
+# To be able to build the example for different HW, in your own project you can
+# copy the relevant lines from those files into your own prj.conf
 
 # Enable Helium (MVE) builds of CMSIS-NN by selecting the FPU and hard-float ABI.
 CONFIG_FPU=y
 CONFIG_FP_HARDABI=y
+
+# Add model specific configs
+
+# Setup memory requirements to scale with the compiled model/network.
+CONFIG_EXECUTORCH_METHOD_ALLOCATOR_POOL_SIZE=2000
+CONFIG_EXECUTORCH_TEMP_ALLOCATOR_POOL_SIZE=2000

--- a/examples/arm/zephyr/src/arm_executor_runner.cpp
+++ b/examples/arm/zephyr/src/arm_executor_runner.cpp
@@ -1,6 +1,6 @@
 /* Copyright (c) Meta Platforms, Inc. and affiliates.
  * All rights reserved.
- * Copyright 2025 Arm Limited and/or its affiliates.
+ * Copyright 2025-2026 Arm Limited and/or its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
@@ -180,7 +180,7 @@ Result<BufferCleanup> prepare_input_tensors(
 
     // If input_buffers.size <= 0, we don't have any input, fill it with 1's.
     if (input_buffers.size() <= 0) {
-      for (size_t j = 0; j < t.numel(); j++) {
+      for (size_t j = 0; j < static_cast<size_t>(t.numel()); j++) {
         switch (t.scalar_type()) {
           case ScalarType::Int:
             t.mutable_data_ptr<int>()[j] = 1;
@@ -226,7 +226,11 @@ int main(int argc, const char* argv[]) {
   std::vector<std::pair<char*, size_t>> input_buffers;
   size_t pte_size = sizeof(model_pte);
 
-  ET_LOG(Info, "PTE at %p Size: %lu bytes", model_pte, pte_size);
+  ET_LOG(
+      Info,
+      "PTE at %p Size: %lu bytes",
+      model_pte,
+      static_cast<unsigned long>(pte_size));
 
   // Find the offset to the embedded Program.
   if (!model_pte_runtime_initialized) {
@@ -237,7 +241,10 @@ int main(int argc, const char* argv[]) {
   size_t program_data_len = pte_size;
 
   auto loader = BufferDataLoader(program_data, program_data_len);
-  ET_LOG(Info, "PTE Model data loaded. Size: %lu bytes.", program_data_len);
+  ET_LOG(
+      Info,
+      "PTE Model data loaded. Size: %lu bytes.",
+      static_cast<unsigned long>(program_data_len));
 
   // Parse the program file. This is immutable, and can also be reused
   // between multiple execution invocations across multiple threads.
@@ -247,7 +254,7 @@ int main(int argc, const char* argv[]) {
         Info,
         "Program loading failed @ 0x%p: 0x%" PRIx32,
         program_data,
-        program.error());
+        static_cast<uint32_t>(program.error()));
   }
 
   ET_LOG(Info, "Model buffer loaded, has %zu methods", program->num_methods());
@@ -325,7 +332,7 @@ int main(int argc, const char* argv[]) {
         Info,
         "Loading of method %s failed with status 0x%" PRIx32,
         method_name,
-        method.error());
+        static_cast<uint32_t>(method.error()));
   }
   size_t method_loaded_memsize =
       method_allocator.used_size() - method_loaded_membase;
@@ -351,7 +358,7 @@ int main(int argc, const char* argv[]) {
           Info,
           "Preparing inputs tensors for method %s failed with status 0x%" PRIx32,
           method_name,
-          prepared_inputs.error());
+          static_cast<uint32_t>(prepared_inputs.error()));
     }
   }
 #if defined(ET_DUMP_INPUT)
@@ -409,8 +416,14 @@ int main(int argc, const char* argv[]) {
   Error status = method->execute();
   size_t executor_memsize = method_allocator.used_size() - executor_membase;
 
-  ET_LOG(Info, "model_pte_program_size:     %lu bytes.", program_data_len);
-  ET_LOG(Info, "model_pte_loaded_size:      %lu bytes.", pte_size);
+  ET_LOG(
+      Info,
+      "model_pte_program_size:     %lu bytes.",
+      static_cast<unsigned long>(program_data_len));
+  ET_LOG(
+      Info,
+      "model_pte_loaded_size:      %lu bytes.",
+      static_cast<unsigned long>(pte_size));
   if (method_allocator.size() != 0) {
     size_t method_allocator_used = method_allocator.used_size();
     ET_LOG(
@@ -432,7 +445,7 @@ int main(int argc, const char* argv[]) {
         Info,
         "Execution of method %s failed with status 0x%" PRIx32,
         method_name,
-        status);
+        static_cast<uint32_t>(status));
   } else {
     ET_LOG(Info, "Model executed successfully.");
   }

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2025 Petri Oksanen
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -13,6 +13,18 @@ if(CONFIG_EXECUTORCH)
   message(STATUS "EXECUTORCH_DIR set to: ${EXECUTORCH_DIR}")
   include(${EXECUTORCH_DIR}/tools/cmake/common/preset.cmake)
   include(${EXECUTORCH_DIR}/tools/cmake/preset/zephyr.cmake)
+
+  # Prefer a local CMSIS-NN checkout from the Zephyr workspace if available.
+  if(NOT DEFINED CMSIS_NN_LOCAL_PATH OR CMSIS_NN_LOCAL_PATH STREQUAL "")
+    set(_cmsis_nn_default "${ZEPHYR_BASE}/../modules/lib/cmsis-nn")
+    if(EXISTS "${_cmsis_nn_default}")
+      set(CMSIS_NN_LOCAL_PATH
+          "${_cmsis_nn_default}"
+          CACHE PATH "Path to existing local CMSIS-NN installation"
+      )
+      message(STATUS "CMSIS_NN_LOCAL_PATH set to: ${CMSIS_NN_LOCAL_PATH}")
+    endif()
+  endif()
 
   # HACK: Force the parent directory of executorch into the global include path.
   # This is needed because the executorch CMake scripts generate a relative
@@ -51,7 +63,9 @@ if(CONFIG_EXECUTORCH)
 
   set(EXECUTORCH_BUILD_EXTENSION_RUNNER_UTIL ON)
   set(EXECUTORCH_BUILD_KERNELS_QUANTIZED ON)
-  set(EXECUTORCH_BUILD_KERNELS_QUANTIZED_AOT ON)
+  # Zephyr builds use -fno-rtti; AOT quantized kernels pull in Torch headers
+  # that require RTTI, so disable to avoid build failures.
+  set(EXECUTORCH_BUILD_KERNELS_QUANTIZED_AOT OFF)
 
   set(EXECUTORCH_ENABLE_LOGGING ${CONFIG_EXECUTORCH_ENABLE_LOGGING})
   set(EXECUTORCH_ENABLE_EVENT_TRACER ${CONFIG_EXECUTORCH_ENABLE_EVENT_TRACER})

--- a/zephyr/README.md
+++ b/zephyr/README.md
@@ -52,7 +52,7 @@ manifest:
 
 ## Run west config and update:
 
-Add ExecuTorch to Zephyr
+Add ExecuTorch and Ethos-U driver to Zephyr
 <!-- RUN west_config -->
 ```
 west config manifest.project-filter -- -.*,+zephyr,+executorch,+cmsis,+cmsis_6,+cmsis-nn,+hal_ethos_u
@@ -88,6 +88,9 @@ modules/lib/executorch/examples/arm/setup.sh --i-agree-to-the-contained-eula
 
 To run you need to point of the path to the installed Corstone&trade; FVP and you can then use west to build and run. You point out the model PTE file you want to run with -DET_PTE_FILE_PATH= see below.
 
+The magic to include and use Ethos-U backend is to set
+CONFIG_ETHOS_U=y/n
+This is done in the example depending on the board you build for so it you build for a different board then the ones below you might want to add a board config file, or add this line to the prj.conf
 
 ## Corstone&trade; 300 FVP (Ethos&trade;-U55)
 
@@ -175,6 +178,47 @@ Run the Ethos-U85 PTE model
 ```
 west build -b mps4/corstone320/fvp modules/lib/executorch/examples/arm/zephyr -t run -- -DET_PTE_FILE_PATH=add_u85_256.pte
 ```
+
+## STM Nucleo n657x0_q
+
+### Run west config and update:
+
+You need to add hal_stm32 driver to Zephyr
+```
+west config manifest.project-filter -- -.*,+zephyr,+executorch,+cmsis,+cmsis_6,+cmsis-nn,+hal_stm32
+west update
+```
+
+### Setup tools
+
+Follow and make sure tools are setup according to this:
+
+https://docs.zephyrproject.org/latest/boards/st/nucleo_n657x0_q/doc/index.html
+
+Test the samples/hello_world in that guide to make sure all tools work.
+
+Please note that the ZephyrOS made a fix for the signing tool version v2.21.0 after the v4.3 release in 20 Nov 2025. Make sure to use a later version of ZephyrOS that contains it.
+Also note that the signing tool must be in your path for it to auto sign your elf.
+
+```
+export PATH=$PATH:~/STMicroelectronics/STM32Cube/STM32CubeProgrammer/bin
+```
+
+### Prepare a PTE model file
+
+Prepare the Cortex-M55 PTE model
+```
+python -m modules.lib.executorch.examples.arm.aot_arm_compiler --model_name=modules/lib/executorch/examples/arm/example_modules/add.py --quantize --output=add_m55.pte
+```
+
+#### Build and run
+
+Run the Cortex-M55 PTE model
+```
+west build -b nucleo_n657x0_q modules/lib/executorch/examples/arm/zephyr -- -DET_PTE_FILE_PATH=add_m55.pte
+west flash
+```
+This will run the simple add model on your hardware one and print the output on the serial consol.
 
 ## Notable files
 


### PR DESCRIPTION
### Summary
Add information in the zephyr readme on how to build and run
a model on STM Nucleo n657x0_q board.

Moves the Ethos-U driver config to Corstone FVPs board files.
This enable smoother building different targets that will enable
or not enable the Ethos-U drivers/backend depending on board.

This makes it possible to build the example both for Ethos-U
and Cortex-M only targets without change.


cc @freddan80 @per @oscarandersson8218 @digantdesai