### PR TITLE
Qualcomm AI Engine Direct - Decouple quantization and compile graphs for faster VLM/LLM PTQ

### DIFF
--- a/backends/qualcomm/tests/test_qnn_delegate.py
+++ b/backends/qualcomm/tests/test_qnn_delegate.py
@@ -7597,6 +7597,11 @@ class TestExampleLLMScript(TestQNN):
             case "sqnr":
                 cmds.extend(
                     [
+                        "--skip_user_prompt_calibration",
+                        "--tasks",
+                        "wikitext",
+                        "--limit",
+                        "1",
                         "--eval_methods",
                         "sqnr_eval",
                     ]

--- a/examples/qualcomm/oss_scripts/llama/decoder_runtime_evaluator.py
+++ b/examples/qualcomm/oss_scripts/llama/decoder_runtime_evaluator.py
@@ -424,7 +424,7 @@ class SqnrEval(EvalBase):
                 self.max_seq_length = pte_max_context_len
 
     def run(self, prompt):
-        golden_logits, _ = INFERENCE_REGISTRY[True](
+        result = INFERENCE_REGISTRY[True](
             get_example_inputs=self.get_example_inputs,
             prompt=prompt,
             module=self.source_model,
@@ -433,6 +433,7 @@ class SqnrEval(EvalBase):
             use_i64_token=self.args.embedding_quantize is not None,
             collect_logits=True,
         )
+        golden_logits = result.logits
 
         input_file_name = f"{self.args.artifact}/input_tokens.raw"
 

--- a/examples/qualcomm/oss_scripts/llama/decoder_utils.py
+++ b/examples/qualcomm/oss_scripts/llama/decoder_utils.py
@@ -77,6 +77,13 @@ class DecoderInputs:
     embedding: Optional[torch.Tensor] = None
 
 
+@dataclass
+class DecoderOutputs:
+    logits: Optional[torch.Tensor] = None
+    token_list: Optional[List[int]] = None
+    input_samples: Optional[List] = None
+
+
 class GraphModuleCalibrationWrapper(EagerEvalWrapper):
     """
     A wrapper class for calibration
@@ -94,6 +101,7 @@ class GraphModuleCalibrationWrapper(EagerEvalWrapper):
         get_example_inputs: Callable,
         use_i64_token: bool,
         seq_mse_candidates: int,
+        collect_input_samples: bool = False,
     ):
         # n seq len = n-1 cache len, so we len(inps) = n-1 during _model_call
         assert max_seq_length is not None, "max_seq_length must be provided"
@@ -108,18 +116,18 @@ class GraphModuleCalibrationWrapper(EagerEvalWrapper):
         self.use_i64_token = use_i64_token
         self.seq_mse_candidates = seq_mse_candidates
         self._input_samples = None
+        self.collect_input_samples = collect_input_samples
 
     def get_input_samples(self):
         return self._input_samples
 
     def _model_call(self, inps):
-        all_logits = None
         kwargs = {}
         if self._use_kv_cache:
             kwargs["ar_len"] = self.ar_len
             kwargs["seq_mse_candidates"] = self.seq_mse_candidates
 
-        all_logits, self._input_samples = INFERENCE_REGISTRY[self._use_kv_cache](
+        result = INFERENCE_REGISTRY[self._use_kv_cache](
             self.get_example_inputs,
             inps,
             self._model,
@@ -127,11 +135,13 @@ class GraphModuleCalibrationWrapper(EagerEvalWrapper):
             max_seq_len=self.max_seq_length,
             use_i64_token=self.use_i64_token,
             collect_logits=True,
+            collect_input_samples=self.collect_input_samples,
             **kwargs,
         )
+        self._input_samples = result.input_samples
         # one shot is enough for seq mse
         self.seq_mse_candidates = 0
-        return all_logits
+        return result.logits
 
 
 class LookaheadDecoder:
@@ -727,7 +737,8 @@ def kv_inference(  # noqa: C901
     collect_logits=False,
     seq_mse_candidates=0,
     lookahead_config=None,
-):
+    collect_input_samples=False,
+) -> DecoderOutputs:
     input_samples = []  # Record input sample for quantization error analysis
     is_multimodal = all(
         [
@@ -814,6 +825,7 @@ def kv_inference(  # noqa: C901
 
     # record total input tokens and generated tokens
     total_token_list = prompt_token_list
+    last_token_in_prompt = prompt_token_list[-1] if len(prompt_token_list) > 0 else None
 
     # 3. prepare decoder inputs
     inputs = DecoderInputs(
@@ -841,28 +853,33 @@ def kv_inference(  # noqa: C901
 
         # Phase 2: Generate tokens until the EOS token is generated or max_seq_len is reached.
         # When run on wikitext for ppl evaluation, this while-loop is not expected to run.
-        generate_input_sample = _generate(
-            inputs,
-            cur_pos,
-            module,
-            tokenizer,
-            tok_embedding,
-            ar_len,
-            max_seq_len,
-            k_caches,
-            v_caches,
-            total_token_list,
-            lookahead_config,
-        )
-        if generate_input_sample is not None:
-            input_samples.append(generate_input_sample)
-        else:
-            input_samples.append(prefill_input_sample)
+        generate_input_sample = None
+        if last_token_in_prompt != tokenizer.eos_id:
+            generate_input_sample = _generate(
+                inputs,
+                cur_pos,
+                module,
+                tokenizer,
+                tok_embedding,
+                ar_len,
+                max_seq_len,
+                k_caches,
+                v_caches,
+                total_token_list,
+                lookahead_config,
+            )
+
+        if collect_input_samples:
+            input_samples.append(generate_input_sample or prefill_input_sample)
 
     logging.info(f"kv inference result:\n{tokenizer.decode(total_token_list)}")
     if collect_logits:
         result_logits = torch.cat(result_logits, dim=1)
-    return result_logits, input_samples
+    return DecoderOutputs(
+        logits=result_logits if collect_logits else None,
+        token_list=total_token_list,
+        input_samples=input_samples if collect_input_samples else None,
+    )
 
 
 @register_inference(use_kv_cache=False)
@@ -878,7 +895,8 @@ def prefill_inference(
     max_seq_len=512,
     use_i64_token=False,
     collect_logits=False,
-):
+    collect_input_samples=False,
+) -> DecoderOutputs:
     input_samples = None  # Record input sample for quantization error analysis
     is_multimodal = all(
         [
@@ -946,7 +964,11 @@ def prefill_inference(
             pos += 1
     if isinstance(prompt, str):
         logging.info(f"prefill inference result:\n{tokenizer.decode(token_list)}")
-    return result_logits, [input_samples]
+    return DecoderOutputs(
+        logits=result_logits if collect_logits else None,
+        token_list=token_list,
+        input_samples=[input_samples] if collect_input_samples else None,
+    )
 
 
 def graph_module_inference(
@@ -968,7 +990,8 @@ def graph_module_inference(
     event_name: Optional[str] = None,
     seq_mse_candidates: int = 0,
     lookahead_config: Optional[Tuple[int]] = None,
-):
+    collect_input_samples: bool = False,
+) -> DecoderOutputs:
     """
     This function supports model execution from static nn.Module decoder model
     all the way to edge program.
@@ -984,7 +1007,7 @@ def graph_module_inference(
             kwargs["ar_len"] = ar_len
             kwargs["lookahead_config"] = lookahead_config
 
-        _, input_samples = INFERENCE_REGISTRY[use_kv_cache](
+        result = INFERENCE_REGISTRY[use_kv_cache](
             get_example_inputs,
             prompt,
             module,
@@ -996,10 +1019,11 @@ def graph_module_inference(
             max_seq_len=max_seq_len,
             use_i64_token=use_i64_token,
             collect_logits=False,
+            collect_input_samples=collect_input_samples,
             **kwargs,
         )
         logging.info(f"Prompt summary for {event_name}")
-        return input_samples
+        return result
     else:
         calibration_wrapper = GraphModuleCalibrationWrapper(
             model=module,
@@ -1010,6 +1034,7 @@ def graph_module_inference(
             get_example_inputs=get_example_inputs,
             use_i64_token=use_i64_token,
             seq_mse_candidates=seq_mse_candidates,
+            collect_input_samples=collect_input_samples,
         )
         with torch.no_grad():
             eval_results = simple_evaluate(
@@ -1022,4 +1047,4 @@ def graph_module_inference(
         for task, res in eval_results["results"].items():
             logging.info(f"{task}: {res}")
 
-        return calibration_wrapper.get_input_samples()
+        return DecoderOutputs(input_samples=calibration_wrapper.get_input_samples())

--- a/examples/qualcomm/oss_scripts/llama/llama.py
+++ b/examples/qualcomm/oss_scripts/llama/llama.py
@@ -577,6 +577,12 @@ def _build_parser():
         help="Enable automatic quant recipe suggestion in PTQ",
     )
 
+    parser.add_argument(
+        "--skip_user_prompt_calibration",
+        action="store_true",
+        help="Skip using user prompt for calibration. Useful when only dataset-based calibration is desired.",
+    )
+
     return parser
 
 
@@ -676,6 +682,9 @@ def export_llama(args) -> None:
     assert (
         not is_multimodal or args.use_attention_sink is None
     ), "Multimodal models currently do not support attention sink feature."
+    assert (
+        not is_multimodal or not args.skip_user_prompt_calibration
+    ), "--skip_user_prompt_calibration is not supported for multimodal models (VLM/ALM) as they do not support task-based calibration yet."
 
     if args.pre_gen_pte:
         text_decoder_pte_path = f"{args.pre_gen_pte}/{pte_filenames[TEXT_DECODER]}.pte"

--- a/examples/qualcomm/oss_scripts/llama/wrappers/base_component.py
+++ b/examples/qualcomm/oss_scripts/llama/wrappers/base_component.py
@@ -40,6 +40,7 @@ from transformers import AutoConfig
 class Mode(Enum):
     PREFILL = 1
     DECODE = 2
+    CALIBRATE = 3
 
 
 def log_info(func):
@@ -83,7 +84,7 @@ def process_model_args(
         model_args: ModelArgs object to be modified.
         quant_recipe: Quantization recipe to be used.
         config: LLMModelConfig object to be used.
-        mode: Mode of operation (PREFILL or DECODE).
+        mode: Mode of operation (PREFILL, DECODE, or CALIBRATE).
     """
     # TODO: support batch inputs if necessary
     if mode == Mode.DECODE:
@@ -95,13 +96,19 @@ def process_model_args(
             if control_args.model_mode == "lookahead"
             else 1
         )
-    else:
+    elif mode == Mode.PREFILL:
         ar_len = control_args.prefill_ar_len
+    elif mode == Mode.CALIBRATE:
+        ar_len = control_args.max_context_len
+    else:
+        raise ValueError(f"Unsupported mode: {mode}")
 
     model_args.max_batch_size = 1
     model_args.max_seq_len = control_args.max_seq_len
     model_args.max_context_len = control_args.max_context_len
-    model_args.use_kv_cache = control_args.max_context_len != ar_len
+    model_args.use_kv_cache = (
+        control_args.max_context_len != ar_len or mode == Mode.CALIBRATE
+    )
     model_args.enable_r3 = config.r3
     model_args.ar_len = ar_len
     model_args.kv_io_bit_width = quant_recipe.get_kv_io_bit_width()

--- a/examples/qualcomm/oss_scripts/llama/wrappers/llm_wrappers.py
+++ b/examples/qualcomm/oss_scripts/llama/wrappers/llm_wrappers.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 import argparse
 import copy
+import gc
 import inspect
 import json
 import logging
@@ -61,6 +62,7 @@ from executorch.examples.qualcomm.oss_scripts.llama.decoder_constants import (
     VISION_ENCODER,
 )
 from executorch.examples.qualcomm.oss_scripts.llama.decoder_utils import (
+    _modality_inputs_merger,
     graph_module_inference,
 )
 from executorch.examples.qualcomm.oss_scripts.llama.encoder.encoder_config import (
@@ -101,7 +103,47 @@ from executorch.extension.llm.export.builder import DType
 from torchao.prototype.spinquant import apply_spinquant
 from torchao.quantization.pt2e import MinMaxObserver
 from torchao.quantization.pt2e.quantize_pt2e import convert_pt2e, prepare_pt2e
-from transformers import AutoModel, AutoModelForSpeechSeq2Seq
+from transformers import (
+    AutoModel,
+    AutoModelForCausalLM,
+    AutoModelForImageTextToText,
+    AutoModelForSpeechSeq2Seq,
+    AutoModelForVision2Seq,
+)
+
+
+def is_node_src_start_with_name(node: torch.fx.Node, kv_cache_prefix: str) -> bool:
+    """
+    Return True if any NodeSource in node.meta['from_node'] has a name
+    starting with `kv_cache_prefix`. Used to identify K/V cache nodes by their
+    "k_" or "v_" name prefix in the traced graph.
+    """
+
+    def has_source_name_prefix(
+        node_src: torch.fx.traceback.NodeSource, kv_cache_prefix: str
+    ) -> bool:
+
+        name = getattr(node_src, "name", None)
+        if isinstance(name, str) and name.startswith(kv_cache_prefix):
+            return True
+
+        children = getattr(node_src, "from_node", None)
+        if not children:
+            return False
+
+        for src in children:
+            if has_source_name_prefix(src, kv_cache_prefix):
+                return True
+
+        return False
+
+    node_srcs = node.meta.get("from_node", None)
+    if not node_srcs:
+        return False
+
+    return any(
+        has_source_name_prefix(node_src, kv_cache_prefix) for node_src in node_srcs
+    )
 
 
 class TextDecoder(Component):
@@ -120,7 +162,9 @@ class TextDecoder(Component):
         self.dep_table = get_passes_dependency_for_capture_program()
         self.meta = {}
         self.quant_recipe: StaticLLMQuantRecipe = (
-            self.config.quant_recipe(True) if self.config.quant_recipe else None
+            self.config.quant_recipe(mode == Mode.CALIBRATE)
+            if self.config.quant_recipe
+            else None
         )
 
         # For multimodal embedding
@@ -525,6 +569,7 @@ class TextDecoder(Component):
         user_calibration_data,
         tok_embedding=None,
         intermediate_outputs=None,
+        collect_input_samples=False,
     ):
         """
         Calibrate the model using either task-based evaluation or prompt-based inference.
@@ -552,7 +597,7 @@ class TextDecoder(Component):
         # Multimodal models (VLMs) cannot use task-based evaluation currently.
         input_samples = []
         if has_task_calibration and not is_multimodal:
-            input_sample = graph_module_inference(
+            result = graph_module_inference(
                 use_kv_cache=self.meta["get_use_kv_cache"],
                 get_example_inputs=self.get_example_inputs,
                 module=model,
@@ -565,41 +610,37 @@ class TextDecoder(Component):
                 use_i64_token=self.control_args.embedding_quantize is not None,
                 event_name=f"{event}_tasks",
                 seq_mse_candidates=self.config.seq_mse_candidates,
+                collect_input_samples=collect_input_samples,
             )
-            input_samples.extend(input_sample)
+            if result.input_samples:
+                input_samples.extend(result.input_samples)
 
-        # prepare lookahead config if applicable
-        lookahead_config = (
-            (self.control_args.window, self.control_args.ngram, self.control_args.gcap)
-            if (
-                self.mode == Mode.DECODE and self.control_args.model_mode == "lookahead"
-            )
-            else None
-        )
-        # check user's prompt which helps calibrate special token
-        for turn in zip(intermediate_outputs, user_calibration_data):
-            hidden_states, prompt = turn
-            input_sample = graph_module_inference(
-                use_kv_cache=self.meta["get_use_kv_cache"],
-                get_example_inputs=self.get_example_inputs,
-                hidden_states=hidden_states,  # hidden_states for multimodal
-                module=model,
-                tok_embedding=tok_embedding,
-                audio_token_id=self.meta.get("audio_token_id", None),
-                image_token_id=self.meta.get("image_token_id", None),
-                tokenizer=tokenizer,
-                ar_len=self.meta["get_ar_len"],
-                max_seq_len=self.meta["get_max_context_len"],
-                prompt=prompt,
-                use_i64_token=self.control_args.embedding_quantize is not None,
-                event_name=f"{event}_prompt",
-                lookahead_config=lookahead_config,
-            )
-            input_samples.extend(input_sample)
+        # the user's prompt helps calibrate the special tokens.
+        if user_calibration_data:
+            for turn in zip(intermediate_outputs, user_calibration_data):
+                hidden_states, prompt = turn
+                result = graph_module_inference(
+                    use_kv_cache=self.meta["get_use_kv_cache"],
+                    get_example_inputs=self.get_example_inputs,
+                    hidden_states=hidden_states,  # hidden_states for multimodal
+                    module=model,
+                    tok_embedding=tok_embedding,
+                    audio_token_id=self.meta.get("audio_token_id", None),
+                    image_token_id=self.meta.get("image_token_id", None),
+                    tokenizer=tokenizer,
+                    ar_len=self.meta["get_ar_len"],
+                    max_seq_len=self.meta["get_max_context_len"],
+                    prompt=torch.Tensor(prompt).to(torch.long),
+                    use_i64_token=self.control_args.embedding_quantize is not None,
+                    event_name=f"{event}_prompt",
+                    collect_input_samples=collect_input_samples,
+                )
+                if result.input_samples:
+                    input_samples.extend(result.input_samples)
         return input_samples
 
     @log_info
-    def quantize(self, request: Request):  # noqa: C901
+    def quantize(self, request: Request, calibration_tokens=None):  # noqa: C901
         if self.quant_recipe is None:
             return
 
@@ -632,24 +673,9 @@ class TextDecoder(Component):
                 )
 
         data = request.method_data[TEXT_DECODER]
-        audio_turns = request.method_data[
-            AUDIO_ENCODER
-        ].calibration_data.intermediate_outputs
-        vision_turns = request.method_data[
-            VISION_ENCODER
-        ].calibration_data.intermediate_outputs
-        if audio_turns is None:
-            audio_turns = [[] for _ in range(len(data.calibration_data.datasets))]
-        if vision_turns is None:
-            vision_turns = [[] for _ in range(len(data.calibration_data.datasets))]
-        intermediate_outputs = [
-            [*audio_turn, *vision_turn]
-            for audio_turn, vision_turn in zip(audio_turns, vision_turns)
-        ]
 
         quantizer = make_quantizer(backend=data.backend, soc_model=data.soc_model)
         quantizer.set_recipe(self.quant_recipe.recipe)
-
         tok_embedding_quantizer = make_quantizer(
             quant_dtype=QuantDtype.use_16a8w,
             per_channel_conv=True,
@@ -660,7 +686,14 @@ class TextDecoder(Component):
         )
 
         with torch.no_grad():
-            # prepare tok embedding model for ptq
+            self.decoder = torch.export.export(
+                self.decoder, self.export_input, strict=True
+            ).module()
+            if (
+                self.mode == Mode.CALIBRATE
+                and self.control_args.quant_recipe_suggestion
+            ):
+                graph_module = copy.deepcopy(self.decoder)
             if self.apply_embedding:
                 self.tok_embedding = torch.export.export(
                     self.tok_embedding,
@@ -668,47 +701,40 @@ class TextDecoder(Component):
                     strict=True,
                 ).module()
 
-            # prepare decoder model for ptq
-            self.decoder = torch.export.export(
-                self.decoder, self.export_input, strict=True
-            ).module()
-            if self.control_args.quant_recipe_suggestion:
-                graph_module = copy.deepcopy(self.decoder)
-
-            # Auto-tune thread count BEFORE prepare_pt2e so the benchmark
-            # runs on the exported model without observers — no risk of
-            # polluting observer state with synthetic inputs.
-            if self.mode == Mode.DECODE or not self.model_args.use_kv_cache:
-                calib_threads = getattr(self.control_args, "calibration_num_threads", 0)
-                if calib_threads <= 0:
-                    calib_threads = self._auto_tune_calibration_threads()
-
             self.decoder = prepare_pt2e(self.decoder, quantizer)
             if self.apply_embedding:
                 self.tok_embedding = prepare_pt2e(
                     self.tok_embedding, tok_embedding_quantizer
                 )
 
-            # start calibration (only for kv mode or prefill mode without kv cache)
-            if self.mode == Mode.DECODE or not self.model_args.use_kv_cache:
-                original_threads = torch.get_num_threads()
-                torch.set_num_threads(calib_threads)
-                logging.info(
-                    "Calibration using %d threads (was %d)",
-                    calib_threads,
-                    original_threads,
+            if self.mode == Mode.CALIBRATE:
+                audio_turns = request.method_data[
+                    AUDIO_ENCODER
+                ].calibration_data.intermediate_outputs
+                vision_turns = request.method_data[
+                    VISION_ENCODER
+                ].calibration_data.intermediate_outputs
+                if audio_turns is None:
+                    audio_turns = [
+                        [] for _ in range(len(data.calibration_data.datasets))
+                    ]
+                if vision_turns is None:
+                    vision_turns = [
+                        [] for _ in range(len(data.calibration_data.datasets))
+                    ]
+                intermediate_outputs = [
+                    [*audio_turn, *vision_turn]
+                    for audio_turn, vision_turn in zip(audio_turns, vision_turns)
+                ]
+                input_samples = self._calibrate(
+                    model=self.decoder,
+                    tokenizer=data.tokenizer,
+                    event="prepare_pt2e",
+                    user_calibration_data=calibration_tokens,
+                    tok_embedding=self.tok_embedding,
+                    intermediate_outputs=intermediate_outputs,
+                    collect_input_samples=self.control_args.quant_recipe_suggestion,
                 )
-                try:
-                    input_samples = self._calibrate(
-                        model=self.decoder,
-                        tokenizer=data.tokenizer,
-                        event="prepare_pt2e",
-                        user_calibration_data=data.calibration_data.datasets,
-                        tok_embedding=self.tok_embedding,
-                        intermediate_outputs=intermediate_outputs,
-                    )
-                finally:
-                    torch.set_num_threads(original_threads)
             else:
                 # one dummy inference to remove affine observer
                 # error happened in convert_pt2e
@@ -716,7 +742,10 @@ class TextDecoder(Component):
 
             self.decoder = convert_pt2e(self.decoder)
 
-            if self.control_args.quant_recipe_suggestion:
+            if (
+                self.mode == Mode.CALIBRATE
+                and self.control_args.quant_recipe_suggestion
+            ):
                 self._quant_recipe_suggestion(
                     graph_module,
                     self.decoder,
@@ -724,19 +753,10 @@ class TextDecoder(Component):
                     self.quant_recipe.recipe,
                 )
 
-            # Saving Decode QDQ Model EP for SQNR evaluation
-            if self.mode == Mode.DECODE:
-                qdq_ep = torch.export.export(
-                    self.decoder, self.export_input, strict=True
-                )
-                qdq_ep_path = f"{self.control_args.artifact}/{DECODE_QDQ_FILENAME}"
-                torch.export.save(qdq_ep, qdq_ep_path)
-                logging.info(f"QDQ EP saved to {qdq_ep_path}")
-
             if self.apply_embedding:
                 self.tok_embedding = convert_pt2e(self.tok_embedding)
 
-            if self.control_args.verbose and self.mode == Mode.DECODE:
+            if self.control_args.verbose and self.mode == Mode.CALIBRATE:
                 audio_turns = request.method_data[
                     AUDIO_ENCODER
                 ].calibration_data.qdq_intermediate_outputs
@@ -759,16 +779,10 @@ class TextDecoder(Component):
                     model=self.decoder,
                     tokenizer=data.tokenizer,
                     event="convert_pt2e",
-                    user_calibration_data=data.calibration_data.datasets,
+                    user_calibration_data=calibration_tokens,
                     tok_embedding=self.tok_embedding,
                     intermediate_outputs=qdq_intermediate_outputs,
                 )
-
-        # save logit's quantization attributes to meta
-        self._save_logits_quant_attrs()
-
-        # save output KV cache's quantization attributes to meta for attention sink
-        self._save_output_kv_cache_quant_attrs()
 
         # setup quantized IO
         self.passes_job[TagQuantIO][QCOM_PASS_ACTIVATE_KEY] = True
@@ -804,13 +818,17 @@ class HybridTextDecoder(Component):
             Mode.PREFILL,
             apply_embedding=apply_embedding,
         )
+        self.calibration_prefill = TextDecoder(  # for quantization only
+            control_args, config, Mode.CALIBRATE, apply_embedding=apply_embedding
+        )
+
         self.control_args = control_args
         self.config = config
         self.set_next(self.decode).set_next(self.prefill)
 
         self.apply_embedding = apply_embedding
 
-    def _encoding_override(self, decode_model, prefill_model):  # noqa: C901
+    def _encoding_override(self, quantized_model, unquantized_model):  # noqa: C901
         pbq_target = {
             torch.ops.torchao.dequantize_affine,
             torch.ops.torchao.quantize_affine,
@@ -825,7 +843,7 @@ class HybridTextDecoder(Component):
         }
         qdq_target = pbq_target | pcq_target | ptq_target
 
-        def compare_nodes(decode_node, prefill_node):
+        def compare_nodes(quantized_node, unquantized_node):
             def info(node):
                 return node.name + (
                     str(node.meta["nn_module_stack"].values())
@@ -833,9 +851,9 @@ class HybridTextDecoder(Component):
                     else ""
                 )
 
-            assert info(decode_node) == info(
-                prefill_node
-            ), f"found unmatched order for ops: {decode_node} va {prefill_node}"
+            assert info(quantized_node) == info(
+                unquantized_node
+            ), f"found unmatched order for ops: {quantized_node} vs {unquantized_node}"
 
         def resolve_param_target(node):
             return (
@@ -844,27 +862,32 @@ class HybridTextDecoder(Component):
                 else resolve_param_target(list(node.users)[0])
             )
 
-        def activation_override(decode_node, prefill_node):
-            for decode_user, prefill_user in zip(
-                list(decode_node.users), list(prefill_node.users)
+        def activation_override(quantized_node, unquantized_node):
+            for quantized_user, unquantized_user in zip(
+                list(quantized_node.users), list(unquantized_node.users)
             ):
-                assert decode_user.target == prefill_user.target, (
+                if "output" == quantized_user.name:
+                    continue
+                assert quantized_user.target == unquantized_user.target, (
                     "found unmatched targets: "
-                    f"{decode_user.target} vs {prefill_user.target}"
+                    f"{quantized_user.target} vs {unquantized_user.target}"
                 )
-                if decode_user.target in qdq_target:
-                    prefill_user.args = (prefill_user.args[0], *decode_user.args[1:])
-                    activation_override(decode_user, prefill_user)
+                if quantized_user.target in qdq_target:
+                    unquantized_user.args = (
+                        unquantized_user.args[0],
+                        *quantized_user.args[1:],
+                    )
+                    activation_override(quantized_user, unquantized_user)
 
-        def parameter_override(decode_node, prefill_node):
+        def parameter_override(quantized_node, unquantized_node):
             setattr(
-                prefill_model,
-                prefill_node.target,
-                getattr(decode_model, decode_node.target),
+                unquantized_model,
+                unquantized_node.target,
+                getattr(quantized_model, quantized_node.target),
             )
             # scale / zero point are part of op's attributes
-            if list(decode_node.users)[0].target in ptq_target:
-                activation_override(decode_node, prefill_node)
+            if list(quantized_node.users)[0].target in ptq_target:
+                activation_override(quantized_node, unquantized_node)
 
         # copy encoding for hybrid mode
         parameters = [
@@ -873,7 +896,7 @@ class HybridTextDecoder(Component):
                 for n in model.graph.nodes
                 if n.op == "get_attr"
             }
-            for model in (decode_model, prefill_model)
+            for model in (quantized_model, unquantized_model)
         ]
         activations = [
             [
@@ -882,50 +905,270 @@ class HybridTextDecoder(Component):
                 if n.target not in qdq_target
                 and n.op in {"call_function", "placeholder"}
             ]
-            for model in (decode_model, prefill_model)
+            for model in (quantized_model, unquantized_model)
         ]
         # check topology order by node name & nn_module_stack
-        for act_decode, act_prefill in zip(*activations):
-            compare_nodes(act_decode, act_prefill)
+        for act_quantized, act_unquantized in zip(*activations):
+            compare_nodes(act_quantized, act_unquantized)
 
-        for op_decode, op_prefill in zip(*[p.values() for p in parameters]):
-            compare_nodes(op_decode, op_prefill)
+        for op_quantized, op_unquantized in zip(*[p.values() for p in parameters]):
+            compare_nodes(op_quantized, op_unquantized)
         # perform encoding override
-        for act_decode, act_prefill in zip(*activations):
-            activation_override(act_decode, act_prefill)
+        for act_quantized, act_unquantized in zip(*activations):
+            activation_override(act_quantized, act_unquantized)
 
-        for param_decode, param_prefill in zip(*[p.keys() for p in parameters]):
-            parameter_override(param_decode, param_prefill)
+        for param_quantized, param_unquantized in zip(*[p.keys() for p in parameters]):
+            parameter_override(param_quantized, param_unquantized)
 
-        prefill_model.recompile()
+        k_input_cache_nodes = []
+        v_input_cache_nodes = []
+        for node in unquantized_model.graph.nodes:
+            if node.op != "placeholder":
+                continue
+
+            if "args_" in node.name:
+                args_idx = int(node.name.split("_")[-1])
+
+                if args_idx >= self.decode.meta["get_n_layers"]:
+                    v_input_cache_nodes.append(node)
+                else:
+                    k_input_cache_nodes.append(node)
+
+        if not k_input_cache_nodes or not v_input_cache_nodes:
+            raise RuntimeError(
+                "KV cache input detection failed. This likely means the model naming "
+                "does not match expected prefixes."
+            )
+
+        k_output_cache_nodes = []
+        v_output_cache_nodes = []
+        for node in quantized_model.graph.nodes:
+            if not is_graph_output(node):
+                continue
+            cache_output_node = node.args[0].args[0]
+            if is_node_src_start_with_name(cache_output_node, kv_cache_prefix="k_"):
+                k_output_cache_nodes.append(cache_output_node)
+            elif is_node_src_start_with_name(cache_output_node, kv_cache_prefix="v_"):
+                v_output_cache_nodes.append(cache_output_node)
+
+        if not k_output_cache_nodes or not v_output_cache_nodes:
+            raise RuntimeError(
+                "KV cache detection failed. This likely means the model naming "
+                "does not match expected prefixes."
+            )
+
+        for input_k_cache_node, output_k_cache_node in zip(
+            k_input_cache_nodes, k_output_cache_nodes
+        ):
+            activation_override(output_k_cache_node, input_k_cache_node)
+        for input_v_cache_node, output_v_cache_node in zip(
+            v_input_cache_nodes, v_output_cache_nodes
+        ):
+            activation_override(output_v_cache_node, input_v_cache_node)
+
+        unquantized_model.recompile()
+
+    def _generate_tokens_from_hf(self, model: AutoModel, data, intermediate_outputs):
+        from pytorch_tokenizers.tiktoken import TiktokenTokenizer
+
+        tok_embedding = self.decode.tok_embedding
+        audio_token_id = self.decode.meta.get("audio_token_id")
+        image_token_id = self.decode.meta.get("image_token_id")
+        use_i64_token = self.decode.control_args.embedding_quantize is not None
+        max_seq_len = self.decode.meta["get_max_context_len"]
+        tokenizer = data.tokenizer
+        is_multimodal = all(
+            [
+                tok_embedding,
+                audio_token_id or image_token_id,
+            ]
+        )
+
+        calibration_tokens = []
+        for hidden_states, prompt in zip(
+            intermediate_outputs, data.calibration_data.datasets
+        ):
+            if isinstance(tokenizer, TiktokenTokenizer):
+                token_ids = tokenizer.encode(
+                    prompt, bos=True, eos=False, allowed_special="all"
+                )
+            else:
+                token_ids = tokenizer.encode(prompt, bos=True, eos=False)
+            input_ids = torch.tensor([token_ids], dtype=torch.int64)
+
+            with torch.no_grad():
+                if is_multimodal and hidden_states:
+                    token_dtype = torch.int64 if use_i64_token else torch.int32
+                    text_embeds = tok_embedding(input_ids.to(token_dtype))
+                    merged_embeds = _modality_inputs_merger(
+                        input_ids,
+                        text_embeds,
+                        torch.cat(hidden_states, dim=1),
+                        audio_token_id or image_token_id,
+                    )
+                    generated_ids = model.generate(
+                        inputs_embeds=merged_embeds,
+                        max_new_tokens=max_seq_len - len(token_ids),
+                        eos_token_id=tokenizer.eos_id,
+                        do_sample=False,
+                    )
+                    full_tokens = token_ids + generated_ids[0].tolist()
+                else:
+                    output_ids = model.generate(
+                        input_ids=input_ids,
+                        max_new_tokens=max_seq_len - len(token_ids),
+                        eos_token_id=tokenizer.eos_id,
+                        do_sample=False,
+                    )
+                    full_tokens = output_ids[0].tolist()
+
+            calibration_tokens.append(full_tokens)
+
+        return calibration_tokens
+
+    def _generate_calibration_tokens(self, request: Request):
+        data = request.method_data[TEXT_DECODER]
+        audio_turns = request.method_data[
+            AUDIO_ENCODER
+        ].calibration_data.intermediate_outputs
+        vision_turns = request.method_data[
+            VISION_ENCODER
+        ].calibration_data.intermediate_outputs
+        if audio_turns is None:
+            audio_turns = [[] for _ in range(len(data.calibration_data.datasets))]
+        if vision_turns is None:
+            vision_turns = [[] for _ in range(len(data.calibration_data.datasets))]
+        intermediate_outputs = [
+            [*audio_turn, *vision_turn]
+            for audio_turn, vision_turn in zip(audio_turns, vision_turns)
+        ]
+
+        if self.config.repo_id:
+            if self.control_args.decoder_model == "smolvlm_500m_instruct":
+                hf_model = AutoModelForVision2Seq.from_pretrained(
+                    self.config.repo_id, torch_dtype=torch.float32
+                )
+
+            elif self.control_args.decoder_model == "internvl3_1b":
+                hf_model = AutoModelForImageTextToText.from_pretrained(
+                    self.config.repo_id, torch_dtype=torch.float32
+                )
+
+            elif self.control_args.decoder_model == "granite_speech_3_3-2b":
+                hf_model = AutoModelForSpeechSeq2Seq.from_pretrained(
+                    self.config.repo_id, torch_dtype=torch.float32
+                )
+            else:
+                hf_model = AutoModelForCausalLM.from_pretrained(
+                    self.config.repo_id,
+                )
+            calibration_tokens = self._generate_tokens_from_hf(
+                model=hf_model,
+                data=data,
+                intermediate_outputs=intermediate_outputs,
+            )
+        else:
+            # Auto-tune thread count for the without-cache calibration pass.
+            calib_threads = getattr(self.control_args, "calibration_num_threads", 0)
+            if calib_threads <= 0:
+                calib_threads = self.decode._auto_tune_calibration_threads()
+            original_threads = torch.get_num_threads()
+            torch.set_num_threads(calib_threads)
+            try:
+                calibration_tokens = []
+                for hidden_states, prompt in zip(
+                    intermediate_outputs, data.calibration_data.datasets
+                ):
+                    result = graph_module_inference(
+                        use_kv_cache=self.decode.meta["get_use_kv_cache"],
+                        get_example_inputs=self.decode.get_example_inputs,
+                        hidden_states=hidden_states,
+                        module=self.decode.decoder,
+                        tok_embedding=self.decode.tok_embedding,
+                        image_token_id=self.decode.meta.get("image_token_id", None),
+                        tokenizer=data.tokenizer,
+                        ar_len=self.decode.meta["get_ar_len"],
+                        max_seq_len=self.decode.meta["get_max_context_len"],
+                        prompt=prompt,
+                        use_i64_token=self.decode.control_args.embedding_quantize
+                        is not None,
+                        event_name="generated_user_prompt",
+                    )
+                    calibration_tokens.append(result.token_list)
+            finally:
+                torch.set_num_threads(original_threads)
+
+        return calibration_tokens
+
+    def quantize(self, request: Request):
+        if request.method_data[TEXT_DECODER].skip_quantize:
+            return
+
+        if self.control_args.skip_user_prompt_calibration:
+            calibration_tokens = None
+        else:
+            calibration_tokens = self._generate_calibration_tokens(request)
+        self.calibration_prefill.quantize(
+            request, calibration_tokens=calibration_tokens
+        )
 
     @log_info
     def compile(self, request: Request):  # noqa: C901
-        # perform encoding override for hybrid mode
+        # perform encoding override for models to compile
         # ---
         # theoretically decode & prefill model should share the same encoding
         # given that they are using the identical calibration dataset.
         #
-        # however, pytorch will use different computaion kernels for different
-        # workloads (AR1 vs ARN) which will introduce some numerical discrepancy.
         #
         # here we use a mechanism to make sure the encoding align correctly and
         # save AoT quantization time as well.
         # ---
-        if (
-            self.prefill.decoder is not None
-            and self.prefill.model_args.use_kv_cache
-            and not request.method_data[TEXT_DECODER].skip_quantize
-        ):
+        if not request.method_data[TEXT_DECODER].skip_quantize:
             self._encoding_override(
-                decode_model=self.decode.decoder,
-                prefill_model=self.prefill.decoder,
+                quantized_model=self.calibration_prefill.decoder,
+                unquantized_model=self.decode.decoder,
             )
+
+            # save logit's quantization attributes to meta
+            self.decode._save_logits_quant_attrs()
+
+            # save output KV cache's quantization attributes to meta for attention sink
+            self.decode._save_output_kv_cache_quant_attrs()
+
             if self.apply_embedding:
                 self._encoding_override(
-                    decode_model=self.decode.tok_embedding,
-                    prefill_model=self.prefill.tok_embedding,
+                    quantized_model=self.calibration_prefill.tok_embedding,
+                    unquantized_model=self.decode.tok_embedding,
                 )
+
+            # Saving Decode QDQ Model EP for SQNR evaluation
+            qdq_ep = torch.export.export(
+                self.decode.decoder, self.decode.export_input, strict=True
+            )
+            qdq_ep_path = f"{self.decode.control_args.artifact}/{DECODE_QDQ_FILENAME}"
+            torch.export.save(qdq_ep, qdq_ep_path)
+            logging.info(f"QDQ EP saved to {qdq_ep_path}")
+
+            # For hybrid mode, override encoding of prefill model.
+            if (
+                self.prefill.decoder is not None
+                and self.prefill.model_args.use_kv_cache
+            ):
+                self._encoding_override(
+                    quantized_model=self.decode.decoder,
+                    unquantized_model=self.prefill.decoder,
+                )
+
+                if self.apply_embedding:
+                    self._encoding_override(
+                        quantized_model=self.decode.tok_embedding,
+                        unquantized_model=self.prefill.tok_embedding,
+                    )
+
+        # calibration_prefill is only used for encoding override
+        # free it once encoding override is complete.
+        del self.calibration_prefill
+        gc.collect()
 
         # prepare lowering tok_embedding if applicable
         if self.apply_embedding:


### PR DESCRIPTION
### Summary
 - Calibrate decoder using prefill stage only (full chunk tokens)
 - Remove need for AR-N calibration loops
 - Significantly reduce calibration overhead

| model name | before</br> Time(sec) | after</br> Time(sec) | speedup |
|------------|--------------|-------------|---------|
|    gemma-2b        |      1216     |    259    |  4.69x  |
|      gemma2-2b      |      1827      |   382   |    4.78x     |
|    gemma3-1b        |       907     |    218   |     4.16x    |
|      glm-1_5b     |        963       |    167   |    5.76x     |
|   granite_3_3-2b        |    1545         |    304     |   5.08x      |
|      llama3_2-1b      |       1237    |      285  |    4.34×     |
|   llama3_2-3b        |      2286     |   813   |     2.81x    |
|      phi_4_mini      |       2824     |   363   |   7.77x     |
|    qwen2_5-0_5b        |     486      |     119       |   4.08x      |
|     qwen2_5-1_5b      |      1068   |     220   |   4.86×    |
|     qwen3-0_6b      |      1013      |     158        |    6.41×      |
|     qwen3-1_7b      |       1478    |     283  |  5.22×      |
|     smollm2_135m      |       399      |    122         |  3.27×   |
|     smollm3-3b      |      2065      |   431   | 4.79x  |
|     smolvlm_500m_instruct      |   170           |       131      |    1.30×     |
|     internvl3_1b      |       170       |         103    |   1.65x      |
|     granite_speech_3_3-2b      |       447      |     215    |  2.07x |


This change decouples the quantization graph from the graph used for subsequent lowering, so calibration no longer depends on the AR-N decoding flow.

Previously, we were running calibration directly on the graph shaped for lowering (with fixed AR-N constraints). That forced us into an autoregressive loop (AR1 per step), which was both inefficient and slow since we never saw the full sequence context in a single pass.

With this update, calibration is done once during the prefill stage using the full tokens chunk. This gives us much better coverage in a single run and completely removes the need for iterative decoding during calibration.

After quantization, we take the KV cache encodings from the output, override the input KV cache encodings, and then propagate those into the graph that will later be lowered. This keeps everything consistent without needing to recalibrate on that graph.

Result: same accuracy, significantly faster calibration, and a much cleaner separation between quantization and lowering

### Test plan
Test CI in `TestExampleLLMScript` and `TestExampleMultimodalityScript`
