### PR TITLE
Report error with context in place for improving debuggability

### DIFF
--- a/runtime/kernel/operator_registry.cpp
+++ b/runtime/kernel/operator_registry.cpp
@@ -88,6 +88,13 @@ Error register_kernels_internal(const Span<const Kernel> kernels) {
           kernel.kernel_key_ == k.kernel_key_) {
         ET_LOG(Error, "Re-registering %s, from %s", k.name_, lib_name);
         ET_LOG_KERNEL_KEY(k.kernel_key_);
+        ET_CHECK_MSG(
+            false,
+            "Kernel registration failed with error %" PRIu32
+            ", Re-registering %s, from %s",
+            static_cast<uint32_t>(Error::RegistrationAlreadyRegistered),
+            k.name_,
+            lib_name);
         return Error::RegistrationAlreadyRegistered;
       }
     }


### PR DESCRIPTION
Summary:
[executorch] Use std::string& output parameter for error reporting in register_kernels_internal

Replace ET_LOG(Error, ...) calls inside register_kernels_internal with a std::string& output parameter to collect error messages. This allows the caller (register_kernels) to include the full error details in the ET_CHECK_MSG panic message, making registration failures easier to diagnose without relying on separate log output.

Changes:
- Add std::string& error_message parameter to register_kernels_internal
- Replace all ET_LOG(Error, ...) and ET_LOG_KERNEL_KEY(...) calls with string appends to error_message
- Add kernel_key_to_string helper to format KernelKey into a std::string
- Update register_kernels to pass error_message through to ET_CHECK_MSG
- Keep ET_LOG(Debug, ...) on the success path unchanged

Reviewed By: RuijieC-dev

Differential Revision: D98298906
