### PR TITLE
[RELEASE ONLY CHANGES] Arm backend: Pin ng_model_gym to v0.2.0

### DIFF
--- a/backends/arm/requirements-arm-models-test.txt
+++ b/backends/arm/requirements-arm-models-test.txt
@@ -4,8 +4,8 @@
 # LICENSE file in the root directory of this source tree.
 
 diffusers[torch] @ git+https://github.com/huggingface/diffusers.git@a7cb14efbe4b255f4c8721c91a04f0ef40f4a05a
-# ng_model_gym deps needed by NSS model tests
-pydantic
-slangtorch
-rich
+# ng_model_gym deps needed by NSS model tests since we install ng_model_gym with --no-deps
+pydantic==2.10.4
+slangtorch==1.3.11
+rich==13.9.3
 setuptools==80.10.2

--- a/backends/arm/scripts/install_models_for_test.sh
+++ b/backends/arm/scripts/install_models_for_test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -8,7 +8,7 @@ set -e
 pip install -r backends/arm/requirements-arm-models-test.txt
 
 # Install model gym repository
-git clone https://github.com/arm/neural-graphics-model-gym.git
+git clone --branch v0.2.0 --depth 1 https://github.com/arm/neural-graphics-model-gym.git
 cd neural-graphics-model-gym
 # Remove model-converter installation from model-gym repository (to prevent overwriting executorch version)
 if [[ "$(uname)" == "Darwin" ]]; then


### PR DESCRIPTION
Pin dependencies in backends/arm/requirements-arm-models-test.txt accordingly.
We want to make sure they are kept on a release that works for 1.2

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell