### PR TITLE
[kernels/quantized] Enable -Werror and fix format specifier warnings

### DIFF
--- a/examples/nxp/executor_runner/nxp_executor_runner.cpp
+++ b/examples/nxp/executor_runner/nxp_executor_runner.cpp
@@ -190,7 +190,7 @@ void printClassificationOutput(
   FILE* results = fopen(resultsFile.c_str(), "a+");
   // Print classification results and save to results.txt.
   std::cout << "Top1 class " << runPathPrefix << " = " << maxIdx << std::endl;
-  fprintf(results, "%s %d ", runPathPrefix.c_str(), maxIdx);
+  fprintf(results, "%s %zu ", runPathPrefix.c_str(), maxIdx);
   std::cout << "Confidence = " << static_cast<float_t>(maxVal) << std::endl;
   fprintf(results, "%f ", static_cast<float_t>(maxVal));
   fprintf(results, "\n");
@@ -238,8 +238,8 @@ void printOutput(
       default:
         fprintf(
             stderr,
-            "Unsupported tensor data type: %d\n",
-            values[0].toTensor().scalar_type());
+            "Unsupported tensor data type: %hhd\n",
+            static_cast<int8_t>(values[0].toTensor().scalar_type()));
         exit(-1);
     }
   }

--- a/kernels/portable/cpu/util/upsample_util.cpp
+++ b/kernels/portable/cpu/util/upsample_util.cpp
@@ -84,8 +84,10 @@ Error resize_upsample_2d(
     scale_w_out =
         static_cast<double>(output_size.value()[1]) / in.sizes()[dim - 1];
 
-    target_size[dim - 2] = output_size.value()[0];
-    target_size[dim - 1] = output_size.value()[1];
+    target_size[dim - 2] =
+        static_cast<Tensor::SizesType>(output_size.value()[0]);
+    target_size[dim - 1] =
+        static_cast<Tensor::SizesType>(output_size.value()[1]);
   } else {
     ET_LOG(Error, "Invalid output_size or scale_factors");
     return Error::InvalidArgument;

--- a/kernels/quantized/CMakeLists.txt
+++ b/kernels/quantized/CMakeLists.txt
@@ -21,7 +21,7 @@ if(NOT EXECUTORCH_ROOT)
   set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../..)
 endif()
 
-set(_common_compile_options -Wno-deprecated-declarations)
+set(_common_compile_options -Wno-deprecated-declarations -Werror)
 
 include(${EXECUTORCH_ROOT}/tools/cmake/Utils.cmake)
 include(${EXECUTORCH_ROOT}/tools/cmake/Codegen.cmake)
@@ -93,7 +93,7 @@ if(NOT CMAKE_GENERATOR STREQUAL "Xcode"
                                              kernels_util_all_deps
       )
       target_compile_options(
-        quantized_pybind_kernels_lib PUBLIC ${_common_compile_options}
+        quantized_pybind_kernels_lib PRIVATE ${_common_compile_options}
       )
       target_include_directories(
         quantized_pybind_kernels_lib PUBLIC "${_common_include_directories}"
@@ -141,7 +141,7 @@ add_library(quantized_kernels ${_quantized_kernels__srcs})
 target_link_libraries(
   quantized_kernels PRIVATE executorch_core kernels_util_all_deps
 )
-target_compile_options(quantized_kernels PUBLIC ${_common_compile_options})
+target_compile_options(quantized_kernels PRIVATE ${_common_compile_options})
 # Build a library for _quantized_kernels_srcs
 #
 # quantized_ops_lib: Register quantized ops kernels into Executorch runtime

--- a/kernels/quantized/cpu/embeddingxb.cpp
+++ b/kernels/quantized/cpu/embeddingxb.cpp
@@ -72,17 +72,19 @@ void check_embedding_xbit_args(
   ET_CHECK_MSG(8 % weight_nbit == 0, "nbit must divide 8");
 
   ET_CHECK_MSG(
-      weight.dim() == 2, "weight must be 2D but got() %zd dims", weight.dim());
+      weight.dim() == 2,
+      "weight must be 2D but got() %" ET_PRI_TENSOR_DIM " dims",
+      weight.dim());
 
   ET_CHECK_MSG(
       weight_scales.dim() == 1 || weight_scales.dim() == 2,
-      "weight_scales must be 1D or 2D but got() %zd dims",
+      "weight_scales must be 1D or 2D but got() %" ET_PRI_TENSOR_DIM " dims",
       weight_scales.dim());
 
   ET_CHECK_MSG(
       weight_scales.size(0) == weight.size(0),
-      "Number of scales must be == weight.size(0)=%zd"
-      ", but got %zd",
+      "Number of scales must be == weight.size(0)=%" ET_PRI_TENSOR_DIM
+      ", but got %" ET_PRI_TENSOR_DIM,
       weight_scales.size(0),
       weight.size(0));
 
@@ -90,9 +92,11 @@ void check_embedding_xbit_args(
     auto num_groups = weight_scales.size(1);
     ET_CHECK_MSG(
         // each 8b uint8 column is packed_values_per_byte columns
-        get_embedding_dim(weight.size(1), weight_nbit) % num_groups == 0,
-        "Number of groups must divide weight.size(1)=%zd"
-        ", but got # of groups = %zd",
+        get_embedding_dim(static_cast<int32_t>(weight.size(1)), weight_nbit) %
+                num_groups ==
+            0,
+        "Number of groups must divide weight.size(1)=%" ET_PRI_TENSOR_DIM
+        ", but got # of groups = %" ET_PRI_TENSOR_DIM,
         weight.size(1),
         num_groups);
   }
@@ -132,8 +136,8 @@ void check_embedding_xbit_args(
       ET_CHECK_MSG(
           opt_weight_zero_points.value().size(i) == weight_scales.size(i),
           "Dimension size misatch at dim %" PRIi32
-          "Weight_zero_point size = %zd"
-          ", weight_scales size = %zd.",
+          " Weight_zero_point size = %" ET_PRI_TENSOR_DIM
+          ", weight_scales size = %" ET_PRI_TENSOR_DIM ".",
           i,
           opt_weight_zero_points.value().size(i),
           weight_scales.size(i));
@@ -172,13 +176,14 @@ void embedding_xbit_per_channel(
     const Tensor& indices,
     Tensor& out,
     int weight_nbit) {
-  auto embedding_dim = get_embedding_dim(weight.size(1), weight_nbit);
+  auto embedding_dim =
+      get_embedding_dim(static_cast<int32_t>(weight.size(1)), weight_nbit);
 
-  int32_t num_groups_per_channel = 1;
+  ssize_t num_groups_per_channel = 1;
   if (weight_scales.dim() == 2) {
     num_groups_per_channel = weight_scales.size(1);
   }
-  int32_t group_size = embedding_dim / num_groups_per_channel;
+  auto group_size = embedding_dim / num_groups_per_channel;
 
   CTYPE_OUT* out_data = out.mutable_data_ptr<CTYPE_OUT>();
   const CTYPE_INDICES* indices_ptr = indices.const_data_ptr<CTYPE_INDICES>();
@@ -192,7 +197,7 @@ void embedding_xbit_per_channel(
   for (int i = 0; i < indices.numel(); i++) {
     CTYPE_INDICES index = indices_ptr[i];
     // If using groupwise embedding
-    int32_t qparams_index = index * num_groups_per_channel;
+    auto qparams_index = index * num_groups_per_channel;
     CTYPE_PARAMS zp = 0.0;
     const CTYPE_PARAMS* scale_ptr = scales + qparams_index;
     const CTYPE_PARAMS* zero_points_ptr = nullptr;
@@ -225,10 +230,13 @@ void resize_out_tensor(
     int weight_nbit) {
   executorch::aten::SizesType expected_output_size[kTensorDimensionLimit];
   for (size_t i = 0; i < indices.dim(); i++) {
-    expected_output_size[i] = indices.size(i);
+    expected_output_size[i] =
+        static_cast<executorch::aten::SizesType>(indices.size(i));
   }
-  const size_t embedding_dim = get_embedding_dim(weight.size(1), weight_nbit);
-  expected_output_size[out.dim() - 1] = embedding_dim;
+  const auto embedding_dim =
+      get_embedding_dim(static_cast<int32_t>(weight.size(1)), weight_nbit);
+  expected_output_size[out.dim() - 1] =
+      static_cast<executorch::aten::SizesType>(embedding_dim);
 
   executorch::aten::ArrayRef<executorch::aten::SizesType> output_size{
       expected_output_size, static_cast<size_t>(out.dim())};

--- a/kernels/quantized/cpu/op_choose_qparams.cpp
+++ b/kernels/quantized/cpu/op_choose_qparams.cpp
@@ -63,23 +63,25 @@ void check_quantize_per_tensor_args(
     for (auto i = 0; i < input.dim() - 1; i++) {
       ET_CHECK_MSG(
           scale_out.size(i) == input.size(i),
-          "Exepcted scale to have the same number of elements at dimentions %d got %zd",
+          "Exepcted scale to have the same number of elements at dimentions %d got %" ET_PRI_TENSOR_DIM,
           i,
           scale_out.size(i));
       ET_CHECK_MSG(
           zero_point_out.size(i) == input.size(i),
-          "Exepcted zero pont to have the same number of elements at dimentions %d got %zd",
+          "Exepcted zero pont to have the same number of elements at dimentions %d got %" ET_PRI_TENSOR_DIM,
           i,
           zero_point_out.size(i));
     }
     ET_CHECK_MSG(
         scale_out.size(input.dim() - 1) == 1,
-        "Exepcted scale to have only one element at dimentions %zd but got %zd",
+        "Exepcted scale to have only one element at dimentions %" ET_PRI_TENSOR_DIM
+        " but got %" ET_PRI_TENSOR_DIM,
         input.dim() - 1,
         scale_out.size(input.dim() - 1));
     ET_CHECK_MSG(
         zero_point_out.size(input.dim() - 1) == 1,
-        "Exepcted zero point to have only one element at dimentions %zd but got %zd",
+        "Exepcted zero point to have only one element at dimentions %" ET_PRI_TENSOR_DIM
+        " but got %" ET_PRI_TENSOR_DIM,
         input.dim() - 1,
         zero_point_out.size(input.dim() - 1));
   } else {
@@ -254,7 +256,12 @@ std::tuple<Tensor&, Tensor&> choose_qparams_tensor_out(
   check_quantize_per_tensor_args(
       input, quant_min, quant_max, dtype, scale_out, zero_point_out);
 
-  choose_qparams(input, quant_min, quant_max, scale_out, zero_point_out);
+  choose_qparams(
+      input,
+      static_cast<int32_t>(quant_min),
+      static_cast<int32_t>(quant_max),
+      scale_out,
+      zero_point_out);
   return {scale_out, zero_point_out};
 }
 
@@ -283,7 +290,7 @@ std::tuple<Tensor&, Tensor&> choose_qparams_per_token_asymmetric_out(
   int64_t quant_max = 127;
   executorch::aten::SizesType output_sizes[kTensorDimensionLimit];
   for (ssize_t i = 0; i < input.dim() - 1; i++) {
-    output_sizes[i] = input.size(i);
+    output_sizes[i] = static_cast<executorch::aten::SizesType>(input.size(i));
   }
   output_sizes[input.dim() - 1] = 1;
   size_t output_dim = input.dim();
@@ -307,7 +314,11 @@ std::tuple<Tensor&, Tensor&> choose_qparams_per_token_asymmetric_out(
       true /* is_per_token*/);
 
   choose_qparams_per_token(
-      input, quant_min, quant_max, scale_out, zero_point_out);
+      input,
+      static_cast<int32_t>(quant_min),
+      static_cast<int32_t>(quant_max),
+      scale_out,
+      zero_point_out);
   return {scale_out, zero_point_out};
 }
 

--- a/kernels/quantized/cpu/op_dequantize.cpp
+++ b/kernels/quantized/cpu/op_dequantize.cpp
@@ -213,7 +213,7 @@ void dequantize_per_channel_optimized(
     zero_points_data = opt_zero_points.value().const_data_ptr<int64_t>();
   }
   const StridesType axis_stride = in.strides()[axis];
-  const StridesType outer_stride = in.size(axis) * axis_stride;
+  const auto outer_stride = in.size(axis) * axis_stride;
   apply_over_unpacked_dim(
       [in_data,
        out_data,
@@ -222,8 +222,7 @@ void dequantize_per_channel_optimized(
        axis_stride,
        outer_stride,
        quant_min,
-       quant_max](
-          SizesType numel, SizesType outer_idx, SizesType unpacked_dim_idx) {
+       quant_max](size_t numel, size_t outer_idx, size_t unpacked_dim_idx) {
         const int8_t* in_data_local =
             in_data + outer_idx * outer_stride + unpacked_dim_idx * axis_stride;
         const double scale = get_scale(scales, unpacked_dim_idx);

--- a/kernels/quantized/cpu/op_embedding.cpp
+++ b/kernels/quantized/cpu/op_embedding.cpp
@@ -34,17 +34,19 @@ void check_embedding_byte_args(
     std::optional<ScalarType> out_dtype,
     Tensor& out) {
   ET_CHECK_MSG(
-      weight.dim() == 2, "weight must be 2D but got() %zd dims", weight.dim());
+      weight.dim() == 2,
+      "weight must be 2D but got() %" ET_PRI_TENSOR_DIM " dims",
+      weight.dim());
 
   ET_CHECK_MSG(
       weight_scales.dim() == 1 || weight_scales.dim() == 2,
-      "weight_scales must be 1D or 2D but got() %zd dims",
+      "weight_scales must be 1D or 2D but got() %" ET_PRI_TENSOR_DIM " dims",
       weight_scales.dim());
 
   ET_CHECK_MSG(
       weight_scales.size(0) == weight.size(0),
-      "Number of scales must be == weight.size(0)=%zd"
-      ", but got %zd",
+      "Number of scales must be == weight.size(0)=%" ET_PRI_TENSOR_DIM
+      ", but got %" ET_PRI_TENSOR_DIM,
       weight_scales.size(0),
       weight.size(0));
 
@@ -52,8 +54,8 @@ void check_embedding_byte_args(
     auto num_groups = weight_scales.size(1);
     ET_CHECK_MSG(
         weight.size(1) % num_groups == 0,
-        "Number of groups must divide weight.size(1)=%zd"
-        ", but got # of groups = %zd",
+        "Number of groups must divide weight.size(1)=%" ET_PRI_TENSOR_DIM
+        ", but got # of groups = %" ET_PRI_TENSOR_DIM,
         weight.size(1),
         num_groups);
   }
@@ -94,8 +96,8 @@ void check_embedding_byte_args(
       ET_CHECK_MSG(
           opt_weight_zero_points.value().size(i) == weight_scales.size(i),
           "Dimension size misatch at dim %" PRIi32
-          "Weight_zero_point size = %zd"
-          ", weight_scales size = %zd.",
+          " Weight_zero_point size = %" ET_PRI_TENSOR_DIM
+          ", weight_scales size = %" ET_PRI_TENSOR_DIM ".",
           i,
           opt_weight_zero_points.value().size(i),
           weight_scales.size(i));
@@ -136,11 +138,11 @@ void embedding_byte_per_channel(
   // weight of shape (num_embeddings, embedding_dim).
   auto embedding_dim = weight.size(1);
 
-  int32_t num_groups_per_channel = 1;
+  ssize_t num_groups_per_channel = 1;
   if (weight_scales.dim() == 2) {
     num_groups_per_channel = weight_scales.size(1);
   }
-  int32_t group_size = weight.size(1) / num_groups_per_channel;
+  auto group_size = weight.size(1) / num_groups_per_channel;
 
   CTYPE_OUT* out_data = out.mutable_data_ptr<CTYPE_OUT>();
   const int64_t* indices_ptr = indices.const_data_ptr<int64_t>();
@@ -158,19 +160,19 @@ void embedding_byte_per_channel(
     ET_CHECK_MSG(
         index >= 0 && index < weight.size(0),
         "Index out of bounds for weight: index %" PRId64
-        " must be in range [0, %zd)",
+        " must be in range [0, %" ET_PRI_TENSOR_DIM ")",
         index,
         weight.size(0));
 
     ET_CHECK_MSG(
         index >= 0 && index < weight_scales.size(0),
         "Index out of bounds for weight_scales: index %" PRId64
-        " must be in range [0, %zd)",
+        " must be in range [0, %" ET_PRI_TENSOR_DIM ")",
         index,
         weight_scales.size(0));
 
     // If using groupwise embedding
-    int32_t qparams_index = index * num_groups_per_channel;
+    auto qparams_index = index * num_groups_per_channel;
     CTYPE_PARAMS zp = 0.0;
     const CTYPE_PARAMS* scale_ptr = scales + qparams_index;
     const CTYPE_PARAMS* zero_points_ptr = nullptr;
@@ -201,10 +203,12 @@ void resize_out_tensor(
     Tensor& out) {
   executorch::aten::SizesType expected_output_size[kTensorDimensionLimit];
   for (size_t i = 0; i < indices.dim(); i++) {
-    expected_output_size[i] = indices.size(i);
+    expected_output_size[i] =
+        static_cast<executorch::aten::SizesType>(indices.size(i));
   }
-  const size_t embedding_dim = weight.size(1);
-  expected_output_size[out.dim() - 1] = embedding_dim;
+  const auto embedding_dim = weight.size(1);
+  expected_output_size[out.dim() - 1] =
+      static_cast<executorch::aten::SizesType>(embedding_dim);
 
   executorch::aten::ArrayRef<executorch::aten::SizesType> output_size{
       expected_output_size, static_cast<size_t>(out.dim())};

--- a/kernels/quantized/cpu/op_mixed_linear.cpp
+++ b/kernels/quantized/cpu/op_mixed_linear.cpp
@@ -79,8 +79,8 @@ Tensor& quantized_mixed_linear_out(
 
   size_t output_ndim = 2;
   executorch::aten::SizesType output_sizes[kTensorDimensionLimit];
-  output_sizes[0] = in.size(0);
-  output_sizes[1] = weight.size(0);
+  output_sizes[0] = static_cast<executorch::aten::SizesType>(in.size(0));
+  output_sizes[1] = static_cast<executorch::aten::SizesType>(weight.size(0));
 
   ET_KERNEL_CHECK(
       ctx,

--- a/kernels/quantized/cpu/op_mixed_mm.cpp
+++ b/kernels/quantized/cpu/op_mixed_mm.cpp
@@ -67,8 +67,8 @@ Tensor& quantized_mixed_mm_out(
 
   size_t output_ndim = 2;
   executorch::aten::SizesType output_sizes[kTensorDimensionLimit];
-  output_sizes[0] = in.size(0);
-  output_sizes[1] = weight.size(1);
+  output_sizes[0] = static_cast<executorch::aten::SizesType>(in.size(0));
+  output_sizes[1] = static_cast<executorch::aten::SizesType>(weight.size(1));
 
   ET_KERNEL_CHECK(
       ctx,

--- a/kernels/quantized/cpu/op_quantize.cpp
+++ b/kernels/quantized/cpu/op_quantize.cpp
@@ -431,7 +431,8 @@ Tensor& quantize_per_channel_out(
 
   ET_CHECK_MSG(
       scale.numel() == input.size(axis),
-      "scale.numel() %zd != input.size(axis) %zd",
+      "scale.numel() %" ET_PRI_TENSOR_DIM
+      " != input.size(axis) %" ET_PRI_TENSOR_DIM,
       scale.numel(),
       input.size(axis));
 
@@ -442,7 +443,8 @@ Tensor& quantize_per_channel_out(
 
   ET_CHECK_MSG(
       zero_point.numel() == input.size(axis),
-      "zero_point.numel() %zd != input.size(axis) %zd",
+      "zero_point.numel() %" ET_PRI_TENSOR_DIM
+      " != input.size(axis) %" ET_PRI_TENSOR_DIM,
       zero_point.numel(),
       input.size(axis));
 
@@ -656,8 +658,9 @@ Tensor& quantize_per_token_out(
 #else
   std::array<executorch::aten::DimOrderType, 2> input_dim_order{0, 1};
   std::array<executorch::aten::SizesType, 2> input_sizes;
-  input_sizes[0] = num_tokens;
-  input_sizes[1] = input.size(input.dim() - 1);
+  input_sizes[0] = static_cast<executorch::aten::SizesType>(num_tokens);
+  input_sizes[1] =
+      static_cast<executorch::aten::SizesType>(input.size(input.dim() - 1));
   std::array<executorch::aten::StridesType, 2> input_strides;
   dim_order_to_stride_nocheck(
       input_sizes.data(), input_dim_order.data(), 2, input_strides.data());

--- a/runtime/core/exec_aten/util/dim_order_util.h
+++ b/runtime/core/exec_aten/util/dim_order_util.h
@@ -139,7 +139,7 @@ inline void dim_order_to_stride_nocheck(
   // dim_order = [0, 2, 3, 1]
   // strides = [60, 1, 15, 3]
   strides[dim_order[dims - 1]] = 1;
-  for (int32_t i = dims - 2; i >= 0; --i) {
+  for (ssize_t i = static_cast<ssize_t>(dims) - 2; i >= 0; --i) {
     if (sizes[dim_order[i + 1]] == 0) {
       strides[dim_order[i]] = strides[dim_order[i + 1]];
     } else {

--- a/runtime/core/exec_aten/util/tensor_util.h
+++ b/runtime/core/exec_aten/util/tensor_util.h
@@ -44,13 +44,14 @@
       UPPER_BOUND,                                          \
       UPPER_BOUND)
 
-#define ET_CHECK_VALID_DIM(DIM, UPPER_BOUND)              \
-  ET_CHECK_MSG(                                           \
-      DIM >= -static_cast<int64_t>(UPPER_BOUND) &&        \
-          DIM < static_cast<int64_t>(UPPER_BOUND),        \
-      "dim %" PRId64 " must be within range [-%zd, %zd)", \
-      DIM,                                                \
-      UPPER_BOUND,                                        \
+#define ET_CHECK_VALID_DIM(DIM, UPPER_BOUND)                       \
+  ET_CHECK_MSG(                                                    \
+      DIM >= -static_cast<int64_t>(UPPER_BOUND) &&                 \
+          DIM < static_cast<int64_t>(UPPER_BOUND),                 \
+      "dim %" PRId64 " must be within range [-%" ET_PRI_TENSOR_DIM \
+      ", %" ET_PRI_TENSOR_DIM ")",                                 \
+      DIM,                                                         \
+      UPPER_BOUND,                                                 \
       UPPER_BOUND)
 
 #define ET_CHECK_NON_ZERO_DIM_SIZE(DIM, T)           \
@@ -891,7 +892,7 @@ inline bool tensor_is_contiguous(executorch::aten::Tensor t) {
       "Tensor is not contiguous; the stride of the last dimension must be 1, "
       "but got %zu",
       static_cast<size_t>(strides[strides.size() - 1]));
-  for (int i = strides.size() - 1; i > 0; --i) {
+  for (auto i = strides.size() - 1; i > 0; --i) {
     ET_CHECK_OR_RETURN_FALSE(
         strides[i - 1] == strides[i] * sizes[i],
         "Tensor is not contiguous; the stride of dim %zu should be equal to "
@@ -984,7 +985,7 @@ inline void memoizeTrailingDims(
     size_t trailing_dims_memo[kTensorDimensionLimit]) {
   const auto tensorDim = tensor.dim();
   size_t dims = 1;
-  for (int ii = tensorDim - 1; ii >= 0; --ii) {
+  for (auto ii = tensorDim - 1; ii >= 0; --ii) {
     trailing_dims_memo[ii] = dims;
     dims *= static_cast<size_t>(tensor.size(ii));
   }


### PR DESCRIPTION
Summary:
Enable -Werror for kernels/quantized and fix format specifier mismatches that were causing -Wformat warnings when tensor dimension/size values (int64_t in ATen mode) were formatted with %zd (for ssize_t).

Mostly wanted to test the OSS flow and saw all the warnings during build 
Changes:
- Add -Werror to _common_compile_options in kernels/quantized/CMakeLists.txt
- Replace %zd with ET_PRI_TENSOR_DIM for tensor .dim(), .size(), and .numel() calls in:
  - op_embedding.cpp
  - embeddingxb.cpp
  - op_choose_qparams.cpp
  - op_quantize.cpp
- Fix ET_CHECK_VALID_DIM macro in tensor_util.h to use ET_PRI_TENSOR_DIM

ET_PRI_TENSOR_DIM is the portable format specifier macro that adapts to the build mode (PRId64 for ATen mode, "zd" for portable mode).

Test Plan:
Build with: cmake --build cmake-out -j9 --target quantized_kernels Verify no -Wformat errors with -Werror enabled.

### Test plan
Add Werr to CMakeLists.txt, see the build fail, apply the changes in the ops and the util and see the build succeed. 