### PR TITLE
Add C++ unit tests for cadence::quantized_conv1d_ncl.out and quantized_conv1d_nlc.out (#19161)

### DIFF
--- a/backends/cadence/hifi/operators/op_quantized_conv1d_ncl.cpp
+++ b/backends/cadence/hifi/operators/op_quantized_conv1d_ncl.cpp
@@ -240,7 +240,10 @@ void xa_opt_quantized_conv1d_ncl_asym8uxsym8u_asym8u(
   WORD32 x_stride = stride[0];
   WORD32 x_padding = padding[0];
   WORD32 input_zero_bias = -in_zero_point;
-  WORD32 out_multiplier32 = bias_scale * (1. / output_scale) * 2147483648;
+  const float eff_scale = bias_scale * (1.0f / output_scale);
+  WORD32 out_multiplier32 = (eff_scale >= 1.0f)
+      ? static_cast<WORD32>(2147483647)
+      : static_cast<WORD32>(eff_scale * 2147483648.0f);
   WORD32 out_shift32 = 0;
   WORD32 kernel_zero_bias = -weight_zero_point;
 
@@ -419,9 +422,9 @@ void quantized_conv1d_ncl_per_tensor_out(
           out);
     }
   } else if (dtype == ScalarType::Byte) {
-    // HiFi nnlib conv1d_std kernel does not support depthwise (groups > 1).
-    // Fall back to generic implementation.
-    if (groups > 1) {
+    // HiFi nnlib conv1d_std kernel does not support depthwise (groups > 1)
+    // or stride > 1. Fall back to generic implementation.
+    if (groups > 1 || stride[0] > 1) {
       impl::generic::native::quantized_conv1d_ncl_per_tensor_out(
           ctx,
           input,

--- a/backends/cadence/hifi/operators/op_quantized_conv1d_nlc.cpp
+++ b/backends/cadence/hifi/operators/op_quantized_conv1d_nlc.cpp
@@ -298,9 +298,9 @@ void quantized_conv1d_nlc_per_tensor_out(
           out);
     }
   } else if (dtype == ScalarType::Byte) {
-    // HiFi nnlib conv1d_std kernel does not support depthwise (groups > 1).
-    // Fall back to generic implementation.
-    if (groups > 1) {
+    // HiFi nnlib conv1d_std kernel does not support depthwise (groups > 1)
+    // or stride > 1. Fall back to generic implementation.
+    if (groups > 1 || stride[0] > 1) {
       impl::generic::native::quantized_conv1d_nlc_per_tensor_out(
           ctx,
           input,


### PR DESCRIPTION
Summary:

Adds C++ unit tests for cadence::quantized_conv1d_ncl.out and cadence::quantized_conv1d_nlc.out in test_op_quantized_conv1d_ncl.cpp. Also modifies op_quantized_conv1d_ncl.cpp and op_quantized_conv1d_nlc.cpp in the HiFi backend to fix correctness issues surfaced by the new tests.

Reviewed By: mcremon-meta, zonglinpeng

Differential Revision: D97886683


