### PR TITLE
Skip np.transpose for identity dim_order in process_node

### DIFF
--- a/backends/arm/process_node.py
+++ b/backends/arm/process_node.py
@@ -42,6 +42,8 @@ def _tensor_to_numpy_with_dim_order(
         np_tensor = tensor.view(torch.uint16).numpy().view(ml_dtypes.bfloat16)
     else:
         np_tensor = tensor.numpy()
+    if dim_order == tuple(range(len(dim_order))):
+        return np_tensor
     return np.transpose(np_tensor, dim_order)
 
 


### PR DESCRIPTION
Summary:
When dim_order is the identity permutation (0, 1, ..., N-1),
np.transpose is a no-op that may create an unnecessary array copy.
Add an early return to avoid this.

Differential Revision: D101430550


