### PR TITLE
Change repository name from 'pytorch' to 'executorch'

### DIFF
--- a/.github/scripts/docathon-label-sync.py
+++ b/.github/scripts/docathon-label-sync.py
@@ -9,7 +9,7 @@ def main() -> None:
     token = os.environ.get("GITHUB_TOKEN")
 
     repo_owner = "pytorch"
-    repo_name = "pytorch"
+    repo_name = "executorch"
     pull_request_number = int(sys.argv[1])
 
     g = Github(token)


### PR DESCRIPTION
Change as part of automation for PyTorch Docathon 