### PR TITLE
Add int4_matmul.py to triton_kernels srcs

### DIFF
--- a/backends/cuda/TARGETS
+++ b/backends/cuda/TARGETS
@@ -55,6 +55,7 @@ runtime.python_library(
     srcs = [
         "triton/kernels/__init__.py",
         "triton/kernels/fused_moe.py",
+        "triton/kernels/int4_matmul.py",
         "triton/kernels/sdpa.py",
         "triton/kernels/topk.py",
     ],


### PR DESCRIPTION
### Summary
Triton int4 matmul was added in #19188, but missed the BUCK update.
