### PR TITLE
[ET-VK] Fix force_fp16 texture bias being silently rejected for CONTIGUOUS_ANY ops

### DIFF
--- a/backends/vulkan/utils.py
+++ b/backends/vulkan/utils.py
@@ -1511,14 +1511,19 @@ class OpRepSets:
         if not arg_current_repset.any_in_common(source_repset):
             return False
 
+        # Compute the narrowed repset (intersection of current arg and source).
+        narrowed = arg_current_repset.make_intersect(source_repset)
+
         if self.sync_primary_io_repr:
-            if not self.get_out_repset(0).has_compatible_packed_dim_info_set(
-                source_repset
-            ):
+            # Check that the narrowed result is compatible with the output.
+            # Using the intersection rather than the raw source_repset avoids
+            # rejecting valid constraints where the source has extra layouts
+            # (e.g. ANY_TEXTURE includes HP/CP) that don't exist in the output
+            # but also don't appear in the intersection.
+            if not self.get_out_repset(0).has_compatible_packed_dim_info_set(narrowed):
                 return False
 
         # If this point is reached, then it is possible to constrain
-        narrowed = arg_current_repset.make_intersect(source_repset)
         self.args_repset_list[arg_i] = narrowed
 
         # Propagate to other synced args via packed-dim compatibility


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #18772
* #18771
* __->__ #18770

The `force_fp16` path in `TagMemoryMetaPass` applies `ANY_TEXTURE` to
bias ops toward texture storage. However, `try_constrain_with_arg_repset`
has a packed-dim compatibility check that requires ALL of the source
repset's PDIs to exist in the output repset. `ANY_TEXTURE` has 3 texture
layouts (WP, HP, CP) but `CONTIGUOUS_ANY` outputs only support WP, so
the check fails and the texture bias is silently dropped.

Without the bias, buffer storage cascades from ops that must use buffer
(e.g. embedding with vocab exceeding texture limits) into downstream ops
that could use texture, causing unnecessary buffer↔texture transitions.

Fix: check PDI compatibility against the intersection of arg and source
repsets (what would actually be applied) rather than the raw source. The
intersection of `ANY_TEXTURE ∩ CONTIGUOUS_ANY` = `WIDTH_PACKED_TEXTURE`,
which IS compatible with the output.

Authored by Claude.

Differential Revision: [D100004702](https://our.internmc.facebook.com/intern/diff/D100004702/)