### PR TITLE
[ET-VK] Use direct buffer-to-image copy for 1D tensor prepacking

### DIFF
--- a/backends/vulkan/runtime/vk_api/Command.h
+++ b/backends/vulkan/runtime/vk_api/Command.h
@@ -94,6 +94,11 @@ class CommandBuffer final {
   void insert_barrier(PipelineBarrier& pipeline_barrier);
   void dispatch(const utils::uvec3&);
   void blit(vkapi::VulkanImage& src, vkapi::VulkanImage& dst);
+  void copy_buffer_to_image(
+      vkapi::VulkanBuffer& src,
+      vkapi::VulkanImage& dst,
+      const VkBufferImageCopy& region,
+      VkImageLayout dst_final_layout);
 
   void write_timestamp(VkQueryPool, const uint32_t) const;
   void reset_querypool(VkQueryPool, const uint32_t, const uint32_t) const;

--- a/backends/vulkan/runtime/vk_api/memory/Allocator.cpp
+++ b/backends/vulkan/runtime/vk_api/memory/Allocator.cpp
@@ -144,7 +144,12 @@ VulkanImage Allocator::create_image(
 VulkanBuffer Allocator::create_staging_buffer(
     const VkDeviceSize size,
     const CopyDirection direction) {
-  const VkBufferUsageFlags buffer_usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
+  // TRANSFER_SRC allows staging buffers to be used as source for
+  // vkCmdCopyBufferToImage, needed for direct buffer-to-image copies
+  // (e.g., 1D tensor prepacking where compute shader coordinate remapping
+  // would produce incorrect results on some GPUs).
+  const VkBufferUsageFlags buffer_usage =
+      VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
 
   VmaAllocationCreateInfo alloc_create_info = {};
   alloc_create_info.flags =


### PR DESCRIPTION
## Summary

Fixes 1D tensor prepacking (e.g., conv2d bias) producing incorrect results on GPUs with strict texture bounds checking (PowerVR).

The `nchw_to_image` compute shader uses `axis_map` coordinate remapping designed for multi-dimensional tensors. For 1D tensors padded to 4D with three fake dimensions of size 1, the coordinate math produces out-of-bounds texture writes. PowerVR GPUs silently drop these writes, so bias values never reach the texture. Other GPUs (Adreno, Mali) wrap coordinates, masking the bug.

For 1D width-packed tensors where the element count is divisible by 4, the staging buffer data is already in the correct layout. This change bypasses the compute shader and uses `vkCmdCopyBufferToImage` to copy the data directly.

Changes:
- `PrepackNode::encode()` — detect 1D width-packed tensors and use direct copy path
- `CommandBuffer::copy_buffer_to_image()` — new helper for buffer-to-image DMA with post-copy barrier
- `Allocator::create_staging_buffer()` — add `TRANSFER_SRC` to staging buffer usage flags (harmless for existing paths, enables direct copy)

Related: #17299

## Test plan

- [ ] Tested on Pixel 10 Pro (PowerVR DXT-48-1536) — conv2d bias values now reach the texture correctly
- [ ] Verified no regression on other GPUs (Adreno, Mali) since the coordinate wrapping behavior is unchanged for multi-dimensional tensors