### PR TITLE
Fix XNNPACK Prelu for non-4d tensors

### DIFF
--- a/backends/test/suite/targets.bzl
+++ b/backends/test/suite/targets.bzl
@@ -1,21 +1,45 @@
+load("@fbcode_macros//build_defs:python_pytest.bzl", "python_pytest")
 load("@fbsource//tools/target_determinator/macros:ci.bzl", "ci")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
 def define_tests_for_backend(name, deps):
-    runtime.python_test(
-        name = "suite_" + name,
-        srcs = glob([
-            "operators/*.py",
-        ]) + [
+    runtime.python_library(
+        name = "suite_" + name + "_lib",
+        srcs = [
+            "flows/__init__.py",
+            "flows/portable.py",
+            "flows/" + name + ".py",
             "__init__.py",
+            "context.py",
+            "discovery.py",
+            "flow.py",
+            "reporting.py",
+            "runner.py",
         ],
         deps = [
             "//executorch/backends/xnnpack/test/tester:tester",
+            "//executorch/devtools/etrecord:etrecord",
             "//executorch/exir:lib",
             "fbsource//third-party/pypi/parameterized:parameterized",
+            "fbsource//third-party/pypi/pytest:pytest",
         ] + deps,
         external_deps = [
             "libtorch",
+        ],
+    )
+
+    python_pytest(
+        name = "suite_" + name,
+        srcs = glob([
+            "operators/test_*.py",
+        ]) + [
+            "conftest.py",
+            "operators/__init__.py",
+        ],
+        typing = False,
+        deps = [
+            ":suite_" + name + "_lib",
+            "fbsource//third-party/pypi/pytest:pytest",
         ],
         supports_static_listing = False,
         labels = [

--- a/backends/xnnpack/_passes/channels_last_tagged_reshape_pass.py
+++ b/backends/xnnpack/_passes/channels_last_tagged_reshape_pass.py
@@ -160,7 +160,19 @@ class ChannelsLastTaggedReshapePass(XNNPACKPass):
         return ChannelsLastTaggedReshapePass._is_nhwc_tensor(tensor)
 
     def requires_nhwc_input(self, node: torch.fx.Node) -> bool:
-        return node.target in self.memory_sensitive_ops_nhwc
+        if node.target not in self.memory_sensitive_ops_nhwc:
+            return False
+
+        # NHWC layout only applies to 4D tensors. For ops like prelu that can
+        # accept inputs of any dimensionality, skip the NHWC requirement when
+        # the input is not 4D.
+        input_node = node.args[0] if node.args else None
+        if input_node is not None and hasattr(input_node, "meta"):
+            val = input_node.meta.get("val")
+            if val is not None and hasattr(val, "shape") and len(val.shape) != 4:
+                return False
+
+        return True
 
     def requires_nchw_inputs(self, node: torch.fx.Node) -> bool:
         if node.target == exir_ops.edge.aten.view_copy.default:


### PR DESCRIPTION
Summary: Prelu with non-4d tensors is broken on xnnpack. This is because the channels last reshape pass assumes that it must be 4d. Update the pass to leave non-4d tensors unmodified. We still treat all 4d tensors as NHWC, though theoretically you could have a 4d tensor + prelu in a non-CV model, but I'm inclined to just leave this for now. We can add smarter 4d handling later if needed.

Differential Revision: D98987039


