### PR TITLE
Disable HF Xet storage to fix CI export timeouts

### DIFF
--- a/.ci/scripts/export_model_artifact.sh
+++ b/.ci/scripts/export_model_artifact.sh
@@ -67,6 +67,8 @@ if [ -z "${1:-}" ]; then
   exit 1
 fi
 
+export HF_HUB_DISABLE_XET=1
+
 set -eux
 
 DEVICE="$1"


### PR DESCRIPTION
HuggingFace's Xet storage backend stalls mid-download on CI runners, causing the 90-minute job timeout to fire before model weights finish downloading. Force standard HTTP downloads instead.

(from debug logs in #19352)