### PR TITLE
Fix ModAI recipe and add a CLI ModAI zoo runner

### DIFF
--- a/backends/cadence/aot/compiler.py
+++ b/backends/cadence/aot/compiler.py
@@ -148,7 +148,11 @@ def apply_pre_edge_transform_passes(
     quantizer: CadenceQuantizer,
 ) -> ExportedProgram:
     """
-    Fuse a converted exported program using the given quantizer.
+    Apply pre-edge transform passes including QuantFusion and torch ops passes.
+    This mirrors the Cadence AOT compiler flow:
+    1. QuantFusion - fuses dq->op->q patterns
+    2. apply_torch_ops_passes - applied just before to_edge()
+
     The quantizer must be the same as the one used to convert the model.
     If you do not expect that behavior, please use quantize_pt2 instead,
     which will instantiate a default quantizer for you if needed.
@@ -158,6 +162,9 @@ def apply_pre_edge_transform_passes(
     # pyre-ignore[16]: no attribute
     patterns = [q.pattern for q in quantizer.quantizers]
     fused_program = _transform(converted_program, QuantFusion(patterns))
+
+    # Apply torch ops passes (e.g., ReplaceMulTensorWithMulAndFullOpsPass)
+    fused_program = apply_torch_ops_passes(fused_program)
 
     return fused_program
 


### PR DESCRIPTION
Summary:
### Summary

This diff fixes the ModAI recipe and adds a CLI ModAI zoo runner.

### ModAI Recipe Fix

The diff updates the `cadence.py` file to apply the same passes as the regular flow. It will be updated again to have a better split.

### ModAI Zoo Runner

The diff adds a new file `zoo_runner_modai.py` to create a CLI ModAI zoo runner. This runner uses the `modai` SDK to run models from the ModAI zoo. The runner is added to the `BUCK` file in both `fbcode` and `xplat` directories.

Reviewed By: ethansfng

Differential Revision: D95989086


