### PR TITLE
Binary size 1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,6 +206,16 @@ endif()
 if(EXECUTORCH_OPTIMIZE_SIZE)
   # -Os: Optimize for size.
   set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Os")
+  if(NOT WIN32 AND NOT MSVC)
+    # Suppress .eh_frame generation to reduce binary size. Safe because
+    # ExecuTorch builds with -fno-exceptions.
+    set(CMAKE_CXX_FLAGS_RELEASE
+        "${CMAKE_CXX_FLAGS_RELEASE} -fno-asynchronous-unwind-tables -fno-unwind-tables"
+    )
+    set(CMAKE_C_FLAGS_RELEASE
+        "${CMAKE_C_FLAGS_RELEASE} -fno-asynchronous-unwind-tables -fno-unwind-tables"
+    )
+  endif()
 else()
   # -O2: Moderate opt.
   set(CMAKE_CXX_FLAGS_RELEASE "-O2 ${CMAKE_CXX_FLAGS_RELEASE}")

--- a/test/build_size_test.sh
+++ b/test/build_size_test.sh
@@ -15,7 +15,7 @@ EXTRA_BUILD_ARGS="${@:-}"
 # TODO(#8357): Remove -Wno-int-in-bool-context
 # TODO: Replace -ET_HAVE_PREAD=0 with a CMake option.
 #  FileDataLoader used in the size_test breaks baremetal builds with pread when missing.
-COMMON_CXXFLAGS="-fno-exceptions -fno-rtti -Wall -Werror -Wno-int-in-bool-context -DET_HAVE_PREAD=0"
+COMMON_CXXFLAGS="-fno-exceptions -fno-rtti -Wall -Werror -Wno-int-in-bool-context -Wno-stringop-overread -DET_HAVE_PREAD=0"
 
 cmake_install_executorch_lib() {
   echo "Installing libexecutorch.a"


### PR DESCRIPTION
# binary-size-1: Suppress .eh_frame generation when EXECUTORCH_OPTIMIZE_SIZE is ON

## Change

Added `-fno-asynchronous-unwind-tables` and `-fno-unwind-tables` to both `CMAKE_CXX_FLAGS_RELEASE` and `CMAKE_C_FLAGS_RELEASE` when `EXECUTORCH_OPTIMIZE_SIZE` is enabled, gated behind `NOT WIN32 AND NOT MSVC`.

This eliminates the `.eh_frame` and `.eh_frame_hdr` sections from the compiled runtime library objects. These sections contain stack unwinding tables that GCC generates by default — even with `-fno-exceptions` — for asynchronous signal handling and debugger stack traces. Since ExecuTorch already opts out of C++ exceptions, these tables serve no runtime purpose in release builds optimized for size.

## Binary size

| Binary | This change (1 vs main) | Cumulative (1 vs main) |
|---|---|---|
| `size_test` (stripped) | -8,192 | -8,192 |
| `size_test_all_ops` (stripped) | -143,360 | -143,360 |

Baseline (main): `size_test` = 56,240 bytes, `size_test_all_ops` = 1,670,416 bytes.

## Repro

```bash
cd /data/users/lfq/binary-size/executorch
git checkout binary-size-1
bash test/build_size_test.sh
strip -o /tmp/size_test_stripped cmake-out/test/size_test
strip -o /tmp/size_test_all_ops_stripped cmake-out/test/size_test_all_ops
ls -la /tmp/size_test_stripped /tmp/size_test_all_ops_stripped
```
