### PR TITLE
Fix libaoti_cuda_shims.so not found when importing _portable_lib on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -947,6 +947,10 @@ if(EXECUTORCH_BUILD_PYBIND)
     list(APPEND _dep_libs openvino_backend)
   endif()
 
+  if(EXECUTORCH_BUILD_CUDA)
+    string(APPEND _portable_lib_rpath ":$ORIGIN/../../backends/cuda")
+  endif()
+
   if(EXECUTORCH_BUILD_QNN)
     list(APPEND _dep_libs qnn_executorch_backend)
     string(APPEND _portable_lib_rpath ":$ORIGIN/../../backends/qualcomm")

--- a/setup.py
+++ b/setup.py
@@ -870,6 +870,13 @@ setup(
             dependent_cmake_flags=[],
         ),
         BuiltFile(
+            src_dir="%CMAKE_CACHE_DIR%/backends/cuda/%BUILD_TYPE%/",
+            src_name="aoti_cuda_shims",
+            dst="executorch/backends/cuda/",
+            is_dynamic_lib=True,
+            dependent_cmake_flags=["EXECUTORCH_BUILD_CUDA"],
+        ),
+        BuiltFile(
             src_dir="%CMAKE_CACHE_DIR%/backends/qualcomm/%BUILD_TYPE%/",
             src_name="qnn_executorch_backend",
             dst="executorch/backends/qualcomm/",


### PR DESCRIPTION
When ExecuTorch is built with CUDA support and installed as a pip package, importing `_portable_lib` fails with:
  ImportError: libaoti_cuda_shims.so: cannot open shared object file

This happens because:
1. `_portable_lib.so` links against `libaoti_cuda_shims.so` (via `aoti_cuda_backend`), but the RPATH only contains a stale build-time temp directory path that no longer exists after installation.
2. `setup.py` only installs the Windows `.lib` import library, not the Linux `.so` shared library.

Fix both issues:
- Add `$ORIGIN/../../backends/cuda` to the `_portable_lib` RPATH when CUDA is enabled, following the same pattern used for QNN.
- Add a `BuiltFile` entry in `setup.py` to install `libaoti_cuda_shims.so` into `executorch/backends/cuda/` in the pip package.
