### PR TITLE
Cap num_externs to 4096 (#18909)

### DIFF
--- a/backends/xnnpack/runtime/XNNCompiler.cpp
+++ b/backends/xnnpack/runtime/XNNCompiler.cpp
@@ -1916,9 +1916,17 @@ ET_NODISCARD Error XNNCompiler::compileModel(
       xnn_status_to_string(status));
 
   // create xnnpack subgraph
+  uint32_t num_externs = flatbuffer_graph->num_externs();
+  ET_CHECK_OR_RETURN_ERROR(
+      num_externs <= 4096,
+      InvalidProgram,
+      "XNNPACK flatbuffer blob has num_externs (%u) which exceeds maximum (4096)."
+      " This likely indicates a corrupted or invalid serialized graph",
+      num_externs);
+
   xnn_subgraph_t subgraph_ptr = nullptr;
   status = xnn_create_subgraph(
-      /*external_value_ids=*/flatbuffer_graph->num_externs(),
+      /*external_value_ids=*/num_externs,
       /*flags=*/0,
       &subgraph_ptr);
   ET_CHECK_OR_RETURN_ERROR(


### PR DESCRIPTION
Summary:

num_externs counts the number of external values that xnnpack receives from the runtime, in the form of arguments. It's taken from the flatbuffer file and used to allocate an internal array.

Attack vector: num_externs in flatbuffer is overwritten to a large number, causing large, oob allocations.

The value of externs is per delegate blob - it's super unlikely to have 4096 allocs, probably expect single digits normally.

Note: there's not a particularly good way to verify the value, as num_externs contains input, output and non-parameters (such as symbolic shapes). Input, output are consumed by the delegate, but symbolic shapes are not, but are passed in anyways. So the flatbuffer doesn't have information to calculate the real total.

Reviewed By: GregoryComer

Differential Revision: D100822659


