### PR TITLE
Weight offloading API surface (CUDA backend)

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -136,6 +136,12 @@ jobs:
         cmake --workflow --preset default
         popd
 
+        # Build and run weight-offload tests (C++): host-level payload
+        # parser + CUDA-gated Session state machine.
+        pushd backends/cuda/runtime/weight_offload/tests
+        cmake --workflow --preset default
+        popd
+
         # Install flash-linear-attention for chunk_gated_delta_rule triton kernel tests
         pip install "flash-linear-attention==0.4.2"
 

--- a/backends/aoti/aoti_backend.py
+++ b/backends/aoti/aoti_backend.py
@@ -9,7 +9,7 @@ import os
 import typing
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 import torch
 from executorch.backends.aoti.passes.replace_view_copy_with_view import (
@@ -130,6 +130,29 @@ class AotiBackend(ABC):
         return
 
     @classmethod
+    def pre_aoti_transform_and_collect_named_data(
+        cls,
+        device_edge_program: ExportedProgram,
+        compile_specs: List[CompileSpec],
+    ) -> List[Tuple[str, bytes, int, Optional[str]]]:
+        """Backend hook for graph mutation + extra NamedDataStore entries.
+
+        Called between ``run_decompositions`` and ``aot_compile``, so
+        overrides can:
+          1. Mutate ``device_edge_program`` in place (e.g. insert
+             custom ops that the backend's AOTI c-shim registry
+             handles), and/or
+          2. Return ``[(key, blob, alignment, external_tag), ...]``
+             entries to be added to the same ``NamedDataStore`` that
+             carries ``_so_blob`` / ``_weights_blob``.
+
+        Default: no-op, returns ``[]``. CudaBackend overrides this to
+        wire weight offloading when its private compile-spec opt-in
+        is set.
+        """
+        return []
+
+    @classmethod
     @contextlib.contextmanager
     def collect_unsupported_fallback_kernels(cls, missing_fallback_kernels: Set[str]):
         """
@@ -182,7 +205,7 @@ class AotiBackend(ABC):
             )
 
     @classmethod
-    def preprocess(
+    def preprocess(  # noqa: C901
         cls,
         edge_program: ExportedProgram,
         compile_specs: List[CompileSpec],
@@ -216,6 +239,15 @@ class AotiBackend(ABC):
             device_edge_program = device_edge_program.run_decompositions(
                 decomposition_table
             )
+
+        # Backend extension point: mutate ``device_edge_program`` in
+        # place (e.g. insert custom ops the AOTI shim path will pick
+        # up) and return extra NamedDataStore entries to attach
+        # alongside ``_so_blob`` / ``_weights_blob`` after compile.
+        # Default: no-op.
+        extra_named_data = cls.pre_aoti_transform_and_collect_named_data(
+            device_edge_program, compile_specs
+        )
 
         edge_program_module = device_edge_program.module()
 
@@ -288,6 +320,11 @@ class AotiBackend(ABC):
         named_data_store.add_named_data(
             method_name + "_weights_blob", blob_data, 1, external_tag
         )
+
+        for extra_key, extra_blob, extra_align, extra_tag in extra_named_data:
+            named_data_store.add_named_data(
+                extra_key, extra_blob, extra_align, extra_tag
+            )
 
         # Clean up the generated files
         os.remove(so_path)

--- a/backends/aoti/aoti_delegate_handle.h
+++ b/backends/aoti/aoti_delegate_handle.h
@@ -122,6 +122,23 @@ using AOTInductorModelContainerUpdateUserManagedConstantBufferPairsFunc =
         bool use_inactive,
         bool validate_full_update);
 
+// Retrieves a constant's data size (storage bytes) by index. Required by
+// the weight-offload runtime to replicate AOTI's source-blob layout
+// without calling update_constants_from_blob.
+using AOTInductorModelContainerGetConstantDataSizeFunc = AOTIRuntimeError (*)(
+    AOTInductorModelContainerHandle container_handle,
+    size_t idx,
+    size_t* data_size);
+
+// Reports whether a constant is computed by AOTI's runtime const-folding.
+// Required by the weight-offload runtime to hard-fail at init if any
+// folded constant exists (run_const_fold reads other constants and would
+// see dummies in our pre-install model).
+using AOTInductorModelContainerGetConstantFromFoldedFunc = AOTIRuntimeError (*)(
+    AOTInductorModelContainerHandle container_handle,
+    size_t idx,
+    bool* from_folded);
+
 } // extern "C"
 
 // AOTI Delegate Handle structure
@@ -146,6 +163,12 @@ struct AOTIDelegateHandle {
   AOTInductorModelContainerExtractConstantsMapFunc extract_constants_map;
   AOTInductorModelContainerUpdateUserManagedConstantBufferPairsFunc
       update_user_managed_constant_buffer_pairs;
+
+  // Weight-offload-only function pointers. Optional for handles where
+  // offload is not enabled; cuda_backend.cpp::init dlsym's them only when
+  // the weight_offload compile spec is present, and hard-fails if missing.
+  AOTInductorModelContainerGetConstantDataSizeFunc get_constant_data_size;
+  AOTInductorModelContainerGetConstantFromFoldedFunc get_constant_from_folded;
 };
 
 } // namespace aoti

--- a/backends/cuda/CMakeLists.txt
+++ b/backends/cuda/CMakeLists.txt
@@ -103,8 +103,10 @@ install(
 )
 
 # CUDA-specific AOTI shim symbols (dynamically linked)
-set(_aoti_cuda_shim_sources runtime/cuda_allocator.cpp runtime/shims/memory.cpp
-                            runtime/shims/cuda_guard.cpp
+set(_aoti_cuda_shim_sources
+    runtime/cuda_allocator.cpp runtime/shims/memory.cpp
+    runtime/shims/cuda_guard.cpp runtime/weight_offload/probe_op.cpp
+    runtime/weight_offload/probe_registry.cpp
 )
 
 # Only build CUDA shims when CUDA language/toolchain is available.
@@ -179,7 +181,9 @@ install(
 )
 
 # CUDA backend implementation
-set(_aoti_cuda_backend_sources runtime/cuda_backend.cpp)
+set(_aoti_cuda_backend_sources runtime/cuda_backend.cpp
+                               runtime/weight_offload/session.cpp
+)
 if(_cuda_is_msvc_toolchain)
   # MSVC links aoti_cuda_backend into portable_lib without relying on C++
   # symbols exported from aoti_cuda_shims.dll.

--- a/backends/cuda/TARGETS
+++ b/backends/cuda/TARGETS
@@ -7,6 +7,7 @@ runtime.python_library(
     srcs = [
         "passes/__init__.py",
         "passes/move_cond_predicate_to_cpu.py",
+        "passes/weight_offload_pass.py",
     ],
     visibility = [
         "//executorch/backends/cuda/...",

--- a/backends/cuda/cuda_backend.py
+++ b/backends/cuda/cuda_backend.py
@@ -228,6 +228,12 @@ class CudaBackend(AotiBackend, BackendDetails):
             "aoti_torch_cuda_randint_low_out": None,
             "executorch_cuda::int4_plain_mm": None,
             "aoti_torch_cuda_int4_plain_mm": None,
+            # Weight-offload probe op (EXPERIMENTAL). Whitelisted so
+            # AOTI's missing-fallback-kernel check doesn't fail when a
+            # graph contains probes; the actual symbol resolution
+            # happens at .so load time against ``libaoti_cuda_shims``.
+            "executorch_weight_offload::probe": None,
+            "aoti_torch_cuda_probe": None,
         }
 
     @classmethod
@@ -261,6 +267,60 @@ class CudaBackend(AotiBackend, BackendDetails):
         if triton_kernel_mode == "ON":
             passes.append(ReplaceEdgeOpWithTritonOpPass())
         return passes
+
+    @classmethod
+    def pre_aoti_transform_and_collect_named_data(
+        cls,
+        device_edge_program,
+        compile_specs: List[CompileSpec],
+    ):
+        """Wire weight offloading when the private opt-in compile spec
+        is set. Otherwise no-op.
+
+        When opted in, the pass writes a NamedData payload describing
+        the per-method probe schedule, floor budget, and constants
+        catalog. ``CudaBackend::init`` reads that payload, pre-installs
+        device dummies, skips AOTI's eager constant load, and builds a
+        ``Session`` that serves weights from a bounded GPU pool backed
+        by a host mirror (with optional pinned-resident weights).
+        """
+        # Cheap opt-in probe first — avoids importing the offload
+        # pass machinery for the (overwhelmingly common) non-offload
+        # export. The key string is duplicated against
+        # ``COMPILE_SPEC_KEY_ENABLE`` on purpose so this branch has
+        # no import dependency at all.
+        opt_in = any(
+            spec.key == "_weight_offload_internal_enable" and len(spec.value) > 0
+            for spec in compile_specs
+        )
+        if not opt_in:
+            return []
+
+        # Opt-in is set: the offload pass MUST be importable. A failing
+        # import here means a broken build, not a "skip and hope for
+        # the best" — the runtime would otherwise hard-fail at init
+        # with a "payload missing" error miles away from the actual
+        # cause.
+        from executorch.backends.cuda.passes.weight_offload_pass import (
+            _apply_weight_offload,
+            _serialize_payload,
+            named_data_key_for_method,
+            pin_fqns_from_specs,
+        )
+
+        method_name = cls.method_name_from_compile_specs(compile_specs)
+        pin_fqns = pin_fqns_from_specs(compile_specs)
+        payload = _apply_weight_offload(
+            device_edge_program,
+            method_name=method_name,
+            pin_fqns=pin_fqns,
+        )
+        blob = _serialize_payload(payload)
+        # Merge into the .pte rather than the external .ptd: the
+        # payload is metadata (a few KB at most) and the runtime
+        # parses it in ``init`` before any heavy data loading, so
+        # keeping it inline avoids dragging the .ptd open early.
+        return [(named_data_key_for_method(method_name), blob, 1, None)]
 
     @classmethod
     def get_aoti_compile_options(
@@ -312,6 +372,31 @@ class CudaBackend(AotiBackend, BackendDetails):
             }
         except AttributeError:
             # int4_dispatch.py not imported — op not registered, skip C shim mapping
+            pass
+
+        # Weight-offload probe op (EXPERIMENTAL). The op is defined in
+        # ``backends/cuda/passes/weight_offload_pass.py``; import it
+        # lazily so a build that excludes the offload pass still
+        # compiles. ``probe`` is registered unconditionally because the
+        # AOTI wrapper only emits the call when an FX-graph node
+        # references it, and the runtime symbol always exists in
+        # ``aoti_cuda_shims``.
+        try:
+            from executorch.backends.cuda.passes import (  # noqa: F401
+                weight_offload_pass,
+            )
+
+            shims = options.setdefault("aot_inductor.custom_ops_to_c_shims", {})
+            shims.setdefault(
+                torch.ops.executorch_weight_offload.probe.default,
+                [
+                    "AOTITorchError aoti_torch_cuda_probe("
+                    "AtenTensorHandle, int64_t, AtenTensorHandle*)"
+                ],
+            )
+        except AttributeError:
+            # weight_offload_pass importable but op not registered (e.g.
+            # torch.library shim missing in the running interpreter); skip.
             pass
 
         # Parse compile_specs to check for platform

--- a/backends/cuda/cuda_partitioner.py
+++ b/backends/cuda/cuda_partitioner.py
@@ -4,13 +4,154 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import final, List
+from typing import final, List, Optional
 
 from executorch.backends.aoti.aoti_partitioner import AotiPartitioner
 from executorch.backends.cuda.cuda_backend import CudaBackend  # usort: skip
 from executorch.exir._warnings import experimental
 from executorch.exir.backend.compile_spec_schema import CompileSpec
 from executorch.exir.passes.propagate_device_pass import TARGET_DEVICE_COMPILE_SPEC_KEY
+
+# Inlined copies of the internal compile-spec key strings owned by
+# ``backends/cuda/passes/weight_offload_pass.py``. We don't import from
+# that module because it registers a custom op at import time
+# (``@custom_op`` decorator), which would defeat the lazy-import
+# pattern in ``CudaBackend.pre_aoti_transform_and_collect_named_data``.
+# The drift hazard is bounded by
+# ``test_partitioner_internal_keys_match_pass``, which asserts these
+# values match the pass-side constants at CI time.
+_WEIGHT_OFFLOAD_ENABLE_SPEC_KEY = "_weight_offload_internal_enable"
+_WEIGHT_OFFLOAD_PIN_FQNS_SPEC_KEY = "_weight_offload_internal_pin_fqns"
+_WEIGHT_OFFLOAD_INTERNAL_KEY_PREFIX = "_weight_offload_internal_"
+
+# Weight offload is device-0-only today: the pass hard-codes
+# device_type=cuda, device_index=0 in the payload, and the runtime
+# calls cudaSetDevice(0) before container/stream creation. Until
+# multi-device offload lands, reject any other target_device when
+# weight_offload=True so callers don't silently end up on the wrong
+# GPU.
+_OFFLOAD_REQUIRED_DEVICE = ("cuda", 0)
+
+
+def _check_pin_fqns_input(weight_offload_pin_fqns) -> List[str]:
+    """Normalize the public ``weight_offload_pin_fqns`` argument to a
+    deduped first-seen-order list of strings. Rejects ``bare str``
+    (the ``list("w1")`` foot-gun) and any non-list iterable (the
+    public contract is ``List[str]``, and dict_keys / sets / generators
+    would either lose ordering or be one-shot). The runtime payload
+    parser hard-fails on empty / NUL-containing FQNs as a trust-boundary
+    check; not duplicating that here."""
+    if weight_offload_pin_fqns is None:
+        return []
+    if isinstance(weight_offload_pin_fqns, str):
+        raise TypeError(
+            "weight_offload_pin_fqns must be a list of strings, not a "
+            "bare str; pass [...] even for a single FQN"
+        )
+    if not isinstance(weight_offload_pin_fqns, list):
+        raise TypeError(
+            f"weight_offload_pin_fqns must be a list, got "
+            f"{type(weight_offload_pin_fqns).__name__}"
+        )
+    seen: set = set()
+    out: List[str] = []
+    for fqn in weight_offload_pin_fqns:
+        if not isinstance(fqn, str):
+            raise TypeError(
+                f"weight_offload_pin_fqns elements must be strings, got "
+                f"{type(fqn).__name__}: {fqn!r}"
+            )
+        if fqn not in seen:
+            seen.add(fqn)
+            out.append(fqn)
+    return out
+
+
+def _reject_non_default_target_device_when_offloading(
+    compile_spec: List[CompileSpec],
+) -> None:
+    """Raise if any caller-supplied ``target_device`` compile spec is
+    not ``cuda:0``. The default (key absent) is fine and gets filled in
+    later by the constructor.
+
+    Parsed inline rather than via
+    ``propagate_device_pass._parse_device_spec_value`` to avoid pulling
+    in the flatbuffer schema import for a one-line check.
+    """
+    want_type, want_index = _OFFLOAD_REQUIRED_DEVICE
+    for spec in compile_spec:
+        if spec.key != TARGET_DEVICE_COMPILE_SPEC_KEY:
+            continue
+        raw = spec.value.decode("utf-8").strip().lower()
+        if ":" in raw:
+            type_str, idx_str = raw.split(":", 1)
+            try:
+                idx = int(idx_str)
+            except ValueError:
+                idx = -1
+        else:
+            type_str, idx = raw, 0
+        if type_str != want_type or idx != want_index:
+            raise ValueError(
+                f"CudaPartitioner: weight_offload=True currently requires "
+                f"target_device='{want_type}:{want_index}'; got "
+                f"{spec.value!r}. Multi-device weight offload is not "
+                f"implemented yet (the payload and runtime hard-code "
+                f"device 0); drop the target_device spec or set it to "
+                f"'{want_type}:{want_index}'."
+            )
+
+
+def _validate_and_translate_weight_offload_kwargs(
+    compile_spec: List[CompileSpec],
+    weight_offload: bool,
+    weight_offload_pin_fqns: Optional[List[str]],
+) -> List[CompileSpec]:
+    """Translate the public weight-offload kwargs to internal compile
+    specs with strict validation. Returns the (possibly augmented)
+    compile_spec list to pass to the base partitioner."""
+    pin_fqns_list = _check_pin_fqns_input(weight_offload_pin_fqns)
+
+    # Reject pin-without-enable.
+    if pin_fqns_list and not weight_offload:
+        raise ValueError(
+            "weight_offload_pin_fqns is set but weight_offload=False; "
+            "pinning requires enabling weight offload"
+        )
+
+    if weight_offload:
+        _reject_non_default_target_device_when_offloading(compile_spec)
+
+    # Strict mixed-channel rejection: when ANY public weight-offload
+    # kwarg is non-default, reject ANY raw `_weight_offload_internal_*`
+    # compile spec. Raw internal specs stay allowed when both public
+    # kwargs are at default values (preserves the test stack).
+    if weight_offload or pin_fqns_list:
+        offenders = [
+            spec.key
+            for spec in compile_spec
+            if spec.key.startswith(_WEIGHT_OFFLOAD_INTERNAL_KEY_PREFIX)
+        ]
+        if offenders:
+            raise ValueError(
+                f"CudaPartitioner: public weight-offload kwargs conflict "
+                f"with raw {_WEIGHT_OFFLOAD_INTERNAL_KEY_PREFIX}* entries "
+                f"in compile_spec ({sorted(set(offenders))!r}); use "
+                f"exactly one channel - either the public kwargs OR the "
+                f"raw compile_spec, not both"
+            )
+
+    out = list(compile_spec)
+    if weight_offload:
+        out.append(CompileSpec(_WEIGHT_OFFLOAD_ENABLE_SPEC_KEY, b"1"))
+        if pin_fqns_list:
+            out.append(
+                CompileSpec(
+                    _WEIGHT_OFFLOAD_PIN_FQNS_SPEC_KEY,
+                    b"\x00".join(f.encode("utf-8") for f in pin_fqns_list),
+                )
+            )
+    return out
 
 
 @final
@@ -29,6 +170,9 @@ class CudaPartitioner(AotiPartitioner):
     def __init__(
         self,
         compile_spec: List[CompileSpec],
+        *,
+        weight_offload: bool = False,
+        weight_offload_pin_fqns: Optional[List[str]] = None,
     ) -> None:
         """
         Initialize the CUDA partitioner.
@@ -37,14 +181,39 @@ class CudaPartitioner(AotiPartitioner):
             compile_spec: List of compile specs for the backend. To specify a
                          target CUDA device, include a CompileSpec with key
                          "target_device" (e.g., value "cuda:1"). If not
-                         provided, defaults to "cuda:0".
+                         provided, defaults to "cuda:0". NOTE: when
+                         ``weight_offload=True`` only ``cuda:0`` is supported
+                         today; any other ``target_device`` is rejected
+                         (multi-device offload is not yet implemented).
+            weight_offload: When True, opt the method into the CUDA weight-
+                         offload runtime: AOTI's eager constant load is
+                         skipped, the runtime installs pre-load dummies,
+                         and probes serve weights through a bounded GPU
+                         pool from a host mirror. The load-time budget is
+                         controlled by the ``weight_offload_budget_mb``
+                         runtime spec (or the default
+                         ``floor + pinned_bytes`` when unset). Default
+                         False. Currently device-0-only.
+            weight_offload_pin_fqns: Optional list of parameter / buffer
+                         FQNs to keep resident on GPU for the Session
+                         lifetime (no streaming). Requires
+                         ``weight_offload=True``. Duplicates are removed
+                         first-seen order.
         """
+        # Translate the public weight-offload kwargs to internal
+        # compile specs (with validation). Extracted to a helper to
+        # keep this constructor under the project's cyclomatic-
+        # complexity cap.
+        compile_spec = _validate_and_translate_weight_offload_kwargs(
+            compile_spec, weight_offload, weight_offload_pin_fqns
+        )
+
         # Add target_device compile spec for device propagation if not already present
         has_target_device = any(
             spec.key == TARGET_DEVICE_COMPILE_SPEC_KEY for spec in compile_spec
         )
         if not has_target_device:
-            compile_spec = list(compile_spec) + [
+            compile_spec = compile_spec + [
                 CompileSpec(
                     TARGET_DEVICE_COMPILE_SPEC_KEY,
                     b"cuda:0",

--- a/backends/cuda/passes/tests/test_weight_offload_pass.py
+++ b/backends/cuda/passes/tests/test_weight_offload_pass.py
@@ -1,0 +1,413 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Contract tests for ``_apply_weight_offload``: payload contents,
+probe-node placement, probe_id ↔ schedule alignment, view-chain
+duplication, floor set-union semantics, and hard-fail paths. Runtime
+serve and partitioner plumbing are covered by other test files."""
+
+import unittest
+
+import torch
+import torch.nn as nn
+from executorch.backends.cuda.passes.weight_offload_pass import (
+    _apply_weight_offload,
+    PAYLOAD_KEY_FLOOR,
+    PAYLOAD_KEY_METHOD_NAME,
+    PAYLOAD_KEY_PIN_FQNS,
+    PAYLOAD_KEY_SCHEDULE,
+    PAYLOAD_KEY_VERSION,
+    PROBE_OP_TARGET,
+    SCHEMA_VERSION,
+)
+from torch.export import export
+
+
+class _SingleConsumerModel(nn.Module):
+    def __init__(self, dim: int = 8):
+        super().__init__()
+        self.w = nn.Parameter(torch.randn(dim, dim))
+
+    def forward(self, x):
+        return x @ self.w
+
+
+class _MultiConsumerModel(nn.Module):
+    """One weight, two consumers — exercises the dense ``probe_id`` rule."""
+
+    def __init__(self, dim: int = 8):
+        super().__init__()
+        self.w = nn.Parameter(torch.randn(dim, dim))
+
+    def forward(self, x):
+        return (x @ self.w) + ((x + 1) @ self.w)
+
+
+class _TwoWeightModel(nn.Module):
+    """Two distinct weights, used in sequence — exercises floor arithmetic.
+
+    Sizes are intentionally asymmetric so ``max_single`` differs from
+    ``max_pair`` in the floor formula:
+      - ``w1``: 8x8 float32  -> 256 bytes
+      - ``w2``: 16x8 float32 -> 512 bytes
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.w1 = nn.Parameter(torch.randn(8, 8))
+        self.w2 = nn.Parameter(torch.randn(16, 8))
+
+    def forward(self, x):
+        # x: [4, 8]
+        y = x @ self.w1  # [4,8] @ [8,8] -> [4,8]
+        return y @ self.w2.T  # [4,8] @ [8,16] -> [4,16]
+
+
+class _BufferModel(nn.Module):
+    def __init__(self, dim: int = 8):
+        super().__init__()
+        self.register_buffer("buf", torch.randn(dim, dim))
+
+    def forward(self, x):
+        return x @ self.buf
+
+
+class _ViewChainModel(nn.Module):
+    """One weight viewed via .T and consumed by two kernels.
+
+    Exercises the view-chain duplication path: the pass must emit two
+    probes (one per kernel) rooted at the placeholder, each with its
+    own duplicated transpose, so a later kernel can re-load ``w`` if
+    the runtime evicts it between the two reads.
+    """
+
+    def __init__(self, dim: int = 8):
+        super().__init__()
+        self.w = nn.Parameter(torch.randn(dim, dim))
+
+    def forward(self, x):
+        v = self.w.T  # single shared view
+        return (x @ v) + ((x + 1) @ v)
+
+
+class _IndependentMultiOutputModel(nn.Module):
+    """``return x*w1, x*w2, x*w3, x*w4`` — independent pointwise
+    branches that Inductor can fuse into a single multi-output
+    kernel reading all four weights. The output node is the
+    fusion sink that ties them together at floor-calculation time.
+    """
+
+    def __init__(self, dim: int = 8):
+        super().__init__()
+        self.w1 = nn.Parameter(torch.randn(dim, dim))
+        self.w2 = nn.Parameter(torch.randn(dim, dim))
+        self.w3 = nn.Parameter(torch.randn(dim, dim))
+        self.w4 = nn.Parameter(torch.randn(dim, dim))
+
+    def forward(self, x):
+        return x * self.w1, x * self.w2, x * self.w3, x * self.w4
+
+
+class _SequentialMatmulModel(nn.Module):
+    """``y = x @ w1; z = y @ w2`` — two matmuls in series.
+
+    Documents the current policy: matmul is NOT treated as a
+    confirmed materializing barrier, so the second matmul's working
+    set includes BOTH weights even though it physically only reads
+    w2. That is a conservative overestimate — safe under the
+    "if unsure, propagate" rule. Could be tightened by adding matmul
+    to a verified barrier list once post-AOTI kernel grouping data
+    is available.
+    """
+
+    def __init__(self, dim: int = 8):
+        super().__init__()
+        self.w1 = nn.Parameter(torch.randn(dim, dim))
+        self.w2 = nn.Parameter(torch.randn(dim, dim))
+
+    def forward(self, x):
+        y = x @ self.w1
+        return y @ self.w2
+
+
+class _FusablePointwiseChainModel(nn.Module):
+    """Pointwise chain Inductor can fuse into one kernel reading all
+    four weights simultaneously. The pre-AOTI floor analysis must
+    upper-bound this by walking the transitive probe cone — the
+    direct-deps-only formula would size the pool for ~2 weights and
+    let the runtime evict a weight the fused kernel still needs."""
+
+    def __init__(self, dim: int = 8):
+        super().__init__()
+        self.w1 = nn.Parameter(torch.randn(dim, dim))
+        self.w2 = nn.Parameter(torch.randn(dim, dim))
+        self.w3 = nn.Parameter(torch.randn(dim, dim))
+        self.w4 = nn.Parameter(torch.randn(dim, dim))
+
+    def forward(self, x):
+        return x * self.w1 + self.w2 + self.w3 + self.w4
+
+
+class _SharedWeightKernelModel(nn.Module):
+    """Two kernels share one weight directly (no view) — the floor's
+    set-union semantics must collapse them so the shared weight isn't
+    double-counted across the pair."""
+
+    def __init__(self):
+        super().__init__()
+        self.w = nn.Parameter(torch.randn(8, 8))  # 256 bytes
+        self.w2 = nn.Parameter(torch.randn(8, 8))  # 256 bytes
+
+    def forward(self, x):
+        a = x @ self.w
+        b = (x + 1) @ self.w  # shares w with `a`
+        c = a @ self.w2
+        return b + c
+
+
+def _export(model: nn.Module, *example_inputs) -> "torch.export.ExportedProgram":
+    return export(model, example_inputs, strict=True)
+
+
+def _probe_nodes(ep) -> list[torch.fx.Node]:
+    return [
+        n
+        for n in ep.graph_module.graph.nodes
+        if n.op == "call_function" and n.target == PROBE_OP_TARGET
+    ]
+
+
+class TestApplyWeightOffload(unittest.TestCase):
+    # -----------------------------------------------------------------
+    # Probe insertion
+    # -----------------------------------------------------------------
+
+    def test_single_consumer_inserts_one_probe(self):
+        ep = _export(_SingleConsumerModel(), torch.randn(4, 8))
+        payload = _apply_weight_offload(ep, method_name="forward")
+        probes = _probe_nodes(ep)
+        self.assertEqual(len(probes), 1)
+        self.assertEqual(payload[PAYLOAD_KEY_SCHEDULE], ["w"])
+
+    def test_multi_consumer_inserts_one_probe_per_consumer(self):
+        ep = _export(_MultiConsumerModel(), torch.randn(4, 8))
+        payload = _apply_weight_offload(ep, method_name="forward")
+        probes = _probe_nodes(ep)
+        self.assertEqual(len(probes), 2)
+        # Same FQN appears twice — once per consumer site.
+        self.assertEqual(payload[PAYLOAD_KEY_SCHEDULE], ["w", "w"])
+
+    def test_buffer_placeholder_is_probed(self):
+        ep = _export(_BufferModel(), torch.randn(4, 8))
+        payload = _apply_weight_offload(ep, method_name="forward")
+        self.assertEqual(len(_probe_nodes(ep)), 1)
+        self.assertEqual(payload[PAYLOAD_KEY_SCHEDULE], ["buf"])
+
+    def test_view_chain_inserts_probe_per_kernel(self):
+        """A weight viewed via ``.T`` and consumed by two kernels gets
+        two probes — one per kernel, each rooted at the placeholder
+        with its own duplicated view chain — so a later kernel can
+        re-load the weight if the runtime evicted it between the
+        reads. The original shared view is dead-code-eliminated."""
+        ep = _export(_ViewChainModel(), torch.randn(4, 8))
+        payload = _apply_weight_offload(ep, method_name="forward")
+        probes = _probe_nodes(ep)
+        self.assertEqual(len(probes), 2)
+        # Both probes wrap the placeholder ``w`` directly, NOT the
+        # transpose's output — the c-shim needs to see the original
+        # weight pointer to resolve the FQN via ProbeRegistry.
+        sig = ep.graph_signature
+        placeholder_fqn = {
+            spec.arg.name: spec.target
+            for spec in sig.input_specs
+            if spec.target is not None
+        }
+        for probe in probes:
+            self.assertIn(probe.args[0].name, placeholder_fqn)
+            self.assertEqual(placeholder_fqn[probe.args[0].name], "w")
+        self.assertEqual(payload[PAYLOAD_KEY_SCHEDULE], ["w", "w"])
+
+    def test_probe_ids_contiguous_from_zero(self):
+        ep = _export(_TwoWeightModel(), torch.randn(4, 8))
+        _apply_weight_offload(ep, method_name="forward")
+        probes = _probe_nodes(ep)
+        ids = [n.args[1] for n in probes]
+        self.assertEqual(ids, list(range(len(probes))))
+
+    def test_schedule_indexed_by_probe_id(self):
+        """``schedule[probe_id]`` matches the FQN the probe wraps."""
+        ep = _export(_TwoWeightModel(), torch.randn(4, 8))
+        payload = _apply_weight_offload(ep, method_name="forward")
+        probes = _probe_nodes(ep)
+        # The probe's first arg is the placeholder it wraps; resolve
+        # back to FQN via the graph signature.
+        sig = ep.graph_signature
+        placeholder_fqn = {
+            spec.arg.name: spec.target
+            for spec in sig.input_specs
+            if spec.target is not None
+        }
+        for probe in probes:
+            probe_id = probe.args[1]
+            wrapped_fqn = placeholder_fqn[probe.args[0].name]
+            self.assertEqual(payload[PAYLOAD_KEY_SCHEDULE][probe_id], wrapped_fqn)
+
+    def test_re_entry_is_hard_error(self):
+        """Pass is single-shot; re-applying would wrap probes in probes
+        and silently corrupt the probe_id -> FQN mapping, so the second
+        call raises instead."""
+        ep = _export(_SingleConsumerModel(), torch.randn(4, 8))
+        _apply_weight_offload(ep, method_name="forward")
+        with self.assertRaises(RuntimeError) as cm:
+            _apply_weight_offload(ep, method_name="forward")
+        self.assertIn("already applied", str(cm.exception))
+
+    # -----------------------------------------------------------------
+    # Payload schema
+    # -----------------------------------------------------------------
+
+    def test_payload_has_v2_schema_version(self):
+        ep = _export(_SingleConsumerModel(), torch.randn(4, 8))
+        payload = _apply_weight_offload(ep, method_name="forward")
+        self.assertEqual(payload[PAYLOAD_KEY_VERSION], SCHEMA_VERSION)
+        self.assertEqual(SCHEMA_VERSION, 2)
+
+    def test_payload_echoes_method_name(self):
+        ep = _export(_SingleConsumerModel(), torch.randn(4, 8))
+        payload = _apply_weight_offload(ep, method_name="prefill")
+        self.assertEqual(payload[PAYLOAD_KEY_METHOD_NAME], "prefill")
+
+    def test_payload_echoes_pin_fqns(self):
+        ep = _export(_TwoWeightModel(), torch.randn(4, 8))
+        payload = _apply_weight_offload(ep, method_name="forward", pin_fqns=["w1"])
+        self.assertEqual(payload[PAYLOAD_KEY_PIN_FQNS], ["w1"])
+
+    def test_payload_pin_fqns_defaults_empty(self):
+        ep = _export(_SingleConsumerModel(), torch.randn(4, 8))
+        payload = _apply_weight_offload(ep, method_name="forward")
+        self.assertEqual(payload[PAYLOAD_KEY_PIN_FQNS], [])
+
+    # -----------------------------------------------------------------
+    # Floor arithmetic
+    #
+    # The floor is a conservative FX fusion upper bound, NOT a
+    # tight kernel-level estimate. ``W_i`` here is the working set
+    # at FX candidate ``i`` (a non-view non-probe ``call_function``
+    # plus the output sink), built by propagating probe FQNs
+    # forward through every fusion-eligible edge — the pass refuses
+    # to claim any op is a barrier without proof. Formula:
+    # ``max(sum bytes W_i ∪ W_{i+1}) + max single weight``. Set
+    # union across the pair window collapses weights shared between
+    # adjacent candidates (the pool only needs one allocation).
+    # -----------------------------------------------------------------
+
+    def test_floor_two_weights_unpinned(self):
+        """Two kernels, each reads one distinct weight."""
+        ep = _export(_TwoWeightModel(), torch.randn(4, 8))
+        payload = _apply_weight_offload(ep, method_name="forward")
+        # working_sets = [{"w1"}, {"w2"}]; bytes(w1)=256, bytes(w2)=512.
+        # max_window over (S_0 ∪ S_1)=768 and (S_1)=512 -> 768.
+        # max_single = 512. floor = 1280.
+        self.assertEqual(payload[PAYLOAD_KEY_FLOOR], 768 + 512)
+
+    def test_floor_pinned_weight_excluded(self):
+        """Pinning w1 collapses the streaming sequence to one kernel
+        (the one reading w2); floor = max_window + max_single = 512+512."""
+        ep = _export(_TwoWeightModel(), torch.randn(4, 8))
+        payload = _apply_weight_offload(ep, method_name="forward", pin_fqns=["w1"])
+        self.assertEqual(payload[PAYLOAD_KEY_FLOOR], 512 + 512)
+
+    def test_floor_all_pinned_is_zero(self):
+        ep = _export(_TwoWeightModel(), torch.randn(4, 8))
+        payload = _apply_weight_offload(
+            ep, method_name="forward", pin_fqns=["w1", "w2"]
+        )
+        self.assertEqual(payload[PAYLOAD_KEY_FLOOR], 0)
+
+    def test_floor_single_consumer(self):
+        """One weight, one consumer: max_window = sum(S_0) = bytes(w);
+        max_single = bytes(w); floor = 2 * bytes(w)."""
+        ep = _export(_SingleConsumerModel(), torch.randn(4, 8))
+        payload = _apply_weight_offload(ep, method_name="forward")
+        # bytes(w) = 8*8*4 = 256
+        self.assertEqual(payload[PAYLOAD_KEY_FLOOR], 256 + 256)
+
+    def test_floor_shared_weight_uses_set_union(self):
+        """Two kernels reading the same weight don't double-count it
+        in the pair window — the pool only needs one allocation."""
+        ep = _export(_MultiConsumerModel(), torch.randn(4, 8))
+        payload = _apply_weight_offload(ep, method_name="forward")
+        # working_sets = [{"w"}, {"w"}]; pair union -> {"w"} (256 bytes).
+        # max_window = 256, max_single = 256, floor = 512.
+        self.assertEqual(payload[PAYLOAD_KEY_FLOOR], 512)
+
+    def test_floor_shared_weight_across_consecutive_kernels(self):
+        """Three kernels: K_0 = {w}, K_1 = {w}, K_2 = {w, w2}. The
+        largest pair window is K_1 ∪ K_2 = {w, w2}, so the pool must
+        hold both bytes, not just the larger single."""
+        ep = _export(_SharedWeightKernelModel(), torch.randn(4, 8))
+        payload = _apply_weight_offload(ep, method_name="forward")
+        # bytes(w)=256, bytes(w2)=256. max_window = 512 (K_1 ∪ K_2 or
+        # K_2 alone). max_single = 256. floor = 768.
+        self.assertEqual(payload[PAYLOAD_KEY_FLOOR], 768)
+
+    def test_floor_sequential_matmul_documents_no_barrier_reset(self):
+        """``y = x @ w1; z = y @ w2`` — the second matmul's working
+        set includes BOTH w1 and w2 even though the second matmul
+        physically only rereads w2. The pass refuses to claim
+        matmul is a barrier under AOTI/Inductor without proof, so
+        deps propagate. Conservative overestimate — safe — but
+        documents the cost of "if unsure, propagate"."""
+        ep = _export(_SequentialMatmulModel(), torch.randn(4, 8))
+        payload = _apply_weight_offload(ep, method_name="forward")
+        # bytes(w1) = bytes(w2) = 256.
+        # working_sets: {mm1: {w1}, mm2: {w1, w2}}
+        # max_window = max(|mm1 ∪ mm2|, |mm2|) = 512.
+        # max_single = 256. floor = 768.
+        self.assertEqual(payload[PAYLOAD_KEY_FLOOR], 768)
+
+    def test_floor_independent_multi_output_includes_all_branches(self):
+        """``return x*w1, x*w2, x*w3, x*w4`` — independent pointwise
+        branches Inductor can fuse into one multi-output kernel
+        reading all four weights. Without treating the output node
+        as a fusion sink, adjacent FX branches would each contribute
+        only ~2 weights to any pair window, missing this case."""
+        ep = _export(_IndependentMultiOutputModel(), torch.randn(8, 8))
+        payload = _apply_weight_offload(ep, method_name="forward")
+        # bytes(each w) = 256. Output-sink working set = {w1, w2,
+        # w3, w4} = 1024. max_window pair touching the output sink
+        # >= 1024. max_single = 256. floor = 1280.
+        self.assertEqual(payload[PAYLOAD_KEY_FLOOR], 1024 + 256)
+
+    def test_floor_fusable_pointwise_chain_uses_transitive_cone(self):
+        """``x * w1 + w2 + w3 + w4`` is a pointwise chain Inductor
+        can fuse into one kernel. The transitive cone at the final
+        add covers all four weights — the floor must size the pool
+        for that, plus eviction headroom. Direct-deps-only sizing
+        would admit ~2 weights and corrupt the fused kernel's read
+        of weights 3 and 4."""
+        ep = _export(_FusablePointwiseChainModel(), torch.randn(8, 8))
+        payload = _apply_weight_offload(ep, method_name="forward")
+        # Each weight = 8*8*4 = 256 bytes. Transitive cone at the
+        # final add = {w1, w2, w3, w4} = 1024 bytes. max_single = 256.
+        # floor = 1024 + 256 = 1280.
+        self.assertEqual(payload[PAYLOAD_KEY_FLOOR], 1024 + 256)
+
+    # -----------------------------------------------------------------
+    # Hard fails
+    # -----------------------------------------------------------------
+
+    def test_unknown_pin_fqn_is_hard_error(self):
+        ep = _export(_SingleConsumerModel(), torch.randn(4, 8))
+        with self.assertRaises(ValueError) as cm:
+            _apply_weight_offload(
+                ep, method_name="forward", pin_fqns=["does_not_exist"]
+            )
+        self.assertIn("does_not_exist", str(cm.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backends/cuda/passes/weight_offload_pass.py
+++ b/backends/cuda/passes/weight_offload_pass.py
@@ -1,0 +1,830 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""EXPERIMENTAL: CUDA weight-offloading pass.
+
+Rewrites every parameter / buffer consumer to read through a
+``probe(w, probe_id)`` op, then serializes a v2 payload (schedule
++ floor + pin_fqns + per-FQN dtype / sizes / strides /
+storage_offset / nbytes / device) into ``NamedDataStore``. The
+runtime half (``backends/cuda/runtime/weight_offload/``) parses
+the payload, installs 1-byte GPU dummies in place of AOTI's
+constants, and serves probes from a pinned host mirror through a
+bounded GPU pool. Single-device only.
+
+Public surface: ``CudaPartitioner(weight_offload=True,
+weight_offload_pin_fqns=[...])``.
+"""
+
+import struct
+import sys
+
+import torch
+from torch.library import custom_op, register_fake
+
+
+_OP_NAMESPACE = "executorch_weight_offload"
+_OP_QUALNAME = f"{_OP_NAMESPACE}::probe"
+
+
+@custom_op(_OP_QUALNAME, mutates_args=())
+def probe(w: torch.Tensor, probe_id: int) -> torch.Tensor:
+    """Identity in semantics. CUDA backend replaces via c-shim at AOTI compile time.
+
+    Inserted by ``_apply_weight_offload`` before every consumer of every
+    parameter (or buffer) placeholder. The CUDA runtime's c-shim
+    (``aoti_torch_cuda_probe``) intercepts each call at runtime and
+    serves bytes through the bounded GPU pool.
+
+    ``probe_id`` self-identifies each ``(consumer, weight)`` site so the
+    runtime needs no schedule cursor — it indexes the schedule directly
+    by ``probe_id``. This closes off the entire class of "graph order
+    drifted from wrapper order" silent failures that an FX-order cursor
+    would have. The pass assigns contiguous ``probe_id`` values 0..N-1
+    in graph order; the payload's ``schedule[probe_id] = fqn`` table is
+    what the runtime keys on.
+
+    Notes:
+      - Eager body returns ``w.clone()`` (not ``w``) so torch's custom-op
+        aliasing checker accepts the call — outputs of ``mutates_args=()``
+        ops are not allowed to alias inputs. Eager is only exercised by
+        tests; the CUDA c-shim is the production path and returns a
+        fresh ``SlimTensor`` handle sharing the input's storage (no
+        copy).
+      - AOTI emits a c-shim call site for every probe in the FX graph
+        regardless of CSE — distinct ``probe_id`` arguments make
+        otherwise-identical calls syntactically distinct from inductor's
+        POV. ``test_weight_offload_probe_dispatch.py`` validates this on
+        a multi-consumer model.
+      - Weight offloading is mutually exclusive with the CUDA backend's
+        ``enable_cuda_graph_for_method`` option: CUDA-graph Replay
+        bypasses AOTI's ``run()``, so probe ops never fire. The runtime
+        will hard-fail at ``init`` if both are set for the same method.
+    """
+    return w.clone()
+
+
+@register_fake(_OP_QUALNAME)
+def _probe_fake(w: torch.Tensor, probe_id: int) -> torch.Tensor:
+    # Fresh fake tensor so inductor doesn't decide to inline the op away.
+    return torch.empty_like(w)
+
+
+PROBE_OP_TARGET = torch.ops.executorch_weight_offload.probe.default
+
+
+# Payload field names. INTERNAL design intent for the partition-payload
+# (or NamedDataStore -- see the "payload transport" open item in the
+# module docstring) that ``CudaBackend.preprocess`` would write and
+# ``cuda_backend.cpp::init`` would parse once wired. Names are
+# namespaced by method so prefill and decode each get their own payload
+# in the same .pte.
+PAYLOAD_KEY_VERSION = "version"
+PAYLOAD_KEY_METHOD_NAME = "method_name"
+PAYLOAD_KEY_SCHEDULE = "schedule"
+PAYLOAD_KEY_FLOOR = "floor_bytes"
+PAYLOAD_KEY_PIN_FQNS = "pin_fqns"
+# Per-FQN metadata block introduced in v2. List of dicts, one per
+# unique(schedule) FQN, each carrying the shape/dtype/device the
+# runtime needs to wrap borrowed pool allocations and validate the
+# AOTI catalog. See `_serialize_payload` for the wire layout.
+PAYLOAD_KEY_CONSTANTS_METADATA = "constants_metadata"
+
+# Schema version for the emitted offload payload.
+#
+# v2 carries the per-FQN ``constants_metadata`` block (dtype / shape /
+# strides / device). Without it the runtime can't reconstruct the
+# original tensor metadata after installing dummies as the AOTI
+# container's constants (extract_constants_map after install returns
+# the dummies' placeholder metadata, not the originals). The block
+# also enables the source-blob offset formula used to slice
+# `_weights_blob` per-FQN without ever loading the constants to GPU.
+# v1 is rejected at parse with a "rebuild required" message —
+# maintaining two runtime paths for an experimental feature is dead
+# weight.
+SCHEMA_VERSION = 2
+
+
+# --------------------------------------------------------------------------
+# Private compile-spec keys and NamedData wire format
+# --------------------------------------------------------------------------
+# EXPERIMENTAL. All keys below carry leading underscores so they
+# read as "internal" at every callsite and stay invisible to anyone who
+# only inspects the public surface. End users opt in through the public
+# ``CudaPartitioner(weight_offload=True, weight_offload_pin_fqns=[...])``
+# kwargs, which translate to these internal COMPILE specs. The keys
+# themselves stay internal so the stack's own callers can still build
+# raw compile specs.
+#
+# Note the separate axis: load-time budget control. The PUBLIC RUNTIME
+# spec is ``weight_offload_budget_mb`` (int megabytes); the INTERNAL
+# RUNTIME spec for exact-byte budgets is
+# ``_weight_offload_internal_budget_bytes`` (decimal string, used by
+# tests that need byte-level precision below 1 MB granularity). Both
+# are runtime specs (consumed via ``BackendInitContext::get_runtime_spec``),
+# not compile specs.
+
+# Compile-spec key that flips the entire offload pipeline on for a method:
+# triggers the pass at preprocess time and tells the runtime to skip
+# ``update_constants_from_blob``, install pre-load dummies, build the
+# pinned host mirror from ``_weights_blob``, and serve probes through
+# the bounded pool. Value: ``b"1"`` (any non-empty byte string treated
+# as enabled; the runtime only checks presence).
+COMPILE_SPEC_KEY_ENABLE = "_weight_offload_internal_enable"
+
+# Compile-spec key carrying the pin set. Value: NUL-separated UTF-8
+# FQNs. The pass validates the list against the catalog and includes
+# it verbatim in the payload.
+COMPILE_SPEC_KEY_PIN_FQNS = "_weight_offload_internal_pin_fqns"
+
+# NamedDataStore key prefix; full key per method is
+# ``f"{prefix}__{method_name}"`` so prefill and decode coexist in the
+# same .pte.
+NAMED_DATA_KEY_PREFIX = "_weight_offload_payload"
+
+
+def named_data_key_for_method(method_name: str) -> str:
+    """The NamedDataStore key the runtime looks up for ``method_name``'s
+    offload payload."""
+    return f"{NAMED_DATA_KEY_PREFIX}__{method_name}"
+
+
+# Magic constant guarding the binary payload header. Spells out "ETWO"
+# in little-endian ASCII — first four bytes of every payload, easy to
+# grep in hex dumps.
+PAYLOAD_MAGIC = 0x4F575445
+
+# Bounded sizes that the runtime parser also enforces. Anything beyond
+# these caps is a hard fail on both sides — a payload that big either
+# means schema drift or an attacker-controlled artifact, neither of
+# which we want to silently accept.
+_MAX_STR_LEN = 1024
+_MAX_SCHEDULE_COUNT = 1_000_000
+_MAX_PIN_COUNT = 100_000
+_MAX_CONSTANTS_METADATA_COUNT = 1_000_000
+_MAX_NDIM = 32
+
+# Single-device assumption. ``create_with_device`` is device-0-only
+# today; lifting it requires plumbing a per-method device index
+# through the payload, runtime, and partitioner kwargs.
+_CUDA_DEVICE_TYPE = 1
+_REQUIRED_DEVICE_INDEX = 0
+
+# torch.dtype -> integer code, matching c10::ScalarType (which AOTI and
+# the slim ScalarType the runtime uses both follow). The runtime's
+# elementSize(static_cast<ScalarType>(dtype)) must agree with this.
+#
+# RESTRICTED to dtypes the slim ScalarType enum
+# (backends/aoti/slim/c10/core/ScalarType.h) actually implements. The
+# slim ScalarType is the subset the runtime can validate + size, so
+# advertising dtype codes the runtime would ET_CHECK on (e.g. Double,
+# Complex*, QInt*) is worse than refusing the export here. To add a
+# dtype: (1) extend slim's ScalarType enum + elementSize switch +
+# isValidScalarType, then (2) add the torch dtype here.
+_TORCH_DTYPE_TO_C10 = {
+    torch.uint8: 0,
+    torch.int8: 1,
+    torch.int16: 2,
+    torch.int32: 3,
+    torch.int64: 4,
+    torch.float16: 5,
+    torch.float32: 6,
+    torch.bool: 11,
+    torch.bfloat16: 15,
+}
+
+
+def _pack_str(buf: bytearray, s: str) -> None:
+    b = s.encode("utf-8")
+    if len(b) > _MAX_STR_LEN:
+        raise ValueError(
+            f"weight offload: string too long for payload ({len(b)} > "
+            f"{_MAX_STR_LEN}): {s!r}"
+        )
+    buf += struct.pack("<I", len(b))
+    buf += b
+
+
+def _serialize_payload(payload: dict) -> bytes:
+    """Serialize the offload payload to the runtime wire format.
+
+    Layout (little-endian throughout):
+      ``magic``                    uint32   = ``PAYLOAD_MAGIC``
+      ``schema_version``           uint32   = 2
+      ``method_name_len``          uint32
+      ``method_name``              UTF-8 bytes
+      ``floor_bytes``              uint64
+      ``schedule_count``           uint32
+      for each schedule entry:
+        ``fqn_len``                uint32
+        ``fqn``                    UTF-8 bytes
+      ``pin_count``                uint32
+      for each pin entry:
+        ``fqn_len``                uint32
+        ``fqn``                    UTF-8 bytes
+      ``constants_metadata_count`` uint32
+      for each metadata entry:
+        ``fqn_len``                uint32
+        ``fqn``                    UTF-8 bytes
+        ``dtype``                  int32   (c10::ScalarType)
+        ``ndim``                   uint32
+        ``sizes[ndim]``            int64 each
+        ``strides[ndim]``          int64 each
+        ``storage_offset``         int64
+        ``nbytes``                 uint64
+        ``device_type``            int32   (== 1 = CUDA)
+        ``device_index``           int32   (== 0; single-device only)
+
+    Custom binary (not JSON) because the runtime must stay free of
+    JSON-parser dependencies for a private, fixed-shape payload.
+    """
+    method_name = payload[PAYLOAD_KEY_METHOD_NAME]
+    schedule = payload[PAYLOAD_KEY_SCHEDULE]
+    pin_fqns = payload[PAYLOAD_KEY_PIN_FQNS]
+    floor_bytes = payload[PAYLOAD_KEY_FLOOR]
+    schema_version = payload[PAYLOAD_KEY_VERSION]
+    constants_metadata = payload[PAYLOAD_KEY_CONSTANTS_METADATA]
+
+    if len(schedule) > _MAX_SCHEDULE_COUNT:
+        raise ValueError(
+            f"weight offload: schedule too long ({len(schedule)} > "
+            f"{_MAX_SCHEDULE_COUNT})"
+        )
+    if len(pin_fqns) > _MAX_PIN_COUNT:
+        raise ValueError(
+            f"weight offload: pin_fqns too long ({len(pin_fqns)} > "
+            f"{_MAX_PIN_COUNT})"
+        )
+    if len(constants_metadata) > _MAX_CONSTANTS_METADATA_COUNT:
+        raise ValueError(
+            f"weight offload: constants_metadata too long "
+            f"({len(constants_metadata)} > {_MAX_CONSTANTS_METADATA_COUNT})"
+        )
+
+    buf = bytearray()
+    buf += struct.pack("<I", PAYLOAD_MAGIC)
+    buf += struct.pack("<I", schema_version)
+    _pack_str(buf, method_name)
+    buf += struct.pack("<Q", floor_bytes)
+    buf += struct.pack("<I", len(schedule))
+    for fqn in schedule:
+        _pack_str(buf, fqn)
+    buf += struct.pack("<I", len(pin_fqns))
+    for fqn in pin_fqns:
+        _pack_str(buf, fqn)
+    buf += struct.pack("<I", len(constants_metadata))
+    for entry in constants_metadata:
+        _pack_str(buf, entry["fqn"])
+        buf += struct.pack("<i", entry["dtype"])
+        sizes = entry["sizes"]
+        strides = entry["strides"]
+        if len(sizes) != len(strides):
+            raise ValueError(
+                f"weight offload: sizes/strides length mismatch for "
+                f"{entry['fqn']!r}: {len(sizes)} vs {len(strides)}"
+            )
+        if len(sizes) > _MAX_NDIM:
+            raise ValueError(
+                f"weight offload: ndim {len(sizes)} > {_MAX_NDIM} for "
+                f"{entry['fqn']!r}"
+            )
+        buf += struct.pack("<I", len(sizes))
+        for s in sizes:
+            buf += struct.pack("<q", s)
+        for st in strides:
+            buf += struct.pack("<q", st)
+        buf += struct.pack("<q", entry["storage_offset"])
+        buf += struct.pack("<Q", entry["nbytes"])
+        buf += struct.pack("<i", entry["device_type"])
+        buf += struct.pack("<i", entry["device_index"])
+    return bytes(buf)
+
+
+def _parse_pin_fqns_spec(value: bytes) -> list[str]:
+    """Decode the NUL-separated UTF-8 pin-FQN compile-spec value into a
+    list. Empty value -> empty list."""
+    if not value:
+        return []
+    return [chunk.decode("utf-8") for chunk in value.split(b"\x00") if chunk]
+
+
+def pin_fqns_from_specs(compile_specs) -> list[str]:
+    """Extract pin-FQN list from compile specs (NUL-separated UTF-8).
+    Empty list if the spec is absent."""
+    for spec in compile_specs:
+        if spec.key == COMPILE_SPEC_KEY_PIN_FQNS:
+            return _parse_pin_fqns_spec(bytes(spec.value))
+    return []
+
+
+def _placeholder_fqn_map(exported_program) -> dict[str, str]:
+    """Build a ``placeholder_node.name -> FQN`` map for parameter and
+    buffer placeholders. Other placeholder kinds are intentionally
+    skipped — USER_INPUT is per-call data, CONSTANT_TENSOR is too
+    fine-grained for offload's bookkeeping, and the rest aren't
+    tensor weights.
+
+    ``torch.export`` auto-lifts inline scalar literals (e.g. the
+    ``1.0`` in ``x + 1.0``) into buffer placeholders with the name
+    ``_lifted_tensor_constant*``. AOTI folds these into kernel code
+    and never surfaces them through ``extract_constants_map``, so
+    probing them would hand the runtime a schedule FQN that fails
+    the ``schedule ⊆ catalog`` check at init. Skip them by name —
+    matches the torch.export naming convention; if upstream renames
+    the prefix, the runtime catalog check will catch the drift.
+    """
+    from torch.export.graph_signature import InputKind
+
+    return {
+        spec.arg.name: spec.target
+        for spec in exported_program.graph_signature.input_specs
+        if spec.kind in (InputKind.PARAMETER, InputKind.BUFFER)
+        and spec.target is not None
+        and not spec.target.startswith("_lifted_tensor_constant")
+    }
+
+
+def _is_view_op(target) -> bool:
+    """True iff ``target`` is a read-only view op (return aliases an
+    input; no in-place mutation on any input). The pass treats view
+    ops as transparent metadata operations — it never probes them
+    directly; it duplicates them per non-view consumer so each
+    consumer sees its own ``probe(root, probe_id) -> view_chain``
+    pipeline."""
+    if not isinstance(target, torch._ops.OpOverload):
+        return False
+    schema = target._schema
+    if not any(ret.alias_info is not None for ret in schema.returns):
+        return False
+    return not any(
+        arg.alias_info is not None and arg.alias_info.is_write
+        for arg in schema.arguments
+    )
+
+
+_warned_view_targets: set = set()
+
+
+def _warn_unrecognised_view_once(node) -> None:
+    """Hint when ``_build_alias_chains`` couldn't pick a source for a
+    view-op node. Dedup keyed on op target so the same custom view
+    appearing N times emits one warning, not N."""
+    target = getattr(node, "target", None)
+    if target in _warned_view_targets:
+        return
+    _warned_view_targets.add(target)
+    sys.stderr.write(
+        f"[weight_offload_pass] view op {target!r} (node {node.name!r}) "
+        f"had no input matching a known placeholder or alias chain; "
+        f"this view will NOT be probed. If you registered a custom "
+        f"view op that aliases an input not at a leading position, "
+        f"or wraps the aliased input through an unrecognised pattern, "
+        f"the offload pass cannot trace the alias and weights backing "
+        f"that view will fall back to AOTI's eager constants.\n"
+    )
+
+
+def _build_alias_chains(graph, placeholder_fqn):
+    """Map view-chain Nodes back to their root placeholder + the chain
+    of view ops that produced them.
+
+    Returns ``alias_info: dict[Node, (root_placeholder, [view_node, ...])]``.
+    Applying the chain in order, starting from ``root_placeholder``,
+    reproduces the alias node — that's what
+    ``_duplicate_view_chain`` re-emits on top of each fresh probe.
+    """
+    alias_info: dict[torch.fx.Node, tuple[torch.fx.Node, list[torch.fx.Node]]] = {}
+    for node in graph.nodes:
+        if node.op != "call_function" or not _is_view_op(node.target):
+            continue
+        # Views can have multiple tensor inputs (e.g.
+        # ``expand_as(self, other)`` aliases ``self`` only). We pick
+        # the FIRST input that's either a placeholder or an
+        # already-recognised alias. ATen view ops universally place
+        # the aliased tensor at the leading position, but we don't
+        # hard-code ``all_input_nodes[0]`` because that would silently
+        # mis-handle any custom view op that places its aliased input
+        # elsewhere — a first-match scan tolerates the convention
+        # without committing to it.
+        source = next(
+            (
+                inp
+                for inp in node.all_input_nodes
+                if inp.name in placeholder_fqn or inp in alias_info
+            ),
+            None,
+        )
+        if source is None:
+            # Diagnostic: a view op whose inputs include something
+            # that LOOKS like it should alias a placeholder
+            # (transitively) but doesn't match our placeholder /
+            # already-aliased set. Most commonly this is benign (a
+            # view on a fresh intermediate result), but it can also
+            # mean a custom view op rewrote the aliased input through
+            # an unrecognised wrapper. Emit a one-time hint so the
+            # case isn't silently dropped without leaving a trace.
+            _warn_unrecognised_view_once(node)
+            continue
+        if source.name in placeholder_fqn:
+            alias_info[node] = (source, [node])
+        else:
+            root, chain = alias_info[source]
+            alias_info[node] = (root, [*chain, node])
+    return alias_info
+
+
+def _duplicate_view_chain(graph, probe_node, chain, original_root):
+    """Re-emit each view op in ``chain`` rooted at ``probe_node`` instead
+    of ``original_root``. Returns the new tail node (the leaf of the
+    duplicated chain — what the consumer will read from)."""
+    current = probe_node
+    prev_original = original_root
+    for orig in chain:
+        new_args = tuple(current if a is prev_original else a for a in orig.args)
+        new_node = graph.call_function(
+            orig.target,
+            args=new_args,
+            kwargs=orig.kwargs,
+        )
+        if "val" in orig.meta:
+            new_node.meta["val"] = orig.meta["val"]
+        prev_original = orig
+        current = new_node
+    return current
+
+
+def _insert_probes_for_node(
+    node, graph, placeholder_fqn, alias_info, schedule, probe_fqn
+):
+    """Walk ``node.args`` / ``node.kwargs``, replacing each placeholder
+    or view-of-placeholder reference with a freshly-inserted
+    ``probe(root, probe_id)`` followed (when the original arg was a
+    view) by a duplicated view chain. Mutates ``schedule`` by
+    appending the rewritten FQN at the new probe's ``probe_id``, and
+    ``probe_fqn`` with the inserted probe Node mapped to its FQN
+    (used downstream by the transitive floor analysis)."""
+
+    def _maybe_probe(arg):
+        if not isinstance(arg, torch.fx.Node):
+            return arg
+
+        if arg.name in placeholder_fqn:
+            root = arg
+            chain: list[torch.fx.Node] = []
+        elif arg in alias_info:
+            root, chain = alias_info[arg]
+        else:
+            return arg
+
+        fqn = placeholder_fqn[root.name]
+        probe_id = len(schedule)
+        schedule.append(fqn)
+        with graph.inserting_before(node):
+            probe_node = graph.call_function(
+                PROBE_OP_TARGET,
+                args=(root, probe_id),
+            )
+            if "val" in root.meta:
+                probe_node.meta["val"] = root.meta["val"]
+            probe_fqn[probe_node] = fqn
+            return _duplicate_view_chain(graph, probe_node, chain, root)
+
+    node.args = torch.fx.map_arg(node.args, _maybe_probe)
+    node.kwargs = torch.fx.map_arg(node.kwargs, _maybe_probe)
+
+
+def _fusion_dependency_sets(
+    graph, probe_fqn: dict[torch.fx.Node, str]
+) -> tuple[dict[torch.fx.Node, set[str]], dict[torch.fx.Node, set[str]]]:
+    """Per-node FX fusion model for the floor calculation.
+
+    Returns ``(working_sets, output_deps)`` after a single topo walk:
+
+      probe node           output_deps = {fqn}
+      view op              output_deps = union(upstream output_deps)
+      fusible call         working_set = union(upstream output_deps)
+                           output_deps = working_set
+      materializing barrier
+                           working_set = union(upstream output_deps)
+                           output_deps = {}
+
+    No op is treated as a confirmed materializing barrier today --
+    proving an op cannot fuse with downstream users under
+    AOTI/Inductor needs the post-lowering kernel-grouping work that
+    a future commit will do. Defaulting to "fusible" overestimates
+    the floor (safe); claiming barrier where none exists
+    underestimates it (corruption). See the ``floor_bytes``
+    description in ``_apply_weight_offload`` for the explicit
+    upper-bound contract.
+    """
+    working_sets: dict[torch.fx.Node, set[str]] = {}
+    output_deps: dict[torch.fx.Node, set[str]] = {}
+
+    for node in graph.nodes:
+        upstream: set[str] = set()
+        for inp in node.all_input_nodes:
+            up = output_deps.get(inp)
+            if up:
+                upstream |= up
+
+        if node in probe_fqn:
+            output_deps[node] = {probe_fqn[node]}
+            continue
+
+        if node.op == "output":
+            # Output is a fusion sink: Inductor may fuse independent
+            # final consumers into one multi-output kernel that
+            # reads every weight any of them touched. Treat it as a
+            # candidate so its upstream union shows up in the pair
+            # window — without this the floor misses the case of
+            # ``return x*w1, x*w2, x*w3, x*w4``.
+            output_deps[node] = upstream
+            if upstream:
+                working_sets[node] = upstream
+            continue
+
+        if node.op != "call_function":
+            # Placeholders, get_attr: nothing to fuse, just carry
+            # whatever came in (empty for true leaves).
+            output_deps[node] = upstream
+            continue
+
+        if _is_view_op(node.target):
+            # Transparent metadata op — no kernel, no working set.
+            output_deps[node] = upstream
+            continue
+
+        # Default: fusible / non-materializing. Replace this branch
+        # with an ``output_deps[node] = set()`` reset once a
+        # confirmed barrier list lands.
+        working_sets[node] = upstream
+        output_deps[node] = upstream
+
+    return working_sets, output_deps
+
+
+def _compute_floor_bytes(
+    graph,
+    probe_fqn: dict[torch.fx.Node, str],
+    pin_set: set[str],
+    nbytes_of,
+) -> int:
+    """Conservative FX fusion upper bound on the streaming-pool
+    floor — NOT a tight kernel-level estimate. See the contract
+    text in ``_apply_weight_offload``.
+
+    Formula: ``max over consecutive FX candidate pairs of (sum
+    bytes of the UNION of non-pinned working sets at each side) +
+    max single non-pinned weight``. FX candidates are non-view
+    non-probe ``call_function`` nodes plus the output sink (the
+    output is included so that Inductor fusing independent final
+    consumers into one multi-output kernel still factors in). The
+    working set comes from ``_fusion_dependency_sets`` and
+    propagates probe FQNs through every fusion-eligible edge (the
+    pass refuses to claim any op is a barrier without proof). The
+    pair window layers depth-1 prefetch on top; the ``+ max
+    single`` is eviction headroom for swapping the largest weight.
+    """
+    working_sets, _ = _fusion_dependency_sets(graph, probe_fqn)
+
+    def non_pinned(s: set[str]) -> set[str]:
+        return s - pin_set
+
+    # ``working_sets`` is populated in ``graph.nodes`` iteration
+    # order, so its insertion order is graph order in Python 3.7+
+    # — the pair window relies on that for "consecutive consumers".
+    candidates = [
+        (node, non_pinned(ws)) for node, ws in working_sets.items() if non_pinned(ws)
+    ]
+    if not candidates:
+        return 0
+
+    def sum_bytes(fqns: set[str]) -> int:
+        return sum(nbytes_of(fqn) for fqn in fqns)
+
+    n = len(candidates)
+    max_window = max(
+        sum_bytes(candidates[i][1] | (candidates[i + 1][1] if i + 1 < n else set()))
+        for i in range(n)
+    )
+    all_non_pinned: set[str] = set().union(*(ws for _, ws in candidates))
+    max_single = max(nbytes_of(fqn) for fqn in all_non_pinned)
+    return max_window + max_single
+
+
+def _apply_weight_offload(
+    exported_program,
+    *,
+    method_name: str,
+    pin_fqns: list[str] | None = None,
+) -> dict:
+    """In-place graph rewrite + offload payload computation.
+
+    Internal: the only supported caller is
+    ``CudaBackend.pre_aoti_transform_and_collect_named_data``. The
+    ``method_name`` arg is required (no default) so a direct caller
+    on a multi-method model cannot silently collide all methods on
+    ``"forward"``.
+
+    Mutates ``exported_program`` in place: inserts ``probe(w, probe_id)``
+    in front of every consumer of every parameter / buffer placeholder
+    and rewrites the consumer's arg to read the probe's output. One
+    probe per ``(consumer, weight)`` pair so the runtime can re-load
+    a weight evicted between two uses in the same forward pass.
+    ``probe_id`` is dense 0..N-1 in graph order.
+
+    Returns the offload payload dict (see ``PAYLOAD_KEY_*`` at module
+    scope for the schema):
+      * ``schedule[probe_id]`` is the FQN that probe site reads;
+        pinned FQNs appear here too (the runtime picks the resident
+        path inside ``serve``).
+      * ``floor_bytes`` is a conservative FX-fusion-aware upper bound
+        on the streaming pool, excluding pinned FQNs. The runtime
+        hard-fails if ``budget - pinned < floor``.
+      * ``pin_fqns`` is the resident set, deduped first-seen-order.
+      * ``constants_metadata`` carries per-FQN dtype / sizes / strides
+        / storage_offset / nbytes / device for runtime cross-check.
+
+    Re-entry: this pass MUST run before AOTI compile (it operates on
+    placeholders) and MUST NOT be re-run on a graph that already
+    contains probe nodes -- the second pass would insert probes on
+    the probes' outputs.
+    """
+    pin_fqns = list(pin_fqns or [])
+    graph = exported_program.graph_module.graph
+
+    # Re-entering the pass would wrap each probe's input (still a
+    # placeholder Node) in a fresh probe, leaving the graph with
+    # probe-of-probe-of-w and a schedule that no longer matches the
+    # ``probe_id`` values the runtime sees. Loud failure beats subtle
+    # wrong answers.
+    existing = sum(
+        1
+        for n in graph.nodes
+        if n.op == "call_function" and n.target is PROBE_OP_TARGET
+    )
+    if existing:
+        raise RuntimeError(
+            f"weight offload: pass already applied to this ExportedProgram "
+            f"({existing} probe(s) present); re-applying is a caller bug"
+        )
+
+    placeholder_fqn = _placeholder_fqn_map(exported_program)
+    catalog_fqns = set(placeholder_fqn.values())
+    for fqn in pin_fqns:
+        if fqn not in catalog_fqns:
+            raise ValueError(
+                f"weight offload: pin_fqns references {fqn!r} which is not a "
+                f"parameter or buffer placeholder; available: "
+                f"{sorted(catalog_fqns)}"
+            )
+
+    # Snapshot the original view chains before any insertion. The
+    # main loop's iteration is also a snapshot, so newly-inserted
+    # probe and duplicated-view nodes are NOT re-traversed.
+    alias_info = _build_alias_chains(graph, placeholder_fqn)
+
+    # Walk consumers in graph order. View ops are skipped — they get
+    # duplicated per non-view consumer inside ``_insert_probes_for_node``.
+    # ``probe_id`` is assigned by ``len(schedule)`` at insertion time,
+    # which gives contiguous 0..N-1 in the order ``torch.fx.map_arg``
+    # visits non-view consumer arguments — the same order ``schedule``
+    # indexes, which is what the runtime ultimately keys on.
+    schedule: list[str] = []
+    probe_fqn: dict[torch.fx.Node, str] = {}
+    for node in list(graph.nodes):
+        if node.op != "call_function" or _is_view_op(node.target):
+            continue
+        _insert_probes_for_node(
+            node, graph, placeholder_fqn, alias_info, schedule, probe_fqn
+        )
+
+    # Original view chains lose their last user once consumers are
+    # rewritten onto duplicates. Drop them so the graph stays small
+    # and AOTI doesn't waste codegen on unreferenced views.
+    graph.eliminate_dead_code()
+    exported_program.graph_module.recompile()
+
+    state_dict = exported_program.state_dict
+    constants = getattr(exported_program, "constants", {}) or {}
+
+    def _nbytes(fqn: str) -> int:
+        if fqn in state_dict:
+            t = state_dict[fqn]
+        elif fqn in constants:
+            t = constants[fqn]
+        else:
+            raise KeyError(
+                f"weight offload: FQN {fqn!r} appears as a placeholder but "
+                f"is missing from state_dict and constants"
+            )
+        # The host mirror is sized at numel * element_size; a non-
+        # contiguous tensor would over-read its storage. The runtime
+        # parser also rejects non-contiguous metadata, but flagging
+        # here names the FQN with a Python stack trace.
+        if not t.is_contiguous():
+            raise ValueError(
+                f"weight offload: FQN {fqn!r} is non-contiguous "
+                f"(shape={tuple(t.shape)}, strides={tuple(t.stride())}); "
+                f"call .contiguous() on the source tensor before exporting"
+            )
+        return t.numel() * t.element_size()
+
+    pin_set = set(pin_fqns)
+    # Drop probes from the map whose nodes were eliminated as dead
+    # code (defensive — the rewriter currently always leaves probes
+    # with a consumer).
+    live_nodes = set(graph.nodes)
+    probe_fqn = {p: f for p, f in probe_fqn.items() if p in live_nodes}
+    floor_bytes = _compute_floor_bytes(graph, probe_fqn, pin_set, _nbytes)
+
+    # Build per-FQN metadata for unique(schedule). v2 payload requires
+    # this so the runtime can wrap pool allocations with original
+    # dtype/shape after replacing AOTI's constants with dummies.
+    constants_metadata = _build_constants_metadata(schedule, state_dict, constants)
+
+    return {
+        PAYLOAD_KEY_VERSION: SCHEMA_VERSION,
+        PAYLOAD_KEY_METHOD_NAME: method_name,
+        PAYLOAD_KEY_SCHEDULE: schedule,
+        PAYLOAD_KEY_FLOOR: floor_bytes,
+        PAYLOAD_KEY_PIN_FQNS: pin_fqns,
+        PAYLOAD_KEY_CONSTANTS_METADATA: constants_metadata,
+    }
+
+
+def _build_constants_metadata(
+    schedule: list[str], state_dict: dict, constants: dict
+) -> list[dict]:
+    """One entry per unique(schedule) FQN, preserving first-seen order
+    so the runtime can iterate deterministically. The runtime parser
+    re-validates set-equality with unique(schedule); first-seen order
+    here matches the order the pass emits, which keeps any later
+    diff-based debugging readable."""
+    out: list[dict] = []
+    seen: set[str] = set()
+    for fqn in schedule:
+        if fqn in seen:
+            continue
+        seen.add(fqn)
+        if fqn in state_dict:
+            t = state_dict[fqn]
+        elif fqn in constants:
+            t = constants[fqn]
+        else:
+            raise KeyError(
+                f"weight offload: FQN {fqn!r} appears in schedule but "
+                f"is missing from state_dict and constants"
+            )
+        if t.dtype not in _TORCH_DTYPE_TO_C10:
+            raise ValueError(
+                f"weight offload: FQN {fqn!r} has unsupported dtype "
+                f"{t.dtype}; extend _TORCH_DTYPE_TO_C10 and the runtime "
+                f"ScalarType enum together"
+            )
+        # Offload mirrors each constant's LOGICAL bytes densely. A constant
+        # backed by a storage larger than its logical size (a view into a
+        # bigger buffer: contiguous + offset 0 but backed by extra bytes,
+        # e.g. ``big[:k]``) would break that: AOTI's per-constant data_size
+        # is ``untyped_storage().nbytes()``, so the dense source-blob offset
+        # math the runtime relies on would misalign. The runtime catches
+        # this via its nbytes==data_size cross-check; naming the FQN at
+        # export is friendlier. The runtime parser stays the trust boundary
+        # (including the cuda:0 device requirement, which is enforced there
+        # and re-checked by AOTI's user-managed install); this is UX only.
+        if t.untyped_storage().nbytes() != t.numel() * t.element_size():
+            raise ValueError(
+                f"weight offload: FQN {fqn!r} is backed by a storage "
+                f"({t.untyped_storage().nbytes()} bytes) larger than its "
+                f"logical size ({t.numel() * t.element_size()} bytes); it "
+                f"likely aliases a view into a bigger buffer. Call "
+                f".contiguous().clone() on the source tensor before exporting."
+            )
+        sizes = list(t.shape)
+        # Hard-fail zero-size constants at the pass. cudaHostAlloc(0)
+        # and friends are undefined; better to surface this at export
+        # than to ship four under-tested edge cases.
+        product = 1
+        for s in sizes:
+            product *= s
+        if product == 0:
+            raise ValueError(
+                f"weight offload: FQN {fqn!r} has zero-product shape "
+                f"{sizes}; offload does not support empty constants"
+            )
+        out.append(
+            {
+                "fqn": fqn,
+                "dtype": _TORCH_DTYPE_TO_C10[t.dtype],
+                "sizes": sizes,
+                "strides": list(t.stride()),
+                "storage_offset": int(t.storage_offset()),
+                "nbytes": t.numel() * t.element_size(),
+                "device_type": _CUDA_DEVICE_TYPE,
+                "device_index": _REQUIRED_DEVICE_INDEX,
+            }
+        )
+    return out

--- a/backends/cuda/runtime/TARGETS
+++ b/backends/cuda/runtime/TARGETS
@@ -36,6 +36,8 @@ runtime.cxx_library(
         "shims/rand.cu",
         "shims/sort.cu",
         "shims/tensor_attribute.cpp",
+        "weight_offload/probe_op.cpp",
+        "weight_offload/probe_registry.cpp",
     ],
     headers = [
         "shims/cuda_guard.h",
@@ -46,6 +48,8 @@ runtime.cxx_library(
         "shims/sort.h",
         "shims/tensor_attribute.h",
         "utils.h",
+        "weight_offload/probe_op.h",
+        "weight_offload/probe_registry.h",
     ],
     # @lint-ignore BUCKLINT: Avoid `link_whole=True` (https://fburl.com/avoid-link-whole)
     link_whole = True,
@@ -105,9 +109,12 @@ runtime.cxx_library(
     name = "cuda_backend",
     srcs = [
         "cuda_backend.cpp",
+        "weight_offload/session.cpp",
     ],
     headers = [
         "cuda_delegate_handle.h",
+        "weight_offload/payload.h",
+        "weight_offload/session.h",
     ],
     # @lint-ignore BUCKLINT: Avoid `link_whole=True` (https://fburl.com/avoid-link-whole)
     link_whole = True,

--- a/backends/cuda/runtime/cuda_backend.cpp
+++ b/backends/cuda/runtime/cuda_backend.cpp
@@ -15,7 +15,10 @@
 #include <executorch/runtime/core/exec_aten/util/scalar_type_util.h>
 #include <executorch/runtime/core/exec_aten/util/tensor_util.h>
 #include <cctype>
+#include <cerrno>
 #include <cstdio>
+#include <cstdlib>
+#include <limits>
 
 #include <array>
 #include <atomic>
@@ -25,10 +28,12 @@
 #include <string>
 #include <string_view>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 // Include SlimTensor headers for CUDA backend
 #include <executorch/backends/aoti/slim/c10/core/Device.h>
+#include <executorch/backends/aoti/slim/c10/core/ScalarType.h>
 #include <executorch/backends/aoti/slim/c10/cuda/Exception.h>
 #include <executorch/backends/aoti/slim/core/slim_tensor.h>
 #include <executorch/backends/aoti/slim/core/storage.h>
@@ -45,6 +50,8 @@
 #include <executorch/backends/cuda/runtime/platform/platform.h>
 #include <executorch/backends/cuda/runtime/shims/memory.h>
 #include <executorch/backends/cuda/runtime/utils.h>
+#include <executorch/backends/cuda/runtime/weight_offload/payload.h>
+#include <executorch/backends/cuda/runtime/weight_offload/session.h>
 
 namespace executorch::backends::cuda {
 
@@ -261,6 +268,11 @@ class ET_EXPERIMENTAL CudaBackend final
     LOAD_OPTIONAL_SYMBOL(
         update_user_managed_constant_buffer_pairs,
         AOTInductorModelContainerUpdateUserManagedConstantBufferPairs);
+    LOAD_OPTIONAL_SYMBOL(
+        get_constant_data_size, AOTInductorModelContainerGetConstantDataSize);
+    LOAD_OPTIONAL_SYMBOL(
+        get_constant_from_folded,
+        AOTInductorModelContainerGetConstantFromFolded);
 #undef LOAD_OPTIONAL_SYMBOL
 
     return Error::Ok;
@@ -340,11 +352,16 @@ class ET_EXPERIMENTAL CudaBackend final
       ArrayRef<CompileSpec> compile_specs // This will be my empty list
   ) const override {
     std::string method_name;
+    bool weight_offload_enabled = false;
     for (const CompileSpec& spec : compile_specs) {
       if (std::strcmp(spec.key, "method_name") == 0) {
         method_name.assign(
             static_cast<const char*>(spec.value.buffer),
             spec.value.nbytes); // no nullptr guarantee, so pass size
+      } else if (
+          std::strcmp(spec.key, weight_offload::kEnableCompileSpecKey) == 0 &&
+          spec.value.nbytes > 0) {
+        weight_offload_enabled = true;
       }
     }
 
@@ -352,6 +369,111 @@ class ET_EXPERIMENTAL CudaBackend final
         method_name.empty() ? "so_blob" : method_name + "_so_blob";
 
     const NamedDataMap* named_data_map = context.get_named_data_map();
+
+    // EXPERIMENTAL weight-offload payload: parsed up front so a bad
+    // artifact hard-fails before we burn time loading the .so.
+    // Catalog validation happens AFTER constants are loaded (below)
+    // so the catalog's data_ptrs reflect the FINAL active handles
+    // — cross-method weight sharing can swap pointers during load.
+    //
+    // All diagnostics in the offload path go through
+    // ``fprintf(stderr, ...)`` rather than ``ET_LOG`` /
+    // ``ET_CHECK_OR_RETURN_ERROR``. The default ExecuTorch build
+    // sets ``ET_LOG_ENABLED=0``, which suppresses the diagnostic
+    // message those macros emit on failure (the early-return itself
+    // still happens). The offload opt-in contract is "loud at init"
+    // — both the success path and the hard-fail paths must produce
+    // stderr output that identifies the cause regardless of the
+    // logging build flag. Matches the probe-trace pattern in
+    // ``runtime/weight_offload/probe_op.cpp``.
+    //
+    // When the opt-in is absent the payload is ignored even if
+    // present in the NamedDataMap — no leakage from disabled state.
+    weight_offload::Payload offload_payload;
+    if (weight_offload_enabled) {
+      // Mutually exclusive with CUDA Graph for this method: graph
+      // Replay bypasses AOTI's ``run()`` entirely, so probe ops
+      // never fire and the offload Session has no way to swap
+      // weights in. Hard-fail at init so a stale config can't
+      // silently degrade to "graph replays with stale weights".
+      if (should_use_cuda_graph_for_method(method_name)) {
+        std::fprintf(
+            stderr,
+            "[ET_WEIGHT_OFFLOAD][ERROR] method '%s': offload and "
+            "enable_cuda_graph_for_method are mutually exclusive\n",
+            method_name.c_str());
+        return Error::InvalidArgument;
+      }
+
+      auto offload_key = weight_offload::named_data_key_for_method(method_name);
+      auto offload_buf = named_data_map->get_data(offload_key.c_str());
+      if (!offload_buf.ok()) {
+        std::fprintf(
+            stderr,
+            "[ET_WEIGHT_OFFLOAD][ERROR] enabled but payload missing at key "
+            "'%s' (error 0x%x)\n",
+            offload_key.c_str(),
+            static_cast<uint32_t>(offload_buf.error()));
+        return Error::Internal;
+      }
+      auto parsed = weight_offload::parse_payload(
+          offload_buf->data(), offload_buf->size(), method_name);
+      if (!parsed.ok()) {
+        std::fprintf(
+            stderr,
+            "[ET_WEIGHT_OFFLOAD][ERROR] payload parse failed for "
+            "method '%s' (error 0x%x)\n",
+            method_name.c_str(),
+            static_cast<uint32_t>(parsed.error()));
+        offload_buf->Free();
+        return Error::InvalidArgument;
+      }
+      offload_payload = std::move(parsed.get());
+      offload_buf->Free();
+
+      // Fail-fast on incompatible runtime modes BEFORE container
+      // creation / .so load / blob fetching — no point allocating
+      // GPU state for a config we'd throw away. pin_fqns dedup,
+      // device_index==0, and per-FQN metadata invariants are all
+      // enforced by the payload parser.
+      //
+      // Disallow shared-stream mode with offload. The shared stream
+      // (see create_shared_cuda_stream) is created on whichever
+      // device happened to be current at the time of the first
+      // create_shared_cuda_stream call; we have no way to verify
+      // that matches the device offload was set up on. Rather than
+      // silently corrupt on multi-GPU hosts, hard-fail at init.
+      if (is_using_shared_cuda_stream()) {
+        std::fprintf(
+            stderr,
+            "[ET_WEIGHT_OFFLOAD][ERROR] method '%s': offload + "
+            "use_shared_cuda_stream is unsupported (shared stream's "
+            "creation device may not match the offload device)\n",
+            method_name.c_str());
+        return Error::InvalidArgument;
+      }
+
+      // Bind the device BEFORE any subsequent CUDA work that this
+      // offload-enabled init does: create_with_device(..., "cuda",
+      // nullptr) uses the CURRENT device (see
+      // model_base.h:433-ish — AOTI parses the string and only
+      // overrides via explicit "cuda:N"), and the per-handle stream
+      // creation later in this function inherits the current device
+      // too. Without this, a process whose current device is not 0
+      // would silently land the container + stream on one GPU while
+      // dummies, pool, and payload assume device 0.
+      cudaError_t set_dev_err = cudaSetDevice(0);
+      if (set_dev_err != cudaSuccess) {
+        std::fprintf(
+            stderr,
+            "[ET_WEIGHT_OFFLOAD][ERROR] cudaSetDevice(0) failed for "
+            "method '%s': %s\n",
+            method_name.c_str(),
+            cudaGetErrorString(set_dev_err));
+        return Error::Internal;
+      }
+    }
+
     auto aoti_dso_buffer = named_data_map->get_data(so_blob_key.c_str());
     ET_CHECK_OR_RETURN_ERROR(
         aoti_dso_buffer.ok(),
@@ -396,7 +518,33 @@ class ET_EXPERIMENTAL CudaBackend final
 
     processed->Free();
 
-    // Create handle and load function pointers into it
+    // Create handle and load function pointers into it.
+    //
+    // Ownership note: every error path below does `delete handle;
+    // return Error::Internal;` without an explicit
+    // `AOTInductorModelContainerDelete(handle->container_handle)`.
+    // That mirrors the success-path destroy() at the bottom of this
+    // file (see the "AOTInductorModelContainerDelete does not work
+    // correctly with multiple .so files" note there) — the container
+    // is intentionally never deleted by CudaBackend; we leak the
+    // container in both success and error paths. The `delete handle`
+    // here frees only the C++ wrapper struct.
+    //
+    // Leak budget: ONE container per init() call that gets past
+    // container_create + load_function_pointers. Both success and
+    // error inits leak the same way; the per-process leak count is
+    // proportional to total init() calls (success + failure), not
+    // to error rate. The pre-offload init had a small per-init
+    // failure surface (mostly file IO + dlopen); offload widens it
+    // (constant-coverage check, AOTI<->payload data_size mismatch,
+    // dummy install, host-mirror alloc, pool/stream create, pinned
+    // alloc, ProbeRegistry collision). Hot-reload callers
+    // (re-init'ing the same model in a loop on init failure) should
+    // budget for a steady GPU leak of ~constants_size + a fixed
+    // per-container overhead per failed retry, and either retry
+    // with a fresh process or gate the retry rate accordingly. A
+    // proper fix lives upstream — see TODO(gasoonjia) at the
+    // destroy() site.
     cuda::CudaDelegateHandle* handle = new cuda::CudaDelegateHandle();
     handle->so_handle = lib_handle;
     handle->so_path = so_path.string();
@@ -415,19 +563,34 @@ class ET_EXPERIMENTAL CudaBackend final
 
     handle->container_handle = container_handle;
 
-    // Load constants. When weight_sharing_across_methods is enabled (opt-in
-    // via the kWeightSharingAcrossMethods runtime backend option set by the
-    // runner), use the per-weight FQN cache so methods that share weights
-    // (e.g. prefill/decode) avoid duplicate GPU allocations. Otherwise fall
-    // back to the legacy per-method blob load — required for models whose
-    // methods are independent sub-graphs that may have FQN collisions
-    // (e.g. parakeet).
-    if (is_weight_sharing_across_methods_enabled()) {
-      ET_CHECK_OK_OR_RETURN_ERROR(
-          load_constants_with_cache(handle, named_data_map, method_name));
+    // Load constants. For OFFLOAD-ENABLED methods, we SKIP
+    // update_constants_from_blob entirely and instead install 1-byte
+    // GPU dummies via update_user_managed_constant_buffer_pairs
+    // BEFORE any AOTI run. AOTI's container then has the dummies as
+    // its active constants; the probe op intercepts every read and
+    // routes through Session::serve, which serves from a pinned host
+    // mirror sourced directly from the _weights_blob NamedData entry
+    // (no GPU allocation for the constants at any point).
+    //
+    // For non-offload methods, the existing eager-load paths apply.
+    if (!weight_offload_enabled) {
+      if (is_weight_sharing_across_methods_enabled()) {
+        ET_CHECK_OK_OR_RETURN_ERROR(
+            load_constants_with_cache(handle, named_data_map, method_name));
+      } else {
+        ET_CHECK_OK_OR_RETURN_ERROR(
+            load_constants_legacy(handle, named_data_map, method_name));
+      }
     } else {
-      ET_CHECK_OK_OR_RETURN_ERROR(
-          load_constants_legacy(handle, named_data_map, method_name));
+      // Distinct tag (not the [ET_WEIGHT_OFFLOAD] success-summary
+      // prefix) so transport tests counting the success line aren't
+      // tripped up. Tests assert the exact "skipped" phrase to verify
+      // the eager-load path is bypassed.
+      std::fprintf(
+          stderr,
+          "[ET_WEIGHT_OFFLOAD_SKIP] skipped update_constants_from_blob "
+          "method=%s\n",
+          method_name.c_str());
     }
 
     // Use shared CUDA stream if enabled via options, otherwise create one.
@@ -455,6 +618,191 @@ class ET_EXPERIMENTAL CudaBackend final
           method_name.c_str());
     }
 
+    // EXPERIMENTAL: build the offload Session now that the compute
+    // stream is in place. Session owns the copy stream + pool + host
+    // mirror + dummies. AOTI's container has dummies installed in
+    // place of constants; the probe op intercepts every read and
+    // routes to Session::serve, which serves from a pinned host
+    // mirror sourced directly from the _weights_blob NamedData entry
+    // (no GPU constants are ever allocated).
+    if (weight_offload_enabled) {
+      // Thin shim: this scope owns the AOTI-handle-requiring checks
+      // (folded constants, schedule <-> catalog coverage, AOTI vs
+      // payload data_size cross-check) and hands the AOTI catalog +
+      // blob to Session::create, which owns dummy creation + AOTI
+      // install + budget resolution + host mirror + pool +
+      // ProbeRegistry registration.
+      auto catalog_res = weight_offload::walk_aoti_catalog(handle, method_name);
+      if (!catalog_res.ok()) {
+        delete handle;
+        return catalog_res.error();
+      }
+      auto catalog = std::move(catalog_res.get());
+
+      // Coverage: catalog.fqns set == unique(schedule).
+      std::unordered_set<std::string> schedule_fqns(
+          offload_payload.schedule.begin(), offload_payload.schedule.end());
+      for (const auto& f : catalog.fqns) {
+        if (schedule_fqns.find(f) == schedule_fqns.end()) {
+          std::fprintf(
+              stderr,
+              "[ET_WEIGHT_OFFLOAD][ERROR] method '%s': catalog FQN '%s' "
+              "not in schedule (missing probe coverage)\n",
+              method_name.c_str(),
+              f.c_str());
+          delete handle;
+          return Error::InvalidArgument;
+        }
+      }
+      for (const auto& f : schedule_fqns) {
+        if (catalog.fqn_to_index.find(f) == catalog.fqn_to_index.end()) {
+          std::fprintf(
+              stderr,
+              "[ET_WEIGHT_OFFLOAD][ERROR] method '%s': schedule FQN '%s' "
+              "not in AOTI catalog (folded or drift vs the .so)\n",
+              method_name.c_str(),
+              f.c_str());
+          delete handle;
+          return Error::InvalidArgument;
+        }
+      }
+      if (schedule_fqns.empty() && catalog.num_constants != 0) {
+        std::fprintf(
+            stderr,
+            "[ET_WEIGHT_OFFLOAD][ERROR] method '%s': schedule=[] but "
+            "container has %zu constants\n",
+            method_name.c_str(),
+            catalog.num_constants);
+        delete handle;
+        return Error::InvalidArgument;
+      }
+
+      // AOTI data_size vs payload nbytes: the only check that bridges
+      // the two independent sources (AOTI's compiled .so vs the .pte
+      // payload). The parser validated the payload internals; this
+      // catches pass <-> AOTI drift.
+      std::unordered_map<std::string, const weight_offload::ConstantMetadata*>
+          fqn_to_meta;
+      fqn_to_meta.reserve(offload_payload.constants_metadata.size());
+      for (const auto& m : offload_payload.constants_metadata) {
+        fqn_to_meta[m.fqn] = &m;
+      }
+      uint64_t total_data_size = 0;
+      for (size_t i = 0; i < catalog.num_constants; ++i) {
+        const auto& fqn = catalog.fqns[i];
+        const auto& m = *fqn_to_meta.at(fqn);
+        if (m.nbytes != static_cast<uint64_t>(catalog.data_sizes[i])) {
+          std::fprintf(
+              stderr,
+              "[ET_WEIGHT_OFFLOAD][ERROR] FQN '%s': AOTI data_size=%zu "
+              "vs payload nbytes=%llu (pass <-> AOTI drift)\n",
+              fqn.c_str(),
+              catalog.data_sizes[i],
+              static_cast<unsigned long long>(m.nbytes));
+          delete handle;
+          return Error::InvalidArgument;
+        }
+        total_data_size += static_cast<uint64_t>(catalog.data_sizes[i]);
+      }
+
+      // Fetch _weights_blob (RAII-released when this scope exits;
+      // Session::create copies into pinned host memory before
+      // returning so it's safe to drop after).
+      auto blob_key = std::string(method_name).empty()
+          ? std::string("weights_blob")
+          : method_name + "_weights_blob";
+      auto blob_buf = named_data_map->get_data(blob_key.c_str());
+      if (!blob_buf.ok()) {
+        std::fprintf(
+            stderr,
+            "[ET_WEIGHT_OFFLOAD][ERROR] method '%s': _weights_blob "
+            "'%s' not in named data map (0x%x)\n",
+            method_name.c_str(),
+            blob_key.c_str(),
+            static_cast<uint32_t>(blob_buf.error()));
+        delete handle;
+        return Error::Internal;
+      }
+      struct BlobGuard {
+        decltype(blob_buf)& b;
+        ~BlobGuard() {
+          if (b.ok()) {
+            b->Free();
+          }
+        }
+      } blob_guard{blob_buf};
+      if (total_data_size != blob_buf->size()) {
+        std::fprintf(
+            stderr,
+            "[ET_WEIGHT_OFFLOAD][ERROR] method '%s': _weights_blob size "
+            "mismatch (sum data_size=%llu vs blob=%zu)\n",
+            method_name.c_str(),
+            static_cast<unsigned long long>(total_data_size),
+            blob_buf->size());
+        delete handle;
+        return Error::Internal;
+      }
+
+      const size_t schedule_fqns_count = schedule_fqns.size();
+      const size_t catalog_constants = catalog.num_constants;
+      auto session_res = weight_offload::Session::create(
+          offload_payload,
+          handle,
+          std::move(catalog),
+          static_cast<const uint8_t*>(blob_buf->data()),
+          handle->get_cuda_stream(),
+          context);
+      if (!session_res.ok()) {
+        std::fprintf(
+            stderr,
+            "[ET_WEIGHT_OFFLOAD][ERROR] Session::create failed for "
+            "method '%s' (0x%x)\n",
+            method_name.c_str(),
+            static_cast<uint32_t>(session_res.error()));
+        delete handle;
+        return session_res.error();
+      }
+      handle->weight_offload_session = std::move(session_res.get());
+
+      std::fprintf(
+          stderr,
+          "[ET_WEIGHT_OFFLOAD] method=%s version=%u schedule_len=%zu "
+          "floor_bytes=%llu pinned=%zu validated_schedule_fqns=%zu "
+          "budget_bytes=%llu installed=%zu\n",
+          offload_payload.method_name.c_str(),
+          offload_payload.schema_version,
+          offload_payload.schedule.size(),
+          static_cast<unsigned long long>(offload_payload.floor_bytes),
+          offload_payload.pin_fqns.size(),
+          schedule_fqns_count,
+          static_cast<unsigned long long>(
+              handle->weight_offload_session->total_budget_bytes()),
+          catalog_constants);
+
+      static const bool trace_per_fqn =
+          std::getenv("EXECUTORCH_WEIGHT_OFFLOAD_TRACE") != nullptr;
+      if (trace_per_fqn) {
+        for (const auto& fqn : schedule_fqns) {
+          const auto& m = *fqn_to_meta.at(fqn);
+          std::fprintf(
+              stderr,
+              "[ET_WEIGHT_OFFLOAD_TRACE] fqn=%s dtype=%d nbytes=%llu "
+              "sizes=[",
+              m.fqn.c_str(),
+              m.dtype,
+              static_cast<unsigned long long>(m.nbytes));
+          for (size_t i = 0; i < m.sizes.size(); ++i) {
+            std::fprintf(
+                stderr,
+                "%s%lld",
+                i == 0 ? "" : ",",
+                static_cast<long long>(m.sizes[i]));
+          }
+          std::fprintf(stderr, "]\n");
+        }
+      }
+    }
+
     // Initialize CUDA graph state if enabled for this method.
     if (should_use_cuda_graph_for_method(method_name)) {
       handle->cuda_graph_state.phase = CudaGraphPhase::Warmup;
@@ -475,6 +823,26 @@ class ET_EXPERIMENTAL CudaBackend final
       DelegateHandle* handle_,
       Span<EValue*> args) const override {
     cuda::CudaDelegateHandle* handle = (cuda::CudaDelegateHandle*)handle_;
+
+    // Re-bind the device for offload-enabled handles. setCurrentCUDAStream
+    // below sets the stream-on-device association the framework reads
+    // back, but it does NOT call cudaSetDevice — and AOTI's kernel
+    // launches use the current device implicitly. A multi-GPU process
+    // whose current device changed between init and execute would
+    // otherwise launch kernels on the wrong GPU while the offload
+    // pool / dummies live on device 0. Offload is device-0-only
+    // today; lifting that requires storing the per-handle device.
+    if (handle->weight_offload_session != nullptr) {
+      cudaError_t set_dev_err = cudaSetDevice(0);
+      if (set_dev_err != cudaSuccess) {
+        ET_LOG(
+            Error,
+            "[ET_WEIGHT_OFFLOAD][ERROR] cudaSetDevice(0) failed in "
+            "execute(): %s",
+            cudaGetErrorString(set_dev_err));
+        return Error::Internal;
+      }
+    }
 
     size_t n_inputs;
     handle->get_num_inputs(handle->container_handle, &n_inputs);
@@ -852,6 +1220,14 @@ class ET_EXPERIMENTAL CudaBackend final
         cached_outputs_.erase(it);
       }
     }
+
+    // Tear down the offload Session FIRST so its destructor
+    // (unregister from ProbeRegistry + free pinned host bytes)
+    // runs while the CUDA stream and the .so are still around.
+    // Relying on ``delete handle`` ordering would also work today,
+    // but doing it explicitly here documents the dependency so a
+    // later refactor doesn't accidentally reshuffle teardown.
+    handle->weight_offload_session.reset();
 
     // The CUDA stream is managed by shared_ptr in the handle.
     // It will be automatically destroyed when the last handle using it

--- a/backends/cuda/runtime/cuda_delegate_handle.h
+++ b/backends/cuda/runtime/cuda_delegate_handle.h
@@ -17,6 +17,16 @@ namespace executorch {
 namespace backends {
 namespace cuda {
 
+namespace weight_offload {
+// Forward declaration so this header can hold a
+// ``unique_ptr<Session>`` without dragging session.h's CUDA / slim
+// includes into every TU that touches the handle. The implicit
+// ``~CudaDelegateHandle`` instantiation requires Session to be
+// complete only at the actual delete site — currently just
+// ``cuda_backend.cpp``, which already includes ``session.h``.
+class Session;
+} // namespace weight_offload
+
 // Shared CUDA stream wrapper with proper RAII cleanup.
 // This ensures the stream is destroyed when all handles using it are destroyed.
 struct CudaStreamDeleter {
@@ -168,6 +178,23 @@ struct CudaDelegateHandle : public aoti::AOTIDelegateHandle {
 
   // CUDA graph state (warmup, capture, replay, static buffers)
   CudaGraphState cuda_graph_state;
+
+  // Weight offloading: per-handle Session that owns the pinned host
+  // mirror and the ProbeRegistry registrations for this method. Set
+  // by ``CudaBackend::init`` after the CUDA stream is in place
+  // (Session needs the stream for H2D copies). Reset explicitly
+  // first in ``CudaBackend::destroy`` so the
+  // ``ProbeRegistry::unregister`` + ``cudaFreeHost`` ordering is
+  // obvious, before the stream and the .so go away.
+  std::unique_ptr<weight_offload::Session> weight_offload_session;
+
+  // Out-of-line so the ``unique_ptr<Session>`` destructor sees the
+  // complete ``Session`` type. Defined in ``session.cpp``; without
+  // this declaration any TU that destroys a ``CudaDelegateHandle``
+  // without first including ``session.h`` would hit an
+  // incomplete-type compile error (or, worse on some compilers,
+  // silently UB).
+  ~CudaDelegateHandle();
 };
 
 } // namespace cuda

--- a/backends/cuda/runtime/weight_offload/payload.h
+++ b/backends/cuda/runtime/weight_offload/payload.h
@@ -1,0 +1,455 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// ===========================================================================
+// EXPERIMENTAL -- PRIVATE WIRE FORMAT, V2
+// ===========================================================================
+// Runtime decoder for the weight-offload payload that
+// ``backends/cuda/passes/weight_offload_pass.py::_serialize_payload``
+// produces and ``CudaBackend::init`` retrieves from the NamedDataMap
+// when the private ``_weight_offload_internal_enable`` compile spec
+// is set.
+//
+// The wire format is a fixed-shape little-endian binary layout (see
+// the Python serializer for the authoritative description). JSON
+// was rejected to keep the runtime free of parser dependencies for a
+// private, fixed-shape payload.
+//
+// The per-FQN ``constants_metadata`` block carries dtype / sizes /
+// strides / device for each scheduled FQN. With AOTI's eager constant
+// load skipped, the runtime can no longer recover that metadata from
+// extract_constants_map (it would return placeholder metadata for the
+// installed dummies), so it has to come over the wire. Schema v1 is
+// rejected at parse — maintaining two runtime paths for an
+// experimental feature is dead weight.
+// ===========================================================================
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include <executorch/runtime/core/error.h>
+#include <executorch/runtime/core/result.h>
+
+namespace executorch::backends::cuda::weight_offload {
+
+// Must match the Python ``PAYLOAD_MAGIC`` constant. Spells "ETWO" in
+// little-endian ASCII.
+inline constexpr uint32_t kPayloadMagic = 0x4F575445;
+
+// Bounded sizes that mirror the Python serializer's limits. Anything
+// past these caps is a hard fail — bounded means schema drift or an
+// attacker-controlled artifact, neither of which we silently accept.
+inline constexpr uint32_t kMaxStrLen = 1024;
+inline constexpr uint32_t kMaxScheduleCount = 1'000'000;
+inline constexpr uint32_t kMaxPinCount = 100'000;
+inline constexpr uint32_t kMaxConstantsMetadataCount = 1'000'000;
+inline constexpr uint32_t kMaxNdim = 32;
+
+// Single-device constraint. ``create_with_device(..., "cuda", nullptr)``
+// doesn't take a per-method device index; until that's plumbed through,
+// dummies + stream + pool land on whichever device happens to be
+// current (effectively 0). Asserting at parse surfaces any payload that
+// disagrees, instead of silently using device 0.
+inline constexpr int32_t kCudaDeviceType = 1;
+inline constexpr int32_t kRequiredDeviceIndex = 0;
+
+struct ConstantMetadata {
+  std::string fqn;
+  int32_t dtype{0};
+  std::vector<int64_t> sizes;
+  std::vector<int64_t> strides;
+  int64_t storage_offset{0};
+  uint64_t nbytes{0};
+  int32_t device_type{0};
+  int32_t device_index{0};
+};
+
+struct Payload {
+  uint32_t schema_version{0};
+  std::string method_name;
+  uint64_t floor_bytes{0};
+  std::vector<std::string> schedule;
+  std::vector<std::string> pin_fqns;
+  // V2 block. Indexed by first-seen position in ``schedule``; the
+  // parser enforces ``{ entry.fqn } == set(schedule)`` so the runtime
+  // can look up by FQN safely.
+  std::vector<ConstantMetadata> constants_metadata;
+};
+
+namespace detail {
+
+// Tiny cursor over a borrowed byte range. Every read advances the
+// offset and bounds-checks against the end; truncation is a single
+// error code (``InvalidArgument``).
+class Cursor {
+ public:
+  Cursor(const uint8_t* data, size_t size) : data_(data), size_(size) {}
+
+  size_t remaining() const {
+    return size_ - offset_;
+  }
+  size_t offset() const {
+    return offset_;
+  }
+  bool exhausted() const {
+    return offset_ == size_;
+  }
+
+  ::executorch::runtime::Error read_u32(uint32_t& out) {
+    if (remaining() < sizeof(uint32_t)) {
+      return ::executorch::runtime::Error::InvalidArgument;
+    }
+    std::memcpy(&out, data_ + offset_, sizeof(uint32_t));
+    offset_ += sizeof(uint32_t);
+    return ::executorch::runtime::Error::Ok;
+  }
+
+  ::executorch::runtime::Error read_u64(uint64_t& out) {
+    if (remaining() < sizeof(uint64_t)) {
+      return ::executorch::runtime::Error::InvalidArgument;
+    }
+    std::memcpy(&out, data_ + offset_, sizeof(uint64_t));
+    offset_ += sizeof(uint64_t);
+    return ::executorch::runtime::Error::Ok;
+  }
+
+  ::executorch::runtime::Error read_i32(int32_t& out) {
+    uint32_t tmp = 0;
+    auto err = read_u32(tmp);
+    if (err != ::executorch::runtime::Error::Ok) {
+      return err;
+    }
+    std::memcpy(&out, &tmp, sizeof(int32_t));
+    return ::executorch::runtime::Error::Ok;
+  }
+
+  ::executorch::runtime::Error read_i64(int64_t& out) {
+    uint64_t tmp = 0;
+    auto err = read_u64(tmp);
+    if (err != ::executorch::runtime::Error::Ok) {
+      return err;
+    }
+    std::memcpy(&out, &tmp, sizeof(int64_t));
+    return ::executorch::runtime::Error::Ok;
+  }
+
+  ::executorch::runtime::Error read_bounded_string(
+      std::string& out,
+      uint32_t max_len) {
+    uint32_t len = 0;
+    auto err = read_u32(len);
+    if (err != ::executorch::runtime::Error::Ok) {
+      return err;
+    }
+    if (len > max_len || len > remaining()) {
+      return ::executorch::runtime::Error::InvalidArgument;
+    }
+    out.assign(reinterpret_cast<const char*>(data_ + offset_), len);
+    offset_ += len;
+    return ::executorch::runtime::Error::Ok;
+  }
+
+ private:
+  const uint8_t* data_;
+  size_t size_;
+  size_t offset_{0};
+};
+
+// Element size by dtype code. Returns 0 for unsupported codes, which
+// the caller treats as an invalid-payload signal. The supported set
+// mirrors the pass-side ``_TORCH_DTYPE_TO_C10`` map; extending one
+// without the other will hard-fail at parse, which is the intended
+// drift signal.
+inline uint64_t element_size(int32_t dtype) {
+  switch (dtype) {
+    case 0: // uint8
+    case 1: // int8
+    case 11: // bool
+      return 1;
+    case 2: // int16
+    case 5: // float16
+    case 15: // bfloat16
+      return 2;
+    case 3: // int32
+    case 6: // float32
+      return 4;
+    case 4: // int64
+      return 8;
+    default:
+      return 0;
+  }
+}
+
+// Read a single ConstantMetadata entry with per-field bounds + cross-
+// field consistency (dtype is supported, sizes positive, strides
+// describe a C-contiguous layout, storage_offset == 0, nbytes ==
+// elementSize(dtype) * product(sizes)). Catching these at parse means
+// downstream code can trust the parsed struct directly.
+inline ::executorch::runtime::Error read_constant_metadata(
+    Cursor& cur,
+    ConstantMetadata& m) {
+  using ::executorch::runtime::Error;
+  if (cur.read_bounded_string(m.fqn, kMaxStrLen) != Error::Ok) {
+    return Error::InvalidArgument;
+  }
+  if (m.fqn.empty()) {
+    return Error::InvalidArgument;
+  }
+  if (cur.read_i32(m.dtype) != Error::Ok) {
+    return Error::InvalidArgument;
+  }
+  const uint64_t esize = element_size(m.dtype);
+  if (esize == 0) {
+    return Error::InvalidArgument;
+  }
+  uint32_t ndim = 0;
+  if (cur.read_u32(ndim) != Error::Ok) {
+    return Error::InvalidArgument;
+  }
+  if (ndim > kMaxNdim) {
+    return Error::InvalidArgument;
+  }
+  m.sizes.resize(ndim);
+  uint64_t logical = esize;
+  for (uint32_t k = 0; k < ndim; ++k) {
+    if (cur.read_i64(m.sizes[k]) != Error::Ok) {
+      return Error::InvalidArgument;
+    }
+    // Positive sizes only. Scalars (ndim==0) skip this loop entirely
+    // and are accepted: logical stays at element_size, numel == 1.
+    if (m.sizes[k] <= 0) {
+      return Error::InvalidArgument;
+    }
+    const uint64_t s_u = static_cast<uint64_t>(m.sizes[k]);
+    if (logical > std::numeric_limits<uint64_t>::max() / s_u) {
+      return Error::InvalidArgument;
+    }
+    logical *= s_u;
+  }
+  m.strides.resize(ndim);
+  for (uint32_t k = 0; k < ndim; ++k) {
+    if (cur.read_i64(m.strides[k]) != Error::Ok) {
+      return Error::InvalidArgument;
+    }
+  }
+  // Strides must describe a C-contiguous layout: strides[i] ==
+  // product(sizes[i+1..]). The offload host mirror is sized for
+  // logical bytes and the H2D copy is dense, so any non-contiguous
+  // layout would over- or under-read.
+  {
+    int64_t expected = 1;
+    for (int64_t i = static_cast<int64_t>(ndim) - 1; i >= 0; --i) {
+      if (m.strides[i] != expected) {
+        return Error::InvalidArgument;
+      }
+      expected *= m.sizes[i];
+    }
+  }
+  if (cur.read_i64(m.storage_offset) != Error::Ok) {
+    return Error::InvalidArgument;
+  }
+  if (m.storage_offset != 0) {
+    return Error::InvalidArgument;
+  }
+  if (cur.read_u64(m.nbytes) != Error::Ok) {
+    return Error::InvalidArgument;
+  }
+  // nbytes must equal the logical byte count derived from dtype +
+  // sizes. The pass writes it as `element_size * product(sizes)`;
+  // catching drift here means downstream consumers can read either
+  // field interchangeably.
+  if (m.nbytes != logical) {
+    return Error::InvalidArgument;
+  }
+  if (cur.read_i32(m.device_type) != Error::Ok) {
+    return Error::InvalidArgument;
+  }
+  if (m.device_type != kCudaDeviceType) {
+    return Error::InvalidArgument;
+  }
+  if (cur.read_i32(m.device_index) != Error::Ok) {
+    return Error::InvalidArgument;
+  }
+  if (m.device_index != kRequiredDeviceIndex) {
+    return Error::InvalidArgument;
+  }
+  return Error::Ok;
+}
+
+} // namespace detail
+
+// Decode the binary payload at ``[data, data + size)``. Validates
+// magic / schema_version / per-field bounds and rejects truncation,
+// trailing bytes, and (when non-empty) ``expected_method`` mismatch.
+// ``expected_method`` is the method this ``init`` call is for; the
+// payload's embedded ``method_name`` must match it.
+//
+// REJECTS v1 with Error::InvalidArgument so the caller can surface
+// a "rebuild required" message. V2-only parser.
+inline ::executorch::runtime::Result<Payload> parse_payload(
+    const void* data,
+    size_t size,
+    const std::string& expected_method) {
+  using ::executorch::runtime::Error;
+  detail::Cursor cur(static_cast<const uint8_t*>(data), size);
+
+  uint32_t magic = 0;
+  if (cur.read_u32(magic) != Error::Ok) {
+    return Error::InvalidArgument;
+  }
+  if (magic != kPayloadMagic) {
+    return Error::InvalidArgument;
+  }
+
+  Payload p;
+  if (cur.read_u32(p.schema_version) != Error::Ok) {
+    return Error::InvalidArgument;
+  }
+  if (p.schema_version != 2) {
+    return Error::InvalidArgument;
+  }
+
+  if (cur.read_bounded_string(p.method_name, kMaxStrLen) != Error::Ok) {
+    return Error::InvalidArgument;
+  }
+  if (!expected_method.empty() && p.method_name != expected_method) {
+    return Error::InvalidArgument;
+  }
+
+  if (cur.read_u64(p.floor_bytes) != Error::Ok) {
+    return Error::InvalidArgument;
+  }
+
+  uint32_t schedule_count = 0;
+  if (cur.read_u32(schedule_count) != Error::Ok) {
+    return Error::InvalidArgument;
+  }
+  if (schedule_count > kMaxScheduleCount) {
+    return Error::InvalidArgument;
+  }
+  p.schedule.reserve(schedule_count);
+  for (uint32_t i = 0; i < schedule_count; ++i) {
+    std::string s;
+    if (cur.read_bounded_string(s, kMaxStrLen) != Error::Ok) {
+      return Error::InvalidArgument;
+    }
+    p.schedule.push_back(std::move(s));
+  }
+
+  uint32_t pin_count = 0;
+  if (cur.read_u32(pin_count) != Error::Ok) {
+    return Error::InvalidArgument;
+  }
+  if (pin_count > kMaxPinCount) {
+    return Error::InvalidArgument;
+  }
+  p.pin_fqns.reserve(pin_count);
+  for (uint32_t i = 0; i < pin_count; ++i) {
+    std::string s;
+    if (cur.read_bounded_string(s, kMaxStrLen) != Error::Ok) {
+      return Error::InvalidArgument;
+    }
+    p.pin_fqns.push_back(std::move(s));
+  }
+
+  uint32_t md_count = 0;
+  if (cur.read_u32(md_count) != Error::Ok) {
+    return Error::InvalidArgument;
+  }
+  if (md_count > kMaxConstantsMetadataCount) {
+    return Error::InvalidArgument;
+  }
+  p.constants_metadata.resize(md_count);
+  for (uint32_t i = 0; i < md_count; ++i) {
+    if (detail::read_constant_metadata(cur, p.constants_metadata[i]) !=
+        Error::Ok) {
+      return Error::InvalidArgument;
+    }
+  }
+
+  // Trailing bytes are a schema-drift signal — refuse to accept a
+  // payload whose serializer wrote extra fields this build doesn't
+  // know about.
+  if (!cur.exhausted()) {
+    return Error::InvalidArgument;
+  }
+
+  // Cross-field invariants for v2:
+  //   - constants_metadata FQN set must equal unique(schedule).
+  //   - No duplicate FQNs across metadata entries.
+  //   - No duplicate FQNs in pin_fqns.
+  //   - Every pin_fqn must appear in the schedule.
+  // Catching these at parse means downstream code (init, Session)
+  // can trust the parsed struct without re-validating.
+  if (!p.constants_metadata.empty() || !p.schedule.empty()) {
+    std::vector<std::string> md_fqns;
+    md_fqns.reserve(p.constants_metadata.size());
+    for (const auto& m : p.constants_metadata) {
+      md_fqns.push_back(m.fqn);
+    }
+    std::sort(md_fqns.begin(), md_fqns.end());
+    for (size_t i = 1; i < md_fqns.size(); ++i) {
+      if (md_fqns[i] == md_fqns[i - 1]) {
+        return Error::InvalidArgument; // duplicate FQN in metadata
+      }
+    }
+    std::vector<std::string> sched_unique = p.schedule;
+    std::sort(sched_unique.begin(), sched_unique.end());
+    sched_unique.erase(
+        std::unique(sched_unique.begin(), sched_unique.end()),
+        sched_unique.end());
+    if (md_fqns != sched_unique) {
+      return Error::InvalidArgument;
+    }
+  }
+  if (!p.pin_fqns.empty()) {
+    std::unordered_set<std::string> sched_set(
+        p.schedule.begin(), p.schedule.end());
+    std::unordered_set<std::string> pin_set;
+    pin_set.reserve(p.pin_fqns.size());
+    for (const auto& f : p.pin_fqns) {
+      if (!pin_set.insert(f).second) {
+        return Error::InvalidArgument; // duplicate in pin_fqns
+      }
+      if (sched_set.find(f) == sched_set.end()) {
+        return Error::InvalidArgument; // pin_fqn not in schedule
+      }
+    }
+  }
+
+  return p;
+}
+
+// Same compile-spec key the Python side uses
+// (``COMPILE_SPEC_KEY_ENABLE``). Defined here so the runtime checks
+// against a single string constant, not a string literal sprinkled
+// through ``cuda_backend.cpp``.
+inline constexpr const char* kEnableCompileSpecKey =
+    "_weight_offload_internal_enable";
+
+// NamedDataMap key prefix; the per-method key is
+// ``f"{prefix}__{method_name}"``. Must match the Python helper
+// ``named_data_key_for_method``.
+inline constexpr const char* kNamedDataKeyPrefix = "_weight_offload_payload";
+
+inline std::string named_data_key_for_method(const std::string& method) {
+  std::string key = kNamedDataKeyPrefix;
+  key += "__";
+  key += method;
+  return key;
+}
+
+} // namespace executorch::backends::cuda::weight_offload

--- a/backends/cuda/runtime/weight_offload/probe_op.cpp
+++ b/backends/cuda/runtime/weight_offload/probe_op.cpp
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// EXPERIMENTAL -- identity passthrough. See ``probe_op.h`` for the
+// staging banner and the planned Session-managed lookup that replaces
+// this body. The current implementation validates that AOTI emits one
+// call per FX-graph probe node — distinct ``probe_id`` constants make
+// otherwise-identical probe calls syntactically distinct from
+// inductor's POV, so the multi-consumer case in
+// ``test_weight_offload_probe_dispatch.py`` survives CSE.
+
+#include <atomic>
+#include <cinttypes>
+#include <cstdio>
+#include <cstdlib>
+
+#include <executorch/backends/aoti/common_shims_slim.h>
+#include <executorch/backends/aoti/utils.h>
+#include <executorch/backends/cuda/runtime/shims/memory.h>
+#include <executorch/backends/cuda/runtime/weight_offload/probe_op.h>
+#include <executorch/backends/cuda/runtime/weight_offload/probe_registry.h>
+
+namespace executorch::backends::cuda {
+
+namespace {
+
+// Process-global call counter. Lives at namespace scope inside the
+// shared library so a test linking ``aoti_cuda_shims`` directly can
+// observe it through ``weight_offload_probe_count_and_reset``.
+std::atomic<int64_t> g_probe_call_count{0};
+
+// Cached env-var read. ``std::getenv`` is racy but the value here is
+// only read on first call (function-local static); the trace channel
+// is an opt-in test affordance, not a production-tunable.
+bool probe_trace_enabled() {
+  static const bool enabled =
+      std::getenv("EXECUTORCH_WEIGHT_OFFLOAD_PROBE_TRACE") != nullptr;
+  return enabled;
+}
+
+} // namespace
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+AOTITorchError
+aoti_torch_cuda_probe(Tensor* input, int64_t probe_id, Tensor** output) {
+  ET_CHECK_OR_RETURN_ERROR(
+      input != nullptr,
+      InvalidArgument,
+      "aoti_torch_cuda_probe: input is null");
+  ET_CHECK_OR_RETURN_ERROR(
+      output != nullptr,
+      InvalidArgument,
+      "aoti_torch_cuda_probe: output is null");
+
+  g_probe_call_count.fetch_add(1, std::memory_order_relaxed);
+
+  if (probe_trace_enabled()) {
+    // Single-line, easy to grep from a subprocess's captured stderr.
+    std::fprintf(
+        stderr, "[ET_WEIGHT_OFFLOAD_PROBE] probe_id=%" PRId64 "\n", probe_id);
+  }
+
+  // Dispatch through the ProbeRegistry. The semantics are:
+  //   * Lookup hit  -> a Session owns this dummy pointer; forward
+  //                    the probe call to its serve callback.
+  //   * Lookup miss, registry empty -> no offload is active; fall
+  //                    back to the identity passthrough (preserves
+  //                    the manual-probe dispatch tests from commit
+  //                    1, where the c-shim is exercised without
+  //                    any Session ever being created).
+  //   * Lookup miss, registry NOT empty -> offload IS active but
+  //                    this pointer is unbound. Hard-fail loudly;
+  //                    otherwise the identity passthrough would
+  //                    silently read the eager AOTI constant and
+  //                    mask the broken binding.
+  void* input_data = nullptr;
+  auto err =
+      ::executorch::backends::aoti::aoti_torch_get_data_ptr(input, &input_data);
+  if (err != ::executorch::runtime::Error::Ok) {
+    return err;
+  }
+
+  auto& registry = weight_offload::ProbeRegistry::instance();
+  auto lookup = registry.lookup(input_data);
+  if (lookup.found) {
+    return lookup.callback(lookup.context, input, probe_id, output);
+  }
+  if (registry.has_any_context()) {
+    std::fprintf(
+        stderr,
+        "[ET_WEIGHT_OFFLOAD][ERROR] probe input data_ptr=%p probe_id=%" PRId64
+        " has no Session binding but the registry has at least one active "
+        "context; refusing to silently identity-passthrough\n",
+        input_data,
+        probe_id);
+    return ::executorch::runtime::Error::Internal;
+  }
+
+  return aoti_torch_new_tensor_handle(input, output);
+}
+
+int64_t weight_offload_probe_count_and_reset() {
+  return g_probe_call_count.exchange(0, std::memory_order_relaxed);
+}
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+} // namespace executorch::backends::cuda

--- a/backends/cuda/runtime/weight_offload/probe_op.h
+++ b/backends/cuda/runtime/weight_offload/probe_op.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// EXPERIMENTAL. The c-shim AOTI dispatches to for
+// ``executorch_weight_offload::probe(w, probe_id)``. Body lives in
+// probe_op.cpp; routes through ProbeRegistry to Session::serve when
+// offload is opted in, identity-passthrough otherwise.
+
+#include <cstdint>
+
+#include <executorch/backends/aoti/common_shims_slim.h>
+#include <executorch/backends/aoti/export.h>
+
+namespace executorch::backends::cuda {
+
+using executorch::backends::aoti::AOTITorchError;
+using executorch::backends::aoti::Tensor;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// AOTI c-shim for ``executorch_weight_offload::probe(w, probe_id)``.
+//
+// AOTI's name mangling convention is ``aoti_torch_<device>_<opname>``
+// (see PyTorch's ``cpp_wrapper_cpu.py``). For
+// ``executorch_weight_offload::probe(Tensor w, int probe_id) -> Tensor``
+// on CUDA, the generated ``wrapper.cpp`` emits a direct call to
+// ``aoti_torch_cuda_probe(input_handle, probe_id, &output_handle)``.
+// The C signature of this symbol is the string the CUDA backend hands
+// AOTI via the ``aot_inductor.custom_ops_to_c_shims`` config (see
+// ``backends/cuda/cuda_backend.py``). ``Tensor*`` here is
+// ``SlimTensor*``; AOTI's ``AtenTensorHandle`` is pointer-compatible.
+//
+// At runtime, the symbol must be globally visible from the host process
+// so the dynamically-loaded AOTI ``.so`` can resolve it. The CUDA
+// backend's ``platform.cpp`` dlopen handshake promotes
+// ``libaoti_cuda_shims.so``'s symbols to global on first
+// ``load_library`` call.
+//
+// ``probe_id`` self-identifies each ``(consumer, weight)`` call site so
+// the runtime needs no schedule cursor — it indexes the payload's
+// ``schedule[probe_id]`` directly. The pass assigns contiguous
+// ``probe_id`` values 0..N-1 in graph order.
+AOTI_SHIM_EXPORT AOTITorchError
+aoti_torch_cuda_probe(Tensor* input, int64_t probe_id, Tensor** output);
+
+// Test-only: read and reset the process-global probe call counter the
+// c-shim increments on every invocation. Exposed as a separate symbol
+// so a C++ unit test that links ``aoti_cuda_shims`` directly can verify
+// the dispatch wiring without running the full executor. The Python
+// e2e test counts ``[ET_WEIGHT_OFFLOAD_PROBE]`` log lines on stderr
+// instead (gated on the ``EXECUTORCH_WEIGHT_OFFLOAD_PROBE_TRACE`` env
+// var).
+AOTI_SHIM_EXPORT int64_t weight_offload_probe_count_and_reset();
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+} // namespace executorch::backends::cuda

--- a/backends/cuda/runtime/weight_offload/probe_registry.cpp
+++ b/backends/cuda/runtime/weight_offload/probe_registry.cpp
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/cuda/runtime/weight_offload/probe_registry.h>
+
+#include <mutex>
+#include <shared_mutex>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace executorch::backends::cuda::weight_offload {
+
+// shared_mutex so the hot-path readers (lookup + has_any_context, both
+// called per-probe from probe_op.cpp) can run concurrently across
+// Sessions. register_entries / unregister_context fire once per
+// Session lifetime and take the exclusive lock.
+struct ProbeRegistry::Impl {
+  mutable std::shared_mutex mu;
+  std::unordered_map<const void*, LookupResult> by_ptr;
+  std::unordered_set<void*> active_contexts;
+};
+
+ProbeRegistry& ProbeRegistry::instance() {
+  static ProbeRegistry* singleton = new ProbeRegistry();
+  return *singleton;
+}
+
+ProbeRegistry::ProbeRegistry() : impl_(new Impl()) {}
+
+ProbeRegistry::~ProbeRegistry() {
+  delete impl_;
+}
+
+::executorch::runtime::Error ProbeRegistry::register_entries(
+    void* context,
+    ServeCallback callback,
+    const void* const* dummy_ptrs,
+    size_t num_dummy_ptrs) {
+  using ::executorch::runtime::Error;
+  if (context == nullptr || callback == nullptr ||
+      (num_dummy_ptrs > 0 && dummy_ptrs == nullptr)) {
+    return Error::InvalidArgument;
+  }
+  std::unique_lock<std::shared_mutex> guard(impl_->mu);
+  // First pass: detect collisions WITHOUT mutating, so a failure
+  // leaves the registry untouched. ``batch_seen`` makes the
+  // intra-batch duplicate check O(N) instead of O(N^2) for the
+  // thousand-constant case.
+  std::unordered_set<const void*> batch_seen;
+  batch_seen.reserve(num_dummy_ptrs);
+  for (size_t i = 0; i < num_dummy_ptrs; ++i) {
+    const void* p = dummy_ptrs[i];
+    if (p == nullptr) {
+      return Error::InvalidArgument;
+    }
+    if (impl_->by_ptr.find(p) != impl_->by_ptr.end()) {
+      return Error::InvalidArgument;
+    }
+    if (!batch_seen.insert(p).second) {
+      return Error::InvalidArgument;
+    }
+  }
+  // Second pass: insert.
+  for (size_t i = 0; i < num_dummy_ptrs; ++i) {
+    impl_->by_ptr.emplace(dummy_ptrs[i], LookupResult{true, callback, context});
+  }
+  impl_->active_contexts.insert(context);
+  return Error::Ok;
+}
+
+void ProbeRegistry::unregister_context(
+    void* context,
+    const void* const* dummy_ptrs,
+    size_t num_dummy_ptrs) {
+  std::unique_lock<std::shared_mutex> guard(impl_->mu);
+  for (size_t i = 0; i < num_dummy_ptrs; ++i) {
+    const void* p = dummy_ptrs[i];
+    if (p == nullptr) {
+      continue;
+    }
+    auto it = impl_->by_ptr.find(p);
+    if (it != impl_->by_ptr.end() && it->second.context == context) {
+      impl_->by_ptr.erase(it);
+    }
+  }
+  impl_->active_contexts.erase(context);
+}
+
+LookupResult ProbeRegistry::lookup(const void* dummy_ptr) const {
+  std::shared_lock<std::shared_mutex> guard(impl_->mu);
+  auto it = impl_->by_ptr.find(dummy_ptr);
+  if (it == impl_->by_ptr.end()) {
+    return LookupResult{};
+  }
+  return it->second;
+}
+
+bool ProbeRegistry::has_any_context() const {
+  std::shared_lock<std::shared_mutex> guard(impl_->mu);
+  return !impl_->active_contexts.empty();
+}
+
+} // namespace executorch::backends::cuda::weight_offload

--- a/backends/cuda/runtime/weight_offload/probe_registry.h
+++ b/backends/cuda/runtime/weight_offload/probe_registry.h
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// ===========================================================================
+// EXPERIMENTAL -- PROCESS-GLOBAL PROBE DISPATCH TABLE
+// ===========================================================================
+// Maps the device pointer AOTI passes into ``aoti_torch_cuda_probe``
+// to the offload runtime that should handle it. The c-shim
+// (``probe_op.cpp``, linked into ``aoti_cuda_shims``) is the sole
+// reader; ``CudaBackend`` ``weight_offload::Session`` is the sole
+// writer, registering its dummy pointers at construction and
+// unregistering at destruction.
+//
+// Lookup hits return ``(callback, context)`` and the c-shim
+// forwards the probe call. Lookup misses fall back to the identity
+// passthrough ONLY when the registry has zero active contexts
+// (preserves manual-probe tests that never construct a Session).
+// Once any Session is registered, a miss is a hard fail — otherwise
+// the runtime could silently read the eager AOTI constant and mask
+// a broken pointer binding.
+//
+// The registry is deliberately tiny: pointer -> (callback,
+// context). FQN resolution stays in
+// ``Session``'s ``schedule[probe_id]`` lookup; nothing in this
+// table knows or cares about FQNs.
+//
+// Thread safety: ``lookup`` and ``has_any_context`` are read-only and
+// take a shared lock, so concurrent probe dispatch across Sessions
+// (e.g. prefill and decode methods running on separate threads) does
+// not serialise. ``register_entries`` and ``unregister_context`` take
+// an exclusive lock and are expected once per Session lifetime.
+// ===========================================================================
+
+#include <cstddef>
+#include <cstdint>
+
+#include <executorch/backends/aoti/common_shims_slim.h>
+#include <executorch/backends/aoti/export.h>
+#include <executorch/runtime/core/error.h>
+
+namespace executorch::backends::cuda::weight_offload {
+
+using ServeCallback = ::executorch::runtime::Error (*)(
+    void* context,
+    ::executorch::backends::aoti::Tensor* input,
+    int64_t probe_id,
+    ::executorch::backends::aoti::Tensor** output);
+
+struct LookupResult {
+  bool found{false};
+  ServeCallback callback{nullptr};
+  void* context{nullptr};
+};
+
+// Class-level ``AOTI_SHIM_EXPORT`` so all methods are visible
+// across the ``aoti_cuda_shims`` shared-library boundary on
+// Windows/MSVC (the library disables export-all-symbols). On
+// Linux/macOS the macro is a no-op and symbol visibility is
+// already default. ``session.cpp`` (in ``aoti_cuda_backend``)
+// calls these methods through the boundary.
+class AOTI_SHIM_EXPORT ProbeRegistry {
+ public:
+  // Process-global singleton. The state lives in
+  // ``aoti_cuda_shims`` so the c-shim accesses it directly without
+  // having to dlsym a function pointer.
+  static ProbeRegistry& instance();
+
+  // Bulk-register ``dummy_ptrs`` for ``context``. Every pointer in
+  // ``dummy_ptrs`` must be unique across all live contexts in the
+  // registry; collisions return ``Error::InvalidArgument`` and
+  // leave the registry untouched.
+  ::executorch::runtime::Error register_entries(
+      void* context,
+      ServeCallback callback,
+      const void* const* dummy_ptrs,
+      size_t num_dummy_ptrs);
+
+  // Remove the entries the caller registered. ``dummy_ptrs`` should
+  // be the exact pointer set this ``context`` previously passed to
+  // ``register_entries``; entries not registered to this context are
+  // skipped silently (so a partial register/unregister sequence is
+  // safe). O(K) in ``num_dummy_ptrs``, NOT O(N) over the whole
+  // registry — important when several Sessions are live and one
+  // teardown shouldn't iterate the others' entries. Safe to call
+  // even if ``context`` never registered.
+  void unregister_context(
+      void* context,
+      const void* const* dummy_ptrs,
+      size_t num_dummy_ptrs);
+
+  // Hot-path lookup. ``found=false`` means the pointer is not in
+  // the table; the c-shim's "registry empty?" check distinguishes
+  // "no offload at all" (identity fallback) from "offload active
+  // but pointer unbound" (hard fail).
+  LookupResult lookup(const void* dummy_ptr) const;
+
+  // True iff at least one context is registered.
+  bool has_any_context() const;
+
+ private:
+  ProbeRegistry();
+  ~ProbeRegistry();
+  ProbeRegistry(const ProbeRegistry&) = delete;
+  ProbeRegistry& operator=(const ProbeRegistry&) = delete;
+
+  struct Impl;
+  Impl* impl_;
+};
+
+} // namespace executorch::backends::cuda::weight_offload

--- a/backends/cuda/runtime/weight_offload/session.cpp
+++ b/backends/cuda/runtime/weight_offload/session.cpp
@@ -1,0 +1,1389 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/cuda/runtime/weight_offload/session.h>
+
+#include <algorithm>
+#include <cinttypes>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <limits>
+#include <unordered_set>
+#include <utility>
+
+#include <executorch/backends/aoti/slim/c10/core/ScalarType.h>
+#include <executorch/backends/cuda/runtime/cuda_delegate_handle.h>
+#include <executorch/backends/cuda/runtime/shims/memory.h>
+#include <executorch/backends/cuda/runtime/weight_offload/probe_registry.h>
+
+// Out-of-line ``CudaDelegateHandle`` destructor lives here so the
+// implicit ``unique_ptr<Session>`` member destructor sees Session
+// complete.
+namespace executorch::backends::cuda {
+CudaDelegateHandle::~CudaDelegateHandle() = default;
+} // namespace executorch::backends::cuda
+
+namespace executorch::backends::cuda::weight_offload {
+
+// ---------------------------------------------------------------------------
+// DummyInstallation — RAII for the 1-byte dummies + SlimTensor wrappers
+// AOTI dispatches probes with. Defined out-of-line because the destructor
+// touches CUDA + the SlimTensor type, and inlining either drags includes
+// into every TU that pulls session.h.
+// ---------------------------------------------------------------------------
+
+DummyInstallation::~DummyInstallation() {
+  clear_and_free();
+}
+
+DummyInstallation::DummyInstallation(DummyInstallation&& other) noexcept
+    : dummy_data_ptrs(std::move(other.dummy_data_ptrs)),
+      dummy_tensors(std::move(other.dummy_tensors)) {
+  other.dummy_data_ptrs.clear();
+  other.dummy_tensors.clear();
+}
+
+DummyInstallation& DummyInstallation::operator=(
+    DummyInstallation&& other) noexcept {
+  if (this != &other) {
+    clear_and_free();
+    dummy_data_ptrs = std::move(other.dummy_data_ptrs);
+    dummy_tensors = std::move(other.dummy_tensors);
+    other.dummy_data_ptrs.clear();
+    other.dummy_tensors.clear();
+  }
+  return *this;
+}
+
+void DummyInstallation::clear_and_free() {
+  for (auto* t : dummy_tensors) {
+    delete t;
+  }
+  dummy_tensors.clear();
+  for (void* p : dummy_data_ptrs) {
+    if (p != nullptr) {
+      cudaFree(p);
+    }
+  }
+  dummy_data_ptrs.clear();
+}
+
+namespace {
+
+// kCudaDeviceType comes from payload.h (in the
+// executorch::backends::cuda::weight_offload namespace).
+
+void free_host_mirror(
+    std::unordered_map<std::string, Session::HostEntry>& host_entries) {
+  for (auto& [fqn, entry] : host_entries) {
+    if (entry.host_ptr != nullptr) {
+      cudaFreeHost(entry.host_ptr);
+      entry.host_ptr = nullptr;
+    }
+  }
+  host_entries.clear();
+}
+
+// Resolved budget + the BudgetSpec describing the user's source
+// (for the below-floor UX message).
+struct ResolvedBudget {
+  uint64_t budget_bytes{0};
+  BudgetSpec spec{};
+};
+
+// Resolve the load-time budget from the runtime-spec chain.
+// Tries the public ``weight_offload_budget_mb`` (int MB) first,
+// then the internal ``_weight_offload_internal_budget_bytes``
+// (decimal string of bytes), then defaults to ``floor + pinned``.
+// Default-path BudgetSpec.name still points at the public spec so
+// the UX hint reaches for the public knob.
+::executorch::runtime::Result<ResolvedBudget> resolve_budget(
+    ::executorch::runtime::BackendInitContext& context,
+    uint64_t floor_bytes,
+    uint64_t pinned_bytes_total) {
+  using ::executorch::runtime::Error;
+  ResolvedBudget out;
+  out.spec.name = "weight_offload_budget_mb";
+  out.spec.value_is_mb = true;
+
+  // Public path: weight_offload_budget_mb (int megabytes).
+  auto mb_res = context.get_runtime_spec<int>("weight_offload_budget_mb");
+  if (mb_res.ok()) {
+    int mb = mb_res.get();
+    if (mb <= 0) {
+      std::fprintf(
+          stderr,
+          "[ET_WEIGHT_OFFLOAD][ERROR] weight_offload_budget_mb=%d "
+          "must be a positive integer\n",
+          mb);
+      return Error::InvalidArgument;
+    }
+    out.budget_bytes = static_cast<uint64_t>(mb) << 20;
+    out.spec.value = static_cast<uint64_t>(mb);
+    return out;
+  }
+  if (mb_res.error() == Error::InvalidArgument) {
+    std::fprintf(
+        stderr,
+        "[ET_WEIGHT_OFFLOAD][ERROR] weight_offload_budget_mb is set "
+        "but not an int\n");
+    return Error::InvalidArgument;
+  }
+  if (mb_res.error() != Error::NotFound) {
+    return mb_res.error();
+  }
+
+  // Internal byte spec — for exact-byte test paths.
+  auto bytes_res = context.get_runtime_spec<const char*>(
+      "_weight_offload_internal_budget_bytes");
+  if (bytes_res.ok()) {
+    const char* spec_cstr = bytes_res.get();
+    if (spec_cstr == nullptr || spec_cstr[0] == '\0') {
+      std::fprintf(
+          stderr,
+          "[ET_WEIGHT_OFFLOAD][ERROR] "
+          "_weight_offload_internal_budget_bytes is empty\n");
+      return Error::InvalidArgument;
+    }
+    if (spec_cstr[0] == '-' || spec_cstr[0] == '+') {
+      std::fprintf(
+          stderr,
+          "[ET_WEIGHT_OFFLOAD][ERROR] "
+          "_weight_offload_internal_budget_bytes='%s' has a sign\n",
+          spec_cstr);
+      return Error::InvalidArgument;
+    }
+    char* end = nullptr;
+    errno = 0;
+    unsigned long long parsed = std::strtoull(spec_cstr, &end, 10);
+    if (errno != 0 || end == spec_cstr || *end != '\0' || parsed == 0) {
+      std::fprintf(
+          stderr,
+          "[ET_WEIGHT_OFFLOAD][ERROR] "
+          "_weight_offload_internal_budget_bytes='%s' must be a "
+          "positive decimal integer\n",
+          spec_cstr);
+      return Error::InvalidArgument;
+    }
+    out.budget_bytes = static_cast<uint64_t>(parsed);
+    out.spec.name = "_weight_offload_internal_budget_bytes";
+    out.spec.value = out.budget_bytes;
+    out.spec.value_is_mb = false;
+    return out;
+  }
+  if (bytes_res.error() == Error::InvalidArgument) {
+    std::fprintf(
+        stderr,
+        "[ET_WEIGHT_OFFLOAD][ERROR] "
+        "_weight_offload_internal_budget_bytes is set but not a string\n");
+    return Error::InvalidArgument;
+  }
+  if (bytes_res.error() != Error::NotFound) {
+    return bytes_res.error();
+  }
+
+  // Default: floor + pinned. Checked addition: a corrupt payload
+  // with absurd floor / pinned could wrap silently.
+  if (floor_bytes > std::numeric_limits<uint64_t>::max() - pinned_bytes_total) {
+    std::fprintf(
+        stderr,
+        "[ET_WEIGHT_OFFLOAD][ERROR] default budget overflows "
+        "(floor=%llu + pinned=%llu > UINT64_MAX)\n",
+        static_cast<unsigned long long>(floor_bytes),
+        static_cast<unsigned long long>(pinned_bytes_total));
+    return Error::Internal;
+  }
+  out.budget_bytes = floor_bytes + pinned_bytes_total;
+  // out.spec.value stays 0 to indicate "default path"; the UX hint
+  // still names the public spec as the recommended knob.
+  //
+  // Loud disclosure at the exact point the default is taken: the floor
+  // is a conservative FX pair-window estimate (see _compute_floor_bytes
+  // in weight_offload_pass.py) and does NOT account for Inductor kernels
+  // that horizontally fuse 3+ independent weights into one launch. Under
+  // such fusion the streaming pool can evict a weight the in-flight
+  // kernel still needs, producing silently wrong outputs. Only the
+  // streaming pool carries that risk, so skip the warning when there is
+  // no streaming (floor_bytes == 0, i.e. everything pinned).
+  if (floor_bytes > 0) {
+    std::fprintf(
+        stderr,
+        "[ET_WEIGHT_OFFLOAD][WARN] no weight_offload_budget_mb set; using "
+        "default budget = floor(%llu) + pinned(%llu) = %llu bytes. The floor "
+        "is a conservative FX pair-window estimate and does NOT cover "
+        "Inductor kernels that horizontally fuse 3+ independent weights into "
+        "one launch; under such fusion the streaming pool can evict a weight "
+        "the in-flight kernel still needs, producing silently wrong outputs. "
+        "If results look incorrect, set weight_offload_budget_mb explicitly "
+        "(larger than the default).\n",
+        static_cast<unsigned long long>(floor_bytes),
+        static_cast<unsigned long long>(pinned_bytes_total),
+        static_cast<unsigned long long>(out.budget_bytes));
+  }
+  return out;
+}
+
+} // namespace
+
+::executorch::runtime::Result<AOTICatalog> walk_aoti_catalog(
+    ::executorch::backends::aoti::AOTIDelegateHandle* handle,
+    const std::string& method_name) {
+  using ::executorch::runtime::Error;
+
+  if (handle->get_num_constants == nullptr ||
+      handle->get_constant_name == nullptr ||
+      handle->get_constant_original_fqn == nullptr ||
+      handle->update_user_managed_constant_buffer_pairs == nullptr ||
+      handle->get_constant_data_size == nullptr ||
+      handle->get_constant_from_folded == nullptr) {
+    std::fprintf(
+        stderr,
+        "[ET_WEIGHT_OFFLOAD][ERROR] method '%s': required AOTI symbols "
+        "unresolved (get_num_constants=%p get_constant_name=%p "
+        "get_constant_original_fqn=%p update_user_managed=%p "
+        "get_constant_data_size=%p get_constant_from_folded=%p)\n",
+        method_name.c_str(),
+        reinterpret_cast<void*>(handle->get_num_constants),
+        reinterpret_cast<void*>(handle->get_constant_name),
+        reinterpret_cast<void*>(handle->get_constant_original_fqn),
+        reinterpret_cast<void*>(
+            handle->update_user_managed_constant_buffer_pairs),
+        reinterpret_cast<void*>(handle->get_constant_data_size),
+        reinterpret_cast<void*>(handle->get_constant_from_folded));
+    return Error::Internal;
+  }
+
+  AOTICatalog out;
+  if (handle->get_num_constants(handle->container_handle, &out.num_constants) !=
+      Error::Ok) {
+    std::fprintf(
+        stderr,
+        "[ET_WEIGHT_OFFLOAD][ERROR] get_num_constants failed for "
+        "method '%s'\n",
+        method_name.c_str());
+    return Error::Internal;
+  }
+  out.fqns.reserve(out.num_constants);
+  out.internal_names.reserve(out.num_constants);
+  out.data_sizes.reserve(out.num_constants);
+  out.fqn_to_index.reserve(out.num_constants);
+
+  for (size_t i = 0; i < out.num_constants; ++i) {
+    bool folded = false;
+    if (handle->get_constant_from_folded(
+            handle->container_handle, i, &folded) != Error::Ok) {
+      return Error::Internal;
+    }
+    if (folded) {
+      const char* iname = nullptr;
+      (void)handle->get_constant_name(handle->container_handle, i, &iname);
+      std::fprintf(
+          stderr,
+          "[ET_WEIGHT_OFFLOAD][ERROR] method '%s': folded constant at "
+          "idx=%zu (internal_name='%s') -- disable "
+          "torch._inductor.config.aot_inductor.use_runtime_constant_folding\n",
+          method_name.c_str(),
+          i,
+          iname == nullptr ? "<null>" : iname);
+      return Error::InvalidArgument;
+    }
+
+    const char* fqn_cstr = nullptr;
+    if (handle->get_constant_original_fqn(
+            handle->container_handle, i, &fqn_cstr) != Error::Ok ||
+        fqn_cstr == nullptr || fqn_cstr[0] == '\0') {
+      std::fprintf(
+          stderr,
+          "[ET_WEIGHT_OFFLOAD][ERROR] method '%s': AOTI constant "
+          "idx=%zu has empty/null original_fqn (cannot probe-route)\n",
+          method_name.c_str(),
+          i);
+      return Error::InvalidArgument;
+    }
+    const char* iname_cstr = nullptr;
+    if (handle->get_constant_name(handle->container_handle, i, &iname_cstr) !=
+            Error::Ok ||
+        iname_cstr == nullptr) {
+      return Error::Internal;
+    }
+    size_t ds = 0;
+    if (handle->get_constant_data_size(handle->container_handle, i, &ds) !=
+        Error::Ok) {
+      return Error::Internal;
+    }
+    out.fqns.emplace_back(fqn_cstr);
+    out.internal_names.emplace_back(iname_cstr);
+    out.data_sizes.push_back(ds);
+    auto [it, inserted] = out.fqn_to_index.emplace(out.fqns.back(), i);
+    if (!inserted) {
+      std::fprintf(
+          stderr,
+          "[ET_WEIGHT_OFFLOAD][ERROR] method '%s': duplicate AOTI "
+          "original_fqn '%s' at indices %zu and %zu\n",
+          method_name.c_str(),
+          out.fqns.back().c_str(),
+          it->second,
+          i);
+      return Error::InvalidArgument;
+    }
+  }
+  return out;
+}
+
+::executorch::runtime::Result<std::unique_ptr<Session>> Session::create(
+    const Payload& payload,
+    ::executorch::backends::aoti::AOTIDelegateHandle* handle,
+    AOTICatalog catalog,
+    const uint8_t* weights_blob,
+    cudaStream_t compute_stream,
+    ::executorch::runtime::BackendInitContext& context) {
+  using ::executorch::runtime::Error;
+
+  // Build fqn -> ConstantMetadata index. The parser validated
+  // metadata FQNs == unique(schedule), so every scheduled FQN is
+  // present and unique.
+  std::unordered_map<std::string, const ConstantMetadata*> fqn_to_meta;
+  fqn_to_meta.reserve(payload.constants_metadata.size());
+  for (const auto& m : payload.constants_metadata) {
+    fqn_to_meta.emplace(m.fqn, &m);
+  }
+
+  // Pinned bytes: parser-validated nbytes == elementSize * product,
+  // and pin_fqns are deduped + subset of schedule, so no overflow
+  // check needed beyond what the parser already did per entry.
+  uint64_t pinned_bytes_total = 0;
+  for (const auto& fqn : payload.pin_fqns) {
+    pinned_bytes_total += fqn_to_meta.at(fqn)->nbytes;
+  }
+
+  // Resolve the load-time budget from the runtime-spec chain.
+  auto budget_res =
+      resolve_budget(context, payload.floor_bytes, pinned_bytes_total);
+  if (!budget_res.ok()) {
+    return budget_res.error();
+  }
+  const uint64_t budget_bytes = budget_res.get().budget_bytes;
+  const BudgetSpec budget_spec = budget_res.get().spec;
+
+  auto session = std::unique_ptr<Session>(new Session());
+  session->schedule_ = payload.schedule;
+  session->compute_stream_ = compute_stream;
+  session->total_budget_bytes_ = budget_bytes;
+  session->pinned_bytes_total_ = pinned_bytes_total;
+  session->floor_bytes_ = payload.floor_bytes;
+  session->method_name_ = payload.method_name;
+  // Single-device today: the parser hard-fails device_index != 0.
+  session->device_index_ = 0;
+
+  std::unordered_set<std::string> unique_fqns(
+      payload.schedule.begin(), payload.schedule.end());
+  session->host_entries_.reserve(unique_fqns.size());
+  session->registered_dummies_.reserve(unique_fqns.size());
+  for (const auto& fqn : payload.pin_fqns) {
+    session->pin_set_.insert(fqn);
+  }
+
+  const uint64_t required_total = payload.floor_bytes + pinned_bytes_total;
+
+  // total < pinned + floor covers both "pinned alone exceeds total"
+  // and "streaming budget < floor". Suggest the public spec name for
+  // the fix (rounded up to whole MB so the value is loadable).
+  if (session->total_budget_bytes_ < required_total) {
+    constexpr uint64_t kMiB = 1ull << 20;
+    const uint64_t required_mb =
+        (required_total / kMiB) + ((required_total % kMiB) != 0 ? 1 : 0);
+    std::fprintf(
+        stderr,
+        "[ET_WEIGHT_OFFLOAD][ERROR] method '%s': budget %llu bytes < "
+        "required total %llu (pinned constants %llu + streaming pool "
+        "floor %llu)",
+        payload.method_name.c_str(),
+        static_cast<unsigned long long>(session->total_budget_bytes_),
+        static_cast<unsigned long long>(required_total),
+        static_cast<unsigned long long>(session->pinned_bytes_total_),
+        static_cast<unsigned long long>(payload.floor_bytes));
+    if (budget_spec.value > 0) {
+      std::fprintf(
+          stderr,
+          " [set via %s=%llu]",
+          budget_spec.name,
+          static_cast<unsigned long long>(budget_spec.value));
+    }
+    std::fprintf(
+        stderr,
+        ". Set weight_offload_budget_mb >= %llu. "
+        "NOTE: floor is a conservative FX-fusion upper bound "
+        "(max consecutive pair-window working set + eviction "
+        "headroom for the largest single weight) — the actual "
+        "runtime peak working set is typically smaller. See "
+        "_compute_floor_bytes in backends/cuda/passes/"
+        "weight_offload_pass.py for the exact formula.\n",
+        static_cast<unsigned long long>(required_mb));
+    return Error::InvalidArgument;
+  }
+
+  // Past the unified check: total >= pinned + floor, so streaming is
+  // non-negative AND >= floor.
+  session->streaming_budget_bytes_ =
+      session->total_budget_bytes_ - session->pinned_bytes_total_;
+
+  // Bind the device BEFORE any device operation (dummy cudaMalloc,
+  // host-mirror H2D, stream/pool create, pinned cudaMalloc). All
+  // subsequent CUDA calls implicitly use the current device.
+  cudaError_t dev_err = cudaSetDevice(session->device_index_);
+  if (dev_err != cudaSuccess) {
+    std::fprintf(
+        stderr,
+        "[ET_WEIGHT_OFFLOAD][ERROR] cudaSetDevice(%d) failed: %s\n",
+        session->device_index_,
+        cudaGetErrorString(dev_err));
+    return Error::Internal;
+  }
+
+  // Build dummies + install via AOTI. One 1-byte cudaMalloc + SlimTensor
+  // wrap per AOTI constant; any failure inside the loop returns and the
+  // unique_ptr<Session>'s dtor runs ~Session() which calls
+  // dummies_.clear_and_free() to free the partial state.
+  DummyInstallation dummy_guard;
+  dummy_guard.dummy_data_ptrs.reserve(catalog.num_constants);
+  dummy_guard.dummy_tensors.reserve(catalog.num_constants);
+  std::vector<::executorch::backends::aoti::AOTInductorConstantMapEntry> pairs;
+  pairs.reserve(catalog.num_constants);
+  static constexpr int64_t kDummySizes[1] = {1};
+  static constexpr int64_t kDummyStrides[1] = {1};
+  // Float (c10::ScalarType::Float == 6). The dummy is opaque — no
+  // kernel reads it; the probe op redirects every read.
+  static constexpr int32_t kDummyDtype = 6;
+  for (size_t i = 0; i < catalog.num_constants; ++i) {
+    void* gpu = nullptr;
+    if (cudaMalloc(&gpu, 1) != cudaSuccess) {
+      std::fprintf(
+          stderr,
+          "[ET_WEIGHT_OFFLOAD][ERROR] cudaMalloc(1) for dummy idx=%zu "
+          "failed\n",
+          i);
+      session->dummies_ = std::move(dummy_guard);
+      return Error::Internal;
+    }
+    dummy_guard.dummy_data_ptrs.push_back(gpu);
+    ::executorch::backends::aoti::Tensor* st = nullptr;
+    auto wrap_err =
+        ::executorch::backends::cuda::aoti_torch_create_tensor_from_blob_v2(
+            gpu,
+            /*ndim=*/1,
+            const_cast<int64_t*>(kDummySizes),
+            const_cast<int64_t*>(kDummyStrides),
+            /*storage_offset=*/0,
+            kDummyDtype,
+            /*device_type=*/1,
+            /*device_index=*/0,
+            &st,
+            /*layout=*/0,
+            /*opaque_metadata=*/nullptr,
+            /*opaque_metadata_size=*/0);
+    if (wrap_err != Error::Ok || st == nullptr) {
+      std::fprintf(
+          stderr,
+          "[ET_WEIGHT_OFFLOAD][ERROR] dummy wrap idx=%zu failed (0x%x)\n",
+          i,
+          static_cast<uint32_t>(wrap_err));
+      session->dummies_ = std::move(dummy_guard);
+      return Error::Internal;
+    }
+    dummy_guard.dummy_tensors.push_back(st);
+    pairs.push_back(
+        {catalog.internal_names[i].c_str(),
+         reinterpret_cast<::executorch::backends::aoti::AtenTensorHandle>(st)});
+  }
+  // Install dummies via AOTI. After this, AOTI dispatches probes
+  // with the dummy SlimTensor as input; ProbeRegistry routes back
+  // here. validate_full_update=true is belt-and-braces; the caller's
+  // catalog/schedule coverage check is the real proof.
+  if (handle->update_user_managed_constant_buffer_pairs(
+          handle->container_handle,
+          pairs.data(),
+          pairs.size(),
+          /*use_inactive=*/false,
+          /*validate_full_update=*/true) != Error::Ok) {
+    std::fprintf(
+        stderr,
+        "[ET_WEIGHT_OFFLOAD][ERROR] method '%s': "
+        "update_user_managed_constant_buffer_pairs failed\n",
+        payload.method_name.c_str());
+    session->dummies_ = std::move(dummy_guard);
+    return Error::Internal;
+  }
+  // Transfer dummy ownership to the session; failures below clean
+  // up via the session dtor.
+  session->dummies_ = std::move(dummy_guard);
+
+  // Per-FQN source-blob offsets. The blob is densely packed by
+  // data_size in declaration order (model_base.h::load_constants's
+  // bytes_read += data_size, no alignment padding).
+  std::unordered_map<std::string, uint64_t> fqn_offsets;
+  fqn_offsets.reserve(catalog.num_constants);
+  {
+    uint64_t running = 0;
+    for (size_t i = 0; i < catalog.num_constants; ++i) {
+      fqn_offsets[catalog.fqns[i]] = running;
+      running += static_cast<uint64_t>(catalog.data_sizes[i]);
+    }
+  }
+
+  // Build the pinned host mirror. Bytes are copied DIRECTLY from
+  // the caller-provided _weights_blob region (NamedData entry); the
+  // caller may free the blob the moment Session::create returns.
+  if (weights_blob == nullptr && !unique_fqns.empty()) {
+    std::fprintf(
+        stderr,
+        "[ET_WEIGHT_OFFLOAD][ERROR] weights_blob is null but schedule is "
+        "non-empty\n");
+    return Error::InvalidArgument;
+  }
+  for (const auto& fqn : unique_fqns) {
+    const ConstantMetadata& m = *fqn_to_meta.at(fqn);
+    const uint64_t blob_offset = fqn_offsets.at(fqn);
+
+    HostEntry entry;
+    entry.nbytes = m.nbytes;
+    entry.dtype = m.dtype;
+    entry.device_index = m.device_index;
+    entry.sizes = m.sizes;
+    entry.strides = m.strides;
+
+    cudaError_t alloc_err =
+        cudaHostAlloc(&entry.host_ptr, entry.nbytes, cudaHostAllocDefault);
+    if (alloc_err != cudaSuccess || entry.host_ptr == nullptr) {
+      std::fprintf(
+          stderr,
+          "[ET_WEIGHT_OFFLOAD][ERROR] cudaHostAlloc(%llu) for FQN '%s' "
+          "failed: %s\n",
+          static_cast<unsigned long long>(entry.nbytes),
+          fqn.c_str(),
+          cudaGetErrorString(alloc_err));
+      return Error::Internal;
+    }
+    std::memcpy(entry.host_ptr, weights_blob + blob_offset, entry.nbytes);
+    session->host_entries_.emplace(fqn, std::move(entry));
+  }
+
+  // 6. Create the copy stream (separate from compute_stream_).
+  cudaError_t stream_err =
+      cudaStreamCreateWithFlags(&session->copy_stream_, cudaStreamNonBlocking);
+  if (stream_err != cudaSuccess) {
+    std::fprintf(
+        stderr,
+        "[ET_WEIGHT_OFFLOAD][ERROR] cudaStreamCreateWithFlags failed: %s\n",
+        cudaGetErrorString(stream_err));
+    return Error::Internal;
+  }
+
+  // 7. Create the pool with PyTorch-style reuse flags. The set-
+  //    attribute calls are NOT optional — the cross-stream reuse
+  //    semantics the hot path relies on require these flags. A
+  //    failure here means the pool would not behave as designed,
+  //    so hard-fail rather than silently degrade.
+  cudaMemPoolProps props{};
+  props.allocType = cudaMemAllocationTypePinned;
+  props.handleTypes = cudaMemHandleTypeNone;
+  props.location.type = cudaMemLocationTypeDevice;
+  props.location.id = session->device_index_;
+  cudaError_t pool_err = cudaMemPoolCreate(&session->pool_, &props);
+  if (pool_err != cudaSuccess) {
+    std::fprintf(
+        stderr,
+        "[ET_WEIGHT_OFFLOAD][ERROR] cudaMemPoolCreate failed: %s\n",
+        cudaGetErrorString(pool_err));
+    return Error::Internal;
+  }
+  int yes = 1;
+  struct PoolAttr {
+    cudaMemPoolAttr attr;
+    void* value;
+    const char* name;
+  };
+  // Release threshold is the pool's preferred upper bound on
+  // driver-side cache. It is SOFT (PyTorch's comment) — the pool
+  // CAN reserve more if pressure demands it — so this is not a
+  // hard cap on physical footprint. Setting it to
+  // streaming_budget_bytes_ (rather than total) keeps the
+  // preferred bound aligned with our REQUESTED-live-bytes
+  // invariant: bytes_in_flight_ + pinned_bytes_total_ <=
+  // total_budget_bytes_. Driver-reserved / cached memory may
+  // briefly exceed pinned + streaming, but our accounting
+  // (peak_live_bytes <= streaming_budget) stays self-consistent.
+  uint64_t release_threshold = session->streaming_budget_bytes_;
+  const PoolAttr pool_attrs[] = {
+      {cudaMemPoolReuseFollowEventDependencies,
+       &yes,
+       "cudaMemPoolReuseFollowEventDependencies"},
+      {cudaMemPoolReuseAllowOpportunistic,
+       &yes,
+       "cudaMemPoolReuseAllowOpportunistic"},
+      {cudaMemPoolReuseAllowInternalDependencies,
+       &yes,
+       "cudaMemPoolReuseAllowInternalDependencies"},
+      {cudaMemPoolAttrReleaseThreshold,
+       &release_threshold,
+       "cudaMemPoolAttrReleaseThreshold"},
+  };
+  for (const auto& pa : pool_attrs) {
+    cudaError_t set_err =
+        cudaMemPoolSetAttribute(session->pool_, pa.attr, pa.value);
+    if (set_err != cudaSuccess) {
+      std::fprintf(
+          stderr,
+          "[ET_WEIGHT_OFFLOAD][ERROR] cudaMemPoolSetAttribute(%s) failed: "
+          "%s\n",
+          pa.name,
+          cudaGetErrorString(set_err));
+      return Error::Internal;
+    }
+  }
+
+  // 7b. Allocate pinned constants. One ``cudaMalloc`` per pinned FQN,
+  //     ``cudaMemcpyAsync`` from the pinned host mirror on
+  //     ``compute_stream_``, then ``cudaStreamSynchronize`` so
+  //     Session::serve's pinned fast path can return without any
+  //     event wait. ``pinned_.emplace`` asserts the parse-time dedupe
+  //     held — duplicate FQN here would shadow the prior pointer
+  //     and leak the GPU buffer.
+  //
+  //     Pinned cudaMalloc bypasses the offload pool: pinned
+  //     allocations are out-of-band and don't count toward
+  //     ``bytes_in_flight_`` against ``streaming_budget_bytes_``.
+  //     They're cleaned up in ``~Session()`` between
+  //     ``dummies_.clear_and_free()`` and ``free_host_mirror``.
+  if (!session->pin_set_.empty()) {
+    // Defensive re-bind: AOTI's update_user_managed_constant_buffer_pairs
+    // contract doesn't promise the current device is preserved (it
+    // doesn't internally re-bind today, but the contract is silent).
+    // Pinned cudaMalloc lands wherever the current device points, so
+    // re-bind here to keep pinned allocations on device_index_ even
+    // if AOTI ever flips the current device.
+    cudaError_t pin_dev_err = cudaSetDevice(session->device_index_);
+    if (pin_dev_err != cudaSuccess) {
+      std::fprintf(
+          stderr,
+          "[ET_WEIGHT_OFFLOAD][ERROR] cudaSetDevice(%d) before pinned "
+          "alloc failed: %s\n",
+          session->device_index_,
+          cudaGetErrorString(pin_dev_err));
+      return Error::Internal;
+    }
+    bool pin_alloc_ok = true;
+    for (const auto& fqn : session->pin_set_) {
+      const HostEntry& host = session->host_entries_.at(fqn);
+      void* dev = nullptr;
+      cudaError_t pin_alloc_err = cudaMalloc(&dev, host.nbytes);
+      if (pin_alloc_err != cudaSuccess) {
+        std::fprintf(
+            stderr,
+            "[ET_WEIGHT_OFFLOAD][ERROR] cudaMalloc(%llu) for pinned "
+            "FQN '%s' failed: %s\n",
+            static_cast<unsigned long long>(host.nbytes),
+            fqn.c_str(),
+            cudaGetErrorString(pin_alloc_err));
+        pin_alloc_ok = false;
+        break;
+      }
+      cudaError_t copy_err = cudaMemcpyAsync(
+          dev,
+          host.host_ptr,
+          host.nbytes,
+          cudaMemcpyHostToDevice,
+          session->compute_stream_);
+      if (copy_err != cudaSuccess) {
+        std::fprintf(
+            stderr,
+            "[ET_WEIGHT_OFFLOAD][ERROR] cudaMemcpyAsync H2D for pinned "
+            "FQN '%s' (%llu bytes) failed: %s\n",
+            fqn.c_str(),
+            static_cast<unsigned long long>(host.nbytes),
+            cudaGetErrorString(copy_err));
+        cudaFree(dev);
+        pin_alloc_ok = false;
+        break;
+      }
+      auto [it, inserted] = session->pinned_.emplace(fqn, dev);
+      (void)it;
+      if (!inserted) {
+        std::fprintf(
+            stderr,
+            "[ET_WEIGHT_OFFLOAD][ERROR] duplicate pinned FQN '%s' "
+            "during alloc — parse-time dedupe was bypassed\n",
+            fqn.c_str());
+        cudaFree(dev);
+        pin_alloc_ok = false;
+        break;
+      }
+    }
+    if (!pin_alloc_ok) {
+      // pinned_ accumulated partial state; let unique_ptr<Session>'s
+      // dtor clean it up (the dtor's pinned-cleanup loop runs
+      // unconditionally over pinned_ entries).
+      return Error::Internal;
+    }
+    // Drain the pinned H2D before returning so the fast path can
+    // serve pinned constants without an event wait.
+    cudaError_t sync_err = cudaStreamSynchronize(session->compute_stream_);
+    if (sync_err != cudaSuccess) {
+      std::fprintf(
+          stderr,
+          "[ET_WEIGHT_OFFLOAD][ERROR] cudaStreamSynchronize after pinned "
+          "H2D failed: %s\n",
+          cudaGetErrorString(sync_err));
+      return Error::Internal;
+    }
+  }
+
+  // Register dummies with ProbeRegistry -- LAST step. Each AOTI
+  // constant index has a unique 1-byte cudaMalloc'd dummy (built
+  // above), so the data_ptrs are already unique; just hand the
+  // vector to the registry.
+  std::vector<const void*> dummy_keys(
+      session->dummies_.dummy_data_ptrs.begin(),
+      session->dummies_.dummy_data_ptrs.end());
+  auto& registry = ProbeRegistry::instance();
+  auto reg_err = registry.register_entries(
+      session.get(),
+      &Session::registry_callback,
+      dummy_keys.data(),
+      dummy_keys.size());
+  if (reg_err != Error::Ok) {
+    std::fprintf(
+        stderr,
+        "[ET_WEIGHT_OFFLOAD][ERROR] ProbeRegistry::register_entries failed "
+        "(error 0x%x); collision against an already-registered pointer is "
+        "the only path that returns here\n",
+        static_cast<uint32_t>(reg_err));
+    return reg_err;
+  }
+  session->registered_dummies_ = std::move(dummy_keys);
+
+  return session;
+}
+
+Session::~Session() {
+  // Unregister from ProbeRegistry FIRST — pure CPU work, safe even
+  // if the GPU is in a bad state. After this point no new probe
+  // calls can land on serve().
+  ProbeRegistry::instance().unregister_context(
+      this, registered_dummies_.data(), registered_dummies_.size());
+
+  // Re-bind the device for GPU teardown. cudaStreamSynchronize /
+  // cudaFreeAsync / cudaEventDestroy are stream-or-pointer-bound
+  // and don't strictly require the current device match, but
+  // cudaMemPoolDestroy and cudaFree (for dummies / pinned) target
+  // resources that live on device_index_, and operating on them
+  // with a wrong current device risks corrupting allocations on
+  // whatever device IS current. If the re-bind fails, SKIP all GPU
+  // cleanup — the GPU-side resources leak (unrecoverable in this
+  // error path), but we don't double-fault into another device's
+  // state. We still drop the CPU-side bookkeeping (live_/lru_order_/
+  // pinned_/dummies_/host_mirror) so the Session object itself is
+  // safe to destroy.
+  cudaError_t set_dev_err = cudaSetDevice(device_index_);
+  if (set_dev_err != cudaSuccess) {
+    std::fprintf(
+        stderr,
+        "[ET_WEIGHT_OFFLOAD][WARN] cudaSetDevice(%d) in ~Session() "
+        "failed: %s; SKIPPING GPU teardown to avoid touching the "
+        "wrong device. Streams/pool/dummies/pinned GPU buffers "
+        "will leak.\n",
+        device_index_,
+        cudaGetErrorString(set_dev_err));
+    // Drop bookkeeping that owns GPU handles WITHOUT touching the
+    // handles themselves. SlimTensor wrappers from
+    // aoti_torch_create_tensor_from_blob_v2 are non-owning
+    // (``from_blob``) so ``delete`` on them is pure CPU work —
+    // safe even with a bad GPU state. The dummy cudaMalloc'd
+    // device pointers DO leak; clearing the ptr vector first
+    // ensures the implicit dummies_ dtor doesn't try to cudaFree
+    // them.
+    for (auto* t : dummies_.dummy_tensors) {
+      delete t;
+    }
+    dummies_.dummy_tensors.clear();
+    dummies_.dummy_data_ptrs.clear();
+    live_.clear();
+    lru_order_.clear();
+    pinned_.clear();
+    host_entries_.clear();
+    return;
+  }
+
+  if (compute_stream_ != nullptr) {
+    // Drain kernels that may be reading any live_ entry.
+    cudaStreamSynchronize(compute_stream_);
+  }
+
+  for (auto& [fqn, e] : live_) {
+    if (e.dev_ptr != nullptr && compute_stream_ != nullptr) {
+      // Stream-order the free behind the entry's H2D. Prefetched
+      // entries may have a ready_event no prior serve() has waited
+      // on; without this wait, cudaFreeAsync on compute_stream_
+      // would queue the free before the in-flight cudaMemcpyAsync
+      // on copy_stream_ drains and free memory still being written
+      // to. cudaStreamWaitEvent is a queued cross-stream dependency
+      // (not a host sync), and a no-op if the event has already
+      // completed.
+      if (e.ready_event != nullptr) {
+        cudaStreamWaitEvent(compute_stream_, e.ready_event, 0);
+      }
+      cudaFreeAsync(e.dev_ptr, compute_stream_);
+    }
+    if (e.ready_event != nullptr) {
+      cudaEventDestroy(e.ready_event);
+    }
+  }
+  live_.clear();
+  lru_order_.clear();
+  bytes_in_flight_ = 0;
+
+  if (compute_stream_ != nullptr) {
+    // Make the async frees enqueued above actually take effect
+    // before destroying the pool.
+    cudaStreamSynchronize(compute_stream_);
+  }
+  if (copy_stream_ != nullptr) {
+    // Drain any work the serve() free_on_error paths left on
+    // copy_stream_; compute_stream_'s sync doesn't cover them.
+    cudaStreamSynchronize(copy_stream_);
+    cudaStreamDestroy(copy_stream_);
+    copy_stream_ = nullptr;
+  }
+  if (pool_ != nullptr) {
+    cudaMemPoolDestroy(pool_);
+    pool_ = nullptr;
+  }
+
+  // Free the dummies BETWEEN pool destroy and host-mirror free. By
+  // this point all streams + the pool are torn down, so no in-flight
+  // GPU work can touch the 1-byte dummy regions. AOTI's
+  // ``constants_map_`` is left pointing at the freed handles —
+  // harmless because run() is never invoked again on this container
+  // and the container itself is never explicitly deleted.
+  dummies_.clear_and_free();
+
+  // Free pinned GPU allocations. Same ordering as dummies — after
+  // pool/stream teardown so no in-flight GPU work touches the
+  // pinned regions, before host_mirror so the pinned host buffers
+  // we copied from are still alive (not strictly required for
+  // cudaFree, but matches the dummies' ordering for consistency).
+  for (auto& [fqn, dev] : pinned_) {
+    if (dev != nullptr) {
+      cudaFree(dev);
+    }
+  }
+  pinned_.clear();
+
+  free_host_mirror(host_entries_);
+
+  if (std::getenv("EXECUTORCH_WEIGHT_OFFLOAD_TRACE") != nullptr) {
+    std::fprintf(
+        stderr,
+        "[ET_WEIGHT_OFFLOAD_STATS] method=%s hits=%llu misses=%llu "
+        "evictions=%llu bytes_h2d=%llu peak_live_bytes=%llu budget=%llu "
+        "floor=%llu prefetch_attempted=%llu prefetch_succeeded=%llu "
+        "pinned_bytes=%llu streaming_budget=%llu\n",
+        method_name_.c_str(),
+        static_cast<unsigned long long>(stats_.pool_hits),
+        static_cast<unsigned long long>(stats_.pool_misses),
+        static_cast<unsigned long long>(stats_.evictions),
+        static_cast<unsigned long long>(stats_.bytes_h2d_copied),
+        static_cast<unsigned long long>(peak_live_bytes_),
+        static_cast<unsigned long long>(total_budget_bytes_),
+        static_cast<unsigned long long>(floor_bytes_),
+        static_cast<unsigned long long>(stats_.prefetch_attempted),
+        static_cast<unsigned long long>(stats_.prefetch_succeeded),
+        static_cast<unsigned long long>(pinned_bytes_total_),
+        static_cast<unsigned long long>(streaming_budget_bytes_));
+  }
+}
+
+::executorch::runtime::Error Session::registry_callback(
+    void* context,
+    ::executorch::backends::aoti::Tensor* input,
+    int64_t probe_id,
+    ::executorch::backends::aoti::Tensor** output) {
+  return static_cast<Session*>(context)->serve(input, probe_id, output);
+}
+
+std::unordered_map<std::string, Session::LiveAllocation>::iterator
+Session::pick_lru() {
+  // O(1): the front of lru_order_ is the least-recently-used FQN.
+  // Pinned entries never enter live_/lru_order_ (they live in
+  // pinned_, allocated out-of-pool via cudaMalloc).
+  if (lru_order_.empty()) {
+    return live_.end();
+  }
+  return live_.find(lru_order_.front());
+}
+
+::executorch::runtime::Error Session::wrap_borrowed_tensor(
+    void* dev_ptr,
+    const HostEntry& host,
+    ::executorch::backends::aoti::Tensor** output) {
+  using ::executorch::runtime::Error;
+  ::executorch::backends::aoti::Tensor* wrapped = nullptr;
+  auto err =
+      ::executorch::backends::cuda::aoti_torch_create_tensor_from_blob_v2(
+          dev_ptr,
+          static_cast<int64_t>(host.sizes.size()),
+          host.sizes.data(),
+          host.strides.data(),
+          /*storage_offset=*/0,
+          host.dtype,
+          kCudaDeviceType,
+          host.device_index,
+          &wrapped,
+          /*layout=*/0,
+          /*opaque_metadata=*/nullptr,
+          /*opaque_metadata_size=*/0);
+  if (err != Error::Ok || wrapped == nullptr) {
+    return err == Error::Ok ? Error::Internal : err;
+  }
+  *output = wrapped;
+  return Error::Ok;
+}
+
+::executorch::runtime::Error Session::make_room_and_alloc(
+    const std::string& fqn,
+    const HostEntry& host,
+    const std::string* guard_fqn,
+    const char* log_tag,
+    void** dev_out,
+    cudaEvent_t* ready_out) {
+  using ::executorch::runtime::Error;
+  *dev_out = nullptr;
+  *ready_out = nullptr;
+  const uint64_t need = host.nbytes;
+
+  // 1. Eviction loop. Stream-wait on each victim's ready_event before
+  //    cudaFreeAsync so a prefetched-but-not-yet-consumed entry isn't
+  //    freed mid-H2D.
+  bool evicted = false;
+  while (bytes_in_flight_ + need > streaming_budget_bytes_) {
+    auto victim_it = pick_lru();
+    if (victim_it == live_.end()) {
+      std::fprintf(
+          stderr,
+          "%s cannot make room for FQN '%s' needing %llu bytes; "
+          "streaming_budget=%llu, bytes_in_flight=%llu\n",
+          log_tag,
+          fqn.c_str(),
+          static_cast<unsigned long long>(need),
+          static_cast<unsigned long long>(streaming_budget_bytes_),
+          static_cast<unsigned long long>(bytes_in_flight_));
+      return Error::Internal;
+    }
+    if (guard_fqn != nullptr && victim_it->first == *guard_fqn) {
+      // Prefetch's "never evict the just-served FQN" guard. The
+      // floor invariant should prevent this; if it ever fires, the
+      // caller should skip the prefetch instead of risking
+      // corruption of the in-flight entry.
+      std::fprintf(
+          stderr,
+          "%s LRU victim for FQN '%s' would be the guarded '%s'; "
+          "floor invariant may be violated\n",
+          log_tag,
+          fqn.c_str(),
+          guard_fqn->c_str());
+      return Error::Internal;
+    }
+    auto& v = victim_it->second;
+    cudaError_t wait_err =
+        cudaStreamWaitEvent(compute_stream_, v.ready_event, 0);
+    if (wait_err != cudaSuccess) {
+      std::fprintf(
+          stderr,
+          "%s cudaStreamWaitEvent on victim '%s': %s\n",
+          log_tag,
+          victim_it->first.c_str(),
+          cudaGetErrorString(wait_err));
+      return Error::Internal;
+    }
+    cudaError_t free_err = cudaFreeAsync(v.dev_ptr, compute_stream_);
+    if (free_err != cudaSuccess) {
+      std::fprintf(
+          stderr,
+          "%s cudaFreeAsync for evicted FQN '%s' (%llu bytes): %s; "
+          "live_ + bytes_in_flight_ left untouched\n",
+          log_tag,
+          victim_it->first.c_str(),
+          static_cast<unsigned long long>(v.nbytes),
+          cudaGetErrorString(free_err));
+      return Error::Internal;
+    }
+    cudaEventDestroy(v.ready_event);
+    bytes_in_flight_ -= v.nbytes;
+    stats_.evictions++;
+    lru_order_.erase(v.lru_it);
+    live_.erase(victim_it);
+    evicted = true;
+  }
+
+  // 2. After eviction batch: record event on compute_, copy_ waits on
+  //    it before the upcoming malloc. Failure here is delicate
+  //    (live_/bytes_in_flight_ already mutated); fall back to a host
+  //    sync on compute_ so the frees physically complete and Session
+  //    state stays consistent.
+  if (evicted) {
+    cudaEvent_t evict_done = nullptr;
+    cudaError_t ev_err =
+        cudaEventCreateWithFlags(&evict_done, cudaEventDisableTiming);
+    if (ev_err != cudaSuccess) {
+      std::fprintf(
+          stderr,
+          "%s cudaEventCreate for eviction batch: %s; syncing compute_stream\n",
+          log_tag,
+          cudaGetErrorString(ev_err));
+      (void)cudaStreamSynchronize(compute_stream_);
+      return Error::Internal;
+    }
+    if (cudaEventRecord(evict_done, compute_stream_) != cudaSuccess ||
+        cudaStreamWaitEvent(copy_stream_, evict_done, 0) != cudaSuccess) {
+      cudaEventDestroy(evict_done);
+      std::fprintf(
+          stderr,
+          "%s event-record/wait for eviction batch failed; syncing "
+          "compute_stream\n",
+          log_tag);
+      (void)cudaStreamSynchronize(compute_stream_);
+      return Error::Internal;
+    }
+    cudaEventDestroy(evict_done);
+  }
+
+  // 3. Allocate on copy_. From here on, any failure must
+  //    cudaFreeAsync(dev) before returning.
+  void* dev = nullptr;
+  cudaError_t malloc_err =
+      cudaMallocFromPoolAsync(&dev, need, pool_, copy_stream_);
+  if (malloc_err != cudaSuccess) {
+    std::fprintf(
+        stderr,
+        "%s cudaMallocFromPoolAsync for FQN '%s' (%llu bytes): %s\n",
+        log_tag,
+        fqn.c_str(),
+        static_cast<unsigned long long>(need),
+        cudaGetErrorString(malloc_err));
+    return Error::Internal;
+  }
+  auto free_on_error = [&]() {
+    if (dev != nullptr) {
+      cudaFreeAsync(dev, copy_stream_);
+      dev = nullptr;
+    }
+  };
+
+  cudaError_t memcpy_err = cudaMemcpyAsync(
+      dev, host.host_ptr, need, cudaMemcpyHostToDevice, copy_stream_);
+  if (memcpy_err != cudaSuccess) {
+    std::fprintf(
+        stderr,
+        "%s cudaMemcpyAsync H2D for FQN '%s' (%llu bytes): %s\n",
+        log_tag,
+        fqn.c_str(),
+        static_cast<unsigned long long>(need),
+        cudaGetErrorString(memcpy_err));
+    free_on_error();
+    return Error::Internal;
+  }
+
+  cudaEvent_t ready = nullptr;
+  cudaError_t ev_err = cudaEventCreateWithFlags(&ready, cudaEventDisableTiming);
+  if (ev_err != cudaSuccess) {
+    std::fprintf(
+        stderr,
+        "%s cudaEventCreate ready for FQN '%s': %s\n",
+        log_tag,
+        fqn.c_str(),
+        cudaGetErrorString(ev_err));
+    free_on_error();
+    return Error::Internal;
+  }
+  if (cudaEventRecord(ready, copy_stream_) != cudaSuccess) {
+    cudaEventDestroy(ready);
+    free_on_error();
+    std::fprintf(
+        stderr,
+        "%s cudaEventRecord ready for FQN '%s'\n",
+        log_tag,
+        fqn.c_str());
+    return Error::Internal;
+  }
+
+  *dev_out = dev;
+  *ready_out = ready;
+  return Error::Ok;
+}
+
+::executorch::runtime::Error Session::serve(
+    ::executorch::backends::aoti::Tensor* input,
+    int64_t probe_id,
+    ::executorch::backends::aoti::Tensor** output) {
+  using ::executorch::runtime::Error;
+  (void)input; // identity comes from schedule_[probe_id]
+
+  // Re-bind the device only if something external (a Python extension,
+  // another backend, a sibling thread) flipped the current device
+  // since the cudaSetDevice in CudaBackend::execute(). The pool,
+  // copy_stream_, and dummy allocations all live on device_index_;
+  // cudaMallocFromPoolAsync / cudaEventCreate /
+  // aoti_torch_create_tensor_from_blob_v2 all implicitly use the
+  // current device, so a mismatch would corrupt across GPUs.
+  //
+  // cudaGetDevice is a much cheaper call than cudaSetDevice; checking
+  // first turns the steady-state cost into one get per probe instead
+  // of one set, which matters for models with hundreds of probes per
+  // forward pass.
+  int current_device = -1;
+  cudaError_t get_dev_err = cudaGetDevice(&current_device);
+  if (get_dev_err != cudaSuccess) {
+    std::fprintf(
+        stderr,
+        "[ET_WEIGHT_OFFLOAD][ERROR] cudaGetDevice in serve() failed: %s\n",
+        cudaGetErrorString(get_dev_err));
+    return Error::Internal;
+  }
+  if (current_device != device_index_) {
+    cudaError_t set_dev_err = cudaSetDevice(device_index_);
+    if (set_dev_err != cudaSuccess) {
+      std::fprintf(
+          stderr,
+          "[ET_WEIGHT_OFFLOAD][ERROR] cudaSetDevice(%d) in serve() failed: "
+          "%s\n",
+          device_index_,
+          cudaGetErrorString(set_dev_err));
+      return Error::Internal;
+    }
+  }
+
+  if (probe_id < 0 || static_cast<size_t>(probe_id) >= schedule_.size()) {
+    std::fprintf(
+        stderr,
+        "[ET_WEIGHT_OFFLOAD][ERROR] probe_id=%" PRId64
+        " out of range for "
+        "schedule of size %zu\n",
+        probe_id,
+        schedule_.size());
+    return Error::InvalidArgument;
+  }
+  const std::string& fqn = schedule_[probe_id];
+  auto host_it = host_entries_.find(fqn);
+  if (host_it == host_entries_.end()) {
+    std::fprintf(
+        stderr,
+        "[ET_WEIGHT_OFFLOAD][ERROR] no host mirror for FQN '%s' "
+        "(probe_id=%" PRId64 ")\n",
+        fqn.c_str(),
+        probe_id);
+    return Error::Internal;
+  }
+  const HostEntry& host = host_it->second;
+
+  // Pinned fast path. Resident GPU allocation, populated once at
+  // init via cudaMemcpyAsync + sync; no event wait, no pool work,
+  // no streaming-stats bump. STILL calls opportunistic_prefetch
+  // at the end so a pinned→streaming transition doesn't lose
+  // overlap.
+  if (auto pin_it = pinned_.find(fqn); pin_it != pinned_.end()) {
+    ::executorch::backends::aoti::Tensor* wrapped = nullptr;
+    auto wrap_err = wrap_borrowed_tensor(pin_it->second, host, &wrapped);
+    if (wrap_err != Error::Ok) {
+      std::fprintf(
+          stderr,
+          "[ET_WEIGHT_OFFLOAD][ERROR] pinned-path borrowed-wrap for FQN "
+          "'%s' failed (error 0x%x)\n",
+          fqn.c_str(),
+          static_cast<uint32_t>(wrap_err));
+      return wrap_err;
+    }
+    *output = wrapped;
+    (void)opportunistic_prefetch(probe_id);
+    return Error::Ok;
+  }
+
+  // Pool hit.
+  if (auto live_it = live_.find(fqn); live_it != live_.end()) {
+    auto& e = live_it->second;
+    cudaError_t wait_err =
+        cudaStreamWaitEvent(compute_stream_, e.ready_event, 0);
+    if (wait_err != cudaSuccess) {
+      std::fprintf(
+          stderr,
+          "[ET_WEIGHT_OFFLOAD][ERROR] cudaStreamWaitEvent on hit for FQN "
+          "'%s' failed: %s\n",
+          fqn.c_str(),
+          cudaGetErrorString(wait_err));
+      return Error::Internal;
+    }
+    // Splice to back of lru_order_: O(1) and preserves the
+    // iterator, so e.lru_it stays valid.
+    lru_order_.splice(lru_order_.end(), lru_order_, e.lru_it);
+    stats_.pool_hits++;
+    ::executorch::backends::aoti::Tensor* wrapped = nullptr;
+    auto err = wrap_borrowed_tensor(e.dev_ptr, host, &wrapped);
+    if (err != Error::Ok) {
+      std::fprintf(
+          stderr,
+          "[ET_WEIGHT_OFFLOAD][ERROR] hit-path borrowed-wrap for FQN '%s' "
+          "failed (error 0x%x)\n",
+          fqn.c_str(),
+          static_cast<uint32_t>(err));
+      return err;
+    }
+    *output = wrapped;
+    // Best-effort depth-1 prefetch. Errors are logged inside the
+    // helper and never propagated — the current probe is already
+    // populated in *output.
+    (void)opportunistic_prefetch(probe_id);
+    return Error::Ok;
+  }
+
+  // Miss.
+  stats_.pool_misses++;
+  const uint64_t need = host.nbytes;
+
+  void* dev = nullptr;
+  cudaEvent_t ready = nullptr;
+  auto room_err = make_room_and_alloc(
+      fqn,
+      host,
+      /*guard_fqn=*/nullptr,
+      "[ET_WEIGHT_OFFLOAD][ERROR]",
+      &dev,
+      &ready);
+  if (room_err != Error::Ok) {
+    return room_err;
+  }
+
+  // Serve-only: gate compute on the H2D ready event.
+  cudaError_t wait_err = cudaStreamWaitEvent(compute_stream_, ready, 0);
+  if (wait_err != cudaSuccess) {
+    std::fprintf(
+        stderr,
+        "[ET_WEIGHT_OFFLOAD][ERROR] cudaStreamWaitEvent for FQN '%s': %s\n",
+        fqn.c_str(),
+        cudaGetErrorString(wait_err));
+    cudaEventDestroy(ready);
+    cudaFreeAsync(dev, copy_stream_);
+    return Error::Internal;
+  }
+
+  ::executorch::backends::aoti::Tensor* wrapped = nullptr;
+  auto wrap_err = wrap_borrowed_tensor(dev, host, &wrapped);
+  if (wrap_err != Error::Ok) {
+    std::fprintf(
+        stderr,
+        "[ET_WEIGHT_OFFLOAD][ERROR] miss-path borrowed-wrap for FQN '%s' "
+        "failed (error 0x%x)\n",
+        fqn.c_str(),
+        static_cast<uint32_t>(wrap_err));
+    cudaEventDestroy(ready);
+    cudaFreeAsync(dev, copy_stream_);
+    return wrap_err;
+  }
+
+  bytes_in_flight_ += need;
+  peak_live_bytes_ = std::max(peak_live_bytes_, bytes_in_flight_);
+  auto lru_it = lru_order_.insert(lru_order_.end(), fqn);
+  live_.emplace(fqn, LiveAllocation{dev, need, ready, lru_it});
+  stats_.bytes_h2d_copied += need;
+
+  *output = wrapped;
+  // Best-effort depth-1 prefetch. Errors are logged inside the
+  // helper and never propagated — the current probe is already
+  // populated in *output.
+  (void)opportunistic_prefetch(probe_id);
+  return Error::Ok;
+}
+
+::executorch::runtime::Error Session::opportunistic_prefetch(
+    int64_t current_probe_id) {
+  using ::executorch::runtime::Error;
+
+  if (schedule_.empty()) {
+    return Error::Ok;
+  }
+  const int64_t next_id =
+      (current_probe_id + 1) % static_cast<int64_t>(schedule_.size());
+  const std::string& fqn = schedule_[static_cast<size_t>(next_id)];
+
+  // Step 1: pinned → already resident, no prefetch needed
+  // (cheaper than the live_ check so do it first).
+  if (pin_set_.find(fqn) != pin_set_.end()) {
+    return Error::Ok;
+  }
+
+  // Step 1a: already-live → no work needed.
+  if (live_.find(fqn) != live_.end()) {
+    return Error::Ok;
+  }
+
+  // Defensive guard — never evict the FQN the c-shim is about to
+  // hand back to AOTI for kernel launch. The floor formula
+  // (budget >= bytes(current) + bytes(next)) should make this
+  // unreachable today; the guard covers a hypothetical
+  // below-floor configuration for the single-immediately-just-
+  // served-FQN case. It does NOT cover multi-probe-before-one-
+  // launch (fused kernels with probes A, B before one launch
+  // could still have A evicted by a prefetch after B if the floor
+  // invariant were violated). The init-time floor hard-fail is
+  // the real general contract.
+  const std::string& current_fqn =
+      schedule_[static_cast<size_t>(current_probe_id)];
+
+  auto host_it = host_entries_.find(fqn);
+  if (host_it == host_entries_.end()) {
+    std::fprintf(
+        stderr,
+        "[ET_WEIGHT_OFFLOAD][WARN] prefetch skipped: no host mirror "
+        "for FQN '%s'\n",
+        fqn.c_str());
+    return Error::Internal;
+  }
+  const HostEntry& host = host_it->second;
+  const uint64_t need = host.nbytes;
+
+  // From here on a real prefetch is attempted. Count the attempt
+  // regardless of whether it succeeds — `attempted - succeeded`
+  // = swallowed errors.
+  stats_.prefetch_attempted++;
+
+  void* dev = nullptr;
+  cudaEvent_t ready = nullptr;
+  auto room_err = make_room_and_alloc(
+      fqn,
+      host,
+      &current_fqn,
+      "[ET_WEIGHT_OFFLOAD][WARN] prefetch",
+      &dev,
+      &ready);
+  if (room_err != Error::Ok) {
+    return room_err;
+  }
+
+  // No cudaStreamWaitEvent(compute_, ready) here — the next serve()
+  // that consumes this entry as a hit does that wait itself.
+  bytes_in_flight_ += need;
+  peak_live_bytes_ = std::max(peak_live_bytes_, bytes_in_flight_);
+  // Treat the prefetched entry as "newest": the FQN is about to be
+  // served next, so its expected next-use is sooner than what we
+  // just served, and a same-cycle miss should evict the older one.
+  auto lru_it = lru_order_.insert(lru_order_.end(), fqn);
+  live_.emplace(fqn, LiveAllocation{dev, need, ready, lru_it});
+  stats_.bytes_h2d_copied += need;
+  stats_.prefetch_succeeded++;
+  return Error::Ok;
+}
+
+} // namespace executorch::backends::cuda::weight_offload

--- a/backends/cuda/runtime/weight_offload/session.h
+++ b/backends/cuda/runtime/weight_offload/session.h
@@ -1,0 +1,352 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// EXPERIMENTAL: per-handle CUDA weight-offload Session.
+//
+// What it owns: a pinned host mirror of the schedule's constants, a
+// bounded cudaMemPool sized by a software byte cap on requested live
+// offload bytes, LRU eviction with event-ordered cudaFreeAsync on the
+// compute stream, depth-1 opportunistic prefetch on the copy stream,
+// optional pinned-resident constants (out-of-pool cudaMalloc), and the
+// DummyInstallation that AOTI's container uses as its "active
+// constants" so probe ops route every constant read here. See
+// session.cpp for the per-step ordering. Single-device only (the
+// payload parser hard-fails device_index != 0).
+//
+// Companion components: payload.{h} (on-wire schema parser, the single
+// trust boundary), probe_op.{h,cpp} (AOTI c-shim), probe_registry.{h,cpp}
+// (process-global dummy_ptr -> Session map). Public entry from the
+// pass side: ``CudaPartitioner(weight_offload=True,
+// weight_offload_pin_fqns=[...])``.
+
+#include <cstdint>
+#include <list>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include <cuda_runtime.h>
+
+#include <executorch/backends/aoti/aoti_delegate_handle.h>
+#include <executorch/backends/aoti/common_shims_slim.h>
+#include <executorch/backends/cuda/runtime/weight_offload/payload.h>
+#include <executorch/runtime/backend/backend_init_context.h>
+#include <executorch/runtime/core/error.h>
+#include <executorch/runtime/core/result.h>
+
+namespace executorch::backends::cuda::weight_offload {
+
+// Snapshot of the AOTI container's constant catalog, produced by
+// walk_aoti_catalog. Indexed by AOTI constant index. The walk hard-
+// fails on folded constants, empty original_fqns, and duplicate
+// original_fqns (each of which would silently corrupt the offload
+// install).
+struct AOTICatalog {
+  size_t num_constants{0};
+  std::vector<std::string> fqns; // original_fqn by index
+  std::vector<std::string> internal_names; // get_constant_name by index
+  std::vector<size_t> data_sizes; // get_constant_data_size by index
+  std::unordered_map<std::string, size_t> fqn_to_index;
+};
+
+// Walk the AOTI container's constants via the function pointers on
+// ``handle``. Hard-fails on folded constants, empty original_fqns,
+// and duplicate original_fqns. Also verifies the required AOTI
+// symbol set is present on the handle.
+::executorch::runtime::Result<AOTICatalog> walk_aoti_catalog(
+    ::executorch::backends::aoti::AOTIDelegateHandle* handle,
+    const std::string& method_name);
+
+// Tag for the below-floor UX hint in Session::create. Populated by
+// cuda_backend.cpp from the runtime-spec resolution chain; the
+// default-budget path leaves value=0 and sets name to the public
+// spec as a forward-looking hint.
+struct BudgetSpec {
+  const char* name{nullptr};
+  uint64_t value{0};
+  bool value_is_mb{false}; // false = bytes (internal spec)
+};
+
+struct SessionStats {
+  uint64_t pool_hits{0};
+  uint64_t pool_misses{0};
+  uint64_t evictions{0};
+  uint64_t bytes_h2d_copied{0};
+  // Best-effort depth-1 prefetch counters. Incremented by
+  // Session::opportunistic_prefetch (called at the end of every
+  // serve). prefetch_attempted bumps BEFORE the H2D is issued;
+  // prefetch_succeeded bumps AFTER cudaMemcpyAsync is queued.
+  // ``attempted - succeeded`` = swallowed errors (eviction / alloc /
+  // copy failure — all logged but never propagated, since the
+  // current probe has already returned).
+  uint64_t prefetch_attempted{0};
+  uint64_t prefetch_succeeded{0};
+};
+
+// Owns the 1-byte GPU dummies + SlimTensor wrappers installed via
+// AOTI's update_user_managed_constant_buffer_pairs. AOTI's contract
+// says the ConstantMap is user-managed; we retain ownership for the
+// lifetime of the container. Move-only so a local RAII guard in
+// CudaBackend::init can be moved into Session::create at the end of
+// the install dance; pre-move failure paths are cleaned up by the
+// guard's own dtor.
+struct DummyInstallation {
+  // Indexed by AOTI constant index (the step-3 hard-fail on folded
+  // constants guarantees num_folded == 0, so non-folded position ==
+  // AOTI index here).
+  std::vector<void*> dummy_data_ptrs; // cudaMalloc'd, 1 byte each.
+  std::vector<::executorch::backends::aoti::Tensor*> dummy_tensors;
+
+  DummyInstallation() = default;
+  ~DummyInstallation();
+
+  DummyInstallation(DummyInstallation&&) noexcept;
+  DummyInstallation& operator=(DummyInstallation&&) noexcept;
+  DummyInstallation(const DummyInstallation&) = delete;
+  DummyInstallation& operator=(const DummyInstallation&) = delete;
+
+  // Idempotent — Session::~Session calls this explicitly at the right
+  // ordering point (after pool/stream teardown, before the field's own
+  // dtor runs). The field's dtor then sees empty vectors and does
+  // nothing.
+  void clear_and_free();
+};
+
+class Session {
+ public:
+  // Build dummies, install them via AOTI, build the host mirror,
+  // allocate the pool + copy stream, register dispatch entries with
+  // ProbeRegistry. The caller has already parsed + validated the
+  // payload and walked the AOTI catalog (folded check + coverage +
+  // AOTI/payload data_size cross-check); Session::create trusts both
+  // inputs and owns everything from dummy install through registry
+  // registration.
+  //
+  // ``weights_blob`` is a borrowed pointer into the NamedDataMap's
+  // ``<method>_weights_blob`` entry; Session::create copies the
+  // per-FQN bytes into pinned host memory and the caller may free
+  // ``weights_blob`` the moment create returns.
+  //
+  // Resolves the load-time budget from the runtime-spec chain
+  // (public ``weight_offload_budget_mb`` -> internal
+  // ``_weight_offload_internal_budget_bytes`` -> default of
+  // ``floor + pinned``) and hard-fails if the result is below
+  // ``floor + pinned``.
+  static ::executorch::runtime::Result<std::unique_ptr<Session>> create(
+      const Payload& payload,
+      ::executorch::backends::aoti::AOTIDelegateHandle* handle,
+      AOTICatalog catalog,
+      const uint8_t* weights_blob,
+      cudaStream_t compute_stream,
+      ::executorch::runtime::BackendInitContext& context);
+
+  ~Session();
+  Session(const Session&) = delete;
+  Session& operator=(const Session&) = delete;
+
+  // Hot path. Called from the probe c-shim via the registry
+  // callback. ``input`` is the AOTI-provided constant tensor handle
+  // (only used here for diagnostics; identity of the FQN comes from
+  // ``schedule[probe_id]``).
+  ::executorch::runtime::Error serve(
+      ::executorch::backends::aoti::Tensor* input,
+      int64_t probe_id,
+      ::executorch::backends::aoti::Tensor** output);
+
+  // Callback shim that ``ProbeRegistry`` invokes. Casts the
+  // ``void* context`` back to ``Session*`` and forwards.
+  static ::executorch::runtime::Error registry_callback(
+      void* context,
+      ::executorch::backends::aoti::Tensor* input,
+      int64_t probe_id,
+      ::executorch::backends::aoti::Tensor** output);
+
+  // Read-only accessors for tests + the destructor stats line.
+  const SessionStats& stats() const {
+    return stats_;
+  }
+  uint64_t peak_live_bytes() const {
+    return peak_live_bytes_;
+  }
+  uint64_t total_budget_bytes() const {
+    return total_budget_bytes_;
+  }
+  uint64_t pinned_bytes_total() const {
+    return pinned_bytes_total_;
+  }
+  uint64_t streaming_budget_bytes() const {
+    return streaming_budget_bytes_;
+  }
+  uint64_t floor_bytes() const {
+    return floor_bytes_;
+  }
+
+  // Per-FQN host mirror. ``host_ptr`` was allocated via
+  // ``cudaHostAlloc`` and is freed in the destructor. Public so the
+  // free-on-error helper in ``session.cpp``'s anonymous namespace
+  // can reference it; nothing outside that TU should touch it.
+  struct HostEntry {
+    void* host_ptr{nullptr};
+    uint64_t nbytes{0};
+    int32_t dtype{0};
+    int32_t device_index{0};
+    std::vector<int64_t> sizes;
+    std::vector<int64_t> strides;
+  };
+
+  // Per-live-allocation tracking. ``ready_event`` is recorded on the
+  // copy stream after the H2D completes; consumers must
+  // ``cudaStreamWaitEvent`` it before reading. ``lru_it`` points into
+  // ``Session::lru_order_`` so a hit splices to the back in O(1)
+  // and pick_lru() returns ``live_.find(lru_order_.front())``. Public
+  // for the same reason as HostEntry: TU-internal cleanup helpers
+  // reference it.
+  struct LiveAllocation {
+    void* dev_ptr{nullptr};
+    uint64_t nbytes{0};
+    cudaEvent_t ready_event{nullptr};
+    std::list<std::string>::iterator lru_it{};
+  };
+
+ private:
+  Session() = default;
+
+  // Returns ``live_.end()`` if ``lru_order_`` is empty. Otherwise
+  // returns the live_ entry for the front (least-recently-used) FQN
+  // — O(1) via lru_order_ + the hash lookup. Pinned entries never
+  // enter live_/lru_order_, so they're naturally excluded.
+  std::unordered_map<std::string, LiveAllocation>::iterator pick_lru();
+
+  // Best-effort depth-1 prefetch. Called at the end of every
+  // successful serve() with the current probe_id. Looks up
+  // schedule_[(probe_id + 1) % size()] and, if that FQN is not
+  // already live AND not the just-served FQN, attempts to evict +
+  // alloc + H2D + record-ready-event for it. Errors are LOGGED and
+  // counted in stats_.prefetch_attempted but never returned —
+  // the caller (serve) has already populated *output with the
+  // current probe's result, and the prefetch is strictly speculative.
+  // The next serve() that consumes this FQN sees it as a pool hit
+  // and waits on its ready_event before the kernel reads it.
+  ::executorch::runtime::Error opportunistic_prefetch(int64_t probe_id);
+
+  // Build a borrowed SlimTensor wrapping the given device pointer
+  // with host_entries_[fqn]'s metadata. Used by the hit path, the
+  // miss path's post-allocation step, the pinned fast path, and
+  // (via prefetch's lookup) the next-hit path. Extracted to one
+  // helper so the four sites share the same arg list and error
+  // handling.
+  //
+  // OWNERSHIP: aoti_torch_create_tensor_from_blob_v2 ``new``s a
+  // SlimTensor; the AOTI c-shim contract (see
+  // backends/cuda/runtime/shims/memory.h and the int4mm output
+  // doc comment) makes the CALLER responsible for freeing the
+  // returned handle via aoti_torch_delete_tensor_object. For probe
+  // outputs that caller is AOTI's generated wrapper.cpp, which
+  // wraps the AtenTensorHandle in a RAIIAtenTensorHandle (PyTorch's
+  // cpp_wrapper_cpu convention) so the handle is freed when it
+  // falls out of scope after the kernel consumes it. ``from_blob``
+  // is NON-OWNING — the delete frees only the wrapper, never our
+  // pool / pinned / dummy GPU buffer, so the per-serve() ``new
+  // SlimTensor`` does not leak the underlying allocation.
+  ::executorch::runtime::Error wrap_borrowed_tensor(
+      void* dev_ptr,
+      const HostEntry& host,
+      ::executorch::backends::aoti::Tensor** output);
+
+  // Shared eviction + alloc + H2D path for serve()'s miss and
+  // opportunistic_prefetch(). On success: ``*dev_out`` holds a
+  // freshly cudaMallocFromPoolAsync'd pool allocation of
+  // ``host.nbytes`` bytes, and ``*ready_out`` is a cudaEvent_t
+  // recorded on ``copy_stream_`` after the H2D queues. Caller is
+  // responsible for: incrementing ``bytes_in_flight_`` +
+  // ``peak_live_bytes_``, emplacing into ``live_`` (with the event
+  // as the entry's ready_event), bumping its own success counter,
+  // and (for serve only) cudaStreamWaitEvent(compute_, ready).
+  //
+  // Internally: evict LRU victims until ``need`` fits in the
+  // streaming budget (skipping ``guard_fqn`` if non-null), update
+  // bytes_in_flight_ / live_ / stats_.evictions for each, then
+  // event-record + cross-stream wait on the eviction batch, then
+  // alloc + memcpy + ready event. On any failure: cudaFreeAsync any
+  // ``*dev_out`` already allocated, leave session state consistent,
+  // return Error::Internal. ``log_tag`` is the prefix used in every
+  // diagnostic the helper emits (e.g. "[ET_WEIGHT_OFFLOAD][ERROR]"
+  // or "[ET_WEIGHT_OFFLOAD][WARN] prefetch").
+  ::executorch::runtime::Error make_room_and_alloc(
+      const std::string& fqn,
+      const HostEntry& host,
+      const std::string* guard_fqn,
+      const char* log_tag,
+      void** dev_out,
+      cudaEvent_t* ready_out);
+
+  // schedule_[probe_id] is the FQN string; host_entries_[fqn] holds
+  // the mirrored bytes + metadata. The two-step indirection is
+  // intentional: schedule may repeat the same FQN at distinct probe
+  // sites (per-consumer probes), but the host mirror is one entry
+  // per unique FQN.
+  std::vector<std::string> schedule_;
+  std::unordered_map<std::string, HostEntry> host_entries_;
+  std::unordered_map<std::string, LiveAllocation> live_;
+  cudaStream_t compute_stream_{nullptr};
+  cudaStream_t copy_stream_{nullptr};
+  cudaMemPool_t pool_{nullptr};
+  int32_t device_index_{0};
+
+  // Total budget = user's GPU memory cap = pinned + streaming pool.
+  uint64_t total_budget_bytes_{0};
+  // Sum of pinned-FQN logical bytes. Subtracted from total to
+  // derive the streaming-pool cap.
+  uint64_t pinned_bytes_total_{0};
+  // Streaming pool cap = total - pinned. The miss/prefetch eviction
+  // loops compare ``bytes_in_flight_ + need`` against this, NOT
+  // total_budget_bytes_ — pinned allocations live outside the pool
+  // (separate cudaMalloc) and don't count toward in-flight.
+  uint64_t streaming_budget_bytes_{0};
+  uint64_t floor_bytes_{0};
+  uint64_t bytes_in_flight_{0};
+  uint64_t peak_live_bytes_{0};
+
+  // Intrusive LRU order. front() = least-recently-used FQN
+  // (eviction candidate); back() = most-recently-used. Every entry
+  // in ``live_`` owns one node here, addressed by
+  // ``LiveAllocation::lru_it``. On a hit / fresh miss we splice the
+  // entry's node to the back in O(1); on eviction we erase the
+  // front node + its live_ entry.
+  std::list<std::string> lru_order_;
+
+  std::string method_name_;
+  SessionStats stats_;
+
+  // Bookkeeping for tear-down: every pointer we registered with
+  // ProbeRegistry so we can unregister precisely on destruction.
+  // Stored as ``void*`` to avoid the lookup needing to round-trip
+  // through ``host_entries_``.
+  std::vector<const void*> registered_dummies_;
+
+  // Owns the 1-byte GPU dummies + SlimTensor wrappers AOTI dispatches
+  // probes with. Session::~Session calls
+  // ``dummies_.clear_and_free()`` explicitly between "destroy pool"
+  // and "free host mirror"; the field's own destructor (which runs
+  // implicitly after the explicit cleanup) is a no-op.
+  DummyInstallation dummies_;
+
+  // Pinning state. ``pin_set_`` is the O(1) hot-path check
+  // Session::serve uses to choose the resident fast path; ``pinned_``
+  // owns the GPU buffers, allocated once via ``cudaMalloc`` at
+  // Session::create and freed in the dtor between dummies cleanup
+  // and host-mirror free.
+  std::unordered_set<std::string> pin_set_;
+  std::unordered_map<std::string, void*> pinned_;
+};
+
+} // namespace executorch::backends::cuda::weight_offload

--- a/backends/cuda/runtime/weight_offload/tests/CMakeLists.txt
+++ b/backends/cuda/runtime/weight_offload/tests/CMakeLists.txt
@@ -1,0 +1,72 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+cmake_minimum_required(VERSION 3.19)
+project(weight_offload_tests LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Fetch GoogleTest
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG v1.14.0
+)
+set(gtest_force_shared_crt
+    ON
+    CACHE BOOL "" FORCE
+)
+FetchContent_MakeAvailable(googletest)
+
+# Get EXECUTORCH_ROOT (this dir is backends/cuda/runtime/weight_offload/tests,
+# five levels below the repo root -- same depth as shims/tests).
+if(NOT EXECUTORCH_ROOT)
+  set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../../../..)
+endif()
+
+# Find installed ExecuTorch
+find_package(executorch CONFIG REQUIRED HINTS ${CMAKE_INSTALL_PREFIX})
+
+enable_testing()
+
+# ---------------------------------------------------------------------------
+# Host-level: payload parser. No CUDA, no GPU. Builds + runs anywhere.
+# ---------------------------------------------------------------------------
+add_executable(payload_test payload_test.cpp)
+target_include_directories(
+  payload_test PRIVATE ${EXECUTORCH_ROOT}/.. ${EXECUTORCH_ROOT}
+)
+target_link_libraries(
+  payload_test PRIVATE GTest::gtest GTest::gtest_main executorch_core
+)
+add_test(NAME payload_test COMMAND payload_test)
+
+# ---------------------------------------------------------------------------
+# Session state machine. Requires a GPU; only built when CUDA is present.
+# ---------------------------------------------------------------------------
+include(CheckLanguage)
+check_language(CUDA)
+if(CMAKE_CUDA_COMPILER)
+  enable_language(CUDA)
+  find_package(CUDAToolkit REQUIRED)
+
+  add_executable(session_test session_test.cpp)
+  target_include_directories(
+    session_test PRIVATE ${EXECUTORCH_ROOT}/.. ${EXECUTORCH_ROOT}
+                         ${CUDAToolkit_INCLUDE_DIRS}
+  )
+  target_compile_definitions(session_test PRIVATE CUDA_AVAILABLE=1)
+  target_link_libraries(
+    session_test
+    PRIVATE GTest::gtest GTest::gtest_main aoti_cuda_backend aoti_cuda_shims
+            executorch_core CUDA::cudart
+  )
+  add_test(NAME session_test COMMAND session_test)
+else()
+  message(STATUS "weight_offload_tests: no CUDA compiler; skipping session_test")
+endif()

--- a/backends/cuda/runtime/weight_offload/tests/CMakePresets.json
+++ b/backends/cuda/runtime/weight_offload/tests/CMakePresets.json
@@ -1,0 +1,56 @@
+{
+    "version": 6,
+    "configurePresets": [
+        {
+            "name": "default",
+            "displayName": "Weight Offload Tests",
+            "binaryDir": "${sourceDir}/../../../../../cmake-out/backends/cuda/runtime/weight_offload/tests",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release",
+                "CMAKE_PREFIX_PATH": "${sourceDir}/../../../../../cmake-out"
+            },
+            "condition": {
+                "type": "inList",
+                "string": "${hostSystemName}",
+                "list": ["Linux", "Windows"]
+            }
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "default",
+            "displayName": "Build Weight Offload Tests",
+            "configurePreset": "default"
+        }
+    ],
+    "workflowPresets": [
+        {
+            "name": "default",
+            "displayName": "Configure, build, and test Weight Offload Tests",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "default"
+                },
+                {
+                    "type": "build",
+                    "name": "default"
+                },
+                {
+                    "type": "test",
+                    "name": "default"
+                }
+            ]
+        }
+    ],
+    "testPresets": [
+        {
+            "name": "default",
+            "displayName": "Run all Weight Offload Tests",
+            "configurePreset": "default",
+            "output": {
+                "outputOnFailure": true
+            }
+        }
+    ]
+}

--- a/backends/cuda/runtime/weight_offload/tests/TARGETS
+++ b/backends/cuda/runtime/weight_offload/tests/TARGETS
@@ -1,0 +1,5 @@
+load(":targets.bzl", "define_common_targets")
+
+oncall("executorch")
+
+define_common_targets()

--- a/backends/cuda/runtime/weight_offload/tests/payload_test.cpp
+++ b/backends/cuda/runtime/weight_offload/tests/payload_test.cpp
@@ -1,0 +1,476 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Host-level (no CUDA, no GPU) tests for the weight-offload payload
+// parser -- the single trust boundary the runtime relies on
+// (``CudaBackend::init`` and ``Session::create`` trust the parsed
+// struct without re-validating). ``payload.h`` is header-only and
+// pulls in nothing CUDA, so these run anywhere.
+//
+// The wire format mirrors
+// ``backends/cuda/passes/weight_offload_pass.py::_serialize_payload``.
+// Tests build little-endian bytes directly (the parser uses memcpy
+// reads, so this is correct on the LE hosts ExecuTorch builds on) and
+// assert each per-field bound and cross-field invariant rejects.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include <executorch/backends/cuda/runtime/weight_offload/payload.h>
+#include <executorch/runtime/core/error.h>
+
+namespace {
+
+using executorch::runtime::Error;
+namespace wo = executorch::backends::cuda::weight_offload;
+
+// c10::ScalarType codes used below (match _TORCH_DTYPE_TO_C10).
+constexpr int32_t kInt8 = 1; // element_size 1
+constexpr int32_t kFloat32 = 6; // element_size 4
+
+// Little-endian byte accumulator mirroring the Python serializer.
+struct Buf {
+  std::vector<uint8_t> bytes;
+
+  void raw(const void* p, size_t n) {
+    const auto* b = static_cast<const uint8_t*>(p);
+    bytes.insert(bytes.end(), b, b + n);
+  }
+  void u32(uint32_t v) {
+    raw(&v, sizeof(v));
+  }
+  void u64(uint64_t v) {
+    raw(&v, sizeof(v));
+  }
+  void i32(int32_t v) {
+    raw(&v, sizeof(v));
+  }
+  void i64(int64_t v) {
+    raw(&v, sizeof(v));
+  }
+  // Length-prefixed string with an EXPLICIT length, so tests can lie
+  // about the length to exercise the bounds checks.
+  void lenstr(uint32_t len, const std::string& s) {
+    u32(len);
+    raw(s.data(), s.size());
+  }
+  void str(const std::string& s) {
+    lenstr(static_cast<uint32_t>(s.size()), s);
+  }
+};
+
+// Append a constants_metadata entry. Every field is a parameter so a
+// test can emit a single inconsistency (bad strides, wrong nbytes,
+// wrong device, ...) on top of an otherwise-valid entry.
+void meta(
+    Buf& b,
+    const std::string& fqn,
+    int32_t dtype,
+    const std::vector<int64_t>& sizes,
+    const std::vector<int64_t>& strides,
+    int64_t storage_offset,
+    uint64_t nbytes,
+    int32_t device_type,
+    int32_t device_index) {
+  b.str(fqn);
+  b.i32(dtype);
+  b.u32(static_cast<uint32_t>(sizes.size()));
+  for (int64_t s : sizes) {
+    b.i64(s);
+  }
+  for (int64_t s : strides) {
+    b.i64(s);
+  }
+  b.i64(storage_offset);
+  b.u64(nbytes);
+  b.i32(device_type);
+  b.i32(device_index);
+}
+
+// Canonical valid payload: method "m", floor 64, schedule [a, b, a],
+// no pins, metadata for a (float32 [2,3] = 24B) and b (int8 [4] = 4B).
+Buf valid() {
+  Buf b;
+  b.u32(wo::kPayloadMagic);
+  b.u32(2); // schema_version
+  b.str("m");
+  b.u64(64); // floor_bytes
+  b.u32(3); // schedule_count
+  b.str("a");
+  b.str("b");
+  b.str("a");
+  b.u32(0); // pin_count
+  b.u32(2); // constants_metadata_count
+  meta(b, "a", kFloat32, {2, 3}, {3, 1}, 0, 24, 1, 0);
+  meta(b, "b", kInt8, {4}, {1}, 0, 4, 1, 0);
+  return b;
+}
+
+wo::Payload parse_ok(const Buf& b, const std::string& method = "m") {
+  auto r = wo::parse_payload(b.bytes.data(), b.bytes.size(), method);
+  EXPECT_TRUE(r.ok()) << "expected parse to succeed";
+  return r.ok() ? r.get() : wo::Payload{};
+}
+
+void parse_rejects(const Buf& b, const std::string& method = "m") {
+  auto r = wo::parse_payload(b.bytes.data(), b.bytes.size(), method);
+  EXPECT_FALSE(r.ok()) << "expected parse to reject";
+  if (!r.ok()) {
+    EXPECT_EQ(r.error(), Error::InvalidArgument);
+  }
+}
+
+// --------------------------------------------------------------------
+// Happy paths
+// --------------------------------------------------------------------
+
+TEST(WeightOffloadPayload, ValidPopulatedRoundTrips) {
+  wo::Payload p = parse_ok(valid());
+  EXPECT_EQ(p.schema_version, 2u);
+  EXPECT_EQ(p.method_name, "m");
+  EXPECT_EQ(p.floor_bytes, 64u);
+  ASSERT_EQ(p.schedule.size(), 3u);
+  EXPECT_EQ(p.schedule[0], "a");
+  EXPECT_EQ(p.schedule[1], "b");
+  EXPECT_EQ(p.schedule[2], "a");
+  EXPECT_TRUE(p.pin_fqns.empty());
+  ASSERT_EQ(p.constants_metadata.size(), 2u);
+  // first-seen order preserved
+  EXPECT_EQ(p.constants_metadata[0].fqn, "a");
+  EXPECT_EQ(p.constants_metadata[0].nbytes, 24u);
+  EXPECT_EQ(p.constants_metadata[1].fqn, "b");
+  EXPECT_EQ(p.constants_metadata[1].nbytes, 4u);
+}
+
+TEST(WeightOffloadPayload, EmptyScheduleIsValid) {
+  Buf b;
+  b.u32(wo::kPayloadMagic);
+  b.u32(2);
+  b.str("m");
+  b.u64(0);
+  b.u32(0); // schedule
+  b.u32(0); // pin
+  b.u32(0); // metadata
+  wo::Payload p = parse_ok(b);
+  EXPECT_TRUE(p.schedule.empty());
+  EXPECT_TRUE(p.constants_metadata.empty());
+}
+
+TEST(WeightOffloadPayload, ScalarConstantAccepted) {
+  // ndim 0: no sizes/strides, logical == element_size, numel 1.
+  Buf b;
+  b.u32(wo::kPayloadMagic);
+  b.u32(2);
+  b.str("m");
+  b.u64(0);
+  b.u32(1);
+  b.str("s");
+  b.u32(0); // pin
+  b.u32(1); // metadata
+  meta(b, "s", kFloat32, {}, {}, 0, 4, 1, 0);
+  wo::Payload p = parse_ok(b);
+  ASSERT_EQ(p.constants_metadata.size(), 1u);
+  EXPECT_EQ(p.constants_metadata[0].nbytes, 4u);
+}
+
+TEST(WeightOffloadPayload, PinSubsetOfScheduleAccepted) {
+  Buf b;
+  b.u32(wo::kPayloadMagic);
+  b.u32(2);
+  b.str("m");
+  b.u64(24);
+  b.u32(2);
+  b.str("a");
+  b.str("b");
+  b.u32(1); // pin
+  b.str("a");
+  b.u32(2);
+  meta(b, "a", kFloat32, {2, 3}, {3, 1}, 0, 24, 1, 0);
+  meta(b, "b", kInt8, {4}, {1}, 0, 4, 1, 0);
+  wo::Payload p = parse_ok(b);
+  ASSERT_EQ(p.pin_fqns.size(), 1u);
+  EXPECT_EQ(p.pin_fqns[0], "a");
+}
+
+TEST(WeightOffloadPayload, EmptyExpectedMethodAcceptsAny) {
+  // expected_method "" disables the method-name match.
+  auto b = valid();
+  auto r = wo::parse_payload(b.bytes.data(), b.bytes.size(), "");
+  EXPECT_TRUE(r.ok());
+}
+
+// --------------------------------------------------------------------
+// Framing / header
+// --------------------------------------------------------------------
+
+TEST(WeightOffloadPayload, RejectsBadMagic) {
+  auto b = valid();
+  // Corrupt the first 4 bytes.
+  uint32_t bad = 0xDEADBEEF;
+  std::memcpy(b.bytes.data(), &bad, sizeof(bad));
+  parse_rejects(b);
+}
+
+TEST(WeightOffloadPayload, RejectsWrongSchemaVersion) {
+  for (uint32_t ver : {1u, 3u, 0u}) {
+    Buf b = valid();
+    std::memcpy(b.bytes.data() + 4, &ver, sizeof(ver));
+    parse_rejects(b);
+  }
+}
+
+TEST(WeightOffloadPayload, RejectsTruncationAtEveryPrefix) {
+  auto full = valid();
+  // Every strict prefix of a valid payload must be rejected (no
+  // truncation read past the end). Skip length 0 trivially-empty.
+  for (size_t n = 1; n < full.bytes.size(); ++n) {
+    auto r = wo::parse_payload(full.bytes.data(), n, "m");
+    EXPECT_FALSE(r.ok()) << "prefix length " << n << " should reject";
+  }
+}
+
+TEST(WeightOffloadPayload, RejectsTrailingBytes) {
+  auto b = valid();
+  b.bytes.push_back(0x00); // one extra byte
+  parse_rejects(b);
+}
+
+TEST(WeightOffloadPayload, RejectsMethodNameMismatch) {
+  parse_rejects(valid(), "not_m");
+}
+
+// --------------------------------------------------------------------
+// Bounds
+// --------------------------------------------------------------------
+
+TEST(WeightOffloadPayload, RejectsOverlongString) {
+  Buf b;
+  b.u32(wo::kPayloadMagic);
+  b.u32(2);
+  // method_name length claims > kMaxStrLen.
+  b.lenstr(wo::kMaxStrLen + 1, std::string(wo::kMaxStrLen + 1, 'x'));
+  b.u64(0);
+  parse_rejects(b);
+}
+
+TEST(WeightOffloadPayload, RejectsScheduleCountOverCap) {
+  Buf b;
+  b.u32(wo::kPayloadMagic);
+  b.u32(2);
+  b.str("m");
+  b.u64(0);
+  b.u32(wo::kMaxScheduleCount + 1); // rejected before any entry is read
+  parse_rejects(b);
+}
+
+TEST(WeightOffloadPayload, RejectsPinCountOverCap) {
+  Buf b;
+  b.u32(wo::kPayloadMagic);
+  b.u32(2);
+  b.str("m");
+  b.u64(0);
+  b.u32(0); // schedule
+  b.u32(wo::kMaxPinCount + 1);
+  parse_rejects(b);
+}
+
+TEST(WeightOffloadPayload, RejectsMetadataCountOverCap) {
+  Buf b;
+  b.u32(wo::kPayloadMagic);
+  b.u32(2);
+  b.str("m");
+  b.u64(0);
+  b.u32(0); // schedule
+  b.u32(0); // pin
+  b.u32(wo::kMaxConstantsMetadataCount + 1);
+  parse_rejects(b);
+}
+
+TEST(WeightOffloadPayload, RejectsNdimOverCap) {
+  Buf b;
+  b.u32(wo::kPayloadMagic);
+  b.u32(2);
+  b.str("m");
+  b.u64(0);
+  b.u32(1);
+  b.str("a");
+  b.u32(0); // pin
+  b.u32(1); // metadata
+  b.str("a");
+  b.i32(kFloat32);
+  b.u32(wo::kMaxNdim + 1); // ndim over cap, rejected before reading sizes
+  parse_rejects(b);
+}
+
+// --------------------------------------------------------------------
+// Per-FQN metadata invariants
+// --------------------------------------------------------------------
+
+// Build a single-constant payload whose lone metadata entry is emitted
+// by ``emit`` (so a test can inject exactly one inconsistency).
+template <typename EmitFn>
+Buf one_const(EmitFn emit) {
+  Buf b;
+  b.u32(wo::kPayloadMagic);
+  b.u32(2);
+  b.str("m");
+  b.u64(0);
+  b.u32(1); // schedule
+  b.str("a");
+  b.u32(0); // pin
+  b.u32(1); // metadata
+  emit(b);
+  return b;
+}
+
+TEST(WeightOffloadPayload, RejectsEmptyFqnInMetadata) {
+  parse_rejects(one_const(
+      [](Buf& b) { meta(b, "", kFloat32, {2}, {1}, 0, 8, 1, 0); }));
+}
+
+TEST(WeightOffloadPayload, RejectsUnsupportedDtype) {
+  // 7, 8, 9, 10 are not in the allow-list (element_size returns 0).
+  for (int32_t dt : {7, 8, 9, 10, 99, -1}) {
+    parse_rejects(one_const(
+        [dt](Buf& b) { meta(b, "a", dt, {2}, {1}, 0, 8, 1, 0); }));
+  }
+}
+
+TEST(WeightOffloadPayload, RejectsNonPositiveSize) {
+  parse_rejects(
+      one_const([](Buf& b) { meta(b, "a", kFloat32, {0}, {1}, 0, 0, 1, 0); }));
+  parse_rejects(
+      one_const([](Buf& b) { meta(b, "a", kFloat32, {-2}, {1}, 0, 8, 1, 0); }));
+}
+
+TEST(WeightOffloadPayload, RejectsNonContiguousStrides) {
+  // [2,3] contiguous strides are {3,1}; {1,2} is not C-contiguous.
+  parse_rejects(one_const(
+      [](Buf& b) { meta(b, "a", kFloat32, {2, 3}, {1, 2}, 0, 24, 1, 0); }));
+}
+
+TEST(WeightOffloadPayload, RejectsNonZeroStorageOffset) {
+  parse_rejects(one_const(
+      [](Buf& b) { meta(b, "a", kFloat32, {2, 3}, {3, 1}, 1, 24, 1, 0); }));
+}
+
+TEST(WeightOffloadPayload, RejectsNbytesMismatch) {
+  // float32 [2,3] logical == 24; claim 23 and 25.
+  parse_rejects(one_const(
+      [](Buf& b) { meta(b, "a", kFloat32, {2, 3}, {3, 1}, 0, 23, 1, 0); }));
+  parse_rejects(one_const(
+      [](Buf& b) { meta(b, "a", kFloat32, {2, 3}, {3, 1}, 0, 25, 1, 0); }));
+}
+
+TEST(WeightOffloadPayload, RejectsWrongDeviceType) {
+  parse_rejects(one_const(
+      [](Buf& b) { meta(b, "a", kFloat32, {2}, {1}, 0, 8, 0, 0); })); // cpu
+}
+
+TEST(WeightOffloadPayload, RejectsWrongDeviceIndex) {
+  parse_rejects(one_const(
+      [](Buf& b) { meta(b, "a", kFloat32, {2}, {1}, 0, 8, 1, 1); })); // cuda:1
+}
+
+// --------------------------------------------------------------------
+// Cross-field invariants
+// --------------------------------------------------------------------
+
+TEST(WeightOffloadPayload, RejectsScheduleMetadataSetMismatch) {
+  // schedule {a} but metadata describes {b}.
+  Buf b;
+  b.u32(wo::kPayloadMagic);
+  b.u32(2);
+  b.str("m");
+  b.u64(0);
+  b.u32(1);
+  b.str("a");
+  b.u32(0);
+  b.u32(1);
+  meta(b, "b", kFloat32, {2}, {1}, 0, 8, 1, 0);
+  parse_rejects(b);
+}
+
+TEST(WeightOffloadPayload, RejectsMetadataMissingScheduledFqn) {
+  // schedule {a, b} but metadata only {a}.
+  Buf b;
+  b.u32(wo::kPayloadMagic);
+  b.u32(2);
+  b.str("m");
+  b.u64(0);
+  b.u32(2);
+  b.str("a");
+  b.str("b");
+  b.u32(0);
+  b.u32(1);
+  meta(b, "a", kFloat32, {2}, {1}, 0, 8, 1, 0);
+  parse_rejects(b);
+}
+
+TEST(WeightOffloadPayload, RejectsDuplicateFqnInMetadata) {
+  Buf b;
+  b.u32(wo::kPayloadMagic);
+  b.u32(2);
+  b.str("m");
+  b.u64(0);
+  b.u32(1);
+  b.str("a");
+  b.u32(0);
+  b.u32(2); // two metadata entries, both "a"
+  meta(b, "a", kFloat32, {2}, {1}, 0, 8, 1, 0);
+  meta(b, "a", kFloat32, {2}, {1}, 0, 8, 1, 0);
+  parse_rejects(b);
+}
+
+TEST(WeightOffloadPayload, RejectsDuplicatePinFqn) {
+  Buf b;
+  b.u32(wo::kPayloadMagic);
+  b.u32(2);
+  b.str("m");
+  b.u64(0);
+  b.u32(1);
+  b.str("a");
+  b.u32(2); // pin "a" twice
+  b.str("a");
+  b.str("a");
+  b.u32(1);
+  meta(b, "a", kFloat32, {2}, {1}, 0, 8, 1, 0);
+  parse_rejects(b);
+}
+
+TEST(WeightOffloadPayload, RejectsPinFqnNotInSchedule) {
+  Buf b;
+  b.u32(wo::kPayloadMagic);
+  b.u32(2);
+  b.str("m");
+  b.u64(0);
+  b.u32(1);
+  b.str("a");
+  b.u32(1); // pin "z" which is not scheduled
+  b.str("z");
+  b.u32(1);
+  meta(b, "a", kFloat32, {2}, {1}, 0, 8, 1, 0);
+  parse_rejects(b);
+}
+
+// --------------------------------------------------------------------
+// named_data_key_for_method must match the Python helper format.
+// --------------------------------------------------------------------
+
+TEST(WeightOffloadPayload, NamedDataKeyFormat) {
+  EXPECT_EQ(wo::named_data_key_for_method("forward"),
+            "_weight_offload_payload__forward");
+  EXPECT_EQ(wo::named_data_key_for_method("decode"),
+            "_weight_offload_payload__decode");
+}
+
+} // namespace

--- a/backends/cuda/runtime/weight_offload/tests/session_test.cpp
+++ b/backends/cuda/runtime/weight_offload/tests/session_test.cpp
@@ -1,0 +1,293 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// CUDA-required unit tests for the weight-offload Session state machine.
+// Unlike the Python end-to-end tests (which drive the whole export +
+// AOTI run), these construct a Session directly from a synthetic
+// Payload + AOTICatalog and a stub AOTI handle, then drive serve()
+// through the hit / miss / evict / prefetch / pinned / budget-reject /
+// out-of-range paths and assert on SessionStats + the budget
+// invariants. This is the only coverage that exercises the eviction
+// and prefetch branches at unit granularity.
+//
+// Requires a GPU (Session::create allocates dummies, a pinned host
+// mirror, a cudaMemPool, and a copy stream). Each test SKIPs when no
+// CUDA device is present.
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+#include <cstdio>
+#include <memory>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include <executorch/backends/aoti/aoti_delegate_handle.h>
+#include <executorch/backends/cuda/runtime/shims/memory.h>
+#include <executorch/backends/cuda/runtime/weight_offload/payload.h>
+#include <executorch/backends/cuda/runtime/weight_offload/session.h>
+#include <executorch/runtime/backend/backend_init_context.h>
+#include <executorch/runtime/backend/options.h>
+#include <executorch/runtime/core/error.h>
+#include <executorch/runtime/core/span.h>
+#include <executorch/runtime/platform/platform.h>
+
+namespace {
+
+using executorch::runtime::BackendInitContext;
+using executorch::runtime::BackendOption;
+using executorch::runtime::Error;
+using executorch::runtime::Result;
+using executorch::runtime::Span;
+namespace aoti = executorch::backends::aoti;
+namespace wo = executorch::backends::cuda::weight_offload;
+
+constexpr int32_t kInt8 = 1; // element_size 1 => nbytes == numel
+
+bool cudaAvailable() {
+  int n = 0;
+  return cudaGetDeviceCount(&n) == cudaSuccess && n > 0;
+}
+
+// Stub for the only AOTI handle function Session::create invokes. The
+// real install validates coverage / device; here the catalog and
+// dummies are synthetic, so a no-op success is the right stub.
+aoti::AOTIRuntimeError stubUpdateUserManaged(
+    aoti::AOTInductorModelContainerHandle,
+    const aoti::AOTInductorConstantMapEntry*,
+    size_t,
+    bool,
+    bool) {
+  return Error::Ok;
+}
+
+std::string constName(size_t i) {
+  return "w" + std::to_string(i);
+}
+
+class SessionTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    et_pal_init();
+    if (!cudaAvailable()) {
+      GTEST_SKIP() << "CUDA device required for Session tests";
+    }
+    ASSERT_EQ(cudaStreamCreate(&stream_), cudaSuccess);
+  }
+
+  void TearDown() override {
+    session_.reset(); // destroy Session before its compute stream
+    if (stream_ != nullptr) {
+      cudaStreamDestroy(stream_);
+      stream_ = nullptr;
+    }
+  }
+
+  // Byte-precise budget via the internal runtime spec.
+  void setBudget(uint64_t bytes) {
+    BackendOption opt{};
+    std::snprintf(
+        opt.key, sizeof(opt.key), "_weight_offload_internal_budget_bytes");
+    std::array<char, executorch::runtime::kMaxOptionValueLength> val{};
+    std::snprintf(
+        val.data(), val.size(), "%llu", static_cast<unsigned long long>(bytes));
+    opt.value = val;
+    specs_.assign(1, opt);
+  }
+
+  // Build + create a Session.
+  //   const_bytes[i] : byte size of catalog constant i (int8 => numel)
+  //   schedule_idx   : catalog indices, in probe order
+  //   pin_idx        : catalog indices to pin resident
+  // ``setBudget`` must have been called first. Returns the create
+  // Result; on success the caller moves it into ``session_``.
+  Result<std::unique_ptr<wo::Session>> build(
+      const std::vector<uint64_t>& const_bytes,
+      const std::vector<size_t>& schedule_idx,
+      const std::vector<size_t>& pin_idx,
+      uint64_t floor_bytes) {
+    wo::Payload p;
+    p.schema_version = 2;
+    p.method_name = "m";
+    p.floor_bytes = floor_bytes;
+    for (size_t i : schedule_idx) {
+      p.schedule.push_back(constName(i));
+    }
+    for (size_t i : pin_idx) {
+      p.pin_fqns.push_back(constName(i));
+    }
+    std::unordered_set<std::string> seen;
+    for (size_t i : schedule_idx) {
+      const std::string nm = constName(i);
+      if (!seen.insert(nm).second) {
+        continue;
+      }
+      wo::ConstantMetadata m;
+      m.fqn = nm;
+      m.dtype = kInt8;
+      m.sizes = {static_cast<int64_t>(const_bytes[i])};
+      m.strides = {1};
+      m.storage_offset = 0;
+      m.nbytes = const_bytes[i];
+      m.device_type = 1;
+      m.device_index = 0;
+      p.constants_metadata.push_back(std::move(m));
+    }
+
+    wo::AOTICatalog cat;
+    cat.num_constants = const_bytes.size();
+    uint64_t total = 0;
+    for (size_t i = 0; i < const_bytes.size(); ++i) {
+      cat.fqns.push_back(constName(i));
+      cat.internal_names.push_back("c" + std::to_string(i));
+      cat.data_sizes.push_back(static_cast<size_t>(const_bytes[i]));
+      cat.fqn_to_index.emplace(constName(i), i);
+      total += const_bytes[i];
+    }
+    blob_.assign(total, 0);
+
+    handle_ = aoti::AOTIDelegateHandle{};
+    handle_.update_user_managed_constant_buffer_pairs = &stubUpdateUserManaged;
+    handle_.container_handle =
+        reinterpret_cast<aoti::AOTInductorModelContainerHandle>(0x1);
+
+    BackendInitContext ctx(
+        /*runtime_allocator=*/nullptr,
+        /*event_tracer=*/nullptr,
+        /*method_name=*/"m",
+        /*named_data_map=*/nullptr,
+        Span<const BackendOption>(specs_.data(), specs_.size()));
+
+    return wo::Session::create(
+        p, &handle_, std::move(cat), blob_.data(), stream_, ctx);
+  }
+
+  // serve() one probe, assert success + a non-null borrowed tensor,
+  // and free the wrapper (AOTI's RAII does this in production).
+  void serveOk(wo::Session* s, int64_t probe_id) {
+    aoti::Tensor* out = nullptr;
+    ASSERT_EQ(s->serve(/*input=*/nullptr, probe_id, &out), Error::Ok);
+    ASSERT_NE(out, nullptr);
+    (void)executorch::backends::cuda::aoti_torch_delete_tensor_object(out);
+  }
+
+  cudaStream_t stream_{nullptr};
+  std::unique_ptr<wo::Session> session_;
+  std::vector<uint8_t> blob_;
+  aoti::AOTIDelegateHandle handle_;
+  std::vector<BackendOption> specs_;
+};
+
+TEST_F(SessionTest, CreateRejectsBudgetBelowFloor) {
+  setBudget(150);
+  auto res = build(
+      /*const_bytes=*/{100, 100},
+      /*schedule_idx=*/{0, 1},
+      /*pin_idx=*/{},
+      /*floor_bytes=*/200);
+  EXPECT_FALSE(res.ok());
+  EXPECT_EQ(res.error(), Error::InvalidArgument);
+}
+
+TEST_F(SessionTest, AllFitNoEviction) {
+  setBudget(100000);
+  auto res = build({100, 100, 100}, {0, 1, 2}, {}, /*floor=*/200);
+  ASSERT_TRUE(res.ok());
+  session_ = std::move(res.get());
+
+  EXPECT_EQ(session_->total_budget_bytes(), 100000u);
+  EXPECT_EQ(session_->floor_bytes(), 200u);
+  EXPECT_EQ(session_->streaming_budget_bytes(), 100000u);
+
+  serveOk(session_.get(), 0);
+  serveOk(session_.get(), 1);
+  serveOk(session_.get(), 2);
+
+  const auto& st = session_->stats();
+  EXPECT_EQ(st.evictions, 0u);
+  EXPECT_EQ(st.pool_hits + st.pool_misses, 3u);
+  EXPECT_LE(session_->peak_live_bytes(), session_->streaming_budget_bytes());
+}
+
+TEST_F(SessionTest, MissThenHitSameWeight) {
+  // Two probe sites reading the same constant; budget holds exactly
+  // one copy. Second serve is a pool hit; the wrap-around prefetch
+  // target is the same (live) FQN, so no prefetch is attempted.
+  setBudget(100);
+  auto res = build({100}, {0, 0}, {}, /*floor=*/100);
+  ASSERT_TRUE(res.ok());
+  session_ = std::move(res.get());
+
+  serveOk(session_.get(), 0);
+  serveOk(session_.get(), 1);
+
+  const auto& st = session_->stats();
+  EXPECT_EQ(st.pool_misses, 1u);
+  EXPECT_EQ(st.pool_hits, 1u);
+  EXPECT_EQ(st.evictions, 0u);
+  EXPECT_EQ(st.prefetch_attempted, 0u);
+}
+
+TEST_F(SessionTest, PinnedResidentDoesNotStream) {
+  // Constant 0 pinned, constant 1 streamed. The pinned serve takes the
+  // resident path (no hit/miss bump); only the streaming serve counts.
+  setBudget(/*pinned 100 + streaming 100*/ 200);
+  auto res = build({100, 100}, {0, 1}, /*pin=*/{0}, /*floor=*/100);
+  ASSERT_TRUE(res.ok());
+  session_ = std::move(res.get());
+
+  EXPECT_EQ(session_->pinned_bytes_total(), 100u);
+  EXPECT_EQ(session_->streaming_budget_bytes(), 100u);
+
+  serveOk(session_.get(), 0); // pinned
+  serveOk(session_.get(), 1); // streamed (may be a prefetch hit)
+
+  const auto& st = session_->stats();
+  // Only the streaming constant participates in the pool; the pinned
+  // serve bumps neither hits nor misses. Whether the streaming serve
+  // lands as a hit (prefetched during the pinned serve) or a miss,
+  // exactly one pool event is recorded.
+  EXPECT_EQ(st.pool_hits + st.pool_misses, 1u);
+}
+
+TEST_F(SessionTest, PeakStaysWithinStreamingBudgetUnderEviction) {
+  // 4 constants, budget holds ~2 -> eviction is forced. The invariant
+  // under test: bytes_in_flight (hence peak) never exceeds the
+  // streaming budget, no matter the access pattern.
+  setBudget(250);
+  auto res = build({100, 100, 100, 100}, {0, 1, 2, 3}, {}, /*floor=*/200);
+  ASSERT_TRUE(res.ok());
+  session_ = std::move(res.get());
+
+  for (int round = 0; round < 2; ++round) {
+    for (int64_t id = 0; id < 4; ++id) {
+      serveOk(session_.get(), id);
+    }
+  }
+
+  const auto& st = session_->stats();
+  EXPECT_GT(st.evictions, 0u);
+  EXPECT_GT(session_->peak_live_bytes(), 0u);
+  EXPECT_LE(session_->peak_live_bytes(), session_->streaming_budget_bytes());
+}
+
+TEST_F(SessionTest, ProbeIdOutOfRangeRejected) {
+  setBudget(100000);
+  auto res = build({100, 100}, {0, 1}, {}, /*floor=*/200);
+  ASSERT_TRUE(res.ok());
+  session_ = std::move(res.get());
+
+  aoti::Tensor* out = nullptr;
+  EXPECT_EQ(session_->serve(nullptr, 9999, &out), Error::InvalidArgument);
+  EXPECT_EQ(session_->serve(nullptr, -1, &out), Error::InvalidArgument);
+}
+
+} // namespace

--- a/backends/cuda/runtime/weight_offload/tests/targets.bzl
+++ b/backends/cuda/runtime/weight_offload/tests/targets.bzl
@@ -1,0 +1,44 @@
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+load("@fbcode_macros//build_defs:cpp_unittest.bzl", "cpp_unittest")
+load("@fbcode_macros//build_defs/lib:re_test_utils.bzl", "re_test_utils")
+
+def define_common_targets():
+    """Defines targets that should be shared between fbcode and xplat.
+
+    The directory containing this targets.bzl file should also contain both
+    TARGETS and BUCK files that call this function.
+    """
+
+    # Host-level: parses the on-wire payload only. No CUDA, no GPU.
+    cpp_unittest(
+        name = "payload_test",
+        srcs = ["payload_test.cpp"],
+        deps = [
+            "//executorch/backends/cuda/runtime:cuda_backend",
+            "//executorch/runtime/core:core",
+        ],
+    )
+
+    # Session state machine (create/serve/evict/prefetch/pinned). Drives
+    # the eviction + prefetch branches at unit granularity. Requires a
+    # GPU; runs on the gpu-remote-execution platform.
+    cpp_unittest(
+        name = "session_test",
+        srcs = ["session_test.cpp"],
+        deps = [
+            "//executorch/backends/cuda/runtime:cuda_backend",
+            "//executorch/backends/cuda/runtime:runtime_shims",
+            "//executorch/backends/aoti:aoti_common_slim",
+            "//executorch/runtime/backend:interface",
+            "//executorch/runtime/core:core",
+            "//executorch/runtime/platform:platform",
+        ],
+        external_deps = [
+            ("cuda", None, "cuda-lazy"),
+        ],
+        preprocessor_flags = ["-DCUDA_AVAILABLE=1"],
+        keep_gpu_sections = True,
+        remote_execution = re_test_utils.remote_execution(
+            platform = "gpu-remote-execution",
+        ),
+    )

--- a/backends/cuda/tests/TARGETS
+++ b/backends/cuda/tests/TARGETS
@@ -46,3 +46,102 @@ python_unittest(
         "//executorch/exir/backend:compile_spec_schema",
     ],
 )
+
+python_unittest_remote_gpu(
+    name = "test_weight_offload_probe_dispatch",
+    srcs = [
+        "test_weight_offload_probe_dispatch.py",
+    ],
+    visibility = [
+        "//executorch/...",
+    ],
+    deps = [
+        "//caffe2:torch",
+        "//executorch/backends/cuda:cuda_backend",
+        "//executorch/backends/cuda:cuda_partitioner",
+        "//executorch/backends/cuda:cuda_passes",
+        "//executorch/exir:lib",
+        "//executorch/exir/passes:lib",
+    ],
+    keep_gpu_sections = True,
+    remote_execution = re_test_utils.remote_execution(
+        subplatform = "A100",
+        mig = "false",
+        platform = "gpu-remote-execution",
+    ),
+)
+
+python_unittest_remote_gpu(
+    name = "test_weight_offload_transport",
+    srcs = [
+        "test_weight_offload_transport.py",
+    ],
+    visibility = [
+        "//executorch/...",
+    ],
+    deps = [
+        "//caffe2:torch",
+        "//executorch/backends/cuda:cuda_backend",
+        "//executorch/backends/cuda:cuda_partitioner",
+        "//executorch/backends/cuda:cuda_passes",
+        "//executorch/exir:lib",
+        "//executorch/exir/backend:compile_spec_schema",
+        "//executorch/exir/passes:lib",
+    ],
+    keep_gpu_sections = True,
+    remote_execution = re_test_utils.remote_execution(
+        subplatform = "A100",
+        mig = "false",
+        platform = "gpu-remote-execution",
+    ),
+)
+
+python_unittest_remote_gpu(
+    name = "test_weight_offload_session",
+    srcs = [
+        "test_weight_offload_session.py",
+    ],
+    visibility = [
+        "//executorch/...",
+    ],
+    deps = [
+        "//caffe2:torch",
+        "//executorch/backends/cuda:cuda_backend",
+        "//executorch/backends/cuda:cuda_partitioner",
+        "//executorch/backends/cuda:cuda_passes",
+        "//executorch/exir:lib",
+        "//executorch/exir/backend:compile_spec_schema",
+        "//executorch/exir/passes:lib",
+    ],
+    keep_gpu_sections = True,
+    remote_execution = re_test_utils.remote_execution(
+        subplatform = "A100",
+        mig = "false",
+        platform = "gpu-remote-execution",
+    ),
+)
+
+python_unittest_remote_gpu(
+    name = "test_weight_offload_pool",
+    srcs = [
+        "test_weight_offload_pool.py",
+    ],
+    visibility = [
+        "//executorch/...",
+    ],
+    deps = [
+        "//caffe2:torch",
+        "//executorch/backends/cuda:cuda_backend",
+        "//executorch/backends/cuda:cuda_partitioner",
+        "//executorch/backends/cuda:cuda_passes",
+        "//executorch/exir:lib",
+        "//executorch/exir/backend:compile_spec_schema",
+        "//executorch/exir/passes:lib",
+    ],
+    keep_gpu_sections = True,
+    remote_execution = re_test_utils.remote_execution(
+        subplatform = "A100",
+        mig = "false",
+        platform = "gpu-remote-execution",
+    ),
+)

--- a/backends/cuda/tests/test_cuda_partitioner.py
+++ b/backends/cuda/tests/test_cuda_partitioner.py
@@ -8,7 +8,12 @@ import unittest
 from typing import Tuple
 
 import torch
-from executorch.backends.cuda.cuda_partitioner import CudaPartitioner
+from executorch.backends.cuda.cuda_partitioner import (
+    _WEIGHT_OFFLOAD_ENABLE_SPEC_KEY,
+    _WEIGHT_OFFLOAD_PIN_FQNS_SPEC_KEY,
+    CudaPartitioner,
+)
+from executorch.exir.backend.compile_spec_schema import CompileSpec
 from executorch.exir.backend.partitioner import PartitionResult
 from torch.export import export
 
@@ -222,3 +227,176 @@ class TestCudaPartitioner(unittest.TestCase):
                 expected_tag,
                 f"Constant placeholder {node.name} has tag '{actual_tag}' but expected '{expected_tag}'",
             )
+
+    # ----------------------------------------------------------------
+    # Weight-offload public kwargs
+    # ----------------------------------------------------------------
+
+    def _find_specs(self, partitioner, key):
+        # Reach into the partitioner's stored compile_spec list. The
+        # base AotiPartitioner stashes it as
+        # ``self.delegation_spec.compile_specs``; we read it back
+        # here to verify the public kwargs produced the expected
+        # internal entries.
+        return [s for s in partitioner.delegation_spec.compile_specs if s.key == key]
+
+    def test_partitioner_public_kwargs_round_trip(self):
+        partitioner = CudaPartitioner(
+            [],
+            weight_offload=True,
+            weight_offload_pin_fqns=["w1"],
+        )
+        enable_specs = self._find_specs(partitioner, _WEIGHT_OFFLOAD_ENABLE_SPEC_KEY)
+        pin_specs = self._find_specs(partitioner, _WEIGHT_OFFLOAD_PIN_FQNS_SPEC_KEY)
+        self.assertEqual(len(enable_specs), 1, "expected one enable spec")
+        self.assertEqual(enable_specs[0].value, b"1")
+        self.assertEqual(len(pin_specs), 1, "expected one pin spec")
+        self.assertEqual(pin_specs[0].value, b"w1")
+
+    def test_partitioner_dedupes_pin_fqns(self):
+        partitioner = CudaPartitioner(
+            [],
+            weight_offload=True,
+            weight_offload_pin_fqns=["w1", "w2", "w1"],
+        )
+        pin_specs = self._find_specs(partitioner, _WEIGHT_OFFLOAD_PIN_FQNS_SPEC_KEY)
+        self.assertEqual(len(pin_specs), 1)
+        # Deduped first-seen order: w1, w2.
+        self.assertEqual(pin_specs[0].value, b"w1\x00w2")
+
+    def test_partitioner_rejects_pin_without_enable(self):
+        with self.assertRaisesRegex(ValueError, "weight_offload=False"):
+            CudaPartitioner(
+                [],
+                weight_offload=False,
+                weight_offload_pin_fqns=["w1"],
+            )
+
+    def test_partitioner_rejects_bare_str_pin_fqns(self):
+        with self.assertRaisesRegex(TypeError, "bare str"):
+            CudaPartitioner(
+                [],
+                weight_offload=True,
+                weight_offload_pin_fqns="w1",  # type: ignore[arg-type]
+            )
+
+    def test_partitioner_rejects_non_string_pin_fqn(self):
+        with self.assertRaisesRegex(TypeError, "must be strings"):
+            CudaPartitioner(
+                [],
+                weight_offload=True,
+                weight_offload_pin_fqns=["w1", 42],  # type: ignore[list-item]
+            )
+
+    def test_partitioner_rejects_non_list_pin_fqns(self):
+        # Tuples, sets, dict_keys, generators are all rejected by the
+        # strict list-only check. Callers must cast to list explicitly
+        # so the first-seen-order contract is preserved.
+        for bad in (
+            ("w1",),  # tuple
+            {"w1"},  # set (nondeterministic iteration)
+            (fqn for fqn in ["w1"]),  # generator (one-shot)
+        ):
+            with self.assertRaisesRegex(TypeError, "must be a list"):
+                CudaPartitioner(
+                    [],
+                    weight_offload=True,
+                    weight_offload_pin_fqns=bad,  # type: ignore[arg-type]
+                )
+
+    def test_partitioner_rejects_any_mixed_channel(self):
+        # Same key — kwarg + raw internal enable both set.
+        with self.assertRaisesRegex(ValueError, "_weight_offload_internal_"):
+            CudaPartitioner(
+                [CompileSpec(_WEIGHT_OFFLOAD_ENABLE_SPEC_KEY, b"1")],
+                weight_offload=True,
+            )
+
+        # Different key — kwarg sets enable, raw sets pin_fqns.
+        with self.assertRaisesRegex(ValueError, "_weight_offload_internal_"):
+            CudaPartitioner(
+                [CompileSpec(_WEIGHT_OFFLOAD_PIN_FQNS_SPEC_KEY, b"w1")],
+                weight_offload=True,
+            )
+
+        # Raw internal specs WITHOUT any public kwarg — still allowed
+        # (preserves the test stack that builds raw specs).
+        partitioner = CudaPartitioner(
+            [CompileSpec(_WEIGHT_OFFLOAD_ENABLE_SPEC_KEY, b"1")],
+        )
+        enable_specs = self._find_specs(partitioner, _WEIGHT_OFFLOAD_ENABLE_SPEC_KEY)
+        self.assertEqual(len(enable_specs), 1)
+
+    def test_partitioner_rejects_non_default_target_device_with_offload(self):
+        """``weight_offload=True`` plus ``target_device != cuda:0`` is
+        rejected: payload + runtime hard-code device 0 today, so any
+        other target would silently end up on the wrong GPU."""
+        from executorch.exir.passes.propagate_device_pass import (
+            TARGET_DEVICE_COMPILE_SPEC_KEY,
+        )
+
+        # Wrong index: cuda:1.
+        with self.assertRaisesRegex(ValueError, "currently requires"):
+            CudaPartitioner(
+                [CompileSpec(TARGET_DEVICE_COMPILE_SPEC_KEY, b"cuda:1")],
+                weight_offload=True,
+            )
+
+        # Wrong device type entirely: cpu.
+        with self.assertRaisesRegex(ValueError, "currently requires"):
+            CudaPartitioner(
+                [CompileSpec(TARGET_DEVICE_COMPILE_SPEC_KEY, b"cpu")],
+                weight_offload=True,
+            )
+
+        # Explicit cuda:0 is fine.
+        p_explicit = CudaPartitioner(
+            [CompileSpec(TARGET_DEVICE_COMPILE_SPEC_KEY, b"cuda:0")],
+            weight_offload=True,
+        )
+        self.assertEqual(
+            len(self._find_specs(p_explicit, _WEIGHT_OFFLOAD_ENABLE_SPEC_KEY)),
+            1,
+        )
+
+        # Bare ``cuda`` (no index) parses to index 0 and is also fine.
+        p_bare = CudaPartitioner(
+            [CompileSpec(TARGET_DEVICE_COMPILE_SPEC_KEY, b"cuda")],
+            weight_offload=True,
+        )
+        self.assertEqual(
+            len(self._find_specs(p_bare, _WEIGHT_OFFLOAD_ENABLE_SPEC_KEY)),
+            1,
+        )
+
+        # Non-default target_device is fine when offload is OFF.
+        p_off = CudaPartitioner(
+            [CompileSpec(TARGET_DEVICE_COMPILE_SPEC_KEY, b"cuda:1")],
+            weight_offload=False,
+        )
+        self.assertEqual(
+            len(self._find_specs(p_off, _WEIGHT_OFFLOAD_ENABLE_SPEC_KEY)),
+            0,
+        )
+
+    def test_partitioner_internal_keys_match_pass(self):
+        """The four string constants inlined in cuda_partitioner.py
+        must equal the canonical constants exported by
+        weight_offload_pass.py. Drift would mean the public kwargs
+        emit specs the runtime doesn't recognize."""
+        from executorch.backends.cuda.cuda_partitioner import (
+            _WEIGHT_OFFLOAD_ENABLE_SPEC_KEY as part_enable,
+            _WEIGHT_OFFLOAD_INTERNAL_KEY_PREFIX as part_prefix,
+            _WEIGHT_OFFLOAD_PIN_FQNS_SPEC_KEY as part_pin,
+        )
+        from executorch.backends.cuda.passes.weight_offload_pass import (
+            COMPILE_SPEC_KEY_ENABLE,
+            COMPILE_SPEC_KEY_PIN_FQNS,
+        )
+
+        self.assertEqual(part_enable, COMPILE_SPEC_KEY_ENABLE)
+        self.assertEqual(part_pin, COMPILE_SPEC_KEY_PIN_FQNS)
+        # Prefix is the shared underscore-prefix that defines the
+        # internal channel.
+        self.assertTrue(part_enable.startswith(part_prefix))
+        self.assertTrue(part_pin.startswith(part_prefix))

--- a/backends/cuda/tests/test_weight_offload_pool.py
+++ b/backends/cuda/tests/test_weight_offload_pool.py
@@ -1,0 +1,557 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""End-to-end correctness + accounting for the bounded pool.
+
+Custom budgets are driven through executor_runner's
+--cuda_runtime_spec CLI flag (see pinning + public-knob tests below
+for the canonical patterns).
+"""
+
+import os
+import re
+import subprocess
+import tempfile
+import unittest
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from executorch.backends.cuda.cuda_backend import CudaBackend
+from executorch.backends.cuda.cuda_partitioner import CudaPartitioner
+from executorch.backends.cuda.passes.weight_offload_pass import (
+    COMPILE_SPEC_KEY_ENABLE,
+    COMPILE_SPEC_KEY_PIN_FQNS,
+)
+from executorch.exir import (
+    EdgeCompileConfig,
+    ExecutorchBackendConfig,
+    to_edge_transform_and_lower,
+)
+from executorch.exir.backend.compile_spec_schema import CompileSpec
+from executorch.exir.passes import MemoryPlanningPass
+from torch.export import export
+
+
+EXECUTORCH_ROOT = os.path.normpath(os.path.join(os.path.dirname(__file__), "../../.."))
+RUNNER_PATH = os.path.join(EXECUTORCH_ROOT, "cmake-out", "executor_runner")
+
+
+class _TwoWeightModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.w1 = nn.Parameter(torch.randn(64, 64))
+        self.w2 = nn.Parameter(torch.randn(64, 64))
+
+    def forward(self, x):
+        return (x @ self.w1) @ self.w2.T
+
+
+class _MultiConsumerSameWeight(nn.Module):
+    """Same weight at two probe sites — exercises the pool-hit path
+    on the second probe. Also catches accidentally-owning borrowed
+    SlimTensor wrapping: a stray deleter on the first probe's
+    returned tensor would free the pool memory, and the second
+    probe's read would see garbage."""
+
+    def __init__(self):
+        super().__init__()
+        self.w = nn.Parameter(torch.randn(64, 64))
+
+    def forward(self, x):
+        return F.linear(x, self.w) + F.linear(x + 1.0, self.w)
+
+
+class _LargePinnedModel(nn.Module):
+    """Two ~1 MB weights (256x1024 float32 each). Used by the
+    public-budget tests where ``weight_offload_budget_mb=1`` (the
+    minimum the int spec accepts) must be strictly below
+    ``floor + pinned``. The exact floor value depends on the
+    pass's formula (which may include prefetch headroom etc.) —
+    tests should not hardcode it; they only need `required > 1 MB`,
+    which holds reliably since pinned alone is ~1 MB."""
+
+    def __init__(self):
+        super().__init__()
+        self.w1 = nn.Parameter(torch.randn(256, 1024))
+        self.w2 = nn.Parameter(torch.randn(256, 1024))
+
+    def forward(self, x):
+        # x: (batch, 1024); both matmuls produce (batch, 256).
+        return (x @ self.w1.T) + (x @ self.w2.T)
+
+
+def _opt_in_specs(method_name, pin_fqns=None):
+    specs = [
+        CudaBackend.generate_method_name_compile_spec(method_name),
+        CompileSpec(COMPILE_SPEC_KEY_ENABLE, b"1"),
+    ]
+    if pin_fqns:
+        specs.append(
+            CompileSpec(
+                COMPILE_SPEC_KEY_PIN_FQNS,
+                b"\x00".join(f.encode("utf-8") for f in pin_fqns),
+            )
+        )
+    return specs
+
+
+def _export_and_lower(model, inputs, specs):
+    ep = export(model, inputs, strict=True)
+    et_prog = to_edge_transform_and_lower(
+        ep,
+        partitioner=[CudaPartitioner(specs)],
+        compile_config=EdgeCompileConfig(
+            _check_ir_validity=False, _skip_dim_order=True
+        ),
+    )
+    return et_prog.to_executorch(
+        config=ExecutorchBackendConfig(
+            extract_delegate_segments=True,
+            do_quant_fusion_and_const_prop=True,
+            memory_planning_pass=MemoryPlanningPass(alloc_graph_input=False),
+        ),
+    )
+
+
+def _save_tensor(t: torch.Tensor, path: str) -> None:
+    with open(path, "wb") as f:
+        f.write(bytes(t.cpu().contiguous().untyped_storage()))
+
+
+def _load_output(path: str, shape, dtype) -> torch.Tensor:
+    with open(path, "rb") as f:
+        return torch.frombuffer(bytearray(f.read()), dtype=dtype).reshape(shape)
+
+
+def _write_artifact(et_program, out_dir: str) -> tuple[str, str]:
+    pte = os.path.join(out_dir, "pool.pte")
+    with open(pte, "wb") as f:
+        et_program.write_to_file(f)
+    if hasattr(et_program, "_tensor_data") and et_program._tensor_data:
+        et_program.write_tensor_data_to_file(out_dir)
+    return pte, os.path.join(out_dir, "aoti_cuda_blob.ptd")
+
+
+def _run_runner(pte, ptd, input_files, out_base, extra_env=None, extra_cli_args=None):
+    cmd = [
+        RUNNER_PATH,
+        f"--model_path={pte}",
+        f"--data_path={ptd}",
+        f"--inputs={','.join(input_files)}",
+        f"--output_file={out_base}",
+    ]
+    if extra_cli_args:
+        cmd.extend(extra_cli_args)
+    env = os.environ.copy()
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(cmd, capture_output=True, text=True, env=env)
+
+
+_STATS_RE = re.compile(
+    r"\[ET_WEIGHT_OFFLOAD_STATS\] method=\S+ hits=(?P<hits>\d+) "
+    r"misses=(?P<misses>\d+) evictions=(?P<evictions>\d+) "
+    r"bytes_h2d=(?P<bytes_h2d>\d+) peak_live_bytes=(?P<peak>\d+) "
+    r"budget=(?P<budget>\d+) floor=(?P<floor>\d+) "
+    r"prefetch_attempted=(?P<prefetch_attempted>\d+) "
+    r"prefetch_succeeded=(?P<prefetch_succeeded>\d+) "
+    r"pinned_bytes=(?P<pinned_bytes>\d+) "
+    r"streaming_budget=(?P<streaming_budget>\d+)"
+)
+
+
+def _parse_stats(stderr: str) -> dict[str, int] | None:
+    m = _STATS_RE.search(stderr)
+    if not m:
+        return None
+    return {k: int(v) for k, v in m.groupdict().items()}
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA is required for runtime")
+class TestPoolRuntime(unittest.TestCase):
+    def setUp(self):
+        if not os.path.exists(RUNNER_PATH):
+            self.skipTest(
+                f"executor_runner not found at {RUNNER_PATH}; build with "
+                "cmake --build cmake-out --target executor_runner"
+            )
+        torch.manual_seed(0)
+
+    def _export(self, model, x, pin_fqns=None):
+        return _export_and_lower(
+            model.to("cuda").eval(),
+            (x,),
+            _opt_in_specs("forward", pin_fqns=pin_fqns),
+        )
+
+    def _run_in_tmp(
+        self,
+        et_program,
+        x,
+        tmp,
+        extra_env_overrides=None,
+        extra_cli_args=None,
+    ):
+        export_dir = os.path.join(tmp, "export")
+        os.makedirs(export_dir)
+        pte, ptd = _write_artifact(et_program, export_dir)
+        run_dir = os.path.join(tmp, "run")
+        os.makedirs(run_dir)
+        in_path = os.path.join(run_dir, "0.bin")
+        _save_tensor(x, in_path)
+        out_base = os.path.join(run_dir, "out")
+        env = {"EXECUTORCH_WEIGHT_OFFLOAD_TRACE": "1"}
+        if extra_env_overrides:
+            env.update(extra_env_overrides)
+        result = _run_runner(
+            pte,
+            ptd,
+            [in_path],
+            out_base,
+            extra_env=env,
+            extra_cli_args=extra_cli_args,
+        )
+        return result, out_base
+
+    def test_correctness_with_default_budget(self):
+        """Pool + event-ordered H2D produces eager-matching output
+        with the default (floor) budget."""
+        x = torch.randn(4, 64, device="cuda")
+        model = _TwoWeightModel().to("cuda").eval()
+        with torch.no_grad():
+            ref = model(x).cpu().contiguous()
+
+        et_program = self._export(model, x)
+        with tempfile.TemporaryDirectory() as tmp:
+            result, out_base = self._run_in_tmp(et_program, x, tmp)
+            self.assertEqual(
+                result.returncode,
+                0,
+                f"runner failed (rc={result.returncode}):\n"
+                f"stderr:\n{result.stderr}\nstdout:\n{result.stdout}",
+            )
+            out = _load_output(f"{out_base}-0.bin", (4, 64), torch.float32)
+            diff = (out.float() - ref.float()).abs().max().item()
+            self.assertLess(diff, 1e-3, f"max abs diff {diff}")
+
+    def test_pool_hit_within_execute(self):
+        """Two probes on the same FQN: first miss, second hit. Also
+        the borrowed-tensor canary — a stray owning deleter would
+        free the pool memory between probes and the second read
+        would see garbage, producing numerical mismatch."""
+        x = torch.randn(4, 64, device="cuda")
+        model = _MultiConsumerSameWeight().to("cuda").eval()
+        with torch.no_grad():
+            ref = model(x).cpu().contiguous()
+
+        et_program = self._export(model, x)
+        with tempfile.TemporaryDirectory() as tmp:
+            result, out_base = self._run_in_tmp(et_program, x, tmp)
+            self.assertEqual(result.returncode, 0, result.stderr)
+
+            # Numerical canary first — if borrowed-tensor wrapping is
+            # broken, the second probe corrupts and this fails before
+            # we even check stats.
+            out = _load_output(f"{out_base}-0.bin", (4, 64), torch.float32)
+            diff = (out.float() - ref.float()).abs().max().item()
+            self.assertLess(diff, 1e-3, f"max abs diff {diff}")
+
+            stats = _parse_stats(result.stderr)
+            self.assertIsNotNone(
+                stats, f"missing [ET_WEIGHT_OFFLOAD_STATS]:\n{result.stderr}"
+            )
+            self.assertEqual(stats["misses"], 1, f"expected 1 miss, got {stats}")
+            self.assertGreaterEqual(stats["hits"], 1, f"expected hit, got {stats}")
+            self.assertEqual(stats["evictions"], 0)
+
+    def test_peak_live_bytes_within_budget(self):
+        """Accounting invariant: ``peak_live_bytes <= budget`` at the
+        end of the run. Direct canary for software-cap bugs."""
+        x = torch.randn(4, 64, device="cuda")
+        et_program = self._export(_TwoWeightModel(), x)
+        with tempfile.TemporaryDirectory() as tmp:
+            result, _ = self._run_in_tmp(et_program, x, tmp)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            stats = _parse_stats(result.stderr)
+            self.assertIsNotNone(stats, result.stderr)
+            self.assertGreater(stats["budget"], 0)
+            self.assertLessEqual(
+                stats["peak"],
+                stats["budget"],
+                f"peak_live_bytes={stats['peak']} exceeded budget={stats['budget']}",
+            )
+
+    def test_stats_log_present_with_trace(self):
+        """Sanity: the [ET_WEIGHT_OFFLOAD_STATS] line is emitted at
+        Session destruction when the trace env var is set."""
+        x = torch.randn(4, 64, device="cuda")
+        et_program = self._export(_TwoWeightModel(), x)
+        with tempfile.TemporaryDirectory() as tmp:
+            result, _ = self._run_in_tmp(et_program, x, tmp)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("[ET_WEIGHT_OFFLOAD_STATS]", result.stderr)
+
+    def test_blob_load_skipped_for_offload(self):
+        """Commit 7 contract: offload-enabled methods MUST skip
+        ``update_constants_from_blob`` entirely. The
+        ``[ET_WEIGHT_OFFLOAD_SKIP]`` stderr trace is the canary —
+        unconditional (not ET_LOG_INFO gated), so this works on any
+        build. Without this trace we would silently regress to the
+        eager-load path."""
+        x = torch.randn(4, 64, device="cuda")
+        et_program = self._export(_TwoWeightModel(), x)
+        with tempfile.TemporaryDirectory() as tmp:
+            result, _ = self._run_in_tmp(et_program, x, tmp)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn(
+                "[ET_WEIGHT_OFFLOAD_SKIP] skipped update_constants_from_blob "
+                "method=forward",
+                result.stderr,
+            )
+            # Defense-in-depth: the success summary's `installed=N`
+            # field must be non-zero, proving we DID install dummies
+            # (otherwise AOTI's run() would have read the un-loaded
+            # blob and either segfaulted or produced garbage).
+            summary = next(
+                line
+                for line in result.stderr.splitlines()
+                if line.startswith("[ET_WEIGHT_OFFLOAD] ")
+            )
+            self.assertRegex(summary, r"installed=\d+")
+            self.assertNotIn("installed=0", summary)
+
+    def test_prefetch_converts_second_probe_to_pool_hit(self):
+        """Depth-1 opportunistic prefetch: after the first cold probe,
+        every subsequent distinct-FQN probe should hit the pool
+        because the prior serve() prefetched it.
+
+        Asserts the stats canary: pool_misses == 1 (just the first
+        cold weight; everything else hits because prior serve()
+        prefetched it) and prefetch_succeeded >= 1.
+
+        Note: "pool hit" only means the live_ entry was already
+        present — the hit path still does cudaStreamWaitEvent on the
+        ready_event, so the consuming kernel can stall briefly if the
+        prefetch H2D hasn't finished. A true "no-stall" assertion
+        needs wall-clock measurement (separate scope from this stats
+        canary).
+
+        Wraparound semantics also exercised: _TwoWeightModel's
+        schedule has 2 distinct FQNs (w1, w2). serve(probe_id=0)
+        misses on the first FQN, prefetches the second. serve(probe_id=1)
+        hits the second FQN, prefetches the first (wraparound).
+        End-state: 1 miss, 1+ hit, at least 1 successful prefetch."""
+        x = torch.randn(4, 64, device="cuda")
+        model = _TwoWeightModel().to("cuda").eval()
+        with torch.no_grad():
+            ref = model(x).cpu().contiguous()
+
+        et_program = self._export(model, x)
+        with tempfile.TemporaryDirectory() as tmp:
+            result, out_base = self._run_in_tmp(et_program, x, tmp)
+            self.assertEqual(result.returncode, 0, result.stderr)
+
+            # Correctness canary first — prefetch must not corrupt.
+            out = _load_output(f"{out_base}-0.bin", (4, 64), torch.float32)
+            diff = (out.float() - ref.float()).abs().max().item()
+            self.assertLess(diff, 1e-3, f"max abs diff {diff}")
+
+            stats = _parse_stats(result.stderr)
+            self.assertIsNotNone(
+                stats, f"missing [ET_WEIGHT_OFFLOAD_STATS]:\n{result.stderr}"
+            )
+            self.assertEqual(
+                stats["misses"],
+                1,
+                f"expected exactly 1 cold miss; got {stats}",
+            )
+            self.assertGreaterEqual(
+                stats["prefetch_succeeded"],
+                1,
+                f"expected at least 1 successful prefetch; got {stats}",
+            )
+            # attempted >= succeeded by construction; the assertion
+            # is loose because some attempts can be "already live"
+            # short-circuits that bump neither counter.
+            self.assertGreaterEqual(
+                stats["prefetch_attempted"],
+                stats["prefetch_succeeded"],
+            )
+
+    # ------------------------------------------------------------------
+    # Pinning
+    # ------------------------------------------------------------------
+
+    def test_pinning_default_budget_covers_pinned(self):
+        """With a non-empty pin_fqns and no explicit budget spec, the
+        runtime's default budget must be ``floor + pinned`` (not just
+        floor — the floor formula excludes pinned weights). Verifies
+        the v3 default-budget-with-pins fix: init succeeds, stats show
+        ``streaming_budget >= floor`` and ``total = streaming +
+        pinned``."""
+        x = torch.randn(4, 64, device="cuda")
+        model = _TwoWeightModel().to("cuda").eval()
+        with torch.no_grad():
+            ref = model(x).cpu().contiguous()
+
+        et_program = self._export(model, x, pin_fqns=["w1"])
+        with tempfile.TemporaryDirectory() as tmp:
+            result, out_base = self._run_in_tmp(et_program, x, tmp)
+            self.assertEqual(result.returncode, 0, result.stderr)
+
+            out = _load_output(f"{out_base}-0.bin", (4, 64), torch.float32)
+            diff = (out.float() - ref.float()).abs().max().item()
+            self.assertLess(diff, 1e-3, f"max abs diff {diff}")
+
+            stats = _parse_stats(result.stderr)
+            self.assertIsNotNone(stats, result.stderr)
+            # w1 is 64*64*4 = 16384 bytes (Float32).
+            self.assertEqual(stats["pinned_bytes"], 16384)
+            # total_budget = streaming + pinned (the default formula).
+            self.assertEqual(
+                stats["streaming_budget"] + stats["pinned_bytes"],
+                stats["budget"],
+            )
+            # Streaming budget must cover the floor.
+            self.assertGreaterEqual(stats["streaming_budget"], stats["floor"])
+
+    def test_pinning_pinned_fqn_resident_no_streaming_h2d(self):
+        """The pinned weight (w1) is allocated once at init via the
+        out-of-pool path; the streaming pool only sees w2. So
+        ``bytes_h2d_copied`` reflects ONLY w2's nbytes, not w1 + w2."""
+        x = torch.randn(4, 64, device="cuda")
+        model = _TwoWeightModel().to("cuda").eval()
+        with torch.no_grad():
+            ref = model(x).cpu().contiguous()
+
+        et_program = self._export(model, x, pin_fqns=["w1"])
+        with tempfile.TemporaryDirectory() as tmp:
+            result, out_base = self._run_in_tmp(et_program, x, tmp)
+            self.assertEqual(result.returncode, 0, result.stderr)
+
+            out = _load_output(f"{out_base}-0.bin", (4, 64), torch.float32)
+            diff = (out.float() - ref.float()).abs().max().item()
+            self.assertLess(diff, 1e-3, f"max abs diff {diff}")
+
+            stats = _parse_stats(result.stderr)
+            self.assertIsNotNone(stats, result.stderr)
+            # Each weight is 16384 bytes. With w1 pinned, the streaming
+            # pool's H2D total covers only w2 (plus any wraparound
+            # prefetch — but prefetch on w1 short-circuits because
+            # it's pinned, so wraparound from w2's serve targets w1
+            # = pinned = no streaming H2D). Net: bytes_h2d_copied
+            # should be exactly w2.nbytes = 16384, NOT 32768.
+            self.assertEqual(stats["pinned_bytes"], 16384)
+            self.assertEqual(
+                stats["bytes_h2d"],
+                16384,
+                f"expected streaming H2D = w2 only (16384); got {stats}",
+            )
+
+    def test_pinning_pinned_then_streaming_still_prefetches(self):
+        """Pinned fast path must still call opportunistic_prefetch at
+        the end of serve() so a pinned→streaming transition doesn't
+        lose overlap. Stats canary: ``prefetch_attempted >= 1`` even
+        though one of the two probes hit the pinned fast path."""
+        x = torch.randn(4, 64, device="cuda")
+        model = _TwoWeightModel().to("cuda").eval()
+        et_program = self._export(model, x, pin_fqns=["w1"])
+        with tempfile.TemporaryDirectory() as tmp:
+            result, _ = self._run_in_tmp(et_program, x, tmp)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            stats = _parse_stats(result.stderr)
+            self.assertIsNotNone(stats, result.stderr)
+            # The pinned serve for w1 triggers prefetch for w2; that
+            # prefetch should be ATTEMPTED (and succeed, given default
+            # budget covers both). If the pinned fast path returned
+            # before opportunistic_prefetch, this would be 0.
+            self.assertGreaterEqual(
+                stats["prefetch_attempted"],
+                1,
+                f"pinned fast path did not call opportunistic_prefetch; "
+                f"got {stats}",
+            )
+
+    # ------------------------------------------------------------------
+    # Public knobs
+    # ------------------------------------------------------------------
+
+    def test_runtime_accepts_public_budget_mb_via_runner_flag(self):
+        """The ``--cuda_runtime_spec=weight_offload_budget_mb=N``
+        runner flag drives the public runtime spec. Init succeeds and
+        the success-summary's ``budget_bytes`` reflects ``N * 1 MB``."""
+        x = torch.randn(4, 1024, device="cuda")
+        model = _LargePinnedModel().to("cuda").eval()
+        et_program = self._export(model, x)
+        with tempfile.TemporaryDirectory() as tmp:
+            result, _ = self._run_in_tmp(
+                et_program,
+                x,
+                tmp,
+                extra_cli_args=[
+                    "--cuda_runtime_spec=weight_offload_budget_mb=4",
+                ],
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            stats = _parse_stats(result.stderr)
+            self.assertIsNotNone(stats, result.stderr)
+            # 4 MB exactly.
+            self.assertEqual(stats["budget"], 4 << 20)
+
+    def test_pinning_below_floor_with_pinned_hard_fails(self):
+        """Inject a budget below ``floor + pinned`` via the public
+        runner flag. Init hard-fails with the new descriptive UX
+        message naming pinned bytes, streaming floor, required total,
+        and the spec the user set."""
+        x = torch.randn(4, 1024, device="cuda")
+        model = _LargePinnedModel().to("cuda").eval()
+        et_program = self._export(model, x, pin_fqns=["w1"])
+        with tempfile.TemporaryDirectory() as tmp:
+            result, _ = self._run_in_tmp(
+                et_program,
+                x,
+                tmp,
+                extra_cli_args=[
+                    # 1 MB — strictly below required (pinned w1
+                    # alone is 1 MB; streaming floor adds the other
+                    # ~1 MB; required > 1 MB).
+                    "--cuda_runtime_spec=weight_offload_budget_mb=1",
+                ],
+            )
+            self.assertNotEqual(result.returncode, 0, result.stderr)
+            self.assertIn("[ET_WEIGHT_OFFLOAD][ERROR]", result.stderr)
+            self.assertIn("pinned constants", result.stderr)
+            self.assertIn("streaming pool floor", result.stderr)
+            self.assertIn("required total", result.stderr)
+
+    def test_floor_message_names_public_spec_when_user_set(self):
+        """When the user set ``weight_offload_budget_mb``, the
+        below-floor message must name that public spec (not the
+        internal byte spec) so the suggested fix is copy-pasteable."""
+        x = torch.randn(4, 1024, device="cuda")
+        model = _LargePinnedModel().to("cuda").eval()
+        et_program = self._export(model, x, pin_fqns=["w1"])
+        with tempfile.TemporaryDirectory() as tmp:
+            result, _ = self._run_in_tmp(
+                et_program,
+                x,
+                tmp,
+                extra_cli_args=[
+                    "--cuda_runtime_spec=weight_offload_budget_mb=1",
+                ],
+            )
+            self.assertNotEqual(result.returncode, 0, result.stderr)
+            # Names the public spec the user passed.
+            self.assertIn("weight_offload_budget_mb", result.stderr)
+            # Echoes the user-supplied value.
+            self.assertIn("weight_offload_budget_mb=1", result.stderr)
+            # Suggested-fix line points at the public spec.
+            self.assertIn("Set weight_offload_budget_mb >=", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backends/cuda/tests/test_weight_offload_probe_dispatch.py
+++ b/backends/cuda/tests/test_weight_offload_probe_dispatch.py
@@ -1,0 +1,240 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Dispatch contract for the AOTI probe c-shim: AOTI's wrapper emits
+one aoti_torch_cuda_probe call per FX probe node, and distinct
+probe_id arguments survive inductor CSE (the property the
+multi-consumer schedule depends on). Counts are exfiltrated via
+EXECUTORCH_WEIGHT_OFFLOAD_PROBE_TRACE."""
+
+import os
+import subprocess
+import tempfile
+import unittest
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from executorch.backends.cuda.cuda_backend import CudaBackend
+from executorch.backends.cuda.cuda_partitioner import CudaPartitioner
+
+# Importing the pass module registers ``executorch_weight_offload::probe``.
+from executorch.backends.cuda.passes import weight_offload_pass  # noqa: F401
+from executorch.exir import (
+    EdgeCompileConfig,
+    ExecutorchBackendConfig,
+    to_edge_transform_and_lower,
+)
+from executorch.exir.passes import MemoryPlanningPass
+from torch.export import export
+
+
+EXECUTORCH_ROOT = os.path.normpath(os.path.join(os.path.dirname(__file__), "../../.."))
+RUNNER_PATH = os.path.join(EXECUTORCH_ROOT, "cmake-out", "executor_runner")
+
+
+_PROBE = torch.ops.executorch_weight_offload.probe
+
+
+# dim chosen large enough that inductor's TRITON-only autotune backend
+# (set in ``cuda_backend.py::get_aoti_compile_options``) has at least one
+# valid choice for both single- and multi-consumer linears.
+_TEST_DIM = 64
+
+
+class _SingleConsumerProbeModel(nn.Module):
+    """One weight, one probe, one consumer."""
+
+    def __init__(self, dim: int = _TEST_DIM):
+        super().__init__()
+        self.w = nn.Parameter(torch.randn(dim, dim, dtype=torch.bfloat16))
+
+    def forward(self, x):
+        wp = _PROBE(self.w, 0)
+        return F.linear(x, wp)
+
+
+class _MultiConsumerProbeModel(nn.Module):
+    """One weight, two probes (distinct probe_id), two consumers.
+
+    This is the CSE-survival case. With identical args inductor would CSE
+    the two probe calls into one; distinct ``probe_id`` constants force
+    AOTI to emit two c-shim calls.
+    """
+
+    def __init__(self, dim: int = _TEST_DIM):
+        super().__init__()
+        self.w = nn.Parameter(torch.randn(dim, dim, dtype=torch.bfloat16))
+
+    def forward(self, x):
+        wp0 = _PROBE(self.w, 0)
+        out0 = F.linear(x, wp0)
+        wp1 = _PROBE(self.w, 1)
+        out1 = F.linear(x + 1.0, wp1)
+        return out0 + out1
+
+
+def _save_tensor(t: torch.Tensor, path: str) -> None:
+    with open(path, "wb") as f:
+        f.write(bytes(t.cpu().contiguous().untyped_storage()))
+
+
+def _load_output(path: str, shape, dtype) -> torch.Tensor:
+    with open(path, "rb") as f:
+        return torch.frombuffer(bytearray(f.read()), dtype=dtype).reshape(shape)
+
+
+def _export_and_lower(model: nn.Module, inputs, out_dir: str) -> tuple[str, str]:
+    """Export ``model`` through CudaPartitioner; return ``(pte_path, ptd_path)``."""
+    with torch.no_grad():
+        ep = export(model, inputs, strict=True)
+
+    specs = [CudaBackend.generate_method_name_compile_spec("forward")]
+    et_prog = to_edge_transform_and_lower(
+        ep,
+        partitioner=[CudaPartitioner(specs)],
+        compile_config=EdgeCompileConfig(
+            _check_ir_validity=False, _skip_dim_order=True
+        ),
+    )
+    et_program = et_prog.to_executorch(
+        config=ExecutorchBackendConfig(
+            extract_delegate_segments=True,
+            do_quant_fusion_and_const_prop=True,
+            memory_planning_pass=MemoryPlanningPass(alloc_graph_input=False),
+        ),
+    )
+
+    pte_path = os.path.join(out_dir, "probe_test.pte")
+    with open(pte_path, "wb") as f:
+        et_program.write_to_file(f)
+    if hasattr(et_program, "_tensor_data") and et_program._tensor_data:
+        et_program.write_tensor_data_to_file(out_dir)
+
+    ptd_path = os.path.join(out_dir, "aoti_cuda_blob.ptd")
+    return pte_path, ptd_path
+
+
+def _run_with_probe_trace(
+    runner_path: str,
+    pte_path: str,
+    ptd_path: str,
+    input_files: list[str],
+    out_base: str,
+) -> subprocess.CompletedProcess:
+    """Run executor_runner with ``EXECUTORCH_WEIGHT_OFFLOAD_PROBE_TRACE=1``.
+
+    Inherits the parent environment (including ``LD_LIBRARY_PATH``) so
+    the embedded AOTI ``.so`` resolves its ``GLIBCXX`` requirement
+    against whatever ``libstdc++`` the caller has configured. CI's
+    ``cuda.yml`` exports the conda-env lib dir before running this
+    test; local invocations should do the same (e.g.
+    ``LD_LIBRARY_PATH=$(conda info --base)/envs/<env>/lib pytest ...``).
+    """
+    env = os.environ.copy()
+    env["EXECUTORCH_WEIGHT_OFFLOAD_PROBE_TRACE"] = "1"
+    cmd = [
+        runner_path,
+        f"--model_path={pte_path}",
+        f"--data_path={ptd_path}",
+        f"--inputs={','.join(input_files)}",
+        f"--output_file={out_base}",
+    ]
+    return subprocess.run(cmd, capture_output=True, text=True, env=env)
+
+
+def _count_probe_lines(stderr: str) -> int:
+    return sum(1 for line in stderr.splitlines() if "[ET_WEIGHT_OFFLOAD_PROBE]" in line)
+
+
+class TestProbeDispatch(unittest.TestCase):
+    def setUp(self):
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA is not available")
+        if not os.path.exists(RUNNER_PATH):
+            self.skipTest(
+                f"executor_runner not found at {RUNNER_PATH}; "
+                "build with: cmake --build cmake-out --target executor_runner"
+            )
+
+    def _run_and_check_dispatch(
+        self,
+        model: nn.Module,
+        expected_probe_calls: int,
+        out_shape: tuple,
+    ) -> None:
+        torch.manual_seed(0)
+        model = model.to(device="cuda", dtype=torch.bfloat16).eval()
+        x = torch.randn(4, _TEST_DIM, dtype=torch.bfloat16, device="cuda")
+
+        with torch.no_grad():
+            ref = model(x)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            export_dir = os.path.join(tmp, "export")
+            os.makedirs(export_dir)
+            pte, ptd = _export_and_lower(model, (x,), export_dir)
+
+            run_dir = os.path.join(tmp, "run")
+            os.makedirs(run_dir)
+            input_file = os.path.join(run_dir, "0.bin")
+            _save_tensor(x, input_file)
+            out_base = os.path.join(run_dir, "out")
+            result = _run_with_probe_trace(
+                RUNNER_PATH, pte, ptd, [input_file], out_base
+            )
+
+            self.assertEqual(
+                result.returncode,
+                0,
+                f"executor_runner failed (rc={result.returncode}):\n"
+                f"stderr:\n{result.stderr}\nstdout:\n{result.stdout}",
+            )
+
+            actual = _count_probe_lines(result.stderr)
+            self.assertEqual(
+                actual,
+                expected_probe_calls,
+                f"expected {expected_probe_calls} [ET_WEIGHT_OFFLOAD_PROBE] "
+                f"lines, got {actual}.\nstderr:\n{result.stderr}",
+            )
+
+            # Identity probe means the lowered output must match eager
+            # up to bf16 accumulation noise. Use a relative threshold
+            # because the multi-consumer path accumulates two mm results
+            # in TRITON's mm_plus_mm fusion, which differs from eager's
+            # per-linear bf16 path by a few LSBs of the magnitude.
+            out = _load_output(f"{out_base}-0.bin", out_shape, torch.bfloat16).to(
+                "cuda"
+            )
+            diff = (out.float() - ref.float()).abs().max().item()
+            rel = diff / max(ref.float().abs().max().item(), 1.0)
+            self.assertLess(
+                rel,
+                2e-2,
+                f"identity-probe output diverged from eager "
+                f"(max abs diff {diff}, rel {rel})",
+            )
+
+    def test_single_consumer_dispatch(self):
+        """One probe in graph → one c-shim call at runtime."""
+        self._run_and_check_dispatch(
+            _SingleConsumerProbeModel(),
+            expected_probe_calls=1,
+            out_shape=(4, _TEST_DIM),
+        )
+
+    def test_multi_consumer_dispatch(self):
+        """Two probes on the same weight survive CSE → two c-shim calls."""
+        self._run_and_check_dispatch(
+            _MultiConsumerProbeModel(),
+            expected_probe_calls=2,
+            out_shape=(4, _TEST_DIM),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backends/cuda/tests/test_weight_offload_session.py
+++ b/backends/cuda/tests/test_weight_offload_session.py
@@ -1,0 +1,251 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""End-to-end correctness for the offload Session (host-mirror + H2D
+serve path, multi-consumer, identity-fallback when opt-in absent,
+CUDA-graph rejection)."""
+
+import os
+import subprocess
+import tempfile
+import unittest
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from executorch.backends.cuda.cuda_backend import CudaBackend
+from executorch.backends.cuda.cuda_partitioner import CudaPartitioner
+from executorch.backends.cuda.passes.weight_offload_pass import COMPILE_SPEC_KEY_ENABLE
+from executorch.exir import (
+    EdgeCompileConfig,
+    ExecutorchBackendConfig,
+    to_edge_transform_and_lower,
+)
+from executorch.exir.backend.compile_spec_schema import CompileSpec
+from executorch.exir.passes import MemoryPlanningPass
+from torch.export import export
+
+
+EXECUTORCH_ROOT = os.path.normpath(os.path.join(os.path.dirname(__file__), "../../.."))
+RUNNER_PATH = os.path.join(EXECUTORCH_ROOT, "cmake-out", "executor_runner")
+
+
+class _TwoWeightModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.w1 = nn.Parameter(torch.randn(64, 64))
+        self.w2 = nn.Parameter(torch.randn(64, 64))
+
+    def forward(self, x):
+        return (x @ self.w1) @ self.w2.T
+
+
+class _MultiConsumerSameWeight(nn.Module):
+    """Same weight read at two probe sites — exercises both schedule
+    entries pointing at one host-mirror FQN."""
+
+    def __init__(self):
+        super().__init__()
+        self.w = nn.Parameter(torch.randn(64, 64))
+
+    def forward(self, x):
+        return F.linear(x, self.w) + F.linear(x + 1.0, self.w)
+
+
+class _TiedWeightModel(nn.Module):
+    """Two FQNs share one underlying tensor (tied embedding ↔ lm_head
+    pattern). At runtime they surface as distinct catalog entries
+    with the SAME ``data_ptr``; without dedupe-before-register the
+    ProbeRegistry would reject the second registration as a
+    duplicate-within-batch and init would hard-fail. Locks in the
+    fix."""
+
+    def __init__(self):
+        super().__init__()
+        shared = nn.Parameter(torch.randn(64, 64))
+        self.a = shared
+        self.b = shared
+
+    def forward(self, x):
+        return F.linear(x, self.a) + F.linear(x + 1.0, self.b)
+
+
+def _opt_in_specs(method_name, extra=None):
+    specs = [
+        CudaBackend.generate_method_name_compile_spec(method_name),
+        CompileSpec(COMPILE_SPEC_KEY_ENABLE, b"1"),
+    ]
+    if extra:
+        specs.extend(extra)
+    return specs
+
+
+def _export_and_lower(model, inputs, specs):
+    ep = export(model, inputs, strict=True)
+    et_prog = to_edge_transform_and_lower(
+        ep,
+        partitioner=[CudaPartitioner(specs)],
+        compile_config=EdgeCompileConfig(
+            _check_ir_validity=False, _skip_dim_order=True
+        ),
+    )
+    return et_prog.to_executorch(
+        config=ExecutorchBackendConfig(
+            extract_delegate_segments=True,
+            do_quant_fusion_and_const_prop=True,
+            memory_planning_pass=MemoryPlanningPass(alloc_graph_input=False),
+        ),
+    )
+
+
+def _save_tensor(t: torch.Tensor, path: str) -> None:
+    with open(path, "wb") as f:
+        f.write(bytes(t.cpu().contiguous().untyped_storage()))
+
+
+def _load_output(path: str, shape, dtype) -> torch.Tensor:
+    with open(path, "rb") as f:
+        return torch.frombuffer(bytearray(f.read()), dtype=dtype).reshape(shape)
+
+
+def _write_artifact(et_program, out_dir: str) -> tuple[str, str]:
+    pte = os.path.join(out_dir, "session.pte")
+    with open(pte, "wb") as f:
+        et_program.write_to_file(f)
+    if hasattr(et_program, "_tensor_data") and et_program._tensor_data:
+        et_program.write_tensor_data_to_file(out_dir)
+    return pte, os.path.join(out_dir, "aoti_cuda_blob.ptd")
+
+
+def _run_runner(pte, ptd, input_files, out_base):
+    cmd = [
+        RUNNER_PATH,
+        f"--model_path={pte}",
+        f"--data_path={ptd}",
+        f"--inputs={','.join(input_files)}",
+        f"--output_file={out_base}",
+    ]
+    return subprocess.run(cmd, capture_output=True, text=True, env=os.environ.copy())
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA is required for runtime")
+class TestOffloadSessionRuntime(unittest.TestCase):
+    def setUp(self):
+        if not os.path.exists(RUNNER_PATH):
+            self.skipTest(
+                f"executor_runner not found at {RUNNER_PATH}; build with "
+                "cmake --build cmake-out --target executor_runner"
+            )
+        torch.manual_seed(0)
+
+    def _run_and_compare(self, model, x, expected_out_shape):
+        et_program = _export_and_lower(
+            model.to("cuda").eval(), (x,), _opt_in_specs("forward")
+        )
+        with torch.no_grad():
+            ref = model(x).cpu().contiguous()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            export_dir = os.path.join(tmp, "export")
+            os.makedirs(export_dir)
+            pte, ptd = _write_artifact(et_program, export_dir)
+            run_dir = os.path.join(tmp, "run")
+            os.makedirs(run_dir)
+            in_path = os.path.join(run_dir, "0.bin")
+            _save_tensor(x, in_path)
+            out_base = os.path.join(run_dir, "out")
+            result = _run_runner(pte, ptd, [in_path], out_base)
+            self.assertEqual(
+                result.returncode,
+                0,
+                f"runner failed (rc={result.returncode}):\n"
+                f"stderr:\n{result.stderr}\nstdout:\n{result.stdout}",
+            )
+            out = _load_output(f"{out_base}-0.bin", expected_out_shape, torch.float32)
+            diff = (out.float() - ref.float()).abs().max().item()
+            self.assertLess(
+                diff,
+                1e-3,
+                f"offload output diverged from eager (max abs diff {diff})",
+            )
+
+    def test_two_weights_match_eager(self):
+        """Sync H2D through pinned host must produce the same output
+        as the direct-AOTI path within float32 numerics."""
+        x = torch.randn(4, 64, device="cuda")
+        self._run_and_compare(_TwoWeightModel(), x, expected_out_shape=(4, 64))
+
+    def test_multi_consumer_same_weight_matches_eager(self):
+        """Same FQN at two probe sites — each ``serve`` does its own
+        H2D from the shared host mirror; result must match eager."""
+        x = torch.randn(4, 64, device="cuda")
+        self._run_and_compare(_MultiConsumerSameWeight(), x, expected_out_shape=(4, 64))
+
+    def test_tied_weights_init_and_match_eager(self):
+        """Two FQNs sharing one ``data_ptr`` (tied embedding pattern)
+        must survive Session::create (registry dedupe per Session)
+        and produce eager-matching output."""
+        x = torch.randn(4, 64, device="cuda")
+        self._run_and_compare(_TiedWeightModel(), x, expected_out_shape=(4, 64))
+
+    def test_no_optin_preserves_identity_fallback(self):
+        """Without the opt-in spec, the registry stays empty so the
+        probe c-shim's identity-passthrough fallback still works.
+        Guards against the offload path silently breaking the
+        non-offload identity fallback."""
+        x = torch.randn(4, 64, device="cuda")
+        model = _TwoWeightModel().to("cuda").eval()
+        et_program = _export_and_lower(
+            model,
+            (x,),
+            [CudaBackend.generate_method_name_compile_spec("forward")],
+        )
+        with torch.no_grad():
+            ref = model(x).cpu().contiguous()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            export_dir = os.path.join(tmp, "export")
+            os.makedirs(export_dir)
+            pte, ptd = _write_artifact(et_program, export_dir)
+            run_dir = os.path.join(tmp, "run")
+            os.makedirs(run_dir)
+            in_path = os.path.join(run_dir, "0.bin")
+            _save_tensor(x, in_path)
+            out_base = os.path.join(run_dir, "out")
+            result = _run_runner(pte, ptd, [in_path], out_base)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertNotIn("[ET_WEIGHT_OFFLOAD]", result.stderr)
+            out = _load_output(f"{out_base}-0.bin", (4, 64), torch.float32)
+            diff = (out.float() - ref.float()).abs().max().item()
+            self.assertLess(diff, 1e-3)
+
+    def test_cuda_graph_plus_offload_is_rejected(self):
+        """Mutually exclusive: graph Replay bypasses AOTI's run(), so
+        probes never fire. The runtime must hard-fail at init when
+        both are set for the same method."""
+        # Construct a .pte with the offload opt-in, then run the
+        # runner with backend options that enable cuda_graph for
+        # the same method. The runner doesn't expose a flag for
+        # this so this test is skipped if we can't toggle the
+        # option from the runner CLI — record the limitation
+        # without making the suite brittle.
+        #
+        # The CUDA-graph option lives on the runtime backend
+        # options surface; setting it from a vanilla
+        # ``executor_runner`` invocation isn't supported. Document
+        # and skip rather than wire a parallel test runner just
+        # for this assertion. The hard-fail itself is exercised by
+        # the unit test of CudaBackend.init via direct C++ call
+        # when that infrastructure lands.
+        self.skipTest(
+            "cuda_graph option not settable from executor_runner CLI; "
+            "the init-time hard-fail is documented and asserted in C++ "
+            "unit tests when those land"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backends/cuda/tests/test_weight_offload_transport.py
+++ b/backends/cuda/tests/test_weight_offload_transport.py
@@ -1,0 +1,477 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Transport contract for the v2 weight-offload payload: serializer
+round-trip + runtime parse/install/serve (success-summary log and
+[ET_WEIGHT_OFFLOAD_SKIP] no-blob-load trace are the canaries)."""
+
+import io
+import os
+import struct
+import subprocess
+import tempfile
+import unittest
+
+import torch
+import torch.nn as nn
+from executorch.backends.cuda.cuda_backend import CudaBackend
+from executorch.backends.cuda.cuda_partitioner import CudaPartitioner
+from executorch.backends.cuda.passes.weight_offload_pass import (
+    _apply_weight_offload,
+    _serialize_payload,
+    COMPILE_SPEC_KEY_ENABLE,
+    COMPILE_SPEC_KEY_PIN_FQNS,
+    named_data_key_for_method,
+    PAYLOAD_KEY_CONSTANTS_METADATA,
+    PAYLOAD_KEY_FLOOR,
+    PAYLOAD_KEY_METHOD_NAME,
+    PAYLOAD_KEY_PIN_FQNS,
+    PAYLOAD_KEY_SCHEDULE,
+    PAYLOAD_KEY_VERSION,
+    PAYLOAD_MAGIC,
+)
+from executorch.exir import (
+    EdgeCompileConfig,
+    ExecutorchBackendConfig,
+    to_edge_transform_and_lower,
+)
+from executorch.exir.backend.compile_spec_schema import CompileSpec
+from executorch.exir.passes import MemoryPlanningPass
+from torch.export import export
+
+
+EXECUTORCH_ROOT = os.path.normpath(os.path.join(os.path.dirname(__file__), "../../.."))
+RUNNER_PATH = os.path.join(EXECUTORCH_ROOT, "cmake-out", "executor_runner")
+
+
+class _TwoWeightModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.w1 = nn.Parameter(torch.randn(64, 64))
+        self.w2 = nn.Parameter(torch.randn(64, 64))
+
+    def forward(self, x):
+        return (x @ self.w1) @ self.w2.T
+
+
+# --------------------------------------------------------------------------
+# Pure serialization round-trip (no export, no runtime)
+# --------------------------------------------------------------------------
+
+
+def _parse_payload_python(blob: bytes) -> dict:
+    """Mirror of the C++ parser (v2), used only by these tests to
+    verify the Python serializer's output without involving the
+    runtime."""
+    buf = io.BytesIO(blob)
+
+    def read(n):
+        b = buf.read(n)
+        if len(b) != n:
+            raise ValueError("truncated payload")
+        return b
+
+    def read_i32():
+        return struct.unpack("<i", read(4))[0]
+
+    def read_u32():
+        return struct.unpack("<I", read(4))[0]
+
+    def read_i64():
+        return struct.unpack("<q", read(8))[0]
+
+    def read_u64():
+        return struct.unpack("<Q", read(8))[0]
+
+    def read_str():
+        n = read_u32()
+        return read(n).decode("utf-8")
+
+    magic = read_u32()
+    if magic != PAYLOAD_MAGIC:
+        raise ValueError(f"bad magic: 0x{magic:08x}")
+    version = read_u32()
+    method_name = read_str()
+    floor_bytes = read_u64()
+    schedule = [read_str() for _ in range(read_u32())]
+    pin_fqns = [read_str() for _ in range(read_u32())]
+    constants_metadata = []
+    for _ in range(read_u32()):
+        fqn = read_str()
+        dtype = read_i32()
+        ndim = read_u32()
+        sizes = [read_i64() for _ in range(ndim)]
+        strides = [read_i64() for _ in range(ndim)]
+        storage_offset = read_i64()
+        nbytes = read_u64()
+        device_type = read_i32()
+        device_index = read_i32()
+        constants_metadata.append(
+            {
+                "fqn": fqn,
+                "dtype": dtype,
+                "sizes": sizes,
+                "strides": strides,
+                "storage_offset": storage_offset,
+                "nbytes": nbytes,
+                "device_type": device_type,
+                "device_index": device_index,
+            }
+        )
+    if buf.read():
+        raise ValueError("trailing bytes after payload")
+    return {
+        PAYLOAD_KEY_VERSION: version,
+        PAYLOAD_KEY_METHOD_NAME: method_name,
+        PAYLOAD_KEY_FLOOR: floor_bytes,
+        PAYLOAD_KEY_SCHEDULE: schedule,
+        PAYLOAD_KEY_PIN_FQNS: pin_fqns,
+        PAYLOAD_KEY_CONSTANTS_METADATA: constants_metadata,
+    }
+
+
+class TestPayloadSerialization(unittest.TestCase):
+    def test_round_trip_preserves_all_fields(self):
+        ep = export(_TwoWeightModel(), (torch.randn(4, 64),), strict=True)
+        payload = _apply_weight_offload(ep, method_name="prefill", pin_fqns=["w1"])
+        blob = _serialize_payload(payload)
+        parsed = _parse_payload_python(blob)
+        self.assertEqual(parsed[PAYLOAD_KEY_VERSION], payload[PAYLOAD_KEY_VERSION])
+        self.assertEqual(parsed[PAYLOAD_KEY_METHOD_NAME], "prefill")
+        self.assertEqual(parsed[PAYLOAD_KEY_FLOOR], payload[PAYLOAD_KEY_FLOOR])
+        self.assertEqual(parsed[PAYLOAD_KEY_SCHEDULE], payload[PAYLOAD_KEY_SCHEDULE])
+        self.assertEqual(parsed[PAYLOAD_KEY_PIN_FQNS], ["w1"])
+        # v2 metadata round-trip — one entry per unique(schedule) FQN.
+        parsed_meta = parsed[PAYLOAD_KEY_CONSTANTS_METADATA]
+        emitted_meta = payload[PAYLOAD_KEY_CONSTANTS_METADATA]
+        self.assertEqual(len(parsed_meta), len(emitted_meta))
+        for p, e in zip(parsed_meta, emitted_meta):
+            self.assertEqual(p["fqn"], e["fqn"])
+            self.assertEqual(p["dtype"], e["dtype"])
+            self.assertEqual(p["sizes"], e["sizes"])
+            self.assertEqual(p["strides"], e["strides"])
+            self.assertEqual(p["storage_offset"], e["storage_offset"])
+            self.assertEqual(p["nbytes"], e["nbytes"])
+            self.assertEqual(p["device_type"], 1)  # CUDA
+            self.assertEqual(p["device_index"], 0)
+
+    def test_magic_is_first_four_bytes(self):
+        ep = export(_TwoWeightModel(), (torch.randn(4, 64),), strict=True)
+        payload = _apply_weight_offload(ep, method_name="forward")
+        blob = _serialize_payload(payload)
+        self.assertEqual(struct.unpack("<I", blob[:4])[0], PAYLOAD_MAGIC)
+
+
+# --------------------------------------------------------------------------
+# Export pipeline: does the payload land in the NamedDataStore?
+# --------------------------------------------------------------------------
+
+
+def _opt_in_specs(method_name: str, pin_fqns: list[str] | None = None):
+    specs = [
+        CudaBackend.generate_method_name_compile_spec(method_name),
+        CompileSpec(COMPILE_SPEC_KEY_ENABLE, b"1"),
+    ]
+    if pin_fqns:
+        specs.append(
+            CompileSpec(
+                COMPILE_SPEC_KEY_PIN_FQNS,
+                b"\x00".join(f.encode("utf-8") for f in pin_fqns),
+            )
+        )
+    return specs
+
+
+def _et_program_from_specs(model: nn.Module, inputs, specs):
+    ep = export(model, inputs, strict=True)
+    et_prog = to_edge_transform_and_lower(
+        ep,
+        partitioner=[CudaPartitioner(specs)],
+        compile_config=EdgeCompileConfig(
+            _check_ir_validity=False, _skip_dim_order=True
+        ),
+    )
+    return et_prog.to_executorch(
+        config=ExecutorchBackendConfig(
+            extract_delegate_segments=True,
+            do_quant_fusion_and_const_prop=True,
+            memory_planning_pass=MemoryPlanningPass(alloc_graph_input=False),
+        ),
+    )
+
+
+def _named_data_entries(et_program) -> dict[str, bytes]:
+    """Flatten the executorch program's NamedDataStoreOutput entries by
+    key. Inspects the private ``_named_data`` attribute on
+    ``ExecutorchProgramManager`` — the public surface only exposes
+    ``write_to_file`` / ``write_tensor_data_to_file`` which already
+    serialize the .pte / .ptd. ``pte_data`` is ``dict[key,
+    DataEntry]``; ``external_data`` is
+    ``dict[tag, dict[key, DataEntry]]``; both index into ``buffers``,
+    a ``list[bytes]``."""
+    out: dict[str, bytes] = {}
+    nd = getattr(et_program, "_named_data", None)
+    if nd is None:
+        return out
+    for key, entry in nd.pte_data.items():
+        out[key] = nd.buffers[entry.buffer_index]
+    for tag_dict in nd.external_data.values():
+        for key, entry in tag_dict.items():
+            out[key] = nd.buffers[entry.buffer_index]
+    return out
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA is required for export")
+class TestPayloadTransportExport(unittest.TestCase):
+    def setUp(self):
+        torch.manual_seed(0)
+
+    def test_payload_present_when_opt_in_set(self):
+        model = _TwoWeightModel().to("cuda").eval()
+        x = torch.randn(4, 64, device="cuda")
+        specs = _opt_in_specs("forward")
+        et_program = _et_program_from_specs(model, (x,), specs)
+
+        entries = _named_data_entries(et_program)
+        key = named_data_key_for_method("forward")
+        self.assertIn(key, entries, f"missing offload payload at key {key!r}")
+        parsed = _parse_payload_python(entries[key])
+        self.assertEqual(parsed[PAYLOAD_KEY_METHOD_NAME], "forward")
+        self.assertEqual(parsed[PAYLOAD_KEY_VERSION], 2)
+        # Two distinct weights, each used once at distinct consumers
+        # — schedule length is 2 minimum (could be more after view
+        # duplication for the .T).
+        self.assertGreaterEqual(len(parsed[PAYLOAD_KEY_SCHEDULE]), 2)
+        self.assertEqual(parsed[PAYLOAD_KEY_PIN_FQNS], [])
+        # Per-FQN metadata block has one entry per unique scheduled FQN
+        self.assertEqual(
+            sorted(m["fqn"] for m in parsed[PAYLOAD_KEY_CONSTANTS_METADATA]),
+            sorted(set(parsed[PAYLOAD_KEY_SCHEDULE])),
+        )
+
+    def test_pin_fqns_round_trip_through_specs(self):
+        model = _TwoWeightModel().to("cuda").eval()
+        x = torch.randn(4, 64, device="cuda")
+        specs = _opt_in_specs("forward", pin_fqns=["w1"])
+        et_program = _et_program_from_specs(model, (x,), specs)
+
+        entries = _named_data_entries(et_program)
+        parsed = _parse_payload_python(entries[named_data_key_for_method("forward")])
+        self.assertEqual(parsed[PAYLOAD_KEY_PIN_FQNS], ["w1"])
+
+    def test_no_payload_when_opt_in_absent(self):
+        model = _TwoWeightModel().to("cuda").eval()
+        x = torch.randn(4, 64, device="cuda")
+        specs = [CudaBackend.generate_method_name_compile_spec("forward")]
+        et_program = _et_program_from_specs(model, (x,), specs)
+
+        entries = _named_data_entries(et_program)
+        self.assertNotIn(named_data_key_for_method("forward"), entries)
+
+
+# --------------------------------------------------------------------------
+# End-to-end: runtime parse-and-log via executor_runner
+# --------------------------------------------------------------------------
+
+
+def _save_tensor(t: torch.Tensor, path: str) -> None:
+    with open(path, "wb") as f:
+        f.write(bytes(t.cpu().contiguous().untyped_storage()))
+
+
+def _write_artifact(et_program, out_dir: str) -> tuple[str, str]:
+    pte = os.path.join(out_dir, "offload.pte")
+    with open(pte, "wb") as f:
+        et_program.write_to_file(f)
+    if hasattr(et_program, "_tensor_data") and et_program._tensor_data:
+        et_program.write_tensor_data_to_file(out_dir)
+    return pte, os.path.join(out_dir, "aoti_cuda_blob.ptd")
+
+
+def _run_runner(
+    runner_path: str, pte: str, ptd: str, input_file: str, out_base: str
+) -> subprocess.CompletedProcess:
+    cmd = [
+        runner_path,
+        f"--model_path={pte}",
+        f"--data_path={ptd}",
+        f"--inputs={input_file}",
+        f"--output_file={out_base}",
+    ]
+    return subprocess.run(cmd, capture_output=True, text=True, env=os.environ.copy())
+
+
+def _count_offload_log_lines(stderr: str) -> int:
+    """Count only the success-path log lines (``[ET_WEIGHT_OFFLOAD]``
+    followed by a space). Error lines use ``[ET_WEIGHT_OFFLOAD][ERROR]``
+    and must NOT count, so the hard-fail test can assert "success log
+    absent + error log present" without ambiguity."""
+    return sum(1 for line in stderr.splitlines() if "[ET_WEIGHT_OFFLOAD] " in line)
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA is required for runtime")
+class TestPayloadTransportRuntime(unittest.TestCase):
+    def setUp(self):
+        if not os.path.exists(RUNNER_PATH):
+            self.skipTest(
+                f"executor_runner not found at {RUNNER_PATH}; build with "
+                "cmake --build cmake-out --target executor_runner"
+            )
+
+    def _run_with(self, specs):
+        """Run the model and return the raw subprocess result. Callers
+        decide whether rc==0 or rc!=0 is expected."""
+        model = _TwoWeightModel().to("cuda").eval()
+        x = torch.randn(4, 64, device="cuda")
+        et_program = _et_program_from_specs(model, (x,), specs)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            export_dir = os.path.join(tmp, "export")
+            os.makedirs(export_dir)
+            pte, ptd = _write_artifact(et_program, export_dir)
+            run_dir = os.path.join(tmp, "run")
+            os.makedirs(run_dir)
+            in_path = os.path.join(run_dir, "0.bin")
+            _save_tensor(x, in_path)
+            out_base = os.path.join(run_dir, "out")
+            return _run_runner(RUNNER_PATH, pte, ptd, in_path, out_base)
+
+    def _run_and_get_stderr(self, specs) -> str:
+        result = self._run_with(specs)
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"executor_runner failed (rc={result.returncode}):\n"
+            f"stderr:\n{result.stderr}\nstdout:\n{result.stdout}",
+        )
+        return result.stderr
+
+    def test_runtime_logs_payload_when_opt_in_set(self):
+        stderr = self._run_and_get_stderr(_opt_in_specs("forward"))
+        self.assertEqual(
+            _count_offload_log_lines(stderr),
+            1,
+            f"expected one [ET_WEIGHT_OFFLOAD] log line, stderr:\n{stderr}",
+        )
+        # Spot-check echoed fields are visible in the log
+        offload_line = next(
+            line
+            for line in stderr.splitlines()
+            if line.startswith("[ET_WEIGHT_OFFLOAD] ")
+        )
+        self.assertIn("method=forward", offload_line)
+        self.assertIn("version=2", offload_line)
+        self.assertIn("pinned=0", offload_line)
+        # Success summary includes installed=N and the no-eager-load trace.
+        self.assertIn("installed=", offload_line)
+        self.assertIn(
+            "[ET_WEIGHT_OFFLOAD_SKIP] skipped update_constants_from_blob "
+            "method=forward",
+            stderr,
+        )
+
+    def test_runtime_accepts_nonempty_pin_fqns(self):
+        """Commit 9a lands pinning. A method with ``pin_fqns=["w1"]``
+        now loads successfully through the runtime: the pinned weight
+        is allocated once at Session::create and served through the
+        resident fast path (the streaming pool only sees w2).
+
+        Asserts loud-and-correct behavior at the transport layer.
+        Detailed accounting (pinned_bytes / streaming_budget stats,
+        prefetch interaction) lives in the pool-side tests."""
+        stderr = self._run_and_get_stderr(_opt_in_specs("forward", pin_fqns=["w1"]))
+        # Success summary emitted = init went all the way through.
+        self.assertEqual(
+            _count_offload_log_lines(stderr),
+            1,
+            f"expected one [ET_WEIGHT_OFFLOAD] success log, stderr:\n{stderr}",
+        )
+        summary = next(
+            line
+            for line in stderr.splitlines()
+            if line.startswith("[ET_WEIGHT_OFFLOAD] ")
+        )
+        # The success summary reports pinned=1 even when pinning is
+        # actually exercised — the field counts payload.pin_fqns
+        # length, which existed pre-9a too.
+        self.assertIn("pinned=1", summary)
+
+    def test_runtime_silent_without_opt_in(self):
+        specs = [CudaBackend.generate_method_name_compile_spec("forward")]
+        stderr = self._run_and_get_stderr(specs)
+        self.assertEqual(
+            _count_offload_log_lines(stderr),
+            0,
+            f"expected no [ET_WEIGHT_OFFLOAD] log line, stderr:\n{stderr}",
+        )
+
+    def test_runtime_hard_fails_on_corrupted_payload(self):
+        """Locks in the runtime parser's hard-fail contract: a payload
+        whose magic header has been clobbered must cause ``init`` to
+        fail loudly, not silently degrade. Mutates the .pte after
+        export by zeroing the four magic bytes (the longer
+        ``ETWO`` + version uint32 needle avoids matching any
+        coincidental occurrence elsewhere in the compiled .so)."""
+        model = _TwoWeightModel().to("cuda").eval()
+        x = torch.randn(4, 64, device="cuda")
+        et_program = _et_program_from_specs(model, (x,), _opt_in_specs("forward"))
+
+        with tempfile.TemporaryDirectory() as tmp:
+            export_dir = os.path.join(tmp, "export")
+            os.makedirs(export_dir)
+            pte, ptd = _write_artifact(et_program, export_dir)
+
+            # Magic (``ETWO``) immediately followed by schema_version
+            # ``= 2`` (little-endian uint32 ``\x02\x00\x00\x00``) is
+            # vanishingly unlikely to appear by chance in the .so or
+            # weights blob; safer than searching for the four-byte
+            # magic alone.
+            needle = b"ETWO\x02\x00\x00\x00"
+            with open(pte, "rb") as f:
+                data = bytearray(f.read())
+            idx = data.find(needle)
+            self.assertGreaterEqual(idx, 0, "expected to find offload magic in .pte")
+            second = data.find(needle, idx + 1)
+            self.assertLess(
+                second,
+                0,
+                "needle appeared twice — corruption target is ambiguous",
+            )
+            data[idx : idx + 4] = b"JUNK"
+            with open(pte, "wb") as f:
+                f.write(data)
+
+            run_dir = os.path.join(tmp, "run")
+            os.makedirs(run_dir)
+            in_path = os.path.join(run_dir, "0.bin")
+            _save_tensor(x, in_path)
+            out_base = os.path.join(run_dir, "out")
+            result = _run_runner(RUNNER_PATH, pte, ptd, in_path, out_base)
+
+        # Non-zero exit because init aborted. The stderr should
+        # mention "weight offload" and "parse" so a future debugger
+        # has a fighting chance.
+        self.assertNotEqual(
+            result.returncode,
+            0,
+            f"executor_runner unexpectedly succeeded with corrupted payload; "
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+        )
+        # Loud-at-init contract: the error path must produce stderr
+        # output regardless of ET_LOG_ENABLED so a debugger can find
+        # the cause.
+        self.assertIn("[ET_WEIGHT_OFFLOAD][ERROR]", result.stderr)
+        self.assertIn("payload parse failed", result.stderr)
+        self.assertEqual(
+            _count_offload_log_lines(result.stderr),
+            0,
+            "the offload log line should NOT appear for a corrupted payload "
+            "(parse must hard-fail before the log emits)",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/models/gemma4_31b/export.py
+++ b/examples/models/gemma4_31b/export.py
@@ -141,11 +141,14 @@ def export_and_lower(
     config: Gemma4_31BConfig,
     output_dir: str,
     backend: str = "cuda",
+    weight_offload: bool = False,
 ) -> None:
     """Export and lower the model to ExecuTorch for the given backend."""
     if backend == "cuda":
-        _export_cuda(model, config, output_dir)
+        _export_cuda(model, config, output_dir, weight_offload=weight_offload)
     elif backend == "mlx":
+        if weight_offload:
+            raise ValueError("weight_offload is only supported on the cuda backend.")
         _export_mlx(model, config, output_dir)
     else:
         raise ValueError(
@@ -153,7 +156,12 @@ def export_and_lower(
         )
 
 
-def _export_cuda(model: Gemma4_31B, config: Gemma4_31BConfig, output_dir: str) -> None:
+def _export_cuda(
+    model: Gemma4_31B,
+    config: Gemma4_31BConfig,
+    output_dir: str,
+    weight_offload: bool = False,
+) -> None:
     import gc
 
     import torch._inductor.config as inductor_config
@@ -222,7 +230,8 @@ def _export_cuda(model: Gemma4_31B, config: Gemma4_31BConfig, output_dir: str) -
                     [
                         CudaBackend.generate_method_name_compile_spec("decode"),
                         CompileSpec("low_memory_mode", b"ON"),
-                    ]
+                    ],
+                    weight_offload=weight_offload,
                 )
             ],
             "prefill": [
@@ -230,7 +239,8 @@ def _export_cuda(model: Gemma4_31B, config: Gemma4_31BConfig, output_dir: str) -
                     [
                         CudaBackend.generate_method_name_compile_spec("prefill"),
                         CompileSpec("low_memory_mode", b"ON"),
-                    ]
+                    ],
+                    weight_offload=weight_offload,
                 )
             ],
         },
@@ -418,6 +428,15 @@ def main() -> None:
         choices=list(_SUPPORTED_BACKENDS),
         help="Target backend for export.",
     )
+    parser.add_argument(
+        "--weight-offload",
+        action="store_true",
+        help=(
+            "Opt the CUDA backend into weight offloading: AOTI constants "
+            "stream from a bounded GPU pool backed by a pinned host mirror. "
+            "Only supported on --backend cuda."
+        ),
+    )
     args = parser.parse_args()
 
     if args.backend == "cuda" and not torch.cuda.is_available():
@@ -443,7 +462,13 @@ def main() -> None:
             backend=args.backend,
         )
 
-    export_and_lower(model, config, args.output_dir, backend=args.backend)
+    export_and_lower(
+        model,
+        config,
+        args.output_dir,
+        backend=args.backend,
+        weight_offload=args.weight_offload,
+    )
 
 
 if __name__ == "__main__":

--- a/examples/models/gemma4_31b/tests/test_cuda_pipeline.py
+++ b/examples/models/gemma4_31b/tests/test_cuda_pipeline.py
@@ -148,6 +148,42 @@ class TestCudaExport(unittest.TestCase):
             ptd_files = [f for f in os.listdir(out_dir) if f.endswith(".ptd")]
             self.assertGreater(len(ptd_files), 0)
 
+    def test_export_with_weight_offload(self):
+        """--prequantized path with weight_offload=True wires the offload
+        payload into the .pte and the per-method ``_weights_blob`` entries
+        into a .ptd. The runtime path is exercised separately in the C++
+        offload test suite; this test only verifies the export artifacts."""
+        with tempfile.TemporaryDirectory() as ckpt_dir, tempfile.TemporaryDirectory() as out_dir:
+            save_checkpoint(ckpt_dir)
+            model, config = load_prequantized_model(
+                ckpt_dir, max_seq_len=TINY_CONFIG.max_seq_len
+            )
+            export_and_lower(model, config, out_dir, weight_offload=True)
+
+            pte_path = os.path.join(out_dir, "model.pte")
+            self.assertTrue(os.path.exists(pte_path))
+            with open(pte_path, "rb") as f:
+                pte_bytes = f.read()
+            # Metadata payload (schedule + constants_metadata + ETWO magic)
+            # is inlined into the .pte under a per-method named-data key.
+            self.assertIn(b"_weight_offload_payload", pte_bytes)
+            self.assertIn(b"ETWO", pte_bytes)
+
+            ptd_files = [f for f in os.listdir(out_dir) if f.endswith(".ptd")]
+            self.assertGreater(len(ptd_files), 0)
+            # _weights_blob entries (one per method) live in the .ptd.
+            blob_seen = False
+            for name in ptd_files:
+                with open(os.path.join(out_dir, name), "rb") as f:
+                    if b"_weights_blob" in f.read():
+                        blob_seen = True
+                        break
+            self.assertTrue(
+                blob_seen,
+                "expected at least one .ptd to contain a '_weights_blob' "
+                "named-data entry when weight_offload=True",
+            )
+
     def test_export_from_hf_checkpoint(self):
         """--model-dir path: load HF → quantize → pack → export."""
         with tempfile.TemporaryDirectory() as ckpt_dir, tempfile.TemporaryDirectory() as out_dir:

--- a/examples/portable/executor_runner/executor_runner.cpp
+++ b/examples/portable/executor_runner/executor_runner.cpp
@@ -34,12 +34,23 @@
 #include <executorch/extension/evalue_util/print_evalue.h>
 #include <executorch/extension/flat_tensor/flat_tensor_data_map.h>
 #include <executorch/extension/runner_util/inputs.h>
+#include <executorch/runtime/backend/backend_options_map.h>
+#include <executorch/runtime/backend/options.h>
 #include <executorch/runtime/core/event_tracer.h>
 #include <executorch/runtime/executor/method.h>
 #include <executorch/runtime/executor/program.h>
 #include <executorch/runtime/platform/log.h>
 #include <executorch/runtime/platform/platform.h>
 #include <executorch/runtime/platform/runtime.h>
+
+#include <array>
+#include <cerrno>
+#include <climits>
+#include <cstdlib>
+#include <cstring>
+#include <string_view>
+#include <unordered_set>
+#include <vector>
 #ifdef ET_EVENT_TRACER_ENABLED
 #include <executorch/devtools/etdump/etdump_flatcc.h>
 #endif // ET_EVENT_TRACER_ENABLED
@@ -86,6 +97,19 @@ DEFINE_int32(
     -1,
     "Number of CPU threads for inference. Defaults to -1, which implies we'll use a heuristic to derive the # of performant cores for a specific device.");
 
+DEFINE_string(
+    cuda_runtime_spec,
+    "",
+    "Comma-separated key=value pairs to pass to CudaBackend as "
+    "load-time runtime specs (read via "
+    "BackendInitContext::get_runtime_spec). Known CUDA runtime specs "
+    "are parsed by their declared type. Supported keys: "
+    "weight_offload_budget_mb (int), "
+    "_weight_offload_internal_budget_bytes (string). Unknown keys "
+    "hard-fail at parse. Duplicate keys hard-fail at parse. "
+    "Example: --cuda_runtime_spec=weight_offload_budget_mb=64. "
+    "Empty (default) means no specs are set.");
+
 #ifdef ET_BUNDLE_IO_ENABLED
 DEFINE_double(bundleio_rtol, 0.01, "Relative tolerance for bundled IO.");
 DEFINE_double(bundleio_atol, 0.01, "Absolute tolerance for bundled IO.");
@@ -101,11 +125,15 @@ using executorch::bundled_program::verify_method_outputs;
 using executorch::extension::BufferDataLoader;
 using executorch::extension::FileDataLoader;
 using executorch::extension::FlatTensorDataMap;
+using executorch::runtime::BackendOption;
 using executorch::runtime::DataLoader;
 using executorch::runtime::Error;
 using executorch::runtime::EValue;
 using executorch::runtime::EventTracer;
 using executorch::runtime::HierarchicalAllocator;
+using executorch::runtime::kMaxOptionKeyLength;
+using executorch::runtime::kMaxOptionValueLength;
+using executorch::runtime::LoadBackendOptionsMap;
 using executorch::runtime::MemoryAllocator;
 using executorch::runtime::MemoryManager;
 using executorch::runtime::Method;
@@ -117,6 +145,102 @@ using executorch::runtime::Tag;
 using executorch::runtime::TensorInfo;
 
 enum class PrintOutputMode { None, Summary, All };
+
+// ---------------------------------------------------------------------------
+// --cuda_runtime_spec parser
+// ---------------------------------------------------------------------------
+// Comma-separated key=value pairs. Key-aware: known CUDA runtime
+// specs are parsed by their declared type; unknown keys and
+// duplicate keys hard-fail at parse so the user sees the bad flag
+// instead of a silent type mismatch deep in init.
+namespace cuda_runtime_spec_parser {
+
+// The CUDA runtime accepts exactly these keys today. Adding a new key
+// here without a matching get_runtime_spec call in cuda_backend.cpp
+// just means the value silently does nothing; the reverse means the
+// runner can't drive the spec via the CLI.
+struct KnownSpec {
+  const char* key;
+  bool is_int; // false = string
+};
+constexpr KnownSpec kKnownCudaSpecs[] = {
+    {"weight_offload_budget_mb", true},
+    {"_weight_offload_internal_budget_bytes", false},
+};
+
+inline std::vector<BackendOption> parse_cuda_runtime_spec_string(
+    const std::string& spec_str) {
+  std::vector<BackendOption> out;
+  std::unordered_set<std::string> seen_keys;
+  std::string_view sv(spec_str);
+  while (!sv.empty()) {
+    auto comma = sv.find(',');
+    std::string_view pair =
+        (comma == std::string_view::npos) ? sv : sv.substr(0, comma);
+    auto eq = pair.find('=');
+    ET_CHECK_MSG(
+        eq != std::string_view::npos,
+        "malformed --cuda_runtime_spec entry '%s': expected key=value",
+        std::string(pair).c_str());
+    std::string key(pair.substr(0, eq));
+    std::string_view val_sv = pair.substr(eq + 1);
+
+    ET_CHECK_MSG(
+        seen_keys.insert(key).second,
+        "duplicate key '%s' in --cuda_runtime_spec",
+        key.c_str());
+
+    const KnownSpec* known = nullptr;
+    for (const auto& s : kKnownCudaSpecs) {
+      if (key == s.key) {
+        known = &s;
+        break;
+      }
+    }
+    ET_CHECK_MSG(
+        known != nullptr, "unknown --cuda_runtime_spec key '%s'", key.c_str());
+    ET_CHECK_MSG(
+        key.size() < kMaxOptionKeyLength,
+        "--cuda_runtime_spec key '%s' exceeds %zu bytes",
+        key.c_str(),
+        static_cast<size_t>(kMaxOptionKeyLength - 1));
+
+    BackendOption opt{};
+    std::memcpy(opt.key, key.data(), key.size());
+    opt.key[key.size()] = '\0';
+    if (known->is_int) {
+      std::string s(val_sv);
+      char* end = nullptr;
+      errno = 0;
+      long long parsed = std::strtoll(s.c_str(), &end, 10);
+      ET_CHECK_MSG(
+          errno == 0 && end == s.c_str() + s.size() && parsed >= INT_MIN &&
+              parsed <= INT_MAX,
+          "--cuda_runtime_spec key '%s' expects int, got '%s'",
+          key.c_str(),
+          s.c_str());
+      opt.value = static_cast<int>(parsed);
+    } else {
+      std::array<char, kMaxOptionValueLength> buf{};
+      ET_CHECK_MSG(
+          val_sv.size() < buf.size(),
+          "--cuda_runtime_spec key '%s' string value too long (max %zu bytes)",
+          key.c_str(),
+          buf.size() - 1);
+      std::memcpy(buf.data(), val_sv.data(), val_sv.size());
+      opt.value = buf;
+    }
+    out.push_back(std::move(opt));
+
+    if (comma == std::string_view::npos) {
+      break;
+    }
+    sv.remove_prefix(comma + 1);
+  }
+  return out;
+}
+
+} // namespace cuda_runtime_spec_parser
 
 /// Helper to manage resources for ETDump generation
 class EventTraceManager {
@@ -450,11 +574,35 @@ int main(int argc, char** argv) {
   // be used by a single thread at at time, but it can be reused.
   //
   EventTraceManager tracer;
+
+  // Build the per-load backend options map from --cuda_runtime_spec.
+  // Empty flag → nullptr; nothing changes for non-CUDA methods or
+  // for CUDA methods that don't need to drive runtime specs.
+  std::vector<BackendOption> cuda_opts;
+  LoadBackendOptionsMap load_backend_options;
+  const LoadBackendOptionsMap* load_backend_options_ptr = nullptr;
+  if (!FLAGS_cuda_runtime_spec.empty()) {
+    cuda_opts = cuda_runtime_spec_parser::parse_cuda_runtime_spec_string(
+        FLAGS_cuda_runtime_spec);
+    if (!cuda_opts.empty()) {
+      auto opts_err = load_backend_options.set_options(
+          "CudaBackend",
+          Span<BackendOption>(cuda_opts.data(), cuda_opts.size()));
+      ET_CHECK_MSG(
+          opts_err == Error::Ok,
+          "LoadBackendOptionsMap::set_options for CudaBackend failed "
+          "(error 0x%" PRIx32 ")",
+          static_cast<uint32_t>(opts_err));
+      load_backend_options_ptr = &load_backend_options;
+    }
+  }
+
   Result<Method> method = program->load_method(
       method_name,
       &memory_manager,
       tracer.get_event_tracer(),
-      ptd_data_map.get());
+      ptd_data_map.get(),
+      load_backend_options_ptr);
   const et_timestamp_t after_load = executorch::runtime::pal_current_ticks();
   ET_CHECK_MSG(
       method.ok(),


### PR DESCRIPTION
Add CUDA weight offloading

Lets a CUDA-backend ExecuTorch program stream model weights from a
pinned host mirror through a bounded GPU pool on demand, instead of
loading the full constant set into VRAM at program load. This lets a
process run a model whose total weight bytes exceed available GPU
memory, or share GPU across methods whose union exceeds memory.

Public surface (CudaPartitioner kwargs):

  weight_offload: bool = False
      Opt the method into offload. The runtime skips AOTI's eager
      ``update_constants_from_blob``, installs 1-byte GPU dummies in
      place of constants via
      ``update_user_managed_constant_buffer_pairs``, and routes every
      constant read through a probe op into Session::serve.

  weight_offload_pin_fqns: Optional[List[str]] = None
      FQNs to keep resident on GPU for the Session lifetime (out-of-
      pool ``cudaMalloc`` + one-time H2D + sync at create). Requires
      weight_offload=True. Currently device-0-only.

Runtime spec (LoadBackendOptionsMap, or executor_runner's
``--cuda_runtime_spec=weight_offload_budget_mb=N``):
      Total GPU bytes the offload pool + pinned constants may use.
      Defaults to floor_bytes + pinned_bytes_total when unset.

Architecture:

  Export-time pass (backends/cuda/passes/weight_offload_pass.py):
    Rewrites every parameter / buffer consumer to read through
    ``executorch_weight_offload::probe(w, probe_id)`` and serializes
    a v2 payload (schedule + floor + pin_fqns + per-FQN dtype /
    sizes / strides / storage_offset / nbytes / device) into
    NamedDataStore. ``probe_id`` is dense 0..N-1 in graph order so
    the runtime can index ``schedule[probe_id]`` directly.

  Payload parser (backends/cuda/runtime/weight_offload/payload.h):
    Single trust boundary. Validates schema version, framing bounds,
    per-FQN invariants (dtype allow-list, contiguous + offset-zero
    layout, nbytes == elementSize(dtype) * product(sizes), device
    == cuda:0), schedule <-> metadata set equality, and pin_fqns
    dedup + subset-of-schedule. Downstream code trusts the parsed
    Payload struct.

  AOTI c-shim (backends/cuda/runtime/weight_offload/probe_op.cpp):
    Looks the dummy data_ptr up in ProbeRegistry and forwards to
    Session::serve. Lookup miss with the registry empty falls back
    to identity-passthrough (preserves non-offload paths); lookup
    miss with the registry non-empty hard-fails (otherwise the
    runtime would silently read AOTI's eager constant).

  Session (backends/cuda/runtime/weight_offload/session.{h,cpp}):
    Owns the offload lifecycle. Builds the pinned host mirror by
    indexing into the ``_weights_blob`` NamedData entry, allocates a
    bounded ``cudaMemPool``, implements LRU eviction with
    event-ordered ``cudaFreeAsync`` on the compute stream, depth-1
    opportunistic prefetch on the copy stream, optional pinned-
    resident constants. ``serve()``'s miss path and

  ProbeRegistry (backends/cuda/runtime/weight_offload/probe_registry.{h,cpp}):
    Process-global ``dummy_ptr -> (callback, context)`` table in the
    shim library. ``lookup`` + ``has_any_context`` take a shared
    lock so concurrent probe dispatch across Sessions does not
    serialise.

  CudaBackend::init (backends/cuda/runtime/cuda_backend.cpp):
    Thin shim for offload methods: parse payload, fail-fast on
    cuda_graph / shared_stream / non-device-0, ``cudaSetDevice(0)``,
    walk the AOTI catalog, coverage check (catalog <-> schedule),
    AOTI <-> payload data_size cross-check (the one genuinely
    cross-source check; AOTI's compiled .so vs the .pte payload),
    fetch ``_weights_blob``, call Session::create.


https://github.com/pytorch/executorch/issues/19709