### PR TITLE
Arm backend: Fix Direct Drive release build

### DIFF
--- a/tools/cmake/preset/arm_ethosu_linux.cmake
+++ b/tools/cmake/preset/arm_ethosu_linux.cmake
@@ -9,11 +9,15 @@ set_overridable_option(EXECUTORCH_BUILD_EXTENSION_EVALUE_UTIL ON)
 set_overridable_option(EXECUTORCH_BUILD_EXTENSION_RUNNER_UTIL ON)
 set_overridable_option(EXECUTORCH_BUILD_KERNELS_QUANTIZED ON)
 
+set(_arm_ethosu_linux_c_flags_release "${CMAKE_C_FLAGS_RELEASE} -UNDEBUG")
 set(CMAKE_C_FLAGS_RELEASE
-    "-UNDEBUG"
+    "${_arm_ethosu_linux_c_flags_release}"
     CACHE STRING "Avoid NDEBUG forward-decl mismatch in musl Release builds"
+          FORCE
 )
+set(_arm_ethosu_linux_cxx_flags_release "${CMAKE_CXX_FLAGS_RELEASE} -UNDEBUG")
 set(CMAKE_CXX_FLAGS_RELEASE
-    "-UNDEBUG"
+    "${_arm_ethosu_linux_cxx_flags_release}"
     CACHE STRING "Avoid NDEBUG forward-decl mismatch in musl Release builds"
+          FORCE
 )


### PR DESCRIPTION
This got mixed up when moving things into a preset cmake file and the -UNDEBUG that is needed to build Release never got set.

Signed-off-by: per.held@arm.com
Change-Id: I8022efa315c9f970a29b6d6bc4a9bee0be091f8b


cc @digantdesai @SS-JIA @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell