### PR TITLE
Unify MultimodalRunner under IRunner with multimodal prefill

### DIFF
--- a/extension/llm/runner/_llm_runner.pyi
+++ b/extension/llm/runner/_llm_runner.pyi
@@ -479,8 +479,8 @@ class MultimodalRunner:
     def prefill(self, inputs: List[MultimodalInput]) -> None:
         """
         Prefill multimodal inputs (e.g., to rebuild KV cache from chat history)
-        without generating tokens. After prefill, call generate("") to start
-        decoding from the prefilled state.
+        without generating tokens. After prefill, call generate() with a
+        non-empty final text input to start decoding.
 
         Args:
             inputs: List of multimodal inputs to prefill

--- a/extension/llm/runner/_llm_runner.pyi
+++ b/extension/llm/runner/_llm_runner.pyi
@@ -479,7 +479,8 @@ class MultimodalRunner:
     def prefill(self, inputs: List[MultimodalInput]) -> None:
         """
         Prefill multimodal inputs (e.g., to rebuild KV cache from chat history)
-        without generating tokens.
+        without generating tokens. After prefill, call generate("") to start
+        decoding from the prefilled state.
 
         Args:
             inputs: List of multimodal inputs to prefill

--- a/extension/llm/runner/irunner.h
+++ b/extension/llm/runner/irunner.h
@@ -16,13 +16,14 @@
 #include <string>
 #include <vector>
 
-#include <executorch/extension/llm/runner/multimodal_input.h>
 #include <executorch/extension/llm/runner/stats.h>
 #include <executorch/runtime/core/error.h>
 
 namespace executorch {
 namespace extension {
 namespace llm {
+
+class MultimodalInput; // Forward declaration
 
 // Configuration struct for generation parameters, fields should be sorted in
 // alphabetic order
@@ -144,16 +145,6 @@ class ET_EXPERIMENTAL IRunner {
       int32_t num_bos = 0,
       int32_t num_eos = 0) {
     return runtime::Error::NotSupported;
-  }
-
-  /**
-   * Convenience overload: prefill a single text prompt.
-   */
-  runtime::Error
-  prefill(const std::string& prompt, int32_t num_bos = 0, int32_t num_eos = 0) {
-    std::vector<MultimodalInput> inputs;
-    inputs.emplace_back(MultimodalInput(prompt));
-    return prefill(inputs, num_bos, num_eos);
   }
 
   /**

--- a/extension/llm/runner/irunner.h
+++ b/extension/llm/runner/irunner.h
@@ -139,7 +139,7 @@ class ET_EXPERIMENTAL IRunner {
    * audio)
    * @param num_bos Number of BOS tokens to prepend during encoding
    * @param num_eos Number of EOS tokens to append during encoding
-   * @return Error::Ok if successful, an error otherwise
+   * @return The next token predicted after prefill, or an error
    */
   virtual runtime::Result<uint64_t> prefill(
       const std::vector<MultimodalInput>& inputs,

--- a/extension/llm/runner/irunner.h
+++ b/extension/llm/runner/irunner.h
@@ -14,7 +14,9 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <vector>
 
+#include <executorch/extension/llm/runner/multimodal_input.h>
 #include <executorch/extension/llm/runner/stats.h>
 #include <executorch/runtime/core/error.h>
 
@@ -127,6 +129,34 @@ class ET_EXPERIMENTAL IRunner {
       const GenerationConfig& config,
       std::function<void(const std::string&)> token_callback,
       std::function<void(const Stats&)> stats_callback) = 0;
+
+  /**
+   * Prefill multimodal inputs into the KV cache without generating.
+   *
+   * @param inputs A vector of MultimodalInput objects (text, tokens, images,
+   * audio)
+   * @param num_bos Number of BOS tokens to prepend during encoding
+   * @param num_eos Number of EOS tokens to append during encoding
+   * @return Error::Ok if successful, an error otherwise
+   */
+  virtual runtime::Error prefill(
+      const std::vector<MultimodalInput>& inputs,
+      int32_t num_bos = 0,
+      int32_t num_eos = 0) {
+    return runtime::Error::NotSupported;
+  }
+
+  /**
+   * Convenience overload: prefill a single text prompt.
+   */
+  runtime::Error prefill(
+      const std::string& prompt,
+      int32_t num_bos = 0,
+      int32_t num_eos = 0) {
+    std::vector<MultimodalInput> inputs;
+    inputs.emplace_back(MultimodalInput(prompt));
+    return prefill(inputs, num_bos, num_eos);
+  }
 
   /**
    * Stop the generation process.

--- a/extension/llm/runner/irunner.h
+++ b/extension/llm/runner/irunner.h
@@ -18,6 +18,7 @@
 
 #include <executorch/extension/llm/runner/stats.h>
 #include <executorch/runtime/core/error.h>
+#include <executorch/runtime/core/result.h>
 
 namespace executorch {
 namespace extension {
@@ -140,7 +141,7 @@ class ET_EXPERIMENTAL IRunner {
    * @param num_eos Number of EOS tokens to append during encoding
    * @return Error::Ok if successful, an error otherwise
    */
-  virtual runtime::Error prefill(
+  virtual runtime::Result<uint64_t> prefill(
       const std::vector<MultimodalInput>& inputs,
       int32_t num_bos = 0,
       int32_t num_eos = 0) {

--- a/extension/llm/runner/irunner.h
+++ b/extension/llm/runner/irunner.h
@@ -149,10 +149,8 @@ class ET_EXPERIMENTAL IRunner {
   /**
    * Convenience overload: prefill a single text prompt.
    */
-  runtime::Error prefill(
-      const std::string& prompt,
-      int32_t num_bos = 0,
-      int32_t num_eos = 0) {
+  runtime::Error
+  prefill(const std::string& prompt, int32_t num_bos = 0, int32_t num_eos = 0) {
     std::vector<MultimodalInput> inputs;
     inputs.emplace_back(MultimodalInput(prompt));
     return prefill(inputs, num_bos, num_eos);

--- a/extension/llm/runner/multimodal_runner.cpp
+++ b/extension/llm/runner/multimodal_runner.cpp
@@ -53,7 +53,7 @@ MultimodalRunner::MultimodalRunner(
 #endif
 }
 
-bool MultimodalRunner::is_loaded() {
+bool MultimodalRunner::is_loaded() const {
   return multimodal_prefiller_->is_method_loaded() &&
       text_token_generator_->is_loaded();
 }
@@ -85,16 +85,133 @@ Error MultimodalRunner::load() {
     ET_LOG(Info, format, __VA_ARGS__);     \
   }
 
-Error MultimodalRunner::prefill(const std::vector<MultimodalInput>& inputs) {
+Error MultimodalRunner::prefill(
+    const std::vector<MultimodalInput>& inputs,
+    int32_t num_bos,
+    int32_t num_eos) {
   if (!is_loaded()) {
     ET_CHECK_OK_OR_RETURN_ERROR(load());
   }
-  for (auto& input : inputs) {
-    auto prefill_result = multimodal_prefiller_->prefill(input, pos_);
+  for (size_t i = 0; i < inputs.size(); ++i) {
+    const auto& input = inputs[i];
+    int32_t bos = 0;
+    int32_t eos = 0;
+    if (i == 0 && pos_ == 0) {
+      if (input.is_text() || input.is_tokens()) {
+        bos = num_bos;
+        eos = num_eos;
+      } else if (num_bos > 0) {
+        // Non-text first input: prepend BOS via a token input
+        auto it = metadata_.find(kBosId);
+        if (it != metadata_.end()) {
+          std::vector<uint64_t> bos_tokens(
+              num_bos, static_cast<uint64_t>(it->second));
+          MultimodalInput bos_input(std::move(bos_tokens));
+          auto bos_result = multimodal_prefiller_->prefill(bos_input, pos_);
+          if (!bos_result.ok()) {
+            return bos_result.error();
+          }
+          prefill_next_token_ = bos_result.get();
+        }
+      }
+    }
+    auto prefill_result =
+        multimodal_prefiller_->prefill(input, pos_, bos, eos);
     if (!prefill_result.ok()) {
       return prefill_result.error();
     }
+    prefill_next_token_ = prefill_result.get();
   }
+  return Error::Ok;
+}
+
+Error MultimodalRunner::generate(
+    const std::string& prompt,
+    const GenerationConfig& config,
+    std::function<void(const std::string&)> token_callback,
+    std::function<void(const Stats&)> stats_callback) {
+  if (!prompt.empty()) {
+    std::vector<MultimodalInput> inputs;
+    inputs.emplace_back(MultimodalInput(prompt));
+    return generate(inputs, config, token_callback, stats_callback);
+  }
+
+  // Empty prompt: consume prefill_next_token_ and go straight to decode
+  ET_CHECK_OR_RETURN_ERROR(
+      prefill_next_token_.has_value(),
+      InvalidState,
+      "Empty prompt requires a prior prefill() call");
+
+  if (!is_loaded()) {
+    ET_CHECK_OK_OR_RETURN_ERROR(load());
+  }
+
+  std::function<void(const std::string&)> wrapped_callback =
+      [token_callback, config](const std::string& piece) {
+        if (!config.warming) {
+          safe_printf(piece.c_str());
+          fflush(stdout);
+        }
+        if (token_callback) {
+          token_callback(piece);
+        }
+      };
+
+  stats_->inference_start_ms = time_in_ms();
+
+  uint64_t cur_token = prefill_next_token_.value();
+  prefill_next_token_.reset();
+
+  stats_->first_token_ms = time_in_ms();
+  stats_->prompt_eval_end_ms = time_in_ms();
+  stats_->num_prompt_tokens = pos_;
+
+  auto decode_result = tokenizer_->decode(cur_token, cur_token);
+  if (!decode_result.ok()) {
+    ET_LOG(
+        Error,
+        "Tokenizers error code %d",
+        static_cast<uint32_t>(decode_result.error()));
+    return Error::InvalidArgument;
+  }
+  wrapped_callback(std::move(*decode_result));
+
+  int64_t max_context_len = metadata_.at(kMaxContextLen);
+  int32_t max_new_tokens = config.resolve_max_new_tokens(max_context_len, pos_);
+
+  ET_CHECK_OR_RETURN_ERROR(
+      max_new_tokens > 0,
+      InvalidArgument,
+      "Max new tokens %d is less than or equal to 0",
+      max_new_tokens);
+
+  text_token_generator_->set_ignore_eos(config.ignore_eos);
+
+  std::vector<uint64_t> prompt_tokens = {cur_token};
+  auto generate_result = text_token_generator_->generate(
+      prompt_tokens, pos_, max_new_tokens - 1, config.temperature,
+      wrapped_callback);
+  if (!generate_result.ok()) {
+    return generate_result.error();
+  }
+  int64_t num_generated_tokens = generate_result.get();
+
+  pos_ += num_generated_tokens;
+  stats_->num_generated_tokens = num_generated_tokens;
+  stats_->inference_end_ms = time_in_ms();
+
+  if (!config.warming) {
+    printf("\n");
+  }
+  if (config.warming) {
+    ET_LOG(Info, "Warmup run finished!");
+  } else {
+    print_report(*stats_);
+  }
+  if (stats_callback) {
+    stats_callback(*stats_);
+  }
+
   return Error::Ok;
 }
 
@@ -121,7 +238,6 @@ Error MultimodalRunner::generate(
       "RSS after loading model: %f MiB (0 if unsupported)",
       get_rss_bytes() / 1024.0 / 1024.0);
 
-  // Wrap the token_callback with print function
   std::function<void(const std::string&)> wrapped_callback =
       [token_callback, config](const std::string& piece) {
         if (!config.warming) {
@@ -133,41 +249,24 @@ Error MultimodalRunner::generate(
         }
       };
 
-  // Reset internal state and start inference
   stats_->inference_start_ms = time_in_ms();
 
-  uint64_t prefill_next_token = 0;
-  // Process multimodal inputs in order
-  for (size_t i = 0; i < inputs.size(); ++i) {
-    const MultimodalInput& input = inputs[i];
-    ET_LOG(
-        Info,
-        "Prefilling input %zu/%zu, type: %s",
-        i,
-        inputs.size(),
-        input.type_name());
-    if (config.echo && i == inputs.size() - 1 && input.is_text()) {
-      wrapped_callback(input.get_text());
-    }
-    int32_t bos = 0;
-    int32_t eos = 0;
-    if (i == 0 && input.is_text()) {
-      bos = config.num_bos;
-      eos = config.num_eos;
-    }
-    auto prefill_result = multimodal_prefiller_->prefill(input, pos_, bos, eos);
-    if (!prefill_result.ok()) {
-      return prefill_result.error();
-    }
-    prefill_next_token = prefill_result.get();
+  // Echo the last text input if enabled
+  if (config.echo && inputs.back().is_text()) {
+    wrapped_callback(inputs.back().get_text());
   }
+
+  // Prefill all inputs
+  ET_CHECK_OK_OR_RETURN_ERROR(
+      prefill(inputs, config.num_bos, config.num_eos));
+  uint64_t cur_token = prefill_next_token_.value();
+  prefill_next_token_.reset();
 
   stats_->first_token_ms = time_in_ms();
   stats_->prompt_eval_end_ms = time_in_ms();
   stats_->num_prompt_tokens = pos_;
 
-  auto decode_result =
-      tokenizer_->decode(prefill_next_token, prefill_next_token);
+  auto decode_result = tokenizer_->decode(cur_token, cur_token);
   if (!decode_result.ok()) {
     ET_LOG(
         Error,
@@ -182,9 +281,7 @@ Error MultimodalRunner::generate(
       "RSS after multimodal input processing: %f MiB (0 if unsupported)",
       get_rss_bytes() / 1024.0 / 1024.0);
 
-  // Resolve max_new_tokens based on config
-  int64_t max_context_len =
-      metadata_.at(kMaxContextLen) - 0; // No start_pos offset
+  int64_t max_context_len = metadata_.at(kMaxContextLen);
   int32_t max_new_tokens = config.resolve_max_new_tokens(max_context_len, pos_);
 
   ET_LOG(
@@ -200,16 +297,13 @@ Error MultimodalRunner::generate(
       "Max new tokens %d is less than or equal to 0",
       max_new_tokens);
 
-  // Set ignore_eos based on config
   text_token_generator_->set_ignore_eos(config.ignore_eos);
 
-  // Generate tokens using the text token generator
-  std::vector<uint64_t> prompt_tokens = {prefill_next_token};
+  std::vector<uint64_t> prompt_tokens = {cur_token};
   auto generate_result = text_token_generator_->generate(
       /*tokens=*/prompt_tokens,
       /*start_pos=*/pos_,
-      /*max_new_tokens=*/max_new_tokens -
-          1, // Subtract 1 because prefill already generated 1 token
+      /*max_new_tokens=*/max_new_tokens - 1,
       /*temperature=*/config.temperature,
       /*token_callback=*/wrapped_callback);
   if (!generate_result.ok()) {
@@ -218,16 +312,13 @@ Error MultimodalRunner::generate(
   int64_t num_generated_tokens = generate_result.get();
 
   pos_ += num_generated_tokens;
-  // Update stats
   stats_->num_generated_tokens = num_generated_tokens;
-  // Finalize stats and call callback
   stats_->inference_end_ms = time_in_ms();
 
 #ifdef CUDA_AVAILABLE
   cuda_memory_tracker_->log_sample("after_generate");
   stats_->gpu_free_after_generate_bytes =
       cuda_memory_tracker_->last_free_bytes();
-  // update peak in case it changed after generation
   stats_->gpu_peak_usage_mb = cuda_memory_tracker_->peak_usage_mb();
 #endif
 
@@ -238,7 +329,6 @@ Error MultimodalRunner::generate(
   if (config.warming) {
     ET_LOG(Info, "Warmup run finished!");
   } else {
-    // Do not print report during warmup
     print_report(*stats_);
   }
 

--- a/extension/llm/runner/multimodal_runner.cpp
+++ b/extension/llm/runner/multimodal_runner.cpp
@@ -304,6 +304,7 @@ Error MultimodalRunner::generate(
   auto prefill_result = prefill(inputs, config.num_bos, config.num_eos);
   ET_CHECK_OK_OR_RETURN_ERROR(prefill_result.error());
   uint64_t cur_token = prefill_result.get();
+  prefill_next_token_.reset();
 
   return decode_from_token(cur_token, config, wrapped_callback, stats_callback);
 }

--- a/extension/llm/runner/multimodal_runner.cpp
+++ b/extension/llm/runner/multimodal_runner.cpp
@@ -221,40 +221,11 @@ Error MultimodalRunner::generate(
     const GenerationConfig& config,
     std::function<void(const std::string&)> token_callback,
     std::function<void(const Stats&)> stats_callback) {
+  std::vector<MultimodalInput> inputs;
   if (!prompt.empty()) {
-    std::vector<MultimodalInput> inputs;
     inputs.emplace_back(MultimodalInput(prompt));
-    return generate(inputs, config, token_callback, stats_callback);
   }
-
-  // Empty prompt: consume prefill_next_token_ and go straight to decode
-  ET_CHECK_OR_RETURN_ERROR(
-      prefill_next_token_.has_value(),
-      InvalidState,
-      "Empty prompt requires a prior prefill() call");
-
-  if (!is_loaded()) {
-    ET_CHECK_OK_OR_RETURN_ERROR(load());
-  }
-
-  // Wrap the token_callback with print function
-  std::function<void(const std::string&)> wrapped_callback =
-      [token_callback, config](const std::string& piece) {
-        if (!config.warming) {
-          safe_printf(piece.c_str());
-          fflush(stdout);
-        }
-        if (token_callback) {
-          token_callback(piece);
-        }
-      };
-
-  stats_->inference_start_ms = time_in_ms();
-
-  uint64_t cur_token = prefill_next_token_.value();
-  prefill_next_token_.reset();
-
-  return decode_from_token(cur_token, config, wrapped_callback, stats_callback);
+  return generate(inputs, config, token_callback, stats_callback);
 }
 
 Error MultimodalRunner::generate(
@@ -262,11 +233,6 @@ Error MultimodalRunner::generate(
     const GenerationConfig& config,
     std::function<void(const std::string&)> token_callback,
     std::function<void(const Stats&)> stats_callback) {
-  if (inputs.empty()) {
-    ET_LOG(Error, "MultimodalInput vector cannot be empty");
-    return Error::InvalidArgument;
-  }
-
   if (!is_loaded()) {
     ET_CHECK_OK_OR_RETURN_ERROR(load());
   }
@@ -295,16 +261,27 @@ Error MultimodalRunner::generate(
   // Reset internal state and start inference
   stats_->inference_start_ms = time_in_ms();
 
-  // Echo the last text input if enabled
-  if (config.echo && inputs.back().is_text()) {
-    wrapped_callback(inputs.back().get_text());
-  }
+  uint64_t cur_token;
+  if (!inputs.empty()) {
+    // Echo the last text input if enabled
+    if (config.echo && inputs.back().is_text()) {
+      wrapped_callback(inputs.back().get_text());
+    }
 
-  // Prefill all inputs and get the first decode token
-  auto prefill_result = prefill(inputs, config.num_bos, config.num_eos);
-  ET_CHECK_OK_OR_RETURN_ERROR(prefill_result.error());
-  uint64_t cur_token = prefill_result.get();
-  prefill_next_token_.reset();
+    // Prefill all inputs and get the first decode token
+    auto prefill_result = prefill(inputs, config.num_bos, config.num_eos);
+    ET_CHECK_OK_OR_RETURN_ERROR(prefill_result.error());
+    cur_token = prefill_result.get();
+    prefill_next_token_.reset();
+  } else {
+    // Empty inputs: consume token from a prior prefill() call
+    ET_CHECK_OR_RETURN_ERROR(
+        prefill_next_token_.has_value(),
+        InvalidState,
+        "Empty inputs requires a prior prefill() call");
+    cur_token = prefill_next_token_.value();
+    prefill_next_token_.reset();
+  }
 
   return decode_from_token(cur_token, config, wrapped_callback, stats_callback);
 }

--- a/extension/llm/runner/multimodal_runner.cpp
+++ b/extension/llm/runner/multimodal_runner.cpp
@@ -172,6 +172,7 @@ Error MultimodalRunner::generate(
       "RSS after loading model: %f MiB (0 if unsupported)",
       get_rss_bytes() / 1024.0 / 1024.0);
 
+  // Wrap the token_callback with print function
   std::function<void(const std::string&)> wrapped_callback =
       [token_callback, config](const std::string& piece) {
         if (!config.warming) {
@@ -183,6 +184,7 @@ Error MultimodalRunner::generate(
         }
       };
 
+  // Reset internal state and start inference
   stats_->inference_start_ms = time_in_ms();
 
   // Echo the last text input if enabled
@@ -215,6 +217,7 @@ Error MultimodalRunner::generate(
       "RSS after multimodal input processing: %f MiB (0 if unsupported)",
       get_rss_bytes() / 1024.0 / 1024.0);
 
+  // Resolve max_new_tokens based on config
   int64_t max_context_len = metadata_.at(kMaxContextLen);
   int32_t max_new_tokens = config.resolve_max_new_tokens(max_context_len, pos_);
 
@@ -231,13 +234,16 @@ Error MultimodalRunner::generate(
       "Max new tokens %d is less than or equal to 0",
       max_new_tokens);
 
+  // Set ignore_eos based on config
   text_token_generator_->set_ignore_eos(config.ignore_eos);
 
+  // Generate tokens using the text token generator
   std::vector<uint64_t> prompt_tokens = {cur_token};
   auto generate_result = text_token_generator_->generate(
       /*tokens=*/prompt_tokens,
       /*start_pos=*/pos_,
-      /*max_new_tokens=*/max_new_tokens - 1,
+      /*max_new_tokens=*/max_new_tokens -
+          1, // Subtract 1 because prefill already generated 1 token
       /*temperature=*/config.temperature,
       /*token_callback=*/wrapped_callback);
   if (!generate_result.ok()) {
@@ -246,13 +252,16 @@ Error MultimodalRunner::generate(
   int64_t num_generated_tokens = generate_result.get();
 
   pos_ += num_generated_tokens;
+  // Update stats
   stats_->num_generated_tokens = num_generated_tokens;
+  // Finalize stats and call callback
   stats_->inference_end_ms = time_in_ms();
 
 #ifdef CUDA_AVAILABLE
   cuda_memory_tracker_->log_sample("after_generate");
   stats_->gpu_free_after_generate_bytes =
       cuda_memory_tracker_->last_free_bytes();
+  // update peak in case it changed after generation
   stats_->gpu_peak_usage_mb = cuda_memory_tracker_->peak_usage_mb();
 #endif
 
@@ -263,6 +272,7 @@ Error MultimodalRunner::generate(
   if (config.warming) {
     ET_LOG(Info, "Warmup run finished!");
   } else {
+    // Do not print report during warmup
     print_report(*stats_);
   }
 

--- a/extension/llm/runner/multimodal_runner.cpp
+++ b/extension/llm/runner/multimodal_runner.cpp
@@ -85,13 +85,11 @@ Error MultimodalRunner::load() {
     ET_LOG(Info, format, __VA_ARGS__);     \
   }
 
-Error MultimodalRunner::prefill(
+Result<uint64_t> MultimodalRunner::prefill_and_sample(
     const std::vector<MultimodalInput>& inputs,
     int32_t num_bos,
     int32_t num_eos) {
-  if (!is_loaded()) {
-    ET_CHECK_OK_OR_RETURN_ERROR(load());
-  }
+  uint64_t last_token = 0;
   for (size_t i = 0; i < inputs.size(); ++i) {
     const auto& input = inputs[i];
     int32_t bos = 0;
@@ -111,7 +109,7 @@ Error MultimodalRunner::prefill(
           if (!bos_result.ok()) {
             return bos_result.error();
           }
-          prefill_next_token_ = bos_result.get();
+          last_token = bos_result.get();
         }
       }
     }
@@ -120,7 +118,21 @@ Error MultimodalRunner::prefill(
     if (!prefill_result.ok()) {
       return prefill_result.error();
     }
-    prefill_next_token_ = prefill_result.get();
+    last_token = prefill_result.get();
+  }
+  return last_token;
+}
+
+Error MultimodalRunner::prefill(
+    const std::vector<MultimodalInput>& inputs,
+    int32_t num_bos,
+    int32_t num_eos) {
+  if (!is_loaded()) {
+    ET_CHECK_OK_OR_RETURN_ERROR(load());
+  }
+  auto result = prefill_and_sample(inputs, num_bos, num_eos);
+  if (!result.ok()) {
+    return result.error();
   }
   return Error::Ok;
 }
@@ -130,89 +142,11 @@ Error MultimodalRunner::generate(
     const GenerationConfig& config,
     std::function<void(const std::string&)> token_callback,
     std::function<void(const Stats&)> stats_callback) {
-  if (!prompt.empty()) {
-    std::vector<MultimodalInput> inputs;
-    inputs.emplace_back(MultimodalInput(prompt));
-    return generate(inputs, config, token_callback, stats_callback);
-  }
-
-  // Empty prompt: consume prefill_next_token_ and go straight to decode
   ET_CHECK_OR_RETURN_ERROR(
-      prefill_next_token_.has_value(),
-      InvalidState,
-      "Empty prompt requires a prior prefill() call");
-
-  if (!is_loaded()) {
-    ET_CHECK_OK_OR_RETURN_ERROR(load());
-  }
-
-  std::function<void(const std::string&)> wrapped_callback =
-      [token_callback, config](const std::string& piece) {
-        if (!config.warming) {
-          safe_printf(piece.c_str());
-          fflush(stdout);
-        }
-        if (token_callback) {
-          token_callback(piece);
-        }
-      };
-
-  stats_->inference_start_ms = time_in_ms();
-
-  uint64_t cur_token = prefill_next_token_.value();
-  prefill_next_token_.reset();
-
-  stats_->first_token_ms = time_in_ms();
-  stats_->prompt_eval_end_ms = time_in_ms();
-  stats_->num_prompt_tokens = pos_;
-
-  auto decode_result = tokenizer_->decode(cur_token, cur_token);
-  if (!decode_result.ok()) {
-    ET_LOG(
-        Error,
-        "Tokenizers error code %d",
-        static_cast<uint32_t>(decode_result.error()));
-    return Error::InvalidArgument;
-  }
-  wrapped_callback(std::move(*decode_result));
-
-  int64_t max_context_len = metadata_.at(kMaxContextLen);
-  int32_t max_new_tokens = config.resolve_max_new_tokens(max_context_len, pos_);
-
-  ET_CHECK_OR_RETURN_ERROR(
-      max_new_tokens > 0,
-      InvalidArgument,
-      "Max new tokens %d is less than or equal to 0",
-      max_new_tokens);
-
-  text_token_generator_->set_ignore_eos(config.ignore_eos);
-
-  std::vector<uint64_t> prompt_tokens = {cur_token};
-  auto generate_result = text_token_generator_->generate(
-      prompt_tokens, pos_, max_new_tokens - 1, config.temperature,
-      wrapped_callback);
-  if (!generate_result.ok()) {
-    return generate_result.error();
-  }
-  int64_t num_generated_tokens = generate_result.get();
-
-  pos_ += num_generated_tokens;
-  stats_->num_generated_tokens = num_generated_tokens;
-  stats_->inference_end_ms = time_in_ms();
-
-  if (!config.warming) {
-    printf("\n");
-  }
-  if (config.warming) {
-    ET_LOG(Info, "Warmup run finished!");
-  } else {
-    print_report(*stats_);
-  }
-  if (stats_callback) {
-    stats_callback(*stats_);
-  }
-
-  return Error::Ok;
+      !prompt.empty(), InvalidArgument, "Prompt cannot be empty");
+  std::vector<MultimodalInput> inputs;
+  inputs.emplace_back(MultimodalInput(prompt));
+  return generate(inputs, config, token_callback, stats_callback);
 }
 
 Error MultimodalRunner::generate(
@@ -256,15 +190,11 @@ Error MultimodalRunner::generate(
     wrapped_callback(inputs.back().get_text());
   }
 
-  // Prefill all inputs
-  ET_CHECK_OK_OR_RETURN_ERROR(
-      prefill(inputs, config.num_bos, config.num_eos));
-  ET_CHECK_OR_RETURN_ERROR(
-      prefill_next_token_.has_value(),
-      InvalidState,
-      "prefill did not produce a next token");
-  uint64_t cur_token = prefill_next_token_.value();
-  prefill_next_token_.reset();
+  // Prefill all inputs and get the first decode token
+  auto prefill_result =
+      prefill_and_sample(inputs, config.num_bos, config.num_eos);
+  ET_CHECK_OK_OR_RETURN_ERROR(prefill_result.error());
+  uint64_t cur_token = prefill_result.get();
 
   stats_->first_token_ms = time_in_ms();
   stats_->prompt_eval_end_ms = time_in_ms();

--- a/extension/llm/runner/multimodal_runner.cpp
+++ b/extension/llm/runner/multimodal_runner.cpp
@@ -113,8 +113,7 @@ Result<uint64_t> MultimodalRunner::prefill_and_sample(
         }
       }
     }
-    auto prefill_result =
-        multimodal_prefiller_->prefill(input, pos_, bos, eos);
+    auto prefill_result = multimodal_prefiller_->prefill(input, pos_, bos, eos);
     if (!prefill_result.ok()) {
       return prefill_result.error();
     }

--- a/extension/llm/runner/multimodal_runner.cpp
+++ b/extension/llm/runner/multimodal_runner.cpp
@@ -259,6 +259,10 @@ Error MultimodalRunner::generate(
   // Prefill all inputs
   ET_CHECK_OK_OR_RETURN_ERROR(
       prefill(inputs, config.num_bos, config.num_eos));
+  ET_CHECK_OR_RETURN_ERROR(
+      prefill_next_token_.has_value(),
+      InvalidState,
+      "prefill did not produce a next token");
   uint64_t cur_token = prefill_next_token_.value();
   prefill_next_token_.reset();
 

--- a/extension/llm/runner/multimodal_runner.cpp
+++ b/extension/llm/runner/multimodal_runner.cpp
@@ -133,6 +133,7 @@ Error MultimodalRunner::prefill(
   if (!result.ok()) {
     return result.error();
   }
+  prefill_next_token_ = result.get();
   return Error::Ok;
 }
 
@@ -141,11 +142,100 @@ Error MultimodalRunner::generate(
     const GenerationConfig& config,
     std::function<void(const std::string&)> token_callback,
     std::function<void(const Stats&)> stats_callback) {
+  if (!prompt.empty()) {
+    std::vector<MultimodalInput> inputs;
+    inputs.emplace_back(MultimodalInput(prompt));
+    return generate(inputs, config, token_callback, stats_callback);
+  }
+
+  // Empty prompt: consume prefill_next_token_ and go straight to decode
   ET_CHECK_OR_RETURN_ERROR(
-      !prompt.empty(), InvalidArgument, "Prompt cannot be empty");
-  std::vector<MultimodalInput> inputs;
-  inputs.emplace_back(MultimodalInput(prompt));
-  return generate(inputs, config, token_callback, stats_callback);
+      prefill_next_token_.has_value(),
+      InvalidState,
+      "Empty prompt requires a prior prefill() call");
+
+  if (!is_loaded()) {
+    ET_CHECK_OK_OR_RETURN_ERROR(load());
+  }
+
+  // Wrap the token_callback with print function
+  std::function<void(const std::string&)> wrapped_callback =
+      [token_callback, config](const std::string& piece) {
+        if (!config.warming) {
+          safe_printf(piece.c_str());
+          fflush(stdout);
+        }
+        if (token_callback) {
+          token_callback(piece);
+        }
+      };
+
+  stats_->inference_start_ms = time_in_ms();
+
+  uint64_t cur_token = prefill_next_token_.value();
+  prefill_next_token_.reset();
+
+  stats_->first_token_ms = time_in_ms();
+  stats_->prompt_eval_end_ms = time_in_ms();
+  stats_->num_prompt_tokens = pos_;
+
+  auto decode_result = tokenizer_->decode(cur_token, cur_token);
+  if (!decode_result.ok()) {
+    ET_LOG(
+        Error,
+        "Tokenizers error code %d",
+        static_cast<uint32_t>(decode_result.error()));
+    return Error::InvalidArgument;
+  }
+  wrapped_callback(std::move(*decode_result));
+
+  // Resolve max_new_tokens based on config
+  int64_t max_context_len = metadata_.at(kMaxContextLen);
+  int32_t max_new_tokens = config.resolve_max_new_tokens(max_context_len, pos_);
+
+  ET_CHECK_OR_RETURN_ERROR(
+      max_new_tokens > 0,
+      InvalidArgument,
+      "Max new tokens %d is less than or equal to 0",
+      max_new_tokens);
+
+  // Set ignore_eos based on config
+  text_token_generator_->set_ignore_eos(config.ignore_eos);
+
+  // Generate tokens using the text token generator
+  std::vector<uint64_t> prompt_tokens = {cur_token};
+  auto generate_result = text_token_generator_->generate(
+      prompt_tokens,
+      pos_,
+      max_new_tokens -
+          1, // Subtract 1 because prefill already generated 1 token
+      config.temperature,
+      wrapped_callback);
+  if (!generate_result.ok()) {
+    return generate_result.error();
+  }
+  int64_t num_generated_tokens = generate_result.get();
+
+  pos_ += num_generated_tokens;
+  // Update stats
+  stats_->num_generated_tokens = num_generated_tokens;
+  // Finalize stats and call callback
+  stats_->inference_end_ms = time_in_ms();
+
+  if (!config.warming) {
+    printf("\n");
+  }
+  if (config.warming) {
+    ET_LOG(Info, "Warmup run finished!");
+  } else {
+    // Do not print report during warmup
+    print_report(*stats_);
+  }
+  if (stats_callback) {
+    stats_callback(*stats_);
+  }
+
+  return Error::Ok;
 }
 
 Error MultimodalRunner::generate(

--- a/extension/llm/runner/multimodal_runner.cpp
+++ b/extension/llm/runner/multimodal_runner.cpp
@@ -126,155 +126,11 @@ Result<uint64_t> MultimodalRunner::prefill(
   return last_token;
 }
 
-Error MultimodalRunner::generate(
-    const std::string& prompt,
+Error MultimodalRunner::decode_from_token(
+    uint64_t cur_token,
     const GenerationConfig& config,
-    std::function<void(const std::string&)> token_callback,
+    std::function<void(const std::string&)> wrapped_callback,
     std::function<void(const Stats&)> stats_callback) {
-  if (!prompt.empty()) {
-    std::vector<MultimodalInput> inputs;
-    inputs.emplace_back(MultimodalInput(prompt));
-    return generate(inputs, config, token_callback, stats_callback);
-  }
-
-  // Empty prompt: consume prefill_next_token_ and go straight to decode
-  ET_CHECK_OR_RETURN_ERROR(
-      prefill_next_token_.has_value(),
-      InvalidState,
-      "Empty prompt requires a prior prefill() call");
-
-  if (!is_loaded()) {
-    ET_CHECK_OK_OR_RETURN_ERROR(load());
-  }
-
-  // Wrap the token_callback with print function
-  std::function<void(const std::string&)> wrapped_callback =
-      [token_callback, config](const std::string& piece) {
-        if (!config.warming) {
-          safe_printf(piece.c_str());
-          fflush(stdout);
-        }
-        if (token_callback) {
-          token_callback(piece);
-        }
-      };
-
-  stats_->inference_start_ms = time_in_ms();
-
-  uint64_t cur_token = prefill_next_token_.value();
-  prefill_next_token_.reset();
-
-  stats_->first_token_ms = time_in_ms();
-  stats_->prompt_eval_end_ms = time_in_ms();
-  stats_->num_prompt_tokens = pos_;
-
-  auto decode_result = tokenizer_->decode(cur_token, cur_token);
-  if (!decode_result.ok()) {
-    ET_LOG(
-        Error,
-        "Tokenizers error code %d",
-        static_cast<uint32_t>(decode_result.error()));
-    return Error::InvalidArgument;
-  }
-  wrapped_callback(std::move(*decode_result));
-
-  // Resolve max_new_tokens based on config
-  int64_t max_context_len = metadata_.at(kMaxContextLen);
-  int32_t max_new_tokens = config.resolve_max_new_tokens(max_context_len, pos_);
-
-  ET_CHECK_OR_RETURN_ERROR(
-      max_new_tokens > 0,
-      InvalidArgument,
-      "Max new tokens %d is less than or equal to 0",
-      max_new_tokens);
-
-  // Set ignore_eos based on config
-  text_token_generator_->set_ignore_eos(config.ignore_eos);
-
-  // Generate tokens using the text token generator
-  std::vector<uint64_t> prompt_tokens = {cur_token};
-  auto generate_result = text_token_generator_->generate(
-      prompt_tokens,
-      pos_,
-      max_new_tokens -
-          1, // Subtract 1 because prefill already generated 1 token
-      config.temperature,
-      wrapped_callback);
-  if (!generate_result.ok()) {
-    return generate_result.error();
-  }
-  int64_t num_generated_tokens = generate_result.get();
-
-  pos_ += num_generated_tokens;
-  // Update stats
-  stats_->num_generated_tokens = num_generated_tokens;
-  // Finalize stats and call callback
-  stats_->inference_end_ms = time_in_ms();
-
-  if (!config.warming) {
-    printf("\n");
-  }
-  if (config.warming) {
-    ET_LOG(Info, "Warmup run finished!");
-  } else {
-    // Do not print report during warmup
-    print_report(*stats_);
-  }
-  if (stats_callback) {
-    stats_callback(*stats_);
-  }
-
-  return Error::Ok;
-}
-
-Error MultimodalRunner::generate(
-    const std::vector<MultimodalInput>& inputs,
-    const GenerationConfig& config,
-    std::function<void(const std::string&)> token_callback,
-    std::function<void(const Stats&)> stats_callback) {
-  if (inputs.empty()) {
-    ET_LOG(Error, "MultimodalInput vector cannot be empty");
-    return Error::InvalidArgument;
-  }
-
-  if (!is_loaded()) {
-    ET_CHECK_OK_OR_RETURN_ERROR(load());
-  }
-
-  if (config.warming) {
-    ET_LOG(Info, "Doing a warmup run...");
-  }
-
-  RUNNER_ET_LOG(
-      config.warming,
-      "RSS after loading model: %f MiB (0 if unsupported)",
-      get_rss_bytes() / 1024.0 / 1024.0);
-
-  // Wrap the token_callback with print function
-  std::function<void(const std::string&)> wrapped_callback =
-      [token_callback, config](const std::string& piece) {
-        if (!config.warming) {
-          safe_printf(piece.c_str());
-          fflush(stdout);
-        }
-        if (token_callback) {
-          token_callback(piece);
-        }
-      };
-
-  // Reset internal state and start inference
-  stats_->inference_start_ms = time_in_ms();
-
-  // Echo the last text input if enabled
-  if (config.echo && inputs.back().is_text()) {
-    wrapped_callback(inputs.back().get_text());
-  }
-
-  // Prefill all inputs and get the first decode token
-  auto prefill_result = prefill(inputs, config.num_bos, config.num_eos);
-  ET_CHECK_OK_OR_RETURN_ERROR(prefill_result.error());
-  uint64_t cur_token = prefill_result.get();
-
   stats_->first_token_ms = time_in_ms();
   stats_->prompt_eval_end_ms = time_in_ms();
   stats_->num_prompt_tokens = pos_;
@@ -358,6 +214,98 @@ Error MultimodalRunner::generate(
   }
 
   return Error::Ok;
+}
+
+Error MultimodalRunner::generate(
+    const std::string& prompt,
+    const GenerationConfig& config,
+    std::function<void(const std::string&)> token_callback,
+    std::function<void(const Stats&)> stats_callback) {
+  if (!prompt.empty()) {
+    std::vector<MultimodalInput> inputs;
+    inputs.emplace_back(MultimodalInput(prompt));
+    return generate(inputs, config, token_callback, stats_callback);
+  }
+
+  // Empty prompt: consume prefill_next_token_ and go straight to decode
+  ET_CHECK_OR_RETURN_ERROR(
+      prefill_next_token_.has_value(),
+      InvalidState,
+      "Empty prompt requires a prior prefill() call");
+
+  if (!is_loaded()) {
+    ET_CHECK_OK_OR_RETURN_ERROR(load());
+  }
+
+  // Wrap the token_callback with print function
+  std::function<void(const std::string&)> wrapped_callback =
+      [token_callback, config](const std::string& piece) {
+        if (!config.warming) {
+          safe_printf(piece.c_str());
+          fflush(stdout);
+        }
+        if (token_callback) {
+          token_callback(piece);
+        }
+      };
+
+  stats_->inference_start_ms = time_in_ms();
+
+  uint64_t cur_token = prefill_next_token_.value();
+  prefill_next_token_.reset();
+
+  return decode_from_token(cur_token, config, wrapped_callback, stats_callback);
+}
+
+Error MultimodalRunner::generate(
+    const std::vector<MultimodalInput>& inputs,
+    const GenerationConfig& config,
+    std::function<void(const std::string&)> token_callback,
+    std::function<void(const Stats&)> stats_callback) {
+  if (inputs.empty()) {
+    ET_LOG(Error, "MultimodalInput vector cannot be empty");
+    return Error::InvalidArgument;
+  }
+
+  if (!is_loaded()) {
+    ET_CHECK_OK_OR_RETURN_ERROR(load());
+  }
+
+  if (config.warming) {
+    ET_LOG(Info, "Doing a warmup run...");
+  }
+
+  RUNNER_ET_LOG(
+      config.warming,
+      "RSS after loading model: %f MiB (0 if unsupported)",
+      get_rss_bytes() / 1024.0 / 1024.0);
+
+  // Wrap the token_callback with print function
+  std::function<void(const std::string&)> wrapped_callback =
+      [token_callback, config](const std::string& piece) {
+        if (!config.warming) {
+          safe_printf(piece.c_str());
+          fflush(stdout);
+        }
+        if (token_callback) {
+          token_callback(piece);
+        }
+      };
+
+  // Reset internal state and start inference
+  stats_->inference_start_ms = time_in_ms();
+
+  // Echo the last text input if enabled
+  if (config.echo && inputs.back().is_text()) {
+    wrapped_callback(inputs.back().get_text());
+  }
+
+  // Prefill all inputs and get the first decode token
+  auto prefill_result = prefill(inputs, config.num_bos, config.num_eos);
+  ET_CHECK_OK_OR_RETURN_ERROR(prefill_result.error());
+  uint64_t cur_token = prefill_result.get();
+
+  return decode_from_token(cur_token, config, wrapped_callback, stats_callback);
 }
 
 } // namespace executorch::extension::llm

--- a/extension/llm/runner/multimodal_runner.cpp
+++ b/extension/llm/runner/multimodal_runner.cpp
@@ -85,10 +85,13 @@ Error MultimodalRunner::load() {
     ET_LOG(Info, format, __VA_ARGS__);     \
   }
 
-Result<uint64_t> MultimodalRunner::prefill_and_sample(
+Result<uint64_t> MultimodalRunner::prefill(
     const std::vector<MultimodalInput>& inputs,
     int32_t num_bos,
     int32_t num_eos) {
+  if (!is_loaded()) {
+    ET_CHECK_OK_OR_RETURN_ERROR(load());
+  }
   uint64_t last_token = 0;
   for (size_t i = 0; i < inputs.size(); ++i) {
     const auto& input = inputs[i];
@@ -119,22 +122,8 @@ Result<uint64_t> MultimodalRunner::prefill_and_sample(
     }
     last_token = prefill_result.get();
   }
+  prefill_next_token_ = last_token;
   return last_token;
-}
-
-Error MultimodalRunner::prefill(
-    const std::vector<MultimodalInput>& inputs,
-    int32_t num_bos,
-    int32_t num_eos) {
-  if (!is_loaded()) {
-    ET_CHECK_OK_OR_RETURN_ERROR(load());
-  }
-  auto result = prefill_and_sample(inputs, num_bos, num_eos);
-  if (!result.ok()) {
-    return result.error();
-  }
-  prefill_next_token_ = result.get();
-  return Error::Ok;
 }
 
 Error MultimodalRunner::generate(
@@ -282,8 +271,7 @@ Error MultimodalRunner::generate(
   }
 
   // Prefill all inputs and get the first decode token
-  auto prefill_result =
-      prefill_and_sample(inputs, config.num_bos, config.num_eos);
+  auto prefill_result = prefill(inputs, config.num_bos, config.num_eos);
   ET_CHECK_OK_OR_RETURN_ERROR(prefill_result.error());
   uint64_t cur_token = prefill_result.get();
 

--- a/extension/llm/runner/multimodal_runner.cpp
+++ b/extension/llm/runner/multimodal_runner.cpp
@@ -261,7 +261,7 @@ Error MultimodalRunner::generate(
   // Reset internal state and start inference
   stats_->inference_start_ms = time_in_ms();
 
-  uint64_t cur_token;
+  uint64_t cur_token = 0;
   if (!inputs.empty()) {
     // Echo the last text input if enabled
     if (config.echo && inputs.back().is_text()) {

--- a/extension/llm/runner/multimodal_runner.h
+++ b/extension/llm/runner/multimodal_runner.h
@@ -15,7 +15,6 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
-#include <optional>
 #include <string>
 #include <unordered_map>
 
@@ -135,7 +134,6 @@ class ET_EXPERIMENTAL MultimodalRunner : public IRunner {
   void reset() override {
     pos_ = 0;
     stats_->reset();
-    prefill_next_token_.reset();
   }
 
   ~MultimodalRunner() override = default;
@@ -157,8 +155,13 @@ class ET_EXPERIMENTAL MultimodalRunner : public IRunner {
 #endif
 
   // Internal state
-  std::optional<uint64_t> prefill_next_token_;
   int64_t pos_;
+
+ private:
+  ::executorch::runtime::Result<uint64_t> prefill_and_sample(
+      const std::vector<MultimodalInput>& inputs,
+      int32_t num_bos,
+      int32_t num_eos);
 };
 
 } // namespace llm

--- a/extension/llm/runner/multimodal_runner.h
+++ b/extension/llm/runner/multimodal_runner.h
@@ -147,9 +147,10 @@ class ET_EXPERIMENTAL MultimodalRunner : public IRunner {
    * text.
    * @param num_bos Number of BOS tokens to prepend during encoding.
    * @param num_eos Number of EOS tokens to append during encoding.
-   * @return The error code. KV cache position is tracked internally in pos_.
+   * @return The next token predicted after prefill, or an error.
+   *         KV cache position is tracked internally in pos_.
    */
-  ::executorch::runtime::Error prefill(
+  ::executorch::runtime::Result<uint64_t> prefill(
       const std::vector<MultimodalInput>& inputs,
       int32_t num_bos = 0,
       int32_t num_eos = 0) override;
@@ -157,7 +158,7 @@ class ET_EXPERIMENTAL MultimodalRunner : public IRunner {
   /**
    * Convenience overload: prefill a single text prompt.
    */
-  ::executorch::runtime::Error
+  ::executorch::runtime::Result<uint64_t>
   prefill(const std::string& prompt, int32_t num_bos = 0, int32_t num_eos = 0) {
     std::vector<MultimodalInput> inputs;
     inputs.emplace_back(MultimodalInput(prompt));
@@ -195,12 +196,6 @@ class ET_EXPERIMENTAL MultimodalRunner : public IRunner {
   // Internal state
   std::optional<uint64_t> prefill_next_token_;
   int64_t pos_;
-
- private:
-  ::executorch::runtime::Result<uint64_t> prefill_and_sample(
-      const std::vector<MultimodalInput>& inputs,
-      int32_t num_bos,
-      int32_t num_eos);
 };
 
 } // namespace llm

--- a/extension/llm/runner/multimodal_runner.h
+++ b/extension/llm/runner/multimodal_runner.h
@@ -138,8 +138,6 @@ class ET_EXPERIMENTAL MultimodalRunner : public IRunner {
       std::function<void(const std::string&)> token_callback = {},
       std::function<void(const Stats&)> stats_callback = {});
 
-  using IRunner::prefill; // Bring in string convenience overload
-
   /**
    * Prefill multimodal inputs to fill the KV cache, for example to reload
    * chat history. Call generate() with a non-empty prompt afterwards to
@@ -154,6 +152,16 @@ class ET_EXPERIMENTAL MultimodalRunner : public IRunner {
       const std::vector<MultimodalInput>& inputs,
       int32_t num_bos = 0,
       int32_t num_eos = 0) override;
+
+  /**
+   * Convenience overload: prefill a single text prompt.
+   */
+  ::executorch::runtime::Error
+  prefill(const std::string& prompt, int32_t num_bos = 0, int32_t num_eos = 0) {
+    std::vector<MultimodalInput> inputs;
+    inputs.emplace_back(MultimodalInput(prompt));
+    return prefill(inputs, num_bos, num_eos);
+  }
 
   void stop() override {
     text_token_generator_->stop();

--- a/extension/llm/runner/multimodal_runner.h
+++ b/extension/llm/runner/multimodal_runner.h
@@ -111,8 +111,9 @@ class ET_EXPERIMENTAL MultimodalRunner : public IRunner {
 
   /**
    * Generate tokens from a text prompt. Wraps the prompt as a MultimodalInput
-   * and delegates to generate(vector).
-   * @param prompt The text prompt to generate from. Must be non-empty.
+   * and delegates to generate(vector). Empty prompt is allowed if prefill()
+   * was called beforehand.
+   * @param prompt The text prompt to generate from.
    * @param config Generation configuration parameters.
    * @param token_callback Callback function called for each generated token.
    * @param stats_callback Callback function for generation statistics.

--- a/extension/llm/runner/multimodal_runner.h
+++ b/extension/llm/runner/multimodal_runner.h
@@ -15,6 +15,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 
@@ -170,6 +171,7 @@ class ET_EXPERIMENTAL MultimodalRunner : public IRunner {
   void reset() override {
     pos_ = 0;
     stats_->reset();
+    prefill_next_token_.reset();
   }
 
   ~MultimodalRunner() override = default;
@@ -191,6 +193,7 @@ class ET_EXPERIMENTAL MultimodalRunner : public IRunner {
 #endif
 
   // Internal state
+  std::optional<uint64_t> prefill_next_token_;
   int64_t pos_;
 
  private:

--- a/extension/llm/runner/multimodal_runner.h
+++ b/extension/llm/runner/multimodal_runner.h
@@ -196,6 +196,13 @@ class ET_EXPERIMENTAL MultimodalRunner : public IRunner {
   // Internal state
   std::optional<uint64_t> prefill_next_token_;
   int64_t pos_;
+
+ private:
+  ::executorch::runtime::Error decode_from_token(
+      uint64_t cur_token,
+      const GenerationConfig& config,
+      std::function<void(const std::string&)> wrapped_callback,
+      std::function<void(const Stats&)> stats_callback);
 };
 
 } // namespace llm

--- a/extension/llm/runner/multimodal_runner.h
+++ b/extension/llm/runner/multimodal_runner.h
@@ -15,6 +15,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 
@@ -74,7 +75,7 @@ namespace llm {
  *
  *   runner->generate(inputs, config, token_callback, stats_callback);
  */
-class ET_EXPERIMENTAL MultimodalRunner {
+class ET_EXPERIMENTAL MultimodalRunner : public IRunner {
  public:
   /**
    * @brief Constructor for MultimodalRunner with dependency injection
@@ -105,43 +106,39 @@ class ET_EXPERIMENTAL MultimodalRunner {
       std::unique_ptr<TextTokenGenerator> text_token_generator,
       std::unique_ptr<Stats> stats);
 
-  virtual bool is_loaded();
-  virtual ::executorch::runtime::Error load();
+  bool is_loaded() const override;
+  ::executorch::runtime::Error load() override;
 
-  /**
-   * Generate tokens from the given multimodal inputs using GenerationConfig.
-   * @param inputs A vector of MultimodalInput objects containing images and
-   * text.
-   * @param config Generation configuration parameters.
-   * @param token_callback Callback function called for each generated token.
-   * @param stats_callback Callback function for generation statistics.
-   * @return The error code. KV cache position is tracked internally in pos_.
-   */
+  ::executorch::runtime::Error generate(
+      const std::string& prompt,
+      const GenerationConfig& config,
+      std::function<void(const std::string&)> token_callback = {},
+      std::function<void(const Stats&)> stats_callback = {}) override;
+
   virtual ::executorch::runtime::Error generate(
       const std::vector<MultimodalInput>& inputs,
       const GenerationConfig& config,
       std::function<void(const std::string&)> token_callback = {},
       std::function<void(const Stats&)> stats_callback = {});
 
-  /**
-   * Prefill multimodal inputs, for example to reload chat history.
-   * @param inputs A vector of MultimodalInput objects containing images and
-   * text.
-   * @return The error code. KV cache position is tracked internally in pos_.
-   */
-  virtual ::executorch::runtime::Error prefill(
-      const std::vector<MultimodalInput>& inputs);
+  using IRunner::prefill; // Bring in string convenience overload
 
-  inline void stop() {
+  ::executorch::runtime::Error prefill(
+      const std::vector<MultimodalInput>& inputs,
+      int32_t num_bos = 0,
+      int32_t num_eos = 0) override;
+
+  void stop() override {
     text_token_generator_->stop();
   }
 
-  inline void reset() {
+  void reset() override {
     pos_ = 0;
     stats_->reset();
+    prefill_next_token_.reset();
   }
 
-  virtual ~MultimodalRunner() = default;
+  ~MultimodalRunner() override = default;
 
  protected:
   // Components
@@ -160,6 +157,7 @@ class ET_EXPERIMENTAL MultimodalRunner {
 #endif
 
   // Internal state
+  std::optional<uint64_t> prefill_next_token_;
   int64_t pos_;
 };
 

--- a/extension/llm/runner/multimodal_runner.h
+++ b/extension/llm/runner/multimodal_runner.h
@@ -108,12 +108,30 @@ class ET_EXPERIMENTAL MultimodalRunner : public IRunner {
   bool is_loaded() const override;
   ::executorch::runtime::Error load() override;
 
+  /**
+   * Generate tokens from a text prompt. Wraps the prompt as a MultimodalInput
+   * and delegates to generate(vector).
+   * @param prompt The text prompt to generate from. Must be non-empty.
+   * @param config Generation configuration parameters.
+   * @param token_callback Callback function called for each generated token.
+   * @param stats_callback Callback function for generation statistics.
+   * @return The error code. KV cache position is tracked internally in pos_.
+   */
   ::executorch::runtime::Error generate(
       const std::string& prompt,
       const GenerationConfig& config,
       std::function<void(const std::string&)> token_callback = {},
       std::function<void(const Stats&)> stats_callback = {}) override;
 
+  /**
+   * Generate tokens from the given multimodal inputs using GenerationConfig.
+   * @param inputs A vector of MultimodalInput objects containing images and
+   * text.
+   * @param config Generation configuration parameters.
+   * @param token_callback Callback function called for each generated token.
+   * @param stats_callback Callback function for generation statistics.
+   * @return The error code. KV cache position is tracked internally in pos_.
+   */
   virtual ::executorch::runtime::Error generate(
       const std::vector<MultimodalInput>& inputs,
       const GenerationConfig& config,
@@ -122,6 +140,16 @@ class ET_EXPERIMENTAL MultimodalRunner : public IRunner {
 
   using IRunner::prefill; // Bring in string convenience overload
 
+  /**
+   * Prefill multimodal inputs to fill the KV cache, for example to reload
+   * chat history. Call generate() with a non-empty prompt afterwards to
+   * start decoding.
+   * @param inputs A vector of MultimodalInput objects containing images and
+   * text.
+   * @param num_bos Number of BOS tokens to prepend during encoding.
+   * @param num_eos Number of EOS tokens to append during encoding.
+   * @return The error code. KV cache position is tracked internally in pos_.
+   */
   ::executorch::runtime::Error prefill(
       const std::vector<MultimodalInput>& inputs,
       int32_t num_bos = 0,

--- a/extension/llm/runner/pybindings.cpp
+++ b/extension/llm/runner/pybindings.cpp
@@ -121,7 +121,7 @@ class PyTextLLMRunner {
     }
     {
       py::gil_scoped_release release;
-      Error error = runner_->prefill(prompt, config);
+      Error error = runner_->prefill(prompt, config.num_bos, config.num_eos);
       THROW_IF_ERROR(error, "Prefill failed");
     }
   }
@@ -234,7 +234,7 @@ class PyMultimodalRunner {
     }
     {
       py::gil_scoped_release release;
-      Error error = runner_->prefill(inputs);
+      Error error = runner_->prefill(inputs, 0, 0);
       THROW_IF_ERROR(error, "Prefill failed");
     }
   }

--- a/extension/llm/runner/pybindings.cpp
+++ b/extension/llm/runner/pybindings.cpp
@@ -121,8 +121,8 @@ class PyTextLLMRunner {
     }
     {
       py::gil_scoped_release release;
-      Error error = runner_->prefill(prompt, config.num_bos, config.num_eos);
-      THROW_IF_ERROR(error, "Prefill failed");
+      auto result = runner_->prefill(prompt, config.num_bos, config.num_eos);
+      THROW_IF_ERROR(result.error(), "Prefill failed");
     }
   }
 
@@ -234,8 +234,8 @@ class PyMultimodalRunner {
     }
     {
       py::gil_scoped_release release;
-      Error error = runner_->prefill(inputs, 0, 0);
-      THROW_IF_ERROR(error, "Prefill failed");
+      auto result = runner_->prefill(inputs, 0, 0);
+      THROW_IF_ERROR(result.error(), "Prefill failed");
     }
   }
 

--- a/extension/llm/runner/test/test_text_llm_runner.cpp
+++ b/extension/llm/runner/test/test_text_llm_runner.cpp
@@ -357,4 +357,145 @@ TEST_F(RunnerTest, IsLoadedReturnsTrueWhenComponentsInitialized) {
   EXPECT_TRUE(runner.is_loaded());
 }
 
+// Test that prefill() returns the predicted next token
+TEST_F(RunnerTest, PrefillReturnsNextToken) {
+  auto tokenizer = createMockTokenizer();
+  auto text_decoder_runner = createMockTextDecoderRunner();
+  auto text_prefiller = createMockTextPrefiller(text_decoder_runner.get());
+
+  ON_CALL(*tokenizer, encode(_, _, _))
+      .WillByDefault([&](const std::string&, int8_t, int8_t) {
+        return ::tokenizers::Result<std::vector<uint64_t>>(
+            std::vector<uint64_t>{1, 2, 3});
+      });
+
+  ON_CALL(*text_prefiller, prefill(_, _))
+      .WillByDefault([&](std::vector<uint64_t>& tokens, int64_t& pos) {
+        pos += tokens.size();
+        return Result<uint64_t>(42);
+      });
+
+  ON_CALL(*text_prefiller, is_loaded()).WillByDefault(Return(true));
+
+  std::unique_ptr<executorch::llm::Stats> stats =
+      std::make_unique<executorch::llm::Stats>();
+  auto text_token_generator = createTextTokenGenerator(
+      tokenizer.get(), text_decoder_runner.get(), stats.get());
+
+  auto module = std::make_unique<MockModule>();
+  auto io_manager =
+      std::make_unique<executorch::extension::llm::IOManager>(*module);
+  TextLLMRunner runner(
+      createDefaultMetadata(),
+      std::unique_ptr<::tokenizers::Tokenizer>(tokenizer.release()),
+      std::move(module),
+      std::move(text_decoder_runner),
+      std::unique_ptr<::executorch::extension::llm::TextPrefiller>(
+          text_prefiller.release()),
+      std::move(io_manager),
+      std::move(text_token_generator),
+      std::move(stats));
+
+  runner.load();
+
+  auto result = runner.prefill("system prompt", 1, 0);
+  EXPECT_TRUE(result.ok());
+  EXPECT_EQ(result.get(), 42);
+}
+
+// Test the prefill() → generate("") workflow
+TEST_F(RunnerTest, PrefillThenGenerateEmpty) {
+  auto tokenizer = createMockTokenizer();
+  auto text_decoder_runner = createMockTextDecoderRunner();
+  auto text_prefiller = createMockTextPrefiller(text_decoder_runner.get());
+
+  ON_CALL(*tokenizer, encode(_, _, _))
+      .WillByDefault([&](const std::string&, int8_t, int8_t) {
+        return ::tokenizers::Result<std::vector<uint64_t>>(
+            std::vector<uint64_t>{1, 2, 3});
+      });
+
+  ON_CALL(*text_prefiller, prefill(_, _))
+      .WillByDefault([&](std::vector<uint64_t>& tokens, int64_t& pos) {
+        pos += tokens.size();
+        return Result<uint64_t>(4);
+      });
+
+  ON_CALL(*text_prefiller, is_loaded()).WillByDefault(Return(true));
+
+  std::unique_ptr<executorch::llm::Stats> stats =
+      std::make_unique<executorch::llm::Stats>();
+  auto text_token_generator = createTextTokenGenerator(
+      tokenizer.get(), text_decoder_runner.get(), stats.get());
+
+  auto module = std::make_unique<MockModule>();
+  auto io_manager =
+      std::make_unique<executorch::extension::llm::IOManager>(*module);
+  TextLLMRunner runner(
+      createDefaultMetadata(),
+      std::unique_ptr<::tokenizers::Tokenizer>(tokenizer.release()),
+      std::move(module),
+      std::move(text_decoder_runner),
+      std::unique_ptr<::executorch::extension::llm::TextPrefiller>(
+          text_prefiller.release()),
+      std::move(io_manager),
+      std::move(text_token_generator),
+      std::move(stats));
+
+  runner.load();
+
+  // Prefill first
+  auto prefill_result = runner.prefill("system prompt", 1, 0);
+  EXPECT_TRUE(prefill_result.ok());
+
+  // Generate with empty prompt — should consume prefill_next_token_
+  GenerationConfig config;
+  config.max_new_tokens = 5;
+  config.echo = false;
+
+  CallbackCounter counter;
+  Error err = runner.generate(
+      "", config, [&counter](const std::string& token) {
+        counter.callback(token);
+      });
+
+  EXPECT_EQ(err, Error::Ok);
+  // First token from prefill + remaining from decode loop
+  EXPECT_EQ(counter.getCount(), config.max_new_tokens);
+}
+
+// Test that generate("") without prior prefill() returns an error
+TEST_F(RunnerTest, GenerateEmptyWithoutPrefillFails) {
+  auto tokenizer = createMockTokenizer();
+  auto text_decoder_runner = createMockTextDecoderRunner();
+  auto text_prefiller = createMockTextPrefiller(text_decoder_runner.get());
+
+  ON_CALL(*text_prefiller, is_loaded()).WillByDefault(Return(true));
+
+  std::unique_ptr<executorch::llm::Stats> stats =
+      std::make_unique<executorch::llm::Stats>();
+  auto text_token_generator = createTextTokenGenerator(
+      tokenizer.get(), text_decoder_runner.get(), stats.get());
+
+  auto module = std::make_unique<MockModule>();
+  auto io_manager =
+      std::make_unique<executorch::extension::llm::IOManager>(*module);
+  TextLLMRunner runner(
+      createDefaultMetadata(),
+      std::unique_ptr<::tokenizers::Tokenizer>(tokenizer.release()),
+      std::move(module),
+      std::move(text_decoder_runner),
+      std::unique_ptr<::executorch::extension::llm::TextPrefiller>(
+          text_prefiller.release()),
+      std::move(io_manager),
+      std::move(text_token_generator),
+      std::move(stats));
+
+  runner.load();
+
+  GenerationConfig config;
+  Error err = runner.generate("", config);
+  EXPECT_EQ(err, Error::InvalidState);
+}
+
 } // namespace

--- a/extension/llm/runner/test/test_text_llm_runner.cpp
+++ b/extension/llm/runner/test/test_text_llm_runner.cpp
@@ -454,10 +454,9 @@ TEST_F(RunnerTest, PrefillThenGenerateEmpty) {
   config.echo = false;
 
   CallbackCounter counter;
-  Error err = runner.generate(
-      "", config, [&counter](const std::string& token) {
-        counter.callback(token);
-      });
+  Error err = runner.generate("", config, [&counter](const std::string& token) {
+    counter.callback(token);
+  });
 
   EXPECT_EQ(err, Error::Ok);
   // First token from prefill + remaining from decode loop

--- a/extension/llm/runner/text_llm_runner.cpp
+++ b/extension/llm/runner/text_llm_runner.cpp
@@ -119,10 +119,7 @@ Error TextLLMRunner::generate(
 
   if (!prompt.empty()) {
     ::tokenizers::Result<std::vector<uint64_t>> encode_res =
-        tokenizer_->encode(
-            prompt,
-            /*bos=*/config.num_bos,
-            /*eos=*/config.num_eos);
+        tokenizer_->encode(prompt, /*bos=*/config.num_bos, /*eos=*/config.num_eos);
 
     if (!encode_res.ok()) {
       ET_LOG(

--- a/extension/llm/runner/text_llm_runner.cpp
+++ b/extension/llm/runner/text_llm_runner.cpp
@@ -76,9 +76,6 @@ Error TextLLMRunner::generate(
     const GenerationConfig& config,
     std::function<void(const std::string&)> token_callback,
     std::function<void(const Stats&)> stats_callback) {
-  // Prepare the inputs.
-  // Use ones-initialized inputs.
-  ET_CHECK_MSG(!prompt.empty(), "Prompt cannot be null");
   if (!is_loaded()) {
     stats_->model_load_start_ms = time_in_ms();
     ET_CHECK_OK_OR_RETURN_ERROR(load());
@@ -105,77 +102,87 @@ Error TextLLMRunner::generate(
           token_callback(piece);
         }
       };
-  // First token time only measures the time it takes to encode the prompt and
-  // return a response token.
 
   stats_->inference_start_ms = time_in_ms();
   shouldStop_ = false;
 
-  ::tokenizers::Result<std::vector<uint64_t>> encode_res = tokenizer_->encode(
-      prompt,
-      /*bos=*/config.num_bos,
-      /*eos=*/config.num_eos);
+  // Capture remaining KV cache capacity before prefill (pos_ will change)
+  int64_t max_context_len = metadata_.at(kMaxContextLen) - pos_;
 
-  if (!encode_res.ok()) {
-    ET_LOG(
-        Error,
-        "Failed to encode prompt %s. Tokenizers error code %d",
-        prompt.c_str(),
-        static_cast<uint32_t>(encode_res.error()));
-    return Error::InvalidArgument;
+  uint64_t cur_token;
+  int num_prompt_tokens;
+  std::vector<uint64_t> prompt_tokens;
+
+  if (!prompt.empty()) {
+    ::tokenizers::Result<std::vector<uint64_t>> encode_res =
+        tokenizer_->encode(
+            prompt,
+            /*bos=*/config.num_bos,
+            /*eos=*/config.num_eos);
+
+    if (!encode_res.ok()) {
+      ET_LOG(
+          Error,
+          "Failed to encode prompt %s. Tokenizers error code %d",
+          prompt.c_str(),
+          static_cast<uint32_t>(encode_res.error()));
+      return Error::InvalidArgument;
+    }
+
+    prompt_tokens = encode_res.get();
+    num_prompt_tokens = prompt_tokens.size();
+
+    ET_CHECK_OR_RETURN_ERROR(
+        num_prompt_tokens >= 1,
+        InvalidArgument,
+        "Expected at least 1 prompt token");
+    ET_CHECK_OR_RETURN_ERROR(
+        num_prompt_tokens < max_context_len,
+        InvalidArgument,
+        "num_prompt_tokens %d >= max_context_len %" PRId64
+        ", Max seq length exceeded - please increase max seq len value in your export script",
+        num_prompt_tokens,
+        max_context_len);
+
+    if (config.echo) {
+      wrapped_callback(prompt);
+    }
+    auto prefill_res = text_prefiller_->prefill(prompt_tokens, pos_);
+    ET_CHECK_OK_OR_RETURN_ERROR(prefill_res.error());
+    cur_token = prefill_res.get();
+    prefill_next_token_.reset();
+  } else {
+    // Empty prompt: consume token from a prior prefill() call
+    ET_CHECK_OR_RETURN_ERROR(
+        prefill_next_token_.has_value(),
+        InvalidState,
+        "Empty prompt requires a prior prefill() call");
+    cur_token = prefill_next_token_.value();
+    prefill_next_token_.reset();
+    num_prompt_tokens = 0;
   }
 
-  // encode the (string) prompt into tokens sequence
-  std::vector<uint64_t> prompt_tokens = encode_res.get();
-  int num_prompt_tokens = prompt_tokens.size();
-
-  // Reduce max_context_len by pos_
-  int64_t max_context_len = metadata_.at(kMaxContextLen) - pos_;
-  ET_CHECK_OR_RETURN_ERROR(
-      num_prompt_tokens >= 1,
-      InvalidArgument,
-      "Expected at least 1 prompt token");
-  ET_CHECK_OR_RETURN_ERROR(
-      num_prompt_tokens < max_context_len,
-      InvalidArgument,
-      "num_prompt_tokens %d >= max_context_len %" PRId64
-      ", Max seq length exceeded - please increase max seq len value in your export script",
-      num_prompt_tokens,
-      max_context_len);
-
-  // Determine max_new_tokens using the GenerationConfig's resolve method,
-  // then subtract pos_ for max_new_tokens.
   int max_new_tokens =
       config.resolve_max_new_tokens(max_context_len, num_prompt_tokens);
 
   ET_LOG(
       Info,
       "Max new tokens resolved: %d, given pos_ %" PRId64
-      ", num_prompt_tokens %zu, max_context_len %" PRId64,
+      ", num_prompt_tokens %d, max_context_len %" PRId64,
       max_new_tokens,
       pos_,
-      prompt_tokens.size(),
+      num_prompt_tokens,
       max_context_len);
   ET_CHECK_OR_RETURN_ERROR(
       max_new_tokens > 0,
       InvalidArgument,
       "Max new tokens %d is less than or equal to 0",
       max_new_tokens);
-  // Prefill first
-  // Here feed all tokens to the model and get the next predicted token
-  // after the prompt. After that we will enter generate loop.
 
-  // print prompts
-  if (config.echo) {
-    wrapped_callback(prompt);
-  }
-  auto prefill_res = text_prefiller_->prefill(prompt_tokens, pos_);
-  ET_CHECK_OK_OR_RETURN_ERROR(prefill_res.error());
-  uint64_t cur_token = prefill_res.get();
   stats_->first_token_ms = time_in_ms();
   stats_->prompt_eval_end_ms = time_in_ms();
 
-  // print the first token from prefill. No prev_token so use cur_token for it.
+  // Decode the first token from prefill
   auto decode_result = tokenizer_->decode(cur_token, cur_token);
   if (!decode_result.ok()) {
     ET_LOG(
@@ -190,13 +197,11 @@ Error TextLLMRunner::generate(
       "RSS after prompt prefill: %f MiB (0 if unsupported)",
       get_rss_bytes() / 1024.0 / 1024.0);
 
-  // start the main loop
+  // Start the main decode loop
   prompt_tokens.push_back(cur_token);
 
-  // Set ignore_eos based on config
   text_token_generator_->set_ignore_eos(config.ignore_eos);
 
-  // Generate max_new_tokens - 1 because prefill already generated 1 token.
   auto generate_result = text_token_generator_->generate(
       prompt_tokens,
       pos_,
@@ -223,13 +228,13 @@ Error TextLLMRunner::generate(
     RUNNER_ET_LOG(config.warming, "Max new tokens %i reached!", max_new_tokens);
   }
 
-  stats_->num_prompt_tokens = num_prompt_tokens;
+  stats_->num_prompt_tokens =
+      prompt.empty() ? static_cast<int64_t>(pos_) : num_prompt_tokens;
   stats_->num_generated_tokens = num_generated_tokens;
 
   if (config.warming) {
     ET_LOG(Info, "Warmup run finished!");
   } else {
-    // Do not print report during warmup
     print_report(*stats_);
   }
   if (stats_callback) {
@@ -240,24 +245,36 @@ Error TextLLMRunner::generate(
 }
 
 Error TextLLMRunner::prefill(
-    const std::string& prompt,
-    const GenerationConfig& config) {
+    const std::vector<MultimodalInput>& inputs,
+    int32_t num_bos,
+    int32_t num_eos) {
   if (!is_loaded()) {
     ET_CHECK_OK_OR_RETURN_ERROR(load());
   }
 
-  ::tokenizers::Result<std::vector<uint64_t>> encode_res = tokenizer_->encode(
-      prompt,
-      /*bos=*/config.num_bos,
-      /*eos=*/config.num_eos);
+  for (const auto& input : inputs) {
+    if (input.is_text()) {
+      auto encode_res = tokenizer_->encode(
+          input.get_text(), /*bos=*/num_bos, /*eos=*/num_eos);
+      ET_CHECK_TK_OK_OR_RETURN_ERROR(
+          encode_res.error(),
+          "Failed to encode prompt %s",
+          input.get_text().c_str());
+      std::vector<uint64_t> tokens = encode_res.get();
+      auto prefill_res = text_prefiller_->prefill(tokens, pos_);
+      ET_CHECK_OK_OR_RETURN_ERROR(prefill_res.error());
+      prefill_next_token_ = prefill_res.get();
+    } else if (input.is_tokens()) {
+      std::vector<uint64_t> tokens = input.get_tokens();
+      auto prefill_res = text_prefiller_->prefill(tokens, pos_);
+      ET_CHECK_OK_OR_RETURN_ERROR(prefill_res.error());
+      prefill_next_token_ = prefill_res.get();
+    }
+    // Skip image/audio — text-only runner
+    num_bos = 0;
+    num_eos = 0;
+  }
 
-  ET_CHECK_TK_OK_OR_RETURN_ERROR(
-      encode_res.error(), "Failed to encode prompt %s", prompt.c_str());
-
-  // encode the (string) prompt into tokens sequence
-  std::vector<uint64_t> prompt_tokens = encode_res.get();
-  auto prefill_res = text_prefiller_->prefill(prompt_tokens, pos_);
-  ET_CHECK_OK_OR_RETURN_ERROR(prefill_res.error());
   return Error::Ok;
 }
 
@@ -287,6 +304,7 @@ void TextLLMRunner::stop() {
 void TextLLMRunner::reset() {
   stats_->reset();
   pos_ = 0;
+  prefill_next_token_.reset();
 }
 
 } // namespace executorch::extension::llm

--- a/extension/llm/runner/text_llm_runner.cpp
+++ b/extension/llm/runner/text_llm_runner.cpp
@@ -11,6 +11,7 @@
 // The module takes in a string as input and emits a string as output.
 
 #include <executorch/extension/llm/runner/io_manager/io_manager.h>
+#include <executorch/extension/llm/runner/multimodal_input.h>
 #include <executorch/extension/llm/runner/text_llm_runner.h>
 #include <executorch/extension/llm/runner/util.h>
 #include <executorch/runtime/platform/runtime.h>
@@ -287,6 +288,21 @@ Result<uint64_t> TextLLMRunner::prefill(
     return Error::InvalidArgument;
   }
   return prefill_next_token_.value();
+}
+
+Result<uint64_t> TextLLMRunner::prefill(
+    const std::string& prompt,
+    int32_t num_bos,
+    int32_t num_eos) {
+  std::vector<MultimodalInput> inputs;
+  inputs.emplace_back(MultimodalInput(prompt));
+  return prefill(inputs, num_bos, num_eos);
+}
+
+Result<uint64_t> TextLLMRunner::prefill(
+    const std::string& prompt,
+    const GenerationConfig& config) {
+  return prefill(prompt, config.num_bos, config.num_eos);
 }
 
 Error TextLLMRunner::warmup(const std::string& prompt, int32_t max_new_tokens) {

--- a/extension/llm/runner/text_llm_runner.cpp
+++ b/extension/llm/runner/text_llm_runner.cpp
@@ -260,10 +260,10 @@ Error TextLLMRunner::prefill(
       std::vector<uint64_t> tokens = encode_res.get();
       auto prefill_res = text_prefiller_->prefill(tokens, pos_);
       ET_CHECK_OK_OR_RETURN_ERROR(prefill_res.error());
+      num_bos = 0;
+      num_eos = 0;
     }
     // Skip non-text inputs — text-only runner
-    num_bos = 0;
-    num_eos = 0;
   }
 
   return Error::Ok;

--- a/extension/llm/runner/text_llm_runner.cpp
+++ b/extension/llm/runner/text_llm_runner.cpp
@@ -76,6 +76,7 @@ Error TextLLMRunner::generate(
     const GenerationConfig& config,
     std::function<void(const std::string&)> token_callback,
     std::function<void(const Stats&)> stats_callback) {
+  ET_CHECK_MSG(!prompt.empty(), "Prompt cannot be null");
   if (!is_loaded()) {
     stats_->model_load_start_ms = time_in_ms();
     ET_CHECK_OK_OR_RETURN_ERROR(load());
@@ -106,61 +107,37 @@ Error TextLLMRunner::generate(
   stats_->inference_start_ms = time_in_ms();
   shouldStop_ = false;
 
-  // Capture remaining KV cache capacity before prefill (pos_ will change)
-  int64_t max_context_len = metadata_.at(kMaxContextLen) - pos_;
+  ::tokenizers::Result<std::vector<uint64_t>> encode_res = tokenizer_->encode(
+      prompt,
+      /*bos=*/config.num_bos,
+      /*eos=*/config.num_eos);
 
-  uint64_t cur_token = 0;
-  int num_prompt_tokens = 0;
-  std::vector<uint64_t> prompt_tokens;
-
-  if (!prompt.empty()) {
-    ::tokenizers::Result<std::vector<uint64_t>> encode_res =
-        tokenizer_->encode(
-            prompt,
-            /*bos=*/config.num_bos,
-            /*eos=*/config.num_eos);
-
-    if (!encode_res.ok()) {
-      ET_LOG(
-          Error,
-          "Failed to encode prompt %s. Tokenizers error code %d",
-          prompt.c_str(),
-          static_cast<uint32_t>(encode_res.error()));
-      return Error::InvalidArgument;
-    }
-
-    prompt_tokens = encode_res.get();
-    num_prompt_tokens = prompt_tokens.size();
-
-    ET_CHECK_OR_RETURN_ERROR(
-        num_prompt_tokens >= 1,
-        InvalidArgument,
-        "Expected at least 1 prompt token");
-    ET_CHECK_OR_RETURN_ERROR(
-        num_prompt_tokens < max_context_len,
-        InvalidArgument,
-        "num_prompt_tokens %d >= max_context_len %" PRId64
-        ", Max seq length exceeded - please increase max seq len value in your export script",
-        num_prompt_tokens,
-        max_context_len);
-
-    if (config.echo) {
-      wrapped_callback(prompt);
-    }
-    auto prefill_res = text_prefiller_->prefill(prompt_tokens, pos_);
-    ET_CHECK_OK_OR_RETURN_ERROR(prefill_res.error());
-    cur_token = prefill_res.get();
-    prefill_next_token_.reset();
-  } else {
-    // Empty prompt: consume token from a prior prefill() call
-    ET_CHECK_OR_RETURN_ERROR(
-        prefill_next_token_.has_value(),
-        InvalidState,
-        "Empty prompt requires a prior prefill() call");
-    cur_token = prefill_next_token_.value();
-    prefill_next_token_.reset();
-    num_prompt_tokens = 0;
+  if (!encode_res.ok()) {
+    ET_LOG(
+        Error,
+        "Failed to encode prompt %s. Tokenizers error code %d",
+        prompt.c_str(),
+        static_cast<uint32_t>(encode_res.error()));
+    return Error::InvalidArgument;
   }
+
+  // encode the (string) prompt into tokens sequence
+  std::vector<uint64_t> prompt_tokens = encode_res.get();
+  int num_prompt_tokens = prompt_tokens.size();
+
+  // Reduce max_context_len by pos_
+  int64_t max_context_len = metadata_.at(kMaxContextLen) - pos_;
+  ET_CHECK_OR_RETURN_ERROR(
+      num_prompt_tokens >= 1,
+      InvalidArgument,
+      "Expected at least 1 prompt token");
+  ET_CHECK_OR_RETURN_ERROR(
+      num_prompt_tokens < max_context_len,
+      InvalidArgument,
+      "num_prompt_tokens %d >= max_context_len %" PRId64
+      ", Max seq length exceeded - please increase max seq len value in your export script",
+      num_prompt_tokens,
+      max_context_len);
 
   int max_new_tokens =
       config.resolve_max_new_tokens(max_context_len, num_prompt_tokens);
@@ -168,10 +145,10 @@ Error TextLLMRunner::generate(
   ET_LOG(
       Info,
       "Max new tokens resolved: %d, given pos_ %" PRId64
-      ", num_prompt_tokens %d, max_context_len %" PRId64,
+      ", num_prompt_tokens %zu, max_context_len %" PRId64,
       max_new_tokens,
       pos_,
-      num_prompt_tokens,
+      prompt_tokens.size(),
       max_context_len);
   ET_CHECK_OR_RETURN_ERROR(
       max_new_tokens > 0,
@@ -179,10 +156,15 @@ Error TextLLMRunner::generate(
       "Max new tokens %d is less than or equal to 0",
       max_new_tokens);
 
+  if (config.echo) {
+    wrapped_callback(prompt);
+  }
+  auto prefill_res = text_prefiller_->prefill(prompt_tokens, pos_);
+  ET_CHECK_OK_OR_RETURN_ERROR(prefill_res.error());
+  uint64_t cur_token = prefill_res.get();
   stats_->first_token_ms = time_in_ms();
   stats_->prompt_eval_end_ms = time_in_ms();
 
-  // Decode the first token from prefill
   auto decode_result = tokenizer_->decode(cur_token, cur_token);
   if (!decode_result.ok()) {
     ET_LOG(
@@ -197,7 +179,6 @@ Error TextLLMRunner::generate(
       "RSS after prompt prefill: %f MiB (0 if unsupported)",
       get_rss_bytes() / 1024.0 / 1024.0);
 
-  // Start the main decode loop
   prompt_tokens.push_back(cur_token);
 
   text_token_generator_->set_ignore_eos(config.ignore_eos);
@@ -228,8 +209,7 @@ Error TextLLMRunner::generate(
     RUNNER_ET_LOG(config.warming, "Max new tokens %i reached!", max_new_tokens);
   }
 
-  stats_->num_prompt_tokens =
-      prompt.empty() ? static_cast<int64_t>(pos_) : num_prompt_tokens;
+  stats_->num_prompt_tokens = num_prompt_tokens;
   stats_->num_generated_tokens = num_generated_tokens;
 
   if (config.warming) {
@@ -263,12 +243,10 @@ Error TextLLMRunner::prefill(
       std::vector<uint64_t> tokens = encode_res.get();
       auto prefill_res = text_prefiller_->prefill(tokens, pos_);
       ET_CHECK_OK_OR_RETURN_ERROR(prefill_res.error());
-      prefill_next_token_ = prefill_res.get();
     } else if (input.is_tokens()) {
       std::vector<uint64_t> tokens = input.get_tokens();
       auto prefill_res = text_prefiller_->prefill(tokens, pos_);
       ET_CHECK_OK_OR_RETURN_ERROR(prefill_res.error());
-      prefill_next_token_ = prefill_res.get();
     }
     // Skip image/audio — text-only runner
     num_bos = 0;
@@ -304,7 +282,6 @@ void TextLLMRunner::stop() {
 void TextLLMRunner::reset() {
   stats_->reset();
   pos_ = 0;
-  prefill_next_token_.reset();
 }
 
 } // namespace executorch::extension::llm

--- a/extension/llm/runner/text_llm_runner.cpp
+++ b/extension/llm/runner/text_llm_runner.cpp
@@ -260,12 +260,8 @@ Error TextLLMRunner::prefill(
       std::vector<uint64_t> tokens = encode_res.get();
       auto prefill_res = text_prefiller_->prefill(tokens, pos_);
       ET_CHECK_OK_OR_RETURN_ERROR(prefill_res.error());
-    } else if (input.is_tokens()) {
-      std::vector<uint64_t> tokens = input.get_tokens();
-      auto prefill_res = text_prefiller_->prefill(tokens, pos_);
-      ET_CHECK_OK_OR_RETURN_ERROR(prefill_res.error());
     }
-    // Skip image/audio — text-only runner
+    // Skip non-text inputs — text-only runner
     num_bos = 0;
     num_eos = 0;
   }

--- a/extension/llm/runner/text_llm_runner.cpp
+++ b/extension/llm/runner/text_llm_runner.cpp
@@ -109,8 +109,8 @@ Error TextLLMRunner::generate(
   // Capture remaining KV cache capacity before prefill (pos_ will change)
   int64_t max_context_len = metadata_.at(kMaxContextLen) - pos_;
 
-  uint64_t cur_token;
-  int num_prompt_tokens;
+  uint64_t cur_token = 0;
+  int num_prompt_tokens = 0;
   std::vector<uint64_t> prompt_tokens;
 
   if (!prompt.empty()) {

--- a/extension/llm/runner/text_llm_runner.cpp
+++ b/extension/llm/runner/text_llm_runner.cpp
@@ -118,8 +118,8 @@ Error TextLLMRunner::generate(
   std::vector<uint64_t> prompt_tokens;
 
   if (!prompt.empty()) {
-    ::tokenizers::Result<std::vector<uint64_t>> encode_res =
-        tokenizer_->encode(prompt, /*bos=*/config.num_bos, /*eos=*/config.num_eos);
+    ::tokenizers::Result<std::vector<uint64_t>> encode_res = tokenizer_->encode(
+        prompt, /*bos=*/config.num_bos, /*eos=*/config.num_eos);
 
     if (!encode_res.ok()) {
       ET_LOG(

--- a/extension/llm/runner/text_llm_runner.cpp
+++ b/extension/llm/runner/text_llm_runner.cpp
@@ -76,6 +76,8 @@ Error TextLLMRunner::generate(
     const GenerationConfig& config,
     std::function<void(const std::string&)> token_callback,
     std::function<void(const Stats&)> stats_callback) {
+  // Prepare the inputs.
+  // Use ones-initialized inputs.
   ET_CHECK_MSG(!prompt.empty(), "Prompt cannot be null");
   if (!is_loaded()) {
     stats_->model_load_start_ms = time_in_ms();
@@ -103,6 +105,9 @@ Error TextLLMRunner::generate(
           token_callback(piece);
         }
       };
+
+  // First token time only measures the time it takes to encode the prompt and
+  // return a response token.
 
   stats_->inference_start_ms = time_in_ms();
   shouldStop_ = false;
@@ -139,6 +144,8 @@ Error TextLLMRunner::generate(
       num_prompt_tokens,
       max_context_len);
 
+  // Determine max_new_tokens using the GenerationConfig's resolve method,
+  // then subtract pos_ for max_new_tokens.
   int max_new_tokens =
       config.resolve_max_new_tokens(max_context_len, num_prompt_tokens);
 
@@ -156,6 +163,11 @@ Error TextLLMRunner::generate(
       "Max new tokens %d is less than or equal to 0",
       max_new_tokens);
 
+  // Prefill first
+  // Here feed all tokens to the model and get the next predicted token
+  // after the prompt. After that we will enter generate loop.
+
+  // print prompts
   if (config.echo) {
     wrapped_callback(prompt);
   }
@@ -165,6 +177,7 @@ Error TextLLMRunner::generate(
   stats_->first_token_ms = time_in_ms();
   stats_->prompt_eval_end_ms = time_in_ms();
 
+  // print the first token from prefill. No prev_token so use cur_token for it.
   auto decode_result = tokenizer_->decode(cur_token, cur_token);
   if (!decode_result.ok()) {
     ET_LOG(
@@ -179,10 +192,13 @@ Error TextLLMRunner::generate(
       "RSS after prompt prefill: %f MiB (0 if unsupported)",
       get_rss_bytes() / 1024.0 / 1024.0);
 
+  // start the main loop
   prompt_tokens.push_back(cur_token);
 
+  // Set ignore_eos based on config
   text_token_generator_->set_ignore_eos(config.ignore_eos);
 
+  // Generate max_new_tokens - 1 because prefill already generated 1 token.
   auto generate_result = text_token_generator_->generate(
       prompt_tokens,
       pos_,
@@ -215,6 +231,7 @@ Error TextLLMRunner::generate(
   if (config.warming) {
     ET_LOG(Info, "Warmup run finished!");
   } else {
+    // Do not print report during warmup
     print_report(*stats_);
   }
   if (stats_callback) {

--- a/extension/llm/runner/text_llm_runner.cpp
+++ b/extension/llm/runner/text_llm_runner.cpp
@@ -76,9 +76,6 @@ Error TextLLMRunner::generate(
     const GenerationConfig& config,
     std::function<void(const std::string&)> token_callback,
     std::function<void(const Stats&)> stats_callback) {
-  // Prepare the inputs.
-  // Use ones-initialized inputs.
-  ET_CHECK_MSG(!prompt.empty(), "Prompt cannot be null");
   if (!is_loaded()) {
     stats_->model_load_start_ms = time_in_ms();
     ET_CHECK_OK_OR_RETURN_ERROR(load());
@@ -112,37 +109,66 @@ Error TextLLMRunner::generate(
   stats_->inference_start_ms = time_in_ms();
   shouldStop_ = false;
 
-  ::tokenizers::Result<std::vector<uint64_t>> encode_res = tokenizer_->encode(
-      prompt,
-      /*bos=*/config.num_bos,
-      /*eos=*/config.num_eos);
-
-  if (!encode_res.ok()) {
-    ET_LOG(
-        Error,
-        "Failed to encode prompt %s. Tokenizers error code %d",
-        prompt.c_str(),
-        static_cast<uint32_t>(encode_res.error()));
-    return Error::InvalidArgument;
-  }
-
-  // encode the (string) prompt into tokens sequence
-  std::vector<uint64_t> prompt_tokens = encode_res.get();
-  int num_prompt_tokens = prompt_tokens.size();
-
-  // Reduce max_context_len by pos_
+  // Capture remaining KV cache capacity before prefill (pos_ will change)
   int64_t max_context_len = metadata_.at(kMaxContextLen) - pos_;
-  ET_CHECK_OR_RETURN_ERROR(
-      num_prompt_tokens >= 1,
-      InvalidArgument,
-      "Expected at least 1 prompt token");
-  ET_CHECK_OR_RETURN_ERROR(
-      num_prompt_tokens < max_context_len,
-      InvalidArgument,
-      "num_prompt_tokens %d >= max_context_len %" PRId64
-      ", Max seq length exceeded - please increase max seq len value in your export script",
-      num_prompt_tokens,
-      max_context_len);
+
+  uint64_t cur_token = 0;
+  int num_prompt_tokens = 0;
+  std::vector<uint64_t> prompt_tokens;
+
+  if (!prompt.empty()) {
+    ::tokenizers::Result<std::vector<uint64_t>> encode_res =
+        tokenizer_->encode(
+            prompt,
+            /*bos=*/config.num_bos,
+            /*eos=*/config.num_eos);
+
+    if (!encode_res.ok()) {
+      ET_LOG(
+          Error,
+          "Failed to encode prompt %s. Tokenizers error code %d",
+          prompt.c_str(),
+          static_cast<uint32_t>(encode_res.error()));
+      return Error::InvalidArgument;
+    }
+
+    // encode the (string) prompt into tokens sequence
+    prompt_tokens = encode_res.get();
+    num_prompt_tokens = prompt_tokens.size();
+
+    ET_CHECK_OR_RETURN_ERROR(
+        num_prompt_tokens >= 1,
+        InvalidArgument,
+        "Expected at least 1 prompt token");
+    ET_CHECK_OR_RETURN_ERROR(
+        num_prompt_tokens < max_context_len,
+        InvalidArgument,
+        "num_prompt_tokens %d >= max_context_len %" PRId64
+        ", Max seq length exceeded - please increase max seq len value in your export script",
+        num_prompt_tokens,
+        max_context_len);
+
+    // print prompts
+    if (config.echo) {
+      wrapped_callback(prompt);
+    }
+
+    // Prefill first
+    // Here feed all tokens to the model and get the next predicted token
+    // after the prompt. After that we will enter generate loop.
+    auto prefill_res = text_prefiller_->prefill(prompt_tokens, pos_);
+    ET_CHECK_OK_OR_RETURN_ERROR(prefill_res.error());
+    cur_token = prefill_res.get();
+    prefill_next_token_.reset();
+  } else {
+    // Empty prompt: consume token from a prior prefill() call
+    ET_CHECK_OR_RETURN_ERROR(
+        prefill_next_token_.has_value(),
+        InvalidState,
+        "Empty prompt requires a prior prefill() call");
+    cur_token = prefill_next_token_.value();
+    prefill_next_token_.reset();
+  }
 
   // Determine max_new_tokens using the GenerationConfig's resolve method,
   // then subtract pos_ for max_new_tokens.
@@ -152,10 +178,10 @@ Error TextLLMRunner::generate(
   ET_LOG(
       Info,
       "Max new tokens resolved: %d, given pos_ %" PRId64
-      ", num_prompt_tokens %zu, max_context_len %" PRId64,
+      ", num_prompt_tokens %d, max_context_len %" PRId64,
       max_new_tokens,
       pos_,
-      prompt_tokens.size(),
+      num_prompt_tokens,
       max_context_len);
   ET_CHECK_OR_RETURN_ERROR(
       max_new_tokens > 0,
@@ -163,17 +189,6 @@ Error TextLLMRunner::generate(
       "Max new tokens %d is less than or equal to 0",
       max_new_tokens);
 
-  // Prefill first
-  // Here feed all tokens to the model and get the next predicted token
-  // after the prompt. After that we will enter generate loop.
-
-  // print prompts
-  if (config.echo) {
-    wrapped_callback(prompt);
-  }
-  auto prefill_res = text_prefiller_->prefill(prompt_tokens, pos_);
-  ET_CHECK_OK_OR_RETURN_ERROR(prefill_res.error());
-  uint64_t cur_token = prefill_res.get();
   stats_->first_token_ms = time_in_ms();
   stats_->prompt_eval_end_ms = time_in_ms();
 
@@ -225,7 +240,8 @@ Error TextLLMRunner::generate(
     RUNNER_ET_LOG(config.warming, "Max new tokens %i reached!", max_new_tokens);
   }
 
-  stats_->num_prompt_tokens = num_prompt_tokens;
+  stats_->num_prompt_tokens =
+      prompt.empty() ? static_cast<int64_t>(pos_) : num_prompt_tokens;
   stats_->num_generated_tokens = num_generated_tokens;
 
   if (config.warming) {
@@ -260,6 +276,7 @@ Error TextLLMRunner::prefill(
       std::vector<uint64_t> tokens = encode_res.get();
       auto prefill_res = text_prefiller_->prefill(tokens, pos_);
       ET_CHECK_OK_OR_RETURN_ERROR(prefill_res.error());
+      prefill_next_token_ = prefill_res.get();
       num_bos = 0;
       num_eos = 0;
     }
@@ -295,6 +312,7 @@ void TextLLMRunner::stop() {
 void TextLLMRunner::reset() {
   stats_->reset();
   pos_ = 0;
+  prefill_next_token_.reset();
 }
 
 } // namespace executorch::extension::llm

--- a/extension/llm/runner/text_llm_runner.cpp
+++ b/extension/llm/runner/text_llm_runner.cpp
@@ -257,7 +257,7 @@ Error TextLLMRunner::generate(
   return Error::Ok;
 }
 
-Error TextLLMRunner::prefill(
+Result<uint64_t> TextLLMRunner::prefill(
     const std::vector<MultimodalInput>& inputs,
     int32_t num_bos,
     int32_t num_eos) {
@@ -283,7 +283,10 @@ Error TextLLMRunner::prefill(
     // Skip non-text inputs — text-only runner
   }
 
-  return Error::Ok;
+  if (!prefill_next_token_.has_value()) {
+    return Error::InvalidArgument;
+  }
+  return prefill_next_token_.value();
 }
 
 Error TextLLMRunner::warmup(const std::string& prompt, int32_t max_new_tokens) {

--- a/extension/llm/runner/text_llm_runner.h
+++ b/extension/llm/runner/text_llm_runner.h
@@ -109,9 +109,10 @@ class ET_EXPERIMENTAL TextLLMRunner : public IRunner {
    * @param inputs A vector of MultimodalInput objects.
    * @param num_bos Number of BOS tokens to prepend during text encoding.
    * @param num_eos Number of EOS tokens to append during text encoding.
-   * @return The error code. KV cache position is tracked internally in pos_.
+   * @return The next token predicted after prefill, or an error.
+   *         KV cache position is tracked internally in pos_.
    */
-  ::executorch::runtime::Error prefill(
+  ::executorch::runtime::Result<uint64_t> prefill(
       const std::vector<MultimodalInput>& inputs,
       int32_t num_bos = 0,
       int32_t num_eos = 0) override;
@@ -119,7 +120,7 @@ class ET_EXPERIMENTAL TextLLMRunner : public IRunner {
   /**
    * Convenience overload: prefill a single text prompt.
    */
-  ::executorch::runtime::Error
+  ::executorch::runtime::Result<uint64_t>
   prefill(const std::string& prompt, int32_t num_bos = 0, int32_t num_eos = 0) {
     std::vector<MultimodalInput> inputs;
     inputs.emplace_back(MultimodalInput(prompt));
@@ -130,7 +131,7 @@ class ET_EXPERIMENTAL TextLLMRunner : public IRunner {
    * Prefill a text prompt using GenerationConfig.
    * Deprecated: prefer prefill(prompt, num_bos, num_eos).
    */
-  ::executorch::runtime::Error prefill(
+  ::executorch::runtime::Result<uint64_t> prefill(
       const std::string& prompt,
       const GenerationConfig& config) {
     return prefill(prompt, config.num_bos, config.num_eos);

--- a/extension/llm/runner/text_llm_runner.h
+++ b/extension/llm/runner/text_llm_runner.h
@@ -18,6 +18,7 @@
 #include <unordered_map>
 
 #include <executorch/extension/llm/runner/irunner.h>
+#include <executorch/extension/llm/runner/multimodal_input.h>
 #include <executorch/extension/llm/runner/stats.h>
 #include <executorch/extension/llm/runner/text_decoder_runner.h>
 #include <executorch/extension/llm/runner/text_prefiller.h>
@@ -101,8 +102,6 @@ class ET_EXPERIMENTAL TextLLMRunner : public IRunner {
       std::function<void(const std::string&)> token_callback = {},
       std::function<void(const Stats&)> stats_callback = {}) override;
 
-  using IRunner::prefill; // Bring in string convenience overload
-
   /**
    * Prefill multimodal inputs into the KV cache without generating.
    * Only text inputs are processed; non-text inputs are skipped.
@@ -115,6 +114,16 @@ class ET_EXPERIMENTAL TextLLMRunner : public IRunner {
       const std::vector<MultimodalInput>& inputs,
       int32_t num_bos = 0,
       int32_t num_eos = 0) override;
+
+  /**
+   * Convenience overload: prefill a single text prompt.
+   */
+  ::executorch::runtime::Error
+  prefill(const std::string& prompt, int32_t num_bos = 0, int32_t num_eos = 0) {
+    std::vector<MultimodalInput> inputs;
+    inputs.emplace_back(MultimodalInput(prompt));
+    return prefill(inputs, num_bos, num_eos);
+  }
 
   /**
    * Prefill a text prompt using GenerationConfig.

--- a/extension/llm/runner/text_llm_runner.h
+++ b/extension/llm/runner/text_llm_runner.h
@@ -118,6 +118,16 @@ class ET_EXPERIMENTAL TextLLMRunner : public IRunner {
       int32_t num_eos = 0) override;
 
   /**
+   * Prefill a text prompt using GenerationConfig.
+   * Deprecated: prefer prefill(prompt, num_bos, num_eos).
+   */
+  ::executorch::runtime::Error prefill(
+      const std::string& prompt,
+      const GenerationConfig& config) {
+    return prefill(prompt, config.num_bos, config.num_eos);
+  }
+
+  /**
    * @brief Warms up the model with a sample prompt
    *
    * This method runs a complete generation cycle without returning results,

--- a/extension/llm/runner/text_llm_runner.h
+++ b/extension/llm/runner/text_llm_runner.h
@@ -14,6 +14,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 
@@ -101,16 +102,20 @@ class ET_EXPERIMENTAL TextLLMRunner : public IRunner {
       std::function<void(const std::string&)> token_callback = {},
       std::function<void(const Stats&)> stats_callback = {}) override;
 
+  using IRunner::prefill; // Bring in string convenience overload
+
   /**
-   * Prefill text inputs, for example to reload chat history.
-   * @param prompt Text prompt to prefill.
-   * @param config Configuration parameters for text generation (e.g.,
-   * max_new_tokens, temperature)
+   * Prefill multimodal inputs into the KV cache without generating.
+   * Text and token inputs are supported; image/audio inputs are skipped.
+   * @param inputs A vector of MultimodalInput objects.
+   * @param num_bos Number of BOS tokens to prepend during text encoding.
+   * @param num_eos Number of EOS tokens to append during text encoding.
    * @return The error code. KV cache position is tracked internally in pos_.
    */
   ::executorch::runtime::Error prefill(
-      const std::string& prompt,
-      const GenerationConfig& config);
+      const std::vector<MultimodalInput>& inputs,
+      int32_t num_bos = 0,
+      int32_t num_eos = 0) override;
 
   /**
    * @brief Warms up the model with a sample prompt
@@ -165,6 +170,9 @@ class ET_EXPERIMENTAL TextLLMRunner : public IRunner {
   // temperature.
   // Deprecated, we should rely on the temperature in GenerationConfig instead.
   float temperature_ = -1.0f;
+
+  // Token predicted by the last prefill() call, consumed by generate("").
+  std::optional<uint64_t> prefill_next_token_;
 
   // The position in KV cache of the input, starting from 0.
   int64_t pos_ = 0;

--- a/extension/llm/runner/text_llm_runner.h
+++ b/extension/llm/runner/text_llm_runner.h
@@ -105,7 +105,7 @@ class ET_EXPERIMENTAL TextLLMRunner : public IRunner {
 
   /**
    * Prefill multimodal inputs into the KV cache without generating.
-   * Text and token inputs are supported; image/audio inputs are skipped.
+   * Only text inputs are processed; non-text inputs are skipped.
    * @param inputs A vector of MultimodalInput objects.
    * @param num_bos Number of BOS tokens to prepend during text encoding.
    * @param num_eos Number of EOS tokens to append during text encoding.

--- a/extension/llm/runner/text_llm_runner.h
+++ b/extension/llm/runner/text_llm_runner.h
@@ -14,7 +14,6 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
-#include <optional>
 #include <string>
 #include <unordered_map>
 
@@ -180,9 +179,6 @@ class ET_EXPERIMENTAL TextLLMRunner : public IRunner {
   // temperature.
   // Deprecated, we should rely on the temperature in GenerationConfig instead.
   float temperature_ = -1.0f;
-
-  // Token predicted by the last prefill() call, consumed by generate("").
-  std::optional<uint64_t> prefill_next_token_;
 
   // The position in KV cache of the input, starting from 0.
   int64_t pos_ = 0;

--- a/extension/llm/runner/text_llm_runner.h
+++ b/extension/llm/runner/text_llm_runner.h
@@ -19,7 +19,6 @@
 #include <unordered_map>
 
 #include <executorch/extension/llm/runner/irunner.h>
-#include <executorch/extension/llm/runner/multimodal_input.h>
 #include <executorch/extension/llm/runner/stats.h>
 #include <executorch/extension/llm/runner/text_decoder_runner.h>
 #include <executorch/extension/llm/runner/text_prefiller.h>
@@ -120,12 +119,10 @@ class ET_EXPERIMENTAL TextLLMRunner : public IRunner {
   /**
    * Convenience overload: prefill a single text prompt.
    */
-  ::executorch::runtime::Result<uint64_t>
-  prefill(const std::string& prompt, int32_t num_bos = 0, int32_t num_eos = 0) {
-    std::vector<MultimodalInput> inputs;
-    inputs.emplace_back(MultimodalInput(prompt));
-    return prefill(inputs, num_bos, num_eos);
-  }
+  ::executorch::runtime::Result<uint64_t> prefill(
+      const std::string& prompt,
+      int32_t num_bos = 0,
+      int32_t num_eos = 0);
 
   /**
    * Prefill a text prompt using GenerationConfig.
@@ -133,9 +130,7 @@ class ET_EXPERIMENTAL TextLLMRunner : public IRunner {
    */
   ::executorch::runtime::Result<uint64_t> prefill(
       const std::string& prompt,
-      const GenerationConfig& config) {
-    return prefill(prompt, config.num_bos, config.num_eos);
-  }
+      const GenerationConfig& config);
 
   /**
    * @brief Warms up the model with a sample prompt

--- a/extension/llm/runner/text_llm_runner.h
+++ b/extension/llm/runner/text_llm_runner.h
@@ -14,6 +14,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 
@@ -188,6 +189,9 @@ class ET_EXPERIMENTAL TextLLMRunner : public IRunner {
   // temperature.
   // Deprecated, we should rely on the temperature in GenerationConfig instead.
   float temperature_ = -1.0f;
+
+  // Token predicted by the last prefill() call, consumed by generate("").
+  std::optional<uint64_t> prefill_next_token_;
 
   // The position in KV cache of the input, starting from 0.
   int64_t pos_ = 0;

--- a/extension/llm/runner/text_llm_runner.h
+++ b/extension/llm/runner/text_llm_runner.h
@@ -119,10 +119,8 @@ class ET_EXPERIMENTAL TextLLMRunner : public IRunner {
   /**
    * Convenience overload: prefill a single text prompt.
    */
-  ::executorch::runtime::Result<uint64_t> prefill(
-      const std::string& prompt,
-      int32_t num_bos = 0,
-      int32_t num_eos = 0);
+  ::executorch::runtime::Result<uint64_t>
+  prefill(const std::string& prompt, int32_t num_bos = 0, int32_t num_eos = 0);
 
   /**
    * Prefill a text prompt using GenerationConfig.


### PR DESCRIPTION
## Summary

Make `MultimodalRunner` inherit from `IRunner` so callers can hold a single `IRunner*` regardless of model type. Add `prefill(vector<MultimodalInput>, num_bos, num_eos)` to `IRunner` returning `Result<uint64_t>` (the predicted next token), with a default `NotSupported` implementation.

Resolves https://github.com/pytorch/executorch/issues/17728

## Changes

**`irunner.h`** — Forward-declare `MultimodalInput`. Add virtual `prefill(vector<MultimodalInput>)` returning `Result<uint64_t>` with default `NotSupported`.

**`multimodal_runner.h/cpp`** — `MultimodalRunner` now inherits `IRunner`. `generate(string)` override is a pure wrapper that delegates to `generate(vector)`. `generate(vector)` handles both non-empty inputs (prefill + decode) and empty inputs (consume `prefill_next_token_` from a prior `prefill()` call). Decode loop extracted into private `decode_from_token()` to avoid duplication. `is_loaded()` becomes `const override`, `stop()`/`reset()`/`load()` gain `override`. String convenience `prefill(string)` provided inline.

**`text_llm_runner.h/cpp`** — New `prefill(vector<MultimodalInput>)` override handles text inputs (encode + prefill KV cache), returns predicted next token. `generate("")` allowed after `prefill()` — consumes stored `prefill_next_token_`. Old `prefill(string, GenerationConfig)` preserved as deprecated wrapper. String convenience methods defined in .cpp to avoid header dependency on `multimodal_input.h`.

**`pybindings.cpp`** — Adapts to `Result<uint64_t>` return type from `prefill()`.

**`_llm_runner.pyi`** — Updated `MultimodalRunner.prefill` docstring.

## Design decisions

- `prefill()` returns `Result<uint64_t>` — the sampled next token from the final forward pass. This is stored internally in `prefill_next_token_` for the `prefill()` → `generate("")`/`generate({})` workflow, and also returned to callers who may want the token directly.
- `prefill()` takes `num_bos`/`num_eos` instead of `GenerationConfig` — those are the only fields relevant to prefill (for tokenizer encoding).
- BOS is only applied when `pos_ == 0` (start of conversation) in `MultimodalRunner`. `TextLLMRunner` trusts the caller's `num_bos` value.
- `generate(string)` is always a pure wrapper to `generate(vector)` in `MultimodalRunner` — empty string passes an empty vector, non-empty wraps as `MultimodalInput`.
- `text_llm_runner.h` avoids `#include multimodal_input.h` — only the forward declaration from `irunner.h` is needed in the header. String convenience methods are defined in the .cpp.

## Backward compatibility

- **C++ source-compatible**: `MultimodalRunner::prefill(inputs)` still compiles (new params have defaults). `TextLLMRunner::prefill(string, GenerationConfig)` preserved as deprecated wrapper. Return type changed from `Error` to `Result<uint64_t>` — callers checking `.error()` still work.
- **ABI-breaking**: Expected for `ET_EXPERIMENTAL` APIs.
- **Python**: Fully compatible, interface signatures unchanged.

## Test plan

- Existing C++ tests: `test_text_llm_runner.cpp`, `test_text_prefiller.cpp`, `test_generation_config.cpp` — verify no regressions
- Build: `cmake --build` for `extension_llm_runner` target
