### PR TITLE
Arm backend: Cast int64 buffers to int32

### DIFF
--- a/backends/arm/_passes/insert_int32_casts_after_int64_placeholders.py
+++ b/backends/arm/_passes/insert_int32_casts_after_int64_placeholders.py
@@ -91,6 +91,8 @@ class InsertInt32CastsAfterInt64PlaceholdersPass(ArmPass):
         for node in graph.nodes:
             if node.op not in ("placeholder", "get_attr"):
                 continue
+            if "val" not in node.meta:
+                continue  # Ignore submodule get_attrs
             node_val = node.meta["val"]
             if not self._is_tensor_of_dtype(node_val, torch.int64):
                 continue

--- a/backends/arm/_passes/insert_int32_casts_after_int64_placeholders.py
+++ b/backends/arm/_passes/insert_int32_casts_after_int64_placeholders.py
@@ -89,7 +89,7 @@ class InsertInt32CastsAfterInt64PlaceholdersPass(ArmPass):
         modified = False
         graph = graph_module.graph
         for node in graph.nodes:
-            if node.op != "placeholder":
+            if node.op not in ("placeholder", "get_attr"):
                 continue
             node_val = node.meta["val"]
             if not self._is_tensor_of_dtype(node_val, torch.int64):

--- a/backends/arm/test/ops/test_clamp.py
+++ b/backends/arm/test/ops/test_clamp.py
@@ -257,7 +257,10 @@ def test_clamp_vgf_quant(test_data):
     pipeline.run()
 
 
-aten_op_tensor = "torch.ops.aten.clamp.Tensor"
+aten_op_tensor = [
+    "torch.ops.aten.clamp.Tensor",
+    "torch.ops.dim_order_ops._to_dim_order_copy.default",
+]
 exir_op_tensor = "executorch_exir_dialects_edge__ops_aten_clamp_Tensor"
 
 test_data_suite_tensor_FP = {

--- a/backends/arm/test/ops/test_clamp.py
+++ b/backends/arm/test/ops/test_clamp.py
@@ -259,7 +259,6 @@ def test_clamp_vgf_quant(test_data):
 
 aten_op_tensor = [
     "torch.ops.aten.clamp.Tensor",
-    "torch.ops.dim_order_ops._to_dim_order_copy.default",
 ]
 exir_op_tensor = "executorch_exir_dialects_edge__ops_aten_clamp_Tensor"
 
@@ -416,10 +415,22 @@ def test_clamp_tosa_INT_tensor(test_data):
     input_tensor, min_val, max_val = test_data()
     model = Clamp(min_val, max_val)
 
+    # Check that int64 inputs are cast to int32 in the tfa pipeline
+    if any(
+        t.dtype == torch.int64
+        for t in (input_tensor, min_val, max_val)
+        if isinstance(t, torch.Tensor)
+    ):
+        aten_op = aten_op_tensor + [
+            "torch.ops.dim_order_ops._to_dim_order_copy.default"
+        ]
+    else:
+        aten_op = aten_op_tensor
+
     pipeline = TosaPipelineINT[input_t](
         model,
         (input_tensor,),
-        aten_op_tensor,
+        aten_op,
         exir_op_tensor,
     )
     pipeline.run()


### PR DESCRIPTION
Cast int64 buffers using get_attr in the same way as regular placeholders.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell