### PR TITLE
[CoreML] Add ONE_BLOB multimethod weight sharing strategy

### DIFF
--- a/backends/apple/coreml/compiler/coreml_preprocess.py
+++ b/backends/apple/coreml/compiler/coreml_preprocess.py
@@ -48,14 +48,37 @@ class COMPILE_SPEC_KEYS(Enum):
 
 
 class MULTIMETHOD_WEIGHT_SHARING_STRATEGY(Enum):
-    # Methods are processed independently with no weight sharing.
+    """Strategy for sharing weights across methods in multi-method models.
+
+    When exporting a model with multiple methods (e.g., prefill and decode),
+    these strategies control how CoreML models are organized and how weights
+    are shared. Different strategies have different tradeoffs — experiment
+    with them to find the best fit for your use case.
+
+    DISABLED:
+        Each method is compiled into its own independent CoreML model.
+        No weight sharing occurs; weights are duplicated across methods.
+        Simplest strategy with no constraints on model structure.
+
+    POSITIONAL:
+        Partitions are aligned by index across methods. Partition 0 from
+        all methods are combined into one multifunction CoreML model,
+        partition 1 into another, and so on. This enables weight sharing
+        for parameters that appear at the same partition index. Requires
+        all methods to have the same number of partitions.
+
+    ONE_BLOB:
+        All partitions from all methods are packed into a single
+        multifunction CoreML model. This maximizes weight sharing
+        opportunities (any parameter can be shared across any method)
+        and does not require partition counts to match. However, it may
+        result in longer compile times and higher peak memory since the
+        entire model — including any method-specific (non-shared) weights
+        — lives in a single blob.
+    """
+
     DISABLED = "disabled"
-    # Partitions must align positionally across methods; enables weight sharing
-    # via NamedDataStore. Raises an error if partition counts don't match.
     POSITIONAL = "positional"
-    # All partitions from all methods are combined into a single multifunction
-    # model. No partition count alignment is required. Function names use
-    # "{method_name}__{partition_idx}" encoding.
     ONE_BLOB = "one_blob"
 
 
@@ -843,7 +866,9 @@ class CoreMLBackend(BackendDetails):
                     f"Method '{method_name}' has {len(programs)} partitions, but "
                     f"'{first_method}' has {num_partitions}. POSITIONAL weight sharing "
                     "strategy requires all methods to have the same number of partitions. "
-                    "Use MULTIMETHOD_WEIGHT_SHARING_STRATEGY.DISABLED if methods should "
+                    "Use MULTIMETHOD_WEIGHT_SHARING_STRATEGY.ONE_BLOB (which supports "
+                    "different partition counts per method) or "
+                    "MULTIMETHOD_WEIGHT_SHARING_STRATEGY.DISABLED if methods should "
                     "be processed independently."
                 )
 
@@ -1034,7 +1059,7 @@ class CoreMLBackend(BackendDetails):
                 method_spec = method_model.get_spec()
                 input_names = [inp.name for inp in method_spec.description.input]
                 output_names = [out.name for out in method_spec.description.output]
-                methods_metadata[method_name] = MethodMetadata(
+                methods_metadata[function_name] = MethodMetadata(
                     inputNames=input_names,
                     outputNames=output_names,
                 )

--- a/backends/apple/coreml/compiler/coreml_preprocess.py
+++ b/backends/apple/coreml/compiler/coreml_preprocess.py
@@ -53,6 +53,10 @@ class MULTIMETHOD_WEIGHT_SHARING_STRATEGY(Enum):
     # Partitions must align positionally across methods; enables weight sharing
     # via NamedDataStore. Raises an error if partition counts don't match.
     POSITIONAL = "positional"
+    # All partitions from all methods are combined into a single multifunction
+    # model. No partition count alignment is required. Function names use
+    # "{method_name}__{partition_idx}" encoding.
+    ONE_BLOB = "one_blob"
 
 
 class MODEL_PATHS(Enum):
@@ -284,6 +288,8 @@ class CoreMLBackend(BackendDetails):
             strategy: The weight sharing strategy to use when combining methods.
                 POSITIONAL: Partitions must align positionally across methods; enables
                     weight sharing via NamedDataStore. Raises error if partitions don't align.
+                ONE_BLOB: All partitions from all methods are combined into a single
+                    multifunction model. No partition count alignment required.
                 DISABLED: Methods are processed independently with no weight sharing.
         """
         return CompileSpec(
@@ -297,7 +303,7 @@ class CoreMLBackend(BackendDetails):
     ) -> "MULTIMETHOD_WEIGHT_SHARING_STRATEGY":
         """
         Returns the multimethod weight sharing strategy by parsing the list of compile specs.
-        Defaults to POSITIONAL if not specified.
+        Defaults to DISABLED if not specified.
         """
         for compile_spec in compile_specs:
             if (
@@ -308,7 +314,7 @@ class CoreMLBackend(BackendDetails):
                     compile_spec.value.decode("utf-8")
                 )
 
-        return MULTIMETHOD_WEIGHT_SHARING_STRATEGY.POSITIONAL
+        return MULTIMETHOD_WEIGHT_SHARING_STRATEGY.DISABLED
 
     @staticmethod
     def generate_enumerated_shapes_compile_spec(
@@ -739,19 +745,10 @@ class CoreMLBackend(BackendDetails):
             )
             return super().preprocess_multimethod(edge_programs, compile_specs)
 
-        assert weight_sharing_strategy == MULTIMETHOD_WEIGHT_SHARING_STRATEGY.POSITIONAL
-
-        # POSITIONAL strategy: verify all methods have the same number of partitions
-        num_partitions = len(edge_programs[first_method])
-        for method_name, programs in edge_programs.items():
-            if len(programs) != num_partitions:
-                raise ValueError(
-                    f"Method '{method_name}' has {len(programs)} partitions, but "
-                    f"'{first_method}' has {num_partitions}. POSITIONAL weight sharing "
-                    "strategy requires all methods to have the same number of partitions. "
-                    "Use MULTIMETHOD_WEIGHT_SHARING_STRATEGY.DISABLED if methods should "
-                    "be processed independently."
-                )
+        assert weight_sharing_strategy in (
+            MULTIMETHOD_WEIGHT_SHARING_STRATEGY.POSITIONAL,
+            MULTIMETHOD_WEIGHT_SHARING_STRATEGY.ONE_BLOB,
+        )
 
         model_type: CoreMLBackend.MODEL_TYPE = cls.model_type_from_compile_specs(
             first_compile_specs
@@ -796,160 +793,302 @@ class CoreMLBackend(BackendDetails):
                         f"Saved method '{method_name}' partition {partition_idx} to {mlpackage_path}"
                     )
 
-            # For each partition index, combine that partition from all methods
-            # into a single multifunction model.
-            # Store combined_processed_bytes[partition_idx] = bytes (for first method)
-            combined_processed_bytes: List[bytes] = []
-            debug_handle_maps: List[Optional[Dict[str, Tuple[int]]]] = []
-            model_keys: List[str] = []  # Keys for NamedDataStore lookup
-
-            for partition_idx in range(num_partitions):
-                logger.info(
-                    f"Combining partition {partition_idx} from all methods into multifunction model..."
+            if weight_sharing_strategy == MULTIMETHOD_WEIGHT_SHARING_STRATEGY.ONE_BLOB:
+                return cls._preprocess_one_blob(
+                    method_names=method_names,
+                    edge_programs=edge_programs,
+                    method_mlpackage_paths=method_mlpackage_paths,
+                    model_type=model_type,
+                    named_data_store=named_data_store,
+                    temp_dir=temp_dir,
                 )
 
-                desc = ct.utils.MultiFunctionDescriptor()
-                for method_name in method_names:
-                    mlpackage_path = method_mlpackage_paths[method_name][partition_idx]
-                    desc.add_function(
-                        str(mlpackage_path),
-                        src_function_name="main",
-                        target_function_name=method_name,
-                    )
-
-                # Set the first method as default
-                desc.default_function_name = first_method
-
-                # Save the combined multifunction model for this partition
-                combined_path = (
-                    temp_dir / f"combined_partition_{partition_idx}.mlpackage"
-                )
-                ct.utils.save_multifunction(desc, str(combined_path))
-
-                logger.info(
-                    f"Saved combined multifunction model for partition {partition_idx} to {combined_path}"
-                )
-
-                # Create output directory for this partition's combined model
-                model_dir_path = temp_dir / f"lowered_module_partition_{partition_idx}"
-                model_dir_path.mkdir(exist_ok=True)
-
-                # Handle model type (compiled vs mlpackage)
-                if model_type == CoreMLBackend.MODEL_TYPE.COMPILED_MODEL:
-                    output_model_path = (
-                        model_dir_path / MODEL_PATHS.COMPILED_MODEL.value
-                    )
-                    combined_model_loaded = ct.models.MLModel(str(combined_path))
-                    compiled_path = combined_model_loaded.get_compiled_model_path()
-                    shutil.move(compiled_path, str(output_model_path))
-                else:
-                    output_model_path = model_dir_path / MODEL_PATHS.MODEL.value
-                    shutil.copytree(str(combined_path), str(output_model_path))
-
-                # For multifunction models, we store all method metadata in a single file
-                # with method names as keys. Each method can have different input/output
-                # names (e.g., masks_1023 vs masks_992).
-                identifier = "executorch_" + str(uuid.uuid4())
-
-                # Extract metadata for each method
-                methods_metadata: Dict[str, MethodMetadata] = {}
-                for method_name in method_names:
-                    method_mlpackage_path = method_mlpackage_paths[method_name][
-                        partition_idx
-                    ]
-                    method_model = ct.models.MLModel(
-                        str(method_mlpackage_path), skip_model_load=True
-                    )
-                    method_spec = method_model.get_spec()
-                    input_names = [inp.name for inp in method_spec.description.input]
-                    output_names = [out.name for out in method_spec.description.output]
-                    methods_metadata[method_name] = MethodMetadata(
-                        inputNames=input_names,
-                        outputNames=output_names,
-                    )
-                    logger.info(
-                        f"Extracted metadata for method '{method_name}' partition {partition_idx}: "
-                        f"{len(input_names)} inputs, {len(output_names)} outputs"
-                    )
-
-                # Create consolidated multifunction metadata
-                multifunction_metadata = MultifunctionModelMetadata(
-                    identifier=identifier,
-                    methods={k: asdict(v) for k, v in methods_metadata.items()},
-                )
-
-                # Save consolidated metadata
-                cls.save_model_metadata(multifunction_metadata, model_dir_path)
-
-                # Note: Debug info is not supported for multifunction models.
-                # The combined model's debug mapping doesn't accurately map back to
-                # individual methods, so we skip it rather than provide incorrect info.
-
-                # Flatten the model directory (with model + metadata) to bytes
-                processed_bytes = (
-                    executorchcoreml.flatten_directory_contents(
-                        str(model_dir_path.resolve())
-                    )
-                    or b""
-                )
-                combined_processed_bytes.append(processed_bytes)
-
-                # Store in NamedDataStore and save the key for later reference
-                model_key = f"coreml_{identifier}"
-                model_keys.append(model_key)
-                named_data_store.add_named_data(model_key, processed_bytes)
-
-                logger.info(
-                    f"Created combined processed bytes for partition {partition_idx} ({len(processed_bytes)} bytes)"
-                )
-                logger.info(f"Stored in NamedDataStore with key '{model_key}'")
-
-                # Debug handle map is not supported for multifunction models
-                debug_handle_maps.append(None)
-
-            # Get the NamedDataStoreOutput to share across PreprocessResults
-            named_data_store_output = named_data_store.get_named_data_store_output()
-
-            # Build PreprocessResults for each method and partition.
-            # All methods get a JSON reference to the model in NamedDataStore.
-            # The model is stored ONLY in NamedDataStore to avoid duplication.
-            # Runtime will detect the JSON reference and load from NamedDataMap.
-            preprocess_results: Dict[str, List[PreprocessResult]] = {
-                method_name: [] for method_name in method_names
-            }
-
-            for partition_idx in range(num_partitions):
-                debug_handle_map = debug_handle_maps[partition_idx]
-
-                for method_name in method_names:
-                    # Create JSON reference for runtime to look up model in NamedDataStore.
-                    # functionName specifies which CoreML function to invoke within the
-                    # multifunction model. The runtime gets the ExecuTorch method name
-                    # separately via BackendInitContext::get_method_name().
-                    #
-                    # We prefix the JSON with a magic number so runtime can identify this
-                    # as a JSON reference rather than raw model bytes.
-                    reference = {
-                        "version": 1,
-                        "key": model_keys[partition_idx],
-                        "functionName": method_name,
-                    }
-                    # Magic number "CMJR" (CoreML JSON Reference) followed by JSON bytes
-                    MAGIC_NUMBER = b"CMJR"
-                    reference_bytes = MAGIC_NUMBER + json.dumps(reference).encode(
-                        "utf-8"
-                    )
-
-                    preprocess_results[method_name].append(
-                        PreprocessResult(
-                            processed_bytes=reference_bytes,
-                            debug_handle_map=debug_handle_map,
-                            data_store_output=named_data_store_output,
-                        )
-                    )
-
-            return preprocess_results
+            assert (
+                weight_sharing_strategy
+                == MULTIMETHOD_WEIGHT_SHARING_STRATEGY.POSITIONAL
+            )
+            return cls._preprocess_positional(
+                method_names=method_names,
+                edge_programs=edge_programs,
+                method_mlpackage_paths=method_mlpackage_paths,
+                model_type=model_type,
+                named_data_store=named_data_store,
+                temp_dir=temp_dir,
+            )
 
         finally:
             # Clean up temporary directory
             shutil.rmtree(str(temp_dir))
+
+    @classmethod
+    def _preprocess_positional(
+        cls,
+        method_names: List[str],
+        edge_programs: Dict[str, List[ExportedProgram]],
+        method_mlpackage_paths: Dict[str, List[Path]],
+        model_type: "CoreMLBackend.MODEL_TYPE",
+        named_data_store: Any,
+        temp_dir: Path,
+    ) -> Dict[str, List[PreprocessResult]]:
+        """
+        POSITIONAL strategy: for each partition index, combine that partition
+        from all methods into a single multifunction model.
+        """
+        first_method = method_names[0]
+        num_partitions = len(edge_programs[first_method])
+
+        for method_name, programs in edge_programs.items():
+            if len(programs) != num_partitions:
+                raise ValueError(
+                    f"Method '{method_name}' has {len(programs)} partitions, but "
+                    f"'{first_method}' has {num_partitions}. POSITIONAL weight sharing "
+                    "strategy requires all methods to have the same number of partitions. "
+                    "Use MULTIMETHOD_WEIGHT_SHARING_STRATEGY.DISABLED if methods should "
+                    "be processed independently."
+                )
+
+        combined_processed_bytes: List[bytes] = []
+        debug_handle_maps: List[Optional[Dict[str, Tuple[int]]]] = []
+        model_keys: List[str] = []
+
+        for partition_idx in range(num_partitions):
+            logger.info(
+                f"Combining partition {partition_idx} from all methods into multifunction model..."
+            )
+
+            desc = ct.utils.MultiFunctionDescriptor()
+            for method_name in method_names:
+                mlpackage_path = method_mlpackage_paths[method_name][partition_idx]
+                desc.add_function(
+                    str(mlpackage_path),
+                    src_function_name="main",
+                    target_function_name=method_name,
+                )
+
+            desc.default_function_name = first_method
+
+            combined_path = temp_dir / f"combined_partition_{partition_idx}.mlpackage"
+            ct.utils.save_multifunction(desc, str(combined_path))
+
+            logger.info(
+                f"Saved combined multifunction model for partition {partition_idx} to {combined_path}"
+            )
+
+            model_dir_path = temp_dir / f"lowered_module_partition_{partition_idx}"
+            model_dir_path.mkdir(exist_ok=True)
+
+            if model_type == CoreMLBackend.MODEL_TYPE.COMPILED_MODEL:
+                output_model_path = model_dir_path / MODEL_PATHS.COMPILED_MODEL.value
+                combined_model_loaded = ct.models.MLModel(str(combined_path))
+                compiled_path = combined_model_loaded.get_compiled_model_path()
+                shutil.move(compiled_path, str(output_model_path))
+            else:
+                output_model_path = model_dir_path / MODEL_PATHS.MODEL.value
+                shutil.copytree(str(combined_path), str(output_model_path))
+
+            identifier = "executorch_" + str(uuid.uuid4())
+
+            methods_metadata: Dict[str, MethodMetadata] = {}
+            for method_name in method_names:
+                method_mlpackage_path = method_mlpackage_paths[method_name][
+                    partition_idx
+                ]
+                method_model = ct.models.MLModel(
+                    str(method_mlpackage_path), skip_model_load=True
+                )
+                method_spec = method_model.get_spec()
+                input_names = [inp.name for inp in method_spec.description.input]
+                output_names = [out.name for out in method_spec.description.output]
+                methods_metadata[method_name] = MethodMetadata(
+                    inputNames=input_names,
+                    outputNames=output_names,
+                )
+                logger.info(
+                    f"Extracted metadata for method '{method_name}' partition {partition_idx}: "
+                    f"{len(input_names)} inputs, {len(output_names)} outputs"
+                )
+
+            multifunction_metadata = MultifunctionModelMetadata(
+                identifier=identifier,
+                methods={k: asdict(v) for k, v in methods_metadata.items()},
+            )
+
+            cls.save_model_metadata(multifunction_metadata, model_dir_path)
+
+            processed_bytes = (
+                executorchcoreml.flatten_directory_contents(
+                    str(model_dir_path.resolve())
+                )
+                or b""
+            )
+            combined_processed_bytes.append(processed_bytes)
+
+            model_key = f"coreml_{identifier}"
+            model_keys.append(model_key)
+            named_data_store.add_named_data(model_key, processed_bytes)
+
+            logger.info(
+                f"Created combined processed bytes for partition {partition_idx} ({len(processed_bytes)} bytes)"
+            )
+            logger.info(f"Stored in NamedDataStore with key '{model_key}'")
+
+            debug_handle_maps.append(None)
+
+        named_data_store_output = named_data_store.get_named_data_store_output()
+
+        preprocess_results: Dict[str, List[PreprocessResult]] = {
+            method_name: [] for method_name in method_names
+        }
+
+        for partition_idx in range(num_partitions):
+            debug_handle_map = debug_handle_maps[partition_idx]
+
+            for method_name in method_names:
+                reference = {
+                    "version": 1,
+                    "key": model_keys[partition_idx],
+                    "functionName": method_name,
+                }
+                MAGIC_NUMBER = b"CMJR"
+                reference_bytes = MAGIC_NUMBER + json.dumps(reference).encode("utf-8")
+
+                preprocess_results[method_name].append(
+                    PreprocessResult(
+                        processed_bytes=reference_bytes,
+                        debug_handle_map=debug_handle_map,
+                        data_store_output=named_data_store_output,
+                    )
+                )
+
+        return preprocess_results
+
+    @classmethod
+    def _preprocess_one_blob(
+        cls,
+        method_names: List[str],
+        edge_programs: Dict[str, List[ExportedProgram]],
+        method_mlpackage_paths: Dict[str, List[Path]],
+        model_type: "CoreMLBackend.MODEL_TYPE",
+        named_data_store: Any,
+        temp_dir: Path,
+    ) -> Dict[str, List[PreprocessResult]]:
+        """
+        ONE_BLOB strategy: combine ALL partitions from ALL methods into a single
+        multifunction model. Function names use "{method_name}__{partition_idx}"
+        encoding. No partition count alignment is required.
+        """
+        first_method = method_names[0]
+
+        logger.info(
+            "ONE_BLOB: Combining all partitions from all methods into a single multifunction model..."
+        )
+
+        # Build a single MultiFunctionDescriptor with all method x partition combinations
+        desc = ct.utils.MultiFunctionDescriptor()
+        for method_name in method_names:
+            for partition_idx, mlpackage_path in enumerate(
+                method_mlpackage_paths[method_name]
+            ):
+                function_name = f"{method_name}__{partition_idx}"
+                desc.add_function(
+                    str(mlpackage_path),
+                    src_function_name="main",
+                    target_function_name=function_name,
+                )
+                logger.info(
+                    f"ONE_BLOB: Added function '{function_name}' from {mlpackage_path}"
+                )
+
+        desc.default_function_name = f"{first_method}__0"
+
+        combined_path = temp_dir / "combined_all.mlpackage"
+        ct.utils.save_multifunction(desc, str(combined_path))
+
+        logger.info(f"ONE_BLOB: Saved combined multifunction model to {combined_path}")
+
+        # Create output directory for the single combined model
+        model_dir_path = temp_dir / "lowered_module_one_blob"
+        model_dir_path.mkdir(exist_ok=True)
+
+        if model_type == CoreMLBackend.MODEL_TYPE.COMPILED_MODEL:
+            output_model_path = model_dir_path / MODEL_PATHS.COMPILED_MODEL.value
+            combined_model_loaded = ct.models.MLModel(str(combined_path))
+            compiled_path = combined_model_loaded.get_compiled_model_path()
+            shutil.move(compiled_path, str(output_model_path))
+        else:
+            output_model_path = model_dir_path / MODEL_PATHS.MODEL.value
+            shutil.copytree(str(combined_path), str(output_model_path))
+
+        identifier = "executorch_" + str(uuid.uuid4())
+
+        # Extract metadata for every method x partition function
+        methods_metadata: Dict[str, MethodMetadata] = {}
+        for method_name in method_names:
+            for partition_idx, mlpackage_path in enumerate(
+                method_mlpackage_paths[method_name]
+            ):
+                function_name = f"{method_name}__{partition_idx}"
+                method_model = ct.models.MLModel(
+                    str(mlpackage_path), skip_model_load=True
+                )
+                method_spec = method_model.get_spec()
+                input_names = [inp.name for inp in method_spec.description.input]
+                output_names = [out.name for out in method_spec.description.output]
+                methods_metadata[method_name] = MethodMetadata(
+                    inputNames=input_names,
+                    outputNames=output_names,
+                )
+                logger.info(
+                    f"ONE_BLOB: Extracted metadata for '{function_name}': "
+                    f"{len(input_names)} inputs, {len(output_names)} outputs"
+                )
+
+        multifunction_metadata = MultifunctionModelMetadata(
+            identifier=identifier,
+            methods={k: asdict(v) for k, v in methods_metadata.items()},
+        )
+
+        cls.save_model_metadata(multifunction_metadata, model_dir_path)
+
+        # Flatten the single model directory to bytes
+        processed_bytes = (
+            executorchcoreml.flatten_directory_contents(str(model_dir_path.resolve()))
+            or b""
+        )
+
+        # Store in NamedDataStore with a single key
+        model_key = f"coreml_{identifier}"
+        named_data_store.add_named_data(model_key, processed_bytes)
+
+        logger.info(
+            f"ONE_BLOB: Stored {len(processed_bytes)} bytes in NamedDataStore with key '{model_key}'"
+        )
+
+        named_data_store_output = named_data_store.get_named_data_store_output()
+
+        # Build PreprocessResults — all point to the same NamedDataStore key,
+        # differing only in functionName.
+        preprocess_results: Dict[str, List[PreprocessResult]] = {
+            method_name: [] for method_name in method_names
+        }
+
+        MAGIC_NUMBER = b"CMJR"
+        for method_name in method_names:
+            for partition_idx in range(len(edge_programs[method_name])):
+                function_name = f"{method_name}__{partition_idx}"
+                reference = {
+                    "version": 1,
+                    "key": model_key,
+                    "functionName": function_name,
+                }
+                reference_bytes = MAGIC_NUMBER + json.dumps(reference).encode("utf-8")
+
+                preprocess_results[method_name].append(
+                    PreprocessResult(
+                        processed_bytes=reference_bytes,
+                        debug_handle_map=None,
+                        data_store_output=named_data_store_output,
+                    )
+                )
+
+        return preprocess_results

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLModelManager.mm
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLModelManager.mm
@@ -656,16 +656,22 @@ NSString *raw_model_identifier(NSString *identifier) {
             return nil;
         }
         
-        std::string method_name_str = [methodName UTF8String];
-        const MethodMetadata* method_metadata = metadataValue.get_method_metadata(method_name_str);
+        if (functionName == nil || functionName.length == 0) {
+            ETCoreMLLogErrorAndSetNSError(error,
+                                          ETCoreMLErrorCorruptedModel,
+                                          "functionName must be non-nil and non-empty for multifunction model metadata lookup.");
+            return nil;
+        }
+        std::string lookup_key = [functionName UTF8String];
+        const MethodMetadata* method_metadata = metadataValue.get_method_metadata(lookup_key);
         if (method_metadata != nullptr) {
             metadataValue.input_names = method_metadata->input_names;
             metadataValue.output_names = method_metadata->output_names;
         } else {
             ETCoreMLLogErrorAndSetNSError(error,
                                           ETCoreMLErrorCorruptedModel,
-                                          "Method '%@' not found in multifunction model metadata.",
-                                          methodName);
+                                          "Function '%@' not found in multifunction model metadata.",
+                                          functionName);
             return nil;
         }
     }

--- a/backends/apple/coreml/test/test_coreml_multifunction.py
+++ b/backends/apple/coreml/test/test_coreml_multifunction.py
@@ -5,6 +5,7 @@
 import platform
 import sys
 import unittest
+from typing import Dict, Optional, Tuple
 
 import coremltools as ct
 import torch
@@ -50,75 +51,98 @@ class TestCoreMLMultifunction(unittest.TestCase):
 
     edge_compile_config = EdgeCompileConfig(_check_ir_validity=False)
 
-    def _get_compile_specs(self, weight_sharing: bool = True):
-        """Get compile specs for multifunction models."""
+    class SimpleModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = torch.nn.Linear(16, 16)
+
+        def forward(self, x):
+            return self.linear(x)
+
+    def _get_compile_specs(
+        self,
+        strategy: Optional[MULTIMETHOD_WEIGHT_SHARING_STRATEGY] = None,
+    ):
+        """Get compile specs, optionally with a weight sharing strategy."""
         compile_specs = CoreMLBackend.generate_compile_specs(
             minimum_deployment_target=ct.target.iOS18,
             compute_precision=ct.precision.FLOAT32,
             compute_unit=ct.ComputeUnit.CPU_ONLY,
             model_type=CoreMLBackend.MODEL_TYPE.MODEL,
         )
-        if weight_sharing:
+        if strategy is not None:
             compile_specs.append(
                 CoreMLBackend.generate_multimethod_weight_sharing_strategy_compile_spec(
-                    MULTIMETHOD_WEIGHT_SHARING_STRATEGY.POSITIONAL
+                    strategy
                 )
             )
         return compile_specs
 
-    def test_multifunction_simple_model(self):
-        """Test exporting a simple model with multiple methods (forward and prefill)."""
+    def _export_and_lower(
+        self,
+        model: torch.nn.Module,
+        method_inputs: Dict[str, Tuple],
+        strategy: Optional[MULTIMETHOD_WEIGHT_SHARING_STRATEGY] = None,
+        constant_methods: Optional[Dict[str, int]] = None,
+    ):
+        """Export methods, partition, and lower to ExecuTorch program.
 
-        class SimpleModel(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.linear = torch.nn.Linear(16, 16)
+        Args:
+            model: The PyTorch module to export.
+            method_inputs: Dict mapping method name to example input tuple.
+            strategy: Weight sharing strategy, or None for no strategy spec.
+            constant_methods: Optional constant methods metadata dict.
 
-            def forward(self, x):
-                return self.linear(x)
+        Returns:
+            Tuple of (et_program, edge_manager).
+        """
+        exported_programs = {
+            name: torch.export.export(model, inputs)
+            for name, inputs in method_inputs.items()
+        }
 
-        model = SimpleModel()
-        model.eval()
-
-        # Create example inputs for two different sequence lengths
-        decode_inputs = (torch.randn(1, 1, 16),)  # seqlen=1
-        prefill_inputs = (torch.randn(1, 8, 16),)  # seqlen=8
-
-        # Export both methods
-        decode_ep = torch.export.export(model, decode_inputs)
-        prefill_ep = torch.export.export(model, prefill_inputs)
-
-        # Create partitioner with multifunction support
         partitioner = CoreMLPartitioner(
-            compile_specs=self._get_compile_specs(weight_sharing=True),
+            compile_specs=self._get_compile_specs(strategy=strategy),
         )
 
-        # Lower to edge with multiple methods
+        kwargs = {}
+        if constant_methods is not None:
+            kwargs["constant_methods"] = constant_methods
+
         edge_manager = to_edge_transform_and_lower(
-            {"forward": decode_ep, "prefill": prefill_ep},
+            exported_programs,
             partitioner=[partitioner],
             compile_config=self.edge_compile_config,
+            **kwargs,
         )
 
-        # Verify both methods exist
-        method_names = edge_manager.methods
-        self.assertIn("forward", method_names)
-        self.assertIn("prefill", method_names)
-
-        # Convert to ExecuTorch
         et_program = edge_manager.to_executorch()
+        return et_program, edge_manager
+
+    def test_multifunction_simple_model(self):
+        """Test exporting a simple model with multiple methods (forward and prefill)."""
+        model = self.SimpleModel()
+        model.eval()
+
+        decode_inputs = (torch.randn(1, 1, 16),)
+        prefill_inputs = (torch.randn(1, 8, 16),)
+
+        et_program, edge_manager = self._export_and_lower(
+            model,
+            {"forward": decode_inputs, "prefill": prefill_inputs},
+            strategy=MULTIMETHOD_WEIGHT_SHARING_STRATEGY.POSITIONAL,
+        )
+
+        self.assertIn("forward", edge_manager.methods)
+        self.assertIn("prefill", edge_manager.methods)
 
         if _TEST_RUNTIME:
-            # Test runtime execution
             runtime = Runtime.get()
             program = runtime.load_program(et_program.buffer)
 
-            # Check both methods are available
-            available_methods = program.method_names
-            self.assertIn("forward", available_methods)
-            self.assertIn("prefill", available_methods)
+            self.assertIn("forward", program.method_names)
+            self.assertIn("prefill", program.method_names)
 
-            # Test forward (decode) method
             forward_method = program.load_method("forward")
             decode_output = forward_method.execute(decode_inputs)
             expected_decode = model(*decode_inputs)
@@ -126,7 +150,6 @@ class TestCoreMLMultifunction(unittest.TestCase):
                 torch.allclose(decode_output[0], expected_decode, atol=1e-4, rtol=1e-4)
             )
 
-            # Test prefill method
             prefill_method = program.load_method("prefill")
             prefill_output = prefill_method.execute(prefill_inputs)
             expected_prefill = model(*prefill_inputs)
@@ -147,10 +170,7 @@ class TestCoreMLMultifunction(unittest.TestCase):
                 self.cache_len = cache_len
 
             def forward(self, x, cache):
-                # x: [batch, seqlen, hidden_dim]
-                # cache: [batch, cache_len, hidden_dim]
                 out = self.linear(x)
-                # Simple cache update simulation
                 new_cache = torch.cat([cache[:, 1:, :], out[:, -1:, :]], dim=1)
                 return out, new_cache
 
@@ -159,38 +179,25 @@ class TestCoreMLMultifunction(unittest.TestCase):
         model = ModelWithCache(hidden_dim, cache_len)
         model.eval()
 
-        # Decode: seqlen=1
         decode_inputs = (
             torch.randn(1, 1, hidden_dim),
             torch.randn(1, cache_len, hidden_dim),
         )
-
-        # Prefill: seqlen=8
         prefill_inputs = (
             torch.randn(1, 8, hidden_dim),
             torch.randn(1, cache_len, hidden_dim),
         )
 
-        decode_ep = torch.export.export(model, decode_inputs)
-        prefill_ep = torch.export.export(model, prefill_inputs)
-
-        partitioner = CoreMLPartitioner(
-            compile_specs=self._get_compile_specs(weight_sharing=True),
+        et_program, _ = self._export_and_lower(
+            model,
+            {"forward": decode_inputs, "prefill": prefill_inputs},
+            strategy=MULTIMETHOD_WEIGHT_SHARING_STRATEGY.POSITIONAL,
         )
-
-        edge_manager = to_edge_transform_and_lower(
-            {"forward": decode_ep, "prefill": prefill_ep},
-            partitioner=[partitioner],
-            compile_config=self.edge_compile_config,
-        )
-
-        et_program = edge_manager.to_executorch()
 
         if _TEST_RUNTIME:
             runtime = Runtime.get()
             program = runtime.load_program(et_program.buffer)
 
-            # Test decode
             forward_method = program.load_method("forward")
             decode_output = forward_method.execute(decode_inputs)
             expected_out, expected_cache = model(*decode_inputs)
@@ -201,7 +208,6 @@ class TestCoreMLMultifunction(unittest.TestCase):
                 torch.allclose(decode_output[1], expected_cache, atol=1e-4, rtol=1e-4)
             )
 
-            # Test prefill
             prefill_method = program.load_method("prefill")
             prefill_output = prefill_method.execute(prefill_inputs)
             expected_out, expected_cache = model(*prefill_inputs)
@@ -214,50 +220,20 @@ class TestCoreMLMultifunction(unittest.TestCase):
 
     def test_multifunction_without_weight_sharing(self):
         """Test multifunction export without weight sharing."""
-
-        class SimpleModel(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.linear = torch.nn.Linear(16, 16)
-
-            def forward(self, x):
-                return self.linear(x)
-
-        model = SimpleModel()
+        model = self.SimpleModel()
         model.eval()
 
         decode_inputs = (torch.randn(1, 1, 16),)
         prefill_inputs = (torch.randn(1, 8, 16),)
 
-        decode_ep = torch.export.export(model, decode_inputs)
-        prefill_ep = torch.export.export(model, prefill_inputs)
-
-        # Create partitioner without weight sharing
-        compile_specs = CoreMLBackend.generate_compile_specs(
-            minimum_deployment_target=ct.target.iOS18,
-            compute_precision=ct.precision.FLOAT32,
-            compute_unit=ct.ComputeUnit.CPU_ONLY,
-            model_type=CoreMLBackend.MODEL_TYPE.MODEL,
-        )
-        compile_specs.append(
-            CoreMLBackend.generate_multimethod_weight_sharing_strategy_compile_spec(
-                MULTIMETHOD_WEIGHT_SHARING_STRATEGY.DISABLED
-            )
+        et_program, edge_manager = self._export_and_lower(
+            model,
+            {"forward": decode_inputs, "prefill": prefill_inputs},
+            strategy=MULTIMETHOD_WEIGHT_SHARING_STRATEGY.DISABLED,
         )
 
-        partitioner = CoreMLPartitioner(compile_specs=compile_specs)
-
-        edge_manager = to_edge_transform_and_lower(
-            {"forward": decode_ep, "prefill": prefill_ep},
-            partitioner=[partitioner],
-            compile_config=self.edge_compile_config,
-        )
-
-        method_names = edge_manager.methods
-        self.assertIn("forward", method_names)
-        self.assertIn("prefill", method_names)
-
-        et_program = edge_manager.to_executorch()
+        self.assertIn("forward", edge_manager.methods)
+        self.assertIn("prefill", edge_manager.methods)
 
         if _TEST_RUNTIME:
             runtime = Runtime.get()
@@ -272,29 +248,12 @@ class TestCoreMLMultifunction(unittest.TestCase):
 
     def test_multifunction_with_constant_methods(self):
         """Test multifunction export with constant methods (metadata)."""
-
-        class SimpleModel(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.linear = torch.nn.Linear(16, 16)
-
-            def forward(self, x):
-                return self.linear(x)
-
-        model = SimpleModel()
+        model = self.SimpleModel()
         model.eval()
 
         decode_inputs = (torch.randn(1, 1, 16),)
         prefill_inputs = (torch.randn(1, 8, 16),)
 
-        decode_ep = torch.export.export(model, decode_inputs)
-        prefill_ep = torch.export.export(model, prefill_inputs)
-
-        partitioner = CoreMLPartitioner(
-            compile_specs=self._get_compile_specs(weight_sharing=True),
-        )
-
-        # Add constant methods (metadata)
         constant_methods = {
             "vocab_size": 32000,
             "hidden_dim": 16,
@@ -302,20 +261,17 @@ class TestCoreMLMultifunction(unittest.TestCase):
             "prefill_seqlen": 8,
         }
 
-        edge_manager = to_edge_transform_and_lower(
-            {"forward": decode_ep, "prefill": prefill_ep},
-            partitioner=[partitioner],
+        et_program, _ = self._export_and_lower(
+            model,
+            {"forward": decode_inputs, "prefill": prefill_inputs},
+            strategy=MULTIMETHOD_WEIGHT_SHARING_STRATEGY.POSITIONAL,
             constant_methods=constant_methods,
-            compile_config=self.edge_compile_config,
         )
-
-        et_program = edge_manager.to_executorch()
 
         if _TEST_RUNTIME:
             runtime = Runtime.get()
             program = runtime.load_program(et_program.buffer)
 
-            # Check all methods are available (executable + constant)
             available_methods = program.method_names
             self.assertIn("forward", available_methods)
             self.assertIn("prefill", available_methods)
@@ -324,6 +280,46 @@ class TestCoreMLMultifunction(unittest.TestCase):
             self.assertIn("decode_seqlen", available_methods)
             self.assertIn("prefill_seqlen", available_methods)
 
+    def test_multifunction_one_blob_simple_model(self):
+        """Test exporting a simple model using ONE_BLOB weight sharing strategy."""
+        model = self.SimpleModel()
+        model.eval()
+
+        decode_inputs = (torch.randn(1, 1, 16),)
+        prefill_inputs = (torch.randn(1, 8, 16),)
+
+        et_program, edge_manager = self._export_and_lower(
+            model,
+            {"forward": decode_inputs, "prefill": prefill_inputs},
+            strategy=MULTIMETHOD_WEIGHT_SHARING_STRATEGY.ONE_BLOB,
+        )
+
+        self.assertIn("forward", edge_manager.methods)
+        self.assertIn("prefill", edge_manager.methods)
+
+        if _TEST_RUNTIME:
+            runtime = Runtime.get()
+            program = runtime.load_program(et_program.buffer)
+
+            self.assertIn("forward", program.method_names)
+            self.assertIn("prefill", program.method_names)
+
+            forward_method = program.load_method("forward")
+            decode_output = forward_method.execute(decode_inputs)
+            expected_decode = model(*decode_inputs)
+            self.assertTrue(
+                torch.allclose(decode_output[0], expected_decode, atol=1e-4, rtol=1e-4)
+            )
+
+            prefill_method = program.load_method("prefill")
+            prefill_output = prefill_method.execute(prefill_inputs)
+            expected_prefill = model(*prefill_inputs)
+            self.assertTrue(
+                torch.allclose(
+                    prefill_output[0], expected_prefill, atol=1e-4, rtol=1e-4
+                )
+            )
+
 
 if __name__ == "__main__":
     test_runner = TestCoreMLMultifunction()
@@ -331,4 +327,5 @@ if __name__ == "__main__":
     test_runner.test_multifunction_with_kv_cache()
     test_runner.test_multifunction_without_weight_sharing()
     test_runner.test_multifunction_with_constant_methods()
+    test_runner.test_multifunction_one_blob_simple_model()
     print("All tests passed!")

--- a/backends/apple/coreml/test/test_coreml_multifunction.py
+++ b/backends/apple/coreml/test/test_coreml_multifunction.py
@@ -9,13 +9,14 @@ from typing import Dict, Optional, Tuple
 
 import coremltools as ct
 import torch
-
+import torch.nn as nn
 from executorch.backends.apple.coreml.compiler.coreml_preprocess import (
     CoreMLBackend,
     MULTIMETHOD_WEIGHT_SHARING_STRATEGY,
 )
 from executorch.backends.apple.coreml.partition import CoreMLPartitioner
 from executorch.exir import EdgeCompileConfig, to_edge_transform_and_lower
+from executorch.exir.graph_break import remove_graph_break_ops
 
 
 def is_fbcode():
@@ -320,6 +321,92 @@ class TestCoreMLMultifunction(unittest.TestCase):
                 )
             )
 
+    def test_multifunction_one_blob_multiple_partitions(self):
+        """Test ONE_BLOB with multiple partitions per method.
+
+        Uses graph breaks to force the CoreML partitioner to create multiple
+        partitions within each method (forward and prefill). The two partitions
+        have a different number of inputs and outputs so their metadata
+        (input/output name lists) differ.
+
+        Partition 0: 1 input (x) → 2 outputs (a, b)
+        Partition 1: 2 inputs (a, b) → 1 output (result)
+        """
+
+        class _GraphBreak(nn.Module):
+            def forward(self, x):
+                return torch.ops.executorch_utils.graph_break.Tensor(x)
+
+        class MultiPartitionModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear_a = nn.Linear(16, 16)
+                self.linear_b = nn.Linear(16, 16)
+                self.graph_break_a = _GraphBreak()
+                self.graph_break_b = _GraphBreak()
+                self.linear_out = nn.Linear(32, 16)
+
+            def forward(self, x):
+                a = self.linear_a(x)
+                b = self.linear_b(x)
+                a = self.graph_break_a(a)
+                b = self.graph_break_b(b)
+                combined = torch.cat([a, b], dim=-1)
+                return self.linear_out(combined)
+
+        model = MultiPartitionModel()
+        model.eval()
+
+        decode_inputs = (torch.randn(1, 1, 16),)
+        prefill_inputs = (torch.randn(1, 8, 16),)
+
+        exported_programs = {
+            "forward": torch.export.export(model, decode_inputs),
+            "prefill": torch.export.export(model, prefill_inputs),
+        }
+
+        partitioner = CoreMLPartitioner(
+            compile_specs=self._get_compile_specs(
+                strategy=MULTIMETHOD_WEIGHT_SHARING_STRATEGY.ONE_BLOB,
+            ),
+        )
+
+        edge_manager = to_edge_transform_and_lower(
+            exported_programs,
+            partitioner=[partitioner],
+            compile_config=self.edge_compile_config,
+        )
+
+        self.assertIn("forward", edge_manager.methods)
+        self.assertIn("prefill", edge_manager.methods)
+
+        remove_graph_break_ops(edge_manager)
+
+        et_program = edge_manager.to_executorch()
+
+        if _TEST_RUNTIME:
+            runtime = Runtime.get()
+            program = runtime.load_program(et_program.buffer)
+
+            self.assertIn("forward", program.method_names)
+            self.assertIn("prefill", program.method_names)
+
+            forward_method = program.load_method("forward")
+            decode_output = forward_method.execute(decode_inputs)
+            expected_decode = model(*decode_inputs)
+            self.assertTrue(
+                torch.allclose(decode_output[0], expected_decode, atol=1e-4, rtol=1e-4)
+            )
+
+            prefill_method = program.load_method("prefill")
+            prefill_output = prefill_method.execute(prefill_inputs)
+            expected_prefill = model(*prefill_inputs)
+            self.assertTrue(
+                torch.allclose(
+                    prefill_output[0], expected_prefill, atol=1e-4, rtol=1e-4
+                )
+            )
+
 
 if __name__ == "__main__":
     test_runner = TestCoreMLMultifunction()
@@ -328,4 +415,5 @@ if __name__ == "__main__":
     test_runner.test_multifunction_without_weight_sharing()
     test_runner.test_multifunction_with_constant_methods()
     test_runner.test_multifunction_one_blob_simple_model()
+    test_runner.test_multifunction_one_blob_multiple_partitions()
     print("All tests passed!")

--- a/examples/apple/coreml/llama/export_static_llm_coreml.py
+++ b/examples/apple/coreml/llama/export_static_llm_coreml.py
@@ -24,9 +24,7 @@ import json
 
 import coremltools as ct
 import torch
-import torch.nn as nn
 import torch.utils._pytree as pytree
-
 from executorch.backends.apple.coreml.compiler.coreml_preprocess import (
     CoreMLBackend,
     MULTIMETHOD_WEIGHT_SHARING_STRATEGY,
@@ -42,68 +40,12 @@ from executorch.examples.models.llama.static_attention import StaticAttentionIOM
 from executorch.exir import EdgeCompileConfig, to_edge_transform_and_lower
 from executorch.exir.backend.utils import format_delegated_graph
 from executorch.exir.capture._config import ExecutorchBackendConfig
+from executorch.exir.graph_break import BlockWithGraphBreak, remove_graph_break_ops
 from executorch.exir.passes import MemoryPlanningPass
 from executorch.exir.passes.sym_shape_eval_pass import ConstraintBasedSymShapeEvalPass
 from executorch.extension.export_util.utils import save_pte_program
-from torch.library import impl, Library
 from torchao.quantization.granularity import PerAxis, PerGroup
 from torchao.quantization.quant_api import IntxWeightOnlyConfig, quantize_
-
-# Define custom graph break op
-lib = Library("executorch_utils", "DEF")
-lib.define("graph_break.Tensor(Tensor x) -> Tensor")
-
-
-@impl(lib, "graph_break.Tensor", "CompositeExplicitAutograd")
-def graph_break_impl(x):
-    return x
-
-
-class ExecutorchGraphBreakModule(nn.Module):
-    def __init__(self):
-        super().__init__()
-
-    def forward(self, *args, **kwargs):
-        return tuple(
-            (
-                torch.ops.executorch_utils.graph_break.Tensor(a)
-                if isinstance(a, torch.Tensor)
-                else a
-            )
-            for a in args
-        )
-
-
-class BlockWithGraphBreak(nn.Module):
-    def __init__(self, block: nn.Module, break_before: bool = True):
-        super().__init__()
-        self.graph_break = ExecutorchGraphBreakModule()
-        self.block = block
-        self.break_before = break_before
-
-    def forward(self, *args, **kwargs):
-        if self.break_before:
-            new_args = self.graph_break(*args)
-            out = self.block(*new_args, **kwargs)
-            return out
-        else:
-            out = self.block(*args, **kwargs)
-            out = self.graph_break(*out)
-            return out
-
-
-def remove_graph_break_(edge_manager):
-    """Remove graph break ops from all methods in the edge manager."""
-    from executorch.exir.dialects._ops import ops as exir_ops
-
-    # Get all method names
-    method_names = edge_manager.methods
-    for method_name in method_names:
-        ep = edge_manager.exported_program(method_name)
-        for n in ep.graph_module.graph.nodes:
-            if n.target == exir_ops.edge.executorch_utils.graph_break.Tensor:
-                n.replace_all_uses_with(n.args[0])
-        ep.graph_module.graph.eliminate_dead_code()
 
 
 def load_model(
@@ -696,7 +638,7 @@ def main():
 
     # Convert to ExecuTorch
     print("\nConverting to ExecuTorch...")
-    remove_graph_break_(edge_manager)
+    remove_graph_break_ops(edge_manager)
     executorch_program = edge_manager.to_executorch(
         ExecutorchBackendConfig(
             extract_delegate_segments=True,

--- a/exir/graph_break.py
+++ b/exir/graph_break.py
@@ -1,0 +1,114 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Utilities for inserting graph breaks to force backend partitioning boundaries.
+
+A graph break is an identity custom op that is not recognized by any backend's
+``CapabilityBasedPartitioner``, which prevents the partitioner from merging
+nodes across the break into a single partition. After partitioning, the graph
+break ops should be removed via :func:`remove_graph_break_ops`.
+
+Typical workflow::
+
+    from executorch.exir.graph_break import BlockWithGraphBreak, remove_graph_break_ops
+
+    # 1. Wrap model blocks with graph breaks before export
+    model.layers[0] = BlockWithGraphBreak(model.layers[0], break_before=True)
+    model.layers[-1] = BlockWithGraphBreak(model.layers[-1], break_before=False)
+
+    # 2. Export and lower (partitioner creates splits at graph breaks)
+    edge_manager = to_edge_transform_and_lower(exported_programs, ...)
+
+    # 3. Remove graph break ops from the edge program
+    remove_graph_break_ops(edge_manager)
+
+    # 4. Convert to ExecuTorch
+    et_program = edge_manager.to_executorch()
+"""
+
+from typing import Any, Tuple
+
+import torch
+import torch.nn as nn
+from torch.library import impl, Library
+
+__all__ = [
+    "GraphBreakModule",
+    "BlockWithGraphBreak",
+    "remove_graph_break_ops",
+]
+
+# Register the custom op. The op is an identity function that is unknown to
+# backends, forcing the partitioner to create a boundary at this node.
+_lib = Library("executorch_utils", "DEF")
+_lib.define("graph_break.Tensor(Tensor x) -> Tensor")
+
+
+@impl(_lib, "graph_break.Tensor", "CompositeExplicitAutograd")
+def _graph_break_impl(x: torch.Tensor) -> torch.Tensor:
+    return x
+
+
+class GraphBreakModule(nn.Module):
+    """Module that applies a graph break to every tensor in ``*args``.
+
+    Non-tensor arguments are passed through unchanged.
+    """
+
+    def forward(self, *args: Any, **kwargs: Any) -> Tuple[Any, ...]:
+        return tuple(
+            (
+                torch.ops.executorch_utils.graph_break.Tensor(a)
+                if isinstance(a, torch.Tensor)
+                else a
+            )
+            for a in args
+        )
+
+
+class BlockWithGraphBreak(nn.Module):
+    """Wraps a module with a graph break inserted before or after it.
+
+    Args:
+        block: The module to wrap.
+        break_before: If ``True``, the graph break is inserted before ``block``.
+            If ``False``, it is inserted after.
+    """
+
+    def __init__(self, block: nn.Module, break_before: bool = True) -> None:
+        super().__init__()
+        self.graph_break = GraphBreakModule()
+        self.block = block
+        self.break_before = break_before
+
+    def forward(self, *args: Any, **kwargs: Any) -> Any:
+        if self.break_before:
+            new_args = self.graph_break(*args)
+            return self.block(*new_args, **kwargs)
+        else:
+            out = self.block(*args, **kwargs)
+            out = self.graph_break(*out)
+            return out
+
+
+def remove_graph_break_ops(edge_manager: Any) -> None:
+    """Remove all graph break ops from an edge manager's methods.
+
+    This should be called after ``to_edge_transform_and_lower`` (which creates
+    partition boundaries at graph breaks) but before ``to_executorch()``.
+
+    Args:
+        edge_manager: The ``EdgeProgramManager`` to modify in-place.
+    """
+    from executorch.exir.dialects._ops import ops as exir_ops
+
+    for method_name in edge_manager.methods:
+        ep = edge_manager.exported_program(method_name)
+        for n in ep.graph_module.graph.nodes:
+            if n.target == exir_ops.edge.executorch_utils.graph_break.Tensor:
+                n.replace_all_uses_with(n.args[0])
+        ep.graph_module.graph.eliminate_dead_code()


### PR DESCRIPTION
Adds a new ONE_BLOB weight sharing strategy for CoreML multifunction models that combines all partitions from all methods into a single multifunction model, stored as one entry in NamedDataStore.

# Motivation
The existing POSITIONAL strategy requires all methods to have the same number of partitions and creates one multifunction model per partition index. This works if each method has the same number of partitions, and these partitions are aligned to naturally share weights. But we want to relax this restriction.

Design
POSITIONAL (existing): N blobs, one per partition index. Each blob contains that partition from every method. Requires partition count alignment.

combined_partition_0.mlpackage → functions: {forward, prefill}
combined_partition_1.mlpackage → functions: {forward, prefill}
combined_partition_2.mlpackage → functions: {forward, prefill}

ONE_BLOB (new): 1 blob containing all partition × method combinations. No partition count alignment required. Function names use {method}__{partition_idx} encoding for CoreML dispatch; metadata is keyed by method name for runtime compatibility.

combined_all.mlpackage → functions: {forward__0, forward__1, forward__2,
                                     prefill__0, prefill__1, prefill__2}

No runtime changes required. The existing CMJR JSON reference mechanism (functionName field) was designed to support arbitrary function names.

# Test plan

Existing CI + new unit test