### PR TITLE
NXP backend: Add QAT tests for AvgPool, MaxPool and Mul tensor ops

### DIFF
--- a/backends/nxp/tests/ir/converter/node_converter/test_avg_pool2d_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_avg_pool2d_converter.py
@@ -29,6 +29,9 @@ from executorch.backends.nxp.tests.executors import (
     ToNHWCPreprocess,
 )
 from executorch.backends.nxp.tests.graph_verifier import DetailedGraphVerifier
+from executorch.backends.nxp.tests.model_output_comparator import (
+    NumericalStatsOutputComparator,
+)
 from executorch.backends.nxp.tests.models import AvgPool2dConvModule, AvgPool2dModule
 
 from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
@@ -312,6 +315,23 @@ class TestAvgPool2DNewNeutronFlow:
 
         lower_run_compare(
             model, input_shape, graph_verifier, use_new_flow_neutron_c=True
+        )
+
+    def test__basic_nsys_inference_qat(self, mocker):
+        input_shape = (2, 9, 6, 15)
+        model = AvgPool2dModule(False, 0)
+        comparator = NumericalStatsOutputComparator()
+        graph_verifier = DetailedGraphVerifier(
+            mocker, expected_delegated_ops={AvgPool2D: 1}, expected_non_delegated_ops={}
+        )
+
+        lower_run_compare(
+            model,
+            input_shape,
+            graph_verifier,
+            output_comparator=comparator,
+            use_new_flow_neutron_c=True,
+            use_qat=True,
         )
 
     def test__kernel_size_limit(self, mocker):

--- a/backends/nxp/tests/ir/converter/node_converter/test_max_pool_2d_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_max_pool_2d_converter.py
@@ -17,6 +17,9 @@ from executorch.backends.nxp.tests.executors import (
     ToChannelLastPreprocess,
 )
 from executorch.backends.nxp.tests.graph_verifier import DetailedGraphVerifier
+from executorch.backends.nxp.tests.model_output_comparator import (
+    NumericalStatsOutputComparator,
+)
 from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
 from executorch.backends.nxp.tests.ops_aliases import (
     ExecutorchDelegateCall,
@@ -279,6 +282,25 @@ class TestMaxPool2DNewNeutronFlow:
         input_shape = (2, 4, 6, 7)  # The old flow limited the batch size to 1.
         model = MaxPool2dModule()
         self.assert_delegated(model, input_shape, mocker)
+
+    def test__basic_nsys_inference_qat(self, mocker):
+        input_shape = (2, 11, 7, 16)  # The old flow limited the batch size to 1.
+        model = MaxPool2dModule()
+        comparator = NumericalStatsOutputComparator()
+        graph_verifier = DetailedGraphVerifier(
+            mocker,
+            expected_delegated_ops={MaxPool2DWithIndices: 1, GetItem: 1},
+            expected_non_delegated_ops={},
+        )
+
+        lower_run_compare(
+            model,
+            input_shape,
+            graph_verifier,
+            output_comparator=comparator,
+            use_new_flow_neutron_c=True,
+            use_qat=True,
+        )
 
     def test__kernel_size_limit(self, mocker):
         kernel_size = (1, 4096)

--- a/backends/nxp/tests/ir/converter/node_converter/test_mul_tensor_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_mul_tensor_converter.py
@@ -20,7 +20,10 @@ from executorch.backends.nxp.tests.executors import (
     ToChannelFirstPreprocess,
     ToChannelLastPreprocess,
 )
-from executorch.backends.nxp.tests.graph_verifier import BaseGraphVerifier
+from executorch.backends.nxp.tests.graph_verifier import DetailedGraphVerifier
+from executorch.backends.nxp.tests.model_output_comparator import (
+    NumericalStatsOutputComparator,
+)
 from executorch.backends.nxp.tests.models import (
     MulTensorConvModule,
     MulTensorModule,
@@ -229,12 +232,11 @@ class TestMulTensorNewNeutronFlow:
             pytest.param((1, 4, 8, 8), id="4D."),
         ],
     )
-    def test__basic_nsys_inference(self, x_input_shape):
+    def test__basic_nsys_inference(self, x_input_shape, mocker):
         x_input_spec = ModelInputSpec(x_input_shape)
         model = MulTensorModule()
-        graph_verifier = BaseGraphVerifier(
-            exp_num_delegate_call_nodes=1,
-            exp_non_delegated_nodes=[],
+        graph_verifier = DetailedGraphVerifier(
+            mocker, expected_delegated_ops={MulTensor: 1}, expected_non_delegated_ops={}
         )
 
         lower_run_compare(
@@ -242,6 +244,30 @@ class TestMulTensorNewNeutronFlow:
             [x_input_spec, x_input_spec],
             graph_verifier,
             use_new_flow_neutron_c=True,
+        )
+
+    @pytest.mark.parametrize(
+        "x_input_shape",
+        [
+            pytest.param((1, 4, 8), id="3D."),
+            pytest.param((1, 4, 8, 8), id="4D."),
+        ],
+    )
+    def test__basic_nsys_inference_qat(self, x_input_shape, mocker):
+        x_input_spec = ModelInputSpec(x_input_shape)
+        model = MulTensorModule()
+        comparator = NumericalStatsOutputComparator()
+        graph_verifier = DetailedGraphVerifier(
+            mocker, expected_delegated_ops={MulTensor: 1}, expected_non_delegated_ops={}
+        )
+
+        lower_run_compare(
+            model,
+            [x_input_spec, x_input_spec],
+            graph_verifier,
+            output_comparator=comparator,
+            use_new_flow_neutron_c=True,
+            use_qat=True,
         )
 
     @pytest.mark.parametrize(
@@ -259,11 +285,10 @@ class TestMulTensorNewNeutronFlow:
             ),
         ],
     )
-    def test__correct_broadcast(self, input_spec):
+    def test__correct_broadcast(self, input_spec, mocker):
         model = MulTensorModule()
-        graph_verifier = BaseGraphVerifier(
-            exp_num_delegate_call_nodes=1,
-            exp_non_delegated_nodes=[],
+        graph_verifier = DetailedGraphVerifier(
+            mocker, expected_delegated_ops={MulTensor: 1}, expected_non_delegated_ops={}
         )
 
         lower_run_compare(
@@ -308,16 +333,17 @@ class TestMulTensorNewNeutronFlow:
             ),
         ],
     )
-    def test__w_conv(self, x_input_shape):
+    def test__w_conv(self, x_input_shape, mocker):
         model = MulTensorConvModule()
 
         n, c, h, w = x_input_shape
         y_input_spec = ModelInputSpec((n, 8, h, w))
         x_input_spec = ModelInputSpec(x_input_shape)
 
-        graph_verifier = BaseGraphVerifier(
-            exp_num_delegate_call_nodes=1,
-            exp_non_delegated_nodes=[],
+        graph_verifier = DetailedGraphVerifier(
+            mocker,
+            expected_delegated_ops={MulTensor: 1, Convolution: 1},
+            expected_non_delegated_ops={},
         )
 
         lower_run_compare(


### PR DESCRIPTION
### Summary
Add QAT tests for AvgPool, MaxPool and Mul tensor ops for Neutron backend using the new Neutron MLIR flow.

### Test plan
Unit tests provided.


cc @robert-kalmar 