### PR TITLE
Pass weights_only flag to EXIR deserialization

### DIFF
--- a/exir/serde/export_serialize.py
+++ b/exir/serde/export_serialize.py
@@ -325,7 +325,7 @@ def serialize_torch_artifact(artifact: Dict[str, Any]) -> bytes:
 
 
 def deserialize_torch_artifact(
-    serialized: Union[Dict[str, Any], Tuple[Any, ...], bytes]
+    serialized: Union[Dict[str, Any], Tuple[Any, ...], bytes], weights_only: bool = True
 ):
     if isinstance(serialized, (dict, tuple)):
         return serialized
@@ -333,7 +333,7 @@ def deserialize_torch_artifact(
         return {}
     buffer = io.BytesIO(serialized)
     buffer.seek(0)
-    artifact = torch.load(buffer, weights_only=True)
+    artifact = torch.load(buffer, weights_only=weights_only)
     assert isinstance(artifact, (tuple, dict))
     return artifact
 
@@ -1836,6 +1836,7 @@ class GraphModuleDeserializer:
             Union[Tuple[Tuple[torch.Tensor, ...], Dict[str, Any]], bytes]
         ] = None,
         symbol_name_to_range: Optional[Dict[str, symbolic_shapes.ValueRanges]] = None,
+        weights_only: bool = True
     ) -> Result:
         global _CURRENT_DESERIALIZER
         current_deserializer_state = _CURRENT_DESERIALIZER.copy()
@@ -1887,7 +1888,7 @@ class GraphModuleDeserializer:
                 signature=self.signature,
                 module_call_graph=module_call_graph,
                 names_to_symbols=self.symbol_name_to_symbol,
-                state_dict=deserialize_torch_artifact(serialized_state_dict),
+                state_dict=deserialize_torch_artifact(serialized_state_dict, weights_only = weights_only),
                 constants=self.constants,
                 example_inputs=self.example_inputs,
             )

--- a/exir/serde/serialize.py
+++ b/exir/serde/serialize.py
@@ -631,6 +631,7 @@ class ExportedProgramDeserializer(export_serialize.ExportedProgramDeserializer):
         example_inputs: Optional[
             Union[Tuple[Tuple[torch.Tensor, ...], Dict[str, Any]], bytes]
         ] = None,
+        weights_only: bool = True
     ) -> ep.ExportedProgram:
         assert isinstance(exported_program, export_serialize.ExportedProgram)
         version = exported_program.schema_version
@@ -657,6 +658,7 @@ class ExportedProgramDeserializer(export_serialize.ExportedProgramDeserializer):
             constants,
             example_inputs,
             symbol_name_to_range,
+            weights_only=weights_only,
         )
         range_constraints = self.deserialize_range_constraints(
             symbol_name_to_range,
@@ -721,7 +723,7 @@ def serialize(
 
 
 def deserialize(
-    artifact: export_serialize.SerializedArtifact,
+    artifact: export_serialize.SerializedArtifact,weights_only: bool = True
 ) -> ep.ExportedProgram:
     assert isinstance(artifact.exported_program, bytes)
     exported_program_str = artifact.exported_program.decode("utf-8")
@@ -734,6 +736,7 @@ def deserialize(
         artifact.state_dict,
         artifact.constants,
         artifact.example_inputs,
+        weights_only=weights_only,
     )
 
 


### PR DESCRIPTION
Summary:
This is a workaround to the following error during deserialization of the EXIR graph:

```Exception has occurred: UnpicklingError       (note: full exception trace is shown but execution is paused at: <module>)
Weights only load failed. This file can still be loaded, to do so you have two options, [1mdo those steps only if you trust the source of the checkpoint[0m.
	(1) In PyTorch 2.6, we changed the default value of the `weights_only` argument in `torch.load` from `False` to `True`. Re-running `torch.load` with `weights_only` set to `False` will likely succeed, but it can result in arbitrary code execution. Do it only if you got the file from a trusted source.
	(2) Alternatively, to load with `weights_only=True` please check the recommended steps in the following error message.
	WeightsUnpickler error: Unsupported global: GLOBAL executorch.exir.serde.export_serialize._reconstruct_fake_tensor was not an allowed global by default. Please use `torch.serialization.add_safe_globals([executorch.exir.serde.export_serialize._reconstruct_fake_tensor])` or the `torch.serialization.safe_globals([executorch.exir.serde.export_serialize._reconstruct_fake_tensor])` context manager to allowlist this global if you trust this class/function.
```

Differential Revision: D98258299


