### PR TITLE
Filter death + DynamicShapeUnbound gtests on Android (#19503)

### DIFF
--- a/shim_et/xplat/executorch/kernels/test/util.bzl
+++ b/shim_et/xplat/executorch/kernels/test/util.bzl
@@ -37,18 +37,38 @@ def op_test(name, deps = [], kernel_name = "portable", use_kernel_prefix = False
 
     name_prefix = ""
     aten_suffix = ""
+
+    # On Android, fork() is unavailable so gtest auto-skips death tests
+    # (*Dies). Filter them out at discovery time so TestInfra stops
+    # reporting them as perpetually-skipped/failing. See T270699623.
+    #
+    # For portable/optimized kernels, *DynamicShapeUnbound tests are also
+    # filtered because output_resize=false for those kernels, so they
+    # GTEST_SKIP() at runtime today. For the ATen kernel, output_resize=true
+    # (see supported_features_def_aten.yaml), so DynamicShapeUnbound tests
+    # actually run and provide coverage on Android — keep them.
     if kernel_name == "aten":
         # For aten kernel, we need to use aten specific utils and types
         name_prefix = "aten_"
         aten_suffix = "_aten"
-    elif use_kernel_prefix:
-        name_prefix = kernel_name + "_"
+        android_gtest_filter = "-*Dies"
+    else:
+        if use_kernel_prefix:
+            name_prefix = kernel_name + "_"
+        android_gtest_filter = "-*Dies:*DynamicShapeUnbound"
+
     runtime.cxx_test(
         name = name_prefix + name,
         srcs = [
             "{}.cpp".format(name),
         ],
         visibility = ["//executorch/kernels/..."],
+        env = select({
+            "ovr_config//os:android": {
+                "GTEST_FILTER": android_gtest_filter,
+            },
+            "DEFAULT": {},
+        }),
         deps = [
             "//executorch/runtime/core/exec_aten:lib" + aten_suffix,
             "//executorch/runtime/core/exec_aten/testing_util:tensor_util" + aten_suffix,


### PR DESCRIPTION
Summary:

~250+ ExecuTorch *_testAndroid GTests have been perpetually reported as
failing in TestInfra because they are auto-skipped on every run. Death
tests (*Dies) require fork(), which Android's test sandbox does not
support, so gtest skips them automatically. *DynamicShapeUnbound tests
hit GTEST_SKIP() at runtime because the Android-specific feature flag
is unset. The result is alert fatigue for the executorch oncall and
distorted CI signal.

Filter these tests out at discovery time on Android only via a
GTEST_FILTER env var on the shared op_test() macro. The filter is
scoped through select() to ovr_config//os:android, so death tests
continue to run and pass on Linux, macOS, iOS, and fbcode targets.

___

overriding_review_checks_triggers_an_audit_and_retroactive_review
Oncall Short Name: ai_infra_mobile_platform

Reviewed By: GregoryComer

Differential Revision: D104784946


