### PR TITLE
Arm backend: Add option to specify actual scratch size for given model

### DIFF
--- a/backends/arm/scripts/build_executor_runner.sh
+++ b/backends/arm/scripts/build_executor_runner.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -59,28 +59,28 @@ help() {
 
 for arg in "$@"; do
     case $arg in
-      -h|--help) help ;;
-      --pte=*) pte_file="${arg#*=}";;
-      --target=*) target="${arg#*=}";;
-      --build_type=*) build_type="${arg#*=}";;
-      --bundleio) bundleio=true ;;
-      --system_config=*) system_config="${arg#*=}";;
-      --memory_mode=*) memory_mode="${arg#*=}";;
-      --etdump) build_with_etdump=true ;;
-      --extra_build_flags=*) extra_build_flags="${arg#*=}";;
-      --output=*) output_folder="${arg#*=}" ; output_folder_set=true ;;
-      --et_build_root=*) et_build_root="${arg#*=}";;
-      --ethosu_tools_dir=*) ethosu_tools_dir="${arg#*=}";;
-      --toolchain=*) toolchain="${arg#*=}";;
-      --select_ops_list=*) select_ops_list="${arg#*=}";;
-      *)
-      ;;
+        -h|--help) help ;;
+        --pte=*) pte_file="${arg#*=}";;
+        --target=*) target="${arg#*=}";;
+        --build_type=*) build_type="${arg#*=}";;
+        --bundleio) bundleio=true ;;
+        --system_config=*) system_config="${arg#*=}";;
+        --memory_mode=*) memory_mode="${arg#*=}";;
+        --etdump) build_with_etdump=true ;;
+        --extra_build_flags=*) extra_build_flags="${arg#*=}";;
+        --output=*) output_folder="${arg#*=}" ; output_folder_set=true ;;
+        --et_build_root=*) et_build_root="${arg#*=}";;
+        --ethosu_tools_dir=*) ethosu_tools_dir="${arg#*=}";;
+        --toolchain=*) toolchain="${arg#*=}";;
+        --select_ops_list=*) select_ops_list="${arg#*=}";;
+        *)
+        ;;
     esac
 done
 
 if [[ ${toolchain} == "arm-none-eabi-gcc" ]]; then
     toolchain_cmake=${et_root_dir}/examples/arm/ethos-u-setup/${toolchain}.cmake
-elif [[ ${toolchain} == "arm-zephyr-eabi-gcc" ]]; then 
+elif [[ ${toolchain} == "arm-zephyr-eabi-gcc" ]]; then
     toolchain_cmake=${et_root_dir}/examples/zephyr/x86_64-linux-arm-zephyr-eabi-gcc.cmake
 else
     echo "Error: Invalid toolchain selection, provided: ${toolchain}"
@@ -99,22 +99,22 @@ source ${setup_path_script}
 if [[ ${pte_file} == "semihosting" ]]; then
     pte_data="-DSEMIHOSTING=ON"
 else
-	if [[ "$pte_file" =~ ^0x[0-9a-fA-F]{1,16}$ ]]; then
-		echo "PTE in memory at ${pte_file}, make sure to put it there on your target before starting."
-		pte_data="-DET_MODEL_PTE_ADDR=${pte_file}"
-		if [ "$output_folder_set" = false ] ; then
-		    # Not locked down to a PTE use 
-		    output_folder=${et_build_root}/${target}_${pte_file}/cmake-out
-		fi
-	else
-		echo "PTE included in elf from file ${pte_file}"
-		pte_file=$(realpath ${pte_file})
-		pte_data="-DET_PTE_FILE_PATH:PATH=${pte_file}"
-		if [ "$output_folder_set" = false ] ; then
-		    # remove file ending
-		    output_folder=${pte_file%.*}/cmake-out
-		fi
-	fi
+    if [[ "$pte_file" =~ ^0x[0-9a-fA-F]{1,16}$ ]]; then
+        echo "PTE in memory at ${pte_file}, make sure to put it there on your target before starting."
+        pte_data="-DET_MODEL_PTE_ADDR=${pte_file}"
+        if [ "$output_folder_set" = false ] ; then
+            # Not locked down to a PTE use
+            output_folder=${et_build_root}/${target}_${pte_file}/cmake-out
+        fi
+    else
+        echo "PTE included in elf from file ${pte_file}"
+        pte_file=$(realpath ${pte_file})
+        pte_data="-DET_PTE_FILE_PATH:PATH=${pte_file}"
+        if [ "$output_folder_set" = false ] ; then
+            # remove file ending
+            output_folder=${pte_file%.*}/cmake-out
+        fi
+    fi
 fi
 ethosu_tools_dir=$(realpath ${ethosu_tools_dir})
 ethos_u_root_dir="$ethosu_tools_dir/ethos-u"

--- a/backends/arm/scripts/get_ethosu_scratch_from_pte.py
+++ b/backends/arm/scripts/get_ethosu_scratch_from_pte.py
@@ -1,0 +1,77 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+#!/usr/bin/env python3
+
+import struct
+from pathlib import Path
+
+from executorch.devtools.bundled_program.serialize import (
+    deserialize_from_flatbuffer_to_bundled_program,
+)
+from executorch.exir._serialize._program import deserialize_pte_binary
+
+
+def iter_vela_blocks(blob: bytes):
+    off = 0
+    while off + 32 <= len(blob):
+        name = blob[off : off + 16].split(b"\x00", 1)[0].decode("ascii", "ignore")
+        off += 16
+        # header: 4 x int32, first is size
+        (size,) = struct.unpack("<i", blob[off : off + 4])
+        off += 16
+        data = blob[off : off + size]
+        off += (size + 15) // 16 * 16  # pad to 16 bytes
+        yield name, data
+        if name == "vela_end_stream":
+            break
+
+
+def get_scratch_size_from_delegate(blob: bytes) -> int | None:
+    for name, data in iter_vela_blocks(blob):
+        if name == "scratch_size":
+            return struct.unpack("<I", data[:4])[0]
+    return None
+
+
+def _extract_pte_from_bundle(pte_data: bytes) -> bytes:
+    try:
+        bundled = deserialize_from_flatbuffer_to_bundled_program(pte_data)
+    except Exception:
+        return pte_data
+    return bundled.program if bundled.program else pte_data
+
+
+def get_scratch_from_pte(pte_path: str) -> int | None:
+    pte_data = _extract_pte_from_bundle(Path(pte_path).read_bytes())
+    pte = deserialize_pte_binary(pte_data)
+    program = pte.program
+
+    sizes = []
+    for plan in program.execution_plan:
+        for delegate in plan.delegates:
+            # delegate.id is the backend key (e.g. "EthosUBackend")
+            idx = delegate.processed.index
+            blob = program.backend_delegate_data[idx].data
+            scratch = get_scratch_size_from_delegate(blob)
+            if scratch is not None:
+                sizes.append((delegate.id, scratch))
+
+    if not sizes:
+        return None
+
+    for did, s in sizes:
+        print(f"{did}: scratch_size={s} bytes")
+    max_size = max(s for _, s in sizes)
+    print(f"max_scratch_size={max_size} bytes")
+    return max_size
+
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) != 2:
+        raise SystemExit(f"Usage: {sys.argv[0]} model.pte")
+    get_scratch_from_pte(sys.argv[1])

--- a/backends/arm/test/runner_utils.py
+++ b/backends/arm/test/runner_utils.py
@@ -361,7 +361,6 @@ def run_vkml_emulation_layer(
 
     result = _run_cmd(cmd_line)
 
-    # TODO: MLETORCH-1234: Support VGF e2e tests in VgfPipeline
     # TODO: Add regex to check for error or fault messages in stdout from Emulation Layer
     result_stdout = result.stdout.decode()  # noqa: F841
 

--- a/backends/arm/test/test_arm_baremetal.sh
+++ b/backends/arm/test/test_arm_baremetal.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2024-2025 Arm Limited and/or its affiliates.
+# Copyright 2024-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -268,17 +268,15 @@ test_run_vkml() {
 # ------------------------------------
 # -------- Miscelaneous tests --------
 # ------------------------------------
-test_model_smollm2-135M() {
+test_model_smollm2_135M() {
     echo "${TEST_SUITE_NAME}: Test SmolLM2-135M on Ethos-U85"
 
     # Build common libs once
     python3 backends/arm/test/test_model.py --test_output=arm_test/test_model --build_libs
 
-    python3 backends/arm/test/test_model.py --test_output=arm_test/test_model --target=ethos-u85-128 --model=smollm2 --extra_flags="-DEXECUTORCH_SELECT_OPS_LIST=dim_order_ops::_to_dim_order_copy.out"
+    python3 backends/arm/test/test_model.py --test_output=arm_test/test_model --target=ethos-u85-128 --model=smollm2 --extra_flags="-DEXECUTORCH_SELECT_OPS_LIST=dim_order_ops::_to_dim_order_copy.out" --specify_ethosu_scratch
 
     echo "${TEST_SUITE_NAME}: PASS"
-
-
 }
 
 test_smaller_stories_llama() {

--- a/examples/arm/executor_runner/CMakeLists.txt
+++ b/examples/arm/executor_runner/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2023-2025 Arm Limited and/or its affiliates.
+# Copyright 2023-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -122,13 +122,20 @@ message(STATUS "SYSTEM_CONFIG is ${SYSTEM_CONFIG}")
 message(STATUS "MEMORY_MODE is ${MEMORY_MODE}")
 message(STATUS "ET_NUM_INFERENCES is ${ET_NUM_INFERENCES}")
 
-# By default, use 2MB of temporary scratch buffer For Dedicated_Sram, use 64MB
-# for the temporary scratch buffer and 384KB for the fast scratch buffer(the
-# cache, applicable only for Ethos-U65 and Ethos-U85)
-set(ET_ARM_BAREMETAL_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE 0x200000)
+# By default, use 2MB of temporary scratch buffer. For Dedicated_Sram, use 64MB
+# for the temporary scratch buffer and 384KB for the fast scratch buffer (the
+# cache, applicable only for Ethos-U65 and Ethos-U85). Allow -D overrides.
 if(MEMORY_MODE MATCHES "Dedicated_Sram")
-  set(ET_ARM_BAREMETAL_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE 0x4000000)
-  set(ET_ARM_BAREMETAL_FAST_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE 0x60000)
+  if(NOT DEFINED ET_ARM_BAREMETAL_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE)
+    set(ET_ARM_BAREMETAL_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE 0x4000000)
+  endif()
+  if(NOT DEFINED ET_ARM_BAREMETAL_FAST_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE)
+    set(ET_ARM_BAREMETAL_FAST_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE 0x60000)
+  endif()
+else()
+  if(NOT DEFINED ET_ARM_BAREMETAL_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE)
+    set(ET_ARM_BAREMETAL_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE 0x200000)
+  endif()
 endif()
 message(
   STATUS

--- a/examples/arm/run.sh
+++ b/examples/arm/run.sh
@@ -2,7 +2,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
 #
-# Copyright 2023-2025 Arm Limited and/or its affiliates.
+# Copyright 2023-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -46,6 +46,7 @@ perf_overlay=false
 visualize_tosa=false
 visualize_pte=false
 model_converter=false
+specify_ethosu_scratch=false
 
 function help() {
     echo "Usage: $(basename $0) [options]"
@@ -73,6 +74,7 @@ function help() {
     echo "  --config=<FILEPATH>                    Ethos-U: System configuration file that specifies system configurations (vela.ini)"
     echo "  --memory_mode=<MODE>                   Ethos-U: Memory mode to select from the Vela configuration file (see vela.ini), e.g. Shared_Sram/Sram_Only. Default: 'Shared_Sram' for Ethos-U55 targets, 'Sram_Only' for Ethos-U85 targets"
     echo "  --pte_placement=<elf|ADDR>             Ethos-U: Control if runtime has PTE baked into the elf or if its placed in memory outside of the elf, defaults to ${pte_placement}"
+    echo "  --specify_ethosu_scratch               Use actual Ethos-U scratch size for given model to size temp allocator"
     echo "  --et_build_root=<FOLDER>               Executorch build output root folder to use, defaults to ${et_build_root}"
     echo "  --scratch-dir=<FOLDER>                 Path to your Arm scrach dir if you not using default ${arm_scratch_dir}"
     echo "  --qdq_fusion_op                        Enable QDQ fusion op"
@@ -106,6 +108,7 @@ for arg in "$@"; do
       --config=*) config="${arg#*=}";;
       --memory_mode=*) memory_mode="${arg#*=}";;
       --pte_placement=*) pte_placement="${arg#*=}";;
+      --specify_ethosu_scratch) specify_ethosu_scratch=true ;;
       --et_build_root=*) et_build_root="${arg#*=}";;
       --scratch-dir=*) arm_scratch_dir="${arg#*=}" ; scratch_dir_set=true ;;
       --qdq_fusion_op) qdq_fusion_op=true;;
@@ -212,7 +215,6 @@ function check_setup () {
 
         [[ -f ${et_root_dir}/CMakeLists.txt ]] \
             || { echo "Executorch repo doesn't contain CMakeLists.txt file at root level"; return 1; }
-        
 
     backends/arm/scripts/build_executorch.sh --et_build_root="${et_build_root}" --build_type=$build_type $devtools_flag $et_dump_flag --toolchain="${toolchain}"
     elif [[ ${target} =~ "vgf" ]]; then
@@ -225,21 +227,36 @@ function check_setup () {
     return 0
 }
 
+function get_ethosu_scratch_size() {
+    local pte_path="$1"
+    python3 - "$pte_path" <<'PY'
+from executorch.backends.arm.scripts.get_ethosu_scratch_from_pte import (
+    get_scratch_from_pte,
+)
+import sys
+
+size = get_scratch_from_pte(sys.argv[1])
+if size is None:
+    sys.exit(2)
+print(size)
+PY
+}
+
 #######
 ### Main
 #######
 if ! check_setup; then
     if [ "$scratch_dir_set" = false ] ; then
-	# check setup failed, no scratchdir given as parameter. trying to run setup.sh
-	if ${script_dir}/setup.sh; then
-	    # and recheck setup. If this fails exit.
-	    if ! check_setup; then
-		exit 1
-	    fi
-	else
-	    # setup.sh failed, it should print why
-	    exit 1
-	fi
+        # check setup failed, no scratchdir given as parameter. trying to run setup.sh
+        if ${script_dir}/setup.sh; then
+            # and recheck setup. If this fails exit.
+            if ! check_setup; then
+                exit 1
+            fi
+        else
+            # setup.sh failed, it should print why
+            exit 1
+        fi
     fi
 fi
 
@@ -352,6 +369,15 @@ for i in "${!test_model[@]}"; do
             pte_file_or_mem="${pte_placement}"
             model_data="--data=${pte_file}@${pte_placement}"
             elf_file="${et_build_root}/${target}_${pte_placement}/cmake-out/arm_executor_runner"
+        fi
+
+        if [ "$specify_ethosu_scratch" = true ] && [[ ${target} =~ "ethos-u" ]]; then
+            scratch_size=$(get_ethosu_scratch_size "$pte_file")
+            if [ "$?" -eq 0 ] && [ -n "$scratch_size" ]; then
+                extra_build_flags="${extra_build_flags} -DET_ARM_BAREMETAL_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE=${scratch_size}"
+            else
+                echo "WARNING: Failed to derive Ethos-U scratch size from ${pte_file}" >&2
+            fi
         fi
 
         set -x


### PR DESCRIPTION
Option --specify_ethosu_scratch extracts the actual scratch size reported by Vela for the given model and rebuilds the runner using this value.

Tested with/without option for MV3 which saves ~66.16 MB. .ddr section drops 133,169,536 -> 67,014,016 bytes (-66,155,520; -49.4%) python backends/arm/test/test_model.py --test_output=arm_test/test_model
  --target=ethos-u85-128 --model=mv3 --extra_flags="-DET_ATOL=0.5"
  [--specify_ethosu_scratch]



cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai @rascani 