### PR TITLE
NXP backend: Enable integer inputs model testing

### DIFF
--- a/backends/nxp/tests/dataset_creator.py
+++ b/backends/nxp/tests/dataset_creator.py
@@ -8,6 +8,7 @@ import os.path
 import shutil
 from collections import OrderedDict
 from copy import deepcopy
+from dataclasses import dataclass
 from os import mkdir
 from random import sample, seed
 
@@ -19,6 +20,7 @@ from executorch.backends.nxp.backend.ir.converter.conversion.translator import (
 )
 from executorch.backends.nxp.tests.calibration_dataset import CalibrationDataset
 from executorch.backends.nxp.tests.executorch_pipeline import ModelInputSpec
+from executorch.exir.scalar_type import ScalarType
 from torch import Tensor
 
 
@@ -31,6 +33,72 @@ def _get_calibration_and_testing_dataset_directory_names(
     mkdir(calibration_path := os.path.join(dataset_dir_name, "calibration"))
     mkdir(test_path := os.path.join(dataset_dir_name, "test"))
     return calibration_path, test_path
+
+
+@dataclass
+class InputQuantizationSpec:
+    name: str
+    scale: float
+    zp: int
+    dtype: ScalarType
+
+
+def _replace_input_binary_tensor_with_quantized_variant(
+    input_bin_tensor_path: str,
+    input_spec: ModelInputSpec,
+    q_params: InputQuantizationSpec,
+):
+    tensor = np.fromfile(
+        input_bin_tensor_path, dtype=torch_type_to_numpy_type(input_spec.dtype)
+    )
+    if q_params.dtype == ScalarType.CHAR:
+        tensor = np.add(np.round(np.divide(tensor, [q_params.scale])), [q_params.zp])
+        tensor = np.clip(tensor, -128, 127).astype(np.int8)
+    else:
+        raise ValueError(f"Unknown quantization type: '{q_params.dtype}.")
+    tensor.tofile(input_bin_tensor_path)
+
+
+def create_quantized_variant_of_dataset(
+    dataset_dir: str,
+    dataset_dir_quant: str,
+    input_quant_spec: list[InputQuantizationSpec],
+    input_spec: list[ModelInputSpec],
+):
+    """
+    Create quantized dataset from provided quantization spec. Dataset is cloned from directory 'dataset_dir'.
+
+    :param dataset_dir: Original (float) dataset directory.
+    :param dataset_dir_quant: Quantized dataset directory.
+    :param input_quant_spec: Quantization parameters used for dataset quantization.
+    :param input_spec: Model inputs specification.
+    """
+    assert len(input_quant_spec) > 0
+
+    shutil.copytree(dataset_dir, dataset_dir_quant, dirs_exist_ok=True)
+
+    if len(input_quant_spec) == 1:
+        # Single input dataset - quantize only files in dataset's root dir with first input_quant_spec
+        input_spec = input_spec[0]
+        input_quant_spec = input_quant_spec[0]
+
+        for file in os.listdir(dataset_dir_quant):
+            input_bin_tensor_path = os.path.join(dataset_dir_quant, file)
+            _replace_input_binary_tensor_with_quantized_variant(
+                input_bin_tensor_path, input_spec, input_quant_spec
+            )
+    else:
+        # Iterate over samples (subfolders)
+        for dir_ in os.listdir(dataset_dir_quant):
+            # Iterate over each input in sample
+            sample_dir = os.path.join(dataset_dir_quant, dir_)
+
+            for idx, input_ in enumerate(sorted(os.listdir(sample_dir))):
+                _replace_input_binary_tensor_with_quantized_variant(
+                    os.path.join(sample_dir, input_),
+                    input_spec[idx],
+                    input_quant_spec[idx],
+                )
 
 
 class DatasetCreator(abc.ABC):

--- a/backends/nxp/tests/executorch_pipeline.py
+++ b/backends/nxp/tests/executorch_pipeline.py
@@ -276,6 +276,8 @@ def to_quantized_executorch_program(
     dataset_dir: str | None = None,
     delegate_to_npu=True,
     use_new_flow_neutron_c: bool = False,
+    operators_not_to_delegate: list[str] = None,
+    remove_quant_io_ops: bool = False,
 ) -> ExecutorchProgramManager:
     if dataset_dir:
         # Extract calibration data from a directory.
@@ -295,6 +297,8 @@ def to_quantized_executorch_program(
         use_neutron_for_format_conversion=use_neutron_for_format_conversion,
         delegate_to_npu=delegate_to_npu,
         use_new_flow_neutron_c=use_new_flow_neutron_c,
+        operators_not_to_delegate=operators_not_to_delegate,
+        remove_quant_io_ops=remove_quant_io_ops,
         **get_calibration_inputs_fn,
     )
 

--- a/backends/nxp/tests/generic_tests/test_quantized_input_data.py
+++ b/backends/nxp/tests/generic_tests/test_quantized_input_data.py
@@ -1,0 +1,130 @@
+# Copyright 2026 NXP
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import executorch.backends.nxp.tests.nsys_testing as nsys_testing
+import torch
+
+from executorch.backends.nxp.tests.executorch_pipeline import ModelInputSpec
+from executorch.backends.nxp.tests.graph_verifier import DetailedGraphVerifier
+from executorch.backends.nxp.tests.models import AvgPool2dModule, MulTensorModule
+from executorch.backends.nxp.tests.nsys_testing import (
+    lower_run_compare,
+    OUTPUTS_DIR,
+    ReferenceModel,
+)
+from executorch.backends.nxp.tests.ops_aliases import AvgPool2D, MulTensor
+
+
+def test__single_quantized_inputs(mocker):
+    input_spec = ModelInputSpec((2, 4, 6, 7))
+    model = AvgPool2dModule(False, 0)
+    graph_verifier = DetailedGraphVerifier(
+        mocker, expected_delegated_ops={AvgPool2D: 1}, expected_non_delegated_ops={}
+    )
+    output_tensor_spec_spy = mocker.spy(nsys_testing, "_get_program_output_spec")
+
+    lower_run_compare(
+        model,
+        [input_spec],
+        graph_verifier,
+        use_new_flow_neutron_c=True,
+        remove_quant_io_ops=True,
+    )
+
+    assert (
+        OUTPUTS_DIR / "test__single_quantized_inputs" / "dataset_quant" / "0000.bin"
+    ).exists()
+
+    # Check outputs are in quantized int8 format
+    output_tensor_spec = output_tensor_spec_spy.spy_return
+    assert output_tensor_spec[0].dtype == torch.int8
+
+
+def test__single_quantized_inputs_edge_python_reference(mocker):
+    input_spec = ModelInputSpec((2, 4, 6, 7))
+    model = AvgPool2dModule(False, 0)
+    graph_verifier = DetailedGraphVerifier(
+        mocker, expected_delegated_ops={AvgPool2D: 1}, expected_non_delegated_ops={}
+    )
+    output_tensor_spec_spy = mocker.spy(nsys_testing, "_get_program_output_spec")
+
+    lower_run_compare(
+        model,
+        [input_spec],
+        graph_verifier,
+        reference_model=ReferenceModel.QUANTIZED_EDGE_PYTHON,
+        use_new_flow_neutron_c=True,
+        remove_quant_io_ops=True,
+    )
+
+    assert (
+        OUTPUTS_DIR
+        / "test__single_quantized_inputs_edge_python_reference"
+        / "dataset_quant"
+        / "0000.bin"
+    ).exists()
+
+    # Check outputs are in quantized int8 format
+    output_tensor_spec = output_tensor_spec_spy.spy_return
+    assert output_tensor_spec[0].dtype == torch.int8
+
+
+def test__multiple_quantized_inputs(mocker):
+    x_input_spec = ModelInputSpec((1, 4, 8, 8))
+    model = MulTensorModule()
+    graph_verifier = DetailedGraphVerifier(
+        mocker, expected_delegated_ops={MulTensor: 1}, expected_non_delegated_ops={}
+    )
+    output_tensor_spec_spy = mocker.spy(nsys_testing, "_get_program_output_spec")
+
+    lower_run_compare(
+        model,
+        [x_input_spec, x_input_spec],
+        graph_verifier,
+        use_new_flow_neutron_c=True,
+        remove_quant_io_ops=True,
+    )
+
+    assert (
+        OUTPUTS_DIR
+        / "test__multiple_quantized_inputs"
+        / "dataset_quant"
+        / "0000"
+        / "00.bin"
+    ).exists()
+
+    # Check outputs are in quantized int8 format
+    output_tensor_spec = output_tensor_spec_spy.spy_return
+    assert output_tensor_spec[0].dtype == torch.int8
+
+
+def test__multiple_quantized_inputs_edge_python_reference(mocker):
+    x_input_spec = ModelInputSpec((1, 4, 8, 8))
+    model = MulTensorModule()
+    graph_verifier = DetailedGraphVerifier(
+        mocker, expected_delegated_ops={MulTensor: 1}, expected_non_delegated_ops={}
+    )
+    output_tensor_spec_spy = mocker.spy(nsys_testing, "_get_program_output_spec")
+
+    lower_run_compare(
+        model,
+        [x_input_spec, x_input_spec],
+        graph_verifier,
+        reference_model=ReferenceModel.QUANTIZED_EDGE_PYTHON,
+        use_new_flow_neutron_c=True,
+        remove_quant_io_ops=True,
+    )
+
+    assert (
+        OUTPUTS_DIR
+        / "test__multiple_quantized_inputs_edge_python_reference"
+        / "dataset_quant"
+        / "0000"
+        / "00.bin"
+    ).exists()
+
+    # Check outputs are in quantized int8 format
+    output_tensor_spec = output_tensor_spec_spy.spy_return
+    assert output_tensor_spec[0].dtype == torch.int8

--- a/backends/nxp/tests/nsys_testing.py
+++ b/backends/nxp/tests/nsys_testing.py
@@ -23,7 +23,11 @@ from executorch.backends.nxp.backend.ir.converter.conversion.translator import (
 )
 from executorch.backends.nxp.neutron_partitioner import NeutronPartitioner
 from executorch.backends.nxp.tests.config_importer import test_config
-from executorch.backends.nxp.tests.dataset_creator import RandomDatasetCreator
+from executorch.backends.nxp.tests.dataset_creator import (
+    create_quantized_variant_of_dataset,
+    InputQuantizationSpec,
+    RandomDatasetCreator,
+)
 from executorch.backends.nxp.tests.executorch_pipeline import (
     get_calibration_inputs_fn_from_dataset_dir,
     ModelInputSpec,
@@ -61,20 +65,7 @@ class ReferenceModel(Enum):
     FLOAT_PYTORCH_PYTHON = 4
 
 
-def _run_delegated_executorch_program(
-    model,
-    test_dir,
-    test_name,
-    calibration_dataset_dir,
-    testing_dataset_dir,
-    input_spec,
-    dlg_model_verifier,
-    npu_results_dir,
-    mocker,
-    use_qat: bool = False,
-    train_fn: Callable[[torch.fx.GraphModule], None] | None = None,
-    use_new_flow_neutron_c: bool = False,
-) -> ExportedProgram:
+def _get_dataset_cli_args(input_spec: list[ModelInputSpec], testing_dataset_dir):
     if len(input_spec) == 1:
         # Single input, use --dataset
         dataset_cli = "--dataset"
@@ -90,14 +81,25 @@ def _run_delegated_executorch_program(
                 ]
             )
         )
+    return dataset_cli, dataset_or_inputs
 
-    # Run nxp_executor_runner with program delegated to NPU
-    delegated_model_path = os.path.abspath(
-        os.path.join(test_dir, f"{test_name}_delegated.pte")
-    )
 
-    delegated_cmd = f"{NEUTRON_TEST_PATH} --model {delegated_model_path} {dataset_cli} {dataset_or_inputs} \
-        --output {npu_results_dir} --firmware {NSYS_FIRMWARE_PATH} --nsys {NSYS_PATH} --nsys_config {NSYS_CONFIG_PATH}"
+def _run_delegated_executorch_program(
+    model,
+    test_dir,
+    test_name,
+    calibration_dataset_dir,
+    testing_dataset_dir,
+    input_spec,
+    dlg_model_verifier,
+    npu_results_dir,
+    mocker,
+    use_qat: bool = False,
+    train_fn: Callable[[torch.fx.GraphModule], None] | None = None,
+    use_new_flow_neutron_c: bool = False,
+    operators_not_to_delegate: list[str] = None,
+    remove_quant_io_ops: bool = False,
+) -> tuple[ExportedProgram, str]:
     try:
         if mocker:
             method = getattr(NeutronPartitioner, "partition")  # noqa B009
@@ -123,6 +125,8 @@ def _run_delegated_executorch_program(
             use_qat=use_qat,
             train_fn=train_fn,
             use_new_flow_neutron_c=use_new_flow_neutron_c,
+            operators_not_to_delegate=operators_not_to_delegate,
+            remove_quant_io_ops=remove_quant_io_ops,
         )
     except RuntimeError as e:
         if "Model converted with neutron-converter has" in str(e) and hasattr(
@@ -139,9 +143,30 @@ def _run_delegated_executorch_program(
     dlg_model_verifier.verify_graph(exported_program.graph)
 
     save_pte_program(delegated_program, test_name + "_delegated", test_dir)
+
+    # Preparation of quantized dataset, requires quantization parameters from converted delegated model
+    if remove_quant_io_ops:
+        dataset_dir_quant = os.path.join(test_dir, "dataset_quant")
+        input_quant_spec = _parse_input_quant_params(input_spec, delegated_program)
+        create_quantized_variant_of_dataset(
+            testing_dataset_dir, dataset_dir_quant, input_quant_spec, input_spec
+        )
+        testing_dataset_dir = dataset_dir_quant
+
+    dataset_cli, dataset_or_inputs = _get_dataset_cli_args(
+        input_spec, testing_dataset_dir
+    )
+
+    # Run nxp_executor_runner with program delegated to NPU
+    delegated_model_path = os.path.abspath(
+        os.path.join(test_dir, f"{test_name}_delegated.pte")
+    )
+
+    delegated_cmd = f"{NEUTRON_TEST_PATH} --model {delegated_model_path} {dataset_cli} {dataset_or_inputs} \
+        --output {npu_results_dir} --firmware {NSYS_FIRMWARE_PATH} --nsys {NSYS_PATH} --nsys_config {NSYS_CONFIG_PATH}"
     execute_cmd(delegated_cmd)
 
-    return exported_program
+    return exported_program, testing_dataset_dir
 
 
 def _run_non_delegated_executorch_program(
@@ -154,30 +179,11 @@ def _run_non_delegated_executorch_program(
     cpu_results_dir,
     use_qat: bool = False,
     train_fn: Callable[[torch.fx.GraphModule], None] | None = None,
+    remove_quant_io_ops: bool = False,
 ) -> ExportedProgram:
-    if len(input_spec) == 1:
-        # Single input, use --dataset
-        dataset_cli = "--dataset"
-        dataset_or_inputs = testing_dataset_dir
-    else:
-        # Multiple input, use --inputs with subdirectories
-        dataset_cli = "--inputs"
-        dataset_or_inputs = ",".join(
-            sorted(
-                [
-                    os.path.join(testing_dataset_dir, d)
-                    for d in os.listdir(testing_dataset_dir)
-                ]
-            )
-        )
-
-    # Run program via nxp_executor_runner on CPU
-    non_delegated_model_path = os.path.abspath(
-        os.path.join(test_dir, f"{test_name}_non_delegated.pte")
+    dataset_cli, dataset_or_inputs = _get_dataset_cli_args(
+        input_spec, testing_dataset_dir
     )
-
-    non_delegated_cmd = f"{NEUTRON_TEST_PATH} --model {non_delegated_model_path} {dataset_cli} {dataset_or_inputs} \
-        --output {cpu_results_dir} --firmware {NSYS_FIRMWARE_PATH} --nsys {NSYS_PATH} --nsys_config {NSYS_CONFIG_PATH}"
 
     non_delegated_program = to_quantized_executorch_program(
         model,
@@ -186,6 +192,7 @@ def _run_non_delegated_executorch_program(
         delegate_to_npu=False,
         use_qat=use_qat,
         train_fn=train_fn,
+        remove_quant_io_ops=remove_quant_io_ops,
     )
 
     nodes = list(non_delegated_program.exported_program().graph.nodes)
@@ -194,6 +201,14 @@ def _run_non_delegated_executorch_program(
     ), "Delegated parts found in program executed on CPU!"
 
     save_pte_program(non_delegated_program, test_name + "_non_delegated", test_dir)
+
+    # Run program via nxp_executor_runner on CPU
+    non_delegated_model_path = os.path.abspath(
+        os.path.join(test_dir, f"{test_name}_non_delegated.pte")
+    )
+
+    non_delegated_cmd = f"{NEUTRON_TEST_PATH} --model {non_delegated_model_path} {dataset_cli} {dataset_or_inputs} \
+        --output {cpu_results_dir} --firmware {NSYS_FIRMWARE_PATH} --nsys {NSYS_PATH} --nsys_config {NSYS_CONFIG_PATH}"
     execute_cmd(non_delegated_cmd)
 
     return non_delegated_program.exported_program()
@@ -229,9 +244,9 @@ def read_prepared_samples(
                 bin_file_path = os.path.join(
                     sample_dir, f"{str(spec_idx).zfill(2)}.bin"
                 )
-                sample_vector = np.fromfile(bin_file_path, dtype=spec.type).reshape(
-                    spec.shape
-                )
+                sample_vector = np.fromfile(
+                    bin_file_path, dtype=torch_type_to_numpy_type(spec.dtype)
+                ).reshape(spec.shape)
                 current_samples.append(sample_vector)
 
             all_samples.append(tuple(current_samples))
@@ -385,6 +400,8 @@ def lower_run_compare(
     use_qat: bool = False,
     train_fn: Callable[[torch.fx.GraphModule], None] | None = None,
     use_new_flow_neutron_c: bool = False,
+    operators_not_to_delegate: list[str] = None,
+    remove_quant_io_ops: bool = False,
 ):
     """
     Run provided program twice with neutron-test and check if results correspond. At first,
@@ -402,6 +419,10 @@ def lower_run_compare(
     :param use_qat: If True, applies quantization-aware training before conversion (without the QAT training).
     :param train_fn: Train/finetune function for QAT training. Is used only when `use_qat=True`.
     :param use_new_flow_neutron_c: Enable experimental MLIR-based flow for Neutron-C with improved INT8 operator support.
+    :param operators_not_to_delegate: list of operators not to delegate.
+    :param remove_quant_io_ops: If true, IO q-ops are removed and verification is done on quantized
+        version of dataset (quantized INT8 input samples).
+
     """
     assert_NSYS()
 
@@ -430,7 +451,7 @@ def lower_run_compare(
     cpu_results_dir = os.path.join(test_dir, "results_cpu")
     npu_results_dir = os.path.join(test_dir, "results_npu")
 
-    delegated_program = _run_delegated_executorch_program(
+    delegated_program, testing_dataset_dir = _run_delegated_executorch_program(
         model_to_delegate,
         test_dir,
         test_name,
@@ -443,6 +464,8 @@ def lower_run_compare(
         use_qat=use_qat,
         train_fn=train_fn,
         use_new_flow_neutron_c=use_new_flow_neutron_c,
+        operators_not_to_delegate=operators_not_to_delegate,
+        remove_quant_io_ops=remove_quant_io_ops,
     )
 
     output_spec = _get_program_output_spec(delegated_program)
@@ -461,6 +484,7 @@ def lower_run_compare(
                 cpu_results_dir,
                 use_qat=use_qat,
                 train_fn=train_fn,
+                remove_quant_io_ops=remove_quant_io_ops,
             )
 
         case ReferenceModel.QUANTIZED_EDGE_PYTHON:
@@ -475,10 +499,19 @@ def lower_run_compare(
                     delegate_to_npu=False,
                     use_qat=use_qat,
                     train_fn=train_fn,
+                    remove_quant_io_ops=remove_quant_io_ops,
                 )
                 .exported_program()
                 .module()
             )
+            # Switch input spec dtype to quantized int8 if run with remove_quant_io_ops flag
+            # The input spec has to still have float32 dtype during edge program lowering to correctly calibrate the
+            # model. When running in Python, the testing data are loaded from numpy tensors according to input spec.
+            # There the testing data are in quantized int8 dtype.
+            if remove_quant_io_ops:
+                for spec in input_spec:
+                    spec.dtype = torch.int8
+
             _run_python_program(
                 non_delegated_edge_program,
                 testing_dataset_dir,
@@ -489,6 +522,12 @@ def lower_run_compare(
             )
 
         case ReferenceModel.FLOAT_PYTORCH_PYTHON:
+            if remove_quant_io_ops:
+                raise ValueError(
+                    "Flag remove_quant_io_ops is not applicable to FLOAT_PYTORCH_PYTHON reference model"
+                    "as it works with float data only. Run with remove_quant_io_ops=False."
+                )
+
             # Run the PyTorch nn.Module directly in Python.
             _run_python_program(
                 model_to_not_delegate,
@@ -561,7 +600,7 @@ def lower_run_compare_ptq_qat(
     ptq_results_dir = os.path.join(test_dir, "results_ptq")
     qat_results_dir = os.path.join(test_dir, "results_qat")
 
-    delegated_program_ptq = _run_delegated_executorch_program(
+    delegated_program_ptq, _ = _run_delegated_executorch_program(
         model_ptq,
         test_dir,
         test_name,
@@ -597,12 +636,39 @@ def lower_run_compare_ptq_qat(
     )
 
 
+def _parse_input_quant_params(
+    input_spec: tuple[ModelInputSpec, ...], exported_program_manager
+) -> list[InputQuantizationSpec]:
+    """
+    Parse input quantization params from provided exported program manager.
+
+    :param input_spec: Model inputs specification.
+    :param exported_program_manager: Exported program manager of parsed model.
+    :return: List of input quantization specification.
+    """
+    if (config_methods := exported_program_manager._config_methods) is None:
+        raise ValueError("Attempt to parse q-params for not fully quantized model")
+
+    q_params = []
+
+    for idx in range(len(input_spec)):
+        input_name = f"input{idx}"
+        scale = config_methods[f"{input_name}_scale"]
+        zp = config_methods[f"{input_name}_zp"]
+        dtype = config_methods[f"{input_name}_dtype"]
+
+        q_params.append(InputQuantizationSpec(input_name, scale, zp, dtype))
+
+    return q_params
+
+
 def _get_caller_name():
     test_function_names = ["lower_run_compare", "lower_run_compare_ptq_qat"]
     for idx, frame in enumerate(inspect.stack()):
         if frame.function in test_function_names:
             # Look one index above to get caller
             return inspect.stack()[idx + 1].function
+    return None
 
 
 def execute_cmd(cmd, cwd="."):


### PR DESCRIPTION
### Summary
Enables to test Neutron delegate with int data created by quantization of generated float data and removed input and output quantization nodes. Turns model to int variant.

### Test plan
Tests provided.


cc @robert-kalmar 