### PR TITLE
Re-apply U55 reject split for bool permute test

### DIFF
--- a/backends/arm/test/ops/test_permute.py
+++ b/backends/arm/test/ops/test_permute.py
@@ -17,6 +17,7 @@ from executorch.backends.arm.test import common
 from executorch.backends.arm.test.tester.test_pipeline import (
     EthosU55PipelineINT,
     EthosU85PipelineINT,
+    OpNotSupportedPipeline,
     TosaPipelineFP,
     TosaPipelineINT,
     VgfPipeline,
@@ -39,6 +40,9 @@ test_data_suite = {
     "rank_3_large": lambda: (torch.rand(16, 64, 65), [1, 2, 0]),
     "reshape_large_1": lambda: (torch.rand(1, 1, 65537), [0, 2, 1]),
     "reshape_large_2": lambda: (torch.rand(65537, 1, 1), [1, 2, 0]),
+}
+
+test_data_suite_u55_reject = {
     "rank2_bool": lambda: (torch.randint(0, 2, (5, 5), dtype=torch.bool), [1, 0]),
 }
 
@@ -111,10 +115,19 @@ def test_permute_u55_INT(test_data):
         aten_op,
         exir_ops="executorch_exir_dialects_edge__ops_aten_permute_copy_default",
     )
-    if test_data[0].dtype == torch.bool:
-        pipeline.tester.use_portable_ops = True
-        pipeline.pop_stage("check_count.exir")
-        pipeline.pop_stage("check_not.exir")
+    pipeline.run()
+
+
+@common.parametrize("test_data", test_data_suite_u55_reject)
+def test_permute_u55_INT_not_delegated(test_data: torch.Tensor):
+    test_data, dims = test_data()
+    pipeline = OpNotSupportedPipeline[input_t1](
+        SimplePermute(dims=dims),
+        (test_data,),
+        non_delegated_ops={exir_op: 1},
+        quantize=True,
+        u55_subset=True,
+    )
     pipeline.run()
 
 


### PR DESCRIPTION
Summary:
Forward fix on top of D103817917 (`Arm backend: Cleanup dim-order
and permute handling` — DiffTrain import of upstream PR #19278).

D103817917 reverted an internally-applied test split: the bool
permute case (`rank2_bool`) is U55-rejected and was already moved
out of the U55-delegating test on master into a separate
`test_data_suite_u55_reject` set with a dedicated
`test_permute_u55_INT_not_delegated` test using
`OpNotSupportedPipeline`. Upstream PR #19278 doesn't include that
split, so the DiffTrain import wipes it out and brings back the
combined `test_data_suite` + special-cased bool branch in
`test_permute_u55_INT`. That regresses CI:
`test_permute_u55_INT[rank2_bool]` is reported as a critical
LAND_BLOCKING failure on D103817917.

Re-apply the split so trunk returns to the clean form after
D103817917 lands:
- Add `OpNotSupportedPipeline` import.
- Move `rank2_bool` out of `test_data_suite` into a new
  `test_data_suite_u55_reject` dict.
- Drop the dead `if test_data[0].dtype == torch.bool: ...`
  workaround block from `test_permute_u55_INT` (no bool flows
  through this test anymore).
- Add `test_permute_u55_INT_not_delegated` parametrized over
  `test_data_suite_u55_reject`, exercising
  `OpNotSupportedPipeline` with `u55_subset=True`.

The `test_data_suite_u55` dict introduced by D103817917 (large
permutes that only U55 needs to exercise) is preserved unchanged.

Differential Revision: D103963260




cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell