### PR TITLE
Add extended_targets CMake hook for non-OSS JNI extensions

### DIFF
--- a/extension/android/CMakeLists.txt
+++ b/extension/android/CMakeLists.txt
@@ -228,8 +228,8 @@ endif()
 
 # Hook for extended build targets (e.g., internal or partner-specific JNI
 # extensions). This is a no-op when extended_targets/ does not exist.
-if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/extended_targets/CMakeLists.txt")
-  include("${CMAKE_CURRENT_SOURCE_DIR}/extended_targets/CMakeLists.txt")
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/fb/extended_targets/CMakeLists.txt")
+  include("${CMAKE_CURRENT_SOURCE_DIR}/fb/extended_targets/CMakeLists.txt")
 endif()
 
 target_include_directories(

--- a/extension/android/CMakeLists.txt
+++ b/extension/android/CMakeLists.txt
@@ -226,6 +226,12 @@ if(EXECUTORCH_BUILD_LLAMA_JNI)
   endif()
 endif()
 
+# Hook for extended build targets (e.g., internal or partner-specific JNI
+# extensions). This is a no-op when extended_targets/ does not exist.
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/extended_targets/CMakeLists.txt")
+  include("${CMAKE_CURRENT_SOURCE_DIR}/extended_targets/CMakeLists.txt")
+endif()
+
 target_include_directories(
   executorch_jni
   PRIVATE


### PR DESCRIPTION
## Summary

Add a generic hook in `extension/android/CMakeLists.txt` that conditionally includes `fb/extended_targets/CMakeLists.txt` if it exists. This allows internal or partner-specific JNI extensions (e.g., Gemma3N) to plug into the Android JNI build **without modifying OSS files**.

When `fb/extended_targets/CMakeLists.txt` does not exist (as in OSS builds), the hook is a complete no-op.

## Motivation

PR #17942 added Gemma3N Android demo app support, but required modifying two OSS files (`extension/android/CMakeLists.txt` and `scripts/build_android_library.sh`) with `@oss-disable` lines. This creates ongoing merge friction and scales poorly as more internal models are added.

This PR introduces a one-time, stable hook so that:

| Build System | How it Works | Result |
| :--- | :--- | :--- |
| **Internal Buck CI** | Uses TARGETS files directly | No change needed |
| **Internal CMake/Gradle** | Hook includes `fb/extended_targets/CMakeLists.txt` which sets internal flags | Works |
| **OSS CMake/Gradle** | Hook is a no-op (`fb/extended_targets/` does not exist) | Works |


## Test plan

- OSS builds: No behavior change. The `fb/extended_targets/` directory does not exist, so the `if(EXISTS ...)` evaluates to false and is a no-op.
- Internal builds: Place a `CMakeLists.txt` in `extension/android/fb/extended_targets/` to verify it gets included.

