### PR TITLE
Arm backend: Make more functions private

### DIFF
--- a/backends/arm/_passes/arm_pass_manager.py
+++ b/backends/arm/_passes/arm_pass_manager.py
@@ -188,7 +188,7 @@ class ArmPassManager(PassManager):
         """
         skip_set: set[type] = set()
 
-        config = override_config or self.compile_spec.get_pass_pipeline_config()
+        config = override_config or self.compile_spec._get_pass_pipeline_config()
         logger.debug(f"Skip Config: {config}")
 
         match config.softmax:

--- a/backends/arm/common/arm_compile_spec.py
+++ b/backends/arm/common/arm_compile_spec.py
@@ -211,7 +211,7 @@ class ArmCompileSpec(ABC):
             )
         return compile_spec
 
-    def get_pass_pipeline_config(self) -> ArmPassPipelineConfig:
+    def _get_pass_pipeline_config(self) -> ArmPassPipelineConfig:
         """Returns configuration that controls how the Arm pass pipeline should
         behave.
 

--- a/backends/arm/common/arm_compile_spec.py
+++ b/backends/arm/common/arm_compile_spec.py
@@ -238,7 +238,7 @@ class ArmCompileSpec(ABC):
             config.disable_masked_softmax()
         return config
 
-    def get_intermediate_path(self) -> str | None:
+    def _get_intermediate_path(self) -> str | None:
         """Gets the path used for dumping intermediate results such as tosa and
         pte.
 

--- a/backends/arm/common/arm_compile_spec.py
+++ b/backends/arm/common/arm_compile_spec.py
@@ -58,7 +58,7 @@ class ArmCompileSpec(ABC):
         self._pipeline_config = pipeline_config
 
     @classmethod
-    def from_list(cls, compile_specs: list[CompileSpec]):  # noqa: C901
+    def _from_list(cls, compile_specs: list[CompileSpec]):  # noqa: C901
         tosa_spec: TosaSpecification | None = None
         output_format: str | None = None
         compiler_flags: list[str] | None = None
@@ -147,10 +147,10 @@ class ArmCompileSpec(ABC):
     def _validate(self):
         """Throws an error if the compile spec is not valid."""
 
-    def to_list(self):
+    def _to_list(self):
         """Get the ArmCompileSpec in list form."""
         if not self.tosa_spec:
-            raise ValueError("tosa_spec must be set before calling to_list()")
+            raise ValueError("tosa_spec must be set before calling _to_list()")
 
         # Always supply a TOSA version
         compile_spec = [

--- a/backends/arm/ethosu/backend.py
+++ b/backends/arm/ethosu/backend.py
@@ -74,7 +74,7 @@ class EthosUBackend(BackendDetails):
             tosa_flatbuffer,
             compile_flags,
             verbose=logger.getEffectiveLevel() <= logging.INFO,
-            intermediate_path=compile_spec.get_intermediate_path(),
+            intermediate_path=compile_spec._get_intermediate_path(),
         )
         return binary
 

--- a/backends/arm/ethosu/backend.py
+++ b/backends/arm/ethosu/backend.py
@@ -96,7 +96,7 @@ class EthosUBackend(BackendDetails):
         """
         logger.info(f"{EthosUBackend.__name__} preprocess")
 
-        compile_spec = EthosUCompileSpec.from_list(compile_specs)
+        compile_spec = EthosUCompileSpec._from_list(compile_specs)
         # deduce TOSA compile_spec from Ethos-U compile spec. We get a new
         # compile spec list, containing only elements relevant for the
         # TOSABackend.

--- a/backends/arm/ethosu/compile_spec.py
+++ b/backends/arm/ethosu/compile_spec.py
@@ -121,9 +121,9 @@ class EthosUCompileSpec(ArmCompileSpec):
         self._set_compile_specs(tosa_spec, compiler_flags)
         self._validate()
 
-    def to_list(self):
+    def _to_list(self):
         """Return compile specs including the encoded Ethos-U target."""
-        compile_specs = super().to_list()
+        compile_specs = super()._to_list()
         compile_specs.append(CompileSpec(self._TARGET_KEY, self.target.encode()))
         return compile_specs
 

--- a/backends/arm/ethosu/partitioner.py
+++ b/backends/arm/ethosu/partitioner.py
@@ -29,7 +29,7 @@ class EthosUPartitioner(TOSAPartitioner):
     ) -> None:
         # Override the delegation spec for Ethos-U
         self.delegation_spec = DelegationSpec(
-            EthosUBackend.__name__, compile_spec.to_list()
+            EthosUBackend.__name__, compile_spec._to_list()
         )
         self.additional_checks = additional_checks
         self.tosa_spec = compile_spec.tosa_spec

--- a/backends/arm/quantizer/arm_quantizer.py
+++ b/backends/arm/quantizer/arm_quantizer.py
@@ -754,7 +754,7 @@ class TOSAQuantizer(Quantizer):
                         f"Quantizer detected operator {node.name} with different device inputs: {devices}."
                     )
 
-    def quantize_with_submodules(
+    def _quantize_with_submodules(
         self,
         model: GraphModule,
         calibration_samples: list[tuple],

--- a/backends/arm/test/misc/test_compile_spec.py
+++ b/backends/arm/test/misc/test_compile_spec.py
@@ -32,14 +32,14 @@ def test_compile_spec_u55_INT():
 def test_ethos_u55_defaults_to_stable_softmax_u55_INT():
     """Test that EthosUCompileSpec for U55 defaults to STABLE softmax config."""
     compile_spec = EthosUCompileSpec("ethos-u55-128")
-    pipeline_config = compile_spec.get_pass_pipeline_config()
+    pipeline_config = compile_spec._get_pass_pipeline_config()
     assert pipeline_config.softmax == SoftmaxDecompositionConfig.STABLE
 
 
 def test_ethos_u85_defaults_to_masked_softmax_u85_INT():
     """Test that EthosUCompileSpec for U85 defaults to MASKED softmax config."""
     compile_spec = EthosUCompileSpec("ethos-u85-256")
-    pipeline_config = compile_spec.get_pass_pipeline_config()
+    pipeline_config = compile_spec._get_pass_pipeline_config()
     assert pipeline_config.softmax == SoftmaxDecompositionConfig.MASKED
 
 

--- a/backends/arm/test/misc/test_compile_spec.py
+++ b/backends/arm/test/misc/test_compile_spec.py
@@ -16,17 +16,17 @@ def test_compile_spec_u55_INT():
         .dump_intermediate_artifacts_to("my_path")
         .dump_debug_info(EthosUCompileSpec.DebugMode.TOSA)
     )
-    spec_list = compile_spec.to_list()
+    spec_list = compile_spec._to_list()
 
-    assert EthosUCompileSpec.from_list(spec_list) == compile_spec
+    assert EthosUCompileSpec._from_list(spec_list) == compile_spec
     assert "--my-flag" in compile_spec.compiler_flags
     assert "--output-format=raw" in compile_spec.compiler_flags
     with raises(ValueError, match="Incorrect output format"):
-        VgfCompileSpec.from_list(spec_list)
+        VgfCompileSpec._from_list(spec_list)
 
     spec_list.pop(0)
     with raises(ValueError, match="No tosa_spec in compile spec."):
-        EthosUCompileSpec.from_list(spec_list)
+        EthosUCompileSpec._from_list(spec_list)
 
 
 def test_ethos_u55_defaults_to_stable_softmax_u55_INT():
@@ -53,18 +53,18 @@ def test_compile_spec_vgf_no_quant():
         compiler_flags=["--my-flag2"]
     ).dump_intermediate_artifacts_to("my_path")
 
-    spec_list = compile_spec.to_list()
+    spec_list = compile_spec._to_list()
 
-    assert VgfCompileSpec.from_list(spec_list) == compile_spec
-    assert VgfCompileSpec.from_list(spec_list) != compile_spec2
+    assert VgfCompileSpec._from_list(spec_list) == compile_spec
+    assert VgfCompileSpec._from_list(spec_list) != compile_spec2
     with raises(ValueError, match="Incorrect output format"):
-        EthosUCompileSpec.from_list(spec_list)
+        EthosUCompileSpec._from_list(spec_list)
 
 
 def test_compile_spec_tosa_INT():
     compile_spec = TosaCompileSpec("TOSA-1.0+INT")
-    spec_list = compile_spec.to_list()
+    spec_list = compile_spec._to_list()
 
-    assert TosaCompileSpec.from_list(spec_list) == compile_spec
+    assert TosaCompileSpec._from_list(spec_list) == compile_spec
     with raises(ValueError, match="Incorrect output format"):
-        VgfCompileSpec.from_list(spec_list)
+        VgfCompileSpec._from_list(spec_list)

--- a/backends/arm/test/misc/test_compile_spec.py
+++ b/backends/arm/test/misc/test_compile_spec.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -10,7 +10,7 @@ from executorch.backends.arm.vgf import VgfCompileSpec
 from pytest import raises
 
 
-def test_ethos_u_compile_spec_no_target():
+def test_compile_spec_u55_INT():
     compile_spec = (
         EthosUCompileSpec("ethos-u55", extra_flags=["--my-flag"])
         .dump_intermediate_artifacts_to("my_path")
@@ -29,21 +29,21 @@ def test_ethos_u_compile_spec_no_target():
         EthosUCompileSpec.from_list(spec_list)
 
 
-def test_ethos_u55_defaults_to_stable_softmax():
+def test_ethos_u55_defaults_to_stable_softmax_u55_INT():
     """Test that EthosUCompileSpec for U55 defaults to STABLE softmax config."""
     compile_spec = EthosUCompileSpec("ethos-u55-128")
     pipeline_config = compile_spec.get_pass_pipeline_config()
     assert pipeline_config.softmax == SoftmaxDecompositionConfig.STABLE
 
 
-def test_ethos_u85_defaults_to_stable_softmax():
+def test_ethos_u85_defaults_to_masked_softmax_u85_INT():
     """Test that EthosUCompileSpec for U85 defaults to MASKED softmax config."""
     compile_spec = EthosUCompileSpec("ethos-u85-256")
     pipeline_config = compile_spec.get_pass_pipeline_config()
     assert pipeline_config.softmax == SoftmaxDecompositionConfig.MASKED
 
 
-def test_vgf_compile_spec_no_target():
+def test_compile_spec_vgf_no_quant():
     compile_spec = (
         VgfCompileSpec(compiler_flags=["--my-flag"])
         .dump_intermediate_artifacts_to("my_path")
@@ -61,7 +61,7 @@ def test_vgf_compile_spec_no_target():
         EthosUCompileSpec.from_list(spec_list)
 
 
-def test_tosa_compile_spec_no_target():
+def test_compile_spec_tosa_INT():
     compile_spec = TosaCompileSpec("TOSA-1.0+INT")
     spec_list = compile_spec.to_list()
 

--- a/backends/arm/test/runner_utils.py
+++ b/backends/arm/test/runner_utils.py
@@ -221,7 +221,7 @@ class TosaReferenceModelDispatch(TorchFunctionMode):
 
     def _tosa_dispatch(self, lowered_backend_module: LoweredBackendModule, inputs):
         tosa_buffer = lowered_backend_module.processed_bytes
-        compile_spec = TosaCompileSpec.from_list(lowered_backend_module.compile_specs)
+        compile_spec = TosaCompileSpec._from_list(lowered_backend_module.compile_specs)
 
         output_node = lowered_backend_module.original_module.graph.output_node()
         return run_tosa_graph(tosa_buffer, compile_spec.tosa_spec, inputs, output_node)

--- a/backends/arm/test/tester/analyze_output_utils.py
+++ b/backends/arm/test/tester/analyze_output_utils.py
@@ -307,7 +307,7 @@ def dump_error_output(
     # Capture assertion error and print more info
     banner = "=" * 40 + "TOSA debug info" + "=" * 40
     logger.error(banner)
-    path_to_tosa_files = tester.compile_spec.get_intermediate_path()
+    path_to_tosa_files = tester.compile_spec._get_intermediate_path()
 
     if path_to_tosa_files is None:
         path_to_tosa_files = tempfile.mkdtemp(prefix="executorch_result_dump_")

--- a/backends/arm/test/tester/quantize.py
+++ b/backends/arm/test/tester/quantize.py
@@ -50,11 +50,11 @@ class ArmQuantize(Quantize):
             raise ValueError("ArmQuantizer can only run with TOSAQuantizer.")
 
         if self.calibration_samples is not None:
-            converted = self.quantizer.quantize_with_submodules(
+            converted = self.quantizer._quantize_with_submodules(
                 captured_graph, self.calibration_samples, bool(self.is_qat), self.fold_quantize  # type: ignore
             )
         else:
-            converted = self.quantizer.quantize_with_submodules(
+            converted = self.quantizer._quantize_with_submodules(
                 captured_graph, [inputs], bool(self.is_qat), self.fold_quantize
             )
 

--- a/backends/arm/test/tester/serialize.py
+++ b/backends/arm/test/tester/serialize.py
@@ -60,7 +60,7 @@ class Serialize(BaseStages.Serialize):
                 "Tried running artifact from Serialize stage without running the stage."
             )
         inputs_flattened, _ = tree_flatten(inputs)
-        intermediate_path = self.compile_spec.get_intermediate_path()
+        intermediate_path = self.compile_spec._get_intermediate_path()
         target_board = get_target_board(self.compile_spec)
         elf_path = get_elf_path(target_board, self.use_portable_ops)
 

--- a/backends/arm/tosa/backend.py
+++ b/backends/arm/tosa/backend.py
@@ -204,7 +204,7 @@ class TOSABackend(BackendDetails):
 
         """
         # if a debug/test build capture output files from TOSA stage
-        artifact_path = compile_spec.get_intermediate_path()
+        artifact_path = compile_spec._get_intermediate_path()
         tosa_spec = compile_spec.tosa_spec
         dump_debug_info = compile_spec.tosa_debug_mode
         debug_hook = None
@@ -332,7 +332,7 @@ class TOSABackend(BackendDetails):
         """
         tosa_spec = compile_spec.tosa_spec
         node_to_id_map = _annotate_external_ids(graph_module.graph)
-        artifact_path = compile_spec.get_intermediate_path()
+        artifact_path = compile_spec._get_intermediate_path()
         output_order_workaround = compile_spec.get_output_order_workaround()
 
         # TODO: Fix the need to lazily import this.
@@ -436,7 +436,7 @@ class TOSABackend(BackendDetails):
         tosa_compile_spec.set_pass_pipeline_config(pipeline_config)
         return (
             tosa_compile_spec.dump_intermediate_artifacts_to(
-                compile_spec.get_intermediate_path()
+                compile_spec._get_intermediate_path()
             )
             .dump_debug_info(compile_spec.tosa_debug_mode)
             .set_output_order_workaround(compile_spec.output_order_workaround)

--- a/backends/arm/tosa/backend.py
+++ b/backends/arm/tosa/backend.py
@@ -431,7 +431,7 @@ class TOSABackend(BackendDetails):
 
         """
 
-        pipeline_config = compile_spec.get_pass_pipeline_config()
+        pipeline_config = compile_spec._get_pass_pipeline_config()
         tosa_compile_spec = TosaCompileSpec(compile_spec.tosa_spec)
         tosa_compile_spec.set_pass_pipeline_config(pipeline_config)
         return (

--- a/backends/arm/tosa/backend.py
+++ b/backends/arm/tosa/backend.py
@@ -170,7 +170,7 @@ class TOSABackend(BackendDetails):
 
         """
         return TOSABackend._preprocess(
-            edge_program, TosaCompileSpec.from_list(compile_specs)
+            edge_program, TosaCompileSpec._from_list(compile_specs)
         )
 
     @staticmethod

--- a/backends/arm/tosa/partitioner.py
+++ b/backends/arm/tosa/partitioner.py
@@ -145,7 +145,7 @@ class TOSAPartitioner(Partitioner):
 
         """
         self.delegation_spec = DelegationSpec(
-            TOSABackend.__name__, compile_spec.to_list()
+            TOSABackend.__name__, compile_spec._to_list()
         )
         self.tosa_spec = compile_spec.tosa_spec
         self.additional_checks = additional_checks

--- a/backends/arm/util/_factory.py
+++ b/backends/arm/util/_factory.py
@@ -26,11 +26,11 @@ def parse_compile_spec(compile_specs: list[CompileSpec]) -> ArmCompileSpec:
     else:
         raise ValueError("Compile spec without output format.")
     if output_format == TosaCompileSpec._get_output_format():
-        return TosaCompileSpec.from_list(compile_specs)
+        return TosaCompileSpec._from_list(compile_specs)
     if output_format == EthosUCompileSpec._get_output_format():
-        return EthosUCompileSpec.from_list(compile_specs)
+        return EthosUCompileSpec._from_list(compile_specs)
     if output_format == VgfCompileSpec._get_output_format():
-        return VgfCompileSpec.from_list(compile_specs)
+        return VgfCompileSpec._from_list(compile_specs)
     raise ValueError(f"Unknown output format {output_format}")
 
 

--- a/backends/arm/vgf/backend.py
+++ b/backends/arm/vgf/backend.py
@@ -95,7 +95,7 @@ class VgfBackend(BackendDetails):
         """
         logger.info(f"{VgfBackend.__name__} preprocess")
 
-        compile_spec = VgfCompileSpec.from_list(compile_specs)
+        compile_spec = VgfCompileSpec._from_list(compile_specs)
         # deduce TOSA compile_spec from VGF compile spec. We get a new
         # compile spec list, containing only elements relevant for the
         # TOSABackend.

--- a/backends/arm/vgf/backend.py
+++ b/backends/arm/vgf/backend.py
@@ -72,7 +72,7 @@ class VgfBackend(BackendDetails):
 
         """
         compile_flags = compile_spec.compiler_flags
-        artifact_path = compile_spec.get_intermediate_path()
+        artifact_path = compile_spec._get_intermediate_path()
         # Pass on the TOSA flatbuffer to the vgf compiler.
         binary = vgf_compile(tosa_flatbuffer, compile_flags, artifact_path, tag_name)
         return binary

--- a/backends/arm/vgf/partitioner.py
+++ b/backends/arm/vgf/partitioner.py
@@ -29,7 +29,7 @@ class VgfPartitioner(TOSAPartitioner):
     ) -> None:
         # Override the delegation spec for Vgf
         self.delegation_spec = DelegationSpec(
-            VgfBackend.__name__, compile_spec.to_list()
+            VgfBackend.__name__, compile_spec._to_list()
         )
         self.additional_checks = additional_checks
         self.tosa_spec = compile_spec.tosa_spec

--- a/docs/source/backends/arm-ethos-u/arm-ethos-u-overview.md
+++ b/docs/source/backends/arm-ethos-u/arm-ethos-u-overview.md
@@ -74,15 +74,6 @@ Args:
 - **output_path**: Path to dump intermediate results to.
 
 ```python
-def EthosUCompileSpec.get_intermediate_path(self) -> str | None:
-```
-Gets the path used for dumping intermediate results such as tosa and
-pte.
-
-Returns:
-    Path where intermediate results are saved.
-
-```python
 def EthosUCompileSpec.get_output_order_workaround(self) -> bool:
 ```
 Gets whether the output order workaround is being applied.

--- a/docs/source/backends/arm-ethos-u/arm-ethos-u-overview.md
+++ b/docs/source/backends/arm-ethos-u/arm-ethos-u-overview.md
@@ -79,14 +79,6 @@ def EthosUCompileSpec.get_output_order_workaround(self) -> bool:
 Gets whether the output order workaround is being applied.
 
 ```python
-def EthosUCompileSpec.get_pass_pipeline_config(self) -> executorch.backends.arm.common.pipeline_config.ArmPassPipelineConfig:
-```
-Returns configuration that controls how the Arm pass pipeline should
-behave.
-
-Subclasses may override to tweak defaults for specific targets.
-
-```python
 def EthosUCompileSpec.set_output_order_workaround(self, output_order_workaround: bool):
 ```
 Sets whether to apply the output order workaround.

--- a/docs/source/backends/arm-ethos-u/arm-ethos-u-quantization.md
+++ b/docs/source/backends/arm-ethos-u/arm-ethos-u-quantization.md
@@ -35,29 +35,6 @@ def EthosUQuantizer.add_quantizer(self, quantizer: 'Quantizer') -> 'TOSAQuantize
 Insert a quantizer with highest precedence.
 
 ```python
-def EthosUQuantizer.quantize_with_submodules(self, model: 'GraphModule', calibration_samples: 'list[tuple]', is_qat: 'bool' = False, fold_quantize: 'bool' = True):
-```
-Quantizes a GraphModule in a way such that conditional submodules are
-handled properly.
-
-Note: torchao's prepare_pt2e and convert_pt2e natively handle
-while_loop body_fn submodules, so we only manually process cond
-branches and while_loop cond_fn here.
-
-Args:
-- **model (GraphModule)**: The model to quantize.
-- **calibration_samples (list[tuple])**: A list of inputs to used to
-        calibrate the model during quantization. To properly calibrate a
-        model with submodules, at least one sample per code path is
-        needed.
-- **is_qat (bool)**: Whether to do quantization aware training or not.
-- **fold_quantize (bool)**: Enables or disables constant folding when quantization
-        is completed.
-
-Returns:
-- **GraphModule**: The quantized model.
-
-```python
 def EthosUQuantizer.set_global(self, quantization_config: 'Optional[QuantizationConfig]') -> 'TOSAQuantizer':
 ```
 Set quantization_config for submodules not matched by other filters.

--- a/docs/source/backends/arm-vgf/arm-vgf-overview.md
+++ b/docs/source/backends/arm-vgf/arm-vgf-overview.md
@@ -70,14 +70,6 @@ def VgfCompileSpec.get_output_order_workaround(self) -> bool:
 Gets whether the output order workaround is being applied.
 
 ```python
-def VgfCompileSpec.get_pass_pipeline_config(self) -> executorch.backends.arm.common.pipeline_config.ArmPassPipelineConfig:
-```
-Returns configuration that controls how the Arm pass pipeline should
-behave.
-
-Subclasses may override to tweak defaults for specific targets.
-
-```python
 def VgfCompileSpec.set_output_order_workaround(self, output_order_workaround: bool):
 ```
 Sets whether to apply the output order workaround.

--- a/docs/source/backends/arm-vgf/arm-vgf-overview.md
+++ b/docs/source/backends/arm-vgf/arm-vgf-overview.md
@@ -65,15 +65,6 @@ Args:
 - **output_path**: Path to dump intermediate results to.
 
 ```python
-def VgfCompileSpec.get_intermediate_path(self) -> str | None:
-```
-Gets the path used for dumping intermediate results such as tosa and
-pte.
-
-Returns:
-    Path where intermediate results are saved.
-
-```python
 def VgfCompileSpec.get_output_order_workaround(self) -> bool:
 ```
 Gets whether the output order workaround is being applied.

--- a/docs/source/backends/arm-vgf/arm-vgf-quantization.md
+++ b/docs/source/backends/arm-vgf/arm-vgf-quantization.md
@@ -54,29 +54,6 @@ def VgfQuantizer.add_quantizer(self, quantizer: 'Quantizer') -> 'TOSAQuantizer':
 Insert a quantizer with highest precedence.
 
 ```python
-def VgfQuantizer.quantize_with_submodules(self, model: 'GraphModule', calibration_samples: 'list[tuple]', is_qat: 'bool' = False, fold_quantize: 'bool' = True):
-```
-Quantizes a GraphModule in a way such that conditional submodules are
-handled properly.
-
-Note: torchao's prepare_pt2e and convert_pt2e natively handle
-while_loop body_fn submodules, so we only manually process cond
-branches and while_loop cond_fn here.
-
-Args:
-- **model (GraphModule)**: The model to quantize.
-- **calibration_samples (list[tuple])**: A list of inputs to used to
-        calibrate the model during quantization. To properly calibrate a
-        model with submodules, at least one sample per code path is
-        needed.
-- **is_qat (bool)**: Whether to do quantization aware training or not.
-- **fold_quantize (bool)**: Enables or disables constant folding when quantization
-        is completed.
-
-Returns:
-- **GraphModule**: The quantized model.
-
-```python
 def VgfQuantizer.set_global(self, quantization_config: 'Optional[QuantizationConfig]') -> 'TOSAQuantizer':
 ```
 Set quantization_config for submodules not matched by other filters.


### PR DESCRIPTION
Make the following functions private:

* get_pass_pipeline_config
* from_list
* to_list
* get_intermediate_path
* quantize_with_submodules
* get_intermediate_path

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @robell