### PR TITLE
Set test seed per-test

### DIFF
--- a/backends/cadence/aot/tests/test_replace_ops_passes.py
+++ b/backends/cadence/aot/tests/test_replace_ops_passes.py
@@ -1250,6 +1250,7 @@ class TestReplaceOpsPasses(unittest.TestCase):
             inputs,
             "ReplaceTrivialConvWithLinear",
             rtol=2e-5,
+            atol=5e-6,
         )
 
         # Assert that conv1d is trivially converted to linear
@@ -1294,6 +1295,7 @@ class TestReplaceOpsPasses(unittest.TestCase):
             inputs,
             "ReplaceTrivialConvWithLinear",
             rtol=2e-5,
+            atol=5e-6,
         )
 
         # Assert that conv2d is trivially converted to linear

--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,4 @@
+import hashlib
 import sys
 
 import torch
@@ -13,5 +14,8 @@ if sys.platform == "win32":
         "backends/apple/**",
     ]
 
-# Seed the run
-torch.manual_seed(42)
+
+def pytest_runtest_setup(item):
+    # Set a stable seed for each test based on a hash of the test name.
+    seed = int(hashlib.sha256(item.nodeid.encode()).hexdigest(), 16) % (2**32)
+    torch.manual_seed(seed)


### PR DESCRIPTION
### Summary
In https://github.com/pytorch/executorch/pull/19651, I added a global seed for pytest runs. This was intended to reduce random tolerance flakes, but didn't actually do so in practice. This is because the parallel test runners don't guarantee any ordering, so random state is unstable between runs.

I've updated it to set the seed per-test. This should hopefully make the random state invariant of test execution order.