### PR TITLE
Handle Byte scalar type in quantized conv2d NHWC (#18427)

### DIFF
--- a/backends/cadence/hifi/operators/op_quantized_conv2d_nhwc_out.cpp
+++ b/backends/cadence/hifi/operators/op_quantized_conv2d_nhwc_out.cpp
@@ -166,7 +166,8 @@ void xa_opt_quantized_conv2d_nhwc(
   bool conv1d = input.dim() == 3;
   constexpr int kNnlibMaxDim = 4;
 
-  if (input.scalar_type() == ScalarType::Char) {
+  if (input.scalar_type() == ScalarType::Char ||
+      input.scalar_type() == ScalarType::Byte) {
     WORD8* __restrict__ p_out =
         (WORD8* __restrict__)out.mutable_data_ptr<int8_t>();
     WORD8* __restrict__ p_inp =

--- a/backends/cadence/hifi/operators/op_quantized_conv2d_nhwc_out.cpp
+++ b/backends/cadence/hifi/operators/op_quantized_conv2d_nhwc_out.cpp
@@ -303,6 +303,28 @@ void xa_opt_quantized_conv2d_nhwc(
     if (groups == input_channels) {
       WORD32 channels_multiplier = out_channels / input_channels;
 
+      // The NNLib depthwise function expects weights in [KH, KW, OC] layout.
+      // When is_depthwise is false, the weight is 4D [OC, KH, KW, IC/G] and
+      // needs to be rearranged from [OC, KH, KW] to [KH, KW, OC].
+      WORD8* p_kernel_dw = p_kernel;
+      if (!is_depthwise) {
+        WORD32 weight_size = kernel_height * kernel_width * out_channels;
+        p_kernel_dw =
+            (WORD8*)kernels::allocate_temp_memory(ctx, weight_size);
+        for (WORD32 oc = 0; oc < out_channels; oc++) {
+          for (WORD32 kh = 0; kh < kernel_height; kh++) {
+            for (WORD32 kw = 0; kw < kernel_width; kw++) {
+              p_kernel_dw
+                  [kh * kernel_width * out_channels + kw * out_channels + oc] =
+                      p_kernel
+                          [oc * kernel_height * kernel_width * kernel_channels +
+                           kh * kernel_width * kernel_channels +
+                           kw * kernel_channels];
+            }
+          }
+        }
+      }
+
       scratch_size = xa_nn_conv2d_depthwise_getsize(
           input_height,
           input_width,
@@ -332,7 +354,7 @@ void xa_opt_quantized_conv2d_nhwc(
 
         xa_nn_conv2d_depthwise_per_chan_sym8sxasym8s(
             out_batch,
-            p_kernel,
+            p_kernel_dw,
             in_batch,
             p_bias,
             input_height,


### PR DESCRIPTION
Summary:

Extend the quantized conv2d NHWC operator to accept `ScalarType::Byte` (uint8) inputs in addition to `ScalarType::Char` (int8), enabling unsigned 8-bit quantized inference through the same HiFi code path.

Differential Revision: D97819850
