### PR TITLE
NXP Neutron forward fix missing arg

### DIFF
--- a/backends/nxp/backend/neutron_converter_manager.py
+++ b/backends/nxp/backend/neutron_converter_manager.py
@@ -92,7 +92,8 @@ class NeutronConverterManager:
         )
         cctx.compilationOpts.fetchConstantsToSRAM = fetch_constants_to_sram
         cctx.compilationOpts.dumpKernelSelectionCode = self.dump_kernel_selection_code
-        cctx.compilationOpts.useNewFlowNeutronC = use_new_flow_neutron_c
+        if hasattr(cctx.compilationOpts, "useNewFlowNeutronC"):
+            cctx.compilationOpts.useNewFlowNeutronC = use_new_flow_neutron_c
 
         # Try to use multiprocessing for isolation, but fall back to direct execution
         # if the environment doesn't support it (e.g., in sandcastle/build environments)

--- a/backends/nxp/tests/test_neutron_converter_manager.py
+++ b/backends/nxp/tests/test_neutron_converter_manager.py
@@ -7,7 +7,6 @@ import multiprocessing
 
 import torch
 from eiq_neutron_sdk.neutron_converter.neutron_converter import CompilationContext
-
 from executorch import exir
 from executorch.backends.nxp.backend.edge_program_converter import (
     EdgeProgramToIRConverter,
@@ -72,4 +71,5 @@ def test_neutron_converter_with_experimental_mlir_flow(mocker):
 
     compilation_context = process_spy.call_args.kwargs["args"][2]
     assert isinstance(compilation_context, CompilationContext)
-    assert compilation_context.compilationOpts.useNewFlowNeutronC
+    if hasattr(compilation_context.compilationOpts, "useNewFlowNeutronC"):
+        assert compilation_context.compilationOpts.useNewFlowNeutronC


### PR DESCRIPTION
Internal sdk version needs to be bumped I think. To get around the failing CI for now I think we can just gate the flag like this. IIUC it shouldnt regress internal since this flag would be false then anyway.
