### PR TITLE
Add TOSA reference model dependency for Arm backend tests (#18478)

### DIFF
--- a/backends/arm/test/runner_utils.py
+++ b/backends/arm/test/runner_utils.py
@@ -202,7 +202,7 @@ def numpy_to_torch_tensor(array: np.ndarray, output_node: Node) -> torch.Tensor:
         tensor = torch.from_numpy(array).reshape(shape_with_dim_order)
         return tensor.permute(NNHWC_INVERSE_ORDER).to(memory_format=torch.channels_last)
     else:
-        if type(array.dtype) is np.dtypes.VoidDType:
+        if array.dtype.type is np.void:
             # If dtype is void, "cheat" and use the output_tensor dtype.
             tensor = torch.frombuffer(array, dtype=output_tensor.dtype)
         else:

--- a/backends/arm/test/targets.bzl
+++ b/backends/arm/test/targets.bzl
@@ -77,5 +77,6 @@ def define_arm_tests():
                 "//executorch/exir:lib",
                 "fbsource//third-party/pypi/pytest:pytest",
                 "fbsource//third-party/pypi/parameterized:parameterized",
+                "fbsource//third-party/tosa_tools:tosa_reference_model",
             ],
         )


### PR DESCRIPTION
Summary:

Add the tosa_reference_model pybind11 library as a dependency for Arm backend
tests, enabling TOSA graph execution via the reference model in the test
pipeline.


bypass-github-export-checks
bypass-github-pytorch-ci-checks
bypass-github-executorch-ci-checks

Reviewed By: digantdesai

Differential Revision: D98027152


