### PR TITLE
Windows schannel fix

### DIFF
--- a/.github/workflows/_unittest.yml
+++ b/.github/workflows/_unittest.yml
@@ -58,10 +58,11 @@ jobs:
     if: ${{ inputs.build-tool == 'cmake' }}
     uses: pytorch/test-infra/.github/workflows/windows_job.yml@main
     with:
-      submodules: 'recursive'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout: 120
       script: |
+        git config --global http.sslBackend openssl
+        git submodule update --init --recursive 
         conda init powershell
 
         powershell -Command "& {

--- a/.github/workflows/build-presets.yml
+++ b/.github/workflows/build-presets.yml
@@ -113,10 +113,11 @@ jobs:
     with:
       job-name: build
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-      submodules: recursive
       timeout: 90
       script: |
         set -eux
+        git config --global http.sslBackend openssl
+        git submodule update --init --recursive
         conda init powershell
         powershell -Command "& {
           Set-PSDebug -Trace 1

--- a/.github/workflows/cuda-windows.yml
+++ b/.github/workflows/cuda-windows.yml
@@ -127,10 +127,11 @@ jobs:
       runner: windows.g5.4xlarge.nvidia.gpu
       gpu-arch-type: cuda
       gpu-arch-version: 12.8
-      submodules: recursive
       download-artifact: ${{ matrix.model_repo }}-${{ matrix.model_name }}-cuda-windows-${{ matrix.quant }}
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       script: |
+        git config --global http.sslBackend openssl
+        git submodule update --init --recursive
         conda init powershell
         powershell -Command "& {
           Set-PSDebug -Trace 1

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -1123,10 +1123,11 @@ jobs:
         model: [mv3, resnet50, vit, mobilebert, emformer_transcribe]
         backend: [portable, xnnpack-q8]
     with:
-      submodules: 'recursive'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout: 60
       script: |
+        git config --global http.sslBackend openssl
+        git submodule update --init --recursive
         conda init powershell
 
         powershell -Command "& {

--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -22,10 +22,11 @@ jobs:
     name: build-windows-msvc
     uses: pytorch/test-infra/.github/workflows/windows_job.yml@main
     with:
-      submodules: 'recursive'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout: 60
       script: |
+        git config --global http.sslBackend openssl
+        git submodule update --init --recursive
         conda init powershell
         powershell -Command "& {
           Set-PSDebug -Trace 1


### PR DESCRIPTION
Fix for windows build failures,

```
Error: fatal: unable to access 'https://git.gitlab.arm.com/artificial-intelligence/ethos-u/ethos-u-core-driver.git/': schannel: next InitializeSecurityContext failed: SEC_E_ILLEGAL_MESSAGE (0x80090326) - This error usually occurs when a fatal SSL/TLS alert is received (e.g. handshake failed). More detail may be available in the Windows System event log.
```