### PR TITLE
[RELEASE ONLY CHANGES] Add torchao>=0.17.0 dependency to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ dependencies=[
   "hydra-core>=1.3.0",
   "omegaconf>=2.3.0",
   "torch>=2.11.0",
+  "torchao>=0.17.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
Update pyproject.toml now that torchao has officially released [0.17.0](https://pypi.org/project/torchao/0.17.0/)