### PR TITLE
Fix: permissions: {} blocks reusable workflow calls

### DIFF
--- a/.github/workflows/mlx.yml
+++ b/.github/workflows/mlx.yml
@@ -22,7 +22,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: true
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   # Emits is-full-run='true' for workflow_dispatch / ciflow tag /

--- a/.github/workflows/viable-strict-gate.yml
+++ b/.github/workflows/viable-strict-gate.yml
@@ -25,7 +25,8 @@ on:
     tags:
       - ciflow/trunk/*
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   run-decision:


### PR DESCRIPTION
viable-strict-gate.yml and mlx.yml had permissions: {} but call _ci-run-decision.yml, which needs contents: read for actions/checkout. GitHub intersects caller permissions with callee needs ({} ∩ {contents: read} = {}), so both workflows were rejected at registration since #19919 landed. The gate hasn't run (so update-viablestrict has had no signal), and mlx.yml hasn't triggered (MLX / * checks show [does not exist] on HUD). Loosen both to permissions: contents: read. Audited all other callers of _ci-run-decision.yml / _get-changed-files.yml; none affected.