### PR TITLE
Arm backend: Configure logging at runtime in aot_arm_compiler

### DIFF
--- a/examples/arm/aot_arm_compiler.py
+++ b/examples/arm/aot_arm_compiler.py
@@ -73,9 +73,6 @@ from ..models import MODEL_NAME_TO_MODEL
 from ..models.model_factory import EagerModelFactory
 
 
-FORMAT = "[%(levelname)s %(asctime)s %(filename)s:%(lineno)s] %(message)s"
-logging.basicConfig(level=logging.WARNING, format=FORMAT)
-
 _arm_model_evaluator = None
 
 
@@ -636,8 +633,9 @@ def get_args():
             "--evaluate requires --quantize, --intermediates and --delegate to be enabled."
         )
 
-    if args.debug:
-        logging.basicConfig(level=logging.DEBUG, format=FORMAT, force=True)
+    LOGGING_FORMAT = "[%(levelname)s %(asctime)s %(filename)s:%(lineno)s] %(message)s"
+    logging_level = logging.DEBUG if args.debug else logging.WARNING
+    logging.basicConfig(level=logging_level, format=LOGGING_FORMAT, force=True)
 
     # if we have custom ops, register them before processing the model
     if args.so_library is not None:


### PR DESCRIPTION
Move logging setup out of module import and into `get_args()`, and always apply it with `force=True`. This prevents prior imports from locking the root logger at a different level.


cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai