### PR TITLE
Arm backend: Simplify fake RESIZE validation

### DIFF
--- a/backends/arm/test/misc/tosa_dialect/test_tosa_resize.py
+++ b/backends/arm/test/misc/tosa_dialect/test_tosa_resize.py
@@ -72,6 +72,30 @@ def test_resize_rejects_scale_numerator_over_tosa_limit():
             )
 
 
+@pytest.mark.parametrize(
+    "offset,border",
+    (
+        ([1, 0], [-1, 0]),
+        ([0, 1], [0, -1]),
+    ),
+)
+def test_resize_rejects_non_positive_output_dimensions(offset, border):
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.0+INT")
+    ), FakeTensorMode() as mode:
+        with pytest.raises(
+            TosaValueError,
+            match="RESIZE output dimensions must be positive",
+        ):
+            exir_ops.backend.tosa.RESIZE.default(
+                mode.from_tensor(torch.randint(0, 10, (1, 1, 1, 1), dtype=torch.int8)),
+                [1, 1, 1, 1],
+                offset,
+                border,
+                resize_mode="nearest",
+            )
+
+
 def test_resize_accepts_symbolic_scale_and_border_values():
     shape_env = ShapeEnv()
     scale_y_n = _make_symint(shape_env, "scale_y_n", hint=2, min=1, max=8)

--- a/backends/arm/tosa/dialect/ops/resize.py
+++ b/backends/arm/tosa/dialect/ops/resize.py
@@ -10,6 +10,7 @@ from executorch.backends.arm.tosa.dialect.lib import TosaValueError
 from executorch.backends.arm.tosa.dialect.ops_registration import register_fake_tosa_op
 from executorch.backends.arm.tosa.resize_utils import (
     calculate_tosa_resize_output_hw,
+    get_tosa_resize_output_hw_validation_error,
     get_tosa_resize_validation_error,
 )
 
@@ -92,7 +93,9 @@ def RESIZE(
     H, W = input_shape[1], input_shape[2]
     _validate_resize_parameters((H, W), None, scale, offset, border, tosa_spec)
     output_hw = calculate_tosa_resize_output_hw((H, W), scale, offset, border)
-    _validate_resize_parameters((H, W), output_hw, scale, offset, border, tosa_spec)
+    validation_error = get_tosa_resize_output_hw_validation_error(output_hw)
+    if validation_error is not None:
+        raise TosaValueError(validation_error, op="RESIZE")
     if output_hw is None:
         scale_y_n, scale_y_d, scale_x_n, scale_x_d = scale
         offset_y, offset_x = offset

--- a/backends/arm/tosa/resize_utils.py
+++ b/backends/arm/tosa/resize_utils.py
@@ -67,6 +67,25 @@ def _validate_dimensions(
     return None
 
 
+def get_tosa_resize_output_hw_validation_error(
+    output_hw: Sequence[int | torch.SymInt] | None,
+) -> str | None:
+    if output_hw is None:
+        return None
+
+    output_hw_ints = _as_concrete_ints(output_hw)
+    if output_hw_ints is None:
+        return None
+
+    invalid_dimension = next(
+        (dimension for dimension in output_hw_ints if dimension <= 0), None
+    )
+    if invalid_dimension is not None:
+        return f"RESIZE output dimensions must be positive; got {invalid_dimension}"
+
+    return _validate_dimensions((), output_hw)
+
+
 def _validate_scale(
     scale: Sequence[int | torch.SymInt],
     tosa_spec: TosaSpecification,


### PR DESCRIPTION
Avoid revalidating RESIZE output shape against dimensions computed by the same formula. Validate parameters once, compute the fake output shape, and directly validate the computed output dimensions.


Change-Id: I97bb91f9fc440c980782955692056196038d5de0


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani