### PR TITLE
Add Pico2 build validation CI (trunk only)

### DIFF
--- a/.github/workflows/test-pico2-build.yml
+++ b/.github/workflows/test-pico2-build.yml
@@ -1,6 +1,11 @@
 name: Pico2 Build Validation
 
 on:
+  pull_request:
+    paths:
+      - .github/workflows/test-pico2-build.yml
+      - examples/raspberry_pi/pico2/**
+      - backends/cortex_m/**
   push:
     branches: [main, release/*]
     paths:

--- a/.github/workflows/test-pico2-build.yml
+++ b/.github/workflows/test-pico2-build.yml
@@ -8,6 +8,7 @@ on:
       - backends/cortex_m/**
       - .ci/scripts/**
       - examples/arm/**
+      - .github/workflows/test-pico2-build.yml
   schedule:
     # Run daily at 3 AM UTC to catch upstream breakages
     - cron: '0 3 * * *'
@@ -30,6 +31,7 @@ jobs:
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout: 120
       script: |
+        set -euo pipefail
         # Activate conda environment from the docker image
         CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
         conda activate "${CONDA_ENV}"
@@ -99,6 +101,7 @@ jobs:
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout: 120
       script: |
+        set -euo pipefail
         # Activate conda environment from the docker image
         CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
         conda activate "${CONDA_ENV}"

--- a/.github/workflows/test-pico2-build.yml
+++ b/.github/workflows/test-pico2-build.yml
@@ -6,12 +6,14 @@ on:
     paths:
       - examples/raspberry_pi/pico2/**
       - backends/cortex_m/**
+      - .ci/scripts/**
+      - examples/arm/**
   schedule:
     # Run daily at 3 AM UTC to catch upstream breakages
     - cron: '0 3 * * *'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:
@@ -26,7 +28,7 @@ jobs:
       docker-image: ci-image:executorch-ubuntu-22.04-arm-sdk
       submodules: 'recursive'
       ref: ${{ github.sha }}
-      timeout: 60
+      timeout: 120
       script: |
         # Activate conda environment from the docker image
         CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
@@ -65,25 +67,24 @@ jobs:
         echo "--- Key symbols ---"
         arm-none-eabi-nm --print-size --size-sort --radix=d "${ELF_FILE}" | tail -20
 
-        # Validate binary fits in Pico2 memory:
-        #   .text in flash (4MB = 4194304 bytes)
-        #   .bss + .data in SRAM (520KB = 532480 bytes)
-        TEXT_SIZE=$(arm-none-eabi-size -A "${ELF_FILE}" | awk '/.text/ {print $2}')
-        BSS_SIZE=$(arm-none-eabi-size -A "${ELF_FILE}" | awk '/.bss/ {print $2}')
-        DATA_SIZE=$(arm-none-eabi-size -A "${ELF_FILE}" | awk '/.data/ {print $2}')
+        # Validate binary fits in Pico2 memory using aggregated totals:
+        #   flash = text + data (4MB = 4194304 bytes)
+        #   SRAM  = data + bss  (520KB = 532480 bytes)
+        eval $(arm-none-eabi-size "${ELF_FILE}" | awk 'NR==2 {printf "TEXT_SIZE=%d DATA_SIZE=%d BSS_SIZE=%d", $1, $2, $3}')
 
-        echo "FP32 binary: .text=${TEXT_SIZE} .bss=${BSS_SIZE} .data=${DATA_SIZE}"
+        FLASH_USED=$((TEXT_SIZE + DATA_SIZE))
+        SRAM_USED=$((DATA_SIZE + BSS_SIZE))
+        echo "FP32 binary: text=${TEXT_SIZE} data=${DATA_SIZE} bss=${BSS_SIZE} => flash=${FLASH_USED} sram=${SRAM_USED}"
 
-        SRAM_USED=$((BSS_SIZE + DATA_SIZE))
-        if [ "${TEXT_SIZE}" -gt 4194304 ]; then
-          echo "FAIL: .text (${TEXT_SIZE}) exceeds 4MB flash"
+        if [ "${FLASH_USED}" -gt 4194304 ]; then
+          echo "FAIL: flash usage (${FLASH_USED}) exceeds 4MB"
           exit 1
         fi
         if [ "${SRAM_USED}" -gt 532480 ]; then
-          echo "FAIL: .bss+.data (${SRAM_USED}) exceeds 520KB SRAM"
+          echo "FAIL: SRAM usage (${SRAM_USED}) exceeds 520KB"
           exit 1
         fi
-        echo "PASS: FP32 firmware fits in Pico2 memory (SRAM: ${SRAM_USED}/532480, Flash: ${TEXT_SIZE}/4194304)"
+        echo "PASS: FP32 firmware fits in Pico2 memory (SRAM: ${SRAM_USED}/532480, Flash: ${FLASH_USED}/4194304)"
 
   test-pico2-cmsis-build:
     name: test-pico2-cmsis-nn-build
@@ -96,7 +97,7 @@ jobs:
       docker-image: ci-image:executorch-ubuntu-22.04-arm-sdk
       submodules: 'recursive'
       ref: ${{ github.sha }}
-      timeout: 60
+      timeout: 120
       script: |
         # Activate conda environment from the docker image
         CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
@@ -136,26 +137,30 @@ jobs:
         arm-none-eabi-nm --print-size --size-sort --radix=d "${ELF_FILE}" | tail -20
 
         # Verify CMSIS-NN symbols are linked
-        if arm-none-eabi-nm "${ELF_FILE}" | grep -q "cmsis_nn\|arm_nn"; then
+        CMSIS_NN_SYMBOLS=$(arm-none-eabi-nm "${ELF_FILE}" | grep -E '(cmsis_nn|arm_nn)' || true)
+        if [ -n "${CMSIS_NN_SYMBOLS}" ]; then
           echo "PASS: CMSIS-NN symbols found in binary"
+          printf '%s\n' "${CMSIS_NN_SYMBOLS}" | head -20
         else
-          echo "WARNING: No CMSIS-NN symbols detected — verify cortex_m backend linked correctly"
+          echo "FAIL: No CMSIS-NN symbols detected — cortex_m backend may not be linked correctly"
+          exit 1
         fi
 
-        # Validate binary fits in Pico2 memory
-        TEXT_SIZE=$(arm-none-eabi-size -A "${ELF_FILE}" | awk '/.text/ {print $2}')
-        BSS_SIZE=$(arm-none-eabi-size -A "${ELF_FILE}" | awk '/.bss/ {print $2}')
-        DATA_SIZE=$(arm-none-eabi-size -A "${ELF_FILE}" | awk '/.data/ {print $2}')
+        # Validate binary fits in Pico2 memory using aggregated totals:
+        #   flash = text + data (4MB = 4194304 bytes)
+        #   SRAM  = data + bss  (520KB = 532480 bytes)
+        eval $(arm-none-eabi-size "${ELF_FILE}" | awk 'NR==2 {printf "TEXT_SIZE=%d DATA_SIZE=%d BSS_SIZE=%d", $1, $2, $3}')
 
-        echo "CMSIS-NN binary: .text=${TEXT_SIZE} .bss=${BSS_SIZE} .data=${DATA_SIZE}"
+        FLASH_USED=$((TEXT_SIZE + DATA_SIZE))
+        SRAM_USED=$((DATA_SIZE + BSS_SIZE))
+        echo "CMSIS-NN binary: text=${TEXT_SIZE} data=${DATA_SIZE} bss=${BSS_SIZE} => flash=${FLASH_USED} sram=${SRAM_USED}"
 
-        SRAM_USED=$((BSS_SIZE + DATA_SIZE))
-        if [ "${TEXT_SIZE}" -gt 4194304 ]; then
-          echo "FAIL: .text (${TEXT_SIZE}) exceeds 4MB flash"
+        if [ "${FLASH_USED}" -gt 4194304 ]; then
+          echo "FAIL: flash usage (${FLASH_USED}) exceeds 4MB"
           exit 1
         fi
         if [ "${SRAM_USED}" -gt 532480 ]; then
-          echo "FAIL: .bss+.data (${SRAM_USED}) exceeds 520KB SRAM"
+          echo "FAIL: SRAM usage (${SRAM_USED}) exceeds 520KB"
           exit 1
         fi
-        echo "PASS: CMSIS-NN firmware fits in Pico2 memory (SRAM: ${SRAM_USED}/532480, Flash: ${TEXT_SIZE}/4194304)"
+        echo "PASS: CMSIS-NN firmware fits in Pico2 memory (SRAM: ${SRAM_USED}/532480, Flash: ${FLASH_USED}/4194304)"

--- a/.github/workflows/test-pico2-build.yml
+++ b/.github/workflows/test-pico2-build.yml
@@ -1,0 +1,161 @@
+name: Pico2 Build Validation
+
+on:
+  push:
+    branches: [main, release/*]
+    paths:
+      - examples/raspberry_pi/pico2/**
+      - backends/cortex_m/**
+  schedule:
+    # Run daily at 3 AM UTC to catch upstream breakages
+    - cron: '0 3 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  test-pico2-fp32-build:
+    name: test-pico2-fp32-build
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      runner: linux.2xlarge.memory
+      docker-image: ci-image:executorch-ubuntu-22.04-arm-sdk
+      submodules: 'recursive'
+      ref: ${{ github.sha }}
+      timeout: 60
+      script: |
+        # Activate conda environment from the docker image
+        CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
+        conda activate "${CONDA_ENV}"
+
+        source .ci/scripts/utils.sh
+        install_executorch "--use-pt-pinned-commit"
+
+        # Install ARM baremetal toolchain
+        .ci/scripts/setup-arm-baremetal-tools.sh
+        source examples/arm/arm-scratch/setup_path.sh
+
+        echo "=== Step 1: Export FP32 model ==="
+        cd examples/raspberry_pi/pico2
+        python export_mlp_mnist.py
+        test -f balanced_tiny_mlp_mnist.pte
+        echo "FP32 model exported: $(ls -la balanced_tiny_mlp_mnist.pte)"
+        cd -
+
+        echo "=== Step 2: Build FP32 firmware ==="
+        ./examples/raspberry_pi/pico2/build_firmware_pico.sh --model=balanced_tiny_mlp_mnist.pte
+
+        echo "=== Step 3: Validate FP32 artifacts ==="
+        ELF_FILE=examples/raspberry_pi/pico2/build/executorch_pico.elf
+        UF2_FILE=examples/raspberry_pi/pico2/build/executorch_pico.uf2
+
+        test -f "${ELF_FILE}" || { echo "FAIL: .elf not found"; exit 1; }
+        test -f "${UF2_FILE}" || { echo "FAIL: .uf2 not found"; exit 1; }
+
+        echo "--- Section sizes ---"
+        arm-none-eabi-size -A "${ELF_FILE}"
+
+        echo "--- Section headers ---"
+        arm-none-eabi-objdump -h "${ELF_FILE}"
+
+        echo "--- Key symbols ---"
+        arm-none-eabi-nm --print-size --size-sort --radix=d "${ELF_FILE}" | tail -20
+
+        # Validate binary fits in Pico2 memory:
+        #   .text in flash (4MB = 4194304 bytes)
+        #   .bss + .data in SRAM (520KB = 532480 bytes)
+        TEXT_SIZE=$(arm-none-eabi-size -A "${ELF_FILE}" | awk '/.text/ {print $2}')
+        BSS_SIZE=$(arm-none-eabi-size -A "${ELF_FILE}" | awk '/.bss/ {print $2}')
+        DATA_SIZE=$(arm-none-eabi-size -A "${ELF_FILE}" | awk '/.data/ {print $2}')
+
+        echo "FP32 binary: .text=${TEXT_SIZE} .bss=${BSS_SIZE} .data=${DATA_SIZE}"
+
+        SRAM_USED=$((BSS_SIZE + DATA_SIZE))
+        if [ "${TEXT_SIZE}" -gt 4194304 ]; then
+          echo "FAIL: .text (${TEXT_SIZE}) exceeds 4MB flash"
+          exit 1
+        fi
+        if [ "${SRAM_USED}" -gt 532480 ]; then
+          echo "FAIL: .bss+.data (${SRAM_USED}) exceeds 520KB SRAM"
+          exit 1
+        fi
+        echo "PASS: FP32 firmware fits in Pico2 memory (SRAM: ${SRAM_USED}/532480, Flash: ${TEXT_SIZE}/4194304)"
+
+  test-pico2-cmsis-build:
+    name: test-pico2-cmsis-nn-build
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      runner: linux.2xlarge.memory
+      docker-image: ci-image:executorch-ubuntu-22.04-arm-sdk
+      submodules: 'recursive'
+      ref: ${{ github.sha }}
+      timeout: 60
+      script: |
+        # Activate conda environment from the docker image
+        CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
+        conda activate "${CONDA_ENV}"
+
+        source .ci/scripts/utils.sh
+        install_executorch "--use-pt-pinned-commit"
+
+        # Install ARM baremetal toolchain
+        .ci/scripts/setup-arm-baremetal-tools.sh
+        source examples/arm/arm-scratch/setup_path.sh
+
+        echo "=== Step 1: Export INT8 CMSIS-NN model ==="
+        cd examples/raspberry_pi/pico2
+        python export_mlp_mnist_cmsis.py
+        test -f balanced_tiny_mlp_mnist_cmsis.pte
+        echo "INT8 model exported: $(ls -la balanced_tiny_mlp_mnist_cmsis.pte)"
+        cd -
+
+        echo "=== Step 2: Build CMSIS-NN firmware ==="
+        ./examples/raspberry_pi/pico2/build_firmware_pico.sh --cmsis --model=balanced_tiny_mlp_mnist_cmsis.pte
+
+        echo "=== Step 3: Validate CMSIS-NN artifacts ==="
+        ELF_FILE=examples/raspberry_pi/pico2/build/executorch_pico.elf
+        UF2_FILE=examples/raspberry_pi/pico2/build/executorch_pico.uf2
+
+        test -f "${ELF_FILE}" || { echo "FAIL: .elf not found"; exit 1; }
+        test -f "${UF2_FILE}" || { echo "FAIL: .uf2 not found"; exit 1; }
+
+        echo "--- Section sizes ---"
+        arm-none-eabi-size -A "${ELF_FILE}"
+
+        echo "--- Section headers ---"
+        arm-none-eabi-objdump -h "${ELF_FILE}"
+
+        echo "--- Key symbols ---"
+        arm-none-eabi-nm --print-size --size-sort --radix=d "${ELF_FILE}" | tail -20
+
+        # Verify CMSIS-NN symbols are linked
+        if arm-none-eabi-nm "${ELF_FILE}" | grep -q "cmsis_nn\|arm_nn"; then
+          echo "PASS: CMSIS-NN symbols found in binary"
+        else
+          echo "WARNING: No CMSIS-NN symbols detected — verify cortex_m backend linked correctly"
+        fi
+
+        # Validate binary fits in Pico2 memory
+        TEXT_SIZE=$(arm-none-eabi-size -A "${ELF_FILE}" | awk '/.text/ {print $2}')
+        BSS_SIZE=$(arm-none-eabi-size -A "${ELF_FILE}" | awk '/.bss/ {print $2}')
+        DATA_SIZE=$(arm-none-eabi-size -A "${ELF_FILE}" | awk '/.data/ {print $2}')
+
+        echo "CMSIS-NN binary: .text=${TEXT_SIZE} .bss=${BSS_SIZE} .data=${DATA_SIZE}"
+
+        SRAM_USED=$((BSS_SIZE + DATA_SIZE))
+        if [ "${TEXT_SIZE}" -gt 4194304 ]; then
+          echo "FAIL: .text (${TEXT_SIZE}) exceeds 4MB flash"
+          exit 1
+        fi
+        if [ "${SRAM_USED}" -gt 532480 ]; then
+          echo "FAIL: .bss+.data (${SRAM_USED}) exceeds 520KB SRAM"
+          exit 1
+        fi
+        echo "PASS: CMSIS-NN firmware fits in Pico2 memory (SRAM: ${SRAM_USED}/532480, Flash: ${TEXT_SIZE}/4194304)"

--- a/.github/workflows/test-pico2-build.yml
+++ b/.github/workflows/test-pico2-build.yml
@@ -1,11 +1,6 @@
 name: Pico2 Build Validation
 
 on:
-  pull_request:
-    paths:
-      - .github/workflows/test-pico2-build.yml
-      - examples/raspberry_pi/pico2/**
-      - backends/cortex_m/**
   push:
     branches: [main, release/*]
     paths:
@@ -32,7 +27,7 @@ jobs:
       runner: linux.2xlarge.memory
       docker-image: ci-image:executorch-ubuntu-22.04-arm-sdk
       submodules: 'recursive'
-      ref: ${{ github.sha }}
+      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout: 120
       script: |
         # Activate conda environment from the docker image
@@ -101,7 +96,7 @@ jobs:
       runner: linux.2xlarge.memory
       docker-image: ci-image:executorch-ubuntu-22.04-arm-sdk
       submodules: 'recursive'
-      ref: ${{ github.sha }}
+      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout: 120
       script: |
         # Activate conda environment from the docker image

--- a/examples/raspberry_pi/pico2/build_firmware_pico.sh
+++ b/examples/raspberry_pi/pico2/build_firmware_pico.sh
@@ -95,8 +95,10 @@ echo "Cross compiling ExecuTorch baremetal ARM..."
 # Resolve the model path for selective build. Using EXECUTORCH_SELECT_OPS_MODEL
 # auto-detects the exact operators the model needs from the .pte file, avoiding
 # "Operator missing" errors at runtime.
+# Note: skip selective build for CMSIS-NN models — their cortex_m:: ops are
+# registered by the cortex_m backend, not by portable kernel codegen.
 SELECT_OPS_FLAGS=""
-if [ -n "$MODEL_INPUT" ] && [ -f "${PICO2_DIR}/${MODEL_INPUT}" ]; then
+if [ $USE_CMSIS -eq 0 ] && [ -n "$MODEL_INPUT" ] && [ -f "${PICO2_DIR}/${MODEL_INPUT}" ]; then
   MODEL_ABS_PATH="$(cd "${PICO2_DIR}" && realpath "${MODEL_INPUT}")"
   SELECT_OPS_FLAGS="-DEXECUTORCH_SELECT_OPS_MODEL=${MODEL_ABS_PATH}"
   echo "Using selective build from model: ${MODEL_ABS_PATH}"


### PR DESCRIPTION
Adds two parallel CI jobs that validate FP32 and CMSIS-NN INT8 Pico2 firmware builds on every push to main. Each job exports a model, cross- compiles firmware, and validates the .elf/.uf2 artifacts fit within Pico2 memory limits (520KB SRAM, 4MB flash).

Triggered on push to main when examples/raspberry_pi/pico2/** or backends/cortex_m/** files change, plus a daily schedule and release branches
