### PR TITLE
Cortex-M backend: Add initial documentation

### DIFF
--- a/backends/cortex_m/README.md
+++ b/backends/cortex_m/README.md
@@ -1,3 +1,28 @@
 # Cortex-M Backend
 
-WIP. This is a temporary/placeholder backend for Cortex-M CPUs. It is not intended to be used in production, but rather as a proof of concept. Things will change without notice.
+> [!NOTE]
+> WIP. This is a temporary/placeholder backend for Cortex-M CPUs. It is not intended to be used in production, but rather as a proof of concept. Things will change without notice.
+
+## Overview
+
+The Cortex-M backend is implemented as an operator dialect/library based on [CMSIS-NN](https://github.com/ARM-software/CMSIS-NN), together with the `CortexMQuantizer` which targets supported ops, and the `CortexMPassManager` which modifies the exported program to use Cortex-M operators where possible. It is intended for use with **channels-last input**  since this is what the accelerated kernels are using.
+
+For a detailed example of the full lowering flow, see `examples/arm/cortex_m_minimal_example.ipynb`.
+
+## Testing
+Tests are available in `backends/cortex-m/test/` using the `backends/test` harness. The python implementations of the operators are tested in tests named `test_dialect_*`, while actual accelerated implementations are tested on simulated hardware in the tests named `test_implementation_*`.
+
+To run tests:
+```
+examples/arm/setup.sh --i-agree-to-the-contained-eula                     # Download needed toolchains and simulators
+examples/arm/arm-scratch/setup_path.sh                                    # Add dependencies to path
+backends/cortex-m/test/setup_testing.sh                                   # Build executor-runner with cortex-m oplib + kernels registred
+pytest --config-file=backends/arm/test/pytest.ini backends/cortex-m/test  # Run tests with correct configuration file
+```
+
+## Supported operators
+Refer to `backends/cortex-m/test/ops` for currently supported accelerated ops/dtypes. Additionally, the quantizer targets pure "data-movement ops" such as data copies, slicing and concatinations to use quantized dtypes using the portable-kernels operator lbrary.
+In general however, operators not supported by Cortex-M are kept in `fp32` using non-accelerated portable-kernels. It is recommended to analyze the graph after lowering to understand how much of the graph has been accelerated.
+
+## Notices
+Arm and Cortex are registered trademarks of Arm Limited (or its subsidiaries) in the US and/or elsewhere.

--- a/examples/arm/cortex_m_mv2_example.ipynb
+++ b/examples/arm/cortex_m_mv2_example.ipynb
@@ -1,0 +1,444 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Copyright 2026 Arm Limited and/or its affiliates.\n",
+    "#\n",
+    "# This source code is licensed under the BSD-style license found in the\n",
+    "# LICENSE file in the root directory of this source tree."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Cortex-M backend flow example - Running MobileNetV2\n",
+    "\n",
+    "This guide demonstrates the full flow for running a module on Arm Cortex-M using ExecuTorch. \n",
+    "**Note that this backend is currently WIP and things may change / break without notice.**\n",
+    "\n",
+    "Before you begin:\n",
+    "1. (In a clean virtual environment with a compatible Python version) Install executorch using `./install_executorch.sh`\n",
+    "2. Install Arm cross-compilation toolchain and simulators using `examples/arm/setup.sh --i-agree-to-the-contained-eula`\n",
+    "3. Add Arm cross-compilation toolchain and simulators to PATH using `examples/arm/arm-scratch/setup_path.sh` \n",
+    "4. Install the following pip packages: `pip install matplotlib`\n",
+    "\n",
+    "With all commands executed from the base `executorch` folder.\n",
+    "\n",
+    "\n",
+    "\n",
+    "*Some scripts in this notebook produces long output logs: Configuring the 'Customizing Notebook Layout' settings to enable 'Output:scrolling' and setting 'Output:Text Line Limit' makes this more manageable*\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup the dataset \n",
+    "\n",
+    "This example uses the [imagenette dataset](https://huggingface.co/datasets/frgfm/imagenette) from huggingface. MobileNetV2 requires some transforms to be applied to the images before interference, and additionally the Cortex-M backend has requirements on the data being of rank 4 and having a channels-last memory format.\n",
+    "\n",
+    "These transforms are applied in the `sample_generator` to ensure a compatible dataset. After that, plot one image to sanity check the input."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "from datasets import load_dataset\n",
+    "from torchvision.models import MobileNet_V2_Weights\n",
+    "\n",
+    "# Load a small ImageNet validation split from Hugging Face\n",
+    "dataset = load_dataset(\"frgfm/imagenette\", \"full_size\", split=\"validation\")\n",
+    "\n",
+    "# Shuffle deterministically\n",
+    "dataset = dataset.shuffle(seed=0)\n",
+    "\n",
+    "# MobileNetV2 preprocessing transforms\n",
+    "weights = MobileNet_V2_Weights.DEFAULT\n",
+    "preprocess = weights.transforms()\n",
+    "\n",
+    "label_names = dataset.features[\"label\"].names\n",
+    "\n",
+    "# Generator yielding (transformed_img, label_name, original_img)\n",
+    "def sample_generator(max_samples=200):\n",
+    "    for i, sample in enumerate(dataset):\n",
+    "        if max_samples is not None and i >= max_samples:\n",
+    "            break\n",
+    "        image = sample[\"image\"].convert(\"RGB\") \n",
+    "        yield (\n",
+    "            preprocess(image).unsqueeze(0).to(memory_format=torch.channels_last),\n",
+    "            label_names[sample[\"label\"]],\n",
+    "            sample[\"image\"],\n",
+    "        )\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "# Display sample image before and after transform\n",
+    "transformed_img, label, original_img = next(sample_generator())\n",
+    "\n",
+    "fig, axes = plt.subplots(1,2)\n",
+    "axes[0].imshow(original_img)\n",
+    "axes[0].set_title(\"Original image\")\n",
+    "\n",
+    "# Undo squeeze and memory format changes and normalize to plot well.\n",
+    "plottable_img = (transformed_img.squeeze(0).permute(1,2,0) - transformed_img.min()) / (transformed_img.max() - transformed_img.min())\n",
+    "axes[1].imshow(plottable_img)\n",
+    "axes[1].set_title(\"Transformed image\")\n",
+    "fig.suptitle(label)\n",
+    "plt.show(fig)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## AOT Flow\n",
+    "\n",
+    "The first step is creating the PyTorch module and exporting it. Exporting converts the python code in the module into a graph structure. The result is still runnable python code, which can be displayed by printing the `graph_module` of the exported program. \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from torchvision.models import mobilenet_v2\n",
+    "\n",
+    "# Init model\n",
+    "model = mobilenet_v2(weights=MobileNet_V2_Weights.DEFAULT)\n",
+    "model = model.eval()\n",
+    "\n",
+    "imagenet_labels = MobileNet_V2_Weights.DEFAULT.meta[\"categories\"]\n",
+    "\n",
+    "# Test model. The output is a likeness-score for each class in ImageNet, pick top-1 for result\n",
+    "def print_result(output_data, true_label):\n",
+    "    output_data = torch.Tensor(output_data)\n",
+    "    index = output_data.argmax().item()\n",
+    "    predicted_label = imagenet_labels[index]\n",
+    "    print(f\"True label: {true_label}. Model output: {predicted_label}\")\n",
+    "    \n",
+    "    return true_label == predicted_label\n",
+    "\n",
+    "output_data = model(transformed_img)\n",
+    "print_result(output_data, label)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "exported_program = torch.export.export(model, (transformed_img,))\n",
+    "graph_module = exported_program.module()\n",
+    "\n",
+    "_ = graph_module.print_readable()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also get a visual representation of exported programs using model-explorer:\n",
+    "```\n",
+    "$ pip install ai-edge-model-explorer\n",
+    "$ model-explorer\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from executorch.devtools.visualization import visualize\n",
+    "visualize(exported_program)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To run on Cortex-M the `graph_module` must be quantized using the CortexMQuantizer. Quantization also requires calibrating the module with example inputs to ensure optimal quantization parameters given the dataset.\n",
+    "\n",
+    "Again printing the module, it can be seen that the quantization wraps operators in quantization/dequantization operators which contain the computed quantization parameters. Note that there are no int8-operators used at this point, those are introduced in the pass lowering by replacing sequences of (int8 dequantization + fp32 operator + int8 quantization) operators with quantized operators. This also means that operators not supported by the backend will run in fp32."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from executorch.backends.cortex_m.quantizer.quantizer import CortexMQuantizer\n",
+    "from torchao.quantization.pt2e.quantize_pt2e import convert_pt2e, prepare_pt2e\n",
+    "\n",
+    "# Create and configure quantizer to use a symmetric quantization config globally on all nodes\n",
+    "quantizer = CortexMQuantizer()\n",
+    "\n",
+    "# Post training quantization\n",
+    "quantized_graph_module = prepare_pt2e(graph_module, quantizer)\n",
+    "N_CALIBRATION_SAMPLES=100\n",
+    "for i, (calibration_img, _, _) in enumerate(sample_generator(N_CALIBRATION_SAMPLES)): \n",
+    "    quantized_graph_module(calibration_img)\n",
+    "    print(f\"{i+1}/{N_CALIBRATION_SAMPLES} samples calibrated.\", end='\\r')\n",
+    "\n",
+    "quantized_graph_module = convert_pt2e(quantized_graph_module)\n",
+    "\n",
+    "_ = quantized_graph_module.print_readable()\n",
+    "\n",
+    "# Create a new exported program using the quantized_graph_module\n",
+    "quantized_exported_program = torch.export.export(quantized_graph_module, (transformed_img,))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Test the quantized model\n",
+    "output_data = quantized_exported_program.module()(transformed_img)\n",
+    "print_result(output_data, label)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The lowering to Cortex-M backend is done by first lowering to the edge-dialect using `to_edge` with a custom `EdgeCompileConfig`, followed by running passes from the `CortexMPassManager`. When lowered, the model is serialized into the flatbuffer which is loaded and run on the embedded device using `to_executorch`. \n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from executorch.exir import (\n",
+    "    EdgeCompileConfig,\n",
+    "    ExecutorchBackendConfig,\n",
+    "    to_edge,\n",
+    ")\n",
+    "from executorch.backends.cortex_m.passes.cortex_m_pass_manager import CortexMPassManager\n",
+    "\n",
+    "# Create compile config for Cortex-M lowering\n",
+    "config = EdgeCompileConfig(\n",
+    "            preserve_ops=[\n",
+    "                torch.ops.aten.linear.default,\n",
+    "                torch.ops.aten.hardsigmoid.default,\n",
+    "                torch.ops.aten.hardsigmoid_.default,\n",
+    "                torch.ops.aten.hardswish.default,\n",
+    "                torch.ops.aten.hardswish_.default,\n",
+    "            ],\n",
+    "            _check_ir_validity=False,\n",
+    "            _core_aten_ops_exception_list=[torch.ops.aten.max_pool2d.default],\n",
+    "        )\n",
+    "\n",
+    "# Lower the exported program for the Cortex-M backend - note to_edge usage rather than to_edge_transform_and_lower, currently required to use preserve_ops w/o partitioner.\n",
+    "edge_program_manager = to_edge(\n",
+    "            quantized_exported_program,\n",
+    "            compile_config=config,\n",
+    "        )\n",
+    "\n",
+    "# Run pass manager on the forward graph_module - use of pass_manager.transform() over edge_program_mangager.transform() is currently required to ensure that the passes can modify the exported_program and not only the graph_module.\n",
+    "pass_manager = CortexMPassManager(edge_program_manager.exported_program())\n",
+    "edge_program_manager._edge_programs[\"forward\"] = pass_manager.transform()\n",
+    "\n",
+    "# Test converted edge program running python implementations of cortex-m dialect.\n",
+    "output_data = edge_program_manager.exported_program().module()(transformed_img)\n",
+    "print_result(output_data, label)\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# It can be a good idea to visualize the final exported program to check the final graph structure after all transformations.\n",
+    "visualize(edge_program_manager)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Serialize edge program\n",
+    "executorch_program_manager = edge_program_manager.to_executorch(\n",
+    "            config=ExecutorchBackendConfig(extract_delegate_segments=False)\n",
+    "        )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To run the model with custom data packed into the model, it can be bundled together into what is called a bundled pte, or `.bpte`. \n",
+    "This can be used for building your runtime with a full testsuite to be validated when running, but here we only use it \n",
+    "to run custom data. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from executorch.devtools.bundled_program.config import MethodTestCase, MethodTestSuite\n",
+    "from executorch.devtools import BundledProgram\n",
+    "from executorch.devtools.bundled_program.serialize import serialize_from_bundled_program_to_flatbuffer\n",
+    "\n",
+    "transformed_img, label, original_img = next(sample_generator())\n",
+    "test_case = MethodTestCase(\n",
+    "    inputs=transformed_img,\n",
+    "    expected_outputs=None)\n",
+    "\n",
+    "test_suite = MethodTestSuite(\n",
+    "                method_name=\"forward\",\n",
+    "                test_cases=[test_case],\n",
+    "            )\n",
+    "\n",
+    "bundled_program = BundledProgram(executorch_program_manager, [test_suite])\n",
+    "bundled_program_buffer = serialize_from_bundled_program_to_flatbuffer(bundled_program)\n",
+    "\n",
+    "cwd_dir = os.getcwd()\n",
+    "pte_base_name = \"cortex_m_mv2_example\"\n",
+    "pte_name = pte_base_name + \".bpte\"\n",
+    "pte_path = os.path.join(cwd_dir, pte_name)\n",
+    "with open(pte_path, \"wb\") as file:\n",
+    "    file.write(bundled_program_buffer)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Build executor runtime\n",
+    "\n",
+    "After the AOT compilation flow is done, the runtime can be cross compiled and linked to the produced .bpte-file using the Arm cross-compilation toolchain. \n",
+    "\n",
+    "This is done in three steps:\n",
+    "1. Build the executorch library and Cortex-M ops/kernels.\n",
+    "2. Build any external kernels required. In this example this is not needed as the graph is fully lowered to Cortex-M, but its included for completeness.\n",
+    "3. Build and link the `arm_executor_runner`.\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "\n",
+    "# Build executorch libraries cross-compiled for arm baremetal to executorch/cmake-out-arm\n",
+    "cmake --preset arm-baremetal \\\n",
+    "-DCMAKE_BUILD_TYPE=Release \\\n",
+    "-DEXECUTORCH_BUILD_DEVTOOLS=ON \\\n",
+    "-B../../cmake-out-arm ../..\n",
+    "cmake --build ../../cmake-out-arm --target install -j$(nproc) \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash \n",
+    "# Build example executor runner application to examples/arm/cortex_m_mv2_example\n",
+    "# Note that his is the same runner as used in the Ethos-U example, creating some overlap in the config even though the Ethos-U is not used.\n",
+    "cmake -DCMAKE_TOOLCHAIN_FILE=$(pwd)/ethos-u-setup/arm-none-eabi-gcc.cmake \\\n",
+    "      -DCMAKE_BUILD_TYPE=Release \\\n",
+    "      -DET_PTE_FILE_PATH=cortex_m_mv2_example.bpte \\\n",
+    "      -DTARGET_CPU=cortex-m55 \\\n",
+    "      -DETHOSU_TARGET_NPU_CONFIG=ethos-u55-128 \\\n",
+    "      -DMEMORY_MODE=Shared_Sram \\\n",
+    "      -DET_BUNDLE_IO=ON \\\n",
+    "      -DSYSTEM_CONFIG=Ethos_U55_High_End_Embedded \\\n",
+    "      -Bcortex_m_mv2_example \\\n",
+    "      executor_runner\n",
+    "cmake --build cortex_m_mv2_example -j$(nproc) -- arm_executor_runner"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Run on simulated model\n",
+    "\n",
+    "We can finally use the `backends/arm/scripts/run_fvp.sh` utility script to run the .elf-file on simulated Arm Cortex-M hardware. This is expected to take a couple of minutes and should produce the expected \"golf ball\" label as top-1 result.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import subprocess\n",
+    "\n",
+    "output = subprocess.run(\"../../backends/arm/scripts/run_fvp.sh --elf=cortex_m_mv2_example/arm_executor_runner --target=ethos-u55-128\", shell=True, capture_output=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import re\n",
+    "\n",
+    "result = [[float(x) for x in re.findall(\"-?\\d\\.\\d{6}\" , str(output.stdout))]]\n",
+    "print_result(result, label)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv (3.10.15)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Adds a jupyter notebook describing the full flow for running mv2 using the cortex-m backend and a few lines to the README.md.

Note that this describes the current state of the backend and not any offical API:s, as the development is still in progress.

cc @freddan80 @per @zingo @oscarandersson8218 @digantdesai