### PR TITLE
[ET-VK][CI] Add macOS MoltenVK Vulkan model tests

### DIFF
--- a/.ci/scripts/setup-vulkan-macos-deps.sh
+++ b/.ci/scripts/setup-vulkan-macos-deps.sh
@@ -1,0 +1,34 @@
+
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -ex
+
+install_vulkan_sdk() {
+  VULKAN_SDK_VERSION=$1
+  _vulkan_sdk_url="https://sdk.lunarg.com/sdk/download/${VULKAN_SDK_VERSION}/mac/vulkansdk-macos-${VULKAN_SDK_VERSION}.zip"
+
+  _vulkan_sdk_dir=/tmp/vulkansdk
+  mkdir -p $_vulkan_sdk_dir
+
+  _tmp_archive="/tmp/vulkansdk.zip"
+
+  curl --silent --show-error --location --fail --retry 3 \
+    --output "${_tmp_archive}" "${_vulkan_sdk_url}"
+
+  unzip -q -o "${_tmp_archive}" -d "${_vulkan_sdk_dir}"
+
+  export VULKAN_SDK="${_vulkan_sdk_dir}/VulkanSDK/${VULKAN_SDK_VERSION}/macOS"
+  export PATH="${VULKAN_SDK}/bin:${PATH}"
+  export VK_ICD_FILENAMES="${VULKAN_SDK}/share/vulkan/icd.d/MoltenVK_icd.json"
+  export VK_LAYER_PATH="${VULKAN_SDK}/share/vulkan/explicit_layer.d"
+  export DYLD_LIBRARY_PATH="${VULKAN_SDK}/lib:${DYLD_LIBRARY_PATH:-}"
+}
+
+VULKAN_SDK_VERSION="1.4.321.0"
+
+install_vulkan_sdk "${VULKAN_SDK_VERSION}"

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -1339,6 +1339,46 @@ jobs:
         python -m unittest backends/vulkan/test/test_vulkan_delegate.py -k "*pt2e*"
         python -m unittest backends/vulkan/test/test_vulkan_delegate.py -k "*torchao*"
 
+  test-vulkan-models-macos:
+    name: test-vulkan-models-macos
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      runner: macos-m1-stable
+      python-version: '3.11'
+      submodules: 'recursive'
+      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      timeout: 90
+      script: |
+        set -eux
+
+        # Setup MoltenVK and Vulkan SDK which are required to build the Vulkan delegate
+        source .ci/scripts/setup-vulkan-macos-deps.sh
+
+        bash .ci/scripts/setup-conda.sh
+
+        # Setup MacOS dependencies and build ExecuTorch with Vulkan enabled
+        PYTHON_EXECUTABLE=python \
+        CMAKE_ARGS="-DEXECUTORCH_BUILD_VULKAN=ON" \
+        ${CONDA_RUN} bash .ci/scripts/setup-macos.sh --build-tool "cmake"
+
+        # Build Vulkan test libraries
+        PYTHON_EXECUTABLE=python ${CONDA_RUN} bash backends/vulkan/test/scripts/test_model.sh --build
+
+        # Test models with static shapes
+        models="mv2 mv3 edsr resnet18 resnet50 dl3 w2l ic3 ic4"
+        for model in $models; do
+          ${CONDA_RUN} python -m examples.vulkan.export --model_name=$model --test
+        done
+
+        # Test selected models with dynamic shapes
+        models="mv2 resnet18 resnet50 ic3 densenet161"
+        for model in $models; do
+          ${CONDA_RUN} python -m examples.vulkan.export --model_name=$model --test -d
+        done
+
   test-coreml-bc-macos:
     name: test-coreml-bc-macos (${{ matrix.runner }})
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main


### PR DESCRIPTION

Summary:
Add a `test-vulkan-models-macos` job to the pull CI workflow that tests
the Vulkan backend on macOS Apple Silicon using MoltenVK. This mirrors
the existing `test-vulkan-models-linux` job (which uses SwiftShader) but
runs on a macOS M1 runner with the LunarG Vulkan SDK providing MoltenVK
as the Vulkan ICD.

The new `setup-vulkan-macos-deps.sh` script downloads the macOS Vulkan
SDK and configures `VK_ICD_FILENAMES` to point at MoltenVK.

Generated with Claude.


cc @manuelcandales @digantdesai @cbilgin