### PR TITLE
Add EfficientNet, Swin, and DistilBERT model wrappers for XNNPACK/Vulkan export

### DIFF
--- a/download_models.sh
+++ b/download_models.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# Download all model checkpoints needed for MLSys benchmarking.
+# Run this from the ExecuTorch repo root.
+#
+# Models that auto-download (torchvision pretrained weights):
+#   - MobileNetV3, ViT, EfficientNet, Swin — downloaded during export, no action needed.
+#
+# Models that need manual download:
+#   - Llama 3.2 1B/3B — Meta checkpoints (llama CLI or llama.com)
+#   - Qwen 3 0.6B — HuggingFace (auto-downloaded during export, but pre-caching here)
+#   - MobileBERT, DistilBERT — HuggingFace transformers models
+
+set -euo pipefail
+
+LLAMA_CHECKPOINT_DIR="$HOME/.llama/checkpoints"
+
+echo "========================================="
+echo " 1. Llama 3.2 1B Instruct"
+echo "========================================="
+if [ -f "$LLAMA_CHECKPOINT_DIR/Llama3.2-1B-Instruct/consolidated.00.pth" ]; then
+    echo "✔ Already downloaded at $LLAMA_CHECKPOINT_DIR/Llama3.2-1B-Instruct/"
+else
+    echo "✘ Not found. Download from https://www.llama.com/llama-downloads/"
+    echo "  Or run: llama download --source meta --model-id Llama3.2-1B-Instruct"
+    echo ""
+fi
+
+echo ""
+echo "========================================="
+echo " 2. Llama 3.2 3B Instruct"
+echo "========================================="
+if [ -f "$LLAMA_CHECKPOINT_DIR/Llama3.2-3B-Instruct/consolidated.00.pth" ]; then
+    echo "✔ Already downloaded at $LLAMA_CHECKPOINT_DIR/Llama3.2-3B-Instruct/"
+else
+    echo "✘ Not found. Download from https://www.llama.com/llama-downloads/"
+    echo "  Or run: llama download --source meta --model-id Llama3.2-3B-Instruct"
+    echo ""
+fi
+
+echo ""
+echo "========================================="
+echo " 3. Qwen 3 0.6B (HuggingFace)"
+echo "========================================="
+echo "Pre-downloading Qwen 3 0.6B from HuggingFace..."
+echo "(This will be auto-converted to Meta format during export)"
+hf download Qwen/Qwen3-0.6B
+
+echo ""
+echo "========================================="
+echo " 4. MobileBERT (HuggingFace)"
+echo "========================================="
+echo "Pre-downloading MobileBERT from HuggingFace..."
+hf download google/mobilebert-uncased
+
+echo ""
+echo "========================================="
+echo " 5. DistilBERT (HuggingFace)"
+echo "========================================="
+echo "Pre-downloading DistilBERT from HuggingFace..."
+hf download distilbert/distilbert-base-uncased
+
+echo ""
+echo "========================================="
+echo " 6. Vision models (auto-download)"
+echo "========================================="
+echo "The following models use torchvision pretrained weights"
+echo "and will be downloaded automatically during export:"
+echo "  - MobileNetV3"
+echo "  - ViT"
+echo "  - EfficientNet-B0"
+echo "  - Swin Transformer Tiny"
+echo ""
+echo "No manual download needed."
+
+echo ""
+echo "========================================="
+echo " Summary"
+echo "========================================="
+echo "Llama 3.2 1B:  $([ -f "$LLAMA_CHECKPOINT_DIR/Llama3.2-1B-Instruct/consolidated.00.pth" ] && echo '✔ Ready' || echo '✘ Missing')"
+echo "Llama 3.2 3B:  $([ -f "$LLAMA_CHECKPOINT_DIR/Llama3.2-3B-Instruct/consolidated.00.pth" ] && echo '✔ Ready' || echo '✘ Missing')"
+echo "Qwen 3 0.6B:   ✔ Downloaded (will convert during export)"
+echo "MobileBERT:    ✔ Downloaded"
+echo "DistilBERT:    ✔ Downloaded"
+echo "MobileNetV3:   ✔ Auto-download during export"
+echo "ViT:           ✔ Auto-download during export"
+echo "EfficientNet:  ✔ Auto-download during export"
+echo "Swin:          ✔ Auto-download during export"

--- a/examples/models/__init__.py
+++ b/examples/models/__init__.py
@@ -45,6 +45,9 @@ class Model(str, Enum):
     MobileNetV1025 = "mobilenet_v1_025"
     ResNet8 = "resnet8"
     Sdpa = "sdpa"
+    EfficientNetB0 = "efficientnet_b0"
+    SwinT = "swin_t"
+    DistilBert = "distilbert"
 
     def __str__(self) -> str:
         return self.value
@@ -105,6 +108,9 @@ MODEL_NAME_TO_MODEL = {
     ),
     str(Model.ResNet8): ("mlperf_tiny.resnet8", "ResNet8Model"),
     str(Model.Sdpa): ("toy_model", "SdpaModule"),
+    str(Model.EfficientNetB0): ("efficientnet", "EfficientNetB0Model"),
+    str(Model.SwinT): ("swin", "SwinTModel"),
+    str(Model.DistilBert): ("distilbert", "DistilBertModelExample"),
 }
 
 __all__ = [

--- a/examples/models/distilbert/__init__.py
+++ b/examples/models/distilbert/__init__.py
@@ -1,0 +1,11 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from .model import DistilBertModelExample
+
+__all__ = [
+    DistilBertModelExample,
+]

--- a/examples/models/distilbert/model.py
+++ b/examples/models/distilbert/model.py
@@ -1,0 +1,29 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+
+import torch
+from transformers import AutoTokenizer, DistilBertModel  # @manual
+
+from ..model_base import EagerModelBase
+
+
+class DistilBertModelExample(EagerModelBase):
+    def __init__(self):
+        pass
+
+    def get_eager_model(self) -> torch.nn.Module:
+        logging.info("Loading DistilBERT model")
+        model = DistilBertModel.from_pretrained(
+            "distilbert/distilbert-base-uncased", return_dict=False
+        )
+        logging.info("Loaded DistilBERT model")
+        return model
+
+    def get_example_inputs(self):
+        tokenizer = AutoTokenizer.from_pretrained("distilbert/distilbert-base-uncased")
+        return (tokenizer("Hello, my dog is cute", return_tensors="pt")["input_ids"],)

--- a/examples/models/efficientnet/__init__.py
+++ b/examples/models/efficientnet/__init__.py
@@ -1,0 +1,11 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from .model import EfficientNetB0Model
+
+__all__ = [
+    EfficientNetB0Model,
+]

--- a/examples/models/efficientnet/model.py
+++ b/examples/models/efficientnet/model.py
@@ -1,0 +1,28 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+
+import torch
+from torchvision import models
+
+from ..model_base import EagerModelBase
+
+
+class EfficientNetB0Model(EagerModelBase):
+    def __init__(self):
+        pass
+
+    def get_eager_model(self) -> torch.nn.Module:
+        logging.info("Loading EfficientNet-B0 model")
+        model = models.efficientnet_b0(
+            weights=models.EfficientNet_B0_Weights.IMAGENET1K_V1
+        )
+        logging.info("Loaded EfficientNet-B0 model")
+        return model
+
+    def get_example_inputs(self):
+        return (torch.randn(1, 3, 224, 224),)

--- a/examples/models/swin/__init__.py
+++ b/examples/models/swin/__init__.py
@@ -1,0 +1,11 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from .model import SwinTModel
+
+__all__ = [
+    SwinTModel,
+]

--- a/examples/models/swin/model.py
+++ b/examples/models/swin/model.py
@@ -1,0 +1,26 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+
+import torch
+from torchvision import models
+
+from ..model_base import EagerModelBase
+
+
+class SwinTModel(EagerModelBase):
+    def __init__(self):
+        pass
+
+    def get_eager_model(self) -> torch.nn.Module:
+        logging.info("Loading Swin Transformer Tiny model")
+        model = models.swin_t(weights=models.Swin_T_Weights.IMAGENET1K_V1)
+        logging.info("Loaded Swin Transformer Tiny model")
+        return model
+
+    def get_example_inputs(self):
+        return (torch.randn(1, 3, 224, 224),)

--- a/examples/vulkan/export.py
+++ b/examples/vulkan/export.py
@@ -51,6 +51,9 @@ def is_vision_model(model_name):
         "convnext_small",
         "densenet161",
         "shufflenet_v2_x1_0",
+        # New vision models
+        "efficientnet_b0",
+        "swin_t",
     ]:
         return True
 

--- a/examples/xnnpack/__init__.py
+++ b/examples/xnnpack/__init__.py
@@ -45,6 +45,9 @@ MODEL_NAME_TO_OPTIONS = {
     "emformer_join": XNNPACKOptions(QuantType.DYNAMIC_PER_CHANNEL, True),
     "emformer_predict": XNNPACKOptions(QuantType.DYNAMIC_PER_CHANNEL, True),
     "emformer_transcribe": XNNPACKOptions(QuantType.STATIC_PER_CHANNEL, True),
+    "efficientnet_b0": XNNPACKOptions(QuantType.STATIC_PER_CHANNEL, True),
+    "swin_t": XNNPACKOptions(QuantType.DYNAMIC_PER_CHANNEL, True),
+    "distilbert": XNNPACKOptions(QuantType.DYNAMIC_PER_CHANNEL, True),
 }
 
 


### PR DESCRIPTION

Summary: These models were previously only exportable via QNN-specific scripts. Add
EagerModelBase wrappers so they can be exported through the standard XNNPACK
and Vulkan export pipelines:

- EfficientNet-B0 (torchvision pretrained)
- Swin Transformer Tiny (torchvision pretrained)
- DistilBERT base uncased (HuggingFace transformers)

Also add model entries to the examples/vulkan and examples/xnnpack export
registries, and a download_models.sh script to pre-cache all model checkpoints
needed for MLSys benchmarking.

Authored with Claude.

Test Plan: Exported EfficientNet, Swin, and DistilBERT to .pte via both XNNPACK and
Vulkan export pipelines. Verified all three models load and produce outputs
on-device.

Reviewers:

Subscribers:

Tasks:

Tags:


cc @manuelcandales @digantdesai @cbilgin