### PR TITLE
Add cortex_passes Buck target and fix quantizer dep

### DIFF
--- a/backends/cortex_m/passes/BUCK
+++ b/backends/cortex_m/passes/BUCK
@@ -26,6 +26,32 @@ fbcode_target(_kind = runtime.python_library,
 )
 
 fbcode_target(_kind = runtime.python_library,
+    name="cortex_passes",
+    srcs=[
+        "activation_fusion_pass.py",
+        "clamp_hardswish_pass.py",
+        "convert_to_cortex_m_pass.py",
+        "cortex_m_pass_manager.py",
+        "decompose_hardswish_pass.py",
+        "decompose_mean_pass.py",
+        "quantized_clamp_activation_pass.py",
+    ],
+    deps=[
+        "//caffe2:torch",
+        "//executorch/backends/arm/_passes:passes",
+        "//executorch/backends/cortex_m/ops:ops",
+        "//executorch/backends/cortex_m/passes:passes_utils",
+        "//executorch/backends/cortex_m/passes:replace_quant_nodes_pass",
+        "//executorch/backends/transforms:remove_getitem_op",
+        "//executorch/backends/transforms:replace_scalar_with_tensor",
+        "//executorch/exir:lib",
+        "//executorch/exir:pass_base",
+        "//executorch/exir:pass_manager",
+        "//executorch/exir/program:lib",
+    ],
+)
+
+fbcode_target(_kind = runtime.python_library,
     name="passes_utils",
     srcs=[
         "passes_utils.py",

--- a/backends/cortex_m/quantizer/TARGETS
+++ b/backends/cortex_m/quantizer/TARGETS
@@ -27,6 +27,7 @@ python_library(
         "//executorch/backends/arm/quantizer:quantization_annotator",
         "//executorch/backends/arm/quantizer:quantization_config",
         "//executorch/backends/cortex_m:quantizer_reporter",
+        "//executorch/backends/cortex_m/passes:cortex_passes",
         "//pytorch/ao:torchao",
         "fbsource//third-party/pypi/tabulate:tabulate",
     ],


### PR DESCRIPTION
Summary: Add a new `cortex_passes` Python library target in `backends/cortex_m/passes` containing the CortexMPassManager and its constituent passes (activation fusion, convert-to-cortex-m, decompose hardswish/mean, quantized clamp activation, clamp hardswish). These were previously not in any Buck target, making CortexMQuantizer unusable from Buck builds.

Differential Revision: D104841579


