### PR TITLE
Arm backend: Remove workaround to build TOSA serializer

### DIFF
--- a/.ci/scripts/unittest-linux-cmake.sh
+++ b/.ci/scripts/unittest-linux-cmake.sh
@@ -14,13 +14,10 @@ if ! python -c "import tosa_serializer" >/dev/null 2>&1; then
   TOSA_SERIALIZATION_DIR="./examples/arm/arm-scratch/tosa-tools/serialization"
   if [[ ! -d "${TOSA_SERIALIZATION_DIR}" ]]; then
     TOSA_TOOLS_DIR="$(mktemp -d /tmp/tosa-tools.XXXXXX)"
-    git clone --depth 1 --branch v2025.11.0 \
+    git clone --depth 1 --branch v2025.11.2 \
       https://git.gitlab.arm.com/tosa/tosa-tools.git "${TOSA_TOOLS_DIR}"
     TOSA_SERIALIZATION_DIR="${TOSA_TOOLS_DIR}/serialization"
   fi
-
-  # Workaround to allow TOSA serializer to build for v2025.11.0
-  python -m pip install pybind11==2.10.4
 
   CMAKE_POLICY_VERSION_MINIMUM=3.5 BUILD_PYBIND=1 \
     python -m pip install --no-dependencies \

--- a/backends/arm/requirements-arm-tosa.txt
+++ b/backends/arm/requirements-arm-tosa.txt
@@ -7,4 +7,3 @@ ml_dtypes == 0.5.1
 flatbuffers == 24.3.25
 tosa-adapter-model-explorer == 0.1.0
 ai-edge-model-explorer >= 0.1.16
-pybind11 == 2.10.4

--- a/examples/arm/setup.sh
+++ b/examples/arm/setup.sh
@@ -335,7 +335,7 @@ if [[ $is_script_sourced -eq 0 ]]; then
     fi
 
     pushd tosa-tools
-    git checkout v2025.11.0
+    git checkout v2025.11.2
 
     if [[ ! -d "reference_model" ]]; then
         log_step "main" "[error] Missing reference_model directory in tosa-tools repo."
@@ -345,7 +345,6 @@ if [[ $is_script_sourced -eq 0 ]]; then
         log_step "main" "[error] Missing serialization directory in tosa-tools repo."
         exit 1
     fi
-
 
     export CMAKE_BUILD_PARALLEL_LEVEL="$(get_parallel_jobs)"
 


### PR DESCRIPTION
* Bump version from v2025.11.0 to v2025.11.2 which includes fix


Change-Id: I3ab942211842470529fcc630fe81c1858fee1bfa


cc @digantdesai @SS-JIA @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell