### PR TITLE
Very early cpu backend prototype

### DIFF
--- a/backends/xnnpack/CMakeLists.txt
+++ b/backends/xnnpack/CMakeLists.txt
@@ -100,6 +100,39 @@ set(xnnpack_third_party pthreadpool extension_threadpool cpuinfo)
 
 include(cmake/Dependencies.cmake)
 
+list(
+  APPEND
+  _xnnpack_backend__srcs
+  backends/xnnpack/runtime/core/tensor.cpp
+  backends/xnnpack/runtime/core/quant_params.cpp
+  backends/xnnpack/runtime/graph/graph.cpp
+  backends/xnnpack/runtime/graph/graph_builder.cpp
+  backends/xnnpack/runtime/plan/xnn_support.cpp
+  backends/xnnpack/runtime/plan/partition.cpp
+  backends/xnnpack/runtime/plan/nhwc_rewrite.cpp
+  backends/xnnpack/runtime/plan/xnn_subgraph.cpp
+  backends/xnnpack/runtime/plan/schedule.cpp
+  backends/xnnpack/runtime/plan/execution_plan.cpp
+  backends/xnnpack/runtime/plan/memory_plan.cpp
+  backends/xnnpack/runtime/operators/operator.cpp
+  backends/xnnpack/runtime/operators/layer_norm.cpp
+  backends/xnnpack/runtime/kernels/layer_norm/layer_norm.cpp
+  backends/xnnpack/runtime/kernels/layer_norm/layer_norm_scalar.cpp
+  backends/xnnpack/runtime/FlatbufferGraphBuilder.cpp
+  backends/xnnpack/runtime/executor/arena.cpp
+  backends/xnnpack/runtime/executor/shape_env.cpp
+  backends/xnnpack/runtime/executor/executor.cpp
+)
+
+# NEON-optimized kernels (ARM64 only).
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64")
+  list(
+    APPEND
+    _xnnpack_backend__srcs
+    backends/xnnpack/runtime/kernels/layer_norm/layer_norm_neon.cpp
+  )
+endif()
+
 list(TRANSFORM _xnnpack_backend__srcs PREPEND "${EXECUTORCH_ROOT}/")
 add_library(xnnpack_backend ${_xnnpack_backend__srcs})
 target_link_libraries(

--- a/backends/xnnpack/runtime/FlatbufferGraphBuilder.cpp
+++ b/backends/xnnpack/runtime/FlatbufferGraphBuilder.cpp
@@ -1,0 +1,791 @@
+#include <executorch/backends/xnnpack/runtime/FlatbufferGraphBuilder.h>
+
+#include <executorch/backends/xnnpack/runtime/XNNHeader.h>
+#include <executorch/backends/xnnpack/runtime/core/dtype.h>
+#include <executorch/backends/xnnpack/runtime/core/quant_params.h>
+#include <executorch/backends/xnnpack/runtime/core/tensor.h>
+#include <executorch/backends/xnnpack/runtime/graph/graph_builder.h>
+#include <executorch/backends/xnnpack/runtime/graph/handles.h>
+#include <executorch/backends/xnnpack/runtime/graph/operator.h>
+#include <executorch/backends/xnnpack/runtime/graph/tensor_spec.h>
+#include <executorch/backends/xnnpack/serialization/schema_generated.h>
+
+#include <algorithm>
+#include <cassert>
+#include <cstring>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+namespace executorch::backends::xnnpack {
+
+using namespace core;
+using namespace graph;
+
+namespace fb = fb_xnnpack;
+
+static DType map_dtype(fb::XNNDatatype dt) {
+    switch (dt) {
+        case fb::XNNDatatype::xnn_datatype_fp32:
+            return DType::Float32;
+        case fb::XNNDatatype::xnn_datatype_qint8:
+            return DType::QInt8Sym;
+        case fb::XNNDatatype::xnn_datatype_quint8:
+            return DType::QUInt8Asym;
+        case fb::XNNDatatype::xnn_datatype_qcint8:
+            return DType::QInt8Sym;
+        case fb::XNNDatatype::xnn_datatype_qcint4:
+            return DType::QInt4Sym;
+        case fb::XNNDatatype::xnn_datatype_qint32:
+            return DType::QInt32Sym;
+        case fb::XNNDatatype::xnn_datatype_qcint32:
+            return DType::QInt32Sym;
+        case fb::XNNDatatype::xnn_datatype_qbint4:
+            return DType::QInt4Sym;
+        default:
+            return DType::Float32;
+    }
+}
+
+static std::vector<DimSizeSpec> dims_to_sizes(
+    const flatbuffers::Vector<uint32_t>* dims) {
+    std::vector<DimSizeSpec> sizes;
+    sizes.reserve(dims->size());
+    for (auto d : *dims) {
+        sizes.push_back(DimSizeSpec::constant(static_cast<int64_t>(d)));
+    }
+    return sizes;
+}
+
+static QuantParams map_quant_params(
+    const fb::XNNQuantizedTensorValue* qtv) {
+    switch (qtv->quant_params_type()) {
+        case fb::XNNQuantParams::PerTensorQuant: {
+            auto qp = qtv->quant_params_as_PerTensorQuant();
+            return PerTensorQuant{
+                .scale = qp->scale(),
+                .zero_point = qp->zero_point(),
+            };
+        }
+        case fb::XNNQuantParams::PerChannelQuant: {
+            auto qp = qtv->quant_params_as_PerChannelQuant();
+            return PerAxisQuant{
+                .axis = static_cast<int8_t>(qp->channel_dim()),
+                .scale_dtype = DType::Float32,
+            };
+        }
+        case fb::XNNQuantParams::PerChannelGroupQuant: {
+            auto qp = qtv->quant_params_as_PerChannelGroupQuant();
+            return BlockwiseQuant{
+                .axis = static_cast<int8_t>(qp->channel_dim()),
+                .block_size = static_cast<int32_t>(qp->group_size()),
+                .scale_dtype = DType::Float32,
+            };
+        }
+        case fb::XNNQuantParams::PerTokenDynamicQuant: {
+            return PerTensorQuant{.scale = 1.0f, .zero_point = 0};
+        }
+        default:
+            return PerTensorQuant{.scale = 1.0f, .zero_point = 0};
+    }
+}
+
+static Operator map_binary_op(fb::XNodeUnion type) {
+    switch (type) {
+        case fb::XNodeUnion::XNNAdd: return Operator::Add;
+        case fb::XNodeUnion::XNNSubtract: return Operator::Subtract;
+        case fb::XNodeUnion::XNNMultiply: return Operator::Multiply;
+        case fb::XNodeUnion::XNNDiv: return Operator::Divide;
+        case fb::XNodeUnion::XNNMinimum: return Operator::Minimum;
+        case fb::XNodeUnion::XNNMaximum: return Operator::Maximum;
+        default: return Operator::Add;
+    }
+}
+
+static bool is_binary_op(fb::XNodeUnion type) {
+    switch (type) {
+        case fb::XNodeUnion::XNNAdd:
+        case fb::XNodeUnion::XNNSubtract:
+        case fb::XNodeUnion::XNNMultiply:
+        case fb::XNodeUnion::XNNDiv:
+        case fb::XNodeUnion::XNNMinimum:
+        case fb::XNodeUnion::XNNMaximum:
+            return true;
+        default:
+            return false;
+    }
+}
+
+static Operator map_unary_op(fb::XNodeUnion type) {
+    switch (type) {
+        case fb::XNodeUnion::XNNSigmoid: return Operator::Sigmoid;
+        case fb::XNodeUnion::XNNFloor: return Operator::Floor;
+        case fb::XNodeUnion::XNNSquareRoot: return Operator::SquareRoot;
+        case fb::XNodeUnion::XNNReciprocalSquareRoot: return Operator::ReciprocalSquareRoot;
+        case fb::XNodeUnion::XNNCeiling: return Operator::Ceiling;
+        case fb::XNodeUnion::XNNGelu: return Operator::GELU;
+        case fb::XNodeUnion::XNNHardswish: return Operator::HardSwish;
+        case fb::XNodeUnion::XNNLog: return Operator::Log;
+        case fb::XNodeUnion::XNNNegate: return Operator::Negate;
+        case fb::XNodeUnion::XNNSquare: return Operator::Square;
+        case fb::XNodeUnion::XNNAbs: return Operator::Abs;
+        case fb::XNodeUnion::XNNSin: return Operator::Sine;
+        case fb::XNodeUnion::XNNCos: return Operator::Cosine;
+        case fb::XNodeUnion::XNNClamp: return Operator::Clamp;
+        case fb::XNodeUnion::XNNLeakyReLU: return Operator::LeakyReLU;
+        case fb::XNodeUnion::XNNELU: return Operator::ELU;
+        default: return Operator::Abs;
+    }
+}
+
+static bool is_unary_op(fb::XNodeUnion type) {
+    switch (type) {
+        case fb::XNodeUnion::XNNSigmoid:
+        case fb::XNodeUnion::XNNFloor:
+        case fb::XNodeUnion::XNNSquareRoot:
+        case fb::XNodeUnion::XNNReciprocalSquareRoot:
+        case fb::XNodeUnion::XNNCeiling:
+        case fb::XNodeUnion::XNNGelu:
+        case fb::XNodeUnion::XNNHardswish:
+        case fb::XNodeUnion::XNNLog:
+        case fb::XNodeUnion::XNNNegate:
+        case fb::XNodeUnion::XNNSquare:
+        case fb::XNodeUnion::XNNAbs:
+        case fb::XNodeUnion::XNNSin:
+        case fb::XNodeUnion::XNNCos:
+        case fb::XNodeUnion::XNNClamp:
+        case fb::XNodeUnion::XNNLeakyReLU:
+        case fb::XNodeUnion::XNNELU:
+            return true;
+        default:
+            return false;
+    }
+}
+
+struct BuildContext {
+    GraphBuilder builder;
+    std::unordered_map<uint32_t, ValueHandle> id_map;
+    std::unordered_map<uint32_t, TensorSpec> spec_map;
+    const fb::XNNGraph* graph;
+    const uint8_t* constant_data;
+
+    ValueHandle lookup(uint32_t id) const {
+        if (id == UINT32_MAX) return ValueHandle::null();
+        auto it = id_map.find(id);
+        assert(it != id_map.end());
+        return it->second;
+    }
+
+    TensorSpec lookup_spec(uint32_t id) const {
+        auto it = spec_map.find(id);
+        assert(it != spec_map.end());
+        return it->second;
+    }
+};
+
+static TensorSpec make_spec(
+    const fb::XNNTensorValue* tv,
+    const fb::XNNQuantizedTensorValue* qtv) {
+    TensorSpec spec;
+    spec.dtype = map_dtype(tv->datatype());
+    spec.sizes = dims_to_sizes(tv->dims());
+    if (qtv) {
+        spec.quant_params = map_quant_params(qtv);
+    }
+    return spec;
+}
+
+static void define_value(
+    BuildContext& ctx,
+    const fb::XValue* value) {
+    const fb::XNNTensorValue* tv = nullptr;
+    const fb::XNNQuantizedTensorValue* qtv = nullptr;
+
+    switch (value->xvalue_union_type()) {
+        case fb::XValueUnion::XNNTensorValue:
+            tv = value->xvalue_union_as_XNNTensorValue();
+            break;
+        case fb::XValueUnion::XNNQuantizedTensorValue:
+            qtv = value->xvalue_union_as_XNNQuantizedTensorValue();
+            tv = qtv->tensor_value();
+            break;
+        default:
+            return;
+    }
+
+    auto spec = make_spec(tv, qtv);
+    uint32_t serial_id = tv->id_out();
+    ctx.spec_map[serial_id] = spec;
+
+    bool is_external_input = (tv->flags() & 1) != 0;  // XNN_VALUE_FLAG_EXTERNAL_INPUT
+    bool is_external_output = (tv->flags() & 2) != 0;  // XNN_VALUE_FLAG_EXTERNAL_OUTPUT
+    bool has_constant_data = tv->constant_buffer_idx() != 0;
+
+    if (is_external_input) {
+        auto handle = ctx.builder.createInput(spec);
+        ctx.id_map[serial_id] = handle;
+    } else if (has_constant_data) {
+        auto tensor = std::make_shared<Tensor>();
+        tensor->dtype = spec.dtype;
+        for (auto& dim : spec.sizes) {
+            assert(dim.coeffs.empty());
+            tensor->sizes.push_back(static_cast<uint64_t>(dim.offset));
+        }
+
+        uint32_t buf_idx = tv->constant_buffer_idx();
+        auto offsets = ctx.graph->constant_data();
+        if (offsets && buf_idx < offsets->size()) {
+            auto offset_entry = offsets->Get(buf_idx);
+            size_t data_offset = offset_entry->offset();
+            size_t data_size = offset_entry->size();
+
+            tensor->storage = Storage::create_owned(data_size);
+            if (ctx.constant_data) {
+                std::memcpy(tensor->storage.data,
+                    ctx.constant_data + data_offset, data_size);
+            }
+        }
+
+        std::optional<QuantParams> qp;
+        if (qtv) qp = map_quant_params(qtv);
+        auto handle = ctx.builder.createConstant(tensor, qp);
+        ctx.id_map[serial_id] = handle;
+    } else if (is_external_output) {
+        // Outputs that are not inputs or constants will be mapped
+        // when a node produces them.
+    }
+    // Internal intermediates will be created as operator outputs.
+}
+
+static const fb::_XNNNode2x1* as_binary(const fb::XNode* node) {
+    switch (node->xnode_union_type()) {
+        case fb::XNodeUnion::XNNAdd: return node->xnode_union_as_XNNAdd();
+        case fb::XNodeUnion::XNNSubtract: return node->xnode_union_as_XNNSubtract();
+        case fb::XNodeUnion::XNNMultiply: return node->xnode_union_as_XNNMultiply();
+        case fb::XNodeUnion::XNNDiv: return node->xnode_union_as_XNNDiv();
+        case fb::XNodeUnion::XNNMinimum: return node->xnode_union_as_XNNMinimum();
+        case fb::XNodeUnion::XNNMaximum: return node->xnode_union_as_XNNMaximum();
+        case fb::XNodeUnion::XNNPReLU: return node->xnode_union_as_XNNPReLU();
+        case fb::XNodeUnion::XNNBatchMatrixMultiply: return node->xnode_union_as_XNNBatchMatrixMultiply();
+        default: return nullptr;
+    }
+}
+
+static const fb::_XNNNode1x1* as_unary(const fb::XNode* node) {
+    switch (node->xnode_union_type()) {
+        case fb::XNodeUnion::XNNSigmoid: return node->xnode_union_as_XNNSigmoid();
+        case fb::XNodeUnion::XNNFloor: return node->xnode_union_as_XNNFloor();
+        case fb::XNodeUnion::XNNSquareRoot: return node->xnode_union_as_XNNSquareRoot();
+        case fb::XNodeUnion::XNNReciprocalSquareRoot: return node->xnode_union_as_XNNReciprocalSquareRoot();
+        case fb::XNodeUnion::XNNCeiling: return node->xnode_union_as_XNNCeiling();
+        case fb::XNodeUnion::XNNGelu: return node->xnode_union_as_XNNGelu();
+        case fb::XNodeUnion::XNNHardswish: return node->xnode_union_as_XNNHardswish();
+        case fb::XNodeUnion::XNNLog: return node->xnode_union_as_XNNLog();
+        case fb::XNodeUnion::XNNNegate: return node->xnode_union_as_XNNNegate();
+        case fb::XNodeUnion::XNNSquare: return node->xnode_union_as_XNNSquare();
+        case fb::XNodeUnion::XNNAbs: return node->xnode_union_as_XNNAbs();
+        case fb::XNodeUnion::XNNSin: return node->xnode_union_as_XNNSin();
+        case fb::XNodeUnion::XNNCos: return node->xnode_union_as_XNNCos();
+        case fb::XNodeUnion::XNNClamp: return node->xnode_union_as_XNNClamp();
+        case fb::XNodeUnion::XNNSoftmax: return node->xnode_union_as_XNNSoftmax();
+        case fb::XNodeUnion::XNNGlobalAvgPooling2d: return node->xnode_union_as_XNNGlobalAvgPooling2d();
+        case fb::XNodeUnion::XNNTanh: return node->xnode_union_as_XNNTanh();
+        case fb::XNodeUnion::XNNExp: return node->xnode_union_as_XNNExp();
+        case fb::XNodeUnion::XNNCopy: return node->xnode_union_as_XNNCopy();
+        default: return nullptr;
+    }
+}
+
+static void define_binary_node(
+    BuildContext& ctx,
+    const fb::XNode* node) {
+    auto n = as_binary(node);
+    auto output_spec = ctx.lookup_spec(n->output_id());
+    auto op = map_binary_op(node->xnode_union_type());
+    auto handle = ctx.builder.createOperator(op, output_spec,
+        {ctx.lookup(n->input1_id()), ctx.lookup(n->input2_id())});
+    ctx.id_map[n->output_id()] = handle;
+}
+
+static void define_unary_node(
+    BuildContext& ctx,
+    const fb::XNode* node) {
+    uint32_t input_id = 0;
+    uint32_t output_id = 0;
+
+    // Most unary ops use _XNNNode1x1, but ELU and LeakyReLU have custom types.
+    switch (node->xnode_union_type()) {
+        case fb::XNodeUnion::XNNELU: {
+            auto n = node->xnode_union_as_XNNELU();
+            input_id = n->input_id();
+            output_id = n->output_id();
+            break;
+        }
+        case fb::XNodeUnion::XNNLeakyReLU: {
+            auto n = node->xnode_union_as_XNNLeakyReLU();
+            input_id = n->input_id();
+            output_id = n->output_id();
+            break;
+        }
+        default: {
+            auto n = as_unary(node);
+            input_id = n->input_id();
+            output_id = n->output_id();
+            break;
+        }
+    }
+
+    auto output_spec = ctx.lookup_spec(output_id);
+    auto op = map_unary_op(node->xnode_union_type());
+    auto handle = ctx.builder.createOperator(op, output_spec,
+        {ctx.lookup(input_id)});
+    ctx.id_map[output_id] = handle;
+}
+
+static void define_fully_connected_node(
+    BuildContext& ctx,
+    const fb::XNode* node) {
+    auto n = node->xnode_union_as_XNNFullyConnected();
+    auto output_spec = ctx.lookup_spec(n->output_id());
+    auto input = ctx.lookup(n->input1_id());
+    auto filter = ctx.lookup(n->filter_id());
+    auto bias = ctx.lookup(n->bias_id());
+    auto handle = ctx.builder.createOperator(Operator::Linear, output_spec,
+        {input, filter, bias});
+    ctx.id_map[n->output_id()] = handle;
+}
+
+static void define_conv2d_node(
+    BuildContext& ctx,
+    const fb::XNode* node) {
+    auto n = node->xnode_union_as_XNNConv2d();
+    auto output_spec = ctx.lookup_spec(n->output_id());
+    auto input = ctx.lookup(n->input1_id());
+    auto filter = ctx.lookup(n->filter_id());
+    auto bias = ctx.lookup(n->bias_id());
+    auto handle = ctx.builder.createOperator(Operator::Conv2d, output_spec,
+        {input, filter, bias});
+    ctx.id_map[n->output_id()] = handle;
+}
+
+static void define_conv_transpose2d_node(
+    BuildContext& ctx,
+    const fb::XNode* node) {
+    auto n = node->xnode_union_as_XNNConvTranspose2d();
+    auto output_spec = ctx.lookup_spec(n->output_id());
+    auto input = ctx.lookup(n->input1_id());
+    auto filter = ctx.lookup(n->filter_id());
+    auto bias = ctx.lookup(n->bias_id());
+    auto handle = ctx.builder.createOperator(Operator::ConvTranspose2d, output_spec,
+        {input, filter, bias});
+    ctx.id_map[n->output_id()] = handle;
+}
+
+static void define_depthwise_conv2d_node(
+    BuildContext& ctx,
+    const fb::XNode* node) {
+    auto n = node->xnode_union_as_XNNDepthwiseConv2d();
+    auto output_spec = ctx.lookup_spec(n->output_id());
+    auto input = ctx.lookup(n->input1_id());
+    auto filter = ctx.lookup(n->filter_id());
+    auto bias = ctx.lookup(n->bias_id());
+    auto handle = ctx.builder.createOperator(Operator::Conv2d, output_spec,
+        {input, filter, bias});
+    ctx.id_map[n->output_id()] = handle;
+}
+
+static void define_softmax_node(
+    BuildContext& ctx,
+    const fb::XNode* node) {
+    auto n = node->xnode_union_as_XNNSoftmax();
+    auto output_spec = ctx.lookup_spec(n->output_id());
+    auto handle = ctx.builder.createOperator(Operator::Softmax, output_spec,
+        {ctx.lookup(n->input_id())});
+    ctx.id_map[n->output_id()] = handle;
+}
+
+static void define_convert_node(
+    BuildContext& ctx,
+    const fb::XNode* node) {
+    auto n = node->xnode_union_as_XNNConvert();
+    auto input_spec = ctx.lookup_spec(n->input_id());
+    auto output_spec = ctx.lookup_spec(n->output_id());
+
+    // Determine if this is a quantize or dequantize based on dtypes.
+    bool input_quantized = is_quantized(input_spec.dtype);
+    bool output_quantized = is_quantized(output_spec.dtype);
+
+    Operator op;
+    if (input_quantized && !output_quantized) {
+        op = Operator::Dequantize;
+    } else if (!input_quantized && output_quantized) {
+        op = Operator::Quantize;
+    } else {
+        op = Operator::Clone;
+    }
+
+    auto handle = ctx.builder.createOperator(op, output_spec,
+        {ctx.lookup(n->input_id())});
+    ctx.id_map[n->output_id()] = handle;
+}
+
+static void define_static_transpose_node(
+    BuildContext& ctx,
+    const fb::XNode* node) {
+    auto n = node->xnode_union_as_XNNStaticTranspose();
+    auto output_spec = ctx.lookup_spec(n->output_id());
+    auto handle = ctx.builder.createOperator(Operator::Permute, output_spec,
+        {ctx.lookup(n->input_id())});
+    ctx.id_map[n->output_id()] = handle;
+}
+
+static void define_static_reshape_node(
+    BuildContext& ctx,
+    const fb::XNode* node) {
+    auto n = node->xnode_union_as_XNNStaticReshape();
+    auto output_spec = ctx.lookup_spec(n->output_id());
+    auto handle = ctx.builder.createOperator(Operator::Reshape, output_spec,
+        {ctx.lookup(n->input_id())});
+    ctx.id_map[n->output_id()] = handle;
+}
+
+static void define_static_slice_node(
+    BuildContext& ctx,
+    const fb::XNode* node) {
+    auto n = node->xnode_union_as_XNNStaticSlice();
+    auto output_spec = ctx.lookup_spec(n->output_id());
+    auto handle = ctx.builder.createOperator(Operator::Slice, output_spec,
+        {ctx.lookup(n->input_id())});
+    ctx.id_map[n->output_id()] = handle;
+}
+
+static void define_static_constant_pad_node(
+    BuildContext& ctx,
+    const fb::XNode* node) {
+    auto n = node->xnode_union_as_XNNStaticConstantPad();
+    auto output_spec = ctx.lookup_spec(n->output_id());
+    auto handle = ctx.builder.createOperator(Operator::Pad, output_spec,
+        {ctx.lookup(n->input_id())});
+    ctx.id_map[n->output_id()] = handle;
+}
+
+static void define_avg_pooling_node(
+    BuildContext& ctx,
+    const fb::XNode* node) {
+    auto n = node->xnode_union_as_XNNAvgPooling2d();
+    auto output_spec = ctx.lookup_spec(n->output_id());
+    auto handle = ctx.builder.createOperator(Operator::AvgPool2d, output_spec,
+        {ctx.lookup(n->input_id())});
+    ctx.id_map[n->output_id()] = handle;
+}
+
+static void define_max_pooling_node(
+    BuildContext& ctx,
+    const fb::XNode* node) {
+    auto n = node->xnode_union_as_XNNMaxPooling2d();
+    auto output_spec = ctx.lookup_spec(n->output_id());
+    auto handle = ctx.builder.createOperator(Operator::MaxPool2d, output_spec,
+        {ctx.lookup(n->input_id())});
+    ctx.id_map[n->output_id()] = handle;
+}
+
+static void define_global_avg_pooling_node(
+    BuildContext& ctx,
+    const fb::XNode* node) {
+    auto n = node->xnode_union_as_XNNGlobalAvgPooling2d();
+    auto output_spec = ctx.lookup_spec(n->output_id());
+    auto handle = ctx.builder.createOperator(Operator::AdaptiveAvgPool2d, output_spec,
+        {ctx.lookup(n->input_id())});
+    ctx.id_map[n->output_id()] = handle;
+}
+
+static void define_batch_matrix_multiply_node(
+    BuildContext& ctx,
+    const fb::XNode* node) {
+    auto n = node->xnode_union_as_XNNBatchMatrixMultiply();
+    auto output_spec = ctx.lookup_spec(n->output_id());
+    auto handle = ctx.builder.createOperator(Operator::BatchMatrixMultiply, output_spec,
+        {ctx.lookup(n->input1_id()), ctx.lookup(n->input2_id())});
+    ctx.id_map[n->output_id()] = handle;
+}
+
+static void define_prelu_node(
+    BuildContext& ctx,
+    const fb::XNode* node) {
+    auto n = node->xnode_union_as_XNNPReLU();
+    auto output_spec = ctx.lookup_spec(n->output_id());
+    auto handle = ctx.builder.createOperator(Operator::PReLU, output_spec,
+        {ctx.lookup(n->input1_id()), ctx.lookup(n->input2_id())});
+    ctx.id_map[n->output_id()] = handle;
+}
+
+static void define_copy_node(
+    BuildContext& ctx,
+    const fb::XNode* node) {
+    auto n = node->xnode_union_as_XNNCopy();
+    auto output_spec = ctx.lookup_spec(n->output_id());
+    auto handle = ctx.builder.createOperator(Operator::Clone, output_spec,
+        {ctx.lookup(n->input_id())});
+    ctx.id_map[n->output_id()] = handle;
+}
+
+static void define_concatenate_node(
+    BuildContext& ctx,
+    const fb::XNode* node) {
+    const fb::_XNNCat* n = nullptr;
+    switch (node->xnode_union_type()) {
+        case fb::XNodeUnion::XNNConcatenate2: n = node->xnode_union_as_XNNConcatenate2(); break;
+        case fb::XNodeUnion::XNNConcatenate3: n = node->xnode_union_as_XNNConcatenate3(); break;
+        case fb::XNodeUnion::XNNConcatenate4: n = node->xnode_union_as_XNNConcatenate4(); break;
+        case fb::XNodeUnion::XNNConcatenate5: n = node->xnode_union_as_XNNConcatenate5(); break;
+        default: return;
+    }
+    auto output_spec = ctx.lookup_spec(n->output_id());
+
+    ValueHandles inputs;
+    inputs.push_back(ctx.lookup(n->input1_id()));
+    inputs.push_back(ctx.lookup(n->input2_id()));
+    if (node->xnode_union_type() == fb::XNodeUnion::XNNConcatenate3 ||
+        node->xnode_union_type() == fb::XNodeUnion::XNNConcatenate4 ||
+        node->xnode_union_type() == fb::XNodeUnion::XNNConcatenate5) {
+        inputs.push_back(ctx.lookup(n->input3_id()));
+    }
+    if (node->xnode_union_type() == fb::XNodeUnion::XNNConcatenate4 ||
+        node->xnode_union_type() == fb::XNodeUnion::XNNConcatenate5) {
+        inputs.push_back(ctx.lookup(n->input4_id()));
+    }
+    if (node->xnode_union_type() == fb::XNodeUnion::XNNConcatenate5) {
+        inputs.push_back(ctx.lookup(n->input5_id()));
+    }
+
+    auto handle = ctx.builder.createOperator(Operator::Cat, output_spec, inputs);
+    ctx.id_map[n->output_id()] = handle;
+}
+
+static void define_tanh_node(
+    BuildContext& ctx,
+    const fb::XNode* node) {
+    auto n = node->xnode_union_as_XNNTanh();
+    auto output_spec = ctx.lookup_spec(n->output_id());
+    auto handle = ctx.builder.createOperator(Operator::Tanh, output_spec,
+        {ctx.lookup(n->input_id())});
+    ctx.id_map[n->output_id()] = handle;
+}
+
+static void define_exp_node(
+    BuildContext& ctx,
+    const fb::XNode* node) {
+    auto n = node->xnode_union_as_XNNExp();
+    auto output_spec = ctx.lookup_spec(n->output_id());
+    auto handle = ctx.builder.createOperator(Operator::Exp, output_spec,
+        {ctx.lookup(n->input_id())});
+    ctx.id_map[n->output_id()] = handle;
+}
+
+static void define_node(BuildContext& ctx, const fb::XNode* node) {
+    auto type = node->xnode_union_type();
+
+    if (is_binary_op(type)) {
+        define_binary_node(ctx, node);
+    } else if (is_unary_op(type)) {
+        define_unary_node(ctx, node);
+    } else {
+        switch (type) {
+            case fb::XNodeUnion::XNNFullyConnected:
+                define_fully_connected_node(ctx, node);
+                break;
+            case fb::XNodeUnion::XNNConv2d:
+                define_conv2d_node(ctx, node);
+                break;
+            case fb::XNodeUnion::XNNConvTranspose2d:
+                define_conv_transpose2d_node(ctx, node);
+                break;
+            case fb::XNodeUnion::XNNDepthwiseConv2d:
+                define_depthwise_conv2d_node(ctx, node);
+                break;
+            case fb::XNodeUnion::XNNSoftmax:
+                define_softmax_node(ctx, node);
+                break;
+            case fb::XNodeUnion::XNNConvert:
+                define_convert_node(ctx, node);
+                break;
+            case fb::XNodeUnion::XNNStaticTranspose:
+                define_static_transpose_node(ctx, node);
+                break;
+            case fb::XNodeUnion::XNNStaticReshape:
+                define_static_reshape_node(ctx, node);
+                break;
+            case fb::XNodeUnion::XNNStaticSlice:
+                define_static_slice_node(ctx, node);
+                break;
+            case fb::XNodeUnion::XNNStaticConstantPad:
+                define_static_constant_pad_node(ctx, node);
+                break;
+            case fb::XNodeUnion::XNNAvgPooling2d:
+                define_avg_pooling_node(ctx, node);
+                break;
+            case fb::XNodeUnion::XNNMaxPooling2d:
+                define_max_pooling_node(ctx, node);
+                break;
+            case fb::XNodeUnion::XNNGlobalAvgPooling2d:
+                define_global_avg_pooling_node(ctx, node);
+                break;
+            case fb::XNodeUnion::XNNBatchMatrixMultiply:
+                define_batch_matrix_multiply_node(ctx, node);
+                break;
+            case fb::XNodeUnion::XNNPReLU:
+                define_prelu_node(ctx, node);
+                break;
+            case fb::XNodeUnion::XNNCopy:
+                define_copy_node(ctx, node);
+                break;
+            case fb::XNodeUnion::XNNConcatenate2:
+            case fb::XNodeUnion::XNNConcatenate3:
+            case fb::XNodeUnion::XNNConcatenate4:
+            case fb::XNodeUnion::XNNConcatenate5:
+                define_concatenate_node(ctx, node);
+                break;
+            case fb::XNodeUnion::XNNTanh:
+                define_tanh_node(ctx, node);
+                break;
+            case fb::XNodeUnion::XNNExp:
+                define_exp_node(ctx, node);
+                break;
+            case fb::XNodeUnion::XNNStaticResizeBilinear2D:
+                // Resize maps to a reshape-like op; skip for now.
+                break;
+            default:
+                break;
+        }
+    }
+}
+
+FlatbufferBuildResult FlatbufferGraphBuilder::build(
+    const void* buffer, size_t size) {
+    using delegate::XNNHeader;
+
+    auto header = XNNHeader::Parse(buffer, size);
+    const uint8_t* flatbuffer_data = nullptr;
+    const uint8_t* constant_data = nullptr;
+
+    if (header.ok()) {
+        flatbuffer_data = reinterpret_cast<const uint8_t*>(buffer) +
+            header->flatbuffer_offset;
+        constant_data = reinterpret_cast<const uint8_t*>(buffer) +
+            header->constant_data_offset;
+    } else {
+        flatbuffer_data = reinterpret_cast<const uint8_t*>(buffer);
+    }
+
+    auto fb_graph = fb::GetXNNGraph(flatbuffer_data);
+
+    BuildContext ctx;
+    ctx.graph = fb_graph;
+    ctx.constant_data = constant_data;
+
+    // Collect input/output external_id mappings.
+    struct ExternalEntry {
+        uint32_t external_id;
+        uint32_t serial_id;
+    };
+    std::vector<ExternalEntry> input_entries;
+    std::vector<ExternalEntry> output_entries;
+
+    for (auto value : *fb_graph->xvalues()) {
+        const fb::XNNTensorValue* tv = nullptr;
+        switch (value->xvalue_union_type()) {
+            case fb::XValueUnion::XNNTensorValue:
+                tv = value->xvalue_union_as_XNNTensorValue();
+                break;
+            case fb::XValueUnion::XNNQuantizedTensorValue:
+                tv = value->xvalue_union_as_XNNQuantizedTensorValue()->tensor_value();
+                break;
+            default:
+                continue;
+        }
+        if (tv->flags() & 1) {  // XNN_VALUE_FLAG_EXTERNAL_INPUT
+            input_entries.push_back({tv->external_id(), tv->id_out()});
+        }
+        if (tv->flags() & 2) {  // XNN_VALUE_FLAG_EXTERNAL_OUTPUT
+            output_entries.push_back({tv->external_id(), tv->id_out()});
+        }
+    }
+
+    // Sort by external_id so graph input/output order matches.
+    auto by_external_id = [](const ExternalEntry& a, const ExternalEntry& b) {
+        return a.external_id < b.external_id;
+    };
+    std::sort(input_entries.begin(), input_entries.end(), by_external_id);
+    std::sort(output_entries.begin(), output_entries.end(), by_external_id);
+
+    // Define values (inputs, constants, intermediates).
+    // Create inputs in sorted external_id order so graph input indices match.
+    for (auto& entry : input_entries) {
+        // define_value will be called for all values below, but we need
+        // inputs created in the right order. Pre-create them here.
+        auto value_it = std::find_if(
+            fb_graph->xvalues()->begin(), fb_graph->xvalues()->end(),
+            [&](const fb::XValue* v) {
+                const fb::XNNTensorValue* tv = nullptr;
+                switch (v->xvalue_union_type()) {
+                    case fb::XValueUnion::XNNTensorValue:
+                        tv = v->xvalue_union_as_XNNTensorValue();
+                        break;
+                    case fb::XValueUnion::XNNQuantizedTensorValue:
+                        tv = v->xvalue_union_as_XNNQuantizedTensorValue()->tensor_value();
+                        break;
+                    default:
+                        return false;
+                }
+                return tv->id_out() == entry.serial_id;
+            });
+        if (value_it != fb_graph->xvalues()->end()) {
+            define_value(ctx, *value_it);
+        }
+    }
+
+    // Define remaining values (constants, intermediates, outputs-only).
+    for (auto value : *fb_graph->xvalues()) {
+        const fb::XNNTensorValue* tv = nullptr;
+        switch (value->xvalue_union_type()) {
+            case fb::XValueUnion::XNNTensorValue:
+                tv = value->xvalue_union_as_XNNTensorValue();
+                break;
+            case fb::XValueUnion::XNNQuantizedTensorValue:
+                tv = value->xvalue_union_as_XNNQuantizedTensorValue()->tensor_value();
+                break;
+            default:
+                continue;
+        }
+        if (ctx.id_map.count(tv->id_out()) == 0) {
+            define_value(ctx, value);
+        }
+    }
+
+    // Define nodes (operators).
+    for (auto node : *fb_graph->xnodes()) {
+        define_node(ctx, node);
+    }
+
+    // Wire up outputs in external_id order.
+    for (auto& entry : output_entries) {
+        auto it = ctx.id_map.find(entry.serial_id);
+        if (it != ctx.id_map.end()) {
+            ctx.builder.createOutput(it->second);
+        }
+    }
+
+    FlatbufferBuildResult result;
+    result.graph = ctx.builder.build();
+    result.input_external_ids.reserve(input_entries.size());
+    for (auto& e : input_entries) {
+        result.input_external_ids.push_back(e.external_id);
+    }
+    result.output_external_ids.reserve(output_entries.size());
+    for (auto& e : output_entries) {
+        result.output_external_ids.push_back(e.external_id);
+    }
+    return result;
+}
+
+}

--- a/backends/xnnpack/runtime/FlatbufferGraphBuilder.h
+++ b/backends/xnnpack/runtime/FlatbufferGraphBuilder.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <executorch/backends/xnnpack/runtime/graph/graph.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace executorch::backends::xnnpack {
+
+struct FlatbufferBuildResult {
+    graph::Graph graph;
+    std::vector<uint32_t> input_external_ids;
+    std::vector<uint32_t> output_external_ids;
+};
+
+struct FlatbufferGraphBuilder {
+    static FlatbufferBuildResult build(const void* buffer, size_t size);
+};
+
+}

--- a/backends/xnnpack/runtime/XNNPACKBackend.cpp
+++ b/backends/xnnpack/runtime/XNNPACKBackend.cpp
@@ -6,18 +6,22 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <executorch/backends/xnnpack/runtime/FlatbufferGraphBuilder.h>
 #include <executorch/backends/xnnpack/runtime/XNNCompiler.h>
 #include <executorch/backends/xnnpack/runtime/XNNPACKBackend.h>
 #include <executorch/backends/xnnpack/runtime/XNNWeightsCache.h>
 #include <executorch/backends/xnnpack/runtime/XNNWorkspace.h>
 #include <executorch/backends/xnnpack/runtime/XnnpackBackendOptions.h>
+#include <executorch/backends/xnnpack/runtime/executor/executor.h>
 #include <executorch/runtime/backend/interface.h>
 #include <executorch/runtime/core/error.h>
 #include <executorch/runtime/core/evalue.h>
 #include <executorch/runtime/executor/pte_data_map.h>
 
+#include <cstring>
 #include <memory>
 #include <mutex>
+#include <vector>
 
 #pragma clang diagnostic ignored "-Wglobal-constructors"
 
@@ -40,6 +44,16 @@ using executorch::runtime::EValue;
 using executorch::runtime::FreeableBuffer;
 using executorch::runtime::Result;
 using executorch::runtime::Span;
+
+struct XnnpackDelegateHandle {
+  bool is_graph_runtime;
+  // Legacy path: XNNExecutor placed via runtime allocator.
+  xnnpack::delegate::XNNExecutor* legacy_executor = nullptr;
+  // Graph path: heap-allocated Executor.
+  xnnpack::executor::Executor* graph_executor = nullptr;
+  std::vector<uint32_t> input_external_ids;
+  std::vector<uint32_t> output_external_ids;
+};
 
 class XnnpackBackend final
     : public ::executorch::ET_RUNTIME_NAMESPACE::BackendInterface {
@@ -66,26 +80,50 @@ class XnnpackBackend final
       BackendInitContext& context,
       FreeableBuffer* processed,
       ArrayRef<CompileSpec> compile_specs) const override {
+    auto* handle = context.get_runtime_allocator()
+                       ->allocateInstance<XnnpackDelegateHandle>();
+    if (handle == nullptr) {
+      return Error::MemoryAllocationFailed;
+    }
+    new (handle) XnnpackDelegateHandle();
+
+    bool use_graph_runtime = options_.resolve_graph_runtime(context);
+    handle->is_graph_runtime = use_graph_runtime;
+
+    if (use_graph_runtime) {
+      auto result = xnnpack::FlatbufferGraphBuilder::build(
+          processed->data(), processed->size());
+      processed->Free();
+
+      auto* executor = new xnnpack::executor::Executor(
+          xnnpack::executor::Executor::build(result.graph));
+      handle->graph_executor = executor;
+      handle->input_external_ids = std::move(result.input_external_ids);
+      handle->output_external_ids = std::move(result.output_external_ids);
+      return handle;
+    }
+
     auto executor = context.get_runtime_allocator()
                         ->allocateInstance<xnnpack::delegate::XNNExecutor>();
     if (executor == nullptr) {
+      handle->~XnnpackDelegateHandle();
       return Error::MemoryAllocationFailed;
     }
 
     const NamedDataMap* named_data_map = context.get_named_data_map();
-    // thread safe. This can happen when multiple threads call init() on
-    // the same backend instance.
 
     auto program_id =
         reinterpret_cast<uintptr_t>(context.get_runtime_allocator());
     auto sharing_mode_result = options_.resolve_sharing_mode(context);
     if (!sharing_mode_result.ok()) {
+      handle->~XnnpackDelegateHandle();
       return sharing_mode_result.error();
     }
     auto workspace_result =
         options_.workspace_manager().get_or_create_workspace(
             program_id, sharing_mode_result.get());
     if (!workspace_result.ok()) {
+      handle->~XnnpackDelegateHandle();
       return workspace_result.error();
     }
     auto workspace = workspace_result.get();
@@ -115,22 +153,27 @@ class XnnpackBackend final
     processed->Free();
 
     if (err != Error::Ok) {
-      // destroy() won't be called on this handle, so we need to clean it up
-      // now.
       executor->~XNNExecutor();
-
+      handle->~XnnpackDelegateHandle();
       ET_LOG(
           Error, "XNNCompiler::compileModel failed: 0x%x", (unsigned int)err);
       return err;
     }
-    return executor;
+    handle->legacy_executor = executor;
+    return handle;
   }
 
   Error execute(
       BackendExecutionContext& context,
       DelegateHandle* handle,
       Span<EValue*> args) const override {
-    auto executor = static_cast<xnnpack::delegate::XNNExecutor*>(handle);
+    auto* delegate = static_cast<XnnpackDelegateHandle*>(handle);
+
+    if (delegate->is_graph_runtime) {
+      return execute_graph(delegate, args);
+    }
+
+    auto executor = delegate->legacy_executor;
 
     std::unique_lock<std::mutex> lock_weights_cache(
         weights_cache_mutex_, std::defer_lock);
@@ -160,7 +203,15 @@ class XnnpackBackend final
 
   void destroy(DelegateHandle* handle) const override {
     if (handle != nullptr) {
-      auto executor = static_cast<xnnpack::delegate::XNNExecutor*>(handle);
+      auto* delegate = static_cast<XnnpackDelegateHandle*>(handle);
+
+      if (delegate->is_graph_runtime) {
+        delete delegate->graph_executor;
+        delegate->~XnnpackDelegateHandle();
+        return;
+      }
+
+      auto executor = delegate->legacy_executor;
 
 #ifdef ENABLE_XNNPACK_PROFILING
       executor->print_avg_op_timings();
@@ -183,6 +234,7 @@ class XnnpackBackend final
       // XNNExecutor is not trivially destructible. Since this was constructed
       // manually in init(), we must destroy it manually here.
       executor->~XNNExecutor();
+      delegate->~XnnpackDelegateHandle();
     }
   }
 
@@ -211,6 +263,62 @@ class XnnpackBackend final
   }
 
  private:
+  Error execute_graph(
+      XnnpackDelegateHandle* delegate,
+      Span<EValue*> args) const {
+    auto* executor = delegate->graph_executor;
+
+    // Build input tensors from EValue args.
+    std::vector<xnnpack::core::Tensor> inputs;
+    inputs.reserve(delegate->input_external_ids.size());
+    for (uint32_t ext_id : delegate->input_external_ids) {
+      auto& et_tensor = args[ext_id]->toTensor();
+      xnnpack::core::Tensor t;
+      t.dtype = xnnpack::core::DType::Float32;  // TODO: map from et_tensor
+      t.sizes.resize(et_tensor.dim());
+      for (ssize_t d = 0; d < et_tensor.dim(); d++) {
+        t.sizes[d] = static_cast<uint64_t>(et_tensor.size(d));
+      }
+      t.storage.data = et_tensor.mutable_data_ptr();
+      t.storage.size_in_bytes = et_tensor.nbytes();
+      t.storage.owner = xnnpack::core::StorageOwner::External;
+      inputs.push_back(std::move(t));
+    }
+
+    auto outputs = executor->run(
+        xnnpack::core::Span<xnnpack::core::Tensor>(
+            inputs.data(), inputs.size()));
+
+    // Copy output data back to EValue tensors.
+    for (size_t i = 0; i < delegate->output_external_ids.size(); i++) {
+      uint32_t ext_id = delegate->output_external_ids[i];
+      auto& et_tensor = args[ext_id]->toTensor();
+      auto& out_tensor = outputs[i];
+
+      // Resize the output EValue tensor to match the computed shape.
+      std::vector<exec_aten::SizesType> new_sizes_vec(out_tensor.sizes.size());
+      for (size_t d = 0; d < out_tensor.sizes.size(); d++) {
+        new_sizes_vec[d] = static_cast<exec_aten::SizesType>(out_tensor.sizes[d]);
+      }
+      exec_aten::ArrayRef<exec_aten::SizesType> new_sizes(
+          new_sizes_vec.data(), new_sizes_vec.size());
+      Error err = executorch::runtime::resize_tensor(et_tensor, new_sizes);
+      if (err != Error::Ok) {
+        return err;
+      }
+
+      // Copy output data if the output lives in arena memory.
+      if (out_tensor.storage.data != et_tensor.mutable_data_ptr()) {
+        std::memcpy(
+            et_tensor.mutable_data_ptr(),
+            out_tensor.storage.data,
+            out_tensor.storage.size_in_bytes);
+      }
+    }
+
+    return Error::Ok;
+  }
+
   mutable xnnpack::XnnpackBackendOptions options_;
 
   // Weights cache is global to all delegate instances.

--- a/backends/xnnpack/runtime/XNNPACKBackend.h
+++ b/backends/xnnpack/runtime/XNNPACKBackend.h
@@ -13,6 +13,10 @@ const char workspace_sharing_mode_option_key[] = "workspace_sharing_mode";
 // across delegate instances. Changes only affect subsequently loaded models.
 const char weight_cache_option_key[] = "weight_cache_enabled";
 
+/// The key for the graph runtime option. When enabled, the new graph-based
+/// runtime is used instead of the legacy XNNCompiler/XNNExecutor path.
+const char use_graph_runtime_option_key[] = "use_graph_runtime";
+
 /// Workspace sharing mode. This is a backend option that can be set via the
 /// set_option API to control memory sharing between CALL_DELEGATE instances.
 /// This is useful for reducing memory consumption.

--- a/backends/xnnpack/runtime/XnnpackBackendOptions.cpp
+++ b/backends/xnnpack/runtime/XnnpackBackendOptions.cpp
@@ -37,6 +37,8 @@ Error XnnpackBackendOptions::get_option(BackendOption& option) const {
     option.value = static_cast<int>(sharing_mode_.load());
   } else if (strcmp(option.key, weight_cache_option_key) == 0) {
     option.value = weight_cache_enabled_.load();
+  } else if (strcmp(option.key, use_graph_runtime_option_key) == 0) {
+    option.value = use_graph_runtime_.load();
   }
   return Error::Ok;
 }
@@ -66,6 +68,14 @@ Error XnnpackBackendOptions::set_option(const BackendOption& option) {
     }
     ET_LOG(Debug, "Setting XNNPACK weight cache enabled to %d.", *val);
     weight_cache_enabled_.store(*val);
+  } else if (strcmp(option.key, use_graph_runtime_option_key) == 0) {
+    auto* val = std::get_if<bool>(&option.value);
+    if (!val) {
+      ET_LOG(Error, "XNNPACK use_graph_runtime must be a bool.");
+      return Error::InvalidArgument;
+    }
+    ET_LOG(Debug, "Setting XNNPACK use_graph_runtime to %d.", *val);
+    use_graph_runtime_.store(*val);
   }
   return Error::Ok;
 }
@@ -94,6 +104,12 @@ XnnpackBackendOptions::resolve_sharing_mode(
     return runtime::Error::InvalidArgument;
   }
   return static_cast<WorkspaceSharingMode>(raw_mode);
+}
+
+bool XnnpackBackendOptions::resolve_graph_runtime(
+    const ET_RUNTIME_NAMESPACE::BackendInitContext& context) const {
+  return resolve_option<bool>(
+      context, use_graph_runtime_option_key, use_graph_runtime_.load());
 }
 
 WorkspaceSharingMode XnnpackBackendOptions::get_sharing_mode() const {

--- a/backends/xnnpack/runtime/XnnpackBackendOptions.h
+++ b/backends/xnnpack/runtime/XnnpackBackendOptions.h
@@ -37,6 +37,9 @@ class XnnpackBackendOptions {
   runtime::Result<WorkspaceSharingMode> resolve_sharing_mode(
       const ET_RUNTIME_NAMESPACE::BackendInitContext& context) const;
 
+  bool resolve_graph_runtime(
+      const ET_RUNTIME_NAMESPACE::BackendInitContext& context) const;
+
   WorkspaceSharingMode get_sharing_mode() const;
   XNNWorkspaceManager& workspace_manager();
   const XNNWorkspaceManager& workspace_manager() const;
@@ -56,6 +59,8 @@ class XnnpackBackendOptions {
 #else
   std::atomic<bool> weight_cache_enabled_{false};
 #endif
+
+  std::atomic<bool> use_graph_runtime_{false};
 };
 
 } // namespace executorch::backends::xnnpack

--- a/backends/xnnpack/runtime/core/dtype.h
+++ b/backends/xnnpack/runtime/core/dtype.h
@@ -1,0 +1,17 @@
+#pragma once
+
+namespace executorch::backends::xnnpack::core {
+
+enum class DType {
+    Float32,
+
+    // Quantized — signed symmetric
+    QInt8Sym,
+    QInt4Sym,
+    QInt32Sym,
+
+    // Quantized — unsigned asymmetric
+    QUInt8Asym,
+};
+
+}

--- a/backends/xnnpack/runtime/core/quant_params.cpp
+++ b/backends/xnnpack/runtime/core/quant_params.cpp
@@ -1,0 +1,120 @@
+#include <executorch/backends/xnnpack/runtime/core/quant_params.h>
+
+#include <cstdlib>
+
+namespace executorch::backends::xnnpack::core {
+
+QuantParams qint8_per_channel_sym(int8_t axis) {
+    return PerAxisQuant { .axis = axis };
+}
+
+QuantParams qint8_per_tensor_sym(float scale) {
+    return PerTensorQuant { .scale = scale, .zero_point = 0 };
+}
+
+QuantParams quint8_per_tensor_asym(float scale, int32_t zero_point) {
+    return PerTensorQuant { .scale = scale, .zero_point = zero_point };
+}
+
+QuantParams quint8_per_token_asym(int8_t axis) {
+    return PerAxisQuant { .axis = axis };
+}
+
+QuantParams qint4_blockwise_sym(int8_t axis, int32_t block_size) {
+    return BlockwiseQuant { .axis = axis, .block_size = block_size };
+}
+
+bool is_quantized(DType dtype) {
+    switch (dtype) {
+        case DType::Float32:
+            return false;
+        case DType::QInt8Sym:
+        case DType::QInt4Sym:
+        case DType::QInt32Sym:
+        case DType::QUInt8Asym:
+            return true;
+    }
+}
+
+bool is_asymmetric(DType dtype) {
+    switch (dtype) {
+        case DType::QUInt8Asym:
+            return true;
+        default:
+            return false;
+    }
+}
+
+size_t element_size(DType dtype) {
+    switch (dtype) {
+        case DType::Float32:    return 4;
+        case DType::QInt8Sym:   return 1;
+        case DType::QUInt8Asym: return 1;
+        case DType::QInt32Sym:  return 4;
+        default:
+            abort();
+    }
+}
+
+uint8_t aux_buffer_count(DType dtype, const QuantParams& params) {
+    (void)params;
+    if (!is_quantized(dtype)) return 0;
+
+    uint8_t count = 1; // scales
+    if (is_asymmetric(dtype)) count++; // zero_points
+    return count;
+}
+
+static size_t scale_element_count(
+    core::Span<const uint64_t> sizes,
+    const QuantParams& params) {
+    return std::visit(overloaded {
+        [](const PerTensorQuant&) -> size_t {
+            return 1;
+        },
+        [&](const PerAxisQuant& p) -> size_t {
+            size_t count = 1;
+            for (size_t i = 0; i < sizes.size(); i++) {
+                if (i != static_cast<size_t>(p.axis)) count *= sizes[i];
+            }
+            return count;
+        },
+        [&](const BlockwiseQuant& p) -> size_t {
+            auto axis = static_cast<size_t>(p.axis);
+            size_t num_blocks = (sizes[axis] + p.block_size - 1) / p.block_size;
+            size_t other_dims = 1;
+            for (size_t i = 0; i < sizes.size(); i++) {
+                if (i != axis) other_dims *= sizes[i];
+            }
+            return num_blocks * other_dims;
+        },
+    }, params);
+}
+
+static DType scale_dtype_of(const QuantParams& params) {
+    return std::visit(overloaded {
+        [](const PerTensorQuant& p) { return p.scale_dtype; },
+        [](const PerAxisQuant& p) { return p.scale_dtype; },
+        [](const BlockwiseQuant& p) { return p.scale_dtype; },
+    }, params);
+}
+
+std::vector<size_t> compute_aux_storage_sizes(
+    Span<const uint64_t> sizes,
+    DType dtype,
+    const QuantParams& params) {
+    std::vector<size_t> result;
+
+    auto num_scales = scale_element_count(sizes, params);
+    auto scale_bytes = num_scales * element_size(scale_dtype_of(params));
+    result.push_back(scale_bytes);
+
+    if (is_asymmetric(dtype)) {
+        auto zp_bytes = num_scales * sizeof(int32_t);
+        result.push_back(zp_bytes);
+    }
+
+    return result;
+}
+
+}

--- a/backends/xnnpack/runtime/core/quant_params.h
+++ b/backends/xnnpack/runtime/core/quant_params.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <executorch/backends/xnnpack/runtime/core/dtype.h>
+#include <executorch/backends/xnnpack/runtime/core/span.h>
+#include <executorch/backends/xnnpack/runtime/core/variant_util.h>
+
+#include <cstdint>
+#include <variant>
+#include <vector>
+
+namespace executorch::backends::xnnpack::core {
+
+struct PerTensorQuant {
+    DType scale_dtype = DType::Float32;
+    float scale = 0.0f;
+    int32_t zero_point = 0;
+
+    bool operator==(const PerTensorQuant& o) const {
+        return scale_dtype == o.scale_dtype
+            && scale == o.scale
+            && zero_point == o.zero_point;
+    }
+};
+
+struct PerAxisQuant {
+    int8_t axis;
+    DType scale_dtype = DType::Float32;
+
+    bool operator==(const PerAxisQuant& o) const {
+        return axis == o.axis && scale_dtype == o.scale_dtype;
+    }
+};
+
+struct BlockwiseQuant {
+    int8_t axis;
+    int32_t block_size;
+    DType scale_dtype = DType::Float32;
+
+    bool operator==(const BlockwiseQuant& o) const {
+        return axis == o.axis
+            && block_size == o.block_size
+            && scale_dtype == o.scale_dtype;
+    }
+};
+
+using QuantParams = std::variant<PerTensorQuant, PerAxisQuant, BlockwiseQuant>;
+
+QuantParams qint8_per_channel_sym(int8_t axis);
+QuantParams qint8_per_tensor_sym(float scale);
+QuantParams quint8_per_tensor_asym(float scale, int32_t zero_point);
+QuantParams quint8_per_token_asym(int8_t axis);
+QuantParams qint4_blockwise_sym(int8_t axis, int32_t block_size);
+
+bool is_quantized(DType dtype);
+bool is_asymmetric(DType dtype);
+size_t element_size(DType dtype);
+uint8_t aux_buffer_count(DType dtype, const QuantParams& params);
+std::vector<size_t> compute_aux_storage_sizes(
+    Span<const uint64_t> sizes,
+    DType dtype,
+    const QuantParams& params);
+
+}

--- a/backends/xnnpack/runtime/core/span.h
+++ b/backends/xnnpack/runtime/core/span.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <cstddef>
+#include <initializer_list>
+#include <type_traits>
+#include <vector>
+
+namespace executorch::backends::xnnpack::core {
+
+template <typename T>
+class Span {
+public:
+    constexpr Span() : data_(nullptr), size_(0) {}
+    constexpr Span(T* data, size_t size) : data_(data), size_(size) {}
+
+    template <typename U>
+    Span(std::vector<U>& v) : data_(v.data()), size_(v.size()) {}
+
+    template <typename U>
+    Span(const std::vector<U>& v) : data_(v.data()), size_(v.size()) {}
+
+    template <typename Dummy = T,
+              typename = std::enable_if_t<std::is_const_v<Dummy>>>
+    Span(std::initializer_list<std::remove_const_t<T>> il) : data_(il.begin()), size_(il.size()) {}
+
+    constexpr T* data() const { return data_; }
+    constexpr size_t size() const { return size_; }
+    constexpr bool empty() const { return size_ == 0; }
+
+    constexpr T& operator[](size_t i) const { return data_[i]; }
+
+    constexpr T* begin() const { return data_; }
+    constexpr T* end() const { return data_ + size_; }
+
+private:
+    T* data_;
+    size_t size_;
+};
+
+}

--- a/backends/xnnpack/runtime/core/tensor.cpp
+++ b/backends/xnnpack/runtime/core/tensor.cpp
@@ -1,0 +1,83 @@
+#include <executorch/backends/xnnpack/runtime/core/tensor.h>
+
+#include <cstdlib>
+#include <numeric>
+
+namespace executorch::backends::xnnpack::core {
+
+Storage::~Storage() {
+    if (owner == StorageOwner::Self) {
+        std::free(data);
+    }
+}
+
+Storage::Storage(Storage&& other) noexcept
+    : data(other.data), owner(other.owner), size_in_bytes(other.size_in_bytes) {
+    other.data = nullptr;
+    other.owner = StorageOwner::External;
+    other.size_in_bytes = 0;
+}
+
+Storage& Storage::operator=(Storage&& other) noexcept {
+    if (this != &other) {
+        if (owner == StorageOwner::Self) {
+            std::free(data);
+        }
+        data = other.data;
+        owner = other.owner;
+        size_in_bytes = other.size_in_bytes;
+        other.data = nullptr;
+        other.owner = StorageOwner::External;
+        other.size_in_bytes = 0;
+    }
+    return *this;
+}
+
+Storage Storage::create_owned(size_t size_in_bytes) {
+    Storage s;
+    s.data = std::malloc(size_in_bytes);
+    s.owner = StorageOwner::Self;
+    s.size_in_bytes = size_in_bytes;
+    return s;
+}
+
+size_t Tensor::numel() const {
+    return std::accumulate(
+        sizes.begin(), sizes.end(), size_t{1}, std::multiplies<>());
+}
+
+bool Tensor::resize(std::vector<uint64_t> new_sizes) {
+    size_t new_size_in_bytes = compute_storage_size(new_sizes, dtype);
+
+    if (new_size_in_bytes <= storage.size_in_bytes) {
+        sizes = std::move(new_sizes);
+        return true;
+    }
+
+    if (storage.owner != StorageOwner::Self) {
+        return false;
+    }
+
+    void* new_data = std::realloc(storage.data, new_size_in_bytes);
+    if (!new_data) { return false; }
+
+    storage.data = new_data;
+    storage.size_in_bytes = new_size_in_bytes;
+    sizes = std::move(new_sizes);
+    return true;
+}
+
+size_t compute_storage_size(Span<const uint64_t> sizes, DType dtype) {
+    size_t num_elements = std::accumulate(
+        sizes.begin(), sizes.end(), size_t{1}, std::multiplies<>());
+
+    switch (dtype) {
+        case DType::Float32:    return num_elements * 4;
+        case DType::QInt8Sym:   return num_elements * 1;
+        case DType::QUInt8Asym: return num_elements * 1;
+        case DType::QInt4Sym:   return (num_elements + 1) / 2;
+        case DType::QInt32Sym:  return num_elements * 4;
+    }
+}
+
+}

--- a/backends/xnnpack/runtime/core/tensor.h
+++ b/backends/xnnpack/runtime/core/tensor.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <executorch/backends/xnnpack/runtime/core/dtype.h>
+#include <executorch/backends/xnnpack/runtime/core/span.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace executorch::backends::xnnpack::core {
+
+enum class StorageOwner {
+    Arena,
+    External,
+    Self
+};
+
+struct Storage {
+    void* data = nullptr;
+    StorageOwner owner = StorageOwner::External;
+    size_t size_in_bytes = 0;
+
+    Storage() = default;
+    ~Storage();
+
+    Storage(const Storage&) = delete;
+    Storage& operator=(const Storage&) = delete;
+
+    Storage(Storage&& other) noexcept;
+    Storage& operator=(Storage&& other) noexcept;
+
+    static Storage create_owned(size_t size_in_bytes);
+};
+
+struct Tensor {
+    DType dtype;
+    std::vector<uint64_t> sizes;
+    Storage storage;
+    std::vector<Storage> aux_storage;
+
+    template <class T>
+    const T* data_const() { return static_cast<const T*>(storage.data); }
+    template <class T>
+    T* data_mut() { return static_cast<T*>(storage.data); }
+
+    size_t numel() const;
+    bool resize(std::vector<uint64_t> new_sizes);
+};
+
+size_t compute_storage_size(Span<const uint64_t> sizes, DType dtype);
+
+}

--- a/backends/xnnpack/runtime/core/variant_util.h
+++ b/backends/xnnpack/runtime/core/variant_util.h
@@ -1,0 +1,4 @@
+#pragma once
+
+template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
+template<class... Ts> overloaded(Ts...) -> overloaded<Ts...>;

--- a/backends/xnnpack/runtime/executor/arena.cpp
+++ b/backends/xnnpack/runtime/executor/arena.cpp
@@ -1,0 +1,11 @@
+#include <executorch/backends/xnnpack/runtime/executor/arena.h>
+
+namespace executorch::backends::xnnpack::executor {
+
+void Arena::resize(size_t new_size) {
+    if (new_size <= size) { return; }
+    buffer = std::make_unique<uint8_t[]>(new_size);
+    size = new_size;
+}
+
+}

--- a/backends/xnnpack/runtime/executor/arena.h
+++ b/backends/xnnpack/runtime/executor/arena.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+
+namespace executorch::backends::xnnpack::executor {
+
+struct Arena {
+    std::unique_ptr<uint8_t[]> buffer;
+    size_t size = 0;
+
+    inline void* data() { return buffer.get(); }
+    void resize(size_t new_size);
+};
+
+}

--- a/backends/xnnpack/runtime/executor/executor.cpp
+++ b/backends/xnnpack/runtime/executor/executor.cpp
@@ -1,0 +1,185 @@
+#include <executorch/backends/xnnpack/runtime/executor/executor.h>
+
+#include <executorch/backends/xnnpack/runtime/core/variant_util.h>
+#include <executorch/backends/xnnpack/runtime/plan/execution_plan.h>
+
+#include <cassert>
+#include <cstdlib>
+#include <xnnpack.h>
+
+namespace executorch::backends::xnnpack::executor {
+
+std::vector<core::Tensor> Executor::run(core::Span<core::Tensor> inputs) {
+    update_planned_memory(inputs);
+
+    for (const auto& step : plan.steps) {
+        run_step(step);
+    }
+
+    std::vector<core::Tensor> outputs;
+    outputs.reserve(output_slots.size());
+    for (auto slot : output_slots) {
+        auto& val = values[slot];
+        core::Tensor t;
+        t.dtype = val.dtype;
+        t.sizes = val.sizes;
+        t.storage.data = val.storage.data;
+        t.storage.size_in_bytes = val.storage.size_in_bytes;
+        t.storage.owner = core::StorageOwner::External;
+        outputs.push_back(std::move(t));
+    }
+    return outputs;
+}
+
+void Executor::run_step(const plan::PlanStep& step) {
+    std::visit(overloaded {
+        [&](const plan::RunOperatorStep& s) {
+            std::vector<core::Tensor*> inputs;
+            inputs.reserve(s.input_slots.size());
+            for (auto slot : s.input_slots) {
+                inputs.push_back(&values[slot]);
+            }
+
+            std::vector<core::Tensor*> outputs;
+            outputs.reserve(s.output_slots.size());
+            for (auto slot : s.output_slots) {
+                outputs.push_back(&values[slot]);
+            }
+
+            s.op->execute(inputs, outputs);
+        },
+        [&](const plan::RunXnnSubgraphStep& s) {
+            auto status = xnn_invoke_runtime(s.runtime.get());
+            assert(status == xnn_status_success);
+        }
+    }, step);
+}
+
+void Executor::update_planned_memory(core::Span<core::Tensor> inputs) {
+    if (!shape_env.specialize(input_specs, inputs)) {
+        abort();
+    }
+
+    memory_plan.replan(shape_env);
+    arena.resize(memory_plan.arena_size);
+
+    for (size_t i = 0; i < inputs.size(); i++) {
+        values[i].sizes = inputs[i].sizes;
+        values[i].storage.data = inputs[i].storage.data;
+        values[i].storage.size_in_bytes = inputs[i].storage.size_in_bytes;
+    }
+
+    assert(memory_plan.value_allocations.size() == values.size());
+    for (auto i = 0u; i < values.size(); i++) {
+        std::visit(overloaded {
+            [&](plan::ArenaAllocation& alloc) {
+                auto& storage = values[i].storage;
+                assert(storage.owner == core::StorageOwner::Arena);
+                storage.data = static_cast<uint8_t*>(arena.data()) + alloc.offset;
+                storage.size_in_bytes = alloc.size;
+            },
+            [&](plan::DynamicAllocation& alloc) {
+                assert(values[i].storage.owner == core::StorageOwner::Self);
+            },
+            [&](plan::ExternalAllocation&) {
+                assert(values[i].storage.owner == core::StorageOwner::External);
+            }
+        }, memory_plan.value_allocations.at(i));
+    }
+
+    for (size_t i = 0; i < values.size(); i++) {
+        if (std::holds_alternative<plan::ArenaAllocation>(memory_plan.value_allocations[i])) {
+            auto& spec = memory_plan.value_specs[i];
+            values[i].sizes.resize(spec.sizes.size());
+            for (size_t d = 0; d < spec.sizes.size(); d++) {
+                auto& dim = spec.sizes[d];
+                int64_t size = dim.offset;
+                for (auto& term : dim.coeffs) {
+                    auto& bound = shape_env.specialized_bounds[term.sym];
+                    size += term.coefficient * static_cast<int64_t>(*bound.max);
+                }
+                values[i].sizes[d] = static_cast<uint64_t>(size);
+            }
+        }
+    }
+
+    for (auto& step : plan.steps) {
+        auto* op_step = std::get_if<plan::RunOperatorStep>(&step);
+        if (!op_step) continue;
+
+        std::vector<graph::TensorSpec> input_specs;
+        input_specs.reserve(op_step->input_slots.size());
+        for (auto slot : op_step->input_slots) {
+            input_specs.push_back(memory_plan.value_specs[slot]);
+        }
+        op_step->op->reshape(input_specs);
+    }
+
+    for (auto& step : plan.steps) {
+        auto* xnn = std::get_if<plan::RunXnnSubgraphStep>(&step);
+        if (!xnn) continue;
+
+        auto* rt = xnn->runtime.get();
+
+        for (uint32_t eid = 0; eid < xnn->external_value_slots.size(); eid++) {
+            auto slot = xnn->external_value_slots[eid];
+            auto& tensor = values[slot];
+            std::vector<size_t> dims(tensor.sizes.begin(), tensor.sizes.end());
+            xnn_reshape_external_value(rt, eid, dims.size(), dims.data());
+        }
+
+        xnn_reshape_runtime(rt);
+
+        std::vector<xnn_external_value> externals(xnn->external_value_slots.size());
+        for (uint32_t eid = 0; eid < xnn->external_value_slots.size(); eid++) {
+            auto slot = xnn->external_value_slots[eid];
+            externals[eid].id = eid;
+            externals[eid].data = values[slot].storage.data;
+        }
+        xnn_setup_runtime_v2(rt, externals.size(), externals.data());
+    }
+}
+
+Executor Executor::build(graph::Graph& graph) {
+    auto init_status = xnn_initialize(nullptr);
+    assert(init_status == xnn_status_success);
+
+    auto execution_plan = plan::create_execution_plan(graph);
+    auto memory_plan = plan::create_memory_plan(graph, execution_plan);
+
+    std::vector<plan::ValueSlot> output_slots;
+    output_slots.reserve(graph.outputs.size());
+    for (auto& vh : graph.outputs) {
+        output_slots.push_back(graph.nodes[vh.node].tag + vh.output);
+    }
+
+    auto num_slots = memory_plan.value_allocations.size();
+    std::vector<core::Tensor> values(num_slots);
+    for (size_t i = 0; i < num_slots; i++) {
+        values[i].dtype = memory_plan.value_specs[i].dtype;
+        if (std::holds_alternative<plan::ArenaAllocation>(memory_plan.value_allocations[i])) {
+            values[i].storage.owner = core::StorageOwner::Arena;
+        }
+    }
+
+    for (size_t n = 0; n < graph.nodes.size(); n++) {
+        auto* cn = std::get_if<graph::ConstantNode>(&graph.nodes[n].value);
+        if (!cn) continue;
+        auto slot = graph.nodes[n].tag;
+        values[slot].sizes = cn->tensor->sizes;
+        values[slot].storage.data = const_cast<void*>(
+            static_cast<const void*>(cn->tensor->storage.data));
+        values[slot].storage.size_in_bytes = cn->tensor->storage.size_in_bytes;
+    }
+
+    Executor exec;
+    exec.input_specs = graph.input_specs;
+    exec.memory_plan = std::move(memory_plan);
+    exec.plan = std::move(execution_plan);
+    exec.shape_env = ShapeEnv(graph.symint_count());
+    exec.output_slots = std::move(output_slots);
+    exec.values = std::move(values);
+    return std::move(exec);
+}
+
+}

--- a/backends/xnnpack/runtime/executor/executor.h
+++ b/backends/xnnpack/runtime/executor/executor.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <executorch/backends/xnnpack/runtime/core/span.h>
+#include <executorch/backends/xnnpack/runtime/core/tensor.h>
+#include <executorch/backends/xnnpack/runtime/executor/arena.h>
+#include <executorch/backends/xnnpack/runtime/executor/shape_env.h>
+#include <executorch/backends/xnnpack/runtime/graph/graph.h>
+#include <executorch/backends/xnnpack/runtime/plan/execution_plan.h>
+#include <executorch/backends/xnnpack/runtime/plan/memory_plan.h>
+
+#include <vector>
+
+namespace executorch::backends::xnnpack::executor {
+
+struct Executor {
+    Arena arena;
+    std::vector<graph::TensorSpec> input_specs;
+    plan::MemoryPlan memory_plan;
+    plan::ExecutionPlan plan;
+    ShapeEnv shape_env;
+    std::vector<plan::ValueSlot> output_slots;
+    std::vector<core::Tensor> values;
+
+    std::vector<core::Tensor> run(core::Span<core::Tensor> inputs);
+    void run_step(const plan::PlanStep& step);
+    void update_planned_memory(core::Span<core::Tensor> inputs);
+
+    static Executor build(graph::Graph& graph);
+};
+
+}

--- a/backends/xnnpack/runtime/executor/shape_env.cpp
+++ b/backends/xnnpack/runtime/executor/shape_env.cpp
@@ -1,0 +1,47 @@
+#include <executorch/backends/xnnpack/runtime/executor/shape_env.h>
+
+namespace executorch::backends::xnnpack::executor {
+
+ShapeEnv::ShapeEnv(uint32_t num_symints) : specialized_bounds(num_symints), unspecialized_bounds(num_symints) {
+
+}
+
+bool ShapeEnv::specialize(core::Span<const graph::TensorSpec> specs, core::Span<core::Tensor> values) {
+    for (auto& b : specialized_bounds) {
+        b.min = 1;
+        b.max = {};
+    }
+
+    if (specs.size() != values.size()) { return false; }
+
+    for (size_t i = 0; i < specs.size(); i++) {
+        auto& spec = specs[i];
+        auto& tensor = values[i];
+
+        if (spec.sizes.size() != tensor.sizes.size()) { return false; }
+
+        for (size_t d = 0; d < spec.sizes.size(); d++) {
+            auto& dim = spec.sizes[d];
+            auto concrete = static_cast<int64_t>(tensor.sizes[d]);
+
+            if (dim.is_constant()) {
+                if (dim.offset != concrete) { return false; }
+                continue;
+            }
+
+            if (dim.coeffs.size() == 1 && dim.coeffs[0].coefficient == 1) {
+                auto sym = dim.coeffs[0].sym;
+                auto solved = static_cast<uint64_t>(concrete - dim.offset);
+                auto& bound = specialized_bounds[sym];
+                bound.min = std::max(bound.min, solved);
+                bound.max = bound.max ? std::min(*bound.max, solved) : solved;
+                if (bound.min > *bound.max) { return false; }
+                continue;
+            }
+        }
+    }
+
+    return true;
+}
+
+}

--- a/backends/xnnpack/runtime/executor/shape_env.h
+++ b/backends/xnnpack/runtime/executor/shape_env.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <executorch/backends/xnnpack/runtime/core/span.h>
+#include <executorch/backends/xnnpack/runtime/core/tensor.h>
+#include <executorch/backends/xnnpack/runtime/graph/tensor_spec.h>
+
+#include <cstdint>
+#include <optional>
+
+namespace executorch::backends::xnnpack::executor {
+
+struct ShapeBound {
+    uint64_t min = 1;
+    std::optional<uint64_t> max = {};
+};
+
+struct ShapeEnv {
+    std::vector<ShapeBound> specialized_bounds;
+    std::vector<ShapeBound> unspecialized_bounds;
+
+    ShapeEnv() = default;
+    ShapeEnv(uint32_t num_symints);
+
+    bool specialize(core::Span<const graph::TensorSpec> specs, core::Span<core::Tensor> values);
+};
+
+}

--- a/backends/xnnpack/runtime/graph/graph.cpp
+++ b/backends/xnnpack/runtime/graph/graph.cpp
@@ -1,0 +1,106 @@
+#include <executorch/backends/xnnpack/runtime/graph/graph.h>
+
+#include <executorch/backends/xnnpack/runtime/core/variant_util.h>
+
+#include <cassert>
+
+namespace executorch::backends::xnnpack::graph {
+
+namespace {
+
+void scan_spec(const TensorSpec& spec, uint32_t& max_id) {
+    for (auto& dim : spec.sizes) {
+        for (auto& term : dim.coeffs) {
+            if (term.sym >= max_id) { max_id = term.sym + 1; }
+        }
+    }
+}
+
+void scan_output_spec(const OutputSpec& os, uint32_t& max_id) {
+    std::visit(overloaded {
+        [&](const TensorSpec& s) { scan_spec(s, max_id); },
+        [&](const std::vector<TensorSpec>& v) { for (auto& s : v) scan_spec(s, max_id); },
+    }, os);
+}
+
+} // namespace
+
+uint32_t Graph::symint_count() const {
+    uint32_t count = 0;
+    for (auto& spec : input_specs) { scan_spec(spec, count); }
+    for (auto& node : nodes) {
+        std::visit(overloaded {
+            [](const InputNode&) {},
+            [](const ConstantNode&) {},
+            [&](const CallOperatorNode& n) { scan_output_spec(n.output_specs, count); },
+            [&](const CallSubgraphNode& n) { scan_output_spec(n.output_specs, count); },
+        }, node.value);
+    }
+    return count;
+}
+
+void Graph::update_users() {
+    for (auto& node : nodes) {
+        node.users.clear();
+    }
+
+    for (NodeHandle i = 0; i < nodes.size(); ++i) {
+        std::visit(overloaded {
+            [](const InputNode&) {},
+            [](const ConstantNode&) {},
+            [&](const CallOperatorNode& n) {
+                for (auto arg : n.args) {
+                    if (!arg.is_null()) {
+                        nodes[arg.node].users.push_back(i);
+                    }
+                }
+            },
+            [&](const CallSubgraphNode& n) {
+                for (auto arg : n.args) {
+                    if (!arg.is_null()) {
+                        nodes[arg.node].users.push_back(i);
+                    }
+                }
+            },
+        }, nodes[i].value);
+    }
+}
+
+void Graph::compact_nodes() {
+    std::vector<uint16_t> remap(nodes.size(), UINT16_MAX);
+    uint16_t new_idx = 0;
+    for (NodeHandle i = 0; i < nodes.size(); i++) {
+        if ((nodes[i].flags & NodeFlags::Dead) != NodeFlags::None) { continue; }
+        remap[i] = new_idx++;
+    }
+
+    auto rewrite_vh = [&](ValueHandle& vh) {
+        if (vh.is_null()) { return; }
+        assert(remap[vh.node] != UINT16_MAX);
+        vh.node = remap[vh.node];
+    };
+
+    for (NodeHandle i = 0; i < nodes.size(); i++) {
+        if ((nodes[i].flags & NodeFlags::Dead) != NodeFlags::None) { continue; }
+        std::visit(overloaded {
+            [](InputNode&) {},
+            [](ConstantNode&) {},
+            [&](CallOperatorNode& n) { for (auto& a : n.args) rewrite_vh(a); },
+            [&](CallSubgraphNode& n) { for (auto& a : n.args) rewrite_vh(a); },
+        }, nodes[i].value);
+    }
+
+    for (auto& out : outputs) { rewrite_vh(out); }
+
+    std::vector<Node> compacted;
+    compacted.reserve(new_idx);
+    for (NodeHandle i = 0; i < nodes.size(); i++) {
+        if ((nodes[i].flags & NodeFlags::Dead) != NodeFlags::None) { continue; }
+        compacted.push_back(std::move(nodes[i]));
+    }
+    nodes = std::move(compacted);
+
+    update_users();
+}
+
+}

--- a/backends/xnnpack/runtime/graph/graph.h
+++ b/backends/xnnpack/runtime/graph/graph.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <executorch/backends/xnnpack/runtime/core/variant_util.h>
+#include <executorch/backends/xnnpack/runtime/graph/handles.h>
+#include <executorch/backends/xnnpack/runtime/graph/node.h>
+#include <executorch/backends/xnnpack/runtime/graph/tensor_spec.h>
+#include <vector>
+
+namespace executorch::backends::xnnpack::graph {
+
+struct Graph {
+    std::vector<TensorSpec> input_specs;
+    std::vector<Node> nodes;
+    std::vector<ValueHandle> outputs;
+
+    void compact_nodes();
+    uint32_t symint_count() const;
+    void update_users();
+
+    inline OutputSpec get_output_spec_for_node(NodeHandle node) const {
+        return std::visit(overloaded {
+            [&](const InputNode& n) -> OutputSpec { return input_specs.at(n.input); },
+            [](const ConstantNode& n) -> OutputSpec {
+                TensorSpec spec;
+                spec.dtype = n.tensor->dtype;
+                spec.sizes.reserve(n.tensor->sizes.size());
+                for (auto s : n.tensor->sizes) {
+                    spec.sizes.push_back(DimSizeSpec::constant(static_cast<int64_t>(s)));
+                }
+                spec.quant_params = n.quant_params;
+                return spec;
+            },
+            [](const CallOperatorNode& n) -> OutputSpec { return n.output_specs; },
+            [](const CallSubgraphNode& n) -> OutputSpec { return n.output_specs; },
+        }, nodes[node].value);
+    }
+
+    inline TensorSpec get_tensor_spec(ValueHandle vh) const {
+        auto spec = get_output_spec_for_node(vh.node);
+        return std::visit(overloaded {
+            [](const TensorSpec& s) -> TensorSpec { return s; },
+            [&](const std::vector<TensorSpec>& v) -> TensorSpec { return v.at(vh.output); },
+        }, spec);
+    }
+};
+
+}

--- a/backends/xnnpack/runtime/graph/graph_builder.cpp
+++ b/backends/xnnpack/runtime/graph/graph_builder.cpp
@@ -1,0 +1,90 @@
+#include <executorch/backends/xnnpack/runtime/graph/graph_builder.h>
+
+#include <utility>
+
+namespace executorch::backends::xnnpack::graph {
+
+Graph GraphBuilder::build() {
+    Graph g;
+    g.input_specs = std::move(input_specs_);
+    g.nodes = std::move(nodes_);
+    g.outputs = std::move(outputs_);
+    return g;
+}
+
+ValueHandle GraphBuilder::createInput(TensorSpec spec) {
+    input_specs_.push_back(std::move(spec));
+
+    InputHandle input = next_input_;
+    next_input_++;
+
+    ValueHandle handle{static_cast<uint16_t>(nodes_.size())};
+    Node node;
+    node.value = InputNode { input };
+    nodes_.push_back(std::move(node));
+    return handle;
+}
+
+ValueHandle GraphBuilder::createConstant(
+    std::shared_ptr<const core::Tensor> tensor,
+    std::optional<core::QuantParams> quant_params) {
+    ValueHandle handle{static_cast<uint16_t>(nodes_.size())};
+    ConstantNode cn;
+    cn.tensor = std::move(tensor);
+    cn.quant_params = std::move(quant_params);
+    Node node;
+    node.value = std::move(cn);
+    nodes_.push_back(std::move(node));
+    return handle;
+}
+
+ValueHandle GraphBuilder::createOperator(Operator op, TensorSpec output_spec, ValueHandles args) {
+    ValueHandle handle{static_cast<uint16_t>(nodes_.size())};
+    CallOperatorNode con;
+    con.args = std::move(args);
+    con.op = op;
+    con.output_specs = std::move(output_spec);
+    Node node;
+    node.value = std::move(con);
+    nodes_.push_back(std::move(node));
+    return handle;
+}
+
+ValueHandle GraphBuilder::createOperator(
+    Operator op, TensorSpec output_spec, ValueHandles args,
+    std::vector<ConstantArg> constant_args) {
+    ValueHandle handle{static_cast<uint16_t>(nodes_.size())};
+    CallOperatorNode con;
+    con.args = std::move(args);
+    con.op = op;
+    con.output_specs = std::move(output_spec);
+    con.constant_args = std::move(constant_args);
+    Node node;
+    node.value = std::move(con);
+    nodes_.push_back(std::move(node));
+    return handle;
+}
+
+ValueHandle GraphBuilder::createOperatorM(Operator op, std::vector<TensorSpec> output_specs, ValueHandles args) {
+    ValueHandle handle{static_cast<uint16_t>(nodes_.size())};
+    CallOperatorNode con;
+    con.args = std::move(args);
+    con.op = op;
+    con.output_specs = std::move(output_specs);
+    Node node;
+    node.value = std::move(con);
+    nodes_.push_back(std::move(node));
+    return handle;
+}
+
+OutputHandle GraphBuilder::createOutput(ValueHandle handle) {
+    OutputHandle output = static_cast<OutputHandle>(outputs_.size());
+    outputs_.push_back(handle);
+    return output;
+}
+
+ValueHandle GraphBuilder::createSymInt() {
+    return ValueHandle{static_cast<uint16_t>(next_sym_int_++)};
+}
+
+}

--- a/backends/xnnpack/runtime/graph/graph_builder.h
+++ b/backends/xnnpack/runtime/graph/graph_builder.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <executorch/backends/xnnpack/runtime/core/tensor.h>
+#include <executorch/backends/xnnpack/runtime/graph/graph.h>
+#include <executorch/backends/xnnpack/runtime/graph/handles.h>
+#include <executorch/backends/xnnpack/runtime/graph/operator.h>
+#include <executorch/backends/xnnpack/runtime/graph/tensor_spec.h>
+
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace executorch::backends::xnnpack::graph {
+
+class GraphBuilder {
+public:
+    Graph build();
+    ValueHandle createInput(TensorSpec spec);
+    ValueHandle createConstant(
+        std::shared_ptr<const core::Tensor> tensor,
+        std::optional<core::QuantParams> quant_params = std::nullopt);
+    ValueHandle createOperator(Operator op, TensorSpec output_spec, ValueHandles args);
+    ValueHandle createOperator(Operator op, TensorSpec output_spec, ValueHandles args,
+        std::vector<ConstantArg> constant_args);
+    ValueHandle createOperatorM(Operator op, std::vector<TensorSpec> output_specs, ValueHandles args);
+    OutputHandle createOutput(ValueHandle handle);
+    ValueHandle createSymInt();
+
+    template <class... Ts>
+    ValueHandle createOperator(Operator op, TensorSpec output_spec, Ts... ts) {
+        return createOperator(op, output_spec, ValueHandles{std::forward<Ts>(ts)...});
+    }
+    template <class... Ts>
+    ValueHandle createOperatorM(Operator op, std::vector<TensorSpec> output_specs, Ts... ts) {
+        return createOperatorM(op, output_specs, ValueHandles{std::forward<Ts>(ts)...});
+    }
+
+private:
+    std::vector<TensorSpec> input_specs_;
+    std::vector<Node> nodes_;
+    std::vector<ValueHandle> outputs_;
+    uint32_t next_input_ = 0;
+    uint32_t next_sym_int_ = 0;
+};
+
+}

--- a/backends/xnnpack/runtime/graph/handles.h
+++ b/backends/xnnpack/runtime/graph/handles.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace executorch::backends::xnnpack::graph {
+
+using InputHandle = uint32_t;
+using NodeHandle = uint32_t;
+using OutputHandle = uint32_t;
+using SymIntHandle = uint32_t;
+
+struct ValueHandle {
+    uint16_t node;
+    uint16_t output = 0;
+
+    bool operator==(const ValueHandle& o) const {
+        return node == o.node && output == o.output;
+    }
+
+    static constexpr ValueHandle null() {
+        return { UINT16_MAX, UINT16_MAX };
+    }
+    bool is_null() const { return node == UINT16_MAX && output == UINT16_MAX; }
+};
+
+using ValueHandles = std::vector<ValueHandle>;
+
+}

--- a/backends/xnnpack/runtime/graph/node.h
+++ b/backends/xnnpack/runtime/graph/node.h
@@ -1,0 +1,126 @@
+#pragma once
+
+#include <executorch/backends/xnnpack/runtime/core/variant_util.h>
+#include <executorch/backends/xnnpack/runtime/graph/handles.h>
+#include <executorch/backends/xnnpack/runtime/graph/operator.h>
+#include <executorch/backends/xnnpack/runtime/graph/tensor_spec.h>
+
+#include <executorch/backends/xnnpack/runtime/core/tensor.h>
+
+#include <cstdint>
+#include <memory>
+#include <variant>
+#include <vector>
+
+namespace executorch::backends::xnnpack::graph {
+
+enum class NodeFlags : uint8_t {
+    None = 0,
+    UseXnnpack = (1 << 1),
+    PassInternal1 = (1 << 2),
+    Dead = (1 << 3),
+};
+
+inline NodeFlags operator|(NodeFlags a, NodeFlags b) {
+    return static_cast<NodeFlags>(static_cast<uint8_t>(a) | static_cast<uint8_t>(b));
+}
+
+inline NodeFlags operator&(NodeFlags a, NodeFlags b) {
+    return static_cast<NodeFlags>(static_cast<uint8_t>(a) & static_cast<uint8_t>(b));
+}
+
+inline NodeFlags operator~(NodeFlags a) {
+    return static_cast<NodeFlags>(~static_cast<uint8_t>(a));
+}
+
+inline NodeFlags& operator|=(NodeFlags& a, NodeFlags b) {
+    a = a | b;
+    return a;
+}
+
+inline NodeFlags& operator&=(NodeFlags& a, NodeFlags b) {
+    a = a & b;
+    return a;
+}
+
+using ConstantArg = std::variant<int64_t, double, std::vector<int64_t>>;
+using OutputSpec = std::variant<TensorSpec, std::vector<TensorSpec>>;
+
+struct Graph;
+
+struct CallSubgraphNode {
+    std::vector<ValueHandle> args;
+    OutputSpec output_specs;
+    std::unique_ptr<Graph> subgraph;
+};
+
+struct InputNode {
+    InputHandle input;
+
+    bool operator==(const InputNode& o) const {
+        return input == o.input;
+    }
+};
+
+struct ConstantNode {
+    std::shared_ptr<const core::Tensor> tensor;
+    std::optional<core::QuantParams> quant_params;
+};
+
+struct CallOperatorNode {
+    std::vector<ValueHandle> args;
+    Operator op;
+    OutputSpec output_specs;
+    std::vector<ConstantArg> constant_args;
+
+    bool operator==(const CallOperatorNode& o) const {
+        return args == o.args && op == o.op
+            && output_specs == o.output_specs
+            && constant_args == o.constant_args;
+    }
+};
+
+using NodeVariant = std::variant<InputNode, ConstantNode, CallOperatorNode, CallSubgraphNode>;
+
+struct Node {
+    NodeVariant value;
+    std::vector<NodeHandle> users;
+    uint32_t tag = 0;
+    NodeFlags flags = NodeFlags::None;
+
+    const std::vector<ValueHandle>& get_args() const {
+        return std::visit(overloaded {
+            [](const InputNode&) -> const std::vector<ValueHandle>& {
+                static const std::vector<ValueHandle> empty;
+                return empty;
+            },
+            [](const ConstantNode&) -> const std::vector<ValueHandle>& {
+                static const std::vector<ValueHandle> empty;
+                return empty;
+            },
+            [](const CallOperatorNode& n) -> const std::vector<ValueHandle>& { return n.args; },
+            [](const CallSubgraphNode& n) -> const std::vector<ValueHandle>& { return n.args; },
+        }, value);
+    }
+
+    uint32_t output_count() const {
+        return std::visit(overloaded {
+            [](const InputNode&) -> uint32_t { return 1; },
+            [](const ConstantNode&) -> uint32_t { return 1; },
+            [](const CallOperatorNode& n) -> uint32_t {
+                return std::visit(overloaded {
+                    [](const TensorSpec&) -> uint32_t { return 1; },
+                    [](const std::vector<TensorSpec>& v) -> uint32_t { return v.size(); },
+                }, n.output_specs);
+            },
+            [](const CallSubgraphNode& n) -> uint32_t {
+                return std::visit(overloaded {
+                    [](const TensorSpec&) -> uint32_t { return 1; },
+                    [](const std::vector<TensorSpec>& v) -> uint32_t { return v.size(); },
+                }, n.output_specs);
+            },
+        }, value);
+    }
+};
+
+}

--- a/backends/xnnpack/runtime/graph/operator.h
+++ b/backends/xnnpack/runtime/graph/operator.h
@@ -1,0 +1,82 @@
+#pragma once
+
+namespace executorch::backends::xnnpack::graph {
+
+enum class Operator {
+    // Binary elementwise
+    Add,
+    Subtract,
+    Multiply,
+    Divide,
+    Maximum,
+    Minimum,
+    CopySign,
+    SquaredDifference,
+    PReLU,
+    Modulus,
+    Atan2,
+    Pow,
+
+    // Unary elementwise
+    Abs,
+    Negate,
+    Clamp,
+    Ceiling,
+    Floor,
+    Round,
+    Square,
+    SquareRoot,
+    ReciprocalSquareRoot,
+    Exp,
+    Log,
+    Sigmoid,
+    Tanh,
+    ELU,
+    GELU,
+    HardSwish,
+    LeakyReLU,
+    Sine,
+    Cosine,
+    Sign,
+    ReLU,
+
+    // Linear algebra
+    Linear,
+    BatchMatrixMultiply,
+
+    // Convolution
+    Conv2d,
+    ConvTranspose2d,
+
+    // Pooling
+    AvgPool2d,
+    AdaptiveAvgPool2d,
+    MaxPool2d,
+
+    // Reduction
+    Softmax,
+    Mean,
+    Sum,
+
+    // Shape / memory
+    Reshape,
+    View,
+    Transpose,
+    Permute,
+    Slice,
+    Cat,
+    Chunk,
+    Unsqueeze,
+    Expand,
+    Clone,
+    Pad,
+
+    // Quantization
+    Quantize,
+    Dequantize,
+
+    // In-tree
+    LayerNorm,
+};
+
+}

--- a/backends/xnnpack/runtime/graph/tensor_spec.h
+++ b/backends/xnnpack/runtime/graph/tensor_spec.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <executorch/backends/xnnpack/runtime/core/dtype.h>
+#include <executorch/backends/xnnpack/runtime/core/quant_params.h>
+#include <executorch/backends/xnnpack/runtime/graph/handles.h>
+
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+namespace executorch::backends::xnnpack::graph {
+
+struct DimSizeSpec {
+    struct Term {
+        SymIntHandle sym;
+        int64_t coefficient;
+
+        bool operator==(const Term& o) const {
+            return sym == o.sym && coefficient == o.coefficient;
+        }
+    };
+
+    std::vector<Term> coeffs;
+    int64_t offset = 0;
+
+    static DimSizeSpec constant(int64_t value) {
+        return { {}, value };
+    }
+
+    static DimSizeSpec sym(SymIntHandle s) {
+        return { {{ s, 1 }}, 0 };
+    }
+
+    bool is_constant() const { return coeffs.empty(); }
+
+    bool operator==(const DimSizeSpec& o) const {
+        return coeffs == o.coeffs && offset == o.offset;
+    }
+};
+
+struct TensorSpec {
+    core::DType dtype;
+    std::vector<DimSizeSpec> sizes;
+    std::optional<core::QuantParams> quant_params;
+
+    bool operator==(const TensorSpec& o) const {
+        return dtype == o.dtype && sizes == o.sizes && quant_params == o.quant_params;
+    }
+};
+
+}

--- a/backends/xnnpack/runtime/kernels/layer_norm/layer_norm.cpp
+++ b/backends/xnnpack/runtime/kernels/layer_norm/layer_norm.cpp
@@ -1,0 +1,20 @@
+#include <executorch/backends/xnnpack/runtime/kernels/layer_norm/layer_norm.h>
+#include <executorch/backends/xnnpack/runtime/kernels/layer_norm/layer_norm_scalar.h>
+#ifdef __aarch64__
+#include <executorch/backends/xnnpack/runtime/kernels/layer_norm/layer_norm_neon.h>
+#endif
+
+#include <cpuinfo.h>
+
+namespace executorch::backends::xnnpack::kernels {
+
+LayerNormF32Fn select_layer_norm_f32_kernel() {
+#ifdef __aarch64__
+    if (cpuinfo_initialize() && cpuinfo_has_arm_neon()) {
+        return layer_norm_f32_neon;
+    }
+#endif
+    return layer_norm_f32_scalar;
+}
+
+}

--- a/backends/xnnpack/runtime/kernels/layer_norm/layer_norm.h
+++ b/backends/xnnpack/runtime/kernels/layer_norm/layer_norm.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <cstddef>
+
+namespace executorch::backends::xnnpack::kernels {
+
+using LayerNormF32Fn = void(*)(
+    const float* input, float* output,
+    const float* weight, const float* bias,
+    size_t outer_size, size_t inner_size, float eps);
+
+LayerNormF32Fn select_layer_norm_f32_kernel();
+
+}

--- a/backends/xnnpack/runtime/kernels/layer_norm/layer_norm_neon.cpp
+++ b/backends/xnnpack/runtime/kernels/layer_norm/layer_norm_neon.cpp
@@ -1,0 +1,233 @@
+#ifdef __aarch64__
+
+#include <executorch/backends/xnnpack/runtime/kernels/layer_norm/layer_norm_neon.h>
+
+#include <arm_neon.h>
+#include <cassert>
+#include <cmath>
+
+namespace executorch::backends::xnnpack::kernels {
+
+namespace {
+float sum_f32_neon(const float* data, size_t len) {
+    float32x4_t acc0 = vdupq_n_f32(0);
+    float32x4_t acc1 = vdupq_n_f32(0);
+    float32x4_t acc2 = vdupq_n_f32(0);
+    float32x4_t acc3 = vdupq_n_f32(0);
+    float32x4_t acc4 = vdupq_n_f32(0);
+    float32x4_t acc5 = vdupq_n_f32(0);
+    float32x4_t acc6 = vdupq_n_f32(0);
+    float32x4_t acc7 = vdupq_n_f32(0);
+
+    size_t i = len;
+    for (; i >= 32; i -= 32) {
+        float32x4x2_t in01 = vld1q_f32_x2(data);
+        float32x4x2_t in23 = vld1q_f32_x2(data + 8);
+        float32x4x2_t in45 = vld1q_f32_x2(data + 16);
+        float32x4x2_t in67 = vld1q_f32_x2(data + 24);
+
+        acc0 = vaddq_f32(acc0, in01.val[0]);
+        acc1 = vaddq_f32(acc1, in01.val[1]);
+        acc2 = vaddq_f32(acc2, in23.val[0]);
+        acc3 = vaddq_f32(acc3, in23.val[1]);
+        acc4 = vaddq_f32(acc4, in45.val[0]);
+        acc5 = vaddq_f32(acc5, in45.val[1]);
+        acc6 = vaddq_f32(acc6, in67.val[0]);
+        acc7 = vaddq_f32(acc7, in67.val[1]);
+
+        data += 32;
+    }
+
+    acc0 = vaddq_f32(acc0, acc1);
+    acc2 = vaddq_f32(acc2, acc3);
+    acc4 = vaddq_f32(acc4, acc5);
+    acc6 = vaddq_f32(acc6, acc7);
+
+    acc0 = vaddq_f32(acc0, acc2);
+    acc4 = vaddq_f32(acc4, acc6);
+
+    acc0 = vaddq_f32(acc0, acc4);
+
+    for (; i >= 4; i -= 4) {
+        float32x4_t in = vld1q_f32(data);
+        acc0 = vaddq_f32(acc0, in);
+        data += 4;
+    }
+
+    float acc = vaddvq_f32(acc0);
+
+    for (; i > 0; i--) {
+        acc += *data;
+        data++;
+    }
+
+    return acc;
+}
+
+float var_sum_f32_neon(const float* data, float mean, size_t len) {
+    float32x4_t vmean = vdupq_n_f32(mean);
+
+    float32x4_t acc0 = vdupq_n_f32(0);
+    float32x4_t acc1 = vdupq_n_f32(0);
+    float32x4_t acc2 = vdupq_n_f32(0);
+    float32x4_t acc3 = vdupq_n_f32(0);
+
+    size_t i = len;
+    for (; i >= 16; i -= 16) {
+        float32x4x2_t in01 = vld1q_f32_x2(data);
+        float32x4x2_t in23 = vld1q_f32_x2(data + 8);
+
+        float32x4_t delta0 = vsubq_f32(in01.val[0], vmean);
+        float32x4_t delta1 = vsubq_f32(in01.val[1], vmean);
+        float32x4_t delta2 = vsubq_f32(in23.val[0], vmean);
+        float32x4_t delta3 = vsubq_f32(in23.val[1], vmean);
+
+        float32x4_t delta_sq0 = vmulq_f32(delta0, delta0);
+        float32x4_t delta_sq1 = vmulq_f32(delta1, delta1);
+        float32x4_t delta_sq2 = vmulq_f32(delta2, delta2);
+        float32x4_t delta_sq3 = vmulq_f32(delta3, delta3);
+
+        acc0 = vaddq_f32(acc0, delta_sq0);
+        acc1 = vaddq_f32(acc1, delta_sq1);
+        acc2 = vaddq_f32(acc2, delta_sq2);
+        acc3 = vaddq_f32(acc3, delta_sq3);
+
+        data += 16;
+    }
+
+    acc0 = vaddq_f32(acc0, acc1);
+    acc2 = vaddq_f32(acc2, acc3);
+    acc0 = vaddq_f32(acc0, acc2);
+
+    for (; i >= 4; i -= 4) {
+        float32x4_t in = vld1q_f32(data);
+        float32x4_t delta = vsubq_f32(in, vmean);
+        float32x4_t delta_sq = vmulq_f32(delta, delta);
+        acc0 = vaddq_f32(acc0, delta_sq);
+        data += 4;
+    }
+
+    float acc = vaddvq_f32(acc0);
+
+    for (; i > 0; i--) {
+        float in = *data;
+        float delta = in - mean;
+        float delta_sq = delta * delta;
+        acc += delta_sq;
+        data++;
+    }
+
+    return acc;
+}
+
+template <bool UseWeightBias>
+void normalize_f32_neon(
+    const float* input,
+    float mean,
+    float inv_std,
+    const float* weight,
+    const float* bias,
+    float* out,
+    size_t len)
+{
+    float32x4_t vmean = vdupq_n_f32(mean);
+    float32x4_t vinv_std = vdupq_n_f32(inv_std);
+
+    size_t i = len;
+    for (; i >= 16; i -= 16) {
+        float32x4x2_t in01 = vld1q_f32_x2(input);
+        float32x4x2_t in23 = vld1q_f32_x2(input + 8);
+
+        float32x4_t norm0 = vmulq_f32(vsubq_f32(in01.val[0], vmean), vinv_std);
+        float32x4_t norm1 = vmulq_f32(vsubq_f32(in01.val[1], vmean), vinv_std);
+        float32x4_t norm2 = vmulq_f32(vsubq_f32(in23.val[0], vmean), vinv_std);
+        float32x4_t norm3 = vmulq_f32(vsubq_f32(in23.val[1], vmean), vinv_std);
+
+        if constexpr (UseWeightBias) {
+            float32x4x2_t w01 = vld1q_f32_x2(weight);
+            float32x4x2_t w23 = vld1q_f32_x2(weight + 8);
+
+            float32x4x2_t b01 = vld1q_f32_x2(bias);
+            float32x4x2_t b23 = vld1q_f32_x2(bias + 8);
+
+            norm0 = vmlaq_f32(b01.val[0], norm0, w01.val[0]);
+            norm1 = vmlaq_f32(b01.val[1], norm1, w01.val[1]);
+            norm2 = vmlaq_f32(b23.val[0], norm2, w23.val[0]);
+            norm3 = vmlaq_f32(b23.val[1], norm3, w23.val[1]);
+
+            weight += 16;
+            bias += 16;
+        }
+
+        vst1q_f32(out, norm0);
+        vst1q_f32(out + 4, norm1);
+        vst1q_f32(out + 8, norm2);
+        vst1q_f32(out + 12, norm3);
+
+        input += 16;
+        out += 16;
+    }
+
+    for (; i > 0; i--) {
+        float in = *input;
+        float norm = (in - mean) * inv_std;
+
+        if constexpr (UseWeightBias) {
+            auto w = *weight;
+            auto b = *bias;
+
+            norm = (norm * w) + b;
+
+            weight++;
+            bias++;
+        }
+
+        *out = norm;
+
+        input++;
+        out++;
+    }
+}
+} // anonymous namespace
+
+void layer_norm_f32_neon(
+    const float* input, float* output,
+    const float* weight, const float* bias,
+    size_t outer_size, size_t inner_size, float eps) {
+    for (size_t i = 0; i < outer_size; i++) {
+        const float* in_row = input + i * inner_size;
+        float* out_row = output + i * inner_size;
+
+        float sum = sum_f32_neon(in_row, inner_size);
+        float mean = sum / static_cast<float>(inner_size);
+
+        float var_sum = var_sum_f32_neon(in_row, mean, inner_size);
+        float inv_std = 1.0f / std::sqrt(var_sum / static_cast<float>(inner_size) + eps);
+
+        if (weight != nullptr) {
+            assert(bias != nullptr);
+            normalize_f32_neon<true>(
+                in_row,
+                mean,
+                inv_std,
+                weight,
+                bias,
+                out_row,
+                inner_size);
+       } else {
+            assert(bias == nullptr);
+            normalize_f32_neon<false>(
+                in_row,
+                mean,
+                inv_std,
+                nullptr,
+                nullptr,
+                out_row,
+                inner_size);
+       }
+    }
+}
+
+}
+
+#endif

--- a/backends/xnnpack/runtime/kernels/layer_norm/layer_norm_neon.h
+++ b/backends/xnnpack/runtime/kernels/layer_norm/layer_norm_neon.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <cstddef>
+
+namespace executorch::backends::xnnpack::kernels {
+
+void layer_norm_f32_neon(
+    const float* input, float* output,
+    const float* weight, const float* bias,
+    size_t outer_size, size_t inner_size, float eps);
+
+}

--- a/backends/xnnpack/runtime/kernels/layer_norm/layer_norm_scalar.cpp
+++ b/backends/xnnpack/runtime/kernels/layer_norm/layer_norm_scalar.cpp
@@ -1,0 +1,37 @@
+#include <executorch/backends/xnnpack/runtime/kernels/layer_norm/layer_norm_scalar.h>
+
+#include <cmath>
+
+namespace executorch::backends::xnnpack::kernels {
+
+void layer_norm_f32_scalar(
+    const float* input, float* output,
+    const float* weight, const float* bias,
+    size_t outer_size, size_t inner_size, float eps) {
+    for (size_t i = 0; i < outer_size; i++) {
+        const float* in_row = input + i * inner_size;
+        float* out_row = output + i * inner_size;
+
+        float sum = 0.0f;
+        for (size_t j = 0; j < inner_size; j++) {
+            sum += in_row[j];
+        }
+        float mean = sum / static_cast<float>(inner_size);
+
+        float var_sum = 0.0f;
+        for (size_t j = 0; j < inner_size; j++) {
+            float diff = in_row[j] - mean;
+            var_sum += diff * diff;
+        }
+        float inv_std = 1.0f / std::sqrt(var_sum / static_cast<float>(inner_size) + eps);
+
+        for (size_t j = 0; j < inner_size; j++) {
+            float normalized = (in_row[j] - mean) * inv_std;
+            if (weight) { normalized *= weight[j]; }
+            if (bias) { normalized += bias[j]; }
+            out_row[j] = normalized;
+        }
+    }
+}
+
+}

--- a/backends/xnnpack/runtime/kernels/layer_norm/layer_norm_scalar.h
+++ b/backends/xnnpack/runtime/kernels/layer_norm/layer_norm_scalar.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <cstddef>
+
+namespace executorch::backends::xnnpack::kernels {
+
+void layer_norm_f32_scalar(
+    const float* input, float* output,
+    const float* weight, const float* bias,
+    size_t outer_size, size_t inner_size, float eps);
+
+}

--- a/backends/xnnpack/runtime/operators/layer_norm.cpp
+++ b/backends/xnnpack/runtime/operators/layer_norm.cpp
@@ -1,0 +1,39 @@
+#include <executorch/backends/xnnpack/runtime/operators/layer_norm.h>
+
+#include <cassert>
+
+namespace executorch::backends::xnnpack::operators {
+
+void LayerNorm::setup(core::Span<const graph::ConstantArg> constant_args) {
+    assert(constant_args.size() == 2);
+    kernel_ = kernels::select_layer_norm_f32_kernel();
+    num_normalized_dims_ = static_cast<uint32_t>(std::get<int64_t>(constant_args[0]));
+    eps_ = static_cast<float>(std::get<double>(constant_args[1]));
+}
+
+void LayerNorm::execute(
+    core::Span<core::Tensor*> inputs,
+    core::Span<core::Tensor*> outputs) {
+    assert(inputs.size() >= 1 && inputs.size() <= 3);
+    assert(outputs.size() == 1);
+
+    auto* input = inputs[0];
+    auto* output = outputs[0];
+
+    size_t inner_size = 1;
+    for (size_t i = input->sizes.size() - num_normalized_dims_; i < input->sizes.size(); i++) {
+        inner_size *= input->sizes[i];
+    }
+    size_t outer_size = input->numel() / inner_size;
+
+    const float* weight = (inputs.size() > 1) ? inputs[1]->data_const<float>() : nullptr;
+    const float* bias = (inputs.size() > 2) ? inputs[2]->data_const<float>() : nullptr;
+
+    kernel_(
+        input->data_const<float>(),
+        output->data_mut<float>(),
+        weight, bias,
+        outer_size, inner_size, eps_);
+}
+
+}

--- a/backends/xnnpack/runtime/operators/layer_norm.h
+++ b/backends/xnnpack/runtime/operators/layer_norm.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <executorch/backends/xnnpack/runtime/kernels/layer_norm/layer_norm.h>
+#include <executorch/backends/xnnpack/runtime/operators/operator.h>
+
+namespace executorch::backends::xnnpack::operators {
+
+class LayerNorm : public Operator {
+public:
+    void setup(core::Span<const graph::ConstantArg> constant_args) override;
+    void execute(core::Span<core::Tensor*> inputs, core::Span<core::Tensor*> outputs) override;
+
+private:
+    kernels::LayerNormF32Fn kernel_ = nullptr;
+    uint32_t num_normalized_dims_ = 0;
+    float eps_ = 1e-5f;
+};
+
+}

--- a/backends/xnnpack/runtime/operators/operator.cpp
+++ b/backends/xnnpack/runtime/operators/operator.cpp
@@ -1,0 +1,18 @@
+#include <executorch/backends/xnnpack/runtime/operators/operator.h>
+
+#include <executorch/backends/xnnpack/runtime/operators/layer_norm.h>
+
+#include <cstdlib>
+
+namespace executorch::backends::xnnpack::operators {
+
+std::unique_ptr<Operator> create_operator(graph::Operator op) {
+    switch (op) {
+        case graph::Operator::LayerNorm:
+            return std::make_unique<LayerNorm>();
+        default:
+            abort();
+    }
+}
+
+}

--- a/backends/xnnpack/runtime/operators/operator.h
+++ b/backends/xnnpack/runtime/operators/operator.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <executorch/backends/xnnpack/runtime/core/span.h>
+#include <executorch/backends/xnnpack/runtime/core/tensor.h>
+#include <executorch/backends/xnnpack/runtime/graph/node.h>
+#include <executorch/backends/xnnpack/runtime/graph/operator.h>
+#include <executorch/backends/xnnpack/runtime/graph/tensor_spec.h>
+
+#include <memory>
+
+namespace executorch::backends::xnnpack::operators {
+
+class Operator {
+public:
+    virtual void setup(core::Span<const graph::ConstantArg> constant_args) {};
+    virtual void reshape(core::Span<const graph::TensorSpec> input_specs) {};
+    virtual void execute(core::Span<core::Tensor*> inputs, core::Span<core::Tensor*> outputs) = 0;
+    virtual ~Operator() = default;
+};
+
+std::unique_ptr<Operator> create_operator(graph::Operator op);
+
+}

--- a/backends/xnnpack/runtime/plan/execution_plan.cpp
+++ b/backends/xnnpack/runtime/plan/execution_plan.cpp
@@ -1,0 +1,102 @@
+#include <executorch/backends/xnnpack/runtime/plan/execution_plan.h>
+#include <executorch/backends/xnnpack/runtime/core/span.h>
+#include <executorch/backends/xnnpack/runtime/operators/operator.h>
+#include <executorch/backends/xnnpack/runtime/plan/nhwc_rewrite.h>
+#include <executorch/backends/xnnpack/runtime/plan/partition.h>
+#include <executorch/backends/xnnpack/runtime/plan/schedule.h>
+#include <executorch/backends/xnnpack/runtime/plan/xnn_subgraph.h>
+
+namespace executorch::backends::xnnpack::plan {
+
+using namespace graph;
+
+namespace {
+
+    uint32_t assign_value_slots(
+        graph::Graph& graph, core::Span<const NodeHandle> linear_schedule) {
+        uint32_t next_slot = 0;
+        for (auto nh : linear_schedule) {
+            graph.nodes[nh].tag = next_slot;
+            next_slot += graph.nodes[nh].output_count();
+        }
+        return next_slot;
+    }
+
+    std::vector<PlanStep> create_plan_steps(
+        const graph::Graph& graph, core::Span<const NodeHandle> linear_schedule) {
+        std::vector<PlanStep> steps;
+        steps.reserve(linear_schedule.size());
+
+        for (auto node_handle : linear_schedule) {
+            auto& node = graph.nodes[node_handle];
+
+            std::visit(overloaded {
+                [&steps, &node, &graph](const CallSubgraphNode& n) {
+                    std::vector<ValueSlot> external_value_slots;
+                    external_value_slots.reserve(
+                        n.args.size() + node.output_count());
+
+                    for (const auto& arg : n.args) {
+                        auto slot = graph.nodes[arg.node].tag + arg.output;
+                        external_value_slots.push_back(slot);
+                    }
+
+                    for (uint32_t i = 0; i < node.output_count(); i++) {
+                        external_value_slots.push_back(node.tag + i);
+                    }
+
+                    RunXnnSubgraphStep step;
+                    step.runtime = compile_xnn_subgraph(
+                        *n.subgraph,
+                        nullptr
+                    );
+                    step.external_value_slots = std::move(external_value_slots);
+                    steps.push_back(std::move(step));
+                },
+                [](const InputNode&) {},
+                [](const ConstantNode&) {},
+                [&steps, &node, &graph](const CallOperatorNode& n) {
+                    std::vector<ValueSlot> input_slots;
+                    input_slots.reserve(n.args.size());
+                    for (const auto& arg : n.args) {
+                        if (arg.is_null()) continue;
+                        input_slots.push_back(graph.nodes[arg.node].tag + arg.output);
+                    }
+
+                    std::vector<ValueSlot> output_slots;
+                    for (uint32_t i = 0; i < node.output_count(); i++) {
+                        output_slots.push_back(node.tag + i);
+                    }
+
+                    auto op = operators::create_operator(n.op);
+                    op->setup(n.constant_args);
+
+                    RunOperatorStep step;
+                    step.op = std::move(op);
+                    step.input_slots = std::move(input_slots);
+                    step.output_slots = std::move(output_slots);
+                    steps.push_back(std::move(step));
+                }
+            }, node.value);
+        }
+
+        return steps;
+    }
+}
+
+ExecutionPlan create_execution_plan(graph::Graph& graph) {
+    rewrite_nhwc(graph);
+    partition_xnn_subgraphs(graph);
+
+    auto linear_schedule = schedule(graph);
+    auto num_value_slots = assign_value_slots(graph, linear_schedule);
+    (void)num_value_slots;
+
+    auto plan_steps = create_plan_steps(graph, linear_schedule);
+    ExecutionPlan plan;
+    plan.steps = std::move(plan_steps);
+
+    return plan;
+}
+
+}

--- a/backends/xnnpack/runtime/plan/execution_plan.h
+++ b/backends/xnnpack/runtime/plan/execution_plan.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <executorch/backends/xnnpack/runtime/operators/operator.h>
+#include <executorch/backends/xnnpack/runtime/plan/xnn_subgraph.h>
+
+#include <memory>
+#include <variant>
+#include <vector>
+
+namespace executorch::backends::xnnpack::graph { struct Graph; }
+
+namespace executorch::backends::xnnpack::plan {
+
+using ValueSlot = uint32_t;
+
+struct RunOperatorStep {
+    std::unique_ptr<operators::Operator> op;
+    std::vector<ValueSlot> input_slots;
+    std::vector<ValueSlot> output_slots;
+};
+
+struct RunXnnSubgraphStep {
+    XnnRuntime runtime;
+    std::vector<ValueSlot> external_value_slots;
+};
+
+using PlanStep = std::variant<RunOperatorStep, RunXnnSubgraphStep>;
+
+struct ExecutionPlan {
+    std::vector<PlanStep> steps;
+};
+
+ExecutionPlan create_execution_plan(graph::Graph& graph);
+
+}

--- a/backends/xnnpack/runtime/plan/memory_plan.cpp
+++ b/backends/xnnpack/runtime/plan/memory_plan.cpp
@@ -1,0 +1,92 @@
+#include <executorch/backends/xnnpack/runtime/plan/memory_plan.h>
+
+#include <cstdlib>
+#include <variant>
+
+namespace executorch::backends::xnnpack::plan {
+
+using namespace graph;
+
+namespace {
+
+uint64_t resolve_dim_upper(const DimSizeSpec& dim,
+                           const executor::ShapeEnv& shape_env) {
+    int64_t result = dim.offset;
+    for (auto& term : dim.coeffs) {
+        auto& bound = shape_env.specialized_bounds[term.sym];
+        if (!bound.max) { abort(); }
+        result += term.coefficient * static_cast<int64_t>(*bound.max);
+    }
+    return static_cast<uint64_t>(result);
+}
+
+std::vector<uint64_t> resolve_sizes_upper(const TensorSpec& spec,
+                                           const executor::ShapeEnv& shape_env) {
+    std::vector<uint64_t> sizes;
+    sizes.reserve(spec.sizes.size());
+    for (auto& dim : spec.sizes) {
+        sizes.push_back(resolve_dim_upper(dim, shape_env));
+    }
+    return sizes;
+}
+
+} // namespace
+
+MemoryPlan create_memory_plan(Graph& graph, ExecutionPlan& execution_plan) {
+    uint32_t num_slots = 0;
+    for (auto& node : graph.nodes) {
+        uint32_t end = node.tag + node.output_count();
+        if (end > num_slots) num_slots = end;
+    }
+
+    std::vector<AllocationInfo> allocations(num_slots);
+    std::vector<TensorSpec> specs(num_slots);
+
+    for (uint32_t n = 0; n < graph.nodes.size(); n++) {
+        auto& node = graph.nodes[n];
+        uint32_t base_slot = node.tag;
+
+        for (uint32_t o = 0; o < node.output_count(); o++) {
+            uint32_t slot = base_slot + o;
+            ValueHandle vh {
+                static_cast<uint16_t>(n),
+                static_cast<uint16_t>(o)
+            };
+            specs[slot] = graph.get_tensor_spec(vh);
+
+            if (std::holds_alternative<InputNode>(node.value)
+                || std::holds_alternative<ConstantNode>(node.value)) {
+                allocations[slot] = ExternalAllocation {};
+            } else {
+                ArenaAllocation a;
+                a.offset = 0;
+                a.size = 0;
+                allocations[slot] = a;
+            }
+        }
+    }
+
+    MemoryPlan mp;
+    mp.arena_size = 0;
+    mp.value_allocations = std::move(allocations);
+    mp.value_specs = std::move(specs);
+    return mp;
+}
+
+void MemoryPlan::replan(const executor::ShapeEnv& shape_env) {
+    size_t arena_offset = 0;
+
+    for (size_t i = 0; i < value_allocations.size(); i++) {
+        if (auto* arena = std::get_if<ArenaAllocation>(&value_allocations[i])) {
+            auto concrete_sizes = resolve_sizes_upper(value_specs[i], shape_env);
+            size_t size = core::compute_storage_size(concrete_sizes, value_specs[i].dtype);
+            arena->offset = arena_offset;
+            arena->size = size;
+            arena_offset += size;
+        }
+    }
+
+    arena_size = arena_offset;
+}
+
+}

--- a/backends/xnnpack/runtime/plan/memory_plan.h
+++ b/backends/xnnpack/runtime/plan/memory_plan.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <executorch/backends/xnnpack/runtime/core/tensor.h>
+#include <executorch/backends/xnnpack/runtime/executor/shape_env.h>
+#include <executorch/backends/xnnpack/runtime/graph/graph.h>
+#include <executorch/backends/xnnpack/runtime/graph/tensor_spec.h>
+#include <executorch/backends/xnnpack/runtime/plan/execution_plan.h>
+
+#include <variant>
+#include <vector>
+
+namespace executorch::backends::xnnpack::plan {
+
+struct ArenaAllocation {
+    size_t offset;
+    size_t size;
+};
+struct DynamicAllocation {};
+struct ExternalAllocation {};
+
+using AllocationInfo = std::variant<ArenaAllocation, DynamicAllocation, ExternalAllocation>;
+
+struct MemoryPlan {
+    size_t arena_size;
+    std::vector<AllocationInfo> value_allocations;
+    std::vector<graph::TensorSpec> value_specs;
+
+    void replan(const executor::ShapeEnv& shape_env);
+};
+
+MemoryPlan create_memory_plan(graph::Graph& graph, ExecutionPlan& execution_plan);
+
+}

--- a/backends/xnnpack/runtime/plan/nhwc_rewrite.cpp
+++ b/backends/xnnpack/runtime/plan/nhwc_rewrite.cpp
@@ -1,0 +1,296 @@
+#include <executorch/backends/xnnpack/runtime/plan/nhwc_rewrite.h>
+
+#include <executorch/backends/xnnpack/runtime/core/quant_params.h>
+#include <executorch/backends/xnnpack/runtime/core/variant_util.h>
+#include <executorch/backends/xnnpack/runtime/graph/node.h>
+#include <executorch/backends/xnnpack/runtime/graph/operator.h>
+#include <executorch/backends/xnnpack/runtime/graph/tensor_spec.h>
+
+#include <cassert>
+#include <cstring>
+#include <vector>
+
+namespace executorch::backends::xnnpack::plan {
+
+using namespace graph;
+namespace {
+
+bool is_nhwc_op(Operator op) {
+    switch (op) {
+        case Operator::Conv2d:
+        case Operator::ConvTranspose2d:
+        case Operator::AvgPool2d:
+        case Operator::AdaptiveAvgPool2d:
+        case Operator::MaxPool2d:
+            return true;
+        default:
+            return false;
+    }
+}
+
+bool is_layout_agnostic(Operator op) {
+    switch (op) {
+        case Operator::Add:
+        case Operator::Subtract:
+        case Operator::Multiply:
+        case Operator::Divide:
+        case Operator::Maximum:
+        case Operator::Minimum:
+        case Operator::CopySign:
+        case Operator::SquaredDifference:
+        case Operator::PReLU:
+        case Operator::Modulus:
+        case Operator::Atan2:
+        case Operator::Pow:
+        case Operator::Abs:
+        case Operator::Negate:
+        case Operator::Clamp:
+        case Operator::Ceiling:
+        case Operator::Floor:
+        case Operator::Round:
+        case Operator::Square:
+        case Operator::SquareRoot:
+        case Operator::ReciprocalSquareRoot:
+        case Operator::Exp:
+        case Operator::Log:
+        case Operator::Sigmoid:
+        case Operator::Tanh:
+        case Operator::ELU:
+        case Operator::GELU:
+        case Operator::HardSwish:
+        case Operator::LeakyReLU:
+        case Operator::Sine:
+        case Operator::Cosine:
+        case Operator::Sign:
+        case Operator::ReLU:
+        case Operator::Clone:
+        case Operator::Pad:
+        case Operator::Quantize:
+        case Operator::Dequantize:
+            return true;
+        default:
+            return false;
+    }
+}
+
+int ndims(const TensorSpec& spec) {
+    return static_cast<int>(spec.sizes.size());
+}
+
+TensorSpec permute_spec(const TensorSpec& spec, const std::vector<int>& perm) {
+    TensorSpec out = spec;
+    out.sizes.clear();
+    out.sizes.reserve(perm.size());
+    for (int p : perm) {
+        out.sizes.push_back(spec.sizes[p]);
+    }
+    return out;
+}
+
+ValueHandle insert_permute(
+    Graph& graph,
+    ValueHandle input,
+    const TensorSpec& output_spec,
+    std::vector<int64_t> perm
+) {
+    auto node_idx = static_cast<uint16_t>(graph.nodes.size());
+    CallOperatorNode con;
+    con.args = { input };
+    con.op = Operator::Permute;
+    con.output_specs = output_spec;
+    con.constant_args = { std::move(perm) };
+    Node node;
+    node.value = std::move(con);
+    graph.nodes.push_back(std::move(node));
+    return ValueHandle { node_idx };
+}
+
+void transpose_weight(Graph& graph, NodeHandle node_handle,
+                      const std::vector<int>& perm) {
+    auto& cnode = std::get<ConstantNode>(graph.nodes[node_handle].value);
+    auto& old_tensor = *cnode.tensor;
+
+    assert(old_tensor.sizes.size() == 4);
+    assert(perm.size() == 4);
+
+    std::vector<uint64_t> new_sizes(4);
+    for (int i = 0; i < 4; i++) {
+        new_sizes[i] = old_tensor.sizes[perm[i]];
+    }
+
+    uint64_t old_strides[4];
+    old_strides[3] = 1;
+    for (int i = 2; i >= 0; i--) {
+        old_strides[i] = old_strides[i + 1] * old_tensor.sizes[i + 1];
+    }
+
+    uint64_t new_strides[4];
+    new_strides[3] = 1;
+    for (int i = 2; i >= 0; i--) {
+        new_strides[i] = new_strides[i + 1] * new_sizes[i + 1];
+    }
+
+    size_t elem_size = core::element_size(old_tensor.dtype);
+    size_t total_bytes = old_tensor.storage.size_in_bytes;
+
+    auto new_storage = core::Storage::create_owned(total_bytes);
+    auto* src = static_cast<const uint8_t*>(old_tensor.storage.data);
+    auto* dst = static_cast<uint8_t*>(new_storage.data);
+
+    for (uint64_t j0 = 0; j0 < new_sizes[0]; j0++) {
+        for (uint64_t j1 = 0; j1 < new_sizes[1]; j1++) {
+            for (uint64_t j2 = 0; j2 < new_sizes[2]; j2++) {
+                for (uint64_t j3 = 0; j3 < new_sizes[3]; j3++) {
+                    uint64_t old_idx[4] = {};
+                    old_idx[perm[0]] = j0;
+                    old_idx[perm[1]] = j1;
+                    old_idx[perm[2]] = j2;
+                    old_idx[perm[3]] = j3;
+
+                    size_t src_offset = old_idx[0] * old_strides[0]
+                                      + old_idx[1] * old_strides[1]
+                                      + old_idx[2] * old_strides[2]
+                                      + old_idx[3] * old_strides[3];
+                    size_t dst_offset = j0 * new_strides[0]
+                                      + j1 * new_strides[1]
+                                      + j2 * new_strides[2]
+                                      + j3 * new_strides[3];
+
+                    std::memcpy(dst + dst_offset * elem_size,
+                                src + src_offset * elem_size,
+                                elem_size);
+                }
+            }
+        }
+    }
+
+    auto new_tensor = std::make_shared<core::Tensor>();
+    new_tensor->dtype = old_tensor.dtype;
+    new_tensor->sizes = std::move(new_sizes);
+    new_tensor->storage = std::move(new_storage);
+    cnode.tensor = std::move(new_tensor);
+}
+
+TensorSpec get_spec(const Graph& graph, ValueHandle vh) {
+    return graph.get_tensor_spec(vh);
+}
+
+} // namespace
+
+void rewrite_nhwc(Graph& graph) {
+    enum class Layout { NCHW, NHWC };
+
+    std::vector<Layout> layout(graph.nodes.size(), Layout::NCHW);
+
+    size_t original_count = graph.nodes.size();
+    graph.nodes.reserve(original_count + original_count);
+
+    auto ensure_nchw = [&](ValueHandle& vh) {
+        if (layout[vh.node] == Layout::NHWC) {
+            auto spec = get_spec(graph, vh);
+            auto nchw_spec = permute_spec(spec, {0, 3, 1, 2});
+            auto perm_vh = insert_permute(graph, vh, nchw_spec,
+                                          {0, 3, 1, 2});
+            layout.push_back(Layout::NCHW);
+            vh = perm_vh;
+        }
+    };
+
+    auto ensure_nhwc = [&](ValueHandle& vh) {
+        if (layout[vh.node] == Layout::NCHW) {
+            auto spec = get_spec(graph, vh);
+            auto nhwc_spec = permute_spec(spec, {0, 2, 3, 1});
+            auto perm_vh = insert_permute(graph, vh, nhwc_spec,
+                                          {0, 2, 3, 1});
+            layout.push_back(Layout::NHWC);
+            vh = perm_vh;
+        }
+    };
+
+    for (size_t i = 0; i < original_count; i++) {
+        auto* call = std::get_if<CallOperatorNode>(&graph.nodes[i].value);
+        if (!call) continue;
+
+        auto& op = *call;
+
+        if (is_nhwc_op(op.op)) {
+            auto input_spec = get_spec(graph, op.args[0]);
+            if (ndims(input_spec) == 4) {
+                ensure_nhwc(op.args[0]);
+            }
+
+            if (op.op == Operator::Conv2d) {
+                transpose_weight(graph, op.args[1].node, {0, 2, 3, 1});
+            } else if (op.op == Operator::ConvTranspose2d) {
+                transpose_weight(graph, op.args[1].node, {1, 2, 3, 0});
+            }
+
+            auto& out_spec = std::get<TensorSpec>(op.output_specs);
+            if (ndims(out_spec) == 4) {
+                out_spec = permute_spec(out_spec, {0, 2, 3, 1});
+            }
+
+            layout[i] = Layout::NHWC;
+
+        } else if (is_layout_agnostic(op.op)) {
+            bool all_nhwc = true;
+            bool any_4d = false;
+            for (auto& arg : op.args) {
+                if (arg.is_null()) continue;
+                auto spec = get_spec(graph, arg);
+                if (ndims(spec) == 4) {
+                    any_4d = true;
+                    if (layout[arg.node] != Layout::NHWC) {
+                        all_nhwc = false;
+                    }
+                }
+            }
+
+            if (any_4d && all_nhwc) {
+                layout[i] = Layout::NHWC;
+                std::visit(overloaded {
+                    [](TensorSpec& s) {
+                        if (static_cast<int>(s.sizes.size()) == 4) {
+                            s = permute_spec(s, {0, 2, 3, 1});
+                        }
+                    },
+                    [](std::vector<TensorSpec>& v) {
+                        for (auto& s : v) {
+                            if (static_cast<int>(s.sizes.size()) == 4) {
+                                s = permute_spec(s, {0, 2, 3, 1});
+                            }
+                        }
+                    },
+                }, op.output_specs);
+            } else {
+                for (auto& arg : op.args) {
+                    if (arg.is_null()) continue;
+                    ensure_nchw(arg);
+                }
+                layout[i] = Layout::NCHW;
+            }
+
+        } else {
+            for (auto& arg : op.args) {
+                if (arg.is_null()) continue;
+                auto spec = get_spec(graph, arg);
+                if (ndims(spec) == 4) {
+                    ensure_nchw(arg);
+                }
+            }
+            layout[i] = Layout::NCHW;
+        }
+    }
+
+    for (auto& out : graph.outputs) {
+        if (out.is_null()) continue;
+        auto spec = get_spec(graph, out);
+        if (ndims(spec) == 4) {
+            ensure_nchw(out);
+        }
+    }
+
+    graph.update_users();
+}
+
+}

--- a/backends/xnnpack/runtime/plan/nhwc_rewrite.h
+++ b/backends/xnnpack/runtime/plan/nhwc_rewrite.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <executorch/backends/xnnpack/runtime/graph/graph.h>
+
+namespace executorch::backends::xnnpack::plan {
+
+void rewrite_nhwc(graph::Graph& graph);
+
+}

--- a/backends/xnnpack/runtime/plan/partition.cpp
+++ b/backends/xnnpack/runtime/plan/partition.cpp
@@ -1,0 +1,422 @@
+#include <executorch/backends/xnnpack/runtime/plan/partition.h>
+#include <executorch/backends/xnnpack/runtime/plan/xnn_support.h>
+
+#include <algorithm>
+#include <cassert>
+#include <cstdlib>
+#include <deque>
+#include <limits>
+#include <optional>
+
+namespace executorch::backends::xnnpack::plan {
+
+using namespace graph;
+
+namespace {
+
+std::optional<NodeHandle> take_from_queue(
+    Graph& graph,
+    std::deque<NodeHandle>& queue,
+    std::vector<uint16_t>& block_in_partition,
+    std::vector<uint32_t>& in_edges,
+    std::vector<NodeHandle>& deferred,
+    uint16_t current_partition
+) {
+    while (!queue.empty()) {
+        auto node_handle = queue.front();
+        queue.pop_front();
+
+        auto& node = graph.nodes[node_handle];
+
+        assert((node.flags & NodeFlags::UseXnnpack) != NodeFlags::None);
+
+        if (node.tag != 0) { continue; }
+        if (in_edges[node_handle] != 0) { continue; }
+        if (block_in_partition[node_handle] == current_partition) {
+            deferred.push_back(node_handle);
+            continue;
+        }
+
+        return node_handle;
+    }
+
+    return {};
+}
+
+void update_block_frontier(
+    Graph& graph,
+    Node& node,
+    std::vector<uint16_t>& block_in_partition,
+    std::vector<uint16_t>& seen_in_partition,
+    uint16_t current_partition
+) {
+    std::deque<NodeHandle> queue;
+    for (auto user_handle : node.users) {
+        auto& user = graph.nodes[user_handle];
+        if ((user.flags & NodeFlags::UseXnnpack) == NodeFlags::None) {
+            queue.push_back(user_handle);
+        }
+    }
+
+    while (!queue.empty()) {
+        auto handle = queue.front();
+        queue.pop_front();
+
+        if (seen_in_partition[handle] == current_partition) { continue; }
+        seen_in_partition[handle] = current_partition;
+
+        for (auto user_handle : graph.nodes[handle].users) {
+            auto& user = graph.nodes[user_handle];
+            if ((user.flags & NodeFlags::UseXnnpack) != NodeFlags::None) {
+                block_in_partition[user_handle] = current_partition;
+            } else {
+                queue.push_back(user_handle);
+            }
+        }
+    }
+}
+
+} // namespace
+
+uint16_t assign_partitions(Graph& graph) {
+    uint16_t current_partition_id = 0;
+
+    std::deque<NodeHandle> delegated_escape_queue;
+    std::deque<NodeHandle> delegated_noescape_queue;
+    std::deque<NodeHandle> non_delegated_queue;
+
+    uint32_t remaining_delegated_node_count = 0;
+
+    std::vector<uint16_t> block_in_partition(graph.nodes.size(), 0);
+    std::vector<uint16_t> seen_in_partition(graph.nodes.size(), 0);
+    std::vector<uint32_t> in_edges(graph.nodes.size(), 0);
+
+    for (NodeHandle n = 0u; n < graph.nodes.size(); n++) {
+        auto& node = graph.nodes[n];
+        auto& args = node.get_args();
+
+        auto has_nondelegated_user = std::any_of(
+            node.users.begin(),
+            node.users.end(),
+            [&](NodeHandle u) { return (graph.nodes[u].flags & NodeFlags::UseXnnpack) == NodeFlags::None; }
+        );
+        if (has_nondelegated_user) {
+            node.flags |= NodeFlags::PassInternal1;
+        } else {
+            node.flags &= ~NodeFlags::PassInternal1;
+        }
+
+        in_edges[n] = std::count_if(
+            args.begin(),
+            args.end(),
+            [&](const ValueHandle& a) {
+                if (a.is_null()) return false;
+                return !std::holds_alternative<InputNode>(graph.nodes[a.node].value)
+                    && !std::holds_alternative<ConstantNode>(graph.nodes[a.node].value);
+            });
+
+        if ((node.flags & NodeFlags::UseXnnpack) != NodeFlags::None) {
+            remaining_delegated_node_count++;
+        }
+
+        if (in_edges[n] == 0) {
+            if ((node.flags & NodeFlags::UseXnnpack) != NodeFlags::None) {
+                if ((node.flags & NodeFlags::PassInternal1) != NodeFlags::None) {
+                    delegated_escape_queue.push_back(n);
+                } else {
+                    delegated_noescape_queue.push_back(n);
+                }
+            } else {
+                non_delegated_queue.push_back(n);
+            }
+        }
+    }
+
+    while (remaining_delegated_node_count > 0) {
+        std::vector<NodeHandle> deferred;
+
+        if (current_partition_id == std::numeric_limits<uint16_t>::max()) {
+            abort();
+        }
+        current_partition_id++;
+
+        while (true) {
+            while (!non_delegated_queue.empty()) {
+                auto ndh = non_delegated_queue.front();
+                non_delegated_queue.pop_front();
+
+                bool is_input = std::holds_alternative<InputNode>(graph.nodes[ndh].value)
+                    || std::holds_alternative<ConstantNode>(graph.nodes[ndh].value);
+
+                for (auto user : graph.nodes[ndh].users) {
+                    if (is_input) { continue; }
+                    assert(in_edges[user] > 0);
+                    in_edges[user]--;
+                    if (in_edges[user] == 0) {
+                        if ((graph.nodes[user].flags & NodeFlags::UseXnnpack) != NodeFlags::None) {
+                            if ((graph.nodes[user].flags & NodeFlags::PassInternal1) != NodeFlags::None) {
+                                delegated_escape_queue.push_back(user);
+                            } else {
+                                delegated_noescape_queue.push_back(user);
+                            }
+                        } else {
+                            non_delegated_queue.push_back(user);
+                        }
+                    }
+                }
+            }
+
+            std::optional<NodeHandle> nh = take_from_queue(
+                graph,
+                delegated_noescape_queue,
+                block_in_partition,
+                in_edges,
+                deferred,
+                current_partition_id
+            );
+
+            if (!nh) {
+                nh = take_from_queue(
+                    graph,
+                    delegated_escape_queue,
+                    block_in_partition,
+                    in_edges,
+                    deferred,
+                    current_partition_id
+                );
+            }
+
+            if (!nh) {
+                break;
+            }
+
+            auto& node = graph.nodes[*nh];
+            node.tag = current_partition_id;
+            remaining_delegated_node_count--;
+
+            if ((node.flags & NodeFlags::PassInternal1) != NodeFlags::None) {
+                update_block_frontier(
+                    graph, node, block_in_partition, seen_in_partition,
+                    current_partition_id);
+            }
+
+            for (auto user : node.users) {
+                assert(in_edges[user] > 0);
+
+                in_edges[user]--;
+                if (in_edges[user] == 0) {
+                    if ((graph.nodes[user].flags & NodeFlags::UseXnnpack) != NodeFlags::None) {
+                        if ((graph.nodes[user].flags & NodeFlags::PassInternal1) != NodeFlags::None) {
+                            delegated_escape_queue.push_back(user);
+                        } else {
+                            delegated_noescape_queue.push_back(user);
+                        }
+                    } else {
+                        non_delegated_queue.push_back(user);
+                    }
+                }
+            }
+        }
+
+        for (auto handle : deferred) {
+            if ((graph.nodes[handle].flags & NodeFlags::PassInternal1) != NodeFlags::None) {
+                delegated_escape_queue.push_back(handle);
+            } else {
+                delegated_noescape_queue.push_back(handle);
+            }
+        }
+    }
+
+    return current_partition_id;
+}
+
+namespace {
+
+void tag_xnn_nodes(Graph& graph) {
+    for (auto& node : graph.nodes) {
+        auto* op_node = std::get_if<CallOperatorNode>(&node.value);
+        if (op_node && check_xnn_node_support(*op_node, graph)) {
+            node.flags |= NodeFlags::UseXnnpack;
+        }
+    }
+}
+
+} // namespace
+
+void fuse_partitions(Graph& graph, uint16_t partition_count) {
+    const auto sentinel = std::numeric_limits<NodeHandle>::max();
+
+    for (uint16_t p = 1; p <= partition_count; p++) {
+        std::vector<NodeHandle> members;
+        for (NodeHandle n = 0; n < graph.nodes.size(); n++) {
+            if (graph.nodes[n].tag == p) {
+                members.push_back(n);
+            }
+        }
+        if (members.empty()) { continue; }
+
+        auto is_member = [&](NodeHandle h) {
+            return std::find(members.begin(), members.end(), h) != members.end();
+        };
+
+        std::vector<ValueHandle> ext_inputs;
+        for (auto m : members) {
+            for (auto arg : graph.nodes[m].get_args()) {
+                if (arg.is_null()) continue;
+                if (std::holds_alternative<ConstantNode>(graph.nodes[arg.node].value)) continue;
+                if (!is_member(arg.node) &&
+                    std::find(ext_inputs.begin(), ext_inputs.end(), arg) == ext_inputs.end()) {
+                    ext_inputs.push_back(arg);
+                }
+            }
+        }
+
+        std::vector<NodeHandle> output_members;
+        for (auto m : members) {
+            bool external = std::any_of(
+                graph.nodes[m].users.begin(), graph.nodes[m].users.end(),
+                [&](NodeHandle u) { return !is_member(u); });
+            if (!external) {
+                external = std::any_of(
+                    graph.outputs.begin(), graph.outputs.end(),
+                    [&](const ValueHandle& vh) { return vh.node == m; });
+            }
+            if (external) {
+                output_members.push_back(m);
+            }
+        }
+        if (output_members.empty()) { continue; }
+
+        NodeHandle anchor = members.back();
+
+        auto subgraph = std::make_unique<Graph>();
+
+        std::vector<NodeHandle> handle_map(graph.nodes.size(), sentinel);
+
+        for (size_t i = 0; i < ext_inputs.size(); i++) {
+            auto ext_node = ext_inputs[i].node;
+            if (handle_map[ext_node] == sentinel) {
+                handle_map[ext_node] = static_cast<NodeHandle>(subgraph->nodes.size());
+
+                auto spec = graph.get_tensor_spec(ext_inputs[i]);
+                subgraph->input_specs.push_back(spec);
+
+                Node node;
+                node.value = InputNode{static_cast<InputHandle>(i)};
+                subgraph->nodes.push_back(std::move(node));
+            }
+        }
+
+        for (auto m : members) {
+            for (auto arg : graph.nodes[m].get_args()) {
+                if (arg.is_null()) continue;
+                if (handle_map[arg.node] != sentinel) continue;
+                auto* cn = std::get_if<ConstantNode>(&graph.nodes[arg.node].value);
+                if (!cn) continue;
+                handle_map[arg.node] = static_cast<NodeHandle>(subgraph->nodes.size());
+                ConstantNode cloned;
+                cloned.tensor = cn->tensor;
+                cloned.quant_params = cn->quant_params;
+                Node node;
+                node.value = std::move(cloned);
+                subgraph->nodes.push_back(std::move(node));
+            }
+        }
+
+        {
+            auto next_pos = static_cast<NodeHandle>(subgraph->nodes.size());
+            for (auto m : members) {
+                handle_map[m] = next_pos++;
+            }
+        }
+
+        for (auto m : members) {
+            auto* op = std::get_if<CallOperatorNode>(&graph.nodes[m].value);
+            assert(op);
+
+            CallOperatorNode remapped;
+            remapped.op = op->op;
+            remapped.output_specs = op->output_specs;
+            remapped.constant_args = op->constant_args;
+            for (auto arg : op->args) {
+                if (arg.is_null()) {
+                    remapped.args.push_back(ValueHandle::null());
+                    continue;
+                }
+                assert(handle_map[arg.node] != sentinel);
+                remapped.args.push_back(ValueHandle{
+                    static_cast<uint16_t>(handle_map[arg.node]),
+                    arg.output,
+                });
+            }
+
+            Node node;
+            node.value = std::move(remapped);
+            subgraph->nodes.push_back(std::move(node));
+        }
+
+        std::vector<uint32_t> output_index(graph.nodes.size(), sentinel);
+        std::vector<TensorSpec> output_specs;
+        for (auto m : output_members) {
+            output_index[m] = static_cast<uint32_t>(subgraph->outputs.size());
+            subgraph->outputs.push_back(ValueHandle{
+                static_cast<uint16_t>(handle_map[m]),
+            });
+            output_specs.push_back(
+                std::get<TensorSpec>(graph.get_output_spec_for_node(m)));
+        }
+
+        CallSubgraphNode fused;
+        fused.args = std::move(ext_inputs);
+        if (output_members.size() == 1) {
+            fused.output_specs = output_specs[0];
+        } else {
+            fused.output_specs = std::move(output_specs);
+        }
+        fused.subgraph = std::move(subgraph);
+
+        graph.nodes[anchor].value = std::move(fused);
+        graph.nodes[anchor].tag = 0;
+        graph.nodes[anchor].flags = NodeFlags::None;
+
+        for (NodeHandle n = 0; n < graph.nodes.size(); n++) {
+            if (is_member(n)) { continue; }
+            auto* op = std::get_if<CallOperatorNode>(&graph.nodes[n].value);
+            if (!op) { continue; }
+            for (auto& arg : op->args) {
+                if (arg.is_null()) continue;
+                if (output_index[arg.node] != sentinel) {
+                    arg = ValueHandle{
+                        static_cast<uint16_t>(anchor),
+                        static_cast<uint16_t>(output_index[arg.node])};
+                }
+            }
+        }
+        for (auto& out : graph.outputs) {
+            if (output_index[out.node] != sentinel) {
+                out = ValueHandle{
+                    static_cast<uint16_t>(anchor),
+                    static_cast<uint16_t>(output_index[out.node])};
+            }
+        }
+
+        for (auto m : members) {
+            if (m == anchor) { continue; }
+            graph.nodes[m].value = InputNode{0};
+            graph.nodes[m].tag = 0;
+            graph.nodes[m].flags = NodeFlags::Dead;
+        }
+    }
+
+    graph.update_users();
+}
+
+void partition_xnn_subgraphs(Graph& graph) {
+    graph.update_users();
+    tag_xnn_nodes(graph);
+    auto partition_count = assign_partitions(graph);
+    fuse_partitions(graph, partition_count);
+    graph.compact_nodes();
+}
+
+}

--- a/backends/xnnpack/runtime/plan/partition.h
+++ b/backends/xnnpack/runtime/plan/partition.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <executorch/backends/xnnpack/runtime/graph/graph.h>
+
+namespace executorch::backends::xnnpack::plan {
+
+void partition_xnn_subgraphs(graph::Graph& graph);
+uint16_t assign_partitions(graph::Graph& graph);
+void fuse_partitions(graph::Graph& graph, uint16_t partition_count);
+
+}

--- a/backends/xnnpack/runtime/plan/schedule.cpp
+++ b/backends/xnnpack/runtime/plan/schedule.cpp
@@ -1,0 +1,58 @@
+#include <executorch/backends/xnnpack/runtime/plan/schedule.h>
+
+#include <algorithm>
+#include <cassert>
+#include <deque>
+#include <variant>
+
+namespace executorch::backends::xnnpack::plan {
+
+using namespace graph;
+
+std::vector<NodeHandle> schedule(const graph::Graph& graph) {
+    const auto& nodes = graph.nodes;
+
+    std::vector<uint32_t> in_edges(nodes.size(), 0);
+    std::deque<NodeHandle> queue;
+
+    for (NodeHandle n = 0; n < nodes.size(); n++) {
+        auto& args = nodes[n].get_args();
+        in_edges[n] = std::count_if(
+            args.begin(), args.end(),
+            [&](const ValueHandle& a) {
+                if (a.is_null()) return false;
+                return !std::holds_alternative<InputNode>(nodes[a.node].value)
+                    && !std::holds_alternative<ConstantNode>(nodes[a.node].value);
+            });
+        if (in_edges[n] == 0) {
+            queue.push_back(n);
+        }
+    }
+
+    std::vector<NodeHandle> order;
+    order.reserve(nodes.size());
+
+    while (!queue.empty()) {
+        auto nh = queue.front();
+        queue.pop_front();
+        order.push_back(nh);
+
+        if (std::holds_alternative<InputNode>(nodes[nh].value)
+            || std::holds_alternative<ConstantNode>(nodes[nh].value)) {
+            continue;
+        }
+
+        for (auto user : nodes[nh].users) {
+            assert(in_edges[user] > 0);
+            in_edges[user]--;
+            if (in_edges[user] == 0) {
+                queue.push_back(user);
+            }
+        }
+    }
+
+    assert(order.size() == nodes.size());
+    return order;
+}
+
+}

--- a/backends/xnnpack/runtime/plan/schedule.h
+++ b/backends/xnnpack/runtime/plan/schedule.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <executorch/backends/xnnpack/runtime/graph/graph.h>
+#include <executorch/backends/xnnpack/runtime/graph/handles.h>
+
+#include <vector>
+
+namespace executorch::backends::xnnpack::plan {
+
+std::vector<graph::NodeHandle> schedule(const graph::Graph& graph);
+
+}

--- a/backends/xnnpack/runtime/plan/xnn_subgraph.cpp
+++ b/backends/xnnpack/runtime/plan/xnn_subgraph.cpp
@@ -1,0 +1,590 @@
+#include <executorch/backends/xnnpack/runtime/plan/xnn_subgraph.h>
+
+#include <executorch/backends/xnnpack/runtime/core/quant_params.h>
+#include <executorch/backends/xnnpack/runtime/core/span.h>
+#include <executorch/backends/xnnpack/runtime/core/tensor.h>
+
+#include <executorch/backends/xnnpack/runtime/graph/graph.h>
+#include <executorch/backends/xnnpack/runtime/graph/tensor_spec.h>
+
+#include <cassert>
+#include <cmath>
+#include <optional>
+
+namespace executorch::backends::xnnpack::plan {
+
+using core::DType;
+using graph::CallOperatorNode;
+using graph::ConstantNode;
+using graph::InputNode;
+using graph::NodeHandle;
+using graph::Operator;
+
+namespace {
+
+xnn_datatype map_xnn_datatype(const graph::TensorSpec& spec) {
+    if (!spec.quant_params) {
+        switch (spec.dtype) {
+            case DType::Float32: return xnn_datatype_fp32;
+            default: abort();
+        }
+    }
+    switch (spec.dtype) {
+        case DType::QUInt8Asym: return xnn_datatype_quint8;
+        case DType::QInt8Sym:
+            if (std::holds_alternative<core::PerAxisQuant>(*spec.quant_params)) {
+                return xnn_datatype_qcint8;
+            }
+            return xnn_datatype_qint8;
+        case DType::QInt32Sym:  return xnn_datatype_qint32;
+        default: abort();
+    }
+}
+
+std::optional<xnn_binary_operator> map_binary_op(Operator op) {
+    switch (op) {
+        case Operator::Add:               return xnn_binary_add;
+        case Operator::Subtract:          return xnn_binary_subtract;
+        case Operator::Multiply:          return xnn_binary_multiply;
+        case Operator::Divide:            return xnn_binary_divide;
+        case Operator::Maximum:           return xnn_binary_maximum;
+        case Operator::Minimum:           return xnn_binary_minimum;
+        case Operator::CopySign:          return xnn_binary_copysign;
+        case Operator::SquaredDifference: return xnn_binary_squared_difference;
+        case Operator::PReLU:             return xnn_binary_prelu;
+        case Operator::Modulus:           return xnn_binary_modulus;
+        case Operator::Atan2:            return xnn_binary_atan2;
+        case Operator::Pow:              return xnn_binary_pow;
+        default:                          return std::nullopt;
+    }
+}
+
+std::optional<xnn_unary_operator> map_unary_op(Operator op) {
+    switch (op) {
+        case Operator::Abs:                    return xnn_unary_abs;
+        case Operator::Negate:                 return xnn_unary_negate;
+        case Operator::Clamp:                  return xnn_unary_clamp;
+        case Operator::Ceiling:                return xnn_unary_ceiling;
+        case Operator::Floor:                  return xnn_unary_floor;
+        case Operator::Round:                  return xnn_unary_bankers_rounding;
+        case Operator::Square:                 return xnn_unary_square;
+        case Operator::SquareRoot:             return xnn_unary_square_root;
+        case Operator::ReciprocalSquareRoot:   return xnn_unary_reciprocal_square_root;
+        case Operator::Exp:                    return xnn_unary_exp;
+        case Operator::Log:                    return xnn_unary_log;
+        case Operator::Sigmoid:                return xnn_unary_sigmoid;
+        case Operator::Tanh:                   return xnn_unary_tanh;
+        case Operator::ELU:                    return xnn_unary_elu;
+        case Operator::GELU:                   return xnn_unary_gelu;
+        case Operator::HardSwish:              return xnn_unary_hardswish;
+        case Operator::LeakyReLU:              return xnn_unary_leaky_relu;
+        case Operator::Sine:                   return xnn_unary_sine;
+        case Operator::Cosine:                 return xnn_unary_cosine;
+        case Operator::Sign:                   return xnn_unary_sign;
+        case Operator::ReLU:                   return xnn_unary_clamp;
+        default:                               return std::nullopt;
+    }
+}
+
+template <typename T>
+T get_const(const graph::ConstantArg& arg) {
+    return std::get<T>(arg);
+}
+
+template <typename T>
+std::vector<size_t> to_size_vec(const std::vector<T>& v) {
+    return {v.begin(), v.end()};
+}
+
+void define_node(
+    const CallOperatorNode& op,
+    uint32_t output_id,
+    core::Span<const uint32_t> xnn_ids,
+    xnn_subgraph_t subgraph) {
+
+    if (auto bin_op = map_binary_op(op.op)) {
+        xnn_binary_params params = {
+            .output_min = -INFINITY,
+            .output_max = INFINITY,
+        };
+        auto status = xnn_define_binary(
+            subgraph,
+            *bin_op,
+            &params,
+            xnn_ids[op.args[0].node],
+            xnn_ids[op.args[1].node],
+            output_id,
+            /*flags=*/0);
+        if (status != xnn_status_success) { abort(); }
+        return;
+    }
+
+    if (auto unary_op = map_unary_op(op.op)) {
+        xnn_unary_params params = {};
+
+        if (op.op == Operator::Clamp) {
+            params.clamp.min = static_cast<float>(
+                get_const<double>(op.constant_args[0]));
+            params.clamp.max = static_cast<float>(
+                get_const<double>(op.constant_args[1]));
+        } else if (op.op == Operator::ReLU) {
+            params.clamp.min = 0.0f;
+            params.clamp.max = INFINITY;
+        } else if (op.op == Operator::ELU) {
+            params.elu.alpha = op.constant_args.empty()
+                ? 1.0f
+                : static_cast<float>(get_const<double>(op.constant_args[0]));
+        } else if (op.op == Operator::LeakyReLU) {
+            params.leaky_relu.negative_slope = static_cast<float>(
+                get_const<double>(op.constant_args[0]));
+        }
+
+        auto status = xnn_define_unary(
+            subgraph, *unary_op, &params,
+            xnn_ids[op.args[0].node],
+            output_id, /*flags=*/0);
+        if (status != xnn_status_success) { abort(); }
+        return;
+    }
+
+    if (op.op == Operator::Linear) {
+        auto bias_id = op.args[2].is_null()
+            ? XNN_INVALID_VALUE_ID
+            : xnn_ids[op.args[2].node];
+        auto status = xnn_define_fully_connected(
+            subgraph, -INFINITY, INFINITY,
+            xnn_ids[op.args[0].node],
+            xnn_ids[op.args[1].node],
+            bias_id,
+            output_id, /*flags=*/0);
+        if (status != xnn_status_success) { abort(); }
+        return;
+    }
+
+    if (op.op == Operator::BatchMatrixMultiply) {
+        auto status = xnn_define_batch_matrix_multiply(
+            subgraph,
+            xnn_ids[op.args[0].node],
+            xnn_ids[op.args[1].node],
+            output_id, /*flags=*/0);
+        if (status != xnn_status_success) { abort(); }
+        return;
+    }
+
+    if (op.op == Operator::Conv2d) {
+        auto stride = get_const<std::vector<int64_t>>(op.constant_args[0]);
+        auto padding = get_const<std::vector<int64_t>>(op.constant_args[1]);
+        auto dilation = get_const<std::vector<int64_t>>(op.constant_args[2]);
+        auto groups = get_const<int64_t>(op.constant_args[3]);
+        auto kernel = get_const<std::vector<int64_t>>(op.constant_args[4]);
+        auto group_input_channels = get_const<int64_t>(op.constant_args[5]);
+        auto group_output_channels = get_const<int64_t>(op.constant_args[6]);
+        auto bias_id = op.args[2].is_null()
+            ? XNN_INVALID_VALUE_ID
+            : xnn_ids[op.args[2].node];
+
+        auto status = xnn_define_convolution_2d(
+            subgraph,
+            padding[0], padding[1], padding[0], padding[1],
+            kernel[0], kernel[1],
+            stride[0], stride[1],
+            dilation[0], dilation[1],
+            groups,
+            group_input_channels, group_output_channels,
+            -INFINITY, INFINITY,
+            xnn_ids[op.args[0].node],
+            xnn_ids[op.args[1].node],
+            bias_id,
+            output_id, /*flags=*/0);
+        if (status != xnn_status_success) { abort(); }
+        return;
+    }
+
+    if (op.op == Operator::ConvTranspose2d) {
+        auto stride = get_const<std::vector<int64_t>>(op.constant_args[0]);
+        auto padding = get_const<std::vector<int64_t>>(op.constant_args[1]);
+        auto output_padding = get_const<std::vector<int64_t>>(op.constant_args[2]);
+        auto groups = get_const<int64_t>(op.constant_args[3]);
+        auto dilation = get_const<std::vector<int64_t>>(op.constant_args[4]);
+        auto kernel = get_const<std::vector<int64_t>>(op.constant_args[5]);
+        auto group_input_channels = get_const<int64_t>(op.constant_args[6]);
+        auto group_output_channels = get_const<int64_t>(op.constant_args[7]);
+        auto bias_id = op.args[2].is_null()
+            ? XNN_INVALID_VALUE_ID
+            : xnn_ids[op.args[2].node];
+
+        auto status = xnn_define_deconvolution_2d(
+            subgraph,
+            padding[0], padding[1], padding[0], padding[1],
+            output_padding[0], output_padding[1],
+            kernel[0], kernel[1],
+            stride[0], stride[1],
+            dilation[0], dilation[1],
+            groups,
+            group_input_channels, group_output_channels,
+            -INFINITY, INFINITY,
+            xnn_ids[op.args[0].node],
+            xnn_ids[op.args[1].node],
+            bias_id,
+            output_id, /*flags=*/0);
+        if (status != xnn_status_success) { abort(); }
+        return;
+    }
+
+    if (op.op == Operator::AvgPool2d) {
+        auto kernel = get_const<std::vector<int64_t>>(op.constant_args[0]);
+        auto stride = get_const<std::vector<int64_t>>(op.constant_args[1]);
+        auto padding = get_const<std::vector<int64_t>>(op.constant_args[2]);
+        uint32_t flags = 0;
+        auto status = xnn_define_average_pooling_2d(
+            subgraph,
+            padding[0], padding[0], padding[1], padding[1],
+            kernel[0], kernel[1],
+            stride[0], stride[1],
+            -INFINITY, INFINITY,
+            xnn_ids[op.args[0].node],
+            output_id, flags);
+        if (status != xnn_status_success) { abort(); }
+        return;
+    }
+
+    if (op.op == Operator::AdaptiveAvgPool2d) {
+        auto status = xnn_define_global_average_pooling_2d(
+            subgraph, -INFINITY, INFINITY,
+            xnn_ids[op.args[0].node],
+            output_id, XNN_FLAG_KEEP_DIMS);
+        if (status != xnn_status_success) { abort(); }
+        return;
+    }
+
+    if (op.op == Operator::MaxPool2d) {
+        auto kernel = get_const<std::vector<int64_t>>(op.constant_args[0]);
+        auto stride = get_const<std::vector<int64_t>>(op.constant_args[1]);
+        auto padding = get_const<std::vector<int64_t>>(op.constant_args[2]);
+        auto dilation = get_const<std::vector<int64_t>>(op.constant_args[3]);
+        auto status = xnn_define_max_pooling_2d(
+            subgraph,
+            padding[0], padding[0], padding[1], padding[1],
+            kernel[0], kernel[1],
+            stride[0], stride[1],
+            dilation[0], dilation[1],
+            -INFINITY, INFINITY,
+            xnn_ids[op.args[0].node],
+            output_id, /*flags=*/0);
+        if (status != xnn_status_success) { abort(); }
+        return;
+    }
+
+    if (op.op == Operator::Softmax) {
+        auto status = xnn_define_softmax(
+            subgraph,
+            xnn_ids[op.args[0].node],
+            output_id, /*flags=*/0);
+        if (status != xnn_status_success) { abort(); }
+        return;
+    }
+
+    if (op.op == Operator::Mean || op.op == Operator::Sum) {
+        auto dims = get_const<std::vector<int64_t>>(op.constant_args[0]);
+        auto keepdim = get_const<int64_t>(op.constant_args[1]);
+        std::vector<size_t> reduction_axes(dims.begin(), dims.end());
+        uint32_t flags = keepdim ? XNN_FLAG_KEEP_DIMS : 0;
+
+        auto reduce_op = (op.op == Operator::Mean)
+            ? xnn_reduce_mean : xnn_reduce_sum;
+
+        auto status = xnn_define_static_reduce(
+            subgraph, reduce_op,
+            reduction_axes.size(), reduction_axes.data(),
+            xnn_ids[op.args[0].node],
+            output_id, flags);
+        if (status != xnn_status_success) { abort(); }
+        return;
+    }
+
+    if (op.op == Operator::Reshape || op.op == Operator::View) {
+        auto shape = get_const<std::vector<int64_t>>(op.constant_args[0]);
+        auto new_shape = to_size_vec(shape);
+        auto status = xnn_define_static_reshape(
+            subgraph,
+            new_shape.size(), new_shape.data(),
+            xnn_ids[op.args[0].node],
+            output_id, /*flags=*/0);
+        if (status != xnn_status_success) { abort(); }
+        return;
+    }
+
+    if (op.op == Operator::Transpose || op.op == Operator::Permute) {
+        auto perm = get_const<std::vector<int64_t>>(op.constant_args[0]);
+        auto perm_sz = to_size_vec(perm);
+        auto status = xnn_define_static_transpose(
+            subgraph,
+            perm_sz.size(), perm_sz.data(),
+            xnn_ids[op.args[0].node],
+            output_id, /*flags=*/0);
+        if (status != xnn_status_success) { abort(); }
+        return;
+    }
+
+    if (op.op == Operator::Slice) {
+        auto dim = get_const<int64_t>(op.constant_args[0]);
+        auto start = get_const<int64_t>(op.constant_args[1]);
+        auto end = get_const<int64_t>(op.constant_args[2]);
+        (void)end;
+
+        auto& out_spec = std::get<graph::TensorSpec>(op.output_specs);
+        auto ndims = out_spec.sizes.size();
+        std::vector<size_t> offsets(ndims, 0);
+        std::vector<size_t> sizes(ndims, 0);
+        for (size_t i = 0; i < ndims; i++) {
+            sizes[i] = static_cast<size_t>(out_spec.sizes[i].offset);
+        }
+        offsets[dim] = static_cast<size_t>(start);
+
+        auto status = xnn_define_static_slice(
+            subgraph,
+            ndims, offsets.data(), sizes.data(),
+            xnn_ids[op.args[0].node],
+            output_id, /*flags=*/0);
+        if (status != xnn_status_success) { abort(); }
+        return;
+    }
+
+    if (op.op == Operator::Cat) {
+        auto axis = get_const<int64_t>(
+            op.constant_args[0]);
+        std::vector<uint32_t> input_ids;
+        for (auto& arg : op.args) {
+            input_ids.push_back(xnn_ids[arg.node]);
+        }
+        auto status = xnn_define_concatenate(
+            subgraph,
+            static_cast<size_t>(axis),
+            input_ids.size(), input_ids.data(),
+            output_id, /*flags=*/0);
+        if (status != xnn_status_success) { abort(); }
+        return;
+    }
+
+    if (op.op == Operator::Unsqueeze) {
+        auto dim = get_const<int64_t>(op.constant_args[0]);
+        size_t axis = static_cast<size_t>(dim);
+        auto status = xnn_define_static_expand_dims(
+            subgraph,
+            1, &axis,
+            xnn_ids[op.args[0].node],
+            output_id, /*flags=*/0);
+        if (status != xnn_status_success) { abort(); }
+        return;
+    }
+
+    if (op.op == Operator::Expand) {
+        auto shape = get_const<std::vector<int64_t>>(op.constant_args[0]);
+        auto new_shape = to_size_vec(shape);
+        auto status = xnn_define_static_broadcast(
+            subgraph,
+            new_shape.size(), new_shape.data(),
+            xnn_ids[op.args[0].node],
+            output_id, /*flags=*/0);
+        if (status != xnn_status_success) { abort(); }
+        return;
+    }
+
+    if (op.op == Operator::Clone) {
+        auto status = xnn_define_copy(
+            subgraph,
+            xnn_ids[op.args[0].node],
+            output_id, /*flags=*/0);
+        if (status != xnn_status_success) { abort(); }
+        return;
+    }
+
+    if (op.op == Operator::Pad) {
+        auto pad = get_const<std::vector<int64_t>>(op.constant_args[0]);
+        auto& out_spec = std::get<graph::TensorSpec>(op.output_specs);
+        auto ndims = out_spec.sizes.size();
+        std::vector<size_t> pre_paddings(ndims, 0);
+        std::vector<size_t> post_paddings(ndims, 0);
+        for (size_t i = 0; i < pad.size() / 2; i++) {
+            auto dim_idx = ndims - 1 - i;
+            pre_paddings[dim_idx] = static_cast<size_t>(pad[2 * i]);
+            post_paddings[dim_idx] = static_cast<size_t>(pad[2 * i + 1]);
+        }
+
+        auto status = xnn_define_static_constant_pad(
+            subgraph, pre_paddings.data(), post_paddings.data(),
+            0.0f,
+            xnn_ids[op.args[0].node],
+            output_id, /*flags=*/0);
+        if (status != xnn_status_success) { abort(); }
+        return;
+    }
+
+    if (op.op == Operator::Quantize || op.op == Operator::Dequantize) {
+        auto status = xnn_define_unary(
+            subgraph, xnn_unary_convert, nullptr,
+            xnn_ids[op.args[0].node],
+            output_id, /*flags=*/0);
+        if (status != xnn_status_success) { abort(); }
+        return;
+    }
+
+    abort();
+}
+
+
+uint32_t define_tensor(
+    const graph::TensorSpec& spec,
+    xnn_subgraph_t subgraph,
+    bool is_input = false,
+    bool is_output = false,
+    uint32_t external_id = XNN_INVALID_VALUE_ID,
+    const core::Tensor* constant_tensor = nullptr) {
+    std::vector<size_t> dims(spec.sizes.size());
+    for (auto i = 0u; i < spec.sizes.size(); i++) {
+        auto& s = spec.sizes[i];
+        dims[i] = s.is_constant() ? static_cast<size_t>(s.offset) : 1;
+    }
+
+    uint32_t flags = 0;
+    if (is_input) { flags |= XNN_VALUE_FLAG_EXTERNAL_INPUT; }
+    if (is_output) { flags |= XNN_VALUE_FLAG_EXTERNAL_OUTPUT; }
+
+    const void* data = constant_tensor ? constant_tensor->storage.data : nullptr;
+    auto xnn_dtype = map_xnn_datatype(spec);
+
+    uint32_t id = 0;
+    xnn_status status;
+
+    if (!spec.quant_params) {
+        status = xnn_define_tensor_value(
+            subgraph, xnn_dtype,
+            spec.sizes.size(), dims.data(),
+            data, external_id, flags, &id);
+    } else if (auto* pt = std::get_if<core::PerTensorQuant>(&*spec.quant_params)) {
+        status = xnn_define_quantized_tensor_value(
+            subgraph, xnn_dtype,
+            pt->zero_point, pt->scale,
+            spec.sizes.size(), dims.data(),
+            data, external_id, flags, &id);
+    } else if (auto* pa = std::get_if<core::PerAxisQuant>(&*spec.quant_params)) {
+        assert(constant_tensor && !constant_tensor->aux_storage.empty());
+        auto* scales = static_cast<const float*>(
+            constant_tensor->aux_storage[0].data);
+        status = xnn_define_channelwise_quantized_tensor_value(
+            subgraph, xnn_dtype,
+            scales,
+            spec.sizes.size(), static_cast<size_t>(pa->axis),
+            dims.data(),
+            data, external_id, flags, &id);
+    } else {
+        abort();
+    }
+
+    if (status != xnn_status_success) { abort(); }
+    return id;
+}
+
+} // namespace
+
+XnnSubgraph build_xnn_subgraph(const graph::Graph& graph) {
+    auto num_external_values = static_cast<uint32_t>(
+        graph.input_specs.size() + graph.outputs.size());
+
+    xnn_subgraph_t raw_subgraph = nullptr;
+    auto status = xnn_create_subgraph(
+        num_external_values,
+        /*flags=*/0,
+        &raw_subgraph
+    );
+
+    if (status != xnn_status_success) {
+        abort();
+    }
+
+    auto subgraph = XnnSubgraph(raw_subgraph);
+
+    std::vector<uint32_t> xnn_input_ids(graph.input_specs.size());
+    for (auto i = 0u; i < graph.input_specs.size(); i++) {
+        xnn_input_ids[i] = define_tensor(
+            graph.input_specs[i],
+            subgraph.get(),
+            /*is_input=*/true,
+            /*is_output=*/false,
+            /*external_id=*/i);
+    }
+
+    std::vector<uint32_t> xnn_output_ids(graph.outputs.size());
+    for (auto i = 0u; i < graph.outputs.size(); i++) {
+        auto external_id = static_cast<uint32_t>(i + graph.input_specs.size());
+        xnn_output_ids[i] = define_tensor(
+            graph.get_tensor_spec(graph.outputs[i]),
+            subgraph.get(),
+            /*is_input=*/false,
+            /*is_output=*/true,
+            external_id);
+    }
+
+    std::vector<uint32_t> xnn_ids(graph.nodes.size(), XNN_INVALID_VALUE_ID);
+
+    for (NodeHandle n = 0; n < graph.nodes.size(); n++) {
+        if (auto* inp = std::get_if<InputNode>(&graph.nodes[n].value)) {
+            xnn_ids[n] = xnn_input_ids[inp->input];
+        }
+    }
+
+    for (NodeHandle n = 0; n < graph.nodes.size(); n++) {
+        if (auto* cn = std::get_if<ConstantNode>(&graph.nodes[n].value)) {
+            auto spec = std::get<graph::TensorSpec>(graph.get_output_spec_for_node(n));
+            xnn_ids[n] = define_tensor(
+                spec, subgraph.get(),
+                /*is_input=*/false, /*is_output=*/false,
+                XNN_INVALID_VALUE_ID, cn->tensor.get());
+        }
+    }
+
+    for (auto i = 0u; i < graph.outputs.size(); i++) {
+        xnn_ids[graph.outputs[i].node] = xnn_output_ids[i];
+    }
+
+    for (NodeHandle n = 0; n < graph.nodes.size(); n++) {
+        auto* op = std::get_if<CallOperatorNode>(&graph.nodes[n].value);
+        if (!op) continue;
+
+        if (xnn_ids[n] == XNN_INVALID_VALUE_ID) {
+            auto spec = std::get<graph::TensorSpec>(op->output_specs);
+            xnn_ids[n] = define_tensor(spec, subgraph.get());
+        }
+    }
+
+    for (NodeHandle n = 0; n < graph.nodes.size(); n++) {
+        auto* op = std::get_if<CallOperatorNode>(&graph.nodes[n].value);
+        if (!op) continue;
+
+        define_node(*op, xnn_ids[n], xnn_ids, subgraph.get());
+    }
+
+    return subgraph;
+}
+
+XnnRuntime compile_xnn_subgraph(const graph::Graph& graph, xnn_workspace_t workspace) {
+    auto subgraph = build_xnn_subgraph(graph);
+
+    xnn_runtime_t runtime = nullptr;
+    auto status = xnn_create_runtime_v4(
+        subgraph.get(),
+        /*weights_cache=*/nullptr,
+        workspace,
+        /*threadpool=*/nullptr,
+        /*flags=*/0,
+        &runtime
+    );
+
+    if (status != xnn_status_success) {
+        abort();
+    }
+
+    return XnnRuntime(runtime);
+}
+
+}

--- a/backends/xnnpack/runtime/plan/xnn_subgraph.h
+++ b/backends/xnnpack/runtime/plan/xnn_subgraph.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <memory>
+
+#include <xnnpack.h>
+
+namespace executorch::backends::xnnpack::graph { struct Graph; }
+
+namespace executorch::backends::xnnpack::plan {
+
+struct XnnSubgraphDeleter {
+    void operator()(xnn_subgraph_t subgraph) const {
+        xnn_delete_subgraph(subgraph);
+    }
+};
+
+struct XnnRuntimeDeleter {
+    void operator()(xnn_runtime_t runtime) const {
+        xnn_delete_runtime(runtime);
+    }
+};
+
+struct XnnWorkspaceDeleter {
+    void operator()(xnn_workspace_t workspace) const {
+        xnn_release_workspace(workspace);
+    }
+};
+
+using XnnSubgraph = std::unique_ptr<xnn_subgraph, XnnSubgraphDeleter>;
+using XnnRuntime = std::unique_ptr<xnn_runtime, XnnRuntimeDeleter>;
+using XnnWorkspace = std::unique_ptr<xnn_workspace, XnnWorkspaceDeleter>;
+
+XnnRuntime compile_xnn_subgraph(const graph::Graph& graph, xnn_workspace_t workspace);
+
+}

--- a/backends/xnnpack/runtime/plan/xnn_support.cpp
+++ b/backends/xnnpack/runtime/plan/xnn_support.cpp
@@ -1,0 +1,106 @@
+#include <executorch/backends/xnnpack/runtime/plan/xnn_support.h>
+
+#include <executorch/backends/xnnpack/runtime/core/dtype.h>
+#include <executorch/backends/xnnpack/runtime/core/variant_util.h>
+
+namespace executorch::backends::xnnpack::plan {
+
+namespace {
+
+using namespace graph;
+
+bool check_xnn_dtype_support(core::DType dtype) {
+    switch (dtype) {
+        case core::DType::Float32:
+        case core::DType::QUInt8Asym:
+        case core::DType::QInt8Sym:
+        case core::DType::QInt32Sym:
+            return true;
+        default:
+            return false;
+    }
+}
+
+bool check_xnn_op_support(Operator op) {
+    switch (op) {
+        case Operator::Add:
+        case Operator::Subtract:
+        case Operator::Multiply:
+        case Operator::Divide:
+        case Operator::Maximum:
+        case Operator::Minimum:
+        case Operator::CopySign:
+        case Operator::SquaredDifference:
+        case Operator::PReLU:
+        case Operator::Modulus:
+        case Operator::Atan2:
+        case Operator::Pow:
+        case Operator::Abs:
+        case Operator::Negate:
+        case Operator::Clamp:
+        case Operator::Ceiling:
+        case Operator::Floor:
+        case Operator::Round:
+        case Operator::Square:
+        case Operator::SquareRoot:
+        case Operator::ReciprocalSquareRoot:
+        case Operator::Exp:
+        case Operator::Log:
+        case Operator::Sigmoid:
+        case Operator::Tanh:
+        case Operator::ELU:
+        case Operator::GELU:
+        case Operator::HardSwish:
+        case Operator::LeakyReLU:
+        case Operator::Sine:
+        case Operator::Cosine:
+        case Operator::Sign:
+        case Operator::ReLU:
+        case Operator::Linear:
+        case Operator::BatchMatrixMultiply:
+        case Operator::Conv2d:
+        case Operator::ConvTranspose2d:
+        case Operator::AvgPool2d:
+        case Operator::AdaptiveAvgPool2d:
+        case Operator::MaxPool2d:
+        case Operator::Softmax:
+        case Operator::Mean:
+        case Operator::Sum:
+        case Operator::Reshape:
+        case Operator::View:
+        case Operator::Transpose:
+        case Operator::Permute:
+        case Operator::Slice:
+        case Operator::Cat:
+        case Operator::Unsqueeze:
+        case Operator::Expand:
+        case Operator::Clone:
+        case Operator::Pad:
+        case Operator::Quantize:
+        case Operator::Dequantize:
+            return true;
+        default:
+            return false;
+    }
+}
+
+}
+
+bool check_xnn_node_support(CallOperatorNode& node, Graph& graph) {
+    if (!check_xnn_op_support(node.op)) {
+        return false;
+    }
+
+    for (auto& arg : node.args) {
+        if (arg.is_null()) continue;
+        const auto& tensor_spec = graph.get_tensor_spec(arg);
+
+        if (!check_xnn_dtype_support(tensor_spec.dtype)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+}

--- a/backends/xnnpack/runtime/plan/xnn_support.h
+++ b/backends/xnnpack/runtime/plan/xnn_support.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <executorch/backends/xnnpack/runtime/graph/graph.h>
+
+namespace executorch::backends::xnnpack::plan {
+
+bool check_xnn_node_support(graph::CallOperatorNode& node, graph::Graph& graph);
+
+}

--- a/backends/xnnpack/targets.bzl
+++ b/backends/xnnpack/targets.bzl
@@ -38,6 +38,12 @@ def define_common_targets():
             srcs = XNNPACK_BACKEND_BUCK_SRCS,
             headers = native.glob([
                 "runtime/*.h",
+                "runtime/core/*.h",
+                "runtime/executor/*.h",
+                "runtime/graph/*.h",
+                "runtime/kernels/**/*.h",
+                "runtime/operators/*.h",
+                "runtime/plan/*.h",
                 "runtime/profiling/*.h",
             ]),
             visibility = ["PUBLIC"],

--- a/backends/xnnpack/test/CMakeLists.txt
+++ b/backends/xnnpack/test/CMakeLists.txt
@@ -40,3 +40,49 @@ target_include_directories(
           ${EXECUTORCH_ROOT}/backends/xnnpack/third-party/cpuinfo/include
           ${EXECUTORCH_ROOT}/backends/xnnpack/third-party/pthreadpool/include
 )
+
+# Graph runtime unit tests.
+set(_graph_runtime_test_srcs
+    runtime/test_graph_builder.cpp
+    runtime/test_partition.cpp
+    runtime/test_schedule.cpp
+    runtime/test_shape_env.cpp
+    runtime/test_quant_params.cpp
+)
+
+et_cxx_test(
+  backends_xnnpack_graph_runtime_test
+  SOURCES
+  ${_graph_runtime_test_srcs}
+  EXTRA_LIBS
+  xnnpack_backend
+  XNNPACK
+  pthreadpool
+  cpuinfo
+  xnnpack-microkernels-prod
+)
+target_include_directories(
+  backends_xnnpack_graph_runtime_test
+  PRIVATE ${EXECUTORCH_ROOT}/backends/xnnpack/third-party/XNNPACK/include
+          ${EXECUTORCH_ROOT}/backends/xnnpack/third-party/cpuinfo/include
+          ${EXECUTORCH_ROOT}/backends/xnnpack/third-party/pthreadpool/include
+)
+
+# Graph runtime E2E tests (requires XNNPACK runtime).
+et_cxx_test(
+  backends_xnnpack_graph_e2e_test
+  SOURCES
+  runtime/test_e2e.cpp
+  EXTRA_LIBS
+  xnnpack_backend
+  XNNPACK
+  pthreadpool
+  cpuinfo
+  xnnpack-microkernels-prod
+)
+target_include_directories(
+  backends_xnnpack_graph_e2e_test
+  PRIVATE ${EXECUTORCH_ROOT}/backends/xnnpack/third-party/XNNPACK/include
+          ${EXECUTORCH_ROOT}/backends/xnnpack/third-party/cpuinfo/include
+          ${EXECUTORCH_ROOT}/backends/xnnpack/third-party/pthreadpool/include
+)

--- a/backends/xnnpack/test/runtime/test_e2e.cpp
+++ b/backends/xnnpack/test/runtime/test_e2e.cpp
@@ -1,0 +1,757 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <cstring>
+#include <memory>
+
+#include <executorch/backends/xnnpack/runtime/core/quant_params.h>
+#include <executorch/backends/xnnpack/runtime/core/tensor.h>
+#include <executorch/backends/xnnpack/runtime/executor/executor.h>
+#include <executorch/backends/xnnpack/runtime/graph/graph_builder.h>
+
+using namespace executorch::backends::xnnpack::core;
+using namespace executorch::backends::xnnpack::executor;
+using namespace executorch::backends::xnnpack::graph;
+
+TEST(TestE2E, add) {
+    // Build graph: output = input_a + input_b
+    // Shape: [1, 4] float32, static sizes.
+    auto builder = GraphBuilder();
+
+    auto spec = TensorSpec {
+        .dtype = DType::Float32,
+        .sizes = { DimSizeSpec::constant(1), DimSizeSpec::constant(4) }
+    };
+
+    auto a = builder.createInput(spec);
+    auto b = builder.createInput(spec);
+    auto add = builder.createOperator(Operator::Add, spec, a, b);
+    builder.createOutput(add);
+
+    auto graph = builder.build();
+    auto executor = Executor::build(graph);
+
+    // Create input tensors.
+    Tensor ta;
+    ta.dtype = DType::Float32;
+    ta.sizes = {1, 4};
+    ta.storage = Storage::create_owned(4 * sizeof(float));
+    float* da = ta.data_mut<float>();
+    da[0] = 1.0f; da[1] = 2.0f; da[2] = 3.0f; da[3] = 4.0f;
+
+    Tensor tb;
+    tb.dtype = DType::Float32;
+    tb.sizes = {1, 4};
+    tb.storage = Storage::create_owned(4 * sizeof(float));
+    float* db = tb.data_mut<float>();
+    db[0] = 10.0f; db[1] = 20.0f; db[2] = 30.0f; db[3] = 40.0f;
+
+    std::vector<Tensor> inputs;
+    inputs.push_back(std::move(ta));
+    inputs.push_back(std::move(tb));
+
+    auto outputs = executor.run(inputs);
+
+    ASSERT_EQ(outputs.size(), 1);
+    ASSERT_EQ(outputs[0].sizes, (std::vector<uint64_t>{1, 4}));
+
+    auto* out = outputs[0].data_const<float>();
+    EXPECT_FLOAT_EQ(out[0], 11.0f);
+    EXPECT_FLOAT_EQ(out[1], 22.0f);
+    EXPECT_FLOAT_EQ(out[2], 33.0f);
+    EXPECT_FLOAT_EQ(out[3], 44.0f);
+}
+
+/*
+ * Helper: build and run a single binary op over two [1,n] float32 inputs.
+ * Returns the executor (owns the arena) and the output tensors (alias it).
+ */
+struct BinaryOpResult {
+    Executor executor;
+    std::vector<Tensor> outputs;
+};
+
+BinaryOpResult run_binary_op(Operator op, const float* a, const float* b, size_t n) {
+    auto builder = GraphBuilder();
+    auto spec = TensorSpec {
+        .dtype = DType::Float32,
+        .sizes = { DimSizeSpec::constant(1), DimSizeSpec::constant(static_cast<int64_t>(n)) }
+    };
+
+    auto ia = builder.createInput(spec);
+    auto ib = builder.createInput(spec);
+    auto out = builder.createOperator(op, spec, ia, ib);
+    builder.createOutput(out);
+
+    auto graph = builder.build();
+    auto executor = Executor::build(graph);
+
+    Tensor ta;
+    ta.dtype = DType::Float32;
+    ta.sizes = {1, static_cast<uint64_t>(n)};
+    ta.storage = Storage::create_owned(n * sizeof(float));
+    std::memcpy(ta.data_mut<float>(), a, n * sizeof(float));
+
+    Tensor tb;
+    tb.dtype = DType::Float32;
+    tb.sizes = {1, static_cast<uint64_t>(n)};
+    tb.storage = Storage::create_owned(n * sizeof(float));
+    std::memcpy(tb.data_mut<float>(), b, n * sizeof(float));
+
+    std::vector<Tensor> inputs;
+    inputs.push_back(std::move(ta));
+    inputs.push_back(std::move(tb));
+
+    auto outputs = executor.run(inputs);
+    return { std::move(executor), std::move(outputs) };
+}
+
+TEST(TestE2E, subtract) {
+    float a[] = {10, 20, 30, 40};
+    float b[] = {1, 2, 3, 4};
+    auto [executor, outputs] = run_binary_op(Operator::Subtract, a, b, 4);
+    auto* d = outputs[0].data_const<float>();
+    EXPECT_FLOAT_EQ(d[0], 9.0f);
+    EXPECT_FLOAT_EQ(d[1], 18.0f);
+    EXPECT_FLOAT_EQ(d[2], 27.0f);
+    EXPECT_FLOAT_EQ(d[3], 36.0f);
+}
+
+TEST(TestE2E, multiply) {
+    float a[] = {2, 3, 4, 5};
+    float b[] = {10, 20, 30, 40};
+    auto [executor, outputs] = run_binary_op(Operator::Multiply, a, b, 4);
+    auto* d = outputs[0].data_const<float>();
+    EXPECT_FLOAT_EQ(d[0], 20.0f);
+    EXPECT_FLOAT_EQ(d[1], 60.0f);
+    EXPECT_FLOAT_EQ(d[2], 120.0f);
+    EXPECT_FLOAT_EQ(d[3], 200.0f);
+}
+
+TEST(TestE2E, divide) {
+    float a[] = {10, 20, 30, 40};
+    float b[] = {2, 4, 5, 8};
+    auto [executor, outputs] = run_binary_op(Operator::Divide, a, b, 4);
+    auto* d = outputs[0].data_const<float>();
+    EXPECT_FLOAT_EQ(d[0], 5.0f);
+    EXPECT_FLOAT_EQ(d[1], 5.0f);
+    EXPECT_FLOAT_EQ(d[2], 6.0f);
+    EXPECT_FLOAT_EQ(d[3], 5.0f);
+}
+
+TEST(TestE2E, maximum) {
+    float a[] = {1, 20, 3, 40};
+    float b[] = {10, 2, 30, 4};
+    auto [executor, outputs] = run_binary_op(Operator::Maximum, a, b, 4);
+    auto* d = outputs[0].data_const<float>();
+    EXPECT_FLOAT_EQ(d[0], 10.0f);
+    EXPECT_FLOAT_EQ(d[1], 20.0f);
+    EXPECT_FLOAT_EQ(d[2], 30.0f);
+    EXPECT_FLOAT_EQ(d[3], 40.0f);
+}
+
+TEST(TestE2E, minimum) {
+    float a[] = {1, 20, 3, 40};
+    float b[] = {10, 2, 30, 4};
+    auto [executor, outputs] = run_binary_op(Operator::Minimum, a, b, 4);
+    auto* d = outputs[0].data_const<float>();
+    EXPECT_FLOAT_EQ(d[0], 1.0f);
+    EXPECT_FLOAT_EQ(d[1], 2.0f);
+    EXPECT_FLOAT_EQ(d[2], 3.0f);
+    EXPECT_FLOAT_EQ(d[3], 4.0f);
+}
+
+TEST(TestE2E, copysign) {
+    float a[] = {5, -5, 5, -5};
+    float b[] = {1, -1, -1, 1};
+    auto [executor, outputs] = run_binary_op(Operator::CopySign, a, b, 4);
+    auto* d = outputs[0].data_const<float>();
+    EXPECT_FLOAT_EQ(d[0], 5.0f);
+    EXPECT_FLOAT_EQ(d[1], -5.0f);
+    EXPECT_FLOAT_EQ(d[2], -5.0f);
+    EXPECT_FLOAT_EQ(d[3], 5.0f);
+}
+
+TEST(TestE2E, squared_difference) {
+    float a[] = {5, 10, 3, 8};
+    float b[] = {2, 7, 1, 4};
+    auto [executor, outputs] = run_binary_op(Operator::SquaredDifference, a, b, 4);
+    auto* d = outputs[0].data_const<float>();
+    EXPECT_FLOAT_EQ(d[0], 9.0f);
+    EXPECT_FLOAT_EQ(d[1], 9.0f);
+    EXPECT_FLOAT_EQ(d[2], 4.0f);
+    EXPECT_FLOAT_EQ(d[3], 16.0f);
+}
+
+TEST(TestE2E, prelu) {
+    float a[] = {1, -2, 3, -4};
+    float b[] = {0.5f, 0.5f, 0.5f, 0.5f};
+    auto [executor, outputs] = run_binary_op(Operator::PReLU, a, b, 4);
+    auto* d = outputs[0].data_const<float>();
+    EXPECT_FLOAT_EQ(d[0], 1.0f);
+    EXPECT_FLOAT_EQ(d[1], -1.0f);
+    EXPECT_FLOAT_EQ(d[2], 3.0f);
+    EXPECT_FLOAT_EQ(d[3], -2.0f);
+}
+
+TEST(TestE2E, add_dynamic_shape) {
+    // Build graph: output = A + B with shape [1, s0] (dynamic second dim).
+    auto builder = GraphBuilder();
+    auto s0 = builder.createSymInt();
+
+    auto spec = TensorSpec {
+        .dtype = DType::Float32,
+        .sizes = { DimSizeSpec::constant(1), DimSizeSpec::sym(s0.node) }
+    };
+
+    auto a = builder.createInput(spec);
+    auto b = builder.createInput(spec);
+    auto add = builder.createOperator(Operator::Add, spec, a, b);
+    builder.createOutput(add);
+
+    auto graph = builder.build();
+    auto executor = Executor::build(graph);
+
+    // First run: n=4
+    {
+        float da[] = {1, 2, 3, 4};
+        float db[] = {10, 20, 30, 40};
+
+        Tensor ta;
+        ta.dtype = DType::Float32;
+        ta.sizes = {1, 4};
+        ta.storage = Storage::create_owned(4 * sizeof(float));
+        std::memcpy(ta.data_mut<float>(), da, sizeof(da));
+
+        Tensor tb;
+        tb.dtype = DType::Float32;
+        tb.sizes = {1, 4};
+        tb.storage = Storage::create_owned(4 * sizeof(float));
+        std::memcpy(tb.data_mut<float>(), db, sizeof(db));
+
+        std::vector<Tensor> inputs;
+        inputs.push_back(std::move(ta));
+        inputs.push_back(std::move(tb));
+
+        auto outputs = executor.run(inputs);
+        ASSERT_EQ(outputs.size(), 1);
+        ASSERT_EQ(outputs[0].sizes, (std::vector<uint64_t>{1, 4}));
+        auto* out = outputs[0].data_const<float>();
+        EXPECT_FLOAT_EQ(out[0], 11.0f);
+        EXPECT_FLOAT_EQ(out[1], 22.0f);
+        EXPECT_FLOAT_EQ(out[2], 33.0f);
+        EXPECT_FLOAT_EQ(out[3], 44.0f);
+    }
+
+    // Second run: n=2 (different dynamic size, same executor)
+    {
+        float da[] = {100, 200};
+        float db[] = {5, 6};
+
+        Tensor ta;
+        ta.dtype = DType::Float32;
+        ta.sizes = {1, 2};
+        ta.storage = Storage::create_owned(2 * sizeof(float));
+        std::memcpy(ta.data_mut<float>(), da, sizeof(da));
+
+        Tensor tb;
+        tb.dtype = DType::Float32;
+        tb.sizes = {1, 2};
+        tb.storage = Storage::create_owned(2 * sizeof(float));
+        std::memcpy(tb.data_mut<float>(), db, sizeof(db));
+
+        std::vector<Tensor> inputs;
+        inputs.push_back(std::move(ta));
+        inputs.push_back(std::move(tb));
+
+        auto outputs = executor.run(inputs);
+        ASSERT_EQ(outputs.size(), 1);
+        ASSERT_EQ(outputs[0].sizes, (std::vector<uint64_t>{1, 2}));
+        auto* out = outputs[0].data_const<float>();
+        EXPECT_FLOAT_EQ(out[0], 105.0f);
+        EXPECT_FLOAT_EQ(out[1], 206.0f);
+    }
+}
+
+TEST(TestE2E, three_adds_two_outputs) {
+    auto builder = GraphBuilder();
+
+    auto spec = TensorSpec {
+        .dtype = DType::Float32,
+        .sizes = { DimSizeSpec::constant(1), DimSizeSpec::constant(4) }
+    };
+
+    auto a = builder.createInput(spec);
+    auto b = builder.createInput(spec);
+    auto c = builder.createInput(spec);
+    auto add0 = builder.createOperator(Operator::Add, spec, a, b);
+    auto add1 = builder.createOperator(Operator::Add, spec, add0, c);
+    auto add2 = builder.createOperator(Operator::Add, spec, add0, add1);
+    builder.createOutput(add0);
+    builder.createOutput(add2);
+
+    auto graph = builder.build();
+    auto executor = Executor::build(graph);
+
+    Tensor ta;
+    ta.dtype = DType::Float32;
+    ta.sizes = {1, 4};
+    ta.storage = Storage::create_owned(4 * sizeof(float));
+    float* da = ta.data_mut<float>();
+    da[0] = 1.0f; da[1] = 2.0f; da[2] = 3.0f; da[3] = 4.0f;
+
+    Tensor tb;
+    tb.dtype = DType::Float32;
+    tb.sizes = {1, 4};
+    tb.storage = Storage::create_owned(4 * sizeof(float));
+    float* db = tb.data_mut<float>();
+    db[0] = 10.0f; db[1] = 20.0f; db[2] = 30.0f; db[3] = 40.0f;
+
+    Tensor tc;
+    tc.dtype = DType::Float32;
+    tc.sizes = {1, 4};
+    tc.storage = Storage::create_owned(4 * sizeof(float));
+    float* dc = tc.data_mut<float>();
+    dc[0] = 100.0f; dc[1] = 200.0f; dc[2] = 300.0f; dc[3] = 400.0f;
+
+    std::vector<Tensor> inputs;
+    inputs.push_back(std::move(ta));
+    inputs.push_back(std::move(tb));
+    inputs.push_back(std::move(tc));
+
+    auto outputs = executor.run(inputs);
+
+    // Add0 = A + B = {11, 22, 33, 44}
+    ASSERT_EQ(outputs.size(), 2);
+    ASSERT_EQ(outputs[0].sizes, (std::vector<uint64_t>{1, 4}));
+    auto* out0 = outputs[0].data_const<float>();
+    EXPECT_FLOAT_EQ(out0[0], 11.0f);
+    EXPECT_FLOAT_EQ(out0[1], 22.0f);
+    EXPECT_FLOAT_EQ(out0[2], 33.0f);
+    EXPECT_FLOAT_EQ(out0[3], 44.0f);
+
+    // Add1 = Add0 + C = {111, 222, 333, 444}
+    // Add2 = Add0 + Add1 = {122, 244, 366, 488}
+    ASSERT_EQ(outputs[1].sizes, (std::vector<uint64_t>{1, 4}));
+    auto* out1 = outputs[1].data_const<float>();
+    EXPECT_FLOAT_EQ(out1[0], 122.0f);
+    EXPECT_FLOAT_EQ(out1[1], 244.0f);
+    EXPECT_FLOAT_EQ(out1[2], 366.0f);
+    EXPECT_FLOAT_EQ(out1[3], 488.0f);
+}
+
+TEST(TestE2E, linear) {
+    auto builder = GraphBuilder();
+
+    auto input_spec = TensorSpec {
+        .dtype = DType::Float32,
+        .sizes = { DimSizeSpec::constant(1), DimSizeSpec::constant(3) }
+    };
+    auto output_spec = TensorSpec {
+        .dtype = DType::Float32,
+        .sizes = { DimSizeSpec::constant(1), DimSizeSpec::constant(2) }
+    };
+
+    auto input = builder.createInput(input_spec);
+
+    auto filter_tensor = std::make_shared<Tensor>();
+    filter_tensor->dtype = DType::Float32;
+    filter_tensor->sizes = {2, 3};
+    filter_tensor->storage = Storage::create_owned(6 * sizeof(float));
+    float* fw = filter_tensor->data_mut<float>();
+    fw[0] = 1; fw[1] = 0; fw[2] = 0;
+    fw[3] = 0; fw[4] = 1; fw[5] = 0;
+    auto filter = builder.createConstant(filter_tensor);
+
+    auto bias_tensor = std::make_shared<Tensor>();
+    bias_tensor->dtype = DType::Float32;
+    bias_tensor->sizes = {2};
+    bias_tensor->storage = Storage::create_owned(2 * sizeof(float));
+    float* bw = bias_tensor->data_mut<float>();
+    bw[0] = 10; bw[1] = 20;
+    auto bias = builder.createConstant(bias_tensor);
+
+    auto out = builder.createOperator(Operator::Linear, output_spec, {input, filter, bias});
+    builder.createOutput(out);
+
+    auto graph = builder.build();
+    auto executor = Executor::build(graph);
+
+    Tensor ti;
+    ti.dtype = DType::Float32;
+    ti.sizes = {1, 3};
+    ti.storage = Storage::create_owned(3 * sizeof(float));
+    float* di = ti.data_mut<float>();
+    di[0] = 1; di[1] = 2; di[2] = 3;
+
+    std::vector<Tensor> inputs;
+    inputs.push_back(std::move(ti));
+
+    auto outputs = executor.run(inputs);
+
+    ASSERT_EQ(outputs.size(), 1);
+    ASSERT_EQ(outputs[0].sizes, (std::vector<uint64_t>{1, 2}));
+    auto* d = outputs[0].data_const<float>();
+    EXPECT_FLOAT_EQ(d[0], 11.0f);  // 1*1+2*0+3*0+10
+    EXPECT_FLOAT_EQ(d[1], 22.0f);  // 1*0+2*1+3*0+20
+}
+
+TEST(TestE2E, linear_no_bias) {
+    auto builder = GraphBuilder();
+
+    auto input_spec = TensorSpec {
+        .dtype = DType::Float32,
+        .sizes = { DimSizeSpec::constant(1), DimSizeSpec::constant(3) }
+    };
+    auto output_spec = TensorSpec {
+        .dtype = DType::Float32,
+        .sizes = { DimSizeSpec::constant(1), DimSizeSpec::constant(2) }
+    };
+
+    auto input = builder.createInput(input_spec);
+
+    auto filter_tensor = std::make_shared<Tensor>();
+    filter_tensor->dtype = DType::Float32;
+    filter_tensor->sizes = {2, 3};
+    filter_tensor->storage = Storage::create_owned(6 * sizeof(float));
+    float* fw = filter_tensor->data_mut<float>();
+    fw[0] = 1; fw[1] = 0; fw[2] = 0;
+    fw[3] = 0; fw[4] = 1; fw[5] = 0;
+    auto filter = builder.createConstant(filter_tensor);
+
+    auto out = builder.createOperator(Operator::Linear, output_spec,
+        {input, filter, ValueHandle::null()});
+    builder.createOutput(out);
+
+    auto graph = builder.build();
+    auto executor = Executor::build(graph);
+
+    Tensor ti;
+    ti.dtype = DType::Float32;
+    ti.sizes = {1, 3};
+    ti.storage = Storage::create_owned(3 * sizeof(float));
+    float* di = ti.data_mut<float>();
+    di[0] = 1; di[1] = 2; di[2] = 3;
+
+    std::vector<Tensor> inputs;
+    inputs.push_back(std::move(ti));
+
+    auto outputs = executor.run(inputs);
+
+    ASSERT_EQ(outputs.size(), 1);
+    ASSERT_EQ(outputs[0].sizes, (std::vector<uint64_t>{1, 2}));
+    auto* d = outputs[0].data_const<float>();
+    EXPECT_FLOAT_EQ(d[0], 1.0f);   // 1*1+2*0+3*0
+    EXPECT_FLOAT_EQ(d[1], 2.0f);   // 1*0+2*1+3*0
+}
+
+TEST(TestE2E, linear_qint8_static_dequantized) {
+    auto builder = GraphBuilder();
+
+    auto input_spec = TensorSpec {
+        .dtype = DType::QInt8Sym,
+        .sizes = { DimSizeSpec::constant(1), DimSizeSpec::constant(3) },
+        .quant_params = qint8_per_tensor_sym(1.0f),
+    };
+    auto quant_output_spec = TensorSpec {
+        .dtype = DType::QInt8Sym,
+        .sizes = { DimSizeSpec::constant(1), DimSizeSpec::constant(2) },
+        .quant_params = qint8_per_tensor_sym(1.0f),
+    };
+    auto float_output_spec = TensorSpec {
+        .dtype = DType::Float32,
+        .sizes = { DimSizeSpec::constant(1), DimSizeSpec::constant(2) },
+    };
+
+    auto input = builder.createInput(input_spec);
+
+    auto filter_tensor = std::make_shared<Tensor>();
+    filter_tensor->dtype = DType::QInt8Sym;
+    filter_tensor->sizes = {2, 3};
+    filter_tensor->storage = Storage::create_owned(6);
+    auto* fw = filter_tensor->data_mut<int8_t>();
+    fw[0] = 1; fw[1] = 0; fw[2] = 0;
+    fw[3] = 0; fw[4] = 1; fw[5] = 0;
+    filter_tensor->aux_storage.push_back(Storage::create_owned(2 * sizeof(float)));
+    auto* scales = static_cast<float*>(filter_tensor->aux_storage[0].data);
+    scales[0] = 1.0f; scales[1] = 1.0f;
+    auto filter = builder.createConstant(filter_tensor, qint8_per_channel_sym(0));
+
+    auto linear_out = builder.createOperator(Operator::Linear, quant_output_spec,
+        {input, filter, ValueHandle::null()});
+    auto dequant_out = builder.createOperator(Operator::Dequantize, float_output_spec,
+        {linear_out});
+    builder.createOutput(dequant_out);
+
+    auto graph = builder.build();
+    auto executor = Executor::build(graph);
+
+    Tensor ti;
+    ti.dtype = DType::QInt8Sym;
+    ti.sizes = {1, 3};
+    ti.storage = Storage::create_owned(3);
+    auto* di = ti.data_mut<int8_t>();
+    di[0] = 1; di[1] = 2; di[2] = 3;
+
+    std::vector<Tensor> inputs;
+    inputs.push_back(std::move(ti));
+
+    auto outputs = executor.run(inputs);
+
+    ASSERT_EQ(outputs.size(), 1);
+    ASSERT_EQ(outputs[0].sizes, (std::vector<uint64_t>{1, 2}));
+    auto* d = outputs[0].data_const<float>();
+    EXPECT_FLOAT_EQ(d[0], 1.0f);
+    EXPECT_FLOAT_EQ(d[1], 2.0f);
+}
+
+TEST(TestE2E, linear_qint8_static_requantized) {
+    auto builder = GraphBuilder();
+
+    auto input_spec = TensorSpec {
+        .dtype = DType::QInt8Sym,
+        .sizes = { DimSizeSpec::constant(1), DimSizeSpec::constant(3) },
+        .quant_params = qint8_per_tensor_sym(1.0f),
+    };
+    auto output_spec = TensorSpec {
+        .dtype = DType::QInt8Sym,
+        .sizes = { DimSizeSpec::constant(1), DimSizeSpec::constant(2) },
+        .quant_params = qint8_per_tensor_sym(1.0f),
+    };
+
+    auto input = builder.createInput(input_spec);
+
+    auto filter_tensor = std::make_shared<Tensor>();
+    filter_tensor->dtype = DType::QInt8Sym;
+    filter_tensor->sizes = {2, 3};
+    filter_tensor->storage = Storage::create_owned(6);
+    auto* fw = filter_tensor->data_mut<int8_t>();
+    fw[0] = 1; fw[1] = 0; fw[2] = 0;
+    fw[3] = 0; fw[4] = 1; fw[5] = 0;
+    filter_tensor->aux_storage.push_back(Storage::create_owned(2 * sizeof(float)));
+    auto* scales = static_cast<float*>(filter_tensor->aux_storage[0].data);
+    scales[0] = 1.0f; scales[1] = 1.0f;
+    auto filter = builder.createConstant(filter_tensor, qint8_per_channel_sym(0));
+
+    auto out = builder.createOperator(Operator::Linear, output_spec,
+        {input, filter, ValueHandle::null()});
+    builder.createOutput(out);
+
+    auto graph = builder.build();
+    auto executor = Executor::build(graph);
+
+    Tensor ti;
+    ti.dtype = DType::QInt8Sym;
+    ti.sizes = {1, 3};
+    ti.storage = Storage::create_owned(3);
+    auto* di = ti.data_mut<int8_t>();
+    di[0] = 1; di[1] = 2; di[2] = 3;
+
+    std::vector<Tensor> inputs;
+    inputs.push_back(std::move(ti));
+
+    auto outputs = executor.run(inputs);
+
+    ASSERT_EQ(outputs.size(), 1);
+    ASSERT_EQ(outputs[0].sizes, (std::vector<uint64_t>{1, 2}));
+    auto* d = outputs[0].data_const<int8_t>();
+    EXPECT_EQ(d[0], 1);
+    EXPECT_EQ(d[1], 2);
+}
+
+TEST(TestE2E, dequantize_quint8) {
+    auto builder = GraphBuilder();
+
+    auto input_spec = TensorSpec {
+        .dtype = DType::QUInt8Asym,
+        .sizes = { DimSizeSpec::constant(1), DimSizeSpec::constant(4) },
+        .quant_params = quint8_per_tensor_asym(0.5f, 1),
+    };
+    auto output_spec = TensorSpec {
+        .dtype = DType::Float32,
+        .sizes = { DimSizeSpec::constant(1), DimSizeSpec::constant(4) },
+    };
+
+    auto input = builder.createInput(input_spec);
+    auto out = builder.createOperator(Operator::Dequantize, output_spec, {input});
+    builder.createOutput(out);
+
+    auto graph = builder.build();
+    auto executor = Executor::build(graph);
+
+    Tensor ti;
+    ti.dtype = DType::QUInt8Asym;
+    ti.sizes = {1, 4};
+    ti.storage = Storage::create_owned(4);
+    auto* di = ti.data_mut<uint8_t>();
+    di[0] = 0; di[1] = 1; di[2] = 2; di[3] = 3;
+
+    std::vector<Tensor> inputs;
+    inputs.push_back(std::move(ti));
+
+    auto outputs = executor.run(inputs);
+
+    ASSERT_EQ(outputs.size(), 1);
+    ASSERT_EQ(outputs[0].sizes, (std::vector<uint64_t>{1, 4}));
+    auto* d = outputs[0].data_const<float>();
+    EXPECT_FLOAT_EQ(d[0], -0.5f);
+    EXPECT_FLOAT_EQ(d[1], 0.0f);
+    EXPECT_FLOAT_EQ(d[2], 0.5f);
+    EXPECT_FLOAT_EQ(d[3], 1.0f);
+}
+
+TEST(TestE2E, quantize_quint8) {
+    auto builder = GraphBuilder();
+
+    auto input_spec = TensorSpec {
+        .dtype = DType::Float32,
+        .sizes = { DimSizeSpec::constant(1), DimSizeSpec::constant(4) },
+    };
+    auto output_spec = TensorSpec {
+        .dtype = DType::QUInt8Asym,
+        .sizes = { DimSizeSpec::constant(1), DimSizeSpec::constant(4) },
+        .quant_params = quint8_per_tensor_asym(0.5f, 1),
+    };
+
+    auto input = builder.createInput(input_spec);
+    auto out = builder.createOperator(Operator::Quantize, output_spec, {input});
+    builder.createOutput(out);
+
+    auto graph = builder.build();
+    auto executor = Executor::build(graph);
+
+    Tensor ti;
+    ti.dtype = DType::Float32;
+    ti.sizes = {1, 4};
+    ti.storage = Storage::create_owned(4 * sizeof(float));
+    auto* di = ti.data_mut<float>();
+    di[0] = -0.5f; di[1] = 0.0f; di[2] = 0.5f; di[3] = 1.0f;
+
+    std::vector<Tensor> inputs;
+    inputs.push_back(std::move(ti));
+
+    auto outputs = executor.run(inputs);
+
+    ASSERT_EQ(outputs.size(), 1);
+    ASSERT_EQ(outputs[0].sizes, (std::vector<uint64_t>{1, 4}));
+    auto* d = outputs[0].data_const<uint8_t>();
+    EXPECT_EQ(d[0], 0);
+    EXPECT_EQ(d[1], 1);
+    EXPECT_EQ(d[2], 2);
+    EXPECT_EQ(d[3], 3);
+}
+
+// --- Layer norm ---
+
+TEST(TestE2E, layer_norm_no_weight_bias) {
+    auto builder = GraphBuilder();
+
+    auto spec = TensorSpec {
+        .dtype = DType::Float32,
+        .sizes = { DimSizeSpec::constant(2), DimSizeSpec::constant(4) }
+    };
+
+    auto input = builder.createInput(spec);
+    auto out = builder.createOperator(
+        Operator::LayerNorm, spec,
+        {input, ValueHandle::null(), ValueHandle::null()},
+        {int64_t{1}, 1e-5});
+    builder.createOutput(out);
+
+    auto graph = builder.build();
+    auto executor = Executor::build(graph);
+
+    Tensor ti;
+    ti.dtype = DType::Float32;
+    ti.sizes = {2, 4};
+    ti.storage = Storage::create_owned(8 * sizeof(float));
+    float* di = ti.data_mut<float>();
+    di[0] = 1; di[1] = 2; di[2] = 3; di[3] = 4;
+    di[4] = 2; di[5] = 4; di[6] = 6; di[7] = 8;
+
+    std::vector<Tensor> inputs;
+    inputs.push_back(std::move(ti));
+
+    auto outputs = executor.run(inputs);
+
+    ASSERT_EQ(outputs.size(), 1);
+    ASSERT_EQ(outputs[0].sizes, (std::vector<uint64_t>{2, 4}));
+    auto* d = outputs[0].data_const<float>();
+
+    // Row 0: {1,2,3,4}, mean=2.5, var=1.25
+    float inv_std0 = 1.0f / std::sqrt(1.25f + 1e-5f);
+    EXPECT_NEAR(d[0], (1 - 2.5f) * inv_std0, 1e-5f);
+    EXPECT_NEAR(d[1], (2 - 2.5f) * inv_std0, 1e-5f);
+    EXPECT_NEAR(d[2], (3 - 2.5f) * inv_std0, 1e-5f);
+    EXPECT_NEAR(d[3], (4 - 2.5f) * inv_std0, 1e-5f);
+
+    // Row 1: {2,4,6,8}, mean=5, var=5
+    float inv_std1 = 1.0f / std::sqrt(5.0f + 1e-5f);
+    EXPECT_NEAR(d[4], (2 - 5.0f) * inv_std1, 1e-5f);
+    EXPECT_NEAR(d[5], (4 - 5.0f) * inv_std1, 1e-5f);
+    EXPECT_NEAR(d[6], (6 - 5.0f) * inv_std1, 1e-5f);
+    EXPECT_NEAR(d[7], (8 - 5.0f) * inv_std1, 1e-5f);
+}
+
+TEST(TestE2E, layer_norm_with_affine) {
+    auto builder = GraphBuilder();
+
+    auto spec = TensorSpec {
+        .dtype = DType::Float32,
+        .sizes = { DimSizeSpec::constant(1), DimSizeSpec::constant(4) }
+    };
+    auto weight_spec = TensorSpec {
+        .dtype = DType::Float32,
+        .sizes = { DimSizeSpec::constant(4) }
+    };
+
+    auto input = builder.createInput(spec);
+
+    auto weight_tensor = std::make_shared<Tensor>();
+    weight_tensor->dtype = DType::Float32;
+    weight_tensor->sizes = {4};
+    weight_tensor->storage = Storage::create_owned(4 * sizeof(float));
+    float* ww = weight_tensor->data_mut<float>();
+    ww[0] = 2.0f; ww[1] = 2.0f; ww[2] = 2.0f; ww[3] = 2.0f;
+    auto weight = builder.createConstant(weight_tensor);
+
+    auto bias_tensor = std::make_shared<Tensor>();
+    bias_tensor->dtype = DType::Float32;
+    bias_tensor->sizes = {4};
+    bias_tensor->storage = Storage::create_owned(4 * sizeof(float));
+    float* bw = bias_tensor->data_mut<float>();
+    bw[0] = 1.0f; bw[1] = 1.0f; bw[2] = 1.0f; bw[3] = 1.0f;
+    auto bias = builder.createConstant(bias_tensor);
+
+    auto out = builder.createOperator(
+        Operator::LayerNorm, spec,
+        {input, weight, bias},
+        {int64_t{1}, 1e-5});
+    builder.createOutput(out);
+
+    auto graph = builder.build();
+    auto executor = Executor::build(graph);
+
+    Tensor ti;
+    ti.dtype = DType::Float32;
+    ti.sizes = {1, 4};
+    ti.storage = Storage::create_owned(4 * sizeof(float));
+    float* di = ti.data_mut<float>();
+    di[0] = 1; di[1] = 2; di[2] = 3; di[3] = 4;
+
+    std::vector<Tensor> inputs;
+    inputs.push_back(std::move(ti));
+
+    auto outputs = executor.run(inputs);
+
+    ASSERT_EQ(outputs.size(), 1);
+    auto* d = outputs[0].data_const<float>();
+
+    // mean=2.5, var=1.25, inv_std = 1/sqrt(1.25+eps)
+    // result = normalized * weight + bias = normalized * 2 + 1
+    float inv_std = 1.0f / std::sqrt(1.25f + 1e-5f);
+    EXPECT_NEAR(d[0], (1 - 2.5f) * inv_std * 2.0f + 1.0f, 1e-5f);
+    EXPECT_NEAR(d[1], (2 - 2.5f) * inv_std * 2.0f + 1.0f, 1e-5f);
+    EXPECT_NEAR(d[2], (3 - 2.5f) * inv_std * 2.0f + 1.0f, 1e-5f);
+    EXPECT_NEAR(d[3], (4 - 2.5f) * inv_std * 2.0f + 1.0f, 1e-5f);
+}

--- a/backends/xnnpack/test/runtime/test_graph_builder.cpp
+++ b/backends/xnnpack/test/runtime/test_graph_builder.cpp
@@ -1,0 +1,41 @@
+#include <gtest/gtest.h>
+
+#include <executorch/backends/xnnpack/runtime/graph/graph_builder.h>
+
+using namespace executorch::backends::xnnpack::core;
+using namespace executorch::backends::xnnpack::graph;
+
+TEST(TestGraphBuilder, add) {
+    // A simple tests which constructs a graph with one input tensor,
+    // one add operator, and one output tensor.
+    auto builder = GraphBuilder();
+
+    auto tensor_spec = TensorSpec {
+        .dtype = DType::Float32,
+        .sizes = { DimSizeSpec::constant(1), DimSizeSpec::constant(10) }
+    };
+
+    auto input_a = builder.createInput(tensor_spec);
+    auto input_b = builder.createInput(tensor_spec);
+    auto add = builder.createOperator(Operator::Add, tensor_spec, input_a, input_b);
+    auto output = builder.createOutput(add);
+
+    auto graph = builder.build();
+
+    // Verify the graph.
+    EXPECT_EQ(graph.input_specs.size(), 2);
+    EXPECT_EQ(graph.input_specs[0], tensor_spec);
+    EXPECT_EQ(graph.input_specs[1], tensor_spec);
+
+    EXPECT_EQ(graph.nodes.size(), 3);
+    EXPECT_EQ(std::get<InputNode>(graph.nodes[0].value), InputNode { 0 });
+    EXPECT_EQ(std::get<InputNode>(graph.nodes[1].value), InputNode { 1 });
+    EXPECT_EQ(std::get<CallOperatorNode>(graph.nodes[2].value), (CallOperatorNode {
+        .args = { ValueHandle{0}, ValueHandle{1} },
+        .op = Operator::Add,
+        .output_specs = tensor_spec
+    }));
+
+    EXPECT_EQ(graph.outputs.size(), 1);
+    EXPECT_EQ(graph.outputs[0], (ValueHandle{2}));
+}

--- a/backends/xnnpack/test/runtime/test_partition.cpp
+++ b/backends/xnnpack/test/runtime/test_partition.cpp
@@ -1,0 +1,376 @@
+#include <gtest/gtest.h>
+
+#include <executorch/backends/xnnpack/runtime/graph/graph_builder.h>
+#include <executorch/backends/xnnpack/runtime/plan/partition.h>
+
+using namespace executorch::backends::xnnpack::core;
+using namespace executorch::backends::xnnpack::graph;
+using namespace executorch::backends::xnnpack::plan;
+
+TEST(TestPartition, single_node) {
+    auto builder = GraphBuilder();
+
+    auto spec = TensorSpec {
+        .dtype = DType::Float32,
+        .sizes = { DimSizeSpec::constant(1), DimSizeSpec::constant(10) }
+    };
+
+    auto input_a = builder.createInput(spec);
+    auto input_b = builder.createInput(spec);
+    auto add = builder.createOperator(Operator::Add, spec, input_a, input_b);
+    builder.createOutput(add);
+
+    auto graph = builder.build();
+
+    // Pre-tag the add node for XNNPACK.
+    graph.nodes[add.node].flags |= NodeFlags::UseXnnpack;
+
+    graph.update_users();
+    auto partition_count = assign_partitions(graph);
+
+    // There should be exactly one partition.
+    EXPECT_EQ(partition_count, 1);
+
+    // The add node should be assigned to partition 1.
+    EXPECT_EQ(graph.nodes[add.node].tag, 1);
+
+    // Input nodes should not be assigned to any partition.
+    EXPECT_EQ(graph.nodes[input_a.node].tag, 0);
+    EXPECT_EQ(graph.nodes[input_b.node].tag, 0);
+}
+
+// Helper to set UseXnnpack on a node.
+static void set_xnnpack(Graph& graph, ValueHandle handle) {
+    graph.nodes[handle.node].flags |= NodeFlags::UseXnnpack;
+}
+
+TEST(TestPartition, sequential_all_delegated) {
+    // Build a chain: input_a, input_b -> add1 -> add2 -> add3 -> add4 -> output
+    auto builder = GraphBuilder();
+
+    auto spec = TensorSpec {
+        .dtype = DType::Float32,
+        .sizes = { DimSizeSpec::constant(1), DimSizeSpec::constant(10) }
+    };
+
+    auto input_a = builder.createInput(spec);
+    auto input_b = builder.createInput(spec);
+    auto add1 = builder.createOperator(Operator::Add, spec, input_a, input_b);
+    auto add2 = builder.createOperator(Operator::Add, spec, add1, input_b);
+    auto add3 = builder.createOperator(Operator::Add, spec, add2, input_b);
+    auto add4 = builder.createOperator(Operator::Add, spec, add3, input_b);
+    builder.createOutput(add4);
+
+    auto graph = builder.build();
+
+    set_xnnpack(graph, add1);
+    set_xnnpack(graph, add2);
+    set_xnnpack(graph, add3);
+    set_xnnpack(graph, add4);
+
+    graph.update_users();
+    auto partition_count = assign_partitions(graph);
+
+    // All delegated nodes should be in a single partition.
+    EXPECT_EQ(partition_count, 1);
+
+    EXPECT_EQ(graph.nodes[add1.node].tag, 1);
+    EXPECT_EQ(graph.nodes[add2.node].tag, 1);
+    EXPECT_EQ(graph.nodes[add3.node].tag, 1);
+    EXPECT_EQ(graph.nodes[add4.node].tag, 1);
+
+    // Input nodes should not be assigned to any partition.
+    EXPECT_EQ(graph.nodes[input_a.node].tag, 0);
+    EXPECT_EQ(graph.nodes[input_b.node].tag, 0);
+}
+
+TEST(TestPartition, sequential_alternating) {
+    // Chain: input_a, input_b -> add1 (D) -> add2 -> add3 (D) -> add4 -> output
+    // Delegated nodes are separated by undelegated nodes, so they can't be in
+    // the same partition without creating a cycle.
+    auto builder = GraphBuilder();
+
+    auto spec = TensorSpec {
+        .dtype = DType::Float32,
+        .sizes = { DimSizeSpec::constant(1), DimSizeSpec::constant(10) }
+    };
+
+    auto input_a = builder.createInput(spec);
+    auto input_b = builder.createInput(spec);
+    auto add1 = builder.createOperator(Operator::Add, spec, input_a, input_b);
+    auto add2 = builder.createOperator(Operator::Add, spec, add1, input_b);
+    auto add3 = builder.createOperator(Operator::Add, spec, add2, input_b);
+    auto add4 = builder.createOperator(Operator::Add, spec, add3, input_b);
+    builder.createOutput(add4);
+
+    auto graph = builder.build();
+
+    set_xnnpack(graph, add1);
+    set_xnnpack(graph, add3);
+
+    graph.update_users();
+    auto partition_count = assign_partitions(graph);
+
+    EXPECT_EQ(partition_count, 2);
+
+    // Each delegated node should be in a separate partition.
+    EXPECT_EQ(graph.nodes[add1.node].tag, 1);
+    EXPECT_EQ(graph.nodes[add3.node].tag, 2);
+
+    // Undelegated nodes should not be assigned.
+    EXPECT_EQ(graph.nodes[add2.node].tag, 0);
+    EXPECT_EQ(graph.nodes[add4.node].tag, 0);
+    EXPECT_EQ(graph.nodes[input_a.node].tag, 0);
+    EXPECT_EQ(graph.nodes[input_b.node].tag, 0);
+}
+
+TEST(TestPartition, diamond_skip_connection) {
+    auto builder = GraphBuilder();
+
+    auto spec = TensorSpec {
+        .dtype = DType::Float32,
+        .sizes = { DimSizeSpec::constant(1), DimSizeSpec::constant(10) }
+    };
+
+    auto input_a = builder.createInput(spec);
+    auto input_b = builder.createInput(spec);
+    auto add1 = builder.createOperator(Operator::Add, spec, input_a, input_b);
+    auto add2 = builder.createOperator(Operator::Add, spec, add1, input_b);
+    auto add3 = builder.createOperator(Operator::Add, spec, add1, input_b);
+    auto add4 = builder.createOperator(Operator::Add, spec, add2, input_b);
+    auto add5 = builder.createOperator(Operator::Add, spec, add3, input_b);
+    auto add6 = builder.createOperator(Operator::Add, spec, add4, add5);
+    builder.createOutput(add6);
+
+    auto graph = builder.build();
+
+    set_xnnpack(graph, add1);
+    // add2 is NOT delegated.
+    set_xnnpack(graph, add3);
+    set_xnnpack(graph, add4);
+    set_xnnpack(graph, add5);
+    set_xnnpack(graph, add6);
+
+    graph.update_users();
+    auto partition_count = assign_partitions(graph);
+
+    EXPECT_EQ(partition_count, 2);
+
+    // Partition 1: add1, add3, add5 (connected through delegated nodes only).
+    EXPECT_EQ(graph.nodes[add1.node].tag, 1);
+    EXPECT_EQ(graph.nodes[add3.node].tag, 1);
+    EXPECT_EQ(graph.nodes[add5.node].tag, 1);
+
+    // Partition 2: add4, add6 (add4 blocked from partition 1; add6 depends on add4).
+    EXPECT_EQ(graph.nodes[add4.node].tag, 2);
+    EXPECT_EQ(graph.nodes[add6.node].tag, 2);
+
+    // Non-delegated / inputs unassigned.
+    EXPECT_EQ(graph.nodes[add2.node].tag, 0);
+    EXPECT_EQ(graph.nodes[input_a.node].tag, 0);
+    EXPECT_EQ(graph.nodes[input_b.node].tag, 0);
+}
+
+TEST(TestPartition, converging_delegated) {
+    auto builder = GraphBuilder();
+
+    auto spec = TensorSpec {
+        .dtype = DType::Float32,
+        .sizes = { DimSizeSpec::constant(1), DimSizeSpec::constant(10) }
+    };
+
+    auto input_a = builder.createInput(spec);
+    auto input_b = builder.createInput(spec);
+    auto add1 = builder.createOperator(Operator::Add, spec, input_a, input_a);
+    auto add2 = builder.createOperator(Operator::Add, spec, input_b, input_b);
+    auto add3 = builder.createOperator(Operator::Add, spec, add1, input_a);
+    auto add_sink = builder.createOperator(Operator::Add, spec, add2, input_b);
+    auto add5 = builder.createOperator(Operator::Add, spec, add3, input_a);
+    auto add6 = builder.createOperator(Operator::Add, spec, add5, add2);
+    builder.createOutput(add6);
+    builder.createOutput(add_sink);
+
+    auto graph = builder.build();
+
+    set_xnnpack(graph, add1);
+    set_xnnpack(graph, add2);
+    set_xnnpack(graph, add3);
+    // add_sink is NOT delegated — makes add2 escape.
+    set_xnnpack(graph, add5);
+    set_xnnpack(graph, add6);
+
+    graph.update_users();
+    auto partition_count = assign_partitions(graph);
+
+    // All delegated nodes should be in one partition.
+    EXPECT_EQ(partition_count, 1);
+    EXPECT_EQ(graph.nodes[add1.node].tag, 1);
+    EXPECT_EQ(graph.nodes[add2.node].tag, 1);
+    EXPECT_EQ(graph.nodes[add3.node].tag, 1);
+    EXPECT_EQ(graph.nodes[add5.node].tag, 1);
+    EXPECT_EQ(graph.nodes[add6.node].tag, 1);
+    EXPECT_EQ(graph.nodes[add_sink.node].tag, 0);
+}
+
+// --- fuse_partitions tests ---
+
+TEST(TestFusePartitions, single_node) {
+    auto builder = GraphBuilder();
+
+    auto spec = TensorSpec {
+        .dtype = DType::Float32,
+        .sizes = { DimSizeSpec::constant(1), DimSizeSpec::constant(10) }
+    };
+
+    auto input_a = builder.createInput(spec);
+    auto input_b = builder.createInput(spec);
+    auto add = builder.createOperator(Operator::Add, spec, input_a, input_b);
+    builder.createOutput(add);
+
+    auto graph = builder.build();
+
+    graph.nodes[add.node].flags |= NodeFlags::UseXnnpack;
+
+    graph.update_users();
+    auto partition_count = assign_partitions(graph);
+
+    EXPECT_EQ(partition_count, 1);
+
+    fuse_partitions(graph, partition_count);
+
+    // The add node should have been replaced with a CallSubgraphNode.
+    EXPECT_TRUE(std::holds_alternative<CallSubgraphNode>(graph.nodes[add.node].value));
+
+    // The subgraph should contain the original operator.
+    auto& subgraph_node = std::get<CallSubgraphNode>(graph.nodes[add.node].value);
+    EXPECT_NE(subgraph_node.subgraph, nullptr);
+
+    // The fused node's args should be the original inputs.
+    EXPECT_EQ(subgraph_node.args.size(), 2);
+
+    // Graph outputs should still reference the fused node.
+    EXPECT_EQ(graph.outputs.size(), 1);
+    EXPECT_EQ(graph.outputs[0].node, add.node);
+}
+
+TEST(TestFusePartitions, parallel_multi_output) {
+    auto builder = GraphBuilder();
+
+    auto spec = TensorSpec {
+        .dtype = DType::Float32,
+        .sizes = { DimSizeSpec::constant(1), DimSizeSpec::constant(10) }
+    };
+
+    auto input_a = builder.createInput(spec);
+    auto input_b = builder.createInput(spec);
+    auto add1 = builder.createOperator(Operator::Add, spec, input_a, input_b);
+    auto add2 = builder.createOperator(Operator::Add, spec, input_a, input_b);
+    builder.createOutput(add1);
+    builder.createOutput(add2);
+
+    auto graph = builder.build();
+
+    set_xnnpack(graph, add1);
+    set_xnnpack(graph, add2);
+
+    graph.update_users();
+    auto partition_count = assign_partitions(graph);
+
+    EXPECT_EQ(partition_count, 1);
+    EXPECT_EQ(graph.nodes[add1.node].tag, 1);
+    EXPECT_EQ(graph.nodes[add2.node].tag, 1);
+
+    fuse_partitions(graph, partition_count);
+
+    // The anchor (add2) should be a CallSubgraphNode.
+    EXPECT_TRUE(std::holds_alternative<CallSubgraphNode>(graph.nodes[add2.node].value));
+    auto& fused = std::get<CallSubgraphNode>(graph.nodes[add2.node].value);
+    EXPECT_NE(fused.subgraph, nullptr);
+
+    // The subgraph should have two outputs.
+    EXPECT_EQ(fused.subgraph->outputs.size(), 2);
+
+    // The fused node should have a multi-output spec.
+    EXPECT_TRUE(std::holds_alternative<std::vector<TensorSpec>>(fused.output_specs));
+    EXPECT_EQ(std::get<std::vector<TensorSpec>>(fused.output_specs).size(), 2);
+
+    // graph.outputs[0] (was add1) should now reference the anchor with output 0.
+    EXPECT_EQ(graph.outputs[0].node, add2.node);
+    EXPECT_EQ(graph.outputs[0].output, 0);
+
+    // graph.outputs[1] (was add2/anchor) keeps its original reference.
+    EXPECT_EQ(graph.outputs[1].node, add2.node);
+
+    // --- Compaction ---
+    // Before compaction, add1 is a Dead tombstone.
+    EXPECT_EQ((graph.nodes[add1.node].flags & NodeFlags::Dead), NodeFlags::Dead);
+
+    size_t pre_compact_size = graph.nodes.size();
+    graph.compact_nodes();
+
+    // Dead nodes should be removed.
+    EXPECT_LT(graph.nodes.size(), pre_compact_size);
+
+    // Graph outputs should still be valid and reference the fused node.
+    EXPECT_EQ(graph.outputs.size(), 2);
+
+    auto& fused_after = std::get<CallSubgraphNode>(graph.nodes[graph.outputs[0].node].value);
+    EXPECT_NE(fused_after.subgraph, nullptr);
+    EXPECT_EQ(graph.outputs[0].node, graph.outputs[1].node);
+}
+
+TEST(TestCompactNodes, sequential_chain) {
+    auto builder = GraphBuilder();
+
+    auto spec = TensorSpec {
+        .dtype = DType::Float32,
+        .sizes = { DimSizeSpec::constant(1), DimSizeSpec::constant(10) }
+    };
+
+    auto input_a = builder.createInput(spec);
+    auto input_b = builder.createInput(spec);
+    auto add1 = builder.createOperator(Operator::Add, spec, input_a, input_b);
+    auto add2 = builder.createOperator(Operator::Add, spec, add1, input_b);
+    auto add3 = builder.createOperator(Operator::Add, spec, add2, input_b);
+    builder.createOutput(add3);
+
+    auto graph = builder.build();
+    size_t original_size = graph.nodes.size();
+
+    set_xnnpack(graph, add1);
+    set_xnnpack(graph, add2);
+    set_xnnpack(graph, add3);
+
+    graph.update_users();
+    auto partition_count = assign_partitions(graph);
+    EXPECT_EQ(partition_count, 1);
+
+    fuse_partitions(graph, partition_count);
+
+    // add1, add2 are tombstoned; add3 (anchor) is the CallSubgraphNode.
+    EXPECT_EQ((graph.nodes[add1.node].flags & NodeFlags::Dead), NodeFlags::Dead);
+    EXPECT_EQ((graph.nodes[add2.node].flags & NodeFlags::Dead), NodeFlags::Dead);
+
+    graph.compact_nodes();
+
+    // Two dead nodes removed: inputs (2) + anchor (1) = 3 live nodes.
+    EXPECT_EQ(graph.nodes.size(), original_size - 2);
+
+    // No Dead nodes remain.
+    for (size_t i = 0; i < graph.nodes.size(); i++) {
+        EXPECT_EQ((graph.nodes[i].flags & NodeFlags::Dead), NodeFlags::None)
+            << "Node " << i << " is still dead after compaction";
+    }
+
+    // Graph output should point to a valid CallSubgraphNode.
+    EXPECT_EQ(graph.outputs.size(), 1);
+    auto& out_node = graph.nodes[graph.outputs[0].node];
+    EXPECT_TRUE(std::holds_alternative<CallSubgraphNode>(out_node.value));
+
+    // The fused node's args should reference valid input nodes.
+    auto& fused = std::get<CallSubgraphNode>(out_node.value);
+    for (auto& arg : fused.args) {
+        EXPECT_LT(arg.node, graph.nodes.size());
+        EXPECT_TRUE(std::holds_alternative<InputNode>(graph.nodes[arg.node].value));
+    }
+}

--- a/backends/xnnpack/test/runtime/test_quant_params.cpp
+++ b/backends/xnnpack/test/runtime/test_quant_params.cpp
@@ -1,0 +1,196 @@
+#include <gtest/gtest.h>
+
+#include <executorch/backends/xnnpack/runtime/core/dtype.h>
+#include <executorch/backends/xnnpack/runtime/core/quant_params.h>
+#include <executorch/backends/xnnpack/runtime/core/tensor.h>
+
+using namespace executorch::backends::xnnpack::core;
+
+// --- is_quantized ---
+
+TEST(TestQuantParams, is_quantized_float) {
+    EXPECT_FALSE(is_quantized(DType::Float32));
+}
+
+TEST(TestQuantParams, is_quantized_qint8sym) {
+    EXPECT_TRUE(is_quantized(DType::QInt8Sym));
+}
+
+TEST(TestQuantParams, is_quantized_qint4sym) {
+    EXPECT_TRUE(is_quantized(DType::QInt4Sym));
+}
+
+TEST(TestQuantParams, is_quantized_quint8asym) {
+    EXPECT_TRUE(is_quantized(DType::QUInt8Asym));
+}
+
+// --- is_asymmetric ---
+
+TEST(TestQuantParams, is_asymmetric_sym) {
+    EXPECT_FALSE(is_asymmetric(DType::QInt8Sym));
+    EXPECT_FALSE(is_asymmetric(DType::QInt4Sym));
+}
+
+TEST(TestQuantParams, is_asymmetric_asym) {
+    EXPECT_TRUE(is_asymmetric(DType::QUInt8Asym));
+}
+
+// --- element_size ---
+
+TEST(TestQuantParams, element_size_float32) {
+    EXPECT_EQ(element_size(DType::Float32), 4);
+}
+
+TEST(TestQuantParams, element_size_qint8) {
+    EXPECT_EQ(element_size(DType::QInt8Sym), 1);
+    EXPECT_EQ(element_size(DType::QUInt8Asym), 1);
+}
+
+// --- compute_storage_size ---
+
+TEST(TestQuantParams, storage_size_qint8sym) {
+    EXPECT_EQ(compute_storage_size({4, 8}, DType::QInt8Sym), 32);
+}
+
+TEST(TestQuantParams, storage_size_quint8asym) {
+    EXPECT_EQ(compute_storage_size({2, 5}, DType::QUInt8Asym), 10);
+}
+
+TEST(TestQuantParams, storage_size_qint4sym_even) {
+    EXPECT_EQ(compute_storage_size({2, 4}, DType::QInt4Sym), 4);
+}
+
+TEST(TestQuantParams, storage_size_qint4sym_odd) {
+    EXPECT_EQ(compute_storage_size({7}, DType::QInt4Sym), 4);
+}
+
+TEST(TestQuantParams, storage_size_qint4sym_one) {
+    EXPECT_EQ(compute_storage_size({1}, DType::QInt4Sym), 1);
+}
+
+// --- Preset factories ---
+
+TEST(TestQuantParams, preset_qint8_per_channel_sym) {
+    auto p = qint8_per_channel_sym(0);
+    auto* pa = std::get_if<PerAxisQuant>(&p);
+    ASSERT_NE(pa, nullptr);
+    EXPECT_EQ(pa->axis, 0);
+    EXPECT_EQ(pa->scale_dtype, DType::Float32);
+}
+
+TEST(TestQuantParams, preset_qint8_per_tensor_sym) {
+    auto p = qint8_per_tensor_sym(0.5f);
+    auto* pt = std::get_if<PerTensorQuant>(&p);
+    ASSERT_NE(pt, nullptr);
+    EXPECT_FLOAT_EQ(pt->scale, 0.5f);
+    EXPECT_EQ(pt->zero_point, 0);
+}
+
+TEST(TestQuantParams, preset_quint8_per_tensor_asym) {
+    auto p = quint8_per_tensor_asym(0.25f, 128);
+    auto* pt = std::get_if<PerTensorQuant>(&p);
+    ASSERT_NE(pt, nullptr);
+    EXPECT_FLOAT_EQ(pt->scale, 0.25f);
+    EXPECT_EQ(pt->zero_point, 128);
+}
+
+TEST(TestQuantParams, preset_quint8_per_token_asym) {
+    auto p = quint8_per_token_asym(0);
+    auto* pa = std::get_if<PerAxisQuant>(&p);
+    ASSERT_NE(pa, nullptr);
+    EXPECT_EQ(pa->axis, 0);
+}
+
+TEST(TestQuantParams, preset_qint4_blockwise_sym) {
+    auto p = qint4_blockwise_sym(1, 32);
+    auto* pb = std::get_if<BlockwiseQuant>(&p);
+    ASSERT_NE(pb, nullptr);
+    EXPECT_EQ(pb->axis, 1);
+    EXPECT_EQ(pb->block_size, 32);
+    EXPECT_EQ(pb->scale_dtype, DType::Float32);
+}
+
+// --- aux_buffer_count ---
+
+TEST(TestQuantParams, aux_buffer_count_float) {
+    QuantParams dummy = PerTensorQuant{};
+    EXPECT_EQ(aux_buffer_count(DType::Float32, dummy), 0);
+}
+
+TEST(TestQuantParams, aux_buffer_count_sym) {
+    auto p = qint8_per_channel_sym(0);
+    EXPECT_EQ(aux_buffer_count(DType::QInt8Sym, p), 1);
+}
+
+TEST(TestQuantParams, aux_buffer_count_asym) {
+    auto p = quint8_per_tensor_asym(1.0f, 0);
+    EXPECT_EQ(aux_buffer_count(DType::QUInt8Asym, p), 2);
+}
+
+// --- compute_aux_storage_sizes ---
+
+TEST(TestQuantParams, aux_sizes_per_tensor_sym) {
+    auto p = qint8_per_tensor_sym(1.0f);
+    auto sizes = compute_aux_storage_sizes({4, 8}, DType::QInt8Sym, p);
+    ASSERT_EQ(sizes.size(), 1);
+    EXPECT_EQ(sizes[0], sizeof(float)); // 1 scale, float32
+}
+
+TEST(TestQuantParams, aux_sizes_per_axis_sym) {
+    // [4, 8], per-channel along axis=0 (quant over dim 0).
+    // Scales indexed by all other dims -> 8 scales.
+    auto p = qint8_per_channel_sym(0);
+    auto sizes = compute_aux_storage_sizes({4, 8}, DType::QInt8Sym, p);
+    ASSERT_EQ(sizes.size(), 1);
+    EXPECT_EQ(sizes[0], 8 * sizeof(float));
+}
+
+TEST(TestQuantParams, aux_sizes_per_axis_sym_weights) {
+    // [out_ch=4, in_ch=8], per-channel along axis=1 (quant over in_ch).
+    // One scale per output channel -> 4 scales.
+    auto p = qint8_per_channel_sym(1);
+    auto sizes = compute_aux_storage_sizes({4, 8}, DType::QInt8Sym, p);
+    ASSERT_EQ(sizes.size(), 1);
+    EXPECT_EQ(sizes[0], 4 * sizeof(float));
+}
+
+TEST(TestQuantParams, aux_sizes_per_axis_asym) {
+    // [4, 8], per-token along axis=1 (quant over feature dim).
+    // One scale per row -> 4 scales + 4 zero_points.
+    auto p = quint8_per_token_asym(1);
+    auto sizes = compute_aux_storage_sizes({4, 8}, DType::QUInt8Asym, p);
+    ASSERT_EQ(sizes.size(), 2);
+    EXPECT_EQ(sizes[0], 4 * sizeof(float));   // scales
+    EXPECT_EQ(sizes[1], 4 * sizeof(int32_t)); // zero_points
+}
+
+TEST(TestQuantParams, aux_sizes_per_token_3d) {
+    // [batch=2, seqlen=3, features=8], per-token along axis=2.
+    // One scale per [batch, seqlen] combo -> 2*3 = 6 scales.
+    auto p = quint8_per_token_asym(2);
+    auto sizes = compute_aux_storage_sizes({2, 3, 8}, DType::QUInt8Asym, p);
+    ASSERT_EQ(sizes.size(), 2);
+    EXPECT_EQ(sizes[0], 6 * sizeof(float));   // scales
+    EXPECT_EQ(sizes[1], 6 * sizeof(int32_t)); // zero_points
+}
+
+TEST(TestQuantParams, aux_sizes_blockwise_sym) {
+    // [4, 128], blockwise along axis=1, block_size=32
+    // num_blocks = 128/32 = 4
+    // other_dims = 4 (axis=1, so dim 0 contributes)
+    // total scales = 4 * 4 = 16
+    auto p = qint4_blockwise_sym(1, 32);
+    auto sizes = compute_aux_storage_sizes({4, 128}, DType::QInt4Sym, p);
+    ASSERT_EQ(sizes.size(), 1);
+    EXPECT_EQ(sizes[0], 16 * sizeof(float));
+}
+
+TEST(TestQuantParams, aux_sizes_blockwise_sym_not_divisible) {
+    // [4, 100], blockwise along axis=1, block_size=32
+    // num_blocks = ceil(100/32) = 4
+    // total scales = 4 * 4 = 16
+    auto p = qint4_blockwise_sym(1, 32);
+    auto sizes = compute_aux_storage_sizes({4, 100}, DType::QInt4Sym, p);
+    ASSERT_EQ(sizes.size(), 1);
+    EXPECT_EQ(sizes[0], 16 * sizeof(float));
+}

--- a/backends/xnnpack/test/runtime/test_schedule.cpp
+++ b/backends/xnnpack/test/runtime/test_schedule.cpp
@@ -1,0 +1,159 @@
+#include <gtest/gtest.h>
+
+#include <executorch/backends/xnnpack/runtime/graph/graph_builder.h>
+#include <executorch/backends/xnnpack/runtime/plan/partition.h>
+#include <executorch/backends/xnnpack/runtime/plan/schedule.h>
+
+#include <algorithm>
+#include <unordered_set>
+
+using namespace executorch::backends::xnnpack::core;
+using namespace executorch::backends::xnnpack::graph;
+using namespace executorch::backends::xnnpack::plan;
+
+// Helper: check that the order is a valid topological sort of the graph.
+static void assert_topological(const Graph& graph, const std::vector<NodeHandle>& order) {
+    ASSERT_EQ(order.size(), graph.nodes.size());
+
+    // Build position map: node -> index in order.
+    std::vector<uint32_t> pos(graph.nodes.size());
+    for (uint32_t i = 0; i < order.size(); i++) {
+        pos[order[i]] = i;
+    }
+
+    // Every arg source must appear before the node that uses it.
+    for (NodeHandle n = 0; n < graph.nodes.size(); n++) {
+        for (auto& arg : graph.nodes[n].get_args()) {
+            EXPECT_LT(pos[arg.node], pos[n])
+                << "Node " << arg.node << " (arg) should appear before node " << n;
+        }
+    }
+}
+
+// Helper: check that all nodes appear exactly once.
+static void assert_all_nodes_present(const Graph& graph, const std::vector<NodeHandle>& order) {
+    ASSERT_EQ(order.size(), graph.nodes.size());
+
+    std::unordered_set<NodeHandle> seen(order.begin(), order.end());
+    EXPECT_EQ(seen.size(), graph.nodes.size());
+}
+
+static TensorSpec make_spec() {
+    return TensorSpec {
+        .dtype = DType::Float32,
+        .sizes = { DimSizeSpec::constant(1), DimSizeSpec::constant(10) }
+    };
+}
+
+TEST(TestSchedule, linear_chain) {
+    // input -> op1 -> op2 -> output
+    auto builder = GraphBuilder();
+    auto spec = make_spec();
+
+    auto input = builder.createInput(spec);
+    auto op1 = builder.createOperator(Operator::Add, spec, input, input);
+    auto op2 = builder.createOperator(Operator::Add, spec, op1, input);
+    builder.createOutput(op2);
+
+    auto graph = builder.build();
+    graph.update_users();
+
+    auto order = schedule(graph);
+
+    assert_all_nodes_present(graph, order);
+    assert_topological(graph, order);
+
+    // Input must be first, then op1, then op2.
+    EXPECT_EQ(order[0], input.node);
+    EXPECT_EQ(order[1], op1.node);
+    EXPECT_EQ(order[2], op2.node);
+}
+
+TEST(TestSchedule, diamond) {
+    // input_a, input_b -> add1; input_b -> add2; add1, add2 -> add3
+    auto builder = GraphBuilder();
+    auto spec = make_spec();
+
+    auto input_a = builder.createInput(spec);
+    auto input_b = builder.createInput(spec);
+    auto add1 = builder.createOperator(Operator::Add, spec, input_a, input_b);
+    auto add2 = builder.createOperator(Operator::Add, spec, add1, input_b);
+    builder.createOutput(add2);
+
+    auto graph = builder.build();
+    graph.update_users();
+
+    auto order = schedule(graph);
+
+    assert_all_nodes_present(graph, order);
+    assert_topological(graph, order);
+
+    // Both inputs before add1, add1 before add2.
+    std::vector<uint32_t> pos(graph.nodes.size());
+    for (uint32_t i = 0; i < order.size(); i++) {
+        pos[order[i]] = i;
+    }
+    EXPECT_LT(pos[input_a.node], pos[add1.node]);
+    EXPECT_LT(pos[input_b.node], pos[add1.node]);
+    EXPECT_LT(pos[add1.node], pos[add2.node]);
+}
+
+TEST(TestSchedule, post_fusion) {
+    auto builder = GraphBuilder();
+    auto spec = make_spec();
+
+    auto input_a = builder.createInput(spec);
+    auto input_b = builder.createInput(spec);
+    auto add1 = builder.createOperator(Operator::Add, spec, input_a, input_b);
+    auto add2 = builder.createOperator(Operator::Add, spec, add1, input_b);
+    auto add3 = builder.createOperator(Operator::Add, spec, add2, input_b);
+    builder.createOutput(add3);
+
+    auto graph = builder.build();
+
+    // Mark all ops for XNNPACK so they get fused.
+    graph.nodes[add1.node].flags |= NodeFlags::UseXnnpack;
+    graph.nodes[add2.node].flags |= NodeFlags::UseXnnpack;
+    graph.nodes[add3.node].flags |= NodeFlags::UseXnnpack;
+
+    partition_xnn_subgraphs(graph);
+
+    auto order = schedule(graph);
+
+    assert_all_nodes_present(graph, order);
+    assert_topological(graph, order);
+
+    // Find the CallSubgraphNode and verify it comes after inputs.
+    std::vector<uint32_t> pos(graph.nodes.size());
+    for (uint32_t i = 0; i < order.size(); i++) {
+        pos[order[i]] = i;
+    }
+
+    for (NodeHandle n = 0; n < graph.nodes.size(); n++) {
+        if (std::holds_alternative<CallSubgraphNode>(graph.nodes[n].value)) {
+            auto& fused = std::get<CallSubgraphNode>(graph.nodes[n].value);
+            for (auto& arg : fused.args) {
+                EXPECT_LT(pos[arg.node], pos[n]);
+            }
+        }
+    }
+}
+
+TEST(TestSchedule, multiple_inputs_no_ops) {
+    // Graph with only input nodes (degenerate case).
+    auto builder = GraphBuilder();
+    auto spec = make_spec();
+
+    auto input_a = builder.createInput(spec);
+    auto input_b = builder.createInput(spec);
+    builder.createOutput(input_a);
+    builder.createOutput(input_b);
+
+    auto graph = builder.build();
+    graph.update_users();
+
+    auto order = schedule(graph);
+
+    assert_all_nodes_present(graph, order);
+    EXPECT_EQ(order.size(), 2u);
+}

--- a/backends/xnnpack/test/runtime/test_shape_env.cpp
+++ b/backends/xnnpack/test/runtime/test_shape_env.cpp
@@ -1,0 +1,178 @@
+#include <gtest/gtest.h>
+
+#include <executorch/backends/xnnpack/runtime/executor/shape_env.h>
+#include <executorch/backends/xnnpack/runtime/graph/tensor_spec.h>
+
+#include <cstdint>
+
+using namespace executorch::backends::xnnpack::core;
+using namespace executorch::backends::xnnpack::executor;
+using namespace executorch::backends::xnnpack::graph;
+
+static TensorSpec make_spec(std::vector<DimSizeSpec> sizes) {
+    return TensorSpec { .dtype = DType::Float32, .sizes = std::move(sizes) };
+}
+
+static Tensor make_tensor(std::vector<uint64_t> sizes) {
+    return Tensor { .dtype = DType::Float32, .sizes = std::move(sizes) };
+}
+
+template <typename... Args>
+static std::vector<Tensor> make_tensors(Args&&... args) {
+    std::vector<Tensor> v;
+    v.reserve(sizeof...(args));
+    (v.push_back(std::forward<Args>(args)), ...);
+    return v;
+}
+
+TEST(TestShapeEnv, single_sym_solves) {
+    // spec: [s0], tensor: [42] => s0 = 42
+    ShapeEnv env(1);
+    std::vector<TensorSpec> specs = { make_spec({ DimSizeSpec::sym(0) }) };
+    auto values = make_tensors(make_tensor({ 42 }));
+
+    EXPECT_TRUE(env.specialize(specs, values));
+    EXPECT_EQ(env.specialized_bounds[0].min, 42u);
+    ASSERT_TRUE(env.specialized_bounds[0].max.has_value());
+    EXPECT_EQ(*env.specialized_bounds[0].max, 42u);
+}
+
+TEST(TestShapeEnv, constant_dim_valid) {
+    // spec: [const(10)], tensor: [10] => ok
+    ShapeEnv env(0);
+    std::vector<TensorSpec> specs = { make_spec({ DimSizeSpec::constant(10) }) };
+    auto values = make_tensors(make_tensor({ 10 }));
+
+    EXPECT_TRUE(env.specialize(specs, values));
+}
+
+TEST(TestShapeEnv, constant_dim_mismatch) {
+    // spec: [const(10)], tensor: [5] => fail
+    ShapeEnv env(0);
+    std::vector<TensorSpec> specs = { make_spec({ DimSizeSpec::constant(10) }) };
+    auto values = make_tensors(make_tensor({ 5 }));
+
+    EXPECT_FALSE(env.specialize(specs, values));
+}
+
+TEST(TestShapeEnv, sym_with_offset) {
+    // spec: [1*s0 + 3], tensor: [13] => s0 = 10
+    ShapeEnv env(1);
+    DimSizeSpec dim = { .coeffs = {{ .sym = 0, .coefficient = 1 }}, .offset = 3 };
+    std::vector<TensorSpec> specs = { make_spec({ dim }) };
+    auto values = make_tensors(make_tensor({ 13 }));
+
+    EXPECT_TRUE(env.specialize(specs, values));
+    EXPECT_EQ(env.specialized_bounds[0].min, 10u);
+    ASSERT_TRUE(env.specialized_bounds[0].max.has_value());
+    EXPECT_EQ(*env.specialized_bounds[0].max, 10u);
+}
+
+TEST(TestShapeEnv, same_sym_consistent) {
+    // Two dims both use s0, both give s0 = 5 => ok, bounds tightened to [5, 5]
+    ShapeEnv env(1);
+    std::vector<TensorSpec> specs = {
+        make_spec({ DimSizeSpec::sym(0) }),
+        make_spec({ DimSizeSpec::sym(0) }),
+    };
+    auto values = make_tensors(make_tensor({ 5 }), make_tensor({ 5 }));
+
+    EXPECT_TRUE(env.specialize(specs, values));
+    EXPECT_EQ(env.specialized_bounds[0].min, 5u);
+    ASSERT_TRUE(env.specialized_bounds[0].max.has_value());
+    EXPECT_EQ(*env.specialized_bounds[0].max, 5u);
+}
+
+TEST(TestShapeEnv, same_sym_contradictory) {
+    // Two dims both use s0, one gives s0=5, other gives s0=7 => fail
+    ShapeEnv env(1);
+    std::vector<TensorSpec> specs = {
+        make_spec({ DimSizeSpec::sym(0) }),
+        make_spec({ DimSizeSpec::sym(0) }),
+    };
+    auto values = make_tensors(make_tensor({ 5 }), make_tensor({ 7 }));
+
+    EXPECT_FALSE(env.specialize(specs, values));
+}
+
+TEST(TestShapeEnv, multiple_syms) {
+    // spec: [s0, s1], tensor: [3, 7] => s0=3, s1=7
+    ShapeEnv env(2);
+    std::vector<TensorSpec> specs = {
+        make_spec({ DimSizeSpec::sym(0), DimSizeSpec::sym(1) }),
+    };
+    auto values = make_tensors(make_tensor({ 3, 7 }));
+
+    EXPECT_TRUE(env.specialize(specs, values));
+    EXPECT_EQ(env.specialized_bounds[0].min, 3u);
+    EXPECT_EQ(*env.specialized_bounds[0].max, 3u);
+    EXPECT_EQ(env.specialized_bounds[1].min, 7u);
+    EXPECT_EQ(*env.specialized_bounds[1].max, 7u);
+}
+
+TEST(TestShapeEnv, spec_value_count_mismatch) {
+    ShapeEnv env(1);
+    std::vector<TensorSpec> specs = {
+        make_spec({ DimSizeSpec::sym(0) }),
+        make_spec({ DimSizeSpec::sym(0) }),
+    };
+    auto values = make_tensors(make_tensor({ 5 }));
+
+    EXPECT_FALSE(env.specialize(specs, values));
+}
+
+TEST(TestShapeEnv, dim_count_mismatch) {
+    // spec has 2 dims, tensor has 1 dim
+    ShapeEnv env(1);
+    std::vector<TensorSpec> specs = {
+        make_spec({ DimSizeSpec::sym(0), DimSizeSpec::constant(10) }),
+    };
+    auto values = make_tensors(make_tensor({ 5 }));
+
+    EXPECT_FALSE(env.specialize(specs, values));
+}
+
+TEST(TestShapeEnv, multi_term_skipped) {
+    // Multi-term dim: 2*s0 + 3*s1 + 0 is left unsolved, bounds stay at defaults
+    ShapeEnv env(2);
+    DimSizeSpec dim = {
+        .coeffs = {{ .sym = 0, .coefficient = 2 }, { .sym = 1, .coefficient = 3 }},
+        .offset = 0
+    };
+    std::vector<TensorSpec> specs = { make_spec({ dim }) };
+    auto values = make_tensors(make_tensor({ 100 }));
+
+    EXPECT_TRUE(env.specialize(specs, values));
+    // Bounds should remain at defaults (min=1, max=nullopt)
+    EXPECT_EQ(env.specialized_bounds[0].min, 1u);
+    EXPECT_FALSE(env.specialized_bounds[0].max.has_value());
+    EXPECT_EQ(env.specialized_bounds[1].min, 1u);
+    EXPECT_FALSE(env.specialized_bounds[1].max.has_value());
+}
+
+TEST(TestShapeEnv, non_unit_coefficient_skipped) {
+    // Single term but coefficient != 1: 2*s0, left unsolved
+    ShapeEnv env(1);
+    DimSizeSpec dim = { .coeffs = {{ .sym = 0, .coefficient = 2 }}, .offset = 0 };
+    std::vector<TensorSpec> specs = { make_spec({ dim }) };
+    auto values = make_tensors(make_tensor({ 10 }));
+
+    EXPECT_TRUE(env.specialize(specs, values));
+    EXPECT_EQ(env.specialized_bounds[0].min, 1u);
+    EXPECT_FALSE(env.specialized_bounds[0].max.has_value());
+}
+
+TEST(TestShapeEnv, repeated_specialize_resets) {
+    // Calling specialize twice should reset bounds from first call
+    ShapeEnv env(1);
+    std::vector<TensorSpec> specs = { make_spec({ DimSizeSpec::sym(0) }) };
+    auto values1 = make_tensors(make_tensor({ 42 }));
+    auto values2 = make_tensors(make_tensor({ 7 }));
+
+    EXPECT_TRUE(env.specialize(specs, values1));
+    EXPECT_EQ(env.specialized_bounds[0].min, 42u);
+
+    EXPECT_TRUE(env.specialize(specs, values2));
+    EXPECT_EQ(env.specialized_bounds[0].min, 7u);
+    EXPECT_EQ(*env.specialized_bounds[0].max, 7u);
+}

--- a/backends/xnnpack/test/targets.bzl
+++ b/backends/xnnpack/test/targets.bzl
@@ -101,3 +101,52 @@ def define_common_targets():
                 "//executorch/backends/xnnpack:xnnpack_backend",
             ],
     )
+
+    runtime.cxx_test(
+        name = "test_graph_builder",
+        srcs = ["runtime/test_graph_builder.cpp"],
+        deps = [
+            "//executorch/backends/xnnpack:xnnpack_backend",
+        ],
+    )
+
+    runtime.cxx_test(
+        name = "test_partition",
+        srcs = ["runtime/test_partition.cpp"],
+        deps = [
+            "//executorch/backends/xnnpack:xnnpack_backend",
+        ],
+    )
+
+    runtime.cxx_test(
+        name = "test_schedule",
+        srcs = ["runtime/test_schedule.cpp"],
+        deps = [
+            "//executorch/backends/xnnpack:xnnpack_backend",
+        ],
+    )
+
+    runtime.cxx_test(
+        name = "test_shape_env",
+        srcs = ["runtime/test_shape_env.cpp"],
+        deps = [
+            "//executorch/backends/xnnpack:xnnpack_backend",
+        ],
+    )
+
+    runtime.cxx_test(
+        name = "test_quant_params",
+        srcs = ["runtime/test_quant_params.cpp"],
+        deps = [
+            "//executorch/backends/xnnpack:xnnpack_backend",
+        ],
+    )
+
+    runtime.cxx_test(
+        name = "test_e2e",
+        srcs = ["runtime/test_e2e.cpp"],
+        deps = [
+            third_party_dep("XNNPACK"),
+            "//executorch/backends/xnnpack:xnnpack_backend",
+        ],
+    )

--- a/shim_et/xplat/executorch/build/build_variables.bzl
+++ b/shim_et/xplat/executorch/build/build_variables.bzl
@@ -468,6 +468,7 @@ XNN_EXECUTOR_RUNNER_SRCS = [
 ]
 
 XNNPACK_BACKEND_BUCK_SRCS = [
+    "runtime/FlatbufferGraphBuilder.cpp",
     "runtime/XNNCompiler.cpp",
     "runtime/XNNExecutor.cpp",
     "runtime/XNNHeader.cpp",
@@ -475,6 +476,25 @@ XNNPACK_BACKEND_BUCK_SRCS = [
     "runtime/XNNWeightsCache.cpp",
     "runtime/XNNWorkspaceManager.cpp",
     "runtime/XnnpackBackendOptions.cpp",
+    "runtime/core/quant_params.cpp",
+    "runtime/core/tensor.cpp",
+    "runtime/executor/arena.cpp",
+    "runtime/executor/executor.cpp",
+    "runtime/executor/shape_env.cpp",
+    "runtime/graph/graph.cpp",
+    "runtime/graph/graph_builder.cpp",
+    "runtime/kernels/layer_norm/layer_norm.cpp",
+    "runtime/kernels/layer_norm/layer_norm_neon.cpp",
+    "runtime/kernels/layer_norm/layer_norm_scalar.cpp",
+    "runtime/operators/layer_norm.cpp",
+    "runtime/operators/operator.cpp",
+    "runtime/plan/execution_plan.cpp",
+    "runtime/plan/memory_plan.cpp",
+    "runtime/plan/nhwc_rewrite.cpp",
+    "runtime/plan/partition.cpp",
+    "runtime/plan/schedule.cpp",
+    "runtime/plan/xnn_subgraph.cpp",
+    "runtime/plan/xnn_support.cpp",
     "runtime/profiling/XNNProfiler.cpp",
 ]
 


### PR DESCRIPTION
Testing a very early prototype for a generalized cpu backend to see what breaks.

Features:
 * Runtime graph and graph builder layer.
 * Translation from existing XNNPACK-targeted serialization format to new graph layer.
 * Runtime partitioner for XNNPACK execution or in-tree ops.
 * Basic layer norm in-tree implementation (mainly to test in-tree op path).
 * Basic memory planning (placeholder, no actual overlapping yet).
 * Nicer quant representation in graph.