### PR TITLE
Add libextension_memory_allocator.a to executorch_llm Apple framework

### DIFF
--- a/scripts/build_apple_frameworks.sh
+++ b/scripts/build_apple_frameworks.sh
@@ -80,6 +80,7 @@ libabsl_tracing_internal.a,\
 libabsl_utf8_for_code_point.a,\
 libextension_llm_apple.a,\
 libextension_llm_runner.a,\
+libextension_memory_allocator.a,\
 libpcre2-8.a,\
 libre2.a,\
 libregex_lookahead.a,\


### PR DESCRIPTION
### Summary
PR #15730 added a dependency from extension/llm/runner on extension::CPUCachingAllocator (defined in libextension_memory_allocator.a) but did not update scripts/build_apple_frameworks.sh, so the executorch_llm iOS framework was missing the symbol. This caused the Benchmark Tests target to fail with `Undefined symbols: CPUCachingAllocator(unsigned int)`, breaking the Apple/build-benchmark-app job on trunk.

Authored with the assistance of Claude (Anthropic).

### Test plan
CI