### PR TITLE
docs(zephyr): update Cortex-M55 examples to use --target=cortex-m55+int8

### DIFF
--- a/zephyr/README.md
+++ b/zephyr/README.md
@@ -133,8 +133,10 @@ west build -b mps3/corstone300/fvp modules/lib/executorch/examples/arm/zephyr -t
 Prepare the Cortex-M55 PTE model
 <!-- RUN test_cortex-m55_generate_pte -->
 ```
-python -m modules.lib.executorch.examples.arm.aot_arm_compiler --model_name=modules/lib/executorch/examples/arm/example_modules/add.py --quantize --output=add_m55.pte
+python -m modules.lib.executorch.examples.arm.aot_arm_compiler --model_name=modules/lib/executorch/examples/arm/example_modules/add.py --quantize --target=cortex-m55+int8 --output=add_m55.pte
 ```
+
+`--target=cortex-m55+int8` selects the Cortex-M/CMSIS-NN portable kernel path (no NPU delegation). This produces a `.pte` optimised for Cortex-M55 with INT8 quantisation.
 
 #### Build and run
 
@@ -208,8 +210,10 @@ export PATH=$PATH:~/STMicroelectronics/STM32Cube/STM32CubeProgrammer/bin
 
 Prepare the Cortex-M55 PTE model
 ```
-python -m modules.lib.executorch.examples.arm.aot_arm_compiler --model_name=modules/lib/executorch/examples/arm/example_modules/add.py --quantize --output=add_m55.pte
+python -m modules.lib.executorch.examples.arm.aot_arm_compiler --model_name=modules/lib/executorch/examples/arm/example_modules/add.py --quantize --target=cortex-m55+int8 --output=add_m55.pte
 ```
+
+`--target=cortex-m55+int8` selects the Cortex-M/CMSIS-NN portable kernel path (no NPU delegation).
 
 #### Build and run
 


### PR DESCRIPTION
The aot_arm_compiler now requires an explicit --target flag to select the Cortex-M/CMSIS-NN portable kernel path. Update the two Cortex-M55 PTE generation commands in the Zephyr README (Corstone-300 FVP and STM Nucleo N6 sections) to pass --target=cortex-m55+int8, and add a short explanatory note below each command.

Follow-up to #17075 which introduced the cortex-m55+int8 target.

cc @digantdesai @SS-JIA @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell