### PR TITLE
Arm backend: Avoid inplace buffer modification

### DIFF
--- a/backends/arm/_passes/replace_inf_and_limit_values_pass.py
+++ b/backends/arm/_passes/replace_inf_and_limit_values_pass.py
@@ -52,9 +52,8 @@ class ReplaceInfAndLimitValuesPass(ArmPass):
 
             modified = True
             # 255 here is mainly for attention_mask in Llama for reasonable quant scale
-            tensor[tensor == float("inf")] = 255
-            tensor[tensor == float("-inf")] = -255
-            setattr(graph_module, buf_name, tensor)
+            t = torch.nan_to_num(tensor, posinf=255, neginf=-255)
+            setattr(graph_module, buf_name, t)
 
         for node in graph_module.graph.nodes:
             arg_list = list(node.args)


### PR DESCRIPTION
For some buffers with grad=True, this triggered
Runtime error: a view of a leaf Variable that requires grad is being used in an in-place operation.

cc @digantdesai @SS-JIA @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell