### PR TITLE
Run multimodal CI under batch gdb

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -393,6 +393,8 @@ jobs:
         echo "::endgroup::"
 
         echo "::group::Test ${{ matrix.model }}"
+        export PYTHONFAULTHANDLER=1
+        export PYTHONUNBUFFERED=1
         python .ci/scripts/test_huggingface_optimum_model.py --model ${{ matrix.model }} --quantize --recipe xnnpack
         echo "::endgroup::"
 


### PR DESCRIPTION
### Summary
We're seeing intermittent segfaults on gemma4b jobs in CI. I can't repro this locally, so I'm going to see if we can get better stack traces on the python side, at least, by enabling the fault handler. The crash is almost certainly in native code, but this should at least help us narrow down what step is failing.