### PR TITLE
CoreML LoRA-as-IO: forward-arg LoRA + per-adapter .ptd

### DIFF
--- a/examples/models/llama/feed_forward.py
+++ b/examples/models/llama/feed_forward.py
@@ -64,5 +64,16 @@ class LoRAFeedForward(nn.Module):
             else nn.Linear(dim, hidden_dim, bias=False)
         )
 
-    def forward(self, x):
-        return self.w2(F.silu(self.w1(x)) * self.w3(x))
+    def forward(self, x, lora_blob=None):
+        # CoreML LoRA-as-IO Path-2: when `lora_blob` is provided, route per-
+        # projection slices to LoRALinear instances tagged with `_lora_key`.
+        # Default behavior (lora_blob=None) is unchanged.
+        def _call(linear, x_in):
+            if lora_blob is not None:
+                key = getattr(linear, "_lora_key", None)
+                if key is not None and key in lora_blob:
+                    a, b = lora_blob[key]
+                    return linear(x_in, a, b)
+            return linear(x_in)
+
+        return _call(self.w2, F.silu(_call(self.w1, x)) * _call(self.w3, x))

--- a/examples/models/llama/llama_transformer.py
+++ b/examples/models/llama/llama_transformer.py
@@ -239,7 +239,18 @@ class TransformerBlock(nn.Module):
             else:
                 out = h + ffn_out
         else:
-            ffn_out = self.feed_forward(self.ffn_norm(h))
+            # CoreML LoRA-as-IO Path-2: forward `lora_blob` (if any) from
+            # attn_options into LoRAFeedForward. FeedForward (no LoRA) does
+            # not accept the kwarg, so we conditionally pass it.
+            from executorch.examples.models.llama.feed_forward import LoRAFeedForward
+
+            if isinstance(self.feed_forward, LoRAFeedForward):
+                ffn_out = self.feed_forward(
+                    self.ffn_norm(h),
+                    lora_blob=attn_options.get("__lora_io_blob__"),
+                )
+            else:
+                ffn_out = self.feed_forward(self.ffn_norm(h))
             if hasattr(self, "post_ffn_norm"):
                 ffn_out = self.post_ffn_norm(ffn_out)
             if self.use_residual_gate:

--- a/examples/models/llama/lora.py
+++ b/examples/models/llama/lora.py
@@ -4,7 +4,10 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Optional
+
 import torch
+import torch.nn.functional as F
 from torch import nn
 
 
@@ -49,9 +52,20 @@ class LoRALinear(nn.Module):
                 state_dict[new_key] = state_dict.pop(old_key)
         super()._load_from_state_dict(state_dict, prefix, *args, **kwargs)
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        # Optional forward-arg LoRA tensors (CoreML LoRA-as-IO Path 2). When
+        # both are provided, they override the stored lora_a/lora_b for this
+        # call. Default behavior (None, None) is unchanged.
+        lora_a: Optional[torch.Tensor] = None,
+        lora_b: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
         out = self.linear(x)
-        lora_out = self.lora_a(self.dropout(x))
-        lora_out = (self.alpha / self.rank) * self.lora_b(lora_out)
-
-        return out + lora_out
+        if lora_a is not None and lora_b is not None:
+            z = F.linear(self.dropout(x), lora_a)
+            z = (self.alpha / self.rank) * F.linear(z, lora_b)
+        else:
+            z = self.lora_a(self.dropout(x))
+            z = (self.alpha / self.rank) * self.lora_b(z)
+        return out + z

--- a/examples/models/llama/static_attention.py
+++ b/examples/models/llama/static_attention.py
@@ -1030,7 +1030,21 @@ class StaticAttention(Attention):
         if self.use_conv2d:
             x = x.reshape(bsz, -1, 1, dim).transpose(1, 3)
 
-        new_qs = [wq(x) for wq in self.wqs]
+        # CoreML LoRA-as-IO Path-2: when an upstream wrapper has stashed
+        # a per-key LoRA blob in attn_options, route per-projection slices
+        # to LoRALinear instances that have been tagged with `_lora_key`.
+        # Default behavior (no blob, or no `_lora_key`) is unchanged.
+        _lora_blob = kwargs.get("__lora_io_blob__")
+
+        def _lora_call(linear, x_in):
+            if _lora_blob is not None:
+                key = getattr(linear, "_lora_key", None)
+                if key is not None and key in _lora_blob:
+                    a, b = _lora_blob[key]
+                    return linear(x_in, a, b)
+            return linear(x_in)
+
+        new_qs = [_lora_call(wq, x) for wq in self.wqs]
 
         shared_kv = kwargs.get("shared_kv")
         if shared_kv is not None:
@@ -1040,8 +1054,8 @@ class StaticAttention(Attention):
             new_ks = []
             new_vs = []
         else:
-            new_ks = [wk(x) for wk in self.wks]
-            new_vs = [wv(x) for wv in self.wvs]
+            new_ks = [_lora_call(wk, x) for wk in self.wks]
+            new_vs = [_lora_call(wv, x) for wv in self.wvs]
 
         if self.use_conv2d:
 
@@ -1078,14 +1092,15 @@ class StaticAttention(Attention):
 
         if self.use_conv2d:
             y = (
-                self.wo(
-                    y.reshape(bsz, -1, 1, self.n_heads * self.head_dim).transpose(1, 3)
+                _lora_call(
+                    self.wo,
+                    y.reshape(bsz, -1, 1, self.n_heads * self.head_dim).transpose(1, 3),
                 )
                 .transpose(1, 3)
                 .reshape(bsz, -1, self.dim)
             )
         else:
-            y = self.wo(y)
+            y = _lora_call(self.wo, y)
 
         update = {"out_cache_state": out_cache_state}
         if kv_to_share is not None:


### PR DESCRIPTION
Summary:
For Llama4 CoreML multimethod LoRA exports, switch the model from "one ET
method per adapter, LoRA values baked into the partition" to "one ET method
shared across adapters, LoRA values supplied as forward() inputs and loaded
at runtime from per-adapter .ptd files."

How the model changed (gated on a new `--lora_runtime_swap` flag):

- Each `LoRALinear`'s stored `lora_a` / `lora_b` `nn.Linear` submodules are
  dropped pre-export; the canonical `LoRALinear.forward` accepts optional
  `lora_a` / `lora_b` tensor kwargs (backward-compat: default-None preserves
  the legacy behaviour for QNN / XNNPack and the existing baked-LoRA path).
- A new `Llama4LoRAIOWrapper` exposes a top-level
  `forward(tokens, attn_options, lora_blob)`. The wrapper unpacks `lora_blob`
  into a per-key dict and threads it through `attn_options["__lora_io_blob__"]`
  down to each LoRALinear (additive `kwargs.get` extraction in
  `StaticAttention.forward` and `LoRAFeedForward.forward`).
- Result: only `forward__prefill` / `forward__forward` ET methods are
  emitted, regardless of how many LoRA adapters are listed in the
  multimethod yaml. Each adapter produces its own
  `adapters/<name>.ptd` file (FlatTensor format keyed by
  `<fqn>.lora_a` / `<fqn>.lora_b`), plus a single `model.lora_keys.json`
  with the canonical FQN ordering.

All canonical-file edits are backward-compatible — without
`--lora_runtime_swap`, behaviour is identical to before.

Output layout:
```
model.pte
model.lora_keys.json
adapters/
  comms.ptd
  message_recall.ptd
  smart_reply.ptd
```

Runtime adapter swap (cria-side, not in this diff):

1. At boot, load `model.lora_keys.json` to get the canonical FQN list.
2. Compute the LoRA input-position offset:
   `idx_start = 1 (tokens) + N attn_options inputs`.
3. To switch adapter, open the new `.ptd` via
   `executorch::extension::FlatTensorDataMap::load(...)`, then iterate
   the FQN list and bind each tensor:
   ```cpp
   size_t idx = idx_start;
   for (const auto& key : keys) {
     auto a = data_map->get_data(key + ".lora_a");
     auto b = data_map->get_data(key + ".lora_b");
     module_->set_input("forward__prefill", wrap_as_tensor(std::move(a)), idx);
     module_->set_input("forward__forward", wrap_as_tensor(std::move(a)), idx);
     ++idx;
     module_->set_input("forward__prefill", wrap_as_tensor(std::move(b)), idx);
     module_->set_input("forward__forward", wrap_as_tensor(std::move(b)), idx);
     ++idx;
   }
   ```
4. Per token call: `module_->execute("forward__forward", tokens)` (and
   `forward__prefill` for prefill). No method-name swap.

Switch latency is bounded by `.ptd` mmap + `set_input` (sub-second on a
typical adapter); the compiled CoreML mlpackage is shared across adapters
so there is no recompile and no method reload.

Differential Revision: D105896960


