### PR TITLE
Update README with Mistral pre-exported .pte files info and demo app video

### DIFF
--- a/examples/models/voxtral_realtime/README.md
+++ b/examples/models/voxtral_realtime/README.md
@@ -22,7 +22,7 @@ microphone input).
 
 https://github.com/user-attachments/assets/44717dc5-777f-4710-ad55-5ec4fa04b9c4
 
-Also, try a sample [standalone macOS app](https://github.com/meta-pytorch/executorch-examples/tree/main/voxtral_realtime/macos) to do realtime transcription 
+Also, try a sample [standalone macOS app](https://github.com/meta-pytorch/executorch-examples/tree/main/voxtral_realtime/macos) to do real time transcription
 
 https://github.com/user-attachments/assets/0ce4fb05-76b2-47e4-85e2-6f49b4e9e34e
 

--- a/examples/models/voxtral_realtime/README.md
+++ b/examples/models/voxtral_realtime/README.md
@@ -22,6 +22,10 @@ microphone input).
 
 https://github.com/user-attachments/assets/44717dc5-777f-4710-ad55-5ec4fa04b9c4
 
+Also, try a sample [standalone macOS app](https://github.com/meta-pytorch/executorch-examples/tree/main/voxtral_realtime/macos) to do realtime transcription 
+
+https://github.com/user-attachments/assets/0ce4fb05-76b2-47e4-85e2-6f49b4e9e34e
+
 ## Prerequisites
 
 - ExecuTorch installed from source (see [building from source](../../../docs/source/using-executorch-building-from-source.md))

--- a/examples/models/voxtral_realtime/README.md
+++ b/examples/models/voxtral_realtime/README.md
@@ -63,7 +63,7 @@ Export produces a single `.pte` containing the audio encoder, text decoder,
 and token embedding.
 
 > [!Tip]
-> Mistral has already published pre-exported `.pte` files for select backends, including macOS Metal, on their [Hugging Face Hub](https://huggingface.co/mistral-labs/Voxtral-Mini-4B-Realtime-2602-Executorch).
+> Mistral has already published pre-exported `.pte` files for select backends, including macOS Metal, on their [HuggingFace Hub](https://huggingface.co/mistral-labs/Voxtral-Mini-4B-Realtime-2602-Executorch).
 
 
 ```bash

--- a/examples/models/voxtral_realtime/README.md
+++ b/examples/models/voxtral_realtime/README.md
@@ -58,6 +58,10 @@ python -m executorch.extension.audio.mel_spectrogram \
 Export produces a single `.pte` containing the audio encoder, text decoder,
 and token embedding.
 
+> [!Tip]
+> Mistral has already published pre-exported .pte files for select backends, including macOS Metal, on their [Hugging Face Hub](https://huggingface.co/mistral-labs/Voxtral-Mini-4B-Realtime-2602-Executorch).
+
+
 ```bash
 python export_voxtral_rt.py \
     --model-path ~/models/Voxtral-Mini-4B-Realtime-2602 \

--- a/examples/models/voxtral_realtime/README.md
+++ b/examples/models/voxtral_realtime/README.md
@@ -59,7 +59,7 @@ Export produces a single `.pte` containing the audio encoder, text decoder,
 and token embedding.
 
 > [!Tip]
-> Mistral has already published pre-exported .pte files for select backends, including macOS Metal, on their [Hugging Face Hub](https://huggingface.co/mistral-labs/Voxtral-Mini-4B-Realtime-2602-Executorch).
+> Mistral has already published pre-exported `.pte` files for select backends, including macOS Metal, on their [Hugging Face Hub](https://huggingface.co/mistral-labs/Voxtral-Mini-4B-Realtime-2602-Executorch).
 
 
 ```bash

--- a/examples/models/voxtral_realtime/README.md
+++ b/examples/models/voxtral_realtime/README.md
@@ -62,7 +62,7 @@ python -m executorch.extension.audio.mel_spectrogram \
 Export produces a single `.pte` containing the audio encoder, text decoder,
 and token embedding.
 
-> [!Tip]
+> [!TIP]
 > Mistral has already published pre-exported `.pte` files for select backends, including macOS Metal, on their [HuggingFace Hub](https://huggingface.co/mistral-labs/Voxtral-Mini-4B-Realtime-2602-Executorch).
 
 

--- a/examples/models/voxtral_realtime/README.md
+++ b/examples/models/voxtral_realtime/README.md
@@ -22,9 +22,9 @@ microphone input).
 
 https://github.com/user-attachments/assets/44717dc5-777f-4710-ad55-5ec4fa04b9c4
 
-Also, try a sample [standalone macOS app](https://github.com/meta-pytorch/executorch-examples/tree/main/voxtral_realtime/macos) to do real time transcription
+Also, try a sample [standalone macOS app](https://github.com/meta-pytorch/executorch-examples/tree/main/voxtral_realtime/macos) to do real time transcription.
 
-https://github.com/user-attachments/assets/0ce4fb05-76b2-47e4-85e2-6f49b4e9e34e
+https://github.com/user-attachments/assets/a89677ef-8309-426e-a2f4-6d1ea8494b99
 
 ## Prerequisites
 


### PR DESCRIPTION
Added a tip about pre-exported .pte files for Mistral. And also add the demo video
