### PR TITLE
[QNN] Fix compiler_specs double-list wrapping bug causing AttributeError

### DIFF
--- a/backends/qualcomm/_passes/lift_constant_scalar_operands.py
+++ b/backends/qualcomm/_passes/lift_constant_scalar_operands.py
@@ -48,6 +48,7 @@ SCALAR_OPS = {
     aten.sub.Scalar: TensorOpInfo(aten.sub.Tensor, False, False),
     aten.sub.Tensor: TensorOpInfo(aten.sub.Tensor, False, False),
     aten.pow.Tensor_Scalar: TensorOpInfo(aten.pow.Tensor_Tensor, False, False),
+    aten.pow.Scalar: TensorOpInfo(aten.pow.Tensor_Tensor, False, False),
     # The scalar number arg[1] is missing when using default. Result in a corner case to deal
     aten.leaky_relu.default: TensorOpInfo(aten.prelu.default, True, False),
     aten.leaky_relu_.default: TensorOpInfo(aten.prelu.default, True, False),
@@ -86,11 +87,13 @@ class LiftConstantScalarOperands(ExportPass):
     ) -> TensorConstant:
         # For dtype, in some cases, we cannot use node.args[0] as scalar dtype.
         # Ex: Where op args[0] can be bool, however, we probably want args[1] and args[2] to be dtype same as node.meta["val"] instead of bool type
+        first_arg = node.args[0]
         tensor = torch.tensor(
             const_val,
             dtype=(
-                node.args[0].meta["val"].dtype
-                if not is_float_tensor(node)
+                first_arg.meta["val"].dtype
+                if isinstance(first_arg, fx.Node)
+                and not is_float_tensor(node)
                 and (info := SCALAR_OPS.get(node.target))
                 and not info.use_self_dtype
                 else node.meta["val"].dtype

--- a/backends/qualcomm/utils/utils.py
+++ b/backends/qualcomm/utils/utils.py
@@ -550,6 +550,12 @@ def _partition_graph_into_submodules(gm, subgm_tag, subgm_cb, ptn):
 def _canonicalize_graph_with_lowered_module(gm, subgm_tag, compiler_specs):
     # return lowered program for user to debug
     edge_prog_mgrs = []
+
+    def _unwrap_compiler_spec(spec_or_list):
+        if isinstance(spec_or_list, list) and len(spec_or_list) == 1:
+            return spec_or_list[0]
+        return spec_or_list
+
     # partition each submodule which went through convert_pt2e
     for node in gm.graph.nodes:
         if node.op == "call_module" and subgm_tag in node.name:
@@ -558,10 +564,12 @@ def _canonicalize_graph_with_lowered_module(gm, subgm_tag, compiler_specs):
                 torch.ones(arg.meta["val"].shape, dtype=arg.meta["val"].dtype)
                 for arg in node.args
             ]
+            # Unwrap single-element list before passing to inner function
+            unwrapped_spec = _unwrap_compiler_spec(compiler_specs)
             # start lowering with given partitioner
             edge_prog_mgrs.append(
                 to_edge_transform_and_lower_to_qnn(
-                    gm.get_submodule(node.name), tuple(subgm_input), compiler_specs
+                    gm.get_submodule(node.name), tuple(subgm_input), unwrapped_spec
                 )
             )
             # replace submodule with lowered module


### PR DESCRIPTION
# [QNN] Fix compiler_specs double-list wrapping bug causing AttributeError

## Summary

### Fix #18996 

Fixes an `AttributeError: 'list' object has no attribute 'key'` bug that occurs in the QNN backend when `build_executorch_binary` is called with `fp_node_id_set` or `fp_node_op_set` non-empty. The root cause is that `compiler_specs` becomes double-list-wrapped through the `skip_annotation` → `_canonicalize_graph_with_lowered_module` → `to_edge_transform_and_lower_to_qnn` call chain, causing `QnnPartitioner` to receive a list instead of a `CompileSpec` object.

## Problem

When using mixed-precision features (`fp_node_id_set` / `fp_node_op_set`), the flow is:

1. `build_executorch_binary` passes `compiler_specs=[compile_spec]` (single-element list) to `skip_annotation`
2. `skip_annotation` wraps it to `{"forward": [compile_spec]}` via `ensure_graph_specific_dict`
3. `_canonicalize_graph_with_lowered_module` passes `{"forward": [compile_spec]}` to `to_edge_transform_and_lower_to_qnn`
4. Inside `to_edge_transform_and_lower_to_qnn`, `ensure_graph_specific_dict` wraps it again to `{"forward": compile_spec}` — but the inner `[compile_spec]` list is **not** unwrapped
5. `QnnPartitioner` receives `compiler_specs["forward"] = [compile_spec]` (still wrapped in a list)
6. In `generate_qnn_executorch_option`, iterating over `compiler_specs["forward"]` yields the string `"forward"` instead of a `CompileSpec`, causing `compiler_spec.key` to raise `AttributeError`

## Solution

Add a `_unwrap_compiler_spec` helper in `_canonicalize_graph_with_lowered_module` that unwraps single-element lists before passing `compiler_specs` to `to_edge_transform_and_lower_to_qnn`, matching the existing pattern in `build_executorch_binary`.

#### Full Traceback (before fix)

```
File "executorch/backends/qualcomm/export_utils.py", line 569, in build_executorch_binary
    _gm, edge_prog_mgrs = skip_annotation(
File "executorch/backends/qualcomm/utils/utils.py", line 735, in skip_annotation
    graph_module, edge_prog_mgrs = _canonicalize_graph_with_lowered_module(
File "executorch/backends/qualcomm/utils/utils.py", line 563, in _canonicalize_graph_with_lowered_module
    to_edge_transform_and_lower_to_qnn(
File "executorch/backends/qualcomm/utils/utils.py", line 417, in <dictcomp>
    QnnPartitioner(
File "executorch/backends/qualcomm/partition/qnn_partitioner.py", line 151, in __init__
    generate_qnn_executorch_option(self.compiler_specs_snapshot)
File "executorch/backends/qualcomm/partition/utils.py", line 22, in generate_qnn_executorch_option
    if compiler_spec.key == QCOM_QNN_COMPILE_SPEC:
AttributeError: 'list' object has no attribute 'key'
```

#### After fix:
```
  build_executorch_binary(compiler_specs=[compile_spec], fp_node_id_set=...)
    → skip_annotation(compiler_specs=[compile_spec])
      → _canonicalize_graph_with_lowered_module(compiler_specs=[compile_spec])
        → _unwrap_compiler_spec([compile_spec]) → compile_spec ✅
        → to_edge_transform_and_lower_to_qnn(..., compile_spec)
          → ensure_graph_specific_dict(compile_spec, graph_names) → {"forward": compile_spec} ✅
          → compiler_specs["forward"] = compile_spec (bare, not list) ✅
          → QnnPartitioner(compile_spec) → ✅
```


## Test Plan

1. Run mixed-precision export with `fp_node_id_set` containing node names (e.g., `"outer.default"`, `"add.Tensor"`, `"mul.Tensor"`)
2. Verify the export completes without `AttributeError` in `generate_qnn_executorch_option`
3. Verify the exported `.pte` file runs correctly on the QNN backend



cc @cccclai @cbilgin @abhinaykukkadapu