### PR TITLE
Metal backend: Enable Voxtral Realtime

### DIFF
--- a/.ci/scripts/test_model_e2e.sh
+++ b/.ci/scripts/test_model_e2e.sh
@@ -9,7 +9,7 @@
 
 show_help() {
   cat << EOF
-Usage: test_model_e2e.sh <device> <hf_model> <quant_name> [model_dir]
+Usage: test_model_e2e.sh <device> <hf_model> <quant_name> [model_dir] [mode]
 
 Build and run end-to-end tests for CUDA/Metal/XNNPACK models.
 
@@ -35,11 +35,18 @@ Arguments:
               Expected files: model.pte, aoti_cuda_blob.ptd (CUDA only)
               Tokenizers and test files will be downloaded to this directory
 
+  mode        Test mode (optional, default: auto-detect based on model and device)
+              Supported modes:
+                - vr-streaming: Voxtral Realtime streaming mode
+                - vr-offline: Voxtral Realtime offline mode
+
 Examples:
   test_model_e2e.sh metal "openai/whisper-small" "non-quantized"
   test_model_e2e.sh cuda "mistralai/Voxtral-Mini-3B-2507" "quantized-int4-tile-packed" "./model_output"
   test_model_e2e.sh cuda "nvidia/parakeet-tdt" "non-quantized" "./model_output"
   test_model_e2e.sh xnnpack "nvidia/parakeet-tdt" "quantized-8da4w" "./model_output"
+  test_model_e2e.sh metal "mistralai/Voxtral-Mini-4B-Realtime-2602" "non-quantized" "." "vr-streaming"
+  test_model_e2e.sh xnnpack "mistralai/Voxtral-Mini-4B-Realtime-2602" "quantized-8da4w" "./model_output" "vr-offline"
 EOF
 }
 
@@ -67,6 +74,26 @@ HF_MODEL="$2"
 QUANT_NAME="$3"
 # Download tokenizers, audio, and image files to this directory
 MODEL_DIR="${4:-.}"
+MODE="${5:-}"
+
+# Validate mode if specified
+if [ -n "$MODE" ]; then
+  case "$MODE" in
+    vr-streaming|vr-offline)
+      # Voxtral Realtime modes require Voxtral Realtime model
+      if [ "$HF_MODEL" != "mistralai/Voxtral-Mini-4B-Realtime-2602" ]; then
+        echo "Error: Mode '$MODE' can only be used with Voxtral Realtime model"
+        echo "Provided model: $HF_MODEL"
+        exit 1
+      fi
+      ;;
+    *)
+      echo "Error: Unsupported mode '$MODE'"
+      echo "Supported modes: vr-streaming, vr-offline"
+      exit 1
+      ;;
+  esac
+fi
 
 echo "Testing model: $HF_MODEL (quantization: $QUANT_NAME)"
 
@@ -236,7 +263,23 @@ case "$MODEL_NAME" in
     fi
     ;;
   voxtral_realtime)
-    RUNNER_ARGS="--model_path ${MODEL_DIR}/model.pte --tokenizer_path ${MODEL_DIR}/$TOKENIZER_FILE --preprocessor_path ${MODEL_DIR}/$PREPROCESSOR --audio_path ${MODEL_DIR}/$AUDIO_FILE --temperature 0 --streaming"
+    RUNNER_ARGS="--model_path ${MODEL_DIR}/model.pte --tokenizer_path ${MODEL_DIR}/$TOKENIZER_FILE --preprocessor_path ${MODEL_DIR}/$PREPROCESSOR --audio_path ${MODEL_DIR}/$AUDIO_FILE --temperature 0"
+    # Determine streaming mode based on MODE parameter
+    USE_STREAMING="false"
+    if [ "$MODE" = "vr-streaming" ]; then
+      USE_STREAMING="true"
+    elif [ "$MODE" = "vr-offline" ]; then
+      USE_STREAMING="false"
+    elif [ -z "$MODE" ]; then
+      # Auto-detect: XNNPACK uses streaming, others use offline
+      if [ "$DEVICE" = "xnnpack" ]; then
+        USE_STREAMING="true"
+      fi
+    fi
+    # Add streaming flag if needed
+    if [ "$USE_STREAMING" = "true" ]; then
+      RUNNER_ARGS="$RUNNER_ARGS --streaming"
+    fi
     ;;
 esac
 

--- a/.github/workflows/metal.yml
+++ b/.github/workflows/metal.yml
@@ -64,6 +64,8 @@ jobs:
         model:
           - repo: "mistralai"
             name: "Voxtral-Mini-3B-2507"
+          - repo: "mistralai"
+            name: "Voxtral-Mini-4B-Realtime-2602"
           - repo: "openai"
             name: "whisper-small"
           - repo: "openai"
@@ -73,6 +75,12 @@ jobs:
         quant:
           - "non-quantized"
           - "quantized-int4-metal"
+        exclude:
+          # Exclude non-quantized for Voxtral Realtime (too large)
+          - model:
+              repo: "mistralai"
+              name: "Voxtral-Mini-4B-Realtime-2602"
+            quant: "non-quantized"
     with:
       runner: macos-m2-stable
       python-version: '3.11'
@@ -115,6 +123,8 @@ jobs:
         model:
           - repo: "mistralai"
             name: "Voxtral-Mini-3B-2507"
+          - repo: "mistralai"
+            name: "Voxtral-Mini-4B-Realtime-2602"
           - repo: "openai"
             name: "whisper-small"
           - repo: "openai"
@@ -124,6 +134,12 @@ jobs:
         quant:
           - "non-quantized"
           - "quantized-int4-metal"
+        exclude:
+          # Exclude non-quantized for Voxtral Realtime (too large)
+          - model:
+              repo: "mistralai"
+              name: "Voxtral-Mini-4B-Realtime-2602"
+            quant: "non-quantized"
     with:
       runner: macos-m2-stable
       python-version: '3.11'

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@
 #
 # ==============================================================================
 
-.PHONY: voxtral-cuda voxtral-cpu voxtral-metal voxtral_realtime-cpu whisper-cuda whisper-cuda-debug whisper-cpu whisper-metal parakeet-cuda parakeet-cuda-debug parakeet-cpu parakeet-metal sortformer-cpu silero-vad-cpu llama-cpu llava-cpu gemma3-cuda gemma3-cpu clean help
+.PHONY: voxtral-cuda voxtral-cpu voxtral-metal voxtral_realtime-cpu voxtral_realtime-metal whisper-cuda whisper-cuda-debug whisper-cpu whisper-metal parakeet-cuda parakeet-cuda-debug parakeet-cpu parakeet-metal sortformer-cpu silero-vad-cpu llama-cpu llava-cpu gemma3-cuda gemma3-cpu clean help
 
 help:
 	@echo "This Makefile adds targets to build runners for various models on various backends. Run using \`make <target>\`. Available targets:"
@@ -99,6 +99,7 @@ help:
 	@echo "  voxtral-cpu         - Build Voxtral runner with CPU backend"
 	@echo "  voxtral-metal       - Build Voxtral runner with Metal backend (macOS only)"
 	@echo "  voxtral_realtime-cpu - Build Voxtral Realtime runner with CPU backend"
+	@echo "  voxtral_realtime-metal - Build Voxtral Realtime runner with Metal backend (macOS only)"
 	@echo "  whisper-cuda        - Build Whisper runner with CUDA backend"
 	@echo "  whisper-cuda-debug  - Build Whisper runner with CUDA backend (debug mode)"
 	@echo "  whisper-cpu         - Build Whisper runner with CPU backend"
@@ -228,6 +229,15 @@ voxtral_realtime-cpu:
 	cmake --workflow --preset llm-release
 	@echo "==> Building Voxtral Realtime runner (CPU)..."
 	cd examples/models/voxtral_realtime && cmake --workflow --preset voxtral-realtime-cpu
+	@echo ""
+	@echo "✓ Build complete!"
+	@echo "  Binary: cmake-out/examples/models/voxtral_realtime/voxtral_realtime_runner"
+
+voxtral_realtime-metal:
+	@echo "==> Building and installing ExecuTorch with Metal (stats enabled)..."
+	cmake --workflow --preset llm-metal-stats
+	@echo "==> Building Voxtral Realtime runner with Metal..."
+	cd examples/models/voxtral_realtime && cmake --workflow --preset voxtral-realtime-metal
 	@echo ""
 	@echo "✓ Build complete!"
 	@echo "  Binary: cmake-out/examples/models/voxtral_realtime/voxtral_realtime_runner"

--- a/examples/models/voxtral_realtime/CMakePresets.json
+++ b/examples/models/voxtral_realtime/CMakePresets.json
@@ -15,6 +15,19 @@
             "name": "voxtral-realtime-cpu",
             "displayName": "Voxtral Realtime runner (CPU)",
             "inherits": ["voxtral-realtime-base"]
+        },
+        {
+            "name": "voxtral-realtime-metal",
+            "displayName": "Voxtral Realtime runner (Metal)",
+            "inherits": ["voxtral-realtime-base"],
+            "cacheVariables": {
+                "EXECUTORCH_BUILD_METAL": "ON"
+            },
+            "condition": {
+                "lhs": "${hostSystemName}",
+                "type": "equals",
+                "rhs": "Darwin"
+            }
         }
     ],
     "buildPresets": [
@@ -22,6 +35,13 @@
             "name": "voxtral-realtime-cpu",
             "displayName": "Build Voxtral Realtime runner (CPU)",
             "configurePreset": "voxtral-realtime-cpu",
+            "targets": ["voxtral_realtime_runner"]
+        },
+        {
+            "name": "voxtral-realtime-metal",
+            "displayName": "Build Voxtral Realtime runner (Metal)",
+            "configurePreset": "voxtral-realtime-metal",
+            "configuration": "Release",
             "targets": ["voxtral_realtime_runner"]
         }
     ],
@@ -37,6 +57,20 @@
                 {
                     "type": "build",
                     "name": "voxtral-realtime-cpu"
+                }
+            ]
+        },
+        {
+            "name": "voxtral-realtime-metal",
+            "displayName": "Configure and build Voxtral Realtime runner (Metal)",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "voxtral-realtime-metal"
+                },
+                {
+                    "type": "build",
+                    "name": "voxtral-realtime-metal"
                 }
             ]
         }

--- a/examples/models/voxtral_realtime/export_voxtral_rt.py
+++ b/examples/models/voxtral_realtime/export_voxtral_rt.py
@@ -323,6 +323,7 @@ def export_streaming(
 # Custom decomposition for Metal backend compatibility.
 # This decomposition is necessary to avoid issues with reinterpret_tensor_wrapper
 # when linear layers have biases, which would cause ExecuTorch errors with 0 stride.
+# TODO(manuelcandales): Remove this once ExecuTorch Metal backend supports bias in linear layers.
 def _linear_bias_decomposition(input, weight, bias=None):
     """Decompose linear with bias into matmul + add."""
     weight_t = torch.ops.aten.t.default(weight)

--- a/examples/models/voxtral_realtime/export_voxtral_rt.py
+++ b/examples/models/voxtral_realtime/export_voxtral_rt.py
@@ -188,7 +188,9 @@ def export_all(
     # For XNNPACK: use small sample with explicit bounds
     if backend == "metal":
         max_t_mel = 24000  # 3000 * 8
-        sample_mel = torch.randn(1, model.config.num_mel_bins, max_t_mel, dtype=param_dtype)
+        sample_mel = torch.randn(
+            1, model.config.num_mel_bins, max_t_mel, dtype=param_dtype
+        )
         dynamic_shapes = {"mel": {2: Dim.AUTO}}
     else:
         _t_mel_base = Dim("_t_mel_base", min=1, max=3000)
@@ -474,7 +476,7 @@ def main():
 
     # Load model
     print("Loading model...")
-    use_standard_attention = (args.backend == "metal")
+    use_standard_attention = args.backend == "metal"
     model = load_model(
         args.model_path,
         max_seq_len=args.max_seq_len,

--- a/examples/models/voxtral_realtime/export_voxtral_rt.py
+++ b/examples/models/voxtral_realtime/export_voxtral_rt.py
@@ -312,6 +312,15 @@ def lower_to_executorch(programs, metadata, backend="xnnpack"):
             key: [XnnpackDynamicallyQuantizedPartitioner(), XnnpackPartitioner()]
             for key in programs
         }
+    elif backend == "metal":
+        from executorch.backends.apple.metal.metal_backend import MetalBackend
+        from executorch.backends.apple.metal.metal_partitioner import MetalPartitioner
+
+        print("\nLowering to ExecuTorch with Metal...")
+        partitioner = {}
+        for key in programs:
+            compile_specs = [MetalBackend.generate_method_name_compile_spec(key)]
+            partitioner[key] = [MetalPartitioner(compile_specs)]
     else:
         print("\nLowering to ExecuTorch (portable)...")
         partitioner = []
@@ -352,7 +361,7 @@ def main():
     parser.add_argument(
         "--backend",
         default="xnnpack",
-        choices=["portable", "xnnpack"],
+        choices=["portable", "xnnpack", "metal"],
         help="Backend for acceleration (default: xnnpack)",
     )
     parser.add_argument(

--- a/examples/models/voxtral_realtime/export_voxtral_rt.py
+++ b/examples/models/voxtral_realtime/export_voxtral_rt.py
@@ -424,7 +424,7 @@ def main():
     parser.add_argument(
         "--qlinear",
         default=None,
-        choices=["4w", "8w", "8da4w", "8da8w"],
+        choices=["4w", "8w", "8da4w", "8da8w", "fpa4w"],
         help="Quantize decoder linear layers.",
     )
     parser.add_argument(
@@ -436,7 +436,7 @@ def main():
     parser.add_argument(
         "--qlinear-encoder",
         default=None,
-        choices=["4w", "8w", "8da4w", "8da8w"],
+        choices=["4w", "8w", "8da4w", "8da8w", "fpa4w"],
         help="Quantize encoder linear layers (separate from decoder).",
     )
     parser.add_argument(
@@ -463,6 +463,12 @@ def main():
         help="Encoder sliding window size for streaming (default: 750).",
     )
     args = parser.parse_args()
+
+    # Validate fpa4w quantization requires Metal backend
+    if args.qlinear == "fpa4w" and args.backend != "metal":
+        parser.error("--qlinear=fpa4w can only be used with --backend=metal")
+    if args.qlinear_encoder == "fpa4w" and args.backend != "metal":
+        parser.error("--qlinear-encoder=fpa4w can only be used with --backend=metal")
 
     os.makedirs(args.output_dir, exist_ok=True)
 

--- a/examples/models/voxtral_realtime/model.py
+++ b/examples/models/voxtral_realtime/model.py
@@ -478,13 +478,14 @@ class StandardSDPA(nn.Module):
             q_pos = input_pos.unsqueeze(1)  # [seqlen, 1]
             k_pos = torch.arange(max_seq_len, device=q.device).unsqueeze(0)  # [1, max_seq_len]
             # Causal mask: can attend where k_pos <= q_pos
-            attn_mask = k_pos > q_pos  # [seqlen, max_seq_len], True = masked out
+            # PyTorch convention: True = attend, False = don't attend
+            attn_mask = k_pos <= q_pos  # [seqlen, max_seq_len], True = can attend
         else:
             # Decode: single token can attend to all positions up to current position
             # Current position is input_pos[0]
             curr_pos = input_pos[0]  # scalar tensor
             k_pos = torch.arange(max_seq_len, device=q.device)
-            attn_mask = k_pos > curr_pos  # [max_seq_len], True = masked out
+            attn_mask = k_pos <= curr_pos  # [max_seq_len], True = can attend
             attn_mask = attn_mask.unsqueeze(0)  # [1, max_seq_len] for broadcasting
 
         # Standard SDPA

--- a/examples/models/voxtral_realtime/model.py
+++ b/examples/models/voxtral_realtime/model.py
@@ -50,7 +50,9 @@ class VoxtralRealtimeConfig:
     downsample_factor: int = 4
     # Runtime
     max_seq_len: int = 4096
-    use_standard_attention: bool = False  # Use standard PyTorch attention instead of custom ops
+    use_standard_attention: bool = (
+        False  # Use standard PyTorch attention instead of custom ops
+    )
 
     @staticmethod
     def from_params_json(path: str) -> "VoxtralRealtimeConfig":
@@ -476,7 +478,9 @@ class StandardSDPA(nn.Module):
             # Prefill: create causal mask where position i can attend to positions 0..input_pos[i]
             # Create position matrix for queries and keys
             q_pos = input_pos.unsqueeze(1)  # [seqlen, 1]
-            k_pos = torch.arange(max_seq_len, device=q.device).unsqueeze(0)  # [1, max_seq_len]
+            k_pos = torch.arange(max_seq_len, device=q.device).unsqueeze(
+                0
+            )  # [1, max_seq_len]
             # Causal mask: can attend where k_pos <= q_pos
             # PyTorch convention: True = attend, False = don't attend
             attn_mask = k_pos <= q_pos  # [seqlen, max_seq_len], True = can attend
@@ -490,7 +494,9 @@ class StandardSDPA(nn.Module):
 
         # Standard SDPA
         y = F.scaled_dot_product_attention(
-            q, k, v,
+            q,
+            k,
+            v,
             attn_mask=attn_mask,
             is_causal=False,  # We handle causal masking explicitly via attn_mask
         )  # [B, n_heads, seq_len, head_dim]


### PR DESCRIPTION
This pull request adds Metal backend support for the Voxtral Realtime model (offline mode, streaming support is coming next)

**Voxtral Realtime Metal backend support:**

* Added Metal backend support to `export_voxtral_rt.py`, including custom decompositions and dynamic shape handling for Metal/AOTI compatibility. Also added validation for Metal-specific quantization (`fpa4w`).
* Updated `export_model_artifact.sh` and `test_model_e2e.sh` scripts to support a new `mode` parameter. This is used in the Voxtral Realtime model for selecting between streaming/offline export modes.

**CI/CD and workflow updates:**

* Added quantized `Voxtral-Mini-4B-Realtime-2602` to Metal workflow matrix.
* Added new CMake presets for building and testing the Voxtral Realtime runner with Metal backend.