### PR TITLE
[executorch][nvidia][tensorrt][25/n] Share CUDA stream across TRT delegates

### DIFF
--- a/backends/nvidia/tensorrt/runtime/TensorRTBackend.cpp
+++ b/backends/nvidia/tensorrt/runtime/TensorRTBackend.cpp
@@ -12,6 +12,8 @@
 #include <executorch/runtime/backend/interface.h>
 #include <executorch/runtime/platform/log.h>
 
+#include <cuda_runtime.h> // @nolint
+
 namespace executorch {
 namespace backends {
 namespace tensorrt {
@@ -34,6 +36,39 @@ namespace {
 
 bool is_tensorrt_available() {
   return true;
+}
+
+// Shared CUDA stream for serialized execution across TRT delegates.
+// When multiple TRT delegate subgraphs execute sequentially (the common case),
+// sharing a single stream avoids synchronization overhead between subgraphs.
+//
+// Thread safety: ExecuTorch's backend init/execute/destroy lifecycle is
+// single-threaded per program instance, so no synchronization is needed.
+// If concurrent multi-program support is added in the future, these globals
+// should be protected with a mutex or made per-program.
+cudaStream_t g_shared_stream = nullptr; // NOLINT(facebook-avoid-non-const-global-variables)
+int g_shared_stream_refcount = 0; // NOLINT(facebook-avoid-non-const-global-variables)
+
+cudaStream_t get_or_create_shared_stream() { // NOLINT(facebook-hte-NullableReturn)
+  if (g_shared_stream == nullptr) {
+    cudaError_t err = cudaStreamCreate(&g_shared_stream);
+    if (err != cudaSuccess) {
+      ET_LOG(Error, "Failed to create shared CUDA stream");
+      return nullptr;
+    }
+  }
+  ++g_shared_stream_refcount;
+  return g_shared_stream;
+}
+
+void release_shared_stream() {
+  if (g_shared_stream_refcount > 0) {
+    --g_shared_stream_refcount;
+  }
+  if (g_shared_stream_refcount == 0 && g_shared_stream != nullptr) {
+    cudaStreamDestroy(g_shared_stream);
+    g_shared_stream = nullptr;
+  }
 }
 
 } // namespace
@@ -83,10 +118,22 @@ Result<DelegateHandle*> TensorRTBackend::init(
 
   new (executor) TensorRTExecutor();
 
+  // Share a CUDA stream across all TRT delegate instances for serialized
+  // execution. This avoids synchronization overhead between subgraphs when
+  // they execute sequentially (the common case).
+  cudaStream_t shared = get_or_create_shared_stream();
+  if (shared != nullptr) {
+    executor->set_cuda_stream(shared, false);
+  }
+
   Error err = executor->initialize(blob_data, blob_size);
   if (err != Error::Ok) {
     ET_LOG(Error, "Failed to initialize TensorRT executor");
+    bool uses_shared = !executor->owns_stream();
     executor->~TensorRTExecutor();
+    if (uses_shared) {
+      release_shared_stream();
+    }
     return err;
   }
 
@@ -172,7 +219,11 @@ Error TensorRTBackend::execute(
 void TensorRTBackend::destroy(DelegateHandle* handle) const {
   if (handle != nullptr) {
     auto* executor = static_cast<TensorRTExecutor*>(handle);
+    bool uses_shared = !executor->owns_stream();
     executor->~TensorRTExecutor();
+    if (uses_shared) {
+      release_shared_stream();
+    }
   }
 }
 

--- a/backends/nvidia/tensorrt/runtime/TensorRTExecutor.cpp
+++ b/backends/nvidia/tensorrt/runtime/TensorRTExecutor.cpp
@@ -70,7 +70,7 @@ size_t get_dtype_size(nvinfer1::DataType dtype) {
 
 TensorRTExecutor::~TensorRTExecutor() {
   free_gpu_buffers();
-  if (stream_) {
+  if (stream_ && owns_stream_) {
     cudaStreamDestroy(stream_);
     stream_ = nullptr;
   }
@@ -84,31 +84,45 @@ TensorRTExecutor::TensorRTExecutor(TensorRTExecutor&& other) noexcept
       engine_(std::move(other.engine_)),
       context_(std::move(other.context_)),
       stream_(other.stream_),
+      owns_stream_(other.owns_stream_),
       io_bindings_(std::move(other.io_bindings_)),
       gpu_buffers_(std::move(other.gpu_buffers_)),
       uses_unified_memory_(other.uses_unified_memory_) {
   other.stream_ = nullptr;
+  other.owns_stream_ = false;
   other.uses_unified_memory_ = false;
 }
 
 TensorRTExecutor& TensorRTExecutor::operator=(TensorRTExecutor&& other) noexcept {
   if (this != &other) {
     free_gpu_buffers();
-    if (stream_) {
+    if (stream_ && owns_stream_) {
       cudaStreamDestroy(stream_);
     }
     runtime_ = std::move(other.runtime_);
     engine_ = std::move(other.engine_);
     context_ = std::move(other.context_);
     stream_ = other.stream_;
+    owns_stream_ = other.owns_stream_;
     io_bindings_ = std::move(other.io_bindings_);
     gpu_buffers_ = std::move(other.gpu_buffers_);
     uses_unified_memory_ = other.uses_unified_memory_;
 
     other.stream_ = nullptr;
+    other.owns_stream_ = false;
     other.uses_unified_memory_ = false;
   }
   return *this;
+}
+
+void TensorRTExecutor::set_cuda_stream(
+    ::cudaStream_t stream,
+    bool owns_stream) {
+  if (stream_ && owns_stream_) {
+    cudaStreamDestroy(stream_);
+  }
+  stream_ = stream;
+  owns_stream_ = owns_stream;
 }
 
 Error TensorRTExecutor::initialize(
@@ -196,14 +210,17 @@ Error TensorRTExecutor::initialize(
     }
   }
 
-  // Create persistent CUDA stream
-  cudaStream_t stream;
-  cuda_err = cudaStreamCreate(&stream);
-  if (cuda_err != cudaSuccess) {
-    ET_LOG(Error, "Failed to create CUDA stream: %s", cudaGetErrorString(cuda_err));
-    return Error::InvalidState;
+  // Create persistent CUDA stream (unless an external stream was already set)
+  if (stream_ == nullptr) {
+    cudaStream_t stream;
+    cuda_err = cudaStreamCreate(&stream);
+    if (cuda_err != cudaSuccess) {
+      ET_LOG(Error, "Failed to create CUDA stream: %s", cudaGetErrorString(cuda_err));
+      return Error::InvalidState;
+    }
+    stream_ = stream;
+    owns_stream_ = true;
   }
-  stream_ = stream;
 
   // Pre-allocate GPU buffers
   // For unified memory (Jetson): use cudaMallocManaged
@@ -351,7 +368,11 @@ Error TensorRTExecutor::execute(
       }
     }
   } else {
-    // Discrete GPU path: use pre-allocated GPU buffers with async copies
+    // Discrete GPU path: use pre-allocated GPU buffers with async copies.
+    // cudaMemcpyDefault auto-detects pointer residency, so this works
+    // correctly whether input/output buffers are on CPU (H2D/D2H) or
+    // already on GPU (D2D), enabling unified backend pipelines where
+    // inter-delegate data stays on the GPU.
     for (const auto& buf : gpu_buffers_) {
       const char* name = engine_->getIOTensorName(buf.tensor_index);
       if (buf.is_input) {
@@ -359,7 +380,7 @@ Error TensorRTExecutor::execute(
             buf.ptr,
             input_buffers[buf.io_index],
             buf.size,
-            cudaMemcpyHostToDevice,
+            cudaMemcpyDefault,
             stream_);
         if (cuda_err != cudaSuccess) {
           ET_LOG(Error, "Failed to copy input to GPU: %s", cudaGetErrorString(cuda_err));
@@ -376,14 +397,14 @@ Error TensorRTExecutor::execute(
       return Error::InvalidState;
     }
 
-    // Copy outputs from GPU to CPU
+    // Copy outputs from GPU
     for (const auto& buf : gpu_buffers_) {
       if (!buf.is_input) {
         cudaError_t cuda_err = cudaMemcpyAsync(
             output_buffers[buf.io_index],
             buf.ptr,
             buf.size,
-            cudaMemcpyDeviceToHost,
+            cudaMemcpyDefault,
             stream_);
         if (cuda_err != cudaSuccess) {
           ET_LOG(Error, "Failed to copy output from GPU: %s", cudaGetErrorString(cuda_err));

--- a/backends/nvidia/tensorrt/runtime/TensorRTExecutor.h
+++ b/backends/nvidia/tensorrt/runtime/TensorRTExecutor.h
@@ -84,12 +84,13 @@ class TensorRTExecutor {
    * Execute inference with the given input/output buffers.
    *
    * On discrete GPUs: copies inputs to pre-allocated GPU memory, executes,
-   * and copies outputs back.
-   * On unified memory (Jetson): uses buffers directly without copies.
+   * and copies outputs back. Input/output buffers may reside on either CPU
+   * or GPU — the transfer direction is auto-detected via cudaMemcpyDefault.
+   * On unified memory (Jetson): uses managed memory buffers directly.
    *
-   * @param input_buffers Array of pointers to input data buffers.
+   * @param input_buffers Array of pointers to input data buffers (CPU or GPU).
    * @param num_inputs Number of input buffers.
-   * @param output_buffers Array of pointers to output data buffers.
+   * @param output_buffers Array of pointers to output data buffers (CPU or GPU).
    * @param num_outputs Number of output buffers.
    * @return Error::Ok on success.
    */
@@ -140,6 +141,24 @@ class TensorRTExecutor {
     return uses_unified_memory_;
   }
 
+  bool owns_stream() const {
+    return owns_stream_;
+  }
+
+  /**
+   * Set an external CUDA stream for this executor.
+   *
+   * When called before initialize(), the executor uses the provided stream
+   * instead of creating its own. This enables stream sharing across multiple
+   * TRT delegate instances for serialized execution, avoiding synchronization
+   * overhead between subgraphs.
+   *
+   * @param stream External CUDA stream to use.
+   * @param owns_stream If true, the executor will destroy the stream on cleanup.
+   *                    If false, the caller retains ownership.
+   */
+  void set_cuda_stream(::cudaStream_t stream, bool owns_stream = false);
+
  private:
   /**
    * Parse I/O binding metadata from JSON.
@@ -166,6 +185,7 @@ class TensorRTExecutor {
   std::unique_ptr<nvinfer1::ICudaEngine> engine_;
   std::unique_ptr<nvinfer1::IExecutionContext> context_;
   ::cudaStream_t stream_{nullptr};
+  bool owns_stream_{true};
   std::vector<IOBinding> io_bindings_;
   std::vector<GPUBuffer> gpu_buffers_;
   bool uses_unified_memory_{false};


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #17978
* #17977
* #17976
* #17975
* #17974
* #17973
* #17972
* #17971
* #17970
* #17969
* #17968
* #17967
* #17966
* #17965
* #17964
* #17963
* #17962
* #17961
* #17960
* #17959
* #17958
* #17957
* #17956
* #17955
* #17954

Share a single CUDA stream across all TensorRT delegate instances instead of creating a per-delegate stream. This improves performance for serialized execution (the common case) by eliminating synchronization overhead between subgraphs.

Internal:
Addresses feedback from D93275039.

Differential Revision: [D93778115](https://our.internmc.facebook.com/intern/diff/D93778115/)