### PR TITLE
Restore VGF skip guards and preload_deps shape

### DIFF
--- a/backends/arm/test/passes/test_rewrite_conv_pass.py
+++ b/backends/arm/test/passes/test_rewrite_conv_pass.py
@@ -3,6 +3,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import os
+
 import pytest
 import torch
 import torch.nn as nn
@@ -33,6 +35,8 @@ from executorch.exir import EdgeCompileConfig, to_edge, to_edge_transform_and_lo
 from executorch.exir.dialects._ops import ops as exir_ops
 from torch.export import Dim, export
 from torch.export.exported_program import _get_shape_env
+
+_VGF_ENABLED = "LAVAPIPE_LIB_PATH" in os.environ
 
 
 class TinyConvReluCat(nn.Module):
@@ -214,6 +218,7 @@ def test_rewrite_conv_tosa_FP():
     pipeline.run()
 
 
+@pytest.mark.skipif(not _VGF_ENABLED, reason="VGF not enabled")
 def test_fold_and_annotate_q_params_vgf_quant_preserves_output_qparams_on_non_fuseable_clamp() -> (
     None
 ):
@@ -228,6 +233,7 @@ def test_fold_and_annotate_q_params_vgf_quant_preserves_output_qparams_on_non_fu
     assert clamp.meta["output_qparams"]
 
 
+@pytest.mark.skipif(not _VGF_ENABLED, reason="VGF not enabled")
 def test_rewrite_conv_vgf_quant_handles_non_fuseable_conv_clamp_cat_branch() -> None:
     exported_program = _export_quantized(TinyConvReluCat())
     compile_spec = _compile_spec()
@@ -239,6 +245,7 @@ def test_rewrite_conv_vgf_quant_handles_non_fuseable_conv_clamp_cat_branch() -> 
     )
 
 
+@pytest.mark.skipif(not _VGF_ENABLED, reason="VGF not enabled")
 def test_rewrite_conv_vgf_quant_infers_quantized_bias_dtype_from_inputs() -> None:
     exported_program = _export_quantized(TinyConvReluCat(conv1_bias=False))
     edge_program = to_edge(

--- a/backends/arm/test/targets.bzl
+++ b/backends/arm/test/targets.bzl
@@ -84,11 +84,12 @@ def define_arm_tests():
                 "EMULATION_LAYER_TENSOR_JSON": "$(location fbsource//third-party/arm-ml-emulation-layer/v0.9.0/src:VkLayer_Tensor_json)",
                 "EMULATION_LAYER_GRAPH_JSON": "$(location fbsource//third-party/arm-ml-emulation-layer/v0.9.0/src:VkLayer_Graph_json)",
             } if _ENABLE_VGF else {}),
-            preload_deps = [] if runtime.is_oss or not _ENABLE_VGF else [
+            preload_deps = [
                 "//executorch/kernels/quantized:custom_ops_generated_lib",
+            ] + ([] if runtime.is_oss or not _ENABLE_VGF else [
                 "fbsource//third-party/khronos:vulkan",
                 "//executorch/backends/arm/runtime:vgf_backend",
-            ],
+            ]),
             deps = [
                 "//executorch/backends/arm/test:arm_tester" if runtime.is_oss else "//executorch/backends/arm/test/tester/fb:arm_tester_fb",
                 "//executorch/backends/arm/test:conftest",


### PR DESCRIPTION
Summary:
Restores two pieces of test plumbing in backends/arm/test/ that were
inadvertently removed from pytorch/executorch on GitHub and are still
required for stable CI:

1. _VGF_ENABLED skip-guards in test_rewrite_conv_pass.py — without
   them, three VGF tests crash (rather than skip) on environments where
   LAVAPIPE_LIB_PATH is unset.
2. preload_deps shape in targets.bzl — the prior refactor silently
   dropped //executorch/kernels/quantized:custom_ops_generated_lib from
   every non-VGF arm test whenever runtime.is_oss or not _ENABLE_VGF.

The guards are no-ops on environments that have lavapipe configured, so
this is a strict safety improvement for OSS CI and a divergence fix for
fbsource. This supersedes the long-stuck fix-up diff D100742931 (which
will be abandoned).

Differential Revision: D104267179




cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell