### PR TITLE
Arm backend: Skip concating single tensors in AdaptiveAvgPool

### DIFF
--- a/backends/arm/_passes/decompose_adaptive_avg_pool2d_pass.py
+++ b/backends/arm/_passes/decompose_adaptive_avg_pool2d_pass.py
@@ -98,15 +98,20 @@ class DecomposeAdaptiveAvgPool2dPass(ArmPass):
                     avg_pool2d_op, pool_args, kwargs, meta, True
                 )
                 row.append(pooled)
-
-            # Concatenate row results along width (dim=3)
-            row_tensor = super().call_operator(
-                cat_op, (row, 3), kwargs, meta_with_no_qparams, True
-            )
+            # Concatenate row results along width (dim=3) if more than one.
+            if len(row) > 1:
+                row_tensor = super().call_operator(
+                    cat_op, (row, 3), kwargs, meta_with_no_qparams, True
+                )
+            else:
+                row_tensor = row[0]
             res.append(row_tensor)
 
-        # Concatenate all rows along height (dim=2)
-        out = super().call_operator(
-            cat_op, (res, 2), kwargs, meta_with_no_qparams, True
-        )
+        # Concatenate all rows along height (dim=2) if more than one.
+        if len(res) > 1:
+            out = super().call_operator(
+                cat_op, (res, 2), kwargs, meta_with_no_qparams, True
+            )
+        else:
+            out = res[0]
         return out


### PR DESCRIPTION
It was inserting no-op concats.
It was discovered in https://github.com/pytorch/executorch/issues/18500

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell