### PR TITLE
Fix execute permissions for flatc binary extracted from PAR files (#18738)

### DIFF
--- a/exir/_serialize/_flatbuffer.py
+++ b/exir/_serialize/_flatbuffer.py
@@ -11,6 +11,7 @@ import importlib.resources
 import os
 import re
 import shutil
+import stat
 import subprocess
 
 import tempfile
@@ -252,6 +253,15 @@ def _run_flatc(args: Sequence[str]) -> None:
     if flatc_resource.is_file():
         # Use the provided flatc binary.
         with importlib.resources.as_file(flatc_resource) as flatc_path:
+            # Ensure the binary has execute permissions (needed for PAR files)
+            try:
+                current_mode = flatc_path.stat().st_mode
+                if not (current_mode & stat.S_IXUSR):
+                    flatc_path.chmod(
+                        current_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+                    )
+            except OSError:
+                pass
             subprocess.run([flatc_path] + list(args), check=True)
     else:
         # Expect the `flatc` tool to be on the system path or set as an env var.


### PR DESCRIPTION
Summary:

When binaries are extracted from PAR files via `importlib.resources.as_file()`,
execute permissions are not preserved, causing PermissionError when trying to
run them.

This change ensures the flatc binary has execute permissions after extraction.

Files fixed:
- `executorch/exir/_serialize/_flatbuffer.py`: `_run_flatc` - ensure flatc binary has execute permissions

Reviewed By: abhinaykukkadapu

Differential Revision: D99780508


