### PR TITLE
Qualcomm AI Engine Direct - Fix Hexagon Tool Chain Build

### DIFF
--- a/backends/qualcomm/aot/wrappers/TensorWrapper.cpp
+++ b/backends/qualcomm/aot/wrappers/TensorWrapper.cpp
@@ -12,6 +12,7 @@
 #include <executorch/runtime/platform/assert.h>
 
 #include <atomic>
+#include <cinttypes>
 #include <cstring>
 #include <limits>
 #include <numeric>
@@ -188,7 +189,7 @@ std::shared_ptr<TensorWrapper> CreateTensorWrapper(
     for (std::uint32_t i = 0; i < rank; ++i) {
       ET_CHECK_MSG(
           !c10::mul_overflows(computed_bytes, dims[i], &computed_bytes),
-          "Overflow computing tensor byte size for tensor of rank %u",
+          "Overflow computing tensor byte size for tensor of rank %" PRIu32,
           rank);
     }
     bytes = computed_bytes;


### PR DESCRIPTION
### Summary
Minor fix on dtype for log message. Hexagon tool chain has compile error in mainline.
We will be introducing Hexagon build for QNN ExecuTorch in future to reduce these errors from happening.

### Test plan
Passing Hexagon Build for build.sh
