### PR TITLE
Skip dynamic shape flow tests for Arm backends.

### DIFF
--- a/backends/test/suite/conftest.py
+++ b/backends/test/suite/conftest.py
@@ -27,10 +27,9 @@ def pytest_collection_modifyitems(config, items):
             flow = callspec.params.get("test_runner")
             if isinstance(flow, TestFlow):
                 test_name = item.originalname or item.name
-                if flow.should_skip_test(test_name):
-                    item.add_marker(
-                        pytest.mark.skip(reason=f"Skipped by {flow.name} skip_patterns")
-                    )
+                should_skip, reason = flow.should_skip_test(test_name, callspec.params)
+                if should_skip:
+                    item.add_marker(pytest.mark.skip(reason))
 
         item_path = str(getattr(item, "path", ""))
         for suite_prefix, timeout_s in FLOW_TEST_CASE_TIMEOUTS.items():

--- a/backends/test/suite/flow.py
+++ b/backends/test/suite/flow.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -7,7 +7,7 @@ import logging
 import os
 
 from dataclasses import dataclass, field
-from typing import Callable
+from typing import Any, Callable
 
 from executorch.backends.test.harness import Tester
 from executorch.backends.test.harness.stages import Quantize
@@ -44,11 +44,30 @@ class TestFlow:
     skip_patterns: list[str] = field(default_factory=lambda: [])
     """ Tests with names containing any substrings in this list are skipped. """
 
+    param_skip_reasons: dict[str, dict[Any, str]] = field(default_factory=dict)
+    """ Skip tests with a given reason when a pytest parameter matches a given value."""
+
     supports_serialize: bool = True
     """ True if the test flow supports the Serialize stage. """
 
-    def should_skip_test(self, test_name: str) -> bool:
-        return any(pattern in test_name for pattern in self.skip_patterns)
+    def should_skip_test(
+        self, test_name: str, params: dict[str, Any] | None = None
+    ) -> tuple[bool, str]:
+        if any(pattern in test_name for pattern in self.skip_patterns):
+            return True, f"Skipped by {self.name} skip_patterns"
+
+        if params is None:
+            return False, ""
+
+        for param_name, values_to_skip in self.param_skip_reasons.items():
+            if param_name not in params:
+                continue
+
+            parameter = params[param_name]
+            if parameter in values_to_skip:
+                return True, values_to_skip[parameter]
+
+        return False, ""
 
     def __str__(self):
         return self.name

--- a/backends/test/suite/flows/arm.py
+++ b/backends/test/suite/flows/arm.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -53,6 +53,12 @@ def _create_arm_flow(
         supports_serialize=support_serialize,
         quantize=quantize,
         quantize_stage_factory=(create_quantize_stage if quantize else False),  # type: ignore
+        param_skip_reasons={
+            "use_dynamic_shapes": {
+                True: "Dynamic-shape suite variants are not supported by the current ARM "
+                "TOSA/Ethos-U/VGF flows."
+            }
+        },
     )
 
 


### PR DESCRIPTION
They are not supported. This is to remove noise of the flow output to make it easier to track.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell