### PR TITLE
NXP Backend: Add imxrt700cm backend which combines the Neutron and CortexM backends

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -224,6 +224,7 @@ exclude_patterns = [
     'extension/llm/tokenizers',
     'extension/llm/tokenizers/**',
     'examples/cuda',
+    'examples/nxp',
     'kernels/portable',
     # File contains @generated
     'extension/llm/custom_ops/spinquant/fast_hadamard_transform_special.h',

--- a/backends/cortex_m/passes/quantized_op_fusion_pass.py
+++ b/backends/cortex_m/passes/quantized_op_fusion_pass.py
@@ -412,5 +412,5 @@ class QuantizedOpFusionPass(ExportPass):
             case _:
                 pass
 
-        result = super().call_operator(op, args, {}, meta)
+        result = super().call_operator(op, args, kwargs, meta)
         return result

--- a/backends/cortex_m/quantizer/quantizer.py
+++ b/backends/cortex_m/quantizer/quantizer.py
@@ -4,10 +4,11 @@
 # LICENSE file in the root directory of this source tree.
 
 
-from typing import cast, List, Optional
+from typing import Callable, cast, Iterator, List, Optional
 
 from executorch.backends.arm.quantizer.arm_quantizer_utils import (
     _mark_node_as_quantized,
+    NodeFinder,
     PatternCheck,
     PatternQuantizer,
     SharedQspecQuantizer,
@@ -30,7 +31,7 @@ from executorch.backends.cortex_m.quantizer.quantizer_support import (
     CORTEX_M_QUANTIZER_SUPPORT_DICT,
 )
 from torch._ops import OpOverload
-from torch.fx import GraphModule
+from torch.fx import GraphModule, Node
 from torchao.quantization.pt2e.quantizer import ComposableQuantizer, Quantizer
 
 
@@ -43,9 +44,27 @@ def mark_node_as_annotated(
     _mark_node_as_quantized(node, input_qspec_map, output_qspec, is_quantized)
 
 
+class FilteredNodeFinder(NodeFinder):
+    """Wrapper that filters out nodes from another NodeFinder."""
+
+    def __init__(
+        self, base_finder: NodeFinder, filter_fn: Callable[[Node], bool] | None = None
+    ) -> None:
+        self.base_finder = base_finder
+        self.filter_fn = filter_fn
+
+    def find_nodes(self, model: GraphModule) -> Iterator[Node]:
+        nested_generator = self.base_finder.find_nodes(model)
+
+        if self.filter_fn is None:
+            return nested_generator
+
+        return filter(self.filter_fn, nested_generator)
+
+
 class CortexMQuantizer(ComposableQuantizer):
 
-    def __init__(self) -> None:
+    def __init__(self, filter_fn: Callable[[Node], bool] | None = None) -> None:
         conv_targets: set[OpOverload] = set()
         for key in CONV_OP_PATTERNS.keys() | CONV_TRANSPOSE_OP_PATTERNS.keys():
             conv_targets.update(key)
@@ -63,12 +82,14 @@ class CortexMQuantizer(ComposableQuantizer):
         quantizers: List[Quantizer] = [
             PatternQuantizer(
                 INT8_PER_CHANNEL_CONFIG,
-                node_finder=NodeTargetNodeFinder(list(conv_targets)),
+                node_finder=FilteredNodeFinder(
+                    NodeTargetNodeFinder(list(conv_targets)), filter_fn
+                ),
                 pattern_matcher=pattern_matcher,
             ),
             PatternQuantizer(
                 INT8_PER_TENSOR_CONFIG,
-                node_finder=GlobalNodeFinder(),
+                node_finder=FilteredNodeFinder(GlobalNodeFinder(), filter_fn),
                 pattern_matcher=pattern_matcher,
             ),
             SharedQspecQuantizer(),

--- a/backends/nxp/__init__.py
+++ b/backends/nxp/__init__.py
@@ -1,0 +1,3 @@
+# Key into `node.meta` dictionary. If it's mapped to `True`, the node will not be quantized by the NeutronQuantizer, and
+#  it will not be selected for delegation by the NeutronPartitioner.
+NXP_NEUTRON_BACKEND_IGNORE = "NXP_NEUTRON_BACKEND_IGNORE"

--- a/backends/nxp/backend/edge_helper.py
+++ b/backends/nxp/backend/edge_helper.py
@@ -124,6 +124,10 @@ def _is_quantize(node_: Node) -> bool:
     ]
 
 
+def is_qdq_op(node: Node) -> bool:
+    return _is_quantize(node) or _is_dequantize(node)
+
+
 def previous_non_qdq_node(node: Node, input_index: int = 0) -> Node | None:
     """Return the first node which is not a `quantize` or `dequantize`, found by traversing the graph backwards
     starting with the `node.args[input_index]`,

--- a/backends/nxp/imxrt700cm/imxrt700cm_pipeline.py
+++ b/backends/nxp/imxrt700cm/imxrt700cm_pipeline.py
@@ -1,0 +1,186 @@
+# Copyright 2026 NXP
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.import copy
+
+import copy
+from typing import Callable
+
+import torch
+
+from executorch.backends.cortex_m.passes import CortexMPassManager
+from executorch.backends.nxp.backend.custom_delegation_options import (
+    CustomDelegationOptions,
+)
+from executorch.backends.nxp.backend.edge_helper import is_qdq_op
+from executorch.backends.nxp.backend.neutron_target_spec import NeutronTargetSpec
+from executorch.backends.nxp.edge_passes.neutron_edge_pass_manager import (
+    NeutronEdgePassManager,
+)
+from executorch.backends.nxp.imxrt700cm.imxrt700cm_quantizer import IMXRT700CMQuantizer
+from executorch.backends.nxp.neutron_partitioner import (
+    NeutronPartitioner,
+    NXP_DELEGATION_TAG,
+)
+from executorch.backends.nxp.nxp_backend import generate_neutron_compile_spec
+from executorch.backends.nxp.quantizer.neutron_quantizer import NeutronQuantizer
+from executorch.backends.nxp.quantizer.utils import calibrate_and_quantize
+from executorch.backends.nxp.tests.executorch_pipeline import (
+    get_random_calibration_inputs,
+    ModelInputSpec,
+    to_model_input_spec,
+    to_quantized_edge_program,
+)
+from executorch.exir import EdgeProgramManager, to_edge
+from executorch.exir.backend.partitioner import PartitionResult
+from executorch.exir.dialects.edge._ops import EdgeOpOverload
+from torch.fx import Node
+
+
+def lower_to_imxrt700cm(
+    model: torch.nn.Module,
+    input_spec: tuple[ModelInputSpec, ...] | tuple[int, ...] | list[tuple[int, ...]],
+    get_calibration_inputs_fn: Callable[
+        [tuple[ModelInputSpec, ...]], list[tuple[torch.Tensor, ...]]
+    ] = get_random_calibration_inputs,
+    target: str = "imxrt700",
+    remove_quant_io_ops: bool = False,
+    custom_delegation_options: CustomDelegationOptions = CustomDelegationOptions(),  # noqa B008
+    use_neutron_for_format_conversion: bool = True,
+    use_quant_state_dict: bool = True,
+    fetch_constants_to_sram: bool = False,
+    dump_kernel_selection_code: bool = False,
+) -> EdgeProgramManager:
+    """Lower model to hybrid Neutron + Cortex-M backend.
+
+    Pipeline:
+    1. Identify nodes not supported by Neutron.
+        1.1 Quantize a copy of the model with 1 dummy calibration tensor.
+        1.2 Run NeutronPartitioner to mark supported nodes.
+        1.3 Extract the names of the aten operator unsupported by neutron.
+    2. Quantize using a hybrid quantizer, which applies NeutronQuantizer to some nodes, and CortexMQuantizer to others.
+    3. Lower to edge using Neutron backend.
+    4. Run Cortex-M passes on the edge program to replace leftover nodes with Cortex-M operators.
+
+    NOTE: Some Cortex-M operators require the channels last dim order. So the provided `model` and `example_inputs`
+          should use the channels last memory format for best results.
+
+    TODO (Martin) The Cortex-M backend requires some aten nodes to be preserved in the edge program.
+     This is not yet implemented. (EIEX-805)
+    """
+    input_spec = to_model_input_spec(input_spec)
+
+    # Discover the names (stored in node.meta["torch_fn"][0]) of the aten operators which are not supported by Neutron.
+    # The Cortex-M backend will be used for these if possible.
+    cortex_m_designated_node_identifiers = _get_neutron_unsupported_node_identifiers(
+        model,
+        input_spec,
+        target,
+    )
+
+    # Use the standard Neutron lowering pipeline
+    edge_program_manager = to_quantized_edge_program(
+        model,
+        input_spec,
+        get_calibration_inputs_fn=get_calibration_inputs_fn,
+        target=target,
+        remove_quant_io_ops=remove_quant_io_ops,
+        custom_delegation_options=custom_delegation_options,
+        get_quantizer_fn=lambda: IMXRT700CMQuantizer(
+            NeutronTargetSpec(target), cortex_m_designated_node_identifiers
+        ),
+        use_neutron_for_format_conversion=use_neutron_for_format_conversion,
+        use_quant_state_dict=use_quant_state_dict,
+        fetch_constants_to_sram=fetch_constants_to_sram,
+        dump_kernel_selection_code=dump_kernel_selection_code,
+    )
+
+    # Apply Cortex-M passes to replace the remaining nodes with Cortex-M variants where possible.
+    pass_manager = CortexMPassManager(edge_program_manager.exported_program())
+    edge_program_manager._edge_programs["forward"] = pass_manager.transform()
+
+    return edge_program_manager
+
+
+def get_non_delegated_nodes(partition_result: PartitionResult) -> list[Node]:
+    """Return a list of nodes which were not marked by the NeutronPartitioner for delegation."""
+
+    def _is_compute_op(node: Node) -> bool:
+        # Return `True` for call functions which represent edge operators (not getitem or ExecutorchCallDelegate, ...)
+        # Also exclude quantize/dequantize operations.
+        return (
+            node.op == "call_function"
+            and isinstance(node.target, EdgeOpOverload)
+            and not is_qdq_op(node)
+        )
+
+    return list(
+        filter(
+            lambda n: _is_compute_op(n) and NXP_DELEGATION_TAG not in n.meta,
+            partition_result.tagged_exported_program.graph.nodes,
+        )
+    )
+
+
+def _get_neutron_unsupported_node_identifiers(
+    model: torch.nn.Module,
+    input_spec: tuple[ModelInputSpec, ...],
+    target: str,
+    use_quant_state_dict: bool = False,
+) -> set[str]:
+    """Identify nodes not supported by Neutron.
+        This is done by running quantization with dummy calibration data and then applying the NeutronPartitioner.
+
+    :param model: Input model to analyze.
+    :param input_spec: Tuple of objects containing information about the model inputs.
+    :param target: Neutron target to use for quantization.
+    :param use_quant_state_dict: If `True` the state dict from the quantized model will be used to assess operator
+                                  support by the NeutronPartitioner.
+    :return: Set of identifiers of nodes (stored in node.meta["torch_fn"][0]) which are not supported by Neutron.
+    """
+    example_inputs = tuple(
+        torch.rand(spec.shape, dtype=spec.dtype) for spec in input_spec
+    )
+    exir_program_aten = torch.export.export(model, example_inputs, strict=True)
+
+    # Make a deep copy for discovery
+    copied_program = copy.deepcopy(exir_program_aten)
+
+    # Use the example input to quantize the model. There is no need to have a representative calibration dataset.
+    #  Instead, we want to use just 1 sample as we only care about speed and which nodes are supported.
+    calibration_inputs = [example_inputs]
+
+    # Quantize with NeutronQuantizer
+    neutron_target_spec = NeutronTargetSpec(target)
+    copied_program_quantized = calibrate_and_quantize(
+        model=copied_program,
+        calibration_inputs=calibration_inputs,
+        quantizer=NeutronQuantizer(neutron_target_spec),
+    )
+
+    # Partition with Neutron
+    compile_spec = generate_neutron_compile_spec(target)
+
+    neutron_partitioner = NeutronPartitioner(
+        compile_spec,
+        neutron_target_spec,
+        post_quantization_state_dict=(
+            copied_program_quantized.state_dict() if use_quant_state_dict else None
+        ),
+    )
+
+    epm = to_edge(
+        torch.export.export(copied_program_quantized, example_inputs, strict=True)
+    )
+    epm = epm.transform(NeutronEdgePassManager())
+    partition_result = neutron_partitioner.partition(epm.exported_program())
+
+    # Identify edge compute operators which were not delegated to Neutron.
+    non_delegated_edge_nodes = get_non_delegated_nodes(partition_result)
+
+    # Extract the identifiers of these nodes, which can be used to identify the original aten nodes.
+    non_delegated_node_identifiers = {
+        n.meta["torch_fn"][0] for n in non_delegated_edge_nodes if "torch_fn" in n.meta
+    }
+
+    return non_delegated_node_identifiers

--- a/backends/nxp/imxrt700cm/imxrt700cm_quantizer.py
+++ b/backends/nxp/imxrt700cm/imxrt700cm_quantizer.py
@@ -1,0 +1,104 @@
+# Copyright 2026 NXP
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.import copy
+
+import torch
+
+from executorch.backends.cortex_m.quantizer.quantizer import CortexMQuantizer
+from executorch.backends.nxp import NXP_NEUTRON_BACKEND_IGNORE
+from executorch.backends.nxp.backend.neutron_target_spec import NeutronTargetSpec
+from executorch.backends.nxp.quantizer.neutron_quantizer import NeutronQuantizer
+from torch.fx import GraphModule, Node
+from torchao.quantization.pt2e.quantizer import Quantizer
+from torchao.quantization.pt2e.quantizer.quantizer import Q_ANNOTATION_KEY
+
+
+class IMXRT700CMQuantizer(Quantizer):
+    """Hybrid quantizer that uses NeutronQuantizer for Neutron supported ops and CortexMQuantizer for the rest."""
+
+    def __init__(
+        self,
+        target_spec: NeutronTargetSpec,
+        cortex_m_designated_node_identifiers: set[str],
+    ):
+        """
+        :param target_spec: Neutron target specification
+        :param cortex_m_designated_node_identifiers: Set of identifiers (stored in node.meta["torch_fn"][0]) of nodes
+                                                      that are not supported by Neutron. Nodes not in this set will use
+                                                      the NeutronQuantizer. Nodes in this set and nodes skipped by
+                                                      NeutronQuantizer will be quantized with the CortexMQuantizer.
+        """
+        super().__init__()
+        self.neutron_quantizer = NeutronQuantizer(target_spec)
+
+        def _should_quantize_with_cortex_m(n: Node) -> bool:
+            # The CortexMQuantizer should be used for nodes which were explicitly chosen, and for nodes which were not
+            #  quantized by the NeutronQuantizer.
+            return (
+                n.meta.get(NXP_NEUTRON_BACKEND_IGNORE, False)
+                or Q_ANNOTATION_KEY not in n.meta
+            )
+
+        self.cortex_m_quantizer = CortexMQuantizer(
+            filter_fn=_should_quantize_with_cortex_m
+        )
+
+        self.target_spec = target_spec
+        self.cortex_m_designated_node_identifiers = cortex_m_designated_node_identifiers
+
+    def annotate(self, model: GraphModule) -> GraphModule:
+        # Due to how SharedQuantizationSpecs are used, skipping select ops in NeutronQuantizer would cause errors.
+        # Instead, first NeutronQuantizer is used to annotate all nodes in the model (that it supports). Then, the
+        #  annotations are removed from nodes that should be handled by the Cortex-M backend, and the CortexMQuantizer
+        #  is applied to these nodes only.
+
+        # Apply NeutronQuantizer.
+        model = self.neutron_quantizer.annotate(model)
+
+        # Mark the nodes which will be handled by the Cortex-M backend.
+        # This mark is used by the CortexMQuantizer, and later by the NeutronPartitioner.
+        self._mark_nodes_to_be_quantized_by_cortex_m_quantizer(
+            model, self.cortex_m_designated_node_identifiers
+        )
+
+        # Remove the annotations from nodes selected for the Cortex-M quantizer.
+        for node in model.graph.nodes:
+            if node.op != "call_function":
+                continue
+            if not node.meta.get(NXP_NEUTRON_BACKEND_IGNORE, False):
+                continue  # Node should be quantized by NeutronQuantizer. All good.
+
+            # This node should be quantized using CortexMQuantizer. Remove the quantization annotation.
+            node.meta.pop(Q_ANNOTATION_KEY, None)
+            node.meta.pop("quantizer_matched", None)
+
+        # Apply CortexMQuantizer.
+        model = self.cortex_m_quantizer.annotate(model)
+
+        return model
+
+    def transform_for_annotation(
+        self, model: torch.fx.GraphModule
+    ) -> torch.fx.GraphModule:
+        model = self.neutron_quantizer.transform_for_annotation(model)
+        model = self.cortex_m_quantizer.transform_for_annotation(model)
+        return model
+
+    def validate(self, model: GraphModule) -> None:
+        self.neutron_quantizer.validate(model)
+        self.cortex_m_quantizer.validate(model)
+
+    # noinspection PyMethodMayBeStatic
+    def _mark_nodes_to_be_quantized_by_cortex_m_quantizer(
+        self, graph: GraphModule, cortex_m_designated_node_identifiers: set[str]
+    ):
+        """Mark nodes which were selected to be handled by to Cortex-M backend.
+        The mark is `node.meta[NXP_NEUTRON_BACKEND_IGNORE] = True`
+        """
+        for node in graph.graph.nodes:
+            if (torch_fn := node.meta.get("torch_fn")) is not None and torch_fn[
+                0
+            ] in cortex_m_designated_node_identifiers:
+                # This node was selected specifically for the Cortex-M backend.
+                node.meta[NXP_NEUTRON_BACKEND_IGNORE] = True

--- a/backends/nxp/quantizer/neutron_quantizer.py
+++ b/backends/nxp/quantizer/neutron_quantizer.py
@@ -5,6 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 import torch
+
+from executorch.backends.nxp import NXP_NEUTRON_BACKEND_IGNORE
 from executorch.backends.nxp.aten_passes.neutron_aten_pass_manager import (
     _get_default_passes,
     NeutronAtenPassManager,
@@ -111,6 +113,13 @@ class NeutronAtenQuantizer(Quantizer):
             if not no_outside_users(fused_partition):
                 continue
 
+            if len(fused_partition) == 1 and all(
+                n.meta.get(NXP_NEUTRON_BACKEND_IGNORE, False)
+                for n in fused_partition[0].nodes
+            ):
+                # This node was selected to be ignored by the NeutronQuantizer.
+                continue
+
             anchors = self.pattern.get_anchors(model, fused_partition)
             if not anchors or anchors.empty:
                 continue
@@ -187,8 +196,6 @@ def act_qspec(is_qat: bool):
 
     return QuantizationSpec(
         dtype=torch.int8,
-        quant_min=-128,
-        quant_max=127,
         qscheme=torch.per_tensor_affine,
         is_dynamic=False,
         observer_or_fake_quant_ctr=observer_or_fake_quant_ctr,

--- a/backends/nxp/quantizer/utils.py
+++ b/backends/nxp/quantizer/utils.py
@@ -1,5 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-# Copyright 2024-2025 NXP
+# Copyright 2024-2026 NXP
 # All rights reserved.
 #
 # This source code is licensed under the BSD-style license found in the
@@ -166,7 +166,7 @@ def find_sequential_partitions_aten(
     fusion_candidates = itertools.product(*typed_partitions_list)
     fused_partitions = []
     for candidate in fusion_candidates:
-        if _partitions_sequential(candidate):
+        if _partitions_sequential(candidate) and candidate != ():
             fused_partitions.append(candidate)
     return fused_partitions
 

--- a/backends/nxp/tests/test_imxrt700cm_backend.py
+++ b/backends/nxp/tests/test_imxrt700cm_backend.py
@@ -1,0 +1,140 @@
+# Copyright 2026 NXP
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import operator
+
+import torch
+
+from executorch.backends.nxp.backend.ir.converter.node_converters.ops_converters import (
+    AddTensorConverter,
+    SoftmaxConverter,
+)
+from executorch.backends.nxp.imxrt700cm.imxrt700cm_pipeline import lower_to_imxrt700cm
+from executorch.backends.nxp.tests.executors import OverrideTargetSupportCheck
+from executorch.examples.nxp.experimental.cifar_net.cifar_net import CifarNet
+from executorch.examples.nxp.models.mobilenet_v2 import MobilenetV2
+from executorch.exir.dialects._ops import ops as exir_ops
+from torch.fx import Node
+
+CortexMAdd = exir_ops.edge.cortex_m.quantized_add.default
+CortexMDequantize = exir_ops.edge.cortex_m.dequantize_per_tensor.default
+CortexMMaximum = exir_ops.edge.cortex_m.maximum.default
+CortexMMinimum = exir_ops.edge.cortex_m.minimum.default
+CortexMQuantize = exir_ops.edge.cortex_m.quantize_per_tensor.default
+CortexMSoftmax = exir_ops.edge.cortex_m.softmax.default
+ExecutorchDelegateCall = torch.ops.higher_order.executorch_call_delegate
+
+
+def test_cifar_net__float_io():
+    model_base = CifarNet()
+    model = model_base.get_eager_model().eval().to(memory_format=torch.channels_last)
+    input_shape = (1, 3, 32, 32)
+    target = "imxrt700"
+
+    # The SoftMax in CifarNet is currently unsupported by Neutron, so it is handled by CortexM. But we prohibit
+    #  Neutron from delegating it anyway, to make sure this test will be passing even with future SoftMax enablement.
+    def _unsupported(*_) -> bool:
+        return False
+
+    with OverrideTargetSupportCheck(
+        SoftmaxConverter, new_target_support_check=_unsupported
+    ):
+        epm = lower_to_imxrt700cm(model, input_shape, target=target)
+
+    nodes = list(epm.exported_program().graph.nodes)
+    assert nodes[1].target == CortexMQuantize
+    assert nodes[3].target == ExecutorchDelegateCall
+    assert nodes[4].target == operator.getitem
+    assert nodes[5].target == CortexMSoftmax
+    assert nodes[6].target == CortexMDequantize
+
+
+def test_mobile_net__simulated_unsupported_add():
+    model_base = MobilenetV2(use_random_dataset=True)
+    model = model_base.get_eager_model().eval().to(memory_format=torch.channels_last)
+    input_shape = (1, 3, 224, 224)
+    target = "imxrt700"
+
+    def _new_add_target_support(node: Node, *_) -> bool:
+        # Do not delegate this one specific node to simulate an unsupported case.
+        return node.meta["torch_fn"][0] != "add_2"
+
+    with OverrideTargetSupportCheck(
+        AddTensorConverter, new_target_support_check=_new_add_target_support
+    ):
+        epm = lower_to_imxrt700cm(model, input_shape, target=target)
+
+    nodes = list(epm.exported_program().graph.nodes)
+    assert nodes[1].target == CortexMQuantize
+    assert nodes[3].target == ExecutorchDelegateCall
+    assert nodes[4].target == operator.getitem
+    assert nodes[5].target == operator.getitem
+    assert nodes[6].target == CortexMAdd and nodes[6].meta["torch_fn"][0] == "add_2"
+    assert nodes[8].target == ExecutorchDelegateCall
+    assert nodes[9].target == operator.getitem
+    assert nodes[10].target == CortexMDequantize
+
+
+class AddMinimumMaximumModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x):
+        y = x + x
+        y = torch.minimum(x, y)
+        x = torch.maximum(x, y)
+        return x
+
+
+def test_add_minimum_maximum():
+    # The `aten.minimum` and `aten.maximum` are not supported by Neutron, but they are supported by Cortex-M.
+    # The 2 consecutive nodes are used to test that the `IMXRT700Quantizer` correctly uses the `CortexMQuantizer` to
+    #  quantize nodes which were not quantized by the `NeutronQuantizer`, and were not marked with
+    #  `NXP_NEUTRON_BACKEND_IGNORE`.
+    model = AddMinimumMaximumModel().eval()
+    input_shape = (24,)
+    target = "imxrt700"
+
+    epm = lower_to_imxrt700cm(model, input_shape, target=target)
+
+    nodes = list(epm.exported_program().graph.nodes)
+    assert nodes[1].target == CortexMQuantize
+    assert nodes[3].target == ExecutorchDelegateCall
+    assert nodes[4].target == operator.getitem
+    assert nodes[5].target == CortexMMinimum
+    assert nodes[6].target == CortexMMaximum
+    assert nodes[7].target == CortexMDequantize
+
+
+class MulMinimumModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x):
+        y = x * x
+        x = torch.minimum(x, y)
+        return x
+
+
+def test_mul_minimum():
+    # The `aten.minimum` is not supported by Neutron, but it is supported by Cortex-M.
+    # The `Mul` is supported by Neutron, but it requires a specific quantization parameters, which are not compatible
+    #  with the CortexM Minimum node after. Therefore, extra Dequantize -> Quantize is inserted.
+    # TODO Look into whether this can be optimized.(EIEX-806)
+    model = MulMinimumModel().eval()
+    input_shape = (24,)
+    target = "imxrt700"
+
+    epm = lower_to_imxrt700cm(model, input_shape, target=target)
+
+    nodes = list(epm.exported_program().graph.nodes)
+    print(nodes)
+    assert nodes[1].target == CortexMQuantize
+    assert nodes[3].target == ExecutorchDelegateCall
+    assert nodes[4].target == operator.getitem
+    assert nodes[5].target == CortexMDequantize
+    assert nodes[6].target == CortexMQuantize
+    assert nodes[7].target == CortexMMinimum
+    assert nodes[8].target == CortexMDequantize

--- a/backends/nxp/tests/test_integration.py
+++ b/backends/nxp/tests/test_integration.py
@@ -47,7 +47,7 @@ def test_cifarnet(use_qat):
     delegation_info = get_delegation_info(exec_prog.exported_program().graph_module)
     assert delegation_info.num_delegated_subgraphs == 1
     assert delegation_info.num_non_delegated_nodes == 11
-    assert delegation_info.num_delegated_nodes == 45
+    assert delegation_info.num_delegated_nodes == 36
 
     nodes = list(exec_prog.exported_program().graph.nodes)
     assert nodes[2].name == "quantized_decomposed_quantize_per_tensor_default"

--- a/backends/nxp/tests_models/dataset_creator.py
+++ b/backends/nxp/tests_models/dataset_creator.py
@@ -100,7 +100,13 @@ class RandomDatasetCreator(DatasetCreator):
                     case _:
                         raise ValueError(f"Unsupported dim_order: {spec.dim_order}")
 
-                sample_vector = rng.random(np.prod(shape), spec.type).reshape(shape)
+                if spec.type == np.int8:
+                    sample_vector = (
+                        rng.random(np.prod(shape), "float32").reshape(shape) * 256 - 128
+                    ).astype("int8")
+                else:
+                    sample_vector = rng.random(np.prod(shape), spec.type).reshape(shape)
+
                 sample_vector.tofile(
                     os.path.join(sample_dir, f"{str(spec_idx).zfill(2)}.bin")
                 )

--- a/examples/nxp/experimental/cifar_net/cifar_net.py
+++ b/examples/nxp/experimental/cifar_net/cifar_net.py
@@ -13,7 +13,6 @@ import numpy as np
 
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 import torch.optim as optim
 import torchvision
 
@@ -27,14 +26,21 @@ logger.setLevel(logging.INFO)
 
 class CifarNet(model_base.EagerModelBase):
 
-    def __init__(self, batch_size: int = 1, pth_file: str | None = None):
+    def __init__(
+        self,
+        batch_size: int = 1,
+        pth_file: str | None = None,
+    ):
         self.batch_size = batch_size
         self.pth_file = pth_file or os.path.join(
             os.path.dirname(__file__), "cifar_net.pth"
         )
 
     def get_eager_model(self) -> torch.nn.Module:
-        return get_model(self.batch_size, state_dict_file=self.pth_file)
+        return get_model(
+            self.batch_size,
+            state_dict_file=self.pth_file,
+        )
 
     def get_example_inputs(self) -> Tuple[torch.Tensor]:
         tl = get_test_loader()
@@ -59,24 +65,21 @@ class CifarNetModel(nn.Module):
     def __init__(self):
         super().__init__()
 
-        self.conv1 = nn.Conv2d(3, 32, 5)
-        self.conv2 = nn.Conv2d(32, 32, 5)
-        self.conv3 = nn.Conv2d(32, 64, 5)
+        self.conv1 = nn.Conv2d(3, 32, 5, padding=2)
+        self.conv2 = nn.Conv2d(32, 32, 5, padding=2)
+        self.conv3 = nn.Conv2d(32, 64, 5, padding=2)
         self.pool1 = nn.MaxPool2d(2, 2)
         self.pool2 = nn.MaxPool2d(1, 2)
         self.fc = nn.Linear(1024, 10)
         self.softmax = nn.Softmax(1)
 
     def forward(self, x):
-        x = F.pad(x, (2, 2, 2, 2))
         x = self.conv1(x)
         x = self.pool1(x)
 
-        x = F.pad(x, (2, 2, 2, 2))
         x = self.conv2(x)
         x = self.pool1(x)
 
-        x = F.pad(x, (2, 2, 2, 2))
         x = self.conv3(x)
         x = self.pool2(x)
 

--- a/examples/nxp/models/BUCK
+++ b/examples/nxp/models/BUCK
@@ -1,0 +1,18 @@
+load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target", "non_fbcode_target")
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+
+oncall("executorch")
+
+fbcode_target(_kind = runtime.python_library,
+    name = "mobilenet_v2",
+    srcs = [
+        "mobilenet_v2.py",
+    ],
+    deps = [
+        "//caffe2:torch",
+        "//executorch/exir:lib",
+        "//executorch/examples/models:model_base",
+        "fbsource//third-party/pypi/numpy:numpy",
+        "//pytorch/vision:torchvision",  # @manual
+    ],
+)

--- a/examples/nxp/setup.sh
+++ b/examples/nxp/setup.sh
@@ -15,3 +15,24 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Install the required visualization dependencies.
 "${SCRIPT_DIR}/../../devtools/install_requirements.sh"
+
+# Install tosa_serializer if needed (required for CortexM dependencies)
+# Taken from executorch/.ci/scripts/unittest-linux-cmake.sh
+if ! python -c "import tosa_serializer" >/dev/null 2>&1; then
+  EXECUTORCH_DIR=$(dirname $(dirname $SCRIPT_DIR))
+  cd $EXECUTORCH_DIR
+  TOSA_SERIALIZATION_DIR="./examples/arm/arm-scratch/tosa-tools/serialization"
+  if [[ ! -d "${TOSA_SERIALIZATION_DIR}" ]]; then
+    TOSA_TOOLS_DIR="$(mktemp -d /tmp/tosa-tools.XXXXXX)"
+    git clone --depth 1 --branch v2025.11.2 \
+      https://git.gitlab.arm.com/tosa/tosa-tools.git "${TOSA_TOOLS_DIR}"
+    TOSA_SERIALIZATION_DIR="${TOSA_TOOLS_DIR}/serialization"
+  fi
+
+  python -m pip install pybind11==2.10.4
+  CMAKE_POLICY_VERSION_MINIMUM=3.5 BUILD_PYBIND=1 \
+    python -m pip install --no-dependencies \
+    "${TOSA_SERIALIZATION_DIR}"
+  python -c "import tosa_serializer"
+  cd -
+fi

--- a/src/executorch/examples/nxp
+++ b/src/executorch/examples/nxp
@@ -1,0 +1,1 @@
+../../../examples/nxp/

--- a/src/executorch/examples/nxp/experimental
+++ b/src/executorch/examples/nxp/experimental
@@ -1,1 +1,0 @@
-../../../../examples/nxp/experimental/


### PR DESCRIPTION
### Summary
Add imxrt700cm backend which combines the Neutron and CortexM backends into one. The backend uses Neutron wherever possible, and the leftover nodes are handled by Cortex-M.

Fixes #13470

### Test plan
Unit tests provided


cc @robert-kalmar @JakeStevens @digantdesai @rascani