### PR TITLE
[executorch][nvidia][tensorrt][13/n] Add examples, C++ runner and CI workflow

### DIFF
--- a/.github/workflows/tensorrt.yml
+++ b/.github/workflows/tensorrt.yml
@@ -1,0 +1,236 @@
+# Test ExecuTorch TensorRT Backend
+#
+# This workflow tests the TensorRT backend for NVIDIA GPU acceleration.
+# It exports models using the TensorRT partitioner and runs them using
+# both Python and C++ runners.
+#
+# Requirements:
+# - NVIDIA GPU with TensorRT support
+# - TensorRT SDK (pip install tensorrt>=10.3)
+# - CUDA toolkit
+
+name: Test TensorRT Backend
+
+on:
+  pull_request:
+    paths:
+      - backends/nvidia/tensorrt/**
+      - examples/nvidia/tensorrt/**
+      - .github/workflows/tensorrt.yml
+  push:
+    branches:
+      - main
+      - release/*
+    paths:
+      - backends/nvidia/tensorrt/**
+      - examples/nvidia/tensorrt/**
+  workflow_dispatch:
+  schedule:
+    # Run daily at 3 AM UTC (after CUDA workflow at 2 AM)
+    - cron: '0 3 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}
+  cancel-in-progress: true
+
+jobs:
+  # Test that TensorRT backend builds correctly
+  test-tensorrt-build:
+    name: test-tensorrt-build
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      timeout: 90
+      runner: linux.g5.4xlarge.nvidia.gpu
+      gpu-arch-type: cuda
+      gpu-arch-version: "12.6"
+      use-custom-docker-registry: false
+      submodules: recursive
+      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      script: |
+        set -eux
+
+        echo "::group::Install TensorRT"
+        pip install tensorrt onnx
+        echo "::endgroup::"
+
+        echo "::group::Install ExecuTorch"
+        PYTHON_EXECUTABLE=python ./install_executorch.sh
+        echo "::endgroup::"
+
+        echo "::group::Build TensorRT Backend"
+        # Build with TensorRT support
+        cmake -S . -B cmake-out \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DEXECUTORCH_BUILD_TENSORRT=ON \
+          -DPYTHON_EXECUTABLE=python
+
+        cmake --build cmake-out --target tensorrt_backend tensorrt_executor_runner -j$(nproc)
+        echo "::endgroup::"
+
+        echo "::group::Verify Build Artifacts"
+        ls -la cmake-out/backends/nvidia/tensorrt/
+        test -f cmake-out/backends/nvidia/tensorrt/libtensorrt_backend.a
+        test -f cmake-out/backends/nvidia/tensorrt/tensorrt_executor_runner
+        echo "Build verification passed!"
+        echo "::endgroup::"
+
+  # Test model export and Python execution
+  test-models-tensorrt-python:
+    name: test-models-tensorrt-python
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        model: [add, mul, linear]
+    with:
+      timeout: 60
+      runner: linux.g5.4xlarge.nvidia.gpu
+      gpu-arch-type: cuda
+      gpu-arch-version: "12.6"
+      use-custom-docker-registry: false
+      submodules: recursive
+      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      script: |
+        set -eux
+
+        echo "::group::Install TensorRT"
+        pip install tensorrt onnx
+        echo "::endgroup::"
+
+        echo "::group::Install ExecuTorch"
+        PYTHON_EXECUTABLE=python ./install_executorch.sh
+        echo "::endgroup::"
+
+        echo "::group::Export ${{ matrix.model }} model with TensorRT"
+        python -m executorch.examples.nvidia.tensorrt.export -m ${{ matrix.model }}
+        test -f ${{ matrix.model }}_tensorrt.pte
+        echo "Model exported successfully!"
+        echo "::endgroup::"
+
+        echo "::group::Run ${{ matrix.model }} model with Python runner"
+        python -m executorch.examples.nvidia.tensorrt.runner \
+          --model_path=${{ matrix.model }}_tensorrt.pte
+        echo "Python execution completed!"
+        echo "::endgroup::"
+
+  # Test model export and C++ execution
+  test-models-tensorrt-cpp:
+    name: test-models-tensorrt-cpp
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        model: [add, mul, linear]
+    with:
+      timeout: 60
+      runner: linux.g5.4xlarge.nvidia.gpu
+      gpu-arch-type: cuda
+      gpu-arch-version: "12.6"
+      use-custom-docker-registry: false
+      submodules: recursive
+      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      script: |
+        set -eux
+
+        echo "::group::Install TensorRT"
+        pip install tensorrt onnx
+        echo "::endgroup::"
+
+        echo "::group::Install ExecuTorch"
+        PYTHON_EXECUTABLE=python ./install_executorch.sh
+        echo "::endgroup::"
+
+        echo "::group::Build TensorRT Backend and Runner"
+        cmake -S . -B cmake-out \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DEXECUTORCH_BUILD_TENSORRT=ON \
+          -DPYTHON_EXECUTABLE=python
+
+        cmake --build cmake-out --target tensorrt_executor_runner -j$(nproc)
+        echo "::endgroup::"
+
+        echo "::group::Export ${{ matrix.model }} model"
+        python -m executorch.examples.nvidia.tensorrt.export -m ${{ matrix.model }}
+        test -f ${{ matrix.model }}_tensorrt.pte
+        echo "::endgroup::"
+
+        echo "::group::Run ${{ matrix.model }} model with C++ runner"
+        RUNNER_PATH="./cmake-out/backends/nvidia/tensorrt/tensorrt_executor_runner"
+        if [ ! -f "$RUNNER_PATH" ]; then
+          # Fallback: search for the runner binary
+          RUNNER_PATH=$(find ./cmake-out -name tensorrt_executor_runner -type f | head -1)
+        fi
+        $RUNNER_PATH \
+          --model_path=${{ matrix.model }}_tensorrt.pte \
+          --verbose
+        echo "C++ execution completed!"
+        echo "::endgroup::"
+
+  # Run TensorRT backend unit tests
+  unittest-tensorrt:
+    name: unittest-tensorrt
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      timeout: 60
+      runner: linux.g5.4xlarge.nvidia.gpu
+      gpu-arch-type: cuda
+      gpu-arch-version: "12.6"
+      use-custom-docker-registry: false
+      submodules: recursive
+      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      script: |
+        set -eux
+
+        echo "::group::Install TensorRT"
+        pip install tensorrt onnx
+        echo "::endgroup::"
+
+        echo "::group::Install ExecuTorch"
+        PYTHON_EXECUTABLE=python ./install_executorch.sh
+        echo "::endgroup::"
+
+        echo "::group::Run TensorRT Backend Unit Tests"
+        # Run all test_*.py files in the backend test directory.
+        # The -o "addopts=" override prevents pytest.ini from injecting
+        # flags that would run unrelated test suites.
+        python -m pytest backends/nvidia/tensorrt/test/ -v -o "addopts="
+        echo "::endgroup::"
+
+  # Summary job to check all tests passed
+  check-all-tensorrt-tests:
+    needs: [test-tensorrt-build, test-models-tensorrt-python, test-models-tensorrt-cpp, unittest-tensorrt]
+    # All four jobs must succeed for the overall check to pass.
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Check if all TensorRT tests succeeded
+        run: |
+          if [[ "${{ needs.test-tensorrt-build.result }}" != "success" ]]; then
+            echo "ERROR: TensorRT build test failed!"
+            exit 1
+          fi
+          if [[ "${{ needs.test-models-tensorrt-python.result }}" != "success" ]]; then
+            echo "ERROR: TensorRT Python model tests failed!"
+            exit 1
+          fi
+          if [[ "${{ needs.test-models-tensorrt-cpp.result }}" != "success" ]]; then
+            echo "ERROR: TensorRT C++ model tests failed!"
+            exit 1
+          fi
+          if [[ "${{ needs.unittest-tensorrt.result }}" != "success" ]]; then
+            echo "ERROR: TensorRT unit tests failed!"
+            exit 1
+          fi
+          echo "SUCCESS: All TensorRT backend tests passed!"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -807,6 +807,12 @@ if(EXECUTORCH_BUILD_PTHREADPOOL AND EXECUTORCH_BUILD_CPUINFO)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/extension/threadpool)
 endif()
 
+# TensorRT examples (runner, benchmark) need extension_module and extension_tensor,
+# so they must be included after those targets are defined above.
+if(EXECUTORCH_BUILD_TENSORRT)
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/examples/nvidia)
+endif()
+
 if(EXECUTORCH_BUILD_KERNELS_TORCHAO)
   if(NOT TARGET cpuinfo)
     message(

--- a/backends/nvidia/tensorrt/README.md
+++ b/backends/nvidia/tensorrt/README.md
@@ -5,6 +5,62 @@ TensorRT is NVIDIA's high-performance deep learning inference optimizer and
 runtime library. The delegate leverages TensorRT to accelerate model execution
 on NVIDIA GPUs.
 
+## Getting Started
+
+### Clone and Install
+
+```bash
+git clone --recurse-submodules https://github.com/pytorch/executorch.git
+cd executorch
+
+python3 -m venv .venv && source .venv/bin/activate && pip install --upgrade pip
+
+# Install TensorRT (x86_64 only — Jetson has it pre-installed via JetPack)
+pip install tensorrt>=10.3
+
+# Install ExecuTorch (auto-detects TensorRT and links it into pybindings)
+./install_executorch.sh --editable
+```
+
+> **Note for Jetson users:** TensorRT is pre-installed via JetPack SDK. The
+> backend automatically detects Jetson hardware and uses the system TensorRT
+> and other system/user-installed packages (e.g. `onnx`) — no additional
+> `pip install` needed.
+
+### Build C++ Components
+
+```bash
+cmake -B cmake-out \
+  -DEXECUTORCH_BUILD_TENSORRT=ON \
+  -DEXECUTORCH_BUILD_EXTENSION_MODULE=ON \
+  -DEXECUTORCH_BUILD_EXTENSION_TENSOR=ON \
+  -DEXECUTORCH_BUILD_EXTENSION_NAMED_DATA_MAP=ON \
+  -DCMAKE_BUILD_TYPE=Release
+
+cmake --build cmake-out --target tensorrt_executor_runner -j$(nproc)
+```
+
+### Export and Run Models
+
+```bash
+# Export a single model
+python -m executorch.examples.nvidia.tensorrt.export -m add
+
+# Export all supported models
+python -m executorch.examples.nvidia.tensorrt.export
+
+# Run inference with the C++ runner
+./cmake-out/backends/nvidia/tensorrt/tensorrt_executor_runner --model_path=add_tensorrt.pte
+```
+
+> **Jetson memory tip:** On memory-constrained devices (e.g., Orin Nano 8GB),
+> export models one at a time to avoid OOM during TRT engine building:
+> ```bash
+> for m in add mv3 resnet18; do
+>     python -m executorch.examples.nvidia.tensorrt.export -m "$m"
+> done
+> ```
+
 ## Prerequisites
 
 ### TensorRT Installation
@@ -34,11 +90,6 @@ pip install tensorrt>=10.3
 Alternatively, download and install from the
 [NVIDIA TensorRT Download Page](https://developer.nvidia.com/tensorrt).
 
-#### Windows x86_64
-
-Download and install from the
-[NVIDIA TensorRT Download Page](https://developer.nvidia.com/tensorrt).
-
 ### Additional Requirements
 
 - **CUDA Toolkit**: TensorRT requires a compatible CUDA installation
@@ -48,10 +99,9 @@ Download and install from the
 ## Supported Platforms
 
 | Platform | Architecture | TensorRT Source |
-|----------|-------------|-----------------|
+|----------|-------------|------------------|
 | Linux | x86_64 | pip or NVIDIA installer |
 | Linux (Jetson) | aarch64 | Pre-installed via JetPack |
-| Windows | x86_64 | NVIDIA installer |
 
 ## Configuration Options
 
@@ -73,6 +123,70 @@ Download and install from the
   compatibility)
 - **Recommended**: TensorRT 10.6 or later for best performance and feature
   support
+
+## Python API
+
+```python
+import torch
+from torch.export import export
+from executorch.exir import to_edge_transform_and_lower
+from executorch.backends.nvidia.tensorrt import TensorRTPartitioner
+
+# Define your model
+class MyModel(torch.nn.Module):
+    def forward(self, x, y):
+        return x + y
+
+model = MyModel()
+example_inputs = (torch.randn(2, 3), torch.randn(2, 3))
+
+# Export and lower to TensorRT
+with torch.no_grad():
+    exported = export(model, example_inputs)
+
+edge_program = to_edge_transform_and_lower(
+    exported,
+    partitioner=[TensorRTPartitioner()],
+)
+
+# Save the .pte file
+exec_prog = edge_program.to_executorch()
+with open("model_tensorrt.pte", "wb") as f:
+    exec_prog.write_to_file(f)
+```
+
+## Supported Operations
+
+| Category | Operations |
+|----------|-----------|
+| Elementwise | add, sub, mul, div, mm, relu |
+| Reshape | view, reshape, squeeze, unsqueeze, permute, contiguous, clone |
+
+## Jetson Deployment
+
+### Performance Tuning
+
+```bash
+sudo nvpmodel -m 0    # Max performance mode
+sudo jetson_clocks     # Lock clocks for consistent benchmarking
+```
+
+### DLA Support
+
+For models that support it, you can use NVIDIA's Deep Learning Accelerator:
+```python
+compile_spec = TensorRTCompileSpec(
+    dla_core=0,
+    allow_gpu_fallback=True,
+)
+```
+
+### Memory Management
+
+On memory-constrained Jetson devices, free RAM before export:
+```bash
+sudo sh -c 'echo 3 > /proc/sys/vm/drop_caches && echo 1 > /proc/sys/vm/compact_memory'
+```
 
 ## Blob Format
 
@@ -107,13 +221,12 @@ The TensorRT delegate uses a custom binary blob format:
 - cuDNN 8.x
 - PyTorch 2.x with CUDA support (for export)
 
-## Build Instructions
+## Troubleshooting
 
-```bash
-cd executorch
-mkdir -p cmake-out && cd cmake-out
-
-cmake .. -DEXECUTORCH_BUILD_TENSORRT=ON
-
-cmake --build . --target tensorrt_backend tensorrt_executor_runner
-```
+| Issue | Fix |
+|-------|-----|
+| `Backend TensorRTBackend is not registered` | Ensure TensorRT is installed, then re-run `./install_executorch.sh --editable` |
+| `ModuleNotFoundError: tensorrt` | On x86_64: `pip install tensorrt>=10.3`. On Jetson: auto-detected |
+| CMake can't find TensorRT | Set `-DTENSORRT_HOME=/path/to/tensorrt` |
+| OOM during TRT engine building | Export models one at a time; free memory first |
+| `extension_module not found` | Add `-DEXECUTORCH_BUILD_EXTENSION_MODULE=ON` to cmake |

--- a/backends/nvidia/tensorrt/converters/div.py
+++ b/backends/nvidia/tensorrt/converters/div.py
@@ -1,0 +1,199 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Converter for element-wise division operations."""
+
+from typing import Any, Dict, Optional
+
+import tensorrt as trt
+import torch
+from executorch.backends.nvidia.tensorrt.converter_registry import converter
+from executorch.backends.nvidia.tensorrt.converter_utils import (
+    broadcast_tensors,
+    cast_trt_tensor,
+    get_node_dtype,
+    get_trt_tensor,
+    promote_and_cast_tensors,
+    set_layer_name,
+)
+
+
+def _get_elementwise_input(
+    network: trt.INetworkDefinition,
+    input_map: Dict[torch.fx.Node, Any],
+    arg: Any,
+    name: str,
+    dtype: Optional[torch.dtype],
+) -> trt.ITensor:
+    """Get TensorRT tensor for an elementwise operation input."""
+    if isinstance(arg, torch.fx.Node):
+        if arg not in input_map:
+            raise ValueError(
+                f"Input node '{arg.name}' not found in input_map. "
+                f"Available nodes: {list(input_map.keys())}"
+            )
+        return input_map[arg]
+    return get_trt_tensor(network, arg, name, dtype)
+
+
+def _get_input_ndim(arg: Any, input_map: Dict[torch.fx.Node, Any]) -> int:
+    """Get the number of dimensions for an elementwise input argument."""
+    if isinstance(arg, torch.fx.Node):
+        if "val" in arg.meta and hasattr(arg.meta["val"], "shape"):
+            return len(arg.meta["val"].shape)
+        if arg in input_map:
+            trt_tensor = input_map[arg]
+            shape = trt_tensor.shape
+            if shape is not None:
+                return len(shape)
+    return 0
+
+
+@converter("aten.div.Tensor", "aten.div_.Tensor", "aten.div.Tensor_mode")
+def convert_div(
+    node: torch.fx.Node,
+    network: trt.INetworkDefinition,
+    input_map: Dict[torch.fx.Node, Any],
+    ctx: Any = None,
+) -> trt.ITensor:
+    """Convert aten.div.Tensor and aten.div.Tensor_mode to TensorRT ElementWise DIV.
+
+    Handles tensor / tensor, tensor / scalar, and scalar / tensor cases.
+    Includes type promotion for mixed-type operands.
+
+    For div.Tensor_mode, supports rounding_mode kwargs:
+    - None: standard float division
+    - "floor": floor division (same as floor_divide)
+    - "trunc": truncated division (round towards zero)
+
+    Note: For integer division, TensorRT requires float types, so we cast
+    integer operands to float32 before division.
+    """
+    if len(node.args) < 2:
+        raise ValueError(
+            f"aten.div requires at least 2 arguments, got {len(node.args)}"
+        )
+
+    lhs_arg = node.args[0]
+    rhs_arg = node.args[1]
+
+    dtype = get_node_dtype(node)
+
+    lhs = _get_elementwise_input(network, input_map, lhs_arg, f"div_lhs_{node.name}", dtype)
+    rhs = _get_elementwise_input(network, input_map, rhs_arg, f"div_rhs_{node.name}", dtype)
+
+    # Type promotion: ensure both operands have compatible types
+    lhs, rhs = promote_and_cast_tensors(network, lhs, rhs, f"div_{node.name}")
+
+    # For integer division, TensorRT requires float types
+    # Cast to float32 if both operands are integer types
+    if lhs.dtype in (trt.int8, trt.int32) and rhs.dtype in (trt.int8, trt.int32):
+        lhs = cast_trt_tensor(network, lhs, trt.float32, f"div_lhs_float_{node.name}")
+        rhs = cast_trt_tensor(network, rhs, trt.float32, f"div_rhs_float_{node.name}")
+
+    # Get target ndim for broadcasting
+    lhs_ndim = _get_input_ndim(lhs_arg, input_map)
+    rhs_ndim = _get_input_ndim(rhs_arg, input_map)
+    target_ndim = max(lhs_ndim, rhs_ndim)
+
+    if target_ndim == 0 and "val" in node.meta and hasattr(node.meta["val"], "shape"):
+        target_ndim = len(node.meta["val"].shape)
+    if target_ndim == 0:
+        target_ndim = 1
+
+    lhs, rhs = broadcast_tensors(network, [lhs, rhs], target_ndim, f"div_{node.name}")
+
+    layer = network.add_elementwise(lhs, rhs, trt.ElementWiseOperation.DIV)
+    if layer is None:
+        raise RuntimeError(f"Failed to create elementwise DIV layer for {node.name}")
+    set_layer_name(layer, node, "div")
+    result = layer.get_output(0)
+
+    # Handle rounding modes for div.Tensor_mode
+    rounding_mode = node.kwargs.get("rounding_mode", None)
+    if rounding_mode == "trunc":
+        # Truncated division: div then round towards zero
+        # trunc(x) = sign(x) * floor(abs(x))
+        # Ensure float type for unary ops (FLOOR/ABS/SIGN require float)
+        original_dtype = result.dtype
+        if result.dtype in (trt.int8, trt.int32, trt.int64):
+            result = cast_trt_tensor(network, result, trt.float32, f"div_trunc_tofloat_{node.name}")
+        abs_layer = network.add_unary(result, trt.UnaryOperation.ABS)
+        abs_layer.name = f"div_trunc_abs_{node.name}"
+        floor_layer = network.add_unary(abs_layer.get_output(0), trt.UnaryOperation.FLOOR)
+        floor_layer.name = f"div_trunc_floor_{node.name}"
+        sign_layer = network.add_unary(result, trt.UnaryOperation.SIGN)
+        sign_layer.name = f"div_trunc_sign_{node.name}"
+        mul_layer = network.add_elementwise(
+            floor_layer.get_output(0), sign_layer.get_output(0),
+            trt.ElementWiseOperation.PROD
+        )
+        mul_layer.name = f"div_trunc_mul_{node.name}"
+        result = mul_layer.get_output(0)
+        # Cast back to the original integer type to match PyTorch semantics.
+        # Without this, integer trunc_div returns float32, causing output
+        # mismatches for models that use integer division (e.g., emformer).
+        if original_dtype in (trt.int8, trt.int32, trt.int64):
+            result = cast_trt_tensor(network, result, original_dtype, f"div_trunc_toint_{node.name}")
+    elif rounding_mode == "floor":
+        original_dtype = result.dtype
+        if result.dtype in (trt.int8, trt.int32, trt.int64):
+            result = cast_trt_tensor(network, result, trt.float32, f"div_floor_tofloat_{node.name}")
+        floor_layer = network.add_unary(result, trt.UnaryOperation.FLOOR)
+        floor_layer.name = f"div_floor_{node.name}"
+        result = floor_layer.get_output(0)
+        # Cast back to the original integer type to match PyTorch semantics.
+        if original_dtype in (trt.int8, trt.int32, trt.int64):
+            result = cast_trt_tensor(network, result, original_dtype, f"div_floor_toint_{node.name}")
+
+    return result
+
+
+@converter("aten.floor_divide.default")
+def convert_floor_divide(
+    node: torch.fx.Node,
+    network: trt.INetworkDefinition,
+    input_map: Dict[torch.fx.Node, Any],
+    ctx: Any = None,
+) -> trt.ITensor:
+    """Convert aten.floor_divide to TensorRT ElementWise FLOOR_DIV.
+
+    Handles tensor // tensor and tensor // scalar cases.
+    """
+    if len(node.args) < 2:
+        raise ValueError(
+            f"aten.floor_divide requires at least 2 arguments, got {len(node.args)}"
+        )
+
+    lhs_arg = node.args[0]
+    rhs_arg = node.args[1]
+
+    dtype = get_node_dtype(node)
+
+    lhs = _get_elementwise_input(network, input_map, lhs_arg, f"floordiv_lhs_{node.name}", dtype)
+    rhs = _get_elementwise_input(network, input_map, rhs_arg, f"floordiv_rhs_{node.name}", dtype)
+
+    # Type promotion
+    lhs, rhs = promote_and_cast_tensors(network, lhs, rhs, f"floordiv_{node.name}")
+
+    # Get target ndim for broadcasting
+    lhs_ndim = _get_input_ndim(lhs_arg, input_map)
+    rhs_ndim = _get_input_ndim(rhs_arg, input_map)
+    target_ndim = max(lhs_ndim, rhs_ndim)
+
+    if target_ndim == 0 and "val" in node.meta and hasattr(node.meta["val"], "shape"):
+        target_ndim = len(node.meta["val"].shape)
+    if target_ndim == 0:
+        target_ndim = 1
+
+    lhs, rhs = broadcast_tensors(network, [lhs, rhs], target_ndim, f"floordiv_{node.name}")
+
+    layer = network.add_elementwise(lhs, rhs, trt.ElementWiseOperation.FLOOR_DIV)
+    if layer is None:
+        raise RuntimeError(f"Failed to create elementwise FLOOR_DIV layer for {node.name}")
+    set_layer_name(layer, node, "floor_divide")
+
+    return layer.get_output(0)

--- a/backends/nvidia/tensorrt/converters/mm.py
+++ b/backends/nvidia/tensorrt/converters/mm.py
@@ -1,0 +1,39 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Converter for matrix multiplication operations."""
+
+from typing import Any, Dict, Optional
+
+import tensorrt as trt
+import torch
+from executorch.backends.nvidia.tensorrt.converter_registry import converter
+from executorch.backends.nvidia.tensorrt.converter_utils import set_layer_name
+
+
+@converter("aten.mm.default")
+def convert_mm(
+    node: torch.fx.Node,
+    network: trt.INetworkDefinition,
+    input_map: Dict[torch.fx.Node, Any],
+    ctx: Any = None,
+) -> trt.ITensor:
+    """Convert aten.mm.default to TensorRT MatrixMultiply.
+
+    Performs matrix multiplication of two 2D tensors (MxK) @ (KxN) -> (MxN).
+    """
+    lhs_arg = node.args[0]
+    rhs_arg = node.args[1]
+
+    lhs = input_map[lhs_arg]
+    rhs = input_map[rhs_arg]
+
+    layer = network.add_matrix_multiply(
+        lhs, trt.MatrixOperation.NONE, rhs, trt.MatrixOperation.NONE
+    )
+    set_layer_name(layer, node, "mm")
+
+    return layer.get_output(0)

--- a/backends/nvidia/tensorrt/converters/mul.py
+++ b/backends/nvidia/tensorrt/converters/mul.py
@@ -1,0 +1,140 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Converter for element-wise multiplication operations."""
+
+from typing import Any, Dict, Optional
+
+import numpy as np
+import tensorrt as trt
+import torch
+from executorch.backends.nvidia.tensorrt.converter_registry import converter
+from executorch.backends.nvidia.tensorrt.converter_utils import (
+    broadcast_tensors,
+    get_node_dtype,
+    get_trt_tensor,
+    promote_and_cast_tensors,
+    set_layer_name,
+)
+
+
+def _get_elementwise_input(
+    network: trt.INetworkDefinition,
+    input_map: Dict[torch.fx.Node, Any],
+    arg: Any,
+    name: str,
+    dtype: Optional[torch.dtype],
+) -> trt.ITensor:
+    """Get TensorRT tensor for an elementwise operation input."""
+    if isinstance(arg, torch.fx.Node):
+        if arg not in input_map:
+            raise ValueError(
+                f"Input node '{arg.name}' not found in input_map. "
+                f"Available nodes: {list(input_map.keys())}"
+            )
+        return input_map[arg]
+    return get_trt_tensor(network, arg, name, dtype)
+
+
+def _get_input_ndim(arg: Any, input_map: Dict[torch.fx.Node, Any]) -> int:
+    """Get the number of dimensions for an elementwise input argument."""
+    if isinstance(arg, torch.fx.Node):
+        if "val" in arg.meta and hasattr(arg.meta["val"], "shape"):
+            return len(arg.meta["val"].shape)
+        if arg in input_map:
+            trt_tensor = input_map[arg]
+            shape = trt_tensor.shape
+            if shape is not None:
+                return len(shape)
+    return 0
+
+
+@converter("aten.mul.Tensor", "aten.mul_.Tensor")
+def convert_mul(
+    node: torch.fx.Node,
+    network: trt.INetworkDefinition,
+    input_map: Dict[torch.fx.Node, Any],
+    edge_program: Optional[Any] = None,
+) -> trt.ITensor:
+    """Convert aten.mul.Tensor to TensorRT ElementWise PROD.
+
+    Handles tensor * tensor, tensor * scalar, and scalar * tensor cases.
+    Includes type promotion for mixed-type operands.
+    """
+    lhs_arg = node.args[0]
+    rhs_arg = node.args[1]
+
+    dtype = get_node_dtype(node)
+
+    lhs = _get_elementwise_input(network, input_map, lhs_arg, f"mul_lhs_{node.name}", dtype)
+    rhs = _get_elementwise_input(network, input_map, rhs_arg, f"mul_rhs_{node.name}", dtype)
+
+    # Type promotion: ensure both operands have compatible types
+    lhs, rhs = promote_and_cast_tensors(network, lhs, rhs, f"mul_{node.name}")
+
+    # Get target ndim for broadcasting
+    lhs_ndim = _get_input_ndim(lhs_arg, input_map)
+    rhs_ndim = _get_input_ndim(rhs_arg, input_map)
+    target_ndim = max(lhs_ndim, rhs_ndim)
+
+    if target_ndim == 0 and "val" in node.meta and hasattr(node.meta["val"], "shape"):
+        target_ndim = len(node.meta["val"].shape)
+    if target_ndim == 0:
+        target_ndim = 1
+
+    lhs, rhs = broadcast_tensors(network, [lhs, rhs], target_ndim, f"mul_{node.name}")
+
+    layer = network.add_elementwise(lhs, rhs, trt.ElementWiseOperation.PROD)
+    if layer is None:
+        raise RuntimeError(f"Failed to create elementwise PROD layer for {node.name}")
+    set_layer_name(layer, node, "mul")
+
+    return layer.get_output(0)
+
+
+@converter("aten.mul.Scalar")
+def convert_mul_scalar(
+    node: torch.fx.Node,
+    network: trt.INetworkDefinition,
+    input_map: Dict[torch.fx.Node, Any],
+    edge_program: Optional[Any] = None,
+) -> trt.ITensor:
+    """Convert aten.mul.Scalar to TensorRT ElementWise PROD.
+
+    Handles tensor * scalar multiplication.
+    """
+    input_arg = node.args[0]
+    scalar_arg = node.args[1]
+
+    if not isinstance(input_arg, torch.fx.Node):
+        raise ValueError(f"Input to mul.Scalar must be a node, got {type(input_arg)}")
+
+    input_tensor = input_map[input_arg]
+
+    # Create scalar constant tensor with same shape as input
+    scalar_value = float(scalar_arg) if isinstance(scalar_arg, (int, float)) else scalar_arg
+    scalar_np = np.array([scalar_value], dtype=np.float32)
+    scalar_const = network.add_constant((1,), trt.Weights(scalar_np))
+    scalar_const.name = f"const_scalar_{node.name}"
+    scalar_trt = scalar_const.get_output(0)
+
+    # Type promotion between input tensor and scalar
+    input_tensor, scalar_trt = promote_and_cast_tensors(
+        network, input_tensor, scalar_trt, f"mul_scalar_{node.name}"
+    )
+
+    # Broadcast scalar to match input dimensions
+    target_ndim = len(input_tensor.shape)
+    (scalar_trt,) = broadcast_tensors(
+        network, [scalar_trt], target_ndim, f"mul_scalar_{node.name}"
+    )
+
+    layer = network.add_elementwise(input_tensor, scalar_trt, trt.ElementWiseOperation.PROD)
+    if layer is None:
+        raise RuntimeError(f"Failed to create elementwise PROD layer for {node.name}")
+    set_layer_name(layer, node, "mul_scalar")
+
+    return layer.get_output(0)

--- a/backends/nvidia/tensorrt/converters/relu.py
+++ b/backends/nvidia/tensorrt/converters/relu.py
@@ -1,0 +1,36 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Converter for ReLU activation operations."""
+
+from typing import Any, Dict, Optional
+
+import tensorrt as trt
+import torch
+from executorch.backends.nvidia.tensorrt.converter_registry import converter
+from executorch.backends.nvidia.tensorrt.converter_utils import set_layer_name
+
+
+@converter("aten.relu.default", "aten.relu_.default")
+def convert_relu(
+    node: torch.fx.Node,
+    network: trt.INetworkDefinition,
+    input_map: Dict[torch.fx.Node, Any],
+    ctx: Any = None,
+) -> trt.ITensor:
+    """Convert aten.relu.default and aten.relu_.default to TensorRT Activation RELU.
+
+    ReLU(x) = max(0, x)
+    Note: In-place variant (relu_) is handled identically since TensorRT doesn't
+    have in-place operations.
+    """
+    input_arg = node.args[0]
+    input_tensor = input_map[input_arg]
+
+    layer = network.add_activation(input_tensor, trt.ActivationType.RELU)
+    set_layer_name(layer, node, "relu")
+
+    return layer.get_output(0)

--- a/backends/nvidia/tensorrt/converters/sub.py
+++ b/backends/nvidia/tensorrt/converters/sub.py
@@ -1,0 +1,106 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Converter for element-wise subtraction operations."""
+
+from typing import Any, Dict, Optional
+
+import tensorrt as trt
+import torch
+from executorch.backends.nvidia.tensorrt.converter_registry import converter
+from executorch.backends.nvidia.tensorrt.converter_utils import (
+    broadcast_tensors,
+    get_node_dtype,
+    get_trt_tensor,
+    promote_and_cast_tensors,
+    set_layer_name,
+)
+
+
+def _get_elementwise_input(
+    network: trt.INetworkDefinition,
+    input_map: Dict[torch.fx.Node, Any],
+    arg: Any,
+    name: str,
+    dtype: Optional[torch.dtype],
+) -> trt.ITensor:
+    """Get TensorRT tensor for an elementwise operation input."""
+    if isinstance(arg, torch.fx.Node):
+        if arg not in input_map:
+            raise ValueError(
+                f"Input node '{arg.name}' not found in input_map. "
+                f"Available nodes: {list(input_map.keys())}"
+            )
+        return input_map[arg]
+    return get_trt_tensor(network, arg, name, dtype)
+
+
+def _get_input_ndim(arg: Any, input_map: Dict[torch.fx.Node, Any]) -> int:
+    """Get the number of dimensions for an elementwise input argument."""
+    if isinstance(arg, torch.fx.Node):
+        if "val" in arg.meta and hasattr(arg.meta["val"], "shape"):
+            return len(arg.meta["val"].shape)
+        if arg in input_map:
+            trt_tensor = input_map[arg]
+            shape = trt_tensor.shape
+            if shape is not None:
+                return len(shape)
+    return 0
+
+
+@converter("aten.sub.Tensor", "aten.sub_.Tensor")
+def convert_sub(
+    node: torch.fx.Node,
+    network: trt.INetworkDefinition,
+    input_map: Dict[torch.fx.Node, Any],
+    ctx: Any = None,
+) -> trt.ITensor:
+    """Convert aten.sub.Tensor to TensorRT ElementWise SUB.
+
+    Handles tensor - tensor, tensor - scalar, and scalar - tensor cases.
+    The alpha parameter (x - alpha * y) is validated to be 1.
+    Includes type promotion for mixed-type operands.
+    """
+    if len(node.args) < 2:
+        raise ValueError(
+            f"aten.sub requires at least 2 arguments, got {len(node.args)}"
+        )
+
+    lhs_arg = node.args[0]
+    rhs_arg = node.args[1]
+
+    alpha = node.args[2] if len(node.args) > 2 else node.kwargs.get("alpha", 1)
+    if alpha != 1:
+        raise ValueError(
+            f"aten.sub.Tensor with alpha != 1 is not supported, got alpha={alpha}"
+        )
+
+    dtype = get_node_dtype(node)
+
+    lhs = _get_elementwise_input(network, input_map, lhs_arg, f"sub_lhs_{node.name}", dtype)
+    rhs = _get_elementwise_input(network, input_map, rhs_arg, f"sub_rhs_{node.name}", dtype)
+
+    # Type promotion: ensure both operands have compatible types
+    lhs, rhs = promote_and_cast_tensors(network, lhs, rhs, f"sub_{node.name}")
+
+    # Get target ndim for broadcasting
+    lhs_ndim = _get_input_ndim(lhs_arg, input_map)
+    rhs_ndim = _get_input_ndim(rhs_arg, input_map)
+    target_ndim = max(lhs_ndim, rhs_ndim)
+
+    if target_ndim == 0 and "val" in node.meta and hasattr(node.meta["val"], "shape"):
+        target_ndim = len(node.meta["val"].shape)
+    if target_ndim == 0:
+        target_ndim = 1
+
+    lhs, rhs = broadcast_tensors(network, [lhs, rhs], target_ndim, f"sub_{node.name}")
+
+    layer = network.add_elementwise(lhs, rhs, trt.ElementWiseOperation.SUB)
+    if layer is None:
+        raise RuntimeError(f"Failed to create elementwise SUB layer for {node.name}")
+    set_layer_name(layer, node, "sub")
+
+    return layer.get_output(0)

--- a/examples/nvidia/__init__.py
+++ b/examples/nvidia/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""NVIDIA backend examples for ExecuTorch."""

--- a/examples/nvidia/tensorrt/README.md
+++ b/examples/nvidia/tensorrt/README.md
@@ -1,0 +1,119 @@
+# TensorRT Delegate Examples
+
+This directory contains examples for exporting and running models with the
+TensorRT delegate on NVIDIA GPUs.
+
+## Overview
+
+The TensorRT delegate accelerates model inference by converting ExecuTorch
+models to TensorRT engines that run optimized on NVIDIA GPUs.
+
+## Quick Start
+
+### Export a Model
+
+Export a supported model to ExecuTorch format with TensorRT delegation:
+
+```bash
+# Export the add model
+python -m executorch.examples.nvidia.tensorrt.export -m add
+
+# Export with validation test
+python -m executorch.examples.nvidia.tensorrt.export -m add --test
+
+# Export to a specific directory
+python -m executorch.examples.nvidia.tensorrt.export -m add -o ./output
+```
+
+### Run with C++ Runner
+
+Run the exported model using the C++ executor runner:
+
+```bash
+# Build with CMake
+cmake -DEXECUTORCH_BUILD_TENSORRT=ON ...
+cmake --build . --target tensorrt_executor_runner
+
+# Run the model
+./tensorrt_executor_runner --model_path=add_tensorrt.pte
+```
+
+Note: The C++ runner requires TensorRT and CUDA which are only available
+on systems with NVIDIA GPUs.
+
+### Supported Models
+
+Currently supported models:
+- `add` - Simple element-wise addition
+
+More models will be added as converters are implemented.
+
+Run `--help` to see all available options:
+
+```bash
+python -m executorch.examples.nvidia.tensorrt.export --help
+./tensorrt_executor_runner --help
+```
+
+## Files
+
+- `export.py` - Main export script for converting models to TensorRT format
+- `runner.py` - Python utilities for running and testing exported models
+- `tensorrt_executor_runner.cpp` - C++ executor runner for TensorRT models
+- `__init__.py` - Package initialization
+
+## Usage
+
+### Python Export
+
+```python
+from executorch.examples.nvidia.tensorrt.export import main
+```
+
+Or run directly:
+
+```bash
+python -m executorch.examples.nvidia.tensorrt.export -m add
+```
+
+### C++ Runner Options
+
+```
+--model_path=PATH    Path to .pte model file (default: model.pte)
+--num_executions=N   Number of times to run inference (default: 1)
+--verbose            Enable verbose output
+--help               Show help message
+```
+
+### Validation Testing
+
+The `--test` flag runs the exported model through the ExecuTorch runtime
+and compares outputs against the PyTorch reference model:
+
+```bash
+python -m executorch.examples.nvidia.tensorrt.export -m add --test
+```
+
+## Adding New Models
+
+To add support for a new model:
+
+1. Ensure the required operator converters exist in
+   `executorch/backends/nvidia/tensorrt/converters/`
+2. Add the model name to `TENSORRT_SUPPORTED_MODELS` in `export.py`
+3. Verify the model is registered in `executorch/examples/models/`
+
+## Architecture
+
+```
+examples/nvidia/tensorrt/
+├── export.py                    # CLI export script using MODEL_NAME_TO_MODEL registry
+├── runner.py                    # Python runtime utilities for testing
+├── tensorrt_executor_runner.cpp # C++ executor runner binary
+├── __init__.py                  # Package exports
+└── README.md                    # This file
+```
+
+The export script follows the same pattern as other backends (XNNPACK, Vulkan,
+CoreML) by using the `MODEL_NAME_TO_MODEL` registry and `EagerModelFactory`
+for model instantiation.

--- a/examples/nvidia/tensorrt/TARGETS
+++ b/examples/nvidia/tensorrt/TARGETS
@@ -1,0 +1,11 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+load(":targets.bzl", "define_common_targets")
+
+oncall("executorch")
+
+define_common_targets()

--- a/examples/nvidia/tensorrt/__init__.py
+++ b/examples/nvidia/tensorrt/__init__.py
@@ -1,0 +1,21 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""TensorRT delegate examples for ExecuTorch.
+
+This module provides utilities for exporting and running models
+with the TensorRT delegate on NVIDIA GPUs.
+"""
+
+from executorch.examples.nvidia.tensorrt.export import (
+    get_supported_models_list,
+    TENSORRT_SUPPORTED_MODELS,
+)
+
+__all__ = [
+    "get_supported_models_list",
+    "TENSORRT_SUPPORTED_MODELS",
+]

--- a/examples/nvidia/tensorrt/export.py
+++ b/examples/nvidia/tensorrt/export.py
@@ -1,0 +1,260 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""Export models to ExecuTorch format with the TensorRT delegate.
+
+Usage:
+    python -m executorch.examples.nvidia.tensorrt.export -m add
+    python -m executorch.examples.nvidia.tensorrt.export -o ./output
+"""
+
+import argparse
+import logging
+from typing import List
+
+import torch
+
+from executorch.backends.nvidia.tensorrt.partitioner import TensorRTPartitioner
+from executorch.examples.models import MODEL_NAME_TO_MODEL
+from executorch.examples.models.model_factory import EagerModelFactory
+from executorch.exir import to_edge_transform_and_lower
+from executorch.extension.export_util.utils import save_pte_program
+from torch.export import export
+from torch.utils._pytree import tree_flatten
+
+FORMAT = "[%(levelname)s %(asctime)s %(filename)s:%(lineno)s] %(message)s"
+logging.basicConfig(level=logging.INFO, format=FORMAT)
+
+
+# Models that are supported by TensorRT delegate (sorted alphabetically).
+TENSORRT_SUPPORTED_MODELS = {
+    "add",
+    "add_mul",
+    "mul",
+}
+
+
+def get_supported_models_list() -> list:
+    """Return list of models supported by TensorRT backend."""
+    return sorted(TENSORRT_SUPPORTED_MODELS)
+
+
+def export_model(
+    model_name: str,
+    output_dir: str,
+    strict: bool,
+    logger: logging.Logger,
+) -> tuple:
+    """Export a single model to ExecuTorch format with TensorRT delegate.
+
+    Returns:
+        (model, example_inputs, exec_prog) for optional downstream use.
+    """
+    if model_name not in MODEL_NAME_TO_MODEL:
+        raise ValueError(
+            f"Model '{model_name}' is not registered in MODEL_NAME_TO_MODEL. "
+            f"Available: {list(MODEL_NAME_TO_MODEL.keys())}"
+        )
+
+    logging.info(f"Creating model: {model_name}")
+    torch.manual_seed(0)
+    model, example_inputs, _, dynamic_shapes = EagerModelFactory.create_model(
+        *MODEL_NAME_TO_MODEL[model_name]
+    )
+
+    model.eval()
+
+    logging.info(f"Exporting model {model_name} with TensorRT delegate")
+
+    if dynamic_shapes is not None:
+        program = export(
+            model, example_inputs, dynamic_shapes=dynamic_shapes, strict=strict
+        )
+    else:
+        program = export(model, example_inputs, strict=strict)
+
+    edge_program = to_edge_transform_and_lower(
+        program,
+        partitioner=[TensorRTPartitioner()],
+    )
+
+    logging.info(f"Lowered graph:\n{edge_program.exported_program().graph}")
+
+    exec_prog = edge_program.to_executorch()
+
+    output_filename = f"{model_name}_tensorrt"
+    save_pte_program(exec_prog, output_filename, output_dir)
+    logger.info(f"Model exported and saved as {output_filename}.pte in {output_dir}")
+
+    return model, example_inputs, exec_prog
+
+
+# ---------------------------------------------------------------------------
+# Correctness verification (used by test_export.py via buck test)
+# ---------------------------------------------------------------------------
+
+_TEST_SEEDS = [2025, 12345, 7777]
+_ATOL = 1e-3
+_RTOL = 1e-3
+
+
+def _verify_correctness(
+    model_name: str,
+    model: torch.nn.Module,
+    example_inputs: tuple,
+    pte_bytes: bytes,
+    logger: logging.Logger,
+) -> None:
+    """Run exported program with random inputs, compare to eager on GPU."""
+    from executorch.extension.pybindings.portable_lib import (
+        _load_for_executorch_from_buffer,
+    )
+
+    et_module = _load_for_executorch_from_buffer(pte_bytes)
+
+    for seed in _TEST_SEEDS:
+        inputs = _randomise_inputs(example_inputs, seed)
+
+        eager_outputs = _run_eager(model, inputs)
+        et_outputs = _run_executorch(et_module, inputs)
+
+        n = min(len(eager_outputs), len(et_outputs))
+        if n == 0:
+            logger.warning(f"{model_name} seed={seed}: no comparable outputs")
+            continue
+
+        max_diff = 0.0
+        for i in range(n):
+            e, a = eager_outputs[i], et_outputs[i]
+            if e.shape != a.shape:
+                continue
+            if e.dtype in (torch.int32, torch.int64, torch.long):
+                continue
+            if torch.isnan(e).any() or torch.isnan(a).any():
+                continue
+            diff = (e.float() - a.float()).abs().max().item()
+            max_diff = max(max_diff, diff)
+            if not torch.allclose(e.float(), a.float(), atol=_ATOL, rtol=_RTOL):
+                raise RuntimeError(
+                    f"FAIL: {model_name} output[{i}] seed={seed}: "
+                    f"max diff {diff:.6e} exceeds tolerance "
+                    f"(atol={_ATOL}, rtol={_RTOL})"
+                )
+
+        logger.info(
+            f"PASS: {model_name} seed={seed} "
+            f"({n} outputs, max_diff={max_diff:.6e})"
+        )
+
+
+def _randomise_inputs(example_inputs: tuple, seed: int) -> tuple:
+    """Create inputs with small perturbation for numerical diversity."""
+    torch.manual_seed(seed)
+
+    def _perturb(obj):
+        if isinstance(obj, torch.Tensor):
+            if obj.dtype in (torch.int32, torch.int64, torch.long):
+                return obj.clone()
+            if obj.dtype == torch.bool:
+                return torch.randint(0, 2, obj.shape).bool()
+            return obj + torch.rand_like(obj) * 0.002 - 0.001
+        if isinstance(obj, (list, tuple)):
+            return type(obj)(_perturb(x) for x in obj)
+        return obj
+
+    return tuple(_perturb(inp) for inp in example_inputs)
+
+
+def _run_eager(
+    model: torch.nn.Module, inputs: tuple
+) -> List[torch.Tensor]:
+    """Run eager PyTorch on CPU with TF32 disabled for strict FP32 reference.
+
+    Uses CPU to avoid CUDA runtime version mismatches on CI GPU workers
+    (standard executorch pattern — all backends use CPU for eager reference).
+    """
+    torch.backends.cuda.matmul.allow_tf32 = False
+    torch.backends.cudnn.allow_tf32 = False
+    model = model.cpu().eval()
+
+    def _to_cpu(obj):
+        if isinstance(obj, torch.Tensor):
+            return obj.cpu()
+        elif isinstance(obj, (list, tuple)):
+            return type(obj)(_to_cpu(item) for item in obj)
+        else:
+            return obj
+
+    cpu_inputs = tuple(_to_cpu(inp) for inp in inputs)
+    with torch.no_grad():
+        out = model(*cpu_inputs)
+    return [t.cpu() for t in tree_flatten(out)[0] if isinstance(t, torch.Tensor)]
+
+
+def _run_executorch(module, inputs: tuple) -> List[torch.Tensor]:
+    """Run inference via ExecuTorch pybindings."""
+    flat, _ = tree_flatten(inputs)
+    flat = [x for x in flat if isinstance(x, torch.Tensor) or x is None]
+    outputs = module.forward(flat)
+    return [t for t in outputs if isinstance(t, torch.Tensor)]
+
+
+def main() -> None:
+    logger = logging.getLogger("")
+    logger.setLevel(logging.INFO)
+
+    parser = argparse.ArgumentParser(
+        description="Export models to ExecuTorch format with TensorRT delegate"
+    )
+    parser.add_argument(
+        "-m",
+        "--model_name",
+        required=False,
+        help=f"Model name to export (default: all). Supported: {get_supported_models_list()}",
+    )
+    parser.add_argument(
+        "-o",
+        "--output_dir",
+        default=".",
+        help="Output directory for exported model (default: current directory)",
+    )
+    parser.add_argument(
+        "--no-strict",
+        dest="strict",
+        action="store_false",
+        default=True,
+        help="Disable strict mode for export (default: strict mode enabled)",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        default=False,
+        help="Enable verbose logging",
+    )
+
+    args = parser.parse_args()
+
+    if args.verbose:
+        logger.setLevel(logging.DEBUG)
+
+    models = [args.model_name] if args.model_name else sorted(TENSORRT_SUPPORTED_MODELS)
+    failed = []
+    for model_name in models:
+        try:
+            export_model(model_name, args.output_dir, args.strict, logger)
+        except Exception as e:
+            logging.error(f"Failed to export {model_name}: {e}")
+            failed.append(model_name)
+    if failed:
+        logging.error(f"Failed models: {failed}")
+
+
+if __name__ == "__main__":
+    with torch.no_grad():
+        main()

--- a/examples/nvidia/tensorrt/runner.py
+++ b/examples/nvidia/tensorrt/runner.py
@@ -1,0 +1,228 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""Runner utilities for TensorRT model validation.
+
+Since TensorRT C++ backend isn't registered in Python pybindings,
+we run inference via TensorRT Python API for validation.
+"""
+
+import logging
+from typing import Any, List, Optional, Tuple, Union
+
+import torch
+from executorch.exir import EdgeProgramManager
+
+logger = logging.getLogger(__name__)
+
+
+def _trt_dtype_to_torch(trt_dtype) -> torch.dtype:
+    """Convert TensorRT dtype to PyTorch dtype."""
+    import tensorrt as trt
+
+    dtype_map = {
+        trt.float32: torch.float32,
+        trt.float16: torch.float16,
+        trt.int8: torch.int8,
+        trt.int32: torch.int32,
+        trt.int64: torch.int64,
+        trt.bool: torch.bool,
+        trt.uint8: torch.uint8,
+    }
+    # Handle bfloat16 if available (TensorRT 8.6+)
+    if hasattr(trt, "bfloat16"):
+        dtype_map[trt.bfloat16] = torch.bfloat16
+
+    if trt_dtype not in dtype_map:
+        logger.warning(f"Unknown TensorRT dtype {trt_dtype}, defaulting to float32")
+        return torch.float32
+    return dtype_map[trt_dtype]
+
+
+def _extract_tensorrt_engine(
+    edge_program: EdgeProgramManager,
+) -> Optional[bytes]:
+    """Extract TensorRT engine from EdgeProgramManager."""
+    try:
+        from executorch.backends.nvidia.tensorrt.serialization import (
+            get_engine_from_blob,
+        )
+
+        # Access lowered modules from edge programs
+        if not hasattr(edge_program, "_edge_programs"):
+            logger.debug("EdgeProgramManager has no _edge_programs attribute")
+            return None
+
+        for method_name, edge_prog in edge_program._edge_programs.items():
+            if not hasattr(edge_prog, "graph_module"):
+                logger.debug(f"Edge program {method_name} has no graph_module")
+                continue
+            for mod_name, mod in edge_prog.graph_module._modules.items():
+                if hasattr(mod, "processed_bytes"):
+                    logger.debug(f"Found processed_bytes in {mod_name}")
+                    engine = get_engine_from_blob(bytes(mod.processed_bytes))
+                    if engine:
+                        logger.debug(f"Successfully extracted TensorRT engine ({len(engine)} bytes)")
+                        return engine
+                    else:
+                        logger.debug(f"get_engine_from_blob returned None for {mod_name}")
+        logger.debug("No TensorRT engine found in edge program modules")
+        return None
+    except Exception as e:
+        logger.warning(f"Engine extraction failed: {e}")
+        return None
+
+
+def _run_tensorrt_inference(
+    engine_bytes: bytes,
+    inputs: Tuple[Any, ...],
+) -> List[torch.Tensor]:
+    """Run inference using TensorRT Python API."""
+    import tensorrt as trt
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA required for TensorRT inference")
+
+    # Deserialize engine
+    runtime = trt.Runtime(trt.Logger(trt.Logger.WARNING))
+    engine = runtime.deserialize_cuda_engine(engine_bytes)
+    if engine is None:
+        raise RuntimeError("Failed to deserialize TensorRT engine")
+
+    context = engine.create_execution_context()
+
+    # Collect I/O info
+    input_names, output_info = [], []
+    for i in range(engine.num_io_tensors):
+        name = engine.get_tensor_name(i)
+        if engine.get_tensor_mode(name) == trt.TensorIOMode.INPUT:
+            input_names.append(name)
+        else:
+            shape = engine.get_tensor_shape(name)
+            dtype = engine.get_tensor_dtype(name)
+            output_info.append((name, shape, dtype))
+
+    # Prepare inputs
+    cuda_inputs = [
+        inp.cuda().contiguous() if isinstance(inp, torch.Tensor) else inp
+        for inp in inputs
+    ]
+
+    # Allocate outputs with correct dtype from engine
+    outputs = [
+        torch.empty(list(shape), dtype=_trt_dtype_to_torch(dtype), device="cuda")
+        for _, shape, dtype in output_info
+    ]
+
+    # Bind tensors
+    for name, cuda_inp in zip(input_names, cuda_inputs):
+        context.set_tensor_address(name, cuda_inp.data_ptr())
+    for (name, _, _), output in zip(output_info, outputs):
+        context.set_tensor_address(name, output.data_ptr())
+
+    # Execute
+    stream = torch.cuda.current_stream().cuda_stream
+    if not context.execute_async_v3(stream):
+        raise RuntimeError("TensorRT inference failed")
+    torch.cuda.synchronize()
+
+    return [out.cpu() for out in outputs]
+
+
+def run_and_compare(
+    reference_model: torch.nn.Module,
+    edge_program: EdgeProgramManager,
+    sample_inputs: Tuple[Any, ...],
+    atol: float = 1e-3,
+    rtol: float = 1e-3,
+) -> bool:
+    """Compare TensorRT outputs against PyTorch reference.
+
+    Both reference model and TensorRT run on CUDA for fair comparison.
+    Requires a properly configured environment with CUDA-compatible PyTorch.
+    """
+    if not torch.cuda.is_available():
+        raise RuntimeError(
+            "CUDA is required for TensorRT validation. "
+            "Please install PyTorch with CUDA support."
+        )
+
+    reference_model.eval()
+    reference_model = reference_model.cuda()
+    inputs_for_ref = tuple(
+        inp.cuda() if isinstance(inp, torch.Tensor) else inp
+        for inp in sample_inputs
+    )
+
+    with torch.no_grad():
+        reference_output = reference_model(*inputs_for_ref)
+
+    if isinstance(reference_output, torch.Tensor):
+        reference_output = reference_output.cpu()
+    elif isinstance(reference_output, (tuple, list)):
+        reference_output = type(reference_output)(
+            out.cpu() if isinstance(out, torch.Tensor) else out
+            for out in reference_output
+        )
+
+    # Try TensorRT Python API
+    engine_bytes = _extract_tensorrt_engine(edge_program)
+    if engine_bytes is not None:
+        try:
+            trt_outputs = _run_tensorrt_inference(engine_bytes, sample_inputs)
+            return _compare_outputs(reference_output, trt_outputs, atol, rtol)
+        except Exception as e:
+            logger.warning(f"TensorRT inference failed: {e}")
+
+    # Fallback to pybindings (unlikely to work for TensorRT)
+    try:
+        from executorch.extension.pybindings.portable_lib import (
+            _load_for_executorch_from_buffer,
+        )
+        from executorch.extension.pytree import tree_flatten
+
+        exec_program = edge_program.to_executorch()
+        program_buffer = exec_program.buffer
+        et_module = _load_for_executorch_from_buffer(bytes(program_buffer))
+        inputs_flat, _ = tree_flatten(sample_inputs)
+        et_outputs = et_module.run_method("forward", inputs_flat)
+        return _compare_outputs(reference_output, et_outputs, atol, rtol)
+    except Exception as e:
+        logger.warning(f"Pybindings validation failed: {e}")
+        logger.warning(
+            "Validation could not be performed. Use C++ runner for full validation."
+        )
+        return False
+
+
+def _compare_outputs(
+    reference: Union[torch.Tensor, Tuple[torch.Tensor, ...]],
+    actual: Union[torch.Tensor, List[torch.Tensor]],
+    atol: float,
+    rtol: float,
+) -> bool:
+    """Compare outputs within tolerance."""
+    ref_list = [reference] if isinstance(reference, torch.Tensor) else list(reference)
+    act_list = [actual] if isinstance(actual, torch.Tensor) else list(actual)
+
+    if len(ref_list) != len(act_list):
+        logger.error(f"Output count mismatch: {len(ref_list)} vs {len(act_list)}")
+        return False
+
+    for i, (ref, act) in enumerate(zip(ref_list, act_list)):
+        if not isinstance(ref, torch.Tensor) or not isinstance(act, torch.Tensor):
+            continue
+        if ref.shape != act.shape:
+            logger.error(f"Shape mismatch at {i}: {ref.shape} vs {act.shape}")
+            return False
+        if not torch.allclose(ref, act, atol=atol, rtol=rtol):
+            max_diff = (ref - act).abs().max().item()
+            logger.error(f"Value mismatch at {i}: max diff {max_diff:.6f}")
+            return False
+
+    return True

--- a/examples/nvidia/tensorrt/targets.bzl
+++ b/examples/nvidia/tensorrt/targets.bzl
@@ -1,0 +1,68 @@
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "get_oss_build_kwargs", "runtime")
+
+def define_common_targets():
+    """Defines targets that should be shared between fbcode and xplat.
+
+    The directory containing this targets.bzl file should also contain both
+    TARGETS and BUCK files that call this function.
+    """
+
+    runtime.python_library(
+        name = "tensorrt_example_lib",
+        srcs = [
+            "__init__.py",
+            "export.py",
+            "runner.py",
+        ],
+        visibility = [
+            "//executorch/examples/nvidia/tensorrt/...",
+            "//executorch/backends/nvidia/tensorrt/...",
+        ],
+        deps = [
+            "//caffe2:torch",
+            "//deeplearning/trt/python:py_tensorrt",
+            "//executorch/backends/nvidia/tensorrt:serialization",
+            "//executorch/backends/nvidia/tensorrt/partitioner:partitioner",
+            "//executorch/examples/models:models",
+            "//executorch/exir:lib",
+            "//executorch/extension/export_util:export_util",
+            "//executorch/extension/pybindings:portable_lib",
+            "//executorch/extension/pytree:pytree",
+        ],
+    )
+
+    runtime.python_binary(
+        name = "export",
+        main_module = "executorch.examples.nvidia.tensorrt.export",
+        preload_deps = [
+            "//executorch/backends/nvidia/tensorrt/runtime:tensorrt_backend",
+        ],
+        deps = [
+            ":tensorrt_example_lib",
+        ],
+        visibility = ["PUBLIC"],
+    )
+
+    runtime.python_binary(
+        name = "runner",
+        main_module = "executorch.examples.nvidia.tensorrt.runner",
+        deps = [
+            ":tensorrt_example_lib",
+        ],
+        visibility = ["PUBLIC"],
+    )
+
+    # C++ executor runner for TensorRT models.
+    # Requires TensorRT and CUDA (NVIDIA GPUs). Not for mobile builds.
+    runtime.cxx_binary(
+        name = "tensorrt_executor_runner",
+        srcs = ["tensorrt_executor_runner.cpp"],
+        visibility = ["PUBLIC"],
+        deps = [
+            "//executorch/extension/data_loader:file_data_loader",
+            "//executorch/extension/runner_util:inputs",
+            "//executorch/runtime/executor:program",
+            "//executorch/backends/nvidia/tensorrt/runtime:tensorrt_backend",
+            "//executorch/kernels/portable:generated_lib",
+        ],
+    )

--- a/examples/nvidia/tensorrt/tensorrt_executor_runner.cpp
+++ b/examples/nvidia/tensorrt/tensorrt_executor_runner.cpp
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * TensorRT Executor Runner - runs ExecuTorch models with TensorRT delegation.
+ *
+ * Usage:
+ *   tensorrt_executor_runner --model_path=model_tensorrt.pte
+ *   tensorrt_executor_runner --model_path=model.pte --num_executions=10
+ */
+
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+#include <executorch/extension/module/module.h>
+#include <executorch/extension/tensor/tensor.h>
+#include <executorch/runtime/platform/log.h>
+#include <executorch/runtime/platform/platform.h>
+#include <executorch/runtime/platform/runtime.h>
+
+using executorch::aten::ScalarType;
+using executorch::extension::Module;
+using executorch::runtime::EValue;
+using executorch::runtime::MethodMeta;
+using executorch::runtime::Tag;
+
+namespace {
+
+struct RunnerArgs {
+  std::string model_path = "model.pte";
+  uint32_t num_executions = 1;
+  bool verbose = false;
+};
+
+bool parse_args(int argc, char** argv, RunnerArgs& args) {
+  for (int i = 1; i < argc; ++i) {
+    std::string arg = argv[i];
+    if (arg == "--help" || arg == "-h") {
+      printf(
+          "Usage: tensorrt_executor_runner [options]\n"
+          "Options:\n"
+          "  --model_path=PATH    Path to .pte model (default: model.pte)\n"
+          "  --num_executions=N   Number of inference runs (default: 1)\n"
+          "  --verbose            Enable verbose output\n"
+          "  --help               Show this message\n");
+      return false;
+    } else if (arg.rfind("--model_path=", 0) == 0) {
+      args.model_path = arg.substr(13);
+    } else if (arg.rfind("--num_executions=", 0) == 0) {
+      args.num_executions = static_cast<uint32_t>(std::stoul(arg.substr(17)));
+    } else if (arg == "--verbose" || arg == "-v") {
+      args.verbose = true;
+    } else {
+      fprintf(stderr, "Unknown argument: %s\n", arg.c_str());
+      return false;
+    }
+  }
+  return true;
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+  executorch::runtime::runtime_init();
+
+  RunnerArgs args;
+  if (!parse_args(argc, argv, args)) {
+    return 1;
+  }
+
+  ET_LOG(Info, "TensorRT Executor Runner");
+  ET_LOG(Info, "Model: %s", args.model_path.c_str());
+  ET_LOG(Info, "Executions: %u", args.num_executions);
+
+  Module module(args.model_path, Module::LoadMode::File);
+
+  auto meta_result = module.method_meta("forward");
+  if (!meta_result.ok()) {
+    ET_LOG(Error, "Failed to get method metadata");
+    return 1;
+  }
+  auto meta = meta_result.get();
+
+  // Create ones-filled inputs matching the model's expected shapes and dtypes.
+  std::vector<executorch::extension::TensorPtr> input_tensors;
+  std::vector<std::vector<float>> float_data;
+  std::vector<std::vector<int64_t>> int64_data;
+  std::vector<EValue> inputs;
+  for (size_t i = 0; i < meta.num_inputs(); ++i) {
+    auto tag = meta.input_tag(i);
+    if (tag.ok() && tag.get() == Tag::Tensor) {
+      auto tmeta = meta.input_tensor_meta(i);
+      if (tmeta.ok()) {
+        auto sizes = tmeta.get().sizes();
+        auto dtype = tmeta.get().scalar_type();
+        auto sizes_vec = std::vector<executorch::aten::SizesType>(
+            sizes.begin(), sizes.end());
+        int64_t numel = 1;
+        for (auto s : sizes_vec) {
+          numel *= s;
+        }
+
+        executorch::extension::TensorPtr tensor;
+        if (dtype == ScalarType::Long || dtype == ScalarType::Int) {
+          int64_data.emplace_back(numel, 1);
+          tensor = executorch::extension::make_tensor_ptr(
+              sizes_vec, int64_data.back());
+        } else {
+          float_data.emplace_back(numel, 1.0f);
+          tensor = executorch::extension::make_tensor_ptr(
+              sizes_vec, float_data.back());
+        }
+        inputs.push_back(EValue(*tensor));
+        input_tensors.push_back(std::move(tensor));
+      }
+    }
+  }
+
+  if (args.verbose) {
+    ET_LOG(Info, "Inputs prepared: %zu tensors", inputs.size());
+  }
+
+  // Warmup
+  constexpr uint32_t kWarmupRuns = 3;
+  for (uint32_t i = 0; i < kWarmupRuns; ++i) {
+    auto r = module.forward(inputs);
+    if (!r.ok()) {
+      ET_LOG(Error, "Warmup execution failed");
+      return 1;
+    }
+  }
+
+  // Benchmark
+  et_timestamp_t total_time = 0;
+  for (uint32_t i = 0; i < args.num_executions; ++i) {
+    auto start = executorch::runtime::pal_current_ticks();
+    auto r = module.forward(inputs);
+    auto end = executorch::runtime::pal_current_ticks();
+    if (!r.ok()) {
+      ET_LOG(Error, "Execution %u failed", i);
+      return 1;
+    }
+    total_time += end - start;
+  }
+
+  auto ratio = et_pal_ticks_to_ns_multiplier();
+  double total_ms = static_cast<double>(total_time) * ratio.numerator /
+      ratio.denominator / 1000000.0;
+  double avg_ms = total_ms / args.num_executions;
+
+  ET_LOG(
+      Info,
+      "Executed %u time(s) in %.3f ms total (%.3f ms avg)",
+      args.num_executions,
+      total_ms,
+      avg_ms);
+
+  // Print output summary
+  auto result = module.forward(inputs);
+  if (result.ok()) {
+    auto outputs = result.get();
+    ET_LOG(Info, "Outputs: %zu values", outputs.size());
+    for (size_t i = 0; i < outputs.size(); ++i) {
+      if (outputs[i].isTensor()) {
+        const auto& t = outputs[i].toTensor();
+        printf("  Output %zu: shape=[", i);
+        for (size_t d = 0; d < t.dim(); ++d) {
+          if (d > 0)
+            printf(", ");
+          printf("%d", static_cast<int>(t.size(d)));
+        }
+        printf("], dtype=%d\n", static_cast<int>(t.scalar_type()));
+      }
+    }
+  }
+
+  return 0;
+}

--- a/examples/nvidia/tensorrt/tests/TARGETS
+++ b/examples/nvidia/tensorrt/tests/TARGETS
@@ -1,0 +1,25 @@
+load("@fbcode_macros//build_defs:python_unittest_remote_gpu.bzl", "python_unittest_remote_gpu")
+
+oncall("executorch")
+
+# Export correctness tests: exports each supported model with TensorRT
+# and compares inference outputs against eager PyTorch on GPU.
+#   buck2 test fbcode//executorch/examples/nvidia/tensorrt/tests:test_export
+#   buck2 test fbcode//executorch/examples/nvidia/tensorrt/tests:test_export -- test_mv3
+python_unittest_remote_gpu(
+    name = "test_export",
+    srcs = ["test_export.py"],
+    env = {
+        "HTTPS_PROXY": "http://fwdproxy.any:8080",
+        "HTTP_PROXY": "http://fwdproxy.any:8080",
+    },
+    keep_gpu_sections = True,
+    labels = ["long_running"],
+    preload_deps = [
+        "//executorch/backends/nvidia/tensorrt/runtime:tensorrt_backend",
+    ],
+    supports_static_listing = False,
+    deps = [
+        "//executorch/examples/nvidia/tensorrt:tensorrt_example_lib",
+    ],
+)

--- a/examples/nvidia/tensorrt/tests/__init__.py
+++ b/examples/nvidia/tensorrt/tests/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/examples/nvidia/tensorrt/tests/targets.bzl
+++ b/examples/nvidia/tensorrt/tests/targets.bzl
@@ -1,0 +1,5 @@
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+
+def define_common_targets():
+    """Defines targets that should be shared between fbcode and xplat."""
+    pass

--- a/examples/nvidia/tensorrt/tests/test_export.py
+++ b/examples/nvidia/tensorrt/tests/test_export.py
@@ -1,0 +1,97 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Export correctness tests for TensorRT backend.
+
+Exports each supported model with TensorRT and compares inference
+outputs against eager PyTorch.
+"""
+
+import io
+import logging
+import os
+import shutil
+import unittest
+
+import torch
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+# Mapping from env var to expected cache filename.
+# The test TARGETS provides these via manifold_get + $(location).
+# Entries are added as models are enabled in later commits.
+_WEIGHT_ENV_VARS = {}
+
+
+def _populate_weight_cache() -> None:
+    """Copy Manifold-cached weights to torch/HF cache so models skip downloads."""
+    cache_dir = os.path.join(
+        os.environ.get("TORCH_HOME", os.path.expanduser("~/.cache/torch")),
+        "hub",
+        "checkpoints",
+    )
+    os.makedirs(cache_dir, exist_ok=True)
+    for env_var, filename in _WEIGHT_ENV_VARS.items():
+        src = os.environ.get(env_var)
+        if src and os.path.isfile(src):
+            # dog.jpg goes to CWD (mv2 model downloads it there)
+            if filename == "dog.jpg":
+                dst = os.path.join(os.getcwd(), filename)
+            else:
+                dst = os.path.join(cache_dir, filename)
+            if not os.path.exists(dst):
+                shutil.copy2(src, dst)
+                logger.info(f"Cached {filename} from {src}")
+
+
+_populate_weight_cache()
+
+
+def _export_and_verify(model_name: str) -> None:
+    """Export a model and verify its outputs against eager PyTorch."""
+    from executorch.examples.nvidia.tensorrt.export import (
+        _verify_correctness,
+        export_model,
+    )
+
+    model, example_inputs, exec_prog = export_model(
+        model_name, ".", True, logger,
+    )
+    buf = io.BytesIO()
+    exec_prog.write_to_file(buf)
+    _verify_correctness(model_name, model, example_inputs, buf.getvalue(), logger)
+
+
+class ExportCorrectnessTest(unittest.TestCase):
+    """Export each model with TensorRT and verify outputs against eager PyTorch."""
+
+    def test_add(self) -> None:
+        _export_and_verify("add")
+
+    def test_add_mul(self) -> None:
+        _export_and_verify("add_mul")
+
+    def test_mul(self) -> None:
+        _export_and_verify("mul")
+
+    def test_add_bf16(self) -> None:
+        """Test add model with bf16 precision."""
+        from executorch.backends.nvidia.tensorrt.compile_spec import TensorRTCompileSpec, TensorRTPrecision
+        from executorch.backends.nvidia.tensorrt.partitioner import TensorRTPartitioner
+        from executorch.examples.models import MODEL_NAME_TO_MODEL
+        from executorch.examples.models.model_factory import EagerModelFactory
+        from executorch.exir import to_edge_transform_and_lower
+        import torch
+        from torch.export import export
+        model, example_inputs, _, _ = EagerModelFactory.create_model(*MODEL_NAME_TO_MODEL["add"])
+        model = model.eval()
+        exported = export(model, example_inputs, strict=True)
+        spec = TensorRTCompileSpec(precision=TensorRTPrecision.BF16)
+        edge = to_edge_transform_and_lower(exported, partitioner=[TensorRTPartitioner(spec.to_compile_specs())])
+        exec_prog = edge.to_executorch()
+        self.assertIsNotNone(exec_prog)
+        logger.info("PASS: add model exported with BF16 precision")

--- a/src/executorch/examples/nvidia
+++ b/src/executorch/examples/nvidia
@@ -1,0 +1,1 @@
+../../../examples/nvidia


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #17978
* #17977
* #17976
* #17975
* #17974
* #17973
* #17972
* #17971
* #17970
* #17969
* #17968
* #17967
* __->__ #17966
* #17965
* #17964
* #17963
* #17962
* #17961
* #17960
* #17959
* #17958
* #17957
* #17956
* #17955
* #17954

Add complete C++ runner example for TensorRT-accelerated model inference. Also sets up GitHub Actions CI workflow for automated builds on NVIDIA GPUs.

Differential Revision: [D93275050](https://our.internmc.facebook.com/intern/diff/D93275050/)