### PR TITLE
[executorch][nvidia][tensorrt][17/n] Add embedding, expand, upsample converters

### DIFF
--- a/backends/nvidia/tensorrt/converters/__init__.py
+++ b/backends/nvidia/tensorrt/converters/__init__.py
@@ -16,6 +16,8 @@ from executorch.backends.nvidia.tensorrt.converters import concat  # noqa: F401
 from executorch.backends.nvidia.tensorrt.converters import conv2d  # noqa: F401
 from executorch.backends.nvidia.tensorrt.converters import dim_order_ops  # noqa: F401
 from executorch.backends.nvidia.tensorrt.converters import div  # noqa: F401
+from executorch.backends.nvidia.tensorrt.converters import embedding  # noqa: F401
+from executorch.backends.nvidia.tensorrt.converters import expand  # noqa: F401
 from executorch.backends.nvidia.tensorrt.converters import getitem  # noqa: F401
 from executorch.backends.nvidia.tensorrt.converters import linear  # noqa: F401
 from executorch.backends.nvidia.tensorrt.converters import mm  # noqa: F401
@@ -26,6 +28,7 @@ from executorch.backends.nvidia.tensorrt.converters import reduction  # noqa: F4
 from executorch.backends.nvidia.tensorrt.converters import relu  # noqa: F401
 from executorch.backends.nvidia.tensorrt.converters import reshape  # noqa: F401
 from executorch.backends.nvidia.tensorrt.converters import sub  # noqa: F401
+from executorch.backends.nvidia.tensorrt.converters import upsample  # noqa: F401
 
 
 def clear_converter_weight_storage() -> None:

--- a/backends/nvidia/tensorrt/converters/embedding.py
+++ b/backends/nvidia/tensorrt/converters/embedding.py
@@ -1,0 +1,177 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""TensorRT Converters for Embedding Operations.
+
+Supported operations:
+- aten.embedding.default: Lookup embeddings from a weight matrix using indices
+
+TensorRT implements embeddings via IGatherLayer which indexes into a tensor.
+"""
+
+import logging
+from typing import Any, Dict, Optional
+
+import numpy as np
+import torch
+from executorch.backends.nvidia.tensorrt.converter_registry import converter
+from executorch.backends.nvidia.tensorrt.converter_utils import create_constant
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+def validate_embedding(node: torch.fx.Node) -> bool:
+    """Validate that an embedding node can be converted to TensorRT.
+
+    Args:
+        node: FX node representing the embedding operation.
+
+    Returns:
+        True if the node can be converted, False otherwise.
+    """
+    if node.op != "call_function":
+        logger.debug(
+            f"[TensorRT] validate_embedding: node {node.name} is not call_function"
+        )
+        return False
+
+    args = node.args
+    if len(args) < 2:
+        logger.debug(
+            f"[TensorRT] validate_embedding: node {node.name} has insufficient args"
+        )
+        return False
+
+    # First arg is weight, second is indices
+    if not isinstance(args[1], torch.fx.Node):
+        logger.debug(
+            f"[TensorRT] validate_embedding: indices is not a node, got {type(args[1])}"
+        )
+        return False
+
+    return True
+
+
+@converter("aten.embedding.default", validator_fn=validate_embedding)
+def convert_embedding(
+    node: torch.fx.Node,
+    network: Any,  # trt.INetworkDefinition
+    input_map: Dict[torch.fx.Node, Any],  # Dict[Node, trt.ITensor]
+    edge_program: Optional[Any] = None,
+) -> Any:  # trt.ITensor
+    """Convert PyTorch embedding to TensorRT.
+
+    PyTorch signature:
+        aten.embedding(
+            Tensor weight,
+            Tensor indices,
+            int padding_idx=-1,
+            bool scale_grad_by_freq=False,
+            bool sparse=False
+        ) -> Tensor
+
+    TensorRT uses IGatherLayer to implement embedding lookup.
+    The gather operation indexes into the weight matrix using the indices.
+
+    Args:
+        node: FX node representing the embedding operation.
+        network: TensorRT network definition.
+        input_map: Mapping from FX nodes to TensorRT tensors.
+        edge_program: Optional edge program for accessing weights/constants.
+
+    Returns:
+        TensorRT output tensor.
+    """
+    try:
+        import tensorrt as trt
+    except ImportError as e:
+        raise ImportError("TensorRT is required for convert_embedding") from e
+
+    logger.debug(f"[TensorRT] Converting embedding node: {node.name}")
+
+    args = node.args
+    weight_node = args[0]  # Embedding weight matrix
+    indices_node = args[1]  # Indices to look up
+
+    # Get weight tensor
+    weight_trt = None
+    if isinstance(weight_node, torch.fx.Node):
+        if weight_node in input_map:
+            weight_trt = input_map[weight_node]
+        elif hasattr(weight_node, "target") and edge_program is not None:
+            # Try to get weight from graph state dict
+            weight_name = weight_node.target
+            if hasattr(edge_program, "graph_module"):
+                gm = edge_program.graph_module
+                if hasattr(gm, "state_dict"):
+                    state_dict = gm.state_dict()
+                    if weight_name in state_dict:
+                        weight_data = state_dict[weight_name].detach().cpu().numpy()
+                        weight_trt = create_constant(
+                            network, weight_data, f"embedding_weight_{node.name}"
+                        )
+
+    if weight_trt is None:
+        raise ValueError(f"Could not get embedding weight for node {node.name}")
+
+    # Get indices tensor
+    if not isinstance(indices_node, torch.fx.Node):
+        raise ValueError(
+            f"Indices for embedding must be a node, got {type(indices_node)}"
+        )
+
+    if indices_node not in input_map:
+        raise ValueError(f"Indices node {indices_node.name} not found in input_map")
+
+    indices_trt = input_map[indices_node]
+
+    weight_shape = weight_trt.shape
+    indices_shape = indices_trt.shape
+
+    logger.debug(
+        f"[TensorRT] embedding: weight_shape={weight_shape}, indices_shape={indices_shape}"
+    )
+
+    # Use gather layer to implement embedding lookup
+    # Gather along axis 0 (the vocabulary dimension)
+    gather_layer = network.add_gather(weight_trt, indices_trt, axis=0)
+    if gather_layer is None:
+        raise RuntimeError(f"Failed to create gather layer for node {node.name}")
+
+    gather_layer.name = f"embedding_gather_{node.name}"
+
+    logger.debug(f"[TensorRT] Created embedding gather layer: {gather_layer.name}")
+
+    return gather_layer.get_output(0)
+
+
+@converter("aten.embedding_renorm_.default", validator_fn=validate_embedding)
+def convert_embedding_renorm(
+    node: torch.fx.Node,
+    network: Any,  # trt.INetworkDefinition
+    input_map: Dict[torch.fx.Node, Any],  # Dict[Node, trt.ITensor]
+    edge_program: Optional[Any] = None,
+) -> Any:  # trt.ITensor
+    """Convert PyTorch embedding_renorm_ to TensorRT.
+
+    This is an in-place operation for renormalizing embeddings.
+    In TensorRT, we treat this as a no-op since it's typically used during training.
+    """
+    logger.warning(
+        f"[TensorRT] embedding_renorm_ is a training operation, treating as no-op"
+    )
+    # Return the weight tensor unchanged
+    weight_node = node.args[0]
+    if isinstance(weight_node, torch.fx.Node) and weight_node in input_map:
+        return input_map[weight_node]
+    raise ValueError(f"Could not get embedding weight for node {node.name}")
+
+
+__all__ = [
+    "convert_embedding",
+    "convert_embedding_renorm",
+    "validate_embedding",
+]

--- a/backends/nvidia/tensorrt/converters/expand.py
+++ b/backends/nvidia/tensorrt/converters/expand.py
@@ -1,0 +1,297 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""TensorRT Converters for Expand and Repeat Operations.
+
+Supported operations:
+- aten.expand.default: Expands a tensor to a larger size with broadcasting
+- aten.expand_copy.default: Same as expand but with copy semantics
+- aten.repeat.default: Repeats tensor along specified dimensions
+
+TensorRT uses ISliceLayer with stride for broadcasting or IShuffleLayer for reshaping.
+"""
+
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+import tensorrt as trt
+import torch
+from executorch.backends.nvidia.tensorrt.converter_registry import converter
+from executorch.backends.nvidia.tensorrt.converter_utils import get_node_shape
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+def validate_expand(node: torch.fx.Node) -> bool:
+    """Validate that an expand node can be converted to TensorRT.
+
+    Args:
+        node: FX node representing the expand operation.
+
+    Returns:
+        True if the node can be converted, False otherwise.
+    """
+    if node.op != "call_function":
+        logger.debug(
+            f"[TensorRT] validate_expand: node {node.name} is not call_function"
+        )
+        return False
+
+    args = node.args
+    if len(args) < 2:
+        logger.debug(
+            f"[TensorRT] validate_expand: node {node.name} has insufficient args"
+        )
+        return False
+
+    if not isinstance(args[0], torch.fx.Node):
+        logger.debug(
+            f"[TensorRT] validate_expand: input is not a node, got {type(args[0])}"
+        )
+        return False
+
+    return True
+
+
+def _get_expand_output_shape(
+    input_shape: Tuple[int, ...], expand_shape: List[int]
+) -> Tuple[int, ...]:
+    """Calculate the output shape after expand operation.
+
+    Args:
+        input_shape: Shape of the input tensor
+        expand_shape: Desired expansion shape (-1 means keep original)
+
+    Returns:
+        Output shape after expansion
+    """
+    # Pad input_shape with 1s on the left to match expand_shape length
+    input_dims = len(input_shape)
+    expand_dims = len(expand_shape)
+
+    if expand_dims > input_dims:
+        input_shape = (1,) * (expand_dims - input_dims) + tuple(input_shape)
+
+    output_shape = []
+    for i, (inp_dim, exp_dim) in enumerate(zip(input_shape, expand_shape)):
+        if exp_dim == -1:
+            output_shape.append(inp_dim)
+        else:
+            if inp_dim != 1 and inp_dim != exp_dim:
+                raise ValueError(
+                    f"Cannot expand dimension {i} from {inp_dim} to {exp_dim}"
+                )
+            output_shape.append(exp_dim)
+
+    return tuple(output_shape)
+
+
+@converter("aten.expand.default", validator_fn=validate_expand)
+def convert_expand(
+    node: torch.fx.Node,
+    network: Any,  # trt.INetworkDefinition
+    input_map: Dict[torch.fx.Node, Any],  # Dict[Node, trt.ITensor]
+    edge_program: Optional[Any] = None,
+) -> Any:  # trt.ITensor
+    """Convert PyTorch expand to TensorRT.
+
+    PyTorch signature:
+        aten.expand(Tensor self, SymInt[] size) -> Tensor
+
+    Expand creates a view of the tensor with additional dimensions.
+    For TensorRT, we use ISliceLayer with step=0 for broadcast dimensions.
+
+    Args:
+        node: FX node representing the expand operation.
+        network: TensorRT network definition.
+        input_map: Mapping from FX nodes to TensorRT tensors.
+        edge_program: Optional edge program for accessing weights/constants.
+
+    Returns:
+        TensorRT output tensor.
+    """
+    logger.debug(f"[TensorRT] Converting expand node: {node.name}")
+
+    args = node.args
+    input_node = args[0]
+    expand_size = list(args[1]) if len(args) > 1 else list(node.kwargs.get("size", []))
+
+    if not isinstance(input_node, torch.fx.Node):
+        raise ValueError(f"Input to expand must be a node, got {type(input_node)}")
+
+    if input_node not in input_map:
+        raise ValueError(f"Input node {input_node.name} not found in input_map")
+
+    input_trt = input_map[input_node]
+
+    # Get shape from node metadata for reliability (TRT shapes can be invalid during network building)
+    input_shape = get_node_shape(input_node) or tuple(input_trt.shape)
+
+    logger.debug(
+        f"[TensorRT] expand: input_shape={input_shape}, expand_size={expand_size}"
+    )
+
+    # Calculate output shape
+    output_shape = _get_expand_output_shape(input_shape, expand_size)
+
+    # Check for dynamic dimensions (negative values in input_shape)
+    has_dynamic = any(d < 0 for d in list(input_shape))
+
+    if has_dynamic:
+        logger.warning(
+            f"[TensorRT] expand with dynamic shapes may have limitations: {input_shape}"
+        )
+
+    # First, add leading dimensions if needed
+    input_dims = len(input_shape)
+    output_dims = len(output_shape)
+
+    current_tensor = input_trt
+
+    if output_dims > input_dims:
+        # Add leading dimensions using shuffle (reshape)
+        new_shape = (1,) * (output_dims - input_dims) + tuple(input_shape)
+        shuffle = network.add_shuffle(current_tensor)
+        if shuffle is None:
+            raise RuntimeError(f"Failed to create shuffle layer for node {node.name}")
+        shuffle.reshape_dims = new_shape
+        shuffle.name = f"expand_reshape_{node.name}"
+        current_tensor = shuffle.get_output(0)
+        input_shape = new_shape
+
+    # Now broadcast using ISliceLayer with appropriate strides
+    # For dimensions that need broadcasting (input=1, output>1), use stride=0
+    start = [0] * output_dims
+    shape = list(output_shape)
+    stride = []
+
+    for i, (inp_dim, out_dim) in enumerate(zip(input_shape, output_shape)):
+        if inp_dim == 1 and out_dim > 1:
+            # This dimension needs broadcasting - use stride 0
+            stride.append(0)
+        else:
+            stride.append(1)
+
+    # Use slice layer for broadcasting
+    slice_layer = network.add_slice(
+        current_tensor,
+        start=start,
+        shape=shape,
+        stride=stride,
+    )
+    if slice_layer is None:
+        raise RuntimeError(f"Failed to create slice layer for node {node.name}")
+    slice_layer.name = f"expand_slice_{node.name}"
+
+    logger.debug(
+        f"[TensorRT] Created expand layers: {slice_layer.name}, "
+        f"output_shape={output_shape}, stride={stride}"
+    )
+
+    return slice_layer.get_output(0)
+
+
+@converter("aten.expand_copy.default", validator_fn=validate_expand)
+def convert_expand_copy(
+    node: torch.fx.Node,
+    network: Any,  # trt.INetworkDefinition
+    input_map: Dict[torch.fx.Node, Any],  # Dict[Node, trt.ITensor]
+    edge_program: Optional[Any] = None,
+) -> Any:  # trt.ITensor
+    """Convert PyTorch expand_copy to TensorRT.
+
+    Same as expand but with copy semantics. In TensorRT, there's no
+    difference since all operations create new tensors.
+    """
+    return convert_expand(node, network, input_map, edge_program)
+
+
+@converter("aten.repeat.default", validator_fn=validate_expand)
+def convert_repeat(
+    node: torch.fx.Node,
+    network: Any,  # trt.INetworkDefinition
+    input_map: Dict[torch.fx.Node, Any],  # Dict[Node, trt.ITensor]
+    edge_program: Optional[Any] = None,
+) -> Any:  # trt.ITensor
+    """Convert PyTorch repeat to TensorRT.
+
+    PyTorch signature:
+        aten.repeat(Tensor self, SymInt[] repeats) -> Tensor
+
+    Repeat copies data along dimensions. We implement this using
+    tile operation via concat layers or a combination of reshape + broadcast.
+
+    Args:
+        node: FX node representing the repeat operation.
+        network: TensorRT network definition.
+        input_map: Mapping from FX nodes to TensorRT tensors.
+        edge_program: Optional edge program for accessing weights/constants.
+
+    Returns:
+        TensorRT output tensor.
+    """
+    logger.debug(f"[TensorRT] Converting repeat node: {node.name}")
+
+    args = node.args
+    input_node = args[0]
+    repeats = list(args[1]) if len(args) > 1 else list(node.kwargs.get("repeats", []))
+
+    if not isinstance(input_node, torch.fx.Node):
+        raise ValueError(f"Input to repeat must be a node, got {type(input_node)}")
+
+    if input_node not in input_map:
+        raise ValueError(f"Input node {input_node.name} not found in input_map")
+
+    input_trt = input_map[input_node]
+
+    # Get shape from node metadata for reliability (TRT shapes can be invalid during network building)
+    input_shape = list(get_node_shape(input_node) or input_trt.shape)
+
+    logger.debug(f"[TensorRT] repeat: input_shape={input_shape}, repeats={repeats}")
+
+    # Pad input shape if repeats has more dimensions
+    input_dims = len(input_shape)
+    repeat_dims = len(repeats)
+
+    current_tensor = input_trt
+
+    if repeat_dims > input_dims:
+        # Add leading dimensions using shuffle
+        new_shape = (1,) * (repeat_dims - input_dims) + tuple(input_shape)
+        shuffle = network.add_shuffle(current_tensor)
+        if shuffle is None:
+            raise RuntimeError(f"Failed to create shuffle layer for node {node.name}")
+        shuffle.reshape_dims = new_shape
+        shuffle.name = f"repeat_reshape_{node.name}"
+        current_tensor = shuffle.get_output(0)
+        input_shape = new_shape
+
+    # For each dimension with repeat > 1, concatenate the tensor
+    for dim, repeat_count in enumerate(repeats):
+        if repeat_count > 1:
+            # Create concat of repeat_count copies along this dimension
+            tensors_to_concat = [current_tensor] * repeat_count
+            concat_layer = network.add_concatenation(tensors_to_concat)
+            if concat_layer is None:
+                raise RuntimeError(
+                    f"Failed to create concat layer for repeat dim {dim}"
+                )
+            concat_layer.axis = dim
+            concat_layer.name = f"repeat_concat_dim{dim}_{node.name}"
+            current_tensor = concat_layer.get_output(0)
+
+    logger.debug(f"[TensorRT] Created repeat layers for node: {node.name}")
+
+    return current_tensor
+
+
+__all__ = [
+    "convert_expand",
+    "convert_expand_copy",
+    "convert_repeat",
+    "validate_expand",
+]

--- a/backends/nvidia/tensorrt/converters/targets.bzl
+++ b/backends/nvidia/tensorrt/converters/targets.bzl
@@ -20,6 +20,8 @@ def define_common_targets():
             "conv2d.py",
             "dim_order_ops.py",
             "div.py",
+            "embedding.py",
+            "expand.py",
             "getitem.py",
             "linear.py",
             "mm.py",
@@ -30,6 +32,7 @@ def define_common_targets():
             "relu.py",
             "reshape.py",
             "sub.py",
+            "upsample.py",
         ],
         visibility = ["PUBLIC"],
         deps = [

--- a/backends/nvidia/tensorrt/converters/upsample.py
+++ b/backends/nvidia/tensorrt/converters/upsample.py
@@ -1,0 +1,240 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""TensorRT Converters for Upsample Operations.
+
+Supported operations:
+- aten.upsample_bilinear2d.vec: 2D bilinear upsampling
+- aten.upsample_nearest2d.vec: 2D nearest neighbor upsampling
+
+TensorRT uses IResizeLayer for upsampling operations with configurable
+interpolation modes (LINEAR for bilinear, NEAREST for nearest neighbor).
+"""
+
+import logging
+from typing import Any, Dict, Optional
+
+import torch
+from executorch.backends.nvidia.tensorrt.converter_registry import converter
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+def validate_upsample(node: torch.fx.Node) -> bool:
+    """Validate that an upsample node can be converted to TensorRT.
+
+    Args:
+        node: FX node representing the upsample operation.
+
+    Returns:
+        True if the node can be converted, False otherwise.
+    """
+    if node.op != "call_function":
+        logger.debug(
+            f"[TensorRT] validate_upsample: node {node.name} is not call_function"
+        )
+        return False
+
+    args = node.args
+    if len(args) < 1:
+        logger.debug(
+            f"[TensorRT] validate_upsample: node {node.name} has insufficient args"
+        )
+        return False
+
+    if not isinstance(args[0], torch.fx.Node):
+        logger.debug(
+            f"[TensorRT] validate_upsample: input is not a node, got {type(args[0])}"
+        )
+        return False
+
+    return True
+
+
+@converter("aten.upsample_bilinear2d.vec", validator_fn=validate_upsample)
+def convert_upsample_bilinear2d(
+    node: torch.fx.Node,
+    network: Any,  # trt.INetworkDefinition
+    input_map: Dict[torch.fx.Node, Any],  # Dict[Node, trt.ITensor]
+    edge_program: Optional[Any] = None,
+) -> Any:  # trt.ITensor
+    """Convert PyTorch upsample_bilinear2d to TensorRT resize layer.
+
+    PyTorch signature:
+        aten.upsample_bilinear2d.vec(
+            Tensor input,
+            SymInt[]? output_size,
+            bool align_corners,
+            float[]? scale_factors
+        ) -> Tensor
+
+    Args:
+        node: FX node representing the upsample_bilinear2d operation.
+        network: TensorRT network definition.
+        input_map: Mapping from FX nodes to TensorRT tensors.
+        edge_program: Optional edge program for accessing weights/constants.
+
+    Returns:
+        TensorRT output tensor.
+    """
+    try:
+        import tensorrt as trt
+    except ImportError as e:
+        raise ImportError(
+            "TensorRT is required for convert_upsample_bilinear2d"
+        ) from e
+
+    logger.debug(f"[TensorRT] Converting upsample_bilinear2d node: {node.name}")
+
+    args = node.args
+    kwargs = node.kwargs
+
+    input_node = args[0]
+    output_size = args[1] if len(args) > 1 else kwargs.get("output_size")
+    align_corners = args[2] if len(args) > 2 else kwargs.get("align_corners", False)
+    scale_factors = args[3] if len(args) > 3 else kwargs.get("scale_factors")
+
+    if not isinstance(input_node, torch.fx.Node):
+        raise ValueError(
+            f"Input to upsample_bilinear2d must be a node, got {type(input_node)}"
+        )
+
+    if input_node not in input_map:
+        raise ValueError(f"Input node {input_node.name} not found in input_map")
+
+    input_trt = input_map[input_node]
+
+    logger.debug(
+        f"[TensorRT] upsample_bilinear2d: output_size={output_size}, "
+        f"align_corners={align_corners}, scale_factors={scale_factors}"
+    )
+
+    layer = network.add_resize(input_trt)
+    if layer is None:
+        raise RuntimeError(f"Failed to create resize layer for node {node.name}")
+
+    # TensorRT 10.x uses InterpolationMode (ResizeMode was deprecated)
+    layer.resize_mode = trt.InterpolationMode.LINEAR
+
+    if align_corners:
+        layer.coordinate_transformation = (
+            trt.ResizeCoordinateTransformation.ALIGN_CORNERS
+        )
+    else:
+        layer.coordinate_transformation = trt.ResizeCoordinateTransformation.HALF_PIXEL
+
+    if output_size is not None:
+        input_shape = input_trt.shape
+        output_shape = tuple(input_shape[:2]) + tuple(output_size)
+        layer.shape = output_shape
+        logger.debug(f"[TensorRT] Set resize output shape: {output_shape}")
+    elif scale_factors is not None:
+        full_scales = [1.0, 1.0] + list(scale_factors)
+        layer.scales = full_scales
+        logger.debug(f"[TensorRT] Set resize scales: {full_scales}")
+    else:
+        raise ValueError(
+            f"upsample_bilinear2d node {node.name} must have "
+            f"either output_size or scale_factors"
+        )
+
+    layer.name = f"upsample_bilinear2d_{node.name}"
+
+    logger.debug(f"[TensorRT] Created upsample_bilinear2d layer: {layer.name}")
+
+    return layer.get_output(0)
+
+
+@converter("aten.upsample_nearest2d.vec", validator_fn=validate_upsample)
+def convert_upsample_nearest2d(
+    node: torch.fx.Node,
+    network: Any,  # trt.INetworkDefinition
+    input_map: Dict[torch.fx.Node, Any],  # Dict[Node, trt.ITensor]
+    edge_program: Optional[Any] = None,
+) -> Any:  # trt.ITensor
+    """Convert PyTorch upsample_nearest2d to TensorRT resize layer.
+
+    PyTorch signature:
+        aten.upsample_nearest2d.vec(
+            Tensor input,
+            SymInt[]? output_size,
+            float[]? scale_factors
+        ) -> Tensor
+
+    Args:
+        node: FX node representing the upsample_nearest2d operation.
+        network: TensorRT network definition.
+        input_map: Mapping from FX nodes to TensorRT tensors.
+        edge_program: Optional edge program for accessing weights/constants.
+
+    Returns:
+        TensorRT output tensor.
+    """
+    try:
+        import tensorrt as trt
+    except ImportError as e:
+        raise ImportError("TensorRT is required for convert_upsample_nearest2d") from e
+
+    logger.debug(f"[TensorRT] Converting upsample_nearest2d node: {node.name}")
+
+    args = node.args
+    kwargs = node.kwargs
+
+    input_node = args[0]
+    output_size = args[1] if len(args) > 1 else kwargs.get("output_size")
+    scale_factors = args[2] if len(args) > 2 else kwargs.get("scale_factors")
+
+    if not isinstance(input_node, torch.fx.Node):
+        raise ValueError(
+            f"Input to upsample_nearest2d must be a node, got {type(input_node)}"
+        )
+
+    if input_node not in input_map:
+        raise ValueError(f"Input node {input_node.name} not found in input_map")
+
+    input_trt = input_map[input_node]
+
+    logger.debug(
+        f"[TensorRT] upsample_nearest2d: output_size={output_size}, "
+        f"scale_factors={scale_factors}"
+    )
+
+    layer = network.add_resize(input_trt)
+    if layer is None:
+        raise RuntimeError(f"Failed to create resize layer for node {node.name}")
+
+    # TensorRT 10.x uses InterpolationMode (ResizeMode was deprecated)
+    layer.resize_mode = trt.InterpolationMode.NEAREST
+
+    if output_size is not None:
+        input_shape = input_trt.shape
+        output_shape = tuple(input_shape[:2]) + tuple(output_size)
+        layer.shape = output_shape
+        logger.debug(f"[TensorRT] Set resize output shape: {output_shape}")
+    elif scale_factors is not None:
+        full_scales = [1.0, 1.0] + list(scale_factors)
+        layer.scales = full_scales
+        logger.debug(f"[TensorRT] Set resize scales: {full_scales}")
+    else:
+        raise ValueError(
+            f"upsample_nearest2d node {node.name} must have "
+            f"either output_size or scale_factors"
+        )
+
+    layer.name = f"upsample_nearest2d_{node.name}"
+
+    logger.debug(f"[TensorRT] Created upsample_nearest2d layer: {layer.name}")
+
+    return layer.get_output(0)
+
+
+__all__ = [
+    "convert_upsample_bilinear2d",
+    "convert_upsample_nearest2d",
+    "validate_upsample",
+]

--- a/examples/nvidia/tensorrt/export.py
+++ b/examples/nvidia/tensorrt/export.py
@@ -35,10 +35,13 @@ logging.basicConfig(level=logging.INFO, format=FORMAT)
 TENSORRT_SUPPORTED_MODELS = {
     "add",
     "add_mul",
+    "conv1d",
+    "dl3",
     "linear",
     "mul",
     "mv3",
     "softmax",
+    "w2l",
 }
 
 

--- a/examples/nvidia/tensorrt/tests/TARGETS
+++ b/examples/nvidia/tensorrt/tests/TARGETS
@@ -1,6 +1,20 @@
 load("@fbcode_macros//build_defs:python_unittest_remote_gpu.bzl", "python_unittest_remote_gpu")
+load("@fbsource//tools/build_defs:manifold.bzl", "manifold_get")
 
 oncall("executorch")
+
+# Model weights cached on Manifold to avoid network downloads on CI GPU workers.
+# Upload new weights: manifold put <local_file> executorch/tree/models/tensorrt/weights/<filename>
+manifold_get(
+    name = "edsr_weights",
+    out = "edsr64_x2.pt",
+    api_key = "executorch-key",
+    artifact_path = "tree/models/tensorrt/weights/edsr64_x2.pt",
+    bucket_name = "executorch",
+    sha1 = "4b67b9f0cbe94e244fc59ca94893a349b63efb8c",
+    timeout_msec = 120000,
+    visibility = ["PUBLIC"],
+)
 
 # Export correctness tests: exports each supported model with TensorRT
 # and compares inference outputs against eager PyTorch on GPU.
@@ -12,6 +26,7 @@ python_unittest_remote_gpu(
     env = {
         "HTTPS_PROXY": "http://fwdproxy.any:8080",
         "HTTP_PROXY": "http://fwdproxy.any:8080",
+        "EDSR_WEIGHTS": "$(location :edsr_weights)",
     },
     keep_gpu_sections = True,
     labels = ["long_running"],

--- a/examples/nvidia/tensorrt/tests/test_export.py
+++ b/examples/nvidia/tensorrt/tests/test_export.py
@@ -24,7 +24,9 @@ logging.basicConfig(level=logging.INFO)
 # Mapping from env var to expected cache filename.
 # The test TARGETS provides these via manifold_get + $(location).
 # Entries are added as models are enabled in later commits.
-_WEIGHT_ENV_VARS = {}
+_WEIGHT_ENV_VARS = {
+    "EDSR_WEIGHTS": "edsr64_x2.pt",
+}
 
 
 def _populate_weight_cache() -> None:
@@ -104,3 +106,12 @@ class ExportCorrectnessTest(unittest.TestCase):
 
     def test_linear(self) -> None:
         _export_and_verify("linear")
+    def test_conv1d(self) -> None:
+        _export_and_verify("conv1d")
+
+    def test_dl3(self) -> None:
+        _export_and_verify("dl3")
+
+
+    def test_w2l(self) -> None:
+        _export_and_verify("w2l")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #17936
* #17935
* #17934
* #17933
* #17932
* #17931
* #17930
* #17929
* __->__ #17928
* #17927
* #17926
* #17925
* #17924
* #17923
* #17922
* #17921
* #17920
* #17919
* #17918
* #17917
* #17916
* #17915
* #17914
* #17913
* #17912

Add converters for embedding, expand, and upsample operations. These enable transformer-based models and upsampling layers.

Differential Revision: [D93275040](https://our.internmc.facebook.com/intern/diff/D93275040/)