### PR TITLE
Build QNN backend on linux: add CXX platform and qnn_executorch_backend_aot host target (#19889)

### DIFF
--- a/backends/qualcomm/aot/wrappers/targets.bzl
+++ b/backends/qualcomm/aot/wrappers/targets.bzl
@@ -1,6 +1,7 @@
 load(
     "@fbsource//tools/build_defs:default_platform_defs.bzl",
     "ANDROID",
+    "CXX",
 )
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 load("@fbsource//xplat/executorch/backends/qualcomm/third-party:third_party_libs.bzl", "qnn_third_party_dep")
@@ -20,7 +21,7 @@ def define_common_targets():
             "*.h",
         ]),
         define_static_target = True,
-        platforms = [ANDROID],
+        platforms = [ANDROID, CXX],
         visibility = ["PUBLIC"],
         deps = [
             qnn_third_party_dep("api"),

--- a/backends/qualcomm/runtime/targets.bzl
+++ b/backends/qualcomm/runtime/targets.bzl
@@ -1,6 +1,7 @@
 load(
     "@fbsource//tools/build_defs:default_platform_defs.bzl",
     "ANDROID",
+    "CXX",
 )
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 load("@fbsource//xplat/executorch/backends/qualcomm/third-party:third_party_libs.bzl", "qnn_third_party_dep")
@@ -21,7 +22,7 @@ def define_common_targets():
             "Logging.h",
         ],
         define_static_target = True,
-        platforms = [ANDROID],
+        platforms = [ANDROID, CXX],
         visibility = ["PUBLIC"],
         deps = [
             qnn_third_party_dep("api"),
@@ -68,7 +69,7 @@ def define_common_targets():
             ),
             define_static_target = True,
             link_whole = True,  # needed for executorch/examples/models/llama:main to register QnnBackend
-            platforms = [ANDROID],
+            platforms = [ANDROID, CXX],
             visibility = ["PUBLIC"],
             resources = ({
                 "qnn_lib": qnn_third_party_dep("qnn_offline_compile_libs"),

--- a/backends/qualcomm/targets.bzl
+++ b/backends/qualcomm/targets.bzl
@@ -1,6 +1,7 @@
 load(
     "@fbsource//tools/build_defs:default_platform_defs.bzl",
     "ANDROID",
+    "CXX",
 )
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 load("@fbsource//xplat/executorch/backends/qualcomm/third-party:third_party_libs.bzl", "qnn_third_party_dep")
@@ -69,7 +70,7 @@ def define_common_targets():
         },
         exported_external_deps = ["flatbuffers-api"],
         define_static_target = True,
-        platforms = [ANDROID],
+        platforms = [ANDROID, CXX],
     )
 
     runtime.cxx_library(
@@ -87,5 +88,32 @@ def define_common_targets():
         exported_deps = [
             ":schema",
         ],
-        platforms = [ANDROID],
+        platforms = [ANDROID, CXX],
+    )
+
+    # Host-side AOT variant of qnn_executorch_backend. Pulls in the QNN
+    # offline-compile libraries as a Buck resource (via :runtime, which
+    # itself depends on qnn_third_party_dep("qnn_offline_compile_libs")),
+    # so a host-side gtest or runner can dlopen the QNN libraries
+    # without a manual path setup.
+    #
+    # Mirrors qnn_executorch_backend's structure but swaps the on-device
+    # runtime_android_build dep for the host runtime which bundles the
+    # x86 simulator libraries as a Buck resource.
+    runtime.cxx_library(
+        name = "qnn_executorch_backend_aot",
+        srcs = [],
+        headers = [],
+        define_static_target = True,
+        visibility = ["PUBLIC"],
+        deps = [
+            qnn_third_party_dep("api"),
+            "//executorch/runtime/backend:interface",
+            "//executorch/runtime/core:core",
+            "//executorch/backends/qualcomm/runtime:runtime",
+        ],
+        exported_deps = [
+            ":schema",
+        ],
+        platforms = [ANDROID, CXX],
     )


### PR DESCRIPTION
Summary:

Make the QNN backend buildable on linux hosts so that AOT / offline
use cases (compilation, validation, host-side testing against the
simulator) can link against the QnnExecuTorchBackend without an
android target.

Two changes:

1. Add `CXX` to `platforms = [ANDROID]` on the QNN backend BUCK
   targets (5 sites across `backends/qualcomm/runtime/`,
   `backends/qualcomm/aot/wrappers/`, and the top-level
   `backends/qualcomm/targets.bzl`). The QNN runtime sources have no
   android-specific code (`__ANDROID__`, `fastrpc`, `dlopen` are not
   referenced), so expanding the platform set is a one-line tag
   change and the ANDROID behavior is unchanged.

2. Add `qnn_executorch_backend_aot` in
   `backends/qualcomm/targets.bzl`. Mirrors the structure of the
   existing `qnn_executorch_backend` (on-device) but depends on the
   host `:runtime` target instead of `:runtime_android_build`. The
   host runtime bundles the QNN offline-compile libraries as a Buck
   resource, so consumers linking the AOT variant get the libs in
   their dlopen search path without manual setup. Registers
   `"QnnBackend"` via the same link-whole static initializer as the
   on-device variant.

Differential Revision: D105761976


