### PR TITLE
Add `grammar` and `grammar_type` fields to `GenerationConfig` (#19729)

### DIFF
--- a/examples/qualcomm/oss_scripts/llama/qnn_llama_runner.cpp
+++ b/examples/qualcomm/oss_scripts/llama/qnn_llama_runner.cpp
@@ -245,6 +245,8 @@ void start_runner(
   };
   executorch::extension::llm::GenerationConfig config{
       true,
+      "",
+      "",
       false,
       -1,
       false,

--- a/extension/llm/runner/irunner.h
+++ b/extension/llm/runner/irunner.h
@@ -33,6 +33,14 @@ struct GenerationConfig {
   // Whether to echo the input prompt in the output
   bool echo = true;
 
+  // Grammar definition for constrained decoding (e.g. a JSON schema, regex,
+  // Lark CFG, or GBNF grammar). Empty string means no constraint.
+  std::string grammar;
+
+  // Grammar format: "json_schema", "regex", "lark", or "gbnf".
+  // Only used when grammar is non-empty.
+  std::string grammar_type;
+
   // Whether to ignore EOS token and continue generating until max_new_tokens
   bool ignore_eos = false;
 


### PR DESCRIPTION
Summary:

Add `grammar` and `grammar_type` fields to `GenerationConfig` to support constrained decoding. `grammar` holds the grammar definition (e.g. a JSON schema, regex, Lark CFG, or GBNF grammar), and `grammar_type` specifies the format. These fields will be consumed by the constrained decoding pipeline to restrict token generation to valid outputs.

Reviewed By: psiddh

Differential Revision: D106007312




cc @larryliu0820 @mergennachin @cccclai @helunwencser @jackzhxng