### PR TITLE
NXP backend: Add option to dump kernel selection for Neutron converter

### DIFF
--- a/backends/nxp/backend/neutron_converter_manager.py
+++ b/backends/nxp/backend/neutron_converter_manager.py
@@ -5,6 +5,7 @@
 
 import logging
 import multiprocessing
+import os
 
 try:
     from eiq_neutron_sdk import neutron_converter, neutron_library_utils
@@ -31,8 +32,19 @@ class NeutronConverterManager:
     contains NeutronGraph nodes.
     """
 
-    def __init__(self):
-        pass
+    def __init__(
+        self,
+        dump_kernel_selection_code: bool = False,
+    ):
+        self.dump_kernel_selection_code = dump_kernel_selection_code
+
+    @staticmethod
+    def _rename_partition_kernel_selection_file(delegation_tag):
+        try:
+            base_name = "_kernel_selection.c"
+            os.rename(base_name, f"_kernel_selection_{delegation_tag}.c")
+        except OSError:
+            logging.error("Failed to rename partition kernel selection file.")
 
     def get_converter(self):
         return neutron_converter
@@ -50,13 +62,18 @@ class NeutronConverterManager:
             )
 
     def convert(
-        self, tflite_model: bytes, target: str, fetch_constants_to_sram: bool = False
+        self,
+        tflite_model: bytes,
+        target: str,
+        delegation_tag: str,
+        fetch_constants_to_sram: bool = False,
     ) -> bytes:
         """
         Call Neutron Converter.
 
         :param tflite_model: A generic TFLite model to be converted.
         :param target: The target platform.
+        :param delegation_tag: The delegation tag of model partition.
         :param fetch_constants_to_sram: Add microcode that fetches weights from external memory.
         This allows running models which do not fit into SRAM. Applies to Neutron-C only (microcontrollers).
 
@@ -72,6 +89,7 @@ class NeutronConverterManager:
             "HoistSliceAboveTranspose,MergeTranspose"
         )
         cctx.compilationOpts.fetchConstantsToSRAM = fetch_constants_to_sram
+        cctx.compilationOpts.dumpKernelSelectionCode = self.dump_kernel_selection_code
 
         # Try to use multiprocessing for isolation, but fall back to direct execution
         # if the environment doesn't support it (e.g., in sandcastle/build environments)
@@ -101,5 +119,6 @@ class NeutronConverterManager:
                 f"Multiprocessing not available ({e}), running neutron converter directly"
             )
             model_converted = neutron_converter.convertModel(list(tflite_model), cctx)
+        self._rename_partition_kernel_selection_file(delegation_tag)
 
         return bytes(model_converted)

--- a/backends/nxp/nxp_backend.py
+++ b/backends/nxp/nxp_backend.py
@@ -46,6 +46,7 @@ class NeutronCompileSpecBuilder:
         self.operators_not_to_delegate: List[str] = []
         self.use_neutron_for_format_conversion = True
         self.fetch_constants_to_sram = False
+        self.dump_kernel_selection_code = False
 
     def _replace_colons(self, operator: str) -> str:
         """
@@ -60,6 +61,7 @@ class NeutronCompileSpecBuilder:
         operators_not_to_delegate: Optional[List[str]] = None,
         use_neutron_for_format_conversion: bool = True,
         fetch_constants_to_sram: bool = False,
+        dump_kernel_selection_code: bool = False,
     ):
         """
         Generate compile spec for Neutron NPU
@@ -73,6 +75,7 @@ class NeutronCompileSpecBuilder:
                                                 delegated to Neutron.
             fetch_constants_to_sram: If True, the Neutron Converter will insert microinstructions to prefetch weights
                                      from FLASH to SRAM. This should be used when the whole model does not fit into SRAM.
+            dump_kernel_selection_code: Whether Neutron converter dumps kernel selection code.
         """
 
         self.config = NeutronTargetSpec(config)
@@ -92,8 +95,8 @@ class NeutronCompileSpecBuilder:
             ]
 
         self.use_neutron_for_format_conversion = use_neutron_for_format_conversion
-
         self.fetch_constants_to_sram = fetch_constants_to_sram
+        self.dump_kernel_selection_code = dump_kernel_selection_code
 
         return self
 
@@ -118,6 +121,10 @@ class NeutronCompileSpecBuilder:
                     "fetch_constants_to_sram",
                     f"{self.fetch_constants_to_sram}".encode(),
                 ),
+                CompileSpec(
+                    "dump_kernel_selection_code",
+                    f"{self.dump_kernel_selection_code}".encode(),
+                ),
             ]
 
         return self.compile_spec
@@ -130,6 +137,7 @@ def generate_neutron_compile_spec(
     operators_not_to_delegate: Optional[List[str]] = None,
     use_neutron_for_format_conversion: bool = True,
     fetch_constants_to_sram: bool = False,
+    dump_kernel_selection_code: bool = False,
 ) -> List[CompileSpec]:
     return (
         NeutronCompileSpecBuilder()
@@ -139,6 +147,7 @@ def generate_neutron_compile_spec(
             operators_not_to_delegate=operators_not_to_delegate,
             use_neutron_for_format_conversion=use_neutron_for_format_conversion,
             fetch_constants_to_sram=fetch_constants_to_sram,
+            dump_kernel_selection_code=dump_kernel_selection_code,
         )
         .build()
     )
@@ -162,6 +171,7 @@ class NeutronBackend(BackendDetails):
         target = ""
         use_neutron_for_format_conversion = None
         fetch_constants_to_sram = False
+        dump_kernel_selection_code = None
         for spec in compile_spec:
             if spec.key == "output_format":
                 output_format = spec.value.decode()
@@ -173,6 +183,8 @@ class NeutronBackend(BackendDetails):
                 use_neutron_for_format_conversion = spec.value.decode() == "True"
             if spec.key == "fetch_constants_to_sram":
                 fetch_constants_to_sram = spec.value.decode() == "True"
+            if spec.key == "dump_kernel_selection_code":
+                dump_kernel_selection_code = spec.value.decode() == "True"
 
         # Check that the output format is set in the compile spec
         if not output_format:
@@ -201,6 +213,14 @@ class NeutronBackend(BackendDetails):
                 edge_program, [RemoveGetItemPass]
             ).transform()
 
+            # Some of the nodes do not have delegation_tag, find any node with delegation tag.
+            delegation_tag = None
+            for n in edge_program.graph.nodes:
+                if "delegation_tag" in n.meta.keys():
+                    delegation_tag = n.meta["delegation_tag"]
+                    break
+            assert delegation_tag is not None
+
             # Convert the edge program to TFLite.
             conversion_config = ConversionConfig(
                 {"use_neutron_for_format_conversion": use_neutron_for_format_conversion}
@@ -213,21 +233,13 @@ class NeutronBackend(BackendDetails):
                 conversion_config=conversion_config,
             )
 
-            neutron_model = NeutronConverterManager().convert(
-                tflite_model, target, fetch_constants_to_sram
+            neutron_model = NeutronConverterManager(dump_kernel_selection_code).convert(
+                tflite_model, target, delegation_tag, fetch_constants_to_sram
             )
 
             # Dump the tflite file if logging level is enabled
             if logging.root.isEnabledFor(logging.DEBUG):
                 import os
-
-                # Some of the nodes do not have delegation_tag, find any node with delegation tag.
-                delegation_tag = None
-                for n in list(edge_program.graph.nodes):
-                    if "delegation_tag" in n.meta.keys():
-                        delegation_tag = n.meta["delegation_tag"]
-                        break
-                assert delegation_tag is not None
 
                 logging.debug(
                     f"Serializing converted graph with tag {delegation_tag} to {os.getcwd()}"

--- a/backends/nxp/requirements-eiq.txt
+++ b/backends/nxp/requirements-eiq.txt
@@ -1,3 +1,3 @@
 --index-url https://eiq.nxp.com/repository
-eiq-neutron-sdk==2.2.2
+eiq-neutron-sdk==3.0.0
 eiq_nsys

--- a/backends/nxp/tests/executorch_pipeline.py
+++ b/backends/nxp/tests/executorch_pipeline.py
@@ -3,10 +3,14 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import logging
+import os
+import re
 from dataclasses import dataclass
 from functools import partial
 from typing import Callable
 
+import eiq_neutron_sdk
 import torch
 
 from executorch import exir
@@ -45,6 +49,31 @@ neutron_target_spec = NeutronTargetSpec(target="imxrt700")
 class ModelInputSpec:
     shape: tuple[int, ...]
     dtype: torch.dtype = torch.float32
+
+
+def handle_kernel_selection(model_name: str = ""):
+    # Collect all kernel selection files in the current working directory
+    kernel_selection_files = [
+        fname
+        for fname in os.listdir(".")
+        if re.search("_kernel_selection.*\\.c$", fname)
+    ]
+
+    if not kernel_selection_files:
+        raise RuntimeError(
+            "No kernel_selection files found in the current directory."
+        )  # Should never happen.
+
+    output_mask = model_name + "_kernel_selection.c"
+    eiq_neutron_sdk.merge_kernel_selection_files(kernel_selection_files, output_mask)
+
+    if not logging.root.isEnabledFor(logging.DEBUG):
+        for fname in kernel_selection_files:
+            os.remove(fname)
+    else:
+        logging.debug(
+            f"Debug mode enabled, keeping intermediate kernel_selection.c files: {kernel_selection_files}"
+        )
 
 
 def get_random_calibration_inputs(
@@ -88,14 +117,15 @@ def to_quantized_edge_program(
     get_calibration_inputs_fn: Callable[
         [tuple[ModelInputSpec, ...]], list[tuple[torch.Tensor, ...]]
     ] = get_random_calibration_inputs,
-    target="imxrt700",
-    use_qat=False,
-    remove_quant_io_ops=False,
-    custom_delegation_options=CustomDelegationOptions(),  # noqa B008
-    get_quantizer_fn=None,
-    use_neutron_for_format_conversion=True,
-    use_quant_state_dict=True,
-    fetch_constants_to_sram=False,
+    target: str = "imxrt700",
+    use_qat: bool = False,
+    remove_quant_io_ops: bool = False,
+    custom_delegation_options: CustomDelegationOptions = CustomDelegationOptions(),  # noqa B008
+    get_quantizer_fn: Callable[[], Quantizer] | None = None,
+    use_neutron_for_format_conversion: bool = True,
+    use_quant_state_dict: bool = True,
+    fetch_constants_to_sram: bool = False,
+    dump_kernel_selection_code: bool = False,
 ) -> EdgeProgramManager:
     _neutron_target_spec = NeutronTargetSpec(target)
     if get_quantizer_fn is None:
@@ -125,6 +155,7 @@ def to_quantized_edge_program(
         operators_not_to_delegate=operators_not_to_delegate,
         use_neutron_for_format_conversion=use_neutron_for_format_conversion,
         fetch_constants_to_sram=fetch_constants_to_sram,
+        dump_kernel_selection_code=dump_kernel_selection_code,
     )
     post_quant_state_dict = (
         exir_program_aten__module_quant.state_dict() if use_quant_state_dict else None
@@ -156,6 +187,9 @@ def to_quantized_edge_program(
     edge_program_manager = edge_program_manager.transform(
         NeutronEdgePassManager([RemoveAdditionalQDQClustersPass()])
     )
+
+    if dump_kernel_selection_code:
+        handle_kernel_selection()
 
     return edge_program_manager
 

--- a/backends/nxp/tests/test_context_sensitive_delegation.py
+++ b/backends/nxp/tests/test_context_sensitive_delegation.py
@@ -172,7 +172,7 @@ def test_noop_partitions__add_mul_sub_div__forced_delegation():
 
     with pytest.raises(
         RuntimeError,
-        match="Model converted with neutron-converter does not contain a NeutronGraph node.",
+        match="Model converted with neutron-converter has `2` operators instead of `1`.",
     ):
         to_quantized_edge_program(
             module, input_shape, custom_delegation_options=cdo

--- a/backends/nxp/tests/test_kernel_selection.py
+++ b/backends/nxp/tests/test_kernel_selection.py
@@ -1,0 +1,80 @@
+# Copyright 2026 NXP
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+
+import eiq_neutron_sdk
+import numpy as np
+import pytest
+import torch
+
+from executorch.backends.nxp.tests.executorch_pipeline import to_quantized_edge_program
+from executorch.backends.nxp.tests.models import (
+    AdaptiveAvgPool2dConvModule,
+    Conv2dReLUMaxPoolModule,
+)
+
+
+@pytest.fixture(autouse=True)
+def reseed_model_per_test_run():
+    torch.manual_seed(23)
+    np.random.seed(23)
+
+
+def test_neutron_converter_kernel_selection():
+    input_shape = (1, 4, 16, 16)
+    model = AdaptiveAvgPool2dConvModule((4, 4))
+
+    # Run conversion
+    _ = to_quantized_edge_program(
+        model,
+        input_shape,
+        dump_kernel_selection_code=True,
+    ).exported_program()
+
+    # Check for the created kernel selection file
+    kernel_selection_file = [
+        fname for fname in os.listdir(".") if fname.endswith("_kernel_selection.c")
+    ]
+    assert len(kernel_selection_file) == 1
+    assert os.path.isfile(kernel_selection_file[0])
+
+    # Check file contains key symbols
+    with open(kernel_selection_file[0]) as f:
+        content = f.read()
+    assert "typedef enum NeutronKernelKind" in content
+    assert "int32_t (*neutronKernels[" in content
+
+
+def test_neutron_converter_kernel_selection_multiple_partitions(mocker):
+    input_shape = (1, 3, 64, 64)
+    model = Conv2dReLUMaxPoolModule()
+
+    kernel_selection_spy = mocker.spy(eiq_neutron_sdk, "merge_kernel_selection_files")
+
+    # Run conversion
+    _ = to_quantized_edge_program(
+        model,
+        input_shape,
+        dump_kernel_selection_code=True,
+        operators_not_to_delegate=["aten_relu_default"],
+    ).exported_program()
+
+    # Get the kernel selection files generated for the Neutron partitions.
+    kernel_selection_files = kernel_selection_spy.call_args.args[0]
+    assert len(kernel_selection_files) == 2  # Expect 2 files for 2 partitions.
+
+    # Check that only 1 final kernel selection file was stored.
+    stored_kernel_selection_files = [
+        fname for fname in os.listdir(".") if fname.endswith("_kernel_selection.c")
+    ]
+    assert len(stored_kernel_selection_files) == 1
+    assert os.path.isfile(stored_kernel_selection_files[0])
+
+    # Check file contains key symbols.
+    with open(stored_kernel_selection_files[0]) as f:
+        content = f.read()
+    assert "typedef enum NeutronKernelKind" in content
+    assert "int32_t (*neutronKernels[" in content

--- a/docs/source/backends/nxp/nxp-kernel-selection.md
+++ b/docs/source/backends/nxp/nxp-kernel-selection.md
@@ -1,0 +1,61 @@
+# NXP eIQ Neutron Kernel Selective Kernel Registration
+
+The NXP ExecuTorch backend supports selective Neutron kernel registration for `Neutron-C` targets, which decreases the
+size of the Neutron Firmware. During the backend's conversion to the Neutron representation by the Neutron Converter,
+microcode for the Neutron accelerator is generated.
+The microcode consists of kernel calls executed by the Neutron Driver. The code for kernel call functions is
+distributed in Neutron Firmware. 
+
+The `eiq_neutron_sdk.neutron_converter` optionally generates the `*_kernel_selection.c` file, registering 
+only kernels that are required for a particular model or in the case of ExecuTorch, a delegated subgraph. This 
+`*_kernel_selection.c`, when used during the application linking, takes precedence over the default list of registered 
+kernels in the Neutron Firmware, and allows the linker to include only the necessary Neutron kernels.
+This software is required for deployment on an edge device (e.g. `i.MXRT700`) and is
+distributed via the MCUXpresso SDK. The MCUXpresso SDK enables building of a final application that is then flashed on 
+the edge device. For more details about this process, see
+[eIQ ExecuTorch Library User Guide](https://mcuxpresso.nxp.com/mcuxsdk/latest/html/middleware/eiq/executorch/docs/nxp/ugindex.html).
+
+By default, for Neutron-C targets like `i.MXRT700`, all kernel implementations are present in the Neutron Firmware, which
+is linked to the final application. This enables an easy build process for any model, but increases the size of the
+final application with unused code. In the case of limited RAM, you can link only kernels that are used in the set of
+models deployed. This way you can reduce the size of the final app by linking only selected kernels, used in one or
+multiple models.
+
+The feature works as follows: The Neutron Converter with the appropriate flag exports a kernel selection file for each 
+converted subgraph, the kernel selection files are then merged and ready to be included in the MCUXpresso SDK to use for
+a selection-only build.
+
+> **Note:** This feature applies only to `Neutron-C` targets. `Neutron-S` has a different implementation and links only
+> kernel calls included in the model's microcode by default.
+
+## Export kernel selection file
+
+To turn on this feature on the side of NXP ExecuTorch backend, use the parameter `--dump_kernel_selection_code` in 
+`aot_neutron_compile.py`. An example with the CifarNet model:
+
+```commandline
+python -m examples.nxp.aot_neutron_compile --quantize \
+    --delegate -m cifar10 \
+    --dump_kernel_selection_code
+```
+
+This command will create a `*_kernel_selection.c` file alongside the converted PTE file in the working directory.
+
+## Kernel Registration for Multiple Models
+
+If you want to use or experiment with multiple models in one application while having reduced kernel set, you can
+create one kernel selection file with the script `merge_kernel_selection_code.py`:
+
+```commandline
+python -m eiq_neutron_sdk.neutron_library_utils.merge_kernel_selection_code \
+    -input-files model1_kernel_selection.c model2_kernel_selection.c [modelX_kernel_selection.c ...] \ 
+    -output-file merged_kernel_selection.c
+```
+
+Each particular model must be converted by the same Neutron converter version, so the `*_kernel_selection.c` files
+share the same version.
+
+## MCUXpresso SDK build with kernel selection
+
+Copy your model PTE file and kernel selection file into the MCUXpresso SDK and follow its 
+[documentation](https://mcuxpresso.nxp.com/mcuxsdk/latest/html/middleware/eiq/executorch/docs/nxp/ugindex.html).

--- a/docs/source/backends/nxp/nxp-overview.md
+++ b/docs/source/backends/nxp/nxp-overview.md
@@ -11,7 +11,7 @@ For up-to-date status about running ExecuTorch on Neutron backend please visit t
 ## Features
 
 
-ExecuTorch v1.0 supports running machine learning models on selected NXP chips (for now only i.MXRT700).
+ExecuTorch v1.0 supports running machine learning models on selected NXP chips (for now only `i.MXRT700`).
 Among currently supported machine learning models are:
 - Convolution-based neutral networks
 - Full support for MobileNetV2 and CifarNet
@@ -59,6 +59,8 @@ For more finegrained tutorial, visit [this manual page](https://mcuxpresso.nxp.c
 
 **→{doc}`nxp-dim-order` — Dim order support (channels last inputs).**
 
+**→{doc}`nxp-kernel-selection` — Neutron Firmware Kernel Selection support.**
+
 ```{toctree}
 :maxdepth: 2
 :hidden:
@@ -68,4 +70,5 @@ nxp-partitioner
 nxp-quantization
 tutorials/nxp-tutorials
 nxp-dim-order
+nxp-kernel-selection
 ```

--- a/examples/nxp/aot_neutron_compile.py
+++ b/examples/nxp/aot_neutron_compile.py
@@ -211,8 +211,17 @@ if __name__ == "__main__":  # noqa C901
         required=False,
         default=False,
         action="store_true",
-        help="The model (including the Neutron backend) will use the channels last dim order, which can result in faster "
-        "inference. The inputs must also be provided in the channels last dim order.",
+        help="The model (including the Neutron backend) will use the channels last dim order, which can result in "
+        "faster inference. The inputs must also be provided in the channels last dim order.",
+    )
+    parser.add_argument(
+        "--dump_kernel_selection_code",
+        required=False,
+        default=False,
+        action="store_true",
+        help="During conversion to Neutron microcode by Neutron Converter, a kernel selection file will be dumped in "
+        "the working directory. This file can be used for reduction of Neutron Firmware size in the built app."
+        "See `docs/source/backends/nxp/nxp-kernel-selection.md` for details.",
     )
     parser.add_argument(
         "--use_random_dataset",
@@ -310,6 +319,7 @@ if __name__ == "__main__":  # noqa C901
         args.target,
         operators_not_to_delegate=args.operators_not_to_delegate,
         fetch_constants_to_sram=args.fetch_constants_to_sram,
+        dump_kernel_selection_code=args.dump_kernel_selection_code,
     )
     partitioners = (
         [

--- a/examples/nxp/setup.sh
+++ b/examples/nxp/setup.sh
@@ -8,7 +8,7 @@ set -u
 EIQ_PYPI_URL="${EIQ_PYPI_URL:-https://eiq.nxp.com/repository}"
 
 # Install eIQ Neutron dependencies - SDK and simulator
-pip install --index-url ${EIQ_PYPI_URL} eiq-neutron-sdk==2.2.2 eiq_nsys
+pip install --index-url ${EIQ_PYPI_URL} eiq-neutron-sdk==3.0.0 eiq_nsys
 
 # Get the directory of the current script
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
### Summary
Adds option to dump kernel selection for Neutron converter. This kernel selection file can be used for selective build of Neutron Firmware, allowing to decrease app size on MCUs with limited RAM. Docs provided.

### Test plan
Unit-tests provided.


cc @robert-kalmar @JakeStevens @digantdesai