### PR TITLE
Check Result before calling .get() on method_meta in getUsedBackends

### DIFF
--- a/extension/android/jni/jni_layer.cpp
+++ b/extension/android/jni/jni_layer.cpp
@@ -503,7 +503,16 @@ class ExecuTorchJni : public facebook::jni::HybridClass<ExecuTorchJni> {
 
   facebook::jni::local_ref<facebook::jni::JArrayClass<jstring>> getUsedBackends(
       facebook::jni::alias_ref<jstring> methodName) {
-    auto methodMeta = module_->method_meta(methodName->toStdString()).get();
+    auto method_name = methodName->toStdString();
+    auto result = module_->method_meta(method_name);
+    if (!result.ok()) {
+      facebook::jni::throwNewJavaException(
+          "java/lang/IllegalArgumentException",
+          "method_meta failed for method %s",
+          method_name.c_str());
+      return {};
+    }
+    auto methodMeta = result.get();
     std::unordered_set<std::string> backends;
     for (auto i = 0; i < methodMeta.num_backends(); i++) {
       backends.insert(methodMeta.get_backend_name(i).get());


### PR DESCRIPTION

### Summary
`getUsedBackends()` called `module_->method_meta(...).get()` without checking if the Result was ok, which is undefined behavior on error. Add an `.ok()` check and throw IllegalArgumentException on failure, consistent with how `method_names()` handles its Result above.

### Test plan
CI