### PR TITLE
Arm backend: Generate random op test inputs lazily

### DIFF
--- a/backends/arm/test/ops/test_addmm.py
+++ b/backends/arm/test/ops/test_addmm.py
@@ -28,73 +28,91 @@ input_t1 = Tuple[torch.Tensor, torch.Tensor, torch.Tensor]  # Input x1, x2, x3
 
 
 test_data_suite = {
-    "basic": [
+    "basic": lambda: [
         torch.tensor([[1.0, 2.0], [3.0, 4.0]]),
         torch.tensor([[1.0, 0.0], [0.0, 1.0]]),
         torch.tensor([[1.0, 2.0], [3.0, 4.0]]),
         1.0,
         1.0,
     ],
-    "zeros": [torch.zeros(2, 2), torch.zeros(2, 3), torch.zeros(3, 2), 1.0, 1.0],
-    "beta_only": [
+    "zeros": lambda: [
+        torch.zeros(2, 2),
+        torch.zeros(2, 3),
+        torch.zeros(3, 2),
+        1.0,
+        1.0,
+    ],
+    "beta_only": lambda: [
         torch.tensor([[10.0, 20.0], [30.0, 40.0]]),
         torch.randn(2, 3),
         torch.randn(3, 2),
         0.0,
         1.0,
     ],
-    "alpha_only": [
+    "alpha_only": lambda: [
         torch.tensor([[10.0, 20.0], [30.0, 40.0]]),
         torch.randn(2, 3),
         torch.randn(3, 2),
         1.0,
         0.0,
     ],
-    "scaled": [
+    "scaled": lambda: [
         torch.ones(2, 2),
         torch.tensor([[1.0, 2.0], [3.0, 4.0]]),
         torch.tensor([[5.0, 6.0], [7.0, 8.0]]),
         0.5,
         2.0,
     ],
-    "negative_scalars": [
+    "negative_scalars": lambda: [
         torch.tensor([[1.0, -1.0], [-1.0, 1.0]]),
         torch.tensor([[2.0, 0.0], [0.0, 2.0]]),
         torch.tensor([[1.0, 1.0], [1.0, 1.0]]),
         -1.0,
         -1.0,
     ],
-    "non_square": [torch.ones(3, 4), torch.rand(3, 2), torch.rand(2, 4), 1.0, 1.0],
-    "large_values": [
+    "non_square": lambda: [
+        torch.ones(3, 4),
+        torch.rand(3, 2),
+        torch.rand(2, 4),
+        1.0,
+        1.0,
+    ],
+    "large_values": lambda: [
         torch.full((2, 2), 1e6),
         torch.full((2, 3), 1e3),
         torch.full((3, 2), 1e3),
         1.0,
         1.0,
     ],
-    "small_values": [
+    "small_values": lambda: [
         torch.full((2, 2), 1e-6),
         torch.full((2, 3), 1e-3),
         torch.full((3, 2), 1e-3),
         1.0,
         1.0,
     ],
-    "random": [torch.randn(4, 5), torch.randn(4, 3), torch.randn(3, 5), 1.0, 1.0],
-    "broadcast_bias_row": [
+    "random": lambda: [
+        torch.randn(4, 5),
+        torch.randn(4, 3),
+        torch.randn(3, 5),
+        1.0,
+        1.0,
+    ],
+    "broadcast_bias_row": lambda: [
         torch.randn(1, 2),
         torch.randn(3, 4),
         torch.randn(4, 2),
         1.0,
         1.0,
     ],
-    "row_bias": [
+    "row_bias": lambda: [
         torch.randn(3, 1),
         torch.randn(3, 4),
         torch.randn(4, 4),
         1.0,
         1.0,
     ],
-    "scalar_bias": [
+    "scalar_bias": lambda: [
         torch.tensor(2.0),
         torch.randn(5, 3),
         torch.randn(3, 6),
@@ -120,7 +138,7 @@ class Addmm(torch.nn.Module):
 def test_addmm_tosa_FP(test_data: Tuple):
     pipeline = TosaPipelineFP[input_t1](
         Addmm(),
-        (*test_data,),
+        (*test_data(),),
         aten_op=aten_op,
         exir_op=exir_op,
     )
@@ -131,7 +149,7 @@ def test_addmm_tosa_FP(test_data: Tuple):
 def test_addmm_tosa_INT(test_data: Tuple):
     pipeline = TosaPipelineINT[input_t1](
         Addmm(),
-        (*test_data,),
+        (*test_data(),),
         aten_op=[],
         exir_op=exir_op,
     )
@@ -143,7 +161,7 @@ def test_addmm_tosa_INT(test_data: Tuple):
 def test_addmm_u55_INT(test_data: Tuple):
     pipeline = EthosU55PipelineINT[input_t1](
         Addmm(),
-        (*test_data,),
+        (*test_data(),),
         aten_ops=[],
         exir_ops=exir_op,
     )
@@ -155,7 +173,7 @@ def test_addmm_u55_INT(test_data: Tuple):
 def test_addmm_u85_INT(test_data: Tuple):
     pipeline = EthosU85PipelineINT[input_t1](
         Addmm(),
-        (*test_data,),
+        (*test_data(),),
         aten_ops=[],
         exir_ops=exir_op,
     )
@@ -167,7 +185,7 @@ def test_addmm_u85_INT(test_data: Tuple):
 def test_addmm_vgf_no_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         Addmm(),
-        (*test_data,),
+        (*test_data(),),
         aten_op=aten_op,
         exir_op=exir_op,
         quantize=False,
@@ -180,7 +198,7 @@ def test_addmm_vgf_no_quant(test_data: input_t1):
 def test_addmm_vgf_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         Addmm(),
-        (*test_data,),
+        (*test_data(),),
         aten_op=[],
         exir_op=exir_op,
         quantize=True,
@@ -197,7 +215,7 @@ def test_addmm_16a8w_tosa_INT(test_data: input_t1):
 
     pipeline = TosaPipelineINT[input_t1](
         Addmm(),
-        (*test_data,),
+        (*test_data(),),
         aten_op=[],
         exir_op=[],
         per_channel_quantization=per_channel_quantization,
@@ -223,7 +241,7 @@ def test_addmm_16a8w_u55_INT(test_data: input_t1):
 
     pipeline = EthosU55PipelineINT[input_t1](
         Addmm(),
-        (*test_data,),
+        (*test_data(),),
         aten_ops=[],
         exir_ops=[],
         per_channel_quantization=per_channel_quantization,
@@ -245,7 +263,7 @@ def test_addmm_16a8w_u85_INT(test_data: input_t1):
 
     pipeline = EthosU85PipelineINT[input_t1](
         Addmm(),
-        (*test_data,),
+        (*test_data(),),
         aten_ops=[],
         exir_ops=[],
         per_channel_quantization=per_channel_quantization,

--- a/backends/arm/test/ops/test_atan.py
+++ b/backends/arm/test/ops/test_atan.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -22,14 +22,14 @@ exir_op = "executorch_exir_dialects_edge__ops_aten__atan_default"
 input_t1 = Tuple[torch.Tensor]
 
 test_data_suite = {
-    "zeros": torch.zeros(1, 10, 10, 10),
-    "zeros_alt_shape": torch.zeros(1, 10, 3, 5),
-    "ones": torch.ones(10, 10, 10),
-    "rand": torch.rand(10, 10) - 0.5,
-    "rand_alt_shape": torch.rand(1, 10, 3, 5) - 0.5,
-    "randn_pos": torch.randn(10) + 10,
-    "randn_neg": torch.randn(10) - 10,
-    "ramp": torch.arange(-16, 16, 0.2),
+    "zeros": lambda: torch.zeros(1, 10, 10, 10),
+    "zeros_alt_shape": lambda: torch.zeros(1, 10, 3, 5),
+    "ones": lambda: torch.ones(10, 10, 10),
+    "rand": lambda: torch.rand(10, 10) - 0.5,
+    "rand_alt_shape": lambda: torch.rand(1, 10, 3, 5) - 0.5,
+    "randn_pos": lambda: torch.randn(10) + 10,
+    "randn_neg": lambda: torch.randn(10) - 10,
+    "ramp": lambda: torch.arange(-16, 16, 0.2),
 }
 
 
@@ -43,7 +43,7 @@ class Atan(torch.nn.Module):
 def test_atan_tosa_FP(test_data: Tuple):
     pipeline = TosaPipelineFP[input_t1](
         Atan(),
-        (test_data,),
+        (test_data(),),
         aten_op=aten_op,
         exir_op=exir_op,
     )
@@ -54,7 +54,7 @@ def test_atan_tosa_FP(test_data: Tuple):
 def test_atan_tosa_INT(test_data: Tuple):
     pipeline = TosaPipelineINT[input_t1](
         Atan(),
-        (test_data,),
+        (test_data(),),
         aten_op=aten_op,
         exir_op=exir_op,
     )
@@ -66,7 +66,7 @@ def test_atan_tosa_INT(test_data: Tuple):
 def test_atan_u55_INT(test_data: Tuple):
     pipeline = EthosU55PipelineINT[input_t1](
         Atan(),
-        (test_data,),
+        (test_data(),),
         aten_ops=aten_op,
         exir_ops=exir_op,
     )
@@ -78,7 +78,7 @@ def test_atan_u55_INT(test_data: Tuple):
 def test_atan_u85_INT(test_data: Tuple):
     pipeline = EthosU85PipelineINT[input_t1](
         Atan(),
-        (test_data,),
+        (test_data(),),
         aten_ops=aten_op,
         exir_ops=exir_op,
     )
@@ -90,7 +90,7 @@ def test_atan_u85_INT(test_data: Tuple):
 def test_atan_vgf_no_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         Atan(),
-        (test_data,),
+        (test_data(),),
         aten_op,
         exir_op,
         quantize=False,
@@ -103,7 +103,7 @@ def test_atan_vgf_no_quant(test_data: Tuple):
 def test_atan_vgf_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         Atan(),
-        (test_data,),
+        (test_data(),),
         aten_op,
         exir_op,
         quantize=True,

--- a/backends/arm/test/ops/test_atanh.py
+++ b/backends/arm/test/ops/test_atanh.py
@@ -24,13 +24,13 @@ input_t1 = Tuple[torch.Tensor]
 
 
 test_data_suite = {
-    "zeros": torch.zeros(1, 10, 10, 10),
-    "zeros_alt_shape": torch.zeros(1, 10, 3, 5),
-    "rand": torch.rand(10, 10) - 0.5,
-    "rand_alt_shape": torch.rand(1, 10, 3, 5) - 0.5,
-    "ramp": torch.arange(-1, 1, 0.2),
-    "near_bounds": torch.tensor([-0.99, -0.9, 0.9, 0.99]),
-    "on_bounds": torch.tensor([-1.0, 1.0]),
+    "zeros": lambda: torch.zeros(1, 10, 10, 10),
+    "zeros_alt_shape": lambda: torch.zeros(1, 10, 3, 5),
+    "rand": lambda: torch.rand(10, 10) - 0.5,
+    "rand_alt_shape": lambda: torch.rand(1, 10, 3, 5) - 0.5,
+    "ramp": lambda: torch.arange(-1, 1, 0.2),
+    "near_bounds": lambda: torch.tensor([-0.99, -0.9, 0.9, 0.99]),
+    "on_bounds": lambda: torch.tensor([-1.0, 1.0]),
 }
 
 
@@ -43,7 +43,7 @@ class Atanh(torch.nn.Module):
 def test_atanh_tosa_FP(test_data: Tuple):
     pipeline = TosaPipelineFP[input_t1](
         Atanh(),
-        (test_data,),
+        (test_data(),),
         aten_op=aten_op,
         exir_op=exir_op,
     )
@@ -52,13 +52,14 @@ def test_atanh_tosa_FP(test_data: Tuple):
 
 @common.parametrize("test_data", test_data_suite)
 def test_atanh_tosa_INT(test_data: Tuple):
+    input_data = test_data()
     pipeline = TosaPipelineINT[input_t1](
         Atanh(),
-        (test_data,),
+        (input_data,),
         aten_op=aten_op,
         exir_op=exir_op,
     )
-    if torch.any(test_data >= 1) or torch.any(test_data <= -1):
+    if torch.any(input_data >= 1) or torch.any(input_data <= -1):
         # The quantized model will saturate to max/min values while the
         # original model will return inf/-inf, so comparison wont be valid here.
         pipeline.pop_stage("run_method_and_compare_outputs.original_model")
@@ -70,7 +71,7 @@ def test_atanh_tosa_INT(test_data: Tuple):
 def test_atanh_u55_INT(test_data: Tuple):
     pipeline = EthosU55PipelineINT[input_t1](
         Atanh(),
-        (test_data,),
+        (test_data(),),
         aten_ops=aten_op,
         exir_ops=exir_op,
     )
@@ -82,7 +83,7 @@ def test_atanh_u55_INT(test_data: Tuple):
 def test_atanh_u85_INT(test_data: Tuple):
     pipeline = EthosU85PipelineINT[input_t1](
         Atanh(),
-        (test_data,),
+        (test_data(),),
         aten_ops=aten_op,
         exir_ops=exir_op,
     )
@@ -94,7 +95,7 @@ def test_atanh_u85_INT(test_data: Tuple):
 def test_atanh_vgf_no_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         Atanh(),
-        (test_data,),
+        (test_data(),),
         aten_op=aten_op,
         exir_op=exir_op,
         quantize=False,
@@ -107,7 +108,7 @@ def test_atanh_vgf_no_quant(test_data: input_t1):
 def test_atanh_vgf_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         Atanh(),
-        (test_data,),
+        (test_data(),),
         aten_op=aten_op,
         exir_op=exir_op,
         quantize=True,

--- a/backends/arm/test/ops/test_bitwise_not.py
+++ b/backends/arm/test/ops/test_bitwise_not.py
@@ -22,20 +22,20 @@ exir_op = "executorch_exir_dialects_edge__ops_aten_bitwise_not_default"
 input_t1 = Tuple[torch.Tensor]
 
 test_data_suite_non_bool = {
-    "zeros": torch.zeros(1, 10, 10, 10, dtype=torch.int32),
-    "ones": torch.ones(10, 2, 3, dtype=torch.int8),
-    "pattern1_int8": 0xAA * torch.ones(1, 2, 2, 2, dtype=torch.int8),
-    "pattern1_int16": 0xAAAA * torch.ones(1, 2, 2, 2, dtype=torch.int16),
-    "pattern1_int32": 0xAAAAAAAA * torch.ones(1, 2, 2, 2, dtype=torch.int32),
-    "pattern2_int8": 0xCC * torch.ones(1, 2, 2, 2, dtype=torch.int8),
-    "pattern2_int16": 0xCCCC * torch.ones(1, 2, 2, 2, dtype=torch.int16),
-    "pattern2_int32": 0xCCCCCCCC * torch.ones(1, 2, 2, 2, dtype=torch.int32),
-    "rand_rank2": torch.randint(-128, 127, (10, 10), dtype=torch.int8),
-    "rand_rank4": torch.randint(-128, 127, (1, 10, 10, 10), dtype=torch.int8),
+    "zeros": lambda: torch.zeros(1, 10, 10, 10, dtype=torch.int32),
+    "ones": lambda: torch.ones(10, 2, 3, dtype=torch.int8),
+    "pattern1_int8": lambda: 0xAA * torch.ones(1, 2, 2, 2, dtype=torch.int8),
+    "pattern1_int16": lambda: 0xAAAA * torch.ones(1, 2, 2, 2, dtype=torch.int16),
+    "pattern1_int32": lambda: 0xAAAAAAAA * torch.ones(1, 2, 2, 2, dtype=torch.int32),
+    "pattern2_int8": lambda: 0xCC * torch.ones(1, 2, 2, 2, dtype=torch.int8),
+    "pattern2_int16": lambda: 0xCCCC * torch.ones(1, 2, 2, 2, dtype=torch.int16),
+    "pattern2_int32": lambda: 0xCCCCCCCC * torch.ones(1, 2, 2, 2, dtype=torch.int32),
+    "rand_rank2": lambda: torch.randint(-128, 127, (10, 10), dtype=torch.int8),
+    "rand_rank4": lambda: torch.randint(-128, 127, (1, 10, 10, 10), dtype=torch.int8),
 }
 
 test_data_suite_bool = {
-    "pattern_bool": torch.tensor([True, False, True], dtype=torch.bool),
+    "pattern_bool": lambda: torch.tensor([True, False, True], dtype=torch.bool),
 }
 
 test_data_suite = {**test_data_suite_non_bool, **test_data_suite_bool}
@@ -52,7 +52,7 @@ def test_bitwise_not_tosa_FP(test_data: Tuple):
     # We don't delegate bitwise_not since it is not supported on the FP profile.
     pipeline = OpNotSupportedPipeline[input_t1](
         BitwiseNot(),
-        (test_data,),
+        (test_data(),),
         {exir_op: 1},
         quantize=False,
     )
@@ -63,7 +63,7 @@ def test_bitwise_not_tosa_FP(test_data: Tuple):
 def test_bitwise_not_tosa_FP_bool(test_data: Tuple):
     pipeline = TosaPipelineFP[input_t1](
         BitwiseNot(),
-        (test_data,),
+        (test_data(),),
         aten_op,
         "executorch_exir_dialects_edge__ops_aten_logical_not_default",
         atol=0,
@@ -77,7 +77,7 @@ def test_bitwise_not_tosa_FP_bool(test_data: Tuple):
 def test_bitwise_not_tosa_INT(test_data: Tuple):
     pipeline = TosaPipelineINT[input_t1](
         BitwiseNot(),
-        (test_data,),
+        (test_data(),),
         aten_op=aten_op,
         exir_op=exir_op,
     )
@@ -89,7 +89,7 @@ def test_bitwise_not_u55_INT(test_data: Tuple):
     # We don't delegate bitwise_not since it is not supported on U55.
     pipeline = OpNotSupportedPipeline[input_t1](
         BitwiseNot(),
-        (test_data,),
+        (test_data(),),
         {exir_op: 1},
         quantize=True,
         u55_subset=True,
@@ -102,7 +102,7 @@ def test_bitwise_not_u55_INT(test_data: Tuple):
 def test_bitwise_not_u85_INT(test_data: Tuple):
     pipeline = EthosU85PipelineINT[input_t1](
         BitwiseNot(),
-        (test_data,),
+        (test_data(),),
         aten_ops=aten_op,
         exir_ops=exir_op,
     )
@@ -114,7 +114,7 @@ def test_bitwise_not_u85_INT(test_data: Tuple):
 def test_bitwise_not_vgf_no_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         BitwiseNot(),
-        (test_data,),
+        (test_data(),),
         aten_op,
         exir_op,
         quantize=False,
@@ -127,7 +127,7 @@ def test_bitwise_not_vgf_no_quant(test_data: Tuple):
 def test_bitwise_not_vgf_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         BitwiseNot(),
-        (test_data,),
+        (test_data(),),
         aten_op,
         exir_op,
         quantize=True,

--- a/backends/arm/test/ops/test_conv_constant_pad_nd.py
+++ b/backends/arm/test/ops/test_conv_constant_pad_nd.py
@@ -25,15 +25,31 @@ exir_op = "executorch_exir_dialects_edge__ops_aten_pad_default"
 input_t1 = Tuple[torch.Tensor]  # Input x
 
 test_data_suite = {
-    "4dim_last1dim": (torch.rand(1, 1, 16, 16), (1, 1, 0, 0, 0, 0, 0, 0), 1),
-    "4dim_last2dim": (torch.rand(1, 1, 16, 16), (1, 0, 1, 0, 0, 0, 0, 0), 2),
-    "4dim_last3dim": (torch.rand(1, 1, 16, 16), (1, 1, 0, 2, 0, 2, 0, 0), 3),
-    "4dim_last4dim": (torch.rand(1, 1, 16, 16), (1, 0, 1, 1, 0, 2, 0, 2), 4),
-    "3dim_last1dim": (torch.rand(1, 1, 16), (1, 1, 0, 0, 0, 0), 1),
-    "3dim_last2dim": (torch.rand(1, 1, 16), (1, 0, 1, 1, 0, 0), 2),
-    "3dim_last3dim": (torch.rand(1, 1, 16), (1, 0, 1, 0, 1, 1), 3),
-    "2dim_last1dim": (torch.rand(1, 1, 16), (1, 1, 0, 0), 1),
-    "2dim_last2dim": (torch.rand(1, 1, 16), (1, 0, 1, 1), 2),
+    "4dim_last1dim": lambda: (
+        torch.rand(1, 1, 16, 16),
+        (1, 1, 0, 0, 0, 0, 0, 0),
+        1,
+    ),
+    "4dim_last2dim": lambda: (
+        torch.rand(1, 1, 16, 16),
+        (1, 0, 1, 0, 0, 0, 0, 0),
+        2,
+    ),
+    "4dim_last3dim": lambda: (
+        torch.rand(1, 1, 16, 16),
+        (1, 1, 0, 2, 0, 2, 0, 0),
+        3,
+    ),
+    "4dim_last4dim": lambda: (
+        torch.rand(1, 1, 16, 16),
+        (1, 0, 1, 1, 0, 2, 0, 2),
+        4,
+    ),
+    "3dim_last1dim": lambda: (torch.rand(1, 1, 16), (1, 1, 0, 0, 0, 0), 1),
+    "3dim_last2dim": lambda: (torch.rand(1, 1, 16), (1, 0, 1, 1, 0, 0), 2),
+    "3dim_last3dim": lambda: (torch.rand(1, 1, 16), (1, 0, 1, 0, 1, 1), 3),
+    "2dim_last1dim": lambda: (torch.rand(1, 1, 16), (1, 1, 0, 0), 1),
+    "2dim_last2dim": lambda: (torch.rand(1, 1, 16), (1, 0, 1, 1), 2),
 }
 """Tests conv + pad."""
 
@@ -91,7 +107,7 @@ class ConstantPadND(torch.nn.Module):
 
 @common.parametrize("test_data", test_data_suite)
 def test_constant_pad_nd_tosa_FP(test_data: Tuple):
-    test_data, padding, value = test_data
+    test_data, padding, value = test_data()
     pipeline = TosaPipelineFP[input_t1](
         ConstantPadND(padding, value),
         (test_data,),
@@ -103,7 +119,7 @@ def test_constant_pad_nd_tosa_FP(test_data: Tuple):
 
 @common.parametrize("test_data", test_data_suite)
 def test_constant_pad_nd_tosa_INT(test_data: Tuple):
-    test_data, padding, value = test_data
+    test_data, padding, value = test_data()
     pipeline = TosaPipelineINT[input_t1](
         ConstantPadND(padding, value),
         (test_data,),
@@ -118,7 +134,7 @@ def test_constant_pad_nd_tosa_INT(test_data: Tuple):
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
 def test_constant_pad_nd_vgf_no_quant(test_data: Tuple):
-    test_data, padding, value = test_data
+    test_data, padding, value = test_data()
     pipeline = VgfPipeline[input_t1](
         ConstantPadND(padding, value),
         (test_data,),
@@ -132,7 +148,7 @@ def test_constant_pad_nd_vgf_no_quant(test_data: Tuple):
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
 def test_constant_pad_nd_vgf_quant(test_data: Tuple):
-    test_data, padding, value = test_data
+    test_data, padding, value = test_data()
     pipeline = VgfPipeline[input_t1](
         ConstantPadND(padding, value),
         (test_data,),

--- a/backends/arm/test/ops/test_cos.py
+++ b/backends/arm/test/ops/test_cos.py
@@ -23,21 +23,21 @@ input_t1 = Tuple[torch.Tensor]  # Input x
 
 test_data_suite = {
     # (test_name, test_data)
-    "zeros": torch.zeros(10, 10, 10, 10),
-    "ones": torch.ones(10, 10, 10),
-    "rand": torch.rand(10, 10) - 0.5,
-    "randn_pos": torch.randn(10) + 10,
-    "randn_neg": torch.randn(10) - 10,
-    "ramp": torch.arange(-16, 16, 0.2),
+    "zeros": lambda: torch.zeros(10, 10, 10, 10),
+    "ones": lambda: torch.ones(10, 10, 10),
+    "rand": lambda: torch.rand(10, 10) - 0.5,
+    "randn_pos": lambda: torch.randn(10) + 10,
+    "randn_neg": lambda: torch.randn(10) - 10,
+    "ramp": lambda: torch.arange(-16, 16, 0.2),
 }
 
 test_data_suite_bf16 = {
-    "rand_bf16": torch.rand(4, 4, dtype=torch.bfloat16) - 0.5,
-    "ramp_bf16": torch.arange(-8, 8, 0.5, dtype=torch.bfloat16),
+    "rand_bf16": lambda: torch.rand(4, 4, dtype=torch.bfloat16) - 0.5,
+    "ramp_bf16": lambda: torch.arange(-8, 8, 0.5, dtype=torch.bfloat16),
 }
 test_data_suite_fp16 = {
-    "rand_fp16": torch.rand(4, 4, dtype=torch.float16) - 0.5,
-    "ramp_fp16": torch.arange(-8, 8, 0.5, dtype=torch.float16),
+    "rand_fp16": lambda: torch.rand(4, 4, dtype=torch.float16) - 0.5,
+    "ramp_fp16": lambda: torch.arange(-8, 8, 0.5, dtype=torch.float16),
 }
 
 
@@ -54,7 +54,7 @@ class Cos(torch.nn.Module):
 def test_cos_tosa_FP(test_data: Tuple):
     pipeline = TosaPipelineFP[input_t1](
         Cos(),
-        (test_data,),
+        (test_data(),),
         aten_op,
         exir_op=[],
         tosa_extensions=["bf16"],
@@ -67,7 +67,7 @@ def test_cos_tosa_FP(test_data: Tuple):
 def test_cos_tosa_INT(test_data: Tuple):
     pipeline = TosaPipelineINT[input_t1](
         Cos(),
-        (test_data,),
+        (test_data(),),
         aten_op,
         exir_op=[],
     )
@@ -79,7 +79,7 @@ def test_cos_tosa_INT(test_data: Tuple):
 def test_cos_u55_INT(test_data: Tuple):
     pipeline = EthosU55PipelineINT[input_t1](
         Cos(),
-        (test_data,),
+        (test_data(),),
         aten_op,
         exir_ops=[],
     )
@@ -91,7 +91,7 @@ def test_cos_u55_INT(test_data: Tuple):
 def test_cos_u85_INT(test_data: Tuple):
     pipeline = EthosU85PipelineINT[input_t1](
         Cos(),
-        (test_data,),
+        (test_data(),),
         aten_op,
         exir_ops=[],
     )
@@ -103,7 +103,7 @@ def test_cos_u85_INT(test_data: Tuple):
 def test_cos_vgf_no_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         Cos(),
-        (test_data,),
+        (test_data(),),
         aten_op,
         exir_op=[],
         quantize=False,
@@ -116,7 +116,7 @@ def test_cos_vgf_no_quant(test_data: Tuple):
 def test_cos_vgf_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         Cos(),
-        (test_data,),
+        (test_data(),),
         aten_op,
         exir_op=[],
         quantize=True,

--- a/backends/arm/test/ops/test_cosh.py
+++ b/backends/arm/test/ops/test_cosh.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -21,21 +21,21 @@ input_t1 = Tuple[torch.Tensor]  # Input x
 
 test_data_suite = {
     # (test_name, test_data)
-    "zeros": torch.zeros(10, 10, 10),
-    "zeros_4D": torch.zeros(1, 10, 32, 7),
-    "zeros_alt_shape": torch.zeros(10, 3, 5),
-    "ones": torch.ones(15, 10, 7),
-    "ones_4D": torch.ones(1, 3, 32, 16),
-    "rand": torch.rand(10, 10) - 0.5,
-    "rand_alt_shape": torch.rand(10, 3, 5) - 0.5,
-    "rand_4D": torch.rand(1, 6, 5, 7) - 0.5,
-    "randn_pos": torch.randn(10) + 3,
-    "randn_neg": torch.randn(10) - 3,
-    "ramp": torch.arange(-16, 16, 0.2),
-    "large": 100 * torch.ones(1, 1),
-    "small": 0.000001 * torch.ones(1, 1),
-    "small_rand": torch.rand(100) * 0.01,
-    "biggest": torch.tensor([700.0, 710.0, 750.0]),
+    "zeros": lambda: torch.zeros(10, 10, 10),
+    "zeros_4D": lambda: torch.zeros(1, 10, 32, 7),
+    "zeros_alt_shape": lambda: torch.zeros(10, 3, 5),
+    "ones": lambda: torch.ones(15, 10, 7),
+    "ones_4D": lambda: torch.ones(1, 3, 32, 16),
+    "rand": lambda: torch.rand(10, 10) - 0.5,
+    "rand_alt_shape": lambda: torch.rand(10, 3, 5) - 0.5,
+    "rand_4D": lambda: torch.rand(1, 6, 5, 7) - 0.5,
+    "randn_pos": lambda: torch.randn(10) + 3,
+    "randn_neg": lambda: torch.randn(10) - 3,
+    "ramp": lambda: torch.arange(-16, 16, 0.2),
+    "large": lambda: 100 * torch.ones(1, 1),
+    "small": lambda: 0.000001 * torch.ones(1, 1),
+    "small_rand": lambda: torch.rand(100) * 0.01,
+    "biggest": lambda: torch.tensor([700.0, 710.0, 750.0]),
 }
 
 
@@ -48,7 +48,7 @@ class Cosh(torch.nn.Module):
 def test_cosh_tosa_FP(test_data: Tuple):
     pipeline = TosaPipelineFP[input_t1](
         Cosh(),
-        (test_data,),
+        (test_data(),),
         aten_op,
         exir_op,
     )
@@ -58,7 +58,7 @@ def test_cosh_tosa_FP(test_data: Tuple):
 @common.parametrize("test_data", test_data_suite)
 def test_cosh_tosa_INT(test_data: Tuple):
     pipeline = TosaPipelineINT[input_t1](
-        Cosh(), (test_data,), aten_op=aten_op, exir_op=exir_op
+        Cosh(), (test_data(),), aten_op=aten_op, exir_op=exir_op
     )
     pipeline.run()
 
@@ -67,7 +67,7 @@ def test_cosh_tosa_INT(test_data: Tuple):
 @common.parametrize("test_data", test_data_suite)
 def test_cosh_u55_INT(test_data: Tuple):
     pipeline = EthosU55PipelineINT[input_t1](
-        Cosh(), (test_data,), aten_ops=aten_op, exir_ops=exir_op
+        Cosh(), (test_data(),), aten_ops=aten_op, exir_ops=exir_op
     )
     pipeline.run()
 
@@ -80,7 +80,7 @@ def test_cosh_u55_INT(test_data: Tuple):
 )
 def test_cosh_u85_INT(test_data: Tuple):
     pipeline = EthosU85PipelineINT[input_t1](
-        Cosh(), (test_data,), aten_ops=aten_op, exir_ops=exir_op
+        Cosh(), (test_data(),), aten_ops=aten_op, exir_ops=exir_op
     )
     pipeline.run()
 
@@ -90,7 +90,7 @@ def test_cosh_u85_INT(test_data: Tuple):
 def test_cosh_vgf_no_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         Cosh(),
-        (test_data,),
+        (test_data(),),
         [],
         [],
         quantize=False,
@@ -103,7 +103,7 @@ def test_cosh_vgf_no_quant(test_data: Tuple):
 def test_cosh_vgf_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         Cosh(),
-        (test_data,),
+        (test_data(),),
         [],
         [],
         quantize=True,

--- a/backends/arm/test/ops/test_detach_copy.py
+++ b/backends/arm/test/ops/test_detach_copy.py
@@ -19,10 +19,10 @@ aten_op = "torch.ops.aten.detach_copy.default"
 exir_op = "executorch_exir_dialects_edge__ops_aten__detach_copy_default"
 
 test_data_suite = {
-    "zeros_2d": torch.zeros(3, 5),
-    "ones_3d": torch.ones(2, 3, 4),
-    "rand_2d": torch.rand(10, 10) - 0.5,
-    "ramp_1d": torch.arange(-8.0, 8.0, 0.5),
+    "zeros_2d": lambda: torch.zeros(3, 5),
+    "ones_3d": lambda: torch.ones(2, 3, 4),
+    "rand_2d": lambda: torch.rand(10, 10) - 0.5,
+    "ramp_1d": lambda: torch.arange(-8.0, 8.0, 0.5),
 }
 
 
@@ -38,7 +38,7 @@ class DetachCopy(torch.nn.Module):
 def test_detach_tosa_FP(test_data: torch.Tensor):
     pipeline = TosaPipelineFP[input_t1](
         DetachCopy(),
-        (test_data,),
+        (test_data(),),
         aten_op=DetachCopy.aten_op,
         exir_op=DetachCopy.exir_op,
     )
@@ -49,7 +49,7 @@ def test_detach_tosa_FP(test_data: torch.Tensor):
 def test_detach_tosa_INT(test_data: torch.Tensor):
     pipeline = TosaPipelineINT[input_t1](
         DetachCopy(),
-        (test_data,),
+        (test_data(),),
         aten_op=DetachCopy.aten_op,
         exir_op=DetachCopy.exir_op,
     )

--- a/backends/arm/test/ops/test_erfinv.py
+++ b/backends/arm/test/ops/test_erfinv.py
@@ -22,26 +22,26 @@ exir_op = "executorch_exir_dialects_edge__ops_aten_erfinv_default"
 input_t1 = Tuple[torch.Tensor]
 
 test_data_suite = {
-    "zeros": torch.zeros(1, 10, 10, 10),
-    "small": torch.randn(100) * 0.01,
-    "mid": torch.rand(10, 10) * 1.8 - 0.9,
-    "near_pos_bound": torch.full((32,), 0.99),
-    "near_neg_bound": torch.full((32,), -0.99),
-    "pos_one": torch.full((32,), 1.0),
-    "neg_one": torch.full((32,), -1.0),
-    "ramp": torch.arange(-0.99, 0.99, 0.02),
+    "zeros": lambda: torch.zeros(1, 10, 10, 10),
+    "small": lambda: torch.randn(100) * 0.01,
+    "mid": lambda: torch.rand(10, 10) * 1.8 - 0.9,
+    "near_pos_bound": lambda: torch.full((32,), 0.99),
+    "near_neg_bound": lambda: torch.full((32,), -0.99),
+    "pos_one": lambda: torch.full((32,), 1.0),
+    "neg_one": lambda: torch.full((32,), -1.0),
+    "ramp": lambda: torch.arange(-0.99, 0.99, 0.02),
 }
 
 
 test_data_nan_outputs = {
-    "pos_two": torch.full((32,), 2.0),
-    "neg_two": torch.full((32,), -2.0),
+    "pos_two": lambda: torch.full((32,), 2.0),
+    "neg_two": lambda: torch.full((32,), -2.0),
 }
 
 
 test_data_fp16 = {
-    "rand_fp16": (torch.rand(8, 8, dtype=torch.float16) * 1.8 - 0.9),
-    "ramp_fp16": torch.arange(-0.9, 0.9, 0.1, dtype=torch.float16),
+    "rand_fp16": lambda: (torch.rand(8, 8, dtype=torch.float16) * 1.8 - 0.9),
+    "ramp_fp16": lambda: torch.arange(-0.9, 0.9, 0.1, dtype=torch.float16),
 }
 
 
@@ -56,7 +56,7 @@ class Erfinv(torch.nn.Module):
 def test_erfinv_tosa_FP(test_data: torch.Tensor):
     pipeline = TosaPipelineFP[input_t1](
         Erfinv(),
-        (test_data,),
+        (test_data(),),
         aten_op,
         exir_op,
     )
@@ -65,7 +65,7 @@ def test_erfinv_tosa_FP(test_data: torch.Tensor):
 
 @common.parametrize("test_data", test_data_suite)
 def test_erfinv_tosa_INT(test_data: torch.Tensor):
-    pipeline = TosaPipelineINT[input_t1](Erfinv(), (test_data,), aten_op, exir_op)
+    pipeline = TosaPipelineINT[input_t1](Erfinv(), (test_data(),), aten_op, exir_op)
     pipeline.run()
 
 
@@ -74,7 +74,7 @@ def test_erfinv_tosa_INT(test_data: torch.Tensor):
 def test_erfinv_u55_INT(test_data: torch.Tensor):
     pipeline = EthosU55PipelineINT[input_t1](
         Erfinv(),
-        (test_data,),
+        (test_data(),),
         aten_ops=aten_op,
         exir_ops=exir_op,
     )
@@ -86,7 +86,7 @@ def test_erfinv_u55_INT(test_data: torch.Tensor):
 def test_erfinv_u85_INT(test_data: torch.Tensor):
     pipeline = EthosU85PipelineINT[input_t1](
         Erfinv(),
-        (test_data,),
+        (test_data(),),
         aten_ops=aten_op,
         exir_ops=exir_op,
     )
@@ -100,7 +100,7 @@ def test_erfinv_u85_INT(test_data: torch.Tensor):
 def test_erfinv_vgf_no_quant(test_data: torch.Tensor):
     pipeline = VgfPipeline[input_t1](
         Erfinv(),
-        (test_data,),
+        (test_data(),),
         aten_op,
         exir_op,
         quantize=False,
@@ -113,7 +113,7 @@ def test_erfinv_vgf_no_quant(test_data: torch.Tensor):
 def test_erfinv_vgf_quant(test_data: torch.Tensor):
     pipeline = VgfPipeline[input_t1](
         Erfinv(),
-        (test_data,),
+        (test_data(),),
         aten_op,
         exir_op,
         quantize=True,

--- a/backends/arm/test/ops/test_expm1.py
+++ b/backends/arm/test/ops/test_expm1.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -22,16 +22,16 @@ exir_op = "executorch_exir_dialects_edge__ops_aten_expm1_default"
 input_t1 = Tuple[torch.Tensor]
 
 test_data_suite = {
-    "zeroes": torch.zeros(1, 10, 10, 10),
-    "ones": torch.ones(10, 2, 3),
-    "rand": torch.rand(10, 10) - 0.5,
-    "near_zero": torch.randn(100) * 0.01,
-    "taylor_small": torch.empty(5).uniform_(
+    "zeroes": lambda: torch.zeros(1, 10, 10, 10),
+    "ones": lambda: torch.ones(10, 2, 3),
+    "rand": lambda: torch.rand(10, 10) - 0.5,
+    "near_zero": lambda: torch.randn(100) * 0.01,
+    "taylor_small": lambda: torch.empty(5).uniform_(
         -0.35, 0.35
     ),  # test cases for taylor series expansion
-    "randn_large_pos": torch.randn(10) + 10,
-    "randn_large_neg": torch.randn(10) - 10,
-    "ramp": torch.arange(-16, 16, 0.2),
+    "randn_large_pos": lambda: torch.randn(10) + 10,
+    "randn_large_neg": lambda: torch.randn(10) - 10,
+    "ramp": lambda: torch.arange(-16, 16, 0.2),
 }
 
 
@@ -45,7 +45,7 @@ class Expm1(torch.nn.Module):
 def test_expm1_tosa_FP(test_data: Tuple):
     pipeline = TosaPipelineFP[input_t1](
         Expm1(),
-        (test_data,),
+        (test_data(),),
         aten_op=aten_op,
         exir_op=exir_op,
     )
@@ -56,7 +56,7 @@ def test_expm1_tosa_FP(test_data: Tuple):
 def test_expm1_tosa_INT(test_data: Tuple):
     pipeline = TosaPipelineINT[input_t1](
         Expm1(),
-        (test_data,),
+        (test_data(),),
         aten_op=aten_op,
         exir_op=exir_op,
     )
@@ -68,7 +68,7 @@ def test_expm1_tosa_INT(test_data: Tuple):
 def test_expm1_u55_INT(test_data: Tuple):
     pipeline = EthosU55PipelineINT[input_t1](
         Expm1(),
-        (test_data,),
+        (test_data(),),
         aten_ops=aten_op,
         exir_ops=exir_op,
     )
@@ -80,7 +80,7 @@ def test_expm1_u55_INT(test_data: Tuple):
 def test_expm1_u85_INT(test_data: Tuple):
     pipeline = EthosU85PipelineINT[input_t1](
         Expm1(),
-        (test_data,),
+        (test_data(),),
         aten_ops=aten_op,
         exir_ops=exir_op,
     )
@@ -92,7 +92,7 @@ def test_expm1_u85_INT(test_data: Tuple):
 def test_expm1_vgf_no_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         Expm1(),
-        (test_data,),
+        (test_data(),),
         aten_op,
         exir_op,
         quantize=False,
@@ -105,7 +105,7 @@ def test_expm1_vgf_no_quant(test_data: Tuple):
 def test_expm1_vgf_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         Expm1(),
-        (test_data,),
+        (test_data(),),
         aten_op,
         exir_op,
         quantize=True,

--- a/backends/arm/test/ops/test_glu.py
+++ b/backends/arm/test/ops/test_glu.py
@@ -23,14 +23,14 @@ exir_op = "executorch_exir_dialects_edge__ops_aten__glu_default"
 input_t1 = Tuple[torch.Tensor]
 
 test_data_suite = {
-    "zeros": [torch.zeros(10, 10, 2), -1],
-    "ones": [torch.ones(10, 10, 2), -1],
-    "rand": [torch.rand(10, 10, 2) - 0.5, -1],
-    "randn_pos": [torch.randn(10, 2) + 10, -1],
-    "randn_neg": [torch.randn(10, 2) - 10, -1],
-    "ramp": [torch.linspace(-16, 15.8, 160).reshape(-1, 2), -1],
-    "zeros_custom_dim": [torch.zeros(7, 10, 5), 1],
-    "rand_custom_dim": [torch.rand(10, 3, 3) - 0.5, 0],
+    "zeros": lambda: [torch.zeros(10, 10, 2), -1],
+    "ones": lambda: [torch.ones(10, 10, 2), -1],
+    "rand": lambda: [torch.rand(10, 10, 2) - 0.5, -1],
+    "randn_pos": lambda: [torch.randn(10, 2) + 10, -1],
+    "randn_neg": lambda: [torch.randn(10, 2) - 10, -1],
+    "ramp": lambda: [torch.linspace(-16, 15.8, 160).reshape(-1, 2), -1],
+    "zeros_custom_dim": lambda: [torch.zeros(7, 10, 5), 1],
+    "rand_custom_dim": lambda: [torch.rand(10, 3, 3) - 0.5, 0],
 }
 
 
@@ -47,7 +47,7 @@ class Glu(torch.nn.Module):
 def test_glu_tosa_FP(test_data: Tuple):
     pipeline = TosaPipelineFP[input_t1](
         Glu(),
-        (*test_data,),
+        (*test_data(),),
         aten_op,
         exir_op,
     )
@@ -59,14 +59,15 @@ def test_glu_tosa_FP(test_data: Tuple):
     test_data_suite,
 )
 def test_glu_tosa_INT(test_data: Tuple):
+    input_data = test_data()
     pipeline = TosaPipelineINT[input_t1](
         Glu(),
-        (*test_data,),
+        (*input_data,),
         aten_op=[],
         exir_op=exir_op,
         # These tests don't make sense when output is ~= 0
-        frobenius_threshold=1.0 if (test_data[0].max() < 5) else 0.1,
-        cosine_threshold=0.0 if (test_data[0].max() < 5) else 0.9,
+        frobenius_threshold=1.0 if (input_data[0].max() < 5) else 0.1,
+        cosine_threshold=0.0 if (input_data[0].max() < 5) else 0.9,
     )
     pipeline.run()
 
@@ -79,7 +80,7 @@ def test_glu_tosa_INT(test_data: Tuple):
 def test_glu_u55_INT(test_data: Tuple):
     pipeline = EthosU55PipelineINT[input_t1](
         Glu(),
-        (*test_data,),
+        (*test_data(),),
         aten_ops=[],
         exir_ops=exir_op,
     )
@@ -94,7 +95,7 @@ def test_glu_u55_INT(test_data: Tuple):
 def test_glu_u85_INT(test_data: Tuple):
     pipeline = EthosU85PipelineINT[input_t1](
         Glu(),
-        (*test_data,),
+        (*test_data(),),
         aten_ops=[],
         exir_ops=exir_op,
     )
@@ -109,7 +110,7 @@ def test_glu_u85_INT(test_data: Tuple):
 def test_glu_vgf_no_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         Glu(),
-        (*test_data,),
+        (*test_data(),),
         [],
         [],
         quantize=False,
@@ -125,7 +126,7 @@ def test_glu_vgf_no_quant(test_data: input_t1):
 def test_glu_vgf_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         Glu(),
-        (*test_data,),
+        (*test_data(),),
         [],
         [],
         quantize=True,

--- a/backends/arm/test/ops/test_group_norm.py
+++ b/backends/arm/test/ops/test_group_norm.py
@@ -40,29 +40,39 @@ class GroupNorm(torch.nn.Module):
 
 input_t = tuple[torch.Tensor]
 test_data_suite = {
-    "rand_4_6_groups_1": ((torch.rand(4, 6),), GroupNorm(1, 6)),
-    "rand_4_6_groups_2": ((torch.rand(4, 6),), GroupNorm(2, 6)),
-    "rand_4_6_groups_6": ((torch.rand(4, 6),), GroupNorm(6, 6)),
-    "rand_4_6_8_groups_2_eps_no_affine": (
+    "rand_4_6_groups_1": lambda: ((torch.rand(4, 6),), GroupNorm(1, 6)),
+    "rand_4_6_groups_2": lambda: ((torch.rand(4, 6),), GroupNorm(2, 6)),
+    "rand_4_6_groups_6": lambda: ((torch.rand(4, 6),), GroupNorm(6, 6)),
+    "rand_4_6_8_groups_2_eps_no_affine": lambda: (
         (torch.rand(4, 6, 8),),
         GroupNorm(2, 6, eps=1e-3, affine=False),
     ),
-    "randn_1_12_8_6_groups_6_eps": (
+    "randn_1_12_8_6_groups_6_eps": lambda: (
         (torch.randn(1, 12, 8, 6),),
         GroupNorm(6, 12, eps=1e-2),
     ),
-    "randn_1_12_8_6_groups_12": ((torch.randn(1, 12, 8, 6),), GroupNorm(12, 12)),
-    "rand_6_8_10_12_groups_1": ((torch.rand(6, 8, 10, 12),), GroupNorm(1, 8)),
-    "rand_6_8_10_12_groups_4_no_affine": (
+    "randn_1_12_8_6_groups_12": lambda: (
+        (torch.randn(1, 12, 8, 6),),
+        GroupNorm(12, 12),
+    ),
+    "rand_6_8_10_12_groups_1": lambda: (
+        (torch.rand(6, 8, 10, 12),),
+        GroupNorm(1, 8),
+    ),
+    "rand_6_8_10_12_groups_4_no_affine": lambda: (
         (torch.rand(6, 8, 10, 12),),
         GroupNorm(4, 8, affine=False),
     ),
-    "rand_6_8_10_12_groups_8": ((torch.rand(6, 8, 10, 12),), GroupNorm(8, 8)),
+    "rand_6_8_10_12_groups_8": lambda: (
+        (torch.rand(6, 8, 10, 12),),
+        GroupNorm(8, 8),
+    ),
 }
 
 
 @common.parametrize("test_data", test_data_suite)
 def test_native_group_norm_tosa_FP(test_data):
+    test_data = test_data()
     aten_op = "torch.ops.aten.group_norm.default"
     exir_op = "executorch_exir_dialects_edge__ops_aten_native_group_norm_default"
     pipeline = TosaPipelineFP[input_t](
@@ -79,6 +89,7 @@ def test_native_group_norm_tosa_FP(test_data):
     test_data_suite,
 )
 def test_native_group_norm_tosa_INT(test_data):
+    test_data = test_data()
     aten_op = "torch.ops.aten.sub.Tensor"  # 'sub' op arbitrarily chosen to confirm groupnorm was decomposed
     exir_op = "executorch_exir_dialects_edge__ops_aten_native_group_norm_default"
     pipeline = TosaPipelineINT[input_t](
@@ -97,6 +108,7 @@ def test_native_group_norm_tosa_INT(test_data):
 )
 @common.XfailIfNoCorstone300
 def test_native_group_norm_u55_INT(test_data):
+    test_data = test_data()
     pipeline = EthosU55PipelineINT[input_t](
         test_data[1],
         test_data[0],
@@ -113,6 +125,7 @@ def test_native_group_norm_u55_INT(test_data):
 )
 @common.XfailIfNoCorstone320
 def test_native_group_norm_u85_INT(test_data):
+    test_data = test_data()
     pipeline = EthosU85PipelineINT[input_t](
         test_data[1],
         test_data[0],
@@ -131,7 +144,7 @@ def test_native_group_norm_u85_INT(test_data):
 def test_native_group_norm_vgf_no_quant(test_data):
     aten_op = "torch.ops.aten.group_norm.default"
     exir_op = "executorch_exir_dialects_edge__ops_aten_native_group_norm_default"
-    model, inp = test_data
+    model, inp = test_data()
     pipeline = VgfPipeline[input_t](
         inp,
         model,
@@ -150,7 +163,7 @@ def test_native_group_norm_vgf_no_quant(test_data):
 def test_native_group_norm_vgf_quant(test_data):
     aten_op = "torch.ops.aten.sub.Tensor"
     exir_op = "executorch_exir_dialects_edge__ops_aten_native_group_norm_default"
-    model, inp = test_data
+    model, inp = test_data()
     pipeline = VgfPipeline[input_t](
         inp,
         model,

--- a/backends/arm/test/ops/test_linalg_vector_norm.py
+++ b/backends/arm/test/ops/test_linalg_vector_norm.py
@@ -53,17 +53,17 @@ class VectorNormModel(torch.nn.Module):
 
 
 test_modules = {
-    "default": (VectorNormModel(dim=1), (torch.rand(10, 4),)),
-    "ord1": (VectorNormModel(ord=1, dim=1), (torch.rand(10, 4),)),
-    "ord2": (VectorNormModel(ord=2, dim=1), (torch.rand(10, 20),)),
+    "default": lambda: (VectorNormModel(dim=1), (torch.rand(10, 4),)),
+    "ord1": lambda: (VectorNormModel(ord=1, dim=1), (torch.rand(10, 4),)),
+    "ord2": lambda: (VectorNormModel(ord=2, dim=1), (torch.rand(10, 20),)),
     # Norm computed along a specific dimension of a 3D tensor
-    "dim_3d": (VectorNormModel(dim=2), (torch.rand(4, 5, 6),)),
+    "dim_3d": lambda: (VectorNormModel(dim=2), (torch.rand(4, 5, 6),)),
 }
 
 
 @common.parametrize("test_module", test_modules)
 def test_vector_norm_tosa_FP(test_module):
-    model, input_tensor = test_module
+    model, input_tensor = test_module()
 
     # We decompose LinalgVectorNorm before quantize stage to have annotations
     # with q/dq nodes. In case of FP, this operator will be decomposed
@@ -79,7 +79,7 @@ def test_vector_norm_tosa_FP(test_module):
 
 @common.parametrize("test_module", test_modules)
 def test_vector_norm_tosa_INT(test_module):
-    model, input_tensor = test_module
+    model, input_tensor = test_module()
 
     # Should not found this op
     exir_op = "executorch_exir_dialects_edge__ops_aten_linalg_vector_norm_default"
@@ -97,7 +97,7 @@ def test_vector_norm_tosa_INT(test_module):
 @common.parametrize("test_module", test_modules)
 @common.XfailIfNoCorstone300
 def test_vector_norm_u55_INT_fvp(test_module):
-    model, input_tensor = test_module
+    model, input_tensor = test_module()
 
     pipeline = EthosU55PipelineINT[input_t](
         model,
@@ -113,7 +113,7 @@ def test_vector_norm_u55_INT_fvp(test_module):
 @common.parametrize("test_module", test_modules)
 @common.XfailIfNoCorstone320
 def test_vector_norm_u85_INT_fvp(test_module):
-    model, input_tensor = test_module
+    model, input_tensor = test_module()
 
     # The should be decomposed and annotated in DecomposeLinalgVectorNorm pass.
     pipeline = EthosU85PipelineINT[input_t](
@@ -130,7 +130,7 @@ def test_vector_norm_u85_INT_fvp(test_module):
 @common.parametrize("test_module", test_modules)
 @common.SkipIfNoModelConverter
 def test_vector_norm_vgf_no_quant(test_module):
-    model, input_tensor = test_module
+    model, input_tensor = test_module()
     # FP VGF
     aten_op = "torch.ops.aten.linalg_vector_norm.default"
     exir_op = "executorch_exir_dialects_edge__ops_aten_linalg_vector_norm_default"
@@ -147,7 +147,7 @@ def test_vector_norm_vgf_no_quant(test_module):
 @common.parametrize("test_module", test_modules)
 @common.SkipIfNoModelConverter
 def test_vector_norm_vgf_quant(test_module):
-    model, input_tensor = test_module
+    model, input_tensor = test_module()
     # Should not found this op
     exir_op = "executorch_exir_dialects_edge__ops_aten_linalg_vector_norm_default"
 

--- a/backends/arm/test/ops/test_logit.py
+++ b/backends/arm/test/ops/test_logit.py
@@ -22,16 +22,16 @@ exir_op = "executorch_exir_dialects_edge__ops_aten__logit_default"
 input_t1 = Tuple[torch.Tensor]
 
 test_data_suite = {
-    "zeros": [torch.zeros((10, 10, 10)), None],
-    "ones": [torch.ones((10, 10, 10)), None],
-    "uniform_valid": [torch.rand((10, 10, 10)), None],
-    "near_zero": [torch.full((10, 10), 1e-8), None],
-    "near_one": [torch.full((10, 10), 1 - 1e-8), None],
-    "mixed": [torch.tensor([0.0, 1e-5, 0.5, 1 - 1e-5, 1.0]), None],
-    "multi_dim": [torch.rand((2, 3, 4)), None],
-    "eps": [torch.zeros((10, 10, 10)), 1e-6],
-    "invalid_neg": [torch.full((5,), -0.1), 1e-6],
-    "invalid_gt1": [torch.full((5,), 1.1), 1e-6],
+    "zeros": lambda: (torch.zeros((10, 10, 10)), None),
+    "ones": lambda: (torch.ones((10, 10, 10)), None),
+    "uniform_valid": lambda: (torch.rand((10, 10, 10)), None),
+    "near_zero": lambda: (torch.full((10, 10), 1e-8), None),
+    "near_one": lambda: (torch.full((10, 10), 1 - 1e-8), None),
+    "mixed": lambda: (torch.tensor([0.0, 1e-5, 0.5, 1 - 1e-5, 1.0]), None),
+    "multi_dim": lambda: (torch.rand((2, 3, 4)), None),
+    "eps": lambda: (torch.zeros((10, 10, 10)), 1e-6),
+    "invalid_neg": lambda: (torch.full((5,), -0.1), 1e-6),
+    "invalid_gt1": lambda: (torch.full((5,), 1.1), 1e-6),
 }
 
 
@@ -45,7 +45,7 @@ class Logit(torch.nn.Module):
 def test_logit_tosa_FP(test_data: Tuple):
     pipeline = TosaPipelineFP[input_t1](
         Logit(),
-        (*test_data,),
+        (*test_data(),),
         aten_op=aten_op,
         exir_op=exir_op,
     )
@@ -56,7 +56,7 @@ def test_logit_tosa_FP(test_data: Tuple):
 def test_logit_tosa_INT(test_data: Tuple):
     pipeline = TosaPipelineINT[input_t1](
         Logit(),
-        (*test_data,),
+        (*test_data(),),
         aten_op=[],
         exir_op=exir_op,
         # Quantization issues when logit(x) -> inf
@@ -71,7 +71,7 @@ def test_logit_tosa_INT(test_data: Tuple):
 def test_logit_u55_INT(test_data: Tuple):
     pipeline = EthosU55PipelineINT[input_t1](
         Logit(),
-        (*test_data,),
+        (*test_data(),),
         aten_ops=[],
         exir_ops=exir_op,
     )
@@ -83,7 +83,7 @@ def test_logit_u55_INT(test_data: Tuple):
 def test_logit_u85_INT(test_data: Tuple):
     pipeline = EthosU85PipelineINT[input_t1](
         Logit(),
-        (*test_data,),
+        (*test_data(),),
         aten_ops=[],
         exir_ops=exir_op,
     )
@@ -98,7 +98,7 @@ def test_logit_u85_INT(test_data: Tuple):
 def test_logit_vgf_no_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         Logit(),
-        (*test_data,),
+        (*test_data(),),
         [],
         [],
         quantize=False,
@@ -114,7 +114,7 @@ def test_logit_vgf_no_quant(test_data: input_t1):
 def test_logit_vgf_quant(test_data: input_t1):
     pipeline = VgfPipeline[input_t1](
         Logit(),
-        (*test_data,),
+        (*test_data(),),
         [],
         [],
         quantize=True,

--- a/backends/arm/test/ops/test_sign.py
+++ b/backends/arm/test/ops/test_sign.py
@@ -22,17 +22,17 @@ exir_op = "executorch_exir_dialects_edge__ops_aten__sign_default"
 input_t1 = Tuple[torch.Tensor]
 
 test_data_suite = {
-    "zeros": torch.zeros(3, 5),
-    "ones": torch.ones(4, 4),
-    "neg_ones": -torch.ones(4, 4),
-    "mixed_signs": torch.tensor([[-2.0, -1.0, 0.0, 1.0, 2.0]]),
-    "positive_ramp": torch.arange(0.1, 1.1, 0.2),
-    "negative_ramp": torch.arange(-1.0, -0.1, 0.2),
-    "small_values": torch.tensor(
+    "zeros": lambda: torch.zeros(3, 5),
+    "ones": lambda: torch.ones(4, 4),
+    "neg_ones": lambda: -torch.ones(4, 4),
+    "mixed_signs": lambda: torch.tensor([[-2.0, -1.0, 0.0, 1.0, 2.0]]),
+    "positive_ramp": lambda: torch.arange(0.1, 1.1, 0.2),
+    "negative_ramp": lambda: torch.arange(-1.0, -0.1, 0.2),
+    "small_values": lambda: torch.tensor(
         [-1e-3, 0.0, 1e-3]
     ),  # Only values > observer's .eps are of interest.
-    "rand": torch.rand(10, 10) - 0.5,
-    "rand_alt_shape": torch.rand(10, 3, 5) - 0.5,
+    "rand": lambda: torch.rand(10, 10) - 0.5,
+    "rand_alt_shape": lambda: torch.rand(10, 3, 5) - 0.5,
 }
 
 
@@ -45,7 +45,7 @@ class Sign(torch.nn.Module):
 def test_sign_tosa_FP(test_data: Tuple):
     pipeline = TosaPipelineFP[input_t1](
         Sign(),
-        (test_data,),
+        (test_data(),),
         aten_op=aten_op,
         exir_op=exir_op,
     )
@@ -55,7 +55,7 @@ def test_sign_tosa_FP(test_data: Tuple):
 @common.parametrize("test_data", test_data_suite)
 def test_sign_tosa_INT(test_data: Tuple):
     pipeline = TosaPipelineINT[input_t1](
-        Sign(), (test_data,), aten_op=[], exir_op=exir_op, frobenius_threshold=None
+        Sign(), (test_data(),), aten_op=[], exir_op=exir_op, frobenius_threshold=None
     )
     pipeline.run()
 
@@ -66,7 +66,7 @@ def test_sign_tosa_INT(test_data: Tuple):
 def test_sign_u55_INT(test_data: Tuple):
     pipeline = EthosU55PipelineINT[input_t1](
         Sign(),
-        (test_data,),
+        (test_data(),),
         aten_ops=[],
         exir_ops=exir_op,
     )
@@ -78,7 +78,7 @@ def test_sign_u55_INT(test_data: Tuple):
 def test_sign_u85_INT(test_data: Tuple):
     pipeline = EthosU85PipelineINT[input_t1](
         Sign(),
-        (test_data,),
+        (test_data(),),
         aten_ops=[],
         exir_ops=exir_op,
     )
@@ -90,7 +90,7 @@ def test_sign_u85_INT(test_data: Tuple):
 def test_sign_vgf_no_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         Sign(),
-        (test_data,),
+        (test_data(),),
         aten_op=aten_op,
         exir_op=exir_op,
         quantize=False,
@@ -103,7 +103,7 @@ def test_sign_vgf_no_quant(test_data: Tuple):
 def test_sign_vgf_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         Sign(),
-        (test_data,),
+        (test_data(),),
         aten_op=[],
         exir_op=exir_op,
         quantize=True,

--- a/backends/arm/test/ops/test_sin.py
+++ b/backends/arm/test/ops/test_sin.py
@@ -22,20 +22,20 @@ input_t1 = Tuple[torch.Tensor]  # Input x
 
 test_data_suite = {
     # (test_name, test_data)
-    "zeros": torch.zeros(10, 10, 10, 10),
-    "ones": torch.ones(10, 10, 10),
-    "rand": torch.rand(10, 10) - 0.5,
-    "randn_pos": torch.randn(10) + 10,
-    "randn_neg": torch.randn(10) - 10,
-    "ramp": torch.arange(-16, 16, 0.2),
+    "zeros": lambda: torch.zeros(10, 10, 10, 10),
+    "ones": lambda: torch.ones(10, 10, 10),
+    "rand": lambda: torch.rand(10, 10) - 0.5,
+    "randn_pos": lambda: torch.randn(10) + 10,
+    "randn_neg": lambda: torch.randn(10) - 10,
+    "ramp": lambda: torch.arange(-16, 16, 0.2),
 }
 
 test_data_suite_fp16 = {
-    "rand_fp16": torch.rand(10, 10, dtype=torch.float16),
+    "rand_fp16": lambda: torch.rand(10, 10, dtype=torch.float16),
 }
 
 test_data_suite_bf16 = {
-    "rand_bf16": torch.rand(3, 3, dtype=torch.bfloat16),
+    "rand_bf16": lambda: torch.rand(3, 3, dtype=torch.bfloat16),
 }
 
 
@@ -51,7 +51,7 @@ class Sin(torch.nn.Module):
 def test_sin_tosa_FP(test_data: Tuple):
     pipeline = TosaPipelineFP[input_t1](
         Sin(),
-        (test_data,),
+        (test_data(),),
         aten_op,
         exir_op=[],
         tosa_extensions=["bf16"],
@@ -63,7 +63,7 @@ def test_sin_tosa_FP(test_data: Tuple):
 def test_sin_tosa_INT(test_data: Tuple):
     pipeline = TosaPipelineINT[input_t1](
         Sin(),
-        (test_data,),
+        (test_data(),),
         aten_op,
         exir_op=[],
     )
@@ -75,7 +75,7 @@ def test_sin_tosa_INT(test_data: Tuple):
 def test_sin_u55_INT(test_data: Tuple):
     pipeline = EthosU55PipelineINT[input_t1](
         Sin(),
-        (test_data,),
+        (test_data(),),
         aten_op,
         exir_ops=[],
     )
@@ -87,7 +87,7 @@ def test_sin_u55_INT(test_data: Tuple):
 def test_sin_u85_INT(test_data: Tuple):
     pipeline = EthosU85PipelineINT[input_t1](
         Sin(),
-        (test_data,),
+        (test_data(),),
         aten_op,
         exir_ops=[],
     )
@@ -99,7 +99,7 @@ def test_sin_u85_INT(test_data: Tuple):
 def test_sin_vgf_no_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         Sin(),
-        (test_data,),
+        (test_data(),),
         aten_op,
         quantize=False,
     )
@@ -111,7 +111,7 @@ def test_sin_vgf_no_quant(test_data: Tuple):
 def test_sin_vgf_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         Sin(),
-        (test_data,),
+        (test_data(),),
         aten_op,
         quantize=True,
     )

--- a/backends/arm/test/ops/test_sinh.py
+++ b/backends/arm/test/ops/test_sinh.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -23,16 +23,16 @@ input_t1 = Tuple[torch.Tensor]  # Input x
 
 test_data_suite = {
     # (test_name, test_data)
-    "zeros": torch.zeros(10, 10, 10),
-    "zeros_alt_shape": torch.zeros(10, 3, 5),
-    "ones": torch.ones(10, 10, 10),
-    "rand": torch.rand(10, 10) - 0.5,
-    "rand_alt_shape": torch.rand(10, 3, 5) - 0.5,
-    "randn_pos": torch.randn(10) + 10,
-    "randn_neg": torch.randn(10) - 10,
-    "ramp": torch.arange(-16, 16, 0.2),
-    "large": 100 * torch.ones(1, 1),
-    "small": 0.000001 * torch.ones(1, 1),
+    "zeros": lambda: torch.zeros(10, 10, 10),
+    "zeros_alt_shape": lambda: torch.zeros(10, 3, 5),
+    "ones": lambda: torch.ones(10, 10, 10),
+    "rand": lambda: torch.rand(10, 10) - 0.5,
+    "rand_alt_shape": lambda: torch.rand(10, 3, 5) - 0.5,
+    "randn_pos": lambda: torch.randn(10) + 10,
+    "randn_neg": lambda: torch.randn(10) - 10,
+    "ramp": lambda: torch.arange(-16, 16, 0.2),
+    "large": lambda: 100 * torch.ones(1, 1),
+    "small": lambda: 0.000001 * torch.ones(1, 1),
 }
 
 
@@ -46,7 +46,7 @@ class Sinh(torch.nn.Module):
 def test_sinh_tosa_FP(test_data: Tuple):
     pipeline = TosaPipelineFP[input_t1](
         Sinh(),
-        (test_data,),
+        (test_data(),),
         aten_op,
         exir_op,
     )
@@ -56,7 +56,7 @@ def test_sinh_tosa_FP(test_data: Tuple):
 @common.parametrize("test_data", test_data_suite)
 def test_sinh_tosa_INT(test_data: Tuple):
     pipeline = TosaPipelineINT[input_t1](
-        Sinh(), (test_data,), aten_op=aten_op, exir_op=exir_op
+        Sinh(), (test_data(),), aten_op=aten_op, exir_op=exir_op
     )
     pipeline.run()
 
@@ -65,7 +65,7 @@ def test_sinh_tosa_INT(test_data: Tuple):
 @common.parametrize("test_data", test_data_suite)
 def test_sinh_u55_INT(test_data: Tuple):
     pipeline = EthosU55PipelineINT[input_t1](
-        Sinh(), (test_data,), aten_ops=aten_op, exir_ops=exir_op
+        Sinh(), (test_data(),), aten_ops=aten_op, exir_ops=exir_op
     )
     pipeline.run()
 
@@ -74,7 +74,7 @@ def test_sinh_u55_INT(test_data: Tuple):
 @common.parametrize("test_data", test_data_suite)
 def test_sinh_u85_INT(test_data: Tuple):
     pipeline = EthosU85PipelineINT[input_t1](
-        Sinh(), (test_data,), aten_ops=aten_op, exir_ops=exir_op
+        Sinh(), (test_data(),), aten_ops=aten_op, exir_ops=exir_op
     )
     pipeline.run()
 
@@ -84,7 +84,7 @@ def test_sinh_u85_INT(test_data: Tuple):
 def test_sinh_vgf_no_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         Sinh(),
-        (test_data,),
+        (test_data(),),
         aten_op,
         quantize=False,
     )
@@ -96,7 +96,7 @@ def test_sinh_vgf_no_quant(test_data: Tuple):
 def test_sinh_vgf_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t1](
         Sinh(),
-        (test_data,),
+        (test_data(),),
         aten_op,
         quantize=True,
     )

--- a/backends/arm/test/ops/test_tan.py
+++ b/backends/arm/test/ops/test_tan.py
@@ -25,16 +25,16 @@ eps32 = torch.finfo(torch.float32).eps
 tiny32 = torch.finfo(torch.float32).tiny
 
 test_data_suite = {
-    "zeros": torch.zeros(1, 10, 10, 10),
-    "zeros_alt_shape": torch.zeros(1, 10, 3, 5),
-    "ones": torch.ones(10, 15, 25),
-    "rand": torch.rand(10, 10) - 0.5,
-    "rand_alt_shape": torch.rand(1, 10, 3, 5) - 0.5,
-    "randn_pos": torch.randn(10) + 10,
-    "randn_neg": torch.randn(10) - 10,
-    "ramp": torch.arange(-16, 16, 0.2),
-    "pi_multiples": (torch.arange(-5, 6, dtype=torch.float32) * math.pi),
-    "common_angles": torch.tensor(
+    "zeros": lambda: torch.zeros(1, 10, 10, 10),
+    "zeros_alt_shape": lambda: torch.zeros(1, 10, 3, 5),
+    "ones": lambda: torch.ones(10, 15, 25),
+    "rand": lambda: torch.rand(10, 10) - 0.5,
+    "rand_alt_shape": lambda: torch.rand(1, 10, 3, 5) - 0.5,
+    "randn_pos": lambda: torch.randn(10) + 10,
+    "randn_neg": lambda: torch.randn(10) - 10,
+    "ramp": lambda: torch.arange(-16, 16, 0.2),
+    "pi_multiples": lambda: (torch.arange(-5, 6, dtype=torch.float32) * math.pi),
+    "common_angles": lambda: torch.tensor(
         [
             -math.pi,
             -2 * math.pi / 3,
@@ -52,7 +52,7 @@ test_data_suite = {
         ],
         dtype=torch.float32,
     ),
-    "near_asymptote_pos": torch.tensor(
+    "near_asymptote_pos": lambda: torch.tensor(
         [
             math.pi / 2 - 1e-7,
             math.pi / 2 - 1e-6,
@@ -63,12 +63,12 @@ test_data_suite = {
         ],
         dtype=torch.float32,
     ),
-    "high_rank": torch.randn(1, 3, 7, 4, 5),
-    "very_small": torch.tensor(
+    "high_rank": lambda: torch.randn(1, 3, 7, 4, 5),
+    "very_small": lambda: torch.tensor(
         [-tiny32, -eps32, -1e-10, 0.0, 1e-10, eps32, tiny32], dtype=torch.float32
     ),
-    "large_values": torch.linspace(-1e6, 1e6, steps=257, dtype=torch.float32),
-    "undefined": torch.tensor([math.pi / 2, -math.pi / 2, 3 * math.pi / 2]),
+    "large_values": lambda: torch.linspace(-1e6, 1e6, steps=257, dtype=torch.float32),
+    "undefined": lambda: torch.tensor([math.pi / 2, -math.pi / 2, 3 * math.pi / 2]),
 }
 
 
@@ -82,7 +82,7 @@ class Tan(torch.nn.Module):
 def test_tan_tosa_FP(test_data: Tuple):
     pipeline = TosaPipelineFP[input_t](
         Tan(),
-        (test_data,),
+        (test_data(),),
         aten_op,
         exir_op,
     )
@@ -93,7 +93,7 @@ def test_tan_tosa_FP(test_data: Tuple):
 def test_tan_tosa_INT(test_data: Tuple):
     pipeline = TosaPipelineINT[input_t](
         Tan(),
-        (test_data,),
+        (test_data(),),
         aten_op,
         exir_op,
         frobenius_threshold=None,
@@ -107,7 +107,7 @@ def test_tan_tosa_INT(test_data: Tuple):
 def test_tan_u55_INT(test_data: Tuple):
     pipeline = EthosU55PipelineINT[input_t](
         Tan(),
-        (test_data,),
+        (test_data(),),
         aten_ops=aten_op,
         exir_ops=exir_op,
     )
@@ -119,7 +119,7 @@ def test_tan_u55_INT(test_data: Tuple):
 def test_tan_u85_INT(test_data: Tuple):
     pipeline = EthosU85PipelineINT[input_t](
         Tan(),
-        (test_data,),
+        (test_data(),),
         aten_ops=aten_op,
         exir_ops=exir_op,
     )
@@ -129,7 +129,7 @@ def test_tan_u85_INT(test_data: Tuple):
 @common.parametrize("test_data", test_data_suite)
 @common.SkipIfNoModelConverter
 def test_tan_vgf_no_quant(test_data: Tuple):
-    pipeline = VgfPipeline[input_t](Tan(), (test_data,), [], [], quantize=False)
+    pipeline = VgfPipeline[input_t](Tan(), (test_data(),), [], [], quantize=False)
     pipeline.run()
 
 
@@ -138,7 +138,7 @@ def test_tan_vgf_no_quant(test_data: Tuple):
 def test_tan_vgf_quant(test_data: Tuple):
     pipeline = VgfPipeline[input_t](
         Tan(),
-        (test_data,),
+        (test_data(),),
         [],
         [],
         quantize=True,

--- a/backends/arm/test/ops/test_upsample_bilinear2d.py
+++ b/backends/arm/test/ops/test_upsample_bilinear2d.py
@@ -24,44 +24,89 @@ input_t1 = Tuple[torch.Tensor]  # Input x
 
 test_data_suite_tosa = {
     # (test_name, test_data, size, scale_factor, compare_outputs)
-    "rand_double_scale": (torch.rand(2, 4, 8, 3), None, 2.0, True),
-    "rand_double_scale_one_dim": (torch.rand(2, 4, 8, 3), None, (1.0, 2.0), True),
-    "rand_double_size": (torch.rand(2, 4, 8, 3), (16, 6), None, True),
-    "rand_one_double_scale": (torch.rand(2, 4, 1, 1), None, 2.0, True),
-    "rand_one_double_size": (torch.rand(2, 4, 1, 1), (2, 2), None, True),
-    "rand_one_same_scale": (torch.rand(2, 4, 1, 1), None, 1.0, True),
-    "rand_one_same_size": (torch.rand(2, 4, 1, 1), (1, 1), None, True),
+    "rand_double_scale": lambda: (torch.rand(2, 4, 8, 3), None, 2.0, True),
+    "rand_double_scale_one_dim": lambda: (
+        torch.rand(2, 4, 8, 3),
+        None,
+        (1.0, 2.0),
+        True,
+    ),
+    "rand_double_size": lambda: (torch.rand(2, 4, 8, 3), (16, 6), None, True),
+    "rand_one_double_scale": lambda: (torch.rand(2, 4, 1, 1), None, 2.0, True),
+    "rand_one_double_size": lambda: (torch.rand(2, 4, 1, 1), (2, 2), None, True),
+    "rand_one_same_scale": lambda: (torch.rand(2, 4, 1, 1), None, 1.0, True),
+    "rand_one_same_size": lambda: (torch.rand(2, 4, 1, 1), (1, 1), None, True),
     # Can't compare outputs as the rounding when selecting the nearest pixel is
     # different between PyTorch and TOSA. Just check the legalization went well.
     # TODO Improve the test infrastructure to support more in depth verification
     # of the TOSA legalization results.
-    "rand_half_scale": (torch.rand(2, 4, 8, 6), None, 0.5, False),
-    "rand_half_size": (torch.rand(2, 4, 8, 6), (4, 3), None, False),
-    "rand_one_and_half_scale": (torch.rand(2, 4, 8, 3), None, 1.5, False),
-    "rand_one_and_half_size": (torch.rand(2, 4, 8, 3), (12, 4), None, False),
+    "rand_half_scale": lambda: (torch.rand(2, 4, 8, 6), None, 0.5, False),
+    "rand_half_size": lambda: (torch.rand(2, 4, 8, 6), (4, 3), None, False),
+    "rand_one_and_half_scale": lambda: (
+        torch.rand(2, 4, 8, 3),
+        None,
+        1.5,
+        False,
+    ),
+    "rand_one_and_half_size": lambda: (
+        torch.rand(2, 4, 8, 3),
+        (12, 4),
+        None,
+        False,
+    ),
     # Use randn for a bunch of tests to get random numbers from the
     # normal distribution where negative is also a possibilty
-    "randn_double_scale_negative": (torch.randn(2, 4, 8, 3), None, 2.0, True),
-    "randn_double_scale_one_dim_negative": (
+    "randn_double_scale_negative": lambda: (
+        torch.randn(2, 4, 8, 3),
+        None,
+        2.0,
+        True,
+    ),
+    "randn_double_scale_one_dim_negative": lambda: (
         torch.randn(2, 4, 8, 3),
         None,
         (1.0, 2.0),
         True,
     ),
-    "randn_double_size_negative": (torch.randn(2, 4, 8, 3), (16, 6), None, True),
-    "randn_one_double_scale_negative": (torch.randn(2, 4, 1, 1), None, 2.0, True),
-    "randn_one_double_size_negative": (torch.randn(2, 4, 1, 1), (2, 2), None, True),
-    "randn_one_same_scale_negative": (torch.randn(2, 4, 1, 1), None, 1.0, True),
-    "randn_one_same_size_negative": (torch.randn(2, 4, 1, 1), (1, 1), None, True),
+    "randn_double_size_negative": lambda: (
+        torch.randn(2, 4, 8, 3),
+        (16, 6),
+        None,
+        True,
+    ),
+    "randn_one_double_scale_negative": lambda: (
+        torch.randn(2, 4, 1, 1),
+        None,
+        2.0,
+        True,
+    ),
+    "randn_one_double_size_negative": lambda: (
+        torch.randn(2, 4, 1, 1),
+        (2, 2),
+        None,
+        True,
+    ),
+    "randn_one_same_scale_negative": lambda: (
+        torch.randn(2, 4, 1, 1),
+        None,
+        1.0,
+        True,
+    ),
+    "randn_one_same_size_negative": lambda: (
+        torch.randn(2, 4, 1, 1),
+        (1, 1),
+        None,
+        True,
+    ),
 }
 test_data_suite_tosa_bf16 = {
-    "randn_double_scale_bf16": (
+    "randn_double_scale_bf16": lambda: (
         torch.randn(1, 2, 2, 2, dtype=torch.bfloat16),
         None,
         2.0,
         True,
     ),
-    "randn_double_size_bf16": (
+    "randn_double_size_bf16": lambda: (
         torch.randn(1, 1, 3, 2, dtype=torch.bfloat16),
         (6, 4),
         None,
@@ -69,13 +114,13 @@ test_data_suite_tosa_bf16 = {
     ),
 }
 test_data_suite_tosa_fp16 = {
-    "randn_double_scale_fp16": (
+    "randn_double_scale_fp16": lambda: (
         torch.randn(1, 2, 2, 2, dtype=torch.float16),
         None,
         2.0,
         True,
     ),
-    "randn_double_size_fp16": (
+    "randn_double_size_fp16": lambda: (
         torch.randn(1, 1, 3, 2, dtype=torch.float16),
         (6, 4),
         None,
@@ -84,14 +129,24 @@ test_data_suite_tosa_fp16 = {
 }
 
 test_data_suite_Uxx = {
-    "rand_half_scale": (torch.rand(2, 4, 8, 6), None, 0.5, False),
-    "rand_half_size": (torch.rand(2, 4, 8, 6), (4, 3), None, False),
-    "rand_one_and_half_scale": (torch.rand(2, 4, 8, 3), None, 1.5, False),
-    "rand_one_and_half_size": (torch.rand(2, 4, 8, 3), (12, 4), None, False),
+    "rand_half_scale": lambda: (torch.rand(2, 4, 8, 6), None, 0.5, False),
+    "rand_half_size": lambda: (torch.rand(2, 4, 8, 6), (4, 3), None, False),
+    "rand_one_and_half_scale": lambda: (
+        torch.rand(2, 4, 8, 3),
+        None,
+        1.5,
+        False,
+    ),
+    "rand_one_and_half_size": lambda: (
+        torch.rand(2, 4, 8, 3),
+        (12, 4),
+        None,
+        False,
+    ),
 }
 
 test_data_u55 = {
-    "rand_double_size": (torch.rand(2, 4, 8, 3), (16, 6), None, True),
+    "rand_double_size": lambda: (torch.rand(2, 4, 8, 3), (16, 6), None, True),
 }
 
 
@@ -166,7 +221,7 @@ class InterpolateAlignCornersFalse(torch.nn.Module):
 def test_upsample_bilinear2d_vec_tosa_FP_UpsamplingBilinear2d(
     test_data: torch.Tensor,
 ):
-    test_data, size, scale_factor, compare_outputs = test_data
+    test_data, size, scale_factor, compare_outputs = test_data()
     match test_data.dtype:
         case torch.bfloat16:
             atol = 1e-2
@@ -196,7 +251,7 @@ def test_upsample_bilinear2d_vec_tosa_FP_UpsamplingBilinear2d(
 def test_upsample_bilinear2d_vec_tosa_FP_Upsample(
     test_data: torch.Tensor,
 ):
-    test_data, size, scale_factor, compare_outputs = test_data
+    test_data, size, scale_factor, compare_outputs = test_data()
     match test_data.dtype:
         case torch.bfloat16:
             atol = 1e-2
@@ -227,7 +282,7 @@ def test_upsample_bilinear2d_vec_tosa_FP_Upsample(
 def test_upsample_bilinear2d_vec_tosa_FP_Interpolate(
     test_data: torch.Tensor,
 ):
-    test_data, size, scale_factor, compare_outputs = test_data
+    test_data, size, scale_factor, compare_outputs = test_data()
     match test_data.dtype:
         case torch.bfloat16:
             atol = 1e-2
@@ -265,7 +320,7 @@ def test_upsample_bilinear2d_vec_tosa_does_not_delegate_exact_one_sixteenth_down
 def test_upsample_bilinear2d_vec_tosa_INT_intropolate(
     test_data: torch.Tensor,
 ):
-    test_data, size, scale_factor, compare_outputs = test_data
+    test_data, size, scale_factor, compare_outputs = test_data()
 
     pipeline = TosaPipelineINT[input_t1](
         UpsamplingBilinear2d(size, scale_factor),
@@ -282,7 +337,7 @@ def test_upsample_bilinear2d_vec_tosa_INT_intropolate(
 def test_upsample_bilinear2d_vec_tosa_INT_Upsample(
     test_data: torch.Tensor,
 ):
-    test_data, size, scale_factor, compare_outputs = test_data
+    test_data, size, scale_factor, compare_outputs = test_data()
 
     pipeline = TosaPipelineINT[input_t1](
         Upsample(size, scale_factor),
@@ -302,7 +357,7 @@ def test_upsample_bilinear2d_vec_tosa_INT_a16w8(
     """Test upsample_bilinear2d vector op with int16 I/O quantization for TOSA
     INT.
     """
-    test_data, size, scale_factor, compare_outputs = test_data
+    test_data, size, scale_factor, compare_outputs = test_data()
     pipeline = TosaPipelineINT[input_t1](
         Upsample(size, scale_factor),
         (test_data,),
@@ -320,7 +375,7 @@ def test_upsample_bilinear2d_vec_tosa_INT_a16w8(
 def test_upsample_bilinear2d_vec_u55_INT_Upsample_not_delegated(
     test_data: torch.Tensor,
 ):
-    test_data, size, scale_factor, compare_outputs = test_data
+    test_data, size, scale_factor, compare_outputs = test_data()
     pipeline = OpNotSupportedPipeline[input_t1](
         Upsample(size, scale_factor),
         (test_data,),
@@ -338,7 +393,7 @@ def test_upsample_bilinear2d_vec_u55_INT_Upsample_not_delegated(
 def test_upsample_bilinear2d_vec_u55_INT_Interpolate_not_delegated(
     test_data: torch.Tensor,
 ):
-    test_data, size, scale_factor, compare_outputs = test_data
+    test_data, size, scale_factor, compare_outputs = test_data()
     pipeline = OpNotSupportedPipeline[input_t1](
         Interpolate(size, scale_factor),
         (test_data,),
@@ -356,7 +411,7 @@ def test_upsample_bilinear2d_vec_u55_INT_Interpolate_not_delegated(
 def test_upsample_bilinear2d_vec_u55_INT_UpsamplingBilinear2d_not_delegated(
     test_data: torch.Tensor,
 ):
-    test_data, size, scale_factor, compare_outputs = test_data
+    test_data, size, scale_factor, compare_outputs = test_data()
     pipeline = OpNotSupportedPipeline[input_t1](
         UpsamplingBilinear2d(size, scale_factor),
         (test_data,),
@@ -372,7 +427,7 @@ def test_upsample_bilinear2d_vec_u55_INT_UpsamplingBilinear2d_not_delegated(
 @common.parametrize("test_data", test_data_suite_Uxx)
 @common.XfailIfNoCorstone320
 def test_upsample_bilinear2d_vec_u85_INT_Upsample(test_data: input_t1):
-    test_data, size, scale_factor, compare_outputs = test_data
+    test_data, size, scale_factor, compare_outputs = test_data()
 
     pipeline = EthosU85PipelineINT[input_t1](
         Upsample(size, scale_factor),
@@ -391,7 +446,7 @@ def test_upsample_bilinear2d_vec_u85_INT_Upsample(test_data: input_t1):
 def test_upsample_bilinear2d_vec_u85_INT_Interpolate(
     test_data: torch.Tensor,
 ):
-    test_data, size, scale_factor, compare_outputs = test_data
+    test_data, size, scale_factor, compare_outputs = test_data()
 
     pipeline = EthosU85PipelineINT[input_t1](
         Interpolate(size, scale_factor),
@@ -410,7 +465,7 @@ def test_upsample_bilinear2d_vec_u85_INT_Interpolate(
 def test_upsample_bilinear2d_vec_u85_INT_UpsamplingBilinear2d(
     test_data: torch.Tensor,
 ):
-    test_data, size, scale_factor, compare_outputs = test_data
+    test_data, size, scale_factor, compare_outputs = test_data()
 
     pipeline = EthosU85PipelineINT[input_t1](
         UpsamplingBilinear2d(size, scale_factor),
@@ -432,7 +487,7 @@ def test_upsample_bilinear2d_vec_u85_INT_a16w8(
     """Test upsample_bilinear2d vec op with 16A8W quantization on U85 (16-bit
     activations, 8-bit weights)
     """
-    data, size, scale_factor, compare_outputs = test_data
+    data, size, scale_factor, compare_outputs = test_data()
 
     pipeline = EthosU85PipelineINT[input_t1](
         UpsamplingBilinear2d(size, scale_factor),
@@ -452,7 +507,7 @@ def test_upsample_bilinear2d_vec_u85_INT_a16w8(
 def test_upsample_bilinear2d_vec_vgf_no_quant_UpsamplingBilinear2d(
     test_data: torch.Tensor,
 ):
-    data, size, scale_factor, compare = test_data
+    data, size, scale_factor, compare = test_data()
     pipeline = VgfPipeline[input_t1](
         UpsamplingBilinear2d(size, scale_factor),
         (data,),
@@ -470,8 +525,8 @@ def test_upsample_bilinear2d_vec_vgf_no_quant_UpsamplingBilinear2d(
 @common.parametrize("test_data", test_data_suite_tosa | test_data_suite_tosa_fp16)
 @common.SkipIfNoModelConverter
 def test_upsample_bilinear2d_vec_vgf_no_quant_Upsample(test_data: torch.Tensor):
-    data, size, scale_factor, compare = test_data
-    match test_data[0].dtype:
+    data, size, scale_factor, compare = test_data()
+    match data.dtype:
         case torch.float16:
             atol = 1e-2
             rtol = 1e-2
@@ -495,7 +550,7 @@ def test_upsample_bilinear2d_vec_vgf_no_quant_Upsample(test_data: torch.Tensor):
 @common.parametrize("test_data", test_data_suite_tosa | test_data_suite_tosa_fp16)
 @common.SkipIfNoModelConverter
 def test_upsample_bilinear2d_vec_vgf_no_quant_Interpolate(test_data: torch.Tensor):
-    data, size, scale_factor, compare = test_data
+    data, size, scale_factor, compare = test_data()
     pipeline = VgfPipeline[input_t1](
         Interpolate(size, scale_factor),
         (data,),
@@ -513,7 +568,7 @@ def test_upsample_bilinear2d_vec_vgf_no_quant_Interpolate(test_data: torch.Tenso
 def test_upsample_bilinear2d_vec_vgf_quant_UpsamplingBilinear2d(
     test_data: torch.Tensor,
 ):
-    data, size, scale_factor, compare = test_data
+    data, size, scale_factor, compare = test_data()
     pipeline = VgfPipeline[input_t1](
         UpsamplingBilinear2d(size, scale_factor),
         (data,),
@@ -529,7 +584,7 @@ def test_upsample_bilinear2d_vec_vgf_quant_UpsamplingBilinear2d(
 @common.parametrize("test_data", test_data_suite_tosa)
 @common.SkipIfNoModelConverter
 def test_upsample_bilinear2d_vec_vgf_quant_Upsample(test_data: torch.Tensor):
-    data, size, scale_factor, compare = test_data
+    data, size, scale_factor, compare = test_data()
     pipeline = VgfPipeline[input_t1](
         Upsample(size, scale_factor),
         (data,),
@@ -545,7 +600,7 @@ def test_upsample_bilinear2d_vec_vgf_quant_Upsample(test_data: torch.Tensor):
 @common.parametrize("test_data", test_data_suite_tosa)
 @common.SkipIfNoModelConverter
 def test_upsample_bilinear2d_vec_vgf_quant_Interpolate(test_data: torch.Tensor):
-    data, size, scale_factor, compare = test_data
+    data, size, scale_factor, compare = test_data()
     pipeline = VgfPipeline[input_t1](
         Interpolate(size, scale_factor),
         (data,),
@@ -563,7 +618,7 @@ def test_upsample_bilinear2d_vec_vgf_quant_Interpolate(test_data: torch.Tensor):
 def test_upsample_bilinear2d_vec_vgf_quant_a16w8_UpsamplingBilinear2d(
     test_data: torch.Tensor,
 ):
-    data, size, scale_factor, compare = test_data
+    data, size, scale_factor, compare = test_data()
     pipeline = VgfPipeline[input_t1](
         UpsamplingBilinear2d(size, scale_factor),
         (data,),
@@ -583,7 +638,7 @@ def test_upsample_bilinear2d_vec_vgf_quant_a16w8_UpsamplingBilinear2d(
 def test_upsample_bilinear2d_vec_vgf_quant_a16w8_Upsample(
     test_data: torch.Tensor,
 ):
-    data, size, scale_factor, compare = test_data
+    data, size, scale_factor, compare = test_data()
     pipeline = VgfPipeline[input_t1](
         Upsample(size, scale_factor),
         (data,),
@@ -603,7 +658,7 @@ def test_upsample_bilinear2d_vec_vgf_quant_a16w8_Upsample(
 def test_upsample_bilinear2d_vec_vgf_quant_a16w8_Interpolate(
     test_data: torch.Tensor,
 ):
-    data, size, scale_factor, compare = test_data
+    data, size, scale_factor, compare = test_data()
     pipeline = VgfPipeline[input_t1](
         Interpolate(size, scale_factor),
         (data,),


### PR DESCRIPTION
Several Arm operator tests were creating random inputs at module import time. The Arm test seed is applied later by an autouse pytest fixture, so those tensors were not actually controlled by ARM_TEST_SEED.

That made tests nondeterministic across fresh pytest processes and could expose different quantization behavior from run to run. Generate the affected inputs lazily inside each test case so the existing seed fixture makes them reproducible and ARM_TEST_SEED=RANDOM can rerandomize the intended data.


Change-Id: Ic4414da5e84b7fb19275e04399634289b10a0a19


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell