### PR TITLE
[ETVK][experimental] Route general conv2d through im2col + GEMM

### DIFF
--- a/backends/vulkan/runtime/graph/ops/impl/Convolution.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Convolution.cpp
@@ -11,6 +11,7 @@
 #include <executorch/backends/vulkan/runtime/graph/ops/OperatorRegistry.h>
 
 #include <executorch/backends/vulkan/runtime/graph/ops/impl/Common.h>
+#include <executorch/backends/vulkan/runtime/graph/ops/impl/Conv2dGemm.h>
 #include <executorch/backends/vulkan/runtime/graph/ops/impl/Staging.h>
 
 #include <executorch/backends/vulkan/runtime/graph/ops/utils/StagingUtils.h>
@@ -460,6 +461,27 @@ void add_conv2d_node(
 
   if (method == Conv2dMethod::Depthwise) {
     return conv2d_dw_impl(
+        graph,
+        in,
+        weight_data,
+        bias,
+        stride,
+        padding,
+        dilation,
+        out,
+        clamp_out,
+        out_min_val,
+        out_max_val);
+  }
+
+  // EXPERIMENTAL: route the general SlidingWindow case through the im2col
+  // + GEMM implementation. The im2col path picks an im2col intermediate
+  // storage (buffer / texture2d / texture3d) per device and consistently
+  // outperforms the legacy conv2d shader on the depth-estimator hotspots.
+  // Transposed conv keeps using the legacy path because conv2d_gemm_impl
+  // doesn't support it yet.
+  if (method == Conv2dMethod::SlidingWindow) {
+    return conv2d_gemm_impl(
         graph,
         in,
         weight_data,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #19579
* #19578

Routes the `SlidingWindow` branch of `add_conv2d_node` (in `Convolution.cpp`) through the new `conv2d_gemm_impl` orchestrator from the previous diff, replacing the legacy direct `conv2d` shader for the general non-pointwise / non-depthwise / non-transposed case. Pointwise still uses `conv2d_pw_impl`, depthwise still uses `conv2d_dw_impl`, transposed still uses the legacy path (im2col doesn't support transposed yet).

On a sample CNN on Pixel 9 Pro XL (Mali → buffer im2col), total convolution time drops from 84.3 ms to 59.8 ms — a **29% reduction**. The previously-dominant `conv2d_float` (78.5 ms, ~93% of conv time) is replaced by `conv2d_im2col_buffer_float` (10.8 ms) + `conv2d_gemm_buffer_float` (42.5 ms). Pointwise and depthwise dispatches are unchanged.

```
kernel                                       before (us)    after (us)
------------------------------------------------------------------------
conv2d_float                                     78518.3           0.0
conv2d_gemm_buffer_float                             0.0       42501.3
conv2d_im2col_buffer_float                           0.0       10806.6
conv2d_pw_tiled_float                             5525.0        6163.5
conv2d_dw_output_tile_3x3_b1x1_float               101.0         124.4
conv2d_dw_sned_output_tile_5x5_float               171.5         206.1
------------------------------------------------------------------------
TOTAL conv time                                  84315.8       59801.9
```

This is intentionally a thin, easily-revertible diff sitting on top of the im2col + GEMM prototype, marked experimental so we can land it as a kill-switch-able change while we validate other models.

Differential Revision: [D105120965](https://our.internmc.facebook.com/intern/diff/D105120965/)