### PR TITLE
Fix empty FLAVOR in scheduled AAR builds

### DIFF
--- a/.github/workflows/android-release-artifacts.yml
+++ b/.github/workflows/android-release-artifacts.yml
@@ -53,6 +53,9 @@ jobs:
         run: |
           VERSION="${{ inputs.version }}"
           FLAVOR="${{ inputs.flavor }}"
+          if [ -z "$FLAVOR" ]; then
+            FLAVOR="xnnpack"
+          fi
           if [ -z "$VERSION" ]; then
             echo "No version name specified. Will create a snapshot AAR"
             echo "should-skip=false" >> $GITHUB_OUTPUT
@@ -115,9 +118,10 @@ jobs:
         fi
 
         FLAVOR="${{ inputs.flavor }}"
-        if [ ! -z "$FLAVOR" ]; then
-          GRADLE_ARGS+=" -Dflavor=${FLAVOR}"
+        if [ -z "$FLAVOR" ]; then
+          FLAVOR="xnnpack"
         fi
+        GRADLE_ARGS+=" -Dflavor=${FLAVOR}"
 
         if [[ "$FLAVOR" == "vulkan" || "$FLAVOR" == "all" || -z "$FLAVOR" ]]; then
           curl -O https://sdk.lunarg.com/sdk/download/1.4.321.1/linux/vulkansdk-linux-x86_64-1.4.321.1.tar.xz


### PR DESCRIPTION

### Summary
When triggered by cron schedule, `inputs.flavor` is empty since scheduled runs don't have inputs. The build-aar job was uploading the artifact as `executorch-.aar` (empty flavor), while upload-release-aar defaults flavor to "xnnpack" and tries to download `executorch-xnnpack.aar`, causing a 404.

Add consistent default fallback to "xnnpack" in both build-aar and check-if-aar-exists jobs, matching upload-release-aar.

### Test plan
CI