### PR TITLE
[ET-VK] Only partition copy.default to Vulkan when it is a no-op

### DIFF
--- a/backends/vulkan/op_registry.py
+++ b/backends/vulkan/op_registry.py
@@ -193,6 +193,7 @@ def register_ephemeral_ops():
         exir_ops.edge.aten.exp.default,
         exir_ops.edge.aten.gelu.default,
         exir_ops.edge.aten.hardshrink.default,
+        exir_ops.edge.aten.hardswish.default,
         exir_ops.edge.aten.hardtanh.default,
         exir_ops.edge.aten.neg.default,
         exir_ops.edge.aten.relu.default,

--- a/backends/vulkan/op_registry.py
+++ b/backends/vulkan/op_registry.py
@@ -169,15 +169,37 @@ def update_features(aten_op):
         # Guard and assert ops
         torch.ops.aten._assert_scalar.default,
         torch.ops.aten.sym_constrain_range_for_size.default,
-        # copy.default is a no-op when src dtype matches dst dtype; removed by
-        # RemoveRedundantOpsTransform before execution.
-        exir_ops.edge.aten.copy.default,
     ]
 )
 def register_ephemeral_ops():
     return OpFeatures(
         inputs_storage=utils.ANY_STORAGE,
         supports_resize=True,
+    )
+
+
+def _check_copy_is_noop(node: torch.fx.Node) -> bool:
+    """Only support copy.default when it's a no-op (same dtype and shape)."""
+    src = node.args[1]
+    if not isinstance(src, torch.fx.Node):
+        return False
+    src_val = src.meta.get("val")
+    dst_val = node.meta.get("val")
+    if src_val is None or dst_val is None:
+        return False
+    return src_val.dtype == dst_val.dtype and src_val.shape == dst_val.shape
+
+
+@update_features(
+    [
+        exir_ops.edge.aten.copy.default,
+    ]
+)
+def register_copy_op():
+    return OpFeatures(
+        inputs_storage=utils.ANY_STORAGE,
+        supports_resize=True,
+        are_node_inputs_supported_fn=_check_copy_is_noop,
     )
 
 

--- a/backends/vulkan/partitioner/vulkan_partitioner.py
+++ b/backends/vulkan/partitioner/vulkan_partitioner.py
@@ -46,6 +46,7 @@ from torch.fx.passes.operator_support import OperatorSupportBase
 
 # pyre-ignore
 ops_not_to_decompose = [
+    torch.ops.aten.hardswish.default,
     torch.ops.aten.upsample_nearest2d.vec,
 ]
 

--- a/backends/vulkan/runtime/graph/ops/glsl/conv2d_dw_output_tile.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/conv2d_dw_output_tile.yaml
@@ -28,3 +28,7 @@ conv2d_dw_output_tile:
     - NAME: conv2d_dw_output_tile_3x3_b1x1
       BATCH_SIZE_X: 1
       BATCH_SIZE_Y: 1
+    - NAME: conv2d_dw_output_tile_3x3_b1x1_clamp
+      OPERATOR: clamp(X, A, B)
+      BATCH_SIZE_X: 1
+      BATCH_SIZE_Y: 1


### PR DESCRIPTION

Summary: Previously, copy.default was unconditionally added to the Vulkan partition as
an ephemeral op (assumed to always be a no-op removed by
RemoveRedundantOpsTransform). However, copy.default can also represent a dtype
cast, and blindly partitioning casts to Vulkan causes runtime failures since
the Vulkan backend has no copy implementation.

Replace the unconditional registration with a custom
are_node_inputs_supported_fn that checks both dtype and shape match between
src and dst. Only same-dtype, same-shape copies (true no-ops) are partitioned
to Vulkan; dtype casts remain on CPU.

Authored with Claude.

Test Plan: Exported EfficientNet for Vulkan, which contains copy.default for dtype casts,
and confirmed it no longer errors during Vulkan compilation. No-op copies in
other models (e.g. MobileNetV3) still partition correctly.

Reviewers:

Subscribers:

Tasks:

Tags:

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/executorch/pull/18576).
* __->__ #18576
* #18575

cc @manuelcandales @digantdesai @cbilgin