### PR TITLE
Convert arvr mode constraint to a constraint() rule

### DIFF
--- a/runtime/core/portable_type/c10/c10/targets.bzl
+++ b/runtime/core/portable_type/c10/c10/targets.bzl
@@ -78,7 +78,7 @@ def define_common_targets():
             "fbsource//xplat/caffe2/c10:c10_headers",
         ] + select({
             "DEFAULT": ["fbsource//xplat/caffe2:generated_aten_config_header"],
-            "ovr_config//build_mode:arvr_mode": ["fbsource//xplat/caffe2:ovrsource_aten_Config.h"],
+            "ovr_config//build_mode:arvr_mode[enabled]": ["fbsource//xplat/caffe2:ovrsource_aten_Config.h"],
         }) + get_sleef_deps(),
         fbcode_exported_deps = ([
             "//caffe2:aten-headers-cpu",


### PR DESCRIPTION
Summary:
#force_dangling_check

Converting the arvr mode constraint to a constraint().

@pytorchbot label "release notes: none"

Reviewed By: rexzhang123

Differential Revision: D99903392


