### PR TITLE
Qualcomm AI Engine Direct - CMake fix for direct mode

### DIFF
--- a/backends/qualcomm/scripts/build.sh
+++ b/backends/qualcomm/scripts/build.sh
@@ -127,6 +127,13 @@ if [ "$BUILD_ANDROID" = true ]; then
 
     # DSP_TYPE variable only matters when building direct_mode.
     # Ignore the variable for traditional mode. 
+
+    if [ "$BUILD_HEXAGON" = "true" ]; then
+        DIRECT_MODE_FLAG="-DBUILD_DIRECT_MODE=ON"
+    else
+        DIRECT_MODE_FLAG="-DBUILD_DIRECT_MODE=OFF"
+    fi
+
     cmake $PRJ_ROOT/$EXAMPLE_ROOT \
         -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK_ROOT/build/cmake/android.toolchain.cmake \
         -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
@@ -140,6 +147,7 @@ if [ "$BUILD_ANDROID" = true ]; then
         -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH \
         -DPYTHON_EXECUTABLE=$PYTHON_EXECUTABLE \
         -DDSP_TYPE=$DSP_TYPE \
+        $DIRECT_MODE_FLAG \
         -B$EXAMPLE_ROOT
 
     cmake --build $EXAMPLE_ROOT -j$BUILD_JOB_NUMBER

--- a/examples/qualcomm/CMakeLists.txt
+++ b/examples/qualcomm/CMakeLists.txt
@@ -89,6 +89,7 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/qaihub_scripts/stable_diffusion)
 # direct-mode qnn_executor_direct_runner is build with ndk toolchain, paired
 # with libraries built with hexagon toolchain, communicate through self-defined
 # fastrpc protocol.
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64" AND DEFINED ENV{HEXAGON_SDK_ROOT})
+option(BUILD_DIRECT_MODE "Build direct mode executor runner" OFF)
+if(BUILD_DIRECT_MODE)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/direct_executor_runner)
 endif()


### PR DESCRIPTION
### Summary
- Android build fails when HEXAGON_SDK_ROOT is set to Hexagon SDK 5.4.0 and the user runs `./backends/qualcomm/scripts/build.sh` (without --enable_hexagon).

- `examples/qualcomm/CMakeLists.txt` conditionally includes `direct_executor_runner` based solely on whether `HEXAGON_SDK_ROOT` is set in the environment and `CMAKE_SYSTEM_PROCESSOR` matches `aarch64`.  So for android build, a user with `HEXAGON_SDK_ROOT` set will inadvertently trigger the direct mode executor runner build, regardless of whether `--enable_hexagon` was passed to build.sh.

- `direct_executor_runner/CMakeLists.txt` then tries to invoke `${HEXAGON_SDK_ROOT}/ipc/fastrpc/qaic/Ubuntu/qaic` path that doesn't exist in Hexagon SDK 5.4.0, causing the build to fail.

- This fix adds a cmake flag `BUILD_DIRECT_MODE` to ensure `direct_executor_runner` is correctly guarded.

### Test plan
N/A
