### PR TITLE
Zephyr: Move CI testing to a script

### DIFF
--- a/.ci/scripts/test_zephyr.sh
+++ b/.ci/scripts/test_zephyr.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
+EXECUTORCH_PROJ_ROOT="$(realpath "${SCRIPT_DIR}/../..")"
+ZEPHYR_README_PATH="zephyr/README.md"
+
+ZEPHYR_SAMPLES_README_PATH="zephyr/samples/hello-executorch/README.md"
+TARGETS_ARG="${TARGET_LIST:-}"
+
+usage() {
+  cat <<EOF
+Usage: $0 [options]
+
+Options:
+  --zephyr-samples-readme-path <path>  README containing test_<TARGET>* command blocks
+  --targets <list>                    Comma-separated target list, e.g. ethos-u55,cortex-m55,ethos-u85
+  -h, --help                           Show this help
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --targets)
+      TARGETS_ARG="$2"
+      shift 2
+      ;;
+    --zephyr-samples-readme-path)
+      ZEPHYR_SAMPLES_README_PATH="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "ERROR: Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "${TARGETS_ARG}" ]]; then
+  echo "ERROR: --targets or TARGET_LIST must be set" >&2
+  usage >&2
+  exit 1
+fi
+
+IFS=',' read -r -a TARGETS <<< "${TARGETS_ARG}"
+
+export EXECUTORCH_PROJ_ROOT
+
+cd "${EXECUTORCH_PROJ_ROOT}"
+
+# Source utility scripts.
+. .ci/scripts/utils.sh
+. .ci/scripts/zephyr-utils.sh
+
+run_target_test_blocks_from_readme() {
+  local readme_path="$1"
+  local target="$2"
+  local resolved_readme_path marker markers
+
+  resolved_readme_path="$(_utils_path_from_root "${readme_path}")"
+  markers="$(awk -v target="${target}" '
+    {
+      line = $0
+      while (match(line, /<!--[[:space:]]*RUN[[:space:]]+[^>]*-->/)) {
+        marker = substr(line, RSTART, RLENGTH)
+        if (index(marker, "<!-- RUN test_" target) == 1) {
+          print marker
+        }
+        line = substr(line, RSTART + RLENGTH)
+      }
+    }
+  ' "${resolved_readme_path}")"
+
+  if [[ -z "${markers}" ]]; then
+    echo "ERROR: No test blocks matching <!-- RUN test_${target}* --> in ${readme_path}" >&2
+    return 1
+  fi
+
+  while IFS= read -r marker; do
+    echo "---- ${target} ${marker} ----"
+    run_command_block_from_readme "${readme_path}" "${marker}"
+  done <<< "${markers}"
+}
+
+# Check that zephyr/README.md and zephyr/executorch.yaml are in sync.
+verify_zephyr_readme
+
+# Based on instructions in zephyr/README.md and the selected sample README.
+run_command_block_from_readme "${ZEPHYR_README_PATH}" "<!-- RUN install_reqs -->"
+
+# Make sure to backup the zephyr_scratch folder if it exists to allow for local
+# testing that does not lose code/data.
+if [[ -d "zephyr_scratch" ]]; then
+  mv "zephyr_scratch" "zephyr_scratch.backup.$(date +%Y%m%d%H%M%S)"
+fi
+mkdir -p zephyr_scratch/
+
+cd zephyr_scratch
+export ZEPHYR_PROJ_ROOT="$(realpath "$(pwd)")"
+
+echo "---- Zephyr SDK ----"
+# Use ZephyrSDK if on the disk (e.g. setup in the docker)
+# Check for a zephyr-sdk-0.17.4 directory and make a symlink if found in parent directories
+if sdk_dir=$(find ../../.. -maxdepth 4 -type d -name 'zephyr-sdk-0.17.4' -print -quit) && [ -n "${sdk_dir}" ]; then
+  echo "---- Found pre downloaded Zephyr SDK in ${sdk_dir} ----"
+  ln -s "${sdk_dir}" .
+fi
+
+# Download and setup Zephyr SDK 0.17.4 if not already present
+if [ ! -d "zephyr-sdk-0.17.4" ]; then
+  echo "---- Downloading Zephyr SDK ----"
+  wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.17.4/zephyr-sdk-0.17.4_linux-x86_64.tar.xz
+  tar -xf zephyr-sdk-0.17.4_linux-x86_64.tar.xz
+  rm -f zephyr-sdk-0.17.4_linux-x86_64.tar.xz*
+fi
+
+./zephyr-sdk-0.17.4/setup.sh -c -t arm-zephyr-eabi
+export ZEPHYR_SDK_INSTALL_DIR=$(realpath ./zephyr-sdk-0.17.4)
+
+cd ${ZEPHYR_PROJ_ROOT}
+
+run_command_block_from_readme "${ZEPHYR_README_PATH}" "<!-- RUN west_init -->"
+
+cp "${EXECUTORCH_PROJ_ROOT}/zephyr/executorch.yaml" zephyr/submanifests/
+
+run_command_block_from_readme "${ZEPHYR_README_PATH}" "<!-- RUN west_config -->"
+
+# Switch to executorch in this PR e.g. replace modules/lib/executorch with the
+# root folder of this repo instead of doing a re-checkout and figuring out the
+# correct commit hash.
+rm -Rf modules/lib/executorch
+ln -s "${EXECUTORCH_PROJ_ROOT}" modules/lib/executorch
+
+# Setup git local user for Executorch git to allow
+# modules/lib/executorch/examples/arm/setup.sh to run inside CI later.
+if ! git config --get user.name >/dev/null 2>&1; then
+  git config --global user.name "Github Executorch"
+fi
+if ! git config --get user.email >/dev/null 2>&1; then
+  git config --global user.email "github_executorch@arm.com"
+fi
+
+run_command_block_from_readme "${ZEPHYR_README_PATH}" "<!-- RUN install_executorch -->"
+run_command_block_from_readme "${ZEPHYR_README_PATH}" "<!-- RUN install_arm_tools -->"
+
+for TARGET in "${TARGETS[@]}"; do
+  TARGET="$(echo "${TARGET}" | xargs)"
+
+  echo "---- ${TARGET} ----"
+  rm -Rf build
+
+  if [[ ${TARGET} == "ethos-u55" || ${TARGET} == "cortex-m55" ]]; then
+    BOARD="corstone300"
+  elif [[ ${TARGET} == "ethos-u85" ]]; then
+    BOARD="corstone320"
+  else
+    echo "Fail unsupported target selection ${TARGET}"
+    exit 1
+  fi
+
+  echo "---- ${TARGET} Board ${BOARD} FVP setup ----"
+  run_command_block_from_readme "${ZEPHYR_SAMPLES_README_PATH}" "<!-- RUN setup_${BOARD} -->"
+
+  # Run all blocks that match <!-- RUN test_${target}* -->
+  run_target_test_blocks_from_readme "${ZEPHYR_SAMPLES_README_PATH}" "${TARGET}"
+done

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -62,7 +62,12 @@ jobs:
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     strategy:
       matrix:
-        target: [ethos-u55, cortex-m55, ethos-u85]
+        include:
+          - { readme: zephyr/samples/hello-executorch/README.md, target: ethos-u55 }
+          - { readme: zephyr/samples/hello-executorch/README.md, target: cortex-m55 }
+          - { readme: zephyr/samples/hello-executorch/README.md, target: ethos-u85 }
+          - { readme: zephyr/samples/mv2-ethosu/README.md, target: ethos-u55 }
+          - { readme: zephyr/samples/mv2-ethosu/README.md, target: ethos-u85 }
       fail-fast: false
     with:
       runner: linux.2xlarge
@@ -79,143 +84,9 @@ jobs:
         # Test zephyr backend
         set -e
 
-        # Support comma-separated TARGET_LIST or ${{ matrix.target }} list, e.g., TARGET_LIST="ethos-u55,cortex-m55,ethos-u85"
-        if [ -z "${TARGET_LIST:-}" ]; then
-          IFS=',' read -r -a TARGETS <<< "${{ matrix.target }}"
-        else
-          IFS=',' read -r -a TARGETS <<< "${TARGET_LIST}"
-        fi
-
-        export EXECUTORCH_PROJ_ROOT=$(realpath $(pwd))
-        ZEPHYR_README_PATH="zephyr/README.md"
-        ZEPHYR_SAMPLES_README_PATH="zephyr/samples/hello-executorch/README.md"
-
-        # Source utility scripts
-        . .ci/scripts/utils.sh
-        . .ci/scripts/zephyr-utils.sh
-
-        # check that zephyr/README.md and zephyr/executorch.yaml are in sync
-        verify_zephyr_readme
-
-        # Based on instructions in zephyr/README.md and zephyr/samples/hello-executorch/README.md
-
-        run_command_block_from_readme "${ZEPHYR_README_PATH}" "<!-- RUN install_reqs -->"
-
-        # Make sure to backup the zephyr_scratch folder if it exists to allow for local
-        # testing that does not lose code/data
-        if [ -d "zephyr_scratch" ]; then
-          mv "zephyr_scratch" "zephyr_scratch.backup.$(date +%Y%m%d%H%M%S)"
-        fi
-        mkdir -p zephyr_scratch/
-
-        cd zephyr_scratch
-        export ZEPHYR_PROJ_ROOT=$(realpath $(pwd))
-
-        echo "---- Zephyr SDK ----"
-        # Use ZephyrSDK if on the disk (e.g. setup in the docker)
-        # Check for a zephyr-sdk-0.17.4 directory and make a symlink if found in parent directories
-        if sdk_dir=$(find ../../.. -maxdepth 4 -type d -name 'zephyr-sdk-0.17.4' -print -quit) && [ -n "${sdk_dir}" ]; then
-          echo "---- Found pre downloaded Zephyr SDK in ${sdk_dir} ----"
-          ln -s "${sdk_dir}" .
-        fi
-
-        # Download and setup Zephyr SDK 0.17.4 if not already present
-        if [ ! -d "zephyr-sdk-0.17.4" ]; then
-          echo "---- Downloading Zephyr SDK ----"
-          wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.17.4/zephyr-sdk-0.17.4_linux-x86_64.tar.xz
-          tar -xf zephyr-sdk-0.17.4_linux-x86_64.tar.xz
-          rm -f zephyr-sdk-0.17.4_linux-x86_64.tar.xz*
-        fi
-
-        ./zephyr-sdk-0.17.4/setup.sh -c -t arm-zephyr-eabi
-        export ZEPHYR_SDK_INSTALL_DIR=$(realpath ./zephyr-sdk-0.17.4)
-
-        cd ${ZEPHYR_PROJ_ROOT}
-
-        run_command_block_from_readme "${ZEPHYR_README_PATH}" "<!-- RUN west_init -->"
-
-        cp ${EXECUTORCH_PROJ_ROOT}/zephyr/executorch.yaml zephyr/submanifests/
-
-        run_command_block_from_readme "${ZEPHYR_README_PATH}" "<!-- RUN west_config -->"
-
-        # Switch to executorch in this PR e.g. replace modules/lib/executorch with the root folder of this repo
-        # instead of doing a re-checkout and figure out the correct commit hash etc
-        rm -Rf modules/lib/executorch
-        ln -s ${EXECUTORCH_PROJ_ROOT} modules/lib/executorch
-
-        # Setup git local user for Executorch git to allows modules/lib/executorch/examples/arm/setup.sh be run inside CI later
-        # Configure git user only if not already set
-        if ! git config --get user.name >/dev/null 2>&1; then
-          git config --global user.name "Github Executorch"
-        fi
-        if ! git config --get user.email >/dev/null 2>&1; then
-          git config --global user.email "github_executorch@arm.com"
-        fi
-
-        run_command_block_from_readme "${ZEPHYR_README_PATH}" "<!-- RUN install_executorch -->"
-
-        run_command_block_from_readme "${ZEPHYR_README_PATH}" "<!-- RUN install_arm_tools -->"
-
-        for TARGET in "${TARGETS[@]}"; do
-          TARGET="$(echo "$TARGET" | xargs)" # trim whitespace
-
-          echo "---- ${TARGET} ----"
-          rm -Rf build
-
-          if [[ ${TARGET} == "ethos-u55" || ${TARGET} == "cortex-m55" ]]; then
-            BOARD="corstone300"
-          elif [[ ${TARGET} == "ethos-u85" ]]; then
-            BOARD="corstone320"
-          else
-            echo "Fail unsupport target selection ${TARGET}"
-            exit 1
-          fi
-
-          echo "---- ${TARGET} Board ${BOARD} FVP setup ----"
-          run_command_block_from_readme "${ZEPHYR_SAMPLES_README_PATH}" "<!-- RUN setup_${BOARD}_fvp -->"
-
-          echo "---- ${TARGET} Create PTE ----"
-          run_command_block_from_readme "${ZEPHYR_SAMPLES_README_PATH}" "<!-- RUN test_${TARGET}_generate_pte -->"
-
-          echo "---- ${TARGET} Build and run ----"
-          run_command_block_from_readme "${ZEPHYR_SAMPLES_README_PATH}" "<!-- RUN test_${TARGET}_build_and_run -->"
-        done
-
-        # MV2 Ethos-U sample (NPU targets only — skips cortex-m55)
-        MV2_README_PATH="zephyr/samples/mv2-ethosu/README.md"
-
-        for TARGET in "${TARGETS[@]}"; do
-          TARGET="$(echo "$TARGET" | xargs)"
-
-          if [[ ${TARGET} == "cortex-m55" ]]; then
-            echo "---- Skipping MV2 for ${TARGET} (NPU-only sample) ----"
-            continue
-          fi
-
-          if [[ ${TARGET} == "ethos-u55" ]]; then
-            BOARD="corstone300"
-          elif [[ ${TARGET} == "ethos-u85" ]]; then
-            BOARD="corstone320"
-          else
-            echo "Fail unsupported target selection ${TARGET}"
-            exit 1
-          fi
-
-          echo "---- MV2 ${TARGET} ----"
-          rm -Rf build
-
-          echo "---- MV2 ${TARGET} Board ${BOARD} FVP setup ----"
-          run_command_block_from_readme "${ZEPHYR_SAMPLES_README_PATH}" "<!-- RUN setup_${BOARD}_fvp -->"
-
-          echo "---- MV2 ${TARGET} Create PTE ----"
-          run_command_block_from_readme "${MV2_README_PATH}" "<!-- RUN test_mv2_${TARGET}_generate_pte -->"
-
-          # Build only — FVP cycle-accurate simulation of MV2 is too slow
-          # for the CI timeout.  Corstone-300 also lacks enough ISRAM for
-          # the runtime pools.  The build step still catches link regressions.
-          echo "---- MV2 ${TARGET} Build only ----"
-          run_command_block_from_readme "${MV2_README_PATH}" "<!-- RUN test_mv2_${TARGET}_build -->"
-        done
+        .ci/scripts/test_zephyr.sh \
+          --targets "${TARGET_LIST:-${{ matrix.target }}}" \
+          --zephyr-samples-readme-path "${{ matrix.readme }}"
 
   test-models-linux-aarch64:
     name: test-models-linux-aarch64

--- a/backends/arm/test/test_github_trunk_zephyr.sh
+++ b/backends/arm/test/test_github_trunk_zephyr.sh
@@ -9,7 +9,7 @@
 # github/workflows/trunk.yml as a bash script, (ignoring the conda commands)
 # This is mostly useful for testing this before upstreaming or for debugging CI issues.
 # Or a way to setup zephyrOS so you can play with it.
-# Parse optional argument to set TARGET_LIST environment variable
+# Parse optional arguments to select README and target list.
 
 # Target list (--target-list) adds a comma separated list of targets you want to test
 # matching the zephyr/README.md tags:
@@ -20,22 +20,33 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-ROOT_DIR="$(cd "${SCRIPT_DIR}" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 
+TARGET_LIST_OVERRIDDEN=0
+if [[ -n "${TARGET_LIST:-}" ]]; then
+    TARGET_LIST_OVERRIDDEN=1
+fi
 TARGET_LIST="${TARGET_LIST:-ethos-u55,cortex-m55,ethos-u85}"
+README_PATH="${README_PATH:-}"
+HELLO_README_PATH="zephyr/samples/hello-executorch/README.md"
+MV2_README_PATH="zephyr/samples/mv2-ethosu/README.md"
+DEFAULT_MV2_TARGET_LIST="ethos-u55,ethos-u85"
 usage() {
     cat <<EOF
 Usage: $(basename "$0") [OPTIONS]
 
 Options:
   -t, --target-list LIST      Comma-separated targets (default: ${TARGET_LIST})
+  -r, --readme PATH           Run only one README path
   -h, --help                  Show this help and exit
 
-You can also set TARGET_LIST environment variable.
+When --readme is used, --target-list or TARGET_LIST is required.
+You can also set TARGET_LIST or README_PATH environment variable.
 Examples:
   $(basename "$0")
   $(basename "$0") -t ethos-u55,cortex-m55
   $(basename "$0") --target-list=ethos-u85
+  $(basename "$0") --readme zephyr/samples/mv2-ethosu/README.md --target-list ethos-u85
 EOF
 }
 
@@ -53,10 +64,25 @@ while [[ $# -gt 0 ]]; do
                 exit 2
             fi
             TARGET_LIST="$2"
+            TARGET_LIST_OVERRIDDEN=1
             shift 2
             ;;
         --target-list=*)
             TARGET_LIST="${1#*=}"
+            TARGET_LIST_OVERRIDDEN=1
+            shift
+            ;;
+        -r|--readme)
+            if [[ -z "${2:-}" || "$2" == -* ]]; then
+                echo "Error: $1 requires a non-empty argument."
+                usage
+                exit 2
+            fi
+            README_PATH="$2"
+            shift 2
+            ;;
+        --readme=*)
+            README_PATH="${1#*=}"
             shift
             ;;
         *)
@@ -66,23 +92,28 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
-export TARGET_LIST
 
-echo "Running .github/workflows/trunk.yml testing ${TARGET_LIST} from zephyr/README.md"
+if [[ -n "${README_PATH}" && ${TARGET_LIST_OVERRIDDEN} -eq 0 ]]; then
+    echo "Error: --readme requires --target-list or TARGET_LIST." >&2
+    usage >&2
+    exit 2
+fi
 
-SCRIPT_CONTENT="$(python - <<'PY'
-from ruamel.yaml import YAML
-with open(".github/workflows/trunk.yml") as f:
-    data = YAML().load(f)
-script = data["jobs"]["test-arm-backend-zephyr"]["with"]["script"]
-filtered = []
-con_lines = ("CONDA_ENV=", "conda activate")
-for line in script.splitlines():
-    if any(line.strip().startswith(prefix) for prefix in con_lines):
-        continue
-    filtered.append(line)
-print("\n".join(filtered))
-PY
-)"
+cd "${ROOT_DIR}"
 
-printf "%s\n" "${SCRIPT_CONTENT}" | /bin/bash
+run_zephyr_readme() {
+    local readme_path="$1"
+    local targets="$2"
+
+    echo "Running ${readme_path} targets: ${targets}"
+    .ci/scripts/test_zephyr.sh \
+        --zephyr-samples-readme-path "${readme_path}" \
+        --targets "${targets}"
+}
+
+if [[ -n "${README_PATH}" ]]; then
+    run_zephyr_readme "${README_PATH}" "${TARGET_LIST}"
+else
+    run_zephyr_readme "${HELLO_README_PATH}" "${TARGET_LIST}"
+    run_zephyr_readme "${MV2_README_PATH}" "${DEFAULT_MV2_TARGET_LIST}"
+fi

--- a/zephyr/samples/hello-executorch/README.md
+++ b/zephyr/samples/hello-executorch/README.md
@@ -17,7 +17,7 @@ This is done in the example depending on the board you build for so if you build
 Set up FVP paths and macs used, this will also set `shutdown_on_eot` so the FVP auto stops after it has run the example.
 
 Config Zephyr Corstone300 FVP
-<!-- RUN setup_corstone300_fvp -->
+<!-- RUN setup_corstone300 -->
 ```
 export FVP_ROOT=$PWD/modules/lib/executorch/examples/arm/arm-scratch/FVP-corstone300
 export ARMFVP_BIN_PATH=${FVP_ROOT}/models/Linux64_GCC-9.3
@@ -72,7 +72,7 @@ west build -b mps3/corstone300/fvp modules/lib/executorch/zephyr/samples/hello-e
 Set up FVP paths, libs and macs used, this will also set `shutdown_on_eot` so the FVP auto stops after it has run the example.
 
 Config Zephyr Corstone320 FVP
-<!-- RUN setup_corstone320_fvp -->
+<!-- RUN setup_corstone320 -->
 ```
 export FVP_ROOT=$PWD/modules/lib/executorch/examples/arm/arm-scratch/FVP-corstone320
 export ARMFVP_BIN_PATH=${FVP_ROOT}/models/Linux64_GCC-9.3

--- a/zephyr/samples/mv2-ethosu/README.md
+++ b/zephyr/samples/mv2-ethosu/README.md
@@ -18,36 +18,66 @@ The model classifies a static RGB test input tensor with shape `[1, 3, 224, 224]
 > ~3 MiB, so the build will link but FVP execution will fail at runtime.
 > Use Corstone-320 (below) for end-to-end MV2 inference.
 
+### Setup FVP paths
+
+Set up FVP paths and macs used, this will also set `shutdown_on_eot` so the FVP auto stops after it has run the example.
+
+Config Zephyr Corstone300 FVP
+<!-- RUN setup_corstone300 -->
+```
+export FVP_ROOT=$PWD/modules/lib/executorch/examples/arm/arm-scratch/FVP-corstone300
+export ARMFVP_BIN_PATH=${FVP_ROOT}/models/Linux64_GCC-9.3
+export ARMFVP_EXTRA_FLAGS="-C mps3_board.uart0.shutdown_on_eot=1 -C ethosu.num_macs=128"
+```
+
 ### Export the model
 
 Export a quantized INT8 MobileNetV2 model with Ethos-U55 delegation:
 
-<!-- RUN test_mv2_ethos-u55_generate_pte -->
+<!-- RUN test_ethos-u55_generate_pte -->
 ```
 python -m modules.lib.executorch.backends.arm.scripts.aot_arm_compiler --model_name=mv2_untrained --quantize --delegate --target=ethos-u55-128 --output=mv2_u55_128.pte
 ```
 
 ### Build (link-check only)
 
-<!-- RUN test_mv2_ethos-u55_build -->
+<!-- RUN test_ethos-u55_build -->
 ```
 west build -b mps3/corstone300/fvp modules/lib/executorch/zephyr/samples/mv2-ethosu -- -DET_PTE_FILE_PATH=mv2_u55_128.pte
 ```
 
 ## Corstone-320 FVP (Ethos-U85)
 
+### Setup FVP paths
+
+Set up FVP paths, libs and macs used, this will also set `shutdown_on_eot` so the FVP auto stops after it has run the example.
+
+These FVP command-line options are passed through the `ARMFVP_EXTRA_FLAGS`
+environment variable. The sample does not set `ARMFVP_FLAGS` in its
+`CMakeLists.txt`; the base `ARMFVP_FLAGS` come from the selected Zephyr board's
+`board.cmake`.
+
+Config Zephyr Corstone320 FVP
+<!-- RUN setup_corstone320 -->
+```
+export FVP_ROOT=$PWD/modules/lib/executorch/examples/arm/arm-scratch/FVP-corstone320
+export ARMFVP_BIN_PATH=${FVP_ROOT}/models/Linux64_GCC-9.3
+export LD_LIBRARY_PATH=${FVP_ROOT}/python/lib:${ARMFVP_BIN_PATH}:${LD_LIBRARY_PATH}
+export ARMFVP_EXTRA_FLAGS="-C mps4_board.uart0.shutdown_on_eot=1 -C mps4_board.subsystem.ethosu.num_macs=256"
+```
+
 ### Export the model
 
 Export a quantized INT8 MobileNetV2 model with Ethos-U85 delegation:
 
-<!-- RUN test_mv2_ethos-u85_generate_pte -->
+<!-- RUN test_ethos-u85_generate_pte -->
 ```
 python -m modules.lib.executorch.backends.arm.scripts.aot_arm_compiler --model_name=mv2_untrained --quantize --delegate --target=ethos-u85-256 --output=mv2_u85_256.pte
 ```
 
 ### Build
 
-<!-- RUN test_mv2_ethos-u85_build -->
+<!-- RUN test_ethos-u85_build -->
 ```
 west build -b mps4/corstone320/fvp modules/lib/executorch/zephyr/samples/mv2-ethosu -- -DET_PTE_FILE_PATH=mv2_u85_256.pte
 ```


### PR DESCRIPTION
Moves CI testing from yaml to .ci/scripts/test_zephyr.sh and create a table of readme and target combinations to run instead of having mv2 tests hard coded. This will make it easier to add more sample and tests in the future as the test flow is more generic.


cc @digantdesai @freddan80 @per @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani