### PR TITLE
Experimental FP Linear Implementation with NV cooperative matrix 2 extension

### DIFF
--- a/backends/vulkan/runtime/gen_vulkan_spv.py
+++ b/backends/vulkan/runtime/gen_vulkan_spv.py
@@ -1091,6 +1091,7 @@ class SPVGenerator:
                     return (spv_out_path, gen_out_path)
 
             vk_version = codegen_params.get("VK_VERSION", "1.1")
+            spv_version = codegen_params.get("SPV_VERSION", None)
             # Only proceed if a GLSL compiler was specified
             if self.glslc_path is not None:
                 cmd_base = [
@@ -1104,6 +1105,9 @@ class SPVGenerator:
                     "-I",
                     output_dir,
                 ]
+                # Add explicit SPIR-V version if specified (for extensions like GL_NV_cooperative_matrix2)
+                if spv_version is not None:
+                    cmd_base.append("--target-spv=spv{}".format(spv_version))
                 cmd = cmd_base + self.glslc_flags
 
                 try:

--- a/backends/vulkan/runtime/graph/ops/glsl/linear_tiled_nv_cm2.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/linear_tiled_nv_cm2.glsl
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/*
+ * Floating-point matrix multiplication shader using GL_NV_cooperative_matrix2
+ * extension for optimized performance on NVIDIA GPUs with tensor cores.
+ *
+ * Based on ggml's mul_mm_cm2.comp implementation.
+ *
+ * RTX 4080 supported configuration:
+ *   - Scope: Subgroup (NOT Workgroup!)
+ *   - A, B, C types: all float16
+ *   - Tile sizes: M=16, N=16, K=16
+ *
+ * Computes: output = input @ weight^T + bias
+ */
+
+#version 450 core
+
+#extension GL_EXT_control_flow_attributes : enable
+#extension GL_EXT_shader_16bit_storage : require
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+#extension GL_KHR_memory_scope_semantics : enable
+#extension GL_KHR_shader_subgroup_basic : enable
+#extension GL_KHR_cooperative_matrix : enable
+#extension GL_NV_cooperative_matrix2 : enable
+
+${define_required_extensions("buffer", DTYPE)}
+
+#define PRECISION ${PRECISION}
+
+#define T ${buffer_scalar_type(DTYPE)}
+#define VEC4_T ${buffer_gvec_type(DTYPE, 4)}
+
+#define TILE_ROWS ${TILE_ROWS}
+#define TILE_COLS ${TILE_COLS}
+
+// Block sizes for cooperative matrix - matching RTX 4080 supported config
+#define BM 16
+#define BN 16
+#define BK 16
+
+layout(std430) buffer;
+
+${layout_declare_tensor(B, "w", "t_output", DTYPE, "buffer", is_scalar_array=True)}
+${layout_declare_tensor(B, "r", "t_input", DTYPE, "buffer", is_scalar_array=True)}
+${layout_declare_tensor(B, "r", "t_weight", DTYPE, "buffer", is_scalar_array=True)}
+${layout_declare_tensor(B, "r", "t_bias", DTYPE, "buffer", is_scalar_array=True)}
+
+${layout_declare_ubo(B, "ivec4", "output_sizes")}
+${layout_declare_ubo(B, "ivec4", "input_sizes")}
+
+// Workgroup size: 1 threads (subgroup/warp size for Subgroup scope)
+layout(local_size_x = 32, local_size_y = 1, local_size_z = 1) in;
+
+${layout_declare_spec_const(C, "int", "apply_bias", "0")}
+
+// Matrix type for float16 computation with SUBGROUP scope (RTX 4080 supported)
+
+#define MAT_TYPE float16_t
+#define ACC_TYPE float16_t
+
+void main() {
+  // Get tile indices
+  const uint M = uint(output_sizes.y);  // batch/rows
+  const uint N = uint(output_sizes.x);  // output features
+  const uint K = uint(input_sizes.x);   // input features
+
+  // Calculate N4 for prepacked weight stride
+  const uint N4 = (N + 3) / 4;
+  const uint weight_stride = N4 * 4;
+
+  const uint blocks_m = (M + BM - 1) / BM;
+  const uint ir = gl_WorkGroupID.x % blocks_m;  // row tile index
+  const uint ic = gl_WorkGroupID.y;             // column tile index
+
+  // Early exit if out of bounds
+  if (ir * BM >= M || ic * BN >= N) {
+    return;
+  }
+
+  // Create tensor layouts with clamping for boundary handling
+  tensorLayoutNV<2, gl_CooperativeMatrixClampModeConstantNV> tensorLayoutA =
+      createTensorLayoutNV(2, gl_CooperativeMatrixClampModeConstantNV);
+  tensorLayoutNV<2, gl_CooperativeMatrixClampModeConstantNV> tensorLayoutB =
+      createTensorLayoutNV(2, gl_CooperativeMatrixClampModeConstantNV);
+  tensorLayoutNV<2, gl_CooperativeMatrixClampModeConstantNV> tensorLayoutD =
+      createTensorLayoutNV(2, gl_CooperativeMatrixClampModeConstantNV);
+
+  // Set dimensions and strides
+  // Input A: M x K, row-major (stride = K)
+  tensorLayoutA = setTensorLayoutDimensionNV(tensorLayoutA, M, K);
+  tensorLayoutA = setTensorLayoutStrideNV(tensorLayoutA, K, 1);
+
+  // Weight B: K x N (prepacked), row-major
+  // Each row k has N elements: weight[k, 0:N]
+  tensorLayoutB = setTensorLayoutDimensionNV(tensorLayoutB, K, N);
+  tensorLayoutB = setTensorLayoutStrideNV(tensorLayoutB, N, 1);
+
+  // Output D: M x N, row-major (stride = N)
+  // Output layout matches expected: [batch, out_features]
+  tensorLayoutD = setTensorLayoutDimensionNV(tensorLayoutD, M, N);
+  tensorLayoutD = setTensorLayoutStrideNV(tensorLayoutD, N, 1);
+
+  // Transpose view for B matrix (weight is stored transposed)
+  tensorViewNV<2, false, 1, 0> tensorViewTranspose = createTensorViewNV(2, false, 1, 0);
+
+  // Initialize accumulator - either with zeros or with bias (broadcast across rows)
+  coopmat<ACC_TYPE, gl_ScopeSubgroup, BM, BN, gl_MatrixUseAccumulator> sum;
+
+  if (apply_bias != 0) {
+    // Create tensor layout for bias with broadcast (stride 0 in row dimension)
+    // This makes all rows read the same bias values
+    // Bias is 1D array of size N, we want to load it as BM x BN matrix
+    // where each row has the same values: bias[ic*BN], bias[ic*BN+1], ..., bias[ic*BN+BN-1]
+    tensorLayoutNV<2, gl_CooperativeMatrixClampModeConstantNV> tensorLayoutBias =
+        createTensorLayoutNV(2, gl_CooperativeMatrixClampModeConstantNV);
+
+    // Dimension: BM rows x N columns (full bias width)
+    // Stride: 0 for rows (broadcast same values), 1 for columns
+    tensorLayoutBias = setTensorLayoutDimensionNV(tensorLayoutBias, BM, N);
+    tensorLayoutBias = setTensorLayoutStrideNV(tensorLayoutBias, 0, 1);  // stride 0 = broadcast rows
+
+    // Load bias into accumulator (slice the column range for this tile)
+    coopMatLoadTensorNV(sum, t_bias, 0,
+        sliceTensorLayoutNV(tensorLayoutBias, 0, BM, ic * BN, BN));
+  } else {
+    // Initialize to zeros
+    sum = coopmat<ACC_TYPE, gl_ScopeSubgroup, BM, BN, gl_MatrixUseAccumulator>(ACC_TYPE(0.0));
+  }
+
+  // Loop over K dimension
+  const uint k_iters = (K + BK - 1) / BK;
+
+  [[dont_unroll]]
+  for (uint block_k = 0, i = 0; i < k_iters; block_k += BK, ++i) {
+    // Use SUBGROUP scope for cooperative matrices (RTX 4080 supported)
+    coopmat<MAT_TYPE, gl_ScopeSubgroup, BM, BK, gl_MatrixUseA> mat_a;
+    coopmat<MAT_TYPE, gl_ScopeSubgroup, BK, BN, gl_MatrixUseB> mat_b;
+
+    // Load A tile: input[ir*BM : ir*BM+BM, block_k : block_k+BK]
+    coopMatLoadTensorNV(mat_a, t_input, 0,
+        sliceTensorLayoutNV(tensorLayoutA, ir * BM, BM, block_k, BK));
+
+    // Load B tile: weight[block_k : block_k+BK, ic*BN : ic*BN+BN]
+    // Weight is prepacked in [K, N] layout, load directly without transpose
+    coopMatLoadTensorNV(mat_b, t_weight, 0,
+        sliceTensorLayoutNV(tensorLayoutB, block_k, BK, ic * BN, BN));
+
+    // Multiply and accumulate
+    sum = coopMatMulAdd(mat_a, mat_b, sum);
+  }
+
+  // Store result directly without transpose (row-major output)
+  coopMatStoreTensorNV(sum, t_output, 0,
+      sliceTensorLayoutNV(tensorLayoutD, ir * BM, BM, ic * BN, BN));
+}

--- a/backends/vulkan/runtime/graph/ops/glsl/linear_tiled_nv_cm2.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/linear_tiled_nv_cm2.yaml
@@ -1,0 +1,31 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Floating-point matrix multiplication shader using GL_NV_cooperative_matrix2
+# extension for optimized performance on NVIDIA GPUs with tensor cores.
+#
+# This shader computes: output = input @ weight^T + bias
+#
+# Tile sizes should be tuned for specific NVIDIA architectures:
+#   - SM80 (Ampere): 16x16x16 or 32x8x16
+#   - SM90 (Hopper): Up to 64x32x16
+
+linear_tiled_nv_cm2:
+  parameter_names_with_default_values:
+    DTYPE: float
+    # Tile sizes for cooperative matrix operations
+    # TILE_ROWS: rows of tile
+    # TILE_COLS: columns of tile
+    TILE_ROWS: 16
+    TILE_COLS: 16
+    # Use Vulkan 1.3 and SPIR-V 1.6 for GL_NV_cooperative_matrix2 support
+    VK_VERSION: "1.3"
+    SPV_VERSION: "1.6"
+  generate_variant_forall:
+    DTYPE:
+      - VALUE: half
+  shader_variants:
+    - NAME: linear_tiled_nv_cm2

--- a/backends/vulkan/runtime/graph/ops/glsl/pack_fp_linear_weight.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/pack_fp_linear_weight.glsl
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#version 450 core
+
+${define_required_extensions(OUTPUT_STORAGE, DTYPE)}
+${define_required_extensions("buffer", DTYPE)}
+
+#define PRECISION ${PRECISION}
+#define VEC4_T ${texel_load_type(DTYPE, OUTPUT_STORAGE)}
+#define T ${texel_load_component_type(DTYPE, OUTPUT_STORAGE)}
+
+$if OUTPUT_STORAGE == "buffer":
+  #define OUTPUT_BUFFER
+
+layout(std430) buffer;
+
+${layout_declare_tensor(B, "w", "t_packed_weight", DTYPE, OUTPUT_STORAGE, is_scalar_array=False)}
+${layout_declare_tensor(B, "r", "t_weight", DTYPE, "buffer", is_scalar_array=True)}
+
+layout(push_constant) uniform restrict Block {
+  // Original weight sizes: [N, K] (out_features, in_features)
+  ivec2 orig_sizes;
+};
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+#include "common.glslh"
+
+void main() {
+  // The source weight tensor has size [W=K, H=N] in WHCN format.
+  // Each shader invocation processes one vec4 of the output.
+  // The thread position (n4, k) corresponds to the output block index.
+  //
+  // Output layout: [K, N4] where each element is a vec4 containing 4
+  // consecutive N values for the same K position.
+  // This layout is optimized for tiled matrix multiplication where we
+  // iterate over K and accumulate into N.
+  //
+  // w_tile.data[k][n4] = vec4(W[n4*4+0, k], W[n4*4+1, k], W[n4*4+2, k], W[n4*4+3, k])
+
+  const int n4 = int(gl_GlobalInvocationID.x);
+  const int k = int(gl_GlobalInvocationID.y);
+
+  const int K = orig_sizes.x;  // in_features
+  const int N = orig_sizes.y;  // out_features
+
+  const int N4 = div_up_4(N);
+
+  if (n4 >= N4 || k >= K) {
+    return;
+  }
+
+  // Each output vec4 contains 4 consecutive N values for position k
+  // Input layout is [N, K] row-major, so element [n, k] is at index n*K + k
+  const int n_base = mul_4(n4);
+
+  VEC4_T packed_data = VEC4_T(0);
+
+  // Load 4 consecutive N values for position k
+  for (int ni = 0; ni < 4; ++ni) {
+    const int n = n_base + ni;
+    if (n < N) {
+      packed_data[ni] = T(t_weight[n * K + k]);
+    }
+  }
+
+  // Write to output
+  // Output is [K, N4] where each vec4 has 4 N values for one K position
+#ifdef OUTPUT_BUFFER
+  t_packed_weight[k * N4 + n4] = packed_data;
+#else
+  imageStore(t_packed_weight, ivec3(n4, k, 0), packed_data);
+#endif
+}

--- a/backends/vulkan/runtime/graph/ops/glsl/pack_fp_linear_weight.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/pack_fp_linear_weight.yaml
@@ -1,0 +1,19 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+pack_fp_linear_weight:
+  parameter_names_with_default_values:
+    DTYPE: float
+    OUTPUT_STORAGE: buffer
+  generate_variant_forall:
+    OUTPUT_STORAGE:
+      - VALUE: buffer
+      - VALUE: texture3d
+    DTYPE:
+      - VALUE: float
+      - VALUE: half
+  shader_variants:
+    - NAME: pack_fp_linear_weight

--- a/backends/vulkan/runtime/graph/ops/impl/LinearNVCoopMat.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/LinearNVCoopMat.cpp
@@ -1,0 +1,291 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/vulkan/runtime/graph/ops/OperatorRegistry.h>
+
+#include <executorch/backends/vulkan/runtime/graph/ops/impl/Common.h>
+#include <executorch/backends/vulkan/runtime/graph/ops/impl/Staging.h>
+
+#include <executorch/backends/vulkan/runtime/graph/ops/utils/ShaderNameUtils.h>
+
+namespace vkcompute {
+
+//
+// Shader dispatch utilities
+//
+
+void resize_linear_tiled_node(
+    ComputeGraph* graph,
+    const std::vector<ArgGroup>& args,
+    const std::vector<ValueRef>& extra_args) {
+  (void)extra_args;
+
+  const ValueRef output = args.at(0).refs.at(0);
+  const ValueRef input = args.at(1).refs.at(0);
+  const ValueRef weight_data = extra_args.at(0);
+
+  std::vector<int64_t> input_sizes = graph->sizes_of(input);
+  std::vector<int64_t> weight_sizes = graph->sizes_of(weight_data);
+
+  // input: [M, K], weight: [N, K] -> output: [M, N]
+  const int64_t M = utils::val_at(-2, input_sizes);
+  const int64_t N = utils::val_at(-2, weight_sizes);
+
+  std::vector<int64_t> new_out_sizes(input_sizes.size());
+  if (input_sizes.size() == 2) {
+    new_out_sizes.at(0) = M;
+    new_out_sizes.at(1) = N;
+  } else {
+    new_out_sizes.at(0) = input_sizes.at(0);
+    new_out_sizes.at(1) = M;
+    new_out_sizes.at(2) = N;
+  }
+
+  graph->virtual_resize(output, new_out_sizes);
+}
+
+utils::uvec3 linear_tiled_nv_cm2_global_wg_size(
+    ComputeGraph* graph,
+    const vkapi::ShaderInfo& shader,
+    const std::vector<ArgGroup>& args,
+    const std::vector<ValueRef>& resize_args) {
+  (void)shader;
+  (void)resize_args;
+
+  const ValueRef output = args.at(0).refs.at(0);
+
+  std::vector<int64_t> out_sizes = graph->sizes_of(output);
+  // Width dimension (N = out_features)
+  const uint32_t N = utils::val_at(-1, out_sizes);
+  // Height dimension (M = batch size)
+  const uint32_t M = utils::val_at(-2, out_sizes);
+
+  // NV cooperative matrix 2 shader uses BM=16 x BN=16 tiles
+  // Following ggml's dispatch pattern: x = blocks_m * k_split, y = blocks_n
+  const uint32_t BM = 16;
+  const uint32_t BN = 16;
+
+  const uint32_t blocks_m = utils::div_up(M, BM);
+  const uint32_t blocks_n = utils::div_up(N, BN);
+
+  // x = blocks_m (row tiles), y = blocks_n (column tiles)
+  return {blocks_m * 32, blocks_n, 1};
+}
+
+// Fixed local workgroup size for NV cooperative matrix 2 linear shader
+// Must match the shader's layout(local_size_x = 32)
+utils::uvec3 linear_tiled_nv_cm2_local_wg_size(
+    ComputeGraph* graph,
+    const vkapi::ShaderInfo& shader,
+    const utils::uvec3& global_workgroup_size,
+    const std::vector<ArgGroup>& args,
+    const std::vector<ValueRef>& resize_args) {
+  (void)graph;
+  (void)shader;
+  (void)global_workgroup_size;
+  (void)args;
+  (void)resize_args;
+
+  // NV cooperative matrix 2 with Subgroup scope always uses 32 threads (subgroup size)
+  // This matches the shader's layout(local_size_x = 32, local_size_y = 1, local_size_z = 1)
+  return {32, 1, 1};
+}
+
+//
+// Prepacking
+//
+
+ValueRef prepack_fp_linear_weight(
+    ComputeGraph& graph,
+    const ValueRef weight_data,
+    const utils::StorageType output_storage_type) {
+  std::vector<int64_t> weight_sizes = graph.sizes_of(weight_data);
+  const int64_t ndim = graph.dim_of(weight_data);
+
+  // Weight tensor has shape [N, K] (out_features, in_features)
+  const int64_t K = weight_sizes.at(ndim - 1);
+  const int64_t N = weight_sizes.at(ndim - 2);
+
+  // Calculate output sizes
+  // Output layout: [K, N4] where each element is a vec4 containing 4
+  // consecutive N values for one K position
+  const int64_t N4 = utils::div_up(N, int64_t(4));
+
+  // Determine if we need to fall back to buffer storage
+  utils::StorageType storage_type = output_storage_type;
+  if (storage_type == utils::kTexture3D) {
+    uint32_t max_extent = graph.context()->adapter_ptr()->max_texture2d_dim();
+    if (N4 > max_extent || K > max_extent) {
+      storage_type = utils::kBuffer;
+    }
+  }
+
+  // Output tensor shape: [K, N4 * 4] for the prepacked weights
+  // The width is N4 * 4 because each vec4 access reads 4 consecutive elements
+  // (matching the standard convention where sizes are in terms of individual
+  // elements, not vec4s)
+  std::vector<int64_t> packed_weight_sizes = {K, N4 * 4};
+
+  ValueRef packed_weight = graph.add_tensor(
+      packed_weight_sizes,
+      graph.dtype_of(weight_data),
+      storage_type,
+      utils::kWidthPacked);
+
+  // Store original sizes for the shader
+  utils::ivec2 orig_sizes = {
+      utils::safe_downcast<int32_t>(K), utils::safe_downcast<int32_t>(N)};
+
+  utils::uvec3 global_wg_size = {
+      utils::safe_downcast<uint32_t>(N4),
+      utils::safe_downcast<uint32_t>(K),
+      1u};
+
+  std::string kernel_name = "pack_fp_linear_weight";
+  add_storage_type_suffix(kernel_name, storage_type);
+  add_dtype_suffix(kernel_name, graph.dtype_of(weight_data));
+
+  graph.prepack_nodes().emplace_back(new PrepackNode(
+      graph,
+      VK_KERNEL_FROM_STR(kernel_name),
+      global_wg_size,
+      graph.create_local_wg_size(global_wg_size),
+      // Inputs and Outputs
+      weight_data,
+      packed_weight,
+      // UBOs
+      {},
+      // Specialization Constants
+      {},
+      // Push Constants
+      {PushConstantDataInfo(&orig_sizes, sizeof(utils::ivec2))}));
+
+  return packed_weight;
+}
+
+//
+// Linear Dispatch
+//
+
+void add_linear_tiled_node(
+    ComputeGraph& graph,
+    const ValueRef input,
+    const ValueRef weight_data,
+    const ValueRef packed_weight,
+    const ValueRef bias_data,
+    const ValueRef packed_bias,
+    const ValueRef output) {
+  // Use CM2 kernel for buffer storage (GL_NV_cooperative_matrix2)
+  std::string kernel_name = "linear_tiled_nv_cm2";
+  add_dtype_suffix(kernel_name, graph.dtype_of(output));
+
+  vkapi::ParamsBindList param_buffers = {
+      graph.sizes_ubo(output), graph.sizes_ubo(input)};
+
+  int32_t apply_bias = graph.val_is_not_none(bias_data) ? 1 : 0;
+
+  graph.execute_nodes().emplace_back(new DynamicDispatchNode(
+      graph,
+      VK_KERNEL_FROM_STR(kernel_name),
+      linear_tiled_nv_cm2_global_wg_size,
+      linear_tiled_nv_cm2_local_wg_size,
+      // Inputs and Outputs
+      {{output, vkapi::kWrite},
+       {{input, packed_weight, packed_bias}, vkapi::kRead}},
+      // Shader params buffers
+      param_buffers,
+      // Push Constants
+      {},
+      // Specialization Constants
+      {apply_bias},
+      // Resize args
+      {weight_data},
+      // Resizing Logic
+      resize_linear_tiled_node));
+}
+
+//
+// High-level operator implementation
+//
+
+void linear_nv_cm2_impl(
+    ComputeGraph& graph,
+    const ValueRef input,
+    const ValueRef weight_data,
+    const ValueRef bias_data,
+    const ValueRef output) {
+  // Check that VK_NV_cooperative_matrix2 extension is available
+  // This is required for the linear_tiled_nv_cm2 shader
+  VK_CHECK_COND(
+      graph.context()->adapter_ptr()->supports_nv_cooperative_matrix2(),
+      "linear_nv_cm2 requires VK_NV_cooperative_matrix2 extension which is "
+      "not available on this device. Please use a device that supports "
+      "VK_NV_cooperative_matrix2 or use a different linear implementation.");
+
+  // Check input dimensions
+  std::vector<int64_t> input_sizes = graph.sizes_of(input);
+  VK_CHECK_COND(
+      input_sizes.size() == 2 || input_sizes.size() == 3,
+      "Input must be 2D or 3D tensor");
+
+  // Determine storage type based on output
+  utils::StorageType storage_type = graph.storage_type_of(output);
+
+  // For the tiled implementation, we need the input to be width-packed
+  // (i.e., K is along the width/x dimension)
+  ValueRef input_W_packed = input;
+  if (graph.estimate_memory_layout_of(input) != utils::kWidthPacked) {
+    input_W_packed = graph.add_tensor_like(input, utils::kWidthPacked);
+    auto viewFn = VK_GET_OP_FN("aten.view_copy.default");
+    viewFn(graph, {input, graph.add_none(), input_W_packed});
+  }
+
+  // Prepack weight
+  ValueRef packed_weight =
+      prepack_fp_linear_weight(graph, weight_data, storage_type);
+
+  // Create dummy bias tensor if bias is not provided
+  TmpTensor dummy_bias(
+      &graph, {}, graph.dtype_of(output), utils::kBuffer, utils::kWidthPacked);
+
+  ValueRef packed_bias = dummy_bias.vref;
+  if (graph.val_is_not_none(bias_data)) {
+    packed_bias =
+        prepack_standard(graph, bias_data, utils::kBuffer, utils::kWidthPacked);
+  }
+
+  add_linear_tiled_node(
+      graph,
+      input_W_packed,
+      weight_data,
+      packed_weight,
+      bias_data,
+      packed_bias,
+      output);
+}
+
+//
+// Registered operator entry point
+//
+
+void linear_nv_cm2(
+    ComputeGraph& graph,
+    const std::vector<ValueRef>& args) {
+  const ValueRef input = args.at(0);
+  const ValueRef weight_data = args.at(1);
+  const ValueRef bias_data = args.at(2);
+  const ValueRef output = args.at(3);
+
+  linear_nv_cm2_impl(graph, input, weight_data, bias_data, output);
+}
+
+REGISTER_OPERATORS {
+  VK_REGISTER_OP(etvk.linear_nv_cm2.default, linear_nv_cm2);
+}
+
+} // namespace vkcompute

--- a/backends/vulkan/runtime/vk_api/Adapter.cpp
+++ b/backends/vulkan/runtime/vk_api/Adapter.cpp
@@ -123,6 +123,12 @@ VkDevice create_logical_device(
     defined(ETVK_INSPECT_PIPELINES)
       VK_KHR_PIPELINE_EXECUTABLE_PROPERTIES_EXTENSION_NAME,
 #endif /* VK_KHR_pipeline_executable_properties && ETVK_INSPECT_PIPELINES */
+#ifdef VK_KHR_cooperative_matrix
+      VK_KHR_COOPERATIVE_MATRIX_EXTENSION_NAME,
+#endif /* VK_KHR_cooperative_matrix */
+#ifdef VK_NV_cooperative_matrix2
+      VK_NV_COOPERATIVE_MATRIX_2_EXTENSION_NAME,
+#endif /* VK_NV_cooperative_matrix2 */
   };
 
   std::vector<const char*> enabled_device_extensions;
@@ -178,6 +184,20 @@ VkDevice create_logical_device(
   shader_int_dot_product_features.pNext = extension_list_top;
   extension_list_top = &shader_int_dot_product_features;
 #endif /* VK_KHR_shader_integer_dot_product */
+
+#ifdef VK_KHR_cooperative_matrix
+  VkPhysicalDeviceCooperativeMatrixFeaturesKHR cooperative_matrix_features{
+      physical_device.cooperative_matrix_features};
+  cooperative_matrix_features.pNext = extension_list_top;
+  extension_list_top = &cooperative_matrix_features;
+#endif /* VK_KHR_cooperative_matrix */
+
+#ifdef VK_NV_cooperative_matrix2
+  VkPhysicalDeviceCooperativeMatrix2FeaturesNV cooperative_matrix2_features{
+      physical_device.cooperative_matrix2_features};
+  cooperative_matrix2_features.pNext = extension_list_top;
+  extension_list_top = &cooperative_matrix2_features;
+#endif /* VK_NV_cooperative_matrix2 */
 
   device_create_info.pNext = extension_list_top;
 

--- a/backends/vulkan/runtime/vk_api/Adapter.h
+++ b/backends/vulkan/runtime/vk_api/Adapter.h
@@ -221,6 +221,16 @@ class Adapter final {
 #endif /* VK_KHR_shader_integer_dot_product */
   }
 
+  inline bool supports_nv_cooperative_matrix2() {
+#ifdef VK_NV_cooperative_matrix2
+    return physical_device_.cooperative_matrix2_features.cooperativeMatrixWorkgroupScope == VK_TRUE &&
+           physical_device_.cooperative_matrix2_features.cooperativeMatrixFlexibleDimensions == VK_TRUE &&
+           physical_device_.cooperative_matrix2_features.cooperativeMatrixTensorAddressing == VK_TRUE;
+#else
+    return false;
+#endif /* VK_NV_cooperative_matrix2 */
+  }
+
   inline bool supports_int16_shader_types() {
     return physical_device_.supports_int16_shader_types;
   }

--- a/backends/vulkan/runtime/vk_api/Device.cpp
+++ b/backends/vulkan/runtime/vk_api/Device.cpp
@@ -51,6 +51,14 @@ PhysicalDevice::PhysicalDevice(
           VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_PROPERTIES_KHR,
           nullptr},
 #endif
+#ifdef VK_KHR_cooperative_matrix
+      cooperative_matrix_features{
+          VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_FEATURES_KHR},
+#endif /* VK_KHR_cooperative_matrix */
+#ifdef VK_NV_cooperative_matrix2
+      cooperative_matrix2_features{
+          VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_2_FEATURES_NV},
+#endif /* VK_NV_cooperative_matrix2 */
       queue_families{},
       num_compute_queues(0),
       api_version_major(0),
@@ -245,6 +253,16 @@ void PhysicalDevice::query_extensions_vk_1_1() {
   shader_int_dot_product_features.pNext = extension_list_top;
   extension_list_top = &shader_int_dot_product_features;
 #endif /* VK_KHR_shader_integer_dot_product */
+
+#ifdef VK_KHR_cooperative_matrix
+  cooperative_matrix_features.pNext = extension_list_top;
+  extension_list_top = &cooperative_matrix_features;
+#endif /* VK_KHR_cooperative_matrix */
+
+#ifdef VK_NV_cooperative_matrix2
+  cooperative_matrix2_features.pNext = extension_list_top;
+  extension_list_top = &cooperative_matrix2_features;
+#endif /* VK_NV_cooperative_matrix2 */
 
   features2.pNext = extension_list_top;
 

--- a/backends/vulkan/runtime/vk_api/Device.h
+++ b/backends/vulkan/runtime/vk_api/Device.h
@@ -52,6 +52,14 @@ struct PhysicalDevice final {
       shader_int_dot_product_properties;
 #endif /* VK_KHR_shader_integer_dot_product */
 
+#ifdef VK_KHR_cooperative_matrix
+  VkPhysicalDeviceCooperativeMatrixFeaturesKHR cooperative_matrix_features;
+#endif /* VK_KHR_cooperative_matrix */
+
+#ifdef VK_NV_cooperative_matrix2
+  VkPhysicalDeviceCooperativeMatrix2FeaturesNV cooperative_matrix2_features;
+#endif /* VK_NV_cooperative_matrix2 */
+
   // Available GPU queues
   std::vector<VkQueueFamilyProperties> queue_families;
 

--- a/backends/vulkan/test/custom_ops/impl/TestLinear.cpp
+++ b/backends/vulkan/test/custom_ops/impl/TestLinear.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/vulkan/runtime/graph/ops/OperatorRegistry.h>
+
+#include <executorch/backends/vulkan/runtime/graph/ops/impl/Common.h>
+#include <executorch/backends/vulkan/runtime/graph/ops/impl/MatMul.h>
+#include <executorch/backends/vulkan/runtime/graph/ops/impl/Staging.h>
+
+#include <executorch/backends/vulkan/runtime/graph/ops/utils/ShaderNameUtils.h>
+
+namespace vkcompute {
+
+// Implementation selector values:
+// 0 = default (use standard aten.linear.default dispatch)
+// 1 = alternative path (also uses aten.linear.default for correctness)
+
+void test_fp_linear(
+    ComputeGraph& graph,
+    const std::vector<ValueRef>& args) {
+  int32_t idx = 0;
+  const ValueRef input = args.at(idx++);
+  const ValueRef weight_data = args.at(idx++);
+  const ValueRef bias_data = args.at(idx++);
+  const ValueRef impl_selector_ref = args.at(idx++);
+  const ValueRef output = args.at(idx++);
+
+  // Extract the impl_selector flag
+  int32_t impl_selector = graph.extract_scalar<int32_t>(impl_selector_ref);
+
+  if (impl_selector == 0 || impl_selector == 1) {
+    // Both paths use the standard linear operator dispatch
+    // impl_selector=1 is provided as a hook for future alternative implementations
+    std::vector<ValueRef> linear_args = {input, weight_data, bias_data, output};
+    VK_GET_OP_FN("aten.linear.default")(graph, linear_args);
+  } else {
+    VK_THROW("Invalid impl_selector value: ", impl_selector);
+  }
+}
+
+REGISTER_OPERATORS {
+  VK_REGISTER_OP(test_etvk.test_fp_linear.default, test_fp_linear);
+}
+
+} // namespace vkcompute

--- a/backends/vulkan/test/custom_ops/nv_utils.cpp
+++ b/backends/vulkan/test/custom_ops/nv_utils.cpp
@@ -1,0 +1,146 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "nv_utils.h"
+
+#include <executorch/backends/vulkan/runtime/vk_api/Runtime.h>
+
+#include <cstdio>
+#include <iostream>
+#include <vector>
+
+namespace executorch {
+namespace vulkan {
+namespace prototyping {
+
+using namespace vkcompute;
+
+
+// Helper function to convert VkComponentTypeKHR to string
+const char* componentTypeToString(VkComponentTypeKHR type) {
+  switch (type) {
+    case VK_COMPONENT_TYPE_FLOAT16_KHR: return "float16";
+    case VK_COMPONENT_TYPE_FLOAT32_KHR: return "float32";
+    case VK_COMPONENT_TYPE_FLOAT64_KHR: return "float64";
+    case VK_COMPONENT_TYPE_SINT8_KHR: return "int8";
+    case VK_COMPONENT_TYPE_SINT16_KHR: return "int16";
+    case VK_COMPONENT_TYPE_SINT32_KHR: return "int32";
+    case VK_COMPONENT_TYPE_SINT64_KHR: return "int64";
+    case VK_COMPONENT_TYPE_UINT8_KHR: return "uint8";
+    case VK_COMPONENT_TYPE_UINT16_KHR: return "uint16";
+    case VK_COMPONENT_TYPE_UINT32_KHR: return "uint32";
+    case VK_COMPONENT_TYPE_UINT64_KHR: return "uint64";
+    default: return "unknown";
+  }
+}
+
+// Helper function to convert VkScopeKHR to string
+const char* scopeToString(VkScopeKHR scope) {
+  switch (scope) {
+    case VK_SCOPE_DEVICE_KHR: return "Device";
+    case VK_SCOPE_WORKGROUP_KHR: return "Workgroup";
+    case VK_SCOPE_SUBGROUP_KHR: return "Subgroup";
+    case VK_SCOPE_QUEUE_FAMILY_KHR: return "QueueFamily";
+    default: return "unknown";
+  }
+}
+
+// Query and print cooperative matrix properties
+void queryCooperativeMatrixProperties() {
+  std::cout << "\n=== Cooperative Matrix Properties ===" << std::endl;
+
+  VkPhysicalDevice physicalDevice = vkcompute::api::context()->adapter_ptr()->physical_handle();
+  VkInstance instance = vkcompute::vkapi::runtime()->instance();
+
+  // Query KHR cooperative matrix properties
+  PFN_vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR =
+      reinterpret_cast<PFN_vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR>(
+          vkGetInstanceProcAddr(
+              instance,
+              "vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR"));
+
+  if (vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR == nullptr) {
+    std::cout << "VK_KHR_cooperative_matrix extension not available." << std::endl;
+    return;
+  }
+
+  // Get count of supported matrix configurations
+  uint32_t propCount = 0;
+  VkResult result = vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR(
+      physicalDevice, &propCount, nullptr);
+
+  if (result != VK_SUCCESS || propCount == 0) {
+    std::cout << "No cooperative matrix configurations supported." << std::endl;
+    return;
+  }
+
+  // Allocate and query properties
+  std::vector<VkCooperativeMatrixPropertiesKHR> matrixProps(propCount);
+  for (auto& prop : matrixProps) {
+    prop.sType = VK_STRUCTURE_TYPE_COOPERATIVE_MATRIX_PROPERTIES_KHR;
+    prop.pNext = nullptr;
+  }
+
+  result = vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR(
+      physicalDevice, &propCount, matrixProps.data());
+
+  if (result != VK_SUCCESS) {
+    std::cout << "Failed to query cooperative matrix properties." << std::endl;
+    return;
+  }
+
+  std::cout << "Found " << propCount << " cooperative matrix configurations:" << std::endl;
+  std::cout << "----------------------------------------------------------------------" << std::endl;
+  std::cout << "  #  |   M  |   N  |   K  | A Type  | B Type  | C Type  | R Type  | Scope" << std::endl;
+  std::cout << "----------------------------------------------------------------------" << std::endl;
+
+  for (uint32_t i = 0; i < propCount; ++i) {
+    const auto& prop = matrixProps[i];
+    printf(" %3u | %4u | %4u | %4u | %-7s | %-7s | %-7s | %-7s | %s\n",
+        i,
+        prop.MSize, prop.NSize, prop.KSize,
+        componentTypeToString(prop.AType),
+        componentTypeToString(prop.BType),
+        componentTypeToString(prop.CType),
+        componentTypeToString(prop.ResultType),
+        scopeToString(prop.scope));
+  }
+
+  std::cout << "----------------------------------------------------------------------" << std::endl;
+
+  // Filter and print configurations useful for FP32 linear (float A, float B, float C)
+  std::cout << "\nConfigurations with float32 A, B, C types:" << std::endl;
+  for (uint32_t i = 0; i < propCount; ++i) {
+    const auto& prop = matrixProps[i];
+    if (prop.AType == VK_COMPONENT_TYPE_FLOAT32_KHR &&
+        prop.BType == VK_COMPONENT_TYPE_FLOAT32_KHR &&
+        prop.CType == VK_COMPONENT_TYPE_FLOAT32_KHR) {
+      printf("  M=%u, N=%u, K=%u, Scope=%s\n",
+          prop.MSize, prop.NSize, prop.KSize,
+          scopeToString(prop.scope));
+    }
+  }
+
+  // Filter and print configurations useful for FP16 input with FP32 accumulator
+  std::cout << "\nConfigurations with float16 A/B, float32 C (mixed precision):" << std::endl;
+  for (uint32_t i = 0; i < propCount; ++i) {
+    const auto& prop = matrixProps[i];
+    if (prop.AType == VK_COMPONENT_TYPE_FLOAT16_KHR &&
+        prop.BType == VK_COMPONENT_TYPE_FLOAT16_KHR &&
+        prop.CType == VK_COMPONENT_TYPE_FLOAT32_KHR) {
+      printf("  M=%u, N=%u, K=%u, Scope=%s\n",
+          prop.MSize, prop.NSize, prop.KSize,
+          scopeToString(prop.scope));
+    }
+  }
+
+  std::cout << std::endl;
+
+}
+
+} // namespace prototyping
+} // namespace vulkan
+} // namespace executorch

--- a/backends/vulkan/test/custom_ops/nv_utils.h
+++ b/backends/vulkan/test/custom_ops/nv_utils.h
@@ -1,0 +1,20 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <executorch/backends/vulkan/runtime/api/api.h>
+
+namespace executorch {
+namespace vulkan {
+namespace prototyping {
+
+// Query and print cooperative matrix properties supported by the device.
+void queryCooperativeMatrixProperties();
+
+} // namespace prototyping
+} // namespace vulkan
+} // namespace executorch

--- a/backends/vulkan/test/custom_ops/targets.bzl
+++ b/backends/vulkan/test/custom_ops/targets.bzl
@@ -55,14 +55,17 @@ def define_common_targets(is_fbcode = False):
         srcs = [
             "utils.cpp",
             "conv2d_utils.cpp",
+            "nv_utils.cpp",
         ],
         headers = [
             "utils.h",
             "conv2d_utils.h",
+            "nv_utils.h",
         ],
         exported_headers = [
             "utils.h",
             "conv2d_utils.h",
+            "nv_utils.h",
         ],
         platforms = get_platforms(),
         deps = [

--- a/backends/vulkan/test/custom_ops/targets.bzl
+++ b/backends/vulkan/test/custom_ops/targets.bzl
@@ -97,3 +97,5 @@ def define_common_targets(is_fbcode = False):
     define_custom_op_test_binary("test_q8ta_conv2d")
     define_custom_op_test_binary("test_q8ta_conv2d_pw")
     define_custom_op_test_binary("test_q8ta_conv2d_dw")
+    define_custom_op_test_binary("q8ta_q8ta_q8to_add")
+    define_custom_op_test_binary("test_fp_linear")

--- a/backends/vulkan/test/custom_ops/test_fp_linear.cpp
+++ b/backends/vulkan/test/custom_ops/test_fp_linear.cpp
@@ -1,0 +1,344 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <iostream>
+#include <vector>
+
+#include <executorch/backends/vulkan/runtime/graph/ops/impl/Common.h>
+#include <executorch/backends/vulkan/runtime/graph/ops/utils/ShaderNameUtils.h>
+
+#include <executorch/backends/vulkan/runtime/graph/ops/impl/Staging.h>
+
+#include "utils.h"
+
+// #define DEBUG_MODE
+
+using namespace executorch::vulkan::prototyping;
+
+using namespace vkcompute;
+
+static constexpr int64_t kRefDimSizeLimit = 512;
+
+// Configuration for linear layer test cases
+struct LinearConfig {
+  int64_t batch_size;
+  int64_t in_features;
+  int64_t out_features;
+  bool has_bias;
+  std::string test_case_name;
+};
+
+// Utility function to create a test case from a LinearConfig
+TestCase create_test_case_from_config(
+    const LinearConfig& config,
+    vkapi::ScalarType dtype,
+    utils::StorageType storage_type,
+    int32_t impl_selector = 0) {
+  TestCase test_case;
+
+  utils::GPUMemoryLayout memory_layout = storage_type == utils::kBuffer
+      ? utils::kWidthPacked
+      : utils::kChannelsPacked;
+
+  // Create test case name
+  // Format: ACCU/PERF  B=batch  I=in_features  O=out_features  Tex/Buf
+  std::string prefix = config.test_case_name.substr(0, 4); // "ACCU" or "PERF"
+  std::string storage_str =
+      storage_type == utils::kBuffer ? "Buf" : "Tex";
+  std::string dtype_str = dtype == vkapi::kFloat ? "fp32" : "fp16";
+  std::string bias_str = config.has_bias ? "+bias" : "";
+
+  std::string test_name = prefix + "  " + "B=" + std::to_string(config.batch_size) +
+      "  I=" + std::to_string(config.in_features) +
+      "  O=" + std::to_string(config.out_features) + "  " + storage_str + "  " +
+      dtype_str + bias_str;
+  if (impl_selector == 1) {
+    test_name += " L"; // Legacy/alternative implementation
+  }
+  test_case.set_name(test_name);
+
+  // Set the operator name for the test case - use the test operator
+  std::string operator_name = "test_etvk.test_fp_linear.default";
+  test_case.set_operator_name(operator_name);
+
+  // Input tensor - [batch_size, in_features]
+  std::vector<int64_t> input_size = {config.batch_size, config.in_features};
+  ValueSpec input_tensor(
+      input_size, dtype, storage_type, memory_layout, DataGenType::RANDOM);
+
+  if (debugging()) {
+    print_valuespec_data(input_tensor, "input_tensor", false, 64);
+  }
+
+  // Weight tensor - [out_features, in_features]
+  std::vector<int64_t> weight_size = {config.out_features, config.in_features};
+  ValueSpec weight_tensor(
+      weight_size, dtype, storage_type, memory_layout, DataGenType::RANDOM);
+  weight_tensor.set_constant(true);
+
+  if (debugging()) {
+    print_valuespec_data(weight_tensor, "weight_tensor", false, 64);
+  }
+
+  // Bias tensor (optional) - [out_features]
+  ValueSpec bias_tensor;
+  if (config.has_bias) {
+    std::vector<int64_t> bias_size = {config.out_features};
+    bias_tensor = ValueSpec(
+        bias_size, dtype, storage_type, utils::kWidthPacked, DataGenType::RANDOM);
+    bias_tensor.set_constant(true);
+
+    if (debugging()) {
+      print_valuespec_data(bias_tensor, "bias_tensor", false, 64);
+    }
+  } else {
+    bias_tensor = ValueSpec();
+    bias_tensor.set_none(true);
+  }
+
+  // Output tensor - [batch_size, out_features]
+  std::vector<int64_t> output_size = {config.batch_size, config.out_features};
+  ValueSpec output_tensor(
+      output_size, dtype, storage_type, memory_layout, DataGenType::ZEROS);
+
+  // Add impl_selector parameter
+  ValueSpec impl_selector_spec(impl_selector);
+
+  // Add all specs to test case
+  test_case.add_input_spec(input_tensor);
+  test_case.add_input_spec(weight_tensor);
+  test_case.add_input_spec(bias_tensor);
+  test_case.add_input_spec(impl_selector_spec);
+  test_case.add_output_spec(output_tensor);
+
+  // Set tolerance based on dtype
+  if (dtype == vkapi::kFloat) {
+    test_case.set_abs_tolerance(1e-4f);
+  } else {
+    test_case.set_abs_tolerance(1e-2f);
+  }
+
+  return test_case;
+}
+
+// Generate easy test cases for debugging
+std::vector<TestCase> generate_linear_easy_cases() {
+  std::vector<TestCase> test_cases;
+
+  // Simple configuration for debugging
+  LinearConfig config = {
+      4,    // batch_size
+      64,   // in_features
+      32,   // out_features
+      true, // has_bias
+      "ACCU",
+  };
+
+  std::vector<utils::StorageType> storage_types = {utils::kBuffer};
+  std::vector<vkapi::ScalarType> dtypes = {vkapi::kFloat, vkapi::kHalf};
+
+  for (const utils::StorageType storage_type : storage_types) {
+    for (const vkapi::ScalarType dtype : dtypes) {
+      config.test_case_name = "ACCU";
+      // Test with impl_selector = 0 (default)
+      test_cases.push_back(
+          create_test_case_from_config(config, dtype, storage_type, 0));
+      // Test with impl_selector = 1 (alternative)
+      test_cases.push_back(
+          create_test_case_from_config(config, dtype, storage_type, 1));
+    }
+  }
+
+  return test_cases;
+}
+
+// Generate comprehensive test cases for linear layer
+std::vector<TestCase> generate_linear_test_cases() {
+  std::vector<TestCase> test_cases;
+
+  std::vector<LinearConfig> configs = {
+      // Small accuracy test cases
+      {1, 64, 64, true, "ACCU"},
+      {4, 128, 64, true, "ACCU"},
+      {8, 256, 128, true, "ACCU"},
+      {16, 64, 256, true, "ACCU"},
+      {1, 512, 512, true, "ACCU"},
+      // Without bias
+      {4, 128, 64, false, "ACCU"},
+      {8, 256, 128, false, "ACCU"},
+
+      // Performance test cases - BERT/ViT style (hidden_dim=768, ffn=3072)
+      {1, 768, 768, true, "PERF"},
+      {32, 768, 768, true, "PERF"},
+      {64, 768, 768, true, "PERF"},
+  };
+
+  std::vector<utils::StorageType> storage_types = {
+      utils::kTexture3D, utils::kBuffer};
+  std::vector<vkapi::ScalarType> dtypes = {vkapi::kFloat, vkapi::kHalf};
+
+  for (auto& config : configs) {
+    bool is_performance = config.batch_size > kRefDimSizeLimit ||
+        config.in_features > kRefDimSizeLimit ||
+        config.out_features > kRefDimSizeLimit;
+
+    for (const utils::StorageType storage_type : storage_types) {
+      for (const vkapi::ScalarType dtype : dtypes) {
+        config.test_case_name = is_performance ? "PERF" : "ACCU";
+        // Test with impl_selector = 0 (default)
+        test_cases.push_back(
+            create_test_case_from_config(config, dtype, storage_type, 0));
+        // Test with impl_selector = 1 (alternative)
+        test_cases.push_back(
+            create_test_case_from_config(config, dtype, storage_type, 1));
+      }
+    }
+  }
+
+  return test_cases;
+}
+
+// Reference implementation for fp32/fp16 linear layer
+void linear_reference_impl(TestCase& test_case) {
+  // Extract input specifications
+  const ValueSpec& input_spec = test_case.inputs()[0];
+  const ValueSpec& weight_spec = test_case.inputs()[1];
+  const ValueSpec& bias_spec = test_case.inputs()[2];
+  ValueSpec& output_spec = test_case.outputs()[0];
+
+  // Get tensor dimensions
+  auto input_sizes = input_spec.get_tensor_sizes();   // [batch, in_features]
+  auto weight_sizes = weight_spec.get_tensor_sizes(); // [out_features, in_features]
+  auto output_sizes = output_spec.get_tensor_sizes(); // [batch, out_features]
+
+  int64_t batch_size = input_sizes[0];
+  int64_t in_features = input_sizes[1];
+  int64_t out_features = weight_sizes[0];
+
+  // Skip for large tensors since computation time will be extremely slow
+  if (batch_size > kRefDimSizeLimit || in_features > kRefDimSizeLimit ||
+      out_features > kRefDimSizeLimit) {
+    throw std::invalid_argument(
+        "One or more dimensions exceed the allowed limit for reference implementation.");
+  }
+
+  bool has_bias = !bias_spec.is_none();
+
+  // Get raw data pointers based on dtype
+  auto& ref_data = output_spec.get_ref_float_data();
+  ref_data.resize(batch_size * out_features);
+
+  if (input_spec.dtype == vkapi::kFloat) {
+    auto& input_data = input_spec.get_float_data();
+    auto& weight_data = weight_spec.get_float_data();
+
+    // Perform linear operation: output = input @ weight^T + bias
+    for (int64_t b = 0; b < batch_size; ++b) {
+      for (int64_t o = 0; o < out_features; ++o) {
+        float sum = 0.0f;
+        for (int64_t i = 0; i < in_features; ++i) {
+          // input[b, i] * weight[o, i]
+          int64_t input_idx = b * in_features + i;
+          int64_t weight_idx = o * in_features + i;
+          sum += input_data[input_idx] * weight_data[weight_idx];
+        }
+
+        // Add bias if present
+        if (has_bias) {
+          auto& bias_data = bias_spec.get_float_data();
+          sum += bias_data[o];
+        }
+
+        int64_t output_idx = b * out_features + o;
+        ref_data[output_idx] = sum;
+      }
+    }
+  } else if (input_spec.dtype == vkapi::kHalf) {
+    auto& input_data = input_spec.get_half_data();
+    auto& weight_data = weight_spec.get_half_data();
+
+    // Perform linear operation: output = input @ weight^T + bias
+    for (int64_t b = 0; b < batch_size; ++b) {
+      for (int64_t o = 0; o < out_features; ++o) {
+        float sum = 0.0f;
+        for (int64_t i = 0; i < in_features; ++i) {
+          // input[b, i] * weight[o, i]
+          int64_t input_idx = b * in_features + i;
+          int64_t weight_idx = o * in_features + i;
+          sum += static_cast<float>(input_data[input_idx]) *
+              static_cast<float>(weight_data[weight_idx]);
+        }
+
+        // Add bias if present
+        if (has_bias) {
+          auto& bias_data = bias_spec.get_half_data();
+          sum += static_cast<float>(bias_data[o]);
+        }
+
+        int64_t output_idx = b * out_features + o;
+        ref_data[output_idx] = sum;
+      }
+    }
+  } else {
+    throw std::invalid_argument("Unsupported dtype for linear reference impl");
+  }
+}
+
+void reference_impl(TestCase& test_case) {
+  linear_reference_impl(test_case);
+}
+
+// FLOP calculator for linear operation
+int64_t linear_flop_calculator(const TestCase& test_case) {
+  const auto& input_sizes = test_case.inputs()[0].get_tensor_sizes();
+  const auto& weight_sizes = test_case.inputs()[1].get_tensor_sizes();
+
+  int64_t batch_size = input_sizes[0];
+  int64_t in_features = input_sizes[1];
+  int64_t out_features = weight_sizes[0];
+
+  // Each output element requires in_features multiply-accumulate operations
+  // Plus one add for bias (if present)
+  int64_t output_elements = batch_size * out_features;
+  int64_t ops_per_output = in_features; // MACs
+
+  int64_t flop = output_elements * ops_per_output;
+
+  return flop;
+}
+
+int main(int argc, char* argv[]) {
+  set_debugging(false);
+  set_print_output(false);
+  set_print_latencies(false);
+  set_use_gpu_timestamps(true);
+
+  print_performance_header();
+  std::cout << "FP32/FP16 Linear Layer Benchmark" << std::endl;
+  print_separator();
+
+  ReferenceComputeFunc ref_fn = reference_impl;
+
+  // Execute test cases using the framework with custom FLOP calculator
+  auto results = execute_test_cases(
+#ifdef DEBUG_MODE
+      generate_linear_easy_cases,
+#else
+      generate_linear_test_cases,
+#endif
+      linear_flop_calculator,
+      "FPLinear",
+#ifdef DEBUG_MODE
+      0,
+      1,
+#else
+      5,
+      40,
+#endif
+      ref_fn);
+
+  return 0;
+}


### PR DESCRIPTION
Summary:
Experimental FP Linear Implementation with NV cooperativate matrix 2






```
 buck run  fbcode/mode/win //xplat/executorch/backends/vulkan/test/custom_ops:test_fp_linear
>>
File changed: fbcode//executorch/backends/vulkan/runtime/gen_vulkan_spv.py
File changed: fbcode//executorch/backends/vulkan/runtime/graph/ops/glsl/pack_fp_linear_weight.yaml
File changed: fbcode//executorch/backends/vulkan/runtime/graph/ops/impl/LinearExperimental.cpp
15 additional file change events
Buck UI: https://www.internalfb.com/buck2/34f0710d-d349-4cba-9e35-10926968dd39
Network: Up: 0B  Down: 0B
Command: run.
Time elapsed: 19.0s
BUILD SUCCEEDED - starting your binary

=== Compute Shader Performance Benchmark ===
FP32/FP16 Linear Layer Benchmark
----------------------------------------------------------------------

=== Cooperative Matrix Properties ===
Loader Message 0 Inserted device layer "VK_LAYER_KHRONOS_validation" (C:\VulkanSDK\1.4.321.1\Bin\.\VkLayer_khronos_validation.dll)
Loader Message 0 Inserted device layer "VK_LAYER_NV_present" (C:\Windows\System32\DriverStore\FileRepository\nvlei.inf_amd64_28d22cc4fdec4a49\.\nvoglv64.dll)
Loader Message 0 Inserted device layer "VK_LAYER_NV_optimus" (C:\Windows\System32\DriverStore\FileRepository\nvlei.inf_amd64_28d22cc4fdec4a49\.\nvoglv64.dll)
Loader Message 0 vkCreateDevice layer callstack setup to:
Loader Message 0    <Application>
Loader Message 0      ||
Loader Message 0    <Loader>
Loader Message 0      ||
Loader Message 0    VK_LAYER_NV_optimus
Loader Message 0            Type: Implicit
Loader Message 0            Enabled By: Implicit Layer
Loader Message 0                Disable Env Var:  DISABLE_LAYER_NV_OPTIMUS_1
Loader Message 0            Manifest: C:\Windows\System32\DriverStore\FileRepository\nvlei.inf_amd64_28d22cc4fdec4a49\nv-vk64.json
Loader Message 0            Library:  C:\Windows\System32\DriverStore\FileRepository\nvlei.inf_amd64_28d22cc4fdec4a49\.\nvoglv64.dll
Loader Message 0      ||
Loader Message 0    VK_LAYER_NV_present
Loader Message 0            Type: Implicit
Loader Message 0            Enabled By: Implicit Layer
Loader Message 0                Disable Env Var:  DISABLE_LAYER_NV_PRESENT_1
Loader Message 0            Manifest: C:\Windows\System32\DriverStore\FileRepository\nvlei.inf_amd64_28d22cc4fdec4a49\nv-vk64.json
Loader Message 0            Library:  C:\Windows\System32\DriverStore\FileRepository\nvlei.inf_amd64_28d22cc4fdec4a49\.\nvoglv64.dll
Loader Message 0      ||
Loader Message 0    VK_LAYER_KHRONOS_validation
Loader Message 0            Type: Explicit
Loader Message 0            Enabled By: By the Application
Loader Message 0            Manifest: C:\VulkanSDK\1.4.321.1\Bin\VkLayer_khronos_validation.json
Loader Message 0            Library:  C:\VulkanSDK\1.4.321.1\Bin\.\VkLayer_khronos_validation.dll
Loader Message 0      ||
Loader Message 0    <Device>
Loader Message 0        Using "NVIDIA GeForce RTX 5080" with driver: "C:\Windows\System32\DriverStore\FileRepository\nvlei.inf_amd64_28d22cc4fdec4a49\.\nvoglv64.dll"
Validation 0 vkCreateImage(): The following VkImageCreateInfo returned VK_ERROR_FORMAT_NOT_SUPPORTED when calling vkGetPhysicalDeviceImageFormatProperties2
format (VK_FORMAT_R32G32B32A32_SFLOAT)
type (VK_IMAGE_TYPE_3D)
tiling (VK_IMAGE_TILING_LINEAR)
usage (VK_IMAGE_USAGE_SAMPLED_BIT|VK_IMAGE_USAGE_STORAGE_BIT)
flags (VkImageCreateFlags(0))
VkImageCreateInfo::pNext is NULL.
The Vulkan spec states: Each of the following values (as described in Image Creation Limits) must not be undefined : imageCreateMaxMipLevels, imageCreateMaxArrayLayers, imageCreateMaxExtent, and imageCreateSampleCounts (https://vulkan.lunarg.com/doc/view/1.4.321.1/windows/antora/spec/latest/chapters/resources.html#VUID-VkImageCreateInfo-imageCreateMaxMipLevels-02251)
Found 15 cooperative matrix configurations:
----------------------------------------------------------------------
  #  |   M  |   N  |   K  | A Type  | B Type  | C Type  | R Type  | Scope
----------------------------------------------------------------------
   0 |   16 |   16 |   16 | float16 | float16 | float16 | float16 | Subgroup
   1 |   16 |    8 |   16 | float16 | float16 | float16 | float16 | Subgroup
   2 |   16 |    8 |    8 | float16 | float16 | float16 | float16 | Subgroup
   3 |   16 |   16 |   16 | float16 | float16 | float32 | float32 | Subgroup
   4 |   16 |    8 |   16 | float16 | float16 | float32 | float32 | Subgroup
   5 |   16 |    8 |    8 | float16 | float16 | float32 | float32 | Subgroup
   6 |   16 |   16 |   32 | uint8   | uint8   | uint32  | uint32  | Subgroup
   7 |   16 |   16 |   32 | int8    | int8    | int32   | int32   | Subgroup
   8 |   16 |    8 |   32 | uint8   | uint8   | uint32  | uint32  | Subgroup
   9 |   16 |    8 |   32 | int8    | int8    | int32   | int32   | Subgroup
  10 |   16 |   16 |   16 | unknown | unknown | float32 | float32 | Subgroup
  11 |   16 |   16 |   32 | unknown | unknown | float16 | float16 | Subgroup
  12 |   16 |   16 |   32 | unknown | unknown | float32 | float32 | Subgroup
  13 |   16 |   16 |   32 | unknown | unknown | float16 | float16 | Subgroup
  14 |   16 |   16 |   32 | unknown | unknown | float32 | float32 | Subgroup
----------------------------------------------------------------------

Configurations with float32 A, B, C types:

Configurations with float16 A/B, float32 C (mixed precision):
  M=16, N=16, K=16, Scope=Subgroup
  M=16, N=8, K=16, Scope=Subgroup
  M=16, N=8, K=8, Scope=Subgroup

Test: ACCU  B=4  I=128  O=128  Buf  fp16+bias L

input_tensor Data:
  Type: ValueSpec(type=Tensor, sizes=[4, 128], dtype=half, memory_layout=WidthPacked, storage_type=Buffer, data_gen=RANDOM)
  Total elements: 512
  Data (first 64 elements): [-0.250732, 0.592773, 0.901367, -0.632812, 0.463867, 0.559082, 0.197266, 0.193604, -0.687500, -0.108276, -0.687988, -0.799805, -0.883789, -0.081482, 0.731934, -0.332520, 0.202148, -0.713867, 0.416016, 0.301758, -0.958496, -0.886719, 0.939453, 0.443848, 0.664551, 0.876953, -0.575195, -0.998047, -0.636230, 0.984375, -0.632812, 0.234863, -0.391357, 0.223267, 0.049500, -0.985840, -0.136108, -0.953613, -0.417480, 0.049530, 0.223633, -0.200195, -0.720703, -0.906250, -0.415527, 0.947266, -0.267090, -0.534180, -0.087830, -0.818359, 0.570312, 0.236694, -0.600586, -0.234985, 0.028458, 0.966309, 0.184814, -0.066467, -0.906738, 0.719727, 0.215088, 0.360596, -0.658691, -0.098999, ... (448 more)] 
  Statistics: min=0.229682, max=1.468703, mean=0.922048, sum=472.088684

weight_tensor Data:
  Type: ValueSpec(type=Tensor, sizes=[128, 128], dtype=half, memory_layout=WidthPacked, storage_type=Buffer, data_gen=RANDOM)
  Total elements: 16384
  Data (first 64 elements): [-0.769531, -0.006275, 0.218018, -0.793945, -0.732910, -0.702148, -0.518555, -0.655273, -0.345703, 0.622070, 0.718262, -0.850098, 0.332031, -0.909668, 0.082275, 0.224243, -0.941895, 0.189575, 0.467285, -0.498535, -0.210083, -0.705078, 0.604004, -0.977051, -0.490967, -0.063721, -0.885742, 0.909180, 0.732910, 0.111511, -0.557617, 0.299316, -0.189941, 0.161743, -0.367676, -0.662109, -0.846191, -0.168213, 0.686035, 0.305908, 0.697754, 0.241089, 0.942871, -0.192383, -0.229126, 0.747070, 0.908691, 0.110107, -0.108459, -0.142090, 0.339355, -0.720215, -0.834961, -0.539062, 0.793945, -0.605469, -0.403809, 0.596680, -0.475342, -0.335205, -0.989258, -0.157715, 0.086365, -0.110352, ... (16320 more)]
  Statistics: min=0.013550, max=1.468764, mean=0.913034, sum=14959.146484

bias_tensor Data:
  Type: ValueSpec(type=Tensor, sizes=[128], dtype=half, memory_layout=WidthPacked, storage_type=Buffer, data_gen=RANDOM)
  Total elements: 128
  Data (first 64 elements): [0.669434, -0.134888, -0.790039, -0.936035, 0.489258, 0.255615, -0.278809, -0.630859, -0.281250, -0.407227, 0.218384, -0.485840, -0.212402, 0.359619, -0.181763, -0.434814, 0.019791, 0.833496, 0.420166, -0.583496, 0.920898, 0.262939, -0.086731, 0.597168, -0.144653, 0.065247, -0.772949, -0.650391, -0.563965, -0.645020, 0.914551, 0.467285, 0.886230, -0.200317, 0.763184, 0.024109, 0.292725, -0.917969, -0.572266, -0.051605, 0.273438, -0.978027, -0.721680, 0.602051, -0.082581, -0.718262, 0.747559, -0.410889, -0.482910, 0.708496, 0.329590, 0.599609, 0.725098, -0.226318, -0.702148, 0.677734, 0.125854, -0.276367, -0.681641, 0.816406, -0.653809, -0.542480, -0.791504, -0.032104, ... (64 more)] 
  Statistics: min=0.289590, max=1.467422, mean=0.940261, sum=120.353394
Executing 1 test cases for FPLinear
----------------------------------------------------------------------
==================== Shared Object List ====================
   idx               sizes                   users
     0                  16                    [7,]
==================== Value List ============================
   idx      type               sizes node_type  storage_bytes    so_idx
     0    TENSOR            [4, 128]     INPUT           1024
     1   STAGING
     2 TENSORREF          [128, 128]   PREPACK
     3 TENSORREF               [128]   PREPACK
     4       INT
     5    TENSOR            [4, 128]    OUTPUT           1024
     6    TENSOR          [128, 128]   PREPACK          32768
     7    TENSOR                  []                       16         0
     8    TENSOR               [128]   PREPACK            256
     9   STAGING
==================== Prepack Node List =====================
   idx                     shader_name    tref  packed
     0pack_fp_linear_weight_buffer_half       2       6
     1        nchw_to_buffer_half_half       3       8
==================== Execute Node List =====================
   idx                     shader_name                READ_arg               WRITE_arg
     0       nchw_to_buffer_half_float                    [1,]                    [0,]
     1        linear_tiled_nv_cm2_half                [0,6,8,]                    [5,]
     2       buffer_to_nchw_half_float                    [5,]                    [9,]

Output[0] Data:
  Type: ValueSpec(type=Tensor, sizes=[4, 128], dtype=half, memory_layout=WidthPacked, storage_type=Buffer, data_gen=ZEROS)
  Total elements: 512
  Data (first 20 elements): [-1.498047, -3.060547, -0.001218, -2.798828, 1.934570, 2.558594, 3.414062, 5.820312, -2.109375, -3.806641, 3.628906, 0.022491, -1.992188, -1.054688, 0.149658, -8.593750, -0.514648, 8.828125, 3.468750, -1.464844, ... (492 more)]
  Statistics: min=0.101169, max=1.581347, mean=1.030442, sum=527.586243

Output[0] (ref) Data:
  Type: ValueSpec(type=Tensor, sizes=[4, 128], dtype=half, memory_layout=WidthPacked, storage_type=Buffer, data_gen=ZEROS)
  Total elements: 512
  Data (first 20 elements): [-1.499553, -3.061874, -0.002150, -2.799306, 1.934955, 2.555415, 3.412702, 5.819950, -2.108622, -3.801892, 3.630069, 0.021923, -1.991505, -1.054845, 0.149873, -8.598531, -0.516323, 8.826857, 3.467027, -1.466808, ... (492 more)]
  Statistics: min=0.101169, max=1.581347, mean=1.030442, sum=527.586243
Correctness validation PASSED
linear_tiled_nv_cm2_half                           ACCU  B=4  I=128  O=128  Buf  fp16+bias L                                 [4x128]           5.920 ╬╝s         11.070 GFLOP/s   PASSED
----------------------------------------------------------------------
````

Differential Revision: D91945037


