### PR TITLE
[ET-VK] Apply safe_idx to block indexing headers for Adreno 740 compatibility

### DIFF
--- a/backends/vulkan/runtime/graph/ops/glsl/block_indexing.glslh
+++ b/backends/vulkan/runtime/graph/ops/glsl/block_indexing.glslh
@@ -11,6 +11,7 @@
 
 #include "block_int8x4_utils.glslh"
 #include "common.glslh"
+#include "indexing.glslh"
 
 //
 // Block Layout Int Utils
@@ -77,17 +78,17 @@ TensorIndex4D contiguous_block_idx_to_tensor4d_idx_with_block_config(
   const int packed_dim_1 = get_block_inner_dim(block_config);
   block_strides[packed_dim_1] = 1;
   const uint block_size_1 = uint(get_block_inner_dim_block_size(block_config));
-  stride = div_up(meta.sizes[0][packed_dim_1], block_size_1);
+  stride = div_up(safe_idx(meta.sizes[0], packed_dim_1), block_size_1);
   // Outer block dim
   const int packed_dim_2 = get_block_outer_dim(block_config);
   block_strides[packed_dim_2] = stride;
   const uint block_size_2 =
       uint(get_block_outer_dim_block_size(block_config));
-  stride *= div_up(meta.sizes[0][packed_dim_2], block_size_2);
+  stride *= div_up(safe_idx(meta.sizes[0], packed_dim_2), block_size_2);
   // First non-block dim
   const int outer_dim_1 = get_block_dim_order_2(block_config);
   block_strides[outer_dim_1] = stride;
-  stride *= meta.sizes[0][outer_dim_1];
+  stride *= safe_idx(meta.sizes[0], outer_dim_1);
   // Second non-block dim
   const int outer_dim_2 = get_block_dim_order_3(block_config);
   block_strides[outer_dim_2] = stride;
@@ -133,19 +134,21 @@ TensorIndex contiguous_block_idx_to_tensor_idx_with_block_config(
   uint stride = 1;
 
   // Inner block dim
-  stride = div_up(size_at(meta, inner_dim), inner_bs);
+  // Use safe_idx for UBO-backed meta.sizes to avoid Adreno dynamic indexing
+  // crash. All block dims are < 4, so they index into meta.sizes[0].
+  stride = div_up(safe_idx(meta.sizes[0], inner_dim), inner_bs);
 
   // Outer block dim
   uint stride_outer = stride;
-  stride *= div_up(size_at(meta, outer_dim), outer_bs);
+  stride *= div_up(safe_idx(meta.sizes[0], outer_dim), outer_bs);
 
   // First non-block dim
   uint stride_nb1 = stride;
-  stride *= size_at(meta, nonblock_dim_1);
+  stride *= safe_idx(meta.sizes[0], nonblock_dim_1);
 
   // Second non-block dim
   uint stride_nb2 = stride;
-  stride *= size_at(meta, nonblock_dim_2);
+  stride *= safe_idx(meta.sizes[0], nonblock_dim_2);
 
   // Extra batch dims (4-7): always non-block, ascending order
   uint batch_strides[4];
@@ -198,17 +201,17 @@ TensorIndex4D contiguous_block_idx_to_tensor4d_idx_with_block_config(
   const int packed_dim_1 = get_block_inner_dim(block_config);
   block_strides[packed_dim_1] = 1;
   const uint block_size_1 = uint(get_block_inner_dim_block_size(block_config));
-  stride = div_up(meta.sizes[packed_dim_1], block_size_1);
+  stride = div_up(safe_idx(meta.sizes, packed_dim_1), block_size_1);
   // Outer block dim
   const int packed_dim_2 = get_block_outer_dim(block_config);
   block_strides[packed_dim_2] = stride;
   const uint block_size_2 =
       uint(get_block_outer_dim_block_size(block_config));
-  stride *= div_up(meta.sizes[packed_dim_2], block_size_2);
+  stride *= div_up(safe_idx(meta.sizes, packed_dim_2), block_size_2);
   // First non-block dim
   const int outer_dim_1 = get_block_dim_order_2(block_config);
   block_strides[outer_dim_1] = stride;
-  stride *= meta.sizes[outer_dim_1];
+  stride *= safe_idx(meta.sizes, outer_dim_1);
   // Second non-block dim
   const int outer_dim_2 = get_block_dim_order_3(block_config);
   block_strides[outer_dim_2] = stride;

--- a/backends/vulkan/runtime/graph/ops/glsl/block_int8x4_load.glslh
+++ b/backends/vulkan/runtime/graph/ops/glsl/block_int8x4_load.glslh
@@ -57,8 +57,9 @@
                                                                              \
     /* General path: use stride for non-contiguous access */                 \
     const uint outer_stride =                                                \
-        stride_at(meta, block_outer_dim) * texels_per_block;                 \
-    const uint outer_size = size_at(meta, block_outer_dim);                  \
+        safe_idx(meta.strides[0], block_outer_dim) * texels_per_block;       \
+    const uint outer_size =                                                  \
+        safe_idx(meta.sizes[0], block_outer_dim);                            \
     const int base_outer_idx = tidx_base.data[block_outer_dim];              \
                                                                              \
     ivec4 block = ivec4(0);                                                  \
@@ -108,8 +109,9 @@
                                                                                \
     /* General path: use stride for non-contiguous access */                   \
     const uint outer_stride =                                                  \
-        stride_at(meta, block_outer_dim) * texels_per_block;                   \
-    const uint outer_size = size_at(meta, block_outer_dim);                    \
+        safe_idx(meta.strides[0], block_outer_dim) * texels_per_block;         \
+    const uint outer_size =                                                    \
+        safe_idx(meta.sizes[0], block_outer_dim);                              \
     const int base_outer_idx = int(tidx_base.data[0][block_outer_dim]);        \
                                                                                \
     ivec4 block = ivec4(0);                                                    \

--- a/backends/vulkan/runtime/graph/ops/glsl/block_int8x4_store.glslh
+++ b/backends/vulkan/runtime/graph/ops/glsl/block_int8x4_store.glslh
@@ -59,8 +59,9 @@
                                                                              \
     /* General path: use stride for non-contiguous access */                 \
     const uint outer_stride =                                                \
-        stride_at(meta, block_outer_dim) * texels_per_block;                 \
-    const uint outer_size = size_at(meta, block_outer_dim);                  \
+        safe_idx(meta.strides[0], block_outer_dim) * texels_per_block;       \
+    const uint outer_size =                                                  \
+        safe_idx(meta.sizes[0], block_outer_dim);                            \
     const int base_outer_idx = tidx_base.data[block_outer_dim];              \
                                                                              \
     [[unroll]] for (int block_y = 0; block_y < 4; ++block_y) {               \
@@ -109,8 +110,9 @@
                                                                                \
     /* General path: use stride for non-contiguous access */                   \
     const uint outer_stride =                                                  \
-        stride_at(meta, block_outer_dim) * texels_per_block;                   \
-    const uint outer_size = size_at(meta, block_outer_dim);                    \
+        safe_idx(meta.strides[0], block_outer_dim) * texels_per_block;         \
+    const uint outer_size =                                                    \
+        safe_idx(meta.sizes[0], block_outer_dim);                              \
     const int base_outer_idx = int(tidx_base.data[0][block_outer_dim]);        \
                                                                                \
     [[unroll]] for (int block_y = 0; block_y < 4; ++block_y) {                 \

--- a/backends/vulkan/runtime/graph/ops/glsl/block_load.glslh
+++ b/backends/vulkan/runtime/graph/ops/glsl/block_load.glslh
@@ -45,12 +45,17 @@
     /* Compute base buffer index once and use strides for iteration */       \
     const uint base_idx =                                                    \
         tensor4d_idx_to_buf_idx(meta, tidx_base, hashed_layout);             \
-    const uint outer_stride = stride_at(meta, block_outer_dim);              \
+    /* Use safe_idx for UBO-backed meta fields to avoid Adreno dynamic */   \
+    /* indexing crash */                                                     \
+    const uint outer_stride =                                                \
+        safe_idx(meta.strides[0], block_outer_dim);                          \
     /* Inner stride is 1 since packed_dim == block_inner_dim */              \
                                                                              \
     /* Pre-compute bounds for efficient checking */                          \
-    const uint outer_size = size_at(meta, block_outer_dim);                  \
-    const uint inner_size = size_at(meta, block_inner_dim);                  \
+    const uint outer_size =                                                  \
+        safe_idx(meta.sizes[0], block_outer_dim);                            \
+    const uint inner_size =                                                  \
+        safe_idx(meta.sizes[0], block_inner_dim);                            \
     const int base_outer_idx = tidx_base.data[block_outer_dim];              \
     const int base_inner_idx = tidx_base.data[block_inner_dim];              \
                                                                              \
@@ -88,7 +93,7 @@
     ivec3 tex_pos =                                                           \
         tensor4d_idx_to_texel_pos_simple(meta, tidx_base, hashed_layout);     \
     const int tex_outer_dim = mod_4(block_outer_dim);                         \
-    const int outer_size = meta.sizes[block_outer_dim];                       \
+    const int outer_size = safe_idx(meta.sizes, block_outer_dim);             \
     const int base_outer_idx = tidx_base.data[block_outer_dim];               \
                                                                               \
     mat4 block;                                                               \
@@ -119,12 +124,17 @@
     /* Compute base buffer index using 8D strides */                           \
     const uint base_idx =                                                      \
         tensor_idx_to_buf_idx(meta, tidx_base, hashed_layout);                 \
-    const uint outer_stride = stride_at(meta, block_outer_dim);                \
+    /* Use safe_idx for UBO-backed meta fields to avoid Adreno dynamic */     \
+    /* indexing crash */                                                       \
+    const uint outer_stride =                                                  \
+        safe_idx(meta.strides[0], block_outer_dim);                            \
     /* Inner stride is 1 since packed_dim == block_inner_dim */                \
                                                                                \
     /* Pre-compute bounds (block dims always < 4, so use data[0]) */           \
-    const uint outer_size = size_at(meta, block_outer_dim);                    \
-    const uint inner_size = size_at(meta, block_inner_dim);                    \
+    const uint outer_size =                                                    \
+        safe_idx(meta.sizes[0], block_outer_dim);                              \
+    const uint inner_size =                                                    \
+        safe_idx(meta.sizes[0], block_inner_dim);                              \
     const int base_outer_idx = int(tidx_base.data[0][block_outer_dim]);        \
     const int base_inner_idx = int(tidx_base.data[0][block_inner_dim]);        \
                                                                                \
@@ -164,7 +174,7 @@
     ivec3 tex_pos =                                                            \
         tensor4d_idx_to_texel_pos_simple(meta, tidx4d, hashed_layout);          \
     const int tex_outer_dim = mod_4(block_outer_dim);                           \
-    const int outer_size = meta.sizes[block_outer_dim];                         \
+    const int outer_size = safe_idx(meta.sizes, block_outer_dim);               \
     const int base_outer_idx = tidx4d.data[block_outer_dim];                    \
                                                                                 \
     mat4 block;                                                                 \

--- a/backends/vulkan/runtime/graph/ops/glsl/block_store.glslh
+++ b/backends/vulkan/runtime/graph/ops/glsl/block_store.glslh
@@ -45,12 +45,17 @@
     /* Compute base buffer index once and use strides for iteration */ \
     const uint base_idx =                                              \
         tensor4d_idx_to_buf_idx(meta, tidx_base, hashed_layout);       \
-    const uint outer_stride = stride_at(meta, block_outer_dim);        \
+    /* Use safe_idx for UBO-backed meta fields to avoid Adreno dynamic */ \
+    /* indexing crash */                                                \
+    const uint outer_stride =                                          \
+        safe_idx(meta.strides[0], block_outer_dim);                    \
     /* Inner stride is 1 since packed_dim == block_inner_dim */        \
                                                                        \
     /* Pre-compute bounds for efficient checking */                    \
-    const uint outer_size = size_at(meta, block_outer_dim);            \
-    const uint inner_size = size_at(meta, block_inner_dim);            \
+    const uint outer_size =                                            \
+        safe_idx(meta.sizes[0], block_outer_dim);                      \
+    const uint inner_size =                                            \
+        safe_idx(meta.sizes[0], block_inner_dim);                      \
     const int base_outer_idx = tidx_base.data[block_outer_dim];        \
     const int base_inner_idx = tidx_base.data[block_inner_dim];        \
                                                                        \
@@ -84,7 +89,7 @@
     ivec3 tex_pos =                                                          \
         tensor4d_idx_to_texel_pos_simple(meta, tidx_base, hashed_layout);     \
     const int tex_outer_dim = mod_4(block_outer_dim);                         \
-    const int outer_size = meta.sizes[block_outer_dim];                       \
+    const int outer_size = safe_idx(meta.sizes, block_outer_dim);             \
     const int base_outer_idx = tidx_base.data[block_outer_dim];               \
                                                                               \
     [[unroll]] for (int block_y = 0; block_y < 4; ++block_y) {                \
@@ -112,12 +117,17 @@
     /* Compute base buffer index using 8D strides */                   \
     const uint base_idx =                                              \
         tensor_idx_to_buf_idx(meta, tidx_base, hashed_layout);         \
-    const uint outer_stride = stride_at(meta, block_outer_dim);        \
+    /* Use safe_idx for UBO-backed meta fields to avoid Adreno dynamic */ \
+    /* indexing crash */                                                \
+    const uint outer_stride =                                          \
+        safe_idx(meta.strides[0], block_outer_dim);                    \
     /* Inner stride is 1 since packed_dim == block_inner_dim */        \
                                                                        \
     /* Pre-compute bounds (block dims always < 4, so use data[0]) */   \
-    const uint outer_size = size_at(meta, block_outer_dim);            \
-    const uint inner_size = size_at(meta, block_inner_dim);            \
+    const uint outer_size =                                            \
+        safe_idx(meta.sizes[0], block_outer_dim);                      \
+    const uint inner_size =                                            \
+        safe_idx(meta.sizes[0], block_inner_dim);                      \
     const int base_outer_idx = int(tidx_base.data[0][block_outer_dim]);\
     const int base_inner_idx = int(tidx_base.data[0][block_inner_dim]);\
                                                                        \
@@ -153,7 +163,7 @@
     ivec3 tex_pos =                                                           \
         tensor4d_idx_to_texel_pos_simple(meta, tidx4d, hashed_layout);         \
     const int tex_outer_dim = mod_4(block_outer_dim);                          \
-    const int outer_size = meta.sizes[block_outer_dim];                        \
+    const int outer_size = safe_idx(meta.sizes, block_outer_dim);              \
     const int base_outer_idx = tidx4d.data[block_outer_dim];                   \
                                                                                \
     [[unroll]] for (int block_y = 0; block_y < 4; ++block_y) {                 \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #18454
* #18453
* #18452
* #18451
* #18450
* #18449

The Adreno 740 SPIR-V compiler crashes (SIGSEGV in libllvm-qgl.so during
vkCreateComputePipelines) when a UBO-backed ivec4/uvec4 is dynamically indexed
with a specialization constant that resolves to value 1 or 2. The block
load/store/indexing headers contained `meta.sizes[block_outer_dim]` and similar
patterns where the index is derived from the block_config specialization
constant.

Replace all UBO dynamic indexing with safe_idx() if/else chains in:
- block_indexing.glslh: contiguous_block_idx_to_tensor* functions
- block_load.glslh: block_load_* functions (size_at/stride_at with spec-const)
- block_store.glslh: block_store_* functions (same pattern)
- block_int8x4_load.glslh: block_int8x4_load_* functions
- block_int8x4_store.glslh: block_int8x4_store_* functions

Since the indices are specialization-constant-derived, the compiler eliminates
all but one branch at pipeline creation time — zero runtime cost.

This fixes the S23 (Adreno 740) crash when running uint8 quantized models that
use q8ta_quantize/q8ta_dequantize shaders.

Differential Revision: [D97959287](https://our.internmc.facebook.com/intern/diff/D97959287/)