### PR TITLE
Fix weight cache bug

### DIFF
--- a/backends/xnnpack/runtime/XNNWeightsCache.cpp
+++ b/backends/xnnpack/runtime/XNNWeightsCache.cpp
@@ -206,9 +206,17 @@ size_t XNNWeightsCache::look_up_or_insert(
     size_t size) {
   size_t offset = context->look_up(context, cache_key);
 
+  // XNNPACK can call this with ptr==nullptr when it previously hit the cache
+  // and skipped packing. We can't validate against the ptr contents in this case,
+  // so just return the offset. This might actually be a bug in XNNPACK since
+  // calling look_up_or_insert with ptr==nullptr doesn't really make sense...
+  if (ptr == nullptr) {
+    return offset;
+  }
+
   if (offset != SIZE_MAX) {
     void* saved_ptr = context->offset_to_addr(context, offset);
-    if (0 == memcmp(ptr, saved_ptr, size)) {
+    if (saved_ptr != nullptr && 0 == memcmp(ptr, saved_ptr, size)) {
       return offset;
     }
     // Failure, cache is out of date

--- a/backends/xnnpack/runtime/XNNWeightsCache.cpp
+++ b/backends/xnnpack/runtime/XNNWeightsCache.cpp
@@ -207,9 +207,10 @@ size_t XNNWeightsCache::look_up_or_insert(
   size_t offset = context->look_up(context, cache_key);
 
   // XNNPACK can call this with ptr==nullptr when it previously hit the cache
-  // and skipped packing. We can't validate against the ptr contents in this case,
-  // so just return the offset. This might actually be a bug in XNNPACK since
-  // calling look_up_or_insert with ptr==nullptr doesn't really make sense...
+  // and skipped packing. We can't validate against the ptr contents in this
+  // case, so just return the offset. This might actually be a bug in XNNPACK
+  // since calling look_up_or_insert with ptr==nullptr doesn't really make
+  // sense...
   if (ptr == nullptr) {
     return offset;
   }


### PR DESCRIPTION
Summary: XNNPACK sometimes calls weight cache look_up_or_insert with ptr==nullptr. This is a bit weird - maybe a bug on the XNNPACK side?, but it seems to do this when it's already hit the cache. Just return the cached value for the key without validating contents in this case, since we can't insert anything.

Differential Revision: D97006279


