### PR TITLE
NXP backend: Add extended support from new Neutron C flow for Clamp operator

### DIFF
--- a/backends/nxp/backend/custom_delegation_options.py
+++ b/backends/nxp/backend/custom_delegation_options.py
@@ -22,7 +22,3 @@ class CustomDelegationOptions:
     #  not create any NeutronGraph that can be called. This is done by the partitioner itself, and is not handled by
     #  the individual node converters.
     allow_no_op_partitions: bool = False
-
-    # The new neutron converter flow has different constraints for supported operators. These need to be addressed when
-    # deciding is operator is delegated or not in _is_supported_on_target().
-    use_new_flow_neutron_c: bool = False

--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/abs_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/abs_converter.py
@@ -5,7 +5,6 @@
 
 
 import torch
-
 from executorch.backends.nxp.backend.ir.converter.node_converter import (
     CustomDelegationOptions,
     NeutronTargetSpec,
@@ -36,7 +35,7 @@ class AbsConverter(NodeConverter):
         custom_delegation_options: CustomDelegationOptions,
     ) -> bool:
 
-        if custom_delegation_options.use_new_flow_neutron_c:
+        if neutron_target_spec.use_new_flow_neutron_c:
             # Requirements specified by the new Neutron flow documentation.
 
             supported_types = [torch.int8, torch.uint8]

--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/adaptive_avg_pool_2d_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/adaptive_avg_pool_2d_converter.py
@@ -78,7 +78,7 @@ class AdaptiveAvgPool2dConverter(NodeConverter):
             AdaptiveAvgPool2dConverter._get_equivalent_avg_pool_parameters(node)
         )
 
-        if custom_delegation_options.use_new_flow_neutron_c:
+        if neutron_target_spec.use_new_flow_neutron_c:
             # Requirements specified by the new Neutron flow documentation.
 
             if not NodeConverter.uses_quantization_type_for_io(

--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/add_tensor_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/add_tensor_converter.py
@@ -26,7 +26,7 @@ class AddTensorConverter(NodeConverter):
         parameters_mapping: dict[str, Parameter],
         custom_delegation_options: CustomDelegationOptions,
     ) -> bool:
-        if custom_delegation_options.use_new_flow_neutron_c:
+        if neutron_target_spec.use_new_flow_neutron_c:
             if not NodeConverter.at_least_one_input_shape_matches_the_output_shape(
                 node
             ):

--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/avg_pool_2d_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/avg_pool_2d_converter.py
@@ -5,7 +5,6 @@
 
 import numpy as np
 import torch
-
 from executorch.backends.nxp.backend.ir.converter.conversion import (
     aten_translator,
     common,
@@ -22,7 +21,6 @@ from executorch.backends.nxp.backend.ir.tflite_generator import tflite_model
 from executorch.backends.nxp.backend.ir.tflite_generator.builtin_options import (
     average_pool_2d_options,
 )
-
 from executorch.backends.nxp.backend.neutron_target_spec import NeutronTargetSpec
 from torch.fx import Node
 from torch.nn import Parameter
@@ -66,7 +64,7 @@ class AvgPool2dConverter(NodeConverter):
         kernel = node.args[1]
         stride = node.args[2]
 
-        if custom_delegation_options.use_new_flow_neutron_c:
+        if neutron_target_spec.use_new_flow_neutron_c:
             # Requirements specified by the new Neutron flow documentation.
 
             supported_types = [torch.int8, torch.uint8]

--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/clamp_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/clamp_converter.py
@@ -3,14 +3,31 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import math
+
+import numpy as np
+import torch
 from executorch.backends.nxp.backend.edge_helper import try_get_arg
+from executorch.backends.nxp.backend.ir.converter.conversion.translator import (
+    torch_type_to_numpy_type,
+)
 from executorch.backends.nxp.backend.ir.converter.node_converter import (
+    _is_dequant_node,
+    _is_quant_node,
     CustomDelegationOptions,
     is_not_qdq_node,
     NodeConverter,
 )
+from executorch.backends.nxp.backend.ir.converter.quantization_utils import (
+    propagate_quantization,
+)
 from executorch.backends.nxp.backend.ir.lib.tflite.BuiltinOperator import (
     BuiltinOperator,
+)
+from executorch.backends.nxp.backend.ir.tflite_generator import tflite_model
+from executorch.backends.nxp.backend.ir.tflite_generator.builtin_options import (
+    maximum_options,
+    minimum_options,
 )
 from executorch.backends.nxp.backend.neutron_operator_support import (
     activation_supported_on_target,
@@ -21,15 +38,26 @@ from torch.fx.passes.infra.partitioner import Partition
 from torch.nn import Parameter
 
 
+def _is_convertible_to_relu(node):
+    bounds = ClampConverter._get_clamp_bounds(node)
+    bounds = tuple(v if v is not None and math.isfinite(v) else None for v in bounds)
+
+    # Some specific bounds can be replaced with single op ReLU.
+    if bounds not in ClampConverter.RELU_COMPATIBLE_BOUNDS.values():
+        return False
+
+    return True
+
+
 class ClampConverter(NodeConverter):
-    SUPPORTED_BOUNDS = {
+    RELU_COMPATIBLE_BOUNDS = {
         "ReluN1To1": (-1, 1),
         "Relu0To1": (0, 1),
         "Relu6": (0, 6),
         "Relu": (0, None),
     }
 
-    BOUNDS_TO_NEUTRON_IR_OP = {
+    BOUNDS_TO_RELU_NEUTRON_IR_OP = {
         (-1, 1): BuiltinOperator.RELU_N1_TO_1,
         (0, 1): BuiltinOperator.RELU_0_TO_1,
         (0, 6): BuiltinOperator.RELU6,
@@ -54,26 +82,55 @@ class ClampConverter(NodeConverter):
         return True
 
     @staticmethod
+    def _io_quant_is_same(node: Node):
+        quant = next(iter(node.users.keys()))
+        dequant = node.args[0]
+
+        if not _is_dequant_node(dequant):
+            return False
+
+        if not _is_quant_node(quant):
+            return False
+
+        q_params = quant.args[1:]
+        dq_params = dequant.args[1:]
+        return all(q == dq for q, dq in zip(q_params, dq_params))
+
+    @staticmethod
     def _is_supported_on_target(
         node: Node,
         neutron_target_spec: NeutronTargetSpec,
         parameters_mapping: dict[str, Parameter],
         custom_delegation_options: CustomDelegationOptions,
     ) -> bool:
+        relu_compatible = _is_convertible_to_relu(node)
         bounds = ClampConverter._get_clamp_bounds(node)
 
-        # Only some specific bounds are supported on the target hardware.
-        if bounds not in ClampConverter.SUPPORTED_BOUNDS.values():
+        if all(b is None or math.isinf(b) for b in bounds):
             return False
 
-        return True
+        if neutron_target_spec.use_new_flow_neutron_c:
+            io_quant_consistent = ClampConverter._io_quant_is_same(node)
+            quant_supported = NodeConverter.uses_quantization_type_for_io(
+                node,
+                supported_types=[torch.int8, torch.uint8],
+                input_indices=[0],
+                output_indices=[0],
+            )
+
+            # We either convert to ReLU -> SingleInputQuantization pattern
+            # or we convert to Min/Max, which requires same quantization on
+            # both input and output.
+            return (relu_compatible | io_quant_consistent) and quant_supported
+
+        return relu_compatible
 
     @classmethod
     def supports_partitioning_result(
         cls,
         node: Node,
         partition_list: list[Partition],
-        custom_delegation_options: CustomDelegationOptions,
+        _: CustomDelegationOptions,
         neutron_target_spec: NeutronTargetSpec,
         parameters_mapping: dict[str, Parameter],
     ) -> bool:
@@ -82,7 +139,10 @@ class ClampConverter(NodeConverter):
         # Neutron cannot delegate a partition where ReLU or ReLU6 is the only operator
         # and at the same time the node does not satisfy delegation requirements.
         # In contrast, ReLUN1To1 and ReLU0To1 are supported and delegated successfuly.
-        if bounds in [cls.SUPPORTED_BOUNDS["Relu"], cls.SUPPORTED_BOUNDS["Relu6"]]:
+        if bounds in [
+            cls.RELU_COMPATIBLE_BOUNDS["Relu"],
+            cls.RELU_COMPATIBLE_BOUNDS["Relu6"],
+        ]:
             is_alone_in_partition = cls.is_node_alone_in_partition(
                 node, partition_list, filter_fn=is_not_qdq_node
             )
@@ -91,8 +151,21 @@ class ClampConverter(NodeConverter):
 
         return True
 
+    @staticmethod
+    def _quantize_value(
+        value: int,
+        zp: int,
+        scale: float,
+        quant_min: int,
+        quant_max: int,
+        dtype: type = np.int8,
+    ) -> np.integer:
+        rescaled_value = round(value / scale) + zp
+        return dtype(np.clip(rescaled_value, quant_min, quant_max))
+
     def convert(self, node: Node):
-        """Convert the `aten.clamp.default` operator to Neutron IR `Relu*` operators.
+        """Convert the `aten.clamp.default` operator to either
+        Neutron IR `Relu*` operator or combination of `Min` and `Max`.
         The schema is:
             aten::clamp(
                 Tensor self,
@@ -101,13 +174,83 @@ class ClampConverter(NodeConverter):
             ) -> Tensor
         """
         self.assert_convertible(node)
+        to_relu = _is_convertible_to_relu(node)
 
         bounds = self._get_clamp_bounds(node)
-
+        bounds = tuple(
+            v if v is not None and math.isfinite(v) else None for v in bounds
+        )
         t_op = self._create_tflite_op_with_io_tensors(node)
 
-        # noinspection PyTypeChecker,PyUnboundLocalVariable
-        t_op.opcode_index = self.builder.op_code_index_for_op_type(
-            self.BOUNDS_TO_NEUTRON_IR_OP[bounds]
-        )
-        self.builder.append_operators([t_op])
+        # Clamp convertible to some variant of ReLU
+        if not self.neutron_target_spec.use_new_flow_neutron_c or to_relu:
+            # noinspection PyTypeChecker,PyUnboundLocalVariable
+            t_op.opcode_index = self.builder.op_code_index_for_op_type(
+                self.BOUNDS_TO_RELU_NEUTRON_IR_OP[bounds]
+            )
+            self.builder.append_operators([t_op])
+            return
+
+        q_node = node.args[0]
+        assert _is_dequant_node(q_node)
+        _, scale, zp, quant_min, quant_max, q_type = q_node.args
+        q_type = torch_type_to_numpy_type(q_type).type
+
+        x = t_op.tmp_inputs[0]
+        y = t_op.tmp_outputs[0]
+
+        if x.quantization is not None and y.quantization is None:
+            propagate_quantization(x, y)
+
+        min_value, max_value = bounds
+
+        if min_value is not None:
+            min_value = self._quantize_value(
+                value=min_value,
+                zp=zp,
+                scale=scale,
+                quant_min=quant_min,
+                quant_max=quant_max,
+                dtype=q_type,
+            )
+            min_tensor = self.builder.create_tensor_for_data(
+                np.array([min_value], q_type), "min"
+            )
+            propagate_quantization(x, min_tensor)
+
+        if max_value is not None:
+            max_value = self._quantize_value(
+                value=max_value,
+                zp=zp,
+                scale=scale,
+                quant_min=quant_min,
+                quant_max=quant_max,
+                dtype=q_type,
+            )
+            max_tensor = self.builder.create_tensor_for_data(
+                np.array([max_value], q_type), "max"
+            )
+            propagate_quantization(x, max_tensor)
+
+        if None not in bounds:
+            tmp_y = self.builder.duplicate_tensor(x)
+            tmp_x = tmp_y
+            propagate_quantization(x, tmp_y)
+        else:
+            tmp_y = y
+            tmp_x = x
+
+        ops_to_add = []
+        if max_value is not None:
+            min_op = tflite_model.Operator(builtin_options=minimum_options.Minimum())
+            min_op.tmp_inputs = [x, max_tensor]
+            min_op.tmp_outputs = [tmp_y]
+            ops_to_add.append(min_op)
+
+        if min_value is not None:
+            max_op = tflite_model.Operator(builtin_options=maximum_options.Maximum())
+            max_op.tmp_inputs = [tmp_x, min_tensor]
+            max_op.tmp_outputs = [y]
+            ops_to_add.append(max_op)
+
+        self.builder.append_operators(ops_to_add)

--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/constant_pad_nd_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/constant_pad_nd_converter.py
@@ -42,7 +42,7 @@ class ConstantPadNDConverter(NodeConverter):
         parameters_mapping: dict[str, Parameter],
         custom_delegation_options: CustomDelegationOptions,
     ) -> bool:
-        if custom_delegation_options.use_new_flow_neutron_c:
+        if neutron_target_spec.use_new_flow_neutron_c:
             # Requirements specified by the new Neutron flow documentation.
 
             if not NodeConverter.uses_quantization_type_for_io(

--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/leaky_relu_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/leaky_relu_converter.py
@@ -35,7 +35,7 @@ class LeakyReluConverter(NodeConverter):
         parameters_mapping: dict[str, Parameter],
         custom_delegation_options: CustomDelegationOptions,
     ) -> bool:
-        if custom_delegation_options.use_new_flow_neutron_c:
+        if neutron_target_spec.use_new_flow_neutron_c:
             # Requirements specified by the new Neutron flow documentation.
 
             if not NodeConverter.uses_quantization_type_for_io(

--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/max_pool2d_with_indices_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/max_pool2d_with_indices_converter.py
@@ -7,7 +7,6 @@ import operator
 
 import numpy as np
 import torch
-
 from executorch.backends.nxp.backend.edge_helper import try_get_arg
 from executorch.backends.nxp.backend.ir.converter.conversion import (
     aten_translator,
@@ -74,7 +73,7 @@ class MaxPool2DWithIndicesConverter(NodeConverter):
             MaxPool2DWithIndicesConverter._get_node_args(node)
         )
 
-        if custom_delegation_options.use_new_flow_neutron_c:
+        if neutron_target_spec.use_new_flow_neutron_c:
             # Requirements specified by the new Neutron flow documentation.
 
             supported_types = [torch.int8, torch.uint8]

--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/mean_dim_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/mean_dim_converter.py
@@ -38,7 +38,7 @@ class MeanDimConverter(NodeConverter):
         neutron_target_spec: NeutronTargetSpec,
         parameters_mapping: dict[str, Parameter],
     ) -> bool:
-        if custom_delegation_options.use_new_flow_neutron_c:
+        if neutron_target_spec.use_new_flow_neutron_c:
             dim, keepdim = MeanDimConverter._get_attrs(node)
             input_shape = node.args[0].meta["val"].shape
 
@@ -64,7 +64,7 @@ class MeanDimConverter(NodeConverter):
         parameters_mapping: dict[str, Parameter],
         custom_delegation_options: CustomDelegationOptions,
     ) -> bool:
-        if custom_delegation_options.use_new_flow_neutron_c:
+        if neutron_target_spec.use_new_flow_neutron_c:
             # Requirements specified by the new Neutron flow documentation.
 
             if not NodeConverter.uses_quantization_type_for_io(

--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/mul_tensor_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/mul_tensor_converter.py
@@ -4,7 +4,6 @@
 # LICENSE file in the root directory of this source tree.
 
 import torch
-
 from executorch.backends.nxp.backend.data_format import NXP_NODE_FORMAT
 from executorch.backends.nxp.backend.ir.converter.node_converter import (
     CustomDelegationOptions,
@@ -26,7 +25,7 @@ class MulTensorConverter(NodeConverter):
         parameters_mapping: dict[str, Parameter],
         custom_delegation_options: CustomDelegationOptions,
     ) -> bool:
-        if custom_delegation_options.use_new_flow_neutron_c:
+        if neutron_target_spec.use_new_flow_neutron_c:
             if not NodeConverter.at_least_one_input_shape_matches_the_output_shape(
                 node
             ):

--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/sigmoid_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/sigmoid_converter.py
@@ -35,7 +35,7 @@ class SigmoidConverter(NodeConverter):
         parameters_mapping: dict[str, Parameter],
         custom_delegation_options: CustomDelegationOptions,
     ) -> bool:
-        if custom_delegation_options.use_new_flow_neutron_c:
+        if neutron_target_spec.use_new_flow_neutron_c:
             # Requirements specified by the new Neutron flow documentation.
 
             if not NodeConverter.uses_quantization_type_for_io(

--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/slice_tensor_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/slice_tensor_converter.py
@@ -32,7 +32,7 @@ class SliceTensorConverter(NodeConverter):
         parameters_mapping: dict[str, Parameter],
         custom_delegation_options: CustomDelegationOptions,
     ) -> bool:
-        if custom_delegation_options.use_new_flow_neutron_c:
+        if neutron_target_spec.use_new_flow_neutron_c:
             supported_types = [torch.int8, torch.uint8]
             if not NodeConverter.uses_quantization_type_for_io(
                 node, supported_types, [0], [0]
@@ -106,7 +106,7 @@ class SliceTensorConverter(NodeConverter):
 
         # In the new Neutron flow, slicing can be done along any dim, so
         # no additional `transpose` ops have to be added.
-        if self.context.custom_delegation_options.use_new_flow_neutron_c:
+        if self.neutron_target_spec.use_new_flow_neutron_c:
             begin_tensor = self.builder.create_tensor_for_data(
                 np.asarray(begin, np.int32), "begin"
             )

--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/sub_tensor_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/sub_tensor_converter.py
@@ -26,7 +26,7 @@ class SubTensorConverter(NodeConverter):
         parameters_mapping: dict[str, Parameter],
         custom_delegation_options: CustomDelegationOptions,
     ) -> bool:
-        if custom_delegation_options.use_new_flow_neutron_c:
+        if neutron_target_spec.use_new_flow_neutron_c:
             if not NodeConverter.at_least_one_input_shape_matches_the_output_shape(
                 node
             ):

--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/tanh_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/tanh_converter.py
@@ -35,7 +35,7 @@ class TanhConverter(NodeConverter):
         parameters_mapping: dict[str, Parameter],
         custom_delegation_options: CustomDelegationOptions,
     ) -> bool:
-        if custom_delegation_options.use_new_flow_neutron_c:
+        if neutron_target_spec.use_new_flow_neutron_c:
             # Requirements specified by the new Neutron flow documentation.
 
             if not NodeConverter.uses_quantization_type_for_io(

--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/upsample_bilinear2d_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/upsample_bilinear2d_converter.py
@@ -82,7 +82,7 @@ class UpsampleBilinear2DConverter(NodeConverter):
         _, in_c, in_h, in_w = node.all_input_nodes[0].meta["val"].shape
         _, _, out_h, out_w = node.meta["val"].shape
 
-        if custom_delegation_options.use_new_flow_neutron_c:
+        if neutron_target_spec.use_new_flow_neutron_c:
             # Requirements specified by the new Neutron flow documentation.
 
             if not NodeConverter.uses_quantization_type_for_io(

--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/upsample_nearest2d_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/upsample_nearest2d_converter.py
@@ -84,7 +84,7 @@ class UpsampleNearest2DConverter(NodeConverter):
         _, in_c, in_h, in_w = node.all_input_nodes[0].meta["val"].shape
         _, _, out_h, out_w = node.meta["val"].shape
 
-        if custom_delegation_options.use_new_flow_neutron_c:
+        if neutron_target_spec.use_new_flow_neutron_c:
             # Requirements specified by the new Neutron flow documentation.
 
             if not NodeConverter.uses_quantization_type_for_io(

--- a/backends/nxp/backend/neutron_target_spec.py
+++ b/backends/nxp/backend/neutron_target_spec.py
@@ -102,6 +102,9 @@ class NeutronTargetSpec:
         converter_manager.verify_target(target)
         neutron_converter = converter_manager.get_converter()
         self.neutron_target = neutron_converter.getNeutronTarget(target)
+
+        # The new neutron converter flow has different constraints for supported operators. These need to be addressed when
+        # deciding is operator is delegated or not in _is_supported_on_target().
         self.use_new_flow_neutron_c = use_new_flow_neutron_c
 
         if self.is_subsystem():

--- a/backends/nxp/backend/neutron_target_spec.py
+++ b/backends/nxp/backend/neutron_target_spec.py
@@ -1,4 +1,4 @@
-# Copyright 2025 NXP
+# Copyright 2026 NXP
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -8,12 +8,10 @@
 from enum import Enum
 
 import torch
-
 from executorch.backends.nxp.backend.neutron_converter_manager import (
     NeutronConverterManager,
 )
 from executorch.exir.dialects._ops import ops as exir_ops
-
 from torch.fx import Node
 
 
@@ -98,12 +96,13 @@ class NeutronTargetSpec:
     The functionality for probing the properties of Neutron Target.
     """
 
-    def __init__(self, target: str):
+    def __init__(self, target: str, use_new_flow_neutron_c: bool = False):
 
         converter_manager = NeutronConverterManager()
         converter_manager.verify_target(target)
         neutron_converter = converter_manager.get_converter()
         self.neutron_target = neutron_converter.getNeutronTarget(target)
+        self.use_new_flow_neutron_c = use_new_flow_neutron_c
 
         if self.is_subsystem():
             raise ValueError(

--- a/backends/nxp/nxp_backend.py
+++ b/backends/nxp/nxp_backend.py
@@ -14,7 +14,6 @@ from typing import final, List, Optional
 
 import numpy as np
 import torch
-
 from executorch.backends.nxp.backend.custom_delegation_options import (
     CustomDelegationOptions,
 )
@@ -86,7 +85,9 @@ class NeutronCompileSpecBuilder:
         :return: self for method chaining
         """
 
-        self.config = NeutronTargetSpec(config)
+        self.config = NeutronTargetSpec(
+            config, use_new_flow_neutron_c=use_new_flow_neutron_c
+        )
 
         assert (
             self.output_format is None

--- a/backends/nxp/nxp_backend.py
+++ b/backends/nxp/nxp_backend.py
@@ -231,11 +231,11 @@ class NeutronBackend(BackendDetails):
             )
             tflite_model, io_formats = EdgeProgramToIRConverter().convert_program(
                 edge_program,
-                neutron_target_spec=NeutronTargetSpec(target),
-                conversion_config=conversion_config,
-                custom_delegation_options=CustomDelegationOptions(
-                    use_new_flow_neutron_c=use_new_flow_neutron_c
+                neutron_target_spec=NeutronTargetSpec(
+                    target, use_new_flow_neutron_c=use_new_flow_neutron_c
                 ),
+                conversion_config=conversion_config,
+                custom_delegation_options=CustomDelegationOptions(),
             )
 
             neutron_model = NeutronConverterManager(dump_kernel_selection_code).convert(

--- a/backends/nxp/quantizer/neutron_quantizer.py
+++ b/backends/nxp/quantizer/neutron_quantizer.py
@@ -9,7 +9,6 @@ from executorch.backends.nxp.aten_passes.neutron_aten_pass_manager import (
     _get_default_passes,
     NeutronAtenPassManager,
 )
-
 from executorch.backends.nxp.backend.neutron_target_spec import NeutronTargetSpec
 from executorch.backends.nxp.quantizer.patterns import (
     AbsPattern,
@@ -264,7 +263,7 @@ class NeutronQuantizer(ComposableQuantizer):
                 OpQuantizer(BatchNormPattern(is_qat=is_qat), static_qconfig),
                 OpQuantizer(BMMPattern(is_qat=is_qat), static_qconfig),
                 OpQuantizer(CatPattern(is_qat=is_qat), static_qconfig),
-                OpQuantizer(ClampPattern(is_qat=is_qat), static_qconfig),
+                OpQuantizer(ClampPattern(self, is_qat=is_qat), static_qconfig),
                 OpQuantizer(Conv2dPattern(self, is_qat=is_qat), static_qconfig),
                 OpQuantizer(
                     ConvTranspose2dPattern(self, is_qat=is_qat), static_qconfig

--- a/backends/nxp/quantizer/patterns.py
+++ b/backends/nxp/quantizer/patterns.py
@@ -10,7 +10,6 @@ from dataclasses import dataclass, field
 from functools import partial
 
 import torch
-
 from executorch.backends.nxp.quantizer.utils import (
     get_bias_qparams,
     get_bias_qparams_transp_conv,
@@ -157,9 +156,6 @@ class SingleInputBasicPattern(QuantizationPattern):
 
 
 class BatchNormPattern(QuantizationPattern):
-    def __init__(self, is_qat: bool):
-        super().__init__(is_qat=is_qat)
-
     def partition_types(self) -> list[OpOverload]:
         # BatchNorm quantization is needed only when in QAT mode
         return [torch.ops.aten.batch_norm.default] if self.is_qat else []
@@ -414,6 +410,10 @@ class CatPattern(QuantizationPattern):
 
 class ClampPattern(SingleInputBasicPattern):
     """Quantizer for the `aten.clamp.default` operator."""
+
+    def __init__(self, neutron_quantizer, is_qat=False):
+        super().__init__(is_qat)
+        self.neutron_quantizer = neutron_quantizer
 
     def partition_types(self):
         return [torch.ops.aten.clamp.default]

--- a/backends/nxp/quantizer/patterns.py
+++ b/backends/nxp/quantizer/patterns.py
@@ -10,6 +10,9 @@ from dataclasses import dataclass, field
 from functools import partial
 
 import torch
+from executorch.backends.nxp.backend.ir.converter.node_converters.ops_converters.clamp_converter import (
+    _is_convertible_to_relu,
+)
 from executorch.backends.nxp.quantizer.utils import (
     get_bias_qparams,
     get_bias_qparams_transp_conv,
@@ -114,8 +117,9 @@ class SharedSpecPattern(QuantizationPattern):
     def partition_types(self) -> list[torch.nn.Module]:
         pass
 
-    def get_anchors(
-        self, gm: fx.GraphModule, fused_partition: list[fx.GraphModule]
+    @staticmethod
+    def get_shared_spec_anchors(
+        gm: fx.GraphModule, fused_partition: list[fx.GraphModule]
     ) -> PartitionAnchors | None:
         node = fused_partition[0].nodes[-1]
         assert len(fused_partition[0].input_nodes) == 1
@@ -136,15 +140,21 @@ class SharedSpecPattern(QuantizationPattern):
             ],
         )
 
+    def get_anchors(
+        self, gm: fx.GraphModule, fused_partition: list[fx.GraphModule]
+    ) -> PartitionAnchors | None:
+        return self.get_shared_spec_anchors(gm, fused_partition)
+
 
 class SingleInputBasicPattern(QuantizationPattern):
     @abstractmethod
     def partition_types(self) -> list[OpOverload]:
         pass
 
-    def get_anchors(
-        self, gm: fx.GraphModule, fused_partition: list[fx.GraphModule]
-    ) -> PartitionAnchors | None:
+    @staticmethod
+    def get_single_input_anchors(
+        gm: fx.GraphModule, fused_partition: list[fx.GraphModule]
+    ):
         node = fused_partition[0].nodes[-1]
 
         return PartitionAnchors(
@@ -153,6 +163,11 @@ class SingleInputBasicPattern(QuantizationPattern):
             biases=[],
             output=[(node,)],
         )
+
+    def get_anchors(
+        self, gm: fx.GraphModule, fused_partition: list[fx.GraphModule]
+    ) -> PartitionAnchors | None:
+        return self.get_single_input_anchors(gm, fused_partition)
 
 
 class BatchNormPattern(QuantizationPattern):
@@ -408,7 +423,7 @@ class CatPattern(QuantizationPattern):
         )
 
 
-class ClampPattern(SingleInputBasicPattern):
+class ClampPattern(QuantizationPattern):
     """Quantizer for the `aten.clamp.default` operator."""
 
     def __init__(self, neutron_quantizer, is_qat=False):
@@ -417,6 +432,19 @@ class ClampPattern(SingleInputBasicPattern):
 
     def partition_types(self):
         return [torch.ops.aten.clamp.default]
+
+    def get_anchors(
+        self, gm: fx.GraphModule, fused_partition: list[fx.GraphModule]
+    ) -> PartitionAnchors | None:
+        node = fused_partition[0].nodes[-1]
+
+        if (
+            self.neutron_quantizer.neutron_target_spec.use_new_flow_neutron_c
+            and not _is_convertible_to_relu(node)
+        ):
+            return SharedSpecPattern.get_shared_spec_anchors(gm, fused_partition)
+        else:
+            return SingleInputBasicPattern.get_single_input_anchors(gm, fused_partition)
 
 
 def _is_batch_norm(node_: Node) -> bool:

--- a/backends/nxp/tests/executorch_pipeline.py
+++ b/backends/nxp/tests/executorch_pipeline.py
@@ -195,7 +195,6 @@ def to_quantized_edge_program(
     _neutron_target_spec = NeutronTargetSpec(
         target, use_new_flow_neutron_c=use_new_flow_neutron_c
     )
-    custom_delegation_options.use_new_flow_neutron_c = use_new_flow_neutron_c
     if get_quantizer_fn is None:
         get_quantizer_fn = partial(
             _get_default_quantizer, _neutron_target_spec, use_qat

--- a/backends/nxp/tests/executorch_pipeline.py
+++ b/backends/nxp/tests/executorch_pipeline.py
@@ -13,7 +13,6 @@ from typing import Callable, Iterable
 import eiq_neutron_sdk
 import numpy as np
 import torch
-
 from executorch import exir
 from executorch.backends.nxp.backend.custom_delegation_options import (
     CustomDelegationOptions,
@@ -98,7 +97,7 @@ def _get_default_quantizer(target_spec: NeutronTargetSpec, use_qat: bool) -> Qua
 
 
 def to_model_input_spec(
-    input_spec: Iterable[ModelInputSpec] | tuple[int, ...] | list[tuple[int, ...]]
+    input_spec: Iterable[ModelInputSpec] | tuple[int, ...] | list[tuple[int, ...]],
 ) -> tuple[ModelInputSpec, ...]:
     match input_spec:
         case _ if isinstance(input_spec, Iterable) and all(
@@ -122,7 +121,7 @@ GetCalibrationInputsFn = Callable[
 
 def get_calibration_inputs_fn_from_dataset_dir(dataset_dir) -> GetCalibrationInputsFn:
     def _nested(
-        input_spec: tuple[ModelInputSpec, ...]
+        input_spec: tuple[ModelInputSpec, ...],
     ) -> Iterable[tuple[torch.Tensor, ...]]:
         data = sorted(os.listdir(dataset_dir))
         inputs_needed = len(input_spec)
@@ -156,7 +155,7 @@ def get_calibration_inputs_fn_from_dataset_dir(dataset_dir) -> GetCalibrationInp
 
 
 def _get_example_input(
-    input_spec: tuple[ModelInputSpec, ...]
+    input_spec: tuple[ModelInputSpec, ...],
 ) -> tuple[torch.Tensor, ...]:
     example_input = []
     for spec in input_spec:
@@ -193,7 +192,9 @@ def to_quantized_edge_program(
     use_new_flow_neutron_c: bool = False,
     delegate_to_npu=True,
 ) -> EdgeProgramManager:
-    _neutron_target_spec = NeutronTargetSpec(target)
+    _neutron_target_spec = NeutronTargetSpec(
+        target, use_new_flow_neutron_c=use_new_flow_neutron_c
+    )
     custom_delegation_options.use_new_flow_neutron_c = use_new_flow_neutron_c
     if get_quantizer_fn is None:
         get_quantizer_fn = partial(

--- a/backends/nxp/tests/ir/converter/node_converter/test_clamp_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_clamp_converter.py
@@ -6,27 +6,40 @@
 import numpy as np
 import pytest
 import torch
-
 from executorch.backends.nxp.backend.edge_program_converter import (
     EdgeProgramToIRConverter,
 )
-from executorch.backends.nxp.tests.executorch_pipeline import to_quantized_edge_program
+from executorch.backends.nxp.backend.ir.converter.builder.aten_model_builder_director import (
+    AtenModelBuilderDirector,
+)
+from executorch.backends.nxp.backend.ir.lib.tflite.BuiltinOperator import (
+    BuiltinOperator as Ops,
+)
+from executorch.backends.nxp.tests.executorch_pipeline import (
+    ModelInputSpec,
+    to_quantized_edge_program,
+)
 from executorch.backends.nxp.tests.executors import (
     convert_run_compare,
     graph_contains_any_of_ops,
 )
-from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.backends.nxp.tests.graph_verifier import DetailedGraphVerifier
+from executorch.backends.nxp.tests.model_output_comparator import (
+    NumericalStatsOutputComparator,
+)
+from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
+from executorch.backends.nxp.tests.ops_aliases import (
+    AddTensor,
+    Clamp,
+    ExecutorchDelegateCall,
+)
+from executorch.backends.nxp.tests.use_qat import *  # noqa: F403 F401
 
 
 @pytest.fixture(autouse=True)
 def reseed_model_per_test_run():
     torch.manual_seed(42)
     np.random.seed(23)
-
-
-# noinspection PyProtectedMember
-ExecutorchDelegateCall = torch.ops.higher_order.executorch_call_delegate
-Clamp = exir_ops.edge.aten.clamp.default
 
 
 class ClampModule(torch.nn.Module):
@@ -180,3 +193,138 @@ def test_convert_clamp__no_delegation__unsupported_bounds(min, max):
 
     # Make sure the `clamp` was NOT delegated.
     assert graph_contains_any_of_ops(delegated_ep.graph, [Clamp])
+
+
+class TestClampNewNeutronFlow:
+    @pytest.mark.parametrize(
+        "min, max",
+        [
+            pytest.param(-1, 2, id="min = -1, max = 2 (Max/Min)"),
+            pytest.param(None, 1, id="min = None, max = 1 (Max/Min)"),
+            pytest.param(1, None, id="min = 1, max = None (Max/Min)"),
+            pytest.param(0, 2, id="min = 0, max = 2 (Max/Min)"),
+            pytest.param(0, 1, id="min = 0, max = 1 (Relu0To1)"),
+            pytest.param(-1, 1, id="min = -1, max = 1 (ReluN1To1)"),
+            pytest.param(0, None, id="min = 0, max = None (Relu)"),
+            # Float bounds
+            pytest.param(-1.0, 2.0, id="min = -1.0, max = 2.0 (Max/Min)"),
+            pytest.param(None, 1.0, id="min = None, max = 1.0 (Max/Min)"),
+            pytest.param(1.0, None, id="min = 1.0, max = None (Max/Min)"),
+            pytest.param(1.0, float("inf"), id="min = 1.0, max = infinity (Max/Min)"),
+            pytest.param(-float("inf"), 1.0, id="min = infinity, max = 1.0 (Max/Min)"),
+            pytest.param(0.1, 0.5, id="min = 0.1, max = 0.5 (Max/Min)"),
+            pytest.param(0.0, 1.0, id="min = 0.0, max = 1.0 (Relu0To1)"),
+            pytest.param(-1.0, 1.0, id="min = -1.0, max = 1.0 (ReluN1To1)"),
+            pytest.param(0.0, None, id="min = 0, max = None (Relu)"),
+        ],
+    )
+    def test_convert_clamp__full_pipeline(self, mocker, min, max, use_qat):
+        input_shape = (2, 7, 2)  # Indivisible by num_macs
+        model = AddClampModule(min, max)
+
+        x_input_spec = ModelInputSpec(input_shape)
+        comparator = NumericalStatsOutputComparator()
+        graph_verifier = DetailedGraphVerifier(
+            mocker,
+            expected_delegated_ops={
+                AddTensor: 1,
+                Clamp: 1,
+            },
+            expected_non_delegated_ops={},
+        )
+
+        lower_run_compare(
+            model=model,
+            input_spec=[x_input_spec],
+            dlg_model_verifier=graph_verifier,
+            output_comparator=comparator,
+            use_new_flow_neutron_c=True,
+            use_qat=use_qat,
+        )
+
+    @pytest.mark.parametrize(
+        "min, max",
+        [
+            pytest.param(
+                float("inf"), float("inf"), id="min = inf, max = inf (invalid)"
+            ),
+            pytest.param(None, float("inf"), id="min = None, max = inf (invalid)"),
+            pytest.param(float("inf"), None, id="min = inf, max = None (invalid)"),
+        ],
+    )
+    def test_convert_clamp__invalid_bounds(self, min, max):
+        input_shape = (2, 7, 2)
+        model = ClampModule(min, max)
+
+        delegated_ep = to_quantized_edge_program(model, input_shape).exported_program()
+
+        # Make sure the `clamp` was NOT delegated.
+        assert graph_contains_any_of_ops(delegated_ep.graph, [Clamp])
+
+    # noinspection PyShadowingBuiltins
+    @pytest.mark.parametrize(
+        "min, max, expected_tflite_ops",
+        [
+            pytest.param(
+                0.1,
+                0.5,
+                [Ops.ADD, Ops.MAXIMUM, Ops.MINIMUM],
+                id="min = 0.1, max = 0.5 (Max/Min)",
+            ),
+            pytest.param(
+                0.0, 1.0, [Ops.ADD, Ops.RELU_0_TO_1], id="min = 0, max = 1 (Relu0To1)"
+            ),
+            pytest.param(
+                -1.0,
+                1.0,
+                [Ops.ADD, Ops.RELU_N1_TO_1],
+                id="min = -1, max = 1 (ReluN1To1)",
+            ),
+            pytest.param(
+                0.0, None, [Ops.ADD, Ops.RELU], id="min = 0, max = None (Relu)"
+            ),
+            pytest.param(
+                0.0,
+                float("inf"),
+                [Ops.ADD, Ops.RELU],
+                id="min = 0, max = infinity (Relu)",
+            ),
+        ],
+    )
+    def test_convert_clamp__relu_vs_maxmin(self, mocker, min, max, expected_tflite_ops):
+        input_shape = (23,)
+        model = AddClampModule(min, max)
+
+        converter_spy = mocker.spy(EdgeProgramToIRConverter, "convert_program")
+        tflite_spy = mocker.spy(AtenModelBuilderDirector, "finish")
+
+        delegated_ep = to_quantized_edge_program(
+            model,
+            input_shape,
+            use_new_flow_neutron_c=True,
+        ).exported_program()
+
+        # Make sure the `clamp` was delegated.
+        assert graph_contains_any_of_ops(delegated_ep.graph, [ExecutorchDelegateCall])
+        assert not graph_contains_any_of_ops(delegated_ep.graph, [Clamp])
+
+        intermediate_ep = converter_spy.call_args.args[1]
+        quant_node = list(intermediate_ep.graph.nodes)[-2]
+        dequant_node = list(intermediate_ep.graph.nodes)[-4]
+        tflite_internal_ops = [
+            op.builtin_code for op in tflite_spy.spy_return.operator_codes.vector
+        ]
+
+        assert graph_contains_any_of_ops(intermediate_ep.graph, [Clamp])
+        assert len(tflite_internal_ops) == len(expected_tflite_ops) + 1  # Transpose
+        assert all(op in tflite_internal_ops for op in expected_tflite_ops)
+
+        if len(expected_tflite_ops) == 3:
+            # Min/Max variant should have same input and output quantization
+            assert all(
+                q == dq for q, dq in zip(quant_node.args[1:], dequant_node.args[1:])
+            )
+        else:
+            assert not all(
+                q == dq for q, dq in zip(quant_node.args[1:], dequant_node.args[1:])
+            )

--- a/backends/nxp/tests/ops_aliases.py
+++ b/backends/nxp/tests/ops_aliases.py
@@ -16,6 +16,7 @@ AdaptiveAvgPool2D = exir_ops.edge.aten._adaptive_avg_pool2d.default
 AddTensor = exir_ops.edge.aten.add.Tensor
 AvgPool2D = exir_ops.edge.aten.avg_pool2d.default
 Bmm = exir_ops.edge.aten.bmm.default
+Clamp = exir_ops.edge.aten.clamp.default
 ConstantPadND = exir_ops.edge.aten.constant_pad_nd.default
 Convolution = exir_ops.edge.aten.convolution.default
 DequantizePerChannel = exir_ops.edge.quantized_decomposed.dequantize_per_channel.default

--- a/examples/nxp/aot_neutron_compile.py
+++ b/examples/nxp/aot_neutron_compile.py
@@ -12,7 +12,6 @@ from collections import defaultdict
 
 import executorch.extension.pybindings.portable_lib
 import executorch.kernels.quantized  # noqa F401
-
 import torch
 from executorch.backends.nxp.backend.neutron_target_spec import NeutronTargetSpec
 from executorch.backends.nxp.edge_passes.neutron_edge_pass_manager import (
@@ -253,7 +252,9 @@ if __name__ == "__main__":  # noqa C901
     if args.debug:
         logging.basicConfig(level=logging.DEBUG, format=FORMAT, force=True)
 
-    neutron_target_spec = NeutronTargetSpec(target=args.target)
+    neutron_target_spec = NeutronTargetSpec(
+        target=args.target, use_new_flow_neutron_c=args.use_new_flow_neutron_c
+    )
 
     # 1. pick model from one of the supported lists
     model, example_inputs, calibration_inputs = get_model_and_inputs_from_name(


### PR DESCRIPTION
### Summary
- Moves flag indicating use of the new Neutron C flow from `CustomCompileConfig` to `NeutronTargetSpec`
- Adds new Neutron C flow support for Clamp operator

### Test plan
New test cases for Clamp are introduced. The relocation of new flag is covered by already existing unit tests.


cc @robert-kalmar @JakeStevens @digantdesai @rascani