### PR TITLE
Fix for Raspberry Pi 5 GPU

### DIFF
--- a/backends/vulkan/runtime/vk_api/Adapter.cpp
+++ b/backends/vulkan/runtime/vk_api/Adapter.cpp
@@ -123,12 +123,6 @@ VkDevice create_logical_device(
     defined(ETVK_INSPECT_PIPELINES)
       VK_KHR_PIPELINE_EXECUTABLE_PROPERTIES_EXTENSION_NAME,
 #endif /* VK_KHR_pipeline_executable_properties && ETVK_INSPECT_PIPELINES */
-#ifdef VK_KHR_cooperative_matrix
-      VK_KHR_COOPERATIVE_MATRIX_EXTENSION_NAME,
-#endif /* VK_KHR_cooperative_matrix */
-#ifdef VK_NV_cooperative_matrix2
-      VK_NV_COOPERATIVE_MATRIX_2_EXTENSION_NAME,
-#endif /* VK_NV_cooperative_matrix2 */
   };
 
   std::vector<const char*> enabled_device_extensions;
@@ -185,20 +179,6 @@ VkDevice create_logical_device(
   extension_list_top = &shader_int_dot_product_features;
 #endif /* VK_KHR_shader_integer_dot_product */
 
-#ifdef VK_KHR_cooperative_matrix
-  VkPhysicalDeviceCooperativeMatrixFeaturesKHR cooperative_matrix_features{
-      physical_device.cooperative_matrix_features};
-  cooperative_matrix_features.pNext = extension_list_top;
-  extension_list_top = &cooperative_matrix_features;
-#endif /* VK_KHR_cooperative_matrix */
-
-#ifdef VK_NV_cooperative_matrix2
-  VkPhysicalDeviceCooperativeMatrix2FeaturesNV cooperative_matrix2_features{
-      physical_device.cooperative_matrix2_features};
-  cooperative_matrix2_features.pNext = extension_list_top;
-  extension_list_top = &cooperative_matrix2_features;
-#endif /* VK_NV_cooperative_matrix2 */
-
   device_create_info.pNext = extension_list_top;
 
   VkDevice handle = nullptr;
@@ -215,7 +195,9 @@ VkDevice create_logical_device(
   return handle;
 }
 
-bool test_linear_tiling_3d_image_support(VkDevice device) {
+bool test_linear_tiling_3d_image_support(
+    VkDevice device,
+    VkPhysicalDevice physical_device) {
   // Test creating a 3D image with linear tiling to see if it is supported.
   // According to the Vulkan spec, linear tiling may not be supported for 3D
   // images.
@@ -242,9 +224,15 @@ bool test_linear_tiling_3d_image_support(VkDevice device) {
 
   if (res == VK_SUCCESS) {
     vkDestroyImage(device, image, nullptr);
+
+    VkFormatProperties props;
+    vkGetPhysicalDeviceFormatProperties(
+        physical_device, VK_FORMAT_R32G32B32A32_SFLOAT, &props);
+
+    return props.linearTilingFeatures & VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT;
   }
 
-  return res == VK_SUCCESS;
+  return false;
 }
 
 } // namespace
@@ -275,8 +263,9 @@ Adapter::Adapter(
       compute_pipeline_cache_(device_.handle, cache_data_path),
       sampler_cache_(device_.handle),
       vma_(instance_, physical_device_.handle, device_.handle),
-      linear_tiling_3d_enabled_{
-          test_linear_tiling_3d_image_support(device_.handle)},
+      linear_tiling_3d_enabled_{test_linear_tiling_3d_image_support(
+          device_.handle,
+          physical_device_.handle)},
       owns_device_{true} {}
 
 Adapter::Adapter(
@@ -286,7 +275,7 @@ Adapter::Adapter(
     const uint32_t num_queues,
     const std::string& cache_data_path)
     : queue_usage_mutex_{},
-      physical_device_(instance, physical_device),
+      physical_device_(physical_device),
       queues_{},
       queue_usage_{},
       queue_mutexes_{},
@@ -298,8 +287,9 @@ Adapter::Adapter(
       compute_pipeline_cache_(device_.handle, cache_data_path),
       sampler_cache_(device_.handle),
       vma_(instance_, physical_device_.handle, device_.handle),
-      linear_tiling_3d_enabled_{
-          test_linear_tiling_3d_image_support(device_.handle)},
+      linear_tiling_3d_enabled_{test_linear_tiling_3d_image_support(
+          device_.handle,
+          physical_device_.handle)},
       owns_device_{false} {
   std::vector<VkDeviceQueueCreateInfo> queue_create_infos;
   std::vector<std::pair<uint32_t, uint32_t>> queues_to_get;
@@ -373,10 +363,6 @@ void Adapter::submit_cmd(
       queue_mutexes_[device_queue.queue_index % NUM_QUEUE_MUTEXES]);
 
   VK_CHECK(vkQueueSubmit(device_queue.handle, 1u, &submit_info, fence));
-}
-
-void Adapter::override_device_name(const std::string& new_name) {
-  physical_device_.override_device_name(new_name);
 }
 
 std::string Adapter::stringize() const {

--- a/backends/vulkan/runtime/vk_api/Adapter.cpp
+++ b/backends/vulkan/runtime/vk_api/Adapter.cpp
@@ -123,6 +123,12 @@ VkDevice create_logical_device(
     defined(ETVK_INSPECT_PIPELINES)
       VK_KHR_PIPELINE_EXECUTABLE_PROPERTIES_EXTENSION_NAME,
 #endif /* VK_KHR_pipeline_executable_properties && ETVK_INSPECT_PIPELINES */
+#ifdef VK_KHR_cooperative_matrix
+      VK_KHR_COOPERATIVE_MATRIX_EXTENSION_NAME,
+#endif /* VK_KHR_cooperative_matrix */
+#ifdef VK_NV_cooperative_matrix2
+      VK_NV_COOPERATIVE_MATRIX_2_EXTENSION_NAME,
+#endif /* VK_NV_cooperative_matrix2 */
   };
 
   std::vector<const char*> enabled_device_extensions;
@@ -178,6 +184,20 @@ VkDevice create_logical_device(
   shader_int_dot_product_features.pNext = extension_list_top;
   extension_list_top = &shader_int_dot_product_features;
 #endif /* VK_KHR_shader_integer_dot_product */
+
+#ifdef VK_KHR_cooperative_matrix
+  VkPhysicalDeviceCooperativeMatrixFeaturesKHR cooperative_matrix_features{
+      physical_device.cooperative_matrix_features};
+  cooperative_matrix_features.pNext = extension_list_top;
+  extension_list_top = &cooperative_matrix_features;
+#endif /* VK_KHR_cooperative_matrix */
+
+#ifdef VK_NV_cooperative_matrix2
+  VkPhysicalDeviceCooperativeMatrix2FeaturesNV cooperative_matrix2_features{
+      physical_device.cooperative_matrix2_features};
+  cooperative_matrix2_features.pNext = extension_list_top;
+  extension_list_top = &cooperative_matrix2_features;
+#endif /* VK_NV_cooperative_matrix2 */
 
   device_create_info.pNext = extension_list_top;
 
@@ -275,7 +295,7 @@ Adapter::Adapter(
     const uint32_t num_queues,
     const std::string& cache_data_path)
     : queue_usage_mutex_{},
-      physical_device_(physical_device),
+      physical_device_(instance, physical_device),
       queues_{},
       queue_usage_{},
       queue_mutexes_{},
@@ -363,6 +383,10 @@ void Adapter::submit_cmd(
       queue_mutexes_[device_queue.queue_index % NUM_QUEUE_MUTEXES]);
 
   VK_CHECK(vkQueueSubmit(device_queue.handle, 1u, &submit_info, fence));
+}
+
+void Adapter::override_device_name(const std::string& new_name) {
+  physical_device_.override_device_name(new_name);
 }
 
 std::string Adapter::stringize() const {

--- a/backends/vulkan/runtime/vk_api/memory/Allocator.cpp
+++ b/backends/vulkan/runtime/vk_api/memory/Allocator.cpp
@@ -11,6 +11,22 @@
 namespace vkcompute {
 namespace vkapi {
 
+bool test_host_cached_available(VkPhysicalDevice physical_device) {
+  VkPhysicalDeviceMemoryProperties mem_props;
+  vkGetPhysicalDeviceMemoryProperties(physical_device, &mem_props);
+
+  VkMemoryPropertyFlags const flags = mem_props.memoryTypes->propertyFlags;
+
+  bool const host_visible = flags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
+  bool const host_cached = flags & VK_MEMORY_PROPERTY_HOST_CACHED_BIT;
+
+  if (host_visible && host_cached) {
+    return VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT;
+  }
+
+  return VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT;
+}
+
 Allocator::Allocator(
     VkInstance instance,
     VkPhysicalDevice physical_device,
@@ -18,7 +34,9 @@ Allocator::Allocator(
     : instance_{},
       physical_device_(physical_device),
       device_(device),
-      allocator_{VK_NULL_HANDLE} {
+      allocator_{VK_NULL_HANDLE},
+      allocation_strategy_device_to_host_{
+          test_host_cached_available(physical_device_)} {
   VmaVulkanFunctions vk_functions{};
   vk_functions.vkGetInstanceProcAddr = vkGetInstanceProcAddr;
   vk_functions.vkGetDeviceProcAddr = vkGetDeviceProcAddr;
@@ -44,7 +62,9 @@ Allocator::Allocator(Allocator&& other) noexcept
     : instance_(other.instance_),
       physical_device_(other.physical_device_),
       device_(other.device_),
-      allocator_(other.allocator_) {
+      allocator_(other.allocator_),
+      allocation_strategy_device_to_host_(
+          other.allocation_strategy_device_to_host_) {
   other.allocator_ = VK_NULL_HANDLE;
   other.device_ = VK_NULL_HANDLE;
   other.physical_device_ = VK_NULL_HANDLE;
@@ -158,7 +178,7 @@ VulkanBuffer Allocator::create_staging_buffer(
     alloc_create_info.flags |=
         VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT;
   } else {
-    alloc_create_info.flags |= VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT;
+    alloc_create_info.flags |= allocation_strategy_device_to_host_;
   }
   alloc_create_info.usage = VMA_MEMORY_USAGE_AUTO_PREFER_HOST;
   alloc_create_info.requiredFlags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;

--- a/backends/vulkan/runtime/vk_api/memory/Allocator.h
+++ b/backends/vulkan/runtime/vk_api/memory/Allocator.h
@@ -57,6 +57,8 @@ class Allocator final {
   VkPhysicalDevice physical_device_;
   VkDevice device_;
   VmaAllocator allocator_;
+  VmaAllocationCreateFlags allocation_strategy_device_to_host_;
+
 
  public:
   VmaAllocationCreateInfo gpuonly_resource_create_info();

--- a/backends/vulkan/runtime/vk_api/memory/Allocator.h
+++ b/backends/vulkan/runtime/vk_api/memory/Allocator.h
@@ -59,7 +59,6 @@ class Allocator final {
   VmaAllocator allocator_;
   VmaAllocationCreateFlags allocation_strategy_device_to_host_;
 
-
  public:
   VmaAllocationCreateInfo gpuonly_resource_create_info();
 


### PR DESCRIPTION
### Summary
The current check for VK_IMAGE_TILING_LINEAR (row-major order) only verifies vkCreateImage(...) succeeds, but Vulkan requires an additional capability VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT. For images that will be sampled by shaders (e.g. for conv2d) VK_IMAGE_TILING_OPTIMAL should be used.

Fixes #17855

### Test plan
converted some models with the VulkanPartitioner() and let it run on the Raspberry Pi 5 -> using VK_IMAGE_TILING_LINEAR will run but produces wrong results, as the Debug info suggests. Also using VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT fixes the issue as before (see https://github.com/pytorch/executorch/pull/7615)


cc @SS-JIA @manuelcandales @digantdesai @cbilgin