### PR TITLE
Arm backend: Add TOSA dialect shape ops 

### DIFF
--- a/backends/arm/_passes/arm_pass_manager.py
+++ b/backends/arm/_passes/arm_pass_manager.py
@@ -220,7 +220,8 @@ class ArmPassManager(PassManager):
                 self.add_pass(p)
 
     def _transform(self, graph_module: GraphModule):
-        with TosaLoweringContext(self.tosa_spec):
+        shape_env = graph_module.shape_env
+        with TosaLoweringContext(self.tosa_spec, shape_env):
             return self(graph_module).graph_module
 
     def add_pass(self, pipeline_pass):

--- a/backends/arm/_passes/to_tosa_memory_format_pass.py
+++ b/backends/arm/_passes/to_tosa_memory_format_pass.py
@@ -15,6 +15,7 @@ from executorch.backends.arm._passes.arm_pass_utils import (
     is_param_node,
 )
 from executorch.backends.arm.constants import NCHW_ORDER, NNCHW_ORDER, NNNCHW_ORDER
+from executorch.backends.arm.tosa.dialect.shape import is_shape_op_node
 from executorch.exir import ExportedProgram
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass, PassResult
@@ -404,6 +405,41 @@ class ToTosaMemoryFormatPass(ArmPass):
 
         node.kwargs = kwargs
 
+    def _propagate_dim_order_to_shape_args(self, node: torch.fx.Node) -> None:
+        for arg in node.all_input_nodes:
+            if is_shape_op_node(arg):
+                # Shape nodes may get its dim_order from multiple users. Keep track of old dim_order to make sure all
+                # users agree on the same dim_order, otherwise we may end up with non-deterministic dim_orders for
+                # shape nodes depending on the order of user traversal.
+                old_dim_order = arg.meta.get("tosa_dim_order", None) is not None
+                dim_order = node.meta["tosa_dim_order"]
+                if len(dim_order) != len(arg.meta["val"]):
+                    dim_order = tuple(range(len(arg.meta["val"])))
+                if old_dim_order and arg.meta["tosa_dim_order"] != dim_order:
+                    raise RuntimeError(
+                        f"Conflicting dim orders {arg.meta['tosa_dim_order']} and {dim_order} for shape node {arg.name}"
+                    )
+                arg.meta["tosa_dim_order"] = dim_order
+                self._propagate_dim_order_to_shape_args(arg)
+
+    def _annotate_shape_nodes(self, graph_module: torch.fx.GraphModule) -> None:
+        for node in graph_module.graph.nodes:
+            if not self._is_ok_for_annotation(node):
+                continue
+            self._propagate_dim_order_to_shape_args(node)
+
+    def _is_ok_for_annotation(self, node: torch.fx.Node) -> bool:
+        if "val" not in node.meta:
+            return False
+        # Shape-only nodes which produce SymInt[] rather than real tensors are annotated separately by propagating dim order from their users.
+        # We must therefore annotate all valid nodes before propagating dim order upwards in graph.
+        if is_shape_op_node(node):
+            return False
+        # For some models, the symbolic value is passed to the graph, skip it
+        if isinstance(node.meta["val"], torch.SymInt):
+            return False
+        return True
+
     def call(self, graph_module: torch.fx.GraphModule):
         """
         Entry point for the pass: annotate spatial ranks, compute dim orders,
@@ -411,7 +447,7 @@ class ToTosaMemoryFormatPass(ArmPass):
         """
         nodes = list(graph_module.graph.nodes)
         for node in nodes:
-            if "val" not in node.meta:
+            if not self._is_ok_for_annotation(node):
                 continue
             node.meta["tosa_spatial_rank"] = self._initial_spatial_rank(node)
             self.remove_dim_order_kwargs(graph_module, node)
@@ -419,7 +455,7 @@ class ToTosaMemoryFormatPass(ArmPass):
         self._propagate_spatial_ranks(nodes)
 
         for node in nodes:
-            if "val" not in node.meta:
+            if not self._is_ok_for_annotation(node):
                 continue
             node_data = get_first_fake_tensor(node).data
             spatial_rank = node.meta["tosa_spatial_rank"]
@@ -437,6 +473,9 @@ class ToTosaMemoryFormatPass(ArmPass):
         # Insert TOSA transposes to convert between (N)NCHW and (N)NHWC format.
         # See insert_tosa_transposes for insertion conditions.
         self.insert_tosa_transposes(graph_module)
+        # Special handling is needed for shape nodes as they don't have real tensors or real dim orders, but the order
+        # still needs to be propagated to them so that they can be serialized with the correct order and shapes.
+        self._annotate_shape_nodes(graph_module)
         graph_module.recompile()
         graph_module = super().call(graph_module).graph_module
 
@@ -450,7 +489,7 @@ class ToTosaMemoryFormatPass(ArmPass):
         while changed:
             changed = False
             for node in reversed(nodes):
-                if "val" not in node.meta:
+                if not self._is_ok_for_annotation(node):
                     continue
                 tensor = get_first_fake_tensor(node)
                 limit = max(tensor.dim() - 2, 0)

--- a/backends/arm/operators/op_tosa_shapes.py
+++ b/backends/arm/operators/op_tosa_shapes.py
@@ -10,12 +10,12 @@ from typing import Any, cast, List
 import torch
 
 import tosa_serializer as ts  # type: ignore
-
 from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
     register_node_visitor,
 )
 from executorch.backends.arm.tosa.mapping import TosaArg
+from executorch.backends.arm.tosa.utils import tosa_shape
 
 
 @register_node_visitor
@@ -33,10 +33,15 @@ class TosaConstShapeVisitor(NodeVisitor):
         output: TosaArg,
     ) -> None:
         shape_input = inputs[0].special
+        rank = len(shape_input)
+        tosa_dim_order = output.dim_order
+        vals = tosa_shape(node.meta["val"], tosa_dim_order)
         tosa_graph = cast(ts.TosaSerializer, tosa_graph)
         tosa_graph.addConst(
-            shape_input,
+            [
+                rank,
+            ],
             dtype=ts.DType.SHAPE,
-            vals=node.meta["val"],
+            vals=vals,
             name=output.name,
         )

--- a/backends/arm/test/misc/test_tosa_dialect_shape_ops.py
+++ b/backends/arm/test/misc/test_tosa_dialect_shape_ops.py
@@ -1,0 +1,347 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+import executorch.backends.arm.tosa.dialect  # noqa: F401
+import pytest
+import sympy  # type: ignore
+import torch
+from executorch.backends.arm.tosa.dialect.lib import TosaValueError
+from executorch.backends.arm.tosa.specification import (
+    TosaLoweringContext,
+    TosaSpecification,
+)
+from executorch.exir.dialects._ops import ops as exir_ops
+from torch._subclasses.fake_tensor import FakeTensorMode
+from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+
+def _make_symint(
+    shape_env: ShapeEnv, symbol: str, hint: int, min: int = 1, max: int = 64
+) -> torch.SymInt:
+    """Create a symbolic dimension backed by the provided ShapeEnv."""
+    symint = shape_env.create_symintnode(sympy.Symbol(symbol), hint=hint)
+    symbol_expr = symint.node.expr
+    shape_env.constrain_symbol_range(symbol_expr, compiler_min=min, compiler_max=max)
+    return symint
+
+
+def _expr(sym: torch.SymInt) -> str:
+    """Return the SymPy expression backing a SymInt."""
+    return str(sym.node._expr)
+
+
+def _expr_equals(sym: torch.SymInt, expected: sympy.Expr) -> bool:
+    """Return True if the SymPy expressions are equivalent."""
+    actual = sympy.sympify(_expr(sym))
+    expected_expr = sympy.sympify(expected)
+    return sympy.simplify(actual - expected_expr) == 0
+
+
+# Test that DIM can extract a symbolic dimension from a tensor when the TOSA specification supports the shape extension.
+def test_dim_extracts_symbolic_dimension_no_target():
+    shape_env = ShapeEnv()
+    s0 = _make_symint(shape_env, "s0", hint=4)
+
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+shape"), shape_env
+    ), FakeTensorMode(shape_env=shape_env) as mode:
+        s0_tensor = torch.empty(size=(1, 3, s0))
+        result = exir_ops.backend.tosa.DIM.default(mode.from_tensor(s0_tensor), axis=2)
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert isinstance(result[0], torch.SymInt)
+    assert _expr(result[0]) == "s0"
+
+
+# Test that DIM raises an error when the TOSA specification doesn't support the shape extension, as DIM relies on shape
+# expressions to return symbolic dimensions.
+def test_dim_requires_shape_extension_no_target():
+    spec_no_shape = TosaSpecification.create_from_string("TOSA-1.0+FP")
+    shape_env = ShapeEnv()
+    s0 = _make_symint(shape_env, "s0", hint=3)
+
+    with TosaLoweringContext(
+        spec_no_shape,
+        shape_env,
+    ), FakeTensorMode(shape_env=shape_env) as mode:
+        s0_tensor = torch.empty(size=(1, 3, s0))
+        with pytest.raises(TosaValueError, match="shape extension"):
+            exir_ops.backend.tosa.DIM.default(mode.from_tensor(s0_tensor), axis=2)
+
+
+# Test that CONST_SHAPE creates a constant shape tensor and returns the expected shape list.
+def test_const_shape_no_target():
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+shape")
+    ), FakeTensorMode():
+        shape = exir_ops.backend.tosa.CONST_SHAPE.default([2, 3, 4])
+    assert shape == [2, 3, 4]
+
+
+# Test that CONCAT_SHAPE with constant shapes performs concatenation and returns a constant shape.
+def test_concat_const_shapes_no_target():
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+shape")
+    ), FakeTensorMode():
+        const_shape_0 = exir_ops.backend.tosa.CONST_SHAPE.default([2, 3])
+        const_shape_1 = exir_ops.backend.tosa.CONST_SHAPE.default([4])
+        result = exir_ops.backend.tosa.CONCAT_SHAPE.default(
+            [const_shape_0, const_shape_1]
+        )
+    assert result == [2, 3, 4]
+
+
+# Test that CONCAT_SHAPE with symbolic shapes produces a symbolic expression concatenating the dimensions.
+def test_concat_symbolic_shape_no_target():
+    shape_env = ShapeEnv()
+    s0 = _make_symint(shape_env, "s0", hint=2)
+    s1 = _make_symint(shape_env, "s1", hint=3)
+
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+shape"), shape_env
+    ), FakeTensorMode(shape_env=shape_env) as mode:
+        s0_tensor = torch.empty(size=(1, 3, s0))
+        s1_tensor = torch.empty(size=(1, 3, s1))
+
+        dim_s0 = exir_ops.backend.tosa.DIM.default(mode.from_tensor(s0_tensor), axis=2)
+        dim_s1 = exir_ops.backend.tosa.DIM.default(mode.from_tensor(s1_tensor), axis=2)
+        result = exir_ops.backend.tosa.CONCAT_SHAPE.default([dim_s0, dim_s1])
+
+    assert len(result) == 2
+    assert _expr(result[0]) == "s0"
+    assert _expr(result[1]) == "s1"
+
+
+def test_concat_mixed_shape_no_target():
+    shape_env = ShapeEnv()
+    s0 = _make_symint(shape_env, "s0", hint=2)
+
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+shape")
+    ), FakeTensorMode(shape_env=shape_env) as mode:
+        const_shape = exir_ops.backend.tosa.CONST_SHAPE.default([4, 5])
+        s0_tensor = torch.empty(size=(1, 3, s0))
+        dim_s0 = exir_ops.backend.tosa.DIM.default(mode.from_tensor(s0_tensor), axis=2)
+        result = exir_ops.backend.tosa.CONCAT_SHAPE.default([const_shape, dim_s0])
+
+    assert len(result) == 3
+    assert result[0] == 4
+    assert result[1] == 5
+    assert _expr(result[2]) == "s0"
+
+
+# Test that CONCAT_SHAPE raises an error when given fewer than 2 shape tensors, as it requires at least 2 to
+# concatenate.
+def test_concat_shape_requires_arguments_no_target():
+    with pytest.raises(
+        TosaValueError, match="CONCAT_SHAPE expected 2 or more shape tensors"
+    ):
+        with TosaLoweringContext(
+            TosaSpecification.create_from_string("TOSA-1.1+FP+shape")
+        ), FakeTensorMode():
+            exir_ops.backend.tosa.CONCAT_SHAPE.default([])
+
+
+# Test ADD_SHAPE with constant values, which should perform elementwise addition and return a constant shape.
+def test_add_const_shape_no_target():
+    shape_env = ShapeEnv()
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+shape"), shape_env
+    ), FakeTensorMode():
+        const_0 = exir_ops.backend.tosa.CONST_SHAPE.default([2, 3])
+        const_1 = exir_ops.backend.tosa.CONST_SHAPE.default([4, 5])
+        result = exir_ops.backend.tosa.ADD_SHAPE.default(const_0, const_1)
+    assert len(result) == 2
+    assert result == [6, 8]
+
+
+# Test ADD_SHAPE with symbolic values, which should produce a symbolic expression adding the two dimensions.
+def test_add_symbolic_shape_no_target():
+    shape_env = ShapeEnv()
+    s0 = _make_symint(shape_env, "s0", hint=2)
+    s1 = _make_symint(shape_env, "s1", hint=3)
+
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+shape"), shape_env
+    ), FakeTensorMode(shape_env=shape_env) as mode:
+        s0_tensor = torch.empty(size=(1, 3, s0))
+        s1_tensor = torch.empty(size=(1, 3, s1))
+
+        dim_s0 = exir_ops.backend.tosa.DIM.default(mode.from_tensor(s0_tensor), axis=2)
+        dim_s1 = exir_ops.backend.tosa.DIM.default(mode.from_tensor(s1_tensor), axis=2)
+        result = exir_ops.backend.tosa.ADD_SHAPE.default(dim_s0, dim_s1)
+    assert len(result) == 1
+    assert isinstance(result[0], torch.SymInt)
+    assert _expr_equals(result[0], sympy.Symbol("s0") + sympy.Symbol("s1"))
+
+
+def test_add_mixed_shape_no_target():
+    shape_env = ShapeEnv()
+    s0 = _make_symint(shape_env, "s0", hint=2)
+
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+shape"), shape_env
+    ), FakeTensorMode(shape_env=shape_env) as mode:
+        const_shape = exir_ops.backend.tosa.CONST_SHAPE.default([4])
+        s0_tensor = torch.empty(size=(1, 3, s0))
+        dim_s0 = exir_ops.backend.tosa.DIM.default(mode.from_tensor(s0_tensor), axis=2)
+        result = exir_ops.backend.tosa.ADD_SHAPE.default(const_shape, dim_s0)
+
+    assert len(result) == 1
+    assert isinstance(result[0], torch.SymInt)
+    assert _expr_equals(result[0], sympy.Symbol("s0") + sympy.Integer(4))
+
+
+# Test SUB_SHAPE with constant values, which should perform subtraction and return a constant shape.
+def test_sub_const_shape_no_target():
+    shape_env = ShapeEnv()
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+shape"), shape_env
+    ), FakeTensorMode():
+        const_0 = exir_ops.backend.tosa.CONST_SHAPE.default([6, 5])
+        const_1 = exir_ops.backend.tosa.CONST_SHAPE.default([2, 3])
+        result = exir_ops.backend.tosa.SUB_SHAPE.default(const_0, const_1)
+    assert len(result) == 2
+    assert result == [4, 2]
+
+
+# Test SUB_SHAPE with symbolic values, which should produce a Sub expression.
+def test_sub_symbolic_shape_no_target():
+    shape_env = ShapeEnv()
+    s0 = _make_symint(shape_env, "s0", hint=2)
+    s1 = _make_symint(shape_env, "s1", hint=3)
+
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+shape"),
+        shape_env,
+    ), FakeTensorMode(shape_env=shape_env) as mode:
+        s0_tensor = torch.empty(size=(1, 3, s0))
+        s1_tensor = torch.empty(size=(1, 3, s1))
+
+        dim_s0 = exir_ops.backend.tosa.DIM.default(mode.from_tensor(s0_tensor), axis=2)
+        dim_s1 = exir_ops.backend.tosa.DIM.default(mode.from_tensor(s1_tensor), axis=2)
+        result = exir_ops.backend.tosa.SUB_SHAPE.default(dim_s0, dim_s1)
+    assert len(result) == 1
+    assert isinstance(result[0], torch.SymInt)
+    assert _expr_equals(result[0], sympy.Symbol("s0") - sympy.Symbol("s1"))
+
+
+def test_sub_mixed_shape_no_target():
+    shape_env = ShapeEnv()
+    s0 = _make_symint(shape_env, "s0", hint=3)
+
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+shape"),
+        shape_env,
+    ), FakeTensorMode(shape_env=shape_env) as mode:
+        const_shape = exir_ops.backend.tosa.CONST_SHAPE.default([6])
+        s0_tensor = torch.empty(size=(1, 3, s0))
+        dim_s0 = exir_ops.backend.tosa.DIM.default(mode.from_tensor(s0_tensor), axis=2)
+        result = exir_ops.backend.tosa.SUB_SHAPE.default(const_shape, dim_s0)
+
+    assert len(result) == 1
+    assert isinstance(result[0], torch.SymInt)
+    assert _expr_equals(result[0], sympy.Integer(6) - sympy.Symbol("s0"))
+
+
+# Test MUL_SHAPE with constant values, which should perform multiplication and return a constant shape.
+def test_mul_const_shape_no_target():
+    shape_env = ShapeEnv()
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+shape"), shape_env
+    ), FakeTensorMode():
+        const_0 = exir_ops.backend.tosa.CONST_SHAPE.default([2, 3])
+        const_1 = exir_ops.backend.tosa.CONST_SHAPE.default([4, 5])
+        result = exir_ops.backend.tosa.MUL_SHAPE.default(const_0, const_1)
+    assert len(result) == 2
+    assert result == [8, 15]
+
+
+# Test MUL_SHAPE with symbolic values, which should produce a Mul expression.
+def test_mul_symbolic_shape_no_target():
+    shape_env = ShapeEnv()
+    s0 = _make_symint(shape_env, "s0", hint=2)
+    s1 = _make_symint(shape_env, "s1", hint=3)
+
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+shape"), shape_env
+    ), FakeTensorMode(shape_env=shape_env) as mode:
+        s0_tensor = torch.empty(size=(1, 3, s0))
+        s1_tensor = torch.empty(size=(1, 3, s1))
+
+        dim_s0 = exir_ops.backend.tosa.DIM.default(mode.from_tensor(s0_tensor), axis=2)
+        dim_s1 = exir_ops.backend.tosa.DIM.default(mode.from_tensor(s1_tensor), axis=2)
+        result = exir_ops.backend.tosa.MUL_SHAPE.default(dim_s0, dim_s1)
+    assert len(result) == 1
+    assert isinstance(result[0], torch.SymInt)
+    assert _expr_equals(result[0], sympy.Symbol("s0") * sympy.Symbol("s1"))
+
+
+def test_mul_mixed_shape_no_target():
+    shape_env = ShapeEnv()
+    s0 = _make_symint(shape_env, "s0", hint=4)
+
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+shape"), shape_env
+    ), FakeTensorMode(shape_env=shape_env) as mode:
+        const_shape = exir_ops.backend.tosa.CONST_SHAPE.default([3])
+        s0_tensor = torch.empty(size=(1, 3, s0))
+        dim_s0 = exir_ops.backend.tosa.DIM.default(mode.from_tensor(s0_tensor), axis=2)
+        result = exir_ops.backend.tosa.MUL_SHAPE.default(const_shape, dim_s0)
+
+    assert len(result) == 1
+    assert isinstance(result[0], torch.SymInt)
+    assert _expr_equals(result[0], sympy.Integer(3) * sympy.Symbol("s0"))
+
+
+# Test DIV_FLOOR_SHAPE with constant values, which should perform floor division and return a constant shape.
+def test_div_floor_const_shape_no_target():
+    shape_env = ShapeEnv()
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+shape"), shape_env
+    ), FakeTensorMode():
+        const_0 = exir_ops.backend.tosa.CONST_SHAPE.default([8, 21])
+        const_1 = exir_ops.backend.tosa.CONST_SHAPE.default([2, 4])
+        result = exir_ops.backend.tosa.DIV_FLOOR_SHAPE.default(const_0, const_1)
+    assert len(result) == 2
+    assert result == [4, 5]
+
+
+# Test DIV_FLOOR_SHAPE with symbolic values, which should produce a FloorDiv expression.
+def test_div_floor_symbolic_shape_no_target():
+    shape_env = ShapeEnv()
+    s0 = _make_symint(shape_env, "s0", hint=8)
+    s1 = _make_symint(shape_env, "s1", hint=3)
+
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+shape"), shape_env
+    ), FakeTensorMode(shape_env=shape_env) as mode:
+        s0_tensor = torch.empty(size=(1, 3, s0))
+        s1_tensor = torch.empty(size=(1, 3, s1))
+        dim_s0 = exir_ops.backend.tosa.DIM.default(mode.from_tensor(s0_tensor), axis=2)
+        dim_s1 = exir_ops.backend.tosa.DIM.default(mode.from_tensor(s1_tensor), axis=2)
+        result = exir_ops.backend.tosa.DIV_FLOOR_SHAPE.default(dim_s0, dim_s1)
+    assert len(result) == 1
+    assert isinstance(result[0], torch.SymInt)
+    assert _expr_equals(result[0], sympy.sympify("(s0//s1)"))
+
+
+def test_div_floor_mixed_shape_no_target():
+    shape_env = ShapeEnv()
+    s0 = _make_symint(shape_env, "s0", hint=4)
+
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+shape"), shape_env
+    ), FakeTensorMode(shape_env=shape_env) as mode:
+        const_shape = exir_ops.backend.tosa.CONST_SHAPE.default([8])
+        s0_tensor = torch.empty(size=(1, 3, s0))
+        dim_s0 = exir_ops.backend.tosa.DIM.default(mode.from_tensor(s0_tensor), axis=2)
+        result = exir_ops.backend.tosa.DIV_FLOOR_SHAPE.default(const_shape, dim_s0)
+
+    assert len(result) == 1
+    assert isinstance(result[0], torch.SymInt)
+    assert _expr_equals(result[0], sympy.sympify("8//s0"))

--- a/backends/arm/tosa/dialect/ops/shape_ops.py
+++ b/backends/arm/tosa/dialect/ops/shape_ops.py
@@ -3,9 +3,21 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Callable
 
+import sympy  # type: ignore[import-untyped]
+import torch
+
+from executorch.backends.arm.tosa.dialect.lib import TosaValueError
 from executorch.backends.arm.tosa.dialect.ops_registration import register_fake_tosa_op
-from executorch.backends.arm.tosa.specification import TosaSpecification
+
+from executorch.backends.arm.tosa.specification import (
+    get_context_shape_env,
+    get_context_spec,
+    TosaSpecification,
+)
+from torch.types import IntLikeType
+from torch.utils._sympy.functions import FloorDiv
 
 
 @register_fake_tosa_op(
@@ -16,3 +28,146 @@ def CONST_SHAPE(shape: list[int]) -> list[int]:
     """CONST_SHAPE operator creates a constant shape tensor."""
 
     return shape
+
+
+@register_fake_tosa_op(
+    "DIM(Tensor input, *, int axis) -> SymInt[]",  # schema
+    TosaSpecification.all_profiles_for_version("1.1"),
+)
+def DIM(x: torch.Tensor, *, axis: int) -> list[torch.SymInt]:
+    tosa_spec = get_context_spec()
+    """Dim operator extracts a dimension from the input tensor shape."""
+
+    if not tosa_spec.support_extension("shape"):
+        raise TosaValueError(
+            f"TOSA spec {tosa_spec} doesn't support shape extension", op="DIM"
+        )
+
+    assert isinstance(
+        x.shape[axis], torch.SymInt
+    ), f"Expected dimension to be SymInt, got {type(x.shape[axis])}"
+    return [x.shape[axis]]  # type: ignore[list-item]
+
+
+def _to_sympy_expr(value: IntLikeType) -> sympy.Expr:
+    """Lift a shape value to a SymPy expression without forcing hints."""
+
+    if isinstance(value, torch.SymInt):
+        # `node.expr` flows through ShapeEnv.replace and would plug in hints.
+        # `_expr` is the raw symbolic expression we need to preserve.
+        return value.node._expr
+    return sympy.Integer(int(value))
+
+
+def _combine_shapes(
+    lhs: list[IntLikeType],
+    rhs: list[IntLikeType],
+    combine: Callable[[sympy.Expr, sympy.Expr], sympy.Expr | sympy.Integer],
+) -> list[IntLikeType]:
+    """The fake kernels run during export/meta execution.
+
+    Using Python arithmetic
+    directly on `torch.SymInt` would consult the current ShapeEnv hints and
+    collapse dynamic symbols to concrete ints.  Instead we work with the
+    underlying SymPy expressions and wrap them back into SymInts via the same
+    ShapeEnv, preserving dynamic information for later passes.
+
+    """
+    assert len(lhs) == len(
+        rhs
+    ), f"Expected shapes to be of same length, got {len(lhs)} and {len(rhs)}"
+
+    expr_lhs = [_to_sympy_expr(v) for v in lhs]
+    expr_rhs = [_to_sympy_expr(v) for v in rhs]
+
+    shape_env = get_context_shape_env()
+    result: list[IntLikeType] = []
+    for a, b in zip(expr_lhs, expr_rhs):
+        expr = combine(a, b)
+        if isinstance(expr, sympy.Expr):
+            result.append(shape_env.create_symintnode(expr, hint=None))
+        else:
+            result.append(int(expr))
+    return result
+
+
+@register_fake_tosa_op(
+    "CONCAT_SHAPE(SymInt[][] shape_list) -> SymInt[]",  # schema (fixed to return SymInt[])
+    TosaSpecification.all_profiles_for_version("1.1"),
+)
+def CONCAT_SHAPE(
+    shape_list: list[list[IntLikeType]],
+) -> list[IntLikeType]:
+    """CONCAT_SHAPE operator concatenates a list of shape lists to create a new
+    list with length the sum of lengths of all lists in input shape_list.
+    """
+
+    if len(shape_list) < 1:
+        raise TosaValueError(
+            f"CONCAT_SHAPE expected 2 or more shape tensors, got {len(shape_list)}",
+            op="CONCAT_SHAPE",
+        )
+
+    concat_shape = list(shape_list[0])
+    for d in shape_list[1:]:
+        concat_shape.extend(d)
+
+    return concat_shape
+
+
+@register_fake_tosa_op(
+    "ADD_SHAPE(SymInt[] shape1, SymInt[] shape2) -> SymInt[]",  # schema
+    TosaSpecification.all_profiles_for_version("1.1"),
+)
+def ADD_SHAPE(
+    shape1: list[IntLikeType],
+    shape2: list[IntLikeType],
+) -> list[IntLikeType]:
+    """ADD_SHAPE operator adds each element of the second shape tensor to the
+    first.
+    """
+    return _combine_shapes(shape1, shape2, lambda a, b: a + b)
+
+
+@register_fake_tosa_op(
+    "SUB_SHAPE(SymInt[] shape1, SymInt[] shape2) -> SymInt[]",  # schema
+    TosaSpecification.all_profiles_for_version("1.1"),
+)
+def SUB_SHAPE(
+    shape1: list[IntLikeType],
+    shape2: list[IntLikeType],
+) -> list[IntLikeType]:
+    """SUB_SHAPE operator subtracts each element of the second shape tensor from
+    the first.
+    """
+
+    return _combine_shapes(shape1, shape2, lambda a, b: a - b)
+
+
+@register_fake_tosa_op(
+    "DIV_FLOOR_SHAPE(SymInt[] shape1, SymInt[] shape2) -> SymInt[]",  # schema
+    TosaSpecification.all_profiles_for_version("1.1"),
+)
+def DIV_FLOOR_SHAPE(
+    shape1: list[IntLikeType],
+    shape2: list[IntLikeType],
+) -> list[IntLikeType]:
+    """DIV_SHAPE operator divides each element of the shape tensor by the given
+    denominator.
+    """
+    return _combine_shapes(shape1, shape2, lambda a, b: FloorDiv(a, b))
+
+
+@register_fake_tosa_op(
+    "MUL_SHAPE(SymInt[] shape1, SymInt[] shape2) -> SymInt[]",  # schema
+    TosaSpecification.all_profiles_for_version("1.1"),
+)
+def MUL_SHAPE(
+    shape1: list[IntLikeType],
+    shape2: list[IntLikeType],
+) -> list[IntLikeType]:
+    """MUL_SHAPE operator multiplies each element of the shape tensor by the
+    given factor.
+    """
+
+    return _combine_shapes(shape1, shape2, lambda a, b: a * b)

--- a/backends/arm/tosa/mapping.py
+++ b/backends/arm/tosa/mapping.py
@@ -131,7 +131,7 @@ def extract_tensor_meta(meta):
     special_dtype = meta.get(TosaSpecialDtype.meta_key())
     if special_dtype == TosaSpecialDtype.SHAPE:
         shape_len = len(meta["val"])
-        return (ts.DType.SHAPE, (shape_len,), (0,))
+        return (ts.DType.SHAPE, (shape_len,), meta["tosa_dim_order"])
 
     if meta.get("val") is None:
         raise ValueError("Expected node.meta['val'] to be set to a FakeTensor")

--- a/backends/arm/tosa/specification.py
+++ b/backends/arm/tosa/specification.py
@@ -14,6 +14,7 @@ import re
 from typing import Dict, Generic, List, Set, TypeVar
 
 from packaging.version import Version
+from torch.fx.experimental.symbolic_shapes import ShapeEnv
 
 T = TypeVar("T")
 
@@ -416,8 +417,9 @@ class TosaLoweringContext:
 
     # Define a context variable for the spec
     tosa_spec_var: contextvars.ContextVar = contextvars.ContextVar("tosa_spec")
+    shape_env_var: contextvars.ContextVar = contextvars.ContextVar("shape_env")
 
-    def __init__(self, spec: TosaSpecification):
+    def __init__(self, spec: TosaSpecification, shape_env: ShapeEnv | None = None):
         """Initialize the lowering context with a specification.
 
         Args:
@@ -425,6 +427,7 @@ class TosaLoweringContext:
 
         """
         self.spec = spec
+        self.shape_env = shape_env
 
     def __enter__(self):
         """Set the context variable and return self.
@@ -434,7 +437,9 @@ class TosaLoweringContext:
 
         """
         # Set the spec in the context variable and store the token for later reset
-        self.token = TosaLoweringContext.tosa_spec_var.set(self.spec)
+        self.tosa_spec_token = TosaLoweringContext.tosa_spec_var.set(self.spec)
+        self.shape_env_token = TosaLoweringContext.shape_env_var.set(self.shape_env)
+
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
@@ -447,7 +452,8 @@ class TosaLoweringContext:
 
         """
         # Reset the context variable to its previous state
-        TosaLoweringContext.tosa_spec_var.reset(self.token)
+        TosaLoweringContext.tosa_spec_var.reset(self.tosa_spec_token)
+        TosaLoweringContext.shape_env_var.reset(self.shape_env_token)
 
 
 def get_context_spec() -> TosaSpecification:
@@ -462,6 +468,26 @@ def get_context_spec() -> TosaSpecification:
     """
     try:
         return TosaLoweringContext.tosa_spec_var.get()
+    except LookupError:
+        raise RuntimeError("Function must be executed within a TosaLoweringContext")
+
+
+def get_context_shape_env() -> ShapeEnv:
+    """Get the current ShapeEnv from the lowering context, if any.
+
+    Returns:
+        ShapeEnv: Active ShapeEnv retrieved from the context var.
+
+    Raises:
+        RuntimeError: If called outside a ``TosaLoweringContext`` or if no ShapeEnv is set.
+
+    """
+    try:
+        # Attempt to get the current context spec and return its shape_env
+        shape_env = TosaLoweringContext.shape_env_var.get()
+        if shape_env is None:
+            raise RuntimeError("No ShapeEnv set in the current TosaLoweringContext")
+        return TosaLoweringContext.shape_env_var.get()
     except LookupError:
         raise RuntimeError("Function must be executed within a TosaLoweringContext")
 


### PR DESCRIPTION
Adds TOSA dialect shape ops. All added shape-ops are currently not serialized and are only tested through isolated tests with FakeTensor-inputs. To enable serialization of shape ops in the future, dim-order propagation of these ops is added.

cc @digantdesai @SS-JIA @freddan80 @per @zingo @mansnils @Sebastian-Larsson @robell