### PR TITLE
ci: cap GITHUB_TOKEN to contents: read

### DIFF
--- a/.github/workflows/pending_user_response.yml
+++ b/.github/workflows/pending_user_response.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  issues: read
 
 jobs:
   needs-user-input:

--- a/.github/workflows/pending_user_response.yml
+++ b/.github/workflows/pending_user_response.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 8 * * 1'  # runs every Monday at 8:00 UTC
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   needs-user-input:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` at the workflow level. The workflow runs checks only; no GitHub API writes.

Same post-CVE-2025-30066 (`tj-actions/changed-files`) supply-chain hardening pattern. YAML validated locally with `yaml.safe_load`.