### PR TITLE
2/x: Introduce new ETCoreMLModelCache that adheres to cache protocol (#18682)

### DIFF
--- a/backends/apple/coreml/BUCK
+++ b/backends/apple/coreml/BUCK
@@ -18,6 +18,7 @@ runtime.cxx_library(
         "runtime/delegate/ETCoreMLDefaultModelExecutor.mm",
         "runtime/delegate/ETCoreMLLogging.mm",
         "runtime/delegate/ETCoreMLModel.mm",
+        "runtime/delegate/ETCoreMLModelCache.mm",
         "runtime/delegate/ETCoreMLModelCompiler.mm",
         "runtime/delegate/ETCoreMLModelLoader.mm",
         "runtime/delegate/ETCoreMLModelManager.mm",

--- a/backends/apple/coreml/CMakeLists.txt
+++ b/backends/apple/coreml/CMakeLists.txt
@@ -32,6 +32,7 @@ set(DELEGATE_SOURCES
     runtime/delegate/ETCoreMLAsset.mm
     runtime/delegate/ETCoreMLAssetManager.mm
     runtime/delegate/ETCoreMLDefaultModelExecutor.mm
+    runtime/delegate/ETCoreMLModelCache.mm
     runtime/delegate/ETCoreMLModelLoader.mm
     runtime/delegate/ETCoreMLModelCompiler.mm
     runtime/delegate/ETCoreMLLogging.mm

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLModelCache.h
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLModelCache.h
@@ -1,0 +1,141 @@
+//
+// ETCoreMLModelCache.h
+//
+// Copyright © 2024 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <Foundation/Foundation.h>
+
+#import "ETCoreMLCacheProtocol.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+extern NSString* const ETCoreMLModelCacheErrorDomain;
+
+typedef NS_ENUM(NSInteger, ETCoreMLModelCacheErrorCode) {
+    ETCoreMLModelCacheErrorCodeUnknown = 0,
+    ETCoreMLModelCacheErrorCodeInitializationFailed = 1,
+    ETCoreMLModelCacheErrorCodeInvalidIdentifier = 2,
+    ETCoreMLModelCacheErrorCodeSourceNotFound = 3,
+    ETCoreMLModelCacheErrorCodeDiskFull = 4,
+    ETCoreMLModelCacheErrorCodeIOError = 5,
+    ETCoreMLModelCacheErrorCodeCorruptedCache = 6,
+};
+
+/// A simplified, filesystem-based cache for compiled CoreML models.
+///
+/// This class provides a cache implementation that stores compiled models as directories
+/// in a versioned cache structure. It uses atomic writes (rename) to ensure cache integrity
+/// even in the presence of crashes or concurrent access.
+///
+/// Directory structure:
+/// ```
+/// cache_root/
+/// ├── version.txt                         (cache format version)
+/// ├── models/
+/// │   ├── {identifier}.mlmodelc/          (compiled model bundle)
+/// │   ├── {identifier}.accessed           (last access time for LRU eviction)
+/// │   └── ...
+/// └── temp/
+///     └── {uuid}/                         (mlpackage files awaiting compilation)
+/// ```
+///
+/// ## Thread Safety and Concurrency Guarantees
+///
+/// This class provides **NO internal synchronization**. It is designed to be used in one of
+/// two ways:
+///
+/// 1. **Single-threaded access**: All calls to a single instance from one thread/queue.
+///
+/// 2. **External serialization**: When used via `ETCoreMLModelManager`, access is serialized
+///    by the manager's per-identifier loading queue. This is the expected usage pattern.
+///
+/// **Multi-process safety** is provided by:
+/// - Atomic filesystem operations (`rename()`)
+/// - Unique temp paths (UUID-based) to avoid conflicts
+/// - "Last writer wins" semantics (acceptable since all writers produce identical output)
+///
+/// **Multiple instances** pointing to the same directory are safe because:
+/// - Each write uses a unique temp path
+/// - Final placement uses atomic `moveItemAtURL:` (POSIX `rename()`)
+/// - Concurrent writes result in "last writer wins" (both write identical data)
+/// - Cleanup only targets entries older than 24 hours
+///
+/// **Callers are responsible for**:
+/// - Handling `MLModel` load failures gracefully (cache entry may be replaced/deleted
+///   between URL retrieval and model load)
+/// - Not relying on returned URLs remaining valid indefinitely
+@interface ETCoreMLModelCache : NSObject <ETCoreMLCache>
+
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
+/// The root directory for all cache data (contains models/, temp/, version.txt).
+@property (nonatomic, readonly) NSURL* cacheRootDirectory;
+
+/// Whether the cache was initialized successfully and is ready for use.
+/// If NO, all operations will fail. Check this after initialization.
+@property (nonatomic, readonly, getter=isReady) BOOL ready;
+
+/// If `ready` is NO, this contains the error that occurred during initialization.
+@property (nonatomic, readonly, nullable) NSError* initializationError;
+
+/// Initializes the cache with the given root directory.
+/// Creates the directory structure if it doesn't exist.
+/// Check the `ready` property after initialization to verify success.
+/// If initialization fails, `initializationError` will contain the reason.
+///
+/// @param cacheRootDirectory The root directory for all cache data.
+- (instancetype)initWithCacheRootDirectory:(NSURL*)cacheRootDirectory NS_DESIGNATED_INITIALIZER;
+
+/// Returns the URL of a cached model if it exists and is valid, otherwise nil.
+///
+/// @param identifier The unique identifier for the cached model.
+/// @param error On failure, error is filled with the failure information.
+/// @return The URL to the cached model bundle, or nil if not found or invalid.
+///
+/// @warning The returned URL may become invalid before the caller uses it if another
+/// process deletes or replaces the cached model. Callers MUST handle MLModel load
+/// failures gracefully by treating them as cache misses and recompiling.
+- (nullable NSURL*)cachedModelURLForIdentifier:(NSString*)identifier error:(NSError**)error;
+
+/// Stores a compiled model in the cache. Returns the cached URL on success.
+///
+/// @param compiledModelURL The URL of the compiled model bundle to cache. Must exist.
+/// @param identifier The unique identifier for this model. Must not contain '/' or '..'.
+/// @param error On failure, contains the error. Check for ETCoreMLModelCacheErrorCodeDiskFull
+///              to handle out-of-space conditions specially.
+/// @return The URL of the cached model, or nil on failure.
+- (nullable NSURL*)storeModelAtURL:(NSURL*)compiledModelURL withIdentifier:(NSString*)identifier error:(NSError**)error;
+
+/// Removes a specific cached model. This is a best-effort operation that removes
+/// the model bundle and access time files for the given identifier.
+///
+/// @param identifier The unique identifier for the cached model to remove.
+/// @param error On failure, error is filled with the failure information.
+/// @return YES on success (including if the model didn't exist), NO on validation errors.
+- (BOOL)removeCachedModelWithIdentifier:(NSString*)identifier error:(NSError**)error;
+
+/// Clears the entire cache, including all cached models.
+/// Recreates the empty directory structure after clearing.
+///
+/// @param error On failure, error is filled with the failure information.
+/// @return YES if the cache was purged successfully, otherwise NO.
+- (BOOL)purgeAndReturnError:(NSError**)error;
+
+#pragma mark - Temp Directory (for mlpackage extraction before compilation)
+
+/// Returns a temp URL where an mlpackage can be extracted before compilation.
+/// The caller is responsible for cleaning up this directory after compilation completes.
+///
+/// @param error On failure, error is filled with the failure information.
+/// @return A temp URL where the mlpackage can be extracted, or nil on failure.
+///
+/// @note The temp URL is unique and includes a UUID to avoid conflicts.
+/// @note Temp entries are automatically cleaned up after 24 hours if not removed.
+- (nullable NSURL*)temporaryDirectoryWithError:(NSError**)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/backends/apple/coreml/runtime/delegate/ETCoreMLModelCache.mm
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLModelCache.mm
@@ -1,0 +1,496 @@
+//
+// ETCoreMLModelCache.mm
+//
+// Copyright © 2024 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import "ETCoreMLModelCache.h"
+
+#import "ETCoreMLLogging.h"
+
+NSString* const ETCoreMLModelCacheErrorDomain = @"com.executorch.coreml.cache";
+
+
+// Timing
+static NSTimeInterval const kStaleEntryTimeoutSeconds = 24 * 60 * 60; // 24 hours
+
+// Cache structure
+static NSString* const kCacheFormatVersion = @"1";
+static NSString* const kModelsDirectoryName = @"models";
+static NSString* const kTempDirectoryName = @"temp";
+static NSString* const kVersionFileName = @"version.txt";
+
+// File extensions (without leading dot - added during URL construction)
+static NSString* const kModelBundleExtension = @"mlmodelc";
+static NSString* const kAccessedFileExtension = @"accessed";
+
+@interface ETCoreMLModelCache ()
+@property (nonatomic, strong) NSURL* modelsDirectory;
+@property (nonatomic, strong) NSURL* tempDirectory;
+@property (nonatomic, readwrite, getter=isReady) BOOL ready;
+@property (nonatomic, readwrite, nullable) NSError* initializationError;
+@end
+
+@implementation ETCoreMLModelCache
+
+#pragma mark - Initialization
+
+- (instancetype)initWithCacheRootDirectory:(NSURL*)cacheRootDirectory {
+    self = [super init];
+    if (self) {
+        _cacheRootDirectory = cacheRootDirectory;
+        _modelsDirectory = [cacheRootDirectory URLByAppendingPathComponent:kModelsDirectoryName
+                                                               isDirectory:YES];
+        _tempDirectory = [cacheRootDirectory URLByAppendingPathComponent:kTempDirectoryName
+                                                             isDirectory:YES];
+
+        NSError* initError = nil;
+        _ready = [self initializeDirectoriesWithError:&initError];
+        _initializationError = initError;
+
+        if (_ready) {
+            // Cleanup stale entries synchronously during init.
+            // These operations are fast (just a directory scan and a few deletions)
+            // and only target entries older than 24 hours, so no race with active writes.
+            [self cleanupStaleEntriesInDirectory:_tempDirectory name:@"temp"];
+            [self cleanupOrphanedEntries];
+        }
+    }
+    return self;
+}
+
+- (BOOL)initializeDirectoriesWithError:(NSError**)error {
+    NSFileManager* fm = [NSFileManager defaultManager];
+
+    // Create all directories
+    NSArray<NSURL*>* directories = @[_cacheRootDirectory, _modelsDirectory, _tempDirectory];
+    for (NSURL* dir in directories) {
+        if (![fm createDirectoryAtURL:dir
+          withIntermediateDirectories:YES
+                           attributes:nil
+                                error:error]) {
+            return NO;
+        }
+        [self applyFileProtectionToDirectory:dir];
+    }
+
+    // Exclude from iCloud/iTunes backup. Only needed on root since this IS inherited
+    // by children. Cached compiled models are regenerable, so backing them up wastes
+    // the user's iCloud storage and backup time.
+    [_cacheRootDirectory setResourceValue:@YES forKey:NSURLIsExcludedFromBackupKey error:nil];
+
+    // Handle version file
+    NSURL* versionURL = [_cacheRootDirectory URLByAppendingPathComponent:kVersionFileName];
+    if ([fm fileExistsAtPath:versionURL.path]) {
+        // Validate existing version
+        NSString* existingVersion = [NSString stringWithContentsOfURL:versionURL
+                                                             encoding:NSUTF8StringEncoding
+                                                                error:nil];
+        if (existingVersion) {
+            existingVersion = [existingVersion stringByTrimmingCharactersInSet:
+                              [NSCharacterSet whitespaceAndNewlineCharacterSet]];
+        }
+
+        if (!existingVersion || ![existingVersion isEqualToString:kCacheFormatVersion]) {
+            // Version mismatch or unreadable - purge and recreate
+            if (existingVersion) {
+                ETCoreMLLogInfo("Cache version mismatch (found '%@', expected '%@'). Purging cache.",
+                                existingVersion, kCacheFormatVersion);
+            } else {
+                ETCoreMLLogInfo("Cache version file unreadable. Purging cache.");
+            }
+
+            // Remove all contents of models and temp directories
+            for (NSURL* dir in @[_modelsDirectory, _tempDirectory]) {
+                [self clearContentsOfDirectory:dir];
+            }
+
+            // Update version file
+            if (![kCacheFormatVersion writeToURL:versionURL
+                                      atomically:YES
+                                        encoding:NSUTF8StringEncoding
+                                           error:error]) {
+                return NO;
+            }
+        }
+    } else {
+        // Write new version file
+        if (![kCacheFormatVersion writeToURL:versionURL
+                                  atomically:YES
+                                    encoding:NSUTF8StringEncoding
+                                       error:error]) {
+            return NO;
+        }
+    }
+
+    return YES;
+}
+
+#pragma mark - Directory Utilities
+
+- (BOOL)ensureDirectoryExists:(NSURL*)directory error:(NSError**)error {
+    NSFileManager* fm = [NSFileManager defaultManager];
+
+    // Fast path: directory already exists
+    if ([fm fileExistsAtPath:directory.path]) {
+        return YES;
+    }
+
+    // Slow path: recreate directory (withIntermediateDirectories also recreates parents)
+    if (![fm createDirectoryAtURL:directory
+        withIntermediateDirectories:YES
+                         attributes:nil
+                              error:error]) {
+        return NO;
+    }
+
+    // Reapply file protection attribute to recreated directory
+    [self applyFileProtectionToDirectory:directory];
+    return YES;
+}
+
+- (void)applyFileProtectionToDirectory:(NSURL*)directory {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSDictionary* protectionAttrs = @{NSFileProtectionKey: NSFileProtectionCompleteUntilFirstUserAuthentication};
+    [fm setAttributes:protectionAttrs ofItemAtPath:directory.path error:nil]; // best-effort
+}
+
+- (void)clearContentsOfDirectory:(NSURL*)directory {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSArray* contents = [fm contentsOfDirectoryAtURL:directory
+                          includingPropertiesForKeys:nil
+                                             options:0
+                                               error:nil];
+    for (NSURL* item in contents) {
+        [fm removeItemAtURL:item error:nil];
+    }
+}
+
+#pragma mark - Identifier Validation
+
+- (BOOL)isValidIdentifier:(NSString*)identifier error:(NSError**)error {
+    if (identifier.length == 0) {
+        if (error) {
+            *error = [NSError errorWithDomain:ETCoreMLModelCacheErrorDomain
+                                         code:ETCoreMLModelCacheErrorCodeInvalidIdentifier
+                                     userInfo:@{NSLocalizedDescriptionKey: @"Identifier cannot be empty"}];
+        }
+        return NO;
+    }
+
+    if ([identifier containsString:@"/"] || [identifier containsString:@".."]) {
+        if (error) {
+            *error = [NSError errorWithDomain:ETCoreMLModelCacheErrorDomain
+                                         code:ETCoreMLModelCacheErrorCodeInvalidIdentifier
+                                     userInfo:@{NSLocalizedDescriptionKey:
+                                         @"Identifier cannot contain '/' or '..'"}];
+        }
+        return NO;
+    }
+
+    return YES;
+}
+
+- (BOOL)validateReadyAndIdentifier:(NSString*)identifier error:(NSError**)error {
+    if (!self.isReady) {
+        if (error) *error = self.initializationError;
+        return NO;
+    }
+    return [self isValidIdentifier:identifier error:error];
+}
+
+#pragma mark - URL Helpers
+
+- (NSURL*)modelURLForIdentifier:(NSString*)identifier {
+    NSString* bundleName = [NSString stringWithFormat:@"%@.%@", identifier, kModelBundleExtension];
+    return [_modelsDirectory URLByAppendingPathComponent:bundleName isDirectory:YES];
+}
+
+- (NSURL*)accessedURLForIdentifier:(NSString*)identifier {
+    NSString* fileName = [NSString stringWithFormat:@"%@.%@", identifier, kAccessedFileExtension];
+    return [_modelsDirectory URLByAppendingPathComponent:fileName isDirectory:NO];
+}
+
+#pragma mark - Cache Operations
+
+- (nullable NSURL*)cachedModelURLForIdentifier:(NSString*)identifier
+                                         error:(NSError**)error {
+    if (!self.isReady) {
+        if (error) *error = self.initializationError;
+        return nil;
+    }
+
+    NSFileManager* fm = [NSFileManager defaultManager];
+
+    // Check bundle exists (cheap stat() call)
+    NSURL* modelURL = [self modelURLForIdentifier:identifier];
+    BOOL isDirectory = NO;
+    if (![fm fileExistsAtPath:modelURL.path isDirectory:&isDirectory]) {
+        return nil;
+    }
+
+    if (!isDirectory) {
+        [fm removeItemAtURL:modelURL error:nil];
+        return nil;
+    }
+
+    // Update access time for LRU eviction (also recreates file if deleted externally)
+    [self touchAccessedFileForIdentifier:identifier];
+
+    return modelURL;
+}
+
+- (nullable NSURL*)storeModelAtURL:(NSURL*)compiledModelURL
+                    withIdentifier:(NSString*)identifier
+                             error:(NSError**)error {
+    if (![self validateReadyAndIdentifier:identifier error:error]) {
+        return nil;
+    }
+
+    if (![self ensureDirectoryExists:_modelsDirectory error:error]) {
+        return nil;
+    }
+
+    NSFileManager* fm = [NSFileManager defaultManager];
+    if (![fm fileExistsAtPath:compiledModelURL.path]) {
+        if (error) {
+            *error = [NSError errorWithDomain:ETCoreMLModelCacheErrorDomain
+                                         code:ETCoreMLModelCacheErrorCodeSourceNotFound
+                                     userInfo:@{NSLocalizedDescriptionKey:
+                                         @"Source model URL does not exist"}];
+        }
+        return nil;
+    }
+
+    // Remove existing model if present
+    NSURL* destURL = [self modelURLForIdentifier:identifier];
+    if ([fm fileExistsAtPath:destURL.path]) {
+        NSError* removeError = nil;
+        if (![fm removeItemAtURL:destURL error:&removeError]) {
+            if (error) {
+                *error = [NSError errorWithDomain:ETCoreMLModelCacheErrorDomain
+                                             code:ETCoreMLModelCacheErrorCodeIOError
+                                         userInfo:@{
+                                             NSLocalizedDescriptionKey: @"Cannot remove existing cached model",
+                                             NSUnderlyingErrorKey: removeError
+                                         }];
+            }
+            return nil;
+        }
+    }
+
+    // Remove any orphaned accessed file for this identifier
+    [fm removeItemAtURL:[self accessedURLForIdentifier:identifier] error:nil];
+
+    // Move source directly to final location (atomic if same filesystem)
+    NSError* moveError = nil;
+    if (![fm moveItemAtURL:compiledModelURL toURL:destURL error:&moveError]) {
+        if ([moveError.domain isEqualToString:NSCocoaErrorDomain] &&
+            moveError.code == NSFileWriteOutOfSpaceError) {
+            ETCoreMLLogInfo("Disk full while storing model: %@", identifier);
+            if (error) {
+                *error = [NSError errorWithDomain:ETCoreMLModelCacheErrorDomain
+                                             code:ETCoreMLModelCacheErrorCodeDiskFull
+                                         userInfo:@{
+                                             NSLocalizedDescriptionKey: @"Disk full",
+                                             NSUnderlyingErrorKey: moveError
+                                         }];
+            }
+        } else {
+            if (error) {
+                *error = [NSError errorWithDomain:ETCoreMLModelCacheErrorDomain
+                                             code:ETCoreMLModelCacheErrorCodeIOError
+                                         userInfo:@{
+                                             NSLocalizedDescriptionKey: @"Cannot move model to cache",
+                                             NSUnderlyingErrorKey: moveError
+                                         }];
+            }
+        }
+        return nil;
+    }
+
+    // Record access time for LRU eviction
+    [self touchAccessedFileForIdentifier:identifier];
+
+    return destURL;
+}
+
+- (BOOL)removeCachedModelWithIdentifier:(NSString*)identifier
+                                  error:(NSError**)error {
+    if (![self validateReadyAndIdentifier:identifier error:error]) {
+        return NO;
+    }
+
+    [self removeAllFilesForIdentifier:identifier];
+    return YES;
+}
+
+- (void)removeAllFilesForIdentifier:(NSString*)identifier {
+    NSFileManager* fm = [NSFileManager defaultManager];
+
+    // Remove all files for this identifier (best-effort, ignore errors)
+    [fm removeItemAtURL:[self modelURLForIdentifier:identifier] error:nil];
+    [fm removeItemAtURL:[self accessedURLForIdentifier:identifier] error:nil];
+}
+
+- (BOOL)purgeAndReturnError:(NSError**)error {
+    if (!self.isReady) {
+        if (error) *error = self.initializationError;
+        return NO;
+    }
+
+    NSFileManager* fm = [NSFileManager defaultManager];
+
+    // Remove models directory contents
+    if ([fm fileExistsAtPath:_modelsDirectory.path]) {
+        if (![fm removeItemAtURL:_modelsDirectory error:error]) {
+            return NO;
+        }
+    }
+
+    // Recreate all directories (in case any were deleted externally)
+    for (NSURL* dir in @[_cacheRootDirectory, _modelsDirectory, _tempDirectory]) {
+        if (![self ensureDirectoryExists:dir error:error]) {
+            return NO;
+        }
+    }
+
+    // Reapply file protection attributes
+    for (NSURL* dir in @[_cacheRootDirectory, _modelsDirectory, _tempDirectory]) {
+        [self applyFileProtectionToDirectory:dir];
+    }
+
+    // Clean temp contents
+    [self clearContentsOfDirectory:_tempDirectory];
+
+    return YES;
+}
+
+#pragma mark - Temp Directory (for mlpackage extraction before compilation)
+
+- (nullable NSURL*)temporaryDirectoryWithError:(NSError**)error {
+    if (!self.isReady) {
+        if (error) *error = self.initializationError;
+        return nil;
+    }
+
+    NSString* tempName = [NSUUID UUID].UUIDString;
+    NSURL* tempURL = [_tempDirectory URLByAppendingPathComponent:tempName isDirectory:YES];
+
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSError* createError = nil;
+    if (![fm createDirectoryAtURL:tempURL
+      withIntermediateDirectories:YES
+                       attributes:nil
+                            error:&createError]) {
+        if (error) *error = createError;
+        return nil;
+    }
+
+    [self applyFileProtectionToDirectory:tempURL];
+    return tempURL;
+}
+
+#pragma mark - Access Time Tracking
+
+- (void)touchAccessedFileForIdentifier:(NSString*)identifier {
+    NSURL* accessedURL = [self accessedURLForIdentifier:identifier];
+    NSFileManager* fm = [NSFileManager defaultManager];
+
+    if ([fm fileExistsAtPath:accessedURL.path]) {
+        // Update mtime
+        NSDictionary* attrs = @{NSFileModificationDate: [NSDate date]};
+        [fm setAttributes:attrs ofItemAtPath:accessedURL.path error:nil];
+    } else {
+        // Create empty file
+        [fm createFileAtPath:accessedURL.path contents:nil attributes:nil];
+    }
+}
+
+- (NSTimeInterval)lastAccessTimeForIdentifier:(NSString*)identifier {
+    NSURL* accessedURL = [self accessedURLForIdentifier:identifier];
+    NSDate* mtime;
+    if ([accessedURL getResourceValue:&mtime forKey:NSURLContentModificationDateKey error:nil] && mtime) {
+        return mtime.timeIntervalSince1970;
+    }
+    return 0;
+}
+
+#pragma mark - Cleanup
+
+- (void)cleanupStaleEntriesInDirectory:(NSURL*)directory name:(NSString*)name {
+    NSFileManager* fm = [NSFileManager defaultManager];
+    NSArray* contents = [fm contentsOfDirectoryAtURL:directory
+                          includingPropertiesForKeys:@[NSURLCreationDateKey]
+                                             options:0
+                                               error:nil];
+
+    NSDate* cutoff = [NSDate dateWithTimeIntervalSinceNow:-kStaleEntryTimeoutSeconds];
+    NSUInteger cleanedCount = 0;
+
+    for (NSURL* url in contents) {
+        NSDate* creationDate;
+        [url getResourceValue:&creationDate forKey:NSURLCreationDateKey error:nil];
+
+        if (creationDate && [creationDate compare:cutoff] == NSOrderedAscending) {
+            if ([fm removeItemAtURL:url error:nil]) {
+                cleanedCount++;
+            }
+        }
+    }
+
+    if (cleanedCount > 0) {
+        ETCoreMLLogInfo("Cleaned up %lu stale %@ entries", (unsigned long)cleanedCount, name);
+    }
+}
+
+- (void)cleanupOrphanedEntries {
+    NSFileManager* fm = [NSFileManager defaultManager];
+
+    NSArray* contents = [fm contentsOfDirectoryAtURL:_modelsDirectory
+                          includingPropertiesForKeys:@[NSURLIsDirectoryKey]
+                                             options:0
+                                               error:nil];
+    if (!contents) {
+        return;
+    }
+
+    // Collect identifiers from bundles and accessed files
+    NSMutableSet<NSString*>* bundleIdentifiers = [NSMutableSet set];
+    NSMutableSet<NSString*>* accessedIdentifiers = [NSMutableSet set];
+
+    NSString* modelExtWithDot = [NSString stringWithFormat:@".%@", kModelBundleExtension];
+    NSString* accessedExtWithDot = [NSString stringWithFormat:@".%@", kAccessedFileExtension];
+
+    for (NSURL* url in contents) {
+        NSString* lastComponent = url.lastPathComponent;
+
+        if ([lastComponent hasSuffix:modelExtWithDot]) {
+            NSString* identifier = [lastComponent substringToIndex:lastComponent.length - modelExtWithDot.length];
+            [bundleIdentifiers addObject:identifier];
+        } else if ([lastComponent hasSuffix:accessedExtWithDot]) {
+            NSString* identifier = [lastComponent substringToIndex:lastComponent.length - accessedExtWithDot.length];
+            [accessedIdentifiers addObject:identifier];
+        }
+    }
+
+    NSUInteger orphanedAccessed = 0;
+
+    // .accessed without bundle → delete .accessed
+    for (NSString* identifier in accessedIdentifiers) {
+        if (![bundleIdentifiers containsObject:identifier]) {
+            NSURL* accessedURL = [self accessedURLForIdentifier:identifier];
+            if ([fm removeItemAtURL:accessedURL error:nil]) {
+                orphanedAccessed++;
+            }
+        }
+    }
+
+    if (orphanedAccessed > 0) {
+        ETCoreMLLogInfo("Cleaned up %lu orphaned accessed files",
+                        (unsigned long)orphanedAccessed);
+    }
+}
+
+@end

--- a/backends/apple/coreml/runtime/test/ETCoreMLModelCacheTests.mm
+++ b/backends/apple/coreml/runtime/test/ETCoreMLModelCacheTests.mm
@@ -1,0 +1,465 @@
+//
+// ETCoreMLModelCacheTests.mm
+//
+// Copyright © 2024 Apple Inc. All rights reserved.
+//
+// Please refer to the license found in the LICENSE file in the root directory of the source tree.
+
+#import <XCTest/XCTest.h>
+
+#import "ETCoreMLModelCache.h"
+
+@interface ETCoreMLModelCacheTests : XCTestCase
+
+@property (strong, nonatomic, nullable) ETCoreMLModelCache *cache;
+@property (strong, nonatomic, nullable) NSFileManager *fileManager;
+@property (copy, nonatomic) NSURL *testDirectoryURL;
+@property (copy, nonatomic) NSURL *cacheRootURL;
+
+@end
+
+@implementation ETCoreMLModelCacheTests
+
+- (void)setUp {
+    [super setUp];
+    self.fileManager = [[NSFileManager alloc] init];
+    self.testDirectoryURL = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:[NSUUID UUID].UUIDString]];
+    self.cacheRootURL = [self.testDirectoryURL URLByAppendingPathComponent:@"cache"];
+
+    // ETCoreMLModelCache creates its directory structure in init
+    self.cache = [[ETCoreMLModelCache alloc] initWithCacheRootDirectory:self.cacheRootURL];
+    XCTAssertTrue(self.cache.isReady, @"Cache should be ready after initialization: %@", self.cache.initializationError);
+}
+
+- (void)tearDown {
+    self.cache = nil;
+    NSError *error = nil;
+    if ([self.fileManager fileExistsAtPath:self.testDirectoryURL.path]) {
+        [self.fileManager removeItemAtURL:self.testDirectoryURL error:&error];
+    }
+    self.fileManager = nil;
+    [super tearDown];
+}
+
+#pragma mark - Helper Methods
+
+- (NSURL *)createMockCompiledModelWithIdentifier:(NSString *)identifier {
+    // Create a mock .mlmodelc directory structure
+    NSURL *modelURL = [[self.testDirectoryURL URLByAppendingPathComponent:identifier] URLByAppendingPathExtension:@"mlmodelc"];
+    NSError *error = nil;
+
+    XCTAssertTrue([self.fileManager createDirectoryAtURL:modelURL withIntermediateDirectories:YES attributes:@{} error:&error],
+                  @"Failed to create mock model directory: %@", error);
+
+    // Add a mock model.mil file with identifier-specific content
+    NSURL *modelFileURL = [modelURL URLByAppendingPathComponent:@"model.mil"];
+    NSString *mockContent = [NSString stringWithFormat:@"mock model data for %@", identifier];
+    NSData *mockData = [mockContent dataUsingEncoding:NSUTF8StringEncoding];
+    [mockData writeToURL:modelFileURL atomically:YES];
+
+    // Add a mock coremldata.bin file
+    NSURL *dataFileURL = [modelURL URLByAppendingPathComponent:@"coremldata.bin"];
+    NSData *mockBinaryData = [[NSData alloc] initWithBytes:"binary" length:6];
+    [mockBinaryData writeToURL:dataFileURL atomically:YES];
+
+    return modelURL;
+}
+
+#pragma mark - Initialization Tests
+
+- (void)testInitializationCreatesDirectoryStructure {
+    XCTAssertTrue(self.cache.isReady);
+    XCTAssertNil(self.cache.initializationError);
+
+    // Verify directory structure exists
+    BOOL isDirectory = NO;
+    XCTAssertTrue([self.fileManager fileExistsAtPath:self.cacheRootURL.path isDirectory:&isDirectory]);
+    XCTAssertTrue(isDirectory);
+
+    // Verify models directory exists
+    NSURL *modelsURL = [self.cacheRootURL URLByAppendingPathComponent:@"models"];
+    XCTAssertTrue([self.fileManager fileExistsAtPath:modelsURL.path isDirectory:&isDirectory]);
+    XCTAssertTrue(isDirectory);
+
+    // Verify temp directory exists
+    NSURL *tempURL = [self.cacheRootURL URLByAppendingPathComponent:@"temp"];
+    XCTAssertTrue([self.fileManager fileExistsAtPath:tempURL.path isDirectory:&isDirectory]);
+    XCTAssertTrue(isDirectory);
+
+    // Verify version.txt exists
+    NSURL *versionURL = [self.cacheRootURL URLByAppendingPathComponent:@"version.txt"];
+    XCTAssertTrue([self.fileManager fileExistsAtPath:versionURL.path]);
+}
+
+- (void)testInitializationWithExistingDirectory {
+    // Create a second cache pointing to the same directory
+    ETCoreMLModelCache *cache2 = [[ETCoreMLModelCache alloc] initWithCacheRootDirectory:self.cacheRootURL];
+    XCTAssertTrue(cache2.isReady);
+    XCTAssertNil(cache2.initializationError);
+}
+
+#pragma mark - Store and Retrieve Tests
+
+- (void)testStoreAndRetrieveModel {
+    NSString *identifier = @"test_model_123";
+    NSURL *sourceModelURL = [self createMockCompiledModelWithIdentifier:identifier];
+
+    NSError *error = nil;
+    NSURL *cachedURL = [self.cache storeModelAtURL:sourceModelURL withIdentifier:identifier error:&error];
+
+    XCTAssertNotNil(cachedURL, @"Store should return cached URL");
+    XCTAssertNil(error, @"Store should not produce error: %@", error);
+    XCTAssertTrue([self.fileManager fileExistsAtPath:cachedURL.path], @"Cached model should exist");
+
+    // Retrieve the model
+    NSURL *retrievedURL = [self.cache cachedModelURLForIdentifier:identifier error:&error];
+
+    XCTAssertNotNil(retrievedURL, @"Should retrieve cached model URL");
+    XCTAssertNil(error, @"Retrieve should not produce error: %@", error);
+    XCTAssertEqualObjects(cachedURL.path, retrievedURL.path, @"Retrieved URL should match stored URL");
+}
+
+- (void)testRetrieveNonExistentModelReturnsNil {
+    NSError *error = nil;
+    NSURL *retrievedURL = [self.cache cachedModelURLForIdentifier:@"nonexistent_model" error:&error];
+
+    XCTAssertNil(retrievedURL, @"Should return nil for non-existent model");
+    // Cache miss is not an error - just returns nil
+    XCTAssertNil(error, @"Cache miss should not produce error");
+}
+
+- (void)testStoreModelOverwritesExisting {
+    NSString *identifier = @"overwrite_test";
+
+    // Store first version
+    NSURL *sourceModelURL1 = [self createMockCompiledModelWithIdentifier:@"source1"];
+    NSError *error = nil;
+    NSURL *cachedURL1 = [self.cache storeModelAtURL:sourceModelURL1 withIdentifier:identifier error:&error];
+    XCTAssertNotNil(cachedURL1);
+
+    // Store second version with same identifier
+    NSURL *sourceModelURL2 = [self createMockCompiledModelWithIdentifier:@"source2"];
+    NSURL *cachedURL2 = [self.cache storeModelAtURL:sourceModelURL2 withIdentifier:identifier error:&error];
+    XCTAssertNotNil(cachedURL2);
+
+    // Retrieve should return the latest
+    NSURL *retrievedURL = [self.cache cachedModelURLForIdentifier:identifier error:&error];
+    XCTAssertNotNil(retrievedURL);
+    XCTAssertTrue([self.fileManager fileExistsAtPath:retrievedURL.path]);
+
+    // Verify content matches source2, not source1
+    NSURL *modelFileURL = [retrievedURL URLByAppendingPathComponent:@"model.mil"];
+    NSString *content = [NSString stringWithContentsOfURL:modelFileURL encoding:NSUTF8StringEncoding error:&error];
+    XCTAssertNil(error, @"Should be able to read model.mil: %@", error);
+    XCTAssertEqualObjects(content, @"mock model data for source2",
+                          @"Retrieved model should contain content from the second store, not the first");
+}
+
+#pragma mark - Remove Tests
+
+- (void)testRemoveCachedModel {
+    NSString *identifier = @"model_to_remove";
+    NSURL *sourceModelURL = [self createMockCompiledModelWithIdentifier:identifier];
+
+    NSError *error = nil;
+    [self.cache storeModelAtURL:sourceModelURL withIdentifier:identifier error:&error];
+    XCTAssertNil(error);
+
+    // Verify model exists
+    NSURL *cachedURL = [self.cache cachedModelURLForIdentifier:identifier error:&error];
+    XCTAssertNotNil(cachedURL);
+
+    // Remove the model
+    BOOL success = [self.cache removeCachedModelWithIdentifier:identifier error:&error];
+    XCTAssertTrue(success, @"Remove should succeed");
+    XCTAssertNil(error, @"Remove should not produce error: %@", error);
+
+    // Verify model no longer exists
+    NSURL *retrievedURL = [self.cache cachedModelURLForIdentifier:identifier error:&error];
+    XCTAssertNil(retrievedURL, @"Model should no longer exist after removal");
+}
+
+- (void)testRemoveNonExistentModelSucceeds {
+    NSError *error = nil;
+    BOOL success = [self.cache removeCachedModelWithIdentifier:@"nonexistent" error:&error];
+
+    // Removing non-existent model should succeed (idempotent)
+    XCTAssertTrue(success, @"Remove should succeed even for non-existent model");
+    XCTAssertNil(error);
+}
+
+#pragma mark - Purge Tests
+
+- (void)testPurgeRemovesAllCachedModels {
+    // Store multiple models
+    NSArray *identifiers = @[@"model_a", @"model_b", @"model_c"];
+    NSError *error = nil;
+
+    for (NSString *identifier in identifiers) {
+        NSURL *sourceURL = [self createMockCompiledModelWithIdentifier:identifier];
+        [self.cache storeModelAtURL:sourceURL withIdentifier:identifier error:&error];
+        XCTAssertNil(error);
+    }
+
+    // Verify all models exist
+    for (NSString *identifier in identifiers) {
+        NSURL *cachedURL = [self.cache cachedModelURLForIdentifier:identifier error:&error];
+        XCTAssertNotNil(cachedURL, @"Model %@ should exist before purge", identifier);
+    }
+
+    // Purge the cache
+    BOOL success = [self.cache purgeAndReturnError:&error];
+    XCTAssertTrue(success, @"Purge should succeed");
+    XCTAssertNil(error, @"Purge should not produce error: %@", error);
+
+    // Verify all models are gone
+    for (NSString *identifier in identifiers) {
+        NSURL *cachedURL = [self.cache cachedModelURLForIdentifier:identifier error:&error];
+        XCTAssertNil(cachedURL, @"Model %@ should not exist after purge", identifier);
+    }
+
+    // Cache should still be usable after purge
+    XCTAssertTrue(self.cache.isReady);
+}
+
+#pragma mark - Temporary Directory Tests
+
+- (void)testTemporaryDirectoryCreation {
+    NSError *error = nil;
+
+    NSURL *tempURL = [self.cache temporaryDirectoryWithError:&error];
+    XCTAssertNotNil(tempURL, @"Should return temp URL");
+    XCTAssertNil(error, @"Temp URL should not produce error: %@", error);
+
+    // Verify temp URL is in the temp directory
+    XCTAssertTrue([tempURL.path containsString:@"temp"], @"Temp URL should be in temp directory");
+
+    // Verify directory was created
+    BOOL isDirectory = NO;
+    XCTAssertTrue([self.fileManager fileExistsAtPath:tempURL.path isDirectory:&isDirectory]);
+    XCTAssertTrue(isDirectory, @"Temp URL should be a directory");
+}
+
+- (void)testMultipleTemporaryDirectoriesAreUnique {
+    NSError *error = nil;
+
+    NSURL *tempURL1 = [self.cache temporaryDirectoryWithError:&error];
+    NSURL *tempURL2 = [self.cache temporaryDirectoryWithError:&error];
+
+    XCTAssertNotNil(tempURL1);
+    XCTAssertNotNil(tempURL2);
+    XCTAssertNotEqualObjects(tempURL1.path, tempURL2.path, @"Each temp URL should be unique");
+}
+
+#pragma mark - Identifier Validation Tests
+
+- (void)testInvalidIdentifierWithSlash {
+    NSString *invalidIdentifier = @"path/to/model";
+    NSURL *sourceURL = [self createMockCompiledModelWithIdentifier:@"valid"];
+
+    NSError *error = nil;
+    NSURL *cachedURL = [self.cache storeModelAtURL:sourceURL withIdentifier:invalidIdentifier error:&error];
+
+    XCTAssertNil(cachedURL, @"Store should fail for identifier with slash");
+    XCTAssertNotNil(error, @"Should produce error for invalid identifier");
+    XCTAssertEqual(error.code, ETCoreMLModelCacheErrorCodeInvalidIdentifier);
+}
+
+- (void)testInvalidIdentifierWithDotDot {
+    NSString *invalidIdentifier = @"model..name";
+    NSURL *sourceURL = [self createMockCompiledModelWithIdentifier:@"valid"];
+
+    NSError *error = nil;
+    NSURL *cachedURL = [self.cache storeModelAtURL:sourceURL withIdentifier:invalidIdentifier error:&error];
+
+    XCTAssertNil(cachedURL, @"Store should fail for identifier with ..");
+    XCTAssertNotNil(error, @"Should produce error for invalid identifier");
+    XCTAssertEqual(error.code, ETCoreMLModelCacheErrorCodeInvalidIdentifier);
+}
+
+- (void)testEmptyIdentifier {
+    NSURL *sourceURL = [self createMockCompiledModelWithIdentifier:@"valid"];
+
+    NSError *error = nil;
+    NSURL *cachedURL = [self.cache storeModelAtURL:sourceURL withIdentifier:@"" error:&error];
+
+    XCTAssertNil(cachedURL, @"Store should fail for empty identifier");
+    XCTAssertNotNil(error, @"Should produce error for empty identifier");
+    XCTAssertEqual(error.code, ETCoreMLModelCacheErrorCodeInvalidIdentifier);
+}
+
+#pragma mark - Source Not Found Tests
+
+- (void)testStoreNonExistentSourceFails {
+    NSURL *nonExistentURL = [self.testDirectoryURL URLByAppendingPathComponent:@"nonexistent.mlmodelc"];
+
+    NSError *error = nil;
+    NSURL *cachedURL = [self.cache storeModelAtURL:nonExistentURL withIdentifier:@"test" error:&error];
+
+    XCTAssertNil(cachedURL, @"Store should fail for non-existent source");
+    XCTAssertNotNil(error, @"Should produce error for non-existent source");
+    XCTAssertEqual(error.code, ETCoreMLModelCacheErrorCodeSourceNotFound);
+}
+
+#pragma mark - Multiple Identifiers Tests
+
+- (void)testMultipleModelsWithDifferentIdentifiers {
+    NSError *error = nil;
+
+    // Store model A
+    NSURL *sourceA = [self createMockCompiledModelWithIdentifier:@"sourceA"];
+    NSURL *cachedA = [self.cache storeModelAtURL:sourceA withIdentifier:@"model_A" error:&error];
+    XCTAssertNotNil(cachedA);
+
+    // Store model B
+    NSURL *sourceB = [self createMockCompiledModelWithIdentifier:@"sourceB"];
+    NSURL *cachedB = [self.cache storeModelAtURL:sourceB withIdentifier:@"model_B" error:&error];
+    XCTAssertNotNil(cachedB);
+
+    // Retrieve both and verify they're different
+    NSURL *retrievedA = [self.cache cachedModelURLForIdentifier:@"model_A" error:&error];
+    NSURL *retrievedB = [self.cache cachedModelURLForIdentifier:@"model_B" error:&error];
+
+    XCTAssertNotNil(retrievedA);
+    XCTAssertNotNil(retrievedB);
+    XCTAssertNotEqualObjects(retrievedA.path, retrievedB.path);
+
+    // Remove one, verify the other still exists
+    [self.cache removeCachedModelWithIdentifier:@"model_A" error:&error];
+
+    XCTAssertNil([self.cache cachedModelURLForIdentifier:@"model_A" error:&error]);
+    XCTAssertNotNil([self.cache cachedModelURLForIdentifier:@"model_B" error:&error]);
+}
+
+#pragma mark - Access Time Tests
+
+- (void)testAccessFileIsCreatedOnStore {
+    NSString *identifier = @"access_test_model";
+    NSURL *sourceModelURL = [self createMockCompiledModelWithIdentifier:identifier];
+
+    NSError *error = nil;
+    NSURL *cachedURL = [self.cache storeModelAtURL:sourceModelURL withIdentifier:identifier error:&error];
+    XCTAssertNotNil(cachedURL);
+    XCTAssertNil(error);
+
+    // Verify .accessed file exists after store
+    NSURL *modelsURL = [self.cacheRootURL URLByAppendingPathComponent:@"models"];
+    NSString *accessedFilename = [identifier stringByAppendingString:@".accessed"];
+    NSURL *accessedURL = [modelsURL URLByAppendingPathComponent:accessedFilename];
+
+    XCTAssertTrue([self.fileManager fileExistsAtPath:accessedURL.path],
+                  @"Accessed file should be created after store");
+}
+
+- (void)testAccessTimeUpdatedOnRetrieval {
+    // Access time is updated on retrieval (cache hit during model load) to support
+    // future LRU eviction. This is NOT called during predict — only during load.
+    NSString *identifier = @"access_time_model";
+    NSURL *sourceModelURL = [self createMockCompiledModelWithIdentifier:identifier];
+
+    NSError *error = nil;
+    [self.cache storeModelAtURL:sourceModelURL withIdentifier:identifier error:&error];
+    XCTAssertNil(error);
+
+    // Verify .accessed file exists after store
+    NSURL *modelsURL = [self.cacheRootURL URLByAppendingPathComponent:@"models"];
+    NSString *accessedFilename = [identifier stringByAppendingString:@".accessed"];
+    NSURL *accessedURL = [modelsURL URLByAppendingPathComponent:accessedFilename];
+
+    XCTAssertTrue([self.fileManager fileExistsAtPath:accessedURL.path],
+                  @"Accessed file should be created after store");
+
+    // Get initial modification time
+    NSDictionary *initialAttrs = [self.fileManager attributesOfItemAtPath:accessedURL.path error:&error];
+    XCTAssertNil(error);
+    NSDate *initialModTime = initialAttrs[NSFileModificationDate];
+    XCTAssertNotNil(initialModTime);
+
+    // Wait a small amount to ensure time difference would be measurable
+    [NSThread sleepForTimeInterval:1.0];
+
+    // Retrieve the model (should update access time)
+    NSURL *retrievedURL = [self.cache cachedModelURLForIdentifier:identifier error:&error];
+    XCTAssertNotNil(retrievedURL);
+
+    // Verify .accessed file WAS updated
+    NSDictionary *newAttrs = [self.fileManager attributesOfItemAtPath:accessedURL.path error:&error];
+    XCTAssertNil(error);
+    NSDate *newModTime = newAttrs[NSFileModificationDate];
+    XCTAssertNotNil(newModTime);
+
+    XCTAssertEqual([newModTime compare:initialModTime], NSOrderedDescending,
+                   @"Access time should be updated on retrieval (model load)");
+}
+
+#pragma mark - Multiple Cache Instances Tests
+
+- (void)testMultipleCacheInstancesSameDirectory {
+    // Create two cache instances pointing to the same directory
+    ETCoreMLModelCache *cache1 = self.cache;
+    ETCoreMLModelCache *cache2 = [[ETCoreMLModelCache alloc] initWithCacheRootDirectory:self.cacheRootURL];
+
+    XCTAssertTrue(cache1.isReady);
+    XCTAssertTrue(cache2.isReady);
+
+    NSError *error = nil;
+
+    // Store via cache1
+    NSString *identifier1 = @"cache1_model";
+    NSURL *source1 = [self createMockCompiledModelWithIdentifier:@"source1"];
+    NSURL *cached1 = [cache1 storeModelAtURL:source1 withIdentifier:identifier1 error:&error];
+    XCTAssertNotNil(cached1);
+    XCTAssertNil(error);
+
+    // Retrieve via cache2 (should see the model stored by cache1)
+    NSURL *retrieved1 = [cache2 cachedModelURLForIdentifier:identifier1 error:&error];
+    XCTAssertNotNil(retrieved1, @"Cache2 should be able to retrieve model stored by cache1");
+    XCTAssertNil(error);
+
+    // Store via cache2
+    NSString *identifier2 = @"cache2_model";
+    NSURL *source2 = [self createMockCompiledModelWithIdentifier:@"source2"];
+    NSURL *cached2 = [cache2 storeModelAtURL:source2 withIdentifier:identifier2 error:&error];
+    XCTAssertNotNil(cached2);
+    XCTAssertNil(error);
+
+    // Retrieve via cache1 (should see the model stored by cache2)
+    NSURL *retrieved2 = [cache1 cachedModelURLForIdentifier:identifier2 error:&error];
+    XCTAssertNotNil(retrieved2, @"Cache1 should be able to retrieve model stored by cache2");
+    XCTAssertNil(error);
+
+    // Both caches can see both models
+    XCTAssertNotNil([cache1 cachedModelURLForIdentifier:identifier1 error:&error]);
+    XCTAssertNotNil([cache1 cachedModelURLForIdentifier:identifier2 error:&error]);
+    XCTAssertNotNil([cache2 cachedModelURLForIdentifier:identifier1 error:&error]);
+    XCTAssertNotNil([cache2 cachedModelURLForIdentifier:identifier2 error:&error]);
+}
+
+- (void)testConcurrentStoresSameIdentifier {
+    // Two caches storing the same identifier should both succeed (last writer wins)
+    ETCoreMLModelCache *cache1 = self.cache;
+    ETCoreMLModelCache *cache2 = [[ETCoreMLModelCache alloc] initWithCacheRootDirectory:self.cacheRootURL];
+
+    NSString *identifier = @"contested_model";
+    NSError *error = nil;
+
+    // Store via cache1
+    NSURL *source1 = [self createMockCompiledModelWithIdentifier:@"source1"];
+    NSURL *cached1 = [cache1 storeModelAtURL:source1 withIdentifier:identifier error:&error];
+    XCTAssertNotNil(cached1);
+
+    // Store via cache2 with same identifier (should overwrite)
+    NSURL *source2 = [self createMockCompiledModelWithIdentifier:@"source2"];
+    NSURL *cached2 = [cache2 storeModelAtURL:source2 withIdentifier:identifier error:&error];
+    XCTAssertNotNil(cached2);
+
+    // Both caches should be able to retrieve (they'll get the same model - last writer)
+    NSURL *retrieved1 = [cache1 cachedModelURLForIdentifier:identifier error:&error];
+    NSURL *retrieved2 = [cache2 cachedModelURLForIdentifier:identifier error:&error];
+
+    XCTAssertNotNil(retrieved1);
+    XCTAssertNotNil(retrieved2);
+    XCTAssertEqualObjects(retrieved1.path, retrieved2.path, @"Both caches should retrieve the same model");
+}
+
+@end

--- a/backends/apple/coreml/runtime/workspace/executorchcoreml.xcodeproj/project.pbxproj
+++ b/backends/apple/coreml/runtime/workspace/executorchcoreml.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		83BB78A02C65DA7300274ED7 /* ETCoreMLModelDebugInfo.mm in Sources */ = {isa = PBXBuildFile; fileRef = 83BB789F2C65DA7300274ED7 /* ETCoreMLModelDebugInfo.mm */; };
 		83BB78BF2C66AAAE00274ED7 /* add_mul_coreml_all.bin in Resources */ = {isa = PBXBuildFile; fileRef = 83BB78BD2C66AAAE00274ED7 /* add_mul_coreml_all.bin */; };
 		83BB78C02C66AAAE00274ED7 /* add_mul_coreml_all.pte in Resources */ = {isa = PBXBuildFile; fileRef = 83BB78BE2C66AAAE00274ED7 /* add_mul_coreml_all.pte */; };
+		9029E4192F6CAED800530A64 /* ETCoreMLModelCache.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9029E4182F6CAED800530A64 /* ETCoreMLModelCache.mm */; };
+		905118692F3FBCCE00BFB5B7 /* ETCoreMLModelCacheTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 905118682F3FBCCE00BFB5B7 /* ETCoreMLModelCacheTests.mm */; };
 		C945E8E02B997ECE009C3FAC /* ETCoreMLModelProfiler.mm in Sources */ = {isa = PBXBuildFile; fileRef = C945E8CF2B997ECD009C3FAC /* ETCoreMLModelProfiler.mm */; };
 		C945E8E12B997ECE009C3FAC /* ETCoreMLModelAnalyzer.mm in Sources */ = {isa = PBXBuildFile; fileRef = C945E8D42B997ECD009C3FAC /* ETCoreMLModelAnalyzer.mm */; };
 		C945E8E22B997ECE009C3FAC /* program_path.mm in Sources */ = {isa = PBXBuildFile; fileRef = C945E8D52B997ECD009C3FAC /* program_path.mm */; };
@@ -128,6 +130,9 @@
 		83BB789F2C65DA7300274ED7 /* ETCoreMLModelDebugInfo.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = ETCoreMLModelDebugInfo.mm; path = ../sdk/ETCoreMLModelDebugInfo.mm; sourceTree = "<group>"; };
 		83BB78BD2C66AAAE00274ED7 /* add_mul_coreml_all.bin */ = {isa = PBXFileReference; lastKnownFileType = archive.macbinary; name = add_mul_coreml_all.bin; path = ../test/models/add_mul_coreml_all.bin; sourceTree = "<group>"; };
 		83BB78BE2C66AAAE00274ED7 /* add_mul_coreml_all.pte */ = {isa = PBXFileReference; lastKnownFileType = file; name = add_mul_coreml_all.pte; path = ../test/models/add_mul_coreml_all.pte; sourceTree = "<group>"; };
+		9029E4172F6CAED800530A64 /* ETCoreMLModelCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ETCoreMLModelCache.h; path = ../delegate/ETCoreMLModelCache.h; sourceTree = "<group>"; };
+		9029E4182F6CAED800530A64 /* ETCoreMLModelCache.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = ETCoreMLModelCache.mm; path = ../delegate/ETCoreMLModelCache.mm; sourceTree = "<group>"; };
+		905118682F3FBCCE00BFB5B7 /* ETCoreMLModelCacheTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = ETCoreMLModelCacheTests.mm; path = ../test/ETCoreMLModelCacheTests.mm; sourceTree = "<group>"; };
 		C945E8CD2B997ECD009C3FAC /* ETCoreMLModelProfiler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ETCoreMLModelProfiler.h; path = ../sdk/ETCoreMLModelProfiler.h; sourceTree = "<group>"; };
 		C945E8CE2B997ECD009C3FAC /* ETCoreMLModelAnalyzer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ETCoreMLModelAnalyzer.h; path = ../sdk/ETCoreMLModelAnalyzer.h; sourceTree = "<group>"; };
 		C945E8CF2B997ECD009C3FAC /* ETCoreMLModelProfiler.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = ETCoreMLModelProfiler.mm; path = ../sdk/ETCoreMLModelProfiler.mm; sourceTree = "<group>"; };
@@ -461,6 +466,8 @@
 		C952663E2A7E06510016283E /* delegate */ = {
 			isa = PBXGroup;
 			children = (
+				9029E4172F6CAED800530A64 /* ETCoreMLModelCache.h */,
+				9029E4182F6CAED800530A64 /* ETCoreMLModelCache.mm */,
 				C9E7D7AB2AB55AC100CCAE5D /* com.apple.executorchcoreml_config.plist */,
 				C9D3DFAF2AA12097001CC178 /* asset.h */,
 				C9D3DFBC2AA84FC6001CC178 /* asset.mm */,
@@ -582,6 +589,7 @@
 		C9E7D7852AB3F99A00CCAE5D /* test */ = {
 			isa = PBXGroup;
 			children = (
+				905118682F3FBCCE00BFB5B7 /* ETCoreMLModelCacheTests.mm */,
 				C9E7D78C2AB3F9BF00CCAE5D /* BackendDelegateTests.mm */,
 				C9E7D7A12AB3FBB200CCAE5D /* CoreMLBackendDelegateTests.mm */,
 				C9E7D78A2AB3F9BF00CCAE5D /* DatabaseTests.mm */,
@@ -739,6 +747,7 @@
 				C9E7D78F2AB3F9BF00CCAE5D /* ETCoreMLTestUtils.mm in Sources */,
 				C945E93A2B997EEE009C3FAC /* MIL.pb.cc in Sources */,
 				C94D51002ABDF83C00AF47FD /* ETCoreMLAssetManager.mm in Sources */,
+				9029E4192F6CAED800530A64 /* ETCoreMLModelCache.mm in Sources */,
 				C945E93E2B997EEE009C3FAC /* Model.pb.cc in Sources */,
 				C945E9362B997EEE009C3FAC /* Identity.pb.cc in Sources */,
 				C94D50EE2ABDF81B00AF47FD /* memory_buffer.cpp in Sources */,
@@ -772,6 +781,7 @@
 				C94D50ED2ABDF81900AF47FD /* inmemory_filesystem.cpp in Sources */,
 				C945E94B2B997EEE009C3FAC /* Normalizer.pb.cc in Sources */,
 				C94D50FA2ABDF83200AF47FD /* multiarray.mm in Sources */,
+				905118692F3FBCCE00BFB5B7 /* ETCoreMLModelCacheTests.mm in Sources */,
 				C9E7D7952AB3F9BF00CCAE5D /* ETCoreMLModelManagerTests.mm in Sources */,
 				C945E9382B997EEE009C3FAC /* Imputer.pb.cc in Sources */,
 				C945E92F2B997EEE009C3FAC /* CategoricalMapping.pb.cc in Sources */,
@@ -830,7 +840,7 @@
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
-                                        "C10_USING_CUSTOM_GENERATED_MACROS",
+					C10_USING_CUSTOM_GENERATED_MACROS,
 					"$(inherited)",
 				);
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -912,7 +922,7 @@
 				DEVELOPMENT_TEAM = "";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
-                                        "C10_USING_CUSTOM_GENERATED_MACROS",
+					C10_USING_CUSTOM_GENERATED_MACROS,
 					"ET_EVENT_TRACER_ENABLED=1",
 					"$(inherited)",
 				);

--- a/backends/apple/coreml/runtime/workspace/executorchcoreml.xcodeproj/xcshareddata/xcschemes/executorchcoreml_tests.xcscheme
+++ b/backends/apple/coreml/runtime/workspace/executorchcoreml.xcodeproj/xcshareddata/xcschemes/executorchcoreml_tests.xcscheme
@@ -51,13 +51,8 @@
       </EnvironmentVariables>
       <AdditionalOptions>
          <AdditionalOption
-            key = "MallocStackLogging"
+            key = "MallocScribble"
             value = ""
-            isEnabled = "YES">
-         </AdditionalOption>
-         <AdditionalOption
-            key = "DYLD_INSERT_LIBRARIES"
-            value = "/usr/lib/libgmalloc.dylib"
             isEnabled = "YES">
          </AdditionalOption>
          <AdditionalOption
@@ -66,18 +61,18 @@
             isEnabled = "YES">
          </AdditionalOption>
          <AdditionalOption
-            key = "NSZombieEnabled"
-            value = "YES"
-            isEnabled = "YES">
-         </AdditionalOption>
-         <AdditionalOption
             key = "MallocGuardEdges"
             value = ""
             isEnabled = "YES">
          </AdditionalOption>
          <AdditionalOption
-            key = "MallocScribble"
+            key = "MallocStackLogging"
             value = ""
+            isEnabled = "YES">
+         </AdditionalOption>
+         <AdditionalOption
+            key = "NSZombieEnabled"
+            value = "YES"
             isEnabled = "YES">
          </AdditionalOption>
       </AdditionalOptions>


### PR DESCRIPTION
Summary:

This is diff 2/9 to implement the new caching system for CoreML, following the design doc here: fbcode/executorch/backends/apple/coreml/docs/new_cache_design.md

[ gdoc version: https://docs.google.com/document/d/1aKwTNj-L3-sAyBetL92RwJdSsSwA4KhvAQ3FO1zbguE/edit?tab=t.0#heading=h.3ecu6rvzx1z3 ]

The design doc contains detailed plans for each diff in the stack, see https://fburl.com/gdoc/h4vincwz for what this diff does.

Reviewed By: digantdesai

Differential Revision: D91183831


