### PR TITLE
Fix MSVC build: replace ET_UNWRAP with manual error check

### DIFF
--- a/extension/llm/runner/llm_runner_helper.cpp
+++ b/extension/llm/runner/llm_runner_helper.cpp
@@ -121,9 +121,11 @@ get_llm_metadata(tokenizers::Tokenizer* tokenizer, Module* module) {
     auto& value = pair.second;
 
     if (method_names.count(method_name)) {
-      value = ET_UNWRAP(module->get(method_name))
-                  .toScalar()
-                  .to<decltype(metadata)::mapped_type>();
+      auto get_result = module->get(method_name);
+      if (!get_result.ok()) {
+        return get_result.error();
+      }
+      value = get_result->toScalar().to<decltype(metadata)::mapped_type>();
     } else {
       ET_LOG(
           Info,


### PR DESCRIPTION
Summary:
ET_UNWRAP uses GCC statement expressions ({...}) which MSVC does not
support, causing compilation failure on Windows CI.

Replace with equivalent manual check: get the Result, check ok(), return
error on failure, then dereference. Same semantics, cross-platform compatible.

Differential Revision: D100218870


