### PR TITLE
Ship runtime/executor and runtime/backend headers in pip wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -599,7 +599,9 @@ class CustomBuildPy(build_py):
         # https://discourse.cmake.org/t/installing-headers-the-modern-way-regurgitated-and-revisited/3238/3
         for include_dir in [
             "runtime/core/",
+            "runtime/executor/",
             "runtime/kernel/",
+            "runtime/backend/",
             "runtime/platform/",
             "extension/kernel_util/",
             "extension/tensor/",


### PR DESCRIPTION

### Summary
The hard-coded list of header directories in `setup.py`'s `CustomBuildPy` diverged from the cmake `install(DIRECTORY ...)` rules in `CMakeLists.txt`, so `runtime/executor/*.h` (e.g. `method.h`, `program.h`, `method_meta.h`) and `runtime/backend/*.h` were never copied into the pip wheel's `include/executorch/...` tree.

Fixes: https://github.com/pytorch/executorch/issues/7261

### Test plan
CI