### PR TITLE
Pin huggingface-hub to <=1.13.0

### DIFF
--- a/requirements-examples.txt
+++ b/requirements-examples.txt
@@ -1,6 +1,7 @@
 # pip packages needed to run examples.
 # TODO: Make each example publish its own requirements.txt
 datasets == 3.6.0 # 4.0.0 deprecates trust_remote_code and load scripts. For now pin to 3.6.0
+huggingface-hub <= 1.13.0 # Dependency of datasets, seems to have download issues in ci with 1.14.0
 timm == 1.0.7
 torchsr == 1.0.4
 torchtune @ git+https://github.com/pytorch/torchtune.git@6f2aa7254458145f99d7004cbd6ebc8e53a06404


### PR DESCRIPTION
huggingface-hub is a dependency in datasets
that is pinned to <2.0 which huging-face has not
reach yet. That means it will currently always get the latest version.

After the 1.14.0 update on 6/5-2026, many jobs
have started to time out when downloading using
huggingface-hub.

Pinning in requirements-examples.txt should be
enough, since those requirements should be installed unless install_executorch.sh is ran with --minimal

Should fix tests that started timing out consistently after 3a4c3a15abcba85cfc4a82bdcf5b5b89949d4d5c (unrelated to PR)
for example trunk / test-arm-ootb-linux (run_deit_e2e_ethos_u)


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell