### PR TITLE
Arm backend: Install TOSA and VGF tooling from pip

### DIFF
--- a/backends/arm/requirements-arm-tosa.txt
+++ b/backends/arm/requirements-arm-tosa.txt
@@ -7,6 +7,5 @@ ml_dtypes == 0.5.1
 flatbuffers == 24.3.25
 tosa-adapter-model-explorer == 0.1.0
 ai-edge-model-explorer >= 0.1.16
-# NOTE: Will be removed when tosa-tools is installed via pypi
-pybind11 == 2.10.4
 pytest-timeout == 2.4.0
+tosa-tools == 2026.2.1

--- a/backends/arm/requirements-arm-vgf.txt
+++ b/backends/arm/requirements-arm-vgf.txt
@@ -3,6 +3,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-ai_ml_emulation_layer_for_vulkan == 0.8.0
-ai_ml_sdk_model_converter == 0.8.0
-ai_ml_sdk_vgf_library == 0.8.0
+ai_ml_emulation_layer_for_vulkan == 0.9.0
+ai_ml_sdk_model_converter == 0.9.0
+ai_ml_sdk_vgf_library == 0.9.0

--- a/backends/arm/runtime/VGFBackend.cpp
+++ b/backends/arm/runtime/VGFBackend.cpp
@@ -157,7 +157,8 @@ class VGFBackend final : public ::executorch::runtime::BackendInterface {
     new (repr) VgfRepr(
         vk_instance, vk_physical_device, vk_device, vk_queue, vk_command_pool);
 
-    auto valid_vgf = repr->process_vgf(vgf_data, compile_specs);
+    auto valid_vgf =
+        repr->process_vgf(vgf_data, processed->size(), compile_specs);
     if (!valid_vgf) {
       ET_LOG(Error, "Failed to process VGF blob.");
       return Error::Internal;

--- a/backends/arm/runtime/VGFSetup.cpp
+++ b/backends/arm/runtime/VGFSetup.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Arm Limited and/or its affiliates.
+ * Copyright 2025-2026 Arm Limited and/or its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
@@ -324,26 +324,38 @@ static void debug_print_modules(
   }
 }
 
-bool VgfRepr::process_vgf(const char* vgf_data, ArrayRef<CompileSpec> specs) {
+bool VgfRepr::process_vgf(
+    const char* vgf_data,
+    size_t vgf_size,
+    ArrayRef<CompileSpec> specs) {
   ET_LOG(Info, "Preparing VGF as Vulkan objects");
 
   VkResult result;
 
   // Prepare temporary decoders
   unique_ptr<vgflib::HeaderDecoder> header_decoder =
-      vgflib::CreateHeaderDecoder(vgf_data);
+      vgflib::CreateHeaderDecoder(vgf_data, vgflib::HeaderSize(), vgf_size);
+  if (!header_decoder) {
+    ET_LOG(Error, "Failed to create VGF header decoder");
+    return false;
+  }
+
   unique_ptr<vgflib::ModelSequenceTableDecoder> sequence_decoder =
       vgflib::CreateModelSequenceTableDecoder(
-          vgf_data + header_decoder->GetModelSequenceTableOffset());
+          vgf_data + header_decoder->GetModelSequenceTableOffset(),
+          header_decoder->GetModelSequenceTableSize());
   unique_ptr<vgflib::ModuleTableDecoder> module_decoder =
       vgflib::CreateModuleTableDecoder(
-          vgf_data + header_decoder->GetModuleTableOffset());
+          vgf_data + header_decoder->GetModuleTableOffset(),
+          header_decoder->GetModuleTableSize());
   unique_ptr<vgflib::ModelResourceTableDecoder> resource_decoder =
       vgflib::CreateModelResourceTableDecoder(
-          vgf_data + header_decoder->GetModelResourceTableOffset());
+          vgf_data + header_decoder->GetModelResourceTableOffset(),
+          header_decoder->GetModelResourceTableSize());
   unique_ptr<vgflib::ConstantDecoder> constant_decoder =
       vgflib::CreateConstantDecoder(
-          vgf_data + header_decoder->GetConstantsOffset());
+          vgf_data + header_decoder->GetConstantsOffset(),
+          header_decoder->GetConstantsSize());
   // Check the VGF decoders
   if (not(header_decoder && module_decoder && sequence_decoder &&
           resource_decoder && constant_decoder && header_decoder->IsValid() &&

--- a/backends/arm/runtime/VGFSetup.h
+++ b/backends/arm/runtime/VGFSetup.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Arm Limited and/or its affiliates.
+ * Copyright 2025-2026 Arm Limited and/or its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
@@ -58,7 +58,10 @@ class VgfRepr {
   /*
    * Process a VGF ready for execution, allocate necessary Vulkan objects.
    */
-  bool process_vgf(const char* vgf_data, ArrayRef<CompileSpec> specs);
+  bool process_vgf(
+      const char* vgf_data,
+      size_t vgf_size,
+      ArrayRef<CompileSpec> specs);
 
   /*
    * Execute the VGF we've previously processed.

--- a/backends/arm/scripts/mlsdk_utils.sh
+++ b/backends/arm/scripts/mlsdk_utils.sh
@@ -291,6 +291,16 @@ PY
         fi
     fi
 
+    local vk_layer_line
+    vk_layer_line=$(echo "$exports" | grep 'VK_LAYER_PATH=' || true)
+    if [[ -n "${vk_layer_line}" ]]; then
+        local vk_layer_value=${vk_layer_line#export VK_LAYER_PATH=}
+        vk_layer_value=${vk_layer_value%%:\$VK_LAYER_PATH*}
+        if [[ -n "${vk_layer_value}" ]]; then
+            prepend_env_in_setup_path VK_LAYER_PATH "${vk_layer_value}"
+        fi
+    fi
+
     local vk_add_line
     vk_add_line=$(echo "$exports" | grep 'VK_ADD_LAYER_PATH=' || true)
     if [[ -n "${vk_add_line}" ]]; then

--- a/examples/arm/setup.sh
+++ b/examples/arm/setup.sh
@@ -335,36 +335,6 @@ if [[ $is_script_sourced -eq 0 ]]; then
     CMAKE_POLICY_VERSION_MINIMUM=3.5 \
         pip install --no-dependencies -r "$et_dir/backends/arm/requirements-arm-tosa.txt"
 
-    pushd "$root_dir"
-    if [[ ! -d "tosa-tools" ]]; then
-        git clone https://git.gitlab.arm.com/tosa/tosa-tools.git
-    fi
-
-    pushd tosa-tools
-    git checkout v2025.11.2
-
-    if [[ ! -d "reference_model" ]]; then
-        log_step "main" "[error] Missing reference_model directory in tosa-tools repo."
-        exit 1
-    fi
-    if [[ ! -d "serialization" ]]; then
-        log_step "main" "[error] Missing serialization directory in tosa-tools repo."
-        exit 1
-    fi
-
-    export CMAKE_BUILD_PARALLEL_LEVEL="$(get_parallel_jobs)"
-
-    CMAKE_POLICY_VERSION_MINIMUM=3.5 \
-        BUILD_PYBIND=1 \
-        BUILD_TOSA_REFERENCE_MODEL_TESTS=0 \
-        pip install --no-dependencies ./reference_model
-
-    CMAKE_POLICY_VERSION_MINIMUM=3.5 \
-        BUILD_PYBIND=1 \
-        pip install --no-dependencies ./serialization
-    popd
-    popd
-
     if [[ "${enable_vela}" -eq 1 ]]; then
         log_step "deps" "Installing Ethos-U Vela compiler"
         setup_ethos_u_tools


### PR DESCRIPTION
Install tosa-tools and the ML SDK model-converter/VGF packages from pip instead of cloning tosa-tools from source.

Update the VGF runtime to the 0.9 decoder API and export VK_LAYER_PATH for the pip-installed emulation layer so the Vulkan ML layers are discovered at runtime.

Signed-off-by: per.held@arm.com
Change-Id: I2d3c2acd21a1bbe587d9af0b44479407afdab82d


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell