### PR TITLE
Fix broken tests caused by runtime gtest skipping (#19658)

### DIFF
--- a/kernels/test/op_clone_test.cpp
+++ b/kernels/test/op_clone_test.cpp
@@ -9,6 +9,7 @@
 #include <executorch/kernels/test/FunctionHeaderWrapper.h> // Declares the operator
 #include <executorch/kernels/test/TestUtil.h>
 #include <executorch/kernels/test/supported_features.h>
+#include <executorch/kernels/test/supported_features_skip.h>
 #include <executorch/runtime/core/exec_aten/exec_aten.h>
 #include <executorch/runtime/core/exec_aten/testing_util/tensor_factory.h>
 #include <executorch/runtime/core/exec_aten/testing_util/tensor_util.h>
@@ -73,9 +74,9 @@ class OpCloneTest : public OperatorTest {
 
 // regular test for clone.out
 TEST_F(OpCloneTest, AllDtypesSupported) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel test fails";
-  }
+  ET_SKIP_IF(
+      torch::executor::testing::SupportedFeatures::get()->is_aten,
+      "ATen kernel test fails");
 #define TEST_ENTRY(ctype, dtype) test_dtype<ctype, ScalarType::dtype>();
   ET_FORALL_REAL_TYPES_AND(Bool, TEST_ENTRY);
 #undef TEST_ENTRY
@@ -88,9 +89,9 @@ TEST_F(OpCloneTest, EmptyInputSupported) {
 }
 
 TEST_F(OpCloneTest, MismatchedSizesDie) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched sizes";
-  }
+  ET_SKIP_IF(
+      torch::executor::testing::SupportedFeatures::get()->is_aten,
+      "ATen kernel can handle mismatched sizes");
   TensorFactory<ScalarType::Int> tf;
   Tensor input = tf.make(/*sizes=*/{3, 1, 1, 2}, /*data=*/{1, 2, 3, 4, 5, 6});
   Tensor out = tf.zeros({3, 2, 1, 1});
@@ -114,9 +115,9 @@ TEST_F(OpCloneTest, MismatchedTypesDie) {
 // MemoryFormat::Contiguous should not be allowed. The function is expected
 // depth if using the illegal memory format.
 TEST_F(OpCloneTest, MismatchedMemoryFormatDie) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle non contiguous memory formats";
-  }
+  ET_SKIP_IF(
+      torch::executor::testing::SupportedFeatures::get()->is_aten,
+      "ATen kernel can handle non contiguous memory formats");
   TensorFactory<ScalarType::Float> tf_in;
   TensorFactory<ScalarType::Float> tf_out;
   Tensor input =

--- a/kernels/test/op_unbind_copy_test.cpp
+++ b/kernels/test/op_unbind_copy_test.cpp
@@ -9,6 +9,7 @@
 #include <executorch/kernels/test/FunctionHeaderWrapper.h> // Declares the operator
 #include <executorch/kernels/test/TestUtil.h>
 #include <executorch/kernels/test/supported_features.h>
+#include <executorch/kernels/test/supported_features_skip.h>
 #include <executorch/runtime/core/exec_aten/exec_aten.h>
 #include <executorch/runtime/core/exec_aten/testing_util/tensor_factory.h>
 #include <executorch/runtime/core/exec_aten/testing_util/tensor_util.h>
@@ -269,9 +270,9 @@ TEST_F(OpUnbindCopyIntOutTest, UnbindWorksWithZeroSizedTensors) {
 }
 
 TEST_F(OpUnbindCopyIntOutTest, UnbindFailsWithWronglyAllocatedOutput) {
-  if (torch::executor::testing::SupportedFeatures::get()->is_aten) {
-    GTEST_SKIP() << "ATen kernel can handle mismatched output shape";
-  }
+  ET_SKIP_IF(
+      torch::executor::testing::SupportedFeatures::get()->is_aten,
+      "ATen kernel can handle mismatched output shape");
   TensorFactory<ScalarType::Int> tf;
   TensorListFactory<ScalarType::Int> tlf;
 

--- a/kernels/test/supported_features_skip.h
+++ b/kernels/test/supported_features_skip.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// `ET_SKIP_IF(cond, reason)` -- skip a kernel test when `cond` is true.
+//
+// Replaces the older inline pattern:
+//     if (SupportedFeatures::get()->is_aten) {
+//       GTEST_SKIP() << "ATen handles X";
+//     }
+// with:
+//     ET_SKIP_IF(SupportedFeatures::get()->is_aten, "ATen handles X");
+//
+// OSS:    expands to `if (cond) GTEST_SKIP() << reason;` (unchanged).
+// fbcode: expands to `if (cond) return;` so the test reports PASS, not SKIP.
+//
+// fbcode's TestX flags consistently-skipping tests as "broken" -- see
+// T208053850 and
+// https://fb.workplace.com/groups/testinfra.discuss/permalink/2044665472719153/.
+// Collapse back to the OSS form once that's resolved.
+//
+// `EXECUTORCH_INTERNAL` is set by BUCK gated on `runtime.is_oss` (see
+// `runtime/executor/targets.bzl` for the existing precedent).
+
+#if defined(EXECUTORCH_INTERNAL) && EXECUTORCH_INTERNAL == 1
+
+namespace executorch::testing::internal {
+// No-op sink so `<<` chains in the reason still parse and type-check.
+struct SkipReasonSink {
+  template <typename T>
+  const SkipReasonSink& operator<<(const T&) const {
+    return *this;
+  }
+};
+} // namespace executorch::testing::internal
+
+// `if/else` form avoids dangling-else hazards and lets the reason still
+// participate in `<<` chains.
+#define ET_SKIP_IF(cond, reason) \
+  if ((cond)) {                  \
+    return;                      \
+  } else                         \
+    ::executorch::testing::internal::SkipReasonSink{} << reason
+
+#else // !EXECUTORCH_INTERNAL
+
+#include <gtest/gtest.h>
+
+#define ET_SKIP_IF(cond, reason) \
+  if ((cond))                    \
+  GTEST_SKIP() << reason
+
+#endif // EXECUTORCH_INTERNAL

--- a/kernels/test/targets.bzl
+++ b/kernels/test/targets.bzl
@@ -115,7 +115,16 @@ def define_common_targets():
     runtime.cxx_library(
         name = "supported_features_header",
         srcs = [],
-        exported_headers = {"supported_features.h": ":supported_feature_header_gen[supported_features.h]"},
+        exported_headers = {
+            "supported_features.h": ":supported_feature_header_gen[supported_features.h]",
+            "supported_features_skip.h": "supported_features_skip.h",
+        },
+        # Set EXECUTORCH_INTERNAL=1 for fbcode-internal builds so the
+        # ET_SKIP_IF helper in supported_features_skip.h compiles to an
+        # early `return;` instead of GTEST_SKIP. This avoids TestX's
+        # "ConsistentlySkipping" / broken-test signal. OSS builds keep
+        # the canonical GTEST_SKIP behavior. See header for context.
+        exported_preprocessor_flags = [] if runtime.is_oss else ["-DEXECUTORCH_INTERNAL=1"],
         visibility = [
             "//executorch/kernels/...",
         ],


### PR DESCRIPTION
Summary:

Convert runtime `GTEST_SKIP()` guards in executorch kernel tests into a new `ET_SKIP_IF(cond, reason)` macro that:

* In OSS builds expands to today's behavior: `if (cond) GTEST_SKIP() << reason;`.
* In fbcode builds (gated on `runtime.is_oss` via `EXECUTORCH_INTERNAL=1`) expands to `if (cond) return;` so the test reports PASS instead of SKIP.

# Why

TestX flags any test that consistently calls `GTEST_SKIP()` at runtime as "broken" / `ConsistentlySkipping` (TI+F's SKIP bucket is overloaded with "infra error -- couldn't run the test"). The `SupportedFeatures::get()->X` guards in `kernels/test/op_*_test.cpp` are statically known per kernel variant -- there's no infra ambiguity, the test just doesn't apply -- but they still trip the broken-test signal in fbcode and file oncall tasks.

Refs: T208053850, https://fb.workplace.com/groups/testinfra.discuss/permalink/2044665472719153/.

Once testinfra distinguishes intentional GTEST_SKIP from infra-error SKIP, the fbcode branch in `supported_features_skip.h` can collapse back to the OSS form.

# What is in this diff

* `supported_features_skip.h` (fbcode + xplat mirror): new helper, dual expansion gated on `EXECUTORCH_INTERNAL`.
* `targets.bzl` (fbcode + xplat): export the new header from `:supported_features_header` and set `exported_preprocessor_flags = ["-DEXECUTORCH_INTERNAL=1"]` for internal builds (gated on `runtime.is_oss`, mirroring the existing `EXECUTORCH_INTERNAL_FLATBUFFERS` precedent in `runtime/executor/targets.bzl`).
* Migrated 2 tests (4 sites total) as a proof of concept:
  - `op_unbind_copy_test.cpp::UnbindFailsWithWronglyAllocatedOutput`
  - `op_clone_test.cpp::AllDtypesSupported`, `MismatchedSizesDie`, `MismatchedMemoryFormatDie`

The remaining ~200 sites in `kernels/test/op_*_test.cpp` will be migrated in follow-up diffs.

OSS behavior is unchanged.

Reviewed By: psiddh, GregoryComer

Differential Revision: D105634345


