### PR TITLE
Add EValue::tryTo<T>() for all EValue payload types

### DIFF
--- a/runtime/core/evalue.h
+++ b/runtime/core/evalue.h
@@ -8,6 +8,7 @@
 
 #pragma once
 #include <executorch/runtime/core/exec_aten/exec_aten.h>
+#include <executorch/runtime/core/result.h>
 #include <executorch/runtime/core/tag.h>
 #include <executorch/runtime/platform/assert.h>
 
@@ -193,6 +194,13 @@ struct EValue {
     return payload.copyable_union.as_int;
   }
 
+  Result<int64_t> tryToInt() const {
+    if (!isInt()) {
+      return Error::InvalidType;
+    }
+    return payload.copyable_union.as_int;
+  }
+
   /****** Double Type ******/
   /*implicit*/ EValue(double d) : tag(Tag::Double) {
     payload.copyable_union.as_double = d;
@@ -207,6 +215,13 @@ struct EValue {
     return payload.copyable_union.as_double;
   }
 
+  Result<double> tryToDouble() const {
+    if (!isDouble()) {
+      return Error::InvalidType;
+    }
+    return payload.copyable_union.as_double;
+  }
+
   /****** Bool Type ******/
   /*implicit*/ EValue(bool b) : tag(Tag::Bool) {
     payload.copyable_union.as_bool = b;
@@ -218,6 +233,13 @@ struct EValue {
 
   bool toBool() const {
     ET_CHECK_MSG(isBool(), "EValue is not a Bool.");
+    return payload.copyable_union.as_bool;
+  }
+
+  Result<bool> tryToBool() const {
+    if (!isBool()) {
+      return Error::InvalidType;
+    }
     return payload.copyable_union.as_bool;
   }
 
@@ -254,6 +276,19 @@ struct EValue {
     } else {
       ET_CHECK_MSG(false, "EValue is not a Scalar.");
     }
+  }
+
+  Result<executorch::aten::Scalar> tryToScalar() const {
+    if (isDouble()) {
+      return executorch::aten::Scalar(payload.copyable_union.as_double);
+    }
+    if (isInt()) {
+      return executorch::aten::Scalar(payload.copyable_union.as_int);
+    }
+    if (isBool()) {
+      return executorch::aten::Scalar(payload.copyable_union.as_bool);
+    }
+    return Error::InvalidType;
   }
 
   /****** Tensor Type ******/
@@ -305,6 +340,13 @@ struct EValue {
     return payload.as_tensor;
   }
 
+  Result<executorch::aten::Tensor> tryToTensor() const {
+    if (!isTensor()) {
+      return Error::InvalidType;
+    }
+    return payload.as_tensor;
+  }
+
   /****** String Type ******/
   /*implicit*/ EValue(executorch::aten::ArrayRef<char>* s) : tag(Tag::String) {
     ET_CHECK_MSG(s != nullptr, "ArrayRef<char> pointer cannot be null");
@@ -320,6 +362,18 @@ struct EValue {
     ET_CHECK_MSG(
         payload.copyable_union.as_string_ptr != nullptr,
         "EValue string pointer is null.");
+    return std::string_view(
+        payload.copyable_union.as_string_ptr->data(),
+        payload.copyable_union.as_string_ptr->size());
+  }
+
+  Result<std::string_view> tryToString() const {
+    if (!isString()) {
+      return Error::InvalidType;
+    }
+    if (payload.copyable_union.as_string_ptr == nullptr) {
+      return Error::InvalidState;
+    }
     return std::string_view(
         payload.copyable_union.as_string_ptr->data(),
         payload.copyable_union.as_string_ptr->size());
@@ -344,6 +398,16 @@ struct EValue {
     return (payload.copyable_union.as_int_list_ptr)->get();
   }
 
+  Result<executorch::aten::ArrayRef<int64_t>> tryToIntList() const {
+    if (!isIntList()) {
+      return Error::InvalidType;
+    }
+    if (payload.copyable_union.as_int_list_ptr == nullptr) {
+      return Error::InvalidState;
+    }
+    return (payload.copyable_union.as_int_list_ptr)->get();
+  }
+
   /****** Bool List Type ******/
   /*implicit*/ EValue(executorch::aten::ArrayRef<bool>* b)
       : tag(Tag::ListBool) {
@@ -360,6 +424,16 @@ struct EValue {
     ET_CHECK_MSG(
         payload.copyable_union.as_bool_list_ptr != nullptr,
         "EValue bool list pointer is null.");
+    return *(payload.copyable_union.as_bool_list_ptr);
+  }
+
+  Result<executorch::aten::ArrayRef<bool>> tryToBoolList() const {
+    if (!isBoolList()) {
+      return Error::InvalidType;
+    }
+    if (payload.copyable_union.as_bool_list_ptr == nullptr) {
+      return Error::InvalidState;
+    }
     return *(payload.copyable_union.as_bool_list_ptr);
   }
 
@@ -382,6 +456,16 @@ struct EValue {
     return *(payload.copyable_union.as_double_list_ptr);
   }
 
+  Result<executorch::aten::ArrayRef<double>> tryToDoubleList() const {
+    if (!isDoubleList()) {
+      return Error::InvalidType;
+    }
+    if (payload.copyable_union.as_double_list_ptr == nullptr) {
+      return Error::InvalidState;
+    }
+    return *(payload.copyable_union.as_double_list_ptr);
+  }
+
   /****** Tensor List Type ******/
   /*implicit*/ EValue(BoxedEvalueList<executorch::aten::Tensor>* t)
       : tag(Tag::ListTensor) {
@@ -399,6 +483,17 @@ struct EValue {
     ET_CHECK_MSG(
         payload.copyable_union.as_tensor_list_ptr != nullptr,
         "EValue tensor list pointer is null.");
+    return payload.copyable_union.as_tensor_list_ptr->get();
+  }
+
+  Result<executorch::aten::ArrayRef<executorch::aten::Tensor>> tryToTensorList()
+      const {
+    if (!isTensorList()) {
+      return Error::InvalidType;
+    }
+    if (payload.copyable_union.as_tensor_list_ptr == nullptr) {
+      return Error::InvalidState;
+    }
     return payload.copyable_union.as_tensor_list_ptr->get();
   }
 
@@ -426,9 +521,28 @@ struct EValue {
     return payload.copyable_union.as_list_optional_tensor_ptr->get();
   }
 
+  Result<executorch::aten::ArrayRef<std::optional<executorch::aten::Tensor>>>
+  tryToListOptionalTensor() const {
+    if (!isListOptionalTensor()) {
+      return Error::InvalidType;
+    }
+    if (payload.copyable_union.as_list_optional_tensor_ptr == nullptr) {
+      return Error::InvalidState;
+    }
+    return payload.copyable_union.as_list_optional_tensor_ptr->get();
+  }
+
   /****** ScalarType Type ******/
   executorch::aten::ScalarType toScalarType() const {
     ET_CHECK_MSG(isInt(), "EValue is not a ScalarType.");
+    return static_cast<executorch::aten::ScalarType>(
+        payload.copyable_union.as_int);
+  }
+
+  Result<executorch::aten::ScalarType> tryToScalarType() const {
+    if (!isInt()) {
+      return Error::InvalidType;
+    }
     return static_cast<executorch::aten::ScalarType>(
         payload.copyable_union.as_int);
   }
@@ -440,15 +554,40 @@ struct EValue {
         payload.copyable_union.as_int);
   }
 
+  Result<executorch::aten::MemoryFormat> tryToMemoryFormat() const {
+    if (!isInt()) {
+      return Error::InvalidType;
+    }
+    return static_cast<executorch::aten::MemoryFormat>(
+        payload.copyable_union.as_int);
+  }
+
   /****** Layout Type ******/
   executorch::aten::Layout toLayout() const {
     ET_CHECK_MSG(isInt(), "EValue is not a Layout.");
     return static_cast<executorch::aten::Layout>(payload.copyable_union.as_int);
   }
 
+  Result<executorch::aten::Layout> tryToLayout() const {
+    if (!isInt()) {
+      return Error::InvalidType;
+    }
+    return static_cast<executorch::aten::Layout>(payload.copyable_union.as_int);
+  }
+
   /****** Device Type ******/
   executorch::aten::Device toDevice() const {
     ET_CHECK_MSG(isInt(), "EValue is not a Device.");
+    return executorch::aten::Device(
+        static_cast<executorch::aten::DeviceType>(
+            payload.copyable_union.as_int),
+        -1);
+  }
+
+  Result<executorch::aten::Device> tryToDevice() const {
+    if (!isInt()) {
+      return Error::InvalidType;
+    }
     return executorch::aten::Device(
         static_cast<executorch::aten::DeviceType>(
             payload.copyable_union.as_int),
@@ -463,6 +602,15 @@ struct EValue {
   typename internal::evalue_to_ref_overload_return<T>::type to() &;
 
   /**
+   * Result-returning equivalent of `to<T>()`. Returns `Error::InvalidType` on
+   * tag mismatch instead of aborting, so callers processing untrusted EValues
+   * (e.g., from a `.pte`) can surface the error rather than terminate.
+   * Specializations are defined below via `EVALUE_DEFINE_TRY_TO`.
+   */
+  template <typename T>
+  Result<T> tryTo() const;
+
+  /**
    * Converts the EValue to an optional object that can represent both T and
    * an uninitialized state.
    */
@@ -472,6 +620,23 @@ struct EValue {
       return executorch::aten::nullopt;
     }
     return this->to<T>();
+  }
+
+  /**
+   * Result-returning equivalent of `toOptional<T>()`. None maps to an empty
+   * optional; any other tag that doesn't match T propagates `tryTo<T>()`'s
+   * error (`Error::InvalidType`).
+   */
+  template <typename T>
+  inline Result<std::optional<T>> tryToOptional() const {
+    if (this->isNone()) {
+      return std::optional<T>(executorch::aten::nullopt);
+    }
+    auto r = this->tryTo<T>();
+    if (!r.ok()) {
+      return r.error();
+    }
+    return std::optional<T>(std::move(r.get()));
   }
 
  private:
@@ -524,7 +689,7 @@ struct EValue {
 
 #define EVALUE_DEFINE_TO(T, method_name)                                       \
   template <>                                                                  \
-  inline T EValue::to<T>()&& {                                                 \
+  inline T EValue::to<T>() && {                                                \
     return static_cast<T>(std::move(*this).method_name());                     \
   }                                                                            \
   template <>                                                                  \
@@ -538,7 +703,7 @@ struct EValue {
   template <>                                                                  \
   inline ::executorch::runtime::internal::evalue_to_ref_overload_return<       \
       T>::type                                                                 \
-  EValue::to<T>()& {                                                           \
+  EValue::to<T>() & {                                                          \
     typedef ::executorch::runtime::internal::evalue_to_ref_overload_return<    \
         T>::type return_type;                                                  \
     return static_cast<return_type>(this->method_name());                      \
@@ -590,6 +755,33 @@ EVALUE_DEFINE_TO(
     executorch::aten::ArrayRef<std::optional<executorch::aten::Tensor>>,
     toListOptionalTensor)
 #undef EVALUE_DEFINE_TO
+
+#define EVALUE_DEFINE_TRY_TO(T, method_name)  \
+  template <>                                 \
+  inline Result<T> EValue::tryTo<T>() const { \
+    return this->method_name();               \
+  }
+
+EVALUE_DEFINE_TRY_TO(executorch::aten::Scalar, tryToScalar)
+EVALUE_DEFINE_TRY_TO(int64_t, tryToInt)
+EVALUE_DEFINE_TRY_TO(bool, tryToBool)
+EVALUE_DEFINE_TRY_TO(double, tryToDouble)
+EVALUE_DEFINE_TRY_TO(std::string_view, tryToString)
+EVALUE_DEFINE_TRY_TO(executorch::aten::ScalarType, tryToScalarType)
+EVALUE_DEFINE_TRY_TO(executorch::aten::MemoryFormat, tryToMemoryFormat)
+EVALUE_DEFINE_TRY_TO(executorch::aten::Layout, tryToLayout)
+EVALUE_DEFINE_TRY_TO(executorch::aten::Device, tryToDevice)
+EVALUE_DEFINE_TRY_TO(executorch::aten::Tensor, tryToTensor)
+EVALUE_DEFINE_TRY_TO(executorch::aten::ArrayRef<int64_t>, tryToIntList)
+EVALUE_DEFINE_TRY_TO(executorch::aten::ArrayRef<double>, tryToDoubleList)
+EVALUE_DEFINE_TRY_TO(executorch::aten::ArrayRef<bool>, tryToBoolList)
+EVALUE_DEFINE_TRY_TO(
+    executorch::aten::ArrayRef<executorch::aten::Tensor>,
+    tryToTensorList)
+EVALUE_DEFINE_TRY_TO(
+    executorch::aten::ArrayRef<std::optional<executorch::aten::Tensor>>,
+    tryToListOptionalTensor)
+#undef EVALUE_DEFINE_TRY_TO
 
 template <typename T>
 executorch::aten::ArrayRef<T> BoxedEvalueList<T>::get() const {

--- a/runtime/core/test/evalue_test.cpp
+++ b/runtime/core/test/evalue_test.cpp
@@ -417,3 +417,231 @@ TEST_F(EValueTest, toListOptionalTensorNullPointerCheck) {
   EXPECT_TRUE(e.isListOptionalTensor());
   ET_EXPECT_DEATH({ e.toListOptionalTensor(); }, "pointer is null");
 }
+
+TEST_F(EValueTest, TryToTensorSuccess) {
+  TensorFactory<ScalarType::Float> tf;
+  EValue e(tf.ones({3, 2}));
+  auto result = e.tryToTensor();
+  EXPECT_TRUE(result.ok());
+  EXPECT_EQ(result->dim(), 2);
+  EXPECT_EQ(result->numel(), 6);
+}
+
+TEST_F(EValueTest, TryToTensorTypeMismatch) {
+  EValue e(static_cast<int64_t>(42));
+  auto result = e.tryToTensor();
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.error(), executorch::runtime::Error::InvalidType);
+}
+
+TEST_F(EValueTest, TryToOptionalTensorSuccess) {
+  TensorFactory<ScalarType::Float> tf;
+  EValue e(tf.ones({3, 2}));
+  auto result = e.tryToOptional<executorch::aten::Tensor>();
+  EXPECT_TRUE(result.ok());
+  EXPECT_TRUE(result->has_value());
+  EXPECT_EQ(result->value().dim(), 2);
+}
+
+TEST_F(EValueTest, TryToOptionalTensorNone) {
+  EValue e;
+  auto result = e.tryToOptional<executorch::aten::Tensor>();
+  EXPECT_TRUE(result.ok());
+  EXPECT_FALSE(result->has_value());
+}
+
+TEST_F(EValueTest, TryToOptionalTensorTypeMismatch) {
+  EValue e(static_cast<int64_t>(42));
+  auto result = e.tryToOptional<executorch::aten::Tensor>();
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.error(), executorch::runtime::Error::InvalidType);
+}
+
+// Scalar/primitive tryTo* coverage. Each test pair exercises the match and
+// mismatch paths; the type-mismatch check uses an int64_t EValue (or a Tensor
+// EValue when testing tryToInt) to guarantee the tag disagrees.
+
+TEST_F(EValueTest, TryToIntSuccess) {
+  EValue e(static_cast<int64_t>(42));
+  auto result = e.tryToInt();
+  EXPECT_TRUE(result.ok());
+  EXPECT_EQ(result.get(), 42);
+}
+
+TEST_F(EValueTest, TryToIntTypeMismatch) {
+  EValue e(3.14);
+  auto result = e.tryToInt();
+  EXPECT_EQ(result.error(), executorch::runtime::Error::InvalidType);
+}
+
+TEST_F(EValueTest, TryToDoubleSuccess) {
+  EValue e(3.14);
+  auto result = e.tryToDouble();
+  EXPECT_TRUE(result.ok());
+  EXPECT_DOUBLE_EQ(result.get(), 3.14);
+}
+
+TEST_F(EValueTest, TryToDoubleTypeMismatch) {
+  EValue e(static_cast<int64_t>(42));
+  auto result = e.tryToDouble();
+  EXPECT_EQ(result.error(), executorch::runtime::Error::InvalidType);
+}
+
+TEST_F(EValueTest, TryToBoolSuccess) {
+  EValue e(true);
+  auto result = e.tryToBool();
+  EXPECT_TRUE(result.ok());
+  EXPECT_EQ(result.get(), true);
+}
+
+TEST_F(EValueTest, TryToBoolTypeMismatch) {
+  EValue e(static_cast<int64_t>(42));
+  auto result = e.tryToBool();
+  EXPECT_EQ(result.error(), executorch::runtime::Error::InvalidType);
+}
+
+TEST_F(EValueTest, TryToScalarFromInt) {
+  EValue e(static_cast<int64_t>(7));
+  auto result = e.tryToScalar();
+  EXPECT_TRUE(result.ok());
+  EXPECT_EQ(result->to<int64_t>(), 7);
+}
+
+TEST_F(EValueTest, TryToScalarFromDouble) {
+  EValue e(2.5);
+  auto result = e.tryToScalar();
+  EXPECT_TRUE(result.ok());
+  EXPECT_DOUBLE_EQ(result->to<double>(), 2.5);
+}
+
+TEST_F(EValueTest, TryToScalarFromBool) {
+  EValue e(true);
+  auto result = e.tryToScalar();
+  EXPECT_TRUE(result.ok());
+  EXPECT_EQ(result->to<bool>(), true);
+}
+
+TEST_F(EValueTest, TryToScalarNoneTag) {
+  // None is neither Int/Double/Bool, so tryToScalar must reject it.
+  EValue e;
+  auto result = e.tryToScalar();
+  EXPECT_EQ(result.error(), executorch::runtime::Error::InvalidType);
+}
+
+TEST_F(EValueTest, TryToScalarTypeTagReturnsScalarType) {
+  // ScalarType/MemoryFormat/Layout/Device share the Int tag; exercise each.
+  EValue e(static_cast<int64_t>(static_cast<int>(ScalarType::Float)));
+  auto st = e.tryToScalarType();
+  EXPECT_TRUE(st.ok());
+  EXPECT_EQ(st.get(), ScalarType::Float);
+}
+
+TEST_F(EValueTest, TryToScalarTypeTypeMismatch) {
+  EValue e(3.14);
+  auto result = e.tryToScalarType();
+  EXPECT_EQ(result.error(), executorch::runtime::Error::InvalidType);
+}
+
+TEST_F(EValueTest, TryToMemoryFormatTypeMismatch) {
+  EValue e(3.14);
+  auto result = e.tryToMemoryFormat();
+  EXPECT_EQ(result.error(), executorch::runtime::Error::InvalidType);
+}
+
+TEST_F(EValueTest, TryToLayoutTypeMismatch) {
+  EValue e(3.14);
+  auto result = e.tryToLayout();
+  EXPECT_EQ(result.error(), executorch::runtime::Error::InvalidType);
+}
+
+TEST_F(EValueTest, TryToDeviceTypeMismatch) {
+  EValue e(3.14);
+  auto result = e.tryToDevice();
+  EXPECT_EQ(result.error(), executorch::runtime::Error::InvalidType);
+}
+
+// List tryTo* — mismatch paths. Success paths require building a
+// BoxedEvalueList or ArrayRef host object, which the non-list tests above
+// already cover via the shared tag-check logic; one mismatch test per list
+// type is enough to exercise the added code.
+
+TEST_F(EValueTest, TryToIntListTypeMismatch) {
+  EValue e(static_cast<int64_t>(42));
+  auto result = e.tryToIntList();
+  EXPECT_EQ(result.error(), executorch::runtime::Error::InvalidType);
+}
+
+TEST_F(EValueTest, TryToDoubleListTypeMismatch) {
+  EValue e(static_cast<int64_t>(42));
+  auto result = e.tryToDoubleList();
+  EXPECT_EQ(result.error(), executorch::runtime::Error::InvalidType);
+}
+
+TEST_F(EValueTest, TryToBoolListTypeMismatch) {
+  EValue e(static_cast<int64_t>(42));
+  auto result = e.tryToBoolList();
+  EXPECT_EQ(result.error(), executorch::runtime::Error::InvalidType);
+}
+
+TEST_F(EValueTest, TryToTensorListTypeMismatch) {
+  EValue e(static_cast<int64_t>(42));
+  auto result = e.tryToTensorList();
+  EXPECT_EQ(result.error(), executorch::runtime::Error::InvalidType);
+}
+
+TEST_F(EValueTest, TryToListOptionalTensorTypeMismatch) {
+  EValue e(static_cast<int64_t>(42));
+  auto result = e.tryToListOptionalTensor();
+  EXPECT_EQ(result.error(), executorch::runtime::Error::InvalidType);
+}
+
+TEST_F(EValueTest, TryToStringTypeMismatch) {
+  EValue e(static_cast<int64_t>(42));
+  auto result = e.tryToString();
+  EXPECT_EQ(result.error(), executorch::runtime::Error::InvalidType);
+}
+
+// Templated tryTo<T>() dispatcher. Matches and mismatches should behave
+// identically to the named tryToX methods.
+
+TEST_F(EValueTest, TryToTemplateIntSuccess) {
+  EValue e(static_cast<int64_t>(42));
+  auto result = e.tryTo<int64_t>();
+  EXPECT_TRUE(result.ok());
+  EXPECT_EQ(result.get(), 42);
+}
+
+TEST_F(EValueTest, TryToTemplateIntMismatch) {
+  EValue e(3.14);
+  auto result = e.tryTo<int64_t>();
+  EXPECT_EQ(result.error(), executorch::runtime::Error::InvalidType);
+}
+
+TEST_F(EValueTest, TryToTemplateTensorSuccess) {
+  TensorFactory<ScalarType::Float> tf;
+  EValue e(tf.ones({3, 2}));
+  auto result = e.tryTo<executorch::aten::Tensor>();
+  EXPECT_TRUE(result.ok());
+  EXPECT_EQ(result->numel(), 6);
+}
+
+TEST_F(EValueTest, TryToOptionalIntSuccess) {
+  EValue e(static_cast<int64_t>(42));
+  auto result = e.tryToOptional<int64_t>();
+  EXPECT_TRUE(result.ok());
+  EXPECT_TRUE(result->has_value());
+  EXPECT_EQ(result->value(), 42);
+}
+
+TEST_F(EValueTest, TryToOptionalIntNone) {
+  EValue e;
+  auto result = e.tryToOptional<int64_t>();
+  EXPECT_TRUE(result.ok());
+  EXPECT_FALSE(result->has_value());
+}
+
+TEST_F(EValueTest, TryToOptionalIntTypeMismatch) {
+  EValue e(3.14);
+  auto result = e.tryToOptional<int64_t>();
+  EXPECT_EQ(result.error(), executorch::runtime::Error::InvalidType);
+}


### PR DESCRIPTION
Introduce `tryTo` versions of each Evalue accessor.

Current accessors `toTensor()`, etc. abort with `ET_CHECK_MSG` when it's an incorrect type.

API additions:
- Per-type: tryToInt, tryToDouble, tryToBool, tryToScalar, tryToString,
  tryToTensor (already present, kept), tryToIntList, tryToBoolList,
  tryToDoubleList, tryToTensorList, tryToListOptionalTensor,
  tryToScalarType, tryToMemoryFormat, tryToLayout, tryToDevice.
  Tag mismatch returns Error::InvalidType; null list/string payload
  returns Error::InvalidState.
- Templated tryTo<T>() dispatcher mirroring to<T>(), via a new
  EVALUE_DEFINE_TRY_TO macro kept adjacent to EVALUE_DEFINE_TO so drift
  between the two surfaces is visible at review time.
- tryToOptional<T>() widened from Tensor-only to generic, delegating
  to tryTo<T>() so it works for any supported payload type.

Tests cover success + mismatch paths for each new accessor, plus the
widened tryToOptional<T>() path.

Authored-with: Claude