### PR TITLE
[ET-VK] Fix fp16 inference: clamp constants and sync view_convert shader dtype combos

### DIFF
--- a/backends/vulkan/runtime/graph/ops/glsl/view_convert_buffer.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/view_convert_buffer.yaml
@@ -19,5 +19,8 @@ view_convert_buffer:
         - parameter_values: [uint8, half]
         - parameter_values: [uint8, int32]
         - parameter_values: [float, int32]
+        - parameter_values: [float, half]
+        - parameter_values: [half, float]
+        - parameter_values: [half, int32]
   shader_variants:
     - NAME: view_convert_buffer

--- a/backends/vulkan/runtime/graph/ops/glsl/view_convert_texture.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/view_convert_texture.yaml
@@ -14,6 +14,13 @@ view_convert_texture:
       parameter_names: [IN_DTYPE, OUT_DTYPE]
       combos:
         - parameter_values: [int32, float]
+        - parameter_values: [int32, half]
+        - parameter_values: [uint8, float]
+        - parameter_values: [uint8, half]
+        - parameter_values: [uint8, int32]
         - parameter_values: [float, int32]
+        - parameter_values: [float, half]
+        - parameter_values: [half, float]
+        - parameter_values: [half, int32]
   shader_variants:
     - NAME: view_convert_texture

--- a/backends/vulkan/serialization/vulkan_graph_builder.py
+++ b/backends/vulkan/serialization/vulkan_graph_builder.py
@@ -118,6 +118,14 @@ class VkGraphBuilder:
 
             # Convert the tensor dtype if needed
             if tensor.dtype != effective_dtype:
+                # Clamp float tensors to the representable range of the effective
+                # dtype to avoid infinities. This is needed when force_fp16 converts
+                # fp32 constants (e.g. -100000 attention mask values) to fp16 where
+                # the max representable value is ~65504.
+                if effective_dtype.is_floating_point:
+                    dtype_info = torch.finfo(effective_dtype)
+                    tensor = tensor.clamp(min=dtype_info.min, max=dtype_info.max)
+
                 tensor = tensor.to(effective_dtype)
 
             # Serialize tensor data to bytes


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #18077
* __->__ #18076

Two fixes for force_fp16 inference mode:

1. Clamp constant tensors to the representable range of the effective dtype
   after conversion in VkGraphBuilder. When force_fp16 converts fp32 constants
   to fp16, values like -100000 (used as attention mask fill values) overflow to
   -inf. A subsequent `0 * (-inf)` produces NaN per IEEE 754, which propagates
   through the entire model. Clamping to finfo(fp16).min/max (-65504/65504)
   prevents the overflow.

2. Sync dtype combos across view_convert_buffer.yaml and
   view_convert_texture.yaml so both define the same set of conversion
   variants. Added float<->half, half<->int32 to the buffer YAML, and
   float<->half, half<->float, uint8<->float/half/int32 to the texture YAML.
   Both files now cover all 9 dtype combos: int32<->float, int32<->half,
   uint8<->float/half/int32, float<->half, half<->float, half<->int32.
   The float<->half variants are needed by the _to_dim_order_copy operator
   when running fp16 models (e.g. SceneX).

Verified on edgeTAM first frame: mask IoU improved from 0.18 (NaN-corrupted)
to 0.9991, matching the fp32 baseline range of 0.9926-0.9995. Also verified
SceneX fp16 model (scenex_v9_512_vulkan_fp16_v3.et) no longer crashes with
missing view_convert_buffer_float_half shader.

Differential Revision: [D96036512](https://our.internmc.facebook.com/intern/diff/D96036512/)