### PR TITLE
Sync FB ArmPassManager with public DecomposeGruPass

### DIFF
--- a/backends/arm/_passes/decompose_gru_pass.py
+++ b/backends/arm/_passes/decompose_gru_pass.py
@@ -66,6 +66,9 @@ class DecomposeGruPass(ArmPass):
     ) -> Tuple[List[torch.fx.Node], torch.fx.Node]:
         """Build GRU cell computation for one direction.
 
+        Uses aten.linear (matching PyTorch's standard decomposition) instead
+        of raw mm to avoid ConvertMmToBmmPass issues with quantized tensors.
+
         Returns (timestep_outputs, h_final) where timestep_outputs are
         unsqueezed hidden states in forward time order.
 

--- a/backends/arm/quantizable/TARGETS
+++ b/backends/arm/quantizable/TARGETS
@@ -1,0 +1,9 @@
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+
+runtime.python_library(
+    name = "quantizable",
+    srcs = glob(["*.py"]),
+    deps = [
+        "//caffe2:torch",
+    ],
+)

--- a/backends/arm/quantizable/__init__.py
+++ b/backends/arm/quantizable/__init__.py
@@ -1,0 +1,7 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from .gru import GRU  # noqa
+from .rnn import RNN  # noqa

--- a/backends/arm/quantizable/gru.py
+++ b/backends/arm/quantizable/gru.py
@@ -1,0 +1,364 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Quantizable GRU modules following the torch.ao.nn.quantizable.LSTM pattern.
+
+The standard nn.GRU is an opaque composite op that the quantizer cannot
+annotate. This module decomposes GRU into nn.Linear + FloatFunctional
+so that QAT observers can be inserted at each arithmetic boundary.
+
+GRU cell equations:
+    r_t = sigmoid(x_t @ W_ir.T + b_ir + h_{t-1} @ W_hr.T + b_hr)
+    z_t = sigmoid(x_t @ W_iz.T + b_iz + h_{t-1} @ W_hz.T + b_hz)
+    n_t = tanh(x_t @ W_in.T + b_in + r_t * (h_{t-1} @ W_hn.T + b_hn))
+    h_t = (1 - z_t) * n_t + z_t * h_{t-1}
+
+"""
+
+from typing import List, Optional, Tuple
+
+import torch
+from torch import nn, Tensor
+
+
+class GRUCell(nn.Module):
+    """A quantizable GRU cell with FloatFunctional ops for each arithmetic boundary."""
+
+    _FLOAT_MODULE = nn.GRUCell
+
+    def __init__(
+        self,
+        input_size: int,
+        hidden_size: int,
+        bias: bool = True,
+        device=None,
+        dtype=None,
+    ) -> None:
+        factory_kwargs = {"device": device, "dtype": dtype}
+        super().__init__()
+        self.input_size = input_size
+        self.hidden_size = hidden_size
+        self.bias = bias
+
+        # Input projections: x_t -> [r, z, n] (3*hidden_size)
+        self.input_linear = nn.Linear(
+            input_size, 3 * hidden_size, bias=bias, **factory_kwargs
+        )
+        # Hidden projections: h_{t-1} -> [r, z, n] (3*hidden_size)
+        self.hidden_linear = nn.Linear(
+            hidden_size, 3 * hidden_size, bias=bias, **factory_kwargs
+        )
+
+        # Gate activations
+        self.reset_gate = nn.Sigmoid()
+        self.update_gate = nn.Sigmoid()
+        self.new_gate = nn.Tanh()
+
+        # FloatFunctional for each observable arithmetic op
+        self.add_r = torch.ao.nn.quantized.FloatFunctional()  # input_r + hidden_r
+        self.add_z = torch.ao.nn.quantized.FloatFunctional()  # input_z + hidden_z
+        self.mul_r_nh = torch.ao.nn.quantized.FloatFunctional()  # r_t * hidden_n
+        self.add_n = torch.ao.nn.quantized.FloatFunctional()  # input_n + r*hidden_n
+        self.mul_1mz_n = torch.ao.nn.quantized.FloatFunctional()  # (1-z) * n
+        self.mul_z_h = torch.ao.nn.quantized.FloatFunctional()  # z * h_{t-1}
+        self.add_h = torch.ao.nn.quantized.FloatFunctional()  # (1-z)*n + z*h
+
+    def forward(self, x: Tensor, hidden: Optional[Tensor] = None) -> Tensor:
+        if hidden is None:
+            hidden = torch.zeros(x.shape[0], self.hidden_size, device=x.device)
+
+        igates = self.input_linear(x)
+        hgates = self.hidden_linear(hidden)
+
+        # Split into r, z, n components
+        H = self.hidden_size
+        input_r, input_z, input_n = (
+            igates[:, :H],
+            igates[:, H : 2 * H],
+            igates[:, 2 * H :],
+        )
+        hidden_r, hidden_z, hidden_n = (
+            hgates[:, :H],
+            hgates[:, H : 2 * H],
+            hgates[:, 2 * H :],
+        )
+
+        r_t = self.reset_gate(self.add_r.add(input_r, hidden_r))
+        z_t = self.update_gate(self.add_z.add(input_z, hidden_z))
+        n_t = self.new_gate(self.add_n.add(input_n, self.mul_r_nh.mul(r_t, hidden_n)))
+
+        h_t = self.add_h.add(
+            self.mul_1mz_n.mul(1.0 - z_t, n_t),
+            self.mul_z_h.mul(z_t, hidden),
+        )
+        return h_t
+
+    @classmethod
+    def from_params(
+        cls,
+        wi: Tensor,
+        wh: Tensor,
+        bi: Optional[Tensor] = None,
+        bh: Optional[Tensor] = None,
+    ) -> "GRUCell":
+        input_size = wi.shape[1]
+        hidden_size = wh.shape[1]
+        cell = cls(input_size, hidden_size, bias=(bi is not None))
+        cell.input_linear.weight = nn.Parameter(wi)
+        if bi is not None:
+            cell.input_linear.bias = nn.Parameter(bi)
+        cell.hidden_linear.weight = nn.Parameter(wh)
+        if bh is not None:
+            cell.hidden_linear.bias = nn.Parameter(bh)
+        return cell
+
+    @classmethod
+    def from_float(cls, other, use_precomputed_fake_quant=False):
+        assert type(other) is cls._FLOAT_MODULE
+        assert hasattr(other, "qconfig"), "The float module must have 'qconfig'"
+        observed = cls.from_params(
+            other.weight_ih,
+            other.weight_hh,
+            other.bias_ih,
+            other.bias_hh,
+        )
+        observed.qconfig = other.qconfig
+        observed.input_linear.qconfig = other.qconfig
+        observed.hidden_linear.qconfig = other.qconfig
+        return observed
+
+
+class _GRUSingleLayer(nn.Module):
+    """A single one-directional GRU layer that processes a sequence."""
+
+    def __init__(
+        self,
+        input_size: int,
+        hidden_size: int,
+        bias: bool = True,
+        device=None,
+        dtype=None,
+    ) -> None:
+        factory_kwargs = {"device": device, "dtype": dtype}
+        super().__init__()
+        self.cell = GRUCell(input_size, hidden_size, bias=bias, **factory_kwargs)
+
+    def forward(
+        self,
+        x: Tensor,
+        hidden: Optional[Tensor] = None,
+        reverse: bool = False,
+    ) -> Tuple[Tensor, Tensor]:
+        result = []
+        seq_len = x.shape[0]
+        indices = range(seq_len - 1, -1, -1) if reverse else range(seq_len)
+        for i in indices:
+            hidden = self.cell(x[i], hidden)
+            result.append(hidden)
+        if reverse:
+            result.reverse()
+        return torch.stack(result, 0), hidden
+
+    @classmethod
+    def from_params(cls, *args, **kwargs):
+        cell = GRUCell.from_params(*args, **kwargs)
+        layer = cls(cell.input_size, cell.hidden_size, cell.bias)
+        layer.cell = cell
+        return layer
+
+
+class _GRULayer(nn.Module):
+    """A single bi-directional GRU layer."""
+
+    def __init__(
+        self,
+        input_size: int,
+        hidden_size: int,
+        bias: bool = True,
+        batch_first: bool = False,
+        bidirectional: bool = False,
+        device=None,
+        dtype=None,
+    ) -> None:
+        factory_kwargs = {"device": device, "dtype": dtype}
+        super().__init__()
+        self.batch_first = batch_first
+        self.bidirectional = bidirectional
+        self.layer_fw = _GRUSingleLayer(
+            input_size, hidden_size, bias=bias, **factory_kwargs
+        )
+        if self.bidirectional:
+            self.layer_bw = _GRUSingleLayer(
+                input_size, hidden_size, bias=bias, **factory_kwargs
+            )
+
+    def forward(
+        self, x: Tensor, hidden: Optional[Tensor] = None
+    ) -> Tuple[Tensor, Tensor]:
+        if self.batch_first:
+            x = x.transpose(0, 1)
+
+        hx_fw = None
+        hx_bw = None
+        if hidden is not None:
+            if self.bidirectional:
+                hx_fw = hidden[0]
+                hx_bw = hidden[1]
+            else:
+                hx_fw = hidden
+
+        result_fw, h_fw = self.layer_fw(x, hx_fw)
+
+        if self.bidirectional:
+            result_bw, h_bw = self.layer_bw(x, hx_bw, reverse=True)
+            result = torch.cat([result_fw, result_bw], result_fw.dim() - 1)
+            h = torch.stack([h_fw, h_bw], 0)
+        else:
+            result = result_fw
+            h = h_fw
+
+        if self.batch_first:
+            result = result.transpose(0, 1)
+
+        return result, h
+
+    @classmethod
+    def from_float(cls, other, layer_idx=0, qconfig=None, **kwargs):
+        assert hasattr(other, "qconfig") or (qconfig is not None)
+
+        input_size = kwargs.get("input_size", other.input_size)
+        hidden_size = kwargs.get("hidden_size", other.hidden_size)
+        bias = kwargs.get("bias", other.bias)
+        batch_first = kwargs.get("batch_first", other.batch_first)
+        bidirectional = kwargs.get("bidirectional", other.bidirectional)
+
+        layer = cls(input_size, hidden_size, bias, batch_first, bidirectional)
+        layer.qconfig = getattr(other, "qconfig", qconfig)
+
+        wi = getattr(other, f"weight_ih_l{layer_idx}")
+        wh = getattr(other, f"weight_hh_l{layer_idx}")
+        bi = getattr(other, f"bias_ih_l{layer_idx}", None)
+        bh = getattr(other, f"bias_hh_l{layer_idx}", None)
+        layer.layer_fw = _GRUSingleLayer.from_params(wi, wh, bi, bh)
+
+        if other.bidirectional:
+            wi = getattr(other, f"weight_ih_l{layer_idx}_reverse")
+            wh = getattr(other, f"weight_hh_l{layer_idx}_reverse")
+            bi = getattr(other, f"bias_ih_l{layer_idx}_reverse", None)
+            bh = getattr(other, f"bias_hh_l{layer_idx}_reverse", None)
+            layer.layer_bw = _GRUSingleLayer.from_params(wi, wh, bi, bh)
+        return layer
+
+
+class GRU(nn.Module):
+    """A quantizable GRU following the torch.ao.nn.quantizable.LSTM pattern.
+
+Converts a standard nn.GRU into observable form with nn.Linear +
+    FloatFunctional ops for each arithmetic boundary.
+
+    """
+
+    _FLOAT_MODULE = nn.GRU
+
+    def __init__(
+        self,
+        input_size: int,
+        hidden_size: int,
+        num_layers: int = 1,
+        bias: bool = True,
+        batch_first: bool = False,
+        dropout: float = 0.0,
+        bidirectional: bool = False,
+        device=None,
+        dtype=None,
+    ) -> None:
+        factory_kwargs = {"device": device, "dtype": dtype}
+        super().__init__()
+        self.input_size = input_size
+        self.hidden_size = hidden_size
+        self.num_layers = num_layers
+        self.bias = bias
+        self.batch_first = batch_first
+        self.dropout = float(dropout)
+        self.bidirectional = bidirectional
+        self.training = False
+
+        num_directions = 2 if bidirectional else 1
+        layers: List[_GRULayer] = [
+            _GRULayer(
+                input_size,
+                hidden_size,
+                bias,
+                batch_first=False,
+                bidirectional=bidirectional,
+                **factory_kwargs,
+            )
+        ]
+        for _ in range(1, num_layers):
+            layers.append(
+                _GRULayer(
+                    hidden_size * num_directions,
+                    hidden_size,
+                    bias,
+                    batch_first=False,
+                    bidirectional=bidirectional,
+                    **factory_kwargs,
+                )
+            )
+        self.layers = nn.ModuleList(layers)
+
+    def forward(
+        self, x: Tensor, hidden: Optional[Tensor] = None
+    ) -> Tuple[Tensor, Tensor]:
+        if self.batch_first:
+            x = x.transpose(0, 1)
+
+        num_directions = 2 if self.bidirectional else 1
+        if hidden is None:
+            hx_list = [None] * self.num_layers
+        else:
+            hx = hidden.reshape(
+                self.num_layers, num_directions, hidden.shape[-2], hidden.shape[-1]
+            )
+            hx_list = [hx[idx].squeeze(0) for idx in range(self.num_layers)]
+
+        h_list = []
+        for idx, layer in enumerate(self.layers):
+            x, h = layer(x, hx_list[idx])
+            h_list.append(h)
+
+        h_tensor = torch.stack(h_list)
+        h_tensor = h_tensor.reshape(-1, h_tensor.shape[-2], h_tensor.shape[-1])
+
+        if self.batch_first:
+            x = x.transpose(0, 1)
+
+        return x, h_tensor
+
+    @classmethod
+    def from_float(cls, other, qconfig=None):
+        assert isinstance(other, cls._FLOAT_MODULE)
+        assert hasattr(other, "qconfig") or qconfig
+        observed = cls(
+            other.input_size,
+            other.hidden_size,
+            other.num_layers,
+            other.bias,
+            other.batch_first,
+            other.dropout,
+            other.bidirectional,
+        )
+        observed.qconfig = getattr(other, "qconfig", qconfig)
+        for idx in range(other.num_layers):
+            observed.layers[idx] = _GRULayer.from_float(
+                other, idx, qconfig, batch_first=False
+            )
+        if other.training:
+            observed.train()
+            observed = torch.ao.quantization.prepare_qat(observed, inplace=True)
+        else:
+            observed.eval()
+            observed = torch.ao.quantization.prepare(observed, inplace=True)
+        return observed

--- a/backends/arm/quantizable/rnn.py
+++ b/backends/arm/quantizable/rnn.py
@@ -1,0 +1,372 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Quantizable RNN modules following the torch.ao.nn.quantizable.LSTM pattern.
+
+The standard nn.RNN is an opaque composite op that the quantizer cannot
+annotate. This module decomposes RNN into nn.Linear + FloatFunctional
+so that QAT observers can be inserted at each arithmetic boundary.
+
+"""
+
+from typing import List, Optional, Tuple
+
+import torch
+from torch import nn, Tensor
+
+
+class RNNCell(nn.Module):
+    """A quantizable RNN cell.
+
+    Equation: h_t = activation(x_t @ W_ih.T + b_ih + h_{t-1} @ W_hh.T + b_hh)
+
+Uses nn.Linear for projections and FloatFunctional for the addition,
+    making each arithmetic op observable for quantization.
+
+    """
+
+    _FLOAT_MODULE = nn.RNNCell
+
+    def __init__(
+        self,
+        input_size: int,
+        hidden_size: int,
+        bias: bool = True,
+        nonlinearity: str = "tanh",
+        device=None,
+        dtype=None,
+    ) -> None:
+        factory_kwargs = {"device": device, "dtype": dtype}
+        super().__init__()
+        self.input_size = input_size
+        self.hidden_size = hidden_size
+        self.bias = bias
+        self.nonlinearity = nonlinearity
+
+        self.input_linear = nn.Linear(
+            input_size, hidden_size, bias=bias, **factory_kwargs
+        )
+        self.hidden_linear = nn.Linear(
+            hidden_size, hidden_size, bias=bias, **factory_kwargs
+        )
+        self.add_gates = torch.ao.nn.quantized.FloatFunctional()
+
+        if nonlinearity == "tanh":
+            self.activation = nn.Tanh()
+        elif nonlinearity == "relu":
+            self.activation = nn.ReLU()
+        else:
+            raise ValueError(f"Unknown nonlinearity: {nonlinearity}")
+
+    def forward(self, x: Tensor, hidden: Optional[Tensor] = None) -> Tensor:
+        if hidden is None:
+            hidden = torch.zeros(x.shape[0], self.hidden_size, device=x.device)
+        gates = self.add_gates.add(self.input_linear(x), self.hidden_linear(hidden))
+        return self.activation(gates)
+
+    @classmethod
+    def from_params(
+        cls,
+        wi: Tensor,
+        wh: Tensor,
+        bi: Optional[Tensor] = None,
+        bh: Optional[Tensor] = None,
+        nonlinearity: str = "tanh",
+    ) -> "RNNCell":
+        input_size = wi.shape[1]
+        hidden_size = wh.shape[1]
+        cell = cls(
+            input_size, hidden_size, bias=(bi is not None), nonlinearity=nonlinearity
+        )
+        cell.input_linear.weight = nn.Parameter(wi)
+        if bi is not None:
+            cell.input_linear.bias = nn.Parameter(bi)
+        cell.hidden_linear.weight = nn.Parameter(wh)
+        if bh is not None:
+            cell.hidden_linear.bias = nn.Parameter(bh)
+        return cell
+
+    @classmethod
+    def from_float(cls, other, use_precomputed_fake_quant=False):
+        assert type(other) is cls._FLOAT_MODULE
+        assert hasattr(other, "qconfig"), "The float module must have 'qconfig'"
+        observed = cls.from_params(
+            other.weight_ih,
+            other.weight_hh,
+            other.bias_ih,
+            other.bias_hh,
+            nonlinearity=other.nonlinearity,
+        )
+        observed.qconfig = other.qconfig
+        observed.input_linear.qconfig = other.qconfig
+        observed.hidden_linear.qconfig = other.qconfig
+        return observed
+
+
+class _RNNSingleLayer(nn.Module):
+    """A single one-directional RNN layer that processes a sequence."""
+
+    def __init__(
+        self,
+        input_size: int,
+        hidden_size: int,
+        bias: bool = True,
+        nonlinearity: str = "tanh",
+        device=None,
+        dtype=None,
+    ) -> None:
+        factory_kwargs = {"device": device, "dtype": dtype}
+        super().__init__()
+        self.cell = RNNCell(
+            input_size,
+            hidden_size,
+            bias=bias,
+            nonlinearity=nonlinearity,
+            **factory_kwargs,
+        )
+
+    def forward(
+        self,
+        x: Tensor,
+        hidden: Optional[Tensor] = None,
+        reverse: bool = False,
+    ) -> Tuple[Tensor, Tensor]:
+        result = []
+        seq_len = x.shape[0]
+        indices = range(seq_len - 1, -1, -1) if reverse else range(seq_len)
+        for i in indices:
+            hidden = self.cell(x[i], hidden)
+            result.append(hidden)
+        if reverse:
+            result.reverse()
+        return torch.stack(result, 0), hidden
+
+    @classmethod
+    def from_params(cls, *args, **kwargs):
+        cell = RNNCell.from_params(*args, **kwargs)
+        layer = cls(cell.input_size, cell.hidden_size, cell.bias, cell.nonlinearity)
+        layer.cell = cell
+        return layer
+
+
+class _RNNLayer(nn.Module):
+    """A single bi-directional RNN layer."""
+
+    def __init__(
+        self,
+        input_size: int,
+        hidden_size: int,
+        bias: bool = True,
+        batch_first: bool = False,
+        bidirectional: bool = False,
+        nonlinearity: str = "tanh",
+        device=None,
+        dtype=None,
+    ) -> None:
+        factory_kwargs = {"device": device, "dtype": dtype}
+        super().__init__()
+        self.batch_first = batch_first
+        self.bidirectional = bidirectional
+        self.layer_fw = _RNNSingleLayer(
+            input_size,
+            hidden_size,
+            bias=bias,
+            nonlinearity=nonlinearity,
+            **factory_kwargs,
+        )
+        if self.bidirectional:
+            self.layer_bw = _RNNSingleLayer(
+                input_size,
+                hidden_size,
+                bias=bias,
+                nonlinearity=nonlinearity,
+                **factory_kwargs,
+            )
+
+    def forward(
+        self, x: Tensor, hidden: Optional[Tensor] = None
+    ) -> Tuple[Tensor, Tensor]:
+        if self.batch_first:
+            x = x.transpose(0, 1)
+
+        hx_fw = None
+        hx_bw = None
+        if hidden is not None:
+            if self.bidirectional:
+                hx_fw = hidden[0]
+                hx_bw = hidden[1]
+            else:
+                hx_fw = hidden
+
+        result_fw, h_fw = self.layer_fw(x, hx_fw)
+
+        if self.bidirectional:
+            result_bw, h_bw = self.layer_bw(x, hx_bw, reverse=True)
+            result = torch.cat([result_fw, result_bw], result_fw.dim() - 1)
+            h = torch.stack([h_fw, h_bw], 0)
+        else:
+            result = result_fw
+            h = h_fw
+
+        if self.batch_first:
+            result = result.transpose(0, 1)
+
+        return result, h
+
+    @classmethod
+    def from_float(cls, other, layer_idx=0, qconfig=None, **kwargs):
+        assert hasattr(other, "qconfig") or (qconfig is not None)
+
+        input_size = kwargs.get("input_size", other.input_size)
+        hidden_size = kwargs.get("hidden_size", other.hidden_size)
+        bias = kwargs.get("bias", other.bias)
+        batch_first = kwargs.get("batch_first", other.batch_first)
+        bidirectional = kwargs.get("bidirectional", other.bidirectional)
+        nonlinearity = kwargs.get("nonlinearity", other.nonlinearity)
+
+        layer = cls(
+            input_size,
+            hidden_size,
+            bias,
+            batch_first,
+            bidirectional,
+            nonlinearity=nonlinearity,
+        )
+        layer.qconfig = getattr(other, "qconfig", qconfig)
+
+        wi = getattr(other, f"weight_ih_l{layer_idx}")
+        wh = getattr(other, f"weight_hh_l{layer_idx}")
+        bi = getattr(other, f"bias_ih_l{layer_idx}", None)
+        bh = getattr(other, f"bias_hh_l{layer_idx}", None)
+        layer.layer_fw = _RNNSingleLayer.from_params(
+            wi, wh, bi, bh, nonlinearity=nonlinearity
+        )
+
+        if other.bidirectional:
+            wi = getattr(other, f"weight_ih_l{layer_idx}_reverse")
+            wh = getattr(other, f"weight_hh_l{layer_idx}_reverse")
+            bi = getattr(other, f"bias_ih_l{layer_idx}_reverse", None)
+            bh = getattr(other, f"bias_hh_l{layer_idx}_reverse", None)
+            layer.layer_bw = _RNNSingleLayer.from_params(
+                wi, wh, bi, bh, nonlinearity=nonlinearity
+            )
+        return layer
+
+
+class RNN(nn.Module):
+    """A quantizable RNN following the torch.ao.nn.quantizable.LSTM pattern.
+
+Converts a standard nn.RNN into observable form with nn.Linear +
+    FloatFunctional ops for each arithmetic boundary.
+
+    """
+
+    _FLOAT_MODULE = nn.RNN
+
+    def __init__(
+        self,
+        input_size: int,
+        hidden_size: int,
+        num_layers: int = 1,
+        bias: bool = True,
+        batch_first: bool = False,
+        dropout: float = 0.0,
+        bidirectional: bool = False,
+        nonlinearity: str = "tanh",
+        device=None,
+        dtype=None,
+    ) -> None:
+        factory_kwargs = {"device": device, "dtype": dtype}
+        super().__init__()
+        self.input_size = input_size
+        self.hidden_size = hidden_size
+        self.num_layers = num_layers
+        self.bias = bias
+        self.batch_first = batch_first
+        self.dropout = float(dropout)
+        self.bidirectional = bidirectional
+        self.nonlinearity = nonlinearity
+        self.training = False
+
+        num_directions = 2 if bidirectional else 1
+        layers: List[_RNNLayer] = [
+            _RNNLayer(
+                input_size,
+                hidden_size,
+                bias,
+                batch_first=False,
+                bidirectional=bidirectional,
+                nonlinearity=nonlinearity,
+                **factory_kwargs,
+            )
+        ]
+        for _ in range(1, num_layers):
+            layers.append(
+                _RNNLayer(
+                    hidden_size * num_directions,
+                    hidden_size,
+                    bias,
+                    batch_first=False,
+                    bidirectional=bidirectional,
+                    nonlinearity=nonlinearity,
+                    **factory_kwargs,
+                )
+            )
+        self.layers = nn.ModuleList(layers)
+
+    def forward(
+        self, x: Tensor, hidden: Optional[Tensor] = None
+    ) -> Tuple[Tensor, Tensor]:
+        if self.batch_first:
+            x = x.transpose(0, 1)
+
+        num_directions = 2 if self.bidirectional else 1
+        if hidden is None:
+            hx_list = [None] * self.num_layers
+        else:
+            hx = hidden.reshape(
+                self.num_layers, num_directions, hidden.shape[-2], hidden.shape[-1]
+            )
+            hx_list = [hx[idx].squeeze(0) for idx in range(self.num_layers)]
+
+        h_list = []
+        for idx, layer in enumerate(self.layers):
+            x, h = layer(x, hx_list[idx])
+            h_list.append(h)
+
+        h_tensor = torch.stack(h_list)
+        h_tensor = h_tensor.reshape(-1, h_tensor.shape[-2], h_tensor.shape[-1])
+
+        if self.batch_first:
+            x = x.transpose(0, 1)
+
+        return x, h_tensor
+
+    @classmethod
+    def from_float(cls, other, qconfig=None):
+        assert isinstance(other, cls._FLOAT_MODULE)
+        assert hasattr(other, "qconfig") or qconfig
+        observed = cls(
+            other.input_size,
+            other.hidden_size,
+            other.num_layers,
+            other.bias,
+            other.batch_first,
+            other.dropout,
+            other.bidirectional,
+            nonlinearity=other.nonlinearity,
+        )
+        observed.qconfig = getattr(other, "qconfig", qconfig)
+        for idx in range(other.num_layers):
+            observed.layers[idx] = _RNNLayer.from_float(
+                other, idx, qconfig, batch_first=False
+            )
+        if other.training:
+            observed.train()
+            observed = torch.ao.quantization.prepare_qat(observed, inplace=True)
+        else:
+            observed.eval()
+            observed = torch.ao.quantization.prepare(observed, inplace=True)
+        return observed

--- a/backends/arm/test/passes/test_decompose_recurrent_tosa_pipelines.py
+++ b/backends/arm/test/passes/test_decompose_recurrent_tosa_pipelines.py
@@ -1,0 +1,224 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+"""End-to-end TosaPipeline tests for recurrent layer decomposition passes.
+
+Tests DecomposeRnnPass, DecomposeGruPass, and DecomposeLstmPass through
+the full ARM/TOSA lowering pipeline using TosaPipelineFP (floating point)
+and TosaPipelineINT (quantized INT8) to verify that decomposed recurrent
+layers compile and run correctly on the TOSA reference model.
+
+These complement the pass-specific unit tests in test_decompose_rnn_pass.py,
+test_decompose_gru_pass.py, and test_decompose_lstm_pass.py.
+"""
+
+from typing import Tuple
+
+import torch
+from executorch.backends.arm.test import common
+from executorch.backends.arm.test.tester.test_pipeline import (
+    EthosU55PipelineINT,
+    EthosU85PipelineINT,
+    TosaPipelineFP,
+    TosaPipelineINT,
+)
+
+
+# ──────────────────────────── Input type aliases ────────────────────────────
+
+rnn_input_t = Tuple[torch.Tensor, torch.Tensor]  # (x, h)
+lstm_input_t = Tuple[torch.Tensor, torch.Tensor, torch.Tensor]  # (x, h0, c0)
+
+
+# ──────────────────────────── Model definitions ─────────────────────────────
+
+
+class RNNTanh(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.rnn = torch.nn.RNN(10, 20, 1, nonlinearity="tanh", batch_first=True)
+
+    def forward(
+        self, x: torch.Tensor, h: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        return self.rnn(x, h)
+
+    @staticmethod
+    def get_inputs() -> rnn_input_t:
+        return (torch.randn(2, 5, 10), torch.randn(1, 2, 20))
+
+
+class RNNRelu(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.rnn = torch.nn.RNN(10, 20, 1, nonlinearity="relu", batch_first=True)
+
+    def forward(
+        self, x: torch.Tensor, h: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        return self.rnn(x, h)
+
+    @staticmethod
+    def get_inputs() -> rnn_input_t:
+        return (torch.randn(2, 5, 10), torch.randn(1, 2, 20))
+
+
+class GRU(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.gru = torch.nn.GRU(10, 20, 1, batch_first=True)
+
+    def forward(
+        self, x: torch.Tensor, h: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        return self.gru(x, h)
+
+    @staticmethod
+    def get_inputs() -> rnn_input_t:
+        return (torch.randn(2, 5, 10), torch.randn(1, 2, 20))
+
+
+class LSTM(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.lstm = torch.nn.LSTM(10, 20, 1, batch_first=True)
+
+    def forward(
+        self, x: torch.Tensor, h0: torch.Tensor, c0: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        output, (h_n, c_n) = self.lstm(x, (h0, c0))
+        return output, h_n, c_n
+
+    @staticmethod
+    def get_inputs() -> lstm_input_t:
+        return (
+            torch.randn(2, 5, 10),
+            torch.randn(1, 2, 20),
+            torch.randn(1, 2, 20),
+        )
+
+
+# ──────────────────────────── Helpers ───────────────────────────────────────
+
+
+def _run_tosa_fp_pipeline(module, inputs, input_type):
+    """Run TosaPipelineFP for a recurrent model."""
+    pipeline = TosaPipelineFP[input_type](
+        module,
+        inputs,
+        aten_op=[],
+        exir_op=[],
+        use_to_edge_transform_and_lower=True,
+        atol=3e-1,
+        rtol=3e-1,
+    )
+    pipeline.pop_stage("check.aten")
+    pipeline.pop_stage("check_count.exir")
+    pipeline.run()
+
+
+def _run_tosa_int_pipeline(module, inputs, input_type):
+    """Run TosaPipelineINT for a recurrent model."""
+    pipeline = TosaPipelineINT[input_type](
+        module,
+        inputs,
+        aten_op=[],
+        exir_op=[],
+        use_to_edge_transform_and_lower=True,
+        frobenius_threshold=None,
+        cosine_threshold=None,
+    )
+    pipeline.pop_stage("check.aten")
+    pipeline.pop_stage("check_count.exir")
+    if pipeline.has_stage("check.quant_nodes"):
+        pipeline.pop_stage("check.quant_nodes")
+    if pipeline.has_stage("check_not.quant_nodes"):
+        pipeline.pop_stage("check_not.quant_nodes")
+    pipeline.change_args(
+        "run_method_and_compare_outputs",
+        atol=3e-1,
+        qtol=1.0,
+    )
+    pipeline.run()
+
+
+def _run_ethos_u_pipeline(pipeline_cls, module, inputs, input_type):
+    """Run an EthosU pipeline for a recurrent model."""
+    pipeline = pipeline_cls[input_type](
+        module,
+        inputs,
+        aten_ops=[],
+        exir_ops=[],
+    )
+    pipeline.pop_stage("check.aten")
+    pipeline.pop_stage("check_count.exir")
+    if pipeline.has_stage("check.quant_nodes"):
+        pipeline.pop_stage("check.quant_nodes")
+    if pipeline.has_stage("check_not.quant_nodes"):
+        pipeline.pop_stage("check_not.quant_nodes")
+    pipeline.run()
+
+
+# ──────────────────────────── RNN FP tests ──────────────────────────────────
+
+
+def test_decompose_rnn_tosa_FP_tanh_e2e():
+    _run_tosa_fp_pipeline(RNNTanh(), RNNTanh.get_inputs(), rnn_input_t)
+
+
+def test_decompose_rnn_tosa_FP_relu_e2e():
+    _run_tosa_fp_pipeline(RNNRelu(), RNNRelu.get_inputs(), rnn_input_t)
+
+
+# ──────────────────────────── RNN INT tests ─────────────────────────────────
+
+
+def test_decompose_rnn_tosa_INT_tanh_e2e():
+    _run_tosa_int_pipeline(RNNTanh(), RNNTanh.get_inputs(), rnn_input_t)
+
+
+def test_decompose_rnn_tosa_INT_relu_e2e():
+    _run_tosa_int_pipeline(RNNRelu(), RNNRelu.get_inputs(), rnn_input_t)
+
+
+# ──────────────────────────── GRU tests ─────────────────────────────────────
+
+
+def test_decompose_gru_tosa_FP_e2e():
+    _run_tosa_fp_pipeline(GRU(), GRU.get_inputs(), rnn_input_t)
+
+
+def test_decompose_gru_tosa_INT_e2e():
+    _run_tosa_int_pipeline(GRU(), GRU.get_inputs(), rnn_input_t)
+
+
+# ──────────────────────────── LSTM tests ────────────────────────────────────
+
+
+def test_decompose_lstm_tosa_FP_e2e():
+    _run_tosa_fp_pipeline(LSTM(), LSTM.get_inputs(), lstm_input_t)
+
+
+def test_decompose_lstm_tosa_INT_e2e():
+    _run_tosa_int_pipeline(LSTM(), LSTM.get_inputs(), lstm_input_t)
+
+
+# ──────────────────────── EthosU55 INT probes ───────────────────────────────
+
+
+@common.XfailIfNoCorstone300
+def test_decompose_rnn_u55_INT_tanh_e2e():
+    _run_ethos_u_pipeline(
+        EthosU55PipelineINT, RNNTanh(), RNNTanh.get_inputs(), rnn_input_t
+    )
+
+
+# ──────────────────────── EthosU85 INT probes ───────────────────────────────
+
+
+@common.XfailIfNoCorstone320
+def test_decompose_rnn_u85_INT_tanh_e2e():
+    _run_ethos_u_pipeline(
+        EthosU85PipelineINT, RNNTanh(), RNNTanh.get_inputs(), rnn_input_t
+    )

--- a/backends/arm/test/quantizer/test_quantizable_rnn_gru.py
+++ b/backends/arm/test/quantizer/test_quantizable_rnn_gru.py
@@ -1,0 +1,201 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Tests for quantizable RNN and GRU modules.
+
+Verifies that quantizable versions produce outputs matching standard nn.RNN/nn.GRU.
+"""
+
+import torch
+from executorch.backends.arm.quantizable import GRU, RNN
+
+
+class TestQuantizableRNN:
+    """Tests for the quantizable RNN module."""
+
+    def test_rnn_basic_forward(self):
+        """Test basic RNN forward pass matches nn.RNN."""
+        input_size, hidden_size, seq_len, batch = 10, 20, 5, 3
+        x = torch.randn(seq_len, batch, input_size)
+
+        # Create standard RNN
+        std_rnn = torch.nn.RNN(input_size, hidden_size, batch_first=False)
+
+        # Create quantizable RNN and copy weights
+        q_rnn = RNN(input_size, hidden_size, batch_first=False)
+        q_rnn.layers[0].layer_fw.cell.input_linear.weight.data = std_rnn.weight_ih_l0.data.clone()
+        q_rnn.layers[0].layer_fw.cell.input_linear.bias.data = std_rnn.bias_ih_l0.data.clone()
+        q_rnn.layers[0].layer_fw.cell.hidden_linear.weight.data = std_rnn.weight_hh_l0.data.clone()
+        q_rnn.layers[0].layer_fw.cell.hidden_linear.bias.data = std_rnn.bias_hh_l0.data.clone()
+
+        std_out, std_h = std_rnn(x)
+        q_out, q_h = q_rnn(x)
+
+        torch.testing.assert_close(q_out, std_out, rtol=1e-4, atol=1e-5)
+        torch.testing.assert_close(q_h, std_h, rtol=1e-4, atol=1e-5)
+
+    def test_rnn_bidirectional(self):
+        """Test bidirectional RNN matches nn.RNN."""
+        input_size, hidden_size, seq_len, batch = 10, 20, 5, 3
+        x = torch.randn(seq_len, batch, input_size)
+
+        std_rnn = torch.nn.RNN(input_size, hidden_size, bidirectional=True)
+
+        q_rnn = RNN(input_size, hidden_size, bidirectional=True)
+        # Copy forward weights
+        q_rnn.layers[0].layer_fw.cell.input_linear.weight.data = std_rnn.weight_ih_l0.data.clone()
+        q_rnn.layers[0].layer_fw.cell.input_linear.bias.data = std_rnn.bias_ih_l0.data.clone()
+        q_rnn.layers[0].layer_fw.cell.hidden_linear.weight.data = std_rnn.weight_hh_l0.data.clone()
+        q_rnn.layers[0].layer_fw.cell.hidden_linear.bias.data = std_rnn.bias_hh_l0.data.clone()
+        # Copy backward weights
+        q_rnn.layers[0].layer_bw.cell.input_linear.weight.data = (
+            std_rnn.weight_ih_l0_reverse.data.clone()
+        )
+        q_rnn.layers[0].layer_bw.cell.input_linear.bias.data = std_rnn.bias_ih_l0_reverse.data.clone()
+        q_rnn.layers[0].layer_bw.cell.hidden_linear.weight.data = (
+            std_rnn.weight_hh_l0_reverse.data.clone()
+        )
+        q_rnn.layers[0].layer_bw.cell.hidden_linear.bias.data = (
+            std_rnn.bias_hh_l0_reverse.data.clone()
+        )
+
+        std_out, std_h = std_rnn(x)
+        q_out, q_h = q_rnn(x)
+
+        torch.testing.assert_close(q_out, std_out, rtol=1e-4, atol=1e-5)
+        torch.testing.assert_close(q_h, std_h, rtol=1e-4, atol=1e-5)
+
+    def test_rnn_batch_first(self):
+        """Test batch_first RNN matches nn.RNN."""
+        input_size, hidden_size, seq_len, batch = 10, 20, 5, 3
+        x = torch.randn(batch, seq_len, input_size)
+
+        std_rnn = torch.nn.RNN(input_size, hidden_size, batch_first=True)
+
+        q_rnn = RNN(input_size, hidden_size, batch_first=True)
+        q_rnn.layers[0].layer_fw.cell.input_linear.weight.data = std_rnn.weight_ih_l0.data.clone()
+        q_rnn.layers[0].layer_fw.cell.input_linear.bias.data = std_rnn.bias_ih_l0.data.clone()
+        q_rnn.layers[0].layer_fw.cell.hidden_linear.weight.data = std_rnn.weight_hh_l0.data.clone()
+        q_rnn.layers[0].layer_fw.cell.hidden_linear.bias.data = std_rnn.bias_hh_l0.data.clone()
+
+        std_out, std_h = std_rnn(x)
+        q_out, q_h = q_rnn(x)
+
+        torch.testing.assert_close(q_out, std_out, rtol=1e-4, atol=1e-5)
+        torch.testing.assert_close(q_h, std_h, rtol=1e-4, atol=1e-5)
+
+    def test_rnn_relu_nonlinearity(self):
+        """Test RNN with ReLU nonlinearity."""
+        input_size, hidden_size, seq_len, batch = 10, 20, 5, 3
+        x = torch.randn(seq_len, batch, input_size)
+
+        std_rnn = torch.nn.RNN(input_size, hidden_size, nonlinearity="relu")
+
+        q_rnn = RNN(input_size, hidden_size, nonlinearity="relu")
+        q_rnn.layers[0].layer_fw.cell.input_linear.weight.data = std_rnn.weight_ih_l0.data.clone()
+        q_rnn.layers[0].layer_fw.cell.input_linear.bias.data = std_rnn.bias_ih_l0.data.clone()
+        q_rnn.layers[0].layer_fw.cell.hidden_linear.weight.data = std_rnn.weight_hh_l0.data.clone()
+        q_rnn.layers[0].layer_fw.cell.hidden_linear.bias.data = std_rnn.bias_hh_l0.data.clone()
+
+        std_out, std_h = std_rnn(x)
+        q_out, q_h = q_rnn(x)
+
+        torch.testing.assert_close(q_out, std_out, rtol=1e-4, atol=1e-5)
+        torch.testing.assert_close(q_h, std_h, rtol=1e-4, atol=1e-5)
+
+
+class TestQuantizableGRU:
+    """Tests for the quantizable GRU module."""
+
+    def test_gru_basic_forward(self):
+        """Test basic GRU forward pass matches nn.GRU."""
+        input_size, hidden_size, seq_len, batch = 10, 20, 5, 3
+        x = torch.randn(seq_len, batch, input_size)
+
+        # Create standard GRU
+        std_gru = torch.nn.GRU(input_size, hidden_size, batch_first=False)
+
+        # Create quantizable GRU and copy weights
+        # GRU uses combined input_linear and hidden_linear (3*hidden_size)
+        q_gru = GRU(input_size, hidden_size, batch_first=False)
+        q_gru.layers[0].layer_fw.cell.input_linear.weight.data = std_gru.weight_ih_l0.data.clone()
+        q_gru.layers[0].layer_fw.cell.input_linear.bias.data = std_gru.bias_ih_l0.data.clone()
+        q_gru.layers[0].layer_fw.cell.hidden_linear.weight.data = std_gru.weight_hh_l0.data.clone()
+        q_gru.layers[0].layer_fw.cell.hidden_linear.bias.data = std_gru.bias_hh_l0.data.clone()
+
+        std_out, std_h = std_gru(x)
+        q_out, q_h = q_gru(x)
+
+        torch.testing.assert_close(q_out, std_out, rtol=1e-4, atol=1e-5)
+        torch.testing.assert_close(q_h, std_h, rtol=1e-4, atol=1e-5)
+
+    def test_gru_bidirectional(self):
+        """Test bidirectional GRU matches nn.GRU."""
+        input_size, hidden_size, seq_len, batch = 10, 20, 5, 3
+        x = torch.randn(seq_len, batch, input_size)
+
+        std_gru = torch.nn.GRU(input_size, hidden_size, bidirectional=True)
+
+        q_gru = GRU(input_size, hidden_size, bidirectional=True)
+
+        # Copy forward weights
+        q_gru.layers[0].layer_fw.cell.input_linear.weight.data = std_gru.weight_ih_l0.data.clone()
+        q_gru.layers[0].layer_fw.cell.input_linear.bias.data = std_gru.bias_ih_l0.data.clone()
+        q_gru.layers[0].layer_fw.cell.hidden_linear.weight.data = std_gru.weight_hh_l0.data.clone()
+        q_gru.layers[0].layer_fw.cell.hidden_linear.bias.data = std_gru.bias_hh_l0.data.clone()
+
+        # Copy backward weights
+        q_gru.layers[0].layer_bw.cell.input_linear.weight.data = (
+            std_gru.weight_ih_l0_reverse.data.clone()
+        )
+        q_gru.layers[0].layer_bw.cell.input_linear.bias.data = std_gru.bias_ih_l0_reverse.data.clone()
+        q_gru.layers[0].layer_bw.cell.hidden_linear.weight.data = (
+            std_gru.weight_hh_l0_reverse.data.clone()
+        )
+        q_gru.layers[0].layer_bw.cell.hidden_linear.bias.data = (
+            std_gru.bias_hh_l0_reverse.data.clone()
+        )
+
+        std_out, std_h = std_gru(x)
+        q_out, q_h = q_gru(x)
+
+        torch.testing.assert_close(q_out, std_out, rtol=1e-4, atol=1e-5)
+        torch.testing.assert_close(q_h, std_h, rtol=1e-4, atol=1e-5)
+
+    def test_gru_batch_first(self):
+        """Test batch_first GRU matches nn.GRU."""
+        input_size, hidden_size, seq_len, batch = 10, 20, 5, 3
+        x = torch.randn(batch, seq_len, input_size)
+
+        std_gru = torch.nn.GRU(input_size, hidden_size, batch_first=True)
+
+        q_gru = GRU(input_size, hidden_size, batch_first=True)
+        q_gru.layers[0].layer_fw.cell.input_linear.weight.data = std_gru.weight_ih_l0.data.clone()
+        q_gru.layers[0].layer_fw.cell.input_linear.bias.data = std_gru.bias_ih_l0.data.clone()
+        q_gru.layers[0].layer_fw.cell.hidden_linear.weight.data = std_gru.weight_hh_l0.data.clone()
+        q_gru.layers[0].layer_fw.cell.hidden_linear.bias.data = std_gru.bias_hh_l0.data.clone()
+
+        std_out, std_h = std_gru(x)
+        q_out, q_h = q_gru(x)
+
+        torch.testing.assert_close(q_out, std_out, rtol=1e-4, atol=1e-5)
+        torch.testing.assert_close(q_h, std_h, rtol=1e-4, atol=1e-5)
+
+    def test_gru_no_bias(self):
+        """Test GRU without bias matches nn.GRU."""
+        input_size, hidden_size, seq_len, batch = 10, 20, 5, 3
+        x = torch.randn(seq_len, batch, input_size)
+
+        std_gru = torch.nn.GRU(input_size, hidden_size, bias=False)
+
+        q_gru = GRU(input_size, hidden_size, bias=False)
+        q_gru.layers[0].layer_fw.cell.input_linear.weight.data = std_gru.weight_ih_l0.data.clone()
+        q_gru.layers[0].layer_fw.cell.hidden_linear.weight.data = std_gru.weight_hh_l0.data.clone()
+
+        std_out, std_h = std_gru(x)
+        q_out, q_h = q_gru(x)
+
+        torch.testing.assert_close(q_out, std_out, rtol=1e-4, atol=1e-5)
+        torch.testing.assert_close(q_h, std_h, rtol=1e-4, atol=1e-5)

--- a/backends/arm/test/targets.bzl
+++ b/backends/arm/test/targets.bzl
@@ -41,6 +41,7 @@ def define_arm_tests():
     test_files += [
         "quantizer/test_generic_annotater.py",
         "quantizer/test_uint8_io_quantization.py",
+        "quantizer/test_quantizable_rnn_gru.py",
     ]
 
     # Misc tests
@@ -99,6 +100,7 @@ def define_arm_tests():
                 "//executorch/backends/arm/tosa:compile_spec",
                 "//executorch/backends/arm/tosa:partitioner",
                 "//executorch/backends/arm:vgf",
+                "//executorch/backends/arm/quantizable:quantizable",
                 "//executorch/backends/test:graph_builder",
                 "//executorch/backends/test:program_builder",
                 "//executorch/exir:lib",

--- a/backends/arm/test/targets.bzl
+++ b/backends/arm/test/targets.bzl
@@ -52,6 +52,7 @@ def define_arm_tests():
     test_files += [
         "quantizer/test_generic_annotater.py",
         "quantizer/test_uint8_io_quantization.py",
+        "quantizer/test_quantizable_rnn_gru.py",
     ]
 
     # Misc tests
@@ -135,6 +136,7 @@ def define_arm_tests():
                 "//executorch/backends/arm/tosa:compile_spec",
                 "//executorch/backends/arm/tosa:partitioner",
                 "//executorch/backends/arm:vgf",
+                "//executorch/backends/arm/quantizable:quantizable",
                 "//executorch/backends/test:graph_builder",
                 "//executorch/backends/test:program_builder",
                 "//executorch/extension/export_util:export_util",


### PR DESCRIPTION
Summary: The shared `DecomposeGruPass` now uses the `aten.linear` rewrite needed for quantized tensors and serves as the single implementation for ARM GRU decomposition.

Differential Revision: D92058313


