### PR TITLE
exir/passes: return PassResult.modified=False when passes leave graph unchanged

### DIFF
--- a/exir/passes/prune_empty_tensors_pass.py
+++ b/exir/passes/prune_empty_tensors_pass.py
@@ -27,9 +27,10 @@ class PruneEmptyTensorsPass(ExportPass):
 
     def remove_empty_tensors_from_cat(
         self, graph_module: GraphModule, cat_node: Node
-    ) -> None:
+    ) -> bool:
         """
-        Removes empty tensors from the graph that are inputs to aten.cat.default
+        Removes empty tensors from the graph that are inputs to aten.cat.default.
+        Returns True if the cat node was rewritten.
         """
         concat_list = cast(List[Node], cat_node.args[0])
         pruned_concat_list = []
@@ -37,6 +38,9 @@ class PruneEmptyTensorsPass(ExportPass):
             input_arg_tensor = input_arg.meta["val"]
             if input_arg_tensor.numel() != 0:
                 pruned_concat_list.append(input_arg)
+
+        if len(pruned_concat_list) == len(concat_list):
+            return False
 
         cat_node.args = (pruned_concat_list,) + cat_node.args[1:]
         if len(pruned_concat_list) == 0:
@@ -52,16 +56,19 @@ class PruneEmptyTensorsPass(ExportPass):
                 )
                 full_like.meta = cat_node.meta
                 cat_node.replace_all_uses_with(full_like)
+        return True
 
     def call(self, graph_module: GraphModule) -> PassResult:
+        modified = False
         for node in graph_module.graph.nodes:
             if node.op != "call_function":
                 continue
 
             if node.target == torch.ops.aten.cat.default:
-                self.remove_empty_tensors_from_cat(graph_module, node)
+                modified |= self.remove_empty_tensors_from_cat(graph_module, node)
 
-        graph_module.graph.eliminate_dead_code()
-        graph_module.graph.lint()
+        if modified:
+            graph_module.graph.eliminate_dead_code()
+            graph_module.graph.lint()
 
-        return PassResult(graph_module, True)
+        return PassResult(graph_module, modified)

--- a/exir/passes/remove_graph_asserts_pass.py
+++ b/exir/passes/remove_graph_asserts_pass.py
@@ -11,33 +11,45 @@ import torch
 from torch.fx.passes.infra.pass_base import PassBase, PassResult
 
 
+def _erase_asserts_from_modules(
+    graph_module: torch.fx.GraphModule,
+    targets: tuple,
+) -> bool:
+    modified = False
+    for module in graph_module.modules():
+        if not isinstance(module, torch.fx.GraphModule):
+            continue
+        module_modified = False
+        for node in module.graph.nodes:
+            if node.op == "call_function" and node.target in targets:
+                module.graph.erase_node(node)
+                module_modified = True
+        if module_modified:
+            module.recompile()
+            module.graph.eliminate_dead_code()
+            modified = True
+    return modified
+
+
+_CORE_ASSERT_TARGETS: tuple = (
+    torch.ops.aten._assert_async.msg,
+    torch.ops.aten._assert_scalar.default,
+    torch.ops.aten.sym_constrain_range_for_size.default,
+    torch.ops.aten.sym_constrain_range.default,
+    torch.ops.aten._assert_tensor_metadata.default,
+)
+
+
 class RemoveGraphAssertsPass(PassBase):
     """
     Temporary pass to remove all the assert ops until runtime decides to address it.
     """
 
     def call(self, graph_module: torch.fx.GraphModule) -> PassResult:
-        for module in graph_module.modules():
-            if not isinstance(module, torch.fx.GraphModule):
-                continue
-
-            for node in module.graph.nodes:
-                if node.op == "call_function" and (
-                    node.target
-                    in (
-                        torch.ops.aten._assert_async.msg,
-                        torch.ops.aten._assert_scalar.default,
-                        torch.ops.aten.sym_constrain_range_for_size.default,
-                        torch.ops.aten.sym_constrain_range.default,
-                        torch.ops.aten._assert_tensor_metadata.default,
-                    )
-                ):
-                    module.graph.erase_node(node)
-
-            module.recompile()
-            module.graph.eliminate_dead_code()
-
-        return PassResult(graph_module, True)
+        return PassResult(
+            graph_module,
+            _erase_asserts_from_modules(graph_module, _CORE_ASSERT_TARGETS),
+        )
 
 
 class RemoveNonCoreAtenOpGraphAssertsPass(PassBase):
@@ -46,17 +58,10 @@ class RemoveNonCoreAtenOpGraphAssertsPass(PassBase):
     """
 
     def call(self, graph_module: torch.fx.GraphModule) -> PassResult:
-        for module in graph_module.modules():
-            if not isinstance(module, torch.fx.GraphModule):
-                continue
-
-            for node in module.graph.nodes:
-                if node.op == "call_function" and (
-                    node.target in (torch.ops.aten._assert_tensor_metadata.default,)
-                ):
-                    module.graph.erase_node(node)
-
-            module.recompile()
-            module.graph.eliminate_dead_code()
-
-        return PassResult(graph_module, True)
+        return PassResult(
+            graph_module,
+            _erase_asserts_from_modules(
+                graph_module,
+                (torch.ops.aten._assert_tensor_metadata.default,),
+            ),
+        )

--- a/exir/passes/remove_noop_pass.py
+++ b/exir/passes/remove_noop_pass.py
@@ -30,7 +30,8 @@ _QUANT_OPS: Tuple[torch._ops.OpOverload] = (
 def eliminate_dq_q(
     graph_module: GraphModule,
     dequant_nodes: List[torch.fx.Node],
-) -> None:
+) -> bool:
+    modified = False
     for node in dequant_nodes:
         assert node.target in _DEQUANT_OPS
         for user in list(node.users):
@@ -41,6 +42,8 @@ def eliminate_dq_q(
                 if qparams_dq != qparams_q:
                     continue
                 user.replace_all_uses_with(node.args[0])  # pyre-fixme[6]
+                modified = True
+    return modified
 
 
 class RemoveNoopPass(ExportPass):
@@ -54,6 +57,7 @@ class RemoveNoopPass(ExportPass):
         # are removed in this pass and later check for redundant dq->q patterns and
         # remove them.
         dequant_nodes = []
+        modified = False
 
         for node in graph_module.graph.nodes:
             if node.op != "call_function":
@@ -74,6 +78,7 @@ class RemoveNoopPass(ExportPass):
                 if node.args[0].target in _DEQUANT_OPS:
                     dequant_nodes += [node.args[0]]
                 node.replace_all_uses_with(node.args[0])
+                modified = True
                 continue
 
             if node.target == torch.ops.aten.slice_copy.Tensor:
@@ -91,13 +96,16 @@ class RemoveNoopPass(ExportPass):
                         if node.args[0].target in _DEQUANT_OPS:
                             dequant_nodes += [node.args[0]]
                         node.replace_all_uses_with(node.args[0])
+                        modified = True
 
-        graph_module.graph.eliminate_dead_code()
-        eliminate_dq_q(graph_module, dequant_nodes)
-        graph_module.graph.lint()
-        graph_module.graph.eliminate_dead_code()
+        if modified:
+            graph_module.graph.eliminate_dead_code()
+        modified |= eliminate_dq_q(graph_module, dequant_nodes)
+        if modified:
+            graph_module.graph.lint()
+            graph_module.graph.eliminate_dead_code()
 
-        return PassResult(graph_module, True)
+        return PassResult(graph_module, modified)
 
 
 class RemoveToCopyPass(ExportPass):
@@ -106,6 +114,7 @@ class RemoveToCopyPass(ExportPass):
     """
 
     def call(self, graph_module: GraphModule) -> PassResult:
+        modified = False
         for node in graph_module.graph.nodes:
             if node.op != "call_function":
                 continue
@@ -122,8 +131,10 @@ class RemoveToCopyPass(ExportPass):
                 and orig_tensor.stride() == node.meta["val"].stride()
             ):
                 node.replace_all_uses_with(node.args[0])
+                modified = True
 
-        graph_module.graph.eliminate_dead_code()
-        graph_module.graph.lint()
+        if modified:
+            graph_module.graph.eliminate_dead_code()
+            graph_module.graph.lint()
 
-        return PassResult(graph_module, True)
+        return PassResult(graph_module, modified)

--- a/exir/passes/replace_sym_size_op_pass.py
+++ b/exir/passes/replace_sym_size_op_pass.py
@@ -26,10 +26,12 @@ class ReplaceSymSizeOpPass(PassBase):
     """
 
     def call(self, graph_module: torch.fx.GraphModule) -> PassResult:
+        modified = False
         for module in graph_module.modules():
             if not isinstance(module, torch.fx.GraphModule):
                 continue
             for node in module.graph.nodes:
                 if node.target in replacements:
                     node.target = replacements[node.target]
-        return PassResult(graph_module, True)
+                    modified = True
+        return PassResult(graph_module, modified)

--- a/exir/passes/to_device_pass.py
+++ b/exir/passes/to_device_pass.py
@@ -38,7 +38,7 @@ class ToDevicePass(ExportPass):
         if modified:
             graph_module.recompile()
 
-        return PassResult(graph_module, True)
+        return PassResult(graph_module, modified)
 
     def __call__(self, graph_module: torch.fx.GraphModule) -> PassResult:
         """Reimplement __call__ to avoid Optional[PassResult] type hint."""

--- a/exir/tests/test_passes.py
+++ b/exir/tests/test_passes.py
@@ -67,8 +67,13 @@ from executorch.exir.passes.memory_format_ops_pass import DimOrderOpsRevertPass
 from executorch.exir.passes.normalize_view_copy_base_pass import (
     NormalizeViewCopyBasePass,
 )
-from executorch.exir.passes.remove_graph_asserts_pass import RemoveGraphAssertsPass
+from executorch.exir.passes.prune_empty_tensors_pass import PruneEmptyTensorsPass
+from executorch.exir.passes.remove_graph_asserts_pass import (
+    RemoveGraphAssertsPass,
+    RemoveNonCoreAtenOpGraphAssertsPass,
+)
 from executorch.exir.passes.remove_mixed_type_operators import RemoveMixedTypeOperators
+from executorch.exir.passes.remove_noop_pass import RemoveToCopyPass
 from executorch.exir.passes.replace_edge_with_backend_pass import EdgeToBackendOpsPass
 from executorch.exir.passes.replace_view_copy_with_view_pass import (
     ReplaceViewCopyWithViewPass,
@@ -77,6 +82,7 @@ from executorch.exir.passes.scalar_to_tensor_pass import ScalarToTensorPass
 from executorch.exir.passes.spec_prop_pass import SpecPropPass
 from executorch.exir.passes.sym_shape_eval_pass import ConstraintBasedSymShapeEvalPass
 from executorch.exir.passes.sym_to_tensor_pass import SymToTensorPass
+from executorch.exir.passes.to_device_pass import ToDevicePass
 from executorch.exir.program._program import lift_constant_tensor_pass
 from executorch.exir.schema import TensorShapeDynamism
 from executorch.exir.sym_util import eval_upper_bound
@@ -2831,3 +2837,185 @@ class TestCSEPass(unittest.TestCase):
         self.assertTrue(result.modified)
         self.assertEqual(self._count_ops(result.graph_module, neg_target), 1)
         self.assertEqual(self._count_ops(result.graph_module, abs_target), 1)
+
+
+class TestPassModifiedFlag(unittest.TestCase):
+    """
+    PassResult.modified is read by _transform_with_pass_manager in
+    exir/program/_program.py; a false-positive forces a full
+    ExportedProgram rebuild + verifier re-run. These tests pin the
+    contract: a pass with nothing to do must report modified=False.
+    """
+
+    @staticmethod
+    def _aten_gm(module, example_inputs):
+        return torch.export.export(module, example_inputs, strict=True).graph_module
+
+    @staticmethod
+    def _identity_aten_gm():
+        class Identity(torch.nn.Module):
+            def forward(self, x):
+                return x + 1
+
+        return TestPassModifiedFlag._aten_gm(Identity(), (torch.ones(2),))
+
+    # ---- RemoveNoopPass ----
+
+    def test_remove_noop_pass_noop_when_nothing_to_remove(self):
+        gm = self._identity_aten_gm()
+        result = RemoveNoopPass()(gm)
+        self.assertFalse(result.modified)
+
+    def test_remove_noop_pass_modified_when_redundant_to_dtype(self):
+        graph = torch.fx.Graph()
+        with FakeTensorMode() as fake_mode:
+            fake_input = fake_mode.from_tensor(torch.randn(2, 3))
+            x = graph.placeholder("x")
+            x.meta["val"] = fake_input
+            to_node = graph.call_function(
+                torch.ops.aten.to.dtype, args=(x, torch.float32)
+            )
+            to_node.meta["val"] = fake_input
+            graph.output(to_node)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        result = RemoveNoopPass()(gm)
+        self.assertTrue(result.modified)
+
+    # ---- RemoveToCopyPass ----
+
+    def test_remove_to_copy_pass_noop_when_nothing_to_remove(self):
+        gm = self._identity_aten_gm()
+        result = RemoveToCopyPass()(gm)
+        self.assertFalse(result.modified)
+
+    def test_remove_to_copy_pass_modified_when_redundant_copy(self):
+        # Build a graph with a redundant aten._to_copy.default whose
+        # output FakeTensor matches the input on dtype/device/shape/stride.
+        graph = torch.fx.Graph()
+        with FakeTensorMode() as fake_mode:
+            fake_input = fake_mode.from_tensor(torch.randn(2, 3))
+            x = graph.placeholder("x")
+            x.meta["val"] = fake_input
+            copy_node = graph.call_function(torch.ops.aten._to_copy.default, args=(x,))
+            copy_node.meta["val"] = fake_mode.from_tensor(torch.randn(2, 3))
+            graph.output(copy_node)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        result = RemoveToCopyPass()(gm)
+        self.assertTrue(result.modified)
+
+    # ---- PruneEmptyTensorsPass ----
+
+    def test_prune_empty_tensors_pass_noop_when_no_cat(self):
+        gm = self._identity_aten_gm()
+        result = PruneEmptyTensorsPass()(gm)
+        self.assertFalse(result.modified)
+
+    def test_prune_empty_tensors_pass_noop_when_cat_has_no_empty(self):
+        class Cat(torch.nn.Module):
+            def forward(self, x, y):
+                return torch.cat([x, y])
+
+        gm = self._aten_gm(Cat(), (torch.ones(2, 3), torch.ones(2, 3)))
+        result = PruneEmptyTensorsPass()(gm)
+        self.assertFalse(result.modified)
+
+    def test_prune_empty_tensors_pass_modified_when_empty_input(self):
+        class Cat(torch.nn.Module):
+            def forward(self, x):
+                return torch.cat([torch.empty((0, 3)), x])
+
+        gm = self._aten_gm(Cat(), (torch.ones(2, 3),))
+        result = PruneEmptyTensorsPass()(gm)
+        self.assertTrue(result.modified)
+
+    # ---- RemoveGraphAssertsPass ----
+
+    def test_remove_graph_asserts_pass_noop_when_no_asserts(self):
+        gm = self._identity_aten_gm()
+        result = RemoveGraphAssertsPass()(gm)
+        self.assertFalse(result.modified)
+
+    def test_remove_graph_asserts_pass_modified_when_asserts_present(self):
+        # Construct a graph with an _assert_async node directly so the test
+        # does not depend on torch.export's heuristics for which asserts
+        # survive constant folding.
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        add = graph.call_function(torch.ops.aten.add.Tensor, args=(x, x))
+        graph.call_function(torch.ops.aten._assert_async.msg, args=(add, "asserted"))
+        graph.output(add)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        result = RemoveGraphAssertsPass()(gm)
+        self.assertTrue(result.modified)
+        remaining = [
+            n
+            for n in result.graph_module.graph.nodes
+            if n.op == "call_function" and n.target == torch.ops.aten._assert_async.msg
+        ]
+        self.assertEqual(remaining, [])
+
+    # ---- RemoveNonCoreAtenOpGraphAssertsPass ----
+
+    def test_remove_noncore_asserts_pass_noop_when_no_asserts(self):
+        gm = self._identity_aten_gm()
+        result = RemoveNonCoreAtenOpGraphAssertsPass()(gm)
+        self.assertFalse(result.modified)
+
+    def test_remove_noncore_asserts_pass_modified_when_metadata_assert(self):
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        add = graph.call_function(torch.ops.aten.add.Tensor, args=(x, x))
+        graph.call_function(
+            torch.ops.aten._assert_tensor_metadata.default,
+            args=(add, None, None, torch.float32),
+        )
+        graph.output(add)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        result = RemoveNonCoreAtenOpGraphAssertsPass()(gm)
+        self.assertTrue(result.modified)
+
+    # ---- ReplaceSymSizeOpPass ----
+
+    def test_replace_sym_size_op_pass_noop_when_no_packets(self):
+        gm = self._identity_aten_gm()
+        result = ReplaceSymSizeOpPass()(gm)
+        self.assertFalse(result.modified)
+
+    def test_replace_sym_size_op_pass_modified_when_packet_present(self):
+        # Build a graph that references torch.ops.aten.sym_size (the
+        # OpOverloadPacket form) so the pass has something to rewrite.
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        sym_node = graph.call_function(torch.ops.aten.sym_size, args=(x, 0))
+        graph.output(sym_node)
+        gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        result = ReplaceSymSizeOpPass()(gm)
+        self.assertTrue(result.modified)
+        new_targets = {
+            n.target for n in result.graph_module.graph.nodes if n.op == "call_function"
+        }
+        self.assertIn(torch.ops.aten.sym_size.int, new_targets)
+        self.assertNotIn(torch.ops.aten.sym_size, new_targets)
+
+    # ---- ToDevicePass ----
+
+    def test_to_device_pass_noop_when_already_target_device(self):
+        # The identity model has no device= kwargs and is already on CPU.
+        gm = self._identity_aten_gm()
+        result = ToDevicePass("cpu")(gm)
+        self.assertFalse(result.modified)
+
+    def test_to_device_pass_modified_when_kwarg_device_differs(self):
+        # arange has an explicit device kwarg in the exported graph.
+        class Arange(torch.nn.Module):
+            def forward(self, x):
+                return torch.arange(0, 4, device="cpu") + x
+
+        gm = self._aten_gm(Arange(), (torch.zeros(4),))
+        result = ToDevicePass("meta")(gm)
+        self.assertTrue(result.modified)


### PR DESCRIPTION
### Summary

Several passes in `exir/passes/` return `PassResult(graph_module, True)` unconditionally — even when they walk the graph and rewrite nothing.

```python
# exir/program/_program.py:271
if transformed_gm is self.graph_module and not res.modified:
    return self
return _update_exported_program_graph_module(self, transformed_gm, override_verifiers)
```

A false-positive `modified=True` forces the consumer to rebuild the `ExportedProgram` (deep-copy `module_call_graph`, recompute the graph signature, re-run verifiers) on every pass run, even when nothing changed.

PR #16231 fixed this for `ScalarToTensorPass`. This PR applies the same pattern to the remaining passes.

### Passes touched

| Pass | Before | After |
| --- | --- | --- |
| `RemoveNoopPass` | always `True` | tracks per-node replacement |
| `RemoveToCopyPass` | always `True` | tracks per-node replacement |
| `PruneEmptyTensorsPass` | always `True` | tracks cat-input rewrites |
| `RemoveGraphAssertsPass` | always `True`, also called `recompile()` per submodule unconditionally | tracks erased asserts, gates `recompile()` / DCE on actual mutation |
| `RemoveNonCoreAtenOpGraphAssertsPass` | same as above | same as above |
| `ReplaceSymSizeOpPass` | always `True` | tracks overload-packet rewrites |
| `ToDevicePass` | already computed `modified`, then discarded it and returned `True` | returns the computed value |

Each fix follows the pattern used by `CSEPass`, `ScalarToTensorPass`, and others: a local `modified` boolean is set at the point of actual graph mutation and returned via `PassResult(gm, modified)`. Cleanup operations (`eliminate_dead_code`, `lint`, `recompile`) are only called when `modified=True`.

As a minor cleanup, `RemoveGraphAssertsPass` and `RemoveNonCoreAtenOpGraphAssertsPass` are refactored to share a private helper `_erase_asserts_from_modules` — the two classes were near-identical, differing only in the target op set.

### Consumers of `PassResult.modified`

While auditing this, I found two consumers of `PassResult.modified` in this repo:

**1. `_transform_with_pass_manager` fast path** (`exir/program/_program.py:271`):

```mermaid
flowchart TB
    A["EdgeProgramManager.transform(MyPass)"] --> B[_transform_with_pass_manager]
    B --> C{res.modified}
    C -- True --> D[rebuild ExportedProgram\nsignature recompute + verifier re-run]
    C -- False --> E[return self\nintended fast path]
```

**2. "Repeat on modification" loop** (`backends/nxp/edge_passes/neutron_edge_pass.py`):

```python
for _ in range(len(graph_module.graph.nodes)):  # iteration_limit
    res = self.run(graph_module)
    if res.modified:
        ...  # keep iterating
    else:
        return PassResult(graph_module, modified)  # converged
```

This loop runs a pass repeatedly until it reports `modified=False`. A pass that always returns `True` would exhaust the full iteration limit (one iteration per graph node) before giving up.

### Test results

```bash
pytest exir/tests/test_passes.py::TestPassModifiedFlag -q
# 15 passed in 6.86s

lintrunner exir/passes/remove_noop_pass.py \
           exir/passes/prune_empty_tensors_pass.py \
           exir/passes/remove_graph_asserts_pass.py \
           exir/passes/replace_sym_size_op_pass.py \
           exir/passes/to_device_pass.py \
           exir/tests/test_passes.py
# ok No lint issues.
```

### Out of scope

The following passes also return `True` unconditionally but were left alone, either because they almost always mutate in practice (`MemoryPlanningPass`, `QuantFusionPass`, `quantize_io_pass`, `HintBasedSymShapeEvalPass`, `ConstraintBasedSymShapeEvalPass`, `debug_handle_generator_pass`) or because they have broader side-effects that warrant separate review (`dead_code_elimination_pass`, `to_scratch_op_pass`, `to_out_var_pass`). Happy to follow up in a separate PR if maintainers want them tightened too.

---

cc @JacobSzwejbka @angelayi