### PR TITLE
1/x: add LoadBackendOptionsMap for backend options routing

### DIFF
--- a/runtime/backend/backend_options_map.h
+++ b/runtime/backend/backend_options_map.h
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <executorch/runtime/backend/options.h>
+#include <executorch/runtime/core/error.h>
+#include <executorch/runtime/core/span.h>
+
+#include <cstring>
+
+namespace executorch {
+namespace runtime {
+
+/**
+ * Maps backend IDs to their load-time options.
+ *
+ * This class is used to provide per-delegate configuration at Module::load()
+ * time. Users can set options for multiple backends, and the runtime will
+ * route the appropriate options to each backend during initialization.
+ *
+ * Example usage:
+ * @code
+ *   BackendOptions<4> coreml_opts;
+ *   coreml_opts.set_option("compute_unit", "cpu_and_gpu");
+ *
+ *   LoadBackendOptionsMap map;
+ *   map.set_options("CoreMLBackend", coreml_opts.view());
+ *
+ *   // Later, during backend init:
+ *   auto opts = map.get_options("CoreMLBackend");
+ * @endcode
+ *
+ * Note: This class does NOT take ownership of the option spans. The caller
+ * must ensure that the BackendOptions objects outlive the LoadBackendOptionsMap
+ * and any loaded models that use it.
+ */
+class LoadBackendOptionsMap final {
+ public:
+  /**
+   * Default constructor - creates an empty map.
+   */
+  LoadBackendOptionsMap() : size_(0) {
+    for (size_t i = 0; i < kMaxBackends; ++i) {
+      entries_[i].backend_id[0] = '\0';
+    }
+  }
+
+  /**
+   * Sets options for a specific backend.
+   *
+   * If options for the given backend_id already exist, they will be replaced.
+   *
+   * @param backend_id The backend identifier (e.g., "CoreMLBackend",
+   * "XNNPACKBackend"). Must not be null or empty.
+   * @param options Span of BackendOption to associate with this backend.
+   *                The span's underlying data must outlive this map and any
+   *                models loaded with it.
+   * @return Error::Ok on success.
+   *         Error::InvalidArgument if backend_id is null/empty or max backends
+   * exceeded.
+   */
+  Error set_options(const char* backend_id, Span<BackendOption> options) {
+    if (backend_id == nullptr || backend_id[0] == '\0') {
+      return Error::InvalidArgument;
+    }
+
+    return set_options_impl(backend_id, options);
+  }
+
+  /**
+   * Sets options from a backend options builder.
+   *
+   * This convenience overload accepts any builder type that provides
+   * backend_id() and view() methods, allowing simpler usage:
+   *
+   * @code
+   *   ExampleBackendOptions opts;
+   *   opts.setNumThreads(4).setEnableOptimization(true);
+   *   map.set_options(opts);
+   * @endcode
+   *
+   * @param builder A backend options builder with backend_id() and view()
+   * methods.
+   * @return Error::Ok on success, Error::InvalidArgument on failure.
+   */
+  template <typename Builder>
+  Error set_options(Builder& builder) {
+    return set_options_impl(builder.backend_id(), builder.view());
+  }
+
+ private:
+  Error set_options_impl(const char* backend_id, Span<BackendOption> options) {
+    // Check if backend already exists and update it
+    for (size_t i = 0; i < size_; ++i) {
+      if (std::strcmp(entries_[i].backend_id, backend_id) == 0) {
+        entries_[i].options = options;
+        return Error::Ok;
+      }
+    }
+
+    // Add new entry if space available
+    if (size_ >= kMaxBackends) {
+      return Error::InvalidArgument;
+    }
+
+    const size_t id_len = std::strlen(backend_id);
+    if (id_len >= kMaxBackendIdLength) {
+      return Error::InvalidArgument;
+    }
+    std::memcpy(entries_[size_].backend_id, backend_id, id_len);
+    entries_[size_].backend_id[id_len] = '\0';
+    entries_[size_].options = options;
+    ++size_;
+
+    return Error::Ok;
+  }
+
+ public:
+  /**
+   * Gets options for a specific backend.
+   *
+   * @param backend_id The backend identifier to look up.
+   * @return Span of options for this backend, or an empty span if the backend
+   *         has no options configured or backend_id is null.
+   */
+  Span<const BackendOption> get_options(const char* backend_id) const {
+    if (backend_id == nullptr) {
+      return Span<const BackendOption>(nullptr, static_cast<size_t>(0));
+    }
+
+    for (size_t i = 0; i < size_; ++i) {
+      if (std::strcmp(entries_[i].backend_id, backend_id) == 0) {
+        return Span<const BackendOption>(
+            entries_[i].options.data(), entries_[i].options.size());
+      }
+    }
+
+    return Span<const BackendOption>(nullptr, static_cast<size_t>(0));
+  }
+
+  /**
+   * Checks if options have been configured for a specific backend.
+   *
+   * @param backend_id The backend identifier to check.
+   * @return true if options are set for this backend, false otherwise.
+   */
+  bool has_options(const char* backend_id) const {
+    if (backend_id == nullptr) {
+      return false;
+    }
+
+    for (size_t i = 0; i < size_; ++i) {
+      if (std::strcmp(entries_[i].backend_id, backend_id) == 0) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Returns the number of backends with configured options.
+   */
+  size_t size() const {
+    return size_;
+  }
+
+ private:
+  static constexpr size_t kMaxBackends = 8;
+  static constexpr size_t kMaxBackendIdLength = 64;
+
+  struct Entry {
+    char backend_id[kMaxBackendIdLength];
+    Span<BackendOption> options;
+  };
+
+  Entry entries_[kMaxBackends];
+  size_t size_;
+};
+
+} // namespace runtime
+} // namespace executorch

--- a/runtime/backend/targets.bzl
+++ b/runtime/backend/targets.bzl
@@ -7,6 +7,30 @@ def define_common_targets():
     TARGETS and BUCK files that call this function.
     """
 
+    # Header-only library for backend options (no aten suffix needed)
+    runtime.cxx_library(
+        name = "backend_options",
+        exported_headers = [
+            "options.h",
+        ],
+        visibility = ["PUBLIC"],
+        exported_deps = [
+            "//executorch/runtime/core:core",
+        ],
+    )
+
+    # Header-only library for backend options map (no aten suffix needed)
+    runtime.cxx_library(
+        name = "backend_options_map",
+        exported_headers = [
+            "backend_options_map.h",
+        ],
+        visibility = ["PUBLIC"],
+        exported_deps = [
+            ":backend_options",
+        ],
+    )
+
     for aten_mode in get_aten_mode_options():
         aten_suffix = ("_aten" if aten_mode else "")
         runtime.cxx_library(
@@ -18,6 +42,7 @@ def define_common_targets():
                 "backend_execution_context.h",
                 "backend_init_context.h",
                 "backend_option_context.h",
+                "backend_options_map.h",
                 "options.h",
                 "interface.h",
             ],

--- a/runtime/backend/test/backend_options_map_test.cpp
+++ b/runtime/backend/test/backend_options_map_test.cpp
@@ -1,0 +1,367 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/runtime/backend/backend_options_map.h>
+#include <executorch/runtime/platform/runtime.h>
+
+#include <gtest/gtest.h>
+
+using namespace ::testing;
+using executorch::runtime::BackendOption;
+using executorch::runtime::BackendOptions;
+using executorch::runtime::Error;
+using executorch::runtime::kMaxOptionValueLength;
+using executorch::runtime::LoadBackendOptionsMap;
+using executorch::runtime::Span;
+
+class LoadBackendOptionsMapTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    executorch::runtime::runtime_init();
+  }
+};
+
+// Test default constructor creates empty map
+TEST_F(LoadBackendOptionsMapTest, DefaultConstructorCreatesEmptyMap) {
+  LoadBackendOptionsMap map;
+  EXPECT_EQ(map.size(), 0);
+  EXPECT_FALSE(map.has_options("CoreMLBackend"));
+}
+
+// Test set_options and get_options round trip
+TEST_F(LoadBackendOptionsMapTest, SetAndGetOptionsRoundTrip) {
+  BackendOptions<4> coreml_opts;
+  coreml_opts.set_option("compute_unit", "cpu_and_gpu");
+  coreml_opts.set_option("num_threads", 4);
+
+  LoadBackendOptionsMap map;
+  EXPECT_EQ(map.set_options("CoreMLBackend", coreml_opts.view()), Error::Ok);
+
+  auto retrieved = map.get_options("CoreMLBackend");
+  EXPECT_EQ(retrieved.size(), 2);
+
+  // Verify we can read the options back
+  const char* compute_unit = nullptr;
+  int num_threads = 0;
+  for (size_t i = 0; i < retrieved.size(); ++i) {
+    const auto& opt = retrieved[i];
+    if (strcmp(opt.key, "compute_unit") == 0) {
+      if (auto* arr = std::get_if<std::array<char, kMaxOptionValueLength>>(
+              &opt.value)) {
+        compute_unit = arr->data();
+      }
+    } else if (strcmp(opt.key, "num_threads") == 0) {
+      if (auto* val = std::get_if<int>(&opt.value)) {
+        num_threads = *val;
+      }
+    }
+  }
+  EXPECT_STREQ(compute_unit, "cpu_and_gpu");
+  EXPECT_EQ(num_threads, 4);
+}
+
+// Test has_options returns correct values
+TEST_F(LoadBackendOptionsMapTest, HasOptionsReturnsCorrectValues) {
+  BackendOptions<2> opts;
+  opts.set_option("key", "value");
+
+  LoadBackendOptionsMap map;
+  EXPECT_FALSE(map.has_options("CoreMLBackend"));
+
+  map.set_options("CoreMLBackend", opts.view());
+  EXPECT_TRUE(map.has_options("CoreMLBackend"));
+  EXPECT_FALSE(map.has_options("XNNPACKBackend"));
+}
+
+// Test get_options returns empty span for unknown backend
+TEST_F(LoadBackendOptionsMapTest, GetOptionsReturnsEmptyForUnknownBackend) {
+  LoadBackendOptionsMap map;
+  auto opts = map.get_options("UnknownBackend");
+  EXPECT_EQ(opts.size(), 0);
+}
+
+// Test multiple backends
+TEST_F(LoadBackendOptionsMapTest, MultipleBackends) {
+  BackendOptions<2> coreml_opts;
+  coreml_opts.set_option("compute_unit", "cpu_and_ne");
+
+  BackendOptions<2> xnnpack_opts;
+  xnnpack_opts.set_option("num_threads", 8);
+
+  LoadBackendOptionsMap map;
+  EXPECT_EQ(map.set_options("CoreMLBackend", coreml_opts.view()), Error::Ok);
+  EXPECT_EQ(map.set_options("XNNPACKBackend", xnnpack_opts.view()), Error::Ok);
+
+  EXPECT_EQ(map.size(), 2);
+  EXPECT_TRUE(map.has_options("CoreMLBackend"));
+  EXPECT_TRUE(map.has_options("XNNPACKBackend"));
+
+  auto coreml_retrieved = map.get_options("CoreMLBackend");
+  auto xnnpack_retrieved = map.get_options("XNNPACKBackend");
+
+  EXPECT_EQ(coreml_retrieved.size(), 1);
+  EXPECT_EQ(xnnpack_retrieved.size(), 1);
+}
+
+// Test updating existing backend options
+TEST_F(LoadBackendOptionsMapTest, UpdateExistingBackendOptions) {
+  BackendOptions<2> opts_v1;
+  opts_v1.set_option("compute_unit", "cpu_only");
+
+  BackendOptions<2> opts_v2;
+  opts_v2.set_option("compute_unit", "cpu_and_gpu");
+  opts_v2.set_option("enable_profiling", true);
+
+  LoadBackendOptionsMap map;
+  map.set_options("CoreMLBackend", opts_v1.view());
+  EXPECT_EQ(map.get_options("CoreMLBackend").size(), 1);
+
+  // Update with new options
+  map.set_options("CoreMLBackend", opts_v2.view());
+  EXPECT_EQ(map.size(), 1); // Still only one backend
+  EXPECT_EQ(map.get_options("CoreMLBackend").size(), 2); // But now 2 options
+}
+
+// Test max backends limit
+TEST_F(LoadBackendOptionsMapTest, MaxBackendsLimit) {
+  LoadBackendOptionsMap map;
+  BackendOptions<1> opts;
+  opts.set_option("key", "value");
+
+  // Add 8 backends (the limit)
+  const char* backend_ids[] = {
+      "Backend1",
+      "Backend2",
+      "Backend3",
+      "Backend4",
+      "Backend5",
+      "Backend6",
+      "Backend7",
+      "Backend8"};
+
+  for (int i = 0; i < 8; ++i) {
+    EXPECT_EQ(map.set_options(backend_ids[i], opts.view()), Error::Ok);
+  }
+
+  EXPECT_EQ(map.size(), 8);
+
+  // Adding a 9th backend should fail
+  EXPECT_EQ(map.set_options("Backend9", opts.view()), Error::InvalidArgument);
+  EXPECT_EQ(map.size(), 8);
+}
+
+// Test null backend_id handling
+TEST_F(LoadBackendOptionsMapTest, NullBackendIdHandling) {
+  LoadBackendOptionsMap map;
+  BackendOptions<1> opts;
+  opts.set_option("key", "value");
+
+  // set_options with null should fail
+  EXPECT_EQ(map.set_options(nullptr, opts.view()), Error::InvalidArgument);
+
+  // get_options with null should return empty span
+  auto result = map.get_options(nullptr);
+  EXPECT_EQ(result.size(), 0);
+
+  // has_options with null should return false
+  EXPECT_FALSE(map.has_options(nullptr));
+}
+
+// Test empty backend_id handling
+TEST_F(LoadBackendOptionsMapTest, EmptyBackendIdHandling) {
+  LoadBackendOptionsMap map;
+  BackendOptions<1> opts;
+  opts.set_option("key", "value");
+
+  // set_options with empty string should fail
+  EXPECT_EQ(map.set_options("", opts.view()), Error::InvalidArgument);
+}
+
+// Test empty options span
+TEST_F(LoadBackendOptionsMapTest, EmptyOptionsSpan) {
+  LoadBackendOptionsMap map;
+  BackendOptions<1> empty_opts;
+
+  // Should be able to set empty options
+  EXPECT_EQ(map.set_options("CoreMLBackend", empty_opts.view()), Error::Ok);
+  EXPECT_TRUE(map.has_options("CoreMLBackend"));
+
+  auto retrieved = map.get_options("CoreMLBackend");
+  EXPECT_EQ(retrieved.size(), 0);
+}
+
+// Test long backend_id is rejected
+TEST_F(LoadBackendOptionsMapTest, LongBackendIdRejected) {
+  LoadBackendOptionsMap map;
+  BackendOptions<1> opts;
+  opts.set_option("key", "value");
+
+  // Create a backend ID that is exactly at the limit (64 chars including null)
+  // This should fail because id_len >= kMaxBackendIdLength
+  char long_id[65];
+  memset(long_id, 'A', 64);
+  long_id[64] = '\0';
+
+  EXPECT_EQ(map.set_options(long_id, opts.view()), Error::InvalidArgument);
+  EXPECT_EQ(map.size(), 0);
+
+  // A backend ID of 63 chars (plus null = 64 total) should succeed
+  char max_valid_id[64];
+  memset(max_valid_id, 'B', 63);
+  max_valid_id[63] = '\0';
+
+  EXPECT_EQ(map.set_options(max_valid_id, opts.view()), Error::Ok);
+  EXPECT_EQ(map.size(), 1);
+  EXPECT_TRUE(map.has_options(max_valid_id));
+}
+
+/**
+ * Example backend options builder demonstrating the recommended pattern.
+ *
+ * Backend developers should follow this pattern to create type-safe option
+ * builders for their backends. Key requirements:
+ *
+ * 1. Provide a static backend_id() method returning the backend identifier
+ * 2. Provide a view() method returning Span<BackendOption>
+ * 3. Use an enum for options with a fixed set of valid values
+ * 4. Provide type-safe setter methods that return *this for chaining
+ *
+ * This enables usage like:
+ * @code
+ *   ExampleBackendOptions opts;
+ *   opts.setNumThreads(4).setEnableOptimization(true);
+ *   map.set_options(opts);  // Uses the template overload
+ * @endcode
+ *
+ * See coreml_backend_options.h for a real-world example.
+ */
+class ExampleBackendOptions {
+ public:
+  // Option 1: Enum-based option with type safety
+  enum class Precision { FLOAT32, FLOAT16, INT8 };
+
+  ExampleBackendOptions& setPrecision(Precision p) {
+    const char* value = nullptr;
+    switch (p) {
+      case Precision::FLOAT32:
+        value = "float32";
+        break;
+      case Precision::FLOAT16:
+        value = "float16";
+        break;
+      case Precision::INT8:
+        value = "int8";
+        break;
+    }
+    options_.set_option("precision", value);
+    return *this;
+  }
+
+  // Option 2: Integer option
+  ExampleBackendOptions& setNumThreads(int num_threads) {
+    options_.set_option("num_threads", num_threads);
+    return *this;
+  }
+
+  // Option 3: Boolean option
+  ExampleBackendOptions& setEnableOptimization(bool enable) {
+    options_.set_option("enable_optimization", enable);
+    return *this;
+  }
+
+  // Required: Returns the backend identifier
+  static constexpr const char* backend_id() {
+    return "ExampleBackend";
+  }
+
+  // Required: Returns a view of the configured options
+  Span<BackendOption> view() {
+    return options_.view();
+  }
+
+ private:
+  BackendOptions<8> options_;
+};
+
+// Test template set_options with builder
+TEST_F(LoadBackendOptionsMapTest, SetOptionsWithBuilder) {
+  LoadBackendOptionsMap map;
+
+  // Example of fluent builder API usage
+  ExampleBackendOptions builder;
+  builder.setPrecision(ExampleBackendOptions::Precision::FLOAT16)
+      .setNumThreads(4)
+      .setEnableOptimization(true);
+
+  EXPECT_EQ(map.set_options(builder), Error::Ok);
+  EXPECT_EQ(map.size(), 1);
+  EXPECT_TRUE(map.has_options("ExampleBackend"));
+
+  auto retrieved = map.get_options("ExampleBackend");
+  EXPECT_EQ(retrieved.size(), 3);
+
+  // Verify we can read the options back
+  const char* precision_value = nullptr;
+  int num_threads_value = 0;
+  bool enable_optimization_value = false;
+  for (size_t i = 0; i < retrieved.size(); ++i) {
+    const auto& opt = retrieved[i];
+    if (strcmp(opt.key, "precision") == 0) {
+      if (auto* arr = std::get_if<std::array<char, kMaxOptionValueLength>>(
+              &opt.value)) {
+        precision_value = arr->data();
+      }
+    } else if (strcmp(opt.key, "num_threads") == 0) {
+      if (auto* val = std::get_if<int>(&opt.value)) {
+        num_threads_value = *val;
+      }
+    } else if (strcmp(opt.key, "enable_optimization") == 0) {
+      if (auto* val = std::get_if<bool>(&opt.value)) {
+        enable_optimization_value = *val;
+      }
+    }
+  }
+  EXPECT_STREQ(precision_value, "float16");
+  EXPECT_EQ(num_threads_value, 4);
+  EXPECT_TRUE(enable_optimization_value);
+}
+
+// Test template set_options updates existing backend
+TEST_F(LoadBackendOptionsMapTest, SetOptionsWithBuilderUpdatesExisting) {
+  LoadBackendOptionsMap map;
+
+  // First set options via builder
+  ExampleBackendOptions builder1;
+  builder1.setNumThreads(4);
+  EXPECT_EQ(map.set_options(builder1), Error::Ok);
+  EXPECT_EQ(map.size(), 1);
+
+  // Verify initial value
+  auto retrieved1 = map.get_options("ExampleBackend");
+  EXPECT_EQ(retrieved1.size(), 1);
+  int num_threads1 = 0;
+  if (auto* val = std::get_if<int>(&retrieved1[0].value)) {
+    num_threads1 = *val;
+  }
+  EXPECT_EQ(num_threads1, 4);
+
+  // Update via builder API with different value
+  ExampleBackendOptions builder2;
+  builder2.setNumThreads(8);
+  EXPECT_EQ(map.set_options(builder2), Error::Ok);
+  EXPECT_EQ(map.size(), 1); // Still only one backend
+
+  // Verify value was updated
+  auto retrieved2 = map.get_options("ExampleBackend");
+  EXPECT_EQ(retrieved2.size(), 1);
+  int num_threads2 = 0;
+  if (auto* val = std::get_if<int>(&retrieved2[0].value)) {
+    num_threads2 = *val;
+  }
+  EXPECT_EQ(num_threads2, 8); // Should be updated value
+}

--- a/runtime/backend/test/targets.bzl
+++ b/runtime/backend/test/targets.bzl
@@ -17,6 +17,15 @@ def define_common_targets():
     )
 
     runtime.cxx_test(
+        name = "backend_options_map_test",
+        srcs = ["backend_options_map_test.cpp"],
+        deps = [
+            "//executorch/runtime/core:core",
+            "//executorch/runtime/backend:interface",
+        ],
+    )
+
+    runtime.cxx_test(
         name = "backend_interface_update_test",
         srcs = ["backend_interface_update_test.cpp"],
         deps = [


### PR DESCRIPTION
Summary:
This diff introduces `LoadBackendOptionsMap`, a container for routing backend-specific options to delegates at model load time. This enables users to configure multiple backends with options that are automatically routed to the appropriate delegate during `Module::load()`.

Key components:
- `LoadBackendOptionsMap` class in `backend_options_map.h` that maps backend IDs to their options
- Template `set_options(const Builder&)` method for builder pattern integration
- Added const overload to `BackendOptions::view()` to support const-correct builders
- `ExampleBackendOptions` reference implementation showing the recommended pattern for backend developers

The builder pattern enables fluent API usage:
```cpp
ExampleBackendOptions opts;
opts.setNumThreads(4).setEnableOptimization(true);

LoadBackendOptionsMap map;
map.set_options(opts);  // Uses builder's backend_id()
```

Reviewed By: larryliu0820

Differential Revision: D92358596


