### PR TITLE
Destroy unwrapped_vals instead of wrapped_vals

### DIFF
--- a/runtime/core/evalue.h
+++ b/runtime/core/evalue.h
@@ -71,6 +71,20 @@ class BoxedEvalueList {
    */
   executorch::aten::ArrayRef<T> get() const;
 
+  /**
+   * Destroys the unwrapped elements without re-dereferencing wrapped_vals_.
+   * This is safe to call during EValue destruction because it does not
+   * dereference wrapped_vals_, which may point to EValues mutated by
+   * MoveCall instructions.
+   */
+  void destroy_elements() {
+    for (typename executorch::aten::ArrayRef<T>::size_type i = 0;
+         i < wrapped_vals_.size();
+         i++) {
+      unwrapped_vals_[i].~T();
+    }
+  }
+
  private:
   static EValue** checkWrappedVals(EValue** wrapped_vals, int size) {
     ET_CHECK_MSG(wrapped_vals != nullptr, "wrapped_vals cannot be null");
@@ -491,18 +505,11 @@ struct EValue {
     } else if (
         isTensorList() &&
         payload.copyable_union.as_tensor_list_ptr != nullptr) {
-      // for (auto& tensor : toTensorList()) {
-      for (auto& tensor : payload.copyable_union.as_tensor_list_ptr->get()) {
-        tensor.~Tensor();
-      }
+      payload.copyable_union.as_tensor_list_ptr->destroy_elements();
     } else if (
         isListOptionalTensor() &&
         payload.copyable_union.as_list_optional_tensor_ptr != nullptr) {
-      // for (auto& optional_tensor : toListOptionalTensor()) {
-      for (auto& optional_tensor :
-           payload.copyable_union.as_list_optional_tensor_ptr->get()) {
-        optional_tensor.~optional();
-      }
+      payload.copyable_union.as_list_optional_tensor_ptr->destroy_elements();
     }
   }
 


### PR DESCRIPTION
Destroy unwrapped_vals instead of dereferencing wrapped_vals.

When a kernel uses TensorLists, it calls EValue::toTensorList(). This dereferences wrapped_vals into unwrapped_vals to get the tensor list.

During execution, a (crafted) MoveCall potentially moves an Int into the TensorList. This means wrapped_vals now points to an Int, whereas unwrapped_vals still holds a Tensor.

Instead of calling destructor on the wrapped_vals (ref to tensor), call the destructor on the unwrapped_vals which contain the real tensor.

Vulnerability: During method destruction, the BoxedEvalueList dereferences its stored pointer and attempts to convert the swapped value to a Tensor, causing a type confusion that terminates the process. This results in a denial of service.

Addresses TOB-EXECUTORCH-31.

This PR was authored with the assistance of Claude.