### PR TITLE
Add error handling for VGF Vulkan memory allocation (#18776)

### DIFF
--- a/backends/arm/runtime/VGFSetup.cpp
+++ b/backends/arm/runtime/VGFSetup.cpp
@@ -173,7 +173,12 @@ VkResult allocate_tensor(
       .memoryTypeIndex = memory_index,
   };
 
-  vkAllocateMemory(device, &allocate_info, nullptr, memory);
+  result = vkAllocateMemory(device, &allocate_info, nullptr, memory);
+  if (result != VK_SUCCESS) {
+    ET_LOG(Error, "Failed to allocate tensor memory, error %d", result);
+    vkDestroyTensorARM(device, *tensor, nullptr);
+    return result;
+  }
 
   // Bind tensor to memory
   const VkBindTensorMemoryInfoARM bind_info = {
@@ -183,7 +188,13 @@ VkResult allocate_tensor(
       .memory = *memory,
       .memoryOffset = 0,
   };
-  vkBindTensorMemoryARM(device, 1, &bind_info);
+  result = vkBindTensorMemoryARM(device, 1, &bind_info);
+  if (result != VK_SUCCESS) {
+    ET_LOG(Error, "Failed to bind tensor memory, error %d", result);
+    vkDestroyTensorARM(device, *tensor, nullptr);
+    vkFreeMemory(device, *memory, nullptr);
+    return result;
+  }
 
   VkTensorViewCreateInfoARM tensor_view_info = {
       .sType = VK_STRUCTURE_TYPE_TENSOR_VIEW_CREATE_INFO_ARM,
@@ -799,7 +810,10 @@ bool VgfRepr::process_vgf(const char* vgf_data, ArrayRef<CompileSpec> specs) {
         .bindPoint = bind_point_requirement.bindPoint,
         .objectIndex = 0, // NOTE: tied to numObjects assert above
     };
-    VkMemoryRequirements2 memory_requirements;
+    VkMemoryRequirements2 memory_requirements = {
+        .sType = VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2,
+        .pNext = nullptr,
+    };
     vkGetDataGraphPipelineSessionMemoryRequirementsARM(
         vk_device, &memory_requirements_info, &memory_requirements);
 


### PR DESCRIPTION
Summary:

https://www.internalfb.com/omh/view/ai_infra_mobile_platform/tests

CONTEXT: VGF tests were segfaulting in CI due to unchecked Vulkan API
return values. When lavapipe's vkAllocateMemory fails (e.g. transient
mmap errors), execution continued with an invalid memory handle,
causing a segfault during model forward().

WHAT: Check vkAllocateMemory and vkBindTensorMemoryARM return values
in VGFSetup.cpp allocate_tensor(), returning early with error logs on
failure. Also validate that lavapipe and emulation layer artifacts
exist before use in the Python test runner, providing actionable
FileNotFoundError messages instead of silent broken symlinks.

Reviewed By: digantdesai

Differential Revision: D99957994


