### PR TITLE
Update gitignore to include generate code under src/executorch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,9 @@ xcuserdata/
 /include/
 /share/
 /version.py
+/src/executorch/include/
+/src/executorch/share/
+/src/executorch/version.py
 *_etdump
 
 # Android


### PR DESCRIPTION
As titled: This comes up when installing ExecuTorch in edit mode: `pip install -e .`
