### PR TITLE
Enable CUDA wheel builds for Linux

### DIFF
--- a/.github/workflows/build-wheels-linux.yml
+++ b/.github/workflows/build-wheels-linux.yml
@@ -30,7 +30,7 @@ jobs:
       os: linux
       test-infra-repository: pytorch/test-infra
       test-infra-ref: main
-      with-cuda: disabled
+      with-cuda: enable
       with-rocm: disabled
       python-versions: '["3.10", "3.11", "3.12", "3.13"]'
 


### PR DESCRIPTION
CUDA was explicitly disabled in the Linux wheel build workflow. Enable it so the reusable workflow from pytorch/test-infra generates wheels for the CUDA versions in PyTorch's support matrix (currently 12.6, 12.8, 13.0).
