### PR TITLE
Collapse Experimental.kt annotation onto a single line to satisfy linter

### DIFF
--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/annotations/Experimental.kt
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/annotations/Experimental.kt
@@ -15,5 +15,4 @@ package org.pytorch.executorch.annotations
  * This status is not permanent, and APIs marked with this annotation will need to be either made
  * more robust or removed in the future.
  */
-@Retention(AnnotationRetention.BINARY)
-annotation class Experimental
+@Retention(AnnotationRetention.BINARY) annotation class Experimental


### PR DESCRIPTION
Summary:
Linter wants the Retention annotation and the annotation class
declaration on a single line.

Differential Revision: D106430647


