### PR TITLE
Remove deprecated jcenter() repository from Android build config

### DIFF
--- a/extension/android/build.gradle
+++ b/extension/android/build.gradle
@@ -24,7 +24,6 @@ allprojects {
 
     repositories {
         google()
-        jcenter()
         mavenCentral()
     }
 }


### PR DESCRIPTION

### Summary
JCenter has been read-only since 2021 and all dependencies are available on Maven Central, which is already listed.

### Test plan
CI