### PR TITLE
Arm backend: Add cmsis_nn fallback example

### DIFF
--- a/examples/arm/ethos_u_cmsis_nn_fallback_example.ipynb
+++ b/examples/arm/ethos_u_cmsis_nn_fallback_example.ipynb
@@ -1,0 +1,266 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Copyright 2026 Arm Limited and/or its affiliates.\n",
+    "#\n",
+    "# This source code is licensed under the BSD-style license found in the\n",
+    "# LICENSE file in the root directory of this source tree."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Ethos-U55 with CMSIS-NN fallback example\n",
+    "\n",
+    "This guide demonstrates the current full flow for handling operators which does not lower\n",
+    "to the Ethos-U55 using the Cortex-M backend to make sure they use accelerated CMSIS-NN implementations.\n",
+    "\n",
+    "The basic idea is that the Ethos-U backend will reject any nodes which are not supported,\n",
+    "leaving them to be handled by the Cortex-M backend. It is however important to note that\n",
+    "the \n",
+    "\n",
+    "Before you begin: Make sure you have completed the `ethos_u_minimal_example` for a\n",
+    "basic understanding of the Ethos-U backend and have your environment setup. \n",
+    "\n",
+    "\n",
+    "*Some scripts in this notebook produces long output logs: Configuring the 'Customizing Notebook Layout' settings to enable 'Output:scrolling' and setting 'Output:Text Line Limit' makes this more manageable*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "The first step is creating a simple model which does not fully lower to the Ethos-U55.\n",
+    "Importantly it is exported with channels_last data, since the Cortex-M backend currently\n",
+    "only supports lowering operators in that data-format.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "from executorch.backends.arm.ethosu import EthosUCompileSpec, EthosUPartitioner\n",
+    "from executorch.backends.arm.quantizer import (\n",
+    "    EthosUQuantizer,\n",
+    "    get_symmetric_quantization_config,\n",
+    ")\n",
+    "from executorch.backends.cortex_m.passes.cortex_m_pass_manager import CortexMPassManager\n",
+    "from executorch.exir import (\n",
+    "    EdgeCompileConfig,\n",
+    "    ExecutorchBackendConfig,\n",
+    "    to_edge_transform_and_lower,\n",
+    ")\n",
+    "from executorch.extension.export_util.utils import save_pte_program\n",
+    "from torchao.quantization.pt2e.quantize_pt2e import convert_pt2e, prepare_pt2e\n",
+    "\n",
+    "target = \"ethos-u55-128\"\n",
+    "output_path = \"ethos_u_cmsis_nn_fallback_example.pte\"\n",
+    "\n",
+    "class ToyMixedModule(torch.nn.Module):\n",
+    "    def __init__(self):\n",
+    "        super().__init__()\n",
+    "        self.conv1 = torch.nn.Conv2d(\n",
+    "            in_channels=3,\n",
+    "            out_channels=4,\n",
+    "            kernel_size=3,\n",
+    "            stride=1,\n",
+    "            padding=1,\n",
+    "            bias=False,\n",
+    "        )\n",
+    "        self.conv2 = torch.nn.Conv2d(\n",
+    "            in_channels=4,\n",
+    "            out_channels=1,\n",
+    "            kernel_size=3,\n",
+    "            stride=4,\n",
+    "            padding=1,\n",
+    "            bias=False,\n",
+    "        ) # Stride=4 not supported on Ethos-U55\n",
+    "\n",
+    "    def forward(self, x: torch.Tensor) -> torch.Tensor:\n",
+    "        x = self.conv1(x)\n",
+    "        x = torch.relu(x)\n",
+    "        return self.conv2(x)\n",
+    "\n",
+    "model = ToyMixedModule().eval().to(memory_format=torch.channels_last)\n",
+    "example_inputs = (\n",
+    "    torch.randn(1, 3, 8, 8, dtype=torch.float32).to(memory_format=torch.channels_last),\n",
+    ")\n",
+    "exported_program = torch.export.export(model, example_inputs)\n",
+    "exported_program.module().graph.print_tabular()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Ethos-U lowering\n",
+    "\n",
+    "The Ethos-U lowering of the model is identical to the minimal example, and as expected\n",
+    "the printed graph leaves the transposed convolution and some quantization/dequantization nodes\n",
+    "outside of the Ethos_u call_delegate operator. \n",
+    "\n",
+    "One important part in this step is that the transposed convolution has been quantized to\n",
+    "a format supported by the Cortex-M backend by the Ethos-U quantizer even if it was not\n",
+    "delegated, since the Cortex-M backend will only lower correctly quantized operators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "compile_spec = EthosUCompileSpec(target=target)\n",
+    "quantizer = EthosUQuantizer(compile_spec)\n",
+    "quantizer.set_global(get_symmetric_quantization_config(is_per_channel=True))\n",
+    "\n",
+    "prepared = prepare_pt2e(exported_program.module(), quantizer)\n",
+    "prepared(*example_inputs)\n",
+    "quantized_model = convert_pt2e(prepared)\n",
+    "quantized_exported_program = torch.export.export(quantized_model, example_inputs)\n",
+    "\n",
+    "edge_program_manager = to_edge_transform_and_lower(\n",
+    "    quantized_exported_program,\n",
+    "    partitioner=[EthosUPartitioner(compile_spec)],\n",
+    "    compile_config=EdgeCompileConfig(_check_ir_validity=False),\n",
+    ")\n",
+    "\n",
+    "edge_program_manager.exported_program().graph_module.graph.print_tabular()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Cortex-M lowering\n",
+    "\n",
+    "Finally the Cortex-M backend is applied, and the graph is now fully accelerated. The\n",
+    "cortex_m kernels can be spotted in the printed graph."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "edge_program_manager._edge_programs[\"forward\"] = CortexMPassManager(\n",
+    "     edge_program_manager.exported_program()\n",
+    ").transform()\n",
+    "\n",
+    "executorch_program = edge_program_manager.to_executorch(\n",
+    "     config=ExecutorchBackendConfig(extract_delegate_segments=False)\n",
+    ")\n",
+    "save_pte_program(executorch_program, output_path)\n",
+    "\n",
+    "edge_program_manager.exported_program().graph_module.graph.print_tabular()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Build\n",
+    "\n",
+    "The executor runner is built as usual, making sure to link the Cortex-M dependencies. Cortex-M kernels and \n",
+    "kernel registrations are linked in the available example executor_runner CMakeLists are named\n",
+    "`cortex_m_kernels` and `cortex_m_ops_lib`, corresponding to the unaccelerated portable\n",
+    "kernels `portable_kernels` and `arm_portable_ops_lib`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash \n",
+    "source arm-scratch/setup_path.sh\n",
+    "# Ensure CMake resolves the ExecuTorch checkout root regardless of caller env\n",
+    "export EXECUTORCH_ROOT=$(cd ../.. && pwd)\n",
+    "\n",
+    "# Build example executor runner application to examples/arm/ethos_u_cmsis_nn_fallback_example\n",
+    "cmake -DCMAKE_TOOLCHAIN_FILE=$(pwd)/ethos-u-setup/arm-none-eabi-gcc.cmake \\\n",
+    "      -DCMAKE_BUILD_TYPE=Release \\\n",
+    "      -DET_PTE_FILE_PATH=ethos_u_cmsis_nn_fallback_example.pte \\\n",
+    "      -DTARGET_CPU=cortex-m55 \\\n",
+    "      -DETHOSU_TARGET_NPU_CONFIG=ethos-u55-128 \\\n",
+    "      -DMEMORY_MODE=Shared_Sram \\\n",
+    "      -DSYSTEM_CONFIG=Ethos_U55_High_End_Embedded \\\n",
+    "      -Bethos_u_cmsis_nn_fallback_example \\\n",
+    "      -S executor_runner/standalone\n",
+    "cmake --build ethos_u_cmsis_nn_fallback_example -j$(nproc) -- arm_executor_runner"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Sanity check output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[0.4067230820655823, 0.5054132342338562, 0.23625826835632324, 0.22429582476615906]\n",
+      "[0.406723, 0.505413, 0.236258, 0.224296]\n"
+     ]
+    }
+   ],
+   "source": [
+    "import subprocess\n",
+    "import re\n",
+    "\n",
+    "# Use quantized model in eager mode as reference. By default the executor runner will use 1:s as input.\n",
+    "test_inputs = (torch.ones_like(example_inputs[0]),)\n",
+    "reference_result = quantized_exported_program.module()(*test_inputs).flatten().tolist()\n",
+    "\n",
+    "# Run the lowered .pte file on FVP using helper script and extract the output numbers using regex\n",
+    "fvp_output = subprocess.run(\"../../backends/arm/scripts/run_fvp.sh --elf=ethos_u_cmsis_nn_fallback_example/arm_executor_runner --target=ethos-u55-128\", shell=True, capture_output=True)\n",
+    "lowered_result = [float(x) for x in re.findall(\"-?\\d\\.\\d{6}\" , str(fvp_output.stdout))]\n",
+    "\n",
+    "print(reference_result)\n",
+    "print(lowered_result)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv (3.10.15)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/arm/ethos_u_cmsis_nn_fallback_example.ipynb
+++ b/examples/arm/ethos_u_cmsis_nn_fallback_example.ipynb
@@ -19,8 +19,7 @@
     "# Ethos-U55 with CMSIS-NN fallback example\n",
     "\n",
     "This guide demonstrates the current full flow for handling operators which does not lower\n",
-    "to the Ethos-U55 using the Cortex-M backend to make sure they use accelerated CMSIS-NN implementations.\n",
-    "\n",
+    "to the Ethos-U55 using the Cortex-M backend to make sure they use accelerated CMSIS-NN implementations. \n",
     "The basic idea is that the Ethos-U backend will reject any nodes which are not supported,\n",
     "leaving them to be handled by the Cortex-M backend.\n",
     "\n",
@@ -39,7 +38,11 @@
     "\n",
     "The first step is creating a simple model which does not fully lower to the Ethos-U55.\n",
     "Importantly it is exported with channels_last data, since the Cortex-M backend currently\n",
-    "only supports lowering operators in that data-format.  "
+    "only supports lowering operators in that data-format.  \n",
+    "\n",
+    "Constraints for the basic operations performed by the Ethos-U55 can be found in the\n",
+    "[Ethos-U Vela repository](https://gitlab.arm.com/artificial-intelligence/ethos-u/ethos-u-vela/-/blob/main/SUPPORTED_OPS.md?ref_type=heads#ethos-u55-and-ethos-u65-tosa-conv2d-constraints). Note that the listed operators does not map exactly to PyTorch operators, but rather a subset found in\n",
+    "the graph after decompositions in the Ethos-U backend."
    ]
   },
   {
@@ -111,7 +114,9 @@
     "\n",
     "One important part in this step is that this `torch.nn.Conv2d` with `stride=4` has been quantized to\n",
     "a format supported by the Cortex-M backend by the Ethos-U quantizer even if it was not\n",
-    "delegated, since the Cortex-M backend will only lower correctly quantized operators."
+    "delegated, since the Cortex-M backend will only lower correctly quantized operators. Would there be\n",
+    "a discrepancy, see the [quantizer tutorial](https://github.com/pytorch/executorch/blob/main/examples/arm/quantizer_tutorial.ipynb) for\n",
+    "how to configure more precise quantization."
    ]
   },
   {
@@ -145,7 +150,7 @@
     "# Cortex-M lowering\n",
     "\n",
     "Finally the Cortex-M backend is applied, and the graph is now fully accelerated. The\n",
-    "cortex_m kernels can be spotted in the printed graph."
+    "`cortex_m_kernels` can be spotted in the printed graph."
    ]
   },
   {
@@ -173,10 +178,11 @@
    "source": [
     "## Build\n",
     "\n",
-    "The executor runner is built as usual, making sure to link the Cortex-M dependencies. Cortex-M kernels and \n",
-    "kernel registrations are linked in the available example executor_runner CMakeLists are named\n",
-    "`cortex_m_kernels` and `cortex_m_ops_lib`, corresponding to the unaccelerated portable\n",
-    "kernels `portable_kernels` and `arm_portable_ops_lib`.\n"
+    "The executor runner is built as usual, making sure to link the Cortex-M dependencies. In the available\n",
+    "example executor_runner CMakeFile this is already done, with the Cortex-M kernel and kernel registration libraries\n",
+    "`cortex_m_kernels` and `cortex_m_ops_lib` corresponding to `portable_kernels` and `arm_portable_ops_lib` for the the\n",
+    "unaccelerated portable kernels. For more information about kernel registration, see the\n",
+    "[documentation](https://docs.pytorch.org/executorch/stable/kernel-library-custom-aten-kernel.html).\n"
    ]
   },
   {

--- a/examples/arm/ethos_u_cmsis_nn_fallback_example.ipynb
+++ b/examples/arm/ethos_u_cmsis_nn_fallback_example.ipynb
@@ -22,8 +22,7 @@
     "to the Ethos-U55 using the Cortex-M backend to make sure they use accelerated CMSIS-NN implementations.\n",
     "\n",
     "The basic idea is that the Ethos-U backend will reject any nodes which are not supported,\n",
-    "leaving them to be handled by the Cortex-M backend. It is however important to note that\n",
-    "the \n",
+    "leaving them to be handled by the Cortex-M backend.\n",
     "\n",
     "Before you begin: Make sure you have completed the `ethos_u_minimal_example` for a\n",
     "basic understanding of the Ethos-U backend and have your environment setup. \n",
@@ -107,10 +106,10 @@
     "# Ethos-U lowering\n",
     "\n",
     "The Ethos-U lowering of the model is identical to the minimal example, and as expected\n",
-    "the printed graph leaves the transposed convolution and some quantization/dequantization nodes\n",
+    "the printed graph leaves the regular `torch.nn.Conv2d` with `stride=4` and some quantization/dequantization nodes\n",
     "outside of the Ethos_u call_delegate operator. \n",
     "\n",
-    "One important part in this step is that the transposed convolution has been quantized to\n",
+    "One important part in this step is that this `torch.nn.Conv2d` with `stride=4` has been quantized to\n",
     "a format supported by the Cortex-M backend by the Ethos-U quantizer even if it was not\n",
     "delegated, since the Cortex-M backend will only lower correctly quantized operators."
    ]
@@ -213,18 +212,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[0.4067230820655823, 0.5054132342338562, 0.23625826835632324, 0.22429582476615906]\n",
-      "[0.406723, 0.505413, 0.236258, 0.224296]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import subprocess\n",
     "import re\n",


### PR DESCRIPTION
Describes how the Ethos-U and Cortex-M backend can be used together to accelerate e.g. op configurations not supported on Ethos-U55, and common pitfalls to consider in doing this.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani