### PR TITLE
[ExecuTorch][ez] Propagate ops_to_not_decompose to config exception list

### DIFF
--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -1252,11 +1252,21 @@ def _gen_edge_manager_for_partitioners(
             preserve_ops=ops_set_to_not_decompose_by_program.get(name, []),
         )
 
+    # Merge ops_to_not_decompose into config so that downstream calls (e.g.
+    # EdgeProgramManager.transform()) carry the exception list through their
+    # verifiers automatically.
+    all_ops_not_to_decompose = list(
+        set().union(*ops_set_to_not_decompose_by_program.values())
+    )
+    config._core_aten_ops_exception_list = list(
+        set(config._core_aten_ops_exception_list) | set(all_ops_not_to_decompose)
+    )
+
     edge_manager = EdgeProgramManager(
         edge_programs,
         constant_methods,
         config,
-        list(set().union(*ops_set_to_not_decompose_by_program.values())),
+        all_ops_not_to_decompose,
     )
 
     if generate_etrecord:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #17404

When a partitioner declares ops in `ops_to_not_decompose()`, the framework preserves them from decomposition during `_gen_edge_manager_for_partitioners` and passes them to `EdgeProgramManager.__init__` as `core_aten_ops_exception_list`. However, `EdgeProgramManager` does not store this list, so when `transform()` is called later (e.g. with `I64toI32` passes), its `EXIREdgeDialectVerifier` creates a fresh verifier without the exception list. This causes a `SpecViolationError` for any preserved op that is not in the core ATen opset.

This was discovered while adding `torch.ops.aten.pixel_shuffle.default` to the Vulkan backend's `ops_not_to_decompose` list. The op was correctly preserved from decomposition, but the subsequent `transform()` call in `to_edge_transform_and_lower` rejected it with: "Operator torch._ops.aten.pixel_shuffle.default is not in Core ATen opset".

The fix merges `ops_to_not_decompose` into `config._core_aten_ops_exception_list` before creating the `EdgeProgramManager`. Since the config object is propagated through `transform()` and its verifier, the exception list is now available at every verification point. This eliminates the need for callers to manually set `_core_aten_ops_exception_list` for ops that their partitioner already declares as not-to-decompose.

Differential Revision: [D93024955](https://our.internmc.facebook.com/intern/diff/D93024955/)