### PR TITLE
Enable rss logs for lora test

### DIFF
--- a/.ci/scripts/test_lora.sh
+++ b/.ci/scripts/test_lora.sh
@@ -12,7 +12,8 @@ source "$(dirname "${BASH_SOURCE[0]}")/utils.sh"
 cmake_install_executorch_libraries() {
     echo "Installing libexecutorch.a, libextension_module.so, libportable_ops_lib.a"
     rm -rf cmake-out
-    cmake --workflow llm-release
+    cmake --preset llm-release -DEXECUTORCH_ENABLE_LOGGING=ON
+    cmake --build --preset llm-release-install
 }
 
 cmake_build_llama_runner() {

--- a/.ci/scripts/test_lora_multimethod.sh
+++ b/.ci/scripts/test_lora_multimethod.sh
@@ -12,7 +12,8 @@ source "$(dirname "${BASH_SOURCE[0]}")/utils.sh"
 cmake_install_executorch_libraries() {
     echo "Installing libexecutorch.a, libextension_module.so, libportable_ops_lib.a"
     rm -rf cmake-out
-    cmake --workflow llm-release
+    cmake --preset llm-release -DEXECUTORCH_ENABLE_LOGGING=ON
+    cmake --build --preset llm-release-install
 }
 
 cmake_build_llama_runner() {


### PR DESCRIPTION
### Summary
Enable RSS logs for the lora test. Easy to check values from CI, rather than exporting and running locally.

### Test plan
CI

Confirm RSS logs
```
I 00:00:33.468142 executorch:text_llm_runner.cpp:95] RSS after loading model: 1782.023438 MiB (0 if unsupported)
I 00:00:33.469817 executorch:text_llm_runner.cpp:158] Max new tokens resolved: 85, given pos_ 0, num_prompt_tokens 15, max_context_len 2048
I 00:00:33.988239 executorch:text_prefiller.cpp:92] Prefill token result numel(): 151936
I 00:00:33.988522 executorch:text_llm_runner.cpp:191] RSS after prompt prefill: 1782.023438 MiB (0 if unsupported)
I 00:01:04.162348 executorch:text_token_generator.h:134] 
Reached to the end of generation
I 00:01:04.162366 executorch:text_llm_runner.cpp:220] RSS after finishing text generation: 1782.023438 MiB (0 if unsupported)
```
