### PR TITLE
Fix size test build on gcc11

### DIFF
--- a/test/build_size_test.sh
+++ b/test/build_size_test.sh
@@ -15,7 +15,7 @@ EXTRA_BUILD_ARGS="${@:-}"
 # TODO(#8357): Remove -Wno-int-in-bool-context
 # TODO: Replace -ET_HAVE_PREAD=0 with a CMake option.
 #  FileDataLoader used in the size_test breaks baremetal builds with pread when missing.
-COMMON_CXXFLAGS="-fno-exceptions -fno-rtti -Wall -Werror -Wno-int-in-bool-context -DET_HAVE_PREAD=0"
+COMMON_CXXFLAGS="-fno-exceptions -fno-rtti -Wall -Werror -Wno-int-in-bool-context -Wno-stringop-overread -DET_HAVE_PREAD=0"
 
 cmake_install_executorch_lib() {
   echo "Installing libexecutorch.a"


### PR DESCRIPTION
### Summary
size_test on gcc11 fails with 
```
In static member function ‘static constexpr std::size_t std::char_traits<char>::length(const char_type*)’,
    inlined from ‘constexpr std::basic_string_view<_CharT, _Traits>::basic_string_view(const _CharT*) [with _CharT = char; _Traits = std::char_traits<char>]’ at /usr/include/c++/11/string_view:132:35,
    inlined from ‘executorch::runtime::Result<void*> executorch::runtime::deserialization::getTensorDataPtr(const executorch_flatbuffer::Tensor*, const executorch::runtime::Program*, size_t, executorch::runtime::HierarchicalAllocator*, const executorch::runtime::NamedDataMap*, executorch::runtime::Span<executorch::runtime::deserialization::NamedData>)’ at /data/users/lfq/binary-size/executorch/runtime/executor/tensor_parser_exec_aten.cpp:218:41:
/usr/include/c++/11/bits/char_traits.h:399:32: error: ‘long unsigned int __builtin_strlen(const char*)’ reading 1 or more bytes from a region of size 0 [-Werror=stringop-overread]
  399 |         return __builtin_strlen(__s);
      |                ~~~~~~~~~~~~~~~~^~~~~
In file included from /data/users/lfq/binary-size/executorch/../executorch/runtime/executor/tensor_parser.h:21,
                 from /data/users/lfq/binary-size/executorch/runtime/executor/tensor_parser_exec_aten.cpp:9:
/data/users/lfq/binary-size/executorch/cmake-out/schema/include/executorch/schema/program_generated.h: In function ‘executorch::runtime::Result<void*> executorch::runtime::deserialization::getTensorDataPtr(const executorch_flatbuffer::Tensor*, const executorch::runtime::Program*, size_t, executorch::runtime::HierarchicalAllocator*, const executorch::runtime::NamedDataMap*, executorch::runtime::Span<executorch::runtime::deserialization::NamedData>)’:
/data/users/lfq/binary-size/executorch/cmake-out/schema/include/executorch/schema/program_generated.h:568:8: note: at offset 5 into source object ‘executorch_flatbuffer::ExtraTensorInfo::<anonymous>’ of size 1
  568 | struct ExtraTensorInfo FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
```

### Test plan
Flatbuffer should be safe - add -Wno-stringop-overread to suppress the error.

size results after stripping
```
sh test/build_size_test.sh 

(executorch) [lfq@devvm11764.nha0 /data/users/lfq/binary-size/executorch (binary-size)]$ ls -la cmake-out/test/size_test_all_ops
-rwxr-xr-x 1 lfq users 1670416 Mar  4 22:37 cmake-out/test/size_test_all_ops

(executorch) [lfq@devvm11764.nha0 /data/users/lfq/binary-size/executorch (binary-size)]$ ls -la cmake-out/test/size_test
-rwxr-xr-x 1 lfq users 56240 Mar  4 22:38 cmake-out/test/size_test
```
