### PR TITLE
Arm backend: Add TOSA.AVG_POOL2D_ADAPTIVE op

### DIFF
--- a/backends/arm/_passes/rewrite_avg_pool2d_pass.py
+++ b/backends/arm/_passes/rewrite_avg_pool2d_pass.py
@@ -42,7 +42,7 @@ class RewriteAvgPool2dPass(ArmPass):
 
         pad_h, pad_w = to_2tuple(args[3]) if len(args) > 3 else (0, 0)
         # Make sure pad corresponds to TOSA
-        pad = [pad_h, pad_w, pad_h, pad_w]
+        pad = [pad_h, pad_h, pad_w, pad_w]
 
         ceil_mode = args[4] if len(args) > 4 else False
 

--- a/backends/arm/test/misc/test_tosa_dialect_avg_pool2d_adaptive.py
+++ b/backends/arm/test/misc/test_tosa_dialect_avg_pool2d_adaptive.py
@@ -1,0 +1,303 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import executorch.backends.arm.tosa.dialect  # noqa: F401
+import pytest
+import torch
+from executorch.backends.arm.tosa.dialect.lib import TosaValueError
+from executorch.backends.arm.tosa.dialect.ops.avg_pool2d import (
+    validate_avg_pool2d_dtype,
+)
+from executorch.backends.arm.tosa.specification import (
+    TosaLoweringContext,
+    TosaSpecification,
+)
+from executorch.exir.dialects._ops import ops as exir_ops
+from torch._subclasses.fake_tensor import FakeTensorMode
+
+
+def test_avg_pool2d_adaptive_tosa_INT():
+    sample_inputs = [
+        (
+            (
+                torch.randint(-128, 127, (1, 20, 20, 8), dtype=torch.int8),
+                torch.zeros((1,), dtype=torch.int8),
+                torch.zeros((1,), dtype=torch.int8),
+                [3, 3],
+                [2, 2],
+                [1, 1, 1, 1],
+                torch.int32,
+            ),
+            (1, 10, 10, 8),
+            torch.int8,
+        ),
+        (
+            (
+                torch.randint(-32768, 32767, (1, 9, 13, 4), dtype=torch.int16),
+                torch.zeros((1,), dtype=torch.int16),
+                torch.zeros((1,), dtype=torch.int16),
+                [2, 4],
+                [1, 3],
+                [0, 0, 1, 1],
+                torch.int32,
+            ),
+            (1, 8, 4, 4),
+            torch.int16,
+        ),
+    ]
+
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+INT+int16")
+    ), FakeTensorMode() as mode:
+        for sample_input, expected_output_shape, expected_output_type in sample_inputs:
+            output = exir_ops.backend.tosa.AVG_POOL2D_ADAPTIVE.default(
+                *tuple(
+                    [
+                        mode.from_tensor(i) if isinstance(i, torch.Tensor) else i
+                        for i in sample_input
+                    ]
+                )
+            )
+            assert output.dtype == expected_output_type
+            assert tuple(output.shape) == expected_output_shape
+
+
+def test_avg_pool2d_adaptive_tosa_FP():
+    sample_inputs = [
+        (
+            (
+                torch.randn((1, 20, 20, 8), dtype=torch.float32),
+                torch.zeros((1,), dtype=torch.float32),
+                torch.zeros((1,), dtype=torch.float32),
+                [3, 3],
+                [2, 2],
+                [1, 1, 1, 1],
+                torch.float32,
+            ),
+            (1, 10, 10, 8),
+            torch.float32,
+        ),
+        (
+            (
+                torch.randn((1, 9, 13, 4), dtype=torch.bfloat16),
+                torch.zeros((1,), dtype=torch.bfloat16),
+                torch.zeros((1,), dtype=torch.bfloat16),
+                [2, 4],
+                [1, 3],
+                [0, 0, 1, 1],
+                torch.float32,
+            ),
+            (1, 8, 4, 4),
+            torch.bfloat16,
+        ),
+    ]
+
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+bf16")
+    ), FakeTensorMode() as mode:
+        for sample_input, expected_output_shape, expected_output_type in sample_inputs:
+            output = exir_ops.backend.tosa.AVG_POOL2D_ADAPTIVE.default(
+                *tuple(
+                    [
+                        mode.from_tensor(i) if isinstance(i, torch.Tensor) else i
+                        for i in sample_input
+                    ]
+                )
+            )
+            assert output.dtype == expected_output_type
+            assert tuple(output.shape) == expected_output_shape
+
+
+def test_avg_pool2d_adaptive_accepts_remainder_one_mapping():
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP")
+    ), FakeTensorMode() as mode:
+        x = mode.from_tensor(torch.randn((1, 5, 5, 4), dtype=torch.float32))
+        input_zp = mode.from_tensor(torch.zeros((1,), dtype=torch.float32))
+        output_zp = mode.from_tensor(torch.zeros((1,), dtype=torch.float32))
+
+        output = exir_ops.backend.tosa.AVG_POOL2D_ADAPTIVE.default(
+            x,
+            input_zp,
+            output_zp,
+            [3, 3],
+            [2, 2],
+            [0, 0, 0, 0],
+            torch.float32,
+        )
+
+        assert tuple(output.shape) == (1, 2, 2, 4)
+
+
+def test_avg_pool2d_adaptive_rejects_irregular_single_op_mapping():
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP")
+    ), FakeTensorMode() as mode:
+        x = mode.from_tensor(torch.randn((1, 8, 8, 4), dtype=torch.float32))
+        input_zp = mode.from_tensor(torch.zeros((1,), dtype=torch.float32))
+        output_zp = mode.from_tensor(torch.zeros((1,), dtype=torch.float32))
+
+        with pytest.raises(
+            TosaValueError, match=r"input_size % output_size in \{0, 1\}"
+        ):
+            exir_ops.backend.tosa.AVG_POOL2D_ADAPTIVE.default(
+                x,
+                input_zp,
+                output_zp,
+                [3, 3],
+                [2, 2],
+                [0, 0, 0, 0],
+                torch.float32,
+            )
+
+
+@pytest.mark.parametrize(
+    "spec_str,input_dtype,zero_point_dtype,acc_type",
+    [
+        ("TOSA-1.0+INT", torch.int8, torch.int8, torch.int32),
+        ("TOSA-1.1+INT+int16", torch.int16, torch.int16, torch.int32),
+        ("TOSA-1.0+FP", torch.float16, torch.float16, torch.float16),
+        ("TOSA-1.0+FP", torch.float16, torch.float16, torch.float32),
+        ("TOSA-1.0+FP", torch.float32, torch.float32, torch.float32),
+        ("TOSA-1.1+FP+bf16", torch.bfloat16, torch.bfloat16, torch.float32),
+    ],
+)
+def test_validate_avg_pool2d_dtype_accepts_spec_supported_combinations(
+    spec_str: str,
+    input_dtype: torch.dtype,
+    zero_point_dtype: torch.dtype,
+    acc_type: torch.dtype,
+):
+    spec = TosaSpecification.create_from_string(spec_str)
+    x = torch.zeros((1, 2, 8, 8), dtype=input_dtype)
+    input_zp = torch.zeros((1,), dtype=zero_point_dtype)
+    output_zp = torch.zeros((1,), dtype=zero_point_dtype)
+
+    validate_avg_pool2d_dtype(spec, x, input_zp, output_zp, acc_type, op="AVG_POOL2D")
+
+
+@pytest.mark.parametrize(
+    "spec_str,input_dtype,zero_point_dtype,acc_type,match",
+    [
+        (
+            "TOSA-1.0+FP",
+            torch.float32,
+            torch.int32,
+            torch.float32,
+            "input zero-point dtype",
+        ),
+        (
+            "TOSA-1.0+FP",
+            torch.float32,
+            torch.float32,
+            torch.int32,
+            "accumulator type must be one of",
+        ),
+        (
+            "TOSA-1.0+INT",
+            torch.int16,
+            torch.int16,
+            torch.int32,
+            "Unsupported input dtype",
+        ),
+        (
+            "TOSA-1.0+INT",
+            torch.uint8,
+            torch.uint8,
+            torch.int32,
+            "Unsupported input dtype",
+        ),
+    ],
+)
+def test_validate_avg_pool2d_dtype_rejects_invalid_combinations(
+    spec_str: str,
+    input_dtype: torch.dtype,
+    zero_point_dtype: torch.dtype,
+    acc_type: torch.dtype,
+    match: str,
+):
+    spec = TosaSpecification.create_from_string(spec_str)
+    x = torch.zeros((1, 2, 8, 8), dtype=input_dtype)
+    input_zp = torch.zeros((1,), dtype=zero_point_dtype)
+    output_zp = torch.zeros((1,), dtype=zero_point_dtype)
+
+    with pytest.raises(TosaValueError, match=match):
+        validate_avg_pool2d_dtype(
+            spec,
+            x,
+            input_zp,
+            output_zp,
+            acc_type,
+            op="AVG_POOL2D",
+        )
+
+
+@pytest.mark.parametrize(
+    "op_target",
+    [
+        exir_ops.backend.tosa.AVG_POOL2D.default,
+        exir_ops.backend.tosa.AVG_POOL2D_ADAPTIVE.default,
+    ],
+)
+def test_avg_pool2d_ops_reject_invalid_parameter_lengths(op_target):
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+shape")
+    ), FakeTensorMode() as mode:
+        x = mode.from_tensor(torch.randn((1, 8, 8, 4), dtype=torch.float32))
+        input_zp = mode.from_tensor(torch.zeros((1,), dtype=torch.float32))
+        output_zp = mode.from_tensor(torch.zeros((1,), dtype=torch.float32))
+
+        with pytest.raises(TosaValueError, match="expects kernel of length 2"):
+            op_target(
+                x,
+                input_zp,
+                output_zp,
+                [2],
+                [2, 2],
+                [0, 0, 0, 0],
+                torch.float32,
+            )
+
+        with pytest.raises(TosaValueError, match="stride of length 2"):
+            op_target(
+                x,
+                input_zp,
+                output_zp,
+                [2, 2],
+                [2],
+                [0, 0, 0, 0],
+                torch.float32,
+            )
+
+        with pytest.raises(TosaValueError, match="pad of length 4"):
+            op_target(
+                x,
+                input_zp,
+                output_zp,
+                [2, 2],
+                [2, 2],
+                [0, 0, 0],
+                torch.float32,
+            )
+
+
+def test_avg_pool2d_adaptive_no_target_requires_tosa_1_1():
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.0+FP")
+    ), FakeTensorMode() as mode:
+        x = mode.from_tensor(torch.randn((1, 8, 8, 4), dtype=torch.float32))
+        input_zp = mode.from_tensor(torch.zeros((1,), dtype=torch.float32))
+        output_zp = mode.from_tensor(torch.zeros((1,), dtype=torch.float32))
+        with pytest.raises(TosaValueError, match="support AVG_POOL2D_ADAPTIVE"):
+            exir_ops.backend.tosa.AVG_POOL2D_ADAPTIVE.default(
+                x,
+                input_zp,
+                output_zp,
+                [2, 2],
+                [2, 2],
+                [0, 0, 0, 0],
+                torch.float32,
+            )

--- a/backends/arm/tosa/dialect/__init__.py
+++ b/backends/arm/tosa/dialect/__init__.py
@@ -5,6 +5,7 @@
 
 from executorch.backends.arm.tosa.dialect.ops import (  # noqa F401
     avg_pool2d,
+    avg_pool2d_adaptive,
     conv2d,
     conv3d,
     custom,

--- a/backends/arm/tosa/dialect/ops/avg_pool2d.py
+++ b/backends/arm/tosa/dialect/ops/avg_pool2d.py
@@ -5,13 +5,100 @@
 
 from typing import List, Union
 
+import sympy  # type: ignore[import-untyped]
 import torch
 from executorch.backends.arm.tosa.dialect.lib import TosaValueError
 from executorch.backends.arm.tosa.dialect.ops_registration import register_fake_tosa_op
 from executorch.backends.arm.tosa.specification import (
+    get_context_shape_env,
     get_context_spec,
     TosaSpecification,
 )
+from torch.fx.experimental.symbolic_shapes import FloorDiv
+from torch.types import IntLikeType
+
+
+def _to_sympy_expr(value: int | torch.SymInt) -> sympy.Expr:
+    if isinstance(value, torch.SymInt):
+        return value.node._expr
+    return sympy.Integer(int(value))
+
+
+def _from_sympy_expr(expr: sympy.Expr) -> int | torch.SymInt:
+    # Full `sympy.simplify()` is too expensive for the large symbolic formulas
+    # produced by dynamic-shape model lowering. Keep the expression in its raw
+    # symbolic form and only fold obviously-static integers.
+    if expr.is_Integer:
+        return int(expr)
+    return get_context_shape_env().create_symintnode(expr, hint=None)
+
+
+def _get_supported_avg_pool2d_acc_types(
+    tosa_spec: TosaSpecification,
+) -> dict[torch.dtype, tuple[torch.dtype, ...]]:
+    supported_acc_types: dict[torch.dtype, tuple[torch.dtype, ...]] = {}
+
+    if tosa_spec.support_integer():
+        supported_acc_types[torch.int8] = (torch.int32,)
+        if tosa_spec.support_extension("int16"):
+            supported_acc_types[torch.int16] = (torch.int32,)
+
+    if tosa_spec.support_float():
+        supported_acc_types[torch.float16] = (torch.float16, torch.float32)
+        supported_acc_types[torch.float32] = (torch.float32,)
+        if tosa_spec.support_extension("bf16"):
+            supported_acc_types[torch.bfloat16] = (torch.float32,)
+
+    return supported_acc_types
+
+
+def validate_avg_pool2d_dtype(
+    tosa_spec: TosaSpecification,
+    x: torch.Tensor,
+    input_zp: torch.Tensor,
+    output_zp: torch.Tensor,
+    acc_type: torch.dtype,
+    op: str,
+) -> None:
+    """Validate dtypes for TOSA AVG_POOL2D and AVG_POOL2D_ADAPTIVE."""
+    supported_acc_types = _get_supported_avg_pool2d_acc_types(tosa_spec)
+    if x.dtype not in supported_acc_types:
+        raise TosaValueError(
+            f"Unsupported input dtype {x.dtype}, supported types are {tuple(supported_acc_types)}",
+            op=op,
+        )
+
+    if input_zp.dtype != x.dtype:
+        raise TosaValueError(
+            f"{op} requires input zero-point dtype {input_zp.dtype} to match input dtype {x.dtype}",
+            op=op,
+        )
+    if output_zp.dtype != x.dtype:
+        raise TosaValueError(
+            f"{op} requires output zero-point dtype {output_zp.dtype} to match input dtype {x.dtype}",
+            op=op,
+        )
+
+    valid_acc_types = supported_acc_types[x.dtype]
+    if acc_type not in valid_acc_types:
+        raise TosaValueError(
+            f"{op} accumulator type must be one of {valid_acc_types}, got {acc_type}",
+            op=op,
+        )
+
+
+def validate_avg_pool2d_args(
+    kernel: List[IntLikeType] | List[int],
+    stride: List[IntLikeType] | List[int],
+    pad: List[IntLikeType] | List[int],
+    op: str,
+) -> None:
+    if len(kernel) != 2 or len(stride) != 2 or len(pad) != 4:
+        raise TosaValueError(
+            f"{op} expects kernel of length 2, stride of length 2, pad of length 4; got "
+            f"kernel={kernel}, stride={stride}, pad={pad}",
+            op=op,
+        )
 
 
 @register_fake_tosa_op(
@@ -29,65 +116,54 @@ def AVG_POOL2D(
 ) -> torch.Tensor:
     """Compute output meta for a TOSA AVG_POOL2D operation."""
     tosa_spec = get_context_spec()
+    validate_avg_pool2d_dtype(
+        tosa_spec, x, input_zp, output_zp, acc_type, op="AVG_POOL2D"
+    )
+    output_shape = compute_avg_pool2d_output_shape(
+        x,
+        kernel,
+        stride,
+        pad,
+        op="AVG_POOL2D",
+    )
+    return torch.empty(size=output_shape, dtype=x.dtype)
 
-    # Validate dtype support
-    supported_int_types = [torch.int8]
-    supported_float_types = [
-        torch.float16,
-        torch.float32,
-    ]
-    if tosa_spec.support_extension("bf16"):
-        supported_float_types.append(torch.bfloat16)
-    if tosa_spec.support_extension("int16"):
-        supported_int_types.append(torch.int16)
 
-    if x.dtype in supported_int_types:
-        if not tosa_spec.support_integer():
-            raise TosaValueError(
-                f"TOSA spec {tosa_spec} doesn't support integer pools", op="AVG_POOL2D"
-            )
-    elif x.dtype in supported_float_types:
-        if not tosa_spec.support_float():
-            raise TosaValueError(
-                f"TOSA spec {tosa_spec} doesn't support float pools", op="AVG_POOL2D"
-            )
-    else:
-        raise TosaValueError(
-            f"Unsupported input dtype {x.dtype} for TOSA AVG_POOL2D", op="AVG_POOL2D"
-        )
+def compute_avg_pool2d_output_shape(
+    x: torch.Tensor,
+    kernel: List[IntLikeType] | List[int],
+    stride: List[IntLikeType] | List[int],
+    pad: List[IntLikeType] | List[int],
+    op: str = "AVG_POOL2D",
+) -> List[IntLikeType]:
+    """Compute the output shape for NCHW avg-pool."""
 
-    # Validate input dimensions
     if x.dim() != 4:
-        raise TosaValueError(
-            f"AVG_POOL2D requires a 4D tensor, got {x.dim()}D", op="AVG_POOL2D"
-        )
+        raise TosaValueError(f"{op} requires a 4D tensor, got {x.dim()}D", op=op)
 
-    # Validate kernel, stride, pad lengths
-    if len(kernel) != 2 or len(stride) != 2 or len(pad) != 4:
-        raise TosaValueError(
-            f"AVG_POOL2D expects kernel of length 2, stride of length 2, pad of length 4; got "
-            f"kernel={kernel}, stride={stride}, pad={pad}",
-            op="AVG_POOL2D",
-        )
+    validate_avg_pool2d_args(kernel, stride, pad, op=op)
 
-    # Validate and determine accumulator (output) dtype: only FP32 or INT32
-    acc_allowed = [torch.float32, torch.int32]
-    if acc_type not in acc_allowed:
-        raise TosaValueError(
-            f"Unsupported acc_type {acc_type} for TOSA AVG_POOL2D; "
-            f"must be one of {acc_allowed}",
-            op="AVG_POOL2D",
-        )
-    # Unpack dimensions and parameters in NHWC order;
-    # zero-points are not used for shape.
     n, h, w, c = x.shape
-
     k_h, k_w = kernel
     s_h, s_w = stride
-    p_top, p_bottom, p_left, p_right = pad
-    # Compute output spatial dimensions (floor division)
-    h_out = (h + p_top + p_bottom - k_h) // s_h + 1
-    w_out = (w + p_left + p_right - k_w) // s_w + 1
+    p_top, p_bot, p_left, p_right = pad
 
-    # Return a tensor with the computed shape and dtype
-    return torch.empty(size=[n, h_out, w_out, c], dtype=x.dtype)
+    h_expr = (
+        FloorDiv(
+            _to_sympy_expr(h) + _to_sympy_expr(p_top) + _to_sympy_expr(p_bot) - k_h,
+            s_h,
+        )
+        + 1
+    )
+    w_expr = (
+        FloorDiv(
+            _to_sympy_expr(w) + _to_sympy_expr(p_left) + _to_sympy_expr(p_right) - k_w,
+            s_w,
+        )
+        + 1
+    )
+
+    h_out = _from_sympy_expr(h_expr)
+    w_out = _from_sympy_expr(w_expr)
+
+    return [n, h_out, w_out, c]

--- a/backends/arm/tosa/dialect/ops/avg_pool2d_adaptive.py
+++ b/backends/arm/tosa/dialect/ops/avg_pool2d_adaptive.py
@@ -1,0 +1,82 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import sympy  # type: ignore[import-untyped]
+import torch
+from executorch.backends.arm.tosa.dialect.lib import TosaValueError
+from executorch.backends.arm.tosa.dialect.ops.avg_pool2d import (
+    compute_avg_pool2d_output_shape,
+    validate_avg_pool2d_dtype,
+)
+from executorch.backends.arm.tosa.dialect.ops_registration import register_fake_tosa_op
+from executorch.backends.arm.tosa.specification import (
+    get_context_shape_env,
+    get_context_spec,
+    TosaSpecification,
+)
+from torch.types import IntLikeType
+
+
+def _is_directly_representable(
+    input_size: IntLikeType, output_size: IntLikeType
+) -> bool:
+    remainder = sympy.Mod(input_size, output_size)
+    if isinstance(remainder, torch.SymInt):
+        shape_env = get_context_shape_env()
+        try:
+            remainder_range = shape_env.bound_sympy(remainder.node.expr)
+        except Exception:
+            return False
+
+        return remainder_range.is_singleton() and int(remainder_range.upper) in (0, 1)
+
+    return remainder in (0, 1)
+
+
+@register_fake_tosa_op(
+    "AVG_POOL2D_ADAPTIVE(Tensor input, Tensor input_zp, Tensor output_zp, SymInt[2] kernel, SymInt[2] stride, SymInt[4] pad, ScalarType acc_type) -> Tensor",
+    TosaSpecification.all_profiles_for_version("1.1"),
+)
+def AVG_POOL2D_ADAPTIVE(
+    x: torch.Tensor,
+    input_zp: torch.Tensor,
+    output_zp: torch.Tensor,
+    kernel: list[IntLikeType],
+    stride: list[IntLikeType],
+    pad: list[IntLikeType],
+    acc_type: torch.dtype,
+) -> torch.Tensor:
+    """Fake AVG_POOL2D_ADAPTIVE stub: computes output shape and returns empty tensor."""
+
+    tosa_spec = get_context_spec()
+    if tosa_spec.version.major != 1 or tosa_spec.version.minor < 1:
+        raise TosaValueError(
+            f"TOSA spec {tosa_spec} doesn't support AVG_POOL2D_ADAPTIVE before TOSA-1.1",
+            op="AVG_POOL2D_ADAPTIVE",
+        )
+
+    validate_avg_pool2d_dtype(
+        tosa_spec, x, input_zp, output_zp, acc_type, op="AVG_POOL2D_ADAPTIVE"
+    )
+    output_shape = compute_avg_pool2d_output_shape(
+        x,
+        kernel,
+        stride,
+        pad,
+        op="AVG_POOL2D_ADAPTIVE",
+    )
+
+    input_h, input_w = x.shape[1], x.shape[2]
+    output_h, output_w = output_shape[1], output_shape[2]
+    if not _is_directly_representable(
+        input_h, output_h
+    ) or not _is_directly_representable(input_w, output_w):
+        raise TosaValueError(
+            "AVG_POOL2D_ADAPTIVE requires input_size % output_size in {0, 1}",
+            op="AVG_POOL2D_ADAPTIVE",
+        )
+
+    return torch.empty(size=output_shape, dtype=x.dtype)


### PR DESCRIPTION
Adds adaptive avg_pool2d TOSA dialect op to be used for TOSA-1.1. Also addresses a bug in tosa.avg_pool2d fake tracing.

cc @digantdesai @freddan80 @per @zingo @mansnils @Sebastian-Larsson @robell