### PR TITLE
Fix JNI reading mTypeCode instead of mData for scalar EValue inputs

### DIFF
--- a/extension/android/jni/jni_layer.cpp
+++ b/extension/android/jni/jni_layer.cpp
@@ -359,14 +359,17 @@ class ExecuTorchJni : public facebook::jni::HybridClass<ExecuTorchJni> {
         tensors.emplace_back(JEValue::JEValueToTensorImpl(jevalue));
         evalues.emplace_back(tensors.back());
       } else if (typeCode == JEValue::kTypeCodeInt) {
-        int64_t value = jevalue->getFieldValue(typeCodeField);
-        evalues.emplace_back(value);
+        static const auto toIntMethod =
+            JEValue::javaClassStatic()->getMethod<jlong()>("toInt");
+        evalues.emplace_back(static_cast<int64_t>(toIntMethod(jevalue)));
       } else if (typeCode == JEValue::kTypeCodeDouble) {
-        double value = jevalue->getFieldValue(typeCodeField);
-        evalues.emplace_back(value);
+        static const auto toDoubleMethod =
+            JEValue::javaClassStatic()->getMethod<jdouble()>("toDouble");
+        evalues.emplace_back(static_cast<double>(toDoubleMethod(jevalue)));
       } else if (typeCode == JEValue::kTypeCodeBool) {
-        bool value = jevalue->getFieldValue(typeCodeField);
-        evalues.emplace_back(value);
+        static const auto toBoolMethod =
+            JEValue::javaClassStatic()->getMethod<jboolean()>("toBool");
+        evalues.emplace_back(static_cast<bool>(toBoolMethod(jevalue)));
       }
     }
 

--- a/extension/android/jni/jni_layer_training.cpp
+++ b/extension/android/jni/jni_layer_training.cpp
@@ -131,14 +131,17 @@ class ExecuTorchTrainingJni
         tensors.emplace_back(JEValue::JEValueToTensorImpl(jevalue));
         evalues.emplace_back(tensors.back());
       } else if (typeCode == JEValue::kTypeCodeInt) {
-        int64_t value = jevalue->getFieldValue(typeCodeField);
-        evalues.emplace_back(value);
+        static const auto toIntMethod =
+            JEValue::javaClassStatic()->getMethod<jlong()>("toInt");
+        evalues.emplace_back(static_cast<int64_t>(toIntMethod(jevalue)));
       } else if (typeCode == JEValue::kTypeCodeDouble) {
-        double value = jevalue->getFieldValue(typeCodeField);
-        evalues.emplace_back(value);
+        static const auto toDoubleMethod =
+            JEValue::javaClassStatic()->getMethod<jdouble()>("toDouble");
+        evalues.emplace_back(static_cast<double>(toDoubleMethod(jevalue)));
       } else if (typeCode == JEValue::kTypeCodeBool) {
-        bool value = jevalue->getFieldValue(typeCodeField);
-        evalues.emplace_back(value);
+        static const auto toBoolMethod =
+            JEValue::javaClassStatic()->getMethod<jboolean()>("toBool");
+        evalues.emplace_back(static_cast<bool>(toBoolMethod(jevalue)));
       }
     }
 


### PR DESCRIPTION
### Summary
  - The `execute_method` paths in `jni_layer.cpp` and `jni_layer_training.cpp` extracted Int/Double/Bool EValue data by re-reading the
  `mTypeCode` field instead of the actual `mData`. This meant every scalar input was silently replaced by its type code constant (e.g. Int always
   became 4, Double became 3.0, Bool was always true).
  - Call the Java accessor methods (`toInt`, `toDouble`, `toBool`) instead, matching the pattern already used for Tensor inputs via `toTensor()`.
### Test plan
  - [ ] Android instrumentation tests pass (`ModuleInstrumentationTest`)
  - [ ] Verify with a model that takes scalar Int/Bool/Double inputs