### PR TITLE
qwen3_5_moe: guard new cudaMemGetInfo blocks behind EXECUTORCH_BUILD_CUDA

### DIFF
--- a/examples/models/qwen3_5_moe/main.cpp
+++ b/examples/models/qwen3_5_moe/main.cpp
@@ -131,6 +131,7 @@ int main(int argc, char** argv) {
     return 1;
   }
 
+#ifdef EXECUTORCH_BUILD_CUDA
   // GPU memory: before load
   {
     size_t free = 0, total = 0;
@@ -139,6 +140,7 @@ int main(int argc, char** argv) {
       stats.gpu_free_before_load_bytes = free;
     }
   }
+#endif
 
   stats.model_load_start_ms = llm::time_in_ms();
 
@@ -224,6 +226,7 @@ int main(int argc, char** argv) {
 
   stats.model_load_end_ms = llm::time_in_ms();
 
+#ifdef EXECUTORCH_BUILD_CUDA
   // GPU memory: after load
   {
     size_t free = 0, total = 0;
@@ -231,6 +234,7 @@ int main(int argc, char** argv) {
       stats.gpu_free_after_load_bytes = free;
     }
   }
+#endif
 
   // Get EOS ids
   auto eos_ids = llm::get_eos_ids(tokenizer.get(), module.get());
@@ -397,6 +401,7 @@ int main(int argc, char** argv) {
   int64_t num_generated = pos - num_prompt_tokens;
   stats.num_generated_tokens = num_generated;
 
+#ifdef EXECUTORCH_BUILD_CUDA
   // GPU memory: after generate + peak usage
   {
     size_t free = 0, total = 0;
@@ -412,6 +417,7 @@ int main(int argc, char** argv) {
       stats.gpu_peak_usage_mb = (double)(total - min_free) / 1024.0 / 1024.0;
     }
   }
+#endif
 
   printf("\n");
 


### PR DESCRIPTION
### Summary

#19228 added structured GPU memory tracking to the qwen3_5_moe runner but did not wrap the new cudaMemGetInfo blocks in the existing EXECUTORCH_BUILD_CUDA guard that the rest of the file uses for CUDA-only APIs. The same main.cpp is built for the Metal target where the CUDA runtime headers are not available, so the new blocks failed to compile on macOS:

    error: use of undeclared identifier 'cudaMemGetInfo'
        if (cudaMemGetInfo(&free, &total) == cudaSuccess) {

Wrap the three new scoped blocks in #ifdef EXECUTORCH_BUILD_CUDA, matching the existing guard pattern at lines 27, 68, 113, 168, and 184. The stats struct fields they would have populated (gpu_free_before_load_bytes, gpu_free_after_load_bytes, gpu_free_after_generate_bytes, gpu_peak_usage_mb) default to their sentinel values on non-CUDA builds, so the rest of the runner's stats reporting tolerates their absence.

Authored with Claude Code.

### Test plan
CI