### PR TITLE
Arm backend: Add build support aarch64-linux-musl

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -285,6 +285,20 @@
         "EXECUTORCH_BUILD_PRESET_FILE": "${sourceDir}/tools/cmake/preset/arm_baremetal.cmake",
         "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/examples/arm/ethos-u-setup/arm-none-eabi-gcc.cmake"
       }
+    },
+    {
+      "name": "arm-ethosu-linux",
+      "displayName": "Build ExecuTorch for Arm Ethos-U Linux",
+      "inherits": ["common"],
+      "description": "musl declares __assert_fail with int for line; avoid NDEBUG forward-decl mismatch in Release builds",
+      "cacheVariables": {
+        "EXECUTORCH_BUILD_ARM_ETHOSU_LINUX": "ON",
+        "EXECUTORCH_BUILD_EXECUTOR_RUNNER": "ON",
+        "EXECUTORCH_BUILD_KERNELS_QUANTIZED": "ON",
+        "CMAKE_C_FLAGS_RELEASE": "-UNDEBUG",
+        "CMAKE_CXX_FLAGS_RELEASE": "-UNDEBUG",
+        "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/examples/arm/ethos-u-setup/aarch64-linux-musl-toolchain.cmake"
+      }
     }
   ],
   "buildPresets": [

--- a/backends/arm/runtime/EthosUBackend_Cortex_A.cpp
+++ b/backends/arm/runtime/EthosUBackend_Cortex_A.cpp
@@ -150,7 +150,12 @@ EthosULinuxDeviceCache& get_linux_device_cache() {
   return cache;
 }
 
-const char* inference_status_to_string(EthosU::InferenceStatus status) {
+/*
+ * Used for logging when building in Debug mode, but unused building
+ * for Release.
+ */
+[[maybe_unused]] const char* inference_status_to_string(
+    EthosU::InferenceStatus status) {
   switch (status) {
     case EthosU::InferenceStatus::OK:
       return "OK";
@@ -288,11 +293,10 @@ Error invoke_linux_driver(
 
     if (options.enable_cycle_counter) {
       try {
-        uint64_t cycles = inference->getCycleCounter();
         ET_LOG(
             Info,
             "Ethos-U Linux delegate cycle counter: %llu",
-            static_cast<unsigned long long>(cycles));
+            static_cast<unsigned long long>(inference->getCycleCounter()));
       } catch (const std::exception& e) {
         ET_LOG(Debug, "Failed to read Ethos-U cycle counter: %s", e.what());
       }

--- a/backends/arm/scripts/build_executor_runner.sh
+++ b/backends/arm/scripts/build_executor_runner.sh
@@ -50,7 +50,7 @@ help() {
     echo "  --output=<FOLDER>                    Output folder Default: <MODEL>/<MODEL>_<TARGET INFO>.pte"
     echo "  --et_build_root=<FOLDER>             Build output root folder to use, defaults to ${et_build_root}"
     echo "  --ethosu_tools_dir=<FOLDER>          Path to your Ethos-U tools dir if you not using default: ${ethosu_tools_dir}"
-    echo "  --toolchain=<TOOLCHAIN>              Toolchain can be specified (e.g. bare metal as arm-none-eabi-gcc or zephyr as arm-zephyr-eabi-gcc Default: ${toolchain}"
+    echo "  --toolchain=<TOOLCHAIN>              Toolchain can be specified (arm-none-eabi-gcc, arm-zephyr-eabi-gcc). Default: ${toolchain}"
     echo "  --select_ops_list=<OPS>              Comma separated list of portable (non delagated) kernels to include Default: ${select_ops_list}"
     echo "                                         NOTE: This is used when select_ops_model is not possible to use, e.g. for semihosting or bundleio."
     echo "                                         See https://docs.pytorch.org/executorch/stable/kernel-library-selective-build.html for more information."
@@ -82,6 +82,11 @@ if [[ ${toolchain} == "arm-none-eabi-gcc" ]]; then
     toolchain_cmake=${et_root_dir}/examples/arm/ethos-u-setup/${toolchain}.cmake
 elif [[ ${toolchain} == "arm-zephyr-eabi-gcc" ]]; then
     toolchain_cmake=${et_root_dir}/examples/zephyr/x86_64-linux-arm-zephyr-eabi-gcc.cmake
+elif [[ ${toolchain} == "aarch64-linux-musl-gcc" ]]; then
+    echo "Error: aarch64-linux-musl-gcc is not supported for this bare-metal runner."
+    echo "       Use executorch/backends/arm/scripts/build_executorch.sh with aarch64-linux-musl-gcc"
+    echo "       or run the direct drive CMake flow to build executor_runner for Linux."
+    exit 1;
 else
     echo "Error: Invalid toolchain selection, provided: ${toolchain}"
     echo "    Valid options are {arm-none-eabi-gcc, arm-zephyr-eabi-gcc}"

--- a/backends/arm/scripts/build_executorch.sh
+++ b/backends/arm/scripts/build_executorch.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -23,6 +23,7 @@ et_build_root="${et_root_dir}/arm_test"
 build_type="Release"
 build_devtools=OFF
 build_with_etdump=OFF
+is_linux_musl=0
 
 help() {
     echo "Usage: $(basename $0) [options]"
@@ -31,7 +32,7 @@ help() {
     echo "  --build_type=<TYPE>       Build with Release, Debug, RelWithDebInfo, UndefinedSanitizer or AddressSanitizer, default is ${build_type}"
     echo "  --devtools                Build Devtools libs"
     echo "  --etdump                  Adds Devtools etdump support to track timing, etdump area will be base64 encoded in the log"
-    echo "  --toolchain=<TOOLCHAIN>   Toolchain can be specified (e.g. bare metal as arm-none-eabi-gcc or zephyr as arm-zephyr-eabi-gcc Default: ${toolchain}"
+    echo "  --toolchain=<TOOLCHAIN>   Toolchain can be specified (arm-none-eabi-gcc, arm-zephyr-eabi-gcc, aarch64-linux-musl-gcc). Default: ${toolchain}"
     exit 0
 }
 
@@ -52,9 +53,12 @@ if [[ ${toolchain} == "arm-none-eabi-gcc" ]]; then
     toolchain_cmake=${et_root_dir}/examples/arm/ethos-u-setup/${toolchain}.cmake
 elif [[ ${toolchain} == "arm-zephyr-eabi-gcc" ]]; then
     toolchain_cmake=${et_root_dir}/examples/zephyr/x86_64-linux-arm-zephyr-eabi-gcc.cmake
+elif [[ ${toolchain} == "aarch64-linux-musl-gcc" ]]; then
+    toolchain_cmake=${et_root_dir}/examples/arm/ethos-u-setup/aarch64-linux-musl-toolchain.cmake
+    is_linux_musl=1
 else
     echo "Error: Invalid toolchain selection, provided: ${toolchain}"
-    echo "    Valid options are {arm-none-eabi-gcc, arm-zephyr-eabi-gcc}"
+    echo "    Valid options are {arm-none-eabi-gcc, arm-zephyr-eabi-gcc, aarch64-linux-musl-gcc}"
     exit 1;
 fi
 toolchain_cmake=$(realpath ${toolchain_cmake})
@@ -76,18 +80,42 @@ cd "${et_root_dir}"
     echo "Build ExecuTorch target libs ${build_type} into '${et_build_dir}'" ;
     echo "--------------------------------------------------------------------------------" )
 
-# Build
-cmake -DCMAKE_TOOLCHAIN_FILE=${toolchain_cmake} \
--DCMAKE_BUILD_TYPE=${build_type} \
--DEXECUTORCH_BUILD_DEVTOOLS=$build_devtools \
--DEXECUTORCH_BUILD_ARM_ETDUMP=$build_with_etdump \
---preset arm-baremetal -B${et_build_dir}
+cmake_args=(
+    -DCMAKE_TOOLCHAIN_FILE=${toolchain_cmake}
+    -DCMAKE_BUILD_TYPE=${build_type}
+    -DEXECUTORCH_BUILD_DEVTOOLS=${build_devtools}
+    -DEXECUTORCH_BUILD_ARM_ETDUMP=${build_with_etdump}
+)
+
+if [[ ${is_linux_musl} -eq 1 ]]; then
+    if [[ -z "${MUSL_TOOLCHAIN_ROOT:-}" ]]; then
+        echo "Error: MUSL_TOOLCHAIN_ROOT is required for aarch64-linux-musl-gcc."
+        echo "       Source ${setup_path_script} after running examples/arm/setup.sh --target-toolchain linux-musl."
+        exit 1
+    fi
+    cmake -S "${et_root_dir}" -B "${et_build_dir}" \
+        "${cmake_args[@]}" \
+        --preset arm-ethosu-linux \
+        -DPYTHON_EXECUTABLE=$(which python3)
+else
+    cmake -S "${et_root_dir}" -B "${et_build_dir}" \
+        "${cmake_args[@]}" \
+        --preset arm-baremetal
+fi
 
 parallel_jobs="$(get_parallel_jobs)"
 
-cmake --build ${et_build_dir} -j"${parallel_jobs}" --target install --config ${build_type} --
+if [[ ${is_linux_musl} -eq 1 ]]; then
+    cmake --build ${et_build_dir} -j"${parallel_jobs}" --target executorch_delegate_ethos_u executor_runner --config ${build_type} --
+else
+    cmake --build ${et_build_dir} -j"${parallel_jobs}" --target install --config ${build_type} --
+fi
 
 set +x
 
-echo "[$(basename $0)] Generated static libraries for ExecuTorch:"
-find ${et_build_dir} -name "*.a" -exec ls -al {} \;
+if [[ ${is_linux_musl} -eq 1 ]]; then
+    echo "[$(basename $0)] Built ExecuTorch targets in ${et_build_dir}"
+else
+    echo "[$(basename $0)] Generated static libraries for ExecuTorch:"
+    find ${et_build_dir} -name "*.a" -exec ls -al {} \;
+fi

--- a/backends/arm/scripts/utils.sh
+++ b/backends/arm/scripts/utils.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -136,6 +136,11 @@ function prepend_env_in_setup_path() {
 function append_env_in_setup_path() {
     echo "export $1=\${$1-}:$2" >> ${setup_path_script}.sh
     echo "set --path -agx $1 $2" >> ${setup_path_script}.fish
+}
+
+function set_env_in_setup_path() {
+    echo "export $1=$2" >> ${setup_path_script}.sh
+    echo "set -gx $1 $2" >> ${setup_path_script}.fish
 }
 
 function clear_setup_path() {

--- a/examples/arm/setup.sh
+++ b/examples/arm/setup.sh
@@ -35,6 +35,7 @@ enable_mlsdk_pip_install=1
 toolchain_url=""
 toolchain_dir=""
 toolchain_md5_checksum=""
+toolchain_archive=""
 
 # Load logging helpers early so option parsing can emit status messages.
 source "$et_dir/backends/arm/scripts/utils.sh"
@@ -45,6 +46,7 @@ OPTION_LIST=(
   "--i-agree-to-the-contained-eula (required) Agree to the EULA"
   "--root-dir Path to scratch directory"
   "--enable-baremetal-toolchain Enable baremetal toolchain setup"
+  "--target-toolchain Select toolchain: gnu (default), zephyr, or linux-musl"
   "--enable-fvps Enable FVP setup"
   "--enable-vela Enable VELA setup"
   "--enable-model-converter Enable MLSDK model converter setup"


### PR DESCRIPTION
Add support for aarch64-linux-musl as a toolchain in setup.sh and building the executor_runner as a Linux binary used for direct drive.

To download the toolchain and setup the development environment: examples/arm/setup.sh \
--i-agree-to-the-contained-eula \
--target-toolchain linux-musl

To build the binary:
backends/arm/scripts/build_executorch.sh \
--toolchain=aarch64-linux-musl-gcc --build_type=Debug


Change-Id: If0335b41754be598647dfef08bf23aae1a72409f



cc @digantdesai @SS-JIA @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell