### PR TITLE
Download QNN SDK outside of CMake for wheel builds

### DIFF
--- a/.ci/scripts/wheel/pre_build_script.sh
+++ b/.ci/scripts/wheel/pre_build_script.sh
@@ -44,3 +44,16 @@ fi
 # able to see the installed torch package.
 
 "${GITHUB_WORKSPACE}/${REPOSITORY}/install_requirements.sh" --example
+
+# Download Qualcomm QNN SDK on Linux x86_64 so the wheel build can include the
+# QNN backend.  The SDK is large, so we download it here (outside CMake) rather
+# than during cmake configure.
+if [[ "$(uname -s)" == "Linux" && "$(uname -m)" == "x86_64" ]]; then
+  echo "Downloading Qualcomm QNN SDK..."
+  QNN_SDK_ROOT=$(python3 \
+    "${GITHUB_WORKSPACE}/${REPOSITORY}/backends/qualcomm/scripts/download_qnn_sdk.py" \
+    --print-sdk-path)
+  export QNN_SDK_ROOT
+  echo "QNN_SDK_ROOT=${QNN_SDK_ROOT}" >> "${GITHUB_ENV}"
+  echo "QNN SDK downloaded to ${QNN_SDK_ROOT}"
+fi

--- a/.ci/scripts/wheel/test_linux.py
+++ b/.ci/scripts/wheel/test_linux.py
@@ -5,10 +5,25 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import platform
+
 import test_base
 from examples.models import Backend, Model
 
 if __name__ == "__main__":
+    # On Linux x86_64 the wheel is built with the Qualcomm backend.
+    # Verify that it was registered correctly.
+    if platform.system() == "Linux" and platform.machine() in ("x86_64", "amd64"):
+        from executorch.extension.pybindings.portable_lib import (
+            _get_registered_backend_names,
+        )
+
+        registered = _get_registered_backend_names()
+        assert (
+            "QnnBackend" in registered
+        ), f"QnnBackend not found in registered backends: {registered}"
+        print("✓ QnnBackend is registered")
+
     test_base.run_tests(
         model_tests=[
             test_base.ModelTest(

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -16,7 +16,6 @@ jobs:
   test-qnn-wheel-packages-linux:
     name: test-qnn-wheel-packages-linux
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
-    if: false
     permissions:
       id-token: write
       contents: read

--- a/backends/qualcomm/CMakeLists.txt
+++ b/backends/qualcomm/CMakeLists.txt
@@ -23,9 +23,19 @@ get_filename_component(
   _common_include_directories "${EXECUTORCH_SOURCE_DIR}/.." ABSOLUTE
 )
 
-# We only download QNN SDK when we build pip wheel for ExecuTorch. Please don't
-# change this code unless you know what you are doing.
-if(EXECUTORCH_BUILD_WHEEL_DO_NOT_USE)
+# If QNN_SDK_ROOT was not passed as a CMake variable, fall back to the
+# environment variable.  Prefer downloading the SDK *outside* of CMake (e.g. via
+# backends/qualcomm/scripts/download_qnn_sdk.py) and passing the path in.
+if(NOT DEFINED QNN_SDK_ROOT AND DEFINED ENV{QNN_SDK_ROOT})
+  set(QNN_SDK_ROOT
+      $ENV{QNN_SDK_ROOT}
+      CACHE PATH "Qualcomm SDK root directory" FORCE
+  )
+endif()
+
+# Last-resort fallback: download during cmake configure when building wheels and
+# QNN_SDK_ROOT was not provided externally.
+if(NOT DEFINED QNN_SDK_ROOT AND EXECUTORCH_BUILD_WHEEL_DO_NOT_USE)
   set(_qnn_default_sdk_dir "${CMAKE_CURRENT_BINARY_DIR}/sdk/qnn")
 
   if(EXISTS "${_qnn_default_sdk_dir}" AND EXISTS "${_qnn_default_sdk_dir}/lib")
@@ -35,7 +45,7 @@ if(EXECUTORCH_BUILD_WHEEL_DO_NOT_USE)
         CACHE PATH "Qualcomm SDK root directory" FORCE
     )
   else()
-    message(STATUS "Downloading Qualcomm SDK")
+    message(STATUS "Downloading Qualcomm SDK (fallback)")
     execute_process(
       COMMAND
         ${PYTHON_EXECUTABLE}

--- a/setup.py
+++ b/setup.py
@@ -706,6 +706,17 @@ class CustomBuild(build):
         ):
             cmake_configuration_args += ["-DEXECUTORCH_BUILD_CUDA=ON"]
 
+        # Check if QNN SDK is available (via QNN_SDK_ROOT env var), and if so,
+        # enable building the Qualcomm backend by default.
+        qnn_sdk_root = os.environ.get("QNN_SDK_ROOT", "").strip()
+        if qnn_sdk_root and install_utils.is_cmake_option_on(
+            cmake_configuration_args, "EXECUTORCH_BUILD_QNN", default=True
+        ):
+            cmake_configuration_args += [
+                "-DEXECUTORCH_BUILD_QNN=ON",
+                f"-DQNN_SDK_ROOT={qnn_sdk_root}",
+            ]
+
         with Buck2EnvironmentFixer():
             # Generate the cmake cache from scratch to ensure that the cache state
             # is predictable.

--- a/tools/cmake/preset/pybind.cmake
+++ b/tools/cmake/preset/pybind.cmake
@@ -37,7 +37,7 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   set_overridable_option(EXECUTORCH_BUILD_EXTENSION_LLM_RUNNER ON)
   set_overridable_option(EXECUTORCH_BUILD_EXTENSION_LLM ON)
   if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|amd64|i.86)$")
-    set_overridable_option(EXECUTORCH_BUILD_QNN OFF)
+    set_overridable_option(EXECUTORCH_BUILD_QNN ON)
   endif()
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows" OR CMAKE_SYSTEM_NAME STREQUAL
                                                "WIN32"


### PR DESCRIPTION
Move the Qualcomm QNN SDK download from cmake configure time to the pre-build stage in CI. setup.py now auto-detects QNN_SDK_ROOT and enables EXECUTORCH_BUILD_QNN, matching the existing CUDA pattern. The cmake download logic is preserved as a last-resort fallback.

Re-enable the test-qnn-wheel-packages-linux CI job and add a QnnBackend registration check to the Linux wheel smoke test.

