### PR TITLE
Remove unneeded include of iostream

### DIFF
--- a/kernels/portable/cpu/util/vectorized_math.h
+++ b/kernels/portable/cpu/util/vectorized_math.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  * All rights reserved.
+ * Copyright 2026 Arm Limited and/or its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
@@ -14,7 +15,6 @@
 #include <ATen/cpu/vec/vec.h>
 #endif // ET_USE_PYTORCH_HEADERS
 
-#include <iostream>
 #include <type_traits>
 
 #if defined(ET_USE_PYTORCH_HEADERS) && ET_USE_PYTORCH_HEADERS

--- a/kernels/portable/cpu/vec_ops.h
+++ b/kernels/portable/cpu/vec_ops.h
@@ -15,9 +15,7 @@
 #include <cmath>
 #include <cstdint>
 #include <cstring>
-#include <iostream>
 #include <numeric>
-#include <ostream>
 #include <type_traits>
 /**
  * @file


### PR DESCRIPTION
### Summary
iostream  was inluded but not used.
This caused a large chunk of code to get included, removing this saved about 180Kb memory on a Zephyr Cortext-M build.


cc @freddan80 @per @oscarandersson8218 @digantdesai