### PR TITLE
Add cmsis_nn pip package to executorch installation

### DIFF
--- a/backends/cortex_m/test/misc/test_cmsis_pybind.py
+++ b/backends/cortex_m/test/misc/test_cmsis_pybind.py
@@ -1,0 +1,33 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import importlib
+
+import pytest
+
+
+def _import_cmsis_nn():
+    try:
+        return importlib.import_module("cmsis_nn")
+    except Exception as exc:
+        pytest.fail(f"Failed to resolve cmsis_nn: {exc}")
+
+
+def test_cmsis_nn_convolve_wrapper_buffer_size() -> None:
+    cmsis_nn = _import_cmsis_nn()
+
+    buf_size = cmsis_nn.convolve_wrapper_buffer_size(
+        cmsis_nn.Backend.MVE,
+        cmsis_nn.DataType.A8W8,
+        input_nhwc=[1, 8, 8, 16],
+        filter_nhwc=[8, 3, 3, 16],
+        output_nhwc=[1, 6, 6, 8],
+        padding_hw=[0, 0],
+        stride_hw=[1, 1],
+        dilation_hw=[1, 1],
+    )
+
+    assert buf_size == 576

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ dependencies=[
   "scikit-learn==1.7.1",
   "hydra-core>=1.3.0",
   "omegaconf>=2.3.0",
+  "cmsis_nn @ git+https://github.com/ARM-software/CMSIS-NN.git@ba16fde665262d2ca3cc5074e1b4894461e06a2f",
 ]
 
 [project.optional-dependencies]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,3 +15,6 @@ pytest<9.0
 pytest-xdist
 pytest-rerunfailures==15.1
 pytest-json-report
+
+pybind11>=2.10 # Required to build cmsis_nn pybindings.
+scikit-build-core>=0.7 # Required to build cmsis_nn pybindings.


### PR DESCRIPTION
It is needed for the Cortex-M AoT flow.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell