### PR TITLE
Fix broken ConvBNReLu from new Convert1DConvTo2D pass (#19558)

### DIFF
--- a/backends/nxp/aten_passes/convert_1d_conv_to_2d.py
+++ b/backends/nxp/aten_passes/convert_1d_conv_to_2d.py
@@ -8,6 +8,7 @@ from executorch.backends.nxp.backend.edge_helper import (
     try_get_tensor_constant_from_node,
 )
 from executorch.backends.nxp.backend.graph_utils import is_batch_norm
+from executorch.backends.nxp.backend.neutron_target_spec import NeutronTargetSpec
 from torch._subclasses import FakeTensor, FakeTensorMode
 from torch.ao.quantization.fx.utils import get_new_attr_name_with_prefix
 from torch.export.unflatten import _assign_attr, _AttrKind
@@ -26,18 +27,21 @@ class ConvertConv1dToConv2dPass(PassBase):
     r"""
     The NXP backend supports only 2D convolutions. Rewrite 1D convolutions into an equivalent 2D form by
     inserting a singleton spatial dimension and then remove it again.
-    If batch norm is present after the convolution, it is also converted from 1D to 2D.
+    If batch norm and/or a fusable activation (as defined by the NeutronTargetSpec) follow the convolution,
+    they are also kept in 2D (before the squeeze) so the partitioner can fuse them with the convolution.
 
-    Without batch norm:
+    Without batch norm or activation:
+
+    Without batch norm or activation:
 
            x                         W                                x                           W
-      [N, C1, H]               [I/O, I/O, k]                     [N, C1, H]                [I/O, I/O, 1, k]
+       [N, C, H]               [I/O, I/O, k]                      [N, C, H]                [I/O, I/O, 1, k]
            │                         │                                │                           │
            │                         │                      ┌─────────▼──────────┐                │
            │                         │                      │  unsqueeze(x, -2)  │                │
            │                         │                      └─────────▼──────────┘                │
            │                         │                                │                           │
-           │                         │                          [N, C1, 1, H]                     │
+           │                         │                           [N, C, 1, H]                     │
            │                         │                                │                           │
            └────────┐       ┌────────┘                                └──────────┐     ┌──────────┘
                     │       │                                                    │     │
@@ -46,26 +50,26 @@ class ConvertConv1dToConv2dPass(PassBase):
            │   (1D/transposed 1D)   │          ────────────────►        │   (2D/transposed 2D)  │
            └────────────┬───────────┘                with               └───────────┬───────────┘
                         │                                                           │
-                        │                                                     [N, C2, 1, H]
+                        │                                                      [N, C, 1, H]
                         │                                                           │
                         │                                                 ┌─────────▼──────────┐
                         │                                                 │   squeeze(x, -2)   │
                         │                                                 └─────────┬──────────┘
                         │                                                           │
                         ▼                                                           ▼
-                   [N, C2, H]                                                  [N, C2, H]
+                    [N, C, H]                                                   [N, C, H]
                         y                                                           y
 
     With batch norm:
 
            x                         W                                x                           W
-      [N, C1, H]               [I/O, I/O, k]                     [N, C1, H]                [I/O, I/O, 1, k]
+       [N, C, H]               [I/O, I/O, k]                      [N, C, H]                [I/O, I/O, 1, k]
            │                         │                                │                           │
            │                         │                      ┌─────────▼──────────┐                │
            │                         │                      │  unsqueeze(x, -2)  │                │
            │                         │                      └─────────▼──────────┘                │
            │                         │                                │                           │
-           │                         │                         [N, C1, 1, H]                      │
+           │                         │                          [N, C, 1, H]                      │
            │                         │                                │                           │
            └────────┐       ┌────────┘                                └──────────┐     ┌──────────┘
                     │       │                                                    │     │
@@ -74,23 +78,101 @@ class ConvertConv1dToConv2dPass(PassBase):
            │   (1D/transposed 1D)   │          ────────────────►        │   (2D/transposed 2D)  │
            └────────────┬───────────┘                with               └───────────┬───────────┘
                         │                                                           │
-                    [N, C2, H]                                                [N, C2, 1, H]
+                    [N, C, H]                                                  [N, C, 1, H]
                         │                                                           │
                 ┌───────▼───────┐                                           ┌───────▼───────┐
                 │   batch_norm  │                                           │   batch_norm  │
                 │      (1D)     │                                           │      (2D)     │
                 └───────┬───────┘                                           └───────┬───────┘
                         │                                                           │
-                        │                                                     [N, C3, 1, H]
+                        │                                                      [N, C, 1, H]
                         │                                                           │
                         │                                                   ┌───────▼────────┐
                         │                                                   │   squeeze(-2)  │
                         │                                                   └───────┬────────┘
                         │                                                           │
                         ▼                                                           ▼
-                    [N, C3, H]                                                  [N, C3, H]
+                    [N, C, H]                                                   [N, C, H]
+                        y                                                           y
+
+    With activation (e.g. relu):
+
+           x                         W                                x                           W
+       [N, C, H]               [I/O, I/O, k]                      [N, C, H]                [I/O, I/O, 1, k]
+           │                         │                                │                           │
+           │                         │                      ┌─────────▼──────────┐                │
+           │                         │                      │  unsqueeze(x, -2)  │                │
+           │                         │                      └─────────▼──────────┘                │
+           │                         │                                │                           │
+           │                         │                           [N, C, 1, H]                     │
+           │                         │                                │                           │
+           └────────┐       ┌────────┘                                └──────────┐     ┌──────────┘
+                    │       │                                                    │     │
+           ┌────────▼───────▼───────┐                                   ┌────────▼─────▼────────┐
+           │       convolution      ◄──B [O]        replace             │      convolution      ◄──B [O]
+           │   (1D/transposed 1D)   │          ────────────────►        │   (2D/transposed 2D)  │
+           └────────────┬───────────┘                with               └───────────┬───────────┘
+                        │                                                           │
+                    [N, C, H]                                                  [N, C, 1, H]
+                        │                                                           │
+                ┌───────▼───────┐                                           ┌───────▼───────┐
+                │     relu      │                                           │     relu      │
+                └───────┬───────┘                                           └───────┬───────┘
+                        │                                                           │
+                        │                                                      [N, C, 1, H]
+                        │                                                           │
+                        │                                                   ┌───────▼────────┐
+                        │                                                   │   squeeze(-2)  │
+                        │                                                   └───────┬────────┘
+                        │                                                           │
+                        ▼                                                           ▼
+                    [N, C, H]                                                   [N, C, H]
+                        y                                                           y
+
+    With batch norm and activation:
+
+           x                         W                                x                           W
+       [N, C, H]               [I/O, I/O, k]                      [N, C, H]                [I/O, I/O, 1, k]
+           │                         │                                │                           │
+           │                         │                      ┌─────────▼──────────┐                │
+           │                         │                      │  unsqueeze(x, -2)  │                │
+           │                         │                      └─────────▼──────────┘                │
+           │                         │                                │                           │
+           │                         │                          [N, C, 1, H]                      │
+           │                         │                                │                           │
+           └────────┐       ┌────────┘                                └──────────┐     ┌──────────┘
+                    │       │                                                    │     │
+           ┌────────▼───────▼───────┐                                   ┌────────▼─────▼────────┐
+           │       convolution      ◄──B [O]        replace             │      convolution      ◄──B [O]
+           │   (1D/transposed 1D)   │          ────────────────►        │   (2D/transposed 2D)  │
+           └────────────┬───────────┘                with               └───────────┬───────────┘
+                        │                                                           │
+                    [N, C, H]                                                  [N, C, 1, H]
+                        │                                                           │
+                ┌───────▼───────┐                                           ┌───────▼───────┐
+                │   batch_norm  │                                           │   batch_norm  │
+                │      (1D)     │                                           │      (2D)     │
+                └───────┬───────┘                                           └───────┬───────┘
+                        │                                                           │
+                    [N, C, H]                                                 [N, C, 1, H]
+                        │                                                           │
+                ┌───────▼───────┐                                           ┌───────▼───────┐
+                │     relu      │                                           │     relu      │
+                └───────┬───────┘                                           └───────┬───────┘
+                        │                                                           │
+                        │                                                      [N, C, 1, H]
+                        │                                                           │
+                        │                                                   ┌───────▼────────┐
+                        │                                                   │   squeeze(-2)  │
+                        │                                                   └───────┬────────┘
+                        │                                                           │
+                        ▼                                                           ▼
+                    [N, C, H]                                                   [N, C, H]
                         y                                                           y
     """
+
+    def __init__(self, neutron_target_spec: NeutronTargetSpec):
+        self.neutron_target_spec = neutron_target_spec
 
     @staticmethod
     def _is_conv_1d(node: Node) -> bool:
@@ -204,12 +286,12 @@ class ConvertConv1dToConv2dPass(PassBase):
 
         return some_conv_node
 
-    def _create_sq_or_unsq_node(self, target, *sq_or_unsq_args) -> Node:
-        sq_or_unsq_node = self.graph_module.graph.call_function(target, sq_or_unsq_args)
+    def _create_generic_node_by_target(self, target, *args) -> Node:
+        new_node = self.graph_module.graph.call_function(target, args)
 
-        sq_or_unsq_node.meta["source_fn_stack"] = [(sq_or_unsq_node.name, target)]
+        new_node.meta["source_fn_stack"] = [(new_node.name, target)]
         with FakeTensorMode() as mode:
-            inp_node = sq_or_unsq_args[0]
+            inp_node = args[0]
             fake_input = FakeTensor.from_tensor(
                 torch.empty(
                     self._get_node_shape(inp_node), dtype=self._get_node_dtype(inp_node)
@@ -217,12 +299,12 @@ class ConvertConv1dToConv2dPass(PassBase):
                 mode,
             )
 
-            output = target(fake_input, *sq_or_unsq_args[1:])
-            sq_or_unsq_node.meta["val"] = FakeTensor.from_tensor(
+            output = target(fake_input, *args[1:])
+            new_node.meta["val"] = FakeTensor.from_tensor(
                 torch.empty(output.shape, dtype=output.dtype), mode
             )
 
-        return sq_or_unsq_node
+        return new_node
 
     @staticmethod
     def _get_conv_1d_transp_args(node: Node):
@@ -299,7 +381,7 @@ class ConvertConv1dToConv2dPass(PassBase):
             # input = [n, c, h] => [n, c, 1, h]
             unsqueeze_target = torch.ops.aten.unsqueeze.default
             inp_unsq_args = (input_node, -2)
-            inp_unsq_node = self._create_sq_or_unsq_node(
+            inp_unsq_node = self._create_generic_node_by_target(
                 unsqueeze_target, *inp_unsq_args
             )
 
@@ -357,35 +439,47 @@ class ConvertConv1dToConv2dPass(PassBase):
                 )
 
             old_1d_conv_users = list(old_1d_node.users.keys())
+            last_4d_node = new_2d_node
+            node_to_replace = old_1d_node
+            nodes_to_erase = []
+
+            old_1d_bn_users = old_1d_conv_users
+
             if len(old_1d_conv_users) == 1 and is_batch_norm(old_1d_conv_users[0]):
                 bn_1d_node = old_1d_conv_users[0]
-
-                # also convert batch_norm 1d to 2d
-                with self.graph_module.graph.inserting_after(new_2d_node):
+                with self.graph_module.graph.inserting_after(last_4d_node):
                     bn_2d_args = (new_2d_node,) + bn_1d_node.args[1:]
                     bn_2d_node = self._create_batch_norm_2d_node(*bn_2d_args)
+                last_4d_node = bn_2d_node
+                node_to_replace = bn_1d_node
+                nodes_to_erase.append(bn_1d_node)
+                old_1d_bn_users = list(bn_1d_node.users.keys())
 
-                with self.graph_module.graph.inserting_after(bn_2d_node):
-                    squeeze_target = torch.ops.aten.squeeze.dim
-
-                    out_sq_args = (bn_2d_node, -2)
-                    out_sq_node = self._create_sq_or_unsq_node(
-                        squeeze_target, *out_sq_args
+            if len(
+                old_1d_bn_users
+            ) == 1 and self.neutron_target_spec.neutron_target_info.is_supported_fused_activation__aten(
+                old_1d_bn_users[0]
+            ):
+                act_1d_node = old_1d_bn_users[0]
+                with self.graph_module.graph.inserting_after(last_4d_node):
+                    act_2d_args = (last_4d_node,) + act_1d_node.args[1:]
+                    act_2d_node = self._create_generic_node_by_target(
+                        act_1d_node.target, *act_2d_args
                     )
+                last_4d_node = act_2d_node
+                node_to_replace = act_1d_node
+                nodes_to_erase.append(act_1d_node)
 
-                bn_1d_node.replace_all_uses_with(out_sq_node)
-                self.graph_module.graph.erase_node(bn_1d_node)
+            with self.graph_module.graph.inserting_after(last_4d_node):
+                squeeze_target = torch.ops.aten.squeeze.dim
+                out_sq_args = (last_4d_node, -2)
+                out_sq_node = self._create_generic_node_by_target(
+                    squeeze_target, *out_sq_args
+                )
 
-            else:
-                with self.graph_module.graph.inserting_after(new_2d_node):
-                    squeeze_target = torch.ops.aten.squeeze.dim
-
-                    out_sq_args = (new_2d_node, -2)
-                    out_sq_node = self._create_sq_or_unsq_node(
-                        squeeze_target, *out_sq_args
-                    )
-
-                old_1d_node.replace_all_uses_with(out_sq_node)
+            node_to_replace.replace_all_uses_with(out_sq_node)
+            for n in reversed(nodes_to_erase):
+                self.graph_module.graph.erase_node(n)
 
             graph_module.graph.erase_node(old_1d_node)
             made_changes = True

--- a/backends/nxp/aten_passes/neutron_aten_pass_manager.py
+++ b/backends/nxp/aten_passes/neutron_aten_pass_manager.py
@@ -52,7 +52,7 @@ def _get_default_passes(neutron_target_spec, qat_mode: bool = False) -> list[Pas
         FuseLinearAndAddPass(),
         MoveActivationBeforeConcat(neutron_target_spec),
         ConvertDivToMulPass(),
-        ConvertConv1dToConv2dPass(),
+        ConvertConv1dToConv2dPass(neutron_target_spec),
     ]
 
     if not qat_mode:

--- a/backends/nxp/tests/BUCK
+++ b/backends/nxp/tests/BUCK
@@ -93,6 +93,26 @@ fbcode_target(_kind = python_pytest,
 )
 
 fbcode_target(_kind = python_pytest,
+    name = "test_convert_1d_conv_to_2d",
+    srcs = [
+        "test_convert_1d_conv_to_2d.py",
+    ],
+    env = {
+        "PYTEST_ADDOPTS": "--ignore-glob=*full_pipeline*  -k 'not full_pipeline'",
+    },
+    deps = [
+        "//caffe2:torch",
+        "//executorch/backends/nxp:aten_passes",
+        "//executorch/backends/nxp:neutron_backend",
+        ":executorch_pipeline",
+        ":models",
+        "fbsource//third-party/pypi/numpy:numpy",
+        "fbsource//third-party/pypi/pytest:pytest",
+        "fbsource//third-party/pypi/pytest-mock:pytest-mock",  # @manual
+    ],
+)
+
+fbcode_target(_kind = python_pytest,
     name = "test_integration",
     srcs = [
         "generic_tests/test_integration.py",

--- a/backends/nxp/tests/generic_tests/test_split_group_convolution.py
+++ b/backends/nxp/tests/generic_tests/test_split_group_convolution.py
@@ -161,7 +161,8 @@ class TestSplitGroupConvolution(unittest.TestCase):
         # `ConvertConv1dToConv2dPass` is needed to convert `conv1d` to `conv2d`.
         # The 1d variant is not supported.
         modified_module = NeutronAtenPassManager(
-            neutron_target_spec, [SplitGroupConvolution(), ConvertConv1dToConv2dPass()]
+            neutron_target_spec,
+            [SplitGroupConvolution(), ConvertConv1dToConv2dPass(neutron_target_spec)],
         )(graph_module).graph_module
 
         # Verify that the behavior has not changed.

--- a/backends/nxp/tests/test_convert_1d_conv_to_2d.py
+++ b/backends/nxp/tests/test_convert_1d_conv_to_2d.py
@@ -24,6 +24,7 @@ from executorch.backends.nxp.tests.executors import (
 )
 from executorch.backends.nxp.tests.models import Conv1dModule, ConvTranspose1dModule
 from executorch.exir.dialects._ops import ops as exir_ops
+from torch import nn
 from torch.export import ExportedProgram
 
 
@@ -39,6 +40,11 @@ AtenConvTranspose1d = torch.ops.aten.conv_transpose1d.default
 AtenConvTranspose2d = torch.ops.aten.conv_transpose2d.input
 AtenSqueeze = torch.ops.aten.squeeze.dim
 AtenUnsqueeze = torch.ops.aten.unsqueeze.default
+AtenRelu = torch.ops.aten.relu.default
+AtenSigmoid = torch.ops.aten.sigmoid.default
+AtenTanh = torch.ops.aten.tanh.default
+AtenHardtanh = torch.ops.aten.hardtanh.default
+AtenBatchNorm = torch.ops.aten.batch_norm.default
 
 EdgeConvolution = exir_ops.edge.aten.convolution.default
 ExecutorchDelegateCall = torch.ops.higher_order.executorch_call_delegate
@@ -99,9 +105,9 @@ def test_convert_conv_1d_to_conv2d(
     outputs_before = [o.detach().numpy() for o in exir_program_aten(example_input)]
 
     # Apply the optimization.
-    NeutronAtenPassManager(neutron_target_spec, [ConvertConv1dToConv2dPass()])(
-        exir_program_aten
-    )
+    NeutronAtenPassManager(
+        neutron_target_spec, [ConvertConv1dToConv2dPass(neutron_target_spec)]
+    )(exir_program_aten)
 
     # Make sure no `aten.conv1d` nodes are in the model.
     assert not graph_contains_any_of_ops(
@@ -207,9 +213,9 @@ def test_convert_conv_1d_transp_to_conv2d_transp(
     outputs_before = [o.detach().numpy() for o in exir_program_aten(example_input)]
 
     # Apply the optimization.
-    NeutronAtenPassManager(neutron_target_spec, [ConvertConv1dToConv2dPass()])(
-        exir_program_aten
-    )
+    NeutronAtenPassManager(
+        neutron_target_spec, [ConvertConv1dToConv2dPass(neutron_target_spec)]
+    )(exir_program_aten)
 
     # Make sure no `aten.conv_transpose1d` nodes are in the model.
     assert not graph_contains_any_of_ops(
@@ -393,3 +399,140 @@ def test_convert_conv_1d_to_conv2d_transp_full_pipeline(
         input_data=example_input,
         tfl_model=neutron_ir_model,
     )
+
+
+class Conv1dActivationModule(nn.Module):
+    def __init__(
+        self, in_channels, out_channels, kernel_size, activation, stride=1, padding=0
+    ):
+        super().__init__()
+        self.conv = nn.Conv1d(in_channels, out_channels, kernel_size, stride, padding)
+        self.activation = activation
+
+    def forward(self, x):
+        return self.activation(self.conv(x))
+
+
+class Conv1dBNActivationModule(nn.Module):
+    def __init__(
+        self, in_channels, out_channels, kernel_size, activation, stride=1, padding=0
+    ):
+        super().__init__()
+        self.conv = nn.Conv1d(in_channels, out_channels, kernel_size, stride, padding)
+        self.bn = nn.BatchNorm1d(out_channels)
+        self.activation = activation
+
+    def forward(self, x):
+        return self.activation(self.bn(self.conv(x)))
+
+
+class Conv1dHardtanhUnsupportedModule(nn.Module):
+    def __init__(self, in_channels, out_channels, kernel_size, stride=1, padding=0):
+        super().__init__()
+        self.conv = nn.Conv1d(in_channels, out_channels, kernel_size, stride, padding)
+        self.hardtanh = nn.Hardtanh(min_val=-1.0, max_val=1.0)
+
+    def forward(self, x):
+        return self.hardtanh(self.conv(x))
+
+
+@pytest.mark.parametrize(
+    "activation, expected_act_target, has_bn",
+    [
+        pytest.param(nn.ReLU(), AtenRelu, False, id="conv1d_relu"),
+        pytest.param(nn.ReLU(), AtenRelu, True, id="conv1d_bn_relu"),
+        pytest.param(nn.Sigmoid(), AtenSigmoid, False, id="conv1d_sigmoid"),
+        pytest.param(nn.Sigmoid(), AtenSigmoid, True, id="conv1d_bn_sigmoid"),
+        pytest.param(nn.Tanh(), AtenTanh, False, id="conv1d_tanh"),
+        pytest.param(nn.Tanh(), AtenTanh, True, id="conv1d_bn_tanh"),
+        pytest.param(
+            nn.Hardtanh(min_val=0.0, max_val=6.0),
+            AtenHardtanh,
+            False,
+            id="conv1d_relu6",
+        ),
+        pytest.param(
+            nn.Hardtanh(min_val=0.0, max_val=6.0),
+            AtenHardtanh,
+            True,
+            id="conv1d_bn_relu6",
+        ),
+    ],
+)
+def test_convert_conv_1d_to_conv2d_keeps_activation_in_4d(
+    activation, expected_act_target, has_bn
+):
+    input_shape = (3, 7, 23)
+    model_cls = Conv1dBNActivationModule if has_bn else Conv1dActivationModule
+    model = model_cls(
+        in_channels=7, out_channels=14, kernel_size=3, activation=activation, padding=1
+    )
+    example_input = torch.rand(input_shape)
+
+    exir_program_aten = torch.export.export(model, (example_input,)).module()
+
+    assert graph_contains_any_of_ops(exir_program_aten.graph, [AtenConv1d])
+    outputs_before = [o.detach().numpy() for o in exir_program_aten(example_input)]
+
+    NeutronAtenPassManager(
+        neutron_target_spec, [ConvertConv1dToConv2dPass(neutron_target_spec)]
+    )(exir_program_aten)
+
+    assert not graph_contains_any_of_ops(exir_program_aten.graph, [AtenConv1d])
+
+    nodes = list(exir_program_aten.graph.nodes)
+    conv_nodes = [i for i, n in enumerate(nodes) if n.target == AtenConv2d]
+    assert len(conv_nodes) == 1
+    i = conv_nodes[0]
+
+    assert nodes[i - 1].target == AtenUnsqueeze
+    assert nodes[i].target == AtenConv2d
+
+    if has_bn:
+        assert nodes[i + 1].target == AtenBatchNorm
+        assert nodes[i + 2].target == expected_act_target
+        assert nodes[i + 3].target == AtenSqueeze
+    else:
+        assert nodes[i + 1].target == expected_act_target
+        assert nodes[i + 2].target == AtenSqueeze
+
+    outputs_after = [o.detach().numpy() for o in exir_program_aten(example_input)]
+
+    assert len(outputs_before) == len(outputs_after)
+    for j in range(len(outputs_before)):
+        assert np.allclose(outputs_before[j], outputs_after[j])
+
+
+def test_convert_conv_1d_to_conv2d_unsupported_hardtanh_not_fused():
+    input_shape = (3, 7, 23)
+    model = Conv1dHardtanhUnsupportedModule(
+        in_channels=7, out_channels=14, kernel_size=3, padding=1
+    )
+    example_input = torch.rand(input_shape)
+
+    exir_program_aten = torch.export.export(model, (example_input,)).module()
+
+    assert graph_contains_any_of_ops(exir_program_aten.graph, [AtenConv1d])
+    outputs_before = [o.detach().numpy() for o in exir_program_aten(example_input)]
+
+    NeutronAtenPassManager(
+        neutron_target_spec, [ConvertConv1dToConv2dPass(neutron_target_spec)]
+    )(exir_program_aten)
+
+    assert not graph_contains_any_of_ops(exir_program_aten.graph, [AtenConv1d])
+
+    nodes = list(exir_program_aten.graph.nodes)
+    conv_nodes = [i for i, n in enumerate(nodes) if n.target == AtenConv2d]
+    assert len(conv_nodes) == 1
+    i = conv_nodes[0]
+
+    assert nodes[i - 1].target == AtenUnsqueeze
+    assert nodes[i].target == AtenConv2d
+    assert nodes[i + 1].target == AtenSqueeze
+    assert nodes[i + 2].target == AtenHardtanh
+
+    outputs_after = [o.detach().numpy() for o in exir_program_aten(example_input)]
+
+    assert len(outputs_before) == len(outputs_after)
+    for j in range(len(outputs_before)):
+        assert np.allclose(outputs_before[j], outputs_after[j])


### PR DESCRIPTION
Summary:

The pass checked for a batch norm following the conv to avoid breaking fusion with a squeeze.

However, it did not support Conv -> Batch Norm -> ReLu OR Conv -> ReLU

This commit adds that support, along with other supported activation

Reviewed By: rascani

Differential Revision: D105017469


