### PR TITLE
Add Voxtral TTS model for ExecuTorch with Metal backend

### DIFF
--- a/.ci/scripts/export_model_artifact.sh
+++ b/.ci/scripts/export_model_artifact.sh
@@ -184,6 +184,14 @@ case "$HF_MODEL" in
     PREPROCESSOR_FEATURE_SIZE=""
     PREPROCESSOR_OUTPUT=""
     ;;
+  mistralai/Voxtral-4B-TTS-2603)
+    MODEL_NAME="voxtral_tts"
+    TASK=""
+    MAX_SEQ_LEN=""
+    EXTRA_PIP=""  # deps installed in handler below
+    PREPROCESSOR_FEATURE_SIZE=""
+    PREPROCESSOR_OUTPUT=""
+    ;;
   SocialLocalMobile/Qwen3.5-35B-A3B-HQQ-INT4)
     MODEL_NAME="qwen3_5_moe"
     TASK=""
@@ -322,6 +330,56 @@ if [ "$MODEL_NAME" = "dinov2" ]; then
   if [ "$DEVICE" = "cuda" ] || [ "$DEVICE" = "cuda-windows" ]; then
     test -f "${OUTPUT_DIR}/aoti_cuda_blob.ptd"
   fi
+  ls -al "${OUTPUT_DIR}"
+  echo "::endgroup::"
+  exit 0
+fi
+
+# Voxtral TTS uses a custom export script
+if [ "$MODEL_NAME" = "voxtral_tts" ]; then
+  pip install safetensors huggingface_hub
+
+  LOCAL_MODEL_DIR="${OUTPUT_DIR}/model_weights"
+  python -c "from huggingface_hub import snapshot_download; snapshot_download('${HF_MODEL}', local_dir='${LOCAL_MODEL_DIR}')"
+
+  VT_QUANT_ARGS=""
+  VT_DTYPE_ARGS=""
+  VT_BACKEND="xnnpack"
+  if [ "$QUANT_NAME" = "quantized-8da4w" ]; then
+    VT_QUANT_ARGS="--qlinear 8da4w --qlinear-group-size 32"
+    VT_BACKEND="xnnpack"
+  elif [ "$QUANT_NAME" = "quantized-int4-metal" ]; then
+    VT_QUANT_ARGS="--qlinear fpa4w"
+    VT_DTYPE_ARGS="--dtype bf16"
+    VT_BACKEND="metal"
+  elif [ "$QUANT_NAME" = "non-quantized" ] && [ "$DEVICE" = "metal" ]; then
+    VT_DTYPE_ARGS="--dtype bf16"
+    VT_BACKEND="metal"
+  fi
+
+  python -m executorch.examples.models.voxtral_tts.export_voxtral_tts \
+      --model-path "$LOCAL_MODEL_DIR" \
+      --backend "$VT_BACKEND" \
+      --output-dir "${OUTPUT_DIR}" \
+      ${VT_QUANT_ARGS} \
+      ${VT_DTYPE_ARGS}
+
+  test -f "${OUTPUT_DIR}/model.pte"
+  test -f "${OUTPUT_DIR}/codec.pte"
+
+  # Convert a voice embedding for testing
+  python -c "
+import torch, struct
+v = torch.load('${LOCAL_MODEL_DIR}/voice_embedding/casual_male.pt', map_location='cpu', weights_only=True).float()
+with open('${OUTPUT_DIR}/voice.bin', 'wb') as f:
+    f.write(struct.pack('<qq', *v.shape))
+    f.write(v.numpy().tobytes())
+print(f'Voice: {v.shape}')
+"
+
+  # Copy tokenizer
+  cp "$LOCAL_MODEL_DIR/tekken.json" "${OUTPUT_DIR}/tekken.json"
+  rm -rf "$LOCAL_MODEL_DIR"
   ls -al "${OUTPUT_DIR}"
   echo "::endgroup::"
   exit 0

--- a/.ci/scripts/test_model_e2e.sh
+++ b/.ci/scripts/test_model_e2e.sh
@@ -216,6 +216,18 @@ case "$HF_MODEL" in
     AUDIO_FILE="test_audio.wav"
     IMAGE_PATH=""
     ;;
+  mistralai/Voxtral-4B-TTS-2603)
+    MODEL_NAME="voxtral_tts"
+    RUNNER_TARGET="voxtral_tts_runner"
+    RUNNER_PATH="voxtral_tts"
+    EXPECTED_OUTPUT=""
+    PREPROCESSOR=""
+    TOKENIZER_URL="https://huggingface.co/mistralai/Voxtral-4B-TTS-2603/resolve/main" # @lint-ignore
+    TOKENIZER_FILE="tekken.json"
+    AUDIO_URL=""
+    AUDIO_FILE=""
+    IMAGE_PATH=""
+    ;;
   SocialLocalMobile/Qwen3.5-35B-A3B-HQQ-INT4)
     MODEL_NAME="qwen3_5_moe"
     RUNNER_TARGET="qwen3_5_moe_runner"
@@ -244,7 +256,7 @@ echo "::group::Prepare $MODEL_NAME Artifacts"
 
 
 # Download tokenizer files (skip for models that bundle tokenizer in export or do not use one)
-if [ "$MODEL_NAME" != "parakeet" ] && [ "$MODEL_NAME" != "voxtral_realtime" ] && [ "$MODEL_NAME" != "sortformer" ] && [ "$MODEL_NAME" != "dinov2" ] && [ "$MODEL_NAME" != "qwen3_5_moe" ]; then
+if [ "$MODEL_NAME" != "parakeet" ] && [ "$MODEL_NAME" != "voxtral_realtime" ] && [ "$MODEL_NAME" != "voxtral_tts" ] && [ "$MODEL_NAME" != "sortformer" ] && [ "$MODEL_NAME" != "dinov2" ] && [ "$MODEL_NAME" != "qwen3_5_moe" ]; then
   if [ "$TOKENIZER_FILE" != "" ]; then
     curl -L $TOKENIZER_URL/$TOKENIZER_FILE -o $MODEL_DIR/$TOKENIZER_FILE
   else
@@ -372,6 +384,10 @@ EOF
       RUNNER_ARGS="$RUNNER_ARGS --streaming"
     fi
     ;;
+  voxtral_tts)
+    RUNNER_ARGS="--model_path ${MODEL_DIR}/model.pte --codec_path ${MODEL_DIR}/codec.pte --tokenizer_path ${MODEL_DIR}/$TOKENIZER_FILE --voice_path ${MODEL_DIR}/voice.bin --prompt Hello --output_path ${MODEL_DIR}/output.wav --max_tokens 50 --temperature 0"
+    VOXTRAL_TTS_WAV="${MODEL_DIR}/output.wav"
+    ;;
 esac
 
 OUTPUT=$(eval $RUNNER_BIN $RUNNER_ARGS 2>&1)
@@ -396,6 +412,23 @@ if [ -n "$EXPECTED_OUTPUT" ]; then
   fi
 else
   echo "SUCCESS: Runner completed successfully"
+fi
+
+# Validate TTS WAV output if applicable
+if [ -n "${VOXTRAL_TTS_WAV:-}" ]; then
+  echo "Validating WAV output: ${VOXTRAL_TTS_WAV}"
+  python3 -c "
+import wave, numpy as np, sys
+with wave.open('${VOXTRAL_TTS_WAV}') as f:
+    sr = f.getframerate()
+    data = np.frombuffer(f.readframes(f.getnframes()), dtype=np.int16).astype(np.float32) / 32767
+duration = len(data) / sr
+rms = np.sqrt(np.mean(data**2))
+print(f'WAV: {duration:.1f}s, {sr}Hz, rms={rms:.4f}')
+assert duration > 0.5, f'Audio too short: {duration:.1f}s'
+assert rms > 0.001, f'Audio is silent: rms={rms}'
+print('WAV validation: PASS')
+"
 fi
 echo "::endgroup::"
 

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -233,6 +233,40 @@ jobs:
         bash .ci/scripts/test_model_e2e.sh xnnpack "mistralai/Voxtral-Mini-4B-Realtime-2602" "quantized-8da4w" "./voxtral_realtime_output"
         echo "::endgroup::"
 
+  test-voxtral-tts-metal-macos:
+    name: test-voxtral-tts-metal-macos
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+    with:
+      runner: macos-m1-stable
+      submodules: 'recursive'
+      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      timeout: 180
+      secrets-env: VOXTRAL_TTS_HF_TOKEN
+      script: |
+        set -eux
+
+        eval "$(conda shell.bash hook)"
+        conda activate
+
+        export HF_TOKEN="${SECRET_VOXTRAL_TTS_HF_TOKEN}"
+
+        echo "::group::Setup ExecuTorch"
+        EXECUTORCH_BUILD_KERNELS_TORCHAO=1 TORCHAO_BUILD_EXPERIMENTAL_MPS=1 ./install_executorch.sh
+        echo "::endgroup::"
+
+        echo "::group::Export Voxtral TTS with Metal"
+        bash .ci/scripts/export_model_artifact.sh metal "mistralai/Voxtral-4B-TTS-2603" "quantized-int4-metal" "./voxtral_tts_output"
+        echo "::endgroup::"
+
+        echo "::group::Test Voxtral TTS with Metal"
+        bash .ci/scripts/test_model_e2e.sh metal "mistralai/Voxtral-4B-TTS-2603" "quantized-int4-metal" "./voxtral_tts_output"
+        echo "::endgroup::"
+
   test-llama-runner-linux:
     # Test Both linux x86 and linux aarch64
     name: test-llama-runner-linux

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@
 #
 # ==============================================================================
 
-.PHONY: voxtral-cuda voxtral-cpu voxtral-metal voxtral_realtime-cuda voxtral_realtime-cpu voxtral_realtime-metal whisper-cuda whisper-cuda-debug whisper-cpu whisper-metal parakeet-cuda parakeet-cuda-debug parakeet-cpu parakeet-metal parakeet-vulkan dinov2-cuda dinov2-cuda-debug sortformer-cuda sortformer-cpu silero-vad-cpu llama-cuda llama-cuda-debug llama-cpu llava-cpu gemma3-cuda gemma3-cpu qwen3_5_moe-cuda clean help
+.PHONY: voxtral-cuda voxtral-cpu voxtral-metal voxtral_realtime-cuda voxtral_realtime-cpu voxtral_realtime-metal voxtral_tts-cpu voxtral_tts-metal whisper-cuda whisper-cuda-debug whisper-cpu whisper-metal parakeet-cuda parakeet-cuda-debug parakeet-cpu parakeet-metal parakeet-vulkan dinov2-cuda dinov2-cuda-debug sortformer-cuda sortformer-cpu silero-vad-cpu llama-cuda llama-cuda-debug llama-cpu llava-cpu gemma3-cuda gemma3-cpu qwen3_5_moe-cuda clean help
 
 help:
 	@echo "This Makefile adds targets to build runners for various models on various backends. Run using \`make <target>\`. Available targets:"
@@ -101,6 +101,8 @@ help:
 	@echo "  voxtral_realtime-cuda - Build Voxtral Realtime runner with CUDA backend"
 	@echo "  voxtral_realtime-cpu - Build Voxtral Realtime runner with CPU backend"
 	@echo "  voxtral_realtime-metal - Build Voxtral Realtime runner with Metal backend (macOS only)"
+	@echo "  voxtral_tts-cpu     - Build Voxtral TTS runner with XNNPACK (CPU)"
+	@echo "  voxtral_tts-metal   - Build Voxtral TTS runner with Metal backend (macOS only)"
 	@echo "  whisper-cuda        - Build Whisper runner with CUDA backend"
 	@echo "  whisper-cuda-debug  - Build Whisper runner with CUDA backend (debug mode)"
 	@echo "  whisper-cpu         - Build Whisper runner with CPU backend"
@@ -294,6 +296,24 @@ voxtral_realtime-cuda:
 	@echo ""
 	@echo "✓ Build complete!"
 	@echo "  Binary: cmake-out/examples/models/voxtral_realtime/voxtral_realtime_runner"
+
+voxtral_tts-cpu:
+	@echo "==> Building and installing ExecuTorch..."
+	cmake --workflow --preset llm-release
+	@echo "==> Building Voxtral TTS runner (CPU/XNNPACK)..."
+	cd examples/models/voxtral_tts && cmake --workflow --preset voxtral-tts-cpu
+	@echo ""
+	@echo "✓ Build complete!"
+	@echo "  Binary: cmake-out/examples/models/voxtral_tts/voxtral_tts_runner"
+
+voxtral_tts-metal:
+	@echo "==> Building and installing ExecuTorch with Metal (stats enabled)..."
+	cmake --workflow --preset llm-metal-stats
+	@echo "==> Building Voxtral TTS runner with Metal..."
+	cd examples/models/voxtral_tts && cmake --workflow --preset voxtral-tts-metal
+	@echo ""
+	@echo "✓ Build complete!"
+	@echo "  Binary: cmake-out/examples/models/voxtral_tts/voxtral_tts_runner"
 
 silero-vad-cpu:
 	@echo "==> Building and installing ExecuTorch..."

--- a/examples/models/voxtral_tts/CMakeLists.txt
+++ b/examples/models/voxtral_tts/CMakeLists.txt
@@ -1,0 +1,95 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+cmake_minimum_required(VERSION 3.24)
+project(voxtral_tts)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
+
+include(${EXECUTORCH_ROOT}/tools/cmake/Utils.cmake)
+
+# Let files say "include <executorch/path/to/header.h>"
+set(_common_include_directories ${EXECUTORCH_ROOT}/..)
+
+# Need this for gflags
+set(gflags_DIR ${CMAKE_CURRENT_BINARY_DIR}/../../../third-party/gflags)
+find_package(gflags REQUIRED)
+
+# Find executorch libraries
+list(APPEND CMAKE_FIND_ROOT_PATH ${CMAKE_CURRENT_BINARY_DIR}/../../..)
+find_package(executorch CONFIG REQUIRED FIND_ROOT_PATH_BOTH)
+executorch_target_link_options_shared_lib(executorch)
+
+set(link_libraries executorch gflags)
+
+# Common ops
+list(APPEND link_libraries optimized_native_cpu_ops_lib cpublas eigen_blas)
+executorch_target_link_options_shared_lib(optimized_native_cpu_ops_lib)
+
+# Quantized and custom ops (needed for XNNPACK CPU path)
+list(APPEND link_libraries quantized_ops_lib custom_ops)
+executorch_target_link_options_shared_lib(quantized_ops_lib)
+executorch_target_link_options_shared_lib(custom_ops)
+
+# XNNPACK
+if(TARGET xnnpack_backend)
+  set(xnnpack_backend_libs xnnpack_backend XNNPACK xnnpack-microkernels-prod)
+  if(TARGET kleidiai)
+    list(APPEND xnnpack_backend_libs kleidiai)
+  endif()
+  list(APPEND link_libraries ${xnnpack_backend_libs})
+  executorch_target_link_options_shared_lib(xnnpack_backend)
+endif()
+
+# LLM runner extension
+if(NOT TARGET extension_llm_runner)
+  message(
+    FATAL_ERROR
+      "ExecuTorch must be installed with EXECUTORCH_BUILD_EXTENSION_LLM_RUNNER enabled."
+  )
+endif()
+
+# Needed for cpuinfo where it uses android specific log lib
+if(ANDROID)
+  list(APPEND link_libraries log)
+endif()
+
+# Add the required ExecuTorch extensions
+list(
+  APPEND
+  link_libraries
+  extension_llm_runner
+  extension_module
+  extension_data_loader
+  extension_tensor
+  extension_flat_tensor
+)
+
+# Metal backend
+if(EXECUTORCH_BUILD_METAL)
+  list(APPEND link_libraries metal_backend)
+  executorch_target_link_options_shared_lib(metal_backend)
+endif()
+
+# Tokenizer
+list(APPEND link_libraries tokenizers::tokenizers)
+
+add_executable(voxtral_tts_runner main.cpp voxtral_tts_runner.cpp)
+if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+  target_link_options_gc_sections(voxtral_tts_runner)
+  if(NOT APPLE)
+    target_link_options(voxtral_tts_runner PRIVATE "LINKER:-s")
+  endif()
+endif()
+
+target_include_directories(
+  voxtral_tts_runner PUBLIC ${_common_include_directories}
+)
+target_link_libraries(voxtral_tts_runner PUBLIC ${link_libraries})
+target_compile_options(voxtral_tts_runner PUBLIC ${_common_compile_options})

--- a/examples/models/voxtral_tts/CMakePresets.json
+++ b/examples/models/voxtral_tts/CMakePresets.json
@@ -1,0 +1,87 @@
+{
+    "version": 6,
+    "configurePresets": [
+        {
+            "name": "voxtral-tts-base",
+            "hidden": true,
+            "binaryDir": "${sourceDir}/../../../cmake-out/examples/models/voxtral_tts",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release",
+                "CMAKE_FIND_ROOT_PATH": "${sourceDir}/../../../cmake-out",
+                "CMAKE_PREFIX_PATH": "${sourceDir}/../../../cmake-out"
+            }
+        },
+        {
+            "name": "voxtral-tts-cpu",
+            "displayName": "Voxtral TTS runner (CPU/XNNPACK)",
+            "inherits": [
+                "voxtral-tts-base"
+            ]
+        },
+        {
+            "name": "voxtral-tts-metal",
+            "displayName": "Voxtral TTS runner (Metal)",
+            "inherits": [
+                "voxtral-tts-base"
+            ],
+            "cacheVariables": {
+                "EXECUTORCH_BUILD_METAL": "ON"
+            },
+            "condition": {
+                "lhs": "${hostSystemName}",
+                "type": "equals",
+                "rhs": "Darwin"
+            }
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "voxtral-tts-cpu",
+            "displayName": "Build Voxtral TTS runner (CPU/XNNPACK)",
+            "configurePreset": "voxtral-tts-cpu",
+            "configuration": "Release",
+            "targets": [
+                "voxtral_tts_runner"
+            ]
+        },
+        {
+            "name": "voxtral-tts-metal",
+            "displayName": "Build Voxtral TTS runner (Metal)",
+            "configurePreset": "voxtral-tts-metal",
+            "configuration": "Release",
+            "targets": [
+                "voxtral_tts_runner"
+            ]
+        }
+    ],
+    "workflowPresets": [
+        {
+            "name": "voxtral-tts-cpu",
+            "displayName": "Configure and build Voxtral TTS runner (CPU/XNNPACK)",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "voxtral-tts-cpu"
+                },
+                {
+                    "type": "build",
+                    "name": "voxtral-tts-cpu"
+                }
+            ]
+        },
+        {
+            "name": "voxtral-tts-metal",
+            "displayName": "Configure and build Voxtral TTS runner (Metal)",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "voxtral-tts-metal"
+                },
+                {
+                    "type": "build",
+                    "name": "voxtral-tts-metal"
+                }
+            ]
+        }
+    ]
+}

--- a/examples/models/voxtral_tts/README.md
+++ b/examples/models/voxtral_tts/README.md
@@ -1,0 +1,245 @@
+# Voxtral TTS
+
+Self-contained ExecuTorch implementation of Mistral's Voxtral TTS,
+a text-to-speech model that generates audio from text using a Mistral LLM
+backbone with a flow-matching acoustic transformer and neural audio codec.
+No HuggingFace Transformers dependency — weights are loaded directly from
+the Mistral checkpoint.
+See [model.md](model.md) for architecture and implementation details.
+
+## Overview
+
+The pipeline converts text to speech in two stages: **generation**
+(autoregressive LLM + flow-matching acoustic transformer → audio codes)
+and **decoding** (neural codec → waveform). Export produces two `.pte` files:
+
+| File | Methods | Description |
+|------|---------|-------------|
+| `model.pte` | `token_embedding`, `text_decoder`, `lm_head`, `decode_audio_frame`, `audio_token_embedding` | LLM + acoustic transformer |
+| `codec.pte` | `audio_decoder` | Neural audio codec decoder |
+
+```
+Text  ──→  LLM (Mistral)  ──→  hidden_states
+                                     │
+                                     └──→  AcousticTransformer (flow matching)  ──→  audio codes
+                                                                                        │
+                                     token_embedding(audio_tok=24)  ──→  embeds (fed back to LLM)
+
+After generation:
+  audio codes  ──→  CodecDecoder  ──→  waveform (.wav)
+```
+
+After the text prompt, the runner enters an audio generation loop where
+every step runs `decode_audio_frame` on the LLM hidden state. The LM head
+is not used — the acoustic transformer drives generation directly. The
+flow-matching ODE runs 7 Euler steps with classifier-free guidance to
+produce one frame of audio codes (1 semantic + N acoustic). The runner
+feeds back the audio token (24) embedding for the next LLM step. Generation
+stops when the acoustic transformer's semantic code signals END_AUDIO.
+After generation completes, accumulated codes are decoded to a waveform
+via the codec.
+
+## Prerequisites
+
+- ExecuTorch installed from source (see [building from source](../../../docs/source/using-executorch-building-from-source.md))
+- [safetensors](https://pypi.org/project/safetensors/) (`pip install safetensors`)
+- Model weights in Mistral format. The directory should contain `params.json`,
+  `consolidated.safetensors`, and `tekken.json`.
+
+## Export
+
+Export converts the Mistral checkpoint into `.pte` files. The codec decoder
+is exported separately with static shapes (chunked processing).
+
+### Metal (recommended for Apple Silicon)
+
+```bash
+python export_voxtral_tts.py \
+    --model-path ~/models/VoxtralTTS \
+    --backend metal \
+    --dtype bf16 \
+    --output-dir ./voxtral_tts_exports
+```
+
+With quantization:
+
+```bash
+python export_voxtral_tts.py \
+    --model-path ~/models/VoxtralTTS \
+    --backend metal \
+    --dtype bf16 \
+    --output-dir ./voxtral_tts_exports \
+    --qlinear fpa4w
+```
+
+Metal 4-bit quantization (`fpa4w`) requires torchao built with experimental MPS ops:
+
+```bash
+# From the ao repo (third-party/ao/)
+USE_CPP=1 TORCHAO_BUILD_EXPERIMENTAL_MPS=1 pip install . --no-build-isolation
+
+# Or while installing ExecuTorch from source
+EXECUTORCH_BUILD_KERNELS_TORCHAO=1 TORCHAO_BUILD_EXPERIMENTAL_MPS=1 ./install_executorch.sh
+```
+
+<details>
+<summary><strong>XNNPACK (CPU)</strong></summary>
+
+```bash
+python export_voxtral_tts.py \
+    --model-path ~/models/VoxtralTTS \
+    --backend xnnpack \
+    --output-dir ./voxtral_tts_exports \
+    --qlinear 8da4w \
+    --qembedding 8w
+```
+
+</details>
+
+> [!NOTE]
+> Use `--skip-codec` for faster iteration when only testing the LLM pipeline.
+
+### Export Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--model-path` | (required) | Directory with `params.json` + `consolidated.safetensors` |
+| `--backend` | `metal` | `metal` or `xnnpack` |
+| `--dtype` | `fp32` | Model dtype: `fp32` or `bf16` |
+| `--output-dir` | `./voxtral_tts_exports` | Output directory |
+| `--max-seq-len` | `4096` | KV cache length |
+| `--qlinear` | (none) | Linear layer quantization (`8da4w` for XNNPACK, `fpa4w` for Metal) |
+| `--qlinear-group-size` | `32` | Group size for linear quantization |
+| `--qembedding` | (none) | Embedding layer quantization (`8w`) |
+| `--skip-codec` | off | Skip codec decoder export (produces `model.pte` only) |
+| `--codec-chunk-size` | `375` | Static chunk size for codec decoder in frames |
+
+**Notes:**
+- `fpa4w` quantization requires `--backend metal`.
+- `--dtype bf16` is recommended for Metal when using quantization.
+
+## Build
+
+ExecuTorch must be installed from source first (see
+[Prerequisites](#prerequisites)). The `make` targets below handle
+building core libraries and the runner binary.
+
+```bash
+make voxtral_tts-cpu      # XNNPACK (CPU)
+make voxtral_tts-metal    # Metal (Apple GPU)
+```
+
+All targets produce the runner binary at
+`cmake-out/examples/models/voxtral_tts/voxtral_tts_runner`.
+
+## Run
+
+The runner requires:
+- `model.pte` — exported model (see [Export](#export))
+- `tekken.json` — tokenizer from the model weights directory
+- `codec.pte` — exported codec decoder (optional; without it, only audio codes are produced)
+
+### Basic usage
+
+```bash
+cmake-out/examples/models/voxtral_tts/voxtral_tts_runner \
+    --model_path voxtral_tts_exports/model.pte \
+    --codec_path voxtral_tts_exports/codec.pte \
+    --tokenizer_path ~/models/VoxtralTTS/tekken.json \
+    --prompt "Hello, how are you?" \
+    --output_path output.wav
+```
+
+### Runner Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--model_path` | `model.pte` | Path to exported model |
+| `--codec_path` | (none) | Path to codec decoder `.pte` (optional) |
+| `--tokenizer_path` | `tekken.json` | Path to Tekken tokenizer |
+| `--prompt` | (required) | Input text to synthesize |
+| `--voice_path` | (none) | Path to voice embedding `.bin` file (see below) |
+| `--output_path` | `output.wav` | Output WAV file path |
+| `--max_tokens` | `2048` | Maximum tokens to generate |
+| `--temperature` | `0.0` | Sampling temperature (0 = greedy) |
+| `--seed` | `42` | Random seed for flow matching noise |
+
+## Exported Methods
+
+### model.pte
+
+| Method | Input | Output | Dynamic shapes |
+|--------|-------|--------|----------------|
+| `token_embedding` | `token_ids (1, seq)` | `embeds (1, seq, D)` | seq: `[1, max_seq_len]` |
+| `text_decoder` | `embeds (1, seq, D)` + `cache_pos (seq,)` | `hidden (1, seq, D)` | seq: `[3, max_seq_len]` (Metal) or `[1, max_seq_len]` (XNNPACK) |
+| `lm_head` | `hidden (1, 1, D)` | `logits (1, 1, vocab)` | static |
+| `decode_audio_frame` | `hidden (1, D)` + `noise (1, C)` | `codes (1, 1+C)` | static |
+| `audio_token_embedding` | `codes (1, K, seq)` | `embeds (1, seq, D)` | seq: `[1, max_seq_len]` |
+
+### codec.pte
+
+| Method | Input | Output | Dynamic shapes |
+|--------|-------|--------|----------------|
+| `audio_decoder` | `codes (1, K, T)` | `waveform (1, 1, T*upsample)` | static (T = chunk_size) |
+
+## Inference Flow
+
+```
+1. token_embedding(prompt_tokens + voice_context) → embeds
+2. Inject voice embeddings at audio token positions
+3. text_decoder(embeds, positions) → hidden          # prefill
+4. Audio generation loop (every step):
+   a. text_decoder(token_emb(24), pos) → hidden      # single-step decode
+   b. decode_audio_frame(hidden, randn()) → codes     # flow matching ODE
+   c. If semantic_code == END_AUDIO: break
+   d. Accumulate codes
+5. audio_decoder(codes[:chunk]) → waveform            # for each chunk
+6. Concatenate chunks → final audio → write WAV
+```
+
+## License
+
+The ExecuTorch example code in this directory is licensed under the
+BSD-style license found in the repository root.
+
+The [Voxtral-4B-TTS-2603](https://huggingface.co/mistralai/Voxtral-4B-TTS-2603)
+model weights and bundled voice embeddings are licensed by Mistral AI under
+[CC BY-NC 4.0](https://creativecommons.org/licenses/by-nc/4.0/)
+(Creative Commons Attribution-NonCommercial 4.0 International). This means:
+
+- **Attribution required**: credit Mistral AI and the voice data sources
+  (EARS, CML-TTS, IndicVoices-R, Arabic Natural Audio datasets).
+- **NonCommercial only**: the model weights may not be used for commercial
+  purposes.
+
+The NC restriction originates from the voice reference datasets used to
+train the model. See the
+[model card](https://huggingface.co/mistralai/Voxtral-4B-TTS-2603) for
+full details.
+
+## Troubleshooting
+
+- **OOM during export**: Reduce `--max-seq-len` or use `--skip-codec` to
+  export only `model.pte`.
+- **`fpa4w` error**: This quantization requires `--backend metal`.
+- **Metal runner fails with `Library not loaded: @rpath/libc++.1.dylib`**:
+  The AOTInductor-compiled `.so` inside the `.pte` references `libc++` via
+  `@rpath`. Add `/usr/lib` to `DYLD_LIBRARY_PATH`:
+  ```bash
+  DYLD_LIBRARY_PATH=/usr/lib \
+      cmake-out/examples/models/voxtral_tts/voxtral_tts_runner ...
+  ```
+- **Metal runner fails with `Library not loaded: libomp.dylib`**:
+  The AOTInductor-compiled `.so` links against OpenMP. Install it via
+  Homebrew and add it to `DYLD_LIBRARY_PATH`:
+  ```bash
+  brew install libomp
+  DYLD_LIBRARY_PATH=/usr/lib:$(brew --prefix libomp)/lib \
+      cmake-out/examples/models/voxtral_tts/voxtral_tts_runner ...
+  ```
+- **`seq_len` constraint violation on Metal**: The MPS SDPA kernel requires
+  `seq_len >= 3`. For single-token decode, the runner pads the input
+  to length 3.
+- **No audio output (only codes)**: Provide `--codec_path` to enable
+  waveform generation. Without it, the runner generates audio codes but
+  cannot produce a WAV file.

--- a/examples/models/voxtral_tts/README.md
+++ b/examples/models/voxtral_tts/README.md
@@ -188,13 +188,18 @@ cmake-out/examples/models/voxtral_tts/voxtral_tts_runner \
 1. token_embedding(prompt_tokens + voice_context) → embeds
 2. Inject voice embeddings at audio token positions
 3. text_decoder(embeds, positions) → hidden          # prefill
-4. Audio generation loop (every step):
-   a. text_decoder(token_emb(24), pos) → hidden      # single-step decode
-   b. decode_audio_frame(hidden, randn()) → codes     # flow matching ODE
+4. Audio generation loop:
+   a. text_decoder(step_embed, pos) → hidden         # single-step decode
+   b. decode_audio_frame(hidden, randn()) → codes    # flow matching ODE
    c. If semantic_code == END_AUDIO: break
    d. Accumulate codes
-5. audio_decoder(codes[:chunk]) → waveform            # for each chunk
+   e. audio_token_embedding(codes) → step_embed      # feedback for next step
+5. audio_decoder(codes[:chunk]) → waveform           # for each chunk
 6. Concatenate chunks → final audio → write WAV
+
+Step 4a uses token_embedding(24) on the first iteration (no previous codes),
+then audio_token_embedding(previous_codes) on subsequent iterations. This
+matches vLLM's tts_preprocess which feeds back multi-codebook embeddings.
 ```
 
 ## License

--- a/examples/models/voxtral_tts/__init__.py
+++ b/examples/models/voxtral_tts/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/examples/models/voxtral_tts/codec.py
+++ b/examples/models/voxtral_tts/codec.py
@@ -1,0 +1,635 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Audio tokenizer decoder for Voxtral TTS.
+
+Reimplements the vLLM VoxtralTTSAudioTokenizer decoder path for ExecuTorch export:
+  - No einops (replaced with explicit permute/reshape)
+  - No flash_attn (manual attention with ALiBi + sliding window)
+  - weight_norm folded before export
+  - Static input shapes (chunked processing)
+
+Decoder architecture:
+  codes (1, K, T) → quantizer.decode → (1, D_latent, T)
+    → CausalConv1d (latent→dim)
+    → [Transformer(n_layers, window) → CausalConvTranspose1d(dim, dim)] × N_stages
+    → Transformer(n_layers, window)
+    → CausalConv1d output_proj (dim→patch_size)
+    → reshape → waveform (1, 1, T * total_upsample * patch_size)
+"""
+
+import math
+from copy import deepcopy
+from dataclasses import dataclass
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from executorch.examples.models.voxtral_tts.model import RMSNorm
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AudioTokenizerArgs:
+    channels: int = 1
+    sampling_rate: int = 24000
+    pretransform_patch_size: int = 240
+    patch_proj_kernel_size: int = 7
+    semantic_codebook_size: int = 8192
+    semantic_dim: int = 256
+    acoustic_codebook_size: int = 21
+    acoustic_dim: int = 36
+    conv_weight_norm: bool = True
+    causal: bool = True
+    attn_sliding_window_size: int = 16
+    half_attn_window_upon_downsampling: bool = True
+    dim: int = 1024
+    hidden_dim: int = 4096
+    head_dim: int = 128
+    n_heads: int = 8
+    n_kv_heads: int = 8
+    qk_norm_eps: float = 1e-6
+    qk_norm: bool = True
+    use_biases: bool = False
+    norm_eps: float = 1e-2
+    layer_scale: bool = True
+    layer_scale_init: float | None = None
+    # Decoder arch (comma-separated in config, parsed here)
+    decoder_transformer_lengths: tuple[int, ...] = (2, 2, 2, 2)
+    decoder_convs_kernels: tuple[int, ...] = (3, 4, 4, 4)
+    decoder_convs_strides: tuple[int, ...] = (1, 2, 2, 2)
+    # Encoder arch (for computing initial decoder window size)
+    encoder_convs_strides: tuple[int, ...] = (2, 2, 2, 1)
+
+    @staticmethod
+    def from_dict(d: dict) -> "AudioTokenizerArgs":
+        def _parse_ints(s):
+            return tuple(int(x) for x in s.split(","))
+
+        return AudioTokenizerArgs(
+            channels=d.get("channels", 1),
+            sampling_rate=d.get("sampling_rate", 24000),
+            pretransform_patch_size=d.get("pretransform_patch_size", 240),
+            patch_proj_kernel_size=d.get("patch_proj_kernel_size", 7),
+            semantic_codebook_size=d.get("semantic_codebook_size", 8192),
+            semantic_dim=d.get("semantic_dim", 256),
+            acoustic_codebook_size=d.get("acoustic_codebook_size", 21),
+            acoustic_dim=d.get("acoustic_dim", 36),
+            conv_weight_norm=d.get("conv_weight_norm", True),
+            causal=d.get("causal", True),
+            attn_sliding_window_size=d.get("attn_sliding_window_size", 16),
+            half_attn_window_upon_downsampling=d.get(
+                "half_attn_window_upon_downsampling", True
+            ),
+            dim=d.get("dim", 1024),
+            hidden_dim=d.get("hidden_dim", 4096),
+            head_dim=d.get("head_dim", 128),
+            n_heads=d.get("n_heads", 8),
+            n_kv_heads=d.get("n_kv_heads", 8),
+            qk_norm_eps=d.get("qk_norm_eps", 1e-6),
+            qk_norm=d.get("qk_norm", True),
+            use_biases=d.get("use_biases", False),
+            norm_eps=d.get("norm_eps", 1e-2),
+            layer_scale=d.get("layer_scale", True),
+            layer_scale_init=d.get("layer_scale_init", None),
+            decoder_transformer_lengths=_parse_ints(
+                d.get("decoder_transformer_lengths_str", "2,2,2,2")
+            ),
+            decoder_convs_kernels=_parse_ints(
+                d.get("decoder_convs_kernels_str", "3,4,4,4")
+            ),
+            decoder_convs_strides=_parse_ints(
+                d.get("decoder_convs_strides_str", "1,2,2,2")
+            ),
+            encoder_convs_strides=_parse_ints(
+                d.get("encoder_convs_strides_str", "2,2,2,1")
+            ),
+        )
+
+    @property
+    def decoder_initial_window_size(self) -> int:
+        """Window size entering the decoder (after encoder downsampling)."""
+        w = self.attn_sliding_window_size
+        for s in self.encoder_convs_strides:
+            if self.half_attn_window_upon_downsampling and s > 1:
+                w = w // 2
+        return w
+
+
+# ---------------------------------------------------------------------------
+# Quantizer (decode path only)
+# ---------------------------------------------------------------------------
+
+
+class SemanticCodebook(nn.Module):
+    def __init__(self, codebook_size: int, codebook_dim: int):
+        super().__init__()
+        self.epsilon = 1e-5
+        self.register_buffer("cluster_usage", torch.ones(codebook_size))
+        self.register_buffer("embedding_sum", torch.zeros(codebook_size, codebook_dim))
+
+    @property
+    def embedding(self) -> torch.Tensor:
+        return self.embedding_sum / self.cluster_usage.clamp(
+            min=self.epsilon
+        ).unsqueeze(1)
+
+    def decode(self, codes: torch.Tensor) -> torch.Tensor:
+        # codes: (B, 1, T) → (B, semantic_dim, T)
+        codes = codes.squeeze(1)  # (B, T)
+        quantized = F.embedding(codes, self.embedding)  # (B, T, D)
+        return quantized.permute(0, 2, 1)  # (B, D, T)
+
+
+class AcousticCodebook(nn.Module):
+    def __init__(self, codebook_size: int, codebook_dim: int):
+        super().__init__()
+        self.n_levels = codebook_size
+        self.num_codebooks = codebook_dim
+
+    def decode(
+        self, codes: torch.Tensor, dtype: torch.dtype = torch.float32
+    ) -> torch.Tensor:
+        # codes: (B, n_codebooks, T) → (B, n_codebooks, T)
+        return (codes.to(dtype) * 2 / (self.n_levels - 1)) - 1
+
+
+class AudioCodebook(nn.Module):
+    def __init__(self, args: AudioTokenizerArgs):
+        super().__init__()
+        self.semantic = SemanticCodebook(args.semantic_codebook_size, args.semantic_dim)
+        self.acoustic = AcousticCodebook(args.acoustic_codebook_size, args.acoustic_dim)
+        self.semantic_dim = args.semantic_dim
+
+    def decode(
+        self, codes: torch.Tensor, dtype: torch.dtype = torch.float32
+    ) -> torch.Tensor:
+        # codes: (B, K, T) where K = 1 (semantic) + n_acoustic
+        sem_codes = codes[:, :1, :]
+        acou_codes = codes[:, 1:, :]
+        sem_emb = self.semantic.decode(sem_codes).to(dtype)
+        acou_emb = self.acoustic.decode(acou_codes, dtype)
+        return torch.cat([sem_emb, acou_emb], dim=1)  # (B, D_latent, T)
+
+
+# ---------------------------------------------------------------------------
+# Conv layers (export-safe, no weight_norm at runtime)
+# ---------------------------------------------------------------------------
+
+
+def _pad1d(
+    x: torch.Tensor, paddings: tuple[int, int], mode: str = "constant"
+) -> torch.Tensor:
+    left, right = paddings
+    if mode == "replicate":
+        length = x.shape[-1]
+        max_pad = max(left, right)
+        if length <= max_pad:
+            extra = max_pad - length + 1
+            x = F.pad(x, (0, extra))
+            padded = F.pad(x, paddings, mode, 0.0)
+            return padded[..., : padded.shape[-1] - extra]
+        return F.pad(x, paddings, mode, 0.0)
+    return F.pad(x, paddings, mode, 0.0)
+
+
+_weight_norm = torch.nn.utils.parametrizations.weight_norm
+
+
+class CodecCausalConv1d(nn.Module):
+    """CausalConv1d for codec. Uses weight_norm to match checkpoint format;
+    call remove_parametrizations() after loading to fold for export."""
+
+    def __init__(
+        self,
+        in_ch: int,
+        out_ch: int,
+        kernel_size: int,
+        stride: int = 1,
+        dilation: int = 1,
+        pad_mode: str = "replicate",
+        use_weight_norm: bool = True,
+        use_bias: bool = True,
+    ):
+        super().__init__()
+        conv = nn.Conv1d(
+            in_ch, out_ch, kernel_size, stride=stride, dilation=dilation, bias=use_bias
+        )
+        self.conv = _weight_norm(conv) if use_weight_norm else conv
+        self.pad_mode = pad_mode
+        self._stride = stride
+        self._eff_ks = (kernel_size - 1) * dilation + 1
+        self._pad_total = self._eff_ks - stride
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # Static padding computation (use integer arithmetic for export)
+        n_frames = (x.shape[-1] - self._eff_ks + self._pad_total) // self._stride + 1
+        target = (n_frames - 1) * self._stride + (self._eff_ks - self._pad_total)
+        extra = target - x.shape[-1]
+        x = _pad1d(x, (self._pad_total, extra), mode=self.pad_mode)
+        return self.conv(x)
+
+
+class CodecCausalConvTranspose1d(nn.Module):
+    def __init__(
+        self,
+        in_ch: int,
+        out_ch: int,
+        kernel_size: int,
+        stride: int = 1,
+        use_weight_norm: bool = True,
+        use_bias: bool = True,
+    ):
+        super().__init__()
+        conv = nn.ConvTranspose1d(
+            in_ch, out_ch, kernel_size, stride=stride, bias=use_bias
+        )
+        self.conv = _weight_norm(conv) if use_weight_norm else conv
+        self._kernel_size = kernel_size
+        self._stride = stride
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        total_pad = self._kernel_size - self._stride
+        out = self.conv(x)
+        # Match vLLM: right = ceil(total_pad * trim_ratio), left = total_pad - right
+        # With trim_ratio=1.0: right = total_pad, left = 0
+        right = total_pad
+        left = 0
+        return out[..., left : out.shape[-1] - right]
+
+
+# ---------------------------------------------------------------------------
+# Attention (ALiBi + sliding window, export-safe)
+# ---------------------------------------------------------------------------
+
+
+def _get_alibi_slopes(n_heads: int) -> torch.Tensor:
+    def _power_of_2(n: int) -> torch.Tensor:
+        r = 2.0 ** (-8.0 / n)
+        return torch.tensor([r**i for i in range(n)], dtype=torch.float32)
+
+    if math.log2(n_heads).is_integer():
+        return _power_of_2(n_heads)
+    m = 2 ** math.floor(math.log2(n_heads))
+    return torch.cat([_power_of_2(m), _power_of_2(2 * m)[::2][: n_heads - m]])
+
+
+class CodecAttention(nn.Module):
+    """ALiBi attention with causal sliding window. No flash_attn."""
+
+    def __init__(self, args: AudioTokenizerArgs, layer_id: int):
+        super().__init__()
+        self.n_heads = args.n_heads
+        self.n_kv_heads = args.n_kv_heads
+        self.head_dim = args.head_dim
+        self.n_rep = args.n_heads // args.n_kv_heads
+        self.sliding_window = args.attn_sliding_window_size
+        self.causal = args.causal
+
+        self.register_buffer(
+            "alibi_slopes", _get_alibi_slopes(self.n_heads), persistent=False
+        )
+
+        self.wq = nn.Linear(args.dim, args.n_heads * args.head_dim, bias=False)
+        self.wk = nn.Linear(args.dim, args.n_kv_heads * args.head_dim, bias=False)
+        self.wv = nn.Linear(args.dim, args.n_kv_heads * args.head_dim, bias=False)
+        self.wo = nn.Linear(
+            args.n_heads * args.head_dim, args.dim, bias=args.use_biases
+        )
+
+        if args.qk_norm:
+            self.q_norm = RMSNorm(args.n_heads * args.head_dim, args.qk_norm_eps)
+            self.k_norm = RMSNorm(args.n_kv_heads * args.head_dim, args.qk_norm_eps)
+        self.has_qk_norm = args.qk_norm
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        B, T, _ = x.shape
+        xq, xk, xv = self.wq(x), self.wk(x), self.wv(x)
+
+        if self.has_qk_norm:
+            xq = self.q_norm(xq)
+            xk = self.k_norm(xk)
+
+        xq = xq.view(B, T, self.n_heads, self.head_dim).transpose(1, 2)
+        xk = xk.view(B, T, self.n_kv_heads, self.head_dim).transpose(1, 2)
+        xv = xv.view(B, T, self.n_kv_heads, self.head_dim).transpose(1, 2)
+
+        # GQA expansion
+        if self.n_rep > 1:
+            xk = xk.repeat_interleave(self.n_rep, dim=1)
+            xv = xv.repeat_interleave(self.n_rep, dim=1)
+
+        # Build ALiBi + causal + sliding window mask
+        positions = torch.arange(T, device=x.device)
+        rel_pos = positions.unsqueeze(0) - positions.unsqueeze(1)  # (T, T)
+        slopes = self.alibi_slopes.to(dtype=x.dtype, device=x.device)
+        attn_bias = slopes.view(self.n_heads, 1, 1) * rel_pos.unsqueeze(0).to(x.dtype)
+
+        if self.causal:
+            attn_bias = attn_bias.masked_fill(rel_pos.unsqueeze(0) > 0, float("-inf"))
+
+        window_left = self.sliding_window
+        window_right = 0 if self.causal else self.sliding_window
+        outside = (rel_pos < -window_left) | (rel_pos > window_right)
+        attn_bias = attn_bias.masked_fill(outside.unsqueeze(0), float("-inf"))
+
+        y = F.scaled_dot_product_attention(
+            xq, xk, xv, attn_mask=attn_bias.unsqueeze(0), is_causal=False
+        )
+        y = y.transpose(1, 2).contiguous().view(B, T, -1)
+        return self.wo(y)
+
+
+# ---------------------------------------------------------------------------
+# Codec transformer block
+# ---------------------------------------------------------------------------
+
+
+class CodecFeedForward(nn.Module):
+    def __init__(self, dim: int, hidden_dim: int, use_biases: bool):
+        super().__init__()
+        self.w1 = nn.Linear(dim, hidden_dim, bias=False)
+        self.w2 = nn.Linear(hidden_dim, dim, bias=use_biases)
+        self.w3 = nn.Linear(dim, hidden_dim, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.w2(F.silu(self.w1(x)) * self.w3(x))
+
+
+class CodecTransformerBlock(nn.Module):
+    def __init__(self, layer_id: int, args: AudioTokenizerArgs):
+        super().__init__()
+        self.attention = CodecAttention(args, layer_id)
+        self.feed_forward = CodecFeedForward(args.dim, args.hidden_dim, args.use_biases)
+        self.attention_norm = RMSNorm(args.dim, args.norm_eps)
+        self.ffn_norm = RMSNorm(args.dim, args.norm_eps)
+
+        self.has_layer_scale = args.layer_scale
+        if args.layer_scale:
+            if args.layer_scale_init is None:
+                if layer_id < 18:
+                    init_scale = 0.1
+                elif layer_id <= 24:
+                    init_scale = 1e-5
+                else:
+                    init_scale = 1e-6
+            else:
+                init_scale = args.layer_scale_init
+            self.attention_scale = nn.Parameter(
+                torch.full((args.dim,), init_scale, requires_grad=True)
+            )
+            self.ffn_scale = nn.Parameter(
+                torch.full((args.dim,), init_scale, requires_grad=True)
+            )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        r = self.attention(self.attention_norm(x))
+        if self.has_layer_scale:
+            r = self.attention_scale * r
+        h = x + r
+        r = self.feed_forward(self.ffn_norm(h))
+        if self.has_layer_scale:
+            r = self.ffn_scale * r
+        return h + r
+
+
+class CodecTransformer(nn.Module):
+    """Wrapper matching vLLM's Transformer class (ModuleDict with string keys).
+    Required for checkpoint key compatibility."""
+
+    def __init__(self, args: AudioTokenizerArgs, n_layers: int):
+        super().__init__()
+        self.layers = nn.ModuleDict()
+        for i in range(n_layers):
+            self.layers[str(i)] = CodecTransformerBlock(i, args)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        for layer in self.layers.values():
+            x = layer(x)
+        return x
+
+
+# ---------------------------------------------------------------------------
+# Codec decoder
+# ---------------------------------------------------------------------------
+
+
+class AudioTokenizerDecoder(nn.Module):
+    """Audio tokenizer decoder: codes → waveform.
+
+    Builds the decoder portion of the codec from AudioTokenizerArgs.
+    The encoder is not needed for TTS inference (codes come from the
+    acoustic transformer, not from encoding audio).
+    """
+
+    def __init__(self, args: AudioTokenizerArgs):
+        super().__init__()
+        self.args = args
+        self.patch_size = args.pretransform_patch_size
+        self.latent_dim = args.semantic_dim + args.acoustic_dim
+
+        # Quantizer (decode only)
+        self.quantizer = AudioCodebook(args)
+
+        # Build decoder blocks
+        decoder_blocks: list[nn.Module] = []
+
+        # Compute initial window size after encoder downsampling
+        cur_window = args.decoder_initial_window_size
+
+        # First projection: latent_dim → dim
+        decoder_blocks.append(
+            CodecCausalConv1d(
+                self.latent_dim,
+                args.dim,
+                kernel_size=args.decoder_convs_kernels[0],
+                stride=args.decoder_convs_strides[0],
+                pad_mode="replicate",
+                use_weight_norm=args.conv_weight_norm,
+                use_bias=False,
+            )
+        )
+        if (
+            args.half_attn_window_upon_downsampling
+            and args.decoder_convs_strides[0] > 1
+        ):
+            cur_window *= 2
+
+        for idx, n_layers in enumerate(args.decoder_transformer_lengths):
+            # Transformer (wrapped in CodecTransformer for checkpoint compat)
+            layer_args = deepcopy(args)
+            layer_args.attn_sliding_window_size = cur_window
+            decoder_blocks.append(CodecTransformer(layer_args, n_layers))
+
+            # Upsampling conv (between stages, not after last)
+            if idx + 1 < len(args.decoder_transformer_lengths):
+                k = args.decoder_convs_kernels[idx + 1]
+                s = args.decoder_convs_strides[idx + 1]
+                if k != 1 or s != 1:
+                    decoder_blocks.append(
+                        CodecCausalConvTranspose1d(
+                            args.dim,
+                            args.dim,
+                            k,
+                            s,
+                            use_weight_norm=args.conv_weight_norm,
+                            use_bias=False,
+                        )
+                    )
+                    if args.half_attn_window_upon_downsampling and s > 1:
+                        cur_window *= 2
+
+        self.decoder_blocks = nn.ModuleList(decoder_blocks)
+
+        # Output projection (uses "reflect" pad_mode matching vLLM's default)
+        self.output_proj = CodecCausalConv1d(
+            args.dim,
+            args.pretransform_patch_size,
+            kernel_size=args.patch_proj_kernel_size,
+            pad_mode="reflect",
+            use_weight_norm=args.conv_weight_norm,
+            use_bias=False,
+        )
+
+        # Downsample factor for waveform reconstruction
+        self._downsample_factor = args.pretransform_patch_size * math.prod(
+            args.decoder_convs_strides
+        )
+
+    @property
+    def downsample_factor(self) -> int:
+        return self._downsample_factor
+
+    def forward(self, codes: torch.Tensor) -> torch.Tensor:
+        """Decode audio codes to waveform.
+
+        Args:
+            codes: (B, K, T) integer audio codes.
+        Returns:
+            waveform: (B, 1, T * downsample_factor).
+        """
+        # Decode codes to continuous embeddings
+        emb = self.quantizer.decode(codes, dtype=codes.new_zeros(1).float().dtype)
+        # emb: (B, D_latent, T)
+
+        # Forward through decoder
+        # Convert to (B, T, D) for transformer blocks
+        x = emb.permute(0, 2, 1).contiguous()
+
+        for block in self.decoder_blocks:
+            if isinstance(block, (CodecCausalConv1d, CodecCausalConvTranspose1d)):
+                x = x.permute(0, 2, 1)  # (B, D, T)
+                x = block(x)
+                x = x.permute(0, 2, 1)  # (B, T, D)
+            else:
+                # CodecTransformer or CodecTransformerBlock: (B, T, D) → (B, T, D)
+                x = block(x)
+
+        # Output projection
+        x = x.permute(0, 2, 1)  # (B, D, T)
+        x = self.output_proj(x)  # (B, patch_size, T)
+
+        # Unpatchify: (B, patch_size, T) → (B, 1, T * patch_size)
+        # Must match vLLM's rearrange("b (c h) t -> b c (t h)", h=patch_size):
+        # for each time step t, take all patch_size values → interleave by time.
+        B, _, T = x.shape
+        # x is (B, patch_size, T) → transpose to (B, T, patch_size) → flatten last two
+        return x.transpose(1, 2).contiguous().reshape(B, 1, T * self.patch_size)
+
+
+# ---------------------------------------------------------------------------
+# Weight mapping for codec checkpoint loading
+# ---------------------------------------------------------------------------
+
+
+def _map_codec_key(ckpt_key: str) -> str | None:
+    """Map codec checkpoint keys to AudioTokenizerDecoder state dict keys."""
+    # Strip "audio_tokenizer." prefix if present
+    if ckpt_key.startswith("audio_tokenizer."):
+        ckpt_key = ckpt_key[len("audio_tokenizer.") :]
+
+    # Skip encoder weights
+    if ckpt_key.startswith("input_proj.") or ckpt_key.startswith("encoder_blocks."):
+        return None
+
+    # Skip audio_token_embedding (handled by model.pte)
+    if ckpt_key.startswith("audio_token_embedding."):
+        return None
+
+    # Map quantizer weights
+    if ckpt_key.startswith("quantizer.semantic_codebook."):
+        return ckpt_key.replace("quantizer.semantic_codebook.", "quantizer.semantic.")
+    if ckpt_key.startswith("quantizer.acoustic_codebook."):
+        return ckpt_key.replace("quantizer.acoustic_codebook.", "quantizer.acoustic.")
+
+    # Decoder blocks and output_proj map directly
+    if ckpt_key.startswith("decoder_blocks.") or ckpt_key.startswith("output_proj."):
+        return ckpt_key
+
+    return None
+
+
+def load_codec_decoder(
+    model_path: str,
+    codec_args_dict: dict,
+    dtype: torch.dtype = torch.float32,
+) -> AudioTokenizerDecoder:
+    """Load codec decoder weights from checkpoint."""
+    import torch.nn.utils.parametrize as parametrize
+    from safetensors import safe_open
+
+    args = AudioTokenizerArgs.from_dict(codec_args_dict)
+
+    with torch.device("meta"):
+        model = AudioTokenizerDecoder(args)
+
+    ckpt_path = str(Path(model_path) / "consolidated.safetensors")
+    state_dict = {}
+    with safe_open(ckpt_path, framework="pt", device="cpu") as f:
+        for key in f.keys():
+            mapped = _map_codec_key(key)
+            if mapped is None:
+                continue
+            state_dict[mapped] = f.get_tensor(key).to(dtype)
+
+    missing, unexpected = model.load_state_dict(state_dict, strict=False, assign=True)
+
+    # Materialize meta buffers
+    for fqn, buf in list(model.named_buffers()):
+        if buf.device.type == "meta":
+            parts = fqn.rsplit(".", 1)
+            parent = model.get_submodule(parts[0]) if len(parts) > 1 else model
+            parent.register_buffer(
+                parts[-1], torch.zeros(buf.shape, dtype=dtype, device="cpu")
+            )
+
+    # Recompute ALiBi slopes (persistent=False, lost during meta construction)
+    for m in model.modules():
+        if isinstance(m, CodecAttention):
+            m.register_buffer(
+                "alibi_slopes",
+                _get_alibi_slopes(m.n_heads),
+                persistent=False,
+            )
+
+    # Fold weight_norm parametrizations (if checkpoint has parametrized weights)
+    for m in model.modules():
+        if parametrize.is_parametrized(m, "weight"):
+            parametrize.remove_parametrizations(m, "weight")
+
+    if missing:
+        print(f"  Codec missing keys ({len(missing)}): {missing[:5]}...")
+    if unexpected:
+        print(f"  Codec unexpected keys ({len(unexpected)}): {unexpected[:5]}...")
+
+    model.eval()
+    return model

--- a/examples/models/voxtral_tts/export_voxtral_tts.py
+++ b/examples/models/voxtral_tts/export_voxtral_tts.py
@@ -1,0 +1,512 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Export Voxtral TTS to ExecuTorch.
+
+Produces model.pte with five methods:
+  - token_embedding:        token_ids (1, seq) -> embeds (1, seq, D)
+  - text_decoder:           embeds (1, seq, D) + cache_pos (seq,) -> hidden (1, seq, D)
+  - lm_head:                hidden (1, 1, D) -> logits (1, 1, vocab)
+  - decode_audio_frame:     hidden (1, D) + noise (1, C) -> codes (1, 1+C)
+  - audio_token_embedding:  codes (1, K, seq) -> embeds (1, seq, D)
+
+Backend support:
+  - Metal/AOTI: MetalSDPA, StaticKVCache, bf16, fpa4w quantization
+  - XNNPACK (CPU): custom_sdpa, KVCache
+
+Usage:
+    python export_voxtral_tts.py --model-path ~/models/VoxtralTTS --backend metal --dtype bf16
+    python export_voxtral_tts.py --model-path ~/models/VoxtralTTS --backend metal --dtype bf16 --qlinear fpa4w
+    python export_voxtral_tts.py --model-path ~/models/VoxtralTTS --backend xnnpack --qlinear 8da4w
+"""
+
+import argparse
+import os
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+
+from executorch.examples.models.voxtral_tts.model import load_model
+
+from executorch.exir import (
+    EdgeCompileConfig,
+    ExecutorchBackendConfig,
+    to_edge_transform_and_lower,
+)
+from executorch.exir.passes import MemoryPlanningPass
+from torch.export import Dim, export
+
+
+# ---------------------------------------------------------------------------
+# Export wrappers
+# ---------------------------------------------------------------------------
+
+
+class TokenEmbeddingExport(nn.Module):
+    def __init__(self, model):
+        super().__init__()
+        self.tok_embeddings = model.decoder.tok_embeddings
+
+    def forward(self, token_ids: torch.Tensor) -> torch.Tensor:
+        return self.tok_embeddings(token_ids)
+
+
+class TextDecoderExport(nn.Module):
+    """Wraps LM decoder. Returns normed hidden states (not logits)."""
+
+    def __init__(self, model):
+        super().__init__()
+        self.decoder = model.decoder
+
+    def forward(
+        self, input_embeds: torch.Tensor, cache_position: torch.Tensor
+    ) -> torch.Tensor:
+        return self.decoder(input_embeds, cache_position)
+
+
+class LMHeadExport(nn.Module):
+    """Output projection: hidden -> logits."""
+
+    def __init__(self, model):
+        super().__init__()
+        self.output = model.decoder.output
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return self.output(hidden_states)
+
+
+class DecodeAudioFrameExport(nn.Module):
+    """Flow matching: hidden + noise -> audio codes."""
+
+    def __init__(self, model):
+        super().__init__()
+        self.acoustic_transformer = model.acoustic_transformer
+
+    def forward(self, hidden_states: torch.Tensor, noise: torch.Tensor) -> torch.Tensor:
+        return self.acoustic_transformer.decode_one_frame(hidden_states, noise)
+
+
+class AudioTokenEmbeddingExport(nn.Module):
+    def __init__(self, model):
+        super().__init__()
+        self.audio_token_embedding = model.audio_token_embedding
+
+    def forward(self, codes: torch.Tensor) -> torch.Tensor:
+        return self.audio_token_embedding(codes)
+
+
+# ---------------------------------------------------------------------------
+# Export
+# ---------------------------------------------------------------------------
+
+
+def _quantize_with_skip(module, qlinear_config, group_size):
+    """Apply quantization, skipping layers whose K dim isn't divisible by group_size.
+
+    The acoustic transformer's input_projection has a small K dimension
+    (n_acoustic_codebook, e.g. 36) that may not be divisible by group_size.
+    This function applies quantization with a filter that skips such layers,
+    regardless of the quantization config.
+    """
+    from executorch.extension.llm.export.quantize import quantize_model_
+
+    if qlinear_config == "fpa4w":
+        import torchao.experimental.ops.mps  # noqa: F401
+        from torchao.experimental.quant_api import UIntxWeightOnlyConfig
+        from torchao.quantization import quantize_
+
+        config = UIntxWeightOnlyConfig(
+            group_size=group_size,
+            bitwidth=4,
+            uintx_choose_qparams_algorithm="hqq",
+        )
+
+        def safe_filter(mod, fqn):
+            if not isinstance(mod, torch.nn.Linear):
+                return False
+            k = mod.weight.shape[1]
+            if k % group_size != 0:
+                print(f"    Skipping {fqn}: K={k} not divisible by {group_size}")
+                return False
+            return True
+
+        quantize_(module, config, filter_fn=safe_filter)
+    else:
+        # For non-fpa4w configs (e.g. 8da4w), quantize_model_ skips layers
+        # whose K dim isn't divisible by group_size with a warning.
+        # Use group_size=0 for per-axis to avoid the issue entirely on
+        # small layers, or accept the skip behavior.
+        quantize_model_(
+            module,
+            qlinear_config=qlinear_config,
+            qlinear_group_size=group_size,
+        )
+
+
+def export_model(
+    model,
+    max_seq_len,
+    qlinear=None,
+    qlinear_group_size=32,
+    qembedding=None,
+    backend="metal",
+):
+    """Export all five model components."""
+    from executorch.extension.llm.export.quantize import quantize_model_
+
+    programs = {}
+    param_dtype = next(model.parameters()).dtype
+
+    # --- 1. Token embedding ---
+    print("\nExporting token_embedding...")
+    tok_emb = TokenEmbeddingExport(model)
+    tok_emb.eval()
+
+    if qembedding:
+        print(f"  Quantizing embedding ({qembedding})...")
+        quantize_model_(tok_emb, qembedding_config=qembedding)
+
+    tok_seq_dim = Dim("tok_seq_len", min=1, max=max_seq_len)
+    tok_dyn = {"token_ids": {1: tok_seq_dim}}
+    sample_ids = torch.tensor([[0, 1, 2, 3]], dtype=torch.long)
+    programs["token_embedding"] = export(
+        tok_emb, (sample_ids,), dynamic_shapes=tok_dyn, strict=True
+    )
+    print("  token_embedding exported")
+
+    # --- 2. Text decoder ---
+    print("\nExporting text_decoder...")
+    text_dec = TextDecoderExport(model)
+    text_dec.eval()
+
+    if qlinear:
+        print(f"  Quantizing decoder ({qlinear})...")
+        quantize_model_(
+            text_dec,
+            qlinear_config=qlinear,
+            qlinear_group_size=qlinear_group_size,
+        )
+
+    # Metal's _scaled_dot_product_attention_math_for_mps requires seq_len > 2.
+    # For decode (seq_len=1), use a separate static export or pad to 3.
+    seq_min = 3 if backend == "metal" else 1
+    seq_dim = Dim("seq_len", min=seq_min, max=max_seq_len)
+    sample_embeds = torch.randn(1, 4, model.config.dim, dtype=param_dtype)
+    sample_pos = torch.arange(4, dtype=torch.long)
+    dec_dyn = {
+        "input_embeds": {1: seq_dim},
+        "cache_position": {0: seq_dim},
+    }
+    programs["text_decoder"] = export(
+        text_dec, (sample_embeds, sample_pos), dynamic_shapes=dec_dyn, strict=True
+    )
+    print("  text_decoder exported")
+
+    # --- 3. LM head ---
+    print("\nExporting lm_head...")
+    lm_head = LMHeadExport(model)
+    lm_head.eval()
+
+    sample_hidden = torch.randn(1, 1, model.config.dim, dtype=param_dtype)
+    programs["lm_head"] = export(
+        lm_head, (sample_hidden,), dynamic_shapes=None, strict=True
+    )
+    print("  lm_head exported")
+
+    # --- 4. Decode audio frame ---
+    print("\nExporting decode_audio_frame...")
+    decode_frame = DecodeAudioFrameExport(model)
+    decode_frame.eval()
+
+    if qlinear:
+        # The acoustic transformer's input_projection has a small K dimension
+        # (n_acoustic_codebook, e.g. 36) that may not be divisible by
+        # group_size. Quantize with a filter that skips incompatible layers.
+        print(f"  Quantizing acoustic transformer ({qlinear})...")
+        _quantize_with_skip(
+            decode_frame,
+            qlinear,
+            qlinear_group_size,
+        )
+
+    sample_h = torch.randn(1, model.config.dim, dtype=param_dtype)
+    sample_noise = torch.randn(1, model.config.n_acoustic_codebook, dtype=param_dtype)
+    programs["decode_audio_frame"] = export(
+        decode_frame, (sample_h, sample_noise), dynamic_shapes=None, strict=True
+    )
+    print("  decode_audio_frame exported")
+
+    # --- 5. Audio token embedding ---
+    print("\nExporting audio_token_embedding...")
+    audio_tok = AudioTokenEmbeddingExport(model)
+    audio_tok.eval()
+
+    n_codebooks = model.config.n_acoustic_codebook + 1  # semantic + acoustic
+    sample_codes = torch.zeros(1, n_codebooks, 4, dtype=torch.long)
+    audio_seq_dim = Dim("audio_seq_len", min=1, max=max_seq_len)
+    audio_dyn = {"codes": {2: audio_seq_dim}}
+    programs["audio_token_embedding"] = export(
+        audio_tok, (sample_codes,), dynamic_shapes=audio_dyn, strict=True
+    )
+    print("  audio_token_embedding exported")
+
+    metadata = {
+        "vocab_size": model.config.vocab_size,
+        "dim": model.config.dim,
+        "max_seq_len": max_seq_len,
+        "n_acoustic_codebook": model.config.n_acoustic_codebook,
+        "semantic_codebook_size": model.config.semantic_codebook_size,
+        "acoustic_codebook_size": model.config.acoustic_codebook_size,
+        "acoustic_decode_iters": 8,
+        "cfg_alpha_x100": 120,  # 1.2 * 100 (integer for constant_methods)
+        "noise_scale_x100": 100,  # 1.0 * 100
+        "audio_tok_id": 24,  # Tekken special_ids.audio
+    }
+
+    return programs, metadata
+
+
+# ---------------------------------------------------------------------------
+# Metal linear bias decomposition
+# ---------------------------------------------------------------------------
+
+
+def _linear_bias_decomposition(input, weight, bias=None):
+    """Decompose linear with bias into matmul + add for Metal compatibility."""
+    weight_t = torch.ops.aten.t.default(weight)
+    out = torch.ops.aten.matmul.default(input, weight_t)
+    if bias is not None:
+        return torch.ops.aten.add.Tensor(out, bias)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Lower
+# ---------------------------------------------------------------------------
+
+
+def lower_to_executorch(programs, metadata, backend="metal"):
+    if backend == "xnnpack":
+        from executorch.backends.xnnpack.partition.xnnpack_partitioner import (
+            XnnpackDynamicallyQuantizedPartitioner,
+            XnnpackPartitioner,
+        )
+
+        print("\nLowering with XNNPACK...")
+        partitioner = {
+            key: [XnnpackDynamicallyQuantizedPartitioner(), XnnpackPartitioner()]
+            for key in programs
+        }
+    elif backend == "metal":
+        from executorch.backends.apple.metal.metal_backend import MetalBackend
+        from executorch.backends.apple.metal.metal_partitioner import MetalPartitioner
+
+        print("\nLowering with Metal...")
+
+        updated = {}
+        decomp_table = torch.export.default_decompositions()
+        decomp_table[torch.ops.aten.linear.default] = _linear_bias_decomposition
+        for key, ep in programs.items():
+            updated[key] = ep.run_decompositions(decomp_table)
+        programs = updated
+
+        partitioner = {}
+        for key in programs:
+            compile_specs = [MetalBackend.generate_method_name_compile_spec(key)]
+            partitioner[key] = [MetalPartitioner(compile_specs)]
+    else:
+        raise ValueError(f"Unsupported backend: {backend}. Use 'xnnpack' or 'metal'.")
+
+    et_prog = to_edge_transform_and_lower(
+        programs,
+        partitioner=partitioner,
+        compile_config=EdgeCompileConfig(
+            _check_ir_validity=False,
+            _skip_dim_order=True,
+        ),
+        constant_methods=metadata,
+    )
+
+    return et_prog.to_executorch(
+        config=ExecutorchBackendConfig(
+            extract_delegate_segments=True,
+            do_quant_fusion_and_const_prop=True,
+            memory_planning_pass=MemoryPlanningPass(alloc_graph_input=False),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Export Voxtral TTS to ExecuTorch")
+    parser.add_argument(
+        "--model-path",
+        required=True,
+        help="Directory with params.json + consolidated.safetensors",
+    )
+    parser.add_argument(
+        "--backend",
+        default="metal",
+        choices=["xnnpack", "metal"],
+        help="Backend (default: metal)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="./voxtral_tts_exports",
+        help="Output directory (default: ./voxtral_tts_exports)",
+    )
+    parser.add_argument(
+        "--max-seq-len", type=int, default=4096, help="KV cache length (default: 4096)"
+    )
+    parser.add_argument(
+        "--qlinear",
+        default=None,
+        choices=["8da4w", "fpa4w"],
+        help="Quantize linear layers.",
+    )
+    parser.add_argument(
+        "--qlinear-group-size",
+        type=int,
+        default=32,
+        help="Group size for linear quantization (default: 32).",
+    )
+    parser.add_argument(
+        "--qembedding",
+        default=None,
+        choices=["8w"],
+        help="Quantize embedding layers.",
+    )
+    parser.add_argument(
+        "--dtype",
+        default="fp32",
+        choices=["fp32", "bf16"],
+        help="Model dtype (default: fp32).",
+    )
+    parser.add_argument(
+        "--skip-codec",
+        action="store_true",
+        help="Skip codec decoder export (model.pte only).",
+    )
+    parser.add_argument(
+        "--codec-chunk-size",
+        type=int,
+        default=375,
+        help="Static chunk size for codec decoder (default: 375 frames).",
+    )
+    args = parser.parse_args()
+
+    if args.qlinear == "fpa4w" and args.backend != "metal":
+        parser.error("--qlinear=fpa4w requires --backend=metal")
+
+    os.makedirs(args.output_dir, exist_ok=True)
+    model_dtype = {"fp32": torch.float32, "bf16": torch.bfloat16}[args.dtype]
+
+    print("Loading model...")
+    model = load_model(
+        args.model_path,
+        max_seq_len=args.max_seq_len,
+        dtype=model_dtype,
+        backend=args.backend,
+    )
+
+    # Untie output/embedding weights before quantization
+    if args.qlinear or args.qembedding:
+        model.decoder.output.weight = nn.Parameter(
+            model.decoder.tok_embeddings.weight.clone()
+        )
+
+    print("\nExporting components...")
+    programs, metadata = export_model(
+        model,
+        args.max_seq_len,
+        qlinear=args.qlinear,
+        qlinear_group_size=args.qlinear_group_size,
+        qembedding=args.qembedding,
+        backend=args.backend,
+    )
+
+    et = lower_to_executorch(programs, metadata, backend=args.backend)
+
+    pte_path = os.path.join(args.output_dir, "model.pte")
+    print(f"\nSaving to {pte_path}...")
+    with open(pte_path, "wb") as f:
+        et.write_to_file(f)
+    size_mb = os.path.getsize(pte_path) / (1024 * 1024)
+    print(f"Saved {size_mb:.1f} MB")
+
+    if et._tensor_data:
+        et.write_tensor_data_to_file(args.output_dir)
+        print(f"Saved tensor data to {args.output_dir}/")
+
+    # --- Codec decoder (separate .pte) ---
+    if not args.skip_codec:
+        _export_codec(args, model_dtype)
+
+    print("\nDone!")
+
+
+def _export_codec(args, model_dtype):
+    """Export codec decoder as a separate .pte file."""
+    import json
+
+    from executorch.examples.models.voxtral_tts.codec import load_codec_decoder
+
+    model_dir = Path(args.model_path)
+    with open(model_dir / "params.json") as f:
+        params = json.load(f)
+
+    codec_args_dict = params.get("multimodal", {}).get("audio_tokenizer_args", {})
+    if not codec_args_dict:
+        print("\nSkipping codec export: no audio_tokenizer_args in params.json")
+        return
+
+    # Codec always uses fp32 + XNNPACK regardless of the main model's backend/dtype.
+    # The Metal AOTI backend has MPS buffer allocation issues with the codec's
+    # ALiBi attention kernels. XNNPACK runs the codec on CPU which is fine since
+    # the codec is only called once after generation completes.
+    print("\nLoading codec decoder...")
+    codec = load_codec_decoder(args.model_path, codec_args_dict, dtype=torch.float32)
+    codec.eval()
+
+    # Export with static shapes
+    n_codebooks = 1 + codec.args.acoustic_dim  # semantic + acoustic
+    T = args.codec_chunk_size
+    sample_codes = torch.zeros(1, n_codebooks, T, dtype=torch.long)
+
+    print("Exporting audio_decoder (xnnpack, fp32)...")
+    codec_programs = {}
+    codec_programs["audio_decoder"] = export(
+        codec, (sample_codes,), dynamic_shapes=None, strict=True
+    )
+    print(f"  audio_decoder exported (static shape: codes={sample_codes.shape})")
+
+    codec_metadata = {
+        "downsample_factor": codec.downsample_factor,
+        "n_codebooks": n_codebooks,
+        "chunk_size": T,
+        "sampling_rate": codec.args.sampling_rate,
+    }
+
+    codec_et = lower_to_executorch(codec_programs, codec_metadata, backend="xnnpack")
+
+    codec_path = os.path.join(args.output_dir, "codec.pte")
+    print(f"\nSaving codec to {codec_path}...")
+    with open(codec_path, "wb") as f:
+        codec_et.write_to_file(f)
+    size_mb = os.path.getsize(codec_path) / (1024 * 1024)
+    print(f"Saved {size_mb:.1f} MB")
+
+    if codec_et._tensor_data:
+        codec_et.write_tensor_data_to_file(args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/models/voxtral_tts/main.cpp
+++ b/examples/models/voxtral_tts/main.cpp
@@ -87,12 +87,12 @@ int main(int argc, char** argv) {
   config.temperature = static_cast<float>(FLAGS_temperature);
   config.seed = static_cast<uint64_t>(FLAGS_seed);
 
-  // Token callback for progress
-  int token_count = 0;
-  auto token_cb = [&token_count](const std::string& piece) {
-    token_count++;
-    if (token_count % 100 == 0) {
-      fprintf(stderr, "\r  %d tokens generated...", token_count);
+  // Progress callback (invoked per audio frame)
+  int frame_count = 0;
+  auto token_cb = [&frame_count](const std::string& piece) {
+    frame_count++;
+    if (frame_count % 100 == 0) {
+      fprintf(stderr, "\r  %d audio frames generated...", frame_count);
       fflush(stderr);
     }
   };
@@ -106,13 +106,13 @@ int main(int argc, char** argv) {
 
   stats.inference_end_ms = ::executorch::extension::llm::time_in_ms();
 
-  if (token_count > 0) {
-    fprintf(stderr, "\r  %d tokens generated.     \n", token_count);
+  if (frame_count > 0) {
+    fprintf(stderr, "\r  %d audio frames generated.     \n", frame_count);
   }
 
   double inference_s =
       (stats.inference_end_ms - stats.inference_start_ms) / 1000.0;
-  ET_LOG(Info, "Inference: %.1f s (%d tokens)", inference_s, token_count);
+  ET_LOG(Info, "Inference: %.1f s (%d audio frames)", inference_s, frame_count);
 
   // Write output
   if (!waveform.empty()) {

--- a/examples/models/voxtral_tts/main.cpp
+++ b/examples/models/voxtral_tts/main.cpp
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// CLI entry point for the Voxtral TTS runner.
+//
+// Loads model.pte (LLM + acoustic transformer), codec.pte (audio decoder),
+// and a tokenizer. Generates speech from text and writes a WAV file.
+//
+// Usage:
+//   ./voxtral_tts_runner \
+//       --model_path model.pte \
+//       --codec_path codec.pte \
+//       --tokenizer_path tekken.json \
+//       --prompt "Hello, how are you?" \
+//       --output_path output.wav
+
+#include <cstdio>
+
+#include <gflags/gflags.h>
+
+#include <executorch/extension/llm/runner/stats.h>
+#include <executorch/extension/llm/runner/util.h>
+#include <executorch/runtime/platform/log.h>
+
+#include "voxtral_tts_runner.h"
+
+DEFINE_string(model_path, "model.pte", "Path to Voxtral TTS model (.pte).");
+DEFINE_string(
+    codec_path,
+    "",
+    "Path to audio codec decoder (.pte). If empty, outputs audio codes only.");
+DEFINE_string(tokenizer_path, "tekken.json", "Path to Tekken tokenizer file.");
+DEFINE_string(prompt, "", "Input text to synthesize.");
+DEFINE_string(
+    output_path,
+    "output.wav",
+    "Output WAV file path (default: output.wav).");
+DEFINE_int32(max_tokens, 2048, "Maximum tokens to generate.");
+DEFINE_double(temperature, 0.0, "Sampling temperature (0 = greedy).");
+DEFINE_int32(seed, 42, "Random seed for flow matching noise.");
+DEFINE_string(
+    voice_path,
+    "",
+    "Path to voice embedding file (.bin). Generate with: "
+    "python -c \"import torch,struct; v=torch.load('voice.pt',map_location='cpu',weights_only=True).float(); "
+    "f=open('voice.bin','wb'); f.write(struct.pack('<qq',*v.shape)); f.write(v.numpy().tobytes())\"");
+
+int main(int argc, char** argv) {
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+  if (FLAGS_prompt.empty()) {
+    ET_LOG(Error, "Provide --prompt with input text.");
+    return 1;
+  }
+
+  // Track timing
+  ::executorch::extension::llm::Stats stats;
+  stats.model_load_start_ms = ::executorch::extension::llm::time_in_ms();
+
+  // Load model + codec + tokenizer
+  voxtral_tts::VoxtralTTSRunner runner(
+      FLAGS_model_path,
+      FLAGS_tokenizer_path,
+      FLAGS_codec_path,
+      /*warmup=*/true);
+
+  // Load voice embedding if provided
+  if (!FLAGS_voice_path.empty()) {
+    runner.load_voice(FLAGS_voice_path);
+  }
+
+  stats.model_load_end_ms = ::executorch::extension::llm::time_in_ms();
+
+  ET_LOG(
+      Info,
+      "Model loaded in %.1f s",
+      (stats.model_load_end_ms - stats.model_load_start_ms) / 1000.0);
+
+  // Configure generation
+  voxtral_tts::GenerateConfig config;
+  config.max_tokens = FLAGS_max_tokens;
+  config.temperature = static_cast<float>(FLAGS_temperature);
+  config.seed = static_cast<uint64_t>(FLAGS_seed);
+
+  // Token callback for progress
+  int token_count = 0;
+  auto token_cb = [&token_count](const std::string& piece) {
+    token_count++;
+    if (token_count % 100 == 0) {
+      fprintf(stderr, "\r  %d tokens generated...", token_count);
+      fflush(stderr);
+    }
+  };
+
+  // Generate
+  ET_LOG(Info, "Generating speech for: \"%s\"", FLAGS_prompt.c_str());
+  stats.inference_start_ms = ::executorch::extension::llm::time_in_ms();
+
+  std::vector<int64_t> audio_codes;
+  auto waveform = runner.generate(FLAGS_prompt, config, token_cb, &audio_codes);
+
+  stats.inference_end_ms = ::executorch::extension::llm::time_in_ms();
+
+  if (token_count > 0) {
+    fprintf(stderr, "\r  %d tokens generated.     \n", token_count);
+  }
+
+  double inference_s =
+      (stats.inference_end_ms - stats.inference_start_ms) / 1000.0;
+  ET_LOG(Info, "Inference: %.1f s (%d tokens)", inference_s, token_count);
+
+  // Write output
+  if (!waveform.empty()) {
+    voxtral_tts::write_wav(
+        FLAGS_output_path,
+        waveform.data(),
+        static_cast<int64_t>(waveform.size()),
+        static_cast<int32_t>(runner.sample_rate()));
+    double duration =
+        static_cast<double>(waveform.size()) / runner.sample_rate();
+    ET_LOG(
+        Info,
+        "Audio: %.1f s at %ld Hz -> %s",
+        duration,
+        static_cast<long>(runner.sample_rate()),
+        FLAGS_output_path.c_str());
+  } else if (!audio_codes.empty()) {
+    ET_LOG(
+        Info,
+        "Generated %zu audio codes (no codec loaded, no WAV output).",
+        audio_codes.size());
+  } else {
+    ET_LOG(Info, "No audio generated.");
+  }
+
+  // Metal backend stats can be added here when the Metal stats API is available
+
+  return 0;
+}

--- a/examples/models/voxtral_tts/model.md
+++ b/examples/models/voxtral_tts/model.md
@@ -1,0 +1,441 @@
+# Voxtral TTS — Architecture & Design Notes
+
+Developer reference for `model.py` and `codec.py`. For export/usage instructions
+see [README.md](README.md).
+
+The model is written directly with ExecuTorch custom ops rather than using
+source transformations. Patterns are reused from `examples/models/voxtral_realtime/`
+and `examples/models/llama/`.
+
+## Architecture
+
+```
+Text tokens
+  -> tok_embeddings: Embedding(vocab_size, D)
+(1, seq, D) = text_embeds
+
+text_embeds
+  -> 26x MistralDecoderLayer (RMSNorm -> GQA attention -> RMSNorm -> SwiGLU)
+  -> RMSNorm
+(1, seq, D) = hidden_states
+
+hidden_states[:, -1, :]
+  -> FlowMatchingAudioTransformer (every step, no lm_head):
+     -> semantic_codebook_output(hidden) -> argmax -> semantic_code
+     -> 7-step Euler ODE with CFG:
+        each step: [input_proj(x_t), time_proj(t_emb), llm_proj(hidden)]
+          -> 3x AcousticTransformerBlock (RMSNorm -> bidirectional GQA -> RMSNorm -> SwiGLU)
+          -> RMSNorm -> acoustic_codebook_output -> velocity
+     -> quantize to discrete codes
+(1, 1 + n_acoustic_codebook) = audio_codes
+
+audio_codes
+  -> AudioTokenEmbedding: multi-codebook lookup + sum
+(1, 1, D) = audio_embeds   (fed back to decoder for next step)
+
+After generation complete:
+  all audio_codes -> AudioTokenizerDecoder (codec.pte):
+    -> quantizer.decode -> (B, D_latent, T)
+    -> [CausalConv1d + Transformer(ALiBi, sliding window) + CausalConvTranspose1d] × N
+    -> output_proj -> reshape
+(1, 1, T * downsample_factor) = waveform
+```
+
+The model exports five methods in `model.pte` and one in `codec.pte`:
+
+| File | Method | Input | Output |
+|------|--------|-------|--------|
+| model.pte | `token_embedding` | token IDs `(1, seq)` | embeddings `(1, seq, D)` |
+| model.pte | `text_decoder` | embeddings `(1, seq, D)` + positions `(seq,)` | hidden states `(1, seq, D)` |
+| model.pte | `lm_head` | hidden `(1, 1, D)` | logits `(1, 1, vocab_size)` |
+| model.pte | `decode_audio_frame` | hidden `(1, D)` + noise `(1, C)` | audio codes `(1, 1+C)` |
+| model.pte | `audio_token_embedding` | codes `(1, K, seq)` | embeddings `(1, seq, D)` |
+| codec.pte | `audio_decoder` | codes `(1, K, T)` | waveform `(1, 1, T*upsample)` |
+
+## Model Parameters
+
+| Parameter | LM Decoder | Acoustic Transformer |
+|-----------|------------|---------------------|
+| dim | D (from config) | D (same as LM) |
+| layers | 26 | 3 |
+| heads | 32 (8 KV, GQA 4:1) | 6 (2 KV, GQA 3:1) |
+| head_dim | 128 | 128 |
+| hidden_dim (FFN) | 9216 | from config (default 2048) |
+| rope_theta | 1,000,000 | — (no RoPE) |
+| biases (attn) | none | none (default) |
+| biases (FFN) | none | none (default) |
+| vocab_size | 131,072 | — |
+| positional encoding | RoPE (split-half) | none (seq_len=3, fixed) |
+| attention type | causal (with KV cache) | bidirectional (no cache) |
+
+| Audio Parameter | Value |
+|-----------------|-------|
+| semantic_codebook_size | 8,192 |
+| acoustic_codebook_size | 21 |
+| n_acoustic_codebook | 36 |
+| n_audio_special_tokens | 2 ([EMPTY_AUDIO]=0, [END_AUDIO]=1) |
+| acoustic_decode_iters | 8 (7 Euler steps) |
+| cfg_alpha | 1.2 |
+
+| Codec Parameter | Value |
+|-----------------|-------|
+| sampling_rate | 24,000 Hz |
+| patch_size | 240 |
+| latent_dim | 292 (256 semantic + 36 acoustic) |
+| dim | 1,024 |
+| decoder stages | 4 (transformer lengths: 2,2,2,2) |
+| decoder convs | kernels: 3,4,4,4; strides: 1,2,2,2 |
+| attention | ALiBi + causal sliding window |
+| downsample_factor | 1,920 (240 × 8) |
+
+## Memory Footprint
+
+Decoder KV cache: 26 layers × 2 (K, V) × 4096 × 8 × 128 × bytes_per_elem.
+fp32: ≈ 832 MB, bf16: ≈ 416 MB.
+
+Runtime memory = model weights + KV cache + working memory. Weight
+sizes depend on quantization: ~16 GB (fp32), ~8 GB (bf16), ~4 GB (8w),
+~2 GB (4w/fpa4w). Metal backend should use bf16 (`--dtype bf16`) when
+quantization is enabled.
+
+## Class Hierarchy
+
+```
+VoxtralTTSModel
+  decoder: MistralDecoder
+    tok_embeddings: Embedding
+    layers: 26x MistralDecoderLayer
+      attention_norm: RMSNorm
+      attention: LMAttention
+        wq/wk/wv/wo: Linear (no bias)
+        kv_cache: KVCache (XNNPACK) or StaticKVCache (Metal)
+        sdpa: SDPA (XNNPACK) or MetalSDPA (Metal)
+      ffn_norm: RMSNorm
+      feed_forward: LMMLP (w1/w2/w3)
+    norm: RMSNorm
+    output: Linear (tied to tok_embeddings)
+  acoustic_transformer: FlowMatchingAudioTransformer
+    time_embedding: TimeEmbedding (sinusoidal, inv_freq buffer)
+    input_projection: Linear(n_acoustic_codebook, at_dim)
+    time_projection: Linear(at_dim, at_dim)
+    llm_projection: Linear(at_input_dim, at_dim)
+    layers: 3x AcousticTransformerBlock
+      attention_norm: RMSNorm
+      attention: BidirectionalAttention (wq/wk/wv/wo, manual attention)
+      ffn_norm: RMSNorm
+      feed_forward: LMMLP (w1/w2/w3)
+    norm: RMSNorm
+    semantic_codebook_output: Linear(at_input_dim, padded_semantic_vocab)
+    acoustic_codebook_output: Linear(at_dim, n_acoustic_codebook)
+  audio_token_embedding: AudioTokenEmbedding
+    embeddings: Embedding (shared multi-codebook with offsets)
+
+AudioTokenizerDecoder (codec.pte, separate)
+  quantizer: AudioCodebook
+    semantic: SemanticCodebook (Euclidean, embedding_sum / cluster_usage)
+    acoustic: AcousticCodebook (FSQ, n_levels=21)
+  decoder_blocks: ModuleList
+    CodecCausalConv1d (latent_dim -> dim, first projection)
+    CodecTransformerBlock × 2 (window=2)
+    CodecCausalConvTranspose1d (dim, dim, k=4, s=2)
+    CodecTransformerBlock × 2 (window=4)
+    CodecCausalConvTranspose1d (dim, dim, k=4, s=2)
+    CodecTransformerBlock × 2 (window=8)
+    CodecCausalConvTranspose1d (dim, dim, k=4, s=2)
+    CodecTransformerBlock × 2 (window=16)
+  output_proj: CodecCausalConv1d (dim -> patch_size)
+```
+
+## Text Decoder
+
+The text decoder (`MistralDecoder`) is a standard Mistral decoder with
+GQA. Unlike voxtral_realtime, there is no adaptive RMSNorm (`ada_rms_norm_t_cond`)
+since TTS has no transcription delay conditioning.
+
+`forward()` returns **normed hidden states** (after `self.norm(x)`) rather
+than logits. This is because hidden states are consumed by both the LM head
+(for text token sampling) and the acoustic transformer (for audio code
+generation). The LM head is exported as a separate method.
+
+### RoPE convention
+
+The LM decoder uses **split-half** (rotate_half) RoPE, matching the
+HuggingFace/Mistral convention. This is different from the Llama
+**interleaved** (reshape+unbind pairs) convention used by
+`examples/models/llama/`. The two conventions are NOT interchangeable —
+using the wrong one produces completely different hidden states.
+
+Split-half: splits head_dim into first half and second half, swaps and
+negates. Interleaved: groups consecutive pairs `(x[0],x[1]), (x[2],x[3])`.
+
+### KV cache
+
+Same as voxtral_realtime:
+
+**XNNPACK/Portable:** `KVCache` with `[B, S, H, D]` layout, `torch.ops.llama.update_cache`.
+
+**Metal:** `StaticKVCache` with `[B, H, S, D]` layout, `index_copy_`.
+
+### SDPA
+
+Same as voxtral_realtime:
+
+**XNNPACK/Portable:** `SDPA` — `torch.ops.llama.custom_sdpa`.
+
+**Metal:** `MetalSDPA` — `_scaled_dot_product_attention_math_for_mps`. The
+MPS SDPA meta kernel requires `seq_len > 2`, so the Metal export uses
+`Dim("seq_len", min=3, ...)`. Single-token decode must pad to length 3.
+
+
+### Attention mask
+
+The Metal attention mask uses an additive float mask matching Q/K/V dtype.
+The branch-free implementation avoids `if seqlen > 1:` to prevent unprovable
+shape guards during export:
+
+```python
+diff = input_pos.unsqueeze(1) - k_pos.unsqueeze(0) + 1
+valid = torch.clamp(diff, min=0, max=1)
+mask = (valid.to(dtype) - 1.0) * 1e9
+```
+
+## Acoustic Transformer
+
+`FlowMatchingAudioTransformer` generates audio codes from LLM hidden states
+via a flow-matching ODE with classifier-free guidance.
+
+### Flow matching decode
+
+`decode_one_frame(hidden_states, noise)`:
+
+1. **Semantic code**: `semantic_codebook_output(hidden_states)` → argmax.
+   The semantic head operates on the raw LLM hidden states (`at_input_dim`),
+   not the transformer's internal dim. In real models, `at_dim == at_input_dim`.
+
+2. **Acoustic codes via Euler ODE** (7 steps, unrolled by `torch.export`):
+   ```
+   x = noise * noise_scale
+   for each timestep pair (t, t+dt):
+     t_emb = time_embedding(t)
+     # Batch conditional + unconditional for CFG
+     v_all = predict_velocity([x, x], [hidden, zeros], [t_emb, t_emb])
+     v = cfg_alpha * v_cond + (1 - cfg_alpha) * v_uncond
+     x = x + v * dt
+   ```
+
+3. **Quantize**: `clamp(-1, 1)` → scale to `[0, levels-1]` → round → offset
+   by `_N_AUDIO_SPECIAL_TOKENS`.
+
+### Noise as input
+
+The runner generates `torch.randn(1, n_acoustic_codebook)` and passes it to
+`decode_audio_frame`. This avoids baking random state into the exported
+graph (same pattern as the vLLM CUDA graph wrapper which uses pre-allocated
+noise buffers).
+
+### Bidirectional attention
+
+`BidirectionalAttention` is non-causal with no positional encoding. The
+sequence length is always 3 tokens: `[input_projection(x_t), time_emb, llm_hidden]`.
+Uses manual attention (`q @ k.T * scale → softmax → @ v`) since the fixed
+seq_len=3 makes SDPA kernel overhead unnecessary. GQA expansion via
+`repeat_interleave` (3:1 ratio with default 6 heads / 2 KV heads).
+
+### `_predict_velocity`
+
+```
+x_t: (B, n_acoustic_codebook) → input_projection → (B, 1, at_dim)
+t_emb: (B, at_dim) → time_projection → (B, 1, at_dim)
+llm_output: (B, at_input_dim) → llm_projection → (B, 1, at_dim)
+  cat → (B, 3, at_dim) → 3x AcousticTransformerBlock → norm
+  → acoustic_codebook_output(token_0) → (B, n_acoustic_codebook)
+```
+
+## Audio Token Embedding
+
+`AudioTokenEmbedding` maps multi-codebook audio codes back to the LLM's
+input space. Each codebook has its own offset into a shared embedding
+table (pre-computed as a registered buffer). Forward:
+
+```python
+offset_codes = codes + offsets[None, :, None]   # per-codebook offset
+emb = embeddings(offset_codes)                  # (B, K, seq, D)
+return emb.sum(dim=1)                           # (B, seq, D)
+```
+
+## Audio Codec Decoder
+
+The codec decoder (`codec.py`) converts discrete audio codes to a waveform.
+It reimplements the vLLM `VoxtralTTSAudioTokenizer` decoder path with
+export-safe modifications.
+
+### Quantizer decode
+
+`AudioCodebook.decode(codes)` splits codes into semantic (codebook 0) and
+acoustic (codebooks 1..K) parts:
+- **Semantic**: Euclidean codebook lookup (`embedding_sum / cluster_usage`)
+- **Acoustic**: FSQ inverse (`(codes * 2 / (levels - 1)) - 1`)
+
+Concatenated to produce `(B, D_latent, T)` continuous embeddings.
+
+### Decoder network
+
+The decoder alternates between transformer blocks and transposed convolutions:
+
+```
+CausalConv1d (latent_dim → dim, k=3, s=1)
+  → 2x TransformerBlock (ALiBi, window=2)
+  → CausalConvTranspose1d (dim, dim, k=4, s=2)    ← 2x upsample
+  → 2x TransformerBlock (ALiBi, window=4)
+  → CausalConvTranspose1d (dim, dim, k=4, s=2)    ← 2x upsample
+  → 2x TransformerBlock (ALiBi, window=8)
+  → CausalConvTranspose1d (dim, dim, k=4, s=2)    ← 2x upsample
+  → 2x TransformerBlock (ALiBi, window=16)
+CausalConv1d output_proj (dim → patch_size, k=7)
+  → reshape (B, patch_size, T) → (B, 1, T * patch_size)
+```
+
+The sliding window size doubles at each upsample stage (2 → 4 → 8 → 16),
+starting from the window size after the encoder's downsampling stages.
+
+### Export-safe modifications
+
+| vLLM pattern | ExecuTorch replacement |
+|-------------|----------------------|
+| `einops.rearrange` | Explicit `permute`/`reshape` |
+| `flash_attn_func` | `F.scaled_dot_product_attention` with ALiBi mask |
+| `weight_norm` parametrizations | Folded via `remove_parametrizations` before export |
+| Dynamic padding (`math.ceil`) | Static input shapes (chunked at `--codec-chunk-size`) |
+| `nn.ModuleDict` (string keys) | Works with `nn.ModuleList` (same state dict keys) |
+
+### Codec attention
+
+`CodecAttention` uses ALiBi (Attention with Linear Biases) instead of RoPE,
+with a causal sliding window. The attention bias is constructed per-forward:
+
+```python
+rel_pos = positions[None, :] - positions[:, None]    # (T, T)
+attn_bias = alibi_slopes[:, None, None] * rel_pos    # (H, T, T)
+attn_bias.masked_fill_(rel_pos > 0, -inf)            # causal
+attn_bias.masked_fill_(|rel_pos| > window, -inf)     # sliding window
+```
+
+ALiBi slopes are pre-computed as a registered buffer using the geometric
+sequence `2^(-8/n)` for power-of-2 head counts.
+
+### Layer scale
+
+`CodecTransformerBlock` uses learnable layer scale parameters
+(`attention_scale`, `ffn_scale`) initialized based on layer depth:
+- Layers 0–17: `0.1`
+- Layers 18–24: `1e-5`
+- Layers 25+: `1e-6`
+
+## Quantization
+
+Quantization is applied per-component after wrapping:
+
+```bash
+# Metal (recommended)
+--qlinear fpa4w           # LM decoder + acoustic transformer linears
+--qembedding 8w           # text embedding
+
+# XNNPACK/Portable
+--qlinear 8da4w           # LM decoder + acoustic transformer linears
+--qembedding 8w           # text embedding
+```
+
+The `--qlinear` flag quantizes both the LM decoder (via `TextDecoderExport`)
+and the acoustic transformer (via `DecodeAudioFrameExport`). The LM head
+shares the output linear with the decoder; when quantized, weights are
+untied first (`output.weight = Parameter(tok_embeddings.weight.clone())`)
+so embedding and output get separate quantization configs.
+
+## Export
+
+Each exported method corresponds to a thin wrapper class in
+`export_voxtral_tts.py`:
+
+| Wrapper | Method | Wraps |
+|---------|--------|-------|
+| `TokenEmbeddingExport` | `token_embedding` | `decoder.tok_embeddings` |
+| `TextDecoderExport` | `text_decoder` | `decoder.forward` (hidden states) |
+| `LMHeadExport` | `lm_head` | `decoder.output` |
+| `DecodeAudioFrameExport` | `decode_audio_frame` | `acoustic_transformer.decode_one_frame` |
+| `AudioTokenEmbeddingExport` | `audio_token_embedding` | `audio_token_embedding` |
+
+All exports use `torch.export.export(..., strict=True)` with explicit
+bounded `Dim` specs. `Dim.AUTO` is avoided because it produces unbounded
+ranges (`int_oo`) that fail in `SymShapeEvalPass` during `to_executorch()`.
+
+`strict=True` is required because the XNNPACK KV cache uses `.item()` to
+extract scalar positions (producing unbacked `SymInt`s).
+
+## Checkpoint
+
+Mistral format: `params.json` + `consolidated.safetensors`.
+
+### Memory-efficient loading
+
+`load_model()` follows the same pattern as voxtral_realtime:
+
+1. **Meta device construction** — zero-storage parameter tensors.
+2. **safetensors lazy access** — loads tensors on demand.
+3. **`assign=True` state dict loading** — replaces meta tensors by reference.
+4. **Post-load fixups** — re-tie output weights, materialize KV caches,
+   recompute RoPE.
+
+### Weight mapping
+
+| Checkpoint prefix | Model prefix |
+|------------------|-------------|
+| `layers.*` | `decoder.layers.*` |
+| `norm.weight` | `decoder.norm.weight` |
+| `output.weight` | `decoder.output.weight` (or tied) |
+| `mm_audio_embeddings.tok_embeddings.weight` | `decoder.tok_embeddings.weight` |
+| `mm_audio_embeddings.audio_codebook_embeddings.embeddings.*` | `audio_token_embedding.embeddings.*` |
+| `acoustic_transformer.*` | `acoustic_transformer.*` |
+| `audio_tokenizer.*` | (codec.pte, separate loading) |
+
+`decoder.output.weight` is tied to `decoder.tok_embeddings.weight`.
+During export with quantization, the tie is broken so embedding and
+output linear get separate quantization configs.
+
+### Codec weight mapping
+
+| Checkpoint prefix | Codec model prefix |
+|------------------|-------------------|
+| `audio_tokenizer.quantizer.semantic_codebook.*` | `quantizer.semantic.*` |
+| `audio_tokenizer.quantizer.acoustic_codebook.*` | `quantizer.acoustic.*` |
+| `audio_tokenizer.decoder_blocks.*` | `decoder_blocks.*` |
+| `audio_tokenizer.output_proj.*` | `output_proj.*` |
+
+Codec weights with `weight_norm` parametrizations are folded via
+`remove_parametrizations` after loading.
+
+## Differences from Voxtral Realtime
+
+| Aspect | Voxtral Realtime (ASR) | Voxtral TTS |
+|--------|----------------------|-------------|
+| Direction | Audio → Text | Text → Audio |
+| Encoder | Whisper (causal conv + transformer) | None |
+| Decoder | Mistral + adaptive RMSNorm | Mistral (standard) |
+| Extra head | — | Acoustic transformer (flow matching) |
+| Audio codec | — | Encoder-decoder with ALiBi |
+| KV cache | Decoder + streaming encoder | Decoder only |
+| Output | Text tokens | Audio waveform |
+| .pte files | 1 (model.pte) | 2 (model.pte + codec.pte) |
+| Decoder returns | Logits | Hidden states (split lm_head) |
+
+## References
+
+- Reference implementation: vLLM-omni `voxtral_tts/` model
+- Voxtral Realtime: `examples/models/voxtral_realtime/`
+
+Upstream ExecuTorch patterns:
+
+- KV cache: `examples/models/llama/source_transformation/custom_kv_cache.py`
+- SDPA: `examples/models/llama/source_transformation/sdpa.py`
+- RoPE: split-half convention (NOT `examples/models/llama/rope.py` which uses interleaved)
+- Model loading: `examples/models/llama/model.py`
+- Export builder: `extension/llm/export/builder.py`

--- a/examples/models/voxtral_tts/model.py
+++ b/examples/models/voxtral_tts/model.py
@@ -246,7 +246,6 @@ def _build_attn_mask(
     return (valid.to(dtype) - 1.0) * 1e9
 
 
-
 # ---------------------------------------------------------------------------
 # SDPA variants
 # ---------------------------------------------------------------------------
@@ -311,7 +310,6 @@ class MetalSDPA(nn.Module):
         )
         y = y.transpose(1, 2).contiguous()
         return y.view(bsz, seqlen, self.dim)
-
 
 
 # ---------------------------------------------------------------------------
@@ -757,6 +755,23 @@ def _map_checkpoint_key(ckpt_key: str) -> str | None:
     return None
 
 
+def _permute_qk(w: torch.Tensor, n_heads: int) -> torch.Tensor:
+    """Permute Q/K weights from Mistral interleaved to split-half layout.
+
+    Mistral checkpoints store Q/K in interleaved RoPE layout:
+      [pair0_real, pair0_imag, pair1_real, pair1_imag, ...]
+    The split-half RoPE used here expects:
+      [pair0_real, pair1_real, ..., pair0_imag, pair1_imag, ...]
+    This matches vLLM's maybe_remap_mistral permutation.
+    """
+    head_dim = w.shape[0] // n_heads
+    return (
+        w.view(n_heads, head_dim // 2, 2, w.shape[1])
+        .transpose(1, 2)
+        .reshape(w.shape[0], w.shape[1])
+    )
+
+
 def load_model(
     model_path: str,
     max_seq_len: int = 4096,
@@ -786,7 +801,13 @@ def load_model(
             model_key = _map_checkpoint_key(ckpt_key)
             if model_key is None:
                 continue
-            state_dict[model_key] = f.get_tensor(ckpt_key).to(dtype)
+            tensor = f.get_tensor(ckpt_key).to(dtype)
+            # Permute Q/K weights from Mistral interleaved to split-half layout
+            if ckpt_key.endswith(".wq.weight") and ckpt_key.startswith("layers."):
+                tensor = _permute_qk(tensor, config.n_heads)
+            elif ckpt_key.endswith(".wk.weight") and ckpt_key.startswith("layers."):
+                tensor = _permute_qk(tensor, config.n_kv_heads)
+            state_dict[model_key] = tensor
 
     missing, unexpected = model.load_state_dict(state_dict, strict=False, assign=True)
 

--- a/examples/models/voxtral_tts/model.py
+++ b/examples/models/voxtral_tts/model.py
@@ -1,0 +1,836 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Voxtral TTS eager model for ExecuTorch.
+
+Two-stage TTS pipeline:
+  Stage 1 (model.pte): LLM + acoustic transformer → audio codes
+  Stage 2 (codec.pte): audio tokenizer decoder → waveform
+
+Architecture follows voxtral_realtime patterns for Metal/XNNPACK compatibility.
+"""
+
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from executorch.extension.llm.custom_ops import custom_ops as _custom_ops  # noqa: F401
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_N_AUDIO_SPECIAL_TOKENS = 2  # [EMPTY_AUDIO]=0, [END_AUDIO]=1
+_EMPTY_AUDIO_TOKEN_ID = 0
+_END_AUDIO_TOKEN_ID = 1
+_ACOUSTIC_DECODE_ITERS = 8
+_CFG_ALPHA = 1.2
+_NOISE_SCALE = 1.0
+
+
+def _round_up(n: int, multiple: int) -> int:
+    return multiple * ((n + multiple - 1) // multiple)
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class VoxtralTTSConfig:
+    # LM decoder
+    dim: int = 3072
+    n_layers: int = 26
+    n_heads: int = 32
+    n_kv_heads: int = 8
+    head_dim: int = 128
+    hidden_dim: int = 9216
+    vocab_size: int = 131072
+    rope_theta: float = 1_000_000.0
+    norm_eps: float = 1e-5
+    # Acoustic transformer
+    at_input_dim: int = 3072
+    at_dim: int = 768
+    at_n_layers: int = 3
+    at_n_heads: int = 6
+    at_n_kv_heads: int = 2
+    at_head_dim: int = 128
+    at_hidden_dim: int = 2048
+    at_use_biases: bool = False
+    at_norm_eps: float = 1e-5
+    # Audio codebooks
+    semantic_codebook_size: int = 8192
+    acoustic_codebook_size: int = 21
+    n_acoustic_codebook: int = 36
+    # Runtime
+    max_seq_len: int = 4096
+    backend: str = "metal"
+
+    @property
+    def padded_semantic_vocab_size(self) -> int:
+        return _round_up(self.semantic_codebook_size + _N_AUDIO_SPECIAL_TOKENS, 128)
+
+    @staticmethod
+    def from_params_json(path: str) -> "VoxtralTTSConfig":
+        with open(path) as f:
+            p = json.load(f)
+        audio = p.get("multimodal", {}).get("audio_model_args", {})
+        at = audio.get("acoustic_transformer_args", {})
+
+        codebook_str = audio.get("codebook_sizes", "")
+        if codebook_str:
+            sizes = [int(c) for c in codebook_str.split(",")]
+            sem_size, acou_size, n_acou = sizes[0], sizes[1], len(sizes) - 1
+        else:
+            sem_size = audio.get("semantic_codebook_size", 8192)
+            acou_size = audio.get("acoustic_codebook_size", 21)
+            n_acou = audio.get("n_acoustic_codebook", 36)
+
+        return VoxtralTTSConfig(
+            dim=p["dim"],
+            n_layers=p["n_layers"],
+            n_heads=p["n_heads"],
+            n_kv_heads=p["n_kv_heads"],
+            head_dim=p["head_dim"],
+            hidden_dim=p["hidden_dim"],
+            vocab_size=p["vocab_size"],
+            rope_theta=p["rope_theta"],
+            norm_eps=p["norm_eps"],
+            at_input_dim=at.get("input_dim", p["dim"]),
+            at_dim=at.get("dim", 768),
+            at_n_layers=at.get("n_layers", 3),
+            at_n_heads=at.get("n_heads", 6),
+            at_n_kv_heads=at.get("n_kv_heads", 2),
+            at_head_dim=at.get("head_dim", 128),
+            at_hidden_dim=at.get("hidden_dim", 2048),
+            at_use_biases=at.get("use_biases", False),
+            at_norm_eps=at.get("norm_eps", 1e-5),
+            semantic_codebook_size=sem_size,
+            acoustic_codebook_size=acou_size,
+            n_acoustic_codebook=n_acou,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Shared building blocks
+# ---------------------------------------------------------------------------
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim: int, eps: float = 1e-5):
+        super().__init__()
+        self.dim = dim
+        self.weight = nn.Parameter(torch.ones(dim))
+        self.eps = eps
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return F.rms_norm(x, (self.dim,), self.weight, self.eps)
+
+
+def precompute_freqs_cis(
+    head_dim: int, max_len: int, theta: float
+) -> tuple[torch.Tensor, torch.Tensor]:
+    freqs = 1.0 / (theta ** (torch.arange(0, head_dim, 2).float() / head_dim))
+    t = torch.arange(max_len, dtype=torch.float)
+    freqs = torch.outer(t, freqs)
+    return freqs.cos(), freqs.sin()
+
+
+def _rotate_half(x: torch.Tensor) -> torch.Tensor:
+    """Split-half rotation: swap first and second halves, negate first."""
+    half = x.shape[-1] // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def apply_rotary_emb(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    freqs_cos: torch.Tensor,
+    freqs_sin: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Apply rotary position embeddings using split-half rotation.
+
+    Uses the HuggingFace/Mistral convention (rotate_half) where the first and
+    second halves of the head dimension are swapped, NOT the Llama interleaved
+    convention (reshape+unbind pairs). Both produce valid rotary embeddings
+    but are NOT interchangeable — the model must be trained with one convention.
+    Mistral models use split-half.
+    """
+    # freqs: (T, head_dim/2) → repeat to (T, head_dim) for split-half
+    fc = freqs_cos.unsqueeze(0).unsqueeze(2)  # (1, T, 1, D/2)
+    fs = freqs_sin.unsqueeze(0).unsqueeze(2)
+    # Repeat cos/sin to match full head_dim
+    fc = fc.repeat(1, 1, 1, 2)  # (1, T, 1, D)
+    fs = fs.repeat(1, 1, 1, 2)
+
+    q_f = q.float()
+    k_f = k.float()
+    q_out = q_f * fc + _rotate_half(q_f) * fs
+    k_out = k_f * fc + _rotate_half(k_f) * fs
+    return q_out.type_as(q), k_out.type_as(k)
+
+
+# ---------------------------------------------------------------------------
+# KV caches
+# ---------------------------------------------------------------------------
+
+
+class KVCache(nn.Module):
+    """[B, S, H, D] layout for torch.ops.llama.update_cache (XNNPACK/Portable)."""
+
+    def __init__(self, max_seq_len: int, n_kv_heads: int, head_dim: int):
+        super().__init__()
+        self.max_seq_len = max_seq_len
+        cache_shape = (1, max_seq_len, n_kv_heads, head_dim)
+        self.register_buffer("k_cache", torch.zeros(cache_shape))
+        self.register_buffer("v_cache", torch.zeros(cache_shape))
+
+    def update(
+        self, input_pos: torch.Tensor, k_val: torch.Tensor, v_val: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        start_pos = input_pos[0].item()
+        torch._check_is_size(start_pos)
+        torch._check(start_pos < self.max_seq_len)
+        torch.ops.llama.update_cache(k_val, self.k_cache, start_pos)
+        torch.ops.llama.update_cache(v_val, self.v_cache, start_pos)
+        return self.k_cache, self.v_cache
+
+
+class StaticKVCache(nn.Module):
+    """[B, H, S, D] layout with index_copy_ (Metal/CUDA/AOTI)."""
+
+    def __init__(self, max_seq_len: int, n_kv_heads: int, head_dim: int):
+        super().__init__()
+        cache_shape = (1, n_kv_heads, max_seq_len, head_dim)
+        self.register_buffer("k_cache", torch.zeros(cache_shape))
+        self.register_buffer("v_cache", torch.zeros(cache_shape))
+
+    def update(
+        self, input_pos: torch.Tensor, k_val: torch.Tensor, v_val: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        k_val = k_val.transpose(1, 2)
+        v_val = v_val.transpose(1, 2)
+        self.k_cache.index_copy_(2, input_pos, k_val)
+        self.v_cache.index_copy_(2, input_pos, v_val)
+        return self.k_cache, self.v_cache
+
+
+# ---------------------------------------------------------------------------
+# Attention masks
+# ---------------------------------------------------------------------------
+
+
+def _build_attn_mask(
+    input_pos: torch.Tensor,
+    max_seq_len: int,
+    device: torch.device,
+    dtype: torch.dtype = torch.float32,
+) -> torch.Tensor:
+    """Additive float mask for Metal. dtype must match Q/K/V."""
+    k_pos = torch.arange(max_seq_len, device=device)
+    # General path: works for both prefill (seq_len>1) and decode (seq_len=1)
+    # without a shape-dependent branch that creates unprovable guards.
+    diff = input_pos.unsqueeze(1) - k_pos.unsqueeze(0) + 1
+    valid = torch.clamp(diff, min=0, max=1)
+    return (valid.to(dtype) - 1.0) * 1e9
+
+
+# ---------------------------------------------------------------------------
+# SDPA variants
+# ---------------------------------------------------------------------------
+
+
+class SDPA(nn.Module):
+    """torch.ops.llama.custom_sdpa for XNNPACK/Portable."""
+
+    def __init__(self, n_heads: int, head_dim: int):
+        super().__init__()
+        self.dim = n_heads * head_dim
+
+    def forward(
+        self,
+        input_pos: torch.Tensor,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        bsz: int,
+        seqlen: int,
+        mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        input_dtype = q.dtype
+        q, k, v = q.float(), k.float(), v.float()
+        start_pos = input_pos[0].item()
+        torch._check_is_size(start_pos)
+        if mask is not None:
+            y = torch.ops.llama.custom_sdpa(q, k, v, start_pos, mask.float(), 0, False)
+        else:
+            y = torch.ops.llama.custom_sdpa(q, k, v, start_pos, None, 0, True)
+        return y.view(bsz, seqlen, self.dim).to(dtype=input_dtype)
+
+
+class MetalSDPA(nn.Module):
+    """Native MPS SDPA kernel. Handles GQA natively."""
+
+    def __init__(
+        self, n_heads: int, n_kv_heads: int, head_dim: int, transpose_kv: bool = False
+    ):
+        super().__init__()
+        self.dim = n_heads * head_dim
+        self.transpose_kv = transpose_kv
+
+    def forward(
+        self,
+        input_pos: torch.Tensor,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        bsz: int,
+        seqlen: int,
+        attn_mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        q = q.transpose(1, 2)
+        if self.transpose_kv:
+            k = k.transpose(1, 2)
+            v = v.transpose(1, 2)
+        if attn_mask is None:
+            attn_mask = _build_attn_mask(input_pos, k.shape[2], q.device, q.dtype)
+        y, _ = torch.ops.aten._scaled_dot_product_attention_math_for_mps(
+            q, k, v, attn_mask, 0.0, False, None
+        )
+        y = y.transpose(1, 2).contiguous()
+        return y.view(bsz, seqlen, self.dim)
+
+
+# ---------------------------------------------------------------------------
+# LM decoder
+# ---------------------------------------------------------------------------
+
+
+class LMAttention(nn.Module):
+    """GQA with RoPE, KV cache, SDPA. No biases."""
+
+    def __init__(self, config: VoxtralTTSConfig, max_seq_len: int):
+        super().__init__()
+        self.n_heads = config.n_heads
+        self.n_kv_heads = config.n_kv_heads
+        self.head_dim = config.head_dim
+        self.backend = config.backend
+
+        self.wq = nn.Linear(config.dim, self.n_heads * self.head_dim, bias=False)
+        self.wk = nn.Linear(config.dim, self.n_kv_heads * self.head_dim, bias=False)
+        self.wv = nn.Linear(config.dim, self.n_kv_heads * self.head_dim, bias=False)
+        self.wo = nn.Linear(self.n_heads * self.head_dim, config.dim, bias=False)
+
+        if self.backend == "metal":
+            self.kv_cache = StaticKVCache(max_seq_len, self.n_kv_heads, self.head_dim)
+            self.sdpa = MetalSDPA(self.n_heads, self.n_kv_heads, self.head_dim)
+        else:  # xnnpack
+            self.kv_cache = KVCache(max_seq_len, self.n_kv_heads, self.head_dim)
+            self.sdpa = SDPA(self.n_heads, self.head_dim)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        freqs_cos: torch.Tensor,
+        freqs_sin: torch.Tensor,
+        input_pos: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        B, T, _ = x.shape
+        q = self.wq(x).view(B, T, self.n_heads, self.head_dim)
+        k = self.wk(x).view(B, T, self.n_kv_heads, self.head_dim)
+        v = self.wv(x).view(B, T, self.n_kv_heads, self.head_dim)
+        q, k = apply_rotary_emb(q, k, freqs_cos, freqs_sin)
+        k, v = self.kv_cache.update(input_pos, k, v)
+        return self.wo(self.sdpa(input_pos, q, k, v, B, T, attn_mask))
+
+
+class LMMLP(nn.Module):
+    """SwiGLU FFN. No biases."""
+
+    def __init__(self, dim: int, hidden_dim: int):
+        super().__init__()
+        self.w1 = nn.Linear(dim, hidden_dim, bias=False)
+        self.w2 = nn.Linear(hidden_dim, dim, bias=False)
+        self.w3 = nn.Linear(dim, hidden_dim, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.w2(F.silu(self.w1(x)) * self.w3(x))
+
+
+class MistralDecoderLayer(nn.Module):
+    def __init__(self, config: VoxtralTTSConfig, max_seq_len: int):
+        super().__init__()
+        self.attention_norm = RMSNorm(config.dim, config.norm_eps)
+        self.attention = LMAttention(config, max_seq_len)
+        self.ffn_norm = RMSNorm(config.dim, config.norm_eps)
+        self.feed_forward = LMMLP(config.dim, config.hidden_dim)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        freqs_cos: torch.Tensor,
+        freqs_sin: torch.Tensor,
+        input_pos: torch.Tensor,
+        attn_mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        x = x + self.attention(
+            self.attention_norm(x), freqs_cos, freqs_sin, input_pos, attn_mask
+        )
+        x = x + self.feed_forward(self.ffn_norm(x))
+        return x
+
+
+class MistralDecoder(nn.Module):
+    """Mistral LM decoder. forward() returns normed hidden states (not logits)."""
+
+    def __init__(self, config: VoxtralTTSConfig, max_seq_len: int):
+        super().__init__()
+        self.config = config
+        self.tok_embeddings = nn.Embedding(config.vocab_size, config.dim)
+        self.layers = nn.ModuleList(
+            [MistralDecoderLayer(config, max_seq_len) for _ in range(config.n_layers)]
+        )
+        self.norm = RMSNorm(config.dim, config.norm_eps)
+        self.output = nn.Linear(config.dim, config.vocab_size, bias=False)
+
+        freqs_cos, freqs_sin = precompute_freqs_cis(
+            config.head_dim, max_seq_len, config.rope_theta
+        )
+        self.register_buffer("freqs_cos", freqs_cos)
+        self.register_buffer("freqs_sin", freqs_sin)
+
+    def forward(
+        self, input_embeds: torch.Tensor, input_pos: torch.Tensor
+    ) -> torch.Tensor:
+        freqs_cos = self.freqs_cos[input_pos]
+        freqs_sin = self.freqs_sin[input_pos]
+
+        attn_mask: torch.Tensor | None = None
+        if self.config.backend == "metal":
+            attn_mask = _build_attn_mask(
+                input_pos,
+                self.freqs_cos.shape[0],
+                input_embeds.device,
+                input_embeds.dtype,
+            )
+
+        x = input_embeds
+        for layer in self.layers:
+            x = layer(x, freqs_cos, freqs_sin, input_pos, attn_mask)
+        return self.norm(x)
+
+
+# ---------------------------------------------------------------------------
+# Acoustic transformer (flow matching)
+# ---------------------------------------------------------------------------
+
+
+class TimeEmbedding(nn.Module):
+    """Sinusoidal time embedding for flow matching step."""
+
+    def __init__(self, dim: int, theta: float = 10000.0):
+        super().__init__()
+        inv_freq = torch.exp(
+            -math.log(theta) * torch.arange(dim // 2).float() / (dim // 2)
+        )
+        self.register_buffer("inv_freq", inv_freq, persistent=True)
+
+    def forward(self, t: torch.Tensor) -> torch.Tensor:
+        # t: (B, 1)
+        emb = t * self.inv_freq  # (B, dim//2) via broadcast
+        return torch.cat((emb.cos(), emb.sin()), dim=-1)
+
+
+class BidirectionalAttention(nn.Module):
+    """Non-causal attention for the acoustic transformer. No RoPE, no KV cache."""
+
+    def __init__(self, config: VoxtralTTSConfig):
+        super().__init__()
+        self.n_heads = config.at_n_heads
+        self.n_kv_heads = config.at_n_kv_heads
+        self.head_dim = config.at_head_dim
+        self.n_rep = self.n_heads // self.n_kv_heads
+        dim = config.at_dim
+
+        self.wq = nn.Linear(
+            dim, self.n_heads * self.head_dim, bias=config.at_use_biases
+        )
+        self.wk = nn.Linear(dim, self.n_kv_heads * self.head_dim, bias=False)
+        self.wv = nn.Linear(
+            dim, self.n_kv_heads * self.head_dim, bias=config.at_use_biases
+        )
+        self.wo = nn.Linear(
+            self.n_heads * self.head_dim, dim, bias=config.at_use_biases
+        )
+        self.scale = self.head_dim**-0.5
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        B, T, _ = x.shape
+        q = self.wq(x).view(B, T, self.n_heads, self.head_dim)
+        k = self.wk(x).view(B, T, self.n_kv_heads, self.head_dim)
+        v = self.wv(x).view(B, T, self.n_kv_heads, self.head_dim)
+
+        # Transpose to [B, H, T, D] for attention
+        q = q.transpose(1, 2)
+        k = k.transpose(1, 2)
+        v = v.transpose(1, 2)
+
+        # GQA expansion
+        if self.n_rep > 1:
+            k = k.repeat_interleave(self.n_rep, dim=1)
+            v = v.repeat_interleave(self.n_rep, dim=1)
+
+        # Manual attention (seq_len=3, no SDPA kernel needed)
+        attn = (q * self.scale) @ k.transpose(-2, -1)
+        attn = attn.softmax(-1)
+        y = attn @ v
+
+        y = y.transpose(1, 2).contiguous().view(B, T, -1)
+        return self.wo(y)
+
+
+class AcousticTransformerBlock(nn.Module):
+    def __init__(self, config: VoxtralTTSConfig):
+        super().__init__()
+        self.attention_norm = RMSNorm(config.at_dim, config.at_norm_eps)
+        self.attention = BidirectionalAttention(config)
+        self.ffn_norm = RMSNorm(config.at_dim, config.at_norm_eps)
+        self.feed_forward = LMMLP(config.at_dim, config.at_hidden_dim)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = x + self.attention(self.attention_norm(x))
+        x = x + self.feed_forward(self.ffn_norm(x))
+        return x
+
+
+class FlowMatchingAudioTransformer(nn.Module):
+    """Generates audio codes from LLM hidden states via flow matching ODE."""
+
+    def __init__(self, config: VoxtralTTSConfig):
+        super().__init__()
+        self.config = config
+        self.n_acoustic_codebook = config.n_acoustic_codebook
+        self.acoustic_levels = config.acoustic_codebook_size
+
+        # Projections
+        self.input_projection = nn.Linear(
+            config.n_acoustic_codebook, config.at_dim, bias=False
+        )
+        self.time_projection = nn.Linear(config.at_dim, config.at_dim, bias=False)
+        self.llm_projection = nn.Linear(config.at_input_dim, config.at_dim, bias=False)
+
+        # Time embedding
+        self.time_embedding = TimeEmbedding(config.at_dim)
+
+        # Transformer layers
+        self.layers = nn.ModuleList(
+            [AcousticTransformerBlock(config) for _ in range(config.at_n_layers)]
+        )
+        self.norm = RMSNorm(config.at_dim, config.at_norm_eps)
+
+        # Output heads
+        # semantic_codebook_output operates on LLM hidden states directly
+        # (at_input_dim), matching vLLM's FlowMatchingAudioTransformer.forward()
+        self.semantic_codebook_output = nn.Linear(
+            config.at_input_dim,
+            config.padded_semantic_vocab_size,
+            bias=config.at_use_biases,
+        )
+        self.acoustic_codebook_output = nn.Linear(
+            config.at_dim, config.n_acoustic_codebook, bias=False
+        )
+
+        # Flow matching timesteps
+        self.register_buffer(
+            "timesteps",
+            torch.linspace(0, 1, _ACOUSTIC_DECODE_ITERS),
+            persistent=False,
+        )
+
+    def _predict_velocity(
+        self,
+        x_t: torch.Tensor,
+        llm_output: torch.Tensor,
+        t_emb: torch.Tensor,
+    ) -> torch.Tensor:
+        """Single velocity prediction step.
+
+        Args:
+            x_t: (B, n_acoustic_codebook) current sample.
+            llm_output: (B, llm_dim) hidden states from LLM.
+            t_emb: (B, at_dim) time embedding.
+        Returns:
+            velocity: (B, n_acoustic_codebook).
+        """
+        x_t = x_t.to(llm_output.dtype)
+        t_emb = self.time_projection(t_emb)
+        llm_output = self.llm_projection(llm_output)
+
+        # Build 3-token sequence: [acoustic_input, time, llm]
+        h = torch.cat(
+            [
+                self.input_projection(x_t.unsqueeze(1)),
+                t_emb.unsqueeze(1),
+                llm_output.unsqueeze(1),
+            ],
+            dim=1,
+        )  # (B, 3, at_dim)
+
+        for layer in self.layers:
+            h = layer(h)
+        h = self.norm(h)
+
+        # Predict velocity from the first token
+        return self.acoustic_codebook_output(h[:, 0, :].contiguous())
+
+    def decode_one_frame(
+        self, hidden_states: torch.Tensor, noise: torch.Tensor
+    ) -> torch.Tensor:
+        """Generate one frame of audio codes via flow matching.
+
+        Args:
+            hidden_states: (B, llm_dim) normed LLM hidden states.
+            noise: (B, n_acoustic_codebook) initial noise from runner.
+        Returns:
+            audio_codes: (B, 1 + n_acoustic_codebook) semantic + acoustic codes.
+        """
+        B = hidden_states.shape[0]
+
+        # Semantic code via greedy decoding
+        semantic_logit = self.semantic_codebook_output(hidden_states).float()
+        semantic_logit[:, _EMPTY_AUDIO_TOKEN_ID] = -float("inf")
+        sem_vocab = self.config.semantic_codebook_size + _N_AUDIO_SPECIAL_TOKENS
+        semantic_logit[:, sem_vocab:] = -float("inf")
+        semantic_code = semantic_logit.argmax(dim=-1, keepdim=True)  # (B, 1)
+
+        should_decode = semantic_code.squeeze(1) != _END_AUDIO_TOKEN_ID
+
+        # Flow matching Euler ODE
+        x = noise * _NOISE_SCALE
+        hidden_zero = torch.zeros_like(hidden_states)
+        timesteps = self.timesteps.to(dtype=hidden_states.dtype)
+
+        for i in range(len(timesteps) - 1):
+            t = timesteps[i]
+            dt = timesteps[i + 1] - timesteps[i]
+
+            t_emb = self.time_embedding(t.view(-1, 1).repeat(B, 1)).to(
+                hidden_states.dtype
+            )
+
+            # Batch conditional + unconditional for CFG
+            x_batched = torch.cat([x, x], dim=0)
+            llm_batched = torch.cat([hidden_states, hidden_zero], dim=0)
+            t_emb_batched = torch.cat([t_emb, t_emb], dim=0)
+
+            v_all = self._predict_velocity(x_batched, llm_batched, t_emb_batched)
+            v_cond, v_uncond = v_all[:B], v_all[B:]
+            v = _CFG_ALPHA * v_cond + (1 - _CFG_ALPHA) * v_uncond
+
+            x = x + v * dt
+
+        # Quantize to discrete codes
+        x = torch.clamp(x, -1, 1)
+        scaled = ((x + 1) / 2) * (self.acoustic_levels - 1)
+        acoustic_codes = scaled.round().long()
+        acoustic_codes[~should_decode] = _EMPTY_AUDIO_TOKEN_ID
+        acoustic_codes = acoustic_codes + _N_AUDIO_SPECIAL_TOKENS
+
+        return torch.cat([semantic_code, acoustic_codes], dim=1)
+
+
+# ---------------------------------------------------------------------------
+# Audio token embedding
+# ---------------------------------------------------------------------------
+
+
+class AudioTokenEmbedding(nn.Module):
+    """Multi-codebook embedding with per-codebook offsets, summed across codebooks."""
+
+    def __init__(self, config: VoxtralTTSConfig):
+        super().__init__()
+        # Codebook sizes with special tokens, no padding
+        sizes = [config.semantic_codebook_size + _N_AUDIO_SPECIAL_TOKENS] + [
+            config.acoustic_codebook_size + _N_AUDIO_SPECIAL_TOKENS
+        ] * config.n_acoustic_codebook
+        total = sum(sizes)
+        padded = _round_up(total, 128)
+
+        offsets = [0]
+        for s in sizes[:-1]:
+            offsets.append(offsets[-1] + s)
+        self.register_buffer("offsets", torch.tensor(offsets, dtype=torch.long))
+        self.embeddings = nn.Embedding(padded, config.dim)
+
+    def forward(self, codes: torch.Tensor) -> torch.Tensor:
+        """
+        Args:
+            codes: (B, n_codebooks, seq_len) integer audio codes.
+        Returns:
+            embeds: (B, seq_len, dim) summed across codebooks.
+        """
+        # Offset each codebook into the shared vocabulary.
+        # Explicit long cast ensures indices stay int64 (not promoted to bf16).
+        offset_codes = codes + self.offsets.long().unsqueeze(0).unsqueeze(2)
+        # (B, n_codebooks, seq_len, dim)
+        emb = self.embeddings(offset_codes)
+        # Sum across codebooks → (B, seq_len, dim)
+        return emb.sum(dim=1)
+
+
+# ---------------------------------------------------------------------------
+# Top-level model
+# ---------------------------------------------------------------------------
+
+
+class VoxtralTTSModel(nn.Module):
+    def __init__(self, config: VoxtralTTSConfig, max_seq_len: int):
+        super().__init__()
+        self.config = config
+        self.decoder = MistralDecoder(config, max_seq_len)
+        self.acoustic_transformer = FlowMatchingAudioTransformer(config)
+        self.audio_token_embedding = AudioTokenEmbedding(config)
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint loading
+# ---------------------------------------------------------------------------
+
+
+_KEY_MAP = {
+    # LM decoder
+    "layers.": "decoder.layers.",
+    "norm.weight": "decoder.norm.weight",
+    "output.weight": "decoder.output.weight",
+    # Token embeddings
+    "mm_audio_embeddings.tok_embeddings.weight": "decoder.tok_embeddings.weight",
+    # Audio token embedding
+    "mm_audio_embeddings.audio_codebook_embeddings.embeddings.weight": "audio_token_embedding.embeddings.weight",
+    "mm_audio_embeddings.audio_codebook_embeddings.embeddings.bias": "audio_token_embedding.embeddings.bias",
+    # Acoustic transformer (prefix stripped by load_weights)
+    "acoustic_transformer.": "acoustic_transformer.",
+}
+
+
+def _map_checkpoint_key(ckpt_key: str) -> str | None:
+    """Map a checkpoint key to the model state dict key."""
+    # Audio tokenizer weights (codec) — skip for model.pte
+    if ckpt_key.startswith("audio_tokenizer."):
+        return None
+
+    # Acoustic transformer: strip prefix
+    if ckpt_key.startswith("acoustic_transformer."):
+        return ckpt_key
+
+    # Audio embeddings
+    if ckpt_key.startswith("mm_audio_embeddings."):
+        for src, dst in _KEY_MAP.items():
+            if ckpt_key == src or ckpt_key.startswith(src):
+                return ckpt_key.replace(src, dst, 1)
+        return None
+
+    # LM decoder
+    if ckpt_key.startswith("layers."):
+        return "decoder." + ckpt_key
+
+    if ckpt_key == "norm.weight":
+        return "decoder.norm.weight"
+
+    if ckpt_key == "output.weight":
+        return "decoder.output.weight"
+
+    # Try direct mapping
+    return None
+
+
+def load_model(
+    model_path: str,
+    max_seq_len: int = 4096,
+    dtype: torch.dtype = torch.float32,
+    backend: str = "metal",
+) -> VoxtralTTSModel:
+    from safetensors import safe_open
+
+    model_dir = Path(model_path)
+    config = VoxtralTTSConfig.from_params_json(str(model_dir / "params.json"))
+    config.max_seq_len = max_seq_len
+    config.backend = backend
+
+    print(
+        f"VoxtralTTS config: dim={config.dim}, n_layers={config.n_layers}, "
+        f"at_dim={config.at_dim}, at_n_layers={config.at_n_layers}, "
+        f"n_acoustic_codebook={config.n_acoustic_codebook}, backend={backend}"
+    )
+
+    with torch.device("meta"):
+        model = VoxtralTTSModel(config, max_seq_len)
+
+    ckpt_path = str(model_dir / "consolidated.safetensors")
+    state_dict = {}
+    with safe_open(ckpt_path, framework="pt", device="cpu") as f:
+        for ckpt_key in f.keys():
+            model_key = _map_checkpoint_key(ckpt_key)
+            if model_key is None:
+                continue
+            state_dict[model_key] = f.get_tensor(ckpt_key).to(dtype)
+
+    missing, unexpected = model.load_state_dict(state_dict, strict=False, assign=True)
+
+    # Re-tie output weights
+    model.decoder.output.weight = model.decoder.tok_embeddings.weight
+
+    # Materialize remaining meta buffers (KV caches, etc.)
+    # Preserve original dtype — int64 index buffers must not become bf16.
+    for fqn, buf in list(model.named_buffers()):
+        if buf.device.type == "meta":
+            parts = fqn.rsplit(".", 1)
+            parent = model.get_submodule(parts[0]) if len(parts) > 1 else model
+            buf_dtype = buf.dtype if not buf.dtype.is_floating_point else dtype
+            parent.register_buffer(
+                parts[-1], torch.zeros(buf.shape, dtype=buf_dtype, device="cpu")
+            )
+
+    # Recompute RoPE
+    dec_cos, dec_sin = precompute_freqs_cis(
+        config.head_dim, max_seq_len, config.rope_theta
+    )
+    model.decoder.register_buffer("freqs_cos", dec_cos)
+    model.decoder.register_buffer("freqs_sin", dec_sin)
+
+    # Recompute flow matching timesteps (persistent=False, lost during meta construction)
+    model.acoustic_transformer.register_buffer(
+        "timesteps",
+        torch.linspace(0, 1, _ACOUSTIC_DECODE_ITERS),
+        persistent=False,
+    )
+
+    # Recompute audio token embedding offsets (lost during meta construction)
+    sizes = [config.semantic_codebook_size + _N_AUDIO_SPECIAL_TOKENS] + [
+        config.acoustic_codebook_size + _N_AUDIO_SPECIAL_TOKENS
+    ] * config.n_acoustic_codebook
+    offsets = [0]
+    for s in sizes[:-1]:
+        offsets.append(offsets[-1] + s)
+    model.audio_token_embedding.register_buffer(
+        "offsets", torch.tensor(offsets, dtype=torch.long)
+    )
+
+    if missing:
+        print(f"  Missing keys ({len(missing)}): {missing[:5]}...")
+    if unexpected:
+        print(f"  Unexpected keys ({len(unexpected)}): {unexpected[:5]}...")
+
+    model.eval()
+    return model

--- a/examples/models/voxtral_tts/model.py
+++ b/examples/models/voxtral_tts/model.py
@@ -32,7 +32,7 @@ from executorch.extension.llm.custom_ops import custom_ops as _custom_ops  # noq
 _N_AUDIO_SPECIAL_TOKENS = 2  # [EMPTY_AUDIO]=0, [END_AUDIO]=1
 _EMPTY_AUDIO_TOKEN_ID = 0
 _END_AUDIO_TOKEN_ID = 1
-_ACOUSTIC_DECODE_ITERS = 8
+_N_FLOW_TIMESTEPS = 8
 _CFG_ALPHA = 1.2
 _NOISE_SCALE = 1.0
 
@@ -246,6 +246,7 @@ def _build_attn_mask(
     return (valid.to(dtype) - 1.0) * 1e9
 
 
+
 # ---------------------------------------------------------------------------
 # SDPA variants
 # ---------------------------------------------------------------------------
@@ -310,6 +311,7 @@ class MetalSDPA(nn.Module):
         )
         y = y.transpose(1, 2).contiguous()
         return y.view(bsz, seqlen, self.dim)
+
 
 
 # ---------------------------------------------------------------------------
@@ -555,7 +557,7 @@ class FlowMatchingAudioTransformer(nn.Module):
         # Flow matching timesteps
         self.register_buffer(
             "timesteps",
-            torch.linspace(0, 1, _ACOUSTIC_DECODE_ITERS),
+            torch.linspace(0, 1, _N_FLOW_TIMESTEPS),
             persistent=False,
         )
 
@@ -812,7 +814,7 @@ def load_model(
     # Recompute flow matching timesteps (persistent=False, lost during meta construction)
     model.acoustic_transformer.register_buffer(
         "timesteps",
-        torch.linspace(0, 1, _ACOUSTIC_DECODE_ITERS),
+        torch.linspace(0, 1, _N_FLOW_TIMESTEPS),
         persistent=False,
     )
 

--- a/examples/models/voxtral_tts/voxtral_tts_runner.cpp
+++ b/examples/models/voxtral_tts/voxtral_tts_runner.cpp
@@ -250,94 +250,74 @@ std::vector<float> VoxtralTTSRunner::generate(
 
   // --- Prefill: process all prompt tokens ---
   ET_LOG(Info, "Prefilling %ld tokens...", static_cast<long>(prompt_len));
-  {
-    auto ids_tensor = from_blob(
-        tokens.data(),
-        {1, static_cast<int>(prompt_len)},
-        ::executorch::aten::ScalarType::Long);
-    auto tok_result =
-        model_->execute("token_embedding", std::vector<EValue>{*ids_tensor});
-    ET_CHECK_MSG(tok_result.ok(), "token_embedding (prefill) failed.");
-    auto embeds = tok_result.get()[0].toTensor();
+  auto ids_tensor = from_blob(
+      tokens.data(),
+      {1, static_cast<int>(prompt_len)},
+      ::executorch::aten::ScalarType::Long);
+  auto tok_result =
+      model_->execute("token_embedding", std::vector<EValue>{*ids_tensor});
+  ET_CHECK_MSG(tok_result.ok(), "token_embedding (prefill) failed.");
+  auto embeds = tok_result.get()[0].toTensor();
 
-    // Inject voice embeddings at audio token positions [voice_start, voice_end)
-    if (n_voice_frames_ > 0 && !voice_data_.empty()) {
-      const size_t elem_size = embeds.element_size();
-      for (int64_t i = voice_start; i < voice_end; i++) {
-        const int64_t voice_idx = i - voice_start;
-        const float* src = voice_data_.data() + voice_idx * dim_;
-        char* dst = static_cast<char*>(embeds.mutable_data_ptr()) +
-            static_cast<size_t>(i * dim_) * elem_size;
-        if (model_dtype_ == ::executorch::aten::ScalarType::BFloat16) {
-          auto* dst_bf16 = reinterpret_cast<::executorch::aten::BFloat16*>(dst);
-          for (int64_t d = 0; d < dim_; d++) {
-            dst_bf16[d] = ::executorch::aten::BFloat16(src[d]);
-          }
-        } else {
-          std::memcpy(dst, src, static_cast<size_t>(dim_) * sizeof(float));
+  // Inject voice embeddings at audio token positions [voice_start, voice_end)
+  if (n_voice_frames_ > 0 && !voice_data_.empty()) {
+    const size_t elem_size = embeds.element_size();
+    for (int64_t i = voice_start; i < voice_end; i++) {
+      const int64_t voice_idx = i - voice_start;
+      const float* src = voice_data_.data() + voice_idx * dim_;
+      char* dst = static_cast<char*>(embeds.mutable_data_ptr()) +
+          static_cast<size_t>(i * dim_) * elem_size;
+      if (model_dtype_ == ::executorch::aten::ScalarType::BFloat16) {
+        auto* dst_bf16 = reinterpret_cast<::executorch::aten::BFloat16*>(dst);
+        for (int64_t d = 0; d < dim_; d++) {
+          dst_bf16[d] = ::executorch::aten::BFloat16(src[d]);
         }
+      } else {
+        std::memcpy(dst, src, static_cast<size_t>(dim_) * sizeof(float));
       }
-      ET_LOG(
-          Info,
-          "Injected %ld voice frames at positions [%ld, %ld)",
-          static_cast<long>(n_voice_frames_),
-          static_cast<long>(voice_start),
-          static_cast<long>(voice_end));
     }
-
-    // Position tensor [0, 1, ..., prompt_len-1]
-    std::vector<int64_t> pos_vec(static_cast<size_t>(prompt_len));
-    for (int64_t i = 0; i < prompt_len; i++)
-      pos_vec[static_cast<size_t>(i)] = i;
-    auto pos_tensor = from_blob(
-        pos_vec.data(),
-        {static_cast<int>(prompt_len)},
-        ::executorch::aten::ScalarType::Long);
-
-    auto dec_result = model_->execute(
-        "text_decoder", std::vector<EValue>{embeds, *pos_tensor});
-    ET_CHECK_MSG(dec_result.ok(), "text_decoder (prefill) failed.");
-
-    dec_pos = prompt_len;
-    ET_LOG(Info, "Prefill done.");
+    ET_LOG(
+        Info,
+        "Injected %ld voice frames at positions [%ld, %ld)",
+        static_cast<long>(n_voice_frames_),
+        static_cast<long>(voice_start),
+        static_cast<long>(voice_end));
   }
 
+  // Position tensor [0, 1, ..., prompt_len-1]
+  std::vector<int64_t> pos_vec(static_cast<size_t>(prompt_len));
+  for (int64_t i = 0; i < prompt_len; i++)
+    pos_vec[static_cast<size_t>(i)] = i;
+  auto pos_tensor = from_blob(
+      pos_vec.data(),
+      {static_cast<int>(prompt_len)},
+      ::executorch::aten::ScalarType::Long);
+
+  auto dec_result =
+      model_->execute("text_decoder", std::vector<EValue>{embeds, *pos_tensor});
+  ET_CHECK_MSG(dec_result.ok(), "text_decoder (prefill) failed.");
+  auto prefill_hidden = dec_result.get()[0].toTensor();
+
+  dec_pos = prompt_len;
+  ET_LOG(Info, "Prefill done.");
+
   // --- Audio generation loop ---
-  // After the prompt ends with [BEGIN_AUDIO], every step:
-  // 1. Extract hidden state from text_decoder
-  // 2. Run decode_audio_frame → audio codes + check semantic code for EOS
-  // 3. Feed audio token (24) back to text_decoder for next step
-  // The LM head is NOT used — the acoustic transformer drives generation.
-  // END_AUDIO (semantic code == 1) signals end of audio.
+  // vLLM's flow: AT runs on the prefill's last hidden state for frame 0,
+  // then each subsequent frame feeds audio_token_embedding(prev_codes)
+  // through the decoder. The LM head is NOT used.
   constexpr int64_t END_AUDIO_SEMANTIC = 1;
 
   ET_LOG(Info, "Generating audio (max %d frames)...", config.max_tokens);
 
   // Pad to 3 tokens for Metal SDPA compatibility (requires seq_len >= 3).
-  // Positions [dec_pos, dec_pos+1, dec_pos+2] — we advance by 1 per step
-  // but present 3 positions to satisfy Metal's min seq_len. Only position 0's
-  // hidden state is used. The padding positions get overwritten next step.
   constexpr int DECODE_SEQ_LEN = 3;
-
-  // First step uses plain token_embedding(audio_tok) since there are no
-  // previous audio codes yet. Subsequent steps use audio_token_embedding
-  // on the previous step's codes (multi-codebook sum), matching vLLM's
-  // tts_preprocess which calls embed_multimodal(audio_tokens).
-  int64_t audio_tok = static_cast<int64_t>(audio_tok_id_);
-  auto audio_tok_t =
-      from_blob(&audio_tok, {1, 1}, ::executorch::aten::ScalarType::Long);
-  auto audio_tok_result =
-      model_->execute("token_embedding", std::vector<EValue>{*audio_tok_t});
-  ET_CHECK_MSG(audio_tok_result.ok(), "token_embedding(audio) failed.");
-  auto first_embed = audio_tok_result.get()[0].toTensor();
   const size_t embed_bytes =
-      static_cast<size_t>(dim_) * first_embed.element_size();
+      static_cast<size_t>(dim_) * prefill_hidden.element_size();
 
   // Build padded embedding buffer (updated each step)
   auto audio_step_embeds =
       empty({1, DECODE_SEQ_LEN, static_cast<int>(dim_)}, model_dtype_);
 
-  // Helper to fill all DECODE_SEQ_LEN slots with the same embedding
   auto fill_step_embeds = [&](const void* src) {
     for (int i = 0; i < DECODE_SEQ_LEN; i++) {
       std::memcpy(
@@ -348,34 +328,10 @@ std::vector<float> VoxtralTTSRunner::generate(
     }
   };
 
-  // Initialize with token_embedding(24) for the first step
-  fill_step_embeds(first_embed.const_data_ptr());
-
-  for (int step = 0; step < config.max_tokens && dec_pos < max_seq_len_;
-       step++) {
-    // 1. Run text_decoder with current step's embedding
-    std::vector<int64_t> pos_data = {dec_pos, dec_pos + 1, dec_pos + 2};
-    auto pos_tensor = from_blob(
-        pos_data.data(),
-        {DECODE_SEQ_LEN},
-        ::executorch::aten::ScalarType::Long);
-    auto dec_result = model_->execute(
-        "text_decoder", std::vector<EValue>{*audio_step_embeds, *pos_tensor});
-    ET_CHECK_MSG(
-        dec_result.ok(),
-        "text_decoder failed at pos %ld.",
-        static_cast<long>(dec_pos));
-    auto hidden = dec_result.get()[0].toTensor();
-    dec_pos++;
-
-    // 2. Extract first position's hidden state: (1, DECODE_SEQ_LEN, dim) -> (1,
-    // dim)
-    auto h_2d = empty({1, static_cast<int>(dim_)}, model_dtype_);
-    std::memcpy(
-        h_2d->mutable_data_ptr(),
-        hidden.const_data_ptr(),
-        static_cast<size_t>(dim_) * hidden.element_size());
-
+  // Frame 0: use the prefill's last hidden state directly (no decode step).
+  // This matches vLLM's make_omni_output which runs AT on hidden[logits_index]
+  // during the prefill step itself, before any decode step occurs.
+  auto generate_frame = [&](const ::executorch::aten::Tensor& h_2d) {
     // Generate noise
     auto noise_tensor =
         empty({1, static_cast<int>(n_acoustic_codebook_)}, model_dtype_);
@@ -392,13 +348,29 @@ std::vector<float> VoxtralTTSRunner::generate(
       }
     }
 
-    // 3. Run acoustic transformer
     auto frame_result = model_->execute(
         "decode_audio_frame", std::vector<EValue>{*h_2d, *noise_tensor});
     ET_CHECK_MSG(frame_result.ok(), "decode_audio_frame failed.");
-    auto codes_tensor = frame_result.get()[0].toTensor();
-    const auto* codes_ptr = codes_tensor.const_data_ptr<int64_t>();
+    return frame_result.get()[0].toTensor();
+  };
 
+  // Extract prefill's last hidden: (1, prompt_len, dim) -> (1, dim)
+  auto h_2d = empty({1, static_cast<int>(dim_)}, model_dtype_);
+  {
+    const size_t last_pos_offset =
+        static_cast<size_t>(prompt_len - 1) * embed_bytes;
+    std::memcpy(
+        h_2d->mutable_data_ptr(),
+        static_cast<const char*>(prefill_hidden.const_data_ptr()) +
+            last_pos_offset,
+        embed_bytes);
+  }
+
+  auto codes_tensor = generate_frame(*h_2d);
+  const auto* codes_ptr = codes_tensor.const_data_ptr<int64_t>();
+
+  for (int step = 0; step < config.max_tokens && dec_pos < max_seq_len_;
+       step++) {
     // Check semantic code (first element) for END_AUDIO
     int64_t semantic_code = codes_ptr[0];
     if (semantic_code == END_AUDIO_SEMANTIC) {
@@ -417,9 +389,7 @@ std::vector<float> VoxtralTTSRunner::generate(
       token_cb("");
     }
 
-    // 4. Prepare next step's embedding via audio_token_embedding.
-    // Reshape codes from (1, n_codebooks) to (1, n_codebooks, 1) for the
-    // multi-codebook embedding lookup, then pad to DECODE_SEQ_LEN.
+    // Feed codes back through audio_token_embedding for next decode step.
     std::vector<int64_t> codes_col(static_cast<size_t>(n_codebooks_));
     for (int64_t i = 0; i < n_codebooks_; i++) {
       codes_col[static_cast<size_t>(i)] = codes_ptr[i];
@@ -431,8 +401,29 @@ std::vector<float> VoxtralTTSRunner::generate(
     auto ate_result = model_->execute(
         "audio_token_embedding", std::vector<EValue>{*codes_3d});
     ET_CHECK_MSG(ate_result.ok(), "audio_token_embedding failed.");
-    auto next_embed = ate_result.get()[0].toTensor(); // (1, 1, dim)
+    auto next_embed = ate_result.get()[0].toTensor();
     fill_step_embeds(next_embed.const_data_ptr());
+
+    // Run text_decoder to get hidden state for next frame
+    std::vector<int64_t> pos_data = {dec_pos, dec_pos + 1, dec_pos + 2};
+    auto pos_tensor = from_blob(
+        pos_data.data(),
+        {DECODE_SEQ_LEN},
+        ::executorch::aten::ScalarType::Long);
+    auto dec_result = model_->execute(
+        "text_decoder", std::vector<EValue>{*audio_step_embeds, *pos_tensor});
+    ET_CHECK_MSG(
+        dec_result.ok(),
+        "text_decoder failed at pos %ld.",
+        static_cast<long>(dec_pos));
+    auto hidden = dec_result.get()[0].toTensor();
+    dec_pos++;
+
+    // Extract first position's hidden state for next AT call
+    std::memcpy(h_2d->mutable_data_ptr(), hidden.const_data_ptr(), embed_bytes);
+
+    codes_tensor = generate_frame(*h_2d);
+    codes_ptr = codes_tensor.const_data_ptr<int64_t>();
   }
 
   ET_LOG(

--- a/examples/models/voxtral_tts/voxtral_tts_runner.cpp
+++ b/examples/models/voxtral_tts/voxtral_tts_runner.cpp
@@ -241,15 +241,11 @@ std::vector<float> VoxtralTTSRunner::generate(
   std::mt19937 noise_rng(static_cast<unsigned int>(config.seed));
   std::normal_distribution<float> noise_dist(0.0f, 1.0f);
 
-  std::vector<float> logits_buf;
-  auto input_embeds = empty({1, 1, static_cast<int>(dim_)}, model_dtype_);
-
   // Accumulated audio codes: flat buffer, n_codebooks values per frame
   std::vector<int64_t> all_codes;
   int64_t num_audio_frames = 0;
 
   int64_t dec_pos = 0;
-  uint64_t prev_token = bos_id_;
   int num_generated = 0;
 
   // --- Prefill: process all prompt tokens ---
@@ -301,10 +297,6 @@ std::vector<float> VoxtralTTSRunner::generate(
     auto dec_result = model_->execute(
         "text_decoder", std::vector<EValue>{embeds, *pos_tensor});
     ET_CHECK_MSG(dec_result.ok(), "text_decoder (prefill) failed.");
-
-    auto hidden = dec_result.get()[0].toTensor();
-    dec_pos = prompt_len;
-    prev_token = static_cast<uint64_t>(tokens.back());
 
     dec_pos = prompt_len;
     ET_LOG(Info, "Prefill done.");
@@ -415,7 +407,7 @@ std::vector<float> VoxtralTTSRunner::generate(
     num_audio_frames++;
     num_generated++;
 
-    if (token_cb && num_generated % 100 == 0) {
+    if (token_cb) {
       token_cb("");
     }
   }
@@ -455,10 +447,11 @@ std::vector<float> VoxtralTTSRunner::decode_audio(
     int64_t this_chunk = std::min(chunk, n_frames - start);
 
     // Pad to full chunk if needed.
-    // Strip _N_AUDIO_SPECIAL_TOKENS (2) offset from acoustic codes:
-    // decode_one_frame outputs acoustic codes in [2, acoustic_levels+1] for
-    // audio_token_embedding compatibility, but the codec expects raw [0,
-    // levels-1].
+    // Strip _N_AUDIO_SPECIAL_TOKENS (2) offset from all codes:
+    // decode_one_frame outputs codes with special token offset (semantic
+    // argmax includes EMPTY=0/END=1 positions, acoustic codes are shifted
+    // by +2). The codec expects raw indices: semantic in [0, codebook_size)
+    // and acoustic in [0, levels-1].
     constexpr int64_t N_SPECIAL = 2;
     std::vector<int64_t> chunk_codes(
         static_cast<size_t>(chunk * n_codebooks_), 0);
@@ -466,10 +459,7 @@ std::vector<float> VoxtralTTSRunner::decode_audio(
       for (int64_t c = 0; c < n_codebooks_; c++) {
         int64_t code =
             codes[static_cast<size_t>((start + f) * n_codebooks_ + c)];
-        if (c > 0) {
-          // Acoustic codes: strip special token offset
-          code -= N_SPECIAL;
-        }
+        code -= N_SPECIAL;
         chunk_codes[static_cast<size_t>(c * chunk + f)] = code;
       }
     }

--- a/examples/models/voxtral_tts/voxtral_tts_runner.cpp
+++ b/examples/models/voxtral_tts/voxtral_tts_runner.cpp
@@ -313,39 +313,47 @@ std::vector<float> VoxtralTTSRunner::generate(
 
   ET_LOG(Info, "Generating audio (max %d frames)...", config.max_tokens);
 
-  // Pre-embed the audio token once (reused every step).
   // Pad to 3 tokens for Metal SDPA compatibility (requires seq_len >= 3).
-  // Positions [dec_pos-2, dec_pos-1, dec_pos] — only last position's hidden
-  // state is used. The first two are padding (same embedding, earlier positions
-  // already in KV cache — the causal mask prevents them from affecting output).
+  // Positions [dec_pos, dec_pos+1, dec_pos+2] — we advance by 1 per step
+  // but present 3 positions to satisfy Metal's min seq_len. Only position 0's
+  // hidden state is used. The padding positions get overwritten next step.
   constexpr int DECODE_SEQ_LEN = 3;
+
+  // First step uses plain token_embedding(audio_tok) since there are no
+  // previous audio codes yet. Subsequent steps use audio_token_embedding
+  // on the previous step's codes (multi-codebook sum), matching vLLM's
+  // tts_preprocess which calls embed_multimodal(audio_tokens).
   int64_t audio_tok = static_cast<int64_t>(audio_tok_id_);
   auto audio_tok_t =
       from_blob(&audio_tok, {1, 1}, ::executorch::aten::ScalarType::Long);
   auto audio_tok_result =
       model_->execute("token_embedding", std::vector<EValue>{*audio_tok_t});
   ET_CHECK_MSG(audio_tok_result.ok(), "token_embedding(audio) failed.");
-  auto audio_embed_ref = audio_tok_result.get()[0].toTensor();
+  auto first_embed = audio_tok_result.get()[0].toTensor();
   const size_t embed_bytes =
-      static_cast<size_t>(dim_) * audio_embed_ref.element_size();
+      static_cast<size_t>(dim_) * first_embed.element_size();
 
-  // Build padded embedding: repeat the audio token embedding 3 times
+  // Build padded embedding buffer (updated each step)
   auto audio_step_embeds =
       empty({1, DECODE_SEQ_LEN, static_cast<int>(dim_)}, model_dtype_);
-  for (int i = 0; i < DECODE_SEQ_LEN; i++) {
-    std::memcpy(
-        static_cast<char*>(audio_step_embeds->mutable_data_ptr()) +
-            static_cast<size_t>(i) * embed_bytes,
-        audio_embed_ref.const_data_ptr(),
-        embed_bytes);
-  }
+
+  // Helper to fill all DECODE_SEQ_LEN slots with the same embedding
+  auto fill_step_embeds = [&](const void* src) {
+    for (int i = 0; i < DECODE_SEQ_LEN; i++) {
+      std::memcpy(
+          static_cast<char*>(audio_step_embeds->mutable_data_ptr()) +
+              static_cast<size_t>(i) * embed_bytes,
+          src,
+          embed_bytes);
+    }
+  };
+
+  // Initialize with token_embedding(24) for the first step
+  fill_step_embeds(first_embed.const_data_ptr());
 
   for (int step = 0; step < config.max_tokens && dec_pos < max_seq_len_;
        step++) {
-    // 1. Run text_decoder with padded audio token embedding
-    // Positions: [dec_pos, dec_pos+1, dec_pos+2] — we advance by 1 per step
-    // but present 3 positions to satisfy Metal's min seq_len.
-    // The KV cache at dec_pos+1 and dec_pos+2 will be overwritten next steps.
+    // 1. Run text_decoder with current step's embedding
     std::vector<int64_t> pos_data = {dec_pos, dec_pos + 1, dec_pos + 2};
     auto pos_tensor = from_blob(
         pos_data.data(),
@@ -360,10 +368,8 @@ std::vector<float> VoxtralTTSRunner::generate(
     auto hidden = dec_result.get()[0].toTensor();
     dec_pos++;
 
-    // 2. Extract hidden (1,1,dim) -> (1,dim) for acoustic transformer
-    // Extract the FIRST position's hidden state (index 0 of DECODE_SEQ_LEN).
-    // hidden is (1, DECODE_SEQ_LEN, dim). Position 0 corresponds to dec_pos-1
-    // (the actual current position after dec_pos++ above).
+    // 2. Extract first position's hidden state: (1, DECODE_SEQ_LEN, dim) -> (1,
+    // dim)
     auto h_2d = empty({1, static_cast<int>(dim_)}, model_dtype_);
     std::memcpy(
         h_2d->mutable_data_ptr(),
@@ -410,6 +416,23 @@ std::vector<float> VoxtralTTSRunner::generate(
     if (token_cb) {
       token_cb("");
     }
+
+    // 4. Prepare next step's embedding via audio_token_embedding.
+    // Reshape codes from (1, n_codebooks) to (1, n_codebooks, 1) for the
+    // multi-codebook embedding lookup, then pad to DECODE_SEQ_LEN.
+    std::vector<int64_t> codes_col(static_cast<size_t>(n_codebooks_));
+    for (int64_t i = 0; i < n_codebooks_; i++) {
+      codes_col[static_cast<size_t>(i)] = codes_ptr[i];
+    }
+    auto codes_3d = from_blob(
+        codes_col.data(),
+        {1, static_cast<int>(n_codebooks_), 1},
+        ::executorch::aten::ScalarType::Long);
+    auto ate_result = model_->execute(
+        "audio_token_embedding", std::vector<EValue>{*codes_3d});
+    ET_CHECK_MSG(ate_result.ok(), "audio_token_embedding failed.");
+    auto next_embed = ate_result.get()[0].toTensor(); // (1, 1, dim)
+    fill_step_embeds(next_embed.const_data_ptr());
   }
 
   ET_LOG(

--- a/examples/models/voxtral_tts/voxtral_tts_runner.cpp
+++ b/examples/models/voxtral_tts/voxtral_tts_runner.cpp
@@ -1,0 +1,565 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "voxtral_tts_runner.h"
+
+#include <cstring>
+#include <ctime>
+#include <fstream>
+
+#include <executorch/extension/llm/runner/llm_runner_helper.h>
+#include <executorch/extension/llm/runner/util.h>
+#include <executorch/extension/tensor/tensor_ptr_maker.h>
+#include <executorch/runtime/core/evalue.h>
+#include <executorch/runtime/platform/log.h>
+
+using ::executorch::extension::empty;
+using ::executorch::extension::from_blob;
+using ::executorch::extension::Module;
+using ::executorch::extension::TensorPtr;
+using ::executorch::runtime::Error;
+using ::executorch::runtime::EValue;
+
+namespace voxtral_tts {
+
+// ---------------------------------------------------------------------------
+// Constructor
+// ---------------------------------------------------------------------------
+
+VoxtralTTSRunner::VoxtralTTSRunner(
+    const std::string& model_path,
+    const std::string& tokenizer_path,
+    const std::string& codec_path,
+    bool warmup) {
+  // Load model.pte
+  ET_LOG(Info, "Loading model from: %s", model_path.c_str());
+  model_ = std::make_unique<Module>(model_path, Module::LoadMode::Mmap);
+  auto load_err = model_->load();
+  ET_CHECK_MSG(load_err == Error::Ok, "Failed to load model.");
+
+  // Read metadata constants
+  std::vector<EValue> empty_args;
+  auto ms = model_->execute("max_seq_len", empty_args);
+  auto vs = model_->execute("vocab_size", empty_args);
+  auto dm = model_->execute("dim", empty_args);
+  auto nac = model_->execute("n_acoustic_codebook", empty_args);
+
+  if (ms.ok())
+    max_seq_len_ = ms.get()[0].toInt();
+  if (vs.ok())
+    vocab_size_ = vs.get()[0].toInt();
+  if (dm.ok())
+    dim_ = dm.get()[0].toInt();
+  if (nac.ok())
+    n_acoustic_codebook_ = nac.get()[0].toInt();
+  n_codebooks_ = 1 + n_acoustic_codebook_;
+
+  // Detect model dtype from text_decoder input
+  auto meta_result = model_->method_meta("text_decoder");
+  if (meta_result.ok()) {
+    auto meta = meta_result.get();
+    if (meta.num_inputs() > 0) {
+      auto input_meta = meta.input_tensor_meta(0);
+      if (input_meta.ok()) {
+        model_dtype_ = input_meta.get().scalar_type();
+      }
+    }
+  }
+
+  ET_LOG(
+      Info,
+      "Model: max_seq_len=%ld, vocab=%ld, dim=%ld, n_codebooks=%ld, dtype=%s",
+      static_cast<long>(max_seq_len_),
+      static_cast<long>(vocab_size_),
+      static_cast<long>(dim_),
+      static_cast<long>(n_codebooks_),
+      ::executorch::runtime::toString(model_dtype_));
+
+  // Load codec.pte (optional)
+  if (!codec_path.empty()) {
+    ET_LOG(Info, "Loading codec from: %s", codec_path.c_str());
+    codec_ = std::make_unique<Module>(codec_path, Module::LoadMode::Mmap);
+    auto codec_err = codec_->load();
+    ET_CHECK_MSG(codec_err == Error::Ok, "Failed to load codec.");
+
+    auto sr = codec_->execute("sampling_rate", empty_args);
+    auto cs = codec_->execute("chunk_size", empty_args);
+    auto nc = codec_->execute("n_codebooks", empty_args);
+    if (sr.ok())
+      sample_rate_ = sr.get()[0].toInt();
+    if (cs.ok())
+      codec_chunk_size_ = cs.get()[0].toInt();
+    if (nc.ok())
+      n_codebooks_ = nc.get()[0].toInt();
+    ET_LOG(
+        Info,
+        "Codec: sample_rate=%ld, chunk_size=%ld",
+        static_cast<long>(sample_rate_),
+        static_cast<long>(codec_chunk_size_));
+  }
+
+  // Load tokenizer
+  tokenizer_ = ::executorch::extension::llm::load_tokenizer(tokenizer_path);
+  bos_id_ = tokenizer_->bos_tok();
+  eos_id_ = tokenizer_->eos_tok();
+  ET_LOG(Info, "Tokenizer: bos=%lu, eos=%lu", bos_id_, eos_id_);
+
+  // Audio token ID from metadata, or default to 24 (Tekken special_ids.audio).
+  auto at = model_->execute("audio_tok_id", empty_args);
+  if (at.ok()) {
+    audio_tok_id_ = static_cast<uint64_t>(at.get()[0].toInt());
+  } else {
+    audio_tok_id_ = 24; // Mistral Tekken default
+  }
+  ET_LOG(Info, "Audio token ID: %lu", audio_tok_id_);
+
+  // Warmup: call each method once with minimal inputs
+  if (warmup) {
+    ET_LOG(Info, "Warming up...");
+    // token_embedding
+    {
+      int64_t tok = 0;
+      auto t = from_blob(&tok, {1, 1}, ::executorch::aten::ScalarType::Long);
+      model_->execute("token_embedding", std::vector<EValue>{*t});
+    }
+    // text_decoder
+    {
+      auto e = empty({1, 4, static_cast<int>(dim_)}, model_dtype_);
+      std::vector<int64_t> pos_data = {0, 1, 2, 3};
+      auto p =
+          from_blob(pos_data.data(), {4}, ::executorch::aten::ScalarType::Long);
+      model_->execute("text_decoder", std::vector<EValue>{*e, *p});
+    }
+    // lm_head
+    {
+      auto h = empty({1, 1, static_cast<int>(dim_)}, model_dtype_);
+      model_->execute("lm_head", std::vector<EValue>{*h});
+    }
+    // decode_audio_frame
+    {
+      auto h = empty({1, static_cast<int>(dim_)}, model_dtype_);
+      auto n = empty({1, static_cast<int>(n_acoustic_codebook_)}, model_dtype_);
+      model_->execute("decode_audio_frame", std::vector<EValue>{*h, *n});
+    }
+    // audio_token_embedding
+    {
+      auto c = empty(
+          {1, static_cast<int>(n_codebooks_), 1},
+          ::executorch::aten::ScalarType::Long);
+      model_->execute("audio_token_embedding", std::vector<EValue>{*c});
+    }
+    ET_LOG(Info, "Warmup complete.");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Voice embedding
+// ---------------------------------------------------------------------------
+
+void VoxtralTTSRunner::load_voice(const std::string& voice_bin_path) {
+  std::ifstream f(voice_bin_path, std::ios::binary);
+  ET_CHECK_MSG(
+      f.is_open(), "Cannot open voice file: %s", voice_bin_path.c_str());
+
+  int64_t n_frames, dim;
+  f.read(reinterpret_cast<char*>(&n_frames), sizeof(n_frames));
+  f.read(reinterpret_cast<char*>(&dim), sizeof(dim));
+  ET_CHECK_MSG(
+      dim == dim_,
+      "Voice dim %ld != model dim %ld",
+      static_cast<long>(dim),
+      static_cast<long>(dim_));
+
+  voice_data_.resize(static_cast<size_t>(n_frames * dim));
+  f.read(
+      reinterpret_cast<char*>(voice_data_.data()),
+      static_cast<std::streamsize>(n_frames * dim * sizeof(float)));
+  n_voice_frames_ = n_frames;
+  ET_LOG(
+      Info,
+      "Loaded voice: %ld frames x %ld dim from %s",
+      static_cast<long>(n_frames),
+      static_cast<long>(dim),
+      voice_bin_path.c_str());
+}
+
+// ---------------------------------------------------------------------------
+// Generate
+// ---------------------------------------------------------------------------
+
+std::vector<float> VoxtralTTSRunner::generate(
+    const std::string& prompt,
+    const GenerateConfig& config,
+    TokenCallback token_cb,
+    std::vector<int64_t>* audio_codes_out) {
+  // Encode prompt
+  auto encode_result = tokenizer_->encode(prompt);
+  ET_CHECK_MSG(encode_result.ok(), "Failed to encode prompt.");
+  auto prompt_tokens = encode_result.get();
+
+  // Build TTS prompt matching mistral_common's encode_speech_request format:
+  // [BOS] [BEGIN_AUDIO] [AUDIO]×n_voice [/INST] text [INST] [BEGIN_AUDIO]
+  // Tekken special token IDs: INST=35, /INST=36, BEGIN_AUDIO=25, AUDIO=24
+  constexpr int64_t INST_TOK = 35;
+  constexpr int64_t END_INST_TOK = 36;
+  constexpr int64_t BEGIN_AUDIO_TOK = 25;
+
+  // Voice context: use loaded voice embedding frames, or 10 dummy tokens
+  const int64_t n_voice = n_voice_frames_ > 0 ? n_voice_frames_ : 10;
+
+  std::vector<int64_t> tokens;
+  tokens.push_back(static_cast<int64_t>(bos_id_));
+  tokens.push_back(BEGIN_AUDIO_TOK);
+  const int64_t voice_start = static_cast<int64_t>(tokens.size());
+  for (int64_t i = 0; i < n_voice; i++) {
+    tokens.push_back(static_cast<int64_t>(audio_tok_id_));
+  }
+  const int64_t voice_end = static_cast<int64_t>(tokens.size());
+  tokens.push_back(END_INST_TOK);
+  for (auto t : prompt_tokens) {
+    tokens.push_back(static_cast<int64_t>(t));
+  }
+  tokens.push_back(INST_TOK);
+  tokens.push_back(BEGIN_AUDIO_TOK);
+  const int64_t prompt_len = static_cast<int64_t>(tokens.size());
+  ET_LOG(
+      Info,
+      "Prompt: %ld tokens (including BOS)",
+      static_cast<long>(prompt_len));
+
+  // Setup sampler and noise RNG
+  ::executorch::extension::llm::Sampler sampler(
+      static_cast<int32_t>(vocab_size_),
+      config.temperature,
+      ::executorch::extension::llm::kTopp,
+      static_cast<unsigned long long>(config.seed));
+  std::mt19937 noise_rng(static_cast<unsigned int>(config.seed));
+  std::normal_distribution<float> noise_dist(0.0f, 1.0f);
+
+  std::vector<float> logits_buf;
+  auto input_embeds = empty({1, 1, static_cast<int>(dim_)}, model_dtype_);
+
+  // Accumulated audio codes: flat buffer, n_codebooks values per frame
+  std::vector<int64_t> all_codes;
+  int64_t num_audio_frames = 0;
+
+  int64_t dec_pos = 0;
+  uint64_t prev_token = bos_id_;
+  int num_generated = 0;
+
+  // --- Prefill: process all prompt tokens ---
+  ET_LOG(Info, "Prefilling %ld tokens...", static_cast<long>(prompt_len));
+  {
+    auto ids_tensor = from_blob(
+        tokens.data(),
+        {1, static_cast<int>(prompt_len)},
+        ::executorch::aten::ScalarType::Long);
+    auto tok_result =
+        model_->execute("token_embedding", std::vector<EValue>{*ids_tensor});
+    ET_CHECK_MSG(tok_result.ok(), "token_embedding (prefill) failed.");
+    auto embeds = tok_result.get()[0].toTensor();
+
+    // Inject voice embeddings at audio token positions [voice_start, voice_end)
+    if (n_voice_frames_ > 0 && !voice_data_.empty()) {
+      const size_t elem_size = embeds.element_size();
+      for (int64_t i = voice_start; i < voice_end; i++) {
+        const int64_t voice_idx = i - voice_start;
+        const float* src = voice_data_.data() + voice_idx * dim_;
+        char* dst = static_cast<char*>(embeds.mutable_data_ptr()) +
+            static_cast<size_t>(i * dim_) * elem_size;
+        if (model_dtype_ == ::executorch::aten::ScalarType::BFloat16) {
+          auto* dst_bf16 = reinterpret_cast<::executorch::aten::BFloat16*>(dst);
+          for (int64_t d = 0; d < dim_; d++) {
+            dst_bf16[d] = ::executorch::aten::BFloat16(src[d]);
+          }
+        } else {
+          std::memcpy(dst, src, static_cast<size_t>(dim_) * sizeof(float));
+        }
+      }
+      ET_LOG(
+          Info,
+          "Injected %ld voice frames at positions [%ld, %ld)",
+          static_cast<long>(n_voice_frames_),
+          static_cast<long>(voice_start),
+          static_cast<long>(voice_end));
+    }
+
+    // Position tensor [0, 1, ..., prompt_len-1]
+    std::vector<int64_t> pos_vec(static_cast<size_t>(prompt_len));
+    for (int64_t i = 0; i < prompt_len; i++)
+      pos_vec[static_cast<size_t>(i)] = i;
+    auto pos_tensor = from_blob(
+        pos_vec.data(),
+        {static_cast<int>(prompt_len)},
+        ::executorch::aten::ScalarType::Long);
+
+    auto dec_result = model_->execute(
+        "text_decoder", std::vector<EValue>{embeds, *pos_tensor});
+    ET_CHECK_MSG(dec_result.ok(), "text_decoder (prefill) failed.");
+
+    auto hidden = dec_result.get()[0].toTensor();
+    dec_pos = prompt_len;
+    prev_token = static_cast<uint64_t>(tokens.back());
+
+    dec_pos = prompt_len;
+    ET_LOG(Info, "Prefill done.");
+  }
+
+  // --- Audio generation loop ---
+  // After the prompt ends with [BEGIN_AUDIO], every step:
+  // 1. Extract hidden state from text_decoder
+  // 2. Run decode_audio_frame → audio codes + check semantic code for EOS
+  // 3. Feed audio token (24) back to text_decoder for next step
+  // The LM head is NOT used — the acoustic transformer drives generation.
+  // END_AUDIO (semantic code == 1) signals end of audio.
+  constexpr int64_t END_AUDIO_SEMANTIC = 1;
+
+  ET_LOG(Info, "Generating audio (max %d frames)...", config.max_tokens);
+
+  // Pre-embed the audio token once (reused every step).
+  // Pad to 3 tokens for Metal SDPA compatibility (requires seq_len >= 3).
+  // Positions [dec_pos-2, dec_pos-1, dec_pos] — only last position's hidden
+  // state is used. The first two are padding (same embedding, earlier positions
+  // already in KV cache — the causal mask prevents them from affecting output).
+  constexpr int DECODE_SEQ_LEN = 3;
+  int64_t audio_tok = static_cast<int64_t>(audio_tok_id_);
+  auto audio_tok_t =
+      from_blob(&audio_tok, {1, 1}, ::executorch::aten::ScalarType::Long);
+  auto audio_tok_result =
+      model_->execute("token_embedding", std::vector<EValue>{*audio_tok_t});
+  ET_CHECK_MSG(audio_tok_result.ok(), "token_embedding(audio) failed.");
+  auto audio_embed_ref = audio_tok_result.get()[0].toTensor();
+  const size_t embed_bytes =
+      static_cast<size_t>(dim_) * audio_embed_ref.element_size();
+
+  // Build padded embedding: repeat the audio token embedding 3 times
+  auto audio_step_embeds =
+      empty({1, DECODE_SEQ_LEN, static_cast<int>(dim_)}, model_dtype_);
+  for (int i = 0; i < DECODE_SEQ_LEN; i++) {
+    std::memcpy(
+        static_cast<char*>(audio_step_embeds->mutable_data_ptr()) +
+            static_cast<size_t>(i) * embed_bytes,
+        audio_embed_ref.const_data_ptr(),
+        embed_bytes);
+  }
+
+  for (int step = 0; step < config.max_tokens && dec_pos < max_seq_len_;
+       step++) {
+    // 1. Run text_decoder with padded audio token embedding
+    // Positions: [dec_pos, dec_pos+1, dec_pos+2] — we advance by 1 per step
+    // but present 3 positions to satisfy Metal's min seq_len.
+    // The KV cache at dec_pos+1 and dec_pos+2 will be overwritten next steps.
+    std::vector<int64_t> pos_data = {dec_pos, dec_pos + 1, dec_pos + 2};
+    auto pos_tensor = from_blob(
+        pos_data.data(),
+        {DECODE_SEQ_LEN},
+        ::executorch::aten::ScalarType::Long);
+    auto dec_result = model_->execute(
+        "text_decoder", std::vector<EValue>{*audio_step_embeds, *pos_tensor});
+    ET_CHECK_MSG(
+        dec_result.ok(),
+        "text_decoder failed at pos %ld.",
+        static_cast<long>(dec_pos));
+    auto hidden = dec_result.get()[0].toTensor();
+    dec_pos++;
+
+    // 2. Extract hidden (1,1,dim) -> (1,dim) for acoustic transformer
+    // Extract the FIRST position's hidden state (index 0 of DECODE_SEQ_LEN).
+    // hidden is (1, DECODE_SEQ_LEN, dim). Position 0 corresponds to dec_pos-1
+    // (the actual current position after dec_pos++ above).
+    auto h_2d = empty({1, static_cast<int>(dim_)}, model_dtype_);
+    std::memcpy(
+        h_2d->mutable_data_ptr(),
+        hidden.const_data_ptr(),
+        static_cast<size_t>(dim_) * hidden.element_size());
+
+    // Generate noise
+    auto noise_tensor =
+        empty({1, static_cast<int>(n_acoustic_codebook_)}, model_dtype_);
+    if (model_dtype_ == ::executorch::aten::ScalarType::BFloat16) {
+      auto* ptr =
+          noise_tensor->mutable_data_ptr<::executorch::aten::BFloat16>();
+      for (int64_t i = 0; i < n_acoustic_codebook_; i++) {
+        ptr[i] = ::executorch::aten::BFloat16(noise_dist(noise_rng));
+      }
+    } else {
+      auto* ptr = noise_tensor->mutable_data_ptr<float>();
+      for (int64_t i = 0; i < n_acoustic_codebook_; i++) {
+        ptr[i] = noise_dist(noise_rng);
+      }
+    }
+
+    // 3. Run acoustic transformer
+    auto frame_result = model_->execute(
+        "decode_audio_frame", std::vector<EValue>{*h_2d, *noise_tensor});
+    ET_CHECK_MSG(frame_result.ok(), "decode_audio_frame failed.");
+    auto codes_tensor = frame_result.get()[0].toTensor();
+    const auto* codes_ptr = codes_tensor.const_data_ptr<int64_t>();
+
+    // Check semantic code (first element) for END_AUDIO
+    int64_t semantic_code = codes_ptr[0];
+    if (semantic_code == END_AUDIO_SEMANTIC) {
+      ET_LOG(Info, "END_AUDIO at frame %d", step);
+      break;
+    }
+
+    // Accumulate codes
+    for (int64_t i = 0; i < n_codebooks_; i++) {
+      all_codes.push_back(codes_ptr[i]);
+    }
+    num_audio_frames++;
+    num_generated++;
+
+    if (token_cb && num_generated % 100 == 0) {
+      token_cb("");
+    }
+  }
+
+  ET_LOG(
+      Info,
+      "Generated %d tokens, %ld audio frames",
+      num_generated,
+      static_cast<long>(num_audio_frames));
+
+  // Output audio codes if requested
+  if (audio_codes_out) {
+    *audio_codes_out = all_codes;
+  }
+
+  // Decode audio codes to waveform via codec
+  if (codec_ && num_audio_frames > 0) {
+    return decode_audio(all_codes, num_audio_frames);
+  }
+
+  return {};
+}
+
+// ---------------------------------------------------------------------------
+// Codec decode
+// ---------------------------------------------------------------------------
+
+std::vector<float> VoxtralTTSRunner::decode_audio(
+    const std::vector<int64_t>& codes,
+    int64_t n_frames) {
+  ET_CHECK_MSG(codec_ != nullptr, "No codec loaded.");
+
+  std::vector<float> waveform;
+  const int64_t chunk = codec_chunk_size_;
+
+  for (int64_t start = 0; start < n_frames; start += chunk) {
+    int64_t this_chunk = std::min(chunk, n_frames - start);
+
+    // Pad to full chunk if needed.
+    // Strip _N_AUDIO_SPECIAL_TOKENS (2) offset from acoustic codes:
+    // decode_one_frame outputs acoustic codes in [2, acoustic_levels+1] for
+    // audio_token_embedding compatibility, but the codec expects raw [0,
+    // levels-1].
+    constexpr int64_t N_SPECIAL = 2;
+    std::vector<int64_t> chunk_codes(
+        static_cast<size_t>(chunk * n_codebooks_), 0);
+    for (int64_t f = 0; f < this_chunk; f++) {
+      for (int64_t c = 0; c < n_codebooks_; c++) {
+        int64_t code =
+            codes[static_cast<size_t>((start + f) * n_codebooks_ + c)];
+        if (c > 0) {
+          // Acoustic codes: strip special token offset
+          code -= N_SPECIAL;
+        }
+        chunk_codes[static_cast<size_t>(c * chunk + f)] = code;
+      }
+    }
+
+    // Shape: (1, n_codebooks, chunk)
+    auto codes_tensor = from_blob(
+        chunk_codes.data(),
+        {1, static_cast<int>(n_codebooks_), static_cast<int>(chunk)},
+        ::executorch::aten::ScalarType::Long);
+
+    auto result =
+        codec_->execute("audio_decoder", std::vector<EValue>{*codes_tensor});
+    ET_CHECK_MSG(result.ok(), "audio_decoder failed.");
+
+    auto wav_tensor = result.get()[0].toTensor();
+    const int64_t wav_samples = wav_tensor.numel();
+
+    // Only take the valid portion (trim padding)
+    const int64_t valid_samples = this_chunk * (wav_samples / chunk);
+
+    const float* wav_data = wav_tensor.const_data_ptr<float>();
+    waveform.insert(waveform.end(), wav_data, wav_data + valid_samples);
+  }
+
+  ET_LOG(
+      Info,
+      "Decoded %ld audio frames -> %zu waveform samples",
+      static_cast<long>(n_frames),
+      waveform.size());
+  return waveform;
+}
+
+// ---------------------------------------------------------------------------
+// WAV writer
+// ---------------------------------------------------------------------------
+
+bool write_wav(
+    const std::string& path,
+    const float* samples,
+    int64_t num_samples,
+    int32_t sample_rate) {
+  std::ofstream file(path, std::ios::binary);
+  if (!file.is_open()) {
+    ET_LOG(Error, "Cannot open %s for writing.", path.c_str());
+    return false;
+  }
+
+  const int16_t num_channels = 1;
+  const int16_t bits_per_sample = 16;
+  const int32_t byte_rate = sample_rate * num_channels * bits_per_sample / 8;
+  const int16_t block_align = num_channels * bits_per_sample / 8;
+  const int32_t data_size = static_cast<int32_t>(num_samples) * block_align;
+  const int32_t chunk_size = 36 + data_size;
+
+  // RIFF header
+  file.write("RIFF", 4);
+  file.write(reinterpret_cast<const char*>(&chunk_size), 4);
+  file.write("WAVE", 4);
+
+  // fmt sub-chunk
+  file.write("fmt ", 4);
+  int32_t fmt_size = 16;
+  int16_t audio_format = 1; // PCM
+  file.write(reinterpret_cast<const char*>(&fmt_size), 4);
+  file.write(reinterpret_cast<const char*>(&audio_format), 2);
+  file.write(reinterpret_cast<const char*>(&num_channels), 2);
+  file.write(reinterpret_cast<const char*>(&sample_rate), 4);
+  file.write(reinterpret_cast<const char*>(&byte_rate), 4);
+  file.write(reinterpret_cast<const char*>(&block_align), 2);
+  file.write(reinterpret_cast<const char*>(&bits_per_sample), 2);
+
+  // data sub-chunk
+  file.write("data", 4);
+  file.write(reinterpret_cast<const char*>(&data_size), 4);
+
+  // Convert float32 [-1, 1] to int16 and write
+  for (int64_t i = 0; i < num_samples; i++) {
+    float s = std::max(-1.0f, std::min(1.0f, samples[i]));
+    int16_t pcm = static_cast<int16_t>(s * 32767.0f);
+    file.write(reinterpret_cast<const char*>(&pcm), 2);
+  }
+
+  file.close();
+  ET_LOG(
+      Info,
+      "Wrote %s: %ld samples, %.1f seconds",
+      path.c_str(),
+      static_cast<long>(num_samples),
+      static_cast<double>(num_samples) / sample_rate);
+  return true;
+}
+
+} // namespace voxtral_tts

--- a/examples/models/voxtral_tts/voxtral_tts_runner.cpp
+++ b/examples/models/voxtral_tts/voxtral_tts_runner.cpp
@@ -302,17 +302,32 @@ std::vector<float> VoxtralTTSRunner::generate(
   ET_LOG(Info, "Prefill done.");
 
   // --- Audio generation loop ---
-  // vLLM's flow: AT runs on the prefill's last hidden state for frame 0,
-  // then each subsequent frame feeds audio_token_embedding(prev_codes)
-  // through the decoder. The LM head is NOT used.
+  // Matching mlx-audio/vLLM flow:
+  // 1. Decode with token_embedding(audio_tok) at pos=prompt_len → hidden
+  // 2. AT(hidden) → frame 0 codes
+  // 3. Decode with audio_token_embedding(frame_0_codes) at pos=prompt_len+1 →
+  // hidden
+  // 4. AT(hidden) → frame 1 codes
+  // 5. ...repeat until END_AUDIO
   constexpr int64_t END_AUDIO_SEMANTIC = 1;
 
   ET_LOG(Info, "Generating audio (max %d frames)...", config.max_tokens);
 
   // Pad to 3 tokens for Metal SDPA compatibility (requires seq_len >= 3).
   constexpr int DECODE_SEQ_LEN = 3;
+
+  // Embed audio token for the first decode step after prefill.
+  // This matches mlx-audio which runs lm_backbone(tok_emb(24)) before
+  // entering the generate loop. Subsequent steps use audio_token_embedding.
+  int64_t audio_tok = static_cast<int64_t>(audio_tok_id_);
+  auto audio_tok_t =
+      from_blob(&audio_tok, {1, 1}, ::executorch::aten::ScalarType::Long);
+  auto audio_tok_result =
+      model_->execute("token_embedding", std::vector<EValue>{*audio_tok_t});
+  ET_CHECK_MSG(audio_tok_result.ok(), "token_embedding(audio) failed.");
+  auto first_embed = audio_tok_result.get()[0].toTensor();
   const size_t embed_bytes =
-      static_cast<size_t>(dim_) * prefill_hidden.element_size();
+      static_cast<size_t>(dim_) * first_embed.element_size();
 
   // Build padded embedding buffer (updated each step)
   auto audio_step_embeds =
@@ -328,11 +343,33 @@ std::vector<float> VoxtralTTSRunner::generate(
     }
   };
 
-  // Frame 0: use the prefill's last hidden state directly (no decode step).
-  // This matches vLLM's make_omni_output which runs AT on hidden[logits_index]
-  // during the prefill step itself, before any decode step occurs.
-  auto generate_frame = [&](const ::executorch::aten::Tensor& h_2d) {
-    // Generate noise
+  // Initialize with token_embedding(24) for the first decode step
+  fill_step_embeds(first_embed.const_data_ptr());
+
+  auto h_2d = empty({1, static_cast<int>(dim_)}, model_dtype_);
+
+  for (int step = 0; step < config.max_tokens && dec_pos < max_seq_len_;
+       step++) {
+    // 1. Run text_decoder with current step's embedding
+    std::vector<int64_t> pos_data = {dec_pos, dec_pos + 1, dec_pos + 2};
+    auto pos_tensor = from_blob(
+        pos_data.data(),
+        {DECODE_SEQ_LEN},
+        ::executorch::aten::ScalarType::Long);
+    auto dec_result = model_->execute(
+        "text_decoder", std::vector<EValue>{*audio_step_embeds, *pos_tensor});
+    ET_CHECK_MSG(
+        dec_result.ok(),
+        "text_decoder failed at pos %ld.",
+        static_cast<long>(dec_pos));
+    auto hidden = dec_result.get()[0].toTensor();
+    dec_pos++;
+
+    // 2. Extract first position's hidden state: (1, DECODE_SEQ_LEN, dim) -> (1,
+    // dim)
+    std::memcpy(h_2d->mutable_data_ptr(), hidden.const_data_ptr(), embed_bytes);
+
+    // 3. Generate noise and run acoustic transformer
     auto noise_tensor =
         empty({1, static_cast<int>(n_acoustic_codebook_)}, model_dtype_);
     if (model_dtype_ == ::executorch::aten::ScalarType::BFloat16) {
@@ -351,34 +388,17 @@ std::vector<float> VoxtralTTSRunner::generate(
     auto frame_result = model_->execute(
         "decode_audio_frame", std::vector<EValue>{*h_2d, *noise_tensor});
     ET_CHECK_MSG(frame_result.ok(), "decode_audio_frame failed.");
-    return frame_result.get()[0].toTensor();
-  };
+    auto codes_tensor = frame_result.get()[0].toTensor();
+    const auto* codes_ptr = codes_tensor.const_data_ptr<int64_t>();
 
-  // Extract prefill's last hidden: (1, prompt_len, dim) -> (1, dim)
-  auto h_2d = empty({1, static_cast<int>(dim_)}, model_dtype_);
-  {
-    const size_t last_pos_offset =
-        static_cast<size_t>(prompt_len - 1) * embed_bytes;
-    std::memcpy(
-        h_2d->mutable_data_ptr(),
-        static_cast<const char*>(prefill_hidden.const_data_ptr()) +
-            last_pos_offset,
-        embed_bytes);
-  }
-
-  auto codes_tensor = generate_frame(*h_2d);
-  const auto* codes_ptr = codes_tensor.const_data_ptr<int64_t>();
-
-  for (int step = 0; step < config.max_tokens && dec_pos < max_seq_len_;
-       step++) {
-    // Check semantic code (first element) for END_AUDIO
+    // 4. Check semantic code for END_AUDIO
     int64_t semantic_code = codes_ptr[0];
     if (semantic_code == END_AUDIO_SEMANTIC) {
       ET_LOG(Info, "END_AUDIO at frame %d", step);
       break;
     }
 
-    // Accumulate codes
+    // 5. Accumulate codes
     for (int64_t i = 0; i < n_codebooks_; i++) {
       all_codes.push_back(codes_ptr[i]);
     }
@@ -389,7 +409,9 @@ std::vector<float> VoxtralTTSRunner::generate(
       token_cb("");
     }
 
-    // Feed codes back through audio_token_embedding for next decode step.
+    // 6. Prepare next step's embedding via audio_token_embedding.
+    // Copy codes first (codes_ptr points to decode_audio_frame's output
+    // buffer).
     std::vector<int64_t> codes_col(static_cast<size_t>(n_codebooks_));
     for (int64_t i = 0; i < n_codebooks_; i++) {
       codes_col[static_cast<size_t>(i)] = codes_ptr[i];
@@ -403,27 +425,6 @@ std::vector<float> VoxtralTTSRunner::generate(
     ET_CHECK_MSG(ate_result.ok(), "audio_token_embedding failed.");
     auto next_embed = ate_result.get()[0].toTensor();
     fill_step_embeds(next_embed.const_data_ptr());
-
-    // Run text_decoder to get hidden state for next frame
-    std::vector<int64_t> pos_data = {dec_pos, dec_pos + 1, dec_pos + 2};
-    auto pos_tensor = from_blob(
-        pos_data.data(),
-        {DECODE_SEQ_LEN},
-        ::executorch::aten::ScalarType::Long);
-    auto dec_result = model_->execute(
-        "text_decoder", std::vector<EValue>{*audio_step_embeds, *pos_tensor});
-    ET_CHECK_MSG(
-        dec_result.ok(),
-        "text_decoder failed at pos %ld.",
-        static_cast<long>(dec_pos));
-    auto hidden = dec_result.get()[0].toTensor();
-    dec_pos++;
-
-    // Extract first position's hidden state for next AT call
-    std::memcpy(h_2d->mutable_data_ptr(), hidden.const_data_ptr(), embed_bytes);
-
-    codes_tensor = generate_frame(*h_2d);
-    codes_ptr = codes_tensor.const_data_ptr<int64_t>();
   }
 
   ET_LOG(

--- a/examples/models/voxtral_tts/voxtral_tts_runner.h
+++ b/examples/models/voxtral_tts/voxtral_tts_runner.h
@@ -82,7 +82,7 @@ class VoxtralTTSRunner {
   // Tokenizer special tokens
   uint64_t bos_id_ = 1;
   uint64_t eos_id_ = 2;
-  uint64_t audio_tok_id_ = 0;
+  uint64_t audio_tok_id_ = 24; // Tekken default, overridden by metadata
 
   // Voice embedding (loaded via load_voice())
   std::vector<float> voice_data_; // fp32, (n_voice_frames * dim)

--- a/examples/models/voxtral_tts/voxtral_tts_runner.h
+++ b/examples/models/voxtral_tts/voxtral_tts_runner.h
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <random>
+#include <string>
+#include <vector>
+
+#include <executorch/extension/llm/sampler/sampler.h>
+#include <executorch/extension/module/module.h>
+#include <executorch/extension/tensor/tensor.h>
+#include <pytorch/tokenizers/tokenizer.h>
+
+namespace voxtral_tts {
+
+struct GenerateConfig {
+  int max_tokens = 2048;
+  float temperature = 0.0f;
+  uint64_t seed = 42;
+};
+
+// Callback invoked for each generated token (for progress display).
+using TokenCallback = std::function<void(const std::string&)>;
+
+class VoxtralTTSRunner {
+ public:
+  VoxtralTTSRunner(
+      const std::string& model_path,
+      const std::string& tokenizer_path,
+      const std::string& codec_path = "",
+      bool warmup = true);
+
+  // Load voice embedding from a raw binary file (int64 n_frames, int64 dim,
+  // then n_frames*dim float32 values). Converts to model dtype internally.
+  void load_voice(const std::string& voice_bin_path);
+
+  // Generate audio from text. Returns float32 PCM samples at codec sample rate.
+  // If no codec is loaded, returns empty and audio_codes_out is populated.
+  std::vector<float> generate(
+      const std::string& prompt,
+      const GenerateConfig& config,
+      TokenCallback token_cb = nullptr,
+      std::vector<int64_t>* audio_codes_out = nullptr);
+
+  int64_t max_seq_len() const {
+    return max_seq_len_;
+  }
+  int64_t vocab_size() const {
+    return vocab_size_;
+  }
+  int64_t sample_rate() const {
+    return sample_rate_;
+  }
+
+ private:
+  std::unique_ptr<::executorch::extension::Module> model_;
+  std::unique_ptr<::executorch::extension::Module> codec_;
+  std::unique_ptr<tokenizers::Tokenizer> tokenizer_;
+
+  // Model metadata (from constant_methods)
+  int64_t max_seq_len_ = 4096;
+  int64_t vocab_size_ = 131072;
+  int64_t dim_ = 3072;
+  int64_t n_acoustic_codebook_ = 36;
+  int64_t n_codebooks_ = 37; // 1 semantic + n_acoustic
+  int64_t codec_chunk_size_ = 375;
+  int64_t sample_rate_ = 24000;
+
+  // Model dtype
+  ::executorch::aten::ScalarType model_dtype_ =
+      ::executorch::aten::ScalarType::Float;
+
+  // Tokenizer special tokens
+  uint64_t bos_id_ = 1;
+  uint64_t eos_id_ = 2;
+  uint64_t audio_tok_id_ = 0;
+
+  // Voice embedding (loaded via load_voice())
+  std::vector<float> voice_data_; // fp32, (n_voice_frames * dim)
+  int64_t n_voice_frames_ = 0;
+
+  // Decode accumulated audio codes to waveform via codec.pte
+  std::vector<float> decode_audio(
+      const std::vector<int64_t>& codes,
+      int64_t n_frames);
+};
+
+// Write float32 PCM samples to a WAV file (mono, 16-bit PCM).
+bool write_wav(
+    const std::string& path,
+    const float* samples,
+    int64_t num_samples,
+    int32_t sample_rate);
+
+} // namespace voxtral_tts


### PR DESCRIPTION
Add Voxtral TTS model for ExecuTorch (Metal + XNNPACK)

Port Mistral's Voxtral-4B-TTS-2603 text-to-speech model to ExecuTorch.
The model generates speech from text using a Mistral LLM backbone with a
flow-matching acoustic transformer and neural audio codec.

Export produces two .pte files:
- model.pte (5 methods): token_embedding, text_decoder, lm_head,
  decode_audio_frame, audio_token_embedding
- codec.pte (1 method): audio_decoder (always XNNPACK/fp32)

Supported backends: Metal (fpa4w quantization) and XNNPACK (8da4w).

Includes:
- Eager model (model.py, codec.py) verified bit-identical to vLLM reference
  for both acoustic transformer and codec decoder
- Export script with per-component quantization, voice embedding conversion
- C++ runner with voice injection, flow-matching noise generation, codec
  chunking, WAV output, Metal decode padding (seq_len=3)
- CI test on macOS Metal (pull.yml) with WAV output validation
- CMake build with make voxtral_tts-metal / voxtral_tts-cpu targets

Key implementation details:
- RoPE uses split-half (rotate_half) convention, not Llama interleaved
- Audio generation loop always runs acoustic transformer (no lm_head);
  END_AUDIO detected from semantic code
- Codec decoder strips +2 special token offset from acoustic codes
- persistent=False buffers (timesteps, ALiBi slopes) recomputed after
  meta-device loading