### PR TITLE
Rename Cadence CI job key from cpu (#18217)

### DIFF
--- a/.github/workflows/build-cadence-runner.yml
+++ b/.github/workflows/build-cadence-runner.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  cpu-x86:
+  cpu:
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     permissions:
       id-token: write


### PR DESCRIPTION
Summary:
Simple rename of the job key in              
  build-cadence-runner.yml

cc mcremon-meta


Test Plan:
{F1986883338}
https://github.com/pytorch/executorch/actions/runs/23170469368/job/67320919651?pr=18217

Differential Revision: D96834252

Pulled By: aliafzal




cc @mcremon-meta