### PR TITLE
Use gpu_cpp_unittest for slim CUDA guard tests

### DIFF
--- a/backends/aoti/slim/cuda/test/targets.bzl
+++ b/backends/aoti/slim/cuda/test/targets.bzl
@@ -1,8 +1,8 @@
-load("@fbcode_macros//build_defs:cpp_unittest.bzl", "cpp_unittest")
+load("@fbcode_macros//build_defs:gpu_cpp_unittest.bzl", "gpu_cpp_unittest")
 load("@fbcode_macros//build_defs/lib:re_test_utils.bzl", "re_test_utils")
 
 def cuda_slim_cpp_unittest(name):
-    cpp_unittest(
+    gpu_cpp_unittest(
         name = "test_" + name,
         srcs = [
             "test_" + name + ".cpp",
@@ -16,6 +16,7 @@ def cuda_slim_cpp_unittest(name):
         external_deps = [
             ("cuda", None, "cuda-lazy"),
         ],
+        hip_compatible = False,
         keep_gpu_sections = True,
         remote_execution = re_test_utils.remote_execution(
             platform = "gpu-remote-execution",


### PR DESCRIPTION
Summary:
The `test_cuda_guard` and `test_cuda_stream_guard` targets in `executorch/backends/aoti/slim/cuda/test/` skip at runtime via `GTEST_SKIP()` in `SetUp()` when no CUDA device is available. On CPU-only sandcastle hosts they emit SKIPPED on every run, never accumulate a PASS record, and TestInfra flags them with a `CONTINUOUS_STATE` violation, marking them DISABLED_FAILING and contributing 15 phantom failures to the ai_infra_mobile_platform oncall feed.

Switch the wrapper macro from `cpp_unittest` to `gpu_cpp_unittest`. The GPU wrapper expands the kwargs through `gpu_common.convert_cpp_args`, which adds CI labels and the appropriate `select_accelerator()` so Buck marks the targets incompatible with non-GPU configurations. TestInfra then omits them from CPU schedules entirely instead of running and reporting SKIPPED.

Authored with Claude.

Differential Revision: D104297130


