### PR TITLE
Move non-runtime deps to dev/example requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,15 +52,10 @@ classifiers = [
 
 requires-python = ">=3.10,<3.14"
 dependencies=[
-  "expecttest",
   "flatbuffers",
-  "hypothesis",
-  "kgb",
-  "mpmath==1.3.0",
   "numpy>=2.0.0; python_version >= '3.10'",
   "packaging",
   "pandas>=2.2.2; python_version >= '3.10'",
-  "parameterized",
   "pytorch-tokenizers",
   "pyyaml",
   "ruamel.yaml",
@@ -70,8 +65,6 @@ dependencies=[
   "typing-extensions>=4.10.0",
   # Keep this version in sync with: ./backends/apple/coreml/scripts/install_requirements.sh
   "coremltools==9.0; platform_system == 'Darwin' or platform_system == 'Linux'",
-  # scikit-learn is used to support palettization in the coreml backend
-  "scikit-learn==1.7.1",
   "hydra-core>=1.3.0",
   "omegaconf>=2.3.0",
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,6 +11,10 @@ certifi  # Imported by resolve_buck.py.
 lintrunner==0.12.7
 lintrunner-adapters==0.13.0
 
+expecttest
+hypothesis
+kgb
+parameterized
 pytest<9.0
 pytest-xdist
 pytest-rerunfailures==15.1

--- a/requirements-examples.txt
+++ b/requirements-examples.txt
@@ -1,6 +1,7 @@
 # pip packages needed to run examples.
 # TODO: Make each example publish its own requirements.txt
 datasets == 3.6.0 # 4.0.0 deprecates trust_remote_code and load scripts. For now pin to 3.6.0
+scikit-learn == 1.7.1 # Used by example scripts such as OpenVINO accuracy checks and Qualcomm MobileBERT fine-tuning
 timm == 1.0.7
 torchsr == 1.0.4
 torchtune @ git+https://github.com/pytorch/torchtune.git@6f2aa7254458145f99d7004cbd6ebc8e53a06404


### PR DESCRIPTION
Follow up to #15379 and  #18188 by trimming more non-runtime dependencies from the published `executorch` wheel metadata.

cc @jackzhxng and @mergennachin since you commented/merged the related issue/PR.

- Move `expecttest`, `hypothesis`, `kgb`, and `parameterized` out of `[project].dependencies` and into `requirements-dev.txt`, since they are only used by tests.
- Move `scikit-learn` to `requirements-examples.txt`, since the in-tree uses are example scripts rather than core runtime paths.
- Drop the direct `mpmath` runtime pin, since `sympy` already pulls it transitively.

This keeps user installs lighter and avoids forcing test/example-only packages into downstream environments.
