### PR TITLE
Migrate executorch moltenVK dep (#18304)

### DIFF
--- a/backends/vulkan/targets.bzl
+++ b/backends/vulkan/targets.bzl
@@ -192,7 +192,7 @@ def define_common_targets(is_fbcode = False):
         if no_volk:
             for deps in [default_deps, android_deps]:
                 deps.append("fbsource//third-party/toolchains:vulkan")
-                deps.append("fbsource//third-party/khronos/version-selector:vulkan-headers")
+                deps.append("fbsource//third-party/khronos:vulkan-headers")
         else:
             for deps in [default_deps, android_deps]:
                 deps.append("fbsource//third-party/volk:volk-header")

--- a/backends/vulkan/targets.bzl
+++ b/backends/vulkan/targets.bzl
@@ -209,7 +209,7 @@ def define_common_targets(is_fbcode = False):
             mac_deps = default_deps
             if link_moltenvk:
                 mac_deps = [
-                    "//third-party/khronos/version-selector:moltenVK_static_unexported"
+                    "//third-party/khronos:moltenVK_static_unexported"
                 ]
 
             if debug_mode:


### PR DESCRIPTION
Summary:

Update moltenVK_static_unexported dependency in executorch vulkan targets.bzl to use proper path

Reviewed By: mboyd

Differential Revision: D97210565
