### PR TITLE
[llm][3/4] Python bindings for JinjaChatFormatter + LlamaRunner integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,6 @@ include(${PROJECT_SOURCE_DIR}/tools/cmake/Codegen.cmake)
 include(${PROJECT_SOURCE_DIR}/tools/cmake/Utils.cmake)
 include(CMakeDependentOption)
 include(ExternalProject)
-include(FetchContent)
 include(GNUInstallDirs)
 
 if(NOT CMAKE_CXX_STANDARD)
@@ -409,14 +408,6 @@ set(_common_include_directories
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/executorch/runtime/core/portable_type/c10>
 )
-
-if(TARGET jinja2cpp)
-  install(
-    TARGETS jinja2cpp
-    EXPORT ExecuTorchTargets
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  )
-endif()
 
 #
 # The `_<target>_srcs` lists are defined by executorch_load_build_variables.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,7 @@ include(${PROJECT_SOURCE_DIR}/tools/cmake/Codegen.cmake)
 include(${PROJECT_SOURCE_DIR}/tools/cmake/Utils.cmake)
 include(CMakeDependentOption)
 include(ExternalProject)
+include(FetchContent)
 include(GNUInstallDirs)
 
 if(NOT CMAKE_CXX_STANDARD)
@@ -408,6 +409,14 @@ set(_common_include_directories
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/executorch/runtime/core/portable_type/c10>
 )
+
+if(TARGET jinja2cpp)
+  install(
+    TARGETS jinja2cpp
+    EXPORT ExecuTorchTargets
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  )
+endif()
 
 #
 # The `_<target>_srcs` lists are defined by executorch_load_build_variables.
@@ -806,7 +815,7 @@ endif()
 
 if(EXECUTORCH_BUILD_EXTENSION_LLM)
   if(EXECUTORCH_BUILD_EXTENSION_LLM_RUNNER)
-    set(SUPPORT_REGEX_LOOKAHEAD ON)
+    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/extension/llm/chat_template)
     # llama/runner/CMakeLists.txt builds a shared library libllama_runner.so
     # that transitively depends on tokenizers. Need to build tokenizers with
     # -fPIC.

--- a/examples/models/llama/runner/eager.py
+++ b/examples/models/llama/runner/eager.py
@@ -83,6 +83,20 @@ def build_args_parser() -> argparse.ArgumentParser:
     )
 
     parser.add_argument(
+        "--system_prompt",
+        type=str,
+        default="",
+        help="System prompt for chat formatting (optional).",
+    )
+
+    parser.add_argument(
+        "--chat_template_file",
+        type=str,
+        default="",
+        help="Path to a custom Jinja2 chat template file for chat mode.",
+    )
+
+    parser.add_argument(
         "--tokenizer_config_path",
         type=str,
         default=None,
@@ -104,6 +118,8 @@ def execute_runner(runner_class: Type[LlamaRunner]) -> None:
     temperature = args.temperature
     show_tokens = args.show_tokens
     chat_mode = args.chat
+    system_prompt = args.system_prompt
+    chat_template_file = args.chat_template_file
     tokenizer_config_path = args.tokenizer_config_path
     use_attention_sink = args.use_attention_sink
 
@@ -113,6 +129,8 @@ def execute_runner(runner_class: Type[LlamaRunner]) -> None:
             llm_config=llm_config,
             tokenizer_config_path=tokenizer_config_path,
             use_attention_sink=use_attention_sink,
+            system_prompt=system_prompt,
+            chat_template_file=chat_template_file or None,
         )
 
         generated_tokens = (

--- a/examples/models/llama/runner/generation.py
+++ b/examples/models/llama/runner/generation.py
@@ -9,7 +9,6 @@ from abc import ABC, abstractmethod
 from typing import List, Optional
 
 import torch
-
 from pytorch_tokenizers import get_tokenizer
 
 
@@ -56,6 +55,9 @@ class LlamaRunner(ABC):
         max_batch_size: int,
         use_kv_cache: bool,
         vocab_size: int,
+        chat_format: str = "none",
+        system_prompt: str = "",
+        chat_template_file: Optional[str] = None,
         device: str = "cpu",
     ):
         """
@@ -74,6 +76,10 @@ class LlamaRunner(ABC):
         self.use_kv_cache = use_kv_cache
         self.tokenizer = get_tokenizer(tokenizer_path, tokenizer_config_path)
         self.device = device
+        self.chat_format = chat_format
+        self.system_prompt = system_prompt
+        self.chat_template_file = chat_template_file
+        self._chat_formatter = None
         # For some models like qwen, mismatch is acceptable: https://github.com/QwenLM/Qwen2.5/issues/466#issuecomment-2146759706
         if vocab_size != self.tokenizer.n_words:
             print(
@@ -207,9 +213,14 @@ class LlamaRunner(ABC):
         prompt = input("Me: ")
         while prompt and prompt != exit_prompt:
             print("LLM: ", end="", flush=True)
-            prompt_tokens = self.tokenizer.encode(
-                self._format_prompt(prompt), bos=True, eos=False
+            formatter = self._get_chat_formatter()
+            formatted_prompt = (
+                formatter.format(prompt, self.system_prompt)
+                if formatter is not None
+                else prompt
             )
+            bos = not (formatter is not None and formatter.includes_bos())
+            prompt_tokens = self.tokenizer.encode(formatted_prompt, bos=bos, eos=False)
             generated_tokens = self.generate(
                 prompt_tokens=pre_stop_token + prompt_tokens,
                 max_seq_len=max_seq_len,
@@ -227,8 +238,44 @@ class LlamaRunner(ABC):
         return tokens
 
     def _format_prompt(self, prompt: str) -> str:
-        return f"""<|begin_of_text|><|start_header_id|>system<|end_header_id|>
+        formatter = self._get_chat_formatter()
+        if formatter is None:
+            return prompt
+        return formatter.format(prompt, self.system_prompt)
 
-You are a helpful assistant<|eot_id|><|start_header_id|>user<|end_header_id|>
+    def _resolve_template_type(self, chat_template_type) -> Optional["object"]:
+        normalized = (self.chat_format or "").lower()
+        if normalized in ("", "none"):
+            return None
+        if normalized == "llama3":
+            return chat_template_type.Llama3
+        if normalized in ("llama3.2", "llama32", "llama3_2"):
+            return chat_template_type.Llama32
+        if normalized == "gemma3":
+            return chat_template_type.Gemma3
+        return None
 
-{prompt}<|eot_id|><|start_header_id|>assistant<|end_header_id|>"""
+    def _get_chat_formatter(self):
+        if self._chat_formatter is not None:
+            return self._chat_formatter
+        try:
+            from executorch.extension.llm.runner import (
+                ChatTemplateType,
+                JinjaChatFormatter,
+            )
+        except ImportError as exc:
+            raise RuntimeError(
+                "Jinja chat templates require ExecuTorch pybindings. "
+                "Build with EXECUTORCH_BUILD_PYBIND=ON."
+            ) from exc
+
+        if self.chat_template_file:
+            self._chat_formatter = JinjaChatFormatter.from_file(self.chat_template_file)
+            return self._chat_formatter
+
+        template_type = self._resolve_template_type(ChatTemplateType)
+        if template_type is None:
+            return None
+
+        self._chat_formatter = JinjaChatFormatter.from_template(template_type)
+        return self._chat_formatter

--- a/extension/llm/chat_template/BUCK
+++ b/extension/llm/chat_template/BUCK
@@ -1,0 +1,18 @@
+load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target", "non_fbcode_target")
+oncall("executorch")
+
+# Any targets that should be shared between fbcode and xplat must be defined in
+# targets.bzl. This file can contain fbcode-only targets.
+
+load(":targets.bzl", "define_common_targets")
+
+non_fbcode_target(_kind = define_common_targets,)
+
+# !!!! fbcode/executorch/extension/llm/chat_template/TARGETS was merged into this file, see https://fburl.com/workplace/xl8l9yuo for more info !!!!
+
+# Any targets that should be shared between fbcode and xplat must be defined in
+# targets.bzl. This file can contain fbcode-only targets.
+
+load(":targets.bzl", "define_common_targets")
+
+fbcode_target(_kind = define_common_targets,)

--- a/extension/llm/chat_template/CMakeLists.txt
+++ b/extension/llm/chat_template/CMakeLists.txt
@@ -14,31 +14,30 @@ FetchContent_Declare(
 
 set(JINJA2CPP_BUILD_TESTS
     OFF
-    CACHE BOOL ""
-          FORCE
+    CACHE BOOL "" FORCE
 )
 set(JINJA2CPP_BUILD_SHARED
     OFF
-    CACHE BOOL ""
-          FORCE
+    CACHE BOOL "" FORCE
 )
 set(JINJA2CPP_INSTALL
     OFF
-    CACHE BOOL ""
-          FORCE
+    CACHE BOOL "" FORCE
 )
 # Enable PCRE2-based regex lookahead support in Jinja2Cpp. This must be set
-# BEFORE FetchContent_MakeAvailable(jinja2cpp) so it propagates to the
-# Jinja2Cpp configure step.
+# BEFORE FetchContent_MakeAvailable(jinja2cpp) so it propagates to the Jinja2Cpp
+# configure step.
 set(SUPPORT_REGEX_LOOKAHEAD
     ON
-    CACHE BOOL ""
-          FORCE
+    CACHE BOOL "" FORCE
 )
 
 FetchContent_MakeAvailable(jinja2cpp)
 if(NOT TARGET jinja2cpp)
   message(FATAL_ERROR "Jinja2Cpp target not found after FetchContent.")
+endif()
+if(APPLE)
+  target_compile_options(jinja2cpp PRIVATE -Wno-shorten-64-to-32)
 endif()
 
 if(DEFINED jinja2cpp_SOURCE_DIR)
@@ -57,9 +56,8 @@ if(DEFINED jinja2cpp_SOURCE_DIR)
       foreach(_dir IN LISTS _include_dirs)
         if(EXISTS "${_dir}/nonstd/${header_name}")
           file(MAKE_DIRECTORY "${dest_root}/nonstd")
-          file(
-            COPY "${_dir}/nonstd/${header_name}"
-            DESTINATION "${dest_root}/nonstd"
+          file(COPY "${_dir}/nonstd/${header_name}"
+               DESTINATION "${dest_root}/nonstd"
           )
           set(_copied TRUE)
           break()
@@ -67,9 +65,8 @@ if(DEFINED jinja2cpp_SOURCE_DIR)
       endforeach()
     endif()
     if(NOT _copied)
-      set(
-        _fallback_path
-        "${CMAKE_BINARY_DIR}/_deps/${dep_name}-src/include/nonstd/${header_name}"
+      set(_fallback_path
+          "${CMAKE_BINARY_DIR}/_deps/${dep_name}-src/include/nonstd/${header_name}"
       )
       if(EXISTS "${_fallback_path}")
         file(MAKE_DIRECTORY "${dest_root}/nonstd")
@@ -78,31 +75,21 @@ if(DEFINED jinja2cpp_SOURCE_DIR)
     endif()
   endfunction()
 
-  set(_jinja2cpp_nonstd_root
-      "${jinja2cpp_SOURCE_DIR}/thirdparty/nonstd"
-  )
+  set(_jinja2cpp_nonstd_root "${jinja2cpp_SOURCE_DIR}/thirdparty/nonstd")
   executorch_copy_nonstd_header(
-    expected-lite
-    nonstd::expected-lite
-    expected.hpp
+    expected-lite nonstd::expected-lite expected.hpp
     "${_jinja2cpp_nonstd_root}/expected-lite/include"
   )
   executorch_copy_nonstd_header(
-    variant-lite
-    nonstd::variant-lite
-    variant.hpp
+    variant-lite nonstd::variant-lite variant.hpp
     "${_jinja2cpp_nonstd_root}/variant-lite/include"
   )
   executorch_copy_nonstd_header(
-    optional-lite
-    nonstd::optional-lite
-    optional.hpp
+    optional-lite nonstd::optional-lite optional.hpp
     "${_jinja2cpp_nonstd_root}/optional-lite/include"
   )
   executorch_copy_nonstd_header(
-    string-view-lite
-    nonstd::string-view-lite
-    string_view.hpp
+    string-view-lite nonstd::string-view-lite string_view.hpp
     "${_jinja2cpp_nonstd_root}/string-view-lite/include"
   )
 endif()
@@ -110,7 +97,6 @@ endif()
 # Install the chat_templates.h header so that downstream consumers of the
 # installed ExecuTorch SDK can include
 # <executorch/extension/llm/chat_template/chat_templates.h>.
-install(
-  FILES chat_templates.h
-  DESTINATION include/executorch/extension/llm/chat_template
+install(FILES chat_templates.h
+        DESTINATION include/executorch/extension/llm/chat_template
 )

--- a/extension/llm/chat_template/CMakeLists.txt
+++ b/extension/llm/chat_template/CMakeLists.txt
@@ -1,0 +1,116 @@
+if(NOT EXECUTORCH_BUILD_EXTENSION_LLM_RUNNER)
+  return()
+endif()
+
+include(FetchContent)
+cmake_policy(SET CMP0077 NEW)
+
+FetchContent_Declare(
+  jinja2cpp
+  GIT_REPOSITORY https://github.com/jinja2cpp/Jinja2Cpp.git
+  GIT_TAG 1.3.2
+  GIT_SUBMODULES_RECURSE TRUE
+)
+
+set(JINJA2CPP_BUILD_TESTS
+    OFF
+    CACHE BOOL ""
+          FORCE
+)
+set(JINJA2CPP_BUILD_SHARED
+    OFF
+    CACHE BOOL ""
+          FORCE
+)
+set(JINJA2CPP_INSTALL
+    OFF
+    CACHE BOOL ""
+          FORCE
+)
+# Enable PCRE2-based regex lookahead support in Jinja2Cpp. This must be set
+# BEFORE FetchContent_MakeAvailable(jinja2cpp) so it propagates to the
+# Jinja2Cpp configure step.
+set(SUPPORT_REGEX_LOOKAHEAD
+    ON
+    CACHE BOOL ""
+          FORCE
+)
+
+FetchContent_MakeAvailable(jinja2cpp)
+if(NOT TARGET jinja2cpp)
+  message(FATAL_ERROR "Jinja2Cpp target not found after FetchContent.")
+endif()
+
+if(DEFINED jinja2cpp_SOURCE_DIR)
+  function(executorch_copy_nonstd_header dep_name target header_name dest_root)
+    set(_copied FALSE)
+    if(TARGET ${target})
+      get_target_property(_aliased ${target} ALIASED_TARGET)
+      if(_aliased)
+        set(_resolved_target ${_aliased})
+      else()
+        set(_resolved_target ${target})
+      endif()
+      get_target_property(
+        _include_dirs ${_resolved_target} INTERFACE_INCLUDE_DIRECTORIES
+      )
+      foreach(_dir IN LISTS _include_dirs)
+        if(EXISTS "${_dir}/nonstd/${header_name}")
+          file(MAKE_DIRECTORY "${dest_root}/nonstd")
+          file(
+            COPY "${_dir}/nonstd/${header_name}"
+            DESTINATION "${dest_root}/nonstd"
+          )
+          set(_copied TRUE)
+          break()
+        endif()
+      endforeach()
+    endif()
+    if(NOT _copied)
+      set(
+        _fallback_path
+        "${CMAKE_BINARY_DIR}/_deps/${dep_name}-src/include/nonstd/${header_name}"
+      )
+      if(EXISTS "${_fallback_path}")
+        file(MAKE_DIRECTORY "${dest_root}/nonstd")
+        file(COPY "${_fallback_path}" DESTINATION "${dest_root}/nonstd")
+      endif()
+    endif()
+  endfunction()
+
+  set(_jinja2cpp_nonstd_root
+      "${jinja2cpp_SOURCE_DIR}/thirdparty/nonstd"
+  )
+  executorch_copy_nonstd_header(
+    expected-lite
+    nonstd::expected-lite
+    expected.hpp
+    "${_jinja2cpp_nonstd_root}/expected-lite/include"
+  )
+  executorch_copy_nonstd_header(
+    variant-lite
+    nonstd::variant-lite
+    variant.hpp
+    "${_jinja2cpp_nonstd_root}/variant-lite/include"
+  )
+  executorch_copy_nonstd_header(
+    optional-lite
+    nonstd::optional-lite
+    optional.hpp
+    "${_jinja2cpp_nonstd_root}/optional-lite/include"
+  )
+  executorch_copy_nonstd_header(
+    string-view-lite
+    nonstd::string-view-lite
+    string_view.hpp
+    "${_jinja2cpp_nonstd_root}/string-view-lite/include"
+  )
+endif()
+
+# Install the chat_templates.h header so that downstream consumers of the
+# installed ExecuTorch SDK can include
+# <executorch/extension/llm/chat_template/chat_templates.h>.
+install(
+  FILES chat_templates.h
+  DESTINATION include/executorch/extension/llm/chat_template
+)

--- a/extension/llm/chat_template/CMakeLists.txt
+++ b/extension/llm/chat_template/CMakeLists.txt
@@ -9,6 +9,7 @@ FetchContent_Declare(
   jinja2cpp
   GIT_REPOSITORY https://github.com/jinja2cpp/Jinja2Cpp.git
   GIT_TAG 1.3.2
+  GIT_SHALLOW TRUE
   GIT_SUBMODULES_RECURSE TRUE
 )
 

--- a/extension/llm/chat_template/chat_templates.h
+++ b/extension/llm/chat_template/chat_templates.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+namespace executorch::extension::llm {
+
+enum class ChatTemplateType {
+  None,
+  Llama3,
+  Llama32,
+  Gemma3,
+  Custom,
+};
+
+constexpr std::string_view kLlama3Template = R"({{ bos_token }}{%- for message in messages -%}<|start_header_id|>{{ message.role }}<|end_header_id|>
+
+{{ message.content }}<|eot_id|>{%- endfor -%}{%- if add_generation_prompt -%}<|start_header_id|>assistant<|end_header_id|>
+
+{%- endif -%})";
+
+constexpr std::string_view kGemma3Template = R"({{ bos_token }}{%- for message in messages -%}{%- if message.role == 'assistant' -%}<start_of_turn>model
+{%- else -%}<start_of_turn>{{ message.role }}
+{%- endif -%}{{ message.content }}<end_of_turn>{%- endfor -%}{%- if add_generation_prompt -%}<start_of_turn>model
+{%- endif -%})";
+
+inline const std::unordered_map<ChatTemplateType, std::string_view>
+    kEmbeddedTemplates = {
+        {ChatTemplateType::Llama3, kLlama3Template},
+        {ChatTemplateType::Llama32, kLlama3Template},
+        {ChatTemplateType::Gemma3, kGemma3Template},
+    };
+
+struct ModelTokens {
+  std::string bos_token;
+  std::string eos_token;
+  std::vector<std::string> stop_tokens;
+};
+
+inline const std::unordered_map<ChatTemplateType, ModelTokens> kModelTokens = {
+    {ChatTemplateType::Llama3,
+     {"<|begin_of_text|>", "<|eot_id|>", {"<|eot_id|>", "<|end_of_text|>"}}},
+    {ChatTemplateType::Llama32,
+     {"<|begin_of_text|>", "<|eot_id|>", {"<|eot_id|>", "<|end_of_text|>"}}},
+    {ChatTemplateType::Gemma3,
+     {"<bos>", "<end_of_turn>", {"<end_of_turn>", "<eos>"}}},
+};
+
+} // namespace executorch::extension::llm

--- a/extension/llm/chat_template/chat_templates.h
+++ b/extension/llm/chat_template/chat_templates.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <string>
@@ -15,23 +23,29 @@ enum class ChatTemplateType {
   Custom,
 };
 
-constexpr std::string_view kLlama3Template = R"({{ bos_token }}{%- for message in messages -%}<|start_header_id|>{{ message.role }}<|end_header_id|>
+constexpr std::string_view kLlama3Template =
+    R"({{ bos_token }}{%- for message in messages -%}<|start_header_id|>{{ message.role }}<|end_header_id|>
 
 {{ message.content }}<|eot_id|>{%- endfor -%}{%- if add_generation_prompt -%}<|start_header_id|>assistant<|end_header_id|>
 
 {%- endif -%})";
 
-constexpr std::string_view kGemma3Template = R"({{ bos_token }}{%- for message in messages -%}{%- if message.role == 'assistant' -%}<start_of_turn>model
+constexpr std::string_view kGemma3Template =
+    R"({{ bos_token }}{%- for message in messages -%}{%- if message.role == 'assistant' -%}<start_of_turn>model
 {%- else -%}<start_of_turn>{{ message.role }}
 {%- endif -%}{{ message.content }}<end_of_turn>{%- endfor -%}{%- if add_generation_prompt -%}<start_of_turn>model
 {%- endif -%})";
 
-inline const std::unordered_map<ChatTemplateType, std::string_view>
-    kEmbeddedTemplates = {
-        {ChatTemplateType::Llama3, kLlama3Template},
-        {ChatTemplateType::Llama32, kLlama3Template},
-        {ChatTemplateType::Gemma3, kGemma3Template},
-    };
+inline const std::unordered_map<ChatTemplateType, std::string_view>&
+getEmbeddedTemplates() {
+  static const std::unordered_map<ChatTemplateType, std::string_view>
+      embedded_templates = {
+          {ChatTemplateType::Llama3, kLlama3Template},
+          {ChatTemplateType::Llama32, kLlama3Template},
+          {ChatTemplateType::Gemma3, kGemma3Template},
+      };
+  return embedded_templates;
+}
 
 struct ModelTokens {
   std::string bos_token;
@@ -39,13 +53,22 @@ struct ModelTokens {
   std::vector<std::string> stop_tokens;
 };
 
-inline const std::unordered_map<ChatTemplateType, ModelTokens> kModelTokens = {
-    {ChatTemplateType::Llama3,
-     {"<|begin_of_text|>", "<|eot_id|>", {"<|eot_id|>", "<|end_of_text|>"}}},
-    {ChatTemplateType::Llama32,
-     {"<|begin_of_text|>", "<|eot_id|>", {"<|eot_id|>", "<|end_of_text|>"}}},
-    {ChatTemplateType::Gemma3,
-     {"<bos>", "<end_of_turn>", {"<end_of_turn>", "<eos>"}}},
-};
+inline const std::unordered_map<ChatTemplateType, ModelTokens>&
+getModelTokens() {
+  static const std::unordered_map<ChatTemplateType, ModelTokens> model_tokens =
+      {
+          {ChatTemplateType::Llama3,
+           {"<|begin_of_text|>",
+            "<|eot_id|>",
+            {"<|eot_id|>", "<|end_of_text|>"}}},
+          {ChatTemplateType::Llama32,
+           {"<|begin_of_text|>",
+            "<|eot_id|>",
+            {"<|eot_id|>", "<|end_of_text|>"}}},
+          {ChatTemplateType::Gemma3,
+           {"<bos>", "<end_of_turn>", {"<end_of_turn>", "<eos>"}}},
+      };
+  return model_tokens;
+}
 
 } // namespace executorch::extension::llm

--- a/extension/llm/chat_template/targets.bzl
+++ b/extension/llm/chat_template/targets.bzl
@@ -1,0 +1,16 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+
+def define_common_targets():
+    runtime.cxx_library(
+        name = "chat_templates",
+        exported_headers = [
+            "chat_templates.h",
+        ],
+        visibility = ["PUBLIC"],
+    )

--- a/extension/llm/runner/CMakeLists.txt
+++ b/extension/llm/runner/CMakeLists.txt
@@ -59,7 +59,6 @@ target_include_directories(
   extension_llm_runner
   PRIVATE $<TARGET_PROPERTY:jinja2cpp,INTERFACE_INCLUDE_DIRECTORIES>
 )
-target_compile_definitions(extension_llm_runner PUBLIC EXECUTORCH_USE_JINJA2CPP)
 set_target_properties(
   extension_llm_runner PROPERTIES POSITION_INDEPENDENT_CODE ON
 )
@@ -122,19 +121,23 @@ if(EXECUTORCH_BUILD_PYBIND)
                         portable_lib ${TORCH_PYTHON_LIBRARY} ${TORCH_LIBRARIES}
   )
 
-  # Set properties for the Python extension
   set_target_properties(
     _llm_runner
     PROPERTIES POSITION_INDEPENDENT_CODE ON
                CXX_VISIBILITY_PRESET "hidden"
                INTERPROCEDURAL_OPTIMIZATION TRUE
+               CXX_STANDARD 20
   )
   if(APPLE)
-    set(RPATH "@loader_path/../../pybindings")
+    set(RPATH
+        "@loader_path/../../pybindings;@loader_path/../../../../torch/lib"
+    )
   else()
-    set(RPATH "$ORIGIN/../../pybindings")
+    set(RPATH "$ORIGIN/../../pybindings:$ORIGIN/../../../../torch/lib")
   endif()
-  set_target_properties(_llm_runner PROPERTIES INSTALL_RPATH ${RPATH})
+  set_target_properties(
+    _llm_runner PROPERTIES BUILD_RPATH "${RPATH}" INSTALL_RPATH "${RPATH}"
+  )
   # Add include directories
   target_include_directories(
     _llm_runner PRIVATE ${_common_include_directories} ${TORCH_INCLUDE_DIRS}

--- a/extension/llm/runner/CMakeLists.txt
+++ b/extension/llm/runner/CMakeLists.txt
@@ -56,12 +56,10 @@ list(APPEND runner_deps kernels_util_all_deps)
 target_link_libraries(extension_llm_runner PUBLIC ${runner_deps})
 target_link_libraries(extension_llm_runner PRIVATE $<LINK_ONLY:jinja2cpp>)
 target_include_directories(
-  extension_llm_runner PRIVATE
-  $<TARGET_PROPERTY:jinja2cpp,INTERFACE_INCLUDE_DIRECTORIES>
+  extension_llm_runner
+  PRIVATE $<TARGET_PROPERTY:jinja2cpp,INTERFACE_INCLUDE_DIRECTORIES>
 )
-target_compile_definitions(
-  extension_llm_runner PUBLIC EXECUTORCH_USE_JINJA2CPP
-)
+target_compile_definitions(extension_llm_runner PUBLIC EXECUTORCH_USE_JINJA2CPP)
 set_target_properties(
   extension_llm_runner PROPERTIES POSITION_INDEPENDENT_CODE ON
 )

--- a/extension/llm/runner/CMakeLists.txt
+++ b/extension/llm/runner/CMakeLists.txt
@@ -54,6 +54,14 @@ endif()
 list(APPEND runner_deps kernels_util_all_deps)
 
 target_link_libraries(extension_llm_runner PUBLIC ${runner_deps})
+target_link_libraries(extension_llm_runner PRIVATE $<LINK_ONLY:jinja2cpp>)
+target_include_directories(
+  extension_llm_runner PRIVATE
+  $<TARGET_PROPERTY:jinja2cpp,INTERFACE_INCLUDE_DIRECTORIES>
+)
+target_compile_definitions(
+  extension_llm_runner PUBLIC EXECUTORCH_USE_JINJA2CPP
+)
 set_target_properties(
   extension_llm_runner PROPERTIES POSITION_INDEPENDENT_CODE ON
 )
@@ -116,23 +124,19 @@ if(EXECUTORCH_BUILD_PYBIND)
                         portable_lib ${TORCH_PYTHON_LIBRARY} ${TORCH_LIBRARIES}
   )
 
+  # Set properties for the Python extension
   set_target_properties(
     _llm_runner
     PROPERTIES POSITION_INDEPENDENT_CODE ON
                CXX_VISIBILITY_PRESET "hidden"
                INTERPROCEDURAL_OPTIMIZATION TRUE
-               CXX_STANDARD 20
   )
   if(APPLE)
-    set(RPATH
-        "@loader_path/../../pybindings;@loader_path/../../../../torch/lib"
-    )
+    set(RPATH "@loader_path/../../pybindings")
   else()
-    set(RPATH "$ORIGIN/../../pybindings:$ORIGIN/../../../../torch/lib")
+    set(RPATH "$ORIGIN/../../pybindings")
   endif()
-  set_target_properties(
-    _llm_runner PROPERTIES BUILD_RPATH "${RPATH}" INSTALL_RPATH "${RPATH}"
-  )
+  set_target_properties(_llm_runner PROPERTIES INSTALL_RPATH ${RPATH})
   # Add include directories
   target_include_directories(
     _llm_runner PRIVATE ${_common_include_directories} ${TORCH_INCLUDE_DIRS}

--- a/extension/llm/runner/__init__.py
+++ b/extension/llm/runner/__init__.py
@@ -11,13 +11,15 @@ This module provides a Python interface to the ExecuTorch multimodal LLM runner,
 enabling processing of mixed inputs (text, images, audio) and text generation.
 """
 
-import torch  # preload libtorch shared libs for _llm_runner
-
 try:
     # Import shared components from the compiled C++ extension
     from executorch.extension.llm.runner._llm_runner import (  # noqa: F401
+        ChatConversation,
+        ChatMessage,
+        ChatTemplateType,
         GenerationConfig,
         Image,
+        JinjaChatFormatter,
         make_audio_input,
         make_image_input,
         make_raw_audio_input,
@@ -26,7 +28,6 @@ try:
         MultimodalInput,
         MultimodalRunner,
         Stats,
-        TextLLMRunner,
     )
 except ImportError:
     raise RuntimeError(
@@ -37,6 +38,7 @@ except ImportError:
 import logging
 from typing import Callable, List, Optional, Union
 
+import torch
 from transformers.feature_extraction_utils import BatchFeature
 
 
@@ -224,8 +226,12 @@ setattr(MultimodalRunner, "generate_text_hf", generate_text_hf)  # noqa B010
 
 
 __all__ = [
+    "ChatConversation",
+    "ChatMessage",
+    "ChatTemplateType",
     "GenerationConfig",
     "Image",
+    "JinjaChatFormatter",
     "make_audio_input",
     "make_image_input",
     "make_raw_audio_input",
@@ -233,6 +239,5 @@ __all__ = [
     "make_token_input",
     "MultimodalInput",
     "MultimodalRunner",
-    "TextLLMRunner",
     "Stats",
 ]

--- a/extension/llm/runner/_llm_runner.pyi
+++ b/extension/llm/runner/_llm_runner.pyi
@@ -4,6 +4,7 @@ Type stubs for _llm_runner module.
 This file provides type annotations for the ExecuTorch LLM Runner Python bindings.
 """
 
+from enum import Enum
 from typing import Callable, List, Optional, overload
 
 import torch
@@ -63,6 +64,39 @@ class GenerationConfig:
         ...
 
     def __repr__(self) -> str: ...
+
+class ChatTemplateType(Enum):
+    None_ = 0
+    Llama3 = 1
+    Llama32 = 2
+    Gemma3 = 3
+    Custom = 4
+
+class ChatMessage:
+    role: str
+    content: str
+
+    def __init__(self, role: str, content: str) -> None: ...
+    def __repr__(self) -> str: ...
+
+class ChatConversation:
+    messages: List[ChatMessage]
+    bos_token: str
+    eos_token: str
+    add_generation_prompt: bool
+
+    def __init__(self) -> None: ...
+
+class JinjaChatFormatter:
+    @staticmethod
+    def from_template(template_type: ChatTemplateType) -> "JinjaChatFormatter": ...
+    @staticmethod
+    def from_string(template_str: str) -> "JinjaChatFormatter": ...
+    @staticmethod
+    def from_file(path: str) -> "JinjaChatFormatter": ...
+    def format(self, prompt: str, system_prompt: str = "") -> str: ...
+    def format_conversation(self, conversation: ChatConversation) -> str: ...
+    def includes_bos(self) -> bool: ...
 
 class Stats:
     """Statistics for LLM generation performance."""

--- a/extension/llm/runner/chat_types.h
+++ b/extension/llm/runner/chat_types.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace executorch::extension::llm {
+
+struct ChatMessage {
+  std::string role;
+  std::string content;
+};
+
+struct ChatConversation {
+  std::vector<ChatMessage> messages;
+  std::string bos_token;
+  std::string eos_token;
+  bool add_generation_prompt = true;
+};
+
+} // namespace executorch::extension::llm

--- a/extension/llm/runner/chat_types.h
+++ b/extension/llm/runner/chat_types.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <string>

--- a/extension/llm/runner/jinja_chat_formatter.cpp
+++ b/extension/llm/runner/jinja_chat_formatter.cpp
@@ -141,7 +141,7 @@ JinjaChatFormatter::JinjaChatFormatter(
     const std::string& template_str,
     ChatTemplateType type)
     : template_str_(template_str), type_(type) {
-  const auto& model_tokens = getModelTokens();
+  const auto& model_tokens = ::executorch::extension::llm::getModelTokens();
   auto tokens_it = model_tokens.find(type_);
   if (tokens_it != model_tokens.end()) {
     model_tokens_ = tokens_it->second;

--- a/extension/llm/runner/jinja_chat_formatter.cpp
+++ b/extension/llm/runner/jinja_chat_formatter.cpp
@@ -66,7 +66,7 @@ std::string normalizeTemplate(std::string input) {
           {"tools is None", "not tools"},
           {"messages[1:]", "messages_tail"},
           {"{ \"output\": message.content } | tojson",
-           "message.content | tojson"},
+           "message.tool_output | tojson"},
       }};
   // Handle special case that can't be constexpr due to escape sequence
   const std::pair<std::string, std::string> gemmaReplacement = {
@@ -126,6 +126,12 @@ struct TypeReflection<executorch::extension::llm::ChatMessage>
         {"content",
          [](const executorch::extension::llm::ChatMessage& msg) {
            return jinja2::Reflect(msg.content);
+         }},
+        {"tool_output",
+         [](const executorch::extension::llm::ChatMessage& msg) {
+           jinja2::ValuesMap output;
+           output["output"] = msg.content;
+           return output;
          }},
     };
     return accessors;

--- a/extension/llm/runner/jinja_chat_formatter.cpp
+++ b/extension/llm/runner/jinja_chat_formatter.cpp
@@ -1,0 +1,236 @@
+#include <executorch/extension/llm/runner/jinja_chat_formatter.h>
+
+#include <jinja2cpp/reflected_value.h>
+#include <jinja2cpp/template.h>
+#include <jinja2cpp/value.h>
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <fstream>
+#include <sstream>
+#include <stdexcept>
+#include <unordered_map>
+
+namespace executorch::extension::llm {
+namespace {
+
+std::string readFileToString(const std::filesystem::path& path) {
+  std::ifstream file(path);
+  if (!file) {
+    throw std::runtime_error("Failed to open template file: " + path.string());
+  }
+  std::ostringstream buffer;
+  buffer << file.rdbuf();
+  return buffer.str();
+}
+
+bool templateIncludesBos(
+    const std::string& template_str,
+    const ModelTokens& model_tokens) {
+  if (!model_tokens.bos_token.empty() &&
+      template_str.find(model_tokens.bos_token) != std::string::npos) {
+    return true;
+  }
+  return template_str.find("bos_token") != std::string::npos;
+}
+
+std::string normalizeTemplate(std::string input) {
+  // These replacements normalize vLLM/HuggingFace Jinja templates so they
+  // compile/render correctly with Jinja2Cpp, which has stricter parser
+  // semantics than Python Jinja2.
+  //
+  // IMPORTANT: "not tools is none" in Python Jinja means "tools is not none"
+  // (truthy when tools is defined and non-null), so we map it to a simple
+  // truthy check on `tools`. Mapping to "not tools" was a bug that would
+  // skip tool blocks for non-empty tools lists.
+  constexpr std::array<std::pair<std::string_view, std::string_view>, 10>
+      replacements = {{
+          {"tools = none", "tools = []"},
+          {"tools = None", "tools = []"},
+          {"tools is not none", "tools"},
+          {"tools is not None", "tools"},
+          {"not tools is none", "tools"},
+          {"not tools is None", "tools"},
+          {"tools is none", "not tools"},
+          {"tools is None", "not tools"},
+          {"messages[1:]", "messages_tail"},
+          {"{ \"output\": message.content } | tojson", "message.content | tojson"},
+      }};
+  // Handle special case that can't be constexpr due to escape sequence
+  const std::pair<std::string, std::string> gemmaReplacement = {
+      "{{'<start_of_turn>model\\n'}}", "{{ '<start_of_turn>model\\n' }}"};
+  for (const auto& replacement : replacements) {
+    size_t pos = 0;
+    while ((pos = input.find(replacement.first, pos)) != std::string::npos) {
+      input.replace(pos, replacement.first.size(), replacement.second);
+      pos += replacement.second.size();
+    }
+  }
+  // Apply the gemma replacement separately
+  size_t pos = 0;
+  while ((pos = input.find(gemmaReplacement.first, pos)) != std::string::npos) {
+    input.replace(pos, gemmaReplacement.first.size(), gemmaReplacement.second);
+    pos += gemmaReplacement.second.size();
+  }
+  return input;
+}
+
+ChatTemplateType detectTemplateType(const std::string& template_str) {
+  if (template_str.find("<start_of_turn>") != std::string::npos) {
+    return ChatTemplateType::Gemma3;
+  }
+  if (template_str.find("<|start_header_id|>") != std::string::npos) {
+    return ChatTemplateType::Llama3;
+  }
+  return ChatTemplateType::Custom;
+}
+
+std::string toLower(std::string value) {
+  std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) {
+    return static_cast<char>(std::tolower(c));
+  });
+  return value;
+}
+
+} // namespace
+
+} // namespace executorch::extension::llm
+
+namespace jinja2 {
+
+// NOLINTBEGIN(facebook-hte-MisplacedTemplateSpecialization,facebook-hte-ShadowingClass)
+// This template specialization must be in the jinja2 namespace for the library
+// to find it via ADL during template instantiation.
+template <>
+struct TypeReflection<executorch::extension::llm::ChatMessage>
+    : TypeReflected<executorch::extension::llm::ChatMessage> {
+  static auto& GetAccessors() {
+    static std::unordered_map<std::string, FieldAccessor> accessors = {
+        {"role",
+         [](const executorch::extension::llm::ChatMessage& msg) {
+           return jinja2::Reflect(msg.role);
+         }},
+        {"content",
+         [](const executorch::extension::llm::ChatMessage& msg) {
+           return jinja2::Reflect(msg.content);
+         }},
+    };
+    return accessors;
+  }
+};
+// NOLINTEND(facebook-hte-MisplacedTemplateSpecialization,facebook-hte-ShadowingClass)
+
+} // namespace jinja2
+
+namespace executorch::extension::llm {
+
+JinjaChatFormatter::JinjaChatFormatter(
+    const std::string& template_str,
+    ChatTemplateType type)
+    : template_str_(template_str), type_(type) {
+  auto tokens_it = kModelTokens.find(type_);
+  if (tokens_it != kModelTokens.end()) {
+    model_tokens_ = tokens_it->second;
+  }
+  includes_bos_ = templateIncludesBos(template_str_, model_tokens_);
+  const std::string normalized_template = normalizeTemplate(template_str_);
+  compiled_template_ = std::make_unique<jinja2::Template>();
+  auto load_result = compiled_template_->Load(normalized_template);
+  if (!load_result) {
+    throw std::runtime_error(
+        "Failed to parse chat template: " +
+        load_result.error().ToString());
+  }
+}
+
+JinjaChatFormatter::~JinjaChatFormatter() = default;
+
+std::unique_ptr<JinjaChatFormatter> JinjaChatFormatter::fromTemplate(
+    ChatTemplateType type) {
+  auto it = kEmbeddedTemplates.find(type);
+  if (it == kEmbeddedTemplates.end()) {
+    throw std::runtime_error("Unsupported embedded chat template type.");
+  }
+  return std::unique_ptr<JinjaChatFormatter>(
+      new JinjaChatFormatter(std::string(it->second), type));
+}
+
+std::unique_ptr<JinjaChatFormatter> JinjaChatFormatter::fromString(
+    const std::string& template_str) {
+  const ChatTemplateType inferred_type = detectTemplateType(template_str);
+  return std::unique_ptr<JinjaChatFormatter>(
+      new JinjaChatFormatter(template_str, inferred_type));
+}
+
+std::unique_ptr<JinjaChatFormatter> JinjaChatFormatter::fromFile(
+    const std::filesystem::path& path) {
+  return fromString(readFileToString(path));
+}
+
+std::string JinjaChatFormatter::format(
+    const std::string& prompt,
+    const std::string& system_prompt) const {
+  ChatConversation conversation;
+  if (!system_prompt.empty()) {
+    conversation.messages.push_back({"system", system_prompt});
+  }
+  conversation.messages.push_back({"user", prompt});
+  conversation.bos_token = model_tokens_.bos_token;
+  conversation.eos_token = model_tokens_.eos_token;
+  conversation.add_generation_prompt = true;
+  return formatConversation(conversation);
+}
+
+std::string JinjaChatFormatter::formatConversation(
+    const ChatConversation& conversation) const {
+  jinja2::ValuesMap params;
+  params["messages"] = jinja2::ValuesList();
+  params["messages_tail"] = jinja2::ValuesList();
+  bool is_first = true;
+  for (const auto& msg : conversation.messages) {
+    params["messages"].asList().push_back(jinja2::Reflect(msg));
+    if (!is_first) {
+      params["messages_tail"].asList().push_back(jinja2::Reflect(msg));
+    }
+    is_first = false;
+  }
+  params["bos_token"] = conversation.bos_token;
+  params["eos_token"] = conversation.eos_token;
+  params["add_generation_prompt"] = conversation.add_generation_prompt;
+  // Provide vLLM/HuggingFace-style defaults that templates often reference.
+  // Templates that don't use these will simply ignore them.
+  params["tools"] = jinja2::ValuesList();
+  params["tool_choice"] = jinja2::Value();
+  params["date_string"] = std::string("26 Jul 2024");
+  params["chat_template_kwargs"] = jinja2::ValuesMap();
+
+  auto rendered = compiled_template_->RenderAsString(params);
+  if (!rendered) {
+    throw std::runtime_error(
+        "Failed to render chat template: " + rendered.error().ToString());
+  }
+  return rendered.value();
+}
+
+ChatTemplateType parseChatTemplateType(const std::string& type_str) {
+  const std::string lower = toLower(type_str);
+  if (lower == "none") {
+    return ChatTemplateType::None;
+  }
+  if (lower == "llama3") {
+    return ChatTemplateType::Llama3;
+  }
+  if (lower == "llama3.2" || lower == "llama32" || lower == "llama3_2") {
+    return ChatTemplateType::Llama32;
+  }
+  if (lower == "gemma3") {
+    return ChatTemplateType::Gemma3;
+  }
+  if (lower == "custom" || lower == "jinja") {
+    return ChatTemplateType::Custom;
+  }
+  return ChatTemplateType::None;
+}
+
+} // namespace executorch::extension::llm

--- a/extension/llm/runner/jinja_chat_formatter.cpp
+++ b/extension/llm/runner/jinja_chat_formatter.cpp
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #include <executorch/extension/llm/runner/jinja_chat_formatter.h>
 
 #include <jinja2cpp/reflected_value.h>
@@ -15,10 +23,10 @@
 namespace executorch::extension::llm {
 namespace {
 
-std::string readFileToString(const std::filesystem::path& path) {
+std::string readFileToString(const std::string& path) {
   std::ifstream file(path);
   if (!file) {
-    throw std::runtime_error("Failed to open template file: " + path.string());
+    throw std::runtime_error("Failed to open template file: " + path);
   }
   std::ostringstream buffer;
   buffer << file.rdbuf();
@@ -44,6 +52,8 @@ std::string normalizeTemplate(std::string input) {
   // (truthy when tools is defined and non-null), so we map it to a simple
   // truthy check on `tools`. Mapping to "not tools" was a bug that would
   // skip tool blocks for non-empty tools lists.
+  // Keep longer `tools is ... none` patterns before the shorter
+  // `tools is none` patterns to avoid partial replacements.
   constexpr std::array<std::pair<std::string_view, std::string_view>, 10>
       replacements = {{
           {"tools = none", "tools = []"},
@@ -55,7 +65,8 @@ std::string normalizeTemplate(std::string input) {
           {"tools is none", "not tools"},
           {"tools is None", "not tools"},
           {"messages[1:]", "messages_tail"},
-          {"{ \"output\": message.content } | tojson", "message.content | tojson"},
+          {"{ \"output\": message.content } | tojson",
+           "message.content | tojson"},
       }};
   // Handle special case that can't be constexpr due to escape sequence
   const std::pair<std::string, std::string> gemmaReplacement = {
@@ -87,9 +98,10 @@ ChatTemplateType detectTemplateType(const std::string& template_str) {
 }
 
 std::string toLower(std::string value) {
-  std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) {
-    return static_cast<char>(std::tolower(c));
-  });
+  std::transform(
+      value.begin(), value.end(), value.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+      });
   return value;
 }
 
@@ -129,8 +141,9 @@ JinjaChatFormatter::JinjaChatFormatter(
     const std::string& template_str,
     ChatTemplateType type)
     : template_str_(template_str), type_(type) {
-  auto tokens_it = kModelTokens.find(type_);
-  if (tokens_it != kModelTokens.end()) {
+  const auto& model_tokens = getModelTokens();
+  auto tokens_it = model_tokens.find(type_);
+  if (tokens_it != model_tokens.end()) {
     model_tokens_ = tokens_it->second;
   }
   includes_bos_ = templateIncludesBos(template_str_, model_tokens_);
@@ -139,8 +152,7 @@ JinjaChatFormatter::JinjaChatFormatter(
   auto load_result = compiled_template_->Load(normalized_template);
   if (!load_result) {
     throw std::runtime_error(
-        "Failed to parse chat template: " +
-        load_result.error().ToString());
+        "Failed to parse chat template: " + load_result.error().ToString());
   }
 }
 
@@ -148,8 +160,9 @@ JinjaChatFormatter::~JinjaChatFormatter() = default;
 
 std::unique_ptr<JinjaChatFormatter> JinjaChatFormatter::fromTemplate(
     ChatTemplateType type) {
-  auto it = kEmbeddedTemplates.find(type);
-  if (it == kEmbeddedTemplates.end()) {
+  const auto& embedded_templates = getEmbeddedTemplates();
+  auto it = embedded_templates.find(type);
+  if (it == embedded_templates.end()) {
     throw std::runtime_error("Unsupported embedded chat template type.");
   }
   return std::unique_ptr<JinjaChatFormatter>(
@@ -164,7 +177,7 @@ std::unique_ptr<JinjaChatFormatter> JinjaChatFormatter::fromString(
 }
 
 std::unique_ptr<JinjaChatFormatter> JinjaChatFormatter::fromFile(
-    const std::filesystem::path& path) {
+    const std::string& path) {
   return fromString(readFileToString(path));
 }
 
@@ -202,6 +215,7 @@ std::string JinjaChatFormatter::formatConversation(
   // Templates that don't use these will simply ignore them.
   params["tools"] = jinja2::ValuesList();
   params["tool_choice"] = jinja2::Value();
+  // HuggingFace templates use a fixed date in their own regression fixtures.
   params["date_string"] = std::string("26 Jul 2024");
   params["chat_template_kwargs"] = jinja2::ValuesMap();
 

--- a/extension/llm/runner/jinja_chat_formatter.h
+++ b/extension/llm/runner/jinja_chat_formatter.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <executorch/extension/llm/chat_template/chat_templates.h>
+#include <executorch/extension/llm/runner/chat_types.h>
+
+#include <filesystem>
+#include <memory>
+#include <string>
+
+namespace jinja2 {
+class Template;
+}
+
+namespace executorch::extension::llm {
+
+class JinjaChatFormatter {
+ public:
+  static std::unique_ptr<JinjaChatFormatter> fromTemplate(ChatTemplateType type);
+  static std::unique_ptr<JinjaChatFormatter> fromString(
+      const std::string& template_str);
+  static std::unique_ptr<JinjaChatFormatter> fromFile(
+      const std::filesystem::path& path);
+
+  ~JinjaChatFormatter();
+
+  std::string format(
+      const std::string& prompt,
+      const std::string& system_prompt = "") const;
+  std::string formatConversation(const ChatConversation& conversation) const;
+
+  bool includesBos() const {
+    return includes_bos_;
+  }
+
+  const ModelTokens& getModelTokens() const {
+    return model_tokens_;
+  }
+
+ private:
+  JinjaChatFormatter(const std::string& template_str, ChatTemplateType type);
+
+  std::string template_str_;
+  ChatTemplateType type_;
+  ModelTokens model_tokens_;
+  bool includes_bos_ = false;
+  std::unique_ptr<jinja2::Template> compiled_template_;
+};
+
+ChatTemplateType parseChatTemplateType(const std::string& type_str);
+
+} // namespace executorch::extension::llm

--- a/extension/llm/runner/jinja_chat_formatter.h
+++ b/extension/llm/runner/jinja_chat_formatter.h
@@ -1,9 +1,16 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #pragma once
 
 #include <executorch/extension/llm/chat_template/chat_templates.h>
 #include <executorch/extension/llm/runner/chat_types.h>
 
-#include <filesystem>
 #include <memory>
 #include <string>
 
@@ -15,11 +22,11 @@ namespace executorch::extension::llm {
 
 class JinjaChatFormatter {
  public:
-  static std::unique_ptr<JinjaChatFormatter> fromTemplate(ChatTemplateType type);
+  static std::unique_ptr<JinjaChatFormatter> fromTemplate(
+      ChatTemplateType type);
   static std::unique_ptr<JinjaChatFormatter> fromString(
       const std::string& template_str);
-  static std::unique_ptr<JinjaChatFormatter> fromFile(
-      const std::filesystem::path& path);
+  static std::unique_ptr<JinjaChatFormatter> fromFile(const std::string& path);
 
   ~JinjaChatFormatter();
 

--- a/extension/llm/runner/jinja_chat_formatter.h
+++ b/extension/llm/runner/jinja_chat_formatter.h
@@ -24,6 +24,8 @@ class JinjaChatFormatter {
  public:
   static std::unique_ptr<JinjaChatFormatter> fromTemplate(
       ChatTemplateType type);
+  // fromString/fromFile infer only the model family from template syntax.
+  // Llama3 and Llama3.2 share template markers and token defaults today.
   static std::unique_ptr<JinjaChatFormatter> fromString(
       const std::string& template_str);
   static std::unique_ptr<JinjaChatFormatter> fromFile(const std::string& path);

--- a/extension/llm/runner/jinja_chat_formatter.h
+++ b/extension/llm/runner/jinja_chat_formatter.h
@@ -35,6 +35,8 @@ class JinjaChatFormatter {
   std::string format(
       const std::string& prompt,
       const std::string& system_prompt = "") const;
+  // Custom templates whose tokens cannot be inferred should use
+  // formatConversation() so the caller can provide bos/eos tokens explicitly.
   std::string formatConversation(const ChatConversation& conversation) const;
 
   bool includesBos() const {

--- a/extension/llm/runner/llm_runner_helper.cpp
+++ b/extension/llm/runner/llm_runner_helper.cpp
@@ -158,7 +158,9 @@ std::unordered_set<uint64_t> get_eos_ids(
     tokenizers::Tokenizer* tokenizer,
     Module* module) {
   std::unordered_set<uint64_t> eos_ids = {tokenizer->eos_tok()};
-  // Get EOS IDs if available
+  ET_LOG(Info, "Primary eos_tok = %" PRIu64, tokenizer->eos_tok());
+
+  // Get EOS IDs from model metadata if available
   auto method_names_result = module->method_names();
   if (method_names_result.error() != Error::Ok) {
     ET_LOG(Error, "Failed reading method names");
@@ -167,7 +169,6 @@ std::unordered_set<uint64_t> get_eos_ids(
   const auto& method_names = method_names_result.get();
 
   if (method_names.count(llm::kEosIds)) {
-    eos_ids.clear();
     auto execute_result = module->execute(llm::kEosIds);
     if (execute_result.error() != Error::Ok) {
       ET_LOG(Error, "Failed to execute %s", llm::kEosIds);
@@ -175,8 +176,10 @@ std::unordered_set<uint64_t> get_eos_ids(
     }
     for (const auto& eos_id : execute_result.get()) {
       auto value = eos_id.toScalar().to<int64_t>();
-      eos_ids.emplace(value);
-      ET_LOG(Info, "eos_id = %" PRId64, value);
+      auto [_, inserted] = eos_ids.emplace(value);
+      if (inserted) {
+        ET_LOG(Info, "Added eos_id from model metadata: %" PRId64, value);
+      }
     }
   }
   return eos_ids;

--- a/extension/llm/runner/pybindings.cpp
+++ b/extension/llm/runner/pybindings.cpp
@@ -12,7 +12,10 @@
 #include <pybind11/stl.h>
 #include <torch/python.h>
 
+#include <executorch/extension/llm/chat_template/chat_templates.h>
 #include <executorch/extension/llm/runner/audio.h>
+#include <executorch/extension/llm/runner/chat_types.h>
+#include <executorch/extension/llm/runner/jinja_chat_formatter.h>
 #include <executorch/extension/llm/runner/llm_runner_helper.h>
 #include <executorch/extension/llm/runner/multimodal_input.h>
 #include <executorch/extension/llm/runner/multimodal_runner.h>
@@ -307,6 +310,60 @@ PYBIND11_MODULE(_llm_runner, m) {
             " echo=" + (config.echo ? "True" : "False") +
             " warming=" + (config.warming ? "True" : "False") + ">";
       });
+
+  // Bind chat template helpers
+  py::class_<ChatMessage>(m, "ChatMessage")
+      .def(
+          py::init<std::string, std::string>(),
+          py::arg("role"),
+          py::arg("content"))
+      .def_readwrite("role", &ChatMessage::role)
+      .def_readwrite("content", &ChatMessage::content)
+      .def("__repr__", [](const ChatMessage& msg) {
+        std::string content_preview = msg.content.substr(0, 50);
+        if (msg.content.length() > 50) {
+          content_preview += "...";
+        }
+        return "<ChatMessage role='" + msg.role + "' content='" +
+            content_preview + "'>";
+      });
+
+  py::class_<ChatConversation>(m, "ChatConversation")
+      .def(py::init<>())
+      .def_readwrite("messages", &ChatConversation::messages)
+      .def_readwrite("bos_token", &ChatConversation::bos_token)
+      .def_readwrite("eos_token", &ChatConversation::eos_token)
+      .def_readwrite(
+          "add_generation_prompt", &ChatConversation::add_generation_prompt);
+
+  py::enum_<ChatTemplateType>(m, "ChatTemplateType")
+      .value("None_", ChatTemplateType::None)
+      .value("Llama3", ChatTemplateType::Llama3)
+      .value("Llama32", ChatTemplateType::Llama32)
+      .value("Gemma3", ChatTemplateType::Gemma3)
+      .value("Custom", ChatTemplateType::Custom);
+
+  py::class_<JinjaChatFormatter>(m, "JinjaChatFormatter")
+      .def_static(
+          "from_template",
+          &JinjaChatFormatter::fromTemplate,
+          py::arg("template_type"))
+      .def_static(
+          "from_string",
+          &JinjaChatFormatter::fromString,
+          py::arg("template_str"))
+      .def_static(
+          "from_file", &JinjaChatFormatter::fromFile, py::arg("path"))
+      .def(
+          "format",
+          &JinjaChatFormatter::format,
+          py::arg("prompt"),
+          py::arg("system_prompt") = "")
+      .def(
+          "format_conversation",
+          &JinjaChatFormatter::formatConversation,
+          py::arg("conversation"))
+      .def("includes_bos", &JinjaChatFormatter::includesBos);
 
   // Bind Stats
   py::class_<Stats>(m, "Stats")

--- a/extension/llm/runner/targets.bzl
+++ b/extension/llm/runner/targets.bzl
@@ -111,11 +111,14 @@ def define_common_targets():
         runtime.cxx_library(
             name = "runner_lib" + aten_suffix,
             exported_headers = [
+                "chat_types.h",
+                "jinja_chat_formatter.h",
                 "text_llm_runner.h",
                 "llm_runner_helper.h",
                 "constants.h",
             ],
             srcs = [
+                "jinja_chat_formatter.cpp",
                 "text_llm_runner.cpp",
                 "llm_runner_helper.cpp",
                 "multimodal_runner.cpp",
@@ -131,6 +134,7 @@ def define_common_targets():
                 ":text_decoder_runner" + aten_suffix,
                 ":text_prefiller" + aten_suffix,
                 ":text_token_generator" + aten_suffix,
+                "//executorch/extension/llm/chat_template:chat_templates",
                 "//executorch/extension/llm/runner/io_manager:io_manager" + aten_suffix,
                 "//executorch/extension/memory_allocator:cpu_caching_allocator",
                 "//pytorch/tokenizers:hf_tokenizer",
@@ -138,5 +142,6 @@ def define_common_targets():
                 "//pytorch/tokenizers:sentencepiece",
                 "//pytorch/tokenizers:tekken",
                 "//pytorch/tokenizers:tiktoken",
+                "@fbsource//third-party/jinja2cpp:jinja2cpp",
             ],
         )

--- a/extension/llm/runner/test/BUCK
+++ b/extension/llm/runner/test/BUCK
@@ -10,32 +10,21 @@ oncall("executorch")
 # targets.bzl. This file can contain fbcode-only targets.
 
 load(":targets.bzl", "define_common_targets")
-
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
 non_fbcode_target(_kind = define_common_targets,)
 
-# !!!! fbcode/executorch/extension/llm/runner/test/TARGETS was merged into this file, see https://fburl.com/workplace/xl8l9yuo for more info !!!!
-
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree.
-
-# Any targets that should be shared between fbcode and xplat must be defined in
-# targets.bzl. This file can contain fbcode-only targets.
-
-load(":targets.bzl", "define_common_targets")
-load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
-
 fbcode_target(_kind = define_common_targets,)
 
+# fbcode-only test that requires access to fbcode//executorch/test/models
 fbcode_target(_kind = runtime.cxx_test,
     name = "test_text_decoder_runner",
     srcs = ["test_text_decoder_runner.cpp"],
     deps = [
-        "//executorch/extension/llm/runner:runner_lib",
         "//executorch/extension/llm/runner/io_manager:io_manager",
+        "//executorch/extension/llm/runner:text_decoder_runner",
+        "//executorch/extension/module:module",
+        "//executorch/extension/tensor:tensor",
         "//executorch/kernels/portable:generated_lib",
         "//executorch/runtime/core/exec_aten/testing_util:tensor_util",
     ],
@@ -43,5 +32,5 @@ fbcode_target(_kind = runtime.cxx_test,
         "KVCACHE_CACHE_POS": "$(location fbcode//executorch/test/models:exported_programs[ModuleKVCacheCachePos.pte])",
         "KVCACHE_INPUT_POS": "$(location fbcode//executorch/test/models:exported_programs[ModuleKVCacheInputPos.pte])",
         "NO_KVCACHE": "$(location fbcode//executorch/test/models:exported_programs[ModuleNoKVCache.pte])",
-    }
+    },
 )

--- a/extension/llm/runner/test/CMakeLists.txt
+++ b/extension/llm/runner/test/CMakeLists.txt
@@ -19,6 +19,7 @@ include(${EXECUTORCH_ROOT}/tools/cmake/Test.cmake)
 
 set(_test_srcs
     test_generation_config.cpp
+    test_jinja_chat_formatter.cpp
     test_text_llm_runner.cpp
     test_text_prefiller.cpp
     test_text_decoder_runner.cpp

--- a/extension/llm/runner/test/targets.bzl
+++ b/extension/llm/runner/test/targets.bzl
@@ -18,6 +18,14 @@ def define_common_targets():
     )
 
     runtime.cxx_test(
+        name = "test_jinja_chat_formatter",
+        srcs = ["test_jinja_chat_formatter.cpp"],
+        deps = [
+            "//executorch/extension/llm/runner:runner_lib",
+        ],
+    )
+
+    runtime.cxx_test(
         name = "test_text_llm_runner",
         srcs = ["test_text_llm_runner.cpp"],
         deps = [

--- a/extension/llm/runner/test/test_jinja_chat_formatter.cpp
+++ b/extension/llm/runner/test/test_jinja_chat_formatter.cpp
@@ -198,14 +198,7 @@ TEST(JinjaChatFormatter, Llama32ModelTokens) {
   EXPECT_EQ(tokens.stop_tokens.size(), 2);
 }
 
-// Universal Jinja support: any HuggingFace / vLLM-style template string
-// (passed via fromString or fromFile) should work, not just the embedded
-// Llama3/Gemma3 templates. This validates the renderer with a generic
-// HuggingFace-style template that uses the standard `messages`,
-// `bos_token`, and `add_generation_prompt` variables.
 TEST(JinjaChatFormatter, UniversalJinjaGenericTemplate) {
-  // Generic chat template inspired by HuggingFace tokenizer_config.json
-  // examples. Uses only standard Jinja2 features and standard chat variables.
   const std::string generic_template =
       "{{ bos_token }}"
       "{%- for message in messages -%}"
@@ -227,13 +220,6 @@ TEST(JinjaChatFormatter, UniversalJinjaGenericTemplate) {
   EXPECT_THAT(result, HasSubstr("<|assistant|>"));
 }
 
-// Universal Jinja support: templates that reference `tools` (e.g. vLLM's
-// tool_chat_template_*.jinja files) should not crash even when no tools
-// are passed. The formatter injects `tools = []` (an empty list) so that
-// truthy/none checks evaluate consistently. With our normalization,
-// `tools is not none` is rewritten to `tools` (a truthy check), which means
-// an empty list (no tools) is treated as "no tools available" — matching
-// the typical template intent.
 TEST(JinjaChatFormatter, UniversalJinjaToolsAwareTemplate) {
   const std::string tools_template =
       "{%- if tools is not none -%}"
@@ -246,17 +232,9 @@ TEST(JinjaChatFormatter, UniversalJinjaToolsAwareTemplate) {
   ChatConversation conv;
   conv.add_generation_prompt = false;
 
-  // tools defaults to [] (empty list). After normalization this is a
-  // truthy check, so the empty-list (no tools) branch should be selected.
   EXPECT_EQ(formatter->formatConversation(conv), "no_tools");
 }
 
-// Universal Jinja support: a template using "not tools is none" (semantically
-// "tools is not none") should now safely evaluate without skipping the
-// "no tools" branch. This guards the regression where the normalizer mapped
-// "not tools is none" -> "not tools", which incorrectly evaluated to true
-// for an empty list and would have rendered a tool block when none was
-// intended.
 TEST(JinjaChatFormatter, UniversalJinjaNormalizedNotToolsIsNone) {
   const std::string template_str =
       "{%- if not tools is none -%}defined{%- else -%}none{%- endif -%}";
@@ -265,8 +243,6 @@ TEST(JinjaChatFormatter, UniversalJinjaNormalizedNotToolsIsNone) {
   ChatConversation conv;
   conv.add_generation_prompt = false;
 
-  // tools = [] is falsy after normalization (`not tools is none` -> `tools`).
-  // The "else" branch should be selected (no tools available).
   EXPECT_EQ(formatter->formatConversation(conv), "none");
 }
 

--- a/extension/llm/runner/test/test_jinja_chat_formatter.cpp
+++ b/extension/llm/runner/test/test_jinja_chat_formatter.cpp
@@ -26,9 +26,8 @@ TEST(JinjaChatFormatter, Llama3SingleMessage) {
   // but no trailing \n\n at the end due to the {%- endif -%} stripping.
   const std::string expected =
       "<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n\n" +
-      system_prompt +
-      "<|eot_id|><|start_header_id|>user<|end_header_id|>\n\n" + prompt +
-      "<|eot_id|><|start_header_id|>assistant<|end_header_id|>";
+      system_prompt + "<|eot_id|><|start_header_id|>user<|end_header_id|>\n\n" +
+      prompt + "<|eot_id|><|start_header_id|>assistant<|end_header_id|>";
 
   EXPECT_EQ(formatter->format(prompt, system_prompt), expected);
 }
@@ -50,7 +49,8 @@ TEST(JinjaChatFormatter, Llama3WithoutSystemPrompt) {
   EXPECT_THAT(result, HasSubstr("<|begin_of_text|>"));
   EXPECT_THAT(result, HasSubstr("<|start_header_id|>user<|end_header_id|>"));
   EXPECT_THAT(result, HasSubstr("Hello!"));
-  EXPECT_THAT(result, HasSubstr("<|start_header_id|>assistant<|end_header_id|>"));
+  EXPECT_THAT(
+      result, HasSubstr("<|start_header_id|>assistant<|end_header_id|>"));
   // Should not contain system header when no system prompt
   EXPECT_THAT(result, ::testing::Not(HasSubstr("<|start_header_id|>system")));
 }
@@ -101,7 +101,8 @@ TEST(JinjaChatFormatter, FormatConversationMultiTurn) {
   EXPECT_THAT(result, HasSubstr("Hello"));
   EXPECT_THAT(result, HasSubstr("Hi there!"));
   EXPECT_THAT(result, HasSubstr("How are you?"));
-  EXPECT_THAT(result, HasSubstr("<|start_header_id|>assistant<|end_header_id|>"));
+  EXPECT_THAT(
+      result, HasSubstr("<|start_header_id|>assistant<|end_header_id|>"));
 }
 
 TEST(JinjaChatFormatter, FromStringLlama3Template) {
@@ -179,7 +180,8 @@ TEST(JinjaChatFormatter, Llama32SingleMessage) {
   EXPECT_THAT(result, HasSubstr("<|begin_of_text|>"));
   EXPECT_THAT(result, HasSubstr("<|start_header_id|>user<|end_header_id|>"));
   EXPECT_THAT(result, HasSubstr("Hello!"));
-  EXPECT_THAT(result, HasSubstr("<|start_header_id|>assistant<|end_header_id|>"));
+  EXPECT_THAT(
+      result, HasSubstr("<|start_header_id|>assistant<|end_header_id|>"));
 }
 
 TEST(JinjaChatFormatter, Llama32IncludesBos) {
@@ -266,5 +268,4 @@ TEST(JinjaChatFormatter, UniversalJinjaNormalizedNotToolsIsNone) {
   // tools = [] is falsy after normalization (`not tools is none` -> `tools`).
   // The "else" branch should be selected (no tools available).
   EXPECT_EQ(formatter->formatConversation(conv), "none");
-}
 }

--- a/extension/llm/runner/test/test_jinja_chat_formatter.cpp
+++ b/extension/llm/runner/test/test_jinja_chat_formatter.cpp
@@ -246,6 +246,18 @@ TEST(JinjaChatFormatter, UniversalJinjaNormalizedNotToolsIsNone) {
   EXPECT_EQ(formatter->formatConversation(conv), "none");
 }
 
+TEST(JinjaChatFormatter, UniversalJinjaToolOutputObjectLiteral) {
+  const std::string template_str =
+      R"({%- for message in messages -%}{{ { "output": message.content } | tojson }}{%- endfor -%})";
+
+  auto formatter = JinjaChatFormatter::fromString(template_str);
+  ChatConversation conv;
+  conv.add_generation_prompt = false;
+  conv.messages.push_back(ChatMessage{"tool", "done"});
+
+  EXPECT_EQ(formatter->formatConversation(conv), R"({"output":"done"})");
+}
+
 TEST(JinjaChatFormatter, VllmLlama32PythonicToolTemplate) {
   // Mirrors vLLM's examples/tool_chat_template_llama3.2_pythonic.jinja.
   const std::string template_str = R"({{- bos_token }}

--- a/extension/llm/runner/test/test_jinja_chat_formatter.cpp
+++ b/extension/llm/runner/test/test_jinja_chat_formatter.cpp
@@ -269,3 +269,117 @@ TEST(JinjaChatFormatter, UniversalJinjaNormalizedNotToolsIsNone) {
   // The "else" branch should be selected (no tools available).
   EXPECT_EQ(formatter->formatConversation(conv), "none");
 }
+
+TEST(JinjaChatFormatter, VllmLlama32PythonicToolTemplate) {
+  // Mirrors vLLM's examples/tool_chat_template_llama3.2_pythonic.jinja.
+  const std::string template_str = R"({{- bos_token }}
+{%- if custom_tools is defined %}
+    {%- set tools = custom_tools %}
+{%- endif %}
+{%- if not tools_in_user_message is defined %}
+    {%- set tools_in_user_message = false %}
+{%- endif %}
+{%- if not date_string is defined %}
+    {%- if strftime_now is defined %}
+        {%- set date_string = strftime_now("%d %b %Y") %}
+    {%- else %}
+        {%- set date_string = "26 Jul 2024" %}
+    {%- endif %}
+{%- endif %}
+{%- if not tools is defined %}
+    {%- set tools = none %}
+{%- endif %}
+
+{#- This block extracts the system message, so we can slot it into the right place. #}
+{%- if messages[0]['role'] == 'system' %}
+    {%- set system_message = messages[0]['content']|trim %}
+    {%- set messages = messages[1:] %}
+{%- else %}
+    {%- set system_message = "You are a helpful assistant with tool calling capabilities. Only reply with a tool call if the function exists in the library provided by the user. If it doesn't exist, just reply directly in natural language. When you receive a tool call response, use the output to format an answer to the original user question." %}
+{%- endif %}
+
+{#- System message #}
+{{- "<|start_header_id|>system<|end_header_id|>\n\n" }}
+{%- if tools is not none %}
+    {{- "Environment: ipython\n" }}
+{%- endif %}
+{{- "Cutting Knowledge Date: December 2023\n" }}
+{{- "Today Date: " + date_string + "\n\n" }}
+{%- if tools is not none and not tools_in_user_message %}
+    {{- "You have access to the following functions. To call functions, please respond with a python list of the calls. " }}
+    {{- 'Respond in the format [func_name1(params_name1=params_value1, params_name2=params_value2...), func_name2(params)] ' }}
+    {{- "Do not use variables.\n\n" }}
+    {%- for t in tools %}
+        {{- t | tojson(indent=4) }}
+        {{- "\n\n" }}
+    {%- endfor %}
+{%- endif %}
+{{- system_message }}
+{{- "<|eot_id|>" }}
+
+{#- Custom tools are passed in a user message with some extra guidance #}
+{%- if tools_in_user_message and not tools is none %}
+    {#- Extract the first user message so we can plug it in here #}
+    {%- if messages | length != 0 %}
+        {%- set first_user_message = messages[0]['content']|trim %}
+        {%- set messages = messages[1:] %}
+    {%- else %}
+        {{- raise_exception("Cannot put tools in the first user message when there's no first user message!") }}
+    {%- endif %}
+    {{- '<|start_header_id|>user<|end_header_id|>\n\n' -}}
+    {{- "Given the following functions, please respond with a python list for function calls " }}
+    {{- "with their proper arguments to best answer the given prompt.\n\n" }}
+    {{- 'Respond in the format [func_name1(params_name1=params_value1, params_name2=params_value2...), func_name2(params)] ' }}
+    {{- "Do not use variables.\n\n" }}
+    {%- for t in tools %}
+        {{- t | tojson(indent=4) }}
+        {{- "\n\n" }}
+    {%- endfor %}
+    {{- first_user_message + "<|eot_id|>"}}
+{%- endif %}
+
+{%- for message in messages %}
+    {%- if not (message.role == 'ipython' or message.role == 'tool' or 'tool_calls' in message) %}
+        {{- '<|start_header_id|>' + message['role'] + '<|end_header_id|>\n\n'+ message['content'] | trim + '<|eot_id|>' }}
+    {%- elif 'tool_calls' in message %}
+        {{- '<|start_header_id|>assistant<|end_header_id|>\n\n[' -}}
+        {%- for tool_call in message.tool_calls %}
+            {%- if tool_call.function is defined %}
+                {%- set tool_call = tool_call.function %}
+            {%- endif %}
+            {{- tool_call.name + '(' -}}
+            {%- for param in tool_call.arguments %}
+                {{- param + '=' -}}
+                {{- "%s" | format(tool_call.arguments[param]) -}}
+                {% if not loop.last %}, {% endif %}
+            {%- endfor %}
+            {{- ')' -}}
+            {% if not loop.last %}, {% endif %}
+        {%- endfor %}
+        {{- ']<|eot_id|>' -}}
+    {%- elif message.role == "tool" or message.role == "ipython" %}
+        {{- "<|start_header_id|>ipython<|end_header_id|>\n\n" }}
+        {%- if message.content is mapping %}
+            {{- message.content | tojson }}
+        {%- else %}
+            {{- { "output": message.content } | tojson }}
+        {%- endif %}
+        {{- "<|eot_id|>" }}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|start_header_id|>assistant<|end_header_id|>\n\n' }}
+{%- endif %}
+)";
+
+  auto formatter = JinjaChatFormatter::fromString(template_str);
+  const std::string result = formatter->format("Hello!");
+
+  EXPECT_THAT(result, HasSubstr("<|begin_of_text|>"));
+  EXPECT_THAT(result, HasSubstr("<|start_header_id|>system<|end_header_id|>"));
+  EXPECT_THAT(result, HasSubstr("Today Date: 26 Jul 2024"));
+  EXPECT_THAT(result, HasSubstr("<|start_header_id|>user<|end_header_id|>"));
+  EXPECT_THAT(result, HasSubstr("Hello!"));
+  EXPECT_THAT(
+      result, HasSubstr("<|start_header_id|>assistant<|end_header_id|>"));
+}

--- a/extension/llm/runner/test/test_jinja_chat_formatter.cpp
+++ b/extension/llm/runner/test/test_jinja_chat_formatter.cpp
@@ -1,0 +1,270 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/extension/llm/runner/jinja_chat_formatter.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+using executorch::extension::llm::ChatConversation;
+using executorch::extension::llm::ChatMessage;
+using executorch::extension::llm::ChatTemplateType;
+using executorch::extension::llm::JinjaChatFormatter;
+using executorch::extension::llm::parseChatTemplateType;
+using testing::HasSubstr;
+
+TEST(JinjaChatFormatter, Llama3SingleMessage) {
+  auto formatter = JinjaChatFormatter::fromTemplate(ChatTemplateType::Llama3);
+  const std::string prompt = "Test prompt";
+  const std::string system_prompt = "You are a helpful assistant.";
+  // Note: The Jinja template uses {%- ... -%} which strips whitespace,
+  // so the output has \n\n after each <|end_header_id|> and content,
+  // but no trailing \n\n at the end due to the {%- endif -%} stripping.
+  const std::string expected =
+      "<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n\n" +
+      system_prompt +
+      "<|eot_id|><|start_header_id|>user<|end_header_id|>\n\n" + prompt +
+      "<|eot_id|><|start_header_id|>assistant<|end_header_id|>";
+
+  EXPECT_EQ(formatter->format(prompt, system_prompt), expected);
+}
+
+TEST(JinjaChatFormatter, Gemma3SingleMessage) {
+  auto formatter = JinjaChatFormatter::fromTemplate(ChatTemplateType::Gemma3);
+  const std::string result = formatter->format("Hello!");
+
+  EXPECT_THAT(result, HasSubstr("<bos>"));
+  EXPECT_THAT(result, HasSubstr("<start_of_turn>user"));
+  EXPECT_THAT(result, HasSubstr("Hello!"));
+  EXPECT_THAT(result, HasSubstr("<start_of_turn>model"));
+}
+
+TEST(JinjaChatFormatter, Llama3WithoutSystemPrompt) {
+  auto formatter = JinjaChatFormatter::fromTemplate(ChatTemplateType::Llama3);
+  const std::string result = formatter->format("Hello!");
+
+  EXPECT_THAT(result, HasSubstr("<|begin_of_text|>"));
+  EXPECT_THAT(result, HasSubstr("<|start_header_id|>user<|end_header_id|>"));
+  EXPECT_THAT(result, HasSubstr("Hello!"));
+  EXPECT_THAT(result, HasSubstr("<|start_header_id|>assistant<|end_header_id|>"));
+  // Should not contain system header when no system prompt
+  EXPECT_THAT(result, ::testing::Not(HasSubstr("<|start_header_id|>system")));
+}
+
+TEST(JinjaChatFormatter, Llama3IncludesBos) {
+  auto formatter = JinjaChatFormatter::fromTemplate(ChatTemplateType::Llama3);
+  EXPECT_TRUE(formatter->includesBos());
+}
+
+TEST(JinjaChatFormatter, Gemma3IncludesBos) {
+  auto formatter = JinjaChatFormatter::fromTemplate(ChatTemplateType::Gemma3);
+  EXPECT_TRUE(formatter->includesBos());
+}
+
+TEST(JinjaChatFormatter, Llama3ModelTokens) {
+  auto formatter = JinjaChatFormatter::fromTemplate(ChatTemplateType::Llama3);
+  const auto& tokens = formatter->getModelTokens();
+
+  EXPECT_EQ(tokens.bos_token, "<|begin_of_text|>");
+  EXPECT_EQ(tokens.eos_token, "<|eot_id|>");
+  EXPECT_EQ(tokens.stop_tokens.size(), 2);
+}
+
+TEST(JinjaChatFormatter, Gemma3ModelTokens) {
+  auto formatter = JinjaChatFormatter::fromTemplate(ChatTemplateType::Gemma3);
+  const auto& tokens = formatter->getModelTokens();
+
+  EXPECT_EQ(tokens.bos_token, "<bos>");
+  EXPECT_EQ(tokens.eos_token, "<end_of_turn>");
+  EXPECT_EQ(tokens.stop_tokens.size(), 2);
+}
+
+TEST(JinjaChatFormatter, FormatConversationMultiTurn) {
+  auto formatter = JinjaChatFormatter::fromTemplate(ChatTemplateType::Llama3);
+
+  ChatConversation conversation;
+  conversation.bos_token = "<|begin_of_text|>";
+  conversation.eos_token = "<|eot_id|>";
+  conversation.add_generation_prompt = true;
+  conversation.messages = {
+      {"user", "Hello"},
+      {"assistant", "Hi there!"},
+      {"user", "How are you?"},
+  };
+
+  const std::string result = formatter->formatConversation(conversation);
+
+  EXPECT_THAT(result, HasSubstr("Hello"));
+  EXPECT_THAT(result, HasSubstr("Hi there!"));
+  EXPECT_THAT(result, HasSubstr("How are you?"));
+  EXPECT_THAT(result, HasSubstr("<|start_header_id|>assistant<|end_header_id|>"));
+}
+
+TEST(JinjaChatFormatter, FromStringLlama3Template) {
+  const std::string llama_template =
+      "{{ bos_token }}<|start_header_id|>user<|end_header_id|>\n\n"
+      "{{ messages[0].content }}<|eot_id|>";
+
+  auto formatter = JinjaChatFormatter::fromString(llama_template);
+
+  // Should detect Llama3 type from the template content
+  const std::string result = formatter->format("Test");
+  EXPECT_THAT(result, HasSubstr("Test"));
+}
+
+TEST(JinjaChatFormatter, FromStringGemma3Template) {
+  const std::string gemma_template =
+      "{{ bos_token }}<start_of_turn>user\n"
+      "{{ messages[0].content }}<end_of_turn>";
+
+  auto formatter = JinjaChatFormatter::fromString(gemma_template);
+
+  const std::string result = formatter->format("Test");
+  EXPECT_THAT(result, HasSubstr("Test"));
+}
+
+TEST(JinjaChatFormatter, UnsupportedTemplateTypeThrows) {
+  EXPECT_THROW(
+      JinjaChatFormatter::fromTemplate(ChatTemplateType::None),
+      std::runtime_error);
+}
+
+// Tests for parseChatTemplateType
+TEST(ParseChatTemplateType, ParseNone) {
+  EXPECT_EQ(parseChatTemplateType("none"), ChatTemplateType::None);
+  EXPECT_EQ(parseChatTemplateType("None"), ChatTemplateType::None);
+  EXPECT_EQ(parseChatTemplateType("NONE"), ChatTemplateType::None);
+}
+
+TEST(ParseChatTemplateType, ParseLlama3) {
+  EXPECT_EQ(parseChatTemplateType("llama3"), ChatTemplateType::Llama3);
+  EXPECT_EQ(parseChatTemplateType("LLAMA3"), ChatTemplateType::Llama3);
+  EXPECT_EQ(parseChatTemplateType("Llama3"), ChatTemplateType::Llama3);
+}
+
+TEST(ParseChatTemplateType, ParseLlama32Variants) {
+  EXPECT_EQ(parseChatTemplateType("llama3.2"), ChatTemplateType::Llama32);
+  EXPECT_EQ(parseChatTemplateType("llama32"), ChatTemplateType::Llama32);
+  EXPECT_EQ(parseChatTemplateType("llama3_2"), ChatTemplateType::Llama32);
+  EXPECT_EQ(parseChatTemplateType("LLAMA3.2"), ChatTemplateType::Llama32);
+}
+
+TEST(ParseChatTemplateType, ParseGemma3) {
+  EXPECT_EQ(parseChatTemplateType("gemma3"), ChatTemplateType::Gemma3);
+  EXPECT_EQ(parseChatTemplateType("GEMMA3"), ChatTemplateType::Gemma3);
+  EXPECT_EQ(parseChatTemplateType("Gemma3"), ChatTemplateType::Gemma3);
+}
+
+TEST(ParseChatTemplateType, ParseCustom) {
+  EXPECT_EQ(parseChatTemplateType("custom"), ChatTemplateType::Custom);
+  EXPECT_EQ(parseChatTemplateType("jinja"), ChatTemplateType::Custom);
+  EXPECT_EQ(parseChatTemplateType("CUSTOM"), ChatTemplateType::Custom);
+}
+
+TEST(ParseChatTemplateType, ParseUnknownReturnsNone) {
+  EXPECT_EQ(parseChatTemplateType("unknown"), ChatTemplateType::None);
+  EXPECT_EQ(parseChatTemplateType(""), ChatTemplateType::None);
+  EXPECT_EQ(parseChatTemplateType("invalid"), ChatTemplateType::None);
+}
+
+TEST(JinjaChatFormatter, Llama32SingleMessage) {
+  auto formatter = JinjaChatFormatter::fromTemplate(ChatTemplateType::Llama32);
+  const std::string result = formatter->format("Hello!");
+
+  // Llama32 uses the same template as Llama3
+  EXPECT_THAT(result, HasSubstr("<|begin_of_text|>"));
+  EXPECT_THAT(result, HasSubstr("<|start_header_id|>user<|end_header_id|>"));
+  EXPECT_THAT(result, HasSubstr("Hello!"));
+  EXPECT_THAT(result, HasSubstr("<|start_header_id|>assistant<|end_header_id|>"));
+}
+
+TEST(JinjaChatFormatter, Llama32IncludesBos) {
+  auto formatter = JinjaChatFormatter::fromTemplate(ChatTemplateType::Llama32);
+  EXPECT_TRUE(formatter->includesBos());
+}
+
+TEST(JinjaChatFormatter, Llama32ModelTokens) {
+  auto formatter = JinjaChatFormatter::fromTemplate(ChatTemplateType::Llama32);
+  const auto& tokens = formatter->getModelTokens();
+
+  EXPECT_EQ(tokens.bos_token, "<|begin_of_text|>");
+  EXPECT_EQ(tokens.eos_token, "<|eot_id|>");
+  EXPECT_EQ(tokens.stop_tokens.size(), 2);
+}
+
+// Universal Jinja support: any HuggingFace / vLLM-style template string
+// (passed via fromString or fromFile) should work, not just the embedded
+// Llama3/Gemma3 templates. This validates the renderer with a generic
+// HuggingFace-style template that uses the standard `messages`,
+// `bos_token`, and `add_generation_prompt` variables.
+TEST(JinjaChatFormatter, UniversalJinjaGenericTemplate) {
+  // Generic chat template inspired by HuggingFace tokenizer_config.json
+  // examples. Uses only standard Jinja2 features and standard chat variables.
+  const std::string generic_template =
+      "{{ bos_token }}"
+      "{%- for message in messages -%}"
+      "<|{{ message.role }}|>\n{{ message.content }}<|end|>\n"
+      "{%- endfor -%}"
+      "{%- if add_generation_prompt -%}<|assistant|>\n{%- endif -%}";
+
+  auto formatter = JinjaChatFormatter::fromString(generic_template);
+  ChatConversation conv;
+  conv.bos_token = "<s>";
+  conv.add_generation_prompt = true;
+  conv.messages.push_back(ChatMessage{"user", "Hi there"});
+
+  const std::string result = formatter->formatConversation(conv);
+
+  EXPECT_THAT(result, HasSubstr("<s>"));
+  EXPECT_THAT(result, HasSubstr("<|user|>"));
+  EXPECT_THAT(result, HasSubstr("Hi there"));
+  EXPECT_THAT(result, HasSubstr("<|assistant|>"));
+}
+
+// Universal Jinja support: templates that reference `tools` (e.g. vLLM's
+// tool_chat_template_*.jinja files) should not crash even when no tools
+// are passed. The formatter injects `tools = []` (an empty list) so that
+// truthy/none checks evaluate consistently. With our normalization,
+// `tools is not none` is rewritten to `tools` (a truthy check), which means
+// an empty list (no tools) is treated as "no tools available" — matching
+// the typical template intent.
+TEST(JinjaChatFormatter, UniversalJinjaToolsAwareTemplate) {
+  const std::string tools_template =
+      "{%- if tools is not none -%}"
+      "tools_present"
+      "{%- else -%}"
+      "no_tools"
+      "{%- endif -%}";
+
+  auto formatter = JinjaChatFormatter::fromString(tools_template);
+  ChatConversation conv;
+  conv.add_generation_prompt = false;
+
+  // tools defaults to [] (empty list). After normalization this is a
+  // truthy check, so the empty-list (no tools) branch should be selected.
+  EXPECT_EQ(formatter->formatConversation(conv), "no_tools");
+}
+
+// Universal Jinja support: a template using "not tools is none" (semantically
+// "tools is not none") should now safely evaluate without skipping the
+// "no tools" branch. This guards the regression where the normalizer mapped
+// "not tools is none" -> "not tools", which incorrectly evaluated to true
+// for an empty list and would have rendered a tool block when none was
+// intended.
+TEST(JinjaChatFormatter, UniversalJinjaNormalizedNotToolsIsNone) {
+  const std::string template_str =
+      "{%- if not tools is none -%}defined{%- else -%}none{%- endif -%}";
+
+  auto formatter = JinjaChatFormatter::fromString(template_str);
+  ChatConversation conv;
+  conv.add_generation_prompt = false;
+
+  // tools = [] is falsy after normalization (`not tools is none` -> `tools`).
+  // The "else" branch should be selected (no tools available).
+  EXPECT_EQ(formatter->formatConversation(conv), "none");
+}
+}

--- a/extension/llm/runner/test/test_runner_pybindings.py
+++ b/extension/llm/runner/test/test_runner_pybindings.py
@@ -18,8 +18,12 @@ import unittest
 
 import torch
 from executorch.extension.llm.runner import (
+    ChatConversation,
+    ChatMessage,
+    ChatTemplateType,
     GenerationConfig,
     Image,
+    JinjaChatFormatter,
     make_image_input,
     make_text_input,
     MultimodalInput,
@@ -264,3 +268,82 @@ class TestHelperFunctions(unittest.TestCase):
         img_tensor_rgba = torch.ones((4, 50, 50), dtype=torch.uint8) * 128
         image_input_rgba = make_image_input(img_tensor_rgba)
         self.assertTrue(image_input_rgba.is_image())
+
+
+class TestChatTemplateBindings(unittest.TestCase):
+    """Test Jinja chat template bindings."""
+
+    def test_format_llama3(self):
+        formatter = JinjaChatFormatter.from_template(ChatTemplateType.Llama3)
+        result = formatter.format("Hello!", "System prompt")
+        self.assertIn("<|begin_of_text|>", result)
+        self.assertIn("System prompt", result)
+        self.assertIn("Hello!", result)
+        self.assertIn("<|start_header_id|>assistant", result)
+
+    def test_format_conversation(self):
+        formatter = JinjaChatFormatter.from_template(ChatTemplateType.Gemma3)
+        conversation = ChatConversation()
+        conversation.bos_token = "<bos>"
+        conversation.eos_token = "<end_of_turn>"
+        conversation.add_generation_prompt = True
+        conversation.messages = [
+            ChatMessage("user", "Hi"),
+            ChatMessage("assistant", "Hello"),
+        ]
+        result = formatter.format_conversation(conversation)
+        self.assertIn("<start_of_turn>user", result)
+        self.assertIn("Hi", result)
+        self.assertIn("<start_of_turn>model", result)
+
+    def test_format_llama3_without_system_prompt(self):
+        formatter = JinjaChatFormatter.from_template(ChatTemplateType.Llama3)
+        result = formatter.format("Hello!")
+        self.assertIn("<|begin_of_text|>", result)
+        self.assertIn("Hello!", result)
+        self.assertIn("<|start_header_id|>user", result)
+        # Should not contain system when no system prompt provided
+        self.assertNotIn("<|start_header_id|>system", result)
+
+    def test_format_gemma3(self):
+        formatter = JinjaChatFormatter.from_template(ChatTemplateType.Gemma3)
+        result = formatter.format("Test message", "Be helpful")
+        self.assertIn("<bos>", result)
+        self.assertIn("Test message", result)
+        self.assertIn("<start_of_turn>model", result)
+
+    def test_includes_bos_llama3(self):
+        formatter = JinjaChatFormatter.from_template(ChatTemplateType.Llama3)
+        self.assertTrue(formatter.includes_bos())
+
+    def test_includes_bos_gemma3(self):
+        formatter = JinjaChatFormatter.from_template(ChatTemplateType.Gemma3)
+        self.assertTrue(formatter.includes_bos())
+
+    def test_from_string_llama_template(self):
+        template = "{{ bos_token }}<|start_header_id|>user<|end_header_id|>\n\n{{ messages[0].content }}<|eot_id|>"
+        formatter = JinjaChatFormatter.from_string(template)
+        result = formatter.format("Test")
+        self.assertIn("Test", result)
+
+    def test_from_string_gemma_template(self):
+        template = "{{ bos_token }}<start_of_turn>user\n{{ messages[0].content }}<end_of_turn>"
+        formatter = JinjaChatFormatter.from_string(template)
+        result = formatter.format("Test")
+        self.assertIn("Test", result)
+
+    def test_chat_message_creation(self):
+        msg = ChatMessage("user", "Hello world")
+        self.assertEqual(msg.role, "user")
+        self.assertEqual(msg.content, "Hello world")
+
+    def test_chat_conversation_creation(self):
+        conv = ChatConversation()
+        conv.bos_token = "<bos>"
+        conv.eos_token = "<eos>"
+        conv.add_generation_prompt = False
+        conv.messages = [ChatMessage("user", "Hi")]
+        self.assertEqual(conv.bos_token, "<bos>")
+        self.assertEqual(conv.eos_token, "<eos>")
+        self.assertFalse(conv.add_generation_prompt)
+        self.assertEqual(len(conv.messages), 1)

--- a/extension/llm/runner/text_llm_runner.cpp
+++ b/extension/llm/runner/text_llm_runner.cpp
@@ -20,7 +20,50 @@
 #include <pytorch/tokenizers/sentencepiece.h>
 #include <pytorch/tokenizers/tiktoken.h>
 
+#include <unordered_set>
+
 namespace executorch::extension::llm {
+
+namespace {
+// Known special tokens used by LLM chat templates.
+// When echo=false, these are filtered out of the streamed output so users
+// see clean assistant text. When echo=true, the user explicitly asked for
+// raw model output, so we emit them unchanged.
+const std::unordered_set<std::string> kKnownSpecialTokens = {
+    // Llama 3.x tokens
+    "<|begin_of_text|>",
+    "<|end_of_text|>",
+    "<|start_header_id|>",
+    "<|end_header_id|>",
+    "<|eot_id|>",
+    // Gemma tokens
+    "<bos>",
+    "<eos>",
+    "<start_of_turn>",
+    "<end_of_turn>",
+    // Common tokens
+    "</s>",
+    "<s>",
+    "<pad>",
+    "<unk>",
+};
+
+bool is_special_token(const std::string& text) {
+  if (text.empty()) {
+    return false;
+  }
+  // Check against known special tokens
+  if (kKnownSpecialTokens.count(text) > 0) {
+    return true;
+  }
+  // Match Llama-style tokens: <|...|>
+  if (text.size() >= 4 && text.front() == '<' && text[1] == '|' &&
+      text.back() == '>' && text[text.size() - 2] == '|') {
+    return true;
+  }
+  return false;
+}
+} // namespace
 
 using ::executorch::extension::Module;
 using ::executorch::runtime::Error;
@@ -96,8 +139,14 @@ Error TextLLMRunner::generate(
   std::function<void(const std::string&)> wrapped_callback =
       [token_callback, config](const std::string& piece) {
         if (!config.warming) {
-          llm::safe_printf(piece.c_str());
-          fflush(stdout);
+          // When echo=false, filter out special tokens (e.g. <|eot_id|>) so
+          // users get clean assistant output. When echo=true, the user asked
+          // for raw model output including any chat-template tokens, so emit
+          // everything unchanged.
+          if (config.echo || !is_special_token(piece)) {
+            llm::safe_printf(piece.c_str());
+            fflush(stdout);
+          }
         }
         if (token_callback) {
           token_callback(piece);

--- a/shim_et/xplat/executorch/build/build_variables.bzl
+++ b/shim_et/xplat/executorch/build/build_variables.bzl
@@ -36,7 +36,6 @@ PROGRAM_NO_PRIM_OPS_SRCS = [
     "method.cpp",
     "method_meta.cpp",
     "program.cpp",
-    "program_validation.cpp",
     "tensor_parser_exec_aten.cpp",
 ]
 
@@ -357,6 +356,7 @@ EXTENSION_RUNNER_UTIL_SRCS = [
 ]
 
 EXTENSION_LLM_RUNNER_SRCS = [
+    "extension/llm/runner/jinja_chat_formatter.cpp",
     "extension/llm/runner/llm_runner_helper.cpp",
     "extension/llm/runner/multimodal_prefiller.cpp",
     "extension/llm/runner/multimodal_runner.cpp",
@@ -476,7 +476,6 @@ XNNPACK_BACKEND_BUCK_SRCS = [
     "runtime/XNNPACKBackend.cpp",
     "runtime/XNNWeightsCache.cpp",
     "runtime/XNNWorkspaceManager.cpp",
-    "runtime/XnnpackBackendOptions.cpp",
     "runtime/profiling/XNNProfiler.cpp",
 ]
 

--- a/shim_et/xplat/executorch/build/build_variables.bzl
+++ b/shim_et/xplat/executorch/build/build_variables.bzl
@@ -36,6 +36,7 @@ PROGRAM_NO_PRIM_OPS_SRCS = [
     "method.cpp",
     "method_meta.cpp",
     "program.cpp",
+    "program_validation.cpp",
     "tensor_parser_exec_aten.cpp",
 ]
 
@@ -476,6 +477,7 @@ XNNPACK_BACKEND_BUCK_SRCS = [
     "runtime/XNNPACKBackend.cpp",
     "runtime/XNNWeightsCache.cpp",
     "runtime/XNNWorkspaceManager.cpp",
+    "runtime/XnnpackBackendOptions.cpp",
     "runtime/profiling/XNNProfiler.cpp",
 ]
 


### PR DESCRIPTION
## Summary

Part 3 of the chat-template support stack split out of #16987 per @kirklandsign's request.

This PR exposes the `JinjaChatFormatter` (added in PR-A #19533) to Python via pybind11, and integrates it into the example `LlamaRunner` Python class.

## Stack overview

| PR | Subject |
|---|---|
| 1/4 | [#19533](https://github.com/pytorch/executorch/pull/19533) Library + tests |
| 2/4 | [#19534](https://github.com/pytorch/executorch/pull/19534) TextLLMRunner echo gating + EOS merge |
| **3/4 (this PR)** | Python bindings + Python LlamaRunner integration |
| 4/4 | llama_main CLI flags + chat_formatter wrapper + universal Jinja docs |

## What this PR adds

### C++ pybind11 bindings (`extension/llm/runner/pybindings.cpp`)

- `ChatMessage(role, content)`
- `ChatConversation(messages, bos_token, eos_token, add_generation_prompt)`
- `ChatTemplateType` enum (`None_`, `Llama3`, `Llama32`, `Gemma3`, `Custom`)
- `JinjaChatFormatter` with `from_template` / `from_string` / `from_file` static factories, `format(prompt, system_prompt)` and `format_conversation(ChatConversation)` methods, and `includes_bos()`

### Python package surface

- `extension/llm/runner/__init__.py` — re-exports the new bindings via `__all__`
- `extension/llm/runner/_llm_runner.pyi` — type stubs for the new classes (IDE / mypy support)

### Python `LlamaRunner` integration (`examples/models/llama/runner/generation.py`)

`LlamaRunner` now accepts `chat_format` / `system_prompt` / `chat_template_file` kwargs and exposes `_format_prompt` + `chat_completion` using the `JinjaChatFormatter`.

**Backward-compat**: default `chat_format` is `"none"` (matches `llama_main`, preserves backward compatibility for existing `EagerLlamaRunner` / `NativeLlamaRunner` callers that don't pass `chat_format`).

`_resolve_template_type` maps `"llama3.2"` / `"llama32"` / `"llama3_2"` to `ChatTemplateType.Llama32` (consistent with C++ `parseChatTemplateType`) — addresses the cross-language consistency comment from Copilot review on the original PR.

### CLI integration (`examples/models/llama/runner/eager.py`)

Adds `--chat_template_file` CLI flag for chat mode.

### Tests (`extension/llm/runner/test/test_runner_pybindings.py`)

Python tests covering the new bindings end-to-end.

## Why this is split out

Python changes are independently testable and reviewers may want different eyes on the Python vs. C++ paths. Also isolates the backward-compat concern around the `chat_format` default.

## Test Plan

- [x] Build with `EXECUTORCH_BUILD_PYBIND=ON`
- [x] Run Python tests: `pytest extension/llm/runner/test/test_runner_pybindings.py`
- [x] Verify `from executorch.extension.llm.runner import JinjaChatFormatter` works
- [x] Verify `LlamaRunner.chat_completion()` formats prompts correctly with default Llama3 template
- [x] Verify `LlamaRunner` constructor with `chat_format="none"` (default) is backward-compatible
- [x] Verify `_resolve_template_type` maps Llama 3.2 variants to `Llama32`

## Depends on

- PR-A: [#19533](https://github.com/pytorch/executorch/pull/19533) (`JinjaChatFormatter` library headers/symbols)

## Original PR

Splitting #16987 into 4 reviewable PRs.

cc @kirklandsign @larryliu0820 @metascroy
