### PR TITLE
Arm backend: Decompose where.ScalarOther for quantization support

### DIFF
--- a/backends/arm/_passes/__init__.py
+++ b/backends/arm/_passes/__init__.py
@@ -94,6 +94,7 @@ from .decompose_tosa_unsupported_clamp_pass import (  # noqa
 from .decompose_tril_pass import DecomposeTrilPass  # noqa
 from .decompose_unfold_to_gather_pass import DecomposeUnfoldToGatherPass  # noqa
 from .decompose_var_pass import DecomposeVarPass  # noqa
+from .decompose_where_scalar_other_pass import DecomposeWhereScalarOtherPass  # noqa
 from .decorate_fp32_to_int32_casting_pass import DecorateFp32toInt32CastingPass  # noqa
 from .fold_qdq_with_annotated_qparams_pass import (  # noqa
     FoldAndAnnotateQParamsPass,

--- a/backends/arm/_passes/arm_pass_manager.py
+++ b/backends/arm/_passes/arm_pass_manager.py
@@ -92,6 +92,7 @@ from executorch.backends.arm._passes import (
     DecomposeTrilPass,
     DecomposeUnfoldToGatherPass,
     DecomposeVarPass,
+    DecomposeWhereScalarOtherPass,
     DecorateFp32toInt32CastingPass,
     FoldAndAnnotateQParamsPass,
     FuseBatchNorm2dPass,
@@ -434,6 +435,7 @@ class ArmPassManager(PassManager):
                 DecomposeRemainderPass(tfa_pass=True),
                 DecomposeFloorDividePass(tfa_pass=True),
                 DecomposeDivTensorModePass(tfa_pass=True),
+                DecomposeWhereScalarOtherPass(tfa_pass=True),
             ]
         )
 

--- a/backends/arm/_passes/decompose_where_scalar_other_pass.py
+++ b/backends/arm/_passes/decompose_where_scalar_other_pass.py
@@ -1,0 +1,64 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Set, Type
+
+from executorch.backends.arm._passes import ArmPass
+from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import ExportPass
+
+
+def _get_where_scalar_other_decomposition(op):
+    """Return the operator overloads used to decompose where.ScalarOther to
+    where.self.
+
+    Raises:
+        RuntimeError: If the provided operator is not supported by this pass.
+
+    """
+    if op is exir_ops.edge.aten.where.ScalarOther:
+        return (
+            exir_ops.edge.aten.full_like.default,
+            exir_ops.edge.aten.where.self,
+        )
+
+    raise RuntimeError(f"Can't get where.ScalarOther decomposition for op {op}")
+
+
+class DecomposeWhereScalarOtherPass(ArmPass):
+    """Decompose where.ScalarOther into where.self with a tensorized scalar."""
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
+
+    _TARGET_OPS = {
+        exir_ops.edge.aten.where.ScalarOther,
+    }
+
+    def call_operator(self, op, args, kwargs, meta, updated=False):
+        if (
+            op not in DecomposeWhereScalarOtherPass._TARGET_OPS
+            or not self.allowed_to_transform(meta)
+        ):
+            return super().call_operator(op, args, kwargs, meta, updated)
+
+        condition, self_tensor, other_scalar = args
+
+        full_like_op, where_op = _get_where_scalar_other_decomposition(op)
+
+        other_tensor = super().call_operator(
+            full_like_op,
+            args=(self_tensor, other_scalar),
+            kwargs={},
+            meta=meta,
+            updated=True,
+        )
+
+        return super().call_operator(
+            where_op,
+            (condition, self_tensor, other_tensor),
+            {},
+            meta,
+            updated=True,
+        )

--- a/backends/arm/test/models/test_T5ForConditionalGeneration_arm.py
+++ b/backends/arm/test/models/test_T5ForConditionalGeneration_arm.py
@@ -37,9 +37,7 @@ class TestT5ForConditionalGeneration:
     }
 
     ops_after_partitioner_INT = {
-        "executorch_exir_dialects_edge__ops_aten_where_self": 3,
         "executorch_exir_dialects_edge__ops_dim_order_ops__to_dim_order_copy_default": 7,
-        "torch.ops.aten.scalar_tensor.default": 3,
         "torch.ops.higher_order.executorch_call_delegate": 3,
     }
 


### PR DESCRIPTION
Arm quantizer does not annotate aten.where.ScalarOther, so where remains unquantized after it is rewritten to aten.where.self pre-QUANTIZE.

Decompose where.ScalarOther(cond, x, s) into where.self(cond, x, full_like(x, s)) before QUANTIZE so existing where.self annotation can handle it.

Change-Id: I82a7ffec5e3e037219ab7185d71371c7c14a5b4f

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell