### PR TITLE
Use scalar fast path in optimized layer_norm for small tensors (#18636)

### DIFF
--- a/kernels/optimized/cpu/op_native_layer_norm.cpp
+++ b/kernels/optimized/cpu/op_native_layer_norm.cpp
@@ -72,6 +72,24 @@ void layer_norm(
   const bool gamma_null = gamma_data == nullptr;
   const bool beta_null = beta_data == nullptr;
 
+  // For small normalized dimensions, fall back to the portable scalar
+  // implementation since SIMD vectorization setup/tail-handling overhead
+  // exceeds the benefit for small N.
+  constexpr size_t kSmallNThreshold = 256;
+  if (N < kSmallNThreshold) {
+    layer_norm_scalar<CTYPE>(
+        input_data,
+        gamma_data,
+        beta_data,
+        out_data,
+        mean_data,
+        rstd_data,
+        M,
+        N,
+        eps);
+    return;
+  }
+
   for (size_t i = 0; i < M; ++i) {
     const CTYPE* src_ptr = input_data + i * N;
     CTYPE* dst_ptr = out_data + i * N;

--- a/kernels/portable/cpu/op_native_layer_norm.cpp
+++ b/kernels/portable/cpu/op_native_layer_norm.cpp
@@ -8,7 +8,6 @@
 #include <c10/util/irange.h>
 
 #include <executorch/kernels/portable/cpu/util/normalization_ops_util.h>
-#include <executorch/kernels/portable/cpu/vec_ops.h>
 #include <executorch/runtime/kernel/kernel_includes.h>
 #include <cmath>
 #include <tuple>
@@ -54,41 +53,21 @@ void layer_norm(
   }
 
   const CTYPE* input_data = input.const_data_ptr<CTYPE>();
-  const CTYPE* weight_data;
-  if (weight.has_value()) {
-    weight_data = weight.value().const_data_ptr<CTYPE>();
-  } else {
-    weight_data = nullptr;
-  }
-  const CTYPE* bias_data;
-  if (bias.has_value()) {
-    bias_data = bias.value().const_data_ptr<CTYPE>();
-  } else {
-    bias_data = nullptr;
-  }
+  const CTYPE* weight_data =
+      weight.has_value() ? weight.value().const_data_ptr<CTYPE>() : nullptr;
+  const CTYPE* bias_data =
+      bias.has_value() ? bias.value().const_data_ptr<CTYPE>() : nullptr;
 
-  const CTYPE ct_normalized = static_cast<CTYPE>(normalized);
-  for (const auto i : c10::irange(leading)) {
-    const CTYPE* x = input_data + i * normalized;
-    CTYPE* y = out_data + i * normalized;
-
-    // compute E[X] and Var[x] = E[x^2] - E[x]^2
-    float sum = reduce_add(x, ct_normalized);
-    float sq_sum = vec_powerf(x, ct_normalized);
-    float mean_value = sum / ct_normalized;
-    float variance = sq_sum / ct_normalized - mean_value * mean_value;
-    float std = std::sqrt(variance + eps);
-
-    // Calculate the elements of output
-    for (const auto j : c10::irange(normalized)) {
-      CTYPE w = weight_data ? weight_data[j] : static_cast<CTYPE>(1);
-      CTYPE b = bias_data ? bias_data[j] : static_cast<CTYPE>(0);
-      y[j] = (x[j] - mean_value) / std * w + b;
-    }
-
-    mean_data[i] = mean_value;
-    rstd_data[i] = 1.0 / std;
-  }
+  layer_norm_scalar<CTYPE>(
+      input_data,
+      weight_data,
+      bias_data,
+      out_data,
+      mean_data,
+      rstd_data,
+      leading,
+      normalized,
+      eps);
 }
 
 } // namespace

--- a/kernels/portable/cpu/util/normalization_ops_util.h
+++ b/kernels/portable/cpu/util/normalization_ops_util.h
@@ -9,9 +9,53 @@
 #pragma once
 
 #include <executorch/runtime/kernel/kernel_includes.h>
+#include <cmath>
+#include <numeric>
 
 namespace torch {
 namespace executor {
+
+/**
+ * Scalar layer_norm computation over M rows of N elements each.
+ * Computes mean/variance in float, normalizes with (x - mean) / std * gamma +
+ * beta. Caller must handle M==0 and N==0 edge cases before calling.
+ */
+template <typename CTYPE>
+inline void layer_norm_scalar(
+    const CTYPE* input_data,
+    const CTYPE* weight_data, // nullable
+    const CTYPE* bias_data, // nullable
+    CTYPE* out_data,
+    CTYPE* mean_data,
+    CTYPE* rstd_data,
+    size_t M,
+    size_t N,
+    float eps) {
+  for (size_t i = 0; i < M; ++i) {
+    const CTYPE* x = input_data + i * N;
+    CTYPE* y = out_data + i * N;
+
+    // compute E[X] and Var[x] = E[x^2] - E[x]^2
+    float sum = std::accumulate(x, x + N, 0.0f);
+    float sq_sum = 0;
+    for (size_t j = 0; j < N; ++j) {
+      sq_sum += static_cast<float>(x[j]) * x[j];
+    }
+    float mean_value = sum / N;
+    float variance = sq_sum / N - mean_value * mean_value;
+    float std = std::sqrt(variance + eps);
+
+    // Calculate the elements of output
+    for (size_t j = 0; j < N; ++j) {
+      CTYPE w = weight_data ? weight_data[j] : static_cast<CTYPE>(1);
+      CTYPE b = bias_data ? bias_data[j] : static_cast<CTYPE>(0);
+      y[j] = (x[j] - mean_value) / std * w + b;
+    }
+
+    mean_data[i] = mean_value;
+    rstd_data[i] = 1.0 / std;
+  }
+}
 
 bool check_batch_norm_args(
     const Tensor& in,


### PR DESCRIPTION
Summary:

The optimized `native_layer_norm` kernel uses SIMD vectorization
(RowwiseMoments + vec::map3) which has significant setup overhead that
exceeds the benefit for small normalized dimensions. For EMG/CTRL-R
trackpad models with N=26-144 features, this causes a latency
regression vs portable kernels (D98628176).

Add a scalar fast path for N < 256 that bypasses SIMD vectorization,
using simple scalar loops for mean/variance computation and element-wise
normalization. This matches the portable kernel's approach for small
tensors while preserving the SIMD path for large tensors (N >= 256).

The threshold of 256 was determined by analyzing per-op layer_norm
dimensions across both trackpad models:
- Old model (HUGC72): 20x N=72 [scalar], 10x N=144 [scalar], 2x N=512 [SIMD]
- New model (O79HDB): 8x N=32-64 [scalar], 8x N=128 [scalar], 16x N=256 [SIMD], 5x N=512 [SIMD]

With threshold=128, the N=144 calls in the old model still hit the slow
SIMD path, causing ~1ms overhead. Raising to 256 captures these.

Portable vs old optimized regression (x86_64 devserver):

Old model (trackpad-HUGC72.pte):
| Threads | Portable (median) | Old Optimized (median) | Regression |
| 1       |          4,845 us |              8,818 us  |      1.8x  |
| 2       |          4,958 us |              8,982 us  |      1.8x  |
| 4       |          5,627 us |              9,564 us  |      1.7x  |

New model (trackpad-O79HDB-FP32.pte):
| Threads | Portable (median) | Old Optimized (median) | Regression |
| 1       |          5,617 us |              7,695 us  |      1.4x  |
| 2       |          5,818 us |              7,931 us  |      1.4x  |
| 4       |          7,399 us |              9,424 us  |      1.3x  |

**Full thread sweep (threshold=256):**

Old model (trackpad-HUGC72.pte):
| Threads | Portable (median) | Old Optimized (median) | New Optimized (median) | Speedup |
| 1       |          4,826 us |              8,818 us  |             3,929 us   |   2.24x |
| 2       |          5,021 us |              8,982 us  |             4,041 us   |   2.22x |
| 4       |          5,657 us |              9,564 us  |             4,712 us   |   2.03x |

New model (trackpad-O79HDB-FP32.pte):
| Threads | Portable (median) | Old Optimized (median) | New Optimized (median) | Speedup |
| 1       |          5,545 us |              7,695 us  |             5,162 us   |   1.49x |
| 2       |          5,744 us |              7,931 us  |             5,235 us   |   1.52x |
| 4       |          7,175 us |              9,424 us  |             6,750 us   |   1.40x |

Optimized kernels now outperform portable on both models. The old model
sees the largest improvement because 10 layer_norm calls at N=144 moved
from the expensive SIMD path to the fast scalar path.

Suggested by Kimish Patel in the [PyTorch Edge Q&A discussion](https://fb.workplace.com/groups/pytorch.edge.users/permalink/2015326169337666/).

Differential Revision: D98795281


