### PR TITLE
Add cuBLAS mm_out shim to eliminate libtorch runtime dependency

### DIFF
--- a/backends/cuda/CMakeLists.txt
+++ b/backends/cuda/CMakeLists.txt
@@ -111,7 +111,7 @@ set(_aoti_cuda_shim_sources runtime/shims/memory.cpp
 if(CMAKE_CUDA_COMPILER)
   list(APPEND _aoti_cuda_shim_sources runtime/shims/int4mm.cu
        runtime/shims/int4_plain_mm.cu runtime/shims/sort.cu
-       runtime/shims/rand.cu
+       runtime/shims/rand.cu runtime/shims/mm.cu
   )
 endif()
 
@@ -154,7 +154,7 @@ endif()
 if(_cuda_is_msvc_toolchain)
   target_link_libraries(
     aoti_cuda_shims PRIVATE cuda_platform CUDA::cudart CUDA::curand
-                            ${CMAKE_DL_LIBS}
+                            CUDA::cublas ${CMAKE_DL_LIBS}
   )
   # Link object library directly so symbols are pulled exactly once while
   # avoiding duplicate static/object inclusion and interface leakage.
@@ -163,8 +163,13 @@ else()
   target_link_libraries(
     aoti_cuda_shims
     PRIVATE cuda_platform
-    PUBLIC -Wl,--whole-archive aoti_common_shims_slim -Wl,--no-whole-archive
-           CUDA::cudart CUDA::curand ${CMAKE_DL_LIBS}
+    PUBLIC -Wl,--whole-archive
+           aoti_common_shims_slim
+           -Wl,--no-whole-archive
+           CUDA::cudart
+           CUDA::curand
+           CUDA::cublas
+           ${CMAKE_DL_LIBS}
   )
 endif()
 

--- a/backends/cuda/cuda_backend.py
+++ b/backends/cuda/cuda_backend.py
@@ -228,6 +228,7 @@ class CudaBackend(AotiBackend, BackendDetails):
             "aoti_torch_cuda_randint_low_out": None,
             "executorch_cuda::int4_plain_mm": None,
             "aoti_torch_cuda_int4_plain_mm": None,
+            "aoti_torch_cuda_mm_out": None,
         }
 
     @classmethod

--- a/backends/cuda/runtime/shims/mm.cu
+++ b/backends/cuda/runtime/shims/mm.cu
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <cublas_v2.h>
+#include <cuda_runtime.h>
+
+#include <executorch/backends/aoti/slim/c10/core/ScalarType.h>
+#include <executorch/backends/aoti/slim/cuda/guard.h>
+#include <executorch/backends/aoti/utils.h>
+#include <executorch/backends/cuda/runtime/shims/mm.h>
+
+#include <mutex>
+
+namespace executorch::backends::cuda {
+
+namespace c10_slim = executorch::backends::aoti::slim::c10;
+
+namespace {
+
+constexpr int kMaxDevices = 16;
+
+struct CuBLASHandles {
+  std::mutex mutex;
+  cublasHandle_t handles[kMaxDevices] = {};
+  bool initialized[kMaxDevices] = {};
+
+  // Caller must hold mutex.
+  cublasHandle_t get(int device) {
+    if (!initialized[device]) {
+      cudaSetDevice(device);
+      cublasCreate(&handles[device]);
+      cublasSetMathMode(handles[device], CUBLAS_DEFAULT_MATH);
+      initialized[device] = true;
+    }
+    return handles[device];
+  }
+};
+
+CuBLASHandles& cublas_handles() {
+  static CuBLASHandles instance;
+  return instance;
+}
+
+bool is_row_major(Tensor* t) {
+  return t->stride(1) == 1 && t->stride(0) == t->size(1);
+}
+
+bool is_col_major(Tensor* t) {
+  return t->stride(0) == 1 && t->stride(1) == t->size(0);
+}
+
+size_t dtype_size(c10_slim::ScalarType dtype) {
+  switch (dtype) {
+    case c10_slim::ScalarType::BFloat16:
+    case c10_slim::ScalarType::Half:
+      return 2;
+    case c10_slim::ScalarType::Float:
+      return 4;
+    default:
+      return 0;
+  }
+}
+
+// Make a contiguous row-major copy of a 2D tensor if it has non-standard
+// strides (broadcast, non-contiguous views). Returns the data pointer to use
+// and a device pointer to free (nullptr if no copy was made).
+void* ensure_contiguous(
+    Tensor* t,
+    int64_t rows,
+    int64_t cols,
+    size_t elem_size,
+    cudaStream_t stream,
+    void** to_free) {
+  *to_free = nullptr;
+  if (is_row_major(t) || is_col_major(t)) {
+    return t->data_ptr();
+  }
+  // Non-standard strides — allocate and copy row by row
+  size_t row_bytes = cols * elem_size;
+  void* dst = nullptr;
+  cudaMallocAsync(&dst, rows * row_bytes, stream);
+  int64_t s0 = t->stride(0) * elem_size;
+  int64_t s1 = t->stride(1) * elem_size;
+  char* src = static_cast<char*>(t->data_ptr());
+  if (s1 == static_cast<int64_t>(elem_size)) {
+    // Stride(1)==1 element but stride(0) is irregular (e.g., broadcast s0=0)
+    cudaMemcpy2DAsync(
+        dst, row_bytes, src, s0, row_bytes, rows, cudaMemcpyDeviceToDevice, stream);
+  } else {
+    // Fully general: copy element by element (slow, but correct)
+    // This shouldn't happen in practice from Inductor output.
+    for (int64_t i = 0; i < rows; i++) {
+      for (int64_t j = 0; j < cols; j++) {
+        cudaMemcpyAsync(
+            static_cast<char*>(dst) + (i * cols + j) * elem_size,
+            src + i * s0 + j * s1,
+            elem_size,
+            cudaMemcpyDeviceToDevice,
+            stream);
+      }
+    }
+  }
+  *to_free = dst;
+  return dst;
+}
+
+} // namespace
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+AOTITorchError
+aoti_torch_cuda_mm_out(Tensor* out, Tensor* self, Tensor* mat2) {
+  ET_CHECK_OR_RETURN_ERROR(
+      out != nullptr, InvalidArgument, "mm_out: out is null");
+  ET_CHECK_OR_RETURN_ERROR(
+      self != nullptr, InvalidArgument, "mm_out: self is null");
+  ET_CHECK_OR_RETURN_ERROR(
+      mat2 != nullptr, InvalidArgument, "mm_out: mat2 is null");
+  ET_CHECK_OR_RETURN_ERROR(
+      self->dim() == 2 && mat2->dim() == 2 && out->dim() == 2,
+      InvalidArgument,
+      "mm_out: all tensors must be 2D");
+
+  int64_t M = self->size(0);
+  int64_t K = self->size(1);
+  int64_t N = mat2->size(1);
+
+  ET_CHECK_OR_RETURN_ERROR(
+      mat2->size(0) == K,
+      InvalidArgument,
+      "mm_out: self [%ld,%ld] x mat2 [%ld,%ld] inner dims mismatch",
+      M, K, mat2->size(0), N);
+  ET_CHECK_OR_RETURN_ERROR(
+      out->size(0) == M && out->size(1) == N,
+      InvalidArgument,
+      "mm_out: out shape mismatch");
+  ET_CHECK_OR_RETURN_ERROR(
+      is_row_major(out), InvalidArgument, "mm_out: out must be contiguous");
+
+  auto dtype = self->dtype();
+  ET_CHECK_OR_RETURN_ERROR(
+      mat2->dtype() == dtype && out->dtype() == dtype,
+      InvalidArgument,
+      "mm_out: dtype mismatch");
+
+  cudaDataType_t cuda_dtype;
+  cublasComputeType_t compute_type;
+  if (dtype == c10_slim::ScalarType::BFloat16) {
+    cuda_dtype = CUDA_R_16BF;
+    compute_type = CUBLAS_COMPUTE_32F;
+  } else if (dtype == c10_slim::ScalarType::Half) {
+    cuda_dtype = CUDA_R_16F;
+    compute_type = CUBLAS_COMPUTE_32F;
+  } else if (dtype == c10_slim::ScalarType::Float) {
+    cuda_dtype = CUDA_R_32F;
+    compute_type = CUBLAS_COMPUTE_32F;
+  } else {
+    ET_CHECK_OR_RETURN_ERROR(
+        false, InvalidArgument, "mm_out: unsupported dtype");
+  }
+
+  int device = self->device_index();
+  ET_CHECK_OR_RETURN_ERROR(
+      device >= 0 && device < kMaxDevices,
+      InvalidArgument,
+      "mm_out: device index %d out of range", device);
+
+  auto stream_result = getCurrentCUDAStream(device);
+  ET_CHECK_OR_RETURN_ERROR(
+      stream_result.ok(), Internal, "mm_out: failed to get CUDA stream");
+  cudaStream_t stream = stream_result.get();
+
+  size_t elem_size = dtype_size(dtype);
+
+  // Ensure inputs are row-major or col-major for cuBLAS. Non-standard strides
+  // (broadcast, irregular views) get copied to a contiguous scratch buffer.
+  void* a_free = nullptr;
+  void* b_free = nullptr;
+  void* a_ptr = ensure_contiguous(self, M, K, elem_size, stream, &a_free);
+  void* b_ptr = ensure_contiguous(mat2, K, N, elem_size, stream, &b_free);
+
+  // After ensure_contiguous, non-standard inputs are now row-major.
+  bool a_row = a_free ? true : is_row_major(self);
+  bool b_row = b_free ? true : is_row_major(mat2);
+
+  auto& handles = cublas_handles();
+  std::lock_guard<std::mutex> lock(handles.mutex);
+  cublasHandle_t handle = handles.get(device);
+  cublasSetStream(handle, stream);
+
+  // cuBLAS uses column-major. A row-major [R,C] tensor is seen by cuBLAS
+  // as column-major [C,R] — already transposed. So:
+  //   row-major → CUBLAS_OP_N (already transposed in cuBLAS's view), ld=stride(0)
+  //   col-major → CUBLAS_OP_T (need cuBLAS to transpose), ld=stride(1)
+  //
+  // We call: C^T[N,M] = B^T[N,K] @ A^T[K,M]
+  //   → cublasGemmEx(op_b, op_a, N, M, K, B, ldb, A, lda, C, ldc)
+
+  cublasOperation_t op_a = a_row ? CUBLAS_OP_N : CUBLAS_OP_T;
+  cublasOperation_t op_b = b_row ? CUBLAS_OP_N : CUBLAS_OP_T;
+  int64_t lda = a_row ? (a_free ? K : self->stride(0))
+                      : self->stride(1);
+  int64_t ldb = b_row ? (b_free ? N : mat2->stride(0))
+                      : mat2->stride(1);
+  int64_t ldc = out->stride(0);
+
+  float alpha = 1.0f;
+  float beta = 0.0f;
+
+  auto status = cublasGemmEx(
+      handle,
+      op_b, op_a,
+      N, M, K,
+      &alpha,
+      b_ptr, cuda_dtype, ldb,
+      a_ptr, cuda_dtype, lda,
+      &beta,
+      out->data_ptr(), cuda_dtype, ldc,
+      compute_type,
+      CUBLAS_GEMM_DEFAULT);
+
+  // Free scratch buffers
+  if (a_free) cudaFreeAsync(a_free, stream);
+  if (b_free) cudaFreeAsync(b_free, stream);
+
+  ET_CHECK_OR_RETURN_ERROR(
+      status == CUBLAS_STATUS_SUCCESS,
+      Internal,
+      "mm_out: cublasGemmEx failed with status %d", (int)status);
+
+  return Error::Ok;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+} // namespace executorch::backends::cuda

--- a/backends/cuda/runtime/shims/mm.h
+++ b/backends/cuda/runtime/shims/mm.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cuda_runtime.h>
+#include <executorch/backends/aoti/common_shims_slim.h>
+#include <executorch/backends/aoti/export.h>
+
+namespace executorch::backends::cuda {
+
+using executorch::backends::aoti::AOTITorchError;
+using executorch::backends::aoti::Tensor;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Matrix multiplication via cuBLAS: out = self @ mat2.
+ *
+ * Replaces libtorch's aoti_torch_cuda_mm_out so the AOTI CUDA backend
+ * can run without libtorch_cuda.so. Calls cublasGemmEx directly.
+ *
+ * @param out  Pre-allocated output [M, N], same dtype as inputs.
+ * @param self Input matrix [M, K]. Must be bf16 or fp16, 2D, contiguous.
+ * @param mat2 Input matrix [K, N]. Must be bf16 or fp16, 2D, contiguous.
+ */
+AOTI_SHIM_EXPORT AOTITorchError
+aoti_torch_cuda_mm_out(Tensor* out, Tensor* self, Tensor* mat2);
+
+#ifdef __cplusplus
+}
+#endif
+
+} // namespace executorch::backends::cuda

--- a/backends/cuda/runtime/shims/tests/CMakeLists.txt
+++ b/backends/cuda/runtime/shims/tests/CMakeLists.txt
@@ -49,8 +49,10 @@ set(CUDA_SHIM_TESTS
 )
 
 # CUDA-specific tests requiring GPU kernels
-set(CUDA_KERNEL_TESTS test_aoti_torch_cuda__weight_int4pack_mm
-                      test_aoti_torch_cuda_int4_plain_mm
+set(CUDA_KERNEL_TESTS
+    test_aoti_torch_cuda__weight_int4pack_mm
+    test_aoti_torch_cuda_int4_plain_mm
+    test_aoti_torch_cuda_mm_out
 )
 
 enable_testing()

--- a/backends/cuda/runtime/shims/tests/targets.bzl
+++ b/backends/cuda/runtime/shims/tests/targets.bzl
@@ -42,3 +42,4 @@ def define_common_targets():
     cuda_shim_cpp_unittest("aoti_torch_new_tensor_handle")
     cuda_shim_cpp_unittest("aoti_torch_item_bool")
     cuda_shim_cpp_unittest("aoti_torch_assign_tensors_out")
+    cuda_shim_cpp_unittest("aoti_torch_cuda_mm_out")

--- a/backends/cuda/runtime/shims/tests/test_aoti_torch_cuda_mm_out.cpp
+++ b/backends/cuda/runtime/shims/tests/test_aoti_torch_cuda_mm_out.cpp
@@ -1,0 +1,300 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+#include <cmath>
+#include <vector>
+
+#include <executorch/backends/aoti/slim/c10/core/DeviceType.h>
+#include <executorch/backends/aoti/slim/c10/core/ScalarType.h>
+#include <executorch/backends/cuda/runtime/shims/memory.h>
+#include <executorch/backends/cuda/runtime/shims/mm.h>
+#include <executorch/runtime/core/error.h>
+#include <executorch/runtime/platform/platform.h>
+
+using executorch::backends::cuda::aoti_torch_cuda_mm_out;
+using executorch::backends::cuda::aoti_torch_delete_tensor_object;
+using executorch::backends::cuda::aoti_torch_empty_strided;
+using executorch::backends::cuda::AOTITorchError;
+using executorch::runtime::Error;
+namespace slim_c10 = executorch::backends::aoti::slim::c10;
+
+using Tensor = executorch::backends::aoti::slim::SlimTensor;
+
+// -- Dtype traits for templated tests ----------------------------------------
+
+template <typename T>
+struct DtypeTraits;
+
+template <>
+struct DtypeTraits<__nv_bfloat16> {
+  static constexpr slim_c10::ScalarType scalar_type =
+      slim_c10::ScalarType::BFloat16;
+  static __nv_bfloat16 from_float(float v) {
+    return __float2bfloat16(v);
+  }
+  static float to_float(__nv_bfloat16 v) {
+    return __bfloat162float(v);
+  }
+};
+
+template <>
+struct DtypeTraits<__half> {
+  static constexpr slim_c10::ScalarType scalar_type =
+      slim_c10::ScalarType::Half;
+  static __half from_float(float v) {
+    return __float2half(v);
+  }
+  static float to_float(__half v) {
+    return __half2float(v);
+  }
+};
+
+template <>
+struct DtypeTraits<float> {
+  static constexpr slim_c10::ScalarType scalar_type =
+      slim_c10::ScalarType::Float;
+  static float from_float(float v) {
+    return v;
+  }
+  static float to_float(float v) {
+    return v;
+  }
+};
+
+// -- Test fixture ------------------------------------------------------------
+
+template <typename T>
+class AOTITorchMmOutTypedTest : public ::testing::Test {
+ protected:
+  using Traits = DtypeTraits<T>;
+
+  void SetUp() override {
+    et_pal_init();
+    int device_count = 0;
+    if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count == 0) {
+      GTEST_SKIP() << "CUDA not available";
+    }
+  }
+
+  Tensor* createTensor(const std::vector<int64_t>& sizes) {
+    Tensor* tensor = nullptr;
+    AOTITorchError error = aoti_torch_empty_strided(
+        sizes.size(),
+        sizes.data(),
+        nullptr,
+        static_cast<int32_t>(Traits::scalar_type),
+        static_cast<int32_t>(slim_c10::DeviceType::CUDA),
+        0,
+        &tensor);
+    return (error == Error::Ok) ? tensor : nullptr;
+  }
+
+  // Small-integer reference: inputs are exactly representable in all dtypes,
+  // so cuBLAS output must match the serial f32 reference exactly.
+  void runExactTest(
+      int64_t M,
+      int64_t K,
+      int64_t N,
+      const std::vector<float>& h_A,
+      const std::vector<float>& h_B) {
+    Tensor* self = createTensor({M, K});
+    ASSERT_NE(self, nullptr);
+    Tensor* mat2 = createTensor({K, N});
+    ASSERT_NE(mat2, nullptr);
+    Tensor* out = createTensor({M, N});
+    ASSERT_NE(out, nullptr);
+
+    std::vector<T> d_A(M * K), d_B(K * N);
+    for (int64_t i = 0; i < M * K; i++)
+      d_A[i] = Traits::from_float(h_A[i]);
+    for (int64_t i = 0; i < K * N; i++)
+      d_B[i] = Traits::from_float(h_B[i]);
+
+    cudaMemcpy(
+        self->data_ptr(),
+        d_A.data(),
+        M * K * sizeof(T),
+        cudaMemcpyHostToDevice);
+    cudaMemcpy(
+        mat2->data_ptr(),
+        d_B.data(),
+        K * N * sizeof(T),
+        cudaMemcpyHostToDevice);
+
+    AOTITorchError error = aoti_torch_cuda_mm_out(out, self, mat2);
+    EXPECT_EQ(error, Error::Ok);
+    cudaDeviceSynchronize();
+
+    std::vector<T> h_out(M * N);
+    cudaMemcpy(
+        h_out.data(),
+        out->data_ptr(),
+        M * N * sizeof(T),
+        cudaMemcpyDeviceToHost);
+
+    // Serial f32 reference
+    for (int64_t i = 0; i < M; i++) {
+      for (int64_t j = 0; j < N; j++) {
+        float expected = 0.0f;
+        for (int64_t p = 0; p < K; p++) {
+          expected += h_A[i * K + p] * h_B[p * N + j];
+        }
+        float actual = Traits::to_float(h_out[i * N + j]);
+        EXPECT_EQ(actual, expected) << "Mismatch at [" << i << "," << j << "]";
+      }
+    }
+
+    EXPECT_EQ(aoti_torch_delete_tensor_object(self), Error::Ok);
+    EXPECT_EQ(aoti_torch_delete_tensor_object(mat2), Error::Ok);
+    EXPECT_EQ(aoti_torch_delete_tensor_object(out), Error::Ok);
+  }
+};
+
+using MmOutTestTypes = ::testing::Types<__nv_bfloat16, __half, float>;
+TYPED_TEST_SUITE(AOTITorchMmOutTypedTest, MmOutTestTypes);
+
+// -- Typed correctness tests (run for bf16, fp16, fp32) ----------------------
+// Use small integers so results are exact in all dtypes.
+
+TYPED_TEST(AOTITorchMmOutTypedTest, SmallSquare) {
+  int64_t M = 4, K = 8, N = 6;
+  std::vector<float> h_A(M * K), h_B(K * N);
+  for (int64_t i = 0; i < M * K; i++)
+    h_A[i] = static_cast<float>((i % 5) + 1);
+  for (int64_t i = 0; i < K * N; i++)
+    h_B[i] = static_cast<float>((i % 3) + 1);
+  this->runExactTest(M, K, N, h_A, h_B);
+}
+
+TYPED_TEST(AOTITorchMmOutTypedTest, SingleRow) {
+  int64_t M = 1, K = 16, N = 8;
+  std::vector<float> h_A(M * K), h_B(K * N);
+  for (int64_t i = 0; i < M * K; i++)
+    h_A[i] = static_cast<float>((i % 4) + 1);
+  for (int64_t i = 0; i < K * N; i++)
+    h_B[i] = static_cast<float>((i % 3) + 1);
+  this->runExactTest(M, K, N, h_A, h_B);
+}
+
+TYPED_TEST(AOTITorchMmOutTypedTest, AllOnes) {
+  int64_t M = 1, K = 2048, N = 256;
+  std::vector<float> h_A(M * K, 1.0f), h_B(K * N, 1.0f);
+  this->runExactTest(M, K, N, h_A, h_B);
+}
+
+TYPED_TEST(AOTITorchMmOutTypedTest, Identity) {
+  int64_t N = 32;
+  std::vector<float> h_A(N * N, 0.0f), h_B(N * N, 0.0f);
+  for (int64_t i = 0; i < N; i++) {
+    h_A[i * N + i] = 1.0f;
+    h_B[i * N + i] = static_cast<float>(i + 1);
+  }
+  this->runExactTest(N, N, N, h_A, h_B);
+}
+
+// -- Non-typed tests (contract validation) -----------------------------------
+
+class AOTITorchMmOutTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    et_pal_init();
+    int device_count = 0;
+    if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count == 0) {
+      GTEST_SKIP() << "CUDA not available";
+    }
+  }
+
+  Tensor* createTensor(
+      const std::vector<int64_t>& sizes,
+      slim_c10::ScalarType dtype) {
+    Tensor* tensor = nullptr;
+    AOTITorchError error = aoti_torch_empty_strided(
+        sizes.size(),
+        sizes.data(),
+        nullptr,
+        static_cast<int32_t>(dtype),
+        static_cast<int32_t>(slim_c10::DeviceType::CUDA),
+        0,
+        &tensor);
+    return (error == Error::Ok) ? tensor : nullptr;
+  }
+};
+
+TEST_F(AOTITorchMmOutTest, InnerDimensionMismatch) {
+  Tensor* self = createTensor({4, 8}, slim_c10::ScalarType::Float);
+  Tensor* mat2 = createTensor({6, 6}, slim_c10::ScalarType::Float);
+  Tensor* out = createTensor({4, 6}, slim_c10::ScalarType::Float);
+  EXPECT_EQ(aoti_torch_cuda_mm_out(out, self, mat2), Error::InvalidArgument);
+  aoti_torch_delete_tensor_object(self);
+  aoti_torch_delete_tensor_object(mat2);
+  aoti_torch_delete_tensor_object(out);
+}
+
+TEST_F(AOTITorchMmOutTest, NullOut) {
+  Tensor* self = createTensor({4, 8}, slim_c10::ScalarType::Float);
+  Tensor* mat2 = createTensor({8, 6}, slim_c10::ScalarType::Float);
+  EXPECT_EQ(
+      aoti_torch_cuda_mm_out(nullptr, self, mat2), Error::InvalidArgument);
+  aoti_torch_delete_tensor_object(self);
+  aoti_torch_delete_tensor_object(mat2);
+}
+
+TEST_F(AOTITorchMmOutTest, NullSelf) {
+  Tensor* mat2 = createTensor({8, 6}, slim_c10::ScalarType::Float);
+  Tensor* out = createTensor({4, 6}, slim_c10::ScalarType::Float);
+  EXPECT_EQ(aoti_torch_cuda_mm_out(out, nullptr, mat2), Error::InvalidArgument);
+  aoti_torch_delete_tensor_object(mat2);
+  aoti_torch_delete_tensor_object(out);
+}
+
+TEST_F(AOTITorchMmOutTest, NullMat2) {
+  Tensor* self = createTensor({4, 8}, slim_c10::ScalarType::Float);
+  Tensor* out = createTensor({4, 6}, slim_c10::ScalarType::Float);
+  EXPECT_EQ(aoti_torch_cuda_mm_out(out, self, nullptr), Error::InvalidArgument);
+  aoti_torch_delete_tensor_object(self);
+  aoti_torch_delete_tensor_object(out);
+}
+
+TEST_F(AOTITorchMmOutTest, DtypeMismatch) {
+  Tensor* self = createTensor({4, 8}, slim_c10::ScalarType::Float);
+  Tensor* mat2 = createTensor({8, 6}, slim_c10::ScalarType::BFloat16);
+  Tensor* out = createTensor({4, 6}, slim_c10::ScalarType::Float);
+  EXPECT_EQ(aoti_torch_cuda_mm_out(out, self, mat2), Error::InvalidArgument);
+  aoti_torch_delete_tensor_object(self);
+  aoti_torch_delete_tensor_object(mat2);
+  aoti_torch_delete_tensor_object(out);
+}
+
+TEST_F(AOTITorchMmOutTest, NonContiguousHandled) {
+  // ensure_contiguous() copies non-standard-stride inputs before cuBLAS call
+  int64_t nc_sizes[] = {4, 8};
+  int64_t nc_strides[] = {16, 1}; // stride(0) > size(1), non-contiguous
+  Tensor* nc = nullptr;
+  aoti_torch_empty_strided(
+      2,
+      nc_sizes,
+      nc_strides,
+      static_cast<int32_t>(slim_c10::ScalarType::Float),
+      static_cast<int32_t>(slim_c10::DeviceType::CUDA),
+      0,
+      &nc);
+  ASSERT_NE(nc, nullptr);
+
+  Tensor* mat2 = createTensor({8, 6}, slim_c10::ScalarType::Float);
+  Tensor* out = createTensor({4, 6}, slim_c10::ScalarType::Float);
+
+  EXPECT_EQ(aoti_torch_cuda_mm_out(out, nc, mat2), Error::Ok);
+
+  aoti_torch_delete_tensor_object(nc);
+  aoti_torch_delete_tensor_object(mat2);
+  aoti_torch_delete_tensor_object(out);
+}


### PR DESCRIPTION
Implements aoti_torch_cuda_mm_out as a thin cuBLAS wrapper in the ExecuTorch AOTI CUDA shims. When Inductor picks cuBLAS over Triton templates for aten::mm (F.linear), the compiled .so requires this symbol at runtime.

In practice, Inductor's autotune on A100 picks Triton templates for the Qwen3.5 MoE dense projections (bf16 [M,2048]x[2048,N]), so the shim is not exercised for this model. It serves as a safety net for models or shapes where cuBLAS wins the autotune.
