### PR TITLE
Backend test suite: Wire skip_patterns into pytest collection

### DIFF
--- a/backends/test/suite/conftest.py
+++ b/backends/test/suite/conftest.py
@@ -4,9 +4,24 @@ from typing import Any
 import pytest
 import torch
 
-from executorch.backends.test.suite.flow import all_flows
+from executorch.backends.test.suite.flow import all_flows, TestFlow
 from executorch.backends.test.suite.reporting import _sum_op_counts
 from executorch.backends.test.suite.runner import run_test
+
+
+def pytest_collection_modifyitems(config, items):
+    for item in items:
+        callspec = getattr(item, "callspec", None)
+        if callspec is None:
+            continue
+        flow = callspec.params.get("test_runner")
+        if not isinstance(flow, TestFlow):
+            continue
+        test_name = item.originalname or item.name
+        if flow.should_skip_test(test_name):
+            item.add_marker(
+                pytest.mark.skip(reason=f"Skipped by {flow.name} skip_patterns")
+            )
 
 
 def pytest_configure(config):


### PR DESCRIPTION
### Summary

TestFlow already has skip_patterns and should_skip_test(), but they were dead code — never called from conftest.py. Add a pytest_collection_modifyitems hook that applies pytest.mark.skip when a flow's skip_patterns match the test name. This activates skip_patterns for all flows (CoreML, Vulkan, etc.).
