### PR TITLE
Cortex-M backend: Move pattern-specific annotation to QuantizerConfig

### DIFF
--- a/backends/cortex_m/quantizer/__init__.py
+++ b/backends/cortex_m/quantizer/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
+# Copyright 2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -7,6 +8,7 @@
 from .quantization_configs import (  # noqa
     CMSIS_SOFTMAX_SCALE,
     CMSIS_SOFTMAX_ZERO_POINT,
+    CortexMQuantizationConfig,
     INT8_ACTIVATION_PER_CHANNEL_QSPEC,
     INT8_ACTIVATION_PER_TENSOR_QSPEC,
     INT8_PER_CHANNEL_CONFIG,
@@ -14,5 +16,4 @@ from .quantization_configs import (  # noqa
     INT8_WEIGHT_PER_CHANNEL_QSPEC,
     INT8_WEIGHT_PER_TENSOR_QSPEC,
     SOFTMAX_OUTPUT_FIXED_QSPEC,
-    SOFTMAX_PER_TENSOR_CONFIG,
 )

--- a/backends/cortex_m/quantizer/pattern_checkers.py
+++ b/backends/cortex_m/quantizer/pattern_checkers.py
@@ -3,19 +3,22 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import cast
+
 import torch
 from executorch.backends.arm._passes.arm_pass_utils import get_first_fake_tensor
-from executorch.backends.arm.quantizer.quantization_config import QuantizationConfig
 from executorch.backends.cortex_m.passes.passes_utils import (
+    coerce_int_pair,
     is_channel_broadcast,
     is_channels_last,
 )
 from executorch.backends.cortex_m.quantizer.quantization_configs import (
     CMSIS_SOFTMAX_SCALE,
     CMSIS_SOFTMAX_ZERO_POINT,
+    CortexMQuantizationConfig,
 )
 from torch.fx import Node
-from torchao.quantization.pt2e.quantizer import QuantizationSpec
+from torchao.quantization.pt2e.quantizer import QuantizationSpec, SharedQuantizationSpec
 
 
 class PatternCheck:
@@ -30,28 +33,39 @@ class PatternCheck:
     """
 
     @classmethod
-    def is_per_tensor(cls, qspec: QuantizationSpec) -> bool:
+    def is_per_tensor(cls, qspec: QuantizationSpec | None) -> bool:
         """
         Returns true if the given quantization spec is per-tensor, otherwise false.
         """
+        if not isinstance(qspec, QuantizationSpec):
+            return False
         return qspec.qscheme in (torch.per_tensor_affine, torch.per_tensor_symmetric)
 
     @classmethod
-    def is_per_channel(cls, qspec: QuantizationSpec) -> bool:
+    def is_per_channel(cls, qspec: QuantizationSpec | None) -> bool:
         """
         Returns true if the given quantization spec is per-channel, otherwise false.
         """
+        if not isinstance(qspec, QuantizationSpec):
+            return False
         return qspec.qscheme in (torch.per_channel_affine, torch.per_channel_symmetric)
 
     @classmethod
-    def is_int8_activations(cls, qconfig: QuantizationConfig) -> bool:
+    def is_int8_activations(
+        cls, qconfig: CortexMQuantizationConfig, output_node: Node | None = None
+    ) -> bool:
         """
         Returns true if the given quantization spec uses int8 quantization, otherwise false.
+
+        Output node is required for determining output quantization spec for some ops, otherwise it can be left as None.
         """
-        return (
-            qconfig.input_activation.dtype == torch.int8
-            and qconfig.output_activation.dtype == torch.int8
-        )
+        input_qspec = qconfig.get_input_act_qspec()
+        output_qspec = qconfig.get_output_act_qspec(output_node)
+        if not isinstance(input_qspec, QuantizationSpec) or not isinstance(
+            output_qspec, QuantizationSpec
+        ):
+            return False
+        return input_qspec.dtype == torch.int8 and output_qspec.dtype == torch.int8
 
     @classmethod
     def check_pattern(cls, pattern: list[Node]) -> bool:
@@ -61,9 +75,11 @@ class PatternCheck:
         return True
 
     @classmethod
-    def check_quantization_config(cls, quantization_config: QuantizationConfig) -> bool:
+    def check_quantization_config(
+        cls, pattern: list[Node], quantization_config: CortexMQuantizationConfig
+    ) -> bool:
         """
-        Returns true if the given quantization config is supported, otherwise false.
+        Returns true if the given quantization config is supported for a given node pattern, otherwise false.
         """
         return True
 
@@ -87,13 +103,15 @@ class CortexMAddMulCheck(PatternCheck):
         return True
 
     @classmethod
-    def check_quantization_config(cls, quantization_config):
+    def check_quantization_config(
+        cls, pattern: list[Node], quantization_config: CortexMQuantizationConfig
+    ):
         """
         Checks that the quantization config uses per-tensor int8 quantization.
         """
         is_per_tensor = PatternCheck.is_per_tensor(
-            quantization_config.input_activation
-        ) and PatternCheck.is_per_tensor(quantization_config.output_activation)
+            quantization_config.get_input_act_qspec()
+        ) and PatternCheck.is_per_tensor(quantization_config.get_output_act_qspec())
         is_int8 = cls.is_int8_activations(quantization_config)
         return is_per_tensor and is_int8
 
@@ -112,16 +130,26 @@ class CortexMConv2DCheck(PatternCheck):
         return True
 
     @classmethod
-    def check_quantization_config(cls, quantization_config):
+    def check_quantization_config(
+        cls, pattern: list[Node], quantization_config: CortexMQuantizationConfig
+    ):
         """
         Checks that the quantization config uses per-tensor int8 quantization.
         """
-        return cls.is_int8_activations(quantization_config)
+        is_int8 = cls.is_int8_activations(quantization_config)
+        conv_node = pattern[0] if pattern else None
+        weight_qspec = quantization_config.get_weight_qspec(conv_node)
+        is_ch_axis_0 = (
+            weight_qspec.ch_axis == 0 or weight_qspec.ch_axis is None
+        )  # Accept if ch_axis is 0 or not specified (default to per-tensor)
+        return is_int8 and is_ch_axis_0
 
 
 class CortexMLinearCheck(PatternCheck):
     @classmethod
-    def check_quantization_config(cls, quantization_config):
+    def check_quantization_config(
+        cls, pattern: list[Node], quantization_config: CortexMQuantizationConfig
+    ):
         """
         Checks that the quantization config uses per-tensor int8 quantization.
         """
@@ -157,20 +185,22 @@ class CortexMSoftmaxCheck(PatternCheck):
         return True
 
     @classmethod
-    def check_quantization_config(cls, quantization_config):
+    def check_quantization_config(
+        cls, pattern: list[Node], quantization_config: CortexMQuantizationConfig
+    ):
         """
         Checks that the quantization config uses a valid configuration for CMSIS-NN softmax.
         """
-        is_int8 = cls.is_int8_activations(quantization_config)
-        is_per_tensor = cls.is_per_tensor(
-            quantization_config.input_activation
-        ) and cls.is_per_tensor(quantization_config.output_activation)
-        correct_output_scale = (
-            quantization_config.output_activation.scale == CMSIS_SOFTMAX_SCALE
+        output_node = pattern[-1] if pattern else None
+        input_qspec = quantization_config.get_input_act_qspec()
+        output_qspec = quantization_config.get_output_act_qspec(output_node)
+
+        is_int8 = cls.is_int8_activations(quantization_config, output_node)
+        is_per_tensor = cls.is_per_tensor(input_qspec) and cls.is_per_tensor(
+            output_qspec
         )
-        correct_output_zero_point = (
-            quantization_config.output_activation.zero_point == CMSIS_SOFTMAX_ZERO_POINT
-        )
+        correct_output_scale = output_qspec.scale == CMSIS_SOFTMAX_SCALE
+        correct_output_zero_point = output_qspec.zero_point == CMSIS_SOFTMAX_ZERO_POINT
 
         return (
             is_int8
@@ -234,11 +264,84 @@ class CortexMConvTranspose2DCheck(PatternCheck):
         return True  # ACCEPT channels_last transpose conv
 
     @classmethod
-    def check_quantization_config(cls, quantization_config):
+    def check_quantization_config(
+        cls, pattern: list[Node], quantization_config: CortexMQuantizationConfig
+    ):
         """
         Checks that the quantization config uses per-tensor int8 quantization.
         """
         is_int8 = cls.is_int8_activations(quantization_config)
-        is_ch_axis_1 = quantization_config.weight.ch_axis == 1
+
+        transpose_conv_node = pattern[0] if pattern else None
+        weight_qspec = quantization_config.get_weight_qspec(transpose_conv_node)
+        is_ch_axis_1 = (
+            weight_qspec.ch_axis == 1 or weight_qspec.ch_axis is None
+        )  # Accept if ch_axis is 1 or not specified (default to per-tensor)
 
         return is_int8 and is_ch_axis_1
+
+
+class CortexMAvgPool2DCheck(PatternCheck):
+    @classmethod
+    def check_pattern(cls, pattern):
+        if not pattern:
+            return False
+        node = pattern[0]
+        ceil_mode = cast(bool, node.args[4]) if len(node.args) > 4 else False
+        count_include_pad = cast(bool, node.args[5]) if len(node.args) > 5 else True
+        return not (ceil_mode or count_include_pad)
+
+    @classmethod
+    def check_quantization_config(
+        cls, pattern: list[Node], quantization_config: CortexMQuantizationConfig
+    ):
+        output_node = pattern[-1] if pattern else None
+        input_qspec = quantization_config.get_input_act_qspec()
+        output_qspec = quantization_config.get_output_act_qspec(output_node)
+        if isinstance(output_qspec, SharedQuantizationSpec):
+            output_qspec = input_qspec
+        if input_qspec is None or output_qspec is None:
+            return False
+        is_int8 = input_qspec.dtype == torch.int8 and output_qspec.dtype == torch.int8
+        is_per_tensor = cls.is_per_tensor(input_qspec) and cls.is_per_tensor(
+            output_qspec
+        )
+        return is_int8 and is_per_tensor
+
+
+class CortexMMaxPool2DCheck(PatternCheck):
+    @classmethod
+    def _pool_arg_as_bool(cls, node: Node, index: int, default: bool) -> bool:
+        raw = node.args[index] if len(node.args) > index else default
+        if raw is None:
+            return default
+        return bool(raw)
+
+    @classmethod
+    def check_pattern(cls, pattern):
+        if not pattern:
+            return False
+        node = pattern[0]
+        raw_dilation = node.args[4] if len(node.args) > 4 else (1, 1)
+        dilation = coerce_int_pair(raw_dilation, (1, 1))
+        ceil_mode = cls._pool_arg_as_bool(node, 5, False)
+        if dilation != (1, 1) or ceil_mode:
+            meta_custom = node.meta.get("custom", {})
+            cortex_m_meta = meta_custom.get("cortex_m", {})
+            cortex_m_meta["skip_quantized_max_pool2d"] = True
+            meta_custom["cortex_m"] = cortex_m_meta
+            node.meta["custom"] = meta_custom
+        return True
+
+    @classmethod
+    def check_quantization_config(
+        cls, pattern: list[Node], quantization_config: CortexMQuantizationConfig
+    ):
+        maxpool_node = pattern[0]
+        input_qspec = quantization_config.get_input_act_qspec()
+        output_qspec = quantization_config.get_output_act_qspec(maxpool_node)
+        if not isinstance(output_qspec, SharedQuantizationSpec):
+            return False
+        is_int8 = input_qspec.dtype == torch.int8
+        is_per_tensor = cls.is_per_tensor(input_qspec)
+        return is_int8 and is_per_tensor

--- a/backends/cortex_m/quantizer/pattern_checkers.py
+++ b/backends/cortex_m/quantizer/pattern_checkers.py
@@ -18,7 +18,10 @@ from executorch.backends.cortex_m.quantizer.quantization_configs import (
     CortexMQuantizationConfig,
 )
 from torch.fx import Node
-from torchao.quantization.pt2e.quantizer import QuantizationSpec, SharedQuantizationSpec
+from torchao.quantization.pt2e.quantizer import (
+    QuantizationSpecBase,
+    SharedQuantizationSpec,
+)
 
 
 class PatternCheck:
@@ -33,20 +36,20 @@ class PatternCheck:
     """
 
     @classmethod
-    def is_per_tensor(cls, qspec: QuantizationSpec | None) -> bool:
+    def is_per_tensor(cls, qspec: QuantizationSpecBase | None) -> bool:
         """
         Returns true if the given quantization spec is per-tensor, otherwise false.
         """
-        if not isinstance(qspec, QuantizationSpec):
+        if not isinstance(qspec, QuantizationSpecBase):
             return False
         return qspec.qscheme in (torch.per_tensor_affine, torch.per_tensor_symmetric)
 
     @classmethod
-    def is_per_channel(cls, qspec: QuantizationSpec | None) -> bool:
+    def is_per_channel(cls, qspec: QuantizationSpecBase | None) -> bool:
         """
         Returns true if the given quantization spec is per-channel, otherwise false.
         """
-        if not isinstance(qspec, QuantizationSpec):
+        if not isinstance(qspec, QuantizationSpecBase):
             return False
         return qspec.qscheme in (torch.per_channel_affine, torch.per_channel_symmetric)
 
@@ -61,8 +64,8 @@ class PatternCheck:
         """
         input_qspec = qconfig.get_input_act_qspec()
         output_qspec = qconfig.get_output_act_qspec(output_node)
-        if not isinstance(input_qspec, QuantizationSpec) or not isinstance(
-            output_qspec, QuantizationSpec
+        if not isinstance(input_qspec, QuantizationSpecBase) or not isinstance(
+            output_qspec, QuantizationSpecBase
         ):
             return False
         return input_qspec.dtype == torch.int8 and output_qspec.dtype == torch.int8

--- a/backends/cortex_m/quantizer/pattern_matcher.py
+++ b/backends/cortex_m/quantizer/pattern_matcher.py
@@ -8,8 +8,10 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import Iterator, List, Optional
 
-from executorch.backends.arm.quantizer.quantization_config import QuantizationConfig
 from executorch.backends.cortex_m.quantizer.pattern_checkers import PatternCheck
+from executorch.backends.cortex_m.quantizer.quantization_configs import (
+    CortexMQuantizationConfig,
+)
 from torch._ops import OpOverload
 from torch.fx import Node
 
@@ -74,7 +76,7 @@ class PatternMatcher:
         self,
         node: Optional[Node],
         pattern: List[OpOverload],
-        quantization_config: QuantizationConfig,
+        quantization_config: CortexMQuantizationConfig,
     ) -> Optional[PatternMatchResult]:
         """
         Returns a PatternMatchResult when the pattern structurally matches, with
@@ -99,14 +101,16 @@ class PatternMatcher:
             if not pattern_ok:
                 return PatternMatchResult(match, False, self.REJECT_UNSUPPORTED_PATTERN)
 
-            qconfig_ok = pattern_checker.check_quantization_config(quantization_config)
+            qconfig_ok = pattern_checker.check_quantization_config(
+                match, quantization_config
+            )
             if not qconfig_ok:
                 return PatternMatchResult(match, False, self.REJECT_UNSUPPORTED_QCONFIG)
 
         return PatternMatchResult(match, True)
 
     def find_pattern_matches(
-        self, nodes: Iterator[Node], quantization_config: QuantizationConfig
+        self, nodes: Iterator[Node], quantization_config: CortexMQuantizationConfig
     ) -> Iterator[PatternMatchResult]:
         """
         Match all given patterns in the graph and return match results with

--- a/backends/cortex_m/quantizer/quantizer_reporter.py
+++ b/backends/cortex_m/quantizer/quantizer_reporter.py
@@ -23,13 +23,11 @@ from executorch.backends.cortex_m.quantizer.quantization_configs import (
     INT8_ACTIVATION_PER_CHANNEL_QSPEC,
     INT8_ACTIVATION_PER_TENSOR_QSPEC,
     INT8_PER_CHANNEL_CONFIG,
-    INT8_PER_CHANNEL_TRANSPOSE_CONFIG,
     INT8_PER_TENSOR_CONFIG,
     INT8_WEIGHT_PER_CHANNEL_QSPEC,
     INT8_WEIGHT_PER_CHANNEL_TRANSPOSE_QSPEC,
     INT8_WEIGHT_PER_TENSOR_QSPEC,
     SOFTMAX_OUTPUT_FIXED_QSPEC,
-    SOFTMAX_PER_TENSOR_CONFIG,
 )
 from tabulate import tabulate
 from torch.fx import GraphModule, Node
@@ -41,9 +39,7 @@ logger = logging.getLogger(__name__)
 # Look-up dicts used to get human readable names for supported quantization configs and specs
 SUPPORTED_QCONFIGS = {
     INT8_PER_CHANNEL_CONFIG: f"{quantization_configs_module}.INT8_PER_CHANNEL_QCONFIG",
-    INT8_PER_CHANNEL_TRANSPOSE_CONFIG: f"{quantization_configs_module}.INT8_PER_CHANNEL_TRANSPOSE_QCONFIG",
     INT8_PER_TENSOR_CONFIG: f"{quantization_configs_module}.INT8_PER_TENSOR_QCONFIG",
-    SOFTMAX_PER_TENSOR_CONFIG: f"{quantization_configs_module}.SOFTMAX_PER_TENSOR_QCONFIG",
 }
 
 

--- a/backends/cortex_m/quantizer/quantizer_support.py
+++ b/backends/cortex_m/quantizer/quantizer_support.py
@@ -6,9 +6,11 @@
 import torch
 from executorch.backends.cortex_m.quantizer.pattern_checkers import (
     CortexMAddMulCheck,
+    CortexMAvgPool2DCheck,
     CortexMConv2DCheck,
     CortexMConvTranspose2DCheck,
     CortexMLinearCheck,
+    CortexMMaxPool2DCheck,
     CortexMSoftmaxCheck,
 )
 
@@ -110,10 +112,17 @@ SOFTMAX_OP_PATTERNS = {
     (torch.ops.aten.softmax.int,): CortexMSoftmaxCheck,
 }
 
+POOL_OP_PATTERNS = {
+    (torch.ops.aten.avg_pool2d.default,): CortexMAvgPool2DCheck,
+    (torch.ops.aten.max_pool2d.default,): CortexMMaxPool2DCheck,
+    (torch.ops.aten.max_pool2d_with_indices.default,): CortexMMaxPool2DCheck,
+}
+
 CORTEX_M_QUANTIZER_SUPPORT_DICT = (
     BINARY_OP_PATTERNS
     | LINEAR_OP_PATTERNS
     | CONV_OP_PATTERNS
     | SOFTMAX_OP_PATTERNS
     | CONV_TRANSPOSE_OP_PATTERNS
+    | POOL_OP_PATTERNS
 )

--- a/backends/cortex_m/test/misc/test_pattern_matcher.py
+++ b/backends/cortex_m/test/misc/test_pattern_matcher.py
@@ -26,7 +26,7 @@ class _AlwaysPassCheck(PatternCheck):
         return True
 
     @classmethod
-    def check_quantization_config(cls, quantization_config):
+    def check_quantization_config(cls, pattern, quantization_config):
         return True
 
 
@@ -36,7 +36,7 @@ class _AlwaysFailCheck(PatternCheck):
         return False
 
     @classmethod
-    def check_quantization_config(cls, quantization_config):
+    def check_quantization_config(cls, pattern, quantization_config):
         return False
 
 


### PR DESCRIPTION
A number of op-patterns require specific annotations in the Cortex-M backend:
- Transpose conv requires channel_axis = 1
- Softmax has fixed output params
- Pooling ops require shared input/output qspecs.

Putting all such logic in the QuantizationConfig keeps the quantizer clean from special cases while not forcing the user to keep them in mind.

cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai