### PR TITLE
4/x: Add LoadBackendOptionsMap support to Module::load()

### DIFF
--- a/extension/module/test/targets.bzl
+++ b/extension/module/test/targets.bzl
@@ -37,6 +37,8 @@ def define_common_targets(is_fbcode=False):
                     "//executorch/extension/data_loader:file_data_loader",
                     "//executorch/extension/module:module" + aten_suffix,
                     "//executorch/extension/tensor:tensor" + aten_suffix,
+                    "//executorch/runtime/backend:backend_options",
+                    "//executorch/runtime/backend:backend_options_map",
                     "//executorch/runtime/core/exec_aten/testing_util:tensor_util" + aten_suffix,
                 ],
                 env = modules_env,


### PR DESCRIPTION
Summary:
This diff exposes the `LoadBackendOptionsMap` API at the `Module` level, providing the user-facing interface for configuring backend options at model load time.

Key changes:
- Added `Module::load()` overload accepting `LoadBackendOptionsMap` parameter
- Options are forwarded through the executor layer to backend delegates
- Backward compatible: existing `load()` calls continue to work without options

This completes the end-to-end user flow:
```cpp
// Configure backend options
LoadOptionsBuilder coreml_opts;
coreml_opts.setComputeUnit(LoadOptionsBuilder::ComputeUnit::CPU_AND_GPU);

LoadBackendOptionsMap options;
options.set_options(coreml_opts);

// Load model with options
Module module(model_path);
module.load("forward", options);
```

Reviewed By: larryliu0820

Differential Revision: D92358607


