### PR TITLE
Return Result for toTensor(), toOptional()

### DIFF
--- a/runtime/core/evalue.h
+++ b/runtime/core/evalue.h
@@ -8,6 +8,7 @@
 
 #pragma once
 #include <executorch/runtime/core/exec_aten/exec_aten.h>
+#include <executorch/runtime/core/result.h>
 #include <executorch/runtime/core/tag.h>
 #include <executorch/runtime/platform/assert.h>
 
@@ -291,6 +292,13 @@ struct EValue {
     return payload.as_tensor;
   }
 
+  Result<executorch::aten::Tensor> tryToTensor() const {
+    if (!isTensor()) {
+      return Error::InvalidType;
+    }
+    return payload.as_tensor;
+  }
+
   /****** String Type ******/
   /*implicit*/ EValue(executorch::aten::ArrayRef<char>* s) : tag(Tag::String) {
     ET_CHECK_MSG(s != nullptr, "ArrayRef<char> pointer cannot be null");
@@ -458,6 +466,20 @@ struct EValue {
       return executorch::aten::nullopt;
     }
     return this->to<T>();
+  }
+
+  template <typename T>
+  inline Result<std::optional<T>> tryToOptional() const {
+    static_assert(
+        std::is_same<T, executorch::aten::Tensor>::value,
+        "tryToOptional only supports Tensor");
+    if (this->isNone()) {
+      return std::optional<T>(executorch::aten::nullopt);
+    }
+    if (!this->isTensor()) {
+      return Error::InvalidType;
+    }
+    return std::optional<T>(this->payload.as_tensor);
   }
 
  private:

--- a/runtime/core/test/evalue_test.cpp
+++ b/runtime/core/test/evalue_test.cpp
@@ -417,3 +417,42 @@ TEST_F(EValueTest, toListOptionalTensorNullPointerCheck) {
   EXPECT_TRUE(e.isListOptionalTensor());
   ET_EXPECT_DEATH({ e.toListOptionalTensor(); }, "pointer is null");
 }
+
+TEST_F(EValueTest, TryToTensorSuccess) {
+  TensorFactory<ScalarType::Float> tf;
+  EValue e(tf.ones({3, 2}));
+  auto result = e.tryToTensor();
+  EXPECT_TRUE(result.ok());
+  EXPECT_EQ(result->dim(), 2);
+  EXPECT_EQ(result->numel(), 6);
+}
+
+TEST_F(EValueTest, TryToTensorTypeMismatch) {
+  EValue e(static_cast<int64_t>(42));
+  auto result = e.tryToTensor();
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.error(), executorch::runtime::Error::InvalidType);
+}
+
+TEST_F(EValueTest, TryToOptionalTensorSuccess) {
+  TensorFactory<ScalarType::Float> tf;
+  EValue e(tf.ones({3, 2}));
+  auto result = e.tryToOptional<executorch::aten::Tensor>();
+  EXPECT_TRUE(result.ok());
+  EXPECT_TRUE(result->has_value());
+  EXPECT_EQ(result->value().dim(), 2);
+}
+
+TEST_F(EValueTest, TryToOptionalTensorNone) {
+  EValue e;
+  auto result = e.tryToOptional<executorch::aten::Tensor>();
+  EXPECT_TRUE(result.ok());
+  EXPECT_FALSE(result->has_value());
+}
+
+TEST_F(EValueTest, TryToOptionalTensorTypeMismatch) {
+  EValue e(static_cast<int64_t>(42));
+  auto result = e.tryToOptional<executorch::aten::Tensor>();
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.error(), executorch::runtime::Error::InvalidType);
+}

--- a/runtime/executor/method.cpp
+++ b/runtime/executor/method.cpp
@@ -1521,17 +1521,16 @@ Error Method::execute_instruction() {
       // We know that instr_args_as_FreeCall is non-null because it was checked
       // at init time.
       auto free_call = instruction->instr_args_as_FreeCall();
-      auto& val = mutable_value(free_call->value_index());
-      if (val.isTensor()) {
-        auto& t = val.toTensor();
-        internal::reset_data_ptr(t);
-      } else {
+      auto t = mutable_value(free_call->value_index()).tryToTensor();
+      if (!t.ok()) {
         ET_LOG(
             Error,
             "FreeCall target at index %u is not a Tensor",
             static_cast<unsigned int>(free_call->value_index()));
-        err = Error::InvalidProgram;
+        err = t.error();
+        break;
       }
+      internal::reset_data_ptr(t.get());
     } break;
     default:
       ET_LOG(

--- a/runtime/executor/tensor_parser.h
+++ b/runtime/executor/tensor_parser.h
@@ -97,15 +97,12 @@ ET_NODISCARD Result<BoxedEvalueList<std::optional<T>>> parseListOptionalType(
           InvalidProgram,
           "Invalid value index %" PRId32 " for ListOptional",
           index);
-      ET_CHECK_OR_RETURN_ERROR(
-          values[index].isNone() || values[index].isTensor(),
-          InvalidProgram,
-          "Expected None or Tensor at value index %" PRId32
-          " for ListOptional, got tag %u",
-          index,
-          static_cast<unsigned>(values[index].tag));
+      auto optional_result = values[index].tryToOptional<T>();
+      if (!optional_result.ok()) {
+        return optional_result.error();
+      }
       new (&optional_tensor_list[output_idx])
-          std::optional<T>(values[index].toOptional<T>());
+          std::optional<T>(std::move(optional_result.get()));
       evalp_list[output_idx] = &values[static_cast<size_t>(index)];
     }
     output_idx++;

--- a/runtime/executor/tensor_parser.h
+++ b/runtime/executor/tensor_parser.h
@@ -97,6 +97,13 @@ ET_NODISCARD Result<BoxedEvalueList<std::optional<T>>> parseListOptionalType(
           InvalidProgram,
           "Invalid value index %" PRId32 " for ListOptional",
           index);
+      ET_CHECK_OR_RETURN_ERROR(
+          values[index].isNone() || values[index].isTensor(),
+          InvalidProgram,
+          "Expected None or Tensor at value index %" PRId32
+          " for ListOptional, got tag %u",
+          index,
+          static_cast<unsigned>(values[index].tag));
       new (&optional_tensor_list[output_idx])
           std::optional<T>(values[index].toOptional<T>());
       evalp_list[output_idx] = &values[static_cast<size_t>(index)];

--- a/runtime/executor/tensor_parser_exec_aten.cpp
+++ b/runtime/executor/tensor_parser_exec_aten.cpp
@@ -98,15 +98,15 @@ ET_NODISCARD Result<BoxedEvalueList<executorch::aten::Tensor>> parseTensorList(
         "Invalid value index %" PRId32 " for TensorList",
         tensor_index);
 
-    ET_CHECK_OR_RETURN_ERROR(
-        values[static_cast<size_t>(tensor_index)].isTensor(),
-        InvalidProgram,
-        "Expected Tensor at value index %" PRId32 " for TensorList",
-        tensor_index);
+    auto tensor_result =
+        values[static_cast<size_t>(tensor_index)].tryToTensor();
+    if (!tensor_result.ok()) {
+      return tensor_result.error();
+    }
     // Placement new as the list elements are not initialized, so calling
     // copy assignment is not defined if it's non trivial.
-    new (&tensor_list[output_idx]) executorch::aten::Tensor(
-        values[static_cast<size_t>(tensor_index)].toTensor());
+    new (&tensor_list[output_idx])
+        executorch::aten::Tensor(std::move(tensor_result.get()));
     evalp_list[output_idx] = &values[static_cast<size_t>(tensor_index)];
     output_idx++;
   }

--- a/runtime/executor/tensor_parser_exec_aten.cpp
+++ b/runtime/executor/tensor_parser_exec_aten.cpp
@@ -98,6 +98,11 @@ ET_NODISCARD Result<BoxedEvalueList<executorch::aten::Tensor>> parseTensorList(
         "Invalid value index %" PRId32 " for TensorList",
         tensor_index);
 
+    ET_CHECK_OR_RETURN_ERROR(
+        values[static_cast<size_t>(tensor_index)].isTensor(),
+        InvalidProgram,
+        "Expected Tensor at value index %" PRId32 " for TensorList",
+        tensor_index);
     // Placement new as the list elements are not initialized, so calling
     // copy assignment is not defined if it's non trivial.
     new (&tensor_list[output_idx]) executorch::aten::Tensor(

--- a/runtime/executor/test/tensor_parser_test.cpp
+++ b/runtime/executor/test/tensor_parser_test.cpp
@@ -250,8 +250,8 @@ struct FlatVectorInt32 {
 };
 } // namespace
 
-// TOB-EXECUTORCH-8: parseTensorList should return an error when the EValue
-// at the given index is not a Tensor, instead of aborting.
+// parseTensorList should return an error when the EValue at the given index
+// is not a Tensor, instead of aborting.
 TEST_F(TensorParserTest, ParseTensorListRejectsNonTensorEValue) {
   ManagedMemoryManager mmm(kDefaultNonConstMemBytes, kDefaultRuntimeMemBytes);
 
@@ -265,11 +265,11 @@ TEST_F(TensorParserTest, ParseTensorListRejectsNonTensorEValue) {
   auto* indices = FlatVectorInt32::create(vec_buf, {0});
 
   auto result = parseTensorList(indices, values, 2, &mmm.get());
-  EXPECT_NE(result.error(), Error::Ok);
+  EXPECT_EQ(result.error(), Error::InvalidType);
 }
 
-// TOB-EXECUTORCH-6: parseListOptionalType should return an error when the
-// EValue at the given index is neither None nor the expected type.
+// parseListOptionalType should return an error when the EValue at the given
+// index is neither None nor the expected type.
 TEST_F(TensorParserTest, ParseListOptionalTypeRejectsWrongType) {
   ManagedMemoryManager mmm(kDefaultNonConstMemBytes, kDefaultRuntimeMemBytes);
 
@@ -282,7 +282,6 @@ TEST_F(TensorParserTest, ParseListOptionalTypeRejectsWrongType) {
   std::vector<uint8_t> vec_buf;
   auto* indices = FlatVectorInt32::create(vec_buf, {0});
 
-  auto result =
-      parseListOptionalType<Tensor>(indices, values, 2, &mmm.get());
-  EXPECT_NE(result.error(), Error::Ok);
+  auto result = parseListOptionalType<Tensor>(indices, values, 2, &mmm.get());
+  EXPECT_EQ(result.error(), Error::InvalidType);
 }

--- a/runtime/executor/test/tensor_parser_test.cpp
+++ b/runtime/executor/test/tensor_parser_test.cpp
@@ -8,6 +8,8 @@
 
 #include <executorch/runtime/executor/tensor_parser.h>
 
+#include <cstring>
+
 #include <executorch/extension/data_loader/file_data_loader.h>
 #include <executorch/runtime/core/exec_aten/exec_aten.h>
 #include <executorch/runtime/core/tensor_layout.h>
@@ -19,6 +21,7 @@
 using namespace ::testing;
 using executorch::aten::ScalarType;
 using executorch::aten::Tensor;
+using executorch::runtime::BoxedEvalueList;
 using executorch::runtime::Error;
 using executorch::runtime::EValue;
 using executorch::runtime::FreeableBuffer;
@@ -26,7 +29,9 @@ using executorch::runtime::Program;
 using executorch::runtime::Result;
 using executorch::runtime::Span;
 using executorch::runtime::TensorLayout;
+using executorch::runtime::deserialization::parseListOptionalType;
 using executorch::runtime::deserialization::parseTensor;
+using executorch::runtime::deserialization::parseTensorList;
 using executorch::runtime::deserialization::validateTensorLayout;
 using executorch::runtime::testing::ManagedMemoryManager;
 using torch::executor::util::FileDataLoader;
@@ -222,4 +227,62 @@ TEST(ValidateTensorLayoutTest, DimOrderSizeMismatchIsRejected) {
 
   EXPECT_EQ(
       validateTensorLayout(s_tensor, layout.get()), Error::InvalidExternalData);
+}
+
+// Helper to construct a flatbuffers::Vector<int32_t> from raw data.
+// FlatBuffer vectors are stored as [uint32_t length][T elements...].
+namespace {
+struct FlatVectorInt32 {
+  static const flatbuffers::Vector<int32_t>* create(
+      std::vector<uint8_t>& buf,
+      const std::vector<int32_t>& elements) {
+    buf.resize(sizeof(uint32_t) + elements.size() * sizeof(int32_t));
+    uint32_t len = static_cast<uint32_t>(elements.size());
+    memcpy(buf.data(), &len, sizeof(len));
+    if (!elements.empty()) {
+      memcpy(
+          buf.data() + sizeof(uint32_t),
+          elements.data(),
+          elements.size() * sizeof(int32_t));
+    }
+    return reinterpret_cast<const flatbuffers::Vector<int32_t>*>(buf.data());
+  }
+};
+} // namespace
+
+// TOB-EXECUTORCH-8: parseTensorList should return an error when the EValue
+// at the given index is not a Tensor, instead of aborting.
+TEST_F(TensorParserTest, ParseTensorListRejectsNonTensorEValue) {
+  ManagedMemoryManager mmm(kDefaultNonConstMemBytes, kDefaultRuntimeMemBytes);
+
+  // Create an EValue array with a non-Tensor value at index 0.
+  EValue values[2];
+  values[0] = EValue(static_cast<int64_t>(42)); // Int, not Tensor
+  values[1] = EValue(static_cast<int64_t>(7));
+
+  // Create a vector with index 0 (pointing to the Int EValue).
+  std::vector<uint8_t> vec_buf;
+  auto* indices = FlatVectorInt32::create(vec_buf, {0});
+
+  auto result = parseTensorList(indices, values, 2, &mmm.get());
+  EXPECT_NE(result.error(), Error::Ok);
+}
+
+// TOB-EXECUTORCH-6: parseListOptionalType should return an error when the
+// EValue at the given index is neither None nor the expected type.
+TEST_F(TensorParserTest, ParseListOptionalTypeRejectsWrongType) {
+  ManagedMemoryManager mmm(kDefaultNonConstMemBytes, kDefaultRuntimeMemBytes);
+
+  // Create an EValue array with a non-Tensor, non-None value at index 0.
+  EValue values[2];
+  values[0] = EValue(static_cast<int64_t>(42)); // Int, not Tensor or None
+  values[1] = EValue(static_cast<int64_t>(7));
+
+  // Create a vector with index 0 (pointing to the Int EValue).
+  std::vector<uint8_t> vec_buf;
+  auto* indices = FlatVectorInt32::create(vec_buf, {0});
+
+  auto result =
+      parseListOptionalType<Tensor>(indices, values, 2, &mmm.get());
+  EXPECT_NE(result.error(), Error::Ok);
 }


### PR DESCRIPTION
Existing toTensor() and toOptional<T>() methods abort via ET_CHECK_MSG on type mismatch, causing a denial of service.

Introduce tryToTensor and tryToOptional methods that return Result. Use them at the following callsites
- parseListOptionalType (tensor_parser.h)
- FreeCall handler in Method::execute_instruction (method.cpp)
- parseTensorList (tensor_parser_exec_aten.cpp)

The follow-ons from this are a little cumbersome:
- Add tryTo for the scalars, so toOptional works for all types (not just Tensors)
- Update codegen to use tryTo methods. This likely causes a binary size regression, as we are generating more code for each kernel arg. We can potentially limit this to tensors only.


This PR was authored with the assistance of Claude.
