### PR TITLE
Fix nullable-to-nonnull conversion warnings in ExecuTorchModule

### DIFF
--- a/extension/apple/ExecuTorch/Exported/ExecuTorchModule.mm
+++ b/extension/apple/ExecuTorch/Exported/ExecuTorchModule.mm
@@ -17,6 +17,10 @@
 using namespace executorch::extension;
 using namespace executorch::runtime;
 
+static inline const char *_Nonnull safeUTF8String(NSString *_Nonnull string) {
+  return string.UTF8String ?: "";
+}
+
 static inline EValue toEValue(ExecuTorchValue *value) {
   if (value.isTensor) {
     auto *nativeTensorPtr = value.tensorValue.nativeInstance;
@@ -258,11 +262,11 @@ static inline ExecuTorchValue *toExecuTorchValue(EValue value) NS_RETURNS_RETAIN
     std::vector<std::string> dataFilePathsVector;
     if (dataFilePaths != nil) {
       for (NSString *dataFile in dataFilePaths) {
-        dataFilePathsVector.emplace_back(dataFile.UTF8String);
+        dataFilePathsVector.emplace_back(safeUTF8String(dataFile));
       }
     }
     _module = std::make_unique<Module>(
-      filePath.UTF8String,
+      safeUTF8String(filePath),
       dataFilePathsVector,
       static_cast<Module::LoadMode>(loadMode)
     );
@@ -314,7 +318,7 @@ static inline ExecuTorchValue *toExecuTorchValue(EValue value) NS_RETURNS_RETAIN
 
 - (BOOL)loadMethod:(NSString *)methodName
              error:(NSError **)error {
-  const auto errorCode = _module->load_method(methodName.UTF8String);
+  const auto errorCode = _module->load_method(safeUTF8String(methodName));
   if (errorCode != Error::Ok) {
     if (error) {
       *error = ExecuTorchErrorWithCode((ExecuTorchErrorCode)errorCode);
@@ -325,11 +329,11 @@ static inline ExecuTorchValue *toExecuTorchValue(EValue value) NS_RETURNS_RETAIN
 }
 
 - (BOOL)isMethodLoaded:(NSString *)methodName {
-  return _module->is_method_loaded(methodName.UTF8String);
+  return _module->is_method_loaded(safeUTF8String(methodName));
 }
 
 - (BOOL)unloadMethod:(NSString *)methodName {
-  const auto didUnload = _module->unload_method(methodName.UTF8String);
+  const auto didUnload = _module->unload_method(safeUTF8String(methodName));
   [_inputs removeObjectForKey:methodName];
   [_outputs removeObjectForKey:methodName];
   return didUnload;
@@ -352,7 +356,7 @@ static inline ExecuTorchValue *toExecuTorchValue(EValue value) NS_RETURNS_RETAIN
 
 - (nullable ExecuTorchMethodMetadata *)methodMetadata:(NSString *)methodName
                                                 error:(NSError **)error {
-  const auto result = _module->method_meta(methodName.UTF8String);
+  const auto result = _module->method_meta(safeUTF8String(methodName));
   if (!result.ok()) {
     if (error) {
       *error = ExecuTorchErrorWithCode((ExecuTorchErrorCode)result.error());
@@ -366,7 +370,7 @@ static inline ExecuTorchValue *toExecuTorchValue(EValue value) NS_RETURNS_RETAIN
 - (nullable NSArray<ExecuTorchValue *> *)executeMethod:(NSString *)methodName
                                             withInputs:(NSArray<ExecuTorchValue *> *)values
                                                  error:(NSError **)error {
-  const char *methodNameString = methodName.UTF8String;
+  const char *methodNameString = safeUTF8String(methodName);
   __block auto errorCode = Error::Ok;
   [values enumerateObjectsUsingBlock:^(ExecuTorchValue *value, NSUInteger index, BOOL *stop) {
     errorCode = _module->set_input(methodNameString, toEValue(value), index);
@@ -497,7 +501,7 @@ static inline ExecuTorchValue *toExecuTorchValue(EValue value) NS_RETURNS_RETAIN
        forMethod:(NSString *)methodName
          atIndex:(NSInteger)index
            error:(NSError **)error {
-  const auto errorCode = _module->set_input(methodName.UTF8String, toEValue(value), index);
+  const auto errorCode = _module->set_input(safeUTF8String(methodName), toEValue(value), index);
   if (errorCode != Error::Ok) {
     if (error) {
       *error = ExecuTorchErrorWithCode((ExecuTorchErrorCode)errorCode);
@@ -537,7 +541,7 @@ static inline ExecuTorchValue *toExecuTorchValue(EValue value) NS_RETURNS_RETAIN
   for (ExecuTorchValue *value in values) {
     inputs.push_back(toEValue(value));
   }
-  const auto errorCode = _module->set_inputs(methodName.UTF8String, inputs);
+  const auto errorCode = _module->set_inputs(safeUTF8String(methodName), inputs);
   if (errorCode != Error::Ok) {
     if (error) {
       *error = ExecuTorchErrorWithCode((ExecuTorchErrorCode)errorCode);
@@ -580,7 +584,7 @@ static inline ExecuTorchValue *toExecuTorchValue(EValue value) NS_RETURNS_RETAIN
         forMethod:(NSString *)methodName
           atIndex:(NSInteger)index
             error:(NSError **)error {
-  const auto errorCode = _module->set_output(methodName.UTF8String, toEValue(value), index);
+  const auto errorCode = _module->set_output(safeUTF8String(methodName), toEValue(value), index);
   if (errorCode != Error::Ok) {
     if (error) {
       *error = ExecuTorchErrorWithCode((ExecuTorchErrorCode)errorCode);


### PR DESCRIPTION
Summary:
## Motivation

We have a build failure because the Xcode staging toolchain (clang19) treats `-Wnullable-to-nonnull-conversion` as an error. `NSString.UTF8String` is declared as returning `const char * _Nullable`, but ExecuTorch's C++ Module methods expect `const char * _Nonnull`. The production toolchain doesn't flag this, but the staging toolchain does, blocking the affected build.

## This Diff

Adds a `safeUTF8String()` helper that returns `string.UTF8String ?: ""` — falling back to an empty string if UTF8String ever returns nil. Applied to all 8 call sites in ExecuTorchModule.mm.

Alternatives considered:
- **Explicit nil check + error return at each site**: Safest, but adds 5+ lines of boilerplate at each of 8 sites. Overkill given UTF8String on a valid NSString essentially never returns nil.
- **Cast to _Nonnull**: Simpler one-liner but crashes with undefined behavior if UTF8String ever did return nil.
- **`#pragma clang diagnostic ignored`**: Suppresses the warning but doesn't fix the underlying issue.

The `?: ""` approach was chosen because: it won't crash (empty string is valid), ExecuTorch will return a "method not found" error which existing error handling already surfaces, and the nil case is essentially impossible for ASCII method name strings. The only downside is a slightly misleading error message in the astronomically unlikely failure case.

Differential Revision: D104697173


