### PR TITLE
Move Cortex-M backend tests from trunk.yml to pull.yml

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -607,6 +607,36 @@ jobs:
           exit 1
         fi
 
+  test-mcu-cortex-m-backend:
+    name: test-mcu-cortex-m-backend
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      runner: linux.2xlarge.memory
+      docker-image: ci-image:executorch-ubuntu-22.04-arm-sdk
+      submodules: 'recursive'
+      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      timeout: 120
+      script: |
+        # The generic Linux job chooses to use base env, not the one setup by the image
+        CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
+        conda activate "${CONDA_ENV}"
+
+        source .ci/scripts/utils.sh
+        install_executorch "--use-pt-pinned-commit"
+
+        # Install arm dependencies
+        .ci/scripts/setup-arm-baremetal-tools.sh
+        source examples/arm/arm-scratch/setup_path.sh
+
+        # To build cortex-m test runner
+        backends/cortex_m/test/build_test_runner.sh
+
+        # To run cortex_m tests
+        pytest --config-file=backends/arm/test/pytest.ini backends/cortex_m/test
+
   android:
     uses: ./.github/workflows/_android.yml
     permissions:

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -1055,32 +1055,3 @@ jobs:
           .ci/scripts/test_model.ps1 -modelName ${{ matrix.model }} -backend ${{ matrix.backend }}
         }"
 
-  test-mcu-cortex-m-backend:
-    name: test-mcu-cortex-m-backend
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
-    permissions:
-      id-token: write
-      contents: read
-    with:
-      runner: linux.2xlarge.memory
-      docker-image: ci-image:executorch-ubuntu-22.04-arm-sdk
-      submodules: 'recursive'
-      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-      timeout: 120
-      script: |
-        # The generic Linux job chooses to use base env, not the one setup by the image
-        CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
-        conda activate "${CONDA_ENV}"
-
-        source .ci/scripts/utils.sh
-        install_executorch "--use-pt-pinned-commit"
-
-        # Install arm dependencies
-        .ci/scripts/setup-arm-baremetal-tools.sh
-        source examples/arm/arm-scratch/setup_path.sh
-
-        # To build cortex-m test runner
-        backends/cortex_m/test/build_test_runner.sh
-
-        # To run cortex_m tests
-        pytest --config-file=backends/arm/test/pytest.ini backends/cortex_m/test

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -1054,4 +1054,3 @@ jobs:
 
           .ci/scripts/test_model.ps1 -modelName ${{ matrix.model }} -backend ${{ matrix.backend }}
         }"
-


### PR DESCRIPTION
The test-mcu-cortex-m-backend CI job runs all Cortex-M pytests but was only in trunk.yml, meaning zero tests ran at diff time. Move it to pull.yml so regressions are caught on-diff before merge.

Authored with Claude.

