### PR TITLE
Fix operator precedence bug in cat_out dtype check

### DIFF
--- a/backends/cadence/fusion_g3/operators/op_cat.cpp
+++ b/backends/cadence/fusion_g3/operators/op_cat.cpp
@@ -100,22 +100,23 @@ Tensor& cat_out(
     out_shapes[i] = out_size[i];
   }
 
-  bool optimized = true;
-
+  bool all_same_dtype = true;
   for (int i = 0; i < tensors.size(); i++) {
     if (out.scalar_type() != tensors[i].scalar_type()) {
-      optimized = false;
+      all_same_dtype = false;
       break;
     }
   }
 
-  if ((optimized) && (out.scalar_type() == ScalarType::Int) ||
-      (out.scalar_type() == ScalarType::Short) ||
-      (out.scalar_type() == ScalarType::Char) ||
-      (out.scalar_type() == ScalarType::UInt32) ||
-      (out.scalar_type() == ScalarType::UInt16) ||
-      (out.scalar_type() == ScalarType::Byte) ||
-      (out.scalar_type() == ScalarType::Float)) {
+  bool supported_dtype = out.scalar_type() == ScalarType::Int ||
+      out.scalar_type() == ScalarType::Short ||
+      out.scalar_type() == ScalarType::Char ||
+      out.scalar_type() == ScalarType::UInt32 ||
+      out.scalar_type() == ScalarType::UInt16 ||
+      out.scalar_type() == ScalarType::Byte ||
+      out.scalar_type() == ScalarType::Float;
+
+  if (all_same_dtype && supported_dtype) {
     XT_KERNEL_CHECK(
         ctx,
         out,


### PR DESCRIPTION
Summary: The `&&` operator binds tighter than `||` in C++, so the `optimized` flag only gated ScalarType::Int. For all other types (Short, Char, Float, etc.), xa_nn_cat was called unconditionally — even when inputs had mixed dtypes — resulting in raw byte copies without type conversion.

Differential Revision: D98801435


