### PR TITLE
Voxtral Realtime: unlimited streaming via decoder ring buffer KV cache

### DIFF
--- a/.ci/scripts/export_model_artifact.sh
+++ b/.ci/scripts/export_model_artifact.sh
@@ -358,7 +358,7 @@ if [ "$MODEL_NAME" = "voxtral_realtime" ]; then
   STREAMING_ARG=""
   PREPROCESSOR_ARGS="--feature_size 128 --output_file ${OUTPUT_DIR}/preprocessor.pte"
   if [ "$USE_STREAMING" = "true" ]; then
-    STREAMING_ARG="--streaming"
+    STREAMING_ARG="--streaming --sliding-window 2048"
     PREPROCESSOR_ARGS="$PREPROCESSOR_ARGS --streaming"
   else
     PREPROCESSOR_ARGS="$PREPROCESSOR_ARGS --stack_output --max_audio_len 300"

--- a/examples/models/voxtral_realtime/README.md
+++ b/examples/models/voxtral_realtime/README.md
@@ -15,9 +15,10 @@ conversion. At inference time, the C++ runner loads both `.pte` files
 and the Tekken tokenizer, then transcribes audio to text.
 
 Two modes are supported: **streaming** (process 80ms chunks in real time,
-including live microphone input) and **offline** (encode full audio, then
-decode). The examples below use streaming mode. Omit `--streaming` from
-export and run commands for offline mode.
+including live microphone input, with unlimited duration) and **offline**
+(encode full audio, then decode, bounded by `--max-seq-len`). The examples
+below use streaming mode. Omit `--streaming` from export and run commands
+for offline mode.
 
 ## Demo: streaming on Metal backend with microphone input
 
@@ -71,6 +72,7 @@ python export_voxtral_rt.py \
     --model-path ~/models/Voxtral-Mini-4B-Realtime-2602 \
     --backend xnnpack \
     --streaming \
+    --sliding-window 2048 \
     --output-dir ./voxtral_rt_exports \
     --qlinear-encoder 8da4w \
     --qlinear 8da4w \
@@ -86,6 +88,7 @@ python export_voxtral_rt.py \
     --backend metal \
     --dtype bf16 \
     --streaming \
+    --sliding-window 2048 \
     --output-dir ./voxtral_rt_exports \
     --qlinear-encoder fpa4w \
     --qlinear fpa4w
@@ -112,6 +115,7 @@ python export_voxtral_rt.py \
     --backend cuda \
     --dtype bf16 \
     --streaming \
+    --sliding-window 2048 \
     --output-dir ./voxtral_rt_exports \
     --qlinear-encoder 4w \
     --qlinear-encoder-packing-format tile_packed_to_4d \
@@ -137,6 +141,7 @@ python export_voxtral_rt.py \
     --backend cuda-windows \
     --dtype bf16 \
     --streaming \
+    --sliding-window 2048 \
     --output-dir ./voxtral_rt_exports \
     --qlinear-encoder 4w \
     --qlinear-encoder-packing-format tile_packed_to_4d \
@@ -159,7 +164,7 @@ python export_voxtral_rt.py \
 | `--backend` | `xnnpack` | `xnnpack`, `metal`, `cuda`, `cuda-windows`, or `portable` |
 | `--dtype` | `fp32` | Model dtype: `fp32` or `bf16` |
 | `--output-dir` | `./voxtral_rt_exports` | Output directory |
-| `--max-seq-len` | `4096` | KV cache length |
+| `--max-seq-len` | `4096` | KV cache length (offline mode only; ignored with `--streaming`) |
 | `--delay-tokens` | `6` | Transcription delay in tokens (6 = 480ms) |
 | `--qlinear` | (none) | Decoder linear layer quantization (`4w`, `8w`, `8da4w`, `8da8w`, `fpa4w`) |
 | `--qlinear-group-size` | `32` | Group size for decoder linear quantization |
@@ -168,12 +173,14 @@ python export_voxtral_rt.py \
 | `--qlinear-encoder-group-size` | `32` | Group size for encoder linear quantization |
 | `--qlinear-encoder-packing-format` | (none) | Packing format for encoder 4w quantization (`tile_packed_to_4d` for CUDA) |
 | `--qembedding` | (none) | Embedding layer quantization (`8w`) |
-| `--streaming` | off | Export streaming encoder with KV cache |
+| `--streaming` | off | Export streaming model with ring buffer KV caches (unlimited duration) |
 | `--max-enc-len` | `750` | Encoder sliding window size (streaming only) |
+| `--sliding-window` | from `params.json` | Decoder sliding window size (streaming only; ignored in offline mode). Smaller values reduce memory and improve decode speed but limit context |
 
 **Notes:**
 - `fpa4w` quantization requires `--backend metal`.
 - The model was trained with `--delay-tokens 6`. Other values may degrade accuracy.
+- The decoder sliding window controls how far back the decoder can attend. At 80ms/step: 2048 = ~2.7 min, 4096 = ~5.5 min, 8192 = ~10.9 min.
 
 ## Build
 
@@ -278,8 +285,8 @@ Ctrl+C stops recording and flushes remaining text.
 
 - **Audio format**: Input must be 16kHz mono WAV. Convert with
   `ffmpeg -i input.mp3 -ar 16000 -ac 1 output.wav`.
-- **OOM during export**: Reduce `--max-seq-len` or skip encoder
-  quantization (`--qlinear-encoder`).
+- **OOM during export**: Reduce `--max-seq-len` (offline mode) or skip
+  encoder quantization (`--qlinear-encoder`).
 - **"Model was not exported with --streaming"**: Re-export with the
   `--streaming` flag. Both `--streaming` and `--mic` runner modes
   require a streaming-exported model.

--- a/examples/models/voxtral_realtime/export_voxtral_rt.py
+++ b/examples/models/voxtral_realtime/export_voxtral_rt.py
@@ -248,6 +248,7 @@ def export_all(
         "dim": model.config.dim,
         "vocab_size": model.config.vocab_size,
         "max_seq_len": max_seq_len,
+        "sliding_window": model.config.sliding_window,
     }
 
     return programs, metadata
@@ -346,6 +347,7 @@ def export_streaming(
         "enc_dim": model.config.enc_dim,
         "vocab_size": model.config.vocab_size,
         "max_seq_len": max_seq_len,
+        "sliding_window": model.config.sliding_window,
         "streaming": 1,
         "step_samples": step_samples,
         "chunk_mel_len": chunk_mel_len,
@@ -542,6 +544,14 @@ def main():
         help="Encoder sliding window size for streaming (default: 750).",
     )
     parser.add_argument(
+        "--sliding-window",
+        type=int,
+        default=None,
+        help="Decoder sliding window size for streaming (default: from params.json, "
+        "typically 8192). Smaller values reduce memory and improve decode speed "
+        "but limit how far back the decoder can attend. Only used with --streaming.",
+    )
+    parser.add_argument(
         "--dtype",
         default="fp32",
         choices=["fp32", "bf16"],
@@ -555,6 +565,8 @@ def main():
         parser.error("--qlinear=fpa4w can only be used with --backend=metal")
     if args.qlinear_encoder == "fpa4w" and backend_for_export != "metal":
         parser.error("--qlinear-encoder=fpa4w can only be used with --backend=metal")
+    if args.sliding_window is not None and not args.streaming:
+        parser.error("--sliding-window only applies to --streaming mode")
 
     os.makedirs(args.output_dir, exist_ok=True)
 
@@ -567,6 +579,8 @@ def main():
         n_delay_tokens=args.delay_tokens,
         dtype=model_dtype,
         backend=backend_for_export,
+        streaming=args.streaming,
+        sliding_window=args.sliding_window,
     )
 
     # Move to CUDA for CUDA backend export (AOTInductor needs CUDA tensors)

--- a/examples/models/voxtral_realtime/model.md
+++ b/examples/models/voxtral_realtime/model.md
@@ -126,7 +126,7 @@ StreamingAudioEncoderExport
   enc_norm: RMSNorm (shared from encoder.norm)
   adapter: AudioLanguageAdapter (shared from model.adapter)
   kv_caches: 32x RingKVCache (XNNPACK) or StandardRingKVCache (Metal/CUDA)
-  sdpa: SDPA (XNNPACK) or MetalSDPA (Metal, transpose_kv=True) or StandardSDPA (CUDA, transpose_kv=True)
+  sdpa: SDPA (XNNPACK) or MetalSDPA (Metal) or StandardSDPA (CUDA)
   inv_freq: RoPE inverse frequencies (owned, on-the-fly computation)
 ```
 
@@ -164,8 +164,8 @@ Sliding window masks are computed each step via `create_causal_mask`.
 
 - XNNPACK/Portable: `RingKVCache` with `[B, S, H, D]` layout, using
   `torch.ops.llama.update_cache_with_indices` for scatter writes.
-- Metal/CUDA: `StandardRingKVCache` with `[B, S, H, D]` layout, using
-  `index_copy_` with wrapped indices.
+- Metal/CUDA: `StandardRingKVCache` with `[B, H, S, D]` layout, using
+  `index_copy_` on dim=2 with wrapped indices.
 
 **Offline (default):** Flat KV cache bounded by `max_seq_len` (default
 4096). Full causal attention — each query attends to all prior positions.
@@ -190,14 +190,14 @@ which handles GQA natively (the kernel infers the group ratio from differing
 Q vs K/V head counts), avoiding the memory bandwidth overhead of
 `repeat_interleave`. Uses explicit additive attention masks
 that must match the Q/K/V dtype (the kernel reads masks as `device T*`).
-In streaming mode, the decoder and encoder both use `transpose_kv=True`
-(ring KV cache in `[B, S, H, D]` layout). In offline mode, the decoder
-uses `transpose_kv=False` (`StaticKVCache` in `[B, H, S, D]` layout).
+Both streaming and offline use `[B, H, S, D]` KV layout
+(`StandardRingKVCache` and `StaticKVCache` share this layout), so
+`transpose_kv=False` in all cases.
 
 **CUDA:** `StandardSDPA` uses `F.scaled_dot_product_attention` with
 `enable_gqa=True`. Uses boolean attention masks (`True`=attend,
 `False`=masked) as required by the Triton SDPA kernel. Same
-`transpose_kv` behavior as Metal (streaming: True, offline: False).
+`[B, H, S, D]` KV layout as Metal.
 
 ### Attention layout
 
@@ -208,13 +208,10 @@ on `[B, T, H, D]`.
 (streaming) use `[B, S, H, D]`. `SDPA` (custom_sdpa) receives Q and
 KV cache in this layout — no `transpose(1, 2)` in the attention hot path.
 
-**Metal/CUDA (streaming):** `StandardRingKVCache` uses `[B, S, H, D]`.
-`MetalSDPA`/`StandardSDPA` transpose Q and KV to `[B, H, S, D]` for
-the SDPA kernel (`transpose_kv=True`), then transpose back.
-
-**Metal/CUDA (offline):** `StaticKVCache` stores in `[B, H, S, D]`
-directly. `MetalSDPA`/`StandardSDPA` use `transpose_kv=False` — KV is
-already in the expected layout.
+**Metal/CUDA:** Both `StandardRingKVCache` (streaming) and `StaticKVCache`
+(offline) use `[B, H, S, D]` layout. `MetalSDPA`/`StandardSDPA` only
+transpose Q from `[B, T, H, D]` to `[B, H, T, D]` — KV is already in
+the expected layout.
 
 ### RoPE
 
@@ -262,11 +259,11 @@ mel_chunk (1, 128, 8) + enc_input_pos (4,)
 custom op) and `SDPA` (`custom_sdpa`).
 
 **Metal:** Uses `StandardRingKVCache` (`index_copy_`-based ring
-buffer) and `MetalSDPA` (native MPS SDPA kernel with `transpose_kv=True`).
+buffer) and `MetalSDPA` (native MPS SDPA kernel).
 Masks are created in the model dtype to match the kernel's `device T*` expectation.
 
 **CUDA:** Uses `StandardRingKVCache` and `StandardSDPA`
-(`F.scaled_dot_product_attention` with `transpose_kv=True` and explicit
+(`F.scaled_dot_product_attention` with explicit
 sliding window masks).
 
 ### Streaming decode loop

--- a/examples/models/voxtral_realtime/model.md
+++ b/examples/models/voxtral_realtime/model.md
@@ -74,10 +74,18 @@ or masked-scatter like the original non-realtime Voxtral).
 
 ## Memory Footprint
 
-Decoder KV cache: 26 layers × 2 (K, V) × 4096 × 8 × 128 × bytes_per_elem.
-fp32: ≈ 832 MB, bf16: ≈ 416 MB. Encoder KV caches (streaming):
-32 layers × 2 × 1500 × 32 × 64 × bytes_per_elem. fp32: ≈ 786 MB,
-bf16: ≈ 393 MB.
+Decoder KV cache depends on mode:
+- **Offline:** flat buffer sized by `max_seq_len` (default 4096).
+  26 layers × 2 × 4096 × 8 × 128 × bytes_per_elem.
+  fp32: ≈ 832 MB, bf16: ≈ 416 MB.
+- **Streaming:** ring buffer sized to 2× `sliding_window` (default 8192
+  → 16384 slots; `--sliding-window 2048` → 4096 slots).
+  26 layers × 2 × 2×sliding_window × 8 × 128 × bytes_per_elem.
+  sw=8192 fp32: ≈ 3.3 GB, bf16: ≈ 1.7 GB.
+  sw=2048 fp32: ≈ 832 MB, bf16: ≈ 416 MB.
+
+Encoder KV caches (streaming only): 32 layers × 2 × 1500 × 32 × 64 ×
+bytes_per_elem. fp32: ≈ 786 MB, bf16: ≈ 393 MB.
 
 Runtime memory = model weights (from `.pte`) + KV caches + working
 memory. Weight sizes depend on quantization: ~16 GB (fp32), ~8 GB
@@ -103,7 +111,7 @@ VoxtralRealtimeModel
       attention_norm: RMSNorm
       attention: LMAttention
         wq/wk/wv/wo: Linear (no bias)
-        kv_cache: KVCache (XNNPACK) or StaticKVCache (Metal/CUDA)
+        kv_cache: streaming: RingKVCache/StandardRingKVCache; offline: KVCache/StaticKVCache
         sdpa: SDPA (XNNPACK) or MetalSDPA (Metal) or StandardSDPA (CUDA)
       ffn_norm: RMSNorm
       ada_rms_norm_t_cond: Sequential(Linear, GELU, Linear)
@@ -117,7 +125,7 @@ StreamingAudioEncoderExport
   layers: 32x CausalEncoderLayer (shared from encoder.layers)
   enc_norm: RMSNorm (shared from encoder.norm)
   adapter: AudioLanguageAdapter (shared from model.adapter)
-  kv_caches: 32x EncoderRingKVCache (XNNPACK) or StandardEncoderRingKVCache (Metal/CUDA)
+  kv_caches: 32x RingKVCache (XNNPACK) or StandardRingKVCache (Metal/CUDA)
   sdpa: SDPA (XNNPACK) or MetalSDPA (Metal, transpose_kv=True) or StandardSDPA (CUDA, transpose_kv=True)
   inv_freq: RoPE inverse frequencies (owned, on-the-fly computation)
 ```
@@ -145,23 +153,36 @@ flag (e.g., `"xnnpack"`, `"metal"`, `"cuda"`, `"portable"`).
 
 ### KV cache
 
-**XNNPACK/Portable:** `KVCache` with `[B, S, H, D]` layout. Uses
-`torch.ops.llama.update_cache(value, cache, start_pos)` which mutates
-the cache in-place. This avoids the `index_put_` + `copy_` pattern that
-triggers a `requires_grad` bug in `SpecPropPass` during `to_executorch()`.
-The `[B, S, H, D]` layout matches what `update_cache` and `custom_sdpa`
-expect, so there are no transposes between cache update and attention.
+The decoder KV cache depends on the export mode:
 
-**Metal/CUDA:** `StaticKVCache` with `[B, H, S, D]` layout. Uses `index_copy_`
-for cache updates, which is compatible with `torch.export` and AOTI.
+**Streaming (`--streaming`):** Ring buffer KV cache for unlimited
+duration. The model's `params.json` specifies `sliding_window: 8192`
+for the decoder (overridable via `--sliding-window`). Each query attends
+to only the last `sliding_window` positions; old entries are overwritten
+when the buffer wraps. Position tracking is analytic (no mutable state).
+Sliding window masks are computed each step via `create_causal_mask`.
+
+- XNNPACK/Portable: `RingKVCache` with `[B, S, H, D]` layout, using
+  `torch.ops.llama.update_cache_with_indices` for scatter writes.
+- Metal/CUDA: `StandardRingKVCache` with `[B, S, H, D]` layout, using
+  `index_copy_` with wrapped indices.
+
+**Offline (default):** Flat KV cache bounded by `max_seq_len` (default
+4096). Full causal attention — each query attends to all prior positions.
+
+- XNNPACK/Portable: `KVCache` with `[B, S, H, D]` layout, using
+  `torch.ops.llama.update_cache`.
+- Metal/CUDA: `StaticKVCache` with `[B, H, S, D]` layout, using
+  `index_copy_`.
 
 ### SDPA
 
 `SDPA` is its own module (not inline code), making it swappable for
 backend-specific implementations.
 
-**XNNPACK/Portable:** `SDPA` uses `torch.ops.llama.custom_sdpa` — a
-fused kernel with causal masking via `start_pos` + `is_causal=True`.
+**XNNPACK/Portable:** `SDPA` uses `torch.ops.llama.custom_sdpa`.
+In streaming mode, receives a sliding window mask from the ring cache.
+In offline mode, uses `is_causal=True` with no explicit mask.
 Handles GQA expansion internally and upcasts to float32.
 
 **Metal:** `MetalSDPA` uses `torch.ops.aten._scaled_dot_product_attention_math_for_mps`
@@ -169,27 +190,37 @@ which handles GQA natively (the kernel infers the group ratio from differing
 Q vs K/V head counts), avoiding the memory bandwidth overhead of
 `repeat_interleave`. Uses explicit additive attention masks
 that must match the Q/K/V dtype (the kernel reads masks as `device T*`).
-Used for both decoder (GQA, `transpose_kv=False`) and streaming encoder
-(no GQA, `transpose_kv=True`).
+In streaming mode, the decoder and encoder both use `transpose_kv=True`
+(ring KV cache in `[B, S, H, D]` layout). In offline mode, the decoder
+uses `transpose_kv=False` (`StaticKVCache` in `[B, H, S, D]` layout).
 
 **CUDA:** `StandardSDPA` uses `F.scaled_dot_product_attention` with
-`repeat_interleave` for GQA expansion (32 query heads / 8 KV heads = 4x).
-Uses boolean attention masks (`True`=attend, `False`=masked) as required
-by the Triton SDPA kernel. The CUDA backend's Triton SDPA replacement
-pass optimizes the attention kernel at compile time.
+`enable_gqa=True`. Uses boolean attention masks (`True`=attend,
+`False`=masked) as required by the Triton SDPA kernel. Same
+`transpose_kv` behavior as Metal (streaming: True, offline: False).
 
 ### Attention layout
 
-**XNNPACK/Portable:** Q/K/V projections produce `[B, T, H, D]` via
-`.view()`. RoPE operates on `[B, T, H, D]`. `KVCache` stores
-`[B, S, H, D]`. `SDPA` (custom_sdpa) receives both in this layout — no
-`transpose(1, 2)` in the attention hot path. This eliminates the need for
-`RemoveRedundantTransposes` post-export pass that Llama/optimum-executorch
-require when using `[B, H, S, D]` attention with `[B, S, H, D]` cache.
+Q/K/V projections produce `[B, T, H, D]` via `.view()`. RoPE operates
+on `[B, T, H, D]`.
 
-**Metal/CUDA:** Q/K/V projections still produce `[B, T, H, D]`, but
-`StaticKVCache` stores `[B, H, S, D]` and `MetalSDPA`/`StandardSDPA` transpose q to
-`[B, H, T, D]` for the SDPA kernel, then transpose back.
+**XNNPACK/Portable:** Both `KVCache` (offline) and `RingKVCache`
+(streaming) use `[B, S, H, D]`. `SDPA` (custom_sdpa) receives Q and
+KV cache in this layout — no `transpose(1, 2)` in the attention hot path.
+
+**Metal/CUDA (streaming):** `StandardRingKVCache` uses `[B, S, H, D]`.
+`MetalSDPA`/`StandardSDPA` transpose Q and KV to `[B, H, S, D]` for
+the SDPA kernel (`transpose_kv=True`), then transpose back.
+
+**Metal/CUDA (offline):** `StaticKVCache` stores in `[B, H, S, D]`
+directly. `MetalSDPA`/`StandardSDPA` use `transpose_kv=False` — KV is
+already in the expected layout.
+
+### RoPE
+
+RoPE frequencies are computed on-the-fly using stored `inv_freq`
+(same pattern as the streaming encoder), enabling unlimited position
+indices without a precomputed table bound.
 
 ### Adaptive RMSNorm
 
@@ -227,14 +258,14 @@ mel_chunk (1, 128, 8) + enc_input_pos (4,)
 -> audio_embeds (1, 1, 3072)
 ```
 
-**XNNPACK/Portable:** Uses `EncoderRingKVCache` (`update_cache_with_indices`
+**XNNPACK/Portable:** Uses `RingKVCache` (`update_cache_with_indices`
 custom op) and `SDPA` (`custom_sdpa`).
 
-**Metal:** Uses `StandardEncoderRingKVCache` (`index_copy_`-based ring
+**Metal:** Uses `StandardRingKVCache` (`index_copy_`-based ring
 buffer) and `MetalSDPA` (native MPS SDPA kernel with `transpose_kv=True`).
 Masks are created in the model dtype to match the kernel's `device T*` expectation.
 
-**CUDA:** Uses `StandardEncoderRingKVCache` and `StandardSDPA`
+**CUDA:** Uses `StandardRingKVCache` and `StandardSDPA`
 (`F.scaled_dot_product_attention` with `transpose_kv=True` and explicit
 sliding window masks).
 
@@ -270,7 +301,7 @@ encoder — verified to within fp32 precision (max diff < 2e-5).
 ### Encoder KV cache
 
 Each of the 32 encoder transformer layers gets its own ring buffer KV
-cache (`EncoderRingKVCache` for XNNPACK/Portable, `StandardEncoderRingKVCache`
+cache (`RingKVCache` for XNNPACK/Portable, `StandardRingKVCache`
 for Metal/CUDA) that overwrites old entries when the window is exceeded,
 enabling streaming of arbitrary length audio.
 

--- a/examples/models/voxtral_realtime/model.py
+++ b/examples/models/voxtral_realtime/model.py
@@ -546,22 +546,19 @@ class LMAttention(nn.Module):
         self.wo = nn.Linear(self.n_heads * self.head_dim, config.dim, bias=False)
 
         if config.streaming:
-            # Ring buffer KV cache for unlimited streaming (same pattern as
-            # the encoder ring cache). All layouts are [B, S, H, D].
+            # Ring buffer KV cache for unlimited streaming.
             if self.backend == "metal":
+                # StandardRingKVCache uses [B, H, S, D] — same layout as
+                # StaticKVCache, so no transpose needed in the SDPA.
                 self.kv_cache = StandardRingKVCache(
                     config.sliding_window, self.n_kv_heads, self.head_dim
                 )
-                self.sdpa = MetalSDPA(
-                    self.n_heads, self.n_kv_heads, self.head_dim, transpose_kv=True
-                )
+                self.sdpa = MetalSDPA(self.n_heads, self.n_kv_heads, self.head_dim)
             elif self.backend == "cuda":
                 self.kv_cache = StandardRingKVCache(
                     config.sliding_window, self.n_kv_heads, self.head_dim
                 )
-                self.sdpa = StandardSDPA(
-                    self.n_heads, self.n_kv_heads, self.head_dim, transpose_kv=True
-                )
+                self.sdpa = StandardSDPA(self.n_heads, self.n_kv_heads, self.head_dim)
             else:
                 self.kv_cache = RingKVCache(
                     config.sliding_window, self.n_kv_heads, self.head_dim
@@ -878,15 +875,16 @@ class RingKVCache(nn.Module):
 class StandardRingKVCache(nn.Module):
     """Export-friendly ring buffer KV cache using index_copy_ for updates.
 
-    Compatible with torch.export and AOTI. Uses [B, S, H, D] layout.
-    Ring buffer enables unlimited streaming.
+    Compatible with torch.export and AOTI. Uses [B, H, S, D] layout
+    (same as StaticKVCache) for fast index_copy_ on dim=2, which scatters
+    into contiguous memory on MPS. Ring buffer enables unlimited streaming.
     """
 
     def __init__(self, window_size: int, n_heads: int, head_dim: int):
         super().__init__()
         self.window_size = window_size
         self.buf_size = window_size * 2
-        cache_shape = (1, self.buf_size, n_heads, head_dim)
+        cache_shape = (1, n_heads, self.buf_size, head_dim)
         self.register_buffer("k_cache", torch.zeros(cache_shape))
         self.register_buffer("v_cache", torch.zeros(cache_shape))
 
@@ -899,15 +897,14 @@ class StandardRingKVCache(nn.Module):
             input_pos: (seq_len,) position indices.
             k_val, v_val: (B, seq_len, n_heads, head_dim) in [B, S, H, D] layout.
         Returns:
-            k_cache, v_cache: (B, buf_size, n_heads, head_dim) in [B, S, H, D] layout.
+            k_cache, v_cache: (B, n_heads, buf_size, head_dim) in [B, H, S, D] layout.
         """
-        # Compute wrapped indices for ring buffer
         wrapped_indices = input_pos % self.buf_size
-
-        # Use index_copy_ on dimension 1 (sequence dimension in [B, S, H, D])
-        self.k_cache.index_copy_(1, wrapped_indices, k_val)
-        self.v_cache.index_copy_(1, wrapped_indices, v_val)
-
+        # Transpose to [B, H, S, D] for index_copy_ on dim=2 (contiguous on MPS)
+        k_val = k_val.transpose(1, 2)
+        v_val = v_val.transpose(1, 2)
+        self.k_cache.index_copy_(2, wrapped_indices, k_val)
+        self.v_cache.index_copy_(2, wrapped_indices, v_val)
         return self.k_cache, self.v_cache
 
     def create_causal_mask(
@@ -994,19 +991,18 @@ class StreamingAudioEncoderExport(nn.Module):
         )
 
         # Choose SDPA based on backend
+        # StandardRingKVCache returns [B, H, S, D] — no transpose needed.
         if config.backend == "metal":
             self.sdpa = MetalSDPA(
                 config.enc_n_heads,
                 config.enc_n_heads,
                 config.enc_head_dim,
-                transpose_kv=True,
             )
         elif config.backend == "cuda":
             self.sdpa = StandardSDPA(
                 config.enc_n_heads,
                 config.enc_n_heads,
                 config.enc_head_dim,
-                transpose_kv=True,
             )
         else:
             self.sdpa = SDPA(config.enc_n_heads, config.enc_head_dim)

--- a/examples/models/voxtral_realtime/model.py
+++ b/examples/models/voxtral_realtime/model.py
@@ -50,6 +50,8 @@ class VoxtralRealtimeConfig:
     downsample_factor: int = 4
     # Runtime
     max_seq_len: int = 4096
+    sliding_window: int = 8192
+    streaming: bool = False
     backend: str = "xnnpack"  # "xnnpack", "metal", "cuda", or "portable"
 
     @staticmethod
@@ -79,6 +81,7 @@ class VoxtralRealtimeConfig:
             enc_norm_eps=enc["norm_eps"],
             num_mel_bins=audio.get("num_mel_bins", 128),
             downsample_factor=ds["downsample_factor"],
+            sliding_window=p.get("sliding_window", 8192),
         )
 
 
@@ -294,7 +297,10 @@ def compute_time_embedding(
 
 
 class KVCache(nn.Module):
-    """KV cache in [B, S, H, D] layout for torch.ops.llama.update_cache."""
+    """KV cache in [B, S, H, D] layout for torch.ops.llama.update_cache.
+
+    Used for offline (non-streaming) mode with a fixed max_seq_len.
+    """
 
     def __init__(self, max_seq_len: int, n_kv_heads: int, head_dim: int):
         super().__init__()
@@ -308,14 +314,6 @@ class KVCache(nn.Module):
     def update(
         self, input_pos: torch.Tensor, k_val: torch.Tensor, v_val: torch.Tensor
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        """Write k_val/v_val into cache and return full cache.
-
-        Args:
-            input_pos: (seq_len,) position indices.
-            k_val, v_val: (B, seq_len, n_kv_heads, head_dim).
-        Returns:
-            k_cache, v_cache: (B, max_seq_len, n_kv_heads, head_dim).
-        """
         start_pos = input_pos[0].item()
         torch._check_is_size(start_pos)
         torch._check(start_pos < self.max_seq_len)
@@ -327,8 +325,8 @@ class KVCache(nn.Module):
 class StaticKVCache(nn.Module):
     """Export-friendly KV cache using index_copy_ for updates.
 
-    Compatible with torch.export and AOTI. Uses [B, H, S, D] layout
-    (matching transformers.StaticCache) for index_copy_ compatibility.
+    Uses [B, H, S, D] layout. Used for offline (non-streaming) mode with
+    a fixed max_seq_len on Metal/CUDA backends.
     """
 
     def __init__(self, max_seq_len: int, n_kv_heads: int, head_dim: int):
@@ -336,7 +334,6 @@ class StaticKVCache(nn.Module):
         self.max_seq_len = max_seq_len
         self.n_kv_heads = n_kv_heads
         self.head_dim = head_dim
-        # Use [B, H, S, D] layout like transformers.StaticCache
         cache_shape = (1, n_kv_heads, max_seq_len, head_dim)
         self.register_buffer("k_cache", torch.zeros(cache_shape))
         self.register_buffer("v_cache", torch.zeros(cache_shape))
@@ -344,23 +341,10 @@ class StaticKVCache(nn.Module):
     def update(
         self, input_pos: torch.Tensor, k_val: torch.Tensor, v_val: torch.Tensor
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        """Write k_val/v_val into cache using index_copy_ (export-friendly).
-
-        Args:
-            input_pos: (seq_len,) position indices [0, 1, 2, ...] or [start_pos] for decode.
-            k_val, v_val: (B, seq_len, n_kv_heads, head_dim).
-        Returns:
-            k_cache, v_cache: (B, n_kv_heads, max_seq_len, head_dim).
-        """
-        # Transpose k_val, v_val from [B, S, H, D] to [B, H, S, D]
-        k_val = k_val.transpose(1, 2)  # [B, n_kv_heads, seq_len, head_dim]
-        v_val = v_val.transpose(1, 2)  # [B, n_kv_heads, seq_len, head_dim]
-
-        # Use index_copy_ on dimension 2 (sequence dimension in [B, H, S, D])
-        # This matches transformers.cache_utils.StaticLayer implementation
+        k_val = k_val.transpose(1, 2)
+        v_val = v_val.transpose(1, 2)
         self.k_cache.index_copy_(2, input_pos, k_val)
         self.v_cache.index_copy_(2, input_pos, v_val)
-
         return self.k_cache, self.v_cache
 
 
@@ -389,10 +373,9 @@ class SDPA(nn.Module):
         Args:
             input_pos: (seq_len,) position indices.
             q: (B, seq_len, n_heads, head_dim).
-            k, v: (B, max_seq_len, n_kv_heads, head_dim) — full KV cache.
+            k, v: (B, cache_len, n_kv_heads, head_dim) — full KV cache.
             bsz, seqlen: batch size and query sequence length.
-            mask: optional (seq_len, max_seq_len) attention mask. If provided,
-                  used instead of causal masking.
+            mask: optional attention mask (sliding window or causal).
         Returns:
             output: (B, seq_len, n_heads * head_dim).
         """
@@ -431,23 +414,16 @@ def _build_attn_mask(
     device: torch.device,
     dtype: torch.dtype = torch.float32,
 ) -> torch.Tensor:
-    """Build additive attention mask matching the model dtype.
+    """Build additive causal attention mask for offline (non-streaming) mode.
 
     Metal AOTI doesn't support bool tensor allocation on MPS, so we use
-    integer arithmetic: clamp(curr_pos - k_pos + 1, 0, 1) gives 1 for
-    valid positions (k <= curr_pos) and 0 for invalid, then convert to
-    additive mask (0.0 = attend, -1e9 = don't attend).
-
-    The mask dtype must match Q/K/V dtype — the Metal SDPA kernel reads
-    the mask buffer with the same element type as Q/K/V.
+    integer arithmetic to build the mask in the model dtype.
     """
     seqlen = input_pos.shape[0]
     k_pos = torch.arange(max_seq_len, device=device)
     if seqlen > 1:
-        # Prefill: [seqlen, max_seq_len]
         diff = input_pos.unsqueeze(1) - k_pos.unsqueeze(0) + 1
     else:
-        # Decode: [1, max_seq_len]
         diff = (input_pos[0] - k_pos + 1).unsqueeze(0)
     valid = torch.clamp(diff, min=0, max=1)
     return (valid.to(dtype) - 1.0) * 1e9
@@ -456,14 +432,13 @@ def _build_attn_mask(
 def _build_causal_mask_bool(
     input_pos: torch.Tensor, max_seq_len: int, device: torch.device
 ) -> torch.Tensor:
-    """Build boolean causal attention mask. True = attend, False = masked.
+    """Build boolean causal attention mask for offline (non-streaming) mode.
 
-    Returns [1, 1, seqlen, max_seq_len] for Triton SDPA compatibility
-    (requires 4D mask with batch and head dims).
+    Returns [1, 1, seqlen, max_seq_len] for Triton SDPA compatibility.
     """
     k_pos = torch.arange(max_seq_len, device=device)
-    mask = input_pos.unsqueeze(1) >= k_pos.unsqueeze(0)  # [seqlen, max_seq_len]
-    return mask.unsqueeze(0).unsqueeze(0)  # [1, 1, seqlen, max_seq_len]
+    mask = input_pos.unsqueeze(1) >= k_pos.unsqueeze(0)
+    return mask.unsqueeze(0).unsqueeze(0)
 
 
 class MetalSDPA(nn.Module):
@@ -499,9 +474,6 @@ class MetalSDPA(nn.Module):
         if self.transpose_kv:
             k = k.transpose(1, 2)
             v = v.transpose(1, 2)
-
-        if attn_mask is None:
-            attn_mask = _build_attn_mask(input_pos, k.shape[2], q.device, q.dtype)
 
         y, _ = torch.ops.aten._scaled_dot_product_attention_math_for_mps(
             q, k, v, attn_mask, 0.0, False, None
@@ -546,9 +518,6 @@ class StandardSDPA(nn.Module):
             k = k.transpose(1, 2)
             v = v.transpose(1, 2)
 
-        if attn_mask is None:
-            attn_mask = _build_causal_mask_bool(input_pos, k.shape[2], q.device)
-
         y = F.scaled_dot_product_attention(
             q, k, v, attn_mask=attn_mask, is_causal=False, enable_gqa=self.enable_gqa
         )
@@ -563,7 +532,7 @@ class LMAttention(nn.Module):
     Supports both custom ops (for XNNPACK) and standard PyTorch ops (for Metal/AOTI).
     """
 
-    def __init__(self, config: VoxtralRealtimeConfig, max_seq_len: int):
+    def __init__(self, config: VoxtralRealtimeConfig):
         super().__init__()
         self.n_heads = config.n_heads
         self.n_kv_heads = config.n_kv_heads
@@ -576,16 +545,45 @@ class LMAttention(nn.Module):
         self.wv = nn.Linear(config.dim, self.n_kv_heads * self.head_dim, bias=False)
         self.wo = nn.Linear(self.n_heads * self.head_dim, config.dim, bias=False)
 
-        # Choose KV cache and SDPA based on backend
-        if self.backend == "metal":
-            self.kv_cache = StaticKVCache(max_seq_len, self.n_kv_heads, self.head_dim)
-            self.sdpa = MetalSDPA(self.n_heads, self.n_kv_heads, self.head_dim)
-        elif self.backend == "cuda":
-            self.kv_cache = StaticKVCache(max_seq_len, self.n_kv_heads, self.head_dim)
-            self.sdpa = StandardSDPA(self.n_heads, self.n_kv_heads, self.head_dim)
+        if config.streaming:
+            # Ring buffer KV cache for unlimited streaming (same pattern as
+            # the encoder ring cache). All layouts are [B, S, H, D].
+            if self.backend == "metal":
+                self.kv_cache = StandardRingKVCache(
+                    config.sliding_window, self.n_kv_heads, self.head_dim
+                )
+                self.sdpa = MetalSDPA(
+                    self.n_heads, self.n_kv_heads, self.head_dim, transpose_kv=True
+                )
+            elif self.backend == "cuda":
+                self.kv_cache = StandardRingKVCache(
+                    config.sliding_window, self.n_kv_heads, self.head_dim
+                )
+                self.sdpa = StandardSDPA(
+                    self.n_heads, self.n_kv_heads, self.head_dim, transpose_kv=True
+                )
+            else:
+                self.kv_cache = RingKVCache(
+                    config.sliding_window, self.n_kv_heads, self.head_dim
+                )
+                self.sdpa = SDPA(self.n_heads, self.head_dim)
         else:
-            self.kv_cache = KVCache(max_seq_len, self.n_kv_heads, self.head_dim)
-            self.sdpa = SDPA(self.n_heads, self.head_dim)
+            # Flat KV cache for offline mode (capped at max_seq_len).
+            if self.backend == "metal":
+                self.kv_cache = StaticKVCache(
+                    config.max_seq_len, self.n_kv_heads, self.head_dim
+                )
+                self.sdpa = MetalSDPA(self.n_heads, self.n_kv_heads, self.head_dim)
+            elif self.backend == "cuda":
+                self.kv_cache = StaticKVCache(
+                    config.max_seq_len, self.n_kv_heads, self.head_dim
+                )
+                self.sdpa = StandardSDPA(self.n_heads, self.n_kv_heads, self.head_dim)
+            else:
+                self.kv_cache = KVCache(
+                    config.max_seq_len, self.n_kv_heads, self.head_dim
+                )
+                self.sdpa = SDPA(self.n_heads, self.head_dim)
 
     def forward(
         self,
@@ -630,10 +628,10 @@ class MistralDecoderLayer(nn.Module):
       scale = 1 + Sequential(Linear, GELU, Linear)(t_cond)
     """
 
-    def __init__(self, config: VoxtralRealtimeConfig, max_seq_len: int):
+    def __init__(self, config: VoxtralRealtimeConfig):
         super().__init__()
         self.attention_norm = RMSNorm(config.dim, config.norm_eps)
-        self.attention = LMAttention(config, max_seq_len)
+        self.attention = LMAttention(config)
         self.ffn_norm = RMSNorm(config.dim, config.norm_eps)
         # nn.Sequential indices 0, 1, 2 match checkpoint keys .0.weight, .2.weight
         self.ada_rms_norm_t_cond = nn.Sequential(
@@ -664,21 +662,32 @@ class MistralDecoderLayer(nn.Module):
 class MistralDecoder(nn.Module):
     """Mistral LM decoder with tied embeddings."""
 
-    def __init__(self, config: VoxtralRealtimeConfig, max_seq_len: int):
+    def __init__(self, config: VoxtralRealtimeConfig):
         super().__init__()
         self.config = config
+        self.streaming = config.streaming
+        self.bool_mask = config.backend == "cuda"
         self.tok_embeddings = nn.Embedding(config.vocab_size, config.dim)
         self.layers = nn.ModuleList(
-            [MistralDecoderLayer(config, max_seq_len) for _ in range(config.n_layers)]
+            [MistralDecoderLayer(config) for _ in range(config.n_layers)]
         )
         self.norm = RMSNorm(config.dim, config.norm_eps)
         self.output = nn.Linear(config.dim, config.vocab_size, bias=False)
 
-        freqs_cos, freqs_sin = precompute_freqs_cis(
-            config.head_dim, max_seq_len, config.rope_theta
-        )
-        self.register_buffer("freqs_cos", freqs_cos)
-        self.register_buffer("freqs_sin", freqs_sin)
+        if config.streaming:
+            # On-the-fly RoPE for unlimited streaming positions.
+            inv_freq = 1.0 / (
+                config.rope_theta
+                ** (torch.arange(0, config.head_dim, 2).float() / config.head_dim)
+            )
+            self.register_buffer("inv_freq", inv_freq)
+        else:
+            # Precomputed RoPE table for offline mode (bounded by max_seq_len).
+            freqs_cos, freqs_sin = precompute_freqs_cis(
+                config.head_dim, config.max_seq_len, config.rope_theta
+            )
+            self.register_buffer("freqs_cos", freqs_cos)
+            self.register_buffer("freqs_sin", freqs_sin)
 
     def forward(
         self,
@@ -686,21 +695,38 @@ class MistralDecoder(nn.Module):
         input_pos: torch.Tensor,
         t_cond: torch.Tensor,
     ) -> torch.Tensor:
-        freqs_cos = self.freqs_cos[input_pos]
-        freqs_sin = self.freqs_sin[input_pos]
+        if self.streaming:
+            # On-the-fly RoPE (no position limit).
+            freqs = torch.outer(input_pos.float(), self.inv_freq)
+            freqs_cos = freqs.cos()
+            freqs_sin = freqs.sin()
 
-        # Compute attention mask once for all 26 layers (P3 optimization).
-        attn_mask: torch.Tensor | None = None
-        if self.config.backend == "metal":
-            max_seq_len = self.freqs_cos.shape[0]
-            attn_mask = _build_attn_mask(
-                input_pos, max_seq_len, input_embeds.device, input_embeds.dtype
+            # Sliding window mask from the ring buffer, computed once for
+            # all 26 layers.
+            seqlen = input_pos.shape[0]
+            attn_mask = self.layers[0].attention.kv_cache.create_causal_mask(
+                input_pos[0],
+                seqlen,
+                bool_mask=self.bool_mask,
+                dtype=input_embeds.dtype,
             )
-        elif self.config.backend == "cuda":
-            max_seq_len = self.freqs_cos.shape[0]
-            attn_mask = _build_causal_mask_bool(
-                input_pos, max_seq_len, input_embeds.device
-            )
+        else:
+            # Precomputed RoPE table lookup.
+            freqs_cos = self.freqs_cos[input_pos]
+            freqs_sin = self.freqs_sin[input_pos]
+
+            # Full causal mask for offline mode.
+            attn_mask: torch.Tensor | None = None
+            if self.config.backend == "metal":
+                max_seq_len = self.freqs_cos.shape[0]
+                attn_mask = _build_attn_mask(
+                    input_pos, max_seq_len, input_embeds.device, input_embeds.dtype
+                )
+            elif self.config.backend == "cuda":
+                max_seq_len = self.freqs_cos.shape[0]
+                attn_mask = _build_causal_mask_bool(
+                    input_pos, max_seq_len, input_embeds.device
+                )
 
         x = input_embeds
         for layer in self.layers:
@@ -715,17 +741,15 @@ class MistralDecoder(nn.Module):
 
 
 class VoxtralRealtimeModel(nn.Module):
-    def __init__(self, config: VoxtralRealtimeConfig, max_seq_len: int | None = None):
+    def __init__(self, config: VoxtralRealtimeConfig):
         super().__init__()
-        if max_seq_len is None:
-            max_seq_len = config.max_seq_len
         self.config = config
 
         self.encoder = CausalWhisperEncoder(config)
         self.adapter = AudioLanguageAdapter(
             config.enc_dim * config.downsample_factor, config.dim
         )
-        self.decoder = MistralDecoder(config, max_seq_len)
+        self.decoder = MistralDecoder(config)
 
         # Tie output and embedding weights
         self.decoder.output.weight = self.decoder.tok_embeddings.weight
@@ -779,10 +803,10 @@ class VoxtralRealtimeModel(nn.Module):
 # ---------------------------------------------------------------------------
 
 
-class EncoderRingKVCache(nn.Module):
+class RingKVCache(nn.Module):
     """Ring buffer KV cache for continuous streaming.
 
-    Uses [B, S, H, D] layout matching the encoder's convention.
+    Uses [B, S, H, D] layout.
     Buffer is 2x the window size for safe wraparound. Old entries
     are overwritten when the buffer wraps, enabling unlimited streaming.
 
@@ -851,11 +875,11 @@ class EncoderRingKVCache(nn.Module):
         )
 
 
-class StandardEncoderRingKVCache(nn.Module):
+class StandardRingKVCache(nn.Module):
     """Export-friendly ring buffer KV cache using index_copy_ for updates.
 
-    Compatible with torch.export and AOTI. Uses [B, S, H, D] layout
-    matching the encoder's convention. Ring buffer enables unlimited streaming.
+    Compatible with torch.export and AOTI. Uses [B, S, H, D] layout.
+    Ring buffer enables unlimited streaming.
     """
 
     def __init__(self, window_size: int, n_heads: int, head_dim: int):
@@ -960,9 +984,7 @@ class StreamingAudioEncoderExport(nn.Module):
         # Buffer is 2x internally for safe wraparound.
         # Choose cache implementation based on backend
         cache_class = (
-            StandardEncoderRingKVCache
-            if config.backend in ("metal", "cuda")
-            else EncoderRingKVCache
+            StandardRingKVCache if config.backend in ("metal", "cuda") else RingKVCache
         )
         self.kv_caches = nn.ModuleList(
             [
@@ -1134,6 +1156,8 @@ def load_model(
     n_delay_tokens: int = 6,
     dtype: torch.dtype = torch.float32,
     backend: str = "xnnpack",
+    streaming: bool = False,
+    sliding_window: int | None = None,
 ) -> VoxtralRealtimeModel:
     """Load VoxtralRealtimeModel from a Mistral consolidated checkpoint.
 
@@ -1143,10 +1167,12 @@ def load_model(
 
     Args:
         model_path: Directory containing params.json and consolidated.safetensors.
-        max_seq_len: Maximum sequence length for KV cache.
+        max_seq_len: Maximum sequence length for KV cache (offline mode).
         n_delay_tokens: Transcription delay in tokens (default 6 = 480ms).
         dtype: Weight dtype (default: float32).
         backend: Backend for acceleration ("xnnpack", "metal", "cuda", or "portable").
+        streaming: If True, use ring buffer KV cache for unlimited streaming.
+        sliding_window: Override decoder sliding window size (default: from params.json).
     """
     _VALID_BACKENDS = ("xnnpack", "metal", "cuda", "portable")
     if backend not in _VALID_BACKENDS:
@@ -1159,15 +1185,19 @@ def load_model(
     model_dir = Path(model_path)
     config = VoxtralRealtimeConfig.from_params_json(str(model_dir / "params.json"))
     config.max_seq_len = max_seq_len
+    config.streaming = streaming
     config.backend = backend
+    if sliding_window is not None:
+        config.sliding_window = sliding_window
 
     print(
         f"Building model on meta device (dim={config.dim}, enc_dim={config.enc_dim}, "
         f"layers={config.n_layers}, enc_layers={config.enc_n_layers}, "
+        f"{'streaming, sliding_window=' + str(config.sliding_window) if streaming else 'offline, max_seq_len=' + str(max_seq_len)}, "
         f"backend={backend})..."
     )
     with torch.device("meta"):
-        model = VoxtralRealtimeModel(config, max_seq_len)
+        model = VoxtralRealtimeModel(config)
 
     print(f"Loading weights from {model_dir / 'consolidated.safetensors'}...")
     ckpt_path = str(model_dir / "consolidated.safetensors")
@@ -1187,10 +1217,9 @@ def load_model(
     # Re-tie output weights (assign=True breaks the tie established in __init__)
     model.decoder.output.weight = model.decoder.tok_embeddings.weight
 
-    # Materialize remaining meta-device buffers (KV caches, RoPE freqs)
+    # Materialize remaining meta-device buffers (KV caches, RoPE inv_freq)
     # that weren't in the checkpoint. Use model dtype for KV caches so they
     # match the K/V values from the model (update_cache requires same dtype).
-    # RoPE freqs are overwritten below so their dtype here doesn't matter.
     for fqn, buf in list(model.named_buffers()):
         if buf.device.type == "meta":
             parts = fqn.rsplit(".", 1)
@@ -1200,22 +1229,33 @@ def load_model(
                 torch.zeros(buf.shape, dtype=dtype, device="cpu"),
             )
 
-    # Recompute RoPE frequency tables (the zero-fill above is wrong for these)
+    # Recompute RoPE (the zero-fill above is wrong for frequency buffers).
     enc_cos, enc_sin = precompute_freqs_cis(
         config.enc_head_dim, 16384, config.enc_rope_theta
     )
     model.encoder.register_buffer("freqs_cos", enc_cos)
     model.encoder.register_buffer("freqs_sin", enc_sin)
-    dec_cos, dec_sin = precompute_freqs_cis(
-        config.head_dim, max_seq_len, config.rope_theta
-    )
-    model.decoder.register_buffer("freqs_cos", dec_cos)
-    model.decoder.register_buffer("freqs_sin", dec_sin)
+
+    if streaming:
+        # Streaming: recompute decoder inv_freq for on-the-fly RoPE.
+        dec_inv_freq = 1.0 / (
+            config.rope_theta
+            ** (torch.arange(0, config.head_dim, 2).float() / config.head_dim)
+        )
+        model.decoder.register_buffer("inv_freq", dec_inv_freq)
+    else:
+        # Offline: recompute decoder RoPE frequency table.
+        dec_cos, dec_sin = precompute_freqs_cis(
+            config.head_dim, max_seq_len, config.rope_theta
+        )
+        model.decoder.register_buffer("freqs_cos", dec_cos)
+        model.decoder.register_buffer("freqs_sin", dec_sin)
 
     # Validate
     runtime_prefixes = (
         "decoder.output.weight",
         "decoder.freqs_",
+        "decoder.inv_freq",
         "encoder.freqs_",
         ".kv_cache.",
     )

--- a/examples/models/voxtral_realtime/voxtral_realtime_runner.cpp
+++ b/examples/models/voxtral_realtime/voxtral_realtime_runner.cpp
@@ -128,6 +128,10 @@ VoxtralRealtimeRunner::VoxtralRealtimeRunner(
     if (dt.ok())
       delay_tokens_ = dt.get()[0].toInt();
 
+    auto sw = model_->execute("sliding_window", empty);
+    if (sw.ok())
+      sliding_window_ = sw.get()[0].toInt();
+
     ET_LOG(
         Info,
         "Streaming: chunk_mel=%ld, max_enc=%ld, enc_dim=%ld",
@@ -486,9 +490,11 @@ bool StreamingSession::try_process_step() {
     return false;
   }
 
-  // Guard: decoder cache capacity (encoder uses ring buffer, no limit).
+  // Old .pte files use a flat decoder KV cache bounded by max_seq_len.
+  // New .pte files (with sliding_window metadata) use a ring buffer with
+  // no position limit.
   const int64_t enc_frames_per_chunk = chunk_mel_len / 2;
-  if (dec_pos_ >= runner_.max_seq_len_) {
+  if (runner_.sliding_window_ == 0 && dec_pos_ >= runner_.max_seq_len_) {
     return false;
   }
 

--- a/examples/models/voxtral_realtime/voxtral_realtime_runner.h
+++ b/examples/models/voxtral_realtime/voxtral_realtime_runner.h
@@ -108,6 +108,10 @@ class VoxtralRealtimeRunner {
   // Streaming transcription delay in steps (read from model metadata).
   int64_t delay_tokens_ = 6;
 
+  // Decoder sliding window (from model metadata). 0 means the model uses
+  // a flat KV cache (old .pte files); >0 means ring buffer (new .pte files).
+  int64_t sliding_window_ = 0;
+
   // Tokenizer special tokens
   uint64_t bos_id_ = 1;
   uint64_t eos_id_ = 2;


### PR DESCRIPTION
The decoder previously used a flat KV cache capped at max_seq_len (default
4096 = ~5.5 min). The model's params.json specifies sliding_window: 8192
for the decoder, matching how vLLM handles it, but ExecuTorch ignored it.

In streaming mode (--streaming), the decoder now uses RingKVCache /
StandardRingKVCache (the same ring buffer classes used by the streaming
encoder) with the decoder's sliding_window=8192, on-the-fly RoPE via
inv_freq, and sliding window attention masks. This removes all position
limits for streaming transcription.

Offline mode is unchanged: flat KV cache, precomputed RoPE table, full
causal masks, bounded by max_seq_len.

Backwards compatible: old .pte files without sliding_window metadata are
detected (sliding_window_==0) and the runner preserves the original
max_seq_len hard stop.


cc @mattjcly 