### PR TITLE
feat(MLX): Add handler for aten.isnan using NotEqualNode

### DIFF
--- a/backends/mlx/ops.py
+++ b/backends/mlx/ops.py
@@ -414,6 +414,28 @@ def _make_unary_handler(node_cls: Any, op_name: str):
     return handler
 
 
+@REGISTRY.register(target=[torch.ops.aten.isnan.default])
+def _isnan_handler(P: MLXProgramBuilder, n: Node) -> Slot:
+    """Handle aten.isnan - check for NaN values element-wise.
+
+    isnan(x) is equivalent to x != x (NaN is the only value not equal to itself).
+    """
+    args = P.args(n)
+    require_args(args, 1, 1, "aten.isnan")
+    require_kwargs(P.kwargs(n), set(), "aten.isnan")
+    x = args[0]
+
+    out = P.make_or_get_slot(n)
+    P.emit(
+        NotEqualNode(
+            a=P.slot_to_tid(x),
+            b=P.slot_to_tid(x),
+            out=P.slot_to_tid(out),
+        )
+    )
+    return out
+
+
 for _target, _node_cls, _op_name in _UNARY_OPS:
     REGISTRY.register(target=[_target])(_make_unary_handler(_node_cls, _op_name))
 

--- a/backends/mlx/test/test_ops.py
+++ b/backends/mlx/test/test_ops.py
@@ -4063,6 +4063,19 @@ def _make_unary_op_test(
     return _Test
 
 
+def _nan_input_fn():
+    """Return a callable(shape, dtype) that generates inputs with some NaN values."""
+
+    def fn(shape, dtype):
+        x = torch.randn(shape, dtype=dtype)
+        # Insert some NaN values
+        mask = torch.rand(shape) > 0.7
+        x[mask] = float("nan")
+        return (x,)
+
+    return fn
+
+
 # fmt: off
 # Each entry is a dict with required keys "op_name" and "op_fn".
 # Optional keys: "shapes" (default _SHAPES_2), "dtypes" (default _UNARY_DTYPES),
@@ -4095,6 +4108,7 @@ _UNARY_OP_TESTS = [
     {"op_name": "abs",        "op_fn": torch.abs},
     {"op_name": "neg",        "op_fn": torch.neg},
     {"op_name": "logical_not","op_fn": torch.logical_not, "shapes": [(2, 3, 4), (10,), (4, 8)], "dtypes": [torch.bool], "input_fn": _bool_input_fn()},
+    {"op_name": "isnan",     "op_fn": torch.isnan,     "shapes": _SHAPES_3, "dtypes": [torch.float32], "input_fn": _nan_input_fn()},
     # activations
     {"op_name": "relu",    "op_fn": torch.relu,    "shapes": [(2, 3, 4), (10,), (4, 8), (2, 8, 16), (1, 128, 64)], "dtypes": [torch.float32], "input_fn": _input_fn(scale=2, offset=-1)},
     {"op_name": "sigmoid", "op_fn": torch.sigmoid, "shapes": [(2, 3, 4), (10,), (4, 8), (2, 8, 16), (1, 1, 128)],  "dtypes": [torch.float32], "input_fn": _input_fn(scale=2)},


### PR DESCRIPTION
Good day

## Summary

This PR adds a handler for the `aten.isnan` operator in the MLX delegate backend.

## Motivation

The MLX delegate converts PyTorch aten ops into MLX graph nodes. Without a handler for `aten.isnan`, the operator falls back to CPU execution, breaking GPU acceleration pipelines.

## Implementation

Uses the mathematical property that `NaN != NaN` — only NaN is not equal to itself:

```
isnan(x) = x != x
```

The handler leverages the existing `NotEqualNode` which is already supported in the MLX backend. No new schema or runtime code is needed.

## Changes

- **backends/mlx/ops.py**: Add `@REGISTRY.register` handler for `torch.ops.aten.isnan.default`
- **backends/mlx/test/test_ops.py**: Add test using `_nan_input_fn` that generates tensors with ~30% NaN values

## Testing

```bash
python -m executorch.backends.mlx.test.run_all_tests -k isnan
```

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
RoomWithOutRoof

cc @metascroy