### PR TITLE
Add executorch-ubuntu-24.04-gcc14 docker image

### DIFF
--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -84,6 +84,11 @@ case "${IMAGE_NAME}" in
     CUDA_VERSION=12.8
     SKIP_PYTORCH=yes
     ;;
+  executorch-ubuntu-24.04-gcc14)
+    LINTRUNNER=""
+    OS_VERSION=24.04
+    GCC_VERSION=14
+    ;;
   *)
     echo "Invalid image name ${IMAGE_NAME}"
     exit 1

--- a/.ci/docker/common/install_user.sh
+++ b/.ci/docker/common/install_user.sh
@@ -7,6 +7,11 @@
 
 set -ex
 
+# On Ubuntu 24.04, there is a `ubuntu` user with id=1000
+if id ubuntu >/dev/null && [[ "$(id -u ubuntu)" == 1000 ]]; then
+    sudo userdel --remove ubuntu;
+fi
+
 # Same as ec2-user
 echo "ci-user:x:1000:1000::/var/lib/ci-user:" >> /etc/passwd
 echo "ci-user:x:1000:" >> /etc/group

--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -41,7 +41,8 @@ jobs:
           executorch-ubuntu-22.04-zephyr-sdk,
           executorch-ubuntu-22.04-qnn-sdk,
           executorch-ubuntu-22.04-mediatek-sdk,
-          executorch-ubuntu-22.04-clang12-android
+          executorch-ubuntu-22.04-clang12-android,
+          executorch-ubuntu-24.04-gcc14,
         ]
         include:
           - docker-image-name: executorch-ubuntu-22.04-gcc11-aarch64


### PR DESCRIPTION
### Summary

Simply add a docker build image based on ubuntu 24.04 with gcc 14. It's necessary for XNNPACK on riscv64 to have a newer toolchain, to support the latest features of the hardware (vectorization with RVV).


cc @larryliu0820 @GregoryComer