### PR TITLE
CUDA backend: fix output stride mismatch in delegate copy-back

### DIFF
--- a/backends/cuda/runtime/utils.h
+++ b/backends/cuda/runtime/utils.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <cuda_runtime.h>
+#include <executorch/backends/aoti/slim/c10/cuda/Exception.h>
 #include <executorch/runtime/core/error.h>
 #include <executorch/runtime/core/exec_aten/exec_aten.h>
 #include <executorch/runtime/core/exec_aten/util/tensor_util.h>
@@ -86,18 +87,158 @@ inline executorch::runtime::Error _check_tensor_metadata(
 
   return executorch::runtime::Error::Ok;
 }
+// Check if src and dst strides match (same layout, no rearrangement needed).
+inline bool _strides_match(
+    const executorch::backends::aoti::slim::SlimTensor* slim_tensor,
+    const executorch::runtime::etensor::Tensor* etensor) {
+  const size_t ndim = slim_tensor->dim();
+  auto slim_strides = slim_tensor->strides();
+  auto et_strides = etensor->strides();
+  for (size_t i = 0; i < ndim; ++i) {
+    if (slim_strides[i] != static_cast<int64_t>(et_strides[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// Element-by-element copy from a contiguous CPU buffer (src_strides layout)
+// to an ETensor (dst_strides layout), rearranging data to match.
+inline void _strided_copy(
+    void* dst,
+    const void* src,
+    size_t elem_size,
+    const std::vector<int64_t>& sizes,
+    const std::vector<int64_t>& src_strides,
+    const std::vector<int32_t>& dst_strides) {
+  const size_t ndim = sizes.size();
+  const size_t numel = [&]() {
+    size_t n = 1;
+    for (auto s : sizes)
+      n *= static_cast<size_t>(s);
+    return n;
+  }();
+
+  // Iterate over all elements using N-dimensional index
+  std::vector<int64_t> idx(ndim, 0);
+  auto* dst_bytes = static_cast<char*>(dst);
+  auto* src_bytes = static_cast<const char*>(src);
+
+  for (size_t i = 0; i < numel; ++i) {
+    // Compute source and destination byte offsets
+    size_t src_offset = 0, dst_offset = 0;
+    for (size_t d = 0; d < ndim; ++d) {
+      src_offset += static_cast<size_t>(idx[d]) *
+          static_cast<size_t>(src_strides[d]) * elem_size;
+      dst_offset += static_cast<size_t>(idx[d]) *
+          static_cast<size_t>(dst_strides[d]) * elem_size;
+    }
+    std::memcpy(dst_bytes + dst_offset, src_bytes + src_offset, elem_size);
+
+    // Increment N-dimensional index (last dimension fastest)
+    for (int d = static_cast<int>(ndim) - 1; d >= 0; --d) {
+      if (++idx[d] < sizes[d])
+        break;
+      idx[d] = 0;
+    }
+  }
+}
+
+// Copy data from SlimTensor to ETensor, rearranging if strides differ.
+// When stream is non-null, GPU copies use that stream (async fast path).
+// When stream is null, GPU copies are synchronous.
+inline executorch::runtime::Error _copy_slimtensor_to_etensor_impl(
+    const executorch::backends::aoti::slim::SlimTensor* slim_tensor,
+    executorch::runtime::etensor::Tensor* etensor,
+    cudaStream_t stream) {
+  ET_CHECK_OK_OR_RETURN_ERROR(_check_tensor_metadata(slim_tensor, etensor));
+
+  size_t nbytes = slim_tensor->nbytes();
+  if (nbytes == 0) {
+    return executorch::runtime::Error::Ok;
+  }
+
+  void* dst_data = etensor->mutable_data_ptr();
+  const void* src_data = slim_tensor->data_ptr();
+
+  if (_strides_match(slim_tensor, etensor)) {
+    // Fast path: strides match, raw byte copy
+    if (slim_tensor->is_cpu()) {
+      std::memcpy(dst_data, src_data, nbytes);
+    } else if (stream) {
+      executorch::backends::aoti::slim::DeviceTraits<
+          executorch::backends::aoti::slim::c10::DeviceType::CUDA>::
+          memcpy_async(
+              dst_data,
+              src_data,
+              nbytes,
+              executorch::backends::aoti::slim::CPU_DEVICE,
+              slim_tensor->device(),
+              stream);
+    } else {
+      executorch::backends::aoti::slim::DeviceTraits<
+          executorch::backends::aoti::slim::c10::DeviceType::CUDA>::
+          memcpy(
+              dst_data,
+              src_data,
+              nbytes,
+              executorch::backends::aoti::slim::CPU_DEVICE,
+              slim_tensor->device());
+    }
+  } else {
+    // Slow path: strides differ (e.g., AOTI delegate output layout differs
+    // from .pte's dim_order). Copy to a temp CPU buffer, then rearrange
+    // element-by-element to match the ETensor's expected layout.
+    std::vector<char> tmp(nbytes);
+    if (slim_tensor->is_cpu()) {
+      std::memcpy(tmp.data(), src_data, nbytes);
+    } else {
+      if (stream) {
+        ET_CUDA_CHECK_OR_RETURN_ERROR(cudaStreamSynchronize(stream));
+      }
+      ET_CUDA_CHECK_OR_RETURN_ERROR(
+          cudaMemcpy(tmp.data(), src_data, nbytes, cudaMemcpyDeviceToHost));
+    }
+
+    const size_t ndim = slim_tensor->dim();
+    auto slim_sizes = slim_tensor->sizes();
+    auto slim_strides = slim_tensor->strides();
+    auto et_strides = etensor->strides();
+
+    std::vector<int64_t> sizes_vec(ndim);
+    std::vector<int64_t> src_strides_vec(ndim);
+    std::vector<int32_t> dst_strides_vec(ndim);
+    for (size_t i = 0; i < ndim; ++i) {
+      sizes_vec[i] = slim_sizes[i];
+      src_strides_vec[i] = slim_strides[i];
+      dst_strides_vec[i] = et_strides[i];
+    }
+
+    size_t elem_size = executorch::backends::aoti::slim::c10::elementSize(
+        slim_tensor->dtype());
+    _strided_copy(
+        dst_data,
+        tmp.data(),
+        elem_size,
+        sizes_vec,
+        src_strides_vec,
+        dst_strides_vec);
+  }
+
+  return executorch::runtime::Error::Ok;
+}
 } // namespace
 
 /**
  * Copies data from a SlimTensor to an ETensor asynchronously.
  *
- * This function converts a SlimTensor back to an ETensor using async copy.
- * The ETensor is assumed to always reside on CPU, so this handles both
- * CPU→CPU and GPU→CPU copies. The function will resize the ETensor if needed
- * and copy the data asynchronously on the provided CUDA stream.
+ * When strides match (common case), performs a fast async GPU-to-CPU copy on
+ * the provided stream. When strides differ (e.g., AOTI delegate output layout
+ * differs from the .pte's dim_order), falls back to a synchronous copy with
+ * element-by-element rearrangement.
  *
- * NOTE: The caller must ensure proper synchronization after calling this
- * function if the ETensor data is accessed on the CPU side.
+ * NOTE: In the fast path the copy is asynchronous. The caller must synchronize
+ * the stream before reading the ETensor data on the CPU side.
  *
  * @param slim_tensor Pointer to the source SlimTensor (must not be null).
  * @param etensor Pointer to the destination ETensor (must not be null).
@@ -108,41 +249,14 @@ inline executorch::runtime::Error copy_slimtensor_to_etensor_async(
     const executorch::backends::aoti::slim::SlimTensor* slim_tensor,
     executorch::runtime::etensor::Tensor* etensor,
     cudaStream_t stream) {
-  _check_tensor_metadata(slim_tensor, etensor);
-
-  // Copy data from SlimTensor to ETensor
-  // SlimTensor may be on GPU or CPU, ETensor is always on CPU
-  size_t nbytes = slim_tensor->nbytes();
-  if (nbytes > 0) {
-    void* dst_data = etensor->mutable_data_ptr();
-    const void* src_data = slim_tensor->data_ptr();
-
-    if (slim_tensor->is_cpu()) {
-      // CPU → CPU copy (always synchronous)
-      std::memcpy(dst_data, src_data, nbytes);
-    } else {
-      // GPU → CPU async copy
-      executorch::backends::aoti::slim::DeviceTraits<
-          executorch::backends::aoti::slim::c10::DeviceType::CUDA>::
-          memcpy_async(
-              dst_data,
-              src_data,
-              nbytes,
-              executorch::backends::aoti::slim::CPU_DEVICE,
-              slim_tensor->device(),
-              stream);
-    }
-  }
-
-  return executorch::runtime::Error::Ok;
+  return _copy_slimtensor_to_etensor_impl(slim_tensor, etensor, stream);
 }
 
 /**
  * Copies data from a SlimTensor to an ETensor synchronously.
  *
- * This function converts a SlimTensor back to an ETensor. The ETensor is
- * assumed to always reside on CPU, so this handles both CPU→CPU and GPU→CPU
- * copies. The function will resize the ETensor if needed and copy the data.
+ * Handles stride mismatches between the delegate output and the .pte's
+ * expected layout by rearranging data element-by-element when needed.
  *
  * @param slim_tensor Pointer to the source SlimTensor (must not be null).
  * @param etensor Pointer to the destination ETensor (must not be null).
@@ -151,32 +265,7 @@ inline executorch::runtime::Error copy_slimtensor_to_etensor_async(
 inline executorch::runtime::Error copy_slimtensor_to_etensor(
     const executorch::backends::aoti::slim::SlimTensor* slim_tensor,
     executorch::runtime::etensor::Tensor* etensor) {
-  _check_tensor_metadata(slim_tensor, etensor);
-
-  // Copy data from SlimTensor to ETensor
-  // SlimTensor may be on GPU or CPU, ETensor is always on CPU
-  size_t nbytes = slim_tensor->nbytes();
-  if (nbytes > 0) {
-    void* dst_data = etensor->mutable_data_ptr();
-    const void* src_data = slim_tensor->data_ptr();
-
-    if (slim_tensor->is_cpu()) {
-      // CPU → CPU copy
-      std::memcpy(dst_data, src_data, nbytes);
-    } else {
-      // GPU → CPU synchronous copy
-      executorch::backends::aoti::slim::DeviceTraits<
-          executorch::backends::aoti::slim::c10::DeviceType::CUDA>::
-          memcpy(
-              dst_data,
-              src_data,
-              nbytes,
-              executorch::backends::aoti::slim::CPU_DEVICE,
-              slim_tensor->device());
-    }
-  }
-
-  return executorch::runtime::Error::Ok;
+  return _copy_slimtensor_to_etensor_impl(slim_tensor, etensor, nullptr);
 }
 
 /**
@@ -197,7 +286,7 @@ inline executorch::runtime::Error copy_slimtensor_to_etensor(
 inline executorch::runtime::Error wrap_slimtensor_to_etensor(
     const executorch::backends::aoti::slim::SlimTensor* slim_tensor,
     executorch::runtime::etensor::Tensor* etensor) {
-  _check_tensor_metadata(slim_tensor, etensor);
+  ET_CHECK_OK_OR_RETURN_ERROR(_check_tensor_metadata(slim_tensor, etensor));
 
   // Set data pointer to point directly to SlimTensor's data (zero-copy)
   etensor->unsafeGetTensorImpl()->set_data(

--- a/backends/cuda/tests/test_output_stride_rearrange.py
+++ b/backends/cuda/tests/test_output_stride_rearrange.py
@@ -1,0 +1,177 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Test that CUDA backend correctly handles output stride mismatches.
+
+The AOTI delegate always produces contiguous output, but the .pte may
+serialize a different dim_order (e.g., from SDPA's efficient attention
+which returns a transposed view). The runtime must rearrange the output
+data to match the ETensor's expected layout.
+
+Fast path: strides match (raw byte copy).
+Slow path: strides differ (element-by-element rearrange).
+
+Usage:
+    python -m pytest backends/cuda/tests/test_output_stride_rearrange.py -v
+"""
+
+import glob
+import os
+import tempfile
+import unittest
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+def _run_et_aoti(module, inputs, triton_mode="OFF"):
+    """Export and run a model through the ExecuTorch CUDA AOTI backend."""
+    from executorch.backends.cuda.cuda_backend import CudaBackend
+    from executorch.backends.cuda.cuda_partitioner import CudaPartitioner
+    from executorch.exir import (
+        EdgeCompileConfig,
+        ExecutorchBackendConfig,
+        to_edge_transform_and_lower,
+    )
+    from executorch.exir.backend.compile_spec_schema import CompileSpec
+    from executorch.exir.passes import MemoryPlanningPass
+    from executorch.extension.pybindings.portable_lib import _load_for_executorch
+
+    ep = torch.export.export(module, inputs, strict=True)
+    compile_specs = [
+        CudaBackend.generate_method_name_compile_spec("forward"),
+        CompileSpec(key="triton_kernel_mode", value=triton_mode.encode()),
+    ]
+    partitioner = {"forward": [CudaPartitioner(compile_specs)]}
+    et_prog = to_edge_transform_and_lower(
+        {"forward": ep},
+        partitioner=partitioner,
+        compile_config=EdgeCompileConfig(
+            _check_ir_validity=False, _skip_dim_order=True
+        ),
+        constant_methods={"test": 1},
+    )
+    et = et_prog.to_executorch(
+        config=ExecutorchBackendConfig(
+            extract_delegate_segments=True,
+            memory_planning_pass=MemoryPlanningPass(alloc_graph_input=False),
+        )
+    )
+    with tempfile.TemporaryDirectory() as tmpdir:
+        pte = os.path.join(tmpdir, "test.pte")
+        with open(pte, "wb") as f:
+            et.write_to_file(f)
+        ptd = None
+        if et._tensor_data:
+            et.write_tensor_data_to_file(tmpdir)
+            ptd_files = glob.glob(os.path.join(tmpdir, "*.ptd"))
+            ptd = ptd_files[0] if ptd_files else None
+        mod = _load_for_executorch(pte, data_path=ptd)
+        return mod.run_method("forward", [t.cpu() for t in inputs])
+
+
+class TestOutputStrideRearrange(unittest.TestCase):
+    """Test CUDA backend output copy with matching and mismatching strides."""
+
+    @classmethod
+    def setUpClass(cls):
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("CUDA not available")
+        if not torch.cuda.is_bf16_supported():
+            raise unittest.SkipTest("BF16 not supported on this GPU")
+
+    def _check_sdpa(self, module, inputs, label):
+        """Run model through ExecuTorch AOTI with both Triton ON and OFF."""
+        with torch.no_grad():
+            eager = module(*inputs).float().cpu()
+
+        for mode in ["OFF", "ON"]:
+            with self.subTest(triton_mode=mode):
+                result = _run_et_aoti(module, inputs, triton_mode=mode)[0].float()
+                rel = (result - eager).abs() / eager.abs().clamp(min=1e-6)
+                self.assertLess(
+                    rel.mean().item(),
+                    0.2,
+                    f"{label} triton={mode} mean_rel={rel.mean():.4f} too large",
+                )
+
+    def test_fast_path_no_mask(self):
+        """No mask SDPA — output strides match, uses fast byte copy path."""
+
+        class SDPANoMask(nn.Module):
+            def forward(self, q, k, v):
+                return F.scaled_dot_product_attention(q, k, v, is_causal=False)
+
+        D = 64
+        q = torch.randn(1, 4, 4, D, dtype=torch.bfloat16, device="cuda")
+        k = torch.randn(1, 4, 200, D, dtype=torch.bfloat16, device="cuda")
+        v = torch.randn(1, 4, 200, D, dtype=torch.bfloat16, device="cuda")
+
+        self._check_sdpa(SDPANoMask().eval(), (q, k, v), "no-mask")
+
+    def test_slow_path_masked_sdpa(self):
+        """Masked SDPA — output strides differ, uses rearrange path."""
+
+        class SDPAWithMask(nn.Module):
+            def forward(self, q, k, v, mask):
+                return F.scaled_dot_product_attention(
+                    q, k, v, attn_mask=mask, is_causal=False
+                )
+
+        D = 64
+        q = torch.randn(1, 4, 4, D, dtype=torch.bfloat16, device="cuda")
+        k = torch.randn(1, 4, 200, D, dtype=torch.bfloat16, device="cuda")
+        v = torch.randn(1, 4, 200, D, dtype=torch.bfloat16, device="cuda")
+        mask = torch.ones(1, 1, 4, 200, dtype=torch.bool, device="cuda")
+
+        self._check_sdpa(SDPAWithMask().eval(), (q, k, v, mask), "masked")
+
+    def test_slow_path_sparse_bool_mask(self):
+        """Sparse bool mask — exercises stride rearrange with real masking."""
+
+        class SDPASparseMask(nn.Module):
+            def forward(self, q, k, v):
+                KV = k.shape[2]
+                mask = (
+                    (torch.arange(KV, device=q.device) < KV // 2)
+                    .view(1, 1, 1, KV)
+                    .expand(1, 1, q.shape[2], -1)
+                )
+                return F.scaled_dot_product_attention(
+                    q, k, v, attn_mask=mask, is_causal=False
+                )
+
+        D = 64
+        q = torch.randn(1, 4, 4, D, dtype=torch.bfloat16, device="cuda")
+        k = torch.randn(1, 4, 200, D, dtype=torch.bfloat16, device="cuda")
+        v = torch.randn(1, 4, 200, D, dtype=torch.bfloat16, device="cuda")
+
+        self._check_sdpa(SDPASparseMask().eval(), (q, k, v), "sparse-mask")
+
+    def test_simple_add_no_rearrange(self):
+        """Simple add — fast path, no stride mismatch."""
+
+        class AddModule(nn.Module):
+            def forward(self, a, b):
+                return a + b
+
+        a = torch.randn(4, 64, dtype=torch.bfloat16, device="cuda")
+        b = torch.randn(4, 64, dtype=torch.bfloat16, device="cuda")
+
+        module = AddModule().eval()
+        with torch.no_grad():
+            eager = module(a, b).float().cpu()
+
+        result = _run_et_aoti(module, (a, b))[0].float()
+        self.assertTrue(
+            torch.allclose(result, eager, atol=1e-3),
+            "simple add should match exactly",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backends/cuda/tests/test_triton_sdpa_nan.py
+++ b/backends/cuda/tests/test_triton_sdpa_nan.py
@@ -204,19 +204,17 @@ class TestTritonSdpaNan(unittest.TestCase):
             mod = _export_pybind(module, (q, k, v), tmpdir)
             triton = _run_pybind(mod, (q, k, v))[0].float()
 
-        self.assertFalse(torch.isnan(triton).any(), "non-pow2 bool mask has NaN")
-        self.assertFalse(torch.isinf(triton).any(), "non-pow2 bool mask has Inf")
-
-        """
         with torch.no_grad():
             eager = module(q, k, v).float().cpu()
+
+        self.assertFalse(torch.isnan(triton).any(), "non-pow2 bool mask has NaN")
+        self.assertFalse(torch.isinf(triton).any(), "non-pow2 bool mask has Inf")
         rel = (triton - eager).abs() / eager.abs().clamp(min=1e-6)
-        TODO: Enable this test. Currently fails.
         self.assertLess(
             rel.mean().item(),
             0.1,
             f"non-pow2 bool mask mean_rel={rel.mean():.4f} too large",
-        )"""
+        )
 
     def test_ring_buffer_bool_mask_no_nan(self):
         """Triton SDPA must not produce NaN with sparse ring buffer bool masks.


### PR DESCRIPTION
The .pte serializes the output dim_order from PyTorch's SDPA composite
(which may return a non-contiguous transposed view, e.g., efficient
attention outputs [B,Lq,H,D] transposed to [B,H,Lq,D]). However, the
AOTI delegate always produces contiguous output in its own layout,
ignoring the .pte's expected dim_order. The runtime byte-copies the
GPU data to the CPU ETensor, but the ETensor interprets it with the
.pte's strides — causing silent data corruption when the layouts differ.

Fix: in copy_slimtensor_to_etensor, detect when the SlimTensor (GPU)
and ETensor (CPU) have different strides. When they match (common case),
use the fast byte-copy path. When they differ, copy GPU data to a temp
CPU buffer then rearrange element-by-element to match the ETensor's
expected layout.

Also enables the accuracy check in test_non_pow2_head_dim_with_bool_mask
and adds test_output_stride_rearrange.py exercising both fast and slow
copy paths with Triton ON and OFF.