### PR TITLE
Add DNS-AID SVCB resolver for cloud endpoint discovery

### DIFF
--- a/docs/llm/dns_aid.md
+++ b/docs/llm/dns_aid.md
@@ -1,0 +1,98 @@
+# DNS-AID Cloud Endpoint Resolution
+
+ExecuTorch edge agents can resolve cloud inference endpoints at runtime via
+[DNS-AID](https://dns-aid.org) SVCB lookups instead of hard-coding URLs.
+
+This is a **client-only** integration: ExecuTorch resolves records but does not
+publish them. Cloud services (vLLM, Ray Serve, remote MCP servers) publish their
+own DNS-AID records.
+
+## Installation
+
+```bash
+pip install executorch[dns-aid]
+```
+
+## Quick Start
+
+```python
+from executorch.extension.llm.dns_aid import DnsAidResolver, DnsAidResolverConfig
+
+config = DnsAidResolverConfig(
+    agent_name="vllm-llama3-70b",
+    domain="inference.example.internal",
+    fallback_url="https://vllm-backup.example.com:8080/v1",
+)
+
+resolver = DnsAidResolver(config)
+host, port = resolver.resolve_sync()
+print(f"Resolved endpoint: {host}:{port}")
+```
+
+## Configuration
+
+`DnsAidResolverConfig` fields:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `agent_name` | `str` | required | Agent name to resolve (e.g., `"vllm-llama3-70b"`) |
+| `domain` | `str` | required | DNS-AID domain (e.g., `"inference.example.internal"`) |
+| `protocol` | `str` | `"mcp"` | Protocol filter for discovery |
+| `min_context_len` | `int \| None` | `None` | Filter agents by minimum context length capability |
+| `fallback_url` | `str \| None` | `None` | Static URL to use if DNS resolution fails |
+
+## Capability Filtering
+
+Filter endpoints by capability hints published in DNS-AID records:
+
+```python
+config = DnsAidResolverConfig(
+    agent_name="vllm-llama3-70b",
+    domain="inference.example.internal",
+    min_context_len=32768,  # only endpoints with >= 32K context
+)
+```
+
+Capability filtering matches against `context_len:<value>` entries in the
+agent's `capabilities` list.
+
+## Fallback Behavior
+
+If no DNS-AID records are found:
+
+1. If `fallback_url` is set, the resolver parses it and returns its host/port.
+2. If no fallback is configured, a `RuntimeError` is raised.
+
+## Async Usage
+
+The resolver is async-native. Use `resolve()` in async contexts:
+
+```python
+import asyncio
+from executorch.extension.llm.dns_aid import DnsAidResolver, DnsAidResolverConfig
+
+async def main():
+    config = DnsAidResolverConfig(
+        agent_name="vllm-llama3-70b",
+        domain="inference.example.internal",
+    )
+    resolver = DnsAidResolver(config)
+    host, port = await resolver.resolve()
+    print(f"Resolved: {host}:{port}")
+
+asyncio.run(main())
+```
+
+For synchronous code, use `resolve_sync()`. Note that `resolve_sync()` cannot be
+called from within a running event loop — use `await resolve()` instead.
+
+## Without dns-aid Installed
+
+The module is importable without dns-aid installed. `DnsAidResolverConfig` works
+standalone. `DnsAidResolver` raises a helpful `ImportError` only when
+instantiated without the package:
+
+```
+ImportError: dns-aid is required for DNS-AID endpoint resolution.
+Install it with: pip install executorch[dns-aid]
+```

--- a/extension/llm/dns_aid/__init__.py
+++ b/extension/llm/dns_aid/__init__.py
@@ -1,0 +1,18 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""DNS-AID client resolver for ExecuTorch cloud endpoint discovery.
+
+Enables edge agents to resolve cloud inference endpoints (vLLM, Ray Serve,
+remote MCP servers) via DNS-AID SVCB lookups rather than hard-coded URLs.
+
+Install the optional dependency: pip install executorch[dns-aid]
+"""
+
+from executorch.extension.llm.dns_aid.config import DnsAidResolverConfig
+from executorch.extension.llm.dns_aid.resolver import DnsAidResolver
+
+__all__ = ["DnsAidResolver", "DnsAidResolverConfig"]

--- a/extension/llm/dns_aid/config.py
+++ b/extension/llm/dns_aid/config.py
@@ -1,0 +1,23 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class DnsAidResolverConfig:
+    """Configuration for DNS-AID based cloud endpoint resolution.
+
+    ExecuTorch edge agents use this to resolve cloud inference endpoints
+    (vLLM, Ray Serve, remote MCP servers) via DNS-AID SVCB lookups.
+    """
+
+    agent_name: str
+    domain: str
+    protocol: str = "mcp"
+    min_context_len: Optional[int] = None
+    fallback_url: Optional[str] = None

--- a/extension/llm/dns_aid/resolver.py
+++ b/extension/llm/dns_aid/resolver.py
@@ -1,0 +1,109 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, List, Tuple
+from urllib.parse import urlparse
+
+from executorch.extension.llm.dns_aid.config import DnsAidResolverConfig
+
+
+class DnsAidResolver:
+    """Resolves cloud inference endpoints via DNS-AID SVCB lookups.
+
+    Client-only: ExecuTorch edge agents use this to discover cloud services
+    (vLLM, Ray Serve, remote MCP servers) without hard-coding URLs.
+    """
+
+    def __init__(self, config: DnsAidResolverConfig) -> None:
+        try:
+            import dns_aid
+
+            self._dns_aid = dns_aid
+        except ImportError:
+            raise ImportError(
+                "dns-aid is required for DNS-AID endpoint resolution. "
+                "Install it with: pip install executorch[dns-aid]"
+            )
+        self.config = config
+
+    async def resolve(self) -> Tuple[str, int]:
+        """Resolve the configured agent name to a (host, port) tuple.
+
+        Queries DNS-AID SVCB records, filters by optional capability
+        requirements, and returns the best match. Falls back to
+        fallback_url if no records match.
+
+        Raises:
+            RuntimeError: If no matching endpoint is found and no fallback
+                is configured.
+        """
+        result = await self._dns_aid.discover(
+            domain=self.config.domain,
+            protocol=self.config.protocol,
+            name=self.config.agent_name,
+        )
+
+        agents = result.agents
+        if self.config.min_context_len is not None:
+            agents = self._filter_by_min_context_len(agents)
+
+        if agents:
+            agent = agents[0]
+            return agent.target_host, agent.port
+
+        if self.config.fallback_url:
+            parsed = urlparse(self.config.fallback_url)
+            host = parsed.hostname or "localhost"
+            port = parsed.port or (443 if parsed.scheme == "https" else 80)
+            return host, port
+
+        raise RuntimeError(
+            f"No DNS-AID records found for agent '{self.config.agent_name}' "
+            f"at domain '{self.config.domain}' and no fallback_url configured."
+        )
+
+    def resolve_sync(self) -> Tuple[str, int]:
+        """Synchronous wrapper around resolve().
+
+        Creates a new event loop if none is running. If called from within
+        an async context, use ``await resolve()`` instead.
+        """
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+
+        if loop is not None:
+            raise RuntimeError(
+                "resolve_sync() cannot be called from within a running event loop. "
+                "Use 'await resolver.resolve()' instead."
+            )
+        return asyncio.run(self.resolve())
+
+    def _filter_by_min_context_len(self, agents: List[Any]) -> List[Any]:
+        """Filter agents whose capabilities include a context_len >= threshold.
+
+        Expects capabilities entries formatted as "context_len:<int>".
+        Agents without a matching entry are excluded.
+        """
+        min_ctx = self.config.min_context_len
+        if min_ctx is None:
+            return agents
+        filtered = []
+        for agent in agents:
+            for cap in agent.capabilities:
+                if cap.startswith("context_len:"):
+                    try:
+                        val = int(cap.split(":", 1)[1])
+                    except ValueError:
+                        continue
+                    if val >= min_ctx:
+                        filtered.append(agent)
+                        break
+        return filtered

--- a/extension/llm/dns_aid/test_dns_aid_resolver.py
+++ b/extension/llm/dns_aid/test_dns_aid_resolver.py
@@ -1,0 +1,156 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import asyncio
+import importlib
+import sys
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from executorch.extension.llm.dns_aid.config import DnsAidResolverConfig
+
+
+def _make_agent(
+    target_host="vllm.example.com",
+    port=443,
+    capabilities=None,
+):
+    agent = MagicMock()
+    agent.target_host = target_host
+    agent.port = port
+    agent.capabilities = capabilities or []
+    agent.endpoint_url = f"https://{target_host}:{port}"
+    return agent
+
+
+def _make_discovery_result(agents=None):
+    result = MagicMock()
+    result.agents = agents or []
+    return result
+
+
+@patch.dict("sys.modules", {"dns_aid": MagicMock()})
+class TestDnsAidResolver(unittest.TestCase):
+    def _config(self, **overrides):
+        defaults = {
+            "agent_name": "vllm-llama3-70b",
+            "domain": "example.internal",
+        }
+        defaults.update(overrides)
+        return DnsAidResolverConfig(**defaults)
+
+    def _resolver(self, **config_overrides):
+        from executorch.extension.llm.dns_aid.resolver import DnsAidResolver
+
+        return DnsAidResolver(self._config(**config_overrides))
+
+    def test_resolve_returns_host_port(self):
+        resolver = self._resolver()
+        agent = _make_agent("vllm.example.com", 8080)
+        resolver._dns_aid.discover = AsyncMock(
+            return_value=_make_discovery_result([agent])
+        )
+
+        host, port = asyncio.run(resolver.resolve())
+        self.assertEqual(host, "vllm.example.com")
+        self.assertEqual(port, 8080)
+
+    def test_resolve_sync(self):
+        resolver = self._resolver()
+        agent = _make_agent("sync.example.com", 443)
+        resolver._dns_aid.discover = AsyncMock(
+            return_value=_make_discovery_result([agent])
+        )
+
+        host, port = resolver.resolve_sync()
+        self.assertEqual(host, "sync.example.com")
+        self.assertEqual(port, 443)
+
+    def test_resolve_sync_raises_inside_event_loop(self):
+        resolver = self._resolver()
+
+        async def _inner():
+            resolver.resolve_sync()
+
+        with self.assertRaises(RuntimeError) as ctx:
+            asyncio.run(_inner())
+        self.assertIn(
+            "cannot be called from within a running event loop", str(ctx.exception)
+        )
+
+    def test_fallback_url_used_when_no_records(self):
+        resolver = self._resolver(fallback_url="https://fallback.example.com:9090/v1")
+        resolver._dns_aid.discover = AsyncMock(return_value=_make_discovery_result([]))
+
+        host, port = asyncio.run(resolver.resolve())
+        self.assertEqual(host, "fallback.example.com")
+        self.assertEqual(port, 9090)
+
+    def test_error_when_no_records_and_no_fallback(self):
+        resolver = self._resolver()
+        resolver._dns_aid.discover = AsyncMock(return_value=_make_discovery_result([]))
+
+        with self.assertRaises(RuntimeError) as ctx:
+            asyncio.run(resolver.resolve())
+        self.assertIn("No DNS-AID records found", str(ctx.exception))
+
+    def test_filter_by_min_context_len(self):
+        resolver = self._resolver(min_context_len=32768)
+
+        small = _make_agent("small.example.com", 443, capabilities=["context_len:8192"])
+        large = _make_agent(
+            "large.example.com", 443, capabilities=["context_len:65536"]
+        )
+
+        filtered = resolver._filter_by_min_context_len([small, large])
+        self.assertEqual(len(filtered), 1)
+        self.assertEqual(filtered[0].target_host, "large.example.com")
+
+    def test_filter_by_min_context_len_noop_when_none(self):
+        resolver = self._resolver(min_context_len=None)
+        agents = [_make_agent(), _make_agent()]
+
+        filtered = resolver._filter_by_min_context_len(agents)
+        self.assertEqual(len(filtered), 2)
+
+    def test_resolve_applies_capability_filter(self):
+        resolver = self._resolver(min_context_len=32768)
+
+        small = _make_agent("small.example.com", 443, capabilities=["context_len:8192"])
+        large = _make_agent(
+            "large.example.com", 8080, capabilities=["context_len:65536"]
+        )
+        resolver._dns_aid.discover = AsyncMock(
+            return_value=_make_discovery_result([small, large])
+        )
+
+        host, port = asyncio.run(resolver.resolve())
+        self.assertEqual(host, "large.example.com")
+        self.assertEqual(port, 8080)
+
+
+class TestDnsAidResolverImportGuard(unittest.TestCase):
+    def test_import_error_without_dns_aid(self):
+        original = sys.modules.get("dns_aid")
+        sys.modules["dns_aid"] = None
+        try:
+            import executorch.extension.llm.dns_aid.resolver as resolver_mod
+
+            importlib.reload(resolver_mod)
+            with self.assertRaises(ImportError) as ctx:
+                resolver_mod.DnsAidResolver(
+                    DnsAidResolverConfig(agent_name="test", domain="example.com")
+                )
+            self.assertIn("dns-aid is required", str(ctx.exception))
+        finally:
+            if original is not None:
+                sys.modules["dns_aid"] = original
+            else:
+                sys.modules.pop("dns_aid", None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,9 @@ dependencies=[
   "omegaconf>=2.3.0",
 ]
 
+[project.optional-dependencies]
+dns-aid = ["dns-aid>=0.14.0"]
+
 [project.urls]
 # The keys are arbitrary but will be visible on PyPI.
 Homepage = "https://pytorch.org/executorch/"


### PR DESCRIPTION
## Summary

Adds a `dns_aid` resolver module to `extension/llm/` enabling ExecuTorch edge agents to resolve cloud inference endpoints (vLLM, Ray Serve, remote MCP servers) via [DNS-AID](https://dns-aid.org) SVCB lookups ([RFC 9460](https://www.rfc-editor.org/rfc/rfc9460)) rather than hard-coded URLs.

- `DnsAidResolver.resolve()` queries the `_agents` subdomain and returns `(host, port)` of the best-matching endpoint
- Optional `min_context_len` capability filter for endpoints publishing `context_len:<int>` capabilities
- Falls back to a static `fallback_url` when no SVCB records are found
- Zero overhead when `dns-aid` is not installed (lazy import guard — `DnsAidResolverConfig` works standalone)
- Client-only: ExecuTorch does not publish DNS records

**New files:**
- `extension/llm/dns_aid/` — resolver module (`config.py`, `resolver.py`, `__init__.py`)
- `extension/llm/dns_aid/test_dns_aid_resolver.py` — 9 unit tests
- `docs/llm/dns_aid.md` — usage guide

**Modified:**
- `pyproject.toml` — adds `[project.optional-dependencies]` entry: `pip install executorch[dns-aid]`

## Test plan

- [x] `python -m pytest extension/llm/dns_aid/test_dns_aid_resolver.py -v` — 9/9 pass
- [x] Verified `DnsAidResolverConfig` importable without dns-aid installed
- [x] Verified `DnsAidResolver()` raises helpful `ImportError` without dns-aid
- [x] Verified `resolve_sync()` raises clear error when called inside a running event loop
- [x] Formatted with `black`; `flake8` clean

cc @larryliu0820 @mergennachin @cccclai @helunwencser @jackzhxng @digantdesai