### PR TITLE
Fix integer overflow in data loader bounds checks

### DIFF
--- a/extension/data_loader/buffer_data_loader.h
+++ b/extension/data_loader/buffer_data_loader.h
@@ -40,7 +40,7 @@ class BufferDataLoader final : public executorch::runtime::DataLoader {
     ET_CHECK_OR_RETURN_ERROR(
         !overflow && total_size <= size_,
         InvalidArgument,
-        "offset %zu + size %zu > size_ %zu",
+        "offset %zu + size %zu > size_ %zu, or overflow detected",
         offset,
         size,
         size_);

--- a/extension/data_loader/file_data_loader.cpp
+++ b/extension/data_loader/file_data_loader.cpp
@@ -144,7 +144,7 @@ Result<FreeableBuffer> FileDataLoader::load(
       InvalidState,
       "Uninitialized");
   ET_CHECK_OR_RETURN_ERROR(
-      offset + size <= file_size_,
+      offset <= file_size_ && size <= file_size_ - offset,
       InvalidArgument,
       "File %s: offset %zu + size %zu > file_size_ %zu",
       file_name_,
@@ -205,7 +205,7 @@ ET_NODISCARD Error FileDataLoader::load_into(
       InvalidState,
       "Uninitialized");
   ET_CHECK_OR_RETURN_ERROR(
-      offset + size <= file_size_,
+      offset <= file_size_ && size <= file_size_ - offset,
       InvalidArgument,
       "File %s: offset %zu + size %zu > file_size_ %zu",
       file_name_,

--- a/extension/data_loader/file_data_loader.cpp
+++ b/extension/data_loader/file_data_loader.cpp
@@ -19,6 +19,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
+#include <c10/util/safe_numerics.h>
 #include <executorch/runtime/core/error.h>
 #include <executorch/runtime/core/result.h>
 #include <executorch/runtime/platform/log.h>
@@ -143,10 +144,12 @@ Result<FreeableBuffer> FileDataLoader::load(
       fd_ >= 0,
       InvalidState,
       "Uninitialized");
+  size_t total_size;
+  bool overflow = c10::add_overflows(offset, size, &total_size);
   ET_CHECK_OR_RETURN_ERROR(
-      offset <= file_size_ && size <= file_size_ - offset,
+      !overflow && total_size <= file_size_,
       InvalidArgument,
-      "File %s: offset %zu + size %zu > file_size_ %zu",
+      "File %s: offset %zu + size %zu > file_size_ %zu, or overflow detected",
       file_name_,
       offset,
       size,
@@ -204,10 +207,12 @@ ET_NODISCARD Error FileDataLoader::load_into(
       fd_ >= 0,
       InvalidState,
       "Uninitialized");
+  size_t total_size;
+  bool overflow = c10::add_overflows(offset, size, &total_size);
   ET_CHECK_OR_RETURN_ERROR(
-      offset <= file_size_ && size <= file_size_ - offset,
+      !overflow && total_size <= file_size_,
       InvalidArgument,
-      "File %s: offset %zu + size %zu > file_size_ %zu",
+      "File %s: offset %zu + size %zu > file_size_ %zu, or overflow detected",
       file_name_,
       offset,
       size,

--- a/extension/data_loader/file_descriptor_data_loader.cpp
+++ b/extension/data_loader/file_descriptor_data_loader.cpp
@@ -158,7 +158,7 @@ Result<FreeableBuffer> FileDescriptorDataLoader::load(
       InvalidState,
       "Uninitialized");
   ET_CHECK_OR_RETURN_ERROR(
-      offset + size <= file_size_,
+      offset <= file_size_ && size <= file_size_ - offset,
       InvalidArgument,
       "File %s: offset %zu + size %zu > file_size_ %zu",
       file_descriptor_uri_,
@@ -219,7 +219,7 @@ ET_NODISCARD Error FileDescriptorDataLoader::load_into(
       InvalidState,
       "Uninitialized");
   ET_CHECK_OR_RETURN_ERROR(
-      offset + size <= file_size_,
+      offset <= file_size_ && size <= file_size_ - offset,
       InvalidArgument,
       "File %s: offset %zu + size %zu > file_size_ %zu",
       file_descriptor_uri_,

--- a/extension/data_loader/file_descriptor_data_loader.cpp
+++ b/extension/data_loader/file_descriptor_data_loader.cpp
@@ -19,6 +19,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include <c10/util/safe_numerics.h>
 #include <executorch/runtime/core/error.h>
 #include <executorch/runtime/core/result.h>
 #include <executorch/runtime/platform/log.h>
@@ -157,10 +158,12 @@ Result<FreeableBuffer> FileDescriptorDataLoader::load(
       fd_ >= 0,
       InvalidState,
       "Uninitialized");
+  size_t total_size;
+  bool overflow = c10::add_overflows(offset, size, &total_size);
   ET_CHECK_OR_RETURN_ERROR(
-      offset <= file_size_ && size <= file_size_ - offset,
+      !overflow && total_size <= file_size_,
       InvalidArgument,
-      "File %s: offset %zu + size %zu > file_size_ %zu",
+      "File %s: offset %zu + size %zu > file_size_ %zu, or overflow detected",
       file_descriptor_uri_,
       offset,
       size,
@@ -218,10 +221,12 @@ ET_NODISCARD Error FileDescriptorDataLoader::load_into(
       fd_ >= 0,
       InvalidState,
       "Uninitialized");
+  size_t total_size;
+  bool overflow = c10::add_overflows(offset, size, &total_size);
   ET_CHECK_OR_RETURN_ERROR(
-      offset <= file_size_ && size <= file_size_ - offset,
+      !overflow && total_size <= file_size_,
       InvalidArgument,
-      "File %s: offset %zu + size %zu > file_size_ %zu",
+      "File %s: offset %zu + size %zu > file_size_ %zu, or overflow detected",
       file_descriptor_uri_,
       offset,
       size,

--- a/extension/data_loader/mmap_data_loader.cpp
+++ b/extension/data_loader/mmap_data_loader.cpp
@@ -160,7 +160,7 @@ Error MmapDataLoader::validate_input(size_t offset, size_t size) const {
       InvalidState,
       "Uninitialized");
   ET_CHECK_OR_RETURN_ERROR(
-      offset + size <= file_size_,
+      offset <= file_size_ && size <= file_size_ - offset,
       InvalidArgument,
       "File %s: offset %zu + size %zu > file_size_ %zu",
       file_name_,

--- a/extension/data_loader/mmap_data_loader.cpp
+++ b/extension/data_loader/mmap_data_loader.cpp
@@ -17,6 +17,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
+#include <c10/util/safe_numerics.h>
 #include <executorch/extension/data_loader/mman.h>
 #include <executorch/runtime/core/error.h>
 #include <executorch/runtime/core/result.h>
@@ -159,10 +160,12 @@ Error MmapDataLoader::validate_input(size_t offset, size_t size) const {
       fd_ >= 0,
       InvalidState,
       "Uninitialized");
+  size_t total_size;
+  bool overflow = c10::add_overflows(offset, size, &total_size);
   ET_CHECK_OR_RETURN_ERROR(
-      offset <= file_size_ && size <= file_size_ - offset,
+      !overflow && total_size <= file_size_,
       InvalidArgument,
-      "File %s: offset %zu + size %zu > file_size_ %zu",
+      "File %s: offset %zu + size %zu > file_size_ %zu, or overflow detected",
       file_name_,
       offset,
       size,

--- a/extension/data_loader/shared_ptr_data_loader.h
+++ b/extension/data_loader/shared_ptr_data_loader.h
@@ -34,7 +34,7 @@ class SharedPtrDataLoader final : public executorch::runtime::DataLoader {
       size_t size,
       ET_UNUSED const DataLoader::SegmentInfo& segment_info) const override {
     ET_CHECK_OR_RETURN_ERROR(
-        offset + size <= size_,
+        offset <= size_ && size <= size_ - offset,
         InvalidArgument,
         "offset %zu + size %zu > size_ %zu",
         offset,

--- a/extension/data_loader/shared_ptr_data_loader.h
+++ b/extension/data_loader/shared_ptr_data_loader.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <c10/util/safe_numerics.h>
 #include <executorch/runtime/core/data_loader.h>
 #include <executorch/runtime/core/error.h>
 #include <executorch/runtime/core/result.h>
@@ -33,10 +34,12 @@ class SharedPtrDataLoader final : public executorch::runtime::DataLoader {
       size_t offset,
       size_t size,
       ET_UNUSED const DataLoader::SegmentInfo& segment_info) const override {
+    size_t total_size;
+    bool overflow = c10::add_overflows(offset, size, &total_size);
     ET_CHECK_OR_RETURN_ERROR(
-        offset <= size_ && size <= size_ - offset,
+        !overflow && total_size <= size_,
         InvalidArgument,
-        "offset %zu + size %zu > size_ %zu",
+        "offset %zu + size %zu > size_ %zu, or overflow detected",
         offset,
         size,
         size_);


### PR DESCRIPTION
Replace `offset + size <= file_size_` with overflow-safe `c10::add_overflows`
Affected files: MmapDataLoader, FileDataLoader,FileDescriptorDataLoader, SharedPtrDataLoader.

This PR was authored with the assistance of Claude.
--
also update the error message