### PR TITLE
Stop using autoglob mode constants

### DIFF
--- a/extension/apple/BUCK
+++ b/extension/apple/BUCK
@@ -9,7 +9,7 @@ oncall("executorch")
 
 non_fbcode_target(_kind = fb_apple_library,
     name = "ExecuTorch",
-    autoglob_mode = EXPORT_UNLESS_INTERNAL,
+    autoglob_mode = "EXPORT_UNLESS_INTERNAL",
     extension_api_only = True,
     frameworks = [
         "Foundation",

--- a/extension/llm/apple/BUCK
+++ b/extension/llm/apple/BUCK
@@ -10,7 +10,7 @@ oncall("executorch")
 
 non_fbcode_target(_kind = fb_apple_library,
     name = "ExecuTorchLLM",
-    autoglob_mode = EXPORT_UNLESS_INTERNAL,
+    autoglob_mode = "EXPORT_UNLESS_INTERNAL",
     extension_api_only = True,
     frameworks = [
         "Foundation",


### PR DESCRIPTION
Summary: There's no point to using constants for this, it's an immediate Buck parse error if you use an invalid mode. It's an extra step the AI needs to figure out (and humans!) - just use strings.

Reviewed By: d16r

Differential Revision: D95399679


