### PR TITLE
Add quantizer support for quantized_conv1d_ncl (#17938)

### DIFF
--- a/backends/cadence/aot/quantizer/patterns.py
+++ b/backends/cadence/aot/quantizer/patterns.py
@@ -267,7 +267,7 @@ class Conv1dPattern(QuantizationPattern):
         )
 
     def replacement_op(self) -> OpOverload:
-        return torch.ops.cadence.quantized_conv2d_nchw.per_tensor
+        return torch.ops.cadence.quantized_conv1d_ncl.per_tensor
 
 
 class Conv2dPattern(QuantizationPattern):
@@ -594,11 +594,17 @@ class Conv1dReluPattern0(ConvReluBasePattern):
     def partition_types(self) -> List[OpOverload]:
         return [torch.ops.aten.conv1d.default, torch.ops.aten.relu.default]
 
+    def replacement_op(self) -> OpOverload:
+        return torch.ops.cadence.quantized_conv1d_ncl.per_tensor
+
 
 # Conv1d + alternate relu op fusion
 class Conv1dReluPattern1(ConvReluBasePattern):
     def partition_types(self) -> List[OpOverload]:
         return [torch.ops.aten.conv1d.default, torch.ops.aten.relu_.default]
+
+    def replacement_op(self) -> OpOverload:
+        return torch.ops.cadence.quantized_conv1d_ncl.per_tensor
 
 
 # Conv2d + regular relu op fusion

--- a/backends/cadence/aot/replace_ops.py
+++ b/backends/cadence/aot/replace_ops.py
@@ -23,6 +23,7 @@ from executorch.backends.cadence.aot.compiler_utils import quantize_tensor_multi
 from executorch.backends.cadence.aot.fuse_ops import FuseCascadedTransposeOrPermuteOps
 from executorch.backends.cadence.aot.pass_utils import (
     CadencePassAttribute,
+    get_arg,
     register_cadence_pass,
     RemoveOrReplacePassInterface,
 )
@@ -868,9 +869,20 @@ class ReplaceTrivialConvWithLinear(RemoveOrReplacePassInterface):
         exir_ops.edge.cadence.conv1d.default: exir_ops.edge.aten.linear.default,
         exir_ops.edge.cadence.conv2d.default: exir_ops.edge.aten.linear.default,
         exir_ops.edge.cadence.conv3d.default: exir_ops.edge.aten.linear.default,
+        exir_ops.edge.cadence.quantized_conv1d_ncl.per_tensor: exir_ops.edge.cadence.quantized_linear.per_tensor,
+        exir_ops.edge.cadence.quantized_conv1d_nlc.per_tensor: exir_ops.edge.cadence.quantized_linear.per_tensor,
         exir_ops.edge.cadence.quantized_conv2d_nchw.per_tensor: exir_ops.edge.cadence.quantized_linear.per_tensor,
         exir_ops.edge.cadence.quantized_conv2d_nhwc.per_tensor: exir_ops.edge.cadence.quantized_linear.per_tensor,
     }
+
+    quantized_conv_ops: frozenset[EdgeOpOverload] = frozenset(
+        {
+            exir_ops.edge.cadence.quantized_conv1d_ncl.per_tensor,
+            exir_ops.edge.cadence.quantized_conv1d_nlc.per_tensor,
+            exir_ops.edge.cadence.quantized_conv2d_nchw.per_tensor,
+            exir_ops.edge.cadence.quantized_conv2d_nhwc.per_tensor,
+        }
+    )
 
     @property
     def targets(self) -> list[EdgeOpOverload]:
@@ -882,14 +894,11 @@ class ReplaceTrivialConvWithLinear(RemoveOrReplacePassInterface):
         # extra args holding at least the zero point and scale of input, weight, bias,
         # and output tensor.
         assert isinstance(node.target, EdgeOpOverload)
-        quantized_op = (
-            node.target == exir_ops.edge.cadence.quantized_conv2d_nchw.per_tensor
-            or node.target == exir_ops.edge.cadence.quantized_conv2d_nhwc.per_tensor
-        )
+        quantized_op = node.target in self.quantized_conv_ops
         assert (len(node.args) == 7 and not quantized_op) or (
             len(node.args) >= 12 and quantized_op
         ), "Inconsistent args for convolution"
-        (in_tensor, weight, bias, stride, padding, dilation, groups) = node.args[0:7]
+        (in_tensor, weight, bias, _, padding, dilation, groups) = node.args[0:7]
 
         assert isinstance(in_tensor, torch.fx.Node)
         assert isinstance(weight, torch.fx.Node)
@@ -901,22 +910,21 @@ class ReplaceTrivialConvWithLinear(RemoveOrReplacePassInterface):
         assert None not in {in_shape, weight_shape, out_shape}
 
         # pyre-ignore[6]: Argument type for iteration
-        stride_list = list(stride)
-        # pyre-ignore[6]: Argument type for iteration
         padding_list = list(padding)
         # pyre-ignore[6]: Argument type for iteration
         dilation_list = list(dilation)
 
         # Check the condition under which conv can be replaced by linear: (1) this
-        # should not be a depthwise convolution; (2) the padding, stride, and dilation
+        # should not be a depthwise convolution; (2) the padding and dilation
         # should be standard; (3) The [channels, height, width] of input must match the
         # [channel, kernel_height, kernel_width] of the weight. These conditions would
         # ensure that output height and width are 1, and the convolution can be replaced
-        # by linear.
+        # by linear. Note: stride is not checked because when in_shape[1:] ==
+        # weight_shape[1:], the output spatial dimensions are always 1 regardless of
+        # stride (there is only one valid convolution position).
         if (
             groups != 1
             or any(x != 0 for x in padding_list)
-            or any(x != 1 for x in stride_list)
             or any(x != 1 for x in dilation_list)
             or (list(in_shape[1:]) != list(weight_shape[1:]))
         ):
@@ -959,25 +967,23 @@ class ReplaceTrivialConvWithLinear(RemoveOrReplacePassInterface):
                 out_scale,
                 out_zero_point,
             ) = node.args[7:12]
-            # If the multiplier and shift tensors are provided, use them.
-            if len(node.args) >= 14:
-                out_multiplier = node.args[12]
-                out_shift = node.args[13]
-            # If not, compute them.
-            else:
-                # pyre-ignore[58]: Division operands
-                requantize_scale = bias_scale / out_scale
-                (out_multiplier, out_shift) = quantize_tensor_multiplier(
-                    requantize_scale
-                )
+            # Always compute out_multiplier and out_shift from bias_scale / out_scale.
+            # The conv reference implementations ignore the out_multiplier and out_shift
+            # args and use out_scale directly, but quantized_linear uses the computed
+            # values. So we must always recompute them to ensure numerical consistency.
+            # pyre-ignore[58]: Division operands
+            requantize_scale = bias_scale / out_scale
+            (out_multiplier, out_shift) = quantize_tensor_multiplier(
+                torch.tensor([requantize_scale])
+            )
             linear_args = (
                 in_view,
                 linear_weight,
                 bias,
                 in_zero_point,
                 weight_zero_point,
-                out_multiplier,
-                out_shift,
+                int(out_multiplier.item()),
+                int(out_shift.item()),
                 out_zero_point,
                 None,
             )
@@ -1023,6 +1029,7 @@ class ReplaceConvWithChannelLastConvPass(RemoveOrReplacePassInterface):
             exir_ops.edge.cadence.conv1d.default,
             exir_ops.edge.cadence.conv2d.default,
             exir_ops.edge.cadence.conv3d.default,
+            exir_ops.edge.cadence.quantized_conv1d_ncl.per_tensor,
             exir_ops.edge.cadence.quantized_conv2d_nchw.per_tensor,
         ]
 
@@ -1047,8 +1054,6 @@ class ReplaceConvWithChannelLastConvPass(RemoveOrReplacePassInterface):
     ) -> torch.fx.Node:
         """Convert NCHW format to NHWC format."""
         shape = node.meta["val"].shape
-        if len(shape) == 3:
-            return self._transpose_dims(graph, node, 1, -1)
         indices = list(range(len(shape)))
         permute_indices = [indices[0]] + indices[2:] + [indices[1]]
         permute_node = graph.call_function(
@@ -1062,8 +1067,6 @@ class ReplaceConvWithChannelLastConvPass(RemoveOrReplacePassInterface):
     ) -> torch.fx.Node:
         """Convert NHWC format to NCHW format."""
         shape = node.meta["val"].shape
-        if len(shape) == 3:
-            return self._transpose_dims(graph, node, 1, -1)
         indices = list(range(len(shape)))
         permute_indices = [indices[0], indices[-1]] + indices[1:-1]
         permute_node = graph.call_function(
@@ -1081,71 +1084,71 @@ class ReplaceConvWithChannelLastConvPass(RemoveOrReplacePassInterface):
         inp_data_format=0 (NHWC), but the standard NCHW->NHWC permutation produces
         [OC, KH, KW, 1]. This function applies the correct permutation for depthwise
         convolution weights.
+
+        For the 1D case, the C++ NLC kernels expect 3D weights in [OC, K, IC/groups]
+        format, so we use the standard NCHW->NHWC transpose (swap dims 1 and -1)
+        to produce [OC, K, 1].
         """
-        # For depthwise: input shape is either:
+        if not is_2d:
+            # 1D case: use standard transpose [OC, 1, K] -> [OC, K, 1]
+            # The C++ NLC kernels expect 3D weight in [OC, K, IC/groups] format.
+            return self._transpose_dims(graph, node, 1, -1)
+
         # 2D case: [OC, 1, KH, KW], target is [KH, KW, OC]
         #    Permute [0, 1, 2, 3] -> [2, 3, 0, 1] gives [KH, KW, OC, 1]
         #   Then squeeze the last dim (which is 1) to get [KH, KW, OC]
-        if is_2d:
-            permute_indices = [2, 3, 0, 1]
-            permute_node = graph.call_function(
-                exir_ops.edge.aten.permute_copy.default, (node, permute_indices), {}
-            )
-            permute_node.meta = node.meta
+        permute_indices = [2, 3, 0, 1]
+        permute_node = graph.call_function(
+            exir_ops.edge.aten.permute_copy.default, (node, permute_indices), {}
+        )
+        permute_node.meta = node.meta
 
-            # Squeeze the last dimension (which has size 1)
-            squeeze_node = graph.call_function(
-                exir_ops.edge.aten.squeeze_copy.dim, (permute_node, -1), {}
-            )
-            squeeze_node.meta = node.meta
-            return squeeze_node
-        else:
-            # 1D case: [OC, 1, K], target is [K, OC]
-            # Permute [0, 1, 2] -> [1, 2, 0] gives [1, K, OC]
-            permute_indices = [1, 2, 0]
-            permute_node = graph.call_function(
-                exir_ops.edge.aten.permute_copy.default, (node, permute_indices), {}
-            )
-            permute_node.meta = node.meta
-
-            # Squeeze the first dimension (which has size 1)
-            squeeze_node = graph.call_function(
-                exir_ops.edge.aten.squeeze_copy.dim, (permute_node, 0), {}
-            )
-            squeeze_node.meta = node.meta
-            return squeeze_node
+        # Squeeze the last dimension (which has size 1)
+        squeeze_node = graph.call_function(
+            exir_ops.edge.aten.squeeze_copy.dim, (permute_node, -1), {}
+        )
+        squeeze_node.meta = node.meta
+        return squeeze_node
 
     def maybe_remove_or_replace(self, node: torch.fx.Node) -> bool:
         assert isinstance(node.target, EdgeOpOverload)
-        quantized_op = (
-            node.target == exir_ops.edge.cadence.quantized_conv2d_nchw.per_tensor
-        )
+        quantized_op = node.target in {
+            exir_ops.edge.cadence.quantized_conv1d_ncl.per_tensor,
+            exir_ops.edge.cadence.quantized_conv2d_nchw.per_tensor,
+        }
 
-        # Check if already in NHWC layout
+        # Check if already in NHWC/NLC layout
         if not quantized_op and len(node.args) == 8 and node.args[-1] is True:
             return False
 
+        # Get input shape to determine if it's 1D or 2D
+        input_node = get_arg(node, "input", torch.fx.Node)
+        input_shape = input_node.meta["val"].shape
+        is_2d = len(input_shape) == 4
+
         # Determine the new op target
         if quantized_op:
-            new_op = exir_ops.edge.cadence.quantized_conv2d_nhwc.per_tensor
+            if is_2d:
+                new_op = exir_ops.edge.cadence.quantized_conv2d_nhwc.per_tensor
+            else:
+                assert len(input_shape) == 3
+                new_op = exir_ops.edge.cadence.quantized_conv1d_nlc.per_tensor
         else:
             new_op = node.target
 
         graph = node.graph
 
-        # Get input and weight nodes
-        input_node = cast(torch.fx.Node, node.args[0])
-        weight_node = cast(torch.fx.Node, node.args[1])
+        # Get weight node
+        weight_node = get_arg(node, "weight", torch.fx.Node)
 
         # Check if this is a depthwise convolution (groups == input_channels)
         # and weight is 4D with shape [OC, 1, KH, KW]
-        groups = cast(int, node.args[6])
-        input_shape = input_node.meta["val"].shape
+        groups = get_arg(node, "groups", int)
         weight_shape = weight_node.meta["val"].shape
         input_channels = input_shape[1]  # NCHW format, channels at index 1
         # NCHW: also verify weight IC dim == 1.
         depthwise = is_depthwise_conv(groups, input_channels) and weight_shape[1] == 1
-        is_2d = len(input_shape) == 4
+
         # Insert transpose operations before the node
         with graph.inserting_before(node):
             # Convert input from NCHW to NHWC
@@ -1333,12 +1336,26 @@ class ReplaceConvWithIm2RowAndLinear(RemoveOrReplacePassInterface):
     # A map from the convolution op to the linear op that it should
     # decompose to.
     conv_op_to_linear_op: Dict[EdgeOpOverload, EdgeOpOverload] = {
-        exir_ops.edge.cadence.conv1d.default: exir_ops.edge.aten.linear.default,
         exir_ops.edge.cadence.conv2d.default: exir_ops.edge.aten.linear.default,
         exir_ops.edge.cadence.conv3d.default: exir_ops.edge.aten.linear.default,
         exir_ops.edge.cadence.quantized_conv2d_nchw.per_tensor: exir_ops.edge.cadence.quantized_linear.per_tensor,
         exir_ops.edge.cadence.quantized_conv2d_nhwc.per_tensor: exir_ops.edge.cadence.quantized_linear.per_tensor,
     }
+
+    # Set of quantized conv ops
+    quantized_conv_ops: frozenset[EdgeOpOverload] = frozenset(
+        {
+            exir_ops.edge.cadence.quantized_conv2d_nchw.per_tensor,
+            exir_ops.edge.cadence.quantized_conv2d_nhwc.per_tensor,
+        }
+    )
+
+    # Set of channel-last conv ops (NHWC for 2D)
+    channel_last_conv_ops: frozenset[EdgeOpOverload] = frozenset(
+        {
+            exir_ops.edge.cadence.quantized_conv2d_nhwc.per_tensor,
+        }
+    )
 
     @property
     def targets(self) -> list[EdgeOpOverload]:
@@ -1347,10 +1364,7 @@ class ReplaceConvWithIm2RowAndLinear(RemoveOrReplacePassInterface):
     def maybe_remove_or_replace(self, node: torch.fx.Node) -> bool:
         # Get the relevant args from convolution node.
         assert isinstance(node.target, EdgeOpOverload)
-        quantized_op = (
-            node.target == exir_ops.edge.cadence.quantized_conv2d_nchw.per_tensor
-            or node.target == exir_ops.edge.cadence.quantized_conv2d_nhwc.per_tensor
-        )
+        quantized_op = node.target in self.quantized_conv_ops
         assert (len(node.args) == 7 and not quantized_op) or (
             len(node.args) >= 12 and quantized_op
         ), "Inconsistent args for convolution"
@@ -1386,13 +1400,9 @@ class ReplaceConvWithIm2RowAndLinear(RemoveOrReplacePassInterface):
         out_shape = node.meta["val"].shape
         assert None not in {weight_shape, out_shape}
 
-        # Determine if the convolution is NCHW or NHWC. The NHWC, i.e., the
-        # channel_last layout is specified by the channel_last arg of conv
-        # op, which is either the last argument (15th) or implicitely False
-        # if the op is quantized, or the last argument if not.
-        channel_last = (
-            node.target == exir_ops.edge.cadence.quantized_conv2d_nhwc.per_tensor
-        )
+        # Determine if the convolution is NCHW or NHWC (for 2D) / NCL or NLC (for 1D).
+        # Channel-last layouts are NHWC for 2D and NLC for 1D.
+        channel_last = node.target in self.channel_last_conv_ops
         # The weight tensor is [out_channels, in_channels, X] for NCHW layout,
         # and [out_channels, X, in_channels] for NHWC layout. Here, X is the
         # kernel_width for conv1d, and X = kernel_height * kernel_width for
@@ -1438,12 +1448,31 @@ class ReplaceConvWithIm2RowAndLinear(RemoveOrReplacePassInterface):
         # Get the product of the >2 dims of the weight
         K = math.prod(weight_shape[1:])
 
+        # For channel-last 2D convolutions (NHWC), the weight layout is
+        # [OC, kH, kW, IC] but im2row outputs patches in channel-first order [C, K].
+        # We need to permute the weight from [OC, kH, kW, IC] to [OC, IC, kH, kW]
+        # before flattening to match the im2row patch ordering.
+        weight_to_flatten = weight
+        if channel_last:
+            # 2D: [OC, kH, kW, IC] -> [OC, IC, kH, kW] via permute
+            with graph.inserting_before(node):
+                weight_to_flatten = graph.call_function(
+                    exir_ops.edge.aten.permute_copy.default,
+                    args=(weight, [0, 3, 1, 2]),
+                )
+                # NB: The shape in node.meta won't match the permuted weight
+                # shape. We copy it as a placeholder to populate non-shape
+                # metadata (e.g., stack_trace, dtype). ExportPass.call() is
+                # invoked after this pass (via HierarchicalInplacePassInterface)
+                # and will re-run shape propagation to correct all meta['val'].
+                weight_to_flatten.meta = node.meta
+
         # Weight is always a Node, so we need a view_copy operation
         with graph.inserting_before(node):
             linear_weight = graph.call_function(
                 exir_ops.edge.aten.view_copy.default,
                 args=(
-                    weight,
+                    weight_to_flatten,
                     [weight_shape[0], K],
                 ),
             )
@@ -1460,25 +1489,23 @@ class ReplaceConvWithIm2RowAndLinear(RemoveOrReplacePassInterface):
                 out_scale,
                 out_zero_point,
             ) = node.args[7:12]
-            # If the multiplier and shift tensors are provided, use them.
-            if len(node.args) >= 14:
-                out_multiplier = node.args[12]
-                out_shift = node.args[13]
-            # If not, compute them.
-            else:
-                # pyre-ignore[58]: Division operands
-                requantize_scale = bias_scale / out_scale
-                (out_multiplier, out_shift) = quantize_tensor_multiplier(
-                    requantize_scale
-                )
+            # Always compute out_multiplier and out_shift from bias_scale / out_scale.
+            # The conv reference implementations ignore the out_multiplier and out_shift
+            # args and use out_scale directly, but quantized_linear uses the computed
+            # values. So we must always recompute them to ensure numerical consistency.
+            # pyre-ignore[58]: Division operands
+            requantize_scale = bias_scale / out_scale
+            (out_multiplier, out_shift) = quantize_tensor_multiplier(
+                torch.tensor([requantize_scale])
+            )
             linear_args = (
                 im2row,
                 linear_weight,
                 bias,
                 in_zero_point,
                 weight_zero_point,
-                out_multiplier,
-                out_shift,
+                int(out_multiplier.item()),
+                int(out_shift.item()),
                 out_zero_point,
                 None,
             )

--- a/backends/cadence/aot/tests/test_replace_ops_passes.py
+++ b/backends/cadence/aot/tests/test_replace_ops_passes.py
@@ -1312,6 +1312,252 @@ class TestReplaceOpsPasses(unittest.TestCase):
         )
 
     @torch.no_grad()
+    def test_replace_quantized_conv1d_ncl_with_linear(self) -> None:
+        """Test that a trivial quantized conv1d NCL (in_length == kernel_length) is
+        replaced with quantized_linear via view_copy."""
+        in_channels = 3
+        out_channels = 4
+        kernel_size = 2
+        x = torch.randint(-10, 10, (1, in_channels, kernel_size), dtype=torch.int8)
+        w = torch.randint(
+            -5, 5, (out_channels, in_channels, kernel_size), dtype=torch.int8
+        )
+        b = torch.zeros(out_channels, dtype=torch.int32)
+        placeholders = (x, w, b)
+        args = (
+            x,
+            w,
+            b,
+            [1],
+            [0],
+            [1],
+            1,
+            0,
+            0,
+            0.001,
+            1.0,
+            0,
+            1,
+            0,
+        )
+        original_gm = single_op_builder(
+            placeholders=placeholders,
+            op=exir_ops.edge.cadence.quantized_conv1d_ncl.per_tensor,
+            args=args,
+        )
+
+        self.assertEqual(
+            count_node(
+                original_gm, exir_ops.edge.cadence.quantized_conv1d_ncl.per_tensor
+            ),
+            1,
+        )
+
+        p = ReplaceTrivialConvWithLinear()
+        result = cast(PassResult, p(original_gm))
+        self.assertTrue(result.modified)
+        graph_after_passes = result.graph_module
+
+        self.assertEqual(
+            count_node(
+                graph_after_passes,
+                exir_ops.edge.cadence.quantized_conv1d_ncl.per_tensor,
+            ),
+            0,
+        )
+        self.assertEqual(
+            count_node(
+                graph_after_passes,
+                exir_ops.edge.cadence.quantized_linear.per_tensor,
+            ),
+            1,
+        )
+        # 3 view_copy ops: weight reshape, input reshape, output reshape
+        self.assertEqual(
+            count_node(
+                graph_after_passes,
+                exir_ops.edge.aten.view_copy.default,
+            ),
+            3,
+        )
+
+    @torch.no_grad()
+    def test_replace_quantized_conv1d_nlc_with_linear(self) -> None:
+        """Test that a trivial quantized conv1d NLC (in_length == kernel_length) is
+        replaced with quantized_linear via view_copy."""
+        in_channels = 3
+        out_channels = 4
+        kernel_size = 2
+        x = torch.randint(-10, 10, (1, kernel_size, in_channels), dtype=torch.int8)
+        w = torch.randint(
+            -5, 5, (out_channels, kernel_size, in_channels), dtype=torch.int8
+        )
+        b = torch.zeros(out_channels, dtype=torch.int32)
+        placeholders = (x, w, b)
+        args = (
+            x,
+            w,
+            b,
+            [1],
+            [0],
+            [1],
+            1,
+            0,
+            0,
+            0.001,
+            1.0,
+            0,
+            1,
+            0,
+        )
+        original_gm = single_op_builder(
+            placeholders=placeholders,
+            op=exir_ops.edge.cadence.quantized_conv1d_nlc.per_tensor,
+            args=args,
+        )
+
+        self.assertEqual(
+            count_node(
+                original_gm, exir_ops.edge.cadence.quantized_conv1d_nlc.per_tensor
+            ),
+            1,
+        )
+
+        p = ReplaceTrivialConvWithLinear()
+        result = cast(PassResult, p(original_gm))
+        self.assertTrue(result.modified)
+        graph_after_passes = result.graph_module
+
+        self.assertEqual(
+            count_node(
+                graph_after_passes,
+                exir_ops.edge.cadence.quantized_conv1d_nlc.per_tensor,
+            ),
+            0,
+        )
+        self.assertEqual(
+            count_node(
+                graph_after_passes,
+                exir_ops.edge.cadence.quantized_linear.per_tensor,
+            ),
+            1,
+        )
+        # 3 view_copy ops: weight reshape, input reshape, output reshape
+        self.assertEqual(
+            count_node(
+                graph_after_passes,
+                exir_ops.edge.aten.view_copy.default,
+            ),
+            3,
+        )
+
+    @torch.no_grad()
+    def test_replace_quantized_conv1d_ncl_with_stride_with_linear(self) -> None:
+        """Test that a trivial quantized conv1d NCL with stride > 1 is still replaced.
+
+        When in_length == kernel_length, stride is irrelevant because
+        out_length = floor((L - K) / stride) + 1 = 1 for any stride.
+        """
+        in_channels = 3
+        out_channels = 4
+        kernel_size = 2
+        x = torch.randint(-10, 10, (1, in_channels, kernel_size), dtype=torch.int8)
+        w = torch.randint(
+            -5, 5, (out_channels, in_channels, kernel_size), dtype=torch.int8
+        )
+        b = torch.zeros(out_channels, dtype=torch.int32)
+        placeholders = (x, w, b)
+        args = (
+            x,
+            w,
+            b,
+            [2],
+            [0],
+            [1],
+            1,
+            0,
+            0,
+            0.001,
+            1.0,
+            0,
+            1,
+            0,
+        )
+        original_gm = single_op_builder(
+            placeholders=placeholders,
+            op=exir_ops.edge.cadence.quantized_conv1d_ncl.per_tensor,
+            args=args,
+        )
+
+        p = ReplaceTrivialConvWithLinear()
+        result = cast(PassResult, p(original_gm))
+        self.assertTrue(result.modified)
+        graph_after_passes = result.graph_module
+
+        self.assertEqual(
+            count_node(
+                graph_after_passes,
+                exir_ops.edge.cadence.quantized_conv1d_ncl.per_tensor,
+            ),
+            0,
+        )
+        self.assertEqual(
+            count_node(
+                graph_after_passes,
+                exir_ops.edge.cadence.quantized_linear.per_tensor,
+            ),
+            1,
+        )
+
+    @torch.no_grad()
+    def test_no_replace_nontrivial_quantized_conv1d_ncl(self) -> None:
+        """Test that a non-trivial quantized conv1d NCL (in_length != kernel_length)
+        is NOT replaced with linear."""
+        in_channels = 3
+        out_channels = 16
+        kernel_size = 4
+        in_length = 224
+        x = torch.randint(0, 100, (1, in_channels, in_length), dtype=torch.int8)
+        w = torch.randint(
+            -128, 127, (out_channels, in_channels, kernel_size), dtype=torch.int8
+        )
+        b = torch.randint(-1000, 1000, (out_channels,), dtype=torch.int32)
+        placeholders = (x, w, b)
+        args = (
+            x,
+            w,
+            b,
+            [1],
+            [0],
+            [1],
+            1,
+            0,
+            0,
+            0.01,
+            0.02,
+            0,
+            1,
+            0,
+        )
+        original_gm = single_op_builder(
+            placeholders=placeholders,
+            op=exir_ops.edge.cadence.quantized_conv1d_ncl.per_tensor,
+            args=args,
+        )
+
+        p = ReplaceTrivialConvWithLinear()
+        result = cast(PassResult, p(original_gm))
+        self.assertFalse(result.modified)
+
+        self.assertEqual(
+            count_node(
+                original_gm,
+                exir_ops.edge.cadence.quantized_conv1d_ncl.per_tensor,
+            ),
+            1,
+        )
+
+    @torch.no_grad()
     def test_replace_conv2d_with_im2row_and_linear(self) -> None:
         x = torch.randn(1, 2, 5, 5)
         weights = torch.randn(3, 2, 4, 4)
@@ -1965,6 +2211,73 @@ class TestReplaceConvWithChannelLastConvPass(unittest.TestCase):
             args=args,
         )
 
+    def create_quantized_conv1d_graph_module(
+        self, channels_last: Optional[bool] = None
+    ) -> tuple[tuple[torch.Tensor, ...], torch.fx.GraphModule]:
+        """Helper to create a quantized conv1d node.
+
+        quantized_conv1d_ncl/nlc.per_tensor(
+            Tensor input, Tensor weight, Tensor bias, int[] stride, SymInt[] padding,
+            int[] dilation, int groups, int input_zero_point, int weight_zero_point,
+            Tensor bias_scale, float out_scale, int out_zero_point, int out_multiplier,
+            int out_shift) -> (Tensor Z)
+        """
+        # NCL: (N, C, L) format
+        # NLC: (N, L, C) format
+        in_channels = 3
+        out_channels = 16
+        kernel_size = 4
+        if channels_last:
+            x = torch.randint(0, 100, (1, 224, in_channels), dtype=torch.int8)  # NLC
+            w = torch.randint(
+                -128, 127, (out_channels, kernel_size, in_channels), dtype=torch.int8
+            )
+        else:
+            x = torch.randint(0, 100, (1, in_channels, 224), dtype=torch.int8)  # NCL
+            w = torch.randint(
+                -128, 127, (out_channels, in_channels, kernel_size), dtype=torch.int8
+            )
+        b = torch.randint(-1000, 1000, (out_channels,), dtype=torch.int32)
+        stride = [2]
+        padding = [0]
+        dilation = [1]
+        groups = 1
+        input_zero_point = 0
+        w_zero_point = 0
+        b_scale = 0.01
+        out_scale = 0.02
+        out_zero_point = 0
+        out_multiplier = 1
+        out_shift = 0
+        args = (
+            x,
+            w,
+            b,
+            stride,
+            padding,
+            dilation,
+            groups,
+            input_zero_point,
+            w_zero_point,
+            b_scale,
+            out_scale,
+            out_zero_point,
+            out_multiplier,
+            out_shift,
+        )
+        if channels_last:
+            op = exir_ops.edge.cadence.quantized_conv1d_nlc.per_tensor
+        else:
+            op = exir_ops.edge.cadence.quantized_conv1d_ncl.per_tensor
+
+        placeholders = (x, w, b)
+
+        return placeholders, single_op_builder(
+            placeholders=placeholders,
+            op=op,
+            args=args,
+        )
+
     def test_quantized_convolution_default_channel_last(self) -> None:
         # Create a graph with a single convolution node.
         placeholders, gm = self.create_quantized_convolution_graph_module()
@@ -1998,6 +2311,78 @@ class TestReplaceConvWithChannelLastConvPass(unittest.TestCase):
         validate(
             original,
             gm_after_replacement,
+            placeholders,
+            "ReplaceConvWithChannelLastConvPass",
+        )
+
+    def test_convert_quantized_conv1d_ncl_to_nlc(self) -> None:
+        # Create a graph with a quantized_conv1d_ncl node
+        placeholders, gm = self.create_quantized_conv1d_graph_module(
+            channels_last=False
+        )
+        original = copy.deepcopy(gm)
+        # Check that we start with quantized_conv1d_ncl
+        self.assertEqual(
+            count_node(gm, exir_ops.edge.cadence.quantized_conv1d_ncl.per_tensor), 1
+        )
+        self.assertEqual(count_node(gm, exir_ops.edge.aten.permute_copy.default), 0)
+
+        # Apply replacement pass
+        p = ReplaceConvWithChannelLastConvPass()
+        gm_after_replacement = p.call(gm).graph_module
+
+        # Verify the quantized_conv1d_nlc node exists
+        self.assertEqual(
+            count_node(
+                gm_after_replacement,
+                exir_ops.edge.cadence.quantized_conv1d_nlc.per_tensor,
+            ),
+            1,
+        )
+        # For 1D conv, the pass uses permute_copy (swap dims 1 and -1)
+        # for input, weight, and output: 3 permute_copy ops total
+        self.assertEqual(
+            count_node(gm_after_replacement, exir_ops.edge.aten.permute_copy.default),
+            3,
+        )
+
+        # Validate numerical accuracy
+        validate(
+            original,
+            gm_after_replacement,
+            placeholders,
+            "ReplaceConvWithChannelLastConvPass",
+        )
+
+    def test_no_transpose_if_already_quantized_conv1d_channel_last(self) -> None:
+        # Create a graph with a quantized_conv1d_nlc node (already channel-last)
+        placeholders, gm = self.create_quantized_conv1d_graph_module(channels_last=True)
+        original = copy.deepcopy(gm)
+        # Check if graph module has quantized_conv1d_nlc
+        self.assertEqual(
+            count_node(gm, exir_ops.edge.cadence.quantized_conv1d_nlc.per_tensor), 1
+        )
+
+        # Apply replacement pass
+        p = ReplaceConvWithChannelLastConvPass()
+        gm_after_replacement = p.call(gm).graph_module
+
+        # Check that no replacement was made - nlc is not a target of this pass
+        # The pass doesn't target nlc, so it should remain unchanged
+        self.assertEqual(
+            count_node(
+                gm_after_replacement,
+                exir_ops.edge.cadence.quantized_conv1d_nlc.per_tensor,
+            ),
+            1,
+        )
+        # No permutes should be added
+        self.assertEqual(
+            count_node(gm_after_replacement, exir_ops.edge.aten.permute_copy.default), 0
+        )
+        validate(
+            gm_after_replacement,
+            original,
             placeholders,
             "ReplaceConvWithChannelLastConvPass",
         )
@@ -2232,7 +2617,7 @@ class TestReplaceConvWithChannelLastConvPass(unittest.TestCase):
         """Test that a regular 1D conv with in_channels=1 is NOT treated as depthwise.
 
         Regression test: when groups == in_channels == 1, the conv is regular (not
-        depthwise). The weight should be converted via the regular NHWC path
+        depthwise). The weight should be converted via the regular NLC path
         [OC, IC, K] -> [OC, K, IC], NOT the depthwise path [OC, 1, K] -> [K, OC].
         """
         placeholders, gm = self.create_1d_conv_with_single_input_channel_graph_module()
@@ -2243,19 +2628,19 @@ class TestReplaceConvWithChannelLastConvPass(unittest.TestCase):
         p = ReplaceConvWithChannelLastConvPass()
         gm_after_replacement = p.call(gm).graph_module
 
+        # 1D convolutions (3D tensors) are now converted to quantized_conv1d_nlc
         self.assertEqual(
             count_node(
                 gm_after_replacement,
-                exir_ops.edge.cadence.quantized_conv2d_nhwc.per_tensor,
+                exir_ops.edge.cadence.quantized_conv1d_nlc.per_tensor,
             ),
             1,
         )
 
-        # For 1D conv, the pass uses transpose_copy.int (not permute_copy)
-        # because _change_nchw_to_nhwc calls _transpose_dims for 3D tensors.
-        # 3 transpose_copy ops: input, weight, output. NO squeeze_copy.
+        # For 1D conv, the pass uses permute_copy
+        # for input, weight, and output: 3 permute_copy ops total. NO squeeze_copy.
         self.assertEqual(
-            count_node(gm_after_replacement, exir_ops.edge.aten.transpose_copy.int),
+            count_node(gm_after_replacement, exir_ops.edge.aten.permute_copy.default),
             3,
         )
         self.assertEqual(
@@ -2264,9 +2649,9 @@ class TestReplaceConvWithChannelLastConvPass(unittest.TestCase):
             "Regular conv with in_channels=1 must NOT have squeeze_copy (not depthwise)",
         )
 
-        # Verify weight shape is 3D [OC, K, IC] (regular NHWC), not 2D [K, OC] (depthwise)
+        # Verify weight shape is 3D [OC, K, IC] (regular NLC), not 2D [K, OC] (depthwise)
         for node in gm_after_replacement.graph.nodes:
-            if node.target != exir_ops.edge.cadence.quantized_conv2d_nhwc.per_tensor:
+            if node.target != exir_ops.edge.cadence.quantized_conv1d_nlc.per_tensor:
                 continue
             weight_node = node.args[1]
             weight_shape = weight_node.meta["val"].shape
@@ -2276,7 +2661,7 @@ class TestReplaceConvWithChannelLastConvPass(unittest.TestCase):
                 f"Regular 1D conv weight should be 3D [OC, K, IC], got {len(weight_shape)}D",
             )
             # Original weight: [258, 1, 256] (OC, IC, K)
-            # Expected after regular NHWC transform: [258, 256, 1] (OC, K, IC)
+            # Expected after regular NLC transform: [258, 256, 1] (OC, K, IC)
             self.assertEqual(weight_shape[0], 258)  # OC
             self.assertEqual(weight_shape[1], 256)  # K
             self.assertEqual(weight_shape[2], 1)  # IC
@@ -2339,10 +2724,11 @@ class TestReplaceConvWithChannelLastConvPass(unittest.TestCase):
         return placeholders, gm
 
     def test_1d_depthwise_convolution_weight_shape(self) -> None:
-        """Test that 1D depthwise conv weight is transformed to [K, OC] format.
+        """Test that 1D depthwise conv weight is transformed to [OC, K, 1] format.
 
         For 1D depthwise conv with groups == in_channels > 1, the weight should be
-        transformed from [OC, 1, K] to [K, OC] (2D) via permute_copy + squeeze_copy.
+        transformed from [OC, 1, K] to [OC, K, 1] (3D) via transpose_copy.int,
+        matching the standard NLC weight format expected by C++ kernels.
         """
         placeholders, gm = self.create_1d_depthwise_convolution_graph_module()
         self.assertEqual(
@@ -2352,49 +2738,42 @@ class TestReplaceConvWithChannelLastConvPass(unittest.TestCase):
         p = ReplaceConvWithChannelLastConvPass()
         gm_after_replacement = p.call(gm).graph_module
 
+        # 1D convolutions (3D tensors) are now converted to quantized_conv1d_nlc
         self.assertEqual(
             count_node(
                 gm_after_replacement,
-                exir_ops.edge.cadence.quantized_conv2d_nhwc.per_tensor,
+                exir_ops.edge.cadence.quantized_conv1d_nlc.per_tensor,
             ),
             1,
         )
 
         # For 1D depthwise:
-        # - Input/output: transpose_copy.int (2 ops, for 3D NCHW<->NHWC)
-        # - Weight: permute_copy.default + squeeze_copy.dim (depthwise layout)
-        self.assertEqual(
-            count_node(gm_after_replacement, exir_ops.edge.aten.transpose_copy.int),
-            2,
-        )
+        # - Input/output/weight all use permute_copy (3 ops)
+        # - No squeeze_copy needed
         self.assertEqual(
             count_node(gm_after_replacement, exir_ops.edge.aten.permute_copy.default),
-            1,
+            3,
         )
         self.assertEqual(
             count_node(gm_after_replacement, exir_ops.edge.aten.squeeze_copy.dim),
-            1,
+            0,
         )
 
         for node in gm_after_replacement.graph.nodes:
-            if node.target != exir_ops.edge.cadence.quantized_conv2d_nhwc.per_tensor:
+            if node.target != exir_ops.edge.cadence.quantized_conv1d_nlc.per_tensor:
                 continue
             weight_node = node.args[1]
-            self.assertEqual(
-                weight_node.target,
-                exir_ops.edge.aten.squeeze_copy.dim,
-                "1D depthwise conv weight should be processed by squeeze_copy",
-            )
             weight_shape = weight_node.meta["val"].shape
             self.assertEqual(
                 len(weight_shape),
-                2,
-                f"1D depthwise weight should be 2D [K, OC], got {len(weight_shape)}D",
+                3,
+                f"1D depthwise weight should be 3D [OC, K, 1], got {len(weight_shape)}D",
             )
             # Original weight: [8, 1, 3] (OC, 1, K)
-            # Expected after depthwise transform: [3, 8] (K, OC)
-            self.assertEqual(weight_shape[0], 3)  # K
-            self.assertEqual(weight_shape[1], 8)  # OC
+            # Expected after standard NLC transform: [8, 3, 1] (OC, K, IC/groups)
+            self.assertEqual(weight_shape[0], 8)  # OC
+            self.assertEqual(weight_shape[1], 3)  # K
+            self.assertEqual(weight_shape[2], 1)  # IC/groups
 
         validate(
             gm,


### PR DESCRIPTION
Summary:

Update quantizer patterns to route conv1d operations to quantized_conv1d_ncl instead of quantized_conv2d_nchw:
- Conv1dPattern.replacement_op() now returns quantized_conv1d_ncl
- Conv1dReluPattern0 and Conv1dReluPattern1 now return quantized_conv1d_ncl
- Added fused_conv1d_relu test and _build_conv1d_relu_graph helper

Details about the change of ops in WakeWord:
```
BEFORE: conv1d is quantized as quantized_conv2d_nchw (4D tensors — input unsqueezed to [N, C, 1, L], weight to [OC, IC, 1, K]).

AFTER: conv1d is quantized as quantized_conv1d_ncl (3D tensors — [N, C, L], [OC, IC, K]).

Both go through ReplaceConvWithChannelLastConvPass. The pass does the same thing in both cases — it creates:

Input permute (_change_nchw_to_nhwc): 1 permute_copy node
Weight conversion: depends on depthwise vs non-depthwise
New conv op: 1 node (replacing the old one)
Output permute (_change_nhwc_to_nchw): 1 permute_copy node
For non-depthwise convolutions, weight conversion is _change_nchw_to_nhwc = 1 permute_copy in both cases. Same node count.

For depthwise convolutions, the weight conversion differs:

BEFORE (2D, is_2d=True) — _change_depthwise_weight_to_hwc(is_2d=True):

# [OC, 1, KH, KW] -> permute [2,3,0,1] -> squeeze(-1) -> [KH, KW, OC]
permute_copy  # 1 node
squeeze_copy  # 1 node  → total: 2 nodes for weight

AFTER (1D, is_2d=False) — _change_depthwise_weight_to_hwc(is_2d=False):

# [OC, 1, K] -> _change_nchw_to_nhwc -> [OC, K, 1]
permute_copy  # 1 node  → total: 1 node for weight

That's exactly -1 node per depthwise conv1d in the model. The 2D depthwise path needs a squeeze_copy to drop the trailing dim-1 (going from [KH, KW, OC, 1] → [KH, KW, OC]), but the 1D path keeps 3D weights and doesn't need the squeeze.

If the wakeword model has exactly one depthwise conv1d, that accounts for the 130 → 129 difference.
```

Reviewed By: DrJessop

Differential Revision: D95279330


