### PR TITLE
NXP backend: Add use new flag to custom compilation options, add op aliases

### DIFF
--- a/backends/nxp/backend/custom_delegation_options.py
+++ b/backends/nxp/backend/custom_delegation_options.py
@@ -22,3 +22,7 @@ class CustomDelegationOptions:
     #  not create any NeutronGraph that can be called. This is done by the partitioner itself, and is not handled by
     #  the individual node converters.
     allow_no_op_partitions: bool = False
+
+    # The new neutron converter flow has different constraints for supported operators. These need to be addressed when
+    # deciding is operator is delegated or not in _is_supported_on_target().
+    use_new_flow_neutron_c: bool = False

--- a/backends/nxp/nxp_backend.py
+++ b/backends/nxp/nxp_backend.py
@@ -15,6 +15,9 @@ from typing import final, List, Optional
 import numpy as np
 import torch
 
+from executorch.backends.nxp.backend.custom_delegation_options import (
+    CustomDelegationOptions,
+)
 from executorch.backends.nxp.backend.data_format import DataFormat
 from executorch.backends.nxp.backend.edge_program_converter import (
     EdgeProgramToIRConverter,
@@ -229,6 +232,9 @@ class NeutronBackend(BackendDetails):
                 edge_program,
                 neutron_target_spec=NeutronTargetSpec(target),
                 conversion_config=conversion_config,
+                custom_delegation_options=CustomDelegationOptions(
+                    use_new_flow_neutron_c=use_new_flow_neutron_c
+                ),
             )
 
             neutron_model = NeutronConverterManager(dump_kernel_selection_code).convert(

--- a/backends/nxp/tests/executorch_pipeline.py
+++ b/backends/nxp/tests/executorch_pipeline.py
@@ -194,6 +194,7 @@ def to_quantized_edge_program(
     delegate_to_npu=True,
 ) -> EdgeProgramManager:
     _neutron_target_spec = NeutronTargetSpec(target)
+    custom_delegation_options.use_new_flow_neutron_c = use_new_flow_neutron_c
     if get_quantizer_fn is None:
         get_quantizer_fn = partial(
             _get_default_quantizer, _neutron_target_spec, use_qat

--- a/backends/nxp/tests/ops_aliases.py
+++ b/backends/nxp/tests/ops_aliases.py
@@ -1,0 +1,26 @@
+# Copyright 2026 NXP
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# This file defines ops aliases for shorter and more readable test description. List is sorted alphabetically.
+# When finding a missing alias, add it at the correct place.
+
+import torch
+from executorch.exir.dialects._ops import ops as exir_ops
+
+AvgPool2D = exir_ops.edge.aten.avg_pool2d.default
+Bmm = exir_ops.edge.aten.bmm.default
+ExecutorchDelegateCall = torch.ops.higher_order.executorch_call_delegate
+HardTanh = exir_ops.edge.aten.hardtanh.default
+HardTanh_ = exir_ops.edge.aten.hardtanh_.default
+Slice = exir_ops.edge.aten.slice.Tensor
+SliceCopy = exir_ops.edge.aten.slice_copy.Tensor
+Softmax = exir_ops.edge.aten._softmax.default
+Squeeze = exir_ops.edge.aten.squeeze.default
+SqueezeDim = exir_ops.edge.aten.squeeze.dim
+SqueezeDims = exir_ops.edge.aten.squeeze.dims
+Unsqueeze = exir_ops.edge.aten.unsqueeze.default
+UpsampleBilinear2D = exir_ops.edge.aten.upsample_bilinear2d.vec
+UpsampleNearest2D = exir_ops.edge.aten.upsample_nearest2d.vec
+ViewCopy = exir_ops.edge.aten.view_copy.default


### PR DESCRIPTION
### Summary
Adds new flag `use_new_flow_neutron_c` to `CustomDelegationOptions`, enable passing it in `to_quantized_edge_program()` for using new Neutron converter conversion flow. Adds ops aliases for more readable tests. Depends on https://github.com/pytorch/executorch/pull/19112, only last commit is from this PR. 

### Test plan
No tests at the moment, they will be added for each op.

cc @robert-kalmar @JakeStevens @digantdesai