### PR TITLE
Fix UB in to_string(Error) for unrecognized error codes (#18554) (#18554)

### DIFF
--- a/runtime/core/error.h
+++ b/runtime/core/error.h
@@ -152,6 +152,7 @@ constexpr const char* to_string(const Error error) {
     case Error::RegistrationAlreadyRegistered:
       return "Error::RegistrationAlreadyRegistered";
   }
+  return "Error::Unknown";
 }
 
 } // namespace runtime

--- a/runtime/core/test/error_handling_test.cpp
+++ b/runtime/core/test/error_handling_test.cpp
@@ -105,6 +105,72 @@ class Movable {
   mutable void* buffer_;
 };
 
+TEST(ErrorHandlingTest, ToStringKnownError) {
+  EXPECT_STREQ(executorch::runtime::to_string(Error::Ok), "Error::Ok");
+  EXPECT_STREQ(
+      executorch::runtime::to_string(Error::Internal), "Error::Internal");
+  EXPECT_STREQ(
+      executorch::runtime::to_string(Error::InvalidState),
+      "Error::InvalidState");
+  EXPECT_STREQ(
+      executorch::runtime::to_string(Error::EndOfMethod), "Error::EndOfMethod");
+  EXPECT_STREQ(
+      executorch::runtime::to_string(Error::AlreadyLoaded),
+      "Error::AlreadyLoaded");
+  EXPECT_STREQ(
+      executorch::runtime::to_string(Error::NotSupported),
+      "Error::NotSupported");
+  EXPECT_STREQ(
+      executorch::runtime::to_string(Error::NotImplemented),
+      "Error::NotImplemented");
+  EXPECT_STREQ(
+      executorch::runtime::to_string(Error::InvalidArgument),
+      "Error::InvalidArgument");
+  EXPECT_STREQ(
+      executorch::runtime::to_string(Error::InvalidType), "Error::InvalidType");
+  EXPECT_STREQ(
+      executorch::runtime::to_string(Error::OperatorMissing),
+      "Error::OperatorMissing");
+  EXPECT_STREQ(
+      executorch::runtime::to_string(Error::RegistrationExceedingMaxKernels),
+      "Error::RegistrationExceedingMaxKernels");
+  EXPECT_STREQ(
+      executorch::runtime::to_string(Error::RegistrationAlreadyRegistered),
+      "Error::RegistrationAlreadyRegistered");
+  EXPECT_STREQ(
+      executorch::runtime::to_string(Error::NotFound), "Error::NotFound");
+  EXPECT_STREQ(
+      executorch::runtime::to_string(Error::MemoryAllocationFailed),
+      "Error::MemoryAllocationFailed");
+  EXPECT_STREQ(
+      executorch::runtime::to_string(Error::AccessFailed),
+      "Error::AccessFailed");
+  EXPECT_STREQ(
+      executorch::runtime::to_string(Error::InvalidProgram),
+      "Error::InvalidProgram");
+  EXPECT_STREQ(
+      executorch::runtime::to_string(Error::InvalidExternalData),
+      "Error::InvalidExternalData");
+  EXPECT_STREQ(
+      executorch::runtime::to_string(Error::OutOfResources),
+      "Error::OutOfResources");
+  EXPECT_STREQ(
+      executorch::runtime::to_string(Error::DelegateInvalidCompatibility),
+      "Error::DelegateInvalidCompatibility");
+  EXPECT_STREQ(
+      executorch::runtime::to_string(Error::DelegateMemoryAllocationFailed),
+      "Error::DelegateMemoryAllocationFailed");
+  EXPECT_STREQ(
+      executorch::runtime::to_string(Error::DelegateInvalidHandle),
+      "Error::DelegateInvalidHandle");
+}
+
+TEST(ErrorHandlingTest, ToStringUnknownError) {
+  auto unknown = static_cast<Error>(0xFF);
+  const char* result = executorch::runtime::to_string(unknown);
+  EXPECT_STREQ(result, "Error::Unknown");
+}
+
 TEST(ErrorHandlingTest, ResultBasic) {
   Result<uint32_t> r(1);
   ASSERT_TRUE(r.ok());


### PR DESCRIPTION
Summary:
executorch::runtime::to_string(Error) returns const char* via a switch statement with no default case. For unrecognized error codes, the function falls off the end without returning (undefined behavior), which in practice returns nullptr.

The fix:
1. Adds a fallback return "Error::Unknown" after the switch in to_string() (without a default: case, preserving -Wswitch coverage for missing enum values).
2. Adds tests for to_string() covering all 21 enum values and the unknown error code path.


Reviewed By: JacobSzwejbka

Differential Revision: D97662639

Pulled By: alexey-sidnev
