### PR TITLE
NXP backend: New Neutron-C flow support for ReLU

### DIFF
--- a/backends/nxp/backend/graph_utils.py
+++ b/backends/nxp/backend/graph_utils.py
@@ -3,7 +3,13 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import numpy as np
 import torch
+from executorch.backends.nxp.backend.ir.converter.conversion.translator import (
+    torch_type_to_numpy_type,
+)
+from executorch.backends.nxp.backend.ir.converter.node_converter import _is_dequant_node
+from executorch.backends.nxp.backend.ir.converter.quantization_utils import quantize
 from executorch.exir.dialects._ops import ops as exir_ops
 from torch.fx import Node
 
@@ -47,3 +53,77 @@ def get_output_shape(node: Node) -> tuple[torch.Size] | torch.Size | None:
         return tuple([v.shape for v in val])
 
     return None
+
+
+def is_clamp_preserved_under_quantization(
+    node: Node, min_val: int = 0, max_val: int | None = None
+) -> bool:
+    """
+    Checks if Clamp/ReLU/HardTanh is preserved under quantization and did
+    not collapse into either identity or constant.
+
+     Valid quant. bounds -                Quant. bounds -
+    one hinge is preserved             Collapse to identity
+            │   │                           │ │
+            │   ▼/¯¯¯¯¯ ReLU6(x)            │ ▼/¯¯¯¯¯ ReLU6(x)
+            │   /                           │ /
+            │  /                            ▼/
+            ▼ /                             /
+        ¯¯¯¯¯ Hinge                   ¯¯¯¯¯ Hinge
+
+        Args:
+        node: Node to check whether is preserved
+        min_val: Lower bound (hinge) of the operator (eg. 0 for ReLU)
+        max_val: Upper bound of the operator (eg. 6 for ReLU6 or None for ReLU)
+    """
+
+    q_node = node.args[0]
+
+    if not _is_dequant_node(q_node):
+        return False
+
+    if len(q_node.args) == 6:
+        # per-tensor
+        _, scale, zp, quant_min, quant_max, q_type = q_node.args
+    else:
+        # per-channel
+        _, scale, zp, quant_min, quant_max, _, q_type = q_node.args
+
+    quant_min = np.iinfo(q_type).min if quant_min is None else quant_min
+    quant_max = np.iinfo(q_type).max if quant_max is None else quant_max
+
+    q_type = torch_type_to_numpy_type(q_type).type
+    quantized_min_val = quantize(
+        value=min_val,
+        zero_point=zp,
+        scale=scale,
+        quant_min=quant_min,
+        quant_max=quant_max,
+        dtype=q_type,
+    )
+
+    if max_val is not None:
+        quantized_max_val = quantize(
+            value=max_val,
+            zero_point=zp,
+            scale=scale,
+            quant_min=quant_min,
+            quant_max=quant_max,
+            dtype=q_type,
+        )
+        return (
+            # If at least one bound is inside the quantization range
+            # the hinge of the ReLU/HardTanh is preserved and therefore does not
+            # collapse to identity or constant.
+            (
+                np.all(quant_min < quantized_min_val)
+                or np.all(quantized_max_val < quant_max)
+            )
+            # When both operator bounds are outside the quantization range
+            # the operator collapses into constant value (eg. 0 or 6 for ReLU6).
+            and not np.all(quant_max < quantized_min_val)
+            and not np.all(quant_min > quantized_max_val)
+        )
+
+    # Ensure ReLU/HardTanh hinge is preserved.
+    return quant_min < quantized_min_val < quant_max

--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/clamp_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/clamp_converter.py
@@ -144,7 +144,7 @@ class ClampConverter(NodeConverter):
                 node, partition_list, filter_fn=is_not_qdq_node
             )
             if is_alone_in_partition:
-                return activation_supported_on_target(node, neutron_target_spec)
+                return activation_supported_on_target(node)
 
         return True
 

--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/clamp_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/clamp_converter.py
@@ -8,6 +8,9 @@ import math
 import numpy as np
 import torch
 from executorch.backends.nxp.backend.edge_helper import try_get_arg
+from executorch.backends.nxp.backend.graph_utils import (
+    is_clamp_preserved_under_quantization,
+)
 from executorch.backends.nxp.backend.ir.converter.conversion.translator import (
     torch_type_to_numpy_type,
 )
@@ -20,6 +23,7 @@ from executorch.backends.nxp.backend.ir.converter.node_converter import (
 )
 from executorch.backends.nxp.backend.ir.converter.quantization_utils import (
     propagate_quantization,
+    quantize,
 )
 from executorch.backends.nxp.backend.ir.lib.tflite.BuiltinOperator import (
     BuiltinOperator,
@@ -117,17 +121,20 @@ class ClampConverter(NodeConverter):
             output_indices=[0],
         )
 
-        # We either convert to ReLU -> SingleInputQuantization pattern
-        # or we convert to Min/Max, which requires same quantization on
-        # both input and output.
-        return (relu_compatible | io_quant_consistent) and quant_supported
+        if relu_compatible and activation_supported_on_target(
+            node,
+        ):
+            return True
+
+        # We convert to Min/Max, which requires same quantization for both input and output.
+        return io_quant_consistent and quant_supported
 
     @classmethod
     def supports_partitioning_result(
         cls,
         node: Node,
         partition_list: list[Partition],
-        _: CustomDelegationOptions,
+        custom_delegation_options: CustomDelegationOptions,
         neutron_target_spec: NeutronTargetSpec,
         parameters_mapping: dict[str, Parameter],
     ) -> bool:
@@ -136,29 +143,18 @@ class ClampConverter(NodeConverter):
         # Neutron cannot delegate a partition where ReLU or ReLU6 is the only operator
         # and at the same time the node does not satisfy delegation requirements.
         # In contrast, ReLUN1To1 and ReLU0To1 are supported and delegated successfuly.
-        if bounds in [
-            cls.RELU_COMPATIBLE_BOUNDS["Relu"],
-            cls.RELU_COMPATIBLE_BOUNDS["Relu6"],
-        ]:
+        if bounds in cls.RELU_COMPATIBLE_BOUNDS.values():
             is_alone_in_partition = cls.is_node_alone_in_partition(
                 node, partition_list, filter_fn=is_not_qdq_node
             )
             if is_alone_in_partition:
-                return activation_supported_on_target(node)
+                return is_clamp_preserved_under_quantization(
+                    node,
+                    min_val=bounds[0],
+                    max_val=bounds[1],
+                )
 
         return True
-
-    @staticmethod
-    def _quantize_value(
-        value: int,
-        zp: int,
-        scale: float,
-        quant_min: int,
-        quant_max: int,
-        dtype: type = np.int8,
-    ) -> np.integer:
-        rescaled_value = round(value / scale) + zp
-        return dtype(np.clip(rescaled_value, quant_min, quant_max))
 
     def convert(self, node: Node):
         """Convert the `aten.clamp.default` operator to either
@@ -202,9 +198,9 @@ class ClampConverter(NodeConverter):
         min_value, max_value = bounds
 
         if min_value is not None:
-            min_value = self._quantize_value(
+            min_value = quantize(
                 value=min_value,
-                zp=zp,
+                zero_point=zp,
                 scale=scale,
                 quant_min=quant_min,
                 quant_max=quant_max,
@@ -216,9 +212,9 @@ class ClampConverter(NodeConverter):
             propagate_quantization(x, min_tensor)
 
         if max_value is not None:
-            max_value = self._quantize_value(
+            max_value = quantize(
                 value=max_value,
-                zp=zp,
+                zero_point=zp,
                 scale=scale,
                 quant_min=quant_min,
                 quant_max=quant_max,

--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/hardtanh_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/hardtanh_converter.py
@@ -94,7 +94,7 @@ class HardTanhConverter(NodeConverter):
                 node, partition_list, filter_fn=is_not_qdq_node
             )
             if is_alone_in_partition:
-                return activation_supported_on_target(node, neutron_target_spec)
+                return activation_supported_on_target(node)
 
         return True
 

--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/relu_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/relu_converter.py
@@ -3,6 +3,10 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+
+from executorch.backends.nxp.backend.graph_utils import (
+    is_clamp_preserved_under_quantization,
+)
 from executorch.backends.nxp.backend.ir.converter.node_converter import (
     CustomDelegationOptions,
     is_not_qdq_node,
@@ -30,6 +34,15 @@ class ReLUConverter(NodeConverter):
     ) -> bool:
         return True
 
+    @staticmethod
+    def _is_supported_on_target(
+        node: Node,
+        neutron_target_spec: NeutronTargetSpec,
+        parameters_mapping: dict[str, Parameter],
+        custom_delegation_options: CustomDelegationOptions,
+    ) -> bool:
+        return activation_supported_on_target(node)
+
     @classmethod
     def supports_partitioning_result(
         cls,
@@ -43,7 +56,7 @@ class ReLUConverter(NodeConverter):
             node, partition_list, filter_fn=is_not_qdq_node
         )
         if is_alone_in_partition:
-            return activation_supported_on_target(node)
+            return is_clamp_preserved_under_quantization(node)
 
         return True
 

--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/relu_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/relu_converter.py
@@ -43,7 +43,7 @@ class ReLUConverter(NodeConverter):
             node, partition_list, filter_fn=is_not_qdq_node
         )
         if is_alone_in_partition:
-            return activation_supported_on_target(node, neutron_target_spec)
+            return activation_supported_on_target(node)
 
         return True
 

--- a/backends/nxp/backend/ir/converter/quantization_utils.py
+++ b/backends/nxp/backend/ir/converter/quantization_utils.py
@@ -135,8 +135,19 @@ def set_quantization_parameters_to_tensor(
 def quantize_int8(
     data: np.ndarray, scale: List[float], zero_point: List[int]
 ) -> np.ndarray:
-    new_data = np.add(np.round(np.divide(data, scale)), zero_point)
-    return np.clip(new_data, -128, 127).astype(np.int8)
+    return quantize(data, zero_point=zero_point, scale=scale)
+
+
+def quantize(
+    value: np.ndarray | int,
+    zero_point: List[int] | int,
+    scale: List[float] | float,
+    quant_min: int = -128,
+    quant_max: int = 127,
+    dtype: type = np.int8,
+) -> np.ndarray | np.integer:
+    rescaled_value = np.add(np.round(np.divide(value, scale)), zero_point)
+    return dtype(np.clip(rescaled_value, quant_min, quant_max))
 
 
 def dequantize(

--- a/backends/nxp/backend/neutron_operator_support.py
+++ b/backends/nxp/backend/neutron_operator_support.py
@@ -3,11 +3,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from executorch.backends.nxp.backend.data_format import NXP_NODE_FORMAT
-from executorch.backends.nxp.backend.edge_helper import input_tensor
-from executorch.backends.nxp.backend.ir.converter.conversion.translator import (
-    dims_to_channels_last,
-)
+import torch
 from executorch.backends.nxp.backend.neutron_target_spec import NeutronTargetSpec
 from torch.fx import Node
 
@@ -86,20 +82,20 @@ def transposition_is_supported_on_neutron(
 
 
 def activation_supported_on_target(
-    node: Node, neutron_target_spec: NeutronTargetSpec
+    node: Node,
 ) -> bool:
     """This function determines if the current NeutronSoftware properly supports an activation operator represented by the given node.
 
     :param node: The node representing the activation operator.
-    :param neutron_target_spec: Object for querying the target platform to retrieve its properties.
     """
-    input_shape = list(input_tensor(node, 0).shape)
-    if node.args[0].meta[NXP_NODE_FORMAT].is_channels_first():
-        input_shape = dims_to_channels_last(input_shape)
+    # Prevent circular import
+    from executorch.backends.nxp.backend.ir.converter.node_converter import (
+        NodeConverter,
+    )
 
-    c = input_shape[-1]
-    num_macs = neutron_target_spec.get_num_macs()
-
-    # activations in Neutron are delegable only
-    # if `num_channels` % `num_macs` == 0
-    return c % num_macs == 0
+    return NodeConverter.uses_quantization_type_for_io(
+        node,
+        supported_types=[torch.int8, torch.uint8],
+        input_indices=[0],
+        output_indices=[0],
+    )

--- a/backends/nxp/tests/ir/converter/node_converter/test_abs_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_abs_converter.py
@@ -8,13 +8,12 @@ import numpy as np
 # noinspection PyUnusedImports
 import pytest
 import torch
-
 from executorch.backends.nxp.tests.graph_verifier import DetailedGraphVerifier
 from executorch.backends.nxp.tests.nsys_testing import (
     lower_run_compare,
     RandomDatasetCreator,
 )
-from executorch.backends.nxp.tests.ops_aliases import Abs, Convolution, Relu
+from executorch.backends.nxp.tests.ops_aliases import Abs
 from executorch.backends.nxp.tests.use_qat import *  # noqa F403
 
 
@@ -90,26 +89,6 @@ class TestAbs:
         model = AbsModule()
         graph_verifier = DetailedGraphVerifier(
             mocker, expected_delegated_ops={Abs: 1}, expected_non_delegated_ops={}
-        )
-
-        dataset_creator = self._get_dataset_creator()
-        lower_run_compare(
-            model,
-            input_shape,
-            graph_verifier,
-            dataset_creator,
-        )
-
-    def test_basic_nsys_inference__with_conv(self, mocker):
-        input_shape = (2, 3, 6, 7)
-        in_channels = input_shape[1]
-        model = ConvBlocksWithAbsModule(conv_in_channels=in_channels)
-
-        # one `relu` ends up in the same delegated partition as `abs`
-        graph_verifier = DetailedGraphVerifier(
-            mocker,
-            expected_delegated_ops={Abs: 1, Relu: 1},
-            expected_non_delegated_ops={Relu: 1, Convolution: 2},
         )
 
         dataset_creator = self._get_dataset_creator()

--- a/backends/nxp/tests/ir/converter/node_converter/test_hardtanh_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_hardtanh_converter.py
@@ -17,7 +17,7 @@ from executorch.backends.nxp.tests.executors import (
     ToChannelFirstPreprocess,
     ToChannelLastPreprocess,
 )
-from executorch.backends.nxp.tests.models import Conv2dWithActivation, HardTanhModule
+from executorch.backends.nxp.tests.models import Conv2dWithActivation
 from executorch.exir.dialects._ops import ops as exir_ops
 from torch.export import ExportedProgram
 from executorch.backends.nxp.tests.use_qat import *  # noqa F403
@@ -117,34 +117,3 @@ def test_custom_hardtanh_quant(
         input_data=input_data,
         atol=2.0,
     )
-
-
-@pytest.mark.parametrize(
-    "input_shape, activation_range",
-    [
-        pytest.param(
-            (3, 7, 15, 7),
-            (0, float("inf")),
-            id="activation range: Relu, num_channels not divisible by NUM_MACS, alone in partition",
-        ),
-        pytest.param(
-            (3, 7, 15, 7),
-            (0, 6),
-            id="activation range: Relu6, num_channels not divisible by NUM_MACS, alone in partition",
-        ),
-    ],
-)
-def test_hardtanh__unsupported(
-    input_shape: tuple[int],
-    activation_range: tuple[float, float],
-    use_qat: bool,
-):
-    min_val, max_val = activation_range
-    model = HardTanhModule(min_val, max_val)
-    delegated_ep = to_quantized_edge_program(
-        model, input_shape, use_qat=use_qat
-    ).exported_program()
-
-    # Make sure the `hardtanh` was NOT delegated.
-    assert not graph_contains_any_of_ops(delegated_ep.graph, [ExecutorchDelegateCall])
-    assert graph_contains_any_of_ops(delegated_ep.graph, [HardTanh, HardTanh_])

--- a/backends/nxp/tests/ir/converter/node_converter/test_relu_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_relu_converter.py
@@ -6,23 +6,23 @@
 import numpy as np
 import pytest
 import torch
-
-from executorch.backends.nxp.backend.edge_program_converter import (
-    EdgeProgramToIRConverter,
-    exir_ops,
-)
-from executorch.backends.nxp.tests.executorch_pipeline import (
-    to_edge_program,
-    to_quantized_edge_program,
-)
-from executorch.backends.nxp.tests.executors import (
-    convert_run_compare,
-    graph_contains_any_of_ops,
-    ToNCHWPreprocess,
-    ToNHWCPreprocess,
-)
+from executorch.backends.nxp.backend.edge_program_converter import exir_ops
+from executorch.backends.nxp.tests.dataset_creator import RandomDatasetCreator
+from executorch.backends.nxp.tests.executorch_pipeline import to_quantized_edge_program
+from executorch.backends.nxp.tests.executors import graph_contains_any_of_ops
+from executorch.backends.nxp.tests.graph_verifier import DetailedGraphVerifier
 from executorch.backends.nxp.tests.models import Conv2dModule, LinearModule, ReLUModule
-from torch.export import ExportedProgram
+from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
+from executorch.backends.nxp.tests.ops_aliases import (
+    AddMm,
+    Convolution,
+    DequantizePerChannel,
+    DequantizePerTensor,
+    PermuteCopy,
+    QuantizePerTensor,
+    Relu,
+    ViewCopy,
+)
 from executorch.backends.nxp.tests.use_qat import *  # noqa F403
 
 
@@ -37,10 +37,10 @@ ReLU = exir_ops.edge.aten.relu.default
 
 
 class ConvReLUModule(torch.nn.Module):
-    def __init__(self):
+    def __init__(self, in_channels=4, out_channels=8):
         super().__init__()
 
-        self.conv = Conv2dModule()
+        self.conv = Conv2dModule(in_channels=in_channels, out_channels=out_channels)
         self.relu = torch.nn.ReLU()
 
     def forward(self, x):
@@ -49,10 +49,12 @@ class ConvReLUModule(torch.nn.Module):
 
 
 class LinearReLUModule(torch.nn.Module):
-    def __init__(self):
+    def __init__(self, in_features: int = 32, out_features: int = 16):
         super().__init__()
 
-        self.linear = LinearModule(bias=True)
+        self.linear = LinearModule(
+            bias=True, in_features=in_features, out_features=out_features
+        )
         self.relu = torch.nn.ReLU()
 
     def forward(self, x):
@@ -60,89 +62,125 @@ class LinearReLUModule(torch.nn.Module):
         return self.relu(x)
 
 
-def test_relu_conversion():
-    input_shape = (10, 4, 32, 32)
-    edge_program = to_edge_program(ReLUModule(), input_shape).exported_program()
-
-    input_data = 2 * np.random.random(input_shape).astype(np.float32) - 1
-
-    convert_run_compare(edge_program, input_data=input_data)
-
-
-def test_relu_with_conv_quant_conversion(mocker, use_qat):
-    input_shape = (1, 4, 32, 32)
-    converter_spy = mocker.spy(EdgeProgramToIRConverter, "convert_program")
-
-    # Run conversion
-    delegated_ep = to_quantized_edge_program(
-        ConvReLUModule(),
-        input_shape,
-        use_qat=use_qat,
-        use_neutron_for_format_conversion=False,
-    ).exported_program()
-
-    # Capture generated model
-    tflite_flatbuffers_model, _ = converter_spy.spy_return
-
-    # Capture converted program
-    edge_program: ExportedProgram = converter_spy.call_args.args[1]
-
-    input_data = (
-        (2 * np.random.random(input_shape).astype(np.float32) - 1) * 50
-    ).astype(np.int8)
-
-    # Make sure the `relu` was delegated.
-    assert graph_contains_any_of_ops(delegated_ep.graph, [ExecutorchDelegateCall])
-    assert not graph_contains_any_of_ops(delegated_ep.graph, [ReLU])
-
-    convert_run_compare(
-        edge_program,
-        input_data,
-        tfl_model=tflite_flatbuffers_model,
-        tflite_input_preprocess=ToNHWCPreprocess(),
-        tflite_output_preprocess=ToNCHWPreprocess(),
+class TestReLUNewNeutronFlow:
+    @pytest.mark.parametrize(
+        ["model", "input_shape"],
+        [
+            pytest.param(
+                lambda: LinearReLUModule(in_features=9, out_features=17),
+                (9, 9),
+                id="Linear(1D-in): num_channels not divisible by NUM_MACS",
+            ),
+            pytest.param(
+                lambda: LinearReLUModule(in_features=9, out_features=15),
+                (1, 7, 9),
+                id="Linear(2D-in): num_channels not divisible by NUM_MACS",
+            ),
+            pytest.param(
+                lambda: LinearReLUModule(in_features=8, out_features=16),
+                (1, 8, 8),
+                id="Linear(2D-in): num_channels divisible by NUM_MACS",
+            ),
+            pytest.param(
+                lambda: LinearReLUModule(in_features=9, out_features=15),
+                (1, 9, 9, 9),
+                id="Linear(3D-in): num_channels not divisible by NUM_MACS",
+            ),
+            pytest.param(
+                lambda: ConvReLUModule(in_channels=17, out_channels=9),
+                (1, 17, 9, 9),
+                id="Conv: num_channels not divisible by NUM_MACS",
+            ),
+            pytest.param(
+                lambda: ConvReLUModule(in_channels=8, out_channels=16),
+                (1, 8, 8, 8),
+                id="Conv: num_channels divisible by NUM_MACS",
+            ),
+        ],
     )
+    def test_relu_conversion__full_pipeline(self, mocker, model, input_shape):
+        model = model()  # Avoid model creation at import time
+        is_conv_module = not hasattr(model, "linear")
 
+        graph_verifier = DetailedGraphVerifier(
+            mocker=mocker,
+            expected_delegated_ops=(
+                {Convolution: 1, Relu: 1} if is_conv_module else {AddMm: 1, Relu: 1}
+            ),
+            expected_non_delegated_ops={},
+            ops_to_ignore=[
+                PermuteCopy,
+                ViewCopy,
+                QuantizePerTensor,
+                DequantizePerTensor,
+                DequantizePerChannel,
+            ],
+        )
 
-def test_relu_with_linear_quant_conversion(mocker, use_qat):
-    input_shape = (256, 32)
-    converter_spy = mocker.spy(EdgeProgramToIRConverter, "convert_program")
+        lower_run_compare(
+            model,
+            input_shape,
+            graph_verifier,
+        )
 
-    # Run conversion
-    delegated_ep = to_quantized_edge_program(
-        LinearReLUModule(), input_shape, use_qat=use_qat
-    ).exported_program()
+    @pytest.mark.parametrize(
+        "input_shape",
+        [
+            pytest.param(
+                (3, 9, 9),
+                id="num_channels not divisible by NUM_MACS, alone in partition",
+            ),
+            pytest.param(
+                (1, 17, 17),
+                id="num_channels not divisible by NUM_MACS, alone in partition",
+            ),
+        ],
+    )
+    def test_relu_conversion__non_delegated_with_old_flow(self, mocker, input_shape):
+        verifier = DetailedGraphVerifier(
+            mocker=mocker,
+            expected_delegated_ops={Relu: 1},
+            expected_non_delegated_ops={},
+        )
 
-    # Capture generated model
-    tflite_flatbuffers_model, _ = converter_spy.spy_return
+        lower_run_compare(
+            ReLUModule(),
+            input_shape,
+            dlg_model_verifier=verifier,
+            dataset_creator=RandomDatasetCreator(low=-1, high=1),
+        )
 
-    # Capture converted program
-    edge_program: ExportedProgram = converter_spy.call_args.args[1]
+    @pytest.mark.parametrize(
+        "input_shape",
+        [
+            pytest.param(
+                (3, 9, 9),
+                id="num_channels not divisible by NUM_MACS, alone in partition",
+            ),
+            pytest.param(
+                (1, 17, 17),
+                id="num_channels not divisible by NUM_MACS, alone in partition",
+            ),
+        ],
+    )
+    def test_relu_conversion__no_delegated_node_when_noop(self, input_shape):
+        def generate_calibration_data(input_spec):
+            return [
+                # Generate inputs in range <0, 1> - ReLU degrades to identity
+                tuple([torch.rand(spec.shape, dtype=spec.dtype) for spec in input_spec])
+                for _ in range(4)
+            ]
 
-    input_data = (
-        (2 * np.random.random(input_shape).astype(np.float32) - 1) * 50
-    ).astype(np.int8)
+        # Run conversion
+        delegated_ep = to_quantized_edge_program(
+            ReLUModule(),
+            input_shape,
+            delegate_to_npu=True,
+            get_calibration_inputs_fn=generate_calibration_data,
+        ).exported_program()
 
-    # Make sure the `relu` was delegated.
-    assert graph_contains_any_of_ops(delegated_ep.graph, [ExecutorchDelegateCall])
-    assert not graph_contains_any_of_ops(delegated_ep.graph, [ReLU])
-
-    convert_run_compare(edge_program, input_data, tfl_model=tflite_flatbuffers_model)
-
-
-@pytest.mark.parametrize(
-    "input_shape",
-    [
-        pytest.param(
-            (3, 9, 7), id="num_channels not divisible by NUM_MACS, alone in partition"
-        ),
-    ],
-)
-def test_relu_conversion__unsupported(mocker, input_shape):
-    delegated_ep = to_quantized_edge_program(
-        ReLUModule(), input_shape
-    ).exported_program()
-
-    # Make sure the `relu` was NOT delegated.
-    assert not graph_contains_any_of_ops(delegated_ep.graph, [ExecutorchDelegateCall])
-    assert graph_contains_any_of_ops(delegated_ep.graph, [ReLU])
+        # Ensure identity ReLU was not delegated
+        assert graph_contains_any_of_ops(delegated_ep.graph, [ReLU])
+        assert not graph_contains_any_of_ops(
+            delegated_ep.graph, [ExecutorchDelegateCall]
+        )

--- a/backends/nxp/tests/models.py
+++ b/backends/nxp/tests/models.py
@@ -194,9 +194,9 @@ class ConvWithSigmoid(torch.nn.Module):
 
 
 class LinearModule(torch.nn.Module):
-    def __init__(self, bias: bool):
+    def __init__(self, bias: bool, in_features: int = 32, out_features: int = 16):
         super().__init__()
-        self.linear = torch.nn.Linear(32, 16, bias=bias)
+        self.linear = torch.nn.Linear(in_features, out_features, bias=bias)
 
     def forward(self, x):
         return self.linear(x)

--- a/backends/nxp/tests/ops_aliases.py
+++ b/backends/nxp/tests/ops_aliases.py
@@ -13,6 +13,7 @@ from executorch.exir.dialects._ops import ops as exir_ops
 
 Abs = exir_ops.edge.aten.abs.default
 AdaptiveAvgPool2D = exir_ops.edge.aten._adaptive_avg_pool2d.default
+AddMm = exir_ops.edge.aten.addmm.default
 AddTensor = exir_ops.edge.aten.add.Tensor
 AvgPool2D = exir_ops.edge.aten.avg_pool2d.default
 Bmm = exir_ops.edge.aten.bmm.default
@@ -29,6 +30,7 @@ LeakyRelu = exir_ops.edge.aten.leaky_relu.default
 MaxPool2DWithIndices = exir_ops.edge.aten.max_pool2d_with_indices.default
 MeanDim = exir_ops.edge.aten.mean.dim
 MulTensor = exir_ops.edge.aten.mul.Tensor
+PermuteCopy = exir_ops.edge.aten.permute_copy.default
 QuantizePerChannel = exir_ops.edge.quantized_decomposed.quantize_per_channel.default
 QuantizePerTensor = exir_ops.edge.quantized_decomposed.quantize_per_tensor.default
 Relu = exir_ops.edge.aten.relu.default


### PR DESCRIPTION
### Summary

Removes unnecessary checks for ReLU conversion when using new Neutron-C flow.

### Test plan
New unit test cases were added.


cc @digantdesai  @robert-kalmar @JakeStevens