### PR TITLE
Arm backend: Guard empty cmake arg array in build_executorch

### DIFF
--- a/backends/arm/scripts/build_executorch.sh
+++ b/backends/arm/scripts/build_executorch.sh
@@ -96,8 +96,11 @@ cmake_args=(
     -DEXECUTORCH_BUILD_DEVTOOLS=${build_devtools}
     -DEXECUTORCH_BUILD_ARM_ETDUMP=${build_with_etdump}
     -DEXECUTORCH_BAREMETAL_SKIP_INSTALL=OFF
-    "${extra_cmake_args[@]}"
 )
+
+if [[ ${#extra_cmake_args[@]} -gt 0 ]]; then
+    cmake_args+=("${extra_cmake_args[@]}")
+fi
 
 if [[ -n "${target_cpu}" ]]; then
     cmake_args+=(-DTARGET_CPU=${target_cpu})


### PR DESCRIPTION
Avoid expanding extra_cmake_args when the array is empty.

Older Bash versions on macOS treat an empty array expansion under set -u as an unbound variable. Append the extra CMake arguments only when the array is non-empty so the script behaves the same on Linux and macOS.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani