### PR TITLE
Disable HF Xet storage across all CI scripts

### DIFF
--- a/.ci/scripts/download_hf_hub.sh
+++ b/.ci/scripts/download_hf_hub.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Disable HF Xet storage to avoid stalled downloads on CI runners
+export HF_HUB_DISABLE_XET=1
+
 # Function to download files from the Hugging Face Hub
 # Arguments:
 # 1. model_id: The Hugging Face repository ID (e.g., "organization/model_name")

--- a/.ci/scripts/export_model_artifact.sh
+++ b/.ci/scripts/export_model_artifact.sh
@@ -67,6 +67,7 @@ if [ -z "${1:-}" ]; then
   exit 1
 fi
 
+# Disable HF Xet storage to avoid stalled downloads on CI runners
 export HF_HUB_DISABLE_XET=1
 
 set -eux

--- a/.ci/scripts/test_huggingface_optimum_model.py
+++ b/.ci/scripts/test_huggingface_optimum_model.py
@@ -2,12 +2,16 @@ import argparse
 import gc
 import logging
 import math
+import os
 import shutil
 import subprocess
 import tempfile
 import time
 from pathlib import Path
 from typing import List
+
+# Disable HF Xet storage to avoid stalled downloads on CI runners
+os.environ.setdefault("HF_HUB_DISABLE_XET", "1")
 
 import torch
 from datasets import load_dataset

--- a/.ci/scripts/test_lora.sh
+++ b/.ci/scripts/test_lora.sh
@@ -6,6 +6,8 @@
 # LICENSE file in the root directory of this source tree.
 
 set -exu
+# Disable HF Xet storage to avoid stalled downloads on CI runners
+export HF_HUB_DISABLE_XET=1
 # shellcheck source=/dev/null
 source "$(dirname "${BASH_SOURCE[0]}")/utils.sh"
 

--- a/.ci/scripts/test_lora_multimethod.sh
+++ b/.ci/scripts/test_lora_multimethod.sh
@@ -6,6 +6,8 @@
 # LICENSE file in the root directory of this source tree.
 
 set -exu
+# Disable HF Xet storage to avoid stalled downloads on CI runners
+export HF_HUB_DISABLE_XET=1
 # shellcheck source=/dev/null
 source "$(dirname "${BASH_SOURCE[0]}")/utils.sh"
 

--- a/.ci/scripts/test_phi_3_mini.sh
+++ b/.ci/scripts/test_phi_3_mini.sh
@@ -6,6 +6,8 @@
 # LICENSE file in the root directory of this source tree.
 
 set -exu
+# Disable HF Xet storage to avoid stalled downloads on CI runners
+export HF_HUB_DISABLE_XET=1
 
 BUILD_TYPE=${1:-Debug}
 BUILD_DIR=${3:-cmake-out}

--- a/.github/workflows/mlx.yml
+++ b/.github/workflows/mlx.yml
@@ -306,6 +306,8 @@ jobs:
       timeout: 90
       script: |
         set -eux
+        # Disable HF Xet storage to avoid stalled downloads on CI runners
+        export HF_HUB_DISABLE_XET=1
 
         echo "::group::Install ExecuTorch"
         ${CONDA_RUN} python install_executorch.py > /dev/null
@@ -382,6 +384,8 @@ jobs:
       timeout: 90
       script: |
         set -eux
+        # Disable HF Xet storage to avoid stalled downloads on CI runners
+        export HF_HUB_DISABLE_XET=1
 
         echo "::group::Install ExecuTorch and configure MLX build"
         ${CONDA_RUN} python install_executorch.py > /dev/null
@@ -510,6 +514,8 @@ jobs:
       timeout: 90
       script: |
         set -eux
+        # Disable HF Xet storage to avoid stalled downloads on CI runners
+        export HF_HUB_DISABLE_XET=1
 
         MODEL_ID="${{ matrix.model.id }}"
         MODEL_NAME="${{ matrix.model.name }}"


### PR DESCRIPTION
HuggingFace's Xet storage backend stalls mid-download on CI runners, causing 90-minute job timeouts. Set HF_HUB_DISABLE_XET=1 in every CI script and workflow that downloads from HuggingFace to force standard HTTP downloads instead.
