### PR TITLE
Add aten::_conj_physical.out operator (#17207)

### DIFF
--- a/kernels/aten/functions.yaml
+++ b/kernels/aten/functions.yaml
@@ -4,6 +4,8 @@
 
 - op: _cdist_forward.out
 
+- op: _conj_physical.out
+
 - op: _fake_quantize_per_tensor_affine_cachemask_tensor_qparams.out
 
 - op: _fft_c2r.out

--- a/kernels/portable/cpu/op__conj_physical.cpp
+++ b/kernels/portable/cpu/op__conj_physical.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/kernels/portable/cpu/util/functional_util.h>
+#include <executorch/runtime/kernel/kernel_includes.h>
+
+namespace torch {
+namespace executor {
+namespace native {
+
+using executorch::aten::Tensor;
+
+Tensor&
+_conj_physical_out(KernelRuntimeContext& ctx, const Tensor& in, Tensor& out) {
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      resize_tensor(out, in.sizes()) == Error::Ok,
+      InvalidArgument,
+      out,
+      "Failed to resize output tensor.");
+
+  ET_KERNEL_CHECK(ctx, tensors_have_same_dtype(in, out), InvalidArgument, out);
+
+  ET_KERNEL_CHECK(
+      ctx, tensors_have_same_dim_order(in, out), InvalidArgument, out);
+
+  // @lint-ignore CLANGTIDY facebook-hte-CArray
+  static constexpr const char op_name[] = "_conj_physical.out";
+
+  ET_SWITCH_COMPLEXH_TYPES(in.scalar_type(), ctx, op_name, CTYPE, [&] {
+    apply_unary_map_fn<CTYPE, CTYPE>(
+        [](const CTYPE val_in) -> CTYPE {
+          return CTYPE(val_in.real_, -val_in.imag_);
+        },
+        in.const_data_ptr<CTYPE>(),
+        out.mutable_data_ptr<CTYPE>(),
+        in.numel());
+  });
+
+  return out;
+}
+
+} // namespace native
+} // namespace executor
+} // namespace torch

--- a/kernels/portable/functions.yaml
+++ b/kernels/portable/functions.yaml
@@ -22,6 +22,11 @@
     - arg_meta: null
       kernel_name: torch::executor::_cdist_forward_out
 
+- op: _conj_physical.out
+  kernels:
+    - arg_meta: null
+      kernel_name: torch::executor::_conj_physical_out
+
 - op: _log_softmax.out
   kernels:
     - arg_meta: null

--- a/kernels/test/op__conj_physical_test.cpp
+++ b/kernels/test/op__conj_physical_test.cpp
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/kernels/test/FunctionHeaderWrapper.h> // Declares the operator
+#include <executorch/kernels/test/TestUtil.h>
+#include <executorch/runtime/core/exec_aten/exec_aten.h>
+#include <executorch/runtime/core/exec_aten/testing_util/tensor_factory.h>
+#include <executorch/runtime/core/exec_aten/testing_util/tensor_util.h>
+
+#include <gtest/gtest.h>
+
+using namespace ::testing;
+using executorch::aten::ScalarType;
+using executorch::aten::Tensor;
+using torch::executor::testing::TensorFactory;
+
+class OpConjPhysicalOutTest : public OperatorTest {
+ protected:
+  Tensor& op_conj_physical_out(const Tensor& in, Tensor& out) {
+    return torch::executor::aten::_conj_physical_outf(context_, in, out);
+  }
+};
+
+TEST_F(OpConjPhysicalOutTest, ComplexFloatBasic) {
+  TensorFactory<ScalarType::ComplexFloat> tf;
+
+  const std::vector<int32_t> sizes = {2, 2};
+
+  // Create input: (1+2i), (3+4i), (5-6i), (-7+8i)
+  Tensor in = tf.make(
+      sizes,
+      {executorch::aten::complex<float>(1.0f, 2.0f),
+       executorch::aten::complex<float>(3.0f, 4.0f),
+       executorch::aten::complex<float>(5.0f, -6.0f),
+       executorch::aten::complex<float>(-7.0f, 8.0f)});
+
+  Tensor out = tf.zeros(sizes);
+
+  op_conj_physical_out(in, out);
+
+  // Expected: (1-2i), (3-4i), (5+6i), (-7-8i)
+  Tensor expected = tf.make(
+      sizes,
+      {executorch::aten::complex<float>(1.0f, -2.0f),
+       executorch::aten::complex<float>(3.0f, -4.0f),
+       executorch::aten::complex<float>(5.0f, 6.0f),
+       executorch::aten::complex<float>(-7.0f, -8.0f)});
+
+  EXPECT_TENSOR_EQ(out, expected);
+}
+
+TEST_F(OpConjPhysicalOutTest, ComplexDoubleBasic) {
+  TensorFactory<ScalarType::ComplexDouble> tf;
+
+  const std::vector<int32_t> sizes = {3};
+
+  Tensor in = tf.make(
+      sizes,
+      {executorch::aten::complex<double>(1.5, 2.5),
+       executorch::aten::complex<double>(-3.5, 4.5),
+       executorch::aten::complex<double>(0.0, -1.0)});
+
+  Tensor out = tf.zeros(sizes);
+
+  op_conj_physical_out(in, out);
+
+  Tensor expected = tf.make(
+      sizes,
+      {executorch::aten::complex<double>(1.5, -2.5),
+       executorch::aten::complex<double>(-3.5, -4.5),
+       executorch::aten::complex<double>(0.0, 1.0)});
+
+  EXPECT_TENSOR_EQ(out, expected);
+}
+
+TEST_F(OpConjPhysicalOutTest, RealPartOnly) {
+  TensorFactory<ScalarType::ComplexFloat> tf;
+
+  const std::vector<int32_t> sizes = {2};
+
+  // When imaginary part is zero, conjugate negates the imaginary part (0 -> -0)
+  // Both are mathematically equivalent, so we verify values directly
+  Tensor in = tf.make(
+      sizes,
+      {executorch::aten::complex<float>(5.0f, 0.0f),
+       executorch::aten::complex<float>(-3.0f, 0.0f)});
+
+  Tensor out = tf.zeros(sizes);
+
+  op_conj_physical_out(in, out);
+
+  // Verify real parts are unchanged and imaginary parts are negated zeros
+  const auto* out_data = out.const_data_ptr<executorch::aten::complex<float>>();
+  EXPECT_EQ(out_data[0].real_, 5.0f);
+  EXPECT_EQ(out_data[0].imag_, -0.0f);
+  EXPECT_EQ(out_data[1].real_, -3.0f);
+  EXPECT_EQ(out_data[1].imag_, -0.0f);
+}
+
+TEST_F(OpConjPhysicalOutTest, ImaginaryPartOnly) {
+  TensorFactory<ScalarType::ComplexFloat> tf;
+
+  const std::vector<int32_t> sizes = {2};
+
+  Tensor in = tf.make(
+      sizes,
+      {executorch::aten::complex<float>(0.0f, 5.0f),
+       executorch::aten::complex<float>(0.0f, -3.0f)});
+
+  Tensor out = tf.zeros(sizes);
+
+  op_conj_physical_out(in, out);
+
+  Tensor expected = tf.make(
+      sizes,
+      {executorch::aten::complex<float>(0.0f, -5.0f),
+       executorch::aten::complex<float>(0.0f, 3.0f)});
+
+  EXPECT_TENSOR_EQ(out, expected);
+}
+
+TEST_F(OpConjPhysicalOutTest, EmptyTensor) {
+  TensorFactory<ScalarType::ComplexFloat> tf;
+
+  const std::vector<int32_t> sizes = {0};
+
+  Tensor in = tf.make(sizes, {});
+  Tensor out = tf.zeros(sizes);
+
+  op_conj_physical_out(in, out);
+
+  EXPECT_EQ(out.numel(), 0);
+}
+
+TEST_F(OpConjPhysicalOutTest, MismatchedDtypeDies) {
+  TensorFactory<ScalarType::ComplexFloat> tf_in;
+  TensorFactory<ScalarType::ComplexDouble> tf_out;
+
+  const std::vector<int32_t> sizes = {2};
+
+  Tensor in = tf_in.make(
+      sizes,
+      {executorch::aten::complex<float>(1.0f, 2.0f),
+       executorch::aten::complex<float>(3.0f, 4.0f)});
+  Tensor out = tf_out.zeros(sizes);
+
+  ET_EXPECT_KERNEL_FAILURE(context_, op_conj_physical_out(in, out));
+}

--- a/kernels/test/targets.bzl
+++ b/kernels/test/targets.bzl
@@ -166,6 +166,7 @@ def define_common_targets():
     _common_op_test("op__to_dim_order_copy_test", ["aten", "portable"])
     _common_op_test("op__empty_dim_order_test", ["aten", "portable"])
     _common_op_test("op__clone_dim_order_test", ["aten", "portable"])
+    _common_op_test("op__conj_physical_test", ["aten", "portable"])
     _common_op_test("op_abs_test", ["aten", "portable"])
     _common_op_test("op_acos_test", ["aten", "portable"])
     _common_op_test("op_acosh_test", ["aten", "portable"])

--- a/shim_et/xplat/executorch/kernels/portable/op_registration_util.bzl
+++ b/shim_et/xplat/executorch/kernels/portable/op_registration_util.bzl
@@ -1356,6 +1356,19 @@ ATEN_OPS = (
         name = "op_zeros",
     ),
     op_target(
+        name = "op__clone_dim_order",
+        deps = [
+            ":scalar_utils",
+            "//executorch/kernels/portable/cpu/util:copy_ops_util",
+        ],
+    ),
+    op_target(
+        name = "op__conj_physical",
+        deps = [
+            "//executorch/kernels/portable/cpu/util:functional_util",
+        ],
+    ),
+    op_target(
         name = "op__empty_dim_order",
         deps = [
             ":scalar_utils",
@@ -1363,13 +1376,6 @@ ATEN_OPS = (
     ),
     op_target(
         name = "op__to_dim_order_copy",
-        deps = [
-            ":scalar_utils",
-            "//executorch/kernels/portable/cpu/util:copy_ops_util",
-        ],
-    ),
-    op_target(
-        name = "op__clone_dim_order",
         deps = [
             ":scalar_utils",
             "//executorch/kernels/portable/cpu/util:copy_ops_util",


### PR DESCRIPTION
Summary:

Added `aten::_conj_physical.out` which implements https://docs.pytorch.org/docs/stable/generated/torch.conj_physical.html

Differential Revision: D92991877


