### PR TITLE
Fix double-scaled pointer arithmetic in ETDumpGen constructor 

### DIFF
--- a/devtools/etdump/etdump_flatcc.cpp
+++ b/devtools/etdump/etdump_flatcc.cpp
@@ -116,8 +116,8 @@ ETDumpGen::ETDumpGen(Span<uint8_t> buffer) {
   if (buffer.data() != nullptr) {
     builder_ =
         (struct flatcc_builder*)internal::align_pointer(buffer.data(), 64);
-    uintptr_t buffer_with_builder = (uintptr_t)internal::align_pointer(
-        builder_ + sizeof(struct flatcc_builder), 64);
+    uintptr_t buffer_with_builder =
+        (uintptr_t)internal::align_pointer(builder_ + 1, 64);
     size_t builder_size =
         (size_t)(buffer_with_builder - (uintptr_t)buffer.data());
     size_t min_buf_size = max_alloc_buf_size + builder_size;


### PR DESCRIPTION
`builder_ + sizeof(struct flatcc_builder)` results in `builder_ + sizeof(struct flatcc_builder) * sizeof(struct flatcc_builder)`

Because C/C++ arithmetic builder_ + N advances by N*sizeof(type) where type is the type of builder_. This means we get a pointer that advances past the intended memory location, potentially into unallocated memory.

Replace with `builder_ + 1`, which correctly advances by exactly one `sizeof(struct flatcc_builder)` element.

This PR was authored with the assistance of Claude.
