### PR TITLE
Fix quantized_conv1d_ncl padding bug in HiFi kernel (#18783)

### DIFF
--- a/backends/cadence/hifi/operators/op_quantized_conv1d_ncl.cpp
+++ b/backends/cadence/hifi/operators/op_quantized_conv1d_ncl.cpp
@@ -59,10 +59,10 @@ void xa_opt_quantized_conv1d_ncl_asym8sxsym8s_asym8s(
   WORD32 kernel_width = weight.size(2);
   WORD32 out_width = out.size(2);
   WORD32 out_height = 1;
-  WORD32 x_stride = 1;
-  WORD32 y_stride = stride[0];
-  WORD32 x_padding = 0;
-  WORD32 y_padding = padding[0];
+  WORD32 x_stride = stride[0];
+  WORD32 y_stride = 1;
+  WORD32 x_padding = padding[0];
+  WORD32 y_padding = 0;
   WORD32 dilation_height = 1;
   WORD32 dilation_width = 1;
   WORD32 input_zero_bias = -in_zero_point;


### PR DESCRIPTION
Summary:

The HiFi optimized int8 path in `op_quantized_conv1d_ncl.cpp` simulates 1D
convolution as 2D (height=1) using `xa_nn_conv2d_per_chan_sym8sxasym8s`.
The NNLib convention is x=width, y=height, but the code had them swapped:
x_stride/x_padding were set to 1/0 (height values) while y_stride/y_padding
held the actual 1D stride/padding (width values). This caused any conv1d with
padding > 0, dilation == 1, stride == 1 to compute without padding, producing
incorrect results.

This was introduced by D95279330 which added the quantized_conv1d_ncl kernel.
Models with conv1d at dilation=1 and padding>0 (e.g., first TemporalBlock in
TCN-based models like microgestures) hit this bug.

Fix: swap the axes so x (width) gets the actual 1D stride/padding and y
(height) gets the trivial 1/0 values.

Differential Revision: D100069524
