### PR TITLE
Use explicit unique targets for fusion_g3 operators

### DIFF
--- a/backends/cadence/fusion_g3/operators/BUCK
+++ b/backends/cadence/fusion_g3/operators/BUCK
@@ -1,13 +1,5 @@
-load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target", "non_fbcode_target")
 load("targets.bzl", "define_common_targets")
 
 oncall("odai_jarvis")
 
-non_fbcode_target(_kind = define_common_targets,)
-
-# !!!! fbcode/executorch/backends/cadence/fusion_g3/operators/TARGETS was merged into this file, see https://fburl.com/workplace/xl8l9yuo for more info !!!!
-
-load("targets.bzl", "define_common_targets")
-
-
-fbcode_target(_kind = define_common_targets,)
+define_common_targets()

--- a/backends/cadence/fusion_g3/operators/targets.bzl
+++ b/backends/cadence/fusion_g3/operators/targets.bzl
@@ -1,56 +1,16 @@
 load("@fbsource//tools/build_defs:platform_defs.bzl", "CXX")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
-def define_operator(name: str, deps: list[str] | None = None) -> None:
-    op_name = "op_{}".format(name)
-
-    # Deps used by all operators.
-    common_deps = [
-        "//executorch/kernels/portable/cpu/util:all_deps",
-        "//executorch/kernels/portable/cpu/pattern:all_deps",
-        "//executorch/runtime/kernel:kernel_includes",
-        "//executorch/kernels/portable/cpu:scalar_utils",
-        "//executorch/backends/cadence/common:xt_macros",
-        "fbsource//third-party/nnlib-FusionG3/xa_nnlib:libxa_nnlib_common",
-        "fbsource//third-party/nnlib-FusionG3/xa_nnlib:libxa_nnlib",
-        ":operators_header",
-        ":xt_utils",
-    ]
-    if deps == None:
-        deps = []
-
-    runtime.cxx_library(
-        name = op_name,
-        srcs = [op_name + ".cpp"],
-        platforms = CXX,
-        visibility = ["PUBLIC"],
-        compatible_with = ["ovr_config//cpu:xtensa"],
-        deps = deps + common_deps,
-    )
-
-OPERATORS = [
-    "add",
-    "cat",
-    "clamp",
-    "lt",
-    "rsqrt",
-    "sigmoid",
-    "sqrt",
-    "hardtanh",
-    "tanh",
-    "transpose_copy",
-    "where",
-    "dequantize",
-    "mul",
-    "native_layer_norm",
-    "quantize",
-    "softmax",
-    "sub",
-    "div",
-    "exp",
-    "mean",
-    "slice_copy",
-    "permute_copy"
+# Deps used by all operators.
+# buildifier: keep sorted
+COMMON_DEPS = [
+    "//executorch/backends/cadence/common:xt_macros",
+    "//executorch/kernels/portable/cpu:scalar_utils",
+    "//executorch/kernels/portable/cpu/pattern:all_deps",
+    "//executorch/kernels/portable/cpu/util:all_deps",
+    "//executorch/runtime/kernel:kernel_includes",
+    "fbsource//third-party/nnlib-FusionG3/xa_nnlib:libxa_nnlib",
+    "fbsource//third-party/nnlib-FusionG3/xa_nnlib:libxa_nnlib_common",
 ]
 
 def define_common_targets():
@@ -59,8 +19,6 @@ def define_common_targets():
     The directory containing this targets.bzl file should also contain both
     TARGETS and BUCK files that call this function.
     """
-
-    # Define build targets for all operators registered in the tables above.
 
     runtime.cxx_library(
         name = "operators_header",
@@ -86,5 +44,266 @@ def define_common_targets():
         ],
     )
 
-    for op in OPERATORS:
-        define_operator(op)
+    runtime.cxx_library(
+        name = "op_add",
+        srcs = ["op_add.cpp"],
+        platforms = CXX,
+        deps = COMMON_DEPS + [
+            ":operators_header",
+            ":xt_utils",
+        ],
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_cat",
+        srcs = ["op_cat.cpp"],
+        platforms = CXX,
+        deps = COMMON_DEPS + [
+            ":operators_header",
+            ":xt_utils",
+        ],
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_clamp",
+        srcs = ["op_clamp.cpp"],
+        platforms = CXX,
+        deps = COMMON_DEPS + [
+            ":operators_header",
+            ":xt_utils",
+        ],
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_dequantize",
+        srcs = ["op_dequantize.cpp"],
+        platforms = CXX,
+        deps = COMMON_DEPS + [
+            ":operators_header",
+            ":xt_utils",
+        ],
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_div",
+        srcs = ["op_div.cpp"],
+        platforms = CXX,
+        deps = COMMON_DEPS + [
+            ":operators_header",
+            ":xt_utils",
+        ],
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_exp",
+        srcs = ["op_exp.cpp"],
+        platforms = CXX,
+        deps = COMMON_DEPS + [
+            ":operators_header",
+            ":xt_utils",
+        ],
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_hardtanh",
+        srcs = ["op_hardtanh.cpp"],
+        platforms = CXX,
+        deps = COMMON_DEPS + [
+            ":operators_header",
+            ":xt_utils",
+        ],
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_lt",
+        srcs = ["op_lt.cpp"],
+        platforms = CXX,
+        deps = COMMON_DEPS + [
+            ":operators_header",
+            ":xt_utils",
+        ],
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_mean",
+        srcs = ["op_mean.cpp"],
+        platforms = CXX,
+        deps = COMMON_DEPS + [
+            ":operators_header",
+            ":xt_utils",
+        ],
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_mul",
+        srcs = ["op_mul.cpp"],
+        platforms = CXX,
+        deps = COMMON_DEPS + [
+            ":operators_header",
+            ":xt_utils",
+        ],
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_native_layer_norm",
+        srcs = ["op_native_layer_norm.cpp"],
+        platforms = CXX,
+        deps = COMMON_DEPS + [
+            ":operators_header",
+            ":xt_utils",
+        ],
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_permute_copy",
+        srcs = ["op_permute_copy.cpp"],
+        platforms = CXX,
+        deps = COMMON_DEPS + [
+            ":operators_header",
+            ":xt_utils",
+        ],
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_quantize",
+        srcs = ["op_quantize.cpp"],
+        platforms = CXX,
+        deps = COMMON_DEPS + [
+            ":operators_header",
+            ":xt_utils",
+        ],
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_rsqrt",
+        srcs = ["op_rsqrt.cpp"],
+        platforms = CXX,
+        deps = COMMON_DEPS + [
+            ":operators_header",
+            ":xt_utils",
+        ],
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_sigmoid",
+        srcs = ["op_sigmoid.cpp"],
+        platforms = CXX,
+        deps = COMMON_DEPS + [
+            ":operators_header",
+            ":xt_utils",
+        ],
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_slice_copy",
+        srcs = ["op_slice_copy.cpp"],
+        platforms = CXX,
+        deps = COMMON_DEPS + [
+            ":operators_header",
+            ":xt_utils",
+        ],
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_softmax",
+        srcs = ["op_softmax.cpp"],
+        platforms = CXX,
+        deps = COMMON_DEPS + [
+            ":operators_header",
+            ":xt_utils",
+        ],
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_sqrt",
+        srcs = ["op_sqrt.cpp"],
+        platforms = CXX,
+        deps = COMMON_DEPS + [
+            ":operators_header",
+            ":xt_utils",
+        ],
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_sub",
+        srcs = ["op_sub.cpp"],
+        platforms = CXX,
+        deps = COMMON_DEPS + [
+            ":operators_header",
+            ":xt_utils",
+        ],
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_tanh",
+        srcs = ["op_tanh.cpp"],
+        platforms = CXX,
+        deps = COMMON_DEPS + [
+            ":operators_header",
+            ":xt_utils",
+        ],
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_transpose_copy",
+        srcs = ["op_transpose_copy.cpp"],
+        platforms = CXX,
+        deps = COMMON_DEPS + [
+            ":operators_header",
+            ":xt_utils",
+        ],
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )
+
+    runtime.cxx_library(
+        name = "op_where",
+        srcs = ["op_where.cpp"],
+        platforms = CXX,
+        deps = COMMON_DEPS + [
+            ":operators_header",
+            ":xt_utils",
+        ],
+        visibility = ["PUBLIC"],
+        compatible_with = ["ovr_config//cpu:xtensa"],
+    )


### PR DESCRIPTION
Summary:
Use explicit, unique cxx_library targets for each fusion_g3 operator, following the same pattern used by generic and hifi operators.

Each operator now has its own named target (e.g., `op_add`, `op_softmax`, `op_dequantize`) with specific dependencies, making the build configuration more maintainable and explicit.

Added `# buildifier: keep sorted` annotation to COMMON_DEPS to enforce alphabetical ordering via the linter.

Differential Revision: D93520739


