### PR TITLE
support qwen2_5-coder

### DIFF
--- a/examples/models/llama/export_llama_lib.py
+++ b/examples/models/llama/export_llama_lib.py
@@ -99,6 +99,7 @@ EXECUTORCH_DEFINED_MODELS = [
     "static_llama",
     "qwen2_5_0_5b",
     "qwen2_5_1_5b",
+    "qwen2_5_coder_32b",
     "qwen3_0_6b",
     "qwen3_1_7b",
     "qwen3_4b",
@@ -112,6 +113,7 @@ TORCHTUNE_DEFINED_MODELS = ["llama3_2_vision"]
 HUGGING_FACE_REPO_IDS = {
     "qwen2_5_0_5b": "Qwen/Qwen2.5-0.5B",
     "qwen2_5_1_5b": "Qwen/Qwen2.5-1.5B",
+    "qwen2_5_coder_32b": "Qwen/Qwen2.5-Coder-32B-Instruct",
     "phi_4_mini": "microsoft/Phi-4-mini-instruct",
     "smollm2": "HuggingFaceTB/SmolLM-135M",
     "qwen3_0_6b": "Qwen/Qwen3-0.6B",

--- a/examples/models/qwen2_5/README.md
+++ b/examples/models/qwen2_5/README.md
@@ -1,5 +1,5 @@
 ## Summary
-Qwen 2.5 is the latest iteration of the Qwen series of large language models (LLMs) developed by Alibaba. At the moment, 1.5b is currently supporting, with plans in the future for adding the 0.5b and 3b versions.
+Qwen 2.5 is the latest iteration of the Qwen series of large language models (LLMs) developed by Alibaba. Supported model variations: 0.5B, 1.5B, and Coder-32B-Instruct.
 
 ## Instructions
 
@@ -8,9 +8,8 @@ Qwen 2.5 uses the same example code as Llama, while the checkpoint, model params
 All commands for exporting and running Llama on various backends should also be applicable to Qwen 2.5, by swapping the following args:
 
 ```
-base.model_class=[qwen2_5_0_5b, qwen2_5_1_5b]
-base.params=[examples/models/qwen2_5/config/0_5b_config.json, examples/models/qwen2_5/config/1_5b_config.json]
-base.checkpoint=<path-to-meta-checkpoint>
+base.model_class=[qwen2_5_0_5b, qwen2_5_1_5b, qwen2_5_coder_32b]
+base.params=[examples/models/qwen2_5/config/0_5b_config.json, examples/models/qwen2_5/config/1_5b_config.json, examples/models/qwen2_5/config/coder_32b_config.json]
 ```
 
 ### Generate the Checkpoint
@@ -25,33 +24,35 @@ python examples/models/qwen2_5/convert_weights.py <path-to-checkpoint-dir> <outp
 ```
 
 ### Example export and run
-Here is an basic example for exporting and running Qwen 2.5, although please refer to [Llama README page](../llama/README.md) for more advanced usage.
+Here is a basic example for exporting and running Qwen 2.5, although please refer to [Llama README page](../llama/README.md) for more advanced usage.
 
-Export to XNNPack, no quantization:
+Export 1.5B to XNNPack, quantized with 8da4w:
 ```
-# No quantization
-# Set these paths to point to the downloaded files
-QWEN_CHECKPOINT=path/to/checkpoint.pth
-
 python -m extension.llm.export.export_llm \
   --config examples/models/qwen2_5/config/qwen2_5_xnnpack_q8da4w.yaml \
   +base.model_class="qwen2_5_1_5b" \
-  +base.checkpoint="${QWEN_CHECKPOINT:?}" \
   +base.params="examples/models/qwen2_5/config/1_5b_config.json" \
-  +export.output_name="qwen2_5-1_5b.pte" \
+  +export.output_name="qwen2_5_1_5b.pte"
 ```
 
-Run using the executor runner:
+Export Coder-32B to XNNPack, quantized with 8da4w:
 ```
-# Currently a work in progress, just need to enable HuggingFace json tokenizer in C++.
-# In the meantime, can run with an example Python runner with pybindings:
+python -m extension.llm.export.export_llm \
+  --config examples/models/qwen2_5/config/qwen2_5_coder_xnnpack_q8da4w.yaml \
+  +base.model_class="qwen2_5_coder_32b" \
+  +base.params="examples/models/qwen2_5/config/coder_32b_config.json" \
+  +export.output_name="qwen2_5_coder_32b.pte"
+```
 
+### Example run
+With ExecuTorch pybindings:
+```
 python -m examples.models.llama.runner.native \
-  --model qwen2_5 \
-  --pte <path-to-pte> \
+  --model qwen2_5_1_5b \
+  --pte qwen2_5_1_5b.pte \
   -kv \
   --tokenizer <path-to-tokenizer>/tokenizer.json \
-  --tokenizer_config <path-to_tokenizer>/tokenizer_config.json \
+  --tokenizer_config <path-to-tokenizer>/tokenizer_config.json \
   --prompt "Who is the founder of Meta?" \
   --params examples/models/qwen2_5/config/1_5b_config.json \
   --max_len 64 \

--- a/examples/models/qwen2_5/config/coder_32b_config.json
+++ b/examples/models/qwen2_5/config/coder_32b_config.json
@@ -1,0 +1,15 @@
+{
+  "dim": 5120,
+  "ffn_dim_multiplier": 1,
+  "hidden_dim": 27648,
+  "n_heads": 40,
+  "head_dim": 128,
+  "n_kv_heads": 8,
+  "n_layers": 64,
+  "norm_eps": 1e-06,
+  "rope_theta": 1000000.0,
+  "use_scaled_rope": false,
+  "vocab_size": 152064,
+  "use_hf_rope": true,
+  "attention_qkv_bias": true
+}

--- a/examples/models/qwen2_5/config/qwen2_5_coder_xnnpack_q8da4w.yaml
+++ b/examples/models/qwen2_5/config/qwen2_5_coder_xnnpack_q8da4w.yaml
@@ -1,0 +1,20 @@
+base:
+  metadata: '{"get_bos_id": 151643, "get_eos_ids":[151645]}'
+
+model:
+  use_kv_cache: True
+  use_sdpa_with_kv_cache: True
+  dtype_override: fp32
+
+quantization:
+  qmode: 8da4w
+  embedding_quantize: 8,0
+
+export:
+  max_seq_length: 2048
+  max_context_length: 2048
+
+backend:
+  xnnpack:
+    enabled: True
+    extended_ops: True

--- a/examples/models/qwen2_5/config/qwen2_5_coder_xnnpack_q8da4w.yaml
+++ b/examples/models/qwen2_5/config/qwen2_5_coder_xnnpack_q8da4w.yaml
@@ -1,5 +1,5 @@
 base:
-  metadata: '{"get_bos_id": 151643, "get_eos_ids":[151645]}'
+  metadata='{"get_bos_id": 151643, "get_eos_ids":[151645]}'
 
 model:
   use_kv_cache: True

--- a/examples/models/qwen2_5/convert_weights.py
+++ b/examples/models/qwen2_5/convert_weights.py
@@ -1,71 +1,86 @@
 import argparse
+import json
+import os
 from typing import Dict
 
 import torch
-
+from safetensors.torch import load_file
 from torchtune.models.convert_weights import get_mapped_key
 
-from torchtune.training import FullModelHFCheckpointer
-
-# Standard _FROM_META weight mapping of Meta weights to TorchTune + additional bias weight mappings.
-_QWEN_2_FROM_META = {
-    "tok_embeddings.weight": "tok_embeddings.weight",
-    "norm.weight": "norm.scale",
-    "layers.{}.attention.wk.weight": "layers.{}.attn.k_proj.weight",
-    "layers.{}.attention.wk.bias": "layers.{}.attn.k_proj.bias",
-    "layers.{}.attention.wq.weight": "layers.{}.attn.q_proj.weight",
-    "layers.{}.attention.wq.bias": "layers.{}.attn.q_proj.bias",
-    "layers.{}.attention.wv.weight": "layers.{}.attn.v_proj.weight",
-    "layers.{}.attention.wv.bias": "layers.{}.attn.v_proj.bias",
-    "layers.{}.attention.wo.weight": "layers.{}.attn.output_proj.weight",
-    "layers.{}.attention_norm.weight": "layers.{}.sa_norm.scale",
-    "layers.{}.ffn_norm.weight": "layers.{}.mlp_norm.scale",
-    "layers.{}.feed_forward.w1.weight": "layers.{}.mlp.w1.weight",
-    "layers.{}.feed_forward.w2.weight": "layers.{}.mlp.w2.weight",
-    "layers.{}.feed_forward.w3.weight": "layers.{}.mlp.w3.weight",
+# Weight mapping from Meta's llama_transformer format to HuggingFace Qwen2 format.
+_QWEN_2_5_FROM_META = {
+    "tok_embeddings.weight": "model.embed_tokens.weight",
+    "norm.weight": "model.norm.weight",
+    "output.weight": "lm_head.weight",
+    "layers.{}.attention.wq.weight": "model.layers.{}.self_attn.q_proj.weight",
+    "layers.{}.attention.wq.bias": "model.layers.{}.self_attn.q_proj.bias",
+    "layers.{}.attention.wk.weight": "model.layers.{}.self_attn.k_proj.weight",
+    "layers.{}.attention.wk.bias": "model.layers.{}.self_attn.k_proj.bias",
+    "layers.{}.attention.wv.weight": "model.layers.{}.self_attn.v_proj.weight",
+    "layers.{}.attention.wv.bias": "model.layers.{}.self_attn.v_proj.bias",
+    "layers.{}.attention.wo.weight": "model.layers.{}.self_attn.o_proj.weight",
+    "layers.{}.attention_norm.weight": "model.layers.{}.input_layernorm.weight",
+    "layers.{}.ffn_norm.weight": "model.layers.{}.post_attention_layernorm.weight",
+    "layers.{}.feed_forward.w1.weight": "model.layers.{}.mlp.gate_proj.weight",
+    "layers.{}.feed_forward.w2.weight": "model.layers.{}.mlp.down_proj.weight",
+    "layers.{}.feed_forward.w3.weight": "model.layers.{}.mlp.up_proj.weight",
 }
 
 
-def qwen_2_tune_to_meta(state_dict: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
-    """
-    Convert a state dict from torchtune's format to Meta's format. This function
-    doesn't handle any sharding or splitting of state dicts. It follows the
-    state_dict IN -> state_dict OUT pattern.
-
-    Args:
-        state_dict (Dict[str, torch.Tensor]): State dict in torchtune's format.
-
-    Returns:
-        Dict[str, torch.Tensor]: State dict in Meta's format.
-    """
+def qwen_2_5_hf_to_meta(
+    state_dict: Dict[str, torch.Tensor],
+) -> Dict[str, torch.Tensor]:
     converted_state_dict = {}
-    inverted_mapping_dict = {v: k for k, v in _QWEN_2_FROM_META.items()}
+    inverted_mapping_dict = {v: k for k, v in _QWEN_2_5_FROM_META.items()}
 
     for key, value in state_dict.items():
         new_key = get_mapped_key(key, inverted_mapping_dict)
         converted_state_dict[new_key] = value
 
-    # 0.5b and 1.5b models share the same weights for tok_embeddings and output embeddings, see https://github.com/QwenLM/Qwen2.5/issues/733.  # @lint-ignore
-    converted_state_dict["output.weight"] = converted_state_dict[
-        "tok_embeddings.weight"
-    ]
+    # Models with tied embeddings (e.g. 0.5B, 1.5B) don't have a separate lm_head.weight.
+    if "lm_head.weight" not in state_dict:
+        converted_state_dict["output.weight"] = converted_state_dict[
+            "tok_embeddings.weight"
+        ]
 
     return converted_state_dict
 
 
-def convert_weights(input_dir: str, output_file: str) -> None:
-    # Don't necessarily need to use TorchTune checkpointer, can just aggregate checkpoint files by ourselves.
-    checkpointer = FullModelHFCheckpointer(
-        checkpoint_dir=input_dir,
-        checkpoint_files=["model.safetensors"],
-        output_dir=".",
-        model_type="QWEN2",
-    )
+def load_checkpoint_from_safetensors(input_dir: str) -> Dict:
+    index_path = os.path.join(input_dir, "model.safetensors.index.json")
+    if os.path.exists(index_path):
+        # Sharded checkpoint.
+        with open(index_path, "r") as f:
+            index = json.load(f)
+        weight_map = index["weight_map"]
+        checkpoint_shards = sorted(set(weight_map.values()))
 
+        # Group weights by shard so we load each shard file only once.
+        shard_to_keys = {}
+        for weight_name, shard in weight_map.items():
+            shard_to_keys.setdefault(shard, []).append(weight_name)
+
+        merged_state_dict = {}
+        for shard in checkpoint_shards:
+            shard_data = load_file(os.path.join(input_dir, shard))
+            for weight_name in shard_to_keys[shard]:
+                merged_state_dict[weight_name] = shard_data[weight_name]
+            del shard_data
+        return merged_state_dict
+
+    # Single checkpoint.
+    model_path = os.path.join(input_dir, "model.safetensors")
+    if os.path.exists(model_path):
+        return load_file(model_path)
+
+    raise FileNotFoundError(f"Could not find safetensors checkpoint in {input_dir}")
+
+
+def convert_weights(input_dir: str, output_file: str) -> None:
     print("Loading checkpoint...")
-    sd = checkpointer.load_checkpoint()
+    sd = load_checkpoint_from_safetensors(input_dir)
     print("Converting checkpoint...")
-    sd = qwen_2_tune_to_meta(sd["model"])
+    sd = qwen_2_5_hf_to_meta(sd)
     print("Saving checkpoint...")
     torch.save(sd, output_file)
     print("Done.")
@@ -73,12 +88,12 @@ def convert_weights(input_dir: str, output_file: str) -> None:
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Convert Qwen2 weights to Meta format."
+        description="Convert Qwen2.5 weights to Meta format."
     )
     parser.add_argument(
         "input_dir",
         type=str,
-        help="Path to directory containing checkpoint files",
+        help="Path to directory containing safetensor checkpoint files.",
     )
     parser.add_argument("output", type=str, help="Path to the output checkpoint")
 

--- a/extension/llm/export/config/llm_config.py
+++ b/extension/llm/export/config/llm_config.py
@@ -40,6 +40,7 @@ class ModelType(str, Enum):
     static_llama = "static_llama"
     qwen2_5_0_5b = "qwen2_5_0_5b"
     qwen2_5_1_5b = "qwen2_5_1_5b"
+    qwen2_5_coder_32b = "qwen2_5_coder_32b"
     qwen3_0_6b = "qwen3_0_6b"
     qwen3_1_7b = "qwen3_1_7b"
     qwen3_4b = "qwen3_4b"


### PR DESCRIPTION
### Summary
Export & run qwen2.5 coder 32b

Update convert_weights to directly convert from hf to meta, instead of using torchtune utility.

TODO: remove dependency on torchtune entirely.

### Test plan
Export
```
python -m extension.llm.export.export_llm \
--config examples/models/qwen2_5/config/qwen2_5_coder_xnnpack_q8da4w.yaml \
+base.model_class="qwen2_5_coder_32b" \
+base.params="examples/models/qwen2_5/config/coder_32b_config.json" \
+export.output_name="qwen2_5_coder_32b.pte"
```
Run
```
cmake --workflow llm-release
pushd examples/models/llama 
cmake --workflow --preset llama-release
popd

cmake-out/examples/models/llama/llama_main     --model_path qwen2_5_coder_32b.pte     --tokenizer_path /data/users/lfq/qwen-coder/tokenizer.json     --prompt "<|im_start|>user\nWrite a Python function to check if a number is prime<|im_end|>\n<|im_start|>assistant\n"     --temperature 0.6     --max_new_tokens 256
```
Output
```
def is_prime(n):
    """Check if a number is prime."""
    if n <= 1:
        return False
    if n <= 3:
        return True
    if n % 2 == 0 or n % 3 == 0:
        return False
    i = 5
    while i * i <= n:
        if n % i == 0 or n % (i + 2) == 0:
            return False
        i += 6
    return True


# Example usage:
number = 29
if is_prime(number):
    print(f"{number} is a prime number.")
else:
    print(f"{number} is not a prime number.")

```