### PR TITLE
Disable mean fallback op (#18815)

### DIFF
--- a/backends/cadence/fusion_g3/operators/op_mean.cpp
+++ b/backends/cadence/fusion_g3/operators/op_mean.cpp
@@ -151,6 +151,7 @@ Tensor& mean_out(
         p_axis,
         num_axis_dims);
   } else {
+#ifdef G3_ENABLE_ALL_DTYPES
     ET_KERNEL_CHECK(
         ctx,
         torch::executor::check_mean_dim_args(in, dim_list, keepdim, dtype, out),
@@ -183,6 +184,10 @@ Tensor& mean_out(
                 }
               });
         });
+#else
+    ET_DCHECK_MSG(
+        false, "mean.out: non-float dtypes require G3_ENABLE_ALL_DTYPES");
+#endif
   }
 
   return out;


### PR DESCRIPTION
Summary:

POR models (and virtually anything else that I've seen) only use mean on floats. Removing the fallback by default saves 75.6kB in .text.

Reviewed By: DrJessop

Differential Revision: D100258757


