### PR TITLE
Add cortex_m visibility to portable kernel utilities

### DIFF
--- a/kernels/portable/cpu/util/targets.bzl
+++ b/kernels/portable/cpu/util/targets.bzl
@@ -155,7 +155,7 @@ def define_common_targets():
         deps = [
             "//executorch/runtime/kernel:kernel_includes",
         ],
-        visibility = ["//executorch/kernels/portable/cpu/...", "//executorch/kernels/optimized/cpu/..."],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_library(
@@ -168,7 +168,10 @@ def define_common_targets():
         deps = [
             "//executorch/runtime/kernel:kernel_includes",
         ],
-        visibility = ["//executorch/kernels/portable/cpu/...", "//executorch/kernels/optimized/cpu/..."],
+        visibility = [
+            "//executorch/kernels/portable/cpu/...",
+            "//executorch/kernels/optimized/cpu/...",
+        ],
     )
 
     runtime.cxx_library(
@@ -181,7 +184,7 @@ def define_common_targets():
         deps = [
             "//executorch/runtime/kernel:kernel_includes",
         ],
-        visibility = ["//executorch/kernels/portable/cpu/...", "//executorch/kernels/optimized/cpu/..."],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_library(
@@ -195,7 +198,10 @@ def define_common_targets():
             ":broadcast_util",
             "//executorch/runtime/kernel:kernel_includes",
         ],
-        visibility = ["//executorch/kernels/portable/cpu/...", "//executorch/kernels/optimized/cpu/..."],
+        visibility = [
+            "//executorch/kernels/portable/cpu/...",
+            "//executorch/kernels/optimized/cpu/...",
+        ],
     )
 
     runtime.cxx_library(
@@ -208,7 +214,7 @@ def define_common_targets():
         deps = [
             "//executorch/runtime/kernel:kernel_includes",
         ],
-        visibility = ["//executorch/kernels/portable/cpu/...", "//executorch/kernels/optimized/cpu/..."],
+        visibility = ["PUBLIC"],
     )
 
     runtime.cxx_library(
@@ -221,7 +227,10 @@ def define_common_targets():
         deps = [
             "//executorch/runtime/kernel:kernel_includes",
         ],
-        visibility = ["//executorch/kernels/portable/cpu/...", "//executorch/kernels/optimized/cpu/..."],
+        visibility = [
+            "//executorch/kernels/portable/cpu/...",
+            "//executorch/kernels/optimized/cpu/...",
+        ],
     )
 
     runtime.cxx_library(


### PR DESCRIPTION
Summary:
Add cortex_m backends to visibility for kernel utilities that cortex_m operators depend on:
- copy_ops_util
- kernel_ops_util
- padding_util

This enables cortex_m operators to import these utilities when building for ARM embedded platforms.

Differential Revision: D93254993


