### PR TITLE
Add complex type support to _to_dim_order_copy operator (#17209)

### DIFF
--- a/kernels/portable/cpu/op__to_dim_order_copy.cpp
+++ b/kernels/portable/cpu/op__to_dim_order_copy.cpp
@@ -57,11 +57,59 @@ Tensor& _to_dim_order_copy_out(
   static constexpr const char op_name[] =
       "dim_order_ops::_to_dim_order_copy.out";
 
-  ET_SWITCH_REALHBBF16_TYPES(self.scalar_type(), ctx, op_name, CTYPE_IN, [&] {
-    ET_SWITCH_REALHBBF16_TYPES(out.scalar_type(), ctx, op_name, CTYPE_OUT, [&] {
-      _to_dim_order_copy_impl<CTYPE_IN, CTYPE_OUT>(self, out);
+  const bool in_is_complex =
+      executorch::runtime::isComplexType(self.scalar_type());
+  const bool out_is_complex =
+      executorch::runtime::isComplexType(out.scalar_type());
+
+  if (in_is_complex && out_is_complex) {
+    // Complex to complex: same type copy
+    ET_SWITCH_COMPLEXH_TYPES(self.scalar_type(), ctx, op_name, CTYPE, [&] {
+      _to_dim_order_copy_impl<CTYPE, CTYPE>(self, out);
     });
-  });
+  } else if (!in_is_complex && out_is_complex) {
+    // Real to complex: convert real value to complex with zero imaginary part
+    ET_SWITCH_FLOATH_TYPES(self.scalar_type(), ctx, op_name, CTYPE_IN, [&] {
+      ET_SWITCH_COMPLEXH_TYPES(out.scalar_type(), ctx, op_name, CTYPE_OUT, [&] {
+        auto self_data = self.mutable_data_ptr<CTYPE_IN>();
+        auto out_data = out.mutable_data_ptr<CTYPE_OUT>();
+        for (const auto [unused_index, self_data_index, out_data_index] :
+             BroadcastIndexesRange<
+                 2,
+                 /*support_noncontiguous_input_tensors=*/true>(
+                 /*dummy output*/ self, self, out)) {
+          (void)unused_index;
+          out_data[out_data_index].real_ = self_data[self_data_index];
+          out_data[out_data_index].imag_ = 0;
+        }
+      });
+    });
+  } else if (in_is_complex && !out_is_complex) {
+    // Complex to real: take real part
+    ET_SWITCH_COMPLEXH_TYPES(self.scalar_type(), ctx, op_name, CTYPE_IN, [&] {
+      ET_SWITCH_FLOATH_TYPES(out.scalar_type(), ctx, op_name, CTYPE_OUT, [&] {
+        auto self_data = self.mutable_data_ptr<CTYPE_IN>();
+        auto out_data = out.mutable_data_ptr<CTYPE_OUT>();
+        for (const auto [unused_index, self_data_index, out_data_index] :
+             BroadcastIndexesRange<
+                 2,
+                 /*support_noncontiguous_input_tensors=*/true>(
+                 /*dummy output*/ self, self, out)) {
+          (void)unused_index;
+          out_data[out_data_index] =
+              static_cast<CTYPE_OUT>(self_data[self_data_index].real_);
+        }
+      });
+    });
+  } else {
+    // Real to real
+    ET_SWITCH_REALHBBF16_TYPES(self.scalar_type(), ctx, op_name, CTYPE_IN, [&] {
+      ET_SWITCH_REALHBBF16_TYPES(
+          out.scalar_type(), ctx, op_name, CTYPE_OUT, [&] {
+            _to_dim_order_copy_impl<CTYPE_IN, CTYPE_OUT>(self, out);
+          });
+    });
+  }
 
   return out;
 }


### PR DESCRIPTION
Summary:

Cover various options when copying from real to float and vice versa:
- complex to complex
- real to complex
- complex to real

Differential Revision: D93105513


