### PR TITLE
[ET-VK][custom_ops] Probe-then-scale adaptive dispatch stacking in test framework

### DIFF
--- a/backends/vulkan/test/custom_ops/add.cpp
+++ b/backends/vulkan/test/custom_ops/add.cpp
@@ -157,8 +157,8 @@ int main(int argc, char* argv[]) {
       generate_add_test_cases,
       add_flop_calculator,
       "Add",
-      3,
-      10,
+      /*warmup_runs = */ 1,
+      /*benchmark_runs = */ 1,
       add_reference_compute);
 
   return 0;

--- a/backends/vulkan/test/custom_ops/choose_qparams_per_row.cpp
+++ b/backends/vulkan/test/custom_ops/choose_qparams_per_row.cpp
@@ -351,8 +351,8 @@ int main(int argc, char* argv[]) {
       generate_choose_qparams_per_channel_test_cases,
       choose_qparams_per_channel_flop_calculator,
       "ChooseQParamsPerChannel",
-      0,
-      10,
+      /*warmup_runs = */ 1,
+      /*benchmark_runs = */ 1,
       ref_fn);
 
   return 0;

--- a/backends/vulkan/test/custom_ops/q4gsw_linear.cpp
+++ b/backends/vulkan/test/custom_ops/q4gsw_linear.cpp
@@ -546,8 +546,8 @@ int main(int argc, char* argv[]) {
       generate_quantized_linear_test_cases,
       quantized_linear_flop_calculator,
       "QuantizedLinearQ4GSW",
-      3,
-      10,
+      /*warmup_runs = */ 1,
+      /*benchmark_runs = */ 1,
       ref_fn);
 
   return 0;

--- a/backends/vulkan/test/custom_ops/q8csw_conv2d.cpp
+++ b/backends/vulkan/test/custom_ops/q8csw_conv2d.cpp
@@ -716,8 +716,8 @@ int main(int argc, char* argv[]) {
       generate_quantized_conv2d_test_cases,
       quantized_conv2d_flop_calculator,
       "QuantizedConv2d",
-      0,
-      10,
+      /*warmup_runs = */ 1,
+      /*benchmark_runs = */ 1,
       ref_fn);
 
   return 0;

--- a/backends/vulkan/test/custom_ops/q8csw_linear.cpp
+++ b/backends/vulkan/test/custom_ops/q8csw_linear.cpp
@@ -471,8 +471,8 @@ int main(int argc, char* argv[]) {
       generate_quantized_linear_test_cases,
       quantized_linear_flop_calculator,
       "QuantizedLinear",
-      3,
-      10,
+      /*warmup_runs = */ 1,
+      /*benchmark_runs = */ 1,
       ref_fn);
 
   return 0;

--- a/backends/vulkan/test/custom_ops/test_conv1d_dw.cpp
+++ b/backends/vulkan/test/custom_ops/test_conv1d_dw.cpp
@@ -259,8 +259,8 @@ int main(int argc, char* argv[]) {
       generate_conv1d_dw_test_cases,
       conv1d_dw_flop_calculator,
       "Conv1dDW",
-      3,
-      10,
+      /*warmup_runs = */ 1,
+      /*benchmark_runs = */ 1,
       ref_fn);
 
   return 0;

--- a/backends/vulkan/test/custom_ops/test_conv1d_pw.cpp
+++ b/backends/vulkan/test/custom_ops/test_conv1d_pw.cpp
@@ -240,8 +240,8 @@ int main(int argc, char* argv[]) {
       generate_conv1d_pw_test_cases,
       conv1d_pw_flop_calculator,
       "Conv1dPW",
-      3,
-      10,
+      /*warmup_runs = */ 1,
+      /*benchmark_runs = */ 1,
       ref_fn);
 
   return 0;

--- a/backends/vulkan/test/custom_ops/test_conv2d_dw.cpp
+++ b/backends/vulkan/test/custom_ops/test_conv2d_dw.cpp
@@ -427,8 +427,8 @@ int main(int argc, char* argv[]) {
       generate_conv2d_dw_test_cases,
       conv2d_dw_flop_calculator,
       "Conv2dDW",
-      3,
-      10,
+      /*warmup_runs = */ 1,
+      /*benchmark_runs = */ 1,
       ref_fn);
 
   return 0;

--- a/backends/vulkan/test/custom_ops/test_conv2d_pw.cpp
+++ b/backends/vulkan/test/custom_ops/test_conv2d_pw.cpp
@@ -260,8 +260,8 @@ int main(int argc, char* argv[]) {
       generate_conv2d_pw_test_cases,
       conv2d_pw_flop_calculator,
       "Conv2dPW",
-      3,
-      10,
+      /*warmup_runs = */ 1,
+      /*benchmark_runs = */ 1,
       ref_fn);
 
   return 0;

--- a/backends/vulkan/test/custom_ops/test_embedding_q4gsw.cpp
+++ b/backends/vulkan/test/custom_ops/test_embedding_q4gsw.cpp
@@ -503,8 +503,8 @@ int main(int argc, char** argv) {
   auto results = execute_test_cases(
       generate_test_cases,
       "embedding_q4gsw",
-      /* warmup_runs */ 3,
-      /* benchmark_runs */ 10,
+      /*warmup_runs = */ 1,
+      /*benchmark_runs = */ 1,
       embedding_4bit_reference);
 
   results.print_summary();

--- a/backends/vulkan/test/custom_ops/test_mm.cpp
+++ b/backends/vulkan/test/custom_ops/test_mm.cpp
@@ -566,7 +566,12 @@ int main(int argc, char* argv[]) {
   ReferenceComputeFunc ref_fn = reference_impl;
 
   auto results = execute_test_cases(
-      generate_mm_test_cases, mm_flop_calculator, "MatMul", 3, 10, ref_fn);
+      generate_mm_test_cases,
+      mm_flop_calculator,
+      "MatMul",
+      /*warmup_runs = */ 1,
+      /*benchmark_runs = */ 1,
+      ref_fn);
 
   return 0;
 }

--- a/backends/vulkan/test/custom_ops/test_q8ta_binary.cpp
+++ b/backends/vulkan/test/custom_ops/test_q8ta_binary.cpp
@@ -382,13 +382,8 @@ int main(int argc, char* argv[]) {
       generate_q8ta_add_test_cases,
 #endif
       "Q8taBinaryAdd",
-#ifdef DEBUG_MODE
-      0,
-      1,
-#else
-      3,
-      10,
-#endif
+      /*warmup_runs = */ 1,
+      /*benchmark_runs = */ 1,
       ref_fn);
 
   return 0;

--- a/backends/vulkan/test/custom_ops/test_q8ta_clone.cpp
+++ b/backends/vulkan/test/custom_ops/test_q8ta_clone.cpp
@@ -331,13 +331,8 @@ int main(int argc, char* argv[]) {
       generate_q8ta_clone_test_cases,
 #endif
       "Q8taClone",
-#ifdef DEBUG_MODE
-      0,
-      1,
-#else
-      3,
-      10,
-#endif
+      /*warmup_runs = */ 1,
+      /*benchmark_runs = */ 1,
       ref_fn);
 
   return 0;

--- a/backends/vulkan/test/custom_ops/test_q8ta_conv2d.cpp
+++ b/backends/vulkan/test/custom_ops/test_q8ta_conv2d.cpp
@@ -734,13 +734,8 @@ int main(int argc, char* argv[]) {
 #endif
       quantized_conv2d_flop_calculator,
       "QuantizedConv2dQ8ToQ8To",
-#ifdef DEBUG_MODE
-      0,
-      1,
-#else
-      3,
-      10,
-#endif
+      /*warmup_runs = */ 1,
+      /*benchmark_runs = */ 1,
       ref_fn);
 
   return 0;

--- a/backends/vulkan/test/custom_ops/test_q8ta_conv2d_dw.cpp
+++ b/backends/vulkan/test/custom_ops/test_q8ta_conv2d_dw.cpp
@@ -640,13 +640,8 @@ int main(int argc, char* argv[]) {
 #endif
       quantized_conv2d_dw_flop_calculator,
       "QuantizedDepthwiseInt8Conv2d",
-#ifdef DEBUG_MODE
-      0,
-      1,
-#else
-      5,
-      40,
-#endif
+      /*warmup_runs = */ 1,
+      /*benchmark_runs = */ 1,
       ref_fn);
 
   return 0;

--- a/backends/vulkan/test/custom_ops/test_q8ta_conv2d_pw.cpp
+++ b/backends/vulkan/test/custom_ops/test_q8ta_conv2d_pw.cpp
@@ -612,13 +612,8 @@ int main(int argc, char* argv[]) {
 #endif
       quantized_conv2d_flop_calculator,
       "QuantizedConv2dPW",
-#ifdef DEBUG_MODE
-      0,
-      1,
-#else
-      5,
-      25,
-#endif
+      /*warmup_runs = */ 1,
+      /*benchmark_runs = */ 1,
       ref_fn);
 
   return 0;

--- a/backends/vulkan/test/custom_ops/test_q8ta_conv2d_transposed.cpp
+++ b/backends/vulkan/test/custom_ops/test_q8ta_conv2d_transposed.cpp
@@ -588,13 +588,8 @@ int main(int argc, char* argv[]) {
 #endif
       quantized_conv2d_transposed_flop_calculator,
       "QuantizedTransposedConv2d",
-#ifdef DEBUG_MODE
-      0,
-      1,
-#else
-      3,
-      10,
-#endif
+      /*warmup_runs = */ 1,
+      /*benchmark_runs = */ 1,
       ref_fn);
 
   return 0;

--- a/backends/vulkan/test/custom_ops/test_q8ta_linear.cpp
+++ b/backends/vulkan/test/custom_ops/test_q8ta_linear.cpp
@@ -351,8 +351,8 @@ int main(int argc, char* argv[]) {
       generate_q8ta_linear_test_cases,
       q8ta_linear_flop_calculator,
       "Q8taLinear",
-      3,
-      10,
+      /*warmup_runs = */ 1,
+      /*benchmark_runs = */ 1,
       ref_fn);
 
   return 0;

--- a/backends/vulkan/test/custom_ops/test_q8ta_pixel_shuffle.cpp
+++ b/backends/vulkan/test/custom_ops/test_q8ta_pixel_shuffle.cpp
@@ -296,8 +296,8 @@ int main(int /*argc*/, char* /*argv*/[]) {
   auto results = execute_test_cases(
       generate_all_cases,
       "Q8taPixelShuffle",
-      3, // warmup
-      10, // benchmark
+      /*warmup_runs = */ 1,
+      /*benchmark_runs = */ 1,
       ref_fn);
 
   return 0;

--- a/backends/vulkan/test/custom_ops/test_q8ta_qdq.cpp
+++ b/backends/vulkan/test/custom_ops/test_q8ta_qdq.cpp
@@ -369,13 +369,8 @@ int main(int argc, char* argv[]) {
       generate_q_dq_8bit_test_cases,
 #endif
       "QDQ8Bit",
-#ifdef DEBUG_MODE
-      0,
-      1,
-#else
-      3,
-      10,
-#endif
+      /*warmup_runs = */ 1,
+      /*benchmark_runs = */ 1,
       ref_fn);
 
   return 0;

--- a/backends/vulkan/test/custom_ops/test_q8ta_unary.cpp
+++ b/backends/vulkan/test/custom_ops/test_q8ta_unary.cpp
@@ -298,13 +298,8 @@ int main(int argc, char* argv[]) {
       generate_q8ta_unary_test_cases,
 #endif
       "Q8taUnary",
-#ifdef DEBUG_MODE
-      0,
-      1,
-#else
-      3,
-      10,
-#endif
+      /*warmup_runs = */ 1,
+      /*benchmark_runs = */ 1,
       ref_fn);
 
   return 0;

--- a/backends/vulkan/test/custom_ops/utils.cpp
+++ b/backends/vulkan/test/custom_ops/utils.cpp
@@ -17,6 +17,20 @@ namespace executorch {
 namespace vulkan {
 namespace prototyping {
 
+namespace {
+
+// Upper bound on the auto-sized chained_dispatches factor. Caps the factor
+// when an op is fast enough that target_us / probe_us would otherwise
+// exceed this; past this point, stacking more dispatches doesn't materially
+// improve measurement precision.
+constexpr int kMaxChainedDispatches = 200;
+
+// Floor for probe_us to avoid division-by-zero / a runaway chained_dispatches
+// factor when an op finishes faster than the wall clock can resolve.
+constexpr float kMinProbeTimeUs = 1.0f;
+
+} // namespace
+
 int get_seed() {
   static int seed = 42;
   return seed++;
@@ -1342,7 +1356,10 @@ int64_t default_flop_calculator(const TestCase& test_case) {
   return total_elements;
 }
 
-ComputeGraph setup_compute_graph(TestCase& test_case, std::string op_name) {
+ComputeGraph setup_compute_graph(
+    TestCase& test_case,
+    std::string op_name,
+    int op_invocations_per_execute) {
   GraphConfig config;
   config.enable_querypool = true;
   ComputeGraph graph(config);
@@ -1423,7 +1440,12 @@ ComputeGraph setup_compute_graph(TestCase& test_case, std::string op_name) {
   std::vector<ValueRef> op_args = input_values;
   op_args.insert(op_args.end(), output_values.begin(), output_values.end());
 
-  opFn(graph, op_args);
+  // Invoke the op op_invocations_per_execute times to stack dispatches per
+  // graph.execute(). The output set_output_value() calls below still happen
+  // exactly once.
+  for (int i = 0; i < op_invocations_per_execute; ++i) {
+    opFn(graph, op_args);
+  }
 
   for (size_t i = 0; i < output_values.size(); ++i) {
     graph.set_output_value(output_values[i]);
@@ -1432,8 +1454,12 @@ ComputeGraph setup_compute_graph(TestCase& test_case, std::string op_name) {
 }
 
 // Test execution utilities
-BenchmarkResult
-execute_test_case(TestCase& test_case, int warmup_runs, int benchmark_runs) {
+BenchmarkResult execute_test_case(
+    TestCase& test_case,
+    int warmup_runs,
+    int benchmark_runs,
+    int chained_dispatches,
+    bool write_outputs) {
   BenchmarkResult result(
       test_case.name().empty() ? "unnamed_test_case" : test_case.name());
 
@@ -1442,9 +1468,11 @@ execute_test_case(TestCase& test_case, int warmup_runs, int benchmark_runs) {
     api::context()->initialize_querypool();
   }
 
-  // Create the compute graph for this test case using setup_compute_graph
-  ComputeGraph graph =
-      setup_compute_graph(test_case, test_case.operator_name());
+  // Build the measurement graph with the requested chained_dispatches factor.
+  // The caller (typically execute_test_cases) decides what it should be —
+  // this function is a pure "run at the given chained_dispatches" primitive.
+  ComputeGraph graph = setup_compute_graph(
+      test_case, test_case.operator_name(), chained_dispatches);
 
   // Prepare the graph
   graph.prepare();
@@ -1505,6 +1533,8 @@ execute_test_case(TestCase& test_case, int warmup_runs, int benchmark_runs) {
   float total_cpu_time_us = 0.0f;
   float total_gpu_time_us = 0.0f;
 
+  const float chained_dispatches_f = static_cast<float>(chained_dispatches);
+
   for (int run = 0; run < benchmark_runs; ++run) {
     // Measure CPU time for each execute() call
     auto cpu_start = std::chrono::high_resolution_clock::now();
@@ -1513,7 +1543,10 @@ execute_test_case(TestCase& test_case, int warmup_runs, int benchmark_runs) {
 
     auto cpu_duration = std::chrono::duration_cast<std::chrono::microseconds>(
         cpu_end - cpu_start);
-    float cpu_time_us = static_cast<float>(cpu_duration.count());
+    // Each execute() ran chained_dispatches op invocations; report
+    // per-invocation time.
+    float cpu_time_us =
+        static_cast<float>(cpu_duration.count()) / chained_dispatches_f;
     total_cpu_time_us += cpu_time_us;
 
     // Collect per-shader GPU timing - get raw shader results to preserve
@@ -1540,7 +1573,10 @@ execute_test_case(TestCase& test_case, int warmup_runs, int benchmark_runs) {
             shader_result.end_time_ns - shader_result.start_time_ns;
         float duration_us = static_cast<float>(duration_ns) / 1000.0f;
         gpu_time_us += duration_us;
-        // Store per-shader timing with work group sizes
+        // Per-shader sample is already one querypool entry per dispatch (at
+        // chained_dispatches>1 we get that many entries per shader), so do NOT
+        // divide here — the aggregator (get_avg_time_us) averages across them
+        // naturally.
         result.add_shader_timing(
             shader_result.kernel_name,
             duration_us,
@@ -1548,6 +1584,9 @@ execute_test_case(TestCase& test_case, int warmup_runs, int benchmark_runs) {
             shader_result.metadata.local_workgroup_size);
       }
     }
+    // gpu_time_us aggregates chained_dispatches worth of shader runs; divide
+    // it down to per-invocation time.
+    gpu_time_us /= chained_dispatches_f;
     total_gpu_time_us += gpu_time_us;
 
     // Add the appropriate timing based on the flag
@@ -1572,30 +1611,34 @@ execute_test_case(TestCase& test_case, int warmup_runs, int benchmark_runs) {
               << " timing for result" << std::endl;
   }
 
-  // Copy output data from the graph's staging buffers
-  for (size_t i = 0; i < test_case.num_outputs(); ++i) {
-    ValueSpec& output_spec = test_case.outputs()[i];
+  // Copy output data from the graph's staging buffers. The benchmarking path
+  // skips this work since it doesn't need correctness data — the probe pass
+  // has already populated test_case.outputs() at chained_dispatches=1.
+  if (write_outputs) {
+    for (size_t i = 0; i < test_case.num_outputs(); ++i) {
+      ValueSpec& output_spec = test_case.outputs()[i];
 
-    if (output_spec.is_tensor() && i < graph.outputs().size()) {
-      const auto& output_ref = graph.outputs()[i];
+      if (output_spec.is_tensor() && i < graph.outputs().size()) {
+        const auto& output_ref = graph.outputs()[i];
 
-      // Ensure output data vector is properly sized
-      size_t data_numel = output_spec.numel();
-      output_spec.resize_data(data_numel);
+        // Ensure output data vector is properly sized
+        size_t data_numel = output_spec.numel();
+        output_spec.resize_data(data_numel);
 
-      // Get mutable data pointer for the output
-      void* data_ptr = output_spec.get_mutable_data_ptr();
+        // Get mutable data pointer for the output
+        void* data_ptr = output_spec.get_mutable_data_ptr();
 
-      if (data_ptr != nullptr) {
-        // Copy data from staging buffer to output spec
-        graph.maybe_cast_and_copy_from_staging(
-            output_ref.staging, data_ptr, data_numel, output_spec.dtype);
-      }
+        if (data_ptr != nullptr) {
+          // Copy data from staging buffer to output spec
+          graph.maybe_cast_and_copy_from_staging(
+              output_ref.staging, data_ptr, data_numel, output_spec.dtype);
+        }
 
-      // Print output tensor data if output printing is enabled
-      if (print_output()) {
-        std::string output_name = "Output[" + std::to_string(i) + "]";
-        print_valuespec_data(output_spec, output_name);
+        // Print output tensor data if output printing is enabled
+        if (print_output()) {
+          std::string output_name = "Output[" + std::to_string(i) + "]";
+          print_valuespec_data(output_spec, output_name);
+        }
       }
     }
   }
@@ -1706,7 +1749,57 @@ TestResult execute_test_cases(
       BenchmarkResult result;
       bool shader_not_supported = false;
       try {
-        result = execute_test_case(test_case, warmup_runs, benchmark_runs);
+        // Always run a probe pass at chained_dispatches=1 with
+        // write_outputs=true. This populates test_case.outputs() for the
+        // downstream correctness check with a clean single-dispatch result,
+        // and also gives us probe_us for adaptive sizing of the measurement
+        // run's chained_dispatches.
+        //
+        // probe_then_scale (Google Benchmark style): size chained_dispatches
+        // so each measurement execute() takes ~target_us. Tiny ops get a
+        // large factor (driving GPU governor escalation); heavy ops get a
+        // small factor (bounded wall time). Caveat: on Adreno 740 the probe
+        // runs at the DCVS-pinned clock (~220 MHz), so probe_us is inflated
+        // and the computed factor comes out under-sized for boost clock — but
+        // the default target is generous enough that an under-sized factor
+        // still drives sustained activity.
+        BenchmarkResult probe_result = execute_test_case(
+            test_case,
+            /*warmup_runs=*/1,
+            /*benchmark_runs=*/1,
+            /*chained_dispatches=*/1,
+            /*write_outputs=*/true);
+        float probe_us = probe_result.get_avg_time_us();
+        if (probe_us < kMinProbeTimeUs) {
+          probe_us = kMinProbeTimeUs;
+        }
+
+        int chained_dispatches;
+        const int manual_n = test_case.get_op_invocations_per_execute();
+        if (manual_n > 0) {
+          chained_dispatches = manual_n;
+        } else {
+          const int target_us = test_case.get_target_execute_time_us();
+          chained_dispatches =
+              std::max(1, static_cast<int>(target_us / probe_us));
+          chained_dispatches =
+              std::min(chained_dispatches, kMaxChainedDispatches);
+        }
+        if (debugging()) {
+          std::cout << "[probe] " << test_case.name()
+                    << ": probe_us=" << probe_us
+                    << ", chained_dispatches=" << chained_dispatches
+                    << std::endl;
+        }
+
+        // Measurement pass: chained_dispatches stacking, skip output copy
+        // since the probe already wrote the correctness data.
+        result = execute_test_case(
+            test_case,
+            warmup_runs,
+            benchmark_runs,
+            chained_dispatches,
+            /*write_outputs=*/false);
         result.set_operator_name(test_case.operator_name());
       } catch (const vkcompute::vkapi::ShaderNotSupportedError&) {
         result = BenchmarkResult(

--- a/backends/vulkan/test/custom_ops/utils.h
+++ b/backends/vulkan/test/custom_ops/utils.h
@@ -474,6 +474,13 @@ struct ValueSpec {
 // TestCase
 //
 
+// Default per-execute() wall-clock target used by the probe-then-scale logic
+// in execute_test_cases(). Picked generously enough that even an under-sized
+// chained_dispatches factor (the probe runs at governor-pinned clock and
+// underestimates the boost-clock latency) still drives sustained GPU
+// activity during measurement.
+constexpr int kDefaultTargetExecuteTimeUs = 100000;
+
 class TestCase {
  public:
   TestCase()
@@ -524,6 +531,28 @@ class TestCase {
     return shader_filter_;
   }
 
+  // Manual override for the number of times the op is dispatched per
+  // graph.execute() (a.k.a. chained_dispatches). If > 0, the framework uses
+  // this directly and skips the probe phase. 0 (the default) means adaptive
+  // (probe-then-scale).
+  void set_op_invocations_per_execute(int n) {
+    op_invocations_per_execute_ = n;
+  }
+  int get_op_invocations_per_execute() const {
+    return op_invocations_per_execute_;
+  }
+
+  // Target single-execute duration in microseconds. Used only when the
+  // manual chained_dispatches override is not set. Default
+  // kDefaultTargetExecuteTimeUs, picked generously enough to mitigate Adreno
+  // DCVS governor pinning during the probe.
+  void set_target_execute_time_us(int us) {
+    target_execute_time_us_ = us;
+  }
+  int get_target_execute_time_us() const {
+    return target_execute_time_us_;
+  }
+
   void add_input_spec(const ValueSpec& spec) {
     inputs_.push_back(spec);
   }
@@ -567,6 +596,8 @@ class TestCase {
     abs_tolerance_ = 2e-3f;
     rel_tolerance_ = 1e-3f;
     shader_filter_ = kDefaultShaderFilter;
+    op_invocations_per_execute_ = 0;
+    target_execute_time_us_ = kDefaultTargetExecuteTimeUs;
   }
 
  private:
@@ -577,6 +608,8 @@ class TestCase {
   float abs_tolerance_;
   float rel_tolerance_;
   std::vector<std::string> shader_filter_;
+  int op_invocations_per_execute_ = 0; // 0 = adaptive
+  int target_execute_time_us_ = kDefaultTargetExecuteTimeUs;
 };
 
 //
@@ -799,24 +832,35 @@ int64_t default_flop_calculator(const TestCase& test_case);
 
 using ReferenceComputeFunc = std::function<void(TestCase&)>;
 
+// Runs a measurement at the given chained_dispatches factor (how many times
+// the op is stacked inside one graph.execute()). This is a primitive; the
+// probe-then-scale orchestration lives in execute_test_cases().
+//
+// write_outputs controls whether the graph's staging output buffers are copied
+// back into test_case.outputs() at the end of the run. The probe path needs
+// write_outputs=true so the correctness check has a clean single-dispatch
+// reference. The benchmarking path passes write_outputs=false to avoid the
+// per-iter GPU->CPU copy cost.
 BenchmarkResult execute_test_case(
     TestCase& test_case,
-    int warmup_runs = 3,
-    int benchmark_runs = 10);
+    int warmup_runs = 1,
+    int benchmark_runs = 1,
+    int chained_dispatches = 1,
+    bool write_outputs = true);
 
 TestResult execute_test_cases(
     std::function<std::vector<TestCase>()> test_case_generator,
     FlopCalculatorFunc flop_calculator,
     const std::string& operation_name = "Operation",
-    int warmup_runs = 3,
-    int benchmark_runs = 10,
+    int warmup_runs = 1,
+    int benchmark_runs = 1,
     ReferenceComputeFunc reference_compute_func = nullptr);
 
 TestResult execute_test_cases(
     std::function<std::vector<TestCase>()> test_case_generator,
     const std::string& operation_name = "Operation",
-    int warmup_runs = 3,
-    int benchmark_runs = 10,
+    int warmup_runs = 1,
+    int benchmark_runs = 1,
     ReferenceComputeFunc reference_compute_func = nullptr);
 
 //
@@ -868,8 +912,14 @@ void compute_weight_sums_4bit_grouped(
 uint16_t float_to_half(float value);
 float half_to_float(uint16_t half_val);
 
-// Setup compute graph based on TestCase and operation name
-ComputeGraph setup_compute_graph(TestCase& test_case, std::string op_name);
+// Setup compute graph based on TestCase and operation name. The op function
+// is invoked op_invocations_per_execute times so that one graph.execute()
+// dispatches the op that many times (Google Benchmark-style stacking). The
+// output set_output_value() calls still happen once at the end.
+ComputeGraph setup_compute_graph(
+    TestCase& test_case,
+    std::string op_name,
+    int op_invocations_per_execute = 1);
 
 } // namespace prototyping
 } // namespace vulkan


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #19571
* #19570
* __->__ #19569

Add Google-Benchmark-style adaptive dispatch stacking to the prototyping test framework. The framework now automatically determines how many op invocations to chain into a single graph.execute() call by probing each test case once, then computing a per-execute dispatch count N that targets a fixed wall-clock budget. No per-binary tuning required.

Motivation: under tight-loop microbenchmark patterns, the Adreno DCVS governor pins the GPU clock at a low step (e.g. 220 MHz on Adreno 740 when boost is 719 MHz), which inflates per-op latency by ~3x and makes per-device perf comparisons misleading. The fix is to drive sustained GPU activity by stacking many dispatches per execute. Previously each test author had to hand-tune the N for each op shape; this commit eliminates that work.

Algorithm (Google Benchmark style):
1. For each TestCase, run a sample execute() at N=1 to measure per-op wall time (probe_us).
2. Compute N = clamp(target_us / probe_us, 1, 1000), with target_us = 50000 us by default. The generous target value mitigates the fact that the probe itself runs at the pinned governor clock — the resulting N is somewhat under-sized, but still drives enough sustained activity for the governor to escalate during the measurement loop.
3. Build a new graph at the computed N and run warmup + benchmark as usual.
4. Per-execute CPU wall time and aggregate GPU time are divided by N before being reported so the user sees per-invocation latency. Per-shader samples remain undivided (each querypool entry is one dispatch; at N>1 the aggregator naturally averages over N samples per execute x benchmark_runs samples).

API surface:

- execute_test_case gains an int chained_dispatches = 1 parameter. It is a pure 'run-at-N' primitive — no internal probe, no orchestration.
- execute_test_cases (the orchestrator) does the probe-then-scale: for each test case, calls execute_test_case(tc, 1, 1, 1) to probe, computes N, prints a single '[probe] {name}: probe_us={us}, N={N}' line, then calls execute_test_case(tc, warmup_runs, benchmark_runs, N) for the real measurement.
- setup_compute_graph gains an int op_invocations_per_execute = 1 parameter; it loops the opFn call that many times.
- TestCase gains set_op_invocations_per_execute(int n) (manual override; 0 = adaptive, default) and set_target_execute_time_us(int us) (default 50000) plus getters.

On-device validation (Samsung Galaxy S24, Adreno 750, test_q8ta_conv2d, 181 test cases): 84/84 ACCU passed. probe_us ranged 125 to 9336 us; computed N ranged 5 to 400; no case hit the N=1000 cap or the N=1 floor. The probe-to-measurement latency ratio reached 15.93x on small ACCU shapes — i.e. the governor visibly escalated from pinned to boost clock between the probe and the measurement loop — confirming the mitigation is doing real work. Heavy PERF shapes showed probe/measured ratios of only 1.04-1.12x because they already hold the GPU at high clock from the first dispatch.

Test binaries do NOT need to be modified — the new behavior is automatic. Manual override via set_op_invocations_per_execute(N) remains available for advanced cases (e.g. ops with numerical sensitivity that requires N=1).

Differential Revision: [D105059943](https://our.internmc.facebook.com/intern/diff/D105059943/)