### PR TITLE
Fix weight layout detection and NHWC indexing in quantized conv ops

### DIFF
--- a/backends/cadence/hifi/operators/op_quantized_conv2d_nhwc_depthwise_asym8sxsym8s_asym8s_per_tensor_out.cpp
+++ b/backends/cadence/hifi/operators/op_quantized_conv2d_nhwc_depthwise_asym8sxsym8s_asym8s_per_tensor_out.cpp
@@ -48,14 +48,18 @@ void xa_opt_quantized_conv2d_nhwc_depthwise_asym8sxsym8s_asym8s(
   WORD32* __restrict__ p_bias =
       (WORD32* __restrict__)bias.const_data_ptr<int32_t>();
 
-  WORD32 input_height = conv1d ? 1 : input.size(2);
-  WORD32 input_width = conv1d ? input.size(2) : input.size(3);
-  WORD32 input_channels = input.size(1);
-  WORD32 kernel_height = conv1d ? 1 : weight.size(2);
-  WORD32 kernel_width = conv1d ? weight.size(2) : weight.size(3);
-  WORD32 out_channels = weight.size(0);
-  WORD32 out_height = conv1d ? 1 : out.size(2);
-  WORD32 out_width = conv1d ? out.size(2) : out.size(3);
+  // NHWC layout: 4D=[N,H,W,C], 3D=[N,W,C]
+  WORD32 input_height = conv1d ? 1 : input.size(1);
+  WORD32 input_width = conv1d ? input.size(1) : input.size(2);
+  WORD32 input_channels = conv1d ? input.size(2) : input.size(3);
+  // Depthwise weight layout:
+  // 2D conv: [KH, KW, OC] (3D tensor)
+  // 1D conv: [K, OC] (2D tensor)
+  WORD32 kernel_height = conv1d ? 1 : weight.size(0);
+  WORD32 kernel_width = conv1d ? weight.size(0) : weight.size(1);
+  WORD32 out_channels = conv1d ? weight.size(1) : weight.size(2);
+  WORD32 out_height = conv1d ? 1 : out.size(1);
+  WORD32 out_width = conv1d ? out.size(1) : out.size(2);
   WORD32 batches = input.size(0);
 
   WORD32 x_stride = stride[1];

--- a/backends/cadence/hifi/operators/op_quantized_conv2d_nhwc_depthwise_asym8uxsym8u_asym8u_per_tensor_out.cpp
+++ b/backends/cadence/hifi/operators/op_quantized_conv2d_nhwc_depthwise_asym8uxsym8u_asym8u_per_tensor_out.cpp
@@ -48,14 +48,18 @@ void xa_opt_quantized_conv2d_nhwc_depthwise_asym8uxsym8u_asym8u(
   WORD32* __restrict__ p_bias =
       (WORD32* __restrict__)bias.const_data_ptr<int32_t>();
 
-  WORD32 input_height = conv1d ? 1 : input.size(2);
-  WORD32 input_width = conv1d ? input.size(2) : input.size(3);
-  WORD32 input_channels = input.size(1);
-  WORD32 kernel_height = conv1d ? 1 : weight.size(2);
-  WORD32 kernel_width = conv1d ? weight.size(2) : weight.size(3);
-  WORD32 out_channels = weight.size(0);
-  WORD32 out_height = conv1d ? 1 : out.size(2);
-  WORD32 out_width = conv1d ? out.size(2) : out.size(3);
+  // NHWC layout: 4D=[N,H,W,C], 3D=[N,W,C]
+  WORD32 input_height = conv1d ? 1 : input.size(1);
+  WORD32 input_width = conv1d ? input.size(1) : input.size(2);
+  WORD32 input_channels = conv1d ? input.size(2) : input.size(3);
+  // Depthwise weight layout:
+  // 2D conv: [KH, KW, OC] (3D tensor)
+  // 1D conv: [K, OC] (2D tensor)
+  WORD32 kernel_height = conv1d ? 1 : weight.size(0);
+  WORD32 kernel_width = conv1d ? weight.size(0) : weight.size(1);
+  WORD32 out_channels = conv1d ? weight.size(1) : weight.size(2);
+  WORD32 out_height = conv1d ? 1 : out.size(1);
+  WORD32 out_width = conv1d ? out.size(1) : out.size(2);
   WORD32 batches = input.size(0);
 
   WORD32 x_stride = stride[1];

--- a/backends/cadence/hifi/operators/op_quantized_conv2d_nhwc_out.cpp
+++ b/backends/cadence/hifi/operators/op_quantized_conv2d_nhwc_out.cpp
@@ -176,15 +176,16 @@ void xa_opt_quantized_conv2d_nhwc(
     WORD32* __restrict__ p_bias =
         (WORD32* __restrict__)bias.const_data_ptr<int32_t>();
 
-    WORD32 input_height = conv1d ? 1 : input.size(2);
-    WORD32 input_width = conv1d ? input.size(2) : input.size(3);
-    WORD32 input_channels = input.size(1);
-    WORD32 kernel_height = conv1d ? 1 : weight.size(2);
-    WORD32 kernel_width = conv1d ? weight.size(2) : weight.size(3);
-    WORD32 kernel_channels = weight.size(1);
+    // NHWC layout: 4D=[N,H,W,C], 3D=[N,W,C]
+    WORD32 input_height = conv1d ? 1 : input.size(1);
+    WORD32 input_width = conv1d ? input.size(1) : input.size(2);
+    WORD32 input_channels = conv1d ? input.size(2) : input.size(3);
+    WORD32 kernel_height = conv1d ? 1 : weight.size(1);
+    WORD32 kernel_width = conv1d ? weight.size(1) : weight.size(2);
+    WORD32 kernel_channels = conv1d ? weight.size(2) : weight.size(3);
     WORD32 out_channels = weight.size(0);
-    WORD32 out_height = conv1d ? 1 : out.size(2);
-    WORD32 out_width = conv1d ? out.size(2) : out.size(3);
+    WORD32 out_height = conv1d ? 1 : out.size(1);
+    WORD32 out_width = conv1d ? out.size(1) : out.size(2);
     WORD32 batches = input.size(0);
 
     WORD32 x_stride = stride[1];


### PR DESCRIPTION
Summary:
1. Weight layout detection switched from ambiguous len(weight.shape) checks to the correct in_channels == groups semantic check for depthwise convolution
  2. C++ HiFi operators fixed to use NHWC dimension indices (the AOT pass already converts to NHWC, but the operators were still indexing as if NCHW)
  3. Added 1D depthwise convolution support in replace_ops.py and ref_implementations.py

Reviewed By: mcremon-meta

Differential Revision: D93525482




cc @mcremon-meta