### PR TITLE
ci: declare workflow-level `contents: read` on 12 workflows

### DIFF
--- a/.github/workflows/build-presets.yml
+++ b/.github/workflows/build-presets.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   apple:
     uses: pytorch/test-infra/.github/workflows/macos_job.yml@main

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -4,6 +4,9 @@ on:
   repository_dispatch:
     types: [try-cherry-pick]
 
+permissions:
+  contents: read
+
 jobs:
   cherry-pick:
     name: cherry-pick-pr-${{ github.event.client_payload.pr_num }}

--- a/.github/workflows/ghstack_land.yml
+++ b/.github/workflows/ghstack_land.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - 'gh/*/[0-9]+/base'
 
+permissions:
+  contents: read
+
 jobs:
   ghstack_merge_to_main:
     name: Try to create a PR with ghstack /orig branch

--- a/.github/workflows/metal.yml
+++ b/.github/workflows/metal.yml
@@ -20,6 +20,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test-metal-builds:
     name: test-executorch-metal-build

--- a/.github/workflows/test-backend-arm.yml
+++ b/.github/workflows/test-backend-arm.yml
@@ -16,6 +16,9 @@ concurrency:
   group: ${{ github.workflow }}--${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test-arm:
     uses: ./.github/workflows/_test_backend.yml

--- a/.github/workflows/test-backend-coreml.yml
+++ b/.github/workflows/test-backend-coreml.yml
@@ -16,6 +16,9 @@ concurrency:
   group: ${{ github.workflow }}--${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   # Emits PR diff file list; non-PR events emit '*' so the per-job
   # `if:` short-circuits via `event_name != 'pull_request'`. This

--- a/.github/workflows/test-backend-openvino.yml
+++ b/.github/workflows/test-backend-openvino.yml
@@ -18,6 +18,9 @@ concurrency:
   group: ${{ github.workflow }}--${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test-openvino:
     uses: ./.github/workflows/_test_backend.yml

--- a/.github/workflows/test-backend-qnn.yml
+++ b/.github/workflows/test-backend-qnn.yml
@@ -16,6 +16,9 @@ concurrency:
   group: ${{ github.workflow }}--${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test-qnn:
     uses: ./.github/workflows/_test_backend.yml

--- a/.github/workflows/test-backend-vulkan.yml
+++ b/.github/workflows/test-backend-vulkan.yml
@@ -16,6 +16,9 @@ concurrency:
   group: ${{ github.workflow }}--${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test-vulkan:
     uses: ./.github/workflows/_test_backend.yml

--- a/.github/workflows/test-backend-xnnpack.yml
+++ b/.github/workflows/test-backend-xnnpack.yml
@@ -16,6 +16,9 @@ concurrency:
   group: ${{ github.workflow }}--${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test-xnnpack:
     uses: ./.github/workflows/_test_backend.yml

--- a/.github/workflows/validate_flatbuffer_gen.yml
+++ b/.github/workflows/validate_flatbuffer_gen.yml
@@ -7,6 +7,9 @@ on:
       - "schema/**"
       - "exir/_serialize/generated/executorch_flatbuffer/**"
 
+permissions:
+  contents: read
+
 jobs:
   exir-flatbuffer:
     runs-on: ubuntu-latest

--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -17,6 +17,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build-windows-msvc:
     name: build-windows-msvc


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 12 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

The following files were left implicit because they reference `GITHUB_TOKEN` / use a write-scope action / trigger on `pull_request_target`. Those scopes are best declared by maintainers: `add-unanswered-to-project.yml`, `docker-builds.yml`, `pending_user_response.yml`.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.