### PR TITLE
Revert xnnpack runtime check

### DIFF
--- a/backends/xnnpack/runtime/XNNCompiler.cpp
+++ b/backends/xnnpack/runtime/XNNCompiler.cpp
@@ -1859,18 +1859,9 @@ ET_NODISCARD Error XNNCompiler::compileModel(
       xnn_status_to_string(status));
 
   // create xnnpack subgraph
-  uint32_t num_externs = flatbuffer_graph->num_externs();
-  uint32_t num_values = flatbuffer_graph->xvalues()->size();
-  ET_CHECK_OR_RETURN_ERROR(
-      num_externs <= num_values,
-      InvalidProgram,
-      "num_externs (%u) exceeds total number of values (%u)",
-      num_externs,
-      num_values);
-
   xnn_subgraph_t subgraph_ptr = nullptr;
   status = xnn_create_subgraph(
-      /*external_value_ids=*/num_externs,
+      /*external_value_ids=*/flatbuffer_graph->num_externs(),
       /*flags=*/0,
       &subgraph_ptr);
   ET_CHECK_OR_RETURN_ERROR(


### PR DESCRIPTION
Internal failures on: https://github.com/pytorch/executorch/pull/18799

`num_externs <= num_values` is not the right check. We should scan xvalues to find `num_externs` and use that, provided they are valid. Will put up separate PR for the change.