### PR TITLE
Suppress cppcheck unusedFunction false positives in headers

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -134,6 +134,8 @@ command = [
     '--extra-arg=--inconclusive',
     '--extra-arg=--suppress=unusedStructMember',
     '--extra-arg=--suppress=toomanyconfigs',
+    '--extra-arg=--suppress=unusedFunction:*.h',
+    '--extra-arg=--suppress=unusedFunction:*.hpp',
     '--',
     '@{{PATHSFILE}}'
 ]


### PR DESCRIPTION
### Summary
cppcheck's unusedFunction is a whole-program check, but lintrunner analyzes files individually. Functions defined in headers are used by the .cpp files that include them, but cppcheck only sees the header in isolation and falsely reports them as never used. Suppress the check for .h/.hpp files while keeping it active for .cpp.

Authored with assistance from Claude.
