### PR TITLE
Run a subset of backend test suite on pull

### DIFF
--- a/.github/workflows/test-backend-arm.yml
+++ b/.github/workflows/test-backend-arm.yml
@@ -5,16 +5,11 @@ on:
     - cron: 0 2 * * *
   push:
     branches:
+      - main
       - release/*
     tags:
       - ciflow/nightly/*
   pull_request:
-    paths:
-      - .github/workflows/test-backend-arm.yml
-      - .github/workflows/_test_backend.yml
-      - .ci/scripts/test_backend.sh
-      - backends/test/suite/flow.py
-      - backends/test/suite/flows/arm.py
   workflow_dispatch:
 
 concurrency:
@@ -26,7 +21,10 @@ jobs:
     uses: ./.github/workflows/_test_backend.yml
     with:
       backend: arm
-      flows: '["arm_tosa_fp", "arm_tosa_int", "arm_ethos_u55", "arm_ethos_u85", "arm_vgf_fp", "arm_vgf_int"]'
+      flows: >-
+        ${{ github.event_name == 'pull_request'
+            && '["arm_tosa_fp", "arm_vgf_fp"]'
+            || '["arm_tosa_fp", "arm_tosa_int", "arm_ethos_u55", "arm_ethos_u85", "arm_vgf_fp", "arm_vgf_int"]' }}
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout: 120
       run-linux: true

--- a/.github/workflows/test-backend-coreml.yml
+++ b/.github/workflows/test-backend-coreml.yml
@@ -5,13 +5,11 @@ on:
     - cron: 0 2 * * *
   push:
     branches:
+      - main
       - release/*
     tags:
       - ciflow/nightly/*
   pull_request:
-    paths:
-      - .github/workflows/test-backend-coreml.yml
-      - .github/workflows/_test_backend.yml
   workflow_dispatch:
 
 concurrency:
@@ -23,7 +21,10 @@ jobs:
     uses: ./.github/workflows/_test_backend.yml
     with:
       backend: coreml
-      flows: '["coreml", "coreml_static_int8"]'
+      flows: >-
+        ${{ github.event_name == 'pull_request'
+            && '["coreml"]'
+            || '["coreml", "coreml_static_int8"]' }}
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout: 120
       run-macos: true

--- a/.github/workflows/test-backend-qnn.yml
+++ b/.github/workflows/test-backend-qnn.yml
@@ -5,13 +5,11 @@ on:
     - cron: 0 2 * * *
   push:
     branches:
+      - main
       - release/*
     tags:
       - ciflow/nightly/*
   pull_request:
-    paths:
-      - .github/workflows/test-backend-qnn.yml
-      - .github/workflows/_test_backend.yml
   workflow_dispatch:
 
 concurrency:
@@ -23,7 +21,10 @@ jobs:
     uses: ./.github/workflows/_test_backend.yml
     with:
       backend: qnn
-      flows: '["qnn", "qnn_16a16w", "qnn_16a8w", "qnn_16a4w", "qnn_16a4w_block", "qnn_8a8w"]'
+      flows: >-
+        ${{ github.event_name == 'pull_request'
+            && '["qnn"]'
+            || '["qnn", "qnn_16a16w", "qnn_16a8w", "qnn_16a4w", "qnn_16a4w_block", "qnn_8a8w"]' }}
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout: 120
       run-linux: true

--- a/.github/workflows/test-backend-vulkan.yml
+++ b/.github/workflows/test-backend-vulkan.yml
@@ -5,13 +5,11 @@ on:
     - cron: 0 2 * * *
   push:
     branches:
+      - main
       - release/*
     tags:
       - ciflow/nightly/*
   pull_request:
-    paths:
-      - .github/workflows/test-backend-vulkan.yml
-      - .github/workflows/_test_backend.yml
   workflow_dispatch:
 
 concurrency:
@@ -23,7 +21,10 @@ jobs:
     uses: ./.github/workflows/_test_backend.yml
     with:
       backend: vulkan
-      flows: '["vulkan", "vulkan_static_int8_per_channel"]'
+      flows: >-
+        ${{ github.event_name == 'pull_request'
+            && '["vulkan"]'
+            || '["vulkan", "vulkan_static_int8_per_channel"]' }}
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout: 120
       run-linux: true

--- a/.github/workflows/test-backend-xnnpack.yml
+++ b/.github/workflows/test-backend-xnnpack.yml
@@ -5,16 +5,11 @@ on:
     - cron: 0 2 * * *
   push:
     branches:
+      - main
       - release/*
     tags:
       - ciflow/nightly/*
   pull_request:
-    paths:
-      - .github/workflows/test-backend-xnnpack.yml
-      - .github/workflows/_test_backend.yml
-      - .ci/scripts/test_backend.sh
-      - backends/test/harness/**
-      - backends/test/suite/**
   workflow_dispatch:
 
 concurrency:
@@ -26,7 +21,10 @@ jobs:
     uses: ./.github/workflows/_test_backend.yml
     with:
       backend: xnnpack
-      flows: '["xnnpack", "xnnpack_dynamic_int8_per_channel", "xnnpack_static_int8_per_channel", "xnnpack_static_int8_per_tensor"]'
+      flows: >-
+        ${{ github.event_name == 'pull_request'
+            && '["xnnpack"]'
+            || '["xnnpack", "xnnpack_dynamic_int8_per_channel", "xnnpack_static_int8_per_channel", "xnnpack_static_int8_per_tensor"]' }}
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout: 120
       run-linux: true


### PR DESCRIPTION
### Summary
Run a subset of operator and model tests on pull. This should help keep these jobs healthy and give better signal.