### PR TITLE
Fix uninitialised _outputNames in ETCoreMLModelProfiler causing crash when debug_buffer_size=0

### DIFF
--- a/backends/apple/coreml/runtime/sdk/ETCoreMLModelProfiler.mm
+++ b/backends/apple/coreml/runtime/sdk/ETCoreMLModelProfiler.mm
@@ -276,6 +276,7 @@ void set_model_outputs(id<MLFeatureProvider> output_features,
         self = [super init];
         if (self) {
             _model = model;
+            _outputNames = model.orderedOutputNames;
             _computePlan = computePlan;
             _operationToPathMap = operationToPathMap;
             _topologicallySortedOperations = topologicallySortedOperations;


### PR DESCRIPTION
### Summary

`ETCoreMLModelProfiler::initWithModel:configuration:error:` does not initialise the `_outputNames` property, leaving it as `nil`. This causes an `NSRangeException` crash when `enable_etdump=True` with
`debug_buffer_size=0`.

**Root cause:**

When `_outputNames` is `nil`, `set_model_outputs()` iterates over `nil.count` (0) and produces an empty `NSMutableArray`. This empty array is returned as `modelOutputs` from `profileModelWithInputs`. Later,
`ETCoreMLModelManager` attempts to access `modelOutputs[0].shape` for dynamic shape resizing, triggering:

NSRangeException: *** -[__NSArrayM objectAtIndexedSubscript:]: index 0 beyond bounds for empty array

This manifests as `RuntimeError: Caught an unknown exception!` at the Python level.

**Why this was not caught earlier:**

When `debug_buffer_size > 0`, `kIntermediateOutputs` debug level is set, which enables both `log_profiling_info` and `log_intermediate_tensors`. In `ETCoreMLModelAnalyzer::executeModelWithInputs`, the
`debugModelWithInputs` path runs after profiling and overwrites the empty array with valid outputs, masking the bug.

**Fix:**

Add `_outputNames = model.orderedOutputNames;` in the initialiser, consistent with how `outputNames` is used in `profilingInfoForOperationsAtPaths:` at line 319.

### Test plan

Tested on macOS 15.6 (arm64) with a CoreML model (input: 1x3x640x640, 3 outputs):

```python
from executorch.runtime import Runtime, Verification
import torch

rt = Runtime.get()
prog = rt.load_program("output_coreml.pte",
                        verification=Verification.Minimal,
                        enable_etdump=True,
                        debug_buffer_size=0)
method = prog.load_method("forward")
out = method.execute(torch.randn(1, 3, 640, 640))  # Previously crashed
prog.write_etdump_result_to_file("profile.etdump", "debug.bin")

┌──────────────────────────────────┬────────────────────────┬──────────────────────────────────┐
│             Scenario             │         Before         │              After               │
├──────────────────────────────────┼────────────────────────┼──────────────────────────────────┤
│ debug_buffer_size=0              │ NSRangeException crash │ Success, ETDump with timing data │
├──────────────────────────────────┼────────────────────────┼──────────────────────────────────┤
│ debug_buffer_size>0 (sufficient) │ Success (bug masked)   │ Success                          │
├──────────────────────────────────┼────────────────────────┼──────────────────────────────────┤
│                                  │                        │                                  │
└──────────────────────────────────┴────────────────────────┴──────────────────────────────────┘

cc @kimishpatel @YifanShenSZ @cymbalrush @metascroy