### PR TITLE
[ET-VK][ez] Use tree reduction in q8ta_linear_gemv shader

### DIFF
--- a/backends/vulkan/runtime/graph/ops/glsl/q8ta_linear_gemv.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/q8ta_linear_gemv.glsl
@@ -66,7 +66,12 @@ layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
 #include "linear_int_weight_sums_load.glslh"
 #include "linear_fp_bias_load.glslh"
 
-shared Int32Accum partial_accums[WGS];
+// Array-of-arrays shared memory layout: partial_accums[lid][tile_n4].
+// Each element is exactly 16 bytes (ivec4). This avoids the Samsung S25
+// (Adreno 830) driver bug triggered by the original Int32Accum struct layout,
+// where barrier() only invalidated the first 16-byte component of each
+// 32-byte struct slot, leaving subsequent components stale.
+shared ivec4 partial_accums[WGS][TILE_N4];
 
 void main() {
   const int lid = int(gl_LocalInvocationID.z);
@@ -104,18 +109,28 @@ void main() {
     }
   }
 
-  partial_accums[lid] = out_accum;
+  [[unroll]] for (int tile_n4 = 0; tile_n4 < TILE_N4; ++tile_n4) {
+    partial_accums[lid][tile_n4] = out_accum.data[0][tile_n4];
+  }
 
   memoryBarrierShared();
   barrier();
 
+  // Tree reduction: O(log2(WGS)).
+  for (int i = WGS / 2; i > 0; i /= 2) {
+    if (lid < i) {
+      [[unroll]] for (int tile_n4 = 0; tile_n4 < TILE_N4; ++tile_n4) {
+        partial_accums[lid][tile_n4] += partial_accums[lid + i][tile_n4];
+      }
+    }
+    memoryBarrierShared();
+    barrier();
+  }
+
   // Only the first thread writes the result
   if (lid == 0) {
-    for (int i = 1; i < WGS; ++i) {
-      [[unroll]] for (int tile_n4 = 0; tile_n4 < TILE_N4; ++tile_n4) {
-        out_accum.data[0][tile_n4] +=
-            partial_accums[i].data[0][tile_n4];
-      }
+    [[unroll]] for (int tile_n4 = 0; tile_n4 < TILE_N4; ++tile_n4) {
+      out_accum.data[0][tile_n4] = partial_accums[0][tile_n4];
     }
 
     FPPerOutChannelParams weight_scales_tile;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #17795
* #17794
* #17793
* __->__ #17792

Replace the serial O(WGS) reduction loop with a tree reduction pattern
(O(log2(WGS))). Previously, only thread 0 summed all 64 partial
accumulators sequentially. Now all threads participate in a classic
halving reduction, matching the pattern already used in
linear_q4gsw_coop.glsl.

Authored by Claude.

Differential Revision: [D94949137](https://our.internmc.facebook.com/intern/diff/D94949137/)