### PR TITLE
Metal backend: Enable Voxtral Realtime streaming mode

### DIFF
--- a/.ci/scripts/export_model_artifact.sh
+++ b/.ci/scripts/export_model_artifact.sh
@@ -262,8 +262,7 @@ if [ "$MODEL_NAME" = "voxtral_realtime" ]; then
   elif [ "$MODE" = "vr-offline" ]; then
     USE_STREAMING="false"
   elif [ -z "$MODE" ]; then
-    # Auto-detect: XNNPACK uses streaming, others use offline
-    if [ "$DEVICE" = "xnnpack" ]; then
+  if [ "$DEVICE" = "xnnpack" ] || [ "$DEVICE" = "metal" ]; then
       USE_STREAMING="true"
     fi
   fi

--- a/.ci/scripts/export_model_artifact.sh
+++ b/.ci/scripts/export_model_artifact.sh
@@ -34,7 +34,7 @@ Arguments:
 
   output_dir   Output directory for artifacts (optional, default: current directory)
 
-  mode         Export mode (optional, default: auto-detect based on model and device)
+  mode         Export mode (optional, default: vr-streaming)
                Supported modes:
                  - vr-streaming: Voxtral Realtime streaming mode
                  - vr-offline: Voxtral Realtime offline mode
@@ -256,15 +256,9 @@ if [ "$MODEL_NAME" = "voxtral_realtime" ]; then
   fi
 
   # Determine streaming mode based on MODE parameter
-  USE_STREAMING="false"
-  if [ "$MODE" = "vr-streaming" ]; then
-    USE_STREAMING="true"
-  elif [ "$MODE" = "vr-offline" ]; then
+  USE_STREAMING="true"
+  if [ "$MODE" = "vr-offline" ]; then
     USE_STREAMING="false"
-  elif [ -z "$MODE" ]; then
-    if [ "$DEVICE" = "xnnpack" ] || [ "$DEVICE" = "metal" ]; then
-      USE_STREAMING="true"
-    fi
   fi
 
   # Configure export and preprocessor based on streaming mode

--- a/.ci/scripts/export_model_artifact.sh
+++ b/.ci/scripts/export_model_artifact.sh
@@ -262,7 +262,7 @@ if [ "$MODEL_NAME" = "voxtral_realtime" ]; then
   elif [ "$MODE" = "vr-offline" ]; then
     USE_STREAMING="false"
   elif [ -z "$MODE" ]; then
-  if [ "$DEVICE" = "xnnpack" ] || [ "$DEVICE" = "metal" ]; then
+    if [ "$DEVICE" = "xnnpack" ] || [ "$DEVICE" = "metal" ]; then
       USE_STREAMING="true"
     fi
   fi

--- a/.ci/scripts/test_model_e2e.sh
+++ b/.ci/scripts/test_model_e2e.sh
@@ -272,15 +272,9 @@ case "$MODEL_NAME" in
   voxtral_realtime)
     RUNNER_ARGS="--model_path ${MODEL_DIR}/model.pte --tokenizer_path ${MODEL_DIR}/$TOKENIZER_FILE --preprocessor_path ${MODEL_DIR}/$PREPROCESSOR --audio_path ${MODEL_DIR}/$AUDIO_FILE --temperature 0"
     # Determine streaming mode based on MODE parameter
-    USE_STREAMING="false"
-    if [ "$MODE" = "vr-streaming" ]; then
-      USE_STREAMING="true"
-    elif [ "$MODE" = "vr-offline" ]; then
+    USE_STREAMING="true"
+    if [ "$MODE" = "vr-offline" ]; then
       USE_STREAMING="false"
-    elif [ -z "$MODE" ]; then
-      if [ "$DEVICE" = "xnnpack" ] || [ "$DEVICE" = "metal" ]; then
-        USE_STREAMING="true"
-      fi
     fi
     # Add streaming flag if needed
     if [ "$USE_STREAMING" = "true" ]; then

--- a/.ci/scripts/test_model_e2e.sh
+++ b/.ci/scripts/test_model_e2e.sh
@@ -278,8 +278,7 @@ case "$MODEL_NAME" in
     elif [ "$MODE" = "vr-offline" ]; then
       USE_STREAMING="false"
     elif [ -z "$MODE" ]; then
-      # Auto-detect: XNNPACK uses streaming, others use offline
-      if [ "$DEVICE" = "xnnpack" ]; then
+      if [ "$DEVICE" = "xnnpack" ] || [ "$DEVICE" = "metal" ]; then
         USE_STREAMING="true"
       fi
     fi

--- a/backends/apple/metal/metal_backend.py
+++ b/backends/apple/metal/metal_backend.py
@@ -66,7 +66,7 @@ class MetalBackend(AotiBackend, BackendDetails):
             "max_autotune": True,
             # "aot_inductor.debug_compile": True,
             # "aot_inductor.force_mmap_weights": False,
-            "padding_stride_threshold": float("inf"), # avoid padding stride
+            "padding_stride_threshold": float("inf"),  # avoid padding stride
         }
 
         from torchao.experimental.ops.mps.cshim import torchao_op_c_shim

--- a/backends/apple/metal/metal_backend.py
+++ b/backends/apple/metal/metal_backend.py
@@ -66,6 +66,7 @@ class MetalBackend(AotiBackend, BackendDetails):
             "max_autotune": True,
             # "aot_inductor.debug_compile": True,
             # "aot_inductor.force_mmap_weights": False,
+            "padding_stride_threshold": float("inf"), # avoid padding stride
         }
 
         from torchao.experimental.ops.mps.cshim import torchao_op_c_shim

--- a/examples/models/voxtral_realtime/export_voxtral_rt.py
+++ b/examples/models/voxtral_realtime/export_voxtral_rt.py
@@ -260,13 +260,11 @@ def export_streaming(
         )
 
     sample_mel_chunk = torch.randn(1, model.config.num_mel_bins, 8, dtype=param_dtype)
-    sample_conv1_state = torch.zeros(1, model.config.num_mel_bins, 2, dtype=param_dtype)
-    sample_conv2_state = torch.zeros(1, model.config.enc_dim, 2, dtype=param_dtype)
     sample_enc_pos = torch.arange(4, dtype=torch.long)
 
     programs["encode_audio_chunk"] = export(
         streaming_enc,
-        (sample_mel_chunk, sample_conv1_state, sample_conv2_state, sample_enc_pos),
+        (sample_mel_chunk, sample_enc_pos),
         dynamic_shapes=None,
         strict=True,
     )

--- a/examples/models/voxtral_realtime/main.cpp
+++ b/examples/models/voxtral_realtime/main.cpp
@@ -35,6 +35,9 @@
 #include <executorch/extension/llm/runner/util.h>
 #include <executorch/extension/llm/runner/wav_loader.h>
 #include <executorch/runtime/platform/log.h>
+#ifdef ET_BUILD_METAL
+#include <executorch/backends/apple/metal/runtime/stats.h>
+#endif
 
 #include "voxtral_realtime_runner.h"
 
@@ -210,6 +213,10 @@ int main(int argc, char** argv) {
   stats.inference_end_ms = ::executorch::extension::llm::time_in_ms();
 
   ::executorch::extension::llm::print_report(stats);
+
+#ifdef ET_BUILD_METAL
+  executorch::backends::metal::print_metal_backend_stats();
+#endif // ET_BUILD_METAL
 
   return 0;
 }

--- a/examples/models/voxtral_realtime/model.py
+++ b/examples/models/voxtral_realtime/model.py
@@ -827,16 +827,13 @@ class StandardEncoderRingKVCache(nn.Module):
         Returns:
             k_cache, v_cache: (B, buf_size, n_heads, head_dim) in [B, S, H, D] layout.
         """
-        start_pos = input_pos[0].item()
-        torch._check_is_size(start_pos)
-        seq_len = k_val.size(1)
-
-        # Compute wraparound indices
-        indices = (torch.arange(seq_len, dtype=torch.long, device=k_val.device) + start_pos) % self.buf_size
+        # Compute wrapped indices for ring buffer - work entirely with tensors
+        # to keep operations symbolic for AOTI
+        wrapped_indices = input_pos % self.buf_size
 
         # Use index_copy_ on dimension 1 (sequence dimension in [B, S, H, D])
-        self.k_cache.index_copy_(1, indices, k_val)
-        self.v_cache.index_copy_(1, indices, v_val)
+        self.k_cache.index_copy_(1, wrapped_indices, k_val)
+        self.v_cache.index_copy_(1, wrapped_indices, v_val)
 
         return self.k_cache, self.v_cache
 

--- a/examples/models/voxtral_realtime/model.py
+++ b/examples/models/voxtral_realtime/model.py
@@ -796,7 +796,11 @@ class EncoderRingKVCache(nn.Module):
     def create_causal_mask(
         self, start_pos: torch.Tensor | int, seq_len: int
     ) -> torch.Tensor:
-        device = start_pos.device if isinstance(start_pos, torch.Tensor) else "cpu"
+        device = (
+            start_pos.device
+            if isinstance(start_pos, torch.Tensor)
+            else self.k_cache.device
+        )
         total_written = start_pos + seq_len
         j = torch.arange(self.buf_size, dtype=torch.long, device=device)
         cache_pos = j + ((total_written - 1 - j) // self.buf_size) * self.buf_size

--- a/examples/models/voxtral_realtime/model.py
+++ b/examples/models/voxtral_realtime/model.py
@@ -793,11 +793,16 @@ class EncoderRingKVCache(nn.Module):
         torch.ops.llama.update_cache_with_indices(v_val, self.v_cache, 0, indices)
         return self.k_cache, self.v_cache
 
-    def create_causal_mask(self, start_pos: int, seq_len: int) -> torch.Tensor:
+    def create_causal_mask(
+        self, start_pos: torch.Tensor | int, seq_len: int
+    ) -> torch.Tensor:
+        device = start_pos.device if isinstance(start_pos, torch.Tensor) else "cpu"
         total_written = start_pos + seq_len
-        j = torch.arange(self.buf_size, dtype=torch.long)
+        j = torch.arange(self.buf_size, dtype=torch.long, device=device)
         cache_pos = j + ((total_written - 1 - j) // self.buf_size) * self.buf_size
-        pos_q = (start_pos + torch.arange(seq_len, dtype=torch.long)).view(-1, 1)
+        pos_q = (
+            start_pos + torch.arange(seq_len, dtype=torch.long, device=device)
+        ).view(-1, 1)
         delta = pos_q - cache_pos.unsqueeze(0)
         valid = (cache_pos >= 0) & (delta >= 0) & (delta < self.window_size)
         return torch.where(valid, 0.0, float("-inf"))

--- a/examples/models/voxtral_realtime/model.py
+++ b/examples/models/voxtral_realtime/model.py
@@ -952,6 +952,12 @@ class StreamingAudioEncoderExport(nn.Module):
         mel_chunk: torch.Tensor,
         enc_input_pos: torch.Tensor,
     ) -> torch.Tensor:
+        # Auto-reset conv states at the start of each new session (enc_input_pos[0] == 0).
+        # Using tensor ops (not .item()) avoids constant-folding during export.
+        is_start = (enc_input_pos[:1] == 0).view(1, 1, 1).to(self.conv1_state.dtype)
+        self.conv1_state.mul_(1.0 - is_start)
+        self.conv2_state.mul_(1.0 - is_start)
+
         # Conv1: cat state + chunk, raw Conv1d (no CausalConv1d padding)
         # (1, 128, 2+8=10) -> conv1(k=3, s=1) -> (1, 1280, 8)
         conv1_input = torch.cat([self.conv1_state, mel_chunk], dim=2)

--- a/examples/models/voxtral_realtime/model.py
+++ b/examples/models/voxtral_realtime/model.py
@@ -802,49 +802,65 @@ class EncoderRingKVCache(nn.Module):
 
 
 class StandardEncoderRingKVCache(nn.Module):
-    """Export-friendly ring buffer KV cache using index_copy_ for updates.
+    """Fixed-size KV cache for Metal/AOTI backend.
 
-    Compatible with torch.export and AOTI. Uses [B, S, H, D] layout
-    matching the encoder's convention. Ring buffer enables unlimited streaming.
+    Uses [B, S, H, D] layout matching the encoder's convention.
+    Unlike the ring buffer version, this has a fixed maximum length
+    and doesn't support wraparound. Simpler for AOTI to trace.
     """
 
     def __init__(self, window_size: int, n_heads: int, head_dim: int):
         super().__init__()
         self.window_size = window_size
-        self.buf_size = window_size * 2
-        cache_shape = (1, self.buf_size, n_heads, head_dim)
+        self.max_seq_len = window_size  # Fixed size, no ring buffer
+        cache_shape = (1, self.max_seq_len, n_heads, head_dim)
         self.register_buffer("k_cache", torch.zeros(cache_shape))
         self.register_buffer("v_cache", torch.zeros(cache_shape))
 
     def update(
         self, input_pos: torch.Tensor, k_val: torch.Tensor, v_val: torch.Tensor
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        """Write k_val/v_val into ring buffer using index_copy_ (export-friendly).
+        """Write k_val/v_val into cache using simple index_copy_.
 
         Args:
-            input_pos: (seq_len,) position indices.
+            input_pos: (seq_len,) position indices within [0, max_seq_len).
             k_val, v_val: (B, seq_len, n_heads, head_dim) in [B, S, H, D] layout.
         Returns:
-            k_cache, v_cache: (B, buf_size, n_heads, head_dim) in [B, S, H, D] layout.
+            k_cache, v_cache: (B, max_seq_len, n_heads, head_dim) in [B, S, H, D] layout.
         """
-        # Compute wrapped indices for ring buffer - work entirely with tensors
-        # to keep operations symbolic for AOTI
-        wrapped_indices = input_pos % self.buf_size
-
-        # Use index_copy_ on dimension 1 (sequence dimension in [B, S, H, D])
-        self.k_cache.index_copy_(1, wrapped_indices, k_val)
-        self.v_cache.index_copy_(1, wrapped_indices, v_val)
+        # Simple index_copy without modulo - assumes input_pos is already within bounds
+        self.k_cache.index_copy_(1, input_pos, k_val)
+        self.v_cache.index_copy_(1, input_pos, v_val)
 
         return self.k_cache, self.v_cache
 
-    def create_causal_mask(self, start_pos: int, seq_len: int) -> torch.Tensor:
-        """Create sliding window attention mask."""
-        total_written = start_pos + seq_len
-        j = torch.arange(self.buf_size, dtype=torch.long)
-        cache_pos = j + ((total_written - 1 - j) // self.buf_size) * self.buf_size
-        pos_q = (start_pos + torch.arange(seq_len, dtype=torch.long)).view(-1, 1)
-        delta = pos_q - cache_pos.unsqueeze(0)
-        valid = (cache_pos >= 0) & (delta >= 0) & (delta < self.window_size)
+    def create_causal_mask(self, start_pos: torch.Tensor, seq_len: int) -> torch.Tensor:
+        """Create sliding window attention mask.
+
+        For fixed-size cache, creates a mask that:
+        - Allows attention to positions [max(0, start_pos - window_size), start_pos + seq_len)
+        - Maintains causality (can only attend to current or earlier positions)
+
+        Args:
+            start_pos: Tensor containing the starting position (scalar tensor)
+            seq_len: Number of query positions
+        """
+        # Query positions: [start_pos, start_pos + 1, ..., start_pos + seq_len - 1]
+        # Use tensor operations to avoid .item() calls
+        q_offsets = torch.arange(seq_len, dtype=torch.long, device=start_pos.device)
+        q_pos = (start_pos + q_offsets).unsqueeze(1)  # [seq_len, 1]
+
+        # Key positions: all positions in cache [0, 1, 2, ..., max_seq_len - 1]
+        k_pos = torch.arange(self.max_seq_len, dtype=torch.long, device=start_pos.device).unsqueeze(0)  # [1, max_seq_len]
+
+        # Compute distance from each query to each key
+        delta = q_pos - k_pos  # [seq_len, max_seq_len]
+
+        # Valid if: key position <= query position AND within sliding window
+        # delta >= 0: causal (attend to earlier or same position)
+        # delta < window_size: within sliding window
+        valid = (delta >= 0) & (delta < self.window_size)
+
         return torch.where(valid, 0.0, float("-inf"))
 
 
@@ -961,9 +977,8 @@ class StreamingAudioEncoderExport(nn.Module):
 
         # Sliding window mask — identical for all layers, compute once.
         T = x.size(1)
-        start_pos = enc_input_pos[0].item()
-        torch._check_is_size(start_pos)
-        mask = self.kv_caches[0].create_causal_mask(start_pos, T)
+        # Pass start position as tensor (not .item()) to avoid unbacked symbols in AOTI
+        mask = self.kv_caches[0].create_causal_mask(enc_input_pos[0], T)
 
         for i, layer in enumerate(self.layers):
             x = self._streaming_encoder_layer(

--- a/examples/models/voxtral_realtime/model.py
+++ b/examples/models/voxtral_realtime/model.py
@@ -546,7 +546,9 @@ class StandardEncoderSDPA(nn.Module):
 
         # Apply SDPA with sliding window mask
         y = F.scaled_dot_product_attention(
-            q, k, v,
+            q,
+            k,
+            v,
             attn_mask=mask,
             is_causal=False,  # We handle masking explicitly via mask parameter
         )  # [B, n_heads, seq_len, head_dim]
@@ -890,7 +892,11 @@ class StreamingAudioEncoderExport(nn.Module):
         # Window size = max_enc_len (encoder sliding window from params.json).
         # Buffer is 2x internally for safe wraparound.
         # Choose cache implementation based on backend
-        cache_class = StandardEncoderRingKVCache if config.use_standard_attention else EncoderRingKVCache
+        cache_class = (
+            StandardEncoderRingKVCache
+            if config.use_standard_attention
+            else EncoderRingKVCache
+        )
         self.kv_caches = nn.ModuleList(
             [
                 cache_class(max_enc_len, config.enc_n_heads, config.enc_head_dim)

--- a/examples/models/voxtral_realtime/model.py
+++ b/examples/models/voxtral_realtime/model.py
@@ -956,15 +956,15 @@ class StreamingAudioEncoderExport(nn.Module):
         # (1, 128, 2+8=10) -> conv1(k=3, s=1) -> (1, 1280, 8)
         conv1_input = torch.cat([self.conv1_state, mel_chunk], dim=2)
         conv1_out = F.gelu(self.conv1(conv1_input))
-        # Update conv1 state in-place with last 2 frames from input
-        self.conv1_state.copy_(conv1_input[:, :, -2:])
+        # Update conv1 state with last 2 frames from mel_chunk
+        self.conv1_state.copy_(mel_chunk[:, :, -2:])
 
         # Conv2: cat state + conv1_out, raw Conv1d
         # (1, 1280, 2+8=10) -> conv2(k=3, s=2) -> (1, 1280, 4)
         conv2_input = torch.cat([self.conv2_state, conv1_out], dim=2)
         conv2_out = F.gelu(self.conv2(conv2_input))
-        # Update conv2 state in-place with last 2 frames from conv1_out
-        self.conv2_state.copy_(conv2_input[:, :, -2:])
+        # Update conv2 state with last 2 frames from conv1_out
+        self.conv2_state.copy_(conv1_out[:, :, -2:])
 
         x = conv2_out.transpose(1, 2)  # (1, 4, 1280)
 

--- a/examples/models/voxtral_realtime/model.py
+++ b/examples/models/voxtral_realtime/model.py
@@ -802,65 +802,57 @@ class EncoderRingKVCache(nn.Module):
 
 
 class StandardEncoderRingKVCache(nn.Module):
-    """Fixed-size KV cache for Metal/AOTI backend.
+    """Export-friendly ring buffer KV cache using index_copy_ for updates.
 
-    Uses [B, S, H, D] layout matching the encoder's convention.
-    Unlike the ring buffer version, this has a fixed maximum length
-    and doesn't support wraparound. Simpler for AOTI to trace.
+    Compatible with torch.export and AOTI. Uses [B, S, H, D] layout
+    matching the encoder's convention. Ring buffer enables unlimited streaming.
     """
 
     def __init__(self, window_size: int, n_heads: int, head_dim: int):
         super().__init__()
         self.window_size = window_size
-        self.max_seq_len = window_size  # Fixed size, no ring buffer
-        cache_shape = (1, self.max_seq_len, n_heads, head_dim)
+        self.buf_size = window_size * 2
+        cache_shape = (1, self.buf_size, n_heads, head_dim)
         self.register_buffer("k_cache", torch.zeros(cache_shape))
         self.register_buffer("v_cache", torch.zeros(cache_shape))
 
     def update(
         self, input_pos: torch.Tensor, k_val: torch.Tensor, v_val: torch.Tensor
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        """Write k_val/v_val into cache using simple index_copy_.
+        """Write k_val/v_val into ring buffer using index_copy_ with modulo wraparound.
 
         Args:
-            input_pos: (seq_len,) position indices within [0, max_seq_len).
+            input_pos: (seq_len,) position indices.
             k_val, v_val: (B, seq_len, n_heads, head_dim) in [B, S, H, D] layout.
         Returns:
-            k_cache, v_cache: (B, max_seq_len, n_heads, head_dim) in [B, S, H, D] layout.
+            k_cache, v_cache: (B, buf_size, n_heads, head_dim) in [B, S, H, D] layout.
         """
-        # Simple index_copy without modulo - assumes input_pos is already within bounds
-        self.k_cache.index_copy_(1, input_pos, k_val)
-        self.v_cache.index_copy_(1, input_pos, v_val)
+        # Compute wrapped indices for ring buffer
+        wrapped_indices = input_pos % self.buf_size
+
+        # Use index_copy_ on dimension 1 (sequence dimension in [B, S, H, D])
+        self.k_cache.index_copy_(1, wrapped_indices, k_val)
+        self.v_cache.index_copy_(1, wrapped_indices, v_val)
 
         return self.k_cache, self.v_cache
 
     def create_causal_mask(self, start_pos: torch.Tensor, seq_len: int) -> torch.Tensor:
-        """Create sliding window attention mask.
-
-        For fixed-size cache, creates a mask that:
-        - Allows attention to positions [max(0, start_pos - window_size), start_pos + seq_len)
-        - Maintains causality (can only attend to current or earlier positions)
+        """Create sliding window attention mask for ring buffer.
 
         Args:
             start_pos: Tensor containing the starting position (scalar tensor)
             seq_len: Number of query positions
         """
-        # Query positions: [start_pos, start_pos + 1, ..., start_pos + seq_len - 1]
-        # Use tensor operations to avoid .item() calls
+        total_written = start_pos + seq_len
+        j = torch.arange(self.buf_size, dtype=torch.long, device=start_pos.device)
+        cache_pos = j + ((total_written - 1 - j) // self.buf_size) * self.buf_size
+
+        # Query positions using tensor operations
         q_offsets = torch.arange(seq_len, dtype=torch.long, device=start_pos.device)
-        q_pos = (start_pos + q_offsets).unsqueeze(1)  # [seq_len, 1]
+        pos_q = (start_pos + q_offsets).view(-1, 1)
 
-        # Key positions: all positions in cache [0, 1, 2, ..., max_seq_len - 1]
-        k_pos = torch.arange(self.max_seq_len, dtype=torch.long, device=start_pos.device).unsqueeze(0)  # [1, max_seq_len]
-
-        # Compute distance from each query to each key
-        delta = q_pos - k_pos  # [seq_len, max_seq_len]
-
-        # Valid if: key position <= query position AND within sliding window
-        # delta >= 0: causal (attend to earlier or same position)
-        # delta < window_size: within sliding window
-        valid = (delta >= 0) & (delta < self.window_size)
-
+        delta = pos_q - cache_pos.unsqueeze(0)
+        valid = (cache_pos >= 0) & (delta >= 0) & (delta < self.window_size)
         return torch.where(valid, 0.0, float("-inf"))
 
 

--- a/examples/models/voxtral_realtime/model.py
+++ b/examples/models/voxtral_realtime/model.py
@@ -756,11 +756,10 @@ class StreamingAudioEncoderExport(nn.Module):
 
     Shares conv/transformer/adapter weights with the offline encoder.
     Owns separate KV caches and SDPA for incremental KV-cached attention.
+    Conv states are maintained as internal buffers.
 
     Forward:
-        mel_chunk(1,128,8) + conv1_state(1,128,2) + conv2_state(1,1280,2)
-        + enc_input_pos(4,)
-        -> audio_embeds(1,1,3072), new_conv1_state(1,128,2), new_conv2_state(1,1280,2)
+        mel_chunk(1,128,8) + enc_input_pos(4,) -> audio_embeds(1,1,3072)
     """
 
     def __init__(self, model: VoxtralRealtimeModel, max_enc_len: int = 750):
@@ -777,6 +776,10 @@ class StreamingAudioEncoderExport(nn.Module):
         self.downsample_factor = config.downsample_factor
         self.n_heads = config.enc_n_heads
         self.head_dim = config.enc_head_dim
+
+        # Register conv states as buffers (mutable state for streaming)
+        self.register_buffer("conv1_state", torch.zeros(1, config.num_mel_bins, 2))
+        self.register_buffer("conv2_state", torch.zeros(1, config.enc_dim, 2))
 
         # Ring buffer KV caches for unlimited streaming.
         # Window size = max_enc_len (encoder sliding window from params.json).
@@ -831,21 +834,21 @@ class StreamingAudioEncoderExport(nn.Module):
     def forward(
         self,
         mel_chunk: torch.Tensor,
-        conv1_state: torch.Tensor,
-        conv2_state: torch.Tensor,
         enc_input_pos: torch.Tensor,
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    ) -> torch.Tensor:
         # Conv1: cat state + chunk, raw Conv1d (no CausalConv1d padding)
         # (1, 128, 2+8=10) -> conv1(k=3, s=1) -> (1, 1280, 8)
-        conv1_input = torch.cat([conv1_state, mel_chunk], dim=2)
+        conv1_input = torch.cat([self.conv1_state, mel_chunk], dim=2)
         conv1_out = F.gelu(self.conv1(conv1_input))
-        new_conv1_state = mel_chunk[:, :, -2:]
+        # Update conv1 state in-place with last 2 frames from input
+        self.conv1_state.copy_(conv1_input[:, :, -2:])
 
         # Conv2: cat state + conv1_out, raw Conv1d
         # (1, 1280, 2+8=10) -> conv2(k=3, s=2) -> (1, 1280, 4)
-        conv2_input = torch.cat([conv2_state, conv1_out], dim=2)
+        conv2_input = torch.cat([self.conv2_state, conv1_out], dim=2)
         conv2_out = F.gelu(self.conv2(conv2_input))
-        new_conv2_state = conv1_out[:, :, -2:]
+        # Update conv2 state in-place with last 2 frames from conv1_out
+        self.conv2_state.copy_(conv2_input[:, :, -2:])
 
         x = conv2_out.transpose(1, 2)  # (1, 4, 1280)
 
@@ -873,7 +876,7 @@ class StreamingAudioEncoderExport(nn.Module):
 
         audio_embeds = self.adapter(x)  # (1, 1, 3072)
 
-        return audio_embeds, new_conv1_state, new_conv2_state
+        return audio_embeds
 
 
 # ---------------------------------------------------------------------------

--- a/examples/models/voxtral_realtime/model.py
+++ b/examples/models/voxtral_realtime/model.py
@@ -506,6 +506,56 @@ class StandardSDPA(nn.Module):
         return y.view(bsz, seqlen, self.dim)
 
 
+class StandardEncoderSDPA(nn.Module):
+    """Standard SDPA for encoder using F.scaled_dot_product_attention.
+
+    Compatible with AOTI/Metal backend. Works with EncoderRingKVCache that uses
+    [B, S, H, D] layout and sliding window masks.
+    """
+
+    def __init__(self, n_heads: int, head_dim: int):
+        super().__init__()
+        self.n_heads = n_heads
+        self.head_dim = head_dim
+        self.dim = n_heads * head_dim
+
+    def forward(
+        self,
+        input_pos: torch.Tensor,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        bsz: int,
+        seqlen: int,
+        mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """
+        Args:
+            input_pos: (seq_len,) position indices.
+            q: (B, seq_len, n_heads, head_dim) in [B, S, H, D] layout.
+            k, v: (B, buf_size, n_heads, head_dim) in [B, S, H, D] layout from EncoderRingKVCache.
+            bsz, seqlen: batch size and query sequence length.
+            mask: (seq_len, buf_size) additive attention mask (0.0 = attend, -inf = don't attend).
+        Returns:
+            output: (B, seq_len, n_heads * head_dim).
+        """
+        # Convert from [B, S, H, D] to [B, H, S, D] for F.scaled_dot_product_attention
+        q = q.transpose(1, 2)  # [B, n_heads, seq_len, head_dim]
+        k = k.transpose(1, 2)  # [B, n_heads, buf_size, head_dim]
+        v = v.transpose(1, 2)  # [B, n_heads, buf_size, head_dim]
+
+        # Apply SDPA with sliding window mask
+        y = F.scaled_dot_product_attention(
+            q, k, v,
+            attn_mask=mask,
+            is_causal=False,  # We handle masking explicitly via mask parameter
+        )  # [B, n_heads, seq_len, head_dim]
+
+        # Convert back to [B, S, H, D] and flatten
+        y = y.transpose(1, 2).contiguous()  # [B, seq_len, n_heads, head_dim]
+        return y.view(bsz, seqlen, self.dim)
+
+
 class LMAttention(nn.Module):
     """GQA with RoPE, KV cache, and SDPA. No biases.
 
@@ -751,6 +801,56 @@ class EncoderRingKVCache(nn.Module):
         return torch.where(valid, 0.0, float("-inf"))
 
 
+class StandardEncoderRingKVCache(nn.Module):
+    """Export-friendly ring buffer KV cache using index_copy_ for updates.
+
+    Compatible with torch.export and AOTI. Uses [B, S, H, D] layout
+    matching the encoder's convention. Ring buffer enables unlimited streaming.
+    """
+
+    def __init__(self, window_size: int, n_heads: int, head_dim: int):
+        super().__init__()
+        self.window_size = window_size
+        self.buf_size = window_size * 2
+        cache_shape = (1, self.buf_size, n_heads, head_dim)
+        self.register_buffer("k_cache", torch.zeros(cache_shape))
+        self.register_buffer("v_cache", torch.zeros(cache_shape))
+
+    def update(
+        self, input_pos: torch.Tensor, k_val: torch.Tensor, v_val: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Write k_val/v_val into ring buffer using index_copy_ (export-friendly).
+
+        Args:
+            input_pos: (seq_len,) position indices.
+            k_val, v_val: (B, seq_len, n_heads, head_dim) in [B, S, H, D] layout.
+        Returns:
+            k_cache, v_cache: (B, buf_size, n_heads, head_dim) in [B, S, H, D] layout.
+        """
+        start_pos = input_pos[0].item()
+        torch._check_is_size(start_pos)
+        seq_len = k_val.size(1)
+
+        # Compute wraparound indices
+        indices = (torch.arange(seq_len, dtype=torch.long, device=k_val.device) + start_pos) % self.buf_size
+
+        # Use index_copy_ on dimension 1 (sequence dimension in [B, S, H, D])
+        self.k_cache.index_copy_(1, indices, k_val)
+        self.v_cache.index_copy_(1, indices, v_val)
+
+        return self.k_cache, self.v_cache
+
+    def create_causal_mask(self, start_pos: int, seq_len: int) -> torch.Tensor:
+        """Create sliding window attention mask."""
+        total_written = start_pos + seq_len
+        j = torch.arange(self.buf_size, dtype=torch.long)
+        cache_pos = j + ((total_written - 1 - j) // self.buf_size) * self.buf_size
+        pos_q = (start_pos + torch.arange(seq_len, dtype=torch.long)).view(-1, 1)
+        delta = pos_q - cache_pos.unsqueeze(0)
+        valid = (cache_pos >= 0) & (delta >= 0) & (delta < self.window_size)
+        return torch.where(valid, 0.0, float("-inf"))
+
+
 class StreamingAudioEncoderExport(nn.Module):
     """Streaming encoder: processes one 8-mel-frame chunk at a time.
 
@@ -784,15 +884,20 @@ class StreamingAudioEncoderExport(nn.Module):
         # Ring buffer KV caches for unlimited streaming.
         # Window size = max_enc_len (encoder sliding window from params.json).
         # Buffer is 2x internally for safe wraparound.
+        # Choose cache implementation based on backend
+        cache_class = StandardEncoderRingKVCache if config.use_standard_attention else EncoderRingKVCache
         self.kv_caches = nn.ModuleList(
             [
-                EncoderRingKVCache(max_enc_len, config.enc_n_heads, config.enc_head_dim)
+                cache_class(max_enc_len, config.enc_n_heads, config.enc_head_dim)
                 for _ in range(config.enc_n_layers)
             ]
         )
 
-        # SDPA for encoder MHA (n_heads=32, head_dim=64 -> attn_dim=2048)
-        self.sdpa = SDPA(config.enc_n_heads, config.enc_head_dim)
+        # Choose SDPA based on backend
+        if config.use_standard_attention:
+            self.sdpa = StandardEncoderSDPA(config.enc_n_heads, config.enc_head_dim)
+        else:
+            self.sdpa = SDPA(config.enc_n_heads, config.enc_head_dim)
 
         # RoPE inverse frequencies for on-the-fly computation.
         # No pre-computed buffer — supports unlimited streaming positions.

--- a/examples/models/voxtral_realtime/voxtral_realtime_runner.cpp
+++ b/examples/models/voxtral_realtime/voxtral_realtime_runner.cpp
@@ -486,8 +486,7 @@ bool StreamingSession::try_process_step() {
   // --- Run streaming encoder ---
   // Conv states are now maintained internally as buffers
   auto enc_result = runner_.model_->execute(
-      "encode_audio_chunk",
-      std::vector<EValue>{*mel_chunk, *enc_pos});
+      "encode_audio_chunk", std::vector<EValue>{*mel_chunk, *enc_pos});
   ET_CHECK_MSG(enc_result.ok(), "encode_audio_chunk failed.");
 
   auto& enc_outputs = enc_result.get();

--- a/examples/models/voxtral_realtime/voxtral_realtime_runner.cpp
+++ b/examples/models/voxtral_realtime/voxtral_realtime_runner.cpp
@@ -360,13 +360,7 @@ StreamingSession::StreamingSession(
           ::executorch::extension::llm::kTopp,
           static_cast<unsigned long long>(std::time(nullptr))),
       input_embeds_buf_(static_cast<size_t>(runner.dim_)) {
-  // Initialize conv states to zero (matches offline encoder's left-padding).
-  // num_mel_bins=128, conv1_pad_=2 → 128*2 = 256 floats
-  conv1_state_.assign(
-      static_cast<size_t>(runner.num_mel_bins_ * runner.conv1_pad_), 0.0f);
-  // enc_dim_=1280, conv2_pad_=2 → 1280*2 = 2560 floats
-  conv2_state_.assign(
-      static_cast<size_t>(runner.enc_dim_ * runner.conv2_pad_), 0.0f);
+  // Conv states are now maintained internally as buffers in the encoder
 }
 
 int StreamingSession::feed_audio(const float* data, int64_t num_samples) {
@@ -480,18 +474,6 @@ bool StreamingSession::try_process_step() {
       {1, static_cast<int>(num_mel_bins), static_cast<int>(chunk_mel_len)},
       ::executorch::aten::ScalarType::Float);
 
-  auto conv1_state = from_blob(
-      conv1_state_.data(),
-      {1, static_cast<int>(num_mel_bins), static_cast<int>(runner_.conv1_pad_)},
-      ::executorch::aten::ScalarType::Float);
-
-  auto conv2_state = from_blob(
-      conv2_state_.data(),
-      {1,
-       static_cast<int>(runner_.enc_dim_),
-       static_cast<int>(runner_.conv2_pad_)},
-      ::executorch::aten::ScalarType::Float);
-
   std::vector<int64_t> enc_pos_data(static_cast<size_t>(enc_frames_per_chunk));
   for (int64_t i = 0; i < enc_frames_per_chunk; i++) {
     enc_pos_data[static_cast<size_t>(i)] = enc_frame_pos_ + i;
@@ -502,24 +484,15 @@ bool StreamingSession::try_process_step() {
       ::executorch::aten::ScalarType::Long);
 
   // --- Run streaming encoder ---
+  // Conv states are now maintained internally as buffers
   auto enc_result = runner_.model_->execute(
       "encode_audio_chunk",
-      std::vector<EValue>{*mel_chunk, *conv1_state, *conv2_state, *enc_pos});
+      std::vector<EValue>{*mel_chunk, *enc_pos});
   ET_CHECK_MSG(enc_result.ok(), "encode_audio_chunk failed.");
 
   auto& enc_outputs = enc_result.get();
   auto audio_embeds = enc_outputs[0].toTensor();
-  auto new_conv1 = enc_outputs[1].toTensor();
-  auto new_conv2 = enc_outputs[2].toTensor();
 
-  std::memcpy(
-      conv1_state_.data(),
-      new_conv1.const_data_ptr<float>(),
-      conv1_state_.size() * sizeof(float));
-  std::memcpy(
-      conv2_state_.data(),
-      new_conv2.const_data_ptr<float>(),
-      conv2_state_.size() * sizeof(float));
   enc_frame_pos_ += enc_frames_per_chunk;
   samples_consumed_ += step;
 

--- a/examples/models/voxtral_realtime/voxtral_realtime_runner.cpp
+++ b/examples/models/voxtral_realtime/voxtral_realtime_runner.cpp
@@ -359,9 +359,7 @@ StreamingSession::StreamingSession(
           config.temperature,
           ::executorch::extension::llm::kTopp,
           static_cast<unsigned long long>(std::time(nullptr))),
-      input_embeds_buf_(static_cast<size_t>(runner.dim_)) {
-  // Conv states are now maintained internally as buffers in the encoder
-}
+      input_embeds_buf_(static_cast<size_t>(runner.dim_)) {}
 
 int StreamingSession::feed_audio(const float* data, int64_t num_samples) {
   audio_buf_.insert(audio_buf_.end(), data, data + num_samples);
@@ -484,7 +482,6 @@ bool StreamingSession::try_process_step() {
       ::executorch::aten::ScalarType::Long);
 
   // --- Run streaming encoder ---
-  // Conv states are now maintained internally as buffers
   auto enc_result = runner_.model_->execute(
       "encode_audio_chunk", std::vector<EValue>{*mel_chunk, *enc_pos});
   ET_CHECK_MSG(enc_result.ok(), "encode_audio_chunk failed.");

--- a/examples/models/voxtral_realtime/voxtral_realtime_runner.h
+++ b/examples/models/voxtral_realtime/voxtral_realtime_runner.h
@@ -136,9 +136,7 @@ class StreamingSession {
   std::vector<float> audio_buf_;
   int64_t samples_consumed_ = 0;
 
-  // Encoder streaming state
-  std::vector<float> conv1_state_;
-  std::vector<float> conv2_state_;
+  // Encoder streaming state (conv states are now internal buffers)
   int64_t enc_frame_pos_ = 0;
 
   // Decoder state


### PR DESCRIPTION
This pull request enables running the Voxtral Realtime streaming mode on Metal backend. It refactors the Voxtral Realtime streaming encoder to maintain convolutional (conv) states as internal buffers within the encoder module, rather than passing them explicitly as inputs and outputs. It also introduces AOTI-friendly streaming attention and KV cache implementations.

**Streaming Encoder Refactor (Python & C++):**
- The streaming encoder (`StreamingAudioEncoderExport` in `model.py`) now manages `conv1_state` and `conv2_state` as internal buffers, removing the need to pass these states as explicit inputs/outputs in both Python and C++ runner code.

**Export and Backend Compatibility:**
- Introduces `StandardEncoderSDPA` and `StandardEncoderRingKVCache` classes for AOTI-compatibility, enabling export-friendly streaming attention and KV caching. The encoder dynamically selects the appropriate implementation based on configuration.
- Adjusts how the causal mask is created to avoid using `.item()` on tensors, which is necessary for AOTI export compatibility.

**Metal Backend AOTI Configuration:**
- Sets `"padding_stride_threshold": float("inf")` in Metal backend options to avoid padding stride.

**Auto-detection Logic for Streaming Mode:**
- Updates shell scripts (`export_model_artifact.sh` and `test_model_e2e.sh`) to auto-enable streaming for both XNNPACK and Metal devices.