### PR TITLE
[ET-VK][qconv] Use ivec4 reads in pack_q8_conv2d_weights to fix Adreno 740 bug

### DIFF
--- a/backends/vulkan/runtime/graph/ops/glsl/pack_q8_conv2d_weights.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/pack_q8_conv2d_weights.glsl
@@ -17,7 +17,7 @@ ${define_active_storage_type(STORAGE)}
 layout(std430) buffer;
 
 ${layout_declare_tensor(B, "w", "t_packed_int8_weight", "int", STORAGE, is_scalar_array=False)}
-${layout_declare_tensor(B, "r", "t_int8_weight", "int", "buffer")}
+${layout_declare_tensor(B, "r", "t_int8_weight", "int", "buffer", is_scalar_array=False)}
 
 layout(push_constant) uniform restrict Block {
   ivec4 qmat2_sizes;
@@ -65,7 +65,8 @@ void main() {
         if (ic + col < orig_sizes.w) {
           const int byte_idx = buf_idx + col;
           const int byte_pos = byte_idx & 3;
-          weight_vals[col] = (t_int8_weight[byte_idx >> 2] >> (byte_pos * 8)) & 0xFF;
+          const int word_idx = byte_idx >> 2;
+          weight_vals[col] = (t_int8_weight[word_idx >> 2][word_idx & 3] >> (byte_pos * 8)) & 0xFF;
         }
       }
       packed_block[row] = pack_into_int32(weight_vals);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #18077
* #18076

On Adreno 740 (Quest 3S), scalar int[] SSBO reads from host-visible staging
buffers in the pack_q8_conv2d_weights shader returned incorrect data —
specifically t_int8_weight[N] returned the value of t_int8_weight[N-1] for N>0.
This caused corrupted conv2d weights for all kernels with kx>0, resulting in
18/45 head-case failures on the SceneX V9 model.

Switching the input buffer declaration from scalar int[] to ivec4[] changes the
GPU load instruction from scalar loads to vec4 loads, which sidesteps the driver
bug. The indexing is updated accordingly: t_int8_weight[word_idx] becomes
t_int8_weight[word_idx >> 2][word_idx & 3].

Authored with Claude.

Differential Revision: [D96036513](https://our.internmc.facebook.com/intern/diff/D96036513/)