### PR TITLE
Updating Arm Learning Paths and Tutorial Links

### DIFF
--- a/docs/source/backends/arm-ethos-u/tutorials/ethos-u-getting-started.md
+++ b/docs/source/backends/arm-ethos-u/tutorials/ethos-u-getting-started.md
@@ -199,7 +199,7 @@ In this tutorial you have learned how to use ExecuTorch to export a PyTorch mode
 
 To learn more, check out the [ExecuTorch on Arm Practical Labs](https://github.com/arm-education/executorch_on_arm_labs) series. This series provides a structured entry-point to developing with ExecuTorch on Arm, across both CPU and Ethos-U NPU.
 
-For quick learning paths showcasing short tutorials: 
+For quick learning paths showcasing short tutorials:
 
 - [Run Llama3 on Raspberry Pi 5 with ExecuTorch](https://learn.arm.com/learning-paths/embedded-and-microcontrollers/rpi-llama3/)
 - [Visualize Ethos-U NPU Performance on FVP](https://learn.arm.com/learning-paths/embedded-and-microcontrollers/visualizing-ethos-u-performance/)

--- a/docs/source/backends/arm-ethos-u/tutorials/ethos-u-getting-started.md
+++ b/docs/source/backends/arm-ethos-u/tutorials/ethos-u-getting-started.md
@@ -201,10 +201,10 @@ To learn more, check out the [ExecuTorch on Arm Practical Labs](https://github.c
 
 For quick learning paths showcasing short tutorials:
 
-[Run LLama3 on Raspberry Pi 5 with ExecuTorch](https://learn.arm.com/learning-paths/embedded-and-microcontrollers/rpi-llama3/)
-[Visualize Ethos-U NPU Performance on FVP](https://learn.arm.com/learning-paths/embedded-and-microcontrollers/visualizing-ethos-u-performance/)
-[Image Classification with ExecuTorch on NXP i.MX 93 (Ethos-U65)](https://learn.arm.com/learning-paths/embedded-and-microcontrollers/observing-ethos-u-on-nxp/)
-[Image Classification with ExecuTorch on Alif E8 DevKit (Ethos-U85)](https://learn.arm.com/learning-paths/embedded-and-microcontrollers/alif-image-classification/)
+- [Run LLama3 on Raspberry Pi 5 with ExecuTorch](https://learn.arm.com/learning-paths/embedded-and-microcontrollers/rpi-llama3/)
+- [Visualize Ethos-U NPU Performance on FVP](https://learn.arm.com/learning-paths/embedded-and-microcontrollers/visualizing-ethos-u-performance/)
+- [Image Classification with ExecuTorch on NXP i.MX 93 (Ethos-U65)](https://learn.arm.com/learning-paths/embedded-and-microcontrollers/observing-ethos-u-on-nxp/)
+- [Image Classification with ExecuTorch on Alif E8 DevKit (Ethos-U85)](https://learn.arm.com/learning-paths/embedded-and-microcontrollers/alif-image-classification/)
 
 ## FAQs
 

--- a/docs/source/backends/arm-ethos-u/tutorials/ethos-u-getting-started.md
+++ b/docs/source/backends/arm-ethos-u/tutorials/ethos-u-getting-started.md
@@ -201,7 +201,7 @@ To learn more, check out the [ExecuTorch on Arm Practical Labs](https://github.c
 
 For quick learning paths showcasing short tutorials:
 
-- [Run LLama3 on Raspberry Pi 5 with ExecuTorch](https://learn.arm.com/learning-paths/embedded-and-microcontrollers/rpi-llama3/)
+- [Run Llama3 on Raspberry Pi 5 with ExecuTorch](https://learn.arm.com/learning-paths/embedded-and-microcontrollers/rpi-llama3/)
 - [Visualize Ethos-U NPU Performance on FVP](https://learn.arm.com/learning-paths/embedded-and-microcontrollers/visualizing-ethos-u-performance/)
 - [Image Classification with ExecuTorch on NXP i.MX 93 (Ethos-U65)](https://learn.arm.com/learning-paths/embedded-and-microcontrollers/observing-ethos-u-on-nxp/)
 - [Image Classification with ExecuTorch on Alif E8 DevKit (Ethos-U85)](https://learn.arm.com/learning-paths/embedded-and-microcontrollers/alif-image-classification/)

--- a/docs/source/backends/arm-ethos-u/tutorials/ethos-u-getting-started.md
+++ b/docs/source/backends/arm-ethos-u/tutorials/ethos-u-getting-started.md
@@ -196,10 +196,15 @@ The example application is by default built with an input of ones, so the expect
 ## Takeaways
 
 In this tutorial you have learned how to use ExecuTorch to export a PyTorch model to an executable that can run on an embedded target, and then run that executable on simulated hardware.
-To learn more, check out these learning paths:
 
-https://learn.arm.com/learning-paths/embedded-and-microcontrollers/rpi-llama3/
-https://learn.arm.com/learning-paths/embedded-and-microcontrollers/visualizing-ethos-u-performance/
+To learn more, check out the [ExecuTorch on Arm Practical Labs](https://github.com/arm-education/executorch_on_arm_labs) series. This series provides a structured entry-point to developing with ExecuTorch on Arm, across both CPU and Ethos-U NPU.
+
+For quick learning paths showcasing short tutorials:
+
+[Run LLama3 on Raspberry Pi 5 with ExecuTorch](https://learn.arm.com/learning-paths/embedded-and-microcontrollers/rpi-llama3/)
+[Visualize Ethos-U NPU Performance on FVP](https://learn.arm.com/learning-paths/embedded-and-microcontrollers/visualizing-ethos-u-performance/)
+[Image Classification with ExecuTorch on NXP i.MX 93 (Ethos-U65)](https://learn.arm.com/learning-paths/embedded-and-microcontrollers/observing-ethos-u-on-nxp/)
+[Image Classification with ExecuTorch on Alif E8 DevKit (Ethos-U85)](https://learn.arm.com/learning-paths/embedded-and-microcontrollers/alif-image-classification/)
 
 ## FAQs
 

--- a/docs/source/backends/arm-ethos-u/tutorials/ethos-u-getting-started.md
+++ b/docs/source/backends/arm-ethos-u/tutorials/ethos-u-getting-started.md
@@ -199,7 +199,7 @@ In this tutorial you have learned how to use ExecuTorch to export a PyTorch mode
 
 To learn more, check out the [ExecuTorch on Arm Practical Labs](https://github.com/arm-education/executorch_on_arm_labs) series. This series provides a structured entry-point to developing with ExecuTorch on Arm, across both CPU and Ethos-U NPU.
 
-For quick learning paths showcasing short tutorials:
+For quick learning paths showcasing short tutorials: 
 
 - [Run Llama3 on Raspberry Pi 5 with ExecuTorch](https://learn.arm.com/learning-paths/embedded-and-microcontrollers/rpi-llama3/)
 - [Visualize Ethos-U NPU Performance on FVP](https://learn.arm.com/learning-paths/embedded-and-microcontrollers/visualizing-ethos-u-performance/)


### PR DESCRIPTION
- Current links to relevant Arm Learning paths are just URLs rather than clickable links. Changed this.

- Added newer, relevant learning paths.

- Added newly released ExecuTorch on Arm Jupyter lab series as a useful next step alongside the learning paths.


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani