### PR TITLE
Add Cadence CI test workflow with separate build and test signals (#18677)

### DIFF
--- a/.github/workflows/_test_cadence.yml
+++ b/.github/workflows/_test_cadence.yml
@@ -1,0 +1,77 @@
+name: Test Cadence
+
+permissions:
+  id-token: write
+  contents: read
+
+on:
+  workflow_call:
+    inputs:
+      docker-image:
+        description: 'Docker image to use'
+        required: false
+        type: string
+        default: ci-image:executorch-ubuntu-22.04-clang12
+      runner:
+        description: 'Runner type'
+        required: false
+        type: string
+        default: linux.8xlarge.memory
+      ref:
+        description: 'Git ref to checkout'
+        required: false
+        type: string
+        default: ${{ github.sha }}
+      timeout:
+        description: 'Job timeout in minutes'
+        required: false
+        type: number
+        default: 90
+
+jobs:
+  test-aot:
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    with:
+      job-name: test-aot
+      runner: ${{ inputs.runner }}
+      docker-image: ${{ inputs.docker-image }}
+      submodules: recursive
+      ref: ${{ inputs.ref }}
+      timeout: ${{ inputs.timeout }}
+      script: |
+        set -eux
+        conda create -y -n cadence_test python=3.12 > /dev/null
+        conda activate cadence_test
+
+        ./install_requirements.sh > /dev/null
+        pip install -e . --no-build-isolation > /dev/null
+        pip install beartype later pyre_extensions pytest-xdist
+
+        python -m pytest backends/cadence/aot/tests/ -v -n auto
+
+  test-ops:
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    with:
+      job-name: test-ops
+      runner: ${{ inputs.runner }}
+      docker-image: ${{ inputs.docker-image }}
+      submodules: recursive
+      ref: ${{ inputs.ref }}
+      timeout: ${{ inputs.timeout }}
+      download-artifact: cadence-runner-build
+      script: |
+        set -eux
+        conda create -y -n cadence_test python=3.12 > /dev/null
+        conda activate cadence_test
+
+        ./install_requirements.sh > /dev/null
+        pip install -e . --no-build-isolation > /dev/null
+        pip install beartype later pyre_extensions pytest-xdist
+
+        # Use the pre-built runner from the build job
+        mkdir -p cmake-out/backends/cadence
+        cp "${RUNNER_ARTIFACT_DIR}/cadence_runner" cmake-out/backends/cadence/cadence_runner
+        chmod +x cmake-out/backends/cadence/cadence_runner
+
+        export PYTHONPATH="${PYTHONPATH:-}:$(pwd)/backends/cadence/utils/FACTO"
+        python -m pytest examples/cadence/operators/ -v -n auto

--- a/.github/workflows/build-cadence-runner.yml
+++ b/.github/workflows/build-cadence-runner.yml
@@ -1,4 +1,4 @@
-name: Build Cadence
+name: Cadence Build & Test
 
 on:
   pull_request:
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  cpu:
+  cpu-build:
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     permissions:
       id-token: write
@@ -25,6 +25,7 @@ jobs:
       submodules: recursive
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout: 90
+      upload-artifact: cadence-runner-build
       script: |
         set -eux
         # The generic Linux job chooses to use base env, not the one setup by the image
@@ -33,3 +34,15 @@ jobs:
 
         ./install_requirements.sh > /dev/null
         bash backends/cadence/build_cadence_runner.sh
+
+        # Copy runner binary to artifact dir for downstream test jobs
+        cp cmake-out/backends/cadence/cadence_runner "${RUNNER_ARTIFACT_DIR}/"
+
+  cpu-test:
+    needs: cpu-build
+    permissions:
+      id-token: write
+      contents: read
+    uses: ./.github/workflows/_test_cadence.yml
+    with:
+      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}


### PR DESCRIPTION
Summary:
Splits Cadence CI into separate build and test jobs with artifact exchange. Build job compiles cadence_runner and uploads it. Test workflow has two parallel jobs: test-aot (Python AOT tests) and test-ops (operator tests using the pre-built runner). Uses linux.8xlarge.memory runners with pytest-xdist for parallel test execution.


Test Plan:
Cadence Build & Test OSS Signal  signal 
 {F1987662503} 

{F1987662009}

OP test failures are real issues which we are now able to detect 
 {F1987662014}

Reviewed By: zonglinpeng

Differential Revision: D99416668

Pulled By: aliafzal




cc @mcremon-meta