### PR TITLE
Wire text-only prefillPrompt() to C++ runner->prefill()

### DIFF
--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmModule.java
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmModule.java
@@ -365,7 +365,6 @@ public class LlmModule {
       float temperature,
       int numBos,
       int numEos) {
-    prefillPrompt(prompt);
     if (image != null) {
       prefillImages(image, width, height, channels);
     }

--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmModule.java
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmModule.java
@@ -493,7 +493,7 @@ public class LlmModule {
    */
   @Experimental
   public long prefillPrompt(String prompt) {
-    int nativeResult = appendTextInput(prompt);
+    int nativeResult = prefillTextInput(prompt);
     if (nativeResult != 0) {
       throw new RuntimeException("Prefill failed with error code: " + nativeResult);
     }
@@ -501,7 +501,7 @@ public class LlmModule {
   }
 
   // returns status
-  private native int appendTextInput(String prompt);
+  private native int prefillTextInput(String prompt);
 
   /**
    * Reset the context of the LLM. This will clear the KV cache and reset the state of the LLM.

--- a/extension/android/jni/jni_layer_llama.cpp
+++ b/extension/android/jni/jni_layer_llama.cpp
@@ -214,8 +214,7 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
     };
 
     if (model_type_category_ == MODEL_TYPE_CATEGORY_MULTIMODAL) {
-      std::vector<llm::MultimodalInput> inputs = prefill_inputs_;
-      prefill_inputs_.clear();
+      std::vector<llm::MultimodalInput> inputs = std::move(prefill_inputs_);
       if (!prompt->toStdString().empty()) {
         inputs.emplace_back(llm::MultimodalInput{prompt->toStdString()});
       }
@@ -263,7 +262,7 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
       jint channels) {
     std::vector<llm::Image> images;
     if (image == nullptr) {
-      return static_cast<jint>(Error::EndOfMethod);
+      return static_cast<jint>(Error::InvalidArgument);
     }
     auto image_size = image->size();
     if (image_size != 0) {
@@ -289,7 +288,7 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
       jint channels) {
     std::vector<llm::Image> images;
     if (image == nullptr) {
-      return static_cast<jint>(Error::EndOfMethod);
+      return static_cast<jint>(Error::InvalidArgument);
     }
     auto image_size = image->size();
     if (image_size != 0) {
@@ -314,7 +313,7 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
       jint n_bins,
       jint n_frames) {
     if (data == nullptr) {
-      return static_cast<jint>(Error::EndOfMethod);
+      return static_cast<jint>(Error::InvalidArgument);
     }
     auto data_size = data->size();
     if (data_size != 0) {
@@ -337,7 +336,7 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
       jint n_bins,
       jint n_frames) {
     if (data == nullptr) {
-      return static_cast<jint>(Error::EndOfMethod);
+      return static_cast<jint>(Error::InvalidArgument);
     }
     auto data_size = data->size();
     if (data_size != 0) {
@@ -360,7 +359,7 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
       jint n_channels,
       jint n_samples) {
     if (data == nullptr) {
-      return static_cast<jint>(Error::EndOfMethod);
+      return static_cast<jint>(Error::InvalidArgument);
     }
     auto data_size = data->size();
     if (data_size != 0) {

--- a/extension/android/jni/jni_layer_llama.cpp
+++ b/extension/android/jni/jni_layer_llama.cpp
@@ -249,7 +249,7 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
 
   // Returns status_code
   // Contract is valid within an AAR (JNI + corresponding Java code)
-  jint append_text_input(facebook::jni::alias_ref<jstring> prompt) {
+  jint prefill_text_input(facebook::jni::alias_ref<jstring> prompt) {
     if (model_type_category_ == MODEL_TYPE_CATEGORY_LLM && runner_) {
       executorch::extension::llm::GenerationConfig config;
       auto err = runner_->prefill(prompt->toStdString(), config);
@@ -444,7 +444,7 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
         makeNativeMethod(
             "appendRawAudioInput", ExecuTorchLlmJni::append_raw_audio_input),
         makeNativeMethod(
-            "appendTextInput", ExecuTorchLlmJni::append_text_input),
+            "prefillTextInput", ExecuTorchLlmJni::prefill_text_input),
         makeNativeMethod("resetContext", ExecuTorchLlmJni::reset_context),
     });
   }

--- a/extension/android/jni/jni_layer_llama.cpp
+++ b/extension/android/jni/jni_layer_llama.cpp
@@ -250,8 +250,14 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
   // Returns status_code
   // Contract is valid within an AAR (JNI + corresponding Java code)
   jint prefill_text_input(facebook::jni::alias_ref<jstring> prompt) {
-    if (model_type_category_ == MODEL_TYPE_CATEGORY_LLM && runner_) {
-      executorch::extension::llm::GenerationConfig config;
+    if (model_type_category_ == MODEL_TYPE_CATEGORY_LLM) {
+      if (!runner_) {
+        return static_cast<jint>(Error::InvalidState);
+      }
+      executorch::extension::llm::GenerationConfig config{
+          .num_bos = num_bos_,
+          .num_eos = num_eos_,
+      };
       auto err = runner_->prefill(prompt->toStdString(), config);
       return static_cast<jint>(err);
     }

--- a/extension/android/jni/jni_layer_llama.cpp
+++ b/extension/android/jni/jni_layer_llama.cpp
@@ -250,6 +250,11 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
   // Returns status_code
   // Contract is valid within an AAR (JNI + corresponding Java code)
   jint append_text_input(facebook::jni::alias_ref<jstring> prompt) {
+    if (model_type_category_ == MODEL_TYPE_CATEGORY_LLM && runner_) {
+      executorch::extension::llm::GenerationConfig config;
+      auto err = runner_->prefill(prompt->toStdString(), config);
+      return static_cast<jint>(err);
+    }
     prefill_inputs_.emplace_back(llm::MultimodalInput{prompt->toStdString()});
     return 0;
   }
@@ -391,6 +396,7 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
     if (multi_modal_runner_ != nullptr) {
       multi_modal_runner_->reset();
     }
+    prefill_inputs_.clear();
   }
 
   jint load() {

--- a/extension/llm/runner/irunner.h
+++ b/extension/llm/runner/irunner.h
@@ -134,6 +134,25 @@ class ET_EXPERIMENTAL IRunner {
   virtual void stop() = 0;
 
   /**
+   * Prefill the model with the given prompt without generating tokens.
+   *
+   * This populates the KV cache with the prompt tokens, allowing subsequent
+   * generate() calls to continue from the prefilled state. Useful for
+   * reloading chat history.
+   *
+   * @param prompt The text to prefill
+   * @param config Generation configuration (num_bos, num_eos used for
+   * encoding)
+   * @return Error::Ok if successful, Error::NotSupported if the runner does
+   * not support standalone prefill
+   */
+  virtual runtime::Error prefill(
+      const std::string& prompt,
+      const GenerationConfig& config) {
+    return runtime::Error::NotSupported;
+  }
+
+  /**
    * Force remove prefilled tokens and reset KV cache start position
    *
    * This method removes the prefilled tokens from the KV cache and resets the

--- a/extension/llm/runner/text_llm_runner.h
+++ b/extension/llm/runner/text_llm_runner.h
@@ -110,7 +110,7 @@ class ET_EXPERIMENTAL TextLLMRunner : public IRunner {
    */
   ::executorch::runtime::Error prefill(
       const std::string& prompt,
-      const GenerationConfig& config);
+      const GenerationConfig& config) override;
 
   /**
    * @brief Warms up the model with a sample prompt


### PR DESCRIPTION
### Summary

Previously, prefillPrompt() only appended to a JNI-side buffer
that was never consumed on the text-only code path. This was a
silent no-op: the buffered data sat there forever while generate()
passed its own prompt directly to the runner.

Now for text-only models (MODEL_TYPE_CATEGORY_LLM), prefillPrompt()
calls runner_->prefill() directly, which runs real model computation
and populates the KV cache. This enables chat history reload:

  module.prefillPrompt("system: ...");  // fills KV cache
  module.prefillPrompt("user: hello");  // fills KV cache
  module.generate("user: new q", cb);   // generates from pos_

Add prefill() to IRunner with a default NotSupported return so
vendor runners (QNN, MediaTek) are unaffected. Mark the existing
TextLLMRunner::prefill() as override.

Also clear prefill_inputs_ in resetContext() so stale multimodal
buffer data doesn't persist across context resets.

### Test plan
CI