### PR TITLE
Add neutronPowerOn/neutronPowerOff hooks to NeutronBackend

### DIFF
--- a/backends/nxp/runtime/NeutronBackend.cpp
+++ b/backends/nxp/runtime/NeutronBackend.cpp
@@ -15,6 +15,12 @@
 #include "NeutronDriver.h"
 #include "NeutronErrors.h"
 
+// Hooks to power on/off the NPU for fine-grained control.
+extern "C" {
+void __attribute__((weak)) neutronPowerOn(void) {}
+void __attribute__((weak)) neutronPowerOff(void) {}
+}
+
 using namespace std;
 
 namespace torch {
@@ -515,7 +521,9 @@ class NeutronBackend final : public PyTorchBackendInterface {
 #endif
 
     // Run neutron compute.
+    neutronPowerOn();
     NeutronError neutronRC = neutronRunBlocking(cfg->nmh, &cfg->dcfg);
+    neutronPowerOff();
     if (neutronRC != ENONE) {
       ET_LOG(
           Error,


### PR DESCRIPTION
Summary:
To minimize power, the NPU should be turned on and off, per:


https://docs.nxp.com/bundle/AN14700/page/topics/imx_rt700_system_details.html

This relies on SDK code.

Some users may wrap this code for protection.

So, we want two things:

1) (potentially) turnOn -> execute NPU -> turnOff
2) ability to override turnOn/Off implementations

Further, some may want to leave these stubs so that the ET backend does not control it for them.

Differential Revision: D106668625




cc @robert-kalmar @digantdesai @rascani