### PR TITLE
Creates a `rope_rotate_stacked_halves` operator which allows rotating the `head_dim` on outer 2xN split instead of inner Nx2 split.

### DIFF
--- a/backends/cadence/aot/ref_implementations.py
+++ b/backends/cadence/aot/ref_implementations.py
@@ -1766,6 +1766,61 @@ def rope(
     return rotated.view(original_shape)
 
 
+@impl_tracked(m, "rope_rotate_stacked_halves")
+def rope_rotate_stacked_halves(
+    input_tensor: torch.Tensor,
+    sin_tensor: torch.Tensor,
+    cos_tensor: torch.Tensor,
+    pos: torch.Tensor | None,
+) -> torch.Tensor:
+    original_shape = input_tensor.shape
+
+    if len(original_shape) not in [4, 5]:
+        raise ValueError(
+            f"Input tensor must be 4D or 5D. Got {len(original_shape)}D tensor"
+        )
+    if original_shape[0] != 1:
+        raise ValueError("Input tensor must have batch size 1")
+    if len(original_shape) == 5:
+        input_tensor = input_tensor.view(
+            input_tensor.shape[0], input_tensor.shape[1], input_tensor.shape[2], -1
+        )
+
+    _, seq, _, hd = input_tensor.shape
+
+    if hd % 2:
+        raise ValueError("Hidden dimension must be divisible by 2")
+
+    if (
+        sin_tensor.size(-1) * 2 != hd
+        or cos_tensor.size(-1) * 2 != hd
+        or sin_tensor.size(0) < seq
+        or cos_tensor.size(0) < seq
+    ):
+        raise ValueError(
+            f"sin_tensor and cos_tensor must have shape <kvseq (> {seq}) x {hd // 2}>. Got {sin_tensor.shape} and {cos_tensor.shape}"
+        )
+
+    if pos is not None:
+        if pos.shape != (seq,):
+            raise ValueError(
+                f"pos must have shape {input_tensor.shape[1]}. Got {pos.shape}"
+            )
+        sin_tensor = sin_tensor[pos]
+        cos_tensor = cos_tensor[pos]
+
+    # seq x 1 x hd
+    sin_tensor = sin_tensor.unsqueeze(1)
+    cos_tensor = cos_tensor.unsqueeze(1)
+
+    # batch x seq x num_heads x hd -> batch x seq x num_heads x 2 x head_dim_by_two
+    x0, x1 = input_tensor[..., 0 : hd // 2], input_tensor[..., hd // 2 :]
+    o0 = x0 * cos_tensor - x1 * sin_tensor
+    o1 = x1 * cos_tensor + x0 * sin_tensor
+    rotated = torch.cat([o0.view(-1, 1), o1.view(-1, 1)], dim=-2)
+    return rotated.view(original_shape)
+
+
 @impl_tracked(m, "im2row")
 def im2row(
     input_tensor: torch.Tensor,

--- a/backends/cadence/generic/operators/op_rope.cpp
+++ b/backends/cadence/generic/operators/op_rope.cpp
@@ -70,3 +70,63 @@ Tensor& rope_out(
 } // namespace native
 } // namespace generic
 } // namespace impl
+
+namespace impl {
+namespace generic {
+namespace native {
+
+using ::executorch::aten::optional;
+using ::executorch::aten::Tensor;
+
+Tensor& rope_rotate_stacked_halves_out(
+    ET_UNUSED ::executorch::runtime::KernelRuntimeContext& ctx,
+    const Tensor& input,
+    const Tensor& sin_tensor,
+    const Tensor& cos_tensor,
+    const optional<Tensor>& pos,
+    Tensor& out) {
+  // Input shape is [1, seq, h, 2, hd / 2] or [1, seq, h, hd]
+  const ssize_t seq_length = input.size(1);
+  const ssize_t num_heads = input.size(2);
+  const ssize_t head_dimension = input.numel() / (seq_length * num_heads);
+  const ssize_t head_dimension_by_two = head_dimension / 2;
+  for (int32_t s = 0; s < seq_length; ++s) {
+    for (int32_t h = 0; h < num_heads; ++h) {
+      for (int32_t hd_half = 0; hd_half < head_dimension_by_two; ++hd_half) {
+        // Process 2 elements in head dimension at a time.
+        // In stacked halves layout: [x0, x1, ...] [y0, y1, ...]
+        const int32_t x0_pos =
+            s * num_heads * head_dimension + h * head_dimension + hd_half;
+        const int32_t x1_pos = s * num_heads * head_dimension +
+            h * head_dimension + head_dimension_by_two + hd_half;
+        const float x_0 = input.const_data_ptr<float>()[x0_pos];
+        const float x_1 = input.const_data_ptr<float>()[x1_pos];
+        int64_t token_id = s;
+        if (pos.has_value()) {
+          if (pos->scalar_type() == ::executorch::aten::ScalarType::Int) {
+            token_id = pos.has_value() ? pos->const_data_ptr<int32_t>()[s] : s;
+          } else {
+            token_id = pos.has_value() ? pos->const_data_ptr<int64_t>()[s] : s;
+          }
+        }
+
+        const float sin = sin_tensor.const_data_ptr<
+            float>()[token_id * head_dimension_by_two + hd_half];
+        const float cos = cos_tensor.const_data_ptr<
+            float>()[token_id * head_dimension_by_two + hd_half];
+
+        const float out_0 = x_0 * cos - x_1 * sin;
+        out.mutable_data_ptr<float>()[x0_pos] = out_0;
+
+        const float out_1 = x_0 * sin + x_1 * cos;
+        out.mutable_data_ptr<float>()[x1_pos] = out_1;
+      }
+    }
+  }
+
+  return out;
+}
+
+} // namespace native
+} // namespace generic
+} // namespace impl

--- a/backends/cadence/generic/operators/op_rope.h
+++ b/backends/cadence/generic/operators/op_rope.h
@@ -23,6 +23,14 @@ namespace native {
     const ::executorch::aten::optional<::executorch::aten::Tensor>& pos,
     ::executorch::aten::Tensor& out);
 
+::executorch::aten::Tensor& rope_rotate_stacked_halves_out(
+    ::executorch::runtime::KernelRuntimeContext& ctx,
+    const ::executorch::aten::Tensor& input,
+    const ::executorch::aten::Tensor& sin_tensor,
+    const ::executorch::aten::Tensor& cos_tensor,
+    const ::executorch::aten::optional<::executorch::aten::Tensor>& pos,
+    ::executorch::aten::Tensor& out);
+
 } // namespace native
 } // namespace generic
 } // namespace impl


### PR DESCRIPTION
Reviewed By: hsharma35

Differential Revision: D94112062


