### PR TITLE
Add supressions to ARM StaticCacheModule

### DIFF
--- a/backends/arm/test/modules/test_static_cache.py
+++ b/backends/arm/test/modules/test_static_cache.py
@@ -80,8 +80,8 @@ class StaticCacheModule(torch.nn.Module):
         )
 
         for i in range(len(self.cache.layers)):
-            self.register_buffer(f"cache_layer_keys_{i}", self.cache.layers[i].keys)
-            self.register_buffer(f"cache_layer_values_{i}", self.cache.layers[i].values)
+            self.register_buffer(f"cache_layer_keys_{i}", self.cache.layers[i].keys)  # type: ignore[union-attr]
+            self.register_buffer(f"cache_layer_values_{i}", self.cache.layers[i].values)  # type: ignore[union-attr]
 
     def forward(
         self,


### PR DESCRIPTION
### Summary
Transformers 5.5 release changed one of the cache types to become a union. Not all union variants have .key and .value, so mypy complains. The code is sound, so just suppress the error since we know what the actual cache type is.

### Test plan
Verified lint passes locally and in CI.