### PR TITLE
Fix typos in Cadence backend docstrings

### DIFF
--- a/backends/cadence/aot/compiler_utils.py
+++ b/backends/cadence/aot/compiler_utils.py
@@ -46,9 +46,9 @@ def get_shape(
     graph_module: torch.fx.GraphModule, node: torch.fx.Node
 ) -> Union[torch.Size, None]:
     """
-    Return the shape of the tensor correspnding to node. If the node has a
+    Return the shape of the tensor corresponding to node. If the node has a
     tensor spec, return the shape from the metadata. If the node is a param,
-    return it shape. Otherwise return None.
+    return its shape. Otherwise return None.
     """
     try:
         # Case 1. node is a scalar (this pass happens before tensorization)

--- a/backends/cadence/aot/utils.py
+++ b/backends/cadence/aot/utils.py
@@ -192,9 +192,9 @@ def get_shape(
     graph_module: torch.fx.GraphModule, node: torch.fx.Node
 ) -> Union[torch.Size, None]:
     """
-    Return the shape of the tensor correspnding to node. If the node has a
+    Return the shape of the tensor corresponding to node. If the node has a
     tensor spec, return the shape from the metadata. If the node is a param,
-    return it shape. Otherwise return None.
+    return its shape. Otherwise return None.
     """
     try:
         # Case 1. node is a scalar


### PR DESCRIPTION
Summary:
Fix typos in `get_shape` docstrings in two Cadence backend files:
- "correspnding" → "corresponding"
- "return it shape" → "return its shape"

Affected files:
- `backends/cadence/aot/compiler_utils.py`
- `backends/cadence/aot/utils.py`

This diff was authored with the help of Claude.

Differential Revision: D95377421


