### PR TITLE
Add cortex_m MVE/Helium int16 quantize/dequantize support (#19218)

### DIFF
--- a/backends/arm/scripts/aot_arm_compiler.py
+++ b/backends/arm/scripts/aot_arm_compiler.py
@@ -847,8 +847,8 @@ def _to_edge_TOSA_delegate(
     )
 
     # Replace quantized_decomposed::{quantize,dequantize}_per_tensor nodes
-    # with cortex_m:: equivalents for int8 QDQ ops remaining outside the
-    # delegated subgraph.
+    # with cortex_m:: equivalents for int8/int16 QDQ ops remaining outside
+    # the delegated subgraph.
     edge = _apply_replace_quant_nodes(edge, target, direct_drive)
 
     return model_quant, edge
@@ -955,8 +955,8 @@ def _to_edge_no_delegate(
     )
 
     # Replace quantized_decomposed::{quantize,dequantize}_per_tensor nodes
-    # with cortex_m:: equivalents for int8 QDQ ops remaining outside the
-    # delegated subgraph.
+    # with cortex_m:: equivalents for int8/int16 QDQ ops remaining outside
+    # the delegated subgraph.
     edge = _apply_replace_quant_nodes(edge, args.target, args.direct_drive)
 
     return model_quant, edge

--- a/backends/cortex_m/ops/op_dequantize_per_tensor.cpp
+++ b/backends/cortex_m/ops/op_dequantize_per_tensor.cpp
@@ -25,7 +25,7 @@ using KernelRuntimeContext = torch::executor::KernelRuntimeContext;
 namespace {
 
 /**
- * Asserts that the parameters are valid for float to int8 quantization.
+ * Asserts that the parameters are valid for int8/int16 to float dequantization.
  */
 void check_dequantize_args(
     const Tensor& input,
@@ -34,11 +34,18 @@ void check_dequantize_args(
     int64_t quant_max,
     ScalarType dtype,
     Tensor& out) {
-  // Ensure input is char type
+  // dtype must be Char (int8) or Short (int16)
   ET_CHECK_MSG(
-      input.scalar_type() == ScalarType::Char,
-      "input.scalar_type() %" PRId8 " is not char type",
-      static_cast<int8_t>(input.scalar_type()));
+      dtype == ScalarType::Char || dtype == ScalarType::Short,
+      "dtype %" PRId8 " is not int8 (Char) or int16 (Short)",
+      static_cast<int8_t>(dtype));
+
+  // Input scalar type must match dtype
+  ET_CHECK_MSG(
+      input.scalar_type() == dtype,
+      "input.scalar_type() %" PRId8 " does not match dtype %" PRId8,
+      static_cast<int8_t>(input.scalar_type()),
+      static_cast<int8_t>(dtype));
 
   // Check zp range
   ET_CHECK_MSG(
@@ -58,26 +65,26 @@ void check_dequantize_args(
       "out.scalar_type() %" PRId8 " is not float",
       static_cast<int8_t>(out.scalar_type()));
 
-  // Check dtype is int8 (Char)
-  ET_CHECK_MSG(
-      dtype == ScalarType::Char,
-      "dtype %" PRId8 " is not int8 (Char)",
-      static_cast<int8_t>(dtype));
-
-  // Validate quant_min and quant_max for int8
-  int32_t quant_min_lower_bound = std::numeric_limits<int8_t>::min();
-  int32_t quant_max_upper_bound = std::numeric_limits<int8_t>::max();
+  // Validate quant_min and quant_max bounds per dtype
+  int32_t quant_min_lower_bound, quant_max_upper_bound;
+  if (dtype == ScalarType::Char) {
+    quant_min_lower_bound = std::numeric_limits<int8_t>::min();
+    quant_max_upper_bound = std::numeric_limits<int8_t>::max();
+  } else { // Short
+    quant_min_lower_bound = std::numeric_limits<int16_t>::min();
+    quant_max_upper_bound = std::numeric_limits<int16_t>::max();
+  }
 
   ET_CHECK_MSG(
       quant_min >= quant_min_lower_bound,
-      "quant_min out of bound for int8, expected quant_min_lower_bound: %" PRId32
+      "quant_min out of bound, expected quant_min_lower_bound: %" PRId32
       " actual quant_min: %" PRId64,
       quant_min_lower_bound,
       quant_min);
 
   ET_CHECK_MSG(
       quant_max <= quant_max_upper_bound,
-      "quant_max out of bound for int8, expected quant_max_upper_bound: %" PRId32
+      "quant_max out of bound, expected quant_max_upper_bound: %" PRId32
       " actual quant_max: %" PRId64,
       quant_max_upper_bound,
       quant_max);
@@ -115,66 +122,108 @@ Tensor& dequantize_per_tensor_out(
 
   int32_t zp = static_cast<int32_t>(zero_point);
 
-  // Get pointers to input and output data
-  const int8_t* input_data = input.const_data_ptr<int8_t>();
+  // Get pointer to output data
   float* out_data = out.mutable_data_ptr<float>();
   const size_t numel = input.numel();
 
   size_t i = 0;
+
+  if (dtype == ScalarType::Char) {
+    const int8_t* input_data = input.const_data_ptr<int8_t>();
+
 #if defined(HAS_HELIUM_SIMD)
-  // Helium MVE implementation for int8 to float quantization
-  static uint8x16_t voffset{
-      0x0,
-      0x8,
-      0x4,
-      0xC,
-      0x1,
-      0x9,
-      0x5,
-      0xD,
-      0x2,
-      0xA,
-      0x6,
-      0xE,
-      0x3,
-      0xB,
-      0x7,
-      0xF};
+    // Helium MVE implementation for int8 to float quantization
+    static uint8x16_t voffset{
+        0x0,
+        0x8,
+        0x4,
+        0xC,
+        0x1,
+        0x9,
+        0x5,
+        0xD,
+        0x2,
+        0xA,
+        0x6,
+        0xE,
+        0x3,
+        0xB,
+        0x7,
+        0xF};
 
-  int16x8_t vzp = vdupq_n_s16(static_cast<int16_t>(zp));
-  float32x4_t vscale = vdupq_n_f32(static_cast<float>(scale));
+    int16x8_t vzp = vdupq_n_s16(static_cast<int16_t>(zp));
+    float32x4_t vscale = vdupq_n_f32(static_cast<float>(scale));
 
-  for (; i + 15 < numel; i += 16) {
-    int8x16_t in_084C195D2A6E3B7F =
-        vldrbq_gather_offset_s8(input_data, voffset);
+    for (; i + 15 < numel; i += 16) {
+      int8x16_t in_084C195D2A6E3B7F =
+          vldrbq_gather_offset_s8(input_data, voffset);
 
-    int16x8_t in_04152637 = vsubq_s16(vmovlbq_s8(in_084C195D2A6E3B7F), vzp);
-    int16x8_t in_8C9DAEBF = vsubq_s16(vmovltq_s8(in_084C195D2A6E3B7F), vzp);
+      int16x8_t in_04152637 = vsubq_s16(vmovlbq_s8(in_084C195D2A6E3B7F), vzp);
+      int16x8_t in_8C9DAEBF = vsubq_s16(vmovltq_s8(in_084C195D2A6E3B7F), vzp);
 
-    float32x4_t inf_0123 = vcvtq_f32_s32(vmovlbq_s16(in_04152637));
-    float32x4_t inf_4567 = vcvtq_f32_s32(vmovltq_s16(in_04152637));
-    float32x4_t inf_89AB = vcvtq_f32_s32(vmovlbq_s16(in_8C9DAEBF));
-    float32x4_t inf_CDEF = vcvtq_f32_s32(vmovltq_s16(in_8C9DAEBF));
+      float32x4_t inf_0123 = vcvtq_f32_s32(vmovlbq_s16(in_04152637));
+      float32x4_t inf_4567 = vcvtq_f32_s32(vmovltq_s16(in_04152637));
+      float32x4_t inf_89AB = vcvtq_f32_s32(vmovlbq_s16(in_8C9DAEBF));
+      float32x4_t inf_CDEF = vcvtq_f32_s32(vmovltq_s16(in_8C9DAEBF));
 
-    float32x4_t out_0123 = vmulq_f32(inf_0123, vscale);
-    float32x4_t out_4567 = vmulq_f32(inf_4567, vscale);
-    float32x4_t out_89AB = vmulq_f32(inf_89AB, vscale);
-    float32x4_t out_CDEF = vmulq_f32(inf_CDEF, vscale);
+      float32x4_t out_0123 = vmulq_f32(inf_0123, vscale);
+      float32x4_t out_4567 = vmulq_f32(inf_4567, vscale);
+      float32x4_t out_89AB = vmulq_f32(inf_89AB, vscale);
+      float32x4_t out_CDEF = vmulq_f32(inf_CDEF, vscale);
 
-    vstrwq_f32(out_data + 0, out_0123);
-    vstrwq_f32(out_data + 4, out_4567);
-    vstrwq_f32(out_data + 8, out_89AB);
-    vstrwq_f32(out_data + 12, out_CDEF);
+      vstrwq_f32(out_data + 0, out_0123);
+      vstrwq_f32(out_data + 4, out_4567);
+      vstrwq_f32(out_data + 8, out_89AB);
+      vstrwq_f32(out_data + 12, out_CDEF);
 
-    input_data += 16;
-    out_data += 16;
-  }
+      input_data += 16;
+      out_data += 16;
+    }
 #endif // defined(HAS_HELIUM_SIMD)
 
-  for (; i < numel; i++) {
-    *out_data = dequantize_val<int8_t, float>(scale, zp, *input_data);
-    input_data++;
-    out_data++;
+    for (; i < numel; i++) {
+      *out_data = dequantize_val<int8_t, float>(scale, zp, *input_data);
+      input_data++;
+      out_data++;
+    }
+  } else { // ScalarType::Short — int16 input
+    const int16_t* input_data = input.const_data_ptr<int16_t>();
+
+#if defined(HAS_HELIUM_SIMD)
+    // Helium MVE implementation for int16 to float dequantization, processing
+    // 8 elements per iteration. Mirrors the int8 byte-gather trick at halfword
+    // granularity: the gather pattern {0,4,1,5,2,6,3,7} arranges int16 lanes
+    // so that vmovlbq/vmovltq_s16 (which read even/odd lanes of int16x8
+    // widened to int32x4) yield sequential values, allowing a sequential
+    // vstrwq_f32 store.
+    static uint16x8_t voffset_h{0, 4, 1, 5, 2, 6, 3, 7};
+
+    int32x4_t vzp = vdupq_n_s32(zp);
+    float32x4_t vscale = vdupq_n_f32(static_cast<float>(scale));
+
+    for (; i + 7 < numel; i += 8) {
+      int16x8_t in_04152637 =
+          vldrhq_gather_shifted_offset_s16(input_data, voffset_h);
+
+      int32x4_t in_0123 = vsubq_s32(vmovlbq_s16(in_04152637), vzp);
+      int32x4_t in_4567 = vsubq_s32(vmovltq_s16(in_04152637), vzp);
+
+      float32x4_t out_0123 = vmulq_f32(vcvtq_f32_s32(in_0123), vscale);
+      float32x4_t out_4567 = vmulq_f32(vcvtq_f32_s32(in_4567), vscale);
+
+      vstrwq_f32(out_data + 0, out_0123);
+      vstrwq_f32(out_data + 4, out_4567);
+
+      input_data += 8;
+      out_data += 8;
+    }
+#endif // defined(HAS_HELIUM_SIMD)
+
+    for (; i < numel; i++) {
+      *out_data = dequantize_val<int16_t, float>(scale, zp, *input_data);
+      input_data++;
+      out_data++;
+    }
   }
   return out;
 }

--- a/backends/cortex_m/ops/op_quantize_per_tensor.cpp
+++ b/backends/cortex_m/ops/op_quantize_per_tensor.cpp
@@ -27,7 +27,7 @@ using KernelRuntimeContext = torch::executor::KernelRuntimeContext;
 namespace {
 
 /**
- * Asserts that the parameters are valid for float to int8 quantization.
+ * Asserts that the parameters are valid for float to int8/int16 quantization.
  */
 void check_quantize_args(
     const Tensor& input,
@@ -41,32 +41,37 @@ void check_quantize_args(
       "input.scalar_type() %" PRId8 " is not float type",
       static_cast<int8_t>(input.scalar_type()));
 
-  // Check output dtype is int8
+  // Check output dtype matches dtype param (Char/int8 or Short/int16)
   ET_CHECK_MSG(
-      out.scalar_type() == ScalarType::Char,
-      "out.scalar_type() %" PRId8 " is not int8 (Char)",
-      static_cast<int8_t>(out.scalar_type()));
-
-  // Check dtype is int8
+      dtype == ScalarType::Char || dtype == ScalarType::Short,
+      "dtype %" PRId8 " is not int8 (Char) or int16 (Short)",
+      static_cast<int8_t>(dtype));
   ET_CHECK_MSG(
-      dtype == ScalarType::Char,
-      "dtype %" PRId8 " is not int8 (Char)",
+      out.scalar_type() == dtype,
+      "out.scalar_type() %" PRId8 " does not match dtype %" PRId8,
+      static_cast<int8_t>(out.scalar_type()),
       static_cast<int8_t>(dtype));
 
-  // Validate quant_min and quant_max for int8
-  int32_t quant_min_lower_bound = std::numeric_limits<int8_t>::min();
-  int32_t quant_max_upper_bound = std::numeric_limits<int8_t>::max();
+  // Validate quant_min and quant_max bounds per dtype
+  int32_t quant_min_lower_bound, quant_max_upper_bound;
+  if (dtype == ScalarType::Char) {
+    quant_min_lower_bound = std::numeric_limits<int8_t>::min();
+    quant_max_upper_bound = std::numeric_limits<int8_t>::max();
+  } else { // Short
+    quant_min_lower_bound = std::numeric_limits<int16_t>::min();
+    quant_max_upper_bound = std::numeric_limits<int16_t>::max();
+  }
 
   ET_CHECK_MSG(
       quant_min >= quant_min_lower_bound,
-      "quant_min out of bound for int8, expected quant_min_lower_bound: %" PRId32
+      "quant_min out of bound, expected quant_min_lower_bound: %" PRId32
       " actual quant_min: %" PRId64,
       quant_min_lower_bound,
       quant_min);
 
   ET_CHECK_MSG(
       quant_max <= quant_max_upper_bound,
-      "quant_max out of bound for int8, expected quant_max_upper_bound: %" PRId32
+      "quant_max out of bound, expected quant_max_upper_bound: %" PRId32
       " actual quant_max: %" PRId64,
       quant_max_upper_bound,
       quant_max);
@@ -120,99 +125,153 @@ Tensor& quantize_per_tensor_out(
 
   // Get pointers to input and output data
   const float* input_data = input.const_data_ptr<float>();
-  int8_t* out_data = out.mutable_data_ptr<int8_t>();
   const size_t numel = input.numel();
 
   size_t i = 0;
 
+  if (dtype == ScalarType::Char) {
+    int8_t* out_data = out.mutable_data_ptr<int8_t>();
+
 #if defined(HAS_HELIUM_SIMD)
-  // Helium MVE implementation for float32 to int8 quantization
-  static uint8x16_t voffset{
-      0x0,
-      0x8,
-      0x4,
-      0xC,
-      0x1,
-      0x9,
-      0x5,
-      0xD,
-      0x2,
-      0xA,
-      0x6,
-      0xE,
-      0x3,
-      0xB,
-      0x7,
-      0xF};
+    // Helium MVE implementation for float32 to int8 quantization
+    static uint8x16_t voffset{
+        0x0,
+        0x8,
+        0x4,
+        0xC,
+        0x1,
+        0x9,
+        0x5,
+        0xD,
+        0x2,
+        0xA,
+        0x6,
+        0xE,
+        0x3,
+        0xB,
+        0x7,
+        0xF};
 
-  float32x4_t inv_scale_vec = vdupq_n_f32(inv_scale);
+    float32x4_t inv_scale_vec = vdupq_n_f32(inv_scale);
 
-  // Magic number for float to int conversion, round to nearest even integer
-  // int magic_round(float f): interpret_as_int32(f + magic_float) - magic_int
-  // where,
-  //    magic_float = 12582912.0f = (2 ** 23 + 2 ** 22) = (1.5 * 2 ** 23)
-  //    magic_int = 1262485504 = 0x4B400000 = bit_pattern_as_int32(magic_float)
+    // Magic number for float to int conversion, round to nearest even integer
+    // int magic_round(float f): interpret_as_int32(f + magic_float) - magic_int
+    // where,
+    //    magic_float = 12582912.0f = (2 ** 23 + 2 ** 22) = (1.5 * 2 ** 23)
+    //    magic_int = 1262485504 = 0x4B400000 =
+    //    bit_pattern_as_int32(magic_float)
 
-  float magic_float = 12582912.0f;
-  int32_t magic_int = 1262485504;
+    float magic_float = 12582912.0f;
+    int32_t magic_int = 1262485504;
 
-  float32x4_t vmagic_float = vdupq_n_f32(magic_float);
-  int32x4_t vmagic_int_less_zp =
-      vdupq_n_s32(magic_int - static_cast<int32_t>(zp));
+    float32x4_t vmagic_float = vdupq_n_f32(magic_float);
+    int32x4_t vmagic_int_less_zp =
+        vdupq_n_s32(magic_int - static_cast<int32_t>(zp));
 
-  int16x8_t vqmin = vdupq_n_s16(qmin);
-  int16x8_t vqmax = vdupq_n_s16(qmax);
+    int16x8_t vqmin = vdupq_n_s16(qmin);
+    int16x8_t vqmax = vdupq_n_s16(qmax);
 
-  // TODO: Measure performnce, we are spilling
-  for (; i + 15 < numel; i += 16) {
-    float32x4_t in_0123 = vldrwq_f32(input_data + 0);
-    float32x4_t in_4567 = vldrwq_f32(input_data + 4);
-    float32x4_t in_89AB = vldrwq_f32(input_data + 8);
-    float32x4_t in_CDEF = vldrwq_f32(input_data + 12);
+    // TODO: Measure performnce, we are spilling
+    for (; i + 15 < numel; i += 16) {
+      float32x4_t in_0123 = vldrwq_f32(input_data + 0);
+      float32x4_t in_4567 = vldrwq_f32(input_data + 4);
+      float32x4_t in_89AB = vldrwq_f32(input_data + 8);
+      float32x4_t in_CDEF = vldrwq_f32(input_data + 12);
 
-    float32x4_t outf_0123 = vfmaq_f32(vmagic_float, in_0123, inv_scale_vec);
-    float32x4_t outf_4567 = vfmaq_f32(vmagic_float, in_4567, inv_scale_vec);
-    float32x4_t outf_89AB = vfmaq_f32(vmagic_float, in_89AB, inv_scale_vec);
-    float32x4_t outf_CDEF = vfmaq_f32(vmagic_float, in_CDEF, inv_scale_vec);
+      float32x4_t outf_0123 = vfmaq_f32(vmagic_float, in_0123, inv_scale_vec);
+      float32x4_t outf_4567 = vfmaq_f32(vmagic_float, in_4567, inv_scale_vec);
+      float32x4_t outf_89AB = vfmaq_f32(vmagic_float, in_89AB, inv_scale_vec);
+      float32x4_t outf_CDEF = vfmaq_f32(vmagic_float, in_CDEF, inv_scale_vec);
 
-    int32x4_t out_0123 =
-        vsubq_s32(vreinterpretq_s32_f32(outf_0123), vmagic_int_less_zp);
-    int32x4_t out_4567 =
-        vsubq_s32(vreinterpretq_s32_f32(outf_4567), vmagic_int_less_zp);
-    int32x4_t out_89AB =
-        vsubq_s32(vreinterpretq_s32_f32(outf_89AB), vmagic_int_less_zp);
-    int32x4_t out_CDEF =
-        vsubq_s32(vreinterpretq_s32_f32(outf_CDEF), vmagic_int_less_zp);
+      int32x4_t out_0123 =
+          vsubq_s32(vreinterpretq_s32_f32(outf_0123), vmagic_int_less_zp);
+      int32x4_t out_4567 =
+          vsubq_s32(vreinterpretq_s32_f32(outf_4567), vmagic_int_less_zp);
+      int32x4_t out_89AB =
+          vsubq_s32(vreinterpretq_s32_f32(outf_89AB), vmagic_int_less_zp);
+      int32x4_t out_CDEF =
+          vsubq_s32(vreinterpretq_s32_f32(outf_CDEF), vmagic_int_less_zp);
 
-    int16x8_t out_04152637;
-    int16x8_t out_8C9DAEBF;
-    out_04152637 = vmovnbq_s32(out_04152637, out_0123);
-    out_04152637 = vmovntq_s32(out_04152637, out_4567);
-    out_8C9DAEBF = vmovnbq_s32(out_8C9DAEBF, out_89AB);
-    out_8C9DAEBF = vmovntq_s32(out_8C9DAEBF, out_CDEF);
+      int16x8_t out_04152637;
+      int16x8_t out_8C9DAEBF;
+      out_04152637 = vmovnbq_s32(out_04152637, out_0123);
+      out_04152637 = vmovntq_s32(out_04152637, out_4567);
+      out_8C9DAEBF = vmovnbq_s32(out_8C9DAEBF, out_89AB);
+      out_8C9DAEBF = vmovntq_s32(out_8C9DAEBF, out_CDEF);
 
-    int16x8_t out_04152637_clamped =
-        vminq_s16(vmaxq_s16(out_04152637, vqmin), vqmax);
-    int16x8_t out_8C9DAEBF_clamped =
-        vminq_s16(vmaxq_s16(out_8C9DAEBF, vqmin), vqmax);
+      int16x8_t out_04152637_clamped =
+          vminq_s16(vmaxq_s16(out_04152637, vqmin), vqmax);
+      int16x8_t out_8C9DAEBF_clamped =
+          vminq_s16(vmaxq_s16(out_8C9DAEBF, vqmin), vqmax);
 
-    int8x16_t out_084C195D2A6E3B7F;
-    out_084C195D2A6E3B7F =
-        vmovnbq_s16(out_084C195D2A6E3B7F, out_04152637_clamped);
-    out_084C195D2A6E3B7F =
-        vmovntq_s16(out_084C195D2A6E3B7F, out_8C9DAEBF_clamped);
+      int8x16_t out_084C195D2A6E3B7F;
+      out_084C195D2A6E3B7F =
+          vmovnbq_s16(out_084C195D2A6E3B7F, out_04152637_clamped);
+      out_084C195D2A6E3B7F =
+          vmovntq_s16(out_084C195D2A6E3B7F, out_8C9DAEBF_clamped);
 
-    vstrbq_scatter_offset_s8(out_data, voffset, out_084C195D2A6E3B7F);
-    input_data += 16;
-    out_data += 16;
-  }
+      vstrbq_scatter_offset_s8(out_data, voffset, out_084C195D2A6E3B7F);
+      input_data += 16;
+      out_data += 16;
+    }
 #endif // defined(HAS_HELIUM_SIMD)
 
-  for (; i < numel; i++) {
-    *out_data =
-        quantize_val<int8_t, float>(inv_scale, zp, *input_data, qmin, qmax);
-    input_data++;
-    out_data++;
+    for (; i < numel; i++) {
+      *out_data =
+          quantize_val<int8_t, float>(inv_scale, zp, *input_data, qmin, qmax);
+      input_data++;
+      out_data++;
+    }
+  } else { // ScalarType::Short — int16
+    int16_t* out_data = out.mutable_data_ptr<int16_t>();
+
+#if defined(HAS_HELIUM_SIMD)
+    // Helium MVE implementation for float32 to int16 quantization, processing
+    // 8 elements per iteration. Uses the same magic-number rounding trick as
+    // the int8 path. Output goes through vstrhq_s32 (narrow int32->int16
+    // sequential store), so no deinterleave dance is needed.
+    float magic_float = 12582912.0f;
+    int32_t magic_int = 1262485504;
+
+    float32x4_t inv_scale_vec = vdupq_n_f32(inv_scale);
+    float32x4_t vmagic_float = vdupq_n_f32(magic_float);
+    int32x4_t vmagic_int_less_zp =
+        vdupq_n_s32(magic_int - static_cast<int32_t>(zp));
+
+    int32x4_t vqmin = vdupq_n_s32(qmin);
+    int32x4_t vqmax = vdupq_n_s32(qmax);
+
+    for (; i + 7 < numel; i += 8) {
+      float32x4_t in_0123 = vldrwq_f32(input_data + 0);
+      float32x4_t in_4567 = vldrwq_f32(input_data + 4);
+
+      float32x4_t outf_0123 = vfmaq_f32(vmagic_float, in_0123, inv_scale_vec);
+      float32x4_t outf_4567 = vfmaq_f32(vmagic_float, in_4567, inv_scale_vec);
+
+      int32x4_t out_0123 =
+          vsubq_s32(vreinterpretq_s32_f32(outf_0123), vmagic_int_less_zp);
+      int32x4_t out_4567 =
+          vsubq_s32(vreinterpretq_s32_f32(outf_4567), vmagic_int_less_zp);
+
+      // Clamp at int32 width before narrowing.
+      out_0123 = vminq_s32(vmaxq_s32(out_0123, vqmin), vqmax);
+      out_4567 = vminq_s32(vmaxq_s32(out_4567, vqmin), vqmax);
+
+      // Narrow store: low 16 bits of each int32 lane stored sequentially.
+      vstrhq_s32(out_data + 0, out_0123);
+      vstrhq_s32(out_data + 4, out_4567);
+
+      input_data += 8;
+      out_data += 8;
+    }
+#endif // defined(HAS_HELIUM_SIMD)
+
+    for (; i < numel; i++) {
+      *out_data =
+          quantize_val<int16_t, float>(inv_scale, zp, *input_data, qmin, qmax);
+      input_data++;
+      out_data++;
+    }
   }
 
   return out;

--- a/backends/cortex_m/passes/replace_quant_nodes_pass.py
+++ b/backends/cortex_m/passes/replace_quant_nodes_pass.py
@@ -21,23 +21,32 @@ class ReplaceQuantNodesPass(ExportPass):
     """
 
     @staticmethod
-    def _is_qualified_int8_node(args) -> bool:
-        return (
-            args[3] >= torch.iinfo(torch.int8).min  # qmin
-            and args[4] <= torch.iinfo(torch.int8).max  # qmax
-            and args[5] == torch.int8  # dtype
-        )
+    def _is_qualified_node(args) -> bool:
+        """Match int8 OR int16 (de)quantize_per_tensor nodes. The cortex_m C++
+        kernels handle both dtypes via MVE-vectorized paths."""
+        dtype = args[5]
+        if dtype == torch.int8:
+            return (
+                args[3] >= torch.iinfo(torch.int8).min  # qmin
+                and args[4] <= torch.iinfo(torch.int8).max  # qmax
+            )
+        if dtype == torch.int16:
+            return (
+                args[3] >= torch.iinfo(torch.int16).min  # qmin
+                and args[4] <= torch.iinfo(torch.int16).max  # qmax
+            )
+        return False
 
     def __init__(self):
         super().__init__()
         self.op_replacements = {
             exir_ops.edge.quantized_decomposed.quantize_per_tensor.default: {
                 "new_target": exir_ops.edge.cortex_m.quantize_per_tensor.default,
-                "qualifier": self._is_qualified_int8_node,
+                "qualifier": self._is_qualified_node,
             },
             exir_ops.edge.quantized_decomposed.dequantize_per_tensor.default: {
                 "new_target": exir_ops.edge.cortex_m.dequantize_per_tensor.default,
-                "qualifier": self._is_qualified_int8_node,
+                "qualifier": self._is_qualified_node,
             },
         }
         self.disallowed_targets = {

--- a/backends/cortex_m/test/op_dequantize_per_tensor_test.cpp
+++ b/backends/cortex_m/test/op_dequantize_per_tensor_test.cpp
@@ -21,7 +21,7 @@ using torch::executor::testing::TensorFactory;
 // Test op
 using cortex_m::native::dequantize_per_tensor_out;
 
-void test_dtype() {
+void test_dtype_int8() {
   TensorFactory<ScalarType::Char> tf;
 
   Tensor input = tf.full({3, 5}, 4);
@@ -50,6 +50,38 @@ void test_dtype() {
   EXPECT_TENSOR_EQ(out, expected);
 }
 
+void test_dtype_int16() {
+  TensorFactory<ScalarType::Short> tf;
+
+  // Shape sized to exercise the MVE int16 path (8-element chunks via
+  // vldrhq_gather_shifted_offset_s16 + vmovlbq/vmovltq deinterleave).
+  Tensor input = tf.full({4, 4}, 4);
+  double scale = 0.5;
+
+  int64_t zero_point = 1000;
+  int64_t quant_min = -32768;
+  int64_t quant_max = 32767;
+
+  TensorFactory<ScalarType::Float> tfo;
+  Tensor out = tfo.zeros({4, 4});
+  // (4 - 1000) * 0.5 = -498
+  Tensor expected = tfo.full({4, 4}, -498.0);
+
+  KernelRuntimeContext ctx;
+  dequantize_per_tensor_out(
+      ctx,
+      input,
+      scale,
+      zero_point,
+      quant_min,
+      quant_max,
+      ScalarType::Short,
+      out);
+
+  EXPECT_TENSOR_EQ(out, expected);
+}
+
 TEST(OpDequantizeOutTest, AllDtypesSupported) {
-  test_dtype();
+  test_dtype_int8();
+  test_dtype_int16();
 }

--- a/backends/cortex_m/test/op_quantize_per_tensor_test.cpp
+++ b/backends/cortex_m/test/op_quantize_per_tensor_test.cpp
@@ -21,7 +21,7 @@ using torch::executor::testing::TensorFactory;
 // Test op
 using cortex_m::native::quantize_per_tensor_out;
 
-void test_dtype() {
+void test_dtype_int8() {
   TensorFactory<ScalarType::Float> tf;
 
   Tensor input = tf.full({3, 5}, 4);
@@ -50,6 +50,67 @@ void test_dtype() {
   EXPECT_TENSOR_EQ(out, expected);
 }
 
+void test_dtype_int16() {
+  TensorFactory<ScalarType::Float> tf;
+
+  // Shape sized to exercise the MVE int16 path (8-element chunks).
+  Tensor input = tf.full({4, 4}, 4);
+  double scale = 0.5;
+
+  int64_t zero_point = 1000;
+  int64_t quant_min = -32768;
+  int64_t quant_max = 32767;
+
+  TensorFactory<ScalarType::Short> tfo;
+  Tensor out = tfo.zeros({4, 4});
+  // 4 / 0.5 + 1000 = 1008
+  Tensor expected = tfo.full({4, 4}, 1008);
+
+  KernelRuntimeContext ctx;
+  quantize_per_tensor_out(
+      ctx,
+      input,
+      scale,
+      zero_point,
+      quant_min,
+      quant_max,
+      ScalarType::Short,
+      out);
+
+  EXPECT_TENSOR_EQ(out, expected);
+}
+
+void test_dtype_int16_clamp() {
+  TensorFactory<ScalarType::Float> tf;
+
+  // Input large enough to clamp at quant_max after scaling.
+  Tensor input = tf.full({4, 4}, 100000);
+  double scale = 0.5;
+
+  int64_t zero_point = 0;
+  int64_t quant_min = -32768;
+  int64_t quant_max = 32767;
+
+  TensorFactory<ScalarType::Short> tfo;
+  Tensor out = tfo.zeros({4, 4});
+  Tensor expected = tfo.full({4, 4}, 32767);
+
+  KernelRuntimeContext ctx;
+  quantize_per_tensor_out(
+      ctx,
+      input,
+      scale,
+      zero_point,
+      quant_min,
+      quant_max,
+      ScalarType::Short,
+      out);
+
+  EXPECT_TENSOR_EQ(out, expected);
+}
+
 TEST(OpQuantizeOutTest, AllDtypesSupported) {
-  test_dtype();
+  test_dtype_int8();
+  test_dtype_int16();
+  test_dtype_int16_clamp();
 }


### PR DESCRIPTION
Summary:

Adds MVE-vectorized int16 (Short) paths to the Cortex-M ExecuTorch quant ops, so the ARM partitioner rewrites int16 quantized_decomposed::* to cortex_m::*. Previously cortex_m only handled int8 — int16 quant ops fell through to the portable scalar fallback.

Differential Revision: D103129855




cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell