### PR TITLE
[executorch][nvidia][tensorrt][5/n] Integrate partitioner

### DIFF
--- a/backends/nvidia/tensorrt/partitioner/__init__.py
+++ b/backends/nvidia/tensorrt/partitioner/__init__.py
@@ -6,21 +6,27 @@
 
 """TensorRT partitioner for ExecuTorch."""
 
-from typing import Dict, List, Optional
+from typing import Callable, Dict, List, Optional, Tuple
+
+import torch
 
 from executorch.backends.nvidia.tensorrt.backend import TensorRTBackend
+from executorch.backends.nvidia.tensorrt.partitioner.operator_support import (
+    TensorRTOperatorSupport,
+)
 from executorch.exir.backend.compile_spec_schema import CompileSpec
 from executorch.exir.backend.partitioner import (
     DelegationSpec,
     Partitioner,
     PartitionResult,
 )
-from torch.export.exported_program import ExportedProgram
+from executorch.exir.backend.utils import tag_constant_data
+from torch.export import ExportedProgram
+from torch.fx.passes.infra.partitioner import CapabilityBasedPartitioner
 
 
 class TensorRTPartitioner(Partitioner):
-    """Partitioner for TensorRT backend.
-    """
+    """Partitioner for TensorRT backend."""
 
     def __init__(
         self,
@@ -38,8 +44,50 @@ class TensorRTPartitioner(Partitioner):
 
         Identifies subgraphs that can be lowered to the TensorRT backend.
         """
+
+        capability_partitioner = CapabilityBasedPartitioner(
+            exported_program.graph_module,
+            TensorRTOperatorSupport(),
+            allows_single_node_partition=True,
+        )
+        partition_list = capability_partitioner.propose_partitions()
+
         partition_tags: Dict[str, DelegationSpec] = {}
+        for partition in partition_list:
+            tag = f"tensorrt_{partition.id}"
+            for node in partition.nodes:
+                node.meta["delegation_tag"] = tag
+            partition_tags[tag] = self.delegation_spec
+
+        tag_constant_data(exported_program)
+
         return PartitionResult(
             tagged_exported_program=exported_program,
             partition_tags=partition_tags,
         )
+
+    def ops_to_not_decompose(
+        self, ep: ExportedProgram
+    ) -> Tuple[List[torch._ops.OpOverload], Optional[Callable[[torch.fx.Node], bool]]]:
+        """Return operators that should not be decomposed.
+
+        This prevents certain operations from being decomposed during edge transform,
+        which can cause partition boundaries when intermediate dim_order operations
+        are inserted. By keeping these operations intact, we ensure the entire model
+        stays in a single TRT partition.
+
+        Args:
+            ep: The exported program being partitioned.
+
+        Returns:
+            Tuple of (list of ops to not decompose, optional filter function).
+        """
+        # pixel_shuffle decomposes into view + permute + view, and the edge transform
+        # inserts dim_order_ops._clone_dim_order operations between them. By preventing
+        # decomposition, we keep pixel_shuffle as a single operation that our converter
+        # handles directly.
+        ops_not_decompose = [
+            torch.ops.aten.pixel_shuffle.default,
+        ]
+
+        return (ops_not_decompose, None)

--- a/backends/nvidia/tensorrt/partitioner/operator_support.py
+++ b/backends/nvidia/tensorrt/partitioner/operator_support.py
@@ -24,7 +24,9 @@ class TensorRTOperatorSupport(OperatorSupportBase):
 
     # Operations that have TensorRT converters.
     # Format: "op_name.overload" (e.g., "add.Tensor")
-    SUPPORTED_OPS: Set[str] = set()
+    SUPPORTED_OPS: Set[str] = {
+        "add.Tensor",
+    }
 
     # Glue operations that don't compute but are needed to keep partitions connected.
     # These are always supported regardless of dtype.

--- a/backends/nvidia/tensorrt/partitioner/targets.bzl
+++ b/backends/nvidia/tensorrt/partitioner/targets.bzl
@@ -18,5 +18,6 @@ def define_common_targets():
             "//caffe2:torch",
             "//executorch/backends/nvidia/tensorrt:backend",
             "//executorch/exir/backend:partitioner",
+            "//executorch/exir/backend:utils",
         ],
     )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #17899
* #17898
* #17897
* #17896
* #17895
* #17894
* #17893
* #17892
* #17891
* #17890
* #17889
* #17888
* #17887
* #17886
* #17885
* #17884
* #17883
* #17882
* #17881
* #17880
* __->__ #17879
* #17878
* #17877
* #17876
* #17875

Integrate the TensorRT partitioner with the export pipeline for graph partitioning.

Differential Revision: [D93275061](https://our.internmc.facebook.com/intern/diff/D93275061/)