### PR TITLE
Remove uses_dotslash label

### DIFF
--- a/backends/vulkan/targets.bzl
+++ b/backends/vulkan/targets.bzl
@@ -123,7 +123,6 @@ def vulkan_spv_shader_lib(name, spv_filegroups, is_fbcode = False, no_volk = Fal
         },
         cmd = genrule_cmd,
         default_outs = ["."],
-        labels = ["uses_dotslash"],
     )
 
     suffix = "_no_volk" if no_volk else ""


### PR DESCRIPTION
Summary: Doesn't seem to be needed, prevents it running on RE and being cached

Differential Revision: D95928348


