### PR TITLE
test_passes: wire QNN SDK into runtime env

### DIFF
--- a/backends/qualcomm/tests/BUCK
+++ b/backends/qualcomm/tests/BUCK
@@ -64,6 +64,10 @@ fbcode_target(_kind = runtime.python_test,
     srcs = [
         "test_passes.py",
     ],
+    env = {} if runtime.is_oss else {
+        "LD_LIBRARY_PATH": "$(location fbsource//third-party/qualcomm/qnn/qnn-{0}:qnn_offline_compile_libs)".format(get_qnn_library_version()),
+        "QNN_SDK_ROOT": "$(location fbsource//third-party/qualcomm/qnn/qnn-{0}:__dir__)".format(get_qnn_library_version()),
+    },
     deps = [
         ":models",
         "fbsource//third-party/pypi/expecttest:expecttest",  # @manual
@@ -77,6 +81,7 @@ fbcode_target(_kind = runtime.python_test,
         "//executorch/backends/qualcomm/builders:builders",
     ] + ([] if runtime.is_oss else [
         # These deps fail in OSS: keep_gpu_sections kwarg breaks TARGETS evaluation
+        "//executorch/devtools:lib",
         "//executorch/examples/models/llama:transformer_modules",
         "//executorch/examples/qualcomm/oss_scripts/llama:masking_utils",
         "//executorch/examples/qualcomm/oss_scripts/llama:static_llama",


### PR DESCRIPTION
Summary: `test_resolve_debug_handle` skipTest()s on every run because the QNN SDK isn't on the library path. This wires in the QNN SDK env vars (`LD_LIBRARY_PATH`, `QNN_SDK_ROOT`) using the same pattern from the sibling `:test_qnn_delegate_simulator` target, which uncovered a missing dep on `//executorch/devtools:lib` — both now gated on `not runtime.is_oss` so OSS CI is unaffected.

Differential Revision: D104309789


