### PR TITLE
Add Jinja2Cpp-based chat template formatter library (#19533)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -830,7 +830,7 @@ endif()
 
 if(EXECUTORCH_BUILD_EXTENSION_LLM)
   if(EXECUTORCH_BUILD_EXTENSION_LLM_RUNNER)
-    set(SUPPORT_REGEX_LOOKAHEAD ON)
+    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/extension/llm/chat_template)
     # llama/runner/CMakeLists.txt builds a shared library libllama_runner.so
     # that transitively depends on tokenizers. Need to build tokenizers with
     # -fPIC.

--- a/extension/llm/chat_template/BUCK
+++ b/extension/llm/chat_template/BUCK
@@ -1,0 +1,18 @@
+load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target", "non_fbcode_target")
+oncall("executorch")
+
+# Any targets that should be shared between fbcode and xplat must be defined in
+# targets.bzl. This file can contain fbcode-only targets.
+
+load(":targets.bzl", "define_common_targets")
+
+non_fbcode_target(_kind = define_common_targets,)
+
+# !!!! fbcode/executorch/extension/llm/chat_template/TARGETS was merged into this file, see https://fburl.com/workplace/xl8l9yuo for more info !!!!
+
+# Any targets that should be shared between fbcode and xplat must be defined in
+# targets.bzl. This file can contain fbcode-only targets.
+
+load(":targets.bzl", "define_common_targets")
+
+fbcode_target(_kind = define_common_targets,)

--- a/extension/llm/chat_template/BUCK
+++ b/extension/llm/chat_template/BUCK
@@ -10,9 +10,4 @@ non_fbcode_target(_kind = define_common_targets,)
 
 # !!!! fbcode/executorch/extension/llm/chat_template/TARGETS was merged into this file, see https://fburl.com/workplace/xl8l9yuo for more info !!!!
 
-# Any targets that should be shared between fbcode and xplat must be defined in
-# targets.bzl. This file can contain fbcode-only targets.
-
-load(":targets.bzl", "define_common_targets")
-
 fbcode_target(_kind = define_common_targets,)

--- a/extension/llm/chat_template/CMakeLists.txt
+++ b/extension/llm/chat_template/CMakeLists.txt
@@ -1,0 +1,103 @@
+if(NOT EXECUTORCH_BUILD_EXTENSION_LLM_RUNNER)
+  return()
+endif()
+
+include(FetchContent)
+cmake_policy(SET CMP0077 NEW)
+
+FetchContent_Declare(
+  jinja2cpp
+  GIT_REPOSITORY https://github.com/jinja2cpp/Jinja2Cpp.git
+  GIT_TAG 1.3.2
+  GIT_SHALLOW TRUE
+  GIT_SUBMODULES_RECURSE TRUE
+)
+
+set(JINJA2CPP_BUILD_TESTS
+    OFF
+    CACHE BOOL "" FORCE
+)
+set(JINJA2CPP_BUILD_SHARED
+    OFF
+    CACHE BOOL "" FORCE
+)
+set(JINJA2CPP_INSTALL
+    OFF
+    CACHE BOOL "" FORCE
+)
+# Enable PCRE2-based regex lookahead support in Jinja2Cpp. This must be set
+# BEFORE FetchContent_MakeAvailable(jinja2cpp) so it propagates to the Jinja2Cpp
+# configure step.
+set(SUPPORT_REGEX_LOOKAHEAD
+    ON
+    CACHE BOOL "" FORCE
+)
+
+FetchContent_MakeAvailable(jinja2cpp)
+if(NOT TARGET jinja2cpp)
+  message(FATAL_ERROR "Jinja2Cpp target not found after FetchContent.")
+endif()
+if(APPLE)
+  target_compile_options(jinja2cpp PRIVATE -Wno-shorten-64-to-32)
+endif()
+
+if(DEFINED jinja2cpp_SOURCE_DIR)
+  function(executorch_copy_nonstd_header dep_name target header_name dest_root)
+    set(_copied FALSE)
+    if(TARGET ${target})
+      get_target_property(_aliased ${target} ALIASED_TARGET)
+      if(_aliased)
+        set(_resolved_target ${_aliased})
+      else()
+        set(_resolved_target ${target})
+      endif()
+      get_target_property(
+        _include_dirs ${_resolved_target} INTERFACE_INCLUDE_DIRECTORIES
+      )
+      foreach(_dir IN LISTS _include_dirs)
+        if(EXISTS "${_dir}/nonstd/${header_name}")
+          file(MAKE_DIRECTORY "${dest_root}/nonstd")
+          file(COPY "${_dir}/nonstd/${header_name}"
+               DESTINATION "${dest_root}/nonstd"
+          )
+          set(_copied TRUE)
+          break()
+        endif()
+      endforeach()
+    endif()
+    if(NOT _copied)
+      set(_fallback_path
+          "${CMAKE_BINARY_DIR}/_deps/${dep_name}-src/include/nonstd/${header_name}"
+      )
+      if(EXISTS "${_fallback_path}")
+        file(MAKE_DIRECTORY "${dest_root}/nonstd")
+        file(COPY "${_fallback_path}" DESTINATION "${dest_root}/nonstd")
+      endif()
+    endif()
+  endfunction()
+
+  set(_jinja2cpp_nonstd_root "${jinja2cpp_SOURCE_DIR}/thirdparty/nonstd")
+  executorch_copy_nonstd_header(
+    expected-lite nonstd::expected-lite expected.hpp
+    "${_jinja2cpp_nonstd_root}/expected-lite/include"
+  )
+  executorch_copy_nonstd_header(
+    variant-lite nonstd::variant-lite variant.hpp
+    "${_jinja2cpp_nonstd_root}/variant-lite/include"
+  )
+  executorch_copy_nonstd_header(
+    optional-lite nonstd::optional-lite optional.hpp
+    "${_jinja2cpp_nonstd_root}/optional-lite/include"
+  )
+  executorch_copy_nonstd_header(
+    string-view-lite nonstd::string-view-lite string_view.hpp
+    "${_jinja2cpp_nonstd_root}/string-view-lite/include"
+  )
+endif()
+
+# Install the chat_templates.h header so that downstream consumers of the
+# installed ExecuTorch SDK can include
+# <executorch/extension/llm/chat_template/chat_templates.h>.
+install(FILES chat_templates.h
+        DESTINATION include/executorch/extension/llm/chat_template
+)

--- a/extension/llm/chat_template/chat_templates.h
+++ b/extension/llm/chat_template/chat_templates.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+namespace executorch::extension::llm {
+
+enum class ChatTemplateType {
+  None,
+  Llama3,
+  Llama32,
+  Gemma3,
+  Custom,
+};
+
+constexpr std::string_view kLlama3Template =
+    R"({{ bos_token }}{%- for message in messages -%}<|start_header_id|>{{ message.role }}<|end_header_id|>
+
+{{ message.content }}<|eot_id|>{%- endfor -%}{%- if add_generation_prompt -%}<|start_header_id|>assistant<|end_header_id|>
+
+{%- endif -%})";
+
+constexpr std::string_view kGemma3Template =
+    R"({{ bos_token }}{%- for message in messages -%}{%- if message.role == 'assistant' -%}<start_of_turn>model
+{%- else -%}<start_of_turn>{{ message.role }}
+{%- endif -%}{{ message.content }}<end_of_turn>{%- endfor -%}{%- if add_generation_prompt -%}<start_of_turn>model
+{%- endif -%})";
+
+inline const std::unordered_map<ChatTemplateType, std::string_view>&
+getEmbeddedTemplates() {
+  static const std::unordered_map<ChatTemplateType, std::string_view>
+      embedded_templates = {
+          {ChatTemplateType::Llama3, kLlama3Template},
+          {ChatTemplateType::Llama32, kLlama3Template},
+          {ChatTemplateType::Gemma3, kGemma3Template},
+      };
+  return embedded_templates;
+}
+
+struct ModelTokens {
+  std::string bos_token;
+  std::string eos_token;
+  std::vector<std::string> stop_tokens;
+};
+
+inline const std::unordered_map<ChatTemplateType, ModelTokens>&
+getModelTokens() {
+  static const std::unordered_map<ChatTemplateType, ModelTokens> model_tokens =
+      {
+          {ChatTemplateType::Llama3,
+           {"<|begin_of_text|>",
+            "<|eot_id|>",
+            {"<|eot_id|>", "<|end_of_text|>"}}},
+          {ChatTemplateType::Llama32,
+           {"<|begin_of_text|>",
+            "<|eot_id|>",
+            {"<|eot_id|>", "<|end_of_text|>"}}},
+          {ChatTemplateType::Gemma3,
+           {"<bos>", "<end_of_turn>", {"<end_of_turn>", "<eos>"}}},
+      };
+  return model_tokens;
+}
+
+} // namespace executorch::extension::llm

--- a/extension/llm/chat_template/targets.bzl
+++ b/extension/llm/chat_template/targets.bzl
@@ -1,0 +1,16 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+
+def define_common_targets():
+    runtime.cxx_library(
+        name = "chat_templates",
+        exported_headers = [
+            "chat_templates.h",
+        ],
+        visibility = ["PUBLIC"],
+    )

--- a/extension/llm/runner/CMakeLists.txt
+++ b/extension/llm/runner/CMakeLists.txt
@@ -31,6 +31,15 @@ executorch_load_build_variables()
 # build llm runner library
 list(TRANSFORM _extension_llm_runner__srcs PREPEND "${EXECUTORCH_ROOT}/")
 
+# The Jinja chat formatter requires jinja2cpp. When jinja2cpp is not built (for
+# example a runner build that does not add the chat_template subdirectory), drop
+# the source so extension_llm_runner has no dependency on jinja2cpp at all.
+if(NOT TARGET jinja2cpp)
+  list(FILTER _extension_llm_runner__srcs EXCLUDE REGEX
+       "extension/llm/runner/jinja_chat_formatter\\.cpp$"
+  )
+endif()
+
 add_library(extension_llm_runner STATIC ${_extension_llm_runner__srcs})
 
 # include sampler
@@ -54,11 +63,20 @@ endif()
 list(APPEND runner_deps kernels_util_all_deps)
 
 target_link_libraries(extension_llm_runner PUBLIC ${runner_deps})
-target_link_libraries(extension_llm_runner PRIVATE $<LINK_ONLY:jinja2cpp>)
-target_include_directories(
-  extension_llm_runner
-  PRIVATE $<TARGET_PROPERTY:jinja2cpp,INTERFACE_INCLUDE_DIRECTORIES>
-)
+# jinja2cpp is a private, build-tree-only dependency of the Jinja chat formatter.
+# It is a FetchContent static library that is not installed, so it must NOT leak
+# into the installed ExecuTorchTargets export -- otherwise downstream
+# find_package(executorch) consumers fail to link with `-ljinja2cpp`.
+# BUILD_INTERFACE keeps the dependency local to this build tree.
+if(TARGET jinja2cpp)
+  target_link_libraries(
+    extension_llm_runner PRIVATE $<BUILD_INTERFACE:jinja2cpp>
+  )
+  target_include_directories(
+    extension_llm_runner
+    PRIVATE $<TARGET_PROPERTY:jinja2cpp,INTERFACE_INCLUDE_DIRECTORIES>
+  )
+endif()
 set_target_properties(
   extension_llm_runner PROPERTIES POSITION_INDEPENDENT_CODE ON
 )

--- a/extension/llm/runner/CMakeLists.txt
+++ b/extension/llm/runner/CMakeLists.txt
@@ -63,10 +63,10 @@ endif()
 list(APPEND runner_deps kernels_util_all_deps)
 
 target_link_libraries(extension_llm_runner PUBLIC ${runner_deps})
-# jinja2cpp is a private, build-tree-only dependency of the Jinja chat formatter.
-# It is a FetchContent static library that is not installed, so it must NOT leak
-# into the installed ExecuTorchTargets export -- otherwise downstream
-# find_package(executorch) consumers fail to link with `-ljinja2cpp`.
+# jinja2cpp is a private, build-tree-only dependency of the Jinja chat
+# formatter. It is a FetchContent static library that is not installed, so it
+# must NOT leak into the installed ExecuTorchTargets export -- otherwise
+# downstream find_package(executorch) consumers fail to link with `-ljinja2cpp`.
 # BUILD_INTERFACE keeps the dependency local to this build tree.
 if(TARGET jinja2cpp)
   target_link_libraries(

--- a/extension/llm/runner/CMakeLists.txt
+++ b/extension/llm/runner/CMakeLists.txt
@@ -54,6 +54,11 @@ endif()
 list(APPEND runner_deps kernels_util_all_deps)
 
 target_link_libraries(extension_llm_runner PUBLIC ${runner_deps})
+target_link_libraries(extension_llm_runner PRIVATE $<LINK_ONLY:jinja2cpp>)
+target_include_directories(
+  extension_llm_runner
+  PRIVATE $<TARGET_PROPERTY:jinja2cpp,INTERFACE_INCLUDE_DIRECTORIES>
+)
 set_target_properties(
   extension_llm_runner PROPERTIES POSITION_INDEPENDENT_CODE ON
 )

--- a/extension/llm/runner/chat_types.h
+++ b/extension/llm/runner/chat_types.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace executorch::extension::llm {
+
+struct ChatMessage {
+  std::string role;
+  std::string content;
+};
+
+struct ChatConversation {
+  std::vector<ChatMessage> messages;
+  std::string bos_token;
+  std::string eos_token;
+  bool add_generation_prompt = true;
+  // Injected as the `date_string` template variable. Defaults to the fixed
+  // date used by HuggingFace/vLLM template fixtures so output stays
+  // deterministic; callers may override it.
+  std::string date_string = "26 Jul 2024";
+};
+
+} // namespace executorch::extension::llm

--- a/extension/llm/runner/jinja_chat_formatter.cpp
+++ b/extension/llm/runner/jinja_chat_formatter.cpp
@@ -1,0 +1,394 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/extension/llm/runner/jinja_chat_formatter.h>
+
+#include <jinja2cpp/generic_list.h>
+#include <jinja2cpp/generic_list_iterator.h>
+#include <jinja2cpp/reflected_value.h>
+#include <jinja2cpp/template.h>
+#include <jinja2cpp/user_callable.h>
+#include <jinja2cpp/value.h>
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <cstdint>
+#include <fstream>
+#include <list>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
+#include <unordered_map>
+
+namespace executorch::extension::llm {
+namespace {
+
+std::string readFileToString(const std::string& path) {
+  std::ifstream file(path);
+  if (!file) {
+    throw std::runtime_error("Failed to open template file: " + path);
+  }
+  std::ostringstream buffer;
+  buffer << file.rdbuf();
+  std::string contents = buffer.str();
+  if (contents.empty()) {
+    throw std::runtime_error("Template file is empty: " + path);
+  }
+  return contents;
+}
+
+bool templateIncludesBos(
+    const std::string& template_str,
+    const ModelTokens& model_tokens) {
+  if (!model_tokens.bos_token.empty() &&
+      template_str.find(model_tokens.bos_token) != std::string::npos) {
+    return true;
+  }
+  return template_str.find("bos_token") != std::string::npos;
+}
+
+std::string normalizeTemplate(std::string input) {
+  // These replacements normalize vLLM/HuggingFace Jinja templates so they
+  // compile/render correctly with Jinja2Cpp, which has stricter parser
+  // semantics than Python Jinja2.
+  //
+  // IMPORTANT: "not tools is none" in Python Jinja means "tools is not none"
+  // (truthy when tools is defined and non-null), so we map it to a simple
+  // truthy check on `tools`. Mapping to "not tools" was a bug that would
+  // skip tool blocks for non-empty tools lists.
+  // Keep longer `tools is ... none` patterns before the shorter
+  // `tools is none` patterns to avoid partial replacements.
+  //
+  // `messages[1:]` is rewritten to a render-time call so each slice operates
+  // on the current value of `messages`. Templates reassign `messages`
+  // (e.g. `{%- set messages = messages[1:] %}`) and slice it again later, so a
+  // precomputed tail of the original list would be wrong for the second slice.
+  constexpr std::array<std::pair<std::string_view, std::string_view>, 10>
+      replacements = {{
+          {"tools = none", "tools = []"},
+          {"tools = None", "tools = []"},
+          {"tools is not none", "tools"},
+          {"tools is not None", "tools"},
+          {"not tools is none", "tools"},
+          {"not tools is None", "tools"},
+          {"tools is none", "not tools"},
+          {"tools is None", "not tools"},
+          {"messages[1:]", "_executorch_messages_tail(messages)"},
+          {"{ \"output\": message.content } | tojson",
+           "message.tool_output | tojson"},
+      }};
+  // Handle special case that can't be constexpr due to escape sequence
+  const std::pair<std::string, std::string> gemmaReplacement = {
+      "{{'<start_of_turn>model\\n'}}", "{{ '<start_of_turn>model\\n' }}"};
+  for (const auto& replacement : replacements) {
+    size_t pos = 0;
+    while ((pos = input.find(replacement.first, pos)) != std::string::npos) {
+      input.replace(pos, replacement.first.size(), replacement.second);
+      pos += replacement.second.size();
+    }
+  }
+  // Apply the gemma replacement separately
+  size_t pos = 0;
+  while ((pos = input.find(gemmaReplacement.first, pos)) != std::string::npos) {
+    input.replace(pos, gemmaReplacement.first.size(), gemmaReplacement.second);
+    pos += gemmaReplacement.second.size();
+  }
+  return input;
+}
+
+ChatTemplateType detectTemplateType(const std::string& template_str) {
+  if (template_str.find("<start_of_turn>") != std::string::npos) {
+    return ChatTemplateType::Gemma3;
+  }
+  if (template_str.find("<|start_header_id|>") != std::string::npos) {
+    return ChatTemplateType::Llama3;
+  }
+  return ChatTemplateType::Custom;
+}
+
+std::string toLower(std::string value) {
+  std::transform(
+      value.begin(), value.end(), value.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+      });
+  return value;
+}
+
+// Materializes a GenericList into an owning ValuesList WITHOUT going through
+// jinja2::detail::GenericListIterator. Infer's USE_AFTER_LIFETIME flags that
+// iterator's begin()/operator++ (its m_current caches the address of a
+// temporary Value), so we read the list via its accessor instead: random-access
+// lists by index, others by single-pass enumeration. GetItemByIndex() and
+// GetCurrent() both return owning Values by value.
+jinja2::ValuesList collectGenericList(const jinja2::GenericList& list) {
+  jinja2::ValuesList items;
+  const auto* accessor = list.GetAccessor();
+  if (accessor == nullptr) {
+    return items;
+  }
+  const auto* indexer = accessor->GetIndexer();
+  const auto size = list.GetSize();
+  if (indexer != nullptr && size) {
+    items.reserve(*size);
+    for (size_t i = 0; i < *size; ++i) {
+      items.push_back(indexer->GetItemByIndex(static_cast<int64_t>(i)));
+    }
+    return items;
+  }
+  auto enumerator = accessor->CreateEnumerator();
+  while (enumerator && enumerator->MoveNext()) {
+    items.push_back(enumerator->GetCurrent());
+  }
+  return items;
+}
+
+// Copies a value into render-lifetime storage so it stays valid after the
+// caller's list is freed. Jinja2Cpp represents strings as non-owning
+// string_views, and reassigning a template variable (e.g.
+// `set messages = messages[1:]`) frees the list that backs them. We copy every
+// string's bytes into `string_store` (whose std::list nodes keep stable
+// addresses for the whole render) and hand back string_views into that store;
+// maps/lists are rebuilt as owning containers whose leaves are store-backed.
+jinja2::Value toStableValue(
+    const jinja2::Value& value,
+    std::list<std::string>& string_store) {
+  if (const auto* str = value.getPtr<std::string>()) {
+    string_store.push_back(*str);
+    return jinja2::Value(nonstd::string_view(string_store.back()));
+  }
+  if (const auto* view = value.getPtr<nonstd::string_view>()) {
+    string_store.emplace_back(view->begin(), view->end());
+    return jinja2::Value(nonstd::string_view(string_store.back()));
+  }
+  // getPtr<GenericMap> is checked before isMap()/asMap() so asMap() is only used
+  // on an owning (non-Generic) map.
+  if (const auto* generic_map = value.getPtr<jinja2::GenericMap>()) {
+    jinja2::ValuesMap owned;
+    for (const auto& key : generic_map->GetKeys()) {
+      owned[key] = toStableValue(generic_map->GetValueByName(key), string_store);
+    }
+    return jinja2::Value(std::move(owned));
+  }
+  if (value.isMap()) {
+    jinja2::ValuesMap owned;
+    for (const auto& entry : value.asMap()) {
+      owned[entry.first] = toStableValue(entry.second, string_store);
+    }
+    return jinja2::Value(std::move(owned));
+  }
+  if (const auto* generic_list = value.getPtr<jinja2::GenericList>()) {
+    jinja2::ValuesList owned;
+    for (const auto& item : collectGenericList(*generic_list)) {
+      owned.push_back(toStableValue(item, string_store));
+    }
+    return jinja2::Value(std::move(owned));
+  }
+  if (value.isList()) {
+    jinja2::ValuesList owned;
+    for (const auto& item : value.asList()) {
+      owned.push_back(toStableValue(item, string_store));
+    }
+    return jinja2::Value(std::move(owned));
+  }
+  // Scalars (bool / int64 / double / empty) are already self-owning.
+  return value;
+}
+
+// Render-time equivalent of the Python slice `messages[1:]`: returns all
+// elements after the first. Used because Jinja2Cpp cannot parse slice syntax
+// and the slice must reflect the current value of `messages` at call time.
+// Jinja2Cpp may pass the list as either a GenericList or a ValuesList, so both
+// representations are handled without using the throwing asList() accessor on
+// the wrong variant. Each element is materialized into render-lifetime storage
+// (see toStableValue) so the slice stays valid after `messages` is reassigned.
+jinja2::ValuesList messagesTail(
+    const jinja2::Value& messages,
+    std::list<std::string>& string_store) {
+  jinja2::ValuesList tail;
+  if (const auto* generic = messages.getPtr<jinja2::GenericList>()) {
+    const jinja2::ValuesList items = collectGenericList(*generic);
+    for (size_t i = 1; i < items.size(); ++i) {
+      tail.push_back(toStableValue(items[i], string_store));
+    }
+  } else if (messages.isList()) {
+    const auto& values = messages.asList();
+    for (size_t i = 1; i < values.size(); ++i) {
+      tail.push_back(toStableValue(values[i], string_store));
+    }
+  }
+  return tail;
+}
+
+} // namespace
+
+} // namespace executorch::extension::llm
+
+namespace jinja2 {
+
+// NOLINTBEGIN(facebook-hte-MisplacedTemplateSpecialization,facebook-hte-ShadowingClass)
+// This template specialization must be in the jinja2 namespace for the library
+// to find it via ADL during template instantiation.
+template <>
+struct TypeReflection<executorch::extension::llm::ChatMessage>
+    : TypeReflected<executorch::extension::llm::ChatMessage> {
+  static auto& GetAccessors() {
+    static std::unordered_map<std::string, FieldAccessor> accessors = {
+        {"role",
+         [](const executorch::extension::llm::ChatMessage& msg) {
+           return jinja2::Reflect(msg.role);
+         }},
+        {"content",
+         [](const executorch::extension::llm::ChatMessage& msg) {
+           return jinja2::Reflect(msg.content);
+         }},
+        {"tool_output",
+         [](const executorch::extension::llm::ChatMessage& msg) {
+           jinja2::ValuesMap output;
+           output["output"] = msg.content;
+           return output;
+         }},
+    };
+    return accessors;
+  }
+};
+// NOLINTEND(facebook-hte-MisplacedTemplateSpecialization,facebook-hte-ShadowingClass)
+
+} // namespace jinja2
+
+namespace executorch::extension::llm {
+
+JinjaChatFormatter::JinjaChatFormatter(
+    const std::string& template_str,
+    ChatTemplateType type)
+    : template_str_(template_str), type_(type) {
+  const auto& model_tokens = ::executorch::extension::llm::getModelTokens();
+  auto tokens_it = model_tokens.find(type_);
+  if (tokens_it != model_tokens.end()) {
+    model_tokens_ = tokens_it->second;
+  }
+  includes_bos_ = templateIncludesBos(template_str_, model_tokens_);
+  const std::string normalized_template = normalizeTemplate(template_str_);
+  compiled_template_ = std::make_unique<jinja2::Template>();
+  auto load_result = compiled_template_->Load(normalized_template);
+  if (!load_result) {
+    throw std::runtime_error(
+        "Failed to parse chat template: " + load_result.error().ToString());
+  }
+}
+
+JinjaChatFormatter::~JinjaChatFormatter() = default;
+
+std::unique_ptr<JinjaChatFormatter> JinjaChatFormatter::fromTemplate(
+    ChatTemplateType type) {
+  const auto& embedded_templates = getEmbeddedTemplates();
+  auto it = embedded_templates.find(type);
+  if (it == embedded_templates.end()) {
+    throw std::runtime_error("Unsupported embedded chat template type.");
+  }
+  return std::unique_ptr<JinjaChatFormatter>(
+      new JinjaChatFormatter(std::string(it->second), type));
+}
+
+std::unique_ptr<JinjaChatFormatter> JinjaChatFormatter::fromString(
+    const std::string& template_str) {
+  const ChatTemplateType inferred_type = detectTemplateType(template_str);
+  return std::unique_ptr<JinjaChatFormatter>(
+      new JinjaChatFormatter(template_str, inferred_type));
+}
+
+std::unique_ptr<JinjaChatFormatter> JinjaChatFormatter::fromFile(
+    const std::string& path) {
+  return fromString(readFileToString(path));
+}
+
+std::string JinjaChatFormatter::format(
+    const std::string& prompt,
+    const std::string& system_prompt) const {
+  ChatConversation conversation;
+  if (!system_prompt.empty()) {
+    conversation.messages.push_back({"system", system_prompt});
+  }
+  conversation.messages.push_back({"user", prompt});
+  conversation.bos_token = model_tokens_.bos_token;
+  conversation.eos_token = model_tokens_.eos_token;
+  conversation.add_generation_prompt = true;
+  return formatConversation(conversation);
+}
+
+std::string JinjaChatFormatter::formatConversation(
+    const ChatConversation& conversation) const {
+  jinja2::ValuesMap params;
+  // Owning, render-lifetime storage for strings produced while slicing
+  // `messages`. Jinja2Cpp keeps non-owning string_views and frees the list that
+  // backs them when a template reassigns `messages`; keeping the bytes here
+  // (stable std::list nodes that outlive RenderAsString) keeps those views
+  // valid. shared_ptr lets the callable hold a reference even if Jinja2Cpp
+  // copies it internally.
+  auto message_string_store = std::make_shared<std::list<std::string>>();
+  params["messages"] = jinja2::ValuesList();
+  for (const auto& msg : conversation.messages) {
+    params["messages"].asList().push_back(jinja2::Reflect(msg));
+  }
+  // Backs the `messages[1:]` normalization so each slice reflects the current
+  // `messages` value rather than a precomputed snapshot.
+  //
+  // We register this via the raw jinja2::UserCallable struct rather than
+  // jinja2::MakeCallable because MakeCallable cannot wrap a function whose
+  // parameter is `const jinja2::Value&`: its argument-promotion path produces
+  // an ArgPromoter<T> that is not convertible to jinja2::Value, so the wrapper
+  // fails to instantiate. The UserCallable form hands us the raw Value via
+  // UserCallableParams::operator[], which is exactly what messagesTail needs.
+  jinja2::UserCallable messages_tail_callable;
+  messages_tail_callable.callable =
+      [message_string_store](
+          const jinja2::UserCallableParams& callable_params) -> jinja2::Value {
+    return jinja2::Value(
+        messagesTail(callable_params["messages"], *message_string_store));
+  };
+  messages_tail_callable.argsInfo = {jinja2::ArgInfo{"messages", true}};
+  params["_executorch_messages_tail"] = std::move(messages_tail_callable);
+  params["bos_token"] = conversation.bos_token;
+  params["eos_token"] = conversation.eos_token;
+  params["add_generation_prompt"] = conversation.add_generation_prompt;
+  // Provide vLLM/HuggingFace-style defaults that templates often reference.
+  // Templates that don't use these will simply ignore them.
+  params["tools"] = jinja2::ValuesList();
+  params["tool_choice"] = jinja2::Value();
+  params["date_string"] = conversation.date_string;
+  params["chat_template_kwargs"] = jinja2::ValuesMap();
+
+  auto rendered = compiled_template_->RenderAsString(params);
+  if (!rendered) {
+    throw std::runtime_error(
+        "Failed to render chat template: " + rendered.error().ToString());
+  }
+  return rendered.value();
+}
+
+ChatTemplateType parseChatTemplateType(const std::string& type_str) {
+  const std::string lower = toLower(type_str);
+  if (lower == "none") {
+    return ChatTemplateType::None;
+  }
+  if (lower == "llama3") {
+    return ChatTemplateType::Llama3;
+  }
+  if (lower == "llama3.2" || lower == "llama32" || lower == "llama3_2") {
+    return ChatTemplateType::Llama32;
+  }
+  if (lower == "gemma3") {
+    return ChatTemplateType::Gemma3;
+  }
+  if (lower == "custom" || lower == "jinja") {
+    return ChatTemplateType::Custom;
+  }
+  return ChatTemplateType::None;
+}
+
+} // namespace executorch::extension::llm

--- a/extension/llm/runner/jinja_chat_formatter.cpp
+++ b/extension/llm/runner/jinja_chat_formatter.cpp
@@ -166,12 +166,13 @@ jinja2::Value toStableValue(
     string_store.emplace_back(view->begin(), view->end());
     return jinja2::Value(nonstd::string_view(string_store.back()));
   }
-  // getPtr<GenericMap> is checked before isMap()/asMap() so asMap() is only used
-  // on an owning (non-Generic) map.
+  // getPtr<GenericMap> is checked before isMap()/asMap() so asMap() is only
+  // used on an owning (non-Generic) map.
   if (const auto* generic_map = value.getPtr<jinja2::GenericMap>()) {
     jinja2::ValuesMap owned;
     for (const auto& key : generic_map->GetKeys()) {
-      owned[key] = toStableValue(generic_map->GetValueByName(key), string_store);
+      owned[key] =
+          toStableValue(generic_map->GetValueByName(key), string_store);
     }
     return jinja2::Value(std::move(owned));
   }

--- a/extension/llm/runner/jinja_chat_formatter.cpp
+++ b/extension/llm/runner/jinja_chat_formatter.cpp
@@ -359,6 +359,11 @@ std::string JinjaChatFormatter::formatConversation(
   params["add_generation_prompt"] = conversation.add_generation_prompt;
   // Provide vLLM/HuggingFace-style defaults that templates often reference.
   // Templates that don't use these will simply ignore them.
+  // `tools` is intentionally an empty list (not null): Jinja2Cpp, like Python,
+  // treats an empty list as falsy, so `{% if tools %}` and the normalized
+  // `tools is not none` -> `tools` checks render the "no tools" path when none
+  // are supplied. See normalizeTemplate() and the UniversalJinjaToolsAware
+  // test.
   params["tools"] = jinja2::ValuesList();
   params["tool_choice"] = jinja2::Value();
   params["date_string"] = conversation.date_string;

--- a/extension/llm/runner/jinja_chat_formatter.h
+++ b/extension/llm/runner/jinja_chat_formatter.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <executorch/extension/llm/chat_template/chat_templates.h>
+#include <executorch/extension/llm/runner/chat_types.h>
+
+#include <memory>
+#include <string>
+
+namespace jinja2 {
+class Template;
+}
+
+namespace executorch::extension::llm {
+
+class JinjaChatFormatter {
+ public:
+  static std::unique_ptr<JinjaChatFormatter> fromTemplate(
+      ChatTemplateType type);
+  // fromString/fromFile infer only the model family from template syntax.
+  // Llama3 and Llama3.2 share template markers and token defaults today.
+  static std::unique_ptr<JinjaChatFormatter> fromString(
+      const std::string& template_str);
+  static std::unique_ptr<JinjaChatFormatter> fromFile(const std::string& path);
+
+  ~JinjaChatFormatter();
+
+  std::string format(
+      const std::string& prompt,
+      const std::string& system_prompt = "") const;
+  // Custom templates whose tokens cannot be inferred should use
+  // formatConversation() so the caller can provide bos/eos tokens explicitly.
+  std::string formatConversation(const ChatConversation& conversation) const;
+
+  bool includesBos() const {
+    return includes_bos_;
+  }
+
+  const ModelTokens& getModelTokens() const {
+    return model_tokens_;
+  }
+
+ private:
+  JinjaChatFormatter(const std::string& template_str, ChatTemplateType type);
+
+  std::string template_str_;
+  ChatTemplateType type_;
+  ModelTokens model_tokens_;
+  bool includes_bos_ = false;
+  std::unique_ptr<jinja2::Template> compiled_template_;
+};
+
+ChatTemplateType parseChatTemplateType(const std::string& type_str);
+
+} // namespace executorch::extension::llm

--- a/extension/llm/runner/targets.bzl
+++ b/extension/llm/runner/targets.bzl
@@ -112,6 +112,8 @@ def define_common_targets():
         runtime.cxx_library(
             name = "runner_lib" + aten_suffix,
             exported_headers = [
+                "chat_types.h",
+                "jinja_chat_formatter.h",
                 "text_llm_runner.h",
                 "llm_runner_helper.h",
                 "constants.h",
@@ -120,7 +122,13 @@ def define_common_targets():
                 "text_llm_runner.cpp",
                 "llm_runner_helper.cpp",
                 "multimodal_runner.cpp",
-            ],
+            ] + select({
+                # jinja2cpp does not compile under Apple's libc++, so the Jinja
+                # chat formatter is excluded on iOS/macOS.
+                "DEFAULT": ["jinja_chat_formatter.cpp"],
+                "ovr_config//os:iphoneos": [],
+                "ovr_config//os:macos": [],
+            }),
             visibility = ["PUBLIC"],
             compiler_flags = [
                 "-Wno-missing-prototypes",
@@ -139,5 +147,14 @@ def define_common_targets():
                 "//pytorch/tokenizers:sentencepiece",
                 "//pytorch/tokenizers:tekken",
                 "//pytorch/tokenizers:tiktoken",
-            ],
+            ] + select({
+                # chat_templates + jinja2cpp are excluded on Apple because
+                # jinja2cpp does not compile under libc++.
+                "DEFAULT": [
+                    "//executorch/extension/llm/chat_template:chat_templates",
+                    "@fbsource//third-party/jinja2cpp:jinja2cpp",
+                ],
+                "ovr_config//os:iphoneos": [],
+                "ovr_config//os:macos": [],
+            }),
         )

--- a/extension/llm/runner/test/BUCK
+++ b/extension/llm/runner/test/BUCK
@@ -10,32 +10,21 @@ oncall("executorch")
 # targets.bzl. This file can contain fbcode-only targets.
 
 load(":targets.bzl", "define_common_targets")
-
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
 non_fbcode_target(_kind = define_common_targets,)
 
-# !!!! fbcode/executorch/extension/llm/runner/test/TARGETS was merged into this file, see https://fburl.com/workplace/xl8l9yuo for more info !!!!
-
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
-
-# Any targets that should be shared between fbcode and xplat must be defined in
-# targets.bzl. This file can contain fbcode-only targets.
-
-load(":targets.bzl", "define_common_targets")
-load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
-
 fbcode_target(_kind = define_common_targets,)
 
+# fbcode-only test that requires access to fbcode//executorch/test/models
 fbcode_target(_kind = runtime.cxx_test,
     name = "test_text_decoder_runner",
     srcs = ["test_text_decoder_runner.cpp"],
     deps = [
-        "//executorch/extension/llm/runner:runner_lib",
         "//executorch/extension/llm/runner/io_manager:io_manager",
+        "//executorch/extension/llm/runner:text_decoder_runner",
+        "//executorch/extension/module:module",
+        "//executorch/extension/tensor:tensor",
         "//executorch/kernels/portable:generated_lib",
         "//executorch/runtime/core/exec_aten/testing_util:tensor_util",
     ],
@@ -43,5 +32,5 @@ fbcode_target(_kind = runtime.cxx_test,
         "KVCACHE_CACHE_POS": "$(location fbcode//executorch/test/models:exported_programs[ModuleKVCacheCachePos.pte])",
         "KVCACHE_INPUT_POS": "$(location fbcode//executorch/test/models:exported_programs[ModuleKVCacheInputPos.pte])",
         "NO_KVCACHE": "$(location fbcode//executorch/test/models:exported_programs[ModuleNoKVCache.pte])",
-    }
+    },
 )

--- a/extension/llm/runner/test/CMakeLists.txt
+++ b/extension/llm/runner/test/CMakeLists.txt
@@ -19,6 +19,7 @@ include(${EXECUTORCH_ROOT}/tools/cmake/Test.cmake)
 
 set(_test_srcs
     test_generation_config.cpp
+    test_jinja_chat_formatter.cpp
     test_text_llm_runner.cpp
     test_text_prefiller.cpp
     test_text_decoder_runner.cpp

--- a/extension/llm/runner/test/CMakeLists.txt
+++ b/extension/llm/runner/test/CMakeLists.txt
@@ -28,6 +28,14 @@ set(_test_srcs
     test_wav_loader.cpp
 )
 
+# test_jinja_chat_formatter.cpp exercises JinjaChatFormatter, which is only
+# compiled into extension_llm_runner when jinja2cpp is available (see
+# ../CMakeLists.txt). Drop the test source when jinja2cpp is not built so the
+# test binary does not fail to link with undefined JinjaChatFormatter symbols.
+if(NOT TARGET jinja2cpp)
+  list(FILTER _test_srcs EXCLUDE REGEX "test_jinja_chat_formatter\\.cpp$")
+endif()
+
 # Add LSan stub for Apple platforms
 if(APPLE)
   list(APPEND _test_srcs lsan_stub.cpp)

--- a/extension/llm/runner/test/targets.bzl
+++ b/extension/llm/runner/test/targets.bzl
@@ -18,6 +18,18 @@ def define_common_targets():
     )
 
     runtime.cxx_test(
+        name = "test_jinja_chat_formatter",
+        srcs = ["test_jinja_chat_formatter.cpp"],
+        deps = [
+            "//executorch/extension/llm/runner:runner_lib",
+        ],
+        # runner_lib drops jinja2cpp/chat_templates on Apple (jinja2cpp does not
+        # compile under libc++), so this test cannot build there. CXX/Android
+        # only; fbcode builds it via its own path.
+        platforms = ["CXX", "ANDROID"],
+    )
+
+    runtime.cxx_test(
         name = "test_text_llm_runner",
         srcs = ["test_text_llm_runner.cpp"],
         deps = [

--- a/extension/llm/runner/test/test_jinja_chat_formatter.cpp
+++ b/extension/llm/runner/test/test_jinja_chat_formatter.cpp
@@ -1,0 +1,417 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/extension/llm/runner/jinja_chat_formatter.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+using executorch::extension::llm::ChatConversation;
+using executorch::extension::llm::ChatMessage;
+using executorch::extension::llm::ChatTemplateType;
+using executorch::extension::llm::JinjaChatFormatter;
+using executorch::extension::llm::parseChatTemplateType;
+using testing::HasSubstr;
+
+TEST(JinjaChatFormatter, Llama3SingleMessage) {
+  auto formatter = JinjaChatFormatter::fromTemplate(ChatTemplateType::Llama3);
+  const std::string prompt = "Test prompt";
+  const std::string system_prompt = "You are a helpful assistant.";
+  // Note: The Jinja template uses {%- ... -%} which strips whitespace,
+  // so the output has \n\n after each <|end_header_id|> and content,
+  // but no trailing \n\n at the end due to the {%- endif -%} stripping.
+  const std::string expected =
+      "<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n\n" +
+      system_prompt + "<|eot_id|><|start_header_id|>user<|end_header_id|>\n\n" +
+      prompt + "<|eot_id|><|start_header_id|>assistant<|end_header_id|>";
+
+  EXPECT_EQ(formatter->format(prompt, system_prompt), expected);
+}
+
+TEST(JinjaChatFormatter, Gemma3SingleMessage) {
+  auto formatter = JinjaChatFormatter::fromTemplate(ChatTemplateType::Gemma3);
+  const std::string result = formatter->format("Hello!");
+
+  EXPECT_THAT(result, HasSubstr("<bos>"));
+  EXPECT_THAT(result, HasSubstr("<start_of_turn>user"));
+  EXPECT_THAT(result, HasSubstr("Hello!"));
+  EXPECT_THAT(result, HasSubstr("<start_of_turn>model"));
+}
+
+TEST(JinjaChatFormatter, Llama3WithoutSystemPrompt) {
+  auto formatter = JinjaChatFormatter::fromTemplate(ChatTemplateType::Llama3);
+  const std::string result = formatter->format("Hello!");
+
+  EXPECT_THAT(result, HasSubstr("<|begin_of_text|>"));
+  EXPECT_THAT(result, HasSubstr("<|start_header_id|>user<|end_header_id|>"));
+  EXPECT_THAT(result, HasSubstr("Hello!"));
+  EXPECT_THAT(
+      result, HasSubstr("<|start_header_id|>assistant<|end_header_id|>"));
+  // Should not contain system header when no system prompt
+  EXPECT_THAT(result, ::testing::Not(HasSubstr("<|start_header_id|>system")));
+}
+
+TEST(JinjaChatFormatter, Llama3IncludesBos) {
+  auto formatter = JinjaChatFormatter::fromTemplate(ChatTemplateType::Llama3);
+  EXPECT_TRUE(formatter->includesBos());
+}
+
+TEST(JinjaChatFormatter, Gemma3IncludesBos) {
+  auto formatter = JinjaChatFormatter::fromTemplate(ChatTemplateType::Gemma3);
+  EXPECT_TRUE(formatter->includesBos());
+}
+
+TEST(JinjaChatFormatter, Llama3ModelTokens) {
+  auto formatter = JinjaChatFormatter::fromTemplate(ChatTemplateType::Llama3);
+  const auto& tokens = formatter->getModelTokens();
+
+  EXPECT_EQ(tokens.bos_token, "<|begin_of_text|>");
+  EXPECT_EQ(tokens.eos_token, "<|eot_id|>");
+  EXPECT_EQ(tokens.stop_tokens.size(), 2);
+}
+
+TEST(JinjaChatFormatter, Gemma3ModelTokens) {
+  auto formatter = JinjaChatFormatter::fromTemplate(ChatTemplateType::Gemma3);
+  const auto& tokens = formatter->getModelTokens();
+
+  EXPECT_EQ(tokens.bos_token, "<bos>");
+  EXPECT_EQ(tokens.eos_token, "<end_of_turn>");
+  EXPECT_EQ(tokens.stop_tokens.size(), 2);
+}
+
+TEST(JinjaChatFormatter, FormatConversationMultiTurn) {
+  auto formatter = JinjaChatFormatter::fromTemplate(ChatTemplateType::Llama3);
+
+  ChatConversation conversation;
+  conversation.bos_token = "<|begin_of_text|>";
+  conversation.eos_token = "<|eot_id|>";
+  conversation.add_generation_prompt = true;
+  conversation.messages = {
+      {"user", "Hello"},
+      {"assistant", "Hi there!"},
+      {"user", "How are you?"},
+  };
+
+  const std::string result = formatter->formatConversation(conversation);
+
+  EXPECT_THAT(result, HasSubstr("Hello"));
+  EXPECT_THAT(result, HasSubstr("Hi there!"));
+  EXPECT_THAT(result, HasSubstr("How are you?"));
+  EXPECT_THAT(
+      result, HasSubstr("<|start_header_id|>assistant<|end_header_id|>"));
+}
+
+TEST(JinjaChatFormatter, FromStringLlama3Template) {
+  const std::string llama_template =
+      "{{ bos_token }}<|start_header_id|>user<|end_header_id|>\n\n"
+      "{{ messages[0].content }}<|eot_id|>";
+
+  auto formatter = JinjaChatFormatter::fromString(llama_template);
+
+  // Should detect Llama3 type from the template content
+  const std::string result = formatter->format("Test");
+  EXPECT_THAT(result, HasSubstr("Test"));
+}
+
+TEST(JinjaChatFormatter, FromStringGemma3Template) {
+  const std::string gemma_template =
+      "{{ bos_token }}<start_of_turn>user\n"
+      "{{ messages[0].content }}<end_of_turn>";
+
+  auto formatter = JinjaChatFormatter::fromString(gemma_template);
+
+  const std::string result = formatter->format("Test");
+  EXPECT_THAT(result, HasSubstr("Test"));
+}
+
+TEST(JinjaChatFormatter, UnsupportedTemplateTypeThrows) {
+  EXPECT_THROW(
+      JinjaChatFormatter::fromTemplate(ChatTemplateType::None),
+      std::runtime_error);
+}
+
+// Tests for parseChatTemplateType
+TEST(ParseChatTemplateType, ParseNone) {
+  EXPECT_EQ(parseChatTemplateType("none"), ChatTemplateType::None);
+  EXPECT_EQ(parseChatTemplateType("None"), ChatTemplateType::None);
+  EXPECT_EQ(parseChatTemplateType("NONE"), ChatTemplateType::None);
+}
+
+TEST(ParseChatTemplateType, ParseLlama3) {
+  EXPECT_EQ(parseChatTemplateType("llama3"), ChatTemplateType::Llama3);
+  EXPECT_EQ(parseChatTemplateType("LLAMA3"), ChatTemplateType::Llama3);
+  EXPECT_EQ(parseChatTemplateType("Llama3"), ChatTemplateType::Llama3);
+}
+
+TEST(ParseChatTemplateType, ParseLlama32Variants) {
+  EXPECT_EQ(parseChatTemplateType("llama3.2"), ChatTemplateType::Llama32);
+  EXPECT_EQ(parseChatTemplateType("llama32"), ChatTemplateType::Llama32);
+  EXPECT_EQ(parseChatTemplateType("llama3_2"), ChatTemplateType::Llama32);
+  EXPECT_EQ(parseChatTemplateType("LLAMA3.2"), ChatTemplateType::Llama32);
+}
+
+TEST(ParseChatTemplateType, ParseGemma3) {
+  EXPECT_EQ(parseChatTemplateType("gemma3"), ChatTemplateType::Gemma3);
+  EXPECT_EQ(parseChatTemplateType("GEMMA3"), ChatTemplateType::Gemma3);
+  EXPECT_EQ(parseChatTemplateType("Gemma3"), ChatTemplateType::Gemma3);
+}
+
+TEST(ParseChatTemplateType, ParseCustom) {
+  EXPECT_EQ(parseChatTemplateType("custom"), ChatTemplateType::Custom);
+  EXPECT_EQ(parseChatTemplateType("jinja"), ChatTemplateType::Custom);
+  EXPECT_EQ(parseChatTemplateType("CUSTOM"), ChatTemplateType::Custom);
+}
+
+TEST(ParseChatTemplateType, ParseUnknownReturnsNone) {
+  EXPECT_EQ(parseChatTemplateType("unknown"), ChatTemplateType::None);
+  EXPECT_EQ(parseChatTemplateType(""), ChatTemplateType::None);
+  EXPECT_EQ(parseChatTemplateType("invalid"), ChatTemplateType::None);
+}
+
+TEST(JinjaChatFormatter, Llama32SingleMessage) {
+  auto formatter = JinjaChatFormatter::fromTemplate(ChatTemplateType::Llama32);
+  const std::string result = formatter->format("Hello!");
+
+  // Llama32 uses the same template as Llama3
+  EXPECT_THAT(result, HasSubstr("<|begin_of_text|>"));
+  EXPECT_THAT(result, HasSubstr("<|start_header_id|>user<|end_header_id|>"));
+  EXPECT_THAT(result, HasSubstr("Hello!"));
+  EXPECT_THAT(
+      result, HasSubstr("<|start_header_id|>assistant<|end_header_id|>"));
+}
+
+TEST(JinjaChatFormatter, Llama32IncludesBos) {
+  auto formatter = JinjaChatFormatter::fromTemplate(ChatTemplateType::Llama32);
+  EXPECT_TRUE(formatter->includesBos());
+}
+
+TEST(JinjaChatFormatter, Llama32ModelTokens) {
+  auto formatter = JinjaChatFormatter::fromTemplate(ChatTemplateType::Llama32);
+  const auto& tokens = formatter->getModelTokens();
+
+  EXPECT_EQ(tokens.bos_token, "<|begin_of_text|>");
+  EXPECT_EQ(tokens.eos_token, "<|eot_id|>");
+  EXPECT_EQ(tokens.stop_tokens.size(), 2);
+}
+
+TEST(JinjaChatFormatter, UniversalJinjaGenericTemplate) {
+  const std::string generic_template =
+      "{{ bos_token }}"
+      "{%- for message in messages -%}"
+      "<|{{ message.role }}|>\n{{ message.content }}<|end|>\n"
+      "{%- endfor -%}"
+      "{%- if add_generation_prompt -%}<|assistant|>\n{%- endif -%}";
+
+  auto formatter = JinjaChatFormatter::fromString(generic_template);
+  ChatConversation conv;
+  conv.bos_token = "<s>";
+  conv.add_generation_prompt = true;
+  conv.messages.push_back(ChatMessage{"user", "Hi there"});
+
+  const std::string result = formatter->formatConversation(conv);
+
+  EXPECT_THAT(result, HasSubstr("<s>"));
+  EXPECT_THAT(result, HasSubstr("<|user|>"));
+  EXPECT_THAT(result, HasSubstr("Hi there"));
+  EXPECT_THAT(result, HasSubstr("<|assistant|>"));
+}
+
+TEST(JinjaChatFormatter, UniversalJinjaToolsAwareTemplate) {
+  const std::string tools_template =
+      "{%- if tools is not none -%}"
+      "tools_present"
+      "{%- else -%}"
+      "no_tools"
+      "{%- endif -%}";
+
+  auto formatter = JinjaChatFormatter::fromString(tools_template);
+  ChatConversation conv;
+  conv.add_generation_prompt = false;
+
+  EXPECT_EQ(formatter->formatConversation(conv), "no_tools");
+}
+
+TEST(JinjaChatFormatter, UniversalJinjaNormalizedNotToolsIsNone) {
+  const std::string template_str =
+      "{%- if not tools is none -%}defined{%- else -%}none{%- endif -%}";
+
+  auto formatter = JinjaChatFormatter::fromString(template_str);
+  ChatConversation conv;
+  conv.add_generation_prompt = false;
+
+  EXPECT_EQ(formatter->formatConversation(conv), "none");
+}
+
+TEST(JinjaChatFormatter, UniversalJinjaToolOutputObjectLiteral) {
+  const std::string template_str =
+      R"({%- for message in messages -%}{{ { "output": message.content } | tojson }}{%- endfor -%})";
+
+  auto formatter = JinjaChatFormatter::fromString(template_str);
+  ChatConversation conv;
+  conv.add_generation_prompt = false;
+  conv.messages.push_back(ChatMessage{"tool", "done"});
+
+  EXPECT_EQ(formatter->formatConversation(conv), R"({"output":"done"})");
+}
+
+TEST(JinjaChatFormatter, VllmLlama32PythonicToolTemplate) {
+  // Mirrors vLLM's examples/tool_chat_template_llama3.2_pythonic.jinja.
+  const std::string template_str = R"({{- bos_token }}
+{%- if custom_tools is defined %}
+    {%- set tools = custom_tools %}
+{%- endif %}
+{%- if not tools_in_user_message is defined %}
+    {%- set tools_in_user_message = false %}
+{%- endif %}
+{%- if not date_string is defined %}
+    {%- if strftime_now is defined %}
+        {%- set date_string = strftime_now("%d %b %Y") %}
+    {%- else %}
+        {%- set date_string = "26 Jul 2024" %}
+    {%- endif %}
+{%- endif %}
+{%- if not tools is defined %}
+    {%- set tools = none %}
+{%- endif %}
+
+{#- This block extracts the system message, so we can slot it into the right place. #}
+{%- if messages[0]['role'] == 'system' %}
+    {%- set system_message = messages[0]['content']|trim %}
+    {%- set messages = messages[1:] %}
+{%- else %}
+    {%- set system_message = "You are a helpful assistant with tool calling capabilities. Only reply with a tool call if the function exists in the library provided by the user. If it doesn't exist, just reply directly in natural language. When you receive a tool call response, use the output to format an answer to the original user question." %}
+{%- endif %}
+
+{#- System message #}
+{{- "<|start_header_id|>system<|end_header_id|>\n\n" }}
+{%- if tools is not none %}
+    {{- "Environment: ipython\n" }}
+{%- endif %}
+{{- "Cutting Knowledge Date: December 2023\n" }}
+{{- "Today Date: " + date_string + "\n\n" }}
+{%- if tools is not none and not tools_in_user_message %}
+    {{- "You have access to the following functions. To call functions, please respond with a python list of the calls. " }}
+    {{- 'Respond in the format [func_name1(params_name1=params_value1, params_name2=params_value2...), func_name2(params)] ' }}
+    {{- "Do not use variables.\n\n" }}
+    {%- for t in tools %}
+        {{- t | tojson(indent=4) }}
+        {{- "\n\n" }}
+    {%- endfor %}
+{%- endif %}
+{{- system_message }}
+{{- "<|eot_id|>" }}
+
+{#- Custom tools are passed in a user message with some extra guidance #}
+{%- if tools_in_user_message and not tools is none %}
+    {#- Extract the first user message so we can plug it in here #}
+    {%- if messages | length != 0 %}
+        {%- set first_user_message = messages[0]['content']|trim %}
+        {%- set messages = messages[1:] %}
+    {%- else %}
+        {{- raise_exception("Cannot put tools in the first user message when there's no first user message!") }}
+    {%- endif %}
+    {{- '<|start_header_id|>user<|end_header_id|>\n\n' -}}
+    {{- "Given the following functions, please respond with a python list for function calls " }}
+    {{- "with their proper arguments to best answer the given prompt.\n\n" }}
+    {{- 'Respond in the format [func_name1(params_name1=params_value1, params_name2=params_value2...), func_name2(params)] ' }}
+    {{- "Do not use variables.\n\n" }}
+    {%- for t in tools %}
+        {{- t | tojson(indent=4) }}
+        {{- "\n\n" }}
+    {%- endfor %}
+    {{- first_user_message + "<|eot_id|>"}}
+{%- endif %}
+
+{%- for message in messages %}
+    {%- if not (message.role == 'ipython' or message.role == 'tool' or 'tool_calls' in message) %}
+        {{- '<|start_header_id|>' + message['role'] + '<|end_header_id|>\n\n'+ message['content'] | trim + '<|eot_id|>' }}
+    {%- elif 'tool_calls' in message %}
+        {{- '<|start_header_id|>assistant<|end_header_id|>\n\n[' -}}
+        {%- for tool_call in message.tool_calls %}
+            {%- if tool_call.function is defined %}
+                {%- set tool_call = tool_call.function %}
+            {%- endif %}
+            {{- tool_call.name + '(' -}}
+            {%- for param in tool_call.arguments %}
+                {{- param + '=' -}}
+                {{- "%s" | format(tool_call.arguments[param]) -}}
+                {% if not loop.last %}, {% endif %}
+            {%- endfor %}
+            {{- ')' -}}
+            {% if not loop.last %}, {% endif %}
+        {%- endfor %}
+        {{- ']<|eot_id|>' -}}
+    {%- elif message.role == "tool" or message.role == "ipython" %}
+        {{- "<|start_header_id|>ipython<|end_header_id|>\n\n" }}
+        {%- if message.content is mapping %}
+            {{- message.content | tojson }}
+        {%- else %}
+            {{- { "output": message.content } | tojson }}
+        {%- endif %}
+        {{- "<|eot_id|>" }}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|start_header_id|>assistant<|end_header_id|>\n\n' }}
+{%- endif %}
+)";
+
+  auto formatter = JinjaChatFormatter::fromString(template_str);
+  const std::string result = formatter->format("Hello!");
+
+  EXPECT_THAT(result, HasSubstr("<|begin_of_text|>"));
+  EXPECT_THAT(result, HasSubstr("<|start_header_id|>system<|end_header_id|>"));
+  EXPECT_THAT(result, HasSubstr("Today Date: 26 Jul 2024"));
+  EXPECT_THAT(result, HasSubstr("<|start_header_id|>user<|end_header_id|>"));
+  EXPECT_THAT(result, HasSubstr("Hello!"));
+  EXPECT_THAT(
+      result, HasSubstr("<|start_header_id|>assistant<|end_header_id|>"));
+}
+
+// `messages[1:]` must reflect the current `messages` value, not a precomputed
+// snapshot of the original list. Templates trim the system message and later
+// slice again; reusing the original tail would re-emit the first user message.
+TEST(JinjaChatFormatter, RepeatedMessageTailSlicesUseCurrentMessages) {
+  const std::string template_str =
+      "{%- if messages[0].role == 'system' -%}"
+      "{%- set messages = messages[1:] -%}"
+      "{%- endif -%}"
+      "{%- set first_user_message = messages[0].content -%}"
+      "{%- set messages = messages[1:] -%}"
+      "first={{ first_user_message }};"
+      "{%- for message in messages -%}"
+      "{{ message.role }}:{{ message.content }};"
+      "{%- endfor -%}";
+
+  auto formatter = JinjaChatFormatter::fromString(template_str);
+  ChatConversation conv;
+  conv.add_generation_prompt = false;
+  conv.messages = {
+      {"system", "system prompt"},
+      {"user", "first user"},
+      {"user", "second user"},
+  };
+
+  EXPECT_EQ(
+      formatter->formatConversation(conv),
+      "first=first user;user:second user;");
+}
+
+TEST(JinjaChatFormatter, DateStringIsOverridable) {
+  const std::string template_str = "{{ date_string }}";
+
+  auto formatter = JinjaChatFormatter::fromString(template_str);
+
+  ChatConversation default_conv;
+  default_conv.add_generation_prompt = false;
+  EXPECT_EQ(formatter->formatConversation(default_conv), "26 Jul 2024");
+
+  ChatConversation override_conv;
+  override_conv.add_generation_prompt = false;
+  override_conv.date_string = "01 Jan 2030";
+  EXPECT_EQ(formatter->formatConversation(override_conv), "01 Jan 2030");
+}

--- a/shim_et/xplat/executorch/build/build_variables.bzl
+++ b/shim_et/xplat/executorch/build/build_variables.bzl
@@ -359,6 +359,7 @@ EXTENSION_RUNNER_UTIL_SRCS = [
 ]
 
 EXTENSION_LLM_RUNNER_SRCS = [
+    "extension/llm/runner/jinja_chat_formatter.cpp",
     "extension/llm/runner/llm_runner_helper.cpp",
     "extension/llm/runner/multimodal_prefiller.cpp",
     "extension/llm/runner/multimodal_runner.cpp",


### PR DESCRIPTION
Summary:
Foundation PR for the chat-template support stack split out of https://github.com/pytorch/executorch/issues/16987 per reviewer request from kirklandsign. This PR adds the Jinja2Cpp-based `JinjaChatFormatter`, supporting chat-types, embedded Llama3 / Llama3.2 / Gemma3 templates, build glue (CMake/Buck), and a focused C++ unit-test suite.

This PR is **reviewable in isolation** — it has no behavior change for any existing runner; downstream PRs (B/C/D) plug it in.

## Stack overview

| PR | Subject |
|---|---|
| **1/4 (this PR)** | Library + tests |
| 2/4 | TextLLMRunner echo-gated special-token filter + EOS merge |
| 3/4 | Python bindings + Python LlamaRunner integration |
| 4/4 | llama_main CLI flags + chat_formatter wrapper + universal Jinja docs |

## What this PR adds

- **`extension/llm/chat_template/{chat_templates.h, BUCK, CMakeLists.txt, targets.bzl}`** — embedded Llama3 / Llama3.2 / Gemma3 templates and the `ChatTemplateType` enum + `ModelTokens`. The CMake file `FetchContent`s Jinja2Cpp 1.3.2, with `SUPPORT_REGEX_LOOKAHEAD` set **before** `FetchContent_MakeAvailable` so it propagates correctly, plus header staging for `nonstd` headers that some Jinja2Cpp installations omit. Installs `chat_templates.h` so SDK consumers can include it.
- **`extension/llm/runner/{chat_types.h, jinja_chat_formatter.{h,cpp}}`** — the **Universal Jinja chat formatter** that supports any HuggingFace / vLLM chat template, not just the embedded ones. Loadable via `fromTemplate` (built-in), `fromString` (any string), or `fromFile` (any `.jinja` file). `formatConversation` injects vLLM/HuggingFace-standard params (`tools=[]`, `tool_choice=None`, `date_string`, `chat_template_kwargs`) so any template that references those variables renders correctly.
- `normalizeTemplate` handles vLLM/HF template quirks for Jinja2Cpp: notably, `not tools is none` maps to `tools` (truthy check), preserving the intent of `tools is not none` for empty-list defaults.
- **`extension/llm/runner/{CMakeLists.txt, targets.bzl}`** — link `extension_llm_runner` against `jinja2cpp` (PRIVATE) and define `EXECUTORCH_USE_JINJA2CPP`.
- **`extension/llm/runner/test/test_jinja_chat_formatter.cpp`** + test build files — unit tests covering Llama3 / Llama3.2 / Gemma3 embedded templates, `parseChatTemplateType` (case-insensitive), and **three universal-Jinja regression tests**:
  - generic HuggingFace-style template (proves it's not Llama-specific)
  - tools-aware template (validates the `tools=[]` default)
  - `not tools is none` normalization regression test
- **`CMakeLists.txt`** — adds `add_subdirectory(extension/llm/chat_template)` guarded by `EXECUTORCH_BUILD_EXTENSION_LLM_RUNNER`.
- **`shim_et/xplat/executorch/build/build_variables.bzl`** — adds `jinja_chat_formatter.cpp` to the runner sources.

## Universal Jinja support

Any HuggingFace / vLLM-style Jinja template works:

```cpp
// From a template file (HuggingFace tokenizer_config.json, vLLM examples)
auto formatter = JinjaChatFormatter::fromFile("path/to/template.jinja");

// From a string
auto formatter = JinjaChatFormatter::fromString(template_str);

// Built-in shortcuts
auto formatter = JinjaChatFormatter::fromTemplate(ChatTemplateType::Llama3);
```

## Notes

- **No behavior change** for existing TextLLMRunner / MultimodalRunner users: the formatter is opt-in, only invoked when downstream code calls it.
- **Sample vLLM templates are NOT checked in** (per reviewer feedback metascroy). Documentation in the follow-up CLI PR (4/4) points users to vLLM's `examples/` directory and HuggingFace `tokenizer_config.json` files.

## `messages[1:]` slicing

Jinja2Cpp cannot parse Python-style slice syntax, so templates that do `{% set messages = messages[1:] %}` are normalized to a `_executorch_messages_tail(...)` call registered through Jinja2Cpp's `UserCallable`. Because Jinja2Cpp represents strings as non-owning `string_view`s, `formatConversation` materializes the sliced messages into a render-lifetime owning store, so the values stay valid across repeated `messages[1:]` reassignments.


Test Plan:
- [x] Build with `cmake --workflow llm-release`
- [x] Build with `make llama-cpu`
- [x] Run unit tests: `extension/llm/runner/test/test_jinja_chat_formatter`
- [x] Verify embedded templates render correctly for Llama3 / Llama3.2 / Gemma3
- [x] Verify universal Jinja support with HuggingFace tokenizer_config.json templates

## Original PR

Splitting https://github.com/pytorch/executorch/issues/16987 into 4 reviewable PRs.

cc kirklandsign larryliu0820 metascroy lucylq mergennachin


## Internal build & test (Buck / ASAN)

- [x] `buck2 build fbcode//executorch/extension/llm/runner:runner_lib` — builds clean
- [x] `buck2 test fbcode//executorch/extension/llm/runner/test:test_jinja_chat_formatter` — 27/27 pass under ASAN (embedded Llama3 / Llama3.2 / Gemma3 templates, the universal-Jinja regression tests, and the repeated `messages[1:]` slice lifetime test)

Differential Revision: D106817172

Pulled By: seyeong-han


