### PR TITLE
fix(qnn): fix OOM and Dequantize type error when compiling sharded LLMs

### DIFF
--- a/backends/qualcomm/_passes/insert_io_qdq.py
+++ b/backends/qualcomm/_passes/insert_io_qdq.py
@@ -118,7 +118,10 @@ class InsertIOQDQ(ExportPass):
                     user.replace_input_with(node, inserted_node)
 
     def _insert(self, graph_module: torch.fx.GraphModule) -> torch.fx.GraphModule:
-        for n in graph_module.graph.nodes:
+        # Snapshot the node list before any insertions to avoid visiting
+        # newly-inserted Q/DQ nodes and triggering infinite re-insertion.
+        nodes = list(graph_module.graph.nodes)
+        for n in nodes:
             # do nothing when a node is expected to output a quant tensor
             if n.meta.get(QCOM_QUANTIZED_IO):
                 continue

--- a/examples/qualcomm/oss_scripts/llama/wrappers/llm_wrappers.py
+++ b/examples/qualcomm/oss_scripts/llama/wrappers/llm_wrappers.py
@@ -425,7 +425,7 @@ class TextDecoder(Component):
         }
 
         freq_op = {
-            exir_ops.edge.aten.select.int,
+            exir_ops.edge.aten.select_copy.int,
         }
         quant_io_type = None
 


### PR DESCRIPTION
This PR fixes two bugs in the QNN backend that caused compilation to fail for sharded LLMs (e.g. Qwen3-1.7B with `num_sharding=2`).

**Bug 1 — `insert_io_qdq.py`: infinite loop → OOM**

`_insert()` iterated over `graph_module.graph.nodes` live while inserting new DQ nodes. The newly inserted DQ nodes inherited `QCOM_QUANT_ATTRS` and still fed into `output`, causing them to be re-processed on the next iteration, leading to an infinite loop and OOM.

Fix: snapshot the node list before iterating with `list(graph_module.graph.nodes)`.

**Bug 2 — `llm_wrappers.py`: wrong op dialect in `_tag_ios`**

`TagQuantIO._tag_ios()` used `exir_ops.edge.aten.select.int` (ATen dialect) to detect freq sin/cos tensors at shard boundaries. After `to_edge()`, all ops are the `_copy` variant, so the check always failed. Affected `select_copy` nodes never received the `QCOM_QUANTIZED_IO` tag, causing `InsertIOQDQ` to wrongly insert a DQ node after them, which QNN then rejected with `q::Dequantize could not create op` on `QuantUint16_T`.

Fix: use `exir_ops.edge.aten.select_copy.int`.

Neither fix affects non-sharded models (`num_sharding=1`).

Fixes #17782 

cc @cccclai @winskuo-quic @shewu-quic @haowhsu-quic @DannyYuyang-quic @cbilgin