### PR TITLE
docs: Fix inconsistent link paths in backends overview table

### DIFF
--- a/docs/source/backends-overview.md
+++ b/docs/source/backends-overview.md
@@ -21,19 +21,19 @@ Backends are the bridge between your exported model and the hardware it runs on.
 | Backend                                                      | Platform(s)   | Hardware Type | Typical Use Case                |
 |--------------------------------------------------------------|---------------|---------------|---------------------------------|
 | [XNNPACK](backends/xnnpack/xnnpack-overview.md)              | All           | CPU           | General-purpose, fallback       |
-| [CUDA](/backends/cuda/cuda-overview.md)                      | Linux/Windows | GPU           | NVIDIA GPU acceleration         |
-| [Core ML](/backends/coreml/coreml-overview.md)               | iOS, macOS    | NPU/GPU/CPU   | Apple devices, high performance |
-| [Metal Performance Shaders](/backends/mps/mps-overview.md)   | iOS, macOS    | GPU           | Apple GPU acceleration          |
-| [Vulkan ](/backends/vulkan/vulkan-overview.md)               | Android       | GPU           | Android GPU acceleration        |
+| [CUDA](backends/cuda/cuda-overview.md)                       | Linux/Windows | GPU           | NVIDIA GPU acceleration         |
+| [Core ML](backends/coreml/coreml-overview.md)                | iOS, macOS    | NPU/GPU/CPU   | Apple devices, high performance |
+| [Metal Performance Shaders](backends/mps/mps-overview.md)    | iOS, macOS    | GPU           | Apple GPU acceleration          |
+| [Vulkan](backends/vulkan/vulkan-overview.md)                 | Android       | GPU           | Android GPU acceleration        |
 | [Qualcomm](backends-qualcomm)                                | Android     | NPU           | Qualcomm SoCs                   |
 | [MediaTek](backends-mediatek)                                | Android     | NPU           | MediaTek SoCs                   |
-| [Arm Ethos-U](/backends/arm-ethos-u/arm-ethos-u-overview.md) | Embedded    | NPU           | Arm MCUs                        |
-| [Arm Cortex-M](/backends/arm-cortex-m/arm-cortex-m-overview.md) | Embedded | CPU          | Arm Cortex-M MCUs               |
-| [Arm VGF](/backends/arm-vgf/arm-vgf-overview.md)             | Android     | GPU           | Arm platforms                   |
+| [Arm Ethos-U](backends/arm-ethos-u/arm-ethos-u-overview.md)  | Embedded    | NPU           | Arm MCUs                        |
+| [Arm Cortex-M](backends/arm-cortex-m/arm-cortex-m-overview.md) | Embedded | CPU          | Arm Cortex-M MCUs               |
+| [Arm VGF](backends/arm-vgf/arm-vgf-overview.md)              | Android     | GPU           | Arm platforms                   |
 | [OpenVINO](build-run-openvino)                               | Embedded    | CPU/GPU/NPU   | Intel SoCs                      |
 | [NXP](backends/nxp/nxp-overview.md)                          | Embedded    | NPU           | NXP SoCs                        |
 | [Cadence](backends-cadence)                                  | Embedded    | DSP           | DSP-optimized workloads         |
-| [Samsung Exynos](/backends/samsung/samsung-overview.md)      | Android     | NPU           | Samsung SoCs                    |
+| [Samsung Exynos](backends/samsung/samsung-overview.md)       | Android     | NPU           | Samsung SoCs                    |
 
 **Tip:** For best performance, export a `.pte` file for each backend you plan to support.
 


### PR DESCRIPTION
### Summary

Fix backend table links in `docs/source/backends-overview.md` to use relative paths consistently.

Several entries in the backends overview table used absolute paths starting with `/` (e.g., `/backends/cuda/cuda-overview.md`) while others used relative paths (e.g., `backends/xnnpack/xnnpack-overview.md`). Absolute paths can break when the documentation is served from a non-root URL.

This change standardizes all links to use relative paths, consistent with the `toctree` directives in the same file. Also removes a trailing space in the Vulkan link text.

cc @mergennachin @AlannaBurke @cccclai @GregoryComer

### Test plan

Verified all target files exist at their relative paths under `docs/source/`:
- `backends/cuda/cuda-overview.md` 
- `backends/coreml/coreml-overview.md` 
- `backends/mps/mps-overview.md` 
- `backends/vulkan/vulkan-overview.md` 
- `backends/arm-ethos-u/arm-ethos-u-overview.md` 
- `backends/arm-cortex-m/arm-cortex-m-overview.md` 
- `backends/arm-vgf/arm-vgf-overview.md` 
- `backends/samsung/samsung-overview.md` 
