### PR TITLE
Add live microphone support and warmup for Voxtral Realtime runner

### DIFF
--- a/examples/models/voxtral_realtime/main.cpp
+++ b/examples/models/voxtral_realtime/main.cpp
@@ -9,13 +9,25 @@
 // CLI entry point for the Voxtral Realtime transcriber.
 //
 // Loads a .pte model, a preprocessor .pte, and a Tekken tokenizer.
-// Processes a WAV file and prints transcribed text.
+// Processes a WAV file or live microphone audio.
 //
 // Modes:
 //   Default:     Offline transcription (full encoder, then decode)
-//   --streaming: Streaming transcription (incremental mel + encoder + decode)
+//   --streaming: Streaming transcription from WAV file
+//   --mic:       Live microphone transcription (reads raw f32le PCM from stdin)
+//
+// Mic usage (pipe from ffmpeg or any audio capture tool):
+//   ffmpeg -f avfoundation -i ":0" -ar 16000 -ac 1 -f f32le -nostats -loglevel
+//   error pipe:1 | \
+//     ./voxtral_realtime_runner --mic ...
 
+#include <csignal>
 #include <cstdio>
+
+#ifndef _WIN32
+#include <fcntl.h>
+#include <unistd.h>
+#endif
 
 #include <gflags/gflags.h>
 
@@ -36,12 +48,28 @@ DEFINE_string(audio_path, "", "Path to input audio file (.wav).");
 DEFINE_double(temperature, 0.0, "Sampling temperature (0 = greedy).");
 DEFINE_int32(max_new_tokens, 500, "Maximum number of tokens to generate.");
 DEFINE_bool(streaming, false, "Use streaming transcription mode.");
+DEFINE_bool(
+    mic,
+    false,
+    "Live microphone mode: read raw 16kHz float32 PCM from stdin.");
+
+namespace {
+volatile sig_atomic_t g_interrupted = 0;
+void sigint_handler(int) {
+  g_interrupted = 1;
+}
+} // namespace
 
 int main(int argc, char** argv) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
 
-  if (FLAGS_audio_path.empty()) {
-    ET_LOG(Error, "audio_path flag must be provided.");
+  if (FLAGS_audio_path.empty() && !FLAGS_mic) {
+    ET_LOG(Error, "Provide --audio_path or --mic.");
+    return 1;
+  }
+
+  if (!FLAGS_audio_path.empty() && FLAGS_mic) {
+    ET_LOG(Error, "--mic and --audio_path are mutually exclusive.");
     return 1;
   }
 
@@ -49,6 +77,9 @@ int main(int argc, char** argv) {
     ET_LOG(Error, "preprocessor_path flag must be provided.");
     return 1;
   }
+
+  // Install signal handler early so Ctrl+C is caught during load/warmup.
+  std::signal(SIGINT, sigint_handler);
 
   ::executorch::extension::llm::Stats stats;
   stats.model_load_start_ms = ::executorch::extension::llm::time_in_ms();
@@ -59,10 +90,6 @@ int main(int argc, char** argv) {
   stats.model_load_end_ms = ::executorch::extension::llm::time_in_ms();
   stats.inference_start_ms = ::executorch::extension::llm::time_in_ms();
 
-  ET_LOG(Info, "Loading audio from: %s", FLAGS_audio_path.c_str());
-  auto audio_data =
-      ::executorch::extension::llm::load_wav_audio_data(FLAGS_audio_path);
-
   voxtral_realtime::TranscribeConfig config;
   config.temperature = static_cast<float>(FLAGS_temperature);
   config.max_new_tokens = FLAGS_max_new_tokens;
@@ -70,24 +97,90 @@ int main(int argc, char** argv) {
   stats.num_prompt_tokens = 0;
   bool first_token = true;
 
+  // Set to true for green-colored output.
+  const bool use_color = false;
+
   auto token_cb = [&](const std::string& piece) {
     if (first_token) {
       stats.first_token_ms = ::executorch::extension::llm::time_in_ms();
       stats.prompt_eval_end_ms = stats.first_token_ms;
       first_token = false;
     }
-    ::executorch::extension::llm::safe_printf(piece.c_str());
+    if (!piece.empty() && piece.front() == '[' && piece.back() == ']') {
+      // Uncomment to print special tokens
+      // ::executorch::extension::llm::safe_printf(piece.c_str());
+    } else {
+      if (use_color) {
+        printf("\033[32m");
+      }
+      ::executorch::extension::llm::safe_printf(piece.c_str());
+      if (use_color) {
+        printf("\033[0m");
+      }
+    }
     fflush(stdout);
   };
 
   int num_generated;
-  if (FLAGS_streaming) {
+  if (FLAGS_mic) {
+    // Live microphone: read raw 16kHz float32 PCM from stdin.
     ET_CHECK_MSG(
         runner.is_streaming(),
         "Model was not exported with --streaming. Re-export with --streaming flag.");
     auto session = runner.create_streaming_session(config, token_cb);
 
-    // Feed audio in 80ms chunks (one streaming step = 1280 samples at 16kHz).
+    // Drain any audio that buffered in stdin during model loading/warmup.
+    // Without this, piped audio (e.g., from ffmpeg) accumulates while the
+    // model loads and gets processed in a burst, breaking real-time behavior.
+#ifndef _WIN32
+    {
+      int fd = fileno(stdin);
+      int flags = fcntl(fd, F_GETFL, 0);
+      if (flags >= 0) {
+        fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+        char drain[4096];
+        while (read(fd, drain, sizeof(drain)) > 0) {
+        }
+        clearerr(stdin);
+        fcntl(fd, F_SETFL, flags);
+      }
+    }
+#endif
+
+    fprintf(stdout, "Listening (Ctrl+C to stop)...\n");
+    fflush(stdout);
+
+    // Read 80ms chunks (1280 samples * 4 bytes = 5120 bytes).
+    // StreamingSession internally processes in 80ms steps.
+    const size_t chunk_samples = 1280;
+    const size_t chunk_bytes = chunk_samples * sizeof(float);
+    std::vector<float> buf(chunk_samples);
+
+    while (!g_interrupted) {
+      size_t bytes_read = fread(buf.data(), 1, chunk_bytes, stdin);
+      if (bytes_read == 0) {
+        break;
+      }
+      // Discard trailing bytes not aligned to sizeof(float).
+      size_t samples_read = bytes_read / sizeof(float);
+      if (samples_read == 0) {
+        continue;
+      }
+      if (samples_read < chunk_samples) {
+        std::fill(buf.begin() + samples_read, buf.end(), 0.0f);
+      }
+      session->feed_audio(buf.data(), static_cast<int64_t>(samples_read));
+    }
+    num_generated = session->flush();
+  } else if (FLAGS_streaming) {
+    ET_CHECK_MSG(
+        runner.is_streaming(),
+        "Model was not exported with --streaming. Re-export with --streaming flag.");
+    ET_LOG(Info, "Loading audio from: %s", FLAGS_audio_path.c_str());
+    auto audio_data =
+        ::executorch::extension::llm::load_wav_audio_data(FLAGS_audio_path);
+    auto session = runner.create_streaming_session(config, token_cb);
+
     const int64_t chunk_size = 1280;
     for (int64_t offset = 0; offset < static_cast<int64_t>(audio_data.size());
          offset += chunk_size) {
@@ -97,6 +190,9 @@ int main(int argc, char** argv) {
     }
     num_generated = session->flush();
   } else {
+    ET_LOG(Info, "Loading audio from: %s", FLAGS_audio_path.c_str());
+    auto audio_data =
+        ::executorch::extension::llm::load_wav_audio_data(FLAGS_audio_path);
     num_generated = runner.transcribe(
         audio_data.data(),
         static_cast<int64_t>(audio_data.size()),

--- a/examples/models/voxtral_realtime/voxtral_realtime_runner.cpp
+++ b/examples/models/voxtral_realtime/voxtral_realtime_runner.cpp
@@ -30,7 +30,8 @@ namespace voxtral_realtime {
 VoxtralRealtimeRunner::VoxtralRealtimeRunner(
     const std::string& model_path,
     const std::string& tokenizer_path,
-    const std::string& preprocessor_path) {
+    const std::string& preprocessor_path,
+    bool warmup) {
   // Load the main model (.pte with audio_encoder, text_decoder,
   // token_embedding methods). Mmap avoids copying the file into memory.
   ET_LOG(Info, "Loading model from: %s", model_path.c_str());
@@ -121,6 +122,66 @@ VoxtralRealtimeRunner::VoxtralRealtimeRunner(
         std::make_unique<Module>(preprocessor_path, Module::LoadMode::Mmap);
     auto pp_error = preprocessor_->load();
     ET_CHECK_MSG(pp_error == Error::Ok, "Failed to load preprocessor.");
+  }
+
+  // Warmup: trigger lazy initialization (XNNPACK workspace allocation, etc.).
+  // For streaming: run a single dummy step through the full pipeline.
+  // For offline: call each method once with minimal inputs (can't use
+  // transcribe() because the offline preprocessor pads to 30-second chunks).
+  if (warmup && preprocessor_) {
+    ET_LOG(Info, "Warming up...");
+    std::vector<float> dummy_audio(static_cast<size_t>(step_samples_), 0.0f);
+
+    if (is_streaming_) {
+      TranscribeConfig warmup_config;
+      warmup_config.max_new_tokens = 1;
+      auto session =
+          create_streaming_session(warmup_config, [](const std::string&) {});
+      session->feed_audio(dummy_audio.data(), step_samples_);
+      session->flush();
+    } else {
+      // Preprocessor
+      auto pp_wav = from_blob(
+          dummy_audio.data(),
+          {static_cast<int>(step_samples_)},
+          ::executorch::aten::ScalarType::Float);
+      auto pp_r =
+          preprocessor_->execute("forward", std::vector<EValue>{*pp_wav});
+      ET_CHECK_MSG(pp_r.ok(), "Warmup: preprocessor failed.");
+
+      // Audio encoder (8 mel frames = minimum valid input)
+      std::vector<float> dummy_mel(
+          static_cast<size_t>(num_mel_bins_ * 8), 0.0f);
+      auto mel_t = from_blob(
+          dummy_mel.data(),
+          {1, static_cast<int>(num_mel_bins_), 8},
+          ::executorch::aten::ScalarType::Float);
+      auto enc_r =
+          model_->execute("audio_encoder", std::vector<EValue>{*mel_t});
+      ET_CHECK_MSG(enc_r.ok(), "Warmup: audio_encoder failed.");
+
+      // Token embedding
+      int64_t dummy_tok = static_cast<int64_t>(bos_id_);
+      auto tok_t =
+          from_blob(&dummy_tok, {1, 1}, ::executorch::aten::ScalarType::Long);
+      auto tok_r =
+          model_->execute("token_embedding", std::vector<EValue>{*tok_t});
+      ET_CHECK_MSG(tok_r.ok(), "Warmup: token_embedding failed.");
+
+      // Text decoder
+      std::vector<float> dummy_emb(static_cast<size_t>(dim_), 0.0f);
+      int64_t dummy_pos = 0;
+      auto emb_t = from_blob(
+          dummy_emb.data(),
+          {1, 1, static_cast<int>(dim_)},
+          ::executorch::aten::ScalarType::Float);
+      auto pos_t =
+          from_blob(&dummy_pos, {1}, ::executorch::aten::ScalarType::Long);
+      auto dec_r =
+          model_->execute("text_decoder", std::vector<EValue>{*emb_t, *pos_t});
+      ET_CHECK_MSG(dec_r.ok(), "Warmup: text_decoder failed.");
+    }
+    ET_LOG(Info, "Warmup complete.");
   }
 }
 

--- a/examples/models/voxtral_realtime/voxtral_realtime_runner.h
+++ b/examples/models/voxtral_realtime/voxtral_realtime_runner.h
@@ -39,7 +39,8 @@ class VoxtralRealtimeRunner {
   VoxtralRealtimeRunner(
       const std::string& model_path,
       const std::string& tokenizer_path,
-      const std::string& preprocessor_path = "");
+      const std::string& preprocessor_path = "",
+      bool warmup = true);
 
   // Offline transcription: full encoder first, then step-by-step decode.
   int transcribe(


### PR DESCRIPTION
- Add --mic flag: reads raw 16kHz float32 PCM from stdin for live
  transcription. Drains buffered stdin after model load to avoid
  processing stale audio. SIGINT handler for clean shutdown.
- Add warmup: runs a dummy transcription during construction to trigger
  XNNPACK lazy initialization. Streaming uses full pipeline (1 step),
  offline uses per-method calls to avoid 30-second preprocessor padding.
- Green ANSI coloring for transcribed text, special tokens printed
  without color.
- Defer WAV loading to branches that need it (not loaded for --mic).



```(executorch_dev) mnachin@mnachin-mbp executorch % ffmpeg -f avfoundation -i ":0" -ar 16000 -ac 1 -f f32le -nostats -loglevel error pipe:1 | \
  cmake-out/examples/models/voxtral_realtime/voxtral_realtime_runner \
    --model_path examples/models/voxtral_realtime/voxtral_streaming_exports/model.pte \
    --tokenizer_path ~/repos/models/Voxtral-Mini-4B-Realtime-2602/tekken.json \
    --preprocessor_path examples/models/voxtral_realtime/voxtral_streaming_exports/preprocessor.pte \
    --mic
I tokenizers:regex.cpp:27] Registering override fallback regex
I tokenizers:tekken.cpp:92] Loading Tekken tokenizer from: /Users/mnachin/repos/models/Voxtral-Mini-4B-Realtime-2602/tekken.json
I tokenizers:tekken.cpp:125] Tekken version: v7, vocab_size: 131072, special_tokens: 1000
I tokenizers:tekken.cpp:131] Loading special tokens from JSON
I tokenizers:tekken.cpp:307] Initialized 1000 special tokens (1000 defined, 0 placeholders)
I tokenizers:tekken.cpp:148] Loading 130072 vocabulary tokens
I tokenizers:tekken.cpp:247] Processing 130072 vocabulary entries (limit: 130072)
I tokenizers:tekken.cpp:280] Built vocabulary with 130072 tokens
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
E0000 00:00:1771336683.851963 22483944 re2.cc:237] Error parsing '([^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]*[\p{Ll}\p{Lm}\p{Lo}\p{M}]+|[^\r\n\p{L}\p{N}]?[\p{...': invalid perl operator: (?!
I tokenizers:re2_regex.cpp:27] Re2 failed to compile regex: ([^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]*[\p{Ll}\p{Lm}\p{Lo}\p{M}]+|[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]+[\p{Ll}\p{Lm}\p{Lo}\p{M}]*|\p{N}| ?[^\s\p{L}\p{N}]+[\r\n/]*|\s*[\r\n]+|\s+(?!\S)|\s+), error: inv$
I tokenizers:regex_lookahead.cpp:27] Creating PCRE2 regex
I tokenizers:tekken.cpp:206] Tekken tokenizer loaded successfully. Vocab size: 131072, BOS: 1, EOS: 2
Listening (Ctrl+C to stop)...
 Good morning, this is Morgan. The 8.50 a.m. Testing an AI model.</s>
PyTorchObserver {"prompt_tokens":0,"generated_tokens":190,"model_load_start_ms":1771336683653,"model_load_end_ms":1771336687993,"inference_start_ms":1771336687993,"inference_end_ms":1771336719517,"prompt_eval_end_ms":1771336688094,"first_token_ms":1771336688094,"aggregate_sampling_time_ms":0,"SCALING_FACTOR_UNITS_PER_SECOND":1000}
```