### PR TITLE
[pytorch/executorch][diff_train] Arm backend: Exclude build metadata from license checks

### DIFF
--- a/backends/arm/scripts/pre-push
+++ b/backends/arm/scripts/pre-push
@@ -177,7 +177,7 @@ for COMMIT in ${COMMITS}; do
     for committed_file in "${license_files[@]}"; do
         # Skip files with certain extensions
         case "$committed_file" in
-            *.md|*.md.in|*.json|*.yml|*.yaml|*.cmake|*.patch|.gitignore|*.bzl)
+            *.md|*.md.in|*.json|*.yml|*.yaml|*.cmake|*.patch|.gitignore|*.bzl|BUCK|*/BUCK|TARGETS|*/TARGETS)
                 echo -e "${INFO} Skipping license check for ${committed_file} (excluded extension)"
                 continue
                 ;;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #19783
* #19782
* #19781
* #19780
* __->__ #19779
* #19778

Treat BUCK and TARGETS files as build metadata in the Arm
pre-push license check so they do not need copyright headers.

Signed-off-by: Per Held <per.held@arm.com>
Change-Id: I4b3bbd1e03ba4b9c38fd06225156344985f0cc70


Internal:
<< DO NOT EDIT BELOW THIS LINE >>

**GitHub Author**: Per Held <per.held@arm.com>
**GitHub Repo**: [pytorch/executorch](https://github.com/pytorch/executorch)
**GitHub Pull Request**: [#19754](https://github.com/pytorch/executorch/pull/19754)

Initially generated by: https://www.internalfb.com/intern/sandcastle/job/49539596320638614/

This was imported as part of a DiffTrain.
Please review this as soon as possible. Since it is a direct copy of a commit on
GitHub, there shouldn't be much to do.

diff-train-source-id: ee4c90ad03f33398cbfa93cfed09caf04fca6099

Differential Revision: [D106292543](https://our.internmc.facebook.com/intern/diff/D106292543/)