### PR TITLE
Add short function support

### DIFF
--- a/runtime/executor/targets.bzl
+++ b/runtime/executor/targets.bzl
@@ -16,8 +16,14 @@ def _program_preprocessor_flags():
     if enable_verification == "false":
         return ["-DET_ENABLE_PROGRAM_VERIFICATION=0"]
     elif enable_verification == "true":
-        # Enabled by default.
-        return []
+        # Enabled by default; allow opt-out via constraint
+        if not runtime.is_oss:
+            return select({
+                "DEFAULT": [],
+                "fbsource//xplat/executorch/tools/buck/constraints:executorch-program-verification-disabled": ["-DET_ENABLE_PROGRAM_VERIFICATION=0"],
+            })
+        else:
+            return []
     else:
         fail("executorch.enable_program_verification must be one of 'true' or 'false'; saw '" +
              enable_verification + "'")

--- a/runtime/platform/compiler.h
+++ b/runtime/platform/compiler.h
@@ -158,12 +158,17 @@
 #define ET_LINE __LINE__
 #endif // __has_builtin(__builtin_LINE)
 
-#if __has_builtin(__builtin_FUNCTION)
+#if defined(ET_USE_BUILTIN_FUNCTION_NAME) && ET_USE_BUILTIN_FUNCTION_NAME == 0
+/// __FUNCTION__ provides a short undecorated name, saving .rodata space
+/// compared to __builtin_FUNCTION() which includes the full signature
+/// (namespace, parameters, return type).
+#define ET_FUNCTION __FUNCTION__
+#elif __has_builtin(__builtin_FUNCTION)
 /// Name of the current function as a const char[].
 #define ET_FUNCTION __builtin_FUNCTION()
 #else
 #define ET_FUNCTION __FUNCTION__
-#endif // __has_builtin(__builtin_FUNCTION)
+#endif
 
 // As of G3 RJ-2024.3 toolchain, zu format specifier is not supported for Xtensa
 #if defined(__XTENSA__)

--- a/runtime/platform/compiler.h
+++ b/runtime/platform/compiler.h
@@ -138,8 +138,14 @@
 #define __has_builtin(x) (0)
 #endif
 
-#if __has_builtin(__builtin_strrchr)
+#if defined(__FILE_NAME__)
+/// __FILE_NAME__ provides just the filename at
+/// compile time, avoiding embedding full paths in the binary
+#define ET_SHORT_FILENAME __FILE_NAME__
+#elif __has_builtin(__builtin_strrchr)
 /// Name of the source file without a directory string.
+/// Note: This approach embeds the full path in .rodata even though only the
+/// basename is used at runtime. __FILE_NAME__ is preferred when available.
 #define ET_SHORT_FILENAME (__builtin_strrchr("/" __FILE__, '/') + 1)
 #else
 #define ET_SHORT_FILENAME __FILE__

--- a/runtime/platform/targets.bzl
+++ b/runtime/platform/targets.bzl
@@ -116,5 +116,9 @@ def define_common_targets():
         exported_headers = [
             "compiler.h",
         ],
+        exported_preprocessor_flags = select({
+            "DEFAULT": [],
+            "fbsource//xplat/executorch/tools/buck/constraints:executorch-builtin-function-name-disabled": ["-DET_USE_BUILTIN_FUNCTION_NAME=0"],
+        }) if not runtime.is_oss else [],
         visibility = ["PUBLIC"],
     )

--- a/tools/buck/constraints/BUCK
+++ b/tools/buck/constraints/BUCK
@@ -80,3 +80,22 @@ fb_native.constraint_value(
     constraint_setting = ":executorch-program-verification",
     visibility = ["PUBLIC"],
 )
+
+fb_native.config_setting(
+    name = "executorch-builtin-function-name-disabled",
+    constraint_values = [
+        ":builtin-function-name-disabled",
+    ],
+    visibility = ["PUBLIC"],
+)
+
+fb_native.constraint_setting(
+    name = "executorch-builtin-function-name",
+    visibility = ["PUBLIC"],
+)
+
+fb_native.constraint_value(
+    name = "builtin-function-name-disabled",
+    constraint_setting = ":executorch-builtin-function-name",
+    visibility = ["PUBLIC"],
+)

--- a/tools/buck/constraints/BUCK
+++ b/tools/buck/constraints/BUCK
@@ -61,3 +61,22 @@ fb_native.constraint_value(
     constraint_setting = ":executorch-event-tracer",
     visibility = ["PUBLIC"],
 )
+
+fb_native.config_setting(
+    name = "executorch-program-verification-disabled",
+    constraint_values = [
+        ":program-verification-disabled",
+    ],
+    visibility = ["PUBLIC"],
+)
+
+fb_native.constraint_setting(
+    name = "executorch-program-verification",
+    visibility = ["PUBLIC"],
+)
+
+fb_native.constraint_value(
+    name = "program-verification-disabled",
+    constraint_setting = ":executorch-program-verification",
+    visibility = ["PUBLIC"],
+)


### PR DESCRIPTION
Summary:
Currently, __builtin_FUNCTION is used opportunistically if it exists.


However, for heavily templated code, this results in extremely long string which adds .rodata which can be wasteful on embedded targets.


This commit adds an override which uses the shorter __FUNCTION__ even if __bultin_FUNCTION exists and exposes as a BUCK constraint.

Integration into CMake intentially left out for now.

Differential Revision: D106668077


