### PR TITLE
Arm backend: Fix missing init in VGFSetup

### DIFF
--- a/backends/arm/runtime/VGFSetup.cpp
+++ b/backends/arm/runtime/VGFSetup.cpp
@@ -793,9 +793,14 @@ bool VgfRepr::process_vgf(
     return false;
   }
 
-  vector<VkDataGraphPipelineSessionBindPointRequirementARM>
-      bind_point_requirements;
-  bind_point_requirements.resize(bind_point_count);
+  vector<VkDataGraphPipelineSessionBindPointRequirementARM> bind_point_requirements(
+      bind_point_count,
+      {
+          .sType =
+              VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_SESSION_BIND_POINT_REQUIREMENT_ARM,
+          .pNext = nullptr,
+      });
+
   result = vkGetDataGraphPipelineSessionBindPointRequirementsARM(
       vk_device,
       &bind_point_requirements_info,


### PR DESCRIPTION
As documented at
https://vkdoc.net/man/VkDataGraphPipelineSessionBindPointRequirementARM .stype of VkDataGraphPipelineSessionBindPointRequirementARM should alway be set to
VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_SESSION_BIND_POINT_REQUIREMENT_ARM

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani