### PR TITLE
[ET-VK][testing] Add GPU device name override for on-device model tests

### DIFF
--- a/backends/vulkan/runtime/vk_api/Adapter.cpp
+++ b/backends/vulkan/runtime/vk_api/Adapter.cpp
@@ -375,6 +375,10 @@ void Adapter::submit_cmd(
   VK_CHECK(vkQueueSubmit(device_queue.handle, 1u, &submit_info, fence));
 }
 
+void Adapter::override_device_name(const std::string& new_name) {
+  physical_device_.override_device_name(new_name);
+}
+
 std::string Adapter::stringize() const {
   std::stringstream ss;
 

--- a/backends/vulkan/runtime/vk_api/Adapter.h
+++ b/backends/vulkan/runtime/vk_api/Adapter.h
@@ -306,6 +306,8 @@ class Adapter final {
       VkSemaphore wait_semaphore = VK_NULL_HANDLE,
       VkSemaphore signal_semaphore = VK_NULL_HANDLE);
 
+  void override_device_name(const std::string& new_name);
+
   std::string stringize() const;
   friend std::ostream& operator<<(std::ostream&, const Adapter&);
 };

--- a/backends/vulkan/runtime/vk_api/Device.cpp
+++ b/backends/vulkan/runtime/vk_api/Device.cpp
@@ -21,6 +21,25 @@
 namespace vkcompute {
 namespace vkapi {
 
+namespace {
+
+DeviceType determine_device_type(const std::string& device_name) {
+  if (device_name.find("adreno") != std::string::npos) {
+    return DeviceType::ADRENO;
+  } else if (device_name.find("swiftshader") != std::string::npos) {
+    return DeviceType::SWIFTSHADER;
+  } else if (device_name.find("nvidia") != std::string::npos) {
+    return DeviceType::NVIDIA;
+  } else if (
+      device_name.find("mali") != std::string::npos ||
+      device_name.find("immortalis") != std::string::npos) {
+    return DeviceType::MALI;
+  }
+  return DeviceType::UNKNOWN;
+}
+
+} // namespace
+
 PhysicalDevice::PhysicalDevice(
     VkInstance instance_handle,
     VkPhysicalDevice physical_device_handle)
@@ -126,17 +145,7 @@ PhysicalDevice::PhysicalDevice(
       device_name.begin(),
       [](unsigned char c) { return std::tolower(c); });
 
-  if (device_name.find("adreno") != std::string::npos) {
-    device_type = DeviceType::ADRENO;
-  } else if (device_name.find("swiftshader") != std::string::npos) {
-    device_type = DeviceType::SWIFTSHADER;
-  } else if (device_name.find("nvidia") != std::string::npos) {
-    device_type = DeviceType::NVIDIA;
-  } else if (
-      device_name.find("mali") != std::string::npos ||
-      device_name.find("immortalis") != std::string::npos) {
-    device_type = DeviceType::MALI;
-  }
+  device_type = determine_device_type(device_name);
 }
 
 void PhysicalDevice::query_extensions_vk_1_0() {
@@ -290,6 +299,17 @@ void PhysicalDevice::query_extensions_vk_1_1() {
 #endif /* VK_KHR_shader_integer_dot_product */
 
   vkGetPhysicalDeviceProperties2(handle, &properties2);
+}
+
+void PhysicalDevice::override_device_name(const std::string& new_name) {
+  device_name = new_name;
+  std::transform(
+      device_name.begin(),
+      device_name.end(),
+      device_name.begin(),
+      [](unsigned char c) { return std::tolower(c); });
+
+  device_type = determine_device_type(device_name);
 }
 
 //

--- a/backends/vulkan/runtime/vk_api/Device.h
+++ b/backends/vulkan/runtime/vk_api/Device.h
@@ -84,6 +84,9 @@ struct PhysicalDevice final {
  private:
   void query_extensions_vk_1_0();
   void query_extensions_vk_1_1();
+
+ public:
+  void override_device_name(const std::string& new_name);
 };
 
 struct DeviceHandle final {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #17795
* #17794
* #17793
* #17792

Add the ability to override the Vulkan device name at runtime so that
device-adaptive code paths (e.g. memory layout selection) can be tested
on hardware that doesn't match the overridden device type.

PhysicalDevice::override_device_name() and Adapter::override_device_name()
are added behind VULKAN_DEBUG. The device type detection logic is refactored
into a reusable determine_device_type() helper to avoid duplication between
the constructor and the override function.

All test binaries in fb/test/models/ (classification, greenscreen, scenex,
skin_seg) now accept --gpu_name to invoke the override before loading the
model. The Skycastle CI workflows are updated to re-run classification and
greenscreen tests with --gpu_name Mali-G715 in addition to the default run.

Differential Revision: [D94949136](https://our.internmc.facebook.com/intern/diff/D94949136/)