### PR TITLE
Default to using edge_program state dict if quantization data not available

### DIFF
--- a/backends/nxp/backend/edge_program_converter.py
+++ b/backends/nxp/backend/edge_program_converter.py
@@ -208,8 +208,12 @@ class EdgeProgramToIRConverter:
                         result_map[input_spec.arg.name] = param
 
                     else:
-                        # There is no data available.
-                        continue
+                        logger.w(
+                            f"No real or post-quantization data found for '{input_spec.target}'. "
+                            f"Using a FakeTensor."
+                        )
+                        param = edge_program.state_dict[input_spec.target]
+                        result_map[input_spec.arg.name] = param
 
         return result_map
 

--- a/backends/nxp/tests/executorch_pipeline.py
+++ b/backends/nxp/tests/executorch_pipeline.py
@@ -98,6 +98,7 @@ def to_quantized_edge_program(
     custom_delegation_options=CustomDelegationOptions(),  # noqa B008
     get_quantizer_fn=None,
     use_neutron_for_format_conversion=True,
+    use_quant_state_dict=True,
 ) -> EdgeProgramManager:
     _neutron_target_spec = NeutronTargetSpec(target, neutron_converter_flavor)
     if get_quantizer_fn is None:
@@ -128,12 +129,15 @@ def to_quantized_edge_program(
         neutron_converter_flavor=neutron_converter_flavor,
         use_neutron_for_format_conversion=use_neutron_for_format_conversion,
     )
+    post_quant_state_dict = (
+        exir_program_aten__module_quant.state_dict() if use_quant_state_dict else None
+    )
     partitioners = [
         NeutronPartitioner(
             compile_spec,
             _neutron_target_spec,
             custom_delegation_options,
-            exir_program_aten__module_quant.state_dict(),
+            post_quant_state_dict,
             preserve_ops=preserve_ops,
         )
     ]


### PR DESCRIPTION
Summary:
PR #16901 added logic to replace FakeTensors with actually quantization data.

The docstring says:

```
        :param post_quantization_state_dict: State-dict of the model right after quantization. During partitioning, the
                                              `edge_program` only contains fake tensors without any data. In this case,
                                              this state dict is used instead (if provided). Notice: It may potentially
                                              contain outdated data,
```

with the key part being **if provided**.  However, this is not the actual functionality.

By not falling back, this introduces a regression for depthwise convolutions, which have a "no dynamic" constraint that is triggered by this missing information.

This PR restores the original behavior if quantization data is not provided.

Differential Revision: D93253828




cc @robert-kalmar @digantdesai