### PR TITLE
Set torch seed for pytest

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,7 @@
 import sys
 
+import torch
+
 collect_ignore_glob: list[str] = []
 
 # Skip Apple tests on Windows. Note that some Core ML tests can run on Linux, as the AOT flow
@@ -10,3 +12,6 @@ if sys.platform == "win32":
     collect_ignore_glob += [
         "backends/apple/**",
     ]
+
+# Seed the run
+torch.manual_seed(42)


### PR DESCRIPTION
As per #19650, set a global deterministic seed for pytorch. This should reduce the number of flakes. Setting it in conftest.py should set it for all pytest runs, which includes our CI jobs.