### PR TITLE
Restore ScalelessRMSNorm hand-rolled forward for eager numerical parity

### DIFF
--- a/examples/models/llama/norm.py
+++ b/examples/models/llama/norm.py
@@ -44,9 +44,9 @@ class RMSNorm(torch.nn.Module):
 class ScalelessRMSNorm(torch.nn.RMSNorm):
     """RMSNorm with weight hardcoded to ones and not trainable.
 
-    Equivalent to a scaleless RMSNorm (no learnable scaling) but implemented as a
-    torch.nn.RMSNorm so the op composes/decomposes cleanly for backends like QNN
-    instead of being expressed as a hand-rolled decomposition.
+    Subclasses torch.nn.RMSNorm so backends (QNN) see a proper RMSNorm op for
+    lowering, but overrides forward with the explicit fp32 decomposition to
+    stay numerically identical to the rlformers reference during eager execution.
     """
 
     def __init__(self, dim: int, eps: float = 1e-6):
@@ -55,6 +55,15 @@ class ScalelessRMSNorm(torch.nn.RMSNorm):
         with torch.no_grad():
             self.weight.fill_(1.0)
         self.weight.requires_grad = False
+
+    def forward(self, x):
+        if torch.compiler.is_compiling():
+            return super().forward(x)
+        x_float = x.float()
+        return (
+            x_float
+            * torch.rsqrt((x_float * x_float).mean(-1, keepdim=True) + self.eps)
+        ).type_as(x)
 
 
 class RMSNormCoreML(torch.nn.Module):


### PR DESCRIPTION
Summary:
D104258950 changed `ScalelessRMSNorm` from a hand-rolled fp32 decomposition to a `torch.nn.RMSNorm` subclass so that QNN and other backends see a proper RMSNorm op for lowering. However, removing the custom `forward` meant eager execution now uses `torch.nn.RMSNorm`'s fused CUDA kernel, which has different internal precision handling than the hand-rolled `x.float() * rsqrt(mean(x^2) + eps)` decomposition used by the rlformers reference model.

This caused both `test_llm_backbone_correctness_cuda` and `test_llm_backbone_correctness_decode` to fail:
- **fp32 case**: SNR dropped from `inf` to 67-85 dB (same decoded text, different logits)
- **quantized case**: SNR dropped to 1-35 dB with negative per-step values and divergent decoded text, because the precision difference was amplified by quantization noise

The fix restores the original hand-rolled `forward` override on `ScalelessRMSNorm` while keeping `torch.nn.RMSNorm` as the base class. A `torch.compiler.is_compiling()` guard ensures that during `torch.export` (for QNN, XNNPACK, or any backend), the fused `torch.nn.RMSNorm` op is used instead — preserving the export-path fix from D104258950.

Differential Revision: D105593738


