### PR TITLE
[ET][arm] Fix missing shape.py in Buck targets for arm tosa dialect

### DIFF
--- a/backends/arm/TARGETS
+++ b/backends/arm/TARGETS
@@ -82,6 +82,7 @@ runtime.python_library(
         "//executorch/backends/arm/operators:node_visitor",
         "//executorch/backends/arm/tosa:mapping",
         "//executorch/backends/arm/tosa:utils",
+        "//executorch/backends/arm/tosa/dialect:core",
         "//executorch/exir:lib",
     ],
 )

--- a/backends/arm/tosa/dialect/BUCK
+++ b/backends/arm/tosa/dialect/BUCK
@@ -6,9 +6,11 @@ fbcode_target(_kind = runtime.python_library,
     srcs = [
         "lib.py",
         "ops_registration.py",
+        "shape.py",
     ],
     deps = [
         "//caffe2:torch",
+        "//executorch/backends/arm/tosa:mapping",
         "//executorch/backends/arm/tosa:tosa",
         "//executorch/exir/dialects:lib",
     ],


### PR DESCRIPTION

shape.py was added to the arm tosa dialect directory but was not included in any Buck build target, causing a ModuleNotFoundError at test collection time. Fix by adding shape.py to the `core` target in both fbcode and xplat dialect BUCK files, along with the required //executorch/backends/arm/tosa:mapping dep. Also add //executorch/backends/arm/tosa/dialect:core as an explicit dep of the process_node target, which imports from shape.py.
