### PR TITLE
Use explicit unique targets for hifi4 operators

### DIFF
--- a/backends/cadence/hifi/operators/BUCK
+++ b/backends/cadence/hifi/operators/BUCK
@@ -1,13 +1,5 @@
-load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target", "non_fbcode_target")
 load("targets.bzl", "define_common_targets")
 
 oncall("odai_jarvis")
 
-non_fbcode_target(_kind = define_common_targets,)
-
-# !!!! fbcode/executorch/backends/cadence/hifi/operators/TARGETS was merged into this file, see https://fburl.com/workplace/xl8l9yuo for more info !!!!
-
-load("targets.bzl", "define_common_targets")
-
-
-fbcode_target(_kind = define_common_targets,)
+define_common_targets()

--- a/backends/cadence/hifi/operators/targets.bzl
+++ b/backends/cadence/hifi/operators/targets.bzl
@@ -1,112 +1,20 @@
 load("@fbsource//tools/build_defs:platform_defs.bzl", "CXX")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
-
-def define_operator(name: str, deps: list[str] | None = None, exported_headers: list[str] | None = None) -> None:
-    op_name = "op_{}".format(name)
-
-    # Deps used by all operators.
-    common_deps = [
-        "//executorch/kernels/portable/cpu/util:all_deps",
-        "//executorch/kernels/portable/cpu/pattern:all_deps",
-        "//executorch/runtime/kernel:kernel_includes",
-        "//executorch/kernels/portable/cpu:scalar_utils",
-        "//executorch/backends/cadence/hifi/kernels:kernels",
-        "//executorch/kernels/portable/cpu/util:dtype_util",
-        "//executorch/kernels/portable/cpu/util:elementwise_util",
-        "//executorch/kernels/portable/cpu/pattern:bitwise_op",
-        "//executorch/backends/cadence/hifi/third-party/nnlib:nnlib-extensions",
-        "//executorch/kernels/portable/cpu/pattern:comparison_op",
-        "//executorch/backends/cadence/common:xt_macros"
-    ]
-    if deps == None:
-        deps = []
-    if exported_headers == None:
-        exported_headers = ["operators.h"]
-
-    runtime.cxx_library(
-        name = op_name,
-        srcs = [op_name + ".cpp"],
-        platforms = CXX,
-        visibility = ["PUBLIC"],
-        compatible_with = ["ovr_config//cpu:xtensa"],
-        deps = deps + common_deps,
-        exported_headers = exported_headers,
-    )
-
-OPERATORS = [
-    "add",
-    "atan2",
-    "bitwise_and",
-    "bitwise_or",
-    "bitwise_xor",
-    "bmm",
-    "cat",
-    "clamp",
-    "dequantize_per_tensor",
-    "dequantize_per_tensor_asym8s",
-    "div",
-    "embedding",
-    "eq",
-    "fmod",
-    "full",
-    "ge",
-    "gt",
-    "hardtanh",
-    "im2row_out",
-    "le",
-    "lt",
-    "masked_fill",
-    "maximum",
-    "mean",
-    "minimum",
-    "mm",
-    "mul",
-    "ne",
-    "permute_copy",
-    "pow",
-    "quantized_conv2d_nchw_asym8sxsym8s_asym8s_per_tensor_out",
-    "quantized_conv2d_nchw_asym8uxsym8u_asym8u_per_tensor_out",
-    "quantized_conv1d_ncl_asym8sxsym8s_asym8s_per_tensor_out",
-    "quantized_conv1d_ncl_asym8uxsym8u_asym8u_per_tensor_out",
-    "quantized_conv2d_nchw_depthwise_asym8sxsym8s_asym8s_per_tensor_out",
-    "quantized_conv2d_nchw_depthwise_asym8uxsym8u_asym8u_per_tensor_out",
-    "quantized_conv2d_nchw_dilated_asym8sxsym8s_asym8s_per_tensor_out",
-    "quantized_conv2d_nchw_dilated_asym8uxsym8u_asym8u_per_tensor_out",
-    "quantized_conv2d_nhwc_asym8sxsym8s_asym8s_per_tensor_out",
-    "quantized_conv2d_nhwc_asym8uxsym8u_asym8u_per_tensor_out",
-    "quantized_conv1d_nlc_asym8sxsym8s_asym8s_per_tensor_out",
-    "quantized_conv1d_nlc_asym8uxsym8u_asym8u_per_tensor_out",
-    "quantized_conv2d_nhwc_depthwise_asym8sxsym8s_asym8s_per_tensor_out",
-    "quantized_conv2d_nhwc_depthwise_asym8uxsym8u_asym8u_per_tensor_out",
-    "quantized_conv2d_nhwc_dilated_asym8sxsym8s_asym8s_per_tensor_out",
-    "quantized_conv2d_nhwc_dilated_asym8uxsym8u_asym8u_per_tensor_out",
-    "quantized_fully_connected_out",
-    "quantized_fully_connected_asym8sxasym8s_asym8s_per_tensor_out",
-    "quantized_fully_connected_asym8uxasym8u_asym8u_per_tensor_out",
-    "quantized_layer_norm",
-    "quantized_linear_asym8sxasym8s_asym8s_per_tensor_out",
-    "quantized_linear_asym8uxasym8u_asym8u_per_tensor_out",
-    "quantized_matmul_asym8sxasym8s_asym8s_out",
-    "quantized_matmul_asym8uxasym8u_asym8u_out",
-    "quantized_relu_out",
-    "quantized_relu_asym8s_asym8s_per_tensor_out",
-    "quantized_relu_asym8u_asym8u_per_tensor_out",
-    "quantize_per_tensor",
-    "quantize_per_tensor_asym8s",
-    "remainder",
-    "rsqrt",
-    "select_copy",
-    "sigmoid",
-    "slice_copy",
-    "softmax",
-    "softmax_f32_f32",
-    "split_with_sizes_copy",
-    "sub",
-    "tanh",
-    "transpose_copy",
-    "view_copy",
-    "where"
+# Deps used by all operators.
+# buildifier: keep sorted
+COMMON_DEPS = [
+    "//executorch/backends/cadence/common:xt_macros",
+    "//executorch/backends/cadence/hifi/kernels:kernels",
+    "//executorch/backends/cadence/hifi/third-party/nnlib:nnlib-extensions",
+    "//executorch/kernels/portable/cpu:scalar_utils",
+    "//executorch/kernels/portable/cpu/pattern:all_deps",
+    "//executorch/kernels/portable/cpu/pattern:bitwise_op",
+    "//executorch/kernels/portable/cpu/pattern:comparison_op",
+    "//executorch/kernels/portable/cpu/util:all_deps",
+    "//executorch/kernels/portable/cpu/util:dtype_util",
+    "//executorch/kernels/portable/cpu/util:elementwise_util",
+    "//executorch/runtime/kernel:kernel_includes",
 ]
 
 def define_common_targets():
@@ -116,17 +24,790 @@ def define_common_targets():
     TARGETS and BUCK files that call this function.
     """
 
-    # Define build targets for all operators registered in the tables above.
-    for op in OPERATORS:
-        define_operator(op)
+    runtime.cxx_library(
+        name = "op_add",
+        srcs = ["op_add.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
 
-    # quantized_linear_out and quantized_linear_per_tensor_out needs additional dependency for int16 support
-    define_operator("quantized_linear_out", deps=["//executorch/backends/cadence/generic/operators:op_quantized_linear"])
-    define_operator("quantized_linear_per_tensor_out", deps=["//executorch/backends/cadence/generic/operators:op_quantized_linear"])
+    runtime.cxx_library(
+        name = "op_atan2",
+        srcs = ["op_atan2.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
 
-    # quantized_conv2d_nchw_out and quantized_conv2d_nhwc_out need additional dependency for int16 support
-    define_operator("quantized_conv2d_nchw_out", deps=["//executorch/backends/cadence/generic/operators:op_quantized_conv2d"])
-    define_operator("quantized_conv2d_nhwc_out", deps=["//executorch/backends/cadence/generic/operators:op_quantized_conv2d"])
+    runtime.cxx_library(
+        name = "op_bitwise_and",
+        srcs = ["op_bitwise_and.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
 
-    # quantized_matmul_out needs additional dependency for int16 support
-    define_operator("quantized_matmul_out", deps=["//executorch/backends/cadence/generic/operators:op_quantized_matmul"], exported_headers=["op_quantized_matmul_out.h"])
+    runtime.cxx_library(
+        name = "op_bitwise_or",
+        srcs = ["op_bitwise_or.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_bitwise_xor",
+        srcs = ["op_bitwise_xor.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_bmm",
+        srcs = ["op_bmm.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_cat",
+        srcs = ["op_cat.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_clamp",
+        srcs = ["op_clamp.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_dequantize_per_tensor",
+        srcs = ["op_dequantize_per_tensor.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_dequantize_per_tensor_asym8s",
+        srcs = ["op_dequantize_per_tensor_asym8s.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_div",
+        srcs = ["op_div.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_embedding",
+        srcs = ["op_embedding.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_eq",
+        srcs = ["op_eq.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_fmod",
+        srcs = ["op_fmod.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_full",
+        srcs = ["op_full.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_ge",
+        srcs = ["op_ge.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_gt",
+        srcs = ["op_gt.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_hardtanh",
+        srcs = ["op_hardtanh.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_im2row_out",
+        srcs = ["op_im2row_out.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_le",
+        srcs = ["op_le.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_lt",
+        srcs = ["op_lt.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_masked_fill",
+        srcs = ["op_masked_fill.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_maximum",
+        srcs = ["op_maximum.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_mean",
+        srcs = ["op_mean.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_minimum",
+        srcs = ["op_minimum.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_mm",
+        srcs = ["op_mm.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_mul",
+        srcs = ["op_mul.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_ne",
+        srcs = ["op_ne.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_permute_copy",
+        srcs = ["op_permute_copy.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_pow",
+        srcs = ["op_pow.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_quantize_per_tensor",
+        srcs = ["op_quantize_per_tensor.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_quantize_per_tensor_asym8s",
+        srcs = ["op_quantize_per_tensor_asym8s.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_quantized_add_asym8sxasym8s_asym8s_per_tensor_out",
+        srcs = ["op_quantized_add_asym8sxasym8s_asym8s_per_tensor_out.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_quantized_add_asym8uxasym8u_asym8u_per_tensor_out",
+        srcs = ["op_quantized_add_asym8uxasym8u_asym8u_per_tensor_out.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_quantized_conv1d_ncl_asym8sxsym8s_asym8s_per_tensor_out",
+        srcs = ["op_quantized_conv1d_ncl_asym8sxsym8s_asym8s_per_tensor_out.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_quantized_conv1d_ncl_asym8uxsym8u_asym8u_per_tensor_out",
+        srcs = ["op_quantized_conv1d_ncl_asym8uxsym8u_asym8u_per_tensor_out.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_quantized_conv1d_nlc_asym8sxsym8s_asym8s_per_tensor_out",
+        srcs = ["op_quantized_conv1d_nlc_asym8sxsym8s_asym8s_per_tensor_out.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_quantized_conv1d_nlc_asym8uxsym8u_asym8u_per_tensor_out",
+        srcs = ["op_quantized_conv1d_nlc_asym8uxsym8u_asym8u_per_tensor_out.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_quantized_conv2d_nchw_asym8sxsym8s_asym8s_per_tensor_out",
+        srcs = ["op_quantized_conv2d_nchw_asym8sxsym8s_asym8s_per_tensor_out.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_quantized_conv2d_nchw_asym8uxsym8u_asym8u_per_tensor_out",
+        srcs = ["op_quantized_conv2d_nchw_asym8uxsym8u_asym8u_per_tensor_out.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_quantized_conv2d_nchw_depthwise_asym8sxsym8s_asym8s_per_tensor_out",
+        srcs = ["op_quantized_conv2d_nchw_depthwise_asym8sxsym8s_asym8s_per_tensor_out.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_quantized_conv2d_nchw_depthwise_asym8uxsym8u_asym8u_per_tensor_out",
+        srcs = ["op_quantized_conv2d_nchw_depthwise_asym8uxsym8u_asym8u_per_tensor_out.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_quantized_conv2d_nchw_dilated_asym8sxsym8s_asym8s_per_tensor_out",
+        srcs = ["op_quantized_conv2d_nchw_dilated_asym8sxsym8s_asym8s_per_tensor_out.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_quantized_conv2d_nchw_dilated_asym8uxsym8u_asym8u_per_tensor_out",
+        srcs = ["op_quantized_conv2d_nchw_dilated_asym8uxsym8u_asym8u_per_tensor_out.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_quantized_conv2d_nchw_out",
+        srcs = ["op_quantized_conv2d_nchw_out.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS + [
+            "//executorch/backends/cadence/generic/operators:op_quantized_conv2d",
+        ],
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_quantized_conv2d_nhwc_asym8sxsym8s_asym8s_per_tensor_out",
+        srcs = ["op_quantized_conv2d_nhwc_asym8sxsym8s_asym8s_per_tensor_out.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_quantized_conv2d_nhwc_asym8uxsym8u_asym8u_per_tensor_out",
+        srcs = ["op_quantized_conv2d_nhwc_asym8uxsym8u_asym8u_per_tensor_out.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_quantized_conv2d_nhwc_depthwise_asym8sxsym8s_asym8s_per_tensor_out",
+        srcs = ["op_quantized_conv2d_nhwc_depthwise_asym8sxsym8s_asym8s_per_tensor_out.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_quantized_conv2d_nhwc_depthwise_asym8uxsym8u_asym8u_per_tensor_out",
+        srcs = ["op_quantized_conv2d_nhwc_depthwise_asym8uxsym8u_asym8u_per_tensor_out.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_quantized_conv2d_nhwc_dilated_asym8sxsym8s_asym8s_per_tensor_out",
+        srcs = ["op_quantized_conv2d_nhwc_dilated_asym8sxsym8s_asym8s_per_tensor_out.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_quantized_conv2d_nhwc_dilated_asym8uxsym8u_asym8u_per_tensor_out",
+        srcs = ["op_quantized_conv2d_nhwc_dilated_asym8uxsym8u_asym8u_per_tensor_out.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_quantized_conv2d_nhwc_out",
+        srcs = ["op_quantized_conv2d_nhwc_out.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS + [
+            "//executorch/backends/cadence/generic/operators:op_quantized_conv2d",
+        ],
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_quantized_fully_connected_asym8sxasym8s_asym8s_per_tensor_out",
+        srcs = ["op_quantized_fully_connected_asym8sxasym8s_asym8s_per_tensor_out.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_quantized_fully_connected_asym8uxasym8u_asym8u_per_tensor_out",
+        srcs = ["op_quantized_fully_connected_asym8uxasym8u_asym8u_per_tensor_out.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_quantized_fully_connected_out",
+        srcs = ["op_quantized_fully_connected_out.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_quantized_layer_norm",
+        srcs = ["op_quantized_layer_norm.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_quantized_linear_asym8sxasym8s_asym8s_per_tensor_out",
+        srcs = ["op_quantized_linear_asym8sxasym8s_asym8s_per_tensor_out.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_quantized_linear_asym8uxasym8u_asym8u_per_tensor_out",
+        srcs = ["op_quantized_linear_asym8uxasym8u_asym8u_per_tensor_out.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_quantized_linear_out",
+        srcs = ["op_quantized_linear_out.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS + [
+            "//executorch/backends/cadence/generic/operators:op_quantized_linear",
+        ],
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_quantized_matmul_asym8sxasym8s_asym8s_out",
+        srcs = ["op_quantized_matmul_asym8sxasym8s_asym8s_out.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_quantized_matmul_asym8uxasym8u_asym8u_out",
+        srcs = ["op_quantized_matmul_asym8uxasym8u_asym8u_out.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_quantized_matmul_out",
+        srcs = ["op_quantized_matmul_out.cpp"],
+        exported_headers = ["op_quantized_matmul_out.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS + [
+            "//executorch/backends/cadence/generic/operators:op_quantized_matmul",
+        ],
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_quantized_relu_asym8s_asym8s_per_tensor_out",
+        srcs = ["op_quantized_relu_asym8s_asym8s_per_tensor_out.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_quantized_relu_asym8u_asym8u_per_tensor_out",
+        srcs = ["op_quantized_relu_asym8u_asym8u_per_tensor_out.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_quantized_relu_out",
+        srcs = ["op_quantized_relu_out.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_remainder",
+        srcs = ["op_remainder.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_rsqrt",
+        srcs = ["op_rsqrt.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_select_copy",
+        srcs = ["op_select_copy.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_sigmoid",
+        srcs = ["op_sigmoid.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_slice_copy",
+        srcs = ["op_slice_copy.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_softmax",
+        srcs = ["op_softmax.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_softmax_f32_f32",
+        srcs = ["op_softmax_f32_f32.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_split_with_sizes_copy",
+        srcs = ["op_split_with_sizes_copy.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_sub",
+        srcs = ["op_sub.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_tanh",
+        srcs = ["op_tanh.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_transpose_copy",
+        srcs = ["op_transpose_copy.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_view_copy",
+        srcs = ["op_view_copy.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_where",
+        srcs = ["op_where.cpp"],
+        exported_headers = ["operators.h"],
+        platforms = CXX,
+        deps = COMMON_DEPS,
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )


### PR DESCRIPTION
Summary:
Use explicit, unique cxx_library targets for each hifi4 operator, following the same pattern used by generic operators.

Each operator now has its own named target (e.g., `op_add`, `op_softmax`, `op_quantized_conv2d_nchw_out`) with specific dependencies, making the build configuration more maintainable and explicit.

Added `# buildifier: keep sorted` annotation to COMMON_DEPS to enforce alphabetical ordering via the linter.

Differential Revision: D93517711


