### PR TITLE
Arm backend: Enable CPPCHECK for Cortex-M

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -112,6 +112,8 @@ include_patterns = [
     'backends/arm/**/*.cpp',
     'backends/arm/**/*.h',
     'backends/arm/**/*.hpp',
+    'backends/cortex_m/**/*.cpp',
+    'backends/cortex_m/**/*.h',
     'examples/arm/**/*.cpp',
     'examples/arm/**/*.h',
     'examples/arm/**/*.hpp',

--- a/backends/cortex_m/ops/cmsis_scratch_buffer_context.h
+++ b/backends/cortex_m/ops/cmsis_scratch_buffer_context.h
@@ -1,3 +1,4 @@
+// cppcheck-suppress-file unusedFunction
 /*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  * All rights reserved.

--- a/backends/cortex_m/ops/cortex_m_ops_common.h
+++ b/backends/cortex_m/ops/cortex_m_ops_common.h
@@ -113,8 +113,7 @@ inline void validate_quantization_params(
     const int64_t shift2,
     const int64_t output_zero_point,
     const int64_t output_multiplier,
-    const int64_t output_shift,
-    Tensor& output) {
+    const int64_t output_shift) {
   validate_single_quant_params(
       zero_point1, multiplier1, shift1, "Single quant Input1");
   validate_single_quant_params(
@@ -346,6 +345,7 @@ inline bool prepare_cmsis_pool2d_config(
 // https://github.com/ARM-software/CMSIS-NN/blob/main/Include/arm_nnsupportfunctions.h#L1625
 // multiplier: Range {ARM_NN_Q31_MIN + 1, Q32_MAX}
 // shift     : Range {-31, 30}
+// cppcheck-suppress unusedFunction
 inline bool validate_per_channel_quant_params(
     const Int64ArrayRef multipliers,
     const Int64ArrayRef shifts,

--- a/backends/cortex_m/ops/op_dequantize_per_tensor.cpp
+++ b/backends/cortex_m/ops/op_dequantize_per_tensor.cpp
@@ -100,6 +100,7 @@ F dequantize_val(float scale, int32_t zero_point, Q qvalue) {
 } // namespace
 
 Tensor& dequantize_per_tensor_out(
+    // cppcheck-suppress constParameterReference
     KernelRuntimeContext& context,
     const Tensor& input,
     double scale,

--- a/backends/cortex_m/ops/op_maximum.cpp
+++ b/backends/cortex_m/ops/op_maximum.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Arm Limited and/or its affiliates.
+ * Copyright 2025-2026 Arm Limited and/or its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
@@ -12,6 +12,7 @@ namespace native {
 
 using KernelRuntimeContext = torch::executor::KernelRuntimeContext;
 
+// cppcheck-suppress unusedFunction
 Tensor& maximum_out(
     KernelRuntimeContext& context,
     const Tensor& input1,

--- a/backends/cortex_m/ops/op_minimum.cpp
+++ b/backends/cortex_m/ops/op_minimum.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  * All rights reserved.
- * Copyright 2025 Arm Limited and/or its affiliates.
+ * Copyright 2025-2026 Arm Limited and/or its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
@@ -14,6 +14,7 @@ namespace native {
 
 using KernelRuntimeContext = torch::executor::KernelRuntimeContext;
 
+// cppcheck-suppress unusedFunction
 Tensor& minimum_out(
     KernelRuntimeContext& context,
     const Tensor& input1,

--- a/backends/cortex_m/ops/op_pad.cpp
+++ b/backends/cortex_m/ops/op_pad.cpp
@@ -19,6 +19,7 @@ constexpr size_t kMaxSupportedDims = 4;
 
 } // namespace
 
+// cppcheck-suppress unusedFunction
 Tensor& pad_out(
     KernelRuntimeContext& context,
     const Tensor& input,

--- a/backends/cortex_m/ops/op_quantize_per_tensor.cpp
+++ b/backends/cortex_m/ops/op_quantize_per_tensor.cpp
@@ -97,6 +97,7 @@ Q quantize_val(
 } // namespace
 
 Tensor& quantize_per_tensor_out(
+    // cppcheck-suppress constParameterReference
     KernelRuntimeContext& context,
     const Tensor& input,
     double scale,

--- a/backends/cortex_m/ops/op_quantized_add.cpp
+++ b/backends/cortex_m/ops/op_quantized_add.cpp
@@ -13,6 +13,7 @@ namespace cortex_m {
 namespace native {
 using KernelRuntimeContext = torch::executor::KernelRuntimeContext;
 
+// cppcheck-suppress unusedFunction
 Tensor& quantized_add_out(
     KernelRuntimeContext& context,
     const Tensor& input1_int8,
@@ -49,8 +50,7 @@ Tensor& quantized_add_out(
       input2_shift,
       output_zero_point,
       output_multiplier,
-      output_shift,
-      out);
+      output_shift);
 
   ET_LOG(
       Debug,

--- a/backends/cortex_m/ops/op_quantized_avg_pool2d.cpp
+++ b/backends/cortex_m/ops/op_quantized_avg_pool2d.cpp
@@ -12,6 +12,7 @@ namespace native {
 
 using KernelRuntimeContext = torch::executor::KernelRuntimeContext;
 
+// cppcheck-suppress unusedFunction
 Tensor& quantized_avg_pool2d_out(
     KernelRuntimeContext& context,
     const Tensor& input,

--- a/backends/cortex_m/ops/op_quantized_batch_matmul.cpp
+++ b/backends/cortex_m/ops/op_quantized_batch_matmul.cpp
@@ -62,6 +62,7 @@ bool validate_batch_matmul_arguments(
 
 } // namespace
 
+// cppcheck-suppress unusedFunction
 Tensor& quantized_batch_matmul_out(
     KernelRuntimeContext& context,
     const Tensor& lhs,

--- a/backends/cortex_m/ops/op_quantized_conv2d.cpp
+++ b/backends/cortex_m/ops/op_quantized_conv2d.cpp
@@ -98,6 +98,7 @@ bool validate_conv2d_arguments(
 }
 } // namespace
 
+// cppcheck-suppress unusedFunction
 Tensor& quantized_conv2d_out(
     KernelRuntimeContext& context,
     const Tensor& input,

--- a/backends/cortex_m/ops/op_quantized_depthwise_conv2d.cpp
+++ b/backends/cortex_m/ops/op_quantized_depthwise_conv2d.cpp
@@ -135,6 +135,7 @@ bool validate_depthwise_conv2d_arguments(
 }
 } // namespace
 
+// cppcheck-suppress unusedFunction
 Tensor& quantized_depthwise_conv2d_out(
     KernelRuntimeContext& context,
     const Tensor& input,

--- a/backends/cortex_m/ops/op_quantized_linear.cpp
+++ b/backends/cortex_m/ops/op_quantized_linear.cpp
@@ -13,6 +13,7 @@ namespace cortex_m {
 namespace native {
 using KernelRuntimeContext = torch::executor::KernelRuntimeContext;
 
+// cppcheck-suppress unusedFunction
 Tensor& quantized_linear_out(
     KernelRuntimeContext& context,
     const Tensor& input,

--- a/backends/cortex_m/ops/op_quantized_max_pool2d.cpp
+++ b/backends/cortex_m/ops/op_quantized_max_pool2d.cpp
@@ -10,6 +10,7 @@
 namespace cortex_m {
 namespace native {
 
+// cppcheck-suppress unusedFunction
 Tensor& quantized_max_pool2d_out(
     KernelRuntimeContext& context,
     const Tensor& input,

--- a/backends/cortex_m/ops/op_quantized_mul.cpp
+++ b/backends/cortex_m/ops/op_quantized_mul.cpp
@@ -18,6 +18,7 @@ constexpr int32_t kInt8ActivationMax = std::numeric_limits<int8_t>::max();
 
 using KernelRuntimeContext = torch::executor::KernelRuntimeContext;
 
+// cppcheck-suppress unusedFunction
 Tensor& quantized_mul_out(
     KernelRuntimeContext& context,
     const Tensor& input1_int8,
@@ -50,8 +51,7 @@ Tensor& quantized_mul_out(
       kZeroShift,
       output_zero_point,
       output_multiplier,
-      output_shift,
-      out);
+      output_shift);
 
   // Extract quantization parameters
   int8_t* input1_ptr = input1_int8.data_ptr<int8_t>();

--- a/backends/cortex_m/ops/op_quantized_transpose_conv2d.cpp
+++ b/backends/cortex_m/ops/op_quantized_transpose_conv2d.cpp
@@ -82,6 +82,7 @@ bool validate_transpose_conv2d_arguments(
 }
 } // namespace
 
+// cppcheck-suppress unusedFunction
 Tensor& quantized_transpose_conv2d_out(
     KernelRuntimeContext& context,
     const Tensor& input,

--- a/backends/cortex_m/ops/op_softmax.cpp
+++ b/backends/cortex_m/ops/op_softmax.cpp
@@ -36,6 +36,7 @@ inline int64_t normalize_dim(const Tensor& tensor, int64_t dim) {
 
 } // namespace
 
+// cppcheck-suppress unusedFunction
 Tensor& softmax_out(
     KernelRuntimeContext& context,
     const Tensor& input,

--- a/backends/cortex_m/ops/op_transpose.cpp
+++ b/backends/cortex_m/ops/op_transpose.cpp
@@ -22,6 +22,7 @@ constexpr size_t kMaxSupportedDims = 4;
 
 } // namespace
 
+// cppcheck-suppress unusedFunction
 Tensor& transpose_out(
     KernelRuntimeContext& context,
     const Tensor& input,


### PR DESCRIPTION
Enable CPPCHECK for Cortex-M sources and headers. The Cortex-M kernels are registered through generated wrappers, so cppcheck cannot see direct call sites for the exported *_out entry points and reports them as unused. Keep narrow unusedFunction suppressions for those registration-visible functions.

The scratch buffer context header is linted as a standalone header but currently exposes helper API without in-tree call sites, so suppress unusedFunction at file scope there instead of dropping Cortex-M header coverage.

Keep the quantize and dequantize context parameters non-const to match the generated kernel ABI; changing them to const changes the mangled symbols used by registration.

Signed-off-by: Per Held <per.held@arm.com>

Change-Id: I3bcb6e5d3f125ae400005d1b033b24a07eb7924f


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani