### PR TITLE
llama_main: wire --num_bos/--num_eos into GenerationConfig

### DIFF
--- a/examples/models/llama/main.cpp
+++ b/examples/models/llama/main.cpp
@@ -176,6 +176,8 @@ int32_t main(int32_t argc, char** argv) {
       .temperature = temperature};
 
   config.ignore_eos = FLAGS_ignore_eos;
+  config.num_bos = FLAGS_num_bos;
+  config.num_eos = FLAGS_num_eos;
 
   if (FLAGS_max_new_tokens != -1) {
     config.max_new_tokens = FLAGS_max_new_tokens;


### PR DESCRIPTION
## Summary
`llama_main` parsed `--num_bos` and `--num_eos` but never propagated them into `GenerationConfig`, so those CLI flags had no effect.

This PR wires both flags into the generation config in `examples/models/llama/main.cpp`.

## Repro (attached)
Reference repro notes: https://gist.github.com/TE-RohanBhide/d25a084e818bc5bffcf244323eed45f6

### Steps
```bash
# Build runner
cmake --workflow --preset llm-release
cd examples/models/llama
cmake --workflow --preset llama-release
cd ../../

# Run with BOS flag
cmake-out/examples/models/llama/llama_main \
  --model_path gemma3_1b_vanilla/model.pte \
  --tokenizer_path gemma3_1b_vanilla/tokenizer.json \
  --prompt "Once upon a time" \
  --seq_len 128 \
  --num_bos 1
```

### Expected behavior
Passing `--num_bos 1` should prepend BOS and increase prompt token count by 1.

### Observed before this fix
`--num_bos 1` had no effect (prompt token count stayed the same as without BOS), and output could become repetitive/degenerate.

### Observed with this fix
- With `--num_bos 1`: `prompt_tokens` becomes `5`, and output is coherent.
- Without `--num_bos`: `prompt_tokens` is `4`, and output is noticeably more repetitive.

This matches the Python path (`ExecuTorchModelForCausalLM.text_generation`), where tokenizer encoding for this prompt includes BOS.

## Change
- `examples/models/llama/main.cpp`
  - `config.num_bos = FLAGS_num_bos;`
  - `config.num_eos = FLAGS_num_eos;`
