### PR TITLE
Add permissions to Android release workflow to fix startup failure

### DIFF
--- a/.github/workflows/android-release-on-tag.yml
+++ b/.github/workflows/android-release-on-tag.yml
@@ -6,6 +6,10 @@ on:
       - 'v*.*.*-rc*'
       - 'v*.*.*'
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   prepare:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The reusable workflow android-release-artifacts.yml requires id-token: write for AWS OIDC authentication, but the calling workflow didn't declare any permissions, preventing GitHub from granting them to the nested workflows.
