### PR TITLE
Add memory planning to oss tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -34,7 +34,7 @@ addopts =
     --ignore=exir/backend/test/demos/test_delegate_aten_mode.py
     --ignore=exir/backend/test/demos/test_xnnpack_qnnpack.py
     --ignore=exir/tests/test_memory_format_ops_pass_aten.py
-    --ignore=exir/tests/test_memory_planning.py
+
     --ignore=exir/tests/test_passes.py
     --ignore=exir/tests/test_quantization.py
     --ignore=exir/tests/test_verification.py


### PR DESCRIPTION
### Summary
add to pytest.ini, and add cmake path-finding import for OSS

### Test plan
python -m unittest exir.tests.test_memory_planning