### PR TITLE
Arm backend: Add FP16 tests of models (mv3, ic3)

### DIFF
--- a/backends/arm/test/models/test_inception_v3_arm.py
+++ b/backends/arm/test/models/test_inception_v3_arm.py
@@ -24,6 +24,9 @@ from torchvision import models, transforms  # type: ignore[import-untyped]
 ic3 = models.inception_v3(weights=models.Inception_V3_Weights)
 ic3 = ic3.eval()
 
+ic3_fp16 = models.inception_v3(weights=models.Inception_V3_Weights).to(torch.float16)
+ic3_fp16 = ic3_fp16.eval()
+
 # Normalization values referenced from here:
 # https://docs.pytorch.org/vision/main/models/generated/torchvision.models.quantization.inception_v3.html
 normalize = transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
@@ -40,6 +43,20 @@ def test_ic3_tosa_FP():
         aten_op=[],
         exir_op=[],
         use_to_edge_transform_and_lower=True,
+    )
+    pipeline.run()
+
+
+@pytest.mark.slow
+def test_ic3_tosa_FP_fp16():
+    inputs_fp16 = tuple(t.to(torch.float16) for t in model_inputs)
+    pipeline = TosaPipelineFP[input_t](
+        ic3_fp16,
+        inputs_fp16,
+        aten_op=[],
+        exir_op=[],
+        use_to_edge_transform_and_lower=True,
+        atol=5e-2,
     )
     pipeline.run()
 

--- a/backends/arm/test/models/test_mobilenet_v3_arm.py
+++ b/backends/arm/test/models/test_mobilenet_v3_arm.py
@@ -24,6 +24,11 @@ from torchvision import models, transforms  # type: ignore[import-untyped]
 mv3 = models.mobilenet_v3_small(weights=models.MobileNet_V3_Small_Weights)
 mv3 = mv3.eval()
 
+mv3_fp16 = models.mobilenet_v3_small(weights=models.MobileNet_V3_Small_Weights).to(
+    torch.float16
+)
+mv3_fp16 = mv3_fp16.eval()
+
 normalize = transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
 
 input_tensor = torch.rand(1, 3, 232, 232)
@@ -36,6 +41,20 @@ input_t = Tuple[torch.Tensor]
 def test_mv3_tosa_FP():
     pipeline = TosaPipelineFP[input_t](
         mv3, model_inputs, aten_op=[], exir_op=[], use_to_edge_transform_and_lower=True
+    )
+    pipeline.run()
+
+
+@pytest.mark.slow
+def test_mv3_tosa_FP_fp16():
+    inputs_fp16 = tuple(t.to(torch.float16) for t in model_inputs)
+    pipeline = TosaPipelineFP[input_t](
+        mv3_fp16,
+        inputs_fp16,
+        aten_op=[],
+        exir_op=[],
+        use_to_edge_transform_and_lower=True,
+        atol=5e-2,
     )
     pipeline.run()
 


### PR DESCRIPTION
Add testing of the following models executed in FP16:
 - MobileNetV3
 - InceptionV3

This patch verifies that the Arm backend is able to lower full models in FP16 to valid TOSA, and execute them with acceptable numerical accuracy.

cc @digantdesai @SS-JIA @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell