### PR TITLE
[wip] Shared kv cache support

### DIFF
--- a/examples/models/llama/export_llama_lib.py
+++ b/examples/models/llama/export_llama_lib.py
@@ -1265,7 +1265,10 @@ def _export_llama_multimethod(llm_config: LlmConfig) -> LLMEdgeManager:
 
     # Convert to executorch and save
     first_builder.edge_manager = edge_manager
-    first_builder = first_builder.to_executorch(passes=additional_passes)
+    first_builder = first_builder.to_executorch(
+        passes=additional_passes,
+        share_mutable_buffers=llm_config.multimethod_lora.share_mutable_buffers,
+    )
 
     output_file = _get_output_filename(
         llm_config,

--- a/extension/llm/export/builder.py
+++ b/extension/llm/export/builder.py
@@ -477,6 +477,7 @@ class LLMEdgeManager:
         external_constants_tag: Optional[
             Callable[[torch.fx.Node], Optional[str]]
         ] = None,
+        share_mutable_buffers: bool = False,
     ) -> "LLMEdgeManager":
         """
         Lower the model to executorch and get an ExecutorchProgram.
@@ -507,7 +508,10 @@ class LLMEdgeManager:
                 # QuantFusionPass]]`.
                 passes=to_executorch_passes,
                 do_quant_fusion_and_const_prop=True,
-                memory_planning_pass=MemoryPlanningPass(alloc_graph_input=False),
+                memory_planning_pass=MemoryPlanningPass(
+                    alloc_graph_input=False,
+                    share_mutable_buffers=share_mutable_buffers,
+                ),
                 sym_shape_eval_pass=ConstraintBasedSymShapeEvalPass(),
                 external_constants=external_constants_tag,
             )

--- a/extension/llm/export/config/llm_config.py
+++ b/extension/llm/export/config/llm_config.py
@@ -303,6 +303,8 @@ class MultimethodLoraConfig:
     Attributes:
         methods: Dict mapping method names to optional LoRA configs.
             Empty dict disables multimethod_lora export.
+        share_mutable_buffers: Whether to share mutable buffers (e.g. kv-cache)
+            across methods.
 
     Example:
         MultimethodLoraConfig(methods={
@@ -312,6 +314,7 @@ class MultimethodLoraConfig:
     """
 
     methods: Dict[str, Optional[LoraConfig]] = field(default_factory=dict)
+    share_mutable_buffers: bool = False
 
     @property
     def enabled(self) -> bool:


### PR DESCRIPTION
### Summary
Support shared memory buffer for multimethod lora.

Move `_insert_mutable_buffer_specs` before the memory planning pass `apply_algo`:
- memory_planning assigns [mem_ids to tensor specs](https://github.com/pytorch/executorch/blob/main/exir/memory_planning.py#L818-L819), [except when mutable](https://github.com/pytorch/executorch/blob/cf79288a44d81397bfb7442e0d0335ed378ccc5f/exir/memory_planning.py#L454-L455)
- however, sometimes placeholders and output nodes share a TensorSpec (this happens when the buffer was mutated only through inplace ops all the way to the placeholder, from [`inplace_lineage`](https://github.com/pytorch/executorch/blob/cf79288a44d81397bfb7442e0d0335ed378ccc5f/exir/passes/insert_write_back_for_buffers_pass.py#L82). Why does kv-cache pass this check?
- After memory planning, `insert_mutable_buffer_specs` errors out because the mutable buffer has a mem id attached, set on the output node (which shares the python object TensorSpec as placeholder, which was skipped).

Also check the output specs for mutability, not just the node, because the output node may be mutable (aliased to a placeholder through SpecPropPass).

### Test plan
Added kv-cache test to test_memory_planning.py

Manual test with 
```
python -m extension.llm.export.export_llm     --config examples/models/qwen3/config/qwen3_multimethod.yaml
```
Confirm that we have an additional memory arena and runtime output is same.
```
>>> model.program.execution_plan[0].non_const_buffer_sizes
[0, 612298816]
>>> model.program.execution_plan[1].non_const_buffer_sizes
[0, 660509760]
--
>>> shared_model.program.execution_plan[0].non_const_buffer_sizes
[0, 142536768, 469762048]
>>> shared_model.program.execution_plan[1].non_const_buffer_sizes
[0, 190747712, 469762048]
```