### PR TITLE
Fix unchecked Result in get_llm_metadata()

### DIFF
--- a/extension/llm/runner/llm_runner_helper.cpp
+++ b/extension/llm/runner/llm_runner_helper.cpp
@@ -121,8 +121,9 @@ get_llm_metadata(tokenizers::Tokenizer* tokenizer, Module* module) {
     auto& value = pair.second;
 
     if (method_names.count(method_name)) {
-      auto get_result = module->get(method_name);
-      value = get_result.get().toScalar().to<decltype(metadata)::mapped_type>();
+      value = ET_UNWRAP(module->get(method_name))
+                  .toScalar()
+                  .to<decltype(metadata)::mapped_type>();
     } else {
       ET_LOG(
           Info,


### PR DESCRIPTION
Summary:
In get_llm_metadata(), module->get() returns a Result but the old code called
.get() without checking if the result is ok. If the method exists in the model
(checked via method_names.count()) but module->get() still fails, this indicates
a serious issue with the .pte file.

Use ET_UNWRAP to propagate the error instead of silently falling back to
defaults, which could mask .pte corruption.

Differential Revision: D99707695


