### PR TITLE
Increase iOS device test timeout on release branch

### DIFF
--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -161,6 +161,7 @@ jobs:
       device-type: ios
       # For iOS testing, the runner just needs to call AWS Device Farm, so there is no need to run this on macOS
       runner: linux.2xlarge
+      timeout: 120
       test-infra-ref: ''
       # This is the ARN of ExecuTorch project on AWS
       project-arn: arn:aws:devicefarm:us-west-2:308535385114:project:02a2cf0f-6d9b-45ee-ba1a-a086587469e6


### PR DESCRIPTION
Summary:\n- pass timeout: 120 to the iOS Device Farm test job in apple.yml\n\nThis is needed because the v1.3.0-rc1 Apple run built and uploaded the iOS artifacts, but the iOS device test was cancelled at the default 60 minute mobile_job timeout.\n\nAuthored with Claude.