### PR TITLE
Fix 'occured' -> 'occurred' typos in backends and exir tracer

### DIFF
--- a/backends/apple/mps/runtime/MPSDevice.mm
+++ b/backends/apple/mps/runtime/MPSDevice.mm
@@ -138,7 +138,7 @@ MPSDevice::compilePSO(LibraryType libraryType, const char* kernelName) {
     ET_CHECK_OR_RETURN_ERROR(
       err == Error::Ok,
       Internal,
-      "An error occured occured while compiling library %d", libraryType
+      "An error occurred while compiling library %d", libraryType
     );
   }
   if (_m_pso_cache.find(kernelName) == _m_pso_cache.end()) {

--- a/backends/cadence/hifi/operators/op_quantized_matmul_asym8sxasym8s_asym8s_out.cpp
+++ b/backends/cadence/hifi/operators/op_quantized_matmul_asym8sxasym8s_asym8s_out.cpp
@@ -79,7 +79,7 @@ void quantized_matmul_asym8sxasym8s_asym8s_out(
           static_cast<int32_t>(out_shift), // out_shift
           static_cast<int32_t>(out_zero_point)); // out_zero_bias
 
-      ET_CHECK_MSG(ret_val == 0, "An internal error occured");
+      ET_CHECK_MSG(ret_val == 0, "An internal error occurred");
     } else {
       /* Assuming matmul is 2D always */
       WORD32 num_inp_dims = 2;
@@ -103,7 +103,7 @@ void quantized_matmul_asym8sxasym8s_asym8s_out(
           num_out_dims,
           num_inp_dims);
 
-      ET_CHECK_MSG(ret_val == 0, "An internal error occured");
+      ET_CHECK_MSG(ret_val == 0, "An internal error occurred");
 
       ret_val = xa_nn_matmul_asym8sxasym8s_asym8s(
           z, // p_out
@@ -123,7 +123,7 @@ void quantized_matmul_asym8sxasym8s_asym8s_out(
           static_cast<int32_t>(out_shift), // out_shift
           static_cast<int32_t>(out_zero_point)); // out_zero_bias
 
-      ET_CHECK_MSG(ret_val == 0, "An internal error occured");
+      ET_CHECK_MSG(ret_val == 0, "An internal error occurred");
     }
   }
 }

--- a/backends/cadence/hifi/operators/op_quantized_matmul_asym8uxasym8u_asym8u_out.cpp
+++ b/backends/cadence/hifi/operators/op_quantized_matmul_asym8uxasym8u_asym8u_out.cpp
@@ -79,7 +79,7 @@ void quantized_matmul_asym8uxasym8u_asym8u_out(
           static_cast<int32_t>(out_shift), // out_shift
           static_cast<int32_t>(out_zero_point)); // out_zero_bias
 
-      ET_CHECK_MSG(ret_val == 0, "An internal error occured");
+      ET_CHECK_MSG(ret_val == 0, "An internal error occurred");
     } else {
       /* Assuming matmul is 2D always */
       WORD32 num_inp_dims = 2;
@@ -103,7 +103,7 @@ void quantized_matmul_asym8uxasym8u_asym8u_out(
           num_out_dims,
           num_inp_dims);
 
-      ET_CHECK_MSG(ret_val == 0, "An internal error occured");
+      ET_CHECK_MSG(ret_val == 0, "An internal error occurred");
 
       ret_val = xa_nn_matmul_asym8uxasym8u_asym8u(
           z, // p_out
@@ -123,7 +123,7 @@ void quantized_matmul_asym8uxasym8u_asym8u_out(
           static_cast<int32_t>(out_shift), // out_shift
           static_cast<int32_t>(out_zero_point)); // out_zero_bias
 
-      ET_CHECK_MSG(ret_val == 0, "An internal error occured");
+      ET_CHECK_MSG(ret_val == 0, "An internal error occurred");
     }
   }
 }

--- a/backends/cadence/hifi/operators/op_quantized_matmul_out.cpp
+++ b/backends/cadence/hifi/operators/op_quantized_matmul_out.cpp
@@ -84,7 +84,7 @@ void inline _typed_quantized_matmul(
             static_cast<int32_t>(out_shift), // out_shift
             static_cast<int32_t>(out_zero_point)); // out_zero_bias
 
-        ET_CHECK_MSG(ret_val == 0, "An internal error occured");
+        ET_CHECK_MSG(ret_val == 0, "An internal error occurred");
       } else {
         WORD32 ret_val = xa_nn_matmul_asym8sxasym8s_asym8s(
             (int8_t*)z, // p_out
@@ -104,7 +104,7 @@ void inline _typed_quantized_matmul(
             static_cast<int32_t>(out_shift), // out_shift
             static_cast<int32_t>(out_zero_point)); // out_zero_bias
 
-        ET_CHECK_MSG(ret_val == 0, "An internal error occured");
+        ET_CHECK_MSG(ret_val == 0, "An internal error occurred");
       }
     } else {
       /* Assuming matmul is 2D always */
@@ -129,7 +129,7 @@ void inline _typed_quantized_matmul(
           num_out_dims,
           num_inp_dims);
 
-      ET_CHECK_MSG(ret_val == 0, "An internal error occured");
+      ET_CHECK_MSG(ret_val == 0, "An internal error occurred");
 
       if (out.scalar_type() == exec_aten::ScalarType::Byte) {
         WORD32 ret_val = xa_nn_matmul_asym8uxasym8u_asym8u(
@@ -150,7 +150,7 @@ void inline _typed_quantized_matmul(
             static_cast<int32_t>(out_shift), // out_shift
             static_cast<int32_t>(out_zero_point)); // out_zero_bias
 
-        ET_CHECK_MSG(ret_val == 0, "An internal error occured");
+        ET_CHECK_MSG(ret_val == 0, "An internal error occurred");
       } else {
         WORD32 ret_val = xa_nn_matmul_asym8sxasym8s_asym8s(
             (int8_t*)z, // p_out
@@ -170,7 +170,7 @@ void inline _typed_quantized_matmul(
             static_cast<int32_t>(out_shift), // out_shift
             static_cast<int32_t>(out_zero_point)); // out_zero_bias
 
-        ET_CHECK_MSG(ret_val == 0, "An internal error occured");
+        ET_CHECK_MSG(ret_val == 0, "An internal error occurred");
       }
     }
   }

--- a/exir/tracer.py
+++ b/exir/tracer.py
@@ -700,7 +700,7 @@ def dynamo_trace(
             ) from exc
         except Exception as exc:
             raise InternalError(
-                "torchdynamo internal error occured. Please see above stacktrace"
+                "torchdynamo internal error occurred. Please see above stacktrace"
             ) from exc
 
 


### PR DESCRIPTION
Nine error messages used the misspelled `occured`:

- `backends/apple/mps/runtime/MPSDevice.mm:141` — additionally had a duplicated `occured occured` (`An error occured occured while compiling library %d`).
- `backends/cadence/hifi/operators/op_quantized_matmul_out.cpp` × 3
- `backends/cadence/hifi/operators/op_quantized_matmul_asym8uxasym8u_asym8u_out.cpp` × 3
- `backends/cadence/hifi/operators/op_quantized_matmul_asym8sxasym8s_asym8s_out.cpp` × 3
- `exir/tracer.py` — torchdynamo internal-error format string

All `ET_CHECK_MSG` and printf-style messages reach end users in build / runtime error output, and the dynamo tracer message is logged on every dynamo trace failure. Python `ast.parse` clean for the touched tracer.py; .cpp/.mm changes are string-literal-only with no logic touched.

cc @mergennachin @nil-is-all