### PR TITLE
[RELEASE TEST] Fix Docker build failure for cuda-windows image by using CUDA_VERSION build arg

### DIFF
--- a/.ci/docker/common/install_cuda_windows_cross_compile.sh
+++ b/.ci/docker/common/install_cuda_windows_cross_compile.sh
@@ -48,19 +48,22 @@ get_torch_cuda_version() {
 }
 
 install_windows_cuda() {
-    # Get CUDA version from torch
-    TORCH_CUDA_VERSION=$(get_torch_cuda_version)
+    # Use CUDA_VERSION env var if set (from Docker build arg), otherwise query PyTorch
+    if [ -n "${CUDA_VERSION:-}" ]; then
+        echo "Using CUDA version from environment: ${CUDA_VERSION}"
+        CUDA_MAJOR_MINOR=$(echo "${CUDA_VERSION}" | cut -d. -f1,2)
+    else
+        TORCH_CUDA_VERSION=$(get_torch_cuda_version)
 
-    if [ -z "${TORCH_CUDA_VERSION}" ] || [ "${TORCH_CUDA_VERSION}" = "None" ]; then
-        echo "ERROR: Could not detect CUDA version from PyTorch."
-        echo "Make sure PyTorch with CUDA support is installed before running this script."
-        exit 1
+        if [ -z "${TORCH_CUDA_VERSION}" ] || [ "${TORCH_CUDA_VERSION}" = "None" ]; then
+            echo "ERROR: Could not detect CUDA version from PyTorch."
+            echo "Make sure PyTorch with CUDA support is installed or set CUDA_VERSION."
+            exit 1
+        fi
+
+        echo "Detected PyTorch CUDA version: ${TORCH_CUDA_VERSION}"
+        CUDA_MAJOR_MINOR=$(echo "${TORCH_CUDA_VERSION}" | cut -d. -f1,2)
     fi
-
-    echo "Detected PyTorch CUDA version: ${TORCH_CUDA_VERSION}"
-
-    # Extract major.minor version (e.g., "12.8" from "12.8.1" or "12.8")
-    CUDA_MAJOR_MINOR=$(echo "${TORCH_CUDA_VERSION}" | cut -d. -f1,2)
 
     # Look up the full version and driver version
     if [ -z "${CUDA_DRIVER_MAP[${CUDA_MAJOR_MINOR}]}" ]; then

--- a/.ci/docker/common/install_pytorch.sh
+++ b/.ci/docker/common/install_pytorch.sh
@@ -12,11 +12,11 @@ source "$(dirname "${BASH_SOURCE[0]}")/utils.sh"
 
 install_domains() {
   echo "Install torchvision and torchaudio"
-  pip_install --force-reinstall --no-cache-dir torchvision==0.26.0 torchaudio==2.11.0 --index-url https://download.pytorch.org/whl/test/cpu
+  pip_install --force-reinstall --no-cache-dir torchvision==0.26.0 torchaudio==2.11.0 --index-url https://download.pytorch.org/whl/cpu
 }
 
 install_pytorch_and_domains() {
-  pip_install --force-reinstall --no-cache-dir torch==2.11.0 torchvision==0.26.0 torchaudio==2.11.0 --index-url https://download.pytorch.org/whl/test/cpu
+  pip_install --force-reinstall --no-cache-dir torch==2.11.0 torchvision==0.26.0 torchaudio==2.11.0 --index-url https://download.pytorch.org/whl/cpu
 }
 
 install_pytorch_and_domains

--- a/.ci/docker/ubuntu/Dockerfile
+++ b/.ci/docker/ubuntu/Dockerfile
@@ -105,7 +105,7 @@ COPY ./common/install_cuda_windows_cross_compile.sh install_cuda_windows_cross_c
 COPY ./common/utils.sh utils.sh
 RUN if [ -n "${CUDA_WINDOWS_CROSS_COMPILE}" ]; then \
     CUDA_VERSION=${CUDA_VERSION} bash ./install_cuda.sh && \
-    bash ./install_cuda_windows_cross_compile.sh; \
+    CUDA_VERSION=${CUDA_VERSION} bash ./install_cuda_windows_cross_compile.sh; \
     fi
 RUN rm -f install_cuda.sh install_cuda_windows_cross_compile.sh utils.sh
 # Set up CUDA environment for Linux compilation (nvcc, etc.)

--- a/.ci/scripts/setup-linux.sh
+++ b/.ci/scripts/setup-linux.sh
@@ -17,9 +17,9 @@ echo "Build tool: $BUILD_TOOL, Mode: $BUILD_MODE"
 # have already been installed, so we use PyTorch build from source here instead
 # of nightly. This allows CI to test against latest commits from PyTorch
 if [[ "${EDITABLE:-false}" == "true" ]]; then
-  install_executorch --use-pt-pinned-commit --editable
+  install_executorch --editable
 else
-  install_executorch --use-pt-pinned-commit
+  install_executorch
 fi
 build_executorch_runner "${BUILD_TOOL}" "${BUILD_MODE}"
 

--- a/.ci/scripts/setup-macos.sh
+++ b/.ci/scripts/setup-macos.sh
@@ -130,9 +130,9 @@ install_pytorch_and_domains
 # We build PyTorch from source here instead of using nightly. This allows CI to test against
 # the pinned commit from PyTorch
 if [[ "$EDITABLE" == "true" ]]; then
-  install_executorch --use-pt-pinned-commit --editable
+  install_executorch --editable
 else
-  install_executorch --use-pt-pinned-commit
+  install_executorch
 fi
 build_executorch_runner "${BUILD_TOOL}" "${BUILD_MODE}"
 

--- a/.ci/scripts/test_wheel_package_qnn.sh
+++ b/.ci/scripts/test_wheel_package_qnn.sh
@@ -161,7 +161,7 @@ PY
   echo "=== [$LABEL] Install torch==${TORCH_VERSION} ==="
 
   # Install torchao based on the pinned PyTorch version
-  "$PIPBIN" install --no-cache-dir torch=="${TORCH_VERSION}" --index-url "https://download.pytorch.org/whl/test/cpu"
+  "$PIPBIN" install --no-cache-dir torch=="${TORCH_VERSION}" --index-url "https://download.pytorch.org/whl/cpu"
   "$PIPBIN" install wheel
 
   # Install torchao based on the pinned commit from third-party/ao submodule

--- a/.ci/scripts/utils.sh
+++ b/.ci/scripts/utils.sh
@@ -84,11 +84,11 @@ dedupe_macos_loader_path_rpaths() {
 
 install_domains() {
   echo "Install torchvision and torchaudio"
-  pip install --force-reinstall --no-cache-dir torchvision==0.26.0 torchaudio==2.11.0 --index-url https://download.pytorch.org/whl/test/cpu
+  pip install --force-reinstall --no-cache-dir torchvision==0.26.0 torchaudio==2.11.0 --index-url https://download.pytorch.org/whl/cpu
 }
 
 install_pytorch_and_domains() {
-  pip install --force-reinstall --no-cache-dir torch==2.11.0 torchvision==0.26.0 torchaudio==2.11.0 --index-url https://download.pytorch.org/whl/test/cpu
+  pip install --force-reinstall --no-cache-dir torch==2.11.0 torchvision==0.26.0 torchaudio==2.11.0 --index-url https://download.pytorch.org/whl/cpu
 }
 
 build_executorch_runner_buck2() {

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -14,7 +14,7 @@ from install_utils import determine_torch_url, is_intel_mac_os, python_is_compat
 
 # The pip repository that hosts torch packages.
 # This will be dynamically set based on CUDA availability and CUDA backend enabled/disabled.
-TORCH_URL_BASE = "https://download.pytorch.org/whl/test"
+TORCH_URL_BASE = "https://download.pytorch.org/whl"
 
 # Since ExecuTorch often uses main-branch features of pytorch, only the nightly
 # pip versions will have the required features.
@@ -111,26 +111,6 @@ def install_requirements(use_pytorch_nightly):
 def install_optional_example_requirements(use_pytorch_nightly):
     # Determine the appropriate PyTorch URL based on CUDA delegate status
     torch_url = determine_torch_url(TORCH_URL_BASE)
-
-    print("Installing torch domain libraries")
-    DOMAIN_LIBRARIES = [
-        ("torchvision==0.26.0" if use_pytorch_nightly else "torchvision"),
-        ("torchaudio==2.11.0" if use_pytorch_nightly else "torchaudio"),
-    ]
-    # Then install domain libraries
-    subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "pip",
-            "install",
-            "--no-cache-dir",
-            *DOMAIN_LIBRARIES,
-            "--extra-index-url",
-            torch_url,
-        ],
-        check=True,
-    )
 
     print("Installing packages in requirements-examples.txt")
     subprocess.run(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ dependencies=[
   "scikit-learn==1.7.1",
   "hydra-core>=1.3.0",
   "omegaconf>=2.3.0",
+  "torch>=2.11.0",
 ]
 
 [project.urls]

--- a/requirements-examples.txt
+++ b/requirements-examples.txt
@@ -4,4 +4,6 @@ datasets == 3.6.0 # 4.0.0 deprecates trust_remote_code and load scripts. For now
 timm == 1.0.7
 torchsr == 1.0.4
 torchtune @ git+https://github.com/pytorch/torchtune.git@6f2aa7254458145f99d7004cbd6ebc8e53a06404
+torchaudio >= 2.11.0
+torchvision >= 0.26.0
 transformers == 5.0.0rc1


### PR DESCRIPTION
The install_cuda_windows_cross_compile.sh script was querying PyTorch for its CUDA version, but PyTorch gets installed indirectly via pip dependencies (torchsr, timm) even when SKIP_PYTORCH=yes. The pip-installed PyTorch reports CUDA 13.0, which isn't in the version map. Pass the CUDA_VERSION Docker build arg to the script and prefer it over querying PyTorch.
