### PR TITLE
Disable nullable-to-nonnull-conversion on ExecuTorch (#19407)

### DIFF
--- a/extension/apple/ExecuTorch/Exported/ExecuTorchModule.mm
+++ b/extension/apple/ExecuTorch/Exported/ExecuTorchModule.mm
@@ -314,7 +314,10 @@ static inline ExecuTorchValue *toExecuTorchValue(EValue value) NS_RETURNS_RETAIN
 
 - (BOOL)loadMethod:(NSString *)methodName
              error:(NSError **)error {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnullable-to-nonnull-conversion"
   const auto errorCode = _module->load_method(methodName.UTF8String);
+#pragma clang diagnostic pop
   if (errorCode != Error::Ok) {
     if (error) {
       *error = ExecuTorchErrorWithCode((ExecuTorchErrorCode)errorCode);
@@ -325,11 +328,17 @@ static inline ExecuTorchValue *toExecuTorchValue(EValue value) NS_RETURNS_RETAIN
 }
 
 - (BOOL)isMethodLoaded:(NSString *)methodName {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnullable-to-nonnull-conversion"
   return _module->is_method_loaded(methodName.UTF8String);
+#pragma clang diagnostic pop
 }
 
 - (BOOL)unloadMethod:(NSString *)methodName {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnullable-to-nonnull-conversion"
   const auto didUnload = _module->unload_method(methodName.UTF8String);
+#pragma clang diagnostic pop
   [_inputs removeObjectForKey:methodName];
   [_outputs removeObjectForKey:methodName];
   return didUnload;
@@ -352,7 +361,10 @@ static inline ExecuTorchValue *toExecuTorchValue(EValue value) NS_RETURNS_RETAIN
 
 - (nullable ExecuTorchMethodMetadata *)methodMetadata:(NSString *)methodName
                                                 error:(NSError **)error {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnullable-to-nonnull-conversion"
   const auto result = _module->method_meta(methodName.UTF8String);
+#pragma clang diagnostic pop
   if (!result.ok()) {
     if (error) {
       *error = ExecuTorchErrorWithCode((ExecuTorchErrorCode)result.error());
@@ -497,7 +509,10 @@ static inline ExecuTorchValue *toExecuTorchValue(EValue value) NS_RETURNS_RETAIN
        forMethod:(NSString *)methodName
          atIndex:(NSInteger)index
            error:(NSError **)error {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnullable-to-nonnull-conversion"
   const auto errorCode = _module->set_input(methodName.UTF8String, toEValue(value), index);
+#pragma clang diagnostic pop
   if (errorCode != Error::Ok) {
     if (error) {
       *error = ExecuTorchErrorWithCode((ExecuTorchErrorCode)errorCode);
@@ -537,7 +552,10 @@ static inline ExecuTorchValue *toExecuTorchValue(EValue value) NS_RETURNS_RETAIN
   for (ExecuTorchValue *value in values) {
     inputs.push_back(toEValue(value));
   }
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnullable-to-nonnull-conversion"
   const auto errorCode = _module->set_inputs(methodName.UTF8String, inputs);
+#pragma clang diagnostic pop
   if (errorCode != Error::Ok) {
     if (error) {
       *error = ExecuTorchErrorWithCode((ExecuTorchErrorCode)errorCode);
@@ -580,7 +598,10 @@ static inline ExecuTorchValue *toExecuTorchValue(EValue value) NS_RETURNS_RETAIN
         forMethod:(NSString *)methodName
           atIndex:(NSInteger)index
             error:(NSError **)error {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnullable-to-nonnull-conversion"
   const auto errorCode = _module->set_output(methodName.UTF8String, toEValue(value), index);
+#pragma clang diagnostic pop
   if (errorCode != Error::Ok) {
     if (error) {
       *error = ExecuTorchErrorWithCode((ExecuTorchErrorCode)errorCode);


### PR DESCRIPTION
Summary:

On the Xcode 26.4 compiler upgrade, we error on:

```
fbsource//xplat/executorch/extension/apple:ExecuTorch (objcxx_compile ExecuTorch/Exported/ExecuTorchModule.mm (pic))
Local command returned non-zero exit code 1
Reproduce locally: `env -C "$(buck2 root --kind project)" -- 'BUCK_SCRATCH_PATH=buck-out/v2/tmp/fbsource/32bf73e24dec3a3 ...<omitted>... tion___0__/output_artifacts/__dep_files_intermediaries__/ExecuTorch/Exported/ExecuTorchModule.mm.pic (run `buck2 log what-failed` to get the full command)`
stdout:
stderr:
clang++: warning: argument unused during compilation: '-fstack-clash-protection' [-Wunused-command-line-argument]
xplat/executorch/extension/apple/ExecuTorch/Exported/ExecuTorchModule.mm:317:47: error: implicit conversion from nullable pointer 'NS_RETURNS_INNER_POINTER const char *' to non-nullable pointer type 'const char * _Nonnull' [-Werror,-Wnullable-to-nonnull-conversion]
  317 |   const auto errorCode = _module->load_method(methodName.UTF8String);
      |                                               ^```

Disable this error.

Differential Revision: D104463212


