### PR TITLE
Add grammar fields to GenerationConfig for constrained decoding

### DIFF
--- a/extension/llm/runner/irunner.h
+++ b/extension/llm/runner/irunner.h
@@ -33,6 +33,14 @@ struct GenerationConfig {
   // Whether to echo the input prompt in the output
   bool echo = true;
 
+  // Grammar definition for constrained decoding (e.g. a JSON schema, regex,
+  // Lark CFG, or GBNF grammar). Empty string means no constraint.
+  std::string grammar;
+
+  // Grammar format: "json_schema", "regex", "lark", or "gbnf".
+  // Only used when grammar is non-empty.
+  std::string grammar_type;
+
   // Whether to ignore EOS token and continue generating until max_new_tokens
   bool ignore_eos = false;
 


### PR DESCRIPTION
Summary:
Add grammar (string) and grammar_type (string) fields to GenerationConfig.
Empty-string defaults, no behavior change when empty. Prepares for
grammar-constrained decoding integration (e.g. JSON schema, regex).

Differential Revision: D105277261


