### PR TITLE
Arm backend: Fix integer overflow in VGFBackend IO size computation

### DIFF
--- a/backends/arm/runtime/VGFBackend.cpp
+++ b/backends/arm/runtime/VGFBackend.cpp
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <list>
-#include <numeric>
+#include <cinttypes>
 using namespace std;
 
+#include <c10/util/safe_numerics.h>
 #include <executorch/runtime/backend/interface.h>
 #include <executorch/runtime/core/error.h>
 #include <executorch/runtime/core/evalue.h>
@@ -191,8 +191,18 @@ class VGFBackend final : public ::executorch::runtime::BackendInterface {
       if (!io->is_input)
         continue;
 
-      size_t io_size = accumulate(
-          io->size.begin(), io->size.end(), io->elt_size, std::multiplies<>());
+      size_t io_size = io->elt_size;
+      for (int64_t dim : io->size) {
+        ET_CHECK_OR_RETURN_ERROR(
+            dim >= 0,
+            InvalidArgument,
+            "Negative dimension in IO size: %" PRId64,
+            dim);
+        ET_CHECK_OR_RETURN_ERROR(
+            !c10::mul_overflows(io_size, static_cast<size_t>(dim), &io_size),
+            InvalidArgument,
+            "Overflow computing IO buffer size");
+      }
 
       void* data;
       if (!repr->map_io(io, &data)) {
@@ -226,8 +236,18 @@ class VGFBackend final : public ::executorch::runtime::BackendInterface {
       if (io->is_input)
         continue;
 
-      size_t io_size = accumulate(
-          io->size.begin(), io->size.end(), io->elt_size, std::multiplies<>());
+      size_t io_size = io->elt_size;
+      for (int64_t dim : io->size) {
+        ET_CHECK_OR_RETURN_ERROR(
+            dim >= 0,
+            InvalidArgument,
+            "Negative dimension in IO size: %" PRId64,
+            dim);
+        ET_CHECK_OR_RETURN_ERROR(
+            !c10::mul_overflows(io_size, static_cast<size_t>(dim), &io_size),
+            InvalidArgument,
+            "Overflow computing IO buffer size");
+      }
 
       void* data;
       if (!repr->map_io(io, &data)) {


### PR DESCRIPTION
Replace std::accumulate with std::multiplies<>() with an explicit loop using c10::mul_overflows() to detect overflow before each multiplication. The previous code would silently wrap on overflow, producing an undersized memcpy size that could lead to out-of-bounds reads/writes when copying tensor data to/from Vulkan device memory.

Also reject negative dimensions before casting to size_t.

This PR was authored with the assistance of Claude.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell