### PR TITLE
Fuse linear projections, SiLU activation, and replace conv1d to reduce kernel launches

### DIFF
--- a/backends/cuda/triton/kernels/fused_moe.py
+++ b/backends/cuda/triton/kernels/fused_moe.py
@@ -147,6 +147,109 @@ def _fused_moe_kernel(
     tl.store(c_ptrs, acc.to(compute_type), mask=n_mask)
 
 
+@triton.jit
+def _fused_moe_silu_kernel(
+    # Pointers
+    A,  # [M * top_k, 2*inter] bf16 GEMM1 output (gate | up)
+    B,  # [E, N, K//2] int8 packed INT4 weights
+    C,  # [M * top_k, N] bf16 output
+    B_scale,  # [E, N, K//group_size] bf16 scales
+    topk_ids,  # [M * top_k] int64 expert indices
+    topk_weights,  # [M * top_k] float32 router weights
+    # Dimensions
+    N: tl.constexpr,
+    K: tl.constexpr,  # intermediate_size
+    num_token_expert_pairs,
+    # Strides
+    stride_am,
+    stride_ak,
+    stride_be,
+    stride_bk,
+    stride_bn,
+    stride_cm,
+    stride_cn,
+    stride_bse,
+    stride_bsk,
+    stride_bsn,
+    # Config
+    group_size: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    compute_type: tl.constexpr,
+):
+    """GEMM2 with fused SiLU activation.
+
+    Reads gate and up columns from GEMM1 output (A), applies SiLU(gate)*up
+    on-the-fly, and multiplies by INT4 w2 weights. Router weights are applied
+    to the output. Eliminates the intermediate activation buffer.
+    """
+    pid = tl.program_id(0)
+    num_n_blocks = tl.cdiv(N, BLOCK_SIZE_N)
+    pair_idx = pid // num_n_blocks
+    n_block = pid % num_n_blocks
+
+    if pair_idx >= num_token_expert_pairs:
+        return
+
+    expert_id = tl.load(topk_ids + pair_idx).to(tl.int64)
+
+    offs_n = n_block * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N).to(tl.int64)
+    n_mask = offs_n < N
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+
+    # A pointers: gate at columns [0, K), up at columns [K, 2*K)
+    a_gate_ptrs = A + pair_idx * stride_am + offs_k * stride_ak
+    a_up_ptrs = a_gate_ptrs + K * stride_ak
+
+    # B pointer: [expert_id, offs_n, offs_k//2]
+    b_ptrs = (
+        B
+        + expert_id * stride_be
+        + (offs_k[:, None] // 2) * stride_bk
+        + offs_n[None, :] * stride_bn
+    )
+    b_shifter = (offs_k[:, None] % 2) * 4
+
+    acc = tl.zeros((BLOCK_SIZE_N,), dtype=tl.float32)
+
+    for k_step in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_remaining = K - k_step * BLOCK_SIZE_K
+        k_mask = offs_k < k_remaining
+
+        # Load gate and up, apply SiLU(gate) * up
+        gate = tl.load(a_gate_ptrs, mask=k_mask, other=0.0).to(tl.float32)
+        up = tl.load(a_up_ptrs, mask=k_mask, other=0.0)
+        a = (gate * tl.sigmoid(gate) * up).to(compute_type)
+
+        # Load and dequantize INT4 weights
+        b = tl.load(b_ptrs, mask=k_mask[:, None] & n_mask[None, :], other=0)
+        b = (b >> b_shifter) & 0xF
+
+        scale_ptrs = (
+            B_scale
+            + expert_id * stride_bse
+            + offs_n[None, :] * stride_bsn
+            + ((offs_k[:, None] + BLOCK_SIZE_K * k_step) // group_size) * stride_bsk
+        )
+        b_scale = tl.load(
+            scale_ptrs, mask=k_mask[:, None] & n_mask[None, :], other=0.0
+        ).to(tl.float32)
+
+        b_dequant = ((b.to(tl.float32) - 8.0) * b_scale).to(compute_type)
+        acc += tl.sum(a[:, None].to(compute_type) * b_dequant, axis=0)
+
+        a_gate_ptrs += BLOCK_SIZE_K * stride_ak
+        a_up_ptrs += BLOCK_SIZE_K * stride_ak
+        b_ptrs += (BLOCK_SIZE_K // 2) * stride_bk
+
+    # Multiply by router weight
+    weight = tl.load(topk_weights + pair_idx)
+    acc = acc * weight
+
+    c_ptrs = C + pair_idx * stride_cm + offs_n * stride_cn
+    tl.store(c_ptrs, acc.to(compute_type), mask=n_mask)
+
+
 # ---------------------------------------------------------------------------
 # triton_op wrapper
 # ---------------------------------------------------------------------------
@@ -231,18 +334,13 @@ def fused_moe(
         compute_type=tl.bfloat16,
     )
 
-    # ---- Activation: SiLU(gate) * up ----
-    gate = cache1[:, :intermediate]
-    up = cache1[:, intermediate:]
-    cache2 = torch.nn.functional.silu(gate) * up
-
-    # ---- GEMM2: down projection, multiply by router weights ----
+    # ---- GEMM2 with fused SiLU: reads gate+up from cache1, no intermediate buffer ----
     cache3 = torch.empty(
         num_pairs, N2, dtype=hidden_states.dtype, device=hidden_states.device
     )
     grid2 = (num_pairs * triton.cdiv(N2, BLOCK_SIZE_N),)
-    wrap_triton(_fused_moe_kernel)[grid2](
-        cache2,
+    wrap_triton(_fused_moe_silu_kernel)[grid2](
+        cache1,
         w2,
         cache3,
         w2_scale,
@@ -251,8 +349,8 @@ def fused_moe(
         N=N2,
         K=intermediate,
         num_token_expert_pairs=num_pairs,
-        stride_am=cache2.stride(0),
-        stride_ak=cache2.stride(1),
+        stride_am=cache1.stride(0),
+        stride_ak=cache1.stride(1),
         stride_be=w2.stride(0),
         stride_bk=w2.stride(2),
         stride_bn=w2.stride(1),
@@ -264,8 +362,6 @@ def fused_moe(
         group_size=group_size,
         BLOCK_SIZE_N=BLOCK_SIZE_N,
         BLOCK_SIZE_K=BLOCK_SIZE_K,
-        MUL_ROUTED_WEIGHT=True,
-        top_k=1,
         compute_type=tl.bfloat16,
     )
 

--- a/examples/models/qwen3_5_moe/export.py
+++ b/examples/models/qwen3_5_moe/export.py
@@ -267,7 +267,6 @@ def export_and_lower(model, config, args):
         to_edge_transform_and_lower,
     )
     from executorch.exir.passes import MemoryPlanningPass
-    from torch._inductor.decomposition import conv1d_to_conv2d
     from torch.export import Dim, export
 
     # Coordinate descent recompiles each kernel trying config perturbations,
@@ -292,11 +291,6 @@ def export_and_lower(model, config, args):
             strict=True,
         )
     print("Export successful!")
-
-    # conv1d → conv2d decomposition (required for CUDA backend)
-    exported = exported.run_decompositions(
-        {torch.ops.aten.conv1d.default: conv1d_to_conv2d}
-    )
 
     # Lower with CUDA backend
     print("Lowering to ExecuTorch with CUDA...")

--- a/examples/models/qwen3_5_moe/model.py
+++ b/examples/models/qwen3_5_moe/model.py
@@ -211,15 +211,12 @@ class FullAttention(nn.Module):
         self.head_dim = config.head_dim
         self.n_kv_groups = self.n_heads // self.n_kv_heads
 
-        # q_proj includes output gate: 2x heads
-        self.q_proj = nn.Linear(
-            config.hidden_size, self.n_heads * self.head_dim * 2, bias=False
-        )
-        self.k_proj = nn.Linear(
-            config.hidden_size, self.n_kv_heads * self.head_dim, bias=False
-        )
-        self.v_proj = nn.Linear(
-            config.hidden_size, self.n_kv_heads * self.head_dim, bias=False
+        # Fused QKV: Q (with gate) + K + V in one linear
+        self.q_dim = self.n_heads * self.head_dim * 2  # Q includes output gate
+        self.k_dim = self.n_kv_heads * self.head_dim
+        self.v_dim = self.n_kv_heads * self.head_dim
+        self.qkv_proj = nn.Linear(
+            config.hidden_size, self.q_dim + self.k_dim + self.v_dim, bias=False
         )
         self.o_proj = nn.Linear(
             self.n_heads * self.head_dim, config.hidden_size, bias=False
@@ -242,13 +239,18 @@ class FullAttention(nn.Module):
         B, T, _ = x.size()
         dtype = x.dtype
 
-        # Q includes gate
-        q_and_gate = self.q_proj(x).view(B, T, self.n_heads, self.head_dim * 2)
+        # Fused QKV projection
+        qkv = self.qkv_proj(x)
+        q_and_gate = qkv[..., : self.q_dim].view(B, T, self.n_heads, self.head_dim * 2)
         q = q_and_gate[..., : self.head_dim]
         gate = q_and_gate[..., self.head_dim :]
 
-        k = self.k_proj(x).view(B, T, self.n_kv_heads, self.head_dim)
-        v = self.v_proj(x).view(B, T, self.n_kv_heads, self.head_dim)
+        k = qkv[..., self.q_dim : self.q_dim + self.k_dim].view(
+            B, T, self.n_kv_heads, self.head_dim
+        )
+        v = qkv[..., self.q_dim + self.k_dim :].view(
+            B, T, self.n_kv_heads, self.head_dim
+        )
 
         # QK-norm before RoPE
         q = self.q_norm(q)
@@ -305,11 +307,9 @@ class GatedDeltaNet(nn.Module):
 
         self.conv_dim = self.key_dim * 2 + self.value_dim
 
-        # Separate projections (matching HF checkpoint structure)
-        self.in_proj_qkv = nn.Linear(config.hidden_size, self.conv_dim, bias=False)
-        self.in_proj_z = nn.Linear(config.hidden_size, self.value_dim, bias=False)
-        self.in_proj_b = nn.Linear(config.hidden_size, self.num_v_heads, bias=False)
-        self.in_proj_a = nn.Linear(config.hidden_size, self.num_v_heads, bias=False)
+        # Fused input projection: qkv + z + b + a in one linear
+        self.in_proj_dim = self.conv_dim + self.value_dim + 2 * self.num_v_heads
+        self.in_proj = nn.Linear(config.hidden_size, self.in_proj_dim, bias=False)
 
         self.conv1d = nn.Conv1d(
             self.conv_dim,
@@ -345,21 +345,33 @@ class GatedDeltaNet(nn.Module):
         self.conv_state[:B].mul_(keep)
         self.recurrent_state[:B].mul_(keep)
 
-        # Projections
-        mixed_qkv = self.in_proj_qkv(x)
-        z = self.in_proj_z(x).reshape(B, T, self.num_v_heads, self.head_v_dim)
-        b = self.in_proj_b(x)
-        a = self.in_proj_a(x)
+        # Fused projection: split into qkv, z, b, a
+        proj = self.in_proj(x)
+        cd = self.conv_dim
+        vd = self.value_dim
+        nh = self.num_v_heads
+        mixed_qkv = proj[..., :cd]
+        z = proj[..., cd : cd + vd].reshape(B, T, self.num_v_heads, self.head_v_dim)
+        b = proj[..., cd + vd : cd + vd + nh]
+        a = proj[..., cd + vd + nh :]
 
-        # Causal conv1d with state
+        # Causal depthwise conv1d with state (manual, avoids conv1d→conv2d decomposition)
         qkv_t = mixed_qkv.transpose(1, 2)
         conv_input = torch.cat([self.conv_state[:B], qkv_t], dim=-1)
         with torch.no_grad():
             self.conv_state[:B].copy_(conv_input[:, :, -self.conv_kernel_size :])
-        qkv_conv = F.conv1d(
-            conv_input, self.conv1d.weight, bias=None, padding=0, groups=self.conv_dim
+        w = self.conv1d.weight.squeeze(1).float()  # [C, 1, K] -> [C, K]
+        T_conv = conv_input.shape[-1] - self.conv_kernel_size + 1
+        acc = torch.zeros(
+            B,
+            conv_input.shape[1],
+            T_conv,
+            dtype=torch.float32,
+            device=conv_input.device,
         )
-        qkv_conv = F.silu(qkv_conv[:, :, -T:]).transpose(1, 2)
+        for k in range(self.conv_kernel_size):
+            acc = acc + conv_input[:, :, k : k + T_conv].float() * w[:, k : k + 1]
+        qkv_conv = F.silu(acc[:, :, -T:]).to(conv_input.dtype).transpose(1, 2)
 
         # Split via slicing (torch.split produces split_copy which lacks AOTI fallback)
         kd = self.key_dim
@@ -450,16 +462,19 @@ class FusedMoEExperts(nn.Module):
 
 
 class SwiGLU(nn.Module):
-    """SwiGLU MLP for shared expert."""
+    """SwiGLU MLP with fused gate+up projection."""
 
     def __init__(self, hidden_size, intermediate_size):
         super().__init__()
-        self.gate_proj = nn.Linear(hidden_size, intermediate_size, bias=False)
-        self.up_proj = nn.Linear(hidden_size, intermediate_size, bias=False)
+        self.gate_up_proj = nn.Linear(hidden_size, 2 * intermediate_size, bias=False)
         self.down_proj = nn.Linear(intermediate_size, hidden_size, bias=False)
+        self.intermediate_size = intermediate_size
 
     def forward(self, x):
-        return self.down_proj(F.silu(self.gate_proj(x)) * self.up_proj(x))
+        gate_up = self.gate_up_proj(x)
+        gate = gate_up[..., : self.intermediate_size]
+        up = gate_up[..., self.intermediate_size :]
+        return self.down_proj(F.silu(gate) * up)
 
 
 class SparseMoE(nn.Module):
@@ -650,11 +665,59 @@ def _load_and_remap_checkpoint(model_dir, config):
                 )  # (E, D, H)
         del expert_weights
 
+    # Fuse projection weights to reduce kernel launches
+    _fuse_projection_weights(state_dict, config)
+
     # Handle tied embeddings
     if "lm_head.weight" not in state_dict and "embed_tokens.weight" in state_dict:
         state_dict["lm_head.weight"] = state_dict["embed_tokens.weight"].clone()
 
     return state_dict
+
+
+def _fuse_projection_weights(state_dict, config):
+    """Fuse separate projection weights into single matrices."""
+    for i in range(config.num_hidden_layers):
+        layer_type = config.layer_types[i]
+
+        if layer_type == "full_attention":
+            # Fuse Q + K + V into qkv_proj
+            q_key = f"layers.{i}.attn._q_proj.weight"
+            k_key = f"layers.{i}.attn._k_proj.weight"
+            v_key = f"layers.{i}.attn._v_proj.weight"
+            if q_key in state_dict:
+                state_dict[f"layers.{i}.attn.qkv_proj.weight"] = torch.cat(
+                    [
+                        state_dict.pop(q_key),
+                        state_dict.pop(k_key),
+                        state_dict.pop(v_key),
+                    ],
+                    dim=0,
+                )
+        else:
+            # Fuse GDN in_proj_qkv + in_proj_z + in_proj_b + in_proj_a
+            qkv_key = f"layers.{i}.attn._in_proj_qkv.weight"
+            z_key = f"layers.{i}.attn._in_proj_z.weight"
+            b_key = f"layers.{i}.attn._in_proj_b.weight"
+            a_key = f"layers.{i}.attn._in_proj_a.weight"
+            if qkv_key in state_dict:
+                state_dict[f"layers.{i}.attn.in_proj.weight"] = torch.cat(
+                    [
+                        state_dict.pop(qkv_key),
+                        state_dict.pop(z_key),
+                        state_dict.pop(b_key),
+                        state_dict.pop(a_key),
+                    ],
+                    dim=0,
+                )
+
+        # Fuse shared expert gate + up into gate_up_proj
+        gate_key = f"layers.{i}.mlp.shared_expert._gate_proj.weight"
+        up_key = f"layers.{i}.mlp.shared_expert._up_proj.weight"
+        if gate_key in state_dict:
+            state_dict[f"layers.{i}.mlp.shared_expert.gate_up_proj.weight"] = torch.cat(
+                [state_dict.pop(gate_key), state_dict.pop(up_key)], dim=0
+            )
 
 
 def _process_checkpoint_key(ckpt_key, tensor, state_dict, expert_weights):
@@ -704,18 +767,18 @@ _HF_KEY_MAP = {
     # Layer norms
     "model.layers.{}.input_layernorm.weight": "layers.{}.ln_1.weight",
     "model.layers.{}.post_attention_layernorm.weight": "layers.{}.ln_2.weight",
-    # Full attention
-    "model.layers.{}.self_attn.q_proj.weight": "layers.{}.attn.q_proj.weight",
-    "model.layers.{}.self_attn.k_proj.weight": "layers.{}.attn.k_proj.weight",
-    "model.layers.{}.self_attn.v_proj.weight": "layers.{}.attn.v_proj.weight",
+    # Full attention (separate Q/K/V loaded then fused in post-processing)
+    "model.layers.{}.self_attn.q_proj.weight": "layers.{}.attn._q_proj.weight",
+    "model.layers.{}.self_attn.k_proj.weight": "layers.{}.attn._k_proj.weight",
+    "model.layers.{}.self_attn.v_proj.weight": "layers.{}.attn._v_proj.weight",
     "model.layers.{}.self_attn.o_proj.weight": "layers.{}.attn.o_proj.weight",
     "model.layers.{}.self_attn.q_norm.weight": "layers.{}.attn.q_norm.weight",
     "model.layers.{}.self_attn.k_norm.weight": "layers.{}.attn.k_norm.weight",
-    # GatedDeltaNet
-    "model.layers.{}.linear_attn.in_proj_qkv.weight": "layers.{}.attn.in_proj_qkv.weight",
-    "model.layers.{}.linear_attn.in_proj_z.weight": "layers.{}.attn.in_proj_z.weight",
-    "model.layers.{}.linear_attn.in_proj_b.weight": "layers.{}.attn.in_proj_b.weight",
-    "model.layers.{}.linear_attn.in_proj_a.weight": "layers.{}.attn.in_proj_a.weight",
+    # GatedDeltaNet (separate projections loaded then fused in post-processing)
+    "model.layers.{}.linear_attn.in_proj_qkv.weight": "layers.{}.attn._in_proj_qkv.weight",
+    "model.layers.{}.linear_attn.in_proj_z.weight": "layers.{}.attn._in_proj_z.weight",
+    "model.layers.{}.linear_attn.in_proj_b.weight": "layers.{}.attn._in_proj_b.weight",
+    "model.layers.{}.linear_attn.in_proj_a.weight": "layers.{}.attn._in_proj_a.weight",
     "model.layers.{}.linear_attn.conv1d.weight": "layers.{}.attn.conv1d.weight",
     "model.layers.{}.linear_attn.dt_bias": "layers.{}.attn.dt_bias",
     "model.layers.{}.linear_attn.A_log": "layers.{}.attn.A_log",
@@ -724,8 +787,9 @@ _HF_KEY_MAP = {
     # MoE (non-expert)
     "model.layers.{}.mlp.gate.weight": "layers.{}.mlp.gate.weight",
     "model.layers.{}.mlp.shared_expert_gate.weight": "layers.{}.mlp.shared_expert_gate.weight",
-    "model.layers.{}.mlp.shared_expert.gate_proj.weight": "layers.{}.mlp.shared_expert.gate_proj.weight",
-    "model.layers.{}.mlp.shared_expert.up_proj.weight": "layers.{}.mlp.shared_expert.up_proj.weight",
+    # Shared expert (separate gate/up loaded then fused in post-processing)
+    "model.layers.{}.mlp.shared_expert.gate_proj.weight": "layers.{}.mlp.shared_expert._gate_proj.weight",
+    "model.layers.{}.mlp.shared_expert.up_proj.weight": "layers.{}.mlp.shared_expert._up_proj.weight",
     "model.layers.{}.mlp.shared_expert.down_proj.weight": "layers.{}.mlp.shared_expert.down_proj.weight",
 }
 


### PR DESCRIPTION
Apply 5 optimizations validated on nano_qwen35_moe:

1. Fuse SiLU into MoE GEMM2: new _fused_moe_silu_kernel reads gate+up
   from GEMM1 output and applies SiLU on-the-fly during GEMM2,
   eliminating the intermediate buffer and 1 kernel launch per layer.

2. Fuse QKV projections in full attention: separate q_proj, k_proj,
   v_proj replaced with single qkv_proj. Saves 2 kernel launches per
   full attention layer (10 layers = 20 launches).

3. Fuse GDN input projections: separate in_proj_qkv, in_proj_z,
   in_proj_b, in_proj_a replaced with single in_proj. Saves 3 kernel
   launches per GDN layer (30 layers = 90 launches).

4. Fuse gate+up in shared expert: separate gate_proj, up_proj replaced
   with single gate_up_proj. Saves 1 kernel launch per layer (40
   layers = 40 launches).

5. Replace F.conv1d with manual depthwise conv (4 slice-multiply-adds).
   The conv1d->conv2d decomposition generated a catastrophically slow
   Triton kernel (2.1ms/call at 8192 channels). The manual approach
   produces simple element-wise ops that Inductor fuses efficiently.
   Eliminates 81.8% of decode CUDA time (64ms -> 4ms per step).

Before: 

Decode latency: 12.41 tokens/s
Prefill latency: 47.3 tokens/s

After

Decode latency: 58.5 tokens/s
Prefill latency: 96 tokens/s

on A100
