### PR TITLE
Add Python runtime end-to-end tests for XNNPACK on Linux

### DIFF
--- a/runtime/test/TARGETS
+++ b/runtime/test/TARGETS
@@ -21,3 +21,14 @@ runtime.python_test(
         "//executorch/devtools/etdump:serialize",
     ],
 )
+
+runtime.python_test(
+    name = "test_runtime_xnnpack",
+    srcs = ["test_runtime_xnnpack.py"],
+    deps = [
+        "//caffe2:torch",
+        "//executorch/backends/xnnpack/partition:xnnpack_partitioner",
+        "//executorch/exir:lib",
+        "//executorch/runtime:runtime",
+    ],
+)

--- a/runtime/test/test_runtime_xnnpack.py
+++ b/runtime/test/test_runtime_xnnpack.py
@@ -4,33 +4,33 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-"""End-to-end tests that export models with XNNPACK delegation and verify
-them through the Python runtime.
+"""Python runtime end-to-end tests for the XNNPACK backend on Linux.
 
-Covers the export → .pte → Python runtime flow that developers use to
-validate exported models before deploying to device.  Complements the
-existing C++ runner tests in .ci/scripts/test_model.sh.
+Covers the export -> .pte -> Python runtime flow that developers use to
+validate exported models before deploying to device. Placing these tests
+under ``runtime/test`` lets the standard unittest jobs collect them cleanly.
 
 See https://github.com/pytorch/executorch/issues/11225
 """
 
+import sys
 import tempfile
 import unittest
 from pathlib import Path
 
 import torch
-from executorch.backends.xnnpack.partition.xnnpack_partitioner import (
-    XnnpackPartitioner,
-)
+from executorch.backends.xnnpack.partition.xnnpack_partitioner import XnnpackPartitioner
 from executorch.exir import EdgeCompileConfig, to_edge_transform_and_lower
 from executorch.runtime import Runtime, Verification
 from torch.export import export
 
 
-def _export_and_load(model: torch.nn.Module, example_inputs: tuple):
-    """Export *model* with XNNPACK, save to a temp .pte, load via Runtime."""
-    model.eval()
-    with torch.no_grad():
+def _export_and_execute(
+    model: torch.nn.Module, example_inputs: tuple[torch.Tensor, ...]
+):
+    """Export *model* with XNNPACK, save to a temp .pte, and run it via Runtime."""
+    with tempfile.TemporaryDirectory() as temp_dir, torch.no_grad():
+        model.eval()
         aten = export(model, example_inputs, strict=True)
         edge = to_edge_transform_and_lower(
             aten,
@@ -39,16 +39,19 @@ def _export_and_load(model: torch.nn.Module, example_inputs: tuple):
         )
         et = edge.to_executorch()
 
-    with tempfile.NamedTemporaryFile(suffix=".pte", delete=False) as f:
-        pte_path = f.name
-    et.save(pte_path)
+        pte_path = Path(temp_dir) / "xnnpack_runtime_test.pte"
+        et.save(str(pte_path))
 
-    rt = Runtime.get()
-    program = rt.load_program(Path(pte_path), verification=Verification.Minimal)
-    return program.load_method("forward"), pte_path
+        runtime = Runtime.get()
+        program = runtime.load_program(pte_path, verification=Verification.Minimal)
+        return program.load_method("forward").execute(example_inputs)
 
 
-class TestPythonRuntimeXNNPACK(unittest.TestCase):
+@unittest.skipUnless(
+    sys.platform == "linux",
+    "XNNPACK Python runtime end-to-end coverage in this batch targets Linux only",
+)
+class RuntimeXNNPACKTest(unittest.TestCase):
     """Export → .pte → Python Runtime tests for XNNPACK on Linux."""
 
     # ------------------------------------------------------------------
@@ -61,10 +64,9 @@ class TestPythonRuntimeXNNPACK(unittest.TestCase):
 
         model = Add()
         inputs = (torch.randn(2, 3), torch.randn(2, 3))
-        method, _ = _export_and_load(model, inputs)
 
         expected = model(*inputs)
-        actual = method.execute(inputs)
+        actual = _export_and_execute(model, inputs)
         torch.testing.assert_close(actual[0], expected, atol=1e-4, rtol=1e-4)
 
     # ------------------------------------------------------------------
@@ -73,11 +75,10 @@ class TestPythonRuntimeXNNPACK(unittest.TestCase):
     def test_linear(self):
         model = torch.nn.Linear(16, 8)
         inputs = (torch.randn(4, 16),)
-        method, _ = _export_and_load(model, inputs)
 
         with torch.no_grad():
             expected = model(*inputs)
-        actual = method.execute(inputs)
+        actual = _export_and_execute(model, inputs)
         torch.testing.assert_close(actual[0], expected, atol=1e-4, rtol=1e-4)
 
     # ------------------------------------------------------------------
@@ -89,11 +90,10 @@ class TestPythonRuntimeXNNPACK(unittest.TestCase):
             torch.nn.ReLU(),
         )
         inputs = (torch.randn(1, 3, 8, 8),)
-        method, _ = _export_and_load(model, inputs)
 
         with torch.no_grad():
             expected = model(*inputs)
-        actual = method.execute(inputs)
+        actual = _export_and_execute(model, inputs)
         torch.testing.assert_close(actual[0], expected, atol=1e-3, rtol=1e-3)
 
     # ------------------------------------------------------------------
@@ -106,11 +106,10 @@ class TestPythonRuntimeXNNPACK(unittest.TestCase):
             torch.nn.Linear(64, 10),
         )
         inputs = (torch.randn(2, 32),)
-        method, _ = _export_and_load(model, inputs)
 
         with torch.no_grad():
             expected = model(*inputs)
-        actual = method.execute(inputs)
+        actual = _export_and_execute(model, inputs)
         torch.testing.assert_close(actual[0], expected, atol=1e-3, rtol=1e-3)
 
     # ------------------------------------------------------------------
@@ -127,11 +126,10 @@ class TestPythonRuntimeXNNPACK(unittest.TestCase):
         )
         model.eval()
         inputs = (torch.randn(1, 3, 8, 8),)
-        method, _ = _export_and_load(model, inputs)
 
         with torch.no_grad():
             expected = model(*inputs)
-        actual = method.execute(inputs)
+        actual = _export_and_execute(model, inputs)
         torch.testing.assert_close(actual[0], expected, atol=1e-3, rtol=1e-3)
 
     # ------------------------------------------------------------------
@@ -147,11 +145,10 @@ class TestPythonRuntimeXNNPACK(unittest.TestCase):
             torch.nn.ReLU(),
         )
         inputs = (torch.randn(1, 16, 8, 8),)
-        method, _ = _export_and_load(model, inputs)
 
         with torch.no_grad():
             expected = model(*inputs)
-        actual = method.execute(inputs)
+        actual = _export_and_execute(model, inputs)
         torch.testing.assert_close(actual[0], expected, atol=1e-3, rtol=1e-3)
 
     # ------------------------------------------------------------------
@@ -171,11 +168,10 @@ class TestPythonRuntimeXNNPACK(unittest.TestCase):
 
         model = ClassifierHead()
         inputs = (torch.randn(1, 32, 8, 8),)
-        method, _ = _export_and_load(model, inputs)
 
         with torch.no_grad():
             expected = model(*inputs)
-        actual = method.execute(inputs)
+        actual = _export_and_execute(model, inputs)
         torch.testing.assert_close(actual[0], expected, atol=1e-3, rtol=1e-3)
 
 

--- a/runtime/test/test_runtime_xnnpack.py
+++ b/runtime/test/test_runtime_xnnpack.py
@@ -44,7 +44,9 @@ def _export_and_execute(
 
         runtime = Runtime.get()
         program = runtime.load_program(pte_path, verification=Verification.Minimal)
-        return program.load_method("forward").execute(example_inputs)
+        method = program.load_method("forward")
+        assert method is not None, "forward method should exist in exported program"
+        return method.execute(example_inputs)
 
 
 @unittest.skipUnless(

--- a/test/end2end/test_python_runtime_xnnpack.py
+++ b/test/end2end/test_python_runtime_xnnpack.py
@@ -1,0 +1,183 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""End-to-end tests that export models with XNNPACK delegation and verify
+them through the Python runtime.
+
+Covers the export → .pte → Python runtime flow that developers use to
+validate exported models before deploying to device.  Complements the
+existing C++ runner tests in .ci/scripts/test_model.sh.
+
+See https://github.com/pytorch/executorch/issues/11225
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import torch
+from executorch.backends.xnnpack.partition.xnnpack_partitioner import (
+    XnnpackPartitioner,
+)
+from executorch.exir import EdgeCompileConfig, to_edge_transform_and_lower
+from executorch.runtime import Runtime, Verification
+from torch.export import export
+
+
+def _export_and_load(model: torch.nn.Module, example_inputs: tuple):
+    """Export *model* with XNNPACK, save to a temp .pte, load via Runtime."""
+    model.eval()
+    with torch.no_grad():
+        aten = export(model, example_inputs, strict=True)
+        edge = to_edge_transform_and_lower(
+            aten,
+            compile_config=EdgeCompileConfig(_check_ir_validity=False),
+            partitioner=[XnnpackPartitioner()],
+        )
+        et = edge.to_executorch()
+
+    with tempfile.NamedTemporaryFile(suffix=".pte", delete=False) as f:
+        pte_path = f.name
+    et.save(pte_path)
+
+    rt = Runtime.get()
+    program = rt.load_program(Path(pte_path), verification=Verification.Minimal)
+    return program.load_method("forward"), pte_path
+
+
+class TestPythonRuntimeXNNPACK(unittest.TestCase):
+    """Export → .pte → Python Runtime tests for XNNPACK on Linux."""
+
+    # ------------------------------------------------------------------
+    # Simple arithmetic
+    # ------------------------------------------------------------------
+    def test_add(self):
+        class Add(torch.nn.Module):
+            def forward(self, x, y):
+                return x + y
+
+        model = Add()
+        inputs = (torch.randn(2, 3), torch.randn(2, 3))
+        method, _ = _export_and_load(model, inputs)
+
+        expected = model(*inputs)
+        actual = method.execute(inputs)
+        torch.testing.assert_close(actual[0], expected, atol=1e-4, rtol=1e-4)
+
+    # ------------------------------------------------------------------
+    # Linear layer (fp32)
+    # ------------------------------------------------------------------
+    def test_linear(self):
+        model = torch.nn.Linear(16, 8)
+        inputs = (torch.randn(4, 16),)
+        method, _ = _export_and_load(model, inputs)
+
+        with torch.no_grad():
+            expected = model(*inputs)
+        actual = method.execute(inputs)
+        torch.testing.assert_close(actual[0], expected, atol=1e-4, rtol=1e-4)
+
+    # ------------------------------------------------------------------
+    # Conv2d + ReLU (common vision pattern)
+    # ------------------------------------------------------------------
+    def test_conv2d_relu(self):
+        model = torch.nn.Sequential(
+            torch.nn.Conv2d(3, 16, 3, padding=1),
+            torch.nn.ReLU(),
+        )
+        inputs = (torch.randn(1, 3, 8, 8),)
+        method, _ = _export_and_load(model, inputs)
+
+        with torch.no_grad():
+            expected = model(*inputs)
+        actual = method.execute(inputs)
+        torch.testing.assert_close(actual[0], expected, atol=1e-3, rtol=1e-3)
+
+    # ------------------------------------------------------------------
+    # Small MLP (multiple linear + activation)
+    # ------------------------------------------------------------------
+    def test_mlp(self):
+        model = torch.nn.Sequential(
+            torch.nn.Linear(32, 64),
+            torch.nn.ReLU(),
+            torch.nn.Linear(64, 10),
+        )
+        inputs = (torch.randn(2, 32),)
+        method, _ = _export_and_load(model, inputs)
+
+        with torch.no_grad():
+            expected = model(*inputs)
+        actual = method.execute(inputs)
+        torch.testing.assert_close(actual[0], expected, atol=1e-3, rtol=1e-3)
+
+    # ------------------------------------------------------------------
+    # BatchNorm + Conv (common in MobileNet-style models)
+    # Skipped: FuseBatchNormPass crashes on Sequential(Conv2d, BN) export.
+    # TODO(#11225): re-enable once the XNNPACK pass is fixed.
+    # ------------------------------------------------------------------
+    @unittest.skip("FuseBatchNormPass bug in XNNPACK backend")
+    def test_conv_bn(self):
+        model = torch.nn.Sequential(
+            torch.nn.Conv2d(3, 16, 3, padding=1),
+            torch.nn.BatchNorm2d(16),
+            torch.nn.ReLU(),
+        )
+        model.eval()
+        inputs = (torch.randn(1, 3, 8, 8),)
+        method, _ = _export_and_load(model, inputs)
+
+        with torch.no_grad():
+            expected = model(*inputs)
+        actual = method.execute(inputs)
+        torch.testing.assert_close(actual[0], expected, atol=1e-3, rtol=1e-3)
+
+    # ------------------------------------------------------------------
+    # Depthwise separable conv (MobileNet building block)
+    # ------------------------------------------------------------------
+    def test_depthwise_separable_conv(self):
+        model = torch.nn.Sequential(
+            # Depthwise
+            torch.nn.Conv2d(16, 16, 3, padding=1, groups=16),
+            torch.nn.ReLU(),
+            # Pointwise
+            torch.nn.Conv2d(16, 32, 1),
+            torch.nn.ReLU(),
+        )
+        inputs = (torch.randn(1, 16, 8, 8),)
+        method, _ = _export_and_load(model, inputs)
+
+        with torch.no_grad():
+            expected = model(*inputs)
+        actual = method.execute(inputs)
+        torch.testing.assert_close(actual[0], expected, atol=1e-3, rtol=1e-3)
+
+    # ------------------------------------------------------------------
+    # Avgpool + Flatten + Linear (classifier head)
+    # ------------------------------------------------------------------
+    def test_classifier_head(self):
+        class ClassifierHead(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.pool = torch.nn.AdaptiveAvgPool2d(1)
+                self.fc = torch.nn.Linear(32, 10)
+
+            def forward(self, x):
+                x = self.pool(x)
+                x = x.flatten(1)
+                return self.fc(x)
+
+        model = ClassifierHead()
+        inputs = (torch.randn(1, 32, 8, 8),)
+        method, _ = _export_and_load(model, inputs)
+
+        with torch.no_grad():
+            expected = model(*inputs)
+        actual = method.execute(inputs)
+        torch.testing.assert_close(actual[0], expected, atol=1e-3, rtol=1e-3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add Python runtime end-to-end tests for the XNNPACK backend on Linux — the first batch for the testing gap described in #11225.

This update keeps the Linux-only coverage under `runtime/test/test_runtime_xnnpack.py` so the standard unittest jobs collect it cleanly. Each test exports a small model with XNNPACK delegation, saves it as `.pte`, loads it via `executorch.runtime.Runtime`, and compares the output against PyTorch eager mode.

**Models tested:**
- `test_add` — element-wise addition
- `test_linear` — single `Linear` layer (fp32)
- `test_conv2d_relu` — `Conv2d + ReLU`
- `test_mlp` — multi-layer perceptron (`Linear -> ReLU -> Linear`)
- `test_depthwise_separable_conv` — depthwise + pointwise conv (MobileNet building block)
- `test_classifier_head` — `AdaptiveAvgPool2d + Flatten + Linear`
- `test_conv_bn` — `Conv2d + BatchNorm2d + ReLU` (**skipped**: `FuseBatchNormPass` crashes; TODO to re-enable)

Part of #11225 (Linux XNNPACK)

<details>
<summary>Before</summary>

```text
$ pull / unittest-editable / linux / linux-job

==================================== ERRORS ====================================
_________ ERROR collecting test/end2end/test_python_runtime_xnnpack.py _________
ImportError while importing test module '/pytorch/executorch/test/end2end/test_python_runtime_xnnpack.py'.
Traceback:
E   ModuleNotFoundError: No module named 'test.end2end'

$ lintrunner --skip MYPY test/end2end/test_python_runtime_xnnpack.py

Warning (UFMT) format
- from executorch.backends.xnnpack.partition.xnnpack_partitioner import (
-     XnnpackPartitioner,
- )
+ from executorch.backends.xnnpack.partition.xnnpack_partitioner import XnnpackPartitioner
```

</details>

<details>
<summary>After</summary>

```text
$ lintrunner --skip MYPY runtime/test/test_runtime_xnnpack.py
ok No lint issues.

$ python -m py_compile runtime/test/test_runtime_xnnpack.py
```

</details>

## Test plan
- [x] Moved the Linux-only XNNPACK runtime tests to `runtime/test/test_runtime_xnnpack.py`
- [x] Added `runtime/test/TARGETS` coverage for the new Python runtime test
- [x] `lintrunner --skip MYPY runtime/test/test_runtime_xnnpack.py`
- [x] `python -m py_compile runtime/test/test_runtime_xnnpack.py`
- [x] `test_conv_bn` remains skipped with TODO — `FuseBatchNormPass` still has a known bug on `Sequential(Conv2d, BN)` export
- [ ] Full `python -m pytest runtime/test/test_runtime_xnnpack.py -v`
  Local blocker: this workstation does not currently have a fully provisioned ExecuTorch runtime test environment; upstream CI remains the source of truth for this suite.

cc @GregoryComer @digantdesai @cbilgin @jathu @larryliu0820

> This PR was authored with the help of Claude.
