### PR TITLE
Fix XNNPACK build errors with -Werror toolchains

### DIFF
--- a/backends/xnnpack/runtime/XNNPACKBackend.cpp
+++ b/backends/xnnpack/runtime/XNNPACKBackend.cpp
@@ -44,7 +44,7 @@ using executorch::runtime::Span;
 class XnnpackBackend final
     : public ::executorch::ET_RUNTIME_NAMESPACE::BackendInterface {
  public:
-  ~XnnpackBackend() = default;
+  ~XnnpackBackend() override = default;
 
   XnnpackBackend() {
     // Initialize XNNPACK


### PR DESCRIPTION
Summary:
Fix two build errors that occur when compiling the XNNPACK backend with
strict `-Werror` toolchains (e.g. the ARVR toolchain on macOS ARM64).

**1. Undefined `XNN_ARCH_HEXAGON` macro in `xnnpack.h`**

The public header uses `#if XNN_ARCH_HEXAGON` without first including
`common.h`, which normally defines it. On non-Hexagon platforms the
macro is undefined — this silently evaluates to 0 by default, but
triggers an error with `-Wundef -Werror`.

Added a `#ifndef` guard to default the macro to 0 when not already
defined.

**2. Missing `override` on `XnnpackBackend` destructor**

The destructor overrides a virtual base class destructor but was not
marked `override`, triggering
`-Winconsistent-missing-destructor-override`.

Differential Revision: D97373597


