### PR TITLE
Disable test-openvino-linux job temporarily

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -919,6 +919,7 @@ jobs:
   test-openvino-linux:
     name: test-openvino-linux
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    if: false # TODO: fix https://github.com/pytorch/executorch/issues/17684
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
Temporarily disable the test-openvino-linux job until https://github.com/pytorch/executorch/issues/17684 is fixed.
