### PR TITLE
Arm backend: Add TOSA dialect reduction ops

### DIFF
--- a/backends/arm/test/misc/tosa_dialect/test_tosa_reduction_ops.py
+++ b/backends/arm/test/misc/tosa_dialect/test_tosa_reduction_ops.py
@@ -1,0 +1,134 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import executorch.backends.arm.tosa.dialect  # noqa: F401
+import pytest
+import torch
+from executorch.backends.arm.tosa.dialect.lib import TosaValueError
+from executorch.backends.arm.tosa.specification import (
+    TosaLoweringContext,
+    TosaSpecification,
+)
+from executorch.exir.dialects._ops import ops as exir_ops
+from torch._subclasses.fake_tensor import FakeTensorMode
+
+
+@pytest.mark.parametrize(
+    "op_name,input_tensor,kwargs,expected_shape",
+    [
+        (
+            "REDUCE_ALL",
+            torch.tensor([[[True, False], [True, True]]]),
+            {"axis": 1},
+            (1, 1, 2),
+        ),
+        (
+            "REDUCE_ANY",
+            torch.tensor([[[True, False], [False, False]]]),
+            {"axis": 2},
+            (1, 2, 1),
+        ),
+        (
+            "REDUCE_MAX",
+            torch.randint(-8, 8, (2, 3, 4), dtype=torch.int32),
+            {"axis": 0, "nan_mode": "PROPAGATE"},
+            (1, 3, 4),
+        ),
+        (
+            "REDUCE_MIN",
+            torch.randn((2, 3, 4), dtype=torch.float32),
+            {"axis": 2, "nan_mode": "IGNORE"},
+            (2, 3, 1),
+        ),
+        (
+            "REDUCE_PRODUCT",
+            torch.randn((2, 3, 4), dtype=torch.float32),
+            {"axis": 1},
+            (2, 1, 4),
+        ),
+        (
+            "REDUCE_SUM",
+            torch.randint(-8, 8, (2, 3, 4), dtype=torch.int32),
+            {"axis": 1},
+            (2, 1, 4),
+        ),
+    ],
+)
+def test_reduction_ops(op_name, input_tensor, kwargs, expected_shape):
+    spec = (
+        "TOSA-1.1+FP+bf16+int64"
+        if input_tensor.dtype.is_floating_point
+        else "TOSA-1.1+INT+int16+int64"
+    )
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string(spec)
+    ), FakeTensorMode() as mode:
+        op = getattr(exir_ops.backend.tosa, op_name).default
+        output = op(mode.from_tensor(input_tensor), **kwargs)
+
+    assert output.dtype == input_tensor.dtype
+    assert tuple(output.shape) == expected_shape
+
+
+def test_reduce_all_rejects_non_bool():
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+INT")
+    ), FakeTensorMode() as mode:
+        with pytest.raises(TosaValueError, match="requires bool input"):
+            exir_ops.backend.tosa.REDUCE_ALL.default(
+                mode.from_tensor(torch.ones((2, 2), dtype=torch.int32)), axis=1
+            )
+
+
+def test_reduce_product_rejects_integer_input():
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+INT")
+    ), FakeTensorMode() as mode:
+        with pytest.raises(TosaValueError, match="floating-point input"):
+            exir_ops.backend.tosa.REDUCE_PRODUCT.default(
+                mode.from_tensor(torch.ones((2, 2), dtype=torch.int32)), axis=1
+            )
+
+
+@pytest.mark.parametrize(
+    "op_name,dtype", [("REDUCE_MAX", torch.float32), ("REDUCE_MIN", torch.int32)]
+)
+def test_reduce_minmax_default_nan_mode(op_name: str, dtype: torch.dtype):
+    spec = "TOSA-1.1+FP" if dtype.is_floating_point else "TOSA-1.1+INT"
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string(spec)
+    ), FakeTensorMode() as mode:
+        op = getattr(exir_ops.backend.tosa, op_name).default
+        output = op(mode.from_tensor(torch.ones((2, 2), dtype=dtype)), axis=1)
+
+    assert output.dtype == dtype
+    assert tuple(output.shape) == (2, 1)
+
+
+@pytest.mark.parametrize("op_name", ["REDUCE_MAX", "REDUCE_MIN"])
+def test_reduce_minmax_rejects_invalid_nan_mode(op_name: str):
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP")
+    ), FakeTensorMode() as mode:
+        op = getattr(exir_ops.backend.tosa, op_name).default
+        with pytest.raises(TosaValueError, match="Invalid nan_mode"):
+            op(
+                mode.from_tensor(torch.ones((2, 2), dtype=torch.float32)),
+                axis=1,
+                nan_mode="INVALID_MODE",
+            )
+
+
+@pytest.mark.parametrize("dtype", [torch.int8, torch.int16])
+def test_reduce_sum_rejects_narrow_integer_inputs(dtype: torch.dtype):
+    spec = "TOSA-1.1+INT+int16" if dtype == torch.int16 else "TOSA-1.1+INT"
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string(spec)
+    ), FakeTensorMode() as mode:
+        with pytest.raises(TosaValueError, match="Unsupported dtype"):
+            exir_ops.backend.tosa.REDUCE_SUM.default(
+                mode.from_tensor(torch.ones((2, 2), dtype=dtype)),
+                axis=1,
+            )

--- a/backends/arm/tosa/dialect/__init__.py
+++ b/backends/arm/tosa/dialect/__init__.py
@@ -15,6 +15,7 @@ from executorch.backends.arm.tosa.dialect.ops import (  # noqa F401
     matmul,
     max_pool2d,
     pad,
+    reduction_ops,
     rescale,
     resize,
     scatter,

--- a/backends/arm/tosa/dialect/ops/reduction_ops.py
+++ b/backends/arm/tosa/dialect/ops/reduction_ops.py
@@ -1,0 +1,186 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+
+from executorch.backends.arm.tosa.dialect.lib import TosaValueError
+from executorch.backends.arm.tosa.dialect.ops_registration import register_fake_tosa_op
+from executorch.backends.arm.tosa.specification import (
+    get_context_spec,
+    TosaSpecification,
+)
+
+
+def _validate_axis(x: torch.Tensor, axis: int, op: str) -> None:
+    if x.dim() < 1:
+        raise TosaValueError(f"{op} requires rank >= 1 input", op=op)
+    if axis < 0 or axis >= x.dim():
+        raise TosaValueError(
+            f"{op} axis {axis} is out of range for rank {x.dim()}",
+            op=op,
+        )
+
+
+def _reduce_shape(x: torch.Tensor, axis: int) -> list[int | torch.SymInt]:
+    output_shape: list[int | torch.SymInt] = list(x.shape)
+    output_shape[axis] = 1
+    return output_shape
+
+
+def _validate_bool_dtype(x: torch.Tensor, op: str) -> None:
+    if x.dtype != torch.bool:
+        raise TosaValueError(f"{op} requires bool input, got {x.dtype}", op=op)
+
+
+def _validate_float_integer_dtype(x: torch.Tensor, op: str) -> None:
+    tosa_spec = get_context_spec()
+    supported_int_dtypes = {torch.int8, torch.int16, torch.int32}
+    supported_float_dtypes = {torch.float16, torch.float32}
+
+    if tosa_spec.support_extension("int64"):
+        supported_int_dtypes.add(torch.int64)
+    if tosa_spec.support_extension("bf16"):
+        supported_float_dtypes.add(torch.bfloat16)
+
+    if x.dtype in supported_int_dtypes:
+        if not tosa_spec.support_integer():
+            raise TosaValueError(
+                f"TOSA spec {tosa_spec} doesn't support integer reductions",
+                op=op,
+            )
+        return
+
+    if x.dtype in supported_float_dtypes:
+        if not tosa_spec.support_float():
+            raise TosaValueError(
+                f"TOSA spec {tosa_spec} doesn't support floating-point reductions",
+                op=op,
+            )
+        return
+
+    raise TosaValueError(f"Unsupported dtype {x.dtype} for {op}", op=op)
+
+
+def _validate_reduce_sum_dtype(x: torch.Tensor) -> None:
+    tosa_spec = get_context_spec()
+    supported_int_dtypes = {torch.int32}
+    supported_float_dtypes = {torch.float16, torch.float32}
+
+    if tosa_spec.support_extension("int64"):
+        supported_int_dtypes.add(torch.int64)
+    if tosa_spec.support_extension("bf16"):
+        supported_float_dtypes.add(torch.bfloat16)
+
+    if x.dtype in supported_int_dtypes:
+        if not tosa_spec.support_integer():
+            raise TosaValueError(
+                f"TOSA spec {tosa_spec} doesn't support integer reductions",
+                op="REDUCE_SUM",
+            )
+        return
+
+    if x.dtype in supported_float_dtypes:
+        if not tosa_spec.support_float():
+            raise TosaValueError(
+                f"TOSA spec {tosa_spec} doesn't support floating-point reductions",
+                op="REDUCE_SUM",
+            )
+        return
+
+    raise TosaValueError(
+        f"Unsupported dtype {x.dtype} for REDUCE_SUM",
+        op="REDUCE_SUM",
+    )
+
+
+def _validate_product_dtype(x: torch.Tensor, op: str) -> None:
+    tosa_spec = get_context_spec()
+    supported_dtypes = {torch.float16, torch.float32}
+    if tosa_spec.support_extension("bf16"):
+        supported_dtypes.add(torch.bfloat16)
+
+    if x.dtype not in supported_dtypes:
+        raise TosaValueError(
+            f"{op} requires floating-point input, got {x.dtype}", op=op
+        )
+    if not tosa_spec.support_float():
+        raise TosaValueError(
+            f"TOSA spec {tosa_spec} doesn't support floating-point reductions",
+            op=op,
+        )
+
+
+def _validate_nan_mode(nan_mode: str, op: str) -> None:
+    if nan_mode not in ("PROPAGATE", "IGNORE"):
+        raise TosaValueError(
+            f"Invalid nan_mode {nan_mode}, must be PROPAGATE or IGNORE",
+            op=op,
+        )
+
+
+@register_fake_tosa_op(
+    "REDUCE_ALL(Tensor input, *, int axis) -> Tensor",
+    TosaSpecification.all_versions_and_profiles(),
+)
+def REDUCE_ALL(x: torch.Tensor, *, axis: int) -> torch.Tensor:
+    _validate_axis(x, axis, "REDUCE_ALL")
+    _validate_bool_dtype(x, "REDUCE_ALL")
+    return torch.empty(size=_reduce_shape(x, axis), dtype=x.dtype)
+
+
+@register_fake_tosa_op(
+    "REDUCE_ANY(Tensor input, *, int axis) -> Tensor",
+    TosaSpecification.all_versions_and_profiles(),
+)
+def REDUCE_ANY(x: torch.Tensor, *, axis: int) -> torch.Tensor:
+    _validate_axis(x, axis, "REDUCE_ANY")
+    _validate_bool_dtype(x, "REDUCE_ANY")
+    return torch.empty(size=_reduce_shape(x, axis), dtype=x.dtype)
+
+
+@register_fake_tosa_op(
+    'REDUCE_MAX(Tensor input, *, int axis, str nan_mode="PROPAGATE") -> Tensor',
+    TosaSpecification.all_versions_and_profiles(),
+)
+def REDUCE_MAX(
+    x: torch.Tensor, *, axis: int, nan_mode: str = "PROPAGATE"
+) -> torch.Tensor:
+    _validate_axis(x, axis, "REDUCE_MAX")
+    _validate_float_integer_dtype(x, "REDUCE_MAX")
+    _validate_nan_mode(nan_mode, "REDUCE_MAX")
+    return torch.empty(size=_reduce_shape(x, axis), dtype=x.dtype)
+
+
+@register_fake_tosa_op(
+    'REDUCE_MIN(Tensor input, *, int axis, str nan_mode="PROPAGATE") -> Tensor',
+    TosaSpecification.all_versions_and_profiles(),
+)
+def REDUCE_MIN(
+    x: torch.Tensor, *, axis: int, nan_mode: str = "PROPAGATE"
+) -> torch.Tensor:
+    _validate_axis(x, axis, "REDUCE_MIN")
+    _validate_float_integer_dtype(x, "REDUCE_MIN")
+    _validate_nan_mode(nan_mode, "REDUCE_MIN")
+    return torch.empty(size=_reduce_shape(x, axis), dtype=x.dtype)
+
+
+@register_fake_tosa_op(
+    "REDUCE_PRODUCT(Tensor input, *, int axis) -> Tensor",
+    TosaSpecification.all_versions_and_profiles(),
+)
+def REDUCE_PRODUCT(x: torch.Tensor, *, axis: int) -> torch.Tensor:
+    _validate_axis(x, axis, "REDUCE_PRODUCT")
+    _validate_product_dtype(x, "REDUCE_PRODUCT")
+    return torch.empty(size=_reduce_shape(x, axis), dtype=x.dtype)
+
+
+@register_fake_tosa_op(
+    "REDUCE_SUM(Tensor input, *, int axis) -> Tensor",
+    TosaSpecification.all_versions_and_profiles(),
+)
+def REDUCE_SUM(x: torch.Tensor, *, axis: int) -> torch.Tensor:
+    _validate_axis(x, axis, "REDUCE_SUM")
+    _validate_reduce_sum_dtype(x)
+    return torch.empty(size=_reduce_shape(x, axis), dtype=x.dtype)


### PR DESCRIPTION
Register fake TOSA dialect implementations for REDUCE_ALL, REDUCE_ANY, REDUCE_MAX, REDUCE_MIN, REDUCE_PRODUCT, and REDUCE_SUM. The new fake ops preserve the reduced axis in the output shape and validate input rank, axis bounds, supported dtypes, profile and extension gating, and NaN propagation mode where required by the TOSA spec.

Add reduction-op dialect tests covering valid shape propagation and the main rejection cases for invalid bool, integer, and narrow-integer inputs.


cc @digantdesai @freddan80 @per @zingo @mansnils @Sebastian-Larsson @robell @rascani