### PR TITLE
Metal CI: isolate Inductor cache and precompiled headers per job

### DIFF
--- a/.github/workflows/metal.yml
+++ b/.github/workflows/metal.yml
@@ -113,7 +113,8 @@ jobs:
 
         # Isolate Inductor cache per job to prevent PCH mtime conflicts between
         # parallel matrix jobs running on the same runner.
-        export TORCHINDUCTOR_CACHE_DIR="${RUNNER_TEMP}/inductor_cache"
+        INDUCTOR_CACHE_DIR=$(mktemp -d "${RUNNER_TEMP}/inductor_cache_XXXXXX")
+        export TORCHINDUCTOR_CACHE_DIR="${INDUCTOR_CACHE_DIR}"
         ${CONDA_RUN} bash .ci/scripts/export_model_artifact.sh metal "${{ matrix.model.repo }}/${{ matrix.model.name }}" "${{ matrix.quant }}" "${RUNNER_ARTIFACT_DIR}"
 
   test-model-metal-e2e:

--- a/.github/workflows/metal.yml
+++ b/.github/workflows/metal.yml
@@ -111,10 +111,12 @@ jobs:
         ${CONDA_RUN} pip list
         echo "::endgroup::"
 
-        # Isolate Inductor cache per job to prevent PCH mtime conflicts between
-        # parallel matrix jobs running on the same runner.
-        INDUCTOR_CACHE_DIR=$(mktemp -d "${RUNNER_TEMP}/inductor_cache_XXXXXX")
-        export TORCHINDUCTOR_CACHE_DIR="${INDUCTOR_CACHE_DIR}"
+        # Isolate Inductor cache and precompiled headers (PCH) per job to prevent
+        # PCH mtime conflicts between parallel matrix jobs on the same runner.
+        # TORCHINDUCTOR_CACHE_DIR isolates the code cache; setting TMPDIR isolates
+        # the PCH dir, which PyTorch derives from tempfile.gettempdir() independently.
+        export TMPDIR=$(mktemp -d "${RUNNER_TEMP}/tmpdir_XXXXXX")
+        export TORCHINDUCTOR_CACHE_DIR=$(mktemp -d "${RUNNER_TEMP}/inductor_cache_XXXXXX")
         ${CONDA_RUN} bash .ci/scripts/export_model_artifact.sh metal "${{ matrix.model.repo }}/${{ matrix.model.name }}" "${{ matrix.quant }}" "${RUNNER_ARTIFACT_DIR}"
 
   test-model-metal-e2e:

--- a/.github/workflows/metal.yml
+++ b/.github/workflows/metal.yml
@@ -111,6 +111,9 @@ jobs:
         ${CONDA_RUN} pip list
         echo "::endgroup::"
 
+        # Isolate Inductor cache per job to prevent PCH mtime conflicts between
+        # parallel matrix jobs running on the same runner.
+        export TORCHINDUCTOR_CACHE_DIR="${RUNNER_TEMP}/inductor_cache"
         ${CONDA_RUN} bash .ci/scripts/export_model_artifact.sh metal "${{ matrix.model.repo }}/${{ matrix.model.name }}" "${{ matrix.quant }}" "${RUNNER_ARTIFACT_DIR}"
 
   test-model-metal-e2e:


### PR DESCRIPTION
  Parallel matrix jobs in the Metal export workflow share the same macOS runner and the same user account (ec2-user). This causes a subtle PCH    
  mtime conflict:                                           

  1. Each job installs its own conda environment under $RUNNER_TEMP at a slightly different wall-clock time, giving shared headers (e.g. mps.h)
  different mtimes across jobs.
  2. PyTorch stores precompiled headers (PCH) in tempfile.gettempdir() + "/torchinductor_<username>" — a path derived from the system temp dir and
   the username, shared by all parallel jobs on the same runner.
  3. Job B finds a PCH built by Job A but the mtime of the underlying header has changed (different conda env install time), causing a fatal
  compile error:

  fatal error: file '...mps.h' has been modified since the precompiled header '...h.pch' was built: mtime changed

  Fix: export both TMPDIR and TORCHINDUCTOR_CACHE_DIR to unique per-job directories (created with mktemp -d) before running the export step.

  - TORCHINDUCTOR_CACHE_DIR isolates the compiled code/kernel cache.
  - TMPDIR isolates the PCH cache: Python's tempfile.gettempdir() checks TMPDIR first, so the PCH lands at
  $TMPDIR/torchinductor_ec2-user/precompiled_headers/ — a path unique to each job. conda run inherits exported env vars, so the isolation applies
  to the entire export pipeline.

  Both directories are created under $RUNNER_TEMP so they are cleaned up with the runner workspace after the job completes.
