### PR TITLE
Guard weight_dequant.args[1] access in _quantize_fused_conv_bias pass

### DIFF
--- a/backends/transforms/quantize_fused_convbn_bias_pass.py
+++ b/backends/transforms/quantize_fused_convbn_bias_pass.py
@@ -238,6 +238,8 @@ def _quantize_fused_conv_bias(
         )
 
         quant_min = -(2**31) + 1 if use_symmetric_quantization else -(2**31)
+        if len(weight_dequant.args) < 2:
+            continue
         if isinstance(weight_dequant.args[1], torch.fx.node.Node):
             weight_scale = get_weight_scale_tensor(weight_dequant.args[1])
             bias_scale = input_dequant.args[1] * weight_scale


### PR DESCRIPTION
Summary:
For models whose conv weight isn't wrapped in a `dequantize_per_tensor/per_channel` call `weight_dequant.args` has fewer than 2 elements and the access throws `IndexError`.

Adds a guard to prevent this error.

Differential Revision: D105503056


