### PR TITLE
Cadence: Add nightly schedule to build and test workflow

### DIFF
--- a/.github/workflows/build-cadence-runner.yml
+++ b/.github/workflows/build-cadence-runner.yml
@@ -1,11 +1,15 @@
 name: Cadence Build & Test
 
 on:
-  pull_request:
+  schedule:
+    - cron: 0 2 * * *
   push:
     branches:
       - main
       - release/*
+    tags:
+      - ciflow/nightly/*
+  pull_request:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/build-cadence-runner.yml
+++ b/.github/workflows/build-cadence-runner.yml
@@ -2,7 +2,7 @@ name: Cadence Build & Test
 
 on:
   schedule:
-    - cron: 0 2 * * *
+    - cron: 0 8 * * *
   push:
     branches:
       - main


### PR DESCRIPTION
## Summary
- Add a cron schedule (2 AM UTC daily) to the Cadence Build & Test workflow so it runs as a nightly job
- Keeps existing PR and push-to-main triggers

## Test plan
- Verified workflow YAML syntax is valid
- Schedule follows the same pattern as other nightly backends (arm, coreml, xnnpack, etc.)