### PR TITLE
fix: prevent dangling pointer in merged embedding buffer(#18410)

### DIFF
--- a/examples/qualcomm/oss_scripts/llama/runner/multimodal_runner/multimodal_embedding_merger.cpp
+++ b/examples/qualcomm/oss_scripts/llama/runner/multimodal_runner/multimodal_embedding_merger.cpp
@@ -92,7 +92,8 @@ TensorStruct<float> MultimodalEmbeddingMerger::merge(
       "No text embeddings added. Call add_text_embeddings() first.");
 
   // Final merged embeddings
-  std::vector<float> merged_buffer;
+  std::shared_ptr<std::vector<float>> merged_buffer =
+      std::make_shared<std::vector<float>>();
   std::vector<executorch::aten::TensorImpl::SizesType> sizes;
   TensorStruct<float> merged_embeddings;
 
@@ -121,7 +122,7 @@ TensorStruct<float> MultimodalEmbeddingMerger::merge(
   total_tokens_ = total_tokens_ - num_placeholder_tokens;
 
   size_t total_elements = total_tokens_ * embedding_dim_;
-  merged_buffer.resize(total_elements);
+  merged_buffer->resize(total_elements);
 
   // Merge embeddings based on input_ids
   size_t text_emb_idx = 0; // Which text embedding chunk in current turn
@@ -144,7 +145,7 @@ TensorStruct<float> MultimodalEmbeddingMerger::merge(
 
       size_t num_elements = num_image_tokens * embedding_dim_;
       std::memcpy(
-          merged_buffer.data() + output_offset,
+          merged_buffer->data() + output_offset,
           image_buffer.data(),
           num_elements * sizeof(float));
 
@@ -160,7 +161,7 @@ TensorStruct<float> MultimodalEmbeddingMerger::merge(
       const std::vector<float>& text_buffer =
           text_embedding_buffers_[text_emb_idx];
       std::memcpy(
-          merged_buffer.data() + output_offset,
+          merged_buffer->data() + output_offset,
           text_buffer.data() + text_token_idx * embedding_dim_,
           embedding_dim_ * sizeof(float));
 
@@ -176,7 +177,8 @@ TensorStruct<float> MultimodalEmbeddingMerger::merge(
       image_embedding_buffers_.size());
 
   // Setup tensor metadata
-  merged_embeddings.data = merged_buffer.data();
+  merged_embeddings.buffer = merged_buffer;
+  merged_embeddings.data = merged_buffer->data();
   merged_embeddings.size = total_elements * sizeof(float);
 
   // Setup sizes and dim_order: [1, total_tokens, embedding_dim]

--- a/examples/qualcomm/oss_scripts/llama/runner/utils.h
+++ b/examples/qualcomm/oss_scripts/llama/runner/utils.h
@@ -15,6 +15,7 @@
 template <typename T>
 struct TensorStruct {
   std::unique_ptr<executorch::aten::TensorImpl> tensor;
+  std::shared_ptr<std::vector<T>> buffer;
   T* data;
   // data size in bytes
   size_t size;


### PR DESCRIPTION
### Summary
Fix dangling pointer in TensorStruct merged embedding buffer.
The merged embedding data was stored in a local std::vector<float> variable inside the function. When the function returned, the local vector was destroyed, leaving merged_embeddings.data as a dangling pointer to freed memory, causing invalid data when accessed in downstream inference stages.
Added a shared_ptr<vector<T>> buffer field to TensorStruct to take ownership of the underlying data, extending the buffer lifetime to match the struct lifetime.

### Test plan
Manually validated by running multimodal inference with the patched TensorStruct:

Confirmed merged_embeddings.data points to valid memory after function return
Verified inference output is correct and consistent across multiple runs
Previously observed invalid/garbage output in embedding data no longer reproduces


cc @mergennachin @iseeyuan @lucylq @helunwencser @tarun292 @kimishpatel @jackzhxng @cccclai @cbilgin @abhinaykukkadapu