### PR TITLE
NXP backend: Add support for `sigmoid` with the new Neutron flow.

### DIFF
--- a/backends/nxp/backend/ir/converter/builder/model_builder.py
+++ b/backends/nxp/backend/ir/converter/builder/model_builder.py
@@ -742,7 +742,10 @@ class ModelBuilder:
         return new_name
 
     def op_code_index_for_op_type(
-        self, op_type: BuiltinOperator, version: int = 1, custom_code: str = None
+        self,
+        op_type: BuiltinOperator | int,
+        version: int = 1,
+        custom_code: str | None = None,
     ):
         """
         Return the index to the 'operator_codes' vector in the TFLite model for the operator

--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/sigmoid_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/sigmoid_converter.py
@@ -1,7 +1,9 @@
-# Copyright 2025 NXP
+# Copyright 2025-2026 NXP
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+
+import torch
 
 from executorch.backends.nxp.backend.ir.converter.node_converter import (
     CustomDelegationOptions,
@@ -10,6 +12,8 @@ from executorch.backends.nxp.backend.ir.converter.node_converter import (
 from executorch.backends.nxp.backend.ir.lib.tflite.BuiltinOperator import (
     BuiltinOperator,
 )
+
+from executorch.backends.nxp.backend.neutron_target_spec import NeutronTargetSpec
 from torch.fx import Node
 from torch.nn import Parameter
 
@@ -24,7 +28,37 @@ class SigmoidConverter(NodeConverter):
     ) -> bool:
         return True
 
+    @staticmethod
+    def _is_supported_on_target(
+        node: Node,
+        neutron_target_spec: NeutronTargetSpec,
+        parameters_mapping: dict[str, Parameter],
+        custom_delegation_options: CustomDelegationOptions,
+    ) -> bool:
+        if custom_delegation_options.use_new_flow_neutron_c:
+            # Requirements specified by the new Neutron flow documentation.
+
+            if not NodeConverter.uses_quantization_type_for_io(
+                node,
+                supported_types=[torch.int8, torch.uint8],
+                input_indices=[0],
+                output_indices=[0],
+            ):
+                return False
+
+            return True
+
+        else:
+            # Requirements of the old Neutron flow.
+            return True
+
     def convert(self, node: Node):
+        """Convert the `aten.sigmoid.default` node to NeutronIR `Logistic` operator.
+        The ExecuTorch schema is:
+            sigmoid(
+                Tensor self
+            ) -> Tensor
+        """
         self.assert_convertible(node)
 
         t_op = self._create_tflite_op_with_io_tensors(node)

--- a/backends/nxp/tests/ir/converter/node_converter/test_sigmoid_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_sigmoid_converter.py
@@ -1,23 +1,33 @@
-# Copyright 2025 NXP
+# Copyright 2025-2026 NXP
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
 
 import numpy as np
+
+# noinspection PyUnusedImports
 import pytest
 import torch
 
 from executorch.backends.nxp.backend.edge_program_converter import (
     EdgeProgramToIRConverter,
 )
+from executorch.backends.nxp.neutron_partitioner import NeutronPartitioner
+from executorch.backends.nxp.tests.dataset_creator import RandomDatasetCreator
 from executorch.backends.nxp.tests.executorch_pipeline import to_quantized_edge_program
 from executorch.backends.nxp.tests.executors import (
     convert_run_compare,
     ToNCHWPreprocess,
     ToNHWCPreprocess,
 )
+from executorch.backends.nxp.tests.graph_verifier import DetailedGraphVerifier
+from executorch.backends.nxp.tests.model_output_comparator import (
+    AllCloseOutputComparator,
+)
 from executorch.backends.nxp.tests.models import ConvWithSigmoid
+from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
+from executorch.backends.nxp.tests.ops_aliases import DequantizePerTensor, Sigmoid
 from torch import nn
 from torch.export import ExportedProgram
 from executorch.backends.nxp.tests.use_qat import *  # noqa F403
@@ -76,3 +86,60 @@ def test_sigmoid_only(mocker, use_qat, input_shape):
     convert_run_compare(
         exported_program, tfl_model=tflite_flatbuffers_model, input_data=input_data
     )
+
+
+class TestSigmoidNewNeutronFlow:
+    # noinspection PyMethodMayBeStatic
+    def assert_delegated(self, model, input_shape, mocker, use_qat=False, atol=None):
+        graph_verifier = DetailedGraphVerifier(
+            mocker,
+            expected_delegated_ops={Sigmoid: 1},
+            expected_non_delegated_ops={},
+        )
+
+        # Create a RandomDatasetCreator that covers also negative numbers to properly test the operator.
+        dataset_creator = RandomDatasetCreator(low=-2, high=2)
+
+        kwargs = {"atol": atol} if atol is not None else {}
+        output_comparator = AllCloseOutputComparator(**kwargs)
+
+        lower_run_compare(
+            model,
+            input_shape,
+            graph_verifier,
+            dataset_creator,
+            output_comparator,
+            use_qat=use_qat,
+            use_new_flow_neutron_c=True,  # Use the new flow.
+        )
+
+    def test__basic_nsys_inference__qat(self, mocker, use_qat):
+        input_shape = (23,)
+        model = nn.Sigmoid()
+        self.assert_delegated(model, input_shape, mocker, use_qat=use_qat)
+
+    @pytest.mark.parametrize(
+        "input_shape",
+        [
+            (2,),
+            (2, 3),
+            (2, 3, 4),
+            (2, 3, 4, 5),
+            (2, 3, 4, 5, 6),
+        ],
+        ids=lambda shape: f"{len(shape)}D",
+    )
+    def test__input_shapes(self, mocker, input_shape):
+        model = nn.Sigmoid()
+
+        output_scale = 1.0 / 256.0
+        lowering_spy = mocker.spy(NeutronPartitioner, "partition")
+        self.assert_delegated(
+            model, input_shape, mocker, atol=output_scale
+        )  # Allow single bit error.
+
+        # Verify that the `atol` is indeed equal to the output scale.
+        # In the near future, we would like to add support for testing with int8 IO, where this check will be trivial.
+        nodes = list(lowering_spy.spy_return.tagged_exported_program.graph.nodes)
+        assert nodes[-2].target == DequantizePerTensor
+        assert nodes[-2].args[1] == output_scale

--- a/backends/nxp/tests/ops_aliases.py
+++ b/backends/nxp/tests/ops_aliases.py
@@ -27,6 +27,7 @@ MulTensor = exir_ops.edge.aten.mul.Tensor
 QuantizePerChannel = exir_ops.edge.quantized_decomposed.quantize_per_channel.default
 QuantizePerTensor = exir_ops.edge.quantized_decomposed.quantize_per_tensor.default
 Relu = exir_ops.edge.aten.relu.default
+Sigmoid = exir_ops.edge.aten.sigmoid.default
 Slice = exir_ops.edge.aten.slice.Tensor
 SliceCopy = exir_ops.edge.aten.slice_copy.Tensor
 Softmax = exir_ops.edge.aten._softmax.default


### PR DESCRIPTION
### Summary
This PR adds support for the aten.sigmoid operator with the new Neutron MLIR flow.

### Test plan
Unit tests provided.

cc @robert-kalmar @JakeStevens @digantdesai @rascani