### PR TITLE
Add view_as_complex_copy operator

### DIFF
--- a/kernels/aten/functions.yaml
+++ b/kernels/aten/functions.yaml
@@ -433,6 +433,8 @@
 
 - op: var.out
 
+- op: view_as_complex_copy.out
+
 - op: view_as_real_copy.out
 
 - op: view_copy.out

--- a/kernels/portable/cpu/op_view_as_complex_copy.cpp
+++ b/kernels/portable/cpu/op_view_as_complex_copy.cpp
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/kernels/portable/cpu/util/copy_ops_util.h>
+#include <executorch/runtime/kernel/kernel_includes.h>
+
+namespace torch {
+namespace executor {
+namespace native {
+
+using Tensor = executorch::aten::Tensor;
+
+namespace {
+
+template <typename IN_CTYPE, typename OUT_CTYPE>
+inline void _to_impl(const Tensor& self, Tensor& out) {
+  auto self_data = self.const_data_ptr<IN_CTYPE>();
+  auto out_data = out.mutable_data_ptr<OUT_CTYPE>();
+
+  for (size_t i = 0, e = out.numel(); i < e; i++) {
+    // Read real and imaginary parts from consecutive elements
+    // Use the same pattern as view_as_real_copy but in reverse
+    out_data[i].real_ =
+        static_cast<decltype(out_data[i].real_)>(self_data[2 * i]);
+    out_data[i].imag_ =
+        static_cast<decltype(out_data[i].imag_)>(self_data[2 * i + 1]);
+  }
+}
+
+} // namespace
+
+// view_as_complex_copy(Tensor self) -> Tensor
+Tensor& view_as_complex_copy_out(
+    KernelRuntimeContext& ctx,
+    const Tensor& self,
+    Tensor& out) {
+  (void)ctx;
+
+  // The input tensor must have at least one dimension
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      self.dim() > 0,
+      InvalidArgument,
+      out,
+      "Input tensor must have at least one dimension");
+
+  // The last dimension must be 2 (real and imaginary parts)
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      self.size(self.dim() - 1) == 2,
+      InvalidArgument,
+      out,
+      "Input tensor must have a last dimension of size 2");
+
+  // The input tensor must be float type
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      executorch::runtime::isFloatingType(self.scalar_type()),
+      InvalidArgument,
+      out,
+      "Input tensor must be float type");
+
+  // The output tensor must be complex type
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      executorch::runtime::isComplexType(out.scalar_type()),
+      InvalidArgument,
+      out,
+      "Output tensor must be complex type");
+
+  // Get the expected output shape (input shape without the last dimension)
+  Tensor::SizesType expected_output_size[kTensorDimensionLimit];
+  get_view_as_complex_copy_out_target_size(self, expected_output_size);
+
+  // Resize for dynamic shape
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      resize_tensor(
+          out, {expected_output_size, static_cast<size_t>(out.dim())}) ==
+          Error::Ok,
+      InvalidArgument,
+      out,
+      "Failed to resize output tensor.");
+
+  ET_KERNEL_CHECK(
+      ctx, tensors_have_same_dim_order(self, out), InvalidArgument, out);
+
+  static constexpr auto op_name = "view_as_complex_copy.out";
+
+  ET_SWITCH_FLOATH_TYPES(self.scalar_type(), ctx, op_name, CTYPE_IN, [&] {
+    ET_SWITCH_COMPLEXH_TYPES(out.scalar_type(), ctx, op_name, CTYPE_OUT, [&] {
+      _to_impl<CTYPE_IN, CTYPE_OUT>(self, out);
+    });
+  });
+
+  return out;
+}
+
+} // namespace native
+} // namespace executor
+} // namespace torch

--- a/kernels/portable/cpu/util/copy_ops_util.cpp
+++ b/kernels/portable/cpu/util/copy_ops_util.cpp
@@ -1033,5 +1033,13 @@ void get_view_as_real_copy_out_target_size(
   out_sizes[self.dim()] = 2;
 }
 
+void get_view_as_complex_copy_out_target_size(
+    const Tensor& self,
+    executorch::aten::SizesType* out_sizes) {
+  for (auto i : c10::irange(self.dim() - 1)) {
+    out_sizes[i] = static_cast<executorch::aten::SizesType>(self.size(i));
+  }
+}
+
 } // namespace executor
 } // namespace torch

--- a/kernels/portable/cpu/util/copy_ops_util.h
+++ b/kernels/portable/cpu/util/copy_ops_util.h
@@ -282,5 +282,9 @@ void get_view_as_real_copy_out_target_size(
     const Tensor& self,
     executorch::aten::SizesType* out_sizes);
 
+void get_view_as_complex_copy_out_target_size(
+    const Tensor& self,
+    executorch::aten::SizesType* out_sizes);
+
 } // namespace executor
 } // namespace torch

--- a/kernels/portable/functions.yaml
+++ b/kernels/portable/functions.yaml
@@ -1015,6 +1015,11 @@
     - arg_meta: null
       kernel_name: torch::executor::var_out
 
+- op: view_as_complex_copy.out
+  kernels:
+    - arg_meta: null
+      kernel_name: torch::executor::view_as_complex_copy_out
+
 - op: view_as_real_copy.out
   kernels:
     - arg_meta: null

--- a/kernels/test/CMakeLists.txt
+++ b/kernels/test/CMakeLists.txt
@@ -310,6 +310,7 @@ set(all_test_sources
     "op_upsample_bilinear2d_aa_test.cpp"
     "op_upsample_nearest2d_test.cpp"
     "op_var_test.cpp"
+    "op_view_as_complex_copy_test.cpp"
     "op_view_as_real_copy_test.cpp"
     "op_view_copy_test.cpp"
     "op_where_test.cpp"

--- a/kernels/test/op_view_as_complex_copy_test.cpp
+++ b/kernels/test/op_view_as_complex_copy_test.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/kernels/test/FunctionHeaderWrapper.h> // Declares the operator
+#include <executorch/kernels/test/TestUtil.h>
+#include <executorch/runtime/core/exec_aten/exec_aten.h>
+#include <executorch/runtime/core/exec_aten/testing_util/tensor_factory.h>
+#include <executorch/runtime/core/exec_aten/testing_util/tensor_util.h>
+
+#include <gtest/gtest.h>
+
+using namespace ::testing;
+using executorch::aten::ScalarType;
+using executorch::aten::Tensor;
+using torch::executor::testing::TensorFactory;
+
+class OpViewAsComplexTest : public OperatorTest {
+ protected:
+  Tensor& view_as_complex_copy_out(const Tensor& self, Tensor& out) {
+    return torch::executor::aten::view_as_complex_copy_outf(
+        context_, self, out);
+  }
+
+  template <typename CTYPE, ScalarType DTYPE>
+  void run_real_smoke_test() {
+    constexpr auto COMPLEX_DTYPE = executorch::runtime::toComplexType(DTYPE);
+    using ComplexType =
+        typename executorch::runtime::ScalarTypeToCppType<COMPLEX_DTYPE>::type;
+
+    TensorFactory<DTYPE> tf;
+    TensorFactory<COMPLEX_DTYPE> tf_out;
+
+    Tensor in = tf.make({2, 2, 2}, {3, 4, -1.7, 7.4, 5, -12, 8.3, 0.1});
+    Tensor out = tf_out.make(
+        {2, 2},
+        {ComplexType(0, 0),
+         ComplexType(0, 0),
+         ComplexType(0, 0),
+         ComplexType(0, 0)});
+    Tensor expected = tf_out.make(
+        {2, 2},
+        {ComplexType(3, 4),
+         ComplexType(-1.7, 7.4),
+         ComplexType(5, -12),
+         ComplexType(8.3, 0.1)});
+    Tensor ret = view_as_complex_copy_out(in, out);
+
+    EXPECT_TENSOR_EQ(out, ret);
+    EXPECT_TENSOR_EQ(out, expected);
+  }
+
+  template <typename CTYPE, ScalarType DTYPE>
+  void test_empty_input() {
+    constexpr auto COMPLEX_DTYPE = executorch::runtime::toComplexType(DTYPE);
+
+    TensorFactory<DTYPE> tf;
+    TensorFactory<COMPLEX_DTYPE> tf_out;
+
+    Tensor in = tf.make(/*sizes=*/{3, 0, 4, 2}, /*data=*/{});
+    Tensor out = tf_out.make(/*sizes=*/{3, 0, 4}, /*data=*/{});
+    Tensor expected = tf_out.make(/*sizes=*/{3, 0, 4}, /*data=*/{});
+    Tensor ret = view_as_complex_copy_out(in, out);
+
+    EXPECT_TENSOR_EQ(out, ret);
+    EXPECT_TENSOR_EQ(out, expected);
+  }
+
+  template <typename CTYPE, ScalarType DTYPE>
+  void one_dim_input() {
+    constexpr auto COMPLEX_DTYPE = executorch::runtime::toComplexType(DTYPE);
+    using ComplexType =
+        typename executorch::runtime::ScalarTypeToCppType<COMPLEX_DTYPE>::type;
+
+    TensorFactory<DTYPE> tf;
+    TensorFactory<COMPLEX_DTYPE> tf_out;
+
+    Tensor in = tf.make(/*sizes=*/{2}, {1.5, 2.5});
+    Tensor out = tf_out.make(/*sizes=*/{}, {ComplexType(0, 0)});
+    Tensor expected = tf_out.make(/*sizes=*/{}, {ComplexType(1.5, 2.5)});
+    Tensor ret = view_as_complex_copy_out(in, out);
+
+    EXPECT_TENSOR_EQ(out, ret);
+    EXPECT_TENSOR_EQ(out, expected);
+  }
+};
+
+TEST_F(OpViewAsComplexTest, RealSmokeTest) {
+#define RUN_SMOKE_TEST(ctype, dtype)               \
+  run_real_smoke_test<ctype, ScalarType::dtype>(); \
+  test_empty_input<ctype, ScalarType::dtype>();    \
+  one_dim_input<ctype, ScalarType::dtype>();
+  ET_FORALL_FLOAT_TYPES(RUN_SMOKE_TEST);
+#undef RUN_SMOKE_TEST
+}

--- a/kernels/test/targets.bzl
+++ b/kernels/test/targets.bzl
@@ -329,6 +329,7 @@ def define_common_targets():
     _common_op_test("op_upsample_bilinear2d_aa_test", ["portable"])
     _common_op_test("op_upsample_nearest2d_test", ["aten", "portable"])
     _common_op_test("op_var_test", ["aten", "portable"])
+    _common_op_test("op_view_as_complex_copy_test", ["aten", "portable"])
     _common_op_test("op_view_as_real_copy_test", ["aten", "portable"])
     _common_op_test("op_view_copy_test", ["aten", "portable"])
     _common_op_test("op_where_test", ["aten", "portable"])

--- a/shim_et/xplat/executorch/kernels/portable/op_registration_util.bzl
+++ b/shim_et/xplat/executorch/kernels/portable/op_registration_util.bzl
@@ -1333,6 +1333,12 @@ ATEN_OPS = (
         ],
     ),
     op_target(
+        name = "op_view_as_complex_copy",
+        deps = [
+            "//executorch/kernels/portable/cpu/util:copy_ops_util",
+        ],
+    ),
+    op_target(
         name = "op_view_as_real_copy",
         deps = [
             "//executorch/kernels/portable/cpu/util:copy_ops_util",


### PR DESCRIPTION
Summary: Add `view_as_complex_copy.out` operator needed for source separation model

Differential Revision: D93365634


