### PR TITLE
[ET-VK][testing] Add ETVK_FORCE_NO_EXTENSIONS debug flag

### DIFF
--- a/backends/vulkan/runtime/vk_api/Adapter.h
+++ b/backends/vulkan/runtime/vk_api/Adapter.h
@@ -179,6 +179,9 @@ class Adapter final {
   // Physical Device Features
 
   inline bool supports_16bit_storage_buffers() {
+#ifdef ETVK_FORCE_NO_EXTENSIONS
+    return false;
+#endif
 #ifdef VK_KHR_16bit_storage
     return physical_device_.shader_16bit_storage.storageBuffer16BitAccess ==
         VK_TRUE;
@@ -188,6 +191,9 @@ class Adapter final {
   }
 
   inline bool supports_8bit_storage_buffers() {
+#ifdef ETVK_FORCE_NO_EXTENSIONS
+    return false;
+#endif
 #ifdef VK_KHR_8bit_storage
     return physical_device_.shader_8bit_storage.storageBuffer8BitAccess ==
         VK_TRUE;
@@ -197,6 +203,9 @@ class Adapter final {
   }
 
   inline bool supports_float16_shader_types() {
+#ifdef ETVK_FORCE_NO_EXTENSIONS
+    return false;
+#endif
 #ifdef VK_KHR_shader_float16_int8
     return physical_device_.shader_float16_int8_types.shaderFloat16 == VK_TRUE;
 #else
@@ -205,6 +214,9 @@ class Adapter final {
   }
 
   inline bool supports_int8_shader_types() {
+#ifdef ETVK_FORCE_NO_EXTENSIONS
+    return false;
+#endif
 #ifdef VK_KHR_shader_float16_int8
     return physical_device_.shader_float16_int8_types.shaderInt8 == VK_TRUE;
 #else
@@ -213,6 +225,9 @@ class Adapter final {
   }
 
   inline bool supports_int8_dot_product() {
+#ifdef ETVK_FORCE_NO_EXTENSIONS
+    return false;
+#endif
 #ifdef VK_KHR_shader_integer_dot_product
     return physical_device_.shader_int_dot_product_features
                .shaderIntegerDotProduct == VK_TRUE;
@@ -222,6 +237,9 @@ class Adapter final {
   }
 
   inline bool supports_nv_cooperative_matrix2() {
+#ifdef ETVK_FORCE_NO_EXTENSIONS
+    return false;
+#endif
 #ifdef VK_NV_cooperative_matrix2
     return physical_device_.cooperative_matrix2_features
                .cooperativeMatrixWorkgroupScope == VK_TRUE &&
@@ -235,14 +253,23 @@ class Adapter final {
   }
 
   inline bool supports_int16_shader_types() {
+#ifdef ETVK_FORCE_NO_EXTENSIONS
+    return false;
+#endif
     return physical_device_.supports_int16_shader_types;
   }
 
   inline bool supports_int64_shader_types() {
+#ifdef ETVK_FORCE_NO_EXTENSIONS
+    return false;
+#endif
     return physical_device_.supports_int64_shader_types;
   }
 
   inline bool supports_float64_shader_types() {
+#ifdef ETVK_FORCE_NO_EXTENSIONS
+    return false;
+#endif
     return physical_device_.supports_float64_shader_types;
   }
 

--- a/backends/vulkan/targets.bzl
+++ b/backends/vulkan/targets.bzl
@@ -20,6 +20,7 @@ def get_vulkan_preprocessor_flags(no_volk, is_fbcode):
     android_flags = []
 
     debug_mode = read_config("etvk", "debug", "0") == "1"
+    force_no_extensions = read_config("etvk", "force_no_extensions", "0") == "1"
 
     if not no_volk:
         for flags in [default_flags, android_flags]:
@@ -67,6 +68,9 @@ def get_vulkan_preprocessor_flags(no_volk, is_fbcode):
 
         if debug_mode:
             VK_API_PREPROCESSOR_FLAGS += ["-DVULKAN_DEBUG"]
+
+    if force_no_extensions:
+        VK_API_PREPROCESSOR_FLAGS += ["-DETVK_FORCE_NO_EXTENSIONS"]
 
     return VK_API_PREPROCESSOR_FLAGS
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #17705
* #17704
* #17703

Add a build config flag `etvk.force_no_extensions` that causes all
Vulkan extension support queries in Adapter.h to return false. This
makes it easy to test fallback code paths for devices that lack
optional extensions (e.g. 8-bit storage buffers, float16, dot product)
on a development host that would otherwise report support for them.

Enable with: --config etvk.force_no_extensions=1

Differential Revision: [D94314257](https://our.internmc.facebook.com/intern/diff/D94314257/)