### PR TITLE
Skip argmin/argmax with dim=None in CoreML partitioner

### DIFF
--- a/backends/apple/coreml/partition/coreml_partitioner.py
+++ b/backends/apple/coreml/partition/coreml_partitioner.py
@@ -63,6 +63,27 @@ _UNSUPPORTED_OP_TARGETS = frozenset(
 )
 
 
+_ARG_MIN_MAX_TARGETS = (
+    torch.ops.aten.argmax.default,
+    torch.ops.aten.argmin.default,
+    exir_ops.edge.aten.argmax.default,
+    exir_ops.edge.aten.argmin.default,
+)
+
+
+def _is_arg_min_max_over_flattened_input(node: torch.fx.Node) -> bool:
+    """``argmin``/``argmax`` with ``dim=None`` reduces over the flattened input.
+
+    CoreML doesn't support that reduction shape and intermittently crashes
+    the process at runtime — see pytorch/executorch#11715.
+    """
+    if node.target not in _ARG_MIN_MAX_TARGETS:
+        return False
+    dim = node.args[1] if len(node.args) >= 2 else node.kwargs.get("dim", None)
+    return dim is None
+
+
+
 def _is_view_op(op: torch._ops.OpOverload) -> bool:
     schema = op._schema
     if len(schema.arguments) == 0:
@@ -129,6 +150,13 @@ class _OperatorsSupportedForCoreMLBackend(OperatorSupportBase):
         if node.target in _UNSUPPORTED_OP_TARGETS:
             self.log_once(
                 f"{node.target} is not supported by CoreML.  Overriding op support."
+            )
+            return True
+
+        if _is_arg_min_max_over_flattened_input(node):
+            self.log_once(
+                "torch.ops.aten.{argmax, argmin}.default with dim=None is "
+                "not supported by CoreML.  Overriding op support."
             )
             return True
 

--- a/backends/apple/coreml/partition/coreml_partitioner.py
+++ b/backends/apple/coreml/partition/coreml_partitioner.py
@@ -83,7 +83,6 @@ def _is_arg_min_max_over_flattened_input(node: torch.fx.Node) -> bool:
     return dim is None
 
 
-
 def _is_view_op(op: torch._ops.OpOverload) -> bool:
     schema = op._schema
     if len(schema.arguments) == 0:

--- a/backends/apple/coreml/test/test_coreml_partitioner.py
+++ b/backends/apple/coreml/test/test_coreml_partitioner.py
@@ -386,6 +386,53 @@ class TestCoreMLPartitioner(unittest.TestCase):
         self.assertIn("executorch_call_delegate", op_names)
         self.assertNotIn("aten.randn.default", op_names)
 
+    def test_argmax_argmin_dim_none_is_skipped(self):
+        """
+        Regression test for https://github.com/pytorch/executorch/issues/11715.
+
+        argmax/argmin with dim=None reduces over the flattened tensor, which
+        CoreML does not support; the resulting model intermittently crashes
+        the process at runtime.  The partitioner must reject these so they
+        fall back to the portable backend, while still delegating the
+        ordinary dim=int form.
+        """
+
+        class FlatModel(torch.nn.Module):
+            def forward(self, x):
+                return torch.argmax(x, dim=None, keepdim=False) + torch.argmin(
+                    x, dim=None
+                )
+
+        ep = torch.export.export(
+            FlatModel().eval(), (torch.randn(10, 10),), strict=True
+        )
+        edge = executorch.exir.to_edge_transform_and_lower(
+            ep, partitioner=[CoreMLPartitioner()]
+        )
+        op_names = [
+            n.target.__name__
+            for n in edge.exported_program().graph.nodes
+            if n.op == "call_function"
+        ]
+        self.assertIn("aten.argmax.default", op_names)
+        self.assertIn("aten.argmin.default", op_names)
+
+        class DimModel(torch.nn.Module):
+            def forward(self, x):
+                return torch.argmax(x, dim=1)
+
+        ep = torch.export.export(DimModel().eval(), (torch.randn(10, 10),), strict=True)
+        edge = executorch.exir.to_edge_transform_and_lower(
+            ep, partitioner=[CoreMLPartitioner()]
+        )
+        op_names = [
+            n.target.__name__
+            for n in edge.exported_program().graph.nodes
+            if n.op == "call_function"
+        ]
+        self.assertIn("executorch_call_delegate", op_names)
+        self.assertNotIn("aten.argmax.default", op_names)
+
     def test_deprecation_warning_for_to_backend_workflow(self):
         """
         Test that the deprecated to_edge + to_backend workflow shows a deprecation warning.


### PR DESCRIPTION
### Summary

`argmax(x, dim=None)` / `argmin(x, dim=None)` reduces over the flattened
tensor.  CoreML does not support this reduction, and the resulting model
intermittently crashes the process at runtime (the issue reproducer
crashes 100% of the time on M1 Pro when the cell is run twice).

Detect the `dim is None` case in `should_override_support` so the op
falls back to the portable backend.  The ordinary `dim=int` form is
unaffected and still gets delegated.

Fixes #11715.

### Test plan

Added `test_argmax_argmin_dim_none_is_skipped` covering both branches:

- `argmax(x, dim=None) + argmin(x, dim=None)` — neither op is delegated.
- `argmax(x, dim=1)` — gets delegated as before.

```
$ python -m unittest -v executorch.backends.apple.coreml.test.test_coreml_partitioner.TestCoreMLPartitioner.test_argmax_argmin_dim_none_is_skipped
Ran 1 test in 1.042s

OK
```

Authored with Claude.

cc @metascroy