### PR TITLE
fix: replace bare except with except Exception in pytree init

### DIFF
--- a/extension/pytree/__init__.py
+++ b/extension/pytree/__init__.py
@@ -32,7 +32,7 @@ try:
         tree_unflatten as tree_unflatten,
         TreeSpec as TreeSpec,
     )
-except:
+except Exception:
     logger.info(
         "Unable to import executorch.extension.pytree, using native torch pytree instead."
     )


### PR DESCRIPTION
## Summary

Replace bare `except:` with `except Exception:` in `extension/pytree/__init__.py`.

Bare `except:` catches all exceptions including `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit`, which should not be silently caught. Since this handler only logs and falls back to torch pytree on import failure, catching `Exception` is the correct scope.

**Change:**
```python
# Before
except:
    logger.info(...)

# After
except Exception:
    logger.info(...)
```

## Testing
No behavior change — the import fallback logic is preserved.