### PR TITLE
Fix unsigned comparison check in const pad kernel

### DIFF
--- a/kernels/portable/cpu/op_constant_pad_nd.cpp
+++ b/kernels/portable/cpu/op_constant_pad_nd.cpp
@@ -206,7 +206,7 @@ void constant_pad_nd_out_impl(
     out_strides[i] = getTrailingDims(out, static_cast<int64_t>(i));
 
     size_t pad_i = ndim - 1 - i;
-    if (pad_i >= 0 && pad_i < pad.size() / 2) {
+    if (pad_i < pad.size() / 2) {
       if (pad[2 * pad_i] + pad[2 * pad_i + 1] > 0) {
         last_padded_dim = i;
       }


### PR DESCRIPTION
Summary:
The logic is:
```
size_t pad_i = ndim - 1 - i;
if (pad_i >= 0 pad_i < pad.size() / 2)
```

the loop range is irange(ndim)

so the min val is when we are at the end of the iterator

ndim - 1 - i

is

ndim - 1 - (ndim - 1)

= 0

pad_i >= 0 check is redundant

Differential Revision: D96926279


