### PR TITLE
NXP backend: Condition Linear+BatchNorm fusing passes to valid combination only

### DIFF
--- a/backends/nxp/aten_passes/fuse_batch_norm_with_linear_pass.py
+++ b/backends/nxp/aten_passes/fuse_batch_norm_with_linear_pass.py
@@ -4,6 +4,8 @@
 # LICENSE file in the root directory of this source tree.
 
 import torch
+
+from executorch.backends.nxp.backend.graph_utils import get_output_shape
 from torch.export.unflatten import _assign_attr, _AttrKind
 from torch.fx import GraphModule, Node
 from torch.fx.passes.infra.pass_base import PassBase, PassResult
@@ -102,6 +104,14 @@ class FuseBatchNormWithLinearPass(PassBase):
                 continue  # Something other than a Linear node comes before the BatchNorm.
 
             linear_node = bn_node.args[0]
+            linear_out_shape = get_output_shape(linear_node)
+
+            # Skip cases where batch norm does not operate on the same dim as linear.
+            # Linear operates on the last dim while batch norm works with the first dim right after batch.
+            # The only case where this occurs is when input shape is (B, C).
+            if not linear_out_shape or len(linear_out_shape) != 2:
+                continue
+
             linear_weight_node_or_fq = linear_node.args[1]
             linear_bias_node_or_fq = (
                 linear_node.args[2] if len(linear_node.args) > 2 else None

--- a/backends/nxp/aten_passes/simulated_linear_bn_fusion_passes/add_simulated_linear_bn_fusion_qat_pass.py
+++ b/backends/nxp/aten_passes/simulated_linear_bn_fusion_passes/add_simulated_linear_bn_fusion_qat_pass.py
@@ -9,7 +9,11 @@ import torch
 from executorch.backends.nxp.aten_passes.fuse_batch_norm_with_linear_pass import (
     _unwrap_if_fq,
 )
-from executorch.backends.nxp.backend.graph_utils import is_batch_norm, is_op_node
+from executorch.backends.nxp.backend.graph_utils import (
+    get_output_shape,
+    is_batch_norm,
+    is_op_node,
+)
 from torch.fx import GraphModule, Node
 from torch.fx.passes.infra.pass_base import PassBase, PassResult
 from torchao.quantization.pt2e.export_utils import WrapperModule
@@ -260,6 +264,13 @@ class AddSimulatedLinearBatchNormFusionQATPass(PassBase):
                 continue
 
             linear_node = bn_in
+            linear_out_shape = get_output_shape(linear_node)
+
+            # Skip cases where batch norm does not operate on the same dim as linear.
+            # Linear operates on the last dim while batch norm works with the first dim right after batch.
+            # The only case where this occurs is when input shape is (B, C).
+            if not linear_out_shape or len(linear_out_shape) != 2:
+                continue
 
             linear_w_node_or_fq = linear_node.args[1]
             linear_b_node_or_fq = (

--- a/backends/nxp/aten_passes/simulated_linear_bn_fusion_passes/remove_simulated_linear_bn_fusion_qat_pass.py
+++ b/backends/nxp/aten_passes/simulated_linear_bn_fusion_passes/remove_simulated_linear_bn_fusion_qat_pass.py
@@ -78,7 +78,7 @@ def _is_denorm_pattern(node: Node) -> bool:
     return False
 
 
-def _remove_pattern_from_graph(graph_module: GraphModule, pattern: GraphModule):
+def _remove_pattern_from_graph(graph_module: GraphModule, pattern: GraphModule) -> bool:
     matcher = SubgraphMatcher(
         pattern.graph,
         match_output=False,
@@ -88,6 +88,7 @@ def _remove_pattern_from_graph(graph_module: GraphModule, pattern: GraphModule):
     )
     matches: list[InternalMatch] = matcher.match(graph_module.graph, node_name_match="")
 
+    made_changes = False
     for match in matches:
         last_pattern_node = match.anchors[0]
         last_matched_subgraph_node = match.nodes_map[last_pattern_node]
@@ -98,31 +99,34 @@ def _remove_pattern_from_graph(graph_module: GraphModule, pattern: GraphModule):
         weight = match.placeholder_nodes[0]
 
         last_matched_subgraph_node.replace_all_uses_with(weight)
+        made_changes = True
 
         for node in match.nodes_map.values():
             if node not in match.placeholder_nodes:
                 graph_module.graph.erase_node(node)
 
+    return made_changes
 
-def _remove_late_bias_pattern(graph_module: GraphModule, bias_node: Node):
+
+def _remove_late_bias_pattern(graph_module: GraphModule, bias_node: Node) -> bool:
     linear_b_users = list(bias_node.users.keys())
 
     if len(linear_b_users) != 2:
-        return
+        return False
 
     if _is_zeros_like(linear_b_users[0]):
         zeros_node, maybe_reshape_node = linear_b_users
     elif _is_zeros_like(linear_b_users[1]):
         maybe_reshape_node, zeros_node = linear_b_users
     else:
-        return
+        return False
 
     if _is_reshape(maybe_reshape_node):
         reshape_node = maybe_reshape_node
         reshape_users = list(reshape_node.users.keys())
 
         if len(reshape_users) != 1:
-            return
+            return False
 
         add_node = reshape_users[0]
     else:
@@ -131,7 +135,7 @@ def _remove_late_bias_pattern(graph_module: GraphModule, bias_node: Node):
         add_node = maybe_reshape_node
 
     if not _is_add(add_node):
-        return
+        return False
 
     # Remove zeroed linear bias
     zeros_node.replace_all_uses_with(bias_node)
@@ -144,10 +148,13 @@ def _remove_late_bias_pattern(graph_module: GraphModule, bias_node: Node):
     if reshape_node:
         graph_module.graph.erase_node(reshape_node)
 
+    return True
+
 
 def _remove_denorm_and_late_bias(graph_module: GraphModule) -> bool:
     named_modules = dict(graph_module.named_modules(remove_duplicate=False))
 
+    made_changes = False
     for node in graph_module.graph.nodes:
         if not _is_linear(node):
             continue
@@ -164,7 +171,7 @@ def _remove_denorm_and_late_bias(graph_module: GraphModule) -> bool:
         has_late_bias = _is_zeros_like(linear_bias_fq_or_zeros)
 
         if has_late_bias:
-            _remove_late_bias_pattern(
+            made_changes |= _remove_late_bias_pattern(
                 graph_module, bias_node=linear_bias_fq_or_zeros.args[0]
             )
 
@@ -173,7 +180,10 @@ def _remove_denorm_and_late_bias(graph_module: GraphModule) -> bool:
                 if any(is_batch_norm(user) for user in user_node.users.keys()):
                     user_node.replace_all_uses_with(node)
                     graph_module.graph.erase_node(user_node)
+                    made_changes = True
                     break
+
+    return made_changes
 
 
 class RemoveSimulatedLinearBatchNormFusionQATPass(PassBase):
@@ -192,6 +202,7 @@ class RemoveSimulatedLinearBatchNormFusionQATPass(PassBase):
         Given a graph of decomposed aten ops, removes nodes corresponding to linear + batch norm fusion.
         """
         is_cuda = False
+        made_changes = False
 
         graph_module.graph.eliminate_dead_code()
         graph_module.recompile()
@@ -219,11 +230,16 @@ class RemoveSimulatedLinearBatchNormFusionQATPass(PassBase):
             is_cuda=is_cuda,
         )
 
-        _remove_pattern_from_graph(graph_module, pattern=scale_match_pattern)
-        _remove_pattern_from_graph(graph_module, pattern=weight_preprocess_pattern)
-        _remove_denorm_and_late_bias(graph_module)
+        made_changes |= _remove_pattern_from_graph(
+            graph_module, pattern=scale_match_pattern
+        )
+        made_changes |= _remove_pattern_from_graph(
+            graph_module, pattern=weight_preprocess_pattern
+        )
+        made_changes |= _remove_denorm_and_late_bias(graph_module)
 
-        graph_module.graph.eliminate_dead_code()
-        graph_module.recompile()
+        if made_changes:
+            graph_module.graph.eliminate_dead_code()
+            graph_module.recompile()
 
-        return PassResult(graph_module, True)
+        return PassResult(graph_module, made_changes)

--- a/backends/nxp/aten_passes/simulated_linear_bn_fusion_passes/remove_simulated_linear_bn_fusion_qat_pass.py
+++ b/backends/nxp/aten_passes/simulated_linear_bn_fusion_passes/remove_simulated_linear_bn_fusion_qat_pass.py
@@ -145,7 +145,7 @@ def _remove_late_bias_pattern(graph_module: GraphModule, bias_node: Node):
         graph_module.graph.erase_node(reshape_node)
 
 
-def _remove_denorm_and_late_bias(graph_module: GraphModule):
+def _remove_denorm_and_late_bias(graph_module: GraphModule) -> bool:
     named_modules = dict(graph_module.named_modules(remove_duplicate=False))
 
     for node in graph_module.graph.nodes:

--- a/backends/nxp/backend/graph_utils.py
+++ b/backends/nxp/backend/graph_utils.py
@@ -38,7 +38,12 @@ def is_batch_norm(node: Node) -> bool:
     return is_op_node(node, batch_norm_target_ops)
 
 
-def get_output_shape(node: Node) -> torch.Size | None:
-    if node.meta.get("tensor_meta") is not None:
-        return node.meta["tensor_meta"].shape
+def get_output_shape(node: Node) -> tuple[torch.Size] | torch.Size | None:
+    val = node.meta.get("val")
+
+    if isinstance(val, torch.Tensor):
+        return val.shape
+    elif isinstance(val, tuple):
+        return tuple([v.shape for v in val])
+
     return None

--- a/backends/nxp/backend/graph_utils.py
+++ b/backends/nxp/backend/graph_utils.py
@@ -36,3 +36,9 @@ def is_op_node(node: Node, target_op) -> bool:
 
 def is_batch_norm(node: Node) -> bool:
     return is_op_node(node, batch_norm_target_ops)
+
+
+def get_output_shape(node: Node) -> torch.Size | None:
+    if node.meta.get("tensor_meta") is not None:
+        return node.meta["tensor_meta"].shape
+    return None

--- a/backends/nxp/tests/ir/edge_passes/test_linear_bn_fusing.py
+++ b/backends/nxp/tests/ir/edge_passes/test_linear_bn_fusing.py
@@ -45,10 +45,12 @@ from torchao.quantization.pt2e.quantize_pt2e import convert_pt2e, prepare_qat_pt
 def test_add_simulated_linear_bn_fusing(input_shape, linear_bias):
     calibration_inputs = get_random_calibration_inputs(to_model_input_spec(input_shape))
     input_sample = calibration_inputs[0]
-    model = models.LinearBNModule(
-        in_features=input_shape[-1],
-        out_features=5,
-        linear_bias=linear_bias,
+    model = models.LinearBatchNormModule(
+        bias=linear_bias,
+        input_rank=len(input_shape),
+        fc_in_features=input_shape[-1],
+        fc_out_features=5,
+        bn_in_features=5,
     )
     model.train()
     raw_output = model(input_sample[0])
@@ -110,10 +112,12 @@ def test_full_linear_bn_fusing(input_shape, linear_bias):
 
     calibration_inputs = get_random_calibration_inputs(to_model_input_spec(input_shape))
     input_sample = calibration_inputs[0]
-    model = models.LinearBNModule(
-        in_features=input_shape[-1],
-        out_features=5,
-        linear_bias=linear_bias,
+    model = models.LinearBatchNormModule(
+        bias=linear_bias,
+        input_rank=len(input_shape),
+        fc_in_features=input_shape[-1],
+        fc_out_features=5,
+        bn_in_features=5,
     )
     model.train()
     raw_output = model(input_sample[0])
@@ -175,11 +179,13 @@ def test_input_output_graph_equivalence(input_shape, linear_bias, bn_eps):
 
     calibration_inputs = get_random_calibration_inputs(to_model_input_spec(input_shape))
     input_sample = calibration_inputs[0]
-    model = models.LinearBNModule(
-        in_features=input_shape[-1],
-        out_features=5,
-        linear_bias=linear_bias,
-        bn_eps=bn_eps,
+    model = models.LinearBatchNormModule(
+        bias=linear_bias,
+        input_rank=len(input_shape),
+        fc_in_features=input_shape[-1],
+        fc_out_features=5,
+        bn_in_features=5,
+        eps=bn_eps,
     )
     model.eval()
 
@@ -216,11 +222,13 @@ def test_linear_bn_full_qat_pipeline_conversion(
             "The graph currently produces Linear layer without quantized bias which is incorrect."
         )
 
-    model = models.LinearBNModule(
-        in_features=input_shape[-1],
-        out_features=5,
-        linear_bias=linear_bias,
-        bn_eps=bn_eps,
+    model = models.LinearBatchNormModule(
+        bias=linear_bias,
+        input_rank=len(input_shape),
+        fc_in_features=input_shape[-1],
+        fc_out_features=5,
+        bn_in_features=5,
+        eps=bn_eps,
     )
     model.eval()
 
@@ -258,3 +266,49 @@ def test_linear_bn_full_qat_pipeline_conversion(
         input_data=input_data,
         atol=0.0,
     )
+
+
+@pytest.mark.parametrize("input_shape", [(2, 3, 5), (2, 3, 5, 5), (2, 3, 3, 5, 5)])
+@pytest.mark.parametrize("linear_bias", [True, False])
+@pytest.mark.parametrize("bn_eps", [1e-5, 1e-6])
+def test_incompatible_linear_bn_not_fused(mocker, input_shape, linear_bias, bn_eps):
+    """
+    Test cases ensuring Linear+BN are not fused when not compatible for fusion.
+    Linear+BN are only fusable when using BatchNorm1d and input has 2 dims (N, L).
+    """
+
+    # TODO: Add pass for quantizing bias node when Linear has bias=False
+    if not linear_bias:
+        pytest.skip(
+            "Linear with bias=False is not yet supported. "
+            "The graph currently produces Linear layer without quantized bias which is incorrect."
+        )
+
+    model = models.LinearBatchNormModule(
+        bias=linear_bias,
+        input_rank=len(input_shape),
+        fc_in_features=input_shape[-1],
+        fc_out_features=5,
+        bn_in_features=input_shape[1],
+        eps=bn_eps,
+    )
+    model.eval()
+    model(torch.randn(input_shape))
+
+    # Run conversion
+    edge_program = to_quantized_edge_program(
+        model, input_shape, use_qat=True, use_neutron_for_format_conversion=False
+    ).exported_program()
+
+    assert graph_contains_any_of_ops(
+        graph=edge_program.graph,
+        ops=[
+            exir_ops.edge.aten.addmm.default,
+            exir_ops.edge.aten.linear.default,
+        ],
+    )
+    assert graph_contains_any_of_ops(
+        graph=edge_program.graph,
+        ops=batch_norm_target_ops,
+    )
+    assert not any("lowered_module" in node.name for node in edge_program.graph.nodes)

--- a/backends/nxp/tests/ir/edge_passes/test_linear_bn_fusing.py
+++ b/backends/nxp/tests/ir/edge_passes/test_linear_bn_fusing.py
@@ -311,4 +311,6 @@ def test_incompatible_linear_bn_not_fused(mocker, input_shape, linear_bias, bn_e
         graph=edge_program.graph,
         ops=batch_norm_target_ops,
     )
-    assert not any("lowered_module" in node.name for node in edge_program.graph.nodes)
+    assert not graph_contains_any_of_ops(
+        edge_program.graph, [torch.ops.higher_order.executorch_call_delegate]
+    )

--- a/backends/nxp/tests/models.py
+++ b/backends/nxp/tests/models.py
@@ -8,7 +8,6 @@ import math
 from typing import Callable, Collection, Union
 
 import torch
-
 from torch import nn
 
 
@@ -463,51 +462,114 @@ class Conv2dReLUMaxPoolModule(torch.nn.Module):
         return self.pool(x)
 
 
-class ConvBNModule(torch.nn.Module):
-    def __init__(self, conv_module, conv_bias, bn_affine):
+class BatchNormModule(torch.nn.Module):
+    def __init__(
+        self, input_rank: int, num_features: int, affine: bool = True, eps: float = 1e-5
+    ):
         super().__init__()
-
-        if conv_module == "conv1d":
-            self.conv = torch.nn.Conv1d(3, 64, 3, padding=1, bias=conv_bias)
-            self.bn = torch.nn.BatchNorm1d(64, affine=bn_affine)
-        elif conv_module == "conv2d":
-            self.conv = torch.nn.Conv2d(3, 64, 3, padding=1, bias=conv_bias)
-            self.bn = torch.nn.BatchNorm2d(64, affine=bn_affine)
-        elif conv_module == "conv1d_t":
-            self.conv = torch.nn.ConvTranspose1d(3, 64, 3, padding=1, bias=conv_bias)
-            self.bn = torch.nn.BatchNorm1d(64, affine=bn_affine)
-        elif conv_module == "conv2d_t":
-            self.conv = torch.nn.ConvTranspose2d(3, 64, 3, padding=1, bias=conv_bias)
-            self.bn = torch.nn.BatchNorm2d(64, affine=bn_affine)
-        else:
-            raise ValueError(f"Unknown conv_module: {conv_module}")
+        match input_rank - 2:
+            case 0 | 1:
+                self.batch_norm = nn.BatchNorm1d(num_features, eps, affine=affine)
+            case 2:
+                self.batch_norm = nn.BatchNorm2d(num_features, eps, affine=affine)
+            case 3:
+                self.batch_norm = nn.BatchNorm3d(num_features, eps, affine=affine)
+            case _:
+                raise ValueError(f"Unsupported rank {input_rank}")
+        self.eval()
 
     def forward(self, x):
-        x = self.conv(x)
-        return self.bn(x)
+        return self.batch_norm(x)
 
 
-class LinearBNModule(torch.nn.Module):
+class ConvBatchNormModule(torch.nn.Module):
     def __init__(
         self,
-        in_features: int,
-        out_features: int,
-        linear_bias: bool,
-        bn_eps: float = 1e-5,
-        act: nn.Module | None = None,
+        bias: bool,
+        input_rank: int,
+        num_features: int,
+        transposed_conv: bool = False,
+        bn_affine: bool = True,
+        eps: float = 1e-5,
     ):
         super().__init__()
 
-        self.linear = torch.nn.Linear(
-            in_features=in_features, out_features=out_features, bias=linear_bias
-        )
-        self.bn = torch.nn.BatchNorm1d(out_features, eps=bn_eps)
-        self.act = act
+        if (input_rank == 2 or input_rank == 3) and not transposed_conv:
+            self.conv = torch.nn.Conv1d(
+                in_channels=num_features,
+                out_channels=num_features,
+                kernel_size=3,
+                bias=bias,
+            )
+        elif input_rank == 4 and not transposed_conv:
+            self.conv = torch.nn.Conv2d(
+                in_channels=num_features,
+                out_channels=num_features,
+                kernel_size=3,
+                bias=bias,
+            )
+        elif input_rank == 5 and not transposed_conv:
+            self.conv = torch.nn.Conv3d(
+                in_channels=num_features,
+                out_channels=num_features,
+                kernel_size=3,
+                bias=bias,
+            )
+        elif (input_rank == 2 or input_rank == 3) and transposed_conv:
+            self.conv = torch.nn.ConvTranspose1d(
+                in_channels=num_features,
+                out_channels=num_features,
+                kernel_size=3,
+                bias=bias,
+            )
+        elif input_rank == 4 and transposed_conv:
+            self.conv = torch.nn.ConvTranspose2d(
+                in_channels=num_features,
+                out_channels=num_features,
+                kernel_size=3,
+                bias=bias,
+            )
+        elif input_rank == 5 and transposed_conv:
+            self.conv = torch.nn.ConvTranspose3d(
+                in_channels=num_features,
+                out_channels=num_features,
+                kernel_size=3,
+                bias=bias,
+            )
+        else:
+            raise ValueError(f"Unsupported rank {input_rank}")
+
+        self.batch_norm = BatchNormModule(input_rank, num_features, bn_affine, eps)
+        self.eval()
+
+    def forward(self, x):
+        x = self.conv(x)
+        return self.batch_norm(x)
+
+
+class LinearBatchNormModule(torch.nn.Module):
+    def __init__(
+        self,
+        bias: bool,
+        input_rank: int,
+        fc_in_features: int,
+        fc_out_features: int,
+        bn_in_features: int,
+        bn_affine: bool = True,
+        eps: float = 1e-5,
+    ):
+        super().__init__()
+        self.linear = torch.nn.Linear(fc_in_features, fc_out_features, bias=bias)
+
+        if input_rank == 2:
+            bn_in_features = fc_out_features
+
+        self.batch_norm = BatchNormModule(input_rank, bn_in_features, bn_affine, eps)
+        self.eval()
 
     def forward(self, x):
         x = self.linear(x)
-        x = self.bn(x)
-        return self.act(x) if self.act is not None else x
+        return self.batch_norm(x)
 
 
 class MulTensorModule(torch.nn.Module):

--- a/backends/nxp/tests/test_batch_norm_fusion.py
+++ b/backends/nxp/tests/test_batch_norm_fusion.py
@@ -11,6 +11,7 @@ import torch
 from executorch.backends.nxp.aten_passes.neutron_aten_pass_manager import (
     NeutronAtenPassManager,
 )
+from executorch.backends.nxp.backend.graph_utils import batch_norm_target_ops
 from executorch.backends.nxp.backend.ir.converter.node_converters.ops_converters import (
     AddMMConverter,
     MMConverter,
@@ -26,9 +27,10 @@ from executorch.backends.nxp.tests.executors import (
     graph_contains_any_of_ops,
     OverrideTargetSupportCheck,
 )
-
-from executorch.backends.nxp.tests.models import ConvBNModule
-from torch import nn
+from executorch.backends.nxp.tests.models import (
+    ConvBatchNormModule,
+    LinearBatchNormModule,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -37,69 +39,11 @@ def reseed_model_per_test_run():
     np.random.seed(23)
 
 
-class BatchNormModule(torch.nn.Module):
-    def __init__(self, input_rank: int, num_features: int, eps: float = 1e-5):
-        super().__init__()
-        match input_rank - 2:
-            case 1:
-                self.batch_norm = nn.BatchNorm1d(num_features, eps)
-            case 2:
-                self.batch_norm = nn.BatchNorm2d(num_features, eps)
-            case 3:
-                self.batch_norm = nn.BatchNorm3d(num_features, eps)
-            case _:
-                raise ValueError
-        self.eval()
-
-    def forward(self, x):
-        return self.batch_norm(x)
-
-
-class ConvBatchNormModule(torch.nn.Module):
-    def __init__(
-        self, bias: bool, input_rank: int, num_features: int, eps: float = 1e-5
-    ):
-        super().__init__()
-        self.conv = torch.nn.Conv2d(
-            in_channels=num_features,
-            out_channels=num_features,
-            kernel_size=3,
-            bias=bias,
-        )
-        self.batch_norm = BatchNormModule(input_rank, num_features, eps)
-        self.eval()
-
-    def forward(self, x):
-        x = self.conv(x)
-        return self.batch_norm(x)
-
-
-class LinearBatchNormModule(torch.nn.Module):
-    def __init__(
-        self,
-        bias: bool,
-        input_rank: int,
-        fc_in_features: int,
-        fc_out_features: int,
-        eps: float = 1e-5,
-    ):
-        super().__init__()
-        self.linear = torch.nn.Linear(fc_in_features, fc_out_features, bias=bias)
-        self.batch_norm = BatchNormModule(input_rank, fc_out_features, eps)
-        self.eval()
-
-    def forward(self, x):
-        x = self.linear(x)
-        return self.batch_norm(x)
-
-
 @pytest.mark.parametrize(
     "bias", [True, False], ids=lambda x: "Bias" if x else "No bias"
 )
-@pytest.mark.parametrize(
-    "input_shape", [[4, 6, 8], [2, 4, 6, 8]], ids=lambda x: f"{len(x)}D"
-)
-def test_batch_norm_conv_fusing(bias: bool, input_shape: list[int]):
+def test_batch_norm_conv_fusing(bias: bool):
+    input_shape = [2, 4, 6, 8]
     example_input = (torch.ones(*input_shape),)
 
     module = ConvBatchNormModule(bias, len(input_shape), 4)
@@ -107,26 +51,19 @@ def test_batch_norm_conv_fusing(bias: bool, input_shape: list[int]):
     og_module = program.module()
 
     pm = NeutronAtenPassManager(neutron_target_spec)
-    graph_module_out = pm(deepcopy(program.module())).graph_module
+    transformed_module = pm(deepcopy(program.module())).graph_module
 
     # Make sure the fusion worked.
-    og_nodes = list(program.graph.nodes)
-    transformed_nodes = list(graph_module_out.graph.nodes)
+    assert graph_contains_any_of_ops(program.graph, batch_norm_target_ops)
 
-    assert any(
-        node.op == "call_function" and node.target.__name__ == "batch_norm.default"
-        for node in og_nodes
-    )
-
-    assert not any(
-        node.op == "call_function" and "batch_norm" in node.target.__name__
-        for node in transformed_nodes
+    assert not graph_contains_any_of_ops(
+        transformed_module.graph, batch_norm_target_ops
     )
 
     # Verify that the behavior has not changed.
     input_data = torch.randn(input_shape, dtype=torch.float32)
     out1 = og_module(input_data).detach().numpy()
-    out2 = graph_module_out(input_data).detach().numpy()
+    out2 = transformed_module(input_data).detach().numpy()
     torch.testing.assert_close(out1, out2)
 
 
@@ -134,10 +71,12 @@ def test_batch_norm_conv_fusing(bias: bool, input_shape: list[int]):
     "bias", [True, False], ids=lambda x: "Bias" if x else "No bias"
 )
 def test_batch_norm_linear_fusing(bias: bool):
-    input_shape = (2, 4, 6, 8)
+    input_shape = (2, 4)
     example_input = (torch.ones(*input_shape),)
 
-    module = LinearBatchNormModule(bias, 4, input_shape[-1], input_shape[1])
+    module = LinearBatchNormModule(
+        bias, 2, input_shape[-1], input_shape[1], input_shape[1]
+    )
     program = torch.export.export(module, example_input, strict=True)
     og_module = program.module()
 
@@ -145,18 +84,15 @@ def test_batch_norm_linear_fusing(bias: bool):
     graph_module_out = pm(deepcopy(program.module())).graph_module
 
     # Make sure the fusion worked.
-    og_nodes = list(og_module.graph.nodes)
-    transformed_nodes = list(graph_module_out.graph.nodes)
-
-    assert any(
-        node.op == "call_function" and node.target.__name__ == "linear.default"
-        for node in og_nodes
+    assert graph_contains_any_of_ops(
+        graph_module_out.graph,
+        [
+            torch.ops.aten.addmm.default,
+            torch.ops.aten.linear.default,
+        ],
     )
 
-    assert not any(
-        node.op == "call_function" and "batch_norm" in node.target.__name__
-        for node in transformed_nodes
-    )
+    assert not graph_contains_any_of_ops(graph_module_out.graph, batch_norm_target_ops)
 
     # Verify that the behavior has not changed.
     input_data = torch.randn(input_shape, dtype=torch.float32)
@@ -170,18 +106,14 @@ def test_batch_norm_linear_fusing(bias: bool):
 )
 def test_batch_norm_conv_fusing__full_pipeline__1d(bias: bool):
     input_shape = [4, 6, 8]
-    module = ConvBatchNormModule(bias, len(input_shape), 4)
+    module = ConvBatchNormModule(bias, len(input_shape), 6)
 
     edge_program = to_quantized_edge_program(
         module, tuple(input_shape)
     ).exported_program()
-    nodes = list(edge_program.graph.nodes)
 
-    assert len(nodes) == 13
-    assert not any(
-        node.op == "call_function" and "batch_norm" in node.target.__name__
-        for node in nodes
-    )
+    assert len(edge_program.graph.nodes) == 15
+    assert not graph_contains_any_of_ops(edge_program.graph, batch_norm_target_ops)
 
 
 @pytest.mark.parametrize(
@@ -194,21 +126,19 @@ def test_batch_norm_conv_fusing__full_pipeline__2d(bias: bool):
     edge_program = to_quantized_edge_program(
         module, tuple(input_shape)
     ).exported_program()
-    nodes = list(edge_program.graph.nodes)
 
-    assert len(nodes) == 7
-    assert not any(
-        node.op == "call_function" and "batch_norm" in node.target.__name__
-        for node in nodes
-    )
+    assert len(edge_program.graph.nodes) == 7
+    assert not graph_contains_any_of_ops(edge_program.graph, batch_norm_target_ops)
 
 
 @pytest.mark.parametrize(
     "bias", [True, False], ids=lambda x: "Bias" if x else "No bias"
 )
 def test_batch_norm_linear_fusing__full_pipeline(bias: bool):
-    input_shape = (2, 4, 6, 8)
-    module = LinearBatchNormModule(bias, 4, input_shape[-1], input_shape[1])
+    input_shape = (2, 4)
+    module = LinearBatchNormModule(
+        bias, 2, input_shape[-1], input_shape[1], input_shape[1]
+    )
 
     # Don't delegate the Linear node, because there seems to be a bug with the NeutronConverter/NeutronPartitioner.
     #  But that doesn't affect the validity of this test.
@@ -227,30 +157,60 @@ def test_batch_norm_linear_fusing__full_pipeline(bias: bool):
                 edge_program = to_quantized_edge_program(
                     module, tuple(input_shape)
                 ).exported_program()
-                nodes = list(edge_program.graph.nodes)
 
-    assert len(nodes) == 18
-    assert not any(
-        node.op == "call_function" and "batch_norm" in node.target.__name__
-        for node in nodes
-    )
+    assert len(edge_program.graph.nodes) == 12
+    assert not graph_contains_any_of_ops(edge_program.graph, batch_norm_target_ops)
 
 
 @pytest.mark.parametrize(
-    "conv_module",
-    ["conv2d"],
+    "bias", [True, False], ids=lambda x: "Bias" if x else "No bias"
 )
-def test_biasless_convbn_fusion_qat(
-    conv_module,
+@pytest.mark.parametrize(
+    "input_shape",
+    [[4, 6, 8], [2, 4, 6, 8], [2, 4, 6, 8, 10]],
+    ids=lambda x: f"{len(x)}D",
+)
+@pytest.mark.parametrize("use_qat", [False, True], ids=lambda x: "QAT" if x else "PTQ")
+def test_batch_norm_linear_incompatible__full_pipeline(
+    bias: bool, input_shape: list[int], use_qat: bool
 ):
-    if conv_module.startswith("conv1d"):
-        input_shape = (1, 3, 32)
-    elif conv_module.startswith("conv2d"):
-        input_shape = (1, 3, 32, 32)
-    else:  # conv3d
-        input_shape = (1, 3, 32, 32, 32)
+    if not use_qat:
+        pytest.skip("Fusion done by `prepare_pt2e` itself. This is a bug in TorchAO.")
 
-    model = ConvBNModule(conv_module, conv_bias=False, bn_affine=True)
+    module = LinearBatchNormModule(
+        bias, len(input_shape), input_shape[-1], input_shape[1], input_shape[1]
+    )
+
+    # Don't delegate the Linear node, because there seems to be a bug with the NeutronConverter/NeutronPartitioner.
+    #  But that doesn't affect the validity of this test.
+    def unsupported_target(*_):  # Accept all input arguments and return `False`.
+        return False
+
+    with OverrideTargetSupportCheck(
+        AddMMConverter, new_target_support_check=unsupported_target
+    ):
+        with OverrideTargetSupportCheck(
+            MMConverter, new_target_support_check=unsupported_target
+        ):
+            with OverrideTargetSupportCheck(
+                ViewCopyConverter, new_target_support_check=unsupported_target
+            ):
+                edge_program = to_quantized_edge_program(
+                    module, tuple(input_shape), use_qat=use_qat
+                ).exported_program()
+
+    expected_num_of_nodes = 20 if bias else 18
+    assert len(edge_program.graph.nodes) == expected_num_of_nodes
+    assert graph_contains_any_of_ops(edge_program.graph, batch_norm_target_ops)
+
+
+def test_biasless_convbn_fusion_qat():
+    input_shape = (1, 3, 3, 3)
+    model = ConvBatchNormModule(
+        bias=False,
+        input_rank=len(input_shape),
+        num_features=3,
+    )
 
     edge_program = to_quantized_edge_program(
         model, input_shape, use_qat=True, use_neutron_for_format_conversion=False

--- a/backends/nxp/tests/test_quantizer.py
+++ b/backends/nxp/tests/test_quantizer.py
@@ -646,22 +646,24 @@ def test_qat_produces_same_graph_as_ptq():
     )
 
 
-# TODO: conv1d_t is currently unsupported, add when resolved
-@pytest.mark.parametrize("conv_module", ["conv1d", "conv2d", "conv2d_t"])
+@pytest.mark.parametrize("input_shape", [(1, 3, 32), (1, 3, 32, 32)])
+@pytest.mark.parametrize("transposed_conv", [True, False])
 @pytest.mark.parametrize("conv_bias", [True, False])
 @pytest.mark.parametrize("bn_affine", [True, False])
-def test_torchao_native_conv_bn_qat_fusing(conv_module, conv_bias, bn_affine):
+def test_torchao_native_conv_bn_qat_fusing(
+    input_shape, transposed_conv, conv_bias, bn_affine
+):
     if not conv_bias:
         pytest.skip("Conv without bias is not supported.")
 
-    if conv_module.startswith("conv1d"):
-        input_shape = (1, 3, 32)
-    elif conv_module.startswith("conv2d"):
-        input_shape = (1, 3, 32, 32)
+    if len(input_shape) < 4 and transposed_conv:
+        pytest.skip("Conv1d transpose is not supported.")
 
-    model = models.ConvBNModule(
-        conv_module=conv_module,
-        conv_bias=conv_bias,
+    model = models.ConvBatchNormModule(
+        bias=conv_bias,
+        input_rank=len(input_shape),
+        num_features=input_shape[1],
+        transposed_conv=transposed_conv,
         bn_affine=bn_affine,
     )
     model.eval()


### PR DESCRIPTION
### Summary

Introduce shape conditioning to Linear+BN fusion related passes. 
Fix `RemoveSimulatedLinearBatchNormFusionQATPass` pass recompiling graph when not necessary.

**Problem description:**
Linear and BatchNorm layers are fusable only in cases where both layers work with the same dimension. Linear layer works strictly with only the last dimension of it's input. BatchNorm on the other hand works in channels dimension (the second one in most cases) except for one case when using BatchNorm1d and input shape `[N, C]` (see [official PyTorch documentation](https://docs.pytorch.org/docs/stable/generated/torch.nn.BatchNorm1d.html) for more info). In this one case both BatchNorm and Linear works on the same dimension and are correctly fusable.

**Example:**
```python
inp = torch.randn((2, 2, 3)) # (N, C, L)
lin = nn.Linear(in_features=3, out_features=5) # Weight of shape (5, 3)
bn = nn.BatchNorm2d(num_features=2) # Running var shape (2, )

# With the following fusing equation:
# linear_w_fused = linear_w * (gamma / sqrt(var + eps))
# And the following shapes:
# linear_w.shape: (5, 3); var.shape: (2, )
# We cannot correctly perform the multiplication.
```

### Test plan
New unit test cases were added + relevant older ones were adjusted.


cc @robert-kalmar @JakeStevens @digantdesai