### PR TITLE
Add float scalar input support (#18751)

### DIFF
--- a/extension/pybindings/pybindings.cpp
+++ b/extension/pybindings/pybindings.cpp
@@ -807,6 +807,8 @@ struct PyModule final {
         cpp_inputs.push_back(EValue(py::cast<bool>(python_input)));
       } else if (py::isinstance<py::int_>(python_input)) {
         cpp_inputs.push_back(EValue(py::cast<int64_t>(python_input)));
+      } else if (py::isinstance<py::float_>(python_input)) {
+        cpp_inputs.push_back(EValue(py::cast<double>(python_input)));
       } else {
         throw std::runtime_error(
             "Unsupported python type " + type_str +
@@ -1135,6 +1137,8 @@ struct PyMethod final {
         cpp_inputs.push_back(EValue(py::cast<bool>(python_input)));
       } else if (py::isinstance<py::int_>(python_input)) {
         cpp_inputs.push_back(EValue(py::cast<int64_t>(python_input)));
+      } else if (py::isinstance<py::float_>(python_input)) {
+        cpp_inputs.push_back(EValue(py::cast<double>(python_input)));
       } else {
         throw std::runtime_error(
             "Unsupported python type " + type_str +


### PR DESCRIPTION
Summary:

The pybindings code handled bool and int scalar inputs but was missing
support for float (Python float → C++ double). This caused failures when
running models like Addmm that take float alpha/beta parameters, throwing
'Unsupported python type <class float>'.

Added py::isinstance<py::float_> handling to convert Python floats to
EValue(double) in both the portable and XNNPACK input processing paths.

Reviewed By: 3l1

Differential Revision: D99845426


