### PR TITLE
Add Unsqueeze copy partitioner configs to reduce XNNPACK delegate fragmentation

### DIFF
--- a/backends/xnnpack/partition/config/__init__.py
+++ b/backends/xnnpack/partition/config/__init__.py
@@ -55,7 +55,9 @@ from executorch.backends.xnnpack.partition.config.generic_node_configs import (
     SubConfig,
     TanhConfig,
     ToDimOrderCopyConfig,
+    UnsqueezeCopyConfig,
     UpsampleBilinear2dConfig,
+    ViewCopyConfig,
 )
 from executorch.backends.xnnpack.partition.config.node_configs import (
     BatchNormConfig,
@@ -116,7 +118,9 @@ ALL_PARTITIONER_CONFIGS: List[Type[XNNPartitionerConfig]] = [
     SoftmaxConfig,
     SquareRootConfig,
     SubConfig,
+    UnsqueezeCopyConfig,
     UpsampleBilinear2dConfig,
+    ViewCopyConfig,
     # Quant/Dequant Op Configs
     QuantizedPerTensorConfig,
     DeQuantizedPerTensorConfig,

--- a/backends/xnnpack/partition/config/generic_node_configs.py
+++ b/backends/xnnpack/partition/config/generic_node_configs.py
@@ -384,7 +384,7 @@ class ViewCopyConfig(GenericNodePartitionerConfig):
     target_name = "view_copy.default"
 
     def supported_precision_types(self) -> List[ConfigPrecisionType]:
-        return [ConfigPrecisionType.FP32]
+        return [ConfigPrecisionType.FP32, ConfigPrecisionType.STATIC_QUANT]
 
     def check_constraints(self, node: torch.fx.Node, ep: ExportedProgram) -> bool:
         """
@@ -722,3 +722,24 @@ class CosConfig(GenericNodePartitionerConfig):
 
     def supported_precision_types(self) -> List[ConfigPrecisionType]:
         return [ConfigPrecisionType.FP32]
+
+
+class UnsqueezeCopyConfig(GenericNodePartitionerConfig):
+    target_name = "unsqueeze_copy.default"
+
+    def supported_precision_types(self) -> List[ConfigPrecisionType]:
+        return [ConfigPrecisionType.FP32, ConfigPrecisionType.STATIC_QUANT]
+
+    def check_constraints(self, node: torch.fx.Node, ep: ExportedProgram) -> bool:
+        if not self.check_common_constraints(node, ep):
+            return False
+
+        # The XNNPACK UnsqueezeVisitor only supports unsqueeze on the trailing
+        # dimension. Mirrors the runtime check in op_squeeze.py.
+        dim = node.args[1]
+        input_rank = len(node.args[0].meta["val"].shape)
+        if dim != -1 and dim != input_rank:
+            why(node, reason="unsqueeze_copy only supported on the trailing dimension")
+            return False
+
+        return True


### PR DESCRIPTION
Summary:
`aten.unsqueeze_copy.default` already have working `NodeVisitor` implementation in
`backends/xnnpack/operators/op_squeeze.py`, but it was never wired into `ALL_PARTITIONER_CONFIGS`. As a result the partitioner could not absorb them, which forced delegate breaks every time the graph passed through one of these reshapes.

This adds `GenericNodePartitionerConfig` subclass`UnsqueezeCopyConfig` which accepts `unsqueeze_copy.default` only when the inserted dim is the trailing dim (mirrors `UnsqueezeVisitor`'s constraint).

Differential Revision: D103450015


