### PR TITLE
move to ssize_t and keep the >=0 check for conv and kernel_ops

### DIFF
--- a/kernels/portable/cpu/op_convolution.cpp
+++ b/kernels/portable/cpu/op_convolution.cpp
@@ -106,18 +106,18 @@ void conv2d_impl(
           for (const auto w_y : c10::irange(w_H)) {
             w_coord[2] = w_y;
 
-            size_t in_y = stride_y * out_y + dilation_y * w_y - padding_y;
+            ssize_t in_y = stride_y * out_y + dilation_y * w_y - padding_y;
             in_coord[2] = in_y;
             // Only proceed if input y coordinate is within bounds
-            if (in_y < in_H) {
+            if (in_y >= 0 && in_y < in_H) {
               for (const auto w_x : c10::irange(w_W)) {
                 w_coord[3] = w_x;
 
-                size_t in_x = stride_x * out_x + dilation_x * w_x - padding_x;
+                ssize_t in_x = stride_x * out_x + dilation_x * w_x - padding_x;
                 in_coord[3] = in_x;
 
                 // Only proceed if input x coordinate is within bounds
-                if (in_x < in_W) {
+                if (in_x >= 0 && in_x < in_W) {
                   size_t in_idx =
                       calculate_linear_index(in_coord, in_strides.data(), 4);
                   CTYPE in_val = in_ptr[in_idx];
@@ -161,18 +161,18 @@ void conv2d_impl(
           w_coord[0] = in_c;
           for (const auto w_y : c10::irange(w_H)) {
             w_coord[2] = w_y;
-            size_t out_y = stride_y * in_y + dilation_y * w_y - padding_y;
+            ssize_t out_y = stride_y * in_y + dilation_y * w_y - padding_y;
             out_coord[2] = out_y;
 
             // Only proceed if output y coordinate is within bounds
-            if (out_y < out_H) {
+            if (out_y >= 0 && out_y < out_H) {
               for (const auto w_x : c10::irange(w_W)) {
                 w_coord[3] = w_x;
-                size_t out_x = stride_x * in_x + dilation_x * w_x - padding_x;
+                ssize_t out_x = stride_x * in_x + dilation_x * w_x - padding_x;
                 out_coord[3] = out_x;
 
                 // Only proceed if output x coordinate is within bounds
-                if (out_x < out_W) {
+                if (out_x >= 0 && out_x < out_W) {
                   size_t w_idx =
                       calculate_linear_index(w_coord, w_strides.data(), 4);
                   CTYPE w_val = w_ptr[w_idx];

--- a/kernels/portable/cpu/util/kernel_ops_util.h
+++ b/kernels/portable/cpu/util/kernel_ops_util.h
@@ -218,7 +218,7 @@ void kernel_reduction_then_map_2d(
         int64_t padding_y = p_H;
         int64_t dilation_y = d_H;
 
-        size_t in_y = stride_y * out_y + dilation_y * w_y - padding_y;
+        ssize_t in_y = stride_y * out_y + dilation_y * w_y - padding_y;
         in_coord[in_dim - 2] = in_y;
 
         for (const auto w_x : c10::irange(k_W)) {
@@ -226,11 +226,11 @@ void kernel_reduction_then_map_2d(
           int64_t padding_x = p_W;
           int64_t dilation_x = d_W;
 
-          size_t in_x = stride_x * out_x + dilation_x * w_x - padding_x;
+          ssize_t in_x = stride_x * out_x + dilation_x * w_x - padding_x;
           in_coord[in_dim - 1] = in_x;
 
-          const bool x_in_bound = (in_x < in_W);
-          const bool y_in_bound = (in_y < in_H);
+          const bool x_in_bound = (in_x >= 0 && in_x < in_W);
+          const bool y_in_bound = (in_y >= 0 && in_y < in_H);
           const bool xy_in_bound = (x_in_bound && y_in_bound);
 
           CTYPE in_val = 0;


### PR DESCRIPTION
Summary:
Original code used unsigned for the bounds check with a "redundant" >= 0 check.

This diff restores the >=0 but switches the variable(s) being check to ssize_t

This allows for clean check when:

stride_y * out_y + dilation_y * w_y < padding_y

Previously, we were likely wrapping around and so still succeeding at:

in_y < in_H

because in_y underflows and becomes quite large.

Differential Revision: D96322425


