### PR TITLE
Qualcomm AI Engine Direct - UT fix

### DIFF
--- a/backends/qualcomm/tests/test_qnn_delegate.py
+++ b/backends/qualcomm/tests/test_qnn_delegate.py
@@ -4919,6 +4919,9 @@ class TestQNNFloatingPointUtils(TestQNN):
     def setUp(self):
         TestQNN.atol = 1e-1
         TestQNN.rtol = 1e-1
+        TestQNN.dump_intermediate_outputs = False
+        TestQNN.enable_profile = False
+        TestQNN.shared_buffer = False
         backend_options = generate_htp_compiler_spec(use_fp16=True)
         TestQNN.compiler_specs = generate_qnn_executorch_compiler_spec(
             soc_model=self.chipset_table[TestQNN.model],
@@ -5547,6 +5550,10 @@ class TestQNNQuantizedUtils(TestQNN):
                 raise ValueError("Backend is not implemented yet")
         TestQNN.atol = 1e-1
         TestQNN.rtol = 1
+        TestQNN.dump_intermediate_outputs = False
+        TestQNN.enable_profile = False
+        TestQNN.shared_buffer = False
+        backend_options = generate_htp_compiler_spec(use_fp16=False)
         TestQNN.compiler_specs = generate_qnn_executorch_compiler_spec(
             soc_model=self.chipset_table[TestQNN.model],
             backend_options=backend_options,


### PR DESCRIPTION
### Summary
Currently we run UT like the following:
`python backends/qualcomm/tests/test_qnn_delegate.py -k TestQNNQuantizedUtils --model SM8750  --device ed8bb642 --build_folder build-android`
This runs all tests under `TestQNNQuantizedUtils`. However, if the first test sets attributes like `TestQNN.enable_profile=True`, this will get carry over to rest of the tests and all tests will have `enable_profile` equals to True, which is not desired. This change takes advantage is `setup` function in UT to reset attributes back to `False` between executions.

### Test plan
Passing all `Utils` tests under `executorch/backends/qualcomm/tests/test_qnn_delegate.py`
