### PR TITLE
Skeleton out more robust program validation

### DIFF
--- a/runtime/executor/program.cpp
+++ b/runtime/executor/program.cpp
@@ -14,6 +14,7 @@
 #include <executorch/runtime/core/event_tracer_hooks.h>
 #include <executorch/runtime/executor/memory_manager.h>
 #include <executorch/runtime/executor/method.h>
+#include <executorch/runtime/executor/program_validation.h>
 #include <executorch/runtime/platform/profiler.h>
 #include <executorch/schema/extended_header.h>
 #include <executorch/schema/program_generated.h>
@@ -150,6 +151,13 @@ Result<executorch_flatbuffer::ExecutionPlan*> get_execution_plan(
         ok,
         InvalidProgram,
         "Verification failed; data may be truncated or corrupt");
+    const executorch_flatbuffer::Program* flatbuffer_program =
+        executorch_flatbuffer::GetProgram(program_data->data());
+    Error err = validate_program(flatbuffer_program);
+    ET_CHECK_OR_RETURN_ERROR(
+        err == Error::Ok,
+        InvalidProgram,
+        "Program validation failed: likely a corrupt file");
 #else
     ET_LOG(
         Info, "InternalConsistency verification requested but not available");

--- a/runtime/executor/program.h
+++ b/runtime/executor/program.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <cinttypes>
 #include <cstdint>
 #include <optional>
 
@@ -58,10 +57,15 @@ class Program final {
      */
     Minimal,
     /**
+     * When ET_ENABLE_PROGRAM_VERIFICATION is enabled,
      * Do full verification of the data, ensuring that internal pointers are
      * self-consistent and that the data has not been truncated or obviously
      * corrupted. May not catch all types of corruption, but should guard
      * against illegal memory operations during parsing.
+     * Also performs additional semantic validation such as:
+     * - Tensor numel overflow checks (ensuring size calculations don't
+     * overflow)
+     * - List element type validation
      *
      * Will have higher runtime overhead, scaling with the complexity of the
      * proram data.

--- a/runtime/executor/program_validation.cpp
+++ b/runtime/executor/program_validation.cpp
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/runtime/executor/program_validation.h>
+
+#include <cstdint>
+
+#include <executorch/runtime/core/exec_aten/util/scalar_type_util.h>
+#include <executorch/runtime/platform/log.h>
+#include <executorch/schema/program_generated.h>
+
+#include <c10/util/safe_numerics.h>
+
+namespace executorch {
+namespace runtime {
+
+ET_NODISCARD Error
+validate_tensor(const executorch_flatbuffer::Tensor* tensor) {
+  if (tensor == nullptr) {
+    return Error::InvalidProgram;
+  }
+
+  const auto* sizes = tensor->sizes();
+  if (sizes == nullptr) {
+    return Error::InvalidProgram;
+  }
+
+  ssize_t numel = 1;
+  for (flatbuffers::uoffset_t i = 0; i < sizes->size(); i++) {
+    int32_t size = sizes->Get(i);
+
+    if (size < 0) {
+      ET_LOG(
+          Error,
+          "Size must be non-negative, got %d at dimension %u",
+          size,
+          static_cast<unsigned>(i));
+      return Error::InvalidProgram;
+    }
+
+    bool overflow =
+        c10::mul_overflows(numel, static_cast<ssize_t>(size), &numel);
+    if (overflow) {
+      ET_LOG(
+          Error,
+          "numel overflowed at dimension %u with size %d",
+          static_cast<unsigned>(i),
+          size);
+      return Error::InvalidProgram;
+    }
+  }
+
+  auto scalar_type =
+      static_cast<executorch::aten::ScalarType>(tensor->scalar_type());
+  if (!executorch::runtime::isValid(scalar_type)) {
+    return Error::InvalidProgram;
+  }
+
+  size_t nbytes;
+  bool nbytes_overflow = c10::mul_overflows(
+      static_cast<size_t>(numel),
+      executorch::runtime::elementSize(scalar_type),
+      &nbytes);
+  if (nbytes_overflow) {
+    ET_LOG(
+        Error,
+        "nbytes overflowed: numel %zd with element size %zu",
+        numel,
+        executorch::runtime::elementSize(scalar_type));
+    return Error::InvalidProgram;
+  }
+
+  return Error::Ok;
+}
+
+ET_NODISCARD Error
+validate_program(const executorch_flatbuffer::Program* program) {
+  if (program == nullptr) {
+    return Error::InvalidProgram;
+  }
+
+  // Validate all execution plans.
+  const auto* execution_plans = program->execution_plan();
+  if (execution_plans == nullptr) {
+    ET_LOG(Error, "Program has null execution_plan");
+    return Error::InvalidProgram;
+  }
+
+  for (flatbuffers::uoffset_t plan_idx = 0; plan_idx < execution_plans->size();
+       plan_idx++) {
+    const auto* plan = execution_plans->Get(plan_idx);
+    if (plan == nullptr) {
+      ET_LOG(
+          Error, "Execution plan %u is null", static_cast<unsigned>(plan_idx));
+      return Error::InvalidProgram;
+    }
+
+    // Validate all values in the plan.
+    const auto* values = plan->values();
+    if (values == nullptr) {
+      ET_LOG(
+          Error,
+          "Execution plan %u has null values table",
+          static_cast<unsigned>(plan_idx));
+      return Error::InvalidProgram;
+    }
+
+    for (flatbuffers::uoffset_t value_idx = 0; value_idx < values->size();
+         value_idx++) {
+      const auto* value = values->Get(value_idx);
+      if (value == nullptr) {
+        continue;
+      }
+
+      // Check if this value is a tensor.
+      if (value->val_type() == executorch_flatbuffer::KernelTypes::Tensor) {
+        const auto* tensor =
+            static_cast<const executorch_flatbuffer::Tensor*>(value->val());
+
+        Error err = validate_tensor(tensor);
+        if (err != Error::Ok) {
+          ET_LOG(
+              Error,
+              "Tensor validation failed for value %u in execution plan %u",
+              static_cast<unsigned>(value_idx),
+              static_cast<unsigned>(plan_idx));
+          return err;
+        }
+      }
+
+      // Check if this value is a TensorList.
+      if (value->val_type() == executorch_flatbuffer::KernelTypes::TensorList) {
+        const auto* tensor_list =
+            static_cast<const executorch_flatbuffer::TensorList*>(value->val());
+
+        if (tensor_list == nullptr) {
+          ET_LOG(
+              Error,
+              "TensorList is null for value %u in execution plan %u",
+              static_cast<unsigned>(value_idx),
+              static_cast<unsigned>(plan_idx));
+          return Error::InvalidProgram;
+        }
+
+        const auto* items = tensor_list->items();
+        if (items == nullptr) {
+          ET_LOG(Error, "TensorList items is null");
+          return Error::InvalidProgram;
+        }
+
+        // Validate that each item index points to a Tensor evalue.
+        for (flatbuffers::uoffset_t item_idx = 0; item_idx < items->size();
+             item_idx++) {
+          int32_t evalue_index = items->Get(item_idx);
+
+          // Check bounds.
+          if (evalue_index < 0 ||
+              static_cast<flatbuffers::uoffset_t>(evalue_index) >=
+                  values->size()) {
+            ET_LOG(
+                Error,
+                "TensorList item %u has out-of-bounds index %d (values size "
+                "%u) in execution plan %u",
+                static_cast<unsigned>(item_idx),
+                evalue_index,
+                static_cast<unsigned>(values->size()),
+                static_cast<unsigned>(plan_idx));
+            return Error::InvalidProgram;
+          }
+
+          // Check that the referenced evalue is actually a Tensor.
+          const auto* referenced_value = values->Get(evalue_index);
+          if (referenced_value == nullptr) {
+            ET_LOG(
+                Error,
+                "TensorList item %u references null evalue at index %d in "
+                "execution plan %u",
+                static_cast<unsigned>(item_idx),
+                evalue_index,
+                static_cast<unsigned>(plan_idx));
+            return Error::InvalidProgram;
+          }
+
+          if (referenced_value->val_type() !=
+              executorch_flatbuffer::KernelTypes::Tensor) {
+            ET_LOG(
+                Error,
+                "TensorList item %u references non-Tensor evalue (type %d) at "
+                "index %d in execution plan %u",
+                static_cast<unsigned>(item_idx),
+                static_cast<int>(referenced_value->val_type()),
+                evalue_index,
+                static_cast<unsigned>(plan_idx));
+            return Error::InvalidProgram;
+          }
+        }
+      }
+    }
+  }
+
+  return Error::Ok;
+}
+
+} // namespace runtime
+} // namespace executorch

--- a/runtime/executor/program_validation.h
+++ b/runtime/executor/program_validation.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <executorch/runtime/core/error.h>
+
+// Forward declare flatbuffer types.
+namespace executorch_flatbuffer {
+struct ExecutionPlan;
+struct Program;
+struct Tensor;
+struct TensorList;
+} // namespace executorch_flatbuffer
+
+namespace executorch {
+namespace runtime {
+
+/**
+ * Validates that computing numel (number of elements) from the tensor's sizes
+ * will not overflow. This check should be performed before creating TensorImpl
+ * objects to prevent undefined behavior from integer overflow.
+ *
+ * @param[in] tensor The flatbuffer Tensor to validate.
+ * @return Error::Ok if the numel calculation is safe, Error::InvalidProgram
+ *     if computing numel would overflow.
+ */
+ET_NODISCARD Error validate_tensor(const executorch_flatbuffer::Tensor* tensor);
+
+/**
+ * Performs validation of all tensors and lists in the program, checking that
+ * their metadata is semantically valid and will not cause issues during
+ * execution.
+ *
+ * Currently validates:
+ * - Tensor numel overflow (all tensors)
+ * - TensorList element types (all TensorLists)
+ *
+ * @param[in] program The flatbuffer Program to validate.
+ * @return Error::Ok if validation passes, Error::InvalidProgram if any
+ *     validation check fails.
+ */
+ET_NODISCARD Error
+validate_program(const executorch_flatbuffer::Program* program);
+
+} // namespace runtime
+} // namespace executorch

--- a/runtime/executor/targets.bzl
+++ b/runtime/executor/targets.bzl
@@ -90,6 +90,7 @@ def define_common_targets():
             ],
             headers = [
                 "platform_memory_allocator.h",
+                "program_validation.h",
             ],
             exported_headers = [
                 "method.h",
@@ -121,7 +122,8 @@ def define_common_targets():
             ],
             deps = [
                 "//executorch/schema:program",
-                "//executorch/runtime/core/exec_aten/util:tensor_dimension_limit"
+                "//executorch/runtime/core/exec_aten/util:tensor_dimension_limit",
+                "//executorch/runtime/core/portable_type/c10/c10:c10",
             ],
             visibility = ["PUBLIC"],
         )

--- a/runtime/executor/test/program_validation_test.cpp
+++ b/runtime/executor/test/program_validation_test.cpp
@@ -1,0 +1,271 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <cstring>
+#include <memory>
+
+#include <executorch/extension/data_loader/buffer_data_loader.h>
+#include <executorch/extension/data_loader/file_data_loader.h>
+#include <executorch/runtime/core/error.h>
+#include <executorch/runtime/executor/program.h>
+#include <executorch/runtime/platform/runtime.h>
+#include <executorch/schema/program_generated.h>
+
+#include <gtest/gtest.h>
+
+using namespace ::testing;
+using executorch::runtime::Error;
+using executorch::runtime::FreeableBuffer;
+using executorch::runtime::Program;
+using executorch::runtime::Result;
+using torch::executor::util::BufferDataLoader;
+using torch::executor::util::FileDataLoader;
+
+namespace {
+
+// RAII wrapper for aligned buffer allocation.
+class AlignedBuffer {
+ public:
+  explicit AlignedBuffer(const std::vector<uint8_t>& data)
+      : buffer_(std::make_unique<uint8_t[]>(data.size() + kAlignment)),
+        size_(data.size()) {
+    uintptr_t addr = reinterpret_cast<uintptr_t>(buffer_.get());
+    offset_ = (kAlignment - (addr % kAlignment)) % kAlignment;
+    memcpy(buffer_.get() + offset_, data.data(), data.size());
+  }
+
+  uint8_t* data() {
+    return buffer_.get() + offset_;
+  }
+  size_t size() const {
+    return size_;
+  }
+
+  BufferDataLoader loader() {
+    return BufferDataLoader(data(), size());
+  }
+
+ private:
+  static constexpr size_t kAlignment = alignof(std::max_align_t);
+  std::unique_ptr<uint8_t[]> buffer_;
+  size_t offset_;
+  size_t size_;
+};
+
+// EValue type configuration for program creation.
+enum class EValueType { Tensor, Int, TensorList };
+
+struct EValueConfig {
+  EValueType type;
+  std::vector<int32_t> tensor_sizes; // For Tensor type.
+  std::vector<int32_t> tensor_list_items; // For TensorList type (indices).
+};
+
+// Unified helper to create a minimal valid PTE flatbuffer with configurable
+// evalues. Returns a buffer containing the flatbuffer data.
+std::vector<uint8_t> CreateTestProgram(
+    const std::vector<EValueConfig>& configs) {
+  flatbuffers::FlatBufferBuilder builder(1024);
+
+  std::vector<flatbuffers::Offset<executorch_flatbuffer::EValue>> evalues;
+
+  for (const auto& config : configs) {
+    switch (config.type) {
+      case EValueType::Tensor: {
+        auto sizes_vec = builder.CreateVector(config.tensor_sizes);
+        std::vector<uint8_t> dim_order(config.tensor_sizes.size());
+        for (size_t i = 0; i < config.tensor_sizes.size(); i++) {
+          dim_order[i] = static_cast<uint8_t>(i);
+        }
+        auto dim_order_vec = builder.CreateVector(dim_order);
+        auto tensor = executorch_flatbuffer::CreateTensor(
+            builder,
+            executorch_flatbuffer::ScalarType::FLOAT,
+            /*storage_offset=*/0,
+            sizes_vec,
+            dim_order_vec,
+            /*requires_grad=*/false,
+            /*data_buffer_idx=*/0,
+            /*allocation_info=*/0,
+            /*layout=*/0,
+            executorch_flatbuffer::TensorShapeDynamism::STATIC,
+            /*extra_tensor_info=*/0);
+        evalues.push_back(executorch_flatbuffer::CreateEValue(
+            builder,
+            executorch_flatbuffer::KernelTypes::Tensor,
+            tensor.Union()));
+        break;
+      }
+      case EValueType::Int: {
+        auto int_val = executorch_flatbuffer::CreateInt(builder, 42);
+        evalues.push_back(executorch_flatbuffer::CreateEValue(
+            builder, executorch_flatbuffer::KernelTypes::Int, int_val.Union()));
+        break;
+      }
+      case EValueType::TensorList: {
+        auto items = builder.CreateVector(config.tensor_list_items);
+        auto tensor_list =
+            executorch_flatbuffer::CreateTensorList(builder, items);
+        evalues.push_back(executorch_flatbuffer::CreateEValue(
+            builder,
+            executorch_flatbuffer::KernelTypes::TensorList,
+            tensor_list.Union()));
+        break;
+      }
+      default:
+        ET_CHECK_MSG(false, "Invalid EValueType");
+    }
+  }
+
+  auto values_vec = builder.CreateVector(evalues);
+  auto plan_name = builder.CreateString("forward");
+  auto empty_int_vec = builder.CreateVector(std::vector<int32_t>{});
+  auto empty_int64_vec = builder.CreateVector(std::vector<int64_t>{0});
+  auto empty_chain_vec = builder.CreateVector(
+      std::vector<flatbuffers::Offset<executorch_flatbuffer::Chain>>{});
+  auto empty_operators_vec = builder.CreateVector(
+      std::vector<flatbuffers::Offset<executorch_flatbuffer::Operator>>{});
+  auto empty_delegates_vec = builder.CreateVector(
+      std::vector<
+          flatbuffers::Offset<executorch_flatbuffer::BackendDelegate>>{});
+
+  auto execution_plan = executorch_flatbuffer::CreateExecutionPlan(
+      builder,
+      plan_name,
+      /*container_meta_type=*/0,
+      values_vec,
+      empty_int_vec,
+      empty_int_vec,
+      empty_chain_vec,
+      empty_operators_vec,
+      empty_delegates_vec,
+      empty_int64_vec);
+
+  std::vector<flatbuffers::Offset<executorch_flatbuffer::ExecutionPlan>> plans;
+  plans.push_back(execution_plan);
+  auto plans_vec = builder.CreateVector(plans);
+
+  auto program = executorch_flatbuffer::CreateProgram(
+      builder,
+      /*version=*/0,
+      plans_vec,
+      /*constant_buffer=*/0,
+      /*backend_delegate_data=*/0,
+      /*segments=*/0,
+      /*constant_segment=*/0,
+      /*mutable_data_segments=*/0,
+      /*named_data=*/0);
+
+  builder.Finish(program, executorch_flatbuffer::ProgramIdentifier());
+
+  const uint8_t* buf = builder.GetBufferPointer();
+  size_t size = builder.GetSize();
+  return std::vector<uint8_t>(buf, buf + size);
+}
+
+} // namespace
+
+class ProgramValidationTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    executorch::runtime::runtime_init();
+
+    const char* path = std::getenv("ET_MODULE_ADD_PATH");
+    Result<FileDataLoader> loader = FileDataLoader::from(path);
+    ASSERT_EQ(loader.error(), Error::Ok);
+    add_loader_ = std::make_unique<FileDataLoader>(std::move(loader.get()));
+  }
+
+  std::unique_ptr<FileDataLoader> add_loader_;
+};
+
+TEST_F(ProgramValidationTest, ValidProgramPassesInternalConsistency) {
+  Result<Program> program = Program::load(
+      add_loader_.get(), Program::Verification::InternalConsistency);
+  EXPECT_EQ(program.error(), Error::Ok);
+}
+
+TEST_F(ProgramValidationTest, InternalConsistencyDetectsTruncatedData) {
+  size_t full_data_len = add_loader_->size().get();
+  Result<FreeableBuffer> full_data = add_loader_->load(
+      /*offset=*/0,
+      full_data_len,
+      executorch::runtime::DataLoader::SegmentInfo(
+          executorch::runtime::DataLoader::SegmentInfo::Type::Program));
+  ASSERT_EQ(full_data.error(), Error::Ok);
+
+  BufferDataLoader half_data_loader(full_data->data(), full_data_len / 2);
+
+  Result<Program> program = Program::load(
+      &half_data_loader, Program::Verification::InternalConsistency);
+  ASSERT_EQ(program.error(), Error::InvalidProgram);
+}
+
+TEST_F(ProgramValidationTest, TensorNumelOverflowDetected) {
+  std::vector<EValueConfig> configs = {
+      {EValueType::Tensor, {2000000000, 2000000000, 2000000000}, {}}};
+
+  AlignedBuffer buf(CreateTestProgram(configs));
+  auto loader = buf.loader();
+
+  Result<Program> program =
+      Program::load(&loader, Program::Verification::InternalConsistency);
+  EXPECT_EQ(program.error(), Error::InvalidProgram);
+}
+
+TEST_F(ProgramValidationTest, TensorNumelOverflowNotDetectedWithMinimal) {
+  std::vector<EValueConfig> configs = {
+      {EValueType::Tensor, {2000000000, 2000000000, 2000000000}, {}}};
+
+  AlignedBuffer buf(CreateTestProgram(configs));
+  auto loader = buf.loader();
+
+  // Minimal verification doesn't run program validation.
+  Result<Program> program =
+      Program::load(&loader, Program::Verification::Minimal);
+}
+
+TEST_F(ProgramValidationTest, NegativeSizeDetected) {
+  std::vector<EValueConfig> configs = {{EValueType::Tensor, {10, -5, 10}, {}}};
+
+  AlignedBuffer buf(CreateTestProgram(configs));
+  auto loader = buf.loader();
+
+  Result<Program> program =
+      Program::load(&loader, Program::Verification::InternalConsistency);
+  EXPECT_EQ(program.error(), Error::InvalidProgram);
+}
+
+TEST_F(ProgramValidationTest, TensorListWithIntElementDetected) {
+  // values[0] = Tensor, values[1] = Int (INVALID!), values[2] = TensorList([0,
+  // 1])
+  std::vector<EValueConfig> configs = {
+      {EValueType::Tensor, {2, 3}, {}},
+      {EValueType::Int, {}, {}},
+      {EValueType::TensorList, {}, {0, 1}}};
+
+  AlignedBuffer buf(CreateTestProgram(configs));
+  auto loader = buf.loader();
+
+  Result<Program> program =
+      Program::load(&loader, Program::Verification::InternalConsistency);
+  EXPECT_EQ(program.error(), Error::InvalidProgram);
+}
+
+TEST_F(ProgramValidationTest, TensorListWithOutOfBoundsIndexDetected) {
+  // values[0] = Tensor, values[1] = TensorList([0, 99]) - 99 is out of bounds
+  std::vector<EValueConfig> configs = {
+      {EValueType::Tensor, {2, 3}, {}}, {EValueType::TensorList, {}, {0, 99}}};
+
+  AlignedBuffer buf(CreateTestProgram(configs));
+  auto loader = buf.loader();
+
+  Result<Program> program =
+      Program::load(&loader, Program::Verification::InternalConsistency);
+  EXPECT_EQ(program.error(), Error::InvalidProgram);
+}

--- a/runtime/executor/test/targets.bzl
+++ b/runtime/executor/test/targets.bzl
@@ -196,6 +196,20 @@ def define_common_targets(is_fbcode = False):
         )
 
         runtime.cxx_test(
+            name = "program_validation_test",
+            srcs = [
+                "program_validation_test.cpp",
+            ],
+            deps = [
+                "//executorch/runtime/executor:program",
+                "//executorch/extension/data_loader:buffer_data_loader",
+                "//executorch/extension/data_loader:file_data_loader",
+                "//executorch/schema:program",
+            ],
+            env = modules_env,
+        )
+
+        runtime.cxx_test(
             name = "kernel_resolution_test",
             srcs = [
                 "kernel_resolution_test.cpp",

--- a/shim_et/xplat/executorch/build/build_variables.bzl
+++ b/shim_et/xplat/executorch/build/build_variables.bzl
@@ -36,6 +36,7 @@ PROGRAM_NO_PRIM_OPS_SRCS = [
     "method.cpp",
     "method_meta.cpp",
     "program.cpp",
+    "program_validation.cpp",
     "tensor_parser_exec_aten.cpp",
 ]
 


### PR DESCRIPTION
Summary:
We should catch errors as early as possible, a great place to do that would be at program init where we can check things once and then not necessarily have to check them every inference or just in general being able to soft fail at invalid programs.

Currently just testing a couple obvious bad things like invalid sizes, or inconsistent list contents. Can add more checks in follow ups.

Differential Revision: D92787645


