### PR TITLE
[ET-VK] Lower reduce_peak_memory threshold from 500 MB to 10 MB

### DIFF
--- a/backends/vulkan/runtime/graph/ComputeGraph.cpp
+++ b/backends/vulkan/runtime/graph/ComputeGraph.cpp
@@ -1134,8 +1134,9 @@ void ComputeGraph::clear_deferred_cmds() {
 void ComputeGraph::prepack() {
   int i = 0;
   bool submitted = false;
-  const bool reduce_peak_memory = total_constant_nbytes_ > 500 * MB;
+  const bool reduce_peak_memory = total_constant_nbytes_ > 10 * MB;
   // int count = 0;
+
   context_->set_cmd();
   for (std::unique_ptr<PrepackNode>& node : prepack_nodes_) {
     // Do not trigger on the first or last prepack node.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #18816

During prepack, staging buffers accumulate in buffers_to_clear_ until
flush() is called. Previously, the reduce_peak_memory path (which calls
submit_and_wait + flush to free staging buffers incrementally) only
triggered when total constant data exceeded 500 MB. This meant models
with moderate weight sizes (e.g. 42 MB) never benefited from incremental
cleanup, causing all staging buffers to coexist in memory until the
final flush.

Lowering the threshold to 10 MB enables incremental staging buffer
cleanup for most models. On SceneX V9 FP16 (42 MB weights, Samsung S24
Adreno 750), this reduces transient VMA peak during prepack from 89.6 MB
to 57.3 MB (-36%) at a cost of ~15 ms additional load latency (+4.4%).
Steady-state memory and inference performance are unaffected.

Authored with Claude.

Differential Revision: [D100332227](https://our.internmc.facebook.com/intern/diff/D100332227/)