### PR TITLE
Add support for shared CustomKVCache

### DIFF
--- a/exir/passes/memory_planning_pass.py
+++ b/exir/passes/memory_planning_pass.py
@@ -247,9 +247,8 @@ class MemoryPlanningPass(PassBase):
             graph_signature,
             self.alloc_graph_input,
             self.alloc_graph_output,
-            # If we are sharing the mutable buffers then do not allocate them in
-            # memory planning algo, instead collect all of the specs over all the entry
-            # points and then allocate them directly in the run_multimethod name call
+            # If mutable buffers are shared, then do not allocate them in the
+            # main memory planning algo; they are allocated in run_multimethod.
             self.alloc_mutable_buffers and not self.share_mutable_buffers,
         )
 
@@ -264,7 +263,10 @@ class MemoryPlanningPass(PassBase):
             graph_module,
             self.alloc_graph_input,
             self.alloc_graph_output,
-            self.alloc_mutable_buffers,
+            # If mutable buffers are shared, they are allocated after the
+            # main memory planning algo in run_multimethod, and should be
+            # skipped in the Verifier.
+            self.alloc_mutable_buffers and not self.share_mutable_buffers,
             graph_signature,
         )
 

--- a/exir/tests/TARGETS
+++ b/exir/tests/TARGETS
@@ -183,6 +183,7 @@ python_unittest(
     ],
     preload_deps = [
         "//executorch/kernels/portable:custom_ops_generated_lib",
+        "//executorch/extension/llm/custom_ops:custom_ops_aot_lib",
     ],
     # Static listing does not support tests generated with parameterized
     supports_static_listing = False,
@@ -195,6 +196,8 @@ python_unittest(
         "//executorch/exir:pass_manager",
         "//executorch/exir/passes:lib",
         "//executorch/exir/passes:sym_shape_eval_pass",
+        "//executorch/examples/models/llama:custom_kv_cache",
+        "//executorch/extension/llm/custom_ops:custom_ops_aot_py",
     ],
 )
 


### PR DESCRIPTION
### Summary

CustomKVCache is a mutable custom op. This means:
- export does not add any copies at functionalization, because it's a custom op and is a black box to export.
- this means it passes `inplace_lineage`, which determines if an output only has inplace ops.
- at `SpecPropPass`, the same TensorSpec (same python object) is given to the placeholder for the kvcache and the output spec, as it is completely inplace. 
- At memory planning, the placeholder is skipped (because it is mutable), and the output spec is assigned a mem_id. Because they share the same tensor spec, the placeholder is also assigned a mem_id.
- When we attempt to share mutable buffers, the placeholder already has a mem_id assigned.

This PR checks all TensorSpecs for mutability and makes sure mutable specs are not yielded to memory planning. A change to the verifier is also required, as the output node would have some specs with mem_id assigned, and some without (the mutable ones) which trigger verification failure.

### Test plan
Added unittest, confirm failing before PR and passing afterwards.

```
python -m pytest exir/tests/test_memory_planning.py -k test_custom_kv_cache_shared_buffers -xvs
```
