### PR TITLE
Remove duplicate log.cpp compilation in Android CMakeLists

### DIFF
--- a/extension/android/CMakeLists.txt
+++ b/extension/android/CMakeLists.txt
@@ -162,7 +162,7 @@ if(EXECUTORCH_JNI_CUSTOM_LIBRARY)
 endif()
 
 if(EXECUTORCH_BUILD_EXTENSION_TRAINING)
-  target_sources(executorch_jni PRIVATE jni/jni_layer_training.cpp jni/log.cpp)
+  target_sources(executorch_jni PRIVATE jni/jni_layer_training.cpp)
   list(APPEND link_libraries extension_training)
   target_compile_definitions(
     executorch_jni PUBLIC EXECUTORCH_BUILD_EXTENSION_TRAINING=1
@@ -172,7 +172,6 @@ endif()
 if(EXECUTORCH_BUILD_LLAMA_JNI)
   target_sources(
     executorch_jni PRIVATE jni/jni_layer_llama.cpp jni/jni_layer_asr.cpp
-                           jni/log.cpp
   )
   list(APPEND link_libraries extension_llm_runner extension_asr_runner)
   target_compile_definitions(executorch_jni PUBLIC EXECUTORCH_BUILD_LLAMA_JNI=1)


### PR DESCRIPTION

### Summary
jni/log.cpp is already included in the base executorch_jni target (line 76). The training and llama conditional blocks were adding it again via target_sources, causing it to be compiled up to 3 times into the same shared library.

### Test plan
CI