### PR TITLE
Fix DecomposeConcatenate passing invalid out_dtype kwarg to quantize_per_tensor

### DIFF
--- a/backends/xnnpack/_passes/decompose_cat.py
+++ b/backends/xnnpack/_passes/decompose_cat.py
@@ -69,7 +69,13 @@ class DecomposeConcatenate(ExportPass):
                     # if quantized we need to enforce the q/dq pattern for the newly inserted
                     # concat node
                     q_params = nodes_to_concat[0].args[1:]
-                    q_kwargs = nodes_to_concat[0].kwargs
+                    dq_kwargs = nodes_to_concat[0].kwargs
+                    # quantize_per_tensor does not accept out_dtype, so exclude
+                    # it from kwargs passed to the quantize node. out_dtype is
+                    # only valid for dequantize_per_tensor (e.g. fp16 models).
+                    q_kwargs = {
+                        k: v for k, v in dq_kwargs.items() if k != "out_dtype"
+                    }
                     # Quantizer enforces all the inputs and output to a concat node must share
                     # the same qparams, this means the newly inserted q/dq pair must share the
                     # same qparams as the first quantized input in the concat node.
@@ -89,7 +95,7 @@ class DecomposeConcatenate(ExportPass):
                             "call_function",
                             target=exir_ops.edge.quantized_decomposed.dequantize_per_tensor.default,
                             args=(q_node,) + q_params,
-                            kwargs=q_kwargs,
+                            kwargs=dq_kwargs,
                         )
                         tag_as_implicit_q_dq(dq_node)
                     remainder_concat_node.args = (

--- a/backends/xnnpack/_passes/decompose_cat.py
+++ b/backends/xnnpack/_passes/decompose_cat.py
@@ -73,9 +73,7 @@ class DecomposeConcatenate(ExportPass):
                     # quantize_per_tensor does not accept out_dtype, so exclude
                     # it from kwargs passed to the quantize node. out_dtype is
                     # only valid for dequantize_per_tensor (e.g. fp16 models).
-                    q_kwargs = {
-                        k: v for k, v in dq_kwargs.items() if k != "out_dtype"
-                    }
+                    q_kwargs = {k: v for k, v in dq_kwargs.items() if k != "out_dtype"}
                     # Quantizer enforces all the inputs and output to a concat node must share
                     # the same qparams, this means the newly inserted q/dq pair must share the
                     # same qparams as the first quantized input in the concat node.


### PR DESCRIPTION
### Summary
When decomposing a quantized `cat` with more than 5 inputs, `DecomposeConcatenate` inserts an intermediate Q/DQ pair. Previously it shared the same `kwargs` dict (copied from the original `dequantize_per_tensor` node) for both the `quantize_per_tensor` and `dequantize_per_tensor` nodes.

However, `quantize_per_tensor.default` does not accept `out_dtype` — only `dequantize_per_tensor.default` does. This causes failures for models where the dequantize node carries `out_dtype` (e.g., fp16 quantized models).

This PR splits the kwargs so that `out_dtype` is excluded from the quantize node kwargs while preserved for the dequantize node.

### Test plan
Existing tests pass:
```
python -m unittest backends.xnnpack.test.passes.test_decompose_cat_pass -v
```
```
test_cat_gt_10 ... ok
test_cat_gt_5 ... ok
test_qs8_cat_gt_10 ... ok
test_qs8_cat_gt_5 ... ok
```

cc @GregoryComer @digantdesai @cbilgin