### PR TITLE
[release/1.3] Cherry-pick mypy fix

### DIFF
--- a/backends/arm/test/misc/test_tosa_dialect_resize.py
+++ b/backends/arm/test/misc/test_tosa_dialect_resize.py
@@ -22,6 +22,7 @@ def _make_symint(
     shape_env: ShapeEnv, symbol: str, hint: int, min: int = 1, max: int = 64
 ) -> torch.SymInt:
     symint = shape_env.create_symintnode(sympy.Symbol(symbol), hint=hint)
+    assert isinstance(symint, torch.SymInt)
     shape_env.constrain_symbol_range(
         symint.node.expr, compiler_min=min, compiler_max=max
     )

--- a/backends/arm/test/misc/test_tosa_dialect_shape_ops.py
+++ b/backends/arm/test/misc/test_tosa_dialect_shape_ops.py
@@ -23,6 +23,7 @@ def _make_symint(
 ) -> torch.SymInt:
     """Create a symbolic dimension backed by the provided ShapeEnv."""
     symint = shape_env.create_symintnode(sympy.Symbol(symbol), hint=hint)
+    assert isinstance(symint, torch.SymInt)
     symbol_expr = symint.node.expr
     shape_env.constrain_symbol_range(symbol_expr, compiler_min=min, compiler_max=max)
     return symint

--- a/backends/arm/test/passes/test_rewrite_upsample_pass.py
+++ b/backends/arm/test/passes/test_rewrite_upsample_pass.py
@@ -14,6 +14,7 @@ def _make_symint(
     shape_env: ShapeEnv, symbol: str, hint: int, min: int = 1, max: int = 64
 ) -> torch.SymInt:
     symint = shape_env.create_symintnode(sympy.Symbol(symbol), hint=hint)
+    assert isinstance(symint, torch.SymInt)
     shape_env.constrain_symbol_range(
         symint.node.expr, compiler_min=min, compiler_max=max
     )

--- a/backends/arm/test/passes/test_symbolic_value_range.py
+++ b/backends/arm/test/passes/test_symbolic_value_range.py
@@ -20,6 +20,7 @@ def _make_shape_env(
 ) -> tuple[ShapeEnv, torch.SymInt]:
     shape_env = ShapeEnv()
     symint = shape_env.create_symintnode(sympy.Symbol(symbol_name), hint=hint)
+    assert isinstance(symint, torch.SymInt)
     shape_env.constrain_symbol_range(
         symint.node.expr,
         compiler_min=compiler_min,


### PR DESCRIPTION
Cherry-pick of #19560 / 1c11601985559bea93c597a4367e9f824c36572b onto release/1.3.

This fixes the current release-branch lintrunner-mypy failure by adding explicit SymInt narrowing after ShapeEnv.create_symintnode in ARM tests. The change is test-only and matches main.

Criteria category: testci
Tracker: #19180

Authored with Claude.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani