### PR TITLE
Add labeler for ARM path changes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,15 @@
+"module: arm":
+- changed-files:
+  - any-glob-to-any-file:
+    - 'backends/arm/**'
+    - 'examples/arm/**'
+    - 'docs/source/backends/arm-*/**'
+    - 'docs/source/embedded-arm-ethos-u.md'
+    - 'docs/source/android-arm-vgf.md'
+    - 'docs/source/arm-delegate-runtime-build.svg'
+
+ciflow/trunk:
+- changed-files:
+  - any-glob-to-any-file:
+    - 'backends/arm/**'
+    - 'examples/arm/**'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,14 @@
+name: Labeler
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5


### PR DESCRIPTION
Apply module: arm and ciflow/trunk labels when backends/arm or examples/arm files are modified.



cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @robell