### PR TITLE
Fix flatbuffer error (#18505)

### DIFF
--- a/runtime/executor/test/program_test.cpp
+++ b/runtime/executor/test/program_test.cpp
@@ -811,7 +811,10 @@ TEST_F(ProgramTest, NullPlanNameDoesNotCrash) {
   auto program = executorch_flatbuffer::CreateProgram(
       builder,
       0,
-      builder.CreateVector({execution_plan}),
+      builder.CreateVector(
+          std::vector<
+              flatbuffers::Offset<executorch_flatbuffer::ExecutionPlan>>{
+              execution_plan}),
       builder.CreateVector(
           std::vector<flatbuffers::Offset<executorch_flatbuffer::Buffer>>{}),
       builder.CreateVector(


### PR DESCRIPTION
Summary:

Error message:
[Pre-existing Failure] Target failed to build.
Action failed: fbcode//executorch/runtime/executor/test:program_test (cfg:dev-linux-x86_64-fbcode-platform010-clang19-asan-ubsan-dev#f651cb08bd7caa6c) (cxx_compile program_test.cpp (pic))
headers/flatbuffers/flatbuffers.h:1678:42: note: candidate function template not viable: requires 2 arguments, but 1 was provided
 1678 |   template<typename T> Offset<Vector<T>> CreateVector(const T *v, size_t

Differential Revision: D98196906


