### PR TITLE
Rename CMake target `executorch` to `executorch_prim_ops`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -546,21 +546,19 @@ if(EXECUTORCH_BUILD_PYBIND AND APPLE)
 endif()
 
 #
-# executorch: Primary runtime library with primitive operators.
+# executorch_prim_ops: Registers primitive operators (aten::copy, aten::view,
+# prim_ops) on top of executorch_core. Does not contain portable kernels,
+# full operators, or any backends.
 #
-# Provides the Program and Method interfaces, along with primitive operators.
-# Does not contain portable kernels or other full operators. Does not contain
-# any backends.
-#
-add_library(executorch ${_executorch__srcs})
-target_link_libraries(executorch PRIVATE executorch_core)
-target_include_directories(executorch PUBLIC ${_common_include_directories})
-target_compile_definitions(executorch PUBLIC C10_USING_CUSTOM_GENERATED_MACROS)
+add_library(executorch_prim_ops ${_executorch__srcs})
+target_link_libraries(executorch_prim_ops PRIVATE executorch_core)
+target_include_directories(executorch_prim_ops PUBLIC ${_common_include_directories})
+target_compile_definitions(executorch_prim_ops PUBLIC C10_USING_CUSTOM_GENERATED_MACROS)
 if(NOT EXECUTORCH_ENABLE_LOGGING)
-  target_compile_definitions(executorch PUBLIC ET_LOG_ENABLED=0)
+  target_compile_definitions(executorch_prim_ops PUBLIC ET_LOG_ENABLED=0)
 endif()
-target_compile_options(executorch PUBLIC ${_common_compile_options})
-executorch_target_link_options_shared_lib(executorch)
+target_compile_options(executorch_prim_ops PUBLIC ${_common_compile_options})
+executorch_target_link_options_shared_lib(executorch_prim_ops)
 
 #
 # portable_ops_lib: A library to register core ATen ops using portable kernels,
@@ -594,7 +592,7 @@ endif()
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/configurations)
 
-# Install `executorch` library as well as `executorch-config.cmake` under
+# Install `executorch_prim_ops` library as well as `executorch-config.cmake` under
 # ${CMAKE_INSTALL_PREFIX}/
 install(
   DIRECTORY runtime/core/
@@ -650,7 +648,7 @@ install(
   PATTERN "*.h"
 )
 install(
-  TARGETS executorch executorch_core
+  TARGETS executorch_prim_ops executorch_core
   EXPORT ExecuTorchTargets
   INCLUDES
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
@@ -952,7 +950,7 @@ if(EXECUTORCH_BUILD_PYBIND)
       bundled_program
       etdump
       flatccrt
-      executorch
+      executorch_prim_ops
       extension_data_loader
       util
       torch
@@ -1051,7 +1049,7 @@ if(EXECUTORCH_BUILD_PYBIND)
   target_compile_definitions(util PUBLIC C10_USING_CUSTOM_GENERATED_MACROS)
 
   target_compile_options(util PUBLIC ${_pybind_compile_options})
-  target_link_libraries(util PRIVATE torch c10 executorch extension_tensor)
+  target_link_libraries(util PRIVATE torch c10 executorch_prim_ops extension_tensor)
 
   # pybind portable_lib
   pybind11_add_module(portable_lib SHARED extension/pybindings/pybindings.cpp)
@@ -1098,7 +1096,7 @@ if(EXECUTORCH_BUILD_PYBIND)
   )
   target_include_directories(data_loader PRIVATE ${_common_include_directories})
   target_compile_options(data_loader PUBLIC ${_pybind_compile_options})
-  target_link_libraries(data_loader PRIVATE executorch)
+  target_link_libraries(data_loader PRIVATE executorch_prim_ops)
   install(TARGETS data_loader
           LIBRARY DESTINATION executorch/extension/pybindings
   )
@@ -1277,7 +1275,7 @@ install(TARGETS executorch_backends executorch_extensions executorch_kernels
 
 if(EXECUTORCH_BUILD_EXECUTOR_RUNNER)
   # Baseline libraries that executor_runner will link against.
-  set(_executor_runner_libs executorch extension_evalue_util
+  set(_executor_runner_libs executorch_prim_ops extension_evalue_util
                             extension_runner_util gflags executorch_backends
   )
 

--- a/backends/cadence/CMakeLists.txt
+++ b/backends/cadence/CMakeLists.txt
@@ -36,11 +36,11 @@ if(EXECUTORCH_CADENCE_CPU_RUNNER)
   # Find prebuilt libraries. executorch package should contain portable_ops_lib,
   # etdump, bundled_program.
   find_package(executorch CONFIG REQUIRED)
-  executorch_target_link_options_shared_lib(executorch)
+  executorch_target_link_options_shared_lib(executorch_prim_ops)
   executorch_target_link_options_shared_lib(portable_ops_lib)
 
   target_include_directories(
-    executorch INTERFACE ${_common_include_directories}
+    executorch_prim_ops INTERFACE ${_common_include_directories}
   )
 
   find_package(
@@ -51,7 +51,7 @@ if(EXECUTORCH_CADENCE_CPU_RUNNER)
     cadence_runner
     ${EXECUTORCH_ROOT}/examples/devtools/example_runner/example_runner.cpp
   )
-  target_compile_options(executorch INTERFACE -DET_EVENT_TRACER_ENABLED)
+  target_compile_options(executorch_prim_ops INTERFACE -DET_EVENT_TRACER_ENABLED)
 
   target_include_directories(
     etdump INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/../../devtools/include
@@ -65,7 +65,7 @@ if(EXECUTORCH_CADENCE_CPU_RUNNER)
 
   target_link_libraries(
     cadence_runner
-    executorch
+    executorch_prim_ops
     gflags
     etdump
     extension_data_loader

--- a/backends/cadence/fusion_g3/operators/CMakeLists.txt
+++ b/backends/cadence/fusion_g3/operators/CMakeLists.txt
@@ -65,7 +65,7 @@ set(_aten_ops__srcs
     "${EXECUTORCH_ROOT}/kernels/portable/cpu/pattern/unary_ufunc_realhbbf16_to_floathbf16.cpp"
 )
 add_library(aten_ops_cadence ${_aten_ops__srcs})
-target_link_libraries(aten_ops_cadence PUBLIC executorch)
+target_link_libraries(aten_ops_cadence PUBLIC executorch_prim_ops)
 target_link_libraries(aten_ops_cadence PRIVATE xa_nnlib)
 
 # Let files say "include <executorch/path/to/header.h>".

--- a/backends/cadence/generic/operators/CMakeLists.txt
+++ b/backends/cadence/generic/operators/CMakeLists.txt
@@ -68,7 +68,7 @@ set(_aten_ops__srcs
     "${EXECUTORCH_ROOT}/kernels/portable/cpu/util/select_copy_util.cpp"
 )
 add_library(aten_ops_cadence ${_aten_ops__srcs})
-target_link_libraries(aten_ops_cadence PUBLIC executorch)
+target_link_libraries(aten_ops_cadence PUBLIC executorch_prim_ops)
 target_link_libraries(aten_ops_cadence PRIVATE cadence_kernels)
 
 # Let files say "include <executorch/path/to/header.h>".
@@ -90,7 +90,7 @@ target_include_directories(
                     ${_common_include_directories}
 )
 
-target_link_libraries(custom_ops PUBLIC executorch)
+target_link_libraries(custom_ops PUBLIC executorch_prim_ops)
 target_link_libraries(custom_ops PRIVATE cadence_kernels)
 
 # Generate C++ bindings to register kernels into both PyTorch (for AOT) and

--- a/backends/cadence/hifi/operators/CMakeLists.txt
+++ b/backends/cadence/hifi/operators/CMakeLists.txt
@@ -80,7 +80,7 @@ set(_aten_ops__srcs
     "${EXECUTORCH_ROOT}/kernels/portable/cpu/util/delinearize_index.cpp"
 )
 add_library(aten_ops_cadence ${_aten_ops__srcs})
-target_link_libraries(aten_ops_cadence PUBLIC executorch)
+target_link_libraries(aten_ops_cadence PUBLIC executorch_prim_ops)
 target_link_libraries(aten_ops_cadence PRIVATE cadence_kernels)
 
 # Let files say "include <executorch/path/to/header.h>".
@@ -157,7 +157,7 @@ target_include_directories(
                     ${_common_include_directories}
 )
 
-target_link_libraries(custom_ops PUBLIC executorch)
+target_link_libraries(custom_ops PUBLIC executorch_prim_ops)
 target_link_libraries(custom_ops PRIVATE cadence_kernels)
 
 # Generate C++ bindings to register kernels into both PyTorch (for AOT) and

--- a/backends/cadence/vision/operators/CMakeLists.txt
+++ b/backends/cadence/vision/operators/CMakeLists.txt
@@ -68,7 +68,7 @@ set(_aten_ops__srcs
     "${EXECUTORCH_ROOT}/kernels/portable/cpu/util/select_copy_util.cpp"
 )
 add_library(aten_ops_cadence ${_aten_ops__srcs})
-target_link_libraries(aten_ops_cadence PUBLIC executorch)
+target_link_libraries(aten_ops_cadence PUBLIC executorch_prim_ops)
 target_link_libraries(aten_ops_cadence PRIVATE cadence_kernels)
 
 # Let files say "include <executorch/path/to/header.h>".
@@ -101,7 +101,7 @@ target_include_directories(
                     ${_common_include_directories}
 )
 
-target_link_libraries(custom_ops PUBLIC executorch)
+target_link_libraries(custom_ops PUBLIC executorch_prim_ops)
 target_link_libraries(custom_ops PRIVATE cadence_kernels)
 
 # Generate C++ bindings to register kernels into both PyTorch (for AOT) and

--- a/backends/cortex_m/CMakeLists.txt
+++ b/backends/cortex_m/CMakeLists.txt
@@ -84,7 +84,7 @@ add_library(cortex_m_kernels ${_cortex_m_kernels__srcs})
 target_link_libraries(
   cortex_m_kernels
   PRIVATE cmsis-nn
-  PRIVATE executorch
+  PRIVATE executorch_prim_ops
   PRIVATE kernels_util_all_deps
 )
 
@@ -96,7 +96,7 @@ target_include_directories(
 
 # cortex_m_ops_lib: Register Cortex-M ops kernels into Executorch runtime
 gen_operators_lib(
-  LIB_NAME "cortex_m_ops_lib" KERNEL_LIBS cortex_m_kernels DEPS executorch
+  LIB_NAME "cortex_m_ops_lib" KERNEL_LIBS cortex_m_kernels DEPS executorch_prim_ops
 )
 
 install(

--- a/backends/mlx/test/CMakeLists.txt
+++ b/backends/mlx/test/CMakeLists.txt
@@ -28,7 +28,7 @@ if(EXECUTORCH_MLX_ENABLE_SANITIZERS)
 endif()
 
 target_link_libraries(
-  op_test_runner PRIVATE extension_module extension_tensor executorch
+  op_test_runner PRIVATE extension_module extension_tensor executorch_prim_ops
                          mlxdelegate
 )
 

--- a/backends/qualcomm/CMakeLists.txt
+++ b/backends/qualcomm/CMakeLists.txt
@@ -326,7 +326,7 @@ if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64")
             qnn_schema
             qnn_manager
             qnn_executorch_header
-            executorch
+            executorch_prim_ops
             extension_tensor
             qnn_backend_options
             wrappers

--- a/backends/samsung/CMakeLists.txt
+++ b/backends/samsung/CMakeLists.txt
@@ -156,7 +156,7 @@ if(${ANDROID})
     PRIVATE enn_logging
             enn_backend
             gflags
-            executorch
+            executorch_prim_ops
             extension_data_loader
             portable_ops_lib
             android

--- a/devtools/bundled_program/CMakeLists.txt
+++ b/devtools/bundled_program/CMakeLists.txt
@@ -40,7 +40,7 @@ add_library(
   bundled_program ${_schema_outputs}
                   ${CMAKE_CURRENT_SOURCE_DIR}/bundled_program.cpp
 )
-target_link_libraries(bundled_program PUBLIC executorch)
+target_link_libraries(bundled_program PUBLIC executorch_prim_ops)
 target_include_directories(
   bundled_program
   PUBLIC

--- a/devtools/etdump/CMakeLists.txt
+++ b/devtools/etdump/CMakeLists.txt
@@ -52,7 +52,7 @@ add_library(
 target_link_libraries(
   etdump
   PUBLIC flatccrt
-  PRIVATE executorch
+  PRIVATE executorch_prim_ops
 )
 target_include_directories(
   etdump

--- a/examples/apple/mps/CMakeLists.txt
+++ b/examples/apple/mps/CMakeLists.txt
@@ -43,8 +43,8 @@ set(_common_include_directories ${EXECUTORCH_ROOT}/..)
 # Find prebuilt libraries. executorch package should contain portable_ops_lib,
 # etdump, bundled_program.
 find_package(executorch CONFIG REQUIRED)
-target_include_directories(executorch INTERFACE ${_common_include_directories})
-target_compile_options(executorch INTERFACE ${_common_compile_options})
+target_include_directories(executorch_prim_ops INTERFACE ${_common_include_directories})
+target_compile_options(executorch_prim_ops INTERFACE ${_common_compile_options})
 
 find_package(
   gflags REQUIRED PATHS ${CMAKE_CURRENT_BINARY_DIR}/../../../third-party
@@ -67,7 +67,7 @@ if(NOT CMAKE_TOOLCHAIN_FILE MATCHES ".*(iOS|ios\.toolchain)\.cmake$")
   )
   gen_operators_lib(
     LIB_NAME "mps_portable_ops_lib" KERNEL_LIBS portable_kernels DEPS
-    executorch
+    executorch_prim_ops
   )
 
   set(mps_executor_runner_libs
@@ -98,7 +98,7 @@ if(NOT CMAKE_TOOLCHAIN_FILE MATCHES ".*(iOS|ios\.toolchain)\.cmake$")
   target_link_libraries(
     mps_executor_runner
     bundled_program
-    executorch
+    executorch_prim_ops
     extension_evalue_util
     extension_runner_util
     gflags

--- a/examples/arm/executor_runner/CMakeLists.txt
+++ b/examples/arm/executor_runner/CMakeLists.txt
@@ -236,7 +236,7 @@ list(
   arm_executor_runner_link
   extension_runner_util
   ethosu_target_init
-  executorch
+  executorch_prim_ops
   quantized_ops_lib
   cortex_m_ops_lib
   executorch_delegate_ethos_u
@@ -319,7 +319,7 @@ if(NOT ("${EXECUTORCH_SELECT_OPS_LIST}" STREQUAL ""
     KERNEL_LIBS
     portable_kernels
     DEPS
-    executorch
+    executorch_prim_ops
     DTYPE_SELECTIVE_BUILD
     "${EXECUTORCH_ENABLE_DTYPE_SELECTIVE_BUILD}"
   )

--- a/examples/arm/image_classification_example_ethos_u/runtime/CMakeLists.txt
+++ b/examples/arm/image_classification_example_ethos_u/runtime/CMakeLists.txt
@@ -86,7 +86,7 @@ target_sources(
 
 target_link_libraries(
   img_class_example
-  PUBLIC executorch
+  PUBLIC executorch_prim_ops
          ethosu_target_init
          extension_runner_util
          quantized_ops_lib

--- a/examples/cadence/CMakeLists.txt
+++ b/examples/cadence/CMakeLists.txt
@@ -123,7 +123,7 @@ target_link_options(
 )
 target_link_libraries(
   cadence_executorch_example dsp_mu_polling_libs cadence_ops_lib
-  extension_runner_util executorch
+  extension_runner_util executorch_prim_ops
 )
 
 add_custom_command(

--- a/examples/devtools/CMakeLists.txt
+++ b/examples/devtools/CMakeLists.txt
@@ -39,10 +39,10 @@ set(_common_include_directories ${EXECUTORCH_ROOT}/..)
 # Find prebuilt libraries. executorch package should contain portable_ops_lib,
 # etdump, bundled_program.
 find_package(executorch CONFIG REQUIRED)
-executorch_target_link_options_shared_lib(executorch)
+executorch_target_link_options_shared_lib(executorch_prim_ops)
 executorch_target_link_options_shared_lib(portable_ops_lib)
 
-target_include_directories(executorch INTERFACE ${_common_include_directories})
+target_include_directories(executorch_prim_ops INTERFACE ${_common_include_directories})
 
 find_package(
   gflags REQUIRED PATHS ${CMAKE_CURRENT_BINARY_DIR}/../../third-party
@@ -50,7 +50,7 @@ find_package(
 
 add_executable(example_runner example_runner/example_runner.cpp)
 target_compile_options(
-  executorch INTERFACE -DET_EVENT_TRACER_ENABLED -DET_BUNDLE_IO_ENABLED
+  executorch_prim_ops INTERFACE -DET_EVENT_TRACER_ENABLED -DET_BUNDLE_IO_ENABLED
 )
 
 target_include_directories(
@@ -59,7 +59,7 @@ target_include_directories(
 )
 target_link_libraries(
   example_runner
-  executorch
+  executorch_prim_ops
   gflags
   etdump
   extension_data_loader

--- a/examples/llm_manual/CMakeLists.txt
+++ b/examples/llm_manual/CMakeLists.txt
@@ -27,7 +27,7 @@ add_subdirectory(
 add_executable(nanogpt_runner main.cpp)
 target_link_libraries(
   nanogpt_runner
-  PRIVATE executorch
+  PRIVATE executorch_prim_ops
           extension_module_static # Provides the Module class
           extension_tensor # Provides the TensorPtr class
           optimized_native_cpu_ops_lib # Provides baseline cross-platform

--- a/examples/mediatek/CMakeLists.txt
+++ b/examples/mediatek/CMakeLists.txt
@@ -43,7 +43,7 @@ executorch_load_build_variables()
 # Find prebuilt libraries. executorch package should contain portable_ops_lib,
 # etdump, bundled_program.
 find_package(executorch CONFIG REQUIRED)
-target_compile_options(executorch INTERFACE -DET_EVENT_TRACER_ENABLED)
+target_compile_options(executorch_prim_ops INTERFACE -DET_EVENT_TRACER_ENABLED)
 find_package(gflags REQUIRED)
 
 link_directories(${EXECUTORCH_ROOT}/cmake-android-out/lib)
@@ -72,7 +72,7 @@ if(${ANDROID})
   target_link_libraries(
     mtk_executor_runner
     ${_executor_runner_libs}
-    executorch
+    executorch_prim_ops
     neuron_backend
     executorch_core
     extension_evalue_util
@@ -103,7 +103,7 @@ if(${ANDROID})
 
   target_link_libraries(
     mtk_oss_executor_runner ${_executor_runner_libs} extension_module
-    executorch neuron_backend gflags
+    executorch_prim_ops neuron_backend gflags
   )
   target_compile_options(
     mtk_oss_executor_runner PUBLIC ${_common_compile_options}

--- a/examples/models/dinov2/CMakeLists.txt
+++ b/examples/models/dinov2/CMakeLists.txt
@@ -24,12 +24,12 @@ find_package(gflags REQUIRED)
 # Find executorch libraries
 list(APPEND CMAKE_FIND_ROOT_PATH ${CMAKE_CURRENT_BINARY_DIR}/../../..)
 find_package(executorch CONFIG REQUIRED FIND_ROOT_PATH_BOTH)
-get_target_property(_executorch_imported executorch IMPORTED)
+get_target_property(_executorch_imported executorch_prim_ops IMPORTED)
 if(NOT _executorch_imported)
-  executorch_target_link_options_shared_lib(executorch)
+  executorch_target_link_options_shared_lib(executorch_prim_ops)
 endif()
 
-set(link_libraries executorch gflags)
+set(link_libraries executorch_prim_ops gflags)
 
 # Common ops
 if(TARGET optimized_native_cpu_ops_lib)

--- a/examples/models/gemma3/CMakeLists.txt
+++ b/examples/models/gemma3/CMakeLists.txt
@@ -34,9 +34,9 @@ find_package(gflags REQUIRED)
 # Find `executorch` libraries, same as for gflags
 list(APPEND CMAKE_FIND_ROOT_PATH ${CMAKE_CURRENT_BINARY_DIR}/../../..)
 find_package(executorch CONFIG REQUIRED FIND_ROOT_PATH_BOTH)
-executorch_target_link_options_shared_lib(executorch)
+executorch_target_link_options_shared_lib(executorch_prim_ops)
 
-set(link_libraries executorch gflags)
+set(link_libraries executorch_prim_ops gflags)
 set(_srcs e2e_runner.cpp)
 
 list(

--- a/examples/models/llama/CMakeLists.txt
+++ b/examples/models/llama/CMakeLists.txt
@@ -82,12 +82,12 @@ find_package(gflags REQUIRED)
 # cross-compiling (e.g., to Android) to work as well.
 list(APPEND CMAKE_FIND_ROOT_PATH ${CMAKE_CURRENT_BINARY_DIR}/../../..)
 find_package(executorch CONFIG REQUIRED FIND_ROOT_PATH_BOTH)
-executorch_target_link_options_shared_lib(executorch)
+executorch_target_link_options_shared_lib(executorch_prim_ops)
 
 # llama_runner library
 add_subdirectory(runner)
 
-set(link_libraries executorch gflags)
+set(link_libraries executorch_prim_ops gflags)
 set(_srcs main.cpp)
 
 if(TARGET optimized_native_cpu_ops_lib)

--- a/examples/models/llava/CMakeLists.txt
+++ b/examples/models/llava/CMakeLists.txt
@@ -77,9 +77,9 @@ find_package(gflags REQUIRED)
 # find `executorch` libraries Same as for gflags
 list(APPEND CMAKE_FIND_ROOT_PATH ${CMAKE_CURRENT_BINARY_DIR}/../../..)
 find_package(executorch CONFIG REQUIRED FIND_ROOT_PATH_BOTH)
-executorch_target_link_options_shared_lib(executorch)
+executorch_target_link_options_shared_lib(executorch_prim_ops)
 
-set(LINK_LIBS executorch gflags extension_llm_runner)
+set(LINK_LIBS executorch_prim_ops gflags extension_llm_runner)
 set(link_libraries ${LINK_LIBS})
 set(_srcs main.cpp)
 

--- a/examples/models/parakeet/CMakeLists.txt
+++ b/examples/models/parakeet/CMakeLists.txt
@@ -25,12 +25,12 @@ find_package(gflags REQUIRED)
 list(APPEND CMAKE_FIND_ROOT_PATH ${CMAKE_CURRENT_BINARY_DIR}/../../..)
 
 find_package(executorch CONFIG REQUIRED FIND_ROOT_PATH_BOTH)
-get_target_property(_executorch_imported executorch IMPORTED)
+get_target_property(_executorch_imported executorch_prim_ops IMPORTED)
 if(NOT _executorch_imported)
-  executorch_target_link_options_shared_lib(executorch)
+  executorch_target_link_options_shared_lib(executorch_prim_ops)
 endif()
 
-set(link_libraries executorch gflags)
+set(link_libraries executorch_prim_ops gflags)
 
 # Common ops for all builds
 if(TARGET optimized_native_cpu_ops_lib)

--- a/examples/models/phi-3-mini/CMakeLists.txt
+++ b/examples/models/phi-3-mini/CMakeLists.txt
@@ -47,6 +47,6 @@ add_executable(phi_3_mini_runner main.cpp)
 target_link_directories(phi_3_mini_runner PUBLIC ${_common_include_directories})
 
 target_link_libraries(
-  phi_3_mini_runner PUBLIC executorch optimized_native_cpu_ops_lib
+  phi_3_mini_runner PUBLIC executorch_prim_ops optimized_native_cpu_ops_lib
                            xnnpack_backend gflags extension_llm_runner
 )

--- a/examples/models/qwen3_5_moe/CMakeLists.txt
+++ b/examples/models/qwen3_5_moe/CMakeLists.txt
@@ -23,9 +23,9 @@ find_package(gflags REQUIRED)
 # executorch
 list(APPEND CMAKE_FIND_ROOT_PATH ${CMAKE_CURRENT_BINARY_DIR}/../../..)
 find_package(executorch CONFIG REQUIRED FIND_ROOT_PATH_BOTH)
-executorch_target_link_options_shared_lib(executorch)
+executorch_target_link_options_shared_lib(executorch_prim_ops)
 
-set(link_libraries executorch gflags)
+set(link_libraries executorch_prim_ops gflags)
 
 # CPU ops
 list(APPEND link_libraries optimized_native_cpu_ops_lib cpublas eigen_blas)

--- a/examples/models/silero_vad/CMakeLists.txt
+++ b/examples/models/silero_vad/CMakeLists.txt
@@ -24,12 +24,12 @@ find_package(gflags REQUIRED)
 # Find executorch libraries
 list(APPEND CMAKE_FIND_ROOT_PATH ${CMAKE_CURRENT_BINARY_DIR}/../../..)
 find_package(executorch CONFIG REQUIRED FIND_ROOT_PATH_BOTH)
-get_target_property(_executorch_imported executorch IMPORTED)
+get_target_property(_executorch_imported executorch_prim_ops IMPORTED)
 if(NOT _executorch_imported)
-  executorch_target_link_options_shared_lib(executorch)
+  executorch_target_link_options_shared_lib(executorch_prim_ops)
 endif()
 
-set(common_link_libraries executorch gflags)
+set(common_link_libraries executorch_prim_ops gflags)
 
 # Common ops for all builds
 if(TARGET optimized_native_cpu_ops_lib)

--- a/examples/models/sortformer/CMakeLists.txt
+++ b/examples/models/sortformer/CMakeLists.txt
@@ -24,12 +24,12 @@ find_package(gflags REQUIRED)
 # Find executorch libraries
 list(APPEND CMAKE_FIND_ROOT_PATH ${CMAKE_CURRENT_BINARY_DIR}/../../..)
 find_package(executorch CONFIG REQUIRED FIND_ROOT_PATH_BOTH)
-get_target_property(_executorch_imported executorch IMPORTED)
+get_target_property(_executorch_imported executorch_prim_ops IMPORTED)
 if(NOT _executorch_imported)
-  executorch_target_link_options_shared_lib(executorch)
+  executorch_target_link_options_shared_lib(executorch_prim_ops)
 endif()
 
-set(link_libraries executorch gflags)
+set(link_libraries executorch_prim_ops gflags)
 
 # Common ops for all builds
 if(TARGET optimized_native_cpu_ops_lib)

--- a/examples/models/voxtral/CMakeLists.txt
+++ b/examples/models/voxtral/CMakeLists.txt
@@ -34,9 +34,9 @@ find_package(gflags REQUIRED)
 # Find `executorch` libraries, same as for gflags
 list(APPEND CMAKE_FIND_ROOT_PATH ${CMAKE_CURRENT_BINARY_DIR}/../../..)
 find_package(executorch CONFIG REQUIRED FIND_ROOT_PATH_BOTH)
-executorch_target_link_options_shared_lib(executorch)
+executorch_target_link_options_shared_lib(executorch_prim_ops)
 
-set(link_libraries executorch gflags)
+set(link_libraries executorch_prim_ops gflags)
 set(_srcs multimodal.cpp)
 
 # Common ops for all builds

--- a/examples/models/voxtral_realtime/CMakeLists.txt
+++ b/examples/models/voxtral_realtime/CMakeLists.txt
@@ -24,9 +24,9 @@ find_package(gflags REQUIRED)
 # Find executorch libraries
 list(APPEND CMAKE_FIND_ROOT_PATH ${CMAKE_CURRENT_BINARY_DIR}/../../..)
 find_package(executorch CONFIG REQUIRED FIND_ROOT_PATH_BOTH)
-executorch_target_link_options_shared_lib(executorch)
+executorch_target_link_options_shared_lib(executorch_prim_ops)
 
-set(link_libraries executorch gflags)
+set(link_libraries executorch_prim_ops gflags)
 
 # Common ops for all builds
 list(APPEND link_libraries optimized_native_cpu_ops_lib cpublas eigen_blas)

--- a/examples/models/voxtral_tts/CMakeLists.txt
+++ b/examples/models/voxtral_tts/CMakeLists.txt
@@ -23,9 +23,9 @@ find_package(gflags REQUIRED)
 # ExecuTorch
 list(APPEND CMAKE_FIND_ROOT_PATH ${CMAKE_CURRENT_BINARY_DIR}/../../..)
 find_package(executorch CONFIG REQUIRED FIND_ROOT_PATH_BOTH)
-executorch_target_link_options_shared_lib(executorch)
+executorch_target_link_options_shared_lib(executorch_prim_ops)
 
-set(link_libraries executorch gflags)
+set(link_libraries executorch_prim_ops gflags)
 
 # Common ops
 list(APPEND link_libraries optimized_native_cpu_ops_lib cpublas eigen_blas)

--- a/examples/models/whisper/CMakeLists.txt
+++ b/examples/models/whisper/CMakeLists.txt
@@ -28,9 +28,9 @@ find_package(gflags REQUIRED)
 
 list(APPEND CMAKE_FIND_ROOT_PATH ${CMAKE_CURRENT_BINARY_DIR}/../../..)
 find_package(executorch CONFIG REQUIRED FIND_ROOT_PATH_BOTH)
-executorch_target_link_options_shared_lib(executorch)
+executorch_target_link_options_shared_lib(executorch_prim_ops)
 
-set(_link_libraries executorch gflags)
+set(_link_libraries executorch_prim_ops gflags)
 set(_srcs multimodal.cpp)
 
 # Common ops for all builds

--- a/examples/models/yolo26/CMakeLists.txt
+++ b/examples/models/yolo26/CMakeLists.txt
@@ -30,7 +30,7 @@ set(_common_include_directories ${EXECUTORCH_ROOT}/..)
 
 # find `executorch` libraries Same as for gflags
 find_package(executorch CONFIG REQUIRED PATHS ${EXECUTORCH_ROOT}/cmake-out)
-executorch_target_link_options_shared_lib(executorch)
+executorch_target_link_options_shared_lib(executorch_prim_ops)
 
 add_subdirectory(${EXECUTORCH_ROOT}/third-party/gflags gflags)
 set(link_libraries gflags)

--- a/examples/nxp/executor_runner/CMakeLists.txt
+++ b/examples/nxp/executor_runner/CMakeLists.txt
@@ -76,9 +76,9 @@ endif()
 
 # Check if the ExecuTorch Target is aleady defined, what indicate this
 # CMakeLists.txt is involved as subproject:
-message(STATUS "Looking for executorch target")
-if(NOT TARGET executorch)
-  message(STATUS "Looking for executorch target -- not found, adding")
+message(STATUS "Looking for executorch_prim_ops target")
+if(NOT TARGET executorch_prim_ops)
+  message(STATUS "Looking for executorch_prim_ops target -- not found, adding")
   set(EXECUTORCH_BUILD_NXP_NEUTRON ON)
   set(EXECUTORCH_BUILD_KERNELS_QUANTIZED ON)
   set(EXECUTORCH_BUILD_KERNELS_QUANTIZED_AOT ON)
@@ -87,7 +87,7 @@ if(NOT TARGET executorch)
     EXCLUDE_FROM_ALL
   )
 else()
-  message(STATUS "Looking for executorch target -- found")
+  message(STATUS "Looking for executorch_prim_ops target -- found")
 endif()
 
 message(STATUS "Looking for gflags")
@@ -112,7 +112,7 @@ target_compile_options(nxp_executor_runner PRIVATE -DNEUTRON_CMODEL)
 
 target_link_libraries(
   nxp_executor_runner
-  PRIVATE executorch
+  PRIVATE executorch_prim_ops
           executorch_kernels
           nd
           gflags::gflags

--- a/examples/portable/custom_ops/CMakeLists.txt
+++ b/examples/portable/custom_ops/CMakeLists.txt
@@ -44,7 +44,7 @@ find_package(
   gflags REQUIRED PATHS ${CMAKE_CURRENT_BINARY_DIR}/../../../third-party
 )
 
-target_include_directories(executorch INTERFACE ${_common_include_directories})
+target_include_directories(executorch_prim_ops INTERFACE ${_common_include_directories})
 
 # ------------------------------ OPTIONS BEGIN -------------------------------
 # Option to register custom operator `my_ops::mul3` or `my_ops::mul4` or no
@@ -106,11 +106,11 @@ elseif(REGISTER_EXAMPLE_CUSTOM_OP EQUAL 2)
 endif()
 
 add_library(custom_kernels ${kernel_sources})
-target_link_libraries(custom_kernels PRIVATE executorch)
+target_link_libraries(custom_kernels PRIVATE executorch_prim_ops)
 target_compile_options(custom_kernels PUBLIC ${_common_compile_options})
 
 gen_operators_lib(
-  LIB_NAME "custom_ops_lib" KERNEL_LIBS custom_kernels DEPS executorch
+  LIB_NAME "custom_ops_lib" KERNEL_LIBS custom_kernels DEPS executorch_prim_ops
 )
 
 list(TRANSFORM _executor_runner__srcs PREPEND "${EXECUTORCH_ROOT}/")
@@ -119,7 +119,7 @@ add_executable(custom_ops_executor_runner ${_executor_runner__srcs})
 target_link_libraries(
   custom_ops_executor_runner
   custom_ops_lib
-  executorch
+  executorch_prim_ops
   extension_evalue_util
   extension_runner_util
   gflags

--- a/examples/qualcomm/CMakeLists.txt
+++ b/examples/qualcomm/CMakeLists.txt
@@ -33,7 +33,7 @@ find_package(absl REQUIRED NO_CMAKE_FIND_ROOT_PATH)
 # Find prebuilt libraries. executorch package should contain portable_ops_lib,
 # etdump, bundled_program.
 find_package(executorch CONFIG REQUIRED)
-target_compile_options(executorch INTERFACE -DET_EVENT_TRACER_ENABLED)
+target_compile_options(executorch_prim_ops INTERFACE -DET_EVENT_TRACER_ENABLED)
 
 set(_common_compile_options -Wno-deprecated-declarations -fPIC)
 
@@ -53,7 +53,7 @@ generate_bindings_for_kernels(
   ${EXECUTORCH_ROOT}/kernels/portable/functions.yaml
 )
 gen_operators_lib(
-  LIB_NAME "full_portable_ops_lib" KERNEL_LIBS portable_kernels DEPS executorch
+  LIB_NAME "full_portable_ops_lib" KERNEL_LIBS portable_kernels DEPS executorch_prim_ops
 )
 target_compile_options(
   full_portable_ops_lib INTERFACE -DET_EVENT_TRACER_ENABLED

--- a/extension/android/CMakeLists.txt
+++ b/extension/android/CMakeLists.txt
@@ -70,7 +70,7 @@ set_target_properties(
     "${CMAKE_CURRENT_BINARY_DIR}/third-party/fbjni/prefab/modules/fbjni/libs/android.${ANDROID_ABI}/libfbjni.so"
 )
 
-executorch_target_link_options_shared_lib(executorch)
+executorch_target_link_options_shared_lib(executorch_prim_ops)
 
 add_library(
   executorch_jni SHARED jni/jni_layer.cpp jni/log.cpp jni/jni_layer_runtime.cpp
@@ -81,7 +81,7 @@ set(link_libraries)
 list(
   APPEND
   link_libraries
-  executorch
+  executorch_prim_ops
   extension_data_loader
   extension_flat_tensor
   extension_module

--- a/extension/apple/CMakeLists.txt
+++ b/extension/apple/CMakeLists.txt
@@ -36,7 +36,7 @@ target_include_directories(
 
 find_library(FOUNDATION_FRAMEWORK Foundation)
 target_link_libraries(
-  extension_apple PRIVATE executorch ${FOUNDATION_FRAMEWORK}
+  extension_apple PRIVATE executorch_prim_ops ${FOUNDATION_FRAMEWORK}
 )
 
 set_source_files_properties(

--- a/extension/llm/runner/test/CMakeLists.txt
+++ b/extension/llm/runner/test/CMakeLists.txt
@@ -33,7 +33,7 @@ if(APPLE)
 endif()
 
 et_cxx_test(
-  test_runner SOURCES ${_test_srcs} EXTRA_LIBS executorch extension_llm_runner
+  test_runner SOURCES ${_test_srcs} EXTRA_LIBS executorch_prim_ops extension_llm_runner
 )
 
 # Override sanitizer to this issue:

--- a/extension/training/CMakeLists.txt
+++ b/extension/training/CMakeLists.txt
@@ -50,7 +50,7 @@ target_compile_options(train_xor PUBLIC ${_common_compile_options})
 
 if(EXECUTORCH_BUILD_PYBIND)
   # Pybind library.
-  set(_pybind_training_dep_libs ${TORCH_PYTHON_LIBRARY} etdump executorch util
+  set(_pybind_training_dep_libs ${TORCH_PYTHON_LIBRARY} etdump executorch_prim_ops util
                                 torch extension_training
   )
 

--- a/kernels/prim_ops/test/CMakeLists.txt
+++ b/kernels/prim_ops/test/CMakeLists.txt
@@ -20,4 +20,4 @@ include(${EXECUTORCH_ROOT}/tools/cmake/Test.cmake)
 
 set(_test_srcs prim_ops_test.cpp)
 
-et_cxx_test(kernels_prim_ops_test SOURCES ${_test_srcs} EXTRA_LIBS executorch)
+et_cxx_test(kernels_prim_ops_test SOURCES ${_test_srcs} EXTRA_LIBS executorch_prim_ops)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -49,7 +49,7 @@ list(TRANSFORM _size_test__srcs PREPEND "${EXECUTORCH_ROOT}/")
 # TODO(larryliu0820): Add EXECUTORCH_BUILD_EXECUTABLES to not build executable
 # when we cross compile to ios
 add_executable(size_test ${_size_test__srcs})
-target_link_libraries(size_test executorch extension_data_loader)
+target_link_libraries(size_test executorch_prim_ops extension_data_loader)
 if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
   target_link_options_gc_sections(size_test)
 endif()
@@ -59,7 +59,7 @@ endif()
 #
 add_executable(size_test_all_ops ${_size_test__srcs})
 target_link_libraries(
-  size_test_all_ops executorch extension_data_loader portable_ops_lib
+  size_test_all_ops executorch_prim_ops extension_data_loader portable_ops_lib
   portable_kernels
 )
 if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -72,7 +72,7 @@ endif()
 if(EXECUTORCH_BUILD_KERNELS_OPTIMIZED)
   add_executable(size_test_all_optimized_ops ${_size_test__srcs})
   target_link_libraries(
-    size_test_all_optimized_ops executorch extension_data_loader
+    size_test_all_optimized_ops executorch_prim_ops extension_data_loader
     optimized_native_cpu_ops_lib
   )
   if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/tools/cmake/executorch-config.cmake
+++ b/tools/cmake/executorch-config.cmake
@@ -29,7 +29,7 @@ include(CMakeFindDependencyMacro)
 find_package(tokenizers CONFIG)
 
 set(_root "${CMAKE_CURRENT_LIST_DIR}/../../..")
-set(required_lib_list executorch executorch_core portable_kernels)
+set(required_lib_list executorch_prim_ops executorch_core portable_kernels)
 set(EXECUTORCH_LIBRARIES)
 set(EXECUTORCH_INCLUDE_DIRS
     ${_root}/include ${_root}/include/executorch/runtime/core/portable_type/c10

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -117,7 +117,7 @@ if(CONFIG_EXECUTORCH)
   # List of all ExecuTorch targets that need flag correction
   set(EXECUTORCH_TARGETS_TO_FIX
       executorch_core
-      executorch
+      executorch_prim_ops
       portable_ops_lib
       portable_kernels
       optimized_portable_kernels

--- a/zephyr/samples/hello-executorch/CMakeLists.txt
+++ b/zephyr/samples/hello-executorch/CMakeLists.txt
@@ -167,7 +167,7 @@ if(_EXECUTORCH_GEN_ZEPHYR_PORTABLE_OPS)
     KERNEL_LIBS
     portable_kernels
     DEPS
-    executorch
+    executorch_prim_ops
     DTYPE_SELECTIVE_BUILD
     "${EXECUTORCH_ENABLE_DTYPE_SELECTIVE_BUILD}"
   )

--- a/zephyr/samples/mv2-ethosu/CMakeLists.txt
+++ b/zephyr/samples/mv2-ethosu/CMakeLists.txt
@@ -165,7 +165,7 @@ if(_EXECUTORCH_GEN_ZEPHYR_PORTABLE_OPS)
     KERNEL_LIBS
     portable_kernels
     DEPS
-    executorch
+    executorch_prim_ops
     DTYPE_SELECTIVE_BUILD
     "${EXECUTORCH_ENABLE_DTYPE_SELECTIVE_BUILD}"
   )


### PR DESCRIPTION

### Summary
The `executorch` CMake target only contains 3 prim_ops files (et_copy_index.cpp, et_view.cpp, register_prim_ops.cpp) linked on top of executorch_core. The name `executorch` was misleading — it suggested the full runtime, but it's just prim_ops registration.

Rename the target to `executorch_prim_ops` across all CMakeLists.txt and .cmake files. Update the definition-site comment to accurately describe what the target provides. Update the required_lib_list in executorch-config.cmake so find_library looks for the new name.

The CMake package name (`find_package(executorch ...)`) and project namespace aliases (`executorch::backends` etc.) are unchanged.

### Test plan
CI


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani