### PR TITLE
Fix out-of-bounds write in Cadence HiFi bmm bias buffer initialization

### DIFF
--- a/backends/cadence/hifi/operators/op_bmm.cpp
+++ b/backends/cadence/hifi/operators/op_bmm.cpp
@@ -78,11 +78,11 @@ Tensor& bmm_out(
 
     WORD32* __restrict__ tmp =
         (WORD32* __restrict__)kernels::allocate_temp_memory(
-            ctx, (batch_size * m * p) * sizeof(float));
+            ctx, (batch_size * m * p) * sizeof(FLOAT32));
 
     ET_KERNEL_CHECK(ctx, tmp != nullptr, MemoryAllocationFailed, out);
 
-    tmp[batch_size * m * p] = {0};
+    memset(tmp, 0, batch_size * m * p * sizeof(FLOAT32));
 
     WORD32* __restrict__ p_o =
         (WORD32* __restrict__)kernels::allocate_temp_memory(


### PR DESCRIPTION
### Summary
The temporary zero-bias buffer for xa_nn_matmul_f32xf32_f32 was being "initialized" by writing a single zero one element past the end of the allocation (`tmp[batch_size * m * p] = {0}`). Replace with memset to correctly zero the entire buffer, and use sizeof(FLOAT32) consistently.

This diff was authored with the help of Claude.

### Test plan
CI