### PR TITLE
Fix ForceChannelLastForConvPass for nhwc depthwise convolutions

### DIFF
--- a/backends/cadence/aot/ref_implementations.py
+++ b/backends/cadence/aot/ref_implementations.py
@@ -1112,9 +1112,16 @@ def quantized_conv2d_nhwc_per_tensor(
         weight = weight.movedim(-1, 1).contiguous()
     else:
         input_tensor = input_tensor.movedim(-1, -3)
-        if len(weight.shape) != 4:
-            raise ValueError("Weight tensor must be 4D if input is nd > 3")
-        weight = torch.permute(weight, (0, -1, 1, 2)).contiguous()
+        if len(weight.shape) == 3:
+            # Depthwise convolution: weight shape is [KH, KW, OC]
+            # Transform to [OC, 1, KH, KW] for NCHW conv
+            weight = weight.permute(2, 0, 1).unsqueeze(1).contiguous()
+        elif len(weight.shape) == 4:
+            weight = torch.permute(weight, (0, -1, 1, 2)).contiguous()
+        else:
+            raise ValueError(
+                f"Weight tensor must be 3D or 4D if input is nd > 3, got {len(weight.shape)}D"
+            )
 
     nchw_out = quantized_conv_per_tensor(
         input_tensor,

--- a/backends/cadence/hifi/operators/op_quantized_conv2d_nhwc_out.cpp
+++ b/backends/cadence/hifi/operators/op_quantized_conv2d_nhwc_out.cpp
@@ -307,18 +307,10 @@ void xa_opt_quantized_conv2d_nhwc(
 
       p_scratch = (pVOID)ALIGN_PTR(ptr_scratch, 8);
 
-      WORD8* ptr1 = (WORD8*)kernels::allocate_temp_memory(
-          ctx,
-          ((batches * out_channels * out_height * out_width) + 8) *
-              sizeof(WORD8));
-
-      WORD8* p_out_temp = (WORD8*)ALIGN_PTR(ptr1, 8);
-
       for (int _n = 0; _n < batches; _n++) {
         WORD8* in_batch =
             p_inp + _n * input_channels * input_height * input_width;
-        WORD8* out_batch =
-            p_out_temp + _n * out_channels * out_height * out_width;
+        WORD8* out_batch = p_out + _n * out_channels * out_height * out_width;
 
         xa_nn_conv2d_depthwise_per_chan_sym8sxasym8s(
             out_batch,


### PR DESCRIPTION
Summary: As titled. The current pass doesn't handle the depthwise weights with the right shape, leading to numerical errors. Add a test to catch that as well.

Reviewed By: DrJessop

Differential Revision: D93188974


