### PR TITLE
Fix LlmModule prefill API bugs in JNI layer

### DIFF
--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmModule.java
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmModule.java
@@ -365,7 +365,6 @@ public class LlmModule {
       float temperature,
       int numBos,
       int numEos) {
-    prefillPrompt(prompt);
     if (image != null) {
       prefillImages(image, width, height, channels);
     }

--- a/extension/android/jni/jni_layer_llama.cpp
+++ b/extension/android/jni/jni_layer_llama.cpp
@@ -214,8 +214,7 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
     };
 
     if (model_type_category_ == MODEL_TYPE_CATEGORY_MULTIMODAL) {
-      std::vector<llm::MultimodalInput> inputs = prefill_inputs_;
-      prefill_inputs_.clear();
+      std::vector<llm::MultimodalInput> inputs = std::move(prefill_inputs_);
       if (!prompt->toStdString().empty()) {
         inputs.emplace_back(llm::MultimodalInput{prompt->toStdString()});
       }
@@ -263,7 +262,7 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
       jint channels) {
     std::vector<llm::Image> images;
     if (image == nullptr) {
-      return static_cast<jint>(Error::EndOfMethod);
+      return static_cast<jint>(Error::InvalidArgument);
     }
     auto image_size = image->size();
     if (image_size != 0) {
@@ -289,7 +288,7 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
       jint channels) {
     std::vector<llm::Image> images;
     if (image == nullptr) {
-      return static_cast<jint>(Error::EndOfMethod);
+      return static_cast<jint>(Error::InvalidArgument);
     }
     auto image_size = image->size();
     if (image_size != 0) {
@@ -314,7 +313,7 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
       jint n_bins,
       jint n_frames) {
     if (data == nullptr) {
-      return static_cast<jint>(Error::EndOfMethod);
+      return static_cast<jint>(Error::InvalidArgument);
     }
     auto data_size = data->size();
     if (data_size != 0) {
@@ -337,7 +336,7 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
       jint n_bins,
       jint n_frames) {
     if (data == nullptr) {
-      return static_cast<jint>(Error::EndOfMethod);
+      return static_cast<jint>(Error::InvalidArgument);
     }
     auto data_size = data->size();
     if (data_size != 0) {
@@ -360,7 +359,7 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
       jint n_channels,
       jint n_samples) {
     if (data == nullptr) {
-      return static_cast<jint>(Error::EndOfMethod);
+      return static_cast<jint>(Error::InvalidArgument);
     }
     auto data_size = data->size();
     if (data_size != 0) {


### PR DESCRIPTION

### Summary
Fix prompt double-prefill in the image generate() overload: the method called prefillPrompt(prompt) which appends to the JNI buffer, then passed the same prompt to native generate() which appends it again on the multimodal path, corrupting KV cache state.

Also fix all 5 null-input checks in JNI append methods that incorrectly returned Error::EndOfMethod (means "method execution finished") instead of Error::InvalidArgument.

Replace deep copy of prefill_inputs_ with std::move to avoid unnecessary allocation for large image/audio inputs.

### Test plan
CI