### PR TITLE
Fix #18654: Add safe_numel()

### DIFF
--- a/runtime/core/portable_type/tensor_impl.cpp
+++ b/runtime/core/portable_type/tensor_impl.cpp
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <limits>
 
 #include <c10/util/irange.h>
 
@@ -66,6 +67,25 @@ TensorImpl::TensorImpl(
   ET_CHECK_MSG(
       isValid(type_), "Invalid type %" PRId8, static_cast<int8_t>(type_));
   ET_CHECK_MSG(dim_ >= 0, "Dimension must be non-negative, got %zd", dim_);
+}
+
+Result<ssize_t> TensorImpl::safe_numel() const {
+  ssize_t numel = 1;
+  for (const auto i : c10::irange(dim_)) {
+    ET_CHECK_OR_RETURN_ERROR(
+        sizes_[i] >= 0,
+        InvalidArgument,
+        "Size must be non-negative, got %zd at dimension %zd",
+        static_cast<ssize_t>(sizes_[i]),
+        i);
+    ET_CHECK_OR_RETURN_ERROR(
+        sizes_[i] == 0 ||
+            numel <= std::numeric_limits<ssize_t>::max() / sizes_[i],
+        InvalidArgument,
+        "Tensor numel overflows ssize_t");
+    numel *= sizes_[i];
+  }
+  return numel;
 }
 
 size_t TensorImpl::nbytes() const {

--- a/runtime/core/portable_type/tensor_impl.h
+++ b/runtime/core/portable_type/tensor_impl.h
@@ -10,6 +10,7 @@
 
 #include <executorch/runtime/core/array_ref.h>
 #include <executorch/runtime/core/error.h>
+#include <executorch/runtime/core/result.h>
 #include <executorch/runtime/core/portable_type/device.h>
 #include <executorch/runtime/core/portable_type/scalar_type.h>
 #include <executorch/runtime/core/tensor_shape_dynamism.h>
@@ -148,6 +149,12 @@ class TensorImpl {
   ssize_t numel() const {
     return numel_;
   }
+
+  /**
+   * Returns the number of elements in the tensor, or an error if the result
+   * would overflow ssize_t.
+   */
+  Result<ssize_t> safe_numel() const;
 
   /// Returns the type of the elements in the tensor (int32, float, bool, etc).
   ScalarType scalar_type() const {

--- a/runtime/core/portable_type/test/tensor_impl_test.cpp
+++ b/runtime/core/portable_type/test/tensor_impl_test.cpp
@@ -10,6 +10,7 @@
 #include <executorch/runtime/core/portable_type/tensor_impl.h>
 
 #include <gtest/gtest.h>
+#include <limits>
 #include <random>
 
 #include <executorch/runtime/core/exec_aten/util/tensor_util.h>
@@ -39,6 +40,33 @@ class TensorImplTest : public ::testing::Test {
     executorch::runtime::runtime_init();
   }
 };
+
+TEST_F(TensorImplTest, SafeNumelReturnsCorrectValue) {
+  SizesType sizes[2] = {3, 2};
+  TensorImpl t(ScalarType::Float, 2, sizes);
+  auto result = t.safe_numel();
+  ASSERT_TRUE(result.ok());
+  EXPECT_EQ(*result, 6);
+}
+
+TEST_F(TensorImplTest, SafeNumelScalar) {
+  TensorImpl t(ScalarType::Float, 0, nullptr);
+  auto result = t.safe_numel();
+  ASSERT_TRUE(result.ok());
+  EXPECT_EQ(*result, 1);
+}
+
+TEST_F(TensorImplTest, SafeNumelOverflowReturnsError) {
+  // Three large dimensions whose product overflows ssize_t on any platform:
+  // On 64-bit: INT32_MAX^2 * 3 > INT64_MAX; on 32-bit: INT32_MAX^2 > INT32_MAX.
+  SizesType sizes[3] = {
+      std::numeric_limits<SizesType>::max(),
+      std::numeric_limits<SizesType>::max(),
+      3};
+  TensorImpl t(ScalarType::Float, 3, sizes);
+  auto result = t.safe_numel();
+  EXPECT_FALSE(result.ok());
+}
 
 TEST_F(TensorImplTest, TestCtorAndGetters) {
   SizesType sizes[2] = {3, 2};


### PR DESCRIPTION
Closes #18654

### Summary
Adds `TensorImpl::safe_numel()`, a bounds-checked alternative to `numel()` that returns a `Result<ssize_t>` instead of silently overflowing.

The existing `numel_` member is computed in the `TensorImpl` constructor and stored as a plain integer, meaning overflow goes undetected and can lead to heap overflows. Because `numel()` is called directly in constructors and must remain ABI/BC-compatible with ATen, we cannot change its return type. Instead, `safe_numel()` is introduced as a new method that callers can opt into when they need overflow safety.

**Changes:**
- `runtime/core/portable_type/tensor_impl.h`: Adds the `Result<ssize_t> safe_numel() const` declaration and includes `result.h`.
- `runtime/core/portable_type/tensor_impl.cpp`: Implements `safe_numel()` by iterating over `sizes_` and checking for overflow before each multiply using `numel <= std::numeric_limits<ssize_t>::max() / sizes_[i]`. Returns `InvalidArgument` if any dimension is negative or if the product would overflow `ssize_t`. Includes `<limits>` for `std::numeric_limits`.

### Test plan
Three new unit tests added in `runtime/core/portable_type/test/tensor_impl_test.cpp`:

- `SafeNumelReturnsCorrectValue`: verifies that a `{3, 2}` tensor returns `6`.
- `SafeNumelScalar`: verifies that a 0-dim tensor (no sizes) returns `1`.
- `SafeNumelOverflowReturnsError`: constructs a tensor with dimensions `{INT32_MAX, INT32_MAX, 3}`, whose product overflows `ssize_t` on both 32-bit and 64-bit platforms, and asserts that `safe_numel()` returns a non-ok `Result`.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*

cc @larryliu0820 @JacobSzwejbka @lucylq