### PR TITLE
NXP backend: Remove `max_pool2d` maximum kernel size restriction.

### DIFF
--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/max_pool2d_with_indices_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/max_pool2d_with_indices_converter.py
@@ -83,14 +83,10 @@ class MaxPool2DWithIndicesConverter(NodeConverter):
             ):
                 return False
 
-            maximum_supported_kernel_size = 4096
             # If there is no padding, Neutron allows maximum stride of 4096. Otherwise, it's 32. But the converter
             #  always inserts a `Pad` operator to add the padding, so the `MaxPool` never pads it's input itself, so
             #  4096 is always the limit. And similarly, the `MaxPool` input padding limitation does not apply either.
             maximum_supported_stride = 4096
-
-            if any(k > maximum_supported_kernel_size for k in kernel_size):
-                return False
             if any(s > maximum_supported_stride for s in stride):
                 return False
 

--- a/backends/nxp/tests/ir/converter/node_converter/test_max_pool_2d_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_max_pool_2d_converter.py
@@ -302,17 +302,11 @@ class TestMaxPool2DNewNeutronFlow:
             use_qat=True,
         )
 
-    def test__kernel_size_limit(self, mocker):
-        kernel_size = (1, 4096)
+    def test__large_kernel_size(self, mocker):
+        kernel_size = (1, 5000)
         input_shape = (1, 4) + kernel_size
-        model = MaxPool2dModule(kernel_size)
+        model = MaxPool2dModule(kernel_size, stride=1)
         self.assert_delegated(model, input_shape, mocker)
-
-    def test__kernel_size_limit_exceeded(self):
-        kernel_size = (1, 4097)  # Exceeds the kernel size limit.
-        input_shape = (1, 4) + kernel_size
-        model = MaxPool2dModule(kernel_size)
-        self.assert_not_delegated(model, input_shape)
 
     def test__stride_limit__no_padding(self, mocker):
         stride = 4096


### PR DESCRIPTION
### Summary
Neutron SW 3.1.1 removes the restriction for maximum supported kernel size of the MaxPool2D operator. This PR reflects this change in the Neutron backend.

### Test plan
Unit test provided.


cc @robert-kalmar @JakeStevens @digantdesai @rascani