### PR TITLE
Fix libc++.so.1 missing for qnn-context-binary-utility (#19622)

### DIFF
--- a/backends/qualcomm/tests/utils.py
+++ b/backends/qualcomm/tests/utils.py
@@ -122,8 +122,27 @@ def generate_context_binary(
         shell=True,
         executable="/bin/bash",
         capture_output=True,
+        text=True,
+        env=_qnn_subprocess_env(qnn_sdk, target),
     )
-    assert os.path.isfile(f"{artifact_dir}/model_ctx.bin"), print(result.stderr)
+    assert os.path.isfile(f"{artifact_dir}/model_ctx.bin"), (
+        f"Failed to generate context binary at {artifact_dir}/model_ctx.bin. "
+        f"returncode={result.returncode}\n"
+        f"stdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )
+
+
+def _qnn_subprocess_env(qnn_sdk: str, target: str) -> Dict[str, str]:
+    """Return an env dict with LD_LIBRARY_PATH set so QNN SDK prebuilt
+    binaries (e.g. qnn-context-binary-utility) can resolve their bundled
+    libc++.so.1, which is shipped at $QNN_SDK_ROOT/lib/<target>/.
+    """
+    env = os.environ.copy()
+    qnn_lib_dir = f"{qnn_sdk}/lib/{target}"
+    existing = env.get("LD_LIBRARY_PATH", "")
+    env["LD_LIBRARY_PATH"] = f"{qnn_lib_dir}:{existing}" if existing else qnn_lib_dir
+    return env
 
 
 def validate_context_binary(ctx_bin: bytes):
@@ -149,8 +168,15 @@ def validate_context_binary(ctx_bin: bytes):
             shell=True,
             executable="/bin/bash",
             capture_output=True,
+            text=True,
+            env=_qnn_subprocess_env(qnn_sdk, target),
         )
-        assert os.path.isfile(f"{tmp_dir}/ctx.json"), print(result.stderr)
+        assert os.path.isfile(f"{tmp_dir}/ctx.json"), (
+            f"qnn-context-binary-utility failed to produce ctx.json. "
+            f"returncode={result.returncode}\n"
+            f"stdout:\n{result.stdout}\n"
+            f"stderr:\n{result.stderr}"
+        )
 
 
 class TestQNN(unittest.TestCase):


### PR DESCRIPTION
Summary:

The QNN SDK 2.37 prebuilt 'qnn-context-binary-utility' is dynamically
linked against libc++.so.1, which is shipped at $QNN_SDK_ROOT/lib/<target>/
but not visible on the default LD_LIBRARY_PATH inside the fbcode test
sandbox. As a result, every invocation of validate_context_binary failed
with:

    qnn-context-binary-utility: error while loading shared libraries:
    libc++.so.1: cannot open shared object file: No such file or directory

…and the test asserted on a missing ctx.json with a useless
'AssertionError: None' (because print() returns None).

This change adds a small _qnn_subprocess_env() helper that prepends the
QNN SDK's bundled lib dir to LD_LIBRARY_PATH and wires it into both
validate_context_binary and generate_context_binary subprocess calls.
Also replaces print(result.stderr) inside the assert with a proper
diagnostic message including stdout and stderr.

Affected tests (previously 0% pass rate, now passing):
  - test_qnn_backend_dump_context_from_pte (Float + Quant variants)
  - test_qnn_backend_context_extraction (Float + Quant variants)

Differential Revision: D105378870


