### PR TITLE
[executorch][runtime] Fix -Werror failures under Apple toolchain

### DIFF
--- a/runtime/core/error.h
+++ b/runtime/core/error.h
@@ -151,8 +151,9 @@ constexpr const char* to_string(const Error error) {
       return "Error::RegistrationExceedingMaxKernels";
     case Error::RegistrationAlreadyRegistered:
       return "Error::RegistrationAlreadyRegistered";
+    default:
+      return "Error::Unknown";
   }
-  return "Error::Unknown";
 }
 
 } // namespace runtime

--- a/runtime/platform/profiler.h
+++ b/runtime/platform/profiler.h
@@ -227,8 +227,12 @@ using ::executorch::runtime::track_allocator;
 #define EXECUTORCH_END_PROF(token_id) \
   ::executorch::runtime::end_profiling(token_id);
 
-#define EXECUTORCH_SCOPE_PROF(name) \
-  ::executorch::runtime::ExecutorchProfiler profiler(name);
+#define EXECUTORCH_SCOPE_PROF_CONCAT_IMPL(a, b) a##b
+#define EXECUTORCH_SCOPE_PROF_CONCAT(a, b) \
+  EXECUTORCH_SCOPE_PROF_CONCAT_IMPL(a, b)
+#define EXECUTORCH_SCOPE_PROF(name)                                       \
+  ::executorch::runtime::ExecutorchProfiler EXECUTORCH_SCOPE_PROF_CONCAT( \
+      et_profiler_, __LINE__)(name);
 
 #define EXECUTORCH_PROFILE_INSTRUCTION_SCOPE(chain_idx, instruction_idx) \
   ::executorch::runtime::ExecutorchProfilerInstructionScope              \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #19789
* __->__ #19811

Two `-Werror` failures surfaced when building `xplat/executorch/runtime` under the iOS toolchain (`-Werror -Wshadow -Wswitch-default`):

1. `EXECUTORCH_SCOPE_PROF` in `runtime/platform/profiler.h` hardcodes the local variable name `profiler`. When the macro is invoked at function scope and again inside a nested block in the same function (for example `Program::load` invokes it at the top of the function and then again inside `check_header` / `verify_internal_consistency` blocks), `-Wshadow` fires and the build fails. Fixed by token-pasting `__LINE__` so each invocation gets a unique identifier. No caller changes required.

2. `to_string(Error)` in `runtime/core/error.h` is a switch statement covering every enum value with a trailing `return "Error::Unknown"` fallback after the switch. Apple's toolchain promotes `-Wswitch-default` to an error and rejects switches that lack an explicit `default:` arm. Folded the trailing fallback into a `default:` arm inside the switch.

Both issues only surfaced under the Apple toolchain; fbcode toolchain does not promote these warnings to errors, so devserver / Linux builds continued to pass.

Differential Revision: [D106523959](https://our.internmc.facebook.com/intern/diff/D106523959/)