### PR TITLE
Enable stricter type checking for torch/fx

### DIFF
--- a/backends/cadence/aot/fuse_ops.py
+++ b/backends/cadence/aot/fuse_ops.py
@@ -55,6 +55,7 @@ from torch.nn.utils.fusion import fuse_conv_bn_weights
 
 def get_tensor_arg(node: torch.fx.Node, arg_name: str) -> torch.Tensor:
     graph_module = node.graph.owning_module
+    assert graph_module is not None
     tensor = get_tensor_from_attr(graph_module, get_arg(node, arg_name, torch.fx.Node))
     assert isinstance(tensor, torch.Tensor), f"{arg_name} must be present"
     return tensor
@@ -264,6 +265,7 @@ class FuseBatchNormWithConv(RemoveOrReplacePassInterface):
         conv_weight = get_tensor_arg(conv_node, "weight")
         # conv_bias is truly optional - fusion function handles None
         graph_module = conv_node.graph.owning_module
+        assert graph_module is not None
         conv_bias = get_tensor_from_attr(
             graph_module, cast(Optional[torch.fx.Node], get_arg(conv_node, "bias"))
         )


### PR DESCRIPTION
Summary:
Add torch/fx/** sub-config to pyrefly.toml enabling implicit-any, unannotated-return, and unannotated-parameter checks. Add tabulate to ignore-missing-imports since it is not a strict requirement

Authored with Claude.

cc voznesenskym penguinwu EikanWang jgong5 Guobing-Chen XiaobingSuper zhuhaozhe blzheng wenzhe-nrv jiayisunx ipiszy kadeng muchulee8 amjames chauhang aakhundov coconutruben jataylo

X-link: https://github.com/pytorch/pytorch/pull/180625

Differential Revision: D102619388

Pulled By: Lucaskabela


