### PR TITLE
Suppress PytestCollectionWarning for non-test classes

### DIFF
--- a/backends/test/suite/reporting.py
+++ b/backends/test/suite/reporting.py
@@ -58,8 +58,9 @@ OP_COUNT_IGNORED_OPS = {
 
 
 class TestResult(IntEnum):
-    __test__ = False
     """Represents the result of a test case run, indicating success or a specific failure reason."""
+
+    __test__ = False
 
     SUCCESS = 0
     """ The test succeeded with the backend delegate part or all of the graph. """
@@ -152,10 +153,11 @@ class TestResult(IntEnum):
 
 @dataclass
 class TestCaseSummary:
-    __test__ = False
     """
     Contains summary results for the execution of a single test case.
     """
+
+    __test__ = False
 
     backend: str
     """ The name of the target backend. """

--- a/backends/test/suite/reporting.py
+++ b/backends/test/suite/reporting.py
@@ -58,6 +58,7 @@ OP_COUNT_IGNORED_OPS = {
 
 
 class TestResult(IntEnum):
+    __test__ = False
     """Represents the result of a test case run, indicating success or a specific failure reason."""
 
     SUCCESS = 0
@@ -151,6 +152,7 @@ class TestResult(IntEnum):
 
 @dataclass
 class TestCaseSummary:
+    __test__ = False
     """
     Contains summary results for the execution of a single test case.
     """
@@ -210,6 +212,8 @@ class TestCaseSummary:
 
 @dataclass
 class TestSessionState:
+    __test__ = False
+
     seed: int
 
     # True if the CSV header has been written to report__path.

--- a/backends/xnnpack/test/tester/tester.py
+++ b/backends/xnnpack/test/tester/tester.py
@@ -102,6 +102,8 @@ class ToExecutorch(BaseStages.ToExecutorch):
 
 
 class Tester(TesterBase):
+    __test__ = False
+
     def __init__(
         self,
         module: torch.nn.Module,

--- a/exir/tests/test_prune_empty_tensors_pass.py
+++ b/exir/tests/test_prune_empty_tensors_pass.py
@@ -15,6 +15,8 @@ from executorch.exir.passes import MemoryPlanningPass
 
 
 class TestCat(nn.Module):
+    __test__ = False
+
     def forward(self, x, y, z):
         empty = torch.empty((0, 6))
         return torch.cat([empty, x, empty, y, z, empty])

--- a/exir/tests/test_remove_view_copy.py
+++ b/exir/tests/test_remove_view_copy.py
@@ -15,6 +15,8 @@ from executorch.exir.passes import MemoryPlanningPass
 
 
 class TestModel1(nn.Module):
+    __test__ = False
+
     def __init__(self):
         super().__init__()
         self.parameter = nn.Parameter(torch.rand(5, 6))


### PR DESCRIPTION
Fixes #18175

Added `__test__ = False` to non-test classes that pytest was incorrectly trying to collect as test classes, causing pages of PytestCollectionWarning output.

Classes fixed:
- `TestResult`, `TestCaseSummary`, `TestSessionState` in `backends/test/suite/reporting.py`
- `Tester` in `backends/xnnpack/test/tester/tester.py`
- `TestCat` in `exir/tests/test_prune_empty_tensors_pass.py`
- `TestModel1` in `exir/tests/test_remove_view_copy.py`

### Test plan
Ran `pytest --collect-only` before and after the changes. Before: multiple PytestCollectionWarning lines for each of these classes. After: 0 warnings found.

To verify:
```bash
pytest --collect-only 2>&1 | python -c "import sys; lines=[l for l in sys.stdin if 'PytestCollectionWarning' in l]; print(f'{len(lines)} warnings found')"
