### PR TITLE
Switch VGF backend from custom vulkan-headers-1.4.343 to standardized khronos (#19031)

### DIFF
--- a/backends/arm/runtime/VGFBackend.cpp
+++ b/backends/arm/runtime/VGFBackend.cpp
@@ -27,8 +27,8 @@ using executorch::runtime::MemoryAllocator;
 using executorch::runtime::Result;
 using executorch::runtime::Span;
 
-// We use the platform and runtime environment provided by the Vulkan delegate
-#include <executorch/backends/vulkan/runtime/vk_api/vk_api.h>
+// Volk meta-loader provides Vulkan function pointers (ARM tensor extensions, etc.)
+#include <volk.h>
 
 // Dependencies for processing VGF files into Vulkan calls
 #include <vgf/decoder.hpp>

--- a/backends/arm/runtime/VGFSetup.h
+++ b/backends/arm/runtime/VGFSetup.h
@@ -15,8 +15,8 @@ using namespace std;
 using executorch::runtime::ArrayRef;
 using executorch::runtime::CompileSpec;
 
-// We use the platform and runtime environment provided by the Vulkan delegate
-#include <executorch/backends/vulkan/runtime/vk_api/vk_api.h>
+// Volk meta-loader provides Vulkan function pointers (ARM tensor extensions, etc.)
+#include <volk.h>
 
 namespace executorch {
 namespace backends {

--- a/backends/arm/runtime/targets.bzl
+++ b/backends/arm/runtime/targets.bzl
@@ -41,7 +41,7 @@ def define_common_targets():
             # function-pointer variables live in the same linkage unit.
             # Linking from a separate static library causes the linker to
             # drop the symbols when building a shared library.
-            "fbsource//third-party/vulkan-headers-1.4.343/v1.4.343/src:volk_arm_src",
+            "fbsource//third-party/volk:volk_src",
         ],
         exported_headers = ["VGFSetup.h"],
         # @lint-ignore BUCKLINT: Avoid `link_whole=True` (https://fburl.com/avoid-link-whole)
@@ -52,15 +52,13 @@ def define_common_targets():
             "-Wno-header-hygiene",
             "-Wno-unused-variable",
             "-Wno-missing-field-initializers",
-            "-DUSE_VULKAN_WRAPPER",
-            "-DUSE_VULKAN_VOLK",
         ],
         visibility = ["PUBLIC"],
         deps = [
             "//executorch/runtime/backend:interface",
             "//executorch/runtime/core:core",
             "fbsource//third-party/arm-vgf-library/v0.9.0/src:vgf",
-            "fbsource//third-party/vulkan-headers-1.4.343/v1.4.343/src:volk_arm",
-            "fbsource//third-party/vulkan-headers-1.4.343/v1.4.343/src:vulkan-headers",
+            "fbsource//third-party/khronos:vulkan-headers",
+            "fbsource//third-party/volk:volk-header",
         ],
     )


### PR DESCRIPTION
Summary:

Migrate the VGF backend's Vulkan dependencies from the custom `third-party/vulkan-headers-1.4.343` package to the standardized `third-party/khronos` and `third-party/volk` packages. The custom package had a regenerated volk with ARM tensor extensions, but the standard volk and khronos 1.4.341 headers already include these extensions (`VK_ARM_tensors`).

Changes:
- `targets.bzl`: Replace custom `vulkan-headers-1.4.343` deps with `third-party/volk:volk_src`, `third-party/volk:volk-header`, and `third-party/khronos:vulkan-headers`
- `VGFBackend.cpp`, `VGFSetup.h`: Include `<volk.h>` directly instead of going through the `vk_api.h` shim (which just forwarded to volk.h when USE_VULKAN_VOLK is defined)
- `third-party/volk/BUCK`: Add `volk_src` export_file target for direct compilation into consumer targets

Reviewed By: corporateshark

Differential Revision: D100706182




cc @SS-JIA @manuelcandales @digantdesai @cbilgin @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani