### PR TITLE
fix linear bias decomposition invokation

### DIFF
--- a/examples/models/parakeet/export_parakeet_tdt.py
+++ b/examples/models/parakeet/export_parakeet_tdt.py
@@ -509,12 +509,10 @@ def _create_metal_partitioners(programs):
 
     # Run decompositions for non-preprocessor programs
     updated_programs = {}
+    decomp_table = torch.export.default_decompositions()
+    decomp_table[torch.ops.aten.linear.default] = _linear_bias_decomposition
     for key, ep in programs.items():
-        # print(f"Running decompositions for {key}")
-        # print(ep.graph_module)
         if key != "preprocessor":
-            decomp_table = torch.export.default_decompositions()
-            decomp_table[torch.ops.aten.linear.default] = _linear_bias_decomposition
             updated_programs[key] = ep.run_decompositions(decomp_table)
         else:
             updated_programs[key] = ep

--- a/examples/models/parakeet/export_parakeet_tdt.py
+++ b/examples/models/parakeet/export_parakeet_tdt.py
@@ -513,9 +513,9 @@ def _create_metal_partitioners(programs):
         # print(f"Running decompositions for {key}")
         # print(ep.graph_module)
         if key != "preprocessor":
-            updated_programs[key] = ep.run_decompositions(
-                {torch.ops.aten.linear.default: _linear_bias_decomposition}
-            )
+            decomp_table = torch.export.default_decompositions()
+            decomp_table[torch.ops.aten.linear.default] = _linear_bias_decomposition
+            updated_programs[key] = ep.run_decompositions(decomp_table)
         else:
             updated_programs[key] = ep
 

--- a/examples/models/voxtral_realtime/export_voxtral_rt.py
+++ b/examples/models/voxtral_realtime/export_voxtral_rt.py
@@ -394,9 +394,9 @@ def lower_to_executorch(programs, metadata, backend="xnnpack"):
 
         # Run decompositions for Metal backend
         updated_programs = {}
+        decomp_table = torch.export.default_decompositions()
+        decomp_table[torch.ops.aten.linear.default] = _linear_bias_decomposition
         for key, ep in programs.items():
-            decomp_table = torch.export.default_decompositions()
-            decomp_table[torch.ops.aten.linear.default] = _linear_bias_decomposition
             updated_programs[key] = ep.run_decompositions(decomp_table)
         programs = updated_programs
 

--- a/examples/models/voxtral_realtime/export_voxtral_rt.py
+++ b/examples/models/voxtral_realtime/export_voxtral_rt.py
@@ -395,9 +395,9 @@ def lower_to_executorch(programs, metadata, backend="xnnpack"):
         # Run decompositions for Metal backend
         updated_programs = {}
         for key, ep in programs.items():
-            updated_programs[key] = ep.run_decompositions(
-                {torch.ops.aten.linear.default: _linear_bias_decomposition}
-            )
+            decomp_table = torch.export.default_decompositions()
+            decomp_table[torch.ops.aten.linear.default] = _linear_bias_decomposition
+            updated_programs[key] = ep.run_decompositions(decomp_table)
         programs = updated_programs
 
         partitioner = {}


### PR DESCRIPTION
Fix parakeet/voxtral realtime export using PyTorch release. In both `export_parakeet_tdt.py` and `export_voxtral_rt.py`, replaced the manual decomposition dictionary with `torch.export.default_decompositions()` and added the custom `_linear_bias_decomposition` for `torch.ops.aten.linear.default`.
