### PR TITLE
Fix conv2d NHWC out_data_format (#18303)

### DIFF
--- a/backends/cadence/hifi/operators/op_quantized_conv2d_nhwc_out.cpp
+++ b/backends/cadence/hifi/operators/op_quantized_conv2d_nhwc_out.cpp
@@ -237,7 +237,7 @@ void xa_opt_quantized_conv2d_nhwc(
     WORD32 scratch_size = 0;
 
     if (groups == 1) {
-      WORD32 out_data_format = 1;
+      WORD32 out_data_format = 0;
 
       scratch_size = xa_nn_conv2d_getsize(
           input_height,


### PR DESCRIPTION
Summary:

Set `out_data_format` to `0` in `xa_nn_conv2d_getsize` for standard (non-grouped) conv2d to match the native NHWC output layout.

Reviewed By: hsharma35

Differential Revision: D97172717
