### PR TITLE
Add LFM2.5-VL export with CUDA/AOTI backend

### DIFF
--- a/examples/models/lfm2/short_conv.py
+++ b/examples/models/lfm2/short_conv.py
@@ -74,7 +74,14 @@ class ShortConv(nn.Module):
         with torch.no_grad():
             self.conv_state.copy_(new_conv_state)
 
-        conv_out = self.conv(Bx)[..., : x.size(-1)]  # (batch_size, dim, seq_len)
+        # Manual depthwise conv: Triton has no template for nn.Conv1d with
+        # groups=dim and dynamic seq_len.  kernel_size is always 3.
+        w = self.conv.weight[:, 0, :]  # (dim, 3)
+        conv_out = (
+            Bx[..., :-2] * w[:, 0:1]
+            + Bx[..., 1:-1] * w[:, 1:2]
+            + Bx[..., 2:] * w[:, 2:3]
+        )  # (batch_size, dim, seq_len)
         y = C * conv_out  # (batch_size, dim, seq_len)
 
         y = y.transpose(-1, -2)  # (batch_size, seq_len, dim)

--- a/examples/models/lfm2_5_vl/__init__.py
+++ b/examples/models/lfm2_5_vl/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from executorch.examples.models.lfm2_5_vl.convert_weights import convert_weights
+from executorch.examples.models.lfm2_5_vl.model import Lfm2p5VlModel
+
+__all__ = [
+    "convert_weights",
+    "Lfm2p5VlModel",
+]

--- a/examples/models/lfm2_5_vl/config/lfm2_5_vl_1_6b_config.json
+++ b/examples/models/lfm2_5_vl/config/lfm2_5_vl_1_6b_config.json
@@ -1,0 +1,33 @@
+{
+  "dim": 2048,
+  "ffn_dim_multiplier": 1,
+  "hidden_dim": 8192,
+  "n_heads": 32,
+  "n_kv_heads": 8,
+  "n_layers": 16,
+  "norm_eps": 1e-5,
+  "rope_theta": 1000000.0,
+  "use_scaled_rope": false,
+  "vocab_size": 65536,
+  "use_hf_rope": true,
+  "use_qk_norm": true,
+  "qk_norm_before_rope": true,
+  "layer_types": [
+    "conv",
+    "conv",
+    "full_attention",
+    "conv",
+    "conv",
+    "full_attention",
+    "conv",
+    "conv",
+    "full_attention",
+    "conv",
+    "full_attention",
+    "conv",
+    "full_attention",
+    "conv",
+    "full_attention",
+    "conv"
+  ]
+}

--- a/examples/models/lfm2_5_vl/config/lfm2_5_vl_450m_config.json
+++ b/examples/models/lfm2_5_vl/config/lfm2_5_vl_450m_config.json
@@ -1,0 +1,33 @@
+{
+  "dim": 1024,
+  "ffn_dim_multiplier": 1,
+  "hidden_dim": 4608,
+  "n_heads": 16,
+  "n_kv_heads": 8,
+  "n_layers": 16,
+  "norm_eps": 1e-5,
+  "rope_theta": 1000000.0,
+  "use_scaled_rope": false,
+  "vocab_size": 65536,
+  "use_hf_rope": true,
+  "use_qk_norm": true,
+  "qk_norm_before_rope": true,
+  "layer_types": [
+    "conv",
+    "conv",
+    "full_attention",
+    "conv",
+    "conv",
+    "full_attention",
+    "conv",
+    "conv",
+    "full_attention",
+    "conv",
+    "full_attention",
+    "conv",
+    "full_attention",
+    "conv",
+    "full_attention",
+    "conv"
+  ]
+}

--- a/examples/models/lfm2_5_vl/convert_weights.py
+++ b/examples/models/lfm2_5_vl/convert_weights.py
@@ -1,0 +1,81 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Convert LFM2.5-VL text decoder weights from HuggingFace to ET format."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import torch
+from executorch.examples.models.checkpoint import get_mapped_key
+from safetensors.torch import load_file
+
+_LFM2_5_VL_TO_META: dict[str, str] = {
+    "model.language_model.embed_tokens.weight": "tok_embeddings.weight",
+    "model.language_model.embedding_norm.weight": "norm.weight",
+    "model.language_model.layers.{}.self_attn.q_proj.weight": "layers.{}.attention.wq.weight",
+    "model.language_model.layers.{}.self_attn.k_proj.weight": "layers.{}.attention.wk.weight",
+    "model.language_model.layers.{}.self_attn.v_proj.weight": "layers.{}.attention.wv.weight",
+    "model.language_model.layers.{}.self_attn.out_proj.weight": "layers.{}.attention.wo.weight",
+    "model.language_model.layers.{}.self_attn.q_layernorm.weight": "layers.{}.attention.q_norm_fn.weight",
+    "model.language_model.layers.{}.self_attn.k_layernorm.weight": "layers.{}.attention.k_norm_fn.weight",
+    "model.language_model.layers.{}.operator_norm.weight": "layers.{}.attention_norm.weight",
+    "model.language_model.layers.{}.ffn_norm.weight": "layers.{}.ffn_norm.weight",
+    "model.language_model.layers.{}.feed_forward.w1.weight": "layers.{}.feed_forward.w1.weight",
+    "model.language_model.layers.{}.feed_forward.w2.weight": "layers.{}.feed_forward.w2.weight",
+    "model.language_model.layers.{}.feed_forward.w3.weight": "layers.{}.feed_forward.w3.weight",
+    "model.language_model.layers.{}.conv.conv.weight": "layers.{}.conv.conv.weight",
+    "model.language_model.layers.{}.conv.out_proj.weight": "layers.{}.conv.out_proj.weight",
+    "model.language_model.lm_head.weight": "output.weight",
+}
+
+_IN_PROJ_SPLITS = ("B_proj", "C_proj", "x_proj")
+
+
+def lfm2_5_vl_to_meta(state_dict: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+    """Extract and remap language model weights from a full VL state dict."""
+    converted: dict[str, torch.Tensor] = {}
+
+    for key, value in state_dict.items():
+        if not key.startswith("model.language_model."):
+            continue
+
+        try:
+            new_key = get_mapped_key(key, _LFM2_5_VL_TO_META)
+        except Exception:
+            new_key = key.removeprefix("model.language_model.")
+
+        if new_key.endswith(".conv.in_proj.weight"):
+            for name, chunk in zip(_IN_PROJ_SPLITS, torch.chunk(value, 3, dim=0)):
+                converted[new_key.replace("in_proj", name)] = chunk
+        else:
+            converted[new_key] = value
+
+    if "output.weight" not in converted:
+        converted["output.weight"] = converted["tok_embeddings.weight"]
+
+    return converted
+
+
+def convert_weights(input_dir: str, output_file: str) -> None:
+    sd = load_file(str(Path(input_dir) / "model.safetensors"))
+    sd = lfm2_5_vl_to_meta(sd)
+    torch.save(sd, output_file)
+    print(f"Saved {len(sd)} tensors to {output_file}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Convert LFM2.5-VL weights to ET format.")
+    parser.add_argument("input_dir", help="Directory containing model.safetensors.")
+    parser.add_argument("output", help="Output .pt checkpoint path.")
+    args = parser.parse_args()
+    convert_weights(args.input_dir, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/models/lfm2_5_vl/export_lfm2_5_vl.py
+++ b/examples/models/lfm2_5_vl/export_lfm2_5_vl.py
@@ -1,0 +1,243 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Export LFM2.5-VL as a multi-method PTE for ExecuTorch with CUDA/AOTI backend.
+
+All three methods are delegated to the CUDA backend.  Conv layer state is
+threaded through attn_options as explicit IO; KV cache uses mark_static_address
+so AOTI can trace through in-place mutations.
+
+Methods (D = text hidden dim):
+  vision_encoder  : [1, 3, 512, 512] f32 -> [1, 256, D] f32
+  token_embedding : [1, seq_len] i64     -> [1, seq_len, D] f32
+  text_decoder    : ([1, seq_len, D], [seq_len] i64) -> [1, vocab] f32
+
+Usage:
+    python examples/models/lfm2_5_vl/export_lfm2_5_vl.py \\
+        --model_dir LiquidAI/LFM2.5-VL-450M --dtype bf16
+"""
+
+from __future__ import annotations
+
+import logging
+from argparse import ArgumentParser
+from pathlib import Path
+from typing import Optional
+
+import torch
+from torch.export import Dim, ExportedProgram
+from torch.nn.attention import SDPBackend
+
+from executorch.backends.cuda.cuda_backend import CudaBackend
+from executorch.backends.cuda.cuda_partitioner import CudaPartitioner
+from executorch.exir import (
+    EdgeCompileConfig,
+    ExecutorchBackendConfig,
+    to_edge_transform_and_lower,
+)
+from executorch.exir.passes import MemoryPlanningPass
+from executorch.exir.passes.sym_shape_eval_pass import ConstraintBasedSymShapeEvalPass
+
+from executorch.examples.models.lfm2_5_vl.model import (
+    IMAGE_SIZE,
+    MAX_SEQ_LEN,
+    Lfm2p5VlModel,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="[%(levelname)s %(asctime)s %(filename)s:%(lineno)s] %(message)s",
+)
+
+# ---------------------------------------------------------------------------
+# Blackwell (sm_103) workaround: torch._inductor maps arch 103 -> "100f" but
+# Triton generates PTX targeting sm_103a.  Patch to match.
+# TODO: Remove once PyTorch bump includes the upstream fix in
+# torch/_inductor/codegen/cuda/compile_utils.py
+# ---------------------------------------------------------------------------
+try:
+    from torch._inductor.codecache import cuda_compile_utils
+
+    _orig_nvcc_arch = cuda_compile_utils._nvcc_arch_as_compile_option
+
+    def _patched_nvcc_arch() -> str:
+        arch = cuda_compile_utils.cuda_env.get_cuda_arch()
+        return "103a" if arch == "103" else _orig_nvcc_arch()
+
+    cuda_compile_utils._nvcc_arch_as_compile_option = _patched_nvcc_arch
+except (ImportError, AttributeError):
+    pass
+
+_CONFIG_DIR = Path(__file__).parent / "config"
+
+_DTYPE_MAP: dict[str, torch.dtype] = {
+    "fp32": torch.float32,
+    "fp16": torch.float16,
+    "bf16": torch.bfloat16,
+}
+
+
+def _resolve_params_path(model_dir: str, params: str | None) -> str | None:
+    if params is not None:
+        return params
+    name = model_dir.lower()
+    if "450m" in name:
+        return str(_CONFIG_DIR / "lfm2_5_vl_450m_config.json")
+    if "1.6b" in name or "1_6b" in name:
+        return str(_CONFIG_DIR / "lfm2_5_vl_1_6b_config.json")
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Per-method export
+# ---------------------------------------------------------------------------
+
+
+def _export_image_encoder(lfm2: torch.nn.Module, *, device: str) -> ExportedProgram:
+    class _Encoder(torch.nn.Module):
+        def __init__(self, lfm2: torch.nn.Module) -> None:
+            super().__init__()
+            self.lfm2 = lfm2
+
+        def forward(self, images: torch.Tensor) -> torch.Tensor:
+            return self.lfm2.image_embedding(images)
+
+    example = torch.randint(0, 256, (1, 3, IMAGE_SIZE, IMAGE_SIZE), dtype=torch.float32, device=device)
+    with torch.nn.attention.sdpa_kernel([SDPBackend.MATH]), torch.no_grad():
+        return torch.export.export(_Encoder(lfm2), (example,), strict=False)
+
+
+def _export_text_decoder(lfm2: torch.nn.Module, *, dtype: torch.dtype, device: str) -> ExportedProgram:
+    dim = lfm2.text_model_args.dim
+
+    class _Decoder(torch.nn.Module):
+        def __init__(self, text_model: torch.nn.Module) -> None:
+            super().__init__()
+            self.text_model = text_model
+
+        def forward(self, embeddings: torch.Tensor, input_pos: torch.Tensor) -> torch.Tensor:
+            out = self.text_model(None, {"input_pos": input_pos}, embeddings)
+            if isinstance(out, tuple):
+                out = out[0]
+            return out.contiguous()
+
+    seq = 8
+    token_dim = Dim("token_dim", min=1, max=MAX_SEQ_LEN - 1)
+    example_emb = torch.randn(1, seq, dim, dtype=dtype, device=device)
+    example_pos = torch.arange(seq, dtype=torch.int64, device=device)
+
+    with torch.nn.attention.sdpa_kernel([SDPBackend.MATH]), torch.no_grad():
+        return torch.export._trace._export(
+            _Decoder(lfm2.text_model),
+            (example_emb, example_pos),
+            dynamic_shapes=({1: token_dim}, {0: token_dim}),
+            strict=False,
+            prefer_deferred_runtime_asserts_over_guards=True,
+        )
+
+
+def _export_token_embedding(lfm2: torch.nn.Module, *, device: str) -> ExportedProgram:
+    embed = lfm2.model_.model.language_model.get_input_embeddings()
+    token_dim = Dim("token_dim_1", min=1, max=MAX_SEQ_LEN)
+    example = torch.zeros(1, MAX_SEQ_LEN, dtype=torch.int64, device=device)
+    with torch.no_grad():
+        return torch.export.export(embed, (example,), dynamic_shapes=[{1: token_dim}], strict=False)
+
+
+# ---------------------------------------------------------------------------
+# Pipeline
+# ---------------------------------------------------------------------------
+
+
+def export_all(
+    model_dir: str,
+    output: str,
+    *,
+    dtype: torch.dtype = torch.bfloat16,
+    max_seq_len: int = MAX_SEQ_LEN,
+    params_path: str | None = None,
+) -> None:
+    logging.info("Loading %s...", model_dir)
+    lfm2_model = Lfm2p5VlModel(
+        model_dir=model_dir,
+        max_seq_len=max_seq_len,
+        max_context_len=max_seq_len,
+        params_path=params_path,
+        use_sdpa_with_kv_cache_op=False,
+    )
+    lfm2 = lfm2_model.get_eager_model().to(dtype=dtype, device="cuda")
+
+    # Mark KV cache and conv state buffers as static addresses so AOTI can
+    # trace through in-place mutations. Must be after .to("cuda") because
+    # marking a CPU buffer that later gets replaced is a no-op.
+    for module in lfm2.text_model.modules():
+        for name, buf in module.named_buffers(recurse=False):
+            if name in ("k_cache", "v_cache", "conv_state"):
+                torch._dynamo.mark_static_address(buf)
+
+    logging.info("[1/3] Vision encoder")
+    vision_ep = _export_image_encoder(lfm2, device="cuda")
+    logging.info("[2/3] Text decoder")
+    decoder_ep = _export_text_decoder(lfm2, dtype=dtype, device="cuda")
+    logging.info("[3/3] Token embedding")
+    token_ep = _export_token_embedding(lfm2, device="cuda")
+
+    programs = {"vision_encoder": vision_ep, "token_embedding": token_ep, "text_decoder": decoder_ep}
+    partitioners = {
+        k: [CudaPartitioner([CudaBackend.generate_method_name_compile_spec(k)])]
+        for k in programs
+    }
+    metadata = {
+        "get_max_seq_len": lfm2.text_model_args.max_seq_len,
+        "get_vocab_size": lfm2.text_model_args.vocab_size,
+        "use_kv_cache": lfm2.text_model_args.use_kv_cache,
+        "get_eos_ids": [7],
+    }
+
+    logging.info("Lowering to Edge IR + CUDA")
+    et_prog = to_edge_transform_and_lower(
+        programs,
+        partitioner=partitioners,
+        compile_config=EdgeCompileConfig(_check_ir_validity=False, _skip_dim_order=True),
+        constant_methods=metadata,
+    )
+
+    logging.info("Finalizing ExecuTorch program")
+    et_program = et_prog.to_executorch(
+        ExecutorchBackendConfig(
+            memory_planning_pass=MemoryPlanningPass(alloc_graph_input=False),
+            sym_shape_eval_pass={k: ConstraintBasedSymShapeEvalPass() for k in programs},
+        )
+    )
+
+    output_path = Path(output)
+    output_dir = output_path.parent or Path(".")
+    logging.info("Saving %s", output_path)
+    with open(output_path, "wb") as f:
+        et_program.write_to_file(f)
+    et_program.write_tensor_data_to_file(str(output_dir))
+    logging.info("Done — methods: %s", et_program.methods)
+
+
+def main() -> None:
+    parser = ArgumentParser(description="Export LFM2.5-VL to ExecuTorch (CUDA)")
+    parser.add_argument("--model_dir", default="LiquidAI/LFM2.5-VL-450M")
+    parser.add_argument("--dtype", default="bf16", choices=list(_DTYPE_MAP))
+    parser.add_argument("--max_seq_len", type=int, default=MAX_SEQ_LEN)
+    parser.add_argument("--params", default=None)
+    parser.add_argument("--output", default=None)
+    args = parser.parse_args()
+
+    dtype = _DTYPE_MAP[args.dtype]
+    params_path = _resolve_params_path(args.model_dir, args.params)
+    output = args.output or f"lfm2_5_vl_{args.dtype}_cuda.pte"
+
+    export_all(args.model_dir, output, dtype=dtype, max_seq_len=args.max_seq_len, params_path=params_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/models/lfm2_5_vl/model.py
+++ b/examples/models/lfm2_5_vl/model.py
@@ -1,0 +1,141 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""ExecuTorch-friendly LFM2.5-VL model. Mirrors examples/models/llava/model.py."""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+
+import torch
+import torch.nn.functional as F
+from executorch.examples.models.lfm2_5_vl.convert_weights import lfm2_5_vl_to_meta
+from executorch.examples.models.llama.llama_transformer import construct_transformer
+from executorch.examples.models.llama.model_args import ModelArgs
+from executorch.examples.models.llama.source_transformation.custom_kv_cache import (
+    replace_kv_cache_with_custom_kv_cache,
+)
+from executorch.examples.models.llama.source_transformation.sdpa import (
+    replace_sdpa_with_custom_op,
+)
+from executorch.examples.models.model_base import EagerModelBase
+from torch.export import Dim
+from transformers import AutoModelForImageTextToText, AutoProcessor
+
+MAX_SEQ_LEN = 2048
+IMAGE_SIZE = 512
+PATCH_SIZE = 16
+FIXED_H, FIXED_W = 32, 32
+
+_DEFAULT_PARAMS = Path(__file__).parent / "config" / "lfm2_5_vl_1_6b_config.json"
+
+
+class Lfm2p5Vl(torch.nn.Module):
+    def __init__(self, hf_model: AutoModelForImageTextToText, params: ModelArgs) -> None:
+        super().__init__()
+        self.model_ = hf_model
+        self.text_model_args = params
+        self.text_model = construct_transformer(params)
+
+        if params.use_sdpa_with_kv_cache_op:
+            self.text_model = replace_kv_cache_with_custom_kv_cache(self.text_model)
+            self.text_model = replace_sdpa_with_custom_op(self.text_model)
+
+        self.text_model.load_state_dict(
+            state_dict=self._translate_weights(), strict=False, assign=True
+        )
+        self._patch_positional_embeddings()
+
+    def _patch_positional_embeddings(self) -> None:
+        embeddings = self.model_.model.vision_tower.vision_model.embeddings
+        orig = embeddings.position_embedding.weight.data
+        sqrt_n = int(math.sqrt(orig.shape[0]))
+
+        grid = orig.reshape(sqrt_n, sqrt_n, -1).permute(2, 0, 1).unsqueeze(0)
+        resized = F.interpolate(
+            grid, size=(FIXED_H, FIXED_W), mode="bilinear", align_corners=False, antialias=True
+        )
+        pe = resized.squeeze(0).permute(1, 2, 0).reshape(FIXED_H * FIXED_W, -1).contiguous()
+        embeddings.register_buffer("_precomputed_pe", pe, persistent=False)
+        embeddings.resize_positional_embeddings = lambda *_args, **_kw: embeddings._precomputed_pe
+
+    def _translate_weights(self) -> dict[str, torch.Tensor]:
+        raw: dict[str, torch.Tensor] = {}
+        for k, v in self.model_.model.language_model.state_dict().items():
+            raw[f"model.language_model.{k}"] = v
+        for k, v in self.model_.lm_head.state_dict().items():
+            raw[f"model.language_model.lm_head.{k}"] = v
+        return lfm2_5_vl_to_meta(raw)
+
+    def embed_tokens(self, tokens: torch.Tensor) -> torch.Tensor:
+        return self.model_.model.language_model.get_input_embeddings()(tokens)
+
+    def image_embedding(self, nchw_pixels: torch.Tensor) -> torch.Tensor:
+        """[B, 3, 512, 512] float32 pixels in [0, 255] -> [B, 256, D]."""
+        x = (nchw_pixels / 255.0 - 0.5) / 0.5
+
+        x = x.unfold(2, PATCH_SIZE, PATCH_SIZE).unfold(3, PATCH_SIZE, PATCH_SIZE)
+        x = x.permute(0, 2, 3, 4, 5, 1).reshape(1, FIXED_H * FIXED_W, PATCH_SIZE * PATCH_SIZE * 3)
+
+        out = self.model_.model.vision_tower(
+            pixel_values=x,
+            pixel_attention_mask=None,
+            spatial_shapes=torch.tensor([[FIXED_H, FIXED_W]], dtype=torch.int64, device=x.device),
+            return_dict=True,
+        )
+        feats = out.last_hidden_state.reshape(-1, FIXED_H, FIXED_W, out.last_hidden_state.shape[-1])
+        projected = self.model_.model.multi_modal_projector(feats)
+        return projected.reshape(1, -1, projected.shape[-1])
+
+    def forward(self, images: torch.Tensor) -> torch.Tensor:
+        return self.image_embedding(images)
+
+
+class Lfm2p5VlModel(EagerModelBase):
+    def __init__(
+        self,
+        *,
+        use_sdpa_with_kv_cache_op: bool = True,
+        use_kv_cache: bool = True,
+        max_seq_len: int = MAX_SEQ_LEN,
+        max_context_len: int = MAX_SEQ_LEN,
+        model_dir: str = "LiquidAI/LFM2.5-VL-1.6B",
+        params_path: str | None = None,
+    ) -> None:
+        self.use_sdpa_with_kv_cache_op = use_sdpa_with_kv_cache_op
+        self.max_context_len = max_context_len
+        self.max_seq_len = max_seq_len
+        self.model_dir = model_dir
+
+        resolved = Path(params_path) if params_path else _DEFAULT_PARAMS
+        params = json.loads(resolved.read_text())
+
+        self.text_model_args = ModelArgs(
+            max_batch_size=1,
+            max_seq_len=max_seq_len,
+            max_context_len=max_context_len,
+            use_kv_cache=use_kv_cache,
+            use_sdpa_with_kv_cache_op=use_sdpa_with_kv_cache_op,
+            enable_dynamic_shape=False,
+            **params,
+        )
+
+        self.hf_model = AutoModelForImageTextToText.from_pretrained(
+            model_dir, device_map="cpu", torch_dtype=torch.float32
+        )
+        self.processor = AutoProcessor.from_pretrained(model_dir)
+        self.tokenizer = self.processor.tokenizer
+
+    def get_eager_model(self) -> torch.nn.Module:
+        return Lfm2p5Vl(self.hf_model, self.text_model_args).to(dtype=torch.float32)
+
+    def get_example_inputs(self) -> tuple[torch.Tensor, ...]:
+        return (torch.randint(0, 256, (1, 3, IMAGE_SIZE, IMAGE_SIZE), dtype=torch.float32),)
+
+    def get_dynamic_shapes(self) -> None:
+        return None

--- a/exir/emit/_emitter.py
+++ b/exir/emit/_emitter.py
@@ -456,10 +456,13 @@ class _Emitter(torch.fx.Interpreter):
                 ctypes.c_char * typing.cast(torch.UntypedStorage, spec.storage).nbytes()
             )
 
+            storage = typing.cast(torch.UntypedStorage, spec.storage)
+            if spec.allocated_memory != 0 and storage.device.type != "cpu":
+                storage = storage.cpu()
             buffer_data = (
                 bytes(
                     ctypes.cast(
-                        typing.cast(torch.UntypedStorage, spec.storage).data_ptr(),
+                        storage.data_ptr(),
                         ctypes.POINTER(spec_array_type),
                     ).contents
                 )


### PR DESCRIPTION
## Summary
Add LFM2.5-VL (450M and 1.6B) as a multi-method PTE with three methods: `vision_encoder`, `token_embedding`, and `text_decoder` for CUDA/AOTI. LFM was not supported via CUDA before. Originally this PR started with XNN, then make it work with CUDA. Unfortunately, I have not got chance to test with XNN. Also, it requires adding ci/unit test probably too for pipeline.

Context: On very small <500M model, Llama cpp and executorch both deliver good perforamnce for low latency use case (i.e, vs SGlang, higher overhead framework at concurrency=1). This is the FIRST step to reach towards unification benchmark + rigorous measurement of such overhead.

**HW**: NVIDIA B300, torch 2.11, CUDA 13.0
**Results**: 333-400 decode tok/s, 435-454 prefill tok/s via `llama_main` C++ runner. 
### Key implementation details
- Conv layer state support. via `attn_options["conv_states"]`for AOTI compatibility. Before,`register_buffer` is still used for XNNPack.
- The usage of `mark_static_address` (same as transformers' `StaticCache` for Gemma3) so AOTI can trace it.
- Manual depthwise conv (pointwise multiply+sum) replaces `nn.Conv1d(groups=dim)` — Triton has no template for depthwise conv1d with dynamic seq_len (or at least I was not able to get this working correctly). If there is an alternative... I would appreciate pointers on its implementation (Did not find in repo too).

### Prefill sweep (B300, bf16)
| ISL | Latency (ms) | Throughput (tok/s) |
|---|---|---|
| 32 | 8.0 | 4,002 |
| 128 | 15.8 | 8,105 |
| 512 | 19.0 | 26,974 |
| 1,024 | 21.0 | 48,758 |

### Sample outputs (llama_main)
```
Prompt: "The capital of France is"
→ Paris.

Prompt: "List the planets in our solar system in order from the sun."
→ 1. Mercury 2. Venus 3. Earth 4. Mars 5. Jupiter 6. Saturn 7. Uranus 8. Neptune

Prompt: "Describe this image in detail." (glacier photo)
→ The image captures a breathtaking view of a majestic glacier, its icy blue surface
  glistening under the bright sunlight...
```

## Test plan

```
=== Vision-Language ===

     Prompt: Describe this image in detail.
     Response: The image captures a breathtaking view of a majestic glacier, with its icy blue hue dominating the scene. The glacier stretches across the frame, its
     surface marked by intricate patterns and ridges that hint at the geological forces shaping it. In the background, a range of snow-capped mountains rises, their
     peaks contrasting sharply against a brilliant blue sky. The sky itself is a canvas of white clouds, some tinged with hints of orange, suggesting the time of day to
      be either dawn or dusk. The foreground features a serene body of water, its surface dotted with small ripples and bubbles, reflecting the tranquility of the
     Time: 12.13s

     Prompt: What objects do you see in this image?
     Response: In this stunning image, I see a breathtaking natural landscape featuring a large glacier in the foreground. The glacier is a striking blue color with
     white patches, creating a beautiful contrast against the surrounding environment.

     The scene is set against a backdrop of majestic mountains, which appear to be part of a larger mountain range. These mountains are covered in lush green
     vegetation, adding depth and richness to the overall composition.

     Above the mountains, the sky is a brilliant blue with scattered white clouds, creating a sense of vastness and openness.

     The water in the foreground is a vibrant turquoise color, reflecting the sunlight and
     Time: 11.66s

     === Text-Only ===

     Prompt: The capital of France is
     Response: Paris.
     Time: 0.28s

     Prompt: Explain the difference between a compiler and an interpreter in two sentences.
     Response: A compiler is a process that converts high-level programming language code into machine code, which can be executed by a computer. An interpreter, on the
      other hand, is a program that executes code line by line, without converting it to machine code.
     Time: 4.59s

     Prompt: What is the speed of light in meters per second?
     Response: The speed of light in a vacuum is approximately 299,792,458 meters per second. This value is derived from the fundamental laws of physics and is a
     constant that applies to all observers, regardless of their relative motion or location.
     Time: 4.36s
```

### Export (multi-method PTE)
```bash
cd /path/to/workdir
python examples/models/lfm2_5_vl/export_lfm2_5_vl.py \
  --model_dir LiquidAI/LFM2.5-VL-450M --dtype bf16 \
  --output lfm2_5_vl_bf16_cuda.pte
# Produces: lfm2_5_vl_bf16_cuda.pte + aoti_cuda_blob.ptd
```

### Run with llama_main (single-method PTE)
<details>
<summary>export_single_method.py</summary>

```python
"""Export LFM2.5-VL-450M as single-method PTE compatible with llama_main."""

from __future__ import annotations

import logging
from pathlib import Path

import torch
from torch.export import Dim
from torch.export._trace import _export
from torch.nn.attention import SDPBackend

from executorch.backends.cuda.cuda_backend import CudaBackend
from executorch.backends.cuda.cuda_partitioner import CudaPartitioner
from executorch.examples.models.lfm2.short_conv import ShortConvBlock
from executorch.examples.models.lfm2_5_vl.model import Lfm2p5VlModel, MAX_SEQ_LEN
from executorch.exir import (
    EdgeCompileConfig,
    ExecutorchBackendConfig,
    to_edge_transform_and_lower,
)
from executorch.exir.passes import MemoryPlanningPass
from executorch.exir.passes.sym_shape_eval_pass import ConstraintBasedSymShapeEvalPass

logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")

try:
    from torch._inductor.codecache import cuda_compile_utils

    _orig_nvcc_arch = cuda_compile_utils._nvcc_arch_as_compile_option

    def _patched_nvcc_arch() -> str:
        return "103a" if cuda_compile_utils.cuda_env.get_cuda_arch() == "103" else _orig_nvcc_arch()

    cuda_compile_utils._nvcc_arch_as_compile_option = _patched_nvcc_arch
except (ImportError, AttributeError):
    pass

_PARAMS = Path(__file__).parent / ".." / "executorch" / "examples" / "models" / "lfm2_5_vl" / "config" / "lfm2_5_vl_450m_config.json"
_MODEL_DIR = Path("LFM2-VL-450M")
_OUTPUT = Path("lfm2_5_vl_llama_cuda.pte")


class _LlamaCompatModel(torch.nn.Module):
    """forward(input_ids, input_pos) -> logits, matching llama_main interface."""

    def __init__(
        self, lfm2: torch.nn.Module, conv_dim: int, conv_indices: list[int],
        *, dtype: torch.dtype, device: str,
    ) -> None:
        super().__init__()
        self.embed = lfm2.model_.model.language_model.get_input_embeddings()
        self.text_model = lfm2.text_model
        self.conv_indices = conv_indices

        for idx in conv_indices:
            buf = torch.zeros(1, conv_dim, 2, dtype=dtype, device=device)
            self.register_buffer(f"conv_state_{idx}", buf, persistent=False)
            if not torch.compiler.is_compiling():
                torch._dynamo.mark_static_address(buf)

    def forward(self, input_ids: torch.Tensor, input_pos: torch.Tensor) -> torch.Tensor:
        embeddings = self.embed(input_ids)
        conv_states = {idx: getattr(self, f"conv_state_{idx}") for idx in self.conv_indices}
        out = self.text_model(None, {"input_pos": input_pos, "conv_states": conv_states}, embeddings)
        if isinstance(out, tuple):
            out = out[0]
        return out.contiguous()


def main() -> None:
    logging.info("Loading model...")
    lfm2_model = Lfm2p5VlModel(
        model_dir=str(_MODEL_DIR),
        max_seq_len=MAX_SEQ_LEN,
        max_context_len=MAX_SEQ_LEN,
        params_path=str(_PARAMS),
        use_sdpa_with_kv_cache_op=False,
    )
    lfm2 = lfm2_model.get_eager_model().to(dtype=torch.bfloat16, device="cuda")

    conv_indices = [i for i, layer in enumerate(lfm2.text_model.layers) if isinstance(layer, ShortConvBlock)]
    model = _LlamaCompatModel(lfm2, lfm2.text_model_args.dim, conv_indices, dtype=torch.bfloat16, device="cuda")

    # Mark KV cache buffers after device migration
    for module in model.text_model.modules():
        for name, buf in module.named_buffers(recurse=False):
            if name in ("k_cache", "v_cache"):
                torch._dynamo.mark_static_address(buf)

    seq = 8
    token_dim = Dim("token_dim", min=1, max=MAX_SEQ_LEN - 1)
    example_ids = torch.randint(1, 65000, (1, seq), dtype=torch.int64, device="cuda")
    example_pos = torch.arange(seq, dtype=torch.int64, device="cuda")

    logging.info("Exporting...")
    with torch.nn.attention.sdpa_kernel([SDPBackend.MATH]), torch.no_grad():
        ep = _export(
            model, (example_ids, example_pos),
            dynamic_shapes=({1: token_dim}, {0: token_dim}),
            strict=False,
            prefer_deferred_runtime_asserts_over_guards=True,
        )

    logging.info("Lowering to CUDA")
    compile_specs = [CudaBackend.generate_method_name_compile_spec("forward")]
    et_prog = to_edge_transform_and_lower(
        {"forward": ep},
        partitioner={"forward": [CudaPartitioner(compile_specs)]},
        compile_config=EdgeCompileConfig(_check_ir_validity=False, _skip_dim_order=True),
        constant_methods={"get_max_seq_len": MAX_SEQ_LEN, "get_vocab_size": lfm2.text_model_args.vocab_size, "use_kv_cache": True, "get_eos_ids": [7]},
    )

    et_program = et_prog.to_executorch(
        ExecutorchBackendConfig(
            memory_planning_pass=MemoryPlanningPass(alloc_graph_input=False),
            sym_shape_eval_pass={"forward": ConstraintBasedSymShapeEvalPass()},
        )
    )

    logging.info("Saving %s", _OUTPUT)
    with open(_OUTPUT, "wb") as f:
        et_program.write_to_file(f)
    et_program.write_tensor_data_to_file(".")
    logging.info("Done")


if __name__ == "__main__":
    main()
```
</details>

```bash
# Build runner
make llama-cuda

# Export single-method
python export_single_method.py

# Run
cmake-out/examples/models/llama/llama_main \
  --model_path lfm2_5_vl_llama_cuda.pte \
  --data_paths aoti_cuda_blob.ptd \
  --tokenizer_path LFM2-VL-450M/tokenizer.json \
  --prompt $'<|startoftext|><|im_start|>user\nThe capital of France is<|im_end|>\n<|im_start|>assistant\n' \
  --max_new_tokens 64 --temperature 0.1 --warmup true
```

### Python inference runner
<details>
<summary>run_lfm2vl.py</summary>

```python
"""Run LFM2.5-VL-450M from an exported PTE+PTD on CUDA."""

from __future__ import annotations

import time
from pathlib import Path

import numpy as np
import torch
from PIL import Image
from transformers import AutoProcessor
from executorch.extension.pybindings.portable_lib import _load_for_executorch

PTE_PATH = Path("lfm2_5_vl_bf16_cuda.pte")
PTD_PATH = Path("aoti_cuda_blob.ptd")
MODEL_DIR = Path("LFM2-VL-450M")

IMAGE_TOKEN_ID = 396
EOS_ID = 7
VISION_INPUT_SIZE = 512

# Model card recommended sampling parameters
TEMPERATURE = 0.1
MIN_P = 0.15
REPETITION_PENALTY = 1.05


def _load_image_pixels(path: Path) -> torch.Tensor:
    """Load an image as [1, 3, 512, 512] NCHW float32 in [0, 255]."""
    img = Image.open(path).convert("RGB").resize((VISION_INPUT_SIZE, VISION_INPUT_SIZE))
    return torch.from_numpy(np.array(img)).permute(2, 0, 1).unsqueeze(0).float()


def _embed_tokens(module, input_ids: torch.Tensor) -> torch.Tensor:
    return module.run_method("token_embedding", [input_ids])[0].contiguous()


def _decode_step(module, embeddings: torch.Tensor, input_pos: torch.Tensor) -> torch.Tensor:
    return module.run_method("text_decoder", [embeddings.contiguous(), input_pos])[0]


def _build_embeddings(
    module,
    input_ids: torch.Tensor,
    image_path: Path | None,
) -> torch.Tensor:
    """Build the full embedding sequence, splicing in vision embeddings if needed."""
    if image_path is None or IMAGE_TOKEN_ID not in input_ids[0]:
        return _embed_tokens(module, input_ids)

    positions = (input_ids[0] == IMAGE_TOKEN_ID).nonzero(as_tuple=True)[0]
    first, last = positions[0].item(), positions[-1].item()

    before = _embed_tokens(module, input_ids[:, :first])
    after = _embed_tokens(module, input_ids[:, last + 1 :])

    pixels = _load_image_pixels(image_path).contiguous()
    image = module.run_method("vision_encoder", [pixels])[0].contiguous()

    return torch.cat([before, image, after], dim=1)


def _sample_token(
    logits: torch.Tensor,
    generated: list[int],
    temperature: float = TEMPERATURE,
    min_p: float = MIN_P,
    repetition_penalty: float = REPETITION_PENALTY,
) -> int:
    """Sample next token with temperature, min-p filtering, and repetition penalty."""
    scores = logits.float()

    # Repetition penalty: reduce logits for already-generated tokens
    if generated and repetition_penalty != 1.0:
        prev_tokens = torch.tensor(generated, dtype=torch.long, device=scores.device)
        token_scores = scores[prev_tokens]
        token_scores = torch.where(
            token_scores > 0,
            token_scores / repetition_penalty,
            token_scores * repetition_penalty,
        )
        scores[prev_tokens] = token_scores

    if temperature <= 0:
        return scores.argmax(dim=-1).item()

    probs = torch.softmax(scores / temperature, dim=-1)

    # Min-p filtering: zero out tokens below min_p * max_prob
    if min_p > 0:
        top_prob = probs.max()
        probs[probs < min_p * top_prob] = 0.0

    return torch.multinomial(probs, num_samples=1).item()


def generate(
    module,
    processor: AutoProcessor,
    prompt: str,
    *,
    image_path: Path | None = None,
    max_new_tokens: int = 128,
) -> str:
    content: list[dict[str, str]] = []
    if image_path is not None:
        content.append({"type": "image"})
    content.append({"type": "text", "text": prompt})

    text = processor.apply_chat_template(
        [{"role": "user", "content": content}], add_generation_prompt=True
    )
    input_ids = processor.tokenizer.encode(text, return_tensors="pt")

    embeddings = _build_embeddings(module, input_ids, image_path).contiguous()
    seq_len = embeddings.shape[1]
    logits = _decode_step(module, embeddings, torch.arange(seq_len, dtype=torch.int64))

    generated: list[int] = []
    cur_pos = seq_len

    for _ in range(max_new_tokens):
        last_logits = logits[:, -1, :].squeeze(0) if logits.dim() == 3 else logits.squeeze(0)
        token_id = _sample_token(last_logits, generated)
        if token_id == EOS_ID:
            break
        generated.append(token_id)

        token_embed = _embed_tokens(module, torch.tensor([[token_id]], dtype=torch.int64))
        logits = _decode_step(module, token_embed, torch.tensor([cur_pos], dtype=torch.int64))
        cur_pos += 1

    return processor.tokenizer.decode(generated, skip_special_tokens=True)


def main() -> None:
    module = _load_for_executorch(str(PTE_PATH), str(PTD_PATH))
    processor = AutoProcessor.from_pretrained(str(MODEL_DIR))

    test_image = Path("/tmp/test_image.jpg")

    sections: list[tuple[str, list[tuple[str, Path | None]]]] = [
        (
            "Vision-Language",
            [
                ("Describe this image in detail.", test_image),
                ("What objects do you see in this image?", test_image),
            ],
        ),
        (
            "Text-Only",
            [
                ("The capital of France is", None),
                ("Explain the difference between a compiler and an interpreter in two sentences.", None),
                ("What is the speed of light in meters per second?", None),
            ],
        ),
    ]

    for section_name, prompts in sections:
        print(f"\n=== {section_name} ===")
        for prompt, img in prompts:
            print(f"\nPrompt: {prompt}")
            t0 = time.perf_counter()
            response = generate(module, processor, prompt, image_path=img)
            elapsed = time.perf_counter() - t0
            print(f"Response: {response}")
            print(f"Time: {elapsed:.2f}s")


if __name__ == "__main__":
    main()
```
</details>

### Benchmark
<details>
<summary>bench_lfm2vl.py</summary>

```python
"""Benchmark LFM2.5-VL-450M on ExecuTorch CUDA — matches llama_main metrics."""

from __future__ import annotations

import time
from pathlib import Path

import torch
from transformers import AutoProcessor
from executorch.extension.pybindings.portable_lib import _load_for_executorch

PTE_PATH = Path("lfm2_5_vl_bf16_cuda.pte")
PTD_PATH = Path("aoti_cuda_blob.ptd")
MODEL_DIR = Path("LFM2-VL-450M")

EOS_ID = 7
IMAGE_TOKEN_ID = 396

TEMPERATURE = 0.1
TOP_P = 0.9


def _embed(module, ids: torch.Tensor) -> torch.Tensor:
    return module.run_method("token_embedding", [ids])[0].contiguous()


def _decode(module, emb: torch.Tensor, pos: torch.Tensor) -> torch.Tensor:
    return module.run_method("text_decoder", [emb.contiguous(), pos])[0]


def _sample(logits: torch.Tensor) -> int:
    if TEMPERATURE <= 0:
        return torch.argmax(logits, dim=-1).item()
    probs = torch.softmax(logits / TEMPERATURE, dim=-1)
    probs_sort, probs_idx = torch.sort(probs, descending=True)
    cum = torch.cumsum(probs_sort, dim=-1)
    mask = (cum - probs_sort) > TOP_P
    probs_sort[mask] = 0.0
    probs_sort /= probs_sort.sum()
    return torch.gather(probs_idx, -1, torch.multinomial(probs_sort, 1)).item()


def benchmark_text(
    module, tokenizer, prompt: str, *, max_new_tokens: int = 128, warmup: bool = True
) -> None:
    tokens = tokenizer.encode(prompt)
    if isinstance(tokens, torch.Tensor):
        tokens = tokens.squeeze().tolist()
    prompt_len = len(tokens)

    if warmup:
        ids = torch.tensor([tokens], dtype=torch.int64)
        emb = _embed(module, ids)
        pos = torch.arange(emb.shape[1], dtype=torch.int64)
        _decode(module, emb, pos)

    # --- Prefill ---
    ids = torch.tensor([tokens], dtype=torch.int64)
    torch.cuda.synchronize()
    t_prefill = time.perf_counter()
    emb = _embed(module, ids)
    pos = torch.arange(emb.shape[1], dtype=torch.int64)
    logits = _decode(module, emb, pos)
    torch.cuda.synchronize()
    prefill_time = time.perf_counter() - t_prefill

    last = logits[:, -1, :].squeeze(0) if logits.dim() == 3 else logits.squeeze(0)
    cur_token = _sample(last)
    generated = [cur_token]
    cur_pos = prompt_len

    # --- Decode ---
    torch.cuda.synchronize()
    t_decode = time.perf_counter()
    while len(generated) < max_new_tokens:
        tok_emb = _embed(module, torch.tensor([[cur_token]], dtype=torch.int64))
        logits = _decode(module, tok_emb, torch.tensor([cur_pos], dtype=torch.int64))
        last = logits[:, -1, :].squeeze(0) if logits.dim() == 3 else logits.squeeze(0)
        cur_token = _sample(last)
        if cur_token == EOS_ID:
            break
        generated.append(cur_token)
        cur_pos += 1
    torch.cuda.synchronize()
    decode_time = time.perf_counter() - t_decode

    decode_tokens = len(generated) - 1  # first token came from prefill
    text = tokenizer.decode(generated, skip_special_tokens=True)

    print(f"  Prompt ({prompt_len} tokens): {prompt[:60]}...")
    print(f"  Output ({len(generated)} tokens): {text[:80]}...")
    print(f"  Prefill:  {prefill_time*1000:.1f} ms  |  {prompt_len/prefill_time:.0f} tok/s")
    print(f"  TTFT:     {prefill_time*1000:.1f} ms")
    if decode_tokens > 0:
        print(f"  Decode:   {decode_time*1000:.1f} ms  |  {decode_tokens/decode_time:.1f} tok/s")
    print()


def benchmark_prefill_sweep(module, tokenizer) -> None:
    """Prefill-only benchmark across different input lengths."""
    print("=== Prefill Sweep ===")
    print(f"{'ISL':>6}  {'Latency (ms)':>12}  {'Throughput (tok/s)':>18}")
    print("-" * 42)

    for isl in [32, 64, 128, 256, 512, 1024]:
        ids = torch.randint(10, 65000, (1, isl), dtype=torch.int64)

        # Warmup
        emb = _embed(module, ids)
        pos = torch.arange(isl, dtype=torch.int64)
        _decode(module, emb, pos)

        # Timed (5 runs, take median)
        times = []
        for _ in range(5):
            torch.cuda.synchronize()
            t0 = time.perf_counter()
            emb = _embed(module, ids)
            pos = torch.arange(isl, dtype=torch.int64)
            _decode(module, emb, pos)
            torch.cuda.synchronize()
            times.append(time.perf_counter() - t0)

        times.sort()
        median = times[len(times) // 2]
        print(f"{isl:>6}  {median*1000:>12.2f}  {isl/median:>18.0f}")

    print()


def main() -> None:
    print(f"Loading {PTE_PATH} + {PTD_PATH}\n")
    module = _load_for_executorch(str(PTE_PATH), str(PTD_PATH))
    processor = AutoProcessor.from_pretrained(str(MODEL_DIR))
    tokenizer = processor.tokenizer

    # --- Text generation benchmarks ---
    prompts = [
        "The capital of France is",
        "Explain the difference between a compiler and an interpreter in two sentences.",
        "Write a short paragraph about the history of artificial intelligence.",
        "What is the speed of light in meters per second? Give just the number.",
    ]

    print("=== Text Generation (warmup + timed) ===\n")
    for prompt in prompts:
        benchmark_text(module, tokenizer, prompt, max_new_tokens=64)

    # --- Prefill sweep ---
    benchmark_prefill_sweep(module, tokenizer)


if __name__ == "__main__":
    main()
```
</details>

```bash
python bench_lfm2vl.py
```


## Verification status
- [x] CUDA/AOTI export (multi-method: vision_encoder + token_embedding + text_decoder)
- [x] CUDA/AOTI export (single-method: forward, for llama_main)
- [x] Text-only generation quality (Paris, compiler/interpreter, speed of light, planets)
- [x] Vision-language generation quality (glacier image: coherent multi-sentence descriptions)
- [x] llama_main C++ runner (333-400 decode tok/s)
- [x] Python pybindings runner
- [x] Prefill sweep benchmark (ISL 32-1024)
- [ ] XNNPack LFM2 text-only export still works (short_conv.py has dual state path but untested)
- [ ] XNNPack LFM2.5-VL export (vision + XNNPack text decoder)
- [ ] CI tests

## Known limitations / future work
- **Blackwell sm_103 arch workaround**: monkey-patches `torch._inductor` private API to fix nvcc/Triton PTX mismatch. Fragile; should be fixed upstream in PyTorch ([relevant code](https://github.com/pytorch/pytorch/blob/main/torch/_inductor/codecache.py) — `_nvcc_arch_as_compile_option` maps 103→100f, should be 103→103a).
- **Emitter CUDA storage fix**: `exir/emit/_emitter.py` copies CUDA tensor storage to CPU before `ctypes.data_ptr()` read. This is a general fix, not LFM2.5-VL-specific — should be upstreamed as a standalone PR.
- **Conv state dynamic `getattr` pattern**: `_Decoder` and `_LlamaCompatModel` use `register_buffer(f"conv_state_{idx}")` + `getattr(self, f"conv_state_{idx}")`. Works but violates the "no dynamic setattr/getattr" style guideline. Could use a list-based approach instead.
- **Batched export**: batch_size>1 works for export but KV cache is pre-allocated at `max_batch_size`, consuming significant memory. batch=2048 OOMs during AOTI autotuning.
- **Vision encoder fixed to 512×512**: the exported vision encoder bakes in normalization and patchification for a single 512×512 image. Multi-image / variable-resolution / tiling (as described in the model card) is not supported.
- **No `llava_main` integration**: the multi-method PTE (vision_encoder + token_embedding + text_decoder) follows the LLaVA runner pattern but hasn't been tested with the actual `llava_main` C++ binary.
- **`lm_head` weight tying assumption**: `convert_weights.py` assumes `lm_head.weight == tok_embeddings.weight` (tied embeddings). If a future checkpoint untied them, the lm_head weights would be silently ignored.


cc @larryliu0820 @mergennachin @cccclai @helunwencser @jackzhxng @digantdesai @Gasoonjia