### PR TITLE
NXP backend: switch from raw tflite to from ir.lib.tflite

### DIFF
--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/clamp_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/clamp_converter.py
@@ -9,8 +9,10 @@ from executorch.backends.nxp.backend.ir.converter.node_converter import (
     is_not_qdq_node,
     NodeConverter,
 )
+from executorch.backends.nxp.backend.ir.lib.tflite.BuiltinOperator import (
+    BuiltinOperator,
+)
 from executorch.backends.nxp.backend.neutron_target_spec import NeutronTargetSpec
-from tflite import BuiltinOperator
 from torch.fx import Node
 from torch.fx.passes.infra.partitioner import Partition
 from torch.nn import Parameter


### PR DESCRIPTION
Summary:
Following convention, do not use from tflite but rather the lib in Executorch backend, eg

from executorch.backends.nxp.backend.ir.lib.tflite.BuiltinOperator import BuiltinOperator

This allows for usage in environments where tflite is not installed.

Reviewed By: SS-JIA

Differential Revision: D93624349




cc @robert-kalmar @digantdesai