### PR TITLE
Share state in module

### DIFF
--- a/extension/module/module.cpp
+++ b/extension/module/module.cpp
@@ -80,7 +80,8 @@ Module::Module(
     const LoadMode load_mode,
     std::unique_ptr<runtime::EventTracer> event_tracer,
     std::unique_ptr<runtime::MemoryAllocator> memory_allocator,
-    std::unique_ptr<runtime::MemoryAllocator> temp_allocator)
+    std::unique_ptr<runtime::MemoryAllocator> temp_allocator,
+    bool share_memory_arenas)
     : file_path_(file_path),
       load_mode_(load_mode),
       memory_allocator_(
@@ -89,7 +90,8 @@ Module::Module(
       temp_allocator_(
           temp_allocator ? std::move(temp_allocator)
                          : std::make_unique<MallocMemoryAllocator>()),
-      event_tracer_(std::move(event_tracer)) {
+      event_tracer_(std::move(event_tracer)),
+      share_memory_arenas_(share_memory_arenas) {
   runtime::runtime_init();
 }
 
@@ -99,7 +101,8 @@ Module::Module(
     const LoadMode load_mode,
     std::unique_ptr<runtime::EventTracer> event_tracer,
     std::unique_ptr<runtime::MemoryAllocator> memory_allocator,
-    std::unique_ptr<runtime::MemoryAllocator> temp_allocator)
+    std::unique_ptr<runtime::MemoryAllocator> temp_allocator,
+    bool share_memory_arenas)
     : file_path_(file_path),
       load_mode_(load_mode),
       memory_allocator_(
@@ -108,7 +111,8 @@ Module::Module(
       temp_allocator_(
           temp_allocator ? std::move(temp_allocator)
                          : std::make_unique<MallocMemoryAllocator>()),
-      event_tracer_(std::move(event_tracer)) {
+      event_tracer_(std::move(event_tracer)),
+      share_memory_arenas_(share_memory_arenas) {
   if (!data_map_path.empty()) {
     data_files_.push_back(data_map_path);
   }
@@ -121,7 +125,8 @@ Module::Module(
     const LoadMode load_mode,
     std::unique_ptr<runtime::EventTracer> event_tracer,
     std::unique_ptr<runtime::MemoryAllocator> memory_allocator,
-    std::unique_ptr<runtime::MemoryAllocator> temp_allocator)
+    std::unique_ptr<runtime::MemoryAllocator> temp_allocator,
+    bool share_memory_arenas)
     : file_path_(file_path),
       data_files_(std::move(data_files)),
       load_mode_(load_mode),
@@ -131,7 +136,8 @@ Module::Module(
       temp_allocator_(
           temp_allocator ? std::move(temp_allocator)
                          : std::make_unique<MallocMemoryAllocator>()),
-      event_tracer_(std::move(event_tracer)) {
+      event_tracer_(std::move(event_tracer)),
+      share_memory_arenas_(share_memory_arenas) {
   runtime::runtime_init();
 }
 
@@ -140,7 +146,8 @@ Module::Module(
     std::unique_ptr<runtime::MemoryAllocator> memory_allocator,
     std::unique_ptr<runtime::MemoryAllocator> temp_allocator,
     std::unique_ptr<runtime::EventTracer> event_tracer,
-    std::unique_ptr<runtime::DataLoader> data_map_loader)
+    std::unique_ptr<runtime::DataLoader> data_map_loader,
+    bool share_memory_arenas)
     : data_loader_(std::move(data_loader)),
       memory_allocator_(
           memory_allocator ? std::move(memory_allocator)
@@ -148,7 +155,8 @@ Module::Module(
       temp_allocator_(
           temp_allocator ? std::move(temp_allocator)
                          : std::make_unique<MallocMemoryAllocator>()),
-      event_tracer_(std::move(event_tracer)) {
+      event_tracer_(std::move(event_tracer)),
+      share_memory_arenas_(share_memory_arenas) {
   if (data_map_loader) {
     data_map_loaders_.push_back(std::move(data_map_loader));
   }
@@ -160,7 +168,8 @@ Module::Module(
     std::unique_ptr<runtime::MemoryAllocator> memory_allocator,
     std::unique_ptr<runtime::MemoryAllocator> temp_allocator,
     std::unique_ptr<runtime::EventTracer> event_tracer,
-    std::unique_ptr<runtime::DataLoader> data_map_loader)
+    std::unique_ptr<runtime::DataLoader> data_map_loader,
+    bool share_memory_arenas)
     : program_(std::move(program)),
       memory_allocator_(
           memory_allocator ? std::move(memory_allocator)
@@ -168,7 +177,8 @@ Module::Module(
       temp_allocator_(
           temp_allocator ? std::move(temp_allocator)
                          : std::make_unique<MallocMemoryAllocator>()),
-      event_tracer_(std::move(event_tracer)) {
+      event_tracer_(std::move(event_tracer)),
+      share_memory_arenas_(share_memory_arenas) {
   if (data_map_loader) {
     data_map_loaders_.push_back(std::move(data_map_loader));
   }
@@ -264,6 +274,82 @@ runtime::Result<std::unordered_set<std::string>> Module::method_names() {
   return result;
 }
 
+std::unique_ptr<Module::PlannedMemory> Module::make_planned_memory(
+    const std::vector<size_t>& buffer_sizes) {
+  auto planned = std::make_unique<PlannedMemory>();
+  planned->planned_buffers.reserve(buffer_sizes.size());
+  planned->planned_spans.reserve(buffer_sizes.size());
+  for (size_t size : buffer_sizes) {
+    planned->planned_buffers.emplace_back(size);
+    planned->planned_spans.emplace_back(
+        planned->planned_buffers.back().data(), size);
+  }
+  planned->planned_memory =
+      std::make_unique<runtime::HierarchicalAllocator>(runtime::Span(
+          planned->planned_spans.data(), planned->planned_spans.size()));
+  return planned;
+}
+
+std::unique_ptr<Module::PlannedMemory>
+Module::make_planned_memory_with_shared_arenas(
+    const std::vector<size_t>& buffer_sizes,
+    std::vector<std::vector<uint8_t>>& shared_arenas) {
+  auto planned = std::make_unique<PlannedMemory>();
+  planned->planned_buffers.reserve(buffer_sizes.size());
+  planned->planned_spans.reserve(buffer_sizes.size());
+  for (size_t i = 0; i < buffer_sizes.size(); i++) {
+    if (i < shared_arenas.size()) {
+      planned->planned_buffers.emplace_back();
+      planned->planned_spans.emplace_back(
+          shared_arenas[i].data(), shared_arenas[i].size());
+    } else {
+      planned->planned_buffers.emplace_back(buffer_sizes[i]);
+      planned->planned_spans.emplace_back(
+          planned->planned_buffers.back().data(), buffer_sizes[i]);
+    }
+  }
+  planned->planned_memory =
+      std::make_unique<runtime::HierarchicalAllocator>(runtime::Span(
+          planned->planned_spans.data(), planned->planned_spans.size()));
+  return planned;
+}
+
+runtime::Result<std::vector<size_t>> Module::get_mem_planned_buffer_sizes(
+    const std::string& method_name) {
+  auto meta_res = program_->method_meta(method_name.c_str());
+  ET_CHECK_OK_OR_RETURN_ERROR(meta_res.error());
+  auto meta = meta_res.get();
+  std::vector<size_t> sizes;
+  sizes.reserve(meta.num_memory_planned_buffers());
+  for (size_t i = 0; i < meta.num_memory_planned_buffers(); i++) {
+    auto size = meta.memory_planned_buffer_size(i);
+    ET_CHECK_OK_OR_RETURN_ERROR(size.error());
+    sizes.push_back(size.get());
+  }
+  return sizes;
+}
+
+runtime::Result<std::vector<size_t>>
+Module::get_max_mem_planned_buffer_sizes() {
+  std::vector<size_t> result;
+  auto method_names_res = method_names();
+  ET_CHECK_OK_OR_RETURN_ERROR(method_names_res.error());
+  for (const auto& name : method_names_res.get()) {
+    auto sizes_res = get_mem_planned_buffer_sizes(name);
+    ET_CHECK_OK_OR_RETURN_ERROR(sizes_res.error());
+    auto& sizes = sizes_res.get();
+    if (sizes.size() > result.size()) {
+      result.resize(sizes.size(), 0);
+    }
+    for (size_t i = 0; i < sizes.size(); i++) {
+      if (sizes[i] > result[i]) {
+        result[i] = sizes[i];
+      }
+    }
+  }
+  return result;
+}
+
 runtime::Error Module::load_method(
     const std::string& method_name,
     runtime::HierarchicalAllocator* planned_memory,
@@ -279,29 +365,30 @@ runtime::Error Module::load_method(
     MethodHolder method_holder;
 
     if (!planned_memory) {
-      auto method_metadata_result = program_->method_meta(method_name.c_str());
-      if (!method_metadata_result.ok()) {
-        return method_metadata_result.error();
+      if (!share_memory_arenas_) {
+        auto sizes_res = get_mem_planned_buffer_sizes(method_name);
+        ET_CHECK_OK_OR_RETURN_ERROR(sizes_res.error());
+        method_holder.planned_memory = make_planned_memory(sizes_res.get());
+      } else {
+        auto sizes_res = get_mem_planned_buffer_sizes(method_name);
+        ET_CHECK_OK_OR_RETURN_ERROR(sizes_res.error());
+        auto& sizes = sizes_res.get();
+        if (shared_arenas_.empty()) {
+          auto max_res = get_max_mem_planned_buffer_sizes();
+          ET_CHECK_OK_OR_RETURN_ERROR(max_res.error());
+          auto& max_sizes = max_res.get();
+          // Only share for mem_id=1,2.
+          size_t shared = (max_sizes.size() > 2) ? 2 : max_sizes.size();
+          for (size_t i = 0; i < shared; i++) {
+            shared_arenas_.emplace_back(max_sizes[i]);
+          }
+        }
+        method_holder.planned_memory =
+            make_planned_memory_with_shared_arenas(sizes, shared_arenas_);
       }
-      const auto method_metadata = std::move(*method_metadata_result);
-      const auto planned_buffers_count =
-          method_metadata.num_memory_planned_buffers();
-      method_holder.planned_buffers.reserve(planned_buffers_count);
-      method_holder.planned_spans.reserve(planned_buffers_count);
-
-      for (auto index = 0; index < planned_buffers_count; ++index) {
-        const auto buffer_size =
-            method_metadata.memory_planned_buffer_size(index).get();
-        method_holder.planned_buffers.emplace_back(buffer_size);
-        method_holder.planned_spans.emplace_back(
-            method_holder.planned_buffers.back().data(), buffer_size);
-      }
-      method_holder.planned_memory =
-          std::make_unique<runtime::HierarchicalAllocator>(runtime::Span(
-              method_holder.planned_spans.data(),
-              method_holder.planned_spans.size()));
-      planned_memory = method_holder.planned_memory.get();
+      planned_memory = method_holder.planned_memory->planned_memory.get();
     }
+
     method_holder.memory_manager = std::make_unique<runtime::MemoryManager>(
         memory_allocator_.get(), planned_memory, temp_allocator_.get());
     auto res_method = program_->load_method(

--- a/extension/module/module.h
+++ b/extension/module/module.h
@@ -60,13 +60,29 @@ class Module {
    * @param[in] file_path The path to the ExecuTorch program file to load.
    * @param[in] load_mode The loading mode to use.
    * @param[in] event_tracer A EventTracer used for tracking and logging events.
+   * @param[in] share_memory_arenas When true, all methods loaded by this Module
+   * share the same memory-planned buffers for mem_id=1 (activation memory)
+   * and mem_id=2 (shared mutable buffer memory), sized to the max
+   * across all methods. mem_id>2 indicates a custom memory plan, and those
+   * receive fresh memory buffers. share_memory_arenas is required for models
+   * exported with share_mutable_buffers=true, where methods access shared
+   * mutable state (e.g., set/get state). When enabled, outputs from one method
+   * may be invalidated by executing another method, since their output tensors
+   * can alias the same underlying buffer. Consume or copy outputs before
+   * calling execute again. NOTE: This class is not thread-safe and performs
+   * no internal synchronization. Calling execute concurrently on the same
+   * Module instance from multiple threads is unsafe, regardless of whether
+   * share_memory_arenas is true or false. When share_memory_arenas is true,
+   * methods may overwrite each other's data in the shared memory arenas,
+   * increasing aliasing and the risk of unintended overwrites.
    */
   explicit Module(
       const std::string& file_path,
       const LoadMode load_mode = LoadMode::File,
       std::unique_ptr<runtime::EventTracer> event_tracer = nullptr,
       std::unique_ptr<runtime::MemoryAllocator> memory_allocator = nullptr,
-      std::unique_ptr<runtime::MemoryAllocator> temp_allocator = nullptr);
+      std::unique_ptr<runtime::MemoryAllocator> temp_allocator = nullptr,
+      bool share_memory_arenas = false);
 
   /**
    * Constructs an instance by loading a program from a file with specified
@@ -76,6 +92,8 @@ class Module {
    * @param[in] data_map_path The path to a .ptd file.
    * @param[in] load_mode The loading mode to use.
    * @param[in] event_tracer A EventTracer used for tracking and logging events.
+   * @param[in] share_memory_arenas When true, all methods loaded by this Module
+   * share a single set of memory-planned buffers.
    */
   explicit Module(
       const std::string& file_path,
@@ -83,7 +101,8 @@ class Module {
       const LoadMode load_mode = LoadMode::File,
       std::unique_ptr<runtime::EventTracer> event_tracer = nullptr,
       std::unique_ptr<runtime::MemoryAllocator> memory_allocator = nullptr,
-      std::unique_ptr<runtime::MemoryAllocator> temp_allocator = nullptr);
+      std::unique_ptr<runtime::MemoryAllocator> temp_allocator = nullptr,
+      bool share_memory_arenas = false);
 
   /**
    * Constructs an instance by loading a program from a file with specified
@@ -93,6 +112,8 @@ class Module {
    * @param[in] data_files The path to one or more .ptd file/s.
    * @param[in] load_mode The loading mode to use.
    * @param[in] event_tracer A EventTracer used for tracking and logging events.
+   * @param[in] share_memory_arenas When true, all methods loaded by this Module
+   * share a single set of memory-planned buffers.
    */
   explicit Module(
       const std::string& file_path,
@@ -100,7 +121,8 @@ class Module {
       const LoadMode load_mode = LoadMode::File,
       std::unique_ptr<runtime::EventTracer> event_tracer = nullptr,
       std::unique_ptr<runtime::MemoryAllocator> memory_allocator = nullptr,
-      std::unique_ptr<runtime::MemoryAllocator> temp_allocator = nullptr);
+      std::unique_ptr<runtime::MemoryAllocator> temp_allocator = nullptr,
+      bool share_memory_arenas = false);
 
   /**
    * Constructs an instance with the provided data loader and memory allocator.
@@ -111,13 +133,16 @@ class Module {
    * temporary data during kernel or delegate execution.
    * @param[in] event_tracer A EventTracer used for tracking and logging events.
    * @param[in] data_map_loader A DataLoader used for loading external weights.
+   * @param[in] share_memory_arenas When true, all methods loaded by this Module
+   * share a single set of memory-planned buffers.
    */
   explicit Module(
       std::unique_ptr<runtime::DataLoader> data_loader,
       std::unique_ptr<runtime::MemoryAllocator> memory_allocator = nullptr,
       std::unique_ptr<runtime::MemoryAllocator> temp_allocator = nullptr,
       std::unique_ptr<runtime::EventTracer> event_tracer = nullptr,
-      std::unique_ptr<runtime::DataLoader> data_map_loader = nullptr);
+      std::unique_ptr<runtime::DataLoader> data_map_loader = nullptr,
+      bool share_memory_arenas = false);
 
   /**
    * Constructs an instance using an existing shared program.
@@ -129,13 +154,16 @@ class Module {
    * temporary data.
    * @param[in] event_tracer A EventTracer used for tracking and logging events.
    * @param[in] data_map_loader A DataLoader used for loading external weights.
+   * @param[in] share_memory_arenas When true, all methods loaded by this Module
+   * share a single set of memory-planned buffers.
    */
   explicit Module(
       std::shared_ptr<Program> program,
       std::unique_ptr<runtime::MemoryAllocator> memory_allocator = nullptr,
       std::unique_ptr<runtime::MemoryAllocator> temp_allocator = nullptr,
       std::unique_ptr<runtime::EventTracer> event_tracer = nullptr,
-      std::unique_ptr<runtime::DataLoader> data_map_loader = nullptr);
+      std::unique_ptr<runtime::DataLoader> data_map_loader = nullptr,
+      bool share_memory_arenas = false);
 
   Module(const Module&) = delete;
   Module& operator=(const Module&) = delete;
@@ -650,10 +678,22 @@ class Module {
   }
 
  private:
-  struct MethodHolder {
+  struct PlannedMemory {
     std::vector<std::vector<uint8_t>> planned_buffers;
     std::vector<runtime::Span<uint8_t>> planned_spans;
     std::unique_ptr<runtime::HierarchicalAllocator> planned_memory;
+  };
+  std::unique_ptr<PlannedMemory> make_planned_memory(
+      const std::vector<size_t>& buffer_sizes);
+  std::unique_ptr<PlannedMemory> make_planned_memory_with_shared_arenas(
+      const std::vector<size_t>& buffer_sizes,
+      std::vector<std::vector<uint8_t>>& shared_arenas);
+  runtime::Result<std::vector<size_t>> get_mem_planned_buffer_sizes(
+      const std::string& method_name);
+  runtime::Result<std::vector<size_t>> get_max_mem_planned_buffer_sizes();
+
+  struct MethodHolder {
+    std::unique_ptr<PlannedMemory> planned_memory;
     std::unique_ptr<runtime::MemoryManager> memory_manager;
     std::unique_ptr<Method> method;
   };
@@ -669,8 +709,10 @@ class Module {
   std::vector<std::unique_ptr<runtime::DataLoader>> data_map_loaders_;
   std::vector<std::unique_ptr<NamedDataMap>> named_data_maps_;
   std::unique_ptr<NamedDataMap> merged_data_map_;
+  std::vector<std::vector<uint8_t>> shared_arenas_;
   ET_DEPRECATED std::vector<uint8_t> debug_buffer_;
   const LoadBackendOptionsMap* backend_options_ = nullptr;
+  bool share_memory_arenas_;
 
   ET_NODISCARD runtime::Error load_internal(
       const Program::Verification verification);

--- a/extension/module/test/CMakeLists.txt
+++ b/extension/module/test/CMakeLists.txt
@@ -25,8 +25,9 @@ add_custom_command(
          "${CMAKE_CURRENT_BINARY_DIR}/ModuleAddMulProgram.ptd"
          "${CMAKE_CURRENT_BINARY_DIR}/ModuleLinearProgram.pte"
          "${CMAKE_CURRENT_BINARY_DIR}/ModuleLinearProgram.ptd"
+         "${CMAKE_CURRENT_BINARY_DIR}/ModuleSharedState.pte"
   COMMAND ${PYTHON_EXECUTABLE} -m test.models.export_program --modules
-          "ModuleAdd" --outdir "${CMAKE_CURRENT_BINARY_DIR}"
+          "ModuleAdd,ModuleSharedState" --outdir "${CMAKE_CURRENT_BINARY_DIR}"
   COMMAND
     ${PYTHON_EXECUTABLE} -m test.models.export_program --modules
     "ModuleAddMul,ModuleLinear" --external-constants --outdir
@@ -41,6 +42,7 @@ add_custom_target(
           "${CMAKE_CURRENT_BINARY_DIR}/ModuleAddMulProgram.ptd"
           "${CMAKE_CURRENT_BINARY_DIR}/ModuleLinearProgram.pte"
           "${CMAKE_CURRENT_BINARY_DIR}/ModuleLinearProgram.ptd"
+          "${CMAKE_CURRENT_BINARY_DIR}/ModuleSharedState.pte"
 )
 
 set(test_env
@@ -49,6 +51,7 @@ set(test_env
     "ET_MODULE_ADD_MUL_DATA_PATH=${CMAKE_CURRENT_BINARY_DIR}/ModuleAddMulProgram.ptd"
     "ET_MODULE_LINEAR_PROGRAM_PATH=${CMAKE_CURRENT_BINARY_DIR}/ModuleLinearProgram.pte"
     "ET_MODULE_LINEAR_DATA_PATH=${CMAKE_CURRENT_BINARY_DIR}/ModuleLinearProgram.ptd"
+    "ET_MODULE_SHARED_STATE=${CMAKE_CURRENT_BINARY_DIR}/ModuleSharedState.pte"
 )
 
 et_cxx_test(

--- a/extension/module/test/module_test.cpp
+++ b/extension/module/test/module_test.cpp
@@ -30,6 +30,7 @@ class ModuleTest : public ::testing::Test {
     add_mul_data_path_ = std::getenv("ET_MODULE_ADD_MUL_DATA_PATH");
     linear_path_ = std::getenv("ET_MODULE_LINEAR_PROGRAM_PATH");
     linear_data_path_ = std::getenv("ET_MODULE_LINEAR_DATA_PATH");
+    shared_state_path_ = std::getenv("ET_MODULE_SHARED_STATE");
   }
 
   static inline std::string model_path_;
@@ -37,6 +38,7 @@ class ModuleTest : public ::testing::Test {
   static inline std::string add_mul_data_path_;
   static inline std::string linear_path_;
   static inline std::string linear_data_path_;
+  static inline std::string shared_state_path_;
 };
 
 TEST_F(ModuleTest, TestLoad) {
@@ -717,4 +719,49 @@ TEST_F(ModuleTest, TestMultipleBackendsInOptionsMap) {
   auto tensor = make_tensor_ptr({2, 2}, {1.f, 2.f, 3.f, 4.f});
   const auto result = module.forward({tensor, tensor, 1.0});
   EXPECT_EQ(result.error(), Error::Ok);
+}
+
+TEST_F(ModuleTest, TestSharedMemoryBuffer) {
+  Module module(
+      shared_state_path_,
+      Module::LoadMode::File,
+      /*event_tracer=*/nullptr,
+      /*memory_allocator=*/nullptr,
+      /*temp_allocator=*/nullptr,
+      /*share_memory_arenas=*/true);
+
+  ASSERT_EQ(module.load_method("forward"), Error::Ok);
+  ASSERT_EQ(module.load_method("get_state"), Error::Ok);
+  ASSERT_EQ(module.load_method("set_state"), Error::Ok);
+
+  auto get_state_initial = module.execute("get_state");
+  ASSERT_EQ(get_state_initial.error(), Error::Ok);
+  EXPECT_TENSOR_CLOSE(
+      get_state_initial.get()[0].toTensor(),
+      *make_tensor_ptr({1}, {0.f}).get());
+  auto tensor = make_tensor_ptr({1}, {2.f});
+  auto forward1 = module.forward(tensor);
+  ASSERT_EQ(forward1.error(), Error::Ok);
+  EXPECT_TENSOR_CLOSE(
+      forward1.get()[0].toTensor(), *make_tensor_ptr({1}, {3.f}).get());
+  auto forward2 = module.forward(tensor);
+  ASSERT_EQ(forward2.error(), Error::Ok);
+  EXPECT_TENSOR_CLOSE(
+      forward2.get()[0].toTensor(), *make_tensor_ptr({1}, {4.f}).get());
+  auto get_state_after_forwards = module.execute("get_state");
+  ASSERT_EQ(get_state_after_forwards.error(), Error::Ok);
+  EXPECT_TENSOR_CLOSE(
+      get_state_after_forwards.get()[0].toTensor(),
+      *make_tensor_ptr({1}, {2.f}).get());
+  auto zero_tensor = make_tensor_ptr({1}, {0.f});
+  ASSERT_EQ(module.execute("set_state", zero_tensor).error(), Error::Ok);
+  auto get_state_after_reset = module.execute("get_state");
+  ASSERT_EQ(get_state_after_reset.error(), Error::Ok);
+  EXPECT_TENSOR_CLOSE(
+      get_state_after_reset.get()[0].toTensor(),
+      *make_tensor_ptr({1}, {0.f}).get());
+  auto forward3 = module.forward(tensor);
+  ASSERT_EQ(forward3.error(), Error::Ok);
+  EXPECT_TENSOR_CLOSE(
+      forward3.get()[0].toTensor(), *make_tensor_ptr({1}, {3.f}).get());
 }


### PR DESCRIPTION
### Summary

Taken from [D82329513](https://www.internalfb.com/diff/D82329513)

Allow Module to share activation memory when `share_memory_arenas=True`. 

In a PTE file, each method may have:
mem_id=1: activation memory
mem_id=2: shared memory (usually for shared state)
mem_id>2: custom memory: remains unshared

These are specified in `program.execution_plan[method_index].non_const_buffer_sizes`. Tensors with `mem_id=2` point to the same memory offset across different methods.

In Module.cpp, freshly allocated memory is provided to each method for activation space. This PR creates a shared_buffer and passes it into to each method instead of allocating fresh memory, when `share_memory_arenas=True`. This is only for mem_id=1,2. For mem_id>2, we allocate fresh memory, as this is likely a custom memory plan.

**NOTE**
1. Regular activation memory is also shared (mem_id=1). The largest activation memory for each method is used.

2. I believe this is safe with the existing concurrent execution. In `TestConcurrentExecutionWithSharedProgram`, it's the (immutable) program that is shared. N separate Modules hold a shared_ptr to the same program. So each module has its own memory buffers etc., and sharing is local to the Module and not across threads. I don't think concurrency within a single Module/between methods is supported.
3. Running multiple methods concurrently in the same Module is unsafe, and this PR makes it even more unsafe.

**RISKS**
1. Data invalidation across methods with shared memory
```
  auto m1 = module.execute("m1", {x1});
  auto m2 = module.execute("m2", {x2});
```
m1 and m2 will point to the same output memory buffer when sharing memory (activation memory is shared); m1 must be copied to a separate buffer, otherwise it will store the result of m2.

### Test plan
```
cmake .. \
-DEXECUTORCH_BUILD_TESTS=ON \
-DEXECUTORCH_BUILD_XNNPACK=ON \
-DEXECUTORCH_BUILD_EXTENSION_MODULE=ON \
-DEXECUTORCH_BUILD_EXTENSION_NAMED_DATA_MAP=ON \
-DEXECUTORCH_BUILD_EXTENSION_DATA_LOADER=ON \
-DEXECUTORCH_BUILD_EXTENSION_TENSOR=ON \
-DEXECUTORCH_BUILD_KERNELS_PORTABLE=ON

cmake --build . --target extension_module_test

ctest -R extension_module_test --output-on-failure 
```