### PR TITLE
Portable kernel fixes for sabaton tests

### DIFF
--- a/kernels/portable/cpu/op_convolution.cpp
+++ b/kernels/portable/cpu/op_convolution.cpp
@@ -109,7 +109,7 @@ void conv2d_impl(
             size_t in_y = stride_y * out_y + dilation_y * w_y - padding_y;
             in_coord[2] = in_y;
             // Only proceed if input y coordinate is within bounds
-            if (in_y >= 0 && in_y < in_H) {
+            if (in_y < in_H) {
               for (const auto w_x : c10::irange(w_W)) {
                 w_coord[3] = w_x;
 
@@ -117,7 +117,7 @@ void conv2d_impl(
                 in_coord[3] = in_x;
 
                 // Only proceed if input x coordinate is within bounds
-                if (in_x >= 0 && in_x < in_W) {
+                if (in_x < in_W) {
                   size_t in_idx =
                       calculate_linear_index(in_coord, in_strides.data(), 4);
                   CTYPE in_val = in_ptr[in_idx];
@@ -165,14 +165,14 @@ void conv2d_impl(
             out_coord[2] = out_y;
 
             // Only proceed if output y coordinate is within bounds
-            if (out_y >= 0 && out_y < out_H) {
+            if (out_y < out_H) {
               for (const auto w_x : c10::irange(w_W)) {
                 w_coord[3] = w_x;
                 size_t out_x = stride_x * in_x + dilation_x * w_x - padding_x;
                 out_coord[3] = out_x;
 
                 // Only proceed if output x coordinate is within bounds
-                if (out_x >= 0 && out_x < out_W) {
+                if (out_x < out_W) {
                   size_t w_idx =
                       calculate_linear_index(w_coord, w_strides.data(), 4);
                   CTYPE w_val = w_ptr[w_idx];

--- a/kernels/portable/cpu/util/kernel_ops_util.h
+++ b/kernels/portable/cpu/util/kernel_ops_util.h
@@ -229,8 +229,8 @@ void kernel_reduction_then_map_2d(
           size_t in_x = stride_x * out_x + dilation_x * w_x - padding_x;
           in_coord[in_dim - 1] = in_x;
 
-          const bool x_in_bound = (in_x >= 0 && in_x < in_W);
-          const bool y_in_bound = (in_y >= 0 && in_y < in_H);
+          const bool x_in_bound = (in_x < in_W);
+          const bool y_in_bound = (in_y < in_H);
           const bool xy_in_bound = (x_in_bound && y_in_bound);
 
           CTYPE in_val = 0;

--- a/kernels/portable/cpu/util/targets.bzl
+++ b/kernels/portable/cpu/util/targets.bzl
@@ -115,12 +115,20 @@ def define_common_targets():
             ":broadcast_util",
             ":dtype_util",
             ":vectorized_math",
-            "//executorch/runtime/core/portable_type/c10/c10:aten_headers_for_executorch",
             "//executorch/runtime/kernel:kernel_runtime_context",
             "//executorch/kernels/portable/cpu:scalar_utils",
             "//executorch/extension/threadpool:threadpool",
             "//executorch/kernels/portable/cpu:scalar_utils",
-        ],
+        ] + (select({
+            # Zephyr builds use -fno-exceptions → ET_HAS_EXCEPTIONS=0 →
+            # ET_USE_PYTORCH_HEADERS=0, so ATen vectorization is unused.
+            "ovr_config//os:zephyr": [],
+            "DEFAULT": [
+                "//executorch/runtime/core/portable_type/c10/c10:aten_headers_for_executorch",
+            ],
+        }) if not runtime.is_oss else [
+            "//executorch/runtime/core/portable_type/c10/c10:aten_headers_for_executorch",
+        ]),
         deps = [
             "//executorch/runtime/kernel:kernel_includes",
         ],
@@ -279,9 +287,16 @@ def define_common_targets():
         srcs = [],
         exported_headers = ["math_util.h"],
         visibility = ["//executorch/kernels/portable/cpu/...", "//executorch/kernels/quantized/..."],
-        exported_deps = [
+        exported_deps = select({
+            # Zephyr builds use -fno-exceptions → ET_HAS_EXCEPTIONS=0 →
+            # ET_USE_PYTORCH_HEADERS=0, so ATen vectorization is unused.
+            "ovr_config//os:zephyr": [],
+            "DEFAULT": [
+                "//executorch/runtime/core/portable_type/c10/c10:aten_headers_for_executorch",
+            ],
+        }) if not runtime.is_oss else [
             "//executorch/runtime/core/portable_type/c10/c10:aten_headers_for_executorch",
-        ],
+            ],
     )
 
     runtime.cxx_library(

--- a/runtime/core/portable_type/c10/c10/targets.bzl
+++ b/runtime/core/portable_type/c10/c10/targets.bzl
@@ -134,6 +134,21 @@ def define_common_targets():
     else:
         runtime.cxx_library(
             name = "c10",
-            exported_deps = [":aten_headers_for_executorch"],
+            exported_deps = select({
+                "ovr_config//os:zephyr": [],
+                "DEFAULT": [":aten_headers_for_executorch"],
+            }),
+            xplat_exported_deps = select({
+                "ovr_config//os:zephyr": [
+                    "fbsource//xplat/caffe2/c10:c10_headers",
+                ],
+                "DEFAULT": [],
+            }),
+            fbcode_exported_deps = select({
+                "ovr_config//os:zephyr": [
+                    "//caffe2/c10:c10_headers",
+                ],
+                "DEFAULT": [],
+            }) if not runtime.is_oss else [],
             visibility = ["PUBLIC"],
         )


### PR DESCRIPTION
Summary:
When running in Sabaton Zephyr Posix tests, the compiler complains for things like

```
foo >= 0 && foo < bar
```

when foo is unsigned.

Also avoid bringing in aten

Reviewed By: rascani

Differential Revision: D95834771


