### PR TITLE
[Qualcomm] Fix repeated output dequant insertion in InsertIOQDQ

### DIFF
--- a/backends/qualcomm/_passes/insert_io_qdq.py
+++ b/backends/qualcomm/_passes/insert_io_qdq.py
@@ -118,7 +118,9 @@ class InsertIOQDQ(ExportPass):
                     user.replace_input_with(node, inserted_node)
 
     def _insert(self, graph_module: torch.fx.GraphModule) -> torch.fx.GraphModule:
-        for n in graph_module.graph.nodes:
+        # Iterate over a stable snapshot. Otherwise, newly inserted Q/DQ nodes
+        # can be revisited in the same pass and trigger unbounded reinsertion.
+        for n in list(graph_module.graph.nodes):
             # do nothing when a node is expected to output a quant tensor
             if n.meta.get(QCOM_QUANTIZED_IO):
                 continue

--- a/backends/qualcomm/tests/test_passes.py
+++ b/backends/qualcomm/tests/test_passes.py
@@ -4,12 +4,16 @@ import torch
 from executorch.backends.qualcomm._passes import (
     ConvertBmmToMatmul,
     ConvertMhaToSha,
+    InsertIOQDQ,
     InsertReshapeForReduceOps,
     RemoveRedundancy,
 )
+from executorch.backends.qualcomm._passes.qnn_pass_manager import QnnPassManager
+from executorch.backends.qualcomm.quantizer.quantizer import QuantDtype
 from executorch.backends.qualcomm.serialization.qc_schema import QcomChipset
 from executorch.backends.qualcomm.tests.models import TopKandIndex
 from executorch.backends.qualcomm.utils.utils import (
+    capture_program,
     generate_htp_compiler_spec,
     generate_qnn_executorch_compiler_spec,
     to_edge_transform_and_lower_to_qnn,
@@ -17,9 +21,54 @@ from executorch.backends.qualcomm.utils.utils import (
 from executorch.exir import to_edge
 from executorch.exir.debug_handle_utils import DEBUG_HANDLE_KEY
 from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.examples.qualcomm.utils import make_quantizer
+from torchao.quantization.pt2e.quantize_pt2e import convert_pt2e, prepare_pt2e
 
 
 class TestPasses(unittest.TestCase):
+    def test_insert_io_qdq_does_not_revisit_newly_inserted_dequant(self):
+        class AddModule(torch.nn.Module):
+            def forward(self, x):
+                return x + 1
+
+        module = AddModule().eval()
+        sample_input = (torch.randn(1, 4),)
+        exported = torch.export.export(module, sample_input, strict=True).module()
+        quantizer = make_quantizer(quant_dtype=QuantDtype.use_8a8w)
+        prepared = prepare_pt2e(exported, quantizer)
+        prepared(*sample_input)
+        qdq_module = convert_pt2e(prepared)
+        delegated_program = capture_program(qdq_module, sample_input)
+
+        original_insert_dequant = InsertIOQDQ._insert_dequant_node
+        call_count = {"value": 0}
+
+        def wrapped_insert_dequant(this, graph_module, node, target):
+            call_count["value"] += 1
+            if call_count["value"] > 1:
+                raise AssertionError(
+                    "InsertIOQDQ revisited a dequant node inserted earlier in the same pass"
+                )
+            return original_insert_dequant(this, graph_module, node, target)
+
+        InsertIOQDQ._insert_dequant_node = wrapped_insert_dequant
+        try:
+            graph_module = QnnPassManager().transform_for_preprocess_pipeline(
+                delegated_program.exported_program
+            )
+        finally:
+            InsertIOQDQ._insert_dequant_node = original_insert_dequant
+
+        dequant_nodes = [
+            node
+            for node in graph_module.graph.nodes
+            if node.op == "call_function"
+            and node.target
+            == exir_ops.edge.quantized_decomposed.dequantize_per_tensor.tensor
+        ]
+        self.assertEqual(call_count["value"], 1)
+        self.assertEqual(len(dequant_nodes), 1)
+
     def test_insert_reshape_for_argmax(self):
         class ArgmaxModule(torch.nn.Module):
             def forward(self, x):


### PR DESCRIPTION
## Summary
`InsertIOQDQ` iterated over `graph_module.graph.nodes` while mutating the graph.
When the pass inserted a dequant node before an output, that newly inserted node could be revisited later in the same pass. Since the inserted dequant node still carried quantization metadata and still fed the graph output, the pass could insert another output dequant in front of it again. In practice this caused repeated reinsertion, large memory growth, and very long preprocess times.
This change makes the pass iterate over a stable snapshot of nodes instead.

## Changes
- iterate over `list(graph_module.graph.nodes)` in `InsertIOQDQ._insert()`
- add a regression test covering repeated output dequant insertion

## Repro
A small quantized graph with one quantized output is enough to trigger this behavior:
- run `InsertIOQDQ`
- insert a dequant node in front of the output
- revisit that newly inserted node in the same pass
- insert another dequant again

## Notes
I first ran into this while debugging very long 8a8w Qualcomm preprocess/export times on a small decoder model. After this fix, the export no longer gets stuck repeatedly inserting output dequant nodes.

cc @cccclai @cbilgin @abhinaykukkadapu