### PR TITLE
Add ARM embedded platform compatibility to all operators

### DIFF
--- a/backends/cortex_m/ops/targets.bzl
+++ b/backends/cortex_m/ops/targets.bzl
@@ -9,22 +9,66 @@ load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 load("@fbsource//xplat/executorch/codegen:codegen.bzl", "et_operator_library", "executorch_generated_lib")
 load("@fbcode_macros//build_defs:export_files.bzl", "export_file")
 
+_ARM_EMBEDDED_PLATFORMS = ["ovr_config//cpu:arm32-embedded", "ovr_config//cpu:arm32-embedded-fpu"]
+
+# Operators that compile without CMSIS-NN (portable scalar + optional Helium/MVE).
+# These can be built and tested on any platform (including x86_64 CI).
+_PORTABLE_OPERATORS = [
+    "quantize_per_tensor",
+    "dequantize_per_tensor",
+]
+
+
 def define_operator_target(name: str):
+    needs_cmsis = name not in _PORTABLE_OPERATORS
+
+    cmsis_deps = [
+        "//executorch/kernels/portable/cpu:scalar_utils",
+        "//executorch/kernels/portable/cpu/util:broadcast_util",
+        "//executorch/kernels/portable/cpu/util:elementwise_util",
+        "//executorch/kernels/portable/cpu/util:kernel_ops_util",
+        "//executorch/kernels/portable/cpu/util:copy_ops_util",
+        "//executorch/kernels/portable/cpu/util:padding_util",
+        "fbsource//third-party/cmsis-nn:cmsis_header",
+        "fbsource//third-party/cmsis-nn:cmsis_nn",
+    ] if needs_cmsis else []
+
+    cmsis_headers = ["cortex_m_ops_common.h"] if needs_cmsis else []
+
+    _compat_kwargs = {}
+    if needs_cmsis:
+        _compat_kwargs["compatible_with"] = _ARM_EMBEDDED_PLATFORMS
+
     runtime.cxx_library(
         name = "op_{}".format(name),
         srcs = [
             "op_{}.cpp".format(name),
         ],
+        headers = cmsis_headers,
         platforms = CXX,
         deps = [
-            "//executorch/runtime/kernel:kernel_includes"
-        ],
+            "//executorch/runtime/kernel:kernel_includes",
+        ] + cmsis_deps,
         link_whole = True,
+        **_compat_kwargs
     )
 
 OPERATORS = [
     "quantize_per_tensor",
     "dequantize_per_tensor",
+    "quantized_add",
+    "quantized_mul",
+    "minimum",
+    "maximum",
+    "quantized_linear",
+    "softmax",
+    "transpose",
+    "pad",
+    "quantized_conv2d",
+    "quantized_depthwise_conv2d",
+    "quantized_transpose_conv2d",
+    "quantized_avg_pool2d",
+    "quantized_max_pool2d",
 ]
 
 def define_common_targets():
@@ -44,6 +88,7 @@ def define_common_targets():
         visibility = ["PUBLIC"],
         platforms = CXX,
         exported_deps = all_op_targets,
+        compatible_with = _ARM_EMBEDDED_PLATFORMS,
     )
 
     export_file(name = "operators.yaml")
@@ -58,18 +103,23 @@ def define_common_targets():
         name = "cortex_m_generated_lib",
         deps = [
             ":ops_lib",
+        ],
+        kernel_deps = [
             ":cortex_m_operators",
         ],
         functions_yaml_target = ":operators.yaml",
         platforms = CXX,
         visibility = ["PUBLIC"],
         define_static_targets = True,
+        compatible_with = _ARM_EMBEDDED_PLATFORMS,
     )
 
     executorch_generated_lib(
         name = "cortex_m_no_except_generated_lib",
         deps = [
             ":ops_lib",
+        ],
+        kernel_deps = [
             ":cortex_m_operators",
         ],
         functions_yaml_target = ":operators.yaml",
@@ -77,4 +127,5 @@ def define_common_targets():
         visibility = ["PUBLIC"],
         define_static_targets = True,
         support_exceptions = False,
+        compatible_with = _ARM_EMBEDDED_PLATFORMS,
     )

--- a/shim_et/xplat/executorch/codegen/codegen.bzl
+++ b/shim_et/xplat/executorch/codegen/codegen.bzl
@@ -820,6 +820,7 @@ def executorch_generated_lib(
         kernel_deps = [],
         dtype_selective_build = False,
         feature = None,
+        compatible_with = None,
         expose_operator_symbols = False,
         support_exceptions = True,
         include_all_prim_ops = True):
@@ -883,10 +884,19 @@ def executorch_generated_lib(
         support_exceptions: enable try/catch wrapper around operator implementations
             to make sure exceptions thrown will not bring down the process. Disable if your
             use case disables exceptions in the build.
+        compatible_with: An optional list of platform constraints (e.g.
+            ["ovr_config//cpu:arm32-embedded"]). When set, the constraint is
+            applied to the compiled registration library (`<name>`) but NOT to
+            the header-only library (`<name>_headers`), so that host-side
+            consumers such as unit tests can still depend on the headers.
         include_all_prim_ops: If true, include all prim ops in the generated library. This option
             allows for selecting only some prim ops to reduce code size for extremely constrained
             environments. For selecting only some prim ops, see examples in //executorch/examples/selective_build
     """
+    _compat_kwargs = {}
+    if compatible_with != None:
+        _compat_kwargs["compatible_with"] = compatible_with
+
     if functions_yaml_target and aten_mode:
         fail("{} is providing functions_yaml_target in ATen mode, it will be ignored. `native_functions.yaml` will be the source of truth.".format(name))
 
@@ -1046,6 +1056,9 @@ def executorch_generated_lib(
                 "//executorch/runtime/core/exec_aten/util:tensor_util" + aten_suffix,
             ],
             feature = feature,
+            # Note: compatible_with is intentionally NOT applied to the
+            # headers-only target so that host-side consumers (e.g. unit tests
+            # on x86_64) can still depend on the generated headers.
         )
 
     if name in libs:
@@ -1098,6 +1111,7 @@ def executorch_generated_lib(
             _is_external_target = True,
             platforms = platforms,
             feature = feature,
+            **_compat_kwargs
         )
 
     if custom_ops_yaml_target and custom_ops_requires_aot_registration:


### PR DESCRIPTION
Summary:
Enable cortex_m operators to build for ARM embedded platforms (FVP simulation, on-device execution).

Changes:
1. Added _ARM_EMBEDDED_PLATFORMS constant for ARM32 embedded targets
2. Added compatible_with = _ARM_EMBEDDED_PLATFORMS to operator definitions
3. Expanded OPERATORS list to include all 15 cortex_m operators (matching operators.yaml)

This requires the visibility fix in portable kernel utilities (parent diff) to allow
cortex_m operators to depend on kernel_ops_util, copy_ops_util, and padding_util.

Differential Revision: D93254992




cc @digantdesai @SS-JIA @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell