### PR TITLE
Arm backend: Move import in DecomposePermuteForU55Pass

### DIFF
--- a/backends/arm/_passes/decompose_permute_for_u55_pass.py
+++ b/backends/arm/_passes/decompose_permute_for_u55_pass.py
@@ -14,7 +14,6 @@ import tosa_serializer as ts
 from executorch.backends.arm._passes.arm_pass import ArmPass
 from executorch.backends.arm._passes.rewrite_slice import RewriteSlicePass
 from executorch.backends.arm.arm_vela import vela_compile
-from executorch.backends.arm.ethosu.compile_spec import EthosUCompileSpec
 from executorch.backends.arm.tosa.mapping import map_dtype
 from executorch.backends.arm.tosa.specification import get_context_spec
 from executorch.exir.dialects._ops import ops as exir_ops
@@ -111,6 +110,9 @@ class DecomposePermuteForU55Pass(ArmPass):
         """Performs a Vela compilation of a permute with given shape,
         permutation and dtype to check wheter it is supported.
         """
+
+        # Lazy import to avoid circular dependency
+        from executorch.backends.arm.ethosu.compile_spec import EthosUCompileSpec
 
         if dtype not in (torch.int8, torch.bool, torch.int16):
             return True


### PR DESCRIPTION
Importing on top-level causes a dependency cycle


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell