### PR TITLE
Add support for exporting 8-bit quantized Token2Wav model

### DIFF
--- a/examples/models/llama/source_transformation/quantize.py
+++ b/examples/models/llama/source_transformation/quantize.py
@@ -131,7 +131,7 @@ def quantize(  # noqa C901
         if verbose:
             print("quantized model:", model)
         return model
-    elif qmode == "8da4w":
+    elif qmode in ("8da4w", "8da8w"):
         if group_size is None:
             # TODO: Default value for group size for 8da4w. Need this here for refactor, will clean this up.
             group_size = 128
@@ -169,11 +169,12 @@ def quantize(  # noqa C901
                 is_linear or is_lora_linear
             ) and has_shape_compatible_with_group_size
 
+        weight_dtype = torch.int4 if qmode == "8da4w" else torch.int8
         quantize_(
             model,
             Int8DynamicActivationIntxWeightConfig(
                 # pyre-ignore[16]
-                weight_dtype=torch.int4,
+                weight_dtype=weight_dtype,
                 weight_granularity=(
                     PerAxis(0) if group_size == 0 else PerGroup(group_size)
                 ),


### PR DESCRIPTION
Summary:
The 8-bit model achieves ~54% faster Token2Wav component latency vs unquantized (very close to the 4-bit model's ~57%), with a 17.4% improvement in end-to-end mean latency. The 8-bit model is only marginally slower than 4-bit (3.40ms vs 3.16ms per Token2Wav step), while providing better weight precision that should better preserve quality. The 8-bit model uses per-channel quantization (required by XNNPACK for 8-bit weights) vs the 4-bit model's per-group (group_size=128) quantization.

PESQ and UTMOS scores show essentially no difference in quality between the unquantized and 8-bit quantized models.

Reviewed By: billmguo

Differential Revision: D93525295


