### PR TITLE
[Fix] Fix Method to Obtain Prefix Token ID

### DIFF
--- a/examples/models/llama/evaluate/eager_eval.py
+++ b/examples/models/llama/evaluate/eager_eval.py
@@ -48,6 +48,8 @@ class EagerEvalWrapper(eval_wrapper):
 
     @property
     def prefix_token_id(self):
+        if hasattr(self._tokenizer, "bos_id"):
+            return self._tokenizer.bos_id
         return self.eot_token_id
 
     @property


### PR DESCRIPTION
### Summary
Fix `prefix_token_id` to return the BOS token ID instead of the EOT token ID.

`EagerEvalWrapper.prefix_token_id` was incorrectly returning the EOT token ID.
Since lm-eval prepends `prefix_token_id` to every evaluation sequence, this caused
Llama 3's <|end_of_text|> (token 128001) to be used instead of <|begin_of_text|>
(token 128000), resulting in higher perplexity scores.

Llama 3 8B Wikitext PPL before fix : 9.18
Llama 3 8B Wikitext PPL after fix  : 7.793

The result after the fix matches the expected perplexity when evaluating
the same model directly via HuggingFace.