### PR TITLE
Replace GTEST_SKIP() aten guards with #ifndef USE_ATEN_LIB (1/3)

### DIFF
--- a/kernels/test/op__clone_dim_order_test.cpp
+++ b/kernels/test/op__clone_dim_order_test.cpp
@@ -154,10 +154,8 @@ TEST_F(OpDimOrderCloneTest, AllDtypesSupported) {
 }
 
 // Cloning with mismatched input and output tensor shapes should fail.
+#ifndef USE_ATEN_LIB
 TEST_F(OpDimOrderCloneTest, MismatchedSizesDie) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "Skipping: ATen kernel supports mismatched sizes.";
-  }
   TensorFactory<ScalarType::Int> tf;
   Tensor input = tf.make(/*sizes=*/{3, 1, 1, 2}, /*data=*/{1, 2, 3, 4, 5, 6});
   Tensor out = tf.zeros({3, 2, 1, 1});
@@ -175,13 +173,11 @@ TEST_F(OpDimOrderCloneTest, MismatchedSizesDie) {
           dim_order,
           out));
 }
+#endif
 
 // Cloning with an unsupported memory format should fail.
+#ifndef USE_ATEN_LIB
 TEST_F(OpDimOrderCloneTest, MismatchedMemoryFormatDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP()
-        << "Skipping: ATen kernel supports non-contiguous memory formats.";
-  }
   TensorFactory<ScalarType::Float> tf_in;
   TensorFactory<ScalarType::Float> tf_out;
   Tensor input =
@@ -206,14 +202,12 @@ TEST_F(OpDimOrderCloneTest, MismatchedMemoryFormatDies) {
           dim_order,
           out));
 }
+#endif
 
 // Cloning with non‑blocking=true should fail because portable kernels only
 // support blocking.
+#ifndef USE_ATEN_LIB
 TEST_F(OpDimOrderCloneTest, MismatchedBlockingDie) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP()
-        << "Skipping: ATen kernel supports non-blocking data transfer.";
-  }
   TensorFactory<ScalarType::Int> tf;
   Tensor input = tf.make(/*sizes=*/{3, 1, 1, 2}, /*data=*/{1, 2, 3, 4, 5, 6});
   Tensor out = tf.zeros(/*sizes=*/{3, 1, 1, 2});
@@ -232,6 +226,7 @@ TEST_F(OpDimOrderCloneTest, MismatchedBlockingDie) {
           dim_order,
           out));
 }
+#endif
 
 TEST_F(OpDimOrderCloneTest, DynamicShapeUpperBoundSameAsExpected) {
   test_dynamic_shape(

--- a/kernels/test/op__to_dim_order_copy_test.cpp
+++ b/kernels/test/op__to_dim_order_copy_test.cpp
@@ -458,10 +458,8 @@ TEST_F(OpToDimOrderCopyTest, HardcodeFloatConvertInt) {
   ET_FORALL_FLOATHBF16_TYPES(TEST_ENTRY);
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpToDimOrderCopyTest, MismatchedSizesDie) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched sizes";
-  }
   TensorFactory<ScalarType::Int> tf;
   Tensor input = tf.make(/*sizes=*/{3, 1, 1, 2}, /*data=*/{1, 2, 3, 4, 5, 6});
   Tensor out = tf.zeros({3, 2, 1, 1});
@@ -479,14 +477,13 @@ TEST_F(OpToDimOrderCopyTest, MismatchedSizesDie) {
           dim_order,
           out));
 }
+#endif
 
 // Only contiguous memory is supported, the memory type MemoryFormat::Contiguous
 // should not be allowed. The function is expected death if using the illegal
 // memory format.
+#ifndef USE_ATEN_LIB
 TEST_F(OpToDimOrderCopyTest, MismatchedMemoryFormatDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle non contiguous memory formats";
-  }
   TensorFactory<ScalarType::Float> tf_in;
   TensorFactory<ScalarType::Float> tf_out;
   Tensor input =
@@ -511,12 +508,11 @@ TEST_F(OpToDimOrderCopyTest, MismatchedMemoryFormatDies) {
           dim_order,
           out));
 }
+#endif
 
 // Only blocking data transfer supported
+#ifndef USE_ATEN_LIB
 TEST_F(OpToDimOrderCopyTest, MismatchedBlockingDie) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle non blocking data transfer";
-  }
   TensorFactory<ScalarType::Int> tf;
   Tensor input = tf.make(/*sizes=*/{3, 1, 1, 2}, /*data=*/{1, 2, 3, 4, 5, 6});
   Tensor out = tf.zeros(/*sizes=*/{3, 1, 1, 2});
@@ -535,6 +531,7 @@ TEST_F(OpToDimOrderCopyTest, MismatchedBlockingDie) {
           dim_order,
           out));
 }
+#endif
 
 TEST_F(OpToDimOrderCopyTest, DynamicShapeUpperBoundSameAsExpected) {
   test_dynamic_shape(

--- a/kernels/test/op_amax_test.cpp
+++ b/kernels/test/op_amax_test.cpp
@@ -259,30 +259,26 @@ void OpAmaxOutTest::test_amax_out_dtype<ScalarType::Bool>() {
   // clang-format on
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpAmaxOutTest, InvalidDimensionListDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel test fails";
-  }
 #define TEST_ENTRY(ctype, dtype) \
   test_amax_out_invalid_dimensions<ScalarType::dtype>();
   ET_FORALL_REAL_TYPES_AND(Bool, TEST_ENTRY);
 #undef TEST_ENTRY
 }
+#endif
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpAmaxOutTest, InvalidShapeDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel test fails";
-  }
 #define TEST_ENTRY(ctype, dtype) \
   test_amax_out_invalid_shape<ScalarType::dtype>();
   ET_FORALL_REAL_TYPES_AND(Bool, TEST_ENTRY);
 #undef TEST_ENTRY
 }
+#endif
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpAmaxOutTest, MismatchedDTypesDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel test fails";
-  }
   TensorFactory<ScalarType::Float> tf_float;
   TensorFactory<ScalarType::Int> tf_int;
 
@@ -308,6 +304,7 @@ TEST_F(OpAmaxOutTest, MismatchedDTypesDies) {
   ET_EXPECT_KERNEL_FAILURE(
       context_, op_amax_out(in, dim_list, /*keepdim=*/true, out));
 }
+#endif
 
 TEST_F(OpAmaxOutTest, AllRealInputOutputPasses) {
 #define TEST_ENTRY(ctype, dtype) test_amax_out_dtype<ScalarType::dtype>();

--- a/kernels/test/op_amin_test.cpp
+++ b/kernels/test/op_amin_test.cpp
@@ -258,30 +258,26 @@ void OpAminOutTest::test_amin_out_dtype<ScalarType::Bool>() {
   // clang-format on
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpAminOutTest, InvalidDimensionListDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel test fails";
-  }
 #define TEST_ENTRY(ctype, dtype) \
   test_amin_out_invalid_dimensions<ScalarType::dtype>();
   ET_FORALL_REAL_TYPES_AND(Bool, TEST_ENTRY);
 #undef TEST_ENTRY
 }
+#endif
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpAminOutTest, InvalidShapeDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel test fails";
-  }
 #define TEST_ENTRY(ctype, dtype) \
   test_amin_out_invalid_shape<ScalarType::dtype>();
   ET_FORALL_REAL_TYPES_AND(Bool, TEST_ENTRY);
 #undef TEST_ENTRY
 }
+#endif
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpAminOutTest, MismatchedDTypesDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel test fails";
-  }
   TensorFactory<ScalarType::Float> tf_float;
   TensorFactory<ScalarType::Int> tf_int;
 
@@ -307,6 +303,7 @@ TEST_F(OpAminOutTest, MismatchedDTypesDies) {
   ET_EXPECT_KERNEL_FAILURE(
       context_, op_amin_out(in, dim_list, /*keepdim=*/true, out));
 }
+#endif
 
 TEST_F(OpAminOutTest, AllRealInputOutputPasses) {
 #define TEST_ENTRY(ctype, dtype) test_amin_out_dtype<ScalarType::dtype>();

--- a/kernels/test/op_any_test.cpp
+++ b/kernels/test/op_any_test.cpp
@@ -98,10 +98,8 @@ class OpAnyOutTest : public OperatorTest {
   }
 };
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpAnyOutTest, MismatchedDimensionsDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched dimensions";
-  }
   TensorFactory<ScalarType::Float> tff;
   const std::vector<int32_t> size{2, 2};
 
@@ -110,6 +108,7 @@ TEST_F(OpAnyOutTest, MismatchedDimensionsDies) {
 
   ET_EXPECT_KERNEL_FAILURE(context_, op_any_all_out(in, out));
 }
+#endif
 
 TEST_F(OpAnyOutTest, InvalidDtypeDies) {
 #define TEST_ENTRY(ctype, dtype) \

--- a/kernels/test/op_arange_test.cpp
+++ b/kernels/test/op_arange_test.cpp
@@ -113,10 +113,8 @@ TEST_F(OpArangeOutTest, FloatNumberNotEqualIntSupport) {
   EXPECT_TENSOR_EQ(out, expected);
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpArangeOutTest, OutDimUnsupportedDie) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched out dim";
-  }
   TensorFactory<ScalarType::Float> tf;
 
   Scalar end = Scalar(5);
@@ -126,6 +124,7 @@ TEST_F(OpArangeOutTest, OutDimUnsupportedDie) {
   // out.dim() should be 1, not 2
   ET_EXPECT_KERNEL_FAILURE(context_, op_arange_out(end, out));
 }
+#endif
 
 TEST_F(OpArangeOutTest, DynamicShapeUpperBoundSameAsExpected) {
   TensorFactory<ScalarType::Float> tf;
@@ -149,10 +148,8 @@ TEST_F(OpArangeOutTest, DynamicShapeUpperBoundLargerThanExpected) {
   EXPECT_TENSOR_CLOSE(out, expected_result);
 }
 
+#ifdef USE_ATEN_LIB
 TEST_F(OpArangeOutTest, DynamicShapeUnbound) {
-  if (!torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "Dynamic Unbound not supported";
-  }
   TensorFactory<ScalarType::Float> tf;
 
   Tensor expected_result = tf.make({5}, {0, 1, 2, 3, 4});
@@ -162,6 +159,7 @@ TEST_F(OpArangeOutTest, DynamicShapeUnbound) {
   Tensor ret = op_arange_out(Scalar(5), out);
   EXPECT_TENSOR_CLOSE(out, expected_result);
 }
+#endif
 
 /// A generic smoke test that works for any dtype that supports  zeros().
 TEST_F(OpArangeStartOutTest, AllRealHBF16DtypesSupported) {
@@ -195,10 +193,8 @@ TEST_F(OpArangeStartOutTest, FloatNumberNotEqualIntSupport) {
   EXPECT_TENSOR_EQ(out, expected);
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpArangeStartOutTest, OutDimUnsupportedDie) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched out dim";
-  }
   TensorFactory<ScalarType::Float> tf;
 
   Scalar start = Scalar(0);
@@ -211,6 +207,7 @@ TEST_F(OpArangeStartOutTest, OutDimUnsupportedDie) {
   ET_EXPECT_KERNEL_FAILURE(
       context_, op_arange_start_out(start, end, step, out));
 }
+#endif
 
 TEST_F(OpArangeStartOutTest, DynamicShapeUpperBoundSameAsExpected) {
   TensorFactory<ScalarType::Float> tf;
@@ -234,10 +231,8 @@ TEST_F(OpArangeStartOutTest, DynamicShapeUpperBoundLargerThanExpected) {
   EXPECT_TENSOR_CLOSE(out, expected_result);
 }
 
+#ifdef USE_ATEN_LIB
 TEST_F(OpArangeStartOutTest, DynamicShapeUnbound) {
-  if (!torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "Dynamic Unbound not supported";
-  }
   TensorFactory<ScalarType::Float> tf;
 
   Tensor expected_result = tf.make({5}, {0, 1, 2, 3, 4});
@@ -247,6 +242,7 @@ TEST_F(OpArangeStartOutTest, DynamicShapeUnbound) {
   Tensor ret = op_arange_start_out(Scalar(0), Scalar(5), Scalar(1), out);
   EXPECT_TENSOR_CLOSE(out, expected_result);
 }
+#endif
 
 TEST_F(OpArangeStartOutTest, StartOut) {
   TensorFactory<ScalarType::Float> tf;

--- a/kernels/test/op_as_strided_copy_test.cpp
+++ b/kernels/test/op_as_strided_copy_test.cpp
@@ -196,15 +196,14 @@ TEST_F(OpAsStridedCopyOutTest, AllScalarInputOutputSupport) {
 #undef TEST_ENTRY
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpAsStridedCopyOutTest, InvalidParametersDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle invalid parameter";
-  }
 #define TEST_ENTRY(ctype, dtype) \
   test_as_strided_copy_out_invalid_parameters<ScalarType::dtype>();
   ET_FORALL_REAL_TYPES_AND(Bool, TEST_ENTRY);
 #undef TEST_ENTRY
 }
+#endif
 
 TEST_F(OpAsStridedCopyOutTest, MismatchedInputDtypesDies) {
   TensorFactory<ScalarType::Byte> tf_byte;

--- a/kernels/test/op_bitwise_not_test.cpp
+++ b/kernels/test/op_bitwise_not_test.cpp
@@ -95,10 +95,8 @@ TEST_F(OpBitwiseNotOutTest, BoolInputOutputSupport) {
 }
 
 // Mismatched shape tests.
+#ifndef USE_ATEN_LIB
 TEST_F(OpBitwiseNotOutTest, MismatchedShapesDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched shapes";
-  }
   TensorFactory<ScalarType::Int> tf;
 
   Tensor a = tf.ones(/*sizes=*/{4});
@@ -106,6 +104,7 @@ TEST_F(OpBitwiseNotOutTest, MismatchedShapesDies) {
 
   ET_EXPECT_KERNEL_FAILURE(context_, op_bitwise_not_out(a, out));
 }
+#endif
 
 TEST_F(OpBitwiseNotOutTest, AllFloatInputDTypeDies) {
 #define TEST_ENTRY(ctype, dtype) \

--- a/kernels/test/op_bmm_test.cpp
+++ b/kernels/test/op_bmm_test.cpp
@@ -238,10 +238,8 @@ TEST_F(OpBmmOutTest, MismatchedDimensionsDies) {
   EXPECT_TENSOR_EQ(op_bmm_out(x, right_y, out), tf.full({2, 10, 4}, 3));
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpBmmOutTest, MismatchedDimensionSizeDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched dimension size";
-  }
   TensorFactory<ScalarType::Int> tf;
 
   Tensor x = tf.ones({2, 10, 3});
@@ -259,11 +257,10 @@ TEST_F(OpBmmOutTest, MismatchedDimensionSizeDies) {
   ET_EXPECT_KERNEL_FAILURE(context_, op_bmm_out(x, right_y, wrong_out));
   ET_EXPECT_KERNEL_FAILURE(context_, op_bmm_out(x, wrong_y, right_out));
 }
+#endif
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpBmmOutTest, WrongOutShapeDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle wrong out shape";
-  }
   TensorFactory<ScalarType::Int> tf;
 
   Tensor x = tf.ones({2, 10, 3});
@@ -278,6 +275,7 @@ TEST_F(OpBmmOutTest, WrongOutShapeDies) {
 
   EXPECT_TENSOR_EQ(op_bmm_out(x, y, right_out), tf.full({2, 10, 4}, 3));
 }
+#endif
 
 TEST_F(OpBmmOutTest, DynamicShapeUpperBoundSameAsExpected) {
   TensorFactory<ScalarType::Float> tf;

--- a/kernels/test/op_cat_test.cpp
+++ b/kernels/test/op_cat_test.cpp
@@ -177,13 +177,12 @@ TEST_F(OpCatOutTest, SmokeDim1) {
   EXPECT_TENSOR_EQ(out, expected);
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpCatOutTest, SixteenBitFloatSupport) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "Test Half/BF16 support only for ExecuTorch mode";
-  }
   test_16bit_dtype<ScalarType::Half>();
   test_16bit_dtype<ScalarType::BFloat16>();
 }
+#endif
 
 TEST_F(OpCatOutTest, ComplexSupport) {
 #define RUN_COMPLEX_TEST(ctype, dtype) \
@@ -245,10 +244,8 @@ TEST_F(OpCatOutTest, AllDtypesSupported) {
   // for those types.
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpCatOutTest, EmptyInputTensorShapeIgnored) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel doesn't ignore empty input tensor shape";
-  }
   TensorFactory<ScalarType::Int> tf;
 
   // An empty tensor with a shape totally different from the non-empty inputs.
@@ -265,6 +262,7 @@ TEST_F(OpCatOutTest, EmptyInputTensorShapeIgnored) {
   op_cat_out(ArrayRef<Tensor>(inputs.data(), inputs.size()), /*dim=*/0, out);
   // Success if it doesn't assert on the weird-shaped empty input.
 }
+#endif
 
 TEST_F(OpCatOutTest, DimBounds) {
   TensorFactory<ScalarType::Int> tf;
@@ -329,10 +327,8 @@ TEST_F(OpCatOutTest, MismatchedDtypesDies) {
           ArrayRef<Tensor>(inputs.data(), inputs.size()), /*dim=*/0, out));
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpCatOutTest, MismatchedDimensionsDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched dimensions";
-  }
   TensorFactory<ScalarType::Int> tf;
   Tensor out = tf.zeros({2, 2});
 
@@ -344,11 +340,10 @@ TEST_F(OpCatOutTest, MismatchedDimensionsDies) {
       op_cat_out(
           ArrayRef<Tensor>(inputs.data(), inputs.size()), /*dim=*/0, out));
 }
+#endif
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpCatOutTest, MismatchedDimensionSizeDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched dimension size";
-  }
   TensorFactory<ScalarType::Int> tf;
   Tensor out = tf.zeros({2, 2});
 
@@ -361,11 +356,10 @@ TEST_F(OpCatOutTest, MismatchedDimensionSizeDies) {
       op_cat_out(
           ArrayRef<Tensor>(inputs.data(), inputs.size()), /*dim=*/0, out));
 }
+#endif
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpCatOutTest, WrongOutShapeDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle wrong out shape";
-  }
   TensorFactory<ScalarType::Int> tf;
 
   // Should be {4, 3} to match the inputs when calling cat() with dim 0.
@@ -381,6 +375,7 @@ TEST_F(OpCatOutTest, WrongOutShapeDies) {
       op_cat_out(
           ArrayRef<Tensor>(inputs.data(), inputs.size()), /*dim=*/0, out));
 }
+#endif
 
 /* %python
 import torch

--- a/kernels/test/op_clamp_test.cpp
+++ b/kernels/test/op_clamp_test.cpp
@@ -359,13 +359,12 @@ TEST_F(OpClampOutTest, DoubleTensors) {
 // int, floating point.
 //
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpClampOutTest, ByteTensorNegativeClampDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle negative clamp on byte tensor";
-  }
   // Cannot be represented by a uint8_t.
   expect_bad_clamp_value_dies<ScalarType::Byte>(-1);
 }
+#endif
 
 TEST_F(OpClampOutTest, ByteTensorTooLargeClampDies) {
   // Cannot be represented by a uint8_t.

--- a/kernels/test/op_clone_test.cpp
+++ b/kernels/test/op_clone_test.cpp
@@ -72,14 +72,13 @@ class OpCloneTest : public OperatorTest {
 };
 
 // regular test for clone.out
+#ifndef USE_ATEN_LIB
 TEST_F(OpCloneTest, AllDtypesSupported) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel test fails";
-  }
 #define TEST_ENTRY(ctype, dtype) test_dtype<ctype, ScalarType::dtype>();
   ET_FORALL_REAL_TYPES_AND(Bool, TEST_ENTRY);
 #undef TEST_ENTRY
 }
+#endif
 
 TEST_F(OpCloneTest, EmptyInputSupported) {
 #define TEST_ENTRY(ctype, dtype) test_empty_input<ctype, ScalarType::dtype>();
@@ -87,10 +86,8 @@ TEST_F(OpCloneTest, EmptyInputSupported) {
 #undef TEST_ENTRY
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpCloneTest, MismatchedSizesDie) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched sizes";
-  }
   TensorFactory<ScalarType::Int> tf;
   Tensor input = tf.make(/*sizes=*/{3, 1, 1, 2}, /*data=*/{1, 2, 3, 4, 5, 6});
   Tensor out = tf.zeros({3, 2, 1, 1});
@@ -98,6 +95,7 @@ TEST_F(OpCloneTest, MismatchedSizesDie) {
       context_,
       op_clone_out(input, /*memory_format=*/executorch::aten::nullopt, out));
 }
+#endif
 
 TEST_F(OpCloneTest, MismatchedTypesDie) {
   TensorFactory<ScalarType::Int> tf_in;
@@ -113,10 +111,8 @@ TEST_F(OpCloneTest, MismatchedTypesDie) {
 // Only contiguous memory is supported, the memory type other than nullopt or
 // MemoryFormat::Contiguous should not be allowed. The function is expected
 // depth if using the illegal memory format.
+#ifndef USE_ATEN_LIB
 TEST_F(OpCloneTest, MismatchedMemoryFormatDie) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle non contiguous memory formats";
-  }
   TensorFactory<ScalarType::Float> tf_in;
   TensorFactory<ScalarType::Float> tf_out;
   Tensor input =
@@ -127,6 +123,7 @@ TEST_F(OpCloneTest, MismatchedMemoryFormatDie) {
       op_clone_out(
           input, static_cast<executorch::aten::MemoryFormat>(55), out));
 }
+#endif
 
 TEST_F(OpCloneTest, SimpleGeneratedCase) {
   TensorFactory<ScalarType::Float> tf;

--- a/kernels/test/op_constant_pad_nd_test.cpp
+++ b/kernels/test/op_constant_pad_nd_test.cpp
@@ -462,10 +462,8 @@ TEST_F(OpConstantPadNDOutTest, TooManyPaddingElementsFail) {
       context_, op_constant_pad_nd_out(self, padding_ref, 0, out));
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpConstantPadNDOutTest, IncorrectOutputShapeFail) {
-  if (SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle reshape output";
-  }
 
   TensorFactory<ScalarType::Float> tf;
 
@@ -481,5 +479,6 @@ TEST_F(OpConstantPadNDOutTest, IncorrectOutputShapeFail) {
   ET_EXPECT_KERNEL_FAILURE(
       context_, op_constant_pad_nd_out(self, padding_ref, 0, out));
 }
+#endif
 
 GENERATE_SCALAR_OVERFLOW_TESTS(OpConstantPadNDOutTest)

--- a/kernels/test/op_copy_test.cpp
+++ b/kernels/test/op_copy_test.cpp
@@ -204,10 +204,8 @@ TEST_F(OpCopyTest, ResizeOutDie) {
 }
 #endif
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpCopyTest, MismatchedSizesDie) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched sizes";
-  }
   TensorFactory<ScalarType::Int> tf;
   Tensor self = tf.make(/*sizes=*/{3, 1, 1, 2}, /*data=*/{1, 2, 3, 4, 5, 6});
   Tensor src = tf.make(/*sizes=*/{3, 1, 1, 2}, /*data=*/{1, 2, 3, 4, 5, 6});
@@ -215,6 +213,7 @@ TEST_F(OpCopyTest, MismatchedSizesDie) {
   Tensor out = tf.zeros({3, 2, 1, 1});
   ET_EXPECT_KERNEL_FAILURE(context_, op_copy_out(self, src, non_blocking, out));
 }
+#endif
 
 TEST_F(OpCopyTest, MismatchedSrcOutTypesDie) {
   TensorFactory<ScalarType::Int> tf_in;
@@ -229,10 +228,8 @@ TEST_F(OpCopyTest, MismatchedSrcOutTypesDie) {
 // Only contiguous memory is supported, the memory type other than nullopt or
 // MemoryFormat::Contiguous should not be allowed. The function is expected
 // depth if using the illegal memory format.
+#ifndef USE_ATEN_LIB
 TEST_F(OpCopyTest, BlockingDie) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle non-contiguous memory formats";
-  }
   TensorFactory<ScalarType::Float> tf_in;
   TensorFactory<ScalarType::Float> tf_out;
   Tensor self = tf_in.make(/*sizes=*/{3, 1, 1, 2}, /*data=*/{1, 2, 3, 4, 5, 6});
@@ -241,6 +238,7 @@ TEST_F(OpCopyTest, BlockingDie) {
   Tensor out = tf_out.zeros({3, 1, 1, 2});
   ET_EXPECT_KERNEL_FAILURE(context_, op_copy_out(self, src, non_blocking, out));
 }
+#endif
 
 TEST_F(OpCopyTest, DynamicShapeUpperBoundSameAsExpected) {
   test_dynamic_shape(

--- a/kernels/test/op_cumsum_test.cpp
+++ b/kernels/test/op_cumsum_test.cpp
@@ -103,10 +103,8 @@ class OpCumSumOutTest : public OperatorTest {
   }
 };
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpCumSumOutTest, MismatchedDimensionsDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched dimensions";
-  }
   TensorFactory<ScalarType::Float> tff;
 
   Tensor in = tff.make({1, 3}, {0, 1, 2});
@@ -124,6 +122,7 @@ TEST_F(OpCumSumOutTest, MismatchedDimensionsDies) {
   ET_EXPECT_KERNEL_FAILURE(
       context_, op_cumsum_out(in, /*dim=*/1, enforced_dtype, wrong_out));
 }
+#endif
 
 /* A generic smoke test that works for the supported dtypes with
  * enforced_dtype specified.

--- a/kernels/test/op_detach_copy_test.cpp
+++ b/kernels/test/op_detach_copy_test.cpp
@@ -87,15 +87,14 @@ TEST_F(OpDetachCopyOutTest, AllScalarInputOutputSupport) {
 }
 
 // Mismatched shape tests.
+#ifndef USE_ATEN_LIB
 TEST_F(OpDetachCopyOutTest, MismatchedShapesDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched shapes";
-  }
 #define TEST_ENTRY(ctype, dtype) \
   test_detach_copy_out_invalid_shape<ScalarType::dtype>();
   ET_FORALL_REAL_TYPES_AND(Bool, TEST_ENTRY);
 #undef TEST_ENTRY
 }
+#endif
 
 TEST_F(OpDetachCopyOutTest, MismatchedInputDtypesDies) {
   TensorFactory<ScalarType::Byte> tf_byte;

--- a/kernels/test/op_div_test.cpp
+++ b/kernels/test/op_div_test.cpp
@@ -426,10 +426,8 @@ TEST_F(OpDivOutTest, BroadcastDimSizeMissingBA) {
 // Death Tests
 //
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpDivOutTest, MismatchedShapesDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched shapes";
-  }
   TensorFactory<ScalarType::Int> tf_int;
   TensorFactory<ScalarType::Float> tf_float;
 
@@ -439,6 +437,7 @@ TEST_F(OpDivOutTest, MismatchedShapesDies) {
 
   ET_EXPECT_KERNEL_FAILURE(context_, op_div_out(a, b, out));
 }
+#endif
 
 TEST_F(OpDivOutTest, AllNonFloatOutputDTypeDies) {
 #define TEST_ENTRY(ctype, dtype) \

--- a/kernels/test/op_embedding_test.cpp
+++ b/kernels/test/op_embedding_test.cpp
@@ -217,10 +217,8 @@ TEST_F(OpEmbeddingOutTest, WeightWrongDimensionsDies) {
           out));
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpEmbeddingOutTest, WrongOutShapeDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle wrong out shape";
-  }
   TensorFactory<ScalarType::Float> tff;
   // clang-format off
   Tensor weight = tff.make(
@@ -253,6 +251,7 @@ TEST_F(OpEmbeddingOutTest, WrongOutShapeDies) {
             wrong_out));
   }
 }
+#endif
 
 TEST_F(OpEmbeddingOutTest, UnmatchedOutTypeDie) {
   TensorFactory<ScalarType::Float> tff;

--- a/kernels/test/op_eq_test.cpp
+++ b/kernels/test/op_eq_test.cpp
@@ -81,10 +81,8 @@ TEST_F(OpEqScalarOutTest, BoolInputDtype) {
 }
 
 // Mismatched shape tests.
+#ifndef USE_ATEN_LIB
 TEST_F(OpEqScalarOutTest, MismatchedShapesDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched shapes";
-  }
   TensorFactory<ScalarType::Int> tf_int;
   TensorFactory<ScalarType::Bool> tf_bool;
 
@@ -94,15 +92,15 @@ TEST_F(OpEqScalarOutTest, MismatchedShapesDies) {
 
   ET_EXPECT_KERNEL_FAILURE(context_, op_eq_scalar_out(a, other, out));
 }
+#endif
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpEqScalarOutTest, AllRealOutputDTypes) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle non-bool output dtype";
-  }
 #define TEST_ENTRY(ctype, dtype) test_eq_all_output_dtypes<ScalarType::dtype>();
   ET_FORALL_REALHBF16_TYPES(TEST_ENTRY);
 #undef TEST_ENTRY
 }
+#endif
 
 /* %python
 import torch

--- a/kernels/test/op_expand_copy_test.cpp
+++ b/kernels/test/op_expand_copy_test.cpp
@@ -215,10 +215,8 @@ TEST_F(OpExpandOutTest, BadOutDataTypeGoodShapeDeath) {
       context_, op_expand_copy_out(a, {dims.data(), dims.size()}, false, out));
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpExpandOutTest, BadOutShapeGoodDataTypeDeath) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle this";
-  }
   TensorFactory<ScalarType::Int> tf;
   Tensor a = tf.make(/*sizes*/ {1, 2}, /*data=*/{42, 96});
   Tensor out = tf.ones({2, 6, 4});
@@ -228,6 +226,7 @@ TEST_F(OpExpandOutTest, BadOutShapeGoodDataTypeDeath) {
   ET_EXPECT_KERNEL_FAILURE(
       context_, op_expand_copy_out(a, {dims.data(), dims.size()}, false, out));
 }
+#endif
 
 TEST_F(OpExpandOutTest, SingleToMany) {
   TensorFactory<ScalarType::Int> tf;
@@ -313,10 +312,8 @@ TEST_F(OpExpandOutTest, ResizedOutput) {
 }
 #endif
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpExpandOutTest, ImplicitTrue) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle this";
-  }
   TensorFactory<ScalarType::Int> tf;
   Tensor a = tf.ones({2, 2});
   Tensor out = tf.zeros({2, 2});
@@ -325,6 +322,7 @@ TEST_F(OpExpandOutTest, ImplicitTrue) {
   ET_EXPECT_KERNEL_FAILURE(
       context_, op_expand_copy_out(a, {dims.data(), dims.size()}, true, out));
 }
+#endif
 
 /* %python
 import torch

--- a/kernels/test/op_fft_c2r_test.cpp
+++ b/kernels/test/op_fft_c2r_test.cpp
@@ -159,11 +159,8 @@ TEST_F(OpFftC2rOutTest, MultipleDims) {
 #undef TEST_ENTRY
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpFftC2rOutTest, InvalidNorm) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen MKL path does not validate norm";
-    return;
-  }
   auto invalid_norm = [this](int64_t norm) {
     test_dtype<float, ScalarType::Float, /* expect_failure = */ true>(norm);
   };
@@ -172,12 +169,10 @@ TEST_F(OpFftC2rOutTest, InvalidNorm) {
   ET_EXPECT_KERNEL_FAILURE(context_, invalid_norm(-1));
   ET_EXPECT_KERNEL_FAILURE(context_, invalid_norm(9999999));
 }
+#endif
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpFftC2rOutTest, InvalidDim) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen fails UBSAN";
-    return;
-  }
   auto negative_dim = [this]() {
     test_dtype<float, ScalarType::Float, /* expect_failure = */ true>(0, -1);
     test_dtype<float, ScalarType::Float, /* expect_failure = */ true>(0, 3);
@@ -185,3 +180,4 @@ TEST_F(OpFftC2rOutTest, InvalidDim) {
   };
   ET_EXPECT_KERNEL_FAILURE(context_, negative_dim());
 }
+#endif

--- a/kernels/test/op_fft_r2c_test.cpp
+++ b/kernels/test/op_fft_r2c_test.cpp
@@ -130,11 +130,8 @@ TEST_F(OpFftR2cOutTest, MultipleDims) {
 #undef TEST_ENTRY
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpFftR2cOutTest, InvalidNorm) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen MKL path does not validate norm";
-    return;
-  }
   auto invalid_norm = [this](int64_t norm) {
     test_dtype<float, ScalarType::Float, /* expect_failure = */ true>(norm);
   };
@@ -143,12 +140,10 @@ TEST_F(OpFftR2cOutTest, InvalidNorm) {
   ET_EXPECT_KERNEL_FAILURE(context_, invalid_norm(-1));
   ET_EXPECT_KERNEL_FAILURE(context_, invalid_norm(9999999));
 }
+#endif
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpFftR2cOutTest, InvalidDim) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen fails UBSAN";
-    return;
-  }
   auto negative_dim = [this]() {
     test_dtype<float, ScalarType::Float, /* expect_failure = */ true>(0, -1);
     test_dtype<float, ScalarType::Float, /* expect_failure = */ true>(0, 3);
@@ -156,16 +151,15 @@ TEST_F(OpFftR2cOutTest, InvalidDim) {
   };
   ET_EXPECT_KERNEL_FAILURE(context_, negative_dim());
 }
+#endif
 
 // TODO: support this and patch test accordingly!
+#ifndef USE_ATEN_LIB
 TEST_F(OpFftR2cOutTest, TwoSidedIsNotSupported) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen supports two-sided";
-    return;
-  }
   auto twosided = [this]() {
     test_dtype<double, ScalarType::Double, /* expect_failure = */ true>(
         0, 1, false);
   };
   ET_EXPECT_KERNEL_FAILURE(context_, twosided());
 }
+#endif


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #19485
* #19484
* __->__ #19483

Replace runtime `if (is_aten) { GTEST_SKIP() }` checks with compile-time `#ifndef USE_ATEN_LIB` / `#ifdef USE_ATEN_LIB` preprocessor guards around the entire test.

Meta test infra does not handle GTEST_SKIP well, so we use preprocessor guards to exclude aten-incompatible tests at compile time instead of skipping them at runtime.

This commit covers ops a-f (clone_dim_order through fft_r2c). Authored with Claude.

Differential Revision: [D104739567](https://our.internmc.facebook.com/intern/diff/D104739567/)