### PR TITLE
CI: recreate conda env from conda-forge to avoid mixed-channel solve

### DIFF
--- a/.ci/scripts/setup-conda.sh
+++ b/.ci/scripts/setup-conda.sh
@@ -9,7 +9,22 @@ set -ex
 
 install_conda() {
   pushd .ci/docker || return
-  ${CONDA_INSTALL} -c conda-forge -y --file conda-env-ci.txt
+
+  # The env created by pytorch/test-infra's setup-miniconda is pre-populated
+  # with cmake=3.22 ninja=1.10 pkg-config=0.29 wheel=0.37 from the anaconda
+  # defaults channel. Mixing those with conda-forge's newer transitive deps
+  # required by our cmake=3.31.2 pin (libzlib>=1.3.1, rhash>=1.4.5) has been
+  # intermittently failing the libmamba solver, especially on ephemeral
+  # GitHub-hosted macOS runners where the env is fresh every job. Tear down
+  # the pre-populated env and recreate it from conda-forge only so the solve
+  # never has to reconcile two channels.
+  PY_VERSION=$(conda run -p "${CONDA_PREFIX}" python -c \
+    'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
+
+  conda env remove --prefix "${CONDA_PREFIX}" -y
+  conda create --prefix "${CONDA_PREFIX}" -c conda-forge --override-channels -y \
+    "python=${PY_VERSION}" --file conda-env-ci.txt
+
   popd || return
 }
 


### PR DESCRIPTION
### Summary
pytorch/test-infra's setup-miniconda action pre-populates the conda env
at ${CONDA_PREFIX} with cmake=3.22, ninja=1.10, pkg-config=0.29, and
wheel=0.37 from the anaconda defaults channel. Our subsequent install
of cmake=3.31.2 from conda-forge has to reconcile two channels in one
solve, and that's been intermittently failing because conda-forge's
newer cmake needs transitive deps (libzlib>=1.3.1, rhash>=1.4.5) that
defaults' shipped versions don't satisfy. Patches that just tweak the
solver flags (--strict-channel-priority, --override-channels alone,
--update-deps) each address one symptom but expose another, because
libmamba on macOS has gaps around channel priority and in-place
upgrades that surface differently per runner class.

Tear down the pre-populated env and recreate it from conda-forge only
with --override-channels. The python version is read from the existing
env so we recreate at parity. Because we recreate at the same prefix,
${CONDA_RUN}, ${CONDA_INSTALL}, and the ~80 workflow callsites that
depend on those vars keep working unchanged. The cache layer in
setup-miniconda caches the base/clone-source rather than the per-run
env, so destroy+recreate doesn't disturb caching either.

Authored with Claude Code.

### Test plan
CI