### PR TITLE
Arm backend: Do not skip _fuse_duplicate_users pass

### DIFF
--- a/backends/arm/test/misc/test_compile_spec.py
+++ b/backends/arm/test/misc/test_compile_spec.py
@@ -5,7 +5,10 @@
 
 import warnings
 
-from executorch.backends.arm.common.pipeline_config import SoftmaxDecompositionConfig
+from executorch.backends.arm.common.pipeline_config import (
+    FuseDuplicateUsersConfig,
+    SoftmaxDecompositionConfig,
+)
 from executorch.backends.arm.ethosu import EthosUCompileSpec
 from executorch.backends.arm.tosa.compile_spec import TosaCompileSpec
 from executorch.backends.arm.vgf import VgfCompileSpec
@@ -61,6 +64,13 @@ def test_compile_spec_vgf_no_quant():
     assert VgfCompileSpec._from_list(spec_list) != compile_spec2
     with raises(ValueError, match="Incorrect output format"):
         EthosUCompileSpec._from_list(spec_list)
+
+
+def test_compile_spec_vgf_defaults_to_enabled_fuse_duplicate_users():
+    compile_spec = VgfCompileSpec()
+    pipeline_config = compile_spec._get_pass_pipeline_config()
+
+    assert pipeline_config.fuse_duplicate_users == FuseDuplicateUsersConfig.ENABLED
 
 
 def test_compile_spec_tosa_INT():

--- a/backends/arm/vgf/compile_spec.py
+++ b/backends/arm/vgf/compile_spec.py
@@ -66,9 +66,3 @@ class VgfCompileSpec(ArmCompileSpec):
     def _get_output_format(cls) -> str:
         """Return the artifact format emitted by this compile spec."""
         return "vgf"
-
-    def _create_default_pipeline_config(self) -> ArmPassPipelineConfig:
-        config = super()._create_default_pipeline_config()
-        # GRPHCOMP-3140 / MLETORCH-1529
-        config.disable_fuse_duplicate_users()
-        return config


### PR DESCRIPTION
Removes previous workaround of skipping a pass for VGF backend, as the actual root cause (GRPHCOMP-3140) has been resolved.


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @Sebastian-Larsson @robell