### PR TITLE
Default to single-threaded shader compilation on macOS (#18506)

### DIFF
--- a/backends/vulkan/targets.bzl
+++ b/backends/vulkan/targets.bzl
@@ -97,7 +97,10 @@ def vulkan_spv_shader_lib(name, spv_filegroups, is_fbcode = False, no_volk = Fal
     for target, subpath in spv_filegroups.items():
         glsl_paths.append("$(location {})/{}".format(target, subpath))
 
-    nthreads = read_config("etvk", "shader_compile_nthreads", "-1")
+    # Default to single-threaded shader compilation on macOS to avoid
+    # multiprocessing issues with the local build toolchain.
+    default_nthreads = "1" if host_info().os.is_macos else "-1"
+    nthreads = read_config("etvk", "shader_compile_nthreads", default_nthreads)
 
     genrule_cmd = (
         "$(exe {}) ".format(gen_vulkan_spv_target) +


### PR DESCRIPTION
Summary:

The parallel shader compilation in gen_vulkan_spv.py (using multiprocessing.Pool) fails when building locally on macOS. This changes the default nthreads from -1 (all cores) to 1 on macOS hosts, while preserving the existing behavior on other platforms.

The setting can still be overridden via `-c etvk.shader_compile_nthreads=N`.

Reviewed By: SS-JIA

Differential Revision: D98195392


