### PR TITLE
[ET-VK] Plumb subgroup property queries + VK_EXT_subgroup_size_control

### DIFF
--- a/backends/vulkan/runtime/api/Context.cpp
+++ b/backends/vulkan/runtime/api/Context.cpp
@@ -149,10 +149,14 @@ vkapi::DescriptorSet Context::get_descriptor_set(
 
   spec_constants.append(additional_constants);
 
+  const uint32_t resolved_required_subgroup_size =
+      vkapi::resolve_required_subgroup_size(shader_descriptor, adapter_p_);
+
   VkPipeline pipeline = pipeline_cache().retrieve(
       {pipeline_layout_cache().retrieve(shader_layout, push_constants_size),
        shader_cache().retrieve(shader_descriptor),
-       spec_constants});
+       spec_constants,
+       resolved_required_subgroup_size});
 
   cmd_.bind_pipeline(pipeline, pipeline_layout, local_workgroup_size);
 
@@ -315,8 +319,14 @@ VkPipeline Context::get_shader_pipeline(
 
   spec_constants.append(additional_constants);
 
+  const uint32_t resolved_required_subgroup_size =
+      vkapi::resolve_required_subgroup_size(shader, adapter_p_);
+
   VkPipeline pipeline = pipeline_cache().retrieve(
-      {pipeline_layout, shader_cache().retrieve(shader), spec_constants});
+      {pipeline_layout,
+       shader_cache().retrieve(shader),
+       spec_constants,
+       resolved_required_subgroup_size});
 
   return pipeline;
 }

--- a/backends/vulkan/runtime/gen_vulkan_spv.py
+++ b/backends/vulkan/runtime/gen_vulkan_spv.py
@@ -281,8 +281,9 @@ def layout_declare_buffer(
     dtype: str,
     precision: str = "PRECISION",
     is_scalar_array: bool = True,
+    vec_size: int = 4,
 ) -> str:
-    array_type = buffer_gvec_type(dtype, 4)
+    array_type = buffer_gvec_type(dtype, vec_size)
     if is_scalar_array:
         array_type = buffer_scalar_type(dtype)
 
@@ -341,6 +342,7 @@ def layout_declare_tensor(
     storage_type: str,
     is_scalar_array: bool = True,
     precision: str = "PRECISION",
+    vec_size: int = 4,
 ) -> str:
     assert storage_type.lower() in ["buffer", "texture3d", "texture2d"]
 
@@ -357,6 +359,7 @@ def layout_declare_tensor(
             dtype,
             precision,
             is_scalar_array=is_scalar_array,
+            vec_size=vec_size,
         )
 
     # Create image/sampler binding
@@ -785,6 +788,10 @@ class SPVGenerator:
                     "generate_variant_forall", None
                 )
 
+                reserved_yaml_keys = {
+                    "generate_variant_forall",
+                }
+
                 for variant in params_dict["shader_variants"]:
                     default_iterated_params_names = set(
                         default_iterated_params.keys()
@@ -797,7 +804,7 @@ class SPVGenerator:
                         variant_params_names
                         - default_iterated_params_names
                         - params_names
-                        - {"generate_variant_forall"}
+                        - reserved_yaml_keys
                     )
                     assert len(invalid_keys) == 0
 
@@ -813,7 +820,7 @@ class SPVGenerator:
                         for combination in variant_combinations:
                             default_params_copy = copy.deepcopy(default_params)
                             for key in variant:
-                                if key != "generate_variant_forall":
+                                if key not in reserved_yaml_keys:
                                     default_params_copy[key] = variant[key]
 
                             variant_name = variant["NAME"]
@@ -842,7 +849,8 @@ class SPVGenerator:
                     else:
                         default_params_copy = copy.deepcopy(default_params)
                         for key in variant:
-                            default_params_copy[key] = variant[key]
+                            if key not in reserved_yaml_keys:
+                                default_params_copy[key] = variant[key]
 
                         self.shader_template_params[template_name].append(
                             default_params_copy
@@ -1026,6 +1034,27 @@ class SPVGenerator:
                 print(f"template_file_path: {template_file_path}")
                 output_text = preprocess(input_text, codegen_params)
 
+            # If the shader yaml declared a SUBGROUP_SIZE template parameter,
+            # embed it into the generated GLSL as a comment. getShaderInfo()
+            # parses it back out alongside TILE_SIZE, WEIGHT_STORAGE, etc.,
+            # avoiding a side-channel name -> value map.
+            subgroup_size = codegen_params.get("SUBGROUP_SIZE")
+            if subgroup_size is not None:
+                try:
+                    subgroup_size_int = int(subgroup_size)
+                except (TypeError, ValueError) as e:
+                    raise RuntimeError(
+                        f"Shader variant {src_file_name!r} declared "
+                        f"SUBGROUP_SIZE={subgroup_size!r}, which is not "
+                        f"parseable as an integer. Fix the SUBGROUP_SIZE "
+                        f"value in the shader's yaml."
+                    ) from e
+                if subgroup_size_int > 0:
+                    output_text = (
+                        f"// REQUIRED_SUBGROUP_SIZE = {subgroup_size_int}\n"
+                        + output_text
+                    )
+
             included_files = get_glsl_includes(output_text)
 
             with codecs.open(gen_out_path, "w", encoding="utf-8") as output_file:
@@ -1184,6 +1213,12 @@ class ShaderInfo:
     requires_integer_dot_product_ext: bool = False
     requires_shader_int64_ext: bool = False
     requires_shader_float64_ext: bool = False
+    # Subgroup size requirement (matches the C++ ShaderInfo encoding):
+    #   0  = no requirement
+    #   >0 = literal fixed size; sourced from the shader yaml's
+    #        `SUBGROUP_SIZE` template parameter (single source of truth for
+    #        both GLSL substitution and the Vulkan pipeline pin).
+    required_subgroup_size: int = 0
 
 
 def getName(filePath: str) -> str:
@@ -1206,6 +1241,17 @@ def findTileSizes(lineStr: str) -> List[int]:
     if matches is None:
         raise AssertionError("matches is None in findTileSizes")
     return [int(matches.group(1)), int(matches.group(2)), int(matches.group(3))]
+
+
+def isRequiredSubgroupSizeLine(lineStr: str) -> bool:
+    return re.search(r"^// REQUIRED_SUBGROUP_SIZE = ", lineStr) is not None
+
+
+def findRequiredSubgroupSize(lineStr: str) -> int:
+    matches = re.search(r"^// REQUIRED_SUBGROUP_SIZE = ([0-9]+)", lineStr)
+    if matches is None:
+        raise AssertionError("matches is None in findRequiredSubgroupSize")
+    return int(matches.group(1))
 
 
 def isWeightStorageTypeLine(lineStr: str) -> bool:
@@ -1281,6 +1327,8 @@ def getShaderInfo(srcFilePath: str) -> ShaderInfo:  # noqa: C901
                 shader_info.layouts.append(determineDescriptorType(line))
             if isTileSizeLine(line):
                 shader_info.tile_size = findTileSizes(line)
+            if isRequiredSubgroupSizeLine(line):
+                shader_info.required_subgroup_size = findRequiredSubgroupSize(line)
             if isWeightStorageTypeLine(line):
                 shader_info.weight_storage_type = getWeightStorageType(line)
             if isBiasStorageTypeLine(line):
@@ -1378,6 +1426,7 @@ def generateShaderInfoStr(shader_info: ShaderInfo, name: str, sizeBytes: int) ->
         to_cpp_str(shader_info.requires_integer_dot_product_ext),
         to_cpp_str(shader_info.requires_shader_int64_ext),
         to_cpp_str(shader_info.requires_shader_float64_ext),
+        str(shader_info.required_subgroup_size),
     ]
 
     shader_info_str = textwrap.indent(
@@ -1406,7 +1455,9 @@ def generateShaderDispatchStr(shader_info: ShaderInfo, name: str) -> str:
 
 
 def genCppFiles(
-    spv_files: Dict[str, str], cpp_header_path: str, cpp_src_file_path: str
+    spv_files: Dict[str, str],
+    cpp_header_path: str,
+    cpp_src_file_path: str,
 ) -> None:
     spv_bin_strs = []
     register_shader_info_strs = []

--- a/backends/vulkan/runtime/graph/ComputeGraph.cpp
+++ b/backends/vulkan/runtime/graph/ComputeGraph.cpp
@@ -825,10 +825,20 @@ void ComputeGraph::register_pipeline_to_create(
 
   spec_constants.append(spec_vars);
 
+  // Resolve any shader-declared required subgroup size into a concrete value
+  // so the pre-built pipeline matches the one created at dispatch time. The
+  // shared helper throws ShaderNotSupportedError when the adapter cannot honor
+  // the requirement; let it propagate so a stale unused pipeline doesn't sit
+  // in the cache while dispatch later throws on the same shader.
+  const uint32_t resolved_required_subgroup_size =
+      vkapi::resolve_required_subgroup_size(
+          shader_info, context()->adapter_ptr());
+
   const vkapi::ComputePipelineCache::Key desc = {
       context()->pipeline_layout_cache().retrieve(shader_layout, pc_offset),
       context()->shader_cache().retrieve(shader_info),
-      spec_constants};
+      spec_constants,
+      resolved_required_subgroup_size};
 
   if (context_->pipeline_cache().contains(desc)) {
     return;

--- a/backends/vulkan/runtime/vk_api/Adapter.cpp
+++ b/backends/vulkan/runtime/vk_api/Adapter.cpp
@@ -129,6 +129,9 @@ VkDevice create_logical_device(
 #ifdef VK_NV_cooperative_matrix2
       VK_NV_COOPERATIVE_MATRIX_2_EXTENSION_NAME,
 #endif /* VK_NV_cooperative_matrix2 */
+#ifdef VK_EXT_subgroup_size_control
+      VK_EXT_SUBGROUP_SIZE_CONTROL_EXTENSION_NAME,
+#endif /* VK_EXT_subgroup_size_control */
   };
 
   std::vector<const char*> enabled_device_extensions;
@@ -198,6 +201,19 @@ VkDevice create_logical_device(
   cooperative_matrix2_features.pNext = extension_list_top;
   extension_list_top = &cooperative_matrix2_features;
 #endif /* VK_NV_cooperative_matrix2 */
+
+#ifdef VK_EXT_subgroup_size_control
+  // Only enable the feature struct if the extension was actually requested
+  // and the feature flag is set on the physical device. The extension itself
+  // is filtered into enabled_device_extensions by
+  // find_requested_device_extensions.
+  VkPhysicalDeviceSubgroupSizeControlFeaturesEXT subgroup_size_control_features{
+      physical_device.subgroup_size_control_features};
+  if (physical_device.supports_subgroup_size_control) {
+    subgroup_size_control_features.pNext = extension_list_top;
+    extension_list_top = &subgroup_size_control_features;
+  }
+#endif /* VK_EXT_subgroup_size_control */
 
   device_create_info.pNext = extension_list_top;
 
@@ -405,7 +421,7 @@ std::string Adapter::stringize() const {
   ss << "    deviceType:    " << device_type << std::endl;
   ss << "    deviceName:    " << properties.deviceName << std::endl;
 
-#define PRINT_BOOL(value, name) \
+#define PRINT_VALUE(value, name) \
   ss << "      " << std::left << std::setw(36) << #name << value << std::endl;
 
 #define PRINT_PROP(struct, name)                                       \
@@ -452,7 +468,7 @@ std::string Adapter::stringize() const {
 #endif /* VK_KHR_8bit_storage */
 
   ss << "    Shader 16bit and 8bit Features {" << std::endl;
-  PRINT_BOOL(physical_device_.supports_int16_shader_types, shaderInt16)
+  PRINT_VALUE(physical_device_.supports_int16_shader_types, shaderInt16)
 #ifdef VK_KHR_shader_float16_int8
   PRINT_PROP(physical_device_.shader_float16_int8_types, shaderFloat16);
   PRINT_PROP(physical_device_.shader_float16_int8_types, shaderInt8);
@@ -460,8 +476,29 @@ std::string Adapter::stringize() const {
   ss << "    }" << std::endl;
 
   ss << "    Shader 64bit Features {" << std::endl;
-  PRINT_BOOL(physical_device_.supports_int64_shader_types, shaderInt64)
-  PRINT_BOOL(physical_device_.supports_float64_shader_types, shaderFloat64)
+  PRINT_VALUE(physical_device_.supports_int64_shader_types, shaderInt64)
+  PRINT_VALUE(physical_device_.supports_float64_shader_types, shaderFloat64)
+  ss << "    }" << std::endl;
+
+  ss << "    Subgroup Properties {" << std::endl;
+  PRINT_VALUE(subgroup_size(), subgroupSize)
+  PRINT_VALUE(supports_subgroup_compute_basic(), computeSubgroupBasic)
+  PRINT_VALUE(supports_subgroup_compute_shuffle(), computeSubgroupShuffle)
+  PRINT_VALUE(supports_subgroup_compute_ballot(), computeSubgroupBallot)
+  PRINT_VALUE(supports_subgroup_compute_vote(), computeSubgroupVote)
+  PRINT_VALUE(supports_subgroup_compute_arithmetic(), computeSubgroupArithmetic)
+  PRINT_VALUE(
+      supports_subgroup_compute_shuffle_relative(),
+      computeSubgroupShuffleRelative)
+  PRINT_VALUE(supports_subgroup_compute_clustered(), computeSubgroupClustered)
+  PRINT_VALUE(supports_subgroup_compute_quad(), computeSubgroupQuad)
+  PRINT_VALUE(min_subgroup_size(), minSubgroupSize)
+  PRINT_VALUE(max_subgroup_size(), maxSubgroupSize)
+  PRINT_VALUE(supports_subgroup_size_control(), subgroupSizeControl)
+  PRINT_VALUE(supports_compute_full_subgroups(), computeFullSubgroups)
+  PRINT_VALUE(
+      supports_required_subgroup_size_for_compute(),
+      requiredSubgroupSizeStages_compute)
   ss << "    }" << std::endl;
 
 #ifdef VK_KHR_shader_integer_dot_product
@@ -612,6 +649,25 @@ std::string Adapter::stringize() const {
 std::ostream& operator<<(std::ostream& os, const Adapter& adapter) {
   os << adapter.stringize() << std::endl;
   return os;
+}
+
+uint32_t resolve_required_subgroup_size(
+    const ShaderInfo& shader,
+    Adapter* adapter) {
+  if (shader.required_subgroup_size == 0u) {
+    return 0u;
+  }
+  if (!adapter->supports_required_subgroup_size_for_compute()) {
+    throw ShaderNotSupportedError(
+        shader.kernel_name, VulkanExtension::SUBGROUP_SIZE_CONTROL);
+  }
+  const uint32_t resolved = shader.required_subgroup_size;
+  if (resolved < adapter->min_subgroup_size() ||
+      resolved > adapter->max_subgroup_size()) {
+    throw ShaderNotSupportedError(
+        shader.kernel_name, VulkanExtension::SUBGROUP_SIZE_CONTROL);
+  }
+  return resolved;
 }
 
 } // namespace vkapi

--- a/backends/vulkan/runtime/vk_api/Adapter.h
+++ b/backends/vulkan/runtime/vk_api/Adapter.h
@@ -285,6 +285,106 @@ class Adapter final {
     return physical_device_.min_ubo_alignment;
   }
 
+  // Subgroup properties
+
+  inline uint32_t subgroup_size() const {
+    return physical_device_.subgroup_size;
+  }
+
+  inline bool supports_subgroup_compute_basic() const {
+    return (physical_device_.supported_subgroup_ops &
+            VK_SUBGROUP_FEATURE_BASIC_BIT) != 0 &&
+        (physical_device_.supported_subgroup_stages &
+         VK_SHADER_STAGE_COMPUTE_BIT) != 0;
+  }
+
+  inline bool supports_subgroup_compute_shuffle() const {
+    return (physical_device_.supported_subgroup_ops &
+            VK_SUBGROUP_FEATURE_SHUFFLE_BIT) != 0 &&
+        (physical_device_.supported_subgroup_stages &
+         VK_SHADER_STAGE_COMPUTE_BIT) != 0;
+  }
+
+  inline bool supports_subgroup_compute_ballot() const {
+    return (physical_device_.supported_subgroup_ops &
+            VK_SUBGROUP_FEATURE_BALLOT_BIT) != 0 &&
+        (physical_device_.supported_subgroup_stages &
+         VK_SHADER_STAGE_COMPUTE_BIT) != 0;
+  }
+
+  inline bool supports_subgroup_compute_vote() const {
+    return (physical_device_.supported_subgroup_ops &
+            VK_SUBGROUP_FEATURE_VOTE_BIT) != 0 &&
+        (physical_device_.supported_subgroup_stages &
+         VK_SHADER_STAGE_COMPUTE_BIT) != 0;
+  }
+
+  inline bool supports_subgroup_compute_arithmetic() const {
+    return (physical_device_.supported_subgroup_ops &
+            VK_SUBGROUP_FEATURE_ARITHMETIC_BIT) != 0 &&
+        (physical_device_.supported_subgroup_stages &
+         VK_SHADER_STAGE_COMPUTE_BIT) != 0;
+  }
+
+  inline bool supports_subgroup_compute_shuffle_relative() const {
+    return (physical_device_.supported_subgroup_ops &
+            VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT) != 0 &&
+        (physical_device_.supported_subgroup_stages &
+         VK_SHADER_STAGE_COMPUTE_BIT) != 0;
+  }
+
+  inline bool supports_subgroup_compute_clustered() const {
+    return (physical_device_.supported_subgroup_ops &
+            VK_SUBGROUP_FEATURE_CLUSTERED_BIT) != 0 &&
+        (physical_device_.supported_subgroup_stages &
+         VK_SHADER_STAGE_COMPUTE_BIT) != 0;
+  }
+
+  inline bool supports_subgroup_compute_quad() const {
+    return (physical_device_.supported_subgroup_ops &
+            VK_SUBGROUP_FEATURE_QUAD_BIT) != 0 &&
+        (physical_device_.supported_subgroup_stages &
+         VK_SHADER_STAGE_COMPUTE_BIT) != 0;
+  }
+
+  // Subgroup size control (VK_EXT_subgroup_size_control / Vulkan 1.3 core).
+
+  inline uint32_t min_subgroup_size() const {
+    return physical_device_.min_subgroup_size;
+  }
+
+  inline uint32_t max_subgroup_size() const {
+    return physical_device_.max_subgroup_size;
+  }
+
+  inline bool supports_subgroup_size_control() const {
+#ifdef ETVK_FORCE_NO_EXTENSIONS
+    return false;
+#endif
+#ifdef VK_EXT_subgroup_size_control
+    return physical_device_.supports_subgroup_size_control;
+#else
+    return false;
+#endif /* VK_EXT_subgroup_size_control */
+  }
+
+  inline bool supports_compute_full_subgroups() const {
+#ifdef ETVK_FORCE_NO_EXTENSIONS
+    return false;
+#endif
+#ifdef VK_EXT_subgroup_size_control
+    return physical_device_.supports_compute_full_subgroups;
+#else
+    return false;
+#endif /* VK_EXT_subgroup_size_control */
+  }
+
+  inline bool supports_required_subgroup_size_for_compute() const {
+    return supports_subgroup_size_control() &&
+        (physical_device_.required_subgroup_size_stages &
+         VK_SHADER_STAGE_COMPUTE_BIT) != 0;
+  }
+
   inline uint32_t max_texture2d_dim() const {
     return physical_device_.properties.limits.maxImageDimension2D;
   }
@@ -311,6 +411,16 @@ class Adapter final {
   std::string stringize() const;
   friend std::ostream& operator<<(std::ostream&, const Adapter&);
 };
+
+// Resolve the shader-declared required subgroup size into a concrete value
+// (or 0 = no requirement) given the adapter capabilities. Throws
+// ShaderNotSupportedError when the shader declares a required subgroup size
+// but the adapter cannot honor it (extension unsupported, or value out of
+// the adapter's [min, max] range). Silent fallback would create a
+// correctness/perf landmine, so callers must be prepared for this throw.
+uint32_t resolve_required_subgroup_size(
+    const ShaderInfo& shader,
+    Adapter* adapter);
 
 } // namespace vkapi
 } // namespace vkcompute

--- a/backends/vulkan/runtime/vk_api/Device.cpp
+++ b/backends/vulkan/runtime/vk_api/Device.cpp
@@ -78,6 +78,14 @@ PhysicalDevice::PhysicalDevice(
       cooperative_matrix2_features{
           VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_2_FEATURES_NV},
 #endif /* VK_NV_cooperative_matrix2 */
+#ifdef VK_EXT_subgroup_size_control
+      subgroup_size_control_features{
+          VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_FEATURES_EXT,
+          nullptr},
+      subgroup_size_control_properties{
+          VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_PROPERTIES_EXT,
+          nullptr},
+#endif /* VK_EXT_subgroup_size_control */
       queue_families{},
       num_compute_queues(0),
       api_version_major(0),
@@ -89,6 +97,14 @@ PhysicalDevice::PhysicalDevice(
       has_timestamps(false),
       timestamp_period(0),
       min_ubo_alignment(0),
+      subgroup_size(0),
+      supported_subgroup_ops(0),
+      supported_subgroup_stages(0),
+      min_subgroup_size(0),
+      max_subgroup_size(0),
+      required_subgroup_size_stages(0),
+      supports_subgroup_size_control(false),
+      supports_compute_full_subgroups(false),
       device_name{},
       device_type{DeviceType::UNKNOWN} {
   // Extract physical device properties
@@ -275,6 +291,11 @@ void PhysicalDevice::query_extensions_vk_1_1() {
   extension_list_top = &cooperative_matrix2_features;
 #endif /* VK_NV_cooperative_matrix2 */
 
+#ifdef VK_EXT_subgroup_size_control
+  subgroup_size_control_features.pNext = extension_list_top;
+  extension_list_top = &subgroup_size_control_features;
+#endif /* VK_EXT_subgroup_size_control */
+
   features2.pNext = extension_list_top;
 
   vkGetPhysicalDeviceFeatures2(handle, &features2);
@@ -289,16 +310,60 @@ void PhysicalDevice::query_extensions_vk_1_1() {
     supports_float64_shader_types = true;
   }
 
+#ifdef VK_EXT_subgroup_size_control
+  supports_subgroup_size_control =
+      subgroup_size_control_features.subgroupSizeControl == VK_TRUE;
+  supports_compute_full_subgroups =
+      subgroup_size_control_features.computeFullSubgroups == VK_TRUE;
+#endif /* VK_EXT_subgroup_size_control */
+
   // Query properties separately from features
   VkPhysicalDeviceProperties2 properties2{
       VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2};
 
+  void* properties_list_top = nullptr;
+
+  VkPhysicalDeviceSubgroupProperties subgroup_properties{
+      VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_PROPERTIES};
+  subgroup_properties.pNext = properties_list_top;
+  properties_list_top = &subgroup_properties;
+
 #ifdef VK_KHR_shader_integer_dot_product
-  shader_int_dot_product_properties.pNext = nullptr;
-  properties2.pNext = &shader_int_dot_product_properties;
+  shader_int_dot_product_properties.pNext = properties_list_top;
+  properties_list_top = &shader_int_dot_product_properties;
 #endif /* VK_KHR_shader_integer_dot_product */
 
+#ifdef VK_EXT_subgroup_size_control
+  subgroup_size_control_properties.pNext = properties_list_top;
+  properties_list_top = &subgroup_size_control_properties;
+#endif /* VK_EXT_subgroup_size_control */
+
+  properties2.pNext = properties_list_top;
+
   vkGetPhysicalDeviceProperties2(handle, &properties2);
+
+  subgroup_size = subgroup_properties.subgroupSize;
+  supported_subgroup_ops = subgroup_properties.supportedOperations;
+  supported_subgroup_stages = subgroup_properties.supportedStages;
+
+#ifdef VK_EXT_subgroup_size_control
+  if (supports_subgroup_size_control) {
+    min_subgroup_size = subgroup_size_control_properties.minSubgroupSize;
+    max_subgroup_size = subgroup_size_control_properties.maxSubgroupSize;
+    required_subgroup_size_stages =
+        subgroup_size_control_properties.requiredSubgroupSizeStages;
+  } else {
+    // Default to the single subgroup_size when control is unavailable so
+    // callers can use min/max range queries unconditionally.
+    min_subgroup_size = subgroup_size;
+    max_subgroup_size = subgroup_size;
+    required_subgroup_size_stages = 0;
+  }
+#else
+  min_subgroup_size = subgroup_size;
+  max_subgroup_size = subgroup_size;
+  required_subgroup_size_stages = 0;
+#endif /* VK_EXT_subgroup_size_control */
 }
 
 void PhysicalDevice::override_device_name(const std::string& new_name) {

--- a/backends/vulkan/runtime/vk_api/Device.h
+++ b/backends/vulkan/runtime/vk_api/Device.h
@@ -60,6 +60,12 @@ struct PhysicalDevice final {
   VkPhysicalDeviceCooperativeMatrix2FeaturesNV cooperative_matrix2_features;
 #endif /* VK_NV_cooperative_matrix2 */
 
+#ifdef VK_EXT_subgroup_size_control
+  VkPhysicalDeviceSubgroupSizeControlFeaturesEXT subgroup_size_control_features;
+  VkPhysicalDeviceSubgroupSizeControlPropertiesEXT
+      subgroup_size_control_properties;
+#endif /* VK_EXT_subgroup_size_control */
+
   // Available GPU queues
   std::vector<VkQueueFamilyProperties> queue_families;
 
@@ -74,6 +80,22 @@ struct PhysicalDevice final {
   bool has_timestamps;
   float timestamp_period;
   size_t min_ubo_alignment;
+
+  // Subgroup properties (queried via VkPhysicalDeviceSubgroupProperties).
+  // Populated from VK_VERSION_1_1+ devices; otherwise left at safe defaults.
+  uint32_t subgroup_size;
+  VkSubgroupFeatureFlags supported_subgroup_ops;
+  VkShaderStageFlags supported_subgroup_stages;
+
+  // Subgroup size control (VK_EXT_subgroup_size_control / Vulkan 1.3 core).
+  // Populated only if the extension/feature is supported; default to safe
+  // values otherwise. min/max set to subgroup_size when the extension is
+  // missing so callers can use the same range queries unconditionally.
+  uint32_t min_subgroup_size;
+  uint32_t max_subgroup_size;
+  VkShaderStageFlags required_subgroup_size_stages;
+  bool supports_subgroup_size_control;
+  bool supports_compute_full_subgroups;
 
   // Device identity
   std::string device_name;

--- a/backends/vulkan/runtime/vk_api/Exception.cpp
+++ b/backends/vulkan/runtime/vk_api/Exception.cpp
@@ -118,6 +118,9 @@ std::ostream& operator<<(std::ostream& out, const VulkanExtension result) {
     case VulkanExtension::SHADER_FLOAT64:
       out << "shaderFloat64";
       break;
+    case VulkanExtension::SUBGROUP_SIZE_CONTROL:
+      out << "VK_EXT_subgroup_size_control (compute stage required size)";
+      break;
   }
   return out;
 }

--- a/backends/vulkan/runtime/vk_api/Exception.h
+++ b/backends/vulkan/runtime/vk_api/Exception.h
@@ -85,6 +85,7 @@ enum class VulkanExtension : uint8_t {
   INTEGER_DOT_PRODUCT,
   SHADER_INT64,
   SHADER_FLOAT64,
+  SUBGROUP_SIZE_CONTROL,
 };
 
 class ShaderNotSupportedError : public std::exception {

--- a/backends/vulkan/runtime/vk_api/Pipeline.cpp
+++ b/backends/vulkan/runtime/vk_api/Pipeline.cpp
@@ -287,9 +287,21 @@ ComputePipeline::ComputePipeline(
       descriptor.specialization_constants.data(), // pData
   };
 
+  const void* shader_stage_pnext = nullptr;
+#ifdef VK_EXT_subgroup_size_control
+  VkPipelineShaderStageRequiredSubgroupSizeCreateInfoEXT
+      required_subgroup_size_info{
+          VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO_EXT,
+          nullptr,
+          descriptor.required_subgroup_size};
+  if (descriptor.required_subgroup_size > 0u) {
+    shader_stage_pnext = &required_subgroup_size_info;
+  }
+#endif /* VK_EXT_subgroup_size_control */
+
   const VkPipelineShaderStageCreateInfo shader_stage_create_info{
       VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO, // sType
-      nullptr, // pNext
+      shader_stage_pnext, // pNext
       0u, // flags
       VK_SHADER_STAGE_COMPUTE_BIT, // stage
       descriptor.shader_module, // module
@@ -355,7 +367,8 @@ bool operator==(
   return (
       _1.pipeline_layout == _2.pipeline_layout &&
       _1.shader_module == _2.shader_module &&
-      _1.specialization_constants == _2.specialization_constants);
+      _1.specialization_constants == _2.specialization_constants &&
+      _1.required_subgroup_size == _2.required_subgroup_size);
 }
 
 //
@@ -489,7 +502,18 @@ void ComputePipelineCache::create_pipelines(
   std::vector<VkComputePipelineCreateInfo> create_infos;
   create_infos.reserve(num_pipelines);
 
-  for (const auto& key : keys_to_create) {
+#ifdef VK_EXT_subgroup_size_control
+  // Stable storage for any required-subgroup-size structs that need to live
+  // until vkCreateComputePipelines returns. Indexed by pipeline index; only
+  // the entries for pipelines that actually request a fixed subgroup size
+  // are populated.
+  std::vector<VkPipelineShaderStageRequiredSubgroupSizeCreateInfoEXT>
+      required_subgroup_size_infos(num_pipelines);
+#endif /* VK_EXT_subgroup_size_control */
+
+  for (size_t pipeline_idx = 0; pipeline_idx < keys_to_create.size();
+       ++pipeline_idx) {
+    const auto& key = keys_to_create[pipeline_idx];
     map_entries.push_back(key.specialization_constants.generate_map_entries());
 
     specialization_infos.push_back(VkSpecializationInfo{
@@ -499,9 +523,20 @@ void ComputePipelineCache::create_pipelines(
         key.specialization_constants.data(), // pData
     });
 
+    const void* shader_stage_pnext = nullptr;
+#ifdef VK_EXT_subgroup_size_control
+    if (key.required_subgroup_size > 0u) {
+      required_subgroup_size_infos[pipeline_idx] = {
+          VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO_EXT,
+          nullptr,
+          key.required_subgroup_size};
+      shader_stage_pnext = &required_subgroup_size_infos[pipeline_idx];
+    }
+#endif /* VK_EXT_subgroup_size_control */
+
     shader_stage_create_infos.push_back(VkPipelineShaderStageCreateInfo{
         VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO, // sType
-        nullptr, // pNext
+        shader_stage_pnext, // pNext
         0u, // flags
         VK_SHADER_STAGE_COMPUTE_BIT, // stage
         key.shader_module, // module

--- a/backends/vulkan/runtime/vk_api/Pipeline.h
+++ b/backends/vulkan/runtime/vk_api/Pipeline.h
@@ -157,6 +157,14 @@ class ComputePipeline final {
     VkPipelineLayout pipeline_layout;
     VkShaderModule shader_module;
     SpecVarList specialization_constants;
+    // Optional: when nonzero, the pipeline is created with
+    // VkPipelineShaderStageRequiredSubgroupSizeCreateInfo chained into the
+    // shader stage pNext, locking the subgroup size to this value. Must be a
+    // power of two within [adapter.min_subgroup_size(),
+    // adapter.max_subgroup_size()] and the adapter must support
+    // VK_EXT_subgroup_size_control with VK_SHADER_STAGE_COMPUTE_BIT in the
+    // required_subgroup_size_stages mask. 0 = no requirement.
+    uint32_t required_subgroup_size = 0u;
   };
 
   explicit ComputePipeline(VkDevice device, VkPipeline handle);
@@ -280,6 +288,9 @@ class ComputePipelineCache final {
         }
         seed = utils::hash_combine(seed, new_seed);
       }
+
+      seed = utils::hash_combine(
+          seed, std::hash<uint32_t>()(descriptor.required_subgroup_size));
 
       return seed;
     }

--- a/backends/vulkan/runtime/vk_api/Shader.cpp
+++ b/backends/vulkan/runtime/vk_api/Shader.cpp
@@ -34,7 +34,8 @@ ShaderInfo::ShaderInfo(
     const bool requires_8bit_storage_ext,
     const bool requires_integer_dot_product_ext,
     const bool requires_shader_int64_ext,
-    const bool requires_shader_float64_ext)
+    const bool requires_shader_float64_ext,
+    const uint32_t required_subgroup_size_arg)
     : src_code{
           spirv_bin,
           size,
@@ -47,7 +48,8 @@ ShaderInfo::ShaderInfo(
       requires_8bit_storage(requires_8bit_storage_ext),
       requires_integer_dot_product(requires_integer_dot_product_ext),
       requires_shader_int64(requires_shader_int64_ext),
-      requires_shader_float64(requires_shader_float64_ext) {
+      requires_shader_float64(requires_shader_float64_ext),
+      required_subgroup_size(required_subgroup_size_arg) {
 }
 
 bool operator==(const ShaderInfo& _1, const ShaderInfo& _2) {

--- a/backends/vulkan/runtime/vk_api/Shader.h
+++ b/backends/vulkan/runtime/vk_api/Shader.h
@@ -69,6 +69,13 @@ struct ShaderInfo final {
   bool requires_shader_int64 = false;
   bool requires_shader_float64 = false;
 
+  // Subgroup size requirement declared in the shader's yaml.
+  //   0  = no requirement (default)
+  //  >0  = literal fixed size; pipeline is pinned to this subgroup size.
+  // Sourced from the yaml's `SUBGROUP_SIZE` template parameter — single
+  // source of truth shared with GLSL ${SUBGROUP_SIZE} substitution.
+  uint32_t required_subgroup_size = 0u;
+
   explicit ShaderInfo();
 
   explicit ShaderInfo(
@@ -82,7 +89,8 @@ struct ShaderInfo final {
       const bool requires_8bit_storage_ext,
       const bool requires_integer_dot_product_ext,
       const bool requires_shader_int64_ext,
-      const bool requires_shader_float64_ext);
+      const bool requires_shader_float64_ext,
+      const uint32_t required_subgroup_size_arg = 0u);
 
   operator bool() const {
     return src_code.bin != nullptr;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #19403
* #19402

Adds infrastructure for querying GPU subgroup capabilities and pinning required subgroup size at pipeline creation time, sourced from the existing `SUBGROUP_SIZE` yaml template parameter. This is the foundation for writing subgroup-using shaders (e.g. cooperative GEMV variants) that remain portable across GPUs with different subgroup widths (Adreno=64, Mali=16, NVIDIA=32, etc.).

`PhysicalDevice` now chains `VkPhysicalDeviceSubgroupProperties` and `VkPhysicalDeviceSubgroupSizeControlProperties` into `vkGetPhysicalDeviceProperties2`, plus `VkPhysicalDeviceSubgroupSizeControlFeatures` into `vkGetPhysicalDeviceFeatures2`. The `Adapter` exposes accessors for subgroup_size, supported subgroup ops/stages, [min,max] subgroup size range, and whether the driver supports per-pipeline required subgroup size for the COMPUTE stage. `VK_EXT_subgroup_size_control` is added to the requested extension list and the size-control features are chained into device-create pNext when supported.

`ComputePipeline::Descriptor` gains a `required_subgroup_size` field that, when nonzero, chains `VkPipelineShaderStageRequiredSubgroupSizeCreateInfoEXT` into pipeline creation (both the on-demand `retrieve` path and the batch `create_pipelines` path). The pipeline cache key includes the field so pipelines compiled for different subgroup widths cache independently. `ShaderInfo` carries the same field so it can be plumbed from shader yaml through to the pipeline descriptor.

The existing `SUBGROUP_SIZE` yaml template parameter is now the single source of truth: `gen_vulkan_spv.py` substitutes it into GLSL as before AND emits it as `ShaderInfo::required_subgroup_size`. At dispatch, `vkapi::resolve_required_subgroup_size` validates the value is within the adapter's `[min, max]` range and throws `ShaderNotSupportedError` if the extension is unsupported or the value is out of range, surfacing a clear failure rather than silently miscompiling a shader whose algorithm depends on the pinned subgroup width.

No shader yamls are modified by this change; subsequent commits opt their shaders into the pinning by declaring `SUBGROUP_SIZE` in their yamls.

Differential Revision: [D104456803](https://our.internmc.facebook.com/intern/diff/D104456803/)