### PR TITLE
Skip Samsung jobs that require secrests on forked PRs

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -1057,7 +1057,8 @@ jobs:
 
   test-samsung-quantmodels-linux:
     name: test-samsung-quantmodels-linux
-    # if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
+    # Skip this job if the pull request is from a fork (secrets are not available)
+    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     permissions:
       id-token: write
@@ -1094,7 +1095,8 @@ jobs:
 
   test-samsung-models-linux:
     name: test-samsung-models-linux
-    # if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
+    # Skip this job if the pull request is from a fork (secrets are not available)
+    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     permissions:
       id-token: write


### PR DESCRIPTION
### Summary
Don't run Samsung jobs which require secrets on forked PRs. They fail. It looks like they used to be disabled on forks, but this line ended up getting left commented out after the jobs were disabled and re-enabled. This PR restores it to the original state.