### PR TITLE
Add entry_at(i) accessor to LoadBackendOptionsMap (#19645)

### DIFF
--- a/runtime/backend/backend_options_map.h
+++ b/runtime/backend/backend_options_map.h
@@ -11,6 +11,7 @@
 #include <executorch/runtime/backend/options.h>
 #include <executorch/runtime/core/error.h>
 #include <executorch/runtime/core/span.h>
+#include <executorch/runtime/platform/assert.h>
 
 #include <cstring>
 
@@ -169,6 +170,46 @@ class LoadBackendOptionsMap final {
    */
   size_t size() const {
     return size_;
+  }
+
+  /**
+   * Non-owning view of a single (backend_id, options) entry, returned by
+   * entry_at(). The pointer / span are valid until the map is mutated or
+   * destroyed.
+   */
+  struct EntryView {
+    const char* backend_id = nullptr;
+    Span<const BackendOption> options;
+  };
+
+  /**
+   * Returns the (backend_id, options) entry at the given index for
+   * enumeration over the map's contents.
+   *
+   * @param index The entry index. Must be < size(); behavior is undefined
+   *     otherwise. Use this together with size() to walk every entry.
+   * @return EntryView referencing the entry's backend_id and options. The
+   *     view is valid until the next mutation of, or destruction of, this
+   *     map.
+   *
+   * Example:
+   * @code
+   *   for (size_t i = 0; i < map.size(); ++i) {
+   *     const auto entry = map.entry_at(i);
+   *     // use entry.backend_id and entry.options ...
+   *   }
+   * @endcode
+   */
+  EntryView entry_at(size_t index) const {
+    ET_DCHECK_MSG(
+        index < size_,
+        "entry_at index %zu out of bounds (size=%zu)",
+        index,
+        size_);
+    return EntryView{
+        entries_[index].backend_id,
+        Span<const BackendOption>(
+            entries_[index].options.data(), entries_[index].options.size())};
   }
 
  private:

--- a/runtime/backend/test/backend_options_map_test.cpp
+++ b/runtime/backend/test/backend_options_map_test.cpp
@@ -365,3 +365,32 @@ TEST_F(LoadBackendOptionsMapTest, SetOptionsWithBuilderUpdatesExisting) {
   }
   EXPECT_EQ(num_threads2, 8); // Should be updated value
 }
+
+// Test entry_at returns each (backend_id, options) pair in insertion order
+// and the spans reference the same data the corresponding get_options
+// calls return.
+TEST_F(LoadBackendOptionsMapTest, EntryAtEnumeratesAllEntries) {
+  LoadBackendOptionsMap map;
+
+  BackendOptions<2> opts1;
+  opts1.set_option("k1", 1);
+  ASSERT_EQ(map.set_options("BackendA", opts1.view()), Error::Ok);
+
+  BackendOptions<2> opts2;
+  opts2.set_option("k2", true);
+  opts2.set_option("k3", "v");
+  ASSERT_EQ(map.set_options("BackendB", opts2.view()), Error::Ok);
+
+  ASSERT_EQ(map.size(), 2u);
+
+  const auto e0 = map.entry_at(0);
+  EXPECT_STREQ(e0.backend_id, "BackendA");
+  EXPECT_EQ(e0.options.size(), 1u);
+  // Spans returned by entry_at point at the same storage as get_options.
+  EXPECT_EQ(e0.options.data(), map.get_options("BackendA").data());
+
+  const auto e1 = map.entry_at(1);
+  EXPECT_STREQ(e1.backend_id, "BackendB");
+  EXPECT_EQ(e1.options.size(), 2u);
+  EXPECT_EQ(e1.options.data(), map.get_options("BackendB").data());
+}


### PR DESCRIPTION
Summary:

LoadBackendOptionsMap exposed get_options(backend_id), has_options(backend_id),
and size() but no way to enumerate the entries. That makes deep-copy,
debugging/pretty-printing, and any other operation that wants to iterate
over the configured backends impossible from outside the class.

Add a public EntryView struct ({backend_id, options}) plus an entry_at(i)
accessor returning a non-owning view at the given index. Header-only,
additive; existing callers are unaffected.

Reviewed By: shoumikhin

Differential Revision: D105100370


