### PR TITLE
Add re2 shim for Buck2 OSS builds

### DIFF
--- a/shim_et/third-party/re2/BUCK
+++ b/shim_et/third-party/re2/BUCK
@@ -1,0 +1,5 @@
+cxx_library(
+    name = "re2",
+    exported_deps = ["root//extension/llm/tokenizers/third-party:re2"],
+    visibility = ["PUBLIC"],
+)


### PR DESCRIPTION
The tokenizers submodule BUCK file references `fbsource//third-party/re2:re2` directly, which resolves to `shim_et//third-party/re2:re2` in OSS via the `.buckconfig` alias. This target didn't exist, breaking Buck2 builds for any target depending on `tokenizers:headers`.

Add a shim `cxx_library` that re-exports the local re2 build from `//extension/llm/tokenizers/third-party:re2`.

This PR was authored with the assistance of Claude.