### PR TITLE
[ET-VK] Modernize staging shaders to use indexing.glslh and TextureMetadata

### DIFF
--- a/backends/vulkan/runtime/graph/ops/glsl/image_to_nchw.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/image_to_nchw.glsl
@@ -21,56 +21,81 @@ ${define_active_storage_type(STORAGE)}
 
 layout(std430) buffer;
 
+#include "indexing.glslh"
+
 ${layout_declare_buffer(B, "w", "buf_out", BUF_DTYPE)}
 ${layout_declare_tensor(B, "r", "t_in", DTYPE, STORAGE)}
 
-$if USE_PUSH_CONST:
-  layout(push_constant) uniform restrict Block {
-    ivec4 sizes;
-  $if not TO_STAGING:
-    ivec4 buf_strides;
-  };
-$else:
-  ${layout_declare_ubo(B, "ivec4", "sizes")}
-  $if not TO_STAGING:
-    ${layout_declare_ubo(B, "ivec4", "buf_strides")}
+${layout_declare_ubo(B, "TextureMetadata", "inp")}
 
-#include "indexing_utils.h"
+$if not TO_STAGING:
+  ${layout_declare_ubo(B, "BufferMetadata", "buf_meta")}
 
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
 
-${layout_declare_spec_const(C, "int", "t_layout", "DEFAULT_LAYOUT")}
-const lowp ivec4 axis_map = unhash_axis_map(t_layout);
-const lowp int packed_dim = unhash_packed_dim(t_layout);
+${layout_declare_spec_const(C, "int", "in_layout", "CONTIG_LAYOUT_INT")}
 
-void write_out_texel(VEC4_T texel, ivec4 tidx) {
-  $if TO_STAGING:
-    const ivec4 buf_indices = tidx_to_nchwi(tidx, sizes, packed_dim);
-  $else:
-    const ivec4 buf_indices = tidx_to_4bufi(tidx, buf_strides, packed_dim);
-
-  if (tidx[packed_dim] < sizes[packed_dim]) {
-    buf_out[buf_indices.x] = BUF_T(texel.x);
-  }
-  if (tidx[packed_dim] + 1 < sizes[packed_dim]) {
-    buf_out[buf_indices.y] = BUF_T(texel.y);
-  }
-  if (tidx[packed_dim] + 2 < sizes[packed_dim]) {
-    buf_out[buf_indices.z] = BUF_T(texel.z);
-  }
-  if (tidx[packed_dim] + 3 < sizes[packed_dim]) {
-    buf_out[buf_indices.w] = BUF_T(texel.w);
-  }
-}
+$if not TO_STAGING:
+  ${layout_declare_spec_const(C, "int", "buf_layout", "CONTIG_LAYOUT_INT")}
 
 void main() {
-  const ivec3 lpos = ivec3(gl_GlobalInvocationID);
-  const ivec4 tidx = lpos_to_tidx(lpos, sizes, axis_map.w, packed_dim);
-
-  if (any(greaterThanEqual(tidx, sizes))) {
+  const ivec3 pos = ivec3(gl_GlobalInvocationID);
+  if (out_of_bounds(pos, inp)) {
     return;
   }
 
-  const VEC4_T intex = load_texel(t_in, lpos_to_pos(lpos, axis_map));
-  write_out_texel(intex, tidx);
+  TensorIndex4D tidx = texture_pos_to_tensor4d_idx_simple(inp, pos, in_layout);
+#ifdef USING_TEXTURE2D
+  const VEC4_T intex = texelFetch(t_in, pos.xy, 0);
+#else
+  const VEC4_T intex = texelFetch(t_in, pos, 0);
+#endif
+
+  const int packed_dim = get_packed_dim(in_layout);
+  int packed_dim_val;
+  if (packed_dim == 0) {
+    packed_dim_val = tidx.data.x;
+  } else if (packed_dim == 1) {
+    packed_dim_val = tidx.data.y;
+  } else if (packed_dim == 2) {
+    packed_dim_val = tidx.data.z;
+  } else {
+    packed_dim_val = tidx.data.w;
+  }
+
+  int packed_dim_size;
+  if (packed_dim == 0) {
+    packed_dim_size = inp.sizes.x;
+  } else if (packed_dim == 1) {
+    packed_dim_size = inp.sizes.y;
+  } else if (packed_dim == 2) {
+    packed_dim_size = inp.sizes.z;
+  } else {
+    packed_dim_size = inp.sizes.w;
+  }
+
+  int limit = min(4, packed_dim_size - packed_dim_val);
+
+  for (int comp = 0; comp < limit; comp++) {
+    $if TO_STAGING:
+      // Compute contiguous NCHW index
+      int nchwi = tidx.data.x
+                + tidx.data.y * inp.sizes.x
+                + tidx.data.z * inp.sizes.x * inp.sizes.y
+                + tidx.data.w * inp.sizes.x * inp.sizes.y * inp.sizes.z;
+      buf_out[nchwi] = BUF_T(intex[comp]);
+    $else:
+      int bufi = tensor4d_idx_to_buf_idx(buf_meta, tidx, buf_layout);
+      buf_out[bufi] = BUF_T(intex[comp]);
+
+    if (packed_dim == 0) {
+      tidx.data.x++;
+    } else if (packed_dim == 1) {
+      tidx.data.y++;
+    } else if (packed_dim == 2) {
+      tidx.data.z++;
+    } else {
+      tidx.data.w++;
+    }
+  }
 }

--- a/backends/vulkan/runtime/graph/ops/glsl/image_to_nchw.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/image_to_nchw.yaml
@@ -10,7 +10,6 @@ image_to_nchw:
     BUF_DTYPE: float
     STORAGE: texture3d
     TO_STAGING: True
-    USE_PUSH_CONST: True
   generate_variant_forall:
     combination:
       parameter_names: [DTYPE, BUF_DTYPE]
@@ -28,11 +27,3 @@ image_to_nchw:
       STORAGE: texture2d
     - NAME: clone_image_to_buffer
       TO_STAGING: False
-    - NAME: image_to_nchw_no_pc_texture3d
-      USE_PUSH_CONST: False
-    - NAME: image_to_nchw_no_pc_texture2d
-      STORAGE: texture2d
-      USE_PUSH_CONST: False
-    - NAME: clone_image_to_buffer_no_pc
-      TO_STAGING: False
-      USE_PUSH_CONST: False

--- a/backends/vulkan/runtime/graph/ops/glsl/indexing.glslh
+++ b/backends/vulkan/runtime/graph/ops/glsl/indexing.glslh
@@ -78,6 +78,7 @@ bool is_channels_last(const int hashed_layout) {
 #define get_outer_packed_dim(layout) (((layout) >> 20) & 0xF)
 #define get_packed_dim_block_size(layout) (((layout) >> 24) & 0xF)
 #define get_outer_packed_dim_block_size(layout) (((layout) >> 28) & 0xF)
+#define get_batch_concat_dim(layout) (((layout) >> 12) & 0xF)
 
 // Safe ivec4 component access via if/else chain. Avoids dynamic vector
 // indexing (v[index]) on UBO-backed ivec4 members, which crashes on Adreno 740
@@ -458,15 +459,16 @@ TensorIndex4D texture_pos_to_tensor4d_idx_simple(
   tidx.data.w = 0;
   safe_set(tidx.data, packed_dim, safe_idx(tidx.data, packed_dim) * 4);
 
-  // Compute batch idx accounting for batch concatenation, assuming channels as
-  // the concatenation dim.
+  // Compute batch idx using batch_concat_dim from hashed_layout
   if (meta.sizes.w > 1) {
-    int channels = meta.sizes.z;
-    if (packed_dim == 2) {
-      channels = align_up_4(channels);
+    const int batch_concat_dim = get_batch_concat_dim(hashed_layout);
+    int concat_dim_size = safe_idx(meta.sizes, batch_concat_dim);
+    if (batch_concat_dim == packed_dim) {
+      concat_dim_size = align_up_4(concat_dim_size);
     }
-    tidx.data.w = tidx.data.z / channels;
-    tidx.data.z = tidx.data.z % channels;
+    int concat_dim_val = safe_idx(tidx.data, batch_concat_dim);
+    tidx.data.w = concat_dim_val / concat_dim_size;
+    safe_set(tidx.data, batch_concat_dim, concat_dim_val % concat_dim_size);
   }
   return tidx;
 }
@@ -489,13 +491,20 @@ ivec3 tensor4d_idx_to_texel_pos_simple(
     texel_pos.z = div_4(packed_dim_idx);
   }
 
-  // Account for batch concatenation, assuming channels as the concatenation dim
+  // Account for batch concatenation
   if (meta.sizes.w > 1) {
-    int channels_ntexels = meta.sizes.z;
-    if (packed_dim == 2) {
-      channels_ntexels = div_up_4(channels_ntexels);
+    const int batch_concat_dim = get_batch_concat_dim(hashed_layout);
+    int concat_dim_ntexels = safe_idx(meta.sizes, batch_concat_dim);
+    if (batch_concat_dim == packed_dim) {
+      concat_dim_ntexels = div_up_4(concat_dim_ntexels);
     }
-    texel_pos.z += tidx.data.w * channels_ntexels;
+    if (batch_concat_dim == 0) {
+      texel_pos.x += tidx.data.w * concat_dim_ntexels;
+    } else if (batch_concat_dim == 1) {
+      texel_pos.y += tidx.data.w * concat_dim_ntexels;
+    } else {
+      texel_pos.z += tidx.data.w * concat_dim_ntexels;
+    }
   }
 
   return texel_pos;
@@ -521,13 +530,20 @@ TextureElementIndex tensor4d_idx_to_texture_element_idx_simple(
   }
   tex_idx.comp = mod_4(packed_dim_idx);
 
-  // Account for batch concatenation, assuming channels as the concatenation dim
+  // Account for batch concatenation
   if (meta.sizes.w > 1) {
-    int channels_ntexels = meta.sizes.z;
-    if (packed_dim == 2) {
-      channels_ntexels = div_up_4(channels_ntexels);
+    const int batch_concat_dim = get_batch_concat_dim(hashed_layout);
+    int concat_dim_ntexels = safe_idx(meta.sizes, batch_concat_dim);
+    if (batch_concat_dim == packed_dim) {
+      concat_dim_ntexels = div_up_4(concat_dim_ntexels);
     }
-    tex_idx.pos.z += tidx.data.w * channels_ntexels;
+    if (batch_concat_dim == 0) {
+      tex_idx.pos.x += tidx.data.w * concat_dim_ntexels;
+    } else if (batch_concat_dim == 1) {
+      tex_idx.pos.y += tidx.data.w * concat_dim_ntexels;
+    } else {
+      tex_idx.pos.z += tidx.data.w * concat_dim_ntexels;
+    }
   }
 
   return tex_idx;

--- a/backends/vulkan/runtime/graph/ops/glsl/nchw_to_image.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/nchw_to_image.glsl
@@ -20,77 +20,95 @@ ${define_active_storage_type(STORAGE)}
 
 layout(std430) buffer;
 
+#include "indexing.glslh"
+
 ${layout_declare_tensor(B, "w", "t_out", DTYPE, STORAGE)}
 ${layout_declare_buffer(B, "r", "buf_in", BUF_DTYPE)}
 
-$if USE_PUSH_CONST:
-  layout(push_constant) uniform restrict Block {
-    ivec4 sizes;
-  $if not FROM_STAGING:
-    ivec4 buf_strides;
-  };
-$else:
-  ${layout_declare_ubo(B, "ivec4", "sizes")}
-  $if not FROM_STAGING:
-    ${layout_declare_ubo(B, "ivec4", "buf_strides")}
+${layout_declare_ubo(B, "TextureMetadata", "outp")}
 
-#include "indexing_utils.h"
+$if not FROM_STAGING:
+  ${layout_declare_ubo(B, "BufferMetadata", "buf_meta")}
 
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
 
-${layout_declare_spec_const(C, "int", "t_layout", "DEFAULT_LAYOUT")}
+${layout_declare_spec_const(C, "int", "out_layout", "CONTIG_LAYOUT_INT")}
 ${layout_declare_spec_const(C, "int", "transpose_hw", "0")}
 
-const lowp ivec4 axis_map = unhash_axis_map(t_layout);
-const lowp int packed_dim = unhash_packed_dim(t_layout);
-
-VEC4_T read_texel(ivec4 tidx) {
-  ivec4 tidx_to_use = tidx;
-  ivec4 sizes_to_use = sizes;
-  int packed_dim_to_use = packed_dim;
-  if (transpose_hw == 1) {
-    sizes_to_use.xy = sizes_to_use.yx;
-    tidx_to_use.xy = tidx.yx;
-
-    if (packed_dim == 1) {
-      packed_dim_to_use = 0;
-    }
-    if (packed_dim == 0) {
-      packed_dim_to_use = 1;
-    }
-  }
-
-  $if FROM_STAGING:
-    const ivec4 buf_indices = tidx_to_nchwi(tidx_to_use, sizes_to_use, packed_dim_to_use);
-  $else:
-    const ivec4 buf_indices = tidx_to_4bufi(tidx_to_use, buf_strides, packed_dim_to_use);
-
-  VEC4_T texel = VEC4_T(0);
-  if (tidx[packed_dim] < sizes[packed_dim]) {
-    texel.x = SCALAR_T(buf_in[buf_indices.x]);
-  }
-  if (tidx[packed_dim] + 1 < sizes[packed_dim]) {
-    texel.y = SCALAR_T(buf_in[buf_indices.y]);
-  }
-  if (tidx[packed_dim] + 2 < sizes[packed_dim]) {
-    texel.z = SCALAR_T(buf_in[buf_indices.z]);
-  }
-  if (tidx[packed_dim] + 3 < sizes[packed_dim]) {
-    texel.w = SCALAR_T(buf_in[buf_indices.w]);
-  }
-  return texel;
-}
+$if not FROM_STAGING:
+  ${layout_declare_spec_const(C, "int", "buf_layout", "CONTIG_LAYOUT_INT")}
 
 void main() {
-  const ivec3 lpos = ivec3(gl_GlobalInvocationID);
-  const ivec4 tidx = lpos_to_tidx(lpos, sizes, axis_map.w, packed_dim);
-  if (any(greaterThanEqual(tidx, sizes))) {
+  const ivec3 pos = ivec3(gl_GlobalInvocationID);
+  if (out_of_bounds(pos, outp)) {
     return;
   }
 
-  $if DTYPE == "double" and DTYPE == "int64":
-    VEC4_T texel = read_texel(tidx);
-    write_texel(t_out, lpos_to_pos(lpos, axis_map), texel);
-  $else:
-    write_texel(t_out, lpos_to_pos(lpos, axis_map), read_texel(tidx));
+  TensorIndex4D tidx = texture_pos_to_tensor4d_idx_simple(outp, pos, out_layout);
+
+  const int packed_dim = get_packed_dim(out_layout);
+  int packed_dim_val;
+  if (packed_dim == 0) {
+    packed_dim_val = tidx.data.x;
+  } else if (packed_dim == 1) {
+    packed_dim_val = tidx.data.y;
+  } else if (packed_dim == 2) {
+    packed_dim_val = tidx.data.z;
+  } else {
+    packed_dim_val = tidx.data.w;
+  }
+
+  int packed_dim_size;
+  if (packed_dim == 0) {
+    packed_dim_size = outp.sizes.x;
+  } else if (packed_dim == 1) {
+    packed_dim_size = outp.sizes.y;
+  } else if (packed_dim == 2) {
+    packed_dim_size = outp.sizes.z;
+  } else {
+    packed_dim_size = outp.sizes.w;
+  }
+
+  VEC4_T texel = VEC4_T(0);
+  int limit = min(4, packed_dim_size - packed_dim_val);
+
+  for (int comp = 0; comp < limit; comp++) {
+    TensorIndex4D buf_tidx = tidx;
+    if (transpose_hw == 1) {
+      int tmp = buf_tidx.data.x;
+      buf_tidx.data.x = buf_tidx.data.y;
+      buf_tidx.data.y = tmp;
+    }
+
+    $if FROM_STAGING:
+      // Compute contiguous NCHW index
+      ivec4 s = outp.sizes;
+      if (transpose_hw == 1) {
+        s.xy = s.yx;
+      }
+      int nchwi = buf_tidx.data.x
+                + buf_tidx.data.y * s.x
+                + buf_tidx.data.z * s.x * s.y
+                + buf_tidx.data.w * s.x * s.y * s.z;
+      texel[comp] = SCALAR_T(buf_in[nchwi]);
+    $else:
+      int bufi = tensor4d_idx_to_buf_idx(buf_meta, buf_tidx, buf_layout);
+      texel[comp] = SCALAR_T(buf_in[bufi]);
+
+    if (packed_dim == 0) {
+      tidx.data.x++;
+    } else if (packed_dim == 1) {
+      tidx.data.y++;
+    } else if (packed_dim == 2) {
+      tidx.data.z++;
+    } else {
+      tidx.data.w++;
+    }
+  }
+
+#ifdef USING_TEXTURE2D
+  imageStore(t_out, pos.xy, texel);
+#else
+  imageStore(t_out, pos, texel);
+#endif
 }

--- a/backends/vulkan/runtime/graph/ops/glsl/nchw_to_image.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/nchw_to_image.yaml
@@ -9,7 +9,6 @@ nchw_to_image:
     STORAGE: texture3d
     DTYPE: float
     FROM_STAGING: True
-    USE_PUSH_CONST: True
   generate_variant_forall:
     combination:
       parameter_names: [DTYPE, BUF_DTYPE]
@@ -27,11 +26,3 @@ nchw_to_image:
       STORAGE: texture2d
     - NAME: clone_buffer_to_image
       FROM_STAGING: False
-    - NAME: nchw_to_image_no_pc_texture3d
-      USE_PUSH_CONST: False
-    - NAME: nchw_to_image_no_pc_texture2d
-      STORAGE: texture2d
-      USE_PUSH_CONST: False
-    - NAME: clone_buffer_to_image_no_pc
-      FROM_STAGING: False
-      USE_PUSH_CONST: False

--- a/backends/vulkan/runtime/graph/ops/impl/Clone.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Clone.cpp
@@ -87,12 +87,12 @@ void add_image_to_buffer_node(
       default_pick_local_wg_size,
       // Input and Outputs
       {{buffer, vkapi::kWrite}, {image, vkapi::kRead}},
-      // Parameter Buffers
+      // Parameter Buffers: TextureMetadata for image, BufferMetadata for buffer
+      {graph.texture_meta_ubo(image), graph.buffer_meta_ubo(buffer)},
+      // Push Constants: none
       {},
-      // Push Constants
-      {graph.sizes_pc_of(image), graph.strides_pc_of(buffer)},
-      // Specialization Constants
-      {graph.hashed_layout_of(image)},
+      // Specialization Constants: image layout + buffer layout
+      {graph.hashed_layout_of(image), graph.hashed_layout_of(buffer)},
       // Resize Args
       {},
       // Resizing Logic
@@ -115,12 +115,12 @@ void add_buffer_to_image_node(
       default_pick_local_wg_size,
       // Input and Outputs
       {{image, vkapi::kWrite}, {buffer, vkapi::kRead}},
-      // Parameter Buffers
+      // Parameter Buffers: TextureMetadata for image, BufferMetadata for buffer
+      {graph.texture_meta_ubo(image), graph.buffer_meta_ubo(buffer)},
+      // Push Constants: none
       {},
-      // Push Constants
-      {graph.sizes_pc_of(image), graph.strides_pc_of(buffer)},
-      // Specialization Constants
-      {graph.hashed_layout_of(image)},
+      // Specialization Constants: image layout, transpose_hw=0, buffer layout
+      {graph.hashed_layout_of(image), int32_t(0), graph.hashed_layout_of(buffer)},
       // Resize Args
       {},
       // Resizing Logic

--- a/backends/vulkan/runtime/graph/ops/impl/Clone.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Clone.cpp
@@ -120,7 +120,9 @@ void add_buffer_to_image_node(
       // Push Constants: none
       {},
       // Specialization Constants: image layout, transpose_hw=0, buffer layout
-      {graph.hashed_layout_of(image), int32_t(0), graph.hashed_layout_of(buffer)},
+      {graph.hashed_layout_of(image),
+       int32_t(0),
+       graph.hashed_layout_of(buffer)},
       // Resize Args
       {},
       // Resizing Logic

--- a/backends/vulkan/runtime/graph/ops/impl/Convolution.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Convolution.cpp
@@ -566,8 +566,7 @@ void add_conv1d_node(
       weight,
       graph.storage_type_of(out),
       utils::kChannelsPacked,
-      /* passthrough = */ false,
-      utils::kOptimizedAxisMap);
+      /* passthrough = */ false);
   ValueRef arg_bias = prepack_biases(
       graph,
       bias,

--- a/backends/vulkan/runtime/graph/ops/impl/Convolution.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Convolution.cpp
@@ -110,6 +110,18 @@ ValueRef prepack_biases(
   vkapi::ShaderInfo shader =
       get_nchw_to_tensor_shader(graph, v, graph.get_staging_dtype_for(weight));
 
+  vkapi::ParamsBindList param_buffers = {};
+  if (graph.is_buffer_storage(v)) {
+    param_buffers.append(graph.buffer_meta_ubo(v));
+  } else {
+    param_buffers.append(graph.texture_meta_ubo(v));
+  }
+
+  std::vector<PushConstantDataInfo> pcs;
+  if (graph.is_buffer_storage(v)) {
+    pcs = {graph.sizes_pc_of(v), graph.strides_pc_of(v), graph.numel_pc_of(v)};
+  }
+
   graph.prepack_nodes().emplace_back(new PrepackNode(
       graph,
       shader,
@@ -117,10 +129,10 @@ ValueRef prepack_biases(
       graph.create_local_wg_size(v),
       vref,
       v,
-      {},
+      param_buffers,
       // Specialization constants
       {graph.hashed_layout_of(v)},
-      {graph.sizes_pc_of(v)}));
+      pcs));
 
   return v;
 }

--- a/backends/vulkan/runtime/graph/ops/impl/SDPA.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/SDPA.cpp
@@ -15,7 +15,6 @@
 #include <executorch/backends/vulkan/runtime/graph/ops/impl/RepeatInterleave.h>
 #include <executorch/backends/vulkan/runtime/graph/ops/impl/Slice.h>
 #include <executorch/backends/vulkan/runtime/graph/ops/impl/Softmax.h>
-#include <executorch/backends/vulkan/runtime/graph/ops/impl/Transpose.h>
 
 #include <executorch/backends/vulkan/runtime/graph/ops/impl/utils/ScalarUtils.h>
 

--- a/backends/vulkan/runtime/graph/ops/impl/Staging.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Staging.cpp
@@ -21,6 +21,21 @@
 
 namespace vkcompute {
 
+const std::string kBitw8PrefixStr = "bitw8_image_to_nchw_nobitw8buffer";
+const std::string kNchwToBitw8PrefixStr = "nchw_to_bitw8_image_nobitw8buffer";
+
+bool is_bitw8_shader(const vkapi::ShaderInfo& shader) {
+  const auto size = kBitw8PrefixStr.size();
+  const std::string& shader_prefix_str = shader.kernel_name.substr(0, size);
+  return shader_prefix_str == kBitw8PrefixStr;
+}
+
+bool is_nchw_to_bitw8_shader(const vkapi::ShaderInfo& shader) {
+  const auto size = kNchwToBitw8PrefixStr.size();
+  const std::string& shader_prefix_str = shader.kernel_name.substr(0, size);
+  return shader_prefix_str == kNchwToBitw8PrefixStr;
+}
+
 void add_staging_to_tensor_node(
     ComputeGraph& graph,
     const ValueRef in_staging,
@@ -40,10 +55,12 @@ void add_staging_to_tensor_node(
   vkapi::ParamsBindList param_buffers = {};
   if (graph.is_buffer_storage(out_tensor)) {
     param_buffers.append(graph.buffer_meta_ubo(out_tensor));
+  } else if (!is_nchw_to_bitw8_shader(shader)) {
+    param_buffers.append(graph.texture_meta_ubo(out_tensor));
   }
 
   std::vector<PushConstantDataInfo> pcs;
-  if (graph.is_texture_storage(out_tensor)) {
+  if (is_nchw_to_bitw8_shader(shader)) {
     pcs = {graph.sizes_pc_of(out_tensor)};
   }
 
@@ -64,14 +81,6 @@ void add_staging_to_tensor_node(
       {},
       // Resizing Logic
       nullptr));
-}
-
-const std::string kBitw8PrefixStr = "bitw8_image_to_nchw_nobitw8buffer";
-
-bool is_bitw8_shader(const vkapi::ShaderInfo& shader) {
-  const auto size = kBitw8PrefixStr.size();
-  const std::string& shader_prefix_str = shader.kernel_name.substr(0, size);
-  return shader_prefix_str == kBitw8PrefixStr;
 }
 
 utils::uvec3 tensor_to_staging_global_wg_size(
@@ -121,14 +130,13 @@ void add_tensor_to_staging_node(
   vkapi::ParamsBindList param_buffers = {};
   if (graph.is_buffer_storage(in_tensor)) {
     param_buffers.append(graph.buffer_meta_ubo(in_tensor));
+  } else if (!is_bitw8_shader(shader)) {
+    param_buffers.append(graph.texture_meta_ubo(in_tensor));
   }
 
   std::vector<PushConstantDataInfo> pcs;
-  if (graph.is_texture_storage(in_tensor)) {
-    pcs = {graph.sizes_pc_of(in_tensor)};
-  }
-
   if (is_bitw8_shader(shader)) {
+    pcs.push_back(graph.sizes_pc_of(in_tensor));
     pcs.push_back(graph.numel_pc_of(in_tensor));
   }
 
@@ -165,6 +173,8 @@ void add_prepack_standard_node(
   vkapi::ParamsBindList param_buffers = {};
   if (graph.is_buffer_storage(tensor)) {
     param_buffers.append(graph.buffer_meta_ubo(tensor));
+  } else if (!is_nchw_to_bitw8_shader(shader)) {
+    param_buffers.append(graph.texture_meta_ubo(tensor));
   }
 
   std::vector<PushConstantDataInfo> pcs;
@@ -173,7 +183,7 @@ void add_prepack_standard_node(
         graph.sizes_pc_of(tensor),
         graph.strides_pc_of(tensor),
         graph.numel_pc_of(tensor)};
-  } else {
+  } else if (is_nchw_to_bitw8_shader(shader)) {
     pcs = {graph.sizes_pc_of(tensor)};
   }
 

--- a/backends/vulkan/runtime/graph/ops/impl/Transpose.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Transpose.cpp
@@ -69,18 +69,4 @@ void add_transpose_view_node(
       resize_transpose_view_node, {out_ref, input_ref, dim0_ref, dim1_ref}));
 }
 
-void transpose(ComputeGraph& graph, const std::vector<ValueRef>& args) {
-  const ValueRef out = args[3];
-  return add_transpose_view_node(
-      graph,
-      args[0], // input
-      args[1], // dim0
-      args[2], // dim1
-      out);
-}
-
-REGISTER_OPERATORS {
-  VK_REGISTER_OP(aten.transpose.int, transpose);
-}
-
 } // namespace vkcompute

--- a/backends/vulkan/runtime/graph/ops/utils/StagingUtils.cpp
+++ b/backends/vulkan/runtime/graph/ops/utils/StagingUtils.cpp
@@ -24,8 +24,7 @@ vkapi::ShaderInfo get_nchw_to_tensor_shader(
     ComputeGraph& graph,
     const ValueRef dst,
     const vkapi::ScalarType staging_dtype,
-    bool int8_buffer_enabled,
-    bool push_constant_variant) {
+    bool int8_buffer_enabled) {
   std::string kernel_name;
   kernel_name.reserve(kShaderNameReserve);
 
@@ -35,9 +34,6 @@ vkapi::ShaderInfo get_nchw_to_tensor_shader(
   if (is_bitw8(dst_dtype) && dst_storage_type != utils::kBuffer &&
       !int8_buffer_enabled) {
     kernel_name = "nchw_to_bitw8_image_nobitw8buffer";
-    if (!push_constant_variant) {
-      kernel_name += "_no_pc";
-    }
     add_storage_type_suffix(kernel_name, dst_storage_type);
     add_dtype_suffix(kernel_name, dst_dtype);
     return VK_KERNEL_FROM_STR(kernel_name);
@@ -51,9 +47,6 @@ vkapi::ShaderInfo get_nchw_to_tensor_shader(
   }
 
   kernel_name = "nchw_to_image";
-  if (!push_constant_variant) {
-    kernel_name += "_no_pc";
-  }
   add_storage_type_suffix(kernel_name, dst_storage_type);
   add_dtype_suffix(kernel_name, dst_dtype);
   add_dtype_suffix(kernel_name, staging_dtype);
@@ -65,8 +58,7 @@ vkapi::ShaderInfo get_tensor_to_nchw_shader(
     ComputeGraph& graph,
     const ValueRef src,
     const vkapi::ScalarType staging_dtype,
-    bool int8_buffer_enabled,
-    bool push_constant_variant) {
+    bool int8_buffer_enabled) {
   std::string kernel_name;
   kernel_name.reserve(kShaderNameReserve);
 
@@ -76,9 +68,6 @@ vkapi::ShaderInfo get_tensor_to_nchw_shader(
   if (is_bitw8(src_dtype) && src_storage_type != utils::kBuffer &&
       !int8_buffer_enabled) {
     kernel_name = "bitw8_image_to_nchw_nobitw8buffer";
-    if (!push_constant_variant) {
-      kernel_name += "_no_pc";
-    }
     add_storage_type_suffix(kernel_name, src_storage_type);
     add_dtype_suffix(kernel_name, src_dtype);
     return VK_KERNEL_FROM_STR(kernel_name);
@@ -92,9 +81,6 @@ vkapi::ShaderInfo get_tensor_to_nchw_shader(
   }
 
   kernel_name = "image_to_nchw";
-  if (!push_constant_variant) {
-    kernel_name += "_no_pc";
-  }
   add_storage_type_suffix(kernel_name, src_storage_type);
   add_dtype_suffix(kernel_name, src_dtype);
   add_dtype_suffix(kernel_name, staging_dtype);

--- a/backends/vulkan/runtime/graph/ops/utils/StagingUtils.h
+++ b/backends/vulkan/runtime/graph/ops/utils/StagingUtils.h
@@ -16,14 +16,12 @@ vkapi::ShaderInfo get_nchw_to_tensor_shader(
     ComputeGraph& graph,
     const ValueRef dst,
     const vkapi::ScalarType staging_dtype,
-    bool int8_buffer_enabled = true,
-    bool push_constant_variant = true);
+    bool int8_buffer_enabled = true);
 
 vkapi::ShaderInfo get_tensor_to_nchw_shader(
     ComputeGraph& graph,
     const ValueRef src,
     const vkapi::ScalarType staging_dtype,
-    bool int8_buffer_enabled = true,
-    bool push_constant_variant = true);
+    bool int8_buffer_enabled = true);
 
 } // namespace vkcompute

--- a/backends/vulkan/test/op_tests/cases.py
+++ b/backends/vulkan/test/op_tests/cases.py
@@ -1106,31 +1106,6 @@ def get_slice_inputs():
     return [view_test_suite, texture_test_suite]
 
 
-@register_test_suite(["aten.transpose.int"])
-def get_transpose_inputs():
-    Test = namedtuple("VkTransposeViewTest", ["self", "dim0", "dim1"])
-    Test.__new__.__defaults__ = (None, 0, 1)
-
-    test_cases = [
-        Test(self=[M1, M2], dim0=0, dim1=1),
-        Test(self=[M1, S2, M], dim0=0, dim1=1),
-        Test(self=[M1, S2, M], dim0=0, dim1=2),
-        Test(self=[M1, S2, M], dim0=2, dim1=1),
-        Test(self=[S, M, S2, M2], dim0=3, dim1=2),
-        Test(self=[S, M, S2, M2], dim0=1, dim1=2),
-        Test(self=[S, M, S2, M2], dim0=3, dim1=1),
-    ]
-
-    test_suite = VkTestSuite([tuple(tc) for tc in test_cases])
-
-    test_suite.dtypes = ["at::kFloat"]
-    test_suite.storage_types = ["utils::kBuffer", "utils::kTexture3D"]
-    test_suite.layouts = ["utils::kWidthPacked", "utils::kChannelsPacked"]
-    test_suite.data_gen = "make_seq_tensor"
-    test_suite.is_view_op = True
-    return test_suite
-
-
 @register_test_suite("aten.index_select.default")
 def get_index_select_inputs():
     Test = namedtuple("VkIndexSelectTest", ["self", "dim", "index"])

--- a/backends/vulkan/test/utils/test_utils.cpp
+++ b/backends/vulkan/test/utils/test_utils.cpp
@@ -25,17 +25,14 @@ bool is_bitw8(vkapi::ScalarType dtype) {
 
 vkapi::ShaderInfo get_nchw_to_tensor_shader(
     const api::vTensor& v_dst,
-    bool int8_buffer_enabled,
-    bool push_constant_variant) {
+    bool int8_buffer_enabled) {
   std::string kernel_name;
   kernel_name.reserve(kShaderNameReserve);
 
   if (is_bitw8(v_dst.dtype()) && v_dst.storage_type() != utils::kBuffer &&
       !int8_buffer_enabled) {
-    kernel_name = "nchw_to_bitw8_image_nobitw8buffer";
-    if (!push_constant_variant) {
-      kernel_name += "_no_pc";
-    }
+    // Use _no_pc variant since submit_compute_job only supports UBOs
+    kernel_name = "nchw_to_bitw8_image_nobitw8buffer_no_pc";
     add_storage_type_suffix(kernel_name, v_dst.storage_type());
     add_dtype_suffix(kernel_name, v_dst.dtype());
     return VK_KERNEL_FROM_STR(kernel_name);
@@ -49,9 +46,6 @@ vkapi::ShaderInfo get_nchw_to_tensor_shader(
   }
 
   kernel_name = "nchw_to_image";
-  if (!push_constant_variant) {
-    kernel_name += "_no_pc";
-  }
   add_storage_type_suffix(kernel_name, v_dst.storage_type());
   add_dtype_suffix(kernel_name, v_dst.dtype());
   add_dtype_suffix(kernel_name, v_dst.dtype());
@@ -61,17 +55,14 @@ vkapi::ShaderInfo get_nchw_to_tensor_shader(
 
 vkapi::ShaderInfo get_tensor_to_nchw_shader(
     const api::vTensor& v_src,
-    bool int8_buffer_enabled,
-    bool push_constant_variant) {
+    bool int8_buffer_enabled) {
   std::string kernel_name;
   kernel_name.reserve(kShaderNameReserve);
 
   if (is_bitw8(v_src.dtype()) && v_src.storage_type() != utils::kBuffer &&
       !int8_buffer_enabled) {
-    kernel_name = "bitw8_image_to_nchw_nobitw8buffer";
-    if (!push_constant_variant) {
-      kernel_name += "_no_pc";
-    }
+    // Use _no_pc variant since submit_compute_job only supports UBOs
+    kernel_name = "bitw8_image_to_nchw_nobitw8buffer_no_pc";
     add_storage_type_suffix(kernel_name, v_src.storage_type());
     add_dtype_suffix(kernel_name, v_src.dtype());
     return VK_KERNEL_FROM_STR(kernel_name);
@@ -85,9 +76,6 @@ vkapi::ShaderInfo get_tensor_to_nchw_shader(
   }
 
   kernel_name = "image_to_nchw";
-  if (!push_constant_variant) {
-    kernel_name += "_no_pc";
-  }
   add_storage_type_suffix(kernel_name, v_src.storage_type());
   add_dtype_suffix(kernel_name, v_src.dtype());
   add_dtype_suffix(kernel_name, v_src.dtype());
@@ -106,7 +94,7 @@ void record_nchw_to_buffer_op(
   vkapi::SpecVarList specialization_constants = {v_dst.hashed_layout()};
 
   context->submit_compute_job(
-      get_nchw_to_tensor_shader(v_dst, true, false),
+      get_nchw_to_tensor_shader(v_dst, true),
       pipeline_barrier,
       {uint32_t(v_dst.numel()), 1, 1},
       {64, 1, 1},
@@ -127,7 +115,7 @@ void record_buffer_to_nchw_op(
     vkapi::VulkanBuffer& dst_buffer) {
   vkapi::PipelineBarrier pipeline_barrier{};
   context->submit_compute_job(
-      get_tensor_to_nchw_shader(v_src, true, false),
+      get_tensor_to_nchw_shader(v_src, true),
       pipeline_barrier,
       {uint32_t(v_src.numel()), 1, 1},
       {64, 1, 1},
@@ -146,23 +134,46 @@ void record_nchw_to_image_op(
   vkapi::PipelineBarrier pipeline_barrier{};
   vkapi::SpecVarList specialization_constants = {v_dst.hashed_layout()};
 
-  context->submit_compute_job(
-      get_nchw_to_tensor_shader(
-          v_dst,
-          context->adapter_ptr()->has_full_int8_buffers_support(),
-          false),
-      pipeline_barrier,
-      v_dst.logical_limits(),
-      adaptive_work_group_size(v_dst.logical_limits()),
-      specialization_constants,
-      VK_NULL_HANDLE,
-      0,
-      v_dst.image(
-          pipeline_barrier,
-          vkapi::PipelineStage::COMPUTE,
-          vkapi::MemoryAccessType::WRITE),
-      src_buffer,
-      v_dst.sizes_ubo());
+  bool int8_buffer_enabled =
+      context->adapter_ptr()->has_full_int8_buffers_support();
+  auto shader = get_nchw_to_tensor_shader(v_dst, int8_buffer_enabled);
+
+  // bitw8 _no_pc shaders expect ivec4 sizes UBO; regular shaders expect
+  // TextureMetadata UBO. The bitw8 path is only used when int8 buffers are
+  // NOT supported.
+  bool use_bitw8 = is_bitw8(v_dst.dtype()) && !int8_buffer_enabled;
+
+  if (use_bitw8) {
+    context->submit_compute_job(
+        shader,
+        pipeline_barrier,
+        v_dst.logical_limits(),
+        adaptive_work_group_size(v_dst.logical_limits()),
+        specialization_constants,
+        VK_NULL_HANDLE,
+        0,
+        v_dst.image(
+            pipeline_barrier,
+            vkapi::PipelineStage::COMPUTE,
+            vkapi::MemoryAccessType::WRITE),
+        src_buffer,
+        v_dst.sizes_ubo());
+  } else {
+    context->submit_compute_job(
+        shader,
+        pipeline_barrier,
+        v_dst.logical_limits(),
+        adaptive_work_group_size(v_dst.logical_limits()),
+        specialization_constants,
+        VK_NULL_HANDLE,
+        0,
+        v_dst.image(
+            pipeline_barrier,
+            vkapi::PipelineStage::COMPUTE,
+            vkapi::MemoryAccessType::WRITE),
+        src_buffer,
+        v_dst.texture_meta_ubo());
+  }
 }
 
 void record_image_to_nchw_op(
@@ -172,17 +183,40 @@ void record_image_to_nchw_op(
   vkapi::PipelineBarrier pipeline_barrier{};
   vkapi::SpecVarList specialization_constants = {v_src.hashed_layout()};
 
-  context->submit_compute_job(
-      get_tensor_to_nchw_shader(v_src, true, false),
-      pipeline_barrier,
-      v_src.logical_limits(),
-      adaptive_work_group_size(v_src.logical_limits()),
-      specialization_constants,
-      VK_NULL_HANDLE,
-      0,
-      dst_buffer,
-      v_src.image(pipeline_barrier, vkapi::PipelineStage::COMPUTE),
-      v_src.sizes_ubo());
+  bool int8_buffer_enabled =
+      context->adapter_ptr()->has_full_int8_buffers_support();
+  auto shader = get_tensor_to_nchw_shader(v_src, int8_buffer_enabled);
+
+  // bitw8 _no_pc shaders expect ivec4 sizes UBO; regular shaders expect
+  // TextureMetadata UBO. The bitw8 path is only used when int8 buffers are
+  // NOT supported.
+  bool use_bitw8 = is_bitw8(v_src.dtype()) && !int8_buffer_enabled;
+
+  if (use_bitw8) {
+    context->submit_compute_job(
+        shader,
+        pipeline_barrier,
+        v_src.logical_limits(),
+        adaptive_work_group_size(v_src.logical_limits()),
+        specialization_constants,
+        VK_NULL_HANDLE,
+        0,
+        dst_buffer,
+        v_src.image(pipeline_barrier, vkapi::PipelineStage::COMPUTE),
+        v_src.sizes_ubo());
+  } else {
+    context->submit_compute_job(
+        shader,
+        pipeline_barrier,
+        v_src.logical_limits(),
+        adaptive_work_group_size(v_src.logical_limits()),
+        specialization_constants,
+        VK_NULL_HANDLE,
+        0,
+        dst_buffer,
+        v_src.image(pipeline_barrier, vkapi::PipelineStage::COMPUTE),
+        v_src.texture_meta_ubo());
+  }
 }
 
 void record_bitw8_image_to_nchw_nobitw8buffer_op(

--- a/backends/vulkan/test/vulkan_compute_api_test.cpp
+++ b/backends/vulkan/test/vulkan_compute_api_test.cpp
@@ -972,48 +972,6 @@ TEST_F(VulkanComputeAPITest, texture_tensor_ubo_metadata_budget_test) {
   EXPECT_NO_THROW(buffer_tensor.numel_ubo());
 }
 
-TEST_F(VulkanComputeAPITest, virtual_transpose_test) {
-  std::vector<int64_t> sizes = {7, 9, 11, 13};
-  // (dim0, dim1), new_sizes, new_dim_order, new_axis_map, new_packed_dim_idx
-  std::vector<std::vector<std::vector<int64_t>>> test_cases = {
-      {{2, 3}, {7, 9, 13, 11}, {0, 1, 3, 2}, {1, 0, 2, 2}, {1}},
-      {{2, 1}, {7, 11, 9, 13}, {0, 2, 1, 3}, {0, 2, 1, 1}, {0}},
-      {{1, 3}, {7, 13, 11, 9}, {0, 3, 2, 1}, {2, 1, 0, 0}, {2}},
-  };
-
-  for (const auto& test_case : test_cases) {
-    const int dim0 = test_case.at(0).at(0);
-    const int dim1 = test_case.at(0).at(1);
-
-    const auto& expected_sizes = test_case.at(1);
-    const auto& expected_dim_order = test_case.at(2);
-    const auto& expected_axis_map = test_case.at(3);
-    const int expected_packed_dim = test_case.at(4).at(0);
-
-    {
-      vTensor a_buffer = vTensor(
-          context(), sizes, vkapi::kFloat, utils::kBuffer, utils::kWidthPacked);
-
-      a_buffer.virtual_transpose(dim0, dim1);
-      EXPECT_TRUE(a_buffer.sizes() == expected_sizes);
-      EXPECT_TRUE(a_buffer.dim_order() == expected_dim_order);
-    }
-
-    {
-      vTensor a_texture = vTensor(
-          context(),
-          sizes,
-          vkapi::kFloat,
-          utils::kTexture3D,
-          utils::kWidthPacked);
-      a_texture.virtual_transpose(dim0, dim1);
-      EXPECT_TRUE(a_texture.sizes() == expected_sizes);
-      EXPECT_TRUE(a_texture.axis_map() == expected_axis_map);
-      EXPECT_TRUE(a_texture.packed_dim() == expected_packed_dim);
-    }
-  }
-}
-
 TEST_F(VulkanComputeAPITest, view_of_view_test) {
   constexpr int N = 3;
   constexpr int C = 5;
@@ -1469,68 +1427,6 @@ TEST_F(VulkanComputeAPITest, tensor_alias_test) {
   }
 }
 
-TEST_F(VulkanComputeAPITest, tensor_no_copy_transpose_test) {
-  constexpr int M = 11;
-  constexpr int K = 23;
-  constexpr int N = 17;
-  std::vector<int64_t> mat1_sizes = {M, K};
-  std::vector<int64_t> mat2_sizes = {N, K};
-  std::vector<int64_t> out_sizes = {M, N};
-
-  for (const auto storage_type : {utils::kBuffer}) {
-    vTensor mat1 = vTensor(
-        context(),
-        mat1_sizes,
-        vkapi::kFloat,
-        storage_type,
-        utils::kWidthPacked);
-    vTensor mat2 = vTensor(
-        context(),
-        mat2_sizes,
-        vkapi::kFloat,
-        storage_type,
-        utils::kWidthPacked);
-    vTensor out = vTensor(
-        context(), out_sizes, vkapi::kFloat, storage_type, utils::kWidthPacked);
-
-    // Generate data
-    std::vector<float> mat1_data =
-        create_random_float_buffer(mat1.staging_buffer_numel());
-    std::vector<float> mat2_data =
-        create_random_float_buffer(mat2.staging_buffer_numel());
-
-    // Create direct view and modify sizes and strides later
-    vTensor mat2_t = vTensor(mat2);
-    // Update sizes and strides of mat2_t to be that of a transposed tensor
-    mat2_t.virtual_transpose(0, 1);
-
-    EXPECT_TRUE(mat2_t.packed_dim() == WHCN::kHeightDim);
-
-    std::vector<float> mat2_t_data = transpose_matrix(mat2_data, N, K);
-    std::vector<float> ref_out =
-        compute_reference_matmul(mat1_data, mat2_t_data, M, K, N);
-
-    // Fill original tensor with some data
-    fill_vtensor(mat1, mat1_data);
-    fill_vtensor(mat2, mat2_data);
-
-    if (storage_type == utils::kTexture3D) {
-      record_matmul_texture3d(
-          context(), out, mat1, mat2_t, /*mat2_is_transposed=*/true);
-    } else {
-      record_reference_matmul(context(), out, mat1, mat2_t);
-    }
-
-    std::vector<float> data_out(out.staging_buffer_numel());
-    // Extract the copy tensor; should contain the data of the original tensor
-    extract_vtensor(out, data_out);
-
-    for (size_t i = 0; i < ref_out.size(); ++i) {
-      EXPECT_TRUE(check_close(data_out[i], ref_out[i]));
-    }
-  }
-}
-
 TEST_F(VulkanComputeAPITest, texture_deferred_allocation_test) {
   // This test is the same as texture_add_sanity_check, except that the tensor
   // memory is allocated in a deferred fashion
@@ -1953,49 +1849,6 @@ TEST(VulkanComputeGraphTest, test_simple_graph_with_buffer) {
       CHECK_VALUE(data_out, i, expected_val);
     }
   }
-}
-
-TEST(VulkanComputeGraphTest, test_graph_view_of_view) {
-  GraphConfig config;
-  config.set_storage_type_override(utils::kTexture3D);
-  ComputeGraph graph(config);
-
-  constexpr int N = 3;
-  constexpr int C = 5;
-  constexpr int H = 17;
-  constexpr int W = 19;
-
-  std::vector<int64_t> orig_sizes = {N, C, H, W};
-
-  // Test a common view of view usage pattern. In delegate execution, the values
-  // of the graph are created first; then operators are added. As a result,
-  // creating views of views is a bit tricky because metadata updates to a view
-  // does not update the metadata of the view's views. Nonetheless, view
-  // operators have an implicit assumption that the metadata of the output is
-  // equivalent to the metadata of the input. Therefore, view operators must
-  // account for unseen updates to the input view by first calling
-  // `virtual_clone()` to make the output equivalent to the input before.
-  // modifying metadata.
-
-  ValueRef t1 = graph.add_tensor(orig_sizes, vkapi::kFloat);
-  ValueRef t2 = graph.add_tensor_view(t1);
-  ValueRef t3 = graph.add_tensor_view(t2);
-
-  ValueRef channels = graph.add_scalar<int64_t>(1);
-  ValueRef height = graph.add_scalar<int64_t>(2);
-  ValueRef width = graph.add_scalar<int64_t>(3);
-
-  auto opFn = VK_GET_OP_FN("aten.transpose.int");
-
-  opFn(graph, {t1, channels, height, t2});
-  std::vector<int64_t> t2_sizes = graph.sizes_of(t2);
-  std::vector<int64_t> expected_t2_sizes = {N, H, C, W};
-  EXPECT_TRUE(t2_sizes == expected_t2_sizes);
-
-  opFn(graph, {t2, height, width, t3});
-  std::vector<int64_t> t3_sizes = graph.sizes_of(t3);
-  std::vector<int64_t> expected_t3_sizes = {N, H, W, C};
-  EXPECT_TRUE(t3_sizes == expected_t3_sizes);
 }
 
 TEST(VulkanComputeGraphTest, test_simple_graph) {

--- a/backends/vulkan/test/vulkan_compute_api_test.cpp
+++ b/backends/vulkan/test/vulkan_compute_api_test.cpp
@@ -2194,8 +2194,8 @@ TEST(VulkanComputeGraphTest, test_simple_shared_objects_with_resize) {
       vkapi::kFloat,
       /*shared_object_idx = */ 4);
 
-  // +2: t.sizes_ubo() for each staging shader
-  expected_vma_allocation_count += 2;
+  // +4: t.sizes_ubo() + t.texture_meta_ubo() for each staging shader (2 inputs)
+  expected_vma_allocation_count += 4;
   EXPECT_EQ(get_vma_allocation_count(), expected_vma_allocation_count);
 
   ValueRef c = graph.add_tensor(
@@ -2214,8 +2214,8 @@ TEST(VulkanComputeGraphTest, test_simple_shared_objects_with_resize) {
       vkapi::kFloat,
       /*shared_object_idx = */ 2);
 
-  // +1: t.sizes_ubo() uniform buffer for staging shader
-  expected_vma_allocation_count += 1;
+  // +2: t.sizes_ubo() + t.texture_meta_ubo() for staging shader
+  expected_vma_allocation_count += 2;
   EXPECT_EQ(get_vma_allocation_count(), expected_vma_allocation_count);
 
   ValueRef e = graph.add_tensor(
@@ -2233,8 +2233,8 @@ TEST(VulkanComputeGraphTest, test_simple_shared_objects_with_resize) {
   out.value = e;
   out.staging = graph.set_output_tensor(out.value);
 
-  // +1: staging buffer input tensor
-  expected_vma_allocation_count += 1;
+  // +2: staging buffer + t.texture_meta_ubo() for output tensor
+  expected_vma_allocation_count += 2;
   EXPECT_EQ(get_vma_allocation_count(), expected_vma_allocation_count);
 
   graph.prepare();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #18454
* #18453
* #18452
* #18451
* __->__ #18450
* #18449

Rewrites nchw_to_image.glsl and image_to_nchw.glsl from scratch using the
modern indexing.glslh header with TextureMetadata UBOs. This eliminates all
dynamic array indexing patterns (e.g. tidx[packed_dim], sizes[packed_dim])
from the old indexing_utils.h header that triggered SIGSEGV crashes in the
Adreno 740 GPU driver's shader compiler during vkCreateComputePipelines.

The new shaders follow the same component loop pattern used by
gather_texture.glsl: convert texture position to TensorIndex4D via
texture_pos_to_tensor4d_idx_simple(), then iterate over packed components.

Also removes the USE_PUSH_CONST/no_pc shader variants since the rewritten
shaders always use UBOs via TextureMetadata.

C++ dispatch code (Staging.cpp, Clone.cpp) updated to pass TextureMetadata
UBOs for texture tensors and BufferMetadata UBOs for the clone
buffer↔image paths.

Differential Revision: [D97959285](https://our.internmc.facebook.com/intern/diff/D97959285/)