### PR TITLE
Fix etsize workflow build failures under -fno-exceptions

### DIFF
--- a/kernels/portable/targets.bzl
+++ b/kernels/portable/targets.bzl
@@ -66,15 +66,19 @@ def define_common_targets():
         "visibility": ["PUBLIC"],
     }
 
-    executorch_generated_lib(
-        name = "generated_lib",
-        deps = [
-            ":executorch_aten_ops",
-            ":executorch_custom_ops",
-        ],
-        kernel_deps = ["//executorch/kernels/portable:operators"],
-        **generated_lib_common_args
-    )
+    for support_exceptions in [True, False]:
+        exception_suffix = "_no_exceptions" if not support_exceptions else ""
+
+        executorch_generated_lib(
+            name = "generated_lib" + exception_suffix,
+            deps = [
+                ":executorch_aten_ops",
+                ":executorch_custom_ops",
+            ],
+            kernel_deps = ["//executorch/kernels/portable:operators"],
+            support_exceptions = support_exceptions,
+            **generated_lib_common_args
+        )
 
     if True in get_aten_mode_options():
         executorch_generated_lib(

--- a/test/targets.bzl
+++ b/test/targets.bzl
@@ -36,7 +36,9 @@ def define_common_targets():
         name = "size_test_all_ops",
         srcs = SIZE_TEST_SOURCES,
         deps = SIZE_TEST_DEPS + [
-            "//executorch/kernels/portable:generated_lib",
+            # size_test_all_ops is built with -fno-exceptions in the size CI;
+            # use the _no_exceptions variant whose codegen omits try/catch.
+            "//executorch/kernels/portable:generated_lib_no_exceptions",
             "//executorch/runtime/executor/test:test_backend_compiler_lib",
         ],
         define_static_target = True,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #19815

The `tools/skycastle/workflows2/pytorch_edge/etsize.sky:post_commit` workflow has been failing because the ExecuTorch x86 size tests cannot compile under `-fno-exceptions -fno-rtti`. Two independent issues, both pre-existing but masked by build caching:

**Issue 1: `ATen/cpu/vec/vec_half.h` uses `TORCH_CHECK(false, ...)` under `-fno-exceptions`.**

ExecuTorch's `runtime/core/portable_type/c10/c10/targets.bzl` defines `-DCPU_CAPABILITY_AVX2` for x86_64 fbcode builds to get fast `_cvtss_sh`/`_cvtsh_ss` fp16<->float32 scalar intrinsics via `torch/headeronly/cpu/vec/vec_half.h`. As a side effect, the BC include in `c10/util/Half.h` pulls in `<ATen/cpu/vec/vec_half.h>`, which contains `TORCH_CHECK(false, "pack_vnni2 is only supported when avx512 is supported")` in the non-AVX512 `#else` branch of the `transpose_pad_2x32_block` and `pack_vnni2` templates. Under `STANDALONE_TORCH_HEADER` (which ExecuTorch sets), `TORCH_CHECK` expands to a literal `throw std::runtime_error(...)`, which fails to compile when exceptions are disabled.

Fix: undefine `CPU_CAPABILITY_AVX2` and `HAVE_AVX2_CPU_DEFINITION` for the x86 size test via `cxx.extra_cxxflags`. The BC include is then skipped and `torch/headeronly/util/Half.h` falls back to `detail::fp16_ieee_from_fp32_value` (software fp16 conversion). The software path is the same one ARM mobile builds use, so the size measurement actually becomes more representative of real deployment instead of including AVX2-only intrinsic paths that production ARM targets never use.

**Issue 2: Codegen'd `try`/`catch` blocks in portable `generated_lib`.**

Since D67906411 (2025-02-07), `executorch_generated_lib` defaults to `support_exceptions = True`, which causes codegen to emit `try { ... } catch (const std::exception& ex) { ... }` blocks around every kernel call in `RegisterCodegenUnboxedKernelsEverything.cpp`. The `size_test_all_ops` binary depends on `//executorch/kernels/portable:generated_lib` but is compiled with `-fno-exceptions`, so the literal `try` keyword cannot be parsed.

Fix: add a `generated_lib_no_exceptions` variant of the portable generated lib, following the same `for support_exceptions in [True, False]` pattern already used in `xplat/executorch/kernels/quantized/targets.bzl`. Point `size_test_all_ops` at the new no-exceptions variant. The default `generated_lib` is unchanged so production consumers keep the exception safety wrapper.

The fbcode and xplat mirrors of `targets.bzl` and `etsize.py` are kept in sync.

Authored by Claude.

Differential Revision: [D106539321](https://our.internmc.facebook.com/intern/diff/D106539321/)