### PR TITLE
runtime: null-check sizes and dim_order in validateTensorLayout

### DIFF
--- a/runtime/executor/tensor_parser_exec_aten.cpp
+++ b/runtime/executor/tensor_parser_exec_aten.cpp
@@ -129,6 +129,12 @@ ET_NODISCARD Error validateTensorLayout(
       "Scalar type mismatch. Expected %hhd, got %hhd.",
       static_cast<int8_t>(s_tensor->scalar_type()),
       static_cast<int8_t>(expected_layout.scalar_type()));
+  ET_CHECK_OR_RETURN_ERROR(
+      s_tensor->sizes() != nullptr, InvalidExternalData, "Missing sizes field");
+  ET_CHECK_OR_RETURN_ERROR(
+      s_tensor->dim_order() != nullptr,
+      InvalidExternalData,
+      "Missing dim_order field");
   int dim = s_tensor->sizes()->size();
   ET_CHECK_OR_RETURN_ERROR(
       dim >= 0, InvalidExternalData, "Dim is negative: %d", dim)

--- a/runtime/executor/test/tensor_parser_test.cpp
+++ b/runtime/executor/test/tensor_parser_test.cpp
@@ -229,6 +229,72 @@ TEST(ValidateTensorLayoutTest, DimOrderSizeMismatchIsRejected) {
       validateTensorLayout(s_tensor, layout.get()), Error::InvalidExternalData);
 }
 
+// Tests that validateTensorLayout rejects tensors with a null sizes field
+// instead of dereferencing it, which would SIGSEGV under the default
+// Verification::Minimal load mode.
+TEST(ValidateTensorLayoutTest, NullSizesIsRejected) {
+  flatbuffers::FlatBufferBuilder builder;
+
+  std::vector<uint8_t> dim_order = {0, 1, 2};
+
+  // Pass 0 for the sizes offset to serialize a null sizes field.
+  auto tensor_offset = executorch_flatbuffer::CreateTensor(
+      builder,
+      executorch_flatbuffer::ScalarType::FLOAT,
+      /*storage_offset=*/0,
+      /*sizes=*/0,
+      builder.CreateVector(dim_order));
+  builder.Finish(tensor_offset);
+
+  const auto* s_tensor = flatbuffers::GetRoot<executorch_flatbuffer::Tensor>(
+      builder.GetBufferPointer());
+  ASSERT_EQ(s_tensor->sizes(), nullptr);
+
+  std::vector<int32_t> expected_sizes = {2, 3, 4};
+  std::vector<uint8_t> expected_dim_order = {0, 1, 2};
+  auto layout = TensorLayout::create(
+      Span<const int32_t>(expected_sizes.data(), expected_sizes.size()),
+      Span<const uint8_t>(expected_dim_order.data(), expected_dim_order.size()),
+      ScalarType::Float);
+  ASSERT_TRUE(layout.ok());
+
+  EXPECT_EQ(
+      validateTensorLayout(s_tensor, layout.get()), Error::InvalidExternalData);
+}
+
+// Tests that validateTensorLayout rejects tensors with a null dim_order field
+// instead of dereferencing it, which would SIGSEGV under the default
+// Verification::Minimal load mode.
+TEST(ValidateTensorLayoutTest, NullDimOrderIsRejected) {
+  flatbuffers::FlatBufferBuilder builder;
+
+  std::vector<int32_t> sizes = {2, 3, 4};
+
+  // Pass 0 for the dim_order offset to serialize a null dim_order field.
+  auto tensor_offset = executorch_flatbuffer::CreateTensor(
+      builder,
+      executorch_flatbuffer::ScalarType::FLOAT,
+      /*storage_offset=*/0,
+      builder.CreateVector(sizes),
+      /*dim_order=*/0);
+  builder.Finish(tensor_offset);
+
+  const auto* s_tensor = flatbuffers::GetRoot<executorch_flatbuffer::Tensor>(
+      builder.GetBufferPointer());
+  ASSERT_EQ(s_tensor->dim_order(), nullptr);
+
+  std::vector<int32_t> expected_sizes = {2, 3, 4};
+  std::vector<uint8_t> expected_dim_order = {0, 1, 2};
+  auto layout = TensorLayout::create(
+      Span<const int32_t>(expected_sizes.data(), expected_sizes.size()),
+      Span<const uint8_t>(expected_dim_order.data(), expected_dim_order.size()),
+      ScalarType::Float);
+  ASSERT_TRUE(layout.ok());
+
+  EXPECT_EQ(
+      validateTensorLayout(s_tensor, layout.get()), Error::InvalidExternalData);
+}
+
 // Helper to construct a flatbuffers::Vector<int32_t> from raw data.
 // FlatBuffer vectors are stored as [uint32_t length][T elements...].
 namespace {


### PR DESCRIPTION
### Problem

This PR adds the two missing null guards. Same pattern as #19267 and #17131, which hardened the same function.

External constants are validated through:

```text
parse_external_constants() -> validateTensorLayout() -> parseTensor()
```

`validateTensorLayout()` dereferences `sizes` and `dim_order`.
Since both FlatBuffer fields are optional, an omitted field causes a SIGSEGV.

| Configuration | Result without this change |
| --- | --- |
| `Verification::Minimal` | SIGSEGV crash |
| `Verification::InternalConsistency` | Validates `sizes`, but not `dim_order`; SIGSEGV crash |

### Fix

Add null guards in `validateTensorLayout()` and return
`InvalidExternalData` instead of dereferencing a null field.

### Tests

Add regression coverage for missing `sizes` and missing `dim_order`.
```bash
./test/run_oss_cpp_tests.sh
lintrunner runtime/executor/tensor_parser_exec_aten.cpp \
           runtime/executor/test/tensor_parser_test.cpp
```

Result: `0 tests failed out of 82`. Lint clean.
