### PR TITLE
[ET-VK] Prevent hardswish decomposition by adding to ops_not_to_decompose

### DIFF
--- a/backends/vulkan/op_registry.py
+++ b/backends/vulkan/op_registry.py
@@ -193,6 +193,7 @@ def register_ephemeral_ops():
         exir_ops.edge.aten.exp.default,
         exir_ops.edge.aten.gelu.default,
         exir_ops.edge.aten.hardshrink.default,
+        exir_ops.edge.aten.hardswish.default,
         exir_ops.edge.aten.hardtanh.default,
         exir_ops.edge.aten.neg.default,
         exir_ops.edge.aten.relu.default,

--- a/backends/vulkan/partitioner/vulkan_partitioner.py
+++ b/backends/vulkan/partitioner/vulkan_partitioner.py
@@ -46,6 +46,7 @@ from torch.fx.passes.operator_support import OperatorSupportBase
 
 # pyre-ignore
 ops_not_to_decompose = [
+    torch.ops.aten.hardswish.default,
     torch.ops.aten.upsample_nearest2d.vec,
 ]
 

--- a/backends/vulkan/runtime/graph/ops/glsl/conv2d_dw_output_tile.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/conv2d_dw_output_tile.yaml
@@ -28,3 +28,7 @@ conv2d_dw_output_tile:
     - NAME: conv2d_dw_output_tile_3x3_b1x1
       BATCH_SIZE_X: 1
       BATCH_SIZE_Y: 1
+    - NAME: conv2d_dw_output_tile_3x3_b1x1_clamp
+      OPERATOR: clamp(X, A, B)
+      BATCH_SIZE_X: 1
+      BATCH_SIZE_Y: 1


### PR DESCRIPTION

Summary: Without this change, aten.hardswish.default decomposes into several
arithmetic ops (add, clamp, mul, div) which prevents the Vulkan conv2d
depthwise fusion pass from recognizing and fusing the activation. Adding
hardswish to ops_not_to_decompose keeps it as a single op so the conv2d
output tile shader can apply the clamp fusion.

Also adds the conv2d_dw_output_tile_3x3_b1x1_clamp shader variant needed
for the fused path.

Authored with Claude.

Test Plan: Exported MobileNetV3 for Vulkan and verified hardswish no longer decomposes.

Reviewers:

Subscribers:

Tasks:

Tags:

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/executorch/pull/18575).
* #18576
* __->__ #18575