### PR TITLE
Fix ghstack merge bot failing to parse PR stack header

### DIFF
--- a/.github/scripts/propose_ghstack_orig_pr.py
+++ b/.github/scripts/propose_ghstack_orig_pr.py
@@ -52,12 +52,9 @@ def extract_stack_from_body(pr_body: str) -> List[int]:
     """
 
     prs = []
-    ghstack_begin = (
-        "Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):"
-    )
     ghstack_begin_seen = False
     for line in pr_body.splitlines():
-        if ghstack_begin in line:
+        if line.startswith("Stack from [ghstack]"):
             ghstack_begin_seen = True
         if not ghstack_begin_seen:
             continue


### PR DESCRIPTION

Summary:

ghstack 0.15.0 changed the header URL in PR bodies from
`Stack from [ghstack](https://github.com/ezyang/ghstack)` to
`Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0)`.

The exact string match in `propose_ghstack_orig_pr.py` no longer matched,
causing every ghstack_land workflow run to fail since May 14. Use
`startswith("Stack from [ghstack]")` instead to be resilient to URL changes.

Test Plan:

Verified the new pattern matches both the old format
(`https://github.com/ezyang/ghstack`) and the new format
(`https://github.com/ezyang/ghstack/tree/0.15.0`).

This PR was authored with the help of Claude.

Reviewers:
