### PR TITLE
Fix unsafe deserialization in ETRecord and export_serialize

### DIFF
--- a/devtools/etrecord/_etrecord.py
+++ b/devtools/etrecord/_etrecord.py
@@ -746,6 +746,11 @@ def parse_etrecord(etrecord_path: str) -> ETRecord:  # noqa: C901
     graph module in the `ETRecord` object with the name being `the original module name + "/" + the
     name of the entry point`.
 
+    WARNING: This function deserializes reference_outputs and representative_inputs
+    using pickle.loads(), which can execute arbitrary code. Only use this function
+    with ETRecord files from trusted sources. Loading ETRecord files from untrusted
+    sources is a security risk.
+
     Args:
         etrecord_path: Path to the `ETRecord` file.
 
@@ -829,11 +834,17 @@ def parse_etrecord(etrecord_path: str) -> ETRecord:  # noqa: C901
             exported_program = deserialize(serialized_artifact)
         elif entry == ETRecordReservedFileNames.REFERENCE_OUTPUTS:
             # @lint-ignore PYTHONPICKLEISBAD
+            # WARNING: pickle.loads() can execute arbitrary code. This is a known
+            # unsafe deserialization path. Only load ETRecord files from trusted
+            # sources.
             reference_outputs = pickle.loads(
                 etrecord_zip.read(ETRecordReservedFileNames.REFERENCE_OUTPUTS)
             )
         elif entry == ETRecordReservedFileNames.REPRESENTATIVE_INPUTS:
             # @lint-ignore PYTHONPICKLEISBAD
+            # WARNING: pickle.loads() can execute arbitrary code. This is a known
+            # unsafe deserialization path. Only load ETRecord files from trusted
+            # sources.
             representative_inputs = pickle.loads(
                 etrecord_zip.read(ETRecordReservedFileNames.REPRESENTATIVE_INPUTS)
             )

--- a/devtools/etrecord/_etrecord.py
+++ b/devtools/etrecord/_etrecord.py
@@ -6,9 +6,9 @@
 
 # pyre-unsafe
 
+import io
 import json
 import os
-import pickle
 from typing import BinaryIO, Dict, IO, List, Optional, Union
 from zipfile import BadZipFile, ZipFile
 
@@ -228,15 +228,19 @@ class ETRecord:
             )
 
         if self._reference_outputs is not None:
+            buf = io.BytesIO()
+            torch.save(self._reference_outputs, buf)
             etrecord_zip.writestr(
                 ETRecordReservedFileNames.REFERENCE_OUTPUTS,
-                pickle.dumps(self._reference_outputs),
+                buf.getvalue(),
             )
 
         if self._representative_inputs is not None:
+            buf = io.BytesIO()
+            torch.save(self._representative_inputs, buf)
             etrecord_zip.writestr(
                 ETRecordReservedFileNames.REPRESENTATIVE_INPUTS,
-                pickle.dumps(self._representative_inputs),
+                buf.getvalue(),
             )
 
         if self.export_graph_id is not None:
@@ -746,11 +750,6 @@ def parse_etrecord(etrecord_path: str) -> ETRecord:  # noqa: C901
     graph module in the `ETRecord` object with the name being `the original module name + "/" + the
     name of the entry point`.
 
-    WARNING: This function deserializes reference_outputs and representative_inputs
-    using pickle.loads(), which can execute arbitrary code. Only use this function
-    with ETRecord files from trusted sources. Loading ETRecord files from untrusted
-    sources is a security risk.
-
     Args:
         etrecord_path: Path to the `ETRecord` file.
 
@@ -833,21 +832,37 @@ def parse_etrecord(etrecord_path: str) -> ETRecord:  # noqa: C901
             )
             exported_program = deserialize(serialized_artifact)
         elif entry == ETRecordReservedFileNames.REFERENCE_OUTPUTS:
-            # @lint-ignore PYTHONPICKLEISBAD
-            # WARNING: pickle.loads() can execute arbitrary code. This is a known
-            # unsafe deserialization path. Only load ETRecord files from trusted
-            # sources.
-            reference_outputs = pickle.loads(
-                etrecord_zip.read(ETRecordReservedFileNames.REFERENCE_OUTPUTS)
-            )
+            try:
+                reference_outputs = torch.load(
+                    io.BytesIO(
+                        etrecord_zip.read(ETRecordReservedFileNames.REFERENCE_OUTPUTS)
+                    ),
+                    weights_only=True,
+                )
+            except Exception as e:
+                raise RuntimeError(
+                    "Failed to load reference_outputs from ETRecord. "
+                    "This ETRecord file may have been created with an older "
+                    "version that used pickle serialization. Please regenerate "
+                    "the ETRecord file with the current version of ExecuTorch."
+                ) from e
         elif entry == ETRecordReservedFileNames.REPRESENTATIVE_INPUTS:
-            # @lint-ignore PYTHONPICKLEISBAD
-            # WARNING: pickle.loads() can execute arbitrary code. This is a known
-            # unsafe deserialization path. Only load ETRecord files from trusted
-            # sources.
-            representative_inputs = pickle.loads(
-                etrecord_zip.read(ETRecordReservedFileNames.REPRESENTATIVE_INPUTS)
-            )
+            try:
+                representative_inputs = torch.load(
+                    io.BytesIO(
+                        etrecord_zip.read(
+                            ETRecordReservedFileNames.REPRESENTATIVE_INPUTS
+                        )
+                    ),
+                    weights_only=True,
+                )
+            except Exception as e:
+                raise RuntimeError(
+                    "Failed to load representative_inputs from ETRecord. "
+                    "This ETRecord file may have been created with an older "
+                    "version that used pickle serialization. Please regenerate "
+                    "the ETRecord file with the current version of ExecuTorch."
+                ) from e
         elif entry == ETRecordReservedFileNames.EXPORT_GRAPH_ID:
             export_graph_id = json.loads(
                 etrecord_zip.read(ETRecordReservedFileNames.EXPORT_GRAPH_ID)

--- a/exir/serde/export_serialize.py
+++ b/exir/serde/export_serialize.py
@@ -333,7 +333,7 @@ def deserialize_torch_artifact(
         return {}
     buffer = io.BytesIO(serialized)
     buffer.seek(0)
-    artifact = torch.load(buffer)
+    artifact = torch.load(buffer, weights_only=True)
     assert isinstance(artifact, (tuple, dict))
     return artifact
 


### PR DESCRIPTION
Add weights_only=True to torch.load() in deserialize_torch_artifact()
to prevent arbitrary code execution via malicious serialized artifacts.

Replace usages of pickle.dumps and pickle.loads with torch.save and torch.load

As generating and reading etrecord should be done as debugging steps and usually on the same version of et, BC is not a big concern.

This PR was authored with the assistance of Claude.


cc @JacobSzwejbka @angelayi