### PR TITLE
Initialize Qwen3.5 mutable buffers during export

### DIFF
--- a/examples/models/llama/export_llama_lib.py
+++ b/examples/models/llama/export_llama_lib.py
@@ -137,6 +137,27 @@ HUGGING_FACE_REPO_IDS = {
 }
 
 
+def _get_additional_export_passes(model_class: str) -> List[InitializedMutableBufferPass]:
+    patterns = []
+
+    if model_class in TORCHTUNE_DEFINED_MODELS:
+        patterns.append("kv_cache_pos")
+
+    # Qwen3.5 uses internal mutable buffers for both the hybrid KV path and
+    # DeltaNet recurrent/conv states.
+    if model_class.startswith("qwen3_5"):
+        patterns.extend(
+            [
+                "k_cache",
+                "v_cache",
+                "conv_state",
+                "recurrent_state",
+            ]
+        )
+
+    return [InitializedMutableBufferPass(patterns)] if patterns else []
+
+
 def set_pkg_name(name: str) -> None:
     global pkg_name
     pkg_name = name
@@ -1285,9 +1306,9 @@ def _export_llama_multimethod(llm_config: LlmConfig) -> LLMEdgeManager:
         "Each method requires separate model instantiation and export."
     )
 
-    additional_passes = []
-    if llm_config.base.model_class.value in TORCHTUNE_DEFINED_MODELS:
-        additional_passes = [InitializedMutableBufferPass(["kv_cache_pos"])]
+    additional_passes = _get_additional_export_passes(
+        llm_config.base.model_class.value
+    )
 
     # Build dict of exported programs
     method_to_program: Dict[str, ExportedProgram] = {}
@@ -1358,9 +1379,9 @@ def _export_llama(llm_config: LlmConfig) -> LLMEdgeManager:  # noqa: C901
         llm_config
     )
 
-    additional_passes = []
-    if llm_config.base.model_class.value in TORCHTUNE_DEFINED_MODELS:
-        additional_passes = [InitializedMutableBufferPass(["kv_cache_pos"])]
+    additional_passes = _get_additional_export_passes(
+        llm_config.base.model_class.value
+    )
 
     # export_to_edge
     builder_manager = _prepare_for_llama_export(llm_config)

--- a/examples/models/llama/export_llama_lib.py
+++ b/examples/models/llama/export_llama_lib.py
@@ -137,7 +137,9 @@ HUGGING_FACE_REPO_IDS = {
 }
 
 
-def _get_additional_export_passes(model_class: str) -> List[InitializedMutableBufferPass]:
+def _get_additional_export_passes(
+    model_class: str,
+) -> List[InitializedMutableBufferPass]:
     patterns = []
 
     if model_class in TORCHTUNE_DEFINED_MODELS:
@@ -1306,9 +1308,7 @@ def _export_llama_multimethod(llm_config: LlmConfig) -> LLMEdgeManager:
         "Each method requires separate model instantiation and export."
     )
 
-    additional_passes = _get_additional_export_passes(
-        llm_config.base.model_class.value
-    )
+    additional_passes = _get_additional_export_passes(llm_config.base.model_class.value)
 
     # Build dict of exported programs
     method_to_program: Dict[str, ExportedProgram] = {}
@@ -1379,9 +1379,7 @@ def _export_llama(llm_config: LlmConfig) -> LLMEdgeManager:  # noqa: C901
         llm_config
     )
 
-    additional_passes = _get_additional_export_passes(
-        llm_config.base.model_class.value
-    )
+    additional_passes = _get_additional_export_passes(llm_config.base.model_class.value)
 
     # export_to_edge
     builder_manager = _prepare_for_llama_export(llm_config)

--- a/examples/models/llama/tests/test_export_llama_lib.py
+++ b/examples/models/llama/tests/test_export_llama_lib.py
@@ -24,10 +24,12 @@ except ImportError:
     VgfQuantizer = None
 
 from executorch.examples.models.llama.export_llama_lib import (
+    _get_additional_export_passes,
     _export_llama,
     build_args_parser,
     get_quantizer_and_quant_params,
 )
+from executorch.exir.passes.init_mutable_pass import InitializedMutableBufferPass
 from executorch.extension.llm.export.config.llm_config import LlmConfig, Pt2eQuantize
 
 UNWANTED_OPS = [
@@ -37,6 +39,24 @@ UNWANTED_OPS = [
 
 
 class ExportLlamaLibTest(unittest.TestCase):
+    def test_qwen3_5_mutable_buffer_passes(self):
+        passes = _get_additional_export_passes("qwen3_5_0_8b")
+        self.assertEqual(len(passes), 1)
+        self.assertIsInstance(passes[0], InitializedMutableBufferPass)
+        self.assertEqual(
+            passes[0].patterns,
+            ["k_cache", "v_cache", "conv_state", "recurrent_state"],
+        )
+
+    def test_torchtune_mutable_buffer_passes(self):
+        passes = _get_additional_export_passes("llama3_2_vision")
+        self.assertEqual(len(passes), 1)
+        self.assertIsInstance(passes[0], InitializedMutableBufferPass)
+        self.assertEqual(passes[0].patterns, ["kv_cache_pos"])
+
+    def test_llama3_has_no_extra_mutable_buffer_passes(self):
+        self.assertEqual(_get_additional_export_passes("llama3"), [])
+
     def test_has_expected_ops_and_op_counts(self):
         """
         Checks the presence of unwanted expensive ops.

--- a/examples/models/llama/tests/test_export_llama_lib.py
+++ b/examples/models/llama/tests/test_export_llama_lib.py
@@ -24,8 +24,8 @@ except ImportError:
     VgfQuantizer = None
 
 from executorch.examples.models.llama.export_llama_lib import (
-    _get_additional_export_passes,
     _export_llama,
+    _get_additional_export_passes,
     build_args_parser,
     get_quantizer_and_quant_params,
 )


### PR DESCRIPTION
## Summary
- factor mutable-buffer pass selection into _get_additional_export_passes
- keep existing torchtune behavior (kv_cache_pos)
- add Qwen3.5 buffer initialization patterns for export: k_cache, v_cache, conv_state, recurrent_state
- wire this helper into both single-method and multimethod export paths
- add unit tests covering pass selection for Qwen3.5, torchtune, and llama3 baseline

## Why
Qwen3.5 uses internal mutable state (KV + DeltaNet recurrent/conv buffers). Initializing these buffers at export time avoids uninitialized mutable-buffer state and makes startup behavior deterministic.

## Test Plan
- PYTHONPATH=src:/Users/sriram/Documents/executorch/third-party/ao:/tmp/qwen35_test/pytok pytest -q examples/models/llama/tests/test_export_llama_lib.py -k "qwen3_5_mutable_buffer_passes or torchtune_mutable_buffer_passes or llama3_has_no_extra_mutable_buffer_passes"
- PYTHONPATH=src:/Users/sriram/Documents/executorch/third-party/ao:/tmp/qwen35_test/pytok pytest -q examples/models/llama/tests/test_qwen3_5_attention.py examples/models/qwen3_5/tests/test_convert_weights.py

## Stacking
- Depends on #17800. Please review commit b4754f20ba for PR2-specific changes.


cc @larryliu0820 @mergennachin @cccclai @helunwencser @jackzhxng