### PR TITLE
Cadence HiFi: Fix build errors for ResNet-18 and Emformer RNNT Encoder

### DIFF
--- a/backends/cadence/aot/functions_hifi.yaml
+++ b/backends/cadence/aot/functions_hifi.yaml
@@ -192,6 +192,11 @@
     - arg_meta: null
       kernel_name: impl::HiFi::minimum_out
 
+- op: native_layer_norm.out
+  kernels:
+    - arg_meta: null
+      kernel_name: torch::executor::native_layer_norm_out
+
 - op: mm.out
   kernels:
     - arg_meta: null
@@ -499,6 +504,11 @@
     - arg_meta: null
       kernel_name: impl::HiFi::quantized_relu_asym8u_asym8u_per_tensor_out
 
+- func: cadence::quantized_max_pool2d_nchw.out(Tensor input, int[] kernel_size, int[] stride, int[] padding, int[] dilation, bool ceil_mode, *, Tensor(a!) out) -> Tensor(a!)
+  kernels:
+    - arg_meta: null
+      kernel_name: impl::generic::quantized_max_pool2d_nchw_out
+
 - func: cadence::quantized_max_pool2d_nhwc.out(Tensor input, int[] kernel_size, int[] stride, int[] padding, int[] dilation, bool ceil_mode, *, Tensor(a!) out) -> Tensor(a!)
   kernels:
     - arg_meta: null
@@ -552,9 +562,9 @@
 - func: cadence::quantized_conv1d_ncl.per_tensor_out(Tensor input, Tensor weight, Tensor bias, int[] stride, SymInt[] padding, int[] dilation, int groups, int input_zero_point, int weight_zero_point, float bias_scale, float out_scale, int out_zero_point, int out_multiplier, int out_shift, *, Tensor(a!) out) -> Tensor(a!)
   kernels:
     - arg_meta: null
-      kernel_name: impl::HiFi::native::quantized_conv1d_ncl_per_tensor_out
+      kernel_name: impl::HiFi::quantized_conv1d_ncl_per_tensor_out
 
 - func: cadence::quantized_conv1d_nlc.per_tensor_out(Tensor input, Tensor weight, Tensor bias, int[] stride, SymInt[] padding, int[] dilation, int groups, int input_zero_point, int weight_zero_point, float bias_scale, float out_scale, int out_zero_point, int out_multiplier, int out_shift, *, Tensor(a!) out) -> Tensor(a!)
   kernels:
     - arg_meta: null
-      kernel_name: impl::HiFi::native::quantized_conv1d_nlc_per_tensor_out
+      kernel_name: impl::HiFi::quantized_conv1d_nlc_per_tensor_out

--- a/backends/cadence/hifi/operators/CMakeLists.txt
+++ b/backends/cadence/hifi/operators/CMakeLists.txt
@@ -59,6 +59,8 @@ set(_aten_ops__srcs
     "${EXECUTORCH_ROOT}/kernels/portable/cpu/op_clone.cpp"
     "${EXECUTORCH_ROOT}/kernels/portable/cpu/op_gelu.cpp"
     "${EXECUTORCH_ROOT}/kernels/portable/cpu/op_max_pool2d_with_indices.cpp"
+    "${EXECUTORCH_ROOT}/kernels/portable/cpu/op_native_layer_norm.cpp"
+    "${EXECUTORCH_ROOT}/kernels/portable/cpu/util/normalization_ops_util.cpp"
     "${EXECUTORCH_ROOT}/kernels/portable/cpu/op_to_copy.cpp"
     "${EXECUTORCH_ROOT}/kernels/portable/cpu/pattern/unary_ufunc_realhbbf16_to_floathbf16.cpp"
     "${EXECUTORCH_ROOT}/kernels/portable/cpu/util/activation_ops_util.cpp"
@@ -99,7 +101,10 @@ set(_generic_kernels__srcs
 # impl::generic::native implementations called by HiFi operators.
 set(_generic_custom_ops__srcs
     "${EXECUTORCH_ROOT}/backends/cadence/generic/operators/op_quantized_linear.cpp"
+    "${EXECUTORCH_ROOT}/backends/cadence/generic/operators/op_quantized_conv1d_ncl.cpp"
+    "${EXECUTORCH_ROOT}/backends/cadence/generic/operators/op_quantized_conv1d_nlc.cpp"
     "${EXECUTORCH_ROOT}/backends/cadence/generic/operators/op_quantized_conv2d.cpp"
+    "${EXECUTORCH_ROOT}/backends/cadence/generic/operators/op_quantized_max_pool2d.cpp"
     "${EXECUTORCH_ROOT}/backends/cadence/generic/operators/op_quantized_matmul.cpp"
 )
 
@@ -140,6 +145,7 @@ add_library(
   "op_quantized_conv2d_nhwc_depthwise_asym8uxsym8u_asym8u_per_tensor_out.cpp"
   "op_quantized_conv2d_nhwc_dilated_asym8sxsym8s_asym8s_per_tensor_out.cpp"
   "op_quantized_conv2d_nhwc_dilated_asym8uxsym8u_asym8u_per_tensor_out.cpp"
+  "op_quantized_max_pool2d_nhwc.cpp"
   "op_quantized_fully_connected_out.cpp"
   "op_quantized_fully_connected_asym8sxasym8s_asym8s_per_tensor_out.cpp"
   "op_quantized_fully_connected_asym8uxasym8u_asym8u_per_tensor_out.cpp"

--- a/backends/cadence/install_requirements.sh
+++ b/backends/cadence/install_requirements.sh
@@ -30,7 +30,7 @@ if [ $STATUS -ne 0 ]; then
     exit 1
 fi
 
-git checkout 102944a6f76a0de4d81adc431f3f132f517aa87f
+git checkout 64d73d729797388b0e346794d7a2e408374a74de
 
 
 ## Fusion G3


### PR DESCRIPTION
### Summary
Fix several HiFi build issues preventing ResNet-18 and Emformer RNNT Encoder from compiling and running on the Xtensa toolchain.

Fixes #18181 

functions_hifi.yaml:
- Add quantized_max_pool2d_nchw op (NCHW variant was missing, only NHWC was registered). Uses generic fallback kernel.
- Add native_layer_norm op (needed by Emformer RNNT Encoder). Uses portable kernel.
- Fix double native:: namespace on quantized_conv1d_ncl and quantized_conv1d_nlc kernel names — codegen adds the native:: namespace automatically, so having it in the yaml produced impl::HiFi::native::native:: which failed to link.

CMakeLists.txt:
- Add op_quantized_max_pool2d_nhwc.cpp to custom_ops sources (file existed but was not compiled)
- Add generic conv1d fallback sources (op_quantized_conv1d_ncl.cpp, op_quantized_conv1d_nlc.cpp) that HiFi conv1d operators call
- Add generic op_quantized_max_pool2d.cpp for NCHW fallback
- Add portable op_native_layer_norm.cpp and normalization_ops_util.cpp

install_requirements.sh:
- Update nnlib-hifi4 SHA to 64d73d72 which adds xa_nn_elm_add_broadcast_4D_f32xf32_f32 (float broadcast add kernel used by op_add.cpp)

Authored with Claude.

### Test Plan
```
  CXXFLAGS="-fno-exceptions -fno-rtti" cmake \
    -DCMAKE_TOOLCHAIN_FILE=./backends/cadence/cadence.cmake \
    -DCMAKE_INSTALL_PREFIX=cmake-xtensa \
    -DCMAKE_BUILD_TYPE=Release \
    -DEXECUTORCH_BUILD_EXECUTOR_RUNNER=ON \
    -DEXECUTORCH_BUILD_PTHREADPOOL=OFF \
    -DEXECUTORCH_BUILD_CPUINFO=OFF \
    -DEXECUTORCH_BUILD_CADENCE=ON \
    -DEXECUTORCH_BUILD_EXTENSION_RUNNER_UTIL=ON \
    -DEXECUTORCH_ENABLE_LOGGING=ON \
    -DEXECUTORCH_ENABLE_PROGRAM_VERIFICATION=ON \
    -DEXECUTORCH_USE_DL=OFF \
    -DEXECUTORCH_BUILD_PORTABLE_OPS=ON \
    -DEXECUTORCH_BUILD_KERNELS_LLM=OFF \
    -DPYTHON_EXECUTABLE=python3 \
    -DEXECUTORCH_NNLIB_OPT=ON \
    -DHAVE_FNMATCH_H=OFF \
    -DFLATCC_ALLOW_WERROR=OFF \
    -Bcmake-xtensa
  cmake --build cmake-xtensa --target install --config Release -j8
```