### PR TITLE
Arm backend: Normalize enum signatures in API manifest

### DIFF
--- a/backends/arm/public_api_manifests/api_manifest_running.toml
+++ b/backends/arm/public_api_manifests/api_manifest_running.toml
@@ -22,7 +22,7 @@ signature = "EthosUCompileSpec(target: str, system_config: str | None = None, me
 
 [python.EthosUCompileSpec.DebugMode]
 kind = "enum"
-signature = "EthosUCompileSpec.DebugMode(value, names=None, *, module=None, qualname=None, type=None, start=1)"
+signature = "EthosUCompileSpec.DebugMode(*values)"
 
 [python.EthosUCompileSpec.__eq__]
 kind = "function"
@@ -106,7 +106,7 @@ signature = "VgfCompileSpec(tosa_spec: executorch.backends.arm.tosa.specificatio
 
 [python.VgfCompileSpec.DebugMode]
 kind = "enum"
-signature = "VgfCompileSpec.DebugMode(value, names=None, *, module=None, qualname=None, type=None, start=1)"
+signature = "VgfCompileSpec.DebugMode(*values)"
 
 [python.VgfCompileSpec.__eq__]
 kind = "function"

--- a/backends/arm/scripts/generate_public_api_manifest.py
+++ b/backends/arm/scripts/generate_public_api_manifest.py
@@ -60,6 +60,9 @@ def _api_kind(obj: object) -> str:
 
 
 def _api_signature(path: str, obj: object) -> str:
+    if inspect.isclass(obj) and issubclass(obj, enum.Enum):
+        # EnumMeta.__call__ renders differently across Python versions.
+        return f"{path}(*values)"
     try:
         return f"{path}{inspect.signature(cast(Any, obj))}"
     except (TypeError, ValueError):


### PR DESCRIPTION
Normalize Enum subclass signatures in the Arm public API manifest generator so the output stays stable across Python versions.

Use a fixed `(*values)` signature for enum entries instead of relying on `inspect.signature()` for `EnumMeta.__call__`, and update the checked-in manifest snapshot to match.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @robell