### PR TITLE
Adapt threadpool for WASM/Emscripten compatibility

### DIFF
--- a/extension/threadpool/targets.bzl
+++ b/extension/threadpool/targets.bzl
@@ -50,6 +50,7 @@ def define_common_targets():
             "ovr_config//os:windows": [":threadpool_lib"],
             "ovr_config//os:android": [":threadpool_lib"],
             "ovr_config//os:iphoneos": [":threadpool_lib"],
+            "ovr_config//runtime:wasm-emscripten": [":threadpool_lib"],
             # Machines without an operating system shouldn't.
             "ovr_config//os:none": ["//executorch/runtime/kernel:thread_parallel_interface"],
             # If we don't know what it is, disable threadpool out of caution.

--- a/extension/threadpool/threadpool.cpp
+++ b/extension/threadpool/threadpool.cpp
@@ -36,7 +36,7 @@
 
 namespace executorch::extension::threadpool {
 
-#if !(defined(WIN32))
+#if !defined(WIN32) && !defined(__EMSCRIPTEN__)
 namespace {
 // After fork, the child process inherits the data-structures of the parent
 // process' thread-pool, but since those threads don't exist, the thread-pool
@@ -153,7 +153,7 @@ ThreadPool* get_threadpool() {
 
 // Inheriting from old threadpool to get around segfault issue
 // commented above at child_atfork
-#if !(defined(WIN32))
+#if !defined(WIN32) && !defined(__EMSCRIPTEN__)
   // @lint-ignore CLANGTIDY facebook-hte-std::once_flag
   static std::once_flag flag;
   // @lint-ignore CLANGTIDY facebook-hte-std::call_once


### PR DESCRIPTION
Summary:
Disable pthread_atfork-related code in threadpool when building for
Emscripten/WASM, since fork() is not supported in WASM environments.

Reviewed By: GregoryComer

Differential Revision: D94744811


