### PR TITLE
Arm backend: Output pytest report in trunk jobs

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -380,6 +380,11 @@ jobs:
 
         ARM_TEST=${{ matrix.test_arm_baremetal }}
 
+        # Output test report on pytest runs so that github can surface failing tests.
+        if [[ -n "${RUNNER_TEST_RESULTS_DIR:-}" ]]; then
+              export PYTEST_ADDOPTS="--junit-xml=${RUNNER_TEST_RESULTS_DIR}/${ARM_TEST}.xml ${PYTEST_ADDOPTS:-}"
+        fi
+
         # Test test_arm_baremetal.sh with test
         backends/arm/test/test_arm_baremetal.sh "${ARM_TEST}"
 
@@ -414,6 +419,11 @@ jobs:
         sudo sysctl fs.inotify.max_user_watches=1048576 # 1024 * 1024
 
         ARM_TEST=${{ matrix.test_arm_baremetal }}
+
+        # Output test report on pytest runs so that github can surface failing tests.
+        if [[ -n "${RUNNER_TEST_RESULTS_DIR:-}" ]]; then
+          export PYTEST_ADDOPTS="--junit-xml=${RUNNER_TEST_RESULTS_DIR}/${ARM_TEST}.xml ${PYTEST_ADDOPTS:-}"
+        fi
 
         backends/arm/test/test_arm_baremetal.sh "${ARM_TEST}"
 


### PR DESCRIPTION
When a pytest report is output to $RUNNER_TEST_RESULTS_DIR, the linux_job_v2.yml workflow can pick it up and
surface it in github ci.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani