### PR TITLE
Enable building for metal with macOS SDK < 15

### DIFF
--- a/backends/apple/metal/runtime/shims/et_metal.mm
+++ b/backends/apple/metal/runtime/shims/et_metal.mm
@@ -19,12 +19,32 @@
 #include <exception>
 
 #if (defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED >= 150000) || \
-  (defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 180000) || \
-  (defined(__TV_OS_VERSION_MAX_ALLOWED) && __TV_OS_VERSION_MAX_ALLOWED >= 180000) || \
-  (defined(__WATCH_OS_VERSION_MAX_ALLOWED) && __WATCH_OS_VERSION_MAX_ALLOWED >= 110000)
-#define ET_METAL_HAS_MTL_MATH_COMPILE_OPTIONS 1
+    (defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 180000) || \
+    (defined(__TV_OS_VERSION_MAX_ALLOWED) && __TV_OS_VERSION_MAX_ALLOWED >= 180000) || \
+    (defined(__WATCH_OS_VERSION_MAX_ALLOWED) && __WATCH_OS_VERSION_MAX_ALLOWED >= 110000)
+#define ET_METAL_SDK_HAS_MTL_MATH_COMPILE_OPTIONS 1
 #else
-#define ET_METAL_HAS_MTL_MATH_COMPILE_OPTIONS 0
+#define ET_METAL_SDK_HAS_MTL_MATH_COMPILE_OPTIONS 0
+#endif
+
+#if !ET_METAL_SDK_HAS_MTL_MATH_COMPILE_OPTIONS
+// When building with an older SDK, declare newer Metal compile option symbols so we can still
+// use them behind runtime availability checks.
+typedef NS_ENUM(NSInteger, MTLMathMode) {
+    MTLMathModeSafe = 0,
+    MTLMathModeRelaxed = 1,
+    MTLMathModeFast = 2,
+};
+
+typedef NS_ENUM(NSInteger, MTLMathFloatingPointFunctions) {
+    MTLMathFloatingPointFunctionsFast = 0,
+    MTLMathFloatingPointFunctionsPrecise = 1,
+};
+
+@interface MTLCompileOptions ()
+@property(readwrite, nonatomic) MTLMathMode mathMode;
+@property(readwrite, nonatomic) MTLMathFloatingPointFunctions mathFloatingPointFunctions;
+@end
 #endif
 
 namespace executorch {
@@ -244,12 +264,10 @@ void ETMetalShaderLibrary::compileLibrary() {
         NSError* error = nil;
 
         MTLCompileOptions* options = [[MTLCompileOptions new] autorelease];
-#if ET_METAL_HAS_MTL_MATH_COMPILE_OPTIONS
         if (@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, *)) {
             options.mathMode = MTLMathModeSafe;
             options.mathFloatingPointFunctions = MTLMathFloatingPointFunctionsPrecise;
         }
-#endif
 
         library_ = [device newLibraryWithSource:sourceString options:options error:&error];
         if (!library_ || error) {

--- a/backends/apple/metal/runtime/shims/et_metal.mm
+++ b/backends/apple/metal/runtime/shims/et_metal.mm
@@ -18,6 +18,15 @@
 #include <optional>
 #include <exception>
 
+#if (defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED >= 150000) || \
+  (defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 180000) || \
+  (defined(__TV_OS_VERSION_MAX_ALLOWED) && __TV_OS_VERSION_MAX_ALLOWED >= 180000) || \
+  (defined(__WATCH_OS_VERSION_MAX_ALLOWED) && __WATCH_OS_VERSION_MAX_ALLOWED >= 110000)
+#define ET_METAL_HAS_MTL_MATH_COMPILE_OPTIONS 1
+#else
+#define ET_METAL_HAS_MTL_MATH_COMPILE_OPTIONS 0
+#endif
+
 namespace executorch {
 namespace backends {
 namespace metal {
@@ -235,10 +244,12 @@ void ETMetalShaderLibrary::compileLibrary() {
         NSError* error = nil;
 
         MTLCompileOptions* options = [[MTLCompileOptions new] autorelease];
+#if ET_METAL_HAS_MTL_MATH_COMPILE_OPTIONS
         if (@available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, *)) {
             options.mathMode = MTLMathModeSafe;
             options.mathFloatingPointFunctions = MTLMathFloatingPointFunctionsPrecise;
         }
+#endif
 
         library_ = [device newLibraryWithSource:sourceString options:options error:&error];
         if (!library_ || error) {


### PR DESCRIPTION
### Summary
Fixes compilation errors on macOS w/ SDK < 15 due to non-existent properties:
```
executorch/backends/apple/metal/runtime/shims/et_metal.mm:239:21: error: property 'mathMode' not found on object of type 'MTLCompileOptions *'
            options.mathMode = MTLMathModeSafe;
                    ^
executorch/backends/apple/metal/runtime/shims/et_metal.mm:239:32: error: use of undeclared identifier 'MTLMathModeSafe'
            options.mathMode = MTLMathModeSafe;
                               ^
executorch/backends/apple/metal/runtime/shims/et_metal.mm:240:21: error: property 'mathFloatingPointFunctions' not found on object of type 'MTLCompileOptions *'
            options.mathFloatingPointFunctions = MTLMathFloatingPointFunctionsPrecise;
                    ^
executorch/backends/apple/metal/runtime/shims/et_metal.mm:240:50: error: use of undeclared identifier 'MTLMathFloatingPointFunctionsPrecise'
            options.mathFloatingPointFunctions = MTLMathFloatingPointFunctionsPrecise;
```
Keep runtime check

### Test plan
 Confirmed working build on machine with:
```
-> % xcodebuild -version
Xcode 15.2
Build version 15C500b
-> % xcrun --sdk macosx --show-sdk-version
14.2
```
That did not work before.

Also confirmed to still work on 26.1:
```
-> % xcodebuild -version
Xcode 26.1.1
Build version 17B100
-> % xcrun --sdk macosx --show-sdk-version
26.1
```
Including verification that inside of if/else def was triggered with a `#warning` (since removed) to see:
```
executorch/backends/apple/metal/runtime/shims/et_metal.mm:249:2: warning: "Compiling with MTLMathModeSafe and MTLMathFloatingPointFunctionsPrecise for improved precision (requires macOS 15/iOS 18 or later)" [-W#warnings]
  249 | #warning "Compiling with MTLMathModeSafe and MTLMathFloatingPointFunctionsPrecise for improved precision (requires macOS 15/iOS 18 or later)"
      |  ^
1 warning generated.
```
Confirmed Parakeet inference to still work on both machines.
