### PR TITLE
Reuse existing Cadence runner build for test run if present

### DIFF
--- a/backends/cadence/aot/export_example.py
+++ b/backends/cadence/aot/export_example.py
@@ -104,6 +104,7 @@ def export_and_run_model(
     file_name: str = "CadenceDemoModel",
     eps_error: float = 1e-1,
     eps_warn: float = 1e-5,
+    force_rebuild: bool = False,
 ):
     # create work directory for outputs and model binary
     working_dir = tempfile.mkdtemp(dir="/tmp")
@@ -118,4 +119,5 @@ def export_and_run_model(
         eps_error=eps_error,
         eps_warn=eps_warn,
         file_name=file_name,
+        force_rebuild=force_rebuild,
     )

--- a/backends/cadence/runtime/executor.py
+++ b/backends/cadence/runtime/executor.py
@@ -105,17 +105,22 @@ class Executor:
         self,
         working_dir: str = "",
         file_name: str = "CadenceDemoModel",
+        force_rebuild: bool = False,
     ):
         self.working_dir = working_dir
         self.executor_builder = "./backends/cadence/build_cadence_runner.sh"
         self.execute_runner = "./cmake-out/backends/cadence/cadence_runner"
         self.bundled_program_path: str = f"{file_name}.bpte"
+        self.force_rebuild = force_rebuild
 
     def __call__(self) -> None:
-        # build executor
-        args = self.get_bash_command(self.executor_builder)
-        logging.info(f"\33[33m{' '.join(args)}\33[0m")
-        execute(args)
+        # build executor if not already built or force rebuild requested
+        if self.force_rebuild or not os.path.isfile(self.execute_runner):
+            args = self.get_bash_command(self.executor_builder)
+            logging.info(f"\33[33m{' '.join(args)}\33[0m")
+            execute(args)
+        else:
+            logging.info("Reusing existing runner at %s", self.execute_runner)
 
         # run executor
         cmd_args = {

--- a/backends/cadence/runtime/runtime.py
+++ b/backends/cadence/runtime/runtime.py
@@ -57,6 +57,7 @@ def run(
     ref_outputs: Optional[Sequence[torch.Tensor]] = None,
     working_dir: Optional[str] = None,
     file_name: str = "CadenceDemoModel",
+    force_rebuild: bool = False,
 ) -> Any:
     # Get the Program
     program = executorch_prog.executorch_program
@@ -70,7 +71,7 @@ def run(
         working_dir = tempfile.mkdtemp(dir="/tmp")
 
     # initialize e2e Executor with executorch_cfg.
-    executor = Executor(working_dir, file_name=file_name)
+    executor = Executor(working_dir, file_name=file_name, force_rebuild=force_rebuild)
 
     # run Executor
     executor()
@@ -138,9 +139,15 @@ def run_and_compare(
     eps_error: float = 1e-1,
     eps_warn: float = 1e-5,
     file_name: str = "CadenceDemoModel",
+    force_rebuild: bool = False,
 ) -> Any:
     outputs = run(
-        executorch_prog, inputs, ref_outputs, working_dir, file_name=file_name
+        executorch_prog,
+        inputs,
+        ref_outputs,
+        working_dir,
+        file_name=file_name,
+        force_rebuild=force_rebuild,
     )
     compare(outputs, ref_outputs, eps_error=eps_error, eps_warn=eps_warn)
 


### PR DESCRIPTION
Skips rebuilding the Cadence runner when a binary already exists, speeding up test execution. Adds a force_rebuild flag through the runtime stack for when a clean build is needed.

## Test plan
- Ran `python -m pytest examples/cadence/operators/test_g3_ops.py -v -n auto` and confirmed runner is built once, then reused for subsequent tests
- Verified `Reusing existing runner` appears in logs after first build
- Individual test execution time dropped from ~32s to ~11s with cached build