### PR TITLE
Add executorch-ubuntu-26.04-gcc15 docker image

### DIFF
--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -89,6 +89,11 @@ case "${IMAGE_NAME}" in
     OS_VERSION=24.04
     GCC_VERSION=14
     ;;
+  executorch-ubuntu-26.04-gcc15)
+    LINTRUNNER=""
+    OS_VERSION=26.04
+    GCC_VERSION=15
+    ;;
   *)
     echo "Invalid image name ${IMAGE_NAME}"
     exit 1

--- a/.ci/docker/common/install_docs_reqs.sh
+++ b/.ci/docker/common/install_docs_reqs.sh
@@ -15,8 +15,8 @@ if [ -n "$BUILD_DOCS" ]; then
   curl --retry 3 --retry-all-errors -sL https://deb.nodesource.com/setup_16.x | sudo -E bash -
   sudo apt-get install -y nodejs
 
-  curl --retry 3 --retry-all-errors -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
-  echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+  curl --retry 3 --retry-all-errors -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo gpg --dearmor -o /usr/share/keyrings/yarn-archive-keyring.gpg
+  echo "deb [signed-by=/usr/share/keyrings/yarn-archive-keyring.gpg] https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
 
   apt-get update
   apt-get install -y --no-install-recommends yarn

--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -43,6 +43,7 @@ jobs:
           executorch-ubuntu-22.04-mediatek-sdk,
           executorch-ubuntu-22.04-clang12-android,
           executorch-ubuntu-24.04-gcc14,
+          executorch-ubuntu-26.04-gcc15,
         ]
         include:
           - docker-image-name: executorch-ubuntu-22.04-gcc11-aarch64


### PR DESCRIPTION
### Summary

Add a docker build image based on Ubuntu 26.04 with gcc 15. It's necessary for the the baremetal on RISC-V use case since `libstdc++-riscv64-unknown-elf-picolibc` is only available starting Ubuntu 26.04. It also makes sure that `gcc-riscv64-unknown-elf` is at least gcc 14+ which has support for RVV

### Test plan

It will be used by the baremetal testing on RISC-V.

Relates to https://github.com/pytorch/executorch/issues/18991 https://github.com/pytorch/executorch/issues/19666

cc @psiddh @AdrianLundell @digantdesai @rascani