### PR TITLE
Zephyr: Bump cmake dependency

### DIFF
--- a/zephyr/README.md
+++ b/zephyr/README.md
@@ -17,7 +17,7 @@ source .zephyr_venv/bin/activate
 Install requirements
 <!-- RUN install_reqs -->
 ```
-pip install west cmake==3.29 pyelftools ninja jsonschema
+pip install west "cmake<4.0.0" pyelftools ninja jsonschema
 ```
 
 Setup zephyr repo


### PR DESCRIPTION
Updated the cmake dependecy v3.29 -> v<4.0.0,
this is due to PyPI not finding 3.29 anymore

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell