### PR TITLE
Arm backend: Validate TOSA resize parameters

### DIFF
--- a/backends/arm/operator_support/TARGETS
+++ b/backends/arm/operator_support/TARGETS
@@ -6,6 +6,7 @@ runtime.python_library(
     deps = [
         "//executorch/backends/arm:constants",
         "//executorch/backends/arm/_passes:passes",
+        "//executorch/backends/arm/tosa:resize_utils",
         "//executorch/backends/arm/tosa:tosa",
         "//executorch/backends/transforms:remove_getitem_op",
         "//executorch/backends/xnnpack/_passes:xnnpack_passes",

--- a/backends/arm/operator_support/upsample_support.py
+++ b/backends/arm/operator_support/upsample_support.py
@@ -13,7 +13,51 @@ from executorch.backends.arm.operator_support.tosa_supported_operators import (
     SupportedTOSAOperatorCheck,
 )
 from executorch.backends.arm.tosa import TosaSpecification
+from executorch.backends.arm.tosa.resize_utils import get_tosa_resize_validation_error
 from executorch.exir.dialects._ops import ops as exir_ops
+
+
+def _is_upsample_node_tosa_supported(
+    support_check: SupportedTOSAOperatorCheck,
+    node: fx.Node,
+    tosa_spec: TosaSpecification,
+    *,
+    align_corners: bool,
+) -> bool:
+    input_node = ensure_type(fx.Node, node.args[0])
+    input_size_yx = get_first_fake_tensor(input_node).shape[2:]
+    output_size_yx = get_first_fake_tensor(node).shape[2:]
+
+    try:
+        scale_y_n, scale_y_d, offset_y, border_y = (
+            RewriteUpsamplePass.get_resize_parameters_1d(
+                input_size_yx[0], output_size_yx[0], align_corners
+            )
+        )
+        scale_x_n, scale_x_d, offset_x, border_x = (
+            RewriteUpsamplePass.get_resize_parameters_1d(
+                input_size_yx[1], output_size_yx[1], align_corners
+            )
+        )
+    except RuntimeError as err:
+        support_check.reporter.report_reject(node, str(err))
+        return False
+
+    # Validate the exact TOSA RESIZE parameters that RewriteUpsamplePass will
+    # emit so support checks and fake-op validation reject the same cases.
+    validation_error = get_tosa_resize_validation_error(
+        input_hw=input_size_yx,
+        output_hw=output_size_yx,
+        scale=[scale_y_n, scale_y_d, scale_x_n, scale_x_d],
+        offset=[offset_y, offset_x],
+        border=[border_y, border_x],
+        tosa_spec=tosa_spec,
+    )
+    if validation_error is not None:
+        support_check.reporter.report_reject(node, validation_error)
+        return False
+
+    return True
 
 
 @register_tosa_support_check
@@ -23,9 +67,11 @@ class UpsampleNearest2dSupported(SupportedTOSAOperatorCheck):
     targets = [exir_ops.edge.aten.upsample_nearest2d.vec]
 
     def is_node_tosa_supported(
-        self, _node: fx.Node, _tosa_spec: TosaSpecification
+        self, node: fx.Node, tosa_spec: TosaSpecification
     ) -> bool:  # type: ignore[override, misc]
-        return True
+        return _is_upsample_node_tosa_supported(
+            self, node, tosa_spec, align_corners=False
+        )
 
 
 @register_tosa_support_check
@@ -37,33 +83,9 @@ class UpsampleBilinear2dSupported(SupportedTOSAOperatorCheck):
     targets = [exir_ops.edge.aten.upsample_bilinear2d.vec]
 
     def is_node_tosa_supported(
-        self, node: fx.Node, _tosa_spec: TosaSpecification
+        self, node: fx.Node, tosa_spec: TosaSpecification
     ) -> bool:  # type: ignore[override, misc]
-        input_node = ensure_type(fx.Node, node.args[0])
         align_corners = ensure_type(bool, node.args[2])
-        input_size_yx = get_first_fake_tensor(input_node).shape[2:]
-        output_size_yx = get_first_fake_tensor(node).shape[2:]
-
-        try:
-            scale_y_n, scale_y_d, _, _ = RewriteUpsamplePass.get_resize_parameters_1d(
-                input_size_yx[0], output_size_yx[0], align_corners
-            )
-            scale_x_n, scale_x_d, _, _ = RewriteUpsamplePass.get_resize_parameters_1d(
-                input_size_yx[1], output_size_yx[1], align_corners
-            )
-        except RuntimeError as err:
-            self.reporter.report_reject(node, str(err))
-            return False
-
-        # get_resize_parameters_1d() returns the TOSA RESIZE scale fraction for
-        # each spatial dimension. For align_corners=False, this is the effective
-        # output_size / input_size ratio, so the 1/16 boundary is checked
-        # directly in the same representation that RESIZE lowering will use.
-        if scale_y_d >= 16 * scale_y_n or scale_x_d >= 16 * scale_x_n:
-            self.reporter.report_reject(
-                node,
-                "Bilinear RESIZE downscale must be strictly greater than 1/16",
-            )
-            return False
-
-        return True
+        return _is_upsample_node_tosa_supported(
+            self, node, tosa_spec, align_corners=align_corners
+        )

--- a/backends/arm/test/misc/tosa_dialect/test_tosa_resize.py
+++ b/backends/arm/test/misc/tosa_dialect/test_tosa_resize.py
@@ -33,13 +33,14 @@ def _expr(sym: torch.SymInt) -> sympy.Expr:
     return sympy.sympify(getattr(sym.node, "expr", sym.node._expr))
 
 
-def test_bilinear_resize_rejects_exact_one_sixteenth_downscale():
+@pytest.mark.parametrize("resize_mode", ("nearest", "bilinear"))
+def test_resize_rejects_exact_one_sixteenth_downscale(resize_mode: str):
     with TosaLoweringContext(
         TosaSpecification.create_from_string("TOSA-1.0+INT")
     ), FakeTensorMode() as mode:
         with pytest.raises(
             TosaValueError,
-            match="Bilinear RESIZE downscale must be strictly greater than 1/16",
+            match="RESIZE downscale must be strictly greater than 1/16",
         ):
             exir_ops.backend.tosa.RESIZE.default(
                 mode.from_tensor(
@@ -48,7 +49,26 @@ def test_bilinear_resize_rejects_exact_one_sixteenth_downscale():
                 [2, 32, 2, 32],
                 [15, 15],
                 [-15, -15],
-                resize_mode="bilinear",
+                resize_mode=resize_mode,
+            )
+
+
+def test_resize_rejects_scale_numerator_over_tosa_limit():
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.0+INT")
+    ), FakeTensorMode() as mode:
+        with pytest.raises(
+            TosaValueError,
+            match="RESIZE scale numerator must be <= 2048",
+        ):
+            exir_ops.backend.tosa.RESIZE.default(
+                mode.from_tensor(torch.randint(0, 10, (1, 3, 4, 2), dtype=torch.int8)),
+                # 2049 violates scale_n <= 1 << 11, while 2049/2 still stays
+                # within MAX_SCALE so this test isolates the numerator rule.
+                [2049, 2, 4, 2],
+                [0, 0],
+                [0, 0],
+                resize_mode="nearest",
             )
 
 

--- a/backends/arm/test/ops/test_upsample_nearest2d.py
+++ b/backends/arm/test/ops/test_upsample_nearest2d.py
@@ -198,6 +198,17 @@ def test_upsample_nearest2d_vec_tosa_FP_interpolate(test_data: torch.Tensor):
     pipeline.run()
 
 
+def test_upsample_nearest2d_vec_tosa_does_not_delegate_exact_one_sixteenth_downscale():
+    pipeline = OpNotSupportedPipeline[input_t1](
+        Interpolate(size=None, scale_factor=1.0 / 16.0),
+        (torch.randn(1, 3, 256, 448),),
+        {exir_op: 1},
+        n_expected_delegates=0,
+    )
+
+    pipeline.run()
+
+
 @common.parametrize("test_data", test_data_suite)
 def test_upsample_nearest2d_vec_tosa_INT(test_data: torch.Tensor):
     test_data, size, scale_factor, compare_outputs = test_data()

--- a/backends/arm/tosa/BUCK
+++ b/backends/arm/tosa/BUCK
@@ -42,6 +42,17 @@ fbcode_target(_kind = runtime.python_library,
 )
 
 fbcode_target(_kind = runtime.python_library,
+    name = "resize_utils",
+    srcs = [
+        "resize_utils.py",
+    ],
+    deps = [
+        "//caffe2:torch",
+        ":specification",
+    ],
+)
+
+fbcode_target(_kind = runtime.python_library,
     name = "tosa",
     srcs = [
         "__init__.py",

--- a/backends/arm/tosa/dialect/BUCK
+++ b/backends/arm/tosa/dialect/BUCK
@@ -22,6 +22,7 @@ fbcode_target(_kind = runtime.python_library,
     deps = [
         ":core",
         "//caffe2:torch",
+        "//executorch/backends/arm/tosa:resize_utils",
         "//executorch/backends/arm/tosa:tosa",
     ],
 )

--- a/backends/arm/tosa/dialect/ops/resize.py
+++ b/backends/arm/tosa/dialect/ops/resize.py
@@ -8,6 +8,10 @@ from typing import Literal
 import torch
 from executorch.backends.arm.tosa.dialect.lib import TosaValueError
 from executorch.backends.arm.tosa.dialect.ops_registration import register_fake_tosa_op
+from executorch.backends.arm.tosa.resize_utils import (
+    calculate_tosa_resize_output_hw,
+    get_tosa_resize_validation_error,
+)
 
 from executorch.backends.arm.tosa.specification import (
     get_context_spec,
@@ -50,23 +54,17 @@ def _get_output_dtype(
     return output_dtype
 
 
-def _validate_resize_parameters(scale, border, resize_mode):
-    def in_int16_range(values):
-        return all(
-            (x >= -(2**15)) and (x <= 2**15 - 1) for x in values if isinstance(x, int)
-        )
-
-    if not in_int16_range(scale):
-        raise TosaValueError("scale is out of the int16 range", op="RESIZE")
-    if not in_int16_range(border):
-        raise TosaValueError("border is out of the int16 range", op="RESIZE")
-    if resize_mode == "bilinear":
-        scale_y_n, scale_y_d, scale_x_n, scale_x_d = scale
-        if scale_y_d >= 16 * scale_y_n or scale_x_d >= 16 * scale_x_n:
-            raise TosaValueError(
-                "Bilinear RESIZE downscale must be strictly greater than 1/16",
-                op="RESIZE",
-            )
+def _validate_resize_parameters(input_hw, output_hw, scale, offset, border, tosa_spec):
+    validation_error = get_tosa_resize_validation_error(
+        input_hw=input_hw,
+        output_hw=output_hw,
+        scale=scale,
+        offset=offset,
+        border=border,
+        tosa_spec=tosa_spec,
+    )
+    if validation_error is not None:
+        raise TosaValueError(validation_error, op="RESIZE")
 
 
 @register_fake_tosa_op(
@@ -88,24 +86,26 @@ def RESIZE(
             f"Input tensor must be 4D, but got {x.dim()}D", op="RESIZE"
         )
     _validate_resize_mode(resize_mode)
-    _validate_resize_parameters(scale, border, resize_mode)
     output_dtype = _get_output_dtype(x.dtype, tosa_spec, resize_mode)
 
     input_shape = x.shape
-    scale_y_n, scale_y_d, scale_x_n, scale_x_d = scale
-    offset_y, offset_x = offset
-    border_y, border_x = border
     H, W = input_shape[1], input_shape[2]
-    # RESIZE first upscales the input by an integer value, to "upscale space".
-    H_upscaled = (H - 1) * scale_y_n
-    # offset and border are provided in this scale, therefore adjust for these while in this space.
-    H_shifted = H_upscaled - offset_y + border_y
-    # Then, complete the RESIZE by downscaling with another integer value, approximating multplication with a fraction.
-    OH = (H_shifted // scale_y_d) + 1
-    # Mirror the same computation horizontally for the output width.
-    W_upscaled = (W - 1) * scale_x_n
-    W_shifted = W_upscaled - offset_x + border_x
-    OW = (W_shifted // scale_x_d) + 1
+    _validate_resize_parameters((H, W), None, scale, offset, border, tosa_spec)
+    output_hw = calculate_tosa_resize_output_hw((H, W), scale, offset, border)
+    _validate_resize_parameters((H, W), output_hw, scale, offset, border, tosa_spec)
+    if output_hw is None:
+        scale_y_n, scale_y_d, scale_x_n, scale_x_d = scale
+        offset_y, offset_x = offset
+        border_y, border_x = border
+        # RESIZE first upscales the input by an integer value to "upscale
+        # space". Offset and border are encoded in that space, then RESIZE
+        # completes by downscaling with another integer value, approximating
+        # multiplication by a fraction.
+        OH = ((H - 1) * scale_y_n - offset_y + border_y) // scale_y_d + 1
+        OW = ((W - 1) * scale_x_n - offset_x + border_x) // scale_x_d + 1
+    else:
+        OH, OW = output_hw
+
     fake_aten_tensor = torch.empty(
         size=(input_shape[0], OH, OW, input_shape[3]), dtype=output_dtype
     )

--- a/backends/arm/tosa/resize_utils.py
+++ b/backends/arm/tosa/resize_utils.py
@@ -1,0 +1,259 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Sequence
+
+import torch
+
+from executorch.backends.arm.tosa.specification import TosaSpecification
+
+_MAX_RESIZE_DIMENSION = 16384
+_MAX_RESIZE_SCALE_NUMERATOR = 1 << 11
+_MAX_SCALE = 2048
+_MAX_SCALE_LEVEL_8K = 256
+_INT16_MIN = -(2**15)
+_INT16_MAX = 2**15 - 1
+
+
+def _as_concrete_ints(values: Sequence[int | torch.SymInt]) -> list[int] | None:
+    if all(isinstance(value, int) for value in values):
+        return [int(value) for value in values]
+    return None
+
+
+def _concrete_int_values(values: Sequence[int | torch.SymInt]) -> list[int]:
+    return [int(value) for value in values if isinstance(value, int)]
+
+
+def _first_outside_range(
+    values: Sequence[int], min_value: int, max_value: int
+) -> int | None:
+    return next(
+        (value for value in values if value < min_value or value > max_value), None
+    )
+
+
+def _max_scale(tosa_spec: TosaSpecification) -> int:
+    return _MAX_SCALE_LEVEL_8K if getattr(tosa_spec, "level_8k", False) else _MAX_SCALE
+
+
+def _validate_dimensions(
+    input_hw: Sequence[int | torch.SymInt],
+    output_hw: Sequence[int | torch.SymInt] | None,
+) -> str | None:
+    concrete_dimensions: list[int] = []
+    input_hw_ints = _as_concrete_ints(input_hw)
+    output_hw_ints = _as_concrete_ints(output_hw) if output_hw is not None else None
+    if input_hw_ints is not None:
+        concrete_dimensions.extend(input_hw_ints)
+    if output_hw_ints is not None:
+        concrete_dimensions.extend(output_hw_ints)
+
+    invalid_dimension = next(
+        (
+            dimension
+            for dimension in concrete_dimensions
+            if dimension >= _MAX_RESIZE_DIMENSION
+        ),
+        None,
+    )
+    if invalid_dimension is not None:
+        return (
+            "RESIZE dimensions must be less than "
+            f"{_MAX_RESIZE_DIMENSION}; got {invalid_dimension}"
+        )
+    return None
+
+
+def _validate_scale(
+    scale: Sequence[int | torch.SymInt],
+    tosa_spec: TosaSpecification,
+) -> str | None:
+    invalid_scale = _first_outside_range(
+        _concrete_int_values(scale), _INT16_MIN, _INT16_MAX
+    )
+    if invalid_scale is not None:
+        return (
+            "RESIZE scale must be in int16 range "
+            f"[{_INT16_MIN}, {_INT16_MAX}]; got {invalid_scale}"
+        )
+
+    scale_ints = _as_concrete_ints(scale)
+    if scale_ints is None:
+        return None
+
+    scale_y_n, scale_y_d, scale_x_n, scale_x_d = scale_ints
+    if min(scale_y_n, scale_y_d, scale_x_n, scale_x_d) <= 0:
+        return f"RESIZE scale values must be positive; got {scale_ints}"
+
+    max_scale = _max_scale(tosa_spec)
+    if scale_y_n > max_scale * scale_y_d or scale_x_n > max_scale * scale_x_d:
+        return (
+            f"RESIZE scale ratio must be <= MAX_SCALE ({max_scale}); "
+            f"got y={scale_y_n}/{scale_y_d}, x={scale_x_n}/{scale_x_d}"
+        )
+
+    if (
+        scale_y_n > _MAX_RESIZE_SCALE_NUMERATOR
+        or scale_x_n > _MAX_RESIZE_SCALE_NUMERATOR
+    ):
+        return (
+            "RESIZE scale numerator must be <= "
+            f"{_MAX_RESIZE_SCALE_NUMERATOR}; got y={scale_y_n}, x={scale_x_n}"
+        )
+
+    # The scale values are already in the doubled rational representation that
+    # TOSA RESIZE lowering emits, so the lower-bound downscale rule can be
+    # checked directly against them.
+    if scale_y_d >= 16 * scale_y_n or scale_x_d >= 16 * scale_x_n:
+        return (
+            "RESIZE downscale must be strictly greater than 1/16; "
+            f"got y={scale_y_n}/{scale_y_d}, x={scale_x_n}/{scale_x_d}"
+        )
+    return None
+
+
+def _validate_offset(
+    offset: Sequence[int | torch.SymInt],
+    scale_ints: list[int],
+) -> str | None:
+    offset_ints = _as_concrete_ints(offset)
+    if offset_ints is None:
+        return None
+
+    scale_y_n, _, scale_x_n, _ = scale_ints
+    offset_y, offset_x = offset_ints
+    if offset_y < -scale_y_n or offset_y >= 16 * scale_y_n:
+        return (
+            f"RESIZE offset_y must be in [{-scale_y_n}, {16 * scale_y_n}); "
+            f"got {offset_y}"
+        )
+    if offset_x < -scale_x_n or offset_x >= 16 * scale_x_n:
+        return (
+            f"RESIZE offset_x must be in [{-scale_x_n}, {16 * scale_x_n}); "
+            f"got {offset_x}"
+        )
+    return None
+
+
+def _validate_border(
+    border: Sequence[int | torch.SymInt],
+    scale_ints: list[int],
+) -> str | None:
+    invalid_border = _first_outside_range(
+        _concrete_int_values(border), _INT16_MIN, _INT16_MAX
+    )
+    if invalid_border is not None:
+        return (
+            "RESIZE border must be in int16 range "
+            f"[{_INT16_MIN}, {_INT16_MAX}]; got {invalid_border}"
+        )
+
+    border_ints = _as_concrete_ints(border)
+    if border_ints is None:
+        return None
+
+    scale_y_n, _, scale_x_n, _ = scale_ints
+    border_y, border_x = border_ints
+    if border_y < -16 * scale_y_n or border_y >= scale_y_n:
+        return (
+            f"RESIZE border_y must be in [{-16 * scale_y_n}, {scale_y_n}); "
+            f"got {border_y}"
+        )
+    if border_x < -16 * scale_x_n or border_x >= scale_x_n:
+        return (
+            f"RESIZE border_x must be in [{-16 * scale_x_n}, {scale_x_n}); "
+            f"got {border_x}"
+        )
+    return None
+
+
+def _validate_output_shape(
+    input_hw: Sequence[int | torch.SymInt],
+    output_hw: Sequence[int | torch.SymInt] | None,
+    scale: Sequence[int | torch.SymInt],
+    offset: Sequence[int | torch.SymInt],
+    border: Sequence[int | torch.SymInt],
+) -> str | None:
+    if output_hw is None:
+        return None
+
+    output_hw_ints = _as_concrete_ints(output_hw)
+    expected_output_hw = calculate_tosa_resize_output_hw(
+        input_hw, scale, offset, border
+    )
+    if (
+        output_hw_ints is not None
+        and expected_output_hw is not None
+        and tuple(output_hw_ints) != expected_output_hw
+    ):
+        return (
+            "RESIZE output shape is inconsistent with input and parameters; "
+            f"expected {expected_output_hw}, got {tuple(output_hw_ints)}"
+        )
+    return None
+
+
+def calculate_tosa_resize_output_hw(
+    input_hw: Sequence[int | torch.SymInt],
+    scale: Sequence[int | torch.SymInt],
+    offset: Sequence[int | torch.SymInt],
+    border: Sequence[int | torch.SymInt],
+) -> tuple[int, int] | None:
+    input_hw_ints = _as_concrete_ints(input_hw)
+    scale_ints = _as_concrete_ints(scale)
+    offset_ints = _as_concrete_ints(offset)
+    border_ints = _as_concrete_ints(border)
+    if (
+        input_hw_ints is None
+        or scale_ints is None
+        or offset_ints is None
+        or border_ints is None
+    ):
+        return None
+
+    input_h, input_w = input_hw_ints
+    scale_y_n, scale_y_d, scale_x_n, scale_x_d = scale_ints
+    offset_y, offset_x = offset_ints
+    border_y, border_x = border_ints
+
+    # RESIZE first upscales the input by an integer value to "upscale space".
+    # Offset and border are encoded in that space, then RESIZE completes by
+    # downscaling with another integer value, approximating multiplication by a
+    # fraction.
+    return (
+        ((input_h - 1) * scale_y_n - offset_y + border_y) // scale_y_d + 1,
+        ((input_w - 1) * scale_x_n - offset_x + border_x) // scale_x_d + 1,
+    )
+
+
+def get_tosa_resize_validation_error(
+    *,
+    input_hw: Sequence[int | torch.SymInt],
+    output_hw: Sequence[int | torch.SymInt] | None,
+    scale: Sequence[int | torch.SymInt],
+    offset: Sequence[int | torch.SymInt],
+    border: Sequence[int | torch.SymInt],
+    tosa_spec: TosaSpecification,
+) -> str | None:
+    scale_ints = _as_concrete_ints(scale)
+
+    validation_error = _validate_dimensions(input_hw, output_hw)
+    if validation_error is not None:
+        return validation_error
+    validation_error = _validate_scale(scale, tosa_spec)
+    if validation_error is not None:
+        return validation_error
+    if scale_ints is None:
+        return None
+
+    for validation_error in (
+        _validate_offset(offset, scale_ints),
+        _validate_border(border, scale_ints),
+        _validate_output_shape(input_hw, output_hw, scale, offset, border),
+    ):
+        if validation_error is not None:
+            return validation_error
+    return None


### PR DESCRIPTION
Re-upload with BUCK changes.

Share TOSA RESIZE parameter validation between upsample support checks and fake RESIZE lowering so invalid nearest and bilinear resize parameters are rejected before delegation.


Change-Id: I57c267aca96d733879ae90329267e44adce399c6


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani