### PR TITLE
Unlimited streaming for Voxtral Realtime encoder

### DIFF
--- a/examples/models/voxtral_realtime/README.md
+++ b/examples/models/voxtral_realtime/README.md
@@ -91,7 +91,7 @@ python export_voxtral_rt.py \
 | `--qlinear-encoder-group-size` | `32` | Group size for encoder linear quantization |
 | `--qembedding` | (none) | Embedding layer quantization (`8w`) |
 | `--streaming` | off | Export streaming encoder with KV cache |
-| `--max-enc-len` | `750` | Max encoder KV cache length (~15s audio, streaming only) |
+| `--max-enc-len` | `750` | Encoder sliding window size (streaming only) |
 
 ## Build
 

--- a/examples/models/voxtral_realtime/export_voxtral_rt.py
+++ b/examples/models/voxtral_realtime/export_voxtral_rt.py
@@ -121,7 +121,7 @@ def _export_decoder_and_embedding(
             "input_embeds": {1: seq_dim},
             "cache_position": {0: seq_dim},
         },
-        strict=False,
+        strict=True,
     )
     print(f"  text_decoder exported (sample input: {sample_embeds.shape})")
 
@@ -142,7 +142,7 @@ def _export_decoder_and_embedding(
         tok_emb,
         (sample_ids,),
         dynamic_shapes={"token_ids": {1: tok_seq_dim}},
-        strict=False,
+        strict=True,
     )
     print(f"  token_embedding exported (sample input: {sample_ids.shape})")
 
@@ -182,7 +182,7 @@ def export_all(
         audio_encoder,
         (sample_mel,),
         dynamic_shapes={"mel": {2: t_mel_dim}},
-        strict=False,
+        strict=True,
     )
     print(f"  audio_encoder exported (sample input: {sample_mel.shape})")
 
@@ -247,7 +247,7 @@ def export_streaming(
         streaming_enc,
         (sample_mel_chunk, sample_conv1_state, sample_conv2_state, sample_enc_pos),
         dynamic_shapes=None,
-        strict=False,
+        strict=True,
     )
     print(
         f"  encode_audio_chunk exported (fixed shapes: mel_chunk={sample_mel_chunk.shape})"
@@ -411,7 +411,7 @@ def main():
         "--max-enc-len",
         type=int,
         default=750,
-        help="Max encoder KV cache length for streaming (default: 750, ~15s audio).",
+        help="Encoder sliding window size for streaming (default: 750).",
     )
     args = parser.parse_args()
 

--- a/examples/models/voxtral_realtime/main.cpp
+++ b/examples/models/voxtral_realtime/main.cpp
@@ -52,6 +52,11 @@ DEFINE_bool(
     mic,
     false,
     "Live microphone mode: read raw 16kHz float32 PCM from stdin.");
+DEFINE_int32(
+    mic_chunk_ms,
+    80,
+    "Mic read chunk size in ms. Multiples of 80 align with the model's "
+    "streaming step (80, 160, 320, 640, 960).");
 
 namespace {
 volatile sig_atomic_t g_interrupted = 0;
@@ -150,9 +155,8 @@ int main(int argc, char** argv) {
     fprintf(stdout, "Listening (Ctrl+C to stop)...\n");
     fflush(stdout);
 
-    // Read 80ms chunks (1280 samples * 4 bytes = 5120 bytes).
-    // StreamingSession internally processes in 80ms steps.
-    const size_t chunk_samples = 1280;
+    // Read chunk size from flag (16 samples per ms at 16kHz).
+    const size_t chunk_samples = static_cast<size_t>(FLAGS_mic_chunk_ms) * 16;
     const size_t chunk_bytes = chunk_samples * sizeof(float);
     std::vector<float> buf(chunk_samples);
 

--- a/examples/models/voxtral_realtime/voxtral_realtime_runner.cpp
+++ b/examples/models/voxtral_realtime/voxtral_realtime_runner.cpp
@@ -404,10 +404,9 @@ bool StreamingSession::try_process_step() {
     return false;
   }
 
-  // Guard: encoder/decoder cache capacity.
+  // Guard: decoder cache capacity (encoder uses ring buffer, no limit).
   const int64_t enc_frames_per_chunk = chunk_mel_len / 2;
-  if (enc_frame_pos_ + enc_frames_per_chunk > runner_.max_enc_len_ ||
-      dec_pos_ >= runner_.max_seq_len_) {
+  if (dec_pos_ >= runner_.max_seq_len_) {
     return false;
   }
 


### PR DESCRIPTION
Replace the bounded linear KV cache with a ring buffer
(`EncoderRingKVCache`) so the streaming encoder can process audio of
arbitrary length. The previous `KVCache` was capped at `max_enc_len`
frames (~60s at default 750).

Two bugs made the old approach non-functional at runtime:

1. Llama's `CachePositionsManager` (the natural ring buffer path)
   uses `index_copy_` on a mutable positions buffer, which decomposes
   to `aten::index.Tensor_out` — unsupported by the XNNPACK runtime.
   `EncoderRingKVCache` avoids this by computing buffer positions
   analytically from `start_pos` with no mutable bookkeeping state.

2. All `torch.export.export()` calls used `strict=False`, which bakes
   `.item()` return values as graph constants — the model lost all
   temporal state. Switched to `strict=True` with `torch._check_is_size`
   / `torch._check` guards, matching the Llama and optimum-executorch
   export pattern.

Ring buffer details:
- 2x window buffer (same rationale as Llama's `RingKVCache`) so
  current-step queries can still attend to entries about to be evicted.
- Writes via `update_cache_with_indices` (scatter-write custom op).
- Sliding window mask computed analytically each step and reused
  across all 32 layers.
- RoPE computed on-the-fly from stored `inv_freq` (no pre-computed
  table that would cap positions).
- SDPA gains an explicit-mask codepath (`is_causal=False` + additive
  mask) for the encoder, while the decoder retains `is_causal=True`.

C++ runner: removed the encoder capacity guard since the ring buffer
has no length limit; only the decoder's `max_seq_len` remains as the
binding constraint.
