### PR TITLE
Remove over-strict softmax mask divisibility assert

### DIFF
--- a/backends/cadence/aot/quantizer/patterns.py
+++ b/backends/cadence/aot/quantizer/patterns.py
@@ -1092,9 +1092,6 @@ class SoftmaxPattern(QuantizationPattern):
             return None
         mask_shape = list(mask_shape)
         # Softmax mask is packed 16 elements per int32 word.
-        assert (
-            mask_shape[-1] % 16 == 0
-        ), f"Softmax mask dimension must be divisible by 16, got {mask_shape[-1]}"
         mask_shape[-1] = mask_shape[-1] // 16
         mask_tensor = insert_node_with_meta(
             gm,


### PR DESCRIPTION
Summary: `SoftmaxPattern.fuse()` asserts `mask_shape[-1] % 16 == 0`. The softmax mask passed to the fused op is a dummy (`mask_type=0`, no masking is applied), so its trailing dimension does not affect numerics, and the historical `QuantFusion` simply floor-divided without asserting. The assert rejects otherwise-valid shapes (e.g. softmax over a last dim of 17 or 33) and fails `test_quantized_softmax_out_*` (T273477740). Remove the assert and floor-divide the mask shape like before, in both the `fbcode/` and `xplat/` cells.

Differential Revision: D106957459


