### PR TITLE
Fix `TrainingModule` class declaration formatting

### DIFF
--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/training/TrainingModule.kt
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/training/TrainingModule.kt
@@ -25,8 +25,8 @@ import org.pytorch.executorch.annotations.Experimental
  * Warning: These APIs are experimental and subject to change without notice
  */
 @Experimental
-class TrainingModule
-private constructor(moduleAbsolutePath: String, dataAbsolutePath: String) : Closeable {
+class TrainingModule private constructor(moduleAbsolutePath: String, dataAbsolutePath: String) :
+    Closeable {
 
   private val mHybridData: HybridData = initHybrid(moduleAbsolutePath, dataAbsolutePath)
   private val mLock = ReentrantLock()


### PR DESCRIPTION
Summary: Reformat `TrainingModule` class declaration to place `private constructor` on the same line as the class name, with `Closeable` wrapping to the next line. This follows the standard Kotlin formatting convention.

Differential Revision: D106574405


