### PR TITLE
Move large test assets from APK to adb push

### DIFF
--- a/.github/workflows/_android.yml
+++ b/.github/workflows/_android.yml
@@ -61,12 +61,6 @@ jobs:
             aar-out/executorch.aar
             extension/android/executorch_android/build/outputs/apk/androidTest/debug/executorch_android-debug-androidTest.apk
 
-      - name: Upload push artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: android-push-artifacts
-          path: extension/android/executorch_android/build/push-artifacts/
-
   # Running Android emulator directly on the runner and not using Docker
   run-emulator:
     needs: build-android
@@ -90,12 +84,6 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: android-apps
-
-      - name: Download push artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: android-push-artifacts
-          path: push-artifacts
 
       - name: Prepare test APK
         run: |

--- a/.github/workflows/_android.yml
+++ b/.github/workflows/_android.yml
@@ -61,6 +61,12 @@ jobs:
             aar-out/executorch.aar
             extension/android/executorch_android/build/outputs/apk/androidTest/debug/executorch_android-debug-androidTest.apk
 
+      - name: Upload push artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-push-artifacts
+          path: extension/android/executorch_android/build/push-artifacts/
+
   # Running Android emulator directly on the runner and not using Docker
   run-emulator:
     needs: build-android
@@ -84,6 +90,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: android-apps
+
+      - name: Download push artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: android-push-artifacts
+          path: push-artifacts
 
       - name: Prepare test APK
         run: |

--- a/extension/android/executorch_android/android_test_setup.sh
+++ b/extension/android/executorch_android/android_test_setup.sh
@@ -14,8 +14,7 @@ which "${PYTHON_EXECUTABLE}"
 
 BASEDIR=$(dirname "$(realpath $0)")
 RESOURCES_DIR="${BASEDIR}/src/androidTest/resources"
-PUSH_ARTIFACTS_DIR="${BASEDIR}/build/push-artifacts"
-mkdir -p "${RESOURCES_DIR}" "${PUSH_ARTIFACTS_DIR}"
+mkdir -p "${RESOURCES_DIR}"
 
 prepare_xor() {
   pushd "${BASEDIR}/../../training/"
@@ -25,12 +24,4 @@ prepare_xor() {
   popd
 }
 
-prepare_tinyllama() {
-  local S3_BASE="https://ossci-android.s3.amazonaws.com/executorch/stories/snapshot-20260114"
-  # stories.pte is ~29MB; push via adb instead of bundling in APK
-  curl -C - -Ls "${S3_BASE}/stories110M.pte" --output "${PUSH_ARTIFACTS_DIR}/stories.pte"
-  curl -C - -Ls "${S3_BASE}/tokenizer.model" --output "${RESOURCES_DIR}/tokenizer.bin"
-}
-
 prepare_xor
-prepare_tinyllama

--- a/extension/android/executorch_android/android_test_setup.sh
+++ b/extension/android/executorch_android/android_test_setup.sh
@@ -25,3 +25,24 @@ prepare_xor() {
 }
 
 prepare_xor
+
+# Large test assets (LLM weights, golden XNNPACK outputs) are no longer bundled
+# in the APK. In CI they are downloaded and adb-pushed by scripts/run_android_emulator.sh.
+# For local runs, you must push them yourself before running connectedAndroidTest.
+PUSH_DIR="/data/local/tmp/executorch"
+REQUIRED_ASSETS=(stories.pte tokenizer.bin mobilenet_v2.pte mobilenet_v2_expected_output.bin vit_b_16.pte vit_b_16_expected_output.bin)
+MISSING=()
+for asset in "${REQUIRED_ASSETS[@]}"; do
+  if ! adb shell "[ -f ${PUSH_DIR}/${asset} ]" 2>/dev/null; then
+    MISSING+=("$asset")
+  fi
+done
+if [[ ${#MISSING[@]} -gt 0 ]]; then
+  echo ""
+  echo "WARNING: The following test assets are missing from ${PUSH_DIR} on the device:"
+  printf "  - %s\n" "${MISSING[@]}"
+  echo ""
+  echo "LlmModuleInstrumentationTest and ModuleE2ETest will fail without them."
+  echo "See scripts/run_android_emulator.sh for download URLs and adb push commands."
+  echo ""
+fi

--- a/extension/android/executorch_android/android_test_setup.sh
+++ b/extension/android/executorch_android/android_test_setup.sh
@@ -32,20 +32,5 @@ prepare_tinyllama() {
   curl -C - -Ls "${S3_BASE}/tokenizer.model" --output "${RESOURCES_DIR}/tokenizer.bin"
 }
 
-prepare_golden() {
-  local url="https://gha-artifacts.s3.amazonaws.com/pytorch/executorch/test-backend-artifacts/golden-artifacts-xnnpack/golden_artifacts_26022500.zip"
-  curl -sL -o /tmp/golden.zip "$url"
-  unzip -o /tmp/golden.zip -d /tmp/golden/
-  for model in mobilenet_v2 vit_b_16; do
-    cp /tmp/golden/xnnpack/${model}_input*.bin "${RESOURCES_DIR}/"
-    cp /tmp/golden/xnnpack/${model}_expected_output*.bin "${RESOURCES_DIR}/" 2>/dev/null || echo "Warning: no expected_output files for ${model}"
-  done
-  # mobilenet_v2.pte (~13MB) stays in APK resources
-  cp "/tmp/golden/xnnpack/mobilenet_v2.pte" "${RESOURCES_DIR}/"
-  # vit_b_16.pte (~330MB) is too large for APK; push via adb
-  cp "/tmp/golden/xnnpack/vit_b_16.pte" "${PUSH_ARTIFACTS_DIR}/"
-}
-
 prepare_xor
 prepare_tinyllama
-prepare_golden

--- a/extension/android/executorch_android/android_test_setup.sh
+++ b/extension/android/executorch_android/android_test_setup.sh
@@ -13,19 +13,23 @@ fi
 which "${PYTHON_EXECUTABLE}"
 
 BASEDIR=$(dirname "$(realpath $0)")
+RESOURCES_DIR="${BASEDIR}/src/androidTest/resources"
+PUSH_ARTIFACTS_DIR="${BASEDIR}/build/push-artifacts"
+mkdir -p "${RESOURCES_DIR}" "${PUSH_ARTIFACTS_DIR}"
 
 prepare_xor() {
   pushd "${BASEDIR}/../../training/"
-  python3 -m examples.XOR.export_model  --outdir "${BASEDIR}/src/androidTest/resources/"
-  mv "${BASEDIR}/src/androidTest/resources/xor.pte" "${BASEDIR}/src/androidTest/resources/xor_full.pte"
-  python3 -m examples.XOR.export_model  --outdir "${BASEDIR}/src/androidTest/resources/" --external
+  python3 -m examples.XOR.export_model  --outdir "${RESOURCES_DIR}/"
+  mv "${RESOURCES_DIR}/xor.pte" "${RESOURCES_DIR}/xor_full.pte"
+  python3 -m examples.XOR.export_model  --outdir "${RESOURCES_DIR}/" --external
   popd
 }
 
 prepare_tinyllama() {
   local S3_BASE="https://ossci-android.s3.amazonaws.com/executorch/stories/snapshot-20260114"
-  curl -C - -Ls "${S3_BASE}/stories110M.pte" --output "${BASEDIR}/src/androidTest/resources/stories.pte"
-  curl -C - -Ls "${S3_BASE}/tokenizer.model" --output "${BASEDIR}/src/androidTest/resources/tokenizer.bin"
+  # stories.pte is ~29MB; push via adb instead of bundling in APK
+  curl -C - -Ls "${S3_BASE}/stories110M.pte" --output "${PUSH_ARTIFACTS_DIR}/stories.pte"
+  curl -C - -Ls "${S3_BASE}/tokenizer.model" --output "${RESOURCES_DIR}/tokenizer.bin"
 }
 
 prepare_golden() {
@@ -33,10 +37,13 @@ prepare_golden() {
   curl -sL -o /tmp/golden.zip "$url"
   unzip -o /tmp/golden.zip -d /tmp/golden/
   for model in mobilenet_v2 vit_b_16; do
-    cp "/tmp/golden/xnnpack/${model}.pte" "${BASEDIR}/src/androidTest/resources/"
-    cp /tmp/golden/xnnpack/${model}_input*.bin "${BASEDIR}/src/androidTest/resources/"
-    cp /tmp/golden/xnnpack/${model}_expected_output*.bin "${BASEDIR}/src/androidTest/resources/" 2>/dev/null || echo "Warning: no expected_output files for ${model}"
+    cp /tmp/golden/xnnpack/${model}_input*.bin "${RESOURCES_DIR}/"
+    cp /tmp/golden/xnnpack/${model}_expected_output*.bin "${RESOURCES_DIR}/" 2>/dev/null || echo "Warning: no expected_output files for ${model}"
   done
+  # mobilenet_v2.pte (~13MB) stays in APK resources
+  cp "/tmp/golden/xnnpack/mobilenet_v2.pte" "${RESOURCES_DIR}/"
+  # vit_b_16.pte (~330MB) is too large for APK; push via adb
+  cp "/tmp/golden/xnnpack/vit_b_16.pte" "${PUSH_ARTIFACTS_DIR}/"
 }
 
 prepare_xor

--- a/extension/android/executorch_android/src/androidTest/java/org/pytorch/executorch/LlmModuleInstrumentationTest.kt
+++ b/extension/android/executorch_android/src/androidTest/java/org/pytorch/executorch/LlmModuleInstrumentationTest.kt
@@ -20,6 +20,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.pytorch.executorch.TestFileUtils.getTestFilePath
+import org.pytorch.executorch.TestFileUtils.prepareTestFile
 import org.pytorch.executorch.extension.llm.LlmCallback
 import org.pytorch.executorch.extension.llm.LlmModule
 
@@ -33,19 +34,14 @@ class LlmModuleInstrumentationTest : LlmCallback {
   @Before
   @Throws(IOException::class)
   fun setUp() {
-    // copy zipped test resources to local device
-    val addPteFile = File(getTestFilePath(TEST_FILE_NAME))
-    var inputStream = javaClass.getResourceAsStream(TEST_FILE_NAME)
-    FileUtils.copyInputStreamToFile(inputStream, addPteFile)
-    inputStream.close()
+    val ptePath = prepareTestFile(javaClass, TEST_FILE_NAME)
 
     val tokenizerFile = File(getTestFilePath(TOKENIZER_FILE_NAME))
-    inputStream = javaClass.getResourceAsStream(TOKENIZER_FILE_NAME)
+    val inputStream = javaClass.getResourceAsStream(TOKENIZER_FILE_NAME)
     FileUtils.copyInputStreamToFile(inputStream, tokenizerFile)
     inputStream.close()
 
-    llmModule =
-        LlmModule(getTestFilePath(TEST_FILE_NAME), getTestFilePath(TOKENIZER_FILE_NAME), 0.0f)
+    llmModule = LlmModule(ptePath, tokenizerFile.absolutePath, 0.0f)
   }
 
   @Test

--- a/extension/android/executorch_android/src/androidTest/java/org/pytorch/executorch/LlmModuleInstrumentationTest.kt
+++ b/extension/android/executorch_android/src/androidTest/java/org/pytorch/executorch/LlmModuleInstrumentationTest.kt
@@ -8,10 +8,8 @@
 package org.pytorch.executorch
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import java.io.File
 import java.io.IOException
 import java.net.URISyntaxException
-import org.apache.commons.io.FileUtils
 import org.json.JSONException
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
@@ -19,7 +17,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.pytorch.executorch.TestFileUtils.getTestFilePath
 import org.pytorch.executorch.TestFileUtils.prepareTestFile
 import org.pytorch.executorch.extension.llm.LlmCallback
 import org.pytorch.executorch.extension.llm.LlmModule
@@ -35,13 +32,8 @@ class LlmModuleInstrumentationTest : LlmCallback {
   @Throws(IOException::class)
   fun setUp() {
     val ptePath = prepareTestFile(javaClass, TEST_FILE_NAME)
-
-    val tokenizerFile = File(getTestFilePath(TOKENIZER_FILE_NAME))
-    val inputStream = javaClass.getResourceAsStream(TOKENIZER_FILE_NAME)
-    FileUtils.copyInputStreamToFile(inputStream, tokenizerFile)
-    inputStream.close()
-
-    llmModule = LlmModule(ptePath, tokenizerFile.absolutePath, 0.0f)
+    val tokenizerPath = prepareTestFile(javaClass, TOKENIZER_FILE_NAME)
+    llmModule = LlmModule(ptePath, tokenizerPath, 0.0f)
   }
 
   @Test

--- a/extension/android/executorch_android/src/androidTest/java/org/pytorch/executorch/ModuleE2ETest.kt
+++ b/extension/android/executorch_android/src/androidTest/java/org/pytorch/executorch/ModuleE2ETest.kt
@@ -41,7 +41,8 @@ class ModuleE2ETest {
 
   private fun testGoldenModel(modelName: String, inputShape: LongArray) {
     val inputData = loadFloatArrayFromFile(prepareTestFile(javaClass, "/${modelName}_input.bin"))
-    val expectedOutput = loadFloatArrayFromFile(prepareTestFile(javaClass, "/${modelName}_expected_output.bin"))
+    val expectedOutput =
+        loadFloatArrayFromFile(prepareTestFile(javaClass, "/${modelName}_expected_output.bin"))
     val inputTensor = Tensor.fromBlob(inputData, inputShape)
 
     val ptePath = prepareTestFile(javaClass, "/${modelName}.pte")

--- a/extension/android/executorch_android/src/androidTest/java/org/pytorch/executorch/ModuleE2ETest.kt
+++ b/extension/android/executorch_android/src/androidTest/java/org/pytorch/executorch/ModuleE2ETest.kt
@@ -19,6 +19,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.pytorch.executorch.TestFileUtils.getTestFilePath
+import org.pytorch.executorch.TestFileUtils.prepareTestFile
 
 /** End-to-end tests that verify JNI inference against nightly golden artifacts. */
 @RunWith(AndroidJUnit4::class)
@@ -45,11 +46,8 @@ class ModuleE2ETest {
     val expectedOutput = loadFloatArrayFromResource("/${modelName}_expected_output.bin")
     val inputTensor = Tensor.fromBlob(inputData, inputShape)
 
-    val pteStream = javaClass.getResourceAsStream("/${modelName}.pte")!!
-    val pteFile = File(getTestFilePath("/${modelName}.pte"))
-    FileUtils.copyInputStreamToFile(pteStream, pteFile)
-
-    val module = Module.load(pteFile.absolutePath)
+    val ptePath = prepareTestFile(javaClass, "/${modelName}.pte")
+    val module = Module.load(ptePath)
     val results = module.forward(EValue.from(inputTensor))
     val actualOutput = results[0].toTensor().dataAsFloatArray
 

--- a/extension/android/executorch_android/src/androidTest/java/org/pytorch/executorch/ModuleE2ETest.kt
+++ b/extension/android/executorch_android/src/androidTest/java/org/pytorch/executorch/ModuleE2ETest.kt
@@ -12,21 +12,19 @@ import java.io.File
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import kotlin.math.abs
-import org.apache.commons.io.FileUtils
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.pytorch.executorch.TestFileUtils.getTestFilePath
 import org.pytorch.executorch.TestFileUtils.prepareTestFile
 
 /** End-to-end tests that verify JNI inference against nightly golden artifacts. */
 @RunWith(AndroidJUnit4::class)
 class ModuleE2ETest {
 
-  private fun loadFloatArrayFromResource(path: String): FloatArray {
-    val bytes = javaClass.getResourceAsStream(path)!!.use { it.readBytes() }
+  private fun loadFloatArrayFromFile(path: String): FloatArray {
+    val bytes = File(path).readBytes()
     val buffer = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN)
     return FloatArray(bytes.size / 4).also { buffer.asFloatBuffer().get(it) }
   }
@@ -42,8 +40,8 @@ class ModuleE2ETest {
   }
 
   private fun testGoldenModel(modelName: String, inputShape: LongArray) {
-    val inputData = loadFloatArrayFromResource("/${modelName}_input.bin")
-    val expectedOutput = loadFloatArrayFromResource("/${modelName}_expected_output.bin")
+    val inputData = loadFloatArrayFromFile(prepareTestFile(javaClass, "/${modelName}_input.bin"))
+    val expectedOutput = loadFloatArrayFromFile(prepareTestFile(javaClass, "/${modelName}_expected_output.bin"))
     val inputTensor = Tensor.fromBlob(inputData, inputShape)
 
     val ptePath = prepareTestFile(javaClass, "/${modelName}.pte")
@@ -57,12 +55,8 @@ class ModuleE2ETest {
 
   @Test
   fun testXnnpackBackendRequired() {
-    val pteFile = File(getTestFilePath("/mobilenet_v2.pte"))
-    val inputStream = javaClass.getResourceAsStream("/mobilenet_v2.pte")
-    FileUtils.copyInputStreamToFile(inputStream, pteFile)
-    inputStream.close()
-
-    val module = Module.load(pteFile.absolutePath)
+    val ptePath = prepareTestFile(javaClass, "/mobilenet_v2.pte")
+    val module = Module.load(ptePath)
     val expectedBackends = arrayOf("XnnpackBackend")
     assertArrayEquals(expectedBackends, module.getMethodMetadata("forward").backends)
   }

--- a/extension/android/executorch_android/src/androidTest/java/org/pytorch/executorch/TestFileUtils.kt
+++ b/extension/android/executorch_android/src/androidTest/java/org/pytorch/executorch/TestFileUtils.kt
@@ -1,11 +1,38 @@
 package org.pytorch.executorch
 
 import androidx.test.InstrumentationRegistry
+import java.io.File
+import java.io.FileNotFoundException
+import org.apache.commons.io.FileUtils
 
 /** Test File Utils */
 object TestFileUtils {
 
+  private const val PUSH_DIR = "/data/local/tmp/executorch"
+
   fun getTestFilePath(fileName: String): String {
     return InstrumentationRegistry.getInstrumentation().targetContext.cacheDir.toString() + fileName
+  }
+
+  /**
+   * Resolve a test file by checking the adb push directory first, then falling back to APK
+   * resources. Returns an absolute file path usable by native code.
+   */
+  fun prepareTestFile(caller: Class<*>, resourceName: String): String {
+    val pushed = File("$PUSH_DIR$resourceName")
+    if (pushed.exists()) {
+      return pushed.absolutePath
+    }
+    val cached = File(getTestFilePath(resourceName))
+    if (!cached.exists()) {
+      val stream =
+          caller.getResourceAsStream(resourceName)
+              ?: throw FileNotFoundException(
+                  "$resourceName not found in $PUSH_DIR or APK resources"
+              )
+      FileUtils.copyInputStreamToFile(stream, cached)
+      stream.close()
+    }
+    return cached.absolutePath
   }
 }

--- a/scripts/run_android_emulator.sh
+++ b/scripts/run_android_emulator.sh
@@ -27,6 +27,12 @@ if [ -d push-artifacts ] && [ "$(ls -A push-artifacts 2>/dev/null)" ]; then
   adb push push-artifacts/. /data/local/tmp/executorch/
 fi
 
+# Download and push golden test artifacts (models + input/output bins)
+GOLDEN_URL="https://gha-artifacts.s3.amazonaws.com/pytorch/executorch/test-backend-artifacts/golden-artifacts-xnnpack/golden_artifacts_26022500.zip"
+curl -sL -o /tmp/golden.zip "$GOLDEN_URL"
+unzip -o /tmp/golden.zip -d /tmp/golden/
+adb push /tmp/golden/xnnpack/. /data/local/tmp/executorch/
+
 adb logcat -c
 adb shell am instrument -w -r \
   org.pytorch.executorch.test/androidx.test.runner.AndroidJUnitRunner >result.txt 2>&1

--- a/scripts/run_android_emulator.sh
+++ b/scripts/run_android_emulator.sh
@@ -31,9 +31,19 @@ adb push /tmp/stories.pte /data/local/tmp/executorch/
 adb push /tmp/tokenizer.bin /data/local/tmp/executorch/
 
 GOLDEN_URL="https://gha-artifacts.s3.amazonaws.com/pytorch/executorch/test-backend-artifacts/golden-artifacts-xnnpack/golden_artifacts_26022500.zip"
+GOLDEN_FILES=(
+  mobilenet_v2.pte
+  mobilenet_v2_input.bin
+  mobilenet_v2_expected_output.bin
+  vit_b_16.pte
+  vit_b_16_input.bin
+  vit_b_16_expected_output.bin
+)
 curl -sL -o /tmp/golden.zip "$GOLDEN_URL"
-unzip -o /tmp/golden.zip -d /tmp/golden/
-adb push /tmp/golden/xnnpack/. /data/local/tmp/executorch/
+unzip -o /tmp/golden.zip "${GOLDEN_FILES[@]/#/xnnpack/}" -d /tmp/golden/
+for f in "${GOLDEN_FILES[@]}"; do
+  adb push "/tmp/golden/xnnpack/$f" /data/local/tmp/executorch/
+done
 
 adb logcat -c
 adb shell am instrument -w -r \

--- a/scripts/run_android_emulator.sh
+++ b/scripts/run_android_emulator.sh
@@ -21,6 +21,12 @@ $ADB_PATH devices
 adb uninstall org.pytorch.executorch.test || true
 adb install -t android-test-debug-androidTest.apk
 
+# Push large test assets that are not bundled in the APK
+if [ -d push-artifacts ] && [ "$(ls -A push-artifacts 2>/dev/null)" ]; then
+  adb shell mkdir -p /data/local/tmp/executorch
+  adb push push-artifacts/. /data/local/tmp/executorch/
+fi
+
 adb logcat -c
 adb shell am instrument -w -r \
   org.pytorch.executorch.test/androidx.test.runner.AndroidJUnitRunner >result.txt 2>&1

--- a/scripts/run_android_emulator.sh
+++ b/scripts/run_android_emulator.sh
@@ -21,13 +21,15 @@ $ADB_PATH devices
 adb uninstall org.pytorch.executorch.test || true
 adb install -t android-test-debug-androidTest.apk
 
-# Push large test assets that are not bundled in the APK
-if [ -d push-artifacts ] && [ "$(ls -A push-artifacts 2>/dev/null)" ]; then
-  adb shell mkdir -p /data/local/tmp/executorch
-  adb push push-artifacts/. /data/local/tmp/executorch/
-fi
+# Download and push test artifacts via adb instead of bundling in APK
+adb shell mkdir -p /data/local/tmp/executorch
 
-# Download and push golden test artifacts (models + input/output bins)
+S3_BASE="https://ossci-android.s3.amazonaws.com/executorch/stories/snapshot-20260114"
+curl -sL -o /tmp/stories.pte "${S3_BASE}/stories110M.pte"
+curl -sL -o /tmp/tokenizer.bin "${S3_BASE}/tokenizer.model"
+adb push /tmp/stories.pte /data/local/tmp/executorch/
+adb push /tmp/tokenizer.bin /data/local/tmp/executorch/
+
 GOLDEN_URL="https://gha-artifacts.s3.amazonaws.com/pytorch/executorch/test-backend-artifacts/golden-artifacts-xnnpack/golden_artifacts_26022500.zip"
 curl -sL -o /tmp/golden.zip "$GOLDEN_URL"
 unzip -o /tmp/golden.zip -d /tmp/golden/

--- a/scripts/run_android_emulator.sh
+++ b/scripts/run_android_emulator.sh
@@ -18,17 +18,17 @@ $ADB_PATH wait-for-device shell 'while [[ -z $(getprop sys.boot_completed) ]]; d
 echo "List all running emulators"
 $ADB_PATH devices
 
-adb uninstall org.pytorch.executorch.test || true
-adb install -t android-test-debug-androidTest.apk
+$ADB_PATH uninstall org.pytorch.executorch.test || true
+$ADB_PATH install -t android-test-debug-androidTest.apk
 
 # Download and push test artifacts via adb instead of bundling in APK
-adb shell mkdir -p /data/local/tmp/executorch
+$ADB_PATH shell mkdir -p /data/local/tmp/executorch
 
 S3_BASE="https://ossci-android.s3.amazonaws.com/executorch/stories/snapshot-20260114"
-curl -sL -o /tmp/stories.pte "${S3_BASE}/stories110M.pte"
-curl -sL -o /tmp/tokenizer.bin "${S3_BASE}/tokenizer.model"
-adb push /tmp/stories.pte /data/local/tmp/executorch/
-adb push /tmp/tokenizer.bin /data/local/tmp/executorch/
+curl -sfL -o /tmp/stories.pte "${S3_BASE}/stories110M.pte"
+curl -sfL -o /tmp/tokenizer.bin "${S3_BASE}/tokenizer.model"
+$ADB_PATH push /tmp/stories.pte /data/local/tmp/executorch/
+$ADB_PATH push /tmp/tokenizer.bin /data/local/tmp/executorch/
 
 GOLDEN_URL="https://gha-artifacts.s3.amazonaws.com/pytorch/executorch/test-backend-artifacts/golden-artifacts-xnnpack/golden_artifacts_26022500.zip"
 GOLDEN_FILES=(
@@ -39,16 +39,16 @@ GOLDEN_FILES=(
   vit_b_16_input.bin
   vit_b_16_expected_output.bin
 )
-curl -sL -o /tmp/golden.zip "$GOLDEN_URL"
+curl -sfL -o /tmp/golden.zip "$GOLDEN_URL"
 unzip -o /tmp/golden.zip "${GOLDEN_FILES[@]/#/xnnpack/}" -d /tmp/golden/
 for f in "${GOLDEN_FILES[@]}"; do
-  adb push "/tmp/golden/xnnpack/$f" /data/local/tmp/executorch/
+  $ADB_PATH push "/tmp/golden/xnnpack/$f" /data/local/tmp/executorch/
 done
 
-adb logcat -c
-adb shell am instrument -w -r \
+$ADB_PATH logcat -c
+$ADB_PATH shell am instrument -w -r \
   org.pytorch.executorch.test/androidx.test.runner.AndroidJUnitRunner >result.txt 2>&1
-adb logcat -d > logcat.txt
+$ADB_PATH logcat -d > logcat.txt
 cat logcat.txt
 grep -q FAILURES result.txt && cat result.txt
 grep -q FAILURES result.txt && exit -1


### PR DESCRIPTION
### Summary
vit_b_16.pte (~330MB) and stories.pte (~29MB) are no longer bundled in the androidTest APK. Instead they are uploaded as a separate CI artifact and pushed to /data/local/tmp/executorch/ via adb before tests run. TestFileUtils.prepareTestFile() checks the push directory first and falls back to APK resources, so both CI and local workflows remain functional. This reduces the APK from ~361MB to ~2MB.

### Test plan
CI