### PR TITLE
Arm backend: Add amin support for Ethos-U55

### DIFF
--- a/backends/arm/operator_support/ethos_u55_support.py
+++ b/backends/arm/operator_support/ethos_u55_support.py
@@ -191,7 +191,6 @@ class EthosU55NotSupported(OperatorSupportBase):
         exir_ops.edge.aten.logical_or.default,
         exir_ops.edge.aten.logical_xor.default,
         exir_ops.edge.aten.logical_not.default,
-        exir_ops.edge.aten.amin.default,  # REDUCE_MIN
         exir_ops.edge.aten.conv3d.default,  # CONV3D
         exir_ops.edge.aten.conv3d.padding,  # CONV3D (deprecated alias)
         exir_ops.edge.aten.eq.Tensor,

--- a/backends/arm/test/ops/test_amin.py
+++ b/backends/arm/test/ops/test_amin.py
@@ -11,6 +11,7 @@ import pytest
 import torch
 from executorch.backends.arm.test import common
 from executorch.backends.arm.test.tester.test_pipeline import (
+    EthosU55PipelineINT,
     EthosU85PipelineINT,
     OpNotSupportedPipeline,
     TosaPipelineFP,
@@ -144,14 +145,14 @@ def test_amin_tosa_INT(test_data: Amin.input_t):
     pipeline.run()
 
 
-def test_amin_u55_INT_not_delegated():
-    data, dim, keep_dims = Amin.test_data["rank_4_all_dim"]()
-    pipeline = OpNotSupportedPipeline[Amin.input_t](
+@common.parametrize("test_data", Amin.test_data)
+@common.XfailIfNoCorstone300
+def test_amin_u55_INT(test_data: Amin.input_t):
+    data, dim, keep_dims = test_data()
+    pipeline = EthosU55PipelineINT[Amin.input_t](
         Amin(dim, keep_dims),
         data,
-        {"executorch_exir_dialects_edge__ops_aten_amin_default": 1},
-        quantize=True,
-        u55_subset=True,
+        amin_aten_op,
     )
     pipeline.run()
 


### PR DESCRIPTION
Amin support was enabled in Vela 5.0.0

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell