### PR TITLE
Windows wheels: fix smoke test hang by forcing single-threaded execution

### DIFF
--- a/.ci/scripts/wheel/test_windows.py
+++ b/.ci/scripts/wheel/test_windows.py
@@ -16,6 +16,7 @@ from executorch.examples.xnnpack.quantization.utils import quantize as quantize_
 from executorch.exir import EdgeCompileConfig, to_edge_transform_and_lower
 from executorch.extension.pybindings.portable_lib import (
     _load_for_executorch_from_buffer,
+    _unsafe_reset_threadpool,
 )
 from test_base import ModelTest
 
@@ -42,6 +43,10 @@ def test_model_xnnpack(model: Model, quantize: bool) -> None:
             _check_ir_validity=False,
         ),
     ).to_executorch()
+
+    # pthreadpool's condvar-based synchronization on Windows can deadlock
+    # with multiple threads. Force single-threaded execution.
+    _unsafe_reset_threadpool(1)
 
     loaded_model = _load_for_executorch_from_buffer(lowered.buffer)
     et_outputs = loaded_model([*example_inputs])


### PR DESCRIPTION
pthreadpool's condvar-based synchronization on Windows can deadlock with multiple threads due to a lost-wakeup bug in signal_num_recruited_threads. Reset the threadpool to 1 thread before loading the model to avoid the issue.
