### PR TITLE
Add re2 shim for Buck2 OSS builds

### DIFF
--- a/shim_et/third-party/re2/BUCK
+++ b/shim_et/third-party/re2/BUCK
@@ -1,0 +1,3 @@
+load(":targets.bzl", "define_common_targets")
+
+define_common_targets()

--- a/shim_et/third-party/re2/targets.bzl
+++ b/shim_et/third-party/re2/targets.bzl
@@ -1,0 +1,9 @@
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+
+def define_common_targets():
+    if runtime.is_oss:
+        native.cxx_library(
+            name = "re2",
+            exported_deps = ["root//extension/llm/tokenizers/third-party:re2"],
+            visibility = ["PUBLIC"],
+        )


### PR DESCRIPTION
This is a follow-up of https://github.com/pytorch/executorch/pull/17638 since it's breaking internal.

The tokenizers BUCK file references fbsource//third-party/re2:re2, which resolves to shim_et//third-party/re2:re2 in OSS builds. This target didn't exist, causing Buck2 build failures.

Add a shim cxx_library in shim_et/third-party/re2/ that re-exports from the actual re2 build in extension/llm/tokenizers/third-party. The shim is gated behind runtime.is_oss so it's a no-op internally.

This PR was authored with the help of Claude.