### PR TITLE
Add LFM2.5 1.2B support with CI integration

### DIFF
--- a/.ci/scripts/test_torchao_huggingface_checkpoints.sh
+++ b/.ci/scripts/test_torchao_huggingface_checkpoints.sh
@@ -103,7 +103,7 @@ case "$MODEL_NAME" in
 
   lfm2_5_1_2b)
     echo "Running LFM2.5-1.2B export..."
-    HF_MODEL_DIR=$(huggingface-cli download LiquidAI/LFM2.5-1.2B-Instruct)
+    HF_MODEL_DIR=$(hf download LiquidAI/LFM2.5-1.2B-Instruct)
     EXPECTED_MODEL_SIZE_UPPER_BOUND=$((2500 * 1024 * 1024)) # 2.5GB
     $PYTHON_EXECUTABLE -m executorch.examples.models.lfm2.convert_weights \
       $HF_MODEL_DIR \

--- a/.ci/scripts/test_torchao_huggingface_checkpoints.sh
+++ b/.ci/scripts/test_torchao_huggingface_checkpoints.sh
@@ -121,6 +121,7 @@ case "$MODEL_NAME" in
       --metadata '{"get_bos_id":1, "get_eos_ids":[7]}' \
       --verbose \
       --dtype fp32 \
+      -qmode 8da4w \
       ${BACKEND_ARGS}
     ;;
 

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -661,7 +661,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        model: [qwen3_4b, phi_4_mini]
+        model: [qwen3_4b, phi_4_mini, lfm2_5_1_2b]
         runner: [linux.2xlarge]
         docker-image: [executorch-ubuntu-22.04-clang12]
         backend: [xnnpack]
@@ -671,6 +671,10 @@ jobs:
             docker-image: executorch-ubuntu-22.04-gcc11-aarch64
             backend: torchao
           - model: phi_4_mini
+            runner: linux.arm64.2xlarge
+            docker-image: executorch-ubuntu-22.04-gcc11-aarch64
+            backend: torchao
+          - model: lfm2_5_1_2b
             runner: linux.arm64.2xlarge
             docker-image: executorch-ubuntu-22.04-gcc11-aarch64
             backend: torchao

--- a/examples/models/lfm2/README.md
+++ b/examples/models/lfm2/README.md
@@ -1,6 +1,8 @@
 ## Summary
 [LFM2](https://huggingface.co/collections/LiquidAI/lfm2-686d721927015b2ad73eaa38) is a new generation of hybrid models developed by [Liquid AI](https://www.liquid.ai/) and available in 3 variants - 350M, 700M, 1.2B.
 
+[LFM2.5](https://huggingface.co/LiquidAI/LFM2.5-1.2B-Instruct) is an updated version with improved training (28T tokens vs 10T) and extended context length support (32K tokens).
+
 ## Instructions
 
 LFM2 uses the same example code as optimized Llama model, while the checkpoint, model params, and tokenizer are different. Please see the [Llama README page](../llama/README.md) for details.
@@ -34,6 +36,26 @@ python -m extension.llm.export.export_llm \
   +base.model_class="lfm2_1_2b" \
   +base.params="examples/models/lfm2/config/lfm2_1_2b_config.json" \
   +export.output_name="lfm2_1_2b_8da4w.pte"
+```
+
+Export LFM2.5 1.2B to XNNPack, quantized with 8da4w:
+```
+python -m extension.llm.export.export_llm \
+  --config examples/models/lfm2/config/lfm2_xnnpack_q8da4w.yaml \
+  +base.model_class="lfm2_5_1_2b" \
+  +base.params="examples/models/lfm2/config/lfm2_5_1_2b_config.json" \
+  +export.output_name="lfm2_5_1_2b_8da4w.pte"
+```
+
+To export with extended context (e.g., 2048 tokens):
+```
+python -m extension.llm.export.export_llm \
+  --config examples/models/lfm2/config/lfm2_xnnpack_q8da4w.yaml \
+  +base.model_class="lfm2_5_1_2b" \
+  +base.params="examples/models/lfm2/config/lfm2_5_1_2b_config.json" \
+  +export.max_seq_length=2048 \
+  +export.max_context_length=2048 \
+  +export.output_name="lfm2_5_1_2b_8da4w.pte"
 ```
 ### Example run
 With ExecuTorch pybindings:

--- a/examples/models/lfm2/config/lfm2_5_1_2b_config.json
+++ b/examples/models/lfm2/config/lfm2_5_1_2b_config.json
@@ -1,0 +1,33 @@
+{
+  "dim": 2048,
+  "ffn_dim_multiplier": 1,
+  "hidden_dim": 8192,
+  "n_heads": 32,
+  "n_kv_heads": 8,
+  "n_layers": 16,
+  "norm_eps": 1e-5,
+  "rope_theta": 1000000.0,
+  "use_scaled_rope": false,
+  "vocab_size": 65536,
+  "use_hf_rope": true,
+  "use_qk_norm": true,
+  "qk_norm_before_rope": true,
+  "layer_types": [
+    "conv",
+    "conv",
+    "full_attention",
+    "conv",
+    "conv",
+    "full_attention",
+    "conv",
+    "conv",
+    "full_attention",
+    "conv",
+    "full_attention",
+    "conv",
+    "full_attention",
+    "conv",
+    "full_attention",
+    "conv"
+  ]
+}

--- a/examples/models/lfm2/convert_weights.py
+++ b/examples/models/lfm2/convert_weights.py
@@ -1,3 +1,4 @@
+import argparse
 import os
 from typing import Dict
 
@@ -72,3 +73,20 @@ def convert_weights(input_dir: str, output_file: str) -> None:
     print("Saving checkpoint...")
     torch.save(sd, output_file)
     print("Done.")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Convert LFM2 weights to Meta format.")
+    parser.add_argument(
+        "input_dir",
+        type=str,
+        help="Path to directory containing safetensor checkpoint files.",
+    )
+    parser.add_argument("output", type=str, help="Path to the output checkpoint")
+
+    args = parser.parse_args()
+    convert_weights(args.input_dir, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/models/llama/export_llama_lib.py
+++ b/examples/models/llama/export_llama_lib.py
@@ -108,6 +108,7 @@ EXECUTORCH_DEFINED_MODELS = [
     "lfm2_350m",  # hybrid
     "lfm2_700m",  # hybrid
     "lfm2_1_2b",  # hybrid
+    "lfm2_5_1_2b",  # hybrid
 ]
 TORCHTUNE_DEFINED_MODELS = ["llama3_2_vision"]
 HUGGING_FACE_REPO_IDS = {
@@ -122,6 +123,7 @@ HUGGING_FACE_REPO_IDS = {
     "lfm2_350m": "LiquidAI/LFM2-350M",
     "lfm2_700m": "LiquidAI/LFM2-700M",
     "lfm2_1_2b": "LiquidAI/LFM2-1.2B",
+    "lfm2_5_1_2b": "LiquidAI/LFM2.5-1.2B-Instruct",
 }
 
 

--- a/extension/llm/export/config/llm_config.py
+++ b/extension/llm/export/config/llm_config.py
@@ -49,6 +49,7 @@ class ModelType(str, Enum):
     lfm2_350m = "lfm2_350m"
     lfm2_700m = "lfm2_700m"
     lfm2_1_2b = "lfm2_1_2b"
+    lfm2_5_1_2b = "lfm2_5_1_2b"
 
 
 class PreqMode(str, Enum):


### PR DESCRIPTION
This adds support for exporting LiquidAI's LFM2.5-1.2B-Instruct model, which features improved training (28T tokens vs 10T) and extended context support (32K tokens).

Changes:
- Add lfm2_5_1_2b model configuration (examples/models/lfm2/config/lfm2_5_1_2b_config.json)
- Register lfm2_5_1_2b in EXECUTORCH_DEFINED_MODELS and HUGGING_FACE_REPO_IDS
- Add lfm2_5_1_2b to ModelType enum
- Update README with LFM2.5 export examples and extended context usage
- Add CI test for lfm2_5_1_2b in test_torchao_huggingface_checkpoints.sh
- Add lfm2_5_1_2b to trunk.yml test matrix (XNNPACK and TorchAO backends)

The model uses the same hybrid architecture as LFM2 (convolution + attention layers) with 16 layers and 8192 FFN dimension. Can be exported with custom max_seq_length and max_context_length for extended context support.

Fixes #17439

