### PR TITLE
Windows wheels: fix git SSL backend for submodule update

### DIFF
--- a/.ci/scripts/wheel/pre_build_script.sh
+++ b/.ci/scripts/wheel/pre_build_script.sh
@@ -26,7 +26,12 @@ fi
 # we should update the core job in test-infra to enable long paths before
 # checkout to avoid needing to do this.
 pushd extension/llm/tokenizers
-git submodule update --init
+UNAME_S=$(uname -s)
+if [[ $UNAME_S == *"MINGW"* || $UNAME_S == *"MSYS"* ]]; then
+  git -c http.sslBackend=openssl submodule update --init
+else
+  git submodule update --init
+fi
 popd
 
 # On Windows, enable symlinks and re-checkout the current revision to create


### PR DESCRIPTION
Use OpenSSL instead of Windows schannel to avoid SSL errors when initializing the tokenizers submodule on Windows CI, matching the fix applied to other Windows workflows in #18137.