### PR TITLE
NXP backend: Enable `aten.upsample_bilinear2d` with new Neutron flow.

### DIFF
--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/upsample_bilinear2d_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/upsample_bilinear2d_converter.py
@@ -4,11 +4,13 @@
 # LICENSE file in the root directory of this source tree.
 
 import numpy as np
+import torch
 
 from executorch.backends.nxp.backend.data_format import DataFormat, NXP_NODE_FORMAT
 from executorch.backends.nxp.backend.edge_helper import node_has_well_defined_shape
 from executorch.backends.nxp.backend.ir.converter.node_converter import (
     CustomDelegationOptions,
+    is_not_qdq_node,
     NodeConverter,
 )
 from executorch.backends.nxp.backend.ir.tflite_generator.builtin_options.resize_bilinear_options import (
@@ -16,11 +18,34 @@ from executorch.backends.nxp.backend.ir.tflite_generator.builtin_options.resize_
 )
 from executorch.backends.nxp.backend.neutron_target_spec import NeutronTargetSpec
 from torch.fx import Node
+from torch.fx.passes.infra.partitioner import Partition
 from torch.nn import Parameter
 
 
 # noinspection SpellCheckingInspection
 class UpsampleBilinear2DConverter(NodeConverter):
+
+    @classmethod
+    def supports_partitioning_result(
+        cls,
+        node: Node,
+        partition_list: list[Partition],
+        custom_delegation_options: CustomDelegationOptions,
+        neutron_target_spec: NeutronTargetSpec,
+        parameters_mapping: dict[str, Parameter],
+    ) -> bool:
+        input_shape = node.all_input_nodes[0].meta["val"].shape
+        output_shape = node.meta["val"].shape
+        is_alone_in_partition = cls.is_node_alone_in_partition(
+            node, partition_list, filter_fn=is_not_qdq_node
+        )
+
+        if is_alone_in_partition and input_shape == output_shape:
+            # The operator is a no-op, so the Neutron Converter will skip it. If it's the only node in the
+            #  partition, the graph would end up empty.
+            return False
+
+        return True
 
     @staticmethod
     def _is_supported_in_IR(
@@ -36,6 +61,14 @@ class UpsampleBilinear2DConverter(NodeConverter):
                 " format. Please report this."
             )
 
+        # The conversion requires the output shape to be known and static.
+        if not node_has_well_defined_shape(node):
+            return False
+
+        if len(node.meta["val"].shape) != 4:
+            # Unexpected case. The input should always be 4D.
+            return False
+
         return True
 
     @staticmethod
@@ -45,38 +78,58 @@ class UpsampleBilinear2DConverter(NodeConverter):
         parameters_mapping: dict[str, Parameter],
         custom_delegation_options: CustomDelegationOptions,
     ) -> bool:
-        # Neutron requires static shapes.
-        #  neutron-converter/src/OperatorC/UpsamplePlugin.cpp?at=NEUTRON_SOFTWARE_2.2.3#74
-        if not node_has_well_defined_shape(node):
-            return False
-
-        if len(node.meta["val"].shape) != 4:
-            # Unexpected case. The input should always be 4D.
-            return False
-
-        # The tensors here use the channels first format (NCHW).
+        # The tensors are always 4D and use the channels first format (NCHW).
         _, in_c, in_h, in_w = node.all_input_nodes[0].meta["val"].shape
         _, _, out_h, out_w = node.meta["val"].shape
 
-        # Neutron supports only the doubling and quadrupleing of both height and width at the same time.
-        #  neutron-library/src/utils/NeutronLibraryInterrogation.cpp?at=refs%2Ftags%2FNEUTRON_SOFTWARE_2.2.3#778
-        supported_scales = [2, 4]
-        if not any(
-            in_h * scale == out_h and in_w * scale == out_w
-            for scale in supported_scales
-        ):
-            return False
+        if custom_delegation_options.use_new_flow_neutron_c:
+            # Requirements specified by the new Neutron flow documentation.
 
-        # Neutron requires the input channels to be a multiple of `num_macs`.
-        #  neutron-library/src/utils/NeutronLibraryInterrogation.cpp?at=refs%2Ftags%2FNEUTRON_SOFTWARE_2.2.3#777
-        if in_c % neutron_target_spec.get_num_macs() != 0:
-            return False
+            if not NodeConverter.uses_quantization_type_for_io(
+                node,
+                supported_types=[torch.int8, torch.uint8],
+                input_indices=[0],
+                output_indices=[0],
+            ):
+                return False
+
+            supported_scales = [1, 2, 4, 8]
+            align_corners = node.args[2]
+            if align_corners:
+                if in_h == 1 or in_w == 1:
+                    return False  # Avoid division by 0.
+                h_scale = (out_h - 1) / (in_h - 1)
+                w_scale = (out_w - 1) / (in_w - 1)
+            else:
+                h_scale = out_h / in_h
+                w_scale = out_w / in_w
+
+            # The H and W scales don't need to be equal, but both must be supported.
+            if (h_scale not in supported_scales) or (w_scale not in supported_scales):
+                return False
+
+        else:
+            # Requirements of the old Neutron flow.
+
+            # Neutron supports only the doubling and quadrupleing of both height and width at the same time.
+            #  neutron-library/src/utils/NeutronLibraryInterrogation.cpp?at=refs%2Ftags%2FNEUTRON_SOFTWARE_2.2.3#778
+            supported_scales = [2, 4]
+            if not any(
+                in_h * scale == out_h and in_w * scale == out_w
+                for scale in supported_scales
+            ):
+                return False
+
+            # Neutron requires the input channels to be a multiple of `num_macs`.
+            #  neutron-library/src/utils/NeutronLibraryInterrogation.cpp?at=refs%2Ftags%2FNEUTRON_SOFTWARE_2.2.3#777
+            if in_c % neutron_target_spec.get_num_macs() != 0:
+                return False
 
         return True
 
     def convert(self, node: Node):
         """Convert the `aten.upsample_bilinear2d.vec` operator to Neutron IR `ResizeBilinear`.
-        The schema is:
+        The ExecuTorch schema is:
         aten::upsample_bilinear2d.vec(
             Tensor input,
             SymInt[]? output_size,
@@ -109,6 +162,7 @@ class UpsampleBilinear2DConverter(NodeConverter):
         #  and the second one is what NeutronIR uses when `align_corners == False and half_pixel_centers == True`.
         # https://github.com/tensorflow/tensorflow/blob/v2.20.0/tensorflow/lite/kernels/internal/reference/resize_bilinear.h#L82-L88
         # https://github.com/tensorflow/tensorflow/blob/v2.20.0/tensorflow/lite/kernels/internal/reference/resize_bilinear.h#L172-L180
+        # Also, the new Neutron flow requires that `align_corners` and `half_pixel_centers` are not True simultainiously.
         align_corners = node.args[2]
         half_pixel_centers = not align_corners
         t_op.builtin_options = ResizeBilinear(align_corners, half_pixel_centers)

--- a/backends/nxp/tests/ir/converter/node_converter/test_convert_upsample_bilinear2d.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_convert_upsample_bilinear2d.py
@@ -4,12 +4,15 @@
 # LICENSE file in the root directory of this source tree.
 
 import numpy as np
+
+# noinspection PyUnusedImports
 import pytest
 import torch
 
 from executorch.backends.nxp.backend.edge_program_converter import (
     EdgeProgramToIRConverter,
 )
+from executorch.backends.nxp.tests.dataset_creator import RandomDatasetCreator
 from executorch.backends.nxp.tests.executorch_pipeline import to_quantized_edge_program
 from executorch.backends.nxp.tests.executors import (
     convert_run_compare,
@@ -17,7 +20,17 @@ from executorch.backends.nxp.tests.executors import (
     ToChannelFirstPreprocess,
     ToChannelLastPreprocess,
 )
-from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.backends.nxp.tests.graph_verifier import DetailedGraphVerifier
+from executorch.backends.nxp.tests.model_output_comparator import (
+    AllCloseOutputComparator,
+)
+from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
+from executorch.backends.nxp.tests.ops_aliases import (
+    AddTensor,
+    ExecutorchDelegateCall,
+    UpsampleBilinear2D,
+)
+from executorch.backends.nxp.tests.use_qat import *  # noqa F403
 
 
 @pytest.fixture(autouse=True)
@@ -26,21 +39,23 @@ def reseed_model_per_test_run():
     np.random.seed(23)
 
 
-# noinspection PyProtectedMember
-ExecutorchDelegateCall = torch.ops.higher_order.executorch_call_delegate
-UpsampleBilinear2D = exir_ops.edge.aten.upsample_bilinear2d.vec
-
-
 class UpsampleBilinearModule(torch.nn.Module):
 
-    def __init__(self, size=None, scale=None):
+    def __init__(self, size=None, scale=None, **kwargs):
         super().__init__()
         self.upsample = torch.nn.Upsample(
-            size=size, scale_factor=scale, mode="bilinear"
+            size=size, scale_factor=scale, mode="bilinear", **kwargs
         )
 
     def forward(self, x):
         return self.upsample(x)
+
+
+class UpsampleBilinearAddModule(UpsampleBilinearModule):
+
+    def forward(self, x):
+        x = super().forward(x)
+        return x + x
 
 
 @pytest.mark.parametrize(
@@ -185,3 +200,255 @@ def test_convert_upsample_bilinear2d__no_delegation__unsupported_size(
     # Make sure the `upsample` was NOT delegated (size != double of input).
     assert not graph_contains_any_of_ops(delegated_ep.graph, [ExecutorchDelegateCall])
     assert graph_contains_any_of_ops(delegated_ep.graph, [UpsampleBilinear2D])
+
+
+class TestUpsampleBilinear2DNewNeutronFlow:
+    # TODO Use quantized dataset and `atol=1` in the tests.
+
+    # noinspection PyMethodMayBeStatic
+    def assert_delegated(
+        self,
+        model,
+        input_shape,
+        mocker,
+        use_qat=False,
+        atol=None,
+        expected_delegated_ops=None,
+    ):
+        if expected_delegated_ops is None:
+            expected_delegated_ops = {UpsampleBilinear2D: 1}
+
+        graph_verifier = DetailedGraphVerifier(
+            mocker,
+            expected_delegated_ops=expected_delegated_ops,
+            expected_non_delegated_ops={},
+        )
+
+        # Cover also negative values to thoroughly test the operator.
+        dataset_creator = RandomDatasetCreator(low=-2, high=2)
+
+        kwargs = {"atol": atol} if atol is not None else {}
+        output_comparator = AllCloseOutputComparator(**kwargs)
+
+        lower_run_compare(
+            model,
+            input_shape,
+            graph_verifier,
+            dataset_creator,
+            output_comparator,
+            use_qat=use_qat,
+            use_new_flow_neutron_c=True,  # Use the new flow.
+        )
+
+    # noinspection PyMethodMayBeStatic
+    def assert_not_delegated(self, model, input_shape):
+        delegated_ep = to_quantized_edge_program(
+            model, input_shape, use_new_flow_neutron_c=True
+        ).exported_program()
+
+        assert not graph_contains_any_of_ops(
+            delegated_ep.graph, [ExecutorchDelegateCall]
+        )
+        assert graph_contains_any_of_ops(delegated_ep.graph, [UpsampleBilinear2D])
+
+    def test__qat__align_corners(self, mocker, use_qat):
+        align_corners = True
+        input_shape = (1, 2, 3, 4)
+        output_size = (5, 7)
+        model = UpsampleBilinearModule(size=output_size, align_corners=align_corners)
+        atol = 0.015  # ~= output scale -> single bit error.
+        self.assert_delegated(model, input_shape, mocker, use_qat=use_qat, atol=atol)
+
+    def test__qat__not_align_corners(self, mocker, use_qat):
+        align_corners = False
+        input_shape = (1, 2, 3, 4)
+        output_size = (6, 8)
+        model = UpsampleBilinearModule(size=output_size, align_corners=align_corners)
+        atol = 0.015  # ~= output scale -> single bit error.
+        self.assert_delegated(model, input_shape, mocker, use_qat=use_qat, atol=atol)
+
+    @pytest.mark.parametrize(
+        "input_shape, output_size",
+        [
+            pytest.param((1, 2, 3, 4), (6, 8), id="batch=1, scale_h=scale_w=2"),
+            pytest.param(
+                (3, 3, 3, 5),
+                (6, 5),
+                id="batch=3, scale_h=2, scale_w=1 (no num_macs multiples)",
+            ),
+            pytest.param((2, 2, 3, 4), (3, 16), id="batch=2, scale_h=1, scale_w=4"),
+            pytest.param((2, 2, 3, 4), (24, 8), id="batch=2, scale_h=8, scale_w=2"),
+        ],
+    )
+    def test__not_align_corners__output_size(self, mocker, input_shape, output_size):
+        align_corners = False
+        model = UpsampleBilinearModule(size=output_size, align_corners=align_corners)
+        atol = 0.016  # ~= output scale -> single bit error.
+        self.assert_delegated(model, input_shape, mocker, atol=atol)
+
+    def test__not_align_corners__output_size__unsupported(self):
+        align_corners = False
+        input_shape = (1, 2, 3, 4)
+        output_size = (9, 12)  # scale = (3, 3)
+        model = UpsampleBilinearModule(size=output_size, align_corners=align_corners)
+        self.assert_not_delegated(model, input_shape)
+
+    @pytest.mark.parametrize(
+        "input_shape, scale",
+        [
+            pytest.param((1, 2, 3, 4), (2, 2), id="batch=1, scale_h=scale_w=2"),
+            pytest.param(
+                (3, 3, 3, 5),
+                (2, 1),
+                id="batch=3, scale_h=2, scale_w=1 (no num_macs multiples)",
+            ),
+            pytest.param((2, 2, 3, 4), (4, 1), id="batch=2, scale_h=4, scale_w=1"),
+            pytest.param((2, 2, 3, 4), (2, 8), id="batch=2, scale_h=2, scale_w=8"),
+        ],
+    )
+    def test__not_align_corners__scales(self, mocker, input_shape, scale):
+        align_corners = False
+        model = UpsampleBilinearModule(scale=scale, align_corners=align_corners)
+        atol = 0.016  # ~= output scale -> single bit error.
+        self.assert_delegated(model, input_shape, mocker, atol=atol)
+
+    def test__not_align_corners__scales__unsupported(self):
+        align_corners = False
+        input_shape = (1, 2, 3, 4)
+        scale = (3, 3)
+        model = UpsampleBilinearModule(scale=scale, align_corners=align_corners)
+        self.assert_not_delegated(model, input_shape)
+
+    @pytest.mark.parametrize(
+        "input_shape, output_size",
+        [
+            pytest.param((1, 2, 4, 5), (7, 9), id="batch=1, scale_h=scale_w=2"),
+            pytest.param(
+                (1, 3, 3, 5),
+                (5, 5),
+                id="batch=1, scale_h=2, scale_w=1 (no num_macs multiples)",
+            ),
+            pytest.param((2, 2, 4, 5), (4, 17), id="batch=2, scale_h=1, scale_w=4"),
+            pytest.param((1, 2, 4, 5), (25, 9), id="batch=1, scale_h=8, scale_w=2"),
+        ],
+    )
+    def test__align_corners__output_size(self, mocker, input_shape, output_size):
+        align_corners = True
+        model = UpsampleBilinearModule(size=output_size, align_corners=align_corners)
+        atol = 0.016  # ~= output scale -> single bit error.
+        self.assert_delegated(model, input_shape, mocker, atol=atol)
+
+    @pytest.mark.parametrize(
+        "input_shape, output_size",
+        [
+            pytest.param(
+                (2, 2, 4, 5), (25, 9), id="batch=2, scale_h=8, scale_w=2"
+            ),  # Error ~= 0.47
+            pytest.param(
+                (3, 3, 3, 5),
+                (5, 5),
+                id="batch=3, scale_h=2, scale_w=1 (no num_macs multiples)",
+            ),  # Error ~= 3.7
+        ],
+    )
+    def test__align_corners__output_size__incorrect_output(
+        self, mocker, input_shape, output_size
+    ):
+        align_corners = True
+        model = UpsampleBilinearModule(size=output_size, align_corners=align_corners)
+        atol = 0.45  # Huge tolerance (still not enough to pass).
+        with pytest.raises(AssertionError):
+            self.assert_delegated(model, input_shape, mocker, atol=atol)
+
+    def test__align_corners__output_size__unsupported(self):
+        align_corners = True
+        input_shape = (1, 2, 3, 4)
+        output_size = (6, 8)  # Neutron scale = (5/2, 7/3)
+        model = UpsampleBilinearModule(size=output_size, align_corners=align_corners)
+        self.assert_not_delegated(model, input_shape)
+
+    def test__align_corners__output_size__input_size_equal_to_one(self):
+        align_corners = True
+        input_shape = (1, 2, 1, 1)  # Neutron scale computation would divide by zero.
+        output_size = (2, 2)
+        model = UpsampleBilinearModule(size=output_size, align_corners=align_corners)
+        self.assert_not_delegated(model, input_shape)
+
+    @pytest.mark.parametrize(
+        "input_shape, scale",
+        [
+            # The PyTorch scales are "weird" because the "Neutron scales" are computed differently.
+            # The fractions correspond to "nice" Neutron scales (1, 2, 4, or 8).
+            pytest.param(
+                (1, 2, 4, 5),
+                (7 / 4, 9 / 5),
+                id="batch=1, scale_h=7/4, scale_w=9/5 (Neutron scales = (2, 2)",
+            ),
+            pytest.param(
+                (1, 3, 3, 5),
+                (5 / 3, 1),
+                id="batch=1, scale_h=5/3, scale_w=1 (Neutron scales = (2, 1))",
+            ),
+            pytest.param(
+                (2, 2, 4, 5),
+                (1, 17 / 5),
+                id="batch=2, scale_h=1, scale_w=17/5 (Neutron scales = (1, 4))",
+            ),
+            pytest.param(
+                (1, 2, 4, 5),
+                (25 / 4, 9 / 5),
+                id="batch=1, scale_h=25/4, scale_w=9/5 (Neutron scales = (8, 2))",
+            ),
+        ],
+    )
+    def test__align_corners__scales(self, mocker, input_shape, scale):
+        align_corners = True
+        model = UpsampleBilinearModule(scale=scale, align_corners=align_corners)
+        atol = 0.016  # ~= output scale -> single bit error.
+        self.assert_delegated(model, input_shape, mocker, atol=atol)
+
+    @pytest.mark.parametrize(
+        "input_shape, scale",
+        [
+            pytest.param(
+                (2, 2, 4, 5),
+                (25 / 4, 9 / 5),
+                id="batch=3, scale_h=25/4, scale_w=9/5 (Neutron scales = (8, 2))",
+            ),  # Error ~= 0.47
+            pytest.param(
+                (3, 3, 3, 5),
+                (5 / 3, 1),
+                id="batch=3, scale_h=5/3, scale_w=1 (Neutron scales = (2, 1))",
+            ),  # Error ~= 3.7
+        ],
+    )
+    def test__align_corners__scales__incorrect_output(self, mocker, input_shape, scale):
+        align_corners = True
+        model = UpsampleBilinearModule(scale=scale, align_corners=align_corners)
+        atol = 0.45  # Huge tolerance (still not enough to pass).
+        with pytest.raises(AssertionError):
+            self.assert_delegated(model, input_shape, mocker, atol=atol)
+
+    def test__align_corners__scales__unsupported(self):
+        align_corners = True
+        input_shape = (1, 2, 3, 4)
+        scale = (2, 2)  # Neutron scale = (5/2, 7/3)
+        model = UpsampleBilinearModule(scale=scale, align_corners=align_corners)
+        self.assert_not_delegated(model, input_shape)
+
+    def test__noop__alone_in_partition__not_delegated(self):
+        input_shape = (1, 2, 3, 4)
+        scale = 1
+        model = UpsampleBilinearModule(scale=scale)
+        self.assert_not_delegated(model, input_shape)
+
+    def test__noop__not_alone_in_partition__delegated(self, mocker):
+        input_shape = (1, 2, 3, 4)
+        scale = 1
+        model = UpsampleBilinearAddModule(scale=scale)
+        self.assert_delegated(
+            model,
+            input_shape,
+            mocker,
+            expected_delegated_ops={UpsampleBilinear2D: 1, AddTensor: 1},
+        )


### PR DESCRIPTION
### Summary
Enable `aten.upsample_bilinear2d` with new Neutron flow.

### Test plan
Unit tests provided.


cc @robert-kalmar @JakeStevens @digantdesai @rascani