### PR TITLE
SDPA decode perf improvements for qwen-3.5-35B-A3B

### DIFF
--- a/backends/cuda/benchmarks/benchmark_sdpa.py
+++ b/backends/cuda/benchmarks/benchmark_sdpa.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Benchmark the Triton SDPA kernel against PyTorch SDPA backends.
+
+Measures latency across decode shapes matching the Qwen3.5 MoE model
+(B=1, H_q=16, H_kv=2, D=256). The ET Triton kernel uses native GQA
+(2 KV heads), while Flash/Efficient/Math require pre-expanded KV
+(16 heads) since they lack native GQA support.
+
+"""
+
+import argparse
+import warnings
+from functools import partial
+
+import torch
+import torch.nn.functional as F
+
+from executorch.backends.cuda.triton.kernels.sdpa import sdpa as triton_sdpa
+from torch.nn.attention import sdpa_kernel, SDPBackend
+from triton.testing import do_bench
+
+
+# PyTorch's Flash/Efficient backends don't support GQA (H_q != H_kv) directly.
+# We expand KV heads via repeat_interleave so they can run, matching what
+# the test reference does. This is fair: it measures the kernel itself, not
+# the GQA dispatch overhead.
+
+
+def _expand_kv(k, v, num_groups):
+    if num_groups > 1:
+        k = k.repeat_interleave(num_groups, dim=1)
+        v = v.repeat_interleave(num_groups, dim=1)
+    return k, v
+
+
+def _expand_mask(mask, H_q):
+    if mask is not None and mask.shape[1] == 1 and H_q > 1:
+        mask = mask.expand(-1, H_q, -1, -1)
+    return mask
+
+
+def _run_triton(q, k, v, attn_mask, enable_gqa):
+    return triton_sdpa(q, k, v, attn_mask=attn_mask, enable_gqa=enable_gqa)
+
+
+def _run_pytorch_default(q, k, v, attn_mask, enable_gqa):
+    return F.scaled_dot_product_attention(
+        q,
+        k,
+        v,
+        attn_mask=attn_mask,
+        enable_gqa=enable_gqa,
+    )
+
+
+def _make_pytorch_runner(backend: SDPBackend):
+    def run(q, k, v, attn_mask, enable_gqa):
+        with sdpa_kernel(backend):
+            return F.scaled_dot_product_attention(q, k, v, attn_mask=attn_mask)
+
+    return run
+
+
+# Flash doesn't support attn_mask at all, only is_causal.
+# Our benchmark mask is all-ones, so no mask is equivalent.
+def _run_flash(q, k, v, attn_mask, enable_gqa):
+    with sdpa_kernel(SDPBackend.FLASH_ATTENTION):
+        return F.scaled_dot_product_attention(q, k, v)
+
+
+BACKENDS = {
+    "triton": ("ET Triton (GQA)", _run_triton),
+    "pytorch": ("PyTorch", _run_pytorch_default),
+    "flash": ("Flash (expanded KV)", _run_flash),
+    "efficient": (
+        "Efficient (expanded KV)",
+        _make_pytorch_runner(SDPBackend.EFFICIENT_ATTENTION),
+    ),
+    "math": ("Math (expanded KV)", _make_pytorch_runner(SDPBackend.MATH)),
+}
+
+# Backends that need KV heads expanded before calling (no native GQA support)
+_NEEDS_KV_EXPAND = {"flash", "efficient", "math"}
+
+# -- Shapes ------------------------------------------------------------------
+
+# Qwen3.5 MoE: B=1, H_q=16, H_kv=2, D=256
+QWEN35_BASE = dict(B=1, H_q=16, H_kv=2, D=256)
+
+DECODE_SHAPES = [
+    dict(**QWEN35_BASE, Lq=1, Lk=64),
+    dict(**QWEN35_BASE, Lq=1, Lk=128),
+    dict(**QWEN35_BASE, Lq=1, Lk=256),
+    dict(**QWEN35_BASE, Lq=1, Lk=512),
+    dict(**QWEN35_BASE, Lq=1, Lk=1024),
+    dict(**QWEN35_BASE, Lq=1, Lk=2048),
+    dict(**QWEN35_BASE, Lq=1, Lk=4096),
+    dict(**QWEN35_BASE, Lq=1, Lk=8192),
+    dict(**QWEN35_BASE, Lq=1, Lk=16384),
+]
+
+SCENARIOS = {
+    "decode": DECODE_SHAPES,
+}
+
+# -- Helpers -----------------------------------------------------------------
+
+
+def _make_tensors(B, H_q, H_kv, Lq, Lk, D, device="cuda", dtype=torch.bfloat16):
+    q = torch.randn(B, H_q, Lq, D, device=device, dtype=dtype)
+    k = torch.randn(B, H_kv, Lk, D, device=device, dtype=dtype)
+    v = torch.randn(B, H_kv, Lk, D, device=device, dtype=dtype)
+    mask = torch.ones(B, 1, Lq, Lk, dtype=torch.bool, device=device)
+    enable_gqa = H_q != H_kv
+    num_groups = H_q // H_kv
+    # Pre-expanded versions for backends without native GQA
+    k_exp, v_exp = _expand_kv(k, v, num_groups)
+    mask_exp = _expand_mask(mask, H_q)
+    return q, k, v, k_exp, v_exp, mask, mask_exp, enable_gqa
+
+
+def _max_abs_error(out, ref):
+    return (out.float() - ref.float()).abs().max().item()
+
+
+# Cross-backend validation tolerance (bf16 vs bf16).
+MAX_ABS_TOL = 1e-2
+
+
+def _bench_us(fn, num_warmup, num_iters):
+    """Return median latency in microseconds using triton.testing.do_bench."""
+    ms = do_bench(fn, warmup=num_warmup, rep=num_iters, return_mode="median")
+    return ms * 1000.0
+
+
+def _try_run(run_fn, q, k, v, mask, enable_gqa):
+    """Run a backend, returning output or None on failure."""
+    try:
+        return run_fn(q, k, v, mask, enable_gqa)
+    except RuntimeError:
+        return None
+
+
+def _try_bench(run_fn, q, k, v, mask, enable_gqa, num_warmup, num_iters):
+    """Benchmark a backend, returning median us or None on failure."""
+    fn = partial(run_fn, q, k, v, mask, enable_gqa)
+    try:
+        run_fn(q, k, v, mask, enable_gqa)
+        return _bench_us(fn, num_warmup, num_iters)
+    except RuntimeError:
+        return None
+
+
+# -- Main --------------------------------------------------------------------
+
+
+def _shape_label(shape):
+    return (
+        f"B={shape['B']} Hq={shape['H_q']} Hkv={shape['H_kv']} "
+        f"D={shape['D']} Lq={shape['Lq']} Lk={shape['Lk']}"
+    )
+
+
+def _short_label(shape, scenario="decode"):
+    return f"Lq={shape['Lq']},Lk={shape['Lk']}"
+
+
+@torch.inference_mode()
+def run_benchmark(
+    scenario: str = "decode",
+    num_warmup: int = 25,
+    num_iters: int = 100,
+):
+    shapes = SCENARIOS[scenario]
+    backends = [(name, *BACKENDS[name]) for name in BACKENDS]
+
+    device_name = torch.cuda.get_device_name()
+    print()
+    print("=" * 100)
+    print(f"SDPA Benchmark Qwen3.5-35B-A3B — {scenario}")
+    print(f"  Device: {device_name}")
+    print(f"  Warmup: {num_warmup}, Iters: {num_iters}")
+    print(f"  Backends: {', '.join(label for _, label, _ in backends)}")
+    print("=" * 100)
+
+    # Build column specs: (header_text, unit_text, min_width)
+    # Each column gets width = max(len(header), len(unit), min_width)
+    max_label = max(len(_short_label(s, scenario)) for s in shapes)
+    col_specs = [("Shape", "", max(8, max_label))]
+    for _, label, _ in backends:
+        col_specs.append((label, "(us)", 8))
+
+    col_widths = [max(len(h), len(u), mw) for h, u, mw in col_specs]
+
+    header = " | ".join(
+        f"{h:<{w}}" if i == 0 else f"{h:>{w}}"
+        for i, ((h, _, _), w) in enumerate(zip(col_specs, col_widths))
+    )
+    units = " | ".join(
+        f"{'':>{w}}" if i == 0 else f"{u:>{w}}"
+        for i, ((_, u, _), w) in enumerate(zip(col_specs, col_widths))
+    )
+    print(header)
+    print(units)
+    print("-" * len(header))
+
+    for shape in shapes:
+        q, k, v, k_exp, v_exp, mask, mask_exp, enable_gqa = _make_tensors(**shape)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+
+            # Validate outputs across backends before benchmarking
+            outputs = {}
+            for name, _label, run_fn in backends:
+                if name in _NEEDS_KV_EXPAND:
+                    bk, bv, bmask = k_exp, v_exp, mask_exp
+                else:
+                    bk, bv, bmask = k, v, mask
+                outputs[name] = _try_run(run_fn, q, bk, bv, bmask, enable_gqa)
+
+            # Use PyTorch F.sdpa as the trusted reference — never validate
+            # against our own Triton kernels.
+            ref_name, ref_out = None, None
+            if outputs.get("pytorch") is not None:
+                ref_name, ref_out = "pytorch", outputs["pytorch"]
+
+            if ref_out is not None:
+                for name, label, _ in backends:
+                    if name == ref_name or outputs[name] is None:
+                        continue
+                    err = _max_abs_error(outputs[name], ref_out)
+                    assert err < MAX_ABS_TOL, (
+                        f"Output mismatch for {_shape_label(shape)}: "
+                        f"{label} vs {BACKENDS[ref_name][0]}, "
+                        f"max abs error {err:.3e} >= 1e-2"
+                    )
+            del outputs
+
+            # Benchmark all backends
+            times = {}
+            for name, _label, run_fn in backends:
+                if name in _NEEDS_KV_EXPAND:
+                    bk, bv, bmask = k_exp, v_exp, mask_exp
+                else:
+                    bk, bv, bmask = k, v, mask
+                times[name] = _try_bench(
+                    run_fn, q, bk, bv, bmask, enable_gqa, num_warmup, num_iters
+                )
+
+        # Format row using col_widths
+        ci = 0
+        row_parts = [f"{_short_label(shape, scenario):<{col_widths[ci]}}"]
+        ci += 1
+        for name, _, _ in backends:
+            t = times[name]
+            w = col_widths[ci]
+            row_parts.append(f"{t:>{w}.1f}" if t is not None else f"{'N/A':>{w}}")
+            ci += 1
+        print(" | ".join(row_parts))
+
+        del q, k, v, k_exp, v_exp, mask, mask_exp
+        torch.cuda.empty_cache()
+
+    print("-" * len(header))
+    print()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Benchmark Triton SDPA vs PyTorch backends"
+    )
+    parser.add_argument(
+        "--scenario",
+        choices=list(SCENARIOS.keys()) + ["all"],
+        default="all",
+        help="Which shape set to benchmark (default: all)",
+    )
+    parser.add_argument("--num_warmup", type=int, default=25)
+    parser.add_argument("--num_iters", type=int, default=100)
+    args = parser.parse_args()
+
+    scenarios = list(SCENARIOS.keys()) if args.scenario == "all" else [args.scenario]
+    for s in scenarios:
+        run_benchmark(
+            scenario=s,
+            num_warmup=args.num_warmup,
+            num_iters=args.num_iters,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/backends/cuda/benchmarks/benchmark_sdpa.py
+++ b/backends/cuda/benchmarks/benchmark_sdpa.py
@@ -22,7 +22,10 @@ from functools import partial
 import torch
 import torch.nn.functional as F
 
-from executorch.backends.cuda.triton.kernels.sdpa import sdpa as triton_sdpa
+from executorch.backends.cuda.triton.kernels.sdpa import (
+    sdpa as triton_sdpa,
+    sdpa_decode_splitk as triton_splitk,
+)
 from torch.nn.attention import sdpa_kernel, SDPBackend
 from triton.testing import do_bench
 
@@ -48,6 +51,10 @@ def _expand_mask(mask, H_q):
 
 def _run_triton(q, k, v, attn_mask, enable_gqa):
     return triton_sdpa(q, k, v, attn_mask=attn_mask, enable_gqa=enable_gqa)
+
+
+def _run_splitk(q, k, v, attn_mask, enable_gqa):
+    return triton_splitk(q, k, v, attn_mask=attn_mask, enable_gqa=enable_gqa)
 
 
 def _run_pytorch_default(q, k, v, attn_mask, enable_gqa):
@@ -77,6 +84,7 @@ def _run_flash(q, k, v, attn_mask, enable_gqa):
 
 BACKENDS = {
     "triton": ("ET Triton (GQA)", _run_triton),
+    "splitk": ("ET Split-K (GQA)", _run_splitk),
     "pytorch": ("PyTorch", _run_pytorch_default),
     "flash": ("Flash (expanded KV)", _run_flash),
     "efficient": (
@@ -92,7 +100,7 @@ _NEEDS_KV_EXPAND = {"flash", "efficient", "math"}
 # -- Shapes ------------------------------------------------------------------
 
 # Qwen3.5 MoE: B=1, H_q=16, H_kv=2, D=256
-QWEN35_BASE = dict(B=1, H_q=16, H_kv=2, D=256)
+QWEN35_BASE = {"B": 1, "H_q": 16, "H_kv": 2, "D": 256}
 
 DECODE_SHAPES = [
     dict(**QWEN35_BASE, Lq=1, Lk=64),

--- a/backends/cuda/tests/test_triton_sdpa.py
+++ b/backends/cuda/tests/test_triton_sdpa.py
@@ -67,6 +67,11 @@ def _max_abs_error(out, ref):
     return (out.float() - ref.float()).abs().max().item()
 
 
+# bf16 kernel vs fp32 reference tolerance.
+# The benchmark cross-validates backends at 1e-2; tests use the same bar.
+MAX_ABS_TOL = 1e-2
+
+
 # ---------------------------------------------------------------------------
 # Test configurations adapted from FlashAttention
 # ---------------------------------------------------------------------------
@@ -130,7 +135,7 @@ class TestTritonSdpa(unittest.TestCase):
 
                 self.assertFalse(torch.isnan(out).any(), "NaN in output")
                 self.assertLess(
-                    _max_abs_error(out, ref), 0.05, f"D={D} Lq={Lq} Lk={Lk}"
+                    _max_abs_error(out, ref), MAX_ABS_TOL, f"D={D} Lq={Lq} Lk={Lk}"
                 )
 
     def test_mha_causal(self):
@@ -148,7 +153,7 @@ class TestTritonSdpa(unittest.TestCase):
                     ref = _reference_sdpa(q, k, v, is_causal=True)
 
                     self.assertFalse(torch.isnan(out).any())
-                    self.assertLess(_max_abs_error(out, ref), 0.05)
+                    self.assertLess(_max_abs_error(out, ref), MAX_ABS_TOL)
 
     def test_mha_bool_mask(self):
         """MHA with explicit bool attention mask."""
@@ -168,7 +173,7 @@ class TestTritonSdpa(unittest.TestCase):
                 ref = _reference_sdpa(q, k, v, attn_mask=mask)
 
                 self.assertFalse(torch.isnan(out).any())
-                self.assertLess(_max_abs_error(out, ref), 0.05)
+                self.assertLess(_max_abs_error(out, ref), MAX_ABS_TOL)
 
     def test_mha_non_pow2_head_dim(self):
         """MHA with non-power-of-2 head dimensions."""
@@ -187,7 +192,7 @@ class TestTritonSdpa(unittest.TestCase):
                     ref = _reference_sdpa(q, k, v)
 
                     self.assertFalse(torch.isnan(out).any())
-                    self.assertLess(_max_abs_error(out, ref), 0.05)
+                    self.assertLess(_max_abs_error(out, ref), MAX_ABS_TOL)
 
     def test_mha_non_pow2_causal(self):
         """MHA with non-pow2 head dim and causal masking."""
@@ -204,7 +209,7 @@ class TestTritonSdpa(unittest.TestCase):
                     ref = _reference_sdpa(q, k, v, is_causal=True)
 
                     self.assertFalse(torch.isnan(out).any())
-                    self.assertLess(_max_abs_error(out, ref), 0.05)
+                    self.assertLess(_max_abs_error(out, ref), MAX_ABS_TOL)
 
     # ------------------------------------------------------------------
     # GQA tests
@@ -230,7 +235,7 @@ class TestTritonSdpa(unittest.TestCase):
                 self.assertEqual(out.shape, (B, H_q, Lq, D))
                 self.assertFalse(torch.isnan(out).any())
                 self.assertLess(
-                    _max_abs_error(out, ref), 0.05, f"{label} D={D} Lk={Lk}"
+                    _max_abs_error(out, ref), MAX_ABS_TOL, f"{label} D={D} Lk={Lk}"
                 )
 
     def test_gqa_decode_with_mask(self):
@@ -253,7 +258,7 @@ class TestTritonSdpa(unittest.TestCase):
                 ref = _reference_sdpa(q, k, v, attn_mask=mask)
 
                 self.assertFalse(torch.isnan(out).any())
-                self.assertLess(_max_abs_error(out, ref), 0.05)
+                self.assertLess(_max_abs_error(out, ref), MAX_ABS_TOL)
 
     def test_gqa_short_seqlen(self):
         """GQA with short seqlen_q (2-8)."""
@@ -270,7 +275,7 @@ class TestTritonSdpa(unittest.TestCase):
                     ref = _reference_sdpa(q, k, v)
 
                     self.assertFalse(torch.isnan(out).any())
-                    self.assertLess(_max_abs_error(out, ref), 0.05)
+                    self.assertLess(_max_abs_error(out, ref), MAX_ABS_TOL)
 
     def test_gqa_prefill(self):
         """GQA prefill (long seqlen_q)."""
@@ -290,7 +295,7 @@ class TestTritonSdpa(unittest.TestCase):
 
                 self.assertEqual(out.shape, (B, H_q, L, D))
                 self.assertFalse(torch.isnan(out).any())
-                self.assertLess(_max_abs_error(out, ref), 0.05)
+                self.assertLess(_max_abs_error(out, ref), MAX_ABS_TOL)
 
     def test_gqa_non_pow2_head_dim(self):
         """GQA with non-power-of-2 head dimensions."""
@@ -308,7 +313,7 @@ class TestTritonSdpa(unittest.TestCase):
 
                     self.assertFalse(torch.isnan(out).any())
                     self.assertLess(
-                        _max_abs_error(out, ref), 0.05, f"D={D} Lq={Lq} Lk={Lk}"
+                        _max_abs_error(out, ref), MAX_ABS_TOL, f"D={D} Lq={Lq} Lk={Lk}"
                     )
 
     def test_gqa_causal_prefill(self):
@@ -326,7 +331,7 @@ class TestTritonSdpa(unittest.TestCase):
                     ref = _reference_sdpa(q, k, v, is_causal=True)
 
                     self.assertFalse(torch.isnan(out).any())
-                    self.assertLess(_max_abs_error(out, ref), 0.05)
+                    self.assertLess(_max_abs_error(out, ref), MAX_ABS_TOL)
 
     def test_gqa_causal_decode_with_mask(self):
         """GQA decode with causal-like bool mask (simulating KV cache)."""
@@ -352,7 +357,7 @@ class TestTritonSdpa(unittest.TestCase):
                 ref = _reference_sdpa(q, k, v, attn_mask=mask)
 
                 self.assertFalse(torch.isnan(out).any())
-                self.assertLess(_max_abs_error(out, ref), 0.05)
+                self.assertLess(_max_abs_error(out, ref), MAX_ABS_TOL)
 
     def test_gqa_batch_size(self):
         """GQA with batch_size > 1."""
@@ -368,7 +373,7 @@ class TestTritonSdpa(unittest.TestCase):
                 ref = _reference_sdpa(q, k, v)
 
                 self.assertFalse(torch.isnan(out).any())
-                self.assertLess(_max_abs_error(out, ref), 0.05)
+                self.assertLess(_max_abs_error(out, ref), MAX_ABS_TOL)
 
     # ------------------------------------------------------------------
     # Qwen 3.5 MoE configuration
@@ -393,7 +398,9 @@ class TestTritonSdpa(unittest.TestCase):
                 self.assertEqual(out.shape, (B, H_q, Lq, D))
                 self.assertFalse(torch.isnan(out).any())
                 self.assertLess(
-                    _max_abs_error(out, ref), 0.05, f"Qwen config Lq={Lq} Lk={Lk}"
+                    _max_abs_error(out, ref),
+                    MAX_ABS_TOL,
+                    f"Qwen config Lq={Lq} Lk={Lk}",
                 )
 
     # ------------------------------------------------------------------
@@ -427,7 +434,7 @@ class TestTritonSdpa(unittest.TestCase):
         ref = _reference_sdpa(q, k, v, scale=scale)
 
         self.assertFalse(torch.isnan(out).any())
-        self.assertLess(_max_abs_error(out, ref), 0.05)
+        self.assertLess(_max_abs_error(out, ref), MAX_ABS_TOL)
 
     def test_all_masked(self):
         """All-masked block should produce zeros, not NaN."""
@@ -508,7 +515,7 @@ class TestTritonSdpa(unittest.TestCase):
         ref = _reference_sdpa(q, k, v)
 
         self.assertFalse(torch.isnan(out).any())
-        self.assertLess(_max_abs_error(out, ref), 0.05)
+        self.assertLess(_max_abs_error(out, ref), MAX_ABS_TOL)
 
 
 if __name__ == "__main__":

--- a/backends/cuda/tests/test_triton_sdpa_splitk.py
+++ b/backends/cuda/tests/test_triton_sdpa_splitk.py
@@ -1,0 +1,310 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Tests for the split-K decode SDPA kernel (sdpa_decode_splitk).
+
+Mirrors test_triton_sdpa.py structure. Reference outputs use torch SDPA with
+expanded KV heads in float32.
+"""
+
+import itertools
+import unittest
+
+import torch
+import torch.nn.functional as F
+
+
+def _skip_if_no_cuda():
+    if not torch.cuda.is_available():
+        raise unittest.SkipTest("CUDA not available")
+    if not torch.cuda.is_bf16_supported():
+        raise unittest.SkipTest("BF16 not supported on this GPU")
+
+
+def _import_splitk():
+    from executorch.backends.cuda.triton.kernels.sdpa import sdpa_decode_splitk
+
+    return sdpa_decode_splitk
+
+
+def _import_sdpa():
+    from executorch.backends.cuda.triton.kernels.sdpa import sdpa
+
+    return sdpa
+
+
+def _reference_sdpa(q, k, v, attn_mask=None, scale=None):
+    """Compute reference SDPA in float32 with expanded KV heads for GQA."""
+    H_q = q.shape[1]
+    H_kv = k.shape[1]
+    num_groups = H_q // H_kv
+
+    if num_groups > 1:
+        k = k.repeat_interleave(num_groups, dim=1)
+        v = v.repeat_interleave(num_groups, dim=1)
+
+    if attn_mask is not None and attn_mask.shape[1] == 1 and H_q > 1:
+        attn_mask = attn_mask.expand(-1, H_q, -1, -1)
+
+    return F.scaled_dot_product_attention(
+        q.float(),
+        k.float(),
+        v.float(),
+        attn_mask=attn_mask,
+        scale=scale,
+    )
+
+
+def _max_abs_error(out, ref):
+    return (out.float() - ref.float()).abs().max().item()
+
+
+# bf16 kernel vs fp32 reference tolerance.
+# Matches benchmark cross-validation and test_triton_sdpa.py.
+MAX_ABS_TOL = 1e-2
+
+
+HEAD_DIMS_POW2 = [64, 128, 256]
+
+GQA_CONFIGS = [
+    (6, 3, "gqa_2x"),
+    (8, 2, "gqa_4x"),
+    (16, 2, "gqa_8x"),
+    (6, 1, "mqa"),
+]
+
+LK_LENGTHS = [64, 128, 512, 1024, 4096]
+
+
+class TestTritonSdpaSplitK(unittest.TestCase):
+    """Test split-K decode SDPA kernel correctness against PyTorch reference."""
+
+    @classmethod
+    def setUpClass(cls):
+        _skip_if_no_cuda()
+        cls.splitk = _import_splitk()
+        cls.sdpa = _import_sdpa()
+
+    # ------------------------------------------------------------------
+    # Correctness
+    # ------------------------------------------------------------------
+
+    def test_decode_basic(self):
+        """GQA decode across head configs, head dims, and KV lengths."""
+        for (H_q, H_kv, label), D, Lk in itertools.product(
+            GQA_CONFIGS,
+            HEAD_DIMS_POW2,
+            LK_LENGTHS,
+        ):
+            with self.subTest(label=label, D=D, Lk=Lk):
+                B, Lq = 1, 1
+                torch.manual_seed(42)
+                q = torch.randn(B, H_q, Lq, D, dtype=torch.bfloat16, device="cuda")
+                k = torch.randn(B, H_kv, Lk, D, dtype=torch.bfloat16, device="cuda")
+                v = torch.randn(B, H_kv, Lk, D, dtype=torch.bfloat16, device="cuda")
+
+                out = self.splitk(q, k, v)
+                ref = _reference_sdpa(q, k, v)
+
+                self.assertEqual(out.shape, (B, H_q, Lq, D))
+                self.assertFalse(torch.isnan(out).any(), "NaN in output")
+                self.assertLess(
+                    _max_abs_error(out, ref),
+                    0.05,
+                    f"{label} D={D} Lk={Lk}",
+                )
+
+    def test_decode_with_mask(self):
+        """Decode with bool mask (KV cache style: first N positions valid)."""
+        for H_q, H_kv, label in GQA_CONFIGS:
+            with self.subTest(label=label):
+                B, Lq, Lk, D = 1, 1, 512, 128
+                torch.manual_seed(42)
+                q = torch.randn(B, H_q, Lq, D, dtype=torch.bfloat16, device="cuda")
+                k = torch.randn(B, H_kv, Lk, D, dtype=torch.bfloat16, device="cuda")
+                v = torch.randn(B, H_kv, Lk, D, dtype=torch.bfloat16, device="cuda")
+
+                mask = torch.zeros(B, 1, Lq, Lk, dtype=torch.bool, device="cuda")
+                mask[:, :, :, :200] = True
+
+                out = self.splitk(q, k, v, attn_mask=mask)
+                ref = _reference_sdpa(q, k, v, attn_mask=mask)
+
+                self.assertFalse(torch.isnan(out).any())
+                self.assertLess(_max_abs_error(out, ref), MAX_ABS_TOL)
+
+    def test_decode_mha(self):
+        """MHA (H_q==H_kv, num_groups=1) should work with split-K."""
+        for D, Lk in itertools.product([64, 128], [128, 512]):
+            with self.subTest(D=D, Lk=Lk):
+                B, H, Lq = 1, 4, 1
+                torch.manual_seed(42)
+                q = torch.randn(B, H, Lq, D, dtype=torch.bfloat16, device="cuda")
+                k = torch.randn(B, H, Lk, D, dtype=torch.bfloat16, device="cuda")
+                v = torch.randn(B, H, Lk, D, dtype=torch.bfloat16, device="cuda")
+
+                out = self.splitk(q, k, v)
+                ref = _reference_sdpa(q, k, v)
+
+                self.assertFalse(torch.isnan(out).any())
+                self.assertLess(_max_abs_error(out, ref), MAX_ABS_TOL)
+
+    def test_qwen35_config(self):
+        """Exact Qwen3.5 MoE config: H_q=16, H_kv=2, D=256."""
+        B, H_q, H_kv, D = 1, 16, 2, 256
+        for Lk in [128, 512, 1024, 4096]:
+            with self.subTest(Lk=Lk):
+                Lq = 1
+                torch.manual_seed(42)
+                q = torch.randn(B, H_q, Lq, D, dtype=torch.bfloat16, device="cuda")
+                k = torch.randn(B, H_kv, Lk, D, dtype=torch.bfloat16, device="cuda")
+                v = torch.randn(B, H_kv, Lk, D, dtype=torch.bfloat16, device="cuda")
+
+                mask = torch.ones(B, 1, Lq, Lk, dtype=torch.bool, device="cuda")
+
+                out = self.splitk(q, k, v, attn_mask=mask)
+                ref = _reference_sdpa(q, k, v, attn_mask=mask)
+
+                self.assertEqual(out.shape, (B, H_q, Lq, D))
+                self.assertFalse(torch.isnan(out).any())
+                self.assertLess(_max_abs_error(out, ref), MAX_ABS_TOL)
+
+    def test_custom_scale(self):
+        """Non-default attention scale."""
+        B, H_q, H_kv, Lq, Lk, D = 1, 8, 2, 1, 256, 128
+        torch.manual_seed(42)
+        q = torch.randn(B, H_q, Lq, D, dtype=torch.bfloat16, device="cuda")
+        k = torch.randn(B, H_kv, Lk, D, dtype=torch.bfloat16, device="cuda")
+        v = torch.randn(B, H_kv, Lk, D, dtype=torch.bfloat16, device="cuda")
+
+        scale = 0.05
+        out = self.splitk(q, k, v, scale=scale)
+        ref = _reference_sdpa(q, k, v, scale=scale)
+
+        self.assertFalse(torch.isnan(out).any())
+        self.assertLess(_max_abs_error(out, ref), MAX_ABS_TOL)
+
+    def test_cross_validate_with_sdpa(self):
+        """Split-K output matches tiled sdpa output for decode shapes."""
+        B, H_q, H_kv, D = 1, 8, 2, 128
+        for Lk in [128, 512, 1024]:
+            with self.subTest(Lk=Lk):
+                Lq = 1
+                torch.manual_seed(42)
+                q = torch.randn(B, H_q, Lq, D, dtype=torch.bfloat16, device="cuda")
+                k = torch.randn(B, H_kv, Lk, D, dtype=torch.bfloat16, device="cuda")
+                v = torch.randn(B, H_kv, Lk, D, dtype=torch.bfloat16, device="cuda")
+                mask = torch.ones(B, 1, Lq, Lk, dtype=torch.bool, device="cuda")
+
+                out_splitk = self.splitk(q, k, v, attn_mask=mask)
+                out_tiled = self.sdpa(q, k, v, attn_mask=mask, enable_gqa=True)
+
+                self.assertLess(
+                    _max_abs_error(out_splitk, out_tiled),
+                    MAX_ABS_TOL,
+                    f"Split-K vs tiled mismatch at Lk={Lk}",
+                )
+
+    # ------------------------------------------------------------------
+    # Edge cases
+    # ------------------------------------------------------------------
+
+    def test_all_masked(self):
+        """All-False mask should produce zeros, not NaN."""
+        B, H_q, H_kv, Lq, Lk, D = 1, 8, 2, 1, 128, 64
+        torch.manual_seed(42)
+        q = torch.randn(B, H_q, Lq, D, dtype=torch.bfloat16, device="cuda")
+        k = torch.randn(B, H_kv, Lk, D, dtype=torch.bfloat16, device="cuda")
+        v = torch.randn(B, H_kv, Lk, D, dtype=torch.bfloat16, device="cuda")
+
+        mask = torch.zeros(B, 1, Lq, Lk, dtype=torch.bool, device="cuda")
+        out = self.splitk(q, k, v, attn_mask=mask)
+
+        self.assertFalse(torch.isnan(out).any(), "All-masked should not NaN")
+        self.assertFalse(torch.isinf(out).any(), "All-masked should not Inf")
+
+    def test_lk_1(self):
+        """Degenerate single KV position (num_splits=1)."""
+        B, H_q, H_kv, Lq, Lk, D = 1, 4, 2, 1, 1, 64
+        torch.manual_seed(42)
+        q = torch.randn(B, H_q, Lq, D, dtype=torch.bfloat16, device="cuda")
+        k = torch.randn(B, H_kv, Lk, D, dtype=torch.bfloat16, device="cuda")
+        v = torch.randn(B, H_kv, Lk, D, dtype=torch.bfloat16, device="cuda")
+
+        out = self.splitk(q, k, v)
+        ref = _reference_sdpa(q, k, v)
+
+        self.assertFalse(torch.isnan(out).any())
+        self.assertLess(_max_abs_error(out, ref), MAX_ABS_TOL)
+
+    def test_batch_size(self):
+        """Batch size > 1."""
+        for B in [2, 4]:
+            with self.subTest(B=B):
+                H_q, H_kv, Lq, Lk, D = 8, 2, 1, 256, 128
+                torch.manual_seed(42)
+                q = torch.randn(B, H_q, Lq, D, dtype=torch.bfloat16, device="cuda")
+                k = torch.randn(B, H_kv, Lk, D, dtype=torch.bfloat16, device="cuda")
+                v = torch.randn(B, H_kv, Lk, D, dtype=torch.bfloat16, device="cuda")
+
+                out = self.splitk(q, k, v)
+                ref = _reference_sdpa(q, k, v)
+
+                self.assertFalse(torch.isnan(out).any())
+                self.assertLess(_max_abs_error(out, ref), MAX_ABS_TOL)
+
+    # ------------------------------------------------------------------
+    # Validation errors
+    # ------------------------------------------------------------------
+
+    def test_lq_not_1_rejected(self):
+        """L_q != 1 should raise RuntimeError."""
+        B, H_q, H_kv, D = 1, 8, 2, 64
+        q = torch.randn(B, H_q, 4, D, dtype=torch.bfloat16, device="cuda")
+        k = torch.randn(B, H_kv, 64, D, dtype=torch.bfloat16, device="cuda")
+        v = torch.randn(B, H_kv, 64, D, dtype=torch.bfloat16, device="cuda")
+        with self.assertRaises(RuntimeError):
+            self.splitk(q, k, v)
+
+    def test_dropout_rejected(self):
+        """dropout_p != 0 should raise RuntimeError."""
+        B, H_q, H_kv, D = 1, 8, 2, 64
+        q = torch.randn(B, H_q, 1, D, dtype=torch.bfloat16, device="cuda")
+        k = torch.randn(B, H_kv, 64, D, dtype=torch.bfloat16, device="cuda")
+        v = torch.randn(B, H_kv, 64, D, dtype=torch.bfloat16, device="cuda")
+        with self.assertRaises(RuntimeError):
+            self.splitk(q, k, v, dropout_p=0.1)
+
+    def test_is_causal_accepted(self):
+        """is_causal=True is a no-op at L_q=1, should not raise."""
+        B, H_q, H_kv, D = 1, 8, 2, 64
+        q = torch.randn(B, H_q, 1, D, dtype=torch.bfloat16, device="cuda")
+        k = torch.randn(B, H_kv, 64, D, dtype=torch.bfloat16, device="cuda")
+        v = torch.randn(B, H_kv, 64, D, dtype=torch.bfloat16, device="cuda")
+        out = self.splitk(q, k, v, is_causal=True)
+        self.assertEqual(out.shape, (B, H_q, 1, D))
+
+    def test_hq_not_divisible_rejected(self):
+        """H_q % H_kv != 0 should raise RuntimeError."""
+        B, D = 1, 64
+        q = torch.randn(B, 5, 1, D, dtype=torch.bfloat16, device="cuda")
+        k = torch.randn(B, 3, 64, D, dtype=torch.bfloat16, device="cuda")
+        v = torch.randn(B, 3, 64, D, dtype=torch.bfloat16, device="cuda")
+        with self.assertRaises(RuntimeError):
+            self.splitk(q, k, v)
+
+    def test_non_pow2_d_rejected(self):
+        """Non-power-of-2 D should raise RuntimeError."""
+        B, H_q, H_kv, D = 1, 8, 2, 96
+        q = torch.randn(B, H_q, 1, D, dtype=torch.bfloat16, device="cuda")
+        k = torch.randn(B, H_kv, 64, D, dtype=torch.bfloat16, device="cuda")
+        v = torch.randn(B, H_kv, 64, D, dtype=torch.bfloat16, device="cuda")
+        with self.assertRaises(RuntimeError):
+            self.splitk(q, k, v)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backends/cuda/triton/kernels/__init__.py
+++ b/backends/cuda/triton/kernels/__init__.py
@@ -5,12 +5,13 @@
 # LICENSE file in the root directory of this source tree.
 
 from executorch.backends.cuda.triton.kernels.fused_moe import fused_moe
-from executorch.backends.cuda.triton.kernels.sdpa import sdpa
+from executorch.backends.cuda.triton.kernels.sdpa import sdpa, sdpa_decode_splitk
 from executorch.backends.cuda.triton.kernels.topk import topk
 
 __all__ = [
     "fused_moe",
     "sdpa",
+    "sdpa_decode_splitk",
     "topk",
 ]
 

--- a/backends/cuda/triton/kernels/sdpa.py
+++ b/backends/cuda/triton/kernels/sdpa.py
@@ -1390,39 +1390,67 @@ def sdpa_decode_splitk(
     key: torch.Tensor,
     value: torch.Tensor,
     attn_mask: Optional[torch.Tensor] = None,
+    dropout_p: float = 0.0,
+    is_causal: bool = False,
     scale: float = 0.0,
+    enable_gqa: bool = False,
 ) -> torch.Tensor:
+    """Split-K flash-decoding SDPA for L_q=1 (decode step).
+
+    Signature mirrors sdpa() for drop-in use with torch.cond dispatch.
+    enable_gqa is accepted but ignored — GQA is handled natively via
+    H_q // H_kv grouping; no packed-GQA tradeoff exists at L_q=1.
+    """
+    _validate_sdpa_inputs(query, key, value, dropout_p, enable_gqa)
+
     B, H_q, L_q, D = query.shape
     _, H_kv, L_kv, _ = key.shape
+
+    out = torch.empty((B, H_q, L_q, D), device=query.device, dtype=query.dtype)
 
     # is_causal is a no-op at L_q=1 (single query can't attend to future
     # positions), so we accept it silently for API compatibility with callers
     # that always pass is_causal=True for decode.
 
-    if L_q != 1:
-        raise RuntimeError(
-            f"sdpa_decode_splitk requires L_q == 1 (decode); got L_q={L_q}"
-        )
-    if H_q % H_kv != 0:
-        raise RuntimeError(
-            f"H_q must be divisible by H_kv; got H_q={H_q}, H_kv={H_kv}"
-        )
-    if not _is_power_of_2(D):
-        raise RuntimeError(
-            f"sdpa_decode_splitk requires power-of-2 head dim; got D={D}"
-        )
+    # Validation — only check at runtime (concrete shapes), not during AOTI
+    # tracing where shapes are symbolic. torch.cond traces both branches with
+    # the same symbolic L_q, so L_q is not necessarily 1 during tracing.
+    if isinstance(L_q, int):
+        if L_q != 1:
+            raise RuntimeError(
+                f"sdpa_decode_splitk requires L_q == 1 (decode); got L_q={L_q}"
+            )
+        if H_q % H_kv != 0:
+            raise RuntimeError(
+                f"H_q must be divisible by H_kv; got H_q={H_q}, H_kv={H_kv}"
+            )
+        if not _is_power_of_2(D):
+            raise RuntimeError(
+                f"sdpa_decode_splitk requires power-of-2 head dim; got D={D}"
+            )
 
     num_groups = H_q // H_kv
-    out = torch.empty((B, H_q, L_q, D), device=query.device, dtype=query.dtype)
     sm_scale = 1.0 / math.sqrt(D) if scale == 0.0 else scale
     HAS_MASK, Mask_ptr, stride_mb, stride_mq, stride_mk = _prepare_mask_params(
         attn_mask, B, L_q, L_kv
     )
 
     _launch_decode_splitk(
-        query, key, value, out,
-        B, H_q, H_kv, L_kv, D, sm_scale,
-        HAS_MASK, Mask_ptr, stride_mb, stride_mq, stride_mk,
+        query,
+        key,
+        value,
+        out,
+        B,
+        H_q,
+        H_kv,
+        L_kv,
+        D,
+        sm_scale,
+        HAS_MASK,
+        Mask_ptr,
+        stride_mb,
+        stride_mq,
+        stride_mk,
         num_groups,
     )
     return out
@@ -1434,7 +1462,10 @@ def _sdpa_decode_splitk_abstract(
     key: torch.Tensor,
     value: torch.Tensor,
     attn_mask: Optional[torch.Tensor] = None,
+    dropout_p: float = 0.0,
+    is_causal: bool = False,
     scale: float = 0.0,
+    enable_gqa: bool = False,
 ) -> torch.Tensor:
     assert query.dtype == key.dtype == value.dtype, "Q, K, V must have the same dtype"
     B, H_q, L_q, D = query.shape

--- a/backends/cuda/triton/kernels/sdpa.py
+++ b/backends/cuda/triton/kernels/sdpa.py
@@ -46,7 +46,11 @@ def _is_power_of_2(n: int) -> bool:
 
 
 def _next_power_of_2(x: int) -> int:
-    """Get the next power of 2 >= x, clamped to [16, 256]."""
+    """Get the next power of 2 >= x, clamped to [16, 256].
+
+    Used for HEAD_DIM tiling where tile sizes below 16 waste warps
+    and head dims above 256 are unsupported.
+    """
     if x <= 16:
         return 16
     if x <= 32:
@@ -56,6 +60,17 @@ def _next_power_of_2(x: int) -> int:
     if x <= 128:
         return 128
     return 256
+
+
+def _next_power_of_2_unclamped(x: int) -> int:
+    """Get the next power of 2 >= x (no clamping).
+
+    Used for GQA group-count tiling where num_groups can be small (1, 2, ...)
+    and should not be inflated to 16.
+    """
+    if x <= 0:
+        return 1
+    return 1 << (x - 1).bit_length()
 
 
 def _should_pack_gqa(L_q: int, num_groups: int, block_m: int) -> bool:
@@ -1032,3 +1047,395 @@ def _sdpa_abstract(
     B, H_q, _H_kv, L_q, _, D_q, _ = _validate_qkv_shapes(query, key, value, enable_gqa)
 
     return torch.empty(B, H_q, L_q, D_q, dtype=query.dtype, device=query.device)
+
+
+# ==============================================================================
+# Split-K decode kernel (flash-decoding)
+# ==============================================================================
+# When L_q == 1 with GQA, the standard kernel launches only
+# ceil(num_groups / BLOCK_M) * B * H_kv CTAs (e.g. 2 for Qwen3.5 MoE).
+# Split-K partitions the KV sequence across many CTAs for better occupancy,
+# then reduces partial results in a second kernel.
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_N": 32}, num_warps=2, num_stages=1),
+        triton.Config({"BLOCK_N": 32}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_N": 64}, num_warps=2, num_stages=1),
+        triton.Config({"BLOCK_N": 64}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_N": 64}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_N": 128}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_N": 128}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_N": 128}, num_warps=4, num_stages=3),
+        triton.Config({"BLOCK_N": 128}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_N": 256}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_N": 256}, num_warps=8, num_stages=2),
+    ],
+    key=["Lk", "HEAD_DIM", "NUM_GROUPS", "HAS_MASK"],
+)
+@triton.jit
+def _sdpa_decode_splitk_kernel(
+    Q_ptr,
+    K_ptr,
+    V_ptr,
+    O_partial_ptr,
+    M_partial_ptr,
+    L_partial_ptr,
+    Mask_ptr,
+    B,
+    H_kv,
+    Lk,
+    stride_qb,
+    stride_qh,
+    stride_qm,
+    stride_qd,
+    stride_kb,
+    stride_kh,
+    stride_kn,
+    stride_kd,
+    stride_vb,
+    stride_vh,
+    stride_vn,
+    stride_vd,
+    stride_op_s,
+    stride_op_b,
+    stride_op_h,
+    stride_op_d,
+    stride_mp_s,
+    stride_mp_b,
+    stride_mp_h,
+    stride_mb,
+    stride_mq,
+    stride_mk,
+    sm_scale: tl.float32,
+    chunk_size,
+    HAS_MASK: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    NUM_GROUPS: tl.constexpr,
+    BLOCK_G: tl.constexpr,
+):
+    split_id = tl.program_id(axis=0)
+    pid_bh = tl.program_id(axis=1)
+    b = pid_bh // H_kv
+    h_kv = pid_bh % H_kv
+
+    start_n = split_id * chunk_size
+    end_n = tl.minimum(start_n + chunk_size, Lk)
+
+    offs_d = tl.arange(0, HEAD_DIM)
+    offs_g = tl.arange(0, BLOCK_G)
+    g_valid = offs_g < NUM_GROUPS
+    h_q_heads = h_kv * NUM_GROUPS + offs_g  # [BLOCK_G]
+
+    # Load Q for all heads in this group: [BLOCK_G, HEAD_DIM]
+    q_ptrs = Q_ptr + (
+        b * stride_qb
+        + h_q_heads[:, None] * stride_qh
+        + 0 * stride_qm
+        + offs_d[None, :] * stride_qd
+    )
+    q = tl.load(q_ptrs, mask=g_valid[:, None], other=0.0).to(tl.bfloat16)
+
+    m_i = tl.full([BLOCK_G], -float("inf"), dtype=tl.float32)
+    l_i = tl.zeros([BLOCK_G], dtype=tl.float32)
+    acc = tl.zeros([BLOCK_G, HEAD_DIM], dtype=tl.float32)
+
+    offs_n_init = tl.arange(0, BLOCK_N)
+
+    for tile_start in tl.range(start_n, end_n, BLOCK_N):
+        offs_n = tile_start + offs_n_init
+        n_valid = offs_n < end_n
+
+        k_ptrs = K_ptr + (
+            b * stride_kb
+            + h_kv * stride_kh
+            + offs_n[:, None] * stride_kn
+            + offs_d[None, :] * stride_kd
+        )
+        k = tl.load(k_ptrs, mask=n_valid[:, None], other=0.0).to(tl.bfloat16)
+
+        # QK: [BLOCK_G, BLOCK_N]
+        qk = (tl.dot(q, tl.trans(k)).to(tl.float32) * sm_scale).to(tl.float32)
+
+        # Mask out-of-bounds KV positions
+        qk = tl.where(
+            n_valid[None, :],
+            qk,
+            tl.full(qk.shape, -float("inf"), dtype=tl.float32),
+        )
+
+        if HAS_MASK:
+            mask_ptrs = Mask_ptr + (
+                b * stride_mb + 0 * stride_mq + offs_n[None, :] * stride_mk
+            )
+            mask_block = tl.load(mask_ptrs, mask=n_valid[None, :], other=False)
+            qk = tl.where(
+                mask_block, qk, tl.full(qk.shape, -float("inf"), dtype=tl.float32)
+            )
+
+        # Online softmax update
+        m_ij = tl.maximum(m_i, tl.max(qk, axis=1).to(tl.float32))
+        safe_diff = tl.where(
+            m_ij[:, None] > -float("inf"), qk - m_ij[:, None], -float("inf")
+        )
+        p_f32 = tl.exp(safe_diff).to(tl.float32)
+        l_ij = tl.sum(p_f32, axis=1).to(tl.float32)
+        safe_alpha_diff = tl.where(m_ij > -float("inf"), m_i - m_ij, 0.0)
+        alpha = tl.exp(safe_alpha_diff).to(tl.float32)
+
+        v_ptrs = V_ptr + (
+            b * stride_vb
+            + h_kv * stride_vh
+            + offs_n[:, None] * stride_vn
+            + offs_d[None, :] * stride_vd
+        )
+        v = tl.load(v_ptrs, mask=n_valid[:, None], other=0.0).to(tl.bfloat16)
+
+        p_bf16 = p_f32.to(tl.bfloat16)
+        acc = (acc * alpha[:, None] + tl.dot(p_bf16, v)).to(tl.float32)
+        l_i = (l_i * alpha + l_ij).to(tl.float32)
+        m_i = m_ij
+
+    # Store partial results for valid groups only
+    h_q_all = h_kv * NUM_GROUPS + offs_g  # [BLOCK_G]
+    o_ptrs = O_partial_ptr + (
+        split_id * stride_op_s
+        + b * stride_op_b
+        + h_q_all[:, None] * stride_op_h
+        + offs_d[None, :] * stride_op_d
+    )
+    tl.store(o_ptrs, acc, mask=g_valid[:, None])
+
+    ml_ptrs = M_partial_ptr + (
+        split_id * stride_mp_s + b * stride_mp_b + h_q_all * stride_mp_h
+    )
+    tl.store(ml_ptrs, m_i, mask=g_valid)
+
+    ll_ptrs = L_partial_ptr + (
+        split_id * stride_mp_s + b * stride_mp_b + h_q_all * stride_mp_h
+    )
+    tl.store(ll_ptrs, l_i, mask=g_valid)
+
+
+@triton.jit
+def _sdpa_decode_reduce_kernel(
+    O_partial_ptr,
+    M_partial_ptr,
+    L_partial_ptr,
+    O_ptr,
+    num_splits,
+    stride_op_s,
+    stride_op_b,
+    stride_op_h,
+    stride_op_d,
+    stride_mp_s,
+    stride_mp_b,
+    stride_mp_h,
+    stride_ob,
+    stride_oh,
+    stride_om,
+    stride_od,
+    HEAD_DIM: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    offs_d = tl.arange(0, HEAD_DIM)
+
+    # pid indexes into flattened (B, H_q). Partial buffers are allocated
+    # contiguous in _launch_decode_splitk, so pid * stride_*_h is valid.
+    # Find global max across all splits
+    m_global = tl.full([1], -float("inf"), dtype=tl.float32)
+    for s in tl.range(0, num_splits):
+        m_ptr = M_partial_ptr + s * stride_mp_s + pid * stride_mp_h
+        m_s = tl.load(m_ptr)
+        m_global = tl.maximum(m_global, m_s)
+
+    # Accumulate rescaled outputs
+    acc = tl.zeros([HEAD_DIM], dtype=tl.float32)
+    l_global = tl.zeros([1], dtype=tl.float32)
+    for s in tl.range(0, num_splits):
+        m_ptr = M_partial_ptr + s * stride_mp_s + pid * stride_mp_h
+        l_ptr = L_partial_ptr + s * stride_mp_s + pid * stride_mp_h
+        o_ptrs = O_partial_ptr + (
+            s * stride_op_s + pid * stride_op_h + offs_d * stride_op_d
+        )
+
+        m_s = tl.load(m_ptr)
+        l_s = tl.load(l_ptr)
+        o_s = tl.load(o_ptrs)
+
+        safe_diff = tl.where(m_global > -float("inf"), m_s - m_global, 0.0)
+        scale = tl.exp(safe_diff).to(tl.float32)
+        acc += o_s * scale
+        l_global += l_s * scale
+
+    inv_l = tl.where(l_global > 0, 1.0 / l_global, 0.0)
+    acc = acc * inv_l
+
+    # pid = b*H_q + h_q. For contiguous output [B, H_q, 1, D] with L_q=1,
+    # stride_ob == H_q * stride_oh, so pid * stride_oh is correct.
+    # This relies on `out` being freshly allocated and contiguous.
+    o_out_ptrs = O_ptr + pid * stride_oh + offs_d * stride_od
+    tl.store(o_out_ptrs, acc.to(tl.bfloat16))
+
+
+def _launch_decode_splitk(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    out: torch.Tensor,
+    B: int,
+    H_q: int,
+    H_kv: int,
+    L_kv: int,
+    D: int,
+    sm_scale: float,
+    HAS_MASK: bool,
+    Mask_ptr,
+    stride_mb: int,
+    stride_mq: int,
+    stride_mk: int,
+    num_groups: int,
+) -> None:
+    num_splits = min(max(triton.cdiv(L_kv, 256), 1), 128)
+    chunk_size = triton.cdiv(L_kv, num_splits)
+
+    O_partial = torch.empty(
+        (num_splits, B, H_q, D), device=query.device, dtype=torch.float32
+    )
+    M_partial = torch.full(
+        (num_splits, B, H_q), -float("inf"), device=query.device, dtype=torch.float32
+    )
+    L_partial = torch.zeros(
+        (num_splits, B, H_q), device=query.device, dtype=torch.float32
+    )
+
+    stride_qb, stride_qh, stride_qm, stride_qd = query.stride()
+    stride_kb, stride_kh, stride_kn, stride_kd = key.stride()
+    stride_vb, stride_vh, stride_vn, stride_vd = value.stride()
+    stride_ob, stride_oh, stride_om, stride_od = out.stride()
+    stride_op_s, stride_op_b, stride_op_h, stride_op_d = O_partial.stride()
+    stride_mp_s, stride_mp_b, stride_mp_h = M_partial.stride()
+
+    grid_split = (num_splits, B * H_kv)
+    wrap_triton(_sdpa_decode_splitk_kernel)[grid_split](
+        query,
+        key,
+        value,
+        O_partial,
+        M_partial,
+        L_partial,
+        Mask_ptr if HAS_MASK else 0,
+        B,
+        H_kv,
+        L_kv,
+        stride_qb,
+        stride_qh,
+        stride_qm,
+        stride_qd,
+        stride_kb,
+        stride_kh,
+        stride_kn,
+        stride_kd,
+        stride_vb,
+        stride_vh,
+        stride_vn,
+        stride_vd,
+        stride_op_s,
+        stride_op_b,
+        stride_op_h,
+        stride_op_d,
+        stride_mp_s,
+        stride_mp_b,
+        stride_mp_h,
+        stride_mb,
+        stride_mq,
+        stride_mk,
+        sm_scale,
+        chunk_size,
+        HAS_MASK=HAS_MASK,
+        HEAD_DIM=D,
+        NUM_GROUPS=num_groups,
+        BLOCK_G=_next_power_of_2_unclamped(num_groups),
+    )
+
+    grid_reduce = (B * H_q,)
+    wrap_triton(_sdpa_decode_reduce_kernel)[grid_reduce](
+        O_partial,
+        M_partial,
+        L_partial,
+        out,
+        num_splits,
+        stride_op_s,
+        stride_op_b,
+        stride_op_h,
+        stride_op_d,
+        stride_mp_s,
+        stride_mp_b,
+        stride_mp_h,
+        stride_ob,
+        stride_oh,
+        stride_om,
+        stride_od,
+        HEAD_DIM=D,
+        num_warps=4,
+        num_stages=1,
+    )
+
+
+@triton_op("triton::sdpa_decode_splitk", mutates_args={})
+def sdpa_decode_splitk(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attn_mask: Optional[torch.Tensor] = None,
+    scale: float = 0.0,
+) -> torch.Tensor:
+    B, H_q, L_q, D = query.shape
+    _, H_kv, L_kv, _ = key.shape
+
+    # is_causal is a no-op at L_q=1 (single query can't attend to future
+    # positions), so we accept it silently for API compatibility with callers
+    # that always pass is_causal=True for decode.
+
+    if L_q != 1:
+        raise RuntimeError(
+            f"sdpa_decode_splitk requires L_q == 1 (decode); got L_q={L_q}"
+        )
+    if H_q % H_kv != 0:
+        raise RuntimeError(
+            f"H_q must be divisible by H_kv; got H_q={H_q}, H_kv={H_kv}"
+        )
+    if not _is_power_of_2(D):
+        raise RuntimeError(
+            f"sdpa_decode_splitk requires power-of-2 head dim; got D={D}"
+        )
+
+    num_groups = H_q // H_kv
+    out = torch.empty((B, H_q, L_q, D), device=query.device, dtype=query.dtype)
+    sm_scale = 1.0 / math.sqrt(D) if scale == 0.0 else scale
+    HAS_MASK, Mask_ptr, stride_mb, stride_mq, stride_mk = _prepare_mask_params(
+        attn_mask, B, L_q, L_kv
+    )
+
+    _launch_decode_splitk(
+        query, key, value, out,
+        B, H_q, H_kv, L_kv, D, sm_scale,
+        HAS_MASK, Mask_ptr, stride_mb, stride_mq, stride_mk,
+        num_groups,
+    )
+    return out
+
+
+@sdpa_decode_splitk.register_fake
+def _sdpa_decode_splitk_abstract(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attn_mask: Optional[torch.Tensor] = None,
+    scale: float = 0.0,
+) -> torch.Tensor:
+    assert query.dtype == key.dtype == value.dtype, "Q, K, V must have the same dtype"
+    B, H_q, L_q, D = query.shape
+    return torch.empty(B, H_q, L_q, D, dtype=query.dtype, device=query.device)

--- a/examples/models/qwen3_5_moe/export.py
+++ b/examples/models/qwen3_5_moe/export.py
@@ -626,9 +626,14 @@ def _export_cuda(model, config, args):
     print("Decode export successful!")
 
     # --- Prefill method (T>=2, dynamic shape) ---
+    # Example T must equal max_seq_len-1 so AOTI compiles kernels (especially
+    # chunk_gated_delta_rule with CHUNK_SIZE=64) for the full range of sequence
+    # lengths. Smaller examples cause AOTI to bake in intermediate buffer sizes
+    # that reject longer prompts at runtime.
     print("Exporting prefill method...")
-    prefill_tokens = torch.tensor([[0, 1]], dtype=torch.long)
-    prefill_pos = torch.tensor([0, 1], dtype=torch.long)
+    example_prefill_len = config.max_seq_len - 1
+    prefill_tokens = torch.zeros((1, example_prefill_len), dtype=torch.long)
+    prefill_pos = torch.arange(example_prefill_len, dtype=torch.long)
     seq_dim = Dim("seq_len", min=2, max=config.max_seq_len - 1)
     prefill_dynamic_shapes = (
         {1: seq_dim},  # tokens

--- a/examples/models/qwen3_5_moe/export.py
+++ b/examples/models/qwen3_5_moe/export.py
@@ -68,7 +68,7 @@ def _prepare_and_quantize_mlx(model, config, args):
     pack_all_switch_linears(model)
 
 
-def load_and_quantize(args):
+def load_and_quantize(args):  # noqa: C901
     """Load model from checkpoint, optionally quantize.
 
     For CUDA: quantizes experts with packed INT4, then transformer layers on CUDA.
@@ -77,6 +77,7 @@ def load_and_quantize(args):
     Returns (model, config) ready for export.
     """
     backend = getattr(args, "backend", "cuda")
+    use_splitk = not getattr(args, "no_splitk", False)
 
     if not args.prequantized:
         if getattr(args, "tiny_test", False):
@@ -111,6 +112,7 @@ def load_and_quantize(args):
                 rms_norm_eps=1e-6,
                 rope_theta=10_000.0,
                 max_seq_len=64,
+                use_splitk_decode=use_splitk,
             )
             print("Building tiny model with random weights...")
             torch.manual_seed(42)
@@ -133,6 +135,10 @@ def load_and_quantize(args):
             model, config = Qwen35MoE.from_hf_checkpoint(
                 args.model_dir, max_seq_len=args.max_seq_len
             )
+            config.use_splitk_decode = use_splitk
+            for layer in model.layers:
+                if hasattr(layer.attn, "use_splitk_decode"):
+                    layer.attn.use_splitk_decode = use_splitk
             model.eval()
             print(
                 f"Model: {config.num_hidden_layers} layers, {config.hidden_size}d, "
@@ -148,7 +154,11 @@ def load_and_quantize(args):
 
     elif backend == "cuda":
         if args.prequantized:
-            return load_prequantized_model(args.prequantized, args.max_seq_len)
+            return load_prequantized_model(
+                args.prequantized,
+                args.max_seq_len,
+                use_splitk_decode=use_splitk,
+            )
 
         # CUDA: quantize experts with packed INT4 for Triton kernel
         if args.qlinear or args.qembedding:
@@ -162,12 +172,13 @@ def load_and_quantize(args):
     return model, config
 
 
-def load_prequantized_model(prequantized_dir, max_seq_len=4096):
+def load_prequantized_model(prequantized_dir, max_seq_len=4096, use_splitk_decode=True):
     """Load a prequantized safetensors bundle into a model.
 
     Args:
         prequantized_dir: Directory containing model.safetensors and config.json.
         max_seq_len: Maximum sequence length for KV cache.
+        use_splitk_decode: Use split-K SDPA for decode instead of tiled SDPA.
 
     Returns:
         (model, config) ready for export.
@@ -181,6 +192,7 @@ def load_prequantized_model(prequantized_dir, max_seq_len=4096):
 
     config = Qwen35MoEConfig.from_hf_config(config_path)
     config.max_seq_len = max_seq_len
+    config.use_splitk_decode = use_splitk_decode
 
     print(f"Loading prequantized weights from {safetensors_path}...")
     state_dict = load_quantized_state_dict(safetensors_path)
@@ -788,6 +800,11 @@ def main():
         help="Build a tiny model with random weights for CI pipeline testing. "
         "No checkpoint download needed. Tests all architectural features "
         "(GQA, GDN head ratio, mixed attention, MoE routing) at small scale.",
+    )
+    parser.add_argument(
+        "--no-splitk",
+        action="store_true",
+        help="Disable split-K (flash-decoding) SDPA for decode; use tiled SDPA instead.",
     )
     args = parser.parse_args()
 

--- a/examples/models/qwen3_5_moe/model.py
+++ b/examples/models/qwen3_5_moe/model.py
@@ -50,6 +50,7 @@ class Qwen35MoEConfig:
     rms_norm_eps: float = 1e-6
     rope_theta: float = 10_000_000.0
     max_seq_len: int = 4096
+    use_splitk_decode: bool = True
     layer_types: list = field(default_factory=list)
 
     def __post_init__(self):
@@ -231,6 +232,7 @@ class FullAttention(nn.Module):
 
         self.kv_cache = KVCache(self.n_kv_heads, self.head_dim, config.max_seq_len)
         self.turboquant = False
+        self.use_splitk_decode = config.use_splitk_decode
 
         self.register_buffer(
             "cache_positions",
@@ -289,7 +291,7 @@ class FullAttention(nn.Module):
             # The export produces two methods — decode (T=1, static) and
             # prefill (T>=2, dynamic). Each traces only one branch, so no
             # torch.cond is needed and we avoid GPU→CPU sync overhead.
-            if T == 1:
+            if T == 1 and self.use_splitk_decode:
                 from executorch.backends.cuda.triton.kernels.sdpa import (
                     sdpa_decode_splitk,
                 )

--- a/examples/models/qwen3_5_moe/model.py
+++ b/examples/models/qwen3_5_moe/model.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass, field
 
 import torch
 import torch.nn as nn
+
 from torch.nn import functional as F
 
 
@@ -285,9 +286,19 @@ class FullAttention(nn.Module):
             )
         else:
             k, v = self.kv_cache.update(input_pos, k, v)
-            y = F.scaled_dot_product_attention(
-                q, k, v, attn_mask=attn_mask, enable_gqa=True
-            )
+            # The export produces two methods — decode (T=1, static) and
+            # prefill (T>=2, dynamic). Each traces only one branch, so no
+            # torch.cond is needed and we avoid GPU→CPU sync overhead.
+            if T == 1:
+                from executorch.backends.cuda.triton.kernels.sdpa import (
+                    sdpa_decode_splitk,
+                )
+
+                y = sdpa_decode_splitk(q, k, v, attn_mask=attn_mask)
+            else:
+                from executorch.backends.cuda.triton.kernels.sdpa import sdpa
+
+                y = sdpa(q, k, v, attn_mask=attn_mask, enable_gqa=True)
 
         y = y.transpose(1, 2).contiguous().view(B, T, -1)
 


### PR DESCRIPTION
  
### Performance Improvements for SDPA
Improves SDPA performance for decode sequences where $L_q = 1$.

#### Benchmark: qwen3.5-35B-A3B
* **Config:** Avg of 3 runs on A100.

### Decode Performance (tok/s)

| Prompt | Decode Len | Baseline | Split-K | Speedup |
|---|---|---|---|---|
| P2 (1 tok) | 16 | 86.3 | 105.3 | +22% |
| P2 | 64 | 87.1 | 108.4 | +24% |
| P2 | 256 | 89.2 | 108.3 | +21% |
| P2 | 1024 | 89.4 | 108.1 | +21% |
| P15 (15 tok) | 16 | 85.9 | 102.8 | +20% |
| P15 | 64 | 85.1 | 104.7 | +23% |
| P15 | 256 | 88.4 | 108.8 | +23% |
| P15 | 1024 | 90.0 | 107.2 | +19% |
| P59 (59 tok) | 16 | 86.8 | 96.1 | +11% |
| P59 | 64 | 89.5 | 99.8 | +12% |
| P59 | 256 | 88.9 | 108.5 | +22% |
| P59 | 1024 | 90.0 | 108.6 | +21% |
| P120 (143 tok) | 16 | 87.5 | 105.0 | +20% |
| P120 | 64 | 88.8 | 107.7 | +21% |
| P120 | 256 | 90.3 | 107.6 | +19% |
| P120 | 1024 | 89.4 | 109.3 | +22% |
| P1000 (1694 tok)| 16 | 86.4 | 103.2 | +19% |
| P1000 | 64 | 89.2 | 106.7 | +20% |
| P1000 | 256 | 90.2 | 108.0 | +20% |
| P1000 | 1024 | 89.7 | 108.0 | +20% |

---

### Prefill Performance (tok/s)

| Prompt | Baseline | Split-K | Delta |
|---|---|---|---|
| P2 (1 tok) | 19.4 | 19.3 | ~same |
| P15 (15 tok) | 192.8 | 191.6 | ~same |
| P59 (59 tok) | 390.2 | 368.1 | -6% |
| P120 (143 tok) | 512.4 | 481.9 | -6% |
| P1000 (1694 tok)| 585.6 | 591.4 | +1% |

> *Note: Prefill averaged across all 4 decode lengths per prompt since prefill is independent of decode length.*

---

### Summary

* **Decode:** Split-K delivers +20% average (88.6 → 106.5 tok/s)
* **Prefill:** similar between variants (both use tiled SDPA)
* **Quality:** Verified identical at `temperature=0`

(~25x speedup at the SDPA op level, for ~10.2K = 1024 tokens x 10 layers, calls we saw 5.3sec to 209ms speedup)

#### Implementation Details
* **Max Context Length:** 4K
* **Kernel Constraints:**
    * **Baseline:** Updates example input shapes to remove the 64-token cap.
    * **Prefill:** Baseline and Split-K should be equivalent for prefill (both use `_sdpa_fwd_kernel_m64`).