### PR TITLE
Pico2: Document selective build options and auto-detect ops from model

### DIFF
--- a/examples/raspberry_pi/pico2/README.md
+++ b/examples/raspberry_pi/pico2/README.md
@@ -15,11 +15,15 @@ This demo demonstrates ExecuTorch's ability to bring your own PyTorch model and 
 - Build firmware with one command and pass the model file (.pte) as an argument
 - Deploy directly to Pico2
 
+### Adapting to Other Baremetal Architectures
+
+While this example targets the Pico2 (ARM Cortex-M33), the same pattern — embedding the `.pte` model as a C array, using `BufferDataLoader`, and statically allocating memory — can be adapted to other baremetal targets (e.g., RISC-V) by providing your own CMake toolchain file. The key requirement is a correct selective build (see below) so all operators your model needs are included.
+
 ### Important Caveats
 
 - Memory constraints - Models must fit in 520KB SRAM (Pico2)
-- Missing operators - Some ops may not be supported
-- Selective builds - Include only operators your model uses if you want to reduce binary size
+- Missing operators - If you get "Operator missing" (error 20) at runtime, your build is missing operators that the model needs. Use `EXECUTORCH_SELECT_OPS_MODEL` (see below) to auto-detect the required operators from your `.pte` file.
+- Selective builds - Include only operators your model uses to reduce binary size
 
 ## Memory Constraints & Optimization
 
@@ -36,10 +40,30 @@ Large models will not fit. Keep your `.pte` files small!
 - Operator fusion
 - Selective builds (include only needed operators)
 
-For more details , refer to the following guides:
+### Selective Build: Choosing the Right Operators
+
+When cross-compiling ExecuTorch for baremetal targets, you need to register the operators your model uses. There are three approaches:
+
+1. **`EXECUTORCH_SELECT_OPS_MODEL` (recommended)** — Point to your `.pte` file and the build system auto-detects all required operators:
+   ```bash
+   cmake ... -DEXECUTORCH_SELECT_OPS_MODEL=/path/to/model.pte
+   ```
+   This is the most reliable approach because it reads the exact operators from the serialized model, including any operators introduced by compiler passes or edge IR lowering that may not be obvious from the original PyTorch model.
+
+2. **`EXECUTORCH_SELECT_OPS_LIST`** — Manually specify operators by name:
+   ```bash
+   cmake ... -DEXECUTORCH_SELECT_OPS_LIST="aten::addmm.out,aten::relu.out,..."
+   ```
+   This requires you to know the exact operator names (including `.out` suffixes). If you miss any, you'll get "Operator missing" (error 20) at runtime.
+
+3. **`EXECUTORCH_SELECT_ALL_OPS=ON`** — Register all portable operators. Simple but produces larger binaries, which matters on memory-constrained targets.
+
+The `build_firmware_pico.sh` script uses `EXECUTORCH_SELECT_OPS_MODEL` by default when a model file is provided.
+
+For more details, refer to the following guides:
 
 - [ExecuTorch Quantization Optimization Guide](https://docs.pytorch.org/executorch/1.0/quantization-optimization.html)
-- [Model Export & Lowering](https://docs.pytorch.org/executorch/1.0/using-executorch-export.html) and
+- [Model Export & Lowering](https://docs.pytorch.org/executorch/1.0/using-executorch-export.html)
 - [Selective Build support](https://docs.pytorch.org/executorch/1.0/kernel-library-selective-build.html)
 
 ## (Prerequisites) Prepare the Environment for Arm

--- a/examples/raspberry_pi/pico2/README.md
+++ b/examples/raspberry_pi/pico2/README.md
@@ -17,7 +17,7 @@ This demo demonstrates ExecuTorch's ability to bring your own PyTorch model and 
 
 ### Adapting to Other Baremetal Architectures
 
-While this example targets the Pico2 (ARM Cortex-M33), the same pattern — embedding the `.pte` model as a C array, using `BufferDataLoader`, and statically allocating memory — can be adapted to other baremetal targets (e.g., RISC-V) by providing your own CMake toolchain file. The key requirement is a correct selective build (see below) so all operators your model needs are included.
+While this example targets the Pico2 board, the same pattern — embedding the `.pte` model as a C array, using `BufferDataLoader`, and statically allocating memory — can be adapted to other baremetal targets (e.g., RISC-V) by providing your own CMake toolchain file. The key requirement is a correct selective build (see below) so all operators your model needs are included.
 
 ### Important Caveats
 
@@ -56,7 +56,7 @@ When cross-compiling ExecuTorch for baremetal targets, you need to register the 
    ```
    This requires you to know the exact operator names (including `.out` suffixes). If you miss any, you'll get "Operator missing" (error 20) at runtime.
 
-3. **`EXECUTORCH_SELECT_ALL_OPS=ON`** — Register all portable operators. Simple but produces larger binaries, which matters on memory-constrained targets.
+3. **All portable operators (no selective build)** — Omit any `EXECUTORCH_SELECT_OPS_*` options when configuring CMake. This registers all portable operators, which is simple but produces larger binaries, an important consideration on memory-constrained targets.
 
 The `build_firmware_pico.sh` script uses `EXECUTORCH_SELECT_OPS_MODEL` by default when a model file is provided.
 

--- a/examples/raspberry_pi/pico2/build_firmware_pico.sh
+++ b/examples/raspberry_pi/pico2/build_firmware_pico.sh
@@ -58,6 +58,16 @@ fi
 # Step 1: Cross compile ExecuTorch from root dir
 echo "Cross compiling ExecuTorch baremetal ARM..."
 
+# Resolve the model path for selective build. Using EXECUTORCH_SELECT_OPS_MODEL
+# auto-detects the exact operators the model needs from the .pte file, avoiding
+# "Operator missing" errors at runtime.
+SELECT_OPS_FLAGS=""
+if [ -n "$MODEL_INPUT" ] && [ -f "${PICO2_DIR}/${MODEL_INPUT}" ]; then
+  MODEL_ABS_PATH="$(cd "${PICO2_DIR}" && realpath "${MODEL_INPUT}")"
+  SELECT_OPS_FLAGS="-DEXECUTORCH_SELECT_OPS_MODEL=${MODEL_ABS_PATH}"
+  echo "Using selective build from model: ${MODEL_ABS_PATH}"
+fi
+
 cmake -B "${EXECUTORCH_BUILD_DIR}" \
   -DCMAKE_TOOLCHAIN_FILE="${ROOT_DIR}/examples/arm/ethos-u-setup/arm-none-eabi-gcc.cmake" \
   -DTARGET_CPU=cortex-m0plus \
@@ -69,6 +79,7 @@ cmake -B "${EXECUTORCH_BUILD_DIR}" \
   -DEXECUTORCH_SELECT_ALL_OPS=OFF \
   -DEXECUTORCH_BUILD_EXECUTOR_RUNNER=OFF \
   -DCMAKE_INSTALL_PREFIX="${EXECUTORCH_BUILD_DIR}" \
+  ${SELECT_OPS_FLAGS} \
   "${ROOT_DIR}"
 
 cmake --build "${EXECUTORCH_BUILD_DIR}" --target install -j$(nproc)


### PR DESCRIPTION
A community user hit "Operator missing" (error 20) on bare-metal RISC-V because the selective build guidance was unclear (see #18573).

- Document the three selective build approaches in README, recommending EXECUTORCH_SELECT_OPS_MODEL as the default
- Update build_firmware_pico.sh to auto-pass SELECT_OPS_MODEL when a model file is provided
- Note that the baremetal pattern is portable to other architectures
