### PR TITLE
Fix QNN runner KV cache bitwidth in Android JNI

### DIFF
--- a/extension/android/jni/jni_layer_llama.cpp
+++ b/extension/android/jni/jni_layer_llama.cpp
@@ -216,7 +216,7 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
           data_files_vector,
           executorch::extension::Module::LoadMode::MmapUseMlockIgnoreErrors);
       std::string decoder_model = "llama3"; // use llama3 for now
-      runner_ = std::make_unique<example::Runner<uint16_t>>( // QNN runner
+      runner_ = std::make_unique<example::Runner<uint8_t>>( // QNN runner (8-bit KV cache)
           std::move(module),
           decoder_model.c_str(),
           model_path->toStdString().c_str(),


### PR DESCRIPTION
### Summary
The QNN runner was hardcoded to use Runner<uint16_t>, but all current Llama quantization recipes use annotate_kv_8bit for 8-bit KV cache. This mismatch caused the KV cache data to be misinterpreted, resulting in degenerate output (repetitive real words like "Nigeria Nigeria...") while the model otherwise ran correctly on the HTP NPU.

Authored with Claude

### Test plan
I built the AAR and used the AAR in the LlamaDemo in executorch-examples.  This does require QAIRT 2.43.0 to test, which is later than the last QAIRT used to build the last Executorch release.  This was tested on a OnePlus 15 running a Snapdragon 8 Elite Gen 5 (SM8850).


cc @kirklandsign @cbilgin @cccclai