### PR TITLE
Arm backend: Add VGF Swin2SR example and OOTB smoke test

### DIFF
--- a/backends/arm/test/models/test_swin2sr_arm.py
+++ b/backends/arm/test/models/test_swin2sr_arm.py
@@ -1,0 +1,118 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Tuple
+
+import torch
+
+from executorch.backends.arm.test import common
+from executorch.backends.arm.test.tester.test_pipeline import (
+    TosaPipelineFP,
+    TosaPipelineINT,
+    VgfPipeline,
+)
+from transformers import Swin2SRConfig, Swin2SRForImageSuperResolution
+
+input_t = Tuple[torch.Tensor]
+
+exir_ops = [
+    "executorch_exir_dialects_edge__ops_aten_add_Tensor",
+    "executorch_exir_dialects_edge__ops_aten_convolution_default",
+    "executorch_exir_dialects_edge__ops_aten_layer_norm_default",
+    "executorch_exir_dialects_edge__ops_aten_matmul_default",
+    "executorch_exir_dialects_edge__ops_aten_mul_Tensor",
+    "executorch_exir_dialects_edge__ops_aten_pixel_shuffle_default",
+    "executorch_exir_dialects_edge__ops_aten_softmax_int",
+]
+
+
+class TinySwin2SR(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        config = Swin2SRConfig(
+            image_size=8,
+            patch_size=1,
+            num_channels=3,
+            embed_dim=16,
+            depths=[1, 1],
+            num_heads=[1, 1],
+            window_size=4,
+            upscale=2,
+            img_range=1.0,
+            resi_connection="1conv",
+            upsampler="pixelshuffle",
+        )
+        self.model = Swin2SRForImageSuperResolution(config).eval()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.model(pixel_values=x, return_dict=True).reconstruction
+
+
+def make_model_and_inputs() -> tuple[torch.nn.Module, input_t]:
+    model = TinySwin2SR().eval()
+    inputs = (torch.rand(1, 3, 8, 8),)
+    return model, inputs
+
+
+def test_swin2sr_tosa_FP():
+    model, model_inputs = make_model_and_inputs()
+    pipeline = TosaPipelineFP[input_t](
+        model,
+        model_inputs,
+        aten_op=[],
+        exir_op=exir_ops,
+        use_to_edge_transform_and_lower=True,
+    )
+    pipeline.pop_stage("check_count.exir")
+    # TODO: MLETORCH-2134 re-enable once Swin2SR runs on the TOSA ref model.
+    pipeline.pop_stage("run_method_and_compare_outputs")
+    pipeline.run()
+
+
+def test_swin2sr_tosa_INT():
+    model, model_inputs = make_model_and_inputs()
+    pipeline = TosaPipelineINT[input_t](
+        model,
+        model_inputs,
+        aten_op=[],
+        exir_op=exir_ops,
+        use_to_edge_transform_and_lower=True,
+    )
+    pipeline.pop_stage("check_count.exir")
+    # TODO: MLETORCH-2134 re-enable once Swin2SR runs on the TOSA ref model.
+    pipeline.pop_stage("run_method_and_compare_outputs")
+    pipeline.run()
+
+
+@common.SkipIfNoModelConverter
+def test_swin2sr_vgf_quant():
+    model, model_inputs = make_model_and_inputs()
+    pipeline = VgfPipeline[input_t](
+        model,
+        model_inputs,
+        aten_op=[],
+        exir_op=exir_ops,
+        use_to_edge_transform_and_lower=True,
+        quantize=True,
+    )
+    pipeline.pop_stage("check_count.exir")
+    # TODO: MLETORCH-2134 re-enable once Swin2SR runs on the TOSA ref model.
+    pipeline.pop_stage("run_method_and_compare_outputs")
+    pipeline.run()
+
+
+@common.SkipIfNoModelConverter
+def test_swin2sr_vgf_no_quant():
+    model, model_inputs = make_model_and_inputs()
+    pipeline = VgfPipeline[input_t](
+        model,
+        model_inputs,
+        aten_op=[],
+        exir_op=exir_ops,
+        use_to_edge_transform_and_lower=True,
+        quantize=False,
+    )
+    pipeline.pop_stage("check_count.exir")
+    pipeline.run()

--- a/backends/arm/test/test_arm_ootb.sh
+++ b/backends/arm/test/test_arm_ootb.sh
@@ -22,7 +22,7 @@ if [[ "$1" == "-h" || "$1" == "--help" ]]; then
 fi
 
 if [[ $# -eq 0 ]]; then
-    TEST_SUITES=(run_ootb_tests_ethos_u run_ootb_tests_tosa run_ootb_tests_vgf run_deit_e2e_ethos_u)
+    TEST_SUITES=(run_ootb_tests_ethos_u run_ootb_tests_tosa run_ootb_tests_vgf run_deit_e2e_ethos_u run_swin2sr_e2e_vgf)
 else
     TEST_SUITES=("$1")
 fi
@@ -66,7 +66,7 @@ run_deit_e2e_ethos_u() {
     local image_path="${work_root}/dog.bmp"
     local pte_path="${export_dir}/deit_tiny_smoke.pte"
     local toolchain_file="${et_root_dir}/examples/arm/ethos-u-setup/arm-none-eabi-gcc.cmake"
-    echo "${FUNCNAME}: Work root is ${work_root}; existing artifacts will be reused if present"
+    echo "${FUNCNAME}: Work directory: ${work_root}; existing artifacts will be reused if present"
 
     mkdir -p "${model_dir}" "${export_dir}" "${build_dir}"
 
@@ -146,6 +146,135 @@ run_deit_e2e_ethos_u() {
         -C mps4_board.uart0.shutdown_on_eot=1 \
         -a "${elf}" \
         -C mps4_board.subsystem.ethosu.extra_args="--fast"
+
+    echo "${FUNCNAME}: PASS"
+}
+
+run_swin2sr_e2e_vgf() {
+    echo "$FUNCNAME: Prepare demo assets, export FP/INT8, build, and run the Swin2SR VGF e2e test"
+
+    local script_dir
+    script_dir=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+    et_root_dir=$(cd "${script_dir}/../../.." && pwd)
+    local example_dir="${et_root_dir}/examples/arm/super_resolution_example_vgf"
+    local work_root="${et_root_dir}/arm_test/swin2sr_vgf_ootb_smoke"
+    local demo_dir="${work_root}/demo_assets"
+    local runtime_dir="${demo_dir}/runtime"
+    local runner_path="${work_root}/executor_runner"
+    local input_image="${runtime_dir}/demo_lr_64.png"
+    local fp_pte_path="${demo_dir}/swin2sr_x2_vgf_fp.pte"
+    local int8_pte_path="${demo_dir}/swin2sr_x2_vgf_int8.pte"
+    local fp_output_image="${runtime_dir}/demo_fp_128.png"
+    local int8_output_image="${runtime_dir}/demo_int8_128.png"
+    local checkpoint_id="caidas/swin2SR-classical-sr-x2-64"
+    local checkpoint_revision="cee1c923c6a37361c6e5650b65dcf4be821e5d52"
+    echo "${FUNCNAME}: Work directory: ${work_root}; existing artifacts will be reused if present"
+
+    mkdir -p "${demo_dir}" "${runtime_dir}"
+
+    setup_path_script=${et_root_dir}/examples/arm/arm-scratch/setup_path.sh
+    source ${setup_path_script}
+
+    echo "${FUNCNAME}: Installing example requirements"
+    pip install -r "${example_dir}/requirements.txt"
+
+    echo "${FUNCNAME}: Preparing deterministic demo assets"
+    python3 "${example_dir}/model_export/prepare_demo_assets.py" \
+        --output-dir "${demo_dir}"
+
+    echo "${FUNCNAME}: Building VKML executor_runner"
+    "${et_root_dir}/backends/arm/scripts/build_executor_runner_vkml.sh" \
+        --output="${work_root}"
+
+    if [[ ! -f "${runner_path}" ]]; then
+        runner_path=$(find "${work_root}" -name executor_runner -type f | head -n 1)
+    fi
+    [[ -f "${runner_path}" ]] || {
+        echo "${FUNCNAME}: Missing executor_runner under ${work_root}"
+        return 1
+    }
+
+    echo "${FUNCNAME}: Exporting FP Swin2SR model"
+    python3 "${example_dir}/model_export/export_super_resolution.py" \
+        --model-name swin2sr \
+        --checkpoint "${checkpoint_id}" \
+        --checkpoint-revision "${checkpoint_revision}" \
+        --input-height 64 \
+        --input-width 64 \
+        --quantization-mode none \
+        --eval-lr-dir "${demo_dir}/eval/lr" \
+        --eval-hr-dir "${demo_dir}/eval/hr" \
+        --num-eval-samples 2 \
+        --output-path "${fp_pte_path}"
+
+    for artifact in \
+        "${fp_pte_path}" \
+        "${demo_dir}/swin2sr_x2_vgf_fp.json" \
+        "${demo_dir}/swin2sr_x2_vgf_fp_delegation.txt" \
+        "${demo_dir}/swin2sr_x2_vgf_fp_metrics.json"; do
+        [[ -f "${artifact}" ]] || {
+            echo "${FUNCNAME}: Missing FP export artifact ${artifact}"
+            return 1
+        }
+    done
+
+    echo "${FUNCNAME}: Exporting INT8 Swin2SR model"
+    python3 "${example_dir}/model_export/export_super_resolution.py" \
+        --model-name swin2sr \
+        --checkpoint "${checkpoint_id}" \
+        --checkpoint-revision "${checkpoint_revision}" \
+        --input-height 64 \
+        --input-width 64 \
+        --quantization-mode int8 \
+        --calibration-lr-dir "${demo_dir}/calibration/lr" \
+        --eval-lr-dir "${demo_dir}/eval/lr" \
+        --eval-hr-dir "${demo_dir}/eval/hr" \
+        --num-calibration-samples 4 \
+        --num-eval-samples 2 \
+        --output-path "${int8_pte_path}"
+
+    for artifact in \
+        "${int8_pte_path}" \
+        "${demo_dir}/swin2sr_x2_vgf_int8.json" \
+        "${demo_dir}/swin2sr_x2_vgf_int8_delegation.txt" \
+        "${demo_dir}/swin2sr_x2_vgf_int8_metrics.json"; do
+        [[ -f "${artifact}" ]] || {
+            echo "${FUNCNAME}: Missing INT8 export artifact ${artifact}"
+            return 1
+        }
+    done
+
+    echo "${FUNCNAME}: Running FP runtime smoke"
+    python3 "${example_dir}/runtime/run_super_resolution.py" \
+        --model-path "${fp_pte_path}" \
+        --runner "${runner_path}" \
+        --input-image "${input_image}" \
+        --output-image "${fp_output_image}" \
+        --working-dir "${runtime_dir}/fp_work"
+
+    [[ -f "${fp_output_image}" ]] || {
+        echo "${FUNCNAME}: Missing FP runtime output ${fp_output_image}"
+        return 1
+    }
+
+    if [[ "$(uname -s)" == "Linux" ]]; then
+        echo "${FUNCNAME}: Running INT8 runtime smoke"
+        python3 "${example_dir}/runtime/run_super_resolution.py" \
+            --model-path "${int8_pte_path}" \
+            --runner "${runner_path}" \
+            --input-image "${input_image}" \
+            --output-image "${int8_output_image}" \
+            --working-dir "${runtime_dir}/int8_work"
+
+        [[ -f "${int8_output_image}" ]] || {
+            echo "${FUNCNAME}: Missing INT8 runtime output ${int8_output_image}"
+            return 1
+        }
+    else
+        # TODO: MLETORCH-2105 remove this once the next ML SDK release supports
+        # quantized VKML runtime validation on Darwin.
+        echo "${FUNCNAME}: Skipping INT8 runtime on $(uname -s); quantized VKML runtime validation is Linux-only"
+    fi
 
     echo "${FUNCNAME}: PASS"
 }

--- a/examples/arm/README.md
+++ b/examples/arm/README.md
@@ -64,6 +64,16 @@ $ python3 -m backends.arm.scripts.aot_arm_compiler --model_name=mv2 --target=eth
 
 `aot_arm_compiler.py` is called from the scripts below so you don't need to, but it can be useful to do by hand in some cases.
 
+## Host VGF example applications
+
+The Arm examples directory also contains host-side VGF reference flows for
+specific tasks:
+
+- `examples/arm/image_classification_example_vgf` for DEiT image
+  classification.
+- `examples/arm/super_resolution_example_vgf` for Swin2SR image
+  super-resolution.
+
 
 ## ExecuTorch on Arm Ethos-U55/U65 and U85
 

--- a/examples/arm/super_resolution_example_vgf/README.md
+++ b/examples/arm/super_resolution_example_vgf/README.md
@@ -1,0 +1,19 @@
+# Swin2SR Super-Resolution Example Application (VGF)
+
+This example shows how to export a Swin2SR image super-resolution model for the
+Arm VGF backend and run it on host using the generic `executor_runner` binary.
+It is a host-only workflow; a device-specific VGF runtime application is out of
+scope here.
+
+## Layout
+
+- `model_export/prepare_demo_assets.py` — Creates a deterministic text-heavy
+  demo input plus small LR/HR calibration and evaluation sets from a repo-local
+  screenshot.
+- `model_export/README.md` — Dataset-backed FP/INT8 export, PTQ
+  calibration and evaluation, and `.pte` generation.
+- `runtime/README.md` — Running the exported `.pte` on host using
+  `executor_runner` and converting the output tensor back into an image.
+
+Use `examples/arm/image_classification_example_vgf` for the image
+classification flow.

--- a/examples/arm/super_resolution_example_vgf/model_export/README.md
+++ b/examples/arm/super_resolution_example_vgf/model_export/README.md
@@ -1,0 +1,116 @@
+# Swin2SR VGF Export
+
+This example provides two scripts:
+
+- `prepare_demo_assets.py` — Creates a deterministic local demo dataset from a
+  repo-local screenshot so the export and runtime steps can be reproduced
+  without an external SR dataset.
+- `export_super_resolution.py` — Loads a checkpoint, applies optional
+  post-training quantization, evaluates PSNR/SSIM on paired LR/HR samples, and
+  exports a VGF-ready ExecuTorch program for host execution.
+
+## Requirements
+
+- Python 3.10+ with `executorch` and the dependencies in
+  `examples/arm/super_resolution_example_vgf/requirements.txt`.
+- ML SDK dependencies installed through `examples/arm/setup.sh
+  --disable-ethos-u-deps --enable-mlsdk-deps`.
+
+## Quick demo assets
+
+To generate the text-heavy demo crop used by the runtime walkthrough, along
+with the small LR/HR directories used for INT8 calibration and evaluation, run:
+
+```bash
+python examples/arm/super_resolution_example_vgf/model_export/prepare_demo_assets.py \
+  --output-dir ./demo_assets
+```
+
+This writes:
+
+```text
+demo_assets/
+  calibration/hr/
+  calibration/lr/
+  eval/hr/
+  eval/lr/
+  runtime/demo_hr_128.png
+  runtime/demo_lr_64.png
+  metadata.json
+```
+
+The export flow expects paired RGB image directories with matching relative
+paths on the LR and HR sides when evaluation metrics are requested. For each
+pair, the HR image must be exactly `upscale x` larger than the LR image. The
+exporter crops LR inputs to `--input-height` x `--input-width` and crops the HR
+target to the matching scaled patch.
+
+## Export and evaluate for VGF
+
+The concrete quick-demo commands below use the pinned revision currently cached
+for `caidas/swin2SR-classical-sr-x2-64`:
+`cee1c923c6a37361c6e5650b65dcf4be821e5d52`.
+
+### FP export
+
+```bash
+python examples/arm/super_resolution_example_vgf/model_export/export_super_resolution.py \
+  --model-name swin2sr \
+  --checkpoint caidas/swin2SR-classical-sr-x2-64 \
+  --checkpoint-revision cee1c923c6a37361c6e5650b65dcf4be821e5d52 \
+  --input-height 64 \
+  --input-width 64 \
+  --quantization-mode none \
+  --eval-lr-dir ./demo_assets/eval/lr \
+  --eval-hr-dir ./demo_assets/eval/hr \
+  --num-eval-samples 2 \
+  --output-path ./demo_assets/swin2sr_x2_vgf_fp.pte
+```
+
+### INT8 export
+
+```bash
+python examples/arm/super_resolution_example_vgf/model_export/export_super_resolution.py \
+  --model-name swin2sr \
+  --checkpoint caidas/swin2SR-classical-sr-x2-64 \
+  --checkpoint-revision cee1c923c6a37361c6e5650b65dcf4be821e5d52 \
+  --input-height 64 \
+  --input-width 64 \
+  --quantization-mode int8 \
+  --calibration-lr-dir ./demo_assets/calibration/lr \
+  --eval-lr-dir ./demo_assets/eval/lr \
+  --eval-hr-dir ./demo_assets/eval/hr \
+  --num-calibration-samples 4 \
+  --num-eval-samples 2 \
+  --output-path ./demo_assets/swin2sr_x2_vgf_int8.pte
+```
+
+For FP export, set `--quantization-mode none`. INT8 export requires
+`--calibration-lr-dir`; the exporter no longer falls back to random calibration
+inputs. The exporter first tries installed ExecuTorch quantized kernels and
+then local build outputs such as `cmake-out/kernels/quantized` or
+`arm_test/*/kernels/quantized` to register the quantized out-variant ops needed
+by `to_executorch()`.
+
+When `--eval-lr-dir` and `--eval-hr-dir` are provided, the exporter compares
+the exported program module against the paired HR images and writes PSNR/SSIM
+metrics. The quick-demo dataset is intentionally tiny, so these metrics are a
+smoke signal for gross quality regressions rather than a benchmark target; use
+a larger paired validation set when setting release-quality thresholds.
+
+In the OOTB smoke flow, FP export over the generated 2-sample eval set produced
+approximately PSNR 34.85 / SSIM 0.994, while INT8 PTQ produced approximately
+PSNR 22.71 / SSIM 0.870. The INT8 drop is expected; these numbers are included
+only as a smoke-test reference for the generated demo assets.
+
+## Output artifacts
+
+For an export path such as `./swin2sr_x2_vgf_int8.pte`, the exporter writes:
+
+- `swin2sr_x2_vgf_int8.pte` — The ExecuTorch program.
+- `swin2sr_x2_vgf_int8.json` — Static input/output metadata consumed by the
+  runtime helper.
+- `swin2sr_x2_vgf_int8_delegation.txt` — A summary of delegated and
+  non-delegated operators.
+- `swin2sr_x2_vgf_int8_metrics.json` — Optional PSNR/SSIM evaluation metrics
+  when `--eval-lr-dir` and `--eval-hr-dir` are provided.

--- a/examples/arm/super_resolution_example_vgf/model_export/common.py
+++ b/examples/arm/super_resolution_example_vgf/model_export/common.py
@@ -273,11 +273,17 @@ def _load_checkpointed_swin2sr(
         raise ValueError(
             "--checkpoint-revision is required when --checkpoint is a remote Hugging Face model id."
         )
-    model = Swin2SRForImageSuperResolution.from_pretrained(  # nosec B615
-        checkpoint,
-        revision=checkpoint_revision,
-        local_files_only=local_files_only,
-    ).eval()
+    if checkpoint_revision is None:
+        model = Swin2SRForImageSuperResolution.from_pretrained(  # nosec B615
+            checkpoint,
+            local_files_only=local_files_only,
+        ).eval()
+    else:
+        model = Swin2SRForImageSuperResolution.from_pretrained(  # nosec B615
+            checkpoint,
+            revision=checkpoint_revision,
+            local_files_only=local_files_only,
+        ).eval()
     return Swin2SRWrapper(model)
 
 

--- a/examples/arm/super_resolution_example_vgf/model_export/common.py
+++ b/examples/arm/super_resolution_example_vgf/model_export/common.py
@@ -1,0 +1,446 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from PIL import Image
+from torch.utils.data import Dataset
+from transformers import Swin2SRForImageSuperResolution
+
+IMAGE_SUFFIXES = {".bmp", ".jpeg", ".jpg", ".png", ".webp"}
+SUPPORTED_MODELS = ("swin2sr",)
+
+
+class Swin2SRWrapper(torch.nn.Module):
+    def __init__(self, model: Swin2SRForImageSuperResolution):
+        super().__init__()
+        self.model = model
+
+    def forward(self, pixel_values: torch.Tensor) -> torch.Tensor:
+        return self.model(pixel_values=pixel_values, return_dict=True).reconstruction
+
+
+@dataclass(frozen=True)
+class SuperResolutionModelBundle:
+    model_name: str
+    model: torch.nn.Module
+    example_inputs: tuple[torch.Tensor]
+    input_shape: tuple[int, ...]
+    output_shape: tuple[int, ...]
+    input_dtype: str
+    output_dtype: str
+    upscale: int
+    window_size: int
+
+
+def write_json(path: str | Path, payload: dict[str, Any]) -> Path:
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    return path
+
+
+def list_image_paths(path: str | Path) -> list[Path]:
+    path = Path(path)
+    if path.is_file():
+        if path.suffix.lower() not in IMAGE_SUFFIXES:
+            raise ValueError(f"Unsupported image file type: {path}")
+        return [path]
+
+    if not path.is_dir():
+        raise ValueError(f"Image path does not exist: {path}")
+
+    image_paths = sorted(
+        candidate
+        for candidate in path.rglob("*")
+        if candidate.is_file() and candidate.suffix.lower() in IMAGE_SUFFIXES
+    )
+    if not image_paths:
+        raise ValueError(f"No supported images found in: {path}")
+    return image_paths
+
+
+def load_image_tensor(image_path: str | Path) -> torch.Tensor:
+    image = Image.open(image_path).convert("RGB")
+    image_np = np.asarray(image, dtype=np.float32) / 255.0
+    return torch.from_numpy(image_np).permute(2, 0, 1).contiguous().clone()
+
+
+def crop_input_tensor(
+    image: torch.Tensor,
+    input_height: int,
+    input_width: int,
+    crop_mode: str,
+) -> torch.Tensor:
+    height, width = image.shape[1:]
+    if height < input_height or width < input_width:
+        raise ValueError(
+            "Image tensor is smaller than the requested crop size: "
+            f"{tuple(image.shape)} vs {(input_height, input_width)}."
+        )
+
+    if height == input_height and width == input_width:
+        return image
+
+    max_top = height - input_height
+    max_left = width - input_width
+    if crop_mode == "random":
+        top = int(torch.randint(max_top + 1, ()).item())
+        left = int(torch.randint(max_left + 1, ()).item())
+    elif crop_mode == "center":
+        top = max_top // 2
+        left = max_left // 2
+    else:
+        raise ValueError(f"Unsupported crop mode: {crop_mode}")
+
+    return image[:, top : top + input_height, left : left + input_width].contiguous()
+
+
+def load_calibration_inputs(
+    image_path: str | Path,
+    input_height: int,
+    input_width: int,
+    max_samples: int,
+) -> list[tuple[torch.Tensor]]:
+    if max_samples <= 0:
+        raise ValueError("max_samples must be positive.")
+
+    calibration_inputs = []
+    for candidate in list_image_paths(image_path)[:max_samples]:
+        image = load_image_tensor(candidate)
+        image = crop_input_tensor(image, input_height, input_width, crop_mode="center")
+        calibration_inputs.append((image.unsqueeze(0),))
+    return calibration_inputs
+
+
+def _collect_image_map(root: Path) -> dict[Path, Path]:
+    image_map = {
+        candidate.relative_to(root): candidate for candidate in list_image_paths(root)
+    }
+    if not image_map:
+        raise ValueError(f"No supported images found in: {root}")
+    return image_map
+
+
+def paired_image_paths(
+    lr_dir: str | Path,
+    hr_dir: str | Path,
+    max_samples: int | None = None,
+) -> list[tuple[Path, Path]]:
+    lr_root = Path(lr_dir)
+    hr_root = Path(hr_dir)
+    lr_map = _collect_image_map(lr_root)
+    hr_map = _collect_image_map(hr_root)
+
+    lr_keys = set(lr_map)
+    hr_keys = set(hr_map)
+    if lr_keys != hr_keys:
+        missing_lr = sorted(str(key) for key in hr_keys - lr_keys)
+        missing_hr = sorted(str(key) for key in lr_keys - hr_keys)
+        details = []
+        if missing_lr:
+            details.append(f"Missing LR files: {missing_lr[:5]}")
+        if missing_hr:
+            details.append(f"Missing HR files: {missing_hr[:5]}")
+        raise ValueError(
+            "LR/HR directories do not contain matching files. " + " ".join(details)
+        )
+
+    pairs = [(lr_map[key], hr_map[key]) for key in sorted(lr_map)]
+    if max_samples is not None:
+        if max_samples <= 0:
+            raise ValueError("max_samples must be positive.")
+        pairs = pairs[:max_samples]
+    if not pairs:
+        raise ValueError("No paired super-resolution samples were found.")
+    return pairs
+
+
+def _validate_pair_shapes(
+    lr_tensor: torch.Tensor,
+    hr_tensor: torch.Tensor,
+    upscale: int,
+) -> None:
+    if lr_tensor.shape[0] != 3 or hr_tensor.shape[0] != 3:
+        raise ValueError("Only RGB LR/HR image pairs are supported.")
+
+    expected_hr_shape = (
+        hr_tensor.shape[0],
+        lr_tensor.shape[1] * upscale,
+        lr_tensor.shape[2] * upscale,
+    )
+    if tuple(hr_tensor.shape) != expected_hr_shape:
+        raise ValueError(
+            "HR image shape does not match the LR image and upscale factor: "
+            f"LR {tuple(lr_tensor.shape)}, HR {tuple(hr_tensor.shape)}, upscale {upscale}."
+        )
+
+
+def crop_super_resolution_pair(
+    lr_tensor: torch.Tensor,
+    hr_tensor: torch.Tensor,
+    input_height: int,
+    input_width: int,
+    upscale: int,
+    crop_mode: str,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    _validate_pair_shapes(lr_tensor, hr_tensor, upscale)
+
+    lr_height, lr_width = lr_tensor.shape[1:]
+    if lr_height < input_height or lr_width < input_width:
+        raise ValueError(
+            "LR image is smaller than the requested crop size: "
+            f"{tuple(lr_tensor.shape)} vs {(input_height, input_width)}."
+        )
+
+    if lr_height == input_height and lr_width == input_width:
+        return lr_tensor.contiguous(), hr_tensor.contiguous()
+
+    max_top = lr_height - input_height
+    max_left = lr_width - input_width
+    if crop_mode == "random":
+        top = int(torch.randint(max_top + 1, ()).item())
+        left = int(torch.randint(max_left + 1, ()).item())
+    elif crop_mode == "center":
+        top = max_top // 2
+        left = max_left // 2
+    else:
+        raise ValueError(f"Unsupported crop mode: {crop_mode}")
+
+    hr_top = top * upscale
+    hr_left = left * upscale
+    return (
+        lr_tensor[:, top : top + input_height, left : left + input_width].contiguous(),
+        hr_tensor[
+            :,
+            hr_top : hr_top + input_height * upscale,
+            hr_left : hr_left + input_width * upscale,
+        ].contiguous(),
+    )
+
+
+class PairedSuperResolutionDataset(Dataset[tuple[torch.Tensor, torch.Tensor]]):
+    def __init__(
+        self,
+        lr_dir: str | Path,
+        hr_dir: str | Path,
+        input_height: int,
+        input_width: int,
+        upscale: int,
+        crop_mode: str,
+        max_samples: int | None = None,
+    ):
+        self.pairs = paired_image_paths(lr_dir, hr_dir, max_samples=max_samples)
+        self.input_height = input_height
+        self.input_width = input_width
+        self.upscale = upscale
+        self.crop_mode = crop_mode
+
+    def __len__(self) -> int:
+        return len(self.pairs)
+
+    def __getitem__(self, idx: int) -> tuple[torch.Tensor, torch.Tensor]:
+        lr_path, hr_path = self.pairs[idx]
+        lr_tensor = load_image_tensor(lr_path)
+        hr_tensor = load_image_tensor(hr_path)
+        return crop_super_resolution_pair(
+            lr_tensor,
+            hr_tensor,
+            self.input_height,
+            self.input_width,
+            self.upscale,
+            self.crop_mode,
+        )
+
+
+def _load_checkpointed_swin2sr(
+    checkpoint: str,
+    checkpoint_revision: str | None,
+    local_files_only: bool,
+) -> Swin2SRWrapper:
+    is_local_checkpoint = Path(checkpoint).expanduser().exists()
+    if checkpoint_revision is None and not (local_files_only or is_local_checkpoint):
+        raise ValueError(
+            "--checkpoint-revision is required when --checkpoint is a remote Hugging Face model id."
+        )
+    model = Swin2SRForImageSuperResolution.from_pretrained(  # nosec B615
+        checkpoint,
+        revision=checkpoint_revision,
+        local_files_only=local_files_only,
+    ).eval()
+    return Swin2SRWrapper(model)
+
+
+def create_model_bundle(
+    model_name: str,
+    input_height: int,
+    input_width: int,
+    checkpoint: str | None = None,
+    checkpoint_revision: str | None = None,
+    local_files_only: bool = False,
+) -> SuperResolutionModelBundle:
+    if model_name not in SUPPORTED_MODELS:
+        raise ValueError(
+            f"Unsupported model '{model_name}'. Supported models: {SUPPORTED_MODELS}"
+        )
+    if input_height <= 0 or input_width <= 0:
+        raise ValueError("Input dimensions must be positive.")
+
+    if checkpoint is None:
+        raise ValueError("--checkpoint is required when --model-name=swin2sr.")
+    model = _load_checkpointed_swin2sr(
+        checkpoint,
+        checkpoint_revision,
+        local_files_only,
+    )
+
+    example_input = torch.rand((1, 3, input_height, input_width), dtype=torch.float32)
+    with torch.no_grad():
+        example_output = model(example_input)
+
+    if example_output.dim() != 4:
+        raise ValueError(
+            f"Expected a 4D reconstruction tensor, got {tuple(example_output.shape)}."
+        )
+
+    model_impl = model.model
+    return SuperResolutionModelBundle(
+        model_name=model_name,
+        model=model,
+        example_inputs=(example_input,),
+        input_shape=tuple(example_input.shape),
+        output_shape=tuple(example_output.shape),
+        input_dtype=str(example_input.dtype).replace("torch.", ""),
+        output_dtype=str(example_output.dtype).replace("torch.", ""),
+        upscale=int(model_impl.config.upscale),
+        window_size=int(model_impl.config.window_size),
+    )
+
+
+def _gaussian_window(
+    channels: int,
+    device: torch.device,
+    dtype: torch.dtype,
+    height: int,
+    width: int,
+) -> torch.Tensor:
+    window_size = min(11, height, width)
+    if window_size % 2 == 0:
+        window_size -= 1
+    window_size = max(window_size, 1)
+    sigma = max(window_size / 6.0, 1e-3)
+
+    coords = torch.arange(window_size, device=device, dtype=dtype) - window_size // 2
+    kernel_1d = torch.exp(-(coords**2) / (2 * sigma**2))
+    kernel_1d = kernel_1d / kernel_1d.sum()
+    kernel_2d = torch.outer(kernel_1d, kernel_1d)
+    return kernel_2d.expand(channels, 1, window_size, window_size).contiguous()
+
+
+def batch_psnr(prediction: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+    mse = F.mse_loss(prediction, target, reduction="none").mean(dim=(1, 2, 3))
+    return 10.0 * torch.log10(1.0 / mse.clamp_min(1e-12))
+
+
+def batch_ssim(prediction: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+    channels = prediction.shape[1]
+    kernel = _gaussian_window(
+        channels,
+        prediction.device,
+        prediction.dtype,
+        prediction.shape[-2],
+        prediction.shape[-1],
+    )
+    padding = kernel.shape[-1] // 2
+    c1 = 0.01**2
+    c2 = 0.03**2
+
+    mu_x = F.conv2d(prediction, kernel, padding=padding, groups=channels)
+    mu_y = F.conv2d(target, kernel, padding=padding, groups=channels)
+
+    mu_x_sq = mu_x.pow(2)
+    mu_y_sq = mu_y.pow(2)
+    mu_xy = mu_x * mu_y
+
+    sigma_x_sq = (
+        F.conv2d(prediction * prediction, kernel, padding=padding, groups=channels)
+        - mu_x_sq
+    )
+    sigma_y_sq = (
+        F.conv2d(target * target, kernel, padding=padding, groups=channels) - mu_y_sq
+    )
+    sigma_xy = (
+        F.conv2d(prediction * target, kernel, padding=padding, groups=channels) - mu_xy
+    )
+
+    ssim_map = ((2 * mu_xy + c1) * (2 * sigma_xy + c2)) / (
+        (mu_x_sq + mu_y_sq + c1) * (sigma_x_sq + sigma_y_sq + c2)
+    )
+    return ssim_map.mean(dim=(1, 2, 3))
+
+
+def _model_reconstruction(
+    model: torch.nn.Module,
+    input_tensor: torch.Tensor,
+) -> torch.Tensor:
+    output = model(input_tensor)
+    if hasattr(output, "reconstruction"):
+        output = output.reconstruction
+    if not isinstance(output, torch.Tensor):
+        raise TypeError(f"Expected tensor output, got {type(output)}")
+    return output
+
+
+def evaluate_super_resolution_model(
+    model: torch.nn.Module,
+    dataset: Iterable[tuple[torch.Tensor, torch.Tensor]],
+    device: torch.device,
+) -> dict[str, float]:
+    if hasattr(model, "eval"):
+        try:
+            model.eval()
+        except NotImplementedError:
+            pass
+
+    total_l1 = 0.0
+    total_psnr = 0.0
+    total_ssim = 0.0
+    total_examples = 0
+
+    with torch.no_grad():
+        for lr_tensor, hr_tensor in dataset:
+            lr_tensor = lr_tensor.to(device)
+            hr_tensor = hr_tensor.to(device)
+            prediction = _model_reconstruction(model, lr_tensor).clamp(0.0, 1.0)
+
+            l1_values = F.l1_loss(prediction, hr_tensor, reduction="none").mean(
+                dim=(1, 2, 3)
+            )
+            psnr_values = batch_psnr(prediction, hr_tensor)
+            ssim_values = batch_ssim(prediction, hr_tensor)
+
+            batch_size = lr_tensor.shape[0]
+            total_l1 += l1_values.sum().item()
+            total_psnr += psnr_values.sum().item()
+            total_ssim += ssim_values.sum().item()
+            total_examples += batch_size
+
+    if total_examples == 0:
+        raise ValueError("Evaluation dataset is empty.")
+
+    return {
+        "l1": total_l1 / total_examples,
+        "psnr": total_psnr / total_examples,
+        "ssim": total_ssim / total_examples,
+        "num_samples": float(total_examples),
+    }

--- a/examples/arm/super_resolution_example_vgf/model_export/export_super_resolution.py
+++ b/examples/arm/super_resolution_example_vgf/model_export/export_super_resolution.py
@@ -1,0 +1,365 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import torch
+
+from executorch.backends.arm.quantizer import (
+    get_symmetric_quantization_config,
+    VgfQuantizer,
+)
+from executorch.backends.arm.vgf import VgfCompileSpec, VgfPartitioner
+from executorch.devtools.backend_debug import get_delegation_info
+from executorch.exir import (
+    EdgeCompileConfig,
+    ExecutorchBackendConfig,
+    to_edge_transform_and_lower,
+)
+from executorch.extension.export_util.utils import save_pte_program
+from torch.utils.data import DataLoader
+from torchao.quantization.pt2e.quantize_pt2e import convert_pt2e, prepare_pt2e
+
+# Keep script-compatible imports without requiring package execution.
+if __package__ is None or __package__ == "":
+    import sys
+
+    sys.path.append(str(Path(__file__).resolve().parent))
+    from common import (  # type: ignore[no-redef]
+        create_model_bundle,
+        evaluate_super_resolution_model,
+        load_calibration_inputs,
+        PairedSuperResolutionDataset,
+        SUPPORTED_MODELS,
+        write_json,
+    )
+else:
+    from .common import (
+        create_model_bundle,
+        evaluate_super_resolution_model,
+        load_calibration_inputs,
+        PairedSuperResolutionDataset,
+        SUPPORTED_MODELS,
+        write_json,
+    )
+
+CALIBRATION_MAX_SAMPLES = 1000
+EVAL_MAX_SAMPLES = 1000
+
+
+def has_quantized_out_variants() -> bool:
+    try:
+        _ = torch.ops.quantized_decomposed.quantize_per_tensor.out
+        _ = torch.ops.quantized_decomposed.dequantize_per_tensor.out
+        return True
+    except AttributeError:
+        return False
+
+
+def ensure_quantized_ops_loaded() -> Path | None:
+    if has_quantized_out_variants():
+        return None
+
+    quantized_kernels_available = False
+    try:
+        import executorch.kernels.quantized  # noqa: F401
+    except ImportError:
+        quantized_kernels_available = False
+    else:
+        quantized_kernels_available = True
+
+    if quantized_kernels_available and has_quantized_out_variants():
+        return None
+
+    repo_root = Path(__file__).resolve().parents[4]
+    search_patterns = (
+        "cmake-out/kernels/quantized/libquantized_ops_aot_lib.*",
+        "arm_test/*/kernels/quantized/libquantized_ops_aot_lib.*",
+    )
+    for pattern in search_patterns:
+        for candidate in sorted(repo_root.glob(pattern)):
+            if not candidate.is_file():
+                continue
+            torch.ops.load_library(str(candidate))
+            if has_quantized_out_variants():
+                return candidate
+
+    raise RuntimeError(
+        "INT8 export requires the quantized ops out-variant library. "
+        "Build or install ExecuTorch quantized kernels so that "
+        "`quantized_decomposed::quantize_per_tensor.out` and "
+        "`quantized_decomposed::dequantize_per_tensor.out` are available."
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Export a Swin2SR model for VGF.")
+    parser.add_argument(
+        "--model-name",
+        choices=SUPPORTED_MODELS,
+        default="swin2sr",
+        help="Model profile to export.",
+    )
+    parser.add_argument(
+        "--checkpoint",
+        default=None,
+        help="Checkpoint directory or Hugging Face model id.",
+    )
+    parser.add_argument(
+        "--local-files-only",
+        action="store_true",
+        help="Resolve Hugging Face assets from local cache only.",
+    )
+    parser.add_argument(
+        "--checkpoint-revision",
+        default=None,
+        help=(
+            "Pinned Hugging Face revision to use when --checkpoint points to a model id. "
+            "Required for remote checkpoints; ignored for local checkpoint paths."
+        ),
+    )
+    parser.add_argument(
+        "--input-height",
+        type=int,
+        default=64,
+        help="Static low-resolution input height used for export.",
+    )
+    parser.add_argument(
+        "--input-width",
+        type=int,
+        default=64,
+        help="Static low-resolution input width used for export.",
+    )
+    parser.add_argument(
+        "--output-path",
+        type=str,
+        required=True,
+        help="Destination .pte path.",
+    )
+    parser.add_argument(
+        "--quantization-mode",
+        choices=("none", "int8"),
+        default="none",
+        help="Quantization mode used before lowering to VGF.",
+    )
+    parser.add_argument(
+        "--calibration-lr-dir",
+        default=None,
+        help=(
+            "Directory of low-resolution images used for PTQ calibration. "
+            "Required when --quantization-mode=int8."
+        ),
+    )
+    parser.add_argument(
+        "--num-calibration-samples",
+        type=int,
+        default=32,
+        help="Maximum number of calibration images to use.",
+    )
+    parser.add_argument(
+        "--eval-lr-dir",
+        default=None,
+        help="Optional directory of low-resolution evaluation images.",
+    )
+    parser.add_argument(
+        "--eval-hr-dir",
+        default=None,
+        help="Optional directory of high-resolution evaluation targets.",
+    )
+    parser.add_argument(
+        "--num-eval-samples",
+        type=int,
+        default=100,
+        help="Maximum number of evaluation image pairs to use.",
+    )
+    parser.add_argument(
+        "--artifact-dir",
+        default=None,
+        help="Optional directory for intermediate VGF/TOSA artifacts.",
+    )
+    return parser.parse_args()
+
+
+def quantize_model(
+    model: torch.nn.Module,
+    quantizer: VgfQuantizer,
+    example_inputs: tuple[torch.Tensor],
+    calibration_samples: list[tuple[torch.Tensor]],
+) -> torch.export.ExportedProgram:
+    exported_program = torch.export.export(model, example_inputs)
+    graph_module = exported_program.module(check_guards=False)
+
+    prepared = prepare_pt2e(graph_module, quantizer)
+    for sample in calibration_samples:
+        prepared(*sample)
+
+    quantized_model = convert_pt2e(prepared)
+    return torch.export.export(quantized_model, example_inputs)
+
+
+def write_delegation_report(edge_program_manager, report_path: Path) -> None:
+    delegation_info = get_delegation_info(
+        edge_program_manager.exported_program().graph_module
+    )
+    report_path.write_text(delegation_info.get_summary() + "\n")
+
+
+def maybe_make_eval_loader(
+    eval_lr_dir: str | None,
+    eval_hr_dir: str | None,
+    input_height: int,
+    input_width: int,
+    upscale: int,
+    num_eval_samples: int,
+) -> DataLoader[tuple[torch.Tensor, torch.Tensor]] | None:
+    if eval_lr_dir is None and eval_hr_dir is None:
+        return None
+    if (eval_lr_dir is None) != (eval_hr_dir is None):
+        raise ValueError("--eval-lr-dir and --eval-hr-dir must be provided together.")
+
+    eval_dataset = PairedSuperResolutionDataset(
+        eval_lr_dir,
+        eval_hr_dir,
+        input_height,
+        input_width,
+        upscale,
+        crop_mode="center",
+        max_samples=min(num_eval_samples, EVAL_MAX_SAMPLES),
+    )
+    return DataLoader(eval_dataset, batch_size=1, shuffle=False, num_workers=0)
+
+
+def main() -> None:
+    args = parse_args()
+
+    output_path = Path(args.output_path).resolve()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    metadata_path = output_path.with_suffix(".json")
+    delegation_path = output_path.with_name(f"{output_path.stem}_delegation.txt")
+    metrics_path = output_path.with_name(f"{output_path.stem}_metrics.json")
+
+    bundle = create_model_bundle(
+        model_name=args.model_name,
+        input_height=args.input_height,
+        input_width=args.input_width,
+        checkpoint=args.checkpoint,
+        checkpoint_revision=args.checkpoint_revision,
+        local_files_only=args.local_files_only,
+    )
+
+    quantize = args.quantization_mode != "none"
+    compile_spec = VgfCompileSpec("TOSA-1.0+INT" if quantize else "TOSA-1.0+FP")
+    if args.artifact_dir is not None:
+        artifact_dir = Path(args.artifact_dir).resolve()
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        compile_spec.dump_intermediate_artifacts_to(str(artifact_dir))
+
+    calibration_samples: list[tuple[torch.Tensor]] | None = None
+    if quantize:
+        quantized_ops_library = ensure_quantized_ops_loaded()
+        if quantized_ops_library is not None:
+            print(f"Loaded quantized ops library from {quantized_ops_library}")
+        if args.calibration_lr_dir is None:
+            raise ValueError(
+                "--calibration-lr-dir is required when --quantization-mode=int8."
+            )
+        calibration_samples = load_calibration_inputs(
+            args.calibration_lr_dir,
+            args.input_height,
+            args.input_width,
+            min(args.num_calibration_samples, CALIBRATION_MAX_SAMPLES),
+        )
+
+    exported_program: torch.export.ExportedProgram
+    if quantize:
+        quantizer = VgfQuantizer(compile_spec)
+        quantizer.set_global(get_symmetric_quantization_config(is_per_channel=True))
+        exported_program = quantize_model(
+            bundle.model,
+            quantizer,
+            bundle.example_inputs,
+            calibration_samples,
+        )
+    else:
+        exported_program = torch.export.export(bundle.model, bundle.example_inputs)
+
+    eval_loader = maybe_make_eval_loader(
+        args.eval_lr_dir,
+        args.eval_hr_dir,
+        args.input_height,
+        args.input_width,
+        bundle.upscale,
+        args.num_eval_samples,
+    )
+    evaluation_metrics: dict[str, float] | None = None
+    if eval_loader is not None:
+        eval_module = exported_program.module(check_guards=False)
+        evaluation_metrics = evaluate_super_resolution_model(
+            eval_module,
+            eval_loader,
+            torch.device("cpu"),
+        )
+        write_json(metrics_path, evaluation_metrics)
+        print(
+            "Evaluation metrics: "
+            f"l1={evaluation_metrics['l1']:.6f} "
+            f"psnr={evaluation_metrics['psnr']:.4f} "
+            f"ssim={evaluation_metrics['ssim']:.4f}"
+        )
+
+    partitioner = VgfPartitioner(compile_spec)
+    edge_program_manager = to_edge_transform_and_lower(
+        programs=exported_program,
+        partitioner=[partitioner],
+        compile_config=EdgeCompileConfig(_check_ir_validity=False),
+    )
+    write_delegation_report(edge_program_manager, delegation_path)
+
+    executorch_program_manager = edge_program_manager.to_executorch(
+        config=ExecutorchBackendConfig(extract_delegate_segments=False)
+    )
+    save_pte_program(
+        executorch_program_manager,
+        str(output_path),
+        output_dir=str(output_path.parent),
+    )
+    if not output_path.is_file():
+        raise RuntimeError(f"Expected exported model at {output_path}")
+
+    write_json(
+        metadata_path,
+        {
+            "model_name": bundle.model_name,
+            "checkpoint": args.checkpoint,
+            "checkpoint_revision": args.checkpoint_revision,
+            "input_shape": list(bundle.input_shape),
+            "output_shape": list(bundle.output_shape),
+            "input_dtype": bundle.input_dtype,
+            "output_dtype": bundle.output_dtype,
+            "num_outputs": 1,
+            "upscale": bundle.upscale,
+            "window_size": bundle.window_size,
+            "quantization_mode": args.quantization_mode,
+            "num_calibration_samples": len(calibration_samples or []),
+            "num_eval_samples": (
+                int(evaluation_metrics["num_samples"])
+                if evaluation_metrics is not None
+                else 0
+            ),
+        },
+    )
+
+    print(f"Exported model saved to {output_path}")
+    print(f"Metadata saved to {metadata_path}")
+    print(f"Delegation summary saved to {delegation_path}")
+    if evaluation_metrics is not None:
+        print(f"Evaluation metrics saved to {metrics_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/arm/super_resolution_example_vgf/model_export/export_super_resolution.py
+++ b/examples/arm/super_resolution_example_vgf/model_export/export_super_resolution.py
@@ -30,7 +30,7 @@ if __package__ is None or __package__ == "":
     import sys
 
     sys.path.append(str(Path(__file__).resolve().parent))
-    from common import (  # type: ignore[no-redef]
+    from common import (  # type: ignore[import-not-found, no-redef]
         create_model_bundle,
         evaluate_super_resolution_model,
         load_calibration_inputs,
@@ -259,7 +259,7 @@ def main() -> None:
         artifact_dir.mkdir(parents=True, exist_ok=True)
         compile_spec.dump_intermediate_artifacts_to(str(artifact_dir))
 
-    calibration_samples: list[tuple[torch.Tensor]] | None = None
+    calibration_samples: list[tuple[torch.Tensor]] = []
     if quantize:
         quantized_ops_library = ensure_quantized_ops_loaded()
         if quantized_ops_library is not None:
@@ -299,17 +299,18 @@ def main() -> None:
     evaluation_metrics: dict[str, float] | None = None
     if eval_loader is not None:
         eval_module = exported_program.module(check_guards=False)
-        evaluation_metrics = evaluate_super_resolution_model(
+        metrics = evaluate_super_resolution_model(
             eval_module,
             eval_loader,
             torch.device("cpu"),
         )
-        write_json(metrics_path, evaluation_metrics)
+        evaluation_metrics = metrics
+        write_json(metrics_path, metrics)
         print(
             "Evaluation metrics: "
-            f"l1={evaluation_metrics['l1']:.6f} "
-            f"psnr={evaluation_metrics['psnr']:.4f} "
-            f"ssim={evaluation_metrics['ssim']:.4f}"
+            f"l1={metrics['l1']:.6f} "
+            f"psnr={metrics['psnr']:.4f} "
+            f"ssim={metrics['ssim']:.4f}"
         )
 
     partitioner = VgfPartitioner(compile_spec)
@@ -345,7 +346,7 @@ def main() -> None:
             "upscale": bundle.upscale,
             "window_size": bundle.window_size,
             "quantization_mode": args.quantization_mode,
-            "num_calibration_samples": len(calibration_samples or []),
+            "num_calibration_samples": len(calibration_samples),
             "num_eval_samples": (
                 int(evaluation_metrics["num_samples"])
                 if evaluation_metrics is not None

--- a/examples/arm/super_resolution_example_vgf/model_export/prepare_demo_assets.py
+++ b/examples/arm/super_resolution_example_vgf/model_export/prepare_demo_assets.py
@@ -1,0 +1,149 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from PIL import Image
+
+RUNTIME_DEMO_CROP = ("demo", 60, 420)
+CALIBRATION_CROPS = (
+    ("calib_0", 60, 280),
+    ("calib_1", 60, 420),
+    ("calib_2", 60, 560),
+    ("calib_3", 60, 700),
+)
+EVAL_CROPS = (
+    ("eval_0", 60, 420),
+    ("eval_1", 60, 700),
+)
+DEFAULT_SOURCE_IMAGE = (
+    Path(__file__).resolve().parents[4] / "docs/source/_static/img/ios_demo_app.jpg"
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Prepare a reproducible Swin2SR demo dataset from a repo-local image."
+    )
+    parser.add_argument(
+        "--output-dir",
+        required=True,
+        help="Directory where calibration, evaluation, and runtime demo assets are written.",
+    )
+    parser.add_argument(
+        "--source-image",
+        default=str(DEFAULT_SOURCE_IMAGE),
+        help="Source image used for the fixed text-heavy crops.",
+    )
+    parser.add_argument(
+        "--hr-size",
+        type=int,
+        default=128,
+        help="High-resolution crop size.",
+    )
+    parser.add_argument(
+        "--lr-size",
+        type=int,
+        default=64,
+        help="Low-resolution size written for runtime/calibration inputs.",
+    )
+    return parser.parse_args()
+
+
+def downsample_to_lr(image: Image.Image, lr_size: int) -> Image.Image:
+    return image.resize((lr_size, lr_size), Image.Resampling.BICUBIC)
+
+
+def save_image(path: Path, image: Image.Image) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    image.save(path)
+
+
+def crop_square(image: Image.Image, left: int, top: int, size: int) -> Image.Image:
+    right = left + size
+    bottom = top + size
+    if right > image.width or bottom > image.height:
+        raise ValueError(
+            f"Crop {(left, top, size)} exceeds source image bounds {image.size}."
+        )
+    return image.crop((left, top, right, bottom))
+
+
+def write_metadata(
+    output_dir: Path,
+    source_image: Path,
+    hr_size: int,
+    lr_size: int,
+) -> None:
+    metadata = {
+        "source_image": str(source_image),
+        "hr_size": hr_size,
+        "lr_size": lr_size,
+        "runtime_demo_crop": {
+            "name": RUNTIME_DEMO_CROP[0],
+            "left": RUNTIME_DEMO_CROP[1],
+            "top": RUNTIME_DEMO_CROP[2],
+        },
+        "calibration_crops": [
+            {"name": name, "left": left, "top": top}
+            for name, left, top in CALIBRATION_CROPS
+        ],
+        "eval_crops": [
+            {"name": name, "left": left, "top": top} for name, left, top in EVAL_CROPS
+        ],
+    }
+    metadata_path = output_dir / "metadata.json"
+    metadata_path.write_text(json.dumps(metadata, indent=2, sort_keys=True) + "\n")
+
+
+def main() -> None:
+    args = parse_args()
+    if args.lr_size <= 0 or args.hr_size <= 0:
+        raise ValueError("--lr-size and --hr-size must be positive.")
+    if args.hr_size != args.lr_size * 2:
+        raise ValueError("This demo helper expects x2 super-resolution sizes.")
+
+    output_dir = Path(args.output_dir).resolve()
+    source_image = Path(args.source_image).resolve()
+    if not source_image.is_file():
+        raise FileNotFoundError(f"Source image not found: {source_image}")
+
+    image = Image.open(source_image).convert("RGB")
+
+    for name, left, top in CALIBRATION_CROPS:
+        hr_crop = crop_square(image, left, top, args.hr_size)
+        lr_crop = downsample_to_lr(hr_crop, args.lr_size)
+        save_image(output_dir / "calibration/hr" / f"{name}.png", hr_crop)
+        save_image(output_dir / "calibration/lr" / f"{name}.png", lr_crop)
+
+    for name, left, top in EVAL_CROPS:
+        hr_crop = crop_square(image, left, top, args.hr_size)
+        lr_crop = downsample_to_lr(hr_crop, args.lr_size)
+        save_image(output_dir / "eval/hr" / f"{name}.png", hr_crop)
+        save_image(output_dir / "eval/lr" / f"{name}.png", lr_crop)
+
+    demo_name, demo_left, demo_top = RUNTIME_DEMO_CROP
+    demo_hr = crop_square(image, demo_left, demo_top, args.hr_size)
+    demo_lr = downsample_to_lr(demo_hr, args.lr_size)
+    save_image(output_dir / "runtime" / f"{demo_name}_hr_{args.hr_size}.png", demo_hr)
+    save_image(output_dir / "runtime" / f"{demo_name}_lr_{args.lr_size}.png", demo_lr)
+
+    write_metadata(output_dir, source_image, args.hr_size, args.lr_size)
+
+    print(f"Prepared demo assets under {output_dir}")
+    print(
+        f"Runtime input: {output_dir / 'runtime' / f'{demo_name}_lr_{args.lr_size}.png'}"
+    )
+    print(
+        f"Runtime reference: {output_dir / 'runtime' / f'{demo_name}_hr_{args.hr_size}.png'}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/arm/super_resolution_example_vgf/requirements.txt
+++ b/examples/arm/super_resolution_example_vgf/requirements.txt
@@ -1,0 +1,8 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+numpy == 2.1.3
+Pillow == 12.0.0
+transformers[torch] == 4.56.1

--- a/examples/arm/super_resolution_example_vgf/runtime/README.md
+++ b/examples/arm/super_resolution_example_vgf/runtime/README.md
@@ -1,0 +1,57 @@
+# VGF Host Runtime (executor_runner)
+
+This flow runs the VGF-exported `.pte` on host using the portable
+`executor_runner` binary built at the repo root. The runtime helper script
+serializes the input image, invokes `executor_runner`, then reconstructs the
+output image from the generated tensor bytes.
+
+For the smallest reproducible demo in this repo, first create the fixed
+text-heavy input and the small LR/HR export set:
+
+```bash
+python examples/arm/super_resolution_example_vgf/model_export/prepare_demo_assets.py \
+  --output-dir ./demo_assets
+```
+
+1. Install ML SDK dependencies and set up the environment:
+
+```bash
+examples/arm/setup.sh --disable-ethos-u-deps --enable-mlsdk-deps
+source examples/arm/arm-scratch/setup_path.sh
+```
+
+2. Build the runner with VGF enabled:
+
+```bash
+cmake -B cmake-out \
+  -DCMAKE_BUILD_TYPE=Debug \
+  -DEXECUTORCH_BUILD_EXTENSION_DATA_LOADER=ON \
+  -DEXECUTORCH_BUILD_EXTENSION_MODULE=ON \
+  -DEXECUTORCH_BUILD_EXTENSION_FLAT_TENSOR=ON \
+  -DEXECUTORCH_BUILD_EXTENSION_TENSOR=ON \
+  -DEXECUTORCH_BUILD_KERNELS_QUANTIZED=ON \
+  -DEXECUTORCH_BUILD_VULKAN=ON \
+  -DEXECUTORCH_BUILD_VGF=ON \
+  -DEXECUTORCH_ENABLE_LOGGING=ON \
+  .
+
+cmake --build cmake-out --target executor_runner
+```
+
+3. Run the exported model on an image that matches the static export size:
+
+```bash
+python examples/arm/super_resolution_example_vgf/runtime/run_super_resolution.py \
+  --model-path ./demo_assets/swin2sr_x2_vgf_fp.pte \
+  --input-image ./demo_assets/runtime/demo_lr_64.png \
+  --output-image ./demo_assets/runtime/demo_fp_128.png
+```
+
+The runtime helper reads the metadata emitted by the exporter to reconstruct the
+output tensor and save it as an image. Because the export uses static shapes,
+the input image must match the exported low-resolution dimensions exactly.
+
+Use the same runtime input with `./demo_assets/swin2sr_x2_vgf_int8.pte` to
+validate the INT8 path once the quantized export has been generated. If the
+host VKML emulation layer rejects quantized shaders, rerun that runtime step on
+Linux or on the target Vulkan driver stack.

--- a/examples/arm/super_resolution_example_vgf/runtime/run_super_resolution.py
+++ b/examples/arm/super_resolution_example_vgf/runtime/run_super_resolution.py
@@ -1,0 +1,252 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import subprocess  # nosec B404 - executes the trusted local executor_runner binary
+import tempfile
+from pathlib import Path
+from typing import Any, Sequence
+
+import numpy as np
+import torch
+from PIL import Image
+
+STRING_TO_NUMPY_DTYPE = {
+    "float16": np.float16,
+    "float32": np.float32,
+    "int8": np.int8,
+    "uint8": np.uint8,
+}
+
+
+def read_json(path: str | Path) -> dict[str, Any]:
+    return json.loads(Path(path).read_text())
+
+
+def load_image_tensor(
+    image_path: str | Path,
+    expected_shape: Sequence[int] | None = None,
+) -> torch.Tensor:
+    image = Image.open(image_path).convert("RGB")
+    image_np = np.asarray(image, dtype=np.float32) / 255.0
+    tensor = (
+        torch.from_numpy(image_np).permute(2, 0, 1).contiguous().unsqueeze(0).clone()
+    )
+    if expected_shape is not None and tuple(tensor.shape) != tuple(expected_shape):
+        raise ValueError(
+            f"Image {image_path} produces tensor shape {tuple(tensor.shape)}, "
+            f"expected {tuple(expected_shape)}."
+        )
+    return tensor
+
+
+def save_tensor_bytes(path: str | Path, tensor: torch.Tensor) -> Path:
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    array = tensor.detach().cpu().contiguous().numpy()
+    path.write_bytes(array.tobytes())
+    return path
+
+
+def load_tensor_bytes(
+    path: str | Path,
+    shape: Sequence[int],
+    dtype_name: str,
+) -> torch.Tensor:
+    np_dtype = STRING_TO_NUMPY_DTYPE.get(dtype_name)
+    if np_dtype is None:
+        raise ValueError(f"Unsupported tensor dtype in metadata: {dtype_name}")
+
+    array = np.fromfile(path, dtype=np_dtype)
+    expected_numel = math.prod(shape)
+    if array.size != expected_numel:
+        raise ValueError(
+            f"Tensor file {path} contains {array.size} values, expected {expected_numel}."
+        )
+
+    reshaped = array.reshape(tuple(shape)).copy()
+    return torch.from_numpy(reshaped)
+
+
+def save_image_tensor(path: str | Path, tensor: torch.Tensor) -> Path:
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    image = tensor.detach().cpu()
+    if image.dim() == 4:
+        if image.shape[0] != 1:
+            raise ValueError(
+                "Only batch size 1 is supported when writing image output."
+            )
+        image = image[0]
+
+    if image.dim() != 3:
+        raise ValueError(f"Expected CHW image tensor, got shape {tuple(image.shape)}.")
+
+    channels = image.shape[0]
+    if channels not in {1, 3}:
+        raise ValueError(f"Expected 1 or 3 channels, got {channels}.")
+
+    image = image.clamp(0.0, 1.0)
+    image_np = (
+        image.permute(1, 2, 0).mul(255.0).round().to(torch.uint8).contiguous().numpy()
+    )
+
+    if channels == 1:
+        pil_image = Image.fromarray(image_np[..., 0], mode="L")
+    else:
+        pil_image = Image.fromarray(image_np, mode="RGB")
+    pil_image.save(path)
+    return path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run a VGF-exported Swin2SR model with executor_runner."
+    )
+    parser.add_argument(
+        "--model-path",
+        required=True,
+        help="Path to the exported .pte file.",
+    )
+    parser.add_argument(
+        "--metadata-path",
+        default=None,
+        help="Optional metadata JSON path. Defaults to <model>.json.",
+    )
+    parser.add_argument(
+        "--runner",
+        default="./cmake-out/executor_runner",
+        help="Path to the host executor_runner binary built with VGF support.",
+    )
+    parser.add_argument(
+        "--input-image",
+        required=True,
+        help="Low-resolution input image.",
+    )
+    parser.add_argument(
+        "--output-image",
+        required=True,
+        help="High-resolution output image path.",
+    )
+    parser.add_argument(
+        "--working-dir",
+        default=None,
+        help="Optional directory for temporary input/output tensor files.",
+    )
+    return parser.parse_args()
+
+
+def resolve_metadata_path(model_path: Path, metadata_path: str | None) -> Path:
+    if metadata_path is not None:
+        return Path(metadata_path).resolve()
+    return model_path.with_suffix(".json")
+
+
+def run_executor_runner(
+    runner: Path,
+    model_path: Path,
+    input_file: Path,
+    output_base: Path,
+) -> subprocess.CompletedProcess[str]:
+    command = [
+        str(runner),
+        "--model_path",
+        str(model_path),
+        "--inputs",
+        str(input_file),
+        "--output_file",
+        str(output_base),
+        "--print_output",
+        "none",
+    ]
+    return subprocess.run(  # nosec B603 - command list is assembled without a shell
+        command,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def main() -> None:
+    args = parse_args()
+    model_path = Path(args.model_path).resolve()
+    metadata_path = resolve_metadata_path(model_path, args.metadata_path)
+    runner_path = Path(args.runner).resolve()
+
+    if not model_path.is_file():
+        raise FileNotFoundError(f"Model file not found: {model_path}")
+    if not metadata_path.is_file():
+        raise FileNotFoundError(f"Metadata file not found: {metadata_path}")
+    if not runner_path.is_file():
+        raise FileNotFoundError(f"executor_runner not found: {runner_path}")
+
+    metadata = read_json(metadata_path)
+    if metadata.get("num_outputs") != 1:
+        raise ValueError(
+            "The runtime helper currently supports single-output models only."
+        )
+
+    if args.working_dir is None:
+        with tempfile.TemporaryDirectory(prefix="executorch-sr-vgf-") as tmp_dir:
+            workdir = Path(tmp_dir)
+            run_once(
+                model_path=model_path,
+                metadata=metadata,
+                runner_path=runner_path,
+                input_image=Path(args.input_image),
+                output_image=Path(args.output_image),
+                working_dir=workdir,
+            )
+    else:
+        workdir = Path(args.working_dir).resolve()
+        workdir.mkdir(parents=True, exist_ok=True)
+        run_once(
+            model_path=model_path,
+            metadata=metadata,
+            runner_path=runner_path,
+            input_image=Path(args.input_image),
+            output_image=Path(args.output_image),
+            working_dir=workdir,
+        )
+
+
+def run_once(
+    model_path: Path,
+    metadata: dict,
+    runner_path: Path,
+    input_image: Path,
+    output_image: Path,
+    working_dir: Path,
+) -> None:
+    input_tensor = load_image_tensor(input_image, metadata["input_shape"])
+    input_path = save_tensor_bytes(working_dir / "input0.bin", input_tensor)
+    output_base = working_dir / "output"
+
+    result = run_executor_runner(runner_path, model_path, input_path, output_base)
+    if result.stdout:
+        print(result.stdout.strip())
+    if result.returncode != 0:
+        raise RuntimeError(
+            "executor_runner failed.\n"
+            f"stdout:\n{result.stdout}\n"
+            f"stderr:\n{result.stderr}"
+        )
+
+    output_tensor = load_tensor_bytes(
+        output_base.with_name(f"{output_base.name}-0.bin"),
+        metadata["output_shape"],
+        metadata["output_dtype"],
+    )
+    save_image_tensor(output_image, output_tensor)
+    print(f"Saved super-resolved image to {output_image.resolve()}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Summary
- Adds a VGF Swin2SR super-resolution example for Arm.
- Adds FP and INT8 export/eval flows with deterministic demo assets.
- Adds Arm OOTB smoke coverage and model tests.

Validation
- bash -n backends/arm/test/test_arm_ootb.sh
- PYTHONPATH=. /Users/usazah01/src/executorch/env/bin/python -m pytest -q -p no:rerunfailures backends/arm/test/models/test_swin2sr_arm.py -s
- PATH=/Users/usazah01/src/executorch/env/bin:$PATH backends/arm/scripts/pre-push


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani