### PR TITLE
Android: add @DoNotStrip and consumer ProGuard rules for JNI classes

### DIFF
--- a/extension/android/executorch_android/build.gradle
+++ b/extension/android/executorch_android/build.gradle
@@ -33,6 +33,7 @@ android {
         minSdk = 23
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        consumerProguardFiles 'consumer-proguard-rules.pro'
     }
 
     compileOptions {

--- a/extension/android/executorch_android/consumer-proguard-rules.pro
+++ b/extension/android/executorch_android/consumer-proguard-rules.pro
@@ -1,0 +1,41 @@
+# ExecuTorch Android AAR — Consumer ProGuard/R8 Rules
+#
+# These rules are automatically applied to any app that depends on the
+# ExecuTorch AAR. They prevent R8/ProGuard from stripping classes and
+# methods that are called from native (JNI) code.
+
+# Keep all classes and members annotated with @DoNotStrip.
+# These are explicitly marked as JNI entry points.
+-keep @com.facebook.jni.annotations.DoNotStrip class * { *; }
+-keepclassmembers class * {
+    @com.facebook.jni.annotations.DoNotStrip *;
+}
+
+# Keep all native methods across ExecuTorch packages.
+-keepclasseswithmembernames class org.pytorch.executorch.** {
+    native <methods>;
+}
+
+# Keep HybridData fields (accessed by fbjni via reflection).
+-keepclassmembers class org.pytorch.executorch.** {
+    com.facebook.jni.HybridData *;
+}
+
+# Keep ExecutorchRuntimeException and its factory/subclasses.
+# These are instantiated from JNI via jni_helper.cpp.
+-keep class org.pytorch.executorch.ExecutorchRuntimeException { *; }
+-keep class org.pytorch.executorch.ExecutorchRuntimeException$* { *; }
+
+# Keep EValue (fields and type codes accessed from native code).
+-keep class org.pytorch.executorch.EValue { *; }
+
+# Keep Tensor and its inner classes. The Tensor class has methods and fields
+# accessed from JNI (dtypeJniCode, shape, getRawDataBuffer, nativeNewTensor).
+-keep class org.pytorch.executorch.Tensor { *; }
+-keep class org.pytorch.executorch.Tensor$* { *; }
+
+# Keep LlmCallback interface methods (invoked from native code).
+-keep interface org.pytorch.executorch.extension.llm.LlmCallback { *; }
+
+# Keep AsrCallback interface methods (invoked from native code).
+-keep interface org.pytorch.executorch.extension.asr.AsrCallback { *; }

--- a/extension/android/executorch_android/consumer-proguard-rules.pro
+++ b/extension/android/executorch_android/consumer-proguard-rules.pro
@@ -4,15 +4,17 @@
 # ExecuTorch AAR. They prevent R8/ProGuard from stripping classes and
 # methods that are called from native (JNI) code.
 
-# Keep all classes and members annotated with @DoNotStrip.
-# These are explicitly marked as JNI entry points.
--keep @com.facebook.jni.annotations.DoNotStrip class * { *; }
--keepclassmembers class * {
+# Keep ExecuTorch classes and members annotated with @DoNotStrip.
+# Scoped to org.pytorch.executorch to avoid affecting unrelated libraries.
+-keep @com.facebook.jni.annotations.DoNotStrip class org.pytorch.executorch.** { *; }
+-keepclassmembers class org.pytorch.executorch.** {
     @com.facebook.jni.annotations.DoNotStrip *;
 }
 
 # Keep all native methods across ExecuTorch packages.
--keepclasseswithmembernames class org.pytorch.executorch.** {
+# Use -keepclasseswithmembers (not -keepclasseswithmembernames) to prevent
+# both shrinking and obfuscation of JNI entry points.
+-keepclasseswithmembers class org.pytorch.executorch.** {
     native <methods>;
 }
 

--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/ExecutorchRuntimeException.java
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/ExecutorchRuntimeException.java
@@ -8,6 +8,7 @@
 
 package org.pytorch.executorch;
 
+import com.facebook.jni.annotations.DoNotStrip;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -156,6 +157,7 @@ public class ExecutorchRuntimeException extends RuntimeException {
 
   private final int errorCode;
 
+  @DoNotStrip
   public ExecutorchRuntimeException(int errorCode, String details) {
     super(ErrorHelper.formatMessage(errorCode, details));
     this.errorCode = errorCode;
@@ -171,14 +173,15 @@ public class ExecutorchRuntimeException extends RuntimeException {
     return ErrorHelper.getDetailedErrorLogs();
   }
 
-  // Idiomatic Java exception for invalid arguments - extends ExecutorchRuntimeException
+  @DoNotStrip
   public static class ExecutorchInvalidArgumentException extends ExecutorchRuntimeException {
+    @DoNotStrip
     public ExecutorchInvalidArgumentException(String details) {
       super(INVALID_ARGUMENT, details);
     }
   }
 
-  // Factory method to create an exception of the appropriate subclass.
+  @DoNotStrip
   public static RuntimeException makeExecutorchException(int errorCode, String details) {
     switch (errorCode) {
       case INVALID_ARGUMENT:


### PR DESCRIPTION
Add @DoNotStrip to ExecutorchRuntimeException constructor, factory method, and subclass to prevent R8 from stripping them in internal Meta app builds where these are only called from native code.

Add consumer-proguard-rules.pro to the AAR for external apps that don't have app-level @DoNotStrip handling. The rules protect all JNI-called classes, native methods, HybridData fields, and callback interfaces from R8 stripping.

This commit was authored with the help of Claude.
