### PR TITLE
Add missing runner_lib dep to main_static (#19210)

### DIFF
--- a/examples/models/llava/main.cpp
+++ b/examples/models/llava/main.cpp
@@ -166,6 +166,7 @@ int32_t main(int32_t argc, char** argv) {
 
   ::executorch::extension::llm::GenerationConfig config;
   config.temperature = temperature;
+  config.seq_len = seq_len;
   config.echo = true;
 
   // Generate

--- a/examples/models/llava/targets.bzl
+++ b/examples/models/llava/targets.bzl
@@ -9,6 +9,7 @@ def define_common_targets():
         compiler_flags = ["-Wno-global-constructors"],
         deps = [
             "//executorch/extension/evalue_util:print_evalue",
+            "//executorch/extension/llm/runner:runner_lib",
             "//executorch/extension/threadpool:cpuinfo_utils",
             "//executorch/extension/threadpool:threadpool",
         ],


### PR DESCRIPTION
Summary:

D82497138 added new transitive includes (`constants.h`, `multimodal_prefiller.h`, `extension/tensor/tensor.h`) into `executorch/extension/llm/runner/util.h`. The llava `main.cpp` already includes `multimodal_runner.h`, `multimodal_input.h`, and `image.h`, and calls `create_multimodal_runner` and `load_tokenizer` from `llm_runner_helper`, but the `main` (and auto-generated `main_static`) target only declared `print_evalue` and `threadpool` deps. After D82497138 the compile fails with `Action failed: ... (cxx_compile main.cpp) Remote command returned non-zero exit code 1` because the `runner_lib` headers cannot be found.

Add `//executorch/extension/llm/runner:runner_lib` (which transitively re-exports `multimodal_runner_lib` and provides `llm_runner_helper`) to the deps of the `main` cxx_binary so the static variant resolves all required headers and symbols. Also wire the existing `seq_len` flag into `GenerationConfig::seq_len` (it was previously read from gflags but never used, which trips `-Werror=unused-variable` once the headers compile).

Reviewed By: psiddh

Differential Revision: D103028501


