### PR TITLE
NXP Backend: Add missing copyright and license info

### DIFF
--- a/backends/nxp/tests/ir/converter/node_converter/test_adaptive_avg_pool2d_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_adaptive_avg_pool2d_converter.py
@@ -1,3 +1,8 @@
+# Copyright 2025 NXP
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import numpy as np
 import pytest
 import torch


### PR DESCRIPTION
### Summary

This fixes the missing copyright and license info in test_adaptive_avg_pool2d_converter.py

### Test plan

This does not need a test. In fact, the file itself is part of a unit test.

cc @robert-kalmar @JakeStevens @digantdesai