### PR TITLE
Harden attention sink export: start_pos, mask mode, and buffer initialization (#18976)

### DIFF
--- a/examples/models/llama/export_llama_lib.py
+++ b/examples/models/llama/export_llama_lib.py
@@ -768,7 +768,8 @@ def _prepare_for_llama_export(llm_config: LlmConfig) -> LLMEdgeManager:
             expand_rope_table=llm_config.model.expand_rope_table,
             use_custom_sdpa_with_attention_mask=getattr(
                 llm_config.model, "use_custom_sdpa_with_attention_mask", False
-            ),
+            )
+            or bool(llm_config.model.use_attention_sink),
             use_sdpa_with_kv_cache=llm_config.model.use_sdpa_with_kv_cache,
             quantize_kv_cache=llm_config.model.quantize_kv_cache,
             use_kv_cache=llm_config.model.use_kv_cache,
@@ -1324,6 +1325,13 @@ def _export_llama_multimethod(llm_config: LlmConfig) -> LLMEdgeManager:
     if llm_config.base.model_class.value in TORCHTUNE_DEFINED_MODELS:
         additional_passes = [InitializedMutableBufferPass(["kv_cache_pos"])]
 
+    # For attention sink models, cache_positions must be initialized to -1
+    # (sentinel for "empty slot"). Without this pass, ExecuTorch only serializes
+    # shape+dtype for mutable buffers, leaving them zero-initialized at runtime,
+    # which corrupts the causal mask computation.
+    if llm_config.model.use_attention_sink:
+        additional_passes.append(InitializedMutableBufferPass(["cache_positions"]))
+
     # Build dict of exported programs
     method_to_program: Dict[str, ExportedProgram] = {}
     first_builder = None
@@ -1396,6 +1404,13 @@ def _export_llama(llm_config: LlmConfig) -> LLMEdgeManager:  # noqa: C901
     additional_passes = []
     if llm_config.base.model_class.value in TORCHTUNE_DEFINED_MODELS:
         additional_passes = [InitializedMutableBufferPass(["kv_cache_pos"])]
+
+    # For attention sink models, cache_positions must be initialized to -1
+    # (sentinel for "empty slot"). Without this pass, ExecuTorch only serializes
+    # shape+dtype for mutable buffers, leaving them zero-initialized at runtime,
+    # which corrupts the causal mask computation.
+    if llm_config.model.use_attention_sink:
+        additional_passes.append(InitializedMutableBufferPass(["cache_positions"]))
 
     # export_to_edge
     builder_manager = _prepare_for_llama_export(llm_config)

--- a/examples/models/llama/source_transformation/custom_kv_cache.py
+++ b/examples/models/llama/source_transformation/custom_kv_cache.py
@@ -521,7 +521,6 @@ class CustomKVCacheWithAttentionSink(CustomKVCache):
         total_cache_size = sink_size + window_size * 2
         super().__init__(max_batch_size, total_cache_size, n_heads, head_dim, dtype)
         from executorch.examples.models.llama.source_transformation.attention_sink import (
-            _create_causal_mask_for_attention_sink,
             CachePositionsManagerWithSink,
         )
 
@@ -531,14 +530,15 @@ class CustomKVCacheWithAttentionSink(CustomKVCache):
         self.is_ring_buffer = True
         self.window_size = window_size
         self.sink_size = sink_size
-        self._create_causal_mask_for_attention_sink = (
-            _create_causal_mask_for_attention_sink
-        )
 
     def create_causal_mask_for_ring_buffer(self, start_pos, seq_len):
         cache_positions = self.cache_positions_manager.cache_positions
         if self.sink_size > 0:
-            return self._create_causal_mask_for_attention_sink(
+            from executorch.examples.models.llama.source_transformation.attention_sink import (
+                _create_causal_mask_for_attention_sink,
+            )
+
+            return _create_causal_mask_for_attention_sink(
                 cache_positions, self.window_size, self.sink_size, start_pos, seq_len
             )
         else:

--- a/examples/models/llama/source_transformation/sdpa.py
+++ b/examples/models/llama/source_transformation/sdpa.py
@@ -54,7 +54,7 @@ class SDPACustom(torch.nn.Module):
                 q,
                 k,
                 v,
-                input_pos[0].item(),
+                0,  # start_pos: unused when mask is provided (is_causal=False)
                 mask,  # Attention mask
                 0,  # dropout probability. Ignored by the code
                 False,  # is_causal
@@ -168,7 +168,7 @@ class QuantizedSDPA(torch.nn.Module):
                 q_quantized,
                 k_quantized,
                 v_quantized,
-                start_pos,
+                0,  # start_pos: unused when mask is provided (is_causal=False)
                 mask,
                 0,
                 False,


### PR DESCRIPTION
Summary:

Improve robustness of the attention sink export pipeline:
- SDPACustom/QuantizedSDPA: pass start_pos=0 when attention mask is provided
  (is_causal=False). The C++ custom_sdpa ignores start_pos in this mode, so
  hardcoding 0 avoids a validation edge case with ring buffer positions.
- Export: auto-enable use_custom_sdpa_with_attention_mask when use_attention_sink
  is set, ensuring attention sink models always use explicit mask mode.
- Export: add InitializedMutableBufferPass for cache_positions buffer so it is
  serialized with its sentinel values rather than left to default initialization.
- CustomKVCacheWithAttentionSink: add ring buffer capacity assertion consistent
  with the non-custom variant, and use lazy import for mask helper.

Reviewed By: lucylq

Differential Revision: D100724151
