### PR TITLE
Arm backend: Remove silu_ from ops_to_not_decompose

### DIFF
--- a/backends/arm/tosa/partitioner.py
+++ b/backends/arm/tosa/partitioner.py
@@ -338,7 +338,6 @@ class TOSAPartitioner(Partitioner):
             torch.ops.aten.linear.default,
             torch.ops.aten.linspace.default,
             torch.ops.aten.silu.default,
-            torch.ops.aten.silu_.default,
         }
         ops_to_not_decompose_if_fp = {
             torch.ops.aten.eye.default,
@@ -353,7 +352,6 @@ class TOSAPartitioner(Partitioner):
             torch.ops.aten.eye.default,
             torch.ops.aten.linspace.default,
             torch.ops.aten.silu.default,
-            torch.ops.aten.silu_.default,
         }
 
         def filter_fn(node: torch.fx.Node) -> bool:


### PR DESCRIPTION
It was causing a warning that it was being ignored.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell