### PR TITLE
Fix broken Ethos-U tutorial reference in embedded-section

### DIFF
--- a/docs/source/embedded-section.md
+++ b/docs/source/embedded-section.md
@@ -24,7 +24,7 @@ Start here for C++ development with ExecuTorch runtime APIs and essential tutori
 
 ## Tutorials
 
-- {doc}`tutorial-arm-ethos-u` — Export a simple PyTorch model for the ExecuTorch Ethos-U backend
+- {doc}`backends/arm-ethos-u/tutorials/ethos-u-getting-started` — Export a simple PyTorch model for the ExecuTorch Ethos-U backend
 - {doc}`raspberry_pi_llama_tutorial` — Deploy a LLaMA model on a Raspberry Pi
 - {doc}`pico2_tutorial` — Deploy a demo MNIST model on the Raspberry Pi Pico 2
 
@@ -38,6 +38,6 @@ extension-tensor
 using-executorch-cpp
 using-executorch-building-from-source
 embedded-backends
-tutorial-arm-ethos-u
+backends/arm-ethos-u/tutorials/ethos-u-getting-started
 raspberry_pi_llama_tutorial
 pico2_tutorial


### PR DESCRIPTION
### Summary

The tutorial was moved from docs/source/tutorial-arm-ethos-u.md to docs/source/backends/arm-ethos-u/tutorials/ethos-u-getting-started.md by docgen but this reference was not updated.