### PR TITLE
Arm backend: Add MXFP Linear source transform

### DIFF
--- a/backends/arm/TARGETS
+++ b/backends/arm/TARGETS
@@ -1,4 +1,4 @@
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -13,6 +13,31 @@ runtime.python_library(
     ],
     deps = [
         "//executorch/exir/dialects:lib",
+    ],
+)
+runtime.python_library(
+    name = "ao_ext",
+    srcs = glob([
+        "ao_ext/*.py",
+        "ao_ext/ops/*.py",
+    ]),
+    deps = [
+        "//caffe2:torch",
+        "//executorch/exir:_warnings",
+        "//pytorch/ao:torchao",
+    ],
+)
+
+runtime.python_library(
+    name = "lib",
+    srcs = [
+        "__init__.py",
+    ],
+    deps = [
+        ":ao_ext",
+        ":ethosu",
+        ":vgf",
+        "//executorch/backends/arm/quantizer:lib",
     ],
 )
 runtime.python_library(

--- a/backends/arm/__init__.py
+++ b/backends/arm/__init__.py
@@ -14,6 +14,10 @@ from __future__ import annotations
 import importlib
 from typing import Any
 
+# Register Arm-specific torch.library ops and MXFP transforms at package
+# import time.
+import executorch.backends.arm.ao_ext  # noqa: F401
+
 # Public for tooling (manifest generation and API validation).
 LAZY_IMPORTS = {
     "EthosUBackend": ("executorch.backends.arm.ethosu", "EthosUBackend"),
@@ -32,6 +36,8 @@ LAZY_IMPORTS = {
         "executorch.backends.arm.quantizer",
         "get_symmetric_a16w8_quantization_config",
     ),
+    "MXFPOpConfig": ("executorch.backends.arm.ao_ext.mxfp", "MXFPOpConfig"),
+    "to_mxfp": ("executorch.backends.arm.ao_ext.mxfp", "to_mxfp"),
 }
 
 

--- a/backends/arm/ao_ext/__init__.py
+++ b/backends/arm/ao_ext/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Import mxfp_transform to trigger registration of the MXFP transforms.
+from . import mxfp_transform  # noqa: F401
+
+from .mxfp import MXFPOpConfig, to_mxfp
+
+
+__all__ = ["MXFPOpConfig", "to_mxfp"]

--- a/backends/arm/ao_ext/mxfp.py
+++ b/backends/arm/ao_ext/mxfp.py
@@ -1,0 +1,64 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+import torch
+from executorch.exir._warnings import experimental
+from torchao.core.config import AOBaseConfig
+from torchao.prototype.mx_formats.config import ScaleCalculationMode
+from torchao.quantization import quantize_
+
+
+def _match_supported_modules(module: torch.nn.Module, _name: str) -> bool:
+    """Default filter function that matches supported modules."""
+    return isinstance(module, torch.nn.Linear)
+
+
+@experimental("This API is experimental and may change without notice.")
+@dataclass
+class MXFPOpConfig(AOBaseConfig):
+    """Configuration for Arm MXFP source transforms."""
+
+    weight_dtype: torch.dtype = torch.float8_e4m3fn
+    weight_scaling_mode: ScaleCalculationMode = ScaleCalculationMode.RCEIL
+
+    # Only block size of 32 is currently supported for now, so we hardcode it here.
+    @property
+    def block_size(self) -> int:
+        return 32
+
+    def __post_init__(self) -> None:
+        if self.weight_dtype not in (torch.float8_e4m3fn, torch.float8_e5m2):
+            raise ValueError(f"Unsupported weight_dtype: {self.weight_dtype}")
+        if not isinstance(self.weight_scaling_mode, ScaleCalculationMode):
+            raise ValueError(
+                f"Unsupported weight_scaling_mode: {self.weight_scaling_mode}"
+            )
+
+
+@experimental("This API is experimental and may change without notice.")
+def to_mxfp(
+    model: torch.nn.Module,
+    config: MXFPOpConfig,
+    filter_fn: Optional[Callable[[torch.nn.Module, str], bool]] = None,
+) -> None:
+    """Convert matching modules in ``model`` to Arm MXFP modules in-place.
+
+    Args:
+        model (torch.nn.Module): Module to transform. Matching submodules are
+            replaced in-place.
+        config (MXFPOpConfig): Configuration controlling the MXFP conversion
+            behavior.
+        filter_fn (Optional[Callable[[torch.nn.Module, str], bool]]): Optional
+            predicate that receives a module and its fully qualified name. When
+            omitted, all modules supported by the MXFP transform are matched.
+
+    """
+    if filter_fn is None:
+        filter_fn = _match_supported_modules
+
+    quantize_(model, config, filter_fn)

--- a/backends/arm/ao_ext/mxfp_tosa_lib.py
+++ b/backends/arm/ao_ext/mxfp_tosa_lib.py
@@ -1,0 +1,11 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from torch.library import Library
+
+# MXFP TOSA library definition for the Arm backend containing.
+# This library will generate custom ops like the following example:
+#   torch.ops.tosa_mxfp.linear.default
+MXFP_TOSA_LIB = Library("tosa_mxfp", "DEF")

--- a/backends/arm/ao_ext/mxfp_transform.py
+++ b/backends/arm/ao_ext/mxfp_transform.py
@@ -1,0 +1,24 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+
+from executorch.backends.arm.ao_ext.mxfp import MXFPOpConfig
+from executorch.backends.arm.ao_ext.ops.mxfp_linear_op import transform_linear_to_mxfp
+from torchao.quantization.transform_module import register_quantize_module_handler
+
+
+@register_quantize_module_handler(MXFPOpConfig)  # type: ignore[misc]
+def _transform_to_mxfp(
+    module: torch.nn.Module,
+    config: MXFPOpConfig,
+) -> torch.nn.Module:
+    """Transforms a given module to use MXFP operations based on the provided
+    MXFPOpConfig configuration.
+    """
+    if isinstance(module, torch.nn.Linear):
+        return transform_linear_to_mxfp(module, config)
+    else:
+        return module

--- a/backends/arm/ao_ext/ops/__init__.py
+++ b/backends/arm/ao_ext/ops/__init__.py
@@ -1,0 +1,10 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from .mxfp_linear_op import MXFPLinearOp
+
+__all__ = [
+    "MXFPLinearOp",
+]

--- a/backends/arm/ao_ext/ops/mxfp_linear_op.py
+++ b/backends/arm/ao_ext/ops/mxfp_linear_op.py
@@ -1,0 +1,179 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+"""MXFP Linear transform for the Arm backend.
+
+TorchAO extension for MXFP linear. It replaces ``nn.Linear`` with a wrapper
+module that stores precomputed MXFP weights and emits a backend-internal custom
+op during export.
+
+"""
+
+import torch
+import torch.nn.functional as F
+from executorch.backends.arm.ao_ext.mxfp import MXFPOpConfig
+from executorch.backends.arm.ao_ext.mxfp_tosa_lib import MXFP_TOSA_LIB
+from torchao.prototype.mx_formats.config import ScaleCalculationMode
+from torchao.prototype.mx_formats.mx_tensor import to_dtype, to_mx
+
+MXFP_TOSA_LIB.define(
+    "linear(Tensor input, Tensor weight_qdata, Tensor weight_scale, "
+    "Tensor? bias=None, SymInt block_size=32) -> Tensor"
+)
+
+
+@torch.library.register_fake("tosa_mxfp::linear", lib=MXFP_TOSA_LIB)  # type: ignore[misc]
+def _mxfp_linear_fake(
+    input: torch.Tensor,
+    weight_qdata: torch.Tensor,
+    weight_scale: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    block_size: int = 32,
+) -> torch.Tensor:
+    if weight_qdata.ndim != 3:
+        raise ValueError(
+            f"Expected weight_qdata to be rank 3 for linear, got {weight_qdata.ndim}"
+        )
+    if weight_qdata.shape[0] != 1:
+        raise ValueError(
+            f"Expected weight_qdata batch dim to be 1, got {weight_qdata.shape[0]}"
+        )
+    if input.shape[-1] != weight_qdata.shape[-1]:
+        raise ValueError(
+            f"Input last dim {input.shape[-1]} must match linear in_features "
+            f"{weight_qdata.shape[-1]}"
+        )
+    expected_scale_shape = (
+        1,
+        weight_qdata.shape[1],
+        weight_qdata.shape[-1] // block_size,
+    )
+    if tuple(weight_scale.shape) != expected_scale_shape:
+        raise ValueError(
+            f"Expected weight_scale shape {expected_scale_shape}, got "
+            f"{tuple(weight_scale.shape)}"
+        )
+    output_shape = (*input.shape[:-1], weight_qdata.shape[1])
+    return input.new_empty(output_shape, dtype=torch.float32)
+
+
+def _cast_to_block_scaled_cpu_ref(
+    input: torch.Tensor,
+    output_dtype: torch.dtype,
+    block_size: int,
+) -> torch.Tensor:
+    """Emulate the current TOSA activation cast in eager mode."""
+    input_scale, input_qdata = to_mx(
+        input.to(torch.float32).contiguous(),
+        elem_dtype=output_dtype,
+        block_size=block_size,
+        scaling_mode=ScaleCalculationMode.RCEIL,
+    )
+    return to_dtype(
+        input_qdata,
+        input_scale,
+        output_dtype,
+        block_size,
+        torch.float32,
+    )
+
+
+@torch.library.impl("tosa_mxfp::linear", "cpu", lib=MXFP_TOSA_LIB)
+def _mxfp_linear_cpu(
+    input: torch.Tensor,
+    weight_qdata: torch.Tensor,
+    weight_scale: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    block_size: int = 32,
+) -> torch.Tensor:
+    """CPU reference implementation of the MXFP linear op."""
+
+    if weight_qdata.ndim != 3 or weight_scale.ndim != 3:
+        raise ValueError("Expected rank-3 weight tensors for MXFP linear")
+
+    # Cast the input to block-scaled format and back again to match the
+    # expected input format of the TOSA
+    dequantized_input = _cast_to_block_scaled_cpu_ref(
+        input,
+        weight_qdata.dtype,
+        block_size,
+    )
+    dequantized_weight = to_dtype(
+        weight_qdata,
+        weight_scale,
+        weight_qdata.dtype,
+        block_size,
+        torch.float32,
+    )
+    dequantized_weight = dequantized_weight.squeeze(0)
+    if bias is not None:
+        bias = bias.to(torch.float32)
+    return F.linear(dequantized_input, dequantized_weight, bias)
+
+
+class MXFPLinearOp(torch.nn.Module):
+    """Linear wrapper that stores MXFP weights and emits a custom op."""
+
+    def __init__(
+        self,
+        weight_qdata: torch.Tensor,
+        weight_scale: torch.Tensor,
+        bias: torch.Tensor | None,
+        config: MXFPOpConfig,
+    ) -> None:
+        super().__init__()
+        self.config = config
+
+        self.register_buffer("weight_qdata", weight_qdata, persistent=True)
+        self.register_buffer("weight_scale", weight_scale, persistent=True)
+
+        self.bias: torch.nn.Parameter | None
+        bias_param = (
+            torch.nn.Parameter(bias.detach(), requires_grad=False)
+            if bias is not None
+            else None
+        )
+        self.register_parameter(
+            "bias",
+            bias_param,
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.ops.tosa_mxfp.linear.default(
+            x,
+            self.weight_qdata,
+            self.weight_scale,
+            self.bias,
+            self.config.block_size,
+        )
+
+
+def transform_linear_to_mxfp(
+    module: torch.nn.Module,
+    config: MXFPOpConfig,
+) -> torch.nn.Module:
+    assert isinstance(module, torch.nn.Linear)
+
+    weight = module.weight.detach().contiguous()
+    if weight.shape[-1] % config.block_size != 0:
+        raise ValueError(
+            f"Linear in_features={weight.shape[-1]} must be divisible by "
+            f"block_size={config.block_size}"
+        )
+
+    weight_scale, weight_qdata = to_mx(
+        weight,
+        elem_dtype=config.weight_dtype,
+        block_size=config.block_size,
+        scaling_mode=config.weight_scaling_mode,
+    )
+
+    # The resulting TOSA op MATMUL_T_BLOCK_SCALED only works with tensors of
+    # rank 3, therefore we prepend a batch dimension of 1 to the weight tensors
+    # here.
+    weight_qdata = weight_qdata.unsqueeze(0)
+    weight_scale = weight_scale.unsqueeze(0)
+
+    bias = module.bias.detach().to(torch.float32) if module.bias is not None else None
+    return MXFPLinearOp(weight_qdata, weight_scale, bias, config)

--- a/backends/arm/operators/op_view.py
+++ b/backends/arm/operators/op_view.py
@@ -35,24 +35,26 @@ class ViewVisitor(NodeVisitor):
         inputs: List[TosaArg],
         output: TosaArg,
     ) -> None:
-        supported_dtypes = [ts.DType.BOOL]
+        supported_dtypes = {ts.DType.BOOL}
         if self.tosa_spec.support_integer():
-            supported_dtypes.extend([ts.DType.INT8, ts.DType.INT16, ts.DType.INT32])
+            supported_dtypes.update([ts.DType.INT8, ts.DType.INT16, ts.DType.INT32])
         if self.tosa_spec.support_float():
-            supported_dtypes.extend([ts.DType.FP16, ts.DType.FP32])
+            supported_dtypes.update([ts.DType.FP16, ts.DType.FP32])
         if self.tosa_spec.support_extension("bf16"):
-            supported_dtypes.append(ts.DType.BF16)
+            supported_dtypes.add(ts.DType.BF16)
         if self.tosa_spec.support_extension("fp8e4m3"):
-            supported_dtypes.append(ts.DType.FP8E4M3)
+            supported_dtypes.add(ts.DType.FP8E4M3)
         if self.tosa_spec.support_extension("fp8e5m2"):
-            supported_dtypes.append(ts.DType.FP8E5M2)
+            supported_dtypes.add(ts.DType.FP8E5M2)
+        if self.tosa_spec.support_extension("mxfp"):
+            supported_dtypes.update([ts.DType.FP8E4M3, ts.DType.FP8E5M2])
 
         validate_num_inputs(self.target, inputs, 2)
         validate_same_dtype(self.target, [inputs[0], output], ts)
         validate_valid_dtype(
             self.target,
             [inputs[0], output],
-            supported_dtypes,
+            list(supported_dtypes),
             self.tosa_spec,
         )
 

--- a/backends/arm/test/misc/test_mxfp_linear_ao.py
+++ b/backends/arm/test/misc/test_mxfp_linear_ao.py
@@ -1,0 +1,46 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+from executorch.backends.arm.ao_ext import MXFPOpConfig, to_mxfp
+from executorch.backends.arm.ao_ext.ops import MXFPLinearOp
+
+from torch.export import export
+
+
+class LinearModule(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.linear = torch.nn.Linear(32, 8, bias=True)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.linear(x)
+
+
+def test_mxfp_linear_quantize_swaps_module() -> None:
+    model = LinearModule().eval()
+
+    to_mxfp(model, MXFPOpConfig())
+
+    assert isinstance(model.linear, MXFPLinearOp)
+    assert model.linear.weight_qdata.dtype == torch.float8_e4m3fn
+    assert model.linear.weight_scale.dtype == torch.float8_e8m0fnu
+    assert tuple(model.linear.weight_qdata.shape) == (1, 8, 32)
+    assert tuple(model.linear.weight_scale.shape) == (1, 8, 1)
+
+
+def test_mxfp_linear_export_preserves_custom_op() -> None:
+    model = LinearModule().eval()
+    to_mxfp(model, MXFPOpConfig())
+
+    exported = export(model, (torch.randn(4, 32),), strict=False)
+
+    targets = [
+        node.target
+        for node in exported.graph_module.graph.nodes
+        if node.op == "call_function"
+    ]
+
+    assert torch.ops.tosa_mxfp.linear.default in targets

--- a/backends/arm/test/ops/test_mxfp_linear.py
+++ b/backends/arm/test/ops/test_mxfp_linear.py
@@ -1,0 +1,226 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import copy
+
+import torch
+from executorch.backends.arm.ao_ext import MXFPOpConfig, to_mxfp
+from executorch.backends.arm.test import common
+from executorch.backends.arm.test.tester.analyze_output_utils import (
+    compare_rel_frobenius_and_cosine_similarity,
+)
+
+
+def _block_input_rank1() -> torch.Tensor:
+    """Create a rank-1 input with distinct MXFP activation block scales."""
+
+    return torch.cat(
+        (
+            1e-3 * torch.randn(32),
+            100.0 * torch.randn(32),
+        )
+    )
+
+
+def _block_input_rank2() -> torch.Tensor:
+    """Create a rank-2 input with per-row activation block scale changes."""
+
+    return torch.stack(
+        (
+            _block_input_rank1(),
+            torch.cat(
+                (
+                    100.0 * torch.randn(32),
+                    1e-3 * torch.randn(32),
+                )
+            ),
+        )
+    )
+
+
+_test_data_rank1_fp = {
+    "mxfp_linear_rank1_zeros": lambda: (
+        torch.zeros(32 * 8),
+        5,
+        True,
+        False,
+    ),
+    "mxfp_linear_rank1_rand": lambda: (
+        torch.rand(32),
+        16,
+        False,
+        False,
+    ),
+}
+
+_test_data_rank2_fp = {
+    "mxfp_linear_rank2_zeros": lambda: (
+        torch.zeros(4, 32),
+        16,
+        True,
+        False,
+    ),
+    "mxfp_linear_rank2_rand": lambda: (
+        torch.rand(4, 32 * 6),
+        13,
+        True,
+        False,
+    ),
+}
+
+_test_data_rank3_fp = {
+    "mxfp_linear_rank3_zeros": lambda: (
+        torch.zeros(2, 4, 32 * 3),
+        1,
+        True,
+        False,
+    ),
+    "mxfp_linear_rank3_rand": lambda: (
+        torch.rand(2, 4, 32),
+        20,
+        True,
+        False,
+    ),
+}
+
+_test_data_rank4_fp = {
+    "mxfp_linear_rank4_zeros": lambda: (
+        torch.zeros(2, 3, 4, 32 * 24),
+        8,
+        True,
+        False,
+    ),
+    "mxfp_linear_rank4_rand": lambda: (
+        torch.rand(2, 3, 4, 32 * 32),
+        64,
+        False,
+        False,
+    ),
+}
+
+_test_data_block_fp = {
+    "mxfp_linear_rank1_block_weights": lambda: (
+        torch.ones(64),
+        4,
+        False,
+        True,
+    ),
+    "mxfp_linear_rank1_block_weights_block_activations": lambda: (
+        _block_input_rank1(),
+        4,
+        False,
+        True,
+    ),
+    "mxfp_linear_rank2_block_weights_block_activations": lambda: (
+        _block_input_rank2(),
+        4,
+        False,
+        True,
+    ),
+}
+
+test_data_fp = (
+    _test_data_rank1_fp
+    | _test_data_rank2_fp
+    | _test_data_rank3_fp
+    | _test_data_rank4_fp
+    | _test_data_block_fp
+)
+
+
+class Linear(torch.nn.Module):
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int = 8,
+        bias: bool = True,
+    ) -> None:
+        super().__init__()
+        self.fc = torch.nn.Linear(
+            in_features=in_features,
+            out_features=out_features,
+            bias=bias,
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.fc(x)
+
+    def set_block_test_weights(self) -> None:
+        """Set weights to exercise separate MXFP weight block scales.
+
+        The first two logical 32-wide input blocks use different magnitudes so
+        tests can verify block scaling does not share one scale across blocks.
+
+        """
+        if self.fc.weight.shape[1] < 64:
+            raise ValueError(
+                "Block test weights require at least 64 input features (2 blocks), got "
+                f"{tuple(self.fc.weight.shape)}"
+            )
+
+        with torch.no_grad():
+            self.fc.weight.zero_()
+            for row in range(self.fc.weight.shape[0]):
+                # Small values in the first block.
+                self.fc.weight[row, 0:32] = 1e-3
+                # Large values in the next block to require a different scale.
+                self.fc.weight[row, 32:64] = 100.0
+            if self.fc.bias is not None:
+                self.fc.bias.zero_()
+
+
+def _is_linear(module: torch.nn.Module, _fqn: str) -> bool:
+    return isinstance(module, torch.nn.Linear)
+
+
+def _test_mxfp_linear_eager_cpu(
+    test_data: torch.Tensor,
+    config: MXFPOpConfig,
+    frobenius_threshold: float,
+    cosine_threshold: float,
+) -> None:
+    test_input, out_features, has_bias, set_block_weights = test_data()
+    in_features = test_input.shape[-1]
+    ref_model = Linear(
+        in_features=in_features,
+        out_features=out_features,
+        bias=has_bias,
+    ).eval()
+    if set_block_weights:
+        ref_model.set_block_test_weights()
+    test_model = copy.deepcopy(ref_model).eval()
+
+    to_mxfp(test_model, config, filter_fn=_is_linear)
+
+    test_output = test_model(test_input)
+    ref_output = ref_model(test_input)
+
+    compare_rel_frobenius_and_cosine_similarity(
+        ref_output,
+        test_output,
+        quantization_parameters=None,
+        frobenius_threshold=frobenius_threshold,
+        cosine_threshold=cosine_threshold,
+        clean_reference=False,
+    )
+
+
+@common.parametrize("test_data", test_data_fp)
+def test_mxfp_linear_eager_cpu(test_data: torch.Tensor) -> None:
+    """Check eager MXFP implementation.
+
+    The Arm lowering tests compare lowered output against the eager CPU
+    implementation, so the eager implementation must be accurate for it to be
+    used as a reference in other tests.
+
+    """
+    _test_mxfp_linear_eager_cpu(
+        test_data,
+        MXFPOpConfig(),
+        frobenius_threshold=0.06,
+        cosine_threshold=0.995,
+    )

--- a/backends/arm/test/targets.bzl
+++ b/backends/arm/test/targets.bzl
@@ -25,6 +25,7 @@ def define_arm_tests():
         "ops/test_log10.py",
         "ops/test_max_pool1d.py",
         "ops/test_mul.py",
+        "ops/test_mxfp_linear.py",
         "ops/test_permute.py",
         "ops/test_rsqrt.py",
         "ops/test_slice.py",
@@ -62,6 +63,7 @@ def define_arm_tests():
         "misc/test_bn_relu_folding_qat.py",
         "misc/test_custom_partition.py",
         "misc/test_debug_hook.py",
+        "misc/test_mxfp_linear_ao.py",
         "misc/test_post_quant_device_switch.py",
         # "misc/test_dim_order.py", (TODO - T238390249)
     ]
@@ -104,6 +106,7 @@ def define_arm_tests():
                 "//executorch/backends/arm/test:arm_tester" if runtime.is_oss else "//executorch/backends/arm/test/tester/fb:arm_tester_fb",
                 "//executorch/backends/arm/test:conftest",
                 "//executorch/backends/arm/test/misc:dw_convs_shared_weights_module",
+                "//executorch/backends/arm:ao_ext",
                 "//executorch/backends/arm:ethosu",
                 "//executorch/backends/arm/tosa:compile_spec",
                 "//executorch/backends/arm/tosa:partitioner",

--- a/backends/arm/test/tester/analyze_output_utils.py
+++ b/backends/arm/test/tester/analyze_output_utils.py
@@ -337,6 +337,24 @@ def dump_error_output(
     logger.error(f"{atol=}, {rtol=}, {qtol=}")
 
 
+def calculate_rel_frobenius_and_cosine_similarity(
+    reference_output: torch.Tensor,
+    test_output: torch.Tensor,
+) -> tuple[float, float]:
+    reference_output = reference_output.to(torch.float32)
+    test_output = test_output.to(torch.float32)
+
+    reference_frobenius_norm = torch.linalg.norm(reference_output).item()
+    error_frobenius_norm = torch.linalg.norm(test_output - reference_output).item()
+
+    relative_frobenius_error = error_frobenius_norm / (reference_frobenius_norm + 1e-8)
+    cosine_similarity = torch.nn.functional.cosine_similarity(
+        test_output.flatten(), reference_output.flatten(), dim=0
+    ).item()
+
+    return relative_frobenius_error, cosine_similarity
+
+
 def compare_rel_frobenius_and_cosine_similarity(
     reference_output: torch.Tensor,
     test_output: torch.Tensor,
@@ -394,15 +412,11 @@ def compare_rel_frobenius_and_cosine_similarity(
     if reference_all_zeros:
         return
 
-    reference_output = reference_output.to(torch.float32)
-    test_output = test_output.to(torch.float32)
-
-    reference_frobenius_norm = torch.linalg.norm(reference_output).item()
-    error_frobenius_norm = torch.linalg.norm(test_output - reference_output).item()
-
-    relative_frobenius_error = error_frobenius_norm / (reference_frobenius_norm + 1e-8)
-    cosine_similarity = torch.nn.functional.cosine_similarity(
-        test_output.flatten(), reference_output.flatten(), dim=0
+    relative_frobenius_error, cosine_similarity = (
+        calculate_rel_frobenius_and_cosine_similarity(reference_output, test_output)
+    )
+    reference_frobenius_norm = torch.linalg.norm(
+        reference_output.to(torch.float32)
     ).item()
 
     # Relative Frobenius is unstable when the reference norm is at quantization-noise scale.


### PR DESCRIPTION
Add the possibility to convert torch.nn.Linear modules to MXFP format. The feature works by replacing all torch.nn.Linear submodules inside a graph by a custom implemented MXFP counterpart: `MXFPLinearOp`.

A new user API called `to_mxfp` has been added to enable this feature (located in backends/arm/ao_ext/mxfp.py). The API is tagged as experimental for now.

An eager CPU and fake implementation is added to the new custom op, but lowering it TOSA is handled in a later patch. To summarize, this patch enables the following flow:

```python
m = MyModule()

to_mxfp(m, MXFPOpConfig())

m.forward(x)
```

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani