### PR TITLE
Fix QNN runner KV cache bitwidth detection in Android JNI

### DIFF
--- a/extension/android/jni/jni_layer_llama.cpp
+++ b/extension/android/jni/jni_layer_llama.cpp
@@ -203,13 +203,41 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
               data_files_vector,
               cpp_load_mode);
       std::string decoder_model = "llama3"; // use llama3 for now
-      runner_ = std::make_unique<example::Runner<uint16_t>>( // QNN runner
-          std::move(module),
-          decoder_model.c_str(),
-          model_path->toStdString().c_str(),
-          tokenizer_path->toStdString().c_str(),
-          "",
-          "");
+      // Using 8bit as default since this meta is introduced with 16bit kv io
+      // support and older models only have 8bit kv io.
+      example::KvBitWidth kv_bitwidth = example::KvBitWidth::kWidth8;
+      if (module->method_names()->count("get_kv_io_bit_width") > 0) {
+        kv_bitwidth = static_cast<example::KvBitWidth>(
+            module->get("get_kv_io_bit_width")
+                .get()
+                .toScalar()
+                .to<int64_t>());
+      }
+
+      if (kv_bitwidth == example::KvBitWidth::kWidth8) {
+        runner_ = std::make_unique<example::Runner<uint8_t>>(
+            std::move(module),
+            decoder_model.c_str(),
+            model_path->toStdString().c_str(),
+            tokenizer_path->toStdString().c_str(),
+            "",
+            "",
+            temperature_);
+      } else if (kv_bitwidth == example::KvBitWidth::kWidth16) {
+        runner_ = std::make_unique<example::Runner<uint16_t>>(
+            std::move(module),
+            decoder_model.c_str(),
+            model_path->toStdString().c_str(),
+            tokenizer_path->toStdString().c_str(),
+            "",
+            "",
+            temperature_);
+      } else {
+        ET_CHECK_MSG(
+            false,
+            "Unsupported kv bitwidth: %ld",
+            static_cast<int64_t>(kv_bitwidth));
+      }
       model_type_category_ = MODEL_TYPE_CATEGORY_LLM;
 #endif
 #if defined(EXECUTORCH_BUILD_MEDIATEK)


### PR DESCRIPTION
## Summary
- The QNN runner in the Android JNI layer was hardcoded to `Runner<uint16_t>`, but models can use either 8-bit or 16-bit KV caches
- This mismatch caused gibberish output in the Android demo app while the CLI runner worked correctly
- Now dynamically queries `get_kv_io_bit_width` from the model (mirroring `qnn_llama_runner.cpp`) and instantiates the correct `Runner<uint8_t>` or `Runner<uint16_t>`
- Also passes `temperature_` to the Runner constructor (was previously omitted)

Fixes #18571
Closes #17622

## Test plan
- [x] Built Android AAR with QNN support (SDK 2.37) — `jni_layer_llama.cpp` compiles cleanly with both template instantiations
- [x] Gradle unit tests pass (`testDebugUnitTest`)
- [ ] On-device test with QNN model (in progress)

cc @cccclai @kirklandsign @infil00p