### PR TITLE
Revert "Fix KeyError in InsertIOQDQ pass for LLM quantization"

### DIFF
--- a/backends/qualcomm/_passes/insert_io_qdq.py
+++ b/backends/qualcomm/_passes/insert_io_qdq.py
@@ -31,16 +31,11 @@ class InsertIOQDQ(ExportPass):
     """
 
     q_dq_map = {
-        # per tensor (quantize -> dequantize)
+        # per tensor
         exir_ops.edge.quantized_decomposed.quantize_per_tensor.default: exir_ops.edge.quantized_decomposed.dequantize_per_tensor.tensor,
         exir_ops.edge.quantized_decomposed.quantize_per_tensor.tensor: exir_ops.edge.quantized_decomposed.dequantize_per_tensor.tensor,
-        # per tensor (dequantize -> dequantize, for nodes with dequantize encoding)
-        exir_ops.edge.quantized_decomposed.dequantize_per_tensor.default: exir_ops.edge.quantized_decomposed.dequantize_per_tensor.default,
-        exir_ops.edge.quantized_decomposed.dequantize_per_tensor.tensor: exir_ops.edge.quantized_decomposed.dequantize_per_tensor.tensor,
-        # per channel (quantize -> dequantize)
+        # per channel
         exir_ops.edge.quantized_decomposed.quantize_per_channel.default: exir_ops.edge.quantized_decomposed.dequantize_per_channel.default,
-        # per channel (dequantize -> dequantize, for nodes with dequantize encoding)
-        exir_ops.edge.quantized_decomposed.dequantize_per_channel.default: exir_ops.edge.quantized_decomposed.dequantize_per_channel.default,
     }
 
     def __init__(self, edge_program: torch.export.ExportedProgram):


### PR DESCRIPTION
Reverts pytorch/executorch#17194

Many QNN trunk jobs started failing after this PR was merged. Testing revert to see if that fixes issue.