### PR TITLE
Move CUDAGuard/CUDAStreamGuard static_assert tests out of CUDA fixtures

### DIFF
--- a/backends/aoti/slim/cuda/test/test_cuda_guard.cpp
+++ b/backends/aoti/slim/cuda/test/test_cuda_guard.cpp
@@ -94,19 +94,22 @@ TEST_F(CUDAGuardTest, NegativeDeviceIndex) {
   EXPECT_FALSE(guard_result.ok());
 }
 
-TEST_F(CUDAGuardTest, CopyConstructorDeleted) {
+// Compile-time type-trait checks. These do not need a CUDA device, so they
+// live outside the CUDAGuardTest fixture (whose SetUp() calls GTEST_SKIP
+// when no CUDA device is available).
+TEST(CUDAGuardCompileTimeTest, CopyConstructorDeleted) {
   static_assert(
       !std::is_copy_constructible_v<CUDAGuard>,
       "CUDAGuard should not be copy constructible");
 }
 
-TEST_F(CUDAGuardTest, CopyAssignmentDeleted) {
+TEST(CUDAGuardCompileTimeTest, CopyAssignmentDeleted) {
   static_assert(
       !std::is_copy_assignable_v<CUDAGuard>,
       "CUDAGuard should not be copy assignable");
 }
 
-TEST_F(CUDAGuardTest, MoveAssignmentDeleted) {
+TEST(CUDAGuardCompileTimeTest, MoveAssignmentDeleted) {
   static_assert(
       !std::is_move_assignable_v<CUDAGuard>,
       "CUDAGuard should not be move assignable");

--- a/backends/aoti/slim/cuda/test/test_cuda_stream_guard.cpp
+++ b/backends/aoti/slim/cuda/test/test_cuda_stream_guard.cpp
@@ -234,19 +234,22 @@ TEST_F(CUDAStreamGuardTest, NegativeDeviceIndex) {
   EXPECT_FALSE(guard_result.ok());
 }
 
-TEST_F(CUDAStreamGuardTest, CopyConstructorDeleted) {
+// Compile-time type-trait checks. These do not need a CUDA device, so they
+// live outside the CUDAStreamGuardTest fixture (whose SetUp() calls
+// GTEST_SKIP when no CUDA device is available).
+TEST(CUDAStreamGuardCompileTimeTest, CopyConstructorDeleted) {
   static_assert(
       !std::is_copy_constructible_v<CUDAStreamGuard>,
       "CUDAStreamGuard should not be copy constructible");
 }
 
-TEST_F(CUDAStreamGuardTest, CopyAssignmentDeleted) {
+TEST(CUDAStreamGuardCompileTimeTest, CopyAssignmentDeleted) {
   static_assert(
       !std::is_copy_assignable_v<CUDAStreamGuard>,
       "CUDAStreamGuard should not be copy assignable");
 }
 
-TEST_F(CUDAStreamGuardTest, MoveAssignmentDeleted) {
+TEST(CUDAStreamGuardCompileTimeTest, MoveAssignmentDeleted) {
   static_assert(
       !std::is_move_assignable_v<CUDAStreamGuard>,
       "CUDAStreamGuard should not be move assignable");


### PR DESCRIPTION
Summary:
The 6 type-trait checks below were defined as TEST_F(CUDAGuardTest, ...)
and TEST_F(CUDAStreamGuardTest, ...). Both fixtures' SetUp() calls
GTEST_SKIP() when no CUDA device is available, so on every test host
without an attached GPU these tests skip instead of running:

  CUDAGuardTest.CopyConstructorDeleted
  CUDAGuardTest.CopyAssignmentDeleted
  CUDAGuardTest.MoveAssignmentDeleted
  CUDAStreamGuardTest.CopyConstructorDeleted
  CUDAStreamGuardTest.CopyAssignmentDeleted
  CUDAStreamGuardTest.MoveAssignmentDeleted

Because they never produced a successful run (Passes: 0 across 173 / 23
runs, all skips), TestX auto-disabled them and they show up as DISABLED
on the executorch dashboard.

These are pure compile-time static_assert checks. They do not need a
CUDA device or any runtime state — if the file compiles, they pass.
Move them into a separate non-fixture test suite (CUDAGuardCompileTimeTest /
CUDAStreamGuardCompileTimeTest) so they run unconditionally.

The remaining 15 fixture-based tests still need a real CUDA device and
will be addressed separately (fixing the gpu-remote-execution platform
deps so cudaGetDeviceCount returns a non-zero value).

Reviewed By: Gasoonjia

Differential Revision: D103937761


