### PR TITLE
(2a/n) Add WASM/Emscripten compiler flags to third-party dependencies

### DIFF
--- a/shim_et/xplat/executorch/build/runtime_wrapper.bzl
+++ b/shim_et/xplat/executorch/build/runtime_wrapper.bzl
@@ -123,6 +123,16 @@ def _patch_build_mode_flags(kwargs):
         # @oss-disable: "fbsource//xplat/assistant/oacr/native/scripts:compiler_flag_O2": ["-O2"],
     })
 
+    # Add pthread flags for Emscripten/WASM builds with threading support.
+    # Required when linking into WASM binaries that use -sUSE_PTHREADS=1.
+    # Without these flags, wasm-ld fails with:
+    #   "error: --shared-memory is disallowed by <file>.o because it was not
+    #    compiled with 'atomics' or 'bulk-memory' features."
+    kwargs["compiler_flags"] = kwargs["compiler_flags"] + select({
+        "DEFAULT": [],
+        # @oss-disable: "ovr_config//runtime:wasm-emscripten": ["-pthread", "-matomics", "-mbulk-memory"],
+    })
+
     return kwargs
 
 def _has_pytorch_dep(dep_list):


### PR DESCRIPTION
Summary:
Add pthread compiler flags (-pthread, -matomics, -mbulk-memory) for
Emscripten/WASM builds across third-party dependencies and ExecuTorch
runtime wrapper.

These flags are required when linking into WASM binaries that use
-sUSE_PTHREADS=1. Without them, wasm-ld fails with:
  "error: --shared-memory is disallowed by <file>.o because it was not
   compiled with 'atomics' or 'bulk-memory' features."

Changes:
- xnnpack.buck.bzl (fbcode + xplat): Add WASM_EMSCRIPTEN_COMPILER_FLAGS select
- runtime_wrapper.bzl (fbcode + xplat): Add emcc compiler flags
- cpuinfo/BUCK: Add wasm-emscripten compatible_with, compiler_flags, and emscripten/init.c wrapper
- clog/BUCK: Add wasm-emscripten compiler_flags
- pthreadpool/BUCK: Add compiler_flags and WASM preprocessor_flags (condvar mode)

Reviewed By: GregoryComer

Differential Revision: D94744813
