### PR TITLE
Fix Cadence test failures (#18655)

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -223,6 +223,7 @@ exclude_patterns = [
     '**/*.gif',
     'extension/llm/tokenizers',
     'extension/llm/tokenizers/**',
+    'backends/cadence/utils/FACTO',
     'examples/cuda',
     'kernels/portable',
     # File contains @generated

--- a/backends/cadence/aot/export_example.py
+++ b/backends/cadence/aot/export_example.py
@@ -117,4 +117,5 @@ def export_and_run_model(
         working_dir=working_dir,
         eps_error=eps_error,
         eps_warn=eps_warn,
+        file_name=file_name,
     )

--- a/backends/cadence/aot/tests/test_pass_filter.py
+++ b/backends/cadence/aot/tests/test_pass_filter.py
@@ -33,7 +33,10 @@ class TestBase(unittest.TestCase):
 
     def tearDown(self) -> None:
         # Restore _all_passes to original state before test.
-        pass_utils.ALL_CADENCE_PASSES = self._all_passes_original
+        # Use clear()+update() instead of rebinding to keep the same dict object
+        # that the module-level ALL_CADENCE_PASSES import references.
+        pass_utils.ALL_CADENCE_PASSES.clear()
+        pass_utils.ALL_CADENCE_PASSES.update(self._all_passes_original)
 
     def get_filtered_passes(
         self, filter_: Callable[[Type[PassBase]], bool]

--- a/backends/cadence/runtime/executor.py
+++ b/backends/cadence/runtime/executor.py
@@ -104,11 +104,12 @@ class Executor:
     def __init__(
         self,
         working_dir: str = "",
+        file_name: str = "CadenceDemoModel",
     ):
         self.working_dir = working_dir
         self.executor_builder = "./backends/cadence/build_cadence_runner.sh"
         self.execute_runner = "./cmake-out/backends/cadence/cadence_runner"
-        self.bundled_program_path: str = "CadenceDemoModel.bpte"
+        self.bundled_program_path: str = f"{file_name}.bpte"
 
     def __call__(self) -> None:
         # build executor

--- a/backends/cadence/runtime/runtime.py
+++ b/backends/cadence/runtime/runtime.py
@@ -56,6 +56,7 @@ def run(
     inputs: Any,
     ref_outputs: Optional[Sequence[torch.Tensor]] = None,
     working_dir: Optional[str] = None,
+    file_name: str = "CadenceDemoModel",
 ) -> Any:
     # Get the Program
     program = executorch_prog.executorch_program
@@ -69,7 +70,7 @@ def run(
         working_dir = tempfile.mkdtemp(dir="/tmp")
 
     # initialize e2e Executor with executorch_cfg.
-    executor = Executor(working_dir)
+    executor = Executor(working_dir, file_name=file_name)
 
     # run Executor
     executor()
@@ -136,8 +137,11 @@ def run_and_compare(
     working_dir: Optional[str] = None,
     eps_error: float = 1e-1,
     eps_warn: float = 1e-5,
+    file_name: str = "CadenceDemoModel",
 ) -> Any:
-    outputs = run(executorch_prog, inputs, ref_outputs, working_dir)
+    outputs = run(
+        executorch_prog, inputs, ref_outputs, working_dir, file_name=file_name
+    )
     compare(outputs, ref_outputs, eps_error=eps_error, eps_warn=eps_warn)
 
 

--- a/examples/cadence/operators/test_g3_ops.py
+++ b/examples/cadence/operators/test_g3_ops.py
@@ -16,9 +16,7 @@ from executorch.backends.cadence.aot.export_example import export_and_run_model
 class ATenOpTestCases(unittest.TestCase):
     def run_and_verify(self, model: nn.Module, inputs: Tuple[Any, ...]) -> None:
         model.eval()
-        export_and_run_model(
-            model, inputs, file_name=self._testMethodName, run_and_compare=False
-        )
+        export_and_run_model(model, inputs, file_name=self._testMethodName)
 
     # pyre-ignore[16]: Module `parameterized.parameterized` has no attribute `expand`.
     @parameterized.expand([*facto_util.facto_testcase_gen("add.Tensor")])


### PR DESCRIPTION
Summary:
- Fix test_pass_filter.py: use clear()+update() instead of rebinding
ALL_CADENCE_PASSES in tearDown to keep the same dict object reference
- Fix test_g3_ops.py: remove obsolete run_and_compare flag
- Thread file_name through export_and_run_model → runtime.run_and_compare
→ runtime.run → Executor so the runner loads the correct .bpte file
- Fix facto_util.py: import random_manager instead of seeded_random_manager
to match the current FACTO submodule


Test Plan:
OSS:
1. `python -m pytest backends/cadence/aot/tests/ -v` — 488 passed
2. `python -m pytest examples/cadence/operators/test_g3_ops.py

Reviewed By: zonglinpeng

Differential Revision: D99168797

Pulled By: aliafzal
