### PR TITLE
[RELEASE ONLY CHANGES] Install torch, vision and audio RC

### DIFF
--- a/.ci/docker/common/install_pytorch.sh
+++ b/.ci/docker/common/install_pytorch.sh
@@ -17,34 +17,7 @@ install_domains() {
 }
 
 install_pytorch_and_domains() {
-  git clone https://github.com/pytorch/pytorch.git
-
-  # Fetch the target commit
-  pushd pytorch || true
-  git checkout "${TORCH_VERSION}"
-  git submodule update --init --recursive
-
-  chown -R ci-user .
-
-  export _GLIBCXX_USE_CXX11_ABI=1
-  # Then build and install PyTorch
-  conda_run python setup.py bdist_wheel
-  pip_install "$(echo dist/*.whl)"
-
-  # Grab the pinned audio and vision commits from PyTorch
-  TORCHAUDIO_VERSION=release/2.11
-  export TORCHAUDIO_VERSION
-  TORCHVISION_VERSION=release/0.26
-  export TORCHVISION_VERSION
-
-  install_domains
-
-  popd || true
-  # Clean up the cloned PyTorch repo to reduce the Docker image size
-  rm -rf pytorch
-
-  # Print sccache stats for debugging
-  as_ci_user sccache --show-stats
+  pip_install --force-reinstall torch==2.11.0 torchvision==0.26.0 torchaudio==2.11.0 --index-url https://download.pytorch.org/whl/test/cpu
 }
 
 install_pytorch_and_domains

--- a/.ci/docker/common/install_pytorch.sh
+++ b/.ci/docker/common/install_pytorch.sh
@@ -12,8 +12,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/utils.sh"
 
 install_domains() {
   echo "Install torchvision and torchaudio"
-  pip_install --no-build-isolation --user "git+https://github.com/pytorch/audio.git@${TORCHAUDIO_VERSION}"
-  pip_install --no-build-isolation --user "git+https://github.com/pytorch/vision.git@${TORCHVISION_VERSION}"
+  pip_install --force-reinstall torchvision==0.26.0 torchaudio==2.11.0 --index-url https://download.pytorch.org/whl/test/cpu
 }
 
 install_pytorch_and_domains() {

--- a/.ci/docker/common/install_pytorch.sh
+++ b/.ci/docker/common/install_pytorch.sh
@@ -12,11 +12,11 @@ source "$(dirname "${BASH_SOURCE[0]}")/utils.sh"
 
 install_domains() {
   echo "Install torchvision and torchaudio"
-  pip_install --force-reinstall torchvision==0.26.0 torchaudio==2.11.0 --index-url https://download.pytorch.org/whl/test/cpu
+  pip_install --force-reinstall --no-cache-dir torchvision==0.26.0 torchaudio==2.11.0 --index-url https://download.pytorch.org/whl/test/cpu
 }
 
 install_pytorch_and_domains() {
-  pip_install --force-reinstall torch==2.11.0 torchvision==0.26.0 torchaudio==2.11.0 --index-url https://download.pytorch.org/whl/test/cpu
+  pip_install --force-reinstall --no-cache-dir torch==2.11.0 torchvision==0.26.0 torchaudio==2.11.0 --index-url https://download.pytorch.org/whl/test/cpu
 }
 
 install_pytorch_and_domains

--- a/.ci/scripts/utils.sh
+++ b/.ci/scripts/utils.sh
@@ -84,11 +84,11 @@ dedupe_macos_loader_path_rpaths() {
 
 install_domains() {
   echo "Install torchvision and torchaudio"
-  pip install --force-reinstall torchvision==0.26.0 torchaudio==2.11.0 --index-url https://download.pytorch.org/whl/test/cpu
+  pip install --force-reinstall --no-cache-dir torchvision==0.26.0 torchaudio==2.11.0 --index-url https://download.pytorch.org/whl/test/cpu
 }
 
 install_pytorch_and_domains() {
-  pip install --force-reinstall torch==2.11.0 torchvision==0.26.0 torchaudio==2.11.0 --index-url https://download.pytorch.org/whl/test/cpu
+  pip install --force-reinstall --no-cache-dir torch==2.11.0 torchvision==0.26.0 torchaudio==2.11.0 --index-url https://download.pytorch.org/whl/test/cpu
 }
 
 build_executorch_runner_buck2() {

--- a/.ci/scripts/utils.sh
+++ b/.ci/scripts/utils.sh
@@ -89,68 +89,7 @@ install_domains() {
 }
 
 install_pytorch_and_domains() {
-  pushd .ci/docker || return
-  TORCH_VERSION=$(cat ci_commit_pins/pytorch.txt)
-  popd || return
-
-  git clone https://github.com/pytorch/pytorch.git
-
-  # Fetch the target commit
-  pushd pytorch || return
-  git checkout "${TORCH_VERSION}"
-
-  local system_name=$(uname)
-  if [[ "${system_name}" == "Darwin" ]]; then
-    local platform=$(python -c 'import sysconfig; import platform; v=platform.mac_ver()[0].split(".")[0]; platform=sysconfig.get_platform().split("-"); platform[1]=f"{v}_0"; print("_".join(platform))')
-  fi
-  local python_version=$(python -c 'import platform; v=platform.python_version_tuple(); print(f"{v[0]}{v[1]}")')
-  local torch_release=$(cat version.txt)
-  local torch_short_hash=${TORCH_VERSION:0:7}
-  local torch_wheel_path="cached_artifacts/pytorch/executorch/pytorch_wheels/${system_name}/${python_version}"
-  local torch_wheel_name="torch-${torch_release}%2Bgit${torch_short_hash}-cp${python_version}-cp${python_version}-${platform:-}.whl"
-
-  local cached_torch_wheel="https://gha-artifacts.s3.us-east-1.amazonaws.com/${torch_wheel_path}/${torch_wheel_name}"
-  # Cache PyTorch wheel is only needed on MacOS, Linux CI already has this as part
-  # of the Docker image
-  local torch_wheel_not_found=0
-  if [[ "${system_name}" == "Darwin" ]]; then
-    pip install "${cached_torch_wheel}" || torch_wheel_not_found=1
-  else
-    torch_wheel_not_found=1
-  fi
-
-  # Found no such wheel, we will build it from source then
-  if [[ "${torch_wheel_not_found}" == "1" ]]; then
-    echo "No cached wheel found, continue with building PyTorch at ${TORCH_VERSION}"
-
-    git submodule update --init --recursive
-    USE_DISTRIBUTED=1 python setup.py bdist_wheel
-    pip install "$(echo dist/*.whl)"
-
-    # Only AWS runners have access to S3
-    if command -v aws && [[ -z "${GITHUB_RUNNER:-}" ]]; then
-      for wheel_path in dist/*.whl; do
-        local wheel_name=$(basename "${wheel_path}")
-        echo "Caching ${wheel_name}"
-        aws s3 cp "${wheel_path}" "s3://gha-artifacts/${torch_wheel_path}/${wheel_name}"
-      done
-    fi
-  else
-    echo "Use cached wheel at ${cached_torch_wheel}"
-  fi
-
-  dedupe_macos_loader_path_rpaths
-  # Grab the pinned audio and vision commits from PyTorch
-  TORCHAUDIO_VERSION=release/2.11
-  export TORCHAUDIO_VERSION
-  TORCHVISION_VERSION=release/0.26
-  export TORCHVISION_VERSION
-
-  install_domains
-
-  popd || return
-  # Print sccache stats for debugging
-  sccache --show-stats || true
+  pip_install --force-reinstall torch==2.11.0 torchvision==0.26.0 torchaudio==2.11.0 --index-url https://download.pytorch.org/whl/test/cpu
 }
 
 build_executorch_runner_buck2() {

--- a/.ci/scripts/utils.sh
+++ b/.ci/scripts/utils.sh
@@ -84,11 +84,11 @@ dedupe_macos_loader_path_rpaths() {
 
 install_domains() {
   echo "Install torchvision and torchaudio"
-  pip_install --force-reinstall torchvision==0.26.0 torchaudio==2.11.0 --index-url https://download.pytorch.org/whl/test/cpu
+  pip install --force-reinstall torchvision==0.26.0 torchaudio==2.11.0 --index-url https://download.pytorch.org/whl/test/cpu
 }
 
 install_pytorch_and_domains() {
-  pip_install --force-reinstall torch==2.11.0 torchvision==0.26.0 torchaudio==2.11.0 --index-url https://download.pytorch.org/whl/test/cpu
+  pip install --force-reinstall torch==2.11.0 torchvision==0.26.0 torchaudio==2.11.0 --index-url https://download.pytorch.org/whl/test/cpu
 }
 
 build_executorch_runner_buck2() {

--- a/.ci/scripts/utils.sh
+++ b/.ci/scripts/utils.sh
@@ -84,8 +84,7 @@ dedupe_macos_loader_path_rpaths() {
 
 install_domains() {
   echo "Install torchvision and torchaudio"
-  pip install --no-build-isolation --user "git+https://github.com/pytorch/audio.git@${TORCHAUDIO_VERSION}"
-  pip install --no-build-isolation --user "git+https://github.com/pytorch/vision.git@${TORCHVISION_VERSION}"
+  pip_install --force-reinstall torchvision==0.26.0 torchaudio==2.11.0 --index-url https://download.pytorch.org/whl/test/cpu
 }
 
 install_pytorch_and_domains() {


### PR DESCRIPTION
This change switches the release branch to install torch, audio, and vision from their respective release candidates, rather than building.
See PRs https://github.com/pytorch/executorch/pull/16723 and https://github.com/pytorch/executorch/pull/14642 for previous examples.
