### PR TITLE
Add quantized_batch_matmul to OPERATORS list

### DIFF
--- a/backends/cortex_m/ops/targets.bzl
+++ b/backends/cortex_m/ops/targets.bzl
@@ -68,6 +68,7 @@ OPERATORS = [
     "quantized_depthwise_conv2d",
     "quantized_transpose_conv2d",
     "quantized_avg_pool2d",
+    "quantized_batch_matmul",
     "quantized_max_pool2d",
 ]
 


### PR DESCRIPTION
Summary:
op_quantized_batch_matmul.cpp has a complete CMSIS-NN implementation of cortex_m::native::quantized_batch_matmul_out (using arm_batch_matmul_s8), but "quantized_batch_matmul" was missing from the OPERATORS list in targets.bzl.

Without it, define_operator_target("quantized_batch_matmul") was never called, so no :op_quantized_batch_matmul Buck target was created. cortex_m_operators exports all_op_targets using [":op_{}".format(op) for op in OPERATORS], so the operator was never included as a dependency.

executorch_generated_lib reads operators.yaml (which correctly declares cortex_m::quantized_batch_matmul.out) and generates RegisterCodegenUnboxedKernelsEverything.cpp, which calls cortex_m::native::quantized_batch_matmul_out. Since the compiled implementation was not linked in, ARM builds failed:
  undefined reference to cortex_m::native::quantized_batch_matmul_out

Fix: add "quantized_batch_matmul" to OPERATORS in both targets.bzl mirrors (xplat and fbcode). This creates the missing :op_quantized_batch_matmul Buck target, includes it in cortex_m_operators, and allows cortex_m_generated_lib and cortex_m_no_except_generated_lib to link successfully.

Differential Revision: D96686225


