### PR TITLE
Arm backend: Correct checking of args in aot_arm_compiler

### DIFF
--- a/examples/arm/aot_arm_compiler.py
+++ b/examples/arm/aot_arm_compiler.py
@@ -630,7 +630,7 @@ def get_args():
     args = parser.parse_args()
 
     if args.evaluate and (
-        args.quantize is None or args.intermediates is None or (not args.delegate)
+        (not args.quantize) or args.intermediates is None or (not args.delegate)
     ):
         raise RuntimeError(
             "--evaluate requires --quantize, --intermediates and --delegate to be enabled."


### PR DESCRIPTION
`args.quantize` can never be `None` (since it is a `bool` and not an `Optional`). Correct a error check to instead check that it's `False`.

cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai