### PR TITLE
Arm backend: Remove evaluation from aot_arm_compiler.py

### DIFF
--- a/examples/arm/aot_arm_compiler.py
+++ b/examples/arm/aot_arm_compiler.py
@@ -21,7 +21,7 @@ _EXECUTORCH_DIR_STR = str(_EXECUTORCH_DIR)
 if _EXECUTORCH_DIR_STR not in sys.path:
     sys.path.insert(0, _EXECUTORCH_DIR_STR)
 
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, List, Optional, Tuple
 
 import torch
 from examples.devtools.scripts.export_bundled_program import save_bundled_program
@@ -57,35 +57,12 @@ from executorch.extension.export_util.utils import save_pte_program
 from tabulate import tabulate
 from torch.export import ExportedProgram
 from torch.fx import GraphModule
-from torch.utils.data import DataLoader
 
 # Quantize model if required using the standard export quantizaion flow.
 from torchao.quantization.pt2e.quantize_pt2e import convert_pt2e, prepare_pt2e
 
 from ..models import MODEL_NAME_TO_MODEL
 from ..models.model_factory import EagerModelFactory
-
-
-_arm_model_evaluator = None
-
-
-def _load_arm_model_evaluator() -> Any:
-    """Lazily import arm_model_evaluator to avoid heavy deps when not evaluating."""
-    global _arm_model_evaluator
-    if _arm_model_evaluator is not None:
-        return _arm_model_evaluator
-
-    try:
-        from executorch.backends.arm.util import arm_model_evaluator as arm_eval
-    except Exception as exc:
-        raise RuntimeError(
-            "Unable to run evaluation because arm_model_evaluator could not be imported. "
-            "You probably need to install torchvision or rerun without --evaluate. "
-            f"Original import error: {exc}"
-        )
-
-    _arm_model_evaluator = arm_eval
-    return arm_eval
 
 
 def _load_example_inputs(model_input: str | None) -> Any:  # nosec B614
@@ -138,7 +115,7 @@ def _load_registered_model(
         return None
 
     logging.warning(
-        "Using a model from examples/models not all of these are currently supported"
+        "Using a model from examples/models. Not all of these are currently supported."
     )
     logging.info(
         f"Load {model_name} -> {MODEL_NAME_TO_MODEL[model_name]} from examples/models"
@@ -254,8 +231,6 @@ def quantize(
     model_name: str,
     compile_specs: ArmCompileSpec,
     example_inputs: Tuple[torch.Tensor],
-    evaluator_name: str | None,
-    evaluator_config: Dict[str, Any] | None,
     is_int16x8: bool = False,
 ) -> GraphModule:
     """This is the official recommended flow for quantization in pytorch 2.0
@@ -282,17 +257,9 @@ def quantize(
     quantizer.set_global(operator_config)
     m = prepare_pt2e(model, quantizer)
 
-    dataset = get_calibration_data(
-        model_name, example_inputs, evaluator_name, evaluator_config
-    )
-
-    # The dataset could be a tuple of tensors or a DataLoader
-    # These two cases need to be accounted for
-    if isinstance(dataset, DataLoader):
-        for sample, _ in dataset:
-            m(sample)
-    else:
-        m(*dataset)
+    # Calibrate model using example inputs
+    # TODO: Add support for using a calibration dataset
+    m(*example_inputs)
 
     m = convert_pt2e(m)
     logging.debug(f"Quantized model: {m}")
@@ -369,20 +336,6 @@ MODELS = {
     "qlinear": QuantLinearTest,
 }
 
-CALIBRATION_DATA = {
-    "qadd": (torch.randn(32, 2, 1),),
-    "qadd2": (
-        torch.randn(32, 2, 1),
-        torch.randn(32, 2, 1),
-    ),
-    "qops": (
-        torch.randn(32, 2, 1),
-        torch.randn(32, 2, 1),
-        torch.randn(32, 2, 1) * -0.000001,
-        torch.randn(32, 2, 1) * 1000,
-    ),
-}
-
 TARGETS = [
     "ethos-u55-32",
     "ethos-u55-64",
@@ -399,30 +352,6 @@ TARGETS = [
     "TOSA-1.0+INT+int16",
     "cortex-m55+int8",
 ]
-
-
-def get_calibration_data(
-    model_name: str,
-    example_inputs: Tuple[torch.Tensor],
-    evaluator_name: str | None,
-    evaluator_config: str | None,
-):
-    # Firstly, if the model is being evaluated, take the evaluators calibration function if it has one
-    if evaluator_name is not None:
-        arm_eval = _load_arm_model_evaluator()
-        evaluator_data = arm_eval.evaluator_calibration_data(
-            evaluator_name, evaluator_config
-        )
-        if evaluator_data is not None:
-            return evaluator_data
-
-    # If the model is in the CALIBRATION_DATA dictionary, get the data from there
-    # This is used for the simple model examples provided
-    if model_name in CALIBRATION_DATA:
-        return CALIBRATION_DATA[model_name]
-
-    # As a last resort, fallback to the scripts previous behavior and return the example inputs
-    return example_inputs
 
 
 def get_compile_spec(args) -> ArmCompileSpec:
@@ -523,6 +452,8 @@ def get_args():
         choices=TARGETS,
         help=f"Target backend. For delegated models: Ethos-U/VGF/TOSA variants. For non-delegated: cortex-m55+int8 (CMSIS-NN portable kernels). Valid targets: {TARGETS}",
     )
+    # TODO: Remove --evaluate and --evaluate_config completely after a suitable time.
+    # They are deprecated and no longer functional in this script.
     parser.add_argument(
         "-e",
         "--evaluate",
@@ -530,14 +461,13 @@ def get_args():
         nargs="?",
         const="generic",
         choices=["generic", "mv2", "deit_tiny", "resnet18"],
-        help="Flag for running evaluation of the model.",
+        help=argparse.SUPPRESS,
     )
     parser.add_argument(
         "-c",
         "--evaluate_config",
         required=False,
-        default=None,
-        help="Provide path to evaluator config, if it is required.",
+        help=argparse.SUPPRESS,
     )
     parser.add_argument(
         "-q",
@@ -562,7 +492,7 @@ def get_args():
         "--intermediates",
         action="store",
         required=False,
-        help="Store intermediate output (like TOSA artefacts) somewhere.",
+        help="Store intermediate output (like TOSA artifacts) somewhere.",
     )
     parser.add_argument(
         "-o",
@@ -616,13 +546,6 @@ def get_args():
     )
     args = parser.parse_args()
 
-    if args.evaluate and (
-        (not args.quantize) or args.intermediates is None or (not args.delegate)
-    ):
-        raise RuntimeError(
-            "--evaluate requires --quantize, --intermediates and --delegate to be enabled."
-        )
-
     LOGGING_FORMAT = "[%(levelname)s %(asctime)s %(filename)s:%(lineno)s] %(message)s"
     logging_level = logging.DEBUG if args.debug else logging.WARNING
     logging.basicConfig(level=logging_level, format=LOGGING_FORMAT, force=True)
@@ -638,6 +561,11 @@ def get_args():
         and MODELS[args.model_name].can_delegate is False
     ):
         raise RuntimeError(f"Model {args.model_name} cannot be delegated.")
+
+    if args.evaluate is not None or args.evaluate_config is not None:
+        logging.error(
+            "Model evaluation is no longer supported in this script. Ignore and continue."
+        )
 
     return args
 
@@ -733,8 +661,6 @@ def quantize_model(
         args.model_name,
         compile_spec,
         example_inputs,
-        args.evaluate,
-        args.evaluate_config,
         is_int16x8,
     )
     # Wrap quantized model back into an exported_program
@@ -812,15 +738,9 @@ def to_edge_cortex_m(
         quantizer = CortexMQuantizer()
         prepared = prepare_pt2e(model, quantizer)
 
-        dataset = get_calibration_data(
-            args.model_name, example_inputs, args.evaluate, args.evaluate_config
-        )
-
-        if isinstance(dataset, DataLoader):
-            for sample, _ in dataset:
-                prepared(_to_channels_last(sample))
-        else:
-            prepared(*tuple(_to_channels_last(x) for x in dataset))
+        # Calibrate model using example inputs
+        # TODO: Add support for using a calibration dataset
+        prepared(*example_inputs)
 
         model_quant = convert_pt2e(prepared)
 
@@ -919,12 +839,6 @@ if __name__ == "__main__":  # noqa: C901
     model_quant = None
     if args.target == "cortex-m55+int8":
         # Cortex-M path: CMSIS-NN portable kernels, no delegation
-        if getattr(args, "evaluate", False):
-            logging.error(
-                "--evaluate is not supported for target 'cortex-m55+int8' "
-                "because this path does not use a TOSA delegate."
-            )
-            sys.exit(1)
         if args.delegate:
             logging.warning(
                 "--delegate is ignored for target 'cortex-m55+int8' "
@@ -1001,16 +915,3 @@ if __name__ == "__main__":  # noqa: C901
     else:
         save_pte_program(exec_prog, output_file_name)
         print(f"PTE file saved as {output_file_name}")
-
-    if args.evaluate:
-        arm_eval = _load_arm_model_evaluator()
-        arm_eval.evaluate_model(
-            args.model_name,
-            args.intermediates,
-            args.target,
-            model_fp32,
-            model_quant,
-            example_inputs,
-            args.evaluate,
-            args.evaluate_config,
-        )


### PR DESCRIPTION
Model evaluation, which means to compute and present a model's top-1/top-5 accuracy on ImageNet, as well as some other useful metrics, is to be moved into a new python program.

Remove the evaluation feature from aot_arm_compiler.py, which is part of the migration.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell