### PR TITLE
Revert "Add grammar fields to GenerationConfig for constrained decoding"

### DIFF
--- a/extension/llm/runner/irunner.h
+++ b/extension/llm/runner/irunner.h
@@ -33,14 +33,6 @@ struct GenerationConfig {
   // Whether to echo the input prompt in the output
   bool echo = true;
 
-  // Grammar definition for constrained decoding (e.g. a JSON schema, regex,
-  // Lark CFG, or GBNF grammar). Empty string means no constraint.
-  std::string grammar;
-
-  // Grammar format: "json_schema", "regex", "lark", or "gbnf".
-  // Only used when grammar is non-empty.
-  std::string grammar_type;
-
   // Whether to ignore EOS token and continue generating until max_new_tokens
   bool ignore_eos = false;
 


### PR DESCRIPTION
This reverts commit 7355d7b52d622f01db1b6f61b4e30678817df4f3.

### Summary
Temporarily reverting to restore test health for QNN jobs.
