### PR TITLE
bring cuda export ci back by using A100 as target GPU (#19440)

### DIFF
--- a/backends/cuda/tests/TARGETS
+++ b/backends/cuda/tests/TARGETS
@@ -1,6 +1,7 @@
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 load("@fbcode_macros//build_defs:python_unittest.bzl", "python_unittest")
 load("@fbcode_macros//build_defs:python_unittest_remote_gpu.bzl", "python_unittest_remote_gpu")
+load("@fbcode_macros//build_defs/lib:re_test_utils.bzl", "re_test_utils")
 
 oncall("executorch")
 
@@ -22,6 +23,11 @@ python_unittest_remote_gpu(
         "//executorch/examples/models/toy_model:toy_model",
     ],
     keep_gpu_sections = True,
+    remote_execution = re_test_utils.remote_execution(
+        subplatform = "A100",
+        mig = "false",
+        platform = "gpu-remote-execution",
+    ),
 )
 
 python_unittest(


### PR DESCRIPTION
Summary:

Currently ci keeps crash by the error msg `Not enough SMs to use max_autotune_gemm mode` due to gpu resource limitation. Make ci always run on A100 to bring ci back

Differential Revision: D104504782


