### PR TITLE
Add missing AttentionSinkRopeRunner source to Android CMake build

### DIFF
--- a/extension/android/CMakeLists.txt
+++ b/extension/android/CMakeLists.txt
@@ -188,6 +188,7 @@ if(EXECUTORCH_BUILD_LLAMA_JNI)
         ${EXECUTORCH_ROOT}/examples/qualcomm/oss_scripts/llama/runner/lhd_token_generator.cpp
         ${EXECUTORCH_ROOT}/examples/qualcomm/oss_scripts/llama/runner/rpc_mem.cpp
         ${EXECUTORCH_ROOT}/examples/qualcomm/oss_scripts/llama/runner/kv_manager.cpp
+        ${EXECUTORCH_ROOT}/examples/qualcomm/oss_scripts/llama/runner/attention_sink_rope_runner.cpp
     )
 
     target_include_directories(


### PR DESCRIPTION
### Summary
attention_sink_rope_runner.cpp was added in #17302 but not included in the Android CMakeLists.txt QNN runner source list, causing linker errors when building the Android AAR with QNN support.

Authored with Claude

### Test plan
This is a build issue, so the build should already be failing?


cc @kirklandsign @cbilgin @cccclai