### PR TITLE
Arm backend: Update Ethos-u linux driver to 26.02

### DIFF
--- a/backends/arm/CMakeLists.txt
+++ b/backends/arm/CMakeLists.txt
@@ -29,7 +29,7 @@ set(ETHOSU_LINUX_DRIVER_GIT_REPO
     CACHE STRING "Git repository that hosts the Ethos-U Linux driver stack"
 )
 set(ETHOSU_LINUX_DRIVER_GIT_TAG
-    "25.11"
+    "26.02"
     CACHE STRING
           "Git tag/branch/commit used to fetch the Ethos-U Linux driver stack"
 )


### PR DESCRIPTION
Signed-off-by: per.held@arm.com
Change-Id: I32e0698c2f2972fd2d2df4050df6600d746462bd


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell