### PR TITLE
Check flatbuffer offset when verification is minimal

### DIFF
--- a/runtime/executor/program.cpp
+++ b/runtime/executor/program.cpp
@@ -139,7 +139,7 @@ Result<executorch_flatbuffer::ExecutionPlan*> get_execution_plan(
     return Error::InvalidProgram;
   }
 
-  // Do extra verification if requested.
+  // Do verification based on the requested level.
   if (verification == Verification::InternalConsistency) {
 #if ET_ENABLE_PROGRAM_VERIFICATION
     EXECUTORCH_SCOPE_PROF("Program::verify_internal_consistency");
@@ -160,8 +160,22 @@ Result<executorch_flatbuffer::ExecutionPlan*> get_execution_plan(
         "Program validation failed: likely a corrupt file");
 #else
     ET_LOG(
-        Info, "InternalConsistency verification requested but not available");
+        Error,
+        "InternalConsistency verification requested but not available; "
+        "build with ET_ENABLE_PROGRAM_VERIFICATION=1");
+    return Error::NotSupported;
 #endif
+  } else {
+    // Minimal verification: check that the root table offset is within bounds.
+    // The first 4 bytes of the flatbuffer contain an offset to the root table.
+    uint32_t root_offset = flatbuffers::ReadScalar<flatbuffers::uoffset_t>(
+        program_data->data());
+    ET_CHECK_OR_RETURN_ERROR(
+        root_offset < program_data->size(),
+        InvalidProgram,
+        "Root table offset %u >= program size %zu",
+        root_offset,
+        program_data->size());
   }
 
   // The flatbuffer data must start at an aligned address to ensure internal

--- a/runtime/executor/program.cpp
+++ b/runtime/executor/program.cpp
@@ -168,12 +168,19 @@ Result<executorch_flatbuffer::ExecutionPlan*> get_execution_plan(
   } else {
     // Minimal verification: check that the root table offset is within bounds.
     // The first 4 bytes of the flatbuffer contain an offset to the root table.
+    ET_CHECK_OR_RETURN_ERROR(
+        program_data->size() >= sizeof(flatbuffers::uoffset_t),
+        InvalidProgram,
+        "Program data size %zu is too small for flatbuffer header",
+        program_data->size());
     uint32_t root_offset = flatbuffers::ReadScalar<flatbuffers::uoffset_t>(
         program_data->data());
+    // The root table is at buf + root_offset, and must have at least a
+    // vtable offset (soffset_t) at that position.
     ET_CHECK_OR_RETURN_ERROR(
-        root_offset < program_data->size(),
+        root_offset <= program_data->size() - sizeof(flatbuffers::uoffset_t),
         InvalidProgram,
-        "Root table offset %u >= program size %zu",
+        "Root table offset %u exceeds program size %zu",
         root_offset,
         program_data->size());
   }

--- a/runtime/executor/program.cpp
+++ b/runtime/executor/program.cpp
@@ -128,6 +128,25 @@ Result<executorch_flatbuffer::ExecutionPlan*> get_execution_plan(
   }
   EXECUTORCH_END_PROF(prof_tok);
 
+  // The flatbuffer data must start at an aligned address to ensure internal
+  // alignment of flatbuffer fields.
+  ET_CHECK_OR_RETURN_ERROR(
+      IsAligned(program_data->data()),
+      InvalidArgument,
+      "Program data 0x%p must be aligned to %zu",
+      program_data->data(),
+      kMinimumAlignment);
+
+  // Minimum size: root offset + file identifier (i.e., the flatbuffer header
+  // before the extended header begins).
+  constexpr size_t kMinBufferSize = ExtendedHeader::kHeaderOffset;
+  ET_CHECK_OR_RETURN_ERROR(
+      program_data->size() >= kMinBufferSize,
+      InvalidProgram,
+      "Program data size %zu is too small (minimum %zu)",
+      program_data->size(),
+      kMinBufferSize);
+
   // Make sure the magic header matches the expected version.
   if (!executorch_flatbuffer::ProgramBufferHasIdentifier(
           program_data->data())) {
@@ -166,34 +185,22 @@ Result<executorch_flatbuffer::ExecutionPlan*> get_execution_plan(
     return Error::NotSupported;
 #endif
   } else {
-    // Minimal verification: check that the root table offset is within bounds.
-    // The first 4 bytes of the flatbuffer contain an offset to the root table.
+    // Verification::Minimal: Verify that the root table offset is within
+    // bounds. This is done in InternalConsistency by VerifyProgramBuffer.
+    uint32_t root_offset =
+        flatbuffers::ReadScalar<flatbuffers::uoffset_t>(program_data->data());
+    // The root table is at buf + root_offset. It must not point into the
+    // header (offset + file identifier = 8 bytes) and must leave room for
+    // at least a vtable offset (soffset_t) at its position.
     ET_CHECK_OR_RETURN_ERROR(
-        program_data->size() >= sizeof(flatbuffers::uoffset_t),
+        root_offset >= kMinBufferSize &&
+            root_offset <=
+                program_data->size() - sizeof(flatbuffers::soffset_t),
         InvalidProgram,
-        "Program data size %zu is too small for flatbuffer header",
-        program_data->size());
-    uint32_t root_offset = flatbuffers::ReadScalar<flatbuffers::uoffset_t>(
-        program_data->data());
-    // The root table is at buf + root_offset, and must have at least a
-    // vtable offset (soffset_t) at that position.
-    ET_CHECK_OR_RETURN_ERROR(
-        root_offset <= program_data->size() - sizeof(flatbuffers::uoffset_t),
-        InvalidProgram,
-        "Root table offset %u exceeds program size %zu",
+        "Root table offset %u is invalid for program size %zu",
         root_offset,
         program_data->size());
   }
-
-  // The flatbuffer data must start at an aligned address to ensure internal
-  // alignment of flatbuffer fields.
-  ET_CHECK_OR_RETURN_ERROR(
-      IsAligned(program_data->data()),
-      InvalidArgument,
-      "Program data 0x%p must be aligned to %zu",
-      program_data->data(),
-      kMinimumAlignment);
-
   // Get the pointer to the root flatbuffer table.
   const executorch_flatbuffer::Program* flatbuffer_program =
       executorch_flatbuffer::GetProgram(program_data->data());

--- a/runtime/executor/test/program_test.cpp
+++ b/runtime/executor/test/program_test.cpp
@@ -266,9 +266,9 @@ TEST_F(ProgramTest, MinimalVerificationCatchesInvalidRootOffset) {
   }
 
   // Corrupt the root offset (first 4 bytes) to point beyond the buffer.
-  // Set it to a value larger than the buffer size.
-  uint32_t invalid_offset = static_cast<uint32_t>(data_len + 1000);
-  memcpy(data.get(), &invalid_offset, sizeof(invalid_offset));
+  // Use WriteScalar for correct little-endian encoding.
+  flatbuffers::WriteScalar<flatbuffers::uoffset_t>(
+      data.get(), static_cast<flatbuffers::uoffset_t>(data_len + 1000));
 
   // Wrap the corrupted data in a loader.
   BufferDataLoader data_loader(data.get(), data_len);

--- a/tools/cmake/preset/pybind.cmake
+++ b/tools/cmake/preset/pybind.cmake
@@ -7,10 +7,11 @@
 set_overridable_option(EXECUTORCH_BUILD_PYBIND ON)
 set_overridable_option(EXECUTORCH_BUILD_KERNELS_QUANTIZED ON)
 set_overridable_option(EXECUTORCH_BUILD_KERNELS_QUANTIZED_AOT ON)
-# Enable logging even when in release mode. We are building for desktop, where
-# saving a few kB is less important than showing useful error information to
-# users.
+# Enable logging and program verification even when in release mode. We are
+# building for desktop, where saving a few kB is less important than showing
+# useful error information to users.
 set_overridable_option(EXECUTORCH_ENABLE_LOGGING ON)
+set_overridable_option(EXECUTORCH_ENABLE_PROGRAM_VERIFICATION ON)
 set_overridable_option(EXECUTORCH_LOG_LEVEL Info)
 set_overridable_option(EXECUTORCH_BUILD_XNNPACK ON)
 set_overridable_option(EXECUTORCH_BUILD_EXTENSION_TENSOR ON)

--- a/tools/cmake/preset/windows.cmake
+++ b/tools/cmake/preset/windows.cmake
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 # keep sorted
+set_overridable_option(EXECUTORCH_ENABLE_PROGRAM_VERIFICATION ON)
 set_overridable_option(EXECUTORCH_BUILD_EXECUTOR_RUNNER ON)
 set_overridable_option(EXECUTORCH_BUILD_EXTENSION_DATA_LOADER ON)
 set_overridable_option(EXECUTORCH_BUILD_EXTENSION_EVALUE_UTIL ON)


### PR DESCRIPTION
### Summary
Unconditionally verify that the offset is within the flatbuffer bounds. Setting InternalConsistency is a binary size burden (20-30kb), so check this separately when we have minimal verification.

Error out if InternalConsistency is requested, but verification is disabled.
-> update tests to set verification=1 when InternalConsistency is requested.

Re-order some checks, so they become:

1. Load data
2. Check alignment
3. Check min file size (root offset + file identifier)
4. Check identifier ET**
5. InternalConsistency check or
6. Minimal check; ensure root offset is valid: `root_offset >= min buffer size && root_offset <= program size - offset size`

### Test plan
```
cd build
cmake .. -DEXECUTORCH_BUILD_TESTS=ON
cmake --build . --target program_test
ctest -R program_test -V
```