### PR TITLE
[executorch][nvidia][tensorrt][1/n] Add directory structure and initialization

### DIFF
--- a/backends/nvidia/TARGETS
+++ b/backends/nvidia/TARGETS
@@ -1,0 +1,5 @@
+load(":targets.bzl", "define_common_targets")
+
+oncall("executorch")
+
+define_common_targets()

--- a/backends/nvidia/__init__.py
+++ b/backends/nvidia/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""NVIDIA backend package for ExecuTorch."""

--- a/backends/nvidia/targets.bzl
+++ b/backends/nvidia/targets.bzl
@@ -1,0 +1,16 @@
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+
+def define_common_targets():
+    """Defines targets that should be shared between fbcode and xplat.
+
+    The directory containing this targets.bzl file should also contain both
+    TARGETS and BUCK files that call this function.
+    """
+
+    runtime.python_library(
+        name = "nvidia",
+        srcs = [
+            "__init__.py",
+        ],
+        visibility = ["PUBLIC"],
+    )

--- a/backends/nvidia/tensorrt/CMakeLists.txt
+++ b/backends/nvidia/tensorrt/CMakeLists.txt
@@ -1,0 +1,30 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# TensorRT backend for ExecuTorch
+#
+# ### Editing this file ###
+#
+# This file should be formatted with
+# ~~~
+# cmake-format -i CMakeLists.txt
+# ~~~
+# It should also be cmake-lint clean.
+#
+# The targets in this file will be built if EXECUTORCH_BUILD_TENSORRT is ON
+
+cmake_minimum_required(VERSION 3.19)
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
+# Source root directory for executorch.
+if(NOT EXECUTORCH_ROOT)
+  set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
+endif()
+
+include(${EXECUTORCH_ROOT}/tools/cmake/Utils.cmake)

--- a/backends/nvidia/tensorrt/README.md
+++ b/backends/nvidia/tensorrt/README.md
@@ -1,0 +1,54 @@
+# ExecuTorch TensorRT Delegate
+
+This subtree contains the TensorRT Delegate implementation for ExecuTorch.
+TensorRT is NVIDIA's high-performance deep learning inference optimizer and
+runtime library. The delegate leverages TensorRT to accelerate model execution
+on NVIDIA GPUs.
+
+## Prerequisites
+
+### TensorRT Installation
+
+TensorRT is required for both ahead-of-time (AOT) compilation and runtime
+execution. The installation method depends on your platform:
+
+#### NVIDIA Jetson (aarch64)
+
+TensorRT is **pre-installed** via JetPack SDK. No additional installation is
+required.
+
+To verify your TensorRT installation:
+```bash
+dpkg -l | grep -i tensorrt
+```
+
+> **Note:** Ensure you are using JetPack 6.x or later for TensorRT 10.x support.
+
+#### Linux x86_64
+
+Install TensorRT via pip:
+```bash
+pip install tensorrt>=10.3
+```
+
+Alternatively, download and install from the
+[NVIDIA TensorRT Download Page](https://developer.nvidia.com/tensorrt).
+
+#### Windows x86_64
+
+Download and install from the
+[NVIDIA TensorRT Download Page](https://developer.nvidia.com/tensorrt).
+
+### Additional Requirements
+
+- **CUDA Toolkit**: TensorRT requires a compatible CUDA installation
+- **cuDNN**: Required for certain layer optimizations
+- **NVIDIA GPU**: Compute capability 7.0 or higher recommended
+
+## Supported Platforms
+
+| Platform | Architecture | TensorRT Source |
+|----------|-------------|-----------------|
+| Linux | x86_64 | pip or NVIDIA installer |
+| Linux (Jetson) | aarch64 | Pre-installed via JetPack |
+| Windows | x86_64 | NVIDIA installer |

--- a/backends/nvidia/tensorrt/TARGETS
+++ b/backends/nvidia/tensorrt/TARGETS
@@ -1,0 +1,5 @@
+load(":targets.bzl", "define_common_targets")
+
+oncall("executorch")
+
+define_common_targets()

--- a/backends/nvidia/tensorrt/__init__.py
+++ b/backends/nvidia/tensorrt/__init__.py
@@ -1,0 +1,11 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""TensorRT backend for ExecuTorch.
+
+This module provides TensorRT delegate support for accelerating
+PyTorch models on NVIDIA GPUs.
+"""

--- a/backends/nvidia/tensorrt/targets.bzl
+++ b/backends/nvidia/tensorrt/targets.bzl
@@ -1,0 +1,16 @@
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+
+def define_common_targets():
+    """Defines targets that should be shared between fbcode and xplat.
+
+    The directory containing this targets.bzl file should also contain both
+    TARGETS and BUCK files that call this function.
+    """
+
+    runtime.python_library(
+        name = "tensorrt",
+        srcs = [
+            "__init__.py",
+        ],
+        visibility = ["PUBLIC"],
+    )

--- a/tools/cmake/preset/default.cmake
+++ b/tools/cmake/preset/default.cmake
@@ -162,6 +162,9 @@ define_overridable_option(
   EXECUTORCH_BUILD_SIZE_TEST "Build the size test" BOOL OFF
 )
 define_overridable_option(
+  EXECUTORCH_BUILD_TENSORRT "Build the TensorRT backend" BOOL OFF
+)
+define_overridable_option(
   EXECUTORCH_BUILD_XNNPACK "Build the XNNPACK backend" BOOL OFF
 )
 define_overridable_option(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #17978
* #17977
* #17976
* #17975
* #17974
* #17973
* #17972
* #17971
* #17970
* #17969
* #17968
* #17967
* #17966
* #17965
* #17964
* #17963
* #17962
* #17961
* #17960
* #17959
* #17958
* #17957
* #17956
* #17955
* __->__ #17954

Establish the foundation for integrating TensorRT as an ExecuTorch delegate backend.

TensorRT enables GPU-accelerated inference on NVIDIA hardware. This initial
commit sets up the project structure and build configuration to support both
OSS (CMake) and internal (Buck) builds, without functional code.

Differential Revision: [D93275046](https://our.internmc.facebook.com/intern/diff/D93275046/)