### PR TITLE
Add explicit matplotlib dep for parakeet and sortformer

### DIFF
--- a/examples/models/parakeet/install_requirements.txt
+++ b/examples/models/parakeet/install_requirements.txt
@@ -1,1 +1,2 @@
 nemo_toolkit[asr]
+matplotlib

--- a/examples/models/parakeet/install_requirements.txt
+++ b/examples/models/parakeet/install_requirements.txt
@@ -1,2 +1,2 @@
-nemo_toolkit[asr]
+nemo_toolkit[asr]==2.7.3
 matplotlib

--- a/examples/models/sortformer/install_requirements.txt
+++ b/examples/models/sortformer/install_requirements.txt
@@ -1,1 +1,2 @@
 nemo_toolkit[asr]
+matplotlib

--- a/examples/models/sortformer/install_requirements.txt
+++ b/examples/models/sortformer/install_requirements.txt
@@ -1,2 +1,2 @@
-nemo_toolkit[asr]
+nemo_toolkit[asr]==2.7.3
 matplotlib


### PR DESCRIPTION
### Summary
The Metal, MLX, and CUDA Windows export workflows started failing on 2026-04-30 with `ModuleNotFoundError: No module named 'matplotlib'` when the parakeet/sortformer export scripts import `nemo.collections.asr`. NeMo's clustering_diarizer module top-level imports matplotlib via vad_utils, but matplotlib is not declared by `nemo_toolkit[asr]`. A release in some transitive dep stopped pulling matplotlib in incidentally. nemo_toolkit itself was unchanged (2.7.3 since 2026-04-23), so adding matplotlib explicitly is the targeted fix.

Authored with Claude Code.

### Test plan
CI

cc @metascroy