### PR TITLE
Wire multimodal prefillXxx() to C++ runner->prefill(), remove buffer

### DIFF
--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmModule.java
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmModule.java
@@ -365,7 +365,6 @@ public class LlmModule {
       float temperature,
       int numBos,
       int numEos) {
-    prefillPrompt(prompt);
     if (image != null) {
       prefillImages(image, width, height, channels);
     }

--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmModule.java
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmModule.java
@@ -384,14 +384,14 @@ public class LlmModule {
    */
   @Experimental
   public long prefillImages(int[] image, int width, int height, int channels) {
-    int nativeResult = appendImagesInput(image, width, height, channels);
+    int nativeResult = prefillImagesInput(image, width, height, channels);
     if (nativeResult != 0) {
       throw new RuntimeException("Prefill failed with error code: " + nativeResult);
     }
     return 0;
   }
 
-  private native int appendImagesInput(int[] image, int width, int height, int channels);
+  private native int prefillImagesInput(int[] image, int width, int height, int channels);
 
   /**
    * Prefill a multimodal Module with the given images input.
@@ -406,14 +406,14 @@ public class LlmModule {
    */
   @Experimental
   public long prefillImages(float[] image, int width, int height, int channels) {
-    int nativeResult = appendNormalizedImagesInput(image, width, height, channels);
+    int nativeResult = prefillNormalizedImagesInput(image, width, height, channels);
     if (nativeResult != 0) {
       throw new RuntimeException("Prefill failed with error code: " + nativeResult);
     }
     return 0;
   }
 
-  private native int appendNormalizedImagesInput(
+  private native int prefillNormalizedImagesInput(
       float[] image, int width, int height, int channels);
 
   /**
@@ -429,14 +429,14 @@ public class LlmModule {
    */
   @Experimental
   public long prefillAudio(byte[] audio, int batch_size, int n_bins, int n_frames) {
-    int nativeResult = appendAudioInput(audio, batch_size, n_bins, n_frames);
+    int nativeResult = prefillAudioInput(audio, batch_size, n_bins, n_frames);
     if (nativeResult != 0) {
       throw new RuntimeException("Prefill failed with error code: " + nativeResult);
     }
     return 0;
   }
 
-  private native int appendAudioInput(byte[] audio, int batch_size, int n_bins, int n_frames);
+  private native int prefillAudioInput(byte[] audio, int batch_size, int n_bins, int n_frames);
 
   /**
    * Prefill a multimodal Module with the given audio input.
@@ -451,14 +451,14 @@ public class LlmModule {
    */
   @Experimental
   public long prefillAudio(float[] audio, int batch_size, int n_bins, int n_frames) {
-    int nativeResult = appendAudioInputFloat(audio, batch_size, n_bins, n_frames);
+    int nativeResult = prefillAudioInputFloat(audio, batch_size, n_bins, n_frames);
     if (nativeResult != 0) {
       throw new RuntimeException("Prefill failed with error code: " + nativeResult);
     }
     return 0;
   }
 
-  private native int appendAudioInputFloat(float[] audio, int batch_size, int n_bins, int n_frames);
+  private native int prefillAudioInputFloat(float[] audio, int batch_size, int n_bins, int n_frames);
 
   /**
    * Prefill a multimodal Module with the given raw audio input.
@@ -473,14 +473,14 @@ public class LlmModule {
    */
   @Experimental
   public long prefillRawAudio(byte[] audio, int batch_size, int n_channels, int n_samples) {
-    int nativeResult = appendRawAudioInput(audio, batch_size, n_channels, n_samples);
+    int nativeResult = prefillRawAudioInput(audio, batch_size, n_channels, n_samples);
     if (nativeResult != 0) {
       throw new RuntimeException("Prefill failed with error code: " + nativeResult);
     }
     return 0;
   }
 
-  private native int appendRawAudioInput(
+  private native int prefillRawAudioInput(
       byte[] audio, int batch_size, int n_channels, int n_samples);
 
   /**

--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmModule.java
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmModule.java
@@ -493,7 +493,7 @@ public class LlmModule {
    */
   @Experimental
   public long prefillPrompt(String prompt) {
-    int nativeResult = appendTextInput(prompt);
+    int nativeResult = prefillTextInput(prompt);
     if (nativeResult != 0) {
       throw new RuntimeException("Prefill failed with error code: " + nativeResult);
     }
@@ -501,7 +501,7 @@ public class LlmModule {
   }
 
   // returns status
-  private native int appendTextInput(String prompt);
+  private native int prefillTextInput(String prompt);
 
   /**
    * Reset the context of the LLM. This will clear the KV cache and reset the state of the LLM.

--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmModule.java
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmModule.java
@@ -458,7 +458,8 @@ public class LlmModule {
     return 0;
   }
 
-  private native int prefillAudioInputFloat(float[] audio, int batch_size, int n_bins, int n_frames);
+  private native int prefillAudioInputFloat(
+      float[] audio, int batch_size, int n_bins, int n_frames);
 
   /**
    * Prefill a multimodal Module with the given raw audio input.

--- a/extension/android/jni/jni_layer_llama.cpp
+++ b/extension/android/jni/jni_layer_llama.cpp
@@ -214,8 +214,7 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
     };
 
     if (model_type_category_ == MODEL_TYPE_CATEGORY_MULTIMODAL) {
-      std::vector<llm::MultimodalInput> inputs = prefill_inputs_;
-      prefill_inputs_.clear();
+      std::vector<llm::MultimodalInput> inputs = std::move(prefill_inputs_);
       if (!prompt->toStdString().empty()) {
         inputs.emplace_back(llm::MultimodalInput{prompt->toStdString()});
       }
@@ -263,7 +262,7 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
       jint channels) {
     std::vector<llm::Image> images;
     if (image == nullptr) {
-      return static_cast<jint>(Error::EndOfMethod);
+      return static_cast<jint>(Error::InvalidArgument);
     }
     auto image_size = image->size();
     if (image_size != 0) {
@@ -289,7 +288,7 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
       jint channels) {
     std::vector<llm::Image> images;
     if (image == nullptr) {
-      return static_cast<jint>(Error::EndOfMethod);
+      return static_cast<jint>(Error::InvalidArgument);
     }
     auto image_size = image->size();
     if (image_size != 0) {
@@ -314,7 +313,7 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
       jint n_bins,
       jint n_frames) {
     if (data == nullptr) {
-      return static_cast<jint>(Error::EndOfMethod);
+      return static_cast<jint>(Error::InvalidArgument);
     }
     auto data_size = data->size();
     if (data_size != 0) {
@@ -337,7 +336,7 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
       jint n_bins,
       jint n_frames) {
     if (data == nullptr) {
-      return static_cast<jint>(Error::EndOfMethod);
+      return static_cast<jint>(Error::InvalidArgument);
     }
     auto data_size = data->size();
     if (data_size != 0) {
@@ -360,7 +359,7 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
       jint n_channels,
       jint n_samples) {
     if (data == nullptr) {
-      return static_cast<jint>(Error::EndOfMethod);
+      return static_cast<jint>(Error::InvalidArgument);
     }
     auto data_size = data->size();
     if (data_size != 0) {

--- a/extension/android/jni/jni_layer_llama.cpp
+++ b/extension/android/jni/jni_layer_llama.cpp
@@ -78,10 +78,7 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
   float temperature_ = 0.0f;
   int num_bos_ = 0;
   int num_eos_ = 0;
-  int model_type_category_;
   std::unique_ptr<llm::IRunner> runner_;
-  std::unique_ptr<executorch::extension::llm::MultimodalRunner>
-      multi_modal_runner_;
 
  public:
   constexpr static auto kJavaDescriptor =
@@ -134,10 +131,9 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
     }
 #endif
 
-    model_type_category_ = model_type_category;
     std::vector<std::string> data_files_vector;
     if (model_type_category == MODEL_TYPE_CATEGORY_MULTIMODAL) {
-      multi_modal_runner_ = llm::create_multimodal_runner(
+      runner_ = llm::create_multimodal_runner(
           model_path->toStdString().c_str(),
           llm::load_tokenizer(tokenizer_path->toStdString()),
           std::nullopt,
@@ -177,15 +173,12 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
           tokenizer_path->toStdString().c_str(),
           "",
           "");
-      model_type_category_ = MODEL_TYPE_CATEGORY_LLM;
 #endif
 #if defined(EXECUTORCH_BUILD_MEDIATEK)
     } else if (model_type_category == MODEL_TYPE_MEDIATEK_LLAMA) {
       runner_ = std::make_unique<MTKLlamaRunner>(
           model_path->toStdString().c_str(),
           tokenizer_path->toStdString().c_str());
-      // Interpret the model type as LLM
-      model_type_category_ = MODEL_TYPE_CATEGORY_LLM;
 #endif
     }
   }
@@ -212,61 +205,32 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
       callback->onResult(result);
     };
 
-    if (model_type_category_ == MODEL_TYPE_CATEGORY_MULTIMODAL) {
-      std::vector<llm::MultimodalInput> inputs;
-      if (!prompt->toStdString().empty()) {
-        inputs.emplace_back(llm::MultimodalInput{prompt->toStdString()});
-      }
-      if (inputs.empty()) {
-        return static_cast<jint>(Error::InvalidArgument);
-      }
-      executorch::extension::llm::GenerationConfig config{
-          .echo = static_cast<bool>(echo),
-          .seq_len = seq_len,
-          .temperature = effective_temperature,
-          .num_bos = num_bos,
-          .num_eos = num_eos,
-      };
-      multi_modal_runner_->generate(
-          std::move(inputs),
-          config,
-          token_callback,
-          [callback](const llm::Stats& result) { callback->onStats(result); });
-    } else if (model_type_category_ == MODEL_TYPE_CATEGORY_LLM) {
-      executorch::extension::llm::GenerationConfig config{
-          .echo = static_cast<bool>(echo),
-          .seq_len = seq_len,
-          .temperature = effective_temperature,
-          .num_bos = num_bos,
-          .num_eos = num_eos,
-      };
-      runner_->generate(
-          prompt->toStdString(),
-          config,
-          token_callback,
-          [callback](const llm::Stats& result) { callback->onStats(result); });
-    }
-    return 0;
+    executorch::extension::llm::GenerationConfig config{
+        .echo = static_cast<bool>(echo),
+        .seq_len = seq_len,
+        .temperature = effective_temperature,
+        .num_bos = num_bos,
+        .num_eos = num_eos,
+    };
+    auto err = runner_->generate(
+        prompt->toStdString(),
+        config,
+        token_callback,
+        [callback](const llm::Stats& result) { callback->onStats(result); });
+    return static_cast<jint>(err);
   }
 
-  // Returns status_code
-  // Contract is valid within an AAR (JNI + corresponding Java code)
   jint prefill_text_input(facebook::jni::alias_ref<jstring> prompt) {
-    if (model_type_category_ == MODEL_TYPE_CATEGORY_LLM && runner_) {
-      executorch::extension::llm::GenerationConfig config;
-      auto err = runner_->prefill(prompt->toStdString(), config);
-      return static_cast<jint>(err);
-    }
-    if (multi_modal_runner_) {
-      std::vector<llm::MultimodalInput> inputs;
-      inputs.emplace_back(llm::MultimodalInput{prompt->toStdString()});
-      auto err = multi_modal_runner_->prefill(inputs);
-      return static_cast<jint>(err);
-    }
-    return 0;
+    std::vector<llm::MultimodalInput> inputs;
+    inputs.emplace_back(llm::MultimodalInput{prompt->toStdString()});
+    llm::GenerationConfig config{
+        .num_bos = num_bos_,
+        .num_eos = num_eos_,
+    };
+    auto err = runner_->prefill(inputs, config);
+    return static_cast<jint>(err);
   }
 
-  // Returns status_code
   jint prefill_images_input(
       facebook::jni::alias_ref<jintArray> image,
       jint width,
@@ -286,13 +250,13 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
       llm::Image image_runner{std::move(image_data), width, height, channels};
       std::vector<llm::MultimodalInput> inputs;
       inputs.emplace_back(llm::MultimodalInput{std::move(image_runner)});
-      auto err = multi_modal_runner_->prefill(inputs);
+      llm::GenerationConfig config;
+      auto err = runner_->prefill(inputs, config);
       return static_cast<jint>(err);
     }
     return 0;
   }
 
-  // Returns status_code
   jint prefill_normalized_images_input(
       facebook::jni::alias_ref<jfloatArray> image,
       jint width,
@@ -312,13 +276,13 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
       llm::Image image_runner{std::move(image_data), width, height, channels};
       std::vector<llm::MultimodalInput> inputs;
       inputs.emplace_back(llm::MultimodalInput{std::move(image_runner)});
-      auto err = multi_modal_runner_->prefill(inputs);
+      llm::GenerationConfig config;
+      auto err = runner_->prefill(inputs, config);
       return static_cast<jint>(err);
     }
     return 0;
   }
 
-  // Returns status_code
   jint prefill_audio_input(
       facebook::jni::alias_ref<jbyteArray> data,
       jint batch_size,
@@ -338,13 +302,13 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
       llm::Audio audio{std::move(data_u8), batch_size, n_bins, n_frames};
       std::vector<llm::MultimodalInput> inputs;
       inputs.emplace_back(llm::MultimodalInput{std::move(audio)});
-      auto err = multi_modal_runner_->prefill(inputs);
+      llm::GenerationConfig config;
+      auto err = runner_->prefill(inputs, config);
       return static_cast<jint>(err);
     }
     return 0;
   }
 
-  // Returns status_code
   jint prefill_audio_input_float(
       facebook::jni::alias_ref<jfloatArray> data,
       jint batch_size,
@@ -364,13 +328,13 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
       llm::Audio audio{std::move(data_f), batch_size, n_bins, n_frames};
       std::vector<llm::MultimodalInput> inputs;
       inputs.emplace_back(llm::MultimodalInput{std::move(audio)});
-      auto err = multi_modal_runner_->prefill(inputs);
+      llm::GenerationConfig config;
+      auto err = runner_->prefill(inputs, config);
       return static_cast<jint>(err);
     }
     return 0;
   }
 
-  // Returns status_code
   jint prefill_raw_audio_input(
       facebook::jni::alias_ref<jbyteArray> data,
       jint batch_size,
@@ -391,53 +355,30 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
           std::move(data_u8), batch_size, n_channels, n_samples};
       std::vector<llm::MultimodalInput> inputs;
       inputs.emplace_back(llm::MultimodalInput{std::move(audio)});
-      auto err = multi_modal_runner_->prefill(inputs);
+      llm::GenerationConfig config;
+      auto err = runner_->prefill(inputs, config);
       return static_cast<jint>(err);
     }
     return 0;
   }
 
   void stop() {
-    if (model_type_category_ == MODEL_TYPE_CATEGORY_MULTIMODAL) {
-      multi_modal_runner_->stop();
-    } else if (model_type_category_ == MODEL_TYPE_CATEGORY_LLM) {
-      runner_->stop();
-    }
+    runner_->stop();
   }
 
   void reset_context() {
-    if (runner_ != nullptr) {
-      runner_->reset();
-    }
-    if (multi_modal_runner_ != nullptr) {
-      multi_modal_runner_->reset();
-    }
+    runner_->reset();
   }
 
   jint load() {
-    int result = -1;
-    std::stringstream ss;
-
-    if (model_type_category_ == MODEL_TYPE_CATEGORY_MULTIMODAL) {
-      result = static_cast<jint>(multi_modal_runner_->load());
-      if (result != 0) {
-        ss << "Failed to load multimodal runner: [" << result << "]";
-      }
-    } else if (model_type_category_ == MODEL_TYPE_CATEGORY_LLM) {
-      result = static_cast<jint>(runner_->load());
-      if (result != 0) {
-        ss << "Failed to load llm runner: [" << result << "]";
-      }
-    } else {
-      ss << "Invalid model type category: " << model_type_category_
-         << ". Valid values are: " << MODEL_TYPE_CATEGORY_LLM << " or "
-         << MODEL_TYPE_CATEGORY_MULTIMODAL;
-    }
-    if (result != 0) {
+    auto result = runner_->load();
+    if (result != Error::Ok) {
+      std::stringstream ss;
+      ss << "Failed to load runner: [" << static_cast<int>(result) << "]";
       executorch::jni_helper::throwExecutorchException(
           static_cast<uint32_t>(Error::InvalidArgument), ss.str().c_str());
     }
-    return result; // 0 on success to keep backward compatibility
+    return static_cast<jint>(result);
   }
 
   static void registerNatives() {

--- a/extension/android/jni/jni_layer_llama.cpp
+++ b/extension/android/jni/jni_layer_llama.cpp
@@ -249,7 +249,7 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
 
   // Returns status_code
   // Contract is valid within an AAR (JNI + corresponding Java code)
-  jint append_text_input(facebook::jni::alias_ref<jstring> prompt) {
+  jint prefill_text_input(facebook::jni::alias_ref<jstring> prompt) {
     if (model_type_category_ == MODEL_TYPE_CATEGORY_LLM && runner_) {
       executorch::extension::llm::GenerationConfig config;
       auto err = runner_->prefill(prompt->toStdString(), config);
@@ -444,7 +444,7 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
         makeNativeMethod(
             "appendRawAudioInput", ExecuTorchLlmJni::append_raw_audio_input),
         makeNativeMethod(
-            "appendTextInput", ExecuTorchLlmJni::append_text_input),
+            "prefillTextInput", ExecuTorchLlmJni::prefill_text_input),
         makeNativeMethod("resetContext", ExecuTorchLlmJni::reset_context),
     });
   }

--- a/extension/android/jni/jni_layer_llama.cpp
+++ b/extension/android/jni/jni_layer_llama.cpp
@@ -82,7 +82,6 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
   std::unique_ptr<llm::IRunner> runner_;
   std::unique_ptr<executorch::extension::llm::MultimodalRunner>
       multi_modal_runner_;
-  std::vector<llm::MultimodalInput> prefill_inputs_;
 
  public:
   constexpr static auto kJavaDescriptor =
@@ -214,9 +213,12 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
     };
 
     if (model_type_category_ == MODEL_TYPE_CATEGORY_MULTIMODAL) {
-      std::vector<llm::MultimodalInput> inputs = std::move(prefill_inputs_);
+      std::vector<llm::MultimodalInput> inputs;
       if (!prompt->toStdString().empty()) {
         inputs.emplace_back(llm::MultimodalInput{prompt->toStdString()});
+      }
+      if (inputs.empty()) {
+        return static_cast<jint>(Error::InvalidArgument);
       }
       executorch::extension::llm::GenerationConfig config{
           .echo = static_cast<bool>(echo),
@@ -255,17 +257,21 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
       auto err = runner_->prefill(prompt->toStdString(), config);
       return static_cast<jint>(err);
     }
-    prefill_inputs_.emplace_back(llm::MultimodalInput{prompt->toStdString()});
+    if (multi_modal_runner_) {
+      std::vector<llm::MultimodalInput> inputs;
+      inputs.emplace_back(llm::MultimodalInput{prompt->toStdString()});
+      auto err = multi_modal_runner_->prefill(inputs);
+      return static_cast<jint>(err);
+    }
     return 0;
   }
 
   // Returns status_code
-  jint append_images_input(
+  jint prefill_images_input(
       facebook::jni::alias_ref<jintArray> image,
       jint width,
       jint height,
       jint channels) {
-    std::vector<llm::Image> images;
     if (image == nullptr) {
       return static_cast<jint>(Error::InvalidArgument);
     }
@@ -278,20 +284,20 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
         image_data[i] = image_data_jint[i];
       }
       llm::Image image_runner{std::move(image_data), width, height, channels};
-      prefill_inputs_.emplace_back(
-          llm::MultimodalInput{std::move(image_runner)});
+      std::vector<llm::MultimodalInput> inputs;
+      inputs.emplace_back(llm::MultimodalInput{std::move(image_runner)});
+      auto err = multi_modal_runner_->prefill(inputs);
+      return static_cast<jint>(err);
     }
-
     return 0;
   }
 
   // Returns status_code
-  jint append_normalized_images_input(
+  jint prefill_normalized_images_input(
       facebook::jni::alias_ref<jfloatArray> image,
       jint width,
       jint height,
       jint channels) {
-    std::vector<llm::Image> images;
     if (image == nullptr) {
       return static_cast<jint>(Error::InvalidArgument);
     }
@@ -304,15 +310,16 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
         image_data[i] = image_data_jfloat[i];
       }
       llm::Image image_runner{std::move(image_data), width, height, channels};
-      prefill_inputs_.emplace_back(
-          llm::MultimodalInput{std::move(image_runner)});
+      std::vector<llm::MultimodalInput> inputs;
+      inputs.emplace_back(llm::MultimodalInput{std::move(image_runner)});
+      auto err = multi_modal_runner_->prefill(inputs);
+      return static_cast<jint>(err);
     }
-
     return 0;
   }
 
   // Returns status_code
-  jint append_audio_input(
+  jint prefill_audio_input(
       facebook::jni::alias_ref<jbyteArray> data,
       jint batch_size,
       jint n_bins,
@@ -329,13 +336,16 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
         data_u8[i] = data_jbyte[i];
       }
       llm::Audio audio{std::move(data_u8), batch_size, n_bins, n_frames};
-      prefill_inputs_.emplace_back(llm::MultimodalInput{std::move(audio)});
+      std::vector<llm::MultimodalInput> inputs;
+      inputs.emplace_back(llm::MultimodalInput{std::move(audio)});
+      auto err = multi_modal_runner_->prefill(inputs);
+      return static_cast<jint>(err);
     }
     return 0;
   }
 
   // Returns status_code
-  jint append_audio_input_float(
+  jint prefill_audio_input_float(
       facebook::jni::alias_ref<jfloatArray> data,
       jint batch_size,
       jint n_bins,
@@ -352,13 +362,16 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
         data_f[i] = data_jfloat[i];
       }
       llm::Audio audio{std::move(data_f), batch_size, n_bins, n_frames};
-      prefill_inputs_.emplace_back(llm::MultimodalInput{std::move(audio)});
+      std::vector<llm::MultimodalInput> inputs;
+      inputs.emplace_back(llm::MultimodalInput{std::move(audio)});
+      auto err = multi_modal_runner_->prefill(inputs);
+      return static_cast<jint>(err);
     }
     return 0;
   }
 
   // Returns status_code
-  jint append_raw_audio_input(
+  jint prefill_raw_audio_input(
       facebook::jni::alias_ref<jbyteArray> data,
       jint batch_size,
       jint n_channels,
@@ -376,7 +389,10 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
       }
       llm::RawAudio audio{
           std::move(data_u8), batch_size, n_channels, n_samples};
-      prefill_inputs_.emplace_back(llm::MultimodalInput{std::move(audio)});
+      std::vector<llm::MultimodalInput> inputs;
+      inputs.emplace_back(llm::MultimodalInput{std::move(audio)});
+      auto err = multi_modal_runner_->prefill(inputs);
+      return static_cast<jint>(err);
     }
     return 0;
   }
@@ -396,7 +412,6 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
     if (multi_modal_runner_ != nullptr) {
       multi_modal_runner_->reset();
     }
-    prefill_inputs_.clear();
   }
 
   jint load() {
@@ -432,17 +447,17 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
         makeNativeMethod("stop", ExecuTorchLlmJni::stop),
         makeNativeMethod("load", ExecuTorchLlmJni::load),
         makeNativeMethod(
-            "appendImagesInput", ExecuTorchLlmJni::append_images_input),
+            "prefillImagesInput", ExecuTorchLlmJni::prefill_images_input),
         makeNativeMethod(
-            "appendNormalizedImagesInput",
-            ExecuTorchLlmJni::append_normalized_images_input),
+            "prefillNormalizedImagesInput",
+            ExecuTorchLlmJni::prefill_normalized_images_input),
         makeNativeMethod(
-            "appendAudioInput", ExecuTorchLlmJni::append_audio_input),
+            "prefillAudioInput", ExecuTorchLlmJni::prefill_audio_input),
         makeNativeMethod(
-            "appendAudioInputFloat",
-            ExecuTorchLlmJni::append_audio_input_float),
+            "prefillAudioInputFloat",
+            ExecuTorchLlmJni::prefill_audio_input_float),
         makeNativeMethod(
-            "appendRawAudioInput", ExecuTorchLlmJni::append_raw_audio_input),
+            "prefillRawAudioInput", ExecuTorchLlmJni::prefill_raw_audio_input),
         makeNativeMethod(
             "prefillTextInput", ExecuTorchLlmJni::prefill_text_input),
         makeNativeMethod("resetContext", ExecuTorchLlmJni::reset_context),

--- a/extension/android/jni/jni_layer_llama.cpp
+++ b/extension/android/jni/jni_layer_llama.cpp
@@ -250,6 +250,11 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
   // Returns status_code
   // Contract is valid within an AAR (JNI + corresponding Java code)
   jint append_text_input(facebook::jni::alias_ref<jstring> prompt) {
+    if (model_type_category_ == MODEL_TYPE_CATEGORY_LLM && runner_) {
+      executorch::extension::llm::GenerationConfig config;
+      auto err = runner_->prefill(prompt->toStdString(), config);
+      return static_cast<jint>(err);
+    }
     prefill_inputs_.emplace_back(llm::MultimodalInput{prompt->toStdString()});
     return 0;
   }
@@ -391,6 +396,7 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
     if (multi_modal_runner_ != nullptr) {
       multi_modal_runner_->reset();
     }
+    prefill_inputs_.clear();
   }
 
   jint load() {

--- a/extension/llm/runner/_llm_runner.pyi
+++ b/extension/llm/runner/_llm_runner.pyi
@@ -479,7 +479,7 @@ class MultimodalRunner:
     def prefill(self, inputs: List[MultimodalInput]) -> None:
         """
         Prefill multimodal inputs (e.g., to rebuild KV cache from chat history)
-        without generating tokens.
+        without generating tokens. Uses default GenerationConfig.
 
         Args:
             inputs: List of multimodal inputs to prefill

--- a/extension/llm/runner/irunner.h
+++ b/extension/llm/runner/irunner.h
@@ -14,7 +14,9 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <vector>
 
+#include <executorch/extension/llm/runner/multimodal_input.h>
 #include <executorch/extension/llm/runner/stats.h>
 #include <executorch/runtime/core/error.h>
 
@@ -134,22 +136,40 @@ class ET_EXPERIMENTAL IRunner {
   virtual void stop() = 0;
 
   /**
-   * Prefill the model with the given prompt without generating tokens.
+   * Prefill the model with the given multimodal inputs without generating
+   * tokens.
    *
-   * This populates the KV cache with the prompt tokens, allowing subsequent
-   * generate() calls to continue from the prefilled state. Useful for
-   * reloading chat history.
+   * This populates the KV cache with the input embeddings, allowing subsequent
+   * generate() calls to continue from the prefilled state. Each runner
+   * decides which modalities to handle: text-only runners process text/tokens
+   * and skip other modalities; multimodal runners process all types.
    *
-   * @param prompt The text to prefill
+   * Can be called multiple times before generate() to incrementally build up
+   * the KV cache with different modalities.
+   *
+   * @param inputs A vector of MultimodalInput objects (text, tokens, images,
+   * audio)
    * @param config Generation configuration (num_bos, num_eos used for
    * encoding)
    * @return Error::Ok if successful, Error::NotSupported if the runner does
    * not support standalone prefill
    */
   virtual runtime::Error prefill(
-      const std::string& prompt,
+      const std::vector<MultimodalInput>& inputs,
       const GenerationConfig& config) {
     return runtime::Error::NotSupported;
+  }
+
+  /**
+   * Convenience overload: prefill with a single text prompt.
+   * Wraps the string as a MultimodalInput and delegates to the vector overload.
+   */
+  runtime::Error prefill(
+      const std::string& prompt,
+      const GenerationConfig& config) {
+    std::vector<MultimodalInput> inputs;
+    inputs.emplace_back(MultimodalInput(prompt));
+    return prefill(inputs, config);
   }
 
   /**

--- a/extension/llm/runner/irunner.h
+++ b/extension/llm/runner/irunner.h
@@ -134,6 +134,25 @@ class ET_EXPERIMENTAL IRunner {
   virtual void stop() = 0;
 
   /**
+   * Prefill the model with the given prompt without generating tokens.
+   *
+   * This populates the KV cache with the prompt tokens, allowing subsequent
+   * generate() calls to continue from the prefilled state. Useful for
+   * reloading chat history.
+   *
+   * @param prompt The text to prefill
+   * @param config Generation configuration (num_bos, num_eos used for
+   * encoding)
+   * @return Error::Ok if successful, Error::NotSupported if the runner does
+   * not support standalone prefill
+   */
+  virtual runtime::Error prefill(
+      const std::string& prompt,
+      const GenerationConfig& config) {
+    return runtime::Error::NotSupported;
+  }
+
+  /**
    * Force remove prefilled tokens and reset KV cache start position
    *
    * This method removes the prefilled tokens from the KV cache and resets the

--- a/extension/llm/runner/multimodal_runner.cpp
+++ b/extension/llm/runner/multimodal_runner.cpp
@@ -46,14 +46,12 @@ MultimodalRunner::MultimodalRunner(
 #ifdef CUDA_AVAILABLE
   cuda_memory_tracker_ =
       std::make_unique<::executorch::backends::cuda::CudaMemoryTracker>();
-  // Probe immediately after creating the tracker to capture GPU state before
-  // any model loading happens.
   stats_->gpu_total_bytes = cuda_memory_tracker_->total_bytes();
   stats_->gpu_free_before_load_bytes = cuda_memory_tracker_->last_free_bytes();
 #endif
 }
 
-bool MultimodalRunner::is_loaded() {
+bool MultimodalRunner::is_loaded() const {
   return multimodal_prefiller_->is_method_loaded() &&
       text_token_generator_->is_loaded();
 }
@@ -85,16 +83,151 @@ Error MultimodalRunner::load() {
     ET_LOG(Info, format, __VA_ARGS__);     \
   }
 
-Error MultimodalRunner::prefill(const std::vector<MultimodalInput>& inputs) {
+Error MultimodalRunner::prefill(
+    const std::vector<MultimodalInput>& inputs,
+    const GenerationConfig& config) {
   if (!is_loaded()) {
     ET_CHECK_OK_OR_RETURN_ERROR(load());
   }
-  for (auto& input : inputs) {
-    auto prefill_result = multimodal_prefiller_->prefill(input, pos_);
+
+  for (size_t i = 0; i < inputs.size(); ++i) {
+    const MultimodalInput& input = inputs[i];
+    ET_LOG(
+        Info,
+        "Prefilling input %zu/%zu, type: %s",
+        i,
+        inputs.size(),
+        input.type_name());
+
+    // BOS/EOS handling: add to first text input, or prepend BOS token if
+    // first input is non-text and pos_ == 0
+    int32_t bos = 0;
+    int32_t eos = 0;
+    if (i == 0 && pos_ == 0) {
+      if (input.is_text() || input.is_tokens()) {
+        bos = config.num_bos;
+        eos = config.num_eos;
+      } else if (config.num_bos > 0) {
+        // Non-text first input: prepend BOS token(s) via token embedding
+        auto bos_it = metadata_.find(kBosId);
+        if (bos_it != metadata_.end()) {
+          std::vector<uint64_t> bos_tokens(config.num_bos, bos_it->second);
+          MultimodalInput bos_input(std::move(bos_tokens));
+          auto bos_result = multimodal_prefiller_->prefill(bos_input, pos_);
+          if (!bos_result.ok()) {
+            return bos_result.error();
+          }
+          prefill_next_token_ = bos_result.get();
+        }
+      }
+    }
+
+    auto prefill_result =
+        multimodal_prefiller_->prefill(input, pos_, bos, eos);
     if (!prefill_result.ok()) {
       return prefill_result.error();
     }
+    prefill_next_token_ = prefill_result.get();
   }
+  return Error::Ok;
+}
+
+Error MultimodalRunner::generate(
+    const std::string& prompt,
+    const GenerationConfig& config,
+    std::function<void(const std::string&)> token_callback,
+    std::function<void(const Stats&)> stats_callback) {
+  if (!prompt.empty()) {
+    // Wrap text prompt as multimodal input and delegate
+    std::vector<MultimodalInput> inputs;
+    inputs.emplace_back(MultimodalInput(prompt));
+    return generate(inputs, config, token_callback, stats_callback);
+  }
+
+  // Empty prompt: run decode loop from current KV cache state
+  ET_CHECK_OR_RETURN_ERROR(
+      prefill_next_token_.has_value(),
+      InvalidArgument,
+      "Empty prompt requires a prior prefill() call");
+
+  if (!is_loaded()) {
+    ET_CHECK_OK_OR_RETURN_ERROR(load());
+  }
+
+  // Wrap the token_callback with print function
+  std::function<void(const std::string&)> wrapped_callback =
+      [token_callback, config](const std::string& piece) {
+        if (!config.warming) {
+          safe_printf(piece.c_str());
+          fflush(stdout);
+        }
+        if (token_callback) {
+          token_callback(piece);
+        }
+      };
+
+  stats_->inference_start_ms = time_in_ms();
+
+  uint64_t cur_token = prefill_next_token_.value();
+  prefill_next_token_.reset();
+
+  stats_->first_token_ms = time_in_ms();
+  stats_->prompt_eval_end_ms = time_in_ms();
+  stats_->num_prompt_tokens = pos_;
+
+  // Decode the first token
+  auto decode_result = tokenizer_->decode(cur_token, cur_token);
+  if (!decode_result.ok()) {
+    ET_LOG(
+        Error,
+        "Tokenizers error code %d",
+        static_cast<uint32_t>(decode_result.error()));
+    return Error::InvalidArgument;
+  }
+  wrapped_callback(std::move(*decode_result));
+
+  // Resolve max_new_tokens
+  int64_t max_context_len = metadata_.at(kMaxContextLen);
+  int32_t max_new_tokens = config.resolve_max_new_tokens(max_context_len, pos_);
+
+  ET_CHECK_OR_RETURN_ERROR(
+      max_new_tokens > 0,
+      InvalidArgument,
+      "Max new tokens %d is less than or equal to 0",
+      max_new_tokens);
+
+  text_token_generator_->set_ignore_eos(config.ignore_eos);
+
+  std::vector<uint64_t> tokens = {cur_token};
+  auto generate_result = text_token_generator_->generate(
+      tokens, pos_, max_new_tokens - 1, config.temperature, wrapped_callback);
+  if (!generate_result.ok()) {
+    return generate_result.error();
+  }
+  int64_t num_generated_tokens = generate_result.get();
+
+  pos_ += num_generated_tokens;
+  stats_->num_generated_tokens = num_generated_tokens;
+  stats_->inference_end_ms = time_in_ms();
+
+#ifdef CUDA_AVAILABLE
+  cuda_memory_tracker_->log_sample("after_generate");
+  stats_->gpu_free_after_generate_bytes =
+      cuda_memory_tracker_->last_free_bytes();
+  stats_->gpu_peak_usage_mb = cuda_memory_tracker_->peak_usage_mb();
+#endif
+
+  if (!config.warming) {
+    printf("\n");
+    print_report(*stats_);
+  } else {
+    ET_LOG(Info, "Warmup run finished!");
+  }
+
+  if (stats_callback) {
+    stats_callback(*stats_);
+  }
+
   return Error::Ok;
 }
 
@@ -133,41 +266,37 @@ Error MultimodalRunner::generate(
         }
       };
 
-  // Reset internal state and start inference
   stats_->inference_start_ms = time_in_ms();
 
-  uint64_t prefill_next_token = 0;
-  // Process multimodal inputs in order
-  for (size_t i = 0; i < inputs.size(); ++i) {
-    const MultimodalInput& input = inputs[i];
-    ET_LOG(
-        Info,
-        "Prefilling input %zu/%zu, type: %s",
-        i,
-        inputs.size(),
-        input.type_name());
-    if (config.echo && i == inputs.size() - 1 && input.is_text()) {
-      wrapped_callback(input.get_text());
+  // Echo last text input if requested
+  if (config.echo) {
+    for (auto it = inputs.rbegin(); it != inputs.rend(); ++it) {
+      if (it->is_text()) {
+        wrapped_callback(it->get_text());
+        break;
+      }
     }
-    int32_t bos = 0;
-    int32_t eos = 0;
-    if (i == 0 && input.is_text()) {
-      bos = config.num_bos;
-      eos = config.num_eos;
-    }
-    auto prefill_result = multimodal_prefiller_->prefill(input, pos_, bos, eos);
-    if (!prefill_result.ok()) {
-      return prefill_result.error();
-    }
-    prefill_next_token = prefill_result.get();
   }
+
+  // Prefill all inputs
+  auto prefill_err = prefill(inputs, config);
+  if (prefill_err != Error::Ok) {
+    return prefill_err;
+  }
+
+  ET_CHECK_OR_RETURN_ERROR(
+      prefill_next_token_.has_value(),
+      Internal,
+      "Prefill did not produce a next token");
+
+  uint64_t cur_token = prefill_next_token_.value();
+  prefill_next_token_.reset();
 
   stats_->first_token_ms = time_in_ms();
   stats_->prompt_eval_end_ms = time_in_ms();
   stats_->num_prompt_tokens = pos_;
 
-  auto decode_result =
-      tokenizer_->decode(prefill_next_token, prefill_next_token);
+  auto decode_result = tokenizer_->decode(cur_token, cur_token);
   if (!decode_result.ok()) {
     ET_LOG(
         Error,
@@ -182,9 +311,8 @@ Error MultimodalRunner::generate(
       "RSS after multimodal input processing: %f MiB (0 if unsupported)",
       get_rss_bytes() / 1024.0 / 1024.0);
 
-  // Resolve max_new_tokens based on config
-  int64_t max_context_len =
-      metadata_.at(kMaxContextLen) - 0; // No start_pos offset
+  // Resolve max_new_tokens
+  int64_t max_context_len = metadata_.at(kMaxContextLen);
   int32_t max_new_tokens = config.resolve_max_new_tokens(max_context_len, pos_);
 
   ET_LOG(
@@ -200,34 +328,28 @@ Error MultimodalRunner::generate(
       "Max new tokens %d is less than or equal to 0",
       max_new_tokens);
 
-  // Set ignore_eos based on config
   text_token_generator_->set_ignore_eos(config.ignore_eos);
 
-  // Generate tokens using the text token generator
-  std::vector<uint64_t> prompt_tokens = {prefill_next_token};
+  std::vector<uint64_t> tokens = {cur_token};
   auto generate_result = text_token_generator_->generate(
-      /*tokens=*/prompt_tokens,
-      /*start_pos=*/pos_,
-      /*max_new_tokens=*/max_new_tokens -
-          1, // Subtract 1 because prefill already generated 1 token
-      /*temperature=*/config.temperature,
-      /*token_callback=*/wrapped_callback);
+      tokens,
+      pos_,
+      max_new_tokens - 1,
+      config.temperature,
+      wrapped_callback);
   if (!generate_result.ok()) {
     return generate_result.error();
   }
   int64_t num_generated_tokens = generate_result.get();
 
   pos_ += num_generated_tokens;
-  // Update stats
   stats_->num_generated_tokens = num_generated_tokens;
-  // Finalize stats and call callback
   stats_->inference_end_ms = time_in_ms();
 
 #ifdef CUDA_AVAILABLE
   cuda_memory_tracker_->log_sample("after_generate");
   stats_->gpu_free_after_generate_bytes =
       cuda_memory_tracker_->last_free_bytes();
-  // update peak in case it changed after generation
   stats_->gpu_peak_usage_mb = cuda_memory_tracker_->peak_usage_mb();
 #endif
 
@@ -238,7 +360,6 @@ Error MultimodalRunner::generate(
   if (config.warming) {
     ET_LOG(Info, "Warmup run finished!");
   } else {
-    // Do not print report during warmup
     print_report(*stats_);
   }
 

--- a/extension/llm/runner/multimodal_runner.h
+++ b/extension/llm/runner/multimodal_runner.h
@@ -15,6 +15,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 
@@ -74,7 +75,7 @@ namespace llm {
  *
  *   runner->generate(inputs, config, token_callback, stats_callback);
  */
-class ET_EXPERIMENTAL MultimodalRunner {
+class ET_EXPERIMENTAL MultimodalRunner : public IRunner {
  public:
   /**
    * @brief Constructor for MultimodalRunner with dependency injection
@@ -105,11 +106,25 @@ class ET_EXPERIMENTAL MultimodalRunner {
       std::unique_ptr<TextTokenGenerator> text_token_generator,
       std::unique_ptr<Stats> stats);
 
-  virtual bool is_loaded();
-  virtual ::executorch::runtime::Error load();
+  bool is_loaded() const override;
+  ::executorch::runtime::Error load() override;
+
+  // Bring the non-virtual string convenience overload into scope
+  using IRunner::prefill;
+
+  // IRunner interface: generate from a text prompt.
+  // If prompt is non-empty, prefills it then runs decode loop.
+  // If prompt is empty and pos_ > 0, runs decode loop from current KV cache
+  // state (requires a prior prefill() call).
+  ::executorch::runtime::Error generate(
+      const std::string& prompt,
+      const GenerationConfig& config,
+      std::function<void(const std::string&)> token_callback = {},
+      std::function<void(const Stats&)> stats_callback = {}) override;
 
   /**
    * Generate tokens from the given multimodal inputs using GenerationConfig.
+   * Convenience method: prefills all inputs then runs the decode loop.
    * @param inputs A vector of MultimodalInput objects containing images and
    * text.
    * @param config Generation configuration parameters.
@@ -117,31 +132,35 @@ class ET_EXPERIMENTAL MultimodalRunner {
    * @param stats_callback Callback function for generation statistics.
    * @return The error code. KV cache position is tracked internally in pos_.
    */
-  virtual ::executorch::runtime::Error generate(
+  ::executorch::runtime::Error generate(
       const std::vector<MultimodalInput>& inputs,
       const GenerationConfig& config,
       std::function<void(const std::string&)> token_callback = {},
       std::function<void(const Stats&)> stats_callback = {});
 
   /**
-   * Prefill multimodal inputs, for example to reload chat history.
-   * @param inputs A vector of MultimodalInput objects containing images and
-   * text.
+   * Prefill multimodal inputs without generating tokens.
+   * Overrides IRunner::prefill to handle all modalities (text, image, audio).
+   * @param inputs A vector of MultimodalInput objects.
+   * @param config Generation configuration (num_bos, num_eos used for text
+   * encoding).
    * @return The error code. KV cache position is tracked internally in pos_.
    */
-  virtual ::executorch::runtime::Error prefill(
-      const std::vector<MultimodalInput>& inputs);
+  ::executorch::runtime::Error prefill(
+      const std::vector<MultimodalInput>& inputs,
+      const GenerationConfig& config) override;
 
-  inline void stop() {
+  void stop() override {
     text_token_generator_->stop();
   }
 
-  inline void reset() {
+  void reset() override {
     pos_ = 0;
+    prefill_next_token_.reset();
     stats_->reset();
   }
 
-  virtual ~MultimodalRunner() = default;
+  ~MultimodalRunner() override = default;
 
  protected:
   // Components
@@ -161,6 +180,10 @@ class ET_EXPERIMENTAL MultimodalRunner {
 
   // Internal state
   int64_t pos_;
+
+  // Token predicted by the last prefill() call, used when generate() is called
+  // with an empty prompt after standalone prefill.
+  std::optional<uint64_t> prefill_next_token_;
 };
 
 } // namespace llm

--- a/extension/llm/runner/pybindings.cpp
+++ b/extension/llm/runner/pybindings.cpp
@@ -234,7 +234,8 @@ class PyMultimodalRunner {
     }
     {
       py::gil_scoped_release release;
-      Error error = runner_->prefill(inputs);
+      GenerationConfig config;
+      Error error = runner_->prefill(inputs, config);
       THROW_IF_ERROR(error, "Prefill failed");
     }
   }

--- a/extension/llm/runner/text_llm_runner.cpp
+++ b/extension/llm/runner/text_llm_runner.cpp
@@ -11,6 +11,7 @@
 // The module takes in a string as input and emits a string as output.
 
 #include <executorch/extension/llm/runner/io_manager/io_manager.h>
+#include <executorch/extension/llm/runner/multimodal_input.h>
 #include <executorch/extension/llm/runner/text_llm_runner.h>
 #include <executorch/extension/llm/runner/util.h>
 #include <executorch/runtime/platform/runtime.h>
@@ -76,9 +77,6 @@ Error TextLLMRunner::generate(
     const GenerationConfig& config,
     std::function<void(const std::string&)> token_callback,
     std::function<void(const Stats&)> stats_callback) {
-  // Prepare the inputs.
-  // Use ones-initialized inputs.
-  ET_CHECK_MSG(!prompt.empty(), "Prompt cannot be null");
   if (!is_loaded()) {
     stats_->model_load_start_ms = time_in_ms();
     ET_CHECK_OK_OR_RETURN_ERROR(load());
@@ -105,84 +103,81 @@ Error TextLLMRunner::generate(
           token_callback(piece);
         }
       };
-  // First token time only measures the time it takes to encode the prompt and
-  // return a response token.
 
   stats_->inference_start_ms = time_in_ms();
   shouldStop_ = false;
 
-  ::tokenizers::Result<std::vector<uint64_t>> encode_res = tokenizer_->encode(
-      prompt,
-      /*bos=*/config.num_bos,
-      /*eos=*/config.num_eos);
-
-  if (!encode_res.ok()) {
-    ET_LOG(
-        Error,
-        "Failed to encode prompt %s. Tokenizers error code %d",
-        prompt.c_str(),
-        static_cast<uint32_t>(encode_res.error()));
-    return Error::InvalidArgument;
-  }
-
-  // encode the (string) prompt into tokens sequence
-  std::vector<uint64_t> prompt_tokens = encode_res.get();
-  int num_prompt_tokens = prompt_tokens.size();
-
-  // Reduce max_context_len by pos_
+  uint64_t cur_token = 0;
+  int num_prompt_tokens = 0;
+  // Capture remaining context BEFORE prefill updates pos_
   int64_t max_context_len = metadata_.at(kMaxContextLen) - pos_;
-  ET_CHECK_OR_RETURN_ERROR(
-      num_prompt_tokens >= 1,
-      InvalidArgument,
-      "Expected at least 1 prompt token");
-  ET_CHECK_OR_RETURN_ERROR(
-      num_prompt_tokens < max_context_len,
-      InvalidArgument,
-      "num_prompt_tokens %d >= max_context_len %" PRId64
-      ", Max seq length exceeded - please increase max seq len value in your export script",
-      num_prompt_tokens,
-      max_context_len);
 
-  // Determine max_new_tokens using the GenerationConfig's resolve method,
-  // then subtract pos_ for max_new_tokens.
-  int max_new_tokens =
-      config.resolve_max_new_tokens(max_context_len, num_prompt_tokens);
+  if (!prompt.empty()) {
+    // Normal path: encode prompt, prefill, get first token
+    auto encode_res = tokenizer_->encode(
+        prompt,
+        /*bos=*/config.num_bos,
+        /*eos=*/config.num_eos);
 
-  ET_LOG(
-      Info,
-      "Max new tokens resolved: %d, given pos_ %" PRId64
-      ", num_prompt_tokens %zu, max_context_len %" PRId64,
-      max_new_tokens,
-      pos_,
-      prompt_tokens.size(),
-      max_context_len);
-  ET_CHECK_OR_RETURN_ERROR(
-      max_new_tokens > 0,
-      InvalidArgument,
-      "Max new tokens %d is less than or equal to 0",
-      max_new_tokens);
-  // Prefill first
-  // Here feed all tokens to the model and get the next predicted token
-  // after the prompt. After that we will enter generate loop.
+    if (!encode_res.ok()) {
+      ET_LOG(
+          Error,
+          "Failed to encode prompt %s. Tokenizers error code %d",
+          prompt.c_str(),
+          static_cast<uint32_t>(encode_res.error()));
+      return Error::InvalidArgument;
+    }
 
-  // print prompts
-  if (config.echo) {
-    wrapped_callback(prompt);
+    std::vector<uint64_t> prompt_tokens = encode_res.get();
+    num_prompt_tokens = prompt_tokens.size();
+
+    ET_CHECK_OR_RETURN_ERROR(
+        num_prompt_tokens >= 1,
+        InvalidArgument,
+        "Expected at least 1 prompt token");
+    ET_CHECK_OR_RETURN_ERROR(
+        num_prompt_tokens < max_context_len,
+        InvalidArgument,
+        "num_prompt_tokens %d >= max_context_len %" PRId64
+        ", Max seq length exceeded - please increase max seq len value in your export script",
+        num_prompt_tokens,
+        max_context_len);
+
+    if (config.echo) {
+      wrapped_callback(prompt);
+    }
+    auto prefill_res = text_prefiller_->prefill(prompt_tokens, pos_);
+    ET_CHECK_OK_OR_RETURN_ERROR(prefill_res.error());
+    cur_token = prefill_res.get();
+    prefill_next_token_.reset();
+  } else {
+    // Empty prompt path: use saved token from prior prefill() call
+    ET_CHECK_OR_RETURN_ERROR(
+        prefill_next_token_.has_value(),
+        InvalidArgument,
+        "Empty prompt requires a prior prefill() call");
+    cur_token = prefill_next_token_.value();
+    prefill_next_token_.reset();
+    // num_prompt_tokens stays 0: no new prompt tokens in this generate call.
+    // max_context_len already correct (kMaxContextLen - pos_ from prior prefills).
   }
-  auto prefill_res = text_prefiller_->prefill(prompt_tokens, pos_);
-  ET_CHECK_OK_OR_RETURN_ERROR(prefill_res.error());
-  uint64_t cur_token = prefill_res.get();
+
+  // Capture for stats before generation loop modifies pos_.
+  // For empty prompt, pos_ reflects total prefilled tokens.
+  int stats_num_prompt_tokens =
+      prompt.empty() ? static_cast<int>(pos_) : num_prompt_tokens;
+
   stats_->first_token_ms = time_in_ms();
   stats_->prompt_eval_end_ms = time_in_ms();
 
-  // print the first token from prefill. No prev_token so use cur_token for it.
+  // Decode and callback the first generated token
   auto decode_result = tokenizer_->decode(cur_token, cur_token);
   if (!decode_result.ok()) {
     ET_LOG(
         Error,
         "Tokenizers error code %d",
         static_cast<uint32_t>(decode_result.error()));
-    return ::executorch::runtime::Error::InvalidArgument;
+    return Error::InvalidArgument;
   }
   wrapped_callback(std::move(*decode_result));
   RUNNER_ET_LOG(
@@ -190,15 +185,31 @@ Error TextLLMRunner::generate(
       "RSS after prompt prefill: %f MiB (0 if unsupported)",
       get_rss_bytes() / 1024.0 / 1024.0);
 
-  // start the main loop
-  prompt_tokens.push_back(cur_token);
+  // Resolve max_new_tokens: max_context_len was captured before prefill
+  int max_new_tokens =
+      config.resolve_max_new_tokens(max_context_len, num_prompt_tokens);
+
+  ET_LOG(
+      Info,
+      "Max new tokens resolved: %d, given pos_ %" PRId64
+      ", num_prompt_tokens %d, max_context_len %" PRId64,
+      max_new_tokens,
+      pos_,
+      num_prompt_tokens,
+      max_context_len);
+  ET_CHECK_OR_RETURN_ERROR(
+      max_new_tokens > 0,
+      InvalidArgument,
+      "Max new tokens %d is less than or equal to 0",
+      max_new_tokens);
 
   // Set ignore_eos based on config
   text_token_generator_->set_ignore_eos(config.ignore_eos);
 
-  // Generate max_new_tokens - 1 because prefill already generated 1 token.
+  // Generate remaining tokens (prefill already produced 1)
+  std::vector<uint64_t> tokens = {cur_token};
   auto generate_result = text_token_generator_->generate(
-      prompt_tokens,
+      tokens,
       pos_,
       max_new_tokens - 1,
       temperature_ == -1.0f ? config.temperature : temperature_,
@@ -223,13 +234,12 @@ Error TextLLMRunner::generate(
     RUNNER_ET_LOG(config.warming, "Max new tokens %i reached!", max_new_tokens);
   }
 
-  stats_->num_prompt_tokens = num_prompt_tokens;
+  stats_->num_prompt_tokens = stats_num_prompt_tokens;
   stats_->num_generated_tokens = num_generated_tokens;
 
   if (config.warming) {
     ET_LOG(Info, "Warmup run finished!");
   } else {
-    // Do not print report during warmup
     print_report(*stats_);
   }
   if (stats_callback) {
@@ -240,24 +250,36 @@ Error TextLLMRunner::generate(
 }
 
 Error TextLLMRunner::prefill(
-    const std::string& prompt,
+    const std::vector<MultimodalInput>& inputs,
     const GenerationConfig& config) {
   if (!is_loaded()) {
     ET_CHECK_OK_OR_RETURN_ERROR(load());
   }
 
-  ::tokenizers::Result<std::vector<uint64_t>> encode_res = tokenizer_->encode(
-      prompt,
-      /*bos=*/config.num_bos,
-      /*eos=*/config.num_eos);
+  for (const auto& input : inputs) {
+    if (input.is_text()) {
+      auto encode_res = tokenizer_->encode(
+          input.get_text(),
+          /*bos=*/config.num_bos,
+          /*eos=*/config.num_eos);
 
-  ET_CHECK_TK_OK_OR_RETURN_ERROR(
-      encode_res.error(), "Failed to encode prompt %s", prompt.c_str());
+      ET_CHECK_TK_OK_OR_RETURN_ERROR(
+          encode_res.error(),
+          "Failed to encode prompt %s",
+          input.get_text().c_str());
 
-  // encode the (string) prompt into tokens sequence
-  std::vector<uint64_t> prompt_tokens = encode_res.get();
-  auto prefill_res = text_prefiller_->prefill(prompt_tokens, pos_);
-  ET_CHECK_OK_OR_RETURN_ERROR(prefill_res.error());
+      std::vector<uint64_t> prompt_tokens = encode_res.get();
+      auto prefill_res = text_prefiller_->prefill(prompt_tokens, pos_);
+      ET_CHECK_OK_OR_RETURN_ERROR(prefill_res.error());
+      prefill_next_token_ = prefill_res.get();
+    } else if (input.is_tokens()) {
+      std::vector<uint64_t> tokens = input.get_tokens();
+      auto prefill_res = text_prefiller_->prefill(tokens, pos_);
+      ET_CHECK_OK_OR_RETURN_ERROR(prefill_res.error());
+      prefill_next_token_ = prefill_res.get();
+    }
+    // Skip image/audio inputs — not supported by text-only runner
+  }
   return Error::Ok;
 }
 
@@ -287,6 +309,7 @@ void TextLLMRunner::stop() {
 void TextLLMRunner::reset() {
   stats_->reset();
   pos_ = 0;
+  prefill_next_token_.reset();
 }
 
 } // namespace executorch::extension::llm

--- a/extension/llm/runner/text_llm_runner.h
+++ b/extension/llm/runner/text_llm_runner.h
@@ -14,10 +14,12 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 
 #include <executorch/extension/llm/runner/irunner.h>
+#include <executorch/extension/llm/runner/multimodal_input.h>
 #include <executorch/extension/llm/runner/stats.h>
 #include <executorch/extension/llm/runner/text_decoder_runner.h>
 #include <executorch/extension/llm/runner/text_prefiller.h>
@@ -101,15 +103,19 @@ class ET_EXPERIMENTAL TextLLMRunner : public IRunner {
       std::function<void(const std::string&)> token_callback = {},
       std::function<void(const Stats&)> stats_callback = {}) override;
 
+  // Bring the non-virtual string convenience overload into scope
+  using IRunner::prefill;
+
   /**
-   * Prefill text inputs, for example to reload chat history.
-   * @param prompt Text prompt to prefill.
-   * @param config Configuration parameters for text generation (e.g.,
-   * max_new_tokens, temperature)
+   * Prefill with multimodal inputs. Only text and token inputs are processed;
+   * image/audio inputs are silently skipped (use MultimodalRunner for those).
+   * @param inputs A vector of MultimodalInput objects.
+   * @param config Configuration parameters (num_bos, num_eos used for
+   * encoding)
    * @return The error code. KV cache position is tracked internally in pos_.
    */
   ::executorch::runtime::Error prefill(
-      const std::string& prompt,
+      const std::vector<MultimodalInput>& inputs,
       const GenerationConfig& config) override;
 
   /**
@@ -168,6 +174,10 @@ class ET_EXPERIMENTAL TextLLMRunner : public IRunner {
 
   // The position in KV cache of the input, starting from 0.
   int64_t pos_ = 0;
+
+  // Token predicted by the last prefill() call, used when generate() is called
+  // with an empty prompt after standalone prefill.
+  std::optional<uint64_t> prefill_next_token_;
 };
 
 } // namespace executorch::extension::llm

--- a/extension/llm/runner/text_llm_runner.h
+++ b/extension/llm/runner/text_llm_runner.h
@@ -110,7 +110,7 @@ class ET_EXPERIMENTAL TextLLMRunner : public IRunner {
    */
   ::executorch::runtime::Error prefill(
       const std::string& prompt,
-      const GenerationConfig& config);
+      const GenerationConfig& config) override;
 
   /**
    * @brief Warms up the model with a sample prompt


### PR DESCRIPTION
### Summary

Each prefillXxx() JNI method now calls multi_modal_runner_->prefill()
directly instead of appending to prefill_inputs_ buffer. This means
prefillImages() actually runs the vision encoder, prefillAudio() runs
the audio encoder, etc. — real model computation at call time.

The generate() multimodal path no longer drains the buffer; it only
passes its prompt parameter to multi_modal_runner_->generate().

Remove prefill_inputs_ member entirely — no buffer exists anywhere.
Rename all append_xxx methods to prefill_xxx to reflect the new
behavior.

### Test plan
CI