### PR TITLE
Add uint64_t support to BackendOptions for pointer-sized handles

### DIFF
--- a/runtime/backend/backend_init_context.h
+++ b/runtime/backend/backend_init_context.h
@@ -15,7 +15,9 @@
 #include <executorch/runtime/core/result.h>
 #include <executorch/runtime/core/span.h>
 
+#include <cstdint>
 #include <cstring>
+#include <type_traits>
 
 #ifdef __GNUC__
 // Disable -Wdeprecated-declarations, as some builds use 'Werror'.
@@ -97,7 +99,7 @@ class BackendInitContext final {
   /**
    * Get a runtime spec value by key and type.
    *
-   * @tparam T The expected type (bool, int, or const char*)
+   * @tparam T The expected type (bool, int, int64_t, or const char*)
    * @param key The option key to look up.
    * @return Result containing the value if found and type matches,
    *         Error::NotFound if key doesn't exist,
@@ -107,8 +109,8 @@ class BackendInitContext final {
   Result<T> get_runtime_spec(const char* key) const {
     static_assert(
         std::is_same_v<T, bool> || std::is_same_v<T, int> ||
-            std::is_same_v<T, const char*>,
-        "get_runtime_spec<T> only supports bool, int, and const char*");
+            std::is_same_v<T, int64_t> || std::is_same_v<T, const char*>,
+        "get_runtime_spec<T> only supports bool, int, int64_t, and const char*");
 
     for (size_t i = 0; i < runtime_specs_.size(); ++i) {
       const auto& opt = runtime_specs_[i];

--- a/runtime/backend/backend_init_context.h
+++ b/runtime/backend/backend_init_context.h
@@ -99,7 +99,7 @@ class BackendInitContext final {
   /**
    * Get a runtime spec value by key and type.
    *
-   * @tparam T The expected type (bool, int, int64_t, or const char*)
+   * @tparam T The expected type (bool, int, uint64_t, or const char*)
    * @param key The option key to look up.
    * @return Result containing the value if found and type matches,
    *         Error::NotFound if key doesn't exist,
@@ -109,8 +109,8 @@ class BackendInitContext final {
   Result<T> get_runtime_spec(const char* key) const {
     static_assert(
         std::is_same_v<T, bool> || std::is_same_v<T, int> ||
-            std::is_same_v<T, int64_t> || std::is_same_v<T, const char*>,
-        "get_runtime_spec<T> only supports bool, int, int64_t, and const char*");
+            std::is_same_v<T, uint64_t> || std::is_same_v<T, const char*>,
+        "get_runtime_spec<T> only supports bool, int, uint64_t, and const char*");
 
     for (size_t i = 0; i < runtime_specs_.size(); ++i) {
       const auto& opt = runtime_specs_[i];

--- a/runtime/backend/options.h
+++ b/runtime/backend/options.h
@@ -59,7 +59,11 @@ struct BackendOption {
  * configuration, with compile-time capacity limits and runtime type checking.
  * It supports bool, int, int64_t, and const char* value types. The int64_t
  * arm allows callers to pass pointer-sized opaque handles (e.g., driver
- * handles like CUgreenCtx) by reinterpret_cast to/from int64_t.
+ * handles like CUgreenCtx) by round-tripping the pointer through uintptr_t
+ * (raw `reinterpret_cast` directly between int64_t and a pointer is
+ * implementation-defined per the standard; via uintptr_t it is well-defined
+ * on every platform). See the file-level comment above for the canonical
+ * pattern.
  *
  * @tparam MaxCapacity The maximum number of options that can be stored
  */

--- a/runtime/backend/options.h
+++ b/runtime/backend/options.h
@@ -9,9 +9,12 @@
 #pragma once
 #include <executorch/runtime/core/error.h>
 #include <executorch/runtime/core/span.h>
+#include <algorithm>
 #include <array>
 #include <cstddef>
+#include <cstdint>
 #include <cstring>
+#include <type_traits>
 #include <variant>
 
 namespace executorch {
@@ -20,11 +23,25 @@ namespace runtime {
 static constexpr size_t kMaxOptionKeyLength = 64;
 static constexpr size_t kMaxOptionValueLength = 256;
 
-// All string keys and values must have static storage duration (string
-// literals, static const char arrays, or global constants). The BackendOptions
-// class does NOT take ownership of strings.
+// String keys: must fit in kMaxOptionKeyLength characters (including null
+// terminator). The public set_option() templates enforce this at compile time
+// via static_assert on the key array's length, so overlong keys fail to
+// compile rather than being silently truncated.
+// String values: COPIED into the internal `std::array<char, ...>` variant arm
+// and truncated at kMaxOptionValueLength - 1 characters (null-terminated).
+// Callers do NOT need to keep the source strings alive after the set_option()
+// call returns.
+// The int64_t arm lets callers pass pointer-sized opaque handles (e.g.,
+// driver handles like CUgreenCtx, cudaStream_t). Round-trip the pointer
+// through uintptr_t so the cast is well-defined on all platforms:
+//   opts.set_option("cuda_stream",
+//       static_cast<int64_t>(reinterpret_cast<uintptr_t>(stream)));
+//   auto* stream = reinterpret_cast<cudaStream_t>(
+//       static_cast<uintptr_t>(value));
+// On 32-bit platforms the int64_t arm is wider than necessary for pointers
+// but remains correct.
 using OptionValue =
-    std::variant<bool, int, std::array<char, kMaxOptionValueLength>>;
+    std::variant<bool, int, int64_t, std::array<char, kMaxOptionValueLength>>;
 
 struct BackendOption {
   // key is the name of the backend option, like num_threads, enable_profiling,
@@ -40,7 +57,9 @@ struct BackendOption {
  *
  * This class provides a type-safe way to store key-value pairs for backend
  * configuration, with compile-time capacity limits and runtime type checking.
- * It supports bool, int, and const char* value types.
+ * It supports bool, int, int64_t, and const char* value types. The int64_t
+ * arm allows callers to pass pointer-sized opaque handles (e.g., driver
+ * handles like CUgreenCtx) by reinterpret_cast to/from int64_t.
  *
  * @tparam MaxCapacity The maximum number of options that can be stored
  */
@@ -114,15 +133,43 @@ class BackendOptions {
   }
 
   /**
-   * Sets a string option value for the given key.
-   * If the key already exists, updates its value. Otherwise, adds a new option.
+   * Sets an int64_t option value for the given key.
    *
-   * Note: The string value must have static storage duration. This class does
-   * NOT take ownership of the string - it only stores the pointer.
+   * Useful for pointer-sized opaque handles. Round-trip the pointer through
+   * uintptr_t so the cast is well-defined on all platforms:
+   *   opts.set_option("cuda_stream",
+   *       static_cast<int64_t>(reinterpret_cast<uintptr_t>(stream)));
+   *
+   * Note: bare integer literals like `42` resolve to `int` (NOT `int64_t`),
+   * and `42L` resolves to `int64_t` only on platforms where `long` is 64-bit
+   * (Linux) but `int` on Windows. To target the int64_t arm unambiguously,
+   * use `static_cast<int64_t>(value)` at the call site.
+   *
+   * If the key already exists, updates its value. Otherwise, adds a new option.
    *
    * @tparam N The length of the key string (automatically deduced)
    * @param key The option key (must be a string literal or array)
-   * @param value The string value to set (must have static storage duration)
+   * @param value The int64_t value to set
+   * @return Error::Ok on success, Error::InvalidArgument if storage is full
+   */
+  template <size_t N>
+  Error set_option(const char (&key)[N], int64_t value) noexcept {
+    static_assert(N <= kMaxOptionKeyLength, "Option key is too long");
+    return set_option_impl(key, value);
+  }
+
+  /**
+   * Sets a string option value for the given key.
+   * If the key already exists, updates its value. Otherwise, adds a new option.
+   *
+   * The string value is copied into an internal fixed-size buffer (truncated
+   * at kMaxOptionValueLength - 1 characters and null-terminated). The caller
+   * does NOT need to keep the source string alive after this call returns.
+   *
+   * @tparam N The length of the key string (automatically deduced)
+   * @param key The option key (must be a string literal or array)
+   * @param value The string value to set (copied; truncated at
+   *              kMaxOptionValueLength - 1 characters)
    * @return Error::Ok on success, Error::InvalidArgument if storage is full
    */
   template <size_t N>
@@ -137,7 +184,8 @@ class BackendOptions {
   /**
    * Retrieves an option value by key and type.
    *
-   * @tparam T The expected type of the option value (bool, int, or const char*)
+   * @tparam T The expected type of the option value (bool, int, int64_t, or
+   * const char*)
    * @tparam KeyLen The length of the key string (automatically deduced)
    * @param key The option key to look up
    * @param out Reference to store the retrieved value
@@ -157,7 +205,7 @@ class BackendOptions {
             return Error::Ok;
           }
         }
-        // Default handling for bool/int
+        // Default handling for bool/int/int64_t
         else if (auto* val = std::get_if<T>(&options_[i].value)) {
           out = *val;
           return Error::Ok;
@@ -176,13 +224,22 @@ class BackendOptions {
    * Internal implementation for setting option values.
    * Handles both updating existing options and adding new ones.
    *
-   * @tparam T The type of the value (bool, int, or const char*)
+   * @tparam T The type of the value (bool, int, int64_t, or const char*)
    * @param key The option key
    * @param value The value to set
    * @return Error::Ok on success, Error::InvalidArgument if storage is full
    */
   template <typename T>
   Error set_option_impl(const char* key, T value) {
+    static_assert(
+        std::variant_size_v<OptionValue> == 4,
+        "OptionValue arm count changed; audit set_option_impl + get_option");
+    static_assert(
+        std::is_same_v<T, bool> || std::is_same_v<T, int> ||
+            std::is_same_v<T, int64_t> ||
+            std::is_same_v<T, std::array<char, kMaxOptionValueLength>>,
+        "set_option_impl<T> only supports the variant arms: bool, int, "
+        "int64_t, and the fixed-size string array");
     // Update existing if found
     for (size_t i = 0; i < size_; ++i) {
       if (strcmp(options_[i].key, key) == 0) {

--- a/runtime/backend/options.h
+++ b/runtime/backend/options.h
@@ -31,17 +31,18 @@ static constexpr size_t kMaxOptionValueLength = 256;
 // and truncated at kMaxOptionValueLength - 1 characters (null-terminated).
 // Callers do NOT need to keep the source strings alive after the set_option()
 // call returns.
-// The int64_t arm lets callers pass pointer-sized opaque handles (e.g.,
+// The uint64_t arm lets callers pass pointer-sized opaque handles (e.g.,
 // driver handles like CUgreenCtx, cudaStream_t). Round-trip the pointer
-// through uintptr_t so the cast is well-defined on all platforms:
+// through uintptr_t -- both are unsigned, so the cast is well-defined on
+// every platform without sign-extension surprises:
 //   opts.set_option("cuda_stream",
-//       static_cast<int64_t>(reinterpret_cast<uintptr_t>(stream)));
+//       static_cast<uint64_t>(reinterpret_cast<uintptr_t>(stream)));
 //   auto* stream = reinterpret_cast<cudaStream_t>(
 //       static_cast<uintptr_t>(value));
-// On 32-bit platforms the int64_t arm is wider than necessary for pointers
+// On 32-bit platforms the uint64_t arm is wider than necessary for pointers
 // but remains correct.
 using OptionValue =
-    std::variant<bool, int, int64_t, std::array<char, kMaxOptionValueLength>>;
+    std::variant<bool, int, uint64_t, std::array<char, kMaxOptionValueLength>>;
 
 struct BackendOption {
   // key is the name of the backend option, like num_threads, enable_profiling,
@@ -57,13 +58,12 @@ struct BackendOption {
  *
  * This class provides a type-safe way to store key-value pairs for backend
  * configuration, with compile-time capacity limits and runtime type checking.
- * It supports bool, int, int64_t, and const char* value types. The int64_t
+ * It supports bool, int, uint64_t, and const char* value types. The uint64_t
  * arm allows callers to pass pointer-sized opaque handles (e.g., driver
- * handles like CUgreenCtx) by round-tripping the pointer through uintptr_t
- * (raw `reinterpret_cast` directly between int64_t and a pointer is
- * implementation-defined per the standard; via uintptr_t it is well-defined
- * on every platform). See the file-level comment above for the canonical
- * pattern.
+ * handles like CUgreenCtx) by round-tripping the pointer through uintptr_t.
+ * Both uint64_t and uintptr_t are unsigned, so the cast is well-defined on
+ * every platform with no sign-extension surprises. See the file-level
+ * comment above for the canonical pattern.
  *
  * @tparam MaxCapacity The maximum number of options that can be stored
  */
@@ -137,27 +137,29 @@ class BackendOptions {
   }
 
   /**
-   * Sets an int64_t option value for the given key.
+   * Sets a uint64_t option value for the given key.
    *
    * Useful for pointer-sized opaque handles. Round-trip the pointer through
-   * uintptr_t so the cast is well-defined on all platforms:
+   * uintptr_t -- both unsigned -- so the cast is well-defined on all
+   * platforms:
    *   opts.set_option("cuda_stream",
-   *       static_cast<int64_t>(reinterpret_cast<uintptr_t>(stream)));
+   *       static_cast<uint64_t>(reinterpret_cast<uintptr_t>(stream)));
    *
-   * Note: bare integer literals like `42` resolve to `int` (NOT `int64_t`),
-   * and `42L` resolves to `int64_t` only on platforms where `long` is 64-bit
-   * (Linux) but `int` on Windows. To target the int64_t arm unambiguously,
-   * use `static_cast<int64_t>(value)` at the call site.
+   * Note: bare integer literals like `42` resolve to `int` (NOT `uint64_t`),
+   * and `42UL` resolves to `uint64_t` only on platforms where `unsigned long`
+   * is 64-bit (Linux) but `unsigned int` on Windows. To target the uint64_t
+   * arm unambiguously, use `static_cast<uint64_t>(value)` (or the `ULL`
+   * suffix) at the call site.
    *
    * If the key already exists, updates its value. Otherwise, adds a new option.
    *
    * @tparam N The length of the key string (automatically deduced)
    * @param key The option key (must be a string literal or array)
-   * @param value The int64_t value to set
+   * @param value The uint64_t value to set
    * @return Error::Ok on success, Error::InvalidArgument if storage is full
    */
   template <size_t N>
-  Error set_option(const char (&key)[N], int64_t value) noexcept {
+  Error set_option(const char (&key)[N], uint64_t value) noexcept {
     static_assert(N <= kMaxOptionKeyLength, "Option key is too long");
     return set_option_impl(key, value);
   }
@@ -188,7 +190,7 @@ class BackendOptions {
   /**
    * Retrieves an option value by key and type.
    *
-   * @tparam T The expected type of the option value (bool, int, int64_t, or
+   * @tparam T The expected type of the option value (bool, int, uint64_t, or
    * const char*)
    * @tparam KeyLen The length of the key string (automatically deduced)
    * @param key The option key to look up
@@ -209,7 +211,7 @@ class BackendOptions {
             return Error::Ok;
           }
         }
-        // Default handling for bool/int/int64_t
+        // Default handling for bool/int/uint64_t
         else if (auto* val = std::get_if<T>(&options_[i].value)) {
           out = *val;
           return Error::Ok;
@@ -228,7 +230,7 @@ class BackendOptions {
    * Internal implementation for setting option values.
    * Handles both updating existing options and adding new ones.
    *
-   * @tparam T The type of the value (bool, int, int64_t, or const char*)
+   * @tparam T The type of the value (bool, int, uint64_t, or const char*)
    * @param key The option key
    * @param value The value to set
    * @return Error::Ok on success, Error::InvalidArgument if storage is full
@@ -240,10 +242,10 @@ class BackendOptions {
         "OptionValue arm count changed; audit set_option_impl + get_option");
     static_assert(
         std::is_same_v<T, bool> || std::is_same_v<T, int> ||
-            std::is_same_v<T, int64_t> ||
+            std::is_same_v<T, uint64_t> ||
             std::is_same_v<T, std::array<char, kMaxOptionValueLength>>,
         "set_option_impl<T> only supports the variant arms: bool, int, "
-        "int64_t, and the fixed-size string array");
+        "uint64_t, and the fixed-size string array");
     // Update existing if found
     for (size_t i = 0; i < size_; ++i) {
       if (strcmp(options_[i].key, key) == 0) {

--- a/runtime/backend/test/backend_init_context_test.cpp
+++ b/runtime/backend/test/backend_init_context_test.cpp
@@ -97,6 +97,31 @@ TEST_F(BackendInitContextTest, GetRuntimeSpecIntValid) {
   EXPECT_EQ(result2.get(), 32);
 }
 
+// Test get_runtime_spec<int64_t> with valid key (covers pointer-sized handle
+// use case, e.g., CUDA driver handles like CUgreenCtx).
+TEST_F(BackendInitContextTest, GetRuntimeSpecInt64Valid) {
+  BackendOptions<2> opts;
+  // Use a value with the top bit clear so the literal is well-defined as a
+  // signed int64_t across toolchains.
+  constexpr int64_t kHandle = static_cast<int64_t>(0x123456789ABCDEF0LL);
+  constexpr int64_t kLargeOffset = static_cast<int64_t>(0x7FFFFFFFFFFFFFFFLL);
+  opts.set_option("opaque_handle", kHandle);
+  opts.set_option("large_offset", kLargeOffset);
+
+  auto view = opts.view();
+  Span<const BackendOption> const_span(view.data(), view.size());
+
+  BackendInitContext context(nullptr, nullptr, nullptr, nullptr, const_span);
+
+  auto result1 = context.get_runtime_spec<int64_t>("opaque_handle");
+  EXPECT_TRUE(result1.ok());
+  EXPECT_EQ(result1.get(), kHandle);
+
+  auto result2 = context.get_runtime_spec<int64_t>("large_offset");
+  EXPECT_TRUE(result2.ok());
+  EXPECT_EQ(result2.get(), kLargeOffset);
+}
+
 // Test get_runtime_spec<const char*> with valid key
 TEST_F(BackendInitContextTest, GetRuntimeSpecStringValid) {
   BackendOptions<2> opts;
@@ -142,9 +167,10 @@ TEST_F(BackendInitContextTest, GetRuntimeSpecNotFound) {
 
 // Test get_runtime_spec<T> with wrong type returns InvalidArgument
 TEST_F(BackendInitContextTest, GetRuntimeSpecTypeMismatch) {
-  BackendOptions<3> opts;
+  BackendOptions<4> opts;
   opts.set_option("bool_opt", true);
   opts.set_option("int_opt", 42);
+  opts.set_option("int64_opt", static_cast<int64_t>(0x123456789ABCDEF0LL));
   opts.set_option("string_opt", "hello");
 
   auto view = opts.view();
@@ -166,6 +192,17 @@ TEST_F(BackendInitContextTest, GetRuntimeSpecTypeMismatch) {
   auto result3 = context.get_runtime_spec<bool>("string_opt");
   EXPECT_FALSE(result3.ok());
   EXPECT_EQ(result3.error(), Error::InvalidArgument);
+
+  // int and int64_t are distinct variant arms; reading an int as int64_t
+  // (and vice versa) must fail with InvalidArgument rather than implicit
+  // narrowing/widening.
+  auto result4 = context.get_runtime_spec<int64_t>("int_opt");
+  EXPECT_FALSE(result4.ok());
+  EXPECT_EQ(result4.error(), Error::InvalidArgument);
+
+  auto result5 = context.get_runtime_spec<int>("int64_opt");
+  EXPECT_FALSE(result5.ok());
+  EXPECT_EQ(result5.error(), Error::InvalidArgument);
 }
 
 // Test empty runtime specs

--- a/runtime/backend/test/backend_init_context_test.cpp
+++ b/runtime/backend/test/backend_init_context_test.cpp
@@ -97,14 +97,14 @@ TEST_F(BackendInitContextTest, GetRuntimeSpecIntValid) {
   EXPECT_EQ(result2.get(), 32);
 }
 
-// Test get_runtime_spec<int64_t> with valid key (covers pointer-sized handle
+// Test get_runtime_spec<uint64_t> with valid key (covers pointer-sized handle
 // use case, e.g., CUDA driver handles like CUgreenCtx).
-TEST_F(BackendInitContextTest, GetRuntimeSpecInt64Valid) {
+TEST_F(BackendInitContextTest, GetRuntimeSpecUint64Valid) {
   BackendOptions<2> opts;
-  // Use a value with the top bit clear so the literal is well-defined as a
-  // signed int64_t across toolchains.
-  constexpr int64_t kHandle = static_cast<int64_t>(0x123456789ABCDEF0LL);
-  constexpr int64_t kLargeOffset = static_cast<int64_t>(0x7FFFFFFFFFFFFFFFLL);
+  // uint64_t and uintptr_t are both unsigned, so any 64-bit bit pattern is a
+  // valid value of the variant arm -- including the all-ones case.
+  constexpr uint64_t kHandle = static_cast<uint64_t>(0x123456789ABCDEF0ULL);
+  constexpr uint64_t kLargeOffset = static_cast<uint64_t>(0xFFFFFFFFFFFFFFFFULL);
   opts.set_option("opaque_handle", kHandle);
   opts.set_option("large_offset", kLargeOffset);
 
@@ -113,11 +113,11 @@ TEST_F(BackendInitContextTest, GetRuntimeSpecInt64Valid) {
 
   BackendInitContext context(nullptr, nullptr, nullptr, nullptr, const_span);
 
-  auto result1 = context.get_runtime_spec<int64_t>("opaque_handle");
+  auto result1 = context.get_runtime_spec<uint64_t>("opaque_handle");
   EXPECT_TRUE(result1.ok());
   EXPECT_EQ(result1.get(), kHandle);
 
-  auto result2 = context.get_runtime_spec<int64_t>("large_offset");
+  auto result2 = context.get_runtime_spec<uint64_t>("large_offset");
   EXPECT_TRUE(result2.ok());
   EXPECT_EQ(result2.get(), kLargeOffset);
 }
@@ -170,7 +170,7 @@ TEST_F(BackendInitContextTest, GetRuntimeSpecTypeMismatch) {
   BackendOptions<4> opts;
   opts.set_option("bool_opt", true);
   opts.set_option("int_opt", 42);
-  opts.set_option("int64_opt", static_cast<int64_t>(0x123456789ABCDEF0LL));
+  opts.set_option("uint64_opt", static_cast<uint64_t>(0x123456789ABCDEF0ULL));
   opts.set_option("string_opt", "hello");
 
   auto view = opts.view();
@@ -193,14 +193,14 @@ TEST_F(BackendInitContextTest, GetRuntimeSpecTypeMismatch) {
   EXPECT_FALSE(result3.ok());
   EXPECT_EQ(result3.error(), Error::InvalidArgument);
 
-  // int and int64_t are distinct variant arms; reading an int as int64_t
+  // int and uint64_t are distinct variant arms; reading an int as uint64_t
   // (and vice versa) must fail with InvalidArgument rather than implicit
   // narrowing/widening.
-  auto result4 = context.get_runtime_spec<int64_t>("int_opt");
+  auto result4 = context.get_runtime_spec<uint64_t>("int_opt");
   EXPECT_FALSE(result4.ok());
   EXPECT_EQ(result4.error(), Error::InvalidArgument);
 
-  auto result5 = context.get_runtime_spec<int>("int64_opt");
+  auto result5 = context.get_runtime_spec<int>("uint64_opt");
   EXPECT_FALSE(result5.ok());
   EXPECT_EQ(result5.error(), Error::InvalidArgument);
 }

--- a/runtime/backend/test/backend_options_test.cpp
+++ b/runtime/backend/test/backend_options_test.cpp
@@ -61,6 +61,31 @@ TEST_F(BackendOptionsTest, HandlesIntOptions) {
   EXPECT_EQ(num_threads, 256);
 }
 
+// Test int64_t options - exercises the variant arm that holds pointer-sized
+// opaque handles. Uses a value with the high 32 bits set to ensure the value
+// is not silently routed through (or truncated by) the int arm.
+TEST_F(BackendOptionsTest, HandlesInt64Options) {
+  constexpr int64_t kHandle = static_cast<int64_t>(0x123456789ABCDEF0LL);
+  options.set_option("handle", kHandle);
+
+  int64_t handle = 0;
+  EXPECT_EQ(options.get_option("handle", handle), Error::Ok);
+  EXPECT_EQ(handle, kHandle);
+
+  // Reading the same key as int should fail because the variant arm differs.
+  int as_int = 0;
+  EXPECT_EQ(options.get_option("handle", as_int), Error::InvalidArgument);
+
+  // Update existing key with a new int64_t value. Use a value with the top
+  // bit clear so the literal is well-defined as a signed int64_t across all
+  // toolchains (0xFEDCBA98... would be treated as an unsigned literal on many
+  // compilers and the cast back to int64_t would be implementation-defined).
+  constexpr int64_t kHandle2 = static_cast<int64_t>(0x7EDCBA9876543210LL);
+  options.set_option("handle", kHandle2);
+  EXPECT_EQ(options.get_option("handle", handle), Error::Ok);
+  EXPECT_EQ(handle, kHandle2);
+}
+
 // Test error conditions
 TEST_F(BackendOptionsTest, HandlesErrors) {
   // Non-existent key

--- a/runtime/backend/test/backend_options_test.cpp
+++ b/runtime/backend/test/backend_options_test.cpp
@@ -61,14 +61,14 @@ TEST_F(BackendOptionsTest, HandlesIntOptions) {
   EXPECT_EQ(num_threads, 256);
 }
 
-// Test int64_t options - exercises the variant arm that holds pointer-sized
+// Test uint64_t options - exercises the variant arm that holds pointer-sized
 // opaque handles. Uses a value with the high 32 bits set to ensure the value
 // is not silently routed through (or truncated by) the int arm.
-TEST_F(BackendOptionsTest, HandlesInt64Options) {
-  constexpr int64_t kHandle = static_cast<int64_t>(0x123456789ABCDEF0LL);
+TEST_F(BackendOptionsTest, HandlesUint64Options) {
+  constexpr uint64_t kHandle = static_cast<uint64_t>(0x123456789ABCDEF0ULL);
   options.set_option("handle", kHandle);
 
-  int64_t handle = 0;
+  uint64_t handle = 0;
   EXPECT_EQ(options.get_option("handle", handle), Error::Ok);
   EXPECT_EQ(handle, kHandle);
 
@@ -76,11 +76,10 @@ TEST_F(BackendOptionsTest, HandlesInt64Options) {
   int as_int = 0;
   EXPECT_EQ(options.get_option("handle", as_int), Error::InvalidArgument);
 
-  // Update existing key with a new int64_t value. Use a value with the top
-  // bit clear so the literal is well-defined as a signed int64_t across all
-  // toolchains (0xFEDCBA98... would be treated as an unsigned literal on many
-  // compilers and the cast back to int64_t would be implementation-defined).
-  constexpr int64_t kHandle2 = static_cast<int64_t>(0x7EDCBA9876543210LL);
+  // Update existing key with a new uint64_t value. uint64_t and uintptr_t are
+  // both unsigned so any 64-bit bit pattern -- including the all-ones case --
+  // round-trips cleanly with no implementation-defined sign-extension.
+  constexpr uint64_t kHandle2 = static_cast<uint64_t>(0xFEDCBA9876543210ULL);
   options.set_option("handle", kHandle2);
   EXPECT_EQ(options.get_option("handle", handle), Error::Ok);
   EXPECT_EQ(handle, kHandle2);


### PR DESCRIPTION
Summary:

Add `uint64_t` as a new variant arm to `OptionValue` in `BackendOptions` and extend `BackendInitContext::get_runtime_spec<T>` to support it. Lets backends receive pointer-sized opaque handles (e.g., `cudaStream_t`, `CUgreenCtx`) as runtime specs at delegate `init()` time.

Motivation: GPU delegates today have no public surface to receive caller-owned device resources, so they default to allocating their own streams from the device's primary-context stream pool. This silently bypasses caller-set CUDA Green Contexts, which is the gap edge / on-device multi-tenant runtimes hit when partitioning a Jetson-class GPU across concurrent models. With this change, callers that own a GPU context can pass a green-ctx-bound stream into a Module's load path via `BackendOptions`, and GPU delegates that opt in (TensorRT, CUDA, future Vulkan / Metal) honor it instead of allocating their own.

Why `uint64_t` (not `int64_t`): `uintptr_t` (the standard pointer<->integer round-trip type) is unsigned by definition. `uint64_t` matches its signedness exactly, so the cast is well-defined on every platform with no sign-extension surprises. A signed `int64_t` arm would force callers through an extra "via uintptr_t" caveat in the docstring to dodge implementation-defined behavior on high-bit-set addresses.

Fully additive:
- New `uint64_t` variant arm + matching `set_option(uint64_t)` overload.
- `get_option<uint64_t>` falls through the existing `bool/int` path.
- `BackendInitContext::get_runtime_spec<uint64_t>` extends the existing `static_assert`.
- No behavior change for existing `bool` / `int` / `const char*` callers.
- No public API removal or signature change.

Documentation:
- The `uint64_t` arm docstring spells out the canonical `uintptr_t` round-trip pattern so callers don't bikeshed the cast.
- Calls out the literal-overload-resolution gotcha (`42` -> `int`, `42UL` -> platform-dependent) and recommends `static_cast<uint64_t>` at the call site.

Defensive scaffolding:
- `static_assert(std::variant_size_v<OptionValue> == 4, ...)` in `set_option_impl` guards against future variant arm additions silently breaking call sites.
- Companion `static_assert` constrains the impl template `T` to the four valid variant arms so accidental misuse fails at compile time.

Test Plan:
```
buck2 test fbcode//executorch/runtime/backend/test:backend_options_test
buck2 test fbcode//executorch/runtime/backend/test:backend_init_context_test
```

Differential Revision: [D103241865](https://our.internmc.facebook.com/intern/diff/D103241865)