### PR TITLE
Add CoreML backend options with compute unit configuration (#18369)

### DIFF
--- a/backends/apple/coreml/BUCK
+++ b/backends/apple/coreml/BUCK
@@ -89,6 +89,7 @@ runtime.cxx_library(
     platforms = [APPLE],
     visibility = ["PUBLIC"],
     deps = [
+        "//executorch/runtime/backend:backend_options",
         "//executorch/runtime/backend:interface",
         "//executorch/runtime/core:core",
         "//executorch/runtime/kernel:kernel_includes",
@@ -132,6 +133,32 @@ _PROTOS = [
     "WordEmbedding",
     "WordTagger",
 ]
+
+runtime.cxx_test(
+    name = "coreml_backend_options_test",
+    srcs = [
+        "runtime/test/coreml_backend_options_test.cpp",
+    ],
+    deps = [
+        ":coreml_backend_options",
+        "//executorch/runtime/backend:backend_options",
+        "//executorch/runtime/backend:backend_options_map",
+        "//executorch/runtime/core:core",
+    ],
+)
+
+# Header-only library for CoreML backend options
+runtime.cxx_library(
+    name = "coreml_backend_options",
+    exported_headers = [
+        "runtime/include/coreml_backend/coreml_backend_options.h",
+    ],
+    header_namespace = "executorch/backends/apple/coreml",
+    visibility = ["PUBLIC"],
+    exported_deps = [
+        "//executorch/runtime/backend:backend_options",
+    ],
+)
 
 runtime.cxx_library(
     name = "proto",

--- a/backends/apple/coreml/TARGETS
+++ b/backends/apple/coreml/TARGETS
@@ -133,3 +133,29 @@ runtime.python_test(
         "fbsource//third-party/pypi/scikit-learn:scikit-learn",
     ],
 )
+
+# Header-only library for CoreML backend options
+runtime.cxx_library(
+    name = "coreml_backend_options",
+    exported_headers = [
+        "runtime/include/coreml_backend/coreml_backend_options.h",
+    ],
+    header_namespace = "executorch/backends/apple/coreml",
+    visibility = ["PUBLIC"],
+    exported_deps = [
+        "//executorch/runtime/backend:backend_options",
+    ],
+)
+
+runtime.cxx_test(
+    name = "coreml_backend_options_test",
+    srcs = [
+        "runtime/test/coreml_backend_options_test.cpp",
+    ],
+    deps = [
+        ":coreml_backend_options",
+        "//executorch/runtime/backend:backend_options",
+        "//executorch/runtime/backend:backend_options_map",
+        "//executorch/runtime/core:core",
+    ],
+)

--- a/backends/apple/coreml/runtime/delegate/backend_delegate.mm
+++ b/backends/apple/coreml/runtime/delegate/backend_delegate.mm
@@ -19,7 +19,7 @@
 namespace  {
 using namespace executorchcoreml;
 
-MLComputeUnits get_compute_units(const Buffer& buffer) {
+std::optional<MLComputeUnits> get_compute_units(const Buffer& buffer) {
     std::string value(reinterpret_cast<const char *>(buffer.data()), buffer.size());
     if (value == std::string(ETCoreMLStrings.cpuComputeUnitName.UTF8String)) {
         return MLComputeUnitsCPUOnly;
@@ -27,22 +27,41 @@ MLComputeUnits get_compute_units(const Buffer& buffer) {
         return MLComputeUnitsCPUAndGPU;
     } else if (value == std::string(ETCoreMLStrings.cpuAndNeuralEngineComputeUnitsName.UTF8String)) {
         return MLComputeUnitsCPUAndNeuralEngine;
-    } else {
+    } else if (value == std::string(ETCoreMLStrings.allComputeUnitsName.UTF8String)) {
         return MLComputeUnitsAll;
+    } else {
+        return std::nullopt;
     }
 }
 
-MLModelConfiguration *get_model_configuration(const std::unordered_map<std::string, Buffer>& specs) {
+MLModelConfiguration * _Nullable get_model_configuration(const std::unordered_map<std::string, Buffer>& specs,
+                                                         NSError * __autoreleasing *error) {
     std::string compute_units_key(ETCoreMLStrings.computeUnitsKeyName.UTF8String);
     MLModelConfiguration *configuration = [[MLModelConfiguration alloc] init];
-    
+
     for (const auto& [key, buffer] : specs) {
         if (key == compute_units_key) {
-            configuration.computeUnits = get_compute_units(buffer);
+            auto compute_units = get_compute_units(buffer);
+            if (!compute_units.has_value()) {
+                std::string value(reinterpret_cast<const char *>(buffer.data()), buffer.size());
+                NSString *errorMessage = [NSString stringWithFormat:@"Invalid compute_unit value: '%s'. Valid values are: %@, %@, %@, %@",
+                    value.c_str(),
+                    ETCoreMLStrings.cpuComputeUnitName,
+                    ETCoreMLStrings.cpuAndGpuComputeUnitsName,
+                    ETCoreMLStrings.cpuAndNeuralEngineComputeUnitsName,
+                    ETCoreMLStrings.allComputeUnitsName];
+                if (error) {
+                    *error = [NSError errorWithDomain:ETCoreMLStrings.productIdentifier
+                                                 code:-1
+                                             userInfo:@{NSLocalizedDescriptionKey: errorMessage}];
+                }
+                return nil;
+            }
+            configuration.computeUnits = compute_units.value();
             break;
         }
     }
-    
+
     return configuration;
 }
 
@@ -112,7 +131,7 @@ ETCoreMLAssetManager * _Nullable create_asset_manager(NSString *assets_directory
         _config = std::move(config);
         _syncQueue = dispatch_queue_create("com.executorchcoreml.modelmanagerdelegate.sync", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
     }
-    
+
     return self;
 }
 
@@ -120,7 +139,7 @@ ETCoreMLAssetManager * _Nullable create_asset_manager(NSString *assets_directory
     if (self.impl != nil) {
         return YES;
     }
-    
+
     ETCoreMLAssetManager *assetManager = create_asset_manager(ETCoreMLStrings.assetsDirectoryPath,
                                                               ETCoreMLStrings.trashDirectoryPath,
                                                               ETCoreMLStrings.databaseDirectoryPath,
@@ -130,14 +149,14 @@ ETCoreMLAssetManager * _Nullable create_asset_manager(NSString *assets_directory
     if (!assetManager) {
         return NO;
     }
-    
+
     ETCoreMLModelManager *modelManager = [[ETCoreMLModelManager alloc] initWithAssetManager:assetManager];
     if (!modelManager) {
         return NO;
     }
-    
+
     self.impl = modelManager;
-    
+
     if (self.config.should_prewarm_asset) {
         [modelManager prewarmRecentlyUsedAssetsWithMaxCount:1];
     }
@@ -151,11 +170,11 @@ ETCoreMLAssetManager * _Nullable create_asset_manager(NSString *assets_directory
     dispatch_sync(self.syncQueue, ^{
         result = [self _loadAndReturnError:&localError];
     });
-    
+
     if (error) {
         *error = localError;
     }
-    
+
     return result;
 }
 
@@ -183,7 +202,7 @@ ETCoreMLAssetManager * _Nullable create_asset_manager(NSString *assets_directory
     if (![self loadAndReturnError:error]) {
         return nil;
     }
-    
+
     auto handle = [self.impl loadModelFromAOTData:data
                                     configuration:configuration
                                        methodName:methodName
@@ -223,7 +242,7 @@ ETCoreMLAssetManager * _Nullable create_asset_manager(NSString *assets_directory
     if (![self loadAndReturnError:error]) {
         return NO;
     }
-    
+
     return [self.impl purgeModelsCacheAndReturnError:error];;
 }
 
@@ -231,7 +250,7 @@ ETCoreMLAssetManager * _Nullable create_asset_manager(NSString *assets_directory
     if (![self loadAndReturnError:nil]) {
         return NO;
     }
-    
+
     return YES;
 }
 
@@ -267,20 +286,24 @@ public:
     {
         [model_manager_ loadAsynchronously];
     }
-    
+
     BackendDelegateImpl(BackendDelegateImpl const&) = delete;
     BackendDelegateImpl& operator=(BackendDelegateImpl const&) = delete;
-    
+
 Handle *init(Buffer processed,
                      const std::unordered_map<std::string, Buffer>& specs,
                      const char* method_name = nullptr,
                      const char* function_name = nullptr) const noexcept override {
         NSError *localError = nil;
-        MLModelConfiguration *configuration = get_model_configuration(specs);
-        
+        MLModelConfiguration *configuration = get_model_configuration(specs, &localError);
+        if (configuration == nil) {
+            ETCoreMLLogError(localError, "Invalid model configuration");
+            return nullptr;
+        }
+
         NSString *methodNameStr = method_name ? @(method_name) : nil;
         NSString *functionNameStr = function_name ? @(function_name) : nil;
-        
+
         NSData *data = [NSData dataWithBytesNoCopy:const_cast<void *>(processed.data())
                                             length:processed.size()
                                       freeWhenDone:NO];
@@ -294,7 +317,7 @@ Handle *init(Buffer processed,
         }
         return modelHandle;
     }
-    
+
     bool execute(Handle* handle,
                  std::vector<MultiArray>& args,
                  const ModelLoggingOptions& logging_options,
@@ -309,36 +332,36 @@ Handle *init(Buffer processed,
             if (localError != nil) {
                 ETCoreMLLogError(localError, "Model execution failed");
                 ec = static_cast<ErrorCode>(localError.code);
-            }                                    
+            }
             return false;
         }
-        
+
         return true;
     }
-    
+
     bool is_valid_handle(Handle* handle) const noexcept override {
         return [model_manager_ modelWithHandle:handle] != nil;
     }
-    
+
     bool is_available() const noexcept override {
         return static_cast<bool>(model_manager_.isAvailable);
     }
-    
+
     std::pair<size_t, size_t> get_num_arguments(Handle* handle) const noexcept override {
         ETCoreMLModel *model = [model_manager_ modelWithHandle:handle];
         return {model.orderedInputNames.count, model.orderedOutputNames.count};
     }
-    
+
     void destroy(Handle* handle) const noexcept override {
         [model_manager_ unloadModelWithHandle:handle];
     }
-    
+
     bool purge_models_cache() const noexcept override {
         NSError *localError = nil;
         bool result = static_cast<bool>([model_manager_ purgeModelsCacheAndReturnError:&localError]);
         return result;
     }
-    
+
     ETCoreMLModelManagerDelegate *model_manager_;
     Config config_;
 };

--- a/backends/apple/coreml/runtime/delegate/coreml_backend_delegate.mm
+++ b/backends/apple/coreml/runtime/delegate/coreml_backend_delegate.mm
@@ -263,6 +263,24 @@ CoreMLBackendDelegate::init(BackendInitContext& context,
         specs_map.emplace(spec.key, std::move(buffer));
     }
 
+    // Check RuntimeSpec for compute_unit override.
+    // RuntimeSpec takes precedence over CompileSpec for load-time configuration.
+    std::string runtime_compute_unit_value;
+    auto runtime_specs = context.runtime_specs();
+    if (runtime_specs.size() > 0) {
+        auto compute_unit_result = context.get_runtime_spec<const char*>("compute_unit");
+        if (compute_unit_result.ok()) {
+            runtime_compute_unit_value = compute_unit_result.get();
+            ET_LOG(Debug, "%s: Using compute_unit from RuntimeSpec: %s",
+                   ETCoreMLStrings.delegateIdentifier.UTF8String,
+                   runtime_compute_unit_value.c_str());
+            // Override the compile spec with runtime spec value
+            std::string compute_units_key(ETCoreMLStrings.computeUnitsKeyName.UTF8String);
+            auto buffer = Buffer(runtime_compute_unit_value.data(), runtime_compute_unit_value.size());
+            specs_map.insert_or_assign(compute_units_key, std::move(buffer));
+        }
+    }
+
     // This will hold the NamedDataStore data if needed, keeping it alive until scope exit
     std::optional<FreeableBuffer> namedDataStoreBuffer;
     Buffer buffer(nullptr, 0);

--- a/backends/apple/coreml/runtime/include/coreml_backend/coreml_backend_options.h
+++ b/backends/apple/coreml/runtime/include/coreml_backend/coreml_backend_options.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <executorch/runtime/backend/options.h>
+
+namespace executorch {
+namespace backends {
+namespace coreml {
+
+/**
+ * Builder for CoreML backend load-time options.
+ *
+ * This class provides a type-safe way to configure CoreML backend options
+ * that are applied when loading a model. Use with LoadBackendOptionsMap
+ * to pass options to Module::load().
+ *
+ * Example usage:
+ * @code
+ *   using executorch::backends::coreml::LoadOptionsBuilder;
+ *
+ *   LoadOptionsBuilder coreml_opts;
+ *   coreml_opts.setComputeUnit(LoadOptionsBuilder::ComputeUnit::CPU_AND_GPU);
+ *
+ *   LoadBackendOptionsMap map;
+ *   map.set_options(coreml_opts);
+ *
+ *   module.load(method_name, map);
+ * @endcode
+ */
+class LoadOptionsBuilder {
+public:
+    /**
+     * Compute unit options for CoreML backend.
+     *
+     * String values are validated in the Objective-C++ backend delegate
+     * using ETCoreMLStrings as the single source of truth.
+     */
+    enum class ComputeUnit {
+        CPU_ONLY, // "cpu_only" - Run on CPU only
+        CPU_AND_GPU, // "cpu_and_gpu" - Run on CPU and GPU
+        CPU_AND_NE, // "cpu_and_ne" - Run on CPU and Neural Engine
+        ALL // "all" - Run on all available compute units
+    };
+
+    /**
+     * Sets the target compute unit for model execution.
+     *
+     * @param unit The compute unit to use.
+     * @return Reference to this builder for chaining.
+     */
+    LoadOptionsBuilder& setComputeUnit(ComputeUnit unit) {
+        const char* value = nullptr;
+        switch (unit) {
+            case ComputeUnit::CPU_ONLY:
+                value = "cpu_only";
+                break;
+            case ComputeUnit::CPU_AND_GPU:
+                value = "cpu_and_gpu";
+                break;
+            case ComputeUnit::CPU_AND_NE:
+                value = "cpu_and_ne";
+                break;
+            case ComputeUnit::ALL:
+                value = "all";
+                break;
+        }
+        options_.set_option("compute_unit", value);
+        return *this;
+    }
+
+    /**
+     * Returns the backend identifier for this options builder.
+     */
+    static constexpr const char* backend_id() { return "CoreMLBackend"; }
+
+    /**
+     * Returns a view of the configured options.
+     */
+    ::executorch::runtime::Span<::executorch::runtime::BackendOption> view() { return options_.view(); }
+
+private:
+    ::executorch::runtime::BackendOptions<8> options_;
+};
+
+} // namespace coreml
+} // namespace backends
+} // namespace executorch

--- a/backends/apple/coreml/runtime/test/coreml_backend_options_test.cpp
+++ b/backends/apple/coreml/runtime/test/coreml_backend_options_test.cpp
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/apple/coreml/runtime/include/coreml_backend/coreml_backend_options.h>
+#include <executorch/runtime/backend/backend_options_map.h>
+#include <executorch/runtime/platform/runtime.h>
+
+#include <gtest/gtest.h>
+
+using executorch::backends::coreml::LoadOptionsBuilder;
+using executorch::runtime::BackendOption;
+using executorch::runtime::Error;
+using executorch::runtime::kMaxOptionValueLength;
+using executorch::runtime::LoadBackendOptionsMap;
+
+class CoreMLBackendOptionsTest : public ::testing::Test {
+protected:
+    void SetUp() override { executorch::runtime::runtime_init(); }
+};
+
+// Test default construction
+TEST_F(CoreMLBackendOptionsTest, DefaultConstruction) {
+    LoadOptionsBuilder builder;
+    auto options = builder.view();
+    EXPECT_EQ(options.size(), 0);
+}
+
+// Test backend_id returns correct value
+TEST_F(CoreMLBackendOptionsTest, BackendId) { EXPECT_STREQ(LoadOptionsBuilder::backend_id(), "CoreMLBackend"); }
+
+// Test setComputeUnit with CPU_ONLY
+TEST_F(CoreMLBackendOptionsTest, SetComputeUnitCpuOnly) {
+    LoadOptionsBuilder builder;
+    builder.setComputeUnit(LoadOptionsBuilder::ComputeUnit::CPU_ONLY);
+
+    auto options = builder.view();
+    EXPECT_EQ(options.size(), 1);
+    EXPECT_STREQ(options[0].key, "compute_unit");
+
+    if (auto* arr = std::get_if<std::array<char, kMaxOptionValueLength>>(&options[0].value)) {
+        EXPECT_STREQ(arr->data(), "cpu_only");
+    } else {
+        FAIL() << "Expected string value for compute_unit";
+    }
+}
+
+// Test setComputeUnit with CPU_AND_GPU
+TEST_F(CoreMLBackendOptionsTest, SetComputeUnitCpuAndGpu) {
+    LoadOptionsBuilder builder;
+    builder.setComputeUnit(LoadOptionsBuilder::ComputeUnit::CPU_AND_GPU);
+
+    auto options = builder.view();
+    EXPECT_EQ(options.size(), 1);
+
+    if (auto* arr = std::get_if<std::array<char, kMaxOptionValueLength>>(&options[0].value)) {
+        EXPECT_STREQ(arr->data(), "cpu_and_gpu");
+    } else {
+        FAIL() << "Expected string value for compute_unit";
+    }
+}
+
+// Test setComputeUnit with CPU_AND_NE
+TEST_F(CoreMLBackendOptionsTest, SetComputeUnitCpuAndNe) {
+    LoadOptionsBuilder builder;
+    builder.setComputeUnit(LoadOptionsBuilder::ComputeUnit::CPU_AND_NE);
+
+    auto options = builder.view();
+    EXPECT_EQ(options.size(), 1);
+
+    if (auto* arr = std::get_if<std::array<char, kMaxOptionValueLength>>(&options[0].value)) {
+        EXPECT_STREQ(arr->data(), "cpu_and_ne");
+    } else {
+        FAIL() << "Expected string value for compute_unit";
+    }
+}
+
+// Test setComputeUnit with ALL
+TEST_F(CoreMLBackendOptionsTest, SetComputeUnitAll) {
+    LoadOptionsBuilder builder;
+    builder.setComputeUnit(LoadOptionsBuilder::ComputeUnit::ALL);
+
+    auto options = builder.view();
+    EXPECT_EQ(options.size(), 1);
+
+    if (auto* arr = std::get_if<std::array<char, kMaxOptionValueLength>>(&options[0].value)) {
+        EXPECT_STREQ(arr->data(), "all");
+    } else {
+        FAIL() << "Expected string value for compute_unit";
+    }
+}
+
+// Test method chaining returns reference to builder
+TEST_F(CoreMLBackendOptionsTest, MethodChaining) {
+    LoadOptionsBuilder builder;
+    auto& result = builder.setComputeUnit(LoadOptionsBuilder::ComputeUnit::CPU_AND_GPU);
+
+    // Should return reference to the same builder
+    EXPECT_EQ(&result, &builder);
+}
+
+// Test integration with LoadBackendOptionsMap using template set_options
+TEST_F(CoreMLBackendOptionsTest, IntegrationWithOptionsMap) {
+    LoadOptionsBuilder coreml_opts;
+    coreml_opts.setComputeUnit(LoadOptionsBuilder::ComputeUnit::CPU_AND_NE);
+
+    LoadBackendOptionsMap map;
+    EXPECT_EQ(map.set_options(coreml_opts), Error::Ok);
+
+    EXPECT_EQ(map.size(), 1);
+    EXPECT_TRUE(map.has_options("CoreMLBackend"));
+
+    auto retrieved = map.get_options("CoreMLBackend");
+    EXPECT_EQ(retrieved.size(), 1);
+    EXPECT_STREQ(retrieved[0].key, "compute_unit");
+
+    if (auto* arr = std::get_if<std::array<char, kMaxOptionValueLength>>(&retrieved[0].value)) {
+        EXPECT_STREQ(arr->data(), "cpu_and_ne");
+    } else {
+        FAIL() << "Expected string value for compute_unit";
+    }
+}
+
+// Test that setting compute unit multiple times updates the value
+TEST_F(CoreMLBackendOptionsTest, SetComputeUnitMultipleTimes) {
+    LoadOptionsBuilder builder;
+    builder.setComputeUnit(LoadOptionsBuilder::ComputeUnit::CPU_ONLY);
+    builder.setComputeUnit(LoadOptionsBuilder::ComputeUnit::ALL);
+
+    auto options = builder.view();
+    // BackendOptions updates existing keys, so we should have 1 entry with the latest value
+    EXPECT_EQ(options.size(), 1);
+
+    if (auto* arr = std::get_if<std::array<char, kMaxOptionValueLength>>(&options[0].value)) {
+        EXPECT_STREQ(arr->data(), "all"); // Last value wins
+    } else {
+        FAIL() << "Expected string value for compute_unit";
+    }
+}


### PR DESCRIPTION
Summary:

This diff adds type-safe backend options support to the CoreML delegate, allowing users to configure compute units (CPU, GPU, Neural Engine) at model load time using the new `LoadBackendOptionsMap` infrastructure.

Key changes:
- Added `LoadOptionsBuilder` class in `coreml_backend_options.h` providing a fluent API for setting CoreML options with compile-time type safety
- `ComputeUnit` enum nested inside the builder for type-safe compute unit selection (CPU_ONLY, CPU_AND_GPU, CPU_AND_NE, ALL)
- Integrated runtime spec retrieval in `backend_delegate.mm` to read `compute_unit` option from `BackendInitContext`
- Added comprehensive unit tests for the new options builder

Example usage:
```cpp
using executorch::backends::coreml::LoadOptionsBuilder;

LoadOptionsBuilder coreml_opts;
coreml_opts.setComputeUnit(LoadOptionsBuilder::ComputeUnit::CPU_AND_GPU);

LoadBackendOptionsMap map;
map.set_options(coreml_opts);

module.load(method_name, map);
```

Differential Revision: D92358632
