### PR TITLE
Update docs of moved aot_arm_compiler.py

### DIFF
--- a/.ci/scripts/test_cortex_m_e2e.sh
+++ b/.ci/scripts/test_cortex_m_e2e.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) Meta Platforms, Inc. and affiliates.
+# Copyright 2026 Arm Limited and/or its affiliates.
 # All rights reserved.
 #
 # This source code is licensed under the BSD-style license found in the
@@ -18,7 +19,7 @@ mkdir -p "./cortex_m_e2e/${MODEL}"
 WORK_DIR=$(realpath "./cortex_m_e2e/${MODEL}")
 
 echo "=== Exporting ${MODEL} with cortex-m55+int8 ==="
-python -m examples.arm.aot_arm_compiler \
+python -m backends.arm.scripts.aot_arm_compiler \
     -m "${MODEL}" \
     --target=cortex-m55+int8 \
     --quantize \

--- a/backends/arm/README.md
+++ b/backends/arm/README.md
@@ -155,7 +155,7 @@ scp -P 2222 arm_test/cmake-out/executor_runner root@127.0.0.1:/tmp/
 Create a PTE file:
 
 ```
-python3 -m examples.arm.aot_arm_compiler \
+python3 -m backends.arm.scripts.aot_arm_compiler \
   --model_name examples/arm/example_modules/add.py \
   --delegate \
   --quantize \

--- a/backends/arm/scripts/aot_arm_compiler.py
+++ b/backends/arm/scripts/aot_arm_compiler.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
 # Copyright 2023-2026 Arm Limited and/or its affiliates.

--- a/backends/arm/scripts/docgen/ethos-u/ethos-u-getting-started-tutorial.md.in
+++ b/backends/arm/scripts/docgen/ethos-u/ethos-u-getting-started-tutorial.md.in
@@ -20,7 +20,7 @@ In this tutorial you will learn how to export a simple PyTorch model for the Exe
 ```{tip}
 If you are already familiar with this delegate, you may want to jump directly to the examples:
 * [Examples in the ExecuTorch repository](https://github.com/pytorch/executorch/tree/main/examples/arm)
-* [A commandline compiler for example models](https://github.com/pytorch/executorch/blob/main/examples/arm/aot_arm_compiler.py)
+* [A commandline compiler for example models](https://github.com/pytorch/executorch/blob/main/backends/arm/scripts/aot_arm_compiler.py)
 ```
 
 This tutorial serves as an introduction to using ExecuTorch to deploy PyTorch models on Arm&reg; Ethos&trade;-U targets. It is based on `ethos_u_minimal_example.ipynb`, provided in Arm’s examples folder.
@@ -69,9 +69,9 @@ The example below shows how to quantize a model consisting of a single addition,
 $MINIMAL_EXAMPLE
 
 ```{tip}
-For a quick start, you can use the script `examples/arm/aot_arm_compiler.py` to produce the pte.
+For a quick start, you can use the script `backends/arm/scripts/aot_arm_compiler.py` to produce the pte.
 To produce a pte file equivalent to the one above, run
-`python -m examples.arm.aot_arm_compiler --model_name=add --delegate --quantize --output=ethos_u_minimal_example.pte`
+`python -m backends.arm.scripts.aot_arm_compiler --model_name=add --delegate --quantize --output=ethos_u_minimal_example.pte`
 ```
 
 ### Runtime:

--- a/backends/arm/scripts/docgen/vgf/vgf-getting-started-tutorial.md.in
+++ b/backends/arm/scripts/docgen/vgf/vgf-getting-started-tutorial.md.in
@@ -26,7 +26,7 @@ You may encounter some rough edges and features which may be documented or plann
 ```{tip}
 If you are already familiar with this delegate, you may want to jump directly to the examples:
 * [Examples in the ExecuTorch repository](https://github.com/pytorch/executorch/tree/main/examples/arm)
-* [A commandline compiler for example models](https://github.com/pytorch/executorch/blob/main/examples/arm/aot_arm_compiler.py)
+* [A commandline compiler for example models](https://github.com/pytorch/executorch/blob/main/backends/arm/scripts/aot_arm_compiler.py)
 ```
 
 This tutorial serves as an introduction to using ExecuTorch to deploy PyTorch models on VGF targets. The tutorial is based on `vgf_minimal_example.ipyb`, provided in Arm's example folder.
@@ -78,9 +78,9 @@ The example below shows how to quantize a model consisting of a single addition,
 $MINIMAL_EXAMPLE
 
 ```{tip}
-For a quick start, you can use the script `examples/arm/aot_arm_compiler.py` to produce the pte.
+For a quick start, you can use the script `backends/arm/scripts/aot_arm_compiler.py` to produce the pte.
 To produce a pte file equivalent to the one above, run
-`python -m examples.arm.aot_arm_compiler --model_name=add --delegate --quantize --output=simple_example.pte --target=vgf` 
+`python -m backends.arm.scripts.aot_arm_compiler --model_name=add --delegate --quantize --output=simple_example.pte --target=vgf`
 ```
 
 ### Runtime:

--- a/backends/arm/test/test_model.py
+++ b/backends/arm/test/test_model.py
@@ -148,7 +148,7 @@ def build_pte(
     command_list = [
         "python3",
         "-m",
-        "examples.arm.aot_arm_compiler",
+        "backends.arm.scripts.aot_arm_compiler",
         "--delegate",
         "--bundleio",
         f"--model_name={model_name}",

--- a/docs/source/backends/arm-ethos-u/tutorials/ethos-u-getting-started.md
+++ b/docs/source/backends/arm-ethos-u/tutorials/ethos-u-getting-started.md
@@ -20,7 +20,7 @@ In this tutorial you will learn how to export a simple PyTorch model for the Exe
 ```{tip}
 If you are already familiar with this delegate, you may want to jump directly to the examples:
 * [Examples in the ExecuTorch repository](https://github.com/pytorch/executorch/tree/main/examples/arm)
-* [A commandline compiler for example models](https://github.com/pytorch/executorch/blob/main/examples/arm/aot_arm_compiler.py)
+* [A commandline compiler for example models](https://github.com/pytorch/executorch/blob/main/backends/arm/scripts/aot_arm_compiler.py)
 ```
 
 This tutorial serves as an introduction to using ExecuTorch to deploy PyTorch models on Arm&reg; Ethos&trade;-U targets. It is based on `ethos_u_minimal_example.ipynb`, provided in Arm’s examples folder.
@@ -142,9 +142,9 @@ save_pte_program(executorch_program_manager, "ethos_u_minimal_example.pte")
 
 
 ```{tip}
-For a quick start, you can use the script `examples/arm/aot_arm_compiler.py` to produce the pte.
+For a quick start, you can use the script `backends/arm/scripts/aot_arm_compiler.py` to produce the pte.
 To produce a pte file equivalent to the one above, run
-`python -m examples.arm.aot_arm_compiler --model_name=add --delegate --quantize --output=ethos_u_minimal_example.pte`
+`python -m backends.arm.scripts.aot_arm_compiler --model_name=add --delegate --quantize --output=ethos_u_minimal_example.pte`
 ```
 
 ### Runtime:

--- a/docs/source/backends/arm-vgf/tutorials/vgf-getting-started.md
+++ b/docs/source/backends/arm-vgf/tutorials/vgf-getting-started.md
@@ -26,7 +26,7 @@ You may encounter some rough edges and features which may be documented or plann
 ```{tip}
 If you are already familiar with this delegate, you may want to jump directly to the examples:
 * [Examples in the ExecuTorch repository](https://github.com/pytorch/executorch/tree/main/examples/arm)
-* [A commandline compiler for example models](https://github.com/pytorch/executorch/blob/main/examples/arm/aot_arm_compiler.py)
+* [A commandline compiler for example models](https://github.com/pytorch/executorch/blob/main/backends/arm/scripts/aot_arm_compiler.py)
 ```
 
 This tutorial serves as an introduction to using ExecuTorch to deploy PyTorch models on VGF targets. The tutorial is based on `vgf_minimal_example.ipyb`, provided in Arm's example folder.
@@ -163,9 +163,9 @@ assert os.path.exists(pte_path), "Build failed; no .pte-file found"
 
 
 ```{tip}
-For a quick start, you can use the script `examples/arm/aot_arm_compiler.py` to produce the pte.
+For a quick start, you can use the script `backends/arm/scripts/aot_arm_compiler.py` to produce the pte.
 To produce a pte file equivalent to the one above, run
-`python -m examples.arm.aot_arm_compiler --model_name=add --delegate --quantize --output=simple_example.pte --target=vgf` 
+`python -m backends.arm.scripts.aot_arm_compiler --model_name=add --delegate --quantize --output=simple_example.pte --target=vgf`
 ```
 
 ### Runtime:

--- a/examples/arm/README.md
+++ b/examples/arm/README.md
@@ -5,7 +5,8 @@ model on a Arm backend via ExecuTorch. This backend supports Ethos-U and VGF as
 targets (using TOSA) but you can also use the Ethos-U example runner as an example
 on Cortex-M if you do not delegate the model.
 
-The main scripts are `setup.sh`, `run.sh` and `aot_arm_compiler.py`.
+The main scripts are `setup.sh`, `run.sh` and
+`backends/arm/scripts/aot_arm_compiler.py`.
 
 `setup.sh` will install the needed tools and with --root-dir <FOLDER> 
 you can change the path to a scratch folder where it will download and generate build
@@ -38,13 +39,13 @@ You point out the model to convert with `--model_name=<MODELNAME/FILE>` It suppo
 from a python file if you just specify `ModelUnderTest` and `ModelInputs` in it.
 
 ```
-$ python3 -m examples.arm.aot_arm_compiler --help
+$ python3 -m backends.arm.scripts.aot_arm_compiler --help
 ```
 
 This is how you generate a BundleIO BPTE of a simple add example
 
 ```
-$ python3 -m examples.arm.aot_arm_compiler --model_name=examples/arm/example_modules/add.py --target=ethos-u55-128 --bundleio
+$ python3 -m backends.arm.scripts.aot_arm_compiler --model_name=examples/arm/example_modules/add.py --target=ethos-u55-128 --bundleio
 ```
 
 The example model used has added two extra variables that is picked up to make this work.
@@ -57,11 +58,11 @@ The example model used has added two extra variables that is picked up to make t
 You can also use the models from example/models directly by just using the short name e.g.
 
 ```
-$ python3 -m examples.arm.aot_arm_compiler --model_name=mv2 --target=ethos-u55-64
+$ python3 -m backends.arm.scripts.aot_arm_compiler --model_name=mv2 --target=ethos-u55-64
 ```
 
 
-The `aot_arm_compiler.py` is called from the scripts below so you don't need to, but it can be useful to do by hand in some cases.
+`aot_arm_compiler.py` is called from the scripts below so you don't need to, but it can be useful to do by hand in some cases.
 
 
 ## ExecuTorch on Arm Ethos-U55/U65 and U85

--- a/examples/arm/example_modules/add.py
+++ b/examples/arm/example_modules/add.py
@@ -1,10 +1,10 @@
 # All rights reserved.
-# Copyright 2023-2025 Arm Limited and/or its affiliates.
+# Copyright 2023-2026 Arm Limited and/or its affiliates.
 #
 # Example of an external model for the Arm AOT Compiler
 #
 # Example of an external Python file to be used as a module by the `run.sh`
-# (and the `aot_arm_compiler.py`) scripts in `examples/arm` directory.
+# (and the `backends/arm/scripts/aot_arm_compiler.py`) script.
 #
 # Just pass the path of the `add.py` file as `--model_name`
 #

--- a/examples/arm/run.sh
+++ b/examples/arm/run.sh
@@ -329,7 +329,7 @@ for i in "${!test_model[@]}"; do
         model_compiler_flags="${model_compiler_flags} --model_input=${model_input}"
     fi
 
-    ARM_AOT_CMD="python3 -m examples.arm.aot_arm_compiler --model_name=${model} --target=${target} ${model_compiler_flags} --intermediate=${output_folder} --output=${pte_file} --system_config=${system_config} --memory_mode=${memory_mode} $bundleio_flag ${etrecord_flag} --config=${config} $qdq_fusion_op_flag"
+    ARM_AOT_CMD="python3 -m backends.arm.scripts.aot_arm_compiler --model_name=${model} --target=${target} ${model_compiler_flags} --intermediate=${output_folder} --output=${pte_file} --system_config=${system_config} --memory_mode=${memory_mode} $bundleio_flag ${etrecord_flag} --config=${config} $qdq_fusion_op_flag"
     echo "CALL ${ARM_AOT_CMD}" >&2
     ${ARM_AOT_CMD} 1>&2
 

--- a/zephyr/samples/hello-executorch/README.md
+++ b/zephyr/samples/hello-executorch/README.md
@@ -31,7 +31,7 @@ export ARMFVP_EXTRA_FLAGS="-C mps3_board.uart0.shutdown_on_eot=1 -C ethosu.num_m
 Prepare the Ethos-U55 PTE model
 <!-- RUN test_ethos-u55_generate_pte -->
 ```
-python -m modules.lib.executorch.examples.arm.aot_arm_compiler --model_name=modules/lib/executorch/zephyr/samples/hello-executorch/models/add.py --quantize --delegate --target=ethos-u55-128 --output=add_u55_128.pte
+python -m modules.lib.executorch.backends.arm.scripts.aot_arm_compiler --model_name=modules/lib/executorch/zephyr/samples/hello-executorch/models/add.py --quantize --delegate --target=ethos-u55-128 --output=add_u55_128.pte
 ```
 
 `--delegate` tells the `aot_arm_compiler` to use Ethos-U backend and `-t ethos-u55-128` specifies the used Ethos-U variant and numbers of macs used, this must match your hardware or FVP config.
@@ -51,7 +51,7 @@ west build -b mps3/corstone300/fvp modules/lib/executorch/zephyr/samples/hello-e
 Prepare the Cortex-M55 PTE model
 <!-- RUN test_cortex-m55_generate_pte -->
 ```
-python -m modules.lib.executorch.examples.arm.aot_arm_compiler --model_name=modules/lib/executorch/zephyr/samples/hello-executorch/models/add.py --quantize --target=cortex-m55+int8 --output=add_m55.pte
+python -m modules.lib.executorch.backends.arm.scripts.aot_arm_compiler --model_name=modules/lib/executorch/zephyr/samples/hello-executorch/models/add.py --quantize --target=cortex-m55+int8 --output=add_m55.pte
 ```
 
 `--target=cortex-m55+int8` selects the Cortex-M/CMSIS-NN portable kernel path (no NPU delegation). This produces a `.pte` optimized for Cortex-M55 with INT8 quantization.
@@ -87,7 +87,7 @@ export ARMFVP_EXTRA_FLAGS="-C mps4_board.uart0.shutdown_on_eot=1 -C mps4_board.s
 Prepare the Ethos-U85 PTE model
 <!-- RUN test_ethos-u85_generate_pte -->
 ```
-python -m modules.lib.executorch.examples.arm.aot_arm_compiler --model_name=modules/lib/executorch/zephyr/samples/hello-executorch/models/add.py --quantize --delegate --target=ethos-u85-256 --output=add_u85_256.pte
+python -m modules.lib.executorch.backends.arm.scripts.aot_arm_compiler --model_name=modules/lib/executorch/zephyr/samples/hello-executorch/models/add.py --quantize --delegate --target=ethos-u85-256 --output=add_u85_256.pte
 ```
 
 `--delegate` tells the `aot_arm_compiler` to use Ethos-U backend and `-t ethos-u85-256` specifies the used Ethos-U variant and numbers of macs used, this must match your hardware or FVP config.
@@ -129,7 +129,7 @@ export PATH=$PATH:~/STMicroelectronics/STM32Cube/STM32CubeProgrammer/bin
 
 Prepare the Cortex-M55 PTE model
 ```
-python -m modules.lib.executorch.examples.arm.aot_arm_compiler --model_name=modules/lib/executorch/zephyr/samples/hello-executorch/models/add.py --quantize --target=cortex-m55+int8 --output=add_m55.pte
+python -m modules.lib.executorch.backends.arm.scripts.aot_arm_compiler --model_name=modules/lib/executorch/zephyr/samples/hello-executorch/models/add.py --quantize --target=cortex-m55+int8 --output=add_m55.pte
 ```
 
 `--target=cortex-m55+int8` selects the Cortex-M/CMSIS-NN portable kernel path (no NPU delegation). This produces a `.pte` optimized for Cortex-M55 with INT8 quantization.

--- a/zephyr/samples/hello-executorch/models/add.py
+++ b/zephyr/samples/hello-executorch/models/add.py
@@ -6,7 +6,7 @@
 # Example of an external model for the Arm AOT Compiler
 #
 # Example of an external Python file to be used as a module by the `run.sh`
-# (and the `aot_arm_compiler.py`) scripts in `examples/arm` directory.
+# (and the `backends/arm/scripts/aot_arm_compiler.py`) script.
 #
 # Just pass the path of the `add.py` file as `--model_name`
 #


### PR DESCRIPTION
aot_arm_compiler.py has been moved from examples/arm to backends/arm/scripts. Update documentation and scripts invoking this script to use the new path.


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell