### PR TITLE
Clean up Voxtral Realtime HF weights after export

### DIFF
--- a/.ci/scripts/export_model_artifact.sh
+++ b/.ci/scripts/export_model_artifact.sh
@@ -373,6 +373,7 @@ if [ "$MODEL_NAME" = "voxtral_realtime" ]; then
   fi
   # Copy tokenizer from downloaded model weights
   cp "$LOCAL_MODEL_DIR/tekken.json" "${OUTPUT_DIR}/tekken.json"
+  rm -rf "$LOCAL_MODEL_DIR"
   ls -al "${OUTPUT_DIR}"
   echo "::endgroup::"
   exit 0


### PR DESCRIPTION
The downloaded model_weights/ directory (~20GB) was not removed
after export, causing it to be uploaded to S3 as part of the CI
artifact. Delete it after copying out the tokenizer since the
weights are fully baked into the .pte at that point.
