### PR TITLE
Arm backend: Fold constants in transform_for_annotation

### DIFF
--- a/backends/arm/_passes/__init__.py
+++ b/backends/arm/_passes/__init__.py
@@ -12,6 +12,7 @@ from .broadcast_args_pass import BroadcastArgsPass  # noqa
 from .canonicalize_gather_pass import CanonicalizeGatherPass  # noqa
 from .cast_int64_pass import CastInt64BuffersToInt32Pass  # noqa
 from .cast_to_int32_pass import CastToInt32Pass  # noqa
+from .constant_folding_pass import ConstantFoldingPass  # noqa
 from .conv1d_unsqueeze_pass import Conv1dUnsqueezePass  # noqa
 from .convert_elu_params import ConvertELUParamsPass  # noqa
 from .convert_expand_copy_to_repeat import ConvertExpandCopyToRepeatPass  # noqa

--- a/backends/arm/_passes/arm_pass_manager.py
+++ b/backends/arm/_passes/arm_pass_manager.py
@@ -18,6 +18,7 @@ from executorch.backends.arm._passes import (
     CastInt64BuffersToInt32Pass,
     CastToInt32Pass,
     ComputeConstantOpsAOTPass,
+    ConstantFoldingPass,
     ControlFlowConstInlinePass,
     Conv1dUnsqueezePass,
     ConvertELUParamsPass,
@@ -396,6 +397,7 @@ class ArmPassManager(PassManager):
     def transform_for_annotation_pipeline(self, graph_module: GraphModule):
         # Preprocessing passes
         self.add_pass(RemoveGraphAssertsPass(tfa_pass=True))
+        self.add_pass(ConstantFoldingPass())
 
         # Transformation passes (pre scalar -> tensor)
         self.add_passes(

--- a/backends/arm/_passes/constant_folding_pass.py
+++ b/backends/arm/_passes/constant_folding_pass.py
@@ -1,0 +1,79 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Set, Type
+
+import torch
+from executorch.backends.arm._passes import ArmPass
+from executorch.exir.pass_base import ExportPass, PassResult
+from torch._export.passes.constant_folding import constant_fold
+
+
+class ConstantFoldingPass(ArmPass):
+    """Fold constant subgraphs using torch's export constant folding pass. To be used before to_edge transform."""
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
+
+    parameter_targets = {
+        torch.ops.aten.linear.default,
+        torch.ops.aten.convolution.default,
+        torch.ops.aten.conv1d.default,
+        torch.ops.aten.conv1d.padding,
+        torch.ops.aten.conv2d.default,
+        torch.ops.aten.conv2d.padding,
+        torch.ops.aten.conv3d.default,
+        torch.ops.aten.conv3d.padding,
+        torch.ops.aten.conv_transpose2d.input,
+    }
+
+    def _ensure_param_attr(
+        self, graph_module: torch.fx.GraphModule, node: torch.fx.Node | None
+    ) -> bool:
+        """
+        Replaces tensor attributes with parameter attributes.
+        """
+        if node is None or node.op != "get_attr":
+            return False
+        target = node.target
+        try:
+            attr = getattr(graph_module, target)  # type: ignore[arg-type]
+        except AttributeError:
+            return False
+        if isinstance(attr, torch.nn.Parameter):
+            return False
+        if not isinstance(attr, torch.Tensor):
+            return False
+        setattr(graph_module, target, torch.nn.Parameter(attr, requires_grad=False))  # type: ignore[arg-type]
+        return True
+
+    def call(self, graph_module: torch.fx.GraphModule) -> PassResult:
+        before_graph = str(graph_module.graph)
+
+        # The ConstantFolder checks for this attribute which does not always exist
+        faked_dequantize_affine = False
+        if not hasattr(torch.ops.pt2e_quant, "dequantize_affine"):
+            torch.ops.pt2e_quant.dequantize_affine = None  # type: ignore[attr-defined]
+            faked_dequantize_affine = True
+
+        constant_fold(graph_module)
+
+        # Remove attribute again if added to not affect global scope
+        if faked_dequantize_affine:
+            del torch.ops.pt2e_quant.dequantize_affine  # type: ignore[attr-defined]
+
+        modified = before_graph != str(graph_module.graph)
+
+        # Constant folding may have replaced some parameters with tensors, so we need to ensure they are still parameters for the backend to work correctly.
+        for node in graph_module.graph.nodes:
+            if node.op != "call_function":
+                continue
+            if node.target in self.parameter_targets:
+                args = node.args
+                if len(args) > 1:
+                    modified |= self._ensure_param_attr(graph_module, args[1])
+                if len(args) > 2:
+                    modified |= self._ensure_param_attr(graph_module, args[2])
+
+        return PassResult(graph_module, modified)

--- a/backends/arm/test/models/stable_diffusion/test_CLIPTextModelWithProjection.py
+++ b/backends/arm/test/models/stable_diffusion/test_CLIPTextModelWithProjection.py
@@ -44,9 +44,6 @@ class TestCLIPTextModelWithProjection:
 
     ops_after_partitioner_INT = {
         "executorch_exir_dialects_edge__ops_aten_argmax_default": 1,
-        "executorch_exir_dialects_edge__ops_aten_index_select_default": 1,
-        "executorch_exir_dialects_edge__ops_aten_slice_copy_Tensor": 1,
-        "executorch_exir_dialects_edge__ops_aten_view_copy_default": 1,
         "executorch_exir_dialects_edge__ops_dim_order_ops__to_dim_order_copy_default": 2,
         "torch.ops.higher_order.executorch_call_delegate": 2,
     }

--- a/backends/arm/test/ops/test_where.py
+++ b/backends/arm/test/ops/test_where.py
@@ -175,13 +175,13 @@ test_modules_common = {
     "two_dim_scalar_cond": lambda: two_dim_scalar_cond,
     "three_dim_scalar_cond": lambda: three_dim_scalar_cond,
     "float32_scalar_cond": lambda: float32_scalar_cond,
-    "const_float32": lambda: const_float32,
 }
 
 test_modules_FP = {
     **test_modules_common,
     "float32_tensor_cond_tuple_dtype_bool": lambda: float32_tensor_cond_tuple_dtype_bool,
     "float16_tensor_cond": lambda: float16_tensor_cond,
+    "const_float32": lambda: const_float32,
 }
 
 test_modules_FP_bf16 = {
@@ -231,6 +231,16 @@ def test_where_self_tosa_INT(test_module):
         test_module().get_inputs(),
         aten_op,
         exir_op,
+    )
+    pipeline.run()
+
+
+def test_where_self_tosa_INT_constant():
+    test_module = const_float32
+    pipeline = TosaPipelineINT[input_t](
+        test_module,
+        test_module.get_inputs(),
+        [],  # No where op expected as the condition is constant and can be folded into the other two inputs
     )
     pipeline.run()
 

--- a/backends/arm/test/passes/test_fuse_constant_ops_pass.py
+++ b/backends/arm/test/passes/test_fuse_constant_ops_pass.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -80,7 +80,6 @@ class FuseBuffer(torch.nn.Module):
 
 class FuseLiftedTensor(torch.nn.Module):
     ops_before_pass: ClassVar[Dict[str, int]] = {
-        "executorch_exir_dialects_edge__ops_aten_select_copy_int": 1,
         "executorch_exir_dialects_edge__ops_aten_add_Tensor": 1,
     }
     ops_after_pass: ClassVar[Dict[str, int]] = {


### PR DESCRIPTION
This pass runs the same code as used in
convert_pt2e(m, fold_quantize=True), forcing that behaviour in the arm-backend. This ensures that linear/convolution ops have constant parameters as inputs, fixing a bug where weights/bias was not quantized according to the weight/bias_qspec defined for the node as expected.

cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai