### PR TITLE
Qualcomm AI Engine Direct - Custom op example fixes

### DIFF
--- a/backends/qualcomm/tests/utils.py
+++ b/backends/qualcomm/tests/utils.py
@@ -519,6 +519,7 @@ class TestQNN(unittest.TestCase):
                     adb.extra_cmds += (
                         f" --performance_output_path {self.inference_speed_output_path}"
                     )
+                adb.execute(custom_runner_cmd=f"rm -rf {adb.output_folder}")
                 adb.execute(method_index=method_index, output_callback=output_callback)
                 adb.pull(host_output_path=tmp_dir, callback=post_process)
                 self._assert_outputs_equal(outputs, ref_outputs)

--- a/examples/qualcomm/custom_op/custom_ops_1.py
+++ b/examples/qualcomm/custom_op/custom_ops_1.py
@@ -177,10 +177,6 @@ def main(args):
     # ensure the working directory exist.
     os.makedirs(args.artifact, exist_ok=True)
 
-    quant_dtype = QuantDtype.use_8a8w
-    if args.use_fp16:
-        quant_dtype = None
-
     instance = Model()
     pte_filename = "custom_qnn"
     sample_input = (torch.ones(1, 32, 28, 28),)
@@ -194,12 +190,17 @@ def main(args):
         soc_info.htp_info.htp_arch,
         args.build_op_package,
     )
-    quantizer = make_quantizer(
-        quant_dtype=quant_dtype,
-        custom_annotations=(annotate_custom,),
-        backend=get_backend_type(args.backend),
-        soc_model=args.model,
-    )
+
+    quant_dtype = QuantDtype.use_8a8w
+    if args.use_fp16:
+        quantizer = None
+    else:
+        quantizer = make_quantizer(
+            quant_dtype=quant_dtype,
+            custom_annotations=(annotate_custom,),
+            backend=get_backend_type(args.backend),
+            soc_model=args.model,
+        )
 
     build_executorch_binary(
         instance,
@@ -262,7 +263,17 @@ def main(args):
             target=args.target,
         )
         adb.push(inputs=sample_input, files=op_package_paths)
+        if args.debug:
+            adb.execute(custom_runner_cmd="logcat -c")
+            adb.execute(
+                custom_runner_cmd=f"echo 0x1f > {workspace}/qnn_executor_runner.farf"
+            )
+
         adb.execute()
+        if args.debug:
+            adb.execute(
+                custom_runner_cmd=f"logcat -d -v time >{workspace}/outputs/debug_logs.txt"
+            )
         adb.pull(host_output_path=args.artifact)
 
     x86_golden = instance(*sample_input)
@@ -322,6 +333,13 @@ if __name__ == "__main__":
         "`HEXAGON_SDK_ROOT` and `ANDROID_NDK_ROOT` environment variable. "
         "And add clang compiler into `PATH`. Please refer to  Qualcomm AI Engine "
         "Direct SDK document to get more details",
+        action="store_true",
+        default=False,
+    )
+
+    parser.add_argument(
+        "--debug",
+        help="Enable device logging",
         action="store_true",
         default=False,
     )

--- a/examples/qualcomm/utils.py
+++ b/examples/qualcomm/utils.py
@@ -266,7 +266,6 @@ class SimpleADB:
         method_index=0,
         output_callback: Optional[Callable[[str], None]] = None,
     ):
-        self._adb(["shell", f"rm -rf {self.output_folder}"])
         self._adb(["shell", f"mkdir -p {self.output_folder}"])
         # run the delegation
         if custom_runner_cmd is None:


### PR DESCRIPTION
Qualcomm AI Engine Direct - Custom op example fixes

# Summary
- Fixed bug in custom_op example, where use_fp16 was failing, due to quantizer being called.
- Added debug flag to custom_op example, so that DSP logs are captured by adb logcat

# Test plan
```bash
python3 examples/qualcomm/custom_op/custom_ops_1.py --build_folder build-android -s $ANDROID_SERIAL -H $ADB_HOST -m SM8650 --op_package_dir examples/qualcomm/custom_op/example_op_package_htp/ExampleOpPackage --build_op_package --debug --use_fp16
```

cc @cccclai @cbilgin