### PR TITLE
Reverts the addition of `RemoveNoopPass` to the Cortex-M pass manager…

### DIFF
--- a/backends/cortex_m/passes/cortex_m_pass_manager.py
+++ b/backends/cortex_m/passes/cortex_m_pass_manager.py
@@ -8,7 +8,6 @@ import inspect
 
 from executorch.backends.arm._passes import (
     FoldAndAnnotateQParamsPass,
-    RemoveNoopPass,
     ScalarsToAttributePass,
 )
 from executorch.backends.transforms.remove_getitem_op import RemoveGetItemPass
@@ -35,7 +34,6 @@ class CortexMPassManager(PassManager):
         # Run before folding so qparams attach to max_pool2d values, not tuple + getitem.
         RemoveGetItemPass,
         FoldAndAnnotateQParamsPass,
-        RemoveNoopPass,
         ReplaceScalarWithTensorArgPass,
         ReplaceQuantNodesPass,
         ActivationFusionPass,

--- a/backends/cortex_m/test/models/test_mobilenet_v2.py
+++ b/backends/cortex_m/test/models/test_mobilenet_v2.py
@@ -34,6 +34,7 @@ ops_after_transforms: dict[str, int] = {
     "executorch_exir_dialects_edge__ops_cortex_m_quantized_conv2d_default": 35,
     "executorch_exir_dialects_edge__ops_cortex_m_quantized_depthwise_conv2d_default": 17,
     "executorch_exir_dialects_edge__ops_cortex_m_quantized_linear_default": 1,
+    "executorch_exir_dialects_edge__ops_dim_order_ops__clone_dim_order_default": 1,
 }
 
 # Use larger sample set for calibration to get better quantization


### PR DESCRIPTION
… (introduced in #17300) which broke 8 quantization tests.

After #17300 merged, the following tests started failing:
- `test_shared_qspec_quantizer[input_fork_x_shared]`
- `test_shared_qspec_quantizer[input_fork_y_shared]`
- `test_shared_qspec_quantizer[surrounded_quantized_op]`
- `test_shared_qspec_quantizer[output_fork_shared]`
- `test_shared_qspec_quantizer[many_forks]`
- `test_dialect_mv2[mobilenet_v2]` (+ 2 more)

`RemoveNoopPass` removes `clone_dim_order` operators that are functionally necessary for shared quantization specs. It only checks dtype equality, not dim_order/layout changes, causing it to incorrectly remove clones needed for:
- Tensor forking in quantized graphs
- Shared quantization parameter propagation
- Correct quantization fusion

Remove `RemoveNoopPass` from the Cortex-M pass pipeline. The MobileNetV2 `clone_dim_order` issue it was meant to address needs a more targeted solution.

```bash
pytest -c backends/arm/test/pytest.ini backends/cortex_m/test/misc/test_quantization.py::test_shared_qspec_quantizer -v
pytest -c backends/arm/test/pytest.ini backends/cortex_m/test/models/test_mobilenet_v2.py::test_dialect_mv2 -v

