### PR TITLE
Replace GTEST_SKIP() aten guards with #ifndef USE_ATEN_LIB (3/3)

### DIFF
--- a/kernels/test/op_ne_test.cpp
+++ b/kernels/test/op_ne_test.cpp
@@ -101,10 +101,8 @@ TEST_F(OpNeScalarOutTest, BoolInputDtype) {
 }
 
 // Mismatched shape tests.
+#ifndef USE_ATEN_LIB
 TEST_F(OpNeScalarOutTest, MismatchedShapesDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched shapes";
-  }
   TensorFactory<ScalarType::Int> tf_int;
   TensorFactory<ScalarType::Bool> tf_bool;
 
@@ -114,6 +112,7 @@ TEST_F(OpNeScalarOutTest, MismatchedShapesDies) {
 
   ET_EXPECT_KERNEL_FAILURE(context_, op_ne_scalar_out(a, other, out));
 }
+#endif
 
 TEST_F(OpNeScalarOutTest, AllRealOutputDTypesSupported) {
 #define TEST_ENTRY(ctype, dtype) test_ne_all_output_dtypes<ScalarType::dtype>();

--- a/kernels/test/op_repeat_test.cpp
+++ b/kernels/test/op_repeat_test.cpp
@@ -86,14 +86,13 @@ class OpRepeatOutTest : public OperatorTest {
   }
 };
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpRepeatOutTest, AllDtypesSupported) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel test fails";
-  }
 #define TEST_ENTRY(ctype, dtype) run_dtype_tests<ctype, ScalarType::dtype>();
   ET_FORALL_REAL_TYPES_AND(Bool, TEST_ENTRY);
 #undef TEST_ENTRY
 }
+#endif
 
 TEST_F(OpRepeatOutTest, EmptyInputSupported) {
   TensorFactory<ScalarType::Int> tf;
@@ -208,10 +207,8 @@ TEST_F(OpRepeatOutTest, NegativeRepeatDie) {
   ET_EXPECT_KERNEL_FAILURE(context_, op_repeat_out(x, repeats, out));
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpRepeatOutTest, WrongOutputShapeDie) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle wrong output shape";
-  }
   TensorFactory<ScalarType::Int> tf;
 
   Tensor x = tf.ones(
@@ -226,6 +223,7 @@ TEST_F(OpRepeatOutTest, WrongOutputShapeDie) {
 
   ET_EXPECT_KERNEL_FAILURE(context_, op_repeat_out(x, repeats, out));
 }
+#endif
 
 TEST_F(OpRepeatOutTest, OutputDtypeMismatchedDie) {
   TensorFactory<ScalarType::Int> tf_in;
@@ -245,10 +243,8 @@ TEST_F(OpRepeatOutTest, OutputDtypeMismatchedDie) {
 
 // Right now we only support the dimension of input and output no larger
 // than 16.
+#ifndef USE_ATEN_LIB
 TEST_F(OpRepeatOutTest, TooManyDimensionsDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle larger number of dimensions";
-  }
   TensorFactory<ScalarType::Int> tf;
 
   Tensor x = tf.ones(
@@ -266,6 +262,7 @@ TEST_F(OpRepeatOutTest, TooManyDimensionsDies) {
 
   ET_EXPECT_KERNEL_FAILURE(context_, op_repeat_out(x, repeats, out));
 }
+#endif
 
 #if !defined(USE_ATEN_LIB)
 TEST_F(OpRepeatOutTest, UpperBoundOutTensor) {

--- a/kernels/test/op_rsub_test.cpp
+++ b/kernels/test/op_rsub_test.cpp
@@ -222,10 +222,8 @@ TEST_F(OpRSubScalarOutTest, MismatchedOutputDtypeDies) {
 
 // Mismatched shape tests.
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpRSubScalarOutTest, MismatchedOutputShapesDies) {
-  if (SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle output shapes";
-  }
 
   TensorFactory<ScalarType::Int> tf;
 
@@ -241,6 +239,7 @@ TEST_F(OpRSubScalarOutTest, MismatchedOutputShapesDies) {
   ET_EXPECT_KERNEL_FAILURE(
       context_, op_rsub_scalar_out(a, 1, /*alpha=*/0, out));
 }
+#endif
 
 TEST_F(OpRSubScalarOutTest, DynamicShapeUpperBoundSameAsExpected) {
   test_dynamic_shape(

--- a/kernels/test/op_scalar_tensor_test.cpp
+++ b/kernels/test/op_scalar_tensor_test.cpp
@@ -109,10 +109,8 @@ ET_FORALL_REAL_TYPES_AND3(Half, Bool, BFloat16, GENERATE_TEST_0D)
 
 ET_FORALL_REAL_TYPES_AND3(Half, Bool, BFloat16, GENERATE_TEST)
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpScalarTensorOutTest, InvalidOutShapeFails) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel will reshape output";
-  }
 
   TensorFactory<ScalarType::Int> tf;
   std::vector<int32_t> sizes{1, 2, 1};
@@ -120,6 +118,7 @@ TEST_F(OpScalarTensorOutTest, InvalidOutShapeFails) {
   Tensor out = tf.ones(sizes);
   ET_EXPECT_KERNEL_FAILURE(context_, op_scalar_tensor_out(7, out));
 }
+#endif
 
 TEST_F(OpScalarTensorOutTest, HalfSupport) {
   TensorFactory<ScalarType::Half> tf;

--- a/kernels/test/op_scatter_add_test.cpp
+++ b/kernels/test/op_scatter_add_test.cpp
@@ -323,15 +323,14 @@ TEST_F(OpScatterAddOutTest, InvalidDimensionsDies) {
 #undef TEST_ENTRY
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpScatterAddOutTest, MismatchedShapeDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched shape";
-  }
 #define TEST_ENTRY(CTYPE, DTYPE) \
   test_scatter_add_out_mismatched_shape<ScalarType::DTYPE>();
   ET_FORALL_REAL_TYPES(TEST_ENTRY);
 #undef TEST_ENTRY
 }
+#endif
 
 TEST_F(OpScatterAddOutTest, MismatchedInputDtypesDies) {
   TensorFactory<ScalarType::Byte> tf_byte;

--- a/kernels/test/op_select_copy_test.cpp
+++ b/kernels/test/op_select_copy_test.cpp
@@ -394,10 +394,8 @@ TEST_F(OpSelectCopyIntOutTest, MismatchedDtypesDies) {
       context_, op_select_copy_int_out(x, /*dim=*/0, /*index=*/0, out));
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpSelectCopyIntOutTest, OutMatchNumelLackDimAtEndDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle out with mismatched dimensions";
-  }
   TensorFactory<ScalarType::Int> tf;
   Tensor x = tf.zeros({1, 2, 2, 1});
 
@@ -408,11 +406,10 @@ TEST_F(OpSelectCopyIntOutTest, OutMatchNumelLackDimAtEndDies) {
   ET_EXPECT_KERNEL_FAILURE(
       context_, op_select_copy_int_out(x, /*dim=*/0, /*index=*/0, out));
 }
+#endif
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpSelectCopyIntOutTest, OutMatchNumelExtraDimAtFrontDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle out with mismatched dimensions";
-  }
   TensorFactory<ScalarType::Int> tf;
   Tensor x = tf.zeros({2, 2});
 
@@ -423,11 +420,10 @@ TEST_F(OpSelectCopyIntOutTest, OutMatchNumelExtraDimAtFrontDies) {
   ET_EXPECT_KERNEL_FAILURE(
       context_, op_select_copy_int_out(x, /*dim=*/0, /*index=*/0, out));
 }
+#endif
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpSelectCopyIntOutTest, OutSizeMismatchDimDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle out with mismatched dimensions";
-  }
   TensorFactory<ScalarType::Int> tf;
 
   Tensor x = tf.zeros({2, 4, 7, 5});
@@ -438,6 +434,7 @@ TEST_F(OpSelectCopyIntOutTest, OutSizeMismatchDimDies) {
   ET_EXPECT_KERNEL_FAILURE(
       context_, op_select_copy_int_out(x, /*dim=*/2, /*index=*/3, out));
 }
+#endif
 
 /* %python
 import torch

--- a/kernels/test/op_sigmoid_test.cpp
+++ b/kernels/test/op_sigmoid_test.cpp
@@ -88,15 +88,14 @@ class OpSigmoidOutTest : public OperatorTest {
   }
 };
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpSigmoidOutTest, AllRealInputHalfOutputSupport) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "Test Half support only for ExecuTorch mode";
-  }
 #define TEST_ENTRY(ctype, dtype) \
   test_integer_sigmoid_out<ScalarType::dtype, ScalarType::Half>();
   ET_FORALL_REALH_TYPES(TEST_ENTRY);
 #undef TEST_ENTRY
 }
+#endif
 
 TEST_F(OpSigmoidOutTest, AllRealInputFloatOutputSupport) {
 #define TEST_ENTRY(ctype, dtype) \
@@ -123,10 +122,8 @@ TEST_F(OpSigmoidOutTest, BooleanInputDoubleOutputSupport) {
 }
 
 // Mismatched shape tests.
+#ifndef USE_ATEN_LIB
 TEST_F(OpSigmoidOutTest, MismatchedShapesDies) {
-  if (SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched shapes";
-  }
 
   TensorFactory<ScalarType::Int> tf;
   TensorFactory<ScalarType::Float> tf_out;
@@ -136,6 +133,7 @@ TEST_F(OpSigmoidOutTest, MismatchedShapesDies) {
 
   ET_EXPECT_KERNEL_FAILURE(context_, op_sigmoid_out(a, out));
 }
+#endif
 
 TEST_F(OpSigmoidOutTest, AllNonFloatOutputDTypeDies) {
 #define TEST_ENTRY(ctype, dtype) \

--- a/kernels/test/op_sign_test.cpp
+++ b/kernels/test/op_sign_test.cpp
@@ -43,19 +43,16 @@ class OpSignTest : public OperatorTest {
   }
 };
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpSignTest, ETSanityCheckFloat) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen returns 0 on NAN input";
-  }
 #define TEST_ENTRY(ctype, dtype) test_et_dtype<ctype, ScalarType::dtype>();
   ET_FORALL_FLOATHBF16_TYPES(TEST_ENTRY);
 #undef TEST_ENTRY
 }
+#endif
 
+#ifdef USE_ATEN_LIB
 TEST_F(OpSignTest, ATenSanityCheckFloat) {
-  if (!torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ET returns NAN on NAN input";
-  }
   TensorFactory<ScalarType::Float> tf;
 
   Tensor in = tf.make({1, 7}, {-INFINITY, -3., -1.5, 0., 1.5, NAN, INFINITY});
@@ -67,6 +64,7 @@ TEST_F(OpSignTest, ATenSanityCheckFloat) {
   EXPECT_TENSOR_EQ(out, ret);
   EXPECT_TENSOR_CLOSE(out, expected);
 }
+#endif
 
 TEST_F(OpSignTest, SanityCheckBool) {
   TensorFactory<ScalarType::Bool> tf;

--- a/kernels/test/op_slice_copy_test.cpp
+++ b/kernels/test/op_slice_copy_test.cpp
@@ -427,10 +427,8 @@ TEST_F(OpSliceCopyTensorOutTest, LegalStepsSupported) {
 
 /// A generic smoke test that works for any dtype that supports ones() and
 /// zeros().
+#ifndef USE_ATEN_LIB
 TEST_F(OpSliceCopyTensorOutTest, AllDtypesSupported) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel test fails";
-  }
 #define TEST_ENTRY(ctype, dtype) test_dtype<ctype, ScalarType::dtype>();
   ET_FORALL_REAL_TYPES_AND(Bool, TEST_ENTRY);
 #undef TEST_ENTRY
@@ -438,6 +436,7 @@ TEST_F(OpSliceCopyTensorOutTest, AllDtypesSupported) {
   // way to do that would be to make TensorFactory support zeros() and ones()
   // for those types.
 }
+#endif
 
 TEST_F(OpSliceCopyTensorOutTest, EmptyInputSupported) {
   TensorFactory<ScalarType::Int> tf;
@@ -540,10 +539,8 @@ TEST_F(OpSliceCopyTensorOutTest, MismatchedDtypesDies) {
           input, /*dim=*/0, /*start=*/0, /*end=*/1, /*step=*/1, out));
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpSliceCopyTensorOutTest, OutSizeMismatchDimDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle out with mismatched dimensions";
-  }
   TensorFactory<ScalarType::Int> tf;
 
   Tensor input = tf.zeros({2, 4, 7, 5});
@@ -556,6 +553,7 @@ TEST_F(OpSliceCopyTensorOutTest, OutSizeMismatchDimDies) {
       op_slice_copy_tensor_out(
           input, /*dim=*/0, /*start=*/0, /*end=*/2, /*step=*/1, out));
 }
+#endif
 
 TEST_F(OpSliceCopyTensorOutTest, DefaultStartValSupported) {
   TensorFactory<ScalarType::Int> tf;

--- a/kernels/test/op_slice_scatter_test.cpp
+++ b/kernels/test/op_slice_scatter_test.cpp
@@ -764,10 +764,8 @@ TEST_F(OpSliceScatterTensorOutTest, MismatchedOutDtypesDies) {
           input, src, /*dim=*/0, /*start=*/0, /*end=*/1, /*step=*/1, out));
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpSliceScatterTensorOutTest, OutSizeMismatchDimDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle out with mismatched dimensions";
-  }
   TensorFactory<ScalarType::Int> tf;
 
   Tensor input = tf.zeros({2, 4, 7, 5});
@@ -781,11 +779,10 @@ TEST_F(OpSliceScatterTensorOutTest, OutSizeMismatchDimDies) {
       op_slice_scatter_out(
           input, src, /*dim=*/0, /*start=*/0, /*end=*/2, /*step=*/1, out));
 }
+#endif
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpSliceScatterTensorOutTest, SrcSizeMismatchDimDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle out with mismatched dimensions";
-  }
   TensorFactory<ScalarType::Int> tf;
 
   Tensor input = tf.zeros({2, 4, 7, 5});
@@ -799,6 +796,7 @@ TEST_F(OpSliceScatterTensorOutTest, SrcSizeMismatchDimDies) {
       op_slice_scatter_out(
           input, src, /*dim=*/0, /*start=*/0, /*end=*/2, /*step=*/1, out));
 }
+#endif
 
 TEST_F(OpSliceScatterTensorOutTest, DefaultStartValSupported) {
   TensorFactory<ScalarType::Int> tf;

--- a/kernels/test/op_softmax_test.cpp
+++ b/kernels/test/op_softmax_test.cpp
@@ -130,10 +130,8 @@ TEST_F(OpSoftmaxOutTest, MismatchedDimensionsDies) {
       context_, op_softmax_out(x, /*dim=*/3, /*half_to_float*/ false, out));
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpSoftmaxOutTest, MismatchedDimensionSizeDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched dimension size";
-  }
   TensorFactory<ScalarType::Float> tf;
 
   Tensor x = tf.ones({3, 4});
@@ -145,11 +143,10 @@ TEST_F(OpSoftmaxOutTest, MismatchedDimensionSizeDies) {
       context_,
       op_softmax_out(x, /*dim=*/1, /*half_to_float*/ false, wrong_out));
 }
+#endif
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpSoftmaxOutTest, NegativeDim) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel test fails";
-  }
   TensorFactory<ScalarType::Float> tf;
 
   // Input tensor with shape (2, 3) and values (0, 1, 2, 3, 4, 5).
@@ -195,6 +192,7 @@ TEST_F(OpSoftmaxOutTest, NegativeDim) {
   EXPECT_TENSOR_CLOSE(out, expected);
   EXPECT_TENSOR_CLOSE(out_negative_dim, expected);
 }
+#endif
 
 TEST_F(OpSoftmaxOutTest, SimpleGeneratedCase) {
   TensorFactory<ScalarType::Float> tf;

--- a/kernels/test/op_split_copy_test.cpp
+++ b/kernels/test/op_split_copy_test.cpp
@@ -473,10 +473,8 @@ TEST_F(OpSplitCopyTensorOutTest, WrongNumOutputEntriesDies) {
   }
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpSplitCopyTensorOutTest, WrongOutputShapeDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle wrong out shape";
-  }
   TensorFactory<ScalarType::Int> tf;
   TensorListFactory<ScalarType::Int> tlf;
 
@@ -557,6 +555,7 @@ TEST_F(OpSplitCopyTensorOutTest, WrongOutputShapeDies) {
         context_, op_split_copy_tensor_out(input, split_size, dim, out));
   }
 }
+#endif
 
 TEST_F(OpSplitCopyTensorOutTest, DynamicShapeUpperBoundSameAsExpected) {
   test_dynamic_shape(

--- a/kernels/test/op_stack_test.cpp
+++ b/kernels/test/op_stack_test.cpp
@@ -347,10 +347,8 @@ TEST_F(OpStackOutTest, MismatchedDtypesDies) {
           ArrayRef<Tensor>(inputs.data(), inputs.size()), /*dim=*/0, out));
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpStackOutTest, OutMatchNumelWithExtraDimAtEndDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle out with mismatched dimensions";
-  }
   TensorFactory<ScalarType::Int> tf;
   Tensor out = tf.zeros({1, 2, 2, 1});
 
@@ -363,11 +361,10 @@ TEST_F(OpStackOutTest, OutMatchNumelWithExtraDimAtEndDies) {
       op_stack_out(
           ArrayRef<Tensor>(inputs.data(), inputs.size()), /*dim=*/0, out));
 }
+#endif
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpStackOutTest, OutMatchNumelLackDimAtFrontDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle out with mismatched dimensions";
-  }
   TensorFactory<ScalarType::Int> tf;
   Tensor out = tf.zeros({2, 2});
 
@@ -380,11 +377,10 @@ TEST_F(OpStackOutTest, OutMatchNumelLackDimAtFrontDies) {
       op_stack_out(
           ArrayRef<Tensor>(inputs.data(), inputs.size()), /*dim=*/0, out));
 }
+#endif
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpStackOutTest, OutRegularMismatchDimDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle out with mismatched dimensions";
-  }
   TensorFactory<ScalarType::Int> tf;
 
   // Should be {2, 2, 3} to match the inputs when calling stack() with dim 0.
@@ -400,6 +396,7 @@ TEST_F(OpStackOutTest, OutRegularMismatchDimDies) {
       op_stack_out(
           ArrayRef<Tensor>(inputs.data(), inputs.size()), /*dim=*/0, out));
 }
+#endif
 
 /* %python
 import torch

--- a/kernels/test/op_sum_test.cpp
+++ b/kernels/test/op_sum_test.cpp
@@ -306,10 +306,8 @@ class OpSumOutTest : public OperatorTest {
   }
 };
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpSumOutTest, InvalidDimensionListDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel test fails";
-  }
   // Use a two layer switch to hanldle each possible data pair
 #define TEST_KERNEL(INPUT_CTYPE, INPUT_DTYPE, OUTPUT_CTYPE, OUTPUT_DTYPE) \
   test_sum_dim_out_invalid_dimensions<                                    \
@@ -323,11 +321,10 @@ TEST_F(OpSumOutTest, InvalidDimensionListDies) {
 #undef TEST_ENTRY
 #undef TEST_KERNEL
 }
+#endif
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpSumOutTest, InvalidShapeDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel test fails";
-  }
   // Use a two layer switch to hanldle each possible data pair
 #define TEST_KERNEL(INPUT_CTYPE, INPUT_DTYPE, OUTPUT_CTYPE, OUTPUT_DTYPE) \
   test_sum_dim_out_invalid_shape<                                         \
@@ -341,11 +338,10 @@ TEST_F(OpSumOutTest, InvalidShapeDies) {
 #undef TEST_ENTRY
 #undef TEST_KERNEL
 }
+#endif
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpSumOutTest, MismatchedDTypesDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel test fails";
-  }
   TensorFactory<ScalarType::Float> tf_float;
   TensorFactory<ScalarType::Int> tf_int;
 
@@ -374,6 +370,7 @@ TEST_F(OpSumOutTest, MismatchedDTypesDies) {
       op_sum_intlist_out(
           self, optional_dim_list, /*keepdim=*/true, dtype, out));
 }
+#endif
 
 TEST_F(OpSumOutTest, AllRealInputRealOutputPasses) {
   // Use a two layer switch to hanldle each possible data pair

--- a/kernels/test/op_t_copy_test.cpp
+++ b/kernels/test/op_t_copy_test.cpp
@@ -38,10 +38,8 @@ TEST_F(OpTCopyTest, 1DTranspose) {
   EXPECT_TENSOR_EQ(t_in, t_out);
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpTCopyTest, 1DTransposeMismatchShapeDie) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched shapes";
-  }
   TensorFactory<ScalarType::Int> tf;
 
   Tensor t_in = tf.make({4}, {1, 2, 3, 4});
@@ -49,6 +47,7 @@ TEST_F(OpTCopyTest, 1DTransposeMismatchShapeDie) {
 
   ET_EXPECT_KERNEL_FAILURE(context_, op_t_copy_out(t_in, t_out));
 }
+#endif
 
 TEST_F(OpTCopyTest, 2DTranspose) {
   TensorFactory<ScalarType::Int> tf;
@@ -61,10 +60,8 @@ TEST_F(OpTCopyTest, 2DTranspose) {
   EXPECT_TENSOR_EQ(t_out, t_expected);
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpTCopyTest, 2DTransposeMismatchShapeDie) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched shapes";
-  }
   TensorFactory<ScalarType::Int> tf;
 
   Tensor t_in = tf.make({2, 3}, {1, 2, 3, 4, 5, 6});
@@ -72,6 +69,7 @@ TEST_F(OpTCopyTest, 2DTransposeMismatchShapeDie) {
 
   ET_EXPECT_KERNEL_FAILURE(context_, op_t_copy_out(t_in, t_out));
 }
+#endif
 
 TEST_F(OpTCopyTest, 3DTransposeDie) {
   TensorFactory<ScalarType::Int> tf;

--- a/kernels/test/op_to_copy_test.cpp
+++ b/kernels/test/op_to_copy_test.cpp
@@ -426,10 +426,8 @@ TEST_F(OpToTest, HardcodeFloatConvertInt) {
   ET_FORALL_FLOATHBF16_TYPES(TEST_ENTRY);
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpToTest, MismatchedSizesDie) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched sizes";
-  }
   TensorFactory<ScalarType::Int> tf;
   Tensor input = tf.make(/*sizes=*/{3, 1, 1, 2}, /*data=*/{1, 2, 3, 4, 5, 6});
   Tensor out = tf.zeros({3, 2, 1, 1});
@@ -441,14 +439,13 @@ TEST_F(OpToTest, MismatchedSizesDie) {
           executorch::aten::MemoryFormat::Contiguous,
           out));
 }
+#endif
 
 // Only contiguous memory is supported, the memory type MemoryFormat::Contiguous
 // should not be allowed. The function is expected death if using the illegal
 // memory format.
+#ifndef USE_ATEN_LIB
 TEST_F(OpToTest, MismatchedMemoryFormatDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle non contiguous memory formats";
-  }
   TensorFactory<ScalarType::Float> tf_in;
   TensorFactory<ScalarType::Float> tf_out;
   Tensor input =
@@ -471,12 +468,11 @@ TEST_F(OpToTest, MismatchedMemoryFormatDies) {
           out),
       input);
 }
+#endif
 
 // Only blocking data transfer supported
+#ifndef USE_ATEN_LIB
 TEST_F(OpToTest, MismatchedBlockingDie) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle non blocking data transfer";
-  }
   TensorFactory<ScalarType::Int> tf;
   Tensor input = tf.make(/*sizes=*/{3, 1, 1, 2}, /*data=*/{1, 2, 3, 4, 5, 6});
   Tensor out = tf.zeros(/*sizes=*/{3, 1, 1, 2});
@@ -488,6 +484,7 @@ TEST_F(OpToTest, MismatchedBlockingDie) {
           executorch::aten::MemoryFormat::Contiguous,
           out));
 }
+#endif
 
 TEST_F(OpToTest, DynamicShapeUpperBoundSameAsExpected) {
   test_dynamic_shape(

--- a/kernels/test/op_transpose_copy_test.cpp
+++ b/kernels/test/op_transpose_copy_test.cpp
@@ -157,10 +157,8 @@ TEST_F(OpTransposeIntCopyTest, OutOfBoundDimDies) {
 }
 
 // transpose a 3d tensor into a 2d one
+#ifndef USE_ATEN_LIB
 TEST_F(OpTransposeIntCopyTest, MismatchedDimDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched dimensions";
-  }
   TensorFactory<ScalarType::Float> tf;
 
   Tensor a = tf.ones(/*sizes=*/{4, 2, 3});
@@ -168,6 +166,7 @@ TEST_F(OpTransposeIntCopyTest, MismatchedDimDies) {
 
   ET_EXPECT_KERNEL_FAILURE(context_, op_transpose_copy_int_out(a, 0, 1, out));
 }
+#endif
 
 /* %python
 import torch

--- a/kernels/test/op_tril_test.cpp
+++ b/kernels/test/op_tril_test.cpp
@@ -758,11 +758,8 @@ TEST_F(OpTrilTest, InvalidInputShapesDies) {
   ET_EXPECT_KERNEL_FAILURE(context_, op_tril_out(self2, 0, out2));
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpTrilTest, MismatchedOutputShapesDies) {
-  // Skip ATen test since it supports `self` and `out` having different shapes.
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched output shape";
-  }
 
   TensorFactory<ScalarType::Int> tf;
 
@@ -773,6 +770,7 @@ TEST_F(OpTrilTest, MismatchedOutputShapesDies) {
   // Assert `out` can't be filled due to incompatible shapes.
   ET_EXPECT_KERNEL_FAILURE(context_, op_tril_out(self, 0, out));
 }
+#endif
 
 TEST_F(OpTrilTest, MismatchedOutputDtypeDies) {
   TensorFactory<ScalarType::Byte> tf_byte;
@@ -786,11 +784,8 @@ TEST_F(OpTrilTest, MismatchedOutputDtypeDies) {
   ET_EXPECT_KERNEL_FAILURE(context_, op_tril_out(self, 0, out));
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpTrilTest, InvalidTensorDims) {
-  // Skip ATen test since it supports `self` and `out` having different shapes.
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched output shape";
-  }
 
   TensorFactory<ScalarType::Int> tf;
 
@@ -802,3 +797,4 @@ TEST_F(OpTrilTest, InvalidTensorDims) {
   // Assert `out` can't be filled due to too many tensor dims.
   ET_EXPECT_KERNEL_FAILURE(context_, op_tril_out(self, 0, out));
 }
+#endif

--- a/kernels/test/op_unbind_copy_test.cpp
+++ b/kernels/test/op_unbind_copy_test.cpp
@@ -268,10 +268,8 @@ TEST_F(OpUnbindCopyIntOutTest, UnbindWorksWithZeroSizedTensors) {
   EXPECT_TENSOR_LISTS_EQ(out, expected_out);
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpUnbindCopyIntOutTest, UnbindFailsWithWronglyAllocatedOutput) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched output shape";
-  }
   TensorFactory<ScalarType::Int> tf;
   TensorListFactory<ScalarType::Int> tlf;
 
@@ -302,6 +300,7 @@ TEST_F(OpUnbindCopyIntOutTest, UnbindFailsWithWronglyAllocatedOutput) {
   ET_EXPECT_KERNEL_FAILURE(
       context_, op_unbind_copy_int_out(input, /*dim=*/1, out));
 }
+#endif
 
 TEST_F(OpUnbindCopyIntOutTest, UnbindProduceScalarTensors) {
   TensorFactory<ScalarType::Int> tf;

--- a/kernels/test/op_unsqueeze_copy_test.cpp
+++ b/kernels/test/op_unsqueeze_copy_test.cpp
@@ -122,10 +122,8 @@ TEST_F(OpUnsqueezeTest, EmptyInputSupported) {
 #undef TEST_ENTRY
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpUnsqueezeTest, InputOutputMismatchedSizesDie) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched sizes";
-  }
   TensorFactory<ScalarType::Int> tf;
 
   Tensor input = tf.make(/*sizes=*/{3, 1, 2}, /*data=*/{1, 2, 3, 4, 5, 6});
@@ -137,11 +135,10 @@ TEST_F(OpUnsqueezeTest, InputOutputMismatchedSizesDie) {
   out = tf.ones(/*sizes=*/{3, 1, 1, 2, 1});
   ET_EXPECT_KERNEL_FAILURE(context_, op_unsqueeze_copy_out(input, dim, out));
 }
+#endif
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpUnsqueezeTest, DimOutputMismatchedSizesDie) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched sizes";
-  }
   TensorFactory<ScalarType::Int> tf;
   Tensor input = tf.make(/*sizes=*/{3, 1, 2}, /*data=*/{1, 2, 3, 4, 5, 6});
   Tensor out = tf.ones(/*sizes=*/{3, 1, 2, 1});
@@ -150,6 +147,7 @@ TEST_F(OpUnsqueezeTest, DimOutputMismatchedSizesDie) {
   // The size of output should be [3,1,1,2], not [3,1,2,1], since dim=2 not 3
   ET_EXPECT_KERNEL_FAILURE(context_, op_unsqueeze_copy_out(input, dim, out));
 }
+#endif
 
 TEST_F(OpUnsqueezeTest, MismatchedTypesDie) {
   TensorFactory<ScalarType::Int> tf_in;

--- a/kernels/test/op_var_mean_test.cpp
+++ b/kernels/test/op_var_mean_test.cpp
@@ -384,10 +384,8 @@ TEST_F(OpVarMeanCorrectionOutTest, SmokeTest) {
 #undef TEST_ENTRY
 }
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpVarMeanCorrectionOutTest, KeepDim) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen supports fewer dtypes";
-  }
 #define TEST_KERNEL(INPUT_CTYPE, INPUT_DTYPE, OUTPUT_CTYPE, OUTPUT_DTYPE) \
   test_keepdim<ScalarType::INPUT_DTYPE, ScalarType::OUTPUT_DTYPE>();
 
@@ -398,22 +396,20 @@ TEST_F(OpVarMeanCorrectionOutTest, KeepDim) {
 #undef TEST_ENTRY
 #undef TEST_KERNEL
 }
+#endif
 
+#ifdef USE_ATEN_LIB
 TEST_F(OpVarMeanCorrectionOutTest, KeepDim_Aten) {
-  if (!torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen-specific variant of test case";
-  }
 #define TEST_ENTRY(CTYPE, DTYPE) \
   test_keepdim<ScalarType::DTYPE, ScalarType::DTYPE>();
 
   ET_FORALL_FLOAT_TYPES(TEST_ENTRY);
 #undef TEST_ENTRY
 }
+#endif
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpVarMeanCorrectionOutTest, MultipleDims) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen supports fewer dtypes";
-  }
 #define TEST_KERNEL(INPUT_CTYPE, INPUT_DTYPE, OUTPUT_CTYPE, OUTPUT_DTYPE) \
   test_multiple_dims<ScalarType::INPUT_DTYPE, ScalarType::OUTPUT_DTYPE>();
 
@@ -424,22 +420,20 @@ TEST_F(OpVarMeanCorrectionOutTest, MultipleDims) {
 #undef TEST_ENTRY
 #undef TEST_KERNEL
 }
+#endif
 
+#ifdef USE_ATEN_LIB
 TEST_F(OpVarMeanCorrectionOutTest, MultipleDims_Aten) {
-  if (!torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen-specific variant of test case";
-  }
 #define TEST_ENTRY(CTYPE, DTYPE) \
   test_multiple_dims<ScalarType::DTYPE, ScalarType::DTYPE>();
 
   ET_FORALL_FLOAT_TYPES(TEST_ENTRY);
 #undef TEST_ENTRY
 }
+#endif
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpVarMeanCorrectionOutTest, NegativeDim) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen supports fewer dtypes";
-  }
 #define TEST_KERNEL(INPUT_CTYPE, INPUT_DTYPE, OUTPUT_CTYPE, OUTPUT_DTYPE) \
   test_negative_dim<ScalarType::INPUT_DTYPE, ScalarType::OUTPUT_DTYPE>();
 
@@ -450,22 +444,20 @@ TEST_F(OpVarMeanCorrectionOutTest, NegativeDim) {
 #undef TEST_ENTRY
 #undef TEST_KERNEL
 }
+#endif
 
+#ifdef USE_ATEN_LIB
 TEST_F(OpVarMeanCorrectionOutTest, NegativeDim_Aten) {
-  if (!torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen-specific variant of test case";
-  }
 #define TEST_ENTRY(CTYPE, DTYPE) \
   test_negative_dim<ScalarType::DTYPE, ScalarType::DTYPE>();
 
   ET_FORALL_FLOAT_TYPES(TEST_ENTRY);
 #undef TEST_ENTRY
 }
+#endif
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpVarMeanCorrectionOutTest, NullAndEmptyDimList) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen supports fewer dtypes";
-  }
 #define TEST_KERNEL(INPUT_CTYPE, INPUT_DTYPE, OUTPUT_CTYPE, OUTPUT_DTYPE) \
   test_null_and_empty_dim_list<                                           \
       ScalarType::INPUT_DTYPE,                                            \
@@ -478,22 +470,20 @@ TEST_F(OpVarMeanCorrectionOutTest, NullAndEmptyDimList) {
 #undef TEST_ENTRY
 #undef TEST_KERNEL
 }
+#endif
 
+#ifdef USE_ATEN_LIB
 TEST_F(OpVarMeanCorrectionOutTest, NullAndEmptyDimList_Aten) {
-  if (!torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen-specific variant of test case";
-  }
 #define TEST_ENTRY(CTYPE, DTYPE) \
   test_null_and_empty_dim_list<ScalarType::DTYPE, ScalarType::DTYPE>();
 
   ET_FORALL_FLOAT_TYPES(TEST_ENTRY);
 #undef TEST_ENTRY
 }
+#endif
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpVarMeanCorrectionOutTest, InvalidDimensionListDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel test fails";
-  }
 #define TEST_KERNEL(INPUT_CTYPE, INPUT_DTYPE, OUTPUT_CTYPE, OUTPUT_DTYPE) \
   test_invalid_dimensions<ScalarType::INPUT_DTYPE, ScalarType::OUTPUT_DTYPE>();
 
@@ -504,11 +494,10 @@ TEST_F(OpVarMeanCorrectionOutTest, InvalidDimensionListDies) {
 #undef TEST_ENTRY
 #undef TEST_KERNEL
 }
+#endif
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpVarMeanCorrectionOutTest, InvalidDTypeDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel test fails";
-  }
   TensorFactory<ScalarType::Float> tf_float;
   TensorFactory<ScalarType::Int> tf_int;
 
@@ -542,6 +531,7 @@ TEST_F(OpVarMeanCorrectionOutTest, InvalidDTypeDies) {
           var_out,
           mean_out));
 }
+#endif
 
 TEST_F(OpVarMeanCorrectionOutTest, EmptyInput) {
   TensorFactory<ScalarType::Float> tf;

--- a/kernels/test/op_var_test.cpp
+++ b/kernels/test/op_var_test.cpp
@@ -283,10 +283,8 @@ class OpVarCorrectionOutTest : public OperatorTest {
   }
 };
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpVarOutTest, InvalidDimensionListDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel test fails";
-  }
   // Use a two layer switch to hanldle each possible data pair
 #define TEST_KERNEL(INPUT_CTYPE, INPUT_DTYPE, OUTPUT_CTYPE, OUTPUT_DTYPE) \
   test_var_out_invalid_dimensions<                                        \
@@ -300,11 +298,10 @@ TEST_F(OpVarOutTest, InvalidDimensionListDies) {
 #undef TEST_ENTRY
 #undef TEST_KERNEL
 }
+#endif
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpVarOutTest, InvalidShapeDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel test fails";
-  }
   // Use a two layer switch to hanldle each possible data pair
 #define TEST_KERNEL(INPUT_CTYPE, INPUT_DTYPE, OUTPUT_CTYPE, OUTPUT_DTYPE) \
   test_var_out_invalid_shape<                                             \
@@ -318,11 +315,10 @@ TEST_F(OpVarOutTest, InvalidShapeDies) {
 #undef TEST_ENTRY
 #undef TEST_KERNEL
 }
+#endif
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpVarOutTest, InvalidDTypeDies) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel test fails";
-  }
   TensorFactory<ScalarType::Float> tf_float;
   TensorFactory<ScalarType::Int> tf_int;
 
@@ -354,11 +350,10 @@ TEST_F(OpVarOutTest, InvalidDTypeDies) {
           /*keepdim=*/true,
           out));
 }
+#endif
 
+#ifndef USE_ATEN_LIB
 TEST_F(OpVarOutTest, AllFloatInputFloatOutputPasses) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen supports fewer dtypes";
-  }
   // Use a two layer switch to hanldle each possible data pair
 #define TEST_KERNEL(INPUT_CTYPE, INPUT_DTYPE, OUTPUT_CTYPE, OUTPUT_DTYPE) \
   test_var_out_dtype<ScalarType::INPUT_DTYPE, ScalarType::OUTPUT_DTYPE>();
@@ -370,11 +365,10 @@ TEST_F(OpVarOutTest, AllFloatInputFloatOutputPasses) {
 #undef TEST_ENTRY
 #undef TEST_KERNEL
 }
+#endif
 
+#ifdef USE_ATEN_LIB
 TEST_F(OpVarOutTest, AllFloatInputFloatOutputPasses_Aten) {
-  if (!torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen-specific variant of test case";
-  }
   // Use a two layer switch to hanldle each possible data pair
 #define TEST_KERNEL(INPUT_CTYPE, INPUT_DTYPE, OUTPUT_CTYPE, OUTPUT_DTYPE) \
   test_var_out_dtype<ScalarType::INPUT_DTYPE, ScalarType::OUTPUT_DTYPE>();
@@ -386,6 +380,7 @@ TEST_F(OpVarOutTest, AllFloatInputFloatOutputPasses_Aten) {
 #undef TEST_ENTRY
 #undef TEST_KERNEL
 }
+#endif
 
 TEST_F(OpVarOutTest, InfinityAndNANTest) {
   TensorFactory<ScalarType::Float> tf_float;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #19485
* #19484
* #19483

Replace runtime `if (is_aten) { GTEST_SKIP() }` checks with compile-time `#ifndef USE_ATEN_LIB` / `#ifdef USE_ATEN_LIB` preprocessor guards around the entire test.

Meta test infra does not handle GTEST_SKIP well, so we use preprocessor guards to exclude aten-incompatible tests at compile time instead of skipping them at runtime.

This commit covers ops n-z (ne through var). Authored with Claude.

Differential Revision: [D104739568](https://our.internmc.facebook.com/intern/diff/D104739568/)