### PR TITLE
Default LLM Android model loading to mmap-only (no mlock)

### DIFF
--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmModule.java
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmModule.java
@@ -34,6 +34,7 @@ public class LlmModule {
   private static final float DEFAULT_TEMPERATURE = -1.0f;
   private static final int DEFAULT_BOS = 0;
   private static final int DEFAULT_EOS = 0;
+  private static final int DEFAULT_LOAD_MODE = LlmModuleConfig.LOAD_MODE_MMAP;
 
   @DoNotStrip
   private static native HybridData initHybrid(
@@ -43,7 +44,26 @@ public class LlmModule {
       float temperature,
       List<String> dataFiles,
       int numBos,
-      int numEos);
+      int numEos,
+      int loadMode);
+
+  private LlmModule(
+      int modelType,
+      String modulePath,
+      String tokenizerPath,
+      float temperature,
+      List<String> dataFiles,
+      int numBos,
+      int numEos,
+      int loadMode) {
+    ExecuTorchRuntime.getRuntime();
+    ExecuTorchRuntime.validateFilePath(modulePath, "model path");
+    ExecuTorchRuntime.validateFilePath(tokenizerPath, "tokenizer path");
+
+    mHybridData =
+        initHybrid(
+            modelType, modulePath, tokenizerPath, temperature, dataFiles, numBos, numEos, loadMode);
+  }
 
   /**
    * Constructs a LLM Module for a model with given type, model path, tokenizer, temperature, and
@@ -57,12 +77,15 @@ public class LlmModule {
       List<String> dataFiles,
       int numBos,
       int numEos) {
-    ExecuTorchRuntime.getRuntime();
-    ExecuTorchRuntime.validateFilePath(modulePath, "model path");
-    ExecuTorchRuntime.validateFilePath(tokenizerPath, "tokenizer path");
-
-    mHybridData =
-        initHybrid(modelType, modulePath, tokenizerPath, temperature, dataFiles, numBos, numEos);
+    this(
+        modelType,
+        modulePath,
+        tokenizerPath,
+        temperature,
+        dataFiles,
+        numBos,
+        numEos,
+        DEFAULT_LOAD_MODE);
   }
 
   /**
@@ -75,7 +98,15 @@ public class LlmModule {
       String tokenizerPath,
       float temperature,
       List<String> dataFiles) {
-    this(modelType, modulePath, tokenizerPath, temperature, dataFiles, DEFAULT_BOS, DEFAULT_EOS);
+    this(
+        modelType,
+        modulePath,
+        tokenizerPath,
+        temperature,
+        dataFiles,
+        DEFAULT_BOS,
+        DEFAULT_EOS,
+        DEFAULT_LOAD_MODE);
   }
 
   /**
@@ -148,9 +179,10 @@ public class LlmModule {
         config.getModulePath(),
         config.getTokenizerPath(),
         config.getTemperature(),
-        config.getDataPath(),
+        config.getDataPath() != null ? List.of(config.getDataPath()) : List.of(),
         config.getNumBos(),
-        config.getNumEos());
+        config.getNumEos(),
+        config.getLoadMode());
   }
 
   public void resetNative() {

--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmModuleConfig.java
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmModuleConfig.java
@@ -21,6 +21,19 @@ public class LlmModuleConfig {
   private final int modelType;
   private final int numBos;
   private final int numEos;
+  private final int loadMode;
+
+  /** Load entire model file into a buffer (no mmap). */
+  public static final int LOAD_MODE_FILE = 0;
+
+  /** Load model via mmap without mlock (default). Pages faulted in on demand. */
+  public static final int LOAD_MODE_MMAP = 1;
+
+  /** Load model via mmap and pin all pages with mlock. */
+  public static final int LOAD_MODE_MMAP_USE_MLOCK = 2;
+
+  /** Load model via mmap and attempt mlock, ignoring mlock failures. */
+  public static final int LOAD_MODE_MMAP_USE_MLOCK_IGNORE_ERRORS = 3;
 
   private LlmModuleConfig(Builder builder) {
     this.modulePath = builder.modulePath;
@@ -30,6 +43,7 @@ public class LlmModuleConfig {
     this.modelType = builder.modelType;
     this.numBos = builder.numBos;
     this.numEos = builder.numEos;
+    this.loadMode = builder.loadMode;
   }
 
   /** Model type constant for text-only models. */
@@ -101,6 +115,13 @@ public class LlmModuleConfig {
   }
 
   /**
+   * @return Load mode for the model file (one of LOAD_MODE_* constants)
+   */
+  public int getLoadMode() {
+    return loadMode;
+  }
+
+  /**
    * Builder class for constructing LlmModuleConfig instances with optional parameters.
    *
    * <p>The builder provides a fluent interface for configuring model parameters and validates
@@ -114,6 +135,7 @@ public class LlmModuleConfig {
     private int modelType = MODEL_TYPE_TEXT;
     private int numBos = 0;
     private int numEos = 0;
+    private int loadMode = LOAD_MODE_MMAP;
 
     Builder() {}
 
@@ -191,6 +213,26 @@ public class LlmModuleConfig {
      */
     public Builder numEos(int numEos) {
       this.numEos = numEos;
+      return this;
+    }
+
+    /**
+     * Sets the load mode for the model file. Defaults to {@link #LOAD_MODE_MMAP} (mmap without
+     * mlock), which avoids pinning model pages in RAM.
+     *
+     * @param loadMode One of LOAD_MODE_FILE, LOAD_MODE_MMAP, LOAD_MODE_MMAP_USE_MLOCK,
+     *     LOAD_MODE_MMAP_USE_MLOCK_IGNORE_ERRORS
+     * @return This builder instance for method chaining
+     * @throws IllegalArgumentException if {@code loadMode} is not one of the supported constants
+     */
+    public Builder loadMode(int loadMode) {
+      if (loadMode != LOAD_MODE_FILE
+          && loadMode != LOAD_MODE_MMAP
+          && loadMode != LOAD_MODE_MMAP_USE_MLOCK
+          && loadMode != LOAD_MODE_MMAP_USE_MLOCK_IGNORE_ERRORS) {
+        throw new IllegalArgumentException("Unknown load mode: " + loadMode);
+      }
+      this.loadMode = loadMode;
       return this;
     }
 

--- a/extension/android/jni/jni_layer_llama.cpp
+++ b/extension/android/jni/jni_layer_llama.cpp
@@ -109,7 +109,8 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
       facebook::jni::alias_ref<facebook::jni::JList<jstring>::javaobject>
           data_files,
       jint num_bos,
-      jint num_eos) {
+      jint num_eos,
+      jint load_mode) {
     return makeCxxInstance(
         model_type_category,
         model_path,
@@ -117,7 +118,25 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
         temperature,
         data_files,
         num_bos,
-        num_eos);
+        num_eos,
+        load_mode);
+  }
+
+  static executorch::extension::Module::LoadMode load_mode_from_int(
+      jint load_mode) {
+    switch (load_mode) {
+      case 0:
+        return executorch::extension::Module::LoadMode::File;
+      case 1:
+        return executorch::extension::Module::LoadMode::Mmap;
+      case 2:
+        return executorch::extension::Module::LoadMode::MmapUseMlock;
+      case 3:
+        return executorch::extension::Module::LoadMode::
+            MmapUseMlockIgnoreErrors;
+      default:
+        return executorch::extension::Module::LoadMode::Mmap;
+    }
   }
 
   ExecuTorchLlmJni(
@@ -127,7 +146,8 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
       jfloat temperature,
       facebook::jni::alias_ref<jobject> data_files = nullptr,
       jint num_bos = 0,
-      jint num_eos = 0) {
+      jint num_eos = 0,
+      jint load_mode = 1) {
     temperature_ = temperature;
     num_bos_ = num_bos;
     num_eos_ = num_eos;
@@ -143,13 +163,14 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
 #endif
 
     model_type_category_ = model_type_category;
+    auto cpp_load_mode = load_mode_from_int(load_mode);
     std::vector<std::string> data_files_vector;
     if (model_type_category == MODEL_TYPE_CATEGORY_MULTIMODAL) {
       runner_ = llm::create_multimodal_runner(
           model_path->toStdString().c_str(),
           llm::load_tokenizer(tokenizer_path->toStdString()),
           std::nullopt,
-          executorch::extension::Module::LoadMode::MmapUseMlockIgnoreErrors);
+          cpp_load_mode);
     } else if (model_type_category == MODEL_TYPE_CATEGORY_LLM) {
       if (data_files != nullptr) {
         // Convert Java List<String> to C++ std::vector<string>
@@ -169,14 +190,18 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
       runner_ = executorch::extension::llm::create_text_llm_runner(
           model_path->toStdString(),
           llm::load_tokenizer(tokenizer_path->toStdString()),
-          data_files_vector);
+          data_files_vector,
+          /*temperature=*/-1.0f,
+          /*event_tracer=*/nullptr,
+          /*method_name=*/"forward",
+          cpp_load_mode);
 #if defined(EXECUTORCH_BUILD_QNN)
     } else if (model_type_category == MODEL_TYPE_QNN_LLAMA) {
-      std::unique_ptr<executorch::extension::Module> module = std::make_unique<
-          executorch::extension::Module>(
-          model_path->toStdString().c_str(),
-          data_files_vector,
-          executorch::extension::Module::LoadMode::MmapUseMlockIgnoreErrors);
+      std::unique_ptr<executorch::extension::Module> module =
+          std::make_unique<executorch::extension::Module>(
+              model_path->toStdString().c_str(),
+              data_files_vector,
+              cpp_load_mode);
       std::string decoder_model = "llama3"; // use llama3 for now
       runner_ = std::make_unique<example::Runner<uint16_t>>( // QNN runner
           std::move(module),


### PR DESCRIPTION
On Android, ExecuTorch LLM apps previously used mmap+mlock to load .pte model files. While mmap memory-maps the file (pages loaded on demand), mlock pins all mapped pages into physical RAM upfront — defeating mmap's lazy-loading benefit for large models (1-4GB). This causes high OOM kill risk on devices with 6-12GB RAM shared across all apps.

Changes:
- LlmModuleConfig.java: Add LOAD_MODE_* constants and loadMode field (default LOAD_MODE_MMAP) with builder method and getter
- LlmModule.java: Thread loadMode through to JNI initHybrid; existing constructors default to LOAD_MODE_MMAP — no breaking change
- jni_layer_llama.cpp: Accept loadMode from Java, map to C++ Module::LoadMode enum, pass to all runner creation paths (text, multimodal, QNN) instead of hardcoded MmapUseMlockIgnoreErrors

Apps needing the old behavior can pass LOAD_MODE_MMAP_USE_MLOCK_IGNORE_ERRORS.
