### PR TITLE
Fix operator precedence bug in permute_copy_out dtype check

### DIFF
--- a/backends/cadence/fusion_g3/operators/op_permute_copy.cpp
+++ b/backends/cadence/fusion_g3/operators/op_permute_copy.cpp
@@ -105,8 +105,8 @@ Tensor& permute_copy_out(
   signed char* out_data = out.mutable_data_ptr<signed char>();
   const signed char* const inp_data = in.const_data_ptr<signed char>();
 
-  if (((out.scalar_type() == in.scalar_type()) &&
-           (out.scalar_type() == ScalarType::Int) ||
+  if ((out.scalar_type() == in.scalar_type()) &&
+      ((out.scalar_type() == ScalarType::Int) ||
        (out.scalar_type() == ScalarType::Short) ||
        (out.scalar_type() == ScalarType::Char) ||
        (out.scalar_type() == ScalarType::UInt32) ||


### PR DESCRIPTION
Summary:
`&&` has precedence over `||` which was missed in the original implementation.

Note that this is purely a cosmetic bug since `(out.scalar_type() == in.scalar_type())` should always be true in practice. Not sure what was the initial motivation for the change in https://github.com/pytorch/executorch/pull/7936.

Differential Revision: D98928236


