### PR TITLE
Arm backend: Enable CPPCHECK linting

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -11,7 +11,7 @@ jobs:
     uses: pytorch/test-infra/.github/workflows/_claude-code.yml@main
     with:
       setup_script: |
-        pip install lintrunner==0.12.7 lintrunner-adapters==0.13.0
+        pip install lintrunner==0.12.7 lintrunner-adapters==0.14.0
         pip install -r requirements-lintrunner.txt
         lintrunner init
     permissions:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install torch --index-url https://download.pytorch.org/whl/cpu
-          pip install lintrunner==0.12.7 lintrunner-adapters==0.13.0
+          pip install lintrunner==0.12.7 lintrunner-adapters==0.14.0
           pip install -r requirements-lintrunner.txt
           USE_CPP=0 pip install --no-build-isolation third-party/ao
           pip install pytest numpy parameterized huggingface_hub transformers timm expecttest types-requests
@@ -93,7 +93,7 @@ jobs:
 
       - name: Install lintrunner and linters
         run: |
-          pip install lintrunner==0.12.7 lintrunner-adapters==0.13.0
+          pip install lintrunner==0.12.7 lintrunner-adapters==0.14.0
           pip install -r requirements-lintrunner.txt
           lintrunner init
 

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -107,6 +107,45 @@ init_command = [
 is_formatter = true
 
 [[linter]]
+code = 'CPPCHECK'
+include_patterns = [
+    'backends/arm/**/*.cpp',
+    'backends/arm/**/*.h',
+    'backends/arm/**/*.hpp',
+    'examples/arm/**/*.cpp',
+    'examples/arm/**/*.h',
+    'examples/arm/**/*.hpp',
+]
+exclude_patterns = [
+]
+command = [
+    'python',
+    '-m',
+    'lintrunner_adapters',
+    'run',
+    'cppcheck_linter',
+    '--enable=warning,style,unusedFunction',
+    '--extra-arg=--check-level=exhaustive',
+    '--extra-arg=--std=c++17',
+    '--extra-arg=--language=c++',
+    '--extra-arg=--inline-suppr',
+    '--extra-arg=--inconclusive',
+    '--extra-arg=--suppress=unusedStructMember',
+    '--extra-arg=--suppress=toomanyconfigs',
+    '--',
+    '@{{PATHSFILE}}'
+]
+init_command = [
+    'python',
+    '-m',
+    'lintrunner_adapters',
+    'run',
+    'pip_init',
+    '--dry-run={{DRYRUN}}',
+    '--requirement=requirements-lintrunner.txt',
+]
+
+[[linter]]
 code = 'CMAKE'
 include_patterns = [
     "**/*.cmake",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,7 @@ wheel  # For building the pip package archive.
 zstd  # Imported by resolve_buck.py.
 certifi  # Imported by resolve_buck.py.
 lintrunner==0.12.7
-lintrunner-adapters==0.13.0
+lintrunner-adapters==0.14.0
 
 pytest<9.0
 pytest-xdist

--- a/requirements-lintrunner.txt
+++ b/requirements-lintrunner.txt
@@ -22,3 +22,7 @@ docformatter==1.7.5
 
 # MyPy
 mypy==1.14.1
+
+# Cppcheck and dependencies
+cppcheck==1.5.1
+defusedxml==0.7.1


### PR DESCRIPTION
Bump lintrunner-adapters to 0.14.0 which supports cppcheck and start linting the arm backend.

Change-Id: I1b28466d7f78d006a38b8d3c711670991cbc327a


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani