### PR TITLE
Fix Cadence CPU runner CMake build

### DIFF
--- a/backends/cadence/build_cadence_runner.sh
+++ b/backends/cadence/build_cadence_runner.sh
@@ -31,12 +31,19 @@ main() {
 
   local example_dir=backends/cadence
   local build_dir="cmake-out/${example_dir}"
-  local cmake_prefix_path="${PWD}/cmake-out/lib/cmake/ExecuTorch;${PWD}/cmake-out/third-party/gflags"
+  # Detect lib vs lib64
+  if [ -d "${PWD}/cmake-out/lib64/cmake/ExecuTorch" ]; then
+    libdir="lib64"
+  else
+    libdir="lib"
+  fi
+  local cmake_prefix_path="${PWD}/cmake-out/${libdir}/cmake/ExecuTorch;${PWD}/cmake-out/third-party/gflags"
   rm -rf ${build_dir}
   CXXFLAGS="-fno-exceptions -fno-rtti" cmake -DCMAKE_PREFIX_PATH="${cmake_prefix_path}" \
     -DCMAKE_BUILD_TYPE=Release \
     -DEXECUTORCH_CADENCE_CPU_RUNNER=ON \
     -DEXECUTORCH_ENABLE_LOGGING=ON \
+    -DPYTHON_EXECUTABLE="$(which python3)" \
     -B"${build_dir}" \
     "${example_dir}"
   cmake --build "${build_dir}" --config Release -j16

--- a/backends/cadence/generic/operators/CMakeLists.txt
+++ b/backends/cadence/generic/operators/CMakeLists.txt
@@ -79,21 +79,9 @@ target_include_directories(
 )
 
 # Custom ops that are needed to run the test model.
-add_library(
-  custom_ops
-  "quantized_add_out.cpp"
-  "quantized_linear_out.cpp"
-  "quantized_conv2d_nchw_out.cpp"
-  "quantized_conv2d_nhwc_out.cpp"
-  "quantized_relu_out.cpp"
-  "quantized_layer_norm.cpp"
-  "quantize_per_tensor.cpp"
-  "quantized_fully_connected_out.cpp"
-  "dequantize_per_tensor.cpp"
-  "quantized_matmul_out.cpp"
-  "op_requantize_out.cpp"
-  "im2row_out.cpp"
-)
+file(GLOB custom_ops_srcs "*.cpp")
+add_library(custom_ops ${custom_ops_srcs})
+
 target_include_directories(
   custom_ops PUBLIC ${ROOT_DIR}/.. ${CMAKE_BINARY_DIR}
                     ${_common_include_directories}


### PR DESCRIPTION
## Summary
- Detect lib vs lib64 install directory in build_cadence_runner.sh
- Add -DPYTHON_EXECUTABLE to prevent GLOB_RECURSE scanning entire filesystem when variable is unset
- Update generic/operators/CMakeLists.txt with actual source filenames

## Test plan
- Built cadence_runner successfully on devvm (CentOS/lib64 system)
- Verified cmake configure completes without hanging
- Verified cadence_runner binary is produced at cmake-out/backends/cadence/cadence_runner