### PR TITLE
Android code quality improvements

### DIFF
--- a/extension/android/build.gradle
+++ b/extension/android/build.gradle
@@ -1,11 +1,6 @@
 allprojects {
     buildscript {
         ext {
-            minSdkVersion = 21
-            targetSdkVersion = 34
-            compileSdkVersion = 34
-            buildToolsVersion = '33.0.1'
-
             fbjniJavaOnlyVersion = "0.7.0"
             soLoaderNativeLoaderVersion = "0.10.5"
         }

--- a/extension/android/executorch_android/build.gradle
+++ b/extension/android/executorch_android/build.gradle
@@ -27,7 +27,7 @@ def flavor = System.properties['flavor']
 
 android {
     namespace = "org.pytorch.executorch"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         minSdk = 23
@@ -36,8 +36,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
 
     sourceSets {
@@ -49,7 +49,7 @@ android {
         }
     }
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
     }
 }
 
@@ -61,12 +61,12 @@ dependencies {
     implementation 'com.facebook.fbjni:fbjni:0.7.0'
     implementation 'com.facebook.soloader:nativeloader:0.10.5'
     implementation libs.core.ktx
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.assertj:assertj-core:3.27.2'
     testImplementation 'org.jetbrains.kotlin:kotlin-test:1.9.23'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
-    androidTestImplementation 'androidx.test:rules:1.2.0'
-    androidTestImplementation 'commons-io:commons-io:2.4'
+    androidTestImplementation 'androidx.test.ext:junit:1.2.1'
+    androidTestImplementation 'androidx.test:rules:1.6.1'
+    androidTestImplementation 'commons-io:commons-io:2.18.0'
     androidTestImplementation 'org.json:json:20250107'
     androidTestImplementation 'org.jetbrains.kotlin:kotlin-test:1.9.23'
     if (qnnVersion) {

--- a/extension/android/executorch_android/build.gradle
+++ b/extension/android/executorch_android/build.gradle
@@ -27,7 +27,7 @@ def flavor = System.properties['flavor']
 
 android {
     namespace = "org.pytorch.executorch"
-    compileSdk = 35
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 23

--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/Module.java
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/Module.java
@@ -54,7 +54,7 @@ public class Module {
 
   @DoNotStrip
   private static native HybridData initHybrid(
-      String moduleAbsolutePath, int loadMode, int initHybrid);
+      String moduleAbsolutePath, int loadMode, int numThreads);
 
   private Module(String moduleAbsolutePath, int loadMode, int numThreads) {
     ExecuTorchRuntime runtime = ExecuTorchRuntime.getRuntime();
@@ -201,7 +201,7 @@ public class Module {
    */
   public MethodMetadata getMethodMetadata(String name) {
     if (!mMethodMetadata.containsKey(name)) {
-      throw new RuntimeException("method " + name + "does not exist for this module");
+      throw new RuntimeException("method " + name + " does not exist for this module");
     }
 
     MethodMetadata methodMetadata = mMethodMetadata.get(name);

--- a/extension/android/jni/jni_layer.cpp
+++ b/extension/android/jni/jni_layer.cpp
@@ -58,14 +58,15 @@ class TensorHybrid : public facebook::jni::HybridClass<TensorHybrid> {
     // Java wrapper currently only supports contiguous tensors.
 
     const auto scalarType = tensor.scalar_type();
-    int jdtype = scalar_type_to_java_dtype.at(scalarType);
     if (scalar_type_to_java_dtype.count(scalarType) == 0) {
       std::stringstream ss;
-      ss << "executorch::aten::Tensor scalar [java] type: " << jdtype
+      ss << "executorch::aten::Tensor scalar type "
+         << static_cast<int>(scalarType)
          << " is not supported on java side";
       jni_helper::throwExecutorchException(
           static_cast<uint32_t>(Error::InvalidArgument), ss.str().c_str());
     }
+    int jdtype = scalar_type_to_java_dtype.at(scalarType);
 
     const auto& tensor_shape = tensor.sizes();
     std::vector<jlong> tensor_shape_vec;

--- a/extension/android/jni/jni_layer.cpp
+++ b/extension/android/jni/jni_layer.cpp
@@ -61,8 +61,7 @@ class TensorHybrid : public facebook::jni::HybridClass<TensorHybrid> {
     if (scalar_type_to_java_dtype.count(scalarType) == 0) {
       std::stringstream ss;
       ss << "executorch::aten::Tensor scalar type "
-         << static_cast<int>(scalarType)
-         << " is not supported on java side";
+         << static_cast<int>(scalarType) << " is not supported on java side";
       jni_helper::throwExecutorchException(
           static_cast<uint32_t>(Error::InvalidArgument), ss.str().c_str());
     }

--- a/extension/android/jni/jni_layer.cpp
+++ b/extension/android/jni/jni_layer.cpp
@@ -64,6 +64,7 @@ class TensorHybrid : public facebook::jni::HybridClass<TensorHybrid> {
          << static_cast<int>(scalarType) << " is not supported on java side";
       jni_helper::throwExecutorchException(
           static_cast<uint32_t>(Error::InvalidArgument), ss.str().c_str());
+      return nullptr;
     }
     int jdtype = scalar_type_to_java_dtype.at(scalarType);
 
@@ -131,6 +132,7 @@ class TensorHybrid : public facebook::jni::HybridClass<TensorHybrid> {
       ss << "Unknown Tensor jdtype: [" << jdtype << "]";
       jni_helper::throwExecutorchException(
           static_cast<uint32_t>(Error::InvalidArgument), ss.str().c_str());
+      return nullptr;
     }
     ScalarType scalar_type = java_dtype_to_scalar_type.at(jdtype);
     const jlong dataCapacity = jni->GetDirectBufferCapacity(jbuffer.get());
@@ -139,6 +141,7 @@ class TensorHybrid : public facebook::jni::HybridClass<TensorHybrid> {
       ss << "Tensor buffer is not direct or has invalid capacity";
       jni_helper::throwExecutorchException(
           static_cast<uint32_t>(Error::InvalidArgument), ss.str().c_str());
+      return nullptr;
     }
     const size_t elementSize = executorch::runtime::elementSize(scalar_type);
     const jlong expectedElements = static_cast<jlong>(numel);
@@ -153,6 +156,7 @@ class TensorHybrid : public facebook::jni::HybridClass<TensorHybrid> {
          << " (element size bytes: " << elementSize << ")";
       jni_helper::throwExecutorchException(
           static_cast<uint32_t>(Error::InvalidArgument), ss.str().c_str());
+      return nullptr;
     }
     return from_blob(
         jni->GetDirectBufferAddress(jbuffer.get()), shape_vec, scalar_type);


### PR DESCRIPTION
  ## Summary

  - Fix check-after-use bug in JNI scalar type lookup: move `.count()` check
    before `.at()` so unsupported scalar types throw a Java exception instead
    of C++ `std::out_of_range`
  - Fix `initHybrid` → `numThreads` parameter name in `Module.java` native
    declaration
  - Fix missing space in `getMethodMetadata()` error message
  - Modernize build config: Java 11 source/target, remove dead
    root ext properties (minSdkVersion, targetSdkVersion, compileSdkVersion,
    buildToolsVersion), update test dependencies (junit 4.13.2,
    androidx.test.ext:junit 1.2.1, androidx.test:rules 1.6.1,
    commons-io 2.18.0)

  Review order: `jni_layer.cpp` → `Module.java` → `build.gradle` files.

  ## Test plan

  - CI (existing unit + instrumentation tests cover the JNI and Module paths)
  - Build config changes are compile-time only; verified locally that Gradle
    sync succeeds