### PR TITLE
Qualcomm AI Engine Direct - AMD backend error

### DIFF
--- a/.ci/scripts/setup-qnn-deps.sh
+++ b/.ci/scripts/setup-qnn-deps.sh
@@ -12,3 +12,4 @@ source "$(dirname "${BASH_SOURCE[0]}")/../../backends/qualcomm/scripts/install_q
 setup_libcpp 12
 setup_android_ndk
 install_qnn
+pip install -r backends/qualcomm/requirements.txt

--- a/.ci/scripts/test_wheel_package_qnn.sh
+++ b/.ci/scripts/test_wheel_package_qnn.sh
@@ -177,6 +177,9 @@ PY
   "$PIPBIN" install . --no-build-isolation
   popd > /dev/null
 
+  # Install qualcomm backend dependencies  
+  "$PIPBIN" install -r "$REPO_ROOT/backends/qualcomm/requirements.txt"
+
   echo "=== [$LABEL] Import smoke tests ==="
   "$PYBIN" -c "import executorch; print('executorch imported successfully')"
   "$PYBIN" -c "import executorch.backends.qualcomm; print('executorch.backends.qualcomm imported successfully')"

--- a/backends/qualcomm/__init__.py
+++ b/backends/qualcomm/__init__.py
@@ -1,7 +1,9 @@
 import os
 
-from .scripts.download_qnn_sdk import install_qnn_sdk, is_linux_x86, QNN_ZIP_URL
+import cpuinfo
+import torch
 
+from .scripts.download_qnn_sdk import install_qnn_sdk, is_linux_x86, QNN_ZIP_URL
 
 env_flag = os.getenv("EXECUTORCH_BUILDING_WHEEL", "0").lower()
 # If users have preinstalled QNN_SDK_ROOT, we will use it.
@@ -27,3 +29,8 @@ if env_flag not in ("1", "true", "yes"):
                 "       export LD_LIBRARY_PATH="
                 "$QNN_SDK_ROOT/lib/x86_64-linux-clang/:$LD_LIBRARY_PATH"
             )
+
+info = cpuinfo.get_cpu_info()
+vendor = info.get("vendor_id_raw", "").lower()
+if "amd" in vendor:
+    torch.backends.mkldnn.enabled = False

--- a/backends/qualcomm/__init__.py
+++ b/backends/qualcomm/__init__.py
@@ -1,9 +1,19 @@
 import os
 
-import cpuinfo
 import torch
 
 from .scripts.download_qnn_sdk import install_qnn_sdk, is_linux_x86, QNN_ZIP_URL
+
+try:
+    import cpuinfo
+
+    info = cpuinfo.get_cpu_info()
+    vendor = info.get("vendor_id_raw", "").lower()
+    if "amd" in vendor:
+        torch.backends.mkldnn.enabled = False
+except ImportError:
+    raise ImportError("Please install the cpuinfo with pip install py-cpuinfo.")
+
 
 env_flag = os.getenv("EXECUTORCH_BUILDING_WHEEL", "0").lower()
 # If users have preinstalled QNN_SDK_ROOT, we will use it.
@@ -29,8 +39,3 @@ if env_flag not in ("1", "true", "yes"):
                 "       export LD_LIBRARY_PATH="
                 "$QNN_SDK_ROOT/lib/x86_64-linux-clang/:$LD_LIBRARY_PATH"
             )
-
-info = cpuinfo.get_cpu_info()
-vendor = info.get("vendor_id_raw", "").lower()
-if "amd" in vendor:
-    torch.backends.mkldnn.enabled = False

--- a/backends/qualcomm/requirements.txt
+++ b/backends/qualcomm/requirements.txt
@@ -1,0 +1,5 @@
+graphviz
+pydot
+py-cpuinfo
+requests
+tabulate

--- a/backends/qualcomm/scripts/build.sh
+++ b/backends/qualcomm/scripts/build.sh
@@ -7,6 +7,7 @@
 set -e
 
 pip install pydot
+pip install py-cpuinfo
 
 # Check if running on macOS/Darwin
 if [[ "$(uname -s)" == "Darwin" ]]; then

--- a/backends/qualcomm/scripts/build.sh
+++ b/backends/qualcomm/scripts/build.sh
@@ -6,8 +6,7 @@
 # LICENSE file in the root directory of this source tree.
 set -e
 
-pip install pydot
-pip install py-cpuinfo
+pip install -r backends/qualcomm/requirements.txt
 
 # Check if running on macOS/Darwin
 if [[ "$(uname -s)" == "Darwin" ]]; then


### PR DESCRIPTION
### Summary
We noticed that when performing inference with AMD CPU, we will run into `Floating point exception (core dumped)`.
This can be easily reproduced with following lines of code:

**import torch.nn as nn**
**import torch**
**w2_conv = nn.Conv2d(1536, 32, 1, bias=False)**
**x = torch.randn(1,1536,1,32)**
**w2_conv(x)**

Temp solution is to set mkldnn.enabled=False:
**torch.backends.mkldnn.enabled = False**

### Test plan
NA

cc @cccclai @cbilgin