### PR TITLE
memory planner to allocate element-wise output buffer in place of input (#19067)

### DIFF
--- a/exir/capture/_config.py
+++ b/exir/capture/_config.py
@@ -6,7 +6,7 @@
 
 # pyre-unsafe
 from dataclasses import dataclass, field
-from typing import Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, FrozenSet, List, Optional, Union
 
 import torch
 
@@ -135,3 +135,9 @@ class ExecutorchBackendConfig:
     # Useful for cross-method GPU pipelines where the next method consumes
     # GPU tensors directly.
     skip_d2h_for_method_outputs: bool = False
+
+    # Add ops to the set of re-inplace ops to be used by the reinplace pass.
+    # Re-inplace pass checks the eligibility of an op to be re-inplaced and
+    # memory planning pass allcoates the output buffer of the op to be the same
+    # as the input buffer.
+    reinplace_extra_ops: Optional[FrozenSet[Any]] = None

--- a/exir/memory_planning.py
+++ b/exir/memory_planning.py
@@ -191,9 +191,16 @@ class Verifier:
                 if not allow_lifetime_and_storage_overlap and self.lifetime_overlap(
                     lhs_spec, rhs_spec
                 ):
-                    raise InternalError(
-                        f"Unexpected storage overlap: {Verifier._debug_message_from_specs(lhs_spec, rhs_spec)}"
+                    # In-place element-wise ops intentionally share storage
+                    # between input and output despite overlapping lifetimes.
+                    is_inplace_pair = (
+                        lhs_spec.inplace_base is rhs_spec
+                        or rhs_spec.inplace_base is lhs_spec
                     )
+                    if not is_inplace_pair:
+                        raise InternalError(
+                            f"Unexpected storage overlap: {Verifier._debug_message_from_specs(lhs_spec, rhs_spec)}"
+                        )
 
                 # Check that each mem_obj_id is consistent with whether the tensors have
                 # storage overlap
@@ -932,6 +939,86 @@ def _contains_xnnpack_delegate(graph_module: torch.fx.GraphModule) -> bool:
     return False
 
 
+def _resolve_inplace_specs(
+    deferred_inplace: List[TensorSpec],
+    spec2obj: Dict[TensorSpec, SharedObject],
+    greedy_result: MemoryAlgoResult,
+) -> None:
+    remaining = list(deferred_inplace)
+    while remaining:
+        progress = False
+        next_remaining = []
+        for spec in remaining:
+            base = spec.inplace_base
+            if base not in spec2obj:
+                next_remaining.append(spec)
+                continue
+            progress = True
+            sobj = spec2obj[base]
+
+            base_alloc_result = greedy_result.spec_dict[base]
+            spec_alloc_result = greedy_result.spec_dict[spec]
+            spec_alloc_result.mem_id = base_alloc_result.mem_id
+
+            base_alloc_offset = None
+            for alloc_entry in sobj.allocations:
+                if alloc_entry.spec is base:
+                    base_alloc_offset = alloc_entry.offset
+                    break
+            assert base_alloc_offset is not None, (
+                f"Base allocation entry not found in shared object for spec "
+                f"with allocated_memory={spec.allocated_memory}"
+            )
+            sobj.first_used_index = min(sobj.first_used_index, spec.lifetime[0])
+            sobj.last_used_index = max(sobj.last_used_index, spec.lifetime[1])
+            sobj.allocations.append(AllocationSpec(base_alloc_offset, spec))
+            spec2obj[spec] = sobj
+        if not progress:
+            unresolved = ", ".join(
+                f"allocated_memory={s.allocated_memory}" for s in next_remaining
+            )
+            raise InternalError(
+                f"Circular or unresolvable in-place dependency chain: {unresolved}"
+            )
+        remaining = next_remaining
+
+
+def _compute_total_sizes(
+    shared_objects: Dict[int, List[SharedObject]],
+    graph_module: torch.fx.GraphModule,
+    extra_padding: int,
+    greedy_result: MemoryAlgoResult,
+    num_specs_expected: int,
+) -> List[int]:
+    if len(shared_objects) == 0:
+        return [0, 0]
+
+    total_sizes = [0] * (max(shared_objects.keys()) + 1)
+    num_specs_processed = 0
+    for mem_id in shared_objects:
+        input_total_size = 0
+        if bufsizes := getattr(graph_module, "input_mem_buffer_sizes", None):
+            assert isinstance(bufsizes, list)
+            if len(bufsizes) > mem_id:
+                input_total_size = bufsizes[mem_id]
+        total_sizes[mem_id] = materialize_buffer(
+            shared_objects[mem_id], input_total_size
+        )
+        total_sizes[mem_id] += extra_padding
+
+        for sobj in shared_objects[mem_id]:
+            for alloc in sobj.allocations:
+                spec_alloc_result = greedy_result.spec_dict.get(alloc.spec, None)
+                assert spec_alloc_result is not None, f"Spec {alloc.spec} not found."
+                spec_alloc_result.mem_obj_id = sobj.idx
+                spec_alloc_result.mem_offset = sobj.offset + alloc.offset
+                num_specs_processed += 1
+    assert (
+        num_specs_expected == num_specs_processed
+    ), f"All specs should be processed but there were {num_specs_expected} specs and processed {num_specs_processed} specs"
+    return total_sizes
+
+
 def greedy(
     alignment: int,
     specs: Set[TensorSpec],
@@ -958,12 +1045,9 @@ def greedy(
         MemoryAlgoResult containing the allocation decisions
     """
     greedy_result = MemoryAlgoResult({}, [])
-    spec2obj = {}
-    shared_objects = defaultdict(list)
+    spec2obj: Dict[TensorSpec, SharedObject] = {}
+    shared_objects: Dict[int, List[SharedObject]] = defaultdict(list)
 
-    # For each tensor, pick the available shared object with closest size to
-    # the tensor. If there are no available shared object left, create a new
-    # one.
     import bisect
 
     sorted_specs = []
@@ -972,9 +1056,9 @@ def greedy(
 
     sorted_specs.reverse()
 
+    deferred_inplace: List[TensorSpec] = []
+
     for spec in sorted_specs:
-        # Create an entry for this TensorSpec in the result object that we'll be
-        # returning from this algorithm.
         spec_alloc_result = greedy_result.spec_dict.get(spec, SpecAllocResult(0, 0, 0))
         if spec.mem_id is None:
             spec_alloc_result.mem_id = 1
@@ -982,46 +1066,22 @@ def greedy(
             spec_alloc_result.mem_id = spec.mem_id
         greedy_result.spec_dict[spec] = spec_alloc_result
         spec.realign(alignment)
+
+        if spec.inplace_base is not None:
+            deferred_inplace.append(spec)
+            continue
+
         spec2obj[spec] = pick_shared_obj(
             shared_objects[spec_alloc_result.mem_id],
             spec,
             allow_overlapping_allocations,
         )
 
-    if len(shared_objects) == 0:
-        # Cannot find any tensor in the graph that needs to be allocated.
-        # Return [0, 0] to be consistent with default behavior of naive.
-        total_sizes = [0, 0]
-    else:
-        total_sizes = [0] * (max(shared_objects.keys()) + 1)
-        num_specs_processed = 0
-        for mem_id in shared_objects:
-            input_total_size = 0
-            if bufsizes := getattr(graph_module, "input_mem_buffer_sizes", None):
-                assert isinstance(bufsizes, list)
-                if len(bufsizes) > mem_id:
-                    input_total_size = bufsizes[mem_id]
-            total_sizes[mem_id] = materialize_buffer(
-                shared_objects[mem_id], input_total_size
-            )
-            total_sizes[mem_id] += extra_padding
+    _resolve_inplace_specs(deferred_inplace, spec2obj, greedy_result)
 
-            # Since we now know the number of shared objects we need and the size of
-            # each shared object, we can assign offset in the memory buffer for each
-            # shared object.
-            for sobj in shared_objects[mem_id]:
-                for alloc in sobj.allocations:
-                    spec = alloc.spec
-                    # Get the spec_alloc_result for this spec and update it with the
-                    # mem_obj_id and mem_offset generated by this algorithm.
-                    spec_alloc_result = greedy_result.spec_dict.get(spec, None)
-                    assert spec_alloc_result is not None, f"Spec {spec} not found."
-                    spec_alloc_result.mem_obj_id = sobj.idx
-                    spec_alloc_result.mem_offset = sobj.offset + alloc.offset
-                    num_specs_processed += 1
-        assert (
-            len(spec2obj) == num_specs_processed
-        ), f"All specs should be processed but there were {len(spec2obj)} specs and processed {num_specs_processed} specs"
+    total_sizes = _compute_total_sizes(
+        shared_objects, graph_module, extra_padding, greedy_result, len(spec2obj)
+    )
 
     logging.debug(f"greedy algorithm returns bufsizes: {total_sizes}")
     greedy_result.bufsizes = total_sizes
@@ -1146,6 +1206,12 @@ def naive(
     bufsizes = cast(List[int], bufsizes)
 
     for spec in specs:
+        if spec.inplace_base is not None:
+            raise InternalError(
+                "The naive memory planning algorithm does not support in-place "
+                "element-wise ops (inplace_base). Use the greedy algorithm instead."
+            )
+
         spec_alloc_result = naive_result.spec_dict.get(spec, SpecAllocResult(0, 0, 0))
         # assume a single memory layer which has mem_id 1
         if spec.mem_id is None:

--- a/exir/passes/memory_planning_pass.py
+++ b/exir/passes/memory_planning_pass.py
@@ -194,6 +194,13 @@ class MemoryPlanningPass(PassBase):
                     if len(out_arg_names) == 1:
                         out_alloc_node = node.kwargs[out_arg_names[0]]
                         out_alloc_node.meta["spec"] = node.meta["spec"]
+                        share_idx = node.meta.get("_share_alloc_with_arg_idx")
+                        if share_idx is not None and share_idx < len(node.args):
+                            input_node = node.args[share_idx]
+                            if isinstance(input_node, Node):
+                                base_spec = input_node.meta.get("spec")
+                                if isinstance(base_spec, TensorSpec):
+                                    node.meta["spec"].inplace_base = base_spec
                         continue
                     specs = get_node_tensor_specs(node)
                     i = 0

--- a/exir/passes/reinplace.py
+++ b/exir/passes/reinplace.py
@@ -6,7 +6,7 @@
 
 # pyre-strict
 
-from typing import Any, Dict, FrozenSet, Iterable, Optional, Set, Tuple
+from typing import Any, Dict, FrozenSet, Iterable, Optional, Set, Tuple, Union
 
 import torch
 from executorch.exir.dialects._ops import ops
@@ -339,20 +339,17 @@ def reinplace_pass(  # noqa: C901
     # Overrides also enroll their key in the candidate set.
     op_set.update(overrides.keys())
 
-    # Validate every entry up front and pre-compute mutated_args so we
-    # don't re-do the schema introspection per node.
-    resolved: Dict[Any, Tuple[Any, Tuple[int, ...]]] = {}
+    _ANNOTATION_ONLY: Tuple[None, None] = (None, None)
+
+    resolved: Dict[Any, Union[Tuple[Any, Tuple[int, ...]], Tuple[None, None]]] = {}
     for functional_op in op_set:
         if functional_op in overrides:
             inplace_op = overrides[functional_op]
         else:
             inplace_op = _derive_edge_inplace_overload(functional_op)
             if inplace_op is None:
-                raise ValueError(
-                    f"Cannot auto-derive in-place form for "
-                    f"{functional_op}. Provide an explicit mapping via "
-                    f"`inplace_overrides={{{functional_op}: <inplace_op>}}`."
-                )
+                resolved[functional_op] = _ANNOTATION_ONLY
+                continue
         _validate_inplace_mapping(functional_op, inplace_op)
         mutated_args = _derive_mutated_args(inplace_op)
         resolved[functional_op] = (inplace_op, mutated_args)
@@ -371,62 +368,71 @@ def reinplace_pass(  # noqa: C901
     }
 
     for node in reversed(ep.graph.nodes):
-        entry = resolved.get(node.target) if node.op == "call_function" else None
-        if entry is not None:
-            inplace_op, mutated_args = entry
-            # Every mutated arg position must independently be safe.
-            all_safe = True
-            for arg_idx in mutated_args:
-                if arg_idx >= len(node.args):
-                    raise ValueError(
-                        f"reinplace: {node.target} call at {node} has "
-                        f"{len(node.args)} positional args, but the "
-                        f"schema declares position {arg_idx} as "
-                        f"Tensor(a!). Export should normalize mutated "
-                        f"args to positional; this graph violates that "
-                        f"assumption."
-                    )
-                arg_node = node.args[arg_idx]
-                if not isinstance(arg_node, torch.fx.Node):
-                    raise ValueError(
-                        f"reinplace: {node.target} call at {node} has a "
-                        f"non-Node value {arg_node!r} at position "
-                        f"{arg_idx}, but the schema declares it as "
-                        f"Tensor(a!). A Tensor input in an FX graph "
-                        f"must be a torch.fx.Node."
-                    )
-                if not _is_safe_to_reinplace(
-                    arg_node, seen_nodes, inputs, mutable_nodes
-                ):
-                    all_safe = False
+        if node.op != "call_function" or node.target not in resolved:
+            if node.op == "call_function":
+                seen_nodes.update(node.all_input_nodes)
+            continue
+
+        entry = resolved[node.target]
+
+        if entry is _ANNOTATION_ONLY:
+            first_tensor_idx = None
+            for idx, arg in enumerate(node.args):
+                if isinstance(arg, torch.fx.Node):
+                    first_tensor_idx = idx
                     break
-            if all_safe:
-                with ep.graph.inserting_before(node):
-                    # Forward both args and kwargs: the in-place overload
-                    # is schema-matched to the functional one, so any
-                    # kwarg valid on the functional op (e.g.
-                    # `accumulate=` for `index_put`) is also valid on
-                    # the in-place form. Dropping kwargs would silently
-                    # change semantics.
-                    new_node = ep.graph.call_function(
-                        inplace_op,
-                        args=node.args,
-                        kwargs=node.kwargs,
-                    )
-                    new_node.meta["val"] = node.meta["val"]
-                    node.replace_all_uses_with(new_node)
-                    ep.graph.erase_node(node)
-                # No explicit `seen_nodes` update needed: the new
-                # in-place node's target isn't in `op_set`, so the
-                # reverse iterator visits it next and falls through
-                # to the generic update below.
+            if first_tensor_idx is not None and _is_safe_to_reinplace(
+                node.args[first_tensor_idx],  # pyre-ignore[6]
+                seen_nodes,
+                inputs,
+                mutable_nodes,
+            ):
+                node.meta["_share_alloc_with_arg_idx"] = first_tensor_idx
                 continue
-        # Note: this intentionally falls through for mapping-matched
-        # nodes that failed the safety check. Their inputs *are* added
-        # to seen_nodes, so further-upstream candidates correctly see
-        # those tensors as "used later" and refuse to reinplace any op
-        # that mutates them.
-        # See test_unsafe_downstream_blocks_upstream_reinplace.
-        if node.op == "call_function":
             seen_nodes.update(node.all_input_nodes)
+            continue
+
+        inplace_op, mutated_args = entry
+        all_safe = True
+        for arg_idx in mutated_args:
+            if arg_idx >= len(node.args):
+                raise ValueError(
+                    f"reinplace: {node.target} call at {node} has "
+                    f"{len(node.args)} positional args, but the "
+                    f"schema declares position {arg_idx} as "
+                    f"Tensor(a!). Export should normalize mutated "
+                    f"args to positional; this graph violates that "
+                    f"assumption."
+                )
+            arg_node = node.args[arg_idx]
+            if not isinstance(arg_node, torch.fx.Node):
+                raise ValueError(
+                    f"reinplace: {node.target} call at {node} has a "
+                    f"non-Node value {arg_node!r} at position "
+                    f"{arg_idx}, but the schema declares it as "
+                    f"Tensor(a!). A Tensor input in an FX graph "
+                    f"must be a torch.fx.Node."
+                )
+            if not _is_safe_to_reinplace(arg_node, seen_nodes, inputs, mutable_nodes):
+                all_safe = False
+                break
+        if all_safe:
+            with ep.graph.inserting_before(node):
+                # Forward both args and kwargs: the in-place overload
+                # is schema-matched to the functional one, so any
+                # kwarg valid on the functional op (e.g.
+                # `accumulate=` for `index_put`) is also valid on
+                # the in-place form. Dropping kwargs would silently
+                # change semantics.
+                new_node = ep.graph.call_function(
+                    inplace_op,
+                    args=node.args,
+                    kwargs=node.kwargs,
+                )
+                new_node.meta["val"] = node.meta["val"]
+                node.replace_all_uses_with(new_node)
+                ep.graph.erase_node(node)
+            continue
+
+        seen_nodes.update(node.all_input_nodes)
     return ep

--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -61,7 +61,7 @@ from executorch.exir.passes.normalize_view_copy_base_pass import (
 )
 from executorch.exir.passes.propagate_device_pass import PropagateDevicePass
 from executorch.exir.passes.quant_fusion_pass import quant_fusion_and_const_prop_pass
-from executorch.exir.passes.reinplace import reinplace_pass
+from executorch.exir.passes.reinplace import DEFAULT_INPLACEABLE_OPS, reinplace_pass
 from executorch.exir.passes.remove_graph_asserts_pass import (
     RemoveGraphAssertsPass,
     RemoveNonCoreAtenOpGraphAssertsPass,
@@ -1683,8 +1683,12 @@ class EdgeProgramManager:
                         " Please set do_quant_fusion_and_const_prop to False in the ExecutorchBackendConfig."
                     )
                 program = quant_fusion_and_const_prop_pass(program)
-            if config.run_reinplace_pass:
-                program = reinplace_pass(program)
+            if config.run_reinplace_pass or config.reinplace_extra_ops:
+                extra = config.reinplace_extra_ops or frozenset()
+                program = reinplace_pass(
+                    program,
+                    ops_to_inplace=DEFAULT_INPLACEABLE_OPS | extra,
+                )
             program = weights_to_outputs_pass(program)
             program = unsafe_remove_auto_functionalized_pass(program)
             gm, new_signature = insert_write_back_for_buffers_pass(program)

--- a/exir/tensor.py
+++ b/exir/tensor.py
@@ -214,6 +214,9 @@ class TensorSpec:
         self.mem_id = None
         self.mem_obj_id = None
         self.mem_offset = None
+        # Set by InPlaceElemWiseLikeOpsPass: the base TensorSpec whose memory
+        # this spec should share (output allocated in-place over the input).
+        self.inplace_base: Optional["TensorSpec"] = None
 
     @property
     def dtype(self) -> torch.dtype:

--- a/exir/tests/test_memory_planning.py
+++ b/exir/tests/test_memory_planning.py
@@ -29,6 +29,7 @@ from executorch.exir.capture._capture import patch_forward
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.memory_planning import (
     _do_user_inputs_exist,
+    _is_inplace_node,
     apply_algo,
     collect_specs_from_nodes,
     filter_nodes,
@@ -1650,3 +1651,117 @@ class TestDeviceAwareMemoryPlanning(unittest.TestCase):
         self.assertEqual(bufsizes[0], 0)
         self.assertGreater(bufsizes[1], 0)
         self.assertNotIn("non_const_buffer_device", gm.meta)
+
+
+class TestInPlaceElemWise(unittest.TestCase):
+    def _run_inplace_pipeline(
+        self,
+        model: torch.nn.Module,
+        inputs: Tuple[torch.Tensor, ...],
+        eligible_ops: set,  # pyre-ignore[2]
+        algo: Callable[..., MemoryAlgoResult] = greedy,
+    ) -> torch.fx.GraphModule:
+        edge = to_edge(export(model.eval(), inputs, strict=True))
+        ep = edge.exported_program()
+        reinplace_pass(ep, ops_to_inplace=eligible_ops)
+        graph_module = ep.graph_module
+        mem_algo = MemoryPlanningAlgorithmSuite(algo_list=[algo])
+        return PassManager(
+            passes=[
+                SpecPropPass(),
+                ToOutVarPass(),
+                MemoryPlanningPass(
+                    memory_planning_algo=mem_algo,
+                    alignment=1,
+                ),
+            ],
+        )(graph_module).graph_module
+
+    def test_basic_inplace_sharing(self) -> None:
+        class Model(torch.nn.Module):
+            def forward(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+                c = a + b
+                d = c * b
+                return d
+
+        gm = self._run_inplace_pipeline(
+            Model(),
+            (torch.randn(10), torch.randn(10)),
+            {exir_ops.edge.aten.mul.Tensor},
+        )
+
+        add_spec = None
+        inplace_node_found = False
+        for node in gm.graph.nodes:
+            if node.op != "call_function":
+                continue
+            if node.target == torch.ops.aten.add.out:
+                add_spec = node.meta["spec"]
+            if _is_inplace_node(node):
+                inplace_node_found = True
+                self.assertIs(node.meta["spec"], add_spec)
+
+        self.assertIsNotNone(add_spec)
+        self.assertTrue(inplace_node_found)
+
+    def test_verifier_allows_inplace_overlap(self) -> None:
+        class Model(torch.nn.Module):
+            def forward(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+                c = a + b
+                d = c * b
+                return d
+
+        gm = self._run_inplace_pipeline(
+            Model(),
+            (torch.randn(10), torch.randn(10)),
+            {exir_ops.edge.aten.mul.Tensor},
+        )
+
+        verifier = Verifier(
+            gm,
+            alloc_graph_input=True,
+            alloc_graph_output=True,
+            alloc_mutable_buffers=True,
+        )
+        verifier.verify_storage_reuse()
+
+    def test_multi_user_blocks_inplace(self) -> None:
+        class Model(torch.nn.Module):
+            def forward(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+                c = a + b
+                d = c * b
+                e = c + d
+                return e
+
+        gm = self._run_inplace_pipeline(
+            Model(),
+            (torch.randn(10), torch.randn(10)),
+            {exir_ops.edge.aten.mul.Tensor},
+        )
+
+        has_mul_out = any(
+            node.target == torch.ops.aten.mul.out
+            for node in gm.graph.nodes
+            if node.op == "call_function"
+        )
+        self.assertTrue(has_mul_out)
+
+    def test_no_inplace_when_ops_not_eligible(self) -> None:
+        class Model(torch.nn.Module):
+            def forward(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+                c = a + b
+                d = c * b
+                return d
+
+        gm = self._run_inplace_pipeline(
+            Model(),
+            (torch.randn(10), torch.randn(10)),
+            set(),
+        )
+
+        has_inplace = any(
+            _is_inplace_node(node)
+            for node in gm.graph.nodes
+            if node.op == "call_function"
+        )
+        self.assertFalse(has_inplace)


### PR DESCRIPTION
Summary:

The re-inplace pass annotate the output as a new alloc type called `memory.alloc_inplace`.
In memory planning, the nodes with output spec type of `alloc_inplace` get output allocation in place of the same node's input.

Reviewed By: JacobSzwejbka

Differential Revision: D100371295


