### PR TITLE
3/x: Wire LoadBackendOptionsMap through Program and Method

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -400,12 +400,12 @@ jobs:
         setup_script_args=""
         if [[ ${{ matrix.os}} == "bare_metal" ]]; then
           toolchain_prefix=arm-none-eabi-
-          threshold="110592" # 108 KiB
+          threshold="110642" # 108 KiB
           toolchain_cmake=examples/arm/ethos-u-setup/arm-none-eabi-gcc.cmake
         elif [[ ${{ matrix.os}} == "zephyr-preset" ]]; then
           setup_script_args="--target-toolchain zephyr"
           toolchain_prefix=arm-zephyr-eabi-
-          threshold="136000" # 136 KiB
+          threshold="136020" # 136 KiB
           toolchain_cmake=examples/zephyr/x86_64-linux-arm-zephyr-eabi-gcc.cmake
         else
           echo "Fail unsupport OS selection ${{ matrix.os }}"
@@ -875,7 +875,7 @@ jobs:
           qwen3-0.6b|xnnpack|--quantize,
           qwen3-1.7b|xnnpack|--quantize,
           gemma3-1b|xnnpack|--quantize,
-          # phi4-mini|xnnpack|--quantize, transformers v5.0.0rc0 introduces a data-dependent branching in transformers/modeling_rope_utils.py:61 
+          # phi4-mini|xnnpack|--quantize, transformers v5.0.0rc0 introduces a data-dependent branching in transformers/modeling_rope_utils.py:61
           smollm2-135m|xnnpack|--quantize,
           smollm3-3b|xnnpack|--quantize
         ]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -579,6 +579,12 @@ install(
   PATTERN "*.h"
 )
 install(
+  DIRECTORY runtime/backend/
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/executorch/runtime/backend
+  FILES_MATCHING
+  PATTERN "*.h"
+)
+install(
   DIRECTORY runtime/platform/
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/executorch/runtime/platform
   FILES_MATCHING

--- a/runtime/executor/method.h
+++ b/runtime/executor/method.h
@@ -14,6 +14,7 @@
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
+#include <executorch/runtime/backend/backend_options_map.h>
 #include <executorch/runtime/core/evalue.h>
 #include <executorch/runtime/core/event_tracer.h>
 #include <executorch/runtime/core/exec_aten/exec_aten.h>
@@ -355,7 +356,8 @@ class Method final {
       const Program* program,
       MemoryManager* memory_manager,
       EventTracer* event_tracer,
-      const NamedDataMap* named_data_map);
+      const NamedDataMap* named_data_map,
+      const LoadBackendOptionsMap* backend_options = nullptr);
 
   /**
    * Initialize the method from its serialized representation.
@@ -364,7 +366,8 @@ class Method final {
    */
   ET_NODISCARD Error init(
       executorch_flatbuffer::ExecutionPlan* s_plan,
-      const NamedDataMap* named_data_map);
+      const NamedDataMap* named_data_map,
+      const LoadBackendOptionsMap* backend_options);
 
   /// Returns true if the Method was successfully initialized.
   inline bool initialized() const {

--- a/runtime/executor/program.cpp
+++ b/runtime/executor/program.cpp
@@ -307,7 +307,8 @@ Result<Method> Program::load_method(
     const char* method_name,
     MemoryManager* memory_manager,
     EventTracer* event_tracer,
-    const NamedDataMap* named_data_map) const {
+    const NamedDataMap* named_data_map,
+    const LoadBackendOptionsMap* backend_options) const {
   EXECUTORCH_SCOPE_PROF("Program::load_method");
   internal::event_tracer_create_event_block(event_tracer, "Default");
   internal::EventTracerProfileMethodScope event_tracer_scope =
@@ -325,7 +326,12 @@ Result<Method> Program::load_method(
     return plan.error();
   }
   return Method::load(
-      plan.get(), this, memory_manager, event_tracer, named_data_map);
+      plan.get(),
+      this,
+      memory_manager,
+      event_tracer,
+      named_data_map,
+      backend_options);
 }
 
 Result<MethodMeta> Program::method_meta(const char* method_name) const {

--- a/runtime/executor/program.h
+++ b/runtime/executor/program.h
@@ -11,6 +11,7 @@
 #include <cstdint>
 #include <optional>
 
+#include <executorch/runtime/backend/backend_options_map.h>
 #include <executorch/runtime/core/data_loader.h>
 #include <executorch/runtime/core/error.h>
 #include <executorch/runtime/core/event_tracer.h>
@@ -139,6 +140,9 @@ class Program final {
    * @param[in] event_tracer The event tracer to use for this method run.
    * @param[in] named_data_map An optional map of {name, blob} used to resolve
    *     data that is external to the PTE, if any.
+   * @param[in] backend_options An optional map of per-backend load-time options
+   *     (RuntimeSpecs). Each backend will receive its corresponding options
+   *     during initialization.
    *
    * @returns The loaded method on success, or an error on failure.
    */
@@ -146,7 +150,8 @@ class Program final {
       const char* method_name,
       MemoryManager* memory_manager,
       EventTracer* event_tracer = nullptr,
-      const NamedDataMap* named_data_map = nullptr) const;
+      const NamedDataMap* named_data_map = nullptr,
+      const LoadBackendOptionsMap* backend_options = nullptr) const;
 
   /**
    * Gathers metadata for the named method.


### PR DESCRIPTION
Summary:
This diff wires the `LoadBackendOptionsMap` through the executor layer, connecting `Program::load_method()` and `Method` to accept and route backend options to delegates.

Key changes:
- `Program::load_method()` now accepts optional `LoadBackendOptionsMap*` parameter
- `Method` stores reference to the options map and looks up options by backend ID
- When initializing delegates, the runtime queries the map for backend-specific options and passes them to `BackendInitContext`

This enables the end-to-end flow:
```
Module::load(method_name, options_map)
  → Program::load_method(..., options_map)
    → Method initialization
      → Backend delegate init with runtime_specs from options_map
```

Reviewed By: larryliu0820

Differential Revision: D92461088


