### PR TITLE
Arm backend: Fix pre-push assuming env setup

### DIFF
--- a/backends/arm/scripts/pre-push
+++ b/backends/arm/scripts/pre-push
@@ -53,7 +53,7 @@ is_docgen_trigger_file() {
 
 run_docgen_check() {
     echo -e "${INFO} Running Arm docgen"
-    env/bin/python backends/arm/scripts/docgen/docgen.py
+    python backends/arm/scripts/docgen/docgen.py
     if [[ $? -ne 0 ]]; then
         echo -e "${ERROR} Failed to run Arm docgen"
         FAILED=1


### PR DESCRIPTION
The pre-push script was assuming the virtual environment was called "env". Remove this assumption and just execute with `python`.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @robell