### PR TITLE
Ethos Driver Backwards Compatibility (#19116)

### DIFF
--- a/backends/arm/runtime/EthosUBackend_Cortex_M.cpp
+++ b/backends/arm/runtime/EthosUBackend_Cortex_M.cpp
@@ -24,6 +24,24 @@ using executorch::runtime::BackendExecutionContext;
 using executorch::runtime::Error;
 using executorch::runtime::Span;
 
+// Compatibility hooks for multi-device driver / non-multi-device driver code
+// When multi-device driver code is available, these declarations are overridden
+extern "C" __attribute__((weak)) int ethosu_get_product_config_from_cop_data(
+    const void*,
+    const int,
+    uint32_t* product_out,
+    uint32_t* log2_macs_out) {
+  *product_out = 0;
+  *log2_macs_out = 0;
+  return 0;
+}
+
+extern "C" __attribute__((weak)) struct ethosu_driver* ethosu_reserve_driver_ex(
+    uint32_t,
+    uint32_t) {
+  return ethosu_reserve_driver();
+}
+
 namespace executorch {
 namespace backends {
 namespace arm {
@@ -48,12 +66,20 @@ Error platform_execute(
     int output_count,
     Span<executorch::runtime::EValue*> args,
     char* ethosu_scratch) {
+  // Parse product config from command stream to reserve the correct driver
+  uint32_t product, log2_macs;
+  if (ethosu_get_product_config_from_cop_data(
+          handles.cmd_data, handles.cmd_data_size, &product, &log2_macs) != 0) {
+    ET_LOG(Error, "Failed to parse product config from command stream");
+    return Error::InvalidProgram;
+  }
+
   // Allocate driver handle and synchronously invoke driver
   auto driver =
       std::unique_ptr<ethosu_driver, decltype(&ethosu_release_driver)>(
-          ethosu_reserve_driver(), ethosu_release_driver);
+          ethosu_reserve_driver_ex(product, log2_macs), ethosu_release_driver);
   if (driver == nullptr) {
-    ET_LOG(Error, "ethosu_reserve_driver failed");
+    ET_LOG(Error, "ethosu_reserve_driver_ex failed");
     return Error::InvalidState;
   }
 

--- a/backends/arm/runtime/targets.bzl
+++ b/backends/arm/runtime/targets.bzl
@@ -29,7 +29,7 @@ def define_common_targets():
             "//executorch/runtime/backend:interface",
             ":vela_bin_stream",
             "//executorch/runtime/core:core",
-            "fbsource//third-party/ethos-u-core-driver:core_driver",
+            "fbsource//third-party/ethos-u-core-driver:core_driver_headers_only",
         ],
     )
     runtime.cxx_library(


### PR DESCRIPTION
Summary:

The version of ethos driver that supports multiple devices / multiple
NPUs has a few breaking API changes. Installing backwards compatibility hooks
so that Executorch continues to work with both old and new driver code.

It adds the new APIs as weak definitions and redirects to old driver code. If
new driver code is available, those definitions override the weak definitions.

Driver code ref:
https://gitlab.arm.com/artificial-intelligence/ethos-u/ethos-u-core-driver/-/blob/experimental/multidevice/README.md?ref_type=heads#experimental---multi-device

Reviewed By: digantdesai

Differential Revision: D102359186


