### PR TITLE
[Docs] Fix python specifiers in tutorials

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -52,7 +52,7 @@ To build the documentation locally:
    Or a Conda environment:
 
    ```bash
-   conda create -yn executorch python=3.10.0 && conda activate executorch
+   conda create -yn executorch python=3.10 && conda activate executorch
    ```
 
 1. Install dependencies:

--- a/docs/source/raspberry_pi_llama_tutorial.md
+++ b/docs/source/raspberry_pi_llama_tutorial.md
@@ -65,7 +65,7 @@ cd executorch
 
 ```bash
 # Create conda environment
-conda create -yn executorch python=3.10.0
+conda create -yn executorch python=3.10
 conda activate executorch
 
 # Upgrade pip

--- a/docs/source/using-executorch-building-from-source.md
+++ b/docs/source/using-executorch-building-from-source.md
@@ -45,7 +45,7 @@ portability details.
    ```bash
    git clone -b viable/strict https://github.com/pytorch/executorch.git
    cd executorch
-   conda create -yn executorch python=3.10.0
+   conda create -yn executorch python=3.10
    conda activate executorch
    ```
 

--- a/examples/raspberry_pi/setup.sh
+++ b/examples/raspberry_pi/setup.sh
@@ -245,7 +245,7 @@ setup_environment() {
         # Check if conda is available
         if command -v conda &> /dev/null; then
             log_info "Creating conda environment..."
-            conda create -yn executorch python=3.10.0
+            conda create -yn executorch python=3.10
             eval "$(conda shell.bash hook)"
             conda activate executorch
             log_success "Created and activated conda environment: executorch"


### PR DESCRIPTION
Fixes #18073 (This issue was already fixed before this PR)

## Problem
The [setup tutorial](https://docs.pytorch.org/executorch/main/using-executorch-building-from-source.html) prescribes:

```bash
conda create -yn executorch python=3.10.0
```

This version has a CPython bug that leaves PyTorch's LeafSpec's init=False
fields uninitialized. run_decompositions() in ExecuTorch deepcopies the
LeafSpec nodes and crashes.
This breaks the export pipeline (`to_edge_transform_and_lower`, `to_edge`, `run_decompositions`),
which leads to any model export attempt failing unconditionally on Python 3.10.0.

> The error message (`AttributeError: 'LeafSpec' object has no attribute 'type'`)
> gives no indication that Python version is the cause, making it hard for tutorial followers to diagnose.

## Upstream Fix Status
The fix has already landed in PyTorch `main` via pytorch/pytorch#177154 and is available in recent nightly builds. 
However, ExecuTorch currently pins to `torch==2.11`.
The 2.11 branch was cut before the fix was merged, which means
the upstream fix does not apply until the ExecutTorch's torch pin is bumped to 2.12.
Until then, this PR is necessary to prevent tutorial followers from hitting the bug and getting lost.

## Resolution
The CI build script (`.ci/docker/build.sh`) uses:

```bash
PYTHON_VERSION=3.10
```

conda interprets `python=3.10` as a **prefix**, installing the latest available
3.10.x — currently 3.10.16 — which does not have this bug.
The CPython fix landed in 3.10.1.
This discrepancy (`3.10` vs `3.10.0`) makes the bug invisible to CI while affecting any user who follows the setup tutorial.

**Fix** python=3.10.0 -> python=3.10 to align the docs with CI.

## Test plan
**Not working**
```
conda create -yn executorch3100 python=3.10.0
conda activate executorch3100
```

**Working**
```
conda create -yn executorch310 python=3.10
conda activate executorch310
```

```python
import torch
from executorch.exir import to_edge_transform_and_lower
from executorch.backends.xnnpack.partition.xnnpack_partitioner import XnnpackPartitioner

class MyModel(torch.nn.Module):
    def forward(self, x):
        return x + 1

# 1. Export your PyTorch model
model = MyModel().eval()
example_inputs = (torch.randn(1, 3, 224, 224),)
exported_program = torch.export.export(model, example_inputs)

# 2. Optimize for target hardware (switch backends with one line)
program = to_edge_transform_and_lower(
    exported_program,
    partitioner=[XnnpackPartitioner()]  # CPU | CoreMLPartitioner() for iOS | QnnPartitioner() for Qualcomm
).to_executorch()
```

cc @mergennachin @AlannaBurke