### PR TITLE
Fix int overflow in Tensor.numel()

### DIFF
--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/Tensor.java
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/Tensor.java
@@ -483,7 +483,7 @@ public abstract class Tensor {
   /** Calculates the number of elements in a tensor with the specified shape. */
   public static long numel(long[] shape) {
     checkShape(shape);
-    int result = 1;
+    long result = 1;
     for (long s : shape) {
       result *= s;
     }


### PR DESCRIPTION

### Summary
The accumulator was declared as int, silently truncating the result for tensors with more than 2^31 elements. Changed to long to match the method's return type and PyTorch/ExecuTorch C++ (int64_t).

### Test plan
CI