### PR TITLE
Windows wheels [A]: fix XNNPACK test hang by disabling pthreadpool on Windows

### DIFF
--- a/.ci/scripts/wheel/pre_build_script.sh
+++ b/.ci/scripts/wheel/pre_build_script.sh
@@ -9,18 +9,6 @@ set -euxo pipefail
 
 # This script is run before building ExecuTorch binaries
 
-if [[ "$(uname -m)" == "aarch64" ]]; then
-  # On some Linux aarch64 systems, the "atomic" library is not found during linking.
-  # To work around this, replace "atomic" with the literal ${ATOMIC_LIB} so the
-  # build system uses the full path to the atomic library.
-  file="extension/llm/tokenizers/third-party/sentencepiece/src/CMakeLists.txt"
-  sed 's/list(APPEND SPM_LIBS "atomic")/list(APPEND SPM_LIBS ${ATOMIC_LIB})/' \
-    "$file" > "${file}.tmp" && mv "${file}.tmp" "$file"
-
-  grep -n 'list(APPEND SPM_LIBS ${ATOMIC_LIB})' "$file" && \
-    echo "the file $file has been modified for atomic to use full path"
-fi
-
 # Initialize submodules here instead of during checkout so we can use OpenSSL
 # on Windows (schannel fails with SEC_E_ILLEGAL_MESSAGE on some gitlab hosts).
 UNAME_S=$(uname -s)
@@ -42,9 +30,20 @@ else
 fi
 popd
 
+if [[ "$(uname -m)" == "aarch64" ]]; then
+  # On some Linux aarch64 systems, the "atomic" library is not found during linking.
+  # To work around this, replace "atomic" with the literal ${ATOMIC_LIB} so the
+  # build system uses the full path to the atomic library.
+  file="extension/llm/tokenizers/third-party/sentencepiece/src/CMakeLists.txt"
+  sed 's/list(APPEND SPM_LIBS "atomic")/list(APPEND SPM_LIBS ${ATOMIC_LIB})/' \
+    "$file" > "${file}.tmp" && mv "${file}.tmp" "$file"
+
+  grep -n 'list(APPEND SPM_LIBS ${ATOMIC_LIB})' "$file" && \
+    echo "the file $file has been modified for atomic to use full path"
+fi
+
 # On Windows, enable symlinks and re-checkout the current revision to create
 # the symlinked src/ directory. This is needed to build the wheel.
-UNAME_S=$(uname -s)
 if [[ $UNAME_S == *"MINGW"* || $UNAME_S == *"MSYS"* ]]; then
     echo "Enabling symlinks on Windows"
     git config core.symlinks true

--- a/.ci/scripts/wheel/pre_build_script.sh
+++ b/.ci/scripts/wheel/pre_build_script.sh
@@ -21,12 +21,20 @@ if [[ "$(uname -m)" == "aarch64" ]]; then
     echo "the file $file has been modified for atomic to use full path"
 fi
 
+# Initialize submodules here instead of during checkout so we can use OpenSSL
+# on Windows (schannel fails with SEC_E_ILLEGAL_MESSAGE on some gitlab hosts).
+UNAME_S=$(uname -s)
+if [[ $UNAME_S == *"MINGW"* || $UNAME_S == *"MSYS"* ]]; then
+  git -c http.sslBackend=openssl submodule update --init
+else
+  git submodule update --init
+fi
+
 # Clone nested submodules for tokenizers - this is a workaround for recursive
 # submodule clone failing due to path length limitations on Windows. Eventually,
 # we should update the core job in test-infra to enable long paths before
 # checkout to avoid needing to do this.
 pushd extension/llm/tokenizers
-UNAME_S=$(uname -s)
 if [[ $UNAME_S == *"MINGW"* || $UNAME_S == *"MSYS"* ]]; then
   git -c http.sslBackend=openssl submodule update --init
 else

--- a/.github/workflows/build-wheels-windows.yml
+++ b/.github/workflows/build-wheels-windows.yml
@@ -64,6 +64,7 @@ jobs:
       smoke-test-script: ${{ matrix.smoke-test-script }}
       trigger-event: ${{ github.event_name }}
       wheel-build-params: "--verbose"
+      timeout: 120
       # Submodules are initialized in pre_build_script.sh with OpenSSL to avoid
       # schannel SSL errors on Windows when cloning from non-GitHub hosts.
       submodules: false

--- a/.github/workflows/build-wheels-windows.yml
+++ b/.github/workflows/build-wheels-windows.yml
@@ -64,4 +64,6 @@ jobs:
       smoke-test-script: ${{ matrix.smoke-test-script }}
       trigger-event: ${{ github.event_name }}
       wheel-build-params: "--verbose"
-      submodules: true
+      # Submodules are initialized in pre_build_script.sh with OpenSSL to avoid
+      # schannel SSL errors on Windows when cloning from non-GitHub hosts.
+      submodules: false

--- a/extension/threadpool/threadpool.cpp
+++ b/extension/threadpool/threadpool.cpp
@@ -171,12 +171,18 @@ ThreadPool* get_threadpool() {
 }
 
 pthreadpool_t get_pthreadpool() {
+#if defined(WIN32)
+  // pthreadpool's condvar-based synchronization on Windows can deadlock
+  // with multiple threads. Return nullptr so XNNPACK runs single-threaded.
+  return nullptr;
+#else
   if (NoThreadPoolGuard::is_enabled()) {
     return nullptr;
   }
   ThreadPool* const threadpool = get_threadpool();
   ET_CHECK_MSG(threadpool, "Failed to acquire an instance of ThreadPool!");
   return threadpool->threadpool_.get();
+#endif
 }
 
 } // namespace executorch::extension::threadpool


### PR DESCRIPTION
pthreadpool's condvar-based synchronization on Windows can deadlock with multiple threads due to a lost-wakeup bug where signal_num_recruited_threads uses cnd_signal on a condition variable shared between two different wait conditions. Return nullptr from get_pthreadpool() on Windows so XNNPACK runs single-threaded.
