### PR TITLE
Fix integer overflow in compute_numel()

### DIFF
--- a/runtime/core/portable_type/tensor_impl.cpp
+++ b/runtime/core/portable_type/tensor_impl.cpp
@@ -9,6 +9,7 @@
 #include <executorch/runtime/core/portable_type/tensor_impl.h>
 
 #include <algorithm>
+#include <climits>
 #include <cstdint>
 
 #include <c10/util/irange.h>
@@ -36,6 +37,12 @@ ssize_t compute_numel(const TensorImpl::SizesType* sizes, ssize_t dim) {
     ET_CHECK_MSG(
         sizes[i] >= 0,
         "Size must be non-negative, got %zd at dimension %zd",
+        static_cast<ssize_t>(sizes[i]),
+        i);
+    ET_CHECK_MSG(
+        sizes[i] == 0 || numel <= SSIZE_MAX / sizes[i],
+        "Overflow computing numel: %zd * %zd would overflow ssize_t at dimension %zd",
+        numel,
         static_cast<ssize_t>(sizes[i]),
         i);
     numel *= sizes[i];

--- a/runtime/core/portable_type/tensor_impl.cpp
+++ b/runtime/core/portable_type/tensor_impl.cpp
@@ -13,6 +13,7 @@
 #include <cstdint>
 
 #include <c10/util/irange.h>
+#include <c10/util/safe_numerics.h>
 
 #include <executorch/runtime/core/exec_aten/util/dim_order_util.h>
 #include <executorch/runtime/core/exec_aten/util/scalar_type_util.h>
@@ -39,13 +40,14 @@ ssize_t compute_numel(const TensorImpl::SizesType* sizes, ssize_t dim) {
         "Size must be non-negative, got %zd at dimension %zd",
         static_cast<ssize_t>(sizes[i]),
         i);
+    ssize_t next_numel;
     ET_CHECK_MSG(
-        sizes[i] == 0 || numel <= SSIZE_MAX / sizes[i],
+        !c10::mul_overflows(numel, static_cast<ssize_t>(sizes[i]), &next_numel),
         "Overflow computing numel: %zd * %zd would overflow ssize_t at dimension %zd",
         numel,
         static_cast<ssize_t>(sizes[i]),
         i);
-    numel *= sizes[i];
+    numel = next_numel;
   }
   return numel;
 }

--- a/runtime/executor/tensor_parser_portable.cpp
+++ b/runtime/executor/tensor_parser_portable.cpp
@@ -8,6 +8,10 @@
 
 #include <executorch/runtime/executor/tensor_parser.h>
 
+#include <climits>
+
+#include <c10/util/safe_numerics.h>
+
 #include <executorch/runtime/core/exec_aten/exec_aten.h>
 #include <executorch/runtime/core/exec_aten/util/dim_order_util.h>
 #include <executorch/runtime/core/exec_aten/util/scalar_type_util.h>
@@ -118,10 +122,11 @@ Result<Tensor> parseTensor(
     dim_order =
         const_cast<executorch::aten::DimOrderType*>(serialized_dim_order);
   }
-  // Validate sizes before using them in case the PTE data is bad. We can't
-  // detect bad positive values, but we can reject negative values, which would
-  // otherwise panic in the TensorImpl ctor. dim_order_to_stride() will validate
-  // dim_order.
+  // Validate sizes before using them in case the PTE data is bad. Reject
+  // negative values and check that the product of all dimensions doesn't
+  // overflow ssize_t, which would otherwise abort in the TensorImpl ctor.
+  // dim_order_to_stride() will validate dim_order.
+  ssize_t numel = 1;
   for (flatbuffers::uoffset_t i = 0; i < dim; i++) {
     ET_CHECK_OR_RETURN_ERROR(
         sizes[i] >= 0,
@@ -129,6 +134,13 @@ Result<Tensor> parseTensor(
         "Negative size[%zu] %" PRId32,
         static_cast<size_t>(i),
         sizes[i]);
+    ssize_t next_numel;
+    ET_CHECK_OR_RETURN_ERROR(
+        !c10::mul_overflows(numel, static_cast<ssize_t>(sizes[i]), &next_numel),
+        InvalidProgram,
+        "Overflow computing numel at dim %zu",
+        static_cast<size_t>(i));
+    numel = next_numel;
   }
 
   // We will remove strides from schema.

--- a/runtime/executor/tensor_parser_portable.cpp
+++ b/runtime/executor/tensor_parser_portable.cpp
@@ -8,8 +8,6 @@
 
 #include <executorch/runtime/executor/tensor_parser.h>
 
-#include <climits>
-
 #include <c10/util/safe_numerics.h>
 
 #include <executorch/runtime/core/exec_aten/exec_aten.h>


### PR DESCRIPTION
compute_numel() multiplies tensor dimensions without overflow protection. The result is used for size calculations in make_tensor_ptr() and clone_tensor_ptr(), so an overflow could lead to undersized allocations and subsequent buffer overflows.

This PR was authored with the assistance of Claude.

-- 
TensorImpl ctor can't return an error. To avoid aborting when calculating numel (because of overflow), we have to introduce a new ctor that takes numel as a precomputed value.

1. Update the tensor ctor to take in numel. Deprecate the old one following cycle.
2. Make compute_numel() return a Result.
3. Update all callsites to use the new tensor ctor (~15 across extension and other places)
4. tensor_ptr and tensor_ptr_maker call compute_numel() directly in their ctor. They also need to be updated with either a new ctor, or use ET_CHECK_MSG.

The blast radius is a bit large. I think we can do this for now and tackle the ET_CHECK_MSG removal across the codebase separately.



