### PR TITLE
Expand Android audio API for decoder-only audio LLMs (#19920)

### DIFF
--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmGenerationConfig.kt
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmGenerationConfig.kt
@@ -24,6 +24,11 @@ private constructor(
     val temperature: Float,
     val numBos: Int,
     val numEos: Int,
+    val audioFilePath: String?,
+    val audioData: FloatArray?,
+    val audioBatchSize: Int,
+    val audioNBins: Int,
+    val audioNFrames: Int,
 ) {
 
   companion object {
@@ -49,6 +54,11 @@ private constructor(
     private var temperature: Float = 0.8f
     private var numBos: Int = 0
     private var numEos: Int = 0
+    private var audioFilePath: String? = null
+    private var audioData: FloatArray? = null
+    private var audioBatchSize: Int = 1
+    private var audioNBins: Int = 0
+    private var audioNFrames: Int = 0
 
     /** Sets whether to include the input prompt in the generated output. */
     fun echo(echo: Boolean): Builder = apply { this.echo = echo }
@@ -71,8 +81,37 @@ private constructor(
     /** Sets the number of EOS tokens to append. */
     fun numEos(numEos: Int): Builder = apply { this.numEos = numEos }
 
+    /** Sets a WAV file path to prefill as audio before text generation. */
+    fun audioFilePath(path: String): Builder = apply { this.audioFilePath = path }
+
+    /** Sets pre-processed audio data (mel spectrogram) to prefill before text generation. */
+    fun audioData(
+        data: FloatArray,
+        batchSize: Int,
+        nBins: Int,
+        nFrames: Int,
+    ): Builder = apply {
+      this.audioData = data
+      this.audioBatchSize = batchSize
+      this.audioNBins = nBins
+      this.audioNFrames = nFrames
+    }
+
     /** Constructs the LlmGenerationConfig instance with the configured parameters. */
     fun build(): LlmGenerationConfig =
-        LlmGenerationConfig(echo, maxNewTokens, warming, seqLen, temperature, numBos, numEos)
+        LlmGenerationConfig(
+            echo,
+            maxNewTokens,
+            warming,
+            seqLen,
+            temperature,
+            numBos,
+            numEos,
+            audioFilePath,
+            audioData,
+            audioBatchSize,
+            audioNBins,
+            audioNFrames,
+        )
   }
 }

--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmModule.kt
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmModule.kt
@@ -376,6 +376,11 @@ private constructor(
    * @param llmCallback callback object to receive results
    */
   fun generate(prompt: String, config: LlmGenerationConfig, llmCallback: LlmCallback) {
+    if (config.audioFilePath != null) {
+      prefillAudioFromFile(config.audioFilePath)
+    } else if (config.audioData != null) {
+      prefillAudio(config.audioData, config.audioBatchSize, config.audioNBins, config.audioNFrames)
+    }
     generate(
         null,
         0,
@@ -804,6 +809,260 @@ private constructor(
   ): Int
 
   /**
+   * Prefill the KV cache with pre-processed audio data from a direct [ByteBuffer] (uint8).
+   *
+   * This is the zero-copy counterpart to [prefillAudio] with [ByteArray]. For large audio inputs
+   * (e.g., multi-minute clips), using a direct ByteBuffer avoids the JNI array copy overhead.
+   *
+   * @param audio Direct ByteBuffer containing uint8 audio data (e.g., quantized mel spectrogram)
+   * @param batchSize Input batch size
+   * @param nBins Input number of frequency bins
+   * @param nFrames Input number of time frames
+   * @throws ExecutorchRuntimeException if the prefill failed
+   * @throws IllegalArgumentException if the buffer is not direct or too small
+   */
+  @Experimental
+  fun prefillAudio(audio: ByteBuffer, batchSize: Int, nBins: Int, nFrames: Int) {
+    mLock.lock()
+    try {
+      checkNotReentrant()
+      checkNotDestroyed()
+      require(audio.isDirect) { "Input ByteBuffer must be direct." }
+      val expectedBytes: Long
+      try {
+        val frames = Math.multiplyExact(batchSize.toLong(), nBins.toLong())
+        expectedBytes = Math.multiplyExact(frames, nFrames.toLong())
+      } catch (ex: ArithmeticException) {
+        throw IllegalArgumentException(
+            "batchSize*nBins*nFrames is too large and overflows the allowed range.", ex)
+      }
+      require(
+          batchSize > 0 && nBins > 0 && nFrames > 0 &&
+              expectedBytes <= Int.MAX_VALUE.toLong() &&
+              audio.remaining().toLong() >= expectedBytes
+      ) {
+        "ByteBuffer remaining (${audio.remaining()}) must be at least batchSize*nBins*nFrames ($expectedBytes)."
+      }
+      val nativeResult = prefillAudioInputBuffer(audio.slice(), batchSize, nBins, nFrames)
+      if (nativeResult != 0) {
+        throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed")
+      }
+    } finally {
+      mLock.unlock()
+    }
+  }
+
+  private external fun prefillAudioInputBuffer(
+      audio: ByteBuffer,
+      batchSize: Int,
+      nBins: Int,
+      nFrames: Int,
+  ): Int
+
+  /**
+   * Prefill the KV cache with pre-processed float audio data from a direct [ByteBuffer].
+   *
+   * This is the zero-copy counterpart to [prefillAudio] with [FloatArray]. The buffer must contain
+   * float32 values in native byte order. Mirrors [prefillNormalizedImage] for image inputs.
+   *
+   * @param audio Direct ByteBuffer containing float32 audio data (e.g., mel spectrogram)
+   * @param batchSize Input batch size
+   * @param nBins Input number of frequency bins
+   * @param nFrames Input number of time frames
+   * @throws ExecutorchRuntimeException if the prefill failed
+   * @throws IllegalArgumentException if the buffer is not direct, wrong byte order, or too small
+   */
+  @Experimental
+  fun prefillNormalizedAudio(audio: ByteBuffer, batchSize: Int, nBins: Int, nFrames: Int) {
+    mLock.lock()
+    try {
+      checkNotReentrant()
+      checkNotDestroyed()
+      require(audio.isDirect) { "Input ByteBuffer must be direct." }
+      require(audio.order() == ByteOrder.nativeOrder()) {
+        "Input ByteBuffer must use native byte order (ByteOrder.nativeOrder())."
+      }
+      require(audio.position() % Float.SIZE_BYTES == 0) {
+        "Input ByteBuffer position (${audio.position()}) must be 4-byte aligned."
+      }
+      val expectedBytes: Long
+      try {
+        val bins = Math.multiplyExact(batchSize, nBins)
+        val elements = Math.multiplyExact(bins.toLong(), nFrames.toLong())
+        val totalBytes = Math.multiplyExact(elements, Float.SIZE_BYTES.toLong())
+        if (totalBytes > Int.MAX_VALUE.toLong()) {
+          throw IllegalArgumentException(
+              "ByteBuffer size (batchSize*nBins*nFrames*4) exceeds Integer.MAX_VALUE bytes: $totalBytes")
+        }
+        expectedBytes = totalBytes
+      } catch (e: ArithmeticException) {
+        throw IllegalArgumentException(
+            "Overflow while computing batchSize*nBins*nFrames*4 for ByteBuffer size.", e)
+      }
+      require(
+          batchSize > 0 && nBins > 0 && nFrames > 0 &&
+              audio.remaining().toLong() >= expectedBytes
+      ) {
+        "ByteBuffer remaining (${audio.remaining()}) must be at least batchSize*nBins*nFrames*4 ($expectedBytes)."
+      }
+      require(audio.remaining() % Float.SIZE_BYTES == 0) {
+        "ByteBuffer remaining (${audio.remaining()}) must be a multiple of 4 (float size)."
+      }
+      val nativeResult =
+          prefillNormalizedAudioInputBuffer(audio.slice(), batchSize, nBins, nFrames)
+      if (nativeResult != 0) {
+        throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed")
+      }
+    } finally {
+      mLock.unlock()
+    }
+  }
+
+  private external fun prefillNormalizedAudioInputBuffer(
+      audio: ByteBuffer,
+      batchSize: Int,
+      nBins: Int,
+      nFrames: Int,
+  ): Int
+
+  /**
+   * Prefill the KV cache with raw PCM-16 audio samples.
+   *
+   * @param audio Input audio as 16-bit signed PCM samples
+   * @param batchSize Input batch size
+   * @param nChannels Input number of channels (1 for mono, 2 for stereo)
+   * @param nSamples Input number of samples per channel
+   * @throws ExecutorchRuntimeException if the prefill failed
+   */
+  @Experimental
+  fun prefillRawAudio(audio: ShortArray, batchSize: Int, nChannels: Int, nSamples: Int) {
+    mLock.lock()
+    try {
+      checkNotReentrant()
+      checkNotDestroyed()
+      val nativeResult = prefillRawAudioInputShort(audio, batchSize, nChannels, nSamples)
+      if (nativeResult != 0) {
+        throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed")
+      }
+    } finally {
+      mLock.unlock()
+    }
+  }
+
+  private external fun prefillRawAudioInputShort(
+      audio: ShortArray,
+      batchSize: Int,
+      nChannels: Int,
+      nSamples: Int,
+  ): Int
+
+  /**
+   * Prefill the KV cache with raw float32 audio samples.
+   *
+   * @param audio Input audio as 32-bit float samples (typically normalized to [-1.0, 1.0])
+   * @param batchSize Input batch size
+   * @param nChannels Input number of channels (1 for mono, 2 for stereo)
+   * @param nSamples Input number of samples per channel
+   * @throws ExecutorchRuntimeException if the prefill failed
+   */
+  @Experimental
+  fun prefillRawAudio(audio: FloatArray, batchSize: Int, nChannels: Int, nSamples: Int) {
+    mLock.lock()
+    try {
+      checkNotReentrant()
+      checkNotDestroyed()
+      val nativeResult = prefillRawAudioInputFloat(audio, batchSize, nChannels, nSamples)
+      if (nativeResult != 0) {
+        throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed")
+      }
+    } finally {
+      mLock.unlock()
+    }
+  }
+
+  private external fun prefillRawAudioInputFloat(
+      audio: FloatArray,
+      batchSize: Int,
+      nChannels: Int,
+      nSamples: Int,
+  ): Int
+
+  /**
+   * Prefill the KV cache with raw audio data from a direct [ByteBuffer].
+   *
+   * @param audio Direct ByteBuffer containing raw PCM audio bytes
+   * @param batchSize Input batch size
+   * @param nChannels Input number of channels
+   * @param nSamples Input number of samples
+   * @throws ExecutorchRuntimeException if the prefill failed
+   * @throws IllegalArgumentException if the buffer is not direct or too small
+   */
+  @Experimental
+  fun prefillRawAudio(audio: ByteBuffer, batchSize: Int, nChannels: Int, nSamples: Int) {
+    mLock.lock()
+    try {
+      checkNotReentrant()
+      checkNotDestroyed()
+      require(audio.isDirect) { "Input ByteBuffer must be direct." }
+      val expectedBytes: Long
+      try {
+        val channels = Math.multiplyExact(batchSize.toLong(), nChannels.toLong())
+        expectedBytes = Math.multiplyExact(channels, nSamples.toLong())
+      } catch (ex: ArithmeticException) {
+        throw IllegalArgumentException(
+            "batchSize*nChannels*nSamples is too large and overflows the allowed range.", ex)
+      }
+      require(
+          batchSize > 0 && nChannels > 0 && nSamples > 0 &&
+              expectedBytes <= Int.MAX_VALUE.toLong() &&
+              audio.remaining().toLong() >= expectedBytes
+      ) {
+        "ByteBuffer remaining (${audio.remaining()}) must be at least batchSize*nChannels*nSamples ($expectedBytes)."
+      }
+      val nativeResult =
+          prefillRawAudioInputBuffer(audio.slice(), batchSize, nChannels, nSamples)
+      if (nativeResult != 0) {
+        throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed")
+      }
+    } finally {
+      mLock.unlock()
+    }
+  }
+
+  private external fun prefillRawAudioInputBuffer(
+      audio: ByteBuffer,
+      batchSize: Int,
+      nChannels: Int,
+      nSamples: Int,
+  ): Int
+
+  /**
+   * Prefill the KV cache with audio loaded from a WAV file.
+   *
+   * The WAV file is decoded natively (supports 16-bit PCM, 32-bit PCM, and 32-bit IEEE float).
+   * Audio samples are normalized to float and fed through the model's audio encoder.
+   *
+   * @param path Absolute path to a WAV file on disk
+   * @throws ExecutorchRuntimeException if the prefill failed or WAV decoding failed
+   */
+  @Experimental
+  fun prefillAudioFromFile(path: String) {
+    mLock.lock()
+    try {
+      checkNotReentrant()
+      checkNotDestroyed()
+      val nativeResult = prefillAudioFromFileNative(path)
+      if (nativeResult != 0) {
+        throw ExecutorchRuntimeException.makeExecutorchException(nativeResult, "Prefill failed")
+      }
+    } finally {
+      mLock.unlock()
+    }
+  }
+
+  private external fun prefillAudioFromFileNative(path: String): Int
+
+  /**
    * Prefill the KV cache with the given text prompt.
    *
    * @param prompt The text prompt to prefill.
@@ -874,6 +1133,7 @@ private constructor(
     const val MODEL_TYPE_TEXT = 1
     const val MODEL_TYPE_TEXT_VISION = 2
     const val MODEL_TYPE_MULTIMODAL = 2
+    const val MODEL_TYPE_TEXT_AUDIO = 5
 
     private const val DEFAULT_SEQ_LEN = 128
     private const val DEFAULT_ECHO = true

--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmModuleConfig.kt
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmModuleConfig.kt
@@ -23,6 +23,8 @@ private constructor(
     val numBos: Int,
     val numEos: Int,
     val loadMode: Int,
+    val sampleRate: Int,
+    val preprocessorPath: String?,
 ) {
 
   companion object {
@@ -47,6 +49,9 @@ private constructor(
     /** Model type constant for generic multimodal models. */
     const val MODEL_TYPE_MULTIMODAL = 2
 
+    /** Model type constant for text-and-audio multimodal models (e.g., Voxtral). */
+    const val MODEL_TYPE_TEXT_AUDIO = 5
+
     /**
      * Creates a new Builder instance for constructing LlmModuleConfig objects.
      *
@@ -70,6 +75,8 @@ private constructor(
     private var numBos: Int = 0
     private var numEos: Int = 0
     private var loadMode: Int = LOAD_MODE_MMAP
+    private var sampleRate: Int = 16000
+    private var preprocessorPath: String? = null
 
     /** Sets the path to the module. */
     fun modulePath(modulePath: String): Builder = apply { this.modulePath = modulePath }
@@ -110,6 +117,13 @@ private constructor(
       return apply { this.loadMode = loadMode }
     }
 
+    /** Sets the audio sample rate in Hz (default 16000). */
+    fun sampleRate(sampleRate: Int): Builder = apply { this.sampleRate = sampleRate }
+
+    /** Sets the path to an optional audio preprocessor .pte (e.g., mel spectrogram extractor). */
+    fun preprocessorPath(preprocessorPath: String?): Builder =
+        apply { this.preprocessorPath = preprocessorPath }
+
     /**
      * Constructs the LlmModuleConfig instance with validated parameters.
      *
@@ -128,6 +142,8 @@ private constructor(
           numBos,
           numEos,
           loadMode,
+          sampleRate,
+          preprocessorPath,
       )
     }
   }

--- a/extension/android/jni/jni_layer_llama.cpp
+++ b/extension/android/jni/jni_layer_llama.cpp
@@ -21,6 +21,7 @@
 #include <executorch/extension/llm/runner/multimodal_input.h>
 #include <executorch/extension/llm/runner/multimodal_runner.h>
 #include <executorch/extension/llm/runner/text_llm_runner.h>
+#include <executorch/extension/llm/runner/wav_loader.h>
 #include <executorch/runtime/platform/log.h>
 #include <executorch/runtime/platform/platform.h>
 #include <executorch/runtime/platform/runtime.h>
@@ -100,6 +101,7 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
   constexpr static int MODEL_TYPE_CATEGORY_MULTIMODAL = 2;
   constexpr static int MODEL_TYPE_MEDIATEK_LLAMA = 3;
   constexpr static int MODEL_TYPE_QNN_LLAMA = 4;
+  constexpr static int MODEL_TYPE_CATEGORY_TEXT_AUDIO = 5;
 
   static facebook::jni::local_ref<jhybriddata> initHybrid(
       facebook::jni::alias_ref<jclass>,
@@ -168,7 +170,8 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
       model_type_category_ = model_type_category;
       auto cpp_load_mode = load_mode_from_int(load_mode);
       std::vector<std::string> data_files_vector;
-      if (model_type_category == MODEL_TYPE_CATEGORY_MULTIMODAL) {
+      if (model_type_category == MODEL_TYPE_CATEGORY_MULTIMODAL ||
+          model_type_category == MODEL_TYPE_CATEGORY_TEXT_AUDIO) {
         runner_ = llm::create_multimodal_runner(
             model_path->toStdString().c_str(),
             llm::load_tokenizer(tokenizer_path->toStdString()),
@@ -567,6 +570,203 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
     return 0;
   }
 
+  jint prefill_audio_input_buffer(
+      facebook::jni::alias_ref<facebook::jni::JByteBuffer> data,
+      jint batch_size,
+      jint n_bins,
+      jint n_frames) {
+    if (!runner_) {
+      return static_cast<jint>(Error::InvalidState);
+    }
+    if (data == nullptr || batch_size <= 0 || n_bins <= 0 || n_frames <= 0) {
+      return static_cast<jint>(Error::InvalidArgument);
+    }
+    auto* raw = data->getDirectBytes();
+    auto size = data->getDirectSize();
+    size_t expected =
+        static_cast<size_t>(batch_size) * static_cast<size_t>(n_bins) * static_cast<size_t>(n_frames);
+    if (raw == nullptr || size < expected) {
+      return static_cast<jint>(Error::InvalidArgument);
+    }
+    std::vector<uint8_t> audio_data(raw, raw + expected);
+    llm::Audio audio{std::move(audio_data), batch_size, n_bins, n_frames};
+    std::vector<llm::MultimodalInput> inputs;
+    inputs.emplace_back(std::move(audio));
+    int32_t bos = needs_bos_ ? num_bos_ : 0;
+    auto result = runner_->prefill(inputs, bos, /*num_eos=*/0);
+    if (!result.ok()) {
+      return static_cast<jint>(result.error());
+    }
+    needs_bos_ = false;
+    return 0;
+  }
+
+  jint prefill_normalized_audio_input_buffer(
+      facebook::jni::alias_ref<facebook::jni::JByteBuffer> data,
+      jint batch_size,
+      jint n_bins,
+      jint n_frames) {
+    if (!runner_) {
+      return static_cast<jint>(Error::InvalidState);
+    }
+    if (data == nullptr || batch_size <= 0 || n_bins <= 0 || n_frames <= 0) {
+      return static_cast<jint>(Error::InvalidArgument);
+    }
+    auto* raw = data->getDirectBytes();
+    auto size = data->getDirectSize();
+    size_t expected_bytes =
+        static_cast<size_t>(batch_size) * static_cast<size_t>(n_bins) * static_cast<size_t>(n_frames) * sizeof(float);
+    if (raw == nullptr || size < expected_bytes ||
+        size % sizeof(float) != 0) {
+      return static_cast<jint>(Error::InvalidArgument);
+    }
+    size_t num_floats =
+        static_cast<size_t>(batch_size) * static_cast<size_t>(n_bins) * static_cast<size_t>(n_frames);
+    std::vector<float> audio_data(num_floats);
+    std::memcpy(audio_data.data(), raw, expected_bytes);
+    llm::Audio audio{std::move(audio_data), batch_size, n_bins, n_frames};
+    std::vector<llm::MultimodalInput> inputs;
+    inputs.emplace_back(std::move(audio));
+    int32_t bos = needs_bos_ ? num_bos_ : 0;
+    auto result = runner_->prefill(inputs, bos, /*num_eos=*/0);
+    if (!result.ok()) {
+      return static_cast<jint>(result.error());
+    }
+    needs_bos_ = false;
+    return 0;
+  }
+
+  jint prefill_raw_audio_input_short(
+      facebook::jni::alias_ref<jshortArray> data,
+      jint batch_size,
+      jint n_channels,
+      jint n_samples) {
+    if (!runner_) {
+      return static_cast<jint>(Error::InvalidState);
+    }
+    if (data == nullptr || batch_size <= 0 || n_channels <= 0 ||
+        n_samples <= 0) {
+      return static_cast<jint>(Error::InvalidArgument);
+    }
+    auto data_size = data->size();
+    if (data_size == 0) {
+      return static_cast<jint>(Error::InvalidArgument);
+    }
+    std::vector<jshort> data_jshort(data_size);
+    data->getRegion(0, data_size, data_jshort.data());
+    size_t byte_size = data_size * sizeof(jshort);
+    std::vector<uint8_t> data_u8(byte_size);
+    std::memcpy(data_u8.data(), data_jshort.data(), byte_size);
+    llm::RawAudio audio{std::move(data_u8), batch_size, n_channels, n_samples};
+    std::vector<llm::MultimodalInput> inputs;
+    inputs.emplace_back(std::move(audio));
+    int32_t bos = needs_bos_ ? num_bos_ : 0;
+    auto result = runner_->prefill(inputs, bos, /*num_eos=*/0);
+    if (!result.ok()) {
+      return static_cast<jint>(result.error());
+    }
+    needs_bos_ = false;
+    return 0;
+  }
+
+  jint prefill_raw_audio_input_float(
+      facebook::jni::alias_ref<jfloatArray> data,
+      jint batch_size,
+      jint n_channels,
+      jint n_samples) {
+    if (!runner_) {
+      return static_cast<jint>(Error::InvalidState);
+    }
+    if (data == nullptr || batch_size <= 0 || n_channels <= 0 ||
+        n_samples <= 0) {
+      return static_cast<jint>(Error::InvalidArgument);
+    }
+    auto data_size = data->size();
+    if (data_size == 0) {
+      return static_cast<jint>(Error::InvalidArgument);
+    }
+    std::vector<jfloat> data_jfloat(data_size);
+    data->getRegion(0, data_size, data_jfloat.data());
+    size_t byte_size = data_size * sizeof(jfloat);
+    std::vector<uint8_t> data_u8(byte_size);
+    std::memcpy(data_u8.data(), data_jfloat.data(), byte_size);
+    llm::RawAudio audio{std::move(data_u8), batch_size, n_channels, n_samples};
+    std::vector<llm::MultimodalInput> inputs;
+    inputs.emplace_back(std::move(audio));
+    int32_t bos = needs_bos_ ? num_bos_ : 0;
+    auto result = runner_->prefill(inputs, bos, /*num_eos=*/0);
+    if (!result.ok()) {
+      return static_cast<jint>(result.error());
+    }
+    needs_bos_ = false;
+    return 0;
+  }
+
+  jint prefill_raw_audio_input_buffer(
+      facebook::jni::alias_ref<facebook::jni::JByteBuffer> data,
+      jint batch_size,
+      jint n_channels,
+      jint n_samples) {
+    if (!runner_) {
+      return static_cast<jint>(Error::InvalidState);
+    }
+    if (data == nullptr || batch_size <= 0 || n_channels <= 0 ||
+        n_samples <= 0) {
+      return static_cast<jint>(Error::InvalidArgument);
+    }
+    auto* raw = data->getDirectBytes();
+    auto size = data->getDirectSize();
+    size_t expected =
+        static_cast<size_t>(batch_size) * static_cast<size_t>(n_channels) * static_cast<size_t>(n_samples);
+    if (raw == nullptr || size < expected) {
+      return static_cast<jint>(Error::InvalidArgument);
+    }
+    std::vector<uint8_t> audio_data(raw, raw + expected);
+    llm::RawAudio audio{std::move(audio_data), batch_size, n_channels, n_samples};
+    std::vector<llm::MultimodalInput> inputs;
+    inputs.emplace_back(std::move(audio));
+    int32_t bos = needs_bos_ ? num_bos_ : 0;
+    auto result = runner_->prefill(inputs, bos, /*num_eos=*/0);
+    if (!result.ok()) {
+      return static_cast<jint>(result.error());
+    }
+    needs_bos_ = false;
+    return 0;
+  }
+
+  jint prefill_audio_from_file(facebook::jni::alias_ref<jstring> path) {
+    if (!runner_) {
+      return static_cast<jint>(Error::InvalidState);
+    }
+    if (path == nullptr) {
+      return static_cast<jint>(Error::InvalidArgument);
+    }
+    std::string file_path = path->toStdString();
+    std::vector<float> audio_data =
+        llm::load_wav_audio_data(file_path);
+    if (audio_data.empty()) {
+      return static_cast<jint>(Error::InvalidArgument);
+    }
+    size_t byte_size = audio_data.size() * sizeof(float);
+    std::vector<uint8_t> data_u8(byte_size);
+    std::memcpy(data_u8.data(), audio_data.data(), byte_size);
+    int32_t n_samples = static_cast<int32_t>(audio_data.size());
+    llm::RawAudio audio{
+        std::move(data_u8),
+        /*batch_size=*/1,
+        /*n_channels=*/1,
+        /*n_samples=*/n_samples};
+    std::vector<llm::MultimodalInput> inputs;
+    inputs.emplace_back(std::move(audio));
+    int32_t bos = needs_bos_ ? num_bos_ : 0;
+    auto result = runner_->prefill(inputs, bos, /*num_eos=*/0);
+    if (!result.ok()) {
+      return static_cast<jint>(result.error());
+    }
+    needs_bos_ = false;
+    return 0;
+  }
+
   void stop() {
     if (runner_) {
       runner_->stop();
@@ -586,7 +786,8 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
       ss << "Model runner was not created. model_type_category="
          << model_type_category_
          << ". Valid values: " << MODEL_TYPE_CATEGORY_LLM << " (LLM), "
-         << MODEL_TYPE_CATEGORY_MULTIMODAL << " (Multimodal)";
+         << MODEL_TYPE_CATEGORY_MULTIMODAL << " (Multimodal), "
+         << MODEL_TYPE_CATEGORY_TEXT_AUDIO << " (TextAudio)";
       executorch::jni_helper::throwExecutorchException(
           static_cast<uint32_t>(Error::InvalidState), ss.str().c_str());
       return static_cast<jint>(Error::InvalidState);
@@ -623,6 +824,24 @@ class ExecuTorchLlmJni : public facebook::jni::HybridClass<ExecuTorchLlmJni> {
             ExecuTorchLlmJni::prefill_audio_input_float),
         makeNativeMethod(
             "prefillRawAudioInput", ExecuTorchLlmJni::prefill_raw_audio_input),
+        makeNativeMethod(
+            "prefillAudioInputBuffer",
+            ExecuTorchLlmJni::prefill_audio_input_buffer),
+        makeNativeMethod(
+            "prefillNormalizedAudioInputBuffer",
+            ExecuTorchLlmJni::prefill_normalized_audio_input_buffer),
+        makeNativeMethod(
+            "prefillRawAudioInputShort",
+            ExecuTorchLlmJni::prefill_raw_audio_input_short),
+        makeNativeMethod(
+            "prefillRawAudioInputFloat",
+            ExecuTorchLlmJni::prefill_raw_audio_input_float),
+        makeNativeMethod(
+            "prefillRawAudioInputBuffer",
+            ExecuTorchLlmJni::prefill_raw_audio_input_buffer),
+        makeNativeMethod(
+            "prefillAudioFromFileNative",
+            ExecuTorchLlmJni::prefill_audio_from_file),
         makeNativeMethod(
             "prefillTextInput", ExecuTorchLlmJni::prefill_text_input),
         makeNativeMethod("resetContextNative", ExecuTorchLlmJni::reset_context),


### PR DESCRIPTION
Summary:

ExecuTorch's Android LLM API has foundational audio support (`prefillAudio`, `prefillRawAudio`), but several gaps remain for running decoder-only audio LLMs like Voxtral smoothly from Kotlin/Java. This diff closes those gaps by adding parity with the image API and introducing new audio-specific features.

Changes:

`MODEL_TYPE_TEXT_AUDIO` constant (value 5) added to `LlmModule` and `LlmModuleConfig` for audio-specific model type discoverability. Routes to the multimodal runner in JNI, same as `MODEL_TYPE_MULTIMODAL`.

ByteBuffer zero-copy variants for audio prefill, mirroring the image API:
- `prefillAudio(ByteBuffer, batchSize, nBins, nFrames)` for uint8 mel spectrograms
- `prefillNormalizedAudio(ByteBuffer, batchSize, nBins, nFrames)` for float32 mel spectrograms (with native byte order and alignment validation)
- `prefillRawAudio(ByteBuffer, batchSize, nChannels, nSamples)` for raw PCM bytes

Typed raw audio variants for common PCM formats:
- `prefillRawAudio(ShortArray, ...)` for PCM-16
- `prefillRawAudio(FloatArray, ...)` for float32

WAV file path API: `prefillAudioFromFile(path)` loads and decodes a WAV file natively (16-bit PCM, 32-bit PCM, 32-bit IEEE float) via `load_wav_audio_data()`, then prefills the audio encoder.

Audio config fields in `LlmModuleConfig`: `sampleRate` (default 16000) and `preprocessorPath` for future audio preprocessing integration.

Audio fields in `LlmGenerationConfig`: `audioFilePath` and `audioData` allow audio+text generation in a single `generate(prompt, config, callback)` call. Audio is prefilled before text generation begins.

Differential Revision: D106580523


