### PR TITLE
Isolate macOS TorchInductor cache

### DIFF
--- a/.ci/scripts/unittest-macos-cmake.sh
+++ b/.ci/scripts/unittest-macos-cmake.sh
@@ -6,6 +6,12 @@
 # LICENSE file in the root directory of this source tree.
 set -eux
 
+# Keep AOTInductor precompiled headers scoped to this job. The default cache
+# location can persist across macOS self-hosted runner jobs and produce stale
+# PCH failures after PyTorch is reinstalled.
+export TORCHINDUCTOR_CACHE_DIR="$(mktemp -d "${RUNNER_TEMP:-/tmp}/torchinductor_cache_XXXXXX")"
+trap 'rm -rf "${TORCHINDUCTOR_CACHE_DIR}"' EXIT
+
 # Run pytest with coverage
 ${CONDA_RUN} pytest -n auto --cov=./ --cov-report=xml
 # Run gtest


### PR DESCRIPTION
Summary

Use a per-job TORCHINDUCTOR_CACHE_DIR for macOS CMake unit tests so AOTInductor does not reuse stale precompiled headers left on self-hosted macOS runners after PyTorch is reinstalled.


Test plan

bash -n .ci/scripts/unittest-macos-cmake.sh
git diff --check origin/main..HEAD

Authored with Claude.