### PR TITLE
Arm backend: Remove Ethos-U core driver submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "backends/arm/third-party/ethos-u-core-driver"]
-	path = backends/arm/third-party/ethos-u-core-driver
-	url = https://git.gitlab.arm.com/artificial-intelligence/ethos-u/ethos-u-core-driver.git
 [submodule "backends/vulkan/third-party/Vulkan-Headers"]
 	path = backends/vulkan/third-party/Vulkan-Headers
 	url = https://github.com/KhronosGroup/Vulkan-Headers

--- a/backends/arm/CMakeLists.txt
+++ b/backends/arm/CMakeLists.txt
@@ -39,6 +39,11 @@ set(ETHOSU_LINUX_DRIVER_SOURCE_DIR
       PATH
       "Optional local path to an existing ethos-u-linux-driver stack checkout"
 )
+set(ETHOS_SDK_PATH
+    "${EXECUTORCH_ROOT}/examples/arm/arm-scratch/ethos-u"
+    CACHE PATH "Path to Ethos-U bare metal driver/env"
+)
+option(FETCH_ETHOS_U_CONTENT "Fetch ethos_u dependencies" ON)
 
 if(EXECUTORCH_BUILD_ARM_BAREMETAL AND EXECUTORCH_BUILD_ARM_ETHOSU_LINUX)
   message(
@@ -51,8 +56,6 @@ endif()
 if(EXECUTORCH_BUILD_ARM_BAREMETAL OR EXECUTORCH_BUILD_ARM_ETHOSU_LINUX)
 
   add_compile_options("-Wall" "-Werror")
-
-  set(THIRD_PARTY_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/third-party")
 
   set(_arm_backend_sources
       backends/arm/runtime/EthosUBackend.cpp
@@ -72,11 +75,22 @@ if(EXECUTORCH_BUILD_ARM_BAREMETAL OR EXECUTORCH_BUILD_ARM_ETHOSU_LINUX)
       executorch_delegate_ethos_u
       PRIVATE ${EXECUTORCH_ROOT}/backends/arm/runtime/EthosUBackend_Cortex_M.cpp
     )
-    set(_ethosu_core_driver_include
-        "${THIRD_PARTY_ROOT}/ethos-u-core-driver/include"
+    include(${EXECUTORCH_ROOT}/backends/arm/scripts/corstone_utils.cmake)
+    if(FETCH_ETHOS_U_CONTENT)
+      fetch_ethos_u_content(${ETHOS_SDK_PATH} ${EXECUTORCH_ROOT})
+    endif()
+    set(DRIVER_ETHOSU_INCLUDE_DIR
+        "${ETHOS_SDK_PATH}/core_software/core_driver/include"
     )
+    if(NOT EXISTS "${DRIVER_ETHOSU_INCLUDE_DIR}/ethosu_driver.h")
+      message(
+        FATAL_ERROR
+          "Ethos-U core driver headers were not found in ${DRIVER_ETHOSU_INCLUDE_DIR}."
+          " Run examples/arm/setup.sh or enable FETCH_ETHOS_U_CONTENT."
+      )
+    endif()
     target_include_directories(
-      executorch_delegate_ethos_u PRIVATE ${_ethosu_core_driver_include}
+      executorch_delegate_ethos_u PRIVATE ${DRIVER_ETHOSU_INCLUDE_DIR}
     )
     target_link_libraries(executorch_delegate_ethos_u PUBLIC ethosu_core_driver)
   elseif(EXECUTORCH_BUILD_ARM_ETHOSU_LINUX)

--- a/backends/arm/README.md
+++ b/backends/arm/README.md
@@ -61,8 +61,6 @@ backends/arm/
 │   ├── models/                    # Model level unit tests
 │   └── tester/                    # Testing harnesses and utilities
 │
-├── third-party/                   # External dependencies
-│
 ├── tosa/                          # Shared TOSA backend implementation and dialect
 │
 └── vgf/                           # Implementations of VgfPartitioner and VgfBackend

--- a/backends/arm/scripts/corstone_utils.cmake
+++ b/backends/arm/scripts/corstone_utils.cmake
@@ -8,6 +8,7 @@ function(fetch_ethos_u_content ETHOS_SDK_PATH ET_DIR_PATH)
 
   file(MAKE_DIRECTORY ${ETHOS_SDK_PATH}/../ethos_u)
   include(FetchContent)
+  find_package(Python3 REQUIRED COMPONENTS Interpreter)
   set(ethos_u_base_tag "26.02")
   FetchContent_Declare(
     ethos_u
@@ -33,10 +34,13 @@ function(fetch_ethos_u_content ETHOS_SDK_PATH ET_DIR_PATH)
       "source backends/arm/scripts/utils.sh && patch_repo ${ETHOS_SDK_PATH} ${ethos_u_base_rev} ${patch_dir}"
     WORKING_DIRECTORY ${ET_DIR_PATH}
   )
-  # Get ethos_u externals only if core_platform folder does not already exist.
-  if(NOT EXISTS "${ETHOS_SDK_PATH}/core_platform")
+
+  # Get ethos_u externals only if core driver headers do not already exist.
+  if(NOT EXISTS
+     "${ETHOS_SDK_PATH}/core_software/core_driver/include/ethosu_driver.h"
+  )
     execute_process(
-      COMMAND ${PYTHON_EXECUTABLE} fetch_externals.py -c
+      COMMAND ${Python3_EXECUTABLE} fetch_externals.py -c
               ${ethos_u_base_tag}.json fetch
       WORKING_DIRECTORY ${ETHOS_SDK_PATH}
     )


### PR DESCRIPTION
Use the Ethos-U scratch checkout as the source for core driver headers. Keep baremetal builds on the same driver copy as the Corstone platform flow, and remove the stale Arm third-party README entry.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @robell @rascani