### PR TITLE
Cortex-M Backend: Skip while_loop test

### DIFF
--- a/backends/cortex_m/test/misc/test_portable_int8.py
+++ b/backends/cortex_m/test/misc/test_portable_int8.py
@@ -683,7 +683,13 @@ xfails = {
 }
 
 
-@parametrize("op_case", OP_CASES, xfails=xfails, strict=False)
+@parametrize(
+    "op_case",
+    OP_CASES,
+    xfails=xfails,
+    strict=False,
+    skips={"while_loop": "Has been observed to hang randomly."},
+)
 def test_shared_qspec_portable_int8_ops(op_case: OpCase) -> None:
     tester = CortexMTester(op_case.module, op_case.example_inputs)
     tester.test_dialect(ops_before_transforms={}, ops_after_transforms={})


### PR DESCRIPTION
It has been observed to hang randomly.
Likely, the random input causes the quantizatized
while loop to never finish in some cases.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell