### PR TITLE
Update HiFi1 to use nnlib (#17676)

### DIFF
--- a/backends/cadence/hifi/operators/op_quantized_linear_out.cpp
+++ b/backends/cadence/hifi/operators/op_quantized_linear_out.cpp
@@ -13,7 +13,6 @@
 #include <optional>
 
 #include <xa_nnlib_api.h>
-#include <xtensa/tie/xt_datacache.h>
 
 #include <executorch/backends/cadence/generic/operators/op_quantized_linear.h>
 #include <executorch/backends/cadence/hifi/kernels/kernels.h>


### PR DESCRIPTION
Summary:

As titled. Was falling back on xtensa.
Adds a few fixes to some operators to enable the build for all cases.

Differential Revision: D94179206
