### PR TITLE
Add sum.dim_IntList to RemovePermutesAroundElementwiseOps

### DIFF
--- a/backends/transforms/remove_permutes_around_elementwise_ops.py
+++ b/backends/transforms/remove_permutes_around_elementwise_ops.py
@@ -50,6 +50,7 @@ class RemovePermutesAroundElementwiseOps(ExportPass):
         # Ops that require special handling.
         exir_ops.edge.aten.cat.default,
         exir_ops.edge.aten.mean.dim,
+        exir_ops.edge.aten.sum.dim_IntList,
         exir_ops.edge.aten.slice_copy.Tensor,
     }
 
@@ -161,7 +162,10 @@ class RemovePermutesAroundElementwiseOps(ExportPass):
     def is_node_permutable(self, node: torch.fx.Node) -> bool:
         if node.target not in self.permutable_ops:
             return False
-        if node.target == exir_ops.edge.aten.mean.dim:
+        if node.target in (
+            exir_ops.edge.aten.mean.dim,
+            exir_ops.edge.aten.sum.dim_IntList,
+        ):
             # keepdim should be True.
             if len(node.args) >= 3:
                 if not node.args[2]:
@@ -236,7 +240,10 @@ class RemovePermutesAroundElementwiseOps(ExportPass):
         for node in subgraph.nodes:
             if node.target == exir_ops.edge.aten.cat.default:
                 self.update_cat(node, subgraph.start_permute)
-            elif node.target == exir_ops.edge.aten.mean.dim:
+            elif node.target in (
+                exir_ops.edge.aten.mean.dim,
+                exir_ops.edge.aten.sum.dim_IntList,
+            ):
                 self.update_mean_dim(node, subgraph.start_permute)
             elif node.target == exir_ops.edge.aten.slice_copy.Tensor:
                 self.update_slice_copy(node, subgraph.start_permute)


### PR DESCRIPTION
Summary:
`DecomposeMeanDimPass` decomposes `mean.dim` into `sum.dim_IntList + mul.Tensor`.
While `mean.dim` and `mul.Tensor` are both in the `permutable_ops` set of
`RemovePermutesAroundElementwiseOps`, `sum.dim_IntList` is not — so the pass
cannot traverse through the decomposed chain to find the matching exit permute.

This adds `aten.sum.dim_IntList` to `permutable_ops` with the same keepdim
validation and dimension-adjustment logic already used for `mean.dim`. This is
safe because:
- `sum.dim_IntList` has identical dimension semantics to `mean.dim`
- `DecomposeMeanDimPass` always calls sum with `keepdim=True`
- `mul.Tensor` (the other half of the decomposition) is already handled

Reviewed By: 3l1

Differential Revision: D103272273




cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell