### PR TITLE
Fix to_edge_transform_and_lower to respect preserve_ops without parti…

### DIFF
--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -1193,7 +1193,10 @@ def _gen_edge_manager_for_partitioners(
 
             # Decompose by default if there are no partitioners for the method
             if not partitioners_for_program:
-                program = program.run_decompositions(_default_decomposition_table())
+                table = _default_decomposition_table()
+                for op in config.preserve_ops:
+                    table.pop(op, None)
+                program = program.run_decompositions(table)
 
             # Process each partitioner individually using their specific requirements
             for curr_partitioner in partitioners_for_program:


### PR DESCRIPTION
…tioner

Summary:
to_edge_transform_and_lower silently ignores EdgeCompileConfig.preserve_ops when no partitioner is provided — ops like aten.linear.default get decomposed to addmm despite being listed in preserve_ops. This is inconsistent with to_edge, which correctly pops preserved ops from the decomposition table. The fix adds 3 lines to _gen_edge_manager_for_partitioners to pop config.preserve_ops from the table in the no-partitioner path, matching the existing to_edge behavior. When preserve_ops is empty (the default for all existing callers), the behavior is unchanged.

Test:
python3 -m unittest exir.program.test.test_program.TestProgramManagers.test_to_edge_transform_and_lower_with_preserve_ops_no_partitioner -v
