### PR TITLE
Cortex-M: Add MLPerf Tiny model tests

### DIFF
--- a/backends/cortex_m/test/models/test_deep_autoencoder.py
+++ b/backends/cortex_m/test/models/test_deep_autoencoder.py
@@ -1,0 +1,44 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+from executorch.backends.arm.test.common import parametrize
+from executorch.backends.cortex_m.test.tester import CortexMTester, McuTestCase
+from executorch.examples.models.mlperf_tiny.deep_autoencoder import DeepAutoEncoder
+
+ops_before_transforms: dict[str, int] = {
+    "executorch_exir_dialects_edge__ops_aten_linear_default": 10,
+    "executorch_exir_dialects_edge__ops_aten_relu_default": 9,
+    "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_tensor_default": 31,
+    "executorch_exir_dialects_edge__ops_quantized_decomposed_quantize_per_tensor_default": 11,
+}
+
+ops_after_transforms: dict[str, int] = {
+    "executorch_exir_dialects_edge__ops_cortex_m_dequantize_per_tensor_default": 1,
+    "executorch_exir_dialects_edge__ops_cortex_m_quantize_per_tensor_default": 1,
+    "executorch_exir_dialects_edge__ops_cortex_m_quantized_linear_default": 10,
+}
+
+test_cases = {
+    "deep_autoencoder": McuTestCase(
+        model=DeepAutoEncoder().eval(),
+        example_inputs=lambda: ((torch.rand(1, 640) * 2 - 1,)),
+    ),
+}
+
+
+@parametrize("test_case", test_cases)
+def test_dialect_deep_autoencoder(test_case):
+    inputs = test_case.get_example_inputs()
+    tester = CortexMTester(test_case.model, inputs)
+    tester.test_dialect(ops_before_transforms, ops_after_transforms, qtol=1)
+
+
+@parametrize("test_case", test_cases)
+def test_implementation_deep_autoencoder(test_case):
+    inputs = test_case.get_example_inputs()
+    tester = CortexMTester(test_case.model, inputs)
+    tester.test_implementation(qtol=1)

--- a/backends/cortex_m/test/models/test_ds_cnn.py
+++ b/backends/cortex_m/test/models/test_ds_cnn.py
@@ -1,0 +1,57 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+from executorch.backends.arm.test.common import parametrize
+from executorch.backends.cortex_m.test.tester import CortexMTester, McuTestCase
+from executorch.examples.models.mlperf_tiny.ds_cnn import DSCNNKWS
+
+ops_before_transforms: dict[str, int] = {
+    "executorch_exir_dialects_edge__ops_aten_avg_pool2d_default": 1,
+    "executorch_exir_dialects_edge__ops_aten_convolution_default": 9,
+    "executorch_exir_dialects_edge__ops_aten_linear_default": 1,
+    "executorch_exir_dialects_edge__ops_aten_relu_default": 9,
+    "executorch_exir_dialects_edge__ops_aten_view_copy_default": 1,
+    "executorch_exir_dialects_edge__ops_dim_order_ops__clone_dim_order_default": 2,
+    "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_channel_default": 18,
+    "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_tensor_default": 17,
+    "executorch_exir_dialects_edge__ops_quantized_decomposed_quantize_per_tensor_default": 15,
+}
+
+ops_after_transforms: dict[str, int] = {
+    "executorch_exir_dialects_edge__ops_aten_view_copy_default": 1,
+    "executorch_exir_dialects_edge__ops_cortex_m_dequantize_per_tensor_default": 1,
+    "executorch_exir_dialects_edge__ops_cortex_m_pad_default": 1,
+    "executorch_exir_dialects_edge__ops_cortex_m_quantize_per_tensor_default": 1,
+    "executorch_exir_dialects_edge__ops_cortex_m_quantized_avg_pool2d_default": 1,
+    "executorch_exir_dialects_edge__ops_cortex_m_quantized_conv2d_default": 4,
+    "executorch_exir_dialects_edge__ops_cortex_m_quantized_depthwise_conv2d_default": 5,
+    "executorch_exir_dialects_edge__ops_cortex_m_quantized_linear_default": 1,
+    "executorch_exir_dialects_edge__ops_dim_order_ops__clone_dim_order_default": 2,
+}
+
+test_cases = {
+    "ds_cnn": McuTestCase(
+        model=DSCNNKWS().eval(),
+        example_inputs=lambda: (
+            (torch.rand(1, 1, 49, 10) * 2 - 1).to(memory_format=torch.channels_last),
+        ),
+    ),
+}
+
+
+@parametrize("test_case", test_cases)
+def test_dialect_ds_cnn(test_case):
+    inputs = test_case.get_example_inputs()
+    tester = CortexMTester(test_case.model, inputs)
+    tester.test_dialect(ops_before_transforms, ops_after_transforms, qtol=1)
+
+
+@parametrize("test_case", test_cases)
+def test_implementation_ds_cnn(test_case):
+    inputs = test_case.get_example_inputs()
+    tester = CortexMTester(test_case.model, inputs)
+    tester.test_implementation(qtol=1)

--- a/backends/cortex_m/test/models/test_mobilenet_v1_025.py
+++ b/backends/cortex_m/test/models/test_mobilenet_v1_025.py
@@ -1,0 +1,54 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+from executorch.backends.arm.test.common import parametrize
+from executorch.backends.cortex_m.test.tester import CortexMTester, McuTestCase
+from executorch.examples.models.mlperf_tiny.mobilenet_v1_025 import MobileNetV1025
+
+ops_before_transforms: dict[str, int] = {
+    "executorch_exir_dialects_edge__ops_aten_avg_pool2d_default": 1,
+    "executorch_exir_dialects_edge__ops_aten_convolution_default": 27,
+    "executorch_exir_dialects_edge__ops_aten_linear_default": 1,
+    "executorch_exir_dialects_edge__ops_aten_relu_default": 27,
+    "executorch_exir_dialects_edge__ops_aten_view_copy_default": 1,
+    "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_channel_default": 54,
+    "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_tensor_default": 33,
+    "executorch_exir_dialects_edge__ops_quantized_decomposed_quantize_per_tensor_default": 31,
+}
+
+ops_after_transforms: dict[str, int] = {
+    "executorch_exir_dialects_edge__ops_aten_view_copy_default": 1,
+    "executorch_exir_dialects_edge__ops_cortex_m_dequantize_per_tensor_default": 1,
+    "executorch_exir_dialects_edge__ops_cortex_m_quantize_per_tensor_default": 1,
+    "executorch_exir_dialects_edge__ops_cortex_m_quantized_avg_pool2d_default": 1,
+    "executorch_exir_dialects_edge__ops_cortex_m_quantized_conv2d_default": 14,
+    "executorch_exir_dialects_edge__ops_cortex_m_quantized_depthwise_conv2d_default": 13,
+    "executorch_exir_dialects_edge__ops_cortex_m_quantized_linear_default": 1,
+}
+
+test_cases = {
+    "mobilenet_v1_025": McuTestCase(
+        model=MobileNetV1025().eval(),
+        example_inputs=lambda: (
+            (torch.rand(1, 3, 96, 96) * 2 - 1).to(memory_format=torch.channels_last),
+        ),
+    ),
+}
+
+
+@parametrize("test_case", test_cases)
+def test_dialect_mobilenet_v1_025(test_case):
+    inputs = test_case.get_example_inputs()
+    tester = CortexMTester(test_case.model, inputs)
+    tester.test_dialect(ops_before_transforms, ops_after_transforms, qtol=1)
+
+
+@parametrize("test_case", test_cases)
+def test_implementation_mobilenet_v1_025(test_case):
+    inputs = test_case.get_example_inputs()
+    tester = CortexMTester(test_case.model, inputs)
+    tester.test_implementation(qtol=1)

--- a/backends/cortex_m/test/models/test_resnet8.py
+++ b/backends/cortex_m/test/models/test_resnet8.py
@@ -45,7 +45,7 @@ test_cases = {
 def test_dialect_resnet8(test_case):
     inputs = test_case.get_example_inputs()
     tester = CortexMTester(test_case.model, inputs)
-    tester.test_dialect(ops_before_transforms, ops_after_transforms, qtol=1, atol=0.1)
+    tester.test_dialect(ops_before_transforms, ops_after_transforms, qtol=1)
 
 
 @parametrize("test_case", test_cases)

--- a/backends/cortex_m/test/models/test_resnet8.py
+++ b/backends/cortex_m/test/models/test_resnet8.py
@@ -1,0 +1,55 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+from executorch.backends.arm.test.common import parametrize
+from executorch.backends.cortex_m.test.tester import CortexMTester, McuTestCase
+from executorch.examples.models.mlperf_tiny.resnet8 import ResNet8
+
+ops_before_transforms: dict[str, int] = {
+    "executorch_exir_dialects_edge__ops_aten_add_Tensor": 3,
+    "executorch_exir_dialects_edge__ops_aten_avg_pool2d_default": 1,
+    "executorch_exir_dialects_edge__ops_aten_convolution_default": 9,
+    "executorch_exir_dialects_edge__ops_aten_linear_default": 1,
+    "executorch_exir_dialects_edge__ops_aten_relu_default": 7,
+    "executorch_exir_dialects_edge__ops_aten_view_copy_default": 1,
+    "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_channel_default": 16,
+    "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_tensor_default": 21,
+    "executorch_exir_dialects_edge__ops_quantized_decomposed_quantize_per_tensor_default": 16,
+}
+
+ops_after_transforms: dict[str, int] = {
+    "executorch_exir_dialects_edge__ops_aten_view_copy_default": 1,
+    "executorch_exir_dialects_edge__ops_cortex_m_dequantize_per_tensor_default": 1,
+    "executorch_exir_dialects_edge__ops_cortex_m_quantize_per_tensor_default": 1,
+    "executorch_exir_dialects_edge__ops_cortex_m_quantized_add_default": 3,
+    "executorch_exir_dialects_edge__ops_cortex_m_quantized_avg_pool2d_default": 1,
+    "executorch_exir_dialects_edge__ops_cortex_m_quantized_conv2d_default": 9,
+    "executorch_exir_dialects_edge__ops_cortex_m_quantized_linear_default": 1,
+}
+
+test_cases = {
+    "resnet8": McuTestCase(
+        model=ResNet8().eval(),
+        example_inputs=lambda: (
+            (torch.rand(1, 3, 32, 32) * 2 - 1).to(memory_format=torch.channels_last),
+        ),
+    ),
+}
+
+
+@parametrize("test_case", test_cases)
+def test_dialect_resnet8(test_case):
+    inputs = test_case.get_example_inputs()
+    tester = CortexMTester(test_case.model, inputs)
+    tester.test_dialect(ops_before_transforms, ops_after_transforms, qtol=1, atol=0.1)
+
+
+@parametrize("test_case", test_cases)
+def test_implementation_resnet8(test_case):
+    inputs = test_case.get_example_inputs()
+    tester = CortexMTester(test_case.model, inputs)
+    tester.test_implementation(qtol=1)

--- a/backends/cortex_m/test/tester.py
+++ b/backends/cortex_m/test/tester.py
@@ -4,8 +4,9 @@
 # LICENSE file in the root directory of this source tree.
 
 
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Callable
+from typing import Any
 
 import torch
 from executorch.backends.arm.test.common import get_u55_compile_spec
@@ -84,6 +85,7 @@ class CortexMTester(TesterBase):
         ops_before_transforms,
         ops_after_transforms,
         qtol=0,
+        atol=1e-03,
         calibration_samples=None,
     ):
         """
@@ -102,9 +104,11 @@ class CortexMTester(TesterBase):
         self.check_count(ops_before_transforms)
         self.run_passes()
         self.check_count(ops_after_transforms)
-        self.run_method_and_compare_outputs(inputs=self.example_inputs, qtol=qtol)
+        self.run_method_and_compare_outputs(
+            inputs=self.example_inputs, qtol=qtol, atol=atol
+        )
 
-    def test_implementation(self, qtol=0, calibration_samples=None):
+    def test_implementation(self, qtol=0, atol=1e-03, calibration_samples=None):
         """
         Test the optimized op implementation in simulation
         """
@@ -122,7 +126,9 @@ class CortexMTester(TesterBase):
         self.run_passes()
         self.to_executorch()
         self.serialize()
-        self.run_method_and_compare_outputs(inputs=self.example_inputs, qtol=qtol)
+        self.run_method_and_compare_outputs(
+            inputs=self.example_inputs, qtol=qtol, atol=atol
+        )
 
 
 @dataclass


### PR DESCRIPTION
### Summary

Add Cortex-M dialect and implementation tests for DeepAutoEncoder, DS-CNN, MobileNet V1 0.25, and ResNet-8 from the MLPerf Tiny benchmark suite. All 4D model inputs use explicit channels_last memory format as required by CMSIS-NN.

Add atol parameter to CortexMTester.test_dialect() and test_implementation() for models that need relaxed tolerance.

Fix McuTestCase.example_inputs type annotation to accept both tuples and callables, matching actual usage.

Fixes #16038

### Test plan
```
pytest backends/cortex_m/test/models/
```


cc @psiddh @AdrianLundell @digantdesai