### PR TITLE
Fix nullable-to-nonnull conversion errors in ExecuTorchModule.mm for Xcode 26 (#19335) (#19335)

### DIFF
--- a/extension/apple/ExecuTorch/Exported/ExecuTorchModule.mm
+++ b/extension/apple/ExecuTorch/Exported/ExecuTorchModule.mm
@@ -284,11 +284,11 @@ static inline ExecuTorchValue *toExecuTorchValue(EValue value) NS_RETURNS_RETAIN
     std::vector<std::string> dataFilePathsVector;
     if (dataFilePaths != nil) {
       for (NSString *dataFile in dataFilePaths) {
-        dataFilePathsVector.emplace_back(dataFile.UTF8String);
+        dataFilePathsVector.emplace_back(dataFile.UTF8String ?: "");
       }
     }
     _module = std::make_unique<Module>(
-      filePath.UTF8String,
+      filePath.UTF8String ?: "",
       dataFilePathsVector,
       static_cast<Module::LoadMode>(loadMode)
     );
@@ -340,7 +340,7 @@ static inline ExecuTorchValue *toExecuTorchValue(EValue value) NS_RETURNS_RETAIN
 
 - (BOOL)loadMethod:(NSString *)methodName
              error:(NSError **)error {
-  const auto errorCode = _module->load_method(methodName.UTF8String);
+  const auto errorCode = _module->load_method(methodName.UTF8String ?: "");
   if (errorCode != Error::Ok) {
     if (error) {
       *error = ExecuTorchErrorWithCode((ExecuTorchErrorCode)errorCode);
@@ -425,11 +425,11 @@ static inline ExecuTorchValue *toExecuTorchValue(EValue value) NS_RETURNS_RETAIN
 }
 
 - (BOOL)isMethodLoaded:(NSString *)methodName {
-  return _module->is_method_loaded(methodName.UTF8String);
+  return _module->is_method_loaded(methodName.UTF8String ?: "");
 }
 
 - (BOOL)unloadMethod:(NSString *)methodName {
-  const auto didUnload = _module->unload_method(methodName.UTF8String);
+  const auto didUnload = _module->unload_method(methodName.UTF8String ?: "");
   [_inputs removeObjectForKey:methodName];
   [_outputs removeObjectForKey:methodName];
   return didUnload;
@@ -452,7 +452,7 @@ static inline ExecuTorchValue *toExecuTorchValue(EValue value) NS_RETURNS_RETAIN
 
 - (nullable ExecuTorchMethodMetadata *)methodMetadata:(NSString *)methodName
                                                 error:(NSError **)error {
-  const auto result = _module->method_meta(methodName.UTF8String);
+  const auto result = _module->method_meta(methodName.UTF8String ?: "");
   if (!result.ok()) {
     if (error) {
       *error = ExecuTorchErrorWithCode((ExecuTorchErrorCode)result.error());
@@ -466,7 +466,7 @@ static inline ExecuTorchValue *toExecuTorchValue(EValue value) NS_RETURNS_RETAIN
 - (nullable NSArray<ExecuTorchValue *> *)executeMethod:(NSString *)methodName
                                             withInputs:(NSArray<ExecuTorchValue *> *)values
                                                  error:(NSError **)error {
-  const char *methodNameString = methodName.UTF8String;
+  const char *methodNameString = methodName.UTF8String ?: "";
   __block auto errorCode = Error::Ok;
   [values enumerateObjectsUsingBlock:^(ExecuTorchValue *value, NSUInteger index, BOOL *stop) {
     errorCode = _module->set_input(methodNameString, toEValue(value), index);
@@ -597,7 +597,7 @@ static inline ExecuTorchValue *toExecuTorchValue(EValue value) NS_RETURNS_RETAIN
        forMethod:(NSString *)methodName
          atIndex:(NSInteger)index
            error:(NSError **)error {
-  const auto errorCode = _module->set_input(methodName.UTF8String, toEValue(value), index);
+  const auto errorCode = _module->set_input(methodName.UTF8String ?: "", toEValue(value), index);
   if (errorCode != Error::Ok) {
     if (error) {
       *error = ExecuTorchErrorWithCode((ExecuTorchErrorCode)errorCode);
@@ -637,7 +637,7 @@ static inline ExecuTorchValue *toExecuTorchValue(EValue value) NS_RETURNS_RETAIN
   for (ExecuTorchValue *value in values) {
     inputs.push_back(toEValue(value));
   }
-  const auto errorCode = _module->set_inputs(methodName.UTF8String, inputs);
+  const auto errorCode = _module->set_inputs(methodName.UTF8String ?: "", inputs);
   if (errorCode != Error::Ok) {
     if (error) {
       *error = ExecuTorchErrorWithCode((ExecuTorchErrorCode)errorCode);
@@ -680,7 +680,7 @@ static inline ExecuTorchValue *toExecuTorchValue(EValue value) NS_RETURNS_RETAIN
         forMethod:(NSString *)methodName
           atIndex:(NSInteger)index
             error:(NSError **)error {
-  const auto errorCode = _module->set_output(methodName.UTF8String, toEValue(value), index);
+  const auto errorCode = _module->set_output(methodName.UTF8String ?: "", toEValue(value), index);
   if (errorCode != Error::Ok) {
     if (error) {
       *error = ExecuTorchErrorWithCode((ExecuTorchErrorCode)errorCode);


### PR DESCRIPTION
Summary:
In Xcode 26 (xcodestaging), NSString.UTF8String is annotated as returning a nullable pointer (const char * _Nullable). When this value is passed directly to C++ methods that expect const char * _Nonnull, the compiler emits -Wnullable-to-nonnull-conversion warnings which are promoted to errors via -Werror. This causes a build failure in xplat/executorch/extension/apple:ExecuTorch that blocks downstream test targets including BSLInspirationActionsTests owned by edits_workflows_ios.

The fix adds ?: "" (nil-coalescing to empty string) at each call site where methodName.UTF8String or similar is passed to a C++ API expecting a non-null pointer. Since the methodName parameters are already typed as nonnull NSString *, the fallback is defensive only — it satisfies the compiler nullability analysis without changing runtime behavior.

Pulled By:
anviatmeta


anviatmeta

Differential Revision: D103724159


