### PR TITLE
Enable debug logging in llm-debug preset

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -185,7 +185,9 @@
       ],
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
-        "CMAKE_INSTALL_PREFIX": "${sourceDir}/cmake-out"
+        "CMAKE_INSTALL_PREFIX": "${sourceDir}/cmake-out",
+        "EXECUTORCH_ENABLE_LOGGING": "ON",
+        "EXECUTORCH_LOG_LEVEL": "Debug"
       }
     },
     {


### PR DESCRIPTION
Add EXECUTORCH_ENABLE_LOGGING and EXECUTORCH_LOG_LEVEL=Debug to the llm-debug CMake preset so debug builds produce runtime log output.
