### PR TITLE
NXP backend: Fix incorrect import of Neutron IR builtin options.

### DIFF
--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/clamp_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/clamp_converter.py
@@ -9,8 +9,11 @@ from executorch.backends.nxp.backend.ir.converter.node_converter import (
     is_not_qdq_node,
     NodeConverter,
 )
+
+from executorch.backends.nxp.backend.ir.lib.tflite.BuiltinOperator import (
+    BuiltinOperator,
+)
 from executorch.backends.nxp.backend.neutron_target_spec import NeutronTargetSpec
-from tflite import BuiltinOperator
 from torch.fx import Node
 from torch.fx.passes.infra.partitioner import Partition
 from torch.nn import Parameter


### PR DESCRIPTION
### Summary
Fix incorrect import which broke internal Meta tests.

### Test plan
Tested by `test_clamp_converter.py`.


cc @robert-kalmar @JakeStevens @digantdesai