### PR TITLE
Upgrade aws-actions/configure-aws-credentials from v1.7.0 to v4

### DIFF
--- a/.github/workflows/android-release-artifacts.yml
+++ b/.github/workflows/android-release-artifacts.yml
@@ -165,7 +165,7 @@ jobs:
       contents: read
     steps:
       - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v1.7.0
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::308535385114:role/gha_executorch_upload-frameworks-android
           aws-region: us-east-1

--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -239,7 +239,7 @@ jobs:
           python-version: '3.11'
           cache: pip
       - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v1.7.0
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::308535385114:role/gha_executorch_upload-frameworks-ios
           aws-region: us-east-1


### PR DESCRIPTION

### Summary
v1.7.0 uses Node.js 20 which is deprecated and will be forced to Node.js 24 starting June 2026. It also uses the deprecated set-output command. v4 supports Node.js 24 and uses Environment Files.

### Test plan
CI