### PR TITLE
Enable true streaming for Voxtral Realtime model on XNNPACK

### DIFF
--- a/.ci/scripts/test_model_e2e.sh
+++ b/.ci/scripts/test_model_e2e.sh
@@ -236,7 +236,7 @@ case "$MODEL_NAME" in
     fi
     ;;
   voxtral_realtime)
-    RUNNER_ARGS="--model_path ${MODEL_DIR}/model.pte --tokenizer_path ${MODEL_DIR}/$TOKENIZER_FILE --preprocessor_path ${MODEL_DIR}/$PREPROCESSOR --audio_path ${MODEL_DIR}/$AUDIO_FILE --temperature 0"
+    RUNNER_ARGS="--model_path ${MODEL_DIR}/model.pte --tokenizer_path ${MODEL_DIR}/$TOKENIZER_FILE --preprocessor_path ${MODEL_DIR}/$PREPROCESSOR --audio_path ${MODEL_DIR}/$AUDIO_FILE --temperature 0 --streaming"
     ;;
 esac
 

--- a/examples/models/voxtral_realtime/README.md
+++ b/examples/models/voxtral_realtime/README.md
@@ -31,6 +31,16 @@ This produces `preprocessor.pte` which takes a 1-D waveform tensor
 `(num_samples,)` and outputs a mel spectrogram `(1, 128, T_mel)`. The
 `--max_audio_len 300` flag supports audio up to 5 minutes.
 
+For streaming, add `--streaming` to skip the 30-second chunk padding so
+that 1280 samples (80ms) produces exactly 8 mel frames:
+
+```bash
+python -m executorch.extension.audio.mel_spectrogram \
+    --feature_size 128 \
+    --streaming \
+    --output_file ./voxtral_rt_exports/preprocessor.pte
+```
+
 ## Export
 
 Export produces a single `.pte` file with three methods:
@@ -46,12 +56,25 @@ python export_voxtral_rt.py \
     --model-path ~/models/Voxtral-Mini-4B-Realtime-2602 \
     --backend xnnpack \
     --output-dir ./voxtral_rt_exports \
+    --qlinear-encoder 8da4w \
     --qlinear 8da4w \
     --qembedding 8w
 ```
 
-This exports with XNNPACK backend acceleration and 8-bit dynamic activation /
-4-bit weight linear quantization + 8-bit embedding quantization.
+For streaming, add `--streaming` to export the encoder with KV caches for
+incremental processing. This replaces `audio_encoder` with
+`encode_audio_chunk` which processes 8 mel frames at a time:
+
+```bash
+python export_voxtral_rt.py \
+    --model-path ~/models/Voxtral-Mini-4B-Realtime-2602 \
+    --backend xnnpack \
+    --streaming \
+    --output-dir ./voxtral_rt_exports \
+    --qlinear-encoder 8da4w \
+    --qlinear 8da4w \
+    --qembedding 8w
+```
 
 ### Options
 
@@ -62,9 +85,13 @@ This exports with XNNPACK backend acceleration and 8-bit dynamic activation /
 | `--output-dir` | `./voxtral_rt_exports` | Output directory |
 | `--max-seq-len` | `4096` | KV cache length |
 | `--delay-tokens` | `6` | Transcription delay in tokens (6 = 480ms) |
-| `--qlinear` | (none) | Linear layer quantization (`4w`, `8w`, `8da4w`, `8da8w`) |
-| `--qlinear-group-size` | `32` | Group size for linear quantization |
+| `--qlinear` | (none) | Decoder linear layer quantization (`4w`, `8w`, `8da4w`, `8da8w`) |
+| `--qlinear-group-size` | `32` | Group size for decoder linear quantization |
+| `--qlinear-encoder` | (none) | Encoder linear layer quantization (`4w`, `8w`, `8da4w`, `8da8w`) |
+| `--qlinear-encoder-group-size` | `32` | Group size for encoder linear quantization |
 | `--qembedding` | (none) | Embedding layer quantization (`8w`) |
+| `--streaming` | off | Export streaming encoder with KV cache |
+| `--max-enc-len` | `750` | Max encoder KV cache length (~60s audio, streaming only) |
 
 ## Build
 
@@ -91,6 +118,21 @@ cmake-out/examples/models/voxtral_realtime/voxtral_realtime_runner \
     --audio_path input.wav
 ```
 
+For streaming, add `--streaming`. The runner feeds audio in 200ms chunks
+(simulating live microphone input), computing mel and running the
+encoder+decoder per 80ms step. The `StreamingSession` C++ API
+(`feed_audio` / `flush`) can be used directly for integration with live
+audio sources.
+
+```bash
+cmake-out/examples/models/voxtral_realtime/voxtral_realtime_runner \
+    --model_path voxtral_rt_exports/model.pte \
+    --tokenizer_path ~/models/Voxtral-Mini-4B-Realtime-2602/tekken.json \
+    --preprocessor_path voxtral_rt_exports/preprocessor.pte \
+    --audio_path input.wav \
+    --streaming
+```
+
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--model_path` | `model.pte` | Path to exported model |
@@ -99,6 +141,7 @@ cmake-out/examples/models/voxtral_realtime/voxtral_realtime_runner \
 | `--audio_path` | (required) | Path to 16kHz mono WAV file |
 | `--temperature` | `0.0` | Sampling temperature (0 = greedy) |
 | `--max_new_tokens` | `500` | Maximum tokens to generate |
+| `--streaming` | off | Use streaming transcription |
 
 ### Example output
 

--- a/examples/models/voxtral_realtime/README.md
+++ b/examples/models/voxtral_realtime/README.md
@@ -91,7 +91,7 @@ python export_voxtral_rt.py \
 | `--qlinear-encoder-group-size` | `32` | Group size for encoder linear quantization |
 | `--qembedding` | (none) | Embedding layer quantization (`8w`) |
 | `--streaming` | off | Export streaming encoder with KV cache |
-| `--max-enc-len` | `750` | Max encoder KV cache length (~60s audio, streaming only) |
+| `--max-enc-len` | `750` | Max encoder KV cache length (~15s audio, streaming only) |
 
 ## Build
 

--- a/examples/models/voxtral_realtime/export_voxtral_rt.py
+++ b/examples/models/voxtral_realtime/export_voxtral_rt.py
@@ -273,6 +273,7 @@ def export_streaming(
     stft_right_lookahead = (
         (chunk_mel_len - 1) * hop_length + n_fft // 2 - chunk_mel_len * hop_length
     )
+    # = (8-1)*160 + 200 - 8*160 = 1320 - 1280 = 40 samples = 2.5ms
 
     metadata = {
         "sample_rate": sample_rate,
@@ -410,7 +411,7 @@ def main():
         "--max-enc-len",
         type=int,
         default=750,
-        help="Max encoder KV cache length for streaming (default: 750, ~60s audio).",
+        help="Max encoder KV cache length for streaming (default: 750, ~15s audio).",
     )
     args = parser.parse_args()
 

--- a/examples/models/voxtral_realtime/main.cpp
+++ b/examples/models/voxtral_realtime/main.cpp
@@ -8,8 +8,12 @@
 
 // CLI entry point for the Voxtral Realtime transcriber.
 //
-// Loads a .pte model, an optional preprocessor .pte, and a Tekken tokenizer.
+// Loads a .pte model, a preprocessor .pte, and a Tekken tokenizer.
 // Processes a WAV file and prints transcribed text.
+//
+// Modes:
+//   Default:     Offline transcription (full encoder, then decode)
+//   --streaming: Streaming transcription (incremental mel + encoder + decode)
 
 #include <cstdio>
 
@@ -27,13 +31,11 @@ DEFINE_string(
     "model.pte",
     "Path to Voxtral Realtime model (.pte).");
 DEFINE_string(tokenizer_path, "tekken.json", "Path to Tekken tokenizer file.");
-DEFINE_string(
-    preprocessor_path,
-    "",
-    "Path to mel preprocessor (.pte). Required for WAV input.");
+DEFINE_string(preprocessor_path, "", "Path to mel preprocessor (.pte).");
 DEFINE_string(audio_path, "", "Path to input audio file (.wav).");
 DEFINE_double(temperature, 0.0, "Sampling temperature (0 = greedy).");
 DEFINE_int32(max_new_tokens, 500, "Maximum number of tokens to generate.");
+DEFINE_bool(streaming, false, "Use streaming transcription mode.");
 
 int main(int argc, char** argv) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
@@ -68,19 +70,39 @@ int main(int argc, char** argv) {
   stats.num_prompt_tokens = 0;
   bool first_token = true;
 
-  int num_generated = runner.transcribe(
-      audio_data.data(),
-      static_cast<int64_t>(audio_data.size()),
-      config,
-      [&](const std::string& piece) {
-        if (first_token) {
-          stats.first_token_ms = ::executorch::extension::llm::time_in_ms();
-          stats.prompt_eval_end_ms = stats.first_token_ms;
-          first_token = false;
-        }
-        ::executorch::extension::llm::safe_printf(piece.c_str());
-        fflush(stdout);
-      });
+  auto token_cb = [&](const std::string& piece) {
+    if (first_token) {
+      stats.first_token_ms = ::executorch::extension::llm::time_in_ms();
+      stats.prompt_eval_end_ms = stats.first_token_ms;
+      first_token = false;
+    }
+    ::executorch::extension::llm::safe_printf(piece.c_str());
+    fflush(stdout);
+  };
+
+  int num_generated;
+  if (FLAGS_streaming) {
+    ET_CHECK_MSG(
+        runner.is_streaming(),
+        "Model was not exported with --streaming. Re-export with --streaming flag.");
+    auto session = runner.create_streaming_session(config, token_cb);
+
+    // Feed audio in 200ms chunks (simulates live microphone input).
+    const int64_t chunk_size = 3200;
+    for (int64_t offset = 0; offset < static_cast<int64_t>(audio_data.size());
+         offset += chunk_size) {
+      int64_t n = std::min(
+          chunk_size, static_cast<int64_t>(audio_data.size()) - offset);
+      session->feed_audio(audio_data.data() + offset, n);
+    }
+    num_generated = session->flush();
+  } else {
+    num_generated = runner.transcribe(
+        audio_data.data(),
+        static_cast<int64_t>(audio_data.size()),
+        config,
+        token_cb);
+  }
 
   printf("\n");
 

--- a/examples/models/voxtral_realtime/main.cpp
+++ b/examples/models/voxtral_realtime/main.cpp
@@ -87,8 +87,8 @@ int main(int argc, char** argv) {
         "Model was not exported with --streaming. Re-export with --streaming flag.");
     auto session = runner.create_streaming_session(config, token_cb);
 
-    // Feed audio in 200ms chunks (simulates live microphone input).
-    const int64_t chunk_size = 3200;
+    // Feed audio in 80ms chunks (one streaming step = 1280 samples at 16kHz).
+    const int64_t chunk_size = 1280;
     for (int64_t offset = 0; offset < static_cast<int64_t>(audio_data.size());
          offset += chunk_size) {
       int64_t n = std::min(

--- a/examples/models/voxtral_realtime/model.md
+++ b/examples/models/voxtral_realtime/model.md
@@ -196,7 +196,7 @@ Each of the 32 encoder transformer layers gets its own `KVCache` instance
 attention via `start_pos`, accumulating encoder frames incrementally.
 
 - Cache shape: `(1, max_enc_len, 32, 64)` per layer
-- Default `max_enc_len=750` (~60s audio, matching the model's trained
+- Default `max_enc_len=750` (~15s audio, matching the model's trained
   sliding window). Configurable via `--max-enc-len`.
 - Memory: 32 layers × 2 × 750 × 32 × 64 × 4 bytes ≈ 393 MB (fp32)
 

--- a/examples/models/voxtral_realtime/voxtral_realtime_runner.cpp
+++ b/examples/models/voxtral_realtime/voxtral_realtime_runner.cpp
@@ -60,6 +60,52 @@ VoxtralRealtimeRunner::VoxtralRealtimeRunner(
       static_cast<long>(vocab_size_),
       static_cast<long>(dim_));
 
+  // Detect streaming model (exported with --streaming flag).
+  auto streaming_val = model_->execute("streaming", empty);
+  if (streaming_val.ok() && streaming_val.get()[0].toInt() == 1) {
+    is_streaming_ = true;
+
+    auto nmb = model_->execute("num_mel_bins", empty);
+    if (nmb.ok())
+      num_mel_bins_ = nmb.get()[0].toInt();
+    auto cm = model_->execute("chunk_mel_len", empty);
+    if (cm.ok())
+      chunk_mel_len_ = cm.get()[0].toInt();
+    auto me = model_->execute("max_enc_len", empty);
+    if (me.ok())
+      max_enc_len_ = me.get()[0].toInt();
+    auto ed = model_->execute("enc_dim", empty);
+    if (ed.ok())
+      enc_dim_ = ed.get()[0].toInt();
+    auto c1 = model_->execute("conv1_pad", empty);
+    if (c1.ok())
+      conv1_pad_ = c1.get()[0].toInt();
+    auto c2 = model_->execute("conv2_pad", empty);
+    if (c2.ok())
+      conv2_pad_ = c2.get()[0].toInt();
+
+    auto ss = model_->execute("step_samples", empty);
+    if (ss.ok())
+      step_samples_ = ss.get()[0].toInt();
+
+    auto slo = model_->execute("stft_left_overlap", empty);
+    if (slo.ok())
+      stft_left_overlap_ = slo.get()[0].toInt();
+    auto srl = model_->execute("stft_right_lookahead", empty);
+    if (srl.ok())
+      stft_right_lookahead_ = srl.get()[0].toInt();
+    auto msf = model_->execute("mel_skip_frames", empty);
+    if (msf.ok())
+      mel_skip_frames_ = msf.get()[0].toInt();
+
+    ET_LOG(
+        Info,
+        "Streaming: chunk_mel=%ld, max_enc=%ld, enc_dim=%ld",
+        static_cast<long>(chunk_mel_len_),
+        static_cast<long>(max_enc_len_),
+        static_cast<long>(enc_dim_));
+  }
+
   // Tekken tokenizer (tekken.json) for the Mistral vocabulary.
   ET_LOG(Info, "Loading tokenizer from: %s", tokenizer_path.c_str());
   tokenizer_ = ::executorch::extension::llm::load_tokenizer(tokenizer_path);
@@ -222,6 +268,295 @@ int VoxtralRealtimeRunner::transcribe(
   }
 
   return num_generated;
+}
+
+// ---------------------------------------------------------------------------
+// StreamingSession
+// ---------------------------------------------------------------------------
+
+std::unique_ptr<StreamingSession>
+VoxtralRealtimeRunner::create_streaming_session(
+    const TranscribeConfig& config,
+    TokenCallback token_cb) {
+  ET_CHECK_MSG(is_streaming_, "Model was not exported with --streaming.");
+  ET_CHECK_MSG(
+      preprocessor_ != nullptr,
+      "No preprocessor loaded. Provide --preprocessor_path.");
+  return std::make_unique<StreamingSession>(*this, config, std::move(token_cb));
+}
+
+StreamingSession::StreamingSession(
+    VoxtralRealtimeRunner& runner,
+    TranscribeConfig config,
+    TokenCallback token_cb)
+    : runner_(runner),
+      config_(config),
+      token_cb_(std::move(token_cb)),
+      prev_token_(runner.bos_id_),
+      sampler_(
+          static_cast<int32_t>(runner.vocab_size_),
+          config.temperature,
+          ::executorch::extension::llm::kTopp,
+          static_cast<unsigned long long>(std::time(nullptr))),
+      input_embeds_buf_(static_cast<size_t>(runner.dim_)) {
+  // Initialize conv states to zero (matches offline encoder's left-padding).
+  // num_mel_bins=128, conv1_pad_=2 → 128*2 = 256 floats
+  conv1_state_.assign(
+      static_cast<size_t>(runner.num_mel_bins_ * runner.conv1_pad_), 0.0f);
+  // enc_dim_=1280, conv2_pad_=2 → 1280*2 = 2560 floats
+  conv2_state_.assign(
+      static_cast<size_t>(runner.enc_dim_ * runner.conv2_pad_), 0.0f);
+}
+
+int StreamingSession::feed_audio(const float* data, int64_t num_samples) {
+  audio_buf_.insert(audio_buf_.end(), data, data + num_samples);
+
+  int new_tokens = 0;
+  while (!eos_reached_ && try_process_step()) {
+    new_tokens++;
+  }
+
+  // Trim consumed audio to bound memory growth. Keep stft_left_overlap_
+  // samples before samples_consumed_ for the next step's left context.
+  int64_t keep_from = samples_consumed_ - runner_.stft_left_overlap_;
+  if (keep_from > 0) {
+    audio_buf_.erase(
+        audio_buf_.begin(),
+        audio_buf_.begin() + static_cast<size_t>(keep_from));
+    samples_consumed_ -= keep_from;
+  }
+
+  return new_tokens;
+}
+
+bool StreamingSession::try_process_step() {
+  const int64_t step = runner_.step_samples_;
+  const int64_t left_overlap = runner_.stft_left_overlap_;
+  const int64_t right_lookahead = runner_.stft_right_lookahead_;
+  const int64_t mel_skip = runner_.mel_skip_frames_;
+  const int64_t chunk_mel_len = runner_.chunk_mel_len_;
+
+  // Need enough audio for: current step + right look-ahead.
+  // Left overlap comes from audio before samples_consumed_ (already in buffer).
+  const int64_t need_end = samples_consumed_ + step + right_lookahead;
+  if (static_cast<int64_t>(audio_buf_.size()) < need_end) {
+    return false;
+  }
+
+  // Guard: encoder/decoder cache capacity.
+  const int64_t enc_frames_per_chunk = chunk_mel_len / 2;
+  if (enc_frame_pos_ + enc_frames_per_chunk > runner_.max_enc_len_ ||
+      dec_pos_ >= runner_.max_seq_len_) {
+    return false;
+  }
+
+  // --- Build the overlapping audio window ---
+  // Window: [left_overlap] + [step (1280)] + [right_lookahead (40)] = 1640
+  // samples For the first step (samples_consumed_=0), left side is zero-padded.
+  const int64_t window_size = left_overlap + step + right_lookahead;
+  std::vector<float> window_buf(static_cast<size_t>(window_size), 0.0f);
+
+  // Left overlap: copy from audio_buf_ before samples_consumed_
+  int64_t left_start = samples_consumed_ - left_overlap;
+  if (left_start >= 0) {
+    std::memcpy(
+        window_buf.data(),
+        audio_buf_.data() + left_start,
+        static_cast<size_t>(left_overlap) * sizeof(float));
+  } else {
+    // Partial left overlap (first step): zero-pad then copy available
+    int64_t available_left = samples_consumed_;
+    int64_t zero_pad = left_overlap - available_left;
+    // window_buf[0..zero_pad) is already 0.0f
+    if (available_left > 0) {
+      std::memcpy(
+          window_buf.data() + zero_pad,
+          audio_buf_.data(),
+          static_cast<size_t>(available_left) * sizeof(float));
+    }
+  }
+
+  // Step + right look-ahead
+  std::memcpy(
+      window_buf.data() + left_overlap,
+      audio_buf_.data() + samples_consumed_,
+      static_cast<size_t>(step + right_lookahead) * sizeof(float));
+
+  // --- Compute mel spectrogram on the full window ---
+  auto audio_tensor = from_blob(
+      window_buf.data(),
+      {static_cast<int>(window_size)},
+      ::executorch::aten::ScalarType::Float);
+
+  auto mel_result = runner_.preprocessor_->execute(
+      "forward", std::vector<EValue>{*audio_tensor});
+  ET_CHECK_MSG(mel_result.ok(), "Streaming preprocessor failed.");
+
+  auto mel = mel_result.get()[0].toTensor();
+  // mel shape: (1, 128, 10) — 10 frames from 1640 samples with center=True
+  const int64_t num_mel_bins = mel.size(1);
+  const int64_t total_mel_frames = mel.size(2);
+
+  ET_CHECK_MSG(
+      total_mel_frames >= mel_skip + chunk_mel_len,
+      "Preprocessor produced fewer mel frames than expected.");
+
+  // --- Extract frames [mel_skip, mel_skip+8) = frames 2-9 ---
+  // These align exactly with the offline mel frames for this step.
+  // Output layout is channels-first: (1, 128, T). For each channel,
+  // copy 8 contiguous frames starting at offset mel_skip.
+  std::vector<float> mel_chunk_buf(
+      static_cast<size_t>(num_mel_bins * chunk_mel_len));
+  const float* mel_data = mel.const_data_ptr<float>();
+  for (int64_t c = 0; c < num_mel_bins; c++) {
+    std::memcpy(
+        mel_chunk_buf.data() + c * chunk_mel_len,
+        mel_data + c * total_mel_frames + mel_skip,
+        static_cast<size_t>(chunk_mel_len) * sizeof(float));
+  }
+
+  auto mel_chunk = from_blob(
+      mel_chunk_buf.data(),
+      {1, static_cast<int>(num_mel_bins), static_cast<int>(chunk_mel_len)},
+      ::executorch::aten::ScalarType::Float);
+
+  auto conv1_state = from_blob(
+      conv1_state_.data(),
+      {1, static_cast<int>(num_mel_bins), static_cast<int>(runner_.conv1_pad_)},
+      ::executorch::aten::ScalarType::Float);
+
+  auto conv2_state = from_blob(
+      conv2_state_.data(),
+      {1,
+       static_cast<int>(runner_.enc_dim_),
+       static_cast<int>(runner_.conv2_pad_)},
+      ::executorch::aten::ScalarType::Float);
+
+  std::vector<int64_t> enc_pos_data(static_cast<size_t>(enc_frames_per_chunk));
+  for (int64_t i = 0; i < enc_frames_per_chunk; i++) {
+    enc_pos_data[static_cast<size_t>(i)] = enc_frame_pos_ + i;
+  }
+  auto enc_pos = from_blob(
+      enc_pos_data.data(),
+      {static_cast<int>(enc_frames_per_chunk)},
+      ::executorch::aten::ScalarType::Long);
+
+  // --- Run streaming encoder ---
+  auto enc_result = runner_.model_->execute(
+      "encode_audio_chunk",
+      std::vector<EValue>{*mel_chunk, *conv1_state, *conv2_state, *enc_pos});
+  ET_CHECK_MSG(enc_result.ok(), "encode_audio_chunk failed.");
+
+  auto& enc_outputs = enc_result.get();
+  auto audio_embeds = enc_outputs[0].toTensor();
+  auto new_conv1 = enc_outputs[1].toTensor();
+  auto new_conv2 = enc_outputs[2].toTensor();
+
+  std::memcpy(
+      conv1_state_.data(),
+      new_conv1.const_data_ptr<float>(),
+      conv1_state_.size() * sizeof(float));
+  std::memcpy(
+      conv2_state_.data(),
+      new_conv2.const_data_ptr<float>(),
+      conv2_state_.size() * sizeof(float));
+  enc_frame_pos_ += enc_frames_per_chunk;
+  samples_consumed_ += step;
+
+  // --- Decode one step ---
+  return decode_step(audio_embeds.const_data_ptr<float>());
+}
+
+bool StreamingSession::decode_step(const float* audio_embeds) {
+  // Token embedding for previous token.
+  int64_t token_id = static_cast<int64_t>(prev_token_);
+  auto token_tensor =
+      from_blob(&token_id, {1, 1}, ::executorch::aten::ScalarType::Long);
+
+  auto tok_result = runner_.model_->execute(
+      "token_embedding", std::vector<EValue>{*token_tensor});
+  ET_CHECK_MSG(tok_result.ok(), "token_embedding failed.");
+  auto tok_embed = tok_result.get()[0].toTensor();
+  const float* tok_data = tok_embed.const_data_ptr<float>();
+
+  // Sum audio + token embeddings (or token-only if audio_embeds is null).
+  if (audio_embeds != nullptr) {
+    for (int64_t i = 0; i < runner_.dim_; i++) {
+      input_embeds_buf_[static_cast<size_t>(i)] = audio_embeds[i] + tok_data[i];
+    }
+  } else {
+    std::memcpy(
+        input_embeds_buf_.data(),
+        tok_data,
+        static_cast<size_t>(runner_.dim_) * sizeof(float));
+  }
+
+  auto input_embeds = from_blob(
+      input_embeds_buf_.data(),
+      {1, 1, static_cast<int>(runner_.dim_)},
+      ::executorch::aten::ScalarType::Float);
+
+  auto cache_pos =
+      from_blob(&dec_pos_, {1}, ::executorch::aten::ScalarType::Long);
+
+  auto dec_result = runner_.model_->execute(
+      "text_decoder", std::vector<EValue>{*input_embeds, *cache_pos});
+  ET_CHECK_MSG(dec_result.ok(), "text_decoder failed.");
+
+  auto logits = dec_result.get()[0].toTensor();
+  float* logits_data =
+      logits.mutable_data_ptr<float>() + (logits.numel() - runner_.vocab_size_);
+  int64_t next_token = static_cast<int64_t>(sampler_.sample(logits_data));
+  num_generated_++;
+
+  auto piece = runner_.tokenizer_->decode(
+      prev_token_, static_cast<uint64_t>(next_token));
+  if (piece.ok()) {
+    token_cb_(*piece);
+  }
+
+  if (static_cast<uint64_t>(next_token) == runner_.eos_id_) {
+    eos_reached_ = true;
+    return true;
+  }
+
+  prev_token_ = static_cast<uint64_t>(next_token);
+  dec_pos_++;
+  return true;
+}
+
+int StreamingSession::flush() {
+  if (flushed_) {
+    return num_generated_;
+  }
+  flushed_ = true;
+
+  // Pad with silence so any remaining audio (including partial steps and
+  // the right look-ahead for the last complete step) can be processed.
+  const int64_t remaining =
+      static_cast<int64_t>(audio_buf_.size()) - samples_consumed_;
+  if (remaining > 0 && !eos_reached_) {
+    const int64_t step = runner_.step_samples_;
+    const int64_t right_lookahead = runner_.stft_right_lookahead_;
+    // Pad to next full step + right look-ahead
+    int64_t pad_to = ((remaining + step - 1) / step) * step + right_lookahead;
+    std::vector<float> silence(static_cast<size_t>(pad_to - remaining), 0.0f);
+    audio_buf_.insert(audio_buf_.end(), silence.begin(), silence.end());
+
+    while (!eos_reached_ && try_process_step()) {
+    }
+  }
+
+  // Text-only decoding after audio ends.
+  const int64_t max_text_steps = std::min(
+      static_cast<int64_t>(config_.max_new_tokens) - num_generated_,
+      runner_.max_seq_len_ - dec_pos_);
+
+  for (int64_t i = 0; i < max_text_steps && !eos_reached_; i++) {
+    decode_step(nullptr);
+  }
+
+  return num_generated_;
 }
 
 } // namespace voxtral_realtime


### PR DESCRIPTION
Follow-up to https://github.com/pytorch/executorch/pull/17431

Enable Voxtral Realtime streaming on XNNPACK
Adds true streaming support for the Voxtral-Mini-4B-Realtime-2602 model,
enabling real-time transcription from live audio input.

Key components:
- StreamingAudioEncoderExport: encoder with KV-cached attention and conv
  state for chunk-by-chunk processing (8 mel frames = 80ms per step)
- StreamingSession C++ API (feed_audio/flush) for incremental audio input
- Streaming mel preprocessor (WhisperAudioProcessor with --streaming flag)
- STFT overlap windowing (320 left + 40 right) for correct mel at chunk
  boundaries
- Per-component quantization (--qlinear-encoder / --qlinear / --qembedding)

Test Plan: 

https://github.com/pytorch/executorch/actions/runs/21993469202/job/63546903665?pr=17440