### PR TITLE
Arm backend: Add Ethos-U65 support to the arm_aot_compiler.py

### DIFF
--- a/backends/arm/ethosu/compile_spec.py
+++ b/backends/arm/ethosu/compile_spec.py
@@ -48,7 +48,7 @@ class EthosUCompileSpec(ArmCompileSpec):
             return resolved_system_config, resolved_memory_mode
         if "ethos-u65" in target_lower:
             resolved_system_config = (
-                "Ethos_U65_SYS_DRAM_Mid" if system_config is None else system_config
+                "Ethos_U65_High_End" if system_config is None else system_config
             )
             resolved_memory_mode = "Sram_Only" if memory_mode is None else memory_mode
             return resolved_system_config, resolved_memory_mode

--- a/backends/arm/scripts/aot_arm_compiler.py
+++ b/backends/arm/scripts/aot_arm_compiler.py
@@ -452,6 +452,8 @@ TARGETS = [
     "ethos-u55-64",
     "ethos-u55-128",
     "ethos-u55-256",
+    "ethos-u65-256",
+    "ethos-u65-512",
     "ethos-u85-128",
     "ethos-u85-256",
     "ethos-u85-512",
@@ -628,13 +630,13 @@ def _get_args():
         "--system_config",
         required=False,
         default=None,
-        help="System configuration to select from the Vela configuration file (see vela.ini). This option must match the selected target, default is for an optimal system 'Ethos_U55_High_End_Embedded'/'Ethos_U85_SYS_DRAM_High'",
+        help="System configuration to select from the Vela configuration file (see vela.ini). This option must match the selected target, default is for an optimal system 'Ethos_U55_High_End_Embedded'/ 'Ethos_U65_High_End' / 'Ethos_U85_SYS_DRAM_Mid'",
     )
     parser.add_argument(
         "--memory_mode",
         required=False,
         default=None,
-        help="Memory mode to select from the Vela configuration file (see vela.ini). Default is 'Shared_Sram' for Ethos-U55 targets and 'Sram_Only' for Ethos-U85 targets",
+        help="Memory mode to select from the Vela configuration file (see vela.ini). Default is 'Shared_Sram' for Ethos-U55 targets and 'Sram_Only' for Ethos-U65 and Ethos-U85 targets",
     )
     parser.add_argument(
         "--config",


### PR DESCRIPTION
Make it possible to generate PTE files for Ethos-U65 hardware.


cc @digantdesai @freddan80 @per @oscarandersson8218 @mansnils @Sebastian-Larsson @robell