### PR TITLE
Bump pytest to 9.0.3, pytest-cov to 6.1.1, hypothesis to 6.131.15

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -9,10 +9,10 @@ torchsr==1.0.4
 transformers==4.56.1
 zstd==1.5.5.1
 pandas>=2.2.2; python_version >= '3.10'
-pytest==7.2.0
-pytest-cov==4.1.0
+pytest==9.0.3
+pytest-cov==6.1.1
 expecttest==0.1.6
-hypothesis==6.84.2
+hypothesis==6.131.15
 parameterized==0.9.0
 
 # Doc build requirements, same as https://github.com/pytorch/pytorch/blob/main/.ci/docker/requirements-docs.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,7 +11,7 @@ certifi  # Imported by resolve_buck.py.
 lintrunner==0.12.7
 lintrunner-adapters==0.13.0
 
-pytest<9.0
+pytest
 pytest-xdist
 pytest-rerunfailures==15.1
 pytest-json-report


### PR DESCRIPTION
Summary:
Brings executorch's open-source CI test-dependency pins forward:
- pytest:       7.2.0   → 9.0.3
- pytest-cov:   4.1.0   → 6.1.1   (required for pytest 9.x compatibility;
                                     pytest-cov 4.x predates pytest 8/9 support)
- hypothesis:   6.84.2  → 6.131.15

\`requirements-ci.txt\` is the pinned dependency set used by the CI Docker
images. The previous pins predated pytest 8 and 9 entirely; bumping in
one go avoids stacking incompatible Dependabot PRs.

Also drops the \`pytest<9.0\` upper bound in \`requirements-dev.txt\`. That
cap pre-dated pytest 8/9 support and now actively conflicts with the CI
pin — without lifting it, contributors hit pip resolver errors when
trying to reproduce CI failures locally.

___

overriding_review_checks_triggers_an_audit_and_retroactive_review
Oncall Short Name: ai_infra_mobile_platform

Differential Revision: D102679505


