### PR TITLE
NXP backend: Add `mean.dim` support with new Neutron flow.

### DIFF
--- a/backends/nxp/backend/edge_helper.py
+++ b/backends/nxp/backend/edge_helper.py
@@ -318,7 +318,7 @@ def is_no_op_on_neutron(node: Node, parameters_mapping: dict[str, Parameter]) ->
                         input_data = torch.rand(val.shape, dtype=val.dtype) * 10 - 5
                         args_with_random_data.append(input_data)
 
-                case list():
+                case list() if any(isinstance(a, Node) for a in arg):
                     # Lists of input nodes are not supported to keep the code simple. It is not crucial to support this
                     #  case as the affected operators are either not supported on Neutron, or are extremely unlikely to
                     #  be no-ops (e.g. GRU). One exception is `aten.cat`, which is explicitly supported above.

--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/max_pool2d_with_indices_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/max_pool2d_with_indices_converter.py
@@ -152,9 +152,7 @@ class MaxPool2DWithIndicesConverter(NodeConverter):
         :return: Tuple of (kernel_size, stride, padding, dilation, ceil_mode).
         """
         kernel_size = node.args[1]
-        stride = node.args[
-            2
-        ]  # The default value is equal to the kernel_size, so it is never empty here.
+        stride = try_get_arg(node, 2) or kernel_size
         padding = try_get_arg(node, 3) or (0, 0)
         dilation = try_get_arg(node, 4) or (1, 1)
         ceil_mode = try_get_arg(node, 5) or False

--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/mean_dim_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/mean_dim_converter.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import torch
+
 from executorch.backends.nxp.backend.data_format import NXP_NODE_FORMAT
 
 from executorch.backends.nxp.backend.ir.converter.conversion.translator import (
@@ -11,6 +12,7 @@ from executorch.backends.nxp.backend.ir.converter.conversion.translator import (
 )
 from executorch.backends.nxp.backend.ir.converter.node_converter import (
     CustomDelegationOptions,
+    is_not_qdq_node,
     NodeConverter,
 )
 from executorch.backends.nxp.backend.ir.converter.node_converters.shared.reduce_utils import (
@@ -21,10 +23,40 @@ from executorch.backends.nxp.backend.ir.tflite_generator.builtin_options import 
 )
 from executorch.backends.nxp.backend.neutron_target_spec import NeutronTargetSpec
 from torch.fx import Node
+from torch.fx.passes.infra.partitioner import Partition
 from torch.nn import Parameter
 
 
 class MeanDimConverter(NodeConverter):
+
+    @classmethod
+    def supports_partitioning_result(
+        cls,
+        node: Node,
+        partition_list: list[Partition],
+        custom_delegation_options: CustomDelegationOptions,
+        neutron_target_spec: NeutronTargetSpec,
+        parameters_mapping: dict[str, Parameter],
+    ) -> bool:
+        if custom_delegation_options.use_new_flow_neutron_c:
+            dim, keepdim = MeanDimConverter._get_attrs(node)
+            input_shape = node.args[0].meta["val"].shape
+
+            is_alone_in_partition = cls.is_node_alone_in_partition(
+                node, partition_list, filter_fn=is_not_qdq_node
+            )
+
+            if (
+                is_alone_in_partition
+                and keepdim
+                and all(input_shape[d] == 1 for d in dim)
+            ):
+                # The operator is a no-op, so the Neutron Converter will skip it. If it's the only node in the
+                #  partition, the graph would end up empty.
+                return False
+
+        return True
+
     @staticmethod
     def _is_supported_on_target(
         node: Node,
@@ -32,34 +64,49 @@ class MeanDimConverter(NodeConverter):
         parameters_mapping: dict[str, Parameter],
         custom_delegation_options: CustomDelegationOptions,
     ) -> bool:
-        keepdim = node.args[2] if len(node.args) >= 3 else False
-        rank = len(node.args[0].meta["val"].shape)
-        dim = [MeanDimConverter._to_pos_dim(d, rank) for d in node.args[1]]
+        if custom_delegation_options.use_new_flow_neutron_c:
+            # Requirements specified by the new Neutron flow documentation.
 
-        if rank != 4 or not keepdim:
-            # neutron-converter/src/OperatorC/GlobalAvgPoolPlugin.cpp#74-77
-            return False
-
-        # The `mean.dim` gets converted to AveragePool by the NeutronConverter, so the channels must be a
-        #  multiple of `num_macs`.
-        # neutron-converter/src/OperatorC/GlobalAvgPoolPlugin.cpp#59-85
-        num_macs = neutron_target_spec.get_num_macs()
-        channels_dim = 1 if node.meta[NXP_NODE_FORMAT].is_channels_first() else -1
-        if (node.meta["val"].shape[channels_dim] % num_macs) != 0:
-            return False
-
-        # Neutron only supports reduction over the spatial dimensions H, W.
-        if node.meta[NXP_NODE_FORMAT].is_channels_first():
-            # The input is NCHW. H and W are at indices 2 and 3.
-            if dim not in [[2, 3], [3, 2]]:
+            if not NodeConverter.uses_quantization_type_for_io(
+                node,
+                supported_types=[torch.int8, torch.uint8],
+                input_indices=[0],
+                output_indices=[0],
+            ):
                 return False
+
+            return True
+
         else:
-            # The input is formatless. It can be considered as NHWC, as this is the way Neutron will look at
-            #  the dimensions. So H and W are the middle dimensions.
-            if dim not in [[1, 2], [2, 1]]:
+            # Requirements of the old Neutron flow.
+            rank = len(node.args[0].meta["val"].shape)
+            dim, keepdim = MeanDimConverter._get_attrs(node)
+            dim = [MeanDimConverter._to_pos_dim(d, rank) for d in dim]
+
+            if rank != 4 or not keepdim:
+                # neutron-converter/src/OperatorC/GlobalAvgPoolPlugin.cpp#74-77
                 return False
 
-        return True
+            # The `mean.dim` gets converted to AveragePool by the NeutronConverter, so the channels must be a
+            #  multiple of `num_macs`.
+            # neutron-converter/src/OperatorC/GlobalAvgPoolPlugin.cpp#59-85
+            num_macs = neutron_target_spec.get_num_macs()
+            channels_dim = 1 if node.meta[NXP_NODE_FORMAT].is_channels_first() else -1
+            if (node.meta["val"].shape[channels_dim] % num_macs) != 0:
+                return False
+
+            # Neutron only supports reduction over the spatial dimensions H, W.
+            if node.meta[NXP_NODE_FORMAT].is_channels_first():
+                # The input is NCHW. H and W are at indices 2 and 3.
+                if dim not in [[2, 3], [3, 2]]:
+                    return False
+            else:
+                # The input is formatless. It can be considered as NHWC, as this is the way Neutron will look at
+                #  the dimensions. So H and W are the middle dimensions.
+                if dim not in [[1, 2], [2, 1]]:
+                    return False
+
+            return True
 
     @staticmethod
     def _is_supported_in_IR(
@@ -91,15 +138,29 @@ class MeanDimConverter(NodeConverter):
         perm = create_channels_last_to_channels_first_permutation(rank, True)
         dim = [perm[d] for d in dim]
 
+        # noinspection PyTypeChecker
         return dim
 
-    # Mean Dim Node format: (Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None)
-    def convert(self, node: Node):
-        """Convert 'mean.dim' operator to TFLite 'Mean'."""
-        self.assert_convertible(node)
-
+    @staticmethod
+    def _get_attrs(node: Node) -> tuple[list[int], bool]:
         dim = node.args[1]
         keepdim = node.args[2] if len(node.args) >= 3 else False
+        return dim, keepdim
+
+    def convert(self, node: Node):
+        """Convert the 'mean.dim' operator to NeutronIR 'Mean'.
+        The ExecuTorch schema is:
+            mean.dim(
+                Tensor self,
+                int[1]? dim,
+                bool keepdim=False,
+                *,
+                ScalarType? dtype=None
+            ) -> Tensor
+        """
+        self.assert_convertible(node)
+
+        dim, keepdim = self._get_attrs(node)
 
         t_op = self._create_tflite_op_with_io_tensors(node)
         t_op.builtin_options = mean_options.Mean(keepdim)

--- a/backends/nxp/tests/ir/converter/node_converter/test_mean_dim_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_mean_dim_converter.py
@@ -1,15 +1,18 @@
-# Copyright 2025 NXP
+# Copyright 2025-2026 NXP
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
 import numpy as np
+
+# noinspection PyUnusedImports
 import pytest
 import torch
 
 from executorch.backends.nxp.backend.edge_program_converter import (
     EdgeProgramToIRConverter,
 )
+from executorch.backends.nxp.tests.dataset_creator import RandomDatasetCreator
 from executorch.backends.nxp.tests.executorch_pipeline import to_quantized_edge_program
 from executorch.backends.nxp.tests.executors import (
     convert_run_compare,
@@ -17,10 +20,21 @@ from executorch.backends.nxp.tests.executors import (
     ToChannelFirstPreprocess,
     ToChannelLastPreprocess,
 )
+from executorch.backends.nxp.tests.graph_verifier import DetailedGraphVerifier
+from executorch.backends.nxp.tests.model_output_comparator import (
+    AllCloseOutputComparator,
+)
 from executorch.backends.nxp.tests.models import MeanDimConvModule, MeanDimLinearModule
-from executorch.backends.nxp.tests.use_qat import *  # noqa F403
-from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
+from executorch.backends.nxp.tests.ops_aliases import (
+    AddTensor,
+    ExecutorchDelegateCall,
+    GetItem,
+    MaxPool2DWithIndices,
+    MeanDim,
+)
 from torch.export import ExportedProgram
+from executorch.backends.nxp.tests.use_qat import *  # noqa F403
 
 
 @pytest.fixture(autouse=True)
@@ -37,6 +51,12 @@ class MeanDimModule(torch.nn.Module):
 
     def forward(self, x):
         return torch.mean(x, dim=self.dim, keepdim=self.keepdim)
+
+
+class MeanDimAddModule(MeanDimModule):
+    def forward(self, x):
+        x = super().forward(x)
+        return x + x
 
 
 @pytest.mark.parametrize(
@@ -60,7 +80,7 @@ def test_mean_dim_conv_quant_conversion(
         model, input_shape, use_qat=use_qat, use_neutron_for_format_conversion=False
     ).exported_program()
     # Make sure the `mean.dim` was delegated.
-    assert not graph_contains_any_of_ops(ep.graph, [exir_ops.edge.aten.mean.dim])
+    assert not graph_contains_any_of_ops(ep.graph, [MeanDim])
     assert any("lowered_module" in n.name for n in ep.graph.nodes)
 
     # Capture generated model
@@ -109,7 +129,7 @@ def test_mean_dim_linear_unsupported_quant_conversion(
     nodes = list(edge_program.graph.nodes)
 
     # Last 2 dimensions are not used or keepdim is False, cannot be converted to MeanDim, node is not delegated
-    assert nodes[6].target.__name__ == "aten.mean.dim"
+    assert nodes[6].target == MeanDim
 
     # Capture generated model
     tflite_flatbuffers_model, io_formats = converter_spy.spy_return
@@ -157,7 +177,7 @@ def test_mean_dim_conv_unsupported_quant_conversion(
     nodes = list(edge_program.graph.nodes)
 
     # Last 2 dimensions are not used or keepdim is False, cannot be converted to MeanDim, node is not delegated
-    assert nodes[6].target.__name__ == "aten.mean.dim"
+    assert nodes[6].target == MeanDim
 
     # Capture generated model
     tflite_flatbuffers_model, io_formats = converter_spy.spy_return
@@ -197,7 +217,7 @@ def test_mean_dim__formatless__supported(
     ).exported_program()
 
     # Make sure the `mean.dim` was delegated.
-    assert not graph_contains_any_of_ops(ep.graph, [exir_ops.edge.aten.mean.dim])
+    assert not graph_contains_any_of_ops(ep.graph, [MeanDim])
     assert any("lowered_module" in n.name for n in ep.graph.nodes)
 
     # Capture generated model
@@ -230,7 +250,7 @@ def test_mean_dim__formatless__unsupported(input_shape, dim, use_qat, keepdim=Tr
     ).exported_program()
 
     # Make sure the `mean.dim` was NOT delegated.
-    assert graph_contains_any_of_ops(ep.graph, [exir_ops.edge.aten.mean.dim])
+    assert graph_contains_any_of_ops(ep.graph, [MeanDim])
     assert not any("lowered_module" in n.name for n in ep.graph.nodes)
 
 
@@ -252,7 +272,7 @@ def test_mean_dim__formatless__unsupported_channels(
     ).exported_program()
 
     # Make sure the `mean.dim` was NOT delegated.
-    assert graph_contains_any_of_ops(ep.graph, [exir_ops.edge.aten.mean.dim])
+    assert graph_contains_any_of_ops(ep.graph, [MeanDim])
     assert not any("lowered_module" in n.name for n in ep.graph.nodes)
 
 
@@ -277,4 +297,181 @@ def test_mean_dim__channels_first__unsupported_channels(
     ).exported_program()
 
     # Make sure the `mean.dim` was NOT delegated.
-    assert graph_contains_any_of_ops(ep.graph, [exir_ops.edge.aten.mean.dim])
+    assert graph_contains_any_of_ops(ep.graph, [MeanDim])
+
+
+class MaxPoolMeanDimModule(torch.nn.Module):
+    def __init__(self, dim, keepdim):
+        super().__init__()
+        self.dim, self.keepdim = dim, keepdim
+
+    def forward(self, x):
+        x = torch.max_pool2d(
+            x, kernel_size=1
+        )  # NoOp, but it enforces the channels first format.
+        return torch.mean(x, dim=self.dim, keepdim=self.keepdim)
+
+
+class TestMeanDimNewNeutronFlow:
+
+    # noinspection PyMethodMayBeStatic
+    def assert_delegated(
+        self,
+        model,
+        input_shape,
+        mocker,
+        use_qat=False,
+        atol=None,
+        expected_delegated_ops=None,
+    ):
+        if expected_delegated_ops is None:
+            expected_delegated_ops = {MeanDim: 1}
+
+        graph_verifier = DetailedGraphVerifier(
+            mocker,
+            expected_delegated_ops=expected_delegated_ops,
+            expected_non_delegated_ops={},
+        )
+
+        # Cover also negative values to thoroughly test the operator.
+        dataset_creator = RandomDatasetCreator(low=-2, high=2)
+
+        kwargs = {"atol": atol} if atol is not None else {}
+        output_comparator = AllCloseOutputComparator(**kwargs)
+
+        lower_run_compare(
+            model,
+            input_shape,
+            graph_verifier,
+            dataset_creator,
+            output_comparator,
+            use_qat=use_qat,
+            use_new_flow_neutron_c=True,  # Use the new flow.
+        )
+
+    # noinspection PyMethodMayBeStatic
+    def assert_not_delegated(self, model, input_shape):
+        delegated_ep = to_quantized_edge_program(
+            model, input_shape, use_new_flow_neutron_c=True
+        ).exported_program()
+
+        # Make sure the `mean` was NOT delegated.
+        assert not graph_contains_any_of_ops(
+            delegated_ep.graph, [ExecutorchDelegateCall]
+        )
+        assert graph_contains_any_of_ops(delegated_ep.graph, [MeanDim])
+
+    @pytest.fixture(params=[True, False], ids=lambda keep_dim: f"keep_dim = {keep_dim}")
+    def keep_dim(self, request):
+        return request.param
+
+    def test__basic_nsys_inference__qat(self, mocker, use_qat, keep_dim):
+        input_shape = (23,)
+        model = MeanDimModule(0, keep_dim)
+        self.assert_delegated(model, input_shape, mocker, use_qat=use_qat)
+
+    @pytest.mark.parametrize(
+        "input_shape, dim",
+        [
+            pytest.param((5,), 0, id="1D, dim = 0."),
+            pytest.param((4, 2), 0, id="2D, dim = 0."),
+            pytest.param((4, 2), -1, id="2D, dim = -1."),
+            pytest.param((3, 1, 4), 2, id="3D, dim = 2."),
+            pytest.param((1, 3, 3, 7), 3, id="4D, dim = 3."),
+            pytest.param((3, 1, 4, 1, 5), -1, id="5D, dim = -1."),
+            pytest.param((3, 1, 4, 1, 5), 0, id="5D, dim = 0."),
+        ],
+    )
+    def test__single_dims(self, mocker, input_shape, dim, keep_dim):
+        model = MeanDimModule(dim, keep_dim)
+        # Relatively large error, but it is actually equal to the output scale, so it is a single bit error.
+        # TODO Replace with quantized dataset testing and `atol = 1`.
+        atol = 0.014
+        self.assert_delegated(model, input_shape, mocker, atol=atol)
+
+    @pytest.mark.parametrize(
+        "input_shape, dim",
+        [
+            pytest.param((4, 2), (-2,), id="2D, dim = (-2,)."),
+            pytest.param((2, 3, 4), (0, 2), id="3D, dim = (0, 2,)."),
+            pytest.param((1, 3, 3, 7), (2, -3), id="4D, dim = (2, -3)."),
+            pytest.param((3, 1, 4, 1, 5), (3, -5, -4), id="5D, dim = (3, -5 ,-4)."),
+        ],
+    )
+    def test__tuple_dims(self, mocker, input_shape, dim, keep_dim):
+        model = MeanDimModule(dim, keep_dim)
+        # Relatively large error, but it is actually equal to the output scale, so it is a single bit error.
+        # TODO Replace with quantized dataset testing and `atol = 1`.
+        atol = 0.015
+        self.assert_delegated(model, input_shape, mocker, atol=atol)
+
+    def test__compute_error(self, mocker, keep_dim):
+        input_shape, dim = (1, 3, 3, 7), -2
+        model = MeanDimModule(dim, keep_dim)
+
+        # Neutron produces an incorrect result in this case (maximum absolute error ~= 0.0607 (more than 2 * scale)).
+        # This test detects the failure to alert us once the bug is fixed. It should be fixed in Neutron 3.1.2.
+        with pytest.raises(AssertionError):
+            self.assert_delegated(model, input_shape, mocker, atol=0.06)
+
+    @pytest.mark.parametrize(
+        "input_shape, dim",
+        [
+            pytest.param((3, 1, 4), 1, id="3D, dim = 1."),
+            pytest.param((3, 1, 4, 1, 5), -2, id="5D, dim = -2."),
+        ],
+    )
+    def test__noop__only_node__not_delegated(self, input_shape, dim):
+        keep_dim = True  # Reduction over a dimension of size `1` with `keep_dim=True` is a no-op.
+        model = MeanDimModule(dim, keep_dim)
+        self.assert_not_delegated(model, input_shape)
+
+    @pytest.mark.parametrize(
+        "input_shape, dim",
+        [
+            pytest.param((3, 1, 4), 1, id="3D, dim = 1."),
+            pytest.param((3, 1, 4, 1, 5), -2, id="5D, dim = -2."),
+        ],
+    )
+    def test__noop__not_only_node__delegated(self, mocker, input_shape, dim):
+        keep_dim = True  # Reduction over a dimension of size `1` with `keep_dim=True` is a no-op.
+        model = MeanDimAddModule(dim, keep_dim)
+        self.assert_delegated(
+            model,
+            input_shape,
+            mocker,
+            expected_delegated_ops={MeanDim: 1, AddTensor: 1},
+        )
+
+    @pytest.mark.parametrize(
+        "input_shape, dim",
+        [
+            pytest.param((3, 1, 4), 1, id="3D, dim = 1."),
+            pytest.param((3, 1, 4, 1, 5), -2, id="5D, dim = -2."),
+        ],
+    )
+    def test__no_reduction__keepdim_false__delegated(self, mocker, input_shape, dim):
+        # These cases reduce over a dimension of size 1.
+        # When `keep_dim=True` the node is a noop, and it's not delegated (see `test__noop__only_node__not_delegated`),
+        # but with `keep_dim=False` it changes the shape so it's not a noop and is therefore delegated successfully.
+        keep_dim = False
+        model = MeanDimModule(dim, keep_dim)
+        self.assert_delegated(model, input_shape, mocker)
+
+    @pytest.mark.parametrize(
+        "input_shape, dim",
+        [((1, 7, 3, 3), 1)],
+        ids=lambda val: f"shape={val}" if isinstance(val, tuple) else f"dim={val}",
+    )
+    def test__channels_first(self, mocker, input_shape, dim, keep_dim):
+        # Just 1 test case to verify correct handling of the `dim`.
+        # Most cases fall into the single bit error case, and since this test uses 2 operators, the error accumulates
+        #  and the final error is larger. We cannot with 100% certainty say that the error is only caused by the single
+        #  bit errors and not related to the format. That's why only this 1 case with no errors is used.
+        model = MaxPoolMeanDimModule(dim, keep_dim)
+        self.assert_delegated(
+            model,
+            input_shape,
+            mocker,
+            expected_delegated_ops={MaxPool2DWithIndices: 1, GetItem: 1, MeanDim: 1},
+        )

--- a/backends/nxp/tests/ops_aliases.py
+++ b/backends/nxp/tests/ops_aliases.py
@@ -26,6 +26,7 @@ HardTanh = exir_ops.edge.aten.hardtanh.default
 HardTanh_ = exir_ops.edge.aten.hardtanh_.default
 LeakyRelu = exir_ops.edge.aten.leaky_relu.default
 MaxPool2DWithIndices = exir_ops.edge.aten.max_pool2d_with_indices.default
+MeanDim = exir_ops.edge.aten.mean.dim
 MulTensor = exir_ops.edge.aten.mul.Tensor
 QuantizePerChannel = exir_ops.edge.quantized_decomposed.quantize_per_channel.default
 QuantizePerTensor = exir_ops.edge.quantized_decomposed.quantize_per_tensor.default


### PR DESCRIPTION
### Summary
Add `mean.dim` support with new Neutron flow.

### Test plan
Unit tests provided.

cc @robert-kalmar @JakeStevens @digantdesai @rascani