### PR TITLE
Arm backend: Fix TOSA compile spec deprecation test

### DIFF
--- a/backends/arm/test/deprecation/test_arm_compile_spec_deprecation.py
+++ b/backends/arm/test/deprecation/test_arm_compile_spec_deprecation.py
@@ -26,7 +26,7 @@ def test_from_list_with_output_order_workaround_warns():
         CompileSpec("ouput_reorder_workaround", b"true"),
     ]
     with pytest.warns(DeprecationWarning):
-        spec = TosaCompileSpec.from_list(compile_specs)
+        spec = TosaCompileSpec._from_list(compile_specs)
     assert isinstance(spec, TosaCompileSpec)
 
 


### PR DESCRIPTION
Update the deprecation test to call `_from_list()` instead of the nonexistent `from_list()` helper on `TosaCompileSpec`.


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @robell