### PR TITLE
cast bounds check to ssize_t (#18162)

### DIFF
--- a/kernels/portable/cpu/op_convolution.cpp
+++ b/kernels/portable/cpu/op_convolution.cpp
@@ -109,7 +109,7 @@ void conv2d_impl(
             ssize_t in_y = stride_y * out_y + dilation_y * w_y - padding_y;
             in_coord[2] = in_y;
             // Only proceed if input y coordinate is within bounds
-            if (in_y >= 0 && in_y < in_H) {
+            if (in_y >= 0 && in_y < static_cast<ssize_t>(in_H)) {
               for (const auto w_x : c10::irange(w_W)) {
                 w_coord[3] = w_x;
 
@@ -117,7 +117,7 @@ void conv2d_impl(
                 in_coord[3] = in_x;
 
                 // Only proceed if input x coordinate is within bounds
-                if (in_x >= 0 && in_x < in_W) {
+                if (in_x >= 0 && in_x < static_cast<ssize_t>(in_W)) {
                   size_t in_idx =
                       calculate_linear_index(in_coord, in_strides.data(), 4);
                   CTYPE in_val = in_ptr[in_idx];
@@ -165,14 +165,14 @@ void conv2d_impl(
             out_coord[2] = out_y;
 
             // Only proceed if output y coordinate is within bounds
-            if (out_y >= 0 && out_y < out_H) {
+            if (out_y >= 0 && out_y < static_cast<ssize_t>(out_H)) {
               for (const auto w_x : c10::irange(w_W)) {
                 w_coord[3] = w_x;
                 ssize_t out_x = stride_x * in_x + dilation_x * w_x - padding_x;
                 out_coord[3] = out_x;
 
                 // Only proceed if output x coordinate is within bounds
-                if (out_x >= 0 && out_x < out_W) {
+                if (out_x >= 0 && out_x < static_cast<ssize_t>(out_W)) {
                   size_t w_idx =
                       calculate_linear_index(w_coord, w_strides.data(), 4);
                   CTYPE w_val = w_ptr[w_idx];

--- a/kernels/portable/cpu/util/kernel_ops_util.h
+++ b/kernels/portable/cpu/util/kernel_ops_util.h
@@ -229,8 +229,10 @@ void kernel_reduction_then_map_2d(
           ssize_t in_x = stride_x * out_x + dilation_x * w_x - padding_x;
           in_coord[in_dim - 1] = in_x;
 
-          const bool x_in_bound = (in_x >= 0 && in_x < in_W);
-          const bool y_in_bound = (in_y >= 0 && in_y < in_H);
+          const bool x_in_bound =
+              (in_x >= 0 && in_x < static_cast<ssize_t>(in_W));
+          const bool y_in_bound =
+              (in_y >= 0 && in_y < static_cast<ssize_t>(in_H));
           const bool xy_in_bound = (x_in_bound && y_in_bound);
 
           CTYPE in_val = 0;


### PR DESCRIPTION
Summary:

We are keeping the dimension size themselves size_t, since they are dimensions and should be nonnegative.

cast in the check itselft

Differential Revision: D96500399


