### PR TITLE
Arm backend: Add Ethos-U FVP tests for MLPerf Tiny models

### DIFF
--- a/backends/arm/MODELS.md
+++ b/backends/arm/MODELS.md
@@ -1,12 +1,17 @@
 <!-- Copyright 2025-2026 Arm Limited and/or its affiliates. -->
 # The following file contains all models that have been confirmed to be functional and tested for the Arm backend:
+# Note: Deep AutoEncoder requires manual Linear+BatchNorm1d fusion as the quantizer does not yet support this pattern.
+# Note: DS CNN requires AvgPool2d workaround for Ethos-U55 due to stride > 3 limitation.
 - Conformer
+- Deep AutoEncoder
 - Deit Tiny
 - DeepLab v3 (DL3)
+- DS CNN
 - Inception v3 (IC3)
 - Llama
 - Gemma3n
 - Long Short-Term Memory (LSTM)
+- MobileNet V1 0.25
 - MobileNet v2 (MV2)
 - MobileNet v3 (MV3)
 - Some popular torch.nn.functional models (NN functional)
@@ -16,6 +21,7 @@
 - Neural Super Sampler (NSS)
 - Phi-3
 - ResNet 18
+- ResNet-8
 - Wav2Letter (W2L)
 - Stable Diffusion:
     * CLIP Text Encoder (CLIP Text with Projection)

--- a/backends/arm/test/models/test_deep_autoencoder.py
+++ b/backends/arm/test/models/test_deep_autoencoder.py
@@ -1,0 +1,123 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+"""Ethos-U FVP tests for the MLPerf Tiny anomaly detection Deep AutoEncoder."""
+
+from typing import Tuple
+
+import pytest
+import torch
+import torch.nn as nn
+from executorch.backends.arm.test import common
+from executorch.backends.arm.test.tester.test_pipeline import (
+    EthosU55PipelineINT,
+    EthosU85PipelineINT,
+    TosaPipelineFP,
+    TosaPipelineINT,
+)
+
+from executorch.examples.models.mlperf_tiny import DeepAutoEncoderModel
+from torch.nn.utils.fusion import fuse_linear_bn_eval
+
+
+def _fuse_linear_bn(mod: nn.Module) -> nn.Module:
+    """Fuse Linear + BatchNorm1d pairs in the model.
+
+    The TOSA quantizer does not annotate linear+batch_norm patterns, so we fold
+    the BatchNorm1d into the preceding Linear before export.
+    TODO: Remove once the quantizer supports linear+bn.
+
+    """
+    if not isinstance(mod, nn.Sequential):
+        for name, child in mod.named_children():
+            setattr(mod, name, _fuse_linear_bn(child))
+        return mod
+    new_layers = []
+    layers = list(mod)
+    i = 0
+    while i < len(layers):
+        if (
+            isinstance(layers[i], nn.Linear)
+            and i + 1 < len(layers)
+            and isinstance(layers[i + 1], nn.BatchNorm1d)
+        ):
+            new_layers.append(fuse_linear_bn_eval(layers[i], layers[i + 1]))  # type: ignore[type-var, arg-type]
+            i += 2
+        else:
+            new_layers.append(_fuse_linear_bn(layers[i]))
+            i += 1
+    return nn.Sequential(*new_layers)
+
+
+_wrapper = DeepAutoEncoderModel()
+model = _fuse_linear_bn(_wrapper.get_eager_model())
+model_inputs = _wrapper.get_example_inputs()
+input_t = Tuple[torch.Tensor]
+
+quant_test_data = {
+    "per_channel_quantization=true": True,
+    "per_channel_quantization=false": False,
+}
+
+
+def test_deep_autoencoder_tosa_FP():
+    pipeline = TosaPipelineFP[input_t](
+        model,
+        model_inputs,
+        aten_op=[],
+        exir_op=[],
+        use_to_edge_transform_and_lower=True,
+    )
+    pipeline.run()
+
+
+@common.parametrize("per_channel_quantization", quant_test_data)
+def test_deep_autoencoder_tosa_INT(per_channel_quantization):
+    pipeline = TosaPipelineINT[input_t](
+        model,
+        model_inputs,
+        aten_op=[],
+        exir_op=[],
+        use_to_edge_transform_and_lower=True,
+        per_channel_quantization=per_channel_quantization,
+        atol=0.25,
+        qtol=1,
+        frobenius_threshold=None,
+        cosine_threshold=None,
+    )
+    pipeline.run()
+
+
+@pytest.mark.slow
+@common.XfailIfNoCorstone300
+@common.parametrize("per_channel_quantization", quant_test_data)
+def test_deep_autoencoder_u55_INT(per_channel_quantization):
+    pipeline = EthosU55PipelineINT[input_t](
+        model,
+        model_inputs,
+        aten_ops=[],
+        exir_ops=[],
+        use_to_edge_transform_and_lower=True,
+        per_channel_quantization=per_channel_quantization,
+        atol=0.25,
+        qtol=1,
+    )
+    pipeline.run()
+
+
+@pytest.mark.slow
+@common.XfailIfNoCorstone320
+@common.parametrize("per_channel_quantization", quant_test_data)
+def test_deep_autoencoder_u85_INT(per_channel_quantization):
+    pipeline = EthosU85PipelineINT[input_t](
+        model,
+        model_inputs,
+        aten_ops=[],
+        exir_ops=[],
+        use_to_edge_transform_and_lower=True,
+        per_channel_quantization=per_channel_quantization,
+        atol=0.25,
+        qtol=1,
+    )
+    pipeline.run()

--- a/backends/arm/test/models/test_ds_cnn.py
+++ b/backends/arm/test/models/test_ds_cnn.py
@@ -1,0 +1,97 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+"""Ethos-U FVP tests for the MLPerf Tiny Keyword Spotting DS-CNN model."""
+
+from typing import Tuple
+
+import pytest
+import torch
+import torch.nn as nn
+from executorch.backends.arm.test import common
+from executorch.backends.arm.test.tester.test_pipeline import (
+    EthosU55PipelineINT,
+    EthosU85PipelineINT,
+    TosaPipelineFP,
+    TosaPipelineINT,
+)
+
+from executorch.examples.models.mlperf_tiny import DSCNNKWSModel
+
+_wrapper = DSCNNKWSModel()
+model = _wrapper.get_eager_model()
+# TODO: Remove once a pass decomposes large-stride AvgPool2d.
+# Replace AvgPool2d(24,5) with AdaptiveAvgPool2d(1) so the
+# DecomposeAdaptiveAvgPool2dPass can break it into stride-1
+# pools that satisfy the Ethos-U55 stride <= 3 constraint.
+model.pool = nn.AdaptiveAvgPool2d(output_size=1)  # type: ignore[assignment]
+model_inputs = _wrapper.get_example_inputs()
+input_t = Tuple[torch.Tensor]
+
+quant_test_data = {
+    "per_channel_quantization=true": True,
+    "per_channel_quantization=false": False,
+}
+
+
+def test_ds_cnn_tosa_FP():
+    pipeline = TosaPipelineFP[input_t](
+        model,
+        model_inputs,
+        aten_op=[],
+        exir_op=[],
+        use_to_edge_transform_and_lower=True,
+    )
+    pipeline.run()
+
+
+@common.parametrize("per_channel_quantization", quant_test_data)
+def test_ds_cnn_tosa_INT(per_channel_quantization):
+    pipeline = TosaPipelineINT[input_t](
+        model,
+        model_inputs,
+        aten_op=[],
+        exir_op=[],
+        use_to_edge_transform_and_lower=True,
+        per_channel_quantization=per_channel_quantization,
+        atol=0.25,
+        qtol=1,
+        frobenius_threshold=None,
+        cosine_threshold=None,
+    )
+    pipeline.run()
+
+
+@pytest.mark.slow
+@common.XfailIfNoCorstone300
+@common.parametrize("per_channel_quantization", quant_test_data)
+def test_ds_cnn_u55_INT(per_channel_quantization):
+    pipeline = EthosU55PipelineINT[input_t](
+        model,
+        model_inputs,
+        aten_ops=[],
+        exir_ops=[],
+        use_to_edge_transform_and_lower=True,
+        per_channel_quantization=per_channel_quantization,
+        atol=0.25,
+        qtol=1,
+    )
+    pipeline.run()
+
+
+@pytest.mark.slow
+@common.XfailIfNoCorstone320
+@common.parametrize("per_channel_quantization", quant_test_data)
+def test_ds_cnn_u85_INT(per_channel_quantization):
+    pipeline = EthosU85PipelineINT[input_t](
+        model,
+        model_inputs,
+        aten_ops=[],
+        exir_ops=[],
+        use_to_edge_transform_and_lower=True,
+        per_channel_quantization=per_channel_quantization,
+        atol=0.25,
+        qtol=1,
+    )
+    pipeline.run()

--- a/backends/arm/test/models/test_mobilenet_v1_025.py
+++ b/backends/arm/test/models/test_mobilenet_v1_025.py
@@ -1,0 +1,93 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+"""Ethos-U FVP tests for the MLPerf Tiny Visual Wake Words MobileNetV1 (width
+0.25).
+"""
+
+from typing import Tuple
+
+import pytest
+import torch
+from executorch.backends.arm.test import common
+from executorch.backends.arm.test.tester.test_pipeline import (
+    EthosU55PipelineINT,
+    EthosU85PipelineINT,
+    TosaPipelineFP,
+    TosaPipelineINT,
+)
+
+from executorch.examples.models.mlperf_tiny import MobileNetV1025Model
+
+_wrapper = MobileNetV1025Model()
+model = _wrapper.get_eager_model()
+model_inputs = _wrapper.get_example_inputs()
+input_t = Tuple[torch.Tensor]
+
+quant_test_data = {
+    "per_channel_quantization=true": True,
+    "per_channel_quantization=false": False,
+}
+
+
+def test_mobilenet_v1_025_tosa_FP():
+    pipeline = TosaPipelineFP[input_t](
+        model,
+        model_inputs,
+        aten_op=[],
+        exir_op=[],
+        use_to_edge_transform_and_lower=True,
+    )
+    pipeline.run()
+
+
+@common.parametrize("per_channel_quantization", quant_test_data)
+def test_mobilenet_v1_025_tosa_INT(per_channel_quantization):
+    pipeline = TosaPipelineINT[input_t](
+        model,
+        model_inputs,
+        aten_op=[],
+        exir_op=[],
+        use_to_edge_transform_and_lower=True,
+        per_channel_quantization=per_channel_quantization,
+        atol=0.25,
+        qtol=1,
+        frobenius_threshold=None,
+        cosine_threshold=None,
+    )
+    pipeline.run()
+
+
+@pytest.mark.slow
+@common.XfailIfNoCorstone300
+@common.parametrize("per_channel_quantization", quant_test_data)
+def test_mobilenet_v1_025_u55_INT(per_channel_quantization):
+    pipeline = EthosU55PipelineINT[input_t](
+        model,
+        model_inputs,
+        aten_ops=[],
+        exir_ops=[],
+        use_to_edge_transform_and_lower=True,
+        per_channel_quantization=per_channel_quantization,
+        atol=0.25,
+        qtol=1,
+    )
+    pipeline.run()
+
+
+@pytest.mark.slow
+@common.XfailIfNoCorstone320
+@common.parametrize("per_channel_quantization", quant_test_data)
+def test_mobilenet_v1_025_u85_INT(per_channel_quantization):
+    pipeline = EthosU85PipelineINT[input_t](
+        model,
+        model_inputs,
+        aten_ops=[],
+        exir_ops=[],
+        use_to_edge_transform_and_lower=True,
+        per_channel_quantization=per_channel_quantization,
+        atol=0.25,
+        qtol=1,
+    )
+    pipeline.run()

--- a/backends/arm/test/models/test_resnet8.py
+++ b/backends/arm/test/models/test_resnet8.py
@@ -1,0 +1,91 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+"""Ethos-U FVP tests for the MLPerf Tiny CIFAR-10 ResNet-8 model."""
+
+from typing import Tuple
+
+import pytest
+import torch
+from executorch.backends.arm.test import common
+from executorch.backends.arm.test.tester.test_pipeline import (
+    EthosU55PipelineINT,
+    EthosU85PipelineINT,
+    TosaPipelineFP,
+    TosaPipelineINT,
+)
+
+from executorch.examples.models.mlperf_tiny import ResNet8Model
+
+_wrapper = ResNet8Model()
+model = _wrapper.get_eager_model()
+model_inputs = _wrapper.get_example_inputs()
+input_t = Tuple[torch.Tensor]
+
+quant_test_data = {
+    "per_channel_quantization=true": True,
+    "per_channel_quantization=false": False,
+}
+
+
+def test_resnet8_tosa_FP():
+    pipeline = TosaPipelineFP[input_t](
+        model,
+        model_inputs,
+        aten_op=[],
+        exir_op=[],
+        use_to_edge_transform_and_lower=True,
+    )
+    pipeline.run()
+
+
+@common.parametrize("per_channel_quantization", quant_test_data)
+def test_resnet8_tosa_INT(per_channel_quantization):
+    pipeline = TosaPipelineINT[input_t](
+        model,
+        model_inputs,
+        aten_op=[],
+        exir_op=[],
+        use_to_edge_transform_and_lower=True,
+        per_channel_quantization=per_channel_quantization,
+        atol=0.25,
+        qtol=1,
+        frobenius_threshold=None,
+        cosine_threshold=None,
+    )
+    pipeline.run()
+
+
+@pytest.mark.slow
+@common.XfailIfNoCorstone300
+@common.parametrize("per_channel_quantization", quant_test_data)
+def test_resnet8_u55_INT(per_channel_quantization):
+    pipeline = EthosU55PipelineINT[input_t](
+        model,
+        model_inputs,
+        aten_ops=[],
+        exir_ops=[],
+        use_to_edge_transform_and_lower=True,
+        per_channel_quantization=per_channel_quantization,
+        atol=0.25,
+        qtol=1,
+    )
+    pipeline.run()
+
+
+@pytest.mark.slow
+@common.XfailIfNoCorstone320
+@common.parametrize("per_channel_quantization", quant_test_data)
+def test_resnet8_u85_INT(per_channel_quantization):
+    pipeline = EthosU85PipelineINT[input_t](
+        model,
+        model_inputs,
+        aten_ops=[],
+        exir_ops=[],
+        use_to_edge_transform_and_lower=True,
+        per_channel_quantization=per_channel_quantization,
+        atol=0.25,
+        qtol=1,
+    )
+    pipeline.run()

--- a/examples/models/__init__.py
+++ b/examples/models/__init__.py
@@ -1,6 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
-# Copyright 2024-2025 Arm Limited and/or its affiliates.
+# Copyright 2024-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -40,6 +40,10 @@ class Model(str, Enum):
     Phi4Mini = "phi_4_mini"
     SmolLM2 = "smollm2"
     DeiTTiny = "deit_tiny"
+    DeepAutoEncoder = "deep_autoencoder"
+    DSCNN = "ds_cnn"
+    MobileNetV1025 = "mobilenet_v1_025"
+    ResNet8 = "resnet8"
     Sdpa = "sdpa"
 
     def __str__(self) -> str:
@@ -90,6 +94,16 @@ MODEL_NAME_TO_MODEL = {
     str(Model.Phi4Mini): ("phi_4_mini", "Phi4MiniModel"),
     str(Model.SmolLM2): ("smollm2", "SmolLM2Model"),
     str(Model.DeiTTiny): ("deit_tiny", "DeiTTinyModel"),
+    str(Model.DeepAutoEncoder): (
+        "mlperf_tiny.deep_autoencoder",
+        "DeepAutoEncoderModel",
+    ),
+    str(Model.DSCNN): ("mlperf_tiny.ds_cnn", "DSCNNKWSModel"),
+    str(Model.MobileNetV1025): (
+        "mlperf_tiny.mobilenet_v1_025",
+        "MobileNetV1025Model",
+    ),
+    str(Model.ResNet8): ("mlperf_tiny.resnet8", "ResNet8Model"),
     str(Model.Sdpa): ("toy_model", "SdpaModule"),
 }
 

--- a/examples/models/mlperf_tiny/__init__.py
+++ b/examples/models/mlperf_tiny/__init__.py
@@ -1,0 +1,20 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from .deep_autoencoder import DeepAutoEncoder, DeepAutoEncoderModel
+from .ds_cnn import DSCNNKWS, DSCNNKWSModel
+from .mobilenet_v1_025 import MobileNetV1025, MobileNetV1025Model
+from .resnet8 import ResNet8, ResNet8Model
+
+__all__ = [
+    "DeepAutoEncoder",
+    "DeepAutoEncoderModel",
+    "DSCNNKWS",
+    "DSCNNKWSModel",
+    "MobileNetV1025",
+    "MobileNetV1025Model",
+    "ResNet8",
+    "ResNet8Model",
+]

--- a/examples/models/mlperf_tiny/deep_autoencoder.py
+++ b/examples/models/mlperf_tiny/deep_autoencoder.py
@@ -1,0 +1,40 @@
+# Copyright (C) 2020 Hitachi, Ltd. All right reserved.
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""PyTorch port of the MLPerf Tiny anomaly detection deep autoencoder."""
+
+import torch
+import torch.nn as nn
+
+from executorch.examples.models.model_base import EagerModelBase
+
+
+class DeepAutoEncoder(nn.Module):
+    def __init__(self, input_dim: int = 640) -> None:
+        super().__init__()
+        hidden = [128, 128, 128, 128, 8, 128, 128, 128, 128]
+        layers = []
+        in_dim = input_dim
+        for dim in hidden:
+            layers.append(nn.Linear(in_dim, dim, bias=True))
+            layers.append(nn.BatchNorm1d(dim))
+            layers.append(nn.ReLU(inplace=True))
+            in_dim = dim
+        self.encoder_decoder = nn.Sequential(*layers)
+        self.output_layer = nn.Linear(in_dim, input_dim)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.encoder_decoder(x)
+        x = self.output_layer(x)
+        return x
+
+
+class DeepAutoEncoderModel(EagerModelBase):
+
+    def get_eager_model(self) -> torch.nn.Module:
+        return DeepAutoEncoder().eval()
+
+    def get_example_inputs(self):
+        return (torch.rand(1, 640) * 2 - 1,)

--- a/examples/models/mlperf_tiny/ds_cnn.py
+++ b/examples/models/mlperf_tiny/ds_cnn.py
@@ -1,0 +1,86 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""PyTorch reimplementation of the MLCommons Tiny Keyword Spotting DS-CNN model."""
+
+import torch
+import torch.nn as nn
+
+from executorch.examples.models.model_base import EagerModelBase
+
+
+class DepthwiseSeparableConv(nn.Module):
+    """Applies a depthwise convolution followed by a pointwise projection."""
+
+    def __init__(self, channels: int, kernel_size: tuple[int, int] = (3, 3)) -> None:
+        super().__init__()
+        padding = tuple(k // 2 for k in kernel_size)
+        self.depthwise = nn.Conv2d(
+            channels,
+            channels,
+            kernel_size=kernel_size,
+            padding=padding,
+            groups=channels,
+            bias=False,
+        )
+        self.depthwise_bn = nn.BatchNorm2d(channels)
+        self.pointwise = nn.Conv2d(channels, channels, kernel_size=1, bias=False)
+        self.pointwise_bn = nn.BatchNorm2d(channels)
+        self.relu = nn.ReLU(inplace=True)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.depthwise(x)
+        x = self.depthwise_bn(x)
+        x = self.relu(x)
+        x = self.pointwise(x)
+        x = self.pointwise_bn(x)
+        x = self.relu(x)
+        return x
+
+
+class DSCNNKWS(nn.Module):
+    """Depthwise Separable CNN used for keyword spotting in MLCommons Tiny."""
+
+    def __init__(self, num_classes: int = 12) -> None:
+        super().__init__()
+        self.num_classes = num_classes
+        self.input_height = 49
+        self.input_width = 10
+        self.input_channels = 1
+        self.feature_extractor = nn.Sequential(
+            nn.Conv2d(
+                in_channels=self.input_channels,
+                out_channels=64,
+                kernel_size=(10, 4),
+                stride=(2, 2),
+                padding=(5, 1),
+                bias=False,
+            ),
+            nn.BatchNorm2d(64),
+            nn.ReLU(inplace=True),
+            nn.Dropout(p=0.2),
+            DepthwiseSeparableConv(64),
+            DepthwiseSeparableConv(64),
+            DepthwiseSeparableConv(64),
+            DepthwiseSeparableConv(64),
+            nn.Dropout(p=0.4),
+        )
+        self.pool = nn.AvgPool2d(kernel_size=(24, 5))
+        self.classifier = nn.Linear(64, num_classes)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.feature_extractor(x)
+        x = self.pool(x)
+        x = torch.flatten(x, 1)
+        x = self.classifier(x)
+        return x
+
+
+class DSCNNKWSModel(EagerModelBase):
+
+    def get_eager_model(self) -> torch.nn.Module:
+        return DSCNNKWS().eval()
+
+    def get_example_inputs(self):
+        return (torch.rand(1, 1, 49, 10) * 2 - 1,)

--- a/examples/models/mlperf_tiny/mobilenet_v1_025.py
+++ b/examples/models/mlperf_tiny/mobilenet_v1_025.py
@@ -1,0 +1,94 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""PyTorch port of the MLPerf Tiny Visual Wake Words MobileNetV1 (width 0.25)."""
+
+import torch
+import torch.nn as nn
+
+from executorch.examples.models.model_base import EagerModelBase
+
+
+class DepthwiseSeparableConv(nn.Module):
+    def __init__(self, in_channels: int, out_channels: int, stride: int = 1) -> None:
+        super().__init__()
+        self.depthwise = nn.Conv2d(
+            in_channels,
+            in_channels,
+            kernel_size=3,
+            stride=stride,
+            padding=1,
+            groups=in_channels,
+            bias=False,
+        )
+        self.depthwise_bn = nn.BatchNorm2d(in_channels)
+        self.pointwise = nn.Conv2d(in_channels, out_channels, kernel_size=1, bias=False)
+        self.pointwise_bn = nn.BatchNorm2d(out_channels)
+        self.relu = nn.ReLU(inplace=True)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.depthwise(x)
+        x = self.depthwise_bn(x)
+        x = self.relu(x)
+        x = self.pointwise(x)
+        x = self.pointwise_bn(x)
+        x = self.relu(x)
+        return x
+
+
+class MobileNetV1025(nn.Module):
+    """MobileNetV1 with width multiplier 0.25 for the Visual Wake Words benchmark."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.num_classes = 2
+        stem_out = 8
+        self.stem = nn.Sequential(
+            nn.Conv2d(3, stem_out, kernel_size=3, stride=2, padding=1, bias=False),
+            nn.BatchNorm2d(stem_out),
+            nn.ReLU(inplace=True),
+        )
+
+        channels = stem_out
+        blocks = []
+        cfg = [
+            (1, True),
+            (2, True),
+            (1, False),
+            (2, True),
+            (1, False),
+            (2, True),
+            (1, False),
+            (1, False),
+            (1, False),
+            (1, False),
+            (1, False),
+            (2, True),
+            (1, False),
+        ]
+        for stride, expand in cfg:
+            out_channels = channels * 2 if expand else channels
+            blocks.append(DepthwiseSeparableConv(channels, out_channels, stride=stride))
+            channels = out_channels
+
+        self.features = nn.Sequential(*blocks)
+        self.avgpool = nn.AdaptiveAvgPool2d(1)
+        self.classifier = nn.Linear(channels, self.num_classes)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.stem(x)
+        x = self.features(x)
+        x = self.avgpool(x)
+        x = torch.flatten(x, 1)
+        x = self.classifier(x)
+        return x
+
+
+class MobileNetV1025Model(EagerModelBase):
+
+    def get_eager_model(self) -> torch.nn.Module:
+        return MobileNetV1025().eval()
+
+    def get_example_inputs(self):
+        return (torch.rand(1, 3, 96, 96) * 2 - 1,)

--- a/examples/models/mlperf_tiny/resnet8.py
+++ b/examples/models/mlperf_tiny/resnet8.py
@@ -1,0 +1,93 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+MLPerf Tiny CIFAR-10 ResNet-8 model for Arm backend testing.
+
+Architecture follows the MLPerf Tiny benchmark specification:
+three residual stages with channel widths [16, 32, 64] operating
+on 32x32 input images, producing 10-class output logits.
+"""
+
+import torch
+
+from executorch.examples.models.model_base import EagerModelBase
+from torch import nn, Tensor
+
+# Channel configuration for each residual stage.
+_STAGE_CHANNELS = (16, 32, 64)
+
+
+def _make_conv(ch_in: int, ch_out: int, ks: int, s: int = 1, pad: int = 0) -> nn.Conv2d:
+    """Create a Conv2d layer without bias (used before batch-norm)."""
+    return nn.Conv2d(ch_in, ch_out, kernel_size=ks, stride=s, padding=pad, bias=False)
+
+
+class _ResStage(nn.Module):
+    """Single residual stage: two 3x3 conv-bn pairs with a skip connection."""
+
+    def __init__(self, ch_in: int, ch_out: int, downsample: bool = False) -> None:
+        super().__init__()
+        s = 2 if downsample else 1
+
+        self.path_a = nn.Sequential(
+            _make_conv(ch_in, ch_out, ks=3, s=s, pad=1),
+            nn.BatchNorm2d(ch_out),
+            nn.ReLU(),
+            _make_conv(ch_out, ch_out, ks=3, s=1, pad=1),
+            nn.BatchNorm2d(ch_out),
+        )
+
+        self.skip = (
+            _make_conv(ch_in, ch_out, ks=1, s=s)
+            if (downsample or ch_in != ch_out)
+            else nn.Identity()
+        )
+
+        self.act = nn.ReLU()
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self.act(self.path_a(x) + self.skip(x))
+
+
+class ResNet8(nn.Module):
+    """
+    Three-stage residual network for the MLPerf Tiny image-classification
+    benchmark (CIFAR-10, 32x32 RGB, 10 classes).
+    """
+
+    def __init__(self, n_classes: int = 10) -> None:
+        super().__init__()
+
+        # Initial convolution + normalisation.
+        self.entry = nn.Sequential(
+            _make_conv(3, _STAGE_CHANNELS[0], ks=3, s=1, pad=1),
+            nn.BatchNorm2d(_STAGE_CHANNELS[0]),
+            nn.ReLU(),
+        )
+
+        # Three residual stages; stages 2 and 3 halve spatial resolution.
+        self.stages = nn.Sequential(
+            _ResStage(_STAGE_CHANNELS[0], _STAGE_CHANNELS[0], downsample=False),
+            _ResStage(_STAGE_CHANNELS[0], _STAGE_CHANNELS[1], downsample=True),
+            _ResStage(_STAGE_CHANNELS[1], _STAGE_CHANNELS[2], downsample=True),
+        )
+
+        self.pool = nn.AdaptiveAvgPool2d(1)
+        self.head = nn.Linear(_STAGE_CHANNELS[-1], n_classes)
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = self.entry(x)
+        x = self.stages(x)
+        x = self.pool(x)
+        x = torch.flatten(x, 1)
+        return self.head(x)
+
+
+class ResNet8Model(EagerModelBase):
+    def get_eager_model(self) -> nn.Module:
+        return ResNet8().eval()
+
+    def get_example_inputs(self):
+        return (torch.rand(1, 3, 32, 32) * 2 - 1,)

--- a/examples/models/model_base.py
+++ b/examples/models/model_base.py
@@ -1,5 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
+# Copyright 2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -17,14 +18,13 @@ class EagerModelBase(ABC):
     Eager mode models inherit from this class to ensure consistent behavior and structure.
     """
 
-    @abstractmethod
-    def __init__(self):
+    def __init__(self) -> None:
         """
         Constructor for EagerModelBase.
 
         This initializer may be overridden in derived classes to provide additional setup if needed.
         """
-        pass
+        super().__init__()
 
     @abstractmethod
     def get_eager_model(self) -> torch.nn.Module:


### PR DESCRIPTION
Add model definitions and Arm backend tests for four MLPerf Tiny benchmark models: ResNet8, DS-CNN, Deep AutoEncoder, and MobileNetV1-0.25.

Model definitions are placed under examples/models/mlperf_tiny/. Each model has tests for tosa_FP, tosa_INT, u55_INT and u85_INT pipelines in backends/arm/test/models/.

Notable model adaptations for Arm delegation:
- Deep AutoEncoder: Fuse Linear + BatchNorm1d pairs before export since the TOSA quantizer only annotates conv + batch_norm patterns.
- DS-CNN: Replace AvgPool2d(24, 5) with AdaptiveAvgPool2d(1) to satisfy the Ethos-U55 stride <= 3 constraint; the DecomposeAdaptiveAvgPool2dPass decomposes it into stride-1 pools.

Change-Id: I8dbf5e8a4b80996faab9f850c21740899f6b36fd

### Summary
[PLEASE REMOVE] See [CONTRIBUTING.md's Pull Requests](https://github.com/pytorch/executorch/blob/main/CONTRIBUTING.md#pull-requests) for ExecuTorch PR guidelines.

[PLEASE REMOVE] If this PR closes an issue, please add a `Fixes #<issue-id>` line.

[PLEASE REMOVE] If this PR introduces a fix or feature that should be the upcoming release notes, please add a "Release notes: <area>" label. For a list of available release notes labels, check out [CONTRIBUTING.md's Pull Requests](https://github.com/pytorch/executorch/blob/main/CONTRIBUTING.md#pull-requests).

### Test plan
[PLEASE REMOVE] How did you test this PR? Please write down any manual commands you used and note down tests that you have written if applicable.


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell