### PR TITLE
Arm backend: aot_arm_compiler.py support BundleIO output file without a path

### DIFF
--- a/backends/arm/scripts/aot_arm_compiler.py
+++ b/backends/arm/scripts/aot_arm_compiler.py
@@ -778,7 +778,8 @@ def _save_bpte_program(
 
     # Generate BundledProgram
     output_dir = os.path.dirname(output_name)
-    os.makedirs(output_dir, exist_ok=True)
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
     _save_bundled_program(exec_prog, method_test_suites, output_name)
 
 


### PR DESCRIPTION
BundleIO output generation needed the specified output file name to be supplied with a folder, so if you wanted to output a file in the current folder you needed to add "./" in front of the file name like "./file.bpte" this change fixes this problem, the normal .pte generation already supported this.



cc @digantdesai @freddan80 @per @oscarandersson8218 @mansnils @Sebastian-Larsson @robell