### PR TITLE
Metal backend: enable causal sdpa

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -224,6 +224,9 @@
         "llm-release-metal"
       ],
       "cacheVariables": {
+        "EXECUTORCH_BUILD_EXTENSION_EVALUE_UTIL": "ON",
+        "EXECUTORCH_BUILD_EXTENSION_RUNNER_UTIL": "ON",
+        "EXECUTORCH_BUILD_EXECUTOR_RUNNER": "ON",
         "EXECUTORCH_METAL_COLLECT_STATS": "ON",
         "EXECUTORCH_ENABLE_LOGGING": "ON",
         "EXECUTORCH_LOG_LEVEL": "Info"


### PR DESCRIPTION
This pull request adds support for causal masking in the scaled dot product attention (SDPA) Metal backend and extends the test suite to cover causal attention scenarios. The main changes include implementing the causal masking logic in the Metal kernel, enabling the feature in the build configuration, and introducing new test modules for causal SDPA.

**Causal masking support in Metal SDPA:**

* Implemented causal masking logic in the Metal SDPA kernel by adding an `is_causal` flag as a kernel argument and applying the causal mask in the attention computation. [[1]](diffhunk://#diff-7e5c21ca52b297e4aa332dd3258ef6be9fde6490300add4a4cac8a05e11a3db0R48) [[2]](diffhunk://#diff-7e5c21ca52b297e4aa332dd3258ef6be9fde6490300add4a4cac8a05e11a3db0L123-R130) [[3]](diffhunk://#diff-7e5c21ca52b297e4aa332dd3258ef6be9fde6490300add4a4cac8a05e11a3db0R220) [[4]](diffhunk://#diff-7e5c21ca52b297e4aa332dd3258ef6be9fde6490300add4a4cac8a05e11a3db0R595-R597)
* Removed the previous check that raised a "not implemented" error for causal masking, enabling the feature in the backend.

**Test suite enhancements:**

* Extended the `BaseStridedSDPA` test module and its subclasses to support the `is_causal` argument, allowing both causal and non-causal attention to be tested. [[1]](diffhunk://#diff-8167150e8ea21aa8d013b164bc1a85a4cedc01accf455215cec8ff4778b63c8fL471-R480) [[2]](diffhunk://#diff-8167150e8ea21aa8d013b164bc1a85a4cedc01accf455215cec8ff4778b63c8fR490) [[3]](diffhunk://#diff-8167150e8ea21aa8d013b164bc1a85a4cedc01accf455215cec8ff4778b63c8fL495-R511)
* Added new test modules and registry entries for contiguous and strided SDPA models with causal attention, ensuring comprehensive test coverage.
