### PR TITLE
NXP Backend: Force backend (NeutronBackend) destructor call before neutronDeInit()

### DIFF
--- a/examples/nxp/executor_runner/nxp_executor_runner.cpp
+++ b/examples/nxp/executor_runner/nxp_executor_runner.cpp
@@ -384,71 +384,30 @@ int main(int argc, char* argv[]) {
   torch::executor::MemoryManager memory_manager(
       &method_allocator, &planned_memory, &tmp_allocator);
 
-  Result<torch::executor::Method> method =
-      program->load_method(method_name, &memory_manager);
-  if (!method.ok()) {
-    fprintf(
-        stderr,
-        "Loading of method (%s) failed with status %" PRIu32 "...\n",
-        method_name,
-        (unsigned int)method.error());
-    exit(-1);
-  }
-  printf("Method loaded...\n");
-
-  Error status = Error::Ok;
-  if (!FLAGS_dataset.empty()) {
-    // Go through entire dataset for this model.
-    FLAGS_dataset += "/";
-    while (dataset = readdir(datasetDir)) {
-      if (!strcmp(dataset->d_name, ".") || !strcmp(dataset->d_name, ".."))
-        continue;
-
-      std::vector<std::string> inputsData;
-      inputsData.push_back(FLAGS_dataset + dataset->d_name);
-      // Set input and call inferrence.
-      setInputs(method.get(), inputsData);
-
-      status = method->execute();
-      if (status != Error::Ok) {
-        fprintf(
-            stderr,
-            "Execution of method %s failed with status %" PRIu32 "...\n",
-            method_name,
-            (unsigned int)status);
-        exit(-1);
-      } else {
-        printf("Method executed successfully...\n");
-      }
-
-      // Save outputs in binary files.
-      saveOutputs(method.get(), FLAGS_output, dataset->d_name);
-      // Print result with highest confidence.
-      printOutput(method.get(), FLAGS_output, dataset->d_name);
+  {
+    Result<torch::executor::Method> method =
+        program->load_method(method_name, &memory_manager);
+    if (!method.ok()) {
+      fprintf(
+          stderr,
+          "Loading of method (%s) failed with status %" PRIu32 "...\n",
+          method_name,
+          (unsigned int)method.error());
+      exit(-1);
     }
-    closedir(datasetDir);
-  } else if (!FLAGS_inputs.empty()) {
-    std::vector<std::string> inputPaths;
+    printf("Method loaded...\n");
 
-    // Validate and process inputs and separate into two lists.
-    processInputs(inputPaths, FLAGS_inputs);
+    Error status = Error::Ok;
+    if (!FLAGS_dataset.empty()) {
+      // Go through entire dataset for this model.
+      FLAGS_dataset += "/";
+      while (dataset = readdir(datasetDir)) {
+        if (!strcmp(dataset->d_name, ".") || !strcmp(dataset->d_name, ".."))
+          continue;
 
-    if (std::all_of(inputPaths.begin(), inputPaths.end(), isDirectory)) {
-      // Inputs are in directories - use files in each directory as the inputs.
-      std::vector<std::string> inputsData;
-      for (std::string& inputDir : inputPaths) {
-        datasetDir = opendir(inputDir.c_str());
-        while (dataset = readdir(datasetDir)) {
-          if (!strcmp(dataset->d_name, ".") || !strcmp(dataset->d_name, ".."))
-            continue;
-
-          inputsData.push_back(inputDir + "/" + dataset->d_name);
-        }
-        closedir(datasetDir);
-
-        // Sort inputsData to ensure correct input ordering
-        std::sort(inputsData.begin(), inputsData.end());
-
+        std::vector<std::string> inputsData;
+        inputsData.push_back(FLAGS_dataset + dataset->d_name);
+        // Set input and call inferrence.
         setInputs(method.get(), inputsData);
 
         status = method->execute();
@@ -463,37 +422,81 @@ int main(int argc, char* argv[]) {
           printf("Method executed successfully...\n");
         }
 
-        if (inputDir.back() == '/')
-          inputDir.pop_back();
+        // Save outputs in binary files.
+        saveOutputs(method.get(), FLAGS_output, dataset->d_name);
+        // Print result with highest confidence.
+        printOutput(method.get(), FLAGS_output, dataset->d_name);
+      }
+      closedir(datasetDir);
+    } else if (!FLAGS_inputs.empty()) {
+      std::vector<std::string> inputPaths;
 
-        auto pos = inputDir.find_last_of('/');
-        if (pos != std::string::npos)
-          inputDir = inputDir.substr(pos + 1);
+      // Validate and process inputs and separate into two lists.
+      processInputs(inputPaths, FLAGS_inputs);
+
+      if (std::all_of(inputPaths.begin(), inputPaths.end(), isDirectory)) {
+        // Inputs are in directories - use files in each directory as the
+        // inputs.
+        std::vector<std::string> inputsData;
+        for (std::string& inputDir : inputPaths) {
+          datasetDir = opendir(inputDir.c_str());
+          while (dataset = readdir(datasetDir)) {
+            if (!strcmp(dataset->d_name, ".") || !strcmp(dataset->d_name, ".."))
+              continue;
+
+            inputsData.push_back(inputDir + "/" + dataset->d_name);
+          }
+          closedir(datasetDir);
+
+          // Sort inputsData to ensure correct input ordering
+          std::sort(inputsData.begin(), inputsData.end());
+
+          setInputs(method.get(), inputsData);
+
+          status = method->execute();
+          if (status != Error::Ok) {
+            fprintf(
+                stderr,
+                "Execution of method %s failed with status %" PRIu32 "...\n",
+                method_name,
+                (unsigned int)status);
+            exit(-1);
+          } else {
+            printf("Method executed successfully...\n");
+          }
+
+          if (inputDir.back() == '/')
+            inputDir.pop_back();
+
+          auto pos = inputDir.find_last_of('/');
+          if (pos != std::string::npos)
+            inputDir = inputDir.substr(pos + 1);
+
+          // Save outputs in binary files.
+          saveOutputs(method.get(), FLAGS_output, inputDir.c_str());
+          inputsData.clear();
+        }
+      } else {
+        // Inputs are files.
+        setInputs(method.get(), inputPaths);
+
+        status = method->execute();
+        if (status != Error::Ok) {
+          fprintf(
+              stderr,
+              "Execution of method %s failed with status %" PRIu32 "...\n",
+              method_name,
+              (unsigned int)status);
+          exit(-1);
+        } else {
+          printf("Method executed successfully...\n");
+        }
 
         // Save outputs in binary files.
-        saveOutputs(method.get(), FLAGS_output, inputDir.c_str());
-        inputsData.clear();
+        saveOutputs(method.get(), FLAGS_output);
       }
-    } else {
-      // Inputs are files.
-      setInputs(method.get(), inputPaths);
-
-      status = method->execute();
-      if (status != Error::Ok) {
-        fprintf(
-            stderr,
-            "Execution of method %s failed with status %" PRIu32 "...\n",
-            method_name,
-            (unsigned int)status);
-        exit(-1);
-      } else {
-        printf("Method executed successfully...\n");
-      }
-
-      // Save outputs in binary files.
-      saveOutputs(method.get(), FLAGS_output);
     }
-  }
+  } // Destruct the method object before destroying the Neutron Device.
 
   printf("Finished...\n");
 


### PR DESCRIPTION
### Summary
The `NeutronBackend::destroy` function shall be called before the Neutron driver's `neutronDeInit()` function to avoid double free. At this moment the ExecuTorch does not provide means to destroy the backend or the method outside of the method's desctructor.  

### Test plan
With upcomming eIQ Neutron SDK 3.1.2 the nxp-executor-runner crash, so existing unit tests covers this problem. 

cc @JakeStevens @digantdesai @rascani