### PR TITLE
fix: replace bare except with except Exception (3 files)

### DIFF
--- a/examples/models/llama/install_requirement_helper.py
+++ b/examples/models/llama/install_requirement_helper.py
@@ -16,7 +16,7 @@ try:
     try:
         # If the import succeeds, this means it isn't using lm_eval's module
         import examples.models
-    except:
+    except Exception:
         print(
             "Failed to import examples.models due to lm_eval conflict. Removing lm_eval examples module"
         )
@@ -25,5 +25,5 @@ try:
         examples_path = examples.__path__[0]
         shutil.rmtree(examples_path)
 
-except:
+except Exception:
     pass

--- a/examples/models/mobilenet_v2/model.py
+++ b/examples/models/mobilenet_v2/model.py
@@ -38,7 +38,7 @@ class MV2Model(EagerModelBase):
             )
             try:
                 urllib.URLopener().retrieve(url, filename)
-            except:
+            except Exception:
                 urllib.request.urlretrieve(url, filename)
             from PIL import Image
             from torchvision import transforms

--- a/extension/pytree/__init__.py
+++ b/extension/pytree/__init__.py
@@ -32,7 +32,7 @@ try:
         tree_unflatten as tree_unflatten,
         TreeSpec as TreeSpec,
     )
-except:
+except Exception:
     logger.info(
         "Unable to import executorch.extension.pytree, using native torch pytree instead."
     )


### PR DESCRIPTION
## Summary

Replace bare `except:` clauses with `except Exception:` across 3 files to improve error handling specificity.

Bare `except:` catches all exceptions including `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit`, which should typically propagate. Since none of these sites re-raise, `except Exception:` is the correct replacement (PEP 8, B001).

**Changes:**

`extension/pytree/__init__.py`:
```python
# Before
except:
# After
except Exception:
```

`examples/models/mobilenet_v2/model.py`:
```python
# Before
            except:
# After
            except Exception:
```

`examples/models/llama/install_requirement_helper.py` (2 occurrences):
```python
# Before
    except:
    except:
# After
    except Exception:
    except Exception:
```

## Testing
No behavior change — style/correctness fix only. All sites are import fallbacks or error-swallowing patterns where `Exception` is the appropriate base class.

cc @larryliu0820 @mergennachin @cccclai @helunwencser @jackzhxng @digantdesai @iseeyuan @lucylq @tarun292 @kimishpatel