### PR TITLE
Deduplicate file validation and UTF-8 checking utilities

### DIFF
--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/ExecuTorchRuntime.java
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/ExecuTorchRuntime.java
@@ -11,6 +11,7 @@ package org.pytorch.executorch;
 import com.facebook.jni.annotations.DoNotStrip;
 import com.facebook.soloader.nativeloader.NativeLoader;
 import com.facebook.soloader.nativeloader.SystemDelegate;
+import java.io.File;
 
 /** Class for entire ExecuTorch Runtime related functions. */
 public class ExecuTorchRuntime {
@@ -30,6 +31,18 @@ public class ExecuTorchRuntime {
   /** Get the runtime instance. */
   public static ExecuTorchRuntime getRuntime() {
     return sInstance;
+  }
+
+  /**
+   * Validates that the given path points to a readable file.
+   *
+   * @throws RuntimeException if the file does not exist or is not readable.
+   */
+  public static void validateFilePath(String path, String description) {
+    File file = new File(path);
+    if (!file.canRead() || !file.isFile()) {
+      throw new RuntimeException("Cannot load " + description + " " + path);
+    }
   }
 
   /** Get all registered ops. */

--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/Module.java
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/Module.java
@@ -13,7 +13,6 @@ import com.facebook.jni.HybridData;
 import com.facebook.jni.annotations.DoNotStrip;
 import com.facebook.soloader.nativeloader.NativeLoader;
 import com.facebook.soloader.nativeloader.SystemDelegate;
-import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.locks.Lock;
@@ -99,10 +98,7 @@ public class Module {
    * @return new {@link org.pytorch.executorch.Module} object which owns the model module.
    */
   public static Module load(final String modelPath, int loadMode, int numThreads) {
-    File modelFile = new File(modelPath);
-    if (!modelFile.canRead() || !modelFile.isFile()) {
-      throw new RuntimeException("Cannot load model path " + modelPath);
-    }
+    ExecuTorchRuntime.validateFilePath(modelPath, "model path");
     return new Module(modelPath, loadMode, numThreads);
   }
 

--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmModule.java
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmModule.java
@@ -10,7 +10,6 @@ package org.pytorch.executorch.extension.llm;
 
 import com.facebook.jni.HybridData;
 import com.facebook.jni.annotations.DoNotStrip;
-import java.io.File;
 import java.util.List;
 import org.pytorch.executorch.ExecuTorchRuntime;
 import org.pytorch.executorch.annotations.Experimental;
@@ -58,15 +57,8 @@ public class LlmModule {
       int numBos,
       int numEos) {
     ExecuTorchRuntime runtime = ExecuTorchRuntime.getRuntime();
-
-    File modelFile = new File(modulePath);
-    if (!modelFile.canRead() || !modelFile.isFile()) {
-      throw new RuntimeException("Cannot load model path " + modulePath);
-    }
-    File tokenizerFile = new File(tokenizerPath);
-    if (!tokenizerFile.canRead() || !tokenizerFile.isFile()) {
-      throw new RuntimeException("Cannot load tokenizer path " + tokenizerPath);
-    }
+    ExecuTorchRuntime.validateFilePath(modulePath, "model path");
+    ExecuTorchRuntime.validateFilePath(tokenizerPath, "tokenizer path");
 
     mHybridData =
         initHybrid(modelType, modulePath, tokenizerPath, temperature, dataFiles, numBos, numEos);

--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmModule.java
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmModule.java
@@ -56,7 +56,7 @@ public class LlmModule {
       List<String> dataFiles,
       int numBos,
       int numEos) {
-    ExecuTorchRuntime runtime = ExecuTorchRuntime.getRuntime();
+    ExecuTorchRuntime.getRuntime();
     ExecuTorchRuntime.validateFilePath(modulePath, "model path");
     ExecuTorchRuntime.validateFilePath(tokenizerPath, "tokenizer path");
 

--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/training/TrainingModule.java
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/training/TrainingModule.java
@@ -13,10 +13,10 @@ import com.facebook.jni.HybridData;
 import com.facebook.jni.annotations.DoNotStrip;
 import com.facebook.soloader.nativeloader.NativeLoader;
 import com.facebook.soloader.nativeloader.SystemDelegate;
-import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 import org.pytorch.executorch.EValue;
+import org.pytorch.executorch.ExecuTorchRuntime;
 import org.pytorch.executorch.Tensor;
 import org.pytorch.executorch.annotations.Experimental;
 
@@ -53,14 +53,8 @@ public class TrainingModule {
    * @return new {@link TrainingModule} object which owns the model module.
    */
   public static TrainingModule load(final String modelPath, final String dataPath) {
-    File modelFile = new File(modelPath);
-    if (!modelFile.canRead() || !modelFile.isFile()) {
-      throw new RuntimeException("Cannot load model path!! " + modelPath);
-    }
-    File dataFile = new File(dataPath);
-    if (!dataFile.canRead() || !dataFile.isFile()) {
-      throw new RuntimeException("Cannot load data path!! " + dataPath);
-    }
+    ExecuTorchRuntime.validateFilePath(modelPath, "model path");
+    ExecuTorchRuntime.validateFilePath(dataPath, "data path");
     return new TrainingModule(modelPath, dataPath);
   }
 
@@ -72,10 +66,7 @@ public class TrainingModule {
    * @return new {@link TrainingModule} object which owns the model module.
    */
   public static TrainingModule load(final String modelPath) {
-    File modelFile = new File(modelPath);
-    if (!modelFile.canRead() || !modelFile.isFile()) {
-      throw new RuntimeException("Cannot load model path!! " + modelPath);
-    }
+    ExecuTorchRuntime.validateFilePath(modelPath, "model path");
     return new TrainingModule(modelPath, "");
   }
 

--- a/extension/android/jni/jni_helper.h
+++ b/extension/android/jni/jni_helper.h
@@ -9,6 +9,8 @@
 #pragma once
 
 #include <fbjni/fbjni.h>
+#include <cstddef>
+#include <cstdint>
 #include <string>
 
 namespace executorch::jni_helper {
@@ -29,5 +31,10 @@ struct JExecutorchRuntimeException
   static constexpr auto kJavaDescriptor =
       "Lorg/pytorch/executorch/ExecutorchRuntimeException;";
 };
+
+/**
+ * Returns true if the given byte sequence is valid UTF-8.
+ */
+bool utf8_check_validity(const char* str, size_t length);
 
 } // namespace executorch::jni_helper

--- a/extension/android/jni/jni_layer_asr.cpp
+++ b/extension/android/jni/jni_layer_asr.cpp
@@ -20,11 +20,14 @@
 #include <executorch/extension/tensor/tensor_ptr_maker.h>
 #include <executorch/runtime/platform/log.h>
 
+#include <executorch/extension/android/jni/jni_helper.h>
+
 namespace asr = ::executorch::extension::asr;
 using ::executorch::extension::from_blob;
 using ::executorch::extension::Module;
 using ::executorch::extension::TensorPtr;
 using ::executorch::runtime::Error;
+using executorch::jni_helper::utf8_check_validity;
 
 namespace {
 
@@ -43,37 +46,6 @@ std::string jstringToString(JNIEnv* env, jstring jstr) {
   std::string result(chars);
   env->ReleaseStringUTFChars(jstr, chars);
   return result;
-}
-
-// Helper for UTF-8 validity checking (for streaming tokens)
-bool utf8_check_validity(const char* str, size_t length) {
-  for (size_t i = 0; i < length; ++i) {
-    uint8_t byte = static_cast<uint8_t>(str[i]);
-    if (byte >= 0x80) {
-      if (i + 1 >= length) {
-        return false;
-      }
-      uint8_t next_byte = static_cast<uint8_t>(str[i + 1]);
-      if ((byte & 0xE0) == 0xC0 && (next_byte & 0xC0) == 0x80) {
-        i += 1;
-      } else if (
-          (byte & 0xF0) == 0xE0 && (next_byte & 0xC0) == 0x80 &&
-          (i + 2 < length) &&
-          (static_cast<uint8_t>(str[i + 2]) & 0xC0) == 0x80) {
-        i += 2;
-      } else if (
-          (byte & 0xF8) == 0xF0 && (next_byte & 0xC0) == 0x80 &&
-          (i + 2 < length) &&
-          (static_cast<uint8_t>(str[i + 2]) & 0xC0) == 0x80 &&
-          (i + 3 < length) &&
-          (static_cast<uint8_t>(str[i + 3]) & 0xC0) == 0x80) {
-        i += 3;
-      } else {
-        return false;
-      }
-    }
-  }
-  return true;
 }
 
 // Global cached JNI references for callback (shared across threads)

--- a/extension/android/jni/jni_layer_asr.cpp
+++ b/extension/android/jni/jni_layer_asr.cpp
@@ -26,8 +26,8 @@ namespace asr = ::executorch::extension::asr;
 using ::executorch::extension::from_blob;
 using ::executorch::extension::Module;
 using ::executorch::extension::TensorPtr;
+using ::executorch::jni_helper::utf8_check_validity;
 using ::executorch::runtime::Error;
-using executorch::jni_helper::utf8_check_validity;
 
 namespace {
 

--- a/extension/android/jni/jni_layer_llama.cpp
+++ b/extension/android/jni/jni_layer_llama.cpp
@@ -44,41 +44,7 @@
 namespace llm = ::executorch::extension::llm;
 using ::executorch::runtime::Error;
 
-namespace {
-bool utf8_check_validity(const char* str, size_t length) {
-  for (size_t i = 0; i < length; ++i) {
-    uint8_t byte = static_cast<uint8_t>(str[i]);
-    if (byte >= 0x80) { // Non-ASCII byte
-      if (i + 1 >= length) { // Incomplete sequence
-        return false;
-      }
-      uint8_t next_byte = static_cast<uint8_t>(str[i + 1]);
-      if ((byte & 0xE0) == 0xC0 &&
-          (next_byte & 0xC0) == 0x80) { // 2-byte sequence
-        i += 1;
-      } else if (
-          (byte & 0xF0) == 0xE0 && (next_byte & 0xC0) == 0x80 &&
-          (i + 2 < length) &&
-          (static_cast<uint8_t>(str[i + 2]) & 0xC0) ==
-              0x80) { // 3-byte sequence
-        i += 2;
-      } else if (
-          (byte & 0xF8) == 0xF0 && (next_byte & 0xC0) == 0x80 &&
-          (i + 2 < length) &&
-          (static_cast<uint8_t>(str[i + 2]) & 0xC0) == 0x80 &&
-          (i + 3 < length) &&
-          (static_cast<uint8_t>(str[i + 3]) & 0xC0) ==
-              0x80) { // 4-byte sequence
-        i += 3;
-      } else {
-        return false; // Invalid sequence
-      }
-    }
-  }
-  return true; // All bytes were valid
-}
-
-} // namespace
+using executorch::jni_helper::utf8_check_validity;
 
 namespace executorch_jni {
 


### PR DESCRIPTION

### Summary
Java: Extract validateFilePath() into ExecuTorchRuntime and replace inline checks in Module, LlmModule, and TrainingModule. This also removes the "!!" typo in TrainingModule error messages.

C++: Move utf8_check_validity() from anonymous namespaces in jni_layer_llama.cpp and jni_layer_asr.cpp into the shared jni_helper.h/.cpp.

### Test plan
CI