### PR TITLE
Android: improve error diagnostics for LlmModule and exceptions

### DIFF
--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/ExecutorchRuntimeException.java
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/ExecutorchRuntimeException.java
@@ -161,6 +161,11 @@ public class ExecutorchRuntimeException extends RuntimeException {
     this.errorCode = errorCode;
   }
 
+  public ExecutorchRuntimeException(int errorCode, String details, Throwable cause) {
+    super(ErrorHelper.formatMessage(errorCode, details), cause);
+    this.errorCode = errorCode;
+  }
+
   /** Returns the numeric error code from {@code runtime/core/error.h}. */
   public int getErrorCode() {
     return errorCode;

--- a/extension/android/jni/jni_layer_llama.cpp
+++ b/extension/android/jni/jni_layer_llama.cpp
@@ -10,6 +10,7 @@
 #include <cstdint>
 #include <cstring>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -594,21 +595,22 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
 
   jint load() {
     if (!runner_) {
-      ET_LOG(
-          Error,
-          "ExecuTorchLlmJni::load() called but runner_ is null. "
-          "The model runner was not created or failed to initialize due to a "
-          "previous configuration or initialization error. "
-          "Model type category: %d.",
-          model_type_category_);
+      std::stringstream ss;
+      ss << "Model runner was not created. model_type_category="
+         << model_type_category_
+         << ". Valid values: " << MODEL_TYPE_CATEGORY_LLM
+         << " (LLM), " << MODEL_TYPE_CATEGORY_MULTIMODAL << " (Multimodal)";
+      executorch::jni_helper::throwExecutorchException(
+          static_cast<uint32_t>(Error::InvalidState), ss.str().c_str());
       return static_cast<jint>(Error::InvalidState);
     }
     const auto load_result = static_cast<jint>(runner_->load());
     if (load_result != static_cast<jint>(Error::Ok)) {
-      ET_LOG(
-          Error,
-          "ExecuTorchLlmJni::load() failed in runner_->load() with error code %d.",
-          static_cast<int>(load_result));
+      std::stringstream ss;
+      ss << "Failed to load model runner [error code: 0x"
+         << std::hex << load_result << "]";
+      executorch::jni_helper::throwExecutorchException(
+          static_cast<uint32_t>(load_result), ss.str().c_str());
     }
     return load_result;
   }

--- a/extension/android/jni/jni_layer_llama.cpp
+++ b/extension/android/jni/jni_layer_llama.cpp
@@ -598,19 +598,16 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
       std::stringstream ss;
       ss << "Model runner was not created. model_type_category="
          << model_type_category_
-         << ". Valid values: " << MODEL_TYPE_CATEGORY_LLM
-         << " (LLM), " << MODEL_TYPE_CATEGORY_MULTIMODAL << " (Multimodal)";
+         << ". Valid values: " << MODEL_TYPE_CATEGORY_LLM << " (LLM), "
+         << MODEL_TYPE_CATEGORY_MULTIMODAL << " (Multimodal)";
       executorch::jni_helper::throwExecutorchException(
           static_cast<uint32_t>(Error::InvalidState), ss.str().c_str());
       return static_cast<jint>(Error::InvalidState);
     }
     const auto load_result = static_cast<jint>(runner_->load());
     if (load_result != static_cast<jint>(Error::Ok)) {
-      std::stringstream ss;
-      ss << "Failed to load model runner [error code: 0x"
-         << std::hex << load_result << "]";
       executorch::jni_helper::throwExecutorchException(
-          static_cast<uint32_t>(load_result), ss.str().c_str());
+          static_cast<uint32_t>(load_result), "Failed to load model runner");
     }
     return load_result;
   }


### PR DESCRIPTION
Add cause-chaining constructor to ExecutorchRuntimeException so wrapped exceptions preserve the original cause in the stack trace.

Restore detailed native error messages in LlmModule.load() — the null runner case now reports the model_type_category and valid values instead of a generic message. Load failures now throw from JNI with the specific error code and description.

This commit was authored with the help of Claude.
