### PR TITLE
NXP backend: Use new Neutron flow for failing constant pad tests.

### DIFF
--- a/backends/nxp/tests/ir/converter/node_converter/test_constant_pad_nd_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_constant_pad_nd_converter.py
@@ -163,13 +163,12 @@ def test_constant_pad_nd__unsupported_paddings(input_shape, paddings, use_qat):
     assert any(node.name == "aten_constant_pad_nd_default" for node in nodes)
 
 
-@pytest.mark.xfail(reason="EIEX=855")
 def test_constant_pad_nd__delegation__formatless__supported_padding(use_qat):
     input_shape = (2, 4, 6, 8)  # Formatless -> the last dim (8) will be padded.
     paddings = [0, 0, 1, 2, 3, 4]  # The last dim is padded using the first 2 paddings.
     model = ConstantPadNDModule(paddings)
     exec_program = to_quantized_edge_program(
-        model, input_shape, use_qat=use_qat
+        model, input_shape, use_qat=use_qat, use_new_flow_neutron_c=True
     ).exported_program()
 
     # Make sure the `pad` was delegated.
@@ -192,13 +191,12 @@ def test_constant_pad_nd__delegation__formatless__unsupported_padding(use_qat):
     )
 
 
-@pytest.mark.xfail(reason="Regression in Neutron SW 3.0.1 (AIR-14264)", strict=True)
 def test_constant_pad_nd__delegation__channels_first__supported_padding(use_qat):
     input_shape = (2, 4, 6, 8)  # Channels first -> the second dim (4) will be padded.
     paddings = [1, 2, 3, 4, 0, 0]  # The second dim is padded using the paddings[4:6].
     model = ConstantPadNDConvModule(paddings)
     exec_program = to_quantized_edge_program(
-        model, input_shape, use_qat=use_qat
+        model, input_shape, use_qat=use_qat, use_new_flow_neutron_c=True
     ).exported_program()
 
     # Make sure the `pad` was delegated.


### PR DESCRIPTION
### Summary
In Neutron SW SDK 3.1.0, some edge cases of the constant pad operator are no longer supported by the old flow. Affected tests now use the new flow where the pad is supported.

(Only the last commit is relevant)

### Test plan
Unit tests provided.


cc @robert-kalmar @JakeStevens @digantdesai