### PR TITLE
Add xplat cxx_binary target for bench_transposed_cache benchmark

### DIFF
--- a/extension/llm/custom_ops/BUCK
+++ b/extension/llm/custom_ops/BUCK
@@ -24,6 +24,20 @@ non_fbcode_target(_kind = runtime.cxx_binary,
     ],
 )
 
+non_fbcode_target(_kind = runtime.cxx_binary,
+    name = "bench_transposed_cache",
+    srcs = ["bench_transposed_cache.cpp"],
+    compiler_flags = ["-O2"],
+    deps = [
+        "fbsource//third-party/benchmark:benchmark",
+        "//executorch/extension/llm/custom_ops:custom_ops",
+        "//executorch/extension/threadpool:threadpool",
+        "//executorch/kernels/optimized:libblas",
+        "//executorch/runtime/core/exec_aten:lib",
+        "//executorch/runtime/core/exec_aten/testing_util:tensor_util",
+    ],
+)
+
 # !!!! fbcode/executorch/extension/llm/custom_ops/TARGETS was merged into this file, see https://fburl.com/workplace/xl8l9yuo for more info !!!!
 
 # Any targets that should be shared between fbcode and xplat must be defined in
@@ -133,7 +147,7 @@ fbcode_target(_kind = cpp_benchmark,
     ],
 )
 
-cpp_benchmark(
+fbcode_target(_kind = cpp_benchmark,
     name = "bench_transposed_cache",
     srcs = ["bench_transposed_cache.cpp"],
     deps = [


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #18719
* __->__ #18718
* #18717
* #18716
* #18715
* #18714
* #18713
* #18712
* #18711
* #18710
* #18709
* #18708
* #18707
* #18706
* #18705
* #18651
* #18650
* #18649
* #18648
* #18647
* #18646
* #18645

The fbcode cpp_benchmark target forces macOS x86_64 compatibility,
making it unusable on arm64 Macs. Add a non_fbcode_target cxx_binary
so the benchmark can be built and run locally via:
  buck build fbsource//xplat/executorch/extension/llm/custom_ops:bench_transposed_cache

Also wrap the existing fbcode cpp_benchmark in fbcode_target() to
avoid duplicate target name conflicts.

Authored with Claude.

Differential Revision: [D99677682](https://our.internmc.facebook.com/intern/diff/D99677682/)