### PR TITLE
Fix missing `override` on XnnpackBackend destructor

### DIFF
--- a/backends/xnnpack/runtime/XNNPACKBackend.cpp
+++ b/backends/xnnpack/runtime/XNNPACKBackend.cpp
@@ -44,7 +44,7 @@ using executorch::runtime::Span;
 class XnnpackBackend final
     : public ::executorch::ET_RUNTIME_NAMESPACE::BackendInterface {
  public:
-  ~XnnpackBackend() = default;
+  ~XnnpackBackend() override = default;
 
   XnnpackBackend() {
     // Initialize XNNPACK


### PR DESCRIPTION
Summary:
Add missing `override` keyword to `XnnpackBackend::~XnnpackBackend()`.

The destructor overrides a virtual base class destructor from
`BackendInterface` but was not marked `override`, which triggers
`-Werror,-Winconsistent-missing-destructor-override` on strict
toolchains (e.g. the ARVR toolchain on macOS).

Differential Revision: D97373597


