### PR TITLE
[ET-VK] Add hashed_layout parameter to indexing.glslh texture functions

### DIFF
--- a/backends/vulkan/runtime/graph/ops/glsl/arange_texture.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/arange_texture.glsl
@@ -38,7 +38,8 @@ void main() {
     return;
   }
 
-  TensorIndex4D out_tidx = texture_pos_to_tensor4d_idx_simple(outp, out_pos);
+  TensorIndex4D out_tidx =
+      texture_pos_to_tensor4d_idx_simple(outp, out_pos, out_layout);
 
   // arange output is 1D, so the W dimension holds the element index.
   // Compute the value for each element in the texel along the packed dim.

--- a/backends/vulkan/runtime/graph/ops/glsl/block_load.glslh
+++ b/backends/vulkan/runtime/graph/ops/glsl/block_load.glslh
@@ -85,7 +85,8 @@
       const int block_outer_dim) {                                            \
     /* Convert tensor index to texture position */                            \
     /* Use tensor4d_idx_to_texel_pos_simple to properly map the packed dim */ \
-    ivec3 tex_pos = tensor4d_idx_to_texel_pos_simple(meta, tidx_base);        \
+    ivec3 tex_pos =                                                           \
+        tensor4d_idx_to_texel_pos_simple(meta, tidx_base, hashed_layout);     \
     const int tex_outer_dim = mod_4(block_outer_dim);                         \
     const int outer_size = meta.sizes[block_outer_dim];                       \
     const int base_outer_idx = tidx_base.data[block_outer_dim];               \
@@ -160,7 +161,8 @@
     /* Convert to 4D for texture operations (textures are always <= 4D) */     \
     TensorIndex4D tidx4d;                                                       \
     tidx4d.data = ivec4(tidx_base.data[0]);                                     \
-    ivec3 tex_pos = tensor4d_idx_to_texel_pos_simple(meta, tidx4d);             \
+    ivec3 tex_pos =                                                            \
+        tensor4d_idx_to_texel_pos_simple(meta, tidx4d, hashed_layout);          \
     const int tex_outer_dim = mod_4(block_outer_dim);                           \
     const int outer_size = meta.sizes[block_outer_dim];                         \
     const int base_outer_idx = tidx4d.data[block_outer_dim];                    \

--- a/backends/vulkan/runtime/graph/ops/glsl/block_store.glslh
+++ b/backends/vulkan/runtime/graph/ops/glsl/block_store.glslh
@@ -81,7 +81,8 @@
       const mat4 block) {                                                     \
     /* Convert tensor index to texture position */                            \
     /* Use tensor4d_idx_to_texel_pos_simple to properly map the packed dim */ \
-    ivec3 tex_pos = tensor4d_idx_to_texel_pos_simple(meta, tidx_base);        \
+    ivec3 tex_pos =                                                          \
+        tensor4d_idx_to_texel_pos_simple(meta, tidx_base, hashed_layout);     \
     const int tex_outer_dim = mod_4(block_outer_dim);                         \
     const int outer_size = meta.sizes[block_outer_dim];                       \
     const int base_outer_idx = tidx_base.data[block_outer_dim];               \
@@ -149,7 +150,8 @@
     /* Convert to 4D for texture operations (textures are always <= 4D) */     \
     TensorIndex4D tidx4d;                                                      \
     tidx4d.data = ivec4(tidx_base.data[0]);                                    \
-    ivec3 tex_pos = tensor4d_idx_to_texel_pos_simple(meta, tidx4d);            \
+    ivec3 tex_pos =                                                           \
+        tensor4d_idx_to_texel_pos_simple(meta, tidx4d, hashed_layout);         \
     const int tex_outer_dim = mod_4(block_outer_dim);                          \
     const int outer_size = meta.sizes[block_outer_dim];                        \
     const int base_outer_idx = tidx4d.data[block_outer_dim];                   \

--- a/backends/vulkan/runtime/graph/ops/glsl/embedding_texture.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/embedding_texture.glsl
@@ -35,13 +35,16 @@ ${layout_declare_ubo(B, "BufferMetadata", "weight")}
 
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
 
+${layout_declare_spec_const(C, "int", "out_layout", "CONTIG_LAYOUT_INT")}
+${layout_declare_spec_const(C, "int", "indices_layout", "CONTIG_LAYOUT_INT")}
+
 int load_embedding_idx(const TensorIndex4D out_tidx) {
   TensorIndex4D indices_tidx;
   indices_tidx.data.xyz = out_tidx.data.yzw;
   indices_tidx.data.w = 0;
 
   TextureElementIndex elem_pos = tensor4d_idx_to_texture_element_idx_simple(
-    indices, indices_tidx);
+    indices, indices_tidx, indices_layout);
 
   const ivec4 in_texel = texelFetch(t_indices, elem_pos.pos, 0);
   return in_texel[elem_pos.comp];
@@ -63,7 +66,8 @@ void main() {
     return;
   }
 
-  TensorIndex4D out_tidx = texture_pos_to_tensor4d_idx_simple(outp, out_pos);
+  TensorIndex4D out_tidx =
+      texture_pos_to_tensor4d_idx_simple(outp, out_pos, out_layout);
   const int embedding_idx = load_embedding_idx(out_tidx);
 
   const VEC4_T weight_texel = load_weight_texel(embedding_idx, out_tidx.data.x);

--- a/backends/vulkan/runtime/graph/ops/glsl/expand_texture.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/expand_texture.glsl
@@ -39,7 +39,8 @@ void main() {
     return;
   }
 
-  TensorIndex4D out_tidx = texture_pos_to_tensor4d_idx_simple(outp, out_pos);
+  TensorIndex4D out_tidx =
+      texture_pos_to_tensor4d_idx_simple(outp, out_pos, out_layout);
 
   VEC4_T out_texel = VEC4_T(0);
 
@@ -58,7 +59,8 @@ void main() {
     inp_tidx.data.w = out_tidx.data.w % inp.sizes.w;
 
     TextureElementIndex inp_elem =
-        tensor4d_idx_to_texture_element_idx_simple(inp, inp_tidx);
+        tensor4d_idx_to_texture_element_idx_simple(
+            inp, inp_tidx, out_layout);
 
     VEC4_T inp_texel = texelFetch(t_inp, inp_elem.pos, 0);
     out_texel[comp] = inp_texel[inp_elem.comp];

--- a/backends/vulkan/runtime/graph/ops/glsl/full_texture.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/full_texture.glsl
@@ -38,7 +38,8 @@ void main() {
 
   VEC4_T outtex = VEC4_T(fill_value);
 
-  TensorIndex4D tidx = texture_pos_to_tensor4d_idx_simple(outp, pos);
+  TensorIndex4D tidx =
+      texture_pos_to_tensor4d_idx_simple(outp, pos, out_layout);
   const int packed_dim_size = outp.sizes[packed_dim];
   int packed_idx = tidx.data[packed_dim];
 

--- a/backends/vulkan/runtime/graph/ops/glsl/gather_buffer.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/gather_buffer.glsl
@@ -32,7 +32,7 @@ ${layout_declare_ubo(B, "BufferMetadata", "index")}
 
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
 
-layout(constant_id = 3) const int gather_dim = 0;
+${layout_declare_spec_const(C, "int", "gather_dim", "0")}
 
 void main() {
   const uint out_bufi = gl_GlobalInvocationID.x;

--- a/backends/vulkan/runtime/graph/ops/glsl/gather_texture.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/gather_texture.glsl
@@ -34,7 +34,10 @@ ${layout_declare_ubo(B, "TextureMetadata", "index")}
 
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
 
-layout(constant_id = 3) const int gather_dim = 0;
+${layout_declare_spec_const(C, "int", "gather_dim", "0")}
+${layout_declare_spec_const(C, "int", "out_layout", "CONTIG_LAYOUT_INT")}
+${layout_declare_spec_const(C, "int", "inp_layout", "CONTIG_LAYOUT_INT")}
+const int out_packed_dim = get_packed_dim(out_layout);
 
 void main() {
   const ivec3 out_pos = ivec3(gl_GlobalInvocationID);
@@ -43,25 +46,26 @@ void main() {
     return;
   }
 
-  TensorIndex4D out_tidx = texture_pos_to_tensor4d_idx_simple(outp, out_pos);
+  TensorIndex4D out_tidx =
+      texture_pos_to_tensor4d_idx_simple(outp, out_pos, out_layout);
   ivec4 idx_texel = texelFetch(t_index, out_pos, 0);
 
   VEC4_T out_texel = VEC4_T(0);
 
   int limit = min(
-      4, outp.sizes[outp.packed_dim] - out_tidx.data[outp.packed_dim]);
+      4, outp.sizes[out_packed_dim] - out_tidx.data[out_packed_dim]);
   for (int comp = 0; comp < 4; comp++) {
     TensorIndex4D input_tidx = out_tidx;
     int gather_idx = idx_texel[comp];
     input_tidx.data[gather_dim] = gather_idx;
 
     TextureElementIndex input_elem_pos = tensor4d_idx_to_texture_element_idx_simple(
-        inp, input_tidx);
+        inp, input_tidx, inp_layout);
 
     VEC4_T input_texel = texelFetch(t_input, input_elem_pos.pos, 0);
     out_texel[comp] = input_texel[input_elem_pos.comp];
 
-    out_tidx.data[outp.packed_dim]++;
+    out_tidx.data[out_packed_dim]++;
   }
 
   imageStore(t_out, out_pos, out_texel);

--- a/backends/vulkan/runtime/graph/ops/glsl/index_tensor_texture.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/index_tensor_texture.glsl
@@ -33,6 +33,10 @@ ${layout_declare_ubo(B, "TextureMetadata", "index")}
 
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
 
+${layout_declare_spec_const(C, "int", "out_layout", "CONTIG_LAYOUT_INT")}
+${layout_declare_spec_const(C, "int", "inp_layout", "CONTIG_LAYOUT_INT")}
+const int out_packed_dim = get_packed_dim(out_layout);
+
 // Implements aten.index.Tensor for the case where self is 1D and there is
 // exactly one index tensor. Each output element is:
 //   output[...] = self[index[...]]
@@ -44,13 +48,14 @@ void main() {
     return;
   }
 
-  TensorIndex4D out_tidx = texture_pos_to_tensor4d_idx_simple(outp, out_pos);
+  TensorIndex4D out_tidx =
+      texture_pos_to_tensor4d_idx_simple(outp, out_pos, out_layout);
   ivec4 idx_texel = texelFetch(t_index, out_pos, 0);
 
   VEC4_T out_texel = VEC4_T(0);
 
   int limit = min(
-      4, outp.sizes[outp.packed_dim] - out_tidx.data[outp.packed_dim]);
+      4, outp.sizes[out_packed_dim] - out_tidx.data[out_packed_dim]);
   for (int comp = 0; comp < limit; comp++) {
     int idx = idx_texel[comp];
 
@@ -60,12 +65,12 @@ void main() {
     self_tidx.data = ivec4(idx, 0, 0, 0);
 
     TextureElementIndex self_elem =
-        tensor4d_idx_to_texture_element_idx_simple(inp, self_tidx);
+        tensor4d_idx_to_texture_element_idx_simple(inp, self_tidx, inp_layout);
 
     VEC4_T self_texel = texelFetch(t_self, self_elem.pos, 0);
     out_texel[comp] = self_texel[self_elem.comp];
 
-    out_tidx.data[outp.packed_dim]++;
+    out_tidx.data[out_packed_dim]++;
   }
 
   imageStore(t_out, out_pos, out_texel);

--- a/backends/vulkan/runtime/graph/ops/glsl/indexing.glslh
+++ b/backends/vulkan/runtime/graph/ops/glsl/indexing.glslh
@@ -79,6 +79,34 @@ bool is_channels_last(const int hashed_layout) {
 #define get_packed_dim_block_size(layout) (((layout) >> 24) & 0xF)
 #define get_outer_packed_dim_block_size(layout) (((layout) >> 28) & 0xF)
 
+// Safe ivec4 component access via if/else chain. Avoids dynamic vector
+// indexing (v[index]) on UBO-backed ivec4 members, which crashes on Adreno 740
+// when the index is a specialization constant with value 1 or 2.
+int safe_idx(const ivec4 v, const int idx) {
+  if (idx == 0) return v.x;
+  if (idx == 1) return v.y;
+  if (idx == 2) return v.z;
+  return v.w;
+}
+
+// Safe uvec4 component access via if/else chain. Same rationale as safe_idx
+// for ivec4 — avoids dynamic vector indexing on UBO-backed uvec4 members.
+uint safe_idx(const uvec4 v, const int idx) {
+  if (idx == 0) return v.x;
+  if (idx == 1) return v.y;
+  if (idx == 2) return v.z;
+  return v.w;
+}
+
+// Safe ivec4 component write via if/else chain. Companion to safe_idx for
+// cases where we need to set a component by a spec-const-derived index.
+void safe_set(inout ivec4 v, const int idx, const int val) {
+  if (idx == 0) { v.x = val; }
+  else if (idx == 1) { v.y = val; }
+  else if (idx == 2) { v.z = val; }
+  else { v.w = val; }
+}
+
 //
 // BufferMetadata
 //
@@ -420,17 +448,21 @@ void clamp_tensor_idx(const BufferMetadata meta, inout TensorIndex tidx) {
 
 // Does not account for axis mapping
 TensorIndex4D texture_pos_to_tensor4d_idx_simple(
-    const TextureMetadata meta, const ivec3 pos) {
+    const TextureMetadata meta,
+    const ivec3 pos,
+    const int hashed_layout) {
+  const int packed_dim = get_packed_dim(hashed_layout);
+
   TensorIndex4D tidx;
   tidx.data.xyz = pos;
   tidx.data.w = 0;
-  tidx.data[meta.packed_dim] *= 4;
+  safe_set(tidx.data, packed_dim, safe_idx(tidx.data, packed_dim) * 4);
 
   // Compute batch idx accounting for batch concatenation, assuming channels as
   // the concatenation dim.
   if (meta.sizes.w > 1) {
     int channels = meta.sizes.z;
-    if (meta.packed_dim == 2) {
+    if (packed_dim == 2) {
       channels = align_up_4(channels);
     }
     tidx.data.w = tidx.data.z / channels;
@@ -441,18 +473,26 @@ TensorIndex4D texture_pos_to_tensor4d_idx_simple(
 
 // Does not account for axis mapping
 ivec3 tensor4d_idx_to_texel_pos_simple(
-    const TextureMetadata meta, const TensorIndex4D tidx) {
-  ivec3 texel_pos;
+    const TextureMetadata meta,
+    const TensorIndex4D tidx,
+    const int hashed_layout) {
+  const int packed_dim = get_packed_dim(hashed_layout);
 
-  const int packed_dim_idx = tidx.data[meta.packed_dim];
+  const int packed_dim_idx = safe_idx(tidx.data, packed_dim);
 
-  texel_pos = tidx.data.xyz;
-  texel_pos[meta.packed_dim] = div_4(packed_dim_idx);
+  ivec3 texel_pos = tidx.data.xyz;
+  if (packed_dim == 0) {
+    texel_pos.x = div_4(packed_dim_idx);
+  } else if (packed_dim == 1) {
+    texel_pos.y = div_4(packed_dim_idx);
+  } else {
+    texel_pos.z = div_4(packed_dim_idx);
+  }
 
   // Account for batch concatenation, assuming channels as the concatenation dim
   if (meta.sizes.w > 1) {
     int channels_ntexels = meta.sizes.z;
-    if (meta.packed_dim == 2) {
+    if (packed_dim == 2) {
       channels_ntexels = div_up_4(channels_ntexels);
     }
     texel_pos.z += tidx.data.w * channels_ntexels;
@@ -463,17 +503,28 @@ ivec3 tensor4d_idx_to_texel_pos_simple(
 
 // Does not account for axis mapping
 TextureElementIndex tensor4d_idx_to_texture_element_idx_simple(
-    const TextureMetadata meta, const TensorIndex4D tidx) {
-  const int packed_dim_idx = tidx.data[meta.packed_dim];
+    const TextureMetadata meta,
+    const TensorIndex4D tidx,
+    const int hashed_layout) {
+  const int packed_dim = get_packed_dim(hashed_layout);
+
+  const int packed_dim_idx = safe_idx(tidx.data, packed_dim);
+
   TextureElementIndex tex_idx;
   tex_idx.pos = tidx.data.xyz;
-  tex_idx.pos[meta.packed_dim] = div_4(packed_dim_idx);
+  if (packed_dim == 0) {
+    tex_idx.pos.x = div_4(packed_dim_idx);
+  } else if (packed_dim == 1) {
+    tex_idx.pos.y = div_4(packed_dim_idx);
+  } else {
+    tex_idx.pos.z = div_4(packed_dim_idx);
+  }
   tex_idx.comp = mod_4(packed_dim_idx);
 
   // Account for batch concatenation, assuming channels as the concatenation dim
   if (meta.sizes.w > 1) {
     int channels_ntexels = meta.sizes.z;
-    if (meta.packed_dim == 2) {
+    if (packed_dim == 2) {
       channels_ntexels = div_up_4(channels_ntexels);
     }
     tex_idx.pos.z += tidx.data.w * channels_ntexels;

--- a/backends/vulkan/runtime/graph/ops/glsl/pad_texture.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/pad_texture.glsl
@@ -47,7 +47,8 @@ void main() {
   // Convert the thread position to output tensor indices in element space.
   // out_tidx.data[packed_dim] is the element index of the first component in
   // this texel; the remaining three dims are scalar element indices.
-  TensorIndex4D out_tidx = texture_pos_to_tensor4d_idx_simple(outp, out_pos);
+  TensorIndex4D out_tidx =
+      texture_pos_to_tensor4d_idx_simple(outp, out_pos, out_layout);
 
   // Tail texels may have fewer than 4 valid elements; leave extras as 0.
   const int limit =
@@ -74,7 +75,8 @@ void main() {
         in_tidx.data[2] >= 0 && in_tidx.data[2] < inp.sizes[2] &&
         in_tidx.data[3] >= 0 && in_tidx.data[3] < inp.sizes[3]) {
       TextureElementIndex elem =
-          tensor4d_idx_to_texture_element_idx_simple(inp, in_tidx);
+          tensor4d_idx_to_texture_element_idx_simple(
+              inp, in_tidx, out_layout);
       VEC4_T in_texel = texelFetch(t_in, elem.pos, 0);
       out_texel[comp] = T(in_texel[elem.comp]);
     } else {

--- a/backends/vulkan/runtime/graph/ops/glsl/repeat_texture.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/repeat_texture.glsl
@@ -41,7 +41,8 @@ void main() {
     return;
   }
 
-  TensorIndex4D out_tidx = texture_pos_to_tensor4d_idx_simple(out_meta, out_pos);
+  TensorIndex4D out_tidx =
+      texture_pos_to_tensor4d_idx_simple(out_meta, out_pos, out_layout);
 
   VEC4_T out_texel = VEC4_T(0);
 
@@ -56,7 +57,8 @@ void main() {
         out_tidx.data.w % in_meta.sizes.w);
 
     TextureElementIndex in_elem =
-        tensor4d_idx_to_texture_element_idx_simple(in_meta, in_tidx);
+        tensor4d_idx_to_texture_element_idx_simple(
+            in_meta, in_tidx, out_layout);
 
     VEC4_T in_texel = texelFetch(t_in, in_elem.pos, 0);
     out_texel[comp] = in_texel[in_elem.comp];

--- a/backends/vulkan/runtime/graph/ops/glsl/rotary_embedding.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/rotary_embedding.glsl
@@ -38,6 +38,9 @@ $else:
 
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
 
+${layout_declare_spec_const(C, "int", "xqout_layout", "CONTIG_LAYOUT_INT")}
+${layout_declare_spec_const(C, "int", "freqs_layout", "CONTIG_LAYOUT_INT")}
+
 /*
  * This shader computes rotary positional embeddings which are used in the Llama
  * model architecture. There are 4 input tensors with the following shapes.
@@ -99,12 +102,15 @@ void main() {
   VEC4_T x_tex_2 = t_xq[x_texel_bufi_2];
 
 #else // USING_TEXTURE
-  const ivec3 freqs_pos = tensor4d_idx_to_texel_pos_simple(freqs_cos, freqs_tidx);
+  const ivec3 freqs_pos =
+      tensor4d_idx_to_texel_pos_simple(freqs_cos, freqs_tidx, freqs_layout);
   VEC4_T cos_tex = texelFetch(t_freqs_cos, freqs_pos, 0);
   VEC4_T sin_tex = texelFetch(t_freqs_sin, freqs_pos, 0);
 
-  const ivec3 x_pos_1 = tensor4d_idx_to_texel_pos_simple(xqout, out_tidx_1);
-  const ivec3 x_pos_2 = tensor4d_idx_to_texel_pos_simple(xqout, out_tidx_2);
+  const ivec3 x_pos_1 =
+      tensor4d_idx_to_texel_pos_simple(xqout, out_tidx_1, xqout_layout);
+  const ivec3 x_pos_2 =
+      tensor4d_idx_to_texel_pos_simple(xqout, out_tidx_2, xqout_layout);
   VEC4_T x_tex_1 = texelFetch(t_xq, x_pos_1, 0);
   VEC4_T x_tex_2 = texelFetch(t_xq, x_pos_2, 0);
 #endif

--- a/backends/vulkan/runtime/graph/ops/glsl/split_buffer.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/split_buffer.glsl
@@ -29,9 +29,9 @@ ${layout_declare_ubo(B, "BufferMetadata", "inp")}
 
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
 
-layout(constant_id = 3) const int split_dim = 0;
-layout(constant_id = 4) const int split_idx = 0;
-layout(constant_id = 5) const int split_offset = 0;
+${layout_declare_spec_const(C, "int", "split_dim", "0")}
+${layout_declare_spec_const(C, "int", "split_idx", "0")}
+${layout_declare_spec_const(C, "int", "split_offset", "0")}
 
 void main() {
   const uint out_bufi = gl_GlobalInvocationID.x;

--- a/backends/vulkan/runtime/graph/ops/glsl/split_texture.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/split_texture.glsl
@@ -31,9 +31,12 @@ ${layout_declare_ubo(B, "TextureMetadata", "inp")}
 
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
 
-layout(constant_id = 3) const int split_dim = 0;
-layout(constant_id = 4) const int split_idx = 0;
-layout(constant_id = 5) const int split_offset = 0;
+${layout_declare_spec_const(C, "int", "split_dim", "0")}
+${layout_declare_spec_const(C, "int", "split_idx", "0")}
+${layout_declare_spec_const(C, "int", "split_offset", "0")}
+${layout_declare_spec_const(C, "int", "out_layout", "CONTIG_LAYOUT_INT")}
+${layout_declare_spec_const(C, "int", "inp_layout", "CONTIG_LAYOUT_INT")}
+const int out_packed_dim = get_packed_dim(out_layout);
 
 void main() {
   const ivec3 out_pos = ivec3(gl_GlobalInvocationID);
@@ -42,24 +45,25 @@ void main() {
     return;
   }
 
-  TensorIndex4D out_tidx = texture_pos_to_tensor4d_idx_simple(outp, out_pos);
+  TensorIndex4D out_tidx =
+      texture_pos_to_tensor4d_idx_simple(outp, out_pos, out_layout);
 
   VEC4_T out_texel = VEC4_T(0);
 
   int limit = min(
-      4, outp.sizes[outp.packed_dim] - out_tidx.data[outp.packed_dim]);
+      4, outp.sizes[out_packed_dim] - out_tidx.data[out_packed_dim]);
 
   TensorIndex4D input_tidx = out_tidx;
   input_tidx.data[split_dim] += split_offset;
 
   for (int comp = 0; comp < limit; comp++) {
     TextureElementIndex input_elem_pos = tensor4d_idx_to_texture_element_idx_simple(
-        inp, input_tidx);
+        inp, input_tidx, inp_layout);
 
     VEC4_T input_texel = texelFetch(t_input, input_elem_pos.pos, 0);
     out_texel[comp] = input_texel[input_elem_pos.comp];
 
-    input_tidx.data[outp.packed_dim]++;
+    input_tidx.data[out_packed_dim]++;
   }
 
   imageStore(t_output, out_pos, out_texel);

--- a/backends/vulkan/runtime/graph/ops/glsl/transfer_texture.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/transfer_texture.glsl
@@ -51,6 +51,10 @@ layout(push_constant) uniform restrict Block {
 
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
 
+${layout_declare_spec_const(C, "int", "out_layout", "CONTIG_LAYOUT_INT")}
+${layout_declare_spec_const(C, "int", "inp_layout", "CONTIG_LAYOUT_INT")}
+const int out_packed_dim = get_packed_dim(out_layout);
+
 #include "${OP_NAME}.glslh"
 
 void main() {
@@ -60,21 +64,22 @@ void main() {
     return;
   }
 
-  TensorIndex4D out_tidx = texture_pos_to_tensor4d_idx_simple(outp, out_pos);
+  TensorIndex4D out_tidx =
+      texture_pos_to_tensor4d_idx_simple(outp, out_pos, out_layout);
   VEC4_T out_texel = VEC4_T(0);
 
   int limit = min(
-      4, outp.sizes[outp.packed_dim] - out_tidx.data[outp.packed_dim]);
+      4, outp.sizes[out_packed_dim] - out_tidx.data[out_packed_dim]);
   for (int comp = 0; comp < limit; comp++) {
     TensorIndex4D in_tidx = out_tidx_to_in_tidx(out_tidx);
 
     TextureElementIndex in_elem_pos = tensor4d_idx_to_texture_element_idx_simple(
-        inp, in_tidx);
+        inp, in_tidx, inp_layout);
 
     VEC4_T in_texel = texelFetch(t_in, in_elem_pos.pos, 0);
     out_texel[comp] = in_texel[in_elem_pos.comp];
 
-    out_tidx.data[outp.packed_dim]++;
+    out_tidx.data[out_packed_dim]++;
   }
 
   imageStore(t_out, out_pos, out_texel);

--- a/backends/vulkan/runtime/graph/ops/glsl/where.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/where.glsl
@@ -41,6 +41,11 @@ $else:
 
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
 
+${layout_declare_spec_const(C, "int", "out_layout", "CONTIG_LAYOUT_INT")}
+${layout_declare_spec_const(C, "int", "cond_layout", "CONTIG_LAYOUT_INT")}
+${layout_declare_spec_const(C, "int", "self_layout", "CONTIG_LAYOUT_INT")}
+${layout_declare_spec_const(C, "int", "other_layout", "CONTIG_LAYOUT_INT")}
+
 #ifdef USING_BUFFER
 
 void main() {
@@ -84,29 +89,34 @@ void main() {
     return;
   }
 
-  TensorIndex4D out_tidx = texture_pos_to_tensor4d_idx_simple(outp, out_pos);
+  const int out_packed_dim = get_packed_dim(out_layout);
+  TensorIndex4D out_tidx =
+      texture_pos_to_tensor4d_idx_simple(outp, out_pos, out_layout);
 
   VEC4_T outtex = VEC4_T(0);
 
   int limit = min(
-      4, outp.sizes[outp.packed_dim] - out_tidx.data[outp.packed_dim]);
+      4, outp.sizes[out_packed_dim] - out_tidx.data[out_packed_dim]);
   for (int comp = 0; comp < limit; comp++) {
     TensorIndex4D cond_tidx;
     cond_tidx.data = min(out_tidx.data, condp.sizes - 1);
     TextureElementIndex cond_elem =
-        tensor4d_idx_to_texture_element_idx_simple(condp, cond_tidx);
+        tensor4d_idx_to_texture_element_idx_simple(
+            condp, cond_tidx, cond_layout);
     uint cond_val = texelFetch(t_condition, cond_elem.pos, 0)[cond_elem.comp];
 
     TensorIndex4D self_tidx;
     self_tidx.data = min(out_tidx.data, selfp.sizes - 1);
     TextureElementIndex self_elem =
-        tensor4d_idx_to_texture_element_idx_simple(selfp, self_tidx);
+        tensor4d_idx_to_texture_element_idx_simple(
+            selfp, self_tidx, self_layout);
     VEC4_T self_texel = texelFetch(t_self, self_elem.pos, 0);
 
     TensorIndex4D other_tidx;
     other_tidx.data = min(out_tidx.data, otherp.sizes - 1);
     TextureElementIndex other_elem =
-        tensor4d_idx_to_texture_element_idx_simple(otherp, other_tidx);
+        tensor4d_idx_to_texture_element_idx_simple(
+            otherp, other_tidx, other_layout);
     VEC4_T other_texel = texelFetch(t_other, other_elem.pos, 0);
 
     if (cond_val > 0) {
@@ -115,7 +125,7 @@ void main() {
       outtex[comp] = other_texel[other_elem.comp];
     }
 
-    out_tidx.data[outp.packed_dim]++;
+    out_tidx.data[out_packed_dim]++;
   }
 
   imageStore(t_out, out_pos, outtex);

--- a/backends/vulkan/runtime/graph/ops/impl/Embedding.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Embedding.cpp
@@ -81,7 +81,7 @@ void add_embedding_node(
       // Push Constants
       {},
       // Specialization Constants
-      {},
+      {graph.hashed_layout_of(out), graph.hashed_layout_of(indices)},
       // Resize Args
       {},
       // Resizing Logic

--- a/backends/vulkan/runtime/graph/ops/impl/Gather.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Gather.cpp
@@ -64,7 +64,9 @@ void add_gather_node(
       // Push Constants
       {},
       // Specialization Constants
-      {static_cast<int32_t>(dim_whcn)},
+      {static_cast<int32_t>(dim_whcn),
+       graph.hashed_layout_of(out),
+       graph.hashed_layout_of(input)},
       // Resize Args
       {},
       // Resizing Logic

--- a/backends/vulkan/runtime/graph/ops/impl/IndexTensor.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/IndexTensor.cpp
@@ -51,7 +51,7 @@ void add_index_tensor_node(
       // Push Constants
       {},
       // Specialization Constants
-      {},
+      {graph.hashed_layout_of(out), graph.hashed_layout_of(self)},
       // Resize Args
       {},
       // Resizing Logic

--- a/backends/vulkan/runtime/graph/ops/impl/RotaryEmbedding.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/RotaryEmbedding.cpp
@@ -101,7 +101,7 @@ void add_rotary_embedding_node(
       // Push Constants
       {},
       // Specialization Constants
-      {},
+      {graph.hashed_layout_of(xq_out), graph.hashed_layout_of(freqs_cos)},
       // Resize Args
       {},
       // Resizing Logic

--- a/backends/vulkan/runtime/graph/ops/impl/Split.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Split.cpp
@@ -53,7 +53,9 @@ void add_split_node(
       // Specialization Constants
       {utils::safe_downcast<int32_t>(dim_whcn),
        static_cast<int32_t>(split_idx),
-       static_cast<int32_t>(split_offset)},
+       static_cast<int32_t>(split_offset),
+       graph.hashed_layout_of(out),
+       graph.hashed_layout_of(input)},
       // Resize Args
       {},
       // Resizing Logic

--- a/backends/vulkan/runtime/graph/ops/impl/Transfer.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Transfer.cpp
@@ -103,7 +103,7 @@ void add_transfer_copy_node(
       // Push Constants
       push_constants,
       // Specialization Constants
-      {},
+      {graph.hashed_layout_of(out), graph.hashed_layout_of(in)},
       // Resize Args
       resize_args,
       // Resizing Logic

--- a/backends/vulkan/runtime/graph/ops/impl/Where.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Where.cpp
@@ -68,7 +68,10 @@ void add_where_node(
       // Push Constants
       {},
       // Specialization Constants
-      {},
+      {graph.hashed_layout_of(out),
+       graph.hashed_layout_of(cond),
+       graph.hashed_layout_of(self),
+       graph.hashed_layout_of(other)},
       // Resize Arguments
       {},
       // Resizing Logic


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #18454
* #18453
* #18452
* #18451
* #18450
* __->__ #18449

The Adreno GPU driver miscompiles dynamic vector component access patterns
(`v[runtime_index]`) in GLSL shaders. This manifests as SIGSEGV crashes on
Adreno 740 and silent data corruption on Adreno 750 when accessing vector
components using a UBO-derived index (e.g. `tidx.data[meta.packed_dim]`).

This diff updates `texture_pos_to_tensor4d_idx_simple`,
`tensor4d_idx_to_texel_pos_simple`, and
`tensor4d_idx_to_texture_element_idx_simple` to accept a `hashed_layout`
parameter (typically a spec constant). The packed_dim is extracted from the
hashed layout and used in if/else chains with literal swizzles instead of
dynamic vector indexing, which the driver handles correctly.

Legacy 2-arg overloads are provided for shaders that don't yet have a
hashed_layout spec constant. These delegate to the 3-arg versions using
`meta.packed_dim << 16` to construct the layout at runtime. While this
doesn't enable compile-time branch elimination, the if/else pattern still
avoids the driver bug.

Shaders that already have hashed_layout spec constants (arange, full, expand,
repeat, pad, block_load, block_store) are updated to use the 3-arg versions.

Differential Revision: [D97959286](https://our.internmc.facebook.com/intern/diff/D97959286/)