### PR TITLE
Arm backend: Fix slice_scatter decomposition

### DIFF
--- a/backends/arm/_passes/decompose_slice_scatter_pass.py
+++ b/backends/arm/_passes/decompose_slice_scatter_pass.py
@@ -41,12 +41,16 @@ def _get_slice_scatter_decomposition(op) -> tuple:
 
 def _fixup_start(start, dim_size: int) -> int:
     s = 0 if start is None else int(start)
-    return max(0, min(s % dim_size if s < 0 else s, dim_size))
+    if s < 0:
+        s += dim_size
+    return max(0, min(s, dim_size))
 
 
 def _fixup_end(end, dim_size: int) -> int:
     e = dim_size if end is None else int(end)
-    return max(0, min(e % dim_size if e < 0 else e, dim_size))
+    if e < 0:
+        e += dim_size
+    return max(0, min(e, dim_size))
 
 
 class DecomposeSliceScatterPass(ArmPass):
@@ -131,31 +135,34 @@ class DecomposeSliceScatterPass(ArmPass):
 
         # ---- fast path: contiguous update (step == 1) ----
         if step == 1:
-            # prefix = input[..., :start_i, ...] along dim_norm
-            prefix = super().call_operator(
-                slice_copy_op,
-                (input, dim_norm, 0, start_i, 1),
-                {},
-                meta,
-                updated=True,
+            prefix = None
+            suffix = None
+
+            # prefix = input[..., :start_i, ...] along dim_norm (only if non-empty)
+            if start_i > 0:
+                prefix = super().call_operator(
+                    slice_copy_op,
+                    (input, dim_norm, 0, start_i, 1),
+                    {},
+                    meta,
+                    updated=True,
+                )
+
+            # suffix = input[..., end_i:, ...] along dim_norm (only if non-empty)
+            if end_i < dim_size:
+                suffix = super().call_operator(
+                    slice_copy_op,
+                    (input, dim_norm, end_i, dim_size, 1),
+                    {},
+                    meta,
+                    updated=True,
+                )
+
+            parts = [x for x in (prefix, src, suffix) if x is not None]
+
+            return super().call_operator(
+                cat_op, (parts, dim_norm), {}, meta, updated=True
             )
-            # suffix = input[..., end_i:, ...] along dim_norm
-            suffix = super().call_operator(
-                slice_copy_op,
-                (input, dim_norm, end_i, dim_size, 1),
-                {},
-                meta,
-                updated=True,
-            )
-            # concat(prefix, src, suffix) along dim_norm
-            updated = super().call_operator(
-                cat_op,
-                ([prefix, src, suffix], dim_norm),
-                {},
-                meta,
-                updated=True,
-            )
-            return updated
 
         # ---- general path: strided update (step > 1) ----
         # Move updated dim to front to use a single index tensor.

--- a/backends/arm/test/ops/test_slice_scatter.py
+++ b/backends/arm/test/ops/test_slice_scatter.py
@@ -26,6 +26,33 @@ test_data_fp_step1 = {
         7,
         1,
     ),
+    # Covers empty-prefix slice in DecomposeSliceScatter fast path (start_i == 0)
+    "rank2_prefix_empty": lambda: (
+        torch.rand((5, 9), dtype=torch.float32),
+        torch.rand((5, 5), dtype=torch.float32),
+        1,
+        0,
+        5,
+        1,
+    ),
+    # Covers empty-suffix slice in DecomposeSliceScatter fast path (end_i == dim_size via end=None)
+    "rank2_suffix_empty_end_none": lambda: (
+        torch.rand((5, 9), dtype=torch.float32),
+        torch.rand((5, 5), dtype=torch.float32),
+        1,
+        4,
+        None,
+        1,
+    ),
+    # Covers “big negative start” correctness: start < -dim_size should clamp to 0 (not modulo wrap)
+    "rank3_big_negative_start": lambda: (
+        torch.rand((2, 8, 4), dtype=torch.float32),
+        torch.rand((2, 5, 4), dtype=torch.float32),
+        1,
+        -999,
+        5,
+        1,
+    ),
     "rank4_negative": lambda: (
         torch.rand((1, 2, 4, 5), dtype=torch.float32),
         torch.rand((1, 2, 2, 5), dtype=torch.float32),
@@ -62,6 +89,24 @@ test_data_int_step1 = {
         1,
         2,
         7,
+        1,
+    ),
+    # Empty-prefix fast path for int8 (start_i == 0)
+    "rank2_prefix_empty_int8": lambda: (
+        torch.randint(-5, 5, (5, 9), dtype=torch.int8),
+        torch.randint(-5, 5, (5, 5), dtype=torch.int8),
+        1,
+        0,
+        5,
+        1,
+    ),
+    # Empty-suffix fast path for int8 (end=None => end_i == dim_size)
+    "rank2_suffix_empty_end_none_int8": lambda: (
+        torch.randint(-5, 5, (5, 9), dtype=torch.int8),
+        torch.randint(-5, 5, (5, 5), dtype=torch.int8),
+        1,
+        4,
+        None,
         1,
     ),
 }
@@ -221,6 +266,8 @@ def test_slice_scatter_u85_INT_stepN(test_module: input_t):
     test_data_int_step1 | test_data_int_stepN | test_data_fp_step1 | test_data_fp_stepN,
     xfails={
         "rank2_step1_int8": "MLETORCH-1823: Fix quantized-node detection",
+        "rank2_prefix_empty_int8": "MLETORCH-1823: Fix quantized-node detection",
+        "rank2_suffix_empty_end_none_int8": "MLETORCH-1823: Fix quantized-node detection",
         "rank3_step2_int32": "MLETORCH-1823: Fix quantized-node detection",
     },
 )


### PR DESCRIPTION
- Avoid emitting zero-length slice_copy for empty prefix/suffix in step==1
- Clamp start/end to match Python slicing semantics

Change-Id: Ied768aa69b49b3ac9bed35acc2a61648fb051d04


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell