### PR TITLE
Fix depthwise conv detection for groups==in_channels==1

### DIFF
--- a/backends/cadence/aot/BUCK
+++ b/backends/cadence/aot/BUCK
@@ -132,6 +132,7 @@ fbcode_target(_kind = runtime.python_library,
     typing = True,
     deps = [
         "fbcode//caffe2:torch",
+        "fbcode//executorch/backends/cadence/aot:utils",
         "fbcode//executorch/exir:scalar_type",
         "fbcode//executorch/kernels/quantized:custom_ops_generated_lib",
     ],
@@ -374,6 +375,7 @@ fbcode_target(_kind = runtime.python_library,
     deps = [
         "//caffe2:torch",
         "//executorch/backends/cadence/aot:pass_utils",
+        "//executorch/backends/cadence/aot:utils",
         "//executorch/exir:pass_base",
     ],
 )

--- a/backends/cadence/aot/utils.py
+++ b/backends/cadence/aot/utils.py
@@ -49,6 +49,15 @@ class ISSRuntimeFailure(Exception):
     pass
 
 
+def is_depthwise_conv(groups: int, in_channels: int) -> bool:
+    """Check whether a convolution is depthwise.
+
+    Depthwise convolution has groups == in_channels with groups > 1.
+    When groups == 1, it is always a regular convolution even if in_channels == 1.
+    """
+    return groups > 1 and groups == in_channels
+
+
 # Get the output size of a 1D convolution given the input size and parameters
 def get_conv1d_output_size(
     in_size: torch.Size,


### PR DESCRIPTION
Summary:
GitHub PR 17528 broke `test_silero_vad_16k_quantized_opt3` by removing the
`len(weight_shape) == 4` guard from the depthwise detection logic. This
caused regular 1D convolutions with `in_channels == groups == 1` (e.g.
Silero VAD's learned STFT conv) to be misclassified as depthwise.

This diff fixes the bug and centralizes the depthwise check into a single
`is_depthwise_conv(groups, in_channels)` utility in `utils.py` that
enforces `groups > 1 and groups == in_channels`. All 7 depthwise
detection sites across 4 files now use this shared function:

- **utils.py**: Added `is_depthwise_conv()` — the single source of truth.
- **ops_registrations.py**: 4 meta functions updated (quantized_conv2d_nhwc,
  per_tensor, asym8s, asym8u).
- **ref_implementations.py**: Updated `quantized_conv2d_nhwc_per_tensor`.
- **replace_ops.py**: Updated `ReplaceConvWithChannelLastConvPass`.
- **type_dispatch.py**: Updated `CompileTimeTypeDispatchPass` (also fixed a
  pre-existing bug where `groups > 1` was missing entirely).
- **test_ref_implementations.py**: Fixed the test harness to squeeze the
  IC=1 dim for depthwise weights when converting to channels_last format,
  matching the actual `replace_ops.py` pipeline behavior.
- **test_replace_ops_passes.py**: Added regression test for the
  `in_channels==groups==1` case and a positive test for 1D depthwise.

Differential Revision: D93869048


