### PR TITLE
Add CI workflow to build Cadence CPU runner

### DIFF
--- a/.github/workflows/build-cadence-runner.yml
+++ b/.github/workflows/build-cadence-runner.yml
@@ -1,0 +1,35 @@
+name: Build Cadence
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - release/*
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true
+
+jobs:
+  cpu-x86:
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      job-name: build
+      runner: linux.2xlarge
+      docker-image: ci-image:executorch-ubuntu-22.04-clang12
+      submodules: recursive
+      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      timeout: 90
+      script: |
+        set -eux
+        # The generic Linux job chooses to use base env, not the one setup by the image
+        CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
+        conda activate "${CONDA_ENV}"
+
+        ./install_requirements.sh > /dev/null
+        bash backends/cadence/build_cadence_runner.sh


### PR DESCRIPTION
## Summary                                                     
  - Adds a new GitHub Actions workflow that builds the Cadence CPU runner on every PR and push to main/release branches
  - Uses the pytorch/test-infra reusable workflow with executorch-ubuntu-22.04-clang12 Docker image                                       
  - Runs install_requirements.sh followed by backends/cadence/build_cadence_runner.sh                                                     
  - Displays as Build Cadence / cpu x86 in the GitHub Actions UI                                                                          
                                                                                                                                          
  ## Test plan
  - workflow triggers on a PR
  - build_cadence_runner.sh completes successfully in CI (https://github.com/pytorch/executorch/actions/runs/22920217757/job/66516393219?pr=18066)