### PR TITLE
Retry all curl errors

### DIFF
--- a/.ci/docker/common/install_android.sh
+++ b/.ci/docker/common/install_android.sh
@@ -43,10 +43,10 @@ install_ndk() {
   ARCH=$(uname -m)
   if [ "${ARCH}" = "aarch64" ]; then
     # aarch64 NDK is not cached on S3, download from Google directly
-    curl -Os --retry 3 "https://dl.google.com/android/repository/android-ndk-${ANDROID_NDK_VERSION}-linux.zip"
+    curl -Os --retry 3 --retry-all-errors "https://dl.google.com/android/repository/android-ndk-${ANDROID_NDK_VERSION}-linux.zip"
   else
     # The NDK installation is cached on ossci-android S3 bucket
-    curl -Os --retry 3 "https://ossci-android.s3.amazonaws.com/android-ndk-${ANDROID_NDK_VERSION}-linux.zip"
+    curl -Os --retry 3 --retry-all-errors "https://ossci-android.s3.amazonaws.com/android-ndk-${ANDROID_NDK_VERSION}-linux.zip"
   fi
   unzip -qo "android-ndk-${ANDROID_NDK_VERSION}-linux.zip"
 
@@ -62,7 +62,7 @@ install_cmdtools() {
 
   pushd /tmp
   # The file is cached on ossci-android S3 bucket
-  curl -Os --retry 3 "https://ossci-android.s3.us-west-1.amazonaws.com/${CMDTOOLS_FILENAME}"
+  curl -Os --retry 3 --retry-all-errors "https://ossci-android.s3.us-west-1.amazonaws.com/${CMDTOOLS_FILENAME}"
   unzip -qo "${CMDTOOLS_FILENAME}" -d /opt
 
   ls -lah /opt/cmdline-tools/bin

--- a/.ci/docker/common/install_cache.sh
+++ b/.ci/docker/common/install_cache.sh
@@ -34,7 +34,7 @@ install_ubuntu() {
 
 install_binary() {
   echo "Downloading sccache binary from S3 repo"
-  curl --retry 3 https://s3.amazonaws.com/ossci-linux/sccache -o /opt/cache/bin/sccache
+  curl --retry 3 --retry-all-errors https://s3.amazonaws.com/ossci-linux/sccache -o /opt/cache/bin/sccache
   chmod +x /opt/cache/bin/sccache
 }
 

--- a/.ci/docker/common/install_docs_reqs.sh
+++ b/.ci/docker/common/install_docs_reqs.sh
@@ -12,10 +12,10 @@ if [ -n "$BUILD_DOCS" ]; then
   # Ignore error if gpg-agent doesn't exist (for Ubuntu 16.04)
   apt-get install -y gpg-agent || :
 
-  curl --retry 3 -sL https://deb.nodesource.com/setup_16.x | sudo -E bash -
+  curl --retry 3 --retry-all-errors -sL https://deb.nodesource.com/setup_16.x | sudo -E bash -
   sudo apt-get install -y nodejs
 
-  curl --retry 3 -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+  curl --retry 3 --retry-all-errors -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
   echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
 
   apt-get update

--- a/.ci/docker/common/install_linter.sh
+++ b/.ci/docker/common/install_linter.sh
@@ -15,5 +15,5 @@ source "$(dirname "${BASH_SOURCE[0]}")/utils.sh"
 pip_install -r requirements-lintrunner.txt
 
 # Install google-java-format
-curl -L --retry 3 https://github.com/google/google-java-format/releases/download/v1.23.0/google-java-format_linux-x86-64 > /opt/google-java-format
+curl -L --retry 3 --retry-all-errors https://github.com/google/google-java-format/releases/download/v1.23.0/google-java-format_linux-x86-64 > /opt/google-java-format
 chmod +x /opt/google-java-format

--- a/.ci/scripts/setup-emscripten.sh
+++ b/.ci/scripts/setup-emscripten.sh
@@ -9,7 +9,7 @@ set -ex
 
 # need version >= 17
 install_node() {
-    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
+    curl --retry 3 --retry-all-errors -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
     source "$HOME/.nvm/nvm.sh"
     nvm install 22
 }

--- a/.ci/scripts/setup-macos.sh
+++ b/.ci/scripts/setup-macos.sh
@@ -34,7 +34,7 @@ install_buck() {
   # team for help.
   BUCK2_VERSION=$(cat ci_commit_pins/buck2.txt)
   BUCK2=buck2-aarch64-apple-darwin-${BUCK2_VERSION}.zst
-  curl -s "https://ossci-macos.s3.amazonaws.com/${BUCK2}" -o "${BUCK2}"
+  curl -s --retry 3 --retry-all-errors "https://ossci-macos.s3.amazonaws.com/${BUCK2}" -o "${BUCK2}"
 
   zstd -d "${BUCK2}" -o buck2
 
@@ -68,7 +68,7 @@ install_sccache() {
   # NB: The function is adopted from PyTorch MacOS build workflow
   # https://github.com/pytorch/pytorch/blob/main/.github/workflows/_mac-build.yml
   if ! command -v sccache &> /dev/null; then
-    sudo curl --retry 3 "https://s3.amazonaws.com/ossci-macos/sccache/sccache-v0.4.1-${RUNNER_ARCH}" --output "${SCCACHE_PATH}/sccache"
+    sudo curl --retry 3 --retry-all-errors "https://s3.amazonaws.com/ossci-macos/sccache/sccache-v0.4.1-${RUNNER_ARCH}" --output "${SCCACHE_PATH}/sccache"
     sudo chmod +x "${SCCACHE_PATH}/sccache"
   fi
 

--- a/.ci/scripts/setup-mediatek-deps.sh
+++ b/.ci/scripts/setup-mediatek-deps.sh
@@ -14,7 +14,7 @@ install_neuropilot() {
   echo "Start installing neuropilot."
   mkdir -p "${MEDIATEK_INSTALLATION_DIR}"
 
-  curl -Lo /tmp/neuropilot-express.tar.gz "https://s3.ap-southeast-1.amazonaws.com/mediatek.neuropilot.com/06302508-4c94-4bf2-9789-b0ee44e83e27.gz"
+  curl -Lo /tmp/neuropilot-express.tar.gz --retry 3 --retry-all-errors "https://s3.ap-southeast-1.amazonaws.com/mediatek.neuropilot.com/06302508-4c94-4bf2-9789-b0ee44e83e27.gz"
   echo "Finishing downloading neuropilot sdk."
   tar zxvf /tmp/neuropilot-express.tar.gz --strip-components=1 --directory "${MEDIATEK_INSTALLATION_DIR}"
   echo "Finishing unzip neuropilot sdk."
@@ -33,7 +33,7 @@ setup_neuropilot() {
 }
 
 setup_calibration_data() {
-  curl -Lo /tmp/imagenette2-160.tgz https://s3.amazonaws.com/fast-ai-imageclas/imagenette2-160.tgz
+  curl -Lo /tmp/imagenette2-160.tgz --retry 3 --retry-all-errors https://s3.amazonaws.com/fast-ai-imageclas/imagenette2-160.tgz
   tar zxvf /tmp/imagenette2-160.tgz --strip-components=1 --directory "${MEDIATEK_INSTALLATION_DIR}"
 }
 

--- a/.ci/scripts/setup-openvino.sh
+++ b/.ci/scripts/setup-openvino.sh
@@ -37,7 +37,7 @@ else
   echo "Using OpenVINO stable release: ${OPENVINO_BUILD}"
 fi
 
-curl -Lo /tmp/openvino_toolkit.tgz --retry 3 --fail ${OPENVINO_URL}
+curl -Lo /tmp/openvino_toolkit.tgz --retry 3 --retry-all-errors --fail ${OPENVINO_URL}
 tar -xzf /tmp/openvino_toolkit.tgz
 mv "${OPENVINO_EXTRACTED_DIR}" openvino
 

--- a/.ci/scripts/setup-samsung-linux-deps.sh
+++ b/.ci/scripts/setup-samsung-linux-deps.sh
@@ -43,7 +43,7 @@ download_and_extract() {
   local out_file="$3"
 
   echo "Downloading from ${download_url}..."
-  curl -fsSL --retry 3 \
+  curl -fsSL --retry 3 --retry-all-errors \
     -H "apikey: ${API_KEY}" \
     -o "${out_file}" \
     "${download_url}"

--- a/.ci/scripts/setup-vulkan-linux-deps.sh
+++ b/.ci/scripts/setup-vulkan-linux-deps.sh
@@ -16,7 +16,7 @@ install_swiftshader() {
 
   _tmp_archive="/tmp/${_swiftshader_archive}"
 
-  curl --silent --show-error --location --fail --retry 3 \
+  curl --silent --show-error --location --fail --retry 3 --retry-all-errors \
     --output "${_tmp_archive}" "$_https_amazon_aws/${_swiftshader_archive}"
 
   tar -C "${_swiftshader_dir}" -xzf "${_tmp_archive}"
@@ -35,7 +35,7 @@ install_vulkan_sdk() {
 
   _tmp_archive="/tmp/vulkansdk.tar.gz"
 
-  curl --silent --show-error --location --fail --retry 3 \
+  curl --silent --show-error --location --fail --retry 3 --retry-all-errors \
     --output "${_tmp_archive}" "${_vulkan_sdk_url}"
 
   tar -C "${_vulkan_sdk_dir}" -xJf "${_tmp_archive}"

--- a/.ci/scripts/test_ios_ci.sh
+++ b/.ci/scripts/test_ios_ci.sh
@@ -55,7 +55,7 @@ mv $MODEL_NAME*.pte "$APP_PATH/Resources/Models/MobileNet/"
 
 say "Downloading Labels"
 
-curl https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt \
+curl --retry 3 --retry-all-errors https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt \
   -o "$APP_PATH/Resources/Models/MobileNet/imagenet_classes.txt"
 
 say "Creating Simulator"

--- a/.ci/scripts/test_model_e2e.sh
+++ b/.ci/scripts/test_model_e2e.sh
@@ -258,17 +258,17 @@ echo "::group::Prepare $MODEL_NAME Artifacts"
 # Download tokenizer files (skip for models that bundle tokenizer in export or do not use one)
 if [ "$MODEL_NAME" != "parakeet" ] && [ "$MODEL_NAME" != "voxtral_realtime" ] && [ "$MODEL_NAME" != "sortformer" ] && [ "$MODEL_NAME" != "dinov2" ] && [ "$MODEL_NAME" != "qwen3_5_moe" ] && [ "$MODEL_NAME" != "gemma4_31b" ]; then
   if [ "$TOKENIZER_FILE" != "" ]; then
-    curl -L $TOKENIZER_URL/$TOKENIZER_FILE -o $MODEL_DIR/$TOKENIZER_FILE
+    curl -L --retry 3 --retry-all-errors $TOKENIZER_URL/$TOKENIZER_FILE -o $MODEL_DIR/$TOKENIZER_FILE
   else
-    curl -L $TOKENIZER_URL/tokenizer.json -o $MODEL_DIR/tokenizer.json
-    curl -L $TOKENIZER_URL/tokenizer_config.json -o $MODEL_DIR/tokenizer_config.json
-    curl -L $TOKENIZER_URL/special_tokens_map.json -o $MODEL_DIR/special_tokens_map.json
+    curl -L --retry 3 --retry-all-errors $TOKENIZER_URL/tokenizer.json -o $MODEL_DIR/tokenizer.json
+    curl -L --retry 3 --retry-all-errors $TOKENIZER_URL/tokenizer_config.json -o $MODEL_DIR/tokenizer_config.json
+    curl -L --retry 3 --retry-all-errors $TOKENIZER_URL/special_tokens_map.json -o $MODEL_DIR/special_tokens_map.json
   fi
 fi
 
 # Download test files
 if [ "$AUDIO_URL" != "" ]; then
-  curl -L $AUDIO_URL -o ${MODEL_DIR}/$AUDIO_FILE
+  curl -L --retry 3 --retry-all-errors $AUDIO_URL -o ${MODEL_DIR}/$AUDIO_FILE
 elif [[ "$MODEL_NAME" == *whisper* ]] || [ "$MODEL_NAME" = "voxtral_realtime" ]; then
   if ! command -v ffmpeg >/dev/null; then
     if [ "$(uname -s)" = "Linux" ] && command -v apt-get >/dev/null; then
@@ -290,7 +290,7 @@ fi
 
 # Download test image for vision models
 if [ -n "${IMAGE_URL:-}" ]; then
-  curl -L "$IMAGE_URL" -o "${MODEL_DIR}/test_image.jpg"
+  curl -L --retry 3 --retry-all-errors "$IMAGE_URL" -o "${MODEL_DIR}/test_image.jpg"
 fi
 
 ls -al

--- a/.ci/scripts/utils.sh
+++ b/.ci/scripts/utils.sh
@@ -242,8 +242,8 @@ cmake_install_executorch_lib() {
 
 download_stories_model_artifacts() {
   # Download stories110M.pt and tokenizer from Github
-  curl -Ls "https://huggingface.co/karpathy/tinyllamas/resolve/main/stories110M.pt" --output stories110M.pt
-  curl -Ls "https://raw.githubusercontent.com/karpathy/llama2.c/master/tokenizer.model" --output tokenizer.model
+  curl -Ls --retry 3 --retry-all-errors "https://huggingface.co/karpathy/tinyllamas/resolve/main/stories110M.pt" --output stories110M.pt
+  curl -Ls --retry 3 --retry-all-errors "https://raw.githubusercontent.com/karpathy/llama2.c/master/tokenizer.model" --output tokenizer.model
   # Create params.json file
   touch params.json
   echo '{"dim": 768, "multiple_of": 32, "n_heads": 12, "n_layers": 12, "norm_eps": 1e-05, "vocab_size": 32000}' > params.json


### PR DESCRIPTION
### Summary
Update `curl` commands in CI scripts to retry all errors. This will hopefully improve CI reliability by reducing download failures.

A common pattern from CI logs is the following. Note that the failure is not retried.
```
+++ curl --retry 3 --retry-delay 5 --retry-connrefused --continue-at - -Lo /tmp/android-ndk-r26c-linux.zip https://dl.google.com/android/repository/android-ndk-r26c-linux.zip
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0  637M    0 1280k    0     0  3727k      0  0:02:55 --:--:--  0:02:55 3720k
  2  637M    2 13.0M    0     0  9928k      0  0:01:05  0:00:01  0:01:04 9923k
  4  637M    4 29.9M    0     0  12.7M      0  0:00:50  0:00:02  0:00:48 12.7M
  4  637M    4 31.2M    0     0  7724k      0  0:01:24  0:00:04  0:01:20 7725k
curl: (92) HTTP/2 stream 0 was not closed cleanly: INTERNAL_ERROR (err 2)
```
https://github.com/pytorch/executorch/actions/runs/26048331262/job/76578254537#step:17:17111

Most of the curl commands in our scripts do retry, but only certain types of errors. Switching to `--retry-all-errors` should hopefully be more robust to flakes. If something is hard down, it may spending ~15s retrying, but that's fine.