### PR TITLE
Add model metadata storage in PTE via NamedData (#19466)

### DIFF
--- a/extension/llm/export/BUCK
+++ b/extension/llm/export/BUCK
@@ -108,3 +108,14 @@ fbcode_target(_kind = runtime.python_test,
         ":export_lib",
     ],
 )
+
+fbcode_target(_kind = runtime.python_library,
+    name = "metadata",
+    srcs = [
+        "metadata.py",
+    ],
+    visibility = ["PUBLIC"],
+    deps = [
+        "//executorch/exir:lib",
+    ],
+)

--- a/extension/llm/export/metadata.py
+++ b/extension/llm/export/metadata.py
@@ -1,0 +1,163 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Model metadata storage for PTE files.
+
+Embeds model metadata (tokenizer config, chat templates, architecture info)
+directly in PTE files via the NamedData mechanism. Replaces the current
+constant_methods approach (which creates full ExecutionPlan entries for
+simple constant values).
+
+Keys use a dotted namespace.field convention:
+    tokenizer.bos_id, tokenizer.eos_ids, context.max_seq_len, etc.
+
+Wire format: each value is prefixed with a 1-byte type tag:
+    0x01 = int64  (8 bytes, little-endian)
+    0x02 = float64 (8 bytes, little-endian)
+    0x03 = string (UTF-8, no length prefix - length is implicit from buffer size)
+    0x04 = int_list (uint32 count + count * int64, all little-endian)
+    0x05 = bytes (raw, no framing)
+"""
+
+from __future__ import annotations
+
+import struct
+from typing import Dict, List, Sequence, TYPE_CHECKING, Union
+
+if TYPE_CHECKING:
+    from executorch.exir import EdgeProgramManager
+
+METADATA_PREFIX = "metadata."
+
+# Type tag constants (1 byte, prefixed to every encoded value).
+TAG_INT: int = 0x01
+TAG_FLOAT: int = 0x02
+TAG_STRING: int = 0x03
+TAG_INT_LIST: int = 0x04
+TAG_BYTES: int = 0x05
+
+MetadataValue = Union[str, int, float, bytes, Sequence[int]]
+
+
+def _encode_value(key: str, value: MetadataValue) -> bytes:
+    if isinstance(value, bool):
+        raise TypeError(f"bool not supported for key '{key}', use int (0/1) instead")
+    if isinstance(value, str):
+        return bytes([TAG_STRING]) + value.encode("utf-8")
+    elif isinstance(value, (list, tuple)):
+        for i, elem in enumerate(value):
+            if not isinstance(elem, int) or isinstance(elem, bool):
+                raise TypeError(
+                    f"list element {i} for key '{key}' must be int, got {type(elem)}"
+                )
+        return bytes([TAG_INT_LIST]) + struct.pack(f"<I{len(value)}q", len(value), *value)
+    elif isinstance(value, int):
+        return bytes([TAG_INT]) + struct.pack("<q", value)
+    elif isinstance(value, float):
+        return bytes([TAG_FLOAT]) + struct.pack("<d", value)
+    elif isinstance(value, bytes):
+        return bytes([TAG_BYTES]) + value
+    raise TypeError(f"Unsupported metadata type {type(value)} for key '{key}'")
+
+
+def add_metadata(
+    edge_manager: EdgeProgramManager,
+    metadata: Dict[str, MetadataValue],
+) -> None:
+    """Add metadata KV pairs to a PTE file during export.
+
+    Call BEFORE edge_manager.to_executorch().
+
+    Args:
+        edge_manager: The EdgeProgramManager from to_edge() or
+            to_edge_transform_and_lower().
+        metadata: Dict mapping string keys to values (str, int, float, bytes,
+            or list[int]). Keys are automatically prefixed with "metadata." to
+            avoid collision with backend named data.
+    """
+    for key, value in metadata.items():
+        edge_manager._named_data_store.add_named_data(
+            key=f"{METADATA_PREFIX}{key}",
+            data=_encode_value(key, value),
+        )
+
+
+def read_metadata(pte_path: str) -> Dict[str, bytes]:
+    """Read all metadata entries from a PTE file.
+
+    Returns raw bytes (including type tag prefix) for each key (without the
+    "metadata." prefix). Use get_string/get_int/get_float for typed access.
+
+    WARNING: Loads the entire PTE file into memory. Not suitable for
+    large model files in production; intended for testing and debugging.
+    """
+    from executorch.exir._serialize._program import deserialize_pte_binary
+
+    with open(pte_path, "rb") as f:
+        pte_data = f.read()
+
+    pte_file = deserialize_pte_binary(pte_data)
+
+    result = {}
+    if pte_file.named_data is not None:
+        for key, entry in pte_file.named_data.pte_data.items():
+            if key.startswith(METADATA_PREFIX):
+                short_key = key[len(METADATA_PREFIX) :]
+                result[short_key] = pte_file.named_data.buffers[entry.buffer_index]
+
+    return result
+
+
+def _check_tag(data: bytes, key: str, expected_tag: int, type_name: str) -> None:
+    """Validate the type tag prefix."""
+    if len(data) == 0:
+        raise ValueError(f"Empty data for key '{key}'")
+    actual_tag = data[0]
+    if actual_tag != expected_tag:
+        tag_names = {
+            TAG_INT: "int",
+            TAG_FLOAT: "float",
+            TAG_STRING: "string",
+            TAG_INT_LIST: "int_list",
+            TAG_BYTES: "bytes",
+        }
+        actual_name = tag_names.get(actual_tag, f"unknown(0x{actual_tag:02x})")
+        raise TypeError(
+            f"Type mismatch for key '{key}': expected {type_name}, "
+            f"got {actual_name} (tag=0x{actual_tag:02x})"
+        )
+
+
+def get_string(metadata: Dict[str, bytes], key: str) -> str:
+    data = metadata[key]
+    _check_tag(data, key, TAG_STRING, "string")
+    return data[1:].decode("utf-8")
+
+
+def get_int(metadata: Dict[str, bytes], key: str) -> int:
+    data = metadata[key]
+    _check_tag(data, key, TAG_INT, "int")
+    return struct.unpack("<q", data[1:])[0]
+
+
+def get_float(metadata: Dict[str, bytes], key: str) -> float:
+    data = metadata[key]
+    _check_tag(data, key, TAG_FLOAT, "float")
+    return struct.unpack("<d", data[1:])[0]
+
+
+def get_bytes(metadata: Dict[str, bytes], key: str) -> bytes:
+    data = metadata[key]
+    _check_tag(data, key, TAG_BYTES, "bytes")
+    return data[1:]
+
+
+def get_int_list(metadata: Dict[str, bytes], key: str) -> List[int]:
+    data = metadata[key]
+    _check_tag(data, key, TAG_INT_LIST, "int_list")
+    payload = data[1:]
+    (count,) = struct.unpack_from("<I", payload, 0)
+    return list(struct.unpack_from(f"<{count}q", payload, 4))

--- a/extension/llm/export/test/BUCK
+++ b/extension/llm/export/test/BUCK
@@ -17,3 +17,15 @@ fbcode_target(_kind = runtime.python_test,
         "//caffe2:torch",
     ],
 )
+
+fbcode_target(_kind = runtime.python_test,
+    name = "test_metadata_roundtrip",
+    srcs = [
+        "test_metadata_roundtrip.py",
+    ],
+    deps = [
+        "//executorch/extension/llm/export:metadata",
+        "//caffe2:torch",
+        "//executorch/exir:lib",
+    ],
+)

--- a/extension/llm/export/test/test_metadata_roundtrip.py
+++ b/extension/llm/export/test/test_metadata_roundtrip.py
@@ -1,0 +1,163 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Round-trip test: export model with metadata stored in NamedData."""
+
+import tempfile
+import unittest
+
+import torch
+from executorch.exir import EdgeCompileConfig, to_edge_transform_and_lower
+from executorch.extension.llm.export.metadata import (
+    add_metadata,
+    get_float,
+    get_int,
+    get_int_list,
+    get_string,
+    read_metadata,
+)
+from torch.export import export
+
+
+class SimpleModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = torch.nn.Linear(10, 5)
+
+    def forward(self, x):
+        return self.linear(x)
+
+
+class TestMetadataRoundTrip(unittest.TestCase):
+    def test_roundtrip(self):
+        model = SimpleModel()
+        example_input = (torch.randn(1, 10),)
+
+        exported = export(model, example_input)
+        edge = to_edge_transform_and_lower(
+            exported,
+            compile_config=EdgeCompileConfig(_check_ir_validity=False),
+        )
+
+        chat_template = (
+            "{% for message in messages %}"
+            "{{ message.role }}: {{ message.content }}\n"
+            "{% endfor %}"
+        )
+
+        add_metadata(
+            edge,
+            {
+                "tokenizer.model": "BPE",
+                "tokenizer.vocab_size": 128256,
+                "chat_template": chat_template,
+                "model.arch": "llama",
+                "model.context_length": 8192,
+                "general.name": "Llama-3.2-1B",
+                "model.temperature": 0.7,
+            },
+        )
+
+        et_program = edge.to_executorch()
+
+        with tempfile.NamedTemporaryFile(suffix=".pte") as f:
+            f.write(et_program.buffer)
+            f.flush()
+
+            metadata = read_metadata(f.name)
+
+            self.assertEqual(len(metadata), 7)
+            self.assertEqual(get_string(metadata, "tokenizer.model"), "BPE")
+            self.assertEqual(get_int(metadata, "tokenizer.vocab_size"), 128256)
+            self.assertEqual(get_string(metadata, "chat_template"), chat_template)
+            self.assertEqual(get_string(metadata, "model.arch"), "llama")
+            self.assertEqual(get_int(metadata, "model.context_length"), 8192)
+            self.assertEqual(get_string(metadata, "general.name"), "Llama-3.2-1B")
+            self.assertAlmostEqual(get_float(metadata, "model.temperature"), 0.7)
+
+    def test_empty_metadata(self):
+        model = SimpleModel()
+        exported = export(model, (torch.randn(1, 10),))
+        edge = to_edge_transform_and_lower(
+            exported,
+            compile_config=EdgeCompileConfig(_check_ir_validity=False),
+        )
+
+        add_metadata(edge, {})
+        et_program = edge.to_executorch()
+
+        with tempfile.NamedTemporaryFile(suffix=".pte") as f:
+            f.write(et_program.buffer)
+            f.flush()
+            metadata = read_metadata(f.name)
+            self.assertEqual(len(metadata), 0)
+
+    def test_raw_bytes_metadata(self):
+        model = SimpleModel()
+        exported = export(model, (torch.randn(1, 10),))
+        edge = to_edge_transform_and_lower(
+            exported,
+            compile_config=EdgeCompileConfig(_check_ir_validity=False),
+        )
+
+        raw = b"\x00\x01\x02\xff"
+        add_metadata(edge, {"binary_blob": raw})
+        et_program = edge.to_executorch()
+
+        with tempfile.NamedTemporaryFile(suffix=".pte") as f:
+            f.write(et_program.buffer)
+            f.flush()
+            metadata = read_metadata(f.name)
+            self.assertEqual(metadata["binary_blob"], raw)
+
+    def test_llm_metadata_replaces_constant_methods(self):
+        """POC: these metadata fields currently live as constant_methods
+        (full ExecutionPlan entries). This test shows they can be stored
+        as lightweight NamedData entries instead."""
+        model = SimpleModel()
+        exported = export(model, (torch.randn(1, 10),))
+        edge = to_edge_transform_and_lower(
+            exported,
+            compile_config=EdgeCompileConfig(_check_ir_validity=False),
+        )
+
+        add_metadata(
+            edge,
+            {
+                "tokenizer.bos_id": 128000,
+                "tokenizer.eos_ids": [128009, 128001],
+                "context.max_seq_len": 8192,
+                "context.max_context_len": 8192,
+                "model.vocab_size": 128256,
+                "model.use_kv_cache": 1,
+                "model.use_sdpa_with_kv_cache": 1,
+                "model.n_layers": 16,
+                "tokenizer.chat_template": "{% for m in messages %}{{ m.content }}{% endfor %}",
+            },
+        )
+
+        et_program = edge.to_executorch()
+
+        with tempfile.NamedTemporaryFile(suffix=".pte") as f:
+            f.write(et_program.buffer)
+            f.flush()
+
+            metadata = read_metadata(f.name)
+
+            self.assertEqual(get_int(metadata, "tokenizer.bos_id"), 128000)
+            self.assertEqual(
+                get_int_list(metadata, "tokenizer.eos_ids"), [128009, 128001]
+            )
+            self.assertEqual(get_int(metadata, "context.max_seq_len"), 8192)
+            self.assertEqual(get_int(metadata, "context.max_context_len"), 8192)
+            self.assertEqual(get_int(metadata, "model.vocab_size"), 128256)
+            self.assertEqual(get_int(metadata, "model.use_kv_cache"), 1)
+            self.assertEqual(get_int(metadata, "model.use_sdpa_with_kv_cache"), 1)
+            self.assertEqual(get_int(metadata, "model.n_layers"), 16)
+            self.assertIn(
+                "{% for m in messages %}",
+                get_string(metadata, "tokenizer.chat_template"),
+            )

--- a/extension/llm/runner/metadata.h
+++ b/extension/llm/runner/metadata.h
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <executorch/runtime/core/named_data_map.h>
+#include <executorch/runtime/core/result.h>
+
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace executorch {
+namespace extension {
+namespace llm {
+namespace metadata {
+
+// Type tag constants (1-byte prefix on every encoded value).
+// Must stay in sync with Python (extension/llm/export/metadata.py).
+inline constexpr uint8_t kTagInt = 0x01;
+inline constexpr uint8_t kTagFloat = 0x02;
+inline constexpr uint8_t kTagString = 0x03;
+inline constexpr uint8_t kTagIntList = 0x04;
+inline constexpr uint8_t kTagBytes = 0x05;
+
+inline constexpr const char* kPrefix = "metadata.";
+
+inline constexpr const char* kBosId = "metadata.tokenizer.bos_id";
+inline constexpr const char* kEosIds = "metadata.tokenizer.eos_ids";
+inline constexpr const char* kMaxSeqLen = "metadata.context.max_seq_len";
+inline constexpr const char* kMaxContextLen =
+    "metadata.context.max_context_len";
+inline constexpr const char* kVocabSize = "metadata.model.vocab_size";
+inline constexpr const char* kUseKVCache = "metadata.model.use_kv_cache";
+inline constexpr const char* kNLayers = "metadata.model.n_layers";
+inline constexpr const char* kChatTemplate = "metadata.tokenizer.chat_template";
+
+namespace detail {
+
+inline runtime::Error check_tag(
+    const void* data,
+    size_t size,
+    uint8_t expected_tag) {
+  if (size == 0) {
+    return runtime::Error::InvalidArgument;
+  }
+  uint8_t actual_tag;
+  std::memcpy(&actual_tag, data, 1);
+  if (actual_tag != expected_tag) {
+    return runtime::Error::InvalidArgument;
+  }
+  return runtime::Error::Ok;
+}
+
+} // namespace detail
+
+inline runtime::Result<int64_t> get_int(
+    const runtime::NamedDataMap& map,
+    const char* key) {
+  auto result = map.get_data(key);
+  if (!result.ok()) {
+    return result.error();
+  }
+  auto buffer = std::move(result.get());
+  if (buffer.size() != 1 + sizeof(int64_t)) {
+    return runtime::Error::InvalidArgument;
+  }
+  auto err = detail::check_tag(buffer.data(), buffer.size(), kTagInt);
+  if (err != runtime::Error::Ok) {
+    return err;
+  }
+  int64_t value;
+  std::memcpy(
+      &value, static_cast<const char*>(buffer.data()) + 1, sizeof(int64_t));
+  return value;
+}
+
+inline runtime::Result<double> get_float(
+    const runtime::NamedDataMap& map,
+    const char* key) {
+  auto result = map.get_data(key);
+  if (!result.ok()) {
+    return result.error();
+  }
+  auto buffer = std::move(result.get());
+  if (buffer.size() != 1 + sizeof(double)) {
+    return runtime::Error::InvalidArgument;
+  }
+  auto err = detail::check_tag(buffer.data(), buffer.size(), kTagFloat);
+  if (err != runtime::Error::Ok) {
+    return err;
+  }
+  double value;
+  std::memcpy(
+      &value, static_cast<const char*>(buffer.data()) + 1, sizeof(double));
+  return value;
+}
+
+inline runtime::Result<std::string> get_string(
+    const runtime::NamedDataMap& map,
+    const char* key) {
+  auto result = map.get_data(key);
+  if (!result.ok()) {
+    return result.error();
+  }
+  auto buffer = std::move(result.get());
+  if (buffer.size() < 1) {
+    return runtime::Error::InvalidArgument;
+  }
+  auto err = detail::check_tag(buffer.data(), buffer.size(), kTagString);
+  if (err != runtime::Error::Ok) {
+    return err;
+  }
+  std::string value(
+      static_cast<const char*>(buffer.data()) + 1, buffer.size() - 1);
+  return value;
+}
+
+inline runtime::Result<std::vector<uint8_t>> get_bytes(
+    const runtime::NamedDataMap& map,
+    const char* key) {
+  auto result = map.get_data(key);
+  if (!result.ok()) {
+    return result.error();
+  }
+  auto buffer = std::move(result.get());
+  if (buffer.size() < 1) {
+    return runtime::Error::InvalidArgument;
+  }
+  auto err = detail::check_tag(buffer.data(), buffer.size(), kTagBytes);
+  if (err != runtime::Error::Ok) {
+    return err;
+  }
+  const auto* begin = static_cast<const uint8_t*>(buffer.data()) + 1;
+  return std::vector<uint8_t>(begin, begin + buffer.size() - 1);
+}
+
+inline runtime::Result<std::vector<int64_t>> get_int_list(
+    const runtime::NamedDataMap& map,
+    const char* key) {
+  auto result = map.get_data(key);
+  if (!result.ok()) {
+    return result.error();
+  }
+  auto buffer = std::move(result.get());
+  if (buffer.size() < 1 + sizeof(uint32_t)) {
+    return runtime::Error::InvalidArgument;
+  }
+  auto err = detail::check_tag(buffer.data(), buffer.size(), kTagIntList);
+  if (err != runtime::Error::Ok) {
+    return err;
+  }
+  const char* base = static_cast<const char*>(buffer.data()) + 1;
+  size_t payload_size = buffer.size() - 1;
+
+  uint32_t count;
+  std::memcpy(&count, base, sizeof(uint32_t));
+  size_t data_size = payload_size - sizeof(uint32_t);
+  if (data_size / sizeof(int64_t) != count || data_size % sizeof(int64_t) != 0) {
+    return runtime::Error::InvalidArgument;
+  }
+  std::vector<int64_t> values(count);
+  if (count > 0) {
+    std::memcpy(values.data(), base + sizeof(uint32_t), count * sizeof(int64_t));
+  }
+  return values;
+}
+
+} // namespace metadata
+} // namespace llm
+} // namespace extension
+} // namespace executorch

--- a/extension/llm/runner/targets.bzl
+++ b/extension/llm/runner/targets.bzl
@@ -17,6 +17,18 @@ def define_common_targets():
         visibility = ["PUBLIC"],
     )
 
+    runtime.cxx_library(
+        name = "metadata",
+        exported_headers = [
+            "metadata.h",
+        ],
+        visibility = ["PUBLIC"],
+        exported_deps = [
+            "//executorch/runtime/core:named_data_map",
+            "//executorch/runtime/core:core",
+        ],
+    )
+
     for aten in get_aten_mode_options():
         aten_suffix = "_aten" if aten else ""
 

--- a/extension/llm/runner/test/targets.bzl
+++ b/extension/llm/runner/test/targets.bzl
@@ -7,6 +7,16 @@ load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
 def define_common_targets():
     runtime.cxx_test(
+        name = "test_metadata",
+        srcs = ["test_metadata.cpp"],
+        deps = [
+            "//executorch/extension/llm/runner:metadata",
+            "//executorch/runtime/core:core",
+            "//executorch/runtime/platform:platform",
+        ],
+    )
+
+    runtime.cxx_test(
         name = "test_generation_config",
         srcs = ["test_generation_config.cpp"],
         deps = [

--- a/extension/llm/runner/test/test_metadata.cpp
+++ b/extension/llm/runner/test/test_metadata.cpp
@@ -1,0 +1,249 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/extension/llm/runner/metadata.h>
+#include <executorch/runtime/platform/runtime.h>
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace {
+
+using namespace executorch::extension::llm::metadata;
+using executorch::runtime::Error;
+using executorch::runtime::FreeableBuffer;
+using executorch::runtime::NamedDataMap;
+using executorch::runtime::Result;
+using executorch::runtime::TensorLayout;
+
+class MockNamedDataMap : public NamedDataMap {
+ public:
+  void add(const std::string& key, std::vector<uint8_t> data) {
+    data_[key] = std::move(data);
+  }
+
+  Result<FreeableBuffer> get_data(
+      executorch::aten::string_view key) const override {
+    std::string k(key.data(), key.size());
+    auto it = data_.find(k);
+    if (it == data_.end()) {
+      return Error::NotFound;
+    }
+    return FreeableBuffer(it->second.data(), it->second.size(), nullptr);
+  }
+
+  Result<const TensorLayout> get_tensor_layout(
+      executorch::aten::string_view /*key*/) const override {
+    return Error::NotFound;
+  }
+
+  Error load_data_into(
+      executorch::aten::string_view /*key*/,
+      void* /*buffer*/,
+      size_t /*size*/) const override {
+    return Error::NotFound;
+  }
+
+  Result<uint32_t> get_num_keys() const override {
+    return static_cast<uint32_t>(data_.size());
+  }
+
+  Result<const char*> get_key(uint32_t /*index*/) const override {
+    return Error::NotFound;
+  }
+
+ private:
+  std::unordered_map<std::string, std::vector<uint8_t>> data_;
+};
+
+std::vector<uint8_t> encode_int(int64_t v) {
+  std::vector<uint8_t> buf(1 + sizeof(int64_t));
+  buf[0] = kTagInt;
+  std::memcpy(buf.data() + 1, &v, sizeof(int64_t));
+  return buf;
+}
+
+std::vector<uint8_t> encode_float(double v) {
+  std::vector<uint8_t> buf(1 + sizeof(double));
+  buf[0] = kTagFloat;
+  std::memcpy(buf.data() + 1, &v, sizeof(double));
+  return buf;
+}
+
+std::vector<uint8_t> encode_string(const std::string& s) {
+  std::vector<uint8_t> buf(1 + s.size());
+  buf[0] = kTagString;
+  std::memcpy(buf.data() + 1, s.data(), s.size());
+  return buf;
+}
+
+std::vector<uint8_t> encode_bytes(const std::vector<uint8_t>& raw) {
+  std::vector<uint8_t> buf(1 + raw.size());
+  buf[0] = kTagBytes;
+  if (!raw.empty()) {
+    std::memcpy(buf.data() + 1, raw.data(), raw.size());
+  }
+  return buf;
+}
+
+std::vector<uint8_t> encode_int_list(const std::vector<int64_t>& vals) {
+  uint32_t count = static_cast<uint32_t>(vals.size());
+  std::vector<uint8_t> buf(1 + sizeof(uint32_t) + count * sizeof(int64_t));
+  buf[0] = kTagIntList;
+  std::memcpy(buf.data() + 1, &count, sizeof(uint32_t));
+  if (count > 0) {
+    std::memcpy(
+        buf.data() + 1 + sizeof(uint32_t), vals.data(), count * sizeof(int64_t));
+  }
+  return buf;
+}
+
+class MetadataTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    executorch::runtime::runtime_init();
+  }
+};
+
+TEST_F(MetadataTest, GetInt) {
+  MockNamedDataMap map;
+  map.add("metadata.tokenizer.bos_id", encode_int(128000));
+  auto result = get_int(map, "metadata.tokenizer.bos_id");
+  ASSERT_TRUE(result.ok());
+  EXPECT_EQ(result.get(), 128000);
+}
+
+TEST_F(MetadataTest, GetIntNegative) {
+  MockNamedDataMap map;
+  map.add("metadata.val", encode_int(-42));
+  auto result = get_int(map, "metadata.val");
+  ASSERT_TRUE(result.ok());
+  EXPECT_EQ(result.get(), -42);
+}
+
+TEST_F(MetadataTest, GetIntWrongSize) {
+  MockNamedDataMap map;
+  map.add("metadata.bad", {kTagInt, 0x01, 0x02, 0x03});
+  auto result = get_int(map, "metadata.bad");
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.error(), Error::InvalidArgument);
+}
+
+TEST_F(MetadataTest, GetIntWrongTag) {
+  MockNamedDataMap map;
+  map.add("metadata.mismatch", encode_string("oops"));
+  auto result = get_int(map, "metadata.mismatch");
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.error(), Error::InvalidArgument);
+}
+
+TEST_F(MetadataTest, GetIntMissing) {
+  MockNamedDataMap map;
+  auto result = get_int(map, "metadata.missing");
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.error(), Error::NotFound);
+}
+
+TEST_F(MetadataTest, GetFloat) {
+  MockNamedDataMap map;
+  map.add("metadata.temp", encode_float(0.7));
+  auto result = get_float(map, "metadata.temp");
+  ASSERT_TRUE(result.ok());
+  EXPECT_DOUBLE_EQ(result.get(), 0.7);
+}
+
+TEST_F(MetadataTest, GetFloatWrongTag) {
+  MockNamedDataMap map;
+  map.add("metadata.mismatch", encode_int(42));
+  auto result = get_float(map, "metadata.mismatch");
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.error(), Error::InvalidArgument);
+}
+
+TEST_F(MetadataTest, GetString) {
+  MockNamedDataMap map;
+  map.add("metadata.model.arch", encode_string("llama"));
+  auto result = get_string(map, "metadata.model.arch");
+  ASSERT_TRUE(result.ok());
+  EXPECT_EQ(result.get(), "llama");
+}
+
+TEST_F(MetadataTest, GetStringEmpty) {
+  MockNamedDataMap map;
+  map.add("metadata.empty", encode_string(""));
+  auto result = get_string(map, "metadata.empty");
+  ASSERT_TRUE(result.ok());
+  EXPECT_EQ(result.get(), "");
+}
+
+TEST_F(MetadataTest, GetStringWrongTag) {
+  MockNamedDataMap map;
+  map.add("metadata.mismatch", encode_int(123));
+  auto result = get_string(map, "metadata.mismatch");
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.error(), Error::InvalidArgument);
+}
+
+TEST_F(MetadataTest, GetBytes) {
+  MockNamedDataMap map;
+  std::vector<uint8_t> raw = {0x00, 0x01, 0x02, 0xFF};
+  map.add("metadata.blob", encode_bytes(raw));
+  auto result = get_bytes(map, "metadata.blob");
+  ASSERT_TRUE(result.ok());
+  EXPECT_EQ(result.get(), raw);
+}
+
+TEST_F(MetadataTest, GetIntList) {
+  MockNamedDataMap map;
+  map.add("metadata.tokenizer.eos_ids", encode_int_list({128009, 128001}));
+  auto result = get_int_list(map, "metadata.tokenizer.eos_ids");
+  ASSERT_TRUE(result.ok());
+  const std::vector<int64_t> expected{128009, 128001};
+  EXPECT_EQ(result.get(), expected);
+}
+
+TEST_F(MetadataTest, GetIntListEmpty) {
+  MockNamedDataMap map;
+  map.add("metadata.empty_list", encode_int_list({}));
+  auto result = get_int_list(map, "metadata.empty_list");
+  ASSERT_TRUE(result.ok());
+  EXPECT_TRUE(result.get().empty());
+}
+
+TEST_F(MetadataTest, GetIntListTruncatedHeader) {
+  MockNamedDataMap map;
+  map.add("metadata.bad", {kTagIntList, 0x01, 0x02});
+  auto result = get_int_list(map, "metadata.bad");
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.error(), Error::InvalidArgument);
+}
+
+TEST_F(MetadataTest, GetIntListCountMismatch) {
+  MockNamedDataMap map;
+  auto buf = encode_int_list({42});
+  uint32_t fake_count = 2;
+  std::memcpy(buf.data() + 1, &fake_count, sizeof(uint32_t));
+  map.add("metadata.bad", std::move(buf));
+  auto result = get_int_list(map, "metadata.bad");
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.error(), Error::InvalidArgument);
+}
+
+TEST_F(MetadataTest, GetIntListWrongTag) {
+  MockNamedDataMap map;
+  map.add("metadata.mismatch", encode_string("not a list"));
+  auto result = get_int_list(map, "metadata.mismatch");
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.error(), Error::InvalidArgument);
+}
+
+} // namespace


### PR DESCRIPTION
Summary:

Add support for embedding model-level metadata (tokenizer config, chat
templates, architecture info) directly in PTE files using the existing
NamedData mechanism. This is a lightweight alternative to the current
constant_methods approach, which creates full ExecutionPlan entries for
simple constant values.

Python export API: add_metadata(edge_manager, {"key": value})
C++ runtime API: metadata::get_int(map, key), get_string, get_int_list, get_float

Supported types: str, int, float, bytes, list[int].
Keys use a namespace.field convention (e.g., tokenizer.bos_id,
context.max_seq_len) and are prefixed with "metadata." to avoid
collision with backend NamedData entries.

Differential Revision: D104322796


