### PR TITLE
[RELEASE ONLY CHANGES] Use torchcodec 0.11.0 release package

### DIFF
--- a/.ci/scripts/test_model_e2e.sh
+++ b/.ci/scripts/test_model_e2e.sh
@@ -234,7 +234,7 @@ if [ "$AUDIO_URL" != "" ]; then
 elif [[ "$MODEL_NAME" == *whisper* ]] || [ "$MODEL_NAME" = "voxtral_realtime" ]; then
   conda install -y -c conda-forge "ffmpeg<8"
   pip install datasets soundfile
-  pip install torchcodec==0.11.0 --extra-index-url https://download.pytorch.org/whl/test/cpu
+  pip install torchcodec==0.11.0 --index-url https://download.pytorch.org/whl/cpu
   python -c "from datasets import load_dataset;import soundfile as sf;sample = load_dataset('distil-whisper/librispeech_long', 'clean', split='validation')[0]['audio'];sf.write('${MODEL_DIR}/$AUDIO_FILE', sample['array'][:sample['sampling_rate']*30], sample['sampling_rate'])"
 fi
 

--- a/examples/models/moshi/mimi/install_requirements.sh
+++ b/examples/models/moshi/mimi/install_requirements.sh
@@ -8,7 +8,7 @@
 set -x
 
 sudo apt install ffmpeg -y
-pip install torchcodec==0.11.0 --extra-index-url https://download.pytorch.org/whl/test/cpu
+pip install torchcodec==0.11.0 --index-url https://download.pytorch.org/whl/cpu
 pip install moshi==0.2.11
 pip install bitsandbytes soundfile einops
 # Run llama2/install requirements for torchao deps


### PR DESCRIPTION
torchcodec 0.11.0 is now officially released. See [here](https://github.com/meta-pytorch/torchcodec/releases/tag/v0.11.0).
Use instead of the test release candidate.
