### PR TITLE
Add float int32 vulkan shader

### DIFF
--- a/backends/vulkan/runtime/graph/ops/glsl/view_convert_buffer.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/view_convert_buffer.yaml
@@ -18,5 +18,6 @@ view_convert_buffer:
         - parameter_values: [uint8, float]
         - parameter_values: [uint8, half]
         - parameter_values: [uint8, int32]
+        - parameter_values: [float, int32]
   shader_variants:
     - NAME: view_convert_buffer


### PR DESCRIPTION
Summary
Adds missing float to int32 conversion support in the Vulkan backend's view_convert_buffer shader.

Problem
When exporting models that require float-to-int32 dtype conversion to the Vulkan backend, execution fails at runtime with:

Exception raised from get_shader_info at /pytorch/executorch/backends/vulkan/runtime/api/ShaderRegistry.cpp:54: 
(it != listings_.end()) is false! Could not find ShaderInfo with name view_convert_buffer_float_int32
This occurs because the view_convert_buffer shader only supports conversions FROM int32/uint8 TO float/half, but not the reverse direction.

Solution
Added float → int32 conversion variant to the shader generation configuration in 
view_convert_buffer.yaml
.

Changed file:

backends/vulkan/runtime/graph/ops/glsl/view_convert_buffer.yaml
Change:

yaml
combos:
  - parameter_values: [int32, float]
  - parameter_values: [int32, half]
  - parameter_values: [uint8, float]
  - parameter_values: [uint8, half]
  - parameter_values: [uint8, int32]
  - parameter_values: [float, int32]  # <-- Added
Testing
Unable to test on Windows due to build environment constraints (requires CMake + MSVC). The change follows the existing pattern for other dtype conversion combinations in the same file.

Test case that would trigger this:

Models with operations requiring float→int32 conversion (e.g., certain quantization or indexing operations)
Export to Vulkan backend using VulkanPartitioner
Additional Context
This issue was encountered while exporting a depth estimation model (PanDA) to the Vulkan backend for Android deployment. The model worked with XNNPACK but failed with Vulkan due to this missing shader variant.

cc @SS-JIA @manuelcandales @digantdesai @cbilgin