### PR TITLE
Remove debug exit(0) blocking test_llama_stories_110m

### DIFF
--- a/backends/qualcomm/tests/test_qnn_delegate.py
+++ b/backends/qualcomm/tests/test_qnn_delegate.py
@@ -7733,8 +7733,6 @@ class TestExampleLLMScript(TestQNN):
         if self.use_fp16:
             cmds.append("--use_fp16")
         self.add_default_cmds(cmds)
-        print(" ".join(cmds))
-        exit(0)
         golden_start_with = "Once upon a time,"
         p = subprocess.Popen(cmds, stdout=subprocess.DEVNULL)
         with Listener((self.ip, self.port)) as listener:


### PR DESCRIPTION
Summary:
Remove debug `print` and `exit(0)` statements accidentally left in `TestExampleLLMScript.test_llama_stories_110m` that cause the test to exit before executing any assertions.

These lines were introduced in commit 508cbf07be38 (PR #19146) and prevent the `test-static-llama-qnn-linux (stories_110m)` CI job from running actual model validation, blocking viable/strict progression.

Differential Revision: D106533426


