### PR TITLE
Make MethodMetadata immutable and populate eagerly

### DIFF
--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/MethodMetadata.java
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/MethodMetadata.java
@@ -8,15 +8,14 @@
 
 package org.pytorch.executorch;
 
-/** Helper class to access the metadata for a method from a Module */
+/** Immutable metadata for a method in a Module. */
 public class MethodMetadata {
-  private String mName;
+  private final String mName;
+  private final String[] mBackends;
 
-  private String[] mBackends;
-
-  MethodMetadata setName(String name) {
+  MethodMetadata(String name, String[] backends) {
     mName = name;
-    return this;
+    mBackends = backends;
   }
 
   /**
@@ -24,11 +23,6 @@ public class MethodMetadata {
    */
   public String getName() {
     return mName;
-  }
-
-  MethodMetadata setBackends(String[] backends) {
-    mBackends = backends;
-    return this;
   }
 
   /**

--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/Module.java
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/Module.java
@@ -64,14 +64,12 @@ public class Module {
     mMethodMetadata = populateMethodMeta();
   }
 
-  Map<String, MethodMetadata> populateMethodMeta() {
+  private Map<String, MethodMetadata> populateMethodMeta() {
     String[] methods = getMethods();
     Map<String, MethodMetadata> metadata = new HashMap<String, MethodMetadata>();
-    for (int i = 0; i < methods.length; i++) {
-      String name = methods[i];
-      metadata.put(name, new MethodMetadata().setName(name));
+    for (String name : methods) {
+      metadata.put(name, new MethodMetadata(name, getUsedBackends(name)));
     }
-
     return metadata;
   }
 
@@ -200,13 +198,9 @@ public class Module {
    * @return @MethodMetadata for this method
    */
   public MethodMetadata getMethodMetadata(String name) {
-    if (!mMethodMetadata.containsKey(name)) {
-      throw new RuntimeException("method " + name + " does not exist for this module");
-    }
-
     MethodMetadata methodMetadata = mMethodMetadata.get(name);
-    if (methodMetadata != null) {
-      methodMetadata.setBackends(getUsedBackends(name));
+    if (methodMetadata == null) {
+      throw new IllegalArgumentException("method " + name + " does not exist for this module");
     }
     return methodMetadata;
   }


### PR DESCRIPTION

### Summary
MethodMetadata was mutable with setters, and getMethodMetadata() called the native getUsedBackends() on every invocation while mutating the cached object — a hidden side effect in a getter that also introduced a thread safety race condition.

Make MethodMetadata fields final with a package-private constructor, populate backends once during Module construction in populateMethodMeta(), and reduce getMethodMetadata() to a pure map lookup. Also change the exception from RuntimeException to IllegalArgumentException for invalid method names.

### Test plan
CI

cc @cbilgin