### PR TITLE
Remove stale run_and_compare parameter from test calls (#18251)

### DIFF
--- a/examples/cadence/operators/test_add_op.py
+++ b/examples/cadence/operators/test_add_op.py
@@ -65,7 +65,7 @@ class ATenOpTestCases(unittest.TestCase):
 
         model.eval()
         export_and_run_model(
-            model, (X, Y), file_name=self._testMethodName, run_and_compare=False
+            model, (X, Y), file_name=self._testMethodName
         )
 
     # pyre-fixme[16]: Module `parameterized.parameterized` has no attribute `expand`.
@@ -115,7 +115,7 @@ class ATenOpTestCases(unittest.TestCase):
 
         model.eval()
         export_and_run_model(
-            model, (X, Y), file_name=self._testMethodName, run_and_compare=False
+            model, (X, Y), file_name=self._testMethodName
         )
 
 

--- a/examples/cadence/operators/test_g3_ops.py
+++ b/examples/cadence/operators/test_g3_ops.py
@@ -17,7 +17,7 @@ class ATenOpTestCases(unittest.TestCase):
     def run_and_verify(self, model: nn.Module, inputs: Tuple[Any, ...]) -> None:
         model.eval()
         export_and_run_model(
-            model, inputs, file_name=self._testMethodName, run_and_compare=False
+            model, inputs, file_name=self._testMethodName
         )
 
     # pyre-ignore[16]: Module `parameterized.parameterized` has no attribute `expand`.


### PR DESCRIPTION
Summary:

`export_and_run_model` no longer accepts a `run_and_compare` parameter,
but `test_add_op.py` and `test_g3_ops.py` were still passing it. This
removes the stale keyword argument to match the current API.

Differential Revision: D96985349


