### PR TITLE
[DO NOT MERGE] ci: instrument HF download paths to diagnose stalls

### DIFF
--- a/.ci/scripts/export_model_artifact.sh
+++ b/.ci/scripts/export_model_artifact.sh
@@ -67,6 +67,15 @@ if [ -z "${1:-}" ]; then
   exit 1
 fi
 
+# DO NOT MERGE: diagnostic instrumentation for HF download stalls. CUDA jobs
+# have been silently hanging mid-`snapshot_download` until the 90-min job
+# timeout fires, with no exception logged. These flags surface what the
+# huggingface_hub / httpx / httpcore stack is doing, and let faulthandler
+# dump a traceback every 60s so we can see where the process is actually
+# stuck. Revert once we have signal.
+export HF_HUB_VERBOSITY=debug
+export PYTHONUNBUFFERED=1
+
 set -eux
 
 DEVICE="$1"
@@ -333,7 +342,14 @@ if [ "$MODEL_NAME" = "voxtral_realtime" ]; then
 
   # Download model weights from HuggingFace (requires HF_TOKEN for gated model)
   LOCAL_MODEL_DIR="${OUTPUT_DIR}/model_weights"
-  python -c "from huggingface_hub import snapshot_download; snapshot_download('${HF_MODEL}', local_dir='${LOCAL_MODEL_DIR}')"
+  # DO NOT MERGE: faulthandler + verbose logging to diagnose HF stalls.
+  python -c "
+import faulthandler, logging, sys
+faulthandler.dump_traceback_later(60, repeat=True, file=sys.stderr)
+logging.basicConfig(level=logging.DEBUG, format='%(asctime)s [%(name)s] %(levelname)s: %(message)s', force=True, stream=sys.stderr)
+from huggingface_hub import snapshot_download
+snapshot_download('${HF_MODEL}', local_dir='${LOCAL_MODEL_DIR}')
+"
 
   # Per-component quantization flags
   VR_QUANT_ARGS=""
@@ -398,7 +414,14 @@ if [ "$MODEL_NAME" = "qwen3_5_moe" ]; then
   INDUCTOR_CACHE=$(mktemp -d)
   trap 'rm -rf "$LOCAL_MODEL_DIR" "$INDUCTOR_CACHE"' EXIT
 
-  python -c "from huggingface_hub import snapshot_download; snapshot_download('${HF_MODEL}', local_dir='${LOCAL_MODEL_DIR}')"
+  # DO NOT MERGE: faulthandler + verbose logging to diagnose HF stalls.
+  python -c "
+import faulthandler, logging, sys
+faulthandler.dump_traceback_later(60, repeat=True, file=sys.stderr)
+logging.basicConfig(level=logging.DEBUG, format='%(asctime)s [%(name)s] %(levelname)s: %(message)s', force=True, stream=sys.stderr)
+from huggingface_hub import snapshot_download
+snapshot_download('${HF_MODEL}', local_dir='${LOCAL_MODEL_DIR}')
+"
 
   # Sanity check: run inference on the prequantized model
   echo "::group::Inference sanity check"

--- a/.ci/scripts/test_huggingface_optimum_model.py
+++ b/.ci/scripts/test_huggingface_optimum_model.py
@@ -1,24 +1,46 @@
 import argparse
+import faulthandler
 import gc
 import logging
 import math
+import os
 import shutil
 import subprocess
+import sys
 import tempfile
 import time
 from pathlib import Path
 from typing import List
 
-import torch
-from datasets import load_dataset
+# DO NOT MERGE: diagnostic instrumentation for HF download stalls. CUDA jobs
+# have been silently hanging mid-download with no exception logged. Dump a
+# traceback every 60s so we can see where the process is actually stuck,
+# turn on verbose huggingface_hub/httpx/httpcore logging, and force every
+# child process invoked via `subprocess.run` (notably `optimum-cli export`)
+# to inherit HF_HUB_VERBOSITY=debug and PYTHONUNBUFFERED=1. Revert once we
+# have signal.
+faulthandler.dump_traceback_later(60, repeat=True, file=sys.stderr)
+logging.basicConfig(
+    level=logging.DEBUG,
+    format="%(asctime)s [%(name)s] %(levelname)s: %(message)s",
+    force=True,
+    stream=sys.stderr,
+)
+for _name in ("huggingface_hub", "httpx", "httpcore", "urllib3"):
+    logging.getLogger(_name).setLevel(logging.DEBUG)
+os.environ.setdefault("HF_HUB_VERBOSITY", "debug")
+os.environ.setdefault("PYTHONUNBUFFERED", "1")
 
-from optimum.executorch import (
+import torch  # noqa: E402
+from datasets import load_dataset  # noqa: E402
+
+from optimum.executorch import (  # noqa: E402
     ExecuTorchModelForImageClassification,
     ExecuTorchModelForMaskedLM,
     ExecuTorchModelForSeq2SeqLM,
     ExecuTorchModelForSpeechSeq2Seq,
 )
-from transformers import (
+from transformers import (  # noqa: E402
     AutoConfig,
     AutoModelForCausalLM,
     AutoModelForImageClassification,

--- a/.github/workflows/mlx.yml
+++ b/.github/workflows/mlx.yml
@@ -307,6 +307,10 @@ jobs:
       script: |
         set -eux
 
+        # DO NOT MERGE: diagnostic instrumentation for HF download stalls.
+        export HF_HUB_VERBOSITY=debug
+        export PYTHONUNBUFFERED=1
+
         echo "::group::Install ExecuTorch"
         ${CONDA_RUN} python install_executorch.py > /dev/null
         echo "::endgroup::"
@@ -318,7 +322,14 @@ jobs:
         ${CONDA_RUN} pip list
 
         echo "::group::Download model"
-        HF_TOKEN=$SECRET_EXECUTORCH_HF_TOKEN ${CONDA_RUN} python -c "from huggingface_hub import snapshot_download; snapshot_download('mistralai/Voxtral-Mini-4B-Realtime-2602')"
+        # DO NOT MERGE: faulthandler + verbose logging to diagnose HF stalls.
+        HF_TOKEN=$SECRET_EXECUTORCH_HF_TOKEN ${CONDA_RUN} python -c "
+import faulthandler, logging, sys
+faulthandler.dump_traceback_later(60, repeat=True, file=sys.stderr)
+logging.basicConfig(level=logging.DEBUG, format='%(asctime)s [%(name)s] %(levelname)s: %(message)s', force=True, stream=sys.stderr)
+from huggingface_hub import snapshot_download
+snapshot_download('mistralai/Voxtral-Mini-4B-Realtime-2602')
+"
         MODEL_PATH=$(HF_TOKEN=$SECRET_EXECUTORCH_HF_TOKEN ${CONDA_RUN} python -c "from huggingface_hub import snapshot_download; print(snapshot_download('mistralai/Voxtral-Mini-4B-Realtime-2602'))")
         echo "Model path: ${MODEL_PATH}"
         echo "::endgroup::"


### PR DESCRIPTION
CUDA jobs that download HuggingFace model weights have been silently hanging mid-download until the 90-min job timeout fires, with no exception logged and no progress-bar updates. Running theories (library version, hf_xet, empty-chunk filtering) are speculation without instrumentation.

Add diagnostic instrumentation to the three known surfaces:
- `export_model_artifact.sh`'s two `snapshot_download` python -c calls plus the surrounding env (HF_HUB_VERBOSITY=debug, PYTHONUNBUFFERED=1)
- `test_huggingface_optimum_model.py`'s top-level setup, before any import that transitively pulls in huggingface_hub
- `mlx.yml`'s inline Voxtral snapshot_download

Each Python entry point installs `faulthandler.dump_traceback_later (60, repeat=True)` so a hung process surfaces a stack trace every 60s — pinpointing exactly where execution is stuck. DEBUG-level logging on `huggingface_hub`, `httpx`, `httpcore`, `urllib3` shows the protocol-level conversation.

Revert once we have signal from a stalled run.

Authored with Claude Code.

