### PR TITLE
Allow passes to operate on unlifted graph modules (#19674)

### DIFF
--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -224,6 +224,7 @@ def _transform(
     self,
     *passes: PassType,
     override_verifiers: None | list[Type[Verifier]] = None,
+    keep_lifted: bool = True
 ) -> "ExportedProgram":
     """
     Transforms the program according to the provided passes.
@@ -243,14 +244,15 @@ def _transform(
     ), f"Expected all passes to be of PassType, not list or Verifier. Use override_verifiers kwarg instead. Got: {list(passes)}"
 
     return _transform_with_pass_manager(
-        self, PassManager(list(passes)), override_verifiers
+        self, PassManager(list(passes)), override_verifiers, keep_lifted
     )
 
 
 def _transform_with_pass_manager(
-    self,
+    self: "ExportedProgram",
     pass_manager: PassManager,
     override_verifiers: None | list[Type[Verifier]] = None,
+    keep_lifted: bool = True
 ) -> "ExportedProgram":
     """
     Transforms the program using the provided pass_manager.
@@ -260,20 +262,48 @@ def _transform_with_pass_manager(
         pass_manager: An instance of PassManager to apply transformations.
         override_verifiers: Optional list of verifier classes to use instead of the default verifiers.
             This is needed if the transforms yields illegal graph that the default verifier cannot handle.
+        keep_lifted: If True, does not lower constants from exported program state dict/constants/buffers into the
+            graph module. Else, it does, which is useful for passes which need to modify constants.
 
     Returns:
         ExportedProgram: A new ExportedProgram with the transformations applied, or self if no changes were made
     """
-    res = pass_manager(self.graph_module)
-    transformed_gm = res.graph_module if res is not None else self.graph_module
-    assert transformed_gm is not None
+    if keep_lifted:
+        graph_module = self.graph_module
+    else:
+        graph_module = self.module()
+
+    res = pass_manager(graph_module)
+    transformed_gm = res.graph_module
 
     if transformed_gm is self.graph_module and not res.modified:
         return self
 
-    return _update_exported_program_graph_module(
-        self, transformed_gm, override_verifiers
-    )
+
+    if keep_lifted:
+        return _update_exported_program_graph_module(
+            self, transformed_gm, override_verifiers
+        )
+    else:
+        # Lift the constants from the graph module back
+        # into the exported program
+        ep = copy.deepcopy(self)
+        ep._graph_module = transformed_gm
+        ep.graph_signature.input_specs = [
+            s for s in ep.graph_signature.input_specs
+            if s.kind == InputKind.USER_INPUT
+        ]
+        # Clear stale state before re-lifting: lift_constant_tensor_pass only
+        # appends new BUFFER entries and never removes existing ones, so we must
+        # start from a clean slate to avoid duplicates from the original signature.
+        ep._state_dict.clear()
+        ep._constants.clear()
+        ep._range_constraints = _get_updated_range_constraints(transformed_gm)
+        lift_constant_tensor_pass(ep)
+        verifiers = override_verifiers or [self.verifier]
+        for verifier in verifiers:
+            verifier()(ep.graph_module)
+        return ep
 
 
 def _update_exported_program_graph_module(
@@ -1606,6 +1636,7 @@ class EdgeProgramManager:
         self,
         passes: Union[Sequence[PassType], Dict[str, Sequence[PassType]], PassManager],
         compile_config: Optional[EdgeCompileConfig] = None,
+        keep_lifted: bool = True
     ) -> "EdgeProgramManager":
         """
         Transforms the program according to the provided passes.
@@ -1658,11 +1689,11 @@ class EdgeProgramManager:
 
             # Depending on the passes parameter, call the corresponding transform function.
             if passes_seq is not None:
-                new_programs[name] = _transform(program, *passes_seq)
+                new_programs[name] = _transform(program, *passes_seq, keep_lifted=keep_lifted)
             elif passes_dict is not None:
-                new_programs[name] = _transform(program, *passes_dict[name])
+                new_programs[name] = _transform(program, *passes_dict[name], keep_lifted=keep_lifted)
             elif pass_manager is not None:
-                new_programs[name] = _transform_with_pass_manager(program, pass_manager)
+                new_programs[name] = _transform_with_pass_manager(program, pass_manager, keep_lifted=keep_lifted)
 
             # Verify the correctness of model graph after each transformation.
             EXIREdgeDialectVerifier(edge_compile_config=compile_config)(

--- a/exir/program/test/test_program.py
+++ b/exir/program/test/test_program.py
@@ -19,7 +19,7 @@ from executorch.exir.backend.test.op_partitioner_demo import (
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.error import ExportError, InternalError
 from executorch.exir.lowered_backend_module import get_lowered_submodules
-from executorch.exir.pass_base import ExportPass
+from executorch.exir.pass_base import ExportPass, PassResult
 from executorch.exir.passes import MemoryPlanningPass
 from executorch.exir.program._program import (
     _transform,
@@ -36,6 +36,7 @@ from executorch.extension.pybindings.portable_lib import (
 )
 from torch._export.verifier import Verifier
 from torch.export import Dim, export, ExportedProgram
+from torch.export.exported_program import InputKind
 from torch.export._trace import _export
 from torch.fx.passes.infra.pass_manager import PassManager
 
@@ -930,6 +931,284 @@ class TestProgramManagers(unittest.TestCase):
         et = edge.to_executorch()
         with self.assertRaises(ValueError):
             _ = et.save("/tmp/test_save.pt")
+
+    def test_transform_keep_lifted_false_fuses_constants(self):
+        """Test that transform with keep_lifted=False allows passes to fuse constants."""
+
+        for const_type in ("buffer", "parameter"):
+            with self.subTest(const_type=const_type):
+                self._test_transform_keep_lifted_false_fuses_constants(const_type)
+
+    def _test_transform_keep_lifted_false_fuses_constants(self, const_type):
+        use_param = const_type == "parameter"
+
+        class TwoConstants(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                if use_param:
+                    self.c1 = torch.nn.Parameter(torch.tensor([2.0]))
+                    self.c2 = torch.nn.Parameter(torch.tensor([3.0]))
+                else:
+                    self.register_buffer("c1", torch.tensor([2.0]))
+                    self.register_buffer("c2", torch.tensor([3.0]))
+
+            def forward(self, x, y):
+                return (x + y) * self.c1 * self.c2
+
+        class FuseConstantMulPass(ExportPass):
+            """Fuses two consecutive multiplications by constants into one."""
+
+            def _remove_attr(self, graph_module, name):
+                if name in graph_module._buffers:
+                    del graph_module._buffers[name]
+                elif name in graph_module._parameters:
+                    del graph_module._parameters[name]
+
+            def call(self, graph_module):
+                graph = graph_module.graph
+                mul_target = exir_ops.edge.aten.mul.Tensor
+                for node in graph.find_nodes(op="call_function", target=mul_target):
+                    lhs, rhs = node.args[0], node.args[1]
+                    if lhs.op != "call_function" or lhs.target != mul_target:
+                        continue
+                    inner_lhs, inner_rhs = lhs.args[0], lhs.args[1]
+                    if inner_rhs.op != "get_attr" or rhs.op != "get_attr":
+                        continue
+
+                    c1 = getattr(graph_module, inner_rhs.target)
+                    c2 = getattr(graph_module, rhs.target)
+                    fused_name = "fused_constant"
+                    setattr(graph_module, fused_name, c1 * c2)
+
+                    with graph.inserting_before(node):
+                        fused_node = graph.get_attr(fused_name)
+                        fused_node.meta = dict(rhs.meta)
+                        new_mul = graph.call_function(mul_target, (inner_lhs, fused_node), {})
+                        new_mul.meta = dict(node.meta)
+
+                    node.replace_all_uses_with(new_mul)
+                    graph.erase_node(node)
+                    if len(lhs.users) == 0:
+                        graph.erase_node(lhs)
+                    if len(rhs.users) == 0:
+                        graph.erase_node(rhs)
+                        self._remove_attr(graph_module, rhs.target)
+                    if len(inner_rhs.users) == 0:
+                        graph.erase_node(inner_rhs)
+                        self._remove_attr(graph_module, inner_rhs.target)
+
+                graph.lint()
+                graph_module.recompile()
+                return PassResult(graph_module, True)
+
+        model = TwoConstants()
+        inp = (torch.tensor([5.0]), torch.tensor([1.0]))
+        expected = model(*inp)
+
+        program = export(model, inp, strict=True)
+        edge = to_edge(program)
+
+        original_ep = edge.exported_program()
+        original_const_count = sum(
+            1
+            for s in original_ep.graph_signature.input_specs
+            if s.kind != InputKind.USER_INPUT
+        )
+        self.assertEqual(original_const_count, 2)
+
+        transformed_edge = edge.transform(
+            [FuseConstantMulPass()], keep_lifted=False
+        )
+
+        transformed_ep = transformed_edge.exported_program()
+
+        new_buffer_count = sum(
+            1
+            for s in transformed_ep.graph_signature.input_specs
+            if s.kind == InputKind.BUFFER
+        )
+        self.assertEqual(new_buffer_count, 1)
+        self.assertEqual(len(transformed_ep.state_dict), 1)
+
+        user_input_count = sum(
+            1
+            for s in transformed_ep.graph_signature.input_specs
+            if s.kind == InputKind.USER_INPUT
+        )
+        self.assertEqual(user_input_count, 2)
+
+        result = transformed_ep.module()(*inp)
+        self.assertTrue(torch.allclose(result, expected))
+
+    def test_transform_keep_lifted_false_adds_constant(self):
+        """Test that transform with keep_lifted=False allows passes to add new constants."""
+
+        for const_type in ("buffer", "parameter"):
+            with self.subTest(const_type=const_type):
+                self._test_transform_keep_lifted_false_adds_constant(const_type)
+
+    def _test_transform_keep_lifted_false_adds_constant(self, const_type):
+        use_param = const_type == "parameter"
+
+        class OneConstant(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                if use_param:
+                    self.c1 = torch.nn.Parameter(torch.tensor([2.0]))
+                else:
+                    self.register_buffer("c1", torch.tensor([2.0]))
+
+            def forward(self, x, y):
+                return (x + y) * self.c1
+
+        class AddConstantPass(ExportPass):
+            """Adds a new constant and multiplies the result by it."""
+
+            def call(self, graph_module):
+                graph = graph_module.graph
+                output_node = graph.output_node()
+                result_node = output_node.args[0][0]
+
+                new_const = torch.tensor([3.0])
+                setattr(graph_module, "added_constant", new_const)
+
+                with graph.inserting_before(output_node):
+                    const_node = graph.get_attr("added_constant")
+                    const_node.meta = dict(result_node.meta)
+                    mul_target = exir_ops.edge.aten.mul.Tensor
+                    new_mul = graph.call_function(mul_target, (result_node, const_node), {})
+                    new_mul.meta = dict(result_node.meta)
+
+                output_node.args = ((new_mul,),)
+                graph.lint()
+                graph_module.recompile()
+                return PassResult(graph_module, True)
+
+        model = OneConstant()
+        inp = (torch.tensor([5.0]), torch.tensor([1.0]))
+
+        program = export(model, inp, strict=True)
+        edge = to_edge(program)
+
+        original_ep = edge.exported_program()
+        original_const_count = sum(
+            1
+            for s in original_ep.graph_signature.input_specs
+            if s.kind != InputKind.USER_INPUT
+        )
+        self.assertEqual(original_const_count, 1)
+
+        transformed_edge = edge.transform(
+            [AddConstantPass()], keep_lifted=False
+        )
+        transformed_ep = transformed_edge.exported_program()
+
+        new_buffer_count = sum(
+            1
+            for s in transformed_ep.graph_signature.input_specs
+            if s.kind == InputKind.BUFFER
+        )
+        self.assertEqual(new_buffer_count, 2)
+        self.assertEqual(len(transformed_ep.state_dict), 2)
+
+        user_input_count = sum(
+            1
+            for s in transformed_ep.graph_signature.input_specs
+            if s.kind == InputKind.USER_INPUT
+        )
+        self.assertEqual(user_input_count, 2)
+
+        result = transformed_ep.module()(*inp)
+        expected = (torch.tensor([5.0]) + torch.tensor([1.0])) * 2.0 * 3.0
+        self.assertTrue(torch.allclose(result, expected))
+
+    def test_transform_keep_lifted_false_removes_constant(self):
+        """Test that transform with keep_lifted=False allows passes to remove constants."""
+
+        for const_type in ("buffer", "parameter"):
+            with self.subTest(const_type=const_type):
+                self._test_transform_keep_lifted_false_removes_constant(const_type)
+
+    def _test_transform_keep_lifted_false_removes_constant(self, const_type):
+        use_param = const_type == "parameter"
+
+        class TwoConstants(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                if use_param:
+                    self.c1 = torch.nn.Parameter(torch.tensor([2.0]))
+                    self.c2 = torch.nn.Parameter(torch.tensor([3.0]))
+                else:
+                    self.register_buffer("c1", torch.tensor([2.0]))
+                    self.register_buffer("c2", torch.tensor([3.0]))
+
+            def forward(self, x, y):
+                return (x + y) * self.c1 + self.c2
+
+        class RemoveAddConstantPass(ExportPass):
+            """Removes the add-constant and just returns (x + y) * c1."""
+
+            def _remove_attr(self, graph_module, name):
+                if name in graph_module._buffers:
+                    del graph_module._buffers[name]
+                elif name in graph_module._parameters:
+                    del graph_module._parameters[name]
+
+            def call(self, graph_module):
+                graph = graph_module.graph
+                add_target = exir_ops.edge.aten.add.Tensor
+                for node in graph.find_nodes(op="call_function", target=add_target):
+                    lhs, rhs = node.args[0], node.args[1]
+                    if rhs.op != "get_attr":
+                        continue
+                    node.replace_all_uses_with(lhs)
+                    graph.erase_node(node)
+                    if len(rhs.users) == 0:
+                        rhs_target = rhs.target
+                        graph.erase_node(rhs)
+                        self._remove_attr(graph_module, rhs_target)
+
+                graph.lint()
+                graph_module.recompile()
+                return PassResult(graph_module, True)
+
+        model = TwoConstants()
+        inp = (torch.tensor([5.0]), torch.tensor([1.0]))
+
+        program = export(model, inp, strict=True)
+        edge = to_edge(program)
+
+        original_ep = edge.exported_program()
+        original_const_count = sum(
+            1
+            for s in original_ep.graph_signature.input_specs
+            if s.kind != InputKind.USER_INPUT
+        )
+        self.assertEqual(original_const_count, 2)
+
+        transformed_edge = edge.transform(
+            [RemoveAddConstantPass()], keep_lifted=False
+        )
+        transformed_ep = transformed_edge.exported_program()
+
+        new_buffer_count = sum(
+            1
+            for s in transformed_ep.graph_signature.input_specs
+            if s.kind == InputKind.BUFFER
+        )
+        self.assertEqual(new_buffer_count, 1)
+        self.assertEqual(len(transformed_ep.state_dict), 1)
+
+        user_input_count = sum(
+            1
+            for s in transformed_ep.graph_signature.input_specs
+            if s.kind == InputKind.USER_INPUT
+        )
+        self.assertEqual(user_input_count, 2)
+
+        result = transformed_ep.module()(*inp)
+        expected = (torch.tensor([5.0]) + torch.tensor([1.0])) * 2.0
+        self.assertTrue(torch.allclose(result, expected))
 
     def test__transform_override_verifiers(self):
         """Test that _transform can override verifiers in the exported program."""


### PR DESCRIPTION
Summary:

EdgeProgramManager.transform assumed that we were applying passes to graph modules which couldn't modify constants. Added functionality to transform to lower constants into the graph module before running passes, and then lift them back at the end. So far, this is done by opting in to minimize the surface area of tests that would be affected by this, but could eventually become the default.

Reviewed By: ethansfng

Differential Revision: D105637321


