### PR TITLE
Reduce visible symbols in AAR so via version script

### DIFF
--- a/extension/android/CMakeLists.txt
+++ b/extension/android/CMakeLists.txt
@@ -240,5 +240,6 @@ target_link_options(
   executorch_jni PRIVATE
   "LINKER:--version-script,${CMAKE_CURRENT_SOURCE_DIR}/jni/version_script.txt"
 )
+target_link_options_gc_sections(executorch_jni)
 
 target_link_libraries(executorch_jni ${link_libraries} log)

--- a/extension/android/CMakeLists.txt
+++ b/extension/android/CMakeLists.txt
@@ -236,4 +236,9 @@ target_include_directories(
 
 target_compile_options(executorch_jni PUBLIC ${_common_compile_options})
 
+target_link_options(
+  executorch_jni PRIVATE
+  "LINKER:--version-script,${CMAKE_CURRENT_SOURCE_DIR}/jni/version_script.txt"
+)
+
 target_link_libraries(executorch_jni ${link_libraries} log)

--- a/extension/android/jni/version_script.txt
+++ b/extension/android/jni/version_script.txt
@@ -1,0 +1,7 @@
+{
+  global:
+    JNI_OnLoad;
+    Java_*;
+  local:
+    *;
+};


### PR DESCRIPTION
### Summary
Limit exposed symbols to JNI_OnLoad and Java_, which is needed by java layer.

This reduces the AAR size from 12MB to 6.6MB.

### Test plan
CI

cc @cbilgin