### PR TITLE
Use flavor-specific artifact names to avoid S3 upload collision

### DIFF
--- a/.github/workflows/android-release-artifacts.yml
+++ b/.github/workflows/android-release-artifacts.yml
@@ -145,9 +145,9 @@ jobs:
         export BUILD_AAR_DIR=aar-out
         bash scripts/build_android_library.sh
         mkdir -p "${ARTIFACTS_DIR_NAME}"
-        cp aar-out/executorch.aar "${ARTIFACTS_DIR_NAME}/executorch.aar"
+        cp aar-out/executorch.aar "${ARTIFACTS_DIR_NAME}/executorch-${FLAVOR}.aar"
 
-        shasum -a 256 "${ARTIFACTS_DIR_NAME}/executorch.aar"
+        shasum -a 256 "${ARTIFACTS_DIR_NAME}/executorch-${FLAVOR}.aar"
 
         # Publish to maven staging
         UPLOAD_TO_MAVEN="${{ inputs.upload_to_maven }}"
@@ -172,11 +172,6 @@ jobs:
       - name: Upload AAR RC to AWS S3
         shell: bash
         run: |
-          wget https://gha-artifacts.s3.amazonaws.com/${{ github.repository }}/${{ github.run_id }}/artifacts/executorch.aar
-          shasum -a 256 executorch.aar > executorch.aar.sha256sums
-
-          pip install awscli==1.32.18
-          AWS_CMD="aws s3 cp"
           VERSION="${{ inputs.version }}"
           FLAVOR="${{ inputs.flavor }}"
           if [ -z "$VERSION" ]; then
@@ -185,5 +180,11 @@ jobs:
           if [ -z "$FLAVOR" ]; then
             FLAVOR="xnnpack"
           fi
+          wget https://gha-artifacts.s3.amazonaws.com/${{ github.repository }}/${{ github.run_id }}/artifacts/executorch-${FLAVOR}.aar
+          mv executorch-${FLAVOR}.aar executorch.aar
+          shasum -a 256 executorch.aar > executorch.aar.sha256sums
+
+          pip install awscli==1.32.18
+          AWS_CMD="aws s3 cp"
           ${AWS_CMD} executorch.aar s3://ossci-android/executorch/release/${VERSION}-${FLAVOR}/executorch.aar --acl public-read
           ${AWS_CMD} executorch.aar.sha256sums s3://ossci-android/executorch/release/${VERSION}-${FLAVOR}/executorch.aar.sha256sums --acl public-read


### PR DESCRIPTION
When android-release-on-tag calls this workflow for multiple flavors, they share the same run_id and S3 prefix. Naming the intermediate artifact executorch-${FLAVOR}.aar prevents the second and third uploads from failing with "file already exists".
