### PR TITLE
Cortex-M Backend: Add tiny model tests for nn.Modules, nn.functional,…

### DIFF
--- a/backends/cortex_m/test/models/test_nn_functional.py
+++ b/backends/cortex_m/test/models/test_nn_functional.py
@@ -1,0 +1,119 @@
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Tests popular torch.nn and torch.nn.functional operations through the Cortex-M pipeline.
+
+Mirrors the Arm backend test_nn_functional.py (PR #18225) but runs through
+the Cortex-M quantizer and pass manager. Tests operations that commonly
+appear in real models but aren't individually covered in ops/.
+
+Functions tested:
+- relu
+- relu6
+- avg_pool2d
+- max_pool2d
+- pad (constant)
+- hardtanh
+- BatchNorm1d (module)
+- linear
+"""
+
+import torch
+from executorch.backends.arm.test.common import parametrize
+from executorch.backends.cortex_m.test.tester import (
+    CortexMTester,
+    McuTestCase,
+    ramp_tensor,
+)
+
+torch.manual_seed(0)
+
+
+class PadModule(torch.nn.Module):
+    def forward(self, x):
+        return torch.nn.functional.pad(x, (1, 1, 1, 1), mode="constant", value=0)
+
+
+class LinearBnModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.randn(8, 16))
+        self.bn = torch.nn.BatchNorm1d(8)
+
+    def forward(self, x):
+        return self.bn(torch.nn.functional.linear(x, self.weight))
+
+
+class ConvReluMaxpool(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = torch.nn.Conv2d(3, 8, 3, padding=1, bias=False)
+
+    def forward(self, x):
+        x = self.conv(x)
+        x = torch.nn.functional.relu(x)
+        x = torch.nn.functional.max_pool2d(x, kernel_size=2, stride=2)
+        return x
+
+
+class ConvRelu6Avgpool(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = torch.nn.Conv2d(3, 8, 3, padding=1, bias=False)
+
+    def forward(self, x):
+        x = self.conv(x)
+        x = torch.nn.functional.relu6(x)
+        x = torch.nn.functional.avg_pool2d(x, kernel_size=2, stride=2)
+        return x
+
+
+class ConvHardtanhModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = torch.nn.Conv2d(3, 4, 3, padding=1, bias=False)
+
+    def forward(self, x):
+        return torch.nn.functional.hardtanh(self.conv(x), min_val=-1.0, max_val=1.0)
+
+
+test_cases = {
+    "conv_relu_maxpool": McuTestCase(
+        model=ConvReluMaxpool(),
+        example_inputs=(
+            ramp_tensor(-1, 1, (1, 3, 8, 8)).to(memory_format=torch.channels_last),
+        ),
+    ),
+    "conv_relu6_avgpool": McuTestCase(
+        model=ConvRelu6Avgpool(),
+        example_inputs=(
+            ramp_tensor(-1, 1, (1, 3, 8, 8)).to(memory_format=torch.channels_last),
+        ),
+    ),
+    "conv_hardtanh": McuTestCase(
+        model=ConvHardtanhModule(),
+        example_inputs=(
+            ramp_tensor(-1, 1, (1, 3, 8, 8)).to(memory_format=torch.channels_last),
+        ),
+    ),
+    "pad_constant": McuTestCase(
+        model=PadModule(),
+        example_inputs=(
+            ramp_tensor(-1, 1, (1, 4, 6, 6)).to(memory_format=torch.channels_last),
+        ),
+    ),
+    "linear_bn": McuTestCase(
+        model=LinearBnModule(),
+        example_inputs=(ramp_tensor(-1, 1, (2, 16)),),
+    ),
+}
+
+
+@parametrize("test_case", test_cases)
+def test_dialect_nn_functional(test_case):
+    tester = CortexMTester(test_case.model, test_case.example_inputs)
+    tester.test_dialect({}, {}, qtol=1)

--- a/backends/cortex_m/test/models/test_nn_modules.py
+++ b/backends/cortex_m/test/models/test_nn_modules.py
@@ -1,0 +1,199 @@
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Tests popular nn.Module classes through the Cortex-M pipeline.
+
+Mirrors the Arm backend test_nn_modules.py (PR #18225) but runs through
+the Cortex-M quantizer and pass manager instead of TOSA/Ethos-U delegation.
+
+Modules tested:
+- Conv2d + BatchNorm2d + ReLU
+- Linear + ReLU
+- Conv2d + Add + ReLU
+- AdaptiveAvgPool2d
+- ConvTranspose2d
+- Hardswish
+- Hardsigmoid
+- MaxPool2d
+- AvgPool2d
+- Softmax
+"""
+
+import torch
+from executorch.backends.arm.test.common import parametrize
+from executorch.backends.cortex_m.test.tester import (
+    CortexMTester,
+    McuTestCase,
+    ramp_tensor,
+)
+
+torch.manual_seed(0)
+
+
+class ConvBnReLU(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = torch.nn.Conv2d(3, 8, 3, padding=1, bias=False)
+        self.bn = torch.nn.BatchNorm2d(8)
+        self.relu = torch.nn.ReLU()
+
+    def forward(self, x):
+        return self.relu(self.bn(self.conv(x)))
+
+
+class LinearReLU(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = torch.nn.Linear(16, 8, bias=True)
+        self.relu = torch.nn.ReLU()
+
+    def forward(self, x):
+        return self.relu(self.linear(x))
+
+
+class ConvTranspose2dModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv_t = torch.nn.ConvTranspose2d(4, 2, 3, stride=2, padding=1)
+
+    def forward(self, x):
+        return self.conv_t(x)
+
+
+class AdaptiveAvgPool2dModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.pool = torch.nn.AdaptiveAvgPool2d((1, 1))
+
+    def forward(self, x):
+        return self.pool(x)
+
+
+class MaxPool2dModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.pool = torch.nn.MaxPool2d(kernel_size=3, stride=2, padding=1)
+
+    def forward(self, x):
+        return self.pool(x)
+
+
+class AvgPool2dModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.pool = torch.nn.AvgPool2d(kernel_size=3, stride=2, padding=1)
+
+    def forward(self, x):
+        return self.pool(x)
+
+
+class SoftmaxModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = torch.nn.Linear(8, 4, bias=False)
+
+    def forward(self, x):
+        return torch.softmax(self.linear(x), dim=-1)
+
+
+class HardswishModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = torch.nn.Conv2d(2, 4, 1, bias=False)
+        self.act = torch.nn.Hardswish()
+
+    def forward(self, x):
+        return self.act(self.conv(x))
+
+
+class HardsigmoidModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = torch.nn.Linear(8, 4, bias=False)
+        self.act = torch.nn.Hardsigmoid()
+
+    def forward(self, x):
+        return self.act(self.linear(x))
+
+
+class ConvAddReLU(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv1 = torch.nn.Conv2d(3, 8, 3, padding=1, bias=False)
+        self.conv2 = torch.nn.Conv2d(3, 8, 3, padding=1, bias=False)
+        self.relu = torch.nn.ReLU()
+
+    def forward(self, x):
+        return self.relu(self.conv1(x) + self.conv2(x))
+
+
+test_cases = {
+    "conv_bn_relu": McuTestCase(
+        model=ConvBnReLU(),
+        example_inputs=(
+            ramp_tensor(-1, 1, (1, 3, 8, 8)).to(memory_format=torch.channels_last),
+        ),
+    ),
+    "linear_relu": McuTestCase(
+        model=LinearReLU(),
+        example_inputs=(ramp_tensor(-1, 1, (1, 16)),),
+    ),
+    "conv_transpose2d": McuTestCase(
+        model=ConvTranspose2dModule(),
+        example_inputs=(
+            ramp_tensor(-1, 1, (1, 4, 4, 4)).to(memory_format=torch.channels_last),
+        ),
+    ),
+    "adaptive_avg_pool2d": McuTestCase(
+        model=AdaptiveAvgPool2dModule(),
+        example_inputs=(
+            ramp_tensor(-1, 1, (1, 3, 8, 8)).to(memory_format=torch.channels_last),
+        ),
+    ),
+    "max_pool2d": McuTestCase(
+        model=MaxPool2dModule(),
+        example_inputs=(
+            ramp_tensor(-1, 1, (1, 4, 8, 8)).to(memory_format=torch.channels_last),
+        ),
+    ),
+    "avg_pool2d": McuTestCase(
+        model=AvgPool2dModule(),
+        example_inputs=(
+            ramp_tensor(-1, 1, (1, 4, 8, 8)).to(memory_format=torch.channels_last),
+        ),
+    ),
+    "softmax": McuTestCase(
+        model=SoftmaxModule(),
+        example_inputs=(ramp_tensor(-1, 1, (1, 8)),),
+    ),
+    "hardswish": McuTestCase(
+        model=HardswishModule(),
+        example_inputs=(
+            ramp_tensor(-3, 3, (1, 2, 4, 4)).to(memory_format=torch.channels_last),
+        ),
+    ),
+    "hardsigmoid": McuTestCase(
+        model=HardsigmoidModule(),
+        example_inputs=(ramp_tensor(-4, 4, (1, 8)),),
+    ),
+    "conv_add_relu": McuTestCase(
+        model=ConvAddReLU(),
+        example_inputs=(
+            ramp_tensor(-1, 1, (1, 3, 8, 8)).to(memory_format=torch.channels_last),
+        ),
+    ),
+}
+
+xfails = {
+    "conv_add_relu": "Activation fusion does not support relu after add",
+}
+
+
+@parametrize("test_case", test_cases, xfails=xfails, strict=False)
+def test_dialect_nn_modules(test_case):
+    tester = CortexMTester(test_case.model, test_case.example_inputs)
+    tester.test_dialect({}, {}, qtol=2)

--- a/backends/cortex_m/test/models/test_torch_functions.py
+++ b/backends/cortex_m/test/models/test_torch_functions.py
@@ -1,0 +1,154 @@
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Tests small composite models using common torch op patterns through the
+Cortex-M pipeline.
+
+Mirrors the Arm backend test_torch_functions.py (PR #18225) but focuses on
+patterns that exercise Cortex-M passes: quantized arithmetic, pooling,
+transposition, and multi-op compositions.
+
+Patterns tested:
+- mul + add (fused arithmetic)
+- transpose + linear
+- conv2d chain (multi-layer)
+- depthwise separable conv2d
+- inverted residual block (MobileNet-style)
+- linear + softmax (classification head)
+"""
+
+import torch
+from executorch.backends.arm.test.common import parametrize
+from executorch.backends.cortex_m.test.tester import (
+    CortexMTester,
+    McuTestCase,
+    ramp_tensor,
+)
+
+torch.manual_seed(0)
+
+
+class MulAdd(torch.nn.Module):
+    def forward(self, x, y, z):
+        return x * y + z
+
+
+class TransposeLinear(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = torch.nn.Linear(4, 8, bias=False)
+
+    def forward(self, x):
+        return self.linear(x.transpose(-1, -2))
+
+
+class ConvChain(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv1 = torch.nn.Conv2d(3, 8, 3, padding=1, bias=False)
+        self.bn1 = torch.nn.BatchNorm2d(8)
+        self.relu1 = torch.nn.ReLU()
+        self.conv2 = torch.nn.Conv2d(8, 16, 3, padding=1, bias=False)
+        self.bn2 = torch.nn.BatchNorm2d(16)
+        self.relu2 = torch.nn.ReLU()
+
+    def forward(self, x):
+        x = self.relu1(self.bn1(self.conv1(x)))
+        x = self.relu2(self.bn2(self.conv2(x)))
+        return x
+
+
+class DepthwiseSeparable(torch.nn.Module):
+    def __init__(self, in_ch=8, out_ch=16):
+        super().__init__()
+        self.dw = torch.nn.Conv2d(in_ch, in_ch, 3, padding=1, groups=in_ch, bias=False)
+        self.bn1 = torch.nn.BatchNorm2d(in_ch)
+        self.pw = torch.nn.Conv2d(in_ch, out_ch, 1, bias=False)
+        self.bn2 = torch.nn.BatchNorm2d(out_ch)
+        self.relu = torch.nn.ReLU6()
+
+    def forward(self, x):
+        x = self.relu(self.bn1(self.dw(x)))
+        x = self.relu(self.bn2(self.pw(x)))
+        return x
+
+
+class InvertedResidual(torch.nn.Module):
+    def __init__(self, in_ch=8, expand_ch=24, out_ch=8):
+        super().__init__()
+        self.expand = torch.nn.Conv2d(in_ch, expand_ch, 1, bias=False)
+        self.bn1 = torch.nn.BatchNorm2d(expand_ch)
+        self.dw = torch.nn.Conv2d(
+            expand_ch, expand_ch, 3, padding=1, groups=expand_ch, bias=False
+        )
+        self.bn2 = torch.nn.BatchNorm2d(expand_ch)
+        self.project = torch.nn.Conv2d(expand_ch, out_ch, 1, bias=False)
+        self.bn3 = torch.nn.BatchNorm2d(out_ch)
+        self.relu6 = torch.nn.ReLU6()
+
+    def forward(self, x):
+        residual = x
+        out = self.relu6(self.bn1(self.expand(x)))
+        out = self.relu6(self.bn2(self.dw(out)))
+        out = self.bn3(self.project(out))
+        return out + residual
+
+
+class LinearSoftmax(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear1 = torch.nn.Linear(16, 8, bias=False)
+        self.relu = torch.nn.ReLU()
+        self.linear2 = torch.nn.Linear(8, 4, bias=False)
+
+    def forward(self, x):
+        x = self.relu(self.linear1(x))
+        return torch.softmax(self.linear2(x), dim=-1)
+
+
+test_cases = {
+    "mul_add": McuTestCase(
+        model=MulAdd(),
+        example_inputs=(
+            ramp_tensor(-1, 1, (1, 8)),
+            ramp_tensor(0, 2, (1, 8)),
+            ramp_tensor(-0.5, 0.5, (1, 8)),
+        ),
+    ),
+    "transpose_linear": McuTestCase(
+        model=TransposeLinear(),
+        example_inputs=(ramp_tensor(-1, 1, (1, 4, 8)),),
+    ),
+    "conv_chain": McuTestCase(
+        model=ConvChain(),
+        example_inputs=(
+            ramp_tensor(-1, 1, (1, 3, 8, 8)).to(memory_format=torch.channels_last),
+        ),
+    ),
+    "depthwise_separable": McuTestCase(
+        model=DepthwiseSeparable(),
+        example_inputs=(
+            ramp_tensor(-1, 1, (1, 8, 8, 8)).to(memory_format=torch.channels_last),
+        ),
+    ),
+    "inverted_residual": McuTestCase(
+        model=InvertedResidual(),
+        example_inputs=(
+            ramp_tensor(-1, 1, (1, 8, 8, 8)).to(memory_format=torch.channels_last),
+        ),
+    ),
+    "linear_softmax": McuTestCase(
+        model=LinearSoftmax(),
+        example_inputs=(ramp_tensor(-1, 1, (1, 16)),),
+    ),
+}
+
+
+@parametrize("test_case", test_cases)
+def test_dialect_torch_functions(test_case):
+    tester = CortexMTester(test_case.model, test_case.example_inputs)
+    tester.test_dialect({}, {}, qtol=2)


### PR DESCRIPTION
… and torch patterns

Add 21 new test cases across 3 files that exercise the Cortex-M quantizer and pass manager on small composite models. These mirror the Arm backend's test_nn_modules/test_nn_functional/test_torch_functions pattern  but target the Cortex-M pipeline.

Tests cover: ConvBnReLU, LinearReLU, ConvTranspose2d, AdaptiveAvgPool2d, MaxPool2d, AvgPool2d, Softmax, Hardswish, Hardsigmoid, depthwise separable conv, inverted residual blocks (MobileNet-style), and multi-op functional compositions.

All tests use test_dialect() which runs quantize→export→to_edge→ run_passes→compare_outputs entirely on the host (no FVP needed).
