### PR TITLE
Fix missing deps in CUDA backend TARGETS (#18605)

### DIFF
--- a/backends/cuda/TARGETS
+++ b/backends/cuda/TARGETS
@@ -54,6 +54,7 @@ runtime.python_library(
     name = "triton_kernels",
     srcs = [
         "triton/kernels/__init__.py",
+        "triton/kernels/fused_moe.py",
         "triton/kernels/sdpa.py",
         "triton/kernels/topk.py",
     ],

--- a/backends/cuda/runtime/TARGETS
+++ b/backends/cuda/runtime/TARGETS
@@ -86,6 +86,7 @@ runtime.cxx_library(
     preprocessor_flags = ["-DCUDA_AVAILABLE=1"],
     visibility = ["PUBLIC"],
     deps = [
+        ":cuda_platform",
         ":runtime_shims",
         "//executorch/backends/aoti:aoti_common_slim",
         "//executorch/backends/aoti/slim/core:slimtensor",


### PR DESCRIPTION
Summary:

- cuda/runtime/TARGETS: Add missing cuda_platform dep to cuda_backend.
  cuda_backend.cpp includes platform/platform.h but the dep was not
  declared.
- cuda/TARGETS: Add fused_moe.py to triton_kernels srcs. The __init__.py
  imports it but it was missing from the build target.

Reviewed By: Gasoonjia

Differential Revision: D98862651
