### PR TITLE
[RELEASE ONLY CHANGES] Pin tokenizers to v1.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ dependencies=[
   "pytest-xdist",
   "pytest-rerunfailures==15.1",
   "pytest-json-report",
-  "pytorch-tokenizers",
+  "pytorch-tokenizers>=1.2.0",
   "pyyaml",
   "ruamel.yaml",
   "sympy",


### PR DESCRIPTION
Now that [pytorch-tokenizers==1.2.0](https://pypi.org/project/pytorch-tokenizers/1.2.0/#history) has been released, this PR moves the `pytorch-tokenizers` dependency in pyproject.toml to >=1.2.0 and updates the `extension/llm/tokenizers` submodule to the `v1.2.0` tag.
Similar change in previous release: https://github.com/pytorch/executorch/pull/16873
