### PR TITLE
[RELEASE TEST] Make nvidia-smi non-fatal in Windows CUDA CI

### DIFF
--- a/.ci/scripts/test_model_e2e_windows.ps1
+++ b/.ci/scripts/test_model_e2e_windows.ps1
@@ -122,7 +122,19 @@ try {
     Write-Host "::group::Check CUDA toolchain"
     $nvccOutput = nvcc --version | Out-String
     Write-Host $nvccOutput
-    try { nvidia-smi } catch { Write-Host "nvidia-smi not available (driver may not be installed)" }
+    $nvidiaSmiCmd = Get-Command nvidia-smi -ErrorAction SilentlyContinue
+    if ($null -eq $nvidiaSmiCmd) {
+        Write-Host "nvidia-smi not available (command not found; driver may not be installed)"
+    }
+    else {
+        try {
+            nvidia-smi
+        }
+        catch {
+            Write-Host "nvidia-smi failed (driver or GPU issue). Error details:"
+            Write-Host $_
+        }
+    }
     if (-not [string]::IsNullOrWhiteSpace($ExpectedCudaVersion)) {
         $versionMatch = [Regex]::Match($nvccOutput, "release\s+(\d+\.\d+)")
         if (-not $versionMatch.Success) {

--- a/.ci/scripts/test_model_e2e_windows.ps1
+++ b/.ci/scripts/test_model_e2e_windows.ps1
@@ -122,7 +122,7 @@ try {
     Write-Host "::group::Check CUDA toolchain"
     $nvccOutput = nvcc --version | Out-String
     Write-Host $nvccOutput
-    nvidia-smi
+    try { nvidia-smi } catch { Write-Host "nvidia-smi not available (driver may not be installed)" }
     if (-not [string]::IsNullOrWhiteSpace($ExpectedCudaVersion)) {
         $versionMatch = [Regex]::Match($nvccOutput, "release\s+(\d+\.\d+)")
         if (-not $versionMatch.Success) {


### PR DESCRIPTION
Some Windows GPU runners don't have nvidia-smi available even though the CUDA toolkit (nvcc) is properly installed. The nvidia-smi call is purely informational — the actual CUDA toolchain validation is done by nvcc --version and the version check that follows.
