### PR TITLE
Android: LlmModule Closeable lifecycle and ModelRunner crash fix                                             

### DIFF
--- a/extension/android/executorch_android/src/androidTest/java/org/pytorch/executorch/LlmModuleInstrumentationTest.kt
+++ b/extension/android/executorch_android/src/androidTest/java/org/pytorch/executorch/LlmModuleInstrumentationTest.kt
@@ -282,12 +282,6 @@ class LlmModuleInstrumentationTest : LlmCallback {
   }
 
   @Test
-  fun testStopAfterCloseIsNoOp() {
-    llmModule.close()
-    llmModule.stop()
-  }
-
-  @Test
   fun testCloseIsIdempotent() {
     llmModule.close()
     llmModule.close()

--- a/extension/android/executorch_android/src/androidTest/java/org/pytorch/executorch/LlmModuleInstrumentationTest.kt
+++ b/extension/android/executorch_android/src/androidTest/java/org/pytorch/executorch/LlmModuleInstrumentationTest.kt
@@ -271,6 +271,28 @@ class LlmModuleInstrumentationTest : LlmCallback {
     }
   }
 
+  // --- Lifecycle tests ---
+
+  @Test
+  fun testUseAfterCloseThrows() {
+    llmModule.close()
+    assertThrows(IllegalStateException::class.java) {
+      llmModule.generate(TEST_PROMPT, SEQ_LEN, this@LlmModuleInstrumentationTest)
+    }
+  }
+
+  @Test
+  fun testStopAfterCloseIsNoOp() {
+    llmModule.close()
+    llmModule.stop()
+  }
+
+  @Test
+  fun testCloseIsIdempotent() {
+    llmModule.close()
+    llmModule.close()
+  }
+
   companion object {
     private const val TEST_FILE_NAME = "/stories.pte"
     private const val TOKENIZER_FILE_NAME = "/tokenizer.bin"

--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmModule.java
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmModule.java
@@ -13,7 +13,6 @@ import com.facebook.jni.annotations.DoNotStrip;
 import java.io.Closeable;
 import java.nio.ByteBuffer;
 import java.util.List;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.pytorch.executorch.ExecuTorchRuntime;
 import org.pytorch.executorch.ExecutorchRuntimeException;
 import org.pytorch.executorch.annotations.Experimental;
@@ -32,8 +31,7 @@ public class LlmModule implements Closeable {
   public static final int MODEL_TYPE_MULTIMODAL = 2;
 
   private final HybridData mHybridData;
-  private final ReentrantReadWriteLock mLock = new ReentrantReadWriteLock(true);
-  private volatile boolean mClosed = false;
+  private boolean mDestroyed = false;
   private static final int DEFAULT_SEQ_LEN = 128;
   private static final boolean DEFAULT_ECHO = true;
   private static final float DEFAULT_TEMPERATURE = -1.0f;
@@ -190,24 +188,24 @@ public class LlmModule implements Closeable {
         config.getLoadMode());
   }
 
-  private void checkNotClosed() {
-    if (mClosed) throw new IllegalStateException("LlmModule has been closed");
+  private void checkNotDestroyed() {
+    if (mDestroyed) throw new IllegalStateException("LlmModule has been destroyed");
   }
 
+  /**
+   * Releases native resources. Callers must ensure no other methods are in-flight. Call {@link
+   * #stop()} and wait for {@link #generate} to return before calling this method.
+   */
   @Override
   public void close() {
-    stopNative();
-    mLock.writeLock().lock();
-    try {
-      if (mClosed) return;
-      mClosed = true;
-      mHybridData.resetNative();
-    } finally {
-      mLock.writeLock().unlock();
-    }
+    if (mDestroyed) return;
+    mDestroyed = true;
+    mHybridData.resetNative();
   }
 
-  /** @deprecated Use {@link #close()} instead. */
+  /**
+   * @deprecated Use {@link #close()} instead.
+   */
   @Deprecated
   public void resetNative() {
     close();
@@ -305,15 +303,10 @@ public class LlmModule implements Closeable {
       float temperature,
       int numBos,
       int numEos) {
-    mLock.readLock().lock();
-    try {
-      checkNotClosed();
-      int err = generateNative(prompt, seqLen, llmCallback, echo, temperature, numBos, numEos);
-      if (err != 0) {
-        throw ExecutorchRuntimeException.makeExecutorchException(err, "Failed to generate");
-      }
-    } finally {
-      mLock.readLock().unlock();
+    checkNotDestroyed();
+    int err = generateNative(prompt, seqLen, llmCallback, echo, temperature, numBos, numEos);
+    if (err != 0) {
+      throw ExecutorchRuntimeException.makeExecutorchException(err, "Failed to generate");
     }
   }
 
@@ -442,22 +435,11 @@ public class LlmModule implements Closeable {
       float temperature,
       int numBos,
       int numEos) {
-    mLock.readLock().lock();
-    try {
-      checkNotClosed();
-      if (image != null) {
-        int nativeResult = prefillImagesInput(image, width, height, channels);
-        if (nativeResult != 0) {
-          throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed");
-        }
-      }
-      int err = generateNative(prompt, seqLen, llmCallback, echo, temperature, numBos, numEos);
-      if (err != 0) {
-        throw ExecutorchRuntimeException.makeExecutorchException(err, "Failed to generate");
-      }
-    } finally {
-      mLock.readLock().unlock();
+    checkNotDestroyed();
+    if (image != null) {
+      prefillImages(image, width, height, channels);
     }
+    generate(prompt, seqLen, llmCallback, echo, temperature, numBos, numEos);
   }
 
   /**
@@ -471,15 +453,10 @@ public class LlmModule implements Closeable {
    */
   @Experimental
   public void prefillImages(int[] image, int width, int height, int channels) {
-    mLock.readLock().lock();
-    try {
-      checkNotClosed();
-      int nativeResult = prefillImagesInput(image, width, height, channels);
-      if (nativeResult != 0) {
-        throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed");
-      }
-    } finally {
-      mLock.readLock().unlock();
+    checkNotDestroyed();
+    int nativeResult = prefillImagesInput(image, width, height, channels);
+    if (nativeResult != 0) {
+      throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed");
     }
   }
 
@@ -500,9 +477,7 @@ public class LlmModule implements Closeable {
    */
   @Experimental
   public void prefillImages(ByteBuffer image, int width, int height, int channels) {
-    mLock.readLock().lock();
-    try {
-      checkNotClosed();
+    checkNotDestroyed();
     if (!image.isDirect()) {
       throw new IllegalArgumentException("Input ByteBuffer must be direct.");
     }
@@ -532,9 +507,6 @@ public class LlmModule implements Closeable {
     if (nativeResult != 0) {
       throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed");
     }
-    } finally {
-      mLock.readLock().unlock();
-    }
   }
 
   /**
@@ -557,9 +529,7 @@ public class LlmModule implements Closeable {
    */
   @Experimental
   public void prefillNormalizedImage(ByteBuffer image, int width, int height, int channels) {
-    mLock.readLock().lock();
-    try {
-      checkNotClosed();
+    checkNotDestroyed();
     if (!image.isDirect()) {
       throw new IllegalArgumentException("Input ByteBuffer must be direct.");
     }
@@ -604,9 +574,6 @@ public class LlmModule implements Closeable {
     if (nativeResult != 0) {
       throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed");
     }
-    } finally {
-      mLock.readLock().unlock();
-    }
   }
 
   private native int prefillImagesInput(int[] image, int width, int height, int channels);
@@ -628,15 +595,10 @@ public class LlmModule implements Closeable {
    */
   @Experimental
   public void prefillImages(float[] image, int width, int height, int channels) {
-    mLock.readLock().lock();
-    try {
-      checkNotClosed();
-      int nativeResult = prefillNormalizedImagesInput(image, width, height, channels);
-      if (nativeResult != 0) {
-        throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed");
-      }
-    } finally {
-      mLock.readLock().unlock();
+    checkNotDestroyed();
+    int nativeResult = prefillNormalizedImagesInput(image, width, height, channels);
+    if (nativeResult != 0) {
+      throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed");
     }
   }
 
@@ -654,15 +616,10 @@ public class LlmModule implements Closeable {
    */
   @Experimental
   public void prefillAudio(byte[] audio, int batch_size, int n_bins, int n_frames) {
-    mLock.readLock().lock();
-    try {
-      checkNotClosed();
-      int nativeResult = prefillAudioInput(audio, batch_size, n_bins, n_frames);
-      if (nativeResult != 0) {
-        throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed");
-      }
-    } finally {
-      mLock.readLock().unlock();
+    checkNotDestroyed();
+    int nativeResult = prefillAudioInput(audio, batch_size, n_bins, n_frames);
+    if (nativeResult != 0) {
+      throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed");
     }
   }
 
@@ -679,15 +636,10 @@ public class LlmModule implements Closeable {
    */
   @Experimental
   public void prefillAudio(float[] audio, int batch_size, int n_bins, int n_frames) {
-    mLock.readLock().lock();
-    try {
-      checkNotClosed();
-      int nativeResult = prefillAudioInputFloat(audio, batch_size, n_bins, n_frames);
-      if (nativeResult != 0) {
-        throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed");
-      }
-    } finally {
-      mLock.readLock().unlock();
+    checkNotDestroyed();
+    int nativeResult = prefillAudioInputFloat(audio, batch_size, n_bins, n_frames);
+    if (nativeResult != 0) {
+      throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed");
     }
   }
 
@@ -705,15 +657,10 @@ public class LlmModule implements Closeable {
    */
   @Experimental
   public void prefillRawAudio(byte[] audio, int batch_size, int n_channels, int n_samples) {
-    mLock.readLock().lock();
-    try {
-      checkNotClosed();
-      int nativeResult = prefillRawAudioInput(audio, batch_size, n_channels, n_samples);
-      if (nativeResult != 0) {
-        throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed");
-      }
-    } finally {
-      mLock.readLock().unlock();
+    checkNotDestroyed();
+    int nativeResult = prefillRawAudioInput(audio, batch_size, n_channels, n_samples);
+    if (nativeResult != 0) {
+      throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed");
     }
   }
 
@@ -728,15 +675,10 @@ public class LlmModule implements Closeable {
    */
   @Experimental
   public void prefillPrompt(String prompt) {
-    mLock.readLock().lock();
-    try {
-      checkNotClosed();
-      int nativeResult = prefillTextInput(prompt);
-      if (nativeResult != 0) {
-        throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed");
-      }
-    } finally {
-      mLock.readLock().unlock();
+    checkNotDestroyed();
+    int nativeResult = prefillTextInput(prompt);
+    if (nativeResult != 0) {
+      throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed");
     }
   }
 
@@ -749,24 +691,19 @@ public class LlmModule implements Closeable {
    * <p>The startPos will be reset to 0.
    */
   public void resetContext() {
-    mLock.readLock().lock();
-    try {
-      checkNotClosed();
-      resetContextNative();
-    } finally {
-      mLock.readLock().unlock();
-    }
+    checkNotDestroyed();
+    resetContextNative();
   }
 
   @DoNotStrip
   private native void resetContextNative();
 
   /**
-   * Stop current generate() before it finishes. Safe to call from any thread. Does not acquire any
-   * lock. After close(), this is a no-op.
+   * Stop current generate() before it finishes. Safe to call from any thread via a native atomic
+   * flag. After close(), this is a no-op.
    */
   public void stop() {
-    if (mClosed) return;
+    if (mDestroyed) return;
     stopNative();
   }
 
@@ -776,15 +713,10 @@ public class LlmModule implements Closeable {
   /** Force loading the module. Otherwise the model is loaded during first generate(). */
   @DoNotStrip
   public void load() {
-    mLock.readLock().lock();
-    try {
-      checkNotClosed();
-      int err = loadNative();
-      if (err != 0) {
-        throw ExecutorchRuntimeException.makeExecutorchException(err, "Failed to load model");
-      }
-    } finally {
-      mLock.readLock().unlock();
+    checkNotDestroyed();
+    int err = loadNative();
+    if (err != 0) {
+      throw ExecutorchRuntimeException.makeExecutorchException(err, "Failed to load model");
     }
   }
 

--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmModule.java
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmModule.java
@@ -699,17 +699,9 @@ public class LlmModule implements Closeable {
   @DoNotStrip
   private native void resetContextNative();
 
-  /**
-   * Stop current generate() before it finishes. Safe to call from any thread via a native atomic
-   * flag. After close(), this is a no-op.
-   */
-  public void stop() {
-    if (mDestroyed) return;
-    stopNative();
-  }
-
+  /** Stop current generate() before it finishes. */
   @DoNotStrip
-  private native void stopNative();
+  public native void stop();
 
   /** Force loading the module. Otherwise the model is loaded during first generate(). */
   @DoNotStrip

--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmModule.java
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmModule.java
@@ -31,7 +31,7 @@ public class LlmModule implements Closeable {
   public static final int MODEL_TYPE_MULTIMODAL = 2;
 
   private final HybridData mHybridData;
-  private volatile boolean mDestroyed = false;
+  private boolean mDestroyed = false;
   private static final int DEFAULT_SEQ_LEN = 128;
   private static final boolean DEFAULT_ECHO = true;
   private static final float DEFAULT_TEMPERATURE = -1.0f;

--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmModule.java
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmModule.java
@@ -13,6 +13,8 @@ import com.facebook.jni.annotations.DoNotStrip;
 import java.io.Closeable;
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import org.pytorch.executorch.ExecuTorchRuntime;
 import org.pytorch.executorch.ExecutorchRuntimeException;
 import org.pytorch.executorch.annotations.Experimental;
@@ -31,6 +33,7 @@ public class LlmModule implements Closeable {
   public static final int MODEL_TYPE_MULTIMODAL = 2;
 
   private final HybridData mHybridData;
+  private final Lock mLock = new ReentrantLock();
   private boolean mDestroyed = false;
   private static final int DEFAULT_SEQ_LEN = 128;
   private static final boolean DEFAULT_ECHO = true;
@@ -199,9 +202,18 @@ public class LlmModule implements Closeable {
    */
   @Override
   public void close() {
-    if (mDestroyed) return;
-    mDestroyed = true;
-    mHybridData.resetNative();
+    if (mLock.tryLock()) {
+      try {
+        if (!mDestroyed) {
+          mDestroyed = true;
+          mHybridData.resetNative();
+        }
+      } finally {
+        mLock.unlock();
+      }
+    } else {
+      throw new IllegalStateException("Cannot close module while method is executing");
+    }
   }
 
   /**
@@ -304,10 +316,15 @@ public class LlmModule implements Closeable {
       float temperature,
       int numBos,
       int numEos) {
-    checkNotDestroyed();
-    int err = generateNative(prompt, seqLen, llmCallback, echo, temperature, numBos, numEos);
-    if (err != 0) {
-      throw ExecutorchRuntimeException.makeExecutorchException(err, "Failed to generate");
+    mLock.lock();
+    try {
+      checkNotDestroyed();
+      int err = generateNative(prompt, seqLen, llmCallback, echo, temperature, numBos, numEos);
+      if (err != 0) {
+        throw ExecutorchRuntimeException.makeExecutorchException(err, "Failed to generate");
+      }
+    } finally {
+      mLock.unlock();
     }
   }
 
@@ -436,11 +453,22 @@ public class LlmModule implements Closeable {
       float temperature,
       int numBos,
       int numEos) {
-    checkNotDestroyed();
-    if (image != null) {
-      prefillImages(image, width, height, channels);
+    mLock.lock();
+    try {
+      checkNotDestroyed();
+      if (image != null) {
+        int nativeResult = prefillImagesInput(image, width, height, channels);
+        if (nativeResult != 0) {
+          throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed");
+        }
+      }
+      int err = generateNative(prompt, seqLen, llmCallback, echo, temperature, numBos, numEos);
+      if (err != 0) {
+        throw ExecutorchRuntimeException.makeExecutorchException(err, "Failed to generate");
+      }
+    } finally {
+      mLock.unlock();
     }
-    generate(prompt, seqLen, llmCallback, echo, temperature, numBos, numEos);
   }
 
   /**
@@ -454,10 +482,15 @@ public class LlmModule implements Closeable {
    */
   @Experimental
   public void prefillImages(int[] image, int width, int height, int channels) {
-    checkNotDestroyed();
-    int nativeResult = prefillImagesInput(image, width, height, channels);
-    if (nativeResult != 0) {
-      throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed");
+    mLock.lock();
+    try {
+      checkNotDestroyed();
+      int nativeResult = prefillImagesInput(image, width, height, channels);
+      if (nativeResult != 0) {
+        throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed");
+      }
+    } finally {
+      mLock.unlock();
     }
   }
 
@@ -478,35 +511,40 @@ public class LlmModule implements Closeable {
    */
   @Experimental
   public void prefillImages(ByteBuffer image, int width, int height, int channels) {
-    checkNotDestroyed();
-    if (!image.isDirect()) {
-      throw new IllegalArgumentException("Input ByteBuffer must be direct.");
-    }
-    long expectedBytes;
+    mLock.lock();
     try {
-      long pixels = Math.multiplyExact((long) width, (long) height);
-      expectedBytes = Math.multiplyExact(pixels, (long) channels);
-    } catch (ArithmeticException ex) {
-      throw new IllegalArgumentException(
-          "width*height*channels is too large and overflows the allowed range.", ex);
-    }
-    if (width <= 0
-        || height <= 0
-        || channels <= 0
-        || expectedBytes > Integer.MAX_VALUE
-        || image.remaining() < expectedBytes) {
-      throw new IllegalArgumentException(
-          "ByteBuffer remaining ("
-              + image.remaining()
-              + ") must be at least width*height*channels ("
-              + expectedBytes
-              + ").");
-    }
-    // slice() so that getDirectBufferAddress on the native side returns a pointer
-    // starting at the current position, not the base address.
-    int nativeResult = prefillImagesInputBuffer(image.slice(), width, height, channels);
-    if (nativeResult != 0) {
-      throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed");
+      checkNotDestroyed();
+      if (!image.isDirect()) {
+        throw new IllegalArgumentException("Input ByteBuffer must be direct.");
+      }
+      long expectedBytes;
+      try {
+        long pixels = Math.multiplyExact((long) width, (long) height);
+        expectedBytes = Math.multiplyExact(pixels, (long) channels);
+      } catch (ArithmeticException ex) {
+        throw new IllegalArgumentException(
+            "width*height*channels is too large and overflows the allowed range.", ex);
+      }
+      if (width <= 0
+          || height <= 0
+          || channels <= 0
+          || expectedBytes > Integer.MAX_VALUE
+          || image.remaining() < expectedBytes) {
+        throw new IllegalArgumentException(
+            "ByteBuffer remaining ("
+                + image.remaining()
+                + ") must be at least width*height*channels ("
+                + expectedBytes
+                + ").");
+      }
+      // slice() so that getDirectBufferAddress on the native side returns a pointer
+      // starting at the current position, not the base address.
+      int nativeResult = prefillImagesInputBuffer(image.slice(), width, height, channels);
+      if (nativeResult != 0) {
+        throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed");
+      }
+    } finally {
+      mLock.unlock();
     }
   }
 
@@ -530,50 +568,58 @@ public class LlmModule implements Closeable {
    */
   @Experimental
   public void prefillNormalizedImage(ByteBuffer image, int width, int height, int channels) {
-    checkNotDestroyed();
-    if (!image.isDirect()) {
-      throw new IllegalArgumentException("Input ByteBuffer must be direct.");
-    }
-    if (image.order() != java.nio.ByteOrder.nativeOrder()) {
-      throw new IllegalArgumentException(
-          "Input ByteBuffer must use native byte order (ByteOrder.nativeOrder()).");
-    }
-    if (image.position() % Float.BYTES != 0) {
-      throw new IllegalArgumentException(
-          "Input ByteBuffer position (" + image.position() + ") must be 4-byte aligned.");
-    }
-    final long expectedBytes;
+    mLock.lock();
     try {
-      int wh = Math.multiplyExact(width, height);
-      long whc = Math.multiplyExact((long) wh, (long) channels);
-      long totalBytes = Math.multiplyExact(whc, (long) Float.BYTES);
-      if (totalBytes > Integer.MAX_VALUE) {
-        throw new IllegalArgumentException(
-            "ByteBuffer size (width*height*channels*4) exceeds Integer.MAX_VALUE bytes: "
-                + totalBytes);
+      checkNotDestroyed();
+      if (!image.isDirect()) {
+        throw new IllegalArgumentException("Input ByteBuffer must be direct.");
       }
-      expectedBytes = totalBytes;
-    } catch (ArithmeticException e) {
-      throw new IllegalArgumentException(
-          "Overflow while computing width*height*channels*4 for ByteBuffer size.", e);
-    }
-    if (width <= 0 || height <= 0 || channels <= 0 || image.remaining() < expectedBytes) {
-      throw new IllegalArgumentException(
-          "ByteBuffer remaining ("
-              + image.remaining()
-              + ") must be at least width*height*channels*4 ("
-              + expectedBytes
-              + ").");
-    }
-    if (image.remaining() % Float.BYTES != 0) {
-      throw new IllegalArgumentException(
-          "ByteBuffer remaining (" + image.remaining() + ") must be a multiple of 4 (float size).");
-    }
-    // slice() so that getDirectBufferAddress on the native side returns a pointer
-    // starting at the current position, not the base address.
-    int nativeResult = prefillNormalizedImagesInputBuffer(image.slice(), width, height, channels);
-    if (nativeResult != 0) {
-      throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed");
+      if (image.order() != java.nio.ByteOrder.nativeOrder()) {
+        throw new IllegalArgumentException(
+            "Input ByteBuffer must use native byte order (ByteOrder.nativeOrder()).");
+      }
+      if (image.position() % Float.BYTES != 0) {
+        throw new IllegalArgumentException(
+            "Input ByteBuffer position (" + image.position() + ") must be 4-byte aligned.");
+      }
+      final long expectedBytes;
+      try {
+        int wh = Math.multiplyExact(width, height);
+        long whc = Math.multiplyExact((long) wh, (long) channels);
+        long totalBytes = Math.multiplyExact(whc, (long) Float.BYTES);
+        if (totalBytes > Integer.MAX_VALUE) {
+          throw new IllegalArgumentException(
+              "ByteBuffer size (width*height*channels*4) exceeds Integer.MAX_VALUE bytes: "
+                  + totalBytes);
+        }
+        expectedBytes = totalBytes;
+      } catch (ArithmeticException e) {
+        throw new IllegalArgumentException(
+            "Overflow while computing width*height*channels*4 for ByteBuffer size.", e);
+      }
+      if (width <= 0 || height <= 0 || channels <= 0 || image.remaining() < expectedBytes) {
+        throw new IllegalArgumentException(
+            "ByteBuffer remaining ("
+                + image.remaining()
+                + ") must be at least width*height*channels*4 ("
+                + expectedBytes
+                + ").");
+      }
+      if (image.remaining() % Float.BYTES != 0) {
+        throw new IllegalArgumentException(
+            "ByteBuffer remaining ("
+                + image.remaining()
+                + ") must be a multiple of 4 (float size).");
+      }
+      // slice() so that getDirectBufferAddress on the native side returns a pointer
+      // starting at the current position, not the base address.
+      int nativeResult =
+          prefillNormalizedImagesInputBuffer(image.slice(), width, height, channels);
+      if (nativeResult != 0) {
+        throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed");
+      }
+    } finally {
+      mLock.unlock();
     }
   }
 
@@ -596,10 +642,15 @@ public class LlmModule implements Closeable {
    */
   @Experimental
   public void prefillImages(float[] image, int width, int height, int channels) {
-    checkNotDestroyed();
-    int nativeResult = prefillNormalizedImagesInput(image, width, height, channels);
-    if (nativeResult != 0) {
-      throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed");
+    mLock.lock();
+    try {
+      checkNotDestroyed();
+      int nativeResult = prefillNormalizedImagesInput(image, width, height, channels);
+      if (nativeResult != 0) {
+        throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed");
+      }
+    } finally {
+      mLock.unlock();
     }
   }
 
@@ -617,10 +668,15 @@ public class LlmModule implements Closeable {
    */
   @Experimental
   public void prefillAudio(byte[] audio, int batch_size, int n_bins, int n_frames) {
-    checkNotDestroyed();
-    int nativeResult = prefillAudioInput(audio, batch_size, n_bins, n_frames);
-    if (nativeResult != 0) {
-      throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed");
+    mLock.lock();
+    try {
+      checkNotDestroyed();
+      int nativeResult = prefillAudioInput(audio, batch_size, n_bins, n_frames);
+      if (nativeResult != 0) {
+        throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed");
+      }
+    } finally {
+      mLock.unlock();
     }
   }
 
@@ -637,10 +693,15 @@ public class LlmModule implements Closeable {
    */
   @Experimental
   public void prefillAudio(float[] audio, int batch_size, int n_bins, int n_frames) {
-    checkNotDestroyed();
-    int nativeResult = prefillAudioInputFloat(audio, batch_size, n_bins, n_frames);
-    if (nativeResult != 0) {
-      throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed");
+    mLock.lock();
+    try {
+      checkNotDestroyed();
+      int nativeResult = prefillAudioInputFloat(audio, batch_size, n_bins, n_frames);
+      if (nativeResult != 0) {
+        throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed");
+      }
+    } finally {
+      mLock.unlock();
     }
   }
 
@@ -658,10 +719,15 @@ public class LlmModule implements Closeable {
    */
   @Experimental
   public void prefillRawAudio(byte[] audio, int batch_size, int n_channels, int n_samples) {
-    checkNotDestroyed();
-    int nativeResult = prefillRawAudioInput(audio, batch_size, n_channels, n_samples);
-    if (nativeResult != 0) {
-      throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed");
+    mLock.lock();
+    try {
+      checkNotDestroyed();
+      int nativeResult = prefillRawAudioInput(audio, batch_size, n_channels, n_samples);
+      if (nativeResult != 0) {
+        throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed");
+      }
+    } finally {
+      mLock.unlock();
     }
   }
 
@@ -676,10 +742,15 @@ public class LlmModule implements Closeable {
    */
   @Experimental
   public void prefillPrompt(String prompt) {
-    checkNotDestroyed();
-    int nativeResult = prefillTextInput(prompt);
-    if (nativeResult != 0) {
-      throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed");
+    mLock.lock();
+    try {
+      checkNotDestroyed();
+      int nativeResult = prefillTextInput(prompt);
+      if (nativeResult != 0) {
+        throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed");
+      }
+    } finally {
+      mLock.unlock();
     }
   }
 
@@ -692,8 +763,13 @@ public class LlmModule implements Closeable {
    * <p>The startPos will be reset to 0.
    */
   public void resetContext() {
-    checkNotDestroyed();
-    resetContextNative();
+    mLock.lock();
+    try {
+      checkNotDestroyed();
+      resetContextNative();
+    } finally {
+      mLock.unlock();
+    }
   }
 
   @DoNotStrip
@@ -706,10 +782,15 @@ public class LlmModule implements Closeable {
   /** Force loading the module. Otherwise the model is loaded during first generate(). */
   @DoNotStrip
   public void load() {
-    checkNotDestroyed();
-    int err = loadNative();
-    if (err != 0) {
-      throw ExecutorchRuntimeException.makeExecutorchException(err, "Failed to load model");
+    mLock.lock();
+    try {
+      checkNotDestroyed();
+      int err = loadNative();
+      if (err != 0) {
+        throw ExecutorchRuntimeException.makeExecutorchException(err, "Failed to load model");
+      }
+    } finally {
+      mLock.unlock();
     }
   }
 

--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmModule.java
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmModule.java
@@ -613,8 +613,7 @@ public class LlmModule implements Closeable {
       }
       // slice() so that getDirectBufferAddress on the native side returns a pointer
       // starting at the current position, not the base address.
-      int nativeResult =
-          prefillNormalizedImagesInputBuffer(image.slice(), width, height, channels);
+      int nativeResult = prefillNormalizedImagesInputBuffer(image.slice(), width, height, channels);
       if (nativeResult != 0) {
         throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed");
       }

--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmModule.java
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmModule.java
@@ -10,8 +10,10 @@ package org.pytorch.executorch.extension.llm;
 
 import com.facebook.jni.HybridData;
 import com.facebook.jni.annotations.DoNotStrip;
+import java.io.Closeable;
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.pytorch.executorch.ExecuTorchRuntime;
 import org.pytorch.executorch.ExecutorchRuntimeException;
 import org.pytorch.executorch.annotations.Experimental;
@@ -23,14 +25,15 @@ import org.pytorch.executorch.annotations.Experimental;
  * <p>Warning: These APIs are experimental and subject to change without notice
  */
 @Experimental
-public class LlmModule {
+public class LlmModule implements Closeable {
 
   public static final int MODEL_TYPE_TEXT = 1;
   public static final int MODEL_TYPE_TEXT_VISION = 2;
   public static final int MODEL_TYPE_MULTIMODAL = 2;
 
   private final HybridData mHybridData;
-  private volatile boolean mDestroyed = false;
+  private final ReentrantReadWriteLock mLock = new ReentrantReadWriteLock(true);
+  private volatile boolean mClosed = false;
   private static final int DEFAULT_SEQ_LEN = 128;
   private static final boolean DEFAULT_ECHO = true;
   private static final float DEFAULT_TEMPERATURE = -1.0f;
@@ -187,15 +190,27 @@ public class LlmModule {
         config.getLoadMode());
   }
 
-  private void checkNotDestroyed() {
-    if (mDestroyed) throw new IllegalStateException("LlmModule has been destroyed");
+  private void checkNotClosed() {
+    if (mClosed) throw new IllegalStateException("LlmModule has been closed");
   }
 
+  @Override
+  public void close() {
+    stopNative();
+    mLock.writeLock().lock();
+    try {
+      if (mClosed) return;
+      mClosed = true;
+      mHybridData.resetNative();
+    } finally {
+      mLock.writeLock().unlock();
+    }
+  }
+
+  /** @deprecated Use {@link #close()} instead. */
   @Deprecated
   public void resetNative() {
-    if (mDestroyed) return;
-    mDestroyed = true;
-    mHybridData.resetNative();
+    close();
   }
 
   /**
@@ -205,7 +220,6 @@ public class LlmModule {
    * @param llmCallback callback object to receive results.
    */
   public void generate(String prompt, LlmCallback llmCallback) {
-    checkNotDestroyed();
     generate(
         prompt,
         DEFAULT_SEQ_LEN,
@@ -224,7 +238,6 @@ public class LlmModule {
    * @param llmCallback callback object to receive results.
    */
   public void generate(String prompt, int seqLen, LlmCallback llmCallback) {
-    checkNotDestroyed();
     generate(
         null,
         0,
@@ -247,7 +260,6 @@ public class LlmModule {
    * @param echo indicate whether to echo the input prompt or not (text completion vs chat)
    */
   public void generate(String prompt, LlmCallback llmCallback, boolean echo) {
-    checkNotDestroyed();
     generate(
         null,
         0,
@@ -271,7 +283,6 @@ public class LlmModule {
    * @param echo indicate whether to echo the input prompt or not (text completion vs chat)
    */
   public void generate(String prompt, int seqLen, LlmCallback llmCallback, boolean echo) {
-    checkNotDestroyed();
     generate(prompt, seqLen, llmCallback, echo, DEFAULT_TEMPERATURE, DEFAULT_BOS, DEFAULT_EOS);
   }
 
@@ -294,10 +305,15 @@ public class LlmModule {
       float temperature,
       int numBos,
       int numEos) {
-    checkNotDestroyed();
-    int err = generateNative(prompt, seqLen, llmCallback, echo, temperature, numBos, numEos);
-    if (err != 0) {
-      throw ExecutorchRuntimeException.makeExecutorchException(err, "Failed to generate");
+    mLock.readLock().lock();
+    try {
+      checkNotClosed();
+      int err = generateNative(prompt, seqLen, llmCallback, echo, temperature, numBos, numEos);
+      if (err != 0) {
+        throw ExecutorchRuntimeException.makeExecutorchException(err, "Failed to generate");
+      }
+    } finally {
+      mLock.readLock().unlock();
     }
   }
 
@@ -319,7 +335,6 @@ public class LlmModule {
    * @param llmCallback callback object to receive results
    */
   public void generate(String prompt, LlmGenerationConfig config, LlmCallback llmCallback) {
-    checkNotDestroyed();
     int seqLen = config.getSeqLen();
     boolean echo = config.isEcho();
     float temperature = config.getTemperature();
@@ -349,7 +364,6 @@ public class LlmModule {
       int seqLen,
       LlmCallback llmCallback,
       boolean echo) {
-    checkNotDestroyed();
     generate(
         image,
         width,
@@ -387,7 +401,6 @@ public class LlmModule {
       LlmCallback llmCallback,
       boolean echo,
       float temperature) {
-    checkNotDestroyed();
     generate(
         image,
         width,
@@ -429,11 +442,22 @@ public class LlmModule {
       float temperature,
       int numBos,
       int numEos) {
-    checkNotDestroyed();
-    if (image != null) {
-      prefillImages(image, width, height, channels);
+    mLock.readLock().lock();
+    try {
+      checkNotClosed();
+      if (image != null) {
+        int nativeResult = prefillImagesInput(image, width, height, channels);
+        if (nativeResult != 0) {
+          throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed");
+        }
+      }
+      int err = generateNative(prompt, seqLen, llmCallback, echo, temperature, numBos, numEos);
+      if (err != 0) {
+        throw ExecutorchRuntimeException.makeExecutorchException(err, "Failed to generate");
+      }
+    } finally {
+      mLock.readLock().unlock();
     }
-    generate(prompt, seqLen, llmCallback, echo, temperature, numBos, numEos);
   }
 
   /**
@@ -447,10 +471,15 @@ public class LlmModule {
    */
   @Experimental
   public void prefillImages(int[] image, int width, int height, int channels) {
-    checkNotDestroyed();
-    int nativeResult = prefillImagesInput(image, width, height, channels);
-    if (nativeResult != 0) {
-      throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed");
+    mLock.readLock().lock();
+    try {
+      checkNotClosed();
+      int nativeResult = prefillImagesInput(image, width, height, channels);
+      if (nativeResult != 0) {
+        throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed");
+      }
+    } finally {
+      mLock.readLock().unlock();
     }
   }
 
@@ -471,7 +500,9 @@ public class LlmModule {
    */
   @Experimental
   public void prefillImages(ByteBuffer image, int width, int height, int channels) {
-    checkNotDestroyed();
+    mLock.readLock().lock();
+    try {
+      checkNotClosed();
     if (!image.isDirect()) {
       throw new IllegalArgumentException("Input ByteBuffer must be direct.");
     }
@@ -501,6 +532,9 @@ public class LlmModule {
     if (nativeResult != 0) {
       throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed");
     }
+    } finally {
+      mLock.readLock().unlock();
+    }
   }
 
   /**
@@ -523,7 +557,9 @@ public class LlmModule {
    */
   @Experimental
   public void prefillNormalizedImage(ByteBuffer image, int width, int height, int channels) {
-    checkNotDestroyed();
+    mLock.readLock().lock();
+    try {
+      checkNotClosed();
     if (!image.isDirect()) {
       throw new IllegalArgumentException("Input ByteBuffer must be direct.");
     }
@@ -568,6 +604,9 @@ public class LlmModule {
     if (nativeResult != 0) {
       throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed");
     }
+    } finally {
+      mLock.readLock().unlock();
+    }
   }
 
   private native int prefillImagesInput(int[] image, int width, int height, int channels);
@@ -589,10 +628,15 @@ public class LlmModule {
    */
   @Experimental
   public void prefillImages(float[] image, int width, int height, int channels) {
-    checkNotDestroyed();
-    int nativeResult = prefillNormalizedImagesInput(image, width, height, channels);
-    if (nativeResult != 0) {
-      throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed");
+    mLock.readLock().lock();
+    try {
+      checkNotClosed();
+      int nativeResult = prefillNormalizedImagesInput(image, width, height, channels);
+      if (nativeResult != 0) {
+        throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed");
+      }
+    } finally {
+      mLock.readLock().unlock();
     }
   }
 
@@ -610,10 +654,15 @@ public class LlmModule {
    */
   @Experimental
   public void prefillAudio(byte[] audio, int batch_size, int n_bins, int n_frames) {
-    checkNotDestroyed();
-    int nativeResult = prefillAudioInput(audio, batch_size, n_bins, n_frames);
-    if (nativeResult != 0) {
-      throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed");
+    mLock.readLock().lock();
+    try {
+      checkNotClosed();
+      int nativeResult = prefillAudioInput(audio, batch_size, n_bins, n_frames);
+      if (nativeResult != 0) {
+        throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed");
+      }
+    } finally {
+      mLock.readLock().unlock();
     }
   }
 
@@ -630,10 +679,15 @@ public class LlmModule {
    */
   @Experimental
   public void prefillAudio(float[] audio, int batch_size, int n_bins, int n_frames) {
-    checkNotDestroyed();
-    int nativeResult = prefillAudioInputFloat(audio, batch_size, n_bins, n_frames);
-    if (nativeResult != 0) {
-      throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed");
+    mLock.readLock().lock();
+    try {
+      checkNotClosed();
+      int nativeResult = prefillAudioInputFloat(audio, batch_size, n_bins, n_frames);
+      if (nativeResult != 0) {
+        throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed");
+      }
+    } finally {
+      mLock.readLock().unlock();
     }
   }
 
@@ -651,10 +705,15 @@ public class LlmModule {
    */
   @Experimental
   public void prefillRawAudio(byte[] audio, int batch_size, int n_channels, int n_samples) {
-    checkNotDestroyed();
-    int nativeResult = prefillRawAudioInput(audio, batch_size, n_channels, n_samples);
-    if (nativeResult != 0) {
-      throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed");
+    mLock.readLock().lock();
+    try {
+      checkNotClosed();
+      int nativeResult = prefillRawAudioInput(audio, batch_size, n_channels, n_samples);
+      if (nativeResult != 0) {
+        throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed");
+      }
+    } finally {
+      mLock.readLock().unlock();
     }
   }
 
@@ -669,10 +728,15 @@ public class LlmModule {
    */
   @Experimental
   public void prefillPrompt(String prompt) {
-    checkNotDestroyed();
-    int nativeResult = prefillTextInput(prompt);
-    if (nativeResult != 0) {
-      throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed");
+    mLock.readLock().lock();
+    try {
+      checkNotClosed();
+      int nativeResult = prefillTextInput(prompt);
+      if (nativeResult != 0) {
+        throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed");
+      }
+    } finally {
+      mLock.readLock().unlock();
     }
   }
 
@@ -685,24 +749,42 @@ public class LlmModule {
    * <p>The startPos will be reset to 0.
    */
   public void resetContext() {
-    checkNotDestroyed();
-    resetContextNative();
+    mLock.readLock().lock();
+    try {
+      checkNotClosed();
+      resetContextNative();
+    } finally {
+      mLock.readLock().unlock();
+    }
   }
 
   @DoNotStrip
   private native void resetContextNative();
 
-  /** Stop current generate() before it finishes. */
+  /**
+   * Stop current generate() before it finishes. Safe to call from any thread. Does not acquire any
+   * lock. After close(), this is a no-op.
+   */
+  public void stop() {
+    if (mClosed) return;
+    stopNative();
+  }
+
   @DoNotStrip
-  public native void stop();
+  private native void stopNative();
 
   /** Force loading the module. Otherwise the model is loaded during first generate(). */
   @DoNotStrip
   public void load() {
-    checkNotDestroyed();
-    int err = loadNative();
-    if (err != 0) {
-      throw ExecutorchRuntimeException.makeExecutorchException(err, "Failed to load model");
+    mLock.readLock().lock();
+    try {
+      checkNotClosed();
+      int err = loadNative();
+      if (err != 0) {
+        throw ExecutorchRuntimeException.makeExecutorchException(err, "Failed to load model");
+      }
+    } finally {
+      mLock.readLock().unlock();
     }
   }
 

--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmModule.java
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmModule.java
@@ -31,7 +31,7 @@ public class LlmModule implements Closeable {
   public static final int MODEL_TYPE_MULTIMODAL = 2;
 
   private final HybridData mHybridData;
-  private boolean mDestroyed = false;
+  private volatile boolean mDestroyed = false;
   private static final int DEFAULT_SEQ_LEN = 128;
   private static final boolean DEFAULT_ECHO = true;
   private static final float DEFAULT_TEMPERATURE = -1.0f;
@@ -194,7 +194,8 @@ public class LlmModule implements Closeable {
 
   /**
    * Releases native resources. Callers must ensure no other methods are in-flight. Call {@link
-   * #stop()} and wait for {@link #generate} to return before calling this method.
+   * #stop()} and wait for {@link #generate(String, LlmCallback)} to return before calling this
+   * method.
    */
   @Override
   public void close() {

--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmModule.java
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmModule.java
@@ -13,7 +13,6 @@ import com.facebook.jni.annotations.DoNotStrip;
 import java.io.Closeable;
 import java.nio.ByteBuffer;
 import java.util.List;
-import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import org.pytorch.executorch.ExecuTorchRuntime;
 import org.pytorch.executorch.ExecutorchRuntimeException;
@@ -33,7 +32,7 @@ public class LlmModule implements Closeable {
   public static final int MODEL_TYPE_MULTIMODAL = 2;
 
   private final HybridData mHybridData;
-  private final Lock mLock = new ReentrantLock();
+  private final ReentrantLock mLock = new ReentrantLock();
   private boolean mDestroyed = false;
   private static final int DEFAULT_SEQ_LEN = 128;
   private static final boolean DEFAULT_ECHO = true;
@@ -204,6 +203,10 @@ public class LlmModule implements Closeable {
   public void close() {
     if (mLock.tryLock()) {
       try {
+        if (mLock.getHoldCount() > 1) {
+          throw new IllegalStateException(
+              "Cannot close module from within a callback during execution");
+        }
         if (!mDestroyed) {
           mDestroyed = true;
           mHybridData.resetNative();

--- a/extension/android/jni/jni_layer_llama.cpp
+++ b/extension/android/jni/jni_layer_llama.cpp
@@ -617,7 +617,7 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
     registerHybrid({
         makeNativeMethod("initHybrid", ExecuTorchLlmJni::initHybrid),
         makeNativeMethod("generateNative", ExecuTorchLlmJni::generate),
-        makeNativeMethod("stopNative", ExecuTorchLlmJni::stop),
+        makeNativeMethod("stop", ExecuTorchLlmJni::stop),
         makeNativeMethod("loadNative", ExecuTorchLlmJni::load),
         makeNativeMethod(
             "prefillImagesInput", ExecuTorchLlmJni::prefill_images_input),

--- a/extension/android/jni/jni_layer_llama.cpp
+++ b/extension/android/jni/jni_layer_llama.cpp
@@ -617,7 +617,7 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
     registerHybrid({
         makeNativeMethod("initHybrid", ExecuTorchLlmJni::initHybrid),
         makeNativeMethod("generateNative", ExecuTorchLlmJni::generate),
-        makeNativeMethod("stop", ExecuTorchLlmJni::stop),
+        makeNativeMethod("stopNative", ExecuTorchLlmJni::stop),
         makeNativeMethod("loadNative", ExecuTorchLlmJni::load),
         makeNativeMethod(
             "prefillImagesInput", ExecuTorchLlmJni::prefill_images_input),

--- a/extension/benchmark/android/benchmark/app/src/main/java/org/pytorch/minibench/ModelRunner.java
+++ b/extension/benchmark/android/benchmark/app/src/main/java/org/pytorch/minibench/ModelRunner.java
@@ -38,6 +38,17 @@ public class ModelRunner {
     }
     long loadEnd = System.nanoTime();
 
+    final BenchmarkMetric.BenchmarkModel benchmarkModel =
+        BenchmarkMetric.extractBackendAndQuantization(model.getName().replace(".pte", ""));
+
+    if (errorCode != 0) {
+      results.add(
+          new BenchmarkMetric(
+              benchmarkModel, "model_load_time(ms)", (loadEnd - loadStart) * 1e-6, 0.0f));
+      results.add(new BenchmarkMetric(benchmarkModel, "load_status", errorCode, 0));
+      return;
+    }
+
     for (int i = 0; i < numWarmupIter; i++) {
       module.forward();
     }
@@ -51,10 +62,6 @@ public class ModelRunner {
 
     module.etdump();
 
-    final BenchmarkMetric.BenchmarkModel benchmarkModel =
-        BenchmarkMetric.extractBackendAndQuantization(model.getName().replace(".pte", ""));
-    // The list of metrics we have atm includes:
-    // Avg inference latency after N iterations
     // Currently the result has large variance from outliers, so only use
     // 80% samples in the middle (trimmean 0.2)
     Collections.sort(latency);

--- a/extension/benchmark/android/benchmark/app/src/main/java/org/pytorch/minibench/ModelRunner.java
+++ b/extension/benchmark/android/benchmark/app/src/main/java/org/pytorch/minibench/ModelRunner.java
@@ -46,6 +46,7 @@ public class ModelRunner {
           new BenchmarkMetric(
               benchmarkModel, "model_load_time(ms)", (loadEnd - loadStart) * 1e-6, 0.0f));
       results.add(new BenchmarkMetric(benchmarkModel, "load_status", errorCode, 0));
+      module.destroy();
       return;
     }
 
@@ -90,5 +91,6 @@ public class ModelRunner {
     results.add(
         new BenchmarkMetric(
             benchmarkModel, "ram_pss_usage(mb)", (Debug.getPss() - pssIdle) / 1024, 0));
+    module.destroy();
   }
 }

--- a/extension/benchmark/android/benchmark/app/src/main/java/org/pytorch/minibench/ModelRunner.java
+++ b/extension/benchmark/android/benchmark/app/src/main/java/org/pytorch/minibench/ModelRunner.java
@@ -50,47 +50,50 @@ public class ModelRunner {
       return;
     }
 
-    for (int i = 0; i < numWarmupIter; i++) {
-      module.forward();
+    try {
+      for (int i = 0; i < numWarmupIter; i++) {
+        module.forward();
+      }
+
+      for (int i = 0; i < numIter; i++) {
+        long start = System.nanoTime();
+        module.forward();
+        double forwardMs = (System.nanoTime() - start) * 1e-6;
+        latency.add(forwardMs);
+      }
+
+      module.etdump();
+
+      // Currently the result has large variance from outliers, so only use
+      // 80% samples in the middle (trimmean 0.2)
+      Collections.sort(latency);
+      int resultSize = latency.size();
+      List<Double> usedLatencyResults = latency.subList(resultSize / 10, resultSize * 9 / 10);
+
+      results.add(
+          new BenchmarkMetric(
+              benchmarkModel,
+              "avg_inference_latency(ms)",
+              latency.stream().mapToDouble(l -> l).average().orElse(0.0f),
+              0.0f));
+      results.add(
+          new BenchmarkMetric(
+              benchmarkModel,
+              "trimmean_inference_latency(ms)",
+              usedLatencyResults.stream().mapToDouble(l -> l).average().orElse(0.0f),
+              0.0f));
+      // Model load time
+      results.add(
+          new BenchmarkMetric(
+              benchmarkModel, "model_load_time(ms)", (loadEnd - loadStart) * 1e-6, 0.0f));
+      // Load status
+      results.add(new BenchmarkMetric(benchmarkModel, "load_status", errorCode, 0));
+      // RAM PSS usage
+      results.add(
+          new BenchmarkMetric(
+              benchmarkModel, "ram_pss_usage(mb)", (Debug.getPss() - pssIdle) / 1024, 0));
+    } finally {
+      module.destroy();
     }
-
-    for (int i = 0; i < numIter; i++) {
-      long start = System.nanoTime();
-      module.forward();
-      double forwardMs = (System.nanoTime() - start) * 1e-6;
-      latency.add(forwardMs);
-    }
-
-    module.etdump();
-
-    // Currently the result has large variance from outliers, so only use
-    // 80% samples in the middle (trimmean 0.2)
-    Collections.sort(latency);
-    int resultSize = latency.size();
-    List<Double> usedLatencyResults = latency.subList(resultSize / 10, resultSize * 9 / 10);
-
-    results.add(
-        new BenchmarkMetric(
-            benchmarkModel,
-            "avg_inference_latency(ms)",
-            latency.stream().mapToDouble(l -> l).average().orElse(0.0f),
-            0.0f));
-    results.add(
-        new BenchmarkMetric(
-            benchmarkModel,
-            "trimmean_inference_latency(ms)",
-            usedLatencyResults.stream().mapToDouble(l -> l).average().orElse(0.0f),
-            0.0f));
-    // Model load time
-    results.add(
-        new BenchmarkMetric(
-            benchmarkModel, "model_load_time(ms)", (loadEnd - loadStart) * 1e-6, 0.0f));
-    // Load status
-    results.add(new BenchmarkMetric(benchmarkModel, "load_status", errorCode, 0));
-    // RAM PSS usage
-    results.add(
-        new BenchmarkMetric(
-            benchmarkModel, "ram_pss_usage(mb)", (Debug.getPss() - pssIdle) / 1024, 0));
-    module.destroy();
   }
 }


### PR DESCRIPTION
## Summary                                                                                                          
  - **LlmModule**: Implement `Closeable` so modules can be used with try-with-resources. Add `close()` with explicit
  caller contract. Deprecate `resetNative()` in favor of `close()`. Add `ReentrantLock` to serialize access to        
  non-thread-safe native state, matching `Module.java`'s pattern. 
  - **ModelRunner**: Add early return after `loadMethod()` failure to prevent cascading crash in warmup/inference     
  loops. Fix native memory leak by wrapping benchmark body in try/finally for `module.destroy()`.                     
  
  ### LlmModule lifecycle design                                                                                      
  - `ReentrantLock` serializes all operations — prevents accidental concurrent access (e.g. double-tap, rotation
  during generation) from causing native crashes                                                                      
  - `generate()`/`prefill*()`/`load()`/`resetContext()` acquire the lock
  - `close()` uses `tryLock()` — fails fast with `IllegalStateException` instead of blocking (no ANR risk)            
  - `stop()` remains a bare native method — lock-free, uses C++ atomic flag for cross-thread interrupt                
  - Caller contract: call `stop()`, wait for `generate()` to return, then `close()`                                   
                                                                                                                      
  ### Tests added                                                 
  - `testUseAfterCloseThrows`: `generate()` after `close()` throws `IllegalStateException`                            
  - `testCloseIsIdempotent`: double `close()` is safe             
                                                                                                                      
  ## Test plan
  - [ ] Existing `LlmModuleInstrumentationTest` tests pass                                                            
  - [ ] New lifecycle tests pass                                  
  - [ ] ModelRunner benchmark handles load failures gracefully

  This PR was authored with the help of Claude.    