### PR TITLE
Update assertRaisesRegex pattern for Python 3.12 compatibility

### DIFF
--- a/exir/backend/test/test_partitioner.py
+++ b/exir/backend/test/test_partitioner.py
@@ -106,7 +106,7 @@ class TestPartitioner(unittest.TestCase):
 
         with self.assertRaisesRegex(
             AttributeError,
-            "can't set attribute 'spec'",
+            "(can't set attribute 'spec'|has no setter)",
         ):
             my_partitioner.spec = {"new_key": "new_value"}
 


### PR DESCRIPTION
Summary: Python 3.12 changed the error message for read-only property assignment from "can't set attribute 'spec'" to "property 'spec' of ... object has no setter". Update the regex pattern to match both versions.

Differential Revision: D92997414


