### PR TITLE
Qualcomm AI Engine Direct - heap profiling at runtime on target

### DIFF
--- a/backends/qualcomm/tests/test_qnn_delegate.py
+++ b/backends/qualcomm/tests/test_qnn_delegate.py
@@ -5891,6 +5891,8 @@ class TestQNNFloatingPointUtils(TestQNN):
         TestQNN.profile_level = 0
 
     def test_qnn_backend_runtime_option_heap_profile(self):
+        if self.enable_x86_64:
+            self.skipTest("heap profiling is not supported on host machine")
         module = SimpleModel()  # noqa: F405
         sample_input = (torch.ones(1, 32, 28, 28), torch.ones(1, 32, 28, 28))
 
@@ -6826,6 +6828,8 @@ class TestQNNQuantizedUtils(TestQNN):
         TestQNN.profile_level = 0
 
     def test_qnn_backend_runtime_option_heap_profile(self):
+        if self.enable_x86_64:
+            self.skipTest("heap profiling is not supported on host machine")
         module = SimpleModel()  # noqa: F405
         sample_input = (torch.ones(1, 32, 28, 28), torch.ones(1, 32, 28, 28))
         module1 = self.get_qdq_module(module, sample_input)


### PR DESCRIPTION

Qualcomm AI Engine Direct - heap profiling at runtime on target
    
    Summary:
    Heap profiling at runtime with HTP backend on Android platforms. DSP
    heap profiling is available for QnnContext_createFromBinary use-cases.
    It captures total DSP heap usage at two checkpoints:
    - Before the first context is created (before_context_created)
    - After the last context is freed (after_context_freed)

    The difference between the two values represents heap consumed during
    context execution. The value after freeing is typically equal to or
    greater than before creation.

    Test plan:
    python backends/qualcomm/tests/test_qnn_delegate.py
    TestQNNQuantizedUtils.test_qnn_backend_runtime_option_heap_profile -b
    build-android -H ${HOST} -s ${SN} -m ${SOC_MODEL}

    Note:
    This test is expected to run on target device.




cc @cccclai @cbilgin @abhinaykukkadapu