### PR TITLE
Relax XNNPACK quantized convolution test tolerances

### DIFF
--- a/backends/xnnpack/test/ops/test_conv2d.py
+++ b/backends/xnnpack/test/ops/test_conv2d.py
@@ -245,7 +245,7 @@ class TestConv2d(unittest.TestCase):
             .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
             .to_executorch()
             .serialize()
-            .run_method_and_compare_outputs(qtol=1)
+            .run_method_and_compare_outputs(qtol=2)
         )
 
     def _test_dq(
@@ -276,7 +276,7 @@ class TestConv2d(unittest.TestCase):
         tester.check_not(["executorch_exir_dialects_edge__ops_aten_conv2d_default"])
         tester.to_executorch()
         tester.serialize()
-        tester.run_method_and_compare_outputs(qtol=1)
+        tester.run_method_and_compare_outputs(qtol=2)
 
     def test_fp16_conv2d(self) -> None:
         for transpose in (True, False):


### PR DESCRIPTION
### Summary
XNNPACK quantized convolution tests are failing sporadically. When tests run multiple convolutions back to back, the output can differ from eager by more than one quant value. This is reasonable, so bump the tolerance to 2 times the output quant step.
