### PR TITLE
Wrap iOS18 quantization errors with ExecuTorch-specific hint

### DIFF
--- a/backends/apple/coreml/compiler/torch_ops.py
+++ b/backends/apple/coreml/compiler/torch_ops.py
@@ -12,20 +12,6 @@ import numpy as np
 import torch as _torch
 from coremltools import _logger
 from coremltools.converters.mil.frontend import _utils
-
-_IOS18_QUANT_HINT = (
-    "ExecuTorch hint: pass `compile_specs=CoreMLBackend.generate_compile_specs("
-    "minimum_deployment_target=ct.target.iOS18)` (or higher) to "
-    "`CoreMLPartitioner` when lowering models that use `quantize_(...)`."
-)
-
-
-def _raise_with_executorch_hint(err: Exception) -> "BaseException":
-    """Re-raise a coremltools quantization error with ExecuTorch-specific guidance."""
-    msg = str(err)
-    if "iOS18" in msg or "iOS 18" in msg:
-        raise ValueError(f"{msg}\n{_IOS18_QUANT_HINT}") from err
-    raise err
 from coremltools.converters.mil.frontend.torch.ops import (
     _get_inputs,
     _get_kwinputs,
@@ -40,6 +26,21 @@ from coremltools.converters.mil.frontend.torch.torch_op_registry import (
 )
 from coremltools.converters.mil.mil import types
 from executorch.exir.dim_order_utils import get_memory_format
+
+
+_IOS18_QUANT_HINT = (
+    "ExecuTorch hint: pass `compile_specs=CoreMLBackend.generate_compile_specs("
+    "minimum_deployment_target=ct.target.iOS18)` (or higher) to "
+    "`CoreMLPartitioner` when lowering models that use `quantize_(...)`."
+)
+
+
+def _raise_with_executorch_hint(err: Exception) -> "BaseException":
+    """Re-raise a coremltools quantization error with ExecuTorch-specific guidance."""
+    msg = str(err)
+    if "iOS18" in msg or "iOS 18" in msg:
+        raise ValueError(f"{msg}\n{_IOS18_QUANT_HINT}") from err
+    raise err
 
 
 # https://github.com/apple/coremltools/pull/2563

--- a/backends/apple/coreml/compiler/torch_ops.py
+++ b/backends/apple/coreml/compiler/torch_ops.py
@@ -12,6 +12,20 @@ import numpy as np
 import torch as _torch
 from coremltools import _logger
 from coremltools.converters.mil.frontend import _utils
+
+_IOS18_QUANT_HINT = (
+    "ExecuTorch hint: pass `compile_specs=CoreMLBackend.generate_compile_specs("
+    "minimum_deployment_target=ct.target.iOS18)` (or higher) to "
+    "`CoreMLPartitioner` when lowering models that use `quantize_(...)`."
+)
+
+
+def _raise_with_executorch_hint(err: Exception) -> "BaseException":
+    """Re-raise a coremltools quantization error with ExecuTorch-specific guidance."""
+    msg = str(err)
+    if "iOS18" in msg or "iOS 18" in msg:
+        raise ValueError(f"{msg}\n{_IOS18_QUANT_HINT}") from err
+    raise err
 from coremltools.converters.mil.frontend.torch.ops import (
     _get_inputs,
     _get_kwinputs,
@@ -159,12 +173,15 @@ def dequantize_affine(context, node):
             f"Unsupported quantization range: {quant_min} to {quant_max}.  CoreML only supports 4-bit and 8-bit quantization."
         )
 
-    output = _utils._construct_constexpr_dequant_op(
-        int_data.astype(quantized_np_dtype),
-        zero_point,
-        scale,
-        name=node.name,
-    )
+    try:
+        output = _utils._construct_constexpr_dequant_op(
+            int_data.astype(quantized_np_dtype),
+            zero_point,
+            scale,
+            name=node.name,
+        )
+    except ValueError as e:
+        _raise_with_executorch_hint(e)
     context.add(output, node.name)
 
 
@@ -211,9 +228,12 @@ def dequantize_codebook(context, node):
             f"Core ML ignores output_dtype {out_np_dtype} on torchao.dequantize_affine and instead uses the native precision."
         )
 
-    output = _utils._construct_constexpr_lut_op(
-        codes.astype(np.int8),
-        codebook,
-        name=node.name,
-    )
+    try:
+        output = _utils._construct_constexpr_lut_op(
+            codes.astype(np.int8),
+            codebook,
+            name=node.name,
+        )
+    except ValueError as e:
+        _raise_with_executorch_hint(e)
     context.add(output, node.name)

--- a/backends/apple/coreml/test/test_torch_ops.py
+++ b/backends/apple/coreml/test/test_torch_ops.py
@@ -317,7 +317,6 @@ class TestTorchOps(unittest.TestCase):
         et_prog = delegated_program.to_executorch()
         self._compare_outputs(et_prog, model, example_inputs)
 
-
     def test_dequantize_affine_below_ios18_raises_with_hint(self):
         """
         Regression test for https://github.com/pytorch/executorch/issues/13122.
@@ -337,9 +336,7 @@ class TestTorchOps(unittest.TestCase):
             executorch.exir.to_edge_transform_and_lower(
                 ep,
                 partitioner=[
-                    self._coreml_partitioner(
-                        minimum_deployment_target=ct.target.iOS17
-                    )
+                    self._coreml_partitioner(minimum_deployment_target=ct.target.iOS17)
                 ],
             )
         msg = str(cm.exception)

--- a/backends/apple/coreml/test/test_torch_ops.py
+++ b/backends/apple/coreml/test/test_torch_ops.py
@@ -318,6 +318,36 @@ class TestTorchOps(unittest.TestCase):
         self._compare_outputs(et_prog, model, example_inputs)
 
 
+    def test_dequantize_affine_below_ios18_raises_with_hint(self):
+        """
+        Regression test for https://github.com/pytorch/executorch/issues/13122.
+
+        `quantize_(...)` with blockwise / int4 configurations requires iOS18.
+        coremltools raises a ValueError that does not mention how to fix the
+        deployment target on the ExecuTorch side; we wrap it to add the
+        partitioner-level guidance.
+        """
+        model = torch.nn.Linear(64, 64)
+        quantize_(
+            model,
+            IntxWeightOnlyConfig(weight_dtype=torch.int4, granularity=PerGroup(32)),
+        )
+        ep = torch.export.export(model.eval(), (torch.randn(1, 64),), strict=True)
+        with self.assertRaises(ValueError) as cm:
+            executorch.exir.to_edge_transform_and_lower(
+                ep,
+                partitioner=[
+                    self._coreml_partitioner(
+                        minimum_deployment_target=ct.target.iOS17
+                    )
+                ],
+            )
+        msg = str(cm.exception)
+        self.assertIn("iOS18", msg)
+        self.assertIn("CoreMLPartitioner", msg)
+        self.assertIn("minimum_deployment_target", msg)
+
+
 if __name__ == "__main__":
     test_runner = TestTorchOps()
     test_runner.test_dequantize_affine_b4w_embedding()


### PR DESCRIPTION
### Summary

When a model prepared with torchao's `quantize_(...)` (e.g. blockwise int4)
is lowered without an iOS18+ `minimum_deployment_target`, coremltools raises
a `ValueError` from inside `_construct_constexpr_dequant_op`:

```
ValueError: The more fine-grained quantization (such as blockwise) is only supported since iOS18.Please set minimum_deployment_target to iOS18 for using it.
```

This message is technically correct but does not tell the ExecuTorch user
*how* to set the deployment target — the answer is buried in
`CoreMLBackend.generate_compile_specs(...)` plus
`CoreMLPartitioner(compile_specs=...)`, which is not obvious unless you've
already been through the docs.

The two `dequantize_affine` / `dequantize_codebook` handlers in
`backends/apple/coreml/compiler/torch_ops.py` are the only call sites where
the failing coremltools utilities are invoked from ExecuTorch code, so I
wrap them and re-raise the error with an additional hint that shows the
exact partitioner call.  After this change the user sees:

```
ValueError: The more fine-grained quantization (such as blockwise) is only supported since iOS18.Please set minimum_deployment_target to iOS18 for using it.
ExecuTorch hint: pass `compile_specs=CoreMLBackend.generate_compile_specs(minimum_deployment_target=ct.target.iOS18)` (or higher) to `CoreMLPartitioner` when lowering models that use `quantize_(...)`.
```

Fixes #13122.

### Test plan

Added `test_dequantize_affine_below_ios18_raises_with_hint` which lowers a
PerGroup-int4 quantized linear with `minimum_deployment_target=ct.target.iOS17`
and asserts the raised `ValueError` mentions both `iOS18` and the
`CoreMLPartitioner` / `minimum_deployment_target` keywords.

The existing iOS18 quantization tests still pass (`test_dequantize_affine_b4w_linear` exercised locally to confirm the wrapper does not affect the success path).

```
$ python -m unittest -v executorch.backends.apple.coreml.test.test_torch_ops.TestTorchOps.test_dequantize_affine_below_ios18_raises_with_hint
Ran 1 test in 0.653s

OK
$ python -m unittest -v executorch.backends.apple.coreml.test.test_torch_ops.TestTorchOps.test_dequantize_affine_b4w_linear
Ran 1 test in 0.536s

OK
```

Authored with Claude.

cc @kimishpatel @YifanShenSZ @cymbalrush @metascroy