### PR TITLE
Replace GTEST_SKIP() aten guards with #ifndef USE_ATEN_LIB (2/3)

### DIFF
--- a/kernels/test/op_fill_test.cpp
+++ b/kernels/test/op_fill_test.cpp
@@ -140,11 +140,8 @@ TEST_F(OpFillTest, MismatchedOtherPropertiesDies) {
   ET_EXPECT_KERNEL_FAILURE(context_, op_fill_tensor_out(self, other3, out));
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpFillTest, MismatchedOutputShapesDies) {
-  // Skip ATen test since it supports `self` and `out` having different shapes.
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched output shape";
-  }
 
   TensorFactory<ScalarType::Int> tf;
 
@@ -155,6 +152,7 @@ TEST_F(OpFillTest, MismatchedOutputShapesDies) {
   // Assert `out` can't be filled due to incompatible shapes.
   ET_EXPECT_KERNEL_FAILURE(context_, op_fill_scalar_out(self, 0, out));
 }
+#endif
 
 TEST_F(OpFillTest, MismatchedOutputDtypeDies) {
   TensorFactory<ScalarType::Byte> tf_byte;

--- a/kernels/test/op_floor_divide_test.cpp
+++ b/kernels/test/op_floor_divide_test.cpp
@@ -155,10 +155,8 @@ TEST_F(OpFloorDivideTest, MismatchedInputShapesDies) {
   ET_EXPECT_KERNEL_FAILURE(context_, op_floor_divide_out(a, b, out));
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpFloorDivideTest, MismatchedOutputShapesDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched output shape";
-  }
   TensorFactory<ScalarType::Int> tf;
 
   const std::vector<int32_t> sizes = {2, 2};
@@ -174,6 +172,7 @@ TEST_F(OpFloorDivideTest, MismatchedOutputShapesDies) {
   // kill the test process.
   ET_EXPECT_KERNEL_FAILURE(context_, op_floor_divide_out(a, b, out));
 }
+#endif
 
 // DISABLED: Dynamic shape not supported
 TEST_F(OpFloorDivideTest, DISABLED_BroadcastDimSizeIsOneAB) {

--- a/kernels/test/op_full_like_test.cpp
+++ b/kernels/test/op_full_like_test.cpp
@@ -104,15 +104,14 @@ TEST_F(OpFullLikeTest, AllDtypeOutputPasses) {
 #undef TEST_ENTRY
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpFullLikeTest, MismatchedShapeDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched shapes";
-  }
 #define TEST_ENTRY(ctype, dtype) \
   test_full_like_out_mismatched_shape<ScalarType::dtype>();
   ET_FORALL_REAL_TYPES_AND(Bool, TEST_ENTRY);
 #undef TEST_ENTRY
 }
+#endif
 
 TEST_F(OpFullLikeTest, SimpleGeneratedCase) {
   TensorFactory<ScalarType::Float> tf;

--- a/kernels/test/op_ge_test.cpp
+++ b/kernels/test/op_ge_test.cpp
@@ -91,10 +91,8 @@ TEST_F(OpGeScalarOutTest, BoolInputDtype) {
 }
 
 // Mismatched shape tests.
+#ifndef USE_ATEN_LIB
 TEST_F(OpGeScalarOutTest, MismatchedInOutShapesDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched shapes";
-  }
   TensorFactory<ScalarType::Int> tf_int;
   TensorFactory<ScalarType::Bool> tf_bool;
 
@@ -104,6 +102,7 @@ TEST_F(OpGeScalarOutTest, MismatchedInOutShapesDies) {
 
   ET_EXPECT_KERNEL_FAILURE(context_, op_ge_scalar_out(a, other, out));
 }
+#endif
 
 TEST_F(OpGeScalarOutTest, DynamicOutShapeTest) {
   TensorFactory<ScalarType::Int> tf;
@@ -134,10 +133,8 @@ TEST_F(OpGeTensorOutTest, AllDtypesSupported) {
 #undef TEST_ENTRY
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpGeTensorOutTest, MismatchedInShapesDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched shapes";
-  }
   TensorFactory<ScalarType::Int> tf_int;
   TensorFactory<ScalarType::Bool> tf_bool;
 
@@ -147,11 +144,10 @@ TEST_F(OpGeTensorOutTest, MismatchedInShapesDies) {
 
   ET_EXPECT_KERNEL_FAILURE(context_, op_ge_tensor_out(a, b, out));
 }
+#endif
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpGeTensorOutTest, MismatchedInOutShapesDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched shapes";
-  }
   TensorFactory<ScalarType::Int> tf_int;
   TensorFactory<ScalarType::Bool> tf_bool;
 
@@ -161,6 +157,7 @@ TEST_F(OpGeTensorOutTest, MismatchedInOutShapesDies) {
 
   ET_EXPECT_KERNEL_FAILURE(context_, op_ge_tensor_out(a, b, out));
 }
+#endif
 
 TEST_F(OpGeTensorOutTest, DynamicOutShapeTest) {
   TensorFactory<ScalarType::Int> tf;

--- a/kernels/test/op_glu_test.cpp
+++ b/kernels/test/op_glu_test.cpp
@@ -170,15 +170,14 @@ TEST_F(OpGluOutTest, InfinityAndNANTest) {
           /*sizes=*/out_sizes, /*data=*/{INFINITY, -INFINITY, NAN, NAN}));
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpGluOutTest, MismatchedShapesDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched shapes";
-  }
 #define TEST_ENTRY(ctype, dtype) \
   test_glu_out_mismatched_shape<ScalarType::dtype>();
   ET_FORALL_FLOAT_TYPES(TEST_ENTRY);
 #undef TEST_ENTRY
 }
+#endif
 
 TEST_F(OpGluOutTest, InvalidDimDies) {
 #define TEST_ENTRY(ctype, dtype) test_glu_out_invalid_dim<ScalarType::dtype>();

--- a/kernels/test/op_gt_test.cpp
+++ b/kernels/test/op_gt_test.cpp
@@ -91,10 +91,8 @@ TEST_F(OpGtScalarOutTest, BoolInputDtype) {
 }
 
 // Mismatched shape tests.
+#ifndef USE_ATEN_LIB
 TEST_F(OpGtScalarOutTest, MismatchedInOutShapesDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched shapes";
-  }
   TensorFactory<ScalarType::Int> tf_int;
   TensorFactory<ScalarType::Bool> tf_bool;
 
@@ -104,6 +102,7 @@ TEST_F(OpGtScalarOutTest, MismatchedInOutShapesDies) {
 
   ET_EXPECT_KERNEL_FAILURE(context_, op_gt_scalar_out(a, other, out));
 }
+#endif
 
 TEST_F(OpGtScalarOutTest, DynamicOutShapeTest) {
   TensorFactory<ScalarType::Int> tf;
@@ -134,10 +133,8 @@ TEST_F(OpGtTensorOutTest, AllDtypesSupported) {
 #undef TEST_ENTRY
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpGtTensorOutTest, MismatchedInShapesDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched shapes";
-  }
   TensorFactory<ScalarType::Int> tf_int;
   TensorFactory<ScalarType::Bool> tf_bool;
 
@@ -147,11 +144,10 @@ TEST_F(OpGtTensorOutTest, MismatchedInShapesDies) {
 
   ET_EXPECT_KERNEL_FAILURE(context_, op_gt_tensor_out(a, b, out));
 }
+#endif
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpGtTensorOutTest, MismatchedInOutShapesDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched shapes";
-  }
   TensorFactory<ScalarType::Int> tf_int;
   TensorFactory<ScalarType::Bool> tf_bool;
 
@@ -161,6 +157,7 @@ TEST_F(OpGtTensorOutTest, MismatchedInOutShapesDies) {
 
   ET_EXPECT_KERNEL_FAILURE(context_, op_gt_tensor_out(a, b, out));
 }
+#endif
 
 TEST_F(OpGtTensorOutTest, DynamicOutShapeTest) {
   TensorFactory<ScalarType::Int> tf;

--- a/kernels/test/op_index_select_test.cpp
+++ b/kernels/test/op_index_select_test.cpp
@@ -281,10 +281,8 @@ TEST_F(OpIndexSelectOutTest, AllDtypesSupported) {
 
 // In this test we are gonnna find if our select function support non-empty
 // tensor input and empty-size tensor output.
+#ifndef USE_ATEN_LIB
 TEST_F(OpIndexSelectOutTest, NonEmptyInputEmptyOutputWithMismatchDimDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle out with mismatched dimensions";
-  }
   TensorFactory<ScalarType::Int> tf;
   TensorFactory<ScalarType::Long> tfl;
   Tensor x = tf.make({10}, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
@@ -299,6 +297,7 @@ TEST_F(OpIndexSelectOutTest, NonEmptyInputEmptyOutputWithMismatchDimDies) {
   ET_EXPECT_KERNEL_FAILURE(
       context_, op_index_select_out(x, /*dim=*/0, /*index=*/index, out));
 }
+#endif
 
 // This test focuses on the support for empty tensor (dim() > 0) input and empty
 // tensor output
@@ -355,10 +354,8 @@ TEST_F(OpIndexSelectOutTest, MismatchedDtypesDies) {
       context_, op_index_select_out(x, /*dim=*/0, /*index=*/index, out));
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpIndexSelectOutTest, OutMatchNumelLackDimAtEndDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle out with mismatched dimensions";
-  }
   TensorFactory<ScalarType::Int> tf;
   TensorFactory<ScalarType::Long> tfl;
 
@@ -372,11 +369,10 @@ TEST_F(OpIndexSelectOutTest, OutMatchNumelLackDimAtEndDies) {
   ET_EXPECT_KERNEL_FAILURE(
       context_, op_index_select_out(x, /*dim=*/0, /*index=*/index, out));
 }
+#endif
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpIndexSelectOutTest, OutMatchNumelExtraDimAtFrontDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle out with mismatched dimensions";
-  }
   TensorFactory<ScalarType::Int> tf;
   TensorFactory<ScalarType::Long> tfl;
 
@@ -390,11 +386,10 @@ TEST_F(OpIndexSelectOutTest, OutMatchNumelExtraDimAtFrontDies) {
   ET_EXPECT_KERNEL_FAILURE(
       context_, op_index_select_out(x, /*dim=*/0, /*index=*/index, out));
 }
+#endif
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpIndexSelectOutTest, OutSizeMismatchDimDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle out with mismatched dimensions";
-  }
   TensorFactory<ScalarType::Int> tf;
   TensorFactory<ScalarType::Long> tfl;
 
@@ -408,6 +403,7 @@ TEST_F(OpIndexSelectOutTest, OutSizeMismatchDimDies) {
   ET_EXPECT_KERNEL_FAILURE(
       context_, op_index_select_out(x, /*dim=*/2, /*index=*/index, out));
 }
+#endif
 
 TEST_F(OpIndexSelectOutTest, IndexWithInvalidDtypeDies) {
   TensorFactory<ScalarType::Int> tf;

--- a/kernels/test/op_index_test.cpp
+++ b/kernels/test/op_index_test.cpp
@@ -432,12 +432,11 @@ TEST_F(OpIndexTensorOutTest, IndicesWithNullTensorsSupported) {
   run_test_cases(x, /*indices=*/indices2, expected2);
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpIndexTensorOutTest, IndicesWithOnlyNullTensorsSupported) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel test fails";
-  }
   test_indices_with_only_null_tensors_enumerate_in_types();
 }
+#endif
 
 TEST_F(OpIndexTensorOutTest, TooManyNullIndices) {
   TensorFactory<ScalarType::Double> tf;
@@ -451,10 +450,8 @@ TEST_F(OpIndexTensorOutTest, TooManyNullIndices) {
       "Indexing too many dimensions");
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpIndexTensorOutTest, EmptyIndicesSupported) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel test fails";
-  }
   TensorFactory<ScalarType::Float> tf;
 
   // Using empty tensors as input.
@@ -467,6 +464,7 @@ TEST_F(OpIndexTensorOutTest, EmptyIndicesSupported) {
   // Success if it doesn't assert on the weird-shaped empty input and the
   // ret is still a empty array
 }
+#endif
 
 //
 // Test that all dtypes are supported
@@ -621,10 +619,8 @@ TEST_F(OpIndexTensorOutTest, InvalidIndicesShapesDies) {
       context_, op_index_tensor_out(x, indices, out), "");
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpIndexTensorOutTest, InvalidIndicesShapeDies2) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "";
-  }
   TensorFactory<ScalarType::Float> tf;
   TensorFactory<ScalarType::Long> tfl;
 
@@ -640,6 +636,7 @@ TEST_F(OpIndexTensorOutTest, InvalidIndicesShapeDies2) {
   ET_EXPECT_KERNEL_FAILURE_WITH_MSG(
       context_, op_index_tensor_out(x, indices, out), "");
 }
+#endif
 
 //
 // Dynamic Shape Tests

--- a/kernels/test/op_le_test.cpp
+++ b/kernels/test/op_le_test.cpp
@@ -91,10 +91,8 @@ TEST_F(OpLeScalarOutTest, BoolInputDtype) {
 }
 
 // Mismatched shape tests.
+#ifndef USE_ATEN_LIB
 TEST_F(OpLeScalarOutTest, MismatchedInOutShapesDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched shapes";
-  }
   TensorFactory<ScalarType::Int> tf_int;
   TensorFactory<ScalarType::Bool> tf_bool;
 
@@ -104,6 +102,7 @@ TEST_F(OpLeScalarOutTest, MismatchedInOutShapesDies) {
 
   ET_EXPECT_KERNEL_FAILURE(context_, op_le_scalar_out(a, other, out));
 }
+#endif
 
 TEST_F(OpLeScalarOutTest, DynamicOutShapeTest) {
   TensorFactory<ScalarType::Int> tf;
@@ -134,10 +133,8 @@ TEST_F(OpLeTensorOutTest, AllDtypesSupported) {
 #undef TEST_ENTRY
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpLeTensorOutTest, MismatchedInShapesDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched shapes";
-  }
   TensorFactory<ScalarType::Int> tf_int;
   TensorFactory<ScalarType::Bool> tf_bool;
 
@@ -147,11 +144,10 @@ TEST_F(OpLeTensorOutTest, MismatchedInShapesDies) {
 
   ET_EXPECT_KERNEL_FAILURE(context_, op_le_tensor_out(a, b, out));
 }
+#endif
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpLeTensorOutTest, MismatchedInOutShapesDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched shapes";
-  }
   TensorFactory<ScalarType::Int> tf_int;
   TensorFactory<ScalarType::Bool> tf_bool;
 
@@ -161,6 +157,7 @@ TEST_F(OpLeTensorOutTest, MismatchedInOutShapesDies) {
 
   ET_EXPECT_KERNEL_FAILURE(context_, op_le_tensor_out(a, b, out));
 }
+#endif
 
 TEST_F(OpLeTensorOutTest, DynamicOutShapeTest) {
   TensorFactory<ScalarType::Int> tf;

--- a/kernels/test/op_lift_fresh_copy_test.cpp
+++ b/kernels/test/op_lift_fresh_copy_test.cpp
@@ -67,15 +67,14 @@ TEST_F(OpLiftFreshCopyTest, EmptyInputSupported) {
 #undef TEST_ENTRY
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpLiftFreshCopyTest, MismatchedSizesDie) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched sizes";
-  }
   TensorFactory<ScalarType::Int> tf;
   Tensor self = tf.make(/*sizes=*/{3, 1, 1, 2}, /*data=*/{1, 2, 3, 4, 5, 6});
   Tensor out = tf.zeros({3, 2, 1, 1});
   ET_EXPECT_KERNEL_FAILURE(context_, op_lift_fresh_copy_out(self, out));
 }
+#endif
 
 TEST_F(OpLiftFreshCopyTest, MismatchedDTypeDie) {
   TensorFactory<ScalarType::Int> tf_in;

--- a/kernels/test/op_linear_test.cpp
+++ b/kernels/test/op_linear_test.cpp
@@ -217,10 +217,8 @@ TEST_F(OpLinearOutTest, MismatchedDimensionsDies) {
   EXPECT_TENSOR_EQ(op_linear_out(x, right_y, out), expected);
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpLinearOutTest, MismatchedDimensionSizeDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched dimension size";
-  }
   TensorFactory<ScalarType::Int> tf;
   Tensor x = tf.full({2, 2}, 3);
 
@@ -235,11 +233,10 @@ TEST_F(OpLinearOutTest, MismatchedDimensionSizeDies) {
   ET_EXPECT_KERNEL_FAILURE(context_, op_linear_out(x, right_y, wrong_out));
   ET_EXPECT_KERNEL_FAILURE(context_, op_linear_out(x, wrong_y, right_out));
 }
+#endif
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpLinearOutTest, WrongOutShapeDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle wrong out shape";
-  }
   TensorFactory<ScalarType::Int> tf;
   Tensor x = tf.ones({10, 3});
 
@@ -253,6 +250,7 @@ TEST_F(OpLinearOutTest, WrongOutShapeDies) {
 
   EXPECT_TENSOR_EQ(op_linear_out(x, y, right_out), tf.full({10, 4}, 3));
 }
+#endif
 
 TEST_F(OpLinearOutTest, DynamicShapeUpperBoundSameAsExpected) {
   TensorFactory<ScalarType::Float> tf;

--- a/kernels/test/op_log_softmax_test.cpp
+++ b/kernels/test/op_log_softmax_test.cpp
@@ -158,10 +158,8 @@ TEST_F(OpLogSoftmaxOutTest, NonContiguous) {
   test_dtype_noncontiguous_dim<float, ScalarType::Float>();
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpLogSoftmaxOutTest, MismatchedDimensionsDies) {
-  if (SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen currently supports mismatched dimensions";
-  }
 
   TensorFactory<ScalarType::Float> tff;
 
@@ -175,11 +173,10 @@ TEST_F(OpLogSoftmaxOutTest, MismatchedDimensionsDies) {
   ET_EXPECT_KERNEL_FAILURE(
       context_, op_log_softmax_out(x, /*dim=*/3, /*half_to_float*/ false, out));
 }
+#endif
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpLogSoftmaxOutTest, MismatchedDimensionSizeDies) {
-  if (SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen currently supports mismatched dimension size";
-  }
 
   TensorFactory<ScalarType::Float> tf;
 
@@ -192,6 +189,7 @@ TEST_F(OpLogSoftmaxOutTest, MismatchedDimensionSizeDies) {
       context_,
       op_log_softmax_out(x, /*dim=*/1, /*half_to_float*/ false, wrong_out));
 }
+#endif
 
 TEST_F(OpLogSoftmaxOutTest, TestWithLargeNumber) {
   if (!SupportedFeatures::get()->op_log_softmax_dtype_double) {

--- a/kernels/test/op_logical_not_test.cpp
+++ b/kernels/test/op_logical_not_test.cpp
@@ -103,10 +103,8 @@ class OpLogicalNotOutTest : public OperatorTest {
   }
 };
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpLogicalNotOutTest, MismatchedDimensionsDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched dimensions";
-  }
   TensorFactory<ScalarType::Float> tff;
   const std::vector<int32_t> size{2, 2};
 
@@ -115,6 +113,7 @@ TEST_F(OpLogicalNotOutTest, MismatchedDimensionsDies) {
 
   ET_EXPECT_KERNEL_FAILURE(context_, op_logical_not_out(in, out));
 }
+#endif
 
 TEST_F(OpLogicalNotOutTest, AllTypePasses) {
 // Use a two layer switch to hanldle each possible data pair

--- a/kernels/test/op_logit_test.cpp
+++ b/kernels/test/op_logit_test.cpp
@@ -133,10 +133,8 @@ TEST_F(OpLogitOutTest, AllRealInputDoubleOutputSupportEpsSet) {
 }
 
 // Mismatched shape tests.
+#ifndef USE_ATEN_LIB
 TEST_F(OpLogitOutTest, MismatchedShapesDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched shapes";
-  }
   TensorFactory<ScalarType::Int> tf;
   TensorFactory<ScalarType::Float> tf_out;
 
@@ -145,6 +143,7 @@ TEST_F(OpLogitOutTest, MismatchedShapesDies) {
 
   ET_EXPECT_KERNEL_FAILURE(context_, op_logit_out(a, 0, out));
 }
+#endif
 
 TEST_F(OpLogitOutTest, AllNonFloatOutputDTypeDies) {
 #define TEST_ENTRY(ctype, dtype) \

--- a/kernels/test/op_lt_test.cpp
+++ b/kernels/test/op_lt_test.cpp
@@ -91,10 +91,8 @@ TEST_F(OpLtScalarOutTest, BoolInputDtype) {
 }
 
 // Mismatched shape tests.
+#ifndef USE_ATEN_LIB
 TEST_F(OpLtScalarOutTest, MismatchedInOutShapesDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched shapes";
-  }
   TensorFactory<ScalarType::Int> tf_int;
   TensorFactory<ScalarType::Bool> tf_bool;
 
@@ -104,6 +102,7 @@ TEST_F(OpLtScalarOutTest, MismatchedInOutShapesDies) {
 
   ET_EXPECT_KERNEL_FAILURE(context_, op_lt_scalar_out(a, other, out));
 }
+#endif
 
 TEST_F(OpLtScalarOutTest, DynamicOutShapeTest) {
   TensorFactory<ScalarType::Int> tf;
@@ -134,10 +133,8 @@ TEST_F(OpLtTensorOutTest, AllDtypesSupported) {
 #undef TEST_ENTRY
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpLtTensorOutTest, MismatchedInShapesDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched shapes";
-  }
   TensorFactory<ScalarType::Int> tf_int;
   TensorFactory<ScalarType::Bool> tf_bool;
 
@@ -147,11 +144,10 @@ TEST_F(OpLtTensorOutTest, MismatchedInShapesDies) {
 
   ET_EXPECT_KERNEL_FAILURE(context_, op_lt_tensor_out(a, b, out));
 }
+#endif
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpLtTensorOutTest, MismatchedInOutShapesDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched shapes";
-  }
   TensorFactory<ScalarType::Int> tf_int;
   TensorFactory<ScalarType::Bool> tf_bool;
 
@@ -161,6 +157,7 @@ TEST_F(OpLtTensorOutTest, MismatchedInOutShapesDies) {
 
   ET_EXPECT_KERNEL_FAILURE(context_, op_lt_tensor_out(a, b, out));
 }
+#endif
 
 TEST_F(OpLtTensorOutTest, DynamicOutShapeTest) {
   TensorFactory<ScalarType::Int> tf;

--- a/kernels/test/op_masked_fill_test.cpp
+++ b/kernels/test/op_masked_fill_test.cpp
@@ -245,10 +245,8 @@ TEST_F(OpMaskedFillTest, BroadcastTest) {
   EXPECT_TENSOR_CLOSE(out, tf.make({2, 2}, /*data=*/{3, 2, 3, 8}));
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpMaskedFillTest, MismatchedOutputShapesDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched output shape";
-  }
   TensorFactory<ScalarType::Int> tf;
   TensorFactory<ScalarType::Bool> tf_bool;
 
@@ -266,6 +264,7 @@ TEST_F(OpMaskedFillTest, MismatchedOutputShapesDies) {
   ET_EXPECT_KERNEL_FAILURE(
       context_, op_masked_fill_scalar_out(a, b, /*value=*/0, out));
 }
+#endif
 
 TEST_F(OpMaskedFillTest, BroadcastDimSizeIsOneAB) {
   TensorFactory<ScalarType::Float> tf;

--- a/kernels/test/op_max_test.cpp
+++ b/kernels/test/op_max_test.cpp
@@ -280,20 +280,17 @@ TEST_F(OpMaxUnaryOutTest, EmptyFloatingInput) {
 #undef TEST_ENTRY
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpMaxOutTest, MismatchedDimensionsDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel test fails";
-  }
 #define TEST_ENTRY(ctype, dtype) \
   test_max_out_invalid_dimensions<ScalarType::dtype>();
   ET_FORALL_REAL_TYPES_AND(Bool, TEST_ENTRY);
 #undef TEST_ENTRY
 }
+#endif
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpMaxOutTest, MismatchedDTypesDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel test fails";
-  }
   TensorFactory<ScalarType::Float> tf_float;
   TensorFactory<ScalarType::Long> tf_long;
 
@@ -313,6 +310,7 @@ TEST_F(OpMaxOutTest, MismatchedDTypesDies) {
       context_,
       op_max_dim_max(self, /*dim=*/-1, /*keepdim=*/true, max, max_indices));
 }
+#endif
 
 TEST_F(OpMaxOutTest, AllRealInputLongOutputPasses) {
 #define TEST_ENTRY(ctype, dtype) test_max_out_dtype<ScalarType::dtype>();

--- a/kernels/test/op_mean_test.cpp
+++ b/kernels/test/op_mean_test.cpp
@@ -262,10 +262,8 @@ void OpMeanOutTest::
   test_mean_dim_out_bool<ScalarType::Double>();
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpMeanOutTest, InvalidDimensionListDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel test fails";
-  }
   // Use a two layer switch to hanldle each possible data pair
 #define TEST_KERNEL(INPUT_CTYPE, INPUT_DTYPE, OUTPUT_CTYPE, OUTPUT_DTYPE) \
   test_mean_dim_out_invalid_dimensions<                                   \
@@ -279,11 +277,10 @@ TEST_F(OpMeanOutTest, InvalidDimensionListDies) {
 #undef TEST_ENTRY
 #undef TEST_KERNEL
 }
+#endif
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpMeanOutTest, InvalidShapeDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel test fails";
-  }
   // Use a two layer switch to hanldle each possible data pair
 #define TEST_KERNEL(INPUT_CTYPE, INPUT_DTYPE, OUTPUT_CTYPE, OUTPUT_DTYPE) \
   test_mean_dim_out_invalid_shape<                                        \
@@ -297,11 +294,10 @@ TEST_F(OpMeanOutTest, InvalidShapeDies) {
 #undef TEST_ENTRY
 #undef TEST_KERNEL
 }
+#endif
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpMeanOutTest, MismatchedDTypesDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel test fails";
-  }
   TensorFactory<ScalarType::Float> tf_float;
   TensorFactory<ScalarType::Int> tf_int;
 
@@ -336,6 +332,7 @@ TEST_F(OpMeanOutTest, MismatchedDTypesDies) {
       context_,
       op_mean_out(self, optional_dim_list, /*keepdim=*/true, dtype, out));
 }
+#endif
 
 TEST_F(OpMeanOutTest, AllRealInputFloatOutputPasses) {
   // Use a two layer switch to hanldle each possible data pair
@@ -350,10 +347,8 @@ TEST_F(OpMeanOutTest, AllRealInputFloatOutputPasses) {
 #undef TEST_KERNEL
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpMeanOutTest, HalfSupport) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "Test Half support only for ExecuTorch mode";
-  }
 #define TEST_ENTRY(ctype, dtype) \
   test_mean_dim_out_dtype<ScalarType::dtype, ScalarType::Half>();
   ET_FORALL_REALH_TYPES(TEST_ENTRY);
@@ -364,6 +359,7 @@ TEST_F(OpMeanOutTest, HalfSupport) {
   ET_FORALL_FLOATH_TYPES(TEST_ENTRY);
 #undef TEST_ENTRY
 }
+#endif
 
 TEST_F(OpMeanOutTest, InfinityAndNANTest) {
   TensorFactory<ScalarType::Float> tf_float;

--- a/kernels/test/op_min_test.cpp
+++ b/kernels/test/op_min_test.cpp
@@ -276,20 +276,17 @@ TEST_F(OpMinUnaryOutTest, EmptyFloatingInput) {
 #undef TEST_ENTRY
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpMinOutTest, MismatchedDimensionsDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel test fails";
-  }
 #define TEST_ENTRY(ctype, dtype) \
   test_min_out_invalid_dimensions<ScalarType::dtype>();
   ET_FORALL_REAL_TYPES_AND(Bool, TEST_ENTRY);
 #undef TEST_ENTRY
 }
+#endif
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpMinOutTest, MismatchedDTypesDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel test fails";
-  }
   TensorFactory<ScalarType::Float> tf_float;
   TensorFactory<ScalarType::Long> tf_long;
 
@@ -309,6 +306,7 @@ TEST_F(OpMinOutTest, MismatchedDTypesDies) {
       context_,
       op_min_dim_min(in, /*dim=*/-1, /*keepdim=*/true, min, min_indices));
 }
+#endif
 
 TEST_F(OpMinOutTest, AllRealInputLongOutputPasses) {
 #define TEST_ENTRY(ctype, dtype) test_min_out_dtype<ScalarType::dtype>();

--- a/kernels/test/op_minimum_test.cpp
+++ b/kernels/test/op_minimum_test.cpp
@@ -125,10 +125,8 @@ TEST_F(OpMinimumOutTest, MismatchedOutputShapesDies) {
       context_, op_minimum_out(tf.ones({2, 2}), tf.ones({3, 3}), out));
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpMinimumOutTest, MismatchedOutputShapeWithSingletonDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched output shape";
-  }
   // First argument is singleton but second and output has different shape.
   TensorFactory<ScalarType::Float> tf;
   Tensor out = tf.zeros({4, 4});
@@ -136,6 +134,7 @@ TEST_F(OpMinimumOutTest, MismatchedOutputShapeWithSingletonDies) {
   ET_EXPECT_KERNEL_FAILURE(
       context_, op_minimum_out(tf.ones({1, 1}), tf.ones({3, 3}), out));
 }
+#endif
 
 /* %python
 import torch

--- a/kernels/test/op_mm_test.cpp
+++ b/kernels/test/op_mm_test.cpp
@@ -134,10 +134,8 @@ TEST_F(OpMmOutTest, MismatchedDimensionsDies) {
   EXPECT_TENSOR_EQ(op_mm_out(x, right_y, out), expected);
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpMmOutTest, MismatchedDimensionSizeDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched dimension size";
-  }
   TensorFactory<ScalarType::Int> tf;
   Tensor x = tf.full({2, 2}, 3);
 
@@ -152,11 +150,10 @@ TEST_F(OpMmOutTest, MismatchedDimensionSizeDies) {
   ET_EXPECT_KERNEL_FAILURE(context_, op_mm_out(x, right_y, wrong_out));
   ET_EXPECT_KERNEL_FAILURE(context_, op_mm_out(x, wrong_y, right_out));
 }
+#endif
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpMmOutTest, WrongOutShapeDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle wrong out shape";
-  }
   TensorFactory<ScalarType::Int> tf;
   Tensor x = tf.ones({10, 3});
 
@@ -170,6 +167,7 @@ TEST_F(OpMmOutTest, WrongOutShapeDies) {
 
   EXPECT_TENSOR_EQ(op_mm_out(x, y, right_out), tf.full({10, 4}, 3));
 }
+#endif
 
 TEST_F(OpMmOutTest, DynamicShapeUpperBoundSameAsExpected) {
   TensorFactory<ScalarType::Float> tf;

--- a/kernels/test/op_mul_test.cpp
+++ b/kernels/test/op_mul_test.cpp
@@ -429,10 +429,8 @@ TEST_F(OpMulOutTest, OptimizedPathIgnoresLeading1Dimensions) {
 }
 
 // Mismatched shape tests.
+#ifndef USE_ATEN_LIB
 TEST_F(OpMulOutTest, MismatchedNonBroadcastableInputShapesDies) {
-  if (SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen currently supports mismatched shapes";
-  }
 
   TensorFactory<ScalarType::Int> tf;
 
@@ -447,6 +445,7 @@ TEST_F(OpMulOutTest, MismatchedNonBroadcastableInputShapesDies) {
   // the test process.
   ET_EXPECT_KERNEL_FAILURE(context_, op_mul_out(a, b, out));
 }
+#endif
 
 // Broadcast tensor b's size to tensor a's size
 TEST_F(OpMulOutTest, BroadcastA2BTest) {
@@ -518,10 +517,8 @@ TEST_F(OpMulOutTest, AllComplexDtypesSupported) {
 #undef TEST_ENTRY
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpMulOutTest, MismatchedOutputShapesDies) {
-  if (SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen currently supports mismatched shapes";
-  }
 
   TensorFactory<ScalarType::Int> tf;
 
@@ -538,6 +535,7 @@ TEST_F(OpMulOutTest, MismatchedOutputShapesDies) {
   // and kill the test process.
   ET_EXPECT_KERNEL_FAILURE(context_, op_mul_out(a, b, out));
 }
+#endif
 
 TEST_F(OpMulOutTest, BroadcastDimSizeIsOneAB) {
   TensorFactory<ScalarType::Float> tf;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #19485
* __->__ #19484
* #19483

Replace runtime `if (is_aten) { GTEST_SKIP() }` checks with compile-time `#ifndef USE_ATEN_LIB` / `#ifdef USE_ATEN_LIB` preprocessor guards around the entire test.

Meta test infra does not handle GTEST_SKIP well, so we use preprocessor guards to exclude aten-incompatible tests at compile time instead of skipping them at runtime.

This commit covers ops f-m (fill through mul). Authored with Claude.

Differential Revision: [D104739569](https://our.internmc.facebook.com/intern/diff/D104739569/)