### PR TITLE
Remove asserts in CoreML resize

### DIFF
--- a/backends/apple/coreml/runtime/delegate/multiarray.h
+++ b/backends/apple/coreml/runtime/delegate/multiarray.h
@@ -85,7 +85,7 @@ public:
         bool is_packed() const noexcept;
 
         // Resizes memory layout
-        // New shape must be the same dimension and no larger than current shape in all dimensions
+        // New shape must be the same rank as the current shape
         // New format is contiguous
         void resize(const std::vector<size_t>& shape);
 


### PR DESCRIPTION
Summary:
The `assert(shape[i] <= shape_[i])` constraint in `MultiArray::MemoryLayout::resize()` was unnecessary and overly restrictive.

`MemoryLayout` is purely metadata describing shape and strides - it has no knowledge of the underlying memory allocation. The actual memory safety is guaranteed at a higher level: ExecuTorch tensors are pre-allocated with sufficient capacity to handle dynamic output shapes from CoreML model execution.

The resize function is called in `ETCoreMLModelManager.mm` to update output tensor metadata after model inference, where the new shape comes directly from CoreML's `modelOutputs[i].shape`. Since the ExecuTorch output buffers are sized appropriately for the model's maximum output dimensions, the resize operation is always safe regardless of whether the new shape is smaller or larger than the previous metadata indicated.

The remaining asserts are retained because they catch actual programming errors:
- `assert(shape.size() == shape_.size())` - prevents rank mismatch causing out-of-bounds access
- `assert(shape[i] >= 1)` - ensures valid dimensions for correct stride computation

Reviewed By: GregoryComer

Differential Revision: D93942192


