### PR TITLE
Validate non-null data pointer in Tensor accessors

### DIFF
--- a/runtime/core/portable_type/tensor.h
+++ b/runtime/core/portable_type/tensor.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <executorch/runtime/platform/assert.h>
 #include <executorch/runtime/platform/compiler.h>
 
 #include <executorch/runtime/core/portable_type/tensor_impl.h>
@@ -118,33 +119,57 @@ class Tensor {
   /// Returns a pointer of type T to the constant underlying data blob.
   template <typename T>
   inline const T* const_data_ptr() const {
+    ET_CHECK_MSG(
+        numel() == 0 || impl_->data() != nullptr,
+        "Tensor has non-zero numel (%zd) but null data pointer",
+        (ssize_t)numel());
     return impl_->data<T>();
   }
 
   /// Returns a pointer to the constant underlying data blob.
   inline const void* const_data_ptr() const {
+    ET_CHECK_MSG(
+        numel() == 0 || impl_->data() != nullptr,
+        "Tensor has non-zero numel (%zd) but null data pointer",
+        (ssize_t)numel());
     return impl_->data();
   }
 
   /// Returns a pointer of type T to the mutable underlying data blob.
   template <typename T>
   inline T* mutable_data_ptr() const {
+    ET_CHECK_MSG(
+        numel() == 0 || impl_->data() != nullptr,
+        "Tensor has non-zero numel (%zd) but null data pointer",
+        (ssize_t)numel());
     return impl_->mutable_data<T>();
   }
 
   /// Returns a pointer to the mutable underlying data blob.
   inline void* mutable_data_ptr() const {
+    ET_CHECK_MSG(
+        numel() == 0 || impl_->data() != nullptr,
+        "Tensor has non-zero numel (%zd) but null data pointer",
+        (ssize_t)numel());
     return impl_->mutable_data();
   }
 
   /// DEPRECATED: Use const_data_ptr or mutable_data_ptr instead.
   template <typename T>
   ET_DEPRECATED inline T* data_ptr() const {
+    ET_CHECK_MSG(
+        numel() == 0 || impl_->data() != nullptr,
+        "Tensor has non-zero numel (%zd) but null data pointer",
+        (ssize_t)numel());
     return impl_->mutable_data<T>();
   }
 
   /// DEPRECATED: Use const_data_ptr or mutable_data_ptr instead.
   ET_DEPRECATED inline void* data_ptr() const {
+    ET_CHECK_MSG(
+        numel() == 0 || impl_->data() != nullptr,
+        "Tensor has non-zero numel (%zd) but null data pointer",
+        (ssize_t)numel());
     return impl_->mutable_data();
   }
 


### PR DESCRIPTION
Summary:
Add null-data-pointer validation to all six data accessor methods on the `Tensor` class (`const_data_ptr`, `mutable_data_ptr`, and deprecated `data_ptr` — two overloads each).

The check fires when `numel() > 0` but the underlying `data_` pointer is null, which indicates an invalid tensor state. This prevents null pointer dereferences in all 225+ kernel implementations that call these accessors.

The Lionhead fuzzer (`FuzzKernels` harness, T234178948) has been filing 50-100+ crash tasks because it constructs tensors with non-zero numel but null data pointers. Every kernel that dereferences the result of `const_data_ptr()` crashes. This centralized check catches the invalid state at the accessor level, eliminating the entire class of fuzzer findings.

Tensors with `numel() == 0` and a null data pointer remain valid (empty tensors).

Differential Revision: D103467785


