### PR TITLE
Fix sign-compare errors in quantized cpu kernels for Zephyr/GCC builds (#19671)

### DIFF
--- a/kernels/quantized/cpu/embeddingxb.cpp
+++ b/kernels/quantized/cpu/embeddingxb.cpp
@@ -224,7 +224,7 @@ void resize_out_tensor(
     Tensor& out,
     int weight_nbit) {
   executorch::aten::SizesType expected_output_size[kTensorDimensionLimit];
-  for (size_t i = 0; i < indices.dim(); i++) {
+  for (ssize_t i = 0; i < indices.dim(); i++) {
     expected_output_size[i] = indices.size(i);
   }
   const size_t embedding_dim = get_embedding_dim(weight.size(1), weight_nbit);

--- a/kernels/quantized/cpu/op_dequantize.cpp
+++ b/kernels/quantized/cpu/op_dequantize.cpp
@@ -590,7 +590,7 @@ Tensor& dequantize_per_token_out(
     Tensor& out) {
   // Refactor this into a util
   size_t num_channels = 1;
-  for (size_t i = 0; i < input.dim() - 1; i++) {
+  for (ssize_t i = 0; i < input.dim() - 1; i++) {
     num_channels *= input.size(i);
   }
   // This unfortunate change is needed because we compile op_quantize for aten

--- a/kernels/quantized/cpu/op_embedding.cpp
+++ b/kernels/quantized/cpu/op_embedding.cpp
@@ -200,7 +200,7 @@ void resize_out_tensor(
     const Tensor& indices,
     Tensor& out) {
   executorch::aten::SizesType expected_output_size[kTensorDimensionLimit];
-  for (size_t i = 0; i < indices.dim(); i++) {
+  for (ssize_t i = 0; i < indices.dim(); i++) {
     expected_output_size[i] = indices.size(i);
   }
   const size_t embedding_dim = weight.size(1);

--- a/kernels/quantized/cpu/op_quantize.cpp
+++ b/kernels/quantized/cpu/op_quantize.cpp
@@ -642,7 +642,7 @@ Tensor& quantize_per_token_out(
     ScalarType dtype,
     Tensor& out) {
   size_t num_tokens = 1;
-  for (size_t i = 0; i < input.dim() - 1; i++) {
+  for (ssize_t i = 0; i < input.dim() - 1; i++) {
     num_tokens *= input.size(i);
   }
 // This unfortunate change is needed because we compile op_quantize for aten

--- a/kernels/test/custom_kernel_example/op_relu.cpp
+++ b/kernels/test/custom_kernel_example/op_relu.cpp
@@ -38,7 +38,7 @@ void relu(const Tensor& input, Tensor& output) {
   CTYPE* out_data = output.data_ptr<CTYPE>();
   size_t lim = input.numel();
   Tensor::SizesType expected_output_size[16];
-  for (size_t i = 0; i < output.dim(); ++i) {
+  for (ssize_t i = 0; i < output.dim(); ++i) {
     expected_output_size[i] = input.size(i);
   }
   auto error = resize_tensor(

--- a/kernels/test/op_split_copy_test.cpp
+++ b/kernels/test/op_split_copy_test.cpp
@@ -288,7 +288,7 @@ TEST_F(OpSplitCopyTensorOutTest, LargerSplitSizeDoesNothing) {
   std::vector<Tensor> expected_out = {input};
 
   for (int64_t split_size = 3; split_size < 6; ++split_size) {
-    for (size_t dim = 0; dim < input.dim(); ++dim) {
+    for (ssize_t dim = 0; dim < input.dim(); ++dim) {
       TensorList out = tlf.zeros_like({input});
       op_split_copy_tensor_out(input, split_size, dim, out);
       EXPECT_TENSOR_LISTS_EQ(out, expected_out);


### PR DESCRIPTION
Summary:

## Why?
The Zephyr firmware target `tycho_t3c-tsn_graph_simulator_mps3_an547_cmake` failed
to compile `xplat/executorch/kernels/quantized/cpu/embeddingxb.cpp` under
`-Werror=sign-compare`. The loop variable was declared `size_t` (unsigned) but
compared against `Tensor::dim()`, which returns `ssize_t` (signed). On 64-bit
host toolchains the warning is often suppressed or both types match in width, so
the regression slipped in via D90402567 (int32 indices support). On the 32-bit
Zephyr ARM target the mismatch is fatal. Several sibling kernels in the same
directory have the identical latent pattern and would break the moment they get
pulled into a Zephyr build path.

## What?
Match the loop variable's type to the signed return type of `Tensor::dim()` by
switching `size_t` to `ssize_t` everywhere this pattern appears in the quantized
cpu kernels and two test files. This is also the safer pattern — casting to
`size_t` would turn a negative `dim()` into `SIZE_MAX` and overflow the
fixed-size stack buffer used for sizes. The change is mirrored across the
xplat and fbcode copies so the diff_train sync stays consistent.

Differential Revision: D105701588


