### PR TITLE
Force Apple Clang for macOS wheel builds

### DIFF
--- a/.ci/scripts/wheel/envvar_macos.sh
+++ b/.ci/scripts/wheel/envvar_macos.sh
@@ -9,3 +9,8 @@
 # any variables so that subprocesses will see them.
 
 source "${GITHUB_WORKSPACE}/${REPOSITORY}/.ci/scripts/wheel/envvar_base.sh"
+
+# Force Apple Clang to avoid Homebrew LLVM, which doesn't properly handle
+# Apple SDK Objective-C framework headers (e.g. NSIntegerMax in NSObjCRuntime.h).
+export CC=/usr/bin/clang
+export CXX=/usr/bin/clang++


### PR DESCRIPTION
A recent test-infra change (https://github.com/pytorch/test-infra/pull/7848) updated `MACOSX_DEPLOYMENT_TARGET` and sets `CC=clang` / `CXX=clang++` without absolute paths. On GitHub Actions `macos-14-xlarge` runners, bare `clang` can resolve to Homebrew LLVM instead of Apple Clang. Homebrew's clang doesn't properly handle Apple SDK Objective-C framework headers, breaking the `limits.h` include chain and causing:
```
NSObjCRuntime.h: error: use of undeclared identifier 'NSIntegerMax'
```
This pins the compiler to `/usr/bin/clang` in the macOS wheel build environment to ensure Apple Clang is always used.
