### PR TITLE
Arm backend: Do not partition detach copy

### DIFF
--- a/backends/arm/tosa/partitioner.py
+++ b/backends/arm/tosa/partitioner.py
@@ -260,6 +260,7 @@ class TOSAPartitioner(Partitioner):
                 _is_noop_clone(node)
                 or _is_noop_alias_copy(node)
                 or _is_noop_expand(node)
+                or _is_noop_detach_copy(node)
                 or _is_noop_to_dim_order_copy(node)
                 or _is_view_copy(node)
                 or node.target in Q_OPS


### PR DESCRIPTION
Fixed an issue where _is_noop_detach_copy(node)
call had been removed when check no compute
partitions

Signed-off-by: Christoffer J.L. <christoffer.johanssonlundqvist@arm.com>

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell