### PR TITLE
Fix ExecutorTorch → ExecuTorch in comments only

### DIFF
--- a/backends/mlx/llm/cache.py
+++ b/backends/mlx/llm/cache.py
@@ -23,7 +23,7 @@ from executorch.backends.mlx import custom_ops as _mlx_custom_ops  # noqa: F401
 
 class KVCache(nn.Module):
     """
-    MLX-optimized KV cache with ExecutorTorch llama KVCache interface.
+    MLX-optimized KV cache with ExecuTorch llama KVCache interface.
 
     This class follows the same interface as examples/models/llama/attention.py KVCache,
     making it a drop-in replacement, but uses the mlx::kv_cache_update op internally

--- a/backends/mlx/llm/et_attention.py
+++ b/backends/mlx/llm/et_attention.py
@@ -7,7 +7,7 @@
 # LICENSE file in the root directory of this source tree.
 
 """
-MLX-optimized attention for ExecutorTorch's Llama attention registry.
+MLX-optimized attention for ExecuTorch's Llama attention registry.
 
 Registers an "mlx" attention type that uses mlx::kv_cache_update and
 mlx::custom_sdpa for efficient execution on Apple Silicon.

--- a/backends/mlx/test/test_ops.py
+++ b/backends/mlx/test/test_ops.py
@@ -1810,7 +1810,7 @@ class KVCacheModel(nn.Module):
     """
     Test model wrapping KVCache from cache.py.
 
-    This tests the ExecutorTorch llama KVCache-compatible interface that uses
+    This tests the ExecuTorch llama KVCache-compatible interface that uses
     the mlx::kv_cache_update op internally.
     """
 
@@ -1845,7 +1845,7 @@ class KVCacheModel(nn.Module):
 @register_test
 class KVCacheTest(OpTestCase):
     """
-    Test case for MLX KVCache with ExecutorTorch llama KVCache interface.
+    Test case for MLX KVCache with ExecuTorch llama KVCache interface.
 
     This verifies that KVCache:
     1. Accepts the ET llama KVCache update interface


### PR DESCRIPTION
Summary: Correct common misspelling.

Differential Revision: D104074211


