### PR TITLE
Fix GenerationConfig initialization in qnn_multimodal_runner

### DIFF
--- a/examples/qualcomm/oss_scripts/llama/qnn_multimodal_runner.cpp
+++ b/examples/qualcomm/oss_scripts/llama/qnn_multimodal_runner.cpp
@@ -177,14 +177,15 @@ void start_multimodal_runner(
     }
   };
   executorch::extension::llm::GenerationConfig config{
-      true,
-      false,
-      -1,
-      false,
-      FLAGS_seq_len,
-      static_cast<float>(FLAGS_temperature),
-      0,
-      0};
+      .echo = true,
+      .ignore_eos = false,
+      .max_new_tokens = -1,
+      .warming = false,
+      .seq_len = FLAGS_seq_len,
+      .temperature = static_cast<float>(FLAGS_temperature),
+      .num_bos = 0,
+      .num_eos = 0,
+  };
 
   // 1. [Multimodal] Get raw files from input_list.txt
   std::vector<std::string> audio_raw_files;


### PR DESCRIPTION
Summary:
...changes.

- Replace fragile positional initialization with explicit field assignments
- Improves code clarity by making field names explicit
- Makes the code robust to future changes in GenerationConfig struct

Differential Revision: D105377713


