### PR TITLE
[ET-VK] Make libtorch optional in custom op test binaries

### DIFF
--- a/backends/vulkan/test/custom_ops/targets.bzl
+++ b/backends/vulkan/test/custom_ops/targets.bzl
@@ -6,14 +6,13 @@ load(
     "vulkan_spv_shader_lib",
 )
 
-def define_custom_op_test_binary(custom_op_name, extra_deps = [], src_file = None):
+def define_custom_op_test_binary(custom_op_name, extra_deps = [], src_file = None, include_torch = False):
     deps_list = [
         ":prototyping_utils",
         ":operator_implementations",
         ":custom_ops_shaderlib",
         "//executorch/backends/vulkan:vulkan_graph_runtime",
-        runtime.external_dep_location("libtorch"),
-    ] + extra_deps
+    ] + ([runtime.external_dep_location("libtorch")] if include_torch else []) + extra_deps
 
     src_file_str = src_file if src_file else "{}.cpp".format(custom_op_name)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #19403
* __->__ #19402

Add `include_torch` parameter (default False) to
`define_custom_op_test_binary()`. None of the custom op test binaries
directly include torch/ATen/c10 headers, so libtorch was unnecessary
baggage. Dropping it reduces the q4gsw_linear_adreno binary from ~1 GB
to 74 MB.

Differential Revision: [D104456804](https://our.internmc.facebook.com/intern/diff/D104456804/)