### PR TITLE
Android/fix evalue string serialization

### DIFF
--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/EValue.java
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/EValue.java
@@ -202,12 +202,14 @@ public class EValue {
     } else if (isDouble()) {
       return ByteBuffer.allocate(9).put((byte) TYPE_CODE_DOUBLE).putDouble(toDouble()).array();
     } else if (isString()) {
-      return ByteBuffer.allocate(1 + toString().length())
+      byte[] strBytes = toStr().getBytes();
+      return ByteBuffer.allocate(1 + 4 + strBytes.length)
           .put((byte) TYPE_CODE_STRING)
-          .put(toString().getBytes())
+          .putInt(strBytes.length)
+          .put(strBytes)
           .array();
     } else {
-      throw new IllegalArgumentException("Unknown Tensor dtype");
+      throw new IllegalArgumentException("Unknown EValue type code: " + mTypeCode);
     }
   }
 
@@ -234,7 +236,10 @@ public class EValue {
         byte[] bufferArray = buffer.array();
         return from(Tensor.fromByteArray(Arrays.copyOfRange(bufferArray, 1, bufferArray.length)));
       case TYPE_CODE_STRING:
-        throw new IllegalArgumentException("TYPE_CODE_STRING is not supported");
+        int strLen = buffer.getInt();
+        byte[] strBytes = new byte[strLen];
+        buffer.get(strBytes);
+        return from(new String(strBytes));
       case TYPE_CODE_DOUBLE:
         return from(buffer.getDouble());
       case TYPE_CODE_INT:

--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/EValue.java
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/EValue.java
@@ -10,6 +10,7 @@ package org.pytorch.executorch;
 
 import com.facebook.jni.annotations.DoNotStrip;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Locale;
 import org.pytorch.executorch.annotations.Experimental;
@@ -202,7 +203,7 @@ public class EValue {
     } else if (isDouble()) {
       return ByteBuffer.allocate(9).put((byte) TYPE_CODE_DOUBLE).putDouble(toDouble()).array();
     } else if (isString()) {
-      byte[] strBytes = toStr().getBytes();
+      byte[] strBytes = toStr().getBytes(StandardCharsets.UTF_8);
       return ByteBuffer.allocate(1 + 4 + strBytes.length)
           .put((byte) TYPE_CODE_STRING)
           .putInt(strBytes.length)
@@ -239,7 +240,7 @@ public class EValue {
         int strLen = buffer.getInt();
         byte[] strBytes = new byte[strLen];
         buffer.get(strBytes);
-        return from(new String(strBytes));
+        return from(new String(strBytes, StandardCharsets.UTF_8));
       case TYPE_CODE_DOUBLE:
         return from(buffer.getDouble());
       case TYPE_CODE_INT:

--- a/extension/android/executorch_android/src/test/java/org/pytorch/executorch/EValueTest.kt
+++ b/extension/android/executorch_android/src/test/java/org/pytorch/executorch/EValueTest.kt
@@ -188,13 +188,23 @@ class EValueTest {
   }
 
   @Test
-  fun testUnicodeStringSerde() {
-    val evalue = EValue.from("こんにちは")
+  fun testChineseStringSerde() {
+    val evalue = EValue.from("你好世界")
     val bytes = evalue.toByteArray()
 
     val deser = EValue.fromByteArray(bytes)
     assertTrue(deser.isString)
-    assertEquals("こんにちは", deser.toStr())
+    assertEquals("你好世界", deser.toStr())
+  }
+
+  @Test
+  fun testEmojiStringSerde() {
+    val evalue = EValue.from("👋🌍")
+    val bytes = evalue.toByteArray()
+
+    val deser = EValue.fromByteArray(bytes)
+    assertTrue(deser.isString)
+    assertEquals("👋🌍", deser.toStr())
   }
 
   @Test

--- a/extension/android/executorch_android/src/test/java/org/pytorch/executorch/EValueTest.kt
+++ b/extension/android/executorch_android/src/test/java/org/pytorch/executorch/EValueTest.kt
@@ -168,6 +168,36 @@ class EValueTest {
   }
 
   @Test
+  fun testStringSerde() {
+    val evalue = EValue.from("hello")
+    val bytes = evalue.toByteArray()
+
+    val deser = EValue.fromByteArray(bytes)
+    assertTrue(deser.isString)
+    assertEquals("hello", deser.toStr())
+  }
+
+  @Test
+  fun testEmptyStringSerde() {
+    val evalue = EValue.from("")
+    val bytes = evalue.toByteArray()
+
+    val deser = EValue.fromByteArray(bytes)
+    assertTrue(deser.isString)
+    assertEquals("", deser.toStr())
+  }
+
+  @Test
+  fun testUnicodeStringSerde() {
+    val evalue = EValue.from("こんにちは")
+    val bytes = evalue.toByteArray()
+
+    val deser = EValue.fromByteArray(bytes)
+    assertTrue(deser.isString)
+    assertEquals("こんにちは", deser.toStr())
+  }
+
+  @Test
   fun testLongTensorSerde() {
     val data = longArrayOf(1, 2, 3, 4)
     val shape = longArrayOf(2, 2)


### PR DESCRIPTION
### Summary
toByteArray() used toString() (returning "EValue@...") instead of
toStr(), and allocated the buffer using char count instead of byte
count. fromByteArray() threw an exception for strings instead of
deserializing them. Fix both directions using a length-prefixed
format, and also fix the misleading "Unknown Tensor dtype" error
message. Add round-trip tests for ASCII, empty, and Unicode strings.

### Test plan
CI