### PR TITLE
increase test pass threshold to bring flacky test back

### DIFF
--- a/backends/cuda/tests/test_fused_moe.py
+++ b/backends/cuda/tests/test_fused_moe.py
@@ -390,7 +390,7 @@ class TestFusedMoE(unittest.TestCase):
                     rel_diff = diff / ref_scale
                     self.assertLess(
                         rel_diff,
-                        0.01,
+                        0.02,
                         f"seed={seed}: abs diff {diff}, rel diff {rel_diff:.4f}",
                     )
 


### PR DESCRIPTION
Summary: current 1e-2 threshould is too tight to have a stable test; increasing it to 2e-2 to bring ci back.

Differential Revision: D100690641


