### PR TITLE
Add Tensor.copyDataInto to Java API

### DIFF
--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/Tensor.java
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/Tensor.java
@@ -555,6 +555,27 @@ public abstract class Tensor {
   }
 
   /**
+   * Copies the tensor's data into a caller-provided {@link FloatBuffer}, avoiding the per-call
+   * {@code float[]} allocation that {@link #getDataAsFloatArray()} performs. The destination
+   * buffer's position is advanced by the number of elements written; its content from the
+   * starting position must have at least {@link #numel()} elements of remaining capacity.
+   *
+   * <p>Useful in steady-state inference loops where the same output tensor shape is read every
+   * frame: pre-allocate a {@code FloatBuffer} once (e.g. via {@link
+   * #allocateFloatBuffer(int)}) and reuse it across calls.
+   *
+   * @param dst the destination buffer; must have remaining capacity {@code >=} {@link #numel()}.
+   * @throws IllegalStateException if it is called for a tensor type that does not support a
+   *     float view (i.e. anything other than float32 or float16).
+   * @throws java.nio.BufferOverflowException if {@code dst} does not have enough remaining
+   *     capacity.
+   */
+  public void copyDataInto(FloatBuffer dst) {
+    throw new IllegalStateException(
+        "Tensor of type " + getClass().getSimpleName() + " cannot copy data into FloatBuffer.");
+  }
+
+  /**
    * @return a Java long array that contains the tensor data. This may be a copy or reference.
    * @throws IllegalStateException if it is called for a non-int64 tensor.
    */
@@ -691,6 +712,12 @@ public abstract class Tensor {
     }
 
     @Override
+    public void copyDataInto(FloatBuffer dst) {
+      data.rewind();
+      dst.put(data);
+    }
+
+    @Override
     public DType dtype() {
       return DType.FLOAT;
     }
@@ -741,6 +768,15 @@ public abstract class Tensor {
         arr[i] = halfBitsToFloat(data.get());
       }
       return arr;
+    }
+
+    @Override
+    public void copyDataInto(FloatBuffer dst) {
+      data.rewind();
+      int remaining = data.remaining();
+      for (int i = 0; i < remaining; i++) {
+        dst.put(halfBitsToFloat(data.get()));
+      }
     }
 
     @Override

--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/Tensor.java
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/Tensor.java
@@ -557,22 +557,117 @@ public abstract class Tensor {
   /**
    * Copies the tensor's data into a caller-provided {@link FloatBuffer}, avoiding the per-call
    * {@code float[]} allocation that {@link #getDataAsFloatArray()} performs. The destination
-   * buffer's position is advanced by the number of elements written; its content from the
-   * starting position must have at least {@link #numel()} elements of remaining capacity.
+   * buffer's position is advanced by the number of elements written; its content from the starting
+   * position must have at least {@link #numel()} elements of remaining capacity.
    *
    * <p>Useful in steady-state inference loops where the same output tensor shape is read every
-   * frame: pre-allocate a {@code FloatBuffer} once (e.g. via {@link
-   * #allocateFloatBuffer(int)}) and reuse it across calls.
+   * frame: pre-allocate a {@code FloatBuffer} once (e.g. via {@link #allocateFloatBuffer(int)}) and
+   * reuse it across calls.
+   *
+   * <p>Supported by float32 (zero-copy bulk put) and float16 (per-element half→float widening,
+   * matching {@link #getDataAsFloatArray()} on that subclass). For raw fp16 bits without widening,
+   * use {@link #copyDataInto(ShortBuffer)}.
    *
    * @param dst the destination buffer; must have remaining capacity {@code >=} {@link #numel()}.
-   * @throws IllegalStateException if it is called for a tensor type that does not support a
-   *     float view (i.e. anything other than float32 or float16).
+   * @throws IllegalStateException if it is called for a tensor type that does not support a float
+   *     view.
    * @throws java.nio.BufferOverflowException if {@code dst} does not have enough remaining
    *     capacity.
    */
   public void copyDataInto(FloatBuffer dst) {
     throw new IllegalStateException(
         "Tensor of type " + getClass().getSimpleName() + " cannot copy data into FloatBuffer.");
+  }
+
+  /**
+   * Copies the tensor's data into a caller-provided {@link ByteBuffer}, avoiding the per-call
+   * {@code byte[]} allocation that {@link #getDataAsByteArray()} performs.
+   *
+   * @param dst the destination buffer; must have remaining capacity {@code >=} {@link #numel()}.
+   * @throws IllegalStateException if it is called for a non-int8 tensor.
+   * @throws java.nio.BufferOverflowException if {@code dst} does not have enough remaining
+   *     capacity.
+   */
+  public void copyDataInto(ByteBuffer dst) {
+    throw new IllegalStateException(
+        "Tensor of type " + getClass().getSimpleName() + " cannot copy data into ByteBuffer.");
+  }
+
+  /**
+   * Copies the tensor's data into a caller-provided {@link ByteBuffer}, avoiding the per-call
+   * {@code byte[]} allocation that {@link #getDataAsUnsignedByteArray()} performs. The bytes carry
+   * the raw uint8 bits — Java's signed {@code byte} representation, with values {@code >127}
+   * appearing negative; reinterpret with {@code & 0xFF} when reading.
+   *
+   * @param dst the destination buffer; must have remaining capacity {@code >=} {@link #numel()}.
+   * @throws IllegalStateException if it is called for a non-uint8 tensor.
+   * @throws java.nio.BufferOverflowException if {@code dst} does not have enough remaining
+   *     capacity.
+   */
+  public void copyDataIntoUnsigned(ByteBuffer dst) {
+    throw new IllegalStateException(
+        "Tensor of type "
+            + getClass().getSimpleName()
+            + " cannot copy data into ByteBuffer (unsigned).");
+  }
+
+  /**
+   * Copies the tensor's data into a caller-provided {@link IntBuffer}, avoiding the per-call {@code
+   * int[]} allocation that {@link #getDataAsIntArray()} performs.
+   *
+   * @param dst the destination buffer; must have remaining capacity {@code >=} {@link #numel()}.
+   * @throws IllegalStateException if it is called for a non-int32 tensor.
+   * @throws java.nio.BufferOverflowException if {@code dst} does not have enough remaining
+   *     capacity.
+   */
+  public void copyDataInto(IntBuffer dst) {
+    throw new IllegalStateException(
+        "Tensor of type " + getClass().getSimpleName() + " cannot copy data into IntBuffer.");
+  }
+
+  /**
+   * Copies the tensor's data into a caller-provided {@link LongBuffer}, avoiding the per-call
+   * {@code long[]} allocation that {@link #getDataAsLongArray()} performs.
+   *
+   * @param dst the destination buffer; must have remaining capacity {@code >=} {@link #numel()}.
+   * @throws IllegalStateException if it is called for a non-int64 tensor.
+   * @throws java.nio.BufferOverflowException if {@code dst} does not have enough remaining
+   *     capacity.
+   */
+  public void copyDataInto(LongBuffer dst) {
+    throw new IllegalStateException(
+        "Tensor of type " + getClass().getSimpleName() + " cannot copy data into LongBuffer.");
+  }
+
+  /**
+   * Copies the tensor's data into a caller-provided {@link DoubleBuffer}, avoiding the per-call
+   * {@code double[]} allocation that {@link #getDataAsDoubleArray()} performs.
+   *
+   * @param dst the destination buffer; must have remaining capacity {@code >=} {@link #numel()}.
+   * @throws IllegalStateException if it is called for a non-float64 tensor.
+   * @throws java.nio.BufferOverflowException if {@code dst} does not have enough remaining
+   *     capacity.
+   */
+  public void copyDataInto(DoubleBuffer dst) {
+    throw new IllegalStateException(
+        "Tensor of type " + getClass().getSimpleName() + " cannot copy data into DoubleBuffer.");
+  }
+
+  /**
+   * Copies the tensor's data into a caller-provided {@link ShortBuffer}, avoiding the per-call
+   * {@code short[]} allocation that {@link #getDataAsShortArray()} performs. For float16 tensors
+   * this writes the raw 16-bit half-precision bits with no widening; use {@link
+   * #copyDataInto(FloatBuffer)} if you want the values widened to fp32.
+   *
+   * @param dst the destination buffer; must have remaining capacity {@code >=} {@link #numel()}.
+   * @throws IllegalStateException if it is called for a tensor type whose backing storage is not a
+   *     {@code ShortBuffer}.
+   * @throws java.nio.BufferOverflowException if {@code dst} does not have enough remaining
+   *     capacity.
+   */
+  public void copyDataInto(ShortBuffer dst) {
+    throw new IllegalStateException(
+        "Tensor of type " + getClass().getSimpleName() + " cannot copy data into ShortBuffer.");
   }
 
   /**
@@ -626,6 +721,12 @@ public abstract class Tensor {
     }
 
     @Override
+    public void copyDataIntoUnsigned(ByteBuffer dst) {
+      data.rewind();
+      dst.put(data);
+    }
+
+    @Override
     public String toString() {
       return String.format("Tensor(%s, dtype=torch.uint8)", Arrays.toString(shape));
     }
@@ -658,6 +759,12 @@ public abstract class Tensor {
     }
 
     @Override
+    public void copyDataInto(ByteBuffer dst) {
+      data.rewind();
+      dst.put(data);
+    }
+
+    @Override
     public String toString() {
       return String.format("Tensor(%s, dtype=torch.int8)", Arrays.toString(shape));
     }
@@ -687,6 +794,12 @@ public abstract class Tensor {
       int[] arr = new int[data.remaining()];
       data.get(arr);
       return arr;
+    }
+
+    @Override
+    public void copyDataInto(IntBuffer dst) {
+      data.rewind();
+      dst.put(data);
     }
 
     @Override
@@ -760,6 +873,12 @@ public abstract class Tensor {
     }
 
     @Override
+    public void copyDataInto(ShortBuffer dst) {
+      data.rewind();
+      dst.put(data);
+    }
+
+    @Override
     public float[] getDataAsFloatArray() {
       data.rewind();
       int remaining = data.remaining();
@@ -774,6 +893,12 @@ public abstract class Tensor {
     public void copyDataInto(FloatBuffer dst) {
       data.rewind();
       int remaining = data.remaining();
+      // Match the all-or-nothing semantics of bulk FloatBuffer.put(FloatBuffer):
+      // verify capacity up front so an undersized destination throws before any
+      // partial widening is observed in dst.
+      if (dst.remaining() < remaining) {
+        throw new java.nio.BufferOverflowException();
+      }
       for (int i = 0; i < remaining; i++) {
         dst.put(halfBitsToFloat(data.get()));
       }
@@ -837,6 +962,12 @@ public abstract class Tensor {
     }
 
     @Override
+    public void copyDataInto(LongBuffer dst) {
+      data.rewind();
+      dst.put(data);
+    }
+
+    @Override
     public String toString() {
       return String.format("Tensor(%s, dtype=torch.int64)", Arrays.toString(shape));
     }
@@ -866,6 +997,12 @@ public abstract class Tensor {
       double[] arr = new double[data.remaining()];
       data.get(arr);
       return arr;
+    }
+
+    @Override
+    public void copyDataInto(DoubleBuffer dst) {
+      data.rewind();
+      dst.put(data);
     }
 
     @Override

--- a/extension/android/executorch_android/src/test/java/org/pytorch/executorch/TensorTest.kt
+++ b/extension/android/executorch_android/src/test/java/org/pytorch/executorch/TensorTest.kt
@@ -275,6 +275,87 @@ class TensorTest {
   }
 
   @Test
+  fun testCopyDataIntoFloat32() {
+    val data = floatArrayOf(Float.MIN_VALUE, 0f, 0.1f, Float.MAX_VALUE)
+    val shape = longArrayOf(2, 2)
+    val tensor = Tensor.fromBlob(data, shape)
+
+    val dst = Tensor.allocateFloatBuffer(4)
+    tensor.copyDataInto(dst)
+    assertEquals(4, dst.position())
+    dst.rewind()
+    for (i in data.indices) {
+      assertEquals(data[i].toDouble(), dst.get().toDouble(), 1e-5)
+    }
+
+    // Verify reuse: a second call refills the same buffer in place.
+    dst.rewind()
+    tensor.copyDataInto(dst)
+    assertEquals(4, dst.position())
+    dst.rewind()
+    for (i in data.indices) {
+      assertEquals(data[i].toDouble(), dst.get().toDouble(), 1e-5)
+    }
+  }
+
+  @Test
+  fun testCopyDataIntoFloat32_writesAtDstPosition() {
+    val data = floatArrayOf(1f, 2f, 3f, 4f)
+    val shape = longArrayOf(4)
+    val tensor = Tensor.fromBlob(data, shape)
+
+    // Pre-fill a larger buffer; copyDataInto should write at the current
+    // position and advance it, not overwrite from index 0.
+    val dst = Tensor.allocateFloatBuffer(8)
+    dst.put(floatArrayOf(-1f, -1f))
+    assertEquals(2, dst.position())
+    tensor.copyDataInto(dst)
+    assertEquals(6, dst.position())
+    dst.rewind()
+    assertEquals(-1f.toDouble(), dst.get().toDouble(), 0.0)
+    assertEquals(-1f.toDouble(), dst.get().toDouble(), 0.0)
+    for (i in data.indices) {
+      assertEquals(data[i].toDouble(), dst.get().toDouble(), 1e-5)
+    }
+  }
+
+  @Test
+  fun testCopyDataIntoFloat32_overflow() {
+    val data = floatArrayOf(1f, 2f, 3f, 4f)
+    val tensor = Tensor.fromBlob(data, longArrayOf(4))
+    val dst = Tensor.allocateFloatBuffer(2)
+    assertThatThrownBy { tensor.copyDataInto(dst) }
+        .isInstanceOf(java.nio.BufferOverflowException::class.java)
+  }
+
+  @Test
+  fun testCopyDataIntoFloat16() {
+    // 0x0000=+0, 0x3C00=1.0, 0x4000=2.0, 0xC000=-2.0
+    val halfBits =
+        shortArrayOf(0x0000.toShort(), 0x3C00.toShort(), 0x4000.toShort(), 0xC000.toShort())
+    val tensor = Tensor.fromBlob(halfBits, longArrayOf(4))
+    assertEquals(DType.HALF, tensor.dtype())
+
+    val dst = Tensor.allocateFloatBuffer(4)
+    tensor.copyDataInto(dst)
+    assertEquals(4, dst.position())
+    dst.rewind()
+    assertEquals(0.0, dst.get().toDouble(), 0.0)
+    assertEquals(1.0, dst.get().toDouble(), 0.0)
+    assertEquals(2.0, dst.get().toDouble(), 0.0)
+    assertEquals(-2.0, dst.get().toDouble(), 0.0)
+  }
+
+  @Test
+  fun testCopyDataIntoFloat_unsupportedDtype() {
+    val tensor = Tensor.fromBlob(intArrayOf(1, 2, 3, 4), longArrayOf(4))
+    val dst = Tensor.allocateFloatBuffer(4)
+    assertThatThrownBy { tensor.copyDataInto(dst) }
+        .isInstanceOf(IllegalStateException::class.java)
+        .hasMessage("Tensor of type Tensor_int32 cannot copy data into FloatBuffer.")
+  }
+
+  @Test
   fun testIllegalArguments() {
     val data = floatArrayOf(Float.MIN_VALUE, 0f, 0.1f, Float.MAX_VALUE)
     val shapeWithNegativeValues = longArrayOf(-1, 2)

--- a/extension/android/executorch_android/src/test/java/org/pytorch/executorch/TensorTest.kt
+++ b/extension/android/executorch_android/src/test/java/org/pytorch/executorch/TensorTest.kt
@@ -347,12 +347,173 @@ class TensorTest {
   }
 
   @Test
+  fun testCopyDataIntoFloat16_overflowIsAtomic() {
+    // The fp16 path widens element-by-element rather than via bulk put. Verify
+    // that an undersized destination throws BufferOverflowException up front
+    // and leaves dst unmodified, matching the all-or-nothing semantics of the
+    // float32 / int / etc. paths.
+    val halfBits =
+        shortArrayOf(0x0000.toShort(), 0x3C00.toShort(), 0x4000.toShort(), 0xC000.toShort())
+    val tensor = Tensor.fromBlob(halfBits, longArrayOf(4))
+    val dst = Tensor.allocateFloatBuffer(2)
+    assertThatThrownBy { tensor.copyDataInto(dst) }
+        .isInstanceOf(java.nio.BufferOverflowException::class.java)
+    assertEquals(0, dst.position())
+  }
+
+  @Test
   fun testCopyDataIntoFloat_unsupportedDtype() {
     val tensor = Tensor.fromBlob(intArrayOf(1, 2, 3, 4), longArrayOf(4))
     val dst = Tensor.allocateFloatBuffer(4)
     assertThatThrownBy { tensor.copyDataInto(dst) }
         .isInstanceOf(IllegalStateException::class.java)
         .hasMessage("Tensor of type Tensor_int32 cannot copy data into FloatBuffer.")
+  }
+
+  @Test
+  fun testCopyDataIntoInt32() {
+    val data = intArrayOf(Int.MIN_VALUE, 0, 1, Int.MAX_VALUE)
+    val tensor = Tensor.fromBlob(data, longArrayOf(4))
+    val dst = Tensor.allocateIntBuffer(4)
+    tensor.copyDataInto(dst)
+    assertEquals(4, dst.position())
+    dst.rewind()
+    for (i in data.indices) {
+      assertEquals(data[i], dst.get())
+    }
+  }
+
+  @Test
+  fun testCopyDataIntoInt32_unsupportedDtype() {
+    val tensor = Tensor.fromBlob(floatArrayOf(1f, 2f), longArrayOf(2))
+    val dst = Tensor.allocateIntBuffer(2)
+    assertThatThrownBy { tensor.copyDataInto(dst) }
+        .isInstanceOf(IllegalStateException::class.java)
+        .hasMessage("Tensor of type Tensor_float32 cannot copy data into IntBuffer.")
+  }
+
+  @Test
+  fun testCopyDataIntoInt64() {
+    val data = longArrayOf(Long.MIN_VALUE, 0, 1, Long.MAX_VALUE)
+    val tensor = Tensor.fromBlob(data, longArrayOf(4))
+    val dst = Tensor.allocateLongBuffer(4)
+    tensor.copyDataInto(dst)
+    assertEquals(4, dst.position())
+    dst.rewind()
+    for (i in data.indices) {
+      assertEquals(data[i], dst.get())
+    }
+  }
+
+  @Test
+  fun testCopyDataIntoInt64_unsupportedDtype() {
+    val tensor = Tensor.fromBlob(floatArrayOf(1f, 2f), longArrayOf(2))
+    val dst = Tensor.allocateLongBuffer(2)
+    assertThatThrownBy { tensor.copyDataInto(dst) }
+        .isInstanceOf(IllegalStateException::class.java)
+        .hasMessage("Tensor of type Tensor_float32 cannot copy data into LongBuffer.")
+  }
+
+  @Test
+  fun testCopyDataIntoFloat64() {
+    val data = doubleArrayOf(Double.MIN_VALUE, 0.0, 0.1, Double.MAX_VALUE)
+    val tensor = Tensor.fromBlob(data, longArrayOf(4))
+    val dst = Tensor.allocateDoubleBuffer(4)
+    tensor.copyDataInto(dst)
+    assertEquals(4, dst.position())
+    dst.rewind()
+    for (i in data.indices) {
+      assertEquals(data[i], dst.get(), 1e-12)
+    }
+  }
+
+  @Test
+  fun testCopyDataIntoFloat64_unsupportedDtype() {
+    val tensor = Tensor.fromBlob(floatArrayOf(1f, 2f), longArrayOf(2))
+    val dst = Tensor.allocateDoubleBuffer(2)
+    assertThatThrownBy { tensor.copyDataInto(dst) }
+        .isInstanceOf(IllegalStateException::class.java)
+        .hasMessage("Tensor of type Tensor_float32 cannot copy data into DoubleBuffer.")
+  }
+
+  @Test
+  fun testCopyDataIntoInt8() {
+    val data = byteArrayOf(Byte.MIN_VALUE, 0, 1, Byte.MAX_VALUE)
+    val tensor = Tensor.fromBlob(data, longArrayOf(4))
+    val dst = Tensor.allocateByteBuffer(4)
+    tensor.copyDataInto(dst)
+    assertEquals(4, dst.position())
+    dst.rewind()
+    for (i in data.indices) {
+      assertEquals(data[i], dst.get())
+    }
+  }
+
+  @Test
+  fun testCopyDataIntoInt8_rejectsUInt8() {
+    val tensor = Tensor.fromBlobUnsigned(byteArrayOf(0, 1, 2, 3), longArrayOf(4))
+    val dst = Tensor.allocateByteBuffer(4)
+    assertThatThrownBy { tensor.copyDataInto(dst) }
+        .isInstanceOf(IllegalStateException::class.java)
+        .hasMessage("Tensor of type Tensor_uint8 cannot copy data into ByteBuffer.")
+  }
+
+  @Test
+  fun testCopyDataIntoUnsignedUInt8() {
+    val data = byteArrayOf(0, 1, 127, -1) // -1 == 255 unsigned
+    val tensor = Tensor.fromBlobUnsigned(data, longArrayOf(4))
+    val dst = Tensor.allocateByteBuffer(4)
+    tensor.copyDataIntoUnsigned(dst)
+    assertEquals(4, dst.position())
+    dst.rewind()
+    for (i in data.indices) {
+      assertEquals(data[i], dst.get())
+    }
+  }
+
+  @Test
+  fun testCopyDataIntoUnsigned_rejectsInt8() {
+    val tensor = Tensor.fromBlob(byteArrayOf(0, 1, 2, 3), longArrayOf(4))
+    val dst = Tensor.allocateByteBuffer(4)
+    assertThatThrownBy { tensor.copyDataIntoUnsigned(dst) }
+        .isInstanceOf(IllegalStateException::class.java)
+        .hasMessage("Tensor of type Tensor_int8 cannot copy data into ByteBuffer (unsigned).")
+  }
+
+  @Test
+  fun testCopyDataIntoByte_unsupportedDtype() {
+    val tensor = Tensor.fromBlob(floatArrayOf(1f, 2f), longArrayOf(2))
+    val dst = Tensor.allocateByteBuffer(2 * java.lang.Float.BYTES)
+    assertThatThrownBy { tensor.copyDataInto(dst) }
+        .isInstanceOf(IllegalStateException::class.java)
+        .hasMessage("Tensor of type Tensor_float32 cannot copy data into ByteBuffer.")
+    assertThatThrownBy { tensor.copyDataIntoUnsigned(dst) }
+        .isInstanceOf(IllegalStateException::class.java)
+        .hasMessage("Tensor of type Tensor_float32 cannot copy data into ByteBuffer (unsigned).")
+  }
+
+  @Test
+  fun testCopyDataIntoFloat16RawBits() {
+    val halfBits =
+        shortArrayOf(0x0000.toShort(), 0x3C00.toShort(), 0x4000.toShort(), 0xC000.toShort())
+    val tensor = Tensor.fromBlob(halfBits, longArrayOf(4))
+    assertEquals(DType.HALF, tensor.dtype())
+    val dst = Tensor.allocateHalfBuffer(4)
+    tensor.copyDataInto(dst)
+    assertEquals(4, dst.position())
+    dst.rewind()
+    for (i in halfBits.indices) {
+      assertEquals(halfBits[i], dst.get())
+    }
+  }
+
+  @Test
+  fun testCopyDataIntoShort_unsupportedDtype() {
+    val tensor = Tensor.fromBlob(floatArrayOf(1f, 2f), longArrayOf(2))
+    val dst = Tensor.allocateHalfBuffer(2)
+    assertThatThrownBy { tensor.copyDataInto(dst) }
+        .isInstanceOf(IllegalStateException::class.java)
+        .hasMessage("Tensor of type Tensor_float32 cannot copy data into ShortBuffer.")
   }
 
   @Test

--- a/extension/android/executorch_android/src/test/java/org/pytorch/executorch/TensorTest.kt
+++ b/extension/android/executorch_android/src/test/java/org/pytorch/executorch/TensorTest.kt
@@ -517,6 +517,111 @@ class TensorTest {
   }
 
   @Test
+  fun testCopyDataIntoInt32_overflow() {
+    val tensor = Tensor.fromBlob(intArrayOf(1, 2, 3, 4), longArrayOf(4))
+    val dst = Tensor.allocateIntBuffer(2)
+    assertThatThrownBy { tensor.copyDataInto(dst) }
+        .isInstanceOf(java.nio.BufferOverflowException::class.java)
+  }
+
+  @Test
+  fun testCopyDataIntoInt64_overflow() {
+    val tensor = Tensor.fromBlob(longArrayOf(1, 2, 3, 4), longArrayOf(4))
+    val dst = Tensor.allocateLongBuffer(2)
+    assertThatThrownBy { tensor.copyDataInto(dst) }
+        .isInstanceOf(java.nio.BufferOverflowException::class.java)
+  }
+
+  @Test
+  fun testCopyDataIntoFloat64_overflow() {
+    val tensor = Tensor.fromBlob(doubleArrayOf(1.0, 2.0, 3.0, 4.0), longArrayOf(4))
+    val dst = Tensor.allocateDoubleBuffer(2)
+    assertThatThrownBy { tensor.copyDataInto(dst) }
+        .isInstanceOf(java.nio.BufferOverflowException::class.java)
+  }
+
+  @Test
+  fun testCopyDataIntoInt8_overflow() {
+    val tensor = Tensor.fromBlob(byteArrayOf(1, 2, 3, 4), longArrayOf(4))
+    val dst = Tensor.allocateByteBuffer(2)
+    assertThatThrownBy { tensor.copyDataInto(dst) }
+        .isInstanceOf(java.nio.BufferOverflowException::class.java)
+  }
+
+  @Test
+  fun testCopyDataIntoUnsignedUInt8_overflow() {
+    val tensor = Tensor.fromBlobUnsigned(byteArrayOf(1, 2, 3, 4), longArrayOf(4))
+    val dst = Tensor.allocateByteBuffer(2)
+    assertThatThrownBy { tensor.copyDataIntoUnsigned(dst) }
+        .isInstanceOf(java.nio.BufferOverflowException::class.java)
+  }
+
+  @Test
+  fun testCopyDataIntoFloat16RawBits_overflow() {
+    val halfBits =
+        shortArrayOf(0x0000.toShort(), 0x3C00.toShort(), 0x4000.toShort(), 0xC000.toShort())
+    val tensor = Tensor.fromBlob(halfBits, longArrayOf(4))
+    val dst = Tensor.allocateHalfBuffer(2)
+    assertThatThrownBy { tensor.copyDataInto(dst) }
+        .isInstanceOf(java.nio.BufferOverflowException::class.java)
+  }
+
+  @Test
+  fun testCopyDataIntoFloat16_writesAtDstPosition() {
+    // 0x3C00=1.0, 0x4000=2.0, 0x4200=3.0, 0x4400=4.0
+    val halfBits =
+        shortArrayOf(0x3C00.toShort(), 0x4000.toShort(), 0x4200.toShort(), 0x4400.toShort())
+    val tensor = Tensor.fromBlob(halfBits, longArrayOf(4))
+
+    // Pre-fill a larger buffer; the fp16 widening path should write at the
+    // current position and advance it, not overwrite from index 0.
+    val dst = Tensor.allocateFloatBuffer(8)
+    dst.put(floatArrayOf(-1f, -1f))
+    assertEquals(2, dst.position())
+    tensor.copyDataInto(dst)
+    assertEquals(6, dst.position())
+    dst.rewind()
+    assertEquals(-1f.toDouble(), dst.get().toDouble(), 0.0)
+    assertEquals(-1f.toDouble(), dst.get().toDouble(), 0.0)
+    assertEquals(1.0, dst.get().toDouble(), 0.0)
+    assertEquals(2.0, dst.get().toDouble(), 0.0)
+    assertEquals(3.0, dst.get().toDouble(), 0.0)
+    assertEquals(4.0, dst.get().toDouble(), 0.0)
+  }
+
+  @Test
+  fun testCopyDataInto_emptyTensor() {
+    val floatTensor = Tensor.fromBlob(floatArrayOf(), longArrayOf(0))
+    val floatDst = Tensor.allocateFloatBuffer(4)
+    floatDst.put(floatArrayOf(7f, 8f))
+    assertEquals(2, floatDst.position())
+    floatTensor.copyDataInto(floatDst)
+    assertEquals(2, floatDst.position())
+
+    // Same for the fp16 widening path, whose explicit remaining() check is
+    // worth exercising at zero.
+    val halfTensor = Tensor.fromBlob(shortArrayOf(), longArrayOf(0))
+    val halfWidenDst = Tensor.allocateFloatBuffer(2)
+    halfTensor.copyDataInto(halfWidenDst)
+    assertEquals(0, halfWidenDst.position())
+  }
+
+  @Test
+  fun testCopyDataInto_rejectsReadOnlyBuffer() {
+    val tensor = Tensor.fromBlob(floatArrayOf(1f, 2f, 3f, 4f), longArrayOf(4))
+    val dst = Tensor.allocateFloatBuffer(4).asReadOnlyBuffer()
+    assertThatThrownBy { tensor.copyDataInto(dst) }
+        .isInstanceOf(java.nio.ReadOnlyBufferException::class.java)
+
+    // fp16 widening path uses element-by-element put, which also rejects.
+    val halfTensor =
+        Tensor.fromBlob(shortArrayOf(0x3C00.toShort(), 0x4000.toShort()), longArrayOf(2))
+    val halfWidenDst = Tensor.allocateFloatBuffer(2).asReadOnlyBuffer()
+    assertThatThrownBy { halfTensor.copyDataInto(halfWidenDst) }
+        .isInstanceOf(java.nio.ReadOnlyBufferException::class.java)
+  }
+
+  @Test
   fun testIllegalArguments() {
     val data = floatArrayOf(Float.MIN_VALUE, 0f, 0.1f, Float.MAX_VALUE)
     val shapeWithNegativeValues = longArrayOf(-1, 2)


### PR DESCRIPTION
## Summary

Adds `Tensor.copyDataInto(... dst)` to the Android Java API for the float32 and float16 dtypes. It copies the tensor's data into a caller-provided destination buffer instead of allocating a fresh `float[]` per call (as `getDataAsFloatArray()` does today). The same pattern is repeated for other types.

## Motivation

While profiling depth inference on Android with Perfetto, output extraction was a meaningful contributor to ART GC pressure. Each call to `output.toTensor().dataAsFloatArray` allocates a new Java `float[]` sized to the tensor's element count and bulk-copies from the underlying off-heap buffer into it.

The native side already exposes the underlying `FloatBuffer` directly (zero-copy view of the C++ tensor's `data_ptr()`), so the only thing missing was a public way for callers to drain it into a destination buffer they already own and reuse across calls.

## API

```java
public void copyDataInto(FloatBuffer dst)
```

- Implemented on all datatypes

## Caller-side usage example

```java
// One-time setup
FloatBuffer depthBuf = Tensor.allocateFloatBuffer(numelDepth);

// Per inference
EValue[] outputs = module.forward(...);
depthBuf.rewind();
outputs[0].toTensor().copyDataInto(depthBuf);   // no allocation
// ... read from depthBuf ...
```

## Test plan

- [x] Added unit tests in `TensorTest.kt`:
  - `testCopyDataIntoFloat32` — round-trip with reuse across two calls
  - `testCopyDataIntoFloat32_writesAtDstPosition` — verifies the call writes at `dst.position()` and advances it (does not overwrite from index 0)
  - `testCopyDataIntoFloat32_overflow` — `BufferOverflowException` on undersized destination
  - `testCopyDataIntoFloat16` — verifies fp16→fp32 widening matches `getDataAsFloatArray`
  - `testCopyDataIntoFloat_unsupportedDtype` — `IllegalStateException` from base default for non-float dtypes

This PR was authored with Claude.

cc @kirklandsign @cbilgin