### PR TITLE
NXP backend: added support for `aten.div`

### DIFF
--- a/backends/nxp/aten_passes/convert_div_to_mul.py
+++ b/backends/nxp/aten_passes/convert_div_to_mul.py
@@ -1,0 +1,177 @@
+# Copyright 2026 NXP
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import math
+
+import torch
+
+from executorch.backends.nxp.backend.edge_helper import (
+    try_get_tensor_constant_from_node,
+)
+from torch._subclasses import FakeTensor, FakeTensorMode
+from torch.ao.quantization.fx.utils import get_new_attr_name_with_prefix
+from torch.export.unflatten import _assign_attr, _AttrKind
+from torch.fx import GraphModule, Node
+from torch.fx.passes.infra.pass_base import PassBase, PassResult
+
+
+class ConvertDivToMulPass(PassBase):
+    """
+    Replace `aten.div.Tensor` with `aten.mul.Tensor` by multiplying the quotient
+    with the reciprocal of the divisor (1 / divisor), when the divisor is known
+    at compile time or the divisor is a scalar (one number).
+
+                        x                                                         x
+                        │                                                         │
+        ┌───────────────▼───────────────┐      replace with      ┌────────────────▼────────────────┐
+        │  aten.div.Tensor(x, divisor)  │   ─────────────────►   │ aten.mul.Tensor(x, 1 / divisor) │
+        └───────────────┬───────────────┘                        └────────────────┬────────────────┘
+                        │                                                         │
+                        ▼                                                         ▼
+                       out                                                       out
+    """
+
+    @staticmethod
+    def _is_div_tensor(node_: Node) -> bool:
+        return node_.op == "call_function" and node_.target == torch.ops.aten.div.Tensor
+
+    def _create_mul_op_node(self, *mul_args) -> Node:
+        mul_target = torch.ops.aten.mul.Tensor
+        mul_node = self.graph_module.graph.call_function(mul_target, mul_args)
+
+        mul_node.meta["source_fn_stack"] = [(mul_node.name, mul_target)]
+
+        multiplier_1 = mul_args[0]
+        multiplier_2 = mul_args[1]
+        mul_1_val = multiplier_1.meta["val"]
+        mul_2_val = multiplier_2.meta["val"]
+        with FakeTensorMode() as mode:
+            fake_input_1 = FakeTensor.from_tensor(
+                torch.empty(mul_1_val.shape, dtype=mul_1_val.dtype), mode
+            )
+            fake_input_2 = FakeTensor.from_tensor(
+                torch.empty(mul_2_val.shape, dtype=mul_2_val.dtype), mode
+            )
+
+            output_shape = mul_target(fake_input_1, fake_input_2).shape
+            mul_node.meta["val"] = FakeTensor.from_tensor(
+                torch.empty(output_shape, dtype=mul_1_val.dtype), mode
+            )
+
+        return mul_node
+
+    def convert_divisor_to_multiplier(self, div_node: Node) -> torch.Tensor | None:
+        if len(div_node.args) <= 1:
+            return None
+
+        divisor_raw = div_node.args[1]
+        check_zero_atol = 1e-12
+        match divisor_raw:
+            # the `divisor` is a scalar - represented by a value in the node's `args`
+            case int() | float():
+                # check for division by zero - if it would occur, don't convert to `mul`
+                if math.isclose(divisor_raw, 0.0, rel_tol=0.0, abs_tol=check_zero_atol):
+                    return None
+
+                quotient_shape = div_node.all_input_nodes[0].meta["val"].shape
+                multiplier_val = 1.0 / divisor_raw
+
+                return torch.full(quotient_shape, multiplier_val, dtype=torch.float32)
+
+            # the `divisor` is a tensor - represented as a node in the graph
+            case Node():
+                divisor_t = try_get_tensor_constant_from_node(
+                    self.graph_module, divisor_raw
+                )
+
+                # check if tensor `divisor` is static
+                if divisor_t is None:
+                    return None
+
+                # check for division by zero - if it would occur, don't convert to `mul`
+                if (
+                    torch.isclose(
+                        divisor_t,
+                        torch.zeros_like(divisor_t),
+                        rtol=0.0,
+                        atol=check_zero_atol,
+                    )
+                    .any()
+                    .item()
+                ):
+                    return None
+
+                return 1.0 / divisor_t
+
+            case _:
+                return None
+
+    def _create_mul_data_node(self, div_node: Node) -> Node | None:
+        # get `multiplier` tensor, i.e. multiplier = (1 / divisor)
+        multiplier_t = self.convert_divisor_to_multiplier(div_node)
+        if multiplier_t is None:
+            return None
+
+        # create new node for the `multiplier` tensor and insert it into graph
+        tensor_name = get_new_attr_name_with_prefix("multiplier_")(self.graph_module)
+        _assign_attr(
+            torch.nn.Parameter(multiplier_t),
+            self.graph_module,
+            tensor_name,
+            _AttrKind.PARAMETER,
+        )
+
+        fake_mode = div_node.meta["val"].fake_mode
+        with self.graph_module.graph.inserting_before(div_node):
+            get_attr_node = self.graph_module.graph.create_node(
+                "get_attr", tensor_name, (), {}
+            )
+            get_attr_node.meta["val"] = fake_mode.from_tensor(
+                multiplier_t, static_shapes=True
+            )
+            multiplier_node = get_attr_node
+
+        return multiplier_node
+
+    def _erase_divisor_from_division_node(self, division_node: Node):
+        divisor_node = division_node.args[1]
+
+        # if the original `divisor` was a scalar,
+        # it was not represented by a node in the graph
+        if isinstance(divisor_node, Node):
+            self.graph_module.graph.erase_node(divisor_node)
+
+    def call(self, graph_module: GraphModule) -> PassResult:
+        self.graph_module = graph_module
+        made_changes = False
+
+        for node in list(graph_module.graph.nodes):
+            if not self._is_div_tensor(node):
+                continue
+            div_node = node
+
+            # division can be rewritten as multiplication:
+            #     quotient / divisor  →  quotient * (1 / divisor)
+            # the term `(1 / divisor)` is referred to as the `multiplier`
+            quotient_node = div_node.all_input_nodes[0]
+            multiplier_node = self._create_mul_data_node(div_node)
+
+            # cannot create `multiplier` because it is a non-static tensor
+            if multiplier_node is None:
+                continue
+
+            with self.graph_module.graph.inserting_after(div_node):
+                mul_node = self._create_mul_op_node(quotient_node, multiplier_node)
+
+            div_node.replace_all_uses_with(mul_node)
+            self.graph_module.graph.erase_node(div_node)
+            self._erase_divisor_from_division_node(div_node)
+
+            made_changes = True
+
+        self.graph_module.recompile()
+        self.graph_module.graph.eliminate_dead_code()
+
+        return PassResult(graph_module, made_changes)

--- a/backends/nxp/aten_passes/neutron_aten_pass_manager.py
+++ b/backends/nxp/aten_passes/neutron_aten_pass_manager.py
@@ -7,6 +7,7 @@ from typing import Callable
 
 import torch
 
+from executorch.backends.nxp.aten_passes.convert_div_to_mul import ConvertDivToMulPass
 from executorch.backends.nxp.aten_passes.decompose_split_to_slices_pass import (
     DecomposeSplitToSlicesPass,
 )
@@ -47,6 +48,7 @@ def _get_default_passes(neutron_target_spec, qat_mode: bool = False) -> list[Pas
         RemoveNodesWithKnownOutputs(),
         FuseLinearAndAddPass(),
         MoveActivationBeforeConcat(neutron_target_spec),
+        ConvertDivToMulPass(),
     ]
 
     if not qat_mode:

--- a/backends/nxp/tests/models.py
+++ b/backends/nxp/tests/models.py
@@ -800,3 +800,24 @@ class SqueezeAddModel(torch.nn.Module):
             return torch.squeeze(x + y)
         else:
             return torch.squeeze(x + y, self.dim)
+
+
+class StaticDivLinearModel(torch.nn.Module):
+    def __init__(self, in_channels=8, out_channels=8, divisor=1):
+        super().__init__()
+        self.linear = torch.nn.Linear(in_channels, out_channels)
+        self.divisor = divisor
+
+    def forward(self, x):
+        x = self.linear(x)
+        return x / self.divisor
+
+
+class NonstaticDivLinearModel(torch.nn.Module):
+    def __init__(self, in_channels=8, out_channels=8):
+        super().__init__()
+        self.linear = torch.nn.Linear(in_channels, out_channels)
+
+    def forward(self, x, divisor):
+        x = self.linear(x)
+        return x / divisor

--- a/backends/nxp/tests/test_convert_div_to_mul.py
+++ b/backends/nxp/tests/test_convert_div_to_mul.py
@@ -1,0 +1,250 @@
+# Copyright 2026 NXP
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import numpy as np
+import pytest
+import torch
+from executorch.backends.nxp.aten_passes.neutron_aten_pass_manager import (
+    ConvertDivToMulPass,
+    NeutronAtenPassManager,
+)
+from executorch.backends.nxp.backend.edge_program_converter import (
+    EdgeProgramToIRConverter,
+)
+from executorch.backends.nxp.tests.executorch_pipeline import (
+    neutron_target_spec,
+    to_quantized_edge_program,
+)
+from executorch.backends.nxp.tests.executors import (
+    convert_run_compare,
+    graph_contains_any_of_ops,
+)
+
+from executorch.backends.nxp.tests.models import (
+    NonstaticDivLinearModel,
+    StaticDivLinearModel,
+)
+from executorch.exir.dialects._ops import ops as exir_ops
+from torch.export import ExportedProgram
+
+
+@pytest.fixture(autouse=True)
+def reseed_model_per_test_run():
+    torch.manual_seed(42)
+    np.random.seed(23)
+
+
+def apply_individual_pass_and_compare(model, export_input, compare_input=None):
+    exir_program_aten = torch.export.export(
+        model,
+        export_input,
+    ).module()
+
+    # Check `aten.div` is present
+    assert graph_contains_any_of_ops(
+        exir_program_aten.graph, [torch.ops.aten.div.Tensor]
+    )
+    div_count_prev = sum(
+        [
+            n.target in [torch.ops.aten.div.Tensor]
+            for n in list(exir_program_aten.graph.nodes)
+        ]
+    )
+
+    if compare_input is None:
+        outputs_before = [o.detach().numpy() for o in exir_program_aten(*export_input)]
+    else:
+        outputs_before = [o.detach().numpy() for o in exir_program_aten(compare_input)]
+
+    # Apply the optimization.
+    NeutronAtenPassManager(neutron_target_spec, [ConvertDivToMulPass()])(
+        exir_program_aten
+    )
+
+    # Make sure no `aten.div` is in the model.
+    assert not graph_contains_any_of_ops(
+        exir_program_aten.graph,
+        [torch.ops.aten.div.Tensor],
+    )
+
+    # Make sure there is `aten.mul` in the model.
+    assert graph_contains_any_of_ops(
+        exir_program_aten.graph,
+        [torch.ops.aten.mul.Tensor],
+    )
+
+    mul_count_prev = sum(
+        [
+            n.target == torch.ops.aten.mul.Tensor
+            for n in list(exir_program_aten.graph.nodes)
+        ]
+    )
+
+    # Make sure the number of converted `mul` operators is the same as original `div` operators
+    assert div_count_prev == mul_count_prev
+
+    if compare_input is None:
+        outputs_after = [o.detach().numpy() for o in exir_program_aten(*export_input)]
+    else:
+        outputs_after = [o.detach().numpy() for o in exir_program_aten(compare_input)]
+
+    # Make sure the model still produces the exact same output
+    assert len(outputs_before) == len(outputs_after)
+
+    for i in range(len(outputs_before)):
+        assert np.allclose(outputs_before[i], outputs_after[i])
+
+
+@pytest.mark.parametrize(
+    "input_shape, is_scalar",
+    [
+        pytest.param((8,), True, id="1D, scalar."),
+        pytest.param((8, 8, 16), True, id="3D, scalar."),
+        pytest.param((8,), False, id="1D, tensor."),
+        pytest.param((16, 8, 16), False, id="3D, tensor."),
+    ],
+)
+def test_convert_div_to_mul_static(mocker, input_shape, is_scalar):
+    channels = input_shape[-1]
+    if is_scalar:
+        divisor = np.random.uniform(0, 15)
+        model = StaticDivLinearModel(
+            in_channels=channels, out_channels=channels, divisor=divisor
+        )
+    else:
+        divisor = torch.rand(input_shape)
+        model = StaticDivLinearModel(
+            in_channels=channels, out_channels=channels, divisor=divisor
+        )
+
+    example_input = torch.rand(input_shape, dtype=torch.float32)
+    apply_individual_pass_and_compare(model, (example_input,), example_input)
+
+
+@pytest.mark.parametrize(
+    "input_shape",
+    [
+        pytest.param((8,), id="1D, scalar."),
+        pytest.param((8, 8, 16), id="3D, scalar."),
+    ],
+)
+def test_convert_div_to_mul_nonstatic_scalar(mocker, input_shape):
+    channels = input_shape[-1]
+    model = NonstaticDivLinearModel(in_channels=channels, out_channels=channels)
+
+    divisor = np.random.uniform(0, 15)
+    example_input = (
+        torch.rand(input_shape, dtype=torch.float32),
+        divisor,
+    )
+    apply_individual_pass_and_compare(model, example_input)
+
+
+@pytest.mark.parametrize(
+    "input_shape",
+    [
+        pytest.param((8, 8, 16), id="3D."),
+    ],
+)
+def test_convert_div_to_mul_non_static_tensor(mocker, input_shape):
+    channels = input_shape[-1]
+    model = NonstaticDivLinearModel(in_channels=channels, out_channels=channels)
+
+    divisor = torch.rand(input_shape, dtype=torch.float32)
+    example_input = (
+        torch.rand(input_shape, dtype=torch.float32),
+        divisor,
+    )
+    exir_program_aten = torch.export.export(
+        model,
+        example_input,
+    ).module()
+
+    # Check `aten.div` is present
+    assert graph_contains_any_of_ops(
+        exir_program_aten.graph, [torch.ops.aten.div.Tensor]
+    )
+
+    # Apply the optimization.
+    NeutronAtenPassManager(neutron_target_spec, [ConvertDivToMulPass()])(
+        exir_program_aten
+    )
+
+    # Make sure `aten.div` is still in the model.
+    assert graph_contains_any_of_ops(
+        exir_program_aten.graph,
+        [torch.ops.aten.div.Tensor],
+    )
+
+    # Make sure there is no `aten.mul` in the model.
+    assert not graph_contains_any_of_ops(
+        exir_program_aten.graph,
+        [torch.ops.aten.mul.Tensor],
+    )
+
+
+@pytest.mark.parametrize(
+    "input_shape, is_scalar",
+    [
+        pytest.param((8, 8, 16), True, id="3D, scalar."),
+        pytest.param((8, 8, 16), False, id="3D, tensor."),
+    ],
+)
+def test_convert_div_to_mul_full_pipeline(mocker, input_shape, is_scalar):
+    converter_spy = mocker.spy(EdgeProgramToIRConverter, "convert_program")
+
+    channels = input_shape[-1]
+    if is_scalar:
+        divisor = np.random.uniform(0, 15)
+        model = StaticDivLinearModel(
+            in_channels=channels, out_channels=channels, divisor=divisor
+        )
+    else:
+        divisor = torch.rand(input_shape)
+        model = StaticDivLinearModel(
+            in_channels=channels, out_channels=channels, divisor=divisor
+        )
+
+    # Run conversion
+    edge_program = to_quantized_edge_program(
+        model,
+        input_shape,
+    ).exported_program()
+
+    # Capture generated model
+    neutron_ir_model = converter_spy.spy_return[0]
+    edge_partition: ExportedProgram = converter_spy.call_args.args[1]
+
+    # Make sure `aten.div` was converted to `aten.mul`
+    assert not graph_contains_any_of_ops(
+        edge_partition.graph,
+        [
+            exir_ops.edge.aten.div.Tensor,
+        ],
+    )
+    assert graph_contains_any_of_ops(
+        edge_partition.graph,
+        [
+            exir_ops.edge.aten.mul.Tensor,
+        ],
+    )
+
+    # Make sure everything was converted.
+    assert not graph_contains_any_of_ops(
+        edge_program.graph,
+        [
+            exir_ops.edge.aten.mul.Tensor,
+            exir_ops.edge.aten.div.Tensor,
+        ],
+    )
+
+    example_input = (np.random.random(input_shape).astype(np.float32) * 50).astype(
+        np.int8
+    )
+    convert_run_compare(
+        edge_partition,
+        input_data=example_input,
+        tfl_model=neutron_ir_model,
+    )

--- a/docs/source/backends/nxp/op-support.csv
+++ b/docs/source/backends/nxp/op-support.csv
@@ -9,6 +9,7 @@ aten.clamp.default,int8,static int8,"Bounds = (-1, 1) or (0, 1) or (0, 6) or (0,
 aten.clone.default,int8,static int8,
 aten.constant_pad_nd.default,int8,static int8,"H or W padding only"
 aten.convolution.default,int8,static int8,"1D or 2D convolution, constant weights, groups=1 or groups=channels_count (depthwise)"
+aten.div.Tensor,int8,static int8,"divisor - static tensor or scalar value, one dimension must satisfy %8 = 0 or scalar division (all dims = 1)"
 aten.hardtanh.default,int8,static int8,"supported ranges: <0,6>, <-1, 1>, <0,1>, <0,inf>"
 aten.leaky_relu.default,int8,static int8,
 aten.max_pool2d.default,int8,static int8,"dilation=1, ceil_mode=False"


### PR DESCRIPTION
### Summary

adds support for `aten.div` operator

### Test plan

tests can be manually run using `pytest -c /dev/null backends/nxp/tests/`

cc @robert-kalmar @JakeStevens @digantdesai @roman-janik-nxp @MartinPavella 