### PR TITLE
Arm backend: Add fp-quantized testing to TosaPipelineINT

### DIFF
--- a/backends/arm/quantizer/arm_quantizer.py
+++ b/backends/arm/quantizer/arm_quantizer.py
@@ -92,7 +92,7 @@ def get_symmetric_quantization_config(
         bias.
 
     """
-    extra_args: Dict[str, Any] = {"eps": 2**-12}
+    extra_args: Dict[str, Any] = {"eps": 2**-16}
     if is_qat:
         if is_dynamic:
             act_observer_or_fake_quant_ctr = FakeQuantize

--- a/backends/arm/test/misc/test_debug_feats.py
+++ b/backends/arm/test/misc/test_debug_feats.py
@@ -80,16 +80,17 @@ def _is_tosa_marker_in_file(tmp_file):
 def test_compare_initial_to_quantized_tosa_INT(test_data: input_t1):
     pipeline = TosaPipelineINT[input_t1](Linear(), test_data, [], [])
     pipeline.pop_stage("run_method_and_compare_outputs")
+    pipeline.pop_stage("run_method_and_compare_outputs.original_model")
 
     pipeline.run_and_compare_to_initial_model(
         frobenius_threshold=0.05, cosine_threshold=0.95
     )
 
     stage_ids = [stage.id for stage in pipeline._stages]
-    assert "run_method_and_compare_outputs" in stage_ids
+    assert "run_method_and_compare_outputs.original_model" in stage_ids
 
     export_index = pipeline.find_pos("export")
-    compare_index = pipeline.find_pos("run_method_and_compare_outputs")
+    compare_index = pipeline.find_pos("run_method_and_compare_outputs.original_model")
     assert compare_index == export_index + 1
 
     compare_stage = pipeline._stages[compare_index]

--- a/backends/arm/test/misc/test_shared_qspecs.py
+++ b/backends/arm/test/misc/test_shared_qspecs.py
@@ -467,10 +467,16 @@ class SharedQspecNoQspecs(torch.nn.Module):
     outputs_qspecs = {None: 1}
     quant_params = {
         "quantized_decomposed.dequantize_per_tensor.default": {
-            (0.000244141, -128, -128, 127, torch.int8): 2,
+            (
+                1.5259e-05,
+                -128,
+                -128,
+                127,
+                torch.int8,
+            ): 2,  # The network always has 0 output -> very small scale.
         },
         "quantized_decomposed.quantize_per_tensor.default": {
-            (0.000244141, -128, -128, 127, torch.int8): 2,
+            (1.5259e-05, -128, -128, 127, torch.int8): 2,
         },
     }
 
@@ -575,7 +581,7 @@ test_cases = {
 
 
 @parametrize("test_case", test_cases)
-def test_shared_qspec_quantizer(test_case):
+def test_shared_qspec_quantizer_no_target(test_case):
     """
     Test that ops which does not change dynamic range are able to use int8 portable kernels.
     """
@@ -608,7 +614,7 @@ float_test_cases = {
 
 
 @parametrize("test_case", float_test_cases)
-def test_shared_qspec_quantizer_no_qspecs(test_case):
+def test_shared_qspec_quantizer_no_qspecs_no_target(test_case):
     """
     Test that ops which does not change dynamic range are able to use int8 portable kernels.
     """
@@ -624,7 +630,7 @@ def test_shared_qspec_quantizer_no_qspecs(test_case):
     _check_quant_params(pipeline, test_case.model.quant_params)
 
 
-def test_maximum_mixed_int8_int16_inputs():
+def test_maximum_mixed_int8_int16_inputs_no_target():
     model = MixedMaximumInt8Int16()
     inputs = (ramp_tensor(-2, 2, (2, 3, 4)),)
 

--- a/backends/arm/test/models/stable_diffusion/test_CLIPTextModelWithProjection.py
+++ b/backends/arm/test/models/stable_diffusion/test_CLIPTextModelWithProjection.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -111,6 +111,8 @@ def test_clip_text_with_projection_tosa_INT():
             exir_op=[],
             use_to_edge_transform_and_lower=True,
             atol=0.8,
+            frobenius_threshold=None,
+            cosine_threshold=None,
         )
         pipeline.change_args(
             "check_count.exir",

--- a/backends/arm/test/models/stable_diffusion/test_SD3Transformer2DModel.py
+++ b/backends/arm/test/models/stable_diffusion/test_SD3Transformer2DModel.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -139,6 +139,8 @@ def test_sd3_transformer_tosa_INT():
             qtol=1.0,  # TODO: MLETORCH-875: Reduce tolerance of SD3Transformer2DModel with FP and INT
             rtol=1.0,
             atol=4.0,
+            frobenius_threshold=None,
+            cosine_threshold=None,
         )
         pipeline.change_args(
             "check_count.exir", TestSD3Transformer2DModel.ops_after_partitioner_INT

--- a/backends/arm/test/models/stable_diffusion/test_T5EncoderModel.py
+++ b/backends/arm/test/models/stable_diffusion/test_T5EncoderModel.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -109,6 +109,8 @@ def test_t5_encoder_tosa_INT():
             aten_op=[],
             exir_op=[],
             use_to_edge_transform_and_lower=True,
+            frobenius_threshold=None,
+            cosine_threshold=None,
         )
         pipeline.change_args(
             "check_count.exir", TestT5EncoderModel.ops_after_partitioner_INT

--- a/backends/arm/test/models/stable_diffusion/test_vae_AutoencoderKL.py
+++ b/backends/arm/test/models/stable_diffusion/test_vae_AutoencoderKL.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -79,6 +79,8 @@ def test_vae_tosa_INT():
             exir_op=[],
             use_to_edge_transform_and_lower=True,
             atol=1.0,  # TODO: MLETORCH-990 Reduce tolerance of vae(AutoencoderKL) with INT
+            frobenius_threshold=None,
+            cosine_threshold=None,
         )
         pipeline.run()
 

--- a/backends/arm/test/models/test_conformer.py
+++ b/backends/arm/test/models/test_conformer.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -74,6 +74,8 @@ def test_conformer_tosa_INT():
         use_to_edge_transform_and_lower=True,
         atol=TestConformer.atol,
         rtol=TestConformer.rtol,
+        frobenius_threshold=None,
+        cosine_threshold=None,
     )
     pipeline.run()
 

--- a/backends/arm/test/models/test_deit_tiny_arm.py
+++ b/backends/arm/test/models/test_deit_tiny_arm.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -57,6 +57,8 @@ def test_deit_tiny_tosa_INT():
         use_to_edge_transform_and_lower=True,
         atol=1.5,
         qtol=1,
+        frobenius_threshold=None,
+        cosine_threshold=None,
     )
     pipeline.run()
 

--- a/backends/arm/test/models/test_dl3_arm.py
+++ b/backends/arm/test/models/test_dl3_arm.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -51,6 +51,8 @@ def test_dl3_tosa_INT():
         TestDl3.model_example_inputs,
         aten_op=[],
         exir_op=[],
+        frobenius_threshold=None,
+        cosine_threshold=None,
     )
     pipeline.change_args(
         "run_method_and_compare_outputs", rtol=1.0, atol=1.0

--- a/backends/arm/test/models/test_inception_v3_arm.py
+++ b/backends/arm/test/models/test_inception_v3_arm.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -54,6 +54,8 @@ def test_ic3_tosa_INT():
         use_to_edge_transform_and_lower=True,
         atol=0.65,
         qtol=1,
+        frobenius_threshold=None,
+        cosine_threshold=None,
     )
     pipeline.run()
 

--- a/backends/arm/test/models/test_llama.py
+++ b/backends/arm/test/models/test_llama.py
@@ -144,6 +144,8 @@ def test_llama_tosa_INT():
             custom_path="llama_tosa_fb_int",
             run_on_tosa_ref_model=False,  # Just want to write TOSA FB to disk
             use_to_edge_transform_and_lower=True,
+            frobenius_threshold=None,
+            cosine_threshold=None,
         )
         pipeline.add_stage_after("to_executorch", pipeline.tester.serialize)
         pipeline.run()
@@ -205,6 +207,8 @@ def test_llama_tosa_INT_FP_partial_quant():
             tosa_extensions=["FP"],
             # Due to a few outliers, atol must be set high
             atol=1.1,
+            frobenius_threshold=None,
+            cosine_threshold=None,
         )
         _use_partial_quantizer(pipeline)
         pipeline.run()

--- a/backends/arm/test/models/test_lstm_arm.py
+++ b/backends/arm/test/models/test_lstm_arm.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -68,6 +68,8 @@ def test_lstm_tosa_INT():
         aten_op=[],
         exir_op=[],
         use_to_edge_transform_and_lower=True,
+        frobenius_threshold=None,
+        cosine_threshold=None,
     )
     pipeline.change_args(
         "run_method_and_compare_outputs",
@@ -151,6 +153,8 @@ def test_lstm_tosa_INT_16a8w():
         per_channel_quantization=False,
         use_to_edge_transform_and_lower=True,
         tosa_extensions=["int16"],
+        frobenius_threshold=None,
+        cosine_threshold=None,
     )
     pipeline.quantizer.set_global(
         get_symmetric_a16w8_quantization_config(is_per_channel=False, epsilon=2**-16)

--- a/backends/arm/test/models/test_mobilenet_v2_arm.py
+++ b/backends/arm/test/models/test_mobilenet_v2_arm.py
@@ -95,6 +95,8 @@ def test_mv2_tosa_INT(per_channel_quantization):
         per_channel_quantization=per_channel_quantization,
         atol=0.25,
         qtol=1,
+        frobenius_threshold=None,
+        cosine_threshold=None,
     )
     pipeline.run()
 
@@ -172,6 +174,8 @@ def test_mv2_tosa_INT_FP_partial_quant():
         tosa_extensions=["FP"],
         use_to_edge_transform_and_lower=True,
         atol=0.20,
+        frobenius_threshold=None,
+        cosine_threshold=None,
     )
     _use_partial_quantizer(pipeline)
     pipeline.run()

--- a/backends/arm/test/models/test_mobilenet_v3_arm.py
+++ b/backends/arm/test/models/test_mobilenet_v3_arm.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -50,6 +50,8 @@ def test_mv3_tosa_INT():
         use_to_edge_transform_and_lower=True,
         atol=0.5,
         qtol=1,
+        frobenius_threshold=None,
+        cosine_threshold=None,
     )
     pipeline.run()
 

--- a/backends/arm/test/models/test_nn_functional.py
+++ b/backends/arm/test/models/test_nn_functional.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -106,7 +106,12 @@ def test_nn_functional_tosa_FP(test_data):
 def test_nn_functional_tosa_INT(test_data):
     module, inputs = test_data
     pipeline = TosaPipelineINT[input_t](
-        module, inputs, "", use_to_edge_transform_and_lower=True
+        module,
+        inputs,
+        "",
+        use_to_edge_transform_and_lower=True,
+        frobenius_threshold=None,
+        cosine_threshold=None,
     )
     pipeline.pop_stage("check.aten")
     pipeline.pop_stage("check_count.exir")

--- a/backends/arm/test/models/test_nn_modules.py
+++ b/backends/arm/test/models/test_nn_modules.py
@@ -150,7 +150,14 @@ def test_nn_modules_tosa_FP(test_data):
 )
 def test_nn_modules_tosa_INT(test_data):
     module, inputs, kwargs = test_data
-    pipeline = TosaPipelineINT[input_t](module, inputs, "", **kwargs)
+    pipeline = TosaPipelineINT[input_t](
+        module,
+        inputs,
+        "",
+        frobenius_threshold=None,
+        cosine_threshold=None,
+        **kwargs,
+    )
     pipeline.pop_stage("check.aten")
     pipeline.pop_stage("check_count.exir")
     if pipeline.has_stage("check.quant_nodes"):

--- a/backends/arm/test/models/test_nss.py
+++ b/backends/arm/test/models/test_nss.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -72,6 +72,8 @@ def test_nss_tosa_INT():
         aten_op=[],
         exir_op=[],
         use_to_edge_transform_and_lower=True,
+        frobenius_threshold=None,
+        cosine_threshold=None,
     )
     pipeline.run()
 

--- a/backends/arm/test/models/test_resnet18.py
+++ b/backends/arm/test/models/test_resnet18.py
@@ -75,6 +75,8 @@ def test_resnet_18_tosa_INT(per_channel_quantization):
         per_channel_quantization=per_channel_quantization,
         atol=0.25,
         qtol=1,
+        frobenius_threshold=None,
+        cosine_threshold=None,
     )
     pipeline.run()
 

--- a/backends/arm/test/models/test_torch_functions.py
+++ b/backends/arm/test/models/test_torch_functions.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -134,7 +134,12 @@ def test_torch_functions_tosa_FP(test_data):
 def test_torch_functions_tosa_INT(test_data):
     module, inputs = test_data
     pipeline = TosaPipelineINT[input_t](
-        module, inputs, "", use_to_edge_transform_and_lower=True
+        module,
+        inputs,
+        "",
+        use_to_edge_transform_and_lower=True,
+        frobenius_threshold=None,
+        cosine_threshold=None,
     )
     pipeline.pop_stage("check.aten")
     pipeline.pop_stage("check_count.exir")

--- a/backends/arm/test/models/test_w2l_arm.py
+++ b/backends/arm/test/models/test_w2l_arm.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# Copyright 2024-2025 Arm Limited and/or its affiliates.
+# Copyright 2024-2026 Arm Limited and/or its affiliates.
 # All rights reserved.
 #
 # This source code is licensed under the BSD-style license found in the
@@ -72,6 +72,8 @@ def test_w2l_tosa_INT():
         aten_op=[],
         exir_op=TestW2L.all_operators,
         use_to_edge_transform_and_lower=True,
+        frobenius_threshold=None,
+        cosine_threshold=None,
     )
     pipeline.run()
 

--- a/backends/arm/test/ops/test_acos.py
+++ b/backends/arm/test/ops/test_acos.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -65,6 +65,7 @@ def test_acos_tosa_INT(test_data: Tuple):
         (test_data(),),
         aten_op=aten_op,
         exir_op=exir_op,
+        frobenius_threshold=0.5,  # MLETORCH-1709
     )
     pipeline.run()
 

--- a/backends/arm/test/ops/test_acosh.py
+++ b/backends/arm/test/ops/test_acosh.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -27,7 +27,7 @@ test_data_suite = {
     "just_above_one": lambda: torch.tensor([1.0001, 1.01, 1.1, 2.0]),
     "rand_valid": lambda: torch.rand(10, 10) * 10 + 1,  # [1, 11)
     "ramp_valid": lambda: torch.linspace(1.0, 20.0, steps=160),
-    "large": lambda: torch.tensor([10.0, 100.0, 1000.0, 1e6]),
+    "large": lambda: torch.tensor([500.0, 100.0, 1000.0, 1e6]),
     "mixed_valid": lambda: torch.tensor([1.0, 2.0, 10.0, 100.0]),
 }
 

--- a/backends/arm/test/ops/test_amin.py
+++ b/backends/arm/test/ops/test_amin.py
@@ -139,6 +139,7 @@ def test_amin_tosa_INT(test_data: Amin.input_t):
         Amin(dim, keep_dims),
         data,
         amin_aten_op,
+        frobenius_threshold=0.5,  # Single output value -> frobenius test sensitive to quantization.
     )
     pipeline.run()
 

--- a/backends/arm/test/ops/test_asin.py
+++ b/backends/arm/test/ops/test_asin.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -55,6 +55,8 @@ def test_asin_tosa_INT(test_data: Tuple):
         (test_data(),),
         aten_op=[],
         exir_op=[],
+        frobenius_threshold=0.6,  # MLETORCH-1709
+        cosine_threshold=0.8,  # MLETORCH-1709
     )
     pipeline.run()
 

--- a/backends/arm/test/ops/test_atanh.py
+++ b/backends/arm/test/ops/test_atanh.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -58,6 +58,8 @@ def test_atanh_tosa_INT(test_data: Tuple):
         (test_data,),
         aten_op=aten_op,
         exir_op=exir_op,
+        frobenius_threshold=None,  # MLETORCH-1709
+        cosine_threshold=0.7,
     )
     pipeline.run()
 

--- a/backends/arm/test/ops/test_conv2d.py
+++ b/backends/arm/test/ops/test_conv2d.py
@@ -509,6 +509,7 @@ def test_convolution_2d_tosa_INT_a8w4(test_data):
         aten_op,
         exir_op,
         tosa_extensions=["int4"],
+        frobenius_threshold=0.3,
     )
     pipeline.quantizer.set_global(
         get_symmetric_a8w4_quantization_config(is_per_channel=per_channel_quantization)

--- a/backends/arm/test/ops/test_conv3d.py
+++ b/backends/arm/test/ops/test_conv3d.py
@@ -529,6 +529,7 @@ def test_convolution_3d_tosa_INT_a8w4(test_data):
         exir_op,
         tosa_extensions=["int4"],
         qtol=1,
+        frobenius_threshold=0.2,
     )
     pipeline.quantizer.set_global(
         get_symmetric_a8w4_quantization_config(is_per_channel=per_channel_quantization)

--- a/backends/arm/test/ops/test_conv_combos.py
+++ b/backends/arm/test/ops/test_conv_combos.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 Arm Limited and/or its affiliates.
+# Copyright 2024-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -106,7 +106,7 @@ class ComboConv2dMeandim(torch.nn.Module):
         self.adaptive_avg_pool2d = torch.nn.AdaptiveAvgPool2d((1, 1))
 
     def get_inputs(self) -> Tuple[torch.Tensor]:
-        return (torch.randn(1, 3, 48, 48),)
+        return (torch.randn(1, 3, 48, 48) + 1,)
 
     def forward(self, x):
         x = self.conv2d(x)

--- a/backends/arm/test/ops/test_div.py
+++ b/backends/arm/test/ops/test_div.py
@@ -1,6 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
-# Copyright 2024-2025 Arm Limited and/or its affiliates.
+# Copyright 2024-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -54,12 +54,12 @@ test_data_suite = {
     ),
     "op_div_rank4_large_rand": lambda: (
         200 * torch.rand(5, 10, 25, 20),
-        torch.rand(5, 10, 25, 20),
+        torch.rand(5, 10, 25, 20) + 0.1,
         None,
     ),
     "op_div_rank4_negative_large_rand": lambda: (
         (-200) * torch.rand(5, 10, 25, 20),
-        torch.rand(5, 10, 25, 20),
+        torch.rand(5, 10, 25, 20) + 0.1,
         None,
     ),
     "op_div_rank4_large_randn": lambda: (

--- a/backends/arm/test/ops/test_eq.py
+++ b/backends/arm/test/ops/test_eq.py
@@ -146,6 +146,7 @@ def test_eq_scalar_tosa_INT_tensor(test_module):
         test_module().get_inputs(),
         Equal.aten_op_Tensor,
         Equal.exir_op,
+        frobenius_threshold=0.5,  # Quantized comparisons with small diffs can be inaccurate, leading to large errors in unlucky cases.
     )
     pipeline.run()
 
@@ -157,6 +158,7 @@ def test_eq_scalar_tosa_INT(test_module):
         test_module().get_inputs(),
         Equal.aten_op_Tensor,
         Equal.exir_op,
+        frobenius_threshold=0.5,  # Quantized comparisons with small diffs can be inaccurate, leading to large errors in unlucky cases.
     )
     pipeline.run()
 

--- a/backends/arm/test/ops/test_floor.py
+++ b/backends/arm/test/ops/test_floor.py
@@ -87,6 +87,7 @@ def test_floor_tosa_INT(test_data: input_t1):
         module.exir_op,
         atol=0.06,
         rtol=0.01,
+        frobenius_threshold=0.2,
     )
     pipeline.run()
 

--- a/backends/arm/test/ops/test_floor_div.py
+++ b/backends/arm/test/ops/test_floor_div.py
@@ -1,6 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
-# Copyright 2024-2025 Arm Limited and/or its affiliates.
+# Copyright 2024-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -36,7 +36,7 @@ test_data_suite = {
         torch.ones(5, 10, 25, 20),
         (-1) * torch.ones(5, 10, 25, 20),
     ),
-    "op_floor_div_rank4_randn_mutltiple_broadcasts": lambda: (
+    "op_floor_div_rank4_randn_multiple_broadcasts": lambda: (
         torch.randn(1, 4, 4, 1),
         torch.randn(1, 1, 4, 4),
     ),
@@ -85,7 +85,13 @@ def test_floor_divide_tosa_FP(test_data: input_t1):
     pipeline.run()
 
 
-@common.parametrize("test_data", test_data_suite)
+@common.parametrize(
+    "test_data",
+    test_data_suite,
+    xfails={
+        "op_floor_div_rank4_large_rand": "Numerical failure in TFA",
+    },
+)
 def test_floor_divide_tosa_INT(test_data: input_t1):
     pipeline = TosaPipelineINT[input_t1](
         FloorDivide(),

--- a/backends/arm/test/ops/test_ge.py
+++ b/backends/arm/test/ops/test_ge.py
@@ -148,6 +148,7 @@ def test_ge_tensor_tosa_INT(test_module):
         test_module().get_inputs(),
         GreaterEqual.aten_op_tensor,
         GreaterEqual.exir_op,
+        frobenius_threshold=0.5,  # Quantized comparisons with small diffs can be inaccurate, leading to large errors in unlucky cases.
     )
     pipeline.run()
 
@@ -159,6 +160,7 @@ def test_ge_scalar_tosa_INT(test_module):
         test_module().get_inputs(),
         GreaterEqual.aten_op_tensor,
         GreaterEqual.exir_op,
+        frobenius_threshold=0.5,  # Quantized comparisons with small diffs can be inaccurate, leading to large errors in unlucky cases.
     )
     pipeline.run()
 

--- a/backends/arm/test/ops/test_glu.py
+++ b/backends/arm/test/ops/test_glu.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -64,6 +64,9 @@ def test_glu_tosa_INT(test_data: Tuple):
         (*test_data,),
         aten_op=[],
         exir_op=exir_op,
+        # These tests don't make sense when output is ~= 0
+        frobenius_threshold=1.0 if (test_data[0].max() < 5) else 0.1,
+        cosine_threshold=0.0 if (test_data[0].max() < 5) else 0.9,
     )
     pipeline.run()
 

--- a/backends/arm/test/ops/test_gt.py
+++ b/backends/arm/test/ops/test_gt.py
@@ -149,6 +149,7 @@ def test_gt_tensor_tosa_INT(test_module):
         test_module().get_inputs(),
         Greater.aten_op_tensor,
         Greater.exir_op,
+        frobenius_threshold=0.5,  # Quantized comparisons with small diffs can be inaccurate, leading to large errors in unlucky cases.
     )
     pipeline.run()
 
@@ -160,6 +161,7 @@ def test_gt_scalar_tosa_INT(test_module):
         test_module().get_inputs(),
         Greater.aten_op_tensor,
         Greater.exir_op,
+        frobenius_threshold=0.5,  # Quantized comparisons with small diffs can be inaccurate, leading to large errors in unlucky cases.
     )
     pipeline.run()
 

--- a/backends/arm/test/ops/test_le.py
+++ b/backends/arm/test/ops/test_le.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -107,6 +107,7 @@ def test_le_tensor_tosa_INT(test_module):
         test_module().get_inputs(),
         LessEqual.aten_op_tensor,
         LessEqual.exir_op,
+        frobenius_threshold=0.5,  # Quantized comparisons with small diffs can be inaccurate, leading to large errors in unlucky cases.
     )
     pipeline.run()
 
@@ -118,6 +119,7 @@ def test_le_scalar_tosa_INT(test_module):
         test_module().get_inputs(),
         LessEqual.aten_op_tensor,
         LessEqual.exir_op,
+        frobenius_threshold=0.5,  # Quantized comparisons with small diffs can be inaccurate, leading to large errors in unlucky cases.
     )
     pipeline.run()
 

--- a/backends/arm/test/ops/test_linear.py
+++ b/backends/arm/test/ops/test_linear.py
@@ -217,6 +217,7 @@ def test_linear_tosa_INT_a8w4(test_data: torch.Tensor):
         (test_data,),
         aten_op,
         tosa_extensions=["int4"],
+        frobenius_threshold=0.15,
     )
     pipeline.quantizer.set_global(
         get_symmetric_a8w4_quantization_config(is_per_channel=per_channel_quantization)

--- a/backends/arm/test/ops/test_log.py
+++ b/backends/arm/test/ops/test_log.py
@@ -30,7 +30,7 @@ test_data_suite = {
     "ones_rank3": lambda: (torch.ones(10, 10, 10)),
     "rand": lambda: (torch.rand(10, 10) + 0.001),
     "randn_pos": lambda: (torch.randn(10) + 10),
-    "randn_spread": lambda: (torch.max(torch.Tensor([0.0]), torch.randn(10) * 100)),
+    "randn_spread": lambda: (torch.max(torch.Tensor([0.1]), torch.randn(10) * 100)),
     "ramp": lambda: (torch.arange(0.01, 20, 0.2)),
 }
 

--- a/backends/arm/test/ops/test_logit.py
+++ b/backends/arm/test/ops/test_logit.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -52,13 +52,18 @@ def test_logit_tosa_FP(test_data: Tuple):
     pipeline.run()
 
 
-@common.parametrize("test_data", test_data_suite)
+@common.parametrize(
+    "test_data", test_data_suite, xfails={"uniform_valid": "Numerical error in TFA"}
+)
 def test_logit_tosa_INT(test_data: Tuple):
     pipeline = TosaPipelineINT[input_t1](
         Logit(),
         (*test_data,),
         aten_op=[],
         exir_op=exir_op,
+        # Quantization issues when logit(x) -> inf
+        frobenius_threshold=1.0,
+        cosine_threshold=0.8,
     )
     pipeline.run()
 

--- a/backends/arm/test/ops/test_lt.py
+++ b/backends/arm/test/ops/test_lt.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -107,6 +107,7 @@ def test_lt_tensor_tosa_INT(test_module):
         test_module().get_inputs(),
         LessThan.aten_op_tensor,
         LessThan.exir_op,
+        frobenius_threshold=0.5,  # Quantized comparisons with small diffs can be inaccurate, leading to large errors in unlucky cases.
     )
     pipeline.run()
 
@@ -118,6 +119,7 @@ def test_lt_scalar_tosa_INT(test_module):
         test_module().get_inputs(),
         LessThan.aten_op_tensor,
         LessThan.exir_op,
+        frobenius_threshold=0.5,  # Quantized comparisons with small diffs can be inaccurate, leading to large errors in unlucky cases.
     )
     pipeline.run()
 

--- a/backends/arm/test/ops/test_masked_fill.py
+++ b/backends/arm/test/ops/test_masked_fill.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -106,7 +106,13 @@ def test_masked_fill_scalar_tosa_FP(test_module):
     pipeline.run()
 
 
-@common.parametrize("test_module", test_modules)
+@common.parametrize(
+    "test_module",
+    test_modules,
+    xfails={
+        "masked_fill_8_extreme_scalar_inf": "MLETORCH-1812 - Quantization inaccurate on inf-values in masked fill"
+    },
+)
 def test_masked_fill_scalar_tosa_INT(test_module):
     module, inputs = test_module()
     pipeline = TosaPipelineINT[input_t](

--- a/backends/arm/test/ops/test_ne.py
+++ b/backends/arm/test/ops/test_ne.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -107,7 +107,11 @@ def test_ne_scalar_tosa_FP(test_module):
 @common.parametrize("test_module", test_data_tensor)
 def test_ne_tensor_tosa_INT(test_module):
     pipeline = TosaPipelineINT[input_t](
-        test_module, test_module.get_inputs(), NotEqual.decomposed_ops, NotEqual.exir_op
+        test_module,
+        test_module.get_inputs(),
+        NotEqual.decomposed_ops,
+        NotEqual.exir_op,
+        frobenius_threshold=0.5,  # Quantized comparisons with small diffs can be inaccurate, leading to large errors in unlucky cases.
     )
     pipeline.run()
 

--- a/backends/arm/test/ops/test_ne.py
+++ b/backends/arm/test/ops/test_ne.py
@@ -119,7 +119,11 @@ def test_ne_tensor_tosa_INT(test_module):
 @common.parametrize("test_module", test_data_scalar)
 def test_ne_scalar_tosa_INT(test_module):
     pipeline = TosaPipelineINT[input_t](
-        test_module, test_module.get_inputs(), NotEqual.decomposed_ops, NotEqual.exir_op
+        test_module,
+        test_module.get_inputs(),
+        NotEqual.decomposed_ops,
+        NotEqual.exir_op,
+        frobenius_threshold=0.5,  # Quantized comparisons with small diffs can be inaccurate, leading to large errors in unlucky cases.
     )
     pipeline.run()
 

--- a/backends/arm/test/ops/test_reciprocal.py
+++ b/backends/arm/test/ops/test_reciprocal.py
@@ -70,6 +70,8 @@ def test_reciprocal_tosa_INT(test_data: torch.Tensor):
         (test_data(),),
         aten_op,
         exir_op=[],
+        frobenius_threshold=None,
+        cosine_threshold=None,
     )
     pipeline.run()
 

--- a/backends/arm/test/ops/test_rsqrt.py
+++ b/backends/arm/test/ops/test_rsqrt.py
@@ -27,9 +27,9 @@ input_t1 = Tuple[torch.Tensor]  # Input x
 class Rsqrt(torch.nn.Module):
     test_parameters = {
         "ones_4d": lambda: (torch.ones(1, 10, 10, 10),),
-        "rand_4d_1": lambda: (torch.rand(1, 10, 10, 10),),
-        "rand_4d_2": lambda: (torch.rand(1, 5, 10, 20),),
-        "rand_3d": lambda: (torch.rand(5, 10, 20),),
+        "rand_4d_1": lambda: (torch.rand(1, 10, 10, 10) + 0.1,),
+        "rand_4d_2": lambda: (torch.rand(1, 5, 10, 20) + 0.1,),
+        "rand_3d": lambda: (torch.rand(5, 10, 20) + 0.1,),
     }
     test_parameters_fp16 = {
         "rand_3d_fp16": lambda: (torch.rand(3, 4, 5, dtype=torch.float16),),
@@ -138,7 +138,8 @@ def test_rsqrt_tosa_INT_a16w8(test_tensor: torch.Tensor):
         aten_op,
         exir_op=[],
         tosa_extensions=["int16"],
-        epsilon=2**16,
+        epsilon=2**-16,
+        qtol=128,
     )
     pipeline.run()
 
@@ -154,7 +155,8 @@ def test_rsqrt_16a8w_u55_INT16(test_tensor: torch.Tensor):
         aten_op,
         exir_ops=[],
         a16w8_quantization=True,
-        epsilon=2**16,
+        epsilon=2**-16,
+        qtol=128,
     )
     pipeline.run()
 
@@ -170,6 +172,7 @@ def test_rsqrt_16a8w_u85_INT(test_tensor: torch.Tensor):
         aten_op,
         exir_ops=[],
         a16w8_quantization=True,
-        epsilon=2**16,
+        epsilon=2**-16,
+        qtol=128,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_rsub.py
+++ b/backends/arm/test/ops/test_rsub.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -47,7 +47,6 @@ def test_rsub_scalar_tosa_FP(test_data):
         test_data(),
         aten_op=Rsub.aten_op,
         exir_op=Rsub.exir_op,
-        use_to_edge_transform_and_lower=False,
     )
     pipeline.run()
 
@@ -60,8 +59,8 @@ def test_rsub_scalar_tosa_INT(test_data):
         test_data(),
         aten_op="torch.ops.aten.sub.Tensor",
         exir_op=Rsub.exir_op,
-        use_to_edge_transform_and_lower=False,
         qtol=0,
+        cosine_threshold=None,  # For rand_4D_big_small, the output diff is large which throws off the cosine similarity even if it is relatively small.
     )
     pipeline.run()
 
@@ -76,7 +75,6 @@ def test_rsub_scalar_u55_INT(test_data):
         aten_ops="torch.ops.aten.sub.Tensor",
         exir_ops=Rsub.exir_op,
         run_on_fvp=True,
-        use_to_edge_transform_and_lower=False,
     )
     pipeline.run()
 
@@ -91,7 +89,6 @@ def test_rsub_scalar_u85_INT(test_data):
         aten_ops="torch.ops.aten.sub.Tensor",
         exir_ops=Rsub.exir_op,
         run_on_fvp=True,
-        use_to_edge_transform_and_lower=False,
     )
     pipeline.run()
 
@@ -105,7 +102,6 @@ def test_rsub_scalar_vgf_no_quant(test_data: Tuple[torch.Tensor]):
         test_data(),
         Rsub.aten_op,
         Rsub.exir_op,
-        use_to_edge_transform_and_lower=False,
         quantize=False,
     )
     pipeline.run()
@@ -120,7 +116,6 @@ def test_rsub_scalar_vgf_quant(test_data: Tuple[torch.Tensor]):
         test_data(),
         aten_op="torch.ops.aten.sub.Tensor",
         exir_op=Rsub.exir_op,
-        use_to_edge_transform_and_lower=False,
         quantize=True,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_scalars.py
+++ b/backends/arm/test/ops/test_scalars.py
@@ -216,7 +216,9 @@ def test_add_tensor_tosa_INT_scalar(test_data):
     pipeline.run()
 
 
-@common.parametrize("test_data", tensor_scalar_tests, xfails=int_inplace_xfails)
+@common.parametrize(
+    "test_data", tensor_scalar_tests, xfails=int_inplace_xfails, strict=False
+)
 def test_add_tensor_tosa_INT_inplace(test_data):
     """Tests inplace add with one scalar input."""
     pipeline = TosaPipelineINT[input_t1](AddInplace(), test_data, aten_op=[])
@@ -284,7 +286,9 @@ def test_sub_tensor_tosa_INT_scalar(test_data):
     pipeline.run()
 
 
-@common.parametrize("test_data", tensor_scalar_tests, xfails=int_inplace_xfails)
+@common.parametrize(
+    "test_data", tensor_scalar_tests, xfails=int_inplace_xfails, strict=False
+)
 def test_sub_tensor_tosa_INT_inplace(test_data):
     """Tests inplace sub with one scalar input."""
     pipeline = TosaPipelineINT[input_t1](SubInplace(), test_data, aten_op=[])
@@ -341,7 +345,9 @@ def test_mul_tensor_tosa_INT_scalar(test_data):
     pipeline.run()
 
 
-@common.parametrize("test_data", tensor_scalar_tests, xfails=int_inplace_xfails)
+@common.parametrize(
+    "test_data", tensor_scalar_tests, xfails=int_inplace_xfails, strict=False
+)
 def test_mul_tensor_tosa_INT_inplace(test_data):
     """Tests inplace mul with one scalar input."""
     pipeline = TosaPipelineINT[input_t1](MulInplace(), test_data, aten_op=[])
@@ -395,7 +401,7 @@ def test_div_scalar_tosa_FP(test_data):
 def test_div_tensor_tosa_INT_scalar(test_data):
     """Tests regular div with one scalar input."""
     pipeline = TosaPipelineINT[input_t1](
-        Div(), test_data, aten_op=[], frobenius_threshold=0.3
+        Div(), test_data, aten_op=[], frobenius_threshold=0.5
     )
     pipeline.run()
 
@@ -404,7 +410,7 @@ def test_div_tensor_tosa_INT_scalar(test_data):
 def test_div_tensor_tosa_INT_inplace(test_data):
     """Tests inplace div with one scalar input."""
     pipeline = TosaPipelineINT[input_t1](
-        DivInplace(), test_data, aten_op=[], frobenius_threshold=0.3
+        DivInplace(), test_data, aten_op=[], frobenius_threshold=0.5
     )
     pipeline.run()
 

--- a/backends/arm/test/ops/test_scalars.py
+++ b/backends/arm/test/ops/test_scalars.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 Arm Limited and/or its affiliates.
+# Copyright 2024-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -169,6 +169,13 @@ xfails = {
     "float_r4_st": "MLETORCH-408: Arithmetic ops can't handle scalars first",
 }
 
+int_inplace_xfails = {
+    "int_r1_ts": "MLETORCH-1708: Numerical error in TFA/quantization",
+    "int_r4_ts": "MLETORCH-1708: Numerical error in TFA/quantization",
+    "float_r1_ts": "MLETORCH-1708: Numerical error in TFA/quantization",
+    "float_r4_ts": "MLETORCH-1708: Numerical error in TFA/quantization",
+}
+
 
 # ADD FP ------------------------------------------------------
 @common.parametrize("test_data", tensor_scalar_tests, xfails=xfails)
@@ -209,7 +216,7 @@ def test_add_tensor_tosa_INT_scalar(test_data):
     pipeline.run()
 
 
-@common.parametrize("test_data", tensor_scalar_tests)
+@common.parametrize("test_data", tensor_scalar_tests, xfails=int_inplace_xfails)
 def test_add_tensor_tosa_INT_inplace(test_data):
     """Tests inplace add with one scalar input."""
     pipeline = TosaPipelineINT[input_t1](AddInplace(), test_data, aten_op=[])
@@ -277,7 +284,7 @@ def test_sub_tensor_tosa_INT_scalar(test_data):
     pipeline.run()
 
 
-@common.parametrize("test_data", tensor_scalar_tests)
+@common.parametrize("test_data", tensor_scalar_tests, xfails=int_inplace_xfails)
 def test_sub_tensor_tosa_INT_inplace(test_data):
     """Tests inplace sub with one scalar input."""
     pipeline = TosaPipelineINT[input_t1](SubInplace(), test_data, aten_op=[])
@@ -334,7 +341,7 @@ def test_mul_tensor_tosa_INT_scalar(test_data):
     pipeline.run()
 
 
-@common.parametrize("test_data", tensor_scalar_tests)
+@common.parametrize("test_data", tensor_scalar_tests, xfails=int_inplace_xfails)
 def test_mul_tensor_tosa_INT_inplace(test_data):
     """Tests inplace mul with one scalar input."""
     pipeline = TosaPipelineINT[input_t1](MulInplace(), test_data, aten_op=[])
@@ -387,14 +394,18 @@ def test_div_scalar_tosa_FP(test_data):
 @common.parametrize("test_data", tensor_scalar_tests)
 def test_div_tensor_tosa_INT_scalar(test_data):
     """Tests regular div with one scalar input."""
-    pipeline = TosaPipelineINT[input_t1](Div(), test_data, aten_op=[])
+    pipeline = TosaPipelineINT[input_t1](
+        Div(), test_data, aten_op=[], frobenius_threshold=0.3
+    )
     pipeline.run()
 
 
 @common.parametrize("test_data", tensor_scalar_tests)
 def test_div_tensor_tosa_INT_inplace(test_data):
     """Tests inplace div with one scalar input."""
-    pipeline = TosaPipelineINT[input_t1](DivInplace(), test_data, aten_op=[])
+    pipeline = TosaPipelineINT[input_t1](
+        DivInplace(), test_data, aten_op=[], frobenius_threshold=0.3
+    )
     pipeline.run()
 
 

--- a/backends/arm/test/ops/test_sdpa.py
+++ b/backends/arm/test/ops/test_sdpa.py
@@ -67,7 +67,9 @@ def test_sdpa_tosa_FP(test_case: test_case_t):
 @common.parametrize("test_case", test_suite)
 def test_sdpa_tosa_INT(test_case: test_case_t):
     model, test_input = test_case()
-    pipeline = TosaPipelineINT[input_t](model, test_input, [], [])
+    pipeline = TosaPipelineINT[input_t](
+        model, test_input, [], [], frobenius_threshold=None, cosine_threshold=None
+    )
     pipeline.pop_stage("check.quant_nodes")
     pipeline.pop_stage("check_count.exir")
     pipeline.pop_stage(

--- a/backends/arm/test/ops/test_sign.py
+++ b/backends/arm/test/ops/test_sign.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -28,10 +28,11 @@ test_data_suite = {
     "mixed_signs": torch.tensor([[-2.0, -1.0, 0.0, 1.0, 2.0]]),
     "positive_ramp": torch.arange(0.1, 1.1, 0.2),
     "negative_ramp": torch.arange(-1.0, -0.1, 0.2),
-    "small_values": torch.tensor([-1e-7, 0.0, 1e-7]),
+    "small_values": torch.tensor(
+        [-1e-3, 0.0, 1e-3]
+    ),  # Only values > observer's .eps are of interest.
     "rand": torch.rand(10, 10) - 0.5,
     "rand_alt_shape": torch.rand(10, 3, 5) - 0.5,
-    "high_magnitude": torch.tensor([-1e6, -10.0, 0.0, 10.0, 1e6]),
 }
 
 
@@ -54,10 +55,7 @@ def test_sign_tosa_FP(test_data: Tuple):
 @common.parametrize("test_data", test_data_suite)
 def test_sign_tosa_INT(test_data: Tuple):
     pipeline = TosaPipelineINT[input_t1](
-        Sign(),
-        (test_data,),
-        aten_op=[],
-        exir_op=exir_op,
+        Sign(), (test_data,), aten_op=[], exir_op=exir_op, frobenius_threshold=None
     )
     pipeline.run()
 

--- a/backends/arm/test/ops/test_silu.py
+++ b/backends/arm/test/ops/test_silu.py
@@ -62,10 +62,16 @@ def test_silu_tosa_FP_inplace(test_data: input_t):
 @common.parametrize("test_data", Silu.test_data)
 def test_silu_tosa_INT(test_data: input_t):
     silu_data = (test_data(), False)
+
+    # When all inputs are negative the output is very close to zero, making the relative frobenius norm large
+    # also for small quantization errors. Hence we relax the frobenius threshold in that case.
+    if torch.all(silu_data[0] < 0):
+        frobenius_threshold = 0.3
+    else:
+        frobenius_threshold = 0.1
+
     pipeline = TosaPipelineINT[input_t](
-        Silu(),
-        silu_data,
-        [],
+        Silu(), silu_data, [], frobenius_threshold=frobenius_threshold
     )
     pipeline.run()
 
@@ -73,10 +79,16 @@ def test_silu_tosa_INT(test_data: input_t):
 @common.parametrize("test_data", Silu.test_data)
 def test_silu_tosa_INT_inplace(test_data: input_t):
     silu_data = (test_data(), True)
+
+    # When all inputs are negative the output is very close to zero, making the relative frobenius norm large
+    # also for small quantization errors. Hence we relax the frobenius threshold in that case.
+    if torch.all(silu_data[0] < 0):
+        frobenius_threshold = 0.3
+    else:
+        frobenius_threshold = 0.1
+
     pipeline = TosaPipelineINT[input_t](
-        Silu(),
-        silu_data,
-        [],
+        Silu(), silu_data, [], frobenius_threshold=frobenius_threshold
     )
     pipeline.run()
 

--- a/backends/arm/test/ops/test_tan.py
+++ b/backends/arm/test/ops/test_tan.py
@@ -2,8 +2,6 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
-
-
 import math
 from typing import Tuple
 
@@ -98,6 +96,8 @@ def test_tan_tosa_INT(test_data: Tuple):
         (test_data,),
         aten_op,
         exir_op,
+        frobenius_threshold=None,
+        cosine_threshold=None,
     )
     pipeline.run()
 

--- a/backends/arm/test/ops/test_while.py
+++ b/backends/arm/test/ops/test_while.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -99,7 +99,7 @@ class DecreasingOutput(torch.nn.Module):
 class WhileAdditionalArg(torch.nn.Module):
     def __init__(self) -> None:
         super().__init__()
-        self.register_buffer("threshold", torch.tensor((300.0,)))
+        self.register_buffer("threshold", torch.tensor((128.0,)))
 
     def forward(self, value: torch.Tensor) -> torch.Tensor:
         def cond_fn(value: torch.Tensor, limit: torch.Tensor) -> torch.Tensor:
@@ -121,7 +121,7 @@ class WhileAdditionalArg(torch.nn.Module):
 class WhileSingleCapturedOutput(torch.nn.Module):
     def __init__(self) -> None:
         super().__init__()
-        self.register_buffer("threshold", torch.tensor((200.0,)))
+        self.register_buffer("threshold", torch.tensor((128.0,)))
 
     def forward(self, value: torch.Tensor) -> torch.Tensor:
         def cond_fn(value: torch.Tensor, limit: torch.Tensor) -> torch.Tensor:
@@ -142,11 +142,33 @@ class WhileSingleCapturedOutput(torch.nn.Module):
         return result[0]  # type: ignore
 
 
+class WhileLargeThreshold(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.register_buffer("threshold", torch.tensor((400.0,)))
+
+    def forward(self, value: torch.Tensor) -> torch.Tensor:
+        def cond_fn(value: torch.Tensor, limit: torch.Tensor) -> torch.Tensor:
+            total = value.sum()
+            return torch.lt(total, limit).squeeze()
+
+        def body_fn(value: torch.Tensor, limit: torch.Tensor) -> tuple[torch.Tensor]:
+            return (torch.add(value, value),)
+
+        result = torch.ops.higher_order.while_loop(
+            cond_fn,
+            body_fn,
+            (value,),
+            (self.threshold,),
+        )
+        return result  # type: ignore
+
+
 def _single_input_case(
     module_factory: Callable[[], torch.nn.Module],
 ) -> Callable[[], Tuple[torch.nn.Module, input_single]]:
     def _create() -> Tuple[torch.nn.Module, input_single]:
-        return module_factory(), (torch.ones(2, 3, 4, 6),)
+        return module_factory(), (torch.ones(2, 3, 2, 2),)
 
     return _create
 
@@ -166,6 +188,7 @@ test_cases: dict[str, Callable[[], Tuple[torch.nn.Module, Tuple]]] = {
     "decreasing_output": _single_input_case(DecreasingOutput),
     "additional_arg": _single_input_case(WhileAdditionalArg),
     "two_in_one_captured_out": _single_input_case(WhileSingleCapturedOutput),
+    "large_threshold": _single_input_case(WhileLargeThreshold),
 }
 
 
@@ -187,6 +210,9 @@ def test_while_loop_tosa_FP(case: Callable[[], Tuple[torch.nn.Module, Tuple]]):
 @common.parametrize(
     "case",
     test_cases,
+    xfails={
+        "large_threshold": "MLETORCH-1808 - Handle different scales for different parameters"
+    },
 )
 def test_while_loop_tosa_INT(case: Callable[[], Tuple[torch.nn.Module, Tuple]]):
     module, example_inputs = case()

--- a/backends/arm/test/passes/test_rescale_pass.py
+++ b/backends/arm/test/passes/test_rescale_pass.py
@@ -21,7 +21,9 @@ class RescaleNetwork(torch.nn.Module):
         "randn": (torch.randn(5, 2), torch.randn(5, 1)),
         "ones": (torch.ones(1, 10, 4, 6), torch.ones(1, 10, 4, 6)),
         "randn_ones": (torch.randn(1, 1, 4, 4), torch.ones(1, 1, 4, 1)),
-        "randn_large": (10000 * torch.randn(1, 1, 4, 4), torch.randn(1, 1, 4, 1)),
+        # Ensure 'uniformly' large values in range [1000, 2000], otherwise small values become zero, leading to diff
+        # between quantized and unquantized graph
+        "randn_large": (1000 * (torch.rand(1, 1, 4, 4) + 1), torch.randn(1, 1, 4, 1)),
     }
 
     def forward(self, x: torch.Tensor, y: torch.Tensor):

--- a/backends/arm/test/tester/analyze_output_utils.py
+++ b/backends/arm/test/tester/analyze_output_utils.py
@@ -66,8 +66,13 @@ def _print_channels(
                         res += " . "
                 else:
                     if not booldata:
-                        diff = (reference[c, y, x] - result[c, y, x]) / 10 ** (int(exp))
-                        res += f"{diff: .2f} "
+                        if exp == "inf":
+                            res += "NA "
+                        else:
+                            diff = (reference[c, y, x] - result[c, y, x]) / 10 ** (
+                                int(exp)
+                            )
+                            res += f"{diff: .2f} "
                     else:
                         diff = reference[c, y, x] ^ result[c, y, x]
                         res += " X "
@@ -350,8 +355,8 @@ def compare_rel_frobenius_and_cosine_similarity(
     reference_output: torch.Tensor,
     test_output: torch.Tensor,
     quantization_parameters,
-    frobenius_threshold: float = 0.05,
-    cosine_threshold: float = 0.95,
+    frobenius_threshold: float | None = 0.05,
+    cosine_threshold: float | None = 0.95,
     clean_reference: bool = True,
 ):
     """Frobenius test: computes the frobenius norm (sum of elementwise squared tensor values) of the *error*, and
@@ -396,13 +401,20 @@ def compare_rel_frobenius_and_cosine_similarity(
         test_output.flatten(), reference_output.flatten(), dim=0
     ).item()
 
-    if relative_frobenius_error > frobenius_threshold:
+    if (
+        frobenius_threshold is not None
+        and relative_frobenius_error > frobenius_threshold
+    ):
         raise AssertionError(
             f"Tensor-wise comparison failed: Relative frobenius norm error {relative_frobenius_error} exceeds threshold {frobenius_threshold}."
             f" (Cosine similarity: {cosine_similarity}, threshold {cosine_threshold})."
         )
 
-    if cosine_similarity < cosine_threshold and not reference_all_zeros:
+    if (
+        cosine_threshold is not None
+        and cosine_similarity < cosine_threshold
+        and not reference_all_zeros
+    ):
         raise AssertionError(
             f"Tensor-wise comparison failed: Cosine similarity {cosine_similarity} is below threshold {cosine_threshold}."
             f" (Relative frobenius error: {relative_frobenius_error}, threshold {frobenius_threshold})."

--- a/backends/arm/test/tester/test_pipeline.py
+++ b/backends/arm/test/tester/test_pipeline.py
@@ -304,8 +304,8 @@ class BasePipeline(Generic[T]):
 
     def run_and_compare_to_initial_model(
         self,
-        frobenius_threshold: float = 0.01,
-        cosine_threshold: float = 0.99,
+        frobenius_threshold: float | None = 0.01,
+        cosine_threshold: float | None = 0.99,
         clean_reference: bool = True,
         compared_stage="export",
     ):
@@ -326,6 +326,7 @@ class BasePipeline(Generic[T]):
                 cosine_threshold,
                 clean_reference,
             ),
+            suffix="original_model",
         )
 
     def run(self):
@@ -375,16 +376,25 @@ class TosaPipelineINT(TOSAPipeline, Generic[T]):
        module: The module which the pipeline is applied to.
        test_data: Data used for quantizing and testing the module.
 
-       aten_ops: Aten dialect ops expected to be found in the graph after export.
-       exir_ops: Exir dialect ops expected to be found in the graph after to_edge.
-       if not using use_edge_to_transform_and_lower.
+       aten_op: Aten dialect ops expected to be found in the graph after export.
+       exir_op: Exir dialect ops expected to be found in the graph after to_edge.
+       if not using use_to_edge_transform_and_lower.
 
        run_on_tosa_ref_model: Set to true to test the tosa file on the TOSA reference model.
-
-       tosa_version: A string for identifying the TOSA version, see common.get_tosa_compile_spec for
-                     options.
-       use_edge_to_transform_and_lower: Selects betweeen two possible ways of lowering the module.
+       symmetric_io_quantization: Whether to use symmetric I/O quantization.
+       per_channel_quantization: Whether to use per-channel quantization.
+       use_to_edge_transform_and_lower: Selects betweeen two possible ways of lowering the module.
        custom_path : Path to dump intermediate artifacts such as tosa and pte to.
+       tosa_debug_mode: Optional debug mode for TOSA compilation.
+       atol: Absolute tolerance for output comparison.
+       rtol: Relative tolerance for output comparison.
+       qtol: Quantization tolerance for output comparison.
+       frobenius_threshold: Threshold for Frobenius norm comparison with original model
+       cosine_threshold: Threshold for cosine similarity comparison with original model
+       dynamic_shapes: Optional dynamic shape specifications.
+       tosa_version: TOSA version string to target.
+       tosa_extensions: Optional list of TOSA extensions.
+       epsilon: Epsilon used in quantization configuration.
     """
 
     def __init__(
@@ -402,10 +412,12 @@ class TosaPipelineINT(TOSAPipeline, Generic[T]):
         atol: float = 1e-03,
         rtol: float = 1e-03,
         qtol: int = 1,
+        frobenius_threshold: float | None = 0.15,
+        cosine_threshold: float | None = 0.9,
         dynamic_shapes: Optional[Tuple[Any]] = None,
         tosa_version: Optional[str] = "1.0",
         tosa_extensions: Optional[List[str]] = None,
-        epsilon: float = 2**-12,
+        epsilon: float = 2**-16,
     ):
         if tosa_extensions is None:
             tosa_extensions = []
@@ -494,6 +506,12 @@ class TosaPipelineINT(TOSAPipeline, Generic[T]):
                 qtol=qtol,
                 inputs=self.test_data,
             )
+
+        self.run_and_compare_to_initial_model(
+            frobenius_threshold=frobenius_threshold,
+            cosine_threshold=cosine_threshold,
+            clean_reference=True,
+        )
 
 
 class TosaPipelineFP(TOSAPipeline, Generic[T]):


### PR DESCRIPTION
Adds a comparison between the original and quantized graph to catch bugs in transform_for_annotation and strange quantization behaviors.

Tests are updated according to the following rules:
1. If the result is unexpectedly off, bug tickets have been created and tests are marked as xfail or using high tolerance limits.
2. If the result is slightly off or there is a reasonable explanation for diffs, tolerances are increased with a comment explaining why.
3. If the input data is impossible to reasonably quantize, the input data is changed.

Additionally lowers default epsilon value since 2**-12 for the arm quantization specs which reduces diffs in test cases with small value ranges and fixes a typo for layer norm which exposed a numerical issue for Ethos-U55/U85.

cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai