### PR TITLE
Remove named tensor handling from executorch (#19642)

### DIFF
--- a/codegen/api/et_cpp.py
+++ b/codegen/api/et_cpp.py
@@ -55,8 +55,6 @@ Difference between this file and torchgen.api.cpp.py:
   - Executorch doesn't support TensorOptions, however in this file we still keep the logic here to be compatible with
     torchgen.api.cpp, so that we can do stuff like ATen mode (running ATen kernels in Executorch).
 
-  - Executorch doesn't support Dimname.
-
   - Executorch runtime doesn't support SymInt, will treat it as int.
 """
 
@@ -141,8 +139,6 @@ def argumenttype_type(
         # TODO: keeping these special cases for Tensor[] and Tensor?[] so that we can hookup with ATen kernels.
         if str(t.elem) == "Tensor":
             return NamedCType(binds, BaseCType(tensorListT))
-        elif str(t.elem) == "Dimname":
-            raise NotImplementedError("Executorch doesn't support Dimname")
         elif str(t.elem) == "Tensor?":
             return NamedCType(binds, ArrayRefCType(OptionalCType(BaseCType(tensorT))))
         elem = argumenttype_type(t.elem, mutable=mutable, binds=binds)


### PR DESCRIPTION
Summary:


The PyTorch team is dropping the named tensor feature entirely to reduce overhead and cleanup code bloat. This diff removes usage of all named tensor APIs in advance of this removal to avoid breakage.

Reviewed By: larryliu0820

Differential Revision: D105195535


