### PR TITLE
Improve Android Emulator Robustness

### DIFF
--- a/.github/workflows/_android.yml
+++ b/.github/workflows/_android.yml
@@ -109,6 +109,9 @@ jobs:
           ram-size: 16384M
           heap-size: 12288M
           force-avd-creation: false
-          disable-animations: true
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          # The action's built-in animation disabling runs immediately after
+          # boot and is not retried. Software-emulated boots can briefly drop
+          # adb there, so scripts/run_android_emulator.sh handles it instead.
+          disable-animations: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-metrics
           emulator-boot-timeout: 900

--- a/scripts/run_android_emulator.sh
+++ b/scripts/run_android_emulator.sh
@@ -10,21 +10,43 @@ set -ex
 # This script is originally adopted from https://github.com/pytorch/pytorch/blob/main/android/run_tests.sh
 ADB_PATH=$ANDROID_HOME/platform-tools/adb
 
+adb_shell_with_retries() {
+  local attempts="$1"
+  shift
+
+  for ((i = 1; i <= attempts; i++)); do
+    if "$ADB_PATH" shell "$@"; then
+      return 0
+    fi
+    sleep 5
+    "$ADB_PATH" wait-for-device
+  done
+
+  return 1
+}
+
 echo "Waiting for emulator boot to complete"
 # shellcheck disable=SC2016
 $ADB_PATH wait-for-device shell 'while [[ -z $(getprop sys.boot_completed) ]]; do sleep 5; done;'
+$ADB_PATH wait-for-device
+
+echo "Unlock emulator and disable animations"
+adb_shell_with_retries 5 input keyevent 82 || true
+adb_shell_with_retries 5 settings put global window_animation_scale 0.0 || true
+adb_shell_with_retries 5 settings put global transition_animation_scale 0.0 || true
+adb_shell_with_retries 5 settings put global animator_duration_scale 0.0 || true
 
 # The device will be created by ReactiveCircus/android-emulator-runner GHA
 echo "List all running emulators"
 $ADB_PATH devices
 
-adb uninstall org.pytorch.executorch.test || true
-adb install -t android-test-debug-androidTest.apk
+"$ADB_PATH" uninstall org.pytorch.executorch.test || true
+"$ADB_PATH" install -t android-test-debug-androidTest.apk
 
-adb logcat -c
-adb shell am instrument -w -r \
+"$ADB_PATH" logcat -c
+"$ADB_PATH" shell am instrument -w -r \
   org.pytorch.executorch.test/androidx.test.runner.AndroidJUnitRunner >result.txt 2>&1
-adb logcat -d > logcat.txt
+"$ADB_PATH" logcat -d > logcat.txt
 cat logcat.txt
 grep -q FAILURES result.txt && cat result.txt
 grep -q FAILURES result.txt && exit -1


### PR DESCRIPTION
Disabling animations sometimes cant happen right after a slow boot. Moving disabling animations to the script where we can retry. Did some general cleaning of other possible sources of flakiness as well.

Authored with codex
