### PR TITLE
Fix overflow and stride>1 fallback in cadence::quantized_conv1d HiFi kernels (#19193)

### DIFF
--- a/backends/cadence/hifi/operators/op_quantized_conv1d_ncl.cpp
+++ b/backends/cadence/hifi/operators/op_quantized_conv1d_ncl.cpp
@@ -24,7 +24,6 @@ namespace native {
 
 namespace {
 
-// Optimized NCHW 1D convolution for int8 x int8 -> int8
 void xa_opt_quantized_conv1d_ncl_asym8sxsym8s_asym8s(
     KernelRuntimeContext& ctx,
     const Tensor& input,
@@ -66,7 +65,6 @@ void xa_opt_quantized_conv1d_ncl_asym8sxsym8s_asym8s(
   WORD32 dilation_height = 1;
   WORD32 dilation_width = 1;
   WORD32 input_zero_bias = -in_zero_point;
-  WORD32 kernel_zero_bias = -weight_zero_point;
 
   WORD32 out_zero_bias = output_zero_point;
 
@@ -131,13 +129,17 @@ void xa_opt_quantized_conv1d_ncl_asym8sxsym8s_asym8s(
       kNnlibMaxDim,
       kNnlibMaxDim);
 
-  WORD32 p_out_multiplier32[out_channels];
-  WORD32 p_out_shift32[out_channels];
+  WORD32* p_out_multiplier32 = (WORD32*)kernels::allocate_temp_memory(
+      ctx, out_channels * sizeof(WORD32));
+  WORD32* p_out_shift32 = (WORD32*)kernels::allocate_temp_memory(
+      ctx, out_channels * sizeof(WORD32));
 
-  float out_scale = 1. / output_scale;
+  const float eff_scale = bias_scale * (1.0f / output_scale);
 
   for (int i = 0; i < out_channels; i++) {
-    p_out_multiplier32[i] = bias_scale * out_scale * 2147483648;
+    p_out_multiplier32[i] = (eff_scale >= 1.0f)
+        ? static_cast<WORD32>(2147483647)
+        : static_cast<WORD32>(eff_scale * 2147483648.0f);
     p_out_shift32[i] = 0;
   }
 
@@ -202,7 +204,6 @@ void xa_opt_quantized_conv1d_ncl_asym8sxsym8s_asym8s(
   }
 }
 
-// Optimized NCHW 1D convolution for uint8 x uint8 -> uint8
 void xa_opt_quantized_conv1d_ncl_asym8uxsym8u_asym8u(
     KernelRuntimeContext& ctx,
     const Tensor& input,
@@ -240,7 +241,10 @@ void xa_opt_quantized_conv1d_ncl_asym8uxsym8u_asym8u(
   WORD32 x_stride = stride[0];
   WORD32 x_padding = padding[0];
   WORD32 input_zero_bias = -in_zero_point;
-  WORD32 out_multiplier32 = bias_scale * (1. / output_scale) * 2147483648;
+  const float eff_scale = bias_scale * (1.0f / output_scale);
+  WORD32 out_multiplier32 = (eff_scale >= 1.0f)
+      ? static_cast<WORD32>(2147483647)
+      : static_cast<WORD32>(eff_scale * 2147483648.0f);
   WORD32 out_shift32 = 0;
   WORD32 kernel_zero_bias = -weight_zero_point;
 
@@ -358,7 +362,6 @@ void quantized_conv1d_ncl_per_tensor_out(
     Tensor& out) {
   // HiFi nnlib kernels only support dilation=1.
   // Fall back to generic implementation for dilation > 1.
-  // Note: For 1D convolution, dilation is a single-element array.
   if (dilation[0] != 1) {
     impl::generic::native::quantized_conv1d_ncl_per_tensor_out(
         ctx,
@@ -419,9 +422,9 @@ void quantized_conv1d_ncl_per_tensor_out(
           out);
     }
   } else if (dtype == ScalarType::Byte) {
-    // HiFi nnlib conv1d_std kernel does not support depthwise (groups > 1).
-    // Fall back to generic implementation.
-    if (groups > 1) {
+    // HiFi nnlib conv1d_std kernel does not support depthwise (groups > 1)
+    // or stride > 1. Fall back to generic implementation.
+    if (groups > 1 || stride[0] > 1) {
       impl::generic::native::quantized_conv1d_ncl_per_tensor_out(
           ctx,
           input,

--- a/backends/cadence/hifi/operators/op_quantized_conv1d_nlc.cpp
+++ b/backends/cadence/hifi/operators/op_quantized_conv1d_nlc.cpp
@@ -24,7 +24,6 @@ namespace native {
 
 namespace {
 
-// Optimized NLC 1D convolution for int8 x int8 -> int8
 void xa_opt_quantized_conv1d_nlc_asym8sxsym8s_asym8s(
     KernelRuntimeContext& ctx,
     const Tensor& input,
@@ -64,7 +63,6 @@ void xa_opt_quantized_conv1d_nlc_asym8sxsym8s_asym8s(
   WORD32 dilation_height = 1;
   WORD32 dilation_width = 1;
   WORD32 input_zero_bias = -in_zero_point;
-  WORD32 kernel_zero_bias = -weight_zero_point;
 
   WORD32 input_precision = 8;
   WORD32 kernel_precision = 8;
@@ -73,13 +71,17 @@ void xa_opt_quantized_conv1d_nlc_asym8sxsym8s_asym8s(
 
   WORD32 out_data_format = 0;
 
-  WORD32 p_out_multiplier32[out_channels];
-  WORD32 p_out_shift32[out_channels];
+  WORD32* p_out_multiplier32 = (WORD32*)kernels::allocate_temp_memory(
+      ctx, out_channels * sizeof(WORD32));
+  WORD32* p_out_shift32 = (WORD32*)kernels::allocate_temp_memory(
+      ctx, out_channels * sizeof(WORD32));
 
-  float out_scale = 1. / output_scale;
+  const float eff_scale = bias_scale * (1.0f / output_scale);
 
   for (int i = 0; i < out_channels; i++) {
-    p_out_multiplier32[i] = bias_scale * out_scale * 2147483648;
+    p_out_multiplier32[i] = (eff_scale >= 1.0f)
+        ? static_cast<WORD32>(2147483647)
+        : static_cast<WORD32>(eff_scale * 2147483648.0f);
     p_out_shift32[i] = 0;
   }
 
@@ -144,7 +146,6 @@ void xa_opt_quantized_conv1d_nlc_asym8sxsym8s_asym8s(
   }
 }
 
-// Optimized NLC 1D convolution for uint8 x uint8 -> uint8
 void xa_opt_quantized_conv1d_nlc_asym8uxsym8u_asym8u(
     KernelRuntimeContext& ctx,
     const Tensor& input,
@@ -176,7 +177,10 @@ void xa_opt_quantized_conv1d_nlc_asym8uxsym8u_asym8u(
   WORD32 x_stride = stride[stride.size() - 1];
   WORD32 x_padding = padding[padding.size() - 1];
   WORD32 input_zero_bias = -in_zero_point;
-  WORD32 out_multiplier32 = bias_scale * (1. / output_scale) * 2147483648;
+  const float eff_scale = bias_scale * (1.0f / output_scale);
+  WORD32 out_multiplier32 = (eff_scale >= 1.0f)
+      ? static_cast<WORD32>(2147483647)
+      : static_cast<WORD32>(eff_scale * 2147483648.0f);
   WORD32 out_shift32 = 0;
   WORD32 kernel_zero_bias = -weight_zero_point;
 
@@ -237,7 +241,6 @@ void quantized_conv1d_nlc_per_tensor_out(
     Tensor& out) {
   // HiFi nnlib kernels only support dilation=1.
   // Fall back to generic implementation for dilation > 1.
-  // Note: For 1D convolution, dilation is a single-element array.
   if (dilation[dilation.size() - 1] != 1) {
     impl::generic::native::quantized_conv1d_nlc_per_tensor_out(
         ctx,
@@ -298,9 +301,9 @@ void quantized_conv1d_nlc_per_tensor_out(
           out);
     }
   } else if (dtype == ScalarType::Byte) {
-    // HiFi nnlib conv1d_std kernel does not support depthwise (groups > 1).
-    // Fall back to generic implementation.
-    if (groups > 1) {
+    // HiFi nnlib conv1d_std kernel does not support depthwise (groups > 1)
+    // or stride > 1. Fall back to generic implementation.
+    if (groups > 1 || stride[stride.size() - 1] > 1) {
       impl::generic::native::quantized_conv1d_nlc_per_tensor_out(
           ctx,
           input,


### PR DESCRIPTION
Summary:

The HiFi kernels for `cadence::quantized_conv1d_ncl` and `cadence::quantized_conv1d_nlc` computed `eff_scale * 2147483648.0f` without clamping, producing signed-integer overflow when `eff_scale >= 1.0f`. Both kernels now clamp the multiplier to `INT32_MAX` (2147483647) in that case. Additionally, the int8 (Char) path in the NCL kernel adds a stride>1 fallback to the generic implementation, matching the existing fallback in NLC, because the HiFi conv2d NNLIB kernel produces incorrect results with stride>1 on some hardware backends (e.g., Artemis HiFi4).

Reviewed By: zonglinpeng

Differential Revision: D102821209


