### PR TITLE
Gate Metal and CUDA CI workflows on path and ciflow labels

### DIFF
--- a/.github/pytorch-probot.yml
+++ b/.github/pytorch-probot.yml
@@ -3,6 +3,8 @@ tracking_issue: 7679
 ciflow_push_tags:
 - ciflow/android
 - ciflow/apple
+- ciflow/cuda
+- ciflow/metal
 - ciflow/nightly
 - ciflow/trunk
 - ciflow/binaries

--- a/.github/workflows/cuda-windows.yml
+++ b/.github/workflows/cuda-windows.yml
@@ -5,11 +5,18 @@
 name: Test CUDA Windows Export and E2E
 
 on:
-  pull_request:
   push:
     branches:
       - main
       - release/*
+    tags:
+      - ciflow/cuda/*
+  pull_request:
+    paths:
+      - .github/workflows/cuda-windows.yml
+      - backends/cuda/**
+      - backends/aoti/**
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -9,11 +9,18 @@
 name: Test CUDA Builds
 
 on:
-  pull_request:
   push:
     branches:
       - main
       - release/*
+    tags:
+      - ciflow/cuda/*
+  pull_request:
+    paths:
+      - .github/workflows/cuda.yml
+      - backends/cuda/**
+      - backends/aoti/**
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}

--- a/.github/workflows/metal.yml
+++ b/.github/workflows/metal.yml
@@ -1,11 +1,18 @@
 name: Test Metal Backend
 
 on:
-  pull_request:
   push:
     branches:
       - main
       - release/*
+    tags:
+      - ciflow/metal/*
+  pull_request:
+    paths:
+      - .github/workflows/metal.yml
+      - backends/apple/metal/**
+      - backends/aoti/**
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}


### PR DESCRIPTION
Metal and CUDA backend tests were running on every PR regardless of
which files were changed. Gate them so they only run when:
- Files in backends/apple/metal/**, backends/cuda/**, or backends/aoti/**
  are touched (aoti is shared by both backends)
- The workflow file itself is modified
- A ciflow/metal or ciflow/cuda label is added to the PR
- Code is pushed to main or release branches

This reduces CI load for PRs that don't touch these backends.
