### PR TITLE
[ET-VK] Fix VMA assertion caused by bool return type truncation

### DIFF
--- a/backends/vulkan/runtime/vk_api/memory/Allocator.cpp
+++ b/backends/vulkan/runtime/vk_api/memory/Allocator.cpp
@@ -11,7 +11,8 @@
 namespace vkcompute {
 namespace vkapi {
 
-bool test_host_cached_available(VkPhysicalDevice physical_device) {
+VmaAllocationCreateFlags test_host_cached_available(
+    VkPhysicalDevice physical_device) {
   VkPhysicalDeviceMemoryProperties mem_props;
   vkGetPhysicalDeviceMemoryProperties(physical_device, &mem_props);
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #18105

The `test_host_cached_available` function in Allocator.cpp was introduced in
D95836687 with a `bool` return type, but its return statements return
`VmaAllocationCreateFlags` values (`VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT`
= 0x1000 and `VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT` = 0x800).
The `bool` return type truncates both to `1`, which equals
`VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT` — not a host access flag.

This caused VMA to assert when allocating host-mapped staging buffers because
the allocation had `MAPPED_BIT` + `AUTO_PREFER_HOST` but no host access flag.

Fix the return type from `bool` to `VmaAllocationCreateFlags` so the correct
flag values are preserved.

Differential Revision: [D96151798](https://our.internmc.facebook.com/intern/diff/D96151798/)