### PR TITLE
Voxtral Realtime: font color option

### DIFF
--- a/examples/models/voxtral_realtime/main.cpp
+++ b/examples/models/voxtral_realtime/main.cpp
@@ -60,6 +60,10 @@ DEFINE_int32(
     80,
     "Mic read chunk size in ms. Multiples of 80 align with the model's "
     "streaming step (80, 160, 320, 640, 960).");
+DEFINE_string(
+    color,
+    "",
+    "Output text color: green or red (default: no color).");
 
 namespace {
 volatile sig_atomic_t g_interrupted = 0;
@@ -105,8 +109,18 @@ int main(int argc, char** argv) {
   stats.num_prompt_tokens = 0;
   bool first_token = true;
 
-  // Set to true for green-colored output.
-  const bool use_color = false;
+  const char* ansi_color = nullptr;
+  if (FLAGS_color == "green") {
+    ansi_color = "\033[32m";
+  } else if (FLAGS_color == "red") {
+    ansi_color = "\033[31m";
+  } else if (!FLAGS_color.empty()) {
+    ET_LOG(
+        Error,
+        "Invalid --color value '%s'. Expected: green, red.",
+        FLAGS_color.c_str());
+    return 1;
+  }
 
   auto token_cb = [&](const std::string& piece) {
     if (first_token) {
@@ -118,11 +132,11 @@ int main(int argc, char** argv) {
       // Uncomment to print special tokens
       // ::executorch::extension::llm::safe_printf(piece.c_str());
     } else {
-      if (use_color) {
-        printf("\033[32m");
+      if (ansi_color) {
+        printf("%s", ansi_color);
       }
       ::executorch::extension::llm::safe_printf(piece.c_str());
-      if (use_color) {
+      if (ansi_color) {
         printf("\033[0m");
       }
     }


### PR DESCRIPTION
This pull request adds support for colored output in the `voxtral_realtime` example, allowing users to specify the color of the output text via a new command-line flag. The implementation replaces the previous hardcoded color logic with a more flexible approach and provides error handling for invalid color values.

**New feature: Output text color customization**
* Added a `--color` command-line flag to `main.cpp`, allowing users to choose between green, red, or no color for output text.
* Implemented logic to parse the `--color` flag, set the appropriate ANSI color code, and handle invalid values with an error message and exit.
* Updated the output printing logic to use the selected color dynamically instead of a hardcoded value, and to reset the color after each token.
