### PR TITLE
NXP backend: Update eiq-neutron-sdk to 3.0.1

### DIFF
--- a/backends/nxp/requirements-eiq.txt
+++ b/backends/nxp/requirements-eiq.txt
@@ -1,3 +1,3 @@
 --index-url https://eiq.nxp.com/repository
-eiq-neutron-sdk==3.0.0
+eiq-neutron-sdk==3.0.1
 eiq_nsys

--- a/backends/nxp/tests/ir/converter/node_converter/test_constant_pad_nd_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_constant_pad_nd_converter.py
@@ -191,6 +191,7 @@ def test_constant_pad_nd__delegation__formatless__unsupported_padding(use_qat):
     )
 
 
+@pytest.mark.xfail(reason="Regression in Neutron SW 3.0.1 (AIR-14264)", strict=True)
 def test_constant_pad_nd__delegation__channels_first__supported_padding(use_qat):
     input_shape = (2, 4, 6, 8)  # Channels first -> the second dim (4) will be padded.
     paddings = [1, 2, 3, 4, 0, 0]  # The second dim is padded using the paddings[4:6].

--- a/backends/nxp/tests/ir/converter/node_converter/test_conv_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_conv_converter.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025 NXP
+# Copyright 2024-2026 NXP
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -83,18 +83,7 @@ def test_conv1d_quant_conversion(bias, stride, dilation, kernel_size, mocker, us
 
 @pytest.mark.parametrize("stride", [1, 2])
 @pytest.mark.parametrize("dilation", [2, 1])
-@pytest.mark.parametrize(
-    "kernel_size",
-    [
-        pytest.param(
-            (1,),
-            marks=pytest.mark.xfail(
-                reason="Regression in Neutron SW 2.1.x (AIR-13336)", strict=True
-            ),
-        ),
-        (3,),
-    ],
-)
+@pytest.mark.parametrize("kernel_size", [(1,), (3,)])
 @pytest.mark.parametrize("padding", [(1,), 2])
 def test_conv1d_quant_conversion__padded(
     stride, dilation, kernel_size, padding, mocker, use_qat
@@ -201,18 +190,7 @@ def test_conv1d_quant_conversion__depthwise(
 
 @pytest.mark.parametrize("stride", [1, 2])
 @pytest.mark.parametrize("dilation", [2, 1])
-@pytest.mark.parametrize(
-    "kernel_size",
-    [
-        pytest.param(
-            (1,),
-            marks=pytest.mark.xfail(
-                reason="Regression in Neutron SW 2.1.x (AIR-13336)", strict=True
-            ),
-        ),
-        (3,),
-    ],
-)
+@pytest.mark.parametrize("kernel_size", [(1,), (3,)])
 @pytest.mark.parametrize("padding", [(1,), 2])
 def test_conv1d_quant_conversion__depthwise__padded(
     stride, dilation, kernel_size, padding, mocker, use_qat

--- a/backends/nxp/tests/test_context_sensitive_delegation.py
+++ b/backends/nxp/tests/test_context_sensitive_delegation.py
@@ -172,7 +172,7 @@ def test_noop_partitions__add_mul_sub_div__forced_delegation():
 
     with pytest.raises(
         RuntimeError,
-        match="Model converted with neutron-converter has `2` operators instead of `1`.",
+        match="Model converted with neutron-converter does not contain a NeutronGraph node.",
     ):
         to_quantized_edge_program(
             module, input_shape, custom_delegation_options=cdo

--- a/examples/nxp/setup.sh
+++ b/examples/nxp/setup.sh
@@ -8,7 +8,7 @@ set -u
 EIQ_PYPI_URL="${EIQ_PYPI_URL:-https://eiq.nxp.com/repository}"
 
 # Install eIQ Neutron dependencies - SDK and simulator
-pip install --index-url ${EIQ_PYPI_URL} eiq-neutron-sdk==3.0.0 eiq_nsys
+pip install --index-url ${EIQ_PYPI_URL} eiq-neutron-sdk==3.0.1 eiq_nsys
 
 # Get the directory of the current script
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
### Summary
Update eiq-neutron-sdk to 3.0.1

### Test plan
Covered by existing unit-tests

cc @JakeStevens @digantdesai