### PR TITLE
[ET-VK][testing] Add Skycastle GPU host test workflow via ECOD

### DIFF
--- a/backends/vulkan/test/custom_ops/q4gsw_linear.cpp
+++ b/backends/vulkan/test/custom_ops/q4gsw_linear.cpp
@@ -499,13 +499,6 @@ void reference_impl(TestCase& test_case) {
 }
 
 int64_t quantized_linear_flop_calculator(const TestCase& test_case) {
-  int input_idx = 0;
-  int weight_idx = 1;
-  if (test_case.operator_name().find("dq8ca") != std::string::npos) {
-    input_idx = 0;
-    weight_idx = 3; // Weight comes after input, input_scale, input_zero_point
-  }
-
   // Get input and weight dimensions
   const auto& input_sizes = test_case.inputs()[0].get_tensor_sizes();
   const auto& output_sizes = test_case.outputs()[0].get_tensor_sizes();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #18174
* __->__ #18173

Create a new Skycastle workflow that mirrors the existing eureka Android device
test workflow but runs on an ECOD NEUTRON_NVIDIA_A10M Linux VM with an NVIDIA
GPU. This enables testing the Vulkan backend on real NVIDIA hardware in CI.

New files:
- gpu_host_utils.sky: Utility functions for ECOD GPU host interaction
  (reserve, upload, ssh, release), analogous to riot_utils.sky but using
  ecod CLI instead of adb.
- executorch_vulkan_gpu_unit_tests.sky: Main workflow (etvk-gpu-host-tests)
  that exports models, reserves an ECOD GPU VM, runs all tests (gtest
  binaries, llama runner, classification, greenscreen, scenex, skin seg),
  and releases the VM.

Modified files:
- executorch_vulkan_test_utils.sky: Added build_target_for_host() to build
  test binaries for x86_64 Linux host (no Android cross-compilation).

Differential Revision: [D96233257](https://our.internmc.facebook.com/intern/diff/D96233257/)