### PR TITLE
Use reusable Claude Code workflow from test-infra

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -3,68 +3,20 @@ name: Claude Code
 on:
   issue_comment:
     types: [created]
-  pull_request_review_comment:
-    types: [created]
   issues:
     types: [opened]
 
 jobs:
   claude-code:
-    # Early exit conditions (fast gate — avoids spinning up a runner for unauthorized users):
-    # 1. Must be pytorch org
-    # 2. Must mention @claude
-    # 3. Must be org member/collaborator OR an allowed bot
-    # Note: issue_comment and pull_request_review_comment share the same payload paths
-    if: |
-      github.repository_owner == 'pytorch' &&
-      (
-        (github.event_name != 'issues' &&
-         contains(github.event.comment.body, '@claude') &&
-         contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
-        (github.event_name == 'issues' &&
-         contains(github.event.issue.body, '@claude') &&
-         contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
-      )
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    environment: bedrock
+    uses: pytorch/test-infra/.github/workflows/_claude-code.yml@main
+    with:
+      setup_script: |
+        pip install lintrunner==0.12.7 lintrunner-adapters==0.13.0
+        pip install -r requirements-lintrunner.txt
+        lintrunner init
     permissions:
       contents: read
       pull-requests: write
       issues: write
       id-token: write
-    steps:
-      # Fork PR support enabled by using izaitsevfb/claude-code-action@forked-pr-fix
-
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-
-      - name: Install lintrunner
-        run: |
-          pip install lintrunner==0.12.5
-          lintrunner init
-
-      - name: Configure AWS credentials via OIDC
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::308535385114:role/gha_workflow_claude_code
-          aws-region: us-east-1
-
-      - name: Run Claude Code
-        uses: izaitsevfb/claude-code-action@forked-pr-fix
-        with:
-          # We filter by github.actor at workflow level, there is no point of filtering here as well
-          allowed_bots: "*"
-          claude_args: "--model global.anthropic.claude-opus-4-6-v1"
-          settings: '{"alwaysThinkingEnabled": true}'
-          use_bedrock: "true"
-
-      - name: Upload usage metrics
-        if: always()
-        uses: pytorch/test-infra/.github/actions/upload-claude-usage@main
+    secrets: inherit


### PR DESCRIPTION
## Summary
- The hand-rolled `claude-code.yml` was failing because it only installed `lintrunner` but not `lintrunner-adapters` or the lintrunner requirements, causing `lintrunner init` to fail with `No module named lintrunner_adapters`
- Switches to the centralized reusable workflow from `pytorch/test-infra` (`_claude-code.yml`), passing lintrunner setup via the `setup_script` input
- This also picks up additional features from the reusable workflow: ghstack PR detection, commit author attribution, and write-access verification
- Drops the `pull_request_review_comment` trigger which the reusable workflow intentionally does not support for [security reasons](https://github.com/orgs/community/discussions/55940#discussioncomment-5950832)

Example of the failing job: https://github.com/pytorch/executorch/actions/runs/23601405262/job/68732162666

## Test plan
- Verify the workflow file is valid YAML and the `uses` reference resolves
- After merge, trigger with `@claude` on a PR comment to confirm the job runs successfully