### PR TITLE
Restrict XOR python export targets to fbcode

### DIFF
--- a/extension/training/examples/XOR/targets.bzl
+++ b/extension/training/examples/XOR/targets.bzl
@@ -1,4 +1,4 @@
-load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "is_xplat", "runtime")
 
 def define_common_targets():
     """Defines targets that should be shared between fbcode and xplat.
@@ -23,30 +23,34 @@ def define_common_targets():
         define_static_target = True,
     )
 
-    runtime.python_library(
-        name = "model",
-        srcs = ["model.py"],
-        visibility = [],  # Private
-        deps = [
-            "//caffe2:torch",
-        ],
-    )
+    # The Python export targets depend on `//caffe2:torch` and
+    # `//executorch/exir:lib`, neither of which exist as xplat (fbsource)
+    # targets. Restrict these to fbcode only.
+    if not is_xplat():
+        runtime.python_library(
+            name = "model",
+            srcs = ["model.py"],
+            visibility = [],  # Private
+            deps = [
+                "//caffe2:torch",
+            ],
+        )
 
-    runtime.python_library(
-        name = "export_model_lib",
-        srcs = ["export_model.py"],
-        visibility = ["//executorch/extension/training/examples/XOR/..."],
-        deps = [
-            ":model",
-            "//caffe2:torch",
-            "//executorch/exir:lib",
-        ],
-    )
+        runtime.python_library(
+            name = "export_model_lib",
+            srcs = ["export_model.py"],
+            visibility = ["//executorch/extension/training/examples/XOR/..."],
+            deps = [
+                ":model",
+                "//caffe2:torch",
+                "//executorch/exir:lib",
+            ],
+        )
 
-    runtime.python_binary(
-        name = "export_model",
-        main_module = "executorch.extension.training.examples.XOR.export_model",
-        deps = [
-            ":export_model_lib",
-        ],
-    )
+        runtime.python_binary(
+            name = "export_model",
+            main_module = "executorch.extension.training.examples.XOR.export_model",
+            deps = [
+                ":export_model_lib",
+            ],
+        )


### PR DESCRIPTION
Summary:
`xplat/executorch/extension/training/examples/XOR/BUCK` invokes
`define_common_targets()` for both fbcode (`fbcode_target`) and xplat
(`non_fbcode_target`). The python targets in this example
(`model`, `export_model_lib`, `export_model`) depend on
`//caffe2:torch` and `//executorch/exir:lib`, neither of which is
defined as an xplat target — `xplat/executorch/exir/BUCK` only
declares the `:lib` target via `fbcode_target(...)`. As a result the
xplat configuration of `fbsource//xplat/executorch/extension/training/examples/XOR:export_model`
fails analysis with:

  Unknown target `lib` from package `fbsource//xplat/executorch/exir`.
  Did you mean one of the 0 targets in fbsource//xplat/executorch/exir:BUCK?

This produced 218/218 BUILD_RULE failures on the
`fbsource//xplat/executorch/extension/training/examples/XOR:export_model`
target with no successful run on record (linked to T168807700).

Wrap the three python rules with `if not is_xplat():` so they only
register when called from fbcode, matching the established precedent
in `xplat/executorch/kernels/portable/test/targets.bzl`. The
`train_xor` C++ binary continues to be defined for both cells since
its dependencies are xplat-compatible.

Differential Revision: D103951555


