### PR TITLE
CI: skip default-packages on every macos_job.yml callsite

### DIFF
--- a/.github/workflows/_test_backend.yml
+++ b/.github/workflows/_test_backend.yml
@@ -124,6 +124,7 @@ jobs:
 
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
     with:
+      default-packages: ""
       ref: ${{ inputs.ref }}
       runner: macos-m1-stable
       python-version: "3.12"

--- a/.github/workflows/_unittest.yml
+++ b/.github/workflows/_unittest.yml
@@ -44,6 +44,7 @@ jobs:
   macos:
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
     with:
+      default-packages: ""
       runner: macos-m1-stable
       python-version: '3.11'
       submodules: 'recursive'

--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -88,6 +88,7 @@ jobs:
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
     secrets: inherit
     with:
+      default-packages: ""
       runner: macos-14-xlarge
       python-version: '3.11'
       submodules: 'recursive'
@@ -175,6 +176,7 @@ jobs:
     needs: set-version
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
     with:
+      default-packages: ""
       runner: macos-14-xlarge
       python-version: '3.11'
       submodules: 'recursive'
@@ -315,6 +317,7 @@ jobs:
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
     secrets: inherit
     with:
+      default-packages: ""
       runner: macos-14-xlarge
       python-version: '3.11'
       submodules: 'recursive'

--- a/.github/workflows/build-presets.yml
+++ b/.github/workflows/build-presets.yml
@@ -20,6 +20,7 @@ jobs:
       matrix:
         preset: [macos, ios, ios-simulator, pybind, profiling, llm]
     with:
+      default-packages: ""
       job-name: build
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       runner: macos-14-xlarge

--- a/.github/workflows/metal.yml
+++ b/.github/workflows/metal.yml
@@ -25,6 +25,7 @@ jobs:
     name: test-executorch-metal-build
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
     with:
+      default-packages: ""
       runner: macos-m2-stable
       python-version: '3.11'
       submodules: 'recursive'
@@ -41,6 +42,7 @@ jobs:
     name: test-metal-backend-modules
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
     with:
+      default-packages: ""
       runner: macos-m2-stable
       python-version: '3.11'
       submodules: 'recursive'
@@ -65,6 +67,7 @@ jobs:
     name: test-metal-qwen35-moe-tiny
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
     with:
+      default-packages: ""
       runner: macos-m2-stable
       python-version: '3.11'
       submodules: 'recursive'
@@ -187,6 +190,7 @@ jobs:
               name: "Voxtral-Mini-4B-Realtime-2602"
             quant: "non-quantized"
     with:
+      default-packages: ""
       runner: macos-m2-stable
       python-version: '3.11'
       submodules: 'recursive'
@@ -252,6 +256,7 @@ jobs:
               name: "Voxtral-Mini-4B-Realtime-2602"
             quant: "non-quantized"
     with:
+      default-packages: ""
       runner: macos-m2-stable
       python-version: '3.11'
       submodules: 'recursive'

--- a/.github/workflows/mlx.yml
+++ b/.github/workflows/mlx.yml
@@ -28,6 +28,7 @@ jobs:
   test-mlx:
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
     with:
+      default-packages: ""
       job-name: test-mlx
       runner: macos-14-xlarge
       python-version: "3.12"
@@ -77,6 +78,7 @@ jobs:
   test-mlx-qwen35-moe:
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
     with:
+      default-packages: ""
       job-name: test-mlx-qwen35-moe
       runner: macos-14-xlarge
       python-version: "3.12"
@@ -132,6 +134,7 @@ jobs:
         suite: [models, operators]
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
     with:
+      default-packages: ""
       job-name: test-mlx-backend-${{ matrix.suite }}
       runner: macos-14-xlarge
       python-version: "3.12"
@@ -173,6 +176,7 @@ jobs:
   test-mlx-parakeet:
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
     with:
+      default-packages: ""
       job-name: test-mlx-parakeet
       runner: macos-14-xlarge
       python-version: "3.12"
@@ -231,6 +235,7 @@ jobs:
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
     secrets: inherit
     with:
+      default-packages: ""
       job-name: test-mlx-voxtral
       runner: macos-14-xlarge
       python-version: "3.12"
@@ -291,6 +296,7 @@ jobs:
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
     secrets: inherit
     with:
+      default-packages: ""
       job-name: test-mlx-voxtral-realtime
       runner: macos-14-xlarge
       python-version: "3.12"
@@ -366,6 +372,7 @@ jobs:
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
     secrets: inherit
     with:
+      default-packages: ""
       job-name: test-mlx-whisper
       runner: macos-14-xlarge
       python-version: "3.12"
@@ -413,6 +420,7 @@ jobs:
   test-mlx-stories110m:
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
     with:
+      default-packages: ""
       job-name: test-mlx-stories110m
       runner: macos-14-xlarge
       python-version: "3.12"
@@ -492,6 +500,7 @@ jobs:
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
     secrets: inherit
     with:
+      default-packages: ""
       job-name: test-mlx-llm-${{ matrix.model.name }}${{ matrix.use-custom && '-custom' || '' }}-${{ matrix.qconfig }}
       runner: macos-14-xlarge
       python-version: "3.12"

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -1521,6 +1521,7 @@ jobs:
         runner: [macos-m1-stable, macos-m2-stable]
       fail-fast: false
     with:
+      default-packages: ""
       runner: ${{ matrix.runner }}
       submodules: 'recursive'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -40,6 +40,7 @@ jobs:
             backend: portable
       fail-fast: false
     with:
+      default-packages: ""
       runner: macos-m1-stable
       python-version: '3.11'
       submodules: 'recursive'
@@ -275,6 +276,7 @@ jobs:
           - build-tool: cmake
       fail-fast: false
     with:
+      default-packages: ""
       runner: macos-m1-stable
       python-version: '3.11'
       submodules: 'recursive'
@@ -297,6 +299,7 @@ jobs:
           - build-tool: cmake
       fail-fast: false
     with:
+      default-packages: ""
       runner: macos-m1-stable
       python-version: '3.11'
       submodules: 'recursive'
@@ -457,6 +460,7 @@ jobs:
     name: test-coreml-delegate
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
     with:
+      default-packages: ""
       runner: macos-14-xlarge
       python-version: '3.11'
       submodules: 'recursive'
@@ -475,6 +479,7 @@ jobs:
     name: test-static-llama-ane
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
     with:
+      default-packages: ""
       runner: macos-m1-stable
       python-version: '3.11'
       submodules: 'recursive'
@@ -497,6 +502,7 @@ jobs:
     name: test-llama-torchao-lowbit
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
     with:
+      default-packages: ""
       runner: macos-m1-stable
       python-version: '3.11'
       submodules: 'recursive'
@@ -581,6 +587,7 @@ jobs:
         mode: [mps, coreml, xnnpack+custom+quantize_kv]
       fail-fast: false
     with:
+      default-packages: ""
       runner: macos-m1-stable
       python-version: '3.11'
       submodules: 'recursive'
@@ -667,6 +674,7 @@ jobs:
       matrix:
         model: ["gemma3-4b"] # llava gives segfault so not covering.
     with:
+      default-packages: ""
       secrets-env: EXECUTORCH_HF_TOKEN
       runner: macos-15-xlarge
       python-version: '3.11'
@@ -754,6 +762,7 @@ jobs:
         model: [dl3, edsr, efficient_sam, emformer_join, emformer_transcribe, ic3, ic4, mobilebert, mv2, mv3, resnet50, vit, w2l]
       fail-fast: false
     with:
+      default-packages: ""
       runner: macos-m1-stable
       python-version: '3.11'
       submodules: 'recursive'
@@ -793,6 +802,7 @@ jobs:
     strategy:
       fail-fast: false
     with:
+      default-packages: ""
       runner: macos-m1-stable
       python-version: '3.11'
       submodules: 'recursive'
@@ -932,6 +942,7 @@ jobs:
         ]
       fail-fast: false
     with:
+      default-packages: ""
       secrets-env: EXECUTORCH_HF_TOKEN
       runner: macos-15-xlarge
       python-version: '3.11'


### PR DESCRIPTION
### Summary
pytorch/test-infra's setup-miniconda action pre-installs cmake=3.22 ninja=1.10 pkg-config=0.29 wheel=0.37 from the anaconda defaults channel into the conda env it sets up for macOS jobs. Our own setup-conda.sh then installs cmake=3.31.2 and friends from conda-forge into the same env, and reconciling the two channels' transitive deps (e.g. zlib=1.2.13 vs libzlib>=1.3.1, rhash=1.4.3 vs rhash>=1.4.5) has been intermittently failing the libmamba solver.

The companion test-infra PR exposes a default-packages input on macos_job.yml. Pass an empty string from every macos_job.yml callsite in this repo so the conda env created by setup-miniconda no longer pre-pollutes the env with defaults-channel packages we don't use, and our subsequent conda-forge install resolves cleanly.

This change has no effect until the [test-infra PR](https://github.com/pytorch/test-infra/pull/8033) lands. Once it's merged on test-infra@main, the workflows here pick it up automatically because executorch tracks @main for all test-infra references.

Authored with Claude Code.

### Test plan
CI