### PR TITLE
Set warnings_as_errors to false on remaining unset targets

### DIFF
--- a/extension/android/BUCK
+++ b/extension/android/BUCK
@@ -5,6 +5,7 @@ oncall("executorch")
 
 non_fbcode_target(_kind = fb_android_library,
     name = "executorch",
+    warnings_as_errors = False,
     required_for_source_only_abi = True,
     srcs = [
         "executorch_android/src/main/java/org/pytorch/executorch/DType.java",
@@ -28,6 +29,7 @@ non_fbcode_target(_kind = fb_android_library,
 
 non_fbcode_target(_kind = fb_android_library,
     name = "executorch_training",
+    warnings_as_errors = False,
     srcs = [
         "executorch_android/src/main/java/org/pytorch/executorch/training/SGD.java",
         "executorch_android/src/main/java/org/pytorch/executorch/training/TrainingModule.java",
@@ -43,6 +45,7 @@ non_fbcode_target(_kind = fb_android_library,
 
 non_fbcode_target(_kind = fb_android_library,
     name = "executorch_llama",
+    warnings_as_errors = False,
     srcs = [
         "executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmCallback.java",
         "executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmGenerationConfig.java",


### PR DESCRIPTION
Summary: This sets warnings_as_errors to False on the remaining targets that have it unset. Since False is the default this is an effective no-op.

Differential Revision: D94846286


