### PR TITLE
[RELEASE TEST] Bump torchao to 02105d4 (v0.17.0-rc1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -846,6 +846,18 @@ if(EXECUTORCH_BUILD_KERNELS_TORCHAO)
   set(TORCHAO_ENABLE_ARM_NEON_DOT ON)
   set(TORCHAO_BUILD_KLEIDIAI ON)
 
+  # TorchAO requires find_package(Torch) for include dirs; add its cmake path.
+  execute_process(
+    COMMAND ${PYTHON_EXECUTABLE} -c
+            "import torch; print(torch.utils.cmake_prefix_path)"
+    OUTPUT_VARIABLE _torch_cmake_prefix
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    RESULT_VARIABLE _torch_cmake_prefix_result
+  )
+  if(_torch_cmake_prefix_result EQUAL 0 AND _torch_cmake_prefix)
+    list(APPEND CMAKE_PREFIX_PATH "${_torch_cmake_prefix}")
+  endif()
+
   # TorchAO kernels look for EXECUTORCH_INCLUDE_DIRS
   if(DEFINED EXECUTORCH_INCLUDE_DIRS)
     message(FATAL_ERROR "EXECUTORCH_INCLUDE_DIRS is already defined")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -847,16 +847,7 @@ if(EXECUTORCH_BUILD_KERNELS_TORCHAO)
   set(TORCHAO_BUILD_KLEIDIAI ON)
 
   # TorchAO requires find_package(Torch) for include dirs; add its cmake path.
-  execute_process(
-    COMMAND ${PYTHON_EXECUTABLE} -c
-            "import torch; print(torch.utils.cmake_prefix_path)"
-    OUTPUT_VARIABLE _torch_cmake_prefix
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    RESULT_VARIABLE _torch_cmake_prefix_result
-  )
-  if(_torch_cmake_prefix_result EQUAL 0 AND _torch_cmake_prefix)
-    list(APPEND CMAKE_PREFIX_PATH "${_torch_cmake_prefix}")
-  endif()
+  add_torch_to_cmake_prefix_path()
 
   # TorchAO kernels look for EXECUTORCH_INCLUDE_DIRS
   if(DEFINED EXECUTORCH_INCLUDE_DIRS)


### PR DESCRIPTION
Update torchao to 02105d4 (v0.17.0-rc1) and add Torch cmake prefix path for TorchAO build

The torchao submodule update introduces a find_package(Torch) call that requires Torch's cmake config to be discoverable. Reuse the existing add_torch_to_cmake_prefix_path() helper from tools/cmake/Utils.cmake to fix the build.
