### PR TITLE
Add ARM CMSIS project template references to documentation

### DIFF
--- a/docs/source/backends/arm-ethos-u/tutorials/ethos-u-getting-started.md
+++ b/docs/source/backends/arm-ethos-u/tutorials/ethos-u-getting-started.md
@@ -202,6 +202,14 @@ To learn more, check out these learning paths:
 https://learn.arm.com/learning-paths/embedded-and-microcontrollers/rpi-llama3/
 https://learn.arm.com/learning-paths/embedded-and-microcontrollers/visualizing-ethos-u-performance/
 
+### Project Templates
+
+These project templates provide alternative starting points for ExecuTorch development:
+
+- [CMSIS-Executorch Project Template](https://github.com/Arm-Examples/cmsis-executorch) — Docker-based build environment with Keil Studio/VS Code integration for Arm Ethos-U applications, featuring automated CI/CD and AVH-SSE-300 simulation support.
+
+- [ExecuTorch on Zephyr RTOS with CMSIS](https://github.com/Arm-Examples/cmsis-zephyr-executorch) — Complete example of running ExecuTorch inference on Arm Cortex-M with Ethos-U NPU acceleration using Zephyr RTOS and CMSIS Toolbox.
+
 ## FAQs
 
 If you encountered any bugs or issues following this tutorial please file a bug/issue here on [Github](https://github.com/pytorch/executorch/issues/new).

--- a/examples/arm/README.md
+++ b/examples/arm/README.md
@@ -151,3 +151,11 @@ $ ./examples/arm/run.sh --model_name=mv2 --target=ethos-u55-128 --no_delegate
 We also have a [tutorial](https://pytorch.org/executorch/stable/backends-arm-ethos-u) explaining the steps performed in these
 scripts, expected results, possible problems and more. It is a step-by-step guide
 you can follow to better understand this delegate.
+
+### Project Templates
+
+These project templates provide alternative starting points with different toolchains and build systems:
+
+- [CMSIS-Executorch Project Template](https://github.com/Arm-Examples/cmsis-executorch) — Docker-based build environment with Keil Studio/VS Code integration, automated CI/CD, and AVH simulation support.
+
+- [ExecuTorch on Zephyr RTOS with CMSIS](https://github.com/Arm-Examples/cmsis-zephyr-executorch) — ExecuTorch on Arm Cortex-M with Ethos-U NPU using Zephyr RTOS and CMSIS Toolbox.

--- a/zephyr/README.md
+++ b/zephyr/README.md
@@ -233,3 +233,7 @@ Do not remove this file. As mentioned in the official Zephyr [documenation](http
 # Reference
 
 <a href="https://docs.pytorch.org/executorch">Documentation</a>
+
+## Related Projects
+
+- [ExecuTorch on Zephyr RTOS with CMSIS](https://github.com/Arm-Examples/cmsis-zephyr-executorch) — An alternative project structure demonstrating ExecuTorch on Zephyr using CMSIS Toolbox for build management.


### PR DESCRIPTION
### Summary

Link to Arm-Examples/cmsis-executorch and Arm-Examples/cmsis-zephyr-executorch repositories, which provide alternative project structures for deploying ExecuTorch on ARM embedded systems with CMSIS tooling.


cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai