### PR TITLE
Make NXP batch norm tests runnable in BUCK

### DIFF
--- a/backends/nxp/tests/BUCK
+++ b/backends/nxp/tests/BUCK
@@ -53,3 +53,18 @@ fbcode_target(_kind = python_pytest,
         ":models",
     ]
 )
+
+fbcode_target(_kind = python_pytest,
+    name = "test_batch_norm_fusion",
+    srcs = [
+        "test_batch_norm_fusion.py",
+    ],
+    deps = [
+        "//caffe2:torch",
+        "//executorch/backends/nxp:neutron_backend",
+        ":executorch_pipeline",
+        ":models",
+        "fbsource//third-party/pypi/pytest:pytest",
+        "fbsource//third-party/pypi/numpy:numpy",
+    ],
+)


### PR DESCRIPTION
Summary:
Make the NXP test_batch_norm_fusion tests compatible with the BUCK build
system. The tflite import in executors.py is made optional since
tensorflow/tflite_runtime are not available in the BUCK environment. The tests enabled do not rely on the functionality enabled by tflite.

Differential Revision: D93880277


