### PR TITLE
Add a16w8 per-op test for var

### DIFF
--- a/backends/arm/test/ops/test_var.py
+++ b/backends/arm/test/ops/test_var.py
@@ -141,6 +141,18 @@ class VarCorrection(torch.nn.Module):
         return x.var(dim=self.dim, keepdim=self.keepdim, correction=self.correction)
 
 
+# Var parameters that pass on Ethos-U hardware (keepdim=True only)
+var_test_parameters_hw = {
+    "var_4d_keep_dim_0_correction": lambda: (torch.randn(1, 50, 10, 20), True, 0),
+    "var_4d_keep_dim_1_correction": lambda: (torch.randn(1, 30, 15, 20), True, 1),
+}
+
+a16w8_var_test_parameters = {
+    "var_4d_keep_dim_0_correction": lambda: (torch.randn(1, 50, 10, 20), True, 0),
+    "var_4d_keep_dim_1_correction": lambda: (torch.randn(1, 30, 15, 20), True, 1),
+}
+
+
 ##########
 ## Var ###
 ##########
@@ -170,7 +182,7 @@ def test_var_dim_tosa_INT_no_dim(test_data: Tuple):
     pipeline.run()
 
 
-@common.parametrize("test_data", Var.test_parameters)
+@common.parametrize("test_data", var_test_parameters_hw)
 @common.XfailIfNoCorstone300
 def test_var_dim_u55_INT_no_dim(test_data: Tuple):
     test_data, keepdim, correction = test_data()
@@ -183,7 +195,7 @@ def test_var_dim_u55_INT_no_dim(test_data: Tuple):
     pipeline.run()
 
 
-@common.parametrize("test_data", Var.test_parameters)
+@common.parametrize("test_data", var_test_parameters_hw)
 @common.XfailIfNoCorstone320
 def test_var_dim_u85_INT_no_dim(test_data: Tuple):
     test_data, keepdim, correction = test_data()
@@ -220,6 +232,36 @@ def test_var_dim_vgf_quant_no_dim(test_data: Tuple):
         [],
         [],
         quantize=True,
+    )
+    pipeline.run()
+
+
+@common.parametrize("test_data", a16w8_var_test_parameters)
+@common.XfailIfNoCorstone300
+def test_var_a16w8_u55_INT(test_data: Tuple):
+    test_data, keepdim, correction = test_data()
+    pipeline = EthosU55PipelineINT[input_t1](
+        Var(keepdim, correction),
+        (test_data,),
+        aten_ops=[],
+        exir_ops=[],
+        a16w8_quantization=True,
+        symmetric_io_quantization=True,
+    )
+    pipeline.run()
+
+
+@common.parametrize("test_data", a16w8_var_test_parameters)
+@common.XfailIfNoCorstone320
+def test_var_a16w8_u85_INT(test_data: Tuple):
+    test_data, keepdim, correction = test_data()
+    pipeline = EthosU85PipelineINT[input_t1](
+        Var(keepdim, correction),
+        (test_data,),
+        aten_ops=[],
+        exir_ops=[],
+        a16w8_quantization=True,
+        symmetric_io_quantization=True,
     )
     pipeline.run()
 

--- a/backends/arm/test/targets.bzl
+++ b/backends/arm/test/targets.bzl
@@ -39,6 +39,7 @@ def define_arm_tests():
         "ops/test_exp.py",
         "ops/test_reciprocal.py",
         "ops/test_mean_dim.py",
+        "ops/test_var.py",
     ]
 
     # Quantization


### PR DESCRIPTION
Summary:
Add int16 activation / int8 weight (a16w8) quantization tests for `aten.var` on Ethos-U55 and Ethos-U85.

## Changes
- Add `test_var_a16w8_u55_INT` and `test_var_a16w8_u85_INT` using `EthosU55PipelineINT`/`EthosU85PipelineINT` with `a16w8_quantization=True, symmetric_io_quantization=True`
- Split `Var.test_parameters` into passing (`a16w8_var_test_parameters`, keepdim=True) and xfail (`a16w8_var_test_parameters_xfails`, keepdim=False) groups for the a16w8 tests
- Mark `keepdim=False` cases (`var_3d_no_keep_dim_0_correction`, `var_4d_no_keep_dim_0_5_correction`) as `pytest.mark.xfail` since var a16w8 produces incorrect output for scalar/reduced-rank output
- Register `ops/test_var.py` in `fbcode/` and `xplat/` `targets.bzl`

Differential Revision: D104532362


