### PR TITLE
CI: experiment — drop macOS pytest to -n 1, remove AOTI skips

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -11,6 +11,7 @@ zstd==1.5.5.1
 pandas>=2.2.2; python_version >= '3.10'
 pytest==7.2.0
 pytest-cov==4.1.0
+pytest-timeout==2.2.0
 expecttest==0.1.6
 hypothesis==6.84.2
 parameterized==0.9.0

--- a/.ci/scripts/unittest-macos-cmake.sh
+++ b/.ci/scripts/unittest-macos-cmake.sh
@@ -12,8 +12,27 @@ set -eux
 export TORCHINDUCTOR_CACHE_DIR="$(mktemp -d "${RUNNER_TEMP:-/tmp}/torchinductor_cache_XXXXXX")"
 trap 'rm -rf "${TORCHINDUCTOR_CACHE_DIR}"' EXIT
 
-# Run pytest with coverage
-${CONDA_RUN} pytest -n auto --cov=./ --cov-report=xml
+# AOTI-packaged .so invocation (torch._inductor.package._package.__call__)
+# hangs on macOS CI runners. Skip every test that loads and calls an
+# AOTI-packaged module on macOS until the hang is root-caused.
+# TODO(SS-JIA): re-enable once AOTI hang is root-caused.
+AOTI_SKIPS=(
+  --ignore=examples/models/llama3_2_vision/preprocess/test_preprocess.py
+  --ignore=examples/models/llama3_2_vision/vision_encoder/test/test_vision_encoder.py
+  --ignore=examples/models/llama3_2_vision/text_decoder/test/test_text_decoder.py
+  --deselect=extension/llm/modules/test/test_position_embeddings.py::TilePositionalEmbeddingTest::test_tile_positional_embedding_aoti
+  --deselect=extension/llm/modules/test/test_position_embeddings.py::TiledTokenPositionalEmbeddingTest::test_tiled_token_positional_embedding_aoti
+  --deselect=extension/llm/modules/test/test_attention.py::AttentionTest::test_attention_aoti
+)
+
+# Run pytest with coverage. --timeout surfaces hung tests with a thread dump
+# and faulthandler_timeout periodically dumps every worker's threads while
+# tests are still running, so we can see which test is dragging before it
+# trips the hard timeout.
+${CONDA_RUN} pytest -n auto --cov=./ --cov-report=xml \
+  --timeout=1500 --timeout-method=thread \
+  -o faulthandler_timeout=180 \
+  "${AOTI_SKIPS[@]}"
 # Run gtest
 LLVM_PROFDATA="xcrun llvm-profdata" LLVM_COV="xcrun llvm-cov" \
 ${CONDA_RUN} test/run_oss_cpp_tests.sh

--- a/.ci/scripts/unittest-macos-cmake.sh
+++ b/.ci/scripts/unittest-macos-cmake.sh
@@ -12,27 +12,15 @@ set -eux
 export TORCHINDUCTOR_CACHE_DIR="$(mktemp -d "${RUNNER_TEMP:-/tmp}/torchinductor_cache_XXXXXX")"
 trap 'rm -rf "${TORCHINDUCTOR_CACHE_DIR}"' EXIT
 
-# AOTI-packaged .so invocation (torch._inductor.package._package.__call__)
-# hangs on macOS CI runners. Skip every test that loads and calls an
-# AOTI-packaged module on macOS until the hang is root-caused.
-# TODO(SS-JIA): re-enable once AOTI hang is root-caused.
-AOTI_SKIPS=(
-  --ignore=examples/models/llama3_2_vision/preprocess/test_preprocess.py
-  --ignore=examples/models/llama3_2_vision/vision_encoder/test/test_vision_encoder.py
-  --ignore=examples/models/llama3_2_vision/text_decoder/test/test_text_decoder.py
-  --deselect=extension/llm/modules/test/test_position_embeddings.py::TilePositionalEmbeddingTest::test_tile_positional_embedding_aoti
-  --deselect=extension/llm/modules/test/test_position_embeddings.py::TiledTokenPositionalEmbeddingTest::test_tiled_token_positional_embedding_aoti
-  --deselect=extension/llm/modules/test/test_attention.py::AttentionTest::test_attention_aoti
-)
-
-# Run pytest with coverage. --timeout surfaces hung tests with a thread dump
-# and faulthandler_timeout periodically dumps every worker's threads while
-# tests are still running, so we can see which test is dragging before it
-# trips the hard timeout.
-${CONDA_RUN} pytest -n auto --cov=./ --cov-report=xml \
+# EXPERIMENT: drop xdist (`-n 1`) on macOS to test whether AOTI hangs are
+# caused by parallel-worker contention (clang/ld, dlopen lock, libomp
+# oversubscription) rather than a true deadlock. AOTI skips removed so we
+# can observe whether the previously-hung tests now pass serially.
+# --timeout surfaces hung tests with a thread dump and faulthandler_timeout
+# periodically dumps every worker's threads while tests are still running.
+${CONDA_RUN} pytest -n 1 --cov=./ --cov-report=xml \
   --timeout=1500 --timeout-method=thread \
-  -o faulthandler_timeout=180 \
-  "${AOTI_SKIPS[@]}"
+  -o faulthandler_timeout=180
 # Run gtest
 LLVM_PROFDATA="xcrun llvm-profdata" LLVM_COV="xcrun llvm-cov" \
 ${CONDA_RUN} test/run_oss_cpp_tests.sh

--- a/.github/workflows/_unittest.yml
+++ b/.github/workflows/_unittest.yml
@@ -49,6 +49,7 @@ jobs:
       python-version: '3.11'
       submodules: 'recursive'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      timeout: 30
       script: |
         set -eux
         # This is needed to get the prebuilt PyTorch wheel from S3

--- a/.github/workflows/_unittest.yml
+++ b/.github/workflows/_unittest.yml
@@ -49,7 +49,7 @@ jobs:
       python-version: '3.11'
       submodules: 'recursive'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-      timeout: 30
+      timeout: 90
       script: |
         set -eux
         # This is needed to get the prebuilt PyTorch wheel from S3


### PR DESCRIPTION

Summary:
Test the hypothesis that the macOS AOTI hangs are caused by xdist-worker
contention (parallel clang/ld during AOTI compile, dlopen lock on darwin,
libomp oversubscription) rather than a true deadlock. Switch the macOS
pytest invocation from `-n auto` to `-n 1` and remove the AOTI skips from
the previous commit so the previously-hung tests actually run. Bump the
job timeout to 90 minutes so a serial run has room to finish; keep the
per-test `--timeout=1500`.

If the AOTI tests pass under `-n 1`, the right permanent fix is splitting
macOS into a serial AOTI lane plus a parallel everything-else lane (or
simply lowering the parallelism cap). If they still hang, the issue is
deeper than xdist contention and we keep the skips.

Co-Authored-By: Claude <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/executorch/pull/19871).
* __->__ #19871
* #19844