### PR TITLE
CI: re-skip AOTI tests to validate they cause the macOS hang

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -11,6 +11,7 @@ zstd==1.5.5.1
 pandas>=2.2.2; python_version >= '3.10'
 pytest==7.2.0
 pytest-cov==4.1.0
+pytest-timeout==2.2.0
 expecttest==0.1.6
 hypothesis==6.84.2
 parameterized==0.9.0

--- a/.ci/scripts/unittest-macos-cmake.sh
+++ b/.ci/scripts/unittest-macos-cmake.sh
@@ -12,8 +12,27 @@ set -eux
 export TORCHINDUCTOR_CACHE_DIR="$(mktemp -d "${RUNNER_TEMP:-/tmp}/torchinductor_cache_XXXXXX")"
 trap 'rm -rf "${TORCHINDUCTOR_CACHE_DIR}"' EXIT
 
-# Run pytest with coverage
-${CONDA_RUN} pytest -n auto --cov=./ --cov-report=xml
+# AOTI-packaged .so invocation (torch._inductor.package._package.__call__)
+# hangs on macOS CI runners. Skip every test that loads and calls an
+# AOTI-packaged module on macOS until the hang is root-caused.
+# TODO(SS-JIA): re-enable once AOTI hang is root-caused.
+AOTI_SKIPS=(
+  --ignore=examples/models/llama3_2_vision/preprocess/test_preprocess.py
+  --ignore=examples/models/llama3_2_vision/vision_encoder/test/test_vision_encoder.py
+  --ignore=examples/models/llama3_2_vision/text_decoder/test/test_text_decoder.py
+  --deselect=extension/llm/modules/test/test_position_embeddings.py::TilePositionalEmbeddingTest::test_tile_positional_embedding_aoti
+  --deselect=extension/llm/modules/test/test_position_embeddings.py::TiledTokenPositionalEmbeddingTest::test_tiled_token_positional_embedding_aoti
+  --deselect=extension/llm/modules/test/test_attention.py::AttentionTest::test_attention_aoti
+)
+
+# Run pytest with coverage. --timeout surfaces hung tests with a thread dump
+# and faulthandler_timeout periodically dumps every worker's threads while
+# tests are still running, so we can see which test is dragging before it
+# trips the hard timeout.
+${CONDA_RUN} pytest -n auto --cov=./ --cov-report=xml \
+  --timeout=1500 --timeout-method=thread \
+  -o faulthandler_timeout=180 \
+  "${AOTI_SKIPS[@]}"
 # Run gtest
 LLVM_PROFDATA="xcrun llvm-profdata" LLVM_COV="xcrun llvm-cov" \
 ${CONDA_RUN} test/run_oss_cpp_tests.sh

--- a/.ci/scripts/unittest-macos-cmake.sh
+++ b/.ci/scripts/unittest-macos-cmake.sh
@@ -12,27 +12,13 @@ set -eux
 export TORCHINDUCTOR_CACHE_DIR="$(mktemp -d "${RUNNER_TEMP:-/tmp}/torchinductor_cache_XXXXXX")"
 trap 'rm -rf "${TORCHINDUCTOR_CACHE_DIR}"' EXIT
 
-# AOTI-packaged .so invocation (torch._inductor.package._package.__call__)
-# hangs on macOS CI runners. Skip every test that loads and calls an
-# AOTI-packaged module on macOS until the hang is root-caused.
-# TODO(SS-JIA): re-enable once AOTI hang is root-caused.
-AOTI_SKIPS=(
-  --ignore=examples/models/llama3_2_vision/preprocess/test_preprocess.py
-  --ignore=examples/models/llama3_2_vision/vision_encoder/test/test_vision_encoder.py
-  --ignore=examples/models/llama3_2_vision/text_decoder/test/test_text_decoder.py
-  --deselect=extension/llm/modules/test/test_position_embeddings.py::TilePositionalEmbeddingTest::test_tile_positional_embedding_aoti
-  --deselect=extension/llm/modules/test/test_position_embeddings.py::TiledTokenPositionalEmbeddingTest::test_tiled_token_positional_embedding_aoti
-  --deselect=extension/llm/modules/test/test_attention.py::AttentionTest::test_attention_aoti
-)
-
-# Run pytest with coverage. --timeout surfaces hung tests with a thread dump
-# and faulthandler_timeout periodically dumps every worker's threads while
-# tests are still running, so we can see which test is dragging before it
-# trips the hard timeout.
-${CONDA_RUN} pytest -n auto --cov=./ --cov-report=xml \
+# EXPERIMENT: run without xdist entirely so output is unbuffered and each test
+# name prints immediately (with -n 1, xdist still buffers all output in a
+# worker process, hiding which test is hanging). -v prints test names as they
+# start; faulthandler_timeout dumps threads if a single test stalls.
+${CONDA_RUN} pytest -p no:xdist -v --cov=./ --cov-report=xml \
   --timeout=1500 --timeout-method=thread \
-  -o faulthandler_timeout=180 \
-  "${AOTI_SKIPS[@]}"
+  -o faulthandler_timeout=180
 # Run gtest
 LLVM_PROFDATA="xcrun llvm-profdata" LLVM_COV="xcrun llvm-cov" \
 ${CONDA_RUN} test/run_oss_cpp_tests.sh

--- a/.ci/scripts/unittest-macos-cmake.sh
+++ b/.ci/scripts/unittest-macos-cmake.sh
@@ -12,13 +12,25 @@ set -eux
 export TORCHINDUCTOR_CACHE_DIR="$(mktemp -d "${RUNNER_TEMP:-/tmp}/torchinductor_cache_XXXXXX")"
 trap 'rm -rf "${TORCHINDUCTOR_CACHE_DIR}"' EXIT
 
-# EXPERIMENT: run without xdist entirely so output is unbuffered and each test
-# name prints immediately (with -n 1, xdist still buffers all output in a
-# worker process, hiding which test is hanging). -v prints test names as they
-# start; faulthandler_timeout dumps threads if a single test stalls.
+# AOTI-packaged .so invocation (torch._inductor.package._package.__call__)
+# hangs on macOS CI runners — the thread blocks in native code so
+# faulthandler cannot even dump a traceback. Skip every test that loads
+# and calls an AOTI-packaged module until the hang is root-caused.
+AOTI_SKIPS=(
+  --ignore=examples/models/llama3_2_vision/preprocess/test_preprocess.py
+  --ignore=examples/models/llama3_2_vision/vision_encoder/test/test_vision_encoder.py
+  --ignore=examples/models/llama3_2_vision/text_decoder/test/test_text_decoder.py
+  --deselect=extension/llm/modules/test/test_position_embeddings.py::TilePositionalEmbeddingTest::test_tile_positional_embedding_aoti
+  --deselect=extension/llm/modules/test/test_position_embeddings.py::TiledTokenPositionalEmbeddingTest::test_tiled_token_positional_embedding_aoti
+  --deselect=extension/llm/modules/test/test_attention.py::AttentionTest::test_attention_aoti
+)
+
+# Run without xdist so output is unbuffered; -v prints test names as they
+# complete; faulthandler_timeout dumps threads if a single test stalls.
 ${CONDA_RUN} pytest -p no:xdist -v --cov=./ --cov-report=xml \
   --timeout=1500 --timeout-method=thread \
-  -o faulthandler_timeout=180
+  -o faulthandler_timeout=180 \
+  "${AOTI_SKIPS[@]}"
 # Run gtest
 LLVM_PROFDATA="xcrun llvm-profdata" LLVM_COV="xcrun llvm-cov" \
 ${CONDA_RUN} test/run_oss_cpp_tests.sh

--- a/.github/workflows/_unittest.yml
+++ b/.github/workflows/_unittest.yml
@@ -49,6 +49,7 @@ jobs:
       python-version: '3.11'
       submodules: 'recursive'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      timeout: 30
       script: |
         set -eux
         # This is needed to get the prebuilt PyTorch wheel from S3

--- a/.github/workflows/_unittest.yml
+++ b/.github/workflows/_unittest.yml
@@ -49,7 +49,7 @@ jobs:
       python-version: '3.11'
       submodules: 'recursive'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-      timeout: 30
+      timeout: 90
       script: |
         set -eux
         # This is needed to get the prebuilt PyTorch wheel from S3


### PR DESCRIPTION

Summary:
Three CI runs with AOTI tests enabled all showed the same pattern:
tests pass normally up to ~55%, then 38-42 minutes of complete silence
before job cancellation. Faulthandler cannot fire during the hang
(no dump appears), confirming the thread is blocked in native C/C++
code — consistent with the AOTI `dlopen` / compiler invocation path.

Re-introduce the AOTI skips from the first diagnostic commit. If the
job completes without timeout, this confirms the AOTI tests are the
sole cause of the hang.

Co-Authored-By: Claude <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/pytorch/executorch/pull/19880).
* __->__ #19880
* #19875
* #19844