### PR TITLE
Add prequantized checkpoint save/load and eager inference for Qwen 3.5 MoE

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -135,6 +135,9 @@ jobs:
         # Run CUDA backend Python tests
         python -m pytest backends/cuda/tests backends/cuda/passes/tests -v -o "addopts="
 
+        # Run quantize roundtrip tests (Qwen 3.5 MoE save/load prequantized)
+        python -m pytest examples/models/qwen3_5_moe/test_quantize_roundtrip.py -v -o "addopts="
+
         # Build Qwen3.5 MoE runner (ExecuTorch already built above)
         cd examples/models/qwen3_5_moe && cmake --workflow --preset qwen3-5-moe-cuda
 

--- a/examples/models/qwen3_5_moe/README.md
+++ b/examples/models/qwen3_5_moe/README.md
@@ -48,6 +48,32 @@ python export.py \
 | `--qlinear` | (none) | Linear layer quantization: `4w`, `8w`, `8da4w`, `8da8w` |
 | `--qlinear-group-size` | `32` | Group size for linear quantization |
 | `--qembedding` | (none) | Embedding quantization: `8w` |
+| `--hqq` | off | Use HQQ scale-only optimization for expert quantization (slower, better accuracy) |
+| `--prequantized` | (none) | Path to prequantized bundle directory (skips quantization) |
+
+### Prequantized Export
+
+Quantization is slow (~30 min with HQQ). To avoid re-quantizing on every
+export, use `quantize_and_save.py` to create a self-contained bundle, then
+export from it:
+
+```bash
+# Step 1: Quantize once (slow)
+python quantize_and_save.py \
+    --model-dir ~/models/Qwen3.5-35B-A3B \
+    --qlinear 4w \
+    --qembedding 8w \
+    --qlinear-group-size 128 \
+    --hqq \
+    --output qwen35_moe_int4_hqq
+
+# Step 2: Export from bundle (fast, no --model-dir needed)
+python export.py \
+    --prequantized qwen35_moe_int4_hqq
+```
+
+The bundle contains `model.safetensors`, `config.json`, and tokenizer files.
+It can be uploaded to HuggingFace Hub for easy sharing.
 
 ## Build
 

--- a/examples/models/qwen3_5_moe/export.py
+++ b/examples/models/qwen3_5_moe/export.py
@@ -4,6 +4,7 @@ Export Qwen 3.5 MoE to ExecuTorch .pte format (CUDA only).
 Usage:
   python export.py --model-dir /path/to/Qwen3.5-MoE-A3B
   python export.py --model-dir /path/to/model --qlinear 4w
+  python export.py --prequantized /path/to/quantized_bundle/
 """
 
 import argparse
@@ -12,7 +13,11 @@ import os
 import torch
 import torch.nn as nn
 
-from executorch.examples.models.qwen3_5_moe.model import FusedMoEExperts, Qwen35MoE
+from executorch.examples.models.qwen3_5_moe.model import (
+    FusedMoEExperts,
+    Qwen35MoE,
+    Qwen35MoEConfig,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -25,6 +30,9 @@ def load_and_quantize(args):
 
     Returns (model, config) ready for export.
     """
+    if args.prequantized:
+        return load_prequantized_model(args.prequantized, args.max_seq_len)
+
     print("Loading model...")
     model, config = Qwen35MoE.from_hf_checkpoint(
         args.model_dir, max_seq_len=args.max_seq_len
@@ -40,6 +48,96 @@ def load_and_quantize(args):
     else:
         model.to(dtype=torch.bfloat16)
 
+    return model, config
+
+
+def load_prequantized_model(prequantized_dir, max_seq_len=4096):
+    """Load a prequantized safetensors bundle into a model.
+
+    Args:
+        prequantized_dir: Directory containing model.safetensors and config.json.
+        max_seq_len: Maximum sequence length for KV cache.
+
+    Returns:
+        (model, config) ready for export.
+    """
+    from executorch.examples.models.qwen3_5_moe.quantize_and_save import (
+        load_quantized_state_dict,
+    )
+
+    config_path = os.path.join(prequantized_dir, "config.json")
+    safetensors_path = os.path.join(prequantized_dir, "model.safetensors")
+
+    config = Qwen35MoEConfig.from_hf_config(config_path)
+    config.max_seq_len = max_seq_len
+
+    print(f"Loading prequantized weights from {safetensors_path}...")
+    state_dict = load_quantized_state_dict(safetensors_path)
+
+    # Build model on meta device and prepare for quantized expert buffers.
+    # The model init creates w1_weight/w2_weight parameters but the checkpoint
+    # has w1/w1_scale/w2/w2_scale buffers. Replace them with matching placeholders
+    # so load_state_dict can assign the quantized weights.
+    print("Building model on meta device...")
+    with torch.device("meta"):
+        model = Qwen35MoE(config)
+
+    for i, layer in enumerate(model.layers):
+        experts = layer.mlp.experts
+        if isinstance(experts, FusedMoEExperts) and hasattr(experts, "w1_weight"):
+            del experts.w1_weight
+            del experts.w2_weight
+            prefix = f"layers.{i}.mlp.experts"
+            for buf_name in ("w1", "w1_scale", "w2", "w2_scale"):
+                t = state_dict[f"{prefix}.{buf_name}"]
+                experts.register_buffer(
+                    buf_name,
+                    torch.empty(t.shape, dtype=t.dtype, device="meta"),
+                )
+            # Infer group_size from packed weight and scale shapes:
+            # w1 is [E, N, K//2] (packed int4), w1_scale is [E, N, K//gs]
+            w1 = state_dict[f"{prefix}.w1"]
+            w1_scale = state_dict[f"{prefix}.w1_scale"]
+            experts.group_size = (w1.shape[2] * 2) // w1_scale.shape[2]
+
+    missing, unexpected = model.load_state_dict(state_dict, strict=False, assign=True)
+    del state_dict
+
+    # Validate: only runtime state buffers should be missing.
+    # Any missing weight key indicates a version mismatch between the
+    # checkpoint and the model (e.g., unfused vs fused projections).
+    runtime_prefixes = (
+        ".kv_cache.",
+        ".conv_state",
+        ".recurrent_state",
+        ".mask",
+        ".inv_freq",
+    )
+    expected_missing = {k for k in missing if any(p in k for p in runtime_prefixes)}
+    weight_missing = set(missing) - expected_missing
+    if weight_missing:
+        raise RuntimeError(
+            f"Prequantized checkpoint is missing {len(weight_missing)} weight keys "
+            f"(model/checkpoint version mismatch?): {sorted(weight_missing)[:10]}"
+        )
+    if unexpected:
+        raise RuntimeError(
+            f"Prequantized checkpoint has {len(unexpected)} unexpected keys "
+            f"(model/checkpoint version mismatch?): {sorted(unexpected)[:10]}"
+        )
+
+    # load_state_dict(assign=True) wraps tensors as Parameter(requires_grad=True).
+    # run_decompositions -> unwrap_tensor_subclass_parameters tries to wrap
+    # int-dtype inner tensors of quantized subclasses as Parameters with
+    # requires_grad=True, which fails. Disable grad on all parameters.
+    for p in model.parameters():
+        p.requires_grad_(False)
+    model.eval()
+
+    print(
+        f"Model: {config.num_hidden_layers} layers, {config.hidden_size}d, "
+        f"{config.num_experts} experts top-{config.num_experts_per_tok}"
+    )
     return model, config
 
 
@@ -347,7 +445,9 @@ def main():
         description="Export Qwen3.5 MoE to ExecuTorch (CUDA)"
     )
     parser.add_argument(
-        "--model-dir", required=True, help="HuggingFace model directory"
+        "--model-dir",
+        default=None,
+        help="HuggingFace model directory (not needed with --prequantized)",
     )
     parser.add_argument(
         "--output-dir", default="./qwen35_moe_exports", help="Output directory"
@@ -373,7 +473,17 @@ def main():
         action="store_true",
         help="Use HQQ scale-only optimization for expert quantization (slower, better accuracy).",
     )
+    parser.add_argument(
+        "--prequantized",
+        default=None,
+        help="Path to prequantized directory (from quantize_and_save.py) "
+        "containing model.safetensors and config.json. "
+        "Skips quantization; --model-dir is not needed.",
+    )
     args = parser.parse_args()
+
+    if not args.prequantized and not args.model_dir:
+        parser.error("--model-dir is required unless --prequantized is provided.")
 
     if args.hqq and not args.qlinear:
         parser.error("--hqq requires --qlinear")

--- a/examples/models/qwen3_5_moe/inference.py
+++ b/examples/models/qwen3_5_moe/inference.py
@@ -1,0 +1,198 @@
+"""Run inference on a prequantized Qwen 3.5 MoE model using torch.compile.
+
+Loads the quantized model from a safetensors bundle, compiles with
+torch.compile for fast CUDA inference, and generates text.
+
+Usage:
+  python inference.py --prequantized /path/to/bundle --prompt "Hello"
+  python inference.py --prequantized /path/to/bundle --prompt "What is 2+2?" --max-new-tokens 64
+"""
+
+import argparse
+import os
+import time
+
+import torch
+
+from executorch.examples.models.qwen3_5_moe.export import load_prequantized_model
+
+
+def _move_to_cuda(model, config):
+    """Move model to CUDA, materializing meta buffers directly on device.
+
+    Handles Int4TilePackedTo4dTensor and other tensor subclasses by moving
+    parameters individually with explicit device transfer. Recomputes RoPE
+    inv_freq and causal masks on CUDA.
+    """
+    for fqn, buf in list(model.named_buffers()):
+        parts = fqn.rsplit(".", 1)
+        parent = model.get_submodule(parts[0]) if len(parts) > 1 else model
+        if buf.device.type == "meta":
+            dtype = torch.bfloat16 if buf.dtype != torch.bool else torch.bool
+            parent.register_buffer(
+                parts[-1], torch.zeros(buf.shape, dtype=dtype, device="cuda")
+            )
+        else:
+            parent.register_buffer(parts[-1], buf.to("cuda"))
+
+    for name, p in model.named_parameters():
+        parts = name.rsplit(".", 1)
+        parent = model.get_submodule(parts[0]) if len(parts) > 1 else model
+        setattr(
+            parent,
+            parts[-1],
+            torch.nn.Parameter(p.data.to("cuda"), requires_grad=False),
+        )
+
+    # Recompute RoPE inv_freq on CUDA
+    for layer in model.layers:
+        if hasattr(layer.attn, "rotary_emb"):
+            rope = layer.attn.rotary_emb
+            inv_freq = 1.0 / (
+                config.rope_theta
+                ** (
+                    torch.arange(0, rope.rotary_dim, 2, dtype=torch.float32)
+                    / rope.rotary_dim
+                )
+            )
+            rope.inv_freq = inv_freq.to("cuda")
+        if hasattr(layer.attn, "mask"):
+            layer.attn.register_buffer(
+                "mask",
+                torch.tril(
+                    torch.ones(
+                        config.max_seq_len,
+                        config.max_seq_len,
+                        dtype=torch.bool,
+                        device="cuda",
+                    )
+                ),
+            )
+
+
+def generate(
+    model, tokenizer, prompt, max_new_tokens=128, temperature=0.0, eos_token_ids=None
+):
+    """Generate text autoregressively with KV cache.
+
+    Prefills one token at a time (the chunk_gated_delta_rule kernel's chunked
+    path has numerical issues with T>1 in eager mode; token-by-token uses the
+    stable recurrent path).
+    """
+    if eos_token_ids is None:
+        eos_token_ids = set()
+
+    input_ids = tokenizer.encode(prompt).ids
+
+    # Prefill: one token at a time
+    with torch.no_grad():
+        for i, tok_id in enumerate(input_ids):
+            tok = torch.tensor([[tok_id]], dtype=torch.long, device="cuda")
+            pos = torch.tensor([i], dtype=torch.long, device="cuda")
+            logits = model(tok, pos)
+
+    # Sample first generated token
+    next_token = _sample(logits[:, -1, :], temperature)
+    generated = [next_token.item()]
+
+    # Decode: one token at a time
+    seq_len = len(input_ids)
+    with torch.no_grad():
+        for i in range(max_new_tokens - 1):
+            pos = torch.tensor([seq_len + i], device="cuda")
+            logits = model(next_token.unsqueeze(0), pos)
+            next_token = _sample(logits[:, -1, :], temperature)
+            tok_id = next_token.item()
+            generated.append(tok_id)
+            if tok_id in eos_token_ids:
+                break
+
+    return tokenizer.decode(generated)
+
+
+def _sample(logits, temperature):
+    """Sample from logits with temperature."""
+    if temperature <= 0:
+        return logits.argmax(dim=-1)
+    probs = torch.softmax(logits / temperature, dim=-1)
+    return torch.multinomial(probs, num_samples=1).squeeze(-1)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Run inference on prequantized Qwen3.5 MoE"
+    )
+    parser.add_argument(
+        "--prequantized",
+        required=True,
+        help="Path to prequantized bundle directory",
+    )
+    parser.add_argument("--prompt", default="Hello", help="Input prompt")
+    parser.add_argument(
+        "--max-new-tokens", type=int, default=128, help="Max tokens to generate"
+    )
+    parser.add_argument(
+        "--temperature",
+        type=float,
+        default=0.0,
+        help="Sampling temperature (0=greedy)",
+    )
+    parser.add_argument(
+        "--max-seq-len", type=int, default=32768, help="KV cache length"
+    )
+    parser.add_argument(
+        "--no-compile", action="store_true", help="Disable torch.compile"
+    )
+    args = parser.parse_args()
+
+    # Register Triton kernels (fused MoE, GatedDeltaNet)
+    import executorch.backends.cuda.triton.kernels  # noqa: F401
+
+    # Load model
+    print(f"Loading model from {args.prequantized}...")
+    model, config = load_prequantized_model(
+        args.prequantized, max_seq_len=args.max_seq_len
+    )
+    _move_to_cuda(model, config)
+    model.eval()
+
+    # Compile
+    if not args.no_compile:
+        print("Compiling model with torch.compile...")
+        model = torch.compile(model, mode="default")
+
+    # Load tokenizer
+    tokenizer_path = os.path.join(args.prequantized, "tokenizer.json")
+    from tokenizers import Tokenizer
+
+    tokenizer = Tokenizer.from_file(tokenizer_path)
+
+    # EOS tokens for Qwen: <|im_end|> and <|endoftext|>
+    eos_token_ids = set()
+    for tok in ["<|im_end|>", "<|endoftext|>"]:
+        ids = tokenizer.encode(tok).ids
+        if len(ids) == 1:
+            eos_token_ids.add(ids[0])
+
+    # Generate
+    print(f"\nPrompt: {args.prompt}")
+    print("-" * 40)
+
+    t0 = time.perf_counter()
+    output = generate(
+        model,
+        tokenizer,
+        args.prompt,
+        max_new_tokens=args.max_new_tokens,
+        temperature=args.temperature,
+        eos_token_ids=eos_token_ids,
+    )
+    elapsed = time.perf_counter() - t0
+
+    print(output)
+    print("-" * 40)
+    print(f"Generated in {elapsed:.2f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/models/qwen3_5_moe/quantize_and_save.py
+++ b/examples/models/qwen3_5_moe/quantize_and_save.py
@@ -1,0 +1,244 @@
+"""Quantize Qwen 3.5 MoE and save as a self-contained safetensors bundle.
+
+Runs quantization once and saves the result so export.py can skip
+re-quantizing via --prequantized. The output directory contains everything
+needed to load the model — no reference to the original HF checkpoint required.
+
+Output:
+  output_dir/
+    model.safetensors       # quantized weights (with reconstruction metadata in header)
+    config.json             # model architecture config
+    tokenizer.json          # tokenizer (for runtime)
+    tokenizer_config.json
+    merges.txt
+    vocab.json
+
+Usage:
+  python quantize_and_save.py --model-dir /path/to/Qwen3.5-MoE-A3B --qlinear 4w
+  python quantize_and_save.py --model-dir /path/to/model --qlinear 4w --hqq
+"""
+
+import argparse
+import json
+import os
+import shutil
+
+import torch
+
+from executorch.examples.models.qwen3_5_moe.export import _quantize
+from executorch.examples.models.qwen3_5_moe.model import Qwen35MoE
+from safetensors.torch import save_file
+
+
+# ---------------------------------------------------------------------------
+# Safetensors roundtrip for quantized models
+#
+# Tensor subclasses (Int4TilePackedTo4dTensor, IntxUnpackedToInt8Tensor) can't
+# be stored directly in safetensors. We flatten them into plain inner tensors
+# with .__<name> suffixes and store reconstruction metadata (class name,
+# block_size, shape, dtypes) in the safetensors header under "quantization".
+# ---------------------------------------------------------------------------
+
+# Registry of tensor subclass types we know how to reconstruct.
+_SUBCLASS_REGISTRY = {}
+
+
+def _register_subclass(cls):
+    _SUBCLASS_REGISTRY[cls.__qualname__] = cls
+
+
+def _init_subclass_registry():
+    """Lazily populate the registry on first use."""
+    if _SUBCLASS_REGISTRY:
+        return
+    from torchao.quantization import IntxUnpackedToInt8Tensor
+    from torchao.quantization.quantize_.workflows.int4.int4_tile_packed_to_4d_tensor import (
+        Int4TilePackedTo4dTensor,
+    )
+
+    _register_subclass(Int4TilePackedTo4dTensor)
+    _register_subclass(IntxUnpackedToInt8Tensor)
+
+
+def save_quantized_model(model, safetensors_path):
+    """Save a quantized model to safetensors with subclass reconstruction metadata.
+
+    Iterates named_parameters and named_buffers directly (no state_dict copy)
+    to avoid doubling peak memory. Tensor subclasses are flattened into plain
+    inner tensors with .__<name> suffixes.
+    """
+    tensors = {}
+    subclass_meta = {}
+
+    seen = set()
+    for key, val in list(model.named_parameters()) + list(model.named_buffers()):
+        if key in seen:
+            continue
+        seen.add(key)
+
+        if val.device.type == "meta":
+            continue
+
+        if hasattr(val, "__tensor_flatten__"):
+            inner_names, attrs = val.__tensor_flatten__()
+            meta = {"_type": type(val).__qualname__}
+            for attr_name, attr_val in attrs.items():
+                if isinstance(attr_val, torch.Size):
+                    meta[attr_name] = list(attr_val)
+                elif isinstance(attr_val, torch.dtype):
+                    meta[attr_name] = str(attr_val)
+                else:
+                    meta[attr_name] = attr_val
+            subclass_meta[key] = meta
+
+            for name in inner_names:
+                inner_tensor = getattr(val, name)
+                tensors[f"{key}.__{name}"] = inner_tensor.contiguous()
+        else:
+            tensors[key] = val.data.contiguous()
+
+    header_metadata = {}
+    if subclass_meta:
+        header_metadata["quantization"] = json.dumps(subclass_meta)
+
+    save_file(tensors, safetensors_path, metadata=header_metadata)
+    return len(tensors)
+
+
+def load_quantized_state_dict(safetensors_path):
+    """Load a quantized state dict from safetensors, reconstructing tensor subclasses.
+
+    Returns a state dict with plain tensors and reconstructed tensor subclasses
+    ready for model.load_state_dict(state_dict, strict=False, assign=True).
+    """
+    from safetensors import safe_open
+
+    _init_subclass_registry()
+
+    with safe_open(safetensors_path, framework="pt", device="cpu") as f:
+        header_metadata = f.metadata()
+        flat_tensors = {key: f.get_tensor(key) for key in f.keys()}
+
+    quantization_meta = json.loads(header_metadata.get("quantization", "{}"))
+
+    state_dict = {}
+    reconstructed_keys = set()
+    for key, meta in quantization_meta.items():
+        cls = _SUBCLASS_REGISTRY[meta["_type"]]
+
+        # Collect inner tensors
+        tensor_data = {}
+        prefix = f"{key}.__"
+        for flat_key in list(flat_tensors.keys()):
+            if flat_key.startswith(prefix):
+                inner_name = flat_key[len(prefix) :]
+                tensor_data[inner_name] = flat_tensors[flat_key]
+                reconstructed_keys.add(flat_key)
+
+        # Restore Python types from JSON (lists stay as lists, not tuples,
+        # because Int4TilePackedTo4dTensor expects block_size as a list)
+        attrs = {}
+        for attr_name, attr_val in meta.items():
+            if attr_name == "_type":
+                continue
+            elif attr_name == "shape":
+                attrs[attr_name] = torch.Size(attr_val)
+            elif isinstance(attr_val, str) and attr_val.startswith("torch."):
+                attrs[attr_name] = getattr(torch, attr_val.split(".")[-1])
+            else:
+                attrs[attr_name] = attr_val
+
+        # outer_size and outer_stride are unused by TorchAOBaseTensor.__tensor_unflatten__
+        state_dict[key] = cls.__tensor_unflatten__(tensor_data, attrs, None, None)
+
+    # Add plain tensors
+    for key, tensor in flat_tensors.items():
+        if key not in reconstructed_keys:
+            state_dict[key] = tensor
+
+    return state_dict
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Quantize Qwen3.5 MoE and save as safetensors"
+    )
+    parser.add_argument(
+        "--model-dir", required=True, help="HuggingFace model directory"
+    )
+    parser.add_argument(
+        "--output",
+        default="qwen35_moe_quantized",
+        help="Output directory (default: qwen35_moe_quantized/)",
+    )
+    parser.add_argument("--max-seq-len", type=int, default=4096, help="KV cache length")
+    parser.add_argument(
+        "--qlinear",
+        default=None,
+        choices=["4w", "8w", "8da4w", "8da8w"],
+        help="Quantize linear layers.",
+    )
+    parser.add_argument(
+        "--qlinear-group-size",
+        type=int,
+        default=32,
+        help="Group size for linear quantization.",
+    )
+    parser.add_argument(
+        "--qembedding", default=None, choices=["8w"], help="Quantize embedding layers."
+    )
+    parser.add_argument(
+        "--hqq",
+        action="store_true",
+        help="Use HQQ scale-only optimization for expert quantization.",
+    )
+    args = parser.parse_args()
+
+    if not args.qlinear and not args.qembedding:
+        parser.error("At least one of --qlinear or --qembedding is required.")
+
+    # Load model
+    print("Loading model...")
+    model, config = Qwen35MoE.from_hf_checkpoint(
+        args.model_dir, max_seq_len=args.max_seq_len
+    )
+    model.eval()
+    print(
+        f"Model: {config.num_hidden_layers} layers, {config.hidden_size}d, "
+        f"{config.num_experts} experts top-{config.num_experts_per_tok}"
+    )
+
+    # Quantize (includes expert INT4 + linear + embedding quantization)
+    _quantize(model, config, args)
+
+    # Save bundle
+    os.makedirs(args.output, exist_ok=True)
+
+    safetensors_path = os.path.join(args.output, "model.safetensors")
+    print("Saving quantized weights...")
+    n_tensors = save_quantized_model(model, safetensors_path)
+
+    # Copy config and tokenizer from source
+    for filename in [
+        "config.json",
+        "tokenizer.json",
+        "tokenizer_config.json",
+        "merges.txt",
+        "vocab.json",
+    ]:
+        src = os.path.join(args.model_dir, filename)
+        if os.path.exists(src):
+            shutil.copy2(src, os.path.join(args.output, filename))
+
+    size_mb = os.path.getsize(safetensors_path) / (1024 * 1024)
+    print(f"Saved {n_tensors} tensors ({size_mb:.1f} MB) to {args.output}/")
+    print(f"Done. Use with: python export.py --prequantized {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/models/qwen3_5_moe/test_quantize_roundtrip.py
+++ b/examples/models/qwen3_5_moe/test_quantize_roundtrip.py
@@ -1,0 +1,212 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Test quantize-save-load roundtrip for quantized Qwen 3.5 MoE.
+
+Creates a tiny model (no downloads needed), quantizes it, saves to safetensors,
+loads back via the production load_prequantized_model codepath, and verifies
+the loaded model produces identical forward outputs.
+
+Requires CUDA (Int4TilePackedTo4dTensor needs _convert_weight_to_int4pack).
+
+Usage:
+    python -m pytest examples/models/qwen3_5_moe/test_quantize_roundtrip.py -v
+"""
+
+import json
+import os
+import tempfile
+import unittest
+
+import torch
+
+from executorch.examples.models.qwen3_5_moe.export import (
+    _materialize_buffers,
+    _quantize,
+    load_prequantized_model,
+)
+from executorch.examples.models.qwen3_5_moe.model import Qwen35MoE, Qwen35MoEConfig
+from executorch.examples.models.qwen3_5_moe.quantize_and_save import (
+    save_quantized_model,
+)
+
+
+TINY_CONFIG = Qwen35MoEConfig(
+    vocab_size=256,
+    hidden_size=128,
+    num_hidden_layers=2,
+    num_attention_heads=2,
+    num_kv_heads=2,
+    head_dim=64,
+    partial_rotary_factor=0.25,
+    linear_num_key_heads=2,
+    linear_num_value_heads=2,
+    linear_key_head_dim=64,
+    linear_value_head_dim=64,
+    linear_conv_kernel_dim=4,
+    num_experts=4,
+    num_experts_per_tok=2,
+    moe_intermediate_size=128,
+    shared_expert_intermediate_size=128,
+    full_attention_interval=2,
+    rms_norm_eps=1e-6,
+    rope_theta=10_000.0,
+    max_seq_len=64,
+)
+
+
+def _make_quantized_model(qlinear, qembedding, group_size, hqq=False):
+    """Create a tiny model with random weights and quantize it."""
+    torch.manual_seed(42)
+    model = Qwen35MoE(TINY_CONFIG)
+    model.to(dtype=torch.bfloat16)
+    for p in model.parameters():
+        if p.device.type != "meta":
+            p.data.normal_(0, 0.02)
+    model.eval()
+
+    class Args:
+        pass
+
+    args = Args()
+    args.qlinear = qlinear
+    args.qembedding = qembedding
+    args.qlinear_group_size = group_size
+    args.qlinear_packing_format = "tile_packed_to_4d"
+
+    args.hqq = hqq
+    _quantize(model, TINY_CONFIG, args)
+
+    return model
+
+
+def _save_bundle(model, output_dir):
+    """Save a quantized model as a bundle (model.safetensors + config.json).
+
+    Uses the production save_quantized_model for weights, and writes a
+    config.json from TINY_CONFIG so load_prequantized_model can read it.
+    """
+    os.makedirs(output_dir, exist_ok=True)
+    save_quantized_model(model, os.path.join(output_dir, "model.safetensors"))
+
+    # Write config.json matching TINY_CONFIG fields that from_hf_config reads
+    config_dict = {
+        "vocab_size": TINY_CONFIG.vocab_size,
+        "hidden_size": TINY_CONFIG.hidden_size,
+        "num_hidden_layers": TINY_CONFIG.num_hidden_layers,
+        "num_attention_heads": TINY_CONFIG.num_attention_heads,
+        "num_key_value_heads": TINY_CONFIG.num_kv_heads,
+        "head_dim": TINY_CONFIG.head_dim,
+        "partial_rotary_factor": TINY_CONFIG.partial_rotary_factor,
+        "linear_num_key_heads": TINY_CONFIG.linear_num_key_heads,
+        "linear_num_value_heads": TINY_CONFIG.linear_num_value_heads,
+        "linear_key_head_dim": TINY_CONFIG.linear_key_head_dim,
+        "linear_value_head_dim": TINY_CONFIG.linear_value_head_dim,
+        "linear_conv_kernel_dim": TINY_CONFIG.linear_conv_kernel_dim,
+        "num_experts": TINY_CONFIG.num_experts,
+        "num_experts_per_tok": TINY_CONFIG.num_experts_per_tok,
+        "moe_intermediate_size": TINY_CONFIG.moe_intermediate_size,
+        "shared_expert_intermediate_size": TINY_CONFIG.shared_expert_intermediate_size,
+        "full_attention_interval": TINY_CONFIG.full_attention_interval,
+        "rms_norm_eps": TINY_CONFIG.rms_norm_eps,
+        "rope_theta": TINY_CONFIG.rope_theta,
+    }
+    with open(os.path.join(output_dir, "config.json"), "w") as f:
+        json.dump(config_dict, f)
+
+
+class TestQuantizeRoundtrip(unittest.TestCase):
+    def setUp(self):
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA is not available")
+
+    def _test_roundtrip(self, qlinear, qembedding, group_size, hqq=False):
+        """Test: quantize -> save -> load_prequantized_model -> forward
+        produces same output as quantize -> forward.
+        """
+        import executorch.backends.cuda.triton.kernels  # noqa: F401
+
+        # Quantize and save bundle (before moving to CUDA, matching production flow)
+        model_a = _make_quantized_model(qlinear, qembedding, group_size, hqq)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _save_bundle(model_a, tmpdir)
+
+            # Path A: materialize, move to CUDA, forward
+            _materialize_buffers(model_a, TINY_CONFIG)
+            model_a.to(device="cuda")
+
+            torch.manual_seed(99)
+            tokens = torch.randint(0, TINY_CONFIG.vocab_size, (1, 4), device="cuda")
+            input_pos = torch.arange(4, device="cuda")
+
+            with torch.no_grad():
+                output_a = model_a(tokens, input_pos)
+            del model_a
+
+            # Path B: load via production codepath, materialize, forward
+            model_b, _ = load_prequantized_model(
+                tmpdir, max_seq_len=TINY_CONFIG.max_seq_len
+            )
+
+        _materialize_buffers(model_b, TINY_CONFIG)
+        model_b.to(device="cuda")
+
+        with torch.no_grad():
+            output_b = model_b(tokens, input_pos)
+
+        self.assertTrue(
+            torch.equal(output_a, output_b),
+            f"Outputs differ: max diff = {(output_a - output_b).abs().max().item()}",
+        )
+
+    def test_4w_8w_gs32(self):
+        """Roundtrip: 4w linear + 8w embedding, group_size=32."""
+        self._test_roundtrip("4w", "8w", 32)
+
+    def test_4w_gs32(self):
+        """Roundtrip: 4w linear only, group_size=32."""
+        self._test_roundtrip("4w", None, 32)
+
+    def test_4w_8w_gs128(self):
+        """Roundtrip: 4w linear + 8w embedding, group_size=128."""
+        self._test_roundtrip("4w", "8w", 128)
+
+    def test_4w_8w_gs128_hqq(self):
+        """Roundtrip: 4w linear + 8w embedding, group_size=128, HQQ experts."""
+        self._test_roundtrip("4w", "8w", 128, hqq=True)
+
+    def test_load_rejects_corrupted_checkpoint(self):
+        """load_prequantized_model raises on corrupted/mismatched checkpoint.
+
+        Saves a valid checkpoint, then replaces it with one that has a
+        renamed key (simulating a version mismatch). The loader should
+        raise RuntimeError instead of silently producing a broken model.
+        """
+        from safetensors import safe_open
+        from safetensors.torch import save_file
+
+        model = _make_quantized_model("4w", None, 32)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _save_bundle(model, tmpdir)
+            path = os.path.join(tmpdir, "model.safetensors")
+
+            # Load, rename a key to simulate version mismatch, re-save
+            with safe_open(path, framework="pt", device="cpu") as f:
+                header = f.metadata()
+                tensors = {k: f.get_tensor(k) for k in f.keys()}
+
+            # Rename norm.weight -> norm.BOGUS (missing + unexpected)
+            tensors["norm.BOGUS"] = tensors.pop("norm.weight")
+            save_file(tensors, path, metadata=header)
+
+            with self.assertRaises(RuntimeError):
+                load_prequantized_model(tmpdir, max_seq_len=TINY_CONFIG.max_seq_len)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Quantization is slow (~30 min with HQQ for 256 experts x 40 layers).
This adds a two-step workflow: quantize once and save as safetensors,
then load the prequantized bundle for export or eager inference without
re-quantizing.

New files:
- quantize_and_save.py: Quantize and save as a self-contained safetensors
  bundle (model.safetensors + config.json + tokenizer files). Tensor
  subclasses (Int4TilePackedTo4dTensor, IntxUnpackedToInt8Tensor) are
  flattened into plain inner tensors with reconstruction metadata in the
  safetensors header.
- inference.py: Eager Python inference using torch.compile. Loads from
  a prequantized bundle and generates text token-by-token.
- test_quantize_roundtrip.py: Unit tests verifying save/load roundtrip
  produces identical forward outputs across quantization configs (4w,
  8w embedding, gs=32/128, HQQ). Includes regression test for
  checkpoint validation.

Changes to export.py:
- Add load_prequantized_model() for loading safetensors bundles
- Add --prequantized flag to skip quantization during export
- Validate missing/unexpected keys on load to catch version mismatches
  (raises RuntimeError instead of silently producing garbage)
- Infer expert group_size from tensor shapes on load

Changes to cuda.yml:
- Add test_quantize_roundtrip.py to CI unittest-cuda job

Changes to README.md:
- Document prequantized workflow and --hqq flag
