### PR TITLE
[executorch][qualcomm] Add op_fallback.py to model_sharding_py BUCK target

### DIFF
--- a/extension/llm/custom_ops/targets.bzl
+++ b/extension/llm/custom_ops/targets.bzl
@@ -141,6 +141,7 @@ def define_common_targets():
         name = "model_sharding_py",
         srcs = [
             "model_sharding.py",
+            "op_fallback.py",
         ],
         visibility = ["PUBLIC"],
         deps = [


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #19809

The parent diff D106350693 imports `executorch.extension.llm.custom_ops.op_fallback` from `model_sharding.py`, but did not add `op_fallback.py` to the `model_sharding_py` python_library target. This caused `ModuleNotFoundError: No module named 'executorch.extension.llm.custom_ops.op_fallback'` when any consumer of `model_sharding_py` tried to import it (e.g. `executorch.examples.models.llama.export_llama_lib`).

Add `op_fallback.py` as a src to the `model_sharding_py` library in both `fbcode/` and `xplat/` `targets.bzl`.

Differential Revision: [D106429294](https://our.internmc.facebook.com/intern/diff/D106429294/)