### PR TITLE
Add general Aten lowering pass

### DIFF
--- a/backends/transforms/aten_to_dialect_pass.py
+++ b/backends/transforms/aten_to_dialect_pass.py
@@ -1,0 +1,138 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import traceback
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import ClassVar, TypeAlias
+
+import torch
+
+from executorch.backends.xnnpack._passes.xnnpack_pass import ExportPass
+
+from executorch.exir import ExportedProgram
+from torch.fx.node import Target
+from torch.fx.passes.infra.pass_manager import PassResult
+
+
+# Expected type to be returned by substitution functions.
+@dataclass
+class DialectNodeSpec:
+    op: Target
+    args: tuple
+    kwargs: dict = None
+
+
+# Expected type to be used for substitution functions
+SubstitutionFn: TypeAlias = Callable[
+    [torch.fx.Node, torch.export.ExportedProgram], DialectNodeSpec | None
+]
+
+
+class AtenToDialectPass(ExportPass):
+    """
+    General pass to convert ops 1-1 from ATen to a specific dialect.
+
+    Usage:
+        1. Subclass the pass for a specific dialect
+        2. For each ATen target to be substituted, implement a function returning a DialectNodeSpec defining the
+           corresponding dialect op, or None if the substitution does not apply.
+        3. Register each substitution function for the subclass using the decorator register_dialect_substitution
+
+    Only one substitution function can be registered for a given target.
+
+    The pass must be initialized with an exported_program to allow substitution functions to modify placeholders,
+    e.g. if the dialect ops require additional scratch buffers.
+    """
+
+    _DIALECT_SUBSTITUTIONS: ClassVar[dict[Target, SubstitutionFn]] = {}
+
+    def __init__(self, exported_program: ExportedProgram):
+        super().__init__()
+        self.exported_program: ExportedProgram = exported_program
+
+    # Ensure each subclass has its own substitution registry.
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        cls._DIALECT_SUBSTITUTIONS = {}
+
+    @classmethod
+    def register_dialect_substitution(
+        cls, target: Target
+    ) -> Callable[[SubstitutionFn], SubstitutionFn]:
+
+        def decorator(func: SubstitutionFn) -> SubstitutionFn:
+            if target in cls._DIALECT_SUBSTITUTIONS:
+                raise RuntimeError(
+                    f"Multiple substitutions registered for the same target in {cls.__name__} are not allowed."
+                )
+            else:
+                cls._DIALECT_SUBSTITUTIONS[target] = func
+            return func
+
+        return decorator
+
+    def call(self, graph_module: torch.fx.GraphModule) -> PassResult:
+        modified = False
+
+        for node in graph_module.graph.nodes:
+            if node.op != "call_function":
+                continue
+
+            substitution_func = self._DIALECT_SUBSTITUTIONS.get(node.target, None)
+            if substitution_func is None:
+                continue
+
+            dialect_node_spec = substitution_func(node, self.exported_program)
+            if dialect_node_spec is None:
+                continue
+
+            modified = True
+            with graph_module.graph.inserting_before(node):
+                dialect_node = graph_module.graph.create_node(
+                    "call_function",
+                    target=dialect_node_spec.op,
+                    args=dialect_node_spec.args,
+                    kwargs=dialect_node_spec.kwargs or {},
+                )
+
+                node.replace_all_uses_with(dialect_node)
+
+                # Keep same meta dict for new node and append new trace
+                dialect_node.meta = node.meta
+                old_stack_trace = dialect_node.meta.get("stack_trace", "")
+                dialect_node.meta["stack_trace"] = (
+                    f"{old_stack_trace}\n{traceback.format_stack()[-2]}"
+                )
+
+                graph_module.graph.erase_node(node)
+
+        if modified:
+            graph_module.graph.eliminate_dead_code()
+            graph_module.recompile()
+            graph_module = super().call(graph_module).graph_module
+
+        return PassResult(graph_module, modified)
+
+    def requires(self, graph_module):
+        self.ops_before = sum(
+            1 for node in graph_module.graph.nodes if node.op == "call_function"
+        )
+        return super().requires(graph_module)
+
+    def ensures(self, graph_module: torch.fx.GraphModule) -> bool:
+        """Ensure that there has only been 1-1 substitution of call_function nodes, i.e. that the number of call_function nodes is preserved after the pass."""
+
+        self.ops_after = sum(
+            1 for node in graph_module.graph.nodes if node.op == "call_function"
+        )
+        if self.ops_after != self.ops_before:
+            raise RuntimeError(
+                f"{self.__class__.__name__} did not preserve the number of call_function nodes: "
+                f"before={self.ops_before}, after={self.ops_after}"
+            )
+
+        return super().ensures(graph_module)

--- a/backends/transforms/targets.bzl
+++ b/backends/transforms/targets.bzl
@@ -177,6 +177,21 @@ def define_common_targets():
     )
 
     runtime.python_library(
+        name = "aten_to_dialect_pass",
+        srcs = [
+            "aten_to_dialect_pass.py",
+        ],
+        visibility = [
+            "//executorch/backends/...",
+        ],
+        deps = [
+            "//caffe2:torch",
+            "//executorch/backends/xnnpack/_passes:xnnpack_passes",
+            "//executorch/exir:lib",
+        ],
+    )
+
+    runtime.python_library(
         name = "rank_0_to_rank_1",
         srcs = [
             "rank_0_to_rank_1.py",
@@ -243,6 +258,16 @@ def define_common_targets():
         ],
     )
 
+    runtime.python_test(
+        name = "test_aten_to_dialect_pass",
+        srcs = [
+            "test/test_aten_to_dialect_pass.py",
+        ],
+        deps = [
+            "//caffe2:torch",
+            ":aten_to_dialect_pass",
+        ],
+    )
 
     runtime.python_test(
         name = "test_rank_0_to_rank_1",

--- a/backends/transforms/test/test_aten_to_dialect_pass.py
+++ b/backends/transforms/test/test_aten_to_dialect_pass.py
@@ -1,0 +1,239 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+from executorch.backends.transforms.aten_to_dialect_pass import (
+    AtenToDialectPass,
+    DialectNodeSpec,
+)
+from executorch.backends.transforms.utils import create_constant_placeholder
+from torch.export import ExportedProgram
+from torch.export.graph_signature import InputKind
+from torch.fx import Node
+
+
+class AddModel(torch.nn.Module):
+    def forward(self, x, y):
+        return torch.ops.aten.add.Tensor(x, y)
+
+
+class AddAlphaModel(torch.nn.Module):
+    def forward(self, x, y):
+        return torch.ops.aten.add.Tensor(x, y, alpha=2)
+
+
+def _count_target(graph_module: torch.fx.GraphModule, target) -> int:
+    return sum(
+        1
+        for node in graph_module.graph.nodes
+        if node.op == "call_function" and node.target == target
+    )
+
+
+def _get_target_node(graph_module: torch.fx.GraphModule, target) -> Node:
+    nodes = [
+        node
+        for node in graph_module.graph.nodes
+        if node.op == "call_function" and node.target == target
+    ]
+    assert len(nodes) == 1
+    return nodes[0]
+
+
+def _export_add_model() -> ExportedProgram:
+    return torch.export.export(
+        AddModel().eval(), (torch.randn(2, 3), torch.randn(2, 3)), strict=True
+    )
+
+
+def _export_add_alpha_model() -> ExportedProgram:
+    return torch.export.export(
+        AddAlphaModel().eval(), (torch.randn(2, 3), torch.randn(2, 3)), strict=True
+    )
+
+
+def test_rewrites_node_when_substitution_matches() -> None:
+    class _TestAtenToDialectPass(AtenToDialectPass):
+        pass
+
+    @_TestAtenToDialectPass.register_dialect_substitution(torch.ops.aten.add.Tensor)
+    def replace_add_with_sub(
+        node: Node, exported_program: ExportedProgram
+    ) -> DialectNodeSpec | None:
+        del exported_program
+        return DialectNodeSpec(torch.ops.aten.sub.Tensor, node.args)
+
+    exported_program = _export_add_model()
+    result = _TestAtenToDialectPass(exported_program=exported_program).call(
+        exported_program.graph_module
+    )
+
+    assert result.modified
+    assert _count_target(result.graph_module, torch.ops.aten.add.Tensor) == 0
+    assert _count_target(result.graph_module, torch.ops.aten.sub.Tensor) == 1
+
+
+def test_substitution_can_add_state_dict_placeholder() -> None:
+    class _TestAtenToDialectPass(AtenToDialectPass):
+        pass
+
+    @_TestAtenToDialectPass.register_dialect_substitution(torch.ops.aten.add.Tensor)
+    def replace_add_rhs_with_constant(
+        node: Node, exported_program: ExportedProgram
+    ) -> DialectNodeSpec | None:
+        first_placeholder = next(
+            graph_node
+            for graph_node in node.graph.nodes
+            if graph_node.op == "placeholder"
+        )
+        with node.graph.inserting_before(first_placeholder):
+            const_node = create_constant_placeholder(
+                exp_program=exported_program,
+                graph=node.graph,
+                name="test_constant",
+                kind=InputKind.PARAMETER,
+                data=torch.ones(2, 3),
+            )
+        return DialectNodeSpec(torch.ops.aten.add.Tensor, (node.args[0], const_node))
+
+    exported_program = _export_add_model()
+    result = _TestAtenToDialectPass(exported_program=exported_program).call(
+        exported_program.graph_module
+    )
+
+    assert result.modified
+    assert "test_constant" in exported_program.state_dict
+    assert torch.equal(exported_program.state_dict["test_constant"], torch.ones(2, 3))
+    assert (
+        exported_program.graph_signature.inputs_to_parameters["test_constant"]
+        == "test_constant"
+    )
+    add_node = _get_target_node(result.graph_module, torch.ops.aten.add.Tensor)
+    assert add_node.args[1].name == "test_constant"
+
+    x = torch.full((2, 3), 2.0)
+    y = torch.full((2, 3), 5.0)
+    torch.testing.assert_close(exported_program.module()(x, y), x + torch.ones_like(x))
+
+
+def test_substitution_can_change_kwargs() -> None:
+    class _TestAtenToDialectPass(AtenToDialectPass):
+        pass
+
+    @_TestAtenToDialectPass.register_dialect_substitution(torch.ops.aten.add.Tensor)
+    def replace_add_alpha(
+        node: Node, exported_program: ExportedProgram
+    ) -> DialectNodeSpec | None:
+        del exported_program
+        return DialectNodeSpec(torch.ops.aten.add.Tensor, node.args, {"alpha": 3})
+
+    exported_program = _export_add_alpha_model()
+    result = _TestAtenToDialectPass(exported_program=exported_program).call(
+        exported_program.graph_module
+    )
+
+    assert result.modified
+    add_node = _get_target_node(result.graph_module, torch.ops.aten.add.Tensor)
+    assert add_node.kwargs["alpha"] == 3
+
+    x = torch.full((2, 3), 2.0)
+    y = torch.full((2, 3), 5.0)
+    torch.testing.assert_close(exported_program.module()(x, y), x + 3 * y)
+
+
+def test_preserves_meta_when_substitution_matches() -> None:
+    class _TestAtenToDialectPass(AtenToDialectPass):
+        pass
+
+    @_TestAtenToDialectPass.register_dialect_substitution(torch.ops.aten.add.Tensor)
+    def replace_add_with_sub(
+        node: Node, exported_program: ExportedProgram
+    ) -> DialectNodeSpec | None:
+        del exported_program
+        return DialectNodeSpec(torch.ops.aten.sub.Tensor, node.args)
+
+    exported_program = _export_add_model()
+    add_node = _get_target_node(
+        exported_program.graph_module, torch.ops.aten.add.Tensor
+    )
+    add_node.meta["test_sentinel"] = "kept"
+    add_node.meta["stack_trace"] = "original stack"
+
+    result = _TestAtenToDialectPass(exported_program=exported_program).call(
+        exported_program.graph_module
+    )
+
+    sub_node = _get_target_node(result.graph_module, torch.ops.aten.sub.Tensor)
+    assert sub_node.meta["test_sentinel"] == "kept"
+    assert sub_node.meta["stack_trace"].startswith("original stack\n")
+    assert sub_node.meta["stack_trace"] != "original stack"
+
+
+def test_keeps_node_when_substitution_returns_none() -> None:
+    class _TestAtenToDialectPass(AtenToDialectPass):
+        pass
+
+    @_TestAtenToDialectPass.register_dialect_substitution(torch.ops.aten.add.Tensor)
+    def do_not_replace(
+        node: Node, exported_program: ExportedProgram
+    ) -> DialectNodeSpec | None:
+        del node, exported_program
+        return None
+
+    exported_program = _export_add_model()
+    result = _TestAtenToDialectPass(exported_program=exported_program).call(
+        exported_program.graph_module
+    )
+
+    assert not result.modified
+    assert _count_target(result.graph_module, torch.ops.aten.add.Tensor) == 1
+    assert _count_target(result.graph_module, torch.ops.aten.sub.Tensor) == 0
+
+
+def test_raises_when_duplicate_substitution_is_registered() -> None:
+    class _TestAtenToDialectPass(AtenToDialectPass):
+        pass
+
+    @_TestAtenToDialectPass.register_dialect_substitution(torch.ops.aten.add.Tensor)
+    def first_replace(
+        node: Node, exported_program: ExportedProgram
+    ) -> DialectNodeSpec | None:
+        del exported_program
+        return DialectNodeSpec(torch.ops.aten.sub.Tensor, node.args)
+
+    with pytest.raises(RuntimeError, match="Multiple substitutions registered"):
+
+        @_TestAtenToDialectPass.register_dialect_substitution(torch.ops.aten.add.Tensor)
+        def second_replace(
+            node: Node, exported_program: ExportedProgram
+        ) -> DialectNodeSpec | None:
+            del exported_program
+            return DialectNodeSpec(torch.ops.aten.mul.Tensor, node.args)
+
+
+def test_ensures_raises_when_call_function_count_changes() -> None:
+    class _TestAtenToDialectPass(AtenToDialectPass):
+        pass
+
+    exported_program = _export_add_model()
+    graph_module = exported_program.graph_module
+    test_pass = _TestAtenToDialectPass(exported_program=exported_program)
+    test_pass.requires(graph_module)
+
+    placeholders = [
+        node for node in graph_module.graph.nodes if node.op == "placeholder"
+    ]
+    output_node = next(node for node in graph_module.graph.nodes if node.op == "output")
+    with graph_module.graph.inserting_before(output_node):
+        graph_module.graph.create_node(
+            "call_function",
+            target=torch.ops.aten.sub.Tensor,
+            args=tuple(placeholders),
+            kwargs={},
+        )
+
+    with pytest.raises(RuntimeError, match="did not preserve"):
+        test_pass.ensures(graph_module)


### PR DESCRIPTION
Adds a simple pass for replacing single Aten ops with corresponding dialect ops to be reused across multiple backends.




cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani