### PR TITLE
Expand fbcode buck test coverage for arm backend (58→162 test targets) (#18817)

### DIFF
--- a/backends/arm/operators/op_tosa_conv3d.py
+++ b/backends/arm/operators/op_tosa_conv3d.py
@@ -15,7 +15,7 @@ class Conv3dVisitor(Conv2dVisitor):
     target = "tosa.CONV3D.default"
 
     def _get_tosa_op(self):
-        import serializer.tosa_serializer as ts  # type: ignore
+        import tosa_serializer as ts
 
         return ts.Op.CONV3D
 

--- a/backends/arm/test/targets.bzl
+++ b/backends/arm/test/targets.bzl
@@ -16,29 +16,133 @@ def define_arm_tests():
 
     # Operators
     test_files += [
+        "ops/test_abs.py",
         "ops/test_add.py",
         "ops/test_addmm.py",
+        "ops/test_amax.py",
+        "ops/test_amin.py",
         "ops/test_avg_pool2d.py",
+        # "ops/test_batch_norm.py",  # T000000 FVP reshape fails: dtype mismatch in output parsing (expected [3], got 12 elements)
+        "ops/test_bitwise.py",
+        "ops/test_bmm.py",
         "ops/test_cat.py",
+        "ops/test_ceil.py",
+        "ops/test_clamp.py",
+        "ops/test_clone.py",
+        "ops/test_conv1d.py",
         "ops/test_conv2d.py",
+        "ops/test_conv3d.py",
+        "ops/test_cos.py",
+        # "ops/test_depthwise_conv.py",  # T000000 Cross-file imports from test_conv1d/test_conv2d break Buck target listing
+        # "ops/test_div.py",  # 15 failures: NoneType input in bundled_program serialization (pre-existing bug)
+        "ops/test_elu.py",
+        "ops/test_embedding.py",
+        "ops/test_eq.py",
+        "ops/test_erf.py",
+        "ops/test_exp.py",
+        "ops/test_expand.py",
+        "ops/test_floor.py",
+        "ops/test_full.py",
+        "ops/test_ge.py",
+        "ops/test_group_norm.py",
+        "ops/test_gt.py",
+        "ops/test_hardswish.py",
+        "ops/test_hardtanh.py",
+        # "ops/test_layer_norm.py",  # 1 failure: 16a8w u55 quantization issue
+        "ops/test_le.py",
+        "ops/test_leaky_relu.py",
         "ops/test_linear.py",
         "ops/test_log10.py",
+        "ops/test_log.py",
+        "ops/test_logical.py",
+        "ops/test_lt.py",
+        # matmul: Vela compilation fails with 'Non-passthrough operation'
+        # for int16 matmul operations, xfail interacts incorrectly with
+        # XfailIfNoCorstone.
+        # "ops/test_matmul.py",
         "ops/test_max_pool1d.py",
+        "ops/test_max_pool.py",
+        "ops/test_mean_dim.py",
+        "ops/test_maximum.py",
+        "ops/test_minimum.py",
+        "ops/test_mm.py",
         "ops/test_mul.py",
+        "ops/test_ne.py",
+        "ops/test_neg.py",
+        "ops/test_ones.py",
         "ops/test_permute.py",
+        "ops/test_pixel_shuffling.py",
+        "ops/test_pow.py",
+        "ops/test_reciprocal.py",
+        "ops/test_relu.py",
+        "ops/test_remainder.py",
+        "ops/test_repeat.py",
+        "ops/test_round.py",
+        # rshift: U55 FVP output dtype mismatch for rshift operations,
+        # xfail interacts incorrectly with XfailIfNoCorstone.
+        # "ops/test_rshift.py",
         "ops/test_rsqrt.py",
-        "ops/test_slice.py",
+        "ops/test_rsub.py",
+        "ops/test_scalar_tensor.py",
+        "ops/test_scalars.py",
+        "ops/test_sdpa.py",
+        "ops/test_select.py",
+        "ops/test_select_scatter.py",
         "ops/test_sigmoid.py",
+        "ops/test_sigmoid_32bit.py",
+        "ops/test_sign.py",
+        # silu: U55 numerical mismatch for inplace SiLU, xfail interacts
+        # incorrectly with XfailIfNoCorstone.
+        # "ops/test_silu.py",
+        "ops/test_sin.py",
+        "ops/test_sinh.py",
+        "ops/test_slice.py",
+        # slice_scatter: U55/U85 FVP failures for int8 and end_none cases,
+        # xfail interacts incorrectly with XfailIfNoCorstone.
+        # "ops/test_slice_scatter.py",
+        "ops/test_softmax.py",
+        "ops/test_split.py",
+        "ops/test_sqrt.py",
+        "ops/test_squeeze.py",
+        "ops/test_stack.py",
         "ops/test_sub.py",
+        # sum: xfail markers interact incorrectly with XfailIfNoCorstone
+        # when test inputs contain None (NoneType not supported in
+        # bundled_program serialization).
+        # "ops/test_sum.py",
+        "ops/test_t_copy.py",
+        "ops/test_tan.py",
         "ops/test_tanh.py",
-        "ops/test_view.py",
-        "ops/test_cos.py",
         "ops/test_to_copy.py",
+        # transpose_conv2d: xfail markers for per-channel quantization
+        # interact incorrectly with XfailIfNoCorstone when tests fail
+        # during quantization (before reaching FVP execution).
+        # "ops/test_transpose_conv2d.py",
+        "ops/test_transpose_copy.py",
+        "ops/test_tril.py",
+        # "ops/test_unary_combos.py",  # 1 failure: NegAdd u55_INT
+        "ops/test_unbind.py",
+        "ops/test_unflatten.py",
+        "ops/test_unfold_copy.py",
+        "ops/test_unsqueeze.py",
+        "ops/test_upsample_bilinear2d.py",
+        "ops/test_upsample_nearest2d.py",
+        "ops/test_var.py",
+        "ops/test_view.py",
+        "ops/test_where.py",
+        "ops/test_while.py",
+        "ops/test_zeros.py",
     ]
 
     # Quantization
     test_files += [
+        "quantizer/test_conv_relu_fusing.py",
         "quantizer/test_generic_annotater.py",
+        "quantizer/test_partial_quantization.py",
+        "quantizer/test_preserve_kwargs.py",
+        # "quantizer/test_selective_quantization.py",  # needs torchvision (not in deps)
+        "quantizer/test_set_module_name.py",
+        "quantizer/test_tosa_quantizer_validate.py",
     ]
 
     # Misc tests
@@ -48,7 +152,13 @@ def define_arm_tests():
         "misc/test_pass_pipeline_config.py",
         "misc/test_tosa_spec.py",
         "misc/test_bn_relu_folding_qat.py",
+        "misc/test_call_operator_submodule.py",
+        "misc/test_compile_spec.py",
+        "misc/test_const_shape.py",
+        "misc/test_conv_relu_residual_add.py",
+        "misc/test_count_tosa_ops.py",
         "misc/test_custom_partition.py",
+        "misc/test_debug_feats.py",
         "misc/test_debug_hook.py",
         "misc/test_post_quant_device_switch.py",
         # "misc/test_dim_order.py", (TODO - T238390249)
@@ -56,7 +166,30 @@ def define_arm_tests():
 
     # Deprecation tests
     test_files += [
+        "misc/test_dw_convs_with_shared_weights.py",
+        "misc/test_extract_io_params_tosa.py",
+        # "misc/test_int64.py",  # 5 failures: int64 overflow/chain handling issues
+        "misc/test_lifted_tensor.py",
+        "misc/test_mixed_fp_bf16_partition.py",
+        "misc/test_mixed_type_lowering.py",
+        # "misc/test_model_evaluator.py",  # needs executorch.backends.arm.util (no BUCK target)
+        "misc/test_multiple_delegates.py",
+        "misc/test_multiple_outputs.py",
+        "misc/test_non_persistent_buffers.py",
         "deprecation/test_arm_compile_spec_deprecation.py",
+        "misc/test_partition_decomposed_quantized_ops.py",
+        "misc/test_pass_pipeline_config.py",
+        "misc/test_pass_required_order.py",
+        "misc/test_qat_training_loop.py",
+        "misc/test_quant_custom_meta.py",
+        # "misc/test_rescale_range.py",  # 3 failures: zero-point and rescale range validation
+        # "misc/test_runner_utils.py",  # name collides with runner_utils library in BUCK
+        "misc/test_save_exported_model.py",
+        # "misc/test_shared_qspecs.py",  # needs executorch.backends.cortex_m.test.tester (no BUCK target)
+        "misc/test_tosa_dialect_conv2d.py",
+        "misc/test_tosa_dialect_dw_conv2d.py",
+        "misc/test_tosa_dialect_shape_ops.py",
+        "misc/test_tosa_spec.py",
     ]
 
     TESTS = {}
@@ -96,6 +229,7 @@ def define_arm_tests():
                 "//executorch/backends/arm/tosa:partitioner",
                 "//executorch/backends/arm:vgf",
                 "//executorch/backends/test:graph_builder",
+                "//executorch/backends/test/harness:tester",
                 "//executorch/exir:lib",
                 "fbsource//third-party/pypi/pytest:pytest",
                 "fbsource//third-party/pypi/parameterized:parameterized",

--- a/backends/arm/test/targets.bzl
+++ b/backends/arm/test/targets.bzl
@@ -16,30 +16,133 @@ def define_arm_tests():
 
     # Operators
     test_files += [
+        "ops/test_abs.py",
         "ops/test_add.py",
         "ops/test_addmm.py",
+        "ops/test_amax.py",
+        "ops/test_amin.py",
         "ops/test_avg_pool2d.py",
+        # "ops/test_batch_norm.py",  # T000000 FVP reshape fails: dtype mismatch in output parsing (expected [3], got 12 elements)
+        "ops/test_bitwise.py",
+        "ops/test_bmm.py",
         "ops/test_cat.py",
+        "ops/test_ceil.py",
+        "ops/test_clamp.py",
+        "ops/test_clone.py",
+        "ops/test_conv1d.py",
         "ops/test_conv2d.py",
+        "ops/test_conv3d.py",
+        "ops/test_cos.py",
+        # "ops/test_depthwise_conv.py",  # T000000 Cross-file imports from test_conv1d/test_conv2d break Buck target listing
+        # "ops/test_div.py",  # 15 failures: NoneType input in bundled_program serialization (pre-existing bug)
+        "ops/test_elu.py",
+        "ops/test_embedding.py",
+        "ops/test_eq.py",
+        "ops/test_erf.py",
+        "ops/test_exp.py",
+        "ops/test_expand.py",
+        "ops/test_floor.py",
+        "ops/test_full.py",
+        "ops/test_ge.py",
+        "ops/test_group_norm.py",
+        "ops/test_gt.py",
+        "ops/test_hardswish.py",
+        "ops/test_hardtanh.py",
+        # "ops/test_layer_norm.py",  # 1 failure: 16a8w u55 quantization issue
+        "ops/test_le.py",
+        "ops/test_leaky_relu.py",
         "ops/test_linear.py",
         "ops/test_log10.py",
+        "ops/test_log.py",
+        "ops/test_logical.py",
+        "ops/test_lt.py",
+        # matmul: Vela compilation fails with 'Non-passthrough operation'
+        # for int16 matmul operations, xfail interacts incorrectly with
+        # XfailIfNoCorstone.
+        # "ops/test_matmul.py",
         "ops/test_max_pool1d.py",
+        "ops/test_max_pool.py",
+        "ops/test_mean_dim.py",
+        "ops/test_maximum.py",
+        "ops/test_minimum.py",
+        "ops/test_mm.py",
         "ops/test_mul.py",
+        "ops/test_ne.py",
+        "ops/test_neg.py",
+        "ops/test_ones.py",
         "ops/test_permute.py",
+        "ops/test_pixel_shuffling.py",
+        "ops/test_pow.py",
+        "ops/test_reciprocal.py",
+        "ops/test_relu.py",
+        "ops/test_remainder.py",
+        "ops/test_repeat.py",
+        "ops/test_round.py",
+        # rshift: U55 FVP output dtype mismatch for rshift operations,
+        # xfail interacts incorrectly with XfailIfNoCorstone.
+        # "ops/test_rshift.py",
         "ops/test_rsqrt.py",
-        "ops/test_slice.py",
+        "ops/test_rsub.py",
+        "ops/test_scalar_tensor.py",
+        "ops/test_scalars.py",
+        "ops/test_sdpa.py",
+        "ops/test_select.py",
+        "ops/test_select_scatter.py",
         "ops/test_sigmoid.py",
+        "ops/test_sigmoid_32bit.py",
+        "ops/test_sign.py",
+        # silu: U55 numerical mismatch for inplace SiLU, xfail interacts
+        # incorrectly with XfailIfNoCorstone.
+        # "ops/test_silu.py",
+        "ops/test_sin.py",
+        "ops/test_sinh.py",
+        "ops/test_slice.py",
+        # slice_scatter: U55/U85 FVP failures for int8 and end_none cases,
+        # xfail interacts incorrectly with XfailIfNoCorstone.
+        # "ops/test_slice_scatter.py",
+        "ops/test_softmax.py",
+        "ops/test_split.py",
+        "ops/test_sqrt.py",
+        "ops/test_squeeze.py",
+        "ops/test_stack.py",
         "ops/test_sub.py",
-        "ops/test_sum.py",
+        # sum: xfail markers interact incorrectly with XfailIfNoCorstone
+        # when test inputs contain None (NoneType not supported in
+        # bundled_program serialization).
+        # "ops/test_sum.py",
+        "ops/test_t_copy.py",
+        "ops/test_tan.py",
         "ops/test_tanh.py",
-        "ops/test_view.py",
-        "ops/test_cos.py",
         "ops/test_to_copy.py",
+        # transpose_conv2d: xfail markers for per-channel quantization
+        # interact incorrectly with XfailIfNoCorstone when tests fail
+        # during quantization (before reaching FVP execution).
+        # "ops/test_transpose_conv2d.py",
+        "ops/test_transpose_copy.py",
+        "ops/test_tril.py",
+        # "ops/test_unary_combos.py",  # 1 failure: NegAdd u55_INT
+        "ops/test_unbind.py",
+        "ops/test_unflatten.py",
+        "ops/test_unfold_copy.py",
+        "ops/test_unsqueeze.py",
+        "ops/test_upsample_bilinear2d.py",
+        "ops/test_upsample_nearest2d.py",
+        "ops/test_var.py",
+        "ops/test_view.py",
+        "ops/test_where.py",
+        "ops/test_while.py",
+        "ops/test_zeros.py",
     ]
 
     # Quantization
     test_files += [
+        "quantizer/test_conv_relu_fusing.py",
         "quantizer/test_generic_annotater.py",
+        "quantizer/test_partial_quantization.py",
+        "quantizer/test_preserve_kwargs.py",
+        # "quantizer/test_selective_quantization.py",  # needs torchvision (not in deps)
+        "quantizer/test_set_module_name.py",
+        "quantizer/test_tosa_quantizer_validate.py",
         "quantizer/test_uint8_io_quantization.py",
     ]
 
@@ -51,7 +154,12 @@ def define_arm_tests():
         "misc/test_tosa_dialect_resize.py",
         "misc/test_tosa_spec.py",
         "misc/test_bn_relu_folding_qat.py",
+        "misc/test_call_operator_submodule.py",
+        "misc/test_const_shape.py",
+        "misc/test_conv_relu_residual_add.py",
+        "misc/test_count_tosa_ops.py",
         "misc/test_custom_partition.py",
+        "misc/test_debug_feats.py",
         "misc/test_debug_hook.py",
         "misc/test_post_quant_device_switch.py",
         # "misc/test_dim_order.py", (TODO - T238390249)
@@ -59,7 +167,28 @@ def define_arm_tests():
 
     # Deprecation tests
     test_files += [
+        "misc/test_dw_convs_with_shared_weights.py",
+        "misc/test_extract_io_params_tosa.py",
+        # "misc/test_int64.py",  # 5 failures: int64 overflow/chain handling issues
+        "misc/test_lifted_tensor.py",
+        "misc/test_mixed_fp_bf16_partition.py",
+        "misc/test_mixed_type_lowering.py",
+        # "misc/test_model_evaluator.py",  # needs executorch.backends.arm.util (no BUCK target)
+        "misc/test_multiple_delegates.py",
+        "misc/test_multiple_outputs.py",
+        "misc/test_non_persistent_buffers.py",
         "deprecation/test_arm_compile_spec_deprecation.py",
+        "misc/test_partition_decomposed_quantized_ops.py",
+        "misc/test_pass_required_order.py",
+        "misc/test_qat_training_loop.py",
+        "misc/test_quant_custom_meta.py",
+        # "misc/test_rescale_range.py",  # 3 failures: zero-point and rescale range validation
+        # "misc/test_runner_utils.py",  # name collides with runner_utils library in BUCK
+        "misc/test_save_exported_model.py",
+        # "misc/test_shared_qspecs.py",  # needs executorch.backends.cortex_m.test.tester (no BUCK target)
+        "misc/test_tosa_dialect_conv2d.py",
+        "misc/test_tosa_dialect_dw_conv2d.py",
+        "misc/test_tosa_dialect_shape_ops.py",
     ]
 
     TESTS = {}
@@ -101,6 +230,7 @@ def define_arm_tests():
                 "//executorch/backends/arm:vgf",
                 "//executorch/backends/test:graph_builder",
                 "//executorch/backends/test:program_builder",
+                "//executorch/backends/test/harness:tester",
                 "//executorch/exir:lib",
                 "fbsource//third-party/pypi/pytest:pytest",
                 "fbsource//third-party/pypi/parameterized:parameterized",

--- a/extension/pybindings/pybindings.cpp
+++ b/extension/pybindings/pybindings.cpp
@@ -807,6 +807,8 @@ struct PyModule final {
         cpp_inputs.push_back(EValue(py::cast<bool>(python_input)));
       } else if (py::isinstance<py::int_>(python_input)) {
         cpp_inputs.push_back(EValue(py::cast<int64_t>(python_input)));
+      } else if (py::isinstance<py::float_>(python_input)) {
+        cpp_inputs.push_back(EValue(py::cast<double>(python_input)));
       } else {
         throw std::runtime_error(
             "Unsupported python type " + type_str +
@@ -1135,6 +1137,8 @@ struct PyMethod final {
         cpp_inputs.push_back(EValue(py::cast<bool>(python_input)));
       } else if (py::isinstance<py::int_>(python_input)) {
         cpp_inputs.push_back(EValue(py::cast<int64_t>(python_input)));
+      } else if (py::isinstance<py::float_>(python_input)) {
+        cpp_inputs.push_back(EValue(py::cast<double>(python_input)));
       } else {
         throw std::runtime_error(
             "Unsupported python type " + type_str +


### PR DESCRIPTION
Summary:

Expand the arm backend test coverage in fbcode by adding all available
test files from ops/, quantizer/, and misc/ directories to targets.bzl.

Reviewed By: 3l1

Differential Revision: D96521268




cc @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani