### PR TITLE
Arm backend: Remove incorrect error message in runner

### DIFF
--- a/examples/arm/executor_runner/arm_executor_runner.cpp
+++ b/examples/arm/executor_runner/arm_executor_runner.cpp
@@ -1284,7 +1284,7 @@ int main(int argc, const char* argv[]) {
       if (buffer == nullptr) {
         ET_LOG(
             Error,
-            "Reading input tensor %zu from file %s ERROR Out of memory",
+            "Reading input tensor %zu from file %s failed.",
             nbr_inputs,
             input_tensor_filename);
         _exit(1);
@@ -1296,10 +1296,7 @@ int main(int argc, const char* argv[]) {
       auto [buffer, buffer_size] =
           read_binary_file(pte_filename, ctx.input_file_allocator.value());
       if (buffer == nullptr) {
-        ET_LOG(
-            Error,
-            "Reading pte model from file %s ERROR Out of memory",
-            pte_filename);
+        ET_LOG(Error, "Reading pte model from file %s failed.", pte_filename);
         _exit(1);
       }
 


### PR DESCRIPTION
when read_binary_file returns a null pointer,
an error message stating out of memory was always
printed, regardless of cause.

A correct diagnostic is already logged in
read_binary_file, so just change this message
one to something more general.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani