### PR TITLE
Fix Zephyr CI cmake install failure by pinning to an existing PyPI version

### DIFF
--- a/zephyr/README.md
+++ b/zephyr/README.md
@@ -17,7 +17,7 @@ source .zephyr_venv/bin/activate
 Install requirements
 <!-- RUN install_reqs -->
 ```
-pip install west cmake==3.29 pyelftools ninja jsonschema
+pip install west cmake==3.29.6 pyelftools ninja jsonschema
 ```
 
 Setup zephyr repo


### PR DESCRIPTION
`cmake==3.29` doesn't exist on PyPI anymore (currently existing versions are `3.29.0.1`, `3.29.2`, etc.), causing the `test-arm-backend-zephyr` trunk jobs to fail. Use `3.29.6` instead (the latest from the `3.29` series).
