### PR TITLE
Add output_linear_intermediate_dim support for ExecuTorch Llama4 backbone export

### DIFF
--- a/examples/models/llama/model_args.py
+++ b/examples/models/llama/model_args.py
@@ -181,6 +181,7 @@ class ModelArgs:
     use_residual_gate: bool = False
     use_ffn_learnable_scales: bool = False
     output_soft_cap_temp: Optional[float] = None
+    output_linear_intermediate_dim: int = 0
 
     def __post_init__(self):  # noqa: C901
         if self.n_kv_heads is None:


### PR DESCRIPTION
Summary:
Adds support for the two-layer output projection (dim -> output_linear_intermediate_dim -> vocab_size) introduced in D90355015 to the ExecuTorch backbone export path. When output_linear_intermediate_dim > 0 in the model config, an output_intermediate_linear layer is inserted before the text output head in both MultimodalTransformer and DiscreteSpeechMultimodalTransformer. Speech output heads continue projecting directly from dim, matching the rlformers training architecture.


The QAT checkpoint loading path is also updated to handle linear layers whose weights lack pre-quantized .scales entries. A new _quantize_float_weights_for_pre_quantization helper performs on-the-fly int4 post-training quantization (per-group absmax scaling) for any such float nn.Linear weights, ensuring all linears are uniformly converted to Int8DynActInt4WeightLinear by _transform_for_pre_quantization. This avoids mixing the dequantize_per_channel_group decomposition (from pre-quantized layers) with the dequantize_affine decomposition (from torchao's Int8DynamicActivationIntxWeightConfig), which XNNPACK cannot lower because it defaults to int8 qmin/qmax range for affine ops without explicit bounds.

Differential Revision: D105658371


