### PR TITLE
Build custom portable ops

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -222,6 +222,7 @@ exclude_patterns = [
     'extension/llm/tokenizers',
     'extension/llm/tokenizers/**',
     'examples/cuda',
+    'kernels/portable',
     # File contains @generated
     'extension/llm/custom_ops/spinquant/fast_hadamard_transform_special.h',
     'extension/llm/custom_ops/spinquant/test/fast_hadamard_transform_special_unstrided_cpu.h',

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -543,6 +543,13 @@ endif()
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/kernels/portable/cpu/util)
 
+# Custom ops AOT needs Torch. Find it at root scope before processing the
+# portable subdirectory so that imported targets (e.g. MKL::MKL) are created at
+# root scope rather than in a child directory scope.
+if(EXECUTORCH_BUILD_KERNELS_CUSTOM_AOT AND EXECUTORCH_BUILD_PORTABLE_OPS)
+  find_package_torch()
+endif()
+
 if(EXECUTORCH_BUILD_PORTABLE_OPS)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/kernels/portable)
 endif()

--- a/kernels/portable/CMakeLists.txt
+++ b/kernels/portable/CMakeLists.txt
@@ -105,3 +105,40 @@ install(
   PUBLIC_HEADER
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/executorch/kernels/portable/
 )
+
+# Build the portable custom ops AOT library for registering custom ops into
+# PyTorch. Requires find_package(Torch), which must be called at root scope
+# before this subdirectory is processed. Not targeting ARM_BAREMETAL as aot_lib
+# depends on incompatible libraries
+if(EXECUTORCH_BUILD_KERNELS_CUSTOM_AOT AND NOT EXECUTORCH_BUILD_ARM_BAREMETAL)
+  set(_custom_ops_yaml "${CMAKE_CURRENT_SOURCE_DIR}/custom_ops.yaml")
+  set(_portable_custom_ops "aten::allclose.out" "aten::allclose.Tensor")
+  gen_selected_ops(
+    LIB_NAME "portable_custom_ops_aot_lib" ROOT_OPS ${_portable_custom_ops}
+  )
+  generate_bindings_for_kernels(
+    LIB_NAME "portable_custom_ops_aot_lib" CUSTOM_OPS_YAML
+    "${_custom_ops_yaml}"
+  )
+  set(_portable_custom_ops_sources
+      "${CMAKE_CURRENT_SOURCE_DIR}/cpu/op_allclose.cpp"
+      "${EXECUTORCH_ROOT}/runtime/core/exec_aten/util/tensor_util_aten.cpp"
+  )
+  gen_custom_ops_aot_lib(
+    LIB_NAME "portable_custom_ops_aot_lib" KERNEL_SOURCES
+    ${_portable_custom_ops_sources}
+  )
+  target_include_directories(
+    portable_custom_ops_aot_lib PRIVATE ${_common_include_directories}
+  )
+
+  if(APPLE)
+    set(RPATH "@loader_path/../../extensions/pybindings")
+  else()
+    set(RPATH "\$ORIGIN/../../extensions/pybindings")
+  endif()
+  set_target_properties(
+    portable_custom_ops_aot_lib PROPERTIES BUILD_RPATH ${RPATH} INSTALL_RPATH
+                                                                ${RPATH}
+  )
+endif()

--- a/kernels/portable/__init__.py
+++ b/kernels/portable/__init__.py
@@ -1,0 +1,26 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+try:
+    from pathlib import Path
+
+    libs = list(Path(__file__).parent.resolve().glob("*portable_custom_ops_aot_lib.*"))
+    del Path
+    if not libs:
+        raise RuntimeError("No portable_custom_ops_aot_lib library found.")
+    if len(libs) > 1:
+        raise RuntimeError(
+            f"Expected 1 portable_custom_ops_aot_lib library but found {len(libs)}."
+        )
+    import torch as _torch
+
+    _torch.ops.load_library(str(libs[0]))
+    del _torch
+except Exception:  # noqa: E722
+    import logging
+
+    logging.info("portable_custom_ops_aot_lib is not loaded")
+    del logging

--- a/kernels/quantized/CMakeLists.txt
+++ b/kernels/quantized/CMakeLists.txt
@@ -4,7 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# Kernel library for quantized operators. Please this file formatted by running:
+# Kernel library for quantized operators. Please keep this file formatted by
+# running:
 # ~~~
 # cmake-format -i CMakeLists.txt
 # ~~~

--- a/src/executorch/kernels/portable
+++ b/src/executorch/kernels/portable
@@ -1,0 +1,1 @@
+../../../kernels/portable

--- a/tools/cmake/preset/default.cmake
+++ b/tools/cmake/preset/default.cmake
@@ -79,6 +79,10 @@ define_overridable_option(
   "Build the optimized ops library for AOT export usage" BOOL OFF
 )
 define_overridable_option(
+  EXECUTORCH_BUILD_KERNELS_CUSTOM_AOT
+  "Build the portable custom ops library for AOT export usage" BOOL OFF
+)
+define_overridable_option(
   EXECUTORCH_BUILD_EXTENSION_ASR_RUNNER "Build the ASR runner extension" BOOL
   OFF
 )


### PR DESCRIPTION
### Summary
Build custom portable ops, allow for easy import in python. This is mostly for testing but it does allow us to run memory planning tests (and potentially others) in OSS.

  - Build portable_custom_ops_aot_lib shared library (registers allclose.out and allclose.Tensor custom ops into PyTorch) in CMake, following the same pattern as quantized_ops_aot_lib
  - Make test_memory_planning.py importable outside Buck by replacing the Buck-only load_library("//executorch/...") with import executorch.kernels.portable
  - Add kernels/portable/__init__.py that discovers and loads the built shared library, mirroring kernels/quantized/__init__.py

### Test plan
Confirm memory planning can be tested in python
```
python -m unittest exir.tests.test_memory_planning
```

Confirm buck test still works
```
buck test @fbcode//mode/dev fbcode//executorch/exir/tests:memory_planning 
```
