### PR TITLE
[ET-VK] Add Vulkan ops for skin segmentation and EdgeTAM models

### DIFF
--- a/backends/vulkan/runtime/graph/ops/glsl/binary_op.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/binary_op.yaml
@@ -116,3 +116,11 @@ binary_op:
           - VALUE: half
           - VALUE: float
           - VALUE: int32
+    - NAME: binary_bitwise_and
+      OPERATOR: X & Y
+      generate_variant_forall:
+        STORAGE:
+          - VALUE: buffer
+          - VALUE: texture3d
+        DTYPE:
+          - VALUE: uint8

--- a/backends/vulkan/runtime/graph/ops/glsl/reduce_per_row_buffer.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/reduce_per_row_buffer.glsl
@@ -115,7 +115,7 @@ void main() {
 #endif
 
 #ifdef OUTPUT_IS_INDICES
-    t_out[out_bufi] = int(0); // int(local_accum.idx);
+    t_out[out_bufi] = int(local_accum.idx);
 #else
     t_out[out_bufi] = convert_to_T(local_accum.val);
 #endif

--- a/backends/vulkan/runtime/graph/ops/glsl/where.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/where.glsl
@@ -1,5 +1,3 @@
-// where.glsl
-
 /*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  * All rights reserved.
@@ -7,7 +5,6 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-
 
 #version 450 core
 
@@ -24,44 +21,50 @@ ${define_active_storage_type(STORAGE)}
 
 layout(std430) buffer;
 
+#include "indexing.glslh"
+
 ${layout_declare_tensor(B, "w", "t_out", DTYPE, STORAGE)}
 ${layout_declare_tensor(B, "r", "t_condition", "bool", STORAGE)}
 ${layout_declare_tensor(B, "r", "t_self", DTYPE, STORAGE)}
 ${layout_declare_tensor(B, "r", "t_other", DTYPE, STORAGE)}
 
-
-#include "indexing_utils.h"
-
 $if STORAGE == "buffer":
-  ${layout_declare_ubo(B, "int", "out_numl")}
-  ${layout_declare_ubo(B, "ivec4", "out_strides")}
-  ${layout_declare_ubo(B, "ivec4", "cond_strides")}
-  ${layout_declare_ubo(B, "ivec4", "self_strides")}
-  ${layout_declare_ubo(B, "ivec4", "other_strides")}
+  ${layout_declare_ubo(B, "BufferMetadata", "outp")}
+  ${layout_declare_ubo(B, "BufferMetadata", "condp")}
+  ${layout_declare_ubo(B, "BufferMetadata", "selfp")}
+  ${layout_declare_ubo(B, "BufferMetadata", "otherp")}
 $else:
-  ${layout_declare_ubo(B, "ivec3", "out_limits")}
-
-${layout_declare_spec_const(C, "int", "out_layout", "DEFAULT_DIM_ORDER")}
-
-const lowp ivec4 out_dim_order = unhash_dim_order(out_layout);
+  ${layout_declare_ubo(B, "TextureMetadata", "outp")}
+  ${layout_declare_ubo(B, "TextureMetadata", "condp")}
+  ${layout_declare_ubo(B, "TextureMetadata", "selfp")}
+  ${layout_declare_ubo(B, "TextureMetadata", "otherp")}
 
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
 
 #ifdef USING_BUFFER
 
 void main() {
-  int out_bufi = int(gl_GlobalInvocationID.x);
-  if (out_bufi >= out_numl) {
+  const uint out_bufi = gl_GlobalInvocationID.x;
+  if (out_of_bounds(out_bufi, outp)) {
     return;
   }
 
-  const ivec4 out_tidx = bufi_to_tidx(out_bufi, out_strides, out_dim_order);
+  TensorIndex out_tidx = linear_idx_to_tensor_idx(outp, out_bufi);
 
-  const int cond_bufi = tidx_to_bufi(out_tidx, cond_strides);
-  const int self_bufi = tidx_to_bufi(out_tidx, self_strides);
-  const int other_bufi = tidx_to_bufi(out_tidx, other_strides);
+  TensorIndex cond_tidx = out_tidx;
+  clamp_tensor_idx(condp, cond_tidx);
 
-  COND_T cond = t_condition[cond_bufi] ;
+  TensorIndex self_tidx = out_tidx;
+  clamp_tensor_idx(selfp, self_tidx);
+
+  TensorIndex other_tidx = out_tidx;
+  clamp_tensor_idx(otherp, other_tidx);
+
+  const uint cond_bufi = tensor_idx_to_linear_idx(condp, cond_tidx);
+  const uint self_bufi = tensor_idx_to_linear_idx(selfp, self_tidx);
+  const uint other_bufi = tensor_idx_to_linear_idx(otherp, other_tidx);
+
+  COND_T cond = t_condition[cond_bufi];
   T v_self = t_self[self_bufi];
   T v_other = t_other[other_bufi];
 
@@ -72,29 +75,49 @@ void main() {
   }
 }
 
-#else // !USING_BUFFER
+#else // USING_TEXTURE
 
 void main() {
-  const ivec3 pos = ivec3(gl_GlobalInvocationID);
+  const ivec3 out_pos = ivec3(gl_GlobalInvocationID);
 
-
-  if (any(greaterThanEqual(pos, out_limits))) {
+  if (out_of_bounds(out_pos, outp)) {
     return;
   }
 
-  vec4 cond = load_texel(t_condition, pos);
-  VEC4_T selftex = load_texel(t_self, pos);
-  VEC4_T othertex = load_texel(t_other, pos);
+  TensorIndex4D out_tidx = texture_pos_to_tensor4d_idx_simple(outp, out_pos);
 
-  VEC4_T outtex;
+  VEC4_T outtex = VEC4_T(0);
 
-  for (int idx = 0; idx < 4; ++idx) {
-    if (cond[idx] == 1) {
-      outtex[idx] = selftex[idx];
+  int limit = min(
+      4, outp.sizes[outp.packed_dim] - out_tidx.data[outp.packed_dim]);
+  for (int comp = 0; comp < limit; comp++) {
+    TensorIndex4D cond_tidx;
+    cond_tidx.data = min(out_tidx.data, condp.sizes - 1);
+    TextureElementIndex cond_elem =
+        tensor4d_idx_to_texture_element_idx_simple(condp, cond_tidx);
+    uint cond_val = texelFetch(t_condition, cond_elem.pos, 0)[cond_elem.comp];
+
+    TensorIndex4D self_tidx;
+    self_tidx.data = min(out_tidx.data, selfp.sizes - 1);
+    TextureElementIndex self_elem =
+        tensor4d_idx_to_texture_element_idx_simple(selfp, self_tidx);
+    VEC4_T self_texel = texelFetch(t_self, self_elem.pos, 0);
+
+    TensorIndex4D other_tidx;
+    other_tidx.data = min(out_tidx.data, otherp.sizes - 1);
+    TextureElementIndex other_elem =
+        tensor4d_idx_to_texture_element_idx_simple(otherp, other_tidx);
+    VEC4_T other_texel = texelFetch(t_other, other_elem.pos, 0);
+
+    if (cond_val > 0) {
+      outtex[comp] = self_texel[self_elem.comp];
     } else {
-      outtex[idx] = othertex[idx];
+      outtex[comp] = other_texel[other_elem.comp];
     }
+
+    out_tidx.data[outp.packed_dim]++;
   }
-  write_texel(t_out, pos, outtex);
+
+  imageStore(t_out, out_pos, outtex);
 }
- #endif // !USING_BUFFER
+#endif

--- a/backends/vulkan/runtime/graph/ops/impl/BinaryOp.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/BinaryOp.cpp
@@ -198,6 +198,7 @@ DEFINE_BINARY_OP_FN(lt);
 DEFINE_BINARY_OP_FN(le);
 DEFINE_BINARY_OP_FN(gt);
 DEFINE_BINARY_OP_FN(ge);
+DEFINE_BINARY_OP_FN(bitwise_and);
 
 REGISTER_OPERATORS {
   VK_REGISTER_OP(aten.add.Tensor, add);
@@ -212,6 +213,7 @@ REGISTER_OPERATORS {
   VK_REGISTER_OP(aten.le.Tensor, le);
   VK_REGISTER_OP(aten.gt.Tensor, gt);
   VK_REGISTER_OP(aten.ge.Tensor, ge);
+  VK_REGISTER_OP(aten.bitwise_and.Tensor, bitwise_and);
 }
 
 } // namespace vkcompute

--- a/backends/vulkan/test/op_tests/cases.py
+++ b/backends/vulkan/test/op_tests/cases.py
@@ -2001,6 +2001,29 @@ def get_where_inputs():
     return test_suite
 
 
+@register_test_suite("aten.bitwise_and.Tensor")
+def get_bitwise_and_inputs():
+    test_suite = VkTestSuite(
+        [
+            ((M1, M2), (M1, M2)),
+            ((S, S1, S2), (S, S1, S2)),
+            ((XS, S, S1, S2), (XS, S, S1, S2)),
+            ((1, M1), (1, M1)),
+        ]
+    )
+    test_suite.layouts = [
+        "utils::kWidthPacked",
+        "utils::kChannelsPacked",
+    ]
+    test_suite.storage_types = [
+        "utils::kBuffer",
+        "utils::kTexture3D",
+    ]
+    test_suite.dtypes = ["at::kBool"]
+    test_suite.data_gen = "make_seq_tensor"
+    return test_suite
+
+
 @register_test_suite("aten.pow.Tensor_Scalar")
 def get_pow_tensor_scalar_inputs():
     test_suite = VkTestSuite(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #17710
* __->__ #17709
* #17708
* #17707

Implement several missing Vulkan operators needed to reduce graph
fragmentation in the skin segmentation and EdgeTAM models.

**Skin segmentation ops:**

- aten.where.self: already had C++ and GLSL implementations but was
  missing the Python partitioner registration.
- aten.bitwise_and.Tensor: added as a new binary_op shader variant
  operating on uint8 (bool) tensors.

**EdgeTAM partitioning fixes:**

- Comparison ops (eq, lt, le, gt, ge): were registered under the
  generic BinaryOp features which inherited FP_INT_T as the output
  dtype set. The partitioner correctly rejected these because their
  outputs are bool tensors. Split them into a dedicated
  register_comparison_ops registration with outputs_dtypes=BOOL_T. The
  binary_op.glsl shader already handles bool output via the
  IS_COMPARISON_OP path (uint8 storage), so no shader changes are
  needed.
- aten.copy.default: not in the op registry, causing a subgraph break
  in the first-frame model. This op appears when valid_num_points.to()
  is called with matching dtype (a no-op cast). Add it to
  RemoveRedundantOpsTransform so it is eliminated before the partitioner
  runs. Also register it as an ephemeral op as a fallback. The removal
  logic requires a _src_arg1_ops set to handle the copy.default(self,
  src) argument order, where the replacement target is args[1] (src)
  rather than args[0] (self) as in all other redundant ops.

Differential Revision: [D94364641](https://our.internmc.facebook.com/intern/diff/D94364641/)

cc @manuelcandales @digantdesai @cbilgin