### PR TITLE
[executorch][nvidia][tensorrt][2/n] Add TensorRT backend stub

### DIFF
--- a/backends/nvidia/tensorrt/__init__.py
+++ b/backends/nvidia/tensorrt/__init__.py
@@ -9,3 +9,25 @@
 This module provides TensorRT delegate support for accelerating
 PyTorch models on NVIDIA GPUs.
 """
+
+import os
+import platform
+import sys
+
+# On Jetson (aarch64 with JetPack), make system and user-installed packages
+# available inside venvs. This is needed for TensorRT (JetPack system package)
+# and optionally for packages like onnx installed via pip at system level.
+if platform.machine() == "aarch64" and os.path.exists("/etc/nv_tegra_release"):
+    _py_ver = f"python{sys.version_info.major}.{sys.version_info.minor}"
+    for _pkg_dir in [
+        f"/usr/lib/{_py_ver}/dist-packages",
+        os.path.expanduser(f"~/.local/lib/{_py_ver}/site-packages"),
+    ]:
+        if os.path.isdir(_pkg_dir) and _pkg_dir not in sys.path:
+            sys.path.append(_pkg_dir)
+
+from executorch.backends.nvidia.tensorrt.backend import TensorRTBackend
+
+__all__ = [
+    "TensorRTBackend",
+]

--- a/backends/nvidia/tensorrt/backend.py
+++ b/backends/nvidia/tensorrt/backend.py
@@ -1,0 +1,42 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""TensorRT backend implementation for ExecuTorch."""
+
+from typing import final, List
+
+from executorch.exir.backend.backend_details import (
+    BackendDetails,
+    CompileSpec,
+    PreprocessResult,
+)
+from torch.export.exported_program import ExportedProgram
+
+
+@final
+class TensorRTBackend(BackendDetails):
+    """TensorRT backend for accelerating models on NVIDIA GPUs.
+
+    This backend compiles ExecuTorch edge programs to TensorRT engines
+    for optimized inference on NVIDIA hardware.
+    """
+
+    @staticmethod
+    def preprocess(
+        edge_program: ExportedProgram,
+        compile_specs: List[CompileSpec],
+    ) -> PreprocessResult:
+        """Compile edge program to TensorRT engine.
+
+        Args:
+            edge_program: The edge dialect program to compile.
+            compile_specs: Backend-specific compilation options.
+
+        Returns:
+            PreprocessResult containing the serialized TensorRT engine.
+        """
+
+        return PreprocessResult(processed_bytes=b"")

--- a/backends/nvidia/tensorrt/targets.bzl
+++ b/backends/nvidia/tensorrt/targets.bzl
@@ -8,9 +8,24 @@ def define_common_targets():
     """
 
     runtime.python_library(
+        name = "backend",
+        srcs = [
+            "backend.py",
+        ],
+        visibility = ["PUBLIC"],
+        deps = [
+            "//caffe2:torch",
+            "//executorch/exir/backend:backend_details",
+        ],
+    )
+
+    runtime.python_library(
         name = "tensorrt",
         srcs = [
             "__init__.py",
         ],
         visibility = ["PUBLIC"],
+        deps = [
+            ":backend",
+        ],
     )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #17936
* #17935
* #17934
* #17933
* #17932
* #17931
* #17930
* #17929
* #17928
* #17927
* #17926
* #17925
* #17924
* #17923
* #17922
* #17921
* #17920
* #17919
* #17918
* #17917
* #17916
* #17915
* #17914
* __->__ #17913
* #17912

Add initial backend stub with empty preprocess implementation and TensorRT backend registration.

Differential Revision: [D93275053](https://our.internmc.facebook.com/intern/diff/D93275053/)