### PR TITLE
Arm backend: add missing buck deps for transform passes in arm_pass_manager

### DIFF
--- a/backends/arm/_passes/TARGETS
+++ b/backends/arm/_passes/TARGETS
@@ -25,6 +25,9 @@ runtime.python_library(
         "//executorch/backends/arm:common",
         "//executorch/backends/arm/tosa:utils",
         "//executorch/backends/arm/tosa/dialect:lib",
+        "//executorch/backends/transforms:fuse_cascaded_transpose_or_permute_ops",
+        "//executorch/backends/transforms:postpone_permute_below_squeeze_view",
+        "//executorch/backends/transforms:remove_permutes_around_elementwise_ops",
         "//executorch/exir:lib",
     ],
 )


### PR DESCRIPTION
### Summary
arm_pass_manager.py imports three transform modules that were missing from the arm_pass_manager_base buck target deps:
- fuse_cascaded_transpose_or_permute_ops
- postpone_permute_below_squeeze_view
- remove_permutes_around_elementwise_ops

This caused ModuleNotFoundError at import time, breaking ARM backend test collection.

Differential Revision: D102650122

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell