### PR TITLE
Switch CPPCHECK to broad coverage with excludes

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -120,6 +120,8 @@ exclude_patterns = [
     'third-party/**',
     'third_party/**',
 
+    # Mirrored sources under src/ (Python package layout). Prefer linting canonical paths.
+    'src/executorch/**',
     # PyTorch compatibility code kept in sync with upstream.
     'runtime/core/portable_type/c10/**',
 

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -179,8 +179,6 @@ exclude_patterns = [
     'extension/kernel_util/make_boxed_from_unboxed_functor.h',
     'extension/kernel_util/test/**',
     'extension/llm/**',
-    'extension/llm/apple/**',
-    'extension/llm/custom_ops/spinquant/third-party/**',
     'extension/memory_allocator/**',
     'extension/module/**',
     'extension/named_data_map/**',

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -118,7 +118,7 @@ exclude_patterns = [
     'third-party/**',
     'third_party/**',
     '**/third-party/**',
-    '**/third_party/**'
+    '**/third_party/**',
 
     # Mirrored sources under src/ (Python package layout). Prefer linting canonical paths.
     'src/executorch/**',

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -115,10 +115,10 @@ include_patterns = [
 ]
 exclude_patterns = [
     # Third-party and vendored code.
-    '**/third-party/**',
-    '**/third_party/**',
     'third-party/**',
     'third_party/**',
+    '**/third-party/**',
+    '**/third_party/**'
 
     # Mirrored sources under src/ (Python package layout). Prefer linting canonical paths.
     'src/executorch/**',

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -109,16 +109,106 @@ is_formatter = true
 [[linter]]
 code = 'CPPCHECK'
 include_patterns = [
-    'backends/arm/**/*.cpp',
-    'backends/arm/**/*.h',
-    'backends/arm/**/*.hpp',
-    'backends/cortex_m/**/*.cpp',
-    'backends/cortex_m/**/*.h',
-    'examples/arm/**/*.cpp',
-    'examples/arm/**/*.h',
-    'examples/arm/**/*.hpp',
+    '**/*.cpp',
+    '**/*.h',
+    '**/*.hpp',
 ]
 exclude_patterns = [
+    # Third-party and vendored code.
+    '**/third-party/**',
+    '**/third_party/**',
+    'third-party/**',
+    'third_party/**',
+
+    # PyTorch compatibility code kept in sync with upstream.
+    'runtime/core/portable_type/c10/**',
+
+    # Generated and template-only sources.
+    'codegen/templates/**',
+    'codegen/tools/selective_build.cpp',
+    'exir/_serialize/**',
+
+    # Backend-owned code to onboard separately.
+    'backends/aoti/**',
+    'backends/apple/**',
+    'backends/cadence/**',
+    'backends/cuda/**',
+    'backends/mediatek/**',
+    'backends/mlx/**',
+    'backends/nxp/**',
+    'backends/openvino/**',
+    'backends/qualcomm/**',
+    'backends/samsung/**',
+    'backends/test/**',
+    'backends/vulkan/**',
+    'backends/webgpu/**',
+    'backends/xnnpack/**',
+
+    # Backend-owned examples to onboard with those backends.
+    'examples/demo-apps/**',
+    'examples/mediatek/**',
+    'examples/nxp/**',
+    'examples/qualcomm/**',
+    'examples/samsung/**',
+
+    # Other examples to onboard separately.
+    'examples/devtools/**',
+    'examples/llm_manual/**',
+    'examples/models/**',
+    'examples/portable/**',
+    'examples/raspberry_pi/**',
+
+    # EXIR and devtools areas to onboard separately.
+    'devtools/bundled_program/**',
+    'devtools/etdump/**',
+    'exir/backend/test/**',
+    'exir/tests/**',
+    'exir/verification/**',
+
+    # Extension areas to onboard incrementally.
+    'extension/android/**',
+    'extension/apple/**',
+    'extension/asr/runner/transducer_runner.h',
+    'extension/aten_util/**',
+    'extension/benchmark/apple/**',
+    'extension/data_loader/**',
+    'extension/evalue_util/**',
+    'extension/flat_tensor/**',
+    'extension/kernel_util/make_boxed_from_unboxed_functor.h',
+    'extension/kernel_util/test/**',
+    'extension/llm/**',
+    'extension/llm/apple/**',
+    'extension/llm/custom_ops/spinquant/third-party/**',
+    'extension/memory_allocator/**',
+    'extension/module/**',
+    'extension/named_data_map/**',
+    'extension/pybindings/**',
+    'extension/pytree/**',
+    'extension/runner_util/**',
+    'extension/tensor/**',
+    'extension/testing_util/**',
+    'extension/threadpool/**',
+    'extension/training/**',
+    'extension/wasm/**',
+
+    # Kernel areas to onboard separately.
+    'kernels/aten/**',
+    'kernels/optimized/**',
+    'kernels/portable/**',
+    'kernels/prim_ops/**',
+    'kernels/quantized/**',
+    'kernels/test/**',
+
+    # Runtime areas to onboard incrementally.
+    'runtime/backend/**',
+    'runtime/core/**',
+    'runtime/executor/**',
+    'runtime/kernel/**',
+    'runtime/platform/**',
+
+    # Top-level test and platform integration areas.
+    'test/**',
+    'zephyr/**',
 ]
 command = [
     'python',

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -125,7 +125,7 @@ exclude_patterns = [
     # PyTorch compatibility code kept in sync with upstream.
     'runtime/core/portable_type/c10/**',
 
-    # Generated and template-only sources.
+    # Generated sources, templates, and codegen tooling to onboard separately.
     'codegen/templates/**',
     'codegen/tools/selective_build.cpp',
     'exir/_serialize/**',


### PR DESCRIPTION
Switch lintrunner cppcheck include pattern to include all files and rely on the exclude pattern to not lint files.

This has the positive side effect that new files would be included in the linting and the exclude list can have a nice sorting and comments why things have ended up there.

The end goal should of course be a empty exclude_patterns list.


Change-Id: Id815fcbf7a6ba901b6d1b1ace4209ff157a15d7e


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani