### PR TITLE
Add lfm2.5 VL Export

### DIFF
--- a/examples/models/lfm2_5_vl/BUCK
+++ b/examples/models/lfm2_5_vl/BUCK
@@ -1,0 +1,55 @@
+load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target", "non_fbcode_target")
+# Any targets that should be shared between fbcode and xplat must be defined in
+# targets.bzl. This file can contain fbcode-only targets.
+
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+
+oncall("executorch")
+
+fbcode_target(_kind = runtime.python_library,
+    name = "lfm2_5_vl",
+    srcs = [
+        "__init__.py",
+        "convert_weights.py",
+        "model.py",
+    ],
+    resources = {
+        "config/lfm2_5_vl_1_6b_config.json": "config/lfm2_5_vl_1_6b_config.json",
+    },
+    base_module = "executorch.examples.models.lfm2_5_vl",
+    visibility = ["PUBLIC"],
+    deps = [
+        "//caffe2:torch",
+        "//executorch/examples/models/llama:transformer_modules",
+        "//executorch/examples/models/llama:export_library",
+        "fbsource//third-party/pypi/safetensors:safetensors",
+        "fbsource//third-party/pypi/transformers:transformers",
+    ],
+)
+
+fbcode_target(_kind = runtime.python_library,
+    name = "export_lib",
+    srcs = [
+        "export_lfm2_5_vl.py",
+    ],
+    _is_external_target = True,
+    base_module = "executorch.examples.models.lfm2_5_vl",
+    visibility = [
+        "//executorch/...",
+    ],
+    deps = [
+        ":lfm2_5_vl",
+    ],
+)
+
+fbcode_target(_kind = runtime.python_binary,
+    name = "export",
+    main_function = "executorch.examples.models.lfm2_5_vl.export_lfm2_5_vl.main",
+    preload_deps = [
+        "//executorch/extension/llm/custom_ops:custom_ops_aot_lib",
+        "//executorch/kernels/quantized:aot_lib",
+    ],
+    deps = [
+        ":export_lib",
+    ],
+)

--- a/examples/models/lfm2_5_vl/README.md
+++ b/examples/models/lfm2_5_vl/README.md
@@ -1,0 +1,49 @@
+# LFM2.5-VL ExecuTorch Export
+
+Export [LiquidAI/LFM2-VL-1.6B](https://huggingface.co/LiquidAI/LFM2-VL-1.6B) to ExecuTorch as a single multi-method PTE compatible with the LLaVA C++ runner.
+
+LFM2.5-VL is a **hybrid SSM+attention vision-language model** — 16 decoder layers alternating between short convolution blocks and full attention blocks, paired with a SigLIP ViT vision encoder.
+
+## Architecture
+
+Three named methods in one PTE:
+
+| Method | Input | Output |
+|--------|-------|--------|
+| `vision_encoder` | `[1, 3, 512, 512]` float32 NCHW pixels [0,255] | `[1, 256, 2048]` float32 |
+| `token_embedding` | `[1, seq_len]` int64 token IDs | `[1, seq_len, 2048]` float32 |
+| `text_decoder` | `([1, seq_len, 2048]` float32, `[seq_len]` int64) | `[1, 65536]` float32 |
+
+## Export
+
+```bash
+python examples/models/lfm2_5_vl/export_lfm2_5_vl.py \
+    --model_dir LiquidAI/LFM2-VL-1.6B \
+    --dtype fp32
+```
+
+With quantization (8da4w decoder + int8 embedding):
+
+```bash
+python examples/models/lfm2_5_vl/export_lfm2_5_vl.py \
+    --model_dir LiquidAI/LFM2-VL-1.6B \
+    --quantize
+```
+
+## Runner Compatibility
+
+The exported PTE is compatible with `llava_main` (the ExecuTorch multimodal C++ runner). Method names match `extension/llm/runner/constants.h`.
+
+### Required runner configuration
+
+- Resize image to exactly 512×512
+- Pass CHW float32 pixels in [0, 255] — normalization is baked into `vision_encoder`
+- EOS token: `<|im_end|>` (ID 7), read from `get_eos_ids()` constant method
+- Chat template: `<|startoftext|><|im_start|>user\n<image>{prompt}<|im_end|>\n<|im_start|>assistant\n`
+
+## Key Implementation Notes
+
+- `enable_dynamic_shape=False` — required to avoid `.item()` in RoPE's `get_freqs` during FakeTensor export
+- `strict=False` — hybrid conv layers have buffer mutations not traceable in strict mode
+- Text decoder exported before token embedding — `EmbeddingQuantHandler` mutates weights in-place
+- Bilinear PE precompute with `antialias=True` — validated correct vs HF processor output

--- a/examples/models/lfm2_5_vl/README.md
+++ b/examples/models/lfm2_5_vl/README.md
@@ -1,24 +1,33 @@
 # LFM2.5-VL ExecuTorch Export
 
-Export [LiquidAI/LFM2-VL-1.6B](https://huggingface.co/LiquidAI/LFM2-VL-1.6B) to ExecuTorch as a single multi-method PTE compatible with the LLaVA C++ runner.
+Export the LFM2.5-VL family to ExecuTorch as a single multi-method PTE compatible with the LLaVA C++ runner. Both checkpoints are supported and share the same export path:
+
+- [LiquidAI/LFM2-VL-1.6B](https://huggingface.co/LiquidAI/LFM2-VL-1.6B) — text dim 2048
+- [LiquidAI/LFM2.5-VL-450M](https://huggingface.co/LiquidAI/LFM2.5-VL-450M) — text dim 1024
 
 LFM2.5-VL is a **hybrid SSM+attention vision-language model** — 16 decoder layers alternating between short convolution blocks and full attention blocks, paired with a SigLIP ViT vision encoder.
 
 ## Architecture
 
-Three named methods in one PTE:
+Three named methods in one PTE (`D` = text hidden dim: 2048 for 1.6B, 1024 for 450M):
 
 | Method | Input | Output |
 |--------|-------|--------|
-| `vision_encoder` | `[1, 3, 512, 512]` float32 NCHW pixels [0,255] | `[1, 256, 2048]` float32 |
-| `token_embedding` | `[1, seq_len]` int64 token IDs | `[1, seq_len, 2048]` float32 |
-| `text_decoder` | `([1, seq_len, 2048]` float32, `[seq_len]` int64) | `[1, 65536]` float32 |
+| `vision_encoder` | `[1, 3, 512, 512]` float32 NCHW pixels [0,255] | `[1, 256, D]` float32 |
+| `token_embedding` | `[1, seq_len]` int64 token IDs | `[1, seq_len, D]` float32 |
+| `text_decoder` | `([1, seq_len, D]` float32, `[seq_len]` int64) | `[1, 65536]` float32 |
 
 ## Export
 
 ```bash
+# 1.6B (default)
 python examples/models/lfm2_5_vl/export_lfm2_5_vl.py \
     --model_dir LiquidAI/LFM2-VL-1.6B \
+    --dtype fp32
+
+# 450M — bundled config is auto-selected from --model_dir
+python examples/models/lfm2_5_vl/export_lfm2_5_vl.py \
+    --model_dir LiquidAI/LFM2.5-VL-450M \
     --dtype fp32
 ```
 
@@ -26,9 +35,11 @@ With quantization (8da4w decoder + int8 embedding + float32 vision encoder):
 
 ```bash
 python examples/models/lfm2_5_vl/export_lfm2_5_vl.py \
-    --model_dir LiquidAI/LFM2-VL-1.6B \
+    --model_dir LiquidAI/LFM2.5-VL-450M \
     --quantize
 ```
+
+The bundled architecture configs live in [config/](config/). Pass `--params /path/to/custom.json` to override.
 
 ### Required runner configuration
 

--- a/examples/models/lfm2_5_vl/README.md
+++ b/examples/models/lfm2_5_vl/README.md
@@ -22,17 +22,13 @@ python examples/models/lfm2_5_vl/export_lfm2_5_vl.py \
     --dtype fp32
 ```
 
-With quantization (8da4w decoder + int8 embedding):
+With quantization (8da4w decoder + int8 embedding + float32 vision encoder):
 
 ```bash
 python examples/models/lfm2_5_vl/export_lfm2_5_vl.py \
     --model_dir LiquidAI/LFM2-VL-1.6B \
     --quantize
 ```
-
-## Runner Compatibility
-
-The exported PTE is compatible with `llava_main` (the ExecuTorch multimodal C++ runner). Method names match `extension/llm/runner/constants.h`.
 
 ### Required runner configuration
 

--- a/examples/models/lfm2_5_vl/__init__.py
+++ b/examples/models/lfm2_5_vl/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/examples/models/lfm2_5_vl/__init__.py
+++ b/examples/models/lfm2_5_vl/__init__.py
@@ -3,3 +3,11 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+
+from executorch.examples.models.lfm2_5_vl.convert_weights import convert_weights
+from executorch.examples.models.lfm2_5_vl.model import Lfm2p5VlModel
+
+__all__ = [
+    "convert_weights",
+    "Lfm2p5VlModel",
+]

--- a/examples/models/lfm2_5_vl/config/lfm2_5_vl_1_6b_config.json
+++ b/examples/models/lfm2_5_vl/config/lfm2_5_vl_1_6b_config.json
@@ -1,0 +1,33 @@
+{
+  "dim": 2048,
+  "ffn_dim_multiplier": 1,
+  "hidden_dim": 8192,
+  "n_heads": 32,
+  "n_kv_heads": 8,
+  "n_layers": 16,
+  "norm_eps": 1e-5,
+  "rope_theta": 1000000.0,
+  "use_scaled_rope": false,
+  "vocab_size": 65536,
+  "use_hf_rope": true,
+  "use_qk_norm": true,
+  "qk_norm_before_rope": true,
+  "layer_types": [
+    "conv",
+    "conv",
+    "full_attention",
+    "conv",
+    "conv",
+    "full_attention",
+    "conv",
+    "conv",
+    "full_attention",
+    "conv",
+    "full_attention",
+    "conv",
+    "full_attention",
+    "conv",
+    "full_attention",
+    "conv"
+  ]
+}

--- a/examples/models/lfm2_5_vl/config/lfm2_5_vl_450m_config.json
+++ b/examples/models/lfm2_5_vl/config/lfm2_5_vl_450m_config.json
@@ -1,0 +1,33 @@
+{
+  "dim": 1024,
+  "ffn_dim_multiplier": 1,
+  "hidden_dim": 4608,
+  "n_heads": 16,
+  "n_kv_heads": 8,
+  "n_layers": 16,
+  "norm_eps": 1e-5,
+  "rope_theta": 1000000.0,
+  "use_scaled_rope": false,
+  "vocab_size": 65536,
+  "use_hf_rope": true,
+  "use_qk_norm": true,
+  "qk_norm_before_rope": true,
+  "layer_types": [
+    "conv",
+    "conv",
+    "full_attention",
+    "conv",
+    "conv",
+    "full_attention",
+    "conv",
+    "conv",
+    "full_attention",
+    "conv",
+    "full_attention",
+    "conv",
+    "full_attention",
+    "conv",
+    "full_attention",
+    "conv"
+  ]
+}

--- a/examples/models/lfm2_5_vl/convert_weights.py
+++ b/examples/models/lfm2_5_vl/convert_weights.py
@@ -1,0 +1,127 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Convert LFM2.5-VL text decoder weights from HuggingFace safetensors format
+to the Meta/ET format expected by construct_transformer.
+
+Usage:
+    python examples/models/lfm2_5_vl/convert_weights.py \
+        /path/to/LFM2-VL-1.6B \
+        lfm2_5_vl_1_6b.pt
+
+The input directory must contain model.safetensors from the HuggingFace
+LiquidAI/LFM2-VL-1.6B checkpoint. Only the language model (text decoder)
+weights are extracted — vision tower and projector weights are not included.
+"""
+
+import argparse
+import os
+from typing import Dict
+
+import torch
+
+from executorch.examples.models.checkpoint import get_mapped_key
+from safetensors.torch import load_file
+
+# HuggingFace key -> ET/Meta key mapping for LFM2.5-VL language model.
+# Keys use {} as a placeholder for the layer index (handled by get_mapped_key).
+# The "model.language_model." prefix is specific to the VL wrapper; text-only
+# LFM2 uses "model." directly.
+_LFM2_5_VL_TO_META = {
+    "model.language_model.embed_tokens.weight": "tok_embeddings.weight",
+    "model.language_model.embedding_norm.weight": "norm.weight",
+    "model.language_model.layers.{}.self_attn.q_proj.weight": "layers.{}.attention.wq.weight",
+    "model.language_model.layers.{}.self_attn.k_proj.weight": "layers.{}.attention.wk.weight",
+    "model.language_model.layers.{}.self_attn.v_proj.weight": "layers.{}.attention.wv.weight",
+    "model.language_model.layers.{}.self_attn.out_proj.weight": "layers.{}.attention.wo.weight",
+    "model.language_model.layers.{}.self_attn.q_layernorm.weight": "layers.{}.attention.q_norm_fn.weight",
+    "model.language_model.layers.{}.self_attn.k_layernorm.weight": "layers.{}.attention.k_norm_fn.weight",
+    "model.language_model.layers.{}.operator_norm.weight": "layers.{}.attention_norm.weight",
+    "model.language_model.layers.{}.ffn_norm.weight": "layers.{}.ffn_norm.weight",
+    "model.language_model.layers.{}.feed_forward.w1.weight": "layers.{}.feed_forward.w1.weight",
+    "model.language_model.layers.{}.feed_forward.w2.weight": "layers.{}.feed_forward.w2.weight",
+    "model.language_model.layers.{}.feed_forward.w3.weight": "layers.{}.feed_forward.w3.weight",
+    "model.language_model.layers.{}.conv.conv.weight": "layers.{}.conv.conv.weight",
+    "model.language_model.layers.{}.conv.out_proj.weight": "layers.{}.conv.out_proj.weight",
+}
+
+
+def lfm2_5_vl_to_meta(state_dict: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
+    """
+    Convert a state dict from LFM2.5-VL HF format to Meta's ET format.
+    Only extracts language model (text decoder) weights.
+
+    Args:
+        state_dict: State dict from model.safetensors (full VL model).
+
+    Returns:
+        State dict in ET construct_transformer format.
+    """
+    converted = {}
+
+    for key, value in state_dict.items():
+        # Skip vision tower and projector — not part of the text decoder
+        if not key.startswith("model.language_model."):
+            continue
+
+        try:
+            new_key = get_mapped_key(key, _LFM2_5_VL_TO_META)
+        except KeyError:
+            # Fallback: strip "model.language_model." prefix
+            new_key = key.removeprefix("model.language_model.")
+
+        # Split conv in_proj: [3*dim, dim] -> B_proj, C_proj, x_proj each [dim, dim]
+        if new_key.endswith(".conv.in_proj.weight"):
+            for name, split_value in zip(
+                ["B_proj", "C_proj", "x_proj"], torch.chunk(value, 3, dim=0)
+            ):
+                converted[new_key.replace("in_proj", name)] = split_value
+        else:
+            converted[new_key] = value
+
+    # lm_head is not in safetensors (tied embeddings) — use tok_embeddings
+    if "output.weight" not in converted:
+        converted["output.weight"] = converted["tok_embeddings.weight"]
+
+    return converted
+
+
+def load_checkpoint(input_dir: str) -> Dict:
+    print("Loading checkpoint from safetensors...")
+    return load_file(os.path.join(input_dir, "model.safetensors"))
+
+
+def convert_weights(input_dir: str, output_file: str) -> None:
+    print("Loading checkpoint...")
+    sd = load_checkpoint(input_dir)
+    print("Converting weights...")
+    sd = lfm2_5_vl_to_meta(sd)
+    print("Saving checkpoint...")
+    torch.save(sd, output_file)
+    print(f"Saved {len(sd)} tensors to {output_file}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Convert LFM2.5-VL text decoder weights to Meta/ET format."
+    )
+    parser.add_argument(
+        "input_dir",
+        type=str,
+        help="Path to directory containing model.safetensors (HuggingFace LFM2-VL-1.6B).",
+    )
+    parser.add_argument(
+        "output",
+        type=str,
+        help="Path to the output .pt checkpoint file.",
+    )
+    args = parser.parse_args()
+    convert_weights(args.input_dir, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/models/lfm2_5_vl/convert_weights.py
+++ b/examples/models/lfm2_5_vl/convert_weights.py
@@ -70,8 +70,9 @@ def lfm2_5_vl_to_meta(state_dict: Dict[str, torch.Tensor]) -> Dict[str, torch.Te
 
         try:
             new_key = get_mapped_key(key, _LFM2_5_VL_TO_META)
-        except KeyError:
-            # Fallback: strip "model.language_model." prefix
+        except Exception:
+            # Fallback: strip "model.language_model." prefix.
+            # This covers in_proj (handled below) and any passthrough keys.
             new_key = key.removeprefix("model.language_model.")
 
         # Split conv in_proj: [3*dim, dim] -> B_proj, C_proj, x_proj each [dim, dim]

--- a/examples/models/lfm2_5_vl/export_lfm2_5_vl.py
+++ b/examples/models/lfm2_5_vl/export_lfm2_5_vl.py
@@ -184,14 +184,7 @@ def export_text_decoder(
             .export()
         )
 
-    with torch.no_grad():
-        decoder_ep = torch.export.export(
-            manager.pre_autograd_graph_module,
-            manager.example_inputs,
-            dynamic_shapes=manager._get_dynamic_shape(),
-            strict=True,
-        )
-    return decoder_ep
+    return manager.export_program
 
 
 def export_token_embedding(

--- a/examples/models/lfm2_5_vl/export_lfm2_5_vl.py
+++ b/examples/models/lfm2_5_vl/export_lfm2_5_vl.py
@@ -9,7 +9,7 @@ Export LFM2.5-VL-1.6B as a single multi-method PTE for ExecuTorch's
 generic MultimodalRunner (C++ llava_main).
 
 Methods:
-  vision_encoder  : [1, 3, 512, 512] f32 NCHW pixels [0,255] -> [1, 256, 2048] f32
+  vision_encoder  : [1, 3, 512, 512] f32 NCHW pixels [0,255] -> [1, 256, 2048] f32/f16
   token_embedding : [1, seq_len] i64                          -> [1, seq_len, 2048] f32
   text_decoder    : ([1, seq_len, 2048] f32, [seq_len] i64)   -> [1, 65536] f32
 
@@ -53,10 +53,7 @@ from executorch.exir import (
 )
 from executorch.exir.passes import MemoryPlanningPass
 from executorch.exir.passes.quant_fusion_pass import QuantFusionPass
-from executorch.exir.passes.sym_shape_eval_pass import (
-    ConstraintBasedSymShapeEvalPass,
-    HintBasedSymShapeEvalPass,
-)
+from executorch.exir.passes.sym_shape_eval_pass import ConstraintBasedSymShapeEvalPass
 from executorch.extension.llm.export.builder import DType, LLMEdgeManager
 from executorch.extension.llm.export.config.llm_config import LlmConfig
 from torch.export import Dim
@@ -87,14 +84,18 @@ class Lfm2p5VlEdgeManager(LLMEdgeManager):
         return self
 
 
-def export_image_encoder(lfm2) -> torch.export.ExportedProgram:
+def export_image_encoder(
+    lfm2, dtype: DType = DType.fp32
+) -> torch.export.ExportedProgram:
     """Export vision encoder as 'vision_encoder' method.
 
     Input:  [1, 3, 512, 512] float32 NCHW pixels in [0, 255]
-    Output: [1, 256, 2048]   float32 image embeddings
+    Output: [1, 256, 2048]   f32/f16 image embeddings
 
     Normalize + patch extraction are baked in so the C++ runner only
     needs to resize to 512x512 and pass the raw pixel buffer.
+    Weights are cast to dtype (fp16 halves the ~1.6 GB vision encoder).
+    The input pixel tensor always stays fp32.
     """
 
     class ImageEncoder(torch.nn.Module):
@@ -106,11 +107,16 @@ def export_image_encoder(lfm2) -> torch.export.ExportedProgram:
             return self.lfm2.image_embedding(images)
 
     encoder = ImageEncoder(lfm2)
+    if dtype != DType.fp32:
+        # Cast only the vision parts of the HF model, not text_model (KV cache buffers
+        # must stay in the text decoder's dtype, not the vision encoder's dtype).
+        lfm2.model_.model.vision_tower.to(dtype.to_torch_dtype())
+        lfm2.model_.model.multi_modal_projector.to(dtype.to_torch_dtype())
     example_pixels = torch.randint(
         0, 256, (1, 3, IMAGE_SIZE, IMAGE_SIZE), dtype=torch.float32
     )
 
-    logging.info("Exporting vision encoder...")
+    logging.info(f"Exporting vision encoder ({dtype.name})...")
     with torch.no_grad():
         ep = torch.export.export(encoder, (example_pixels,), strict=False)
     return ep
@@ -251,8 +257,10 @@ def export_all(
     if dtype != DType.fp32:
         lfm2 = lfm2.to(dtype.to_torch_dtype())
 
+    # Vision encoder: use fp16 when quantizing (halves ~1.6 GB SigLIP2) or when dtype=fp16
+    vision_dtype = DType.fp16 if (quantize or dtype == DType.fp16) else DType.fp32
     logging.info("[1/3] Exporting vision encoder...")
-    vision_ep = export_image_encoder(lfm2)
+    vision_ep = export_image_encoder(lfm2, vision_dtype)
 
     # Text decoder MUST come before token embedding (see export_token_embedding docstring)
     logging.info("[2/3] Exporting text decoder...")
@@ -304,7 +312,7 @@ def export_all(
             memory_planning_pass=MemoryPlanningPass(alloc_graph_input=False),
             sym_shape_eval_pass={
                 "vision_encoder": ConstraintBasedSymShapeEvalPass(),
-                "token_embedding": HintBasedSymShapeEvalPass(),
+                "token_embedding": ConstraintBasedSymShapeEvalPass(),
                 "text_decoder": ConstraintBasedSymShapeEvalPass(),
             },
         )

--- a/examples/models/lfm2_5_vl/export_lfm2_5_vl.py
+++ b/examples/models/lfm2_5_vl/export_lfm2_5_vl.py
@@ -88,9 +88,7 @@ class Lfm2p5VlEdgeManager(LLMEdgeManager):
         return self
 
 
-def export_image_encoder(
-    lfm2, quantize: bool = False
-) -> torch.export.ExportedProgram:
+def export_image_encoder(lfm2, quantize: bool = False) -> torch.export.ExportedProgram:
     """Export vision encoder as 'vision_encoder' method.
 
     Input:  [1, 3, 512, 512] float32 NCHW pixels in [0, 255]
@@ -120,9 +118,7 @@ def export_image_encoder(
 
     if quantize:
         logging.info("Exporting vision encoder (int8 dynamic quantized)...")
-        quantizer = XNNPACKQuantizer().set_global(
-            get_symmetric_quantization_config()
-        )
+        quantizer = XNNPACKQuantizer().set_global(get_symmetric_quantization_config())
         manager = (
             Lfm2p5VlEdgeManager(
                 model=encoder,
@@ -285,7 +281,7 @@ def export_all(
         lfm2 = lfm2.to(dtype.to_torch_dtype())
 
     logging.info("[1/3] Exporting vision encoder...")
-    vision_ep = export_image_encoder(lfm2, quantize)
+    vision_ep = export_image_encoder(lfm2, quantize=False)
 
     # Text decoder MUST come before token embedding (see export_token_embedding docstring)
     logging.info("[2/3] Exporting text decoder...")

--- a/examples/models/lfm2_5_vl/export_lfm2_5_vl.py
+++ b/examples/models/lfm2_5_vl/export_lfm2_5_vl.py
@@ -5,21 +5,25 @@
 # LICENSE file in the root directory of this source tree.
 
 """
-Export LFM2.5-VL-1.6B as a single multi-method PTE for ExecuTorch's
-generic MultimodalRunner (C++ llava_main).
+Export LFM2.5-VL as a single multi-method PTE for ExecuTorch's generic
+MultimodalRunner (C++ llava_main). Supports both LFM2.5-VL-1.6B (text dim
+2048) and LFM2.5-VL-450M (text dim 1024); the architecture config is picked
+from the bundled config/ directory based on --model_dir, or you can pass
+--params to point at a custom JSON.
 
-Methods:
-  vision_encoder  : [1, 3, 512, 512] f32 NCHW pixels [0,255] -> [1, 256, 2048] f32
-  token_embedding : [1, seq_len] i64                          -> [1, seq_len, 2048] f32
-  text_decoder    : ([1, seq_len, 2048] f32, [seq_len] i64)   -> [1, 65536] f32
+Methods (D = text hidden dim: 2048 for 1.6B, 1024 for 450M):
+  vision_encoder  : [1, 3, 512, 512] f32 NCHW pixels [0,255] -> [1, 256, D] f32
+  token_embedding : [1, seq_len] i64                          -> [1, seq_len, D] f32
+  text_decoder    : ([1, seq_len, D] f32, [seq_len] i64)      -> [1, 65536] f32
 
 Usage:
     python examples/models/lfm2_5_vl/export_lfm2_5_vl.py \
-        --model_dir /path/to/LFM2-VL-1.6B \
+        --model_dir LiquidAI/LFM2.5-VL-450M \
         [--dtype fp32|fp16] [--quantize] [--output lfm2_5_vl_xnnpack.pte]
 """
 
 import logging
+import os
 from argparse import ArgumentParser, BooleanOptionalAction
 from typing import Optional
 
@@ -65,6 +69,23 @@ from torch.nn.attention import SDPBackend
 
 FORMAT = "[%(levelname)s %(asctime)s %(filename)s:%(lineno)s] %(message)s"
 logging.basicConfig(level=logging.INFO, format=FORMAT)
+
+_CONFIG_DIR = os.path.join(os.path.dirname(__file__), "config")
+
+
+def _resolve_params_path(model_dir: str, params: Optional[str]) -> Optional[str]:
+    """Pick a bundled config based on model_dir if --params was not provided.
+
+    Returns None to fall back to model.py's default (1.6B).
+    """
+    if params is not None:
+        return params
+    name = model_dir.lower()
+    if "450m" in name:
+        return os.path.join(_CONFIG_DIR, "lfm2_5_vl_450m_config.json")
+    if "1.6b" in name or "1_6b" in name:
+        return os.path.join(_CONFIG_DIR, "lfm2_5_vl_1_6b_config.json")
+    return None
 
 
 class Lfm2p5VlEdgeManager(LLMEdgeManager):
@@ -354,11 +375,14 @@ def export_all(
 
 
 def main():
-    parser = ArgumentParser(description="Export LFM2.5-VL-1.6B to ExecuTorch")
+    parser = ArgumentParser(description="Export LFM2.5-VL to ExecuTorch")
     parser.add_argument(
         "--model_dir",
         default="LiquidAI/LFM2-VL-1.6B",
-        help="HuggingFace model ID or local path",
+        help=(
+            "HuggingFace model ID or local path. Supported: "
+            "LiquidAI/LFM2-VL-1.6B, LiquidAI/LFM2.5-VL-450M."
+        ),
     )
     parser.add_argument(
         "--dtype",
@@ -388,8 +412,8 @@ def main():
         "--params",
         default=None,
         help=(
-            "Path to model params JSON (architecture config). "
-            "Defaults to the bundled config/lfm2_5_vl_1_6b_config.json."
+            "Path to model params JSON (architecture config). When omitted, "
+            "the bundled 1.6B or 450M config is selected from --model_dir."
         ),
     )
     parser.add_argument(
@@ -400,8 +424,12 @@ def main():
     args = parser.parse_args()
 
     dtype = DType.fp16 if args.dtype == "fp16" else DType.fp32
-    suffix = ("_fp16" if dtype == DType.fp16 else "") + (
-        "_quantized" if args.quantize else ""
+    params_path = _resolve_params_path(args.model_dir, args.params)
+    size_tag = "_450m" if (params_path or "").endswith("450m_config.json") else ""
+    suffix = (
+        size_tag
+        + ("_fp16" if dtype == DType.fp16 else "")
+        + ("_quantized" if args.quantize else "")
     )
     output = args.output or f"lfm2_5_vl{suffix}_xnnpack.pte"
 
@@ -412,7 +440,7 @@ def main():
         args.quantize,
         args.max_seq_len,
         args.max_context_len,
-        args.params,
+        params_path,
     )
 
 

--- a/examples/models/lfm2_5_vl/export_lfm2_5_vl.py
+++ b/examples/models/lfm2_5_vl/export_lfm2_5_vl.py
@@ -9,7 +9,7 @@ Export LFM2.5-VL-1.6B as a single multi-method PTE for ExecuTorch's
 generic MultimodalRunner (C++ llava_main).
 
 Methods:
-  vision_encoder  : [1, 3, 512, 512] f32 NCHW pixels [0,255] -> [1, 256, 2048] f32/f16
+  vision_encoder  : [1, 3, 512, 512] f32 NCHW pixels [0,255] -> [1, 256, 2048] f32
   token_embedding : [1, seq_len] i64                          -> [1, seq_len, 2048] f32
   text_decoder    : ([1, seq_len, 2048] f32, [seq_len] i64)   -> [1, 65536] f32
 
@@ -28,6 +28,10 @@ from executorch.backends.xnnpack.partition.config.xnnpack_config import (
     ConfigPrecisionType,
 )
 from executorch.backends.xnnpack.partition.xnnpack_partitioner import XnnpackPartitioner
+from executorch.backends.xnnpack.quantizer.xnnpack_quantizer import (
+    XNNPACKQuantizer,
+    get_symmetric_quantization_config,
+)
 from executorch.examples.models.llama.export_llama_lib import (
     get_quantizer_and_quant_params,
 )
@@ -85,17 +89,20 @@ class Lfm2p5VlEdgeManager(LLMEdgeManager):
 
 
 def export_image_encoder(
-    lfm2, dtype: DType = DType.fp32
+    lfm2, quantize: bool = False
 ) -> torch.export.ExportedProgram:
     """Export vision encoder as 'vision_encoder' method.
 
     Input:  [1, 3, 512, 512] float32 NCHW pixels in [0, 255]
-    Output: [1, 256, 2048]   f32/f16 image embeddings
+    Output: [1, 256, 2048]   float32 image embeddings
 
     Normalize + patch extraction are baked in so the C++ runner only
     needs to resize to 512x512 and pass the raw pixel buffer.
-    Weights are cast to dtype (fp16 halves the ~1.6 GB vision encoder).
-    The input pixel tensor always stays fp32.
+
+    When quantize=True, mirrors LLaVA's export_image_encoder: uses
+    LLMEdgeManager.export().pt2e_quantize() so quantization happens on
+    the pre-autograd graph (aten.linear still intact), then re-exports
+    the quantized graph for to_edge_transform_and_lower.
     """
 
     class ImageEncoder(torch.nn.Module):
@@ -107,18 +114,38 @@ def export_image_encoder(
             return self.lfm2.image_embedding(images)
 
     encoder = ImageEncoder(lfm2)
-    if dtype != DType.fp32:
-        # Cast only the vision parts of the HF model, not text_model (KV cache buffers
-        # must stay in the text decoder's dtype, not the vision encoder's dtype).
-        lfm2.model_.model.vision_tower.to(dtype.to_torch_dtype())
-        lfm2.model_.model.multi_modal_projector.to(dtype.to_torch_dtype())
     example_pixels = torch.randint(
         0, 256, (1, 3, IMAGE_SIZE, IMAGE_SIZE), dtype=torch.float32
     )
 
-    logging.info(f"Exporting vision encoder ({dtype.name})...")
-    with torch.no_grad():
-        ep = torch.export.export(encoder, (example_pixels,), strict=False)
+    if quantize:
+        logging.info("Exporting vision encoder (int8 dynamic quantized)...")
+        quantizer = XNNPACKQuantizer().set_global(
+            get_symmetric_quantization_config()
+        )
+        manager = (
+            Lfm2p5VlEdgeManager(
+                model=encoder,
+                modelname="lfm2_5_vl_image_encoder",
+                max_seq_len=MAX_SEQ_LEN,
+                dtype=DType.fp32,
+                use_kv_cache=False,
+                example_inputs=(example_pixels,),
+            )
+            .export()
+            .pt2e_quantize([quantizer])
+        )
+        with torch.no_grad():
+            ep = torch.export.export(
+                manager.pre_autograd_graph_module,
+                manager.example_inputs,
+                strict=False,
+            )
+    else:
+        logging.info("Exporting vision encoder (fp32)...")
+        with torch.no_grad():
+            ep = torch.export.export(encoder, (example_pixels,), strict=False)
+
     return ep
 
 
@@ -257,10 +284,8 @@ def export_all(
     if dtype != DType.fp32:
         lfm2 = lfm2.to(dtype.to_torch_dtype())
 
-    # Vision encoder: use fp16 when quantizing (halves ~1.6 GB SigLIP2) or when dtype=fp16
-    vision_dtype = DType.fp16 if (quantize or dtype == DType.fp16) else DType.fp32
     logging.info("[1/3] Exporting vision encoder...")
-    vision_ep = export_image_encoder(lfm2, vision_dtype)
+    vision_ep = export_image_encoder(lfm2, quantize)
 
     # Text decoder MUST come before token embedding (see export_token_embedding docstring)
     logging.info("[2/3] Exporting text decoder...")

--- a/examples/models/lfm2_5_vl/export_lfm2_5_vl.py
+++ b/examples/models/lfm2_5_vl/export_lfm2_5_vl.py
@@ -234,9 +234,15 @@ def export_all(
     output: str,
     dtype: DType = DType.fp32,
     quantize: bool = False,
+    max_seq_len: int = MAX_SEQ_LEN,
+    max_context_len: int = MAX_SEQ_LEN,
 ) -> None:
     logging.info(f"Loading {model_dir}...")
-    lfm2_model = Lfm2p5VlModel(model_dir=model_dir)
+    lfm2_model = Lfm2p5VlModel(
+        model_dir=model_dir,
+        max_seq_len=max_seq_len,
+        max_context_len=max_context_len,
+    )
     lfm2 = lfm2_model.get_eager_model()
     if dtype != DType.fp32:
         lfm2 = lfm2.to(dtype.to_torch_dtype())
@@ -272,13 +278,13 @@ def export_all(
             else [XnnpackPartitioner()],
         },
         constant_methods={
-            "get_max_seq_len": MAX_SEQ_LEN,
-            "get_max_context_len": MAX_SEQ_LEN,
-            "get_n_layers": 16,
-            "get_vocab_size": 65536,
-            "use_kv_cache": True,
-            "use_sdpa_with_kv_cache": True,
-            "enable_dynamic_shape": False,
+            "get_max_seq_len": lfm2.text_model_args.max_seq_len,
+            "get_max_context_len": lfm2.text_model_args.max_context_len,
+            "get_n_layers": lfm2.text_model_args.n_layers,
+            "get_vocab_size": lfm2.text_model_args.vocab_size,
+            "use_kv_cache": lfm2.text_model_args.use_kv_cache,
+            "use_sdpa_with_kv_cache": lfm2.text_model_args.use_sdpa_with_kv_cache_op,
+            "enable_dynamic_shape": lfm2.text_model_args.enable_dynamic_shape,
             # EOS = <|im_end|> (token 7). Runner reads this from PTE rather than
             # relying on tokenizer default.
             "get_eos_ids": [7],
@@ -326,6 +332,18 @@ def main():
         help="Quantize decoder (8da4w) and embedding (int8)",
     )
     parser.add_argument(
+        "--max_seq_len",
+        type=int,
+        default=MAX_SEQ_LEN,
+        help=f"Maximum sequence length (default: {MAX_SEQ_LEN})",
+    )
+    parser.add_argument(
+        "--max_context_len",
+        type=int,
+        default=MAX_SEQ_LEN,
+        help=f"Maximum context length (default: {MAX_SEQ_LEN})",
+    )
+    parser.add_argument(
         "--output",
         default=None,
         help="Output PTE path (default: lfm2_5_vl[_fp16][_quantized]_xnnpack.pte)",
@@ -338,7 +356,7 @@ def main():
     )
     output = args.output or f"lfm2_5_vl{suffix}_xnnpack.pte"
 
-    export_all(args.model_dir, output, dtype, args.quantize)
+    export_all(args.model_dir, output, dtype, args.quantize, args.max_seq_len, args.max_context_len)
 
 
 if __name__ == "__main__":

--- a/examples/models/lfm2_5_vl/export_lfm2_5_vl.py
+++ b/examples/models/lfm2_5_vl/export_lfm2_5_vl.py
@@ -232,13 +232,14 @@ def export_token_embedding(
 
 def export_all(
     model_dir: str,
-    output: str,
+    output: Optional[str],
     dtype: DType = DType.fp32,
     quantize: bool = False,
     max_seq_len: int = MAX_SEQ_LEN,
     max_context_len: int = MAX_SEQ_LEN,
     params_path: Optional[str] = None,
-) -> None:
+    _return_program: bool = False,
+):
     logging.info(f"Loading {model_dir}...")
     lfm2_model = Lfm2p5VlModel(
         model_dir=model_dir,
@@ -309,8 +310,16 @@ def export_all(
         )
     )
 
+    for execution_plan in et_program._emitter_output.program.execution_plan:
+        logging.info(
+            f"Required memory for activation in bytes: {execution_plan.non_const_buffer_sizes}"
+        )
+
+    if _return_program:
+        return et_program
+
     logging.info(f"Saving {output}...")
-    with open(output, "wb") as f:
+    with open(output, "wb") as f:  # type: ignore[arg-type]
         et_program.write_to_file(f)
     logging.info(f"Saved {output}. Methods: {et_program.methods}")
 

--- a/examples/models/lfm2_5_vl/export_lfm2_5_vl.py
+++ b/examples/models/lfm2_5_vl/export_lfm2_5_vl.py
@@ -45,7 +45,11 @@ from executorch.examples.models.lfm2_5_vl.model import (
     MAX_SEQ_LEN,
     IMAGE_SIZE,
 )
-from executorch.exir import EdgeCompileConfig, ExecutorchBackendConfig, to_edge_transform_and_lower
+from executorch.exir import (
+    EdgeCompileConfig,
+    ExecutorchBackendConfig,
+    to_edge_transform_and_lower,
+)
 from executorch.exir.passes import MemoryPlanningPass
 from executorch.exir.passes.quant_fusion_pass import QuantFusionPass
 from executorch.exir.passes.sym_shape_eval_pass import (
@@ -101,7 +105,9 @@ def export_image_encoder(lfm2) -> torch.export.ExportedProgram:
             return self.lfm2.image_embedding(images)
 
     encoder = ImageEncoder(lfm2)
-    example_pixels = torch.randint(0, 256, (1, 3, IMAGE_SIZE, IMAGE_SIZE), dtype=torch.float32)
+    example_pixels = torch.randint(
+        0, 256, (1, 3, IMAGE_SIZE, IMAGE_SIZE), dtype=torch.float32
+    )
 
     logging.info("Exporting vision encoder...")
     with torch.no_grad():
@@ -125,7 +131,9 @@ def export_text_decoder(
             super().__init__()
             self.text_model = text_model
 
-        def forward(self, embeddings: torch.Tensor, input_pos: torch.Tensor) -> torch.Tensor:
+        def forward(
+            self, embeddings: torch.Tensor, input_pos: torch.Tensor
+        ) -> torch.Tensor:
             return self.text_model(None, {"input_pos": input_pos}, embeddings)
 
     decoder = TextDecoder(lfm2.text_model)
@@ -259,10 +267,18 @@ def export_all(
                     per_op_mode=True,
                 ),
                 XnnpackPartitioner(),
-            ] if quantize else [XnnpackPartitioner()],
+            ]
+            if quantize
+            else [XnnpackPartitioner()],
         },
         constant_methods={
             "get_max_seq_len": MAX_SEQ_LEN,
+            "get_max_context_len": MAX_SEQ_LEN,
+            "get_n_layers": 16,
+            "get_vocab_size": 65536,
+            "use_kv_cache": True,
+            "use_sdpa_with_kv_cache": True,
+            "enable_dynamic_shape": False,
             # EOS = <|im_end|> (token 7). Runner reads this from PTE rather than
             # relying on tokenizer default.
             "get_eos_ids": [7],
@@ -317,7 +333,9 @@ def main():
     args = parser.parse_args()
 
     dtype = DType.fp16 if args.dtype == "fp16" else DType.fp32
-    suffix = ("_fp16" if dtype == DType.fp16 else "") + ("_quantized" if args.quantize else "")
+    suffix = ("_fp16" if dtype == DType.fp16 else "") + (
+        "_quantized" if args.quantize else ""
+    )
     output = args.output or f"lfm2_5_vl{suffix}_xnnpack.pte"
 
     export_all(args.model_dir, output, dtype, args.quantize)

--- a/examples/models/lfm2_5_vl/export_lfm2_5_vl.py
+++ b/examples/models/lfm2_5_vl/export_lfm2_5_vl.py
@@ -216,7 +216,7 @@ def export_token_embedding(
     example_ids = torch.zeros(1, MAX_SEQ_LEN, dtype=torch.int64)
     with torch.no_grad():
         ep = torch.export.export(
-            embed_module, (example_ids,), dynamic_shapes=dynamic_shapes, strict=True
+            embed_module, (example_ids,), dynamic_shapes=dynamic_shapes, strict=False
         )
     return ep
 

--- a/examples/models/lfm2_5_vl/export_lfm2_5_vl.py
+++ b/examples/models/lfm2_5_vl/export_lfm2_5_vl.py
@@ -1,0 +1,334 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Export LFM2.5-VL-1.6B as a single multi-method PTE for ExecuTorch's
+generic MultimodalRunner (C++ llava_main).
+
+Methods:
+  vision_encoder  : [1, 3, 512, 512] f32 NCHW pixels [0,255] -> [1, 256, 2048] f32
+  token_embedding : [1, seq_len] i64                          -> [1, seq_len, 2048] f32
+  text_decoder    : ([1, seq_len, 2048] f32, [seq_len] i64)   -> [1, 65536] f32
+
+Usage:
+    python examples/models/lfm2_5_vl/export_lfm2_5_vl.py \
+        --model_dir /path/to/LFM2-VL-1.6B \
+        [--dtype fp32|fp16] [--quantize] [--output lfm2_5_vl_xnnpack.pte]
+"""
+
+import logging
+from argparse import ArgumentParser, BooleanOptionalAction
+
+import torch
+from executorch.backends.xnnpack.partition.config.xnnpack_config import (
+    ConfigPrecisionType,
+)
+from executorch.backends.xnnpack.partition.xnnpack_partitioner import XnnpackPartitioner
+from executorch.examples.models.llama.export_llama_lib import (
+    get_quantizer_and_quant_params,
+)
+from executorch.examples.models.llama.source_transformation.custom_kv_cache import (
+    replace_kv_cache_with_custom_kv_cache,
+)
+from executorch.examples.models.llama.source_transformation.quantize import (
+    EmbeddingQuantHandler,
+    get_quant_weight_transform,
+)
+from executorch.examples.models.llama.source_transformation.sdpa import (
+    replace_sdpa_with_custom_op,
+)
+from executorch.examples.models.lfm2_5_vl.model import (
+    Lfm2p5VlModel,
+    MAX_SEQ_LEN,
+    IMAGE_SIZE,
+)
+from executorch.exir import EdgeCompileConfig, ExecutorchBackendConfig, to_edge_transform_and_lower
+from executorch.exir.passes import MemoryPlanningPass
+from executorch.exir.passes.quant_fusion_pass import QuantFusionPass
+from executorch.exir.passes.sym_shape_eval_pass import (
+    ConstraintBasedSymShapeEvalPass,
+    HintBasedSymShapeEvalPass,
+)
+from executorch.extension.llm.export.builder import DType, LLMEdgeManager
+from executorch.extension.llm.export.config.llm_config import LlmConfig
+from torch.export import Dim
+from torch.nn.attention import SDPBackend
+
+FORMAT = "[%(levelname)s %(asctime)s %(filename)s:%(lineno)s] %(message)s"
+logging.basicConfig(level=logging.INFO, format=FORMAT)
+
+
+class Lfm2p5VlEdgeManager(LLMEdgeManager):
+    """LLMEdgeManager subclass for LFM2.5-VL.
+
+    Overrides export() to use SDPBackend.MATH (avoids dynamo tracing errors)
+    and strict=False (required for hybrid conv layer buffer mutations).
+    Mirrors LlavaEdgeManager in examples/models/llava/export_llava.py.
+    """
+
+    def export(self) -> "Lfm2p5VlEdgeManager":
+        dynamic_shape = self._get_dynamic_shape()
+        with torch.nn.attention.sdpa_kernel([SDPBackend.MATH]), torch.no_grad():
+            self.export_program = torch.export.export(
+                self.model,
+                self.example_inputs,
+                dynamic_shapes=dynamic_shape,
+                strict=False,
+            )
+            self.pre_autograd_graph_module = self.export_program.module()
+        return self
+
+
+def export_image_encoder(lfm2) -> torch.export.ExportedProgram:
+    """Export vision encoder as 'vision_encoder' method.
+
+    Input:  [1, 3, 512, 512] float32 NCHW pixels in [0, 255]
+    Output: [1, 256, 2048]   float32 image embeddings
+
+    Normalize + patch extraction are baked in so the C++ runner only
+    needs to resize to 512x512 and pass the raw pixel buffer.
+    """
+
+    class ImageEncoder(torch.nn.Module):
+        def __init__(self, lfm2):
+            super().__init__()
+            self.lfm2 = lfm2
+
+        def forward(self, images: torch.Tensor) -> torch.Tensor:
+            return self.lfm2.image_embedding(images)
+
+    encoder = ImageEncoder(lfm2)
+    example_pixels = torch.randint(0, 256, (1, 3, IMAGE_SIZE, IMAGE_SIZE), dtype=torch.float32)
+
+    logging.info("Exporting vision encoder...")
+    with torch.no_grad():
+        ep = torch.export.export(encoder, (example_pixels,), strict=False)
+    return ep
+
+
+def export_text_decoder(
+    lfm2,
+    quantize: bool,
+    dtype: DType = DType.fp32,
+) -> torch.export.ExportedProgram:
+    """Export hybrid LFM2.5 decoder as 'text_decoder' method.
+
+    Uses Lfm2p5VlEdgeManager (strict=False, SDPBackend.MATH).
+    enable_dynamic_shape=False in ModelArgs avoids .item() in rope.get_freqs.
+    """
+
+    class TextDecoder(torch.nn.Module):
+        def __init__(self, text_model):
+            super().__init__()
+            self.text_model = text_model
+
+        def forward(self, embeddings: torch.Tensor, input_pos: torch.Tensor) -> torch.Tensor:
+            return self.text_model(None, {"input_pos": input_pos}, embeddings)
+
+    decoder = TextDecoder(lfm2.text_model)
+    dim = lfm2.text_model_args.dim
+    dummy_seq = 8
+    dummy_embeddings = torch.randn(1, dummy_seq, dim, dtype=dtype.to_torch_dtype())
+    dummy_input_pos = torch.arange(dummy_seq, dtype=torch.int64)
+    token_dim = Dim("token_dim", min=1, max=MAX_SEQ_LEN)
+    dynamic_shapes = ({1: token_dim}, {0: token_dim})
+
+    manager = Lfm2p5VlEdgeManager(
+        model=decoder,
+        modelname="lfm2_5_vl_text_decoder",
+        max_seq_len=MAX_SEQ_LEN,
+        dtype=dtype,
+        use_kv_cache=True,
+        example_inputs=(dummy_embeddings, dummy_input_pos),
+        dynamic_shapes=dynamic_shapes,
+    )
+
+    source_transforms = [
+        replace_kv_cache_with_custom_kv_cache,
+        replace_sdpa_with_custom_op,
+    ]
+
+    if quantize:
+        llm_config = LlmConfig()
+        llm_config.quantization.qmode = "8da4w"
+        llm_config.quantization.group_size = 128
+        quant_transform = get_quant_weight_transform(
+            quantization_mode=llm_config.quantization.qmode,
+            group_size=llm_config.quantization.group_size,
+            computation_dtype=dtype,
+            checkpoint_path=None,
+            tokenizer_path=None,
+            calibration_tasks=None,
+            calibration_limit=None,
+            calibration_seq_length=None,
+        )
+        _, quantizers, _ = get_quantizer_and_quant_params(llm_config)
+        source_transforms.append(quant_transform)
+        logging.info("Exporting text decoder (8da4w quantized)...")
+        manager = (
+            manager.set_output_dir("./")
+            .to_dtype(dtype)
+            .source_transform(source_transforms)
+            .export()
+            .pt2e_quantize(quantizers)
+        )
+    else:
+        logging.info("Exporting text decoder (fp32)...")
+        manager = (
+            manager.set_output_dir("./")
+            .to_dtype(dtype)
+            .source_transform(source_transforms)
+            .export()
+        )
+
+    with torch.no_grad():
+        decoder_ep = torch.export.export(
+            manager.pre_autograd_graph_module,
+            manager.example_inputs,
+            dynamic_shapes=manager._get_dynamic_shape(),
+            strict=True,
+        )
+    return decoder_ep
+
+
+def export_token_embedding(
+    lfm2,
+    quantize: bool,
+) -> torch.export.ExportedProgram:
+    """Export token embedding table as 'token_embedding' method.
+
+    Uses fixed MAX_SEQ_LEN=2048 input buffer. The C++ runner pads shorter
+    sequences to this length before calling, then slices the output back.
+
+    IMPORTANT: call this AFTER export_text_decoder. EmbeddingQuantHandler
+    mutates model.embed_tokens in-place (replaces fp32 weight with int8).
+    """
+    language_model = lfm2.model_.model.language_model
+    token_dim = Dim("token_dim_1", min=1, max=MAX_SEQ_LEN)
+    dynamic_shapes = [{1: token_dim}]
+
+    if quantize:
+        logging.info("Exporting token embedding (int8 quantized)...")
+        quantized_lm = EmbeddingQuantHandler(
+            language_model, bitwidth=8, group_size=32, packed=False
+        ).quantized_model()
+        embed_module = quantized_lm.embed_tokens
+    else:
+        logging.info("Exporting token embedding (fp32)...")
+        embed_module = language_model.get_input_embeddings()
+
+    example_ids = torch.zeros(1, MAX_SEQ_LEN, dtype=torch.int64)
+    with torch.no_grad():
+        ep = torch.export.export(
+            embed_module, (example_ids,), dynamic_shapes=dynamic_shapes, strict=True
+        )
+    return ep
+
+
+def export_all(
+    model_dir: str,
+    output: str,
+    dtype: DType = DType.fp32,
+    quantize: bool = False,
+) -> None:
+    logging.info(f"Loading {model_dir}...")
+    lfm2_model = Lfm2p5VlModel(model_dir=model_dir)
+    lfm2 = lfm2_model.get_eager_model()
+    if dtype != DType.fp32:
+        lfm2 = lfm2.to(dtype.to_torch_dtype())
+
+    logging.info("[1/3] Exporting vision encoder...")
+    vision_ep = export_image_encoder(lfm2)
+
+    # Text decoder MUST come before token embedding (see export_token_embedding docstring)
+    logging.info("[2/3] Exporting text decoder...")
+    decoder_ep = export_text_decoder(lfm2, quantize, dtype)
+
+    logging.info("[3/3] Exporting token embedding...")
+    token_ep = export_token_embedding(lfm2, quantize)
+
+    logging.info("Lowering to Edge IR + XNNPACK...")
+    lowered = to_edge_transform_and_lower(
+        {
+            "vision_encoder": vision_ep,
+            "token_embedding": token_ep,
+            "text_decoder": decoder_ep,
+        },
+        partitioner={
+            "vision_encoder": [XnnpackPartitioner()],
+            "token_embedding": [XnnpackPartitioner()],
+            "text_decoder": [
+                XnnpackPartitioner(
+                    config_precisions=ConfigPrecisionType.DYNAMIC_QUANT,
+                    per_op_mode=True,
+                ),
+                XnnpackPartitioner(),
+            ] if quantize else [XnnpackPartitioner()],
+        },
+        constant_methods={
+            "get_max_seq_len": MAX_SEQ_LEN,
+            # EOS = <|im_end|> (token 7). Runner reads this from PTE rather than
+            # relying on tokenizer default.
+            "get_eos_ids": [7],
+        },
+        compile_config=EdgeCompileConfig(_check_ir_validity=False),
+    )
+
+    logging.info("Finalizing ExecuTorch program...")
+    et_program = lowered.to_executorch(
+        ExecutorchBackendConfig(
+            extract_delegate_segments=True,
+            passes=[QuantFusionPass()] if quantize else [],
+            memory_planning_pass=MemoryPlanningPass(alloc_graph_input=False),
+            sym_shape_eval_pass={
+                "vision_encoder": ConstraintBasedSymShapeEvalPass(),
+                "token_embedding": HintBasedSymShapeEvalPass(),
+                "text_decoder": ConstraintBasedSymShapeEvalPass(),
+            },
+        )
+    )
+
+    logging.info(f"Saving {output}...")
+    with open(output, "wb") as f:
+        et_program.write_to_file(f)
+    logging.info(f"Saved {output}. Methods: {et_program.methods}")
+
+
+def main():
+    parser = ArgumentParser(description="Export LFM2.5-VL-1.6B to ExecuTorch")
+    parser.add_argument(
+        "--model_dir",
+        default="LiquidAI/LFM2-VL-1.6B",
+        help="HuggingFace model ID or local path",
+    )
+    parser.add_argument(
+        "--dtype",
+        default="fp32",
+        choices=["fp32", "fp16"],
+        help="Model dtype (default: fp32)",
+    )
+    parser.add_argument(
+        "--quantize",
+        default=False,
+        action=BooleanOptionalAction,
+        help="Quantize decoder (8da4w) and embedding (int8)",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Output PTE path (default: lfm2_5_vl[_fp16][_quantized]_xnnpack.pte)",
+    )
+    args = parser.parse_args()
+
+    dtype = DType.fp16 if args.dtype == "fp16" else DType.fp32
+    suffix = ("_fp16" if dtype == DType.fp16 else "") + ("_quantized" if args.quantize else "")
+    output = args.output or f"lfm2_5_vl{suffix}_xnnpack.pte"
+
+    export_all(args.model_dir, output, dtype, args.quantize)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/models/lfm2_5_vl/export_lfm2_5_vl.py
+++ b/examples/models/lfm2_5_vl/export_lfm2_5_vl.py
@@ -21,6 +21,7 @@ Usage:
 
 import logging
 from argparse import ArgumentParser, BooleanOptionalAction
+from typing import Optional
 
 import torch
 from executorch.backends.xnnpack.partition.config.xnnpack_config import (
@@ -236,12 +237,14 @@ def export_all(
     quantize: bool = False,
     max_seq_len: int = MAX_SEQ_LEN,
     max_context_len: int = MAX_SEQ_LEN,
+    params_path: Optional[str] = None,
 ) -> None:
     logging.info(f"Loading {model_dir}...")
     lfm2_model = Lfm2p5VlModel(
         model_dir=model_dir,
         max_seq_len=max_seq_len,
         max_context_len=max_context_len,
+        params_path=params_path,
     )
     lfm2 = lfm2_model.get_eager_model()
     if dtype != DType.fp32:
@@ -344,6 +347,14 @@ def main():
         help=f"Maximum context length (default: {MAX_SEQ_LEN})",
     )
     parser.add_argument(
+        "--params",
+        default=None,
+        help=(
+            "Path to model params JSON (architecture config). "
+            "Defaults to the bundled config/lfm2_5_vl_1_6b_config.json."
+        ),
+    )
+    parser.add_argument(
         "--output",
         default=None,
         help="Output PTE path (default: lfm2_5_vl[_fp16][_quantized]_xnnpack.pte)",
@@ -356,7 +367,15 @@ def main():
     )
     output = args.output or f"lfm2_5_vl{suffix}_xnnpack.pte"
 
-    export_all(args.model_dir, output, dtype, args.quantize, args.max_seq_len, args.max_context_len)
+    export_all(
+        args.model_dir,
+        output,
+        dtype,
+        args.quantize,
+        args.max_seq_len,
+        args.max_context_len,
+        args.params,
+    )
 
 
 if __name__ == "__main__":

--- a/examples/models/lfm2_5_vl/model.py
+++ b/examples/models/lfm2_5_vl/model.py
@@ -7,9 +7,10 @@
 # An ExecuTorch-friendly implementation of LFM2.5-VL-1.6B.
 # Mirrors examples/models/llava/model.py in structure.
 
+import json
 import math
-import re
-from typing import Any, Dict, Optional, Tuple
+import os
+from typing import Optional, Tuple
 
 import torch
 import torch.nn.functional as F
@@ -27,65 +28,34 @@ from transformers import AutoModelForImageTextToText, AutoProcessor
 
 
 MAX_SEQ_LEN = 2048
-IMAGE_SIZE = 512      # 512x512 -> 32x32 patches -> 256 tokens after projector
+IMAGE_SIZE = 512  # 512x512 -> 32x32 patches -> 256 tokens after projector
 PATCH_SIZE = 16
 FIXED_H, FIXED_W = 32, 32
 
-# LFM2.5-VL-1.6B layer pattern: 10 conv + 6 full_attention
-LAYER_TYPES = [
-    "conv", "conv", "full_attention",
-    "conv", "conv", "full_attention",
-    "conv", "conv", "full_attention",
-    "conv", "full_attention",
-    "conv", "full_attention",
-    "conv", "full_attention",
-    "conv",
-]
+# Path to the bundled config for LFM2.5-VL-1.6B, used when no --params is given.
+_DEFAULT_PARAMS = os.path.join(
+    os.path.dirname(__file__), "config", "lfm2_5_vl_1_6b_config.json"
+)
 
 
 class Lfm2p5Vl(torch.nn.Module):
     def __init__(
         self,
         hf_model: AutoModelForImageTextToText,
-        use_sdpa_with_kv_cache_op: bool = True,
-        max_context_len: int = MAX_SEQ_LEN,
-        max_seq_len: int = MAX_SEQ_LEN,
+        params: ModelArgs,
     ):
         super().__init__()
-        self.use_sdpa_with_kv_cache_op = use_sdpa_with_kv_cache_op
         self.model_ = hf_model
-
-        # Build ET text model
-        self.text_model_args = ModelArgs(
-            dim=2048,
-            n_layers=16,
-            n_heads=32,
-            n_kv_heads=8,
-            vocab_size=65536,
-            hidden_dim=8192,
-            ffn_dim_multiplier=1,
-            norm_eps=1e-5,
-            max_batch_size=1,
-            max_seq_len=max_seq_len,
-            max_context_len=max_context_len,
-            use_kv_cache=True,
-            use_sdpa_with_kv_cache_op=use_sdpa_with_kv_cache_op,
-            use_hf_rope=True,
-            # CRITICAL: False avoids .item() in rope.get_freqs which crashes FakeTensor export
-            enable_dynamic_shape=False,
-            rope_theta=1000000.0,
-            use_qk_norm=True,
-            qk_norm_before_rope=True,
-            layer_types=LAYER_TYPES,
-        )
+        self.text_model_args = params
         self.text_model = construct_transformer(self.text_model_args)
 
         # Source transforms must happen before load_state_dict so buffers exist
-        if use_sdpa_with_kv_cache_op:
+        if params.use_sdpa_with_kv_cache_op:
             self.text_model = replace_kv_cache_with_custom_kv_cache(self.text_model)
             self.text_model = replace_sdpa_with_custom_op(self.text_model)
 
-        # Load translated weights (strict=False: KV/conv buffers are runtime state)
+        # Load translated weights from HF model (strict=False: KV/conv buffers
+        # are runtime state initialised as zeros by construct_transformer)
         self.text_model.load_state_dict(
             state_dict=self._translate_weights(),
             strict=False,
@@ -120,56 +90,26 @@ class Lfm2p5Vl(torch.nn.Module):
             _patched_resize
         )
 
-    def _translate_weights(self) -> Dict[str, Any]:
+    def _translate_weights(self):
         """Translate HF LFM2-VL state dict keys to ET construct_transformer format.
 
         Handles all layer types (conv + full_attention) and the critical
         in_proj [3*dim, dim] -> three [dim, dim] split for conv layers.
         """
-        sd = {}
+        from executorch.examples.models.lfm2_5_vl.convert_weights import (
+            lfm2_5_vl_to_meta,
+        )
+
+        # Build a flat state dict with the "model.language_model." prefix that
+        # convert_weights expects (same layout as the HF safetensors file).
+        raw = {}
         for k, v in self.model_.model.language_model.state_dict().items():
-            sd[k] = v
+            raw[f"model.language_model.{k}"] = v
+        # lm_head is a separate top-level module in the VL wrapper
         for k, v in self.model_.lm_head.state_dict().items():
-            sd[f"lm_head.{k}"] = v
+            raw[f"model.language_model.lm_head.{k}"] = v
 
-        # Simple renames (applied via regex on full key)
-        key_map = {
-            r"^embed_tokens\.": "tok_embeddings.",
-            r"^embedding_norm\.": "norm.",
-            r"^lm_head\.": "output.",
-            r"^layers\.([0-9]+)\.operator_norm\.": r"layers.\1.attention_norm.",
-            r"^layers\.([0-9]+)\.self_attn\.q_proj\.": r"layers.\1.attention.wq.",
-            r"^layers\.([0-9]+)\.self_attn\.k_proj\.": r"layers.\1.attention.wk.",
-            r"^layers\.([0-9]+)\.self_attn\.v_proj\.": r"layers.\1.attention.wv.",
-            r"^layers\.([0-9]+)\.self_attn\.out_proj\.": r"layers.\1.attention.wo.",
-            r"^layers\.([0-9]+)\.self_attn\.q_layernorm\.": r"layers.\1.attention.q_norm_fn.",
-            r"^layers\.([0-9]+)\.self_attn\.k_layernorm\.": r"layers.\1.attention.k_norm_fn.",
-        }
-
-        def remap(key: str) -> Optional[str]:
-            for pattern, replacement in key_map.items():
-                new_key = re.sub(pattern, replacement, key)
-                if new_key != key:
-                    return new_key
-            return key
-
-        out = {}
-        for key, val in sd.items():
-            # Handle in_proj: split [3*dim, dim] -> B_proj, C_proj, x_proj each [dim, dim]
-            m = re.match(r"^layers\.([0-9]+)\.conv\.in_proj\.weight$", key)
-            if m:
-                n = m.group(1)
-                B, C, x = torch.chunk(val, 3, dim=0)
-                out[f"layers.{n}.conv.B_proj.weight"] = B
-                out[f"layers.{n}.conv.C_proj.weight"] = C
-                out[f"layers.{n}.conv.x_proj.weight"] = x
-                continue
-
-            new_key = remap(key)
-            if new_key is not None:
-                out[new_key] = val
-
-        return out
+        return lfm2_5_vl_to_meta(raw)
 
     def embed_tokens(self, tokens: torch.Tensor) -> torch.Tensor:
         return self.model_.model.language_model.get_input_embeddings()(tokens)
@@ -186,7 +126,9 @@ class Lfm2p5Vl(torch.nn.Module):
 
         # Extract 16x16 patches in HW-major order -> [1, 1024, PATCH_SIZE*PATCH_SIZE*3]
         x = x.unfold(2, PATCH_SIZE, PATCH_SIZE).unfold(3, PATCH_SIZE, PATCH_SIZE)
-        x = x.permute(0, 2, 3, 4, 5, 1).reshape(1, FIXED_H * FIXED_W, PATCH_SIZE * PATCH_SIZE * 3)
+        x = x.permute(0, 2, 3, 4, 5, 1).reshape(
+            1, FIXED_H * FIXED_W, PATCH_SIZE * PATCH_SIZE * 3
+        )
 
         FULL_MASK = torch.ones(1, FIXED_H * FIXED_W, dtype=torch.int32)
         out = self.model_.model.vision_tower(
@@ -198,7 +140,7 @@ class Lfm2p5Vl(torch.nn.Module):
         feats = out.last_hidden_state  # [1, 1024, vision_hidden_size]
         feats = feats.reshape(feats.shape[0], FIXED_H, FIXED_W, -1)
         projected = self.model_.model.multi_modal_projector(feats)  # [1, 16, 16, 2048]
-        return projected.reshape(1, -1, projected.shape[-1])        # [1, 256, 2048]
+        return projected.reshape(1, -1, projected.shape[-1])  # [1, 256, 2048]
 
     def image_embedding(self, images: torch.Tensor) -> torch.Tensor:
         return self.encode_images(images)
@@ -242,12 +184,33 @@ class Lfm2p5VlModel(EagerModelBase):
         use_sdpa_with_kv_cache_op: bool = True,
         max_seq_len: int = MAX_SEQ_LEN,
         max_context_len: int = MAX_SEQ_LEN,
+        # HF auto-load path (model ID or local dir containing the full VL checkpoint)
         model_dir: str = "LiquidAI/LFM2-VL-1.6B",
+        # Path to params JSON (architecture config). Defaults to bundled
+        # config/lfm2_5_vl_1_6b_config.json if not provided.
+        params_path: Optional[str] = None,
     ):
         self.use_sdpa_with_kv_cache_op = use_sdpa_with_kv_cache_op
         self.max_context_len = max_context_len
         self.max_seq_len = max_seq_len
         self.model_dir = model_dir
+
+        # Load architecture config from JSON (mirrors LLaMA model.py pattern)
+        resolved_params = params_path or _DEFAULT_PARAMS
+        with open(resolved_params, "r") as f:
+            params = json.loads(f.read())
+
+        self.text_model_args = ModelArgs(
+            max_batch_size=1,
+            max_seq_len=max_seq_len,
+            max_context_len=max_context_len,
+            use_kv_cache=True,
+            use_sdpa_with_kv_cache_op=use_sdpa_with_kv_cache_op,
+            # CRITICAL: False avoids .item() in rope.get_freqs which crashes
+            # FakeTensor export via to_edge_transform_and_lower
+            enable_dynamic_shape=False,
+            **params,
+        )
 
         self.hf_model = AutoModelForImageTextToText.from_pretrained(
             model_dir, device_map="cpu", torch_dtype=torch.float32
@@ -270,12 +233,7 @@ class Lfm2p5VlModel(EagerModelBase):
         self.example_image = None
 
     def get_eager_model(self) -> torch.nn.Module:
-        model = Lfm2p5Vl(
-            self.hf_model,
-            self.use_sdpa_with_kv_cache_op,
-            self.max_context_len,
-            self.max_seq_len,
-        )
+        model = Lfm2p5Vl(self.hf_model, self.text_model_args)
         model.to(dtype=torch.float32)
         return model
 

--- a/examples/models/lfm2_5_vl/model.py
+++ b/examples/models/lfm2_5_vl/model.py
@@ -1,0 +1,320 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# An ExecuTorch-friendly implementation of LFM2.5-VL-1.6B.
+# Mirrors examples/models/llava/model.py in structure.
+
+import math
+import re
+from typing import Any, Dict, Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+from executorch.examples.models.llama.llama_transformer import construct_transformer
+from executorch.examples.models.llama.model_args import ModelArgs
+from executorch.examples.models.llama.source_transformation.custom_kv_cache import (
+    replace_kv_cache_with_custom_kv_cache,
+)
+from executorch.examples.models.llama.source_transformation.sdpa import (
+    replace_sdpa_with_custom_op,
+)
+from executorch.examples.models.model_base import EagerModelBase
+from torch.export import Dim
+from transformers import AutoModelForImageTextToText, AutoProcessor
+
+
+MAX_SEQ_LEN = 2048
+IMAGE_SIZE = 512      # 512x512 -> 32x32 patches -> 256 tokens after projector
+PATCH_SIZE = 16
+FIXED_H, FIXED_W = 32, 32
+
+# LFM2.5-VL-1.6B layer pattern: 10 conv + 6 full_attention
+LAYER_TYPES = [
+    "conv", "conv", "full_attention",
+    "conv", "conv", "full_attention",
+    "conv", "conv", "full_attention",
+    "conv", "full_attention",
+    "conv", "full_attention",
+    "conv", "full_attention",
+    "conv",
+]
+
+
+class Lfm2p5Vl(torch.nn.Module):
+    def __init__(
+        self,
+        hf_model: AutoModelForImageTextToText,
+        use_sdpa_with_kv_cache_op: bool = True,
+        max_context_len: int = MAX_SEQ_LEN,
+        max_seq_len: int = MAX_SEQ_LEN,
+    ):
+        super().__init__()
+        self.use_sdpa_with_kv_cache_op = use_sdpa_with_kv_cache_op
+        self.model_ = hf_model
+
+        # Build ET text model
+        self.text_model_args = ModelArgs(
+            dim=2048,
+            n_layers=16,
+            n_heads=32,
+            n_kv_heads=8,
+            vocab_size=65536,
+            hidden_dim=8192,
+            ffn_dim_multiplier=1,
+            norm_eps=1e-5,
+            max_batch_size=1,
+            max_seq_len=max_seq_len,
+            max_context_len=max_context_len,
+            use_kv_cache=True,
+            use_sdpa_with_kv_cache_op=use_sdpa_with_kv_cache_op,
+            use_hf_rope=True,
+            # CRITICAL: False avoids .item() in rope.get_freqs which crashes FakeTensor export
+            enable_dynamic_shape=False,
+            rope_theta=1000000.0,
+            use_qk_norm=True,
+            qk_norm_before_rope=True,
+            layer_types=LAYER_TYPES,
+        )
+        self.text_model = construct_transformer(self.text_model_args)
+
+        # Source transforms must happen before load_state_dict so buffers exist
+        if use_sdpa_with_kv_cache_op:
+            self.text_model = replace_kv_cache_with_custom_kv_cache(self.text_model)
+            self.text_model = replace_sdpa_with_custom_op(self.text_model)
+
+        # Load translated weights (strict=False: KV/conv buffers are runtime state)
+        self.text_model.load_state_dict(
+            state_dict=self._translate_weights(),
+            strict=False,
+            assign=True,
+        )
+
+        # Pre-compute bilinear PE for 32x32 grid and patch the resize method.
+        # This avoids dynamic F.interpolate calls that are not exportable.
+        self._patch_positional_embeddings()
+
+    def _patch_positional_embeddings(self) -> None:
+        orig = self.model_.model.vision_tower.vision_model.embeddings.position_embedding.weight.data
+        num_positions, dim = orig.shape
+        sqrt_num = int(math.sqrt(num_positions))
+        grid = orig.reshape(sqrt_num, sqrt_num, dim)
+        resized = F.interpolate(
+            grid.permute(2, 0, 1).unsqueeze(0),
+            size=(FIXED_H, FIXED_W),
+            mode="bilinear",
+            align_corners=False,
+            antialias=True,
+        )
+        # .contiguous() prevents dim_order mismatches in portable aten::add.out kernel
+        precomputed_pe = (
+            resized.squeeze(0).permute(1, 2, 0).reshape(FIXED_H * FIXED_W, dim).contiguous()
+        )
+
+        def _patched_resize(positional_embeddings, height=None, width=None, max_length=None):
+            return precomputed_pe
+
+        self.model_.model.vision_tower.vision_model.embeddings.resize_positional_embeddings = (
+            _patched_resize
+        )
+
+    def _translate_weights(self) -> Dict[str, Any]:
+        """Translate HF LFM2-VL state dict keys to ET construct_transformer format.
+
+        Handles all layer types (conv + full_attention) and the critical
+        in_proj [3*dim, dim] -> three [dim, dim] split for conv layers.
+        """
+        sd = {}
+        for k, v in self.model_.model.language_model.state_dict().items():
+            sd[k] = v
+        for k, v in self.model_.lm_head.state_dict().items():
+            sd[f"lm_head.{k}"] = v
+
+        # Simple renames (applied via regex on full key)
+        key_map = {
+            r"^embed_tokens\.": "tok_embeddings.",
+            r"^embedding_norm\.": "norm.",
+            r"^lm_head\.": "output.",
+            r"^layers\.([0-9]+)\.operator_norm\.": r"layers.\1.attention_norm.",
+            r"^layers\.([0-9]+)\.self_attn\.q_proj\.": r"layers.\1.attention.wq.",
+            r"^layers\.([0-9]+)\.self_attn\.k_proj\.": r"layers.\1.attention.wk.",
+            r"^layers\.([0-9]+)\.self_attn\.v_proj\.": r"layers.\1.attention.wv.",
+            r"^layers\.([0-9]+)\.self_attn\.out_proj\.": r"layers.\1.attention.wo.",
+            r"^layers\.([0-9]+)\.self_attn\.q_layernorm\.": r"layers.\1.attention.q_norm_fn.",
+            r"^layers\.([0-9]+)\.self_attn\.k_layernorm\.": r"layers.\1.attention.k_norm_fn.",
+        }
+
+        def remap(key: str) -> Optional[str]:
+            for pattern, replacement in key_map.items():
+                new_key = re.sub(pattern, replacement, key)
+                if new_key != key:
+                    return new_key
+            return key
+
+        out = {}
+        for key, val in sd.items():
+            # Handle in_proj: split [3*dim, dim] -> B_proj, C_proj, x_proj each [dim, dim]
+            m = re.match(r"^layers\.([0-9]+)\.conv\.in_proj\.weight$", key)
+            if m:
+                n = m.group(1)
+                B, C, x = torch.chunk(val, 3, dim=0)
+                out[f"layers.{n}.conv.B_proj.weight"] = B
+                out[f"layers.{n}.conv.C_proj.weight"] = C
+                out[f"layers.{n}.conv.x_proj.weight"] = x
+                continue
+
+            new_key = remap(key)
+            if new_key is not None:
+                out[new_key] = val
+
+        return out
+
+    def embed_tokens(self, tokens: torch.Tensor) -> torch.Tensor:
+        return self.model_.model.language_model.get_input_embeddings()(tokens)
+
+    def encode_images(self, nchw_pixels: torch.Tensor) -> torch.Tensor:
+        """Accept [1, 3, 512, 512] NCHW float32 pixels in [0, 255].
+
+        Bakes in normalize + patch extraction so the C++ runner only needs
+        to resize to 512x512 and pass raw pixel values -- same as LLaVA runner.
+        """
+        # Normalize: (x/255 - 0.5) / 0.5
+        x = nchw_pixels / 255.0
+        x = (x - 0.5) / 0.5
+
+        # Extract 16x16 patches in HW-major order -> [1, 1024, PATCH_SIZE*PATCH_SIZE*3]
+        x = x.unfold(2, PATCH_SIZE, PATCH_SIZE).unfold(3, PATCH_SIZE, PATCH_SIZE)
+        x = x.permute(0, 2, 3, 4, 5, 1).reshape(1, FIXED_H * FIXED_W, PATCH_SIZE * PATCH_SIZE * 3)
+
+        FULL_MASK = torch.ones(1, FIXED_H * FIXED_W, dtype=torch.int32)
+        out = self.model_.model.vision_tower(
+            pixel_values=x,
+            pixel_attention_mask=FULL_MASK,
+            spatial_shapes=torch.tensor([[FIXED_H, FIXED_W]], dtype=torch.int64),
+            return_dict=True,
+        )
+        feats = out.last_hidden_state  # [1, 1024, vision_hidden_size]
+        feats = feats.reshape(feats.shape[0], FIXED_H, FIXED_W, -1)
+        projected = self.model_.model.multi_modal_projector(feats)  # [1, 16, 16, 2048]
+        return projected.reshape(1, -1, projected.shape[-1])        # [1, 256, 2048]
+
+    def image_embedding(self, images: torch.Tensor) -> torch.Tensor:
+        return self.encode_images(images)
+
+    def prefill_embedding(
+        self,
+        prompt_before_image: torch.Tensor,
+        images: torch.Tensor,
+        prompt_after_image: torch.Tensor,
+    ) -> torch.Tensor:
+        image_embeds = self.image_embedding(images)
+        embeds_before = self.embed_tokens(prompt_before_image)
+        embeds_after = self.embed_tokens(prompt_after_image)
+        return torch.cat((embeds_before, image_embeds, embeds_after), dim=1)
+
+    def step(
+        self, token: torch.Tensor, input_pos: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
+        """Single decode step. Input: one token. Output: logits."""
+        token_embeds = self.embed_tokens(token).unsqueeze(0)
+        return self.text_model.forward(None, {"input_pos": input_pos}, token_embeds)
+
+    def prefill(
+        self,
+        prompt_before_image: torch.Tensor,
+        images: torch.Tensor,
+        prompt_after_image: torch.Tensor,
+    ) -> Tuple[int, torch.Tensor]:
+        embeds = self.prefill_embedding(prompt_before_image, images, prompt_after_image)
+        return embeds.shape[1], self.text_model.forward(
+            None, {"input_pos": torch.tensor([0])}, embeds
+        )
+
+    def forward(self, images: torch.Tensor) -> torch.Tensor:
+        return self.image_embedding(images)
+
+
+class Lfm2p5VlModel(EagerModelBase):
+    def __init__(
+        self,
+        use_sdpa_with_kv_cache_op: bool = True,
+        max_seq_len: int = MAX_SEQ_LEN,
+        max_context_len: int = MAX_SEQ_LEN,
+        model_dir: str = "LiquidAI/LFM2-VL-1.6B",
+    ):
+        self.use_sdpa_with_kv_cache_op = use_sdpa_with_kv_cache_op
+        self.max_context_len = max_context_len
+        self.max_seq_len = max_seq_len
+        self.model_dir = model_dir
+
+        self.hf_model = AutoModelForImageTextToText.from_pretrained(
+            model_dir, device_map="cpu", torch_dtype=torch.float32
+        )
+        self.processor = AutoProcessor.from_pretrained(model_dir)
+        self.tokenizer = self.processor.tokenizer
+
+        self.conversation = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image"},
+                    {"type": "text", "text": "Describe this image."},
+                ],
+            }
+        ]
+
+        # Lazy-initialized inputs
+        self.input = None
+        self.example_image = None
+
+    def get_eager_model(self) -> torch.nn.Module:
+        model = Lfm2p5Vl(
+            self.hf_model,
+            self.use_sdpa_with_kv_cache_op,
+            self.max_context_len,
+            self.max_seq_len,
+        )
+        model.to(dtype=torch.float32)
+        return model
+
+    def get_example_inputs(self):
+        """Returns a [1, 3, 512, 512] pixel tensor for the vision encoder."""
+        if self.example_image is not None:
+            return self.example_image
+        self.example_image = (
+            torch.randint(0, 256, (1, 3, IMAGE_SIZE, IMAGE_SIZE), dtype=torch.float32),
+        )
+        return self.example_image
+
+    def get_inputs_for_prefill(self):
+        """Returns (prompt_before_image, pixel_values, prompt_after_image)."""
+        if self.input is not None:
+            return self.input
+
+        text = self.processor.apply_chat_template(
+            self.conversation, add_generation_prompt=True
+        )
+        inputs = self.processor(
+            text=[text],
+            images=[torch.zeros(3, IMAGE_SIZE, IMAGE_SIZE)],
+            return_tensors="pt",
+        )
+        input_ids = inputs["input_ids"]
+        index = torch.where(input_ids == self.hf_model.config.image_token_index)[1]
+        prompt_before = input_ids[:, : index[0]]
+        prompt_after = input_ids[:, index[-1] + 1 :]
+        self.input = (prompt_before, *self.get_example_inputs(), prompt_after)
+        return self.input
+
+    def get_dynamic_shapes(self):
+        return self._get_image_dynamic_shapes()
+
+    def _get_image_dynamic_shapes(self):
+        # Vision encoder has fixed 512x512 input -- no dynamic shapes needed
+        return None
+
+    def _get_prompt_dynamic_shapes(self):
+        dim = Dim("token_dim", min=1, max=self.max_seq_len)
+        return ({1: dim}, {1: dim})

--- a/examples/models/lfm2_5_vl/test/test_lfm2_5_vl.py
+++ b/examples/models/lfm2_5_vl/test/test_lfm2_5_vl.py
@@ -1,0 +1,116 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+import unittest
+
+import torch
+from executorch.examples.models.lfm2_5_vl.export_lfm2_5_vl import export_all
+from executorch.examples.models.lfm2_5_vl.model import IMAGE_SIZE, MAX_SEQ_LEN, Lfm2p5VlModel
+
+# import order matters: portable_lib must come first so its static op registry
+# is in place before custom_ops registers against it.
+from executorch.extension.pybindings.portable_lib import (  # noqa # usort: skip
+    _load_for_executorch_from_buffer,
+)
+from executorch.extension.llm.custom_ops import custom_ops  # noqa # usort: skip
+from executorch.kernels import quantized  # noqa # usort: skip
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+MODEL_DIR = "LiquidAI/LFM2-VL-1.6B"
+
+
+class TestLfm2p5Vl(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.lfm2_model = Lfm2p5VlModel(model_dir=MODEL_DIR)
+        cls.lfm2 = cls.lfm2_model.get_eager_model().eval()
+
+    def test_vision_encoder_shape(self):
+        """Vision encoder must produce [1, 256, 2048] embeddings."""
+        pixels = torch.randint(0, 256, (1, 3, IMAGE_SIZE, IMAGE_SIZE), dtype=torch.float32)
+        with torch.no_grad():
+            embeds = self.lfm2.image_embedding(pixels)
+        self.assertEqual(embeds.shape, (1, 256, 2048))
+
+    def test_prefill_output_shape(self):
+        """Prefill must return (seq_len: int, logits [1, vocab_size])."""
+        prompt_before, pixels, prompt_after = self.lfm2_model.get_inputs_for_prefill()
+        with torch.no_grad():
+            seq_len, logits = self.lfm2.prefill(prompt_before, pixels, prompt_after)
+        self.assertIsInstance(seq_len, int)
+        self.assertEqual(logits.shape[-1], 65536)
+
+    def test_export_methods(self):
+        """Exported PTE must contain the three named methods and metadata."""
+        et_program = export_all(
+            model_dir=MODEL_DIR,
+            output=None,  # in-memory only
+            _return_program=True,
+        )
+        self.assertIn("vision_encoder", et_program.methods)
+        self.assertIn("token_embedding", et_program.methods)
+        self.assertIn("text_decoder", et_program.methods)
+
+    def test_export_and_run(self):
+        """Export to PTE and run a short prefill + decode loop end-to-end."""
+        et_program = export_all(
+            model_dir=MODEL_DIR,
+            output=None,
+            _return_program=True,
+        )
+        module = _load_for_executorch_from_buffer(et_program.buffer)
+
+        prompt_before, pixels, prompt_after = self.lfm2_model.get_inputs_for_prefill()
+        start_pos = 0
+
+        # Embed and prefill tokens before image
+        before_embeds = module.run_method("token_embedding", (prompt_before,))[0]
+        module.run_method(
+            "text_decoder",
+            (before_embeds, torch.arange(start_pos, start_pos + before_embeds.shape[1])),
+        )
+        start_pos += before_embeds.shape[1]
+
+        # Vision encoder
+        image_embeds = module.run_method("vision_encoder", (pixels,))[0]
+        module.run_method(
+            "text_decoder",
+            (image_embeds, torch.arange(start_pos, start_pos + image_embeds.shape[1])),
+        )
+        start_pos += image_embeds.shape[1]
+
+        # Embed and prefill tokens after image
+        after_embeds = module.run_method("token_embedding", (prompt_after,))[0]
+        logits = module.run_method(
+            "text_decoder",
+            (after_embeds, torch.arange(start_pos, start_pos + after_embeds.shape[1])),
+        )[0]
+        start_pos += after_embeds.shape[1]
+
+        # Decode a few tokens — just check we get valid token IDs
+        new_tokens = [torch.argmax(logits).item()]
+        for i in range(3):
+            token_embed = module.run_method(
+                "token_embedding",
+                (torch.tensor([[new_tokens[i]]], dtype=torch.int64),),
+            )[0]
+            logits = module.run_method(
+                "text_decoder",
+                (token_embed, torch.tensor([start_pos + i], dtype=torch.int64)),
+            )[0]
+            new_tokens.append(torch.argmax(logits).item())
+
+        self.assertEqual(len(new_tokens), 4)
+        for tok in new_tokens:
+            self.assertGreaterEqual(tok, 0)
+            self.assertLess(tok, 65536)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/models/lfm2_5_vl/test/test_lfm2_5_vl.py
+++ b/examples/models/lfm2_5_vl/test/test_lfm2_5_vl.py
@@ -9,15 +9,10 @@ import unittest
 
 import torch
 from executorch.examples.models.lfm2_5_vl.export_lfm2_5_vl import export_all
-from executorch.examples.models.lfm2_5_vl.model import IMAGE_SIZE, MAX_SEQ_LEN, Lfm2p5VlModel
-
-# import order matters: portable_lib must come first so its static op registry
-# is in place before custom_ops registers against it.
-from executorch.extension.pybindings.portable_lib import (  # noqa # usort: skip
+from executorch.examples.models.lfm2_5_vl.model import IMAGE_SIZE, Lfm2p5VlModel
+from executorch.extension.pybindings.portable_lib import (
     _load_for_executorch_from_buffer,
 )
-from executorch.extension.llm.custom_ops import custom_ops  # noqa # usort: skip
-from executorch.kernels import quantized  # noqa # usort: skip
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -33,7 +28,9 @@ class TestLfm2p5Vl(unittest.TestCase):
 
     def test_vision_encoder_shape(self):
         """Vision encoder must produce [1, 256, 2048] embeddings."""
-        pixels = torch.randint(0, 256, (1, 3, IMAGE_SIZE, IMAGE_SIZE), dtype=torch.float32)
+        pixels = torch.randint(
+            0, 256, (1, 3, IMAGE_SIZE, IMAGE_SIZE), dtype=torch.float32
+        )
         with torch.no_grad():
             embeds = self.lfm2.image_embedding(pixels)
         self.assertEqual(embeds.shape, (1, 256, 2048))
@@ -73,7 +70,10 @@ class TestLfm2p5Vl(unittest.TestCase):
         before_embeds = module.run_method("token_embedding", (prompt_before,))[0]
         module.run_method(
             "text_decoder",
-            (before_embeds, torch.arange(start_pos, start_pos + before_embeds.shape[1])),
+            (
+                before_embeds,
+                torch.arange(start_pos, start_pos + before_embeds.shape[1]),
+            ),
         )
         start_pos += before_embeds.shape[1]
 


### PR DESCRIPTION
## Summary

- Adds `examples/models/lfm2_5_vl/` — export of [LiquidAI/LFM2-VL-1.6B](https://huggingface.co/LiquidAI/LFM2-VL-1.6B) to a single multi-method ExecuTorch PTE
- Follows the same `EagerModelBase` + `LLMEdgeManager` pattern as `examples/models/llava/`
- Compatible with the existing `llava_main` C++ multimodal runner (same method names: `vision_encoder`, `token_embedding`, `text_decoder`)
- Supports fp32 and fp16 export; optional 8da4w + int8 embedding quantization via `--quantize`

## Architecture

LFM2.5-VL-1.6B is a hybrid SSM+attention VLM — 16 layers alternating between `ShortConvBlock` (conv) and `TransformerBlock` (full attention), with a SigLIP ViT vision encoder.

Key export decisions:
- `enable_dynamic_shape=False` — avoids `.item()` in RoPE's `get_freqs` during FakeTensor tracing
- `strict=False` — hybrid conv layers have mutable buffer state not traceable in strict mode
- Bilinear PE precompute (`antialias=True`) for 32×32 grid — avoids dynamic `F.interpolate` during export
- Text decoder exported before token embedding — `EmbeddingQuantHandler` mutates weights in-place

## Test plan
- [ ] `python -c "from executorch.examples.models.lfm2_5_vl.model import Lfm2p5VlModel"` passes
- [ ] `python -c "from executorch.examples.models.lfm2_5_vl.export_lfm2_5_vl import export_all"` passes
- [ ] Export completes: `python examples/models/lfm2_5_vl/export_lfm2_5_vl.py --model_dir LiquidAI/LFM2-VL-1.6B`