### PR TITLE
Fix mypy override error in ArmTester.run_method_and_compare_outputs

### DIFF
--- a/backends/arm/test/tester/arm_tester.py
+++ b/backends/arm/test/tester/arm_tester.py
@@ -474,7 +474,8 @@ class ArmTester(Tester):
         rtol: float = 1e-03,
         qtol: int = 0,
         statistics_callback: Callable[[ErrorStatistics], None] | None = None,
-        # Preserve positional compatibility while keeping new flags keyword-only.
+        artifact_dir: Optional[str] = None,
+        artifact_name: Optional[str] = None,
         *,
         reference_stage_type: StageType | None = None,
         compare_callback: Optional[Callable[..., None]] = None,


### PR DESCRIPTION

### Summary
Add missing `artifact_dir` and `artifact_name` positional parameters to match the base class `Tester` signature, resolving the mypy `[override]` incompatibility.

### Test plan
CI