### PR TITLE
Add dynamic shape tests for xnnpack model tests

### DIFF
--- a/backends/xnnpack/test/models/deeplab_v3.py
+++ b/backends/xnnpack/test/models/deeplab_v3.py
@@ -22,6 +22,24 @@ class DL3Wrapper(torch.nn.Module):
         return self.m(*args)["out"]
 
 
+class DynamicDL3Wrapper(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.m = deeplabv3_resnet50(
+            weights=deeplabv3.DeepLabV3_ResNet50_Weights.DEFAULT
+        )
+
+    def forward(self, x):
+        x = torch.nn.functional.interpolate(
+            x,
+            size=(224, 224),
+            mode="bilinear",
+            align_corners=True,
+            antialias=False,
+        )
+        return self.m(x)["out"]
+
+
 class TestDeepLabV3(unittest.TestCase):
     def setUp(self):
         torch._dynamo.reset()
@@ -29,11 +47,27 @@ class TestDeepLabV3(unittest.TestCase):
     dl3 = DL3Wrapper()
     dl3 = dl3.eval()
     model_inputs = (torch.randn(1, 3, 224, 224),)
+    dynamic_shapes = (
+        {
+            2: torch.export.Dim("height", min=224, max=455),
+            3: torch.export.Dim("width", min=224, max=455),
+        },
+    )
 
     def test_fp32_dl3(self):
 
         (
             Tester(self.dl3, self.model_inputs)
+            .export()
+            .to_edge_transform_and_lower()
+            .to_executorch()
+            .serialize()
+            .run_method_and_compare_outputs()
+        )
+
+    def test_fp32_dl3_dynamic(self):
+        (
+            Tester(DynamicDL3Wrapper(), self.model_inputs, self.dynamic_shapes)
             .export()
             .to_edge_transform_and_lower()
             .to_executorch()

--- a/backends/xnnpack/test/models/edsr.py
+++ b/backends/xnnpack/test/models/edsr.py
@@ -13,12 +13,34 @@ from executorch.backends.xnnpack.test.tester.tester import Quantize
 from torchsr.models import edsr_r16f64
 
 
+class DynamicEDSR(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.model = edsr_r16f64(2, False).eval()
+
+    def forward(self, x):
+        x = torch.nn.functional.interpolate(
+            x,
+            size=(224, 224),
+            mode="bilinear",
+            align_corners=True,
+            antialias=False,
+        )
+        return self.model(x)
+
+
 class TestEDSR(unittest.TestCase):
     def setUp(self):
         torch._dynamo.reset()
 
     edsr = edsr_r16f64(2, False).eval()  # noqa
     model_inputs = (torch.randn(1, 3, 224, 224),)
+    dynamic_shapes = (
+        {
+            2: torch.export.Dim("height", min=224, max=455),
+            3: torch.export.Dim("width", min=224, max=455),
+        },
+    )
 
     def test_fp32_edsr(self):
         (
@@ -47,6 +69,16 @@ class TestEDSR(unittest.TestCase):
         (
             Tester(self.edsr, self.model_inputs)
             .quantize(Quantize(calibrate=False))
+            .export()
+            .to_edge_transform_and_lower()
+            .to_executorch()
+            .serialize()
+            .run_method_and_compare_outputs()
+        )
+
+    def test_fp32_edsr_dynamic(self):
+        (
+            Tester(DynamicEDSR(), self.model_inputs, self.dynamic_shapes)
             .export()
             .to_edge_transform_and_lower()
             .to_executorch()

--- a/backends/xnnpack/test/models/emformer_rnnt.py
+++ b/backends/xnnpack/test/models/emformer_rnnt.py
@@ -48,6 +48,24 @@ class TestEmformerModel(unittest.TestCase):
             .run_method_and_compare_outputs()
         )
 
+    def test_fp32_emformer_joiner_dynamic(self):
+        joiner = self.Joiner()
+        dynamic_shapes = (
+            {0: torch.export.Dim("batch", min=1, max=4)},
+            None,
+            {0: torch.export.Dim("batch", min=1, max=4)},
+            None,
+        )
+        (
+            Tester(joiner, joiner.get_example_inputs(), dynamic_shapes=dynamic_shapes)
+            .export()
+            .to_edge_transform_and_lower()
+            .check(["torch.ops.higher_order.executorch_call_delegate"])
+            .to_executorch()
+            .serialize()
+            .run_method_and_compare_outputs()
+        )
+
     class Predictor(EmformerRnnt):
         def forward(self, a, b):
             return self.rnnt.predict(a, b, None)
@@ -89,6 +107,26 @@ class TestEmformerModel(unittest.TestCase):
         transcriber = self.Transcriber()
         (
             Tester(transcriber, transcriber.get_example_inputs())
+            .export()
+            .to_edge_transform_and_lower()
+            .check(["torch.ops.higher_order.executorch_call_delegate"])
+            .to_executorch()
+            .serialize()
+            .run_method_and_compare_outputs()
+        )
+
+    def test_fp32_emformer_transcriber_dynamic(self):
+        transcriber = self.Transcriber()
+        dynamic_shapes = (
+            {0: torch.export.Dim("batch", min=1, max=4)},
+            None,
+        )
+        (
+            Tester(
+                transcriber,
+                transcriber.get_example_inputs(),
+                dynamic_shapes=dynamic_shapes,
+            )
             .export()
             .to_edge_transform_and_lower()
             .check(["torch.ops.higher_order.executorch_call_delegate"])

--- a/backends/xnnpack/test/models/inception_v3.py
+++ b/backends/xnnpack/test/models/inception_v3.py
@@ -12,12 +12,34 @@ from executorch.backends.xnnpack.test.tester.tester import Quantize
 from torchvision import models
 
 
+class DynamicInceptionV3(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.model = models.inception_v3(weights="IMAGENET1K_V1").eval()
+
+    def forward(self, x):
+        x = torch.nn.functional.interpolate(
+            x,
+            size=(224, 224),
+            mode="bilinear",
+            align_corners=True,
+            antialias=False,
+        )
+        return self.model(x)
+
+
 class TestInceptionV3(unittest.TestCase):
     def setUp(self):
         torch._dynamo.reset()
 
     ic3 = models.inception_v3(weights="IMAGENET1K_V1").eval()  # noqa
     model_inputs = (torch.randn(1, 3, 224, 224),)
+    dynamic_shapes = (
+        {
+            2: torch.export.Dim("height", min=224, max=455),
+            3: torch.export.Dim("width", min=224, max=455),
+        },
+    )
 
     all_operators = {
         "executorch_exir_dialects_edge__ops_aten_addmm_default",
@@ -78,6 +100,17 @@ class TestInceptionV3(unittest.TestCase):
             .to_edge_transform_and_lower()
             .check(["torch.ops.higher_order.executorch_call_delegate"])
             .check_not(list(ops_after_quantization))
+            .to_executorch()
+            .serialize()
+            .run_method_and_compare_outputs()
+        )
+
+    def test_fp32_ic3_dynamic(self):
+        (
+            Tester(DynamicInceptionV3(), self.model_inputs, self.dynamic_shapes)
+            .export()
+            .to_edge_transform_and_lower()
+            .check(["torch.ops.higher_order.executorch_call_delegate"])
             .to_executorch()
             .serialize()
             .run_method_and_compare_outputs()

--- a/backends/xnnpack/test/models/inception_v4.py
+++ b/backends/xnnpack/test/models/inception_v4.py
@@ -11,12 +11,34 @@ from executorch.backends.xnnpack.test.tester import Tester
 from timm.models import inception_v4
 
 
+class DynamicInceptionV4(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.model = inception_v4(pretrained=False).eval()
+
+    def forward(self, x):
+        x = torch.nn.functional.interpolate(
+            x,
+            size=(299, 299),
+            mode="bilinear",
+            align_corners=True,
+            antialias=False,
+        )
+        return self.model(x)
+
+
 class TestInceptionV4(unittest.TestCase):
     def setUp(self):
         torch._dynamo.reset()
 
     ic4 = inception_v4(pretrained=False).eval()
     model_inputs = (torch.randn(3, 299, 299).unsqueeze(0),)
+    dynamic_shapes = (
+        {
+            2: torch.export.Dim("height", min=299, max=455),
+            3: torch.export.Dim("width", min=299, max=455),
+        },
+    )
 
     all_operators = {
         "executorch_exir_dialects_edge__ops_aten_addmm_default",
@@ -56,6 +78,17 @@ class TestInceptionV4(unittest.TestCase):
             .to_edge_transform_and_lower()
             .check(["torch.ops.higher_order.executorch_call_delegate"])
             .check_not(list(ops_after_quantization))
+            .to_executorch()
+            .serialize()
+            .run_method_and_compare_outputs()
+        )
+
+    def test_fp32_ic4_dynamic(self):
+        (
+            Tester(DynamicInceptionV4(), self.model_inputs, self.dynamic_shapes)
+            .export()
+            .to_edge_transform_and_lower()
+            .check(["torch.ops.higher_order.executorch_call_delegate"])
             .to_executorch()
             .serialize()
             .run_method_and_compare_outputs()

--- a/backends/xnnpack/test/models/mobilebert.py
+++ b/backends/xnnpack/test/models/mobilebert.py
@@ -31,6 +31,10 @@ class TestMobilebert(unittest.TestCase):
         "executorch_exir_dialects_edge__ops_aten_constant_pad_nd_default",
     }
 
+    dynamic_shapes = (
+        {1: torch.export.Dim("seq_length", min=2, max=32)},
+    )
+
     def test_fp32_mobilebert(self):
         (
             Tester(self.mobilebert, self.example_inputs)
@@ -49,6 +53,21 @@ class TestMobilebert(unittest.TestCase):
             .export()
             .to_edge_transform_and_lower()
             .check_not(list(self.supported_ops))
+            .to_executorch()
+            .serialize()
+            .run_method_and_compare_outputs(inputs=self.example_inputs)
+        )
+
+    def test_fp32_mobilebert_dynamic(self):
+        (
+            Tester(
+                self.mobilebert,
+                self.example_inputs,
+                dynamic_shapes=self.dynamic_shapes,
+            )
+            .export()
+            .to_edge_transform_and_lower()
+            .check(["torch.ops.higher_order.executorch_call_delegate"])
             .to_executorch()
             .serialize()
             .run_method_and_compare_outputs(inputs=self.example_inputs)

--- a/backends/xnnpack/test/models/mobilebert.py
+++ b/backends/xnnpack/test/models/mobilebert.py
@@ -31,9 +31,7 @@ class TestMobilebert(unittest.TestCase):
         "executorch_exir_dialects_edge__ops_aten_constant_pad_nd_default",
     }
 
-    dynamic_shapes = (
-        {1: torch.export.Dim("seq_length", min=2, max=32)},
-    )
+    dynamic_shapes = ({1: torch.export.Dim("seq_length", min=2, max=32)},)
 
     def test_fp32_mobilebert(self):
         (


### PR DESCRIPTION
## Summary

Add dynamic shape tests for xnnpack model tests that previously only tested with static inputs, as requested in #11585.

**Models covered:**
- **DeepLab V3** — dynamic height/width with DynamicWrapper + interpolate
- **EDSR** — dynamic height/width with DynamicWrapper + interpolate
- **Inception V3/V4** — dynamic height/width with DynamicWrapper + interpolate
- **Emformer RNNT** — dynamic batch dimension for joiner and transcriber
- **MobileBERT** — dynamic sequence length

All dynamic tests follow the established pattern from `resnet.py` (`DynamicResNet`) and `torchvision_vit.py` (`DynamicViT`): a wrapper module that resizes dynamic spatial inputs to fixed dimensions via `F.interpolate` before feeding into the model.

**Models already covered by existing dynamic tests (no changes):**
- MobileNet V2, MobileNet V3, ResNet, ViT

**Models skipped:**
- `llama2_et_example.py` — LLM, requires separate dynamic shape strategy
- `very_big_model.py` — synthetic test model

<details>
<summary>Before (only static tests)</summary>

```
$ python -m pytest backends/xnnpack/test/models/deeplab_v3.py -v
backends/xnnpack/test/models/deeplab_v3.py::TestDeepLabV3::test_fp32_dl3 PASSED

(no dynamic shape test exists)
```

</details>

<details>
<summary>After (static + dynamic tests pass)</summary>

```
$ python -m pytest backends/xnnpack/test/models/deeplab_v3.py::TestDeepLabV3::test_fp32_dl3_dynamic -v
backends/xnnpack/test/models/deeplab_v3.py::TestDeepLabV3::test_fp32_dl3_dynamic PASSED [100%]
======================== 1 passed in 28.84s ==============================

$ python -m pytest backends/xnnpack/test/models/mobilebert.py::TestMobilebert::test_fp32_mobilebert_dynamic -v
backends/xnnpack/test/models/mobilebert.py::TestMobilebert::test_fp32_mobilebert_dynamic PASSED [100%]
======================== 1 passed in 160.79s (0:02:40) ===================
```

</details>

## Test plan
- [x] `test_fp32_dl3_dynamic` passes locally
- [x] `test_fp32_mobilebert_dynamic` passes locally
- [ ] CI xnnpack test suite passes

cc @GregoryComer @digantdesai @cbilgin