### PR TITLE
Arm backend: Preserve inputs for pow zero decomposition

### DIFF
--- a/backends/arm/_passes/decompose_int_pow_pass.py
+++ b/backends/arm/_passes/decompose_int_pow_pass.py
@@ -32,11 +32,15 @@ class DecomposeIntPowPass(ArmPass):
         x = args[0]
         exp = args[1]
 
-        # Handle zero first and return early
         if exp == 0:
-            # return a tensor of ones with the same shape as x
-            return super().call_operator(
+            zeros = super().call_operator(
+                exir_ops.edge.aten.sub.Tensor, (x, x), {}, meta, True
+            )
+            ones = super().call_operator(
                 exir_ops.edge.aten.full_like.default, (x, 1), {}, meta, True
+            )
+            return super().call_operator(
+                exir_ops.edge.aten.add.Tensor, (zeros, ones), {}, meta, True
             )
 
         if not isinstance(exp, int):

--- a/backends/arm/test/ops/test_pow.py
+++ b/backends/arm/test/ops/test_pow.py
@@ -147,7 +147,6 @@ x_fail = {
 
 x_fail_FP = {
     "exp_two": "TOSA constraints: If x <0 .",
-    "exp_zero": "MLETORCH-2041 : Invalid inputs.",
 }
 
 

--- a/backends/arm/test/passes/test_decompose_int_pow_pass.py
+++ b/backends/arm/test/passes/test_decompose_int_pow_pass.py
@@ -59,18 +59,18 @@ test_data: Dict[str, TestParam] = {
 def test_decompose_int_pow_tosa_FP(data: TestParam) -> None:
     module_with_inputs, nbr_muls = data
     module = cast(torch.nn.Module, module_with_inputs)
+    pow_op = "executorch_exir_dialects_edge__ops_aten_pow_Tensor_Scalar"
     pipeline = PassPipeline[input_t](
         module,
         module_with_inputs.get_inputs(),
         quantize=False,
         ops_before_pass={
-            "executorch_exir_dialects_edge__ops_aten_pow_Tensor_Scalar": 1,
+            pow_op: 1,
         },
         ops_not_before_pass=[],
         ops_after_pass={
             "executorch_exir_dialects_edge__ops_aten_mul_Tensor": nbr_muls,
         },
-        ops_not_after_pass=["executorch_exir_dialects_edge__ops_pow_Tensor_Scalar"],
         pass_list=[DecomposeIntPowPass],
     )
     pipeline.run()


### PR DESCRIPTION
Keep pow(x, 0) dependent on the original input when decomposing it to ones, so the TOSA graph still expects the user input.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @robell @rascani