### PR TITLE
Fix CUDA device mismatch in KVCache.update for index_copy_

### DIFF
--- a/examples/models/llama/attention.py
+++ b/examples/models/llama/attention.py
@@ -134,7 +134,7 @@ class KVCache(nn.Module):
             torch._check(start_pos < self.max_context_length)
             dim_to_slice = 2
             seq_length = k_val.size(dim_to_slice)
-            indices = torch.arange(seq_length) + start_pos
+            indices = torch.arange(seq_length, device=k_val.device) + start_pos
             self.k_cache.index_copy_(dim_to_slice, indices, k_val)
             self.v_cache.index_copy_(dim_to_slice, indices, v_val)
             return self.k_cache, self.v_cache


### PR DESCRIPTION
Summary:
D93692727 (the torch nightly bump that landed Feb 2026) replaced the `narrow().copy_()` cache update path in `Attention.update` with `index_copy_()`. The new code constructs `indices` via `torch.arange(seq_length) + start_pos`, which defaults to CPU. When `k_cache`/`v_cache` are on CUDA (any GPU consumer), `index_copy_` raises `RuntimeError: Expected all tensors to be on the same device, but got index is on cpu, different from other tensors on cuda:0 (when checking argument in method wrapper_CUDA_index_copy_)`. The fix is a single-arg addition to `torch.arange` to construct `indices` on the same device as `k_val` (which is always the same device as the cache). Safe for CPU consumers — `device=k_val.device` resolves to CPU when nothing is on GPU.

This unblocks `coreai/rlformers/buck_tests/core:test_quant_utils - test_prepared_vs_et_eager` (T217650451), which was failing on this exact stack (`attention.py:103 -> wrapper_CUDA_index_copy_`). Note: the test still fails on a separate, latent assertion (`compute_sqnr(qat, et_eager)` returns 16.5 dB but the test asserts `math.isinf(result)`); that divergence is also attributable to D93692727 (which simultaneously bumped torch nightly and changed `.contiguous().view()` → `.reshape()` in the same attention paths) and needs a separate decision from the test owner — flagged as a comment on T217650451.

Both `fbcode/executorch/examples/models/llama/attention.py` and `xplat/executorch/examples/models/llama/attention.py` are updated since D93692727 modified both copies.

Reviewed By: larryliu0820

Differential Revision: D102644542


