### PR TITLE
Enable Silero Voice Activitiy Detection (VAD) model to detect speech on XNNPACK

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@
 # - whisper:  Speech recognition model (CPU, CUDA, Metal)
 # - parakeet: Speech recognition model (CPU, CUDA, Metal)
 # - sortformer: Speaker diarization model (CPU)
+# - silero_vad: Voice activity detection model (CPU)
 # - llama:    Text generation model (CPU)
 # - llava:    Vision + language model (CPU)
 # - gemma3:   Text generation model (CPU, CUDA)
@@ -89,7 +90,7 @@
 #
 # ==============================================================================
 
-.PHONY: voxtral-cuda voxtral-cpu voxtral-metal whisper-cuda whisper-cuda-debug whisper-cpu whisper-metal parakeet-cuda parakeet-cuda-debug parakeet-cpu parakeet-metal sortformer-cpu llama-cpu llava-cpu gemma3-cuda gemma3-cpu clean help
+.PHONY: voxtral-cuda voxtral-cpu voxtral-metal whisper-cuda whisper-cuda-debug whisper-cpu whisper-metal parakeet-cuda parakeet-cuda-debug parakeet-cpu parakeet-metal sortformer-cpu silero-vad-cpu llama-cpu llava-cpu gemma3-cuda gemma3-cpu clean help
 
 help:
 	@echo "This Makefile adds targets to build runners for various models on various backends. Run using \`make <target>\`. Available targets:"
@@ -105,6 +106,7 @@ help:
 	@echo "  parakeet-cpu        - Build Parakeet runner with CPU backend"
 	@echo "  parakeet-metal      - Build Parakeet runner with Metal backend (macOS only)"
 	@echo "  sortformer-cpu      - Build Sortformer runner with CPU backend"
+	@echo "  silero-vad-cpu      - Build Silero VAD runner with CPU backend"
 	@echo "  llama-cpu           - Build Llama runner with CPU backend"
 	@echo "  llava-cpu           - Build Llava runner with CPU backend"
 	@echo "  gemma3-cuda         - Build Gemma3 runner with CUDA backend"
@@ -218,6 +220,20 @@ sortformer-cpu:
 	@echo ""
 	@echo "✓ Build complete!"
 	@echo "  Binary: cmake-out/examples/models/sortformer/sortformer_runner"
+
+silero-vad-cpu:
+	@echo "==> Building and installing ExecuTorch..."
+	cmake --workflow --preset llm-release
+	@echo "==> Building Silero VAD runner (CPU)..."
+	cmake -DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_FIND_ROOT_PATH=$(CURDIR)/cmake-out \
+		-DCMAKE_PREFIX_PATH=$(CURDIR)/cmake-out \
+		-S examples/models/silero_vad \
+		-B cmake-out/examples/models/silero_vad
+	cmake --build cmake-out/examples/models/silero_vad --target silero_vad_runner
+	@echo ""
+	@echo "✓ Build complete!"
+	@echo "  Binary: cmake-out/examples/models/silero_vad/silero_vad_runner"
 
 llama-cpu:
 	@echo "==> Building and installing ExecuTorch..."

--- a/examples/models/silero_vad/CMakeLists.txt
+++ b/examples/models/silero_vad/CMakeLists.txt
@@ -1,0 +1,84 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+cmake_minimum_required(VERSION 3.24)
+project(silero_vad_runner)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
+
+include(${EXECUTORCH_ROOT}/tools/cmake/Utils.cmake)
+
+# Let files say "include <executorch/path/to/header.h>"
+set(_common_include_directories ${EXECUTORCH_ROOT}/..)
+
+# Need this for gflags
+set(gflags_DIR ${CMAKE_CURRENT_BINARY_DIR}/../../../third-party/gflags)
+find_package(gflags REQUIRED)
+
+# Find executorch libraries
+list(APPEND CMAKE_FIND_ROOT_PATH ${CMAKE_CURRENT_BINARY_DIR}/../../..)
+find_package(executorch CONFIG REQUIRED FIND_ROOT_PATH_BOTH)
+get_target_property(_executorch_imported executorch IMPORTED)
+if(NOT _executorch_imported)
+  executorch_target_link_options_shared_lib(executorch)
+endif()
+
+set(link_libraries executorch gflags)
+
+# Common ops for all builds
+if(TARGET optimized_native_cpu_ops_lib)
+  list(APPEND link_libraries optimized_native_cpu_ops_lib cpublas eigen_blas)
+  get_target_property(_is_imported optimized_native_cpu_ops_lib IMPORTED)
+  if(NOT _is_imported)
+    executorch_target_link_options_shared_lib(optimized_native_cpu_ops_lib)
+  endif()
+endif()
+
+# XNNPACK
+if(TARGET xnnpack_backend)
+  set(xnnpack_backend_libs xnnpack_backend XNNPACK xnnpack-microkernels-prod)
+  if(TARGET kleidiai)
+    list(APPEND xnnpack_backend_libs kleidiai)
+  endif()
+  list(APPEND link_libraries ${xnnpack_backend_libs})
+  get_target_property(_xnnpack_imported xnnpack_backend IMPORTED)
+  if(NOT _xnnpack_imported)
+    executorch_target_link_options_shared_lib(xnnpack_backend)
+  endif()
+endif()
+
+# Needed for cpuinfo where it uses android specific log lib
+if(ANDROID)
+  list(APPEND link_libraries log)
+endif()
+
+# Add the required ExecuTorch extensions
+list(
+  APPEND
+  link_libraries
+  extension_llm_runner
+  extension_module
+  extension_data_loader
+  extension_tensor
+  extension_flat_tensor
+)
+
+add_executable(silero_vad_runner main.cpp silero_vad_runner.cpp)
+if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+  target_link_options_gc_sections(silero_vad_runner)
+  if(NOT APPLE AND NOT MSVC)
+    target_link_options(silero_vad_runner PRIVATE "LINKER:-s")
+  endif()
+endif()
+
+target_include_directories(
+  silero_vad_runner PUBLIC ${_common_include_directories}
+)
+target_link_libraries(silero_vad_runner PUBLIC ${link_libraries})
+target_compile_options(silero_vad_runner PUBLIC ${_common_compile_options})

--- a/examples/models/silero_vad/README.md
+++ b/examples/models/silero_vad/README.md
@@ -1,0 +1,124 @@
+# Silero VAD for ExecuTorch
+
+Export and run [Silero VAD](https://github.com/snakers4/silero-vad) (16kHz, ~2MB, MIT license) on ExecuTorch for native C++ voice activity detection.
+
+Voice activity detection answers "when is someone speaking" — the model outputs a speech probability (0.0–1.0) for each 32ms audio chunk.
+
+## Quick Start
+
+```bash
+# Export to .pte
+cd examples/models/silero_vad
+python export_silero_vad.py --jit-model /path/to/silero_vad.jit
+
+# Build the C++ runner (from repo root)
+make silero-vad-cpu
+
+# Run VAD
+./cmake-out/examples/models/silero_vad/silero_vad_runner \
+    --model_path examples/models/silero_vad/silero_vad_exports/silero_vad.pte \
+    --audio_path /path/to/audio.wav
+```
+
+Output:
+
+```
+  12.512 12.672 speech
+  12.736 13.216 speech
+  13.248 13.696 speech
+  13.728 13.952 speech
+  13.984 14.144 speech
+  14.176 14.240 speech
+  14.272 14.432 speech
+  18.144 18.176 speech
+  19.168 19.200 speech
+  22.624 23.776 speech
+  25.216 25.312 speech
+  25.344 26.240 speech
+  26.304 26.592 speech
+  29.376 30.464 speech
+  ...
+
+502 segments, 32793 frames, 1049.4s
+Speech: 19489/32793 frames (59.4%)
+```
+
+Each line is `start_seconds end_seconds speech`. Each output frame covers 32ms of audio (512 samples at 16kHz).
+
+## Getting the Model
+
+The export script requires the `silero_vad.jit` file from the Silero VAD repository:
+
+```bash
+git clone https://github.com/snakers4/silero-vad.git
+```
+
+The JIT model is at `silero-vad/src/silero_vad/data/silero_vad.jit`.
+
+## Export
+
+```bash
+python export_silero_vad.py --jit-model /path/to/silero-vad/src/silero_vad/data/silero_vad.jit
+```
+
+| Argument | Description |
+|----------|-------------|
+| `--jit-model` | Path to `silero_vad.jit` file (required) |
+| `--backend` | `portable` or `xnnpack` (default: `xnnpack`) |
+| `--output-dir` | Output directory (default: `./silero_vad_exports`) |
+
+Output: `silero_vad_exports/silero_vad.pte` (~2 MB).
+
+## C++ Runner
+
+### Build
+
+From the repository root:
+
+```bash
+make silero-vad-cpu
+```
+
+Binary: `cmake-out/examples/models/silero_vad/silero_vad_runner`
+
+### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `--model_path` | Path to `.pte` file (default: `silero_vad.pte`) |
+| `--audio_path` | Path to input WAV file (16kHz mono, required) |
+| `--threshold` | Speech probability threshold, 0.0–1.0 (default: `0.5`) |
+
+### How It Works
+
+The model processes audio in 512-sample chunks (32ms at 16kHz). Each chunk is prepended with 64 samples of context from the previous chunk, forming a 576-sample input. The model carries an LSTM hidden state across chunks and outputs a single speech probability per chunk.
+
+The runner applies a simple threshold to produce speech segments: consecutive frames above the threshold are merged into a single segment.
+
+### Limitations
+
+- Input must be 16kHz mono WAV.
+- No smoothing or minimum segment duration filtering — raw threshold output.
+
+## Architecture
+
+```
+Input: audio (1, 576), LSTM state (2, 1, 128)
+
+Learned STFT:  Conv1d(1, 258, 256, stride=128)  →  magnitude spectrum (1, 129, 4)
+CNN encoder:   Conv1d(129→128→64→64→128, kernel=3) →  (1, 128)
+LSTM:          LSTMCell(128, 128)                 →  h, c
+Decoder:       Conv1d(128, 1, 1) → Sigmoid        →  probability (1, 1)
+
+Output: speech probability (1, 1), new LSTM state (2, 1, 128)
+```
+
+## Exported Method
+
+The `.pte` contains a single method:
+
+| Method | Backend | Input | Output |
+|--------|---------|-------|--------|
+| `forward` | XNNPACK | `x` (1, 576) float, `state` (2, 1, 128) float | `prob` (1, 1) float, `new_state` (2, 1, 128) float |
+
+**Metadata** via `constant_methods`: `sample_rate` (16000), `window_size` (512), `context_size` (64).

--- a/examples/models/silero_vad/export_silero_vad.py
+++ b/examples/models/silero_vad/export_silero_vad.py
@@ -1,0 +1,232 @@
+"""Export Silero VAD (16kHz) to ExecuTorch.
+
+Reimplements the model in eager PyTorch, loads weights from the official
+JIT model, and exports as a single-method .pte.
+
+Usage:
+    python export_silero_vad.py --jit-model /path/to/silero_vad.jit
+"""
+
+import argparse
+import os
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from executorch.exir import (
+    EdgeCompileConfig,
+    ExecutorchBackendConfig,
+    to_edge_transform_and_lower,
+)
+from executorch.exir.passes import MemoryPlanningPass
+from torch.export import export
+
+
+SAMPLE_RATE = 16000
+WINDOW_SIZE = 512
+CONTEXT_SIZE = 64
+INPUT_SIZE = WINDOW_SIZE + CONTEXT_SIZE  # 576
+HIDDEN_DIM = 128
+STFT_FILTERS = 258
+FREQ_BINS = STFT_FILTERS // 2  # 129
+
+
+class SileroVAD16k(nn.Module):
+    """Eager PyTorch reimplementation of Silero VAD (16kHz).
+
+    Architecture: learned STFT -> 4-layer CNN encoder -> LSTMCell -> sigmoid.
+    Weights are loaded from the official JIT model's _model sub-module.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.stft_conv = nn.Conv1d(
+            1, STFT_FILTERS, kernel_size=256, stride=128, bias=False
+        )
+        self.encoder = nn.ModuleList(
+            [
+                nn.Conv1d(FREQ_BINS, HIDDEN_DIM, 3, stride=1, padding=1),
+                nn.Conv1d(HIDDEN_DIM, 64, 3, stride=2, padding=1),
+                nn.Conv1d(64, 64, 3, stride=2, padding=1),
+                nn.Conv1d(64, HIDDEN_DIM, 3, stride=1, padding=1),
+            ]
+        )
+        self.lstm_cell = nn.LSTMCell(HIDDEN_DIM, HIDDEN_DIM)
+        self.final_conv = nn.Conv1d(HIDDEN_DIM, 1, 1)
+
+    def forward(
+        self, x: torch.Tensor, state: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        # x: (1, 576) — 64 context + 512 audio samples
+        # state: (2, 1, 128) — [h, c] LSTM state
+
+        # Learned STFT
+        x = F.pad(x, (0, 64), mode="reflect")
+        x = x.unsqueeze(1)
+        x = self.stft_conv(x)
+        real, imag = x[:, :FREQ_BINS], x[:, FREQ_BINS:]
+        x = (real**2 + imag**2).sqrt()
+
+        # CNN encoder
+        for conv in self.encoder:
+            x = F.relu(conv(x))
+        x = x.squeeze(-1)
+
+        # LSTM
+        h, c = self.lstm_cell(x, (state[0], state[1]))
+        new_state = torch.stack([h, c], dim=0)
+
+        # Decoder
+        x = F.relu(h).unsqueeze(-1)
+        x = torch.sigmoid(self.final_conv(x))
+        x = x.squeeze(1).mean(dim=1, keepdim=True)
+
+        return x, new_state
+
+
+def load_model(jit_path: str) -> SileroVAD16k:
+    """Load weights from JIT model into eager PyTorch reimplementation."""
+    jit_model = torch.jit.load(jit_path, map_location="cpu")
+    jit_sd = jit_model._model.state_dict()
+
+    model = SileroVAD16k()
+
+    key_map = {
+        "stft.forward_basis_buffer": "stft_conv.weight",
+        "encoder.0.reparam_conv.weight": "encoder.0.weight",
+        "encoder.0.reparam_conv.bias": "encoder.0.bias",
+        "encoder.1.reparam_conv.weight": "encoder.1.weight",
+        "encoder.1.reparam_conv.bias": "encoder.1.bias",
+        "encoder.2.reparam_conv.weight": "encoder.2.weight",
+        "encoder.2.reparam_conv.bias": "encoder.2.bias",
+        "encoder.3.reparam_conv.weight": "encoder.3.weight",
+        "encoder.3.reparam_conv.bias": "encoder.3.bias",
+        "decoder.rnn.weight_ih": "lstm_cell.weight_ih",
+        "decoder.rnn.weight_hh": "lstm_cell.weight_hh",
+        "decoder.rnn.bias_ih": "lstm_cell.bias_ih",
+        "decoder.rnn.bias_hh": "lstm_cell.bias_hh",
+        "decoder.decoder.2.weight": "final_conv.weight",
+        "decoder.decoder.2.bias": "final_conv.bias",
+    }
+
+    mapped_sd = {}
+    for jit_key, eager_key in key_map.items():
+        mapped_sd[eager_key] = jit_sd[jit_key]
+
+    model.load_state_dict(mapped_sd)
+    model.eval()
+
+    # Verify against JIT model
+    with torch.no_grad():
+        sample_x = torch.randn(1, INPUT_SIZE)
+        sample_state = torch.zeros(2, 1, HIDDEN_DIM)
+
+        jit_out, jit_state = jit_model._model(sample_x, sample_state)
+        eager_out, eager_state = model(sample_x, sample_state)
+
+        max_diff = (jit_out - eager_out).abs().max().item()
+        print(f"  Verification: max output diff = {max_diff:.2e}")
+        assert max_diff < 1e-5, f"Output mismatch: {max_diff}"
+
+    return model
+
+
+def export_model(model: SileroVAD16k):
+    """Export the model with explicit state passing."""
+    sample_x = torch.randn(1, INPUT_SIZE)
+    sample_state = torch.zeros(2, 1, HIDDEN_DIM)
+
+    print("  Exporting forward...")
+    programs = {
+        "forward": export(
+            model,
+            (sample_x, sample_state),
+            strict=False,
+        )
+    }
+
+    metadata = {
+        "sample_rate": SAMPLE_RATE,
+        "window_size": WINDOW_SIZE,
+        "context_size": CONTEXT_SIZE,
+    }
+
+    return programs, metadata
+
+
+def lower_to_executorch(programs, metadata=None, backend="portable"):
+    if backend == "xnnpack":
+        from executorch.backends.xnnpack.partition.xnnpack_partitioner import (
+            XnnpackPartitioner,
+        )
+
+        print("\nLowering to ExecuTorch with XNNPACK...")
+        partitioner = {"forward": [XnnpackPartitioner()]}
+    else:
+        print("\nLowering to ExecuTorch...")
+        partitioner = []
+
+    constant_methods = {}
+    if metadata:
+        for key, value in metadata.items():
+            constant_methods[key] = value
+
+    et_prog = to_edge_transform_and_lower(
+        programs,
+        partitioner=partitioner,
+        compile_config=EdgeCompileConfig(
+            _check_ir_validity=False,
+            _skip_dim_order=True,
+        ),
+        constant_methods=constant_methods if constant_methods else None,
+    )
+    return et_prog.to_executorch(
+        config=ExecutorchBackendConfig(
+            extract_delegate_segments=True,
+            memory_planning_pass=MemoryPlanningPass(alloc_graph_input=False),
+        ),
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Export Silero VAD (16kHz) to ExecuTorch"
+    )
+    parser.add_argument("--output-dir", default="./silero_vad_exports")
+    parser.add_argument(
+        "--jit-model",
+        type=str,
+        required=True,
+        help="Path to silero_vad.jit file",
+    )
+    parser.add_argument(
+        "--backend",
+        type=str,
+        default="xnnpack",
+        choices=["portable", "xnnpack"],
+        help="Backend for acceleration (default: xnnpack)",
+    )
+
+    args = parser.parse_args()
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    print("Loading model...")
+    model = load_model(args.jit_model)
+
+    print("\nExporting...")
+    programs, metadata = export_model(model)
+
+    et = lower_to_executorch(programs, metadata=metadata, backend=args.backend)
+
+    pte_path = os.path.join(args.output_dir, "silero_vad.pte")
+    print(f"\nSaving ExecuTorch program to: {pte_path}")
+    with open(pte_path, "wb") as f:
+        et.write_to_file(f)
+    print(f"Saved {os.path.getsize(pte_path) / 1024:.1f} KB")
+
+    print("\nDone!")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/models/silero_vad/main.cpp
+++ b/examples/models/silero_vad/main.cpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// CLI entry point for Silero VAD.
+//
+// Loads a .pte model and a 16kHz mono WAV file, runs voice activity detection,
+// and prints speech segments as "start end speech". See README.md for usage.
+
+#include <iomanip>
+#include <iostream>
+
+#include <gflags/gflags.h>
+
+#include <executorch/extension/llm/runner/stats.h>
+#include <executorch/extension/llm/runner/util.h>
+#include <executorch/extension/llm/runner/wav_loader.h>
+#include <executorch/runtime/platform/log.h>
+
+#include "silero_vad_runner.h"
+
+DEFINE_string(model_path, "silero_vad.pte", "Path to Silero VAD model (.pte).");
+DEFINE_string(audio_path, "", "Path to input audio file (.wav).");
+DEFINE_double(threshold, 0.5, "Speech probability threshold (0.0 - 1.0).");
+
+int main(int argc, char** argv) {
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+  if (FLAGS_audio_path.empty()) {
+    ET_LOG(Error, "audio_path flag must be provided.");
+    return 1;
+  }
+
+  ::executorch::extension::llm::Stats stats;
+  stats.model_load_start_ms = ::executorch::extension::llm::time_in_ms();
+
+  silero_vad::SileroVadRunner runner(FLAGS_model_path);
+
+  stats.model_load_end_ms = ::executorch::extension::llm::time_in_ms();
+  stats.inference_start_ms = ::executorch::extension::llm::time_in_ms();
+
+  ET_LOG(Info, "Loading audio from: %s", FLAGS_audio_path.c_str());
+  auto audio_data =
+      ::executorch::extension::llm::load_wav_audio_data(FLAGS_audio_path);
+
+  std::cout << std::fixed << std::setprecision(3);
+
+  auto result = runner.detect(
+      audio_data.data(),
+      static_cast<int64_t>(audio_data.size()),
+      static_cast<float>(FLAGS_threshold),
+      [](const silero_vad::Segment& seg) {
+        std::cout << "  " << seg.start << " " << seg.end << " speech"
+                  << std::endl;
+      });
+
+  stats.inference_end_ms = ::executorch::extension::llm::time_in_ms();
+
+  // Summary
+  double total_duration = result.num_frames * runner.frame_duration();
+  double speech_pct =
+      100.0 * result.speech_frames / static_cast<double>(result.num_frames);
+  std::cout << "\n"
+            << result.num_segments << " segments, " << result.num_frames
+            << " frames, " << std::setprecision(1) << total_duration << "s\n"
+            << "Speech: " << result.speech_frames << "/" << result.num_frames
+            << " frames (" << std::setprecision(1) << speech_pct << "%)\n";
+
+  ::executorch::extension::llm::print_report(stats);
+
+  return 0;
+}

--- a/examples/models/silero_vad/silero_vad_runner.cpp
+++ b/examples/models/silero_vad/silero_vad_runner.cpp
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "silero_vad_runner.h"
+
+#include <algorithm>
+#include <cstring>
+#include <vector>
+
+#include <executorch/extension/tensor/tensor_ptr_maker.h>
+#include <executorch/runtime/core/evalue.h>
+#include <executorch/runtime/core/exec_aten/util/scalar_type_util.h>
+#include <executorch/runtime/platform/log.h>
+
+using ::executorch::extension::from_blob;
+using ::executorch::extension::Module;
+using ::executorch::runtime::Error;
+using ::executorch::runtime::EValue;
+
+namespace silero_vad {
+
+SileroVadRunner::SileroVadRunner(const std::string& model_path) {
+  ET_LOG(Info, "Loading model from: %s", model_path.c_str());
+  model_ = std::make_unique<Module>(model_path, Module::LoadMode::Mmap);
+  auto load_error = model_->load();
+  if (load_error != Error::Ok) {
+    ET_LOG(Error, "Failed to load model.");
+    return;
+  }
+
+  std::vector<EValue> empty;
+  auto sr = model_->execute("sample_rate", empty);
+  auto ws = model_->execute("window_size", empty);
+  auto cs = model_->execute("context_size", empty);
+
+  sample_rate_ = sr.ok() ? sr.get()[0].toInt() : 16000;
+  window_size_ = ws.ok() ? ws.get()[0].toInt() : 512;
+  context_size_ = cs.ok() ? cs.get()[0].toInt() : 64;
+  input_size_ = window_size_ + context_size_;
+  frame_duration_ = static_cast<double>(window_size_) / sample_rate_;
+}
+
+SileroVadRunner::Result SileroVadRunner::detect(
+    const float* audio_data,
+    int64_t num_samples,
+    float threshold,
+    SegmentCallback segment_cb) {
+  // LSTM state: (2, 1, 128) — [h, c]
+  std::vector<float> state_data(static_cast<size_t>(2 * kHiddenDim), 0.0f);
+
+  // Context: previous chunk's last context_size_ samples
+  std::vector<float> context(static_cast<size_t>(context_size_), 0.0f);
+
+  // Input buffer: [context | chunk] = input_size_ samples
+  std::vector<float> input(static_cast<size_t>(input_size_));
+
+  bool speech_active = false;
+  int64_t speech_start_frame = 0;
+  int64_t num_frames = 0;
+  int64_t speech_frames = 0;
+  int num_segments = 0;
+
+  for (int64_t offset = 0; offset < num_samples; offset += window_size_) {
+    int64_t chunk_len = std::min(window_size_, num_samples - offset);
+
+    // Build input: [context | chunk]
+    std::memcpy(
+        input.data(),
+        context.data(),
+        static_cast<size_t>(context_size_) * sizeof(float));
+
+    if (chunk_len == window_size_) {
+      std::memcpy(
+          input.data() + context_size_,
+          audio_data + offset,
+          static_cast<size_t>(window_size_) * sizeof(float));
+    } else {
+      // Pad the last partial chunk with zeros
+      std::memcpy(
+          input.data() + context_size_,
+          audio_data + offset,
+          static_cast<size_t>(chunk_len) * sizeof(float));
+      std::memset(
+          input.data() + context_size_ + chunk_len,
+          0,
+          static_cast<size_t>(window_size_ - chunk_len) * sizeof(float));
+    }
+
+    auto input_tensor = from_blob(
+        input.data(),
+        {1, static_cast<::executorch::aten::SizesType>(input_size_)},
+        ::executorch::aten::ScalarType::Float);
+    auto state_tensor = from_blob(
+        state_data.data(),
+        {2, 1, static_cast<::executorch::aten::SizesType>(kHiddenDim)},
+        ::executorch::aten::ScalarType::Float);
+
+    auto result = model_->execute(
+        "forward", std::vector<EValue>{input_tensor, state_tensor});
+    if (!result.ok()) {
+      ET_LOG(
+          Error,
+          "forward failed at offset %lld.",
+          static_cast<long long>(offset));
+      break;
+    }
+
+    auto& outputs = result.get();
+    float prob = outputs[0].toTensor().const_data_ptr<float>()[0];
+
+    // Update LSTM state
+    auto new_state = outputs[1].toTensor();
+    std::memcpy(
+        state_data.data(),
+        new_state.const_data_ptr<float>(),
+        static_cast<size_t>(2 * kHiddenDim) * sizeof(float));
+
+    // Update context from current chunk
+    if (chunk_len >= context_size_) {
+      std::memcpy(
+          context.data(),
+          audio_data + offset + chunk_len - context_size_,
+          static_cast<size_t>(context_size_) * sizeof(float));
+    } else {
+      // Shift existing context and append partial chunk
+      int64_t keep = context_size_ - chunk_len;
+      std::memmove(
+          context.data(),
+          context.data() + chunk_len,
+          static_cast<size_t>(keep) * sizeof(float));
+      std::memcpy(
+          context.data() + keep,
+          audio_data + offset,
+          static_cast<size_t>(chunk_len) * sizeof(float));
+    }
+
+    // Threshold-based speech detection
+    if (prob > threshold) {
+      speech_frames++;
+      if (!speech_active) {
+        speech_active = true;
+        speech_start_frame = num_frames;
+      }
+    } else if (speech_active) {
+      speech_active = false;
+      segment_cb(
+          {speech_start_frame * frame_duration_, num_frames * frame_duration_});
+      num_segments++;
+    }
+
+    num_frames++;
+  }
+
+  // Close any still-active segment
+  if (speech_active) {
+    segment_cb(
+        {speech_start_frame * frame_duration_, num_frames * frame_duration_});
+    num_segments++;
+  }
+
+  return {num_frames, num_segments, speech_frames};
+}
+
+} // namespace silero_vad

--- a/examples/models/silero_vad/silero_vad_runner.h
+++ b/examples/models/silero_vad/silero_vad_runner.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Silero VAD runner.
+//
+// Runs the Silero VAD 16kHz model exported as a single-method .pte:
+//   forward: (1, 576) audio + (2, 1, 128) LSTM state → (1, 1) probability +
+//   (2, 1, 128) new state
+//
+// Audio is processed in 512-sample chunks (32ms at 16kHz). Each chunk is
+// prepended with 64 samples of context from the previous chunk. The model
+// outputs a single speech probability per chunk. See export_silero_vad.py
+// for architecture details.
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <executorch/extension/module/module.h>
+
+namespace silero_vad {
+
+struct Segment {
+  double start;
+  double end;
+};
+
+using SegmentCallback = std::function<void(const Segment&)>;
+
+class SileroVadRunner {
+ public:
+  explicit SileroVadRunner(const std::string& model_path);
+
+  struct Result {
+    int64_t num_frames;
+    int num_segments;
+    int64_t speech_frames;
+  };
+
+  Result detect(
+      const float* audio_data,
+      int64_t num_samples,
+      float threshold,
+      SegmentCallback segment_cb);
+
+  double frame_duration() const {
+    return frame_duration_;
+  }
+
+ private:
+  std::unique_ptr<::executorch::extension::Module> model_;
+
+  int64_t sample_rate_;
+  int64_t window_size_;
+  int64_t context_size_;
+  int64_t input_size_;
+  double frame_duration_;
+
+  static constexpr int64_t kHiddenDim = 128;
+};
+
+} // namespace silero_vad


### PR DESCRIPTION
It's useful to have a voice detection -- to detect human speaking vs long silence and noise

https://github.com/snakers4/silero-vad seems to be the standard way of doing it


```
./cmake-out/examples/models/silero_vad/silero_vad_runner \
    --model_path examples/models/silero_vad/silero_vad_exports/silero_vad.pte \
    --audio_path /path/to/audio.wav
```

Output:

```
  12.512 12.672 speech
  12.736 13.216 speech
  13.248 13.696 speech
  13.728 13.952 speech
  13.984 14.144 speech
  14.176 14.240 speech
  14.272 14.432 speech
  18.144 18.176 speech
  19.168 19.200 speech
  22.624 23.776 speech
  25.216 25.312 speech
  25.344 26.240 speech
  26.304 26.592 speech
  29.376 30.464 speech
  ...

502 segments, 32793 frames, 1049.4s
Speech: 19489/32793 frames (59.4%)
```