### PR TITLE
NXP backend: added support for `slice` using new Neutron flow

### DIFF
--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/slice_tensor_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/slice_tensor_converter.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import numpy as np
+import torch
 from executorch.backends.nxp.backend.data_format import NXP_NODE_FORMAT
 from executorch.backends.nxp.backend.edge_helper import input_tensor
 from executorch.backends.nxp.backend.ir.converter.conversion import translator
@@ -31,6 +32,15 @@ class SliceTensorConverter(NodeConverter):
         parameters_mapping: dict[str, Parameter],
         custom_delegation_options: CustomDelegationOptions,
     ) -> bool:
+        if custom_delegation_options.use_new_flow_neutron_c:
+            supported_types = [torch.int8, torch.uint8]
+            if not NodeConverter.uses_quantization_type_for_io(
+                node, supported_types, [0], [0]
+            ):
+                return False
+
+            return True
+
         input_shape = input_tensor(node, 0).shape
         dim = node.args[1]
         if node.args[0].meta[NXP_NODE_FORMAT].is_channels_first():
@@ -94,6 +104,23 @@ class SliceTensorConverter(NodeConverter):
         size[dim] = max(end - start, 0)
         begin[dim] = start
 
+        # In the new Neutron flow, slicing can be done along any dim, so
+        # no additional `transpose` ops have to be added.
+        if self.context.custom_delegation_options.use_new_flow_neutron_c:
+            begin_tensor = self.builder.create_tensor_for_data(
+                np.asarray(begin, np.int32), "begin"
+            )
+            size_tensor = self.builder.create_tensor_for_data(
+                np.asarray(size, np.int32), "size"
+            )
+
+            t_op.tmp_inputs = [main_input, begin_tensor, size_tensor]
+            t_op.builtin_options = slice_options.Slice()
+            ops = OpsList(middle_op=t_op)
+
+            self.builder.append_operators(ops.flatten())
+            return None
+
         # We can slice only the channels dimension
         # So we swap the sliced dimension with the channels dimension
         begin[-1], begin[dim] = begin[dim], begin[-1]
@@ -130,6 +157,10 @@ class SliceTensorConverter(NodeConverter):
         input_shape = input_tensor(node, 0).shape
         _, dim, start, end = node.args
         sliced_tensor_rank = input_shape[dim]
+
+        # convert numbering `from the end` to `from the beginning`, ie. normalize
+        end = end + sliced_tensor_rank if end < 0 else end
+        start = start + sliced_tensor_rank if start < 0 else start
 
         end = int(np.clip(end, 0, sliced_tensor_rank))
         start = int(np.clip(start, 0, sliced_tensor_rank))

--- a/backends/nxp/tests/ir/converter/node_converter/test_slice_tensor_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_slice_tensor_converter.py
@@ -8,6 +8,7 @@ import torch
 from executorch.backends.nxp.backend.edge_program_converter import (
     EdgeProgramToIRConverter,
 )
+from executorch.backends.nxp.tests.dataset_creator import RandomDatasetCreator
 from executorch.backends.nxp.tests.executorch_pipeline import to_quantized_edge_program
 from executorch.backends.nxp.tests.executors import (
     convert_run_compare,
@@ -15,12 +16,22 @@ from executorch.backends.nxp.tests.executors import (
     ToChannelFirstPreprocess,
     ToChannelLastPreprocess,
 )
+from executorch.backends.nxp.tests.graph_verifier import DetailedGraphVerifier
+from executorch.backends.nxp.tests.model_output_comparator import (
+    AllCloseOutputComparator,
+)
 
 from executorch.backends.nxp.tests.models import (
     SliceTensorConvModule,
     SliceTensorModule,
 )
-from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
+from executorch.backends.nxp.tests.ops_aliases import (
+    Convolution,
+    ExecutorchDelegateCall,
+    Slice,
+    SliceCopy,
+)
 from torch.export import ExportedProgram
 
 
@@ -28,11 +39,6 @@ from torch.export import ExportedProgram
 def reseed_model_per_test_run():
     torch.manual_seed(23)
     np.random.seed(23)
-
-
-ExecutorchDelegateCall = torch.ops.higher_order.executorch_call_delegate
-Slice = exir_ops.edge.aten.slice.Tensor
-SliceCopy = exir_ops.edge.aten.slice_copy.Tensor
 
 
 passing_cases = [
@@ -238,7 +244,7 @@ def test_slice_tensor_w_conv_quant_conversion(
             (24, 32), (0, 1), (0, 32), (24, 32), id="2D, start is equal to size"
         ),
         pytest.param(
-            (24, 32), (0, 1), (0, 0), (24, -5), id="2D, clipped end equal to zero"
+            (24, 32), (0, 1), (0, 0), (24, -35), id="2D, clipped end equal to zero"
         ),
         pytest.param(
             (24, 32), (0, 1), (64, 0), (24, 32), id="2D, clipped start equal to size"
@@ -298,3 +304,353 @@ def test_slice_not_delegated(mocker, x_input_shape, dims, starts, ends):
     for i in range(0, num_slice_ops):
         slice_idx = (i + 1) * 3
         assert nodes[slice_idx].target in [Slice, SliceCopy]
+
+
+class TestSliceTensorConverterNewNeutronFlow:
+    @staticmethod
+    def _slice_id(prefix, input_shape, dims, starts, ends):
+        return f"{prefix}rank={len(input_shape)}_dims={str(dims)}_starts={str(starts)}_ends={str(ends)}"
+
+    @staticmethod
+    def assert_delegated_and_correct(model, input_shape, num_slices, mocker, use_qat):
+        graph_verifier = DetailedGraphVerifier(
+            mocker,
+            expected_delegated_ops={SliceCopy: num_slices},
+            expected_non_delegated_ops={},
+        )
+        dataset = RandomDatasetCreator(low=-255.0, high=255.0)
+        comparator = AllCloseOutputComparator()
+
+        lower_run_compare(
+            model,
+            input_shape,
+            graph_verifier,
+            dataset,
+            comparator,
+            use_new_flow_neutron_c=True,
+            use_qat=use_qat,
+        )
+
+    @staticmethod
+    def assert_model_without_slices(model, input_shape):
+        delegated_ep = to_quantized_edge_program(
+            model, input_shape, use_new_flow_neutron_c=True
+        ).exported_program()
+
+        # Check there are no slices and nothing is delegated
+        assert not graph_contains_any_of_ops(
+            delegated_ep.graph, [ExecutorchDelegateCall]
+        )
+        assert not graph_contains_any_of_ops(delegated_ep.graph, [Slice, SliceCopy])
+
+    @staticmethod
+    def assert_not_delegated(model, input_shape):
+        delegated_ep = to_quantized_edge_program(
+            model, input_shape, use_new_flow_neutron_c=True
+        ).exported_program()
+
+        # Make sure the `slice` was NOT delegated.
+        assert not graph_contains_any_of_ops(
+            delegated_ep.graph, [ExecutorchDelegateCall]
+        )
+        assert graph_contains_any_of_ops(delegated_ep.graph, [Slice, SliceCopy])
+
+    @pytest.mark.parametrize(
+        "input_shape, dims, starts, ends",
+        [
+            pytest.param(
+                ins := (5, 2, 3, 4),
+                d := (0,),
+                s := (1,),
+                e := (4,),
+                id=_slice_id("basic, left and right trimmed:", ins, d, s, e),
+            ),
+            pytest.param(
+                ins := (5, 5, 3, 4),
+                d := (0, 1),
+                s := (1, 1),
+                e := (4, 3),
+                id=_slice_id("basic, left and right trimmed:", ins, d, s, e),
+            ),
+            pytest.param(
+                ins := (7, 13, 5, 15),
+                d := (0, 1, 2, 3),
+                s := (4, 3, 1, 8),
+                e := (5, 10, 4, 11),
+                id=_slice_id("basic, left and right trimmed:", ins, d, s, e),
+            ),
+            pytest.param(
+                ins := (5, 13, 5, 13),
+                d := (0, 1, 2, 3),
+                s := (0, 0, 0, 0),
+                e := (4, 11, 4, 11),
+                id=_slice_id("basic, right trimmed:", ins, d, s, e),
+            ),
+            pytest.param(
+                ins := (7, 13, 3, 15),
+                d := (0, 1, 2, 3),
+                s := (2, 5, 1, 4),
+                e := ins,
+                id=_slice_id("basic, left trimmed:", ins, d, s, e),
+            ),
+            pytest.param(
+                ins := (7, 4, 7),
+                d := (0, 1, 2),
+                s := (1, 1, 3),
+                e := (6, 3, 5),
+                id=_slice_id("basic, left and right trimmed:", ins, d, s, e),
+            ),
+            pytest.param(
+                ins := (4, 5, 9),
+                d := (0, 1, 2),
+                s := (0, 0, 0),
+                e := (3, 4, 7),
+                id=_slice_id("basic, right trimmed:", ins, d, s, e),
+            ),
+            pytest.param(
+                ins := (4, 7, 9),
+                d := (0, 1, 2),
+                s := (3, 2, 2),
+                e := ins,
+                id=_slice_id("basic, left trimmed:", ins, d, s, e),
+            ),
+            pytest.param(
+                ins := (4, 5),
+                d := (0, 1),
+                s := (1, 1),
+                e := (2, 4),
+                id=_slice_id("basic, left and right trimmed:", ins, d, s, e),
+            ),
+            pytest.param(
+                ins := (4, 5),
+                d := (0, 1),
+                s := (0, 0),
+                e := (2, 4),
+                id=_slice_id("basic, right trimmed:", ins, d, s, e),
+            ),
+            pytest.param(
+                ins := (4, 5),
+                d := (0, 1),
+                s := (1, 2),
+                e := ins,
+                id=_slice_id("basic, left trimmed:", ins, d, s, e),
+            ),
+            pytest.param(
+                ins := (5,),
+                d := (0,),
+                s := (1,),
+                e := (4,),
+                id=_slice_id("basic, left and right trimmed:", ins, d, s, e),
+            ),
+            pytest.param(
+                ins := (5,),
+                d := (0,),
+                s := (0,),
+                e := (4,),
+                id=_slice_id("basic, right trimmed:", ins, d, s, e),
+            ),
+            pytest.param(
+                ins := (5,),
+                d := (0,),
+                s := (1,),
+                e := ins,
+                id=_slice_id("basic, left trimmed:", ins, d, s, e),
+            ),
+        ],
+    )
+    def test_nsys_inference__basic(self, input_shape, dims, starts, ends, mocker):
+        model = SliceTensorModule(dims, starts, ends)
+
+        num_slices = len(dims)
+        self.assert_delegated_and_correct(
+            model, input_shape, num_slices, mocker, use_qat=False
+        )
+
+    @pytest.mark.parametrize(
+        "input_shape, dims, starts, ends",
+        [
+            pytest.param(
+                ins := (4, 2, 7, 4),
+                d := (2,),
+                s := (5,),
+                e := (6,),
+                id=_slice_id("edge case, dimension reduced to 1:", ins, d, s, e),
+            ),
+            pytest.param(
+                ins := (11, 2, 7, 5),
+                d := (2,),
+                s := (6,),
+                e := (6,),
+                id=_slice_id("edge case, dimension reduced to 0:", ins, d, s, e),
+            ),
+        ],
+    )
+    def test_nsys_inference__reduction(self, input_shape, dims, starts, ends, mocker):
+        model = SliceTensorModule(dims, starts, ends)
+
+        slice_lengths = [e - s for s, e in zip(starts, ends)]
+        if all(sl == 0 for sl in slice_lengths):
+            # reductions to 0 are disabled in the backend
+            self.assert_not_delegated(model, input_shape)
+        else:
+            num_slices = len(dims)
+            self.assert_delegated_and_correct(
+                model, input_shape, num_slices, mocker, use_qat=False
+            )
+
+    @pytest.mark.parametrize(
+        "input_shape, dims, starts, ends",
+        [
+            pytest.param(
+                ins := (5, 2, 3, 4),
+                d := (0,),
+                s := (-12,),
+                e := (2,),
+                id=_slice_id("edge case, `start` clipped:", ins, d, s, e),
+            ),
+            pytest.param(
+                ins := (5, 7, 5, 7),
+                d := (0,),
+                s := (1,),
+                e := (12,),
+                id=_slice_id("edge case, `end` clipped:", ins, d, s, e),
+            ),
+        ],
+    )
+    def test_nsys_inference__clipped(self, input_shape, dims, starts, ends, mocker):
+        model = SliceTensorModule(dims, starts, ends)
+
+        num_slices = len(dims)
+        self.assert_delegated_and_correct(
+            model, input_shape, num_slices, mocker, use_qat=False
+        )
+
+    @pytest.mark.parametrize(
+        "input_shape, dims, starts, ends",
+        [
+            pytest.param(
+                ins := (5, 11, 13, 3),
+                d := (1,),
+                s := (-5,),
+                e := (10,),
+                id=_slice_id("edge case, `start` normalized:", ins, d, s, e),
+            ),
+            pytest.param(
+                ins := (7, 15, 5, 7),
+                d := (1,),
+                s := (2,),
+                e := (-2,),
+                id=_slice_id("edge case, `end` normalized:", ins, d, s, e),
+            ),
+        ],
+    )
+    def test_nsys_inference__normalization(
+        self, input_shape, dims, starts, ends, mocker
+    ):
+        model = SliceTensorModule(dims, starts, ends)
+
+        num_slices = len(dims)
+        self.assert_delegated_and_correct(
+            model, input_shape, num_slices, mocker, use_qat=False
+        )
+
+    @pytest.mark.parametrize(
+        "input_shape, dims, starts, ends",
+        [
+            pytest.param(
+                ins := (5000, 3, 5, 3),
+                d := (0,),
+                s := (1250,),
+                e := (2500,),
+                id=_slice_id("big args, left and right trimmed:", ins, d, s, e),
+            ),
+            pytest.param(
+                ins := (2, 5000, 5, 3),
+                d := (1,),
+                s := (0,),
+                e := (4999,),
+                id=_slice_id("big args, right trimmed:", ins, d, s, e),
+            ),
+            pytest.param(
+                ins := (2, 3, 5000, 3),
+                d := (2,),
+                s := (1,),
+                e := (5000,),
+                id=_slice_id("big args, left trimmed:", ins, d, s, e),
+            ),
+        ],
+    )
+    def test_nsys_inference__big(self, input_shape, dims, starts, ends, mocker):
+        model = SliceTensorModule(dims, starts, ends)
+
+        num_slices = len(dims)
+        self.assert_delegated_and_correct(
+            model, input_shape, num_slices, mocker, use_qat=False
+        )
+
+    @pytest.mark.parametrize(
+        "input_shape, dims, starts, ends",
+        [
+            pytest.param(
+                ins := (5, 2, 3, 4),
+                d := (2,),
+                s := (0,),
+                e := (3,),
+                id=_slice_id("edge case, one dimension identity:", ins, d, s, e),
+            ),
+            pytest.param(
+                ins := (5, 2, 3, 4),
+                d := (0, 1, 2, 3),
+                s := (0, 0, 0, 0),
+                e := ins,
+                id=_slice_id("edge case, all dimensions identity:", ins, d, s, e),
+            ),
+        ],
+    )
+    def test_nsys_inference__identity(self, input_shape, dims, starts, ends):
+        model = SliceTensorModule(dims, starts, ends)
+
+        self.assert_model_without_slices(model, input_shape)
+
+    def test_nsys_inference__with_conv(self, mocker):
+        input_shape = (11, 13, 5, 7)
+        in_channels = input_shape[1]
+        out_channels = 19
+
+        # we test functionality on `channels` dim
+        dims = (1,)
+        starts = (2,)
+        ends = (out_channels - 2,)
+        model = SliceTensorConvModule(dims, starts, ends, in_channels, out_channels)
+
+        num_slices = len(dims)
+        graph_verifier = DetailedGraphVerifier(
+            mocker,
+            expected_delegated_ops={SliceCopy: num_slices},
+            expected_non_delegated_ops={Convolution: 1},
+        )
+        dataset = RandomDatasetCreator(low=-255.0, high=255.0)
+        comparator = AllCloseOutputComparator()
+
+        lower_run_compare(
+            model,
+            input_shape,
+            graph_verifier,
+            dataset,
+            comparator,
+            use_new_flow_neutron_c=True,
+            use_qat=False,
+        )
+
+    def test_nsys_inference__qat(self, mocker):
+        input_shape = (7, 13, 7, 9)
+        dims = (0, 1, 2, 3)
+        starts = (1, 2, 3, 2)
+        ends = (6, 10, 5, 8)
+
+        model = SliceTensorModule(dims, starts, ends)
+
+        num_slices = len(dims)
+        self.assert_delegated_and_correct(
+            model, input_shape, num_slices, mocker, use_qat=True
+        )


### PR DESCRIPTION
### Summary

Added support for `aten.slice` using new Neutron flow.

### Test plan

tests can be manually run using `pytest -c /dev/null backends/nxp/tests/`

cc @robert-kalmar @JakeStevens @digantdesai @rascani @MartinPavella @roman-janik-nxp @jirioc @irtrukhina @StrycekSimon 