### PR TITLE
Add BackendCache interface for backend init caching

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -757,6 +757,17 @@ if(EXECUTORCH_BUILD_EXTENSION_MODULE)
   list(APPEND _executorch_extensions extension_module_static)
 endif()
 
+if(EXECUTORCH_BUILD_EXTENSION_BACKEND_CACHE)
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/extension/backend_cache)
+  install(
+    DIRECTORY extension/backend_cache/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/executorch/extension/backend_cache
+    FILES_MATCHING
+    PATTERN "*.h"
+  )
+  list(APPEND _executorch_extensions extension_backend_cache)
+endif()
+
 if(EXECUTORCH_BUILD_EXTENSION_NAMED_DATA_MAP)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/extension/named_data_map)
   list(APPEND _executorch_extensions extension_named_data_map)

--- a/docs/source/design/backend-cache.md
+++ b/docs/source/design/backend-cache.md
@@ -1,0 +1,324 @@
+# Backend Init Caching
+
+## Problem
+
+Backend initialization in ExecuTorch can be expensive. Backends like XNNPACK
+repack weights during `init()`, which involves parsing the processed data
+segment, allocating aligned buffers, and transforming tensor layouts. For large
+models this takes hundreds of milliseconds on every load — even though the
+output is identical across runs on the same device.
+
+Today there is no way to persist these artifacts. Every `Program::load_method()`
+call pays the full initialization cost.
+
+## Design
+
+### Goals
+
+- Let backends persist init artifacts (packed weights, compiled graphs) and
+  restore them on subsequent loads, skipping the processed data segment entirely.
+- Keep the runtime layer (`runtime/`) free of string manipulation, heap
+  allocation, and filesystem I/O.
+- Provide a concrete filesystem-backed implementation in `extension/` that
+  handles aligned allocation, atomic writes, and directory structure.
+- Avoid TOCTOU races in the cache API.
+
+### Non-goals
+
+- Cache invalidation policy (LRU, TTL, size limits). The caller owns eviction.
+- Thread-safe writes to the same key. Concurrent writes use last-writer-wins.
+- Caching execution outputs or intermediate tensors — this is init-only.
+
+## Architecture
+
+```
+┌──────────┐   load_method(cache)   ┌─────────┐   init()   ┌──────────────────┐
+│  Module  │ ─────────────────────► │ Program │ ─────────► │      Method      │
+└──────────┘                        └─────────┘            │                  │
+                                                           │  for each delegate:
+                                                           │  ┌──────────────┐│
+                                                           │  │ Delegate     ││
+                                                           │  │ BackendCache ││
+                                                           │  │ (bid, idx)   ││
+                                                           │  └──────┬───────┘│
+                                                           └─────────┼────────┘
+                                                                     │
+                                                              load/save/remove
+                                                                     │
+                                                                     ▼
+                                                           ┌──────────────────┐
+                                                           │  BackendCache    │
+                                                           │  (abstract)      │
+                                                           └────────┬─────────┘
+                                                                    │
+                                                                    ▼
+                                                           ┌──────────────────┐
+                                                           │ FileBackendCache │
+                                                           │ (extension/)     │
+                                                           └──────────────────┘
+```
+
+### Call flow
+
+The runtime attempts `init_from_cache()` before loading the processed data
+segment. This means a cache hit avoids both the data load and the init
+computation:
+
+```
+BackendDelegate::Init(delegate, program, context, out)
+  │
+  ├─ if cache available:
+  │    result = backend->init_from_cache(context, compile_specs)
+  │    ├─ Ok         → return handle, skip data load entirely
+  │    ├─ NotSupported → fall through (backend doesn't support caching)
+  │    └─ other error → return error
+  │
+  └─ normal path:
+       data = GetProcessedData(delegate, program)
+       handle = backend->init(context, &data, compile_specs)
+```
+
+### Key scoping
+
+A single `BackendCache` instance is shared across all backends and delegates in
+a program. The runtime must prevent key collisions. Rather than concatenating
+`"{backend_id}/{delegate_index}/{key}"` into a string buffer (which introduces
+silent truncation risk and string manipulation in `runtime/`), the scoping
+components are passed separately through the entire stack:
+
+```
+BackendCache::load(backend_id, delegate_index, key, alignment)
+BackendCache::save(backend_id, delegate_index, key, data, size)
+BackendCache::remove(backend_id, delegate_index, key)
+```
+
+`DelegateBackendCache` captures `backend_id` and `delegate_index` at construction
+time (during `Method::init`) and presents a simple key-only API to backends:
+
+```cpp
+DelegateBackendCache delegate_cache(&cache, "XnnpackBackend", 0);
+delegate_cache.save("v1/packed_weights", data, size);
+// delegates to: cache.save("XnnpackBackend", 0, "v1/packed_weights", data, size)
+```
+
+`DelegateBackendCache` is **not** a subclass of `BackendCache`. It's a separate,
+simpler type that forwards to the underlying cache with the scoping components
+attached. Backends interact with `DelegateBackendCache*` (via
+`BackendInitContext::get_cache()`), while cache implementations subclass
+`BackendCache`.
+
+## API
+
+### `BackendCache` (abstract, `runtime/backend/backend_cache.h`)
+
+```cpp
+class BackendCache {
+ public:
+  virtual ~BackendCache() = default;
+
+  virtual Result<FreeableBuffer> load(
+      const char* backend_id,
+      size_t delegate_index,
+      const char* key,
+      size_t alignment = alignof(std::max_align_t)) const = 0;
+
+  virtual Error save(
+      const char* backend_id,
+      size_t delegate_index,
+      const char* key,
+      const void* data,
+      size_t size) = 0;
+
+  virtual Error remove(
+      const char* backend_id,
+      size_t delegate_index,
+      const char* key) = 0;
+};
+```
+
+There is no `contains()` method. Checking existence then loading is a TOCTOU
+race — callers should `load()` and handle `Error::NotFound`.
+
+The `alignment` parameter on `load()` lets backends request SIMD-aligned
+buffers (e.g., 64-byte for AVX-512 weight packing).
+
+### `DelegateBackendCache` (`runtime/backend/backend_cache.h`)
+
+Wraps a `BackendCache`, capturing `backend_id` and `delegate_index` so that
+backends see a simple key-only API:
+
+```cpp
+class DelegateBackendCache final {
+ public:
+  DelegateBackendCache(BackendCache* cache, const char* backend_id, size_t delegate_index);
+
+  Result<FreeableBuffer> load(const char* key, size_t alignment = alignof(std::max_align_t)) const;
+  Error save(const char* key, const void* data, size_t size);
+  Error remove(const char* key);
+};
+```
+
+### `BackendInterface::init_from_cache` (`runtime/backend/interface.h`)
+
+```cpp
+virtual Result<DelegateHandle*> init_from_cache(
+    BackendInitContext& context,
+    ArrayRef<CompileSpec> compile_specs) const {
+  return Error::NotSupported;  // default: no caching support
+}
+```
+
+Backends that support caching override this. The default returns
+`Error::NotSupported`, which tells the runtime to fall through to the normal
+`init()` path. Any other error is treated as fatal.
+
+### `FileBackendCache` (`extension/backend_cache/`)
+
+Concrete implementation that maps cache entries to filesystem paths:
+
+```
+{cache_dir}/{backend_id}/{delegate_index}/{key}
+```
+
+Key properties:
+
+- **Aligned allocation**: `load()` uses `::operator new(size, align_val_t, nothrow)`
+  with matching `::operator delete(ptr, align_val_t)`. This ensures SIMD-aligned
+  weight buffers.
+- **Atomic writes**: `save()` writes to `{path}.tmp` then renames. Prevents
+  corruption if the process is killed mid-write.
+- **Concurrency**: Safe for concurrent reads. Concurrent writes to the same key
+  use last-writer-wins via atomic rename.
+- **`remove()`**: Deletes a single cache entry. Returns `Error::NotFound` if the
+  file doesn't exist.
+
+## Threading through the stack
+
+The `BackendCache*` pointer flows from the user down through:
+
+```
+Module::load_method(backend_cache=)
+  → Program::load_method(backend_cache=)
+    → Method::load(backend_cache=)
+      → Method::init(backend_cache=)
+        → for each delegate:
+            DelegateBackendCache(backend_cache, delegate.id, i)
+              → BackendInitContext(backend_cache=&delegate_cache)
+                → backend->init_from_cache(context, ...)
+```
+
+The `DelegateBackendCache` is stack-allocated in `Method::init`'s delegate loop,
+so its lifetime covers the `BackendDelegate::Init` call. The `backend_id`
+string is owned by the flatbuffer and lives as long as the `Program`.
+
+## Usage
+
+### Loading with a cache
+
+```cpp
+FileBackendCache cache("/data/local/tmp/et_cache");
+Module module("model.pte");
+module.load_method("forward", /*planned_memory=*/nullptr,
+                   /*event_tracer=*/nullptr, /*backend_options=*/nullptr,
+                   &cache);
+```
+
+First load: backends call `init()` normally and can `save()` artifacts to the
+cache. Second load: backends' `init_from_cache()` finds the cached data and
+returns immediately, skipping the processed data segment load.
+
+### Implementing caching in a backend
+
+```cpp
+Result<DelegateHandle*> MyBackend::init_from_cache(
+    BackendInitContext& context,
+    ArrayRef<CompileSpec> compile_specs) const {
+  auto* cache = context.get_cache();  // returns DelegateBackendCache*
+  if (!cache) {
+    return Error::NotSupported;
+  }
+  auto result = cache->load("v1/packed_weights", /*alignment=*/64);
+  if (!result.ok()) {
+    return Error::NotSupported;  // cache miss, fall through to init()
+  }
+  // Restore from cached data...
+  return handle;
+}
+
+Result<DelegateHandle*> MyBackend::init(
+    BackendInitContext& context,
+    FreeableBuffer* processed,
+    ArrayRef<CompileSpec> compile_specs) const {
+  // Normal init: process weights...
+  auto* cache = context.get_cache();  // returns DelegateBackendCache*
+  if (cache) {
+    cache->save("v1/packed_weights", packed_data, packed_size);
+  }
+  return handle;
+}
+```
+
+## File layout
+
+```
+runtime/backend/
+  backend_cache.h          # BackendCache + DelegateBackendCache
+  backend_init_context.h   # stores DelegateBackendCache*, get_cache()
+  interface.h              # init_from_cache() virtual method
+  test/
+    backend_cache_test.cpp # Unit tests for BackendCache + DelegateBackendCache
+
+runtime/executor/test/
+  backend_integration_test.cpp  # Integration tests for cache-first init flow
+
+extension/backend_cache/
+  file_backend_cache.h     # FileBackendCache declaration
+  file_backend_cache.cpp   # FileBackendCache implementation
+  CMakeLists.txt           # extension_backend_cache library
+  targets.bzl              # Buck targets
+  test/
+    file_backend_cache_test.cpp
+    CMakeLists.txt
+    targets.bzl
+```
+
+## Testing
+
+- **`backend_cache_test.cpp`** (unit): Tests `BackendCache` and
+  `DelegateBackendCache` with an in-memory implementation. Verifies key scoping
+  (delegates and backends are isolated), save/load/remove semantics, and
+  overwrite behavior.
+
+- **`file_backend_cache_test.cpp`** (unit): Tests `FileBackendCache` against a
+  real temp directory. Covers save/load roundtrip, subdirectory creation,
+  overwrite, 1MB data, remove, aligned load (verifies pointer alignment), and
+  backend/delegate isolation.
+
+- **`backend_integration_test.cpp`** (integration): Tests the cache-first init
+  protocol end-to-end using `StubBackend` with injectable callbacks and real
+  `.pte` fixtures loaded via `FileDataLoader`. Parameterized on segments vs
+  no-segments. Five cache-specific test cases:
+  - **CacheHitSkipsInit**: `init_from_cache` succeeds — `init()` is never
+    called and the processed data segment is never loaded (verified via
+    `DataLoaderSpy`).
+  - **CacheMissFallsThrough**: `init_from_cache` returns `NotSupported` —
+    `init()` is called normally with the processed data.
+  - **CacheErrorFailsLoad**: `init_from_cache` returns a non-`NotSupported`
+    error — `load_method` propagates the error.
+  - **NoCacheSkipsInitFromCache**: No `BackendCache` provided —
+    `init_from_cache` is never called, `init()` proceeds normally.
+  - **CacheAvailableInContext**: `context.get_cache()` returns a non-null
+    `DelegateBackendCache*` during `init()` when a cache is provided.
+
+## Design decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Separate scoping components instead of string concatenation | Eliminates `snprintf` and fixed-size buffers in `runtime/`. No silent truncation risk. Implementations decide how to use the components. |
+| No `contains()` | TOCTOU race: file could be deleted between `contains()` and `load()`. Callers should `load()` and check for `NotFound`. |
+| `DelegateBackendCache` is not a subclass of `BackendCache` | Backends should not see the 3-component API. The simple key-only API prevents misuse. Different types enforce this at compile time. |
+| `init_from_cache` defaults to `NotSupported` | Existing backends are unaffected. The runtime treats `NotSupported` as "no caching", not as an error. |
+| Aligned allocation in `load()` | Backend-packed weights often require SIMD alignment (16, 32, 64 bytes). `std::malloc` only guarantees `max_align_t` (~16 bytes). |
+| `nothrow` operator new | ExecuTorch can be built with `-fno-exceptions`. The throwing variant would call `std::terminate` on OOM instead of returning an error. |
+| Atomic rename in `save()` | Prevents partially-written cache files if the process crashes. |
+| Cache at `Method::init` level, not `Program` level | Different methods may have different delegates. Scoping is per-delegate. |

--- a/extension/backend_cache/CMakeLists.txt
+++ b/extension/backend_cache/CMakeLists.txt
@@ -1,0 +1,38 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+cmake_minimum_required(VERSION 3.19)
+
+# Source root directory for executorch.
+if(NOT EXECUTORCH_ROOT)
+  set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../..)
+endif()
+
+add_library(
+  extension_backend_cache ${CMAKE_CURRENT_SOURCE_DIR}/file_backend_cache.cpp
+)
+target_link_libraries(extension_backend_cache PRIVATE executorch_core)
+target_include_directories(
+  extension_backend_cache PUBLIC ${_common_include_directories}
+)
+target_compile_options(
+  extension_backend_cache
+  PUBLIC $<$<CXX_COMPILER_ID:MSVC>:/wd4996>
+         $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wno-deprecated-declarations -fPIC>
+)
+
+# Install libraries
+install(
+  TARGETS extension_backend_cache
+  EXPORT ExecuTorchTargets
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  INCLUDES
+  DESTINATION ${_common_include_directories}
+)
+
+if(BUILD_TESTING)
+  add_subdirectory(test)
+endif()

--- a/extension/backend_cache/file_backend_cache.cpp
+++ b/extension/backend_cache/file_backend_cache.cpp
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/extension/backend_cache/file_backend_cache.h>
+
+#ifdef _WIN32
+#include <direct.h>
+#endif
+#include <sys/stat.h>
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
+#include <new>
+#include <string>
+
+namespace executorch {
+namespace extension {
+
+namespace {
+
+bool mkdirs(const std::string& path) {
+  if (path.empty()) {
+    return true;
+  }
+  struct stat st;
+  if (stat(path.c_str(), &st) == 0) {
+    return S_ISDIR(st.st_mode);
+  }
+  auto pos = path.find_last_of('/');
+  if (pos != std::string::npos && pos > 0) {
+    if (!mkdirs(path.substr(0, pos))) {
+      return false;
+    }
+  }
+#ifdef _WIN32
+  return _mkdir(path.c_str()) == 0;
+#else
+  return mkdir(path.c_str(), 0755) == 0;
+#endif
+}
+
+void free_aligned_buffer(void* context, void* data, size_t /*size*/) {
+  auto alignment =
+      static_cast<std::align_val_t>(reinterpret_cast<uintptr_t>(context));
+  ::operator delete(data, alignment);
+}
+
+} // namespace
+
+FileBackendCache::FileBackendCache(std::string cache_dir)
+    : cache_dir_(std::move(cache_dir)) {}
+
+std::string FileBackendCache::key_to_path(
+    const char* backend_id,
+    size_t delegate_index,
+    const char* key) const {
+  return cache_dir_ + "/" + backend_id + "/" + std::to_string(delegate_index) +
+      "/" + key;
+}
+
+runtime::Result<runtime::FreeableBuffer> FileBackendCache::load(
+    const char* backend_id,
+    size_t delegate_index,
+    const char* key,
+    size_t alignment) const {
+  std::string path = key_to_path(backend_id, delegate_index, key);
+  FILE* f = std::fopen(path.c_str(), "rb");
+  if (!f) {
+    return runtime::Error::NotFound;
+  }
+
+  std::fseek(f, 0, SEEK_END);
+  long file_size = std::ftell(f);
+  std::fseek(f, 0, SEEK_SET);
+
+  if (file_size <= 0) {
+    std::fclose(f);
+    return runtime::Error::NotFound;
+  }
+
+  void* buf = ::operator new(
+      static_cast<size_t>(file_size),
+      static_cast<std::align_val_t>(alignment),
+      std::nothrow);
+  if (!buf) {
+    std::fclose(f);
+    return runtime::Error::MemoryAllocationFailed;
+  }
+
+  size_t read = std::fread(buf, 1, static_cast<size_t>(file_size), f);
+  std::fclose(f);
+
+  if (read != static_cast<size_t>(file_size)) {
+    ::operator delete(buf, static_cast<std::align_val_t>(alignment));
+    return runtime::Error::AccessFailed;
+  }
+
+  return runtime::FreeableBuffer(
+      buf,
+      static_cast<size_t>(file_size),
+      free_aligned_buffer,
+      reinterpret_cast<void*>(alignment));
+}
+
+runtime::Error FileBackendCache::save(
+    const char* backend_id,
+    size_t delegate_index,
+    const char* key,
+    const void* data,
+    size_t size) {
+  std::string path = key_to_path(backend_id, delegate_index, key);
+
+  auto pos = path.find_last_of('/');
+  if (pos != std::string::npos) {
+    if (!mkdirs(path.substr(0, pos))) {
+      return runtime::Error::AccessFailed;
+    }
+  }
+
+  std::string tmp_path = path + ".tmp";
+  FILE* f = std::fopen(tmp_path.c_str(), "wb");
+  if (!f) {
+    return runtime::Error::AccessFailed;
+  }
+
+  size_t written = std::fwrite(data, 1, size, f);
+  std::fclose(f);
+
+  if (written != size) {
+    std::remove(tmp_path.c_str());
+    return runtime::Error::AccessFailed;
+  }
+
+  if (std::rename(tmp_path.c_str(), path.c_str()) != 0) {
+    std::remove(tmp_path.c_str());
+    return runtime::Error::AccessFailed;
+  }
+
+  return runtime::Error::Ok;
+}
+
+runtime::Error FileBackendCache::remove(
+    const char* backend_id,
+    size_t delegate_index,
+    const char* key) {
+  std::string path = key_to_path(backend_id, delegate_index, key);
+  if (std::remove(path.c_str()) != 0) {
+    if (errno == ENOENT) {
+      return runtime::Error::NotFound;
+    }
+    return runtime::Error::AccessFailed;
+  }
+  return runtime::Error::Ok;
+}
+
+} // namespace extension
+} // namespace executorch

--- a/extension/backend_cache/file_backend_cache.h
+++ b/extension/backend_cache/file_backend_cache.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <string>
+
+#include <executorch/runtime/backend/backend_cache.h>
+
+namespace executorch {
+namespace extension {
+
+/**
+ * Filesystem-based BackendCache implementation.
+ *
+ * Keys map to file paths under a cache directory:
+ *   {cache_dir}/{backend_id}/{delegate_index}/{key}
+ *
+ * Uses atomic writes (write to temp + rename) to prevent corruption.
+ *
+ * Concurrency: safe for concurrent reads from multiple threads/processes.
+ * Concurrent writes use last-writer-wins semantics via atomic rename.
+ */
+class FileBackendCache final : public runtime::BackendCache {
+ public:
+  explicit FileBackendCache(std::string cache_dir);
+
+  runtime::Result<runtime::FreeableBuffer> load(
+      const char* backend_id,
+      size_t delegate_index,
+      const char* key,
+      size_t alignment = alignof(std::max_align_t)) const override;
+
+  runtime::Error save(
+      const char* backend_id,
+      size_t delegate_index,
+      const char* key,
+      const void* data,
+      size_t size) override;
+
+  runtime::Error remove(
+      const char* backend_id,
+      size_t delegate_index,
+      const char* key) override;
+
+ private:
+  std::string cache_dir_;
+
+  std::string key_to_path(
+      const char* backend_id,
+      size_t delegate_index,
+      const char* key) const;
+};
+
+} // namespace extension
+} // namespace executorch

--- a/extension/backend_cache/targets.bzl
+++ b/extension/backend_cache/targets.bzl
@@ -1,0 +1,22 @@
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+
+def define_common_targets():
+    """Defines targets that should be shared between fbcode and xplat.
+
+    The directory containing this targets.bzl file should also contain both
+    TARGETS and BUCK files that call this function.
+    """
+
+    runtime.cxx_library(
+        name = "file_backend_cache",
+        srcs = [
+            "file_backend_cache.cpp",
+        ],
+        exported_headers = [
+            "file_backend_cache.h",
+        ],
+        visibility = ["PUBLIC"],
+        exported_deps = [
+            "//executorch/runtime/backend:interface",
+        ],
+    )

--- a/extension/backend_cache/test/CMakeLists.txt
+++ b/extension/backend_cache/test/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+cmake_minimum_required(VERSION 3.19)
+
+add_executable(
+  file_backend_cache_test
+  ${CMAKE_CURRENT_SOURCE_DIR}/file_backend_cache_test.cpp
+)
+target_link_libraries(
+  file_backend_cache_test PRIVATE extension_backend_cache executorch_core
+                                  GTest::gtest GTest::gtest_main
+)
+target_include_directories(
+  file_backend_cache_test PRIVATE ${_common_include_directories}
+)
+add_test(NAME file_backend_cache_test COMMAND file_backend_cache_test)

--- a/extension/backend_cache/test/file_backend_cache_test.cpp
+++ b/extension/backend_cache/test/file_backend_cache_test.cpp
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/extension/backend_cache/file_backend_cache.h>
+#include <executorch/runtime/platform/runtime.h>
+
+#include <gtest/gtest.h>
+
+#include <sys/stat.h>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+
+using executorch::extension::FileBackendCache;
+using executorch::runtime::Error;
+
+namespace {
+
+const char* kBackend = "TestBackend";
+constexpr size_t kIdx = 0;
+
+std::string make_temp_dir() {
+  std::string tmpl = "/tmp/et_cache_test_XXXXXX";
+  char* dir = mkdtemp(&tmpl[0]);
+  return std::string(dir);
+}
+
+void remove_dir_recursive(const std::string& path) {
+  std::string cmd = "rm -rf " + path;
+  std::system(cmd.c_str());
+}
+
+} // namespace
+
+class FileBackendCacheTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    executorch::runtime::runtime_init();
+    cache_dir_ = make_temp_dir();
+  }
+
+  void TearDown() override {
+    remove_dir_recursive(cache_dir_);
+  }
+
+  std::string cache_dir_;
+};
+
+TEST_F(FileBackendCacheTest, SaveAndLoad) {
+  FileBackendCache cache(cache_dir_);
+
+  const char* key = "test_data";
+  const char* data = "hello file cache";
+  size_t size = std::strlen(data) + 1;
+
+  auto err = cache.save(kBackend, kIdx, key, data, size);
+  EXPECT_EQ(err, Error::Ok);
+
+  auto result = cache.load(kBackend, kIdx, key);
+  ASSERT_TRUE(result.ok());
+  EXPECT_EQ(result->size(), size);
+  EXPECT_STREQ(static_cast<const char*>(result->data()), data);
+}
+
+TEST_F(FileBackendCacheTest, LoadNonExistent) {
+  FileBackendCache cache(cache_dir_);
+
+  auto result = cache.load(kBackend, kIdx, "nonexistent");
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.error(), Error::NotFound);
+}
+
+TEST_F(FileBackendCacheTest, SaveCreatesSubdirectories) {
+  FileBackendCache cache(cache_dir_);
+
+  const char* key = "v1/packed_weights";
+  const char* data = "packed weight data";
+  size_t size = std::strlen(data) + 1;
+
+  auto err = cache.save(kBackend, kIdx, key, data, size);
+  EXPECT_EQ(err, Error::Ok);
+
+  auto result = cache.load(kBackend, kIdx, key);
+  ASSERT_TRUE(result.ok());
+  EXPECT_STREQ(static_cast<const char*>(result->data()), data);
+}
+
+TEST_F(FileBackendCacheTest, SaveOverwrites) {
+  FileBackendCache cache(cache_dir_);
+
+  const char* key = "data";
+  const char* data1 = "first version";
+  const char* data2 = "second version";
+
+  EXPECT_EQ(
+      cache.save(kBackend, kIdx, key, data1, std::strlen(data1) + 1),
+      Error::Ok);
+  EXPECT_EQ(
+      cache.save(kBackend, kIdx, key, data2, std::strlen(data2) + 1),
+      Error::Ok);
+
+  auto result = cache.load(kBackend, kIdx, key);
+  ASSERT_TRUE(result.ok());
+  EXPECT_STREQ(static_cast<const char*>(result->data()), data2);
+}
+
+TEST_F(FileBackendCacheTest, LargeData) {
+  FileBackendCache cache(cache_dir_);
+
+  const size_t size = 1024 * 1024; // 1MB
+  std::vector<uint8_t> data(size);
+  for (size_t i = 0; i < size; ++i) {
+    data[i] = static_cast<uint8_t>(i & 0xFF);
+  }
+
+  auto err = cache.save(kBackend, kIdx, "large", data.data(), size);
+  EXPECT_EQ(err, Error::Ok);
+
+  auto result = cache.load(kBackend, kIdx, "large");
+  ASSERT_TRUE(result.ok());
+  EXPECT_EQ(result->size(), size);
+  EXPECT_EQ(std::memcmp(result->data(), data.data(), size), 0);
+}
+
+TEST_F(FileBackendCacheTest, Remove) {
+  FileBackendCache cache(cache_dir_);
+
+  const char* key = "removable";
+  const char* data = "some data";
+
+  EXPECT_EQ(cache.remove(kBackend, kIdx, key), Error::NotFound);
+
+  EXPECT_EQ(
+      cache.save(kBackend, kIdx, key, data, std::strlen(data) + 1), Error::Ok);
+  EXPECT_EQ(cache.remove(kBackend, kIdx, key), Error::Ok);
+
+  auto result = cache.load(kBackend, kIdx, key);
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.error(), Error::NotFound);
+}
+
+TEST_F(FileBackendCacheTest, AlignedLoad) {
+  FileBackendCache cache(cache_dir_);
+
+  const size_t size = 256;
+  std::vector<uint8_t> data(size, 0xAB);
+
+  EXPECT_EQ(
+      cache.save(kBackend, kIdx, "aligned", data.data(), size), Error::Ok);
+
+  constexpr size_t kAlignment = 64;
+  auto result = cache.load(kBackend, kIdx, "aligned", kAlignment);
+  ASSERT_TRUE(result.ok());
+  EXPECT_EQ(result->size(), size);
+  EXPECT_EQ(
+      reinterpret_cast<uintptr_t>(result->data()) % kAlignment,
+      static_cast<uintptr_t>(0));
+  EXPECT_EQ(std::memcmp(result->data(), data.data(), size), 0);
+}
+
+TEST_F(FileBackendCacheTest, IsolatesBackendsAndDelegates) {
+  FileBackendCache cache(cache_dir_);
+
+  const char* key = "weights";
+  const char* data_a0 = "backend_a delegate 0";
+  const char* data_a1 = "backend_a delegate 1";
+  const char* data_b0 = "backend_b delegate 0";
+
+  EXPECT_EQ(
+      cache.save("BackendA", 0, key, data_a0, std::strlen(data_a0) + 1),
+      Error::Ok);
+  EXPECT_EQ(
+      cache.save("BackendA", 1, key, data_a1, std::strlen(data_a1) + 1),
+      Error::Ok);
+  EXPECT_EQ(
+      cache.save("BackendB", 0, key, data_b0, std::strlen(data_b0) + 1),
+      Error::Ok);
+
+  auto r_a0 = cache.load("BackendA", 0, key);
+  ASSERT_TRUE(r_a0.ok());
+  EXPECT_STREQ(static_cast<const char*>(r_a0->data()), data_a0);
+
+  auto r_a1 = cache.load("BackendA", 1, key);
+  ASSERT_TRUE(r_a1.ok());
+  EXPECT_STREQ(static_cast<const char*>(r_a1->data()), data_a1);
+
+  auto r_b0 = cache.load("BackendB", 0, key);
+  ASSERT_TRUE(r_b0.ok());
+  EXPECT_STREQ(static_cast<const char*>(r_b0->data()), data_b0);
+}

--- a/extension/backend_cache/test/targets.bzl
+++ b/extension/backend_cache/test/targets.bzl
@@ -1,0 +1,17 @@
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+
+def define_common_targets():
+    """Defines targets that should be shared between fbcode and xplat.
+
+    The directory containing this targets.bzl file should also contain both
+    TARGETS and BUCK files that call this function.
+    """
+
+    runtime.cxx_test(
+        name = "file_backend_cache_test",
+        srcs = ["file_backend_cache_test.cpp"],
+        deps = [
+            "//executorch/runtime/core:core",
+            "//executorch/extension/backend_cache:file_backend_cache",
+        ],
+    )

--- a/extension/module/module.cpp
+++ b/extension/module/module.cpp
@@ -268,7 +268,8 @@ runtime::Error Module::load_method(
     const std::string& method_name,
     runtime::HierarchicalAllocator* planned_memory,
     torch::executor::EventTracer* event_tracer,
-    const LoadBackendOptionsMap* backend_options) {
+    const LoadBackendOptionsMap* backend_options,
+    runtime::BackendCache* backend_cache) {
   if (!is_method_loaded(method_name)) {
     ET_CHECK_OK_OR_RETURN_ERROR(load());
 
@@ -309,7 +310,8 @@ runtime::Error Module::load_method(
         method_holder.memory_manager.get(),
         event_tracer ? event_tracer : this->event_tracer(),
         merged_data_map_.get(),
-        effective_backend_options);
+        effective_backend_options,
+        backend_cache);
     if (!res_method.ok()) {
       return res_method.error();
     }

--- a/extension/module/module.h
+++ b/extension/module/module.h
@@ -225,7 +225,8 @@ class Module {
       const std::string& method_name,
       runtime::HierarchicalAllocator* planned_memory = nullptr,
       torch::executor::EventTracer* event_tracer = nullptr,
-      const LoadBackendOptionsMap* backend_options = nullptr);
+      const LoadBackendOptionsMap* backend_options = nullptr,
+      runtime::BackendCache* backend_cache = nullptr);
 
   ET_DEPRECATED ET_NODISCARD runtime::Error inline load_method(
       const std::string& method_name,
@@ -273,9 +274,14 @@ class Module {
   ET_NODISCARD inline runtime::Error load_forward(
       runtime::HierarchicalAllocator* planned_memory = nullptr,
       torch::executor::EventTracer* event_tracer = nullptr,
-      const LoadBackendOptionsMap* backend_options = nullptr) {
+      const LoadBackendOptionsMap* backend_options = nullptr,
+      runtime::BackendCache* backend_cache = nullptr) {
     return load_method(
-        "forward", planned_memory, event_tracer, backend_options);
+        "forward",
+        planned_memory,
+        event_tracer,
+        backend_options,
+        backend_cache);
   }
 
   ET_DEPRECATED ET_NODISCARD inline runtime::Error load_forward(

--- a/runtime/backend/backend_cache.h
+++ b/runtime/backend/backend_cache.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstddef>
+
+#include <executorch/runtime/core/error.h>
+#include <executorch/runtime/core/freeable_buffer.h>
+#include <executorch/runtime/core/result.h>
+
+namespace executorch {
+namespace runtime {
+
+/**
+ * Abstract key-value cache for backend init artifacts.
+ *
+ * Backends can persist expensive initialization results (packed weights,
+ * compiled graphs, etc.) and restore them on subsequent runs, skipping the
+ * processed data load entirely.
+ *
+ * Keys are arbitrary C strings chosen by the backend. The runtime wraps
+ * each backend's view of the cache with DelegateBackendCache to prevent
+ * key collisions between backends and delegates.
+ *
+ * All methods receive the full scoping triple (backend_id, delegate_index,
+ * key) so implementations can organize storage however they choose, without
+ * string concatenation in the runtime layer.
+ */
+class BackendCache {
+ public:
+  virtual ~BackendCache() = default;
+
+  /// Load cached data. Returns Error::NotFound if key doesn't exist.
+  virtual Result<FreeableBuffer> load(
+      const char* backend_id,
+      size_t delegate_index,
+      const char* key,
+      size_t alignment = alignof(std::max_align_t)) const = 0;
+
+  /// Save data to cache. Overwrites existing entries.
+  virtual Error save(
+      const char* backend_id,
+      size_t delegate_index,
+      const char* key,
+      const void* data,
+      size_t size) = 0;
+
+  /// Remove a cache entry. Returns Error::NotFound if key doesn't exist.
+  virtual Error
+  remove(const char* backend_id, size_t delegate_index, const char* key) = 0;
+};
+
+/**
+ * Wraps a BackendCache, capturing backend_id and delegate_index so that
+ * backends see a simple (key)-only API.
+ *
+ * Not a subclass of BackendCache -- this is a separate, simpler type that
+ * forwards to the underlying cache with the scoping components attached.
+ */
+class DelegateBackendCache final {
+ public:
+  DelegateBackendCache(
+      BackendCache* cache,
+      const char* backend_id,
+      size_t delegate_index)
+      : cache_(cache),
+        backend_id_(backend_id),
+        delegate_index_(delegate_index) {}
+
+  Result<FreeableBuffer> load(
+      const char* key,
+      size_t alignment = alignof(std::max_align_t)) const {
+    return cache_->load(backend_id_, delegate_index_, key, alignment);
+  }
+
+  Error save(const char* key, const void* data, size_t size) {
+    return cache_->save(backend_id_, delegate_index_, key, data, size);
+  }
+
+  Error remove(const char* key) {
+    return cache_->remove(backend_id_, delegate_index_, key);
+  }
+
+ private:
+  BackendCache* cache_;
+  const char* backend_id_;
+  size_t delegate_index_;
+};
+
+} // namespace runtime
+} // namespace executorch

--- a/runtime/backend/backend_init_context.h
+++ b/runtime/backend/backend_init_context.h
@@ -7,6 +7,7 @@
  */
 
 #pragma once
+#include <executorch/runtime/backend/backend_cache.h>
 #include <executorch/runtime/backend/options.h>
 #include <executorch/runtime/core/error.h>
 #include <executorch/runtime/core/event_tracer.h>
@@ -36,7 +37,8 @@ class BackendInitContext final {
       EventTracer* event_tracer = nullptr,
       const char* method_name = nullptr,
       const NamedDataMap* named_data_map = nullptr,
-      Span<const BackendOption> runtime_specs = {})
+      Span<const BackendOption> runtime_specs = {},
+      DelegateBackendCache* backend_cache = nullptr)
       : runtime_allocator_(runtime_allocator),
 #ifdef ET_EVENT_TRACER_ENABLED
         event_tracer_(event_tracer),
@@ -45,7 +47,8 @@ class BackendInitContext final {
 #endif
         method_name_(method_name),
         named_data_map_(named_data_map),
-        runtime_specs_(runtime_specs) {
+        runtime_specs_(runtime_specs),
+        backend_cache_(backend_cache) {
   }
 
   /** Get the runtime allocator passed from Method. It's the same runtime
@@ -95,6 +98,14 @@ class BackendInitContext final {
   }
 
   /**
+   * Get the backend cache for this delegate, if one was provided.
+   * Returns nullptr if no cache is available.
+   */
+  DelegateBackendCache* get_cache() const {
+    return backend_cache_;
+  }
+
+  /**
    * Get a runtime spec value by key and type.
    *
    * @tparam T The expected type (bool, int, or const char*)
@@ -135,6 +146,7 @@ class BackendInitContext final {
   const char* method_name_ = nullptr;
   const NamedDataMap* named_data_map_ = nullptr;
   Span<const BackendOption> runtime_specs_;
+  DelegateBackendCache* backend_cache_ = nullptr;
 };
 
 } // namespace ET_RUNTIME_NAMESPACE

--- a/runtime/backend/interface.h
+++ b/runtime/backend/interface.h
@@ -87,6 +87,30 @@ class BackendInterface {
       ArrayRef<CompileSpec> compile_specs) const = 0;
 
   /**
+   * Initialize from cached artifacts, without loading the processed data
+   * segment. Called before init() when a BackendCache is available.
+   *
+   * Backends that support caching override this to restore from
+   * context.get_cache(). On cache hit, the runtime skips loading
+   * the processed data segment entirely.
+   *
+   * @param[in] context The init context, including the scoped backend cache.
+   * @param[in] compile_specs The compile specs from the program.
+   *
+   * @returns On cache hit, an opaque DelegateHandle* (same as init()).
+   * @returns Error::NotSupported if the backend doesn't support caching
+   *     or no cache entry exists (default). The runtime will fall through
+   *     to the normal init() path.
+   */
+  ET_NODISCARD virtual Result<DelegateHandle*> init_from_cache(
+      BackendInitContext& context,
+      ArrayRef<CompileSpec> compile_specs) const {
+    (void)context;
+    (void)compile_specs;
+    return Error::NotSupported;
+  }
+
+  /**
    * Responsible for executing the given method’s handle, as it was produced
    * by compile.
    *

--- a/runtime/backend/targets.bzl
+++ b/runtime/backend/targets.bzl
@@ -39,6 +39,7 @@ def define_common_targets():
                 "interface.cpp",
             ],
             exported_headers = [
+                "backend_cache.h",
                 "backend_execution_context.h",
                 "backend_init_context.h",
                 "backend_option_context.h",

--- a/runtime/backend/test/backend_cache_test.cpp
+++ b/runtime/backend/test/backend_cache_test.cpp
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/runtime/backend/backend_cache.h>
+#include <executorch/runtime/platform/runtime.h>
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+using executorch::runtime::BackendCache;
+using executorch::runtime::DelegateBackendCache;
+using executorch::runtime::Error;
+using executorch::runtime::FreeableBuffer;
+using executorch::runtime::Result;
+
+namespace {
+
+std::string
+make_store_key(const char* backend_id, size_t delegate_index, const char* key) {
+  return std::string(backend_id) + "/" + std::to_string(delegate_index) + "/" +
+      key;
+}
+
+class InMemoryBackendCache : public BackendCache {
+ public:
+  Result<FreeableBuffer> load(
+      const char* backend_id,
+      size_t delegate_index,
+      const char* key,
+      size_t /*alignment*/ = alignof(std::max_align_t)) const override {
+    auto store_key = make_store_key(backend_id, delegate_index, key);
+    auto it = store_.find(store_key);
+    if (it == store_.end()) {
+      return Error::NotFound;
+    }
+    const auto& data = it->second;
+    void* copy = std::malloc(data.size());
+    if (!copy) {
+      return Error::MemoryAllocationFailed;
+    }
+    std::memcpy(copy, data.data(), data.size());
+    return FreeableBuffer(
+        copy, data.size(), [](void*, void* d, size_t) { std::free(d); });
+  }
+
+  Error save(
+      const char* backend_id,
+      size_t delegate_index,
+      const char* key,
+      const void* data,
+      size_t size) override {
+    auto store_key = make_store_key(backend_id, delegate_index, key);
+    auto bytes = static_cast<const uint8_t*>(data);
+    store_[store_key] = std::vector<uint8_t>(bytes, bytes + size);
+    return Error::Ok;
+  }
+
+  Error remove(const char* backend_id, size_t delegate_index, const char* key)
+      override {
+    auto store_key = make_store_key(backend_id, delegate_index, key);
+    return store_.erase(store_key) > 0 ? Error::Ok : Error::NotFound;
+  }
+
+  bool has_key(const std::string& key) const {
+    return store_.count(key) > 0;
+  }
+
+ private:
+  std::unordered_map<std::string, std::vector<uint8_t>> store_;
+};
+
+} // namespace
+
+class BackendCacheTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    executorch::runtime::runtime_init();
+  }
+};
+
+TEST_F(BackendCacheTest, InMemorySaveAndLoad) {
+  InMemoryBackendCache cache;
+
+  const char* bid = "TestBackend";
+  size_t idx = 0;
+  const char* key = "test_key";
+  const char* data = "hello world";
+  size_t size = std::strlen(data) + 1;
+
+  {
+    auto result = cache.load(bid, idx, key);
+    EXPECT_FALSE(result.ok());
+    EXPECT_EQ(result.error(), Error::NotFound);
+  }
+
+  auto err = cache.save(bid, idx, key, data, size);
+  EXPECT_EQ(err, Error::Ok);
+
+  auto result = cache.load(bid, idx, key);
+  ASSERT_TRUE(result.ok());
+  EXPECT_EQ(result->size(), size);
+  EXPECT_STREQ(static_cast<const char*>(result->data()), data);
+}
+
+TEST_F(BackendCacheTest, LoadNonExistent) {
+  InMemoryBackendCache cache;
+
+  auto result = cache.load("Backend", 0, "nonexistent");
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.error(), Error::NotFound);
+}
+
+TEST_F(BackendCacheTest, SaveOverwrites) {
+  InMemoryBackendCache cache;
+
+  const char* bid = "Backend";
+  size_t idx = 0;
+  const char* key = "key";
+  const char* data1 = "first";
+  const char* data2 = "second";
+
+  EXPECT_EQ(
+      cache.save(bid, idx, key, data1, std::strlen(data1) + 1), Error::Ok);
+  EXPECT_EQ(
+      cache.save(bid, idx, key, data2, std::strlen(data2) + 1), Error::Ok);
+
+  auto result = cache.load(bid, idx, key);
+  ASSERT_TRUE(result.ok());
+  EXPECT_STREQ(static_cast<const char*>(result->data()), data2);
+}
+
+TEST_F(BackendCacheTest, Remove) {
+  InMemoryBackendCache cache;
+
+  const char* bid = "Backend";
+  size_t idx = 0;
+  const char* key = "key";
+  const char* data = "data";
+
+  EXPECT_EQ(cache.remove(bid, idx, key), Error::NotFound);
+
+  EXPECT_EQ(cache.save(bid, idx, key, data, std::strlen(data) + 1), Error::Ok);
+  EXPECT_EQ(cache.remove(bid, idx, key), Error::Ok);
+
+  auto result = cache.load(bid, idx, key);
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.error(), Error::NotFound);
+}
+
+TEST_F(BackendCacheTest, ScopedCacheForwardsComponents) {
+  InMemoryBackendCache base_cache;
+  DelegateBackendCache scoped(&base_cache, "TestBackend", 0);
+
+  const char* key = "packed_weights";
+  const char* data = "weight data";
+  size_t size = std::strlen(data) + 1;
+
+  {
+    auto result = scoped.load(key);
+    EXPECT_FALSE(result.ok());
+  }
+
+  auto err = scoped.save(key, data, size);
+  EXPECT_EQ(err, Error::Ok);
+
+  EXPECT_TRUE(base_cache.has_key("TestBackend/0/packed_weights"));
+  EXPECT_FALSE(base_cache.has_key("packed_weights"));
+
+  auto result = scoped.load(key);
+  ASSERT_TRUE(result.ok());
+  EXPECT_STREQ(static_cast<const char*>(result->data()), data);
+}
+
+TEST_F(BackendCacheTest, ScopedCacheIsolatesDelegates) {
+  InMemoryBackendCache base_cache;
+  DelegateBackendCache scoped0(&base_cache, "Backend", 0);
+  DelegateBackendCache scoped1(&base_cache, "Backend", 1);
+
+  const char* key = "model";
+  const char* data0 = "delegate0";
+  const char* data1 = "delegate1";
+
+  EXPECT_EQ(scoped0.save(key, data0, std::strlen(data0) + 1), Error::Ok);
+  EXPECT_EQ(scoped1.save(key, data1, std::strlen(data1) + 1), Error::Ok);
+
+  auto result0 = scoped0.load(key);
+  ASSERT_TRUE(result0.ok());
+  EXPECT_STREQ(static_cast<const char*>(result0->data()), data0);
+
+  auto result1 = scoped1.load(key);
+  ASSERT_TRUE(result1.ok());
+  EXPECT_STREQ(static_cast<const char*>(result1->data()), data1);
+}
+
+TEST_F(BackendCacheTest, ScopedCacheIsolatesBackends) {
+  InMemoryBackendCache base_cache;
+  DelegateBackendCache xnnpack(&base_cache, "XnnpackBackend", 0);
+  DelegateBackendCache vulkan(&base_cache, "VulkanBackend", 0);
+
+  const char* key = "weights";
+  const char* xnnpack_data = "xnnpack weights";
+  const char* vulkan_data = "vulkan weights";
+
+  EXPECT_EQ(
+      xnnpack.save(key, xnnpack_data, std::strlen(xnnpack_data) + 1),
+      Error::Ok);
+  EXPECT_EQ(
+      vulkan.save(key, vulkan_data, std::strlen(vulkan_data) + 1), Error::Ok);
+
+  auto xnnpack_result = xnnpack.load(key);
+  ASSERT_TRUE(xnnpack_result.ok());
+  EXPECT_STREQ(static_cast<const char*>(xnnpack_result->data()), xnnpack_data);
+
+  auto vulkan_result = vulkan.load(key);
+  ASSERT_TRUE(vulkan_result.ok());
+  EXPECT_STREQ(static_cast<const char*>(vulkan_result->data()), vulkan_data);
+}
+
+TEST_F(BackendCacheTest, ScopedCacheRemove) {
+  InMemoryBackendCache base_cache;
+  DelegateBackendCache scoped(&base_cache, "TestBackend", 0);
+
+  const char* key = "weights";
+  const char* data = "data";
+
+  EXPECT_EQ(scoped.save(key, data, std::strlen(data) + 1), Error::Ok);
+  EXPECT_EQ(scoped.remove(key), Error::Ok);
+
+  auto result = scoped.load(key);
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.error(), Error::NotFound);
+}

--- a/runtime/backend/test/targets.bzl
+++ b/runtime/backend/test/targets.bzl
@@ -42,3 +42,12 @@ def define_common_targets():
             "//executorch/runtime/backend:interface",
         ],
     )
+
+    runtime.cxx_test(
+        name = "backend_cache_test",
+        srcs = ["backend_cache_test.cpp"],
+        deps = [
+            "//executorch/runtime/core:core",
+            "//executorch/runtime/backend:interface",
+        ],
+    )

--- a/runtime/executor/method.cpp
+++ b/runtime/executor/method.cpp
@@ -78,13 +78,6 @@ class BackendDelegate final {
         "Backend %s is not available.",
         backend_id);
 
-    // Get the delegate data.
-    Result<FreeableBuffer> processed_data = GetProcessedData(delegate, program);
-    if (!processed_data.ok()) {
-      ET_LOG(Error, "Failed to load data for backend %s", backend_id);
-      return processed_data.error();
-    }
-
     // Parse compilation specs from program
     CompileSpec* compile_specs;
     Error err = PopulateCompileSpecs(
@@ -94,6 +87,37 @@ class BackendDelegate final {
       return err;
     }
     size_t num_compile_specs = delegate.compile_specs()->size();
+
+    // Try cache-first path: if a cache is available, call init_from_cache()
+    // before loading the processed data segment.
+    if (backend_init_context.get_cache() != nullptr) {
+      Result<DelegateHandle*> cached_handle = backend->init_from_cache(
+          backend_init_context,
+          ArrayRef<CompileSpec>(compile_specs, num_compile_specs));
+      if (cached_handle.ok()) {
+        out->backend_ = backend;
+        out->handle_ = cached_handle.get();
+        new (&out->segment_) FreeableBuffer();
+        return Error::Ok;
+      }
+      // NotSupported means the backend doesn't support caching or had a
+      // cache miss. Fall through to the normal init() path.
+      if (cached_handle.error() != Error::NotSupported) {
+        ET_LOG(
+            Error,
+            "init_from_cache failed for backend %s: 0x%" PRIx32,
+            backend_id,
+            static_cast<uint32_t>(cached_handle.error()));
+        return cached_handle.error();
+      }
+    }
+
+    // Normal path: load the processed data and call init().
+    Result<FreeableBuffer> processed_data = GetProcessedData(delegate, program);
+    if (!processed_data.ok()) {
+      ET_LOG(Error, "Failed to load data for backend %s", backend_id);
+      return processed_data.error();
+    }
 
     out->backend_ = backend;
     out->handle_ = nullptr;
@@ -807,7 +831,8 @@ Result<Method> Method::load(
     MemoryManager* memory_manager,
     EventTracer* event_tracer,
     const NamedDataMap* external_data_map,
-    const LoadBackendOptionsMap* backend_options) {
+    const LoadBackendOptionsMap* backend_options,
+    BackendCache* backend_cache) {
   MemoryAllocator* temp_allocator = memory_manager->temp_allocator();
   if (temp_allocator == nullptr) {
     PlatformMemoryAllocator* platform_allocator =
@@ -821,7 +846,8 @@ Result<Method> Method::load(
   }
   Method method(program, memory_manager, event_tracer, temp_allocator);
   ET_LOG(Debug, "Loading method: %s.", s_plan->name()->c_str());
-  Error err = method.init(s_plan, external_data_map, backend_options);
+  Error err =
+      method.init(s_plan, external_data_map, backend_options, backend_cache);
   if (err != Error::Ok) {
     return err;
   } else {
@@ -833,7 +859,8 @@ Result<Method> Method::load(
 Error Method::init(
     executorch_flatbuffer::ExecutionPlan* s_plan,
     const NamedDataMap* external_data_map,
-    const LoadBackendOptionsMap* backend_options) {
+    const LoadBackendOptionsMap* backend_options,
+    BackendCache* backend_cache) {
   internal::EventTracerProfileMethodScope event_tracer_scope =
       internal::EventTracerProfileMethodScope(event_tracer_, "Method::init");
   ET_CHECK_OR_RETURN_ERROR(
@@ -912,12 +939,16 @@ Error Method::init(
             backend_options->get_options(delegate.id()->c_str());
       }
 
+      DelegateBackendCache scoped_cache(
+          backend_cache, delegate.id()->c_str(), i);
+
       BackendInitContext backend_init_context(
           method_allocator,
           /*event_tracer=*/event_tracer_,
           /*method_name=*/serialization_plan_->name()->c_str(),
           /*named_data_map=*/named_data_map,
-          /*runtime_specs=*/delegate_runtime_specs);
+          /*runtime_specs=*/delegate_runtime_specs,
+          /*backend_cache=*/backend_cache ? &scoped_cache : nullptr);
       Error err = BackendDelegate::Init(
           delegate, program_, backend_init_context, &delegates_[i]);
       if (err != Error::Ok) {

--- a/runtime/executor/method.h
+++ b/runtime/executor/method.h
@@ -14,6 +14,7 @@
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
+#include <executorch/runtime/backend/backend_cache.h>
 #include <executorch/runtime/backend/backend_options_map.h>
 #include <executorch/runtime/core/evalue.h>
 #include <executorch/runtime/core/event_tracer.h>
@@ -357,7 +358,8 @@ class Method final {
       MemoryManager* memory_manager,
       EventTracer* event_tracer,
       const NamedDataMap* named_data_map,
-      const LoadBackendOptionsMap* backend_options = nullptr);
+      const LoadBackendOptionsMap* backend_options = nullptr,
+      BackendCache* backend_cache = nullptr);
 
   /**
    * Initialize the method from its serialized representation.
@@ -367,7 +369,8 @@ class Method final {
   ET_NODISCARD Error init(
       executorch_flatbuffer::ExecutionPlan* s_plan,
       const NamedDataMap* named_data_map,
-      const LoadBackendOptionsMap* backend_options);
+      const LoadBackendOptionsMap* backend_options,
+      BackendCache* backend_cache = nullptr);
 
   /// Returns true if the Method was successfully initialized.
   inline bool initialized() const {

--- a/runtime/executor/program.cpp
+++ b/runtime/executor/program.cpp
@@ -308,7 +308,8 @@ Result<Method> Program::load_method(
     MemoryManager* memory_manager,
     EventTracer* event_tracer,
     const NamedDataMap* named_data_map,
-    const LoadBackendOptionsMap* backend_options) const {
+    const LoadBackendOptionsMap* backend_options,
+    BackendCache* backend_cache) const {
   EXECUTORCH_SCOPE_PROF("Program::load_method");
   internal::event_tracer_create_event_block(event_tracer, "Default");
   internal::EventTracerProfileMethodScope event_tracer_scope =
@@ -331,7 +332,8 @@ Result<Method> Program::load_method(
       memory_manager,
       event_tracer,
       named_data_map,
-      backend_options);
+      backend_options,
+      backend_cache);
 }
 
 Result<MethodMeta> Program::method_meta(const char* method_name) const {

--- a/runtime/executor/program.h
+++ b/runtime/executor/program.h
@@ -11,6 +11,7 @@
 #include <cstdint>
 #include <optional>
 
+#include <executorch/runtime/backend/backend_cache.h>
 #include <executorch/runtime/backend/backend_options_map.h>
 #include <executorch/runtime/core/data_loader.h>
 #include <executorch/runtime/core/error.h>
@@ -151,7 +152,8 @@ class Program final {
       MemoryManager* memory_manager,
       EventTracer* event_tracer = nullptr,
       const NamedDataMap* named_data_map = nullptr,
-      const LoadBackendOptionsMap* backend_options = nullptr) const;
+      const LoadBackendOptionsMap* backend_options = nullptr,
+      BackendCache* backend_cache = nullptr) const;
 
   /**
    * Gathers metadata for the named method.

--- a/runtime/executor/test/backend_integration_test.cpp
+++ b/runtime/executor/test/backend_integration_test.cpp
@@ -10,11 +10,14 @@
 #include <cstring>
 #include <functional>
 #include <optional>
+#include <string>
+#include <unordered_map>
 #include <vector>
 
 #include <executorch/extension/data_loader/buffer_data_loader.h>
 #include <executorch/extension/data_loader/file_data_loader.h>
 #include <executorch/extension/runner_util/inputs.h>
+#include <executorch/runtime/backend/backend_cache.h>
 #include <executorch/runtime/backend/interface.h>
 #include <executorch/runtime/core/error.h>
 #include <executorch/runtime/core/result.h>
@@ -29,6 +32,7 @@
 
 using namespace ::testing;
 using executorch::aten::ArrayRef;
+using executorch::runtime::BackendCache;
 using executorch::runtime::BackendExecutionContext;
 using executorch::runtime::BackendInitContext;
 using executorch::runtime::BackendInterface;
@@ -59,6 +63,8 @@ class StubBackend final : public BackendInterface {
       BackendInitContext&)>;
   using ExecuteFn = std::function<
       Error(BackendExecutionContext&, DelegateHandle*, Span<EValue*>)>;
+  using InitFromCacheFn = std::function<
+      Result<DelegateHandle*>(ArrayRef<CompileSpec>, BackendInitContext&)>;
   using DestroyFn = std::function<void(DelegateHandle*)>;
 
   // Default name that this backend is registered as.
@@ -89,6 +95,19 @@ class StubBackend final : public BackendInterface {
     }
     // Return a benign value otherwise.
     return nullptr;
+  }
+
+  void install_init_from_cache(InitFromCacheFn fn) {
+    init_from_cache_fn_ = fn;
+  }
+
+  Result<DelegateHandle*> init_from_cache(
+      BackendInitContext& context,
+      ArrayRef<CompileSpec> compile_specs) const override {
+    if (init_from_cache_fn_) {
+      return init_from_cache_fn_.value()(compile_specs, context);
+    }
+    return Error::NotSupported;
   }
 
   void install_execute(ExecuteFn fn) {
@@ -122,6 +141,7 @@ class StubBackend final : public BackendInterface {
   void reset() {
     is_available_fn_.reset();
     init_fn_.reset();
+    init_from_cache_fn_.reset();
     execute_fn_.reset();
     destroy_fn_.reset();
   }
@@ -154,6 +174,7 @@ class StubBackend final : public BackendInterface {
 
   std::optional<IsAvailableFn> is_available_fn_;
   std::optional<InitFn> init_fn_;
+  std::optional<InitFromCacheFn> init_from_cache_fn_;
   std::optional<ExecuteFn> execute_fn_;
   std::optional<DestroyFn> destroy_fn_;
 };
@@ -272,6 +293,58 @@ class DataLoaderSpy final : public DataLoader {
   DataLoader* delegate_;
 
   mutable std::vector<Operation> operations_;
+};
+
+/**
+ * In-memory BackendCache for testing the cache-first init flow.
+ */
+class InMemoryBackendCache : public BackendCache {
+ public:
+  Result<FreeableBuffer> load(
+      const char* backend_id,
+      size_t delegate_index,
+      const char* key,
+      size_t /*alignment*/) const override {
+    auto composite = make_key(backend_id, delegate_index, key);
+    auto it = store_.find(composite);
+    if (it == store_.end()) {
+      return Error::NotFound;
+    }
+    const auto& blob = it->second;
+    return FreeableBuffer(blob.data(), blob.size(), /*free_fn=*/nullptr);
+  }
+
+  Error save(
+      const char* backend_id,
+      size_t delegate_index,
+      const char* key,
+      const void* data,
+      size_t size) override {
+    auto composite = make_key(backend_id, delegate_index, key);
+    auto* bytes = static_cast<const uint8_t*>(data);
+    store_[composite] = std::vector<uint8_t>(bytes, bytes + size);
+    return Error::Ok;
+  }
+
+  Error remove(const char* backend_id, size_t delegate_index, const char* key)
+      override {
+    auto composite = make_key(backend_id, delegate_index, key);
+    auto it = store_.find(composite);
+    if (it == store_.end()) {
+      return Error::NotFound;
+    }
+    store_.erase(it);
+    return Error::Ok;
+  }
+
+ private:
+  static std::string
+  make_key(const char* backend_id, size_t delegate_index, const char* key) {
+    return std::string(backend_id) + "/" + std::to_string(delegate_index) +
+        "/" + key;
+  }
+
+  mutable std::unordered_map<std::string, std::vector<uint8_t>> store_;
 };
 
 constexpr size_t kDefaultNonConstMemBytes = 32 * 1024;
@@ -788,6 +861,203 @@ TEST_P(BackendIntegrationTest, NoRuntimeSpecsWhenBackendNotInMap) {
   // (because StubBackend wasn't in the map)
   EXPECT_TRUE(init_called);
   EXPECT_EQ(received_specs_size, 0);
+}
+
+TEST_P(BackendIntegrationTest, CacheHitSkipsInit) {
+  // Provide a cache and an init_from_cache that succeeds. init() should
+  // never be called and the processed data segment should not be loaded.
+  InMemoryBackendCache cache;
+  bool init_from_cache_called = false;
+  bool init_called = false;
+
+  StubBackend::singleton().install_init_from_cache(
+      [&](ET_UNUSED ArrayRef<CompileSpec> compile_specs,
+          ET_UNUSED BackendInitContext& context) -> Result<DelegateHandle*> {
+        init_from_cache_called = true;
+        return nullptr;
+      });
+
+  StubBackend::singleton().install_init(
+      [&](FreeableBuffer* processed,
+          ET_UNUSED ArrayRef<CompileSpec> compile_specs,
+          ET_UNUSED BackendInitContext& context) -> Result<DelegateHandle*> {
+        init_called = true;
+        return nullptr;
+      });
+
+  Result<FileDataLoader> loader = FileDataLoader::from(program_path());
+  ASSERT_EQ(loader.error(), Error::Ok);
+  DataLoaderSpy spy_loader(&loader.get());
+
+  Result<Program> program = Program::load(&spy_loader);
+  ASSERT_EQ(program.error(), Error::Ok);
+
+  ManagedMemoryManager mmm(kDefaultNonConstMemBytes, kDefaultRuntimeMemBytes);
+  Result<Method> method = program->load_method(
+      "forward",
+      &mmm.get(),
+      /*event_tracer=*/nullptr,
+      /*named_data_map=*/nullptr,
+      /*backend_options=*/nullptr,
+      /*backend_cache=*/&cache);
+  EXPECT_TRUE(method.ok());
+
+  EXPECT_TRUE(init_from_cache_called);
+  EXPECT_FALSE(init_called);
+
+  // When using segments, the backend processed data segment should not have
+  // been loaded since the cache hit avoided it.
+  if (using_segments()) {
+    EXPECT_FALSE(spy_loader.UsedLoad(
+        DataLoader::SegmentInfo::Type::Backend, "StubBackend"));
+  }
+}
+
+TEST_P(BackendIntegrationTest, CacheMissFallsThrough) {
+  // init_from_cache returns NotSupported → normal init() path is taken.
+  InMemoryBackendCache cache;
+  bool init_from_cache_called = false;
+  bool init_called = false;
+  const void* processed_data = nullptr;
+
+  StubBackend::singleton().install_init_from_cache(
+      [&](ET_UNUSED ArrayRef<CompileSpec> compile_specs,
+          ET_UNUSED BackendInitContext& context) -> Result<DelegateHandle*> {
+        init_from_cache_called = true;
+        return Error::NotSupported;
+      });
+
+  StubBackend::singleton().install_init(
+      [&](FreeableBuffer* processed,
+          ET_UNUSED ArrayRef<CompileSpec> compile_specs,
+          ET_UNUSED BackendInitContext& context) -> Result<DelegateHandle*> {
+        init_called = true;
+        processed_data = processed->data();
+        processed->Free();
+        return nullptr;
+      });
+
+  Result<FileDataLoader> loader = FileDataLoader::from(program_path());
+  ASSERT_EQ(loader.error(), Error::Ok);
+
+  Result<Program> program = Program::load(&loader.get());
+  ASSERT_EQ(program.error(), Error::Ok);
+
+  ManagedMemoryManager mmm(kDefaultNonConstMemBytes, kDefaultRuntimeMemBytes);
+  Result<Method> method = program->load_method(
+      "forward",
+      &mmm.get(),
+      /*event_tracer=*/nullptr,
+      /*named_data_map=*/nullptr,
+      /*backend_options=*/nullptr,
+      /*backend_cache=*/&cache);
+  EXPECT_TRUE(method.ok());
+
+  EXPECT_TRUE(init_from_cache_called);
+  EXPECT_TRUE(init_called);
+  EXPECT_NE(processed_data, nullptr);
+}
+
+TEST_P(BackendIntegrationTest, CacheErrorFailsLoad) {
+  // init_from_cache returns an error other than NotSupported → load_method
+  // should propagate the error.
+  InMemoryBackendCache cache;
+
+  StubBackend::singleton().install_init_from_cache(
+      [&](ET_UNUSED ArrayRef<CompileSpec> compile_specs,
+          ET_UNUSED BackendInitContext& context) -> Result<DelegateHandle*> {
+        return Error::InvalidState;
+      });
+
+  Result<FileDataLoader> loader = FileDataLoader::from(program_path());
+  ASSERT_EQ(loader.error(), Error::Ok);
+
+  Result<Program> program = Program::load(&loader.get());
+  ASSERT_EQ(program.error(), Error::Ok);
+
+  ManagedMemoryManager mmm(kDefaultNonConstMemBytes, kDefaultRuntimeMemBytes);
+  Result<Method> method = program->load_method(
+      "forward",
+      &mmm.get(),
+      /*event_tracer=*/nullptr,
+      /*named_data_map=*/nullptr,
+      /*backend_options=*/nullptr,
+      /*backend_cache=*/&cache);
+  EXPECT_EQ(method.error(), Error::InvalidState);
+}
+
+TEST_P(BackendIntegrationTest, NoCacheSkipsInitFromCache) {
+  // No BackendCache provided → init_from_cache is never called,
+  // init() proceeds normally.
+  bool init_from_cache_called = false;
+  bool init_called = false;
+
+  StubBackend::singleton().install_init_from_cache(
+      [&](ET_UNUSED ArrayRef<CompileSpec> compile_specs,
+          ET_UNUSED BackendInitContext& context) -> Result<DelegateHandle*> {
+        init_from_cache_called = true;
+        return Error::NotSupported;
+      });
+
+  StubBackend::singleton().install_init(
+      [&](FreeableBuffer* processed,
+          ET_UNUSED ArrayRef<CompileSpec> compile_specs,
+          ET_UNUSED BackendInitContext& context) -> Result<DelegateHandle*> {
+        init_called = true;
+        processed->Free();
+        return nullptr;
+      });
+
+  Result<FileDataLoader> loader = FileDataLoader::from(program_path());
+  ASSERT_EQ(loader.error(), Error::Ok);
+
+  Result<Program> program = Program::load(&loader.get());
+  ASSERT_EQ(program.error(), Error::Ok);
+
+  ManagedMemoryManager mmm(kDefaultNonConstMemBytes, kDefaultRuntimeMemBytes);
+  // No backend_cache parameter — uses the default nullptr.
+  Result<Method> method = program->load_method("forward", &mmm.get());
+  EXPECT_TRUE(method.ok());
+
+  EXPECT_FALSE(init_from_cache_called);
+  EXPECT_TRUE(init_called);
+}
+
+TEST_P(BackendIntegrationTest, CacheAvailableInContext) {
+  // When a BackendCache is provided, context.get_cache() returns a non-null
+  // DelegateBackendCache* during init().
+  InMemoryBackendCache cache;
+  bool init_called = false;
+  executorch::runtime::DelegateBackendCache* observed_cache = nullptr;
+
+  StubBackend::singleton().install_init(
+      [&](FreeableBuffer* processed,
+          ET_UNUSED ArrayRef<CompileSpec> compile_specs,
+          BackendInitContext& context) -> Result<DelegateHandle*> {
+        init_called = true;
+        observed_cache = context.get_cache();
+        processed->Free();
+        return nullptr;
+      });
+
+  Result<FileDataLoader> loader = FileDataLoader::from(program_path());
+  ASSERT_EQ(loader.error(), Error::Ok);
+
+  Result<Program> program = Program::load(&loader.get());
+  ASSERT_EQ(program.error(), Error::Ok);
+
+  ManagedMemoryManager mmm(kDefaultNonConstMemBytes, kDefaultRuntimeMemBytes);
+  Result<Method> method = program->load_method(
+      "forward",
+      &mmm.get(),
+      /*event_tracer=*/nullptr,
+      /*named_data_map=*/nullptr,
+      /*backend_options=*/nullptr,
+      /*backend_cache=*/&cache);
+  EXPECT_TRUE(method.ok());
+
+  EXPECT_TRUE(init_called);
+  EXPECT_NE(observed_cache, nullptr);
 }
 
 // TODO: Add more tests for the runtime-to-backend interface. E.g.:

--- a/tools/cmake/preset/default.cmake
+++ b/tools/cmake/preset/default.cmake
@@ -105,6 +105,10 @@ define_overridable_option(
   OFF
 )
 define_overridable_option(
+  EXECUTORCH_BUILD_EXTENSION_BACKEND_CACHE "Build the Backend Cache extension"
+  BOOL OFF
+)
+define_overridable_option(
   EXECUTORCH_BUILD_EXTENSION_MODULE "Build the Module extension" BOOL OFF
 )
 define_overridable_option(


### PR DESCRIPTION
### Summary
Backends can persist expensive init artifacts (packed weights, compiled graphs) and restore them on subsequent runs, skipping the processed data load entirely. On cache hit the runtime skips loading the processed data segment, avoiding both the I/O and the init computation.

The runtime calls init_from_cache() before init() when a BackendCache is provided. Backends that don't support caching return NotSupported (the default), and the runtime falls through to the normal init() path. Any other error is treated as fatal.

BackendCache (abstract, in runtime/) takes (backend_id, delegate_index, key) as separate parameters rather than concatenating them into a single string. This keeps string manipulation and heap allocation out of the runtime layer entirely. DelegateBackendCache is a non-inheriting wrapper that captures the scoping components at construction time and presents a simple key-only API to backends via BackendInitContext::get_cache().

FileBackendCache (in extension/) maps entries to filesystem paths:
  {cache_dir}/{backend_id}/{delegate_index}/{key}

It uses aligned allocation (operator new with align_val_t and nothrow) so backends can request SIMD-aligned buffers, atomic rename for crash safety, and std::remove for cache entry deletion.

The BackendCache* flows through Module::load_method -> Program::load_method -> Method::load -> Method::init, where each delegate gets its own DelegateBackendCache placement-new'd from the method allocator.

### Test plan
Integration tests in backend_integration_test.cpp verify the cache-first init protocol end-to-end using the StubBackend and real .pte fixtures.