### PR TITLE
Arm backend: Fix bmm quantization bug

### DIFF
--- a/backends/arm/_passes/replace_scalar_with_tensor_pass.py
+++ b/backends/arm/_passes/replace_scalar_with_tensor_pass.py
@@ -126,4 +126,4 @@ class ReplaceScalarWithTensorByProfilePass(ArmPass, ReplaceScalarWithTensorArgPa
             return super().call_operator(op, args, kwargs, meta)
         else:
             # Do not handle; forward unchanged.
-            return ExportPass.call_operator(self, op, args, kwargs, meta)
+            return ArmPass.call_operator(self, op, args, kwargs, meta)


### PR DESCRIPTION
bmm nodes are now forwarded to ArmPass in stead of ExportPass.

This fixes an issue where _call_quantized_bmm_without_fake_kernel() 
does not get called, leading to dtype mismatch error


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani