### PR TITLE
[RELEASE ONLY CHANGES] Update version references in docs for 1.2 release

### DIFF
--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -158,7 +158,7 @@ For a full example of running a model on Android, see the [DeepLabV3AndroidDemo]
 #### Installation
 ExecuTorch supports both iOS and macOS via C++, as well as hardware backends for CoreML, MPS, and CPU. The iOS runtime library is provided as a collection of .xcframework targets and are made available as a Swift PM package.
 
-To get started with Xcode, go to File > Add Package Dependencies. Paste the URL of the ExecuTorch repo into the search bar and select it. Make sure to change the branch name to the desired ExecuTorch version in format “swiftpm-”, (e.g. “swiftpm-0.6.0”).  The ExecuTorch dependency can also be added to the package file manually. See [Using ExecuTorch on iOS](using-executorch-ios.md) for more information.
+To get started with Xcode, go to File > Add Package Dependencies. Paste the URL of the ExecuTorch repo into the search bar and select it. Make sure to change the branch name to the desired ExecuTorch version in format “swiftpm-”, (e.g. “swiftpm-1.2.0”).  The ExecuTorch dependency can also be added to the package file manually. See [Using ExecuTorch on iOS](using-executorch-ios.md) for more information.
 
 #### Runtime APIs
 Models can be loaded and run from Objective-C using the C++ APIs.

--- a/docs/source/raspberry_pi_llama_tutorial.md
+++ b/docs/source/raspberry_pi_llama_tutorial.md
@@ -57,7 +57,7 @@ First, clone the ExecuTorch repository with the Raspberry Pi support:
 
 ```bash
 # Create project directory
-mkdir ~/executorch-rpi && cd ~/executorch-rpi &&  git clone -b release/1.0 https://github.com/pytorch/executorch.git &&
+mkdir ~/executorch-rpi && cd ~/executorch-rpi &&  git clone -b release/1.2 https://github.com/pytorch/executorch.git &&
 cd executorch
 ```
 

--- a/docs/source/using-executorch-ios.md
+++ b/docs/source/using-executorch-ios.md
@@ -28,7 +28,7 @@ The prebuilt ExecuTorch runtime, backend, and kernels are available as a [Swift 
 
 #### Xcode
 
-In Xcode, go to `File > Add Package Dependencies`. Paste the URL of the [ExecuTorch repo](https://github.com/pytorch/executorch) into the search bar and select it. Make sure to change the branch name to the desired ExecuTorch version in format "swiftpm-<version>", (e.g. "swiftpm-1.0.0"), or a branch name in format "swiftpm-<version>.<year_month_date>" (e.g. "swiftpm-1.1.0-20251101") for a [nightly build](https://ossci-ios.s3.amazonaws.com/list.html) on a specific date.
+In Xcode, go to `File > Add Package Dependencies`. Paste the URL of the [ExecuTorch repo](https://github.com/pytorch/executorch) into the search bar and select it. Make sure to change the branch name to the desired ExecuTorch version in format "swiftpm-<version>", (e.g. "swiftpm-1.2.0"), or a branch name in format "swiftpm-<version>.<year_month_date>" (e.g. "swiftpm-1.3.0-20260401") for a [nightly build](https://ossci-ios.s3.amazonaws.com/list.html) on a specific date.
 
 ![](_static/img/swiftpm_xcode1.png)
 
@@ -61,7 +61,7 @@ let package = Package(
   ],
   dependencies: [
     // Use "swiftpm-<version>.<year_month_day>" branch name for a nightly build.
-    .package(url: "https://github.com/pytorch/executorch.git", branch: "swiftpm-1.0.0")
+    .package(url: "https://github.com/pytorch/executorch.git", branch: "swiftpm-1.2.0")
   ],
   targets: [
     .target(


### PR DESCRIPTION
Update swiftpm branch examples and git clone branch to reflect the 1.2 release across getting-started, iOS, and Raspberry Pi docs.
