### PR TITLE
Examples: Fix integer overflows in size computations

### DIFF
--- a/examples/mediatek/executor_runner/llama_runner/LlamaModelChunk.cpp
+++ b/examples/mediatek/executor_runner/llama_runner/LlamaModelChunk.cpp
@@ -11,6 +11,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include <c10/util/safe_numerics.h>
 #include <executorch/extension/data_loader/file_data_loader.h>
 #include <executorch/extension/evalue_util/print_evalue.h>
 #include <executorch/runtime/executor/method.h>
@@ -445,19 +446,35 @@ void LlamaModelChunk::PrepareCacheIOs() {
 }
 
 size_t LlamaModelChunk::GetCacheNumRows() const {
-  return std::reduce(
-      mCacheShape.begin(),
-      mCacheShape.begin() + kCacheLengthDim,
-      1,
-      std::multiplies<>());
+  size_t result = 1;
+  for (auto it = mCacheShape.begin();
+       it != mCacheShape.begin() + kCacheLengthDim;
+       ++it) {
+    ET_CHECK_MSG(
+        *it >= 0,
+        "Negative dimension %d in cache shape",
+        static_cast<int>(*it));
+    ET_CHECK_MSG(
+        !c10::mul_overflows(result, static_cast<size_t>(*it), &result),
+        "Overflow computing cache row count");
+  }
+  return result;
 }
 
 size_t LlamaModelChunk::GetCacheStrideSize() const {
-  return std::reduce(
-      mCacheShape.begin() + kCacheLengthDim + 1,
-      mCacheShape.end(),
-      kCacheTypeSize,
-      std::multiplies<>());
+  size_t result = kCacheTypeSize;
+  for (auto it = mCacheShape.begin() + kCacheLengthDim + 1;
+       it != mCacheShape.end();
+       ++it) {
+    ET_CHECK_MSG(
+        *it >= 0,
+        "Negative dimension %d in cache shape",
+        static_cast<int>(*it));
+    ET_CHECK_MSG(
+        !c10::mul_overflows(result, static_cast<size_t>(*it), &result),
+        "Overflow computing cache stride size");
+  }
+  return result;
 }
 
 void LlamaModelChunk::InitMaskBuilder() {

--- a/examples/models/llama/runner/static_attention_io_manager.h
+++ b/examples/models/llama/runner/static_attention_io_manager.h
@@ -14,6 +14,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include <c10/util/safe_numerics.h>
 #include <executorch/runtime/core/exec_aten/util/scalar_type_util.h>
 #include <executorch/runtime/core/span.h>
 #include <executorch/runtime/executor/method.h>
@@ -54,11 +55,25 @@ class StaticKVCache {
         style_(style),
         input_ptrs_(n_caches_),
         output_ptrs_(n_caches_) {
-    size_t total_cache_len = std::accumulate(
-        cache_lengths_.begin(), cache_lengths_.end(), size_t(0));
-    cache_data_size_ = total_cache_len * n_heads_per_cache_ * head_dim_;
-    update_data_size_ =
-        n_caches_ * n_heads_per_cache_ * max_input_len_ * head_dim_;
+    size_t total_cache_len = 0;
+    for (size_t cache_len : cache_lengths_) {
+      ET_CHECK_MSG(
+          !c10::add_overflows(total_cache_len, cache_len, &total_cache_len),
+          "Overflow summing cache lengths");
+    }
+    ET_CHECK_MSG(
+        !c10::mul_overflows(
+            total_cache_len, n_heads_per_cache_, &cache_data_size_) &&
+            !c10::mul_overflows(cache_data_size_, head_dim_, &cache_data_size_),
+        "Overflow computing cache_data_size_");
+    ET_CHECK_MSG(
+        !c10::mul_overflows(
+            n_caches_, n_heads_per_cache_, &update_data_size_) &&
+            !c10::mul_overflows(
+                update_data_size_, max_input_len_, &update_data_size_) &&
+            !c10::mul_overflows(
+                update_data_size_, head_dim_, &update_data_size_),
+        "Overflow computing update_data_size_");
 
     cache_data_ = allocator_.allocate(cache_data_size_);
     update_data_ = allocator_.allocate(update_data_size_);

--- a/examples/qualcomm/executor_runner/qnn_executor_runner.cpp
+++ b/examples/qualcomm/executor_runner/qnn_executor_runner.cpp
@@ -29,6 +29,7 @@
 #include <executorch/runtime/platform/log.h>
 #include <executorch/runtime/platform/runtime.h>
 
+#include <c10/util/safe_numerics.h>
 #include <gflags/gflags.h>
 
 #include <chrono>
@@ -613,11 +614,19 @@ int main(int argc, char** argv) {
         auto output_tensor = outputs[output_index].toTensor();
         size_t nbytes = output_tensor.nbytes();
         if (!expected_output_shapes.empty()) {
-          nbytes = std::accumulate(
-              expected_output_shapes[output_index].begin(),
-              expected_output_shapes[output_index].end(),
-              executorch::runtime::elementSize(output_tensor.scalar_type()),
-              std::multiplies<int>());
+          size_t computed = static_cast<size_t>(
+              executorch::runtime::elementSize(output_tensor.scalar_type()));
+          for (int32_t dim : expected_output_shapes[output_index]) {
+            ET_CHECK_MSG(
+                dim >= 0,
+                "Negative dimension %d in expected output shape",
+                dim);
+            ET_CHECK_MSG(
+                !c10::mul_overflows(
+                    computed, static_cast<size_t>(dim), &computed),
+                "Overflow computing expected output nbytes");
+          }
+          nbytes = computed;
         }
         auto output_file_name = FLAGS_output_folder_path + "/output_" +
             std::to_string(inference_index) + "_" +


### PR DESCRIPTION
Replace std::accumulate / std::reduce with std::multiplies<>() and std::accumulate sums with explicit loops using c10::mul_overflows() and c10::add_overflows() to detect overflow before each operation. The previous code would silently wrap on overflow, producing undersized buffer sizes that could lead to out-of-bounds access.

Touches:
- examples/mediatek/.../LlamaModelChunk.cpp: GetCacheNumRows and GetCacheStrideSize (multiplicative reductions over cache shape)
- examples/models/llama/runner/static_attention_io_manager.h: StaticKVCache constructor cache_data_size_/update_data_size_ (sum and chained multiplies)
- examples/qualcomm/executor_runner/qnn_executor_runner.cpp: output nbytes computation from dynamic shape file

These functions cannot return Error, so abort via ET_CHECK_MSG when overflow is detected. As examples they also serve as templates for third-party code, so getting the pattern right matters.

This PR was authored with the assistance of Claude.