### PR TITLE
Fix _llm_runner.so RPATH for pip wheel installs

### DIFF
--- a/extension/llm/runner/CMakeLists.txt
+++ b/extension/llm/runner/CMakeLists.txt
@@ -123,11 +123,15 @@ if(EXECUTORCH_BUILD_PYBIND)
                CXX_STANDARD 20
   )
   if(APPLE)
-    set(RPATH "@loader_path/../../pybindings")
+    set(RPATH
+        "@loader_path/../../pybindings;@loader_path/../../../../torch/lib"
+    )
   else()
-    set(RPATH "$ORIGIN/../../pybindings")
+    set(RPATH "$ORIGIN/../../pybindings:$ORIGIN/../../../../torch/lib")
   endif()
-  set_target_properties(_llm_runner PROPERTIES INSTALL_RPATH ${RPATH})
+  set_target_properties(
+    _llm_runner PROPERTIES BUILD_RPATH "${RPATH}" INSTALL_RPATH "${RPATH}"
+  )
   # Add include directories
   target_include_directories(
     _llm_runner PRIVATE ${_common_include_directories} ${TORCH_INCLUDE_DIRS}

--- a/extension/llm/runner/__init__.py
+++ b/extension/llm/runner/__init__.py
@@ -11,6 +11,8 @@ This module provides a Python interface to the ExecuTorch multimodal LLM runner,
 enabling processing of mixed inputs (text, images, audio) and text generation.
 """
 
+import torch  # preload libtorch shared libs for _llm_runner
+
 try:
     # Import shared components from the compiled C++ extension
     from executorch.extension.llm.runner._llm_runner import (  # noqa: F401
@@ -35,7 +37,6 @@ except ImportError:
 import logging
 from typing import Callable, List, Optional, Union
 
-import torch
 from transformers.feature_extraction_utils import BatchFeature
 
 


### PR DESCRIPTION
Summary

  from executorch.extension.llm.runner import TextLLMRunner fails on pip wheel installs because _llm_runner.so cannot find _portable_lib.so or its transitive libtorch*.so dependencies at runtime.

  Root cause — two issues:

  1. Missing torch preload: __init__.py imported torch after _llm_runner, so libtorch*.so shared libs weren't loaded when the dynamic linker tried to resolve _llm_runner.so's dependencies. The existing
  portable_lib.py already solves this correctly by importing torch first.
  2. Incomplete RPATH + wrong RPATH property: The RPATH on _llm_runner.so only included ../../pybindings (to find _portable_lib.so) but was missing ../../../../torch/lib (to find libtorch*.so). More critically, only
   INSTALL_RPATH was set — but pip install never runs cmake --install; it copies .so files directly from the build directory, so only BUILD_RPATH takes effect. The portable_lib target already handles this correctly
  by setting both properties.

  Fixes:

  - extension/llm/runner/__init__.py: Move import torch before the _llm_runner import to preload libtorch shared libs.
  - extension/llm/runner/CMakeLists.txt: Add torch/lib to the RPATH, and set both BUILD_RPATH and INSTALL_RPATH so the paths are embedded regardless of whether the .so is copied from the build tree or installed via
  CMake.

  Test plan

  - Build from source with EXECUTORCH_BUILD_PYBIND=ON
  - Remove build directories (pip-out/, cmake-out/) to simulate a clean pip install environment
  - Verify RPATH with otool -l _llm_runner*.so | grep -A2 RPATH (macOS) — confirms @loader_path/../../pybindings and @loader_path/../../../../torch/lib are present
  - Verify from executorch.extension.llm.runner import TextLLMRunner succeeds