### PR TITLE
Fix nullable pointer errors in ExecuTorchModule.mm

### DIFF
--- a/extension/apple/ExecuTorch/Exported/ExecuTorchModule.mm
+++ b/extension/apple/ExecuTorch/Exported/ExecuTorchModule.mm
@@ -314,7 +314,7 @@ static inline ExecuTorchValue *toExecuTorchValue(EValue value) NS_RETURNS_RETAIN
 
 - (BOOL)loadMethod:(NSString *)methodName
              error:(NSError **)error {
-  const auto errorCode = _module->load_method(methodName.UTF8String);
+  const auto errorCode = _module->load_method(methodName.UTF8String ?: "");
   if (errorCode != Error::Ok) {
     if (error) {
       *error = ExecuTorchErrorWithCode((ExecuTorchErrorCode)errorCode);
@@ -325,11 +325,11 @@ static inline ExecuTorchValue *toExecuTorchValue(EValue value) NS_RETURNS_RETAIN
 }
 
 - (BOOL)isMethodLoaded:(NSString *)methodName {
-  return _module->is_method_loaded(methodName.UTF8String);
+  return _module->is_method_loaded(methodName.UTF8String ?: "");
 }
 
 - (BOOL)unloadMethod:(NSString *)methodName {
-  const auto didUnload = _module->unload_method(methodName.UTF8String);
+  const auto didUnload = _module->unload_method(methodName.UTF8String ?: "");
   [_inputs removeObjectForKey:methodName];
   [_outputs removeObjectForKey:methodName];
   return didUnload;
@@ -352,7 +352,7 @@ static inline ExecuTorchValue *toExecuTorchValue(EValue value) NS_RETURNS_RETAIN
 
 - (nullable ExecuTorchMethodMetadata *)methodMetadata:(NSString *)methodName
                                                 error:(NSError **)error {
-  const auto result = _module->method_meta(methodName.UTF8String);
+  const auto result = _module->method_meta(methodName.UTF8String ?: "");
   if (!result.ok()) {
     if (error) {
       *error = ExecuTorchErrorWithCode((ExecuTorchErrorCode)result.error());
@@ -497,7 +497,7 @@ static inline ExecuTorchValue *toExecuTorchValue(EValue value) NS_RETURNS_RETAIN
        forMethod:(NSString *)methodName
          atIndex:(NSInteger)index
            error:(NSError **)error {
-  const auto errorCode = _module->set_input(methodName.UTF8String, toEValue(value), index);
+  const auto errorCode = _module->set_input(methodName.UTF8String ?: "", toEValue(value), index);
   if (errorCode != Error::Ok) {
     if (error) {
       *error = ExecuTorchErrorWithCode((ExecuTorchErrorCode)errorCode);
@@ -537,7 +537,7 @@ static inline ExecuTorchValue *toExecuTorchValue(EValue value) NS_RETURNS_RETAIN
   for (ExecuTorchValue *value in values) {
     inputs.push_back(toEValue(value));
   }
-  const auto errorCode = _module->set_inputs(methodName.UTF8String, inputs);
+  const auto errorCode = _module->set_inputs(methodName.UTF8String ?: "", inputs);
   if (errorCode != Error::Ok) {
     if (error) {
       *error = ExecuTorchErrorWithCode((ExecuTorchErrorCode)errorCode);
@@ -580,7 +580,7 @@ static inline ExecuTorchValue *toExecuTorchValue(EValue value) NS_RETURNS_RETAIN
         forMethod:(NSString *)methodName
           atIndex:(NSInteger)index
             error:(NSError **)error {
-  const auto errorCode = _module->set_output(methodName.UTF8String, toEValue(value), index);
+  const auto errorCode = _module->set_output(methodName.UTF8String ?: "", toEValue(value), index);
   if (errorCode != Error::Ok) {
     if (error) {
       *error = ExecuTorchErrorWithCode((ExecuTorchErrorCode)errorCode);


### PR DESCRIPTION
Summary:
NSString.UTF8String returns a nullable pointer (const char * _Nullable), but the ExecuTorch C++ Module methods expect non-nullable const char *. This causes 14 compilation errors (7 call sites × 2 architectures) that block downstream iOS test targets from building.

The fix adds the idiomatic Objective-C null-coalescing operator (`?: ""`) at each call site. Since the methodName parameters are already non-null NSString *, UTF8String will never actually return null in practice - this just satisfies the compiler's nullability checker.

Differential Revision: D103190695


