### PR TITLE
[DOC] Add extension APIs to runtime API reference

### DIFF
--- a/docs/source/Doxyfile
+++ b/docs/source/Doxyfile
@@ -963,6 +963,11 @@ INPUT                  = ../devtools/bundled_program/bundled_program.h \
                          ../runtime/core/span.h \
                          ../runtime/core/tag.h \
                          ../runtime/core/tensor_shape_dynamism.h \
+                         ../extension/module/bundled_module.h \
+                         ../extension/module/module.h \
+                         ../extension/tensor/tensor_accessor.h \
+                         ../extension/tensor/tensor_ptr.h \
+                         ../extension/tensor/tensor_ptr_maker.h \
                          ../runtime/platform/compiler.h \
                          ../runtime/executor/ \
                          ../runtime/platform/
@@ -2374,7 +2379,7 @@ ENABLE_PREPROCESSING   = YES
 # The default value is: NO.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-MACRO_EXPANSION        = NO
+MACRO_EXPANSION        = YES
 
 # If the EXPAND_ONLY_PREDEF and MACRO_EXPANSION tags are both set to YES then
 # the macro expansion is limited to the macros specified with the PREDEFINED and
@@ -2382,7 +2387,7 @@ MACRO_EXPANSION        = NO
 # The default value is: NO.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-EXPAND_ONLY_PREDEF     = NO
+EXPAND_ONLY_PREDEF     = YES
 
 # If the SEARCH_INCLUDES tag is set to YES, the include files in the
 # INCLUDE_PATH will be searched if a #include is found.
@@ -2415,7 +2420,8 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             =
+PREDEFINED             = ET_MODULE_NAMESPACE=module \
+                         ET_BUNDLED_MODULE_NAMESPACE=bundled_module
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/docs/source/executorch-runtime-api-reference.rst
+++ b/docs/source/executorch-runtime-api-reference.rst
@@ -40,3 +40,26 @@ Values
 
 .. doxygenclass:: executorch::runtime::etensor::Tensor
   :members:
+
+Module Extension
+----------------
+
+The Module extension provides a higher-level C++ facade for loading programs,
+setting inputs and outputs, and executing methods with common runtime defaults.
+
+.. doxygenclass:: executorch::extension::module::Module
+  :members:
+
+.. doxygenclass:: executorch::extension::bundled_module::BundledModule
+  :members:
+
+Tensor Extension
+----------------
+
+The Tensor extension provides managed tensor helpers for C++ applications that
+need to create, alias, resize, or index tensors before passing them to runtime
+APIs.
+
+.. doxygennamespace:: executorch::extension
+  :members:
+  :content-only:


### PR DESCRIPTION
Fixes #19348

### Summary

- Add `extension/module` and `extension/tensor` headers to the Doxygen inputs used by the runtime API reference.
- Expand the module namespace macros so Breathe can resolve the documented extension classes with stable namespace names.
- Add runtime API reference sections for `Module`, `BundledModule`, and the tensor extension namespace.

### Test plan

- `git diff --check origin/main..HEAD`
- `python -m py_compile docs/source/conf.py`
- `cd docs && doxygen source/Doxyfile`
- Isolated Breathe/Sphinx build of `executorch-runtime-api-reference.rst` against the generated Doxygen XML
- Verified the rendered runtime API page contains the new Module Extension and Tensor Extension entries

cc @mergennachin @AlannaBurke
