### PR TITLE
Add meaningful matchers to death tests

### DIFF
--- a/devtools/etdump/tests/etdump_test.cpp
+++ b/devtools/etdump/tests/etdump_test.cpp
@@ -247,7 +247,9 @@ TEST_F(ProfilerETDumpTest, AddAllocators) {
     // Add a profiling event and then try to add an allocator which should fail.
     EventTracerEntry entry = etdump_gen[i]->start_profiling("test_event", 0, 1);
     etdump_gen[i]->end_profiling(entry);
-    ET_EXPECT_DEATH(etdump_gen[i]->track_allocator("test_allocator"), "");
+    ET_EXPECT_DEATH(
+        etdump_gen[i]->track_allocator("test_allocator"),
+        "before any events are added");
   }
 }
 

--- a/extension/aten_util/test/aten_bridge_test.cpp
+++ b/extension/aten_util/test/aten_bridge_test.cpp
@@ -193,7 +193,8 @@ TEST(ATenBridgeTest, AliasATTensorToETensorFailDimOrder) {
       dim_order.data(),
       strides.data());
   torch::executor::Tensor etensor(&tensor_impl);
-  ET_EXPECT_DEATH(alias_attensor_to_etensor(etensor), "");
+  ET_EXPECT_DEATH(
+      alias_attensor_to_etensor(etensor), "Strides don't match dim order");
 }
 
 TEST(ATenBridgeTest, AliasETensorToATenTensorChannelsLast) {

--- a/runtime/core/exec_aten/util/test/operator_impl_example_test.cpp
+++ b/runtime/core/exec_aten/util/test/operator_impl_example_test.cpp
@@ -131,7 +131,7 @@ TEST(OperatorImplExampleTest, UnhandledDtypeDies) {
 
   // Adding the two boolean tensors should cause an assertion and kill the
   // test process.
-  ET_EXPECT_DEATH(add_tensors_op(a, b, out), "");
+  ET_EXPECT_DEATH(add_tensors_op(a, b, out), "Unhandled dtype");
 }
 
 TEST(OpAddOutKernelTest, MismatchedInputDimsDies) {

--- a/runtime/core/exec_aten/util/test/scalar_type_util_test.cpp
+++ b/runtime/core/exec_aten/util/test/scalar_type_util_test.cpp
@@ -91,13 +91,15 @@ TEST(ScalarTypeUtilTest, IsValidFalse) {
 TEST(ScalarTypeUtilTest, UnknownTypeElementSizeDies) {
   // Undefined, which is sort of a special case since it's not part of the
   // iteration macros but is still a part of the enum.
-  ET_EXPECT_DEATH(elementSize(ScalarType::Undefined), "");
+  ET_EXPECT_DEATH(elementSize(ScalarType::Undefined), "Unknown ScalarType");
 
   // Some out-of-range types, also demonstrating that NumOptions is not really a
   // scalar type.
-  ET_EXPECT_DEATH(elementSize(ScalarType::NumOptions), "");
-  ET_EXPECT_DEATH(elementSize(static_cast<ScalarType>(127)), "");
-  ET_EXPECT_DEATH(elementSize(static_cast<ScalarType>(-1)), "");
+  ET_EXPECT_DEATH(elementSize(ScalarType::NumOptions), "Unknown ScalarType");
+  ET_EXPECT_DEATH(
+      elementSize(static_cast<ScalarType>(127)), "Unknown ScalarType");
+  ET_EXPECT_DEATH(
+      elementSize(static_cast<ScalarType>(-1)), "Unknown ScalarType");
 }
 
 TEST(ScalarTypeUtilTest, canCastTest) {

--- a/runtime/core/exec_aten/util/test/tensor_util_test.cpp
+++ b/runtime/core/exec_aten/util/test/tensor_util_test.cpp
@@ -223,7 +223,8 @@ TEST_F(TensorUtilTest, ContiguousCheckSupported) {
   ET_CHECK_CONTIGUOUS(t_contiguous);
 
   // Assert t_incontiguous is incontiguous.
-  ET_EXPECT_DEATH(ET_CHECK_CONTIGUOUS(t_incontiguous), "");
+  ET_EXPECT_DEATH(
+      ET_CHECK_CONTIGUOUS(t_incontiguous), "stride of the.*dimension shall");
 }
 
 TEST_F(TensorUtilTest, CheckSameContiguousStrideSupported) {

--- a/runtime/executor/test/memory_manager_test.cpp
+++ b/runtime/executor/test/memory_manager_test.cpp
@@ -79,7 +79,7 @@ TEST(MemoryManagerTest, DeprecatedCtorWithSameAllocator) {
           /*non_constant_allocator=*/&planned_memory,
           /*runtime_allocator=*/&method_allocator,
           /*temp_allocator=*/&method_allocator),
-      "");
+      "cannot be the same");
 }
 
 TEST(MemoryManagerTest, CtorWithSameAllocator) {
@@ -91,5 +91,5 @@ TEST(MemoryManagerTest, CtorWithSameAllocator) {
           /*runtime_allocator=*/&method_allocator,
           /*non_constant_allocator=*/&planned_memory,
           /*temp_allocator=*/&method_allocator),
-      "");
+      "cannot be the same");
 }

--- a/runtime/executor/test/method_test.cpp
+++ b/runtime/executor/test/method_test.cpp
@@ -140,8 +140,8 @@ TEST_F(MethodTest, GetInputTests) {
   method->get_input(num_inputs - 1);
 
   // Out-of-range inputs should abort.
-  ET_EXPECT_DEATH(method->get_input(num_inputs), "");
-  ET_EXPECT_DEATH(method->get_input(num_inputs + 1), "");
+  ET_EXPECT_DEATH(method->get_input(num_inputs), "[0-9]+ >= [0-9]+");
+  ET_EXPECT_DEATH(method->get_input(num_inputs + 1), "[0-9]+ >= [0-9]+");
 }
 
 TEST_F(MethodTest, MutableInputTests) {
@@ -157,8 +157,8 @@ TEST_F(MethodTest, MutableInputTests) {
   method->mutable_input(num_inputs - 1);
 
   // Out-of-range inputs should abort.
-  ET_EXPECT_DEATH(method->mutable_input(num_inputs), "");
-  ET_EXPECT_DEATH(method->mutable_input(num_inputs + 1), "");
+  ET_EXPECT_DEATH(method->mutable_input(num_inputs), "[0-9]+ >= [0-9]+");
+  ET_EXPECT_DEATH(method->mutable_input(num_inputs + 1), "[0-9]+ >= [0-9]+");
 }
 
 TEST_F(MethodTest, GetOutputTests) {
@@ -174,8 +174,8 @@ TEST_F(MethodTest, GetOutputTests) {
   method->get_output(num_outputs - 1);
 
   // Out-of-range outputs should abort.
-  ET_EXPECT_DEATH(method->get_output(num_outputs), "");
-  ET_EXPECT_DEATH(method->get_output(num_outputs + 1), "");
+  ET_EXPECT_DEATH(method->get_output(num_outputs), "[0-9]+ >= [0-9]+");
+  ET_EXPECT_DEATH(method->get_output(num_outputs + 1), "[0-9]+ >= [0-9]+");
 }
 
 TEST_F(MethodTest, MutableOutputTests) {
@@ -191,8 +191,8 @@ TEST_F(MethodTest, MutableOutputTests) {
   method->mutable_output(num_outputs - 1);
 
   // Out-of-range outputs should abort.
-  ET_EXPECT_DEATH(method->mutable_output(num_outputs), "");
-  ET_EXPECT_DEATH(method->mutable_output(num_outputs + 1), "");
+  ET_EXPECT_DEATH(method->mutable_output(num_outputs), "[0-9]+ >= [0-9]+");
+  ET_EXPECT_DEATH(method->mutable_output(num_outputs + 1), "[0-9]+ >= [0-9]+");
 }
 
 TEST_F(MethodTest, SetPrimInputTest) {

--- a/runtime/kernel/test/operator_registry_test.cpp
+++ b/runtime/kernel/test/operator_registry_test.cpp
@@ -197,7 +197,7 @@ TEST_F(OperatorRegistryTest, RegisterOpsMoreThanOnceDie) {
       Kernel("foo", [](KernelRuntimeContext&, Span<EValue*>) {}),
       Kernel("foo", [](KernelRuntimeContext&, Span<EValue*>) {})};
   Span<const Kernel> kernels_span = Span<const Kernel>(kernels);
-  ET_EXPECT_DEATH({ (void)register_kernels(kernels_span); }, "");
+  ET_EXPECT_DEATH((void)register_kernels(kernels_span), "registration failed");
 }
 
 TEST_F(OperatorRegistryTest, KernelKeyEquals) {
@@ -408,7 +408,7 @@ TEST_F(OperatorRegistryTest, DoubleRegisterKernelsDies) {
       });
   Kernel kernels[] = {kernel_1, kernel_2};
   // clang-tidy off
-  ET_EXPECT_DEATH({ (void)register_kernels(kernels); }, "");
+  ET_EXPECT_DEATH((void)register_kernels(kernels), "registration failed");
   // clang-tidy on
 }
 

--- a/runtime/platform/test/CMakeLists.txt
+++ b/runtime/platform/test/CMakeLists.txt
@@ -29,9 +29,7 @@ et_cxx_test(
   executor_pal_static_runtime_override_test.cpp
 )
 
-# TODO: Re-enable this test on OSS
-#
-# et_cxx_test(platform_death_test SOURCES executor_pal_death_test.cpp)
+et_cxx_test(platform_death_test SOURCES executor_pal_death_test.cpp)
 
 # No weak function symbols on Windows/MSVC, thus PAL intercept doesn't work.
 # Skip logging tests in Release mode.

--- a/runtime/platform/test/executor_pal_death_test.cpp
+++ b/runtime/platform/test/executor_pal_death_test.cpp
@@ -16,14 +16,15 @@ TEST(ExecutorPalTest, UninitializedPalDeath) {
 
 #ifndef NDEBUG
 
-  ET_EXPECT_DEATH({ et_pal_current_ticks(); }, "");
+  ET_EXPECT_DEATH_NO_PAL_INIT(
+      { et_pal_current_ticks(); }, "PAL must be initialized");
 
-  ET_EXPECT_DEATH(
+  ET_EXPECT_DEATH_NO_PAL_INIT(
       {
         et_pal_emit_log_message(
             0, et_pal_log_level_t::kFatal, "", "", 0, "", 0);
       },
-      "");
+      "PAL must be initialized");
 
 #endif // !defined(NDEBUG)
 }

--- a/test/utils/DeathTest.h
+++ b/test/utils/DeathTest.h
@@ -16,6 +16,7 @@
 #include <gtest/gtest.h>
 
 #include <executorch/runtime/platform/log.h>
+#include <executorch/runtime/platform/platform.h>
 
 #ifndef ET_BUILD_MODE_COV
 #define ET_BUILD_MODE_COV 0
@@ -40,7 +41,12 @@
  * causes the process to terminate.
  */
 #define ET_EXPECT_DEATH(_statement, _matcher) \
-  EXPECT_DEATH_IF_SUPPORTED(_statement, "")
+  EXPECT_DEATH_IF_SUPPORTED(                  \
+      {                                       \
+        et_pal_init();                        \
+        _statement;                           \
+      },                                      \
+      "")
 
 #else // ET_BUILD_MODE_COV
 
@@ -52,6 +58,11 @@
  * the dying process. If this does not match, the test will fail.
  */
 #define ET_EXPECT_DEATH(_statement, _matcher) \
-  EXPECT_DEATH_IF_SUPPORTED(_statement, _matcher)
+  EXPECT_DEATH_IF_SUPPORTED(                  \
+      {                                       \
+        et_pal_init();                        \
+        _statement;                           \
+      },                                      \
+      _matcher)
 
 #endif // ET_BUILD_MODE_COV

--- a/test/utils/DeathTest.h
+++ b/test/utils/DeathTest.h
@@ -31,6 +31,7 @@
  * tests.
  */
 #define ET_EXPECT_DEATH(_statement, _matcher) ((void)0)
+#define ET_EXPECT_DEATH_NO_PAL_INIT(_statement, _matcher) ((void)0)
 
 #elif defined(_WIN32) || !ET_LOG_ENABLED
 
@@ -48,6 +49,9 @@
       },                                      \
       "")
 
+#define ET_EXPECT_DEATH_NO_PAL_INIT(_statement, _matcher) \
+  EXPECT_DEATH_IF_SUPPORTED(_statement, "")
+
 #else // ET_BUILD_MODE_COV
 
 /**
@@ -64,5 +68,12 @@
         _statement;                           \
       },                                      \
       _matcher)
+
+/**
+ * Like ET_EXPECT_DEATH but without PAL initialization.
+ * Use this only for tests that specifically test uninitialized PAL behavior.
+ */
+#define ET_EXPECT_DEATH_NO_PAL_INIT(_statement, _matcher) \
+  EXPECT_DEATH_IF_SUPPORTED(_statement, _matcher)
 
 #endif // ET_BUILD_MODE_COV


### PR DESCRIPTION
### Summary

Replace empty string matchers with descriptive patterns that document the expected failure:
- operator_registry_test: "registration failed"
- operator_impl_example_test: "Unhandled dtype"
- scalar_type_util_test: "Unknown ScalarType"
- memory_manager_test: "cannot be the same"
- method_test: "[0-9]+ >= [0-9]+"
- tensor_util_test: "stride of the.*dimension shall"
- etdump_test: "before any events are added"
- aten_bridge_test: "Strides don't match dim order"

Also add et_pal_init() to ET_EXPECT_DEATH macro to initialize PAL in the forked subprocess.

Authored with Claude.

### Test plan
```
./test/run_oss_cpp_tests.sh
```