### PR TITLE
Enable VGF tests and add Vulkan format compatibility shim (#19383)

### DIFF
--- a/backends/arm/test/targets.bzl
+++ b/backends/arm/test/targets.bzl
@@ -3,7 +3,7 @@ load("@fbcode_macros//build_defs:python_pytest.bzl", "python_pytest")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
-_ENABLE_VGF = False
+_ENABLE_VGF = True
 
 def define_arm_tests():
     # TODO [fbonly] Add more tests


### PR DESCRIPTION
Summary:

Two changes to make `buck test fbcode//executorch/backends/arm/test:permute -- 'test_permute_vgf'` run end-to-end:

Flip `_ENABLE_VGF` from `False` to `True` in `fbcode/executorch/backends/arm/test/targets.bzl` so the VGF test variants are emitted instead of being skipped with "Did not find model-converter on path".


bypass-github-export-checks
bypass-github-pytorch-ci-checks
bypass-github-executorch-ci-checks

Reviewed By: digantdesai, ocvh

Differential Revision: D102431804


