### PR TITLE
fix export issue

### DIFF
--- a/backends/qualcomm/_passes/decompose_wrap_with_autocast.py
+++ b/backends/qualcomm/_passes/decompose_wrap_with_autocast.py
@@ -60,8 +60,14 @@ class DecomposeWrapWithAutocast(ExportPass):
                 with graph.inserting_before(node):
                     # remap is used to map original node values to new node values,
                     # which ensures that reference to nodes are correctly updated in the new graph
-                    # remap = {"expand_1": node.args[5], "to_4": node.args[6]}
-                    remap = {n_args[i].name: n_args[i] for i in range(5, len(n_args))}
+                    placeholders = [
+                        n
+                        for n in decomposed_module.graph.nodes
+                        if n.op == "placeholder"
+                    ]
+                    remap = {
+                        ph.name: n_args[5 + i] for i, ph in enumerate(placeholders)
+                    }
                     merge_decomposed_graph(
                         remap=remap,
                         target_node=node,


### PR DESCRIPTION
Summary:
Root cause: decompose_wrap_with_autocast.py:64 built the remap dict keyed by the parent graph's argument node names (n_args[i].name), but merge_decomposed_graph looks up entries by the decomposed submodule's placeholder names (decomposed_node.name). After 17 prior QNN passes transform the graph, argument nodes get renamed/replaced, causing the names to diverge. The placeholder 'permute_3' in the submodule no longer matches any key in remap.

Fix: Build remap by extracting placeholders from the decomposed submodule and mapping them positionally to n_args[5:], which is the correct correspondence regardless of node naming. This matches the pattern all other callers of merge_decomposed_graph use (hardcoded placeholder names from modules they control).

Differential Revision: D103306388


