### PR TITLE
NXP backend: Migrate from neutron_converter_SDK_25_12 package to eIQ Neutron SDK

### DIFF
--- a/backends/nxp/backend/edge_program_converter.py
+++ b/backends/nxp/backend/edge_program_converter.py
@@ -63,7 +63,7 @@ class EdgeProgramToIRConverter:
     """
 
     _default_conversion_config = ConversionConfig()
-    _default_target_spec = NeutronTargetSpec("imxrt700", "SDK_25_12")
+    _default_target_spec = NeutronTargetSpec("imxrt700")
     _default_delegation_options = CustomDelegationOptions()
 
     def convert_program(

--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/slice_tensor_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/slice_tensor_converter.py
@@ -31,11 +31,6 @@ class SliceTensorConverter(NodeConverter):
         parameters_mapping: dict[str, Parameter],
         custom_delegation_options: CustomDelegationOptions,
     ) -> bool:
-        # Provisional solution - slice conversion works for neutron software 2.2.1+
-        neutron_flavor = neutron_target_spec.neutron_target.__module__.split(".")[0]
-        if neutron_flavor != "neutron_converter_SDK_25_12":
-            return False
-
         input_shape = input_tensor(node, 0).shape
         dim = node.args[1]
         if node.args[0].meta[NXP_NODE_FORMAT].is_channels_first():

--- a/backends/nxp/backend/neutron_target_spec.py
+++ b/backends/nxp/backend/neutron_target_spec.py
@@ -98,9 +98,9 @@ class NeutronTargetSpec:
     The functionality for probing the properties of Neutron Target.
     """
 
-    def __init__(self, target: str, neutron_converter_flavor: str):
+    def __init__(self, target: str):
 
-        converter_manager = NeutronConverterManager(neutron_converter_flavor)
+        converter_manager = NeutronConverterManager()
         converter_manager.verify_target(target)
         neutron_converter = converter_manager.get_converter()
         self.neutron_target = neutron_converter.getNeutronTarget(target)

--- a/backends/nxp/neutron_partitioner.py
+++ b/backends/nxp/neutron_partitioner.py
@@ -433,7 +433,7 @@ class NeutronPartitioner(Partitioner):
 
         graph_module.recompile()
 
-        operators_not_to_delegate = self.delegation_spec[1][4].value.decode().split(",")
+        operators_not_to_delegate = self.delegation_spec[1][3].value.decode().split(",")
         logging.info(f"Operators not to delegate: {operators_not_to_delegate}")
 
         parameters_mapping = EdgeProgramToIRConverter.map_inputs_to_parameters(

--- a/backends/nxp/requirements-eiq.txt
+++ b/backends/nxp/requirements-eiq.txt
@@ -1,4 +1,3 @@
 --index-url https://eiq.nxp.com/repository
-neutron_converter_SDK_25_12
 eiq_neutron_sdk==2.2.2
 eiq_nsys

--- a/backends/nxp/tests/executorch_pipeline.py
+++ b/backends/nxp/tests/executorch_pipeline.py
@@ -38,10 +38,7 @@ from torch import nn
 from torch.export import export
 from torchao.quantization.pt2e.quantizer import Quantizer
 
-neutron_converter_flavor = "SDK_25_12"
-neutron_target_spec = NeutronTargetSpec(
-    target="imxrt700", neutron_converter_flavor=neutron_converter_flavor
-)
+neutron_target_spec = NeutronTargetSpec(target="imxrt700")
 
 
 @dataclass
@@ -92,7 +89,6 @@ def to_quantized_edge_program(
         [tuple[ModelInputSpec, ...]], list[tuple[torch.Tensor, ...]]
     ] = get_random_calibration_inputs,
     target="imxrt700",
-    neutron_converter_flavor=neutron_converter_flavor,
     use_qat=False,
     remove_quant_io_ops=False,
     custom_delegation_options=CustomDelegationOptions(),  # noqa B008
@@ -101,7 +97,7 @@ def to_quantized_edge_program(
     use_quant_state_dict=True,
     fetch_constants_to_sram=False,
 ) -> EdgeProgramManager:
-    _neutron_target_spec = NeutronTargetSpec(target, neutron_converter_flavor)
+    _neutron_target_spec = NeutronTargetSpec(target)
     if get_quantizer_fn is None:
         get_quantizer_fn = partial(
             _get_default_quantizer, _neutron_target_spec, use_qat
@@ -127,7 +123,6 @@ def to_quantized_edge_program(
     compile_spec = generate_neutron_compile_spec(
         target,
         operators_not_to_delegate=operators_not_to_delegate,
-        neutron_converter_flavor=neutron_converter_flavor,
         use_neutron_for_format_conversion=use_neutron_for_format_conversion,
         fetch_constants_to_sram=fetch_constants_to_sram,
     )

--- a/backends/nxp/tests/ir/converter/node_converter/test_cat_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_cat_converter.py
@@ -363,7 +363,6 @@ def test_cat__same_shapes_converter_padding_last_dimension(use_qat):
         CatModule(2),
         [input_shape, input_shape],
         target=target,
-        neutron_converter_flavor="SDK_25_12",
         custom_delegation_options=CustomDelegationOptions(),
         use_qat=use_qat,
     ).exported_program()
@@ -385,7 +384,6 @@ def test_cat__same_shapes__channels_first__padding_channels(use_qat):
         CatConvModule(1),
         [input_shape, input_shape],
         target=target,
-        neutron_converter_flavor="SDK_25_12",
         custom_delegation_options=CustomDelegationOptions(),
         use_qat=use_qat,
     ).exported_program()

--- a/backends/nxp/tests/ir/converter/node_converter/test_slice_tensor_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_slice_tensor_converter.py
@@ -8,10 +8,7 @@ import torch
 from executorch.backends.nxp.backend.edge_program_converter import (
     EdgeProgramToIRConverter,
 )
-from executorch.backends.nxp.tests.executorch_pipeline import (
-    neutron_converter_flavor,
-    to_quantized_edge_program,
-)
+from executorch.backends.nxp.tests.executorch_pipeline import to_quantized_edge_program
 from executorch.backends.nxp.tests.executors import (
     convert_run_compare,
     ToChannelFirstPreprocess,
@@ -105,10 +102,6 @@ def test_slice_tensor_quant_conversion(mocker, x_input_shape, dims, starts, ends
         starts=starts,
         ends=ends,
     )
-
-    if neutron_converter_flavor == "SDK_25_09":
-        pytest.skip("Neutron Software must be version 2.2.1 or higher.")
-
     converter_spy = mocker.spy(EdgeProgramToIRConverter, "convert_program")
 
     # Run conversion
@@ -152,9 +145,6 @@ def test_slice_tensor_quant_conversion(mocker, x_input_shape, dims, starts, ends
 def test_slice_tensor_w_conv_quant_conversion(
     mocker, x_input_shape, dims, starts, ends
 ):
-    if neutron_converter_flavor == "SDK_25_09":
-        pytest.skip("Neutron Software must be version 2.2.1 or higher.")
-
     model = SliceTensorConvModule(dims=dims, starts=starts, ends=ends)
 
     converter_spy = mocker.spy(EdgeProgramToIRConverter, "convert_program")

--- a/backends/nxp/tests/test_aot_example.py
+++ b/backends/nxp/tests/test_aot_example.py
@@ -30,8 +30,6 @@ def test_aot_example__mobilenet_v2():
         "--quantize",
         "--target",
         "imxrt700",
-        "--neutron_converter_flavor",
-        "SDK_25_12",
         "--use_random_dataset",  # Avoid downloading the dataset.
     ]
 

--- a/backends/nxp/tests/test_decompose_split_to_slices.py
+++ b/backends/nxp/tests/test_decompose_split_to_slices.py
@@ -16,7 +16,6 @@ from executorch.backends.nxp.backend.edge_program_converter import (
     EdgeProgramToIRConverter,
 )
 from executorch.backends.nxp.tests.executorch_pipeline import (
-    neutron_converter_flavor,
     neutron_target_spec,
     to_quantized_edge_program,
 )
@@ -271,10 +270,6 @@ def test_decompose_split_with_one_chunk(mocker, input_shape, size_or_sections, d
 def test_decompose_gru_with_split_full_pipeline(
     mocker, input_shape, size_or_sections, dim
 ):
-    # The delegation of slices will not work in older versions, thus making the tests fail.
-    if neutron_converter_flavor == "SDK_25_09":
-        pytest.skip("Neutron Software must be version 2.2.1 or higher.")
-
     converter_spy = mocker.spy(EdgeProgramToIRConverter, "convert_program")
 
     if isinstance(size_or_sections, list):

--- a/backends/nxp/tests/test_edge_passes.py
+++ b/backends/nxp/tests/test_edge_passes.py
@@ -319,7 +319,7 @@ class TestEdgePasses(unittest.TestCase):
 
         edge_program_manager = edge_program_manager.transform(NeutronEdgePassManager())
 
-        compile_spec = generate_neutron_compile_spec(target, "SDK_25_12")
+        compile_spec = generate_neutron_compile_spec(target)
         partitioner = NeutronPartitioner(
             compile_spec, neutron_target_spec, custom_delegation_options
         )

--- a/backends/nxp/tests/test_neutron_backend_executor.py
+++ b/backends/nxp/tests/test_neutron_backend_executor.py
@@ -165,7 +165,7 @@ def test_delegating_format_related_transpose_operators__supported_case(mocker):
     # Make sure the output channels (channels for the trailing Transpose), and the last input dimension (channels for
     #  the leading Transpose) are multiples of `num_macs``.
 
-    num_macs = NeutronTargetSpec("imxrt700", "SDK_25_12").get_num_macs()
+    num_macs = NeutronTargetSpec("imxrt700").get_num_macs()
     model = Conv2dModule(
         in_channels=num_macs, out_channels=num_macs, padding=1, stride=1
     )
@@ -222,7 +222,7 @@ def test_delegating_format_related_transpose_operators__supported_case(mocker):
 def test_delegating_format_related_transpose_operators__supported_output__unsupported_input(
     mocker,
 ):
-    num_macs = NeutronTargetSpec("imxrt700", "SDK_25_12").get_num_macs()
+    num_macs = NeutronTargetSpec("imxrt700").get_num_macs()
     model = Conv2dModule(
         in_channels=num_macs,
         out_channels=num_macs,  # The output `Transpose` will be supported.
@@ -278,7 +278,7 @@ def test_delegating_format_related_transpose_operators__supported_output__unsupp
 def test_delegating_format_related_transpose_operators__supported_input__unsupported_output(
     mocker,
 ):
-    num_macs = NeutronTargetSpec("imxrt700", "SDK_25_12").get_num_macs()
+    num_macs = NeutronTargetSpec("imxrt700").get_num_macs()
     model = Conv2dModule(
         in_channels=num_macs,
         out_channels=3,  # The output `Transpose` will NOT be supported.

--- a/backends/nxp/tests/test_neutron_converter_manager.py
+++ b/backends/nxp/tests/test_neutron_converter_manager.py
@@ -3,7 +3,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import pytest
 import torch
 
 from executorch import exir
@@ -18,7 +17,7 @@ from executorch.backends.nxp.tests.executorch_pipeline import to_quantized_edge_
 from executorch.backends.nxp.tests.models import Conv2dModule, LinearModule
 
 
-def test_conv2d_neutron_conversion__default_flavor():
+def test_conv2d_neutron_conversion():
     model = Conv2dModule()
 
     example_input = (torch.ones(1, 4, 32, 32),)
@@ -37,29 +36,6 @@ def test_conv2d_neutron_conversion__default_flavor():
     assert len(
         neutron_model
     ), "Produced NeutronGraph-based TFLite model has zero length!"
-
-
-def test__conv2d_neutron_conversion__invalid_flavor():
-    model = Conv2dModule()
-
-    example_input = (torch.ones(1, 4, 32, 32),)
-    exir_program = torch.export.export(model, example_input)
-    edge_program_manager = exir.to_edge(exir_program)
-
-    NodeFormatInference(edge_program_manager.exported_program()).identify_node_formats()
-    edge_program_converter = EdgeProgramToIRConverter()
-    tflite_model, _ = edge_program_converter.convert_program(
-        edge_program_manager.exported_program()
-    )
-
-    with pytest.raises(RuntimeError) as excinfo:
-        _ = NeutronConverterManager("bad_flavor").convert(
-            tflite_model, "imxrt700", False
-        )
-
-    assert "Neutron Converter module with flavor 'bad_flavor' not found." in str(
-        excinfo
-    )
 
 
 def test_conv2d_neutron_conversion__prefetching(mocker):

--- a/backends/nxp/tests/test_split_group_convolution.py
+++ b/backends/nxp/tests/test_split_group_convolution.py
@@ -56,7 +56,7 @@ def _quantize_and_lower_module(
         edge_compile_config=edge_compile_config,
     )
 
-    compile_spec = generate_neutron_compile_spec(target, "SDK_25_12")
+    compile_spec = generate_neutron_compile_spec(target)
     partitioner = NeutronPartitioner(compile_spec, neutron_target_spec)
     return edge_program_manager.to_backend(partitioner)
 

--- a/backends/nxp/tests_models/utils.py
+++ b/backends/nxp/tests_models/utils.py
@@ -75,9 +75,7 @@ def to_quantized_edge_program(
     exir_program_aten = torch.export.export(model, example_input, strict=True)
     module = exir_program_aten.module()
 
-    neutron_target_spec = NeutronTargetSpec(
-        target="imxrt700", neutron_converter_flavor="SDK_25_12"
-    )
+    neutron_target_spec = NeutronTargetSpec(target="imxrt700")
 
     # Quantize model
     quantizer = NeutronQuantizer(
@@ -134,7 +132,7 @@ def to_quantized_edge_program(
         (
             [
                 NeutronPartitioner(
-                    generate_neutron_compile_spec("imxrt700", "SDK_25_12"),
+                    generate_neutron_compile_spec("imxrt700"),
                     neutron_target_spec=neutron_target_spec,
                     post_quantization_state_dict=exir_program_aten_quant.state_dict(),
                 )

--- a/docs/source/backends/nxp/nxp-dim-order.md
+++ b/docs/source/backends/nxp/nxp-dim-order.md
@@ -61,7 +61,7 @@ compatible with the `i.MX RT700` board using **MCUXpresso SDK 25.06**:
 
 ```bash
 python -m examples.nxp.aot_neutron_compile --quantize \
-    --delegate --neutron_converter_flavor SDK_25_12 -m cifar10 \
+    --delegate -m cifar10 \
     --use_channels_last_dim_order
 ```
 

--- a/docs/source/backends/nxp/nxp-overview.md
+++ b/docs/source/backends/nxp/nxp-overview.md
@@ -27,7 +27,7 @@ Among currently supported machine learning models are:
 - eIQ Neutron Converter for MCUXPresso SDK 25.12, what you can download from eIQ PyPI:
 
 ```commandline
-$ pip install --index-url https://eiq.nxp.com/repository neutron_converter_SDK_25_12
+$ pip install --index-url https://eiq.nxp.com/repository eiq_neutron_sdk
 ```
 
 Instead of manually installing requirements, except MCUXpresso IDE and SDK, you can use the setup script: 

--- a/docs/source/backends/nxp/nxp-partitioner.rst
+++ b/docs/source/backends/nxp/nxp-partitioner.rst
@@ -16,7 +16,6 @@ To generate the Compile Spec for Neutron backend, you can use the `generate_neut
 Following fields can be set:
 
 * `config` - NXP platform defining the Neutron NPU configuration, e.g. "imxrt700".
-* `neutron_converter_flavor` - Flavor of the neutron-converter module to use. Neutron-converter module named neutron_converter_SDK_25_12' has flavor 'SDK_25_12'. You shall set the flavour to the MCUXpresso SDK version you will use.
 * `extra_flags` - Extra flags for the Neutron compiler.
 * `operators_not_to_delegate` - List of operators that will not be delegated.
 

--- a/docs/source/backends/nxp/nxp-quantization.md
+++ b/docs/source/backends/nxp/nxp-quantization.md
@@ -64,7 +64,7 @@ from torchao.quantization.pt2e.quantize_pt2e import convert_pt2e, prepare_pt2e
 model = models.mobilenetv2.mobilenet_v2(weights=MobileNet_V2_Weights.DEFAULT).eval()
 sample_inputs = (torch.randn(1, 3, 224, 224), )
 
-target_spec = NeutronTargetSpec(target="imxrt700", converter_flavor="SDK_25_12")
+neutron_target_spec = NeutronTargetSpec(target="imxrt700")
 quantizer = NeutronQuantizer(neutron_target_spec) # (1)
 
 training_ep = torch.export.export(model, sample_inputs).module() # (2)
@@ -78,7 +78,6 @@ quantized_model = convert_pt2e(prepared_model) # (5)
 compile_spec = generate_neutron_compile_spec(
     "imxrt700",
     operators_not_to_delegate=None,
-    neutron_converter_flavor="SDK_25_12",
 )
 
 et_program = to_edge_transform_and_lower( # (6)
@@ -95,7 +94,7 @@ from executorch.backends.nxp.quantizer.utils import calibrate_and_quantize
 
 ...
 
-target_spec = NeutronTargetSpec(target="imxrt700", converter_flavor="SDK_25_12")
+target_spec = NeutronTargetSpec(target="imxrt700")
 quantized_graph_module = calibrate_and_quantize(
     aten_model,
     calibration_inputs,

--- a/docs/source/backends/nxp/tutorials/nxp-basic-tutorial.md
+++ b/docs/source/backends/nxp/tutorials/nxp-basic-tutorial.md
@@ -59,7 +59,7 @@ See the example `aot_neutron_compile.py` and its [README](https://github.com/pyt
 For the purpose of this tutorial we will use a simple image classification model CifarNet10.
 ```bash
 python -m examples.nxp.aot_neutron_compile --quantize \
-    --delegate --neutron_converter_flavor SDK_25_12 -m "cifar10"
+    --delegate -m "cifar10"
 ```
 
 Also, we will dump few of the images from the Cifar 10 dataset to a folder: 

--- a/examples/nxp/README.md
+++ b/examples/nxp/README.md
@@ -36,7 +36,7 @@ The steps are expected to be executed from the `executorch` root folder.
 1. Run the `aot_neutron_compile.py` example with the `cifar10` model 
     ```commandline
     $ python -m examples.nxp.aot_neutron_compile --quantize \
-        --delegate --neutron_converter_flavor SDK_25_12 -m cifar10 
+        --delegate -m cifar10 
     ```
 
 2. It will generate you `cifar10_nxp_delegate.pte` file which can be used with the MCUXpresso SDK `cifarnet_example` 

--- a/examples/nxp/aot_neutron_compile.py
+++ b/examples/nxp/aot_neutron_compile.py
@@ -151,14 +151,6 @@ if __name__ == "__main__":  # noqa C901
         help="Platform for running the delegated model",
     )
     parser.add_argument(
-        "-c",
-        "--neutron_converter_flavor",
-        required=False,
-        default="SDK_25_12",
-        help="Flavor of installed neutron-converter module. Neutron-converter module named "
-        "'neutron_converter_SDK_25_12' has flavor 'SDK_25_12'.",
-    )
-    parser.add_argument(
         "-q",
         "--quantize",
         action="store_true",
@@ -242,9 +234,7 @@ if __name__ == "__main__":  # noqa C901
     if args.debug:
         logging.basicConfig(level=logging.DEBUG, format=FORMAT, force=True)
 
-    neutron_target_spec = NeutronTargetSpec(
-        target=args.target, neutron_converter_flavor=args.neutron_converter_flavor
-    )
+    neutron_target_spec = NeutronTargetSpec(target=args.target)
 
     # 1. pick model from one of the supported lists
     model, example_inputs, calibration_inputs = get_model_and_inputs_from_name(
@@ -319,7 +309,6 @@ if __name__ == "__main__":  # noqa C901
     compile_spec = generate_neutron_compile_spec(
         args.target,
         operators_not_to_delegate=args.operators_not_to_delegate,
-        neutron_converter_flavor=args.neutron_converter_flavor,
         fetch_constants_to_sram=args.fetch_constants_to_sram,
     )
     partitioners = (

--- a/examples/nxp/run.sh
+++ b/examples/nxp/run.sh
@@ -24,8 +24,7 @@ popd
 
 echo "** Export cifar10 model to executorch"
 # Run the AoT example
-python -m examples.nxp.aot_neutron_compile --quantize \
-    --delegate --neutron_converter_flavor SDK_25_12 -m "cifar10"
+python -m examples.nxp.aot_neutron_compile --quantize --delegate -m "cifar10"
 test -f cifar10_nxp_delegate.pte
 
 echo "** Generate test dataset"

--- a/examples/nxp/run_aot_example.sh
+++ b/examples/nxp/run_aot_example.sh
@@ -13,6 +13,6 @@ cd $EXECUTORCH_DIR
 
 # Run the AoT example
 python -m examples.nxp.aot_neutron_compile --quantize \
-    --delegate --neutron_converter_flavor SDK_25_12 -m ${MODEL}
+    --delegate -m ${MODEL}
 # verify file exists
 test -f ${MODEL}_nxp_delegate.pte

--- a/examples/nxp/setup.sh
+++ b/examples/nxp/setup.sh
@@ -7,9 +7,7 @@
 set -u
 EIQ_PYPI_URL="${EIQ_PYPI_URL:-https://eiq.nxp.com/repository}"
 
-# Install neutron-converter
-pip install --index-url ${EIQ_PYPI_URL} neutron_converter_SDK_25_12
-
+# Install eIQ Neutron dependencies - SDK and simulator
 pip install --index-url ${EIQ_PYPI_URL} eiq_neutron_sdk==2.2.2 eiq_nsys
 
 # Get the directory of the current script


### PR DESCRIPTION
Migration from legacy "neutron_converter_SDK_YY_MM" python packages to the recently introduced eIQ Neutron SDK python package. The eIQ Neutron SDK compared to "neutron_converter_SDK_YY_MM" is an complete eIQ Neutron software distribution containing both converter and runtime parts for all NXP supported Neutron platforms. 

This change removes Neutron converter "flavor" functionality and switches to eiq_neutron_sdk.

### Test plan
Already existing unit-test tests this change. 

cc @JakeStevens @digantdesai