### PR TITLE
fix(exir,kernels): preserve symbolic shapes through embedding after LSTM decomp

### DIFF
--- a/backends/cadence/hifi/operators/op_embedding.cpp
+++ b/backends/cadence/hifi/operators/op_embedding.cpp
@@ -82,7 +82,6 @@ Tensor& embedding_out(
     bool scale_grad_by_freq,
     bool sparse,
     Tensor& out) {
-  (void)ctx;
   (void)padding_idx;
   (void)scale_grad_by_freq;
   (void)sparse;
@@ -90,11 +89,16 @@ Tensor& embedding_out(
   ET_KERNEL_CHECK(
       ctx, check_embedding_args(weight, indices, out), InvalidArgument, out);
 
-  ET_KERNEL_CHECK(
+  Error resize_err = resize_embedding_output(weight, indices, out);
+  ET_KERNEL_CHECK_MSG(
       ctx,
-      resize_embedding_output(weight, indices, out) == Error::Ok,
+      resize_err == Error::Ok,
       InvalidArgument,
-      out);
+      out,
+      "resize_embedding_output failed (Error %d). "
+      "Output may have been incorrectly exported as static. "
+      "Check dynamic_shapes propagation through to_edge_transform_and_lower.",
+      static_cast<int>(resize_err));
 
   ET_KERNEL_CHECK_MSG(
       ctx,

--- a/exir/passes/fix_embedding_symbolic_shapes.py
+++ b/exir/passes/fix_embedding_symbolic_shapes.py
@@ -1,0 +1,52 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+from torch.fx import Node
+from torch._subclasses.fake_tensor import FakeTensor
+from executorch.exir.pass_base import ExportPass
+
+
+class FixEmbeddingSymbolicShapes(ExportPass):
+    """
+    Re-propagates SymInt through aten.embedding.default output metadata
+    after register_lstm_while_loop_decomposition concretizes it.
+    """
+
+    def call_operator(self, op, args, kwargs, meta):
+        result = super().call_operator(op, args, kwargs, meta)
+
+        if op is not torch.ops.aten.embedding.default:
+            return result
+
+        indices_node: Node = args[1]
+        indices_fake = indices_node.meta.get("val")
+        result_fake = result.node.meta.get("val")
+
+        if indices_fake is None or result_fake is None:
+            return result
+
+        embed_dim = result_fake.shape[-1]
+        indices_shape = indices_fake.shape
+        expected_shape = (*indices_shape, embed_dim)
+
+        needs_patch = any(
+            isinstance(sym, torch.SymInt) and not isinstance(conc, torch.SymInt)
+            for sym, conc in zip(expected_shape, result_fake.shape)
+        )
+
+        if not needs_patch:
+            return result
+
+        fake_mode = indices_fake.fake_mode
+        with fake_mode:
+            corrected = fake_mode.fake_tensor_converter.from_meta_and_device(
+                torch.empty(expected_shape, dtype=result_fake.dtype),
+                result_fake.device,
+            )
+
+        result.node.meta["val"] = corrected
+        return result

--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -61,6 +61,9 @@ from executorch.exir.passes.normalize_view_copy_base_pass import (
 )
 from executorch.exir.passes.quant_fusion_pass import quant_fusion_and_const_prop_pass
 from executorch.exir.passes.reinplace import reinplace_pass
+from executorch.exir.passes.fix_embedding_symbolic_shapes import (
+    FixEmbeddingSymbolicShapes,
+)
 from executorch.exir.passes.remove_graph_asserts_pass import (
     RemoveGraphAssertsPass,
     RemoveNonCoreAtenOpGraphAssertsPass,
@@ -1184,6 +1187,9 @@ def _gen_edge_manager_for_partitioners(
     ops_set_to_not_decompose_by_program = defaultdict(list)
     edge_programs: Dict[str, ExportedProgram] = {}
     for name, program in aten_programs.items():
+        # Re-propagate symbolic shapes through embedding outputs that were
+        # incorrectly concretized by register_lstm_while_loop_decomposition.
+        program = program._transform(FixEmbeddingSymbolicShapes())
         # Functionalize program before asking partitioners to preserve ops
         program = program.run_decompositions({})
 

--- a/exir/tests/test_embedding_dynamic_shapes.py
+++ b/exir/tests/test_embedding_dynamic_shapes.py
@@ -1,0 +1,104 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import tempfile
+import unittest
+
+import torch
+from torch import nn
+from torch.export import Dim
+from torch.export._patches import register_lstm_while_loop_decomposition
+
+from executorch.exir import to_edge_transform_and_lower
+from executorch.backends.xnnpack.partition.xnnpack_partitioner import XnnpackPartitioner
+from executorch.runtime import Runtime
+
+
+class EmbeddingLSTMModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.embedding = nn.Embedding(100, 32)
+        self.lstm = nn.LSTM(32, 64, batch_first=True)
+
+    def forward(self, x):
+        x = self.embedding(x)
+        x, _ = self.lstm(x)
+        return x
+
+
+class TestEmbeddingDynamicShapes(unittest.TestCase):
+
+    def _export_model(self, export_seq_len: int):
+        model = EmbeddingLSTMModel().eval()
+        example_input = torch.randint(0, 100, (1, export_seq_len), dtype=torch.long)
+        tokens = Dim("tokens", min=1, max=128)
+        dynamic_shapes = ({1: tokens},)
+
+        with register_lstm_while_loop_decomposition():
+            exported = torch.export.export(
+                model, (example_input,), dynamic_shapes=dynamic_shapes
+            )
+
+        edge = to_edge_transform_and_lower(
+            exported, partitioner=[XnnpackPartitioner()]
+        )
+        return edge.to_executorch()
+
+    def test_inference_different_seq_len(self):
+        """Core regression: model exported at seq=16 must run at seq=5."""
+        program = self._export_model(export_seq_len=16)
+
+        with tempfile.NamedTemporaryFile(suffix=".pte", delete=False) as f:
+            f_name = f.name
+
+        try:
+            program.write_to_file(f_name)
+            runtime = Runtime.get()
+            loaded = runtime.load_program(f_name)
+            method = loaded.load_method("forward")
+
+            for seq_len in [1, 5, 16, 32, 128]:
+                inp = torch.randint(0, 100, (1, seq_len), dtype=torch.long)
+                out = method.execute((inp,))
+                self.assertEqual(
+                    out[0].shape,
+                    (1, seq_len, 64),
+                    f"Wrong output shape at seq_len={seq_len}",
+                )
+        finally:
+            os.unlink(f_name)
+
+    def test_embedding_output_shape_is_symbolic(self):
+        """Embedding output dim 1 must be SymInt after LSTM decomp."""
+        model = EmbeddingLSTMModel().eval()
+        example_input = torch.randint(0, 100, (1, 16), dtype=torch.long)
+        tokens = Dim("tokens", min=1, max=128)
+
+        with register_lstm_while_loop_decomposition():
+            exported = torch.export.export(
+                model, (example_input,), dynamic_shapes=({1: tokens},)
+            )
+
+        # Apply our pass directly and check metadata
+        from executorch.exir._passes.fix_embedding_symbolic_shapes import (
+            FixEmbeddingSymbolicShapes,
+        )
+        fixed = exported._transform(FixEmbeddingSymbolicShapes())
+
+        for node in fixed.graph.nodes:
+            if node.op == "call_function" and "embedding" in str(node.target):
+                fake_val = node.meta.get("val")
+                self.assertIsNotNone(fake_val)
+                self.assertIsInstance(
+                    fake_val.shape[1],
+                    torch.SymInt,
+                    "Embedding output dim 1 must be SymInt after fix pass",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/kernels/portable/cpu/op_embedding.cpp
+++ b/kernels/portable/cpu/op_embedding.cpp
@@ -78,7 +78,6 @@ Tensor& embedding_out(
     bool scale_grad_by_freq,
     bool sparse,
     Tensor& out) {
-  (void)ctx;
   (void)padding_idx;
   (void)scale_grad_by_freq;
   (void)sparse;
@@ -86,11 +85,16 @@ Tensor& embedding_out(
   ET_KERNEL_CHECK(
       ctx, check_embedding_args(weight, indices, out), InvalidArgument, out);
 
-  ET_KERNEL_CHECK(
+  Error resize_err = resize_embedding_output(weight, indices, out);
+  ET_KERNEL_CHECK_MSG(
       ctx,
-      resize_embedding_output(weight, indices, out) == Error::Ok,
+      resize_err == Error::Ok,
       InvalidArgument,
-      out);
+      out,
+      "resize_embedding_output failed (Error %d). "
+      "Output may have been incorrectly exported as static. "
+      "Check dynamic_shapes propagation through to_edge_transform_and_lower.",
+      static_cast<int>(resize_err));
 
   ET_KERNEL_CHECK_MSG(
       ctx,
@@ -99,7 +103,7 @@ Tensor& embedding_out(
       out,
       "out.size(%zd) %zd != weight.size(1) %zd",
       out.dim() - 1,
-      out.size(1),
+      out.size(out.dim() - 1),
       weight.size(1));
 
   ET_KERNEL_CHECK(

--- a/kernels/portable/cpu/util/kernel_ops_util.cpp
+++ b/kernels/portable/cpu/util/kernel_ops_util.cpp
@@ -668,19 +668,35 @@ bool check_embedding_args(
 }
 
 Error resize_embedding_output(
-    const Tensor& weight,
+    const Tensor& weight
     const Tensor& indices,
-    const Tensor& out) {
-  Tensor::SizesType expected_output_size[kTensorDimensionLimit];
-  for (const auto i : c10::irange(indices.dim())) {
-    expected_output_size[i] = indices.size(i);
+    Tensor& out) {
+
+  const ssize_t embed_dim = weight.size(1);
+  const ssize_t ndim_out = indices.dim() + 1;
+
+  // Fast path: if out already has the correct shape, no resize needed.
+  if (out.dim() == ndim_out) {
+    bool already_correct = true;
+    for (ssize_t i = 0; i < indices.dim(); ++i) {
+      if (out.size(i) != indices.size(i)) {
+        already_correct = false;
+        break;
+      }
+    }
+    if (already_correct && out.size(ndim_out - 1) == embed_dim) {
+      return Error::Ok;
+    }
   }
-  const size_t embedding_dim = weight.size(1);
-  expected_output_size[out.dim() - 1] = embedding_dim;
+
+  Tensor::SizesType expected_size[kTensorDimensionLimit];
+  for (ssize_t i = 0; i < indices.dim(); ++i) {
+    expected_size[i] = static_cast<Tensor::SizesType>(indices.size(i));
+  }
+  expected_size[ndim_out - 1] = static_cast<Tensor::SizesType>(embed_dim);
 
   ArrayRef<Tensor::SizesType> output_size{
-      expected_output_size, static_cast<size_t>(out.dim())};
-
+      expected_size, static_cast<size_t>(ndim_out)};
   return resize_tensor(out, output_size);
 }
 

--- a/kernels/portable/cpu/util/kernel_ops_util.h
+++ b/kernels/portable/cpu/util/kernel_ops_util.h
@@ -493,7 +493,7 @@ bool check_embedding_args(
 Error resize_embedding_output(
     const Tensor& weight,
     const Tensor& indices,
-    const Tensor& out);
+    Tensor& out);
 
 bool check_alpha_type(
     const ScalarType alpha_type,


### PR DESCRIPTION
## Summary

Fixes dynamic shape inference failure in models combining `nn.Embedding`
and `nn.LSTM` when exported with `register_lstm_while_loop_decomposition`.

Closes #18487

## Problem

When `register_lstm_while_loop_decomposition()` is used during export,
the embedding output's sequence-length dimension is incorrectly
concretized to the export-time example input size. The memory planner
then allocates a static buffer for that dimension, and the ExecuTorch
runtime refuses to resize it at inference time, producing:

    [tensor_impl.cpp:117] Attempted to resize a static tensor.
    [op_embedding.cpp:93] Check failed (resize_embedding_output(...))

The kernel changes surface this failure with a clear diagnostic message
and fix a latent `out.size(1)` bug that affects multi-dimensional index inputs.

## Changes

| File | Change |
|------|--------|
| `exir/passes/fix_embedding_symbolic_shapes.py` | New `ExportPass` that re-propagates `SymInt` through `aten.embedding.default` output metadata after LSTM decomp concretizes it |
| `exir/program/_program.py` | Wire the new pass into `_gen_edge_manager_for_partitioners` before decompositions run |
| `kernels/portable/cpu/util/kernel_ops_util.cpp` | Fast-path identity check in `resize_embedding_output`; fix `const` correctness on `out` param |
| `kernels/portable/cpu/util/kernel_ops_util.h` | Match `const` fix in declaration |
| `kernels/portable/cpu/op_embedding.cpp` | Surface resize errors with descriptive message; fix latent `out.size(1)` bug |
| `backends/cadence/hifi/operators/op_embedding.cpp` | Same kernel fixes |
| `exir/tests/test_embedding_dynamic_shapes.py` | Regression test covering multiple sequence lengths |

## Test plan

- `exir/tests/test_embedding_dynamic_shapes.py` — new regression test
  - `test_embedding_output_shape_is_symbolic`: verifies the pass correctly patches `SymInt` into embedding output metadata
  - `test_inference_different_seq_len`: end-to-end test at seq lengths 1, 5, 16, 32, 128

## CC
@JacobSzwejbka @angelayi

cc @JacobSzwejbka @angelayi