### PR TITLE
Arm backend: Fix sum call signature in DecomposeSumPass

### DIFF
--- a/backends/arm/_passes/decompose_sum_pass.py
+++ b/backends/arm/_passes/decompose_sum_pass.py
@@ -78,7 +78,7 @@ class DecomposeSumPass(ArmPass):
         for dim in dims:
             input_node = super().call_operator(
                 sum_op,
-                (input_node, dim, True),
+                (input_node, [dim], True),
                 kwargs,
                 meta,
                 updated=True,

--- a/backends/arm/operators/op_sum.py
+++ b/backends/arm/operators/op_sum.py
@@ -43,7 +43,7 @@ class SumVisitor(NodeVisitor):
 
         tensor = inputs[0]
         input_shape = list(tensor.shape)
-        dim = int(inputs[1].number % len(input_shape))
+        dim = int(inputs[1].special[0] % len(input_shape))
 
         attr = ts.TosaSerializerAttribute()
         attr.ReduceSumAttribute(dim)


### PR DESCRIPTION
exir_ops.edge.aten.sum.dim_IntList requires the second arg to be a list[int]. The DecomposeSumPass and op_sum, however, used int. Seems like the operator itself could handle it, but later passes tripped on it in some cases.

Since the documented signature is list[int], modify DecomposeSumPass and op_sum to use that.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani