### PR TITLE
Add macOS SDK support to ExecuTorch Swift wrapper (#18688)

### DIFF
--- a/extension/apple/BUCK
+++ b/extension/apple/BUCK
@@ -1,5 +1,5 @@
 load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target", "non_fbcode_target")
-load("@fbsource//tools/build_defs:platform_defs.bzl", "IOS")
+load("@fbsource//tools/build_defs:platform_defs.bzl", "IOS", "MACOSX")
 load("@fbsource//tools/build_defs/apple:fb_apple_library.bzl", "fb_apple_library")
 load("@fbsource//tools/build_defs/apple:fb_apple_resource.bzl", "fb_apple_resource")
 load("@fbsource//xplat/executorch/build/fb:clients.bzl", "EXECUTORCH_CLIENTS")
@@ -21,17 +21,24 @@ non_fbcode_target(_kind = fb_apple_library,
         "-Wno-switch-enum",  # @cwt-override FIXME[T153556462]
         "-Wno-switch-default",
     ],
-    sdks = IOS,
+    sdks = (IOS, MACOSX),
     test_deps = [
         ":ExecuTorchTestResource",
         "//xplat/executorch/kernels/portable:generated_libApple",
     ],
     visibility = EXECUTORCH_CLIENTS,
-    deps = [
-        "//xplat/executorch/extension/module:moduleApple",
-        "//xplat/executorch/extension/tensor:tensorApple",
-        "//xplat/executorch/runtime/platform:platformApple",
-    ],
+    deps = select({
+        "ovr_config//os:macos": [
+            "//xplat/executorch/extension/module:moduleAppleMac",
+            "//xplat/executorch/extension/tensor:tensorAppleMac",
+            "//xplat/executorch/runtime/platform:platformAppleMac",
+        ],
+        "DEFAULT": [
+            "//xplat/executorch/extension/module:moduleApple",
+            "//xplat/executorch/extension/tensor:tensorApple",
+            "//xplat/executorch/runtime/platform:platformApple",
+        ],
+    }),
 )
 
 fb_apple_resource(


### PR DESCRIPTION
Summary:

Add MACOSX to the ExecuTorch Swift wrapper's supported SDKs and use
platform-specific deps via select() to resolve the correct Apple vs
AppleMac suffixed C++ targets per platform. This enables macOS binaries
to link ExecuTorch without platform variant conflicts (duplicate symbols
from mixing Apple and AppleMac transitive deps).

Reviewed By: shoumikhin

Differential Revision: D99333988
