### PR TITLE
Arm backend: Add real implementation for TOSA dialect ops.

### DIFF
--- a/backends/arm/_passes/fuse_constant_ops_pass.py
+++ b/backends/arm/_passes/fuse_constant_ops_pass.py
@@ -174,13 +174,10 @@ class FuseConstantArgsPass(ArmPass):
         for node in graph_module.graph.nodes:
             if node.op != "call_function":
                 continue
-            # Don't fuse TOSA dialect ops as they do not have eager forward functions.
-            # Also don't fuse ops whose explicit args/kwargs include symbolic shape values.
-            if (
-                self._is_tosa_dialect_op(node.target)
-                or self._arg_contains_symbolic_shape(node.args)
-                or self._arg_contains_symbolic_shape(node.kwargs)
-            ):
+            # Don't fuse ops whose explicit args/kwargs include symbolic shape values.
+            if self._arg_contains_symbolic_shape(
+                node.args
+            ) or self._arg_contains_symbolic_shape(node.kwargs):
                 continue
 
             input_nodes = node.all_input_nodes

--- a/backends/arm/operators/node_visitor.py
+++ b/backends/arm/operators/node_visitor.py
@@ -250,6 +250,9 @@ def get_node_visitors(*args) -> Dict[str, NodeVisitor]:
 
 
 def get_node_visitor(target: str, tosa_spec: TosaSpecification):
+    # Ensure all operator modules are imported so visitors are registered.
+    import executorch.backends.arm.operators  # noqa: F401
+
     node_visitor_tuples = _node_visitor_tuples.get(tosa_spec)
     for target_name, node_visitor_cls in node_visitor_tuples:
         if target_name == target:

--- a/backends/arm/operators/node_visitor.py
+++ b/backends/arm/operators/node_visitor.py
@@ -31,6 +31,7 @@ from executorch.backends.arm.tosa.specification import (
     TosaSpecMapping,
 )
 
+
 logger = logging.getLogger(__name__)
 
 
@@ -246,3 +247,12 @@ def get_node_visitors(*args) -> Dict[str, NodeVisitor]:
         node_visitors[target] = visitor(*args)
 
     return node_visitors
+
+
+def get_node_visitor(target: str, tosa_spec: TosaSpecification):
+    node_visitor_tuples = _node_visitor_tuples.get(tosa_spec)
+    for target_name, node_visitor_cls in node_visitor_tuples:
+        if target_name == target:
+            return node_visitor_cls(tosa_spec)
+
+    raise ValueError(f"No {target} NodeVisitor registered for {tosa_spec}")

--- a/backends/arm/test/misc/tosa_dialect/test_tosa_gather.py
+++ b/backends/arm/test/misc/tosa_dialect/test_tosa_gather.py
@@ -1,0 +1,44 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import executorch.backends.arm.tosa.dialect  # noqa: F401
+
+import torch
+from executorch.backends.arm.tosa.specification import (
+    TosaLoweringContext,
+    TosaSpecification,
+)
+from executorch.exir.dialects._ops import ops as exir_ops
+from torch._subclasses.fake_tensor import FakeTensorMode
+
+
+def test_gather_tosa_FP_fake() -> None:
+    values = torch.randn((1, 4, 3), dtype=torch.float32)
+    indices = torch.tensor([[0, 2]], dtype=torch.int32)
+
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.0+FP")
+    ), FakeTensorMode() as mode:
+        output = exir_ops.backend.tosa.GATHER.default(
+            mode.from_tensor(values),
+            mode.from_tensor(indices),
+        )
+
+    assert output.dtype == values.dtype
+    assert tuple(output.shape) == (1, 2, 3)
+
+
+def test_gather_tosa_FP_real() -> None:
+    values = torch.tensor(
+        [[[1.0, 10.0], [2.0, 20.0], [3.0, 30.0], [4.0, 40.0]]],
+        dtype=torch.float32,
+    )
+    indices = torch.tensor([[3, 1]], dtype=torch.int32)
+
+    with TosaLoweringContext(TosaSpecification.create_from_string("TOSA-1.0+FP")):
+        output = exir_ops.backend.tosa.GATHER.default(values, indices)
+
+    expected = values[:, indices[0], :]
+    torch.testing.assert_close(output, expected)

--- a/backends/arm/test/misc/tosa_dialect/test_tosa_identity.py
+++ b/backends/arm/test/misc/tosa_dialect/test_tosa_identity.py
@@ -13,7 +13,7 @@ from executorch.exir.dialects._ops import ops as exir_ops
 from torch._subclasses.fake_tensor import FakeTensorMode
 
 
-def test_identity_tosa_FP() -> None:
+def test_identity_tosa_FP_fake() -> None:
     sample_input = torch.randn((1, 2, 3, 4), dtype=torch.float32)
 
     with TosaLoweringContext(
@@ -23,3 +23,12 @@ def test_identity_tosa_FP() -> None:
 
         assert output.dtype == sample_input.dtype
         assert tuple(output.shape) == tuple(sample_input.shape)
+
+
+def test_identity_tosa_FP_real() -> None:
+    sample_input = torch.randn((1, 2, 3, 4), dtype=torch.float32)
+
+    with TosaLoweringContext(TosaSpecification.create_from_string("TOSA-1.0+FP")):
+        output = exir_ops.backend.tosa.IDENTITY.default(sample_input)
+
+    torch.testing.assert_close(output, sample_input)

--- a/backends/arm/test/passes/test_ensure_unique_output_nodes_pass.py
+++ b/backends/arm/test/passes/test_ensure_unique_output_nodes_pass.py
@@ -35,7 +35,6 @@ def test_ensure_unique_output_nodes_no_target_inserts_identity_per_repeated_outp
             "executorch_exir_dialects_backend__ops_tosa_IDENTITY_default": 2,
         },
     )
-    pipeline.pop_stage("run_method_and_compare_outputs")
     pipeline.run()
 
     graph_module = (
@@ -62,5 +61,4 @@ def test_ensure_unique_output_nodes_no_target_keeps_unique_outputs_unchanged() -
             "executorch_exir_dialects_backend__ops_tosa_IDENTITY_default",
         ],
     )
-    pipeline.pop_stage("run_method_and_compare_outputs")
     pipeline.run()

--- a/backends/arm/test/passes/test_rewrite_avg_pool2d_pass.py
+++ b/backends/arm/test/passes/test_rewrite_avg_pool2d_pass.py
@@ -6,7 +6,7 @@
 from typing import cast, Dict, Protocol, Tuple
 
 import torch
-from executorch.backends.arm._passes.rewrite_avg_pool2d_pass import RewriteAvgPool2dPass
+from executorch.backends.arm._passes import RewriteAvgPool2dPass
 from executorch.backends.arm.test import common
 from executorch.backends.arm.test.tester.test_pipeline import PassPipeline
 from executorch.backends.test.harness.stages import StageType
@@ -29,7 +29,7 @@ class AvgPool2dWithStride(torch.nn.Module):
 
 class AvgPool2dWithoutStride(torch.nn.Module):
     def get_inputs(self) -> input_t:
-        return (torch.rand(1, 3, 8, 8),)
+        return (torch.rand(1, 3, 9, 9),)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return torch.nn.functional.avg_pool2d(x, kernel_size=3)
@@ -37,7 +37,7 @@ class AvgPool2dWithoutStride(torch.nn.Module):
 
 class AvgPool2dListKernel(torch.nn.Module):
     def get_inputs(self) -> input_t:
-        return (torch.rand(1, 3, 8, 8),)
+        return (torch.rand(1, 3, 8, 9),)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return torch.nn.functional.avg_pool2d(x, kernel_size=[2, 3])
@@ -45,7 +45,7 @@ class AvgPool2dListKernel(torch.nn.Module):
 
 class AvgPool2dScalarPadding(torch.nn.Module):
     def get_inputs(self) -> input_t:
-        return (torch.rand(1, 3, 8, 8),)
+        return (torch.rand(1, 3, 9, 9),)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return torch.nn.functional.avg_pool2d(x, kernel_size=3, stride=2, padding=1)
@@ -53,7 +53,7 @@ class AvgPool2dScalarPadding(torch.nn.Module):
 
 class AvgPool2dWithEmptyStride(torch.nn.Module):
     def get_inputs(self) -> input_t:
-        return (torch.rand(1, 3, 8, 8),)
+        return (torch.rand(1, 3, 8, 9),)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return torch.nn.functional.avg_pool2d(x, kernel_size=[2, 3], stride=[])
@@ -81,9 +81,6 @@ def test_rewrite_avg_pool2d_tosa(module: ModuleWithInputs) -> None:
         },
         pass_list=[RewriteAvgPool2dPass],
     )
-    pipeline.pop_stage(
-        "run_method_and_compare_outputs"
-    )  # Cannot run aten graph with tosa dialect ops
     pipeline.run()
 
 
@@ -119,7 +116,6 @@ def test_rewrite_avg_pool2d_tosa_empty_stride_uses_kernel_size() -> None:
         },
         pass_list=[RewriteAvgPool2dPass],
     )
-    pipeline.pop_stage("run_method_and_compare_outputs")
     pipeline.run()
 
     tosa_node = _get_tosa_avg_pool2d_node(pipeline)

--- a/backends/arm/test/passes/test_rewrite_conv_pass.py
+++ b/backends/arm/test/passes/test_rewrite_conv_pass.py
@@ -213,8 +213,6 @@ def test_rewrite_conv_tosa_FP():
     pipeline = PassPipeline(
         module, module.get_inputs(), passes_with_exported_program=[RewriteConvPass]
     )
-    # We cannot run TOSA backend dialect operators in eager mode.
-    pipeline.pop_stage("run_method_and_compare_outputs")
     pipeline.run()
 
 

--- a/backends/arm/test/passes/test_rewrite_max_pool2d_pass.py
+++ b/backends/arm/test/passes/test_rewrite_max_pool2d_pass.py
@@ -37,7 +37,7 @@ class MaxPool2dWithStride(torch.nn.Module):
 
 class MaxPool2dWithoutStride(torch.nn.Module):
     def get_inputs(self) -> input_t:
-        return (torch.rand(1, 3, 8, 8),)
+        return (torch.rand(1, 3, 9, 9),)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return torch.nn.functional.max_pool2d(x, kernel_size=3)
@@ -45,7 +45,7 @@ class MaxPool2dWithoutStride(torch.nn.Module):
 
 class MaxPool2dListKernel(torch.nn.Module):
     def get_inputs(self) -> input_t:
-        return (torch.rand(1, 3, 8, 8),)
+        return (torch.rand(1, 3, 8, 9),)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return torch.nn.functional.max_pool2d(x, kernel_size=[2, 3])
@@ -56,7 +56,7 @@ class MaxPool2dWithEmptyStride(torch.nn.Module):
         return (torch.rand(1, 3, 8, 8),)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return torch.nn.functional.max_pool2d(x, kernel_size=[2, 3], stride=[])
+        return torch.nn.functional.max_pool2d(x, kernel_size=[2, 2], stride=[])
 
 
 class MaxPool2dDynamic(torch.nn.Module):
@@ -94,9 +94,6 @@ def test_rewrite_max_pool2d_tosa(module: ModuleWithInputs) -> None:
         },
         pass_list=[RemoveGetItemPass, RewriteMaxPool2dPass],
     )
-    pipeline.pop_stage(
-        "run_method_and_compare_outputs"
-    )  # Cannnot run aten graph with tosa dialect ops
     pipeline.run()
 
 
@@ -131,11 +128,10 @@ def test_rewrite_max_pool2d_tosa_empty_stride_uses_kernel_size() -> None:
         },
         pass_list=[RemoveGetItemPass, RewriteMaxPool2dPass],
     )
-    pipeline.pop_stage("run_method_and_compare_outputs")
     pipeline.run()
 
     tosa_node = _get_tosa_max_pool2d_node(pipeline)
-    assert tosa_node.args[2] == [2, 3]
+    assert tosa_node.args[2] == [2, 2]
 
 
 def test_rewrite_max_pool2d_tosa_dynamic_shape() -> None:

--- a/backends/arm/tosa/dialect/BUCK
+++ b/backends/arm/tosa/dialect/BUCK
@@ -6,6 +6,7 @@ fbcode_target(_kind = runtime.python_library,
     srcs = [
         "lib.py",
         "ops_registration.py",
+        "real_impl.py",
         "shape.py",
     ],
     deps = [

--- a/backends/arm/tosa/dialect/lib.py
+++ b/backends/arm/tosa/dialect/lib.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -14,16 +14,22 @@ from torchgen.model import FunctionSchema
 tosa_lib = Library("tosa", "DEF")
 
 
-def register_tosa_dialect_op(op_schema, func) -> Callable:
+def register_tosa_dialect_op(
+    op_schema,
+    fake_func,
+    real_func: Callable | None = None,
+    real_dispatch_key: str = "CompositeExplicitAutograd",
+) -> Callable:
     """Register a TOSA dialect operator with the backend op library.
 
     Args:
         op_schema (str): Operator schema without namespace or overload name.
-        func (Callable): Fake implementation used for registration.
+        fake_func (Callable): Fake implementation used for registration.
+        real_func (Optional[Callable]): Optional eager implementation.
+        real_dispatch_key (str): Dispatch key used for the eager implementation.
 
     Returns:
-        Callable: Backend dialect operator handle exposed via ``exir_ops`` and
-        marked ``not_callable`` for runtime use.
+        Callable: Backend dialect operator handle exposed via ``exir_ops``.
 
     """
     if tosa_lib.ns not in _BACKEND_OP_LIB:
@@ -46,18 +52,10 @@ def register_tosa_dialect_op(op_schema, func) -> Callable:
     overload_name = "default"
     op_qualified_name = f"{tosa_lib.ns}::{opname}"
 
-    register_fake(op_qualified_name, func, lib=tosa_lib)
-
+    register_fake(op_qualified_name, fake_func, lib=tosa_lib)
+    if real_func is not None:
+        tosa_lib.impl(opname, real_func, real_dispatch_key)
     op = getattr(getattr(getattr(exir_ops.backend, tosa_lib.ns), opname), overload_name)
-
-    # For now, since the TOSA operators are only used for lowering and serialization in the backend
-    # the op doesn't need to be callable. This can be changed in the future if needed to support
-    # execution of TOSA ops directly.
-    def not_callable():
-        """Raise when the dialect op handle is invoked at runtime."""
-        raise RuntimeError("TOSA dialect op is not callable")
-
-    op.__equvalent_callable__ = not_callable
 
     return op
 

--- a/backends/arm/tosa/dialect/ops/activation.py
+++ b/backends/arm/tosa/dialect/ops/activation.py
@@ -8,7 +8,7 @@ import math
 import torch
 from executorch.backends.arm.tosa.dialect.lib import TosaValueError
 from executorch.backends.arm.tosa.dialect.ops._common import validate_nan_mode
-from executorch.backends.arm.tosa.dialect.ops_registration import register_fake_tosa_op
+from executorch.backends.arm.tosa.dialect.ops_registration import register_tosa_op
 from executorch.backends.arm.tosa.specification import (
     get_context_spec,
     TosaSpecification,
@@ -84,7 +84,7 @@ def _validate_integer_clamp_bounds(
             )
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     'CLAMP(Tensor input, Scalar min_val, Scalar max_val, *, str nan_mode="PROPAGATE") -> Tensor',
     TosaSpecification.all_versions_and_profiles(),
 )
@@ -111,7 +111,7 @@ def CLAMP(
     return torch.empty_like(input, dtype=input.dtype)
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "ERF(Tensor input) -> Tensor",
     FP_SPECS,
 )
@@ -120,7 +120,7 @@ def ERF(input: torch.Tensor) -> torch.Tensor:
     return torch.empty_like(input, dtype=input.dtype)
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "SIGMOID(Tensor input) -> Tensor",
     FP_SPECS,
 )
@@ -129,7 +129,7 @@ def SIGMOID(input: torch.Tensor) -> torch.Tensor:
     return torch.empty_like(input, dtype=input.dtype)
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "TANH(Tensor input) -> Tensor",
     FP_SPECS,
 )

--- a/backends/arm/tosa/dialect/ops/argmax.py
+++ b/backends/arm/tosa/dialect/ops/argmax.py
@@ -6,7 +6,7 @@
 import torch
 from executorch.backends.arm.tosa.dialect.lib import TosaValueError
 from executorch.backends.arm.tosa.dialect.ops._common import validate_nan_mode
-from executorch.backends.arm.tosa.dialect.ops_registration import register_fake_tosa_op
+from executorch.backends.arm.tosa.dialect.ops_registration import register_tosa_op
 from executorch.backends.arm.tosa.specification import (
     get_context_spec,
     TosaSpecification,
@@ -51,7 +51,7 @@ def _validate_argmax_dtype(dtype: torch.dtype) -> None:
     raise TosaValueError(f"Unsupported dtype {dtype} for ARGMAX", op="ARGMAX")
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     'ARGMAX(Tensor input, int axis, *, str nan_mode="PROPAGATE") -> Tensor',
     TosaSpecification.all_versions_and_profiles(),
 )

--- a/backends/arm/tosa/dialect/ops/avg_pool2d.py
+++ b/backends/arm/tosa/dialect/ops/avg_pool2d.py
@@ -8,7 +8,7 @@ from typing import List, Union
 import sympy  # type: ignore[import-untyped]
 import torch
 from executorch.backends.arm.tosa.dialect.lib import TosaValueError
-from executorch.backends.arm.tosa.dialect.ops_registration import register_fake_tosa_op
+from executorch.backends.arm.tosa.dialect.ops_registration import register_tosa_op
 from executorch.backends.arm.tosa.specification import (
     get_context_shape_env,
     get_context_spec,
@@ -105,7 +105,7 @@ def validate_avg_pool2d_args(
         )
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "AVG_POOL2D(Tensor input, Tensor input_zp, Tensor output_zp, int[2] kernel, int[2] stride, SymInt[4] pad, ScalarType acc_type) -> Tensor",
     TosaSpecification.all_versions_and_profiles(),
 )

--- a/backends/arm/tosa/dialect/ops/avg_pool2d_adaptive.py
+++ b/backends/arm/tosa/dialect/ops/avg_pool2d_adaptive.py
@@ -11,7 +11,7 @@ from executorch.backends.arm.tosa.dialect.ops.avg_pool2d import (
     compute_avg_pool2d_output_shape,
     validate_avg_pool2d_dtype,
 )
-from executorch.backends.arm.tosa.dialect.ops_registration import register_fake_tosa_op
+from executorch.backends.arm.tosa.dialect.ops_registration import register_tosa_op
 from executorch.backends.arm.tosa.specification import (
     get_context_shape_env,
     get_context_spec,
@@ -36,7 +36,7 @@ def _is_directly_representable(
     return remainder in (0, 1)
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "AVG_POOL2D_ADAPTIVE(Tensor input, Tensor input_zp, Tensor output_zp, SymInt[2] kernel, SymInt[2] stride, SymInt[4] pad, ScalarType acc_type) -> Tensor",
     TosaSpecification.all_profiles_for_version("1.1"),
 )

--- a/backends/arm/tosa/dialect/ops/binary_elementwise.py
+++ b/backends/arm/tosa/dialect/ops/binary_elementwise.py
@@ -10,7 +10,7 @@ from executorch.backends.arm.tosa.dialect.ops._common import (
     require_same_dtype,
     validate_nan_mode,
 )
-from executorch.backends.arm.tosa.dialect.ops_registration import register_fake_tosa_op
+from executorch.backends.arm.tosa.dialect.ops_registration import register_tosa_op
 from executorch.backends.arm.tosa.specification import (
     get_context_spec,
     TosaSpecification,
@@ -134,7 +134,7 @@ def _validate_and_infer_mul_output_dtype(dtype: torch.dtype) -> torch.dtype:  # 
     _raise_unsupported_dtype(dtype, "MUL")
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "ADD(Tensor input1, Tensor input2) -> Tensor",
     TosaSpecification.all_versions_and_profiles(),
 )
@@ -143,7 +143,7 @@ def ADD(input1: torch.Tensor, input2: torch.Tensor) -> torch.Tensor:
     return _binary_meta(input1, input2, "ADD")
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "ARITHMETIC_RIGHT_SHIFT(Tensor input1, Tensor input2, *, bool round=False) -> Tensor",
     INT_SPECS,
 )
@@ -157,7 +157,7 @@ def ARITHMETIC_RIGHT_SHIFT(
     return _binary_meta(input1, input2, "ARITHMETIC_RIGHT_SHIFT")
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "BITWISE_AND(Tensor input1, Tensor input2) -> Tensor",
     TosaSpecification.all_versions_and_profiles(),
 )
@@ -166,7 +166,7 @@ def BITWISE_AND(input1: torch.Tensor, input2: torch.Tensor) -> torch.Tensor:
     return _binary_meta(input1, input2, "BITWISE_AND")
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "BITWISE_OR(Tensor input1, Tensor input2) -> Tensor",
     INT_SPECS,
 )
@@ -175,7 +175,7 @@ def BITWISE_OR(input1: torch.Tensor, input2: torch.Tensor) -> torch.Tensor:
     return _binary_meta(input1, input2, "BITWISE_OR")
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "BITWISE_XOR(Tensor input1, Tensor input2) -> Tensor",
     INT_SPECS,
 )
@@ -184,7 +184,7 @@ def BITWISE_XOR(input1: torch.Tensor, input2: torch.Tensor) -> torch.Tensor:
     return _binary_meta(input1, input2, "BITWISE_XOR")
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "EQUAL(Tensor input1, Tensor input2) -> Tensor",
     TosaSpecification.all_versions_and_profiles(),
 )
@@ -193,7 +193,7 @@ def EQUAL(input1: torch.Tensor, input2: torch.Tensor) -> torch.Tensor:
     return _binary_meta(input1, input2, "EQUAL", output_dtype=torch.bool)
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "GREATER(Tensor input1, Tensor input2) -> Tensor",
     TosaSpecification.all_versions_and_profiles(),
 )
@@ -202,7 +202,7 @@ def GREATER(input1: torch.Tensor, input2: torch.Tensor) -> torch.Tensor:
     return _binary_meta(input1, input2, "GREATER", output_dtype=torch.bool)
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "GREATER_EQUAL(Tensor input1, Tensor input2) -> Tensor",
     TosaSpecification.all_versions_and_profiles(),
 )
@@ -211,7 +211,7 @@ def GREATER_EQUAL(input1: torch.Tensor, input2: torch.Tensor) -> torch.Tensor:
     return _binary_meta(input1, input2, "GREATER_EQUAL", output_dtype=torch.bool)
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "INTDIV(Tensor input1, Tensor input2) -> Tensor",
     TosaSpecification.all_versions_and_profiles(),
 )
@@ -220,7 +220,7 @@ def INTDIV(input1: torch.Tensor, input2: torch.Tensor) -> torch.Tensor:
     return _binary_meta(input1, input2, "INTDIV")
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "LOGICAL_AND(Tensor input1, Tensor input2) -> Tensor",
     TosaSpecification.all_versions_and_profiles(),
 )
@@ -229,7 +229,7 @@ def LOGICAL_AND(input1: torch.Tensor, input2: torch.Tensor) -> torch.Tensor:
     return _binary_meta(input1, input2, "LOGICAL_AND")
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "LOGICAL_LEFT_SHIFT(Tensor input1, Tensor input2) -> Tensor",
     TosaSpecification.all_versions_and_profiles(),
 )
@@ -238,7 +238,7 @@ def LOGICAL_LEFT_SHIFT(input1: torch.Tensor, input2: torch.Tensor) -> torch.Tens
     return _binary_meta(input1, input2, "LOGICAL_LEFT_SHIFT")
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "LOGICAL_RIGHT_SHIFT(Tensor input1, Tensor input2) -> Tensor",
     TosaSpecification.all_versions_and_profiles(),
 )
@@ -247,7 +247,7 @@ def LOGICAL_RIGHT_SHIFT(input1: torch.Tensor, input2: torch.Tensor) -> torch.Ten
     return _binary_meta(input1, input2, "LOGICAL_RIGHT_SHIFT")
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "LOGICAL_OR(Tensor input1, Tensor input2) -> Tensor",
     TosaSpecification.all_versions_and_profiles(),
 )
@@ -256,7 +256,7 @@ def LOGICAL_OR(input1: torch.Tensor, input2: torch.Tensor) -> torch.Tensor:
     return _binary_meta(input1, input2, "LOGICAL_OR")
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "LOGICAL_XOR(Tensor input1, Tensor input2) -> Tensor",
     TosaSpecification.all_versions_and_profiles(),
 )
@@ -265,7 +265,7 @@ def LOGICAL_XOR(input1: torch.Tensor, input2: torch.Tensor) -> torch.Tensor:
     return _binary_meta(input1, input2, "LOGICAL_XOR")
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "MAXIMUM(Tensor input1, Tensor input2, *, str nan_mode='PROPAGATE') -> Tensor",
     TosaSpecification.all_versions_and_profiles(),
 )
@@ -280,7 +280,7 @@ def MAXIMUM(
     return _binary_meta(input1, input2, "MAXIMUM")
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "MINIMUM(Tensor input1, Tensor input2, *, str nan_mode='PROPAGATE') -> Tensor",
     TosaSpecification.all_versions_and_profiles(),
 )
@@ -295,7 +295,7 @@ def MINIMUM(
     return _binary_meta(input1, input2, "MINIMUM")
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "MUL(Tensor input1, Tensor input2, *, int shift=0) -> Tensor",
     TosaSpecification.all_versions_and_profiles(),
 )
@@ -318,7 +318,7 @@ def MUL(
     return _binary_meta(input1, input2, "MUL", output_dtype=output_dtype)
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "POW(Tensor input1, Tensor input2) -> Tensor",
     FP_SPECS,
 )
@@ -327,7 +327,7 @@ def POW(input1: torch.Tensor, input2: torch.Tensor) -> torch.Tensor:
     return _binary_meta(input1, input2, "POW")
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "SUB(Tensor input1, Tensor input2) -> Tensor",
     TosaSpecification.all_versions_and_profiles(),
 )

--- a/backends/arm/tosa/dialect/ops/cast_to_block_scaled.py
+++ b/backends/arm/tosa/dialect/ops/cast_to_block_scaled.py
@@ -8,14 +8,14 @@ from __future__ import annotations
 import torch
 
 from executorch.backends.arm.tosa.dialect.lib import TosaValueError
-from executorch.backends.arm.tosa.dialect.ops_registration import register_fake_tosa_op
+from executorch.backends.arm.tosa.dialect.ops_registration import register_tosa_op
 from executorch.backends.arm.tosa.specification import (
     get_context_spec,
     TosaSpecification,
 )
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "CAST_TO_BLOCK_SCALED(Tensor input, SymInt block_size, ScalarType output_dtype) -> (Tensor, Tensor)",
     [TosaSpecification.create_from_string("TOSA-1.1+FP")],
 )

--- a/backends/arm/tosa/dialect/ops/conv2d.py
+++ b/backends/arm/tosa/dialect/ops/conv2d.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 import torch
 from executorch.backends.arm.tosa.dialect.lib import TosaValueError
-from executorch.backends.arm.tosa.dialect.ops_registration import register_fake_tosa_op
+from executorch.backends.arm.tosa.dialect.ops_registration import register_tosa_op
 from executorch.backends.arm.tosa.specification import (
     get_context_spec,
     TosaSpecification,
@@ -89,7 +89,7 @@ def validate_conv2d_args_dtypes(  # noqa: C901
     return output_dtype
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "CONV2D(Tensor input, "
     "Tensor weight, "
     "Tensor bias, "

--- a/backends/arm/tosa/dialect/ops/conv3d.py
+++ b/backends/arm/tosa/dialect/ops/conv3d.py
@@ -9,7 +9,7 @@ from typing import Optional
 import torch
 from executorch.backends.arm.tosa.dialect.lib import TosaValueError
 from executorch.backends.arm.tosa.dialect.ops.conv2d import validate_conv2d_args_dtypes
-from executorch.backends.arm.tosa.dialect.ops_registration import register_fake_tosa_op
+from executorch.backends.arm.tosa.dialect.ops_registration import register_tosa_op
 from executorch.backends.arm.tosa.specification import (
     get_context_spec,
     TosaSpecification,
@@ -30,7 +30,7 @@ def validate_conv3d_args_dtypes(
     return validate_conv2d_args_dtypes(tosa_spec, x, weight, bias, op="CONV3D")
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "CONV3D(Tensor input, "
     "Tensor weight, "
     "Tensor bias, "

--- a/backends/arm/tosa/dialect/ops/custom.py
+++ b/backends/arm/tosa/dialect/ops/custom.py
@@ -31,7 +31,7 @@ import inspect
 from collections.abc import Callable
 
 import torch
-from executorch.backends.arm.tosa.dialect.ops_registration import register_fake_tosa_op
+from executorch.backends.arm.tosa.dialect.ops_registration import register_tosa_op
 
 from executorch.backends.arm.tosa.specification import (
     get_context_spec,
@@ -132,7 +132,7 @@ def run_registered_fake_tosa_impl(
     return outputs
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "CUSTOM(Tensor[] inputs, str operator_name, str domain_name, int[] implementation_attrs) -> Tensor[]",
     TosaSpecification.all_versions_and_profiles(),
 )

--- a/backends/arm/tosa/dialect/ops/data_layout_ops.py
+++ b/backends/arm/tosa/dialect/ops/data_layout_ops.py
@@ -9,7 +9,7 @@ import torch
 
 from executorch.backends.arm.constants import MAX_RANK
 from executorch.backends.arm.tosa.dialect.lib import TosaValueError
-from executorch.backends.arm.tosa.dialect.ops_registration import register_fake_tosa_op
+from executorch.backends.arm.tosa.dialect.ops_registration import register_tosa_op
 from executorch.backends.arm.tosa.specification import (
     get_context_spec,
     TosaSpecification,
@@ -73,7 +73,7 @@ def _shape_product(shape: Iterable[int | torch.SymInt], op: str) -> int | torch.
     return result
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "CONCAT(Tensor[] input1, *, int axis) -> Tensor",
     TosaSpecification.all_versions_and_profiles(),
 )
@@ -124,7 +124,7 @@ def CONCAT(inputs: list[torch.Tensor], *, axis: int) -> torch.Tensor:
     return torch.empty(size=output_shape, dtype=reference.dtype)
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "PAD(Tensor input1, SymInt[] padding, *, Scalar value) -> Tensor",
     TosaSpecification.all_versions_and_profiles(),
 )
@@ -151,7 +151,7 @@ def PAD(x: torch.Tensor, padding: list[int | torch.SymInt], *, value) -> torch.T
     return torch.empty(size=output_shape, dtype=x.dtype)
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "RESHAPE(Tensor input1, SymInt[] shape) -> Tensor",
     TosaSpecification.all_versions_and_profiles(),
 )
@@ -166,7 +166,7 @@ def RESHAPE(x: torch.Tensor, shape: list[int | torch.SymInt]) -> torch.Tensor:
     return torch.empty(size=shape, dtype=x.dtype)
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "REVERSE(Tensor input1, *, int axis) -> Tensor",
     TosaSpecification.all_versions_and_profiles(),
 )
@@ -182,7 +182,7 @@ def REVERSE(x: torch.Tensor, *, axis: int) -> torch.Tensor:
     return torch.empty_like(x)
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "SLICE(Tensor input1, SymInt[] start, SymInt[] size) -> Tensor",
     TosaSpecification.all_versions_and_profiles(),
 )
@@ -219,7 +219,7 @@ def SLICE(
     return torch.empty(size=size, dtype=x.dtype)
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "TILE(Tensor input1, SymInt[] multiples) -> Tensor",
     TosaSpecification.all_versions_and_profiles(),
 )
@@ -241,7 +241,7 @@ def TILE(x: torch.Tensor, multiples: list[int | torch.SymInt]) -> torch.Tensor:
     return torch.empty(size=output_shape, dtype=x.dtype)
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "TRANSPOSE(Tensor input, int[] perms) -> Tensor",
     TosaSpecification.all_versions_and_profiles(),
 )

--- a/backends/arm/tosa/dialect/ops/depthwise_conv2d.py
+++ b/backends/arm/tosa/dialect/ops/depthwise_conv2d.py
@@ -7,7 +7,7 @@ import math
 
 import torch
 from executorch.backends.arm.tosa.dialect.ops.conv2d import validate_conv2d_args_dtypes
-from executorch.backends.arm.tosa.dialect.ops_registration import register_fake_tosa_op
+from executorch.backends.arm.tosa.dialect.ops_registration import register_tosa_op
 
 from executorch.backends.arm.tosa.specification import (
     get_context_spec,
@@ -15,7 +15,7 @@ from executorch.backends.arm.tosa.specification import (
 )
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "DEPTHWISE_CONV2D(Tensor input, "
     "Tensor weight, "
     "Tensor bias, "

--- a/backends/arm/tosa/dialect/ops/fft.py
+++ b/backends/arm/tosa/dialect/ops/fft.py
@@ -6,7 +6,7 @@
 import sympy  # type: ignore[import-untyped]
 import torch
 from executorch.backends.arm.tosa.dialect.lib import TosaValueError
-from executorch.backends.arm.tosa.dialect.ops_registration import register_fake_tosa_op
+from executorch.backends.arm.tosa.dialect.ops_registration import register_tosa_op
 from executorch.backends.arm.tosa.specification import (
     get_context_shape_env,
     get_context_spec,
@@ -97,7 +97,7 @@ def _same_fft_shape(
     )
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "FFT2D(Tensor input_real, Tensor input_imag, *, bool inverse=False, bool local_bound=False) -> (Tensor output_real, Tensor output_imag)",
     TosaSpecification.all_versions_and_profiles(),
 )
@@ -124,7 +124,7 @@ def FFT2D(
     )
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "RFFT2D(Tensor input_real, *, bool local_bound=False) -> (Tensor output_real, Tensor output_imag)",
     TosaSpecification.all_versions_and_profiles(),
 )

--- a/backends/arm/tosa/dialect/ops/gather.py
+++ b/backends/arm/tosa/dialect/ops/gather.py
@@ -7,14 +7,14 @@
 import torch
 
 from executorch.backends.arm.tosa.dialect.lib import TosaValueError
-from executorch.backends.arm.tosa.dialect.ops_registration import register_fake_tosa_op
+from executorch.backends.arm.tosa.dialect.ops_registration import register_tosa_op
 from executorch.backends.arm.tosa.specification import (
     get_context_spec,
     TosaSpecification,
 )
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "GATHER(Tensor values, Tensor indices) -> Tensor",
     TosaSpecification.all_versions_and_profiles(),
 )

--- a/backends/arm/tosa/dialect/ops/identity.py
+++ b/backends/arm/tosa/dialect/ops/identity.py
@@ -4,11 +4,11 @@
 # LICENSE file in the root directory of this source tree.
 
 import torch
-from executorch.backends.arm.tosa.dialect.ops_registration import register_fake_tosa_op
+from executorch.backends.arm.tosa.dialect.ops_registration import register_tosa_op
 from executorch.backends.arm.tosa.specification import TosaSpecification
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "IDENTITY(Tensor input) -> Tensor",
     TosaSpecification.all_versions_and_profiles(),
 )

--- a/backends/arm/tosa/dialect/ops/matmul.py
+++ b/backends/arm/tosa/dialect/ops/matmul.py
@@ -5,7 +5,7 @@
 
 import torch
 from executorch.backends.arm.tosa.dialect.lib import TosaValueError
-from executorch.backends.arm.tosa.dialect.ops_registration import register_fake_tosa_op
+from executorch.backends.arm.tosa.dialect.ops_registration import register_tosa_op
 
 from executorch.backends.arm.tosa.specification import (
     get_context_spec,
@@ -14,7 +14,7 @@ from executorch.backends.arm.tosa.specification import (
 from executorch.exir.dialects._ops import ops as exir_ops
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "MATMUL(Tensor input1, Tensor input2) -> Tensor",  # schema
     TosaSpecification.all_versions_and_profiles(),
 )

--- a/backends/arm/tosa/dialect/ops/matmul_t_block_scaled.py
+++ b/backends/arm/tosa/dialect/ops/matmul_t_block_scaled.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import torch
 
 from executorch.backends.arm.tosa.dialect.lib import TosaValueError
-from executorch.backends.arm.tosa.dialect.ops_registration import register_fake_tosa_op
+from executorch.backends.arm.tosa.dialect.ops_registration import register_tosa_op
 from executorch.backends.arm.tosa.specification import (
     get_context_spec,
     TosaSpecification,
@@ -99,7 +99,7 @@ def _validate_shapes(
     return N, H, W
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "MATMUL_T_BLOCK_SCALED(Tensor A_data, Tensor A_scale, Tensor B_data, Tensor B_scale, SymInt block_size) -> Tensor",
     [TosaSpecification.create_from_string("TOSA-1.1+FP")],
 )

--- a/backends/arm/tosa/dialect/ops/max_pool2d.py
+++ b/backends/arm/tosa/dialect/ops/max_pool2d.py
@@ -8,7 +8,7 @@ from typing import List, Union
 import sympy  # type: ignore[import-untyped]
 import torch
 from executorch.backends.arm.tosa.dialect.lib import TosaValueError
-from executorch.backends.arm.tosa.dialect.ops_registration import register_fake_tosa_op
+from executorch.backends.arm.tosa.dialect.ops_registration import register_tosa_op
 from executorch.backends.arm.tosa.specification import (
     get_context_shape_env,
     get_context_spec,
@@ -68,7 +68,7 @@ def validate_max_pool2d_dtype(
         raise TosaValueError(f"Unsupported input dtype {x.dtype} pools", op=op)
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "MAX_POOL2D(Tensor input, int[2] kernel, int[2] stride, SymInt[4] pad) -> Tensor",
     TosaSpecification.all_versions_and_profiles(),
 )

--- a/backends/arm/tosa/dialect/ops/max_pool2d_adaptive.py
+++ b/backends/arm/tosa/dialect/ops/max_pool2d_adaptive.py
@@ -10,7 +10,7 @@ from executorch.backends.arm.tosa.dialect.ops.max_pool2d import (
     compute_max_pool2d_output_shape,
     validate_max_pool2d_dtype,
 )
-from executorch.backends.arm.tosa.dialect.ops_registration import register_fake_tosa_op
+from executorch.backends.arm.tosa.dialect.ops_registration import register_tosa_op
 from executorch.backends.arm.tosa.specification import (
     get_context_shape_env,
     get_context_spec,
@@ -35,7 +35,7 @@ def _is_directly_representable(
     return remainder in (0, 1)
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "MAX_POOL2D_ADAPTIVE(Tensor input, SymInt[2] kernel, SymInt[2] stride, SymInt[4] pad) -> Tensor",
     TosaSpecification.all_profiles_for_version("1.1"),
 )

--- a/backends/arm/tosa/dialect/ops/reduction_ops.py
+++ b/backends/arm/tosa/dialect/ops/reduction_ops.py
@@ -6,7 +6,7 @@
 import torch
 
 from executorch.backends.arm.tosa.dialect.lib import TosaValueError
-from executorch.backends.arm.tosa.dialect.ops_registration import register_fake_tosa_op
+from executorch.backends.arm.tosa.dialect.ops_registration import register_tosa_op
 from executorch.backends.arm.tosa.specification import (
     get_context_spec,
     TosaSpecification,
@@ -120,7 +120,7 @@ def _validate_nan_mode(nan_mode: str, op: str) -> None:
         )
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "REDUCE_ALL(Tensor input, *, int axis) -> Tensor",
     TosaSpecification.all_versions_and_profiles(),
 )
@@ -130,7 +130,7 @@ def REDUCE_ALL(x: torch.Tensor, *, axis: int) -> torch.Tensor:
     return torch.empty(size=_reduce_shape(x, axis), dtype=x.dtype)
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "REDUCE_ANY(Tensor input, *, int axis) -> Tensor",
     TosaSpecification.all_versions_and_profiles(),
 )
@@ -140,7 +140,7 @@ def REDUCE_ANY(x: torch.Tensor, *, axis: int) -> torch.Tensor:
     return torch.empty(size=_reduce_shape(x, axis), dtype=x.dtype)
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     'REDUCE_MAX(Tensor input, *, int axis, str nan_mode="PROPAGATE") -> Tensor',
     TosaSpecification.all_versions_and_profiles(),
 )
@@ -153,7 +153,7 @@ def REDUCE_MAX(
     return torch.empty(size=_reduce_shape(x, axis), dtype=x.dtype)
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     'REDUCE_MIN(Tensor input, *, int axis, str nan_mode="PROPAGATE") -> Tensor',
     TosaSpecification.all_versions_and_profiles(),
 )
@@ -166,7 +166,7 @@ def REDUCE_MIN(
     return torch.empty(size=_reduce_shape(x, axis), dtype=x.dtype)
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "REDUCE_PRODUCT(Tensor input, *, int axis) -> Tensor",
     TosaSpecification.all_versions_and_profiles(),
 )
@@ -176,7 +176,7 @@ def REDUCE_PRODUCT(x: torch.Tensor, *, axis: int) -> torch.Tensor:
     return torch.empty(size=_reduce_shape(x, axis), dtype=x.dtype)
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "REDUCE_SUM(Tensor input, *, int axis) -> Tensor",
     TosaSpecification.all_versions_and_profiles(),
 )

--- a/backends/arm/tosa/dialect/ops/rescale.py
+++ b/backends/arm/tosa/dialect/ops/rescale.py
@@ -7,7 +7,7 @@ from typing import List
 
 import torch
 from executorch.backends.arm.tosa.dialect.lib import TosaValueError
-from executorch.backends.arm.tosa.dialect.ops_registration import register_fake_tosa_op
+from executorch.backends.arm.tosa.dialect.ops_registration import register_tosa_op
 
 from executorch.backends.arm.tosa.specification import (
     get_context_spec,
@@ -15,7 +15,7 @@ from executorch.backends.arm.tosa.specification import (
 )
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "RESCALE(Tensor input1, ScalarType dtype, float[] scale, int in_zp, int out_zp, *, bool input_unsigned=False, bool output_unsigned=False) -> Tensor",  # schema
     TosaSpecification.all_versions_for_profile("INT"),  # target TOSA specifications
 )

--- a/backends/arm/tosa/dialect/ops/resize.py
+++ b/backends/arm/tosa/dialect/ops/resize.py
@@ -7,7 +7,7 @@ from typing import Literal
 
 import torch
 from executorch.backends.arm.tosa.dialect.lib import TosaValueError
-from executorch.backends.arm.tosa.dialect.ops_registration import register_fake_tosa_op
+from executorch.backends.arm.tosa.dialect.ops_registration import register_tosa_op
 from executorch.backends.arm.tosa.resize_utils import (
     calculate_tosa_resize_output_hw,
     get_tosa_resize_output_hw_validation_error,
@@ -68,7 +68,7 @@ def _validate_resize_parameters(input_hw, output_hw, scale, offset, border, tosa
         raise TosaValueError(validation_error, op="RESIZE")
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "RESIZE(Tensor input, SymInt[4] scale_factors, SymInt[2] offset, SymInt[2] border, *, str resize_mode) -> Tensor",  # schema
     TosaSpecification.all_versions_and_profiles(),  # target TOSA specifications
 )

--- a/backends/arm/tosa/dialect/ops/scatter.py
+++ b/backends/arm/tosa/dialect/ops/scatter.py
@@ -5,12 +5,12 @@
 
 
 import torch
-from executorch.backends.arm.tosa.dialect.ops_registration import register_fake_tosa_op
+from executorch.backends.arm.tosa.dialect.ops_registration import register_tosa_op
 
 from executorch.backends.arm.tosa.specification import TosaSpecification
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "SCATTER(Tensor values_in, Tensor indices, Tensor input) -> Tensor",  # schema
     TosaSpecification.all_versions_and_profiles(),  # target TOSA specifications
 )

--- a/backends/arm/tosa/dialect/ops/table.py
+++ b/backends/arm/tosa/dialect/ops/table.py
@@ -5,7 +5,7 @@
 
 import torch
 from executorch.backends.arm.tosa.dialect.lib import TosaValueError
-from executorch.backends.arm.tosa.dialect.ops_registration import register_fake_tosa_op
+from executorch.backends.arm.tosa.dialect.ops_registration import register_tosa_op
 
 from executorch.backends.arm.tosa.specification import (
     get_context_spec,
@@ -13,7 +13,7 @@ from executorch.backends.arm.tosa.specification import (
 )
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "TABLE(Tensor input1, Tensor table) -> Tensor",  # schema
     TosaSpecification.all_versions_for_profile("INT"),  # target TOSA specifications
 )

--- a/backends/arm/tosa/dialect/ops/transpose_conv2d.py
+++ b/backends/arm/tosa/dialect/ops/transpose_conv2d.py
@@ -6,14 +6,14 @@
 import torch
 from executorch.backends.arm.tosa.dialect.lib import TosaValueError
 from executorch.backends.arm.tosa.dialect.ops.conv2d import validate_conv2d_args_dtypes
-from executorch.backends.arm.tosa.dialect.ops_registration import register_fake_tosa_op
+from executorch.backends.arm.tosa.dialect.ops_registration import register_tosa_op
 from executorch.backends.arm.tosa.specification import (
     get_context_spec,
     TosaSpecification,
 )
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "TRANSPOSE_CONV2D(Tensor input, "
     "Tensor weight, "
     "Tensor bias, "

--- a/backends/arm/tosa/dialect/ops/unary_elementwise.py
+++ b/backends/arm/tosa/dialect/ops/unary_elementwise.py
@@ -5,7 +5,7 @@
 
 import torch
 from executorch.backends.arm.tosa.dialect.lib import TosaValueError
-from executorch.backends.arm.tosa.dialect.ops_registration import register_fake_tosa_op
+from executorch.backends.arm.tosa.dialect.ops_registration import register_tosa_op
 from executorch.backends.arm.tosa.specification import (
     get_context_spec,
     TosaSpecification,
@@ -107,7 +107,7 @@ def _validate_negate_dtype(dtype: torch.dtype) -> None:
     _validate_float_dtype(dtype, "NEGATE")
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "ABS(Tensor input1) -> Tensor",
     DUAL_PROFILE_SPECS,
 )
@@ -116,7 +116,7 @@ def ABS(input1: torch.Tensor) -> torch.Tensor:
     return torch.empty_like(input1, dtype=input1.dtype)
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "BITWISE_NOT(Tensor input1) -> Tensor",
     INT_SPECS,
 )
@@ -125,7 +125,7 @@ def BITWISE_NOT(input1: torch.Tensor) -> torch.Tensor:
     return torch.empty_like(input1, dtype=input1.dtype)
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "CEIL(Tensor input1) -> Tensor",
     FP_SPECS,
 )
@@ -134,7 +134,7 @@ def CEIL(input1: torch.Tensor) -> torch.Tensor:
     return torch.empty_like(input1, dtype=input1.dtype)
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "CLZ(Tensor input1) -> Tensor",
     INT_SPECS,
 )
@@ -143,7 +143,7 @@ def CLZ(input1: torch.Tensor) -> torch.Tensor:
     return torch.empty_like(input1, dtype=input1.dtype)
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "COS(Tensor input1) -> Tensor",
     FP_SPECS,
 )
@@ -152,7 +152,7 @@ def COS(input1: torch.Tensor) -> torch.Tensor:
     return torch.empty_like(input1, dtype=input1.dtype)
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "EXP(Tensor input1) -> Tensor",
     FP_SPECS,
 )
@@ -161,7 +161,7 @@ def EXP(input1: torch.Tensor) -> torch.Tensor:
     return torch.empty_like(input1, dtype=input1.dtype)
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "FLOOR(Tensor input1) -> Tensor",
     FP_SPECS,
 )
@@ -170,7 +170,7 @@ def FLOOR(input1: torch.Tensor) -> torch.Tensor:
     return torch.empty_like(input1, dtype=input1.dtype)
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "LOG(Tensor input1) -> Tensor",
     FP_SPECS,
 )
@@ -179,7 +179,7 @@ def LOG(input1: torch.Tensor) -> torch.Tensor:
     return torch.empty_like(input1, dtype=input1.dtype)
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "LOGICAL_NOT(Tensor input1) -> Tensor",
     DUAL_PROFILE_SPECS,
 )
@@ -188,7 +188,7 @@ def LOGICAL_NOT(input1: torch.Tensor) -> torch.Tensor:
     return torch.empty_like(input1, dtype=input1.dtype)
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "NEGATE(Tensor input1) -> Tensor",
     DUAL_PROFILE_SPECS,
 )
@@ -197,7 +197,7 @@ def NEGATE(input1: torch.Tensor) -> torch.Tensor:
     return torch.empty_like(input1, dtype=input1.dtype)
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "RECIPROCAL(Tensor input1) -> Tensor",
     FP_SPECS,
 )
@@ -206,7 +206,7 @@ def RECIPROCAL(input1: torch.Tensor) -> torch.Tensor:
     return torch.empty_like(input1, dtype=input1.dtype)
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "RSQRT(Tensor input1) -> Tensor",
     FP_SPECS,
 )
@@ -215,7 +215,7 @@ def RSQRT(input1: torch.Tensor) -> torch.Tensor:
     return torch.empty_like(input1, dtype=input1.dtype)
 
 
-@register_fake_tosa_op(
+@register_tosa_op(
     "SIN(Tensor input1) -> Tensor",
     FP_SPECS,
 )

--- a/backends/arm/tosa/dialect/ops_registration.py
+++ b/backends/arm/tosa/dialect/ops_registration.py
@@ -7,6 +7,9 @@
 from typing import Callable, Iterable, List, ParamSpec, TypeVar
 
 from executorch.backends.arm.tosa.dialect.lib import register_tosa_dialect_op
+from executorch.backends.arm.tosa.dialect.real_impl import (
+    make_tosa_reference_model_impl,
+)
 
 from executorch.backends.arm.tosa.specification import (
     get_context_spec,
@@ -41,10 +44,32 @@ def register_fake_tosa_op(
 
     """
 
+    return register_tosa_op(op_schema, tosa_specs, include_real_impl=False)
+
+
+def register_tosa_op(
+    op_schema: str,
+    tosa_specs: Iterable[TosaSpecification],
+    include_real_impl: bool = True,
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    """Register a TOSA op with fake/meta and optional real eager execution."""
+
     def decorator(func: Callable[P, R]) -> Callable[P, R]:
         # Only call register_tosa_dialect_op if the function hasn't been registered yet.
         if func not in _registered_tosa_ops_by_func:
-            op_callable = register_tosa_dialect_op(op_schema, func)
+            real_impl = None
+            if include_real_impl:
+                real_impl = make_tosa_reference_model_impl(
+                    fake_func=func,
+                    op_schema=op_schema,
+                )
+
+            op_callable = register_tosa_dialect_op(
+                op_schema,
+                fake_func=func,
+                real_func=real_impl,
+                real_dispatch_key="CompositeExplicitAutograd",
+            )
             _registered_tosa_ops_by_func[func] = op_callable
         else:
             op_callable = _registered_tosa_ops_by_func[func]

--- a/backends/arm/tosa/dialect/real_impl.py
+++ b/backends/arm/tosa/dialect/real_impl.py
@@ -23,16 +23,26 @@ def _torch_tensor_to_numpy(tensor: torch.Tensor) -> np.ndarray:
     tensor = tensor.detach().cpu()
     if tensor.dtype == torch.bfloat16:
         tensor = tensor.view(torch.uint16)
+    elif tensor.dtype == torch.float8_e4m3fn:
+        tensor = tensor.view(torch.uint8)
+    elif tensor.dtype == torch.float8_e5m2:
+        tensor = tensor.view(torch.uint8)
     return tensor.numpy()
 
 
-def _numpy_to_torch_tensor(array: np.ndarray, dtype: torch.dtype) -> torch.Tensor:
+def _numpy_to_torch_tensor(
+    array: np.ndarray, expected_dtype: torch.dtype, expected_shape: torch.Size
+) -> torch.Tensor:
     if array.dtype.type is np.void:
-        return torch.frombuffer(array, dtype=dtype)
+        return torch.frombuffer(array, dtype=expected_dtype).reshape(expected_shape)
 
     tensor = torch.from_numpy(array)
-    if dtype == torch.bfloat16:
-        return tensor.view(torch.bfloat16)
+    if expected_dtype == torch.bfloat16:
+        tensor = tensor.view(torch.bfloat16)
+    elif expected_dtype == torch.float8_e4m3fn:
+        tensor = tensor.view(torch.float8_e4m3fn)
+    elif expected_dtype == torch.float8_e5m2:
+        tensor = tensor.view(torch.float8_e5m2)
     return tensor
 
 
@@ -129,9 +139,9 @@ def make_tosa_reference_model_impl(
                 f"TOSA reference model rejected tosa.{op_name} graph: {status}"
             )
 
-        return _numpy_to_torch_tensor(outputs_np[0], fake_output.dtype).to(
-            device=tensor_args[0].device
-        )
+        return _numpy_to_torch_tensor(
+            outputs_np[0], fake_output.dtype, fake_output.shape
+        ).to(device=tensor_args[0].device)
 
     return real_impl
 

--- a/backends/arm/tosa/dialect/real_impl.py
+++ b/backends/arm/tosa/dialect/real_impl.py
@@ -1,0 +1,152 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import inspect
+import logging
+from typing import Any, Callable
+
+import numpy as np
+import torch
+import tosa_reference_model as reference_model  # type: ignore[import-not-found, import-untyped]
+import tosa_serializer as ts
+from executorch.backends.arm.tosa.mapping import TosaArg
+from executorch.backends.arm.tosa.specification import get_context_spec
+from executorch.exir.dialects._ops import ops as exir_ops
+from torch._subclasses.fake_tensor import FakeTensorMode
+
+logger = logging.getLogger(__name__)
+
+
+def _torch_tensor_to_numpy(tensor: torch.Tensor) -> np.ndarray:
+    tensor = tensor.detach().cpu()
+    if tensor.dtype == torch.bfloat16:
+        tensor = tensor.view(torch.uint16)
+    return tensor.numpy()
+
+
+def _numpy_to_torch_tensor(array: np.ndarray, dtype: torch.dtype) -> torch.Tensor:
+    if array.dtype.type is np.void:
+        return torch.frombuffer(array, dtype=dtype)
+
+    tensor = torch.from_numpy(array)
+    if dtype == torch.bfloat16:
+        return tensor.view(torch.bfloat16)
+    return tensor
+
+
+def make_tosa_reference_model_impl(
+    fake_func: Callable,
+    op_schema: str,
+) -> Callable:
+    """Create a real eager implementation from a fake TOSA dialect op."""
+
+    signature = inspect.signature(fake_func)
+    op_name = op_schema.split("(")[0]
+
+    def real_impl(*args, **kwargs) -> torch.Tensor:
+
+        bound = signature.bind(*args, **kwargs)
+        bound.apply_defaults()
+        normalized_args = list(bound.arguments.values())
+
+        fake_output = fake_func(*args, **kwargs)
+        if not isinstance(fake_output, torch.Tensor):
+            raise TypeError(
+                f"Only single-tensor outputs are supported for real TOSA op execution, got {type(fake_output).__name__}"
+            )
+
+        tensor_args = [arg for arg in normalized_args if isinstance(arg, torch.Tensor)]
+        if not tensor_args:
+            raise ValueError(
+                f"Real TOSA op execution requires at least one tensor input: {op_name}"
+            )
+
+        graph = torch.fx.Graph()
+        node_args: list[Any] = []
+        placeholder_nodes: list[torch.fx.Node] = []
+        op_handle = getattr(exir_ops.backend.tosa, op_name).default
+
+        with FakeTensorMode(allow_non_fake_inputs=True) as mode:
+            for parameter, arg in zip(signature.parameters.values(), normalized_args):
+                if isinstance(arg, torch.Tensor):
+                    placeholder = graph.placeholder(parameter.name)
+                    placeholder.meta["val"] = mode.from_tensor(arg.detach().cpu())
+                    placeholder_nodes.append(placeholder)
+                    node_args.append(placeholder)
+                else:
+                    node_args.append(arg)
+
+            op_node = graph.call_function(op_handle, tuple(node_args), {})
+            op_node.meta["val"] = mode.from_tensor(fake_output.detach().cpu())
+            graph.output((op_node,))
+
+        tosa_spec = get_context_spec()
+        version = tosa_spec.version
+        tosa_graph = ts.TosaSerializer(
+            "",
+            targetMajor=version.major,
+            targetMinor=version.minor,
+            targetPatch=version.micro,
+            targetDraft=False,
+        )
+
+        for node in placeholder_nodes:
+            arg = TosaArg(node, tosa_spec)
+            tosa_graph.addInputTensor(
+                ts.TosaSerializerTensor(arg.name, list(arg.shape), arg.dtype, data=None)
+            )
+
+        output_arg = TosaArg(op_node, tosa_spec)
+        tosa_graph.currRegion.currBasicBlock.addTensor(
+            output_arg.name,
+            list(output_arg.shape),
+            output_arg.dtype,
+        )
+        from executorch.backends.arm.operators.node_visitor import get_node_visitor
+
+        visitor = get_node_visitor(f"tosa.{op_name}.default", tosa_spec)
+        visitor.define_node(
+            op_node,
+            tosa_graph,
+            [TosaArg(arg, tosa_spec) for arg in op_node.args],
+            output_arg,
+        )
+        tosa_graph.addOutputTensor(
+            tosa_graph.currRegion.currBasicBlock.tensors[output_arg.name]
+        )
+
+        outputs_np, status = reference_model.run(
+            tosa_graph.serialize(),
+            [_torch_tensor_to_numpy(arg) for arg in tensor_args],
+            verbosity=_tosa_refmodel_loglevel(logger.getEffectiveLevel()),
+            initialize_variable_tensor_from_numpy=True,
+            debug_mode="ALL" if logger.isEnabledFor(logging.DEBUG) else None,
+        )
+        if status != reference_model.GraphStatus.TOSA_VALID:
+            raise RuntimeError(
+                f"TOSA reference model rejected tosa.{op_name} graph: {status}"
+            )
+
+        return _numpy_to_torch_tensor(outputs_np[0], fake_output.dtype).to(
+            device=tensor_args[0].device
+        )
+
+    return real_impl
+
+
+def _tosa_refmodel_loglevel(loglevel: int) -> str:
+    """Converts a logging loglevel to tosa_reference_model logginglevel,
+    returned as string.
+    """
+    loglevel_map = {
+        logging.INFO: "INFO",
+        logging.CRITICAL: "LOW",
+        logging.ERROR: "LOW",
+        logging.WARNING: "MED",
+        logging.DEBUG: "HIGH",
+        logging.NOTSET: "MED",
+    }
+    clamped_logging_level = max(min(loglevel // 10 * 10, 50), 0)
+    return loglevel_map[clamped_logging_level]


### PR DESCRIPTION
In a first commit,

    Arm backend: Add infra for real implementations of Tosa ops
    
    Tested by applying the infra to the avg_pool2d Tosa dialect op.
    The rewrite_avg_pool2d tests can now be ran to verify that
    the produced Tosa is correct. To make it completely correct,
    two additional passes need to be added to the test.

Then,

    Arm backend: Add real impls to all TOSA dialect ops
    
    Additionally,
    - Remove special case in ComputeOpsAOT pass for such ops,
    since they can now be executed.
    - Start running the model in tests were this was previously
    impossible due to ops not having a real impl.


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani