### PR TITLE
Fix QNN Android AAR build

### DIFF
--- a/extension/android/CMakeLists.txt
+++ b/extension/android/CMakeLists.txt
@@ -185,6 +185,7 @@ if(EXECUTORCH_BUILD_LLAMA_JNI)
         ${EXECUTORCH_ROOT}/examples/qualcomm/oss_scripts/llama/runner/prompt_processor.cpp
         ${EXECUTORCH_ROOT}/examples/qualcomm/oss_scripts/llama/runner/token_generator.cpp
         ${EXECUTORCH_ROOT}/examples/qualcomm/oss_scripts/llama/runner/lhd_token_generator.cpp
+        ${EXECUTORCH_ROOT}/examples/qualcomm/oss_scripts/llama/runner/attention_sink_rope_runner.cpp
         ${EXECUTORCH_ROOT}/examples/qualcomm/oss_scripts/llama/runner/rpc_mem.cpp
         ${EXECUTORCH_ROOT}/examples/qualcomm/oss_scripts/llama/runner/kv_manager.cpp
     )


### PR DESCRIPTION
Add missing attention_sink_rope_runner.cpp to Android JNI build

This fixes a linker error when building libexecutorch_jni.so for the QNN flavor of the Android AAR. The QNN llama runner sources (lhd_token_generator.cpp, token_generator.cpp, prompt_processor.cpp, runner.cpp) reference AttentionSinkRopeRunner but its implementation wasn't being compiled into the JNI library.
