### PR TITLE
Qualcomm AI Engine Direct - Fix for documentation and reuse dead_code_elimination_pass

### DIFF
--- a/backends/qualcomm/_passes/canonicalize_conv.py
+++ b/backends/qualcomm/_passes/canonicalize_conv.py
@@ -10,6 +10,7 @@ import torch
 
 from executorch.backends.qualcomm.builders.utils import get_parameter, set_parameter
 from executorch.exir.pass_base import ExportPass, PassResult
+from executorch.exir.passes import dead_code_elimination_pass
 from torch._guards import detect_fake_mode
 
 from .utils import append_qdq, copy_meta
@@ -199,6 +200,5 @@ class CanonicalizeConv(ExportPass):
                 for user in node.users.copy():
                     user.replace_input_with(node, squeeze_node)
 
-        graph.eliminate_dead_code()
-        graph_module.recompile()
+        dead_code_elimination_pass(graph_module)
         return PassResult(graph_module, True)

--- a/backends/qualcomm/_passes/convert_bmm_to_matmul.py
+++ b/backends/qualcomm/_passes/convert_bmm_to_matmul.py
@@ -10,6 +10,7 @@ from typing import List
 import torch
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass, PassResult
+from executorch.exir.passes import dead_code_elimination_pass
 from torch.fx.passes.utils.source_matcher_utils import get_source_partitions
 
 
@@ -78,6 +79,5 @@ class ConvertBmmToMatmul(ExportPass):
                     for user in output.users.copy():
                         user.replace_input_with(output, matmul_node)
 
-        graph.eliminate_dead_code()
-        graph_module.recompile()
+        dead_code_elimination_pass(graph_module)
         return PassResult(graph_module, True)

--- a/backends/qualcomm/_passes/convert_linear_to_conv2d.py
+++ b/backends/qualcomm/_passes/convert_linear_to_conv2d.py
@@ -8,6 +8,7 @@ import torch
 from executorch.backends.qualcomm._passes.utils import append_qdq, copy_meta
 from executorch.backends.qualcomm.builders.utils import get_parameter, set_parameter
 from executorch.exir.pass_base import ExportPass, PassResult
+from executorch.exir.passes import dead_code_elimination_pass
 from torch.fx import GraphModule
 from torchao.quantization.pt2e.utils import get_new_attr_name_with_prefix
 
@@ -227,6 +228,5 @@ class ConvertLinearToConv2d(ExportPass):
                     node.replace_all_uses_with(y)
                     graph.erase_node(node)
 
-        graph.eliminate_dead_code()
-        graph_module.recompile()
+        dead_code_elimination_pass(graph_module)
         return PassResult(graph_module, True)

--- a/backends/qualcomm/_passes/convert_square_to_pow.py
+++ b/backends/qualcomm/_passes/convert_square_to_pow.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 import torch
 from executorch.exir.pass_base import ExportPass, PassResult
+from executorch.exir.passes import dead_code_elimination_pass
 
 from .utils import copy_meta
 
@@ -33,6 +34,5 @@ class ConvertSquareToPow(ExportPass):
                 for user in node.users.copy():
                     user.replace_input_with(node, pow_node)
 
-        graph.eliminate_dead_code()
-        graph_module.recompile()
+        dead_code_elimination_pass(graph_module)
         return PassResult(graph_module, True)

--- a/backends/qualcomm/_passes/decompose_any.py
+++ b/backends/qualcomm/_passes/decompose_any.py
@@ -7,6 +7,7 @@
 import torch
 from executorch.exir import to_edge
 from executorch.exir.pass_base import ExportPass, PassResult
+from executorch.exir.passes import dead_code_elimination_pass
 
 from .utils import merge_decomposed_graph
 
@@ -59,6 +60,5 @@ class DecomposeAny(ExportPass):
                     )
                     graph.erase_node(node)
 
-        graph.eliminate_dead_code()
-        graph_module.recompile()
+        dead_code_elimination_pass(graph_module)
         return PassResult(graph_module, True)

--- a/backends/qualcomm/_passes/decompose_binary_alpha.py
+++ b/backends/qualcomm/_passes/decompose_binary_alpha.py
@@ -6,6 +6,7 @@
 
 import torch
 from executorch.exir.pass_base import ExportPass, PassResult
+from executorch.exir.passes import dead_code_elimination_pass
 
 from .utils import copy_meta
 
@@ -56,6 +57,5 @@ class DecomposeBinaryAlpha(ExportPass):
                         mul_node,
                     )
 
-        graph.eliminate_dead_code()
-        graph_module.recompile()
+        dead_code_elimination_pass(graph_module)
         return PassResult(graph_module, True)

--- a/backends/qualcomm/_passes/decompose_cdist.py
+++ b/backends/qualcomm/_passes/decompose_cdist.py
@@ -6,6 +6,7 @@
 
 import torch
 from executorch.exir.pass_base import ExportPass, PassResult
+from executorch.exir.passes import dead_code_elimination_pass
 
 from .utils import merge_decomposed_graph
 
@@ -64,6 +65,5 @@ class DecomposeCDist(ExportPass):
                     )
                     graph.erase_node(node)
 
-        graph.eliminate_dead_code()
-        graph_module.recompile()
+        dead_code_elimination_pass(graph_module)
         return PassResult(graph_module, True)

--- a/backends/qualcomm/_passes/decompose_col_im.py
+++ b/backends/qualcomm/_passes/decompose_col_im.py
@@ -6,6 +6,7 @@
 import torch
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass, PassResult
+from executorch.exir.passes import dead_code_elimination_pass
 
 from .utils import copy_meta
 
@@ -117,5 +118,5 @@ class DecomposeColIm(ExportPass):
     def call(self, graph_module: torch.fx.GraphModule):
         self._decompose_im2col(graph_module)
         self._decompose_col2im(graph_module)
-        graph_module.recompile()
+        dead_code_elimination_pass(graph_module)
         return PassResult(graph_module, True)

--- a/backends/qualcomm/_passes/decompose_einsum.py
+++ b/backends/qualcomm/_passes/decompose_einsum.py
@@ -6,6 +6,7 @@
 
 import torch
 from executorch.exir.pass_base import ExportPass, PassResult
+from executorch.exir.passes import dead_code_elimination_pass
 from torch.fx.experimental.proxy_tensor import make_fx
 
 from .utils import merge_decomposed_graph
@@ -46,6 +47,5 @@ class DecomposeEinsum(ExportPass):
                     )
                     graph.erase_node(node)
 
-        graph.eliminate_dead_code()
-        graph_module.recompile()
+        dead_code_elimination_pass(graph_module)
         return PassResult(graph_module, True)

--- a/backends/qualcomm/_passes/decompose_expm1.py
+++ b/backends/qualcomm/_passes/decompose_expm1.py
@@ -6,6 +6,7 @@
 
 import torch
 from executorch.exir.pass_base import ExportPass, PassResult
+from executorch.exir.passes import dead_code_elimination_pass
 
 from .utils import copy_meta
 
@@ -41,6 +42,5 @@ class DecomposeExpM1(ExportPass):
                 for user in node.users.copy():
                     user.replace_input_with(node, sub_node)
 
-        graph.eliminate_dead_code()
-        graph_module.recompile()
+        dead_code_elimination_pass(graph_module)
         return PassResult(graph_module, True)

--- a/backends/qualcomm/_passes/decompose_floor_divide.py
+++ b/backends/qualcomm/_passes/decompose_floor_divide.py
@@ -6,6 +6,7 @@
 
 import torch
 from executorch.exir.pass_base import ExportPass, PassResult
+from executorch.exir.passes import dead_code_elimination_pass
 
 from .utils import merge_decomposed_graph
 
@@ -57,6 +58,5 @@ class DecomposeFloorDivide(ExportPass):
                     )
                     graph.erase_node(node)
 
-        graph.eliminate_dead_code()
-        graph_module.recompile()
+        dead_code_elimination_pass(graph_module)
         return PassResult(graph_module, True)

--- a/backends/qualcomm/_passes/decompose_glu.py
+++ b/backends/qualcomm/_passes/decompose_glu.py
@@ -6,6 +6,7 @@
 
 import torch
 from executorch.exir.pass_base import ExportPass, PassResult
+from executorch.exir.passes import dead_code_elimination_pass
 
 from .utils import merge_decomposed_graph
 
@@ -50,6 +51,5 @@ class DecomposeGlu(ExportPass):
                     )
                     graph.erase_node(node)
 
-        graph.eliminate_dead_code()
-        graph_module.recompile()
+        dead_code_elimination_pass(graph_module)
         return PassResult(graph_module, True)

--- a/backends/qualcomm/_passes/decompose_linalg_vector_norm.py
+++ b/backends/qualcomm/_passes/decompose_linalg_vector_norm.py
@@ -7,6 +7,7 @@
 import torch
 from executorch.exir import to_edge
 from executorch.exir.pass_base import ExportPass, PassResult
+from executorch.exir.passes import dead_code_elimination_pass
 
 from .utils import merge_decomposed_graph
 
@@ -70,6 +71,5 @@ class DecomposeLinalgVectorNorm(ExportPass):
                     )
                     graph.erase_node(node)
 
-        graph.eliminate_dead_code()
-        graph_module.recompile()
+        dead_code_elimination_pass(graph_module)
         return PassResult(graph_module, True)

--- a/backends/qualcomm/_passes/decompose_maxpool3d.py
+++ b/backends/qualcomm/_passes/decompose_maxpool3d.py
@@ -10,6 +10,7 @@ import torch
 import torch.nn as nn
 from executorch.exir import to_edge
 from executorch.exir.pass_base import ExportPass, PassResult
+from executorch.exir.passes import dead_code_elimination_pass
 
 from .utils import merge_decomposed_graph
 
@@ -128,6 +129,5 @@ class DecomposeMaxPool3d(ExportPass):
                     )
                     graph.erase_node(node)
 
-        graph.eliminate_dead_code()
-        graph_module.recompile()
+        dead_code_elimination_pass(graph_module)
         return PassResult(graph_module, True)

--- a/backends/qualcomm/_passes/decompose_minmaxdim.py
+++ b/backends/qualcomm/_passes/decompose_minmaxdim.py
@@ -11,6 +11,7 @@ from collections import Counter
 import torch
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass, PassResult
+from executorch.exir.passes import dead_code_elimination_pass
 from torch.fx.passes.utils.source_matcher_utils import get_source_partitions
 
 
@@ -104,6 +105,5 @@ class DecomposeMinMaxDim(ExportPass):
                     for user in list(idx_node.users):
                         user.replace_input_with(idx_node, argmin_node)
 
-        graph.eliminate_dead_code()
-        graph_module.recompile()
+        dead_code_elimination_pass(graph_module)
         return PassResult(graph_module, True)

--- a/backends/qualcomm/_passes/decompose_roll.py
+++ b/backends/qualcomm/_passes/decompose_roll.py
@@ -6,6 +6,7 @@
 import torch
 
 from executorch.exir.pass_base import ExportPass, PassResult
+from executorch.exir.passes import dead_code_elimination_pass
 
 from .utils import merge_decomposed_graph
 
@@ -73,6 +74,5 @@ class DecomposeRoll(ExportPass):
                     )
                     graph.erase_node(node)
 
-        graph.eliminate_dead_code()
-        graph_module.recompile()
+        dead_code_elimination_pass(graph_module)
         return PassResult(graph_module, True)

--- a/backends/qualcomm/_passes/decompose_silu.py
+++ b/backends/qualcomm/_passes/decompose_silu.py
@@ -6,6 +6,7 @@
 
 import torch
 from executorch.exir.pass_base import ExportPass, PassResult
+from executorch.exir.passes import dead_code_elimination_pass
 
 from .utils import copy_meta
 
@@ -40,6 +41,5 @@ class DecomposeSilu(ExportPass):
                         for user in silu_node.users.copy():
                             user.replace_input_with(silu_node, mul_node)
 
-        graph.eliminate_dead_code()
-        graph_module.recompile()
+        dead_code_elimination_pass(graph_module)
         return PassResult(graph_module, True)

--- a/backends/qualcomm/_passes/decompose_threshold.py
+++ b/backends/qualcomm/_passes/decompose_threshold.py
@@ -6,6 +6,7 @@
 import torch
 
 from executorch.exir.pass_base import ExportPass, PassResult
+from executorch.exir.passes import dead_code_elimination_pass
 
 from .utils import merge_decomposed_graph
 
@@ -56,6 +57,5 @@ class DecomposeThreshold(ExportPass):
                     )
                     graph.erase_node(node)
 
-        graph.eliminate_dead_code()
-        graph_module.recompile()
+        dead_code_elimination_pass(graph_module)
         return PassResult(graph_module, True)

--- a/backends/qualcomm/_passes/decompose_triu.py
+++ b/backends/qualcomm/_passes/decompose_triu.py
@@ -8,6 +8,7 @@ from typing import Dict
 
 import torch
 from executorch.exir.pass_base import ExportPass, PassResult
+from executorch.exir.passes import dead_code_elimination_pass
 from torch._decomp import get_decompositions
 from torch.fx.experimental.proxy_tensor import make_fx
 
@@ -66,6 +67,5 @@ class DecomposeTriu(ExportPass):
                     )
                     graph.erase_node(node)
 
-        graph.eliminate_dead_code()
-        graph_module.recompile()
+        dead_code_elimination_pass(graph_module)
         return PassResult(graph_module, True)

--- a/backends/qualcomm/_passes/decompose_wrap_with_autocast.py
+++ b/backends/qualcomm/_passes/decompose_wrap_with_autocast.py
@@ -9,6 +9,7 @@ from typing import Dict, Tuple
 
 import torch
 from executorch.exir.pass_base import ExportPass, PassResult
+from executorch.exir.passes import dead_code_elimination_pass
 
 from .utils import merge_decomposed_graph
 
@@ -74,6 +75,5 @@ class DecomposeWrapWithAutocast(ExportPass):
 
     def call(self, graph_module: torch.fx.GraphModule) -> PassResult:
         self._replace(graph_module)
-        graph_module.graph.eliminate_dead_code()
-        graph_module.recompile()
+        dead_code_elimination_pass(graph_module)
         return PassResult(graph_module, True)

--- a/backends/qualcomm/_passes/expand_broadcast_tensor_shape.py
+++ b/backends/qualcomm/_passes/expand_broadcast_tensor_shape.py
@@ -62,6 +62,5 @@ class ExpandBroadcastTensorShape(ExportPass):
 
     def call(self, graph_module: torch.fx.GraphModule):
         self.traverse_broadcast_node(graph_module)
-        graph_module.recompile()
         dead_code_elimination_pass(graph_module)
         return PassResult(graph_module, True)

--- a/backends/qualcomm/_passes/fixed_linear_keep_dim.py
+++ b/backends/qualcomm/_passes/fixed_linear_keep_dim.py
@@ -91,5 +91,4 @@ class FixedLinearKeepDim(ExportPass):
     def call(self, graph_module: torch.fx.GraphModule):
         self._fixed_keep_dim(graph_module)
         dead_code_elimination_pass(graph_module)
-        graph_module.recompile()
         return PassResult(graph_module, True)

--- a/backends/qualcomm/_passes/fold_qdq.py
+++ b/backends/qualcomm/_passes/fold_qdq.py
@@ -75,6 +75,5 @@ class FoldQDQ(ExportPass):
     def call(self, graph_module: torch.fx.GraphModule):
         self._fold_dq(graph_module)
         self._fold_q(graph_module)
-        graph_module.recompile()
         dead_code_elimination_pass(graph_module)
         return PassResult(graph_module, True)

--- a/backends/qualcomm/_passes/fuse_consecutive_cast.py
+++ b/backends/qualcomm/_passes/fuse_consecutive_cast.py
@@ -111,6 +111,5 @@ class FuseConsecutiveCast(ExportPass):
     def call(self, graph_module: torch.fx.GraphModule):
         self._canonicalize_cast(graph_module)
         self._fuse(graph_module)
-        graph_module.recompile()
         dead_code_elimination_pass(graph_module)
         return PassResult(graph_module, True)

--- a/backends/qualcomm/_passes/fuse_consecutive_transpose.py
+++ b/backends/qualcomm/_passes/fuse_consecutive_transpose.py
@@ -104,6 +104,5 @@ class FuseConsecutiveTranspose(ExportPass):
     def call(self, graph_module: torch.fx.GraphModule):
         self._clone_transpose(graph_module)
         self._fuse(graph_module)
-        graph_module.recompile()
         dead_code_elimination_pass(graph_module)
         return PassResult(graph_module, True)

--- a/backends/qualcomm/_passes/insert_io_qdq.py
+++ b/backends/qualcomm/_passes/insert_io_qdq.py
@@ -20,6 +20,7 @@ from executorch.backends.qualcomm.utils.constants import (
 )
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass, PassResult
+from executorch.exir.passes import dead_code_elimination_pass
 
 
 class InsertIOQDQ(ExportPass):
@@ -149,6 +150,5 @@ class InsertIOQDQ(ExportPass):
 
     def call(self, graph_module: torch.fx.GraphModule):
         self._insert(graph_module)
-        graph_module.graph.eliminate_dead_code()
-        graph_module.recompile()
+        dead_code_elimination_pass(graph_module)
         return PassResult(graph_module, True)

--- a/backends/qualcomm/_passes/insert_requantize.py
+++ b/backends/qualcomm/_passes/insert_requantize.py
@@ -17,6 +17,7 @@ from executorch.backends.qualcomm.utils.constants import (
 
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass, PassResult
+from executorch.exir.passes import dead_code_elimination_pass
 
 
 class InsertRequantize(ExportPass):
@@ -106,6 +107,5 @@ class InsertRequantize(ExportPass):
 
     def call(self, graph_module: torch.fx.GraphModule):
         self._insert(graph_module)
-        graph_module.graph.eliminate_dead_code()
-        graph_module.recompile()
+        dead_code_elimination_pass(graph_module)
         return PassResult(graph_module, True)

--- a/backends/qualcomm/_passes/insert_reshape_for_reduce_ops.py
+++ b/backends/qualcomm/_passes/insert_reshape_for_reduce_ops.py
@@ -53,7 +53,6 @@ class InsertReshapeForReduceOps(ExportPass):
                 modified = True
 
         if modified:
-            graph_module.recompile()
             dead_code_elimination_pass(graph_module)
 
         return PassResult(graph_module, modified)

--- a/backends/qualcomm/_passes/lift_constant_scalar_operands.py
+++ b/backends/qualcomm/_passes/lift_constant_scalar_operands.py
@@ -181,6 +181,5 @@ class LiftConstantScalarOperands(ExportPass):
 
     def call(self, graph_module: torch.fx.GraphModule):
         self._lift(graph_module)
-        graph_module.recompile()
         dead_code_elimination_pass(graph_module)
         return PassResult(graph_module, True)

--- a/backends/qualcomm/_passes/recompose_pad_maxpool2d.py
+++ b/backends/qualcomm/_passes/recompose_pad_maxpool2d.py
@@ -11,6 +11,7 @@ import torch
 
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass, PassResult
+from executorch.exir.passes import dead_code_elimination_pass
 
 from torch._subclasses.fake_tensor import FakeTensorMode
 
@@ -142,6 +143,5 @@ class RecomposePadMaxPool2d(ExportPass):
                         for user in node.users.copy():
                             user.replace_input_with(node, maxpool2d_node_tuple)
 
-        graph.eliminate_dead_code()
-        graph_module.recompile()
+        dead_code_elimination_pass(graph_module)
         return PassResult(graph_module, True)

--- a/backends/qualcomm/_passes/recompose_pixel_unshuffle.py
+++ b/backends/qualcomm/_passes/recompose_pixel_unshuffle.py
@@ -6,6 +6,7 @@
 import torch
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass, PassResult
+from executorch.exir.passes import dead_code_elimination_pass
 
 
 class RecomposePixelUnshuffle(ExportPass):
@@ -76,6 +77,5 @@ class RecomposePixelUnshuffle(ExportPass):
                     # copy metadata
                     pixel_unshuffle_node.meta = node.meta
 
-        graph.eliminate_dead_code()
-        graph_module.recompile()
+        dead_code_elimination_pass(graph_module)
         return PassResult(graph_module, True)

--- a/backends/qualcomm/_passes/recompose_rms_norm.py
+++ b/backends/qualcomm/_passes/recompose_rms_norm.py
@@ -8,6 +8,7 @@ from executorch.backends.qualcomm._passes.utils import find_patterns
 from executorch.backends.qualcomm.builders.node_visitor import dq_ops
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass, PassResult
+from executorch.exir.passes import dead_code_elimination_pass
 
 
 def _is_node(node):
@@ -150,6 +151,5 @@ class RecomposeRmsNorm(ExportPass):
                     # copy metadata
                     rms_node.meta = last_mul_node.meta
 
-        graph.eliminate_dead_code()
-        graph_module.recompile()
+        dead_code_elimination_pass(graph_module)
         return PassResult(graph_module, True)

--- a/backends/qualcomm/_passes/reduce_dynamic_range.py
+++ b/backends/qualcomm/_passes/reduce_dynamic_range.py
@@ -55,6 +55,5 @@ class ReduceDynamicRange(ExportPass):
 
     def call(self, graph_module: torch.fx.GraphModule):
         self._traverse_binary_node(graph_module)
-        graph_module.recompile()
         dead_code_elimination_pass(graph_module)
         return PassResult(graph_module, True)

--- a/backends/qualcomm/_passes/remove_0d_tensor.py
+++ b/backends/qualcomm/_passes/remove_0d_tensor.py
@@ -7,6 +7,7 @@
 import torch
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass, PassResult
+from executorch.exir.passes import dead_code_elimination_pass
 
 
 class Remove0DTensor(ExportPass):
@@ -31,6 +32,5 @@ class Remove0DTensor(ExportPass):
                     user_n.replace_input_with(node, node.args[0])
                 graph.erase_node(node)
 
-        graph.eliminate_dead_code()
-        graph_module.recompile()
+        dead_code_elimination_pass(graph_module)
         return PassResult(graph_module, True)

--- a/backends/qualcomm/_passes/remove_redundancy.py
+++ b/backends/qualcomm/_passes/remove_redundancy.py
@@ -68,6 +68,5 @@ class RemoveRedundancy(ExportPass):
 
     def call(self, graph_module: torch.fx.GraphModule):
         self._remove(graph_module)
-        graph_module.recompile()
         dead_code_elimination_pass(graph_module)
         return PassResult(graph_module, True)

--- a/backends/qualcomm/_passes/replace_arange_args.py
+++ b/backends/qualcomm/_passes/replace_arange_args.py
@@ -6,6 +6,7 @@
 
 import torch
 from executorch.exir.pass_base import ExportPass, PassResult
+from executorch.exir.passes import dead_code_elimination_pass
 
 from .utils import copy_meta
 
@@ -43,6 +44,5 @@ class ReplaceArangeArgs(ExportPass):
                         for user in node.users.copy():
                             user.replace_input_with(node, step_arange_node)
 
-        graph.eliminate_dead_code()
-        graph_module.recompile()
+        dead_code_elimination_pass(graph_module)
         return PassResult(graph_module, True)

--- a/backends/qualcomm/debugger/format_outputs.py
+++ b/backends/qualcomm/debugger/format_outputs.py
@@ -158,8 +158,9 @@ def export_svg(
                 pydot.Edge(cur_pydot_node, user_pydot_node, dir="forward")
             )
 
-    pydot_graph.write_svg(f"{path}/{title}.svg")
-    print(f"Intermediate debugger graph saved at: {path}/{title}.svg")
+    svg_file_path = os.path.join(path, f"{title}.svg")
+    pydot_graph.write_svg(svg_file_path)
+    print(f"Intermediate debugger graph saved at: {svg_file_path}")
 
 
 def export_csv(
@@ -180,7 +181,8 @@ def export_csv(
         node_info_list.append(node_info)
 
     # Writing to a CSV file
-    with open(f"{path}/{title}.csv", mode="w", newline="") as csv_file:
+    csv_file_path = os.path.join(path, f"{title}.csv")
+    with open(csv_file_path, mode="w", newline="") as csv_file:
         fieldnames = [
             "name",
             "op_code",
@@ -198,7 +200,7 @@ def export_csv(
         writer.writeheader()
         writer.writerows(node_info_list)
 
-    print(f"Intermediate debugger csv saved at: {path}/{title}.csv")
+    print(f"Intermediate debugger csv saved at: {csv_file_path}")
 
 
 def export_raw(

--- a/examples/qualcomm/util_scripts/README.md
+++ b/examples/qualcomm/util_scripts/README.md
@@ -43,7 +43,7 @@ This tool aims for users who want to deploy models with ExecuTorch runtime. It's
 * Quantize
   ```bash 
   # user could get more information via: PYTHONPATH=.. python -m examples.qualcomm.util_scripts.cli quantize -h
-  PYTHONPATH=.. python -m examples.qualcomm.util_scripts.cli quantize -a cli_example/simple_model.pt2 -o cli_example/quantize_output -c use_8a8w -i cli_example/input_list --per_channel
+  PYTHONPATH=.. python -m examples.qualcomm.util_scripts.cli quantize -a cli_example/simple_model.pt2 -o cli_example/quantize_output -c use_8a8w -i cli_example/input_list.txt --per_channel
   ```
 * Artifacts for quantized .pt2 file
   - `cli_example/quantize_output/simple_model_quantized.pt2`
@@ -72,7 +72,7 @@ This tool aims for users who want to deploy models with ExecuTorch runtime. It's
 * Execute .pte program
   ```bash
   # user could get more information via: PYTHONPATH=.. python -m examples.qualcomm.util_scripts.cli execute -h
-  PYTHONPATH=.. python -m examples.qualcomm.util_scripts.cli execute -a cli_example/compile_output/simple_model_quantized.pte -o cli_example/execute_output -i cli_example/input_list -s $DEVICE_SERIAL -b build-android -m SM8750
+  PYTHONPATH=.. python -m examples.qualcomm.util_scripts.cli execute -a cli_example/compile_output/simple_model_quantized.pte -o cli_example/execute_output -i cli_example/input_list.txt -H $HOST_NAME -s $DEVICE_SERIAL -b build-android -m SM8750
   ```
 * Artifacts for .pte file and figure of graph information
   - `cli_example/execute_output/output_{data_index}_{output_index}.pt`.<br/>

--- a/examples/qualcomm/util_scripts/cli.py
+++ b/examples/qualcomm/util_scripts/cli.py
@@ -113,6 +113,20 @@ def get_io_info(pte_path, compiler_specs):
     return tensor_info
 
 
+def get_input_list_description(type: str):
+    return (
+        f"List of input files specified for {type}. Two content formats are supported. "
+        "Format 1: Positional Input Mapping. Each line lists input files in positional order. "
+        'e.g. File content with: "input_0_0.pt input_0_1.pt\\ninput_1_0.pt input_1_1.pt" '
+        "indicates that there are two data sets for a graph with two inputs. Notes that "
+        "the order of input files in each line must exactly match the order of the graph inputs. "
+        "Format 2: Named Input Mapping. Each input file is explicitly associated with a graph input name. "
+        'e.g. File content with: "pixel_values:=input_0_0.pt depth:=input_0_1.pt\\npixel_values:=input_1_0.pt depth:=input_1_1.pt" '
+        "indicates that there are two data sets for a graph with two named inputs: pixel_values and depth. "
+        "Notes that the input name specified in the file must exactly match the corresponding graph input name."
+    )
+
+
 class InputListParser:
     def __init__(self, input_list):
         self.input_list = input_list
@@ -411,11 +425,7 @@ def main():
         "--input_list",
         type=str,
         required=True,
-        help=(
-            "List of input files specified for calibration. "
-            'e.g. File content with: "input_0_0.pt2 input_0_1.pt2\\ninput_1_0.pt2 input_1_1.pt2" '
-            "means there are 2 sets of data for calibration on a graph with 2 inputs."
-        ),
+        help=get_input_list_description("quantize"),
     )
     sub_quantize.add_argument(
         "--per_channel",
@@ -520,11 +530,7 @@ def main():
         "-i",
         "--input_list",
         type=str,
-        help=(
-            "List of input files specified for execution. "
-            'e.g. File content with: "input_0_0.pt2 input_0_1.pt2\\ninput_1_0.pt2 input_1_1.pt2" '
-            "means there are 2 sets of data for execution on a graph with 2 inputs.\n"
-        ),
+        help=get_input_list_description("execute"),
     )
     sub_execute.add_argument(
         "-m",

--- a/examples/qualcomm/utils.py
+++ b/examples/qualcomm/utils.py
@@ -475,7 +475,7 @@ def build_executorch_binary(
     metadata=None,
     dump_intermediate_outputs=False,
     qnn_intermediate_debugger: QNNIntermediateDebugger = None,
-    backend=QnnExecuTorchBackendType.kHtpBackend,
+    backend: QnnExecuTorchBackendType = QnnExecuTorchBackendType.kHtpBackend,
     passes_job=None,
     passes_dependency=None,
     qat_training_data=None,
@@ -491,7 +491,6 @@ def build_executorch_binary(
         model (torch.nn.Module): The model to be converted into an ExecuTorch binary.
         inputs (torch.Tensor): Sample input tensors required for model export.
         soc_model (QcomChipset): The target Qualcomm System on Chip (SoC) model.
-        backend (QnnExecuTorchBackendType): The target backend.
         file_name (str): Name for the output binary file (.pte).
         dataset (List[torch.Tensor] | Callable): A dataset for quantization calibration.
         skip_node_id_set (set, optional): Set of node IDs to be skipped during partition.
@@ -501,6 +500,8 @@ def build_executorch_binary(
         shared_buffer (bool, optional): Applies zero-copy mechanism to optimize runtime memory allocation.
         metadata (dict, optional): An optional dictionary that maps each method name to a constant value in eager mode.
         dump_intermediate_outputs (bool, optional): Enables dumping model intermediate outputs.
+        qnn_intermediate_debugger (QNNIntermediateDebugger, optional): A debugger instance capable of retrieving intermediate tensor results.
+        backend (QnnExecuTorchBackendType, optional): The target backend.
         passes_job (OrderedDict, optional): Custom passes job in capture_program, users can enable/disable specific passes or modify their attributes.
         passes_dependency (Dict, optional): A dictionary mapping each pass to its corresponding list of dependencies.
         qat_training_data (List[torch.Tensor], optional): A dataset for quantization aware training(QAT). Typically is a pair of tensors, such as [features, ground truth].


### PR DESCRIPTION
### Summary
- Replace `graph_module.graph.eliminate_dead_code()` and `graph_module.recompile()` with `dead_code_elimination_pass` from exir/passes/.
- Fix the documentation.

### Test plan
```bash
python  $EXECUTORCH_ROOT/backends/qualcomm/tests/test_qnn_delegate.py -b $EXECUTORCH_ROOT/build-android -H $HOST_NAME -s $DEVICE_ID -m $SOC_ID
```