### PR TITLE
Update comments for xnnpack partitioner

### DIFF
--- a/examples/models/llama/export_llama_lib.py
+++ b/examples/models/llama/export_llama_lib.py
@@ -1171,6 +1171,8 @@ def _get_xnnpack_partitioners(llm_config: LlmConfig) -> Optional[List[Partitione
     """Get XNNPACK partitioners for multimethod_lora export."""
     partitioners = []
 
+    # Order matters here, dynamic quantization should be applied first when
+    # both xnnpack and xnnpack_extended_ops are enabled.
     if llm_config.backend.xnnpack.enabled:
         partitioners.append(
             get_xnnpack_partitioner(dynamic_quant_only_partitioner=True)


### PR DESCRIPTION
Summary: Add some comments on why we use each xnnpack partitioner, and rely on config (even though xnnpack_extended_ops is hardcoded to True at the moment)

Differential Revision: D93900109


