### PR TITLE
Fix ATen/Config.h missing on Android after arvr_mode constraint migration

### DIFF
--- a/runtime/core/portable_type/c10/c10/targets.bzl
+++ b/runtime/core/portable_type/c10/c10/targets.bzl
@@ -78,7 +78,13 @@ def define_common_targets():
             "fbsource//xplat/caffe2/c10:c10_headers",
         ] + select({
             "DEFAULT": ["fbsource//xplat/caffe2:generated_aten_config_header"],
-            "ovr_config//build_mode:arvr_mode[enabled]": ["fbsource//xplat/caffe2:ovrsource_aten_Config.h"],
+            "ovr_config//build_mode:arvr_mode[enabled]": select({
+                "DEFAULT": ["fbsource//xplat/caffe2:ovrsource_aten_Config.h"],
+                # ovrsource_aten_Config.h is an oxx_static_library that only
+                # works on OVR-native platforms. On Android, it produces no
+                # outputs, so use the xplat variant instead.
+                "ovr_config//os:android": ["fbsource//xplat/caffe2:generated_aten_config_header"],
+            }),
         }) + get_sleef_deps(),
         fbcode_exported_deps = ([
             "//caffe2:aten-headers-cpu",


### PR DESCRIPTION
Summary:
Recently D99903392 broke our builds (see multisect on that diff), this is an attempt to fix this.

D99903392 converted arvr_mode from a constraint_setting to a
constraint() rule. This changed how the select() in
aten_headers_for_executorch resolves: Android platforms now match
arvr_mode[enabled], routing to ovrsource_aten_Config.h. But that
target is an oxx_static_library that produces no outputs on Android

Fix: use a nested select to fall back to generated_aten_config_header
on Android, while preserving the OVR variant for non-Android ARVR
platforms. Same pattern as D100438873 but for Android.

Differential Revision: D100832205


