### PR TITLE
Add executorch-ubuntu-24.04-gcc14 docker image (#19521)

### DIFF
--- a/backends/arm/test/ops/test_exp.py
+++ b/backends/arm/test/ops/test_exp.py
@@ -129,3 +129,42 @@ def test_exp_vgf_quant(test_data: Tuple):
         quantize=True,
     )
     pipeline.run()
+
+
+a16w8_exp_test_parameters = {
+    "rank1_rand": lambda: torch.rand(10),
+    "rank2_rand": lambda: torch.rand(8, 8) - 0.5,
+    "rank3_rand": lambda: torch.rand(1, 4, 4) * 2 - 1,
+}
+
+
+@common.parametrize("test_data", a16w8_exp_test_parameters)
+@common.XfailIfNoCorstone300
+def test_exp_a16w8_u55_INT(test_data: Tuple):
+    pipeline = EthosU55PipelineINT[input_t1](
+        Exp(),
+        (test_data(),),
+        aten_op,
+        exir_ops=[],
+        symmetric_io_quantization=True,
+        a16w8_quantization=True,
+        qtol=128,
+        epsilon=2**-16,
+    )
+    pipeline.run()
+
+
+@common.parametrize("test_data", a16w8_exp_test_parameters)
+@common.XfailIfNoCorstone320
+def test_exp_a16w8_u85_INT(test_data: Tuple):
+    pipeline = EthosU85PipelineINT[input_t1](
+        Exp(),
+        (test_data(),),
+        aten_op,
+        exir_ops=[],
+        symmetric_io_quantization=True,
+        a16w8_quantization=True,
+        qtol=128,
+        epsilon=2**-16,
+    )
+    pipeline.run()

--- a/backends/arm/test/targets.bzl
+++ b/backends/arm/test/targets.bzl
@@ -36,6 +36,7 @@ def define_arm_tests():
         "ops/test_view.py",
         "ops/test_cos.py",
         "ops/test_to_copy.py",
+        "ops/test_exp.py",
     ]
 
     # Quantization


### PR DESCRIPTION
### Summary

Simply add a docker build image based on ubuntu 24.04 with gcc 14. It's
necessary for XNNPACK on riscv64 to have a newer toolchain, to support
the latest features of the hardware (vectorization with RVV).