### PR TITLE
only register test device allocator once for multiple invoke

### DIFF
--- a/runtime/core/test/device_allocator_test.cpp
+++ b/runtime/core/test/device_allocator_test.cpp
@@ -147,7 +147,9 @@ class DeviceAllocatorTest : public ::testing::Test {
 
   static void SetUpTestSuite() {
     executorch::runtime::runtime_init();
-    register_device_allocator(&cuda_allocator());
+    if (get_device_allocator(DeviceType::CUDA) == nullptr) {
+      register_device_allocator(&cuda_allocator());
+    }
   }
 
   void SetUp() override {


### PR DESCRIPTION
Summary:
On AppleMac, the XCTest harness invokes RUN_ALL_TESTS() once per test method within the same process, so DeviceAllocatorTest::SetUpTestSuite() runs multiple times. The second invocation calls register_device_allocator(&cuda_allocator()) for an already-registered CUDA slot, hitting ET_CHECK_MSG(allocators_[index] == nullptr, ...) in device_allocator.cpp:30 and aborting the process.

This diff made the registration in SetUpTestSuite() idempotent by guarding it with get_device_allocator(DeviceType::CUDA) == nullptr.

Differential Revision: D104955274


