### PR TITLE
Arm backend: Add support for shader segment in VGF runtime

### DIFF
--- a/backends/arm/operators/op_tosa_custom.py
+++ b/backends/arm/operators/op_tosa_custom.py
@@ -81,6 +81,12 @@ def _validate_vulkan_custom_shader_payload(
     if domain_name != _VULKAN_CUSTOM_SHADER_DOMAIN:
         return
 
+    if not implementation_attrs:
+        raise ValueError(
+            "Vulkan custom shader tosa.CUSTOM requires non-empty JSON "
+            "implementation_attrs"
+        )
+
     payload = json.loads(bytes(implementation_attrs).decode("utf-8"))
 
     for input_idx, input_arg in enumerate(inputs):

--- a/backends/arm/operators/op_tosa_custom.py
+++ b/backends/arm/operators/op_tosa_custom.py
@@ -3,6 +3,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import json
 from typing import Any, List
 
 import torch
@@ -13,6 +14,88 @@ from executorch.backends.arm.operators.node_visitor import (
     register_node_visitor,
 )
 from executorch.backends.arm.tosa.mapping import TosaArg
+
+_VULKAN_CUSTOM_SHADER_DOMAIN = "com.arm.VulkanCustomShader"
+
+
+def _vk_format_component_count(vk_format: str) -> int:
+    component_count = {
+        "VK_FORMAT_R8_BOOL_ARM": 1,
+        "VK_FORMAT_R8_UINT": 1,
+        "VK_FORMAT_R8_SINT": 1,
+        "VK_FORMAT_R16_UINT": 1,
+        "VK_FORMAT_R16_SINT": 1,
+        "VK_FORMAT_R16_SFLOAT": 1,
+        "VK_FORMAT_R32_UINT": 1,
+        "VK_FORMAT_R32_SINT": 1,
+        "VK_FORMAT_R32_SFLOAT": 1,
+        "VK_FORMAT_R64_SINT": 1,
+        "VK_FORMAT_R8G8_UINT": 2,
+        "VK_FORMAT_R8G8_SINT": 2,
+        "VK_FORMAT_R16G16_UINT": 2,
+        "VK_FORMAT_R16G16_SINT": 2,
+        "VK_FORMAT_R16G16_SFLOAT": 2,
+        "VK_FORMAT_R32G32_UINT": 2,
+        "VK_FORMAT_R32G32_SINT": 2,
+        "VK_FORMAT_R32G32_SFLOAT": 2,
+        "VK_FORMAT_R8G8B8A8_UINT": 4,
+        "VK_FORMAT_R8G8B8A8_SINT": 4,
+        "VK_FORMAT_R16G16B16A16_UINT": 4,
+        "VK_FORMAT_R16G16B16A16_SINT": 4,
+        "VK_FORMAT_R16G16B16A16_SFLOAT": 4,
+        "VK_FORMAT_R32G32B32A32_UINT": 4,
+        "VK_FORMAT_R32G32B32A32_SINT": 4,
+        "VK_FORMAT_R32G32B32A32_SFLOAT": 4,
+    }.get(vk_format)
+    if component_count is None:
+        raise ValueError(f"Unsupported image VkFormat '{vk_format}'")
+    return component_count
+
+
+def _validate_image_tensor_arg(arg: TosaArg, arg_name: str, vk_format: str) -> None:
+    if arg.shape is None:
+        raise ValueError(f"{arg_name} must have a statically known shape")
+    if len(arg.shape) not in (3, 4):
+        raise ValueError(
+            f"{arg_name} image tensors must be rank 3 or 4, got shape {arg.shape}"
+        )
+    if len(arg.shape) == 4 and arg.shape[0] != 1:
+        raise ValueError(
+            f"{arg_name} image tensors must have batch size 1, got shape {arg.shape}"
+        )
+    channels = int(arg.shape[-1])
+    format_component_count = _vk_format_component_count(vk_format)
+    if channels != format_component_count:
+        raise ValueError(
+            f"{arg_name} channel dimension {channels} does not match image format "
+            f"{vk_format} component count {format_component_count}"
+        )
+
+
+def _validate_vulkan_custom_shader_payload(
+    domain_name: str,
+    implementation_attrs: list[int],
+    inputs: list[TosaArg],
+    output: TosaArg,
+) -> None:
+    if domain_name != _VULKAN_CUSTOM_SHADER_DOMAIN:
+        return
+
+    payload = json.loads(bytes(implementation_attrs).decode("utf-8"))
+
+    for input_idx, input_arg in enumerate(inputs):
+        if payload.get(f"input_{input_idx}_type") != "Image":
+            continue
+        vk_format = payload.get(f"input_{input_idx}_vkformat")
+        if not isinstance(vk_format, str):
+            raise ValueError(f"Missing input_{input_idx}_vkformat for image input")
+        _validate_image_tensor_arg(input_arg, f"input_{input_idx}", vk_format)
+
+    if payload.get("output_0_type") == "Image":
+        vk_format = payload.get("output_0_vkformat")
+        if not isinstance(vk_format, str):
+            raise ValueError("Missing output_0_vkformat for image output")
+        _validate_image_tensor_arg(output, "output_0", vk_format)
 
 
 @register_node_visitor
@@ -43,6 +126,10 @@ class CustomVisitor(NodeVisitor):
             raise ValueError(
                 "tosa.CUSTOM requires operator_name and domain_name in kwargs"
             )
+        if not isinstance(operator_name, str) or not isinstance(domain_name, str):
+            raise TypeError(
+                "tosa.CUSTOM requires operator_name and domain_name to be strings"
+            )
 
         if implementation_attrs is None:
             impl_list = []
@@ -56,6 +143,14 @@ class CustomVisitor(NodeVisitor):
                 f"got {type(implementation_attrs)}"
             )
 
+        expanded = [TosaArg(item, self.tosa_spec) for item in inputs[0].special]
+        _validate_vulkan_custom_shader_payload(
+            domain_name=domain_name,
+            implementation_attrs=impl_list,
+            inputs=expanded,
+            output=output,
+        )
+
         attr = ts.TosaSerializerAttribute()
         attr.CustomAttribute(
             operator_name=operator_name,
@@ -63,7 +158,6 @@ class CustomVisitor(NodeVisitor):
             implementation_attrs=impl_list,
         )
 
-        expanded = [TosaArg(item, self.tosa_spec) for item in inputs[0].special]
         input_names = [arg.name for arg in expanded]
         output_names = (
             output.multiple_output_names

--- a/backends/arm/runtime/VGFBackend.cpp
+++ b/backends/arm/runtime/VGFBackend.cpp
@@ -12,7 +12,6 @@ using namespace std;
 #include <executorch/runtime/backend/interface.h>
 #include <executorch/runtime/core/error.h>
 #include <executorch/runtime/core/evalue.h>
-#include <executorch/runtime/core/portable_type/scalar_type.h>
 
 using executorch::aten::Tensor;
 using executorch::runtime::ArrayRef;

--- a/backends/arm/runtime/VGFBackend.cpp
+++ b/backends/arm/runtime/VGFBackend.cpp
@@ -12,6 +12,7 @@ using namespace std;
 #include <executorch/runtime/backend/interface.h>
 #include <executorch/runtime/core/error.h>
 #include <executorch/runtime/core/evalue.h>
+#include <executorch/runtime/core/portable_type/scalar_type.h>
 
 using executorch::aten::Tensor;
 using executorch::runtime::ArrayRef;
@@ -172,36 +173,49 @@ class VGFBackend final : public ::executorch::runtime::BackendInterface {
       DelegateHandle* handle,
       Span<EValue*> args) const override {
     VgfRepr* repr = static_cast<VgfRepr*>(handle);
+    const size_t input_count = repr->model_input_count;
+    const size_t output_count = repr->model_output_count;
+    ET_LOG(
+        Info,
+        "VGF execute: args=%zu IOs=%zu inputs=%zu outputs=%zu",
+        args.size(),
+        repr->IOs.size(),
+        input_count,
+        output_count);
+    if (args.size() < input_count + output_count) {
+      ET_LOG(Error, "Insufficient args for IOs");
+      return Error::InvalidArgument;
+    }
 
     // Copy all inputs from EValue to VkDeviceMemory
-    for (int i = 0; i < repr->IOs.size(); i++) {
-      if (!args[i]->isTensor()) {
+    for (size_t input_arg_idx = 0; input_arg_idx < input_count;
+         ++input_arg_idx) {
+      const int io_idx = repr->model_input_io_index[input_arg_idx];
+      if (io_idx < 0) {
+        ET_LOG(Error, "Missing IO mapping for input %zu", input_arg_idx);
+        return Error::InvalidArgument;
+      }
+      if (!args[input_arg_idx]->isTensor()) {
         ET_LOG(
             Error,
-            "Expected EValue %d to be tensor, got %d",
-            i,
-            static_cast<uint32_t>(args[i]->tag));
+            "Expected input EValue %zu to be tensor, got %d",
+            input_arg_idx,
+            static_cast<uint32_t>(args[input_arg_idx]->tag));
         return Error::InvalidArgument;
       }
 
-      Tensor* tensor = &args[i]->toTensor();
-      IO* io = &repr->IOs[i];
+      Tensor* tensor = &args[input_arg_idx]->toTensor();
+      IO* io = &repr->IOs[io_idx];
 
-      // skip non-inputs
-      if (!io->is_input)
-        continue;
-
-      size_t io_size = io->elt_size;
-      for (int64_t dim : io->size) {
-        ET_CHECK_OR_RETURN_ERROR(
-            dim >= 0,
-            InvalidArgument,
-            "Negative dimension in IO size: %" PRId64,
-            dim);
-        ET_CHECK_OR_RETURN_ERROR(
-            !c10::mul_overflows(io_size, static_cast<size_t>(dim), &io_size),
-            InvalidArgument,
-            "Overflow computing IO buffer size");
+      ET_LOG(Info, "Copy input IO[%d] -> args[%zu]", io_idx, input_arg_idx);
+      size_t io_size = tensor->nbytes();
+      if (io_size != io->allocation_size) {
+        ET_LOG(
+            Error,
+            "Input tensor byte size %zu does not match IO allocation %zu",
+            io_size,
+            io->allocation_size);
+        return Error::InvalidArgument;
       }
 
       void* data;
@@ -220,33 +234,34 @@ class VGFBackend final : public ::executorch::runtime::BackendInterface {
     }
 
     // Copy all outputs from VKDeviceMemory to EValue
-    for (int i = 0; i < repr->IOs.size(); i++) {
-      if (!args[i]->isTensor()) {
-        ET_LOG(
-            Error,
-            "Expected EValue %d to be tensor, got %d",
-            i,
-            static_cast<uint32_t>(args[i]->tag));
+    for (size_t output_rel_idx = 0; output_rel_idx < output_count;
+         ++output_rel_idx) {
+      const size_t output_arg_idx = input_count + output_rel_idx;
+      const int io_idx = repr->model_output_io_index[output_rel_idx];
+      if (io_idx < 0) {
+        ET_LOG(Error, "Missing IO mapping for output %zu", output_rel_idx);
         return Error::InvalidArgument;
       }
-      Tensor* tensor = &args[i]->toTensor();
-      IO* io = &repr->IOs[i];
+      if (!args[output_arg_idx]->isTensor()) {
+        ET_LOG(
+            Error,
+            "Expected output EValue %zu to be tensor, got %d",
+            output_arg_idx,
+            static_cast<uint32_t>(args[output_arg_idx]->tag));
+        return Error::InvalidArgument;
+      }
+      Tensor* tensor = &args[output_arg_idx]->toTensor();
+      IO* io = &repr->IOs[io_idx];
 
-      // skip non-outputs
-      if (io->is_input)
-        continue;
-
-      size_t io_size = io->elt_size;
-      for (int64_t dim : io->size) {
-        ET_CHECK_OR_RETURN_ERROR(
-            dim >= 0,
-            InvalidArgument,
-            "Negative dimension in IO size: %" PRId64,
-            dim);
-        ET_CHECK_OR_RETURN_ERROR(
-            !c10::mul_overflows(io_size, static_cast<size_t>(dim), &io_size),
-            InvalidArgument,
-            "Overflow computing IO buffer size");
+      ET_LOG(Info, "Copy output IO[%d] -> args[%zu]", io_idx, output_arg_idx);
+      size_t io_size = tensor->nbytes();
+      if (io_size != io->allocation_size) {
+        ET_LOG(
+            Error,
+            "Output tensor byte size %zu does not match IO allocation %zu",
+            io_size,
+            io->allocation_size);
+        return Error::InvalidArgument;
       }
 
       void* data;

--- a/backends/arm/runtime/VGFSetup.cpp
+++ b/backends/arm/runtime/VGFSetup.cpp
@@ -13,9 +13,30 @@
 #include <executorch/backends/arm/runtime/VGFSetup.h>
 
 #include <vgf/decoder.hpp>
+#if __has_include(<vgf/version.h>)
+#include <vgf/version.h>
+#endif
 #include <vgf/vulkan_helpers.generated.hpp>
 
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <limits>
+#include <optional>
+#include <type_traits>
+
 using namespace mlsdk;
+
+#if defined(MLSDK_VGF_LIBRARY_API_VERSION_MAJOR) && \
+    defined(MLSDK_VGF_LIBRARY_API_VERSION_MINOR)
+#define EXECUTORCH_ARM_VGF_HAS_DECODER_V10_APIS \
+  ((MLSDK_VGF_LIBRARY_API_VERSION_MAJOR > 0) || \
+   (MLSDK_VGF_LIBRARY_API_VERSION_MAJOR == 0 && \
+    MLSDK_VGF_LIBRARY_API_VERSION_MINOR >= 10))
+#else
+#define EXECUTORCH_ARM_VGF_HAS_DECODER_V10_APIS 0
+#endif
 
 namespace executorch {
 namespace backends {
@@ -29,96 +50,551 @@ static uint32_t get_format_size(VkFormat format);
 // shape. Tensors are output as rank 0 when copied back from the vgf backend.
 namespace {
 constexpr int64_t kScalarSentinelDimension = 1;
+static bool is_image_descriptor_type(VkDescriptorType descriptor_type);
+static bool is_tensor_like_descriptor_type(VkDescriptorType descriptor_type);
+
+enum class FormatScalarKind {
+  Bool,
+  Uint,
+  Sint,
+  Float,
+};
+
+struct FormatInfo {
+  uint32_t component_count = 0;
+  uint32_t bytes_per_component = 0;
+  FormatScalarKind scalar_kind = FormatScalarKind::Uint;
+};
+
+struct AliasLogicalContract {
+  bool initialized = false;
+  vector<int64_t> shape;
+  vector<int64_t> stride;
+  size_t logical_byte_size = 0;
+  uint32_t scalar_bytes = 0;
+  FormatScalarKind scalar_kind = FormatScalarKind::Uint;
+  bool image_initialized = false;
+  uint32_t image_component_count = 0;
+};
+
+static size_t element_count_from_shape(const vector<int64_t>& shape) {
+  if (shape.empty()) {
+    return 1;
+  }
+  size_t count = 1;
+  for (auto dim : shape) {
+    if (dim <= 0) {
+      return 0;
+    }
+    count *= static_cast<size_t>(dim);
+  }
+  return count;
 }
 
-#if defined(ET_ARM_VGF_DEBUG)
-// Debug function to inspect memory properties
-static string memory_flags_to_string(VkMemoryPropertyFlags flags) {
-  if (flags == 0)
-    return "0";
-
-  vector<string> parts;
-#define TRY_FLAG(f)         \
-  if (flags & (f)) {        \
-    parts.emplace_back(#f); \
-    flags &= ~(f);          \
+static vector<int64_t> normalize_stride(
+    const vector<int64_t>& shape,
+    const vector<int64_t>& stride) {
+  if (!stride.empty()) {
+    return stride;
   }
 
-  TRY_FLAG(VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT)
-  TRY_FLAG(VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)
-  TRY_FLAG(VK_MEMORY_PROPERTY_HOST_COHERENT_BIT)
-  TRY_FLAG(VK_MEMORY_PROPERTY_HOST_CACHED_BIT)
-  TRY_FLAG(VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT)
-#ifdef VK_MEMORY_PROPERTY_PROTECTED_BIT
-  TRY_FLAG(VK_MEMORY_PROPERTY_PROTECTED_BIT)
-#endif
-#undef TRY_FLAG
-
-  if (flags) {
-    // Preserve any unrecognized bits in hex so debug logs stay complete.
-    ostringstream hex;
-    hex << "0x" << std::hex << flags;
-    parts.emplace_back(hex.str());
+  vector<int64_t> contiguous_stride(shape.size(), 1);
+  int64_t running = 1;
+  for (size_t idx = shape.size(); idx > 0; --idx) {
+    contiguous_stride[idx - 1] = running;
+    running *= shape[idx - 1];
   }
-
-  ostringstream joined;
-  for (size_t i = 0; i < parts.size(); ++i) {
-    if (i)
-      joined << " | ";
-    joined << parts[i];
-  }
-  return joined.str();
+  return contiguous_stride;
 }
-#endif
 
-/**
- * Tensor free helper function
- */
-void free_tensor(
+static uint32_t get_format_component_count(VkFormat format) {
+  switch (format) {
+    case VK_FORMAT_R8_BOOL_ARM:
+    case VK_FORMAT_R8_UINT:
+    case VK_FORMAT_R8_SINT:
+    case VK_FORMAT_R16_UINT:
+    case VK_FORMAT_R16_SINT:
+    case VK_FORMAT_R16_SFLOAT:
+    case VK_FORMAT_R32_UINT:
+    case VK_FORMAT_R32_SINT:
+    case VK_FORMAT_R32_SFLOAT:
+    case VK_FORMAT_R64_SINT:
+      return 1;
+    case VK_FORMAT_R8G8_UINT:
+    case VK_FORMAT_R8G8_SINT:
+    case VK_FORMAT_R16G16_UINT:
+    case VK_FORMAT_R16G16_SINT:
+    case VK_FORMAT_R16G16_SFLOAT:
+    case VK_FORMAT_R32G32_UINT:
+    case VK_FORMAT_R32G32_SINT:
+    case VK_FORMAT_R32G32_SFLOAT:
+      return 2;
+    case VK_FORMAT_R8G8B8A8_UINT:
+    case VK_FORMAT_R8G8B8A8_SINT:
+    case VK_FORMAT_R16G16B16A16_UINT:
+    case VK_FORMAT_R16G16B16A16_SINT:
+    case VK_FORMAT_R16G16B16A16_SFLOAT:
+    case VK_FORMAT_R32G32B32A32_UINT:
+    case VK_FORMAT_R32G32B32A32_SINT:
+    case VK_FORMAT_R32G32B32A32_SFLOAT:
+      return 4;
+    default:
+      ET_LOG(
+          Error,
+          "Unsupported image VkFormat %u for component count",
+          static_cast<uint32_t>(format));
+      return 0;
+  }
+}
+
+static bool get_format_info(VkFormat format, FormatInfo* info) {
+  switch (format) {
+    case VK_FORMAT_R8_BOOL_ARM:
+      *info = FormatInfo{1, 1, FormatScalarKind::Bool};
+      return true;
+    case VK_FORMAT_R8_UINT:
+      *info = FormatInfo{1, 1, FormatScalarKind::Uint};
+      return true;
+    case VK_FORMAT_R8_SINT:
+      *info = FormatInfo{1, 1, FormatScalarKind::Sint};
+      return true;
+    case VK_FORMAT_R16_UINT:
+      *info = FormatInfo{1, 2, FormatScalarKind::Uint};
+      return true;
+    case VK_FORMAT_R16_SINT:
+      *info = FormatInfo{1, 2, FormatScalarKind::Sint};
+      return true;
+    case VK_FORMAT_R16_SFLOAT:
+      *info = FormatInfo{1, 2, FormatScalarKind::Float};
+      return true;
+    case VK_FORMAT_R32_UINT:
+      *info = FormatInfo{1, 4, FormatScalarKind::Uint};
+      return true;
+    case VK_FORMAT_R32_SINT:
+      *info = FormatInfo{1, 4, FormatScalarKind::Sint};
+      return true;
+    case VK_FORMAT_R32_SFLOAT:
+      *info = FormatInfo{1, 4, FormatScalarKind::Float};
+      return true;
+    case VK_FORMAT_R64_SINT:
+      *info = FormatInfo{1, 8, FormatScalarKind::Sint};
+      return true;
+    case VK_FORMAT_R8G8_UINT:
+      *info = FormatInfo{2, 1, FormatScalarKind::Uint};
+      return true;
+    case VK_FORMAT_R8G8_SINT:
+      *info = FormatInfo{2, 1, FormatScalarKind::Sint};
+      return true;
+    case VK_FORMAT_R16G16_UINT:
+      *info = FormatInfo{2, 2, FormatScalarKind::Uint};
+      return true;
+    case VK_FORMAT_R16G16_SINT:
+      *info = FormatInfo{2, 2, FormatScalarKind::Sint};
+      return true;
+    case VK_FORMAT_R16G16_SFLOAT:
+      *info = FormatInfo{2, 2, FormatScalarKind::Float};
+      return true;
+    case VK_FORMAT_R32G32_UINT:
+      *info = FormatInfo{2, 4, FormatScalarKind::Uint};
+      return true;
+    case VK_FORMAT_R32G32_SINT:
+      *info = FormatInfo{2, 4, FormatScalarKind::Sint};
+      return true;
+    case VK_FORMAT_R32G32_SFLOAT:
+      *info = FormatInfo{2, 4, FormatScalarKind::Float};
+      return true;
+    case VK_FORMAT_R8G8B8A8_UINT:
+      *info = FormatInfo{4, 1, FormatScalarKind::Uint};
+      return true;
+    case VK_FORMAT_R8G8B8A8_SINT:
+      *info = FormatInfo{4, 1, FormatScalarKind::Sint};
+      return true;
+    case VK_FORMAT_R16G16B16A16_UINT:
+      *info = FormatInfo{4, 2, FormatScalarKind::Uint};
+      return true;
+    case VK_FORMAT_R16G16B16A16_SINT:
+      *info = FormatInfo{4, 2, FormatScalarKind::Sint};
+      return true;
+    case VK_FORMAT_R16G16B16A16_SFLOAT:
+      *info = FormatInfo{4, 2, FormatScalarKind::Float};
+      return true;
+    case VK_FORMAT_R32G32B32A32_UINT:
+      *info = FormatInfo{4, 4, FormatScalarKind::Uint};
+      return true;
+    case VK_FORMAT_R32G32B32A32_SINT:
+      *info = FormatInfo{4, 4, FormatScalarKind::Sint};
+      return true;
+    case VK_FORMAT_R32G32B32A32_SFLOAT:
+      *info = FormatInfo{4, 4, FormatScalarKind::Float};
+      return true;
+    default:
+      ET_LOG(Error, "Unsupported VkFormat %u", static_cast<uint32_t>(format));
+      return false;
+  }
+}
+
+static bool validate_image_shape_and_format(
+    const vector<int64_t>& shape,
+    VkFormat format,
+    VkExtent3D* image_extent,
+    size_t* staging_size = nullptr) {
+  const uint32_t format_component_count = get_format_component_count(format);
+  const size_t bytes_per_pixel = get_format_size(format);
+  if (format_component_count == 0 || bytes_per_pixel == 0) {
+    return false;
+  }
+
+  int64_t height = 0;
+  int64_t width = 0;
+  int64_t channels = 0;
+  if (shape.size() == 4) {
+    if (shape[0] != 1) {
+      ET_LOG(Error, "Only batch size 1 images are currently supported");
+      return false;
+    }
+    height = shape[1];
+    width = shape[2];
+    channels = shape[3];
+  } else if (shape.size() == 3) {
+    height = shape[0];
+    width = shape[1];
+    channels = shape[2];
+  } else {
+    ET_LOG(Error, "Unsupported image shape rank %zu", shape.size());
+    return false;
+  }
+
+  if (height <= 0 || width <= 0 || channels <= 0) {
+    ET_LOG(
+        Error,
+        "Image shape dimensions must be positive, got [%lld, %lld, %lld]",
+        static_cast<long long>(height),
+        static_cast<long long>(width),
+        static_cast<long long>(channels));
+    return false;
+  }
+
+  if (static_cast<uint32_t>(channels) != format_component_count) {
+    ET_LOG(
+        Error,
+        "Image channel count %lld does not match VkFormat %u component count %u",
+        static_cast<long long>(channels),
+        static_cast<uint32_t>(format),
+        format_component_count);
+    return false;
+  }
+
+  image_extent->width = static_cast<uint32_t>(width);
+  image_extent->height = static_cast<uint32_t>(height);
+  image_extent->depth = 1;
+
+  if (staging_size != nullptr) {
+    const size_t pixel_count = static_cast<size_t>(image_extent->width) *
+        static_cast<size_t>(image_extent->height) *
+        static_cast<size_t>(image_extent->depth);
+    if (pixel_count > std::numeric_limits<size_t>::max() / bytes_per_pixel) {
+      ET_LOG(Error, "Image staging allocation size overflow");
+      return false;
+    }
+    *staging_size = pixel_count * bytes_per_pixel;
+  }
+
+  return true;
+}
+
+static bool validate_alias_group_logical_contract(
+    uint32_t alias_group_id,
+    uint32_t resource_index,
+    VkDescriptorType descriptor_type,
+    VkFormat format,
+    const vector<int64_t>& shape,
+    const vector<int64_t>& stride,
+    AliasLogicalContract* contract) {
+  FormatInfo format_info;
+  if (!get_format_info(format, &format_info)) {
+    return false;
+  }
+
+  size_t logical_byte_size = 0;
+  if (is_image_descriptor_type(descriptor_type)) {
+    VkExtent3D image_extent = {};
+    if (!validate_image_shape_and_format(
+            shape, format, &image_extent, &logical_byte_size)) {
+      return false;
+    }
+  } else if (is_tensor_like_descriptor_type(descriptor_type)) {
+    if (format_info.component_count != 1) {
+      ET_LOG(
+          Error,
+          "Alias group %u tensor-like resource %u must use a scalar VkFormat",
+          alias_group_id,
+          resource_index);
+      return false;
+    }
+    logical_byte_size =
+        element_count_from_shape(shape) * get_format_size(format);
+  } else {
+    ET_LOG(
+        Error,
+        "Alias group %u contains unsupported descriptor type %u for resource %u",
+        alias_group_id,
+        static_cast<uint32_t>(descriptor_type),
+        resource_index);
+    return false;
+  }
+
+  const vector<int64_t> normalized_stride = normalize_stride(shape, stride);
+  if (!contract->initialized) {
+    contract->initialized = true;
+    contract->shape = shape;
+    contract->stride = normalized_stride;
+    contract->logical_byte_size = logical_byte_size;
+    contract->scalar_bytes = format_info.bytes_per_component;
+    contract->scalar_kind = format_info.scalar_kind;
+  } else {
+    if (contract->shape != shape || contract->stride != normalized_stride) {
+      ET_LOG(
+          Error,
+          "Alias group %u has mismatched logical layout at resource %u",
+          alias_group_id,
+          resource_index);
+      return false;
+    }
+    if (contract->logical_byte_size != logical_byte_size) {
+      ET_LOG(
+          Error,
+          "Alias group %u has mismatched logical byte size at resource %u",
+          alias_group_id,
+          resource_index);
+      return false;
+    }
+    if (contract->scalar_bytes != format_info.bytes_per_component ||
+        contract->scalar_kind != format_info.scalar_kind) {
+      ET_LOG(
+          Error,
+          "Alias group %u has mismatched scalar format at resource %u",
+          alias_group_id,
+          resource_index);
+      return false;
+    }
+  }
+
+  if (is_image_descriptor_type(descriptor_type)) {
+    if (!contract->image_initialized) {
+      contract->image_initialized = true;
+      contract->image_component_count = format_info.component_count;
+    } else if (contract->image_component_count != format_info.component_count) {
+      ET_LOG(
+          Error,
+          "Alias group %u has mismatched image channel packing at resource %u",
+          alias_group_id,
+          resource_index);
+      return false;
+    }
+  }
+
+  if (contract->image_initialized && !shape.empty() &&
+      static_cast<uint32_t>(shape.back()) != contract->image_component_count) {
+    ET_LOG(
+        Error,
+        "Alias group %u shape channel dimension does not match image packing at resource %u",
+        alias_group_id,
+        resource_index);
+    return false;
+  }
+
+  return true;
+}
+
+static VkDescriptorType resolve_descriptor_type(
+    unique_ptr<vgflib::ModelResourceTableDecoder>& resource_decoder,
+    uint32_t index) {
+  auto descriptor_type = resource_decoder->getDescriptorType(index);
+  if (descriptor_type.has_value()) {
+    return vgflib::ToVkDescriptorType(descriptor_type.value());
+  }
+  ET_LOG(
+      Info,
+      "Resource %u has no explicit descriptor type; assuming VK_DESCRIPTOR_TYPE_TENSOR_ARM",
+      index);
+  return VK_DESCRIPTOR_TYPE_TENSOR_ARM;
+}
+
+static VkPipelineStageFlags2 vgf_execution_stage_mask() {
+  return VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT |
+      VK_PIPELINE_STAGE_2_DATA_GRAPH_BIT_ARM;
+}
+
+static VkAccessFlags2 vgf_execution_read_access_mask() {
+  return VK_ACCESS_2_SHADER_READ_BIT | VK_ACCESS_2_DATA_GRAPH_READ_BIT_ARM;
+}
+
+static VkAccessFlags2 vgf_execution_write_access_mask() {
+  return VK_ACCESS_2_SHADER_WRITE_BIT | VK_ACCESS_2_DATA_GRAPH_WRITE_BIT_ARM;
+}
+
+static bool is_image_descriptor_type(VkDescriptorType descriptor_type) {
+  return descriptor_type == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER ||
+      descriptor_type == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE ||
+      descriptor_type == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+}
+
+static bool is_tensor_like_descriptor_type(VkDescriptorType descriptor_type) {
+  return descriptor_type == VK_DESCRIPTOR_TYPE_TENSOR_ARM ||
+      descriptor_type == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+}
+
+static void record_image_layout_transition(
+    VkCommandBuffer command_buffer,
+    VkImage image,
+    VkImageLayout old_layout,
+    VkImageLayout new_layout) {
+  const VkImageMemoryBarrier2 image_barrier = {
+      .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2,
+      .pNext = nullptr,
+      .srcStageMask = old_layout == VK_IMAGE_LAYOUT_UNDEFINED
+          ? VK_PIPELINE_STAGE_2_NONE
+          : (VK_PIPELINE_STAGE_2_TRANSFER_BIT | vgf_execution_stage_mask()),
+      .srcAccessMask = old_layout == VK_IMAGE_LAYOUT_UNDEFINED
+          ? VK_ACCESS_2_NONE
+          : (VK_ACCESS_2_TRANSFER_READ_BIT | VK_ACCESS_2_TRANSFER_WRITE_BIT |
+             vgf_execution_read_access_mask() |
+             vgf_execution_write_access_mask()),
+      .dstStageMask =
+          VK_PIPELINE_STAGE_2_TRANSFER_BIT | vgf_execution_stage_mask(),
+      .dstAccessMask = VK_ACCESS_2_TRANSFER_READ_BIT |
+          VK_ACCESS_2_TRANSFER_WRITE_BIT | vgf_execution_read_access_mask() |
+          vgf_execution_write_access_mask(),
+      .oldLayout = old_layout,
+      .newLayout = new_layout,
+      .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+      .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+      .image = image,
+      .subresourceRange =
+          {
+              .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
+              .baseMipLevel = 0,
+              .levelCount = 1,
+              .baseArrayLayer = 0,
+              .layerCount = 1,
+          },
+  };
+  const VkDependencyInfo dependency_info = {
+      .sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO,
+      .pNext = nullptr,
+      .memoryBarrierCount = 0,
+      .pMemoryBarriers = nullptr,
+      .bufferMemoryBarrierCount = 0,
+      .pBufferMemoryBarriers = nullptr,
+      .imageMemoryBarrierCount = 1,
+      .pImageMemoryBarriers = &image_barrier,
+  };
+  vkCmdPipelineBarrier2(command_buffer, &dependency_info);
+}
+
+} // namespace
+
+void destroy_tensor(
     VkDevice device,
     VkTensorViewARM tensor_view,
-    VkTensorARM tensor,
-    VkDeviceMemory memory) {
+    VkTensorARM tensor) {
   vkDestroyTensorViewARM(device, tensor_view, nullptr);
   vkDestroyTensorARM(device, tensor, nullptr);
-  vkFreeMemory(device, memory, nullptr);
 }
 
-uint32_t get_memory_index(
+void destroy_buffer(VkDevice device, VkBuffer buffer) {
+  vkDestroyBuffer(device, buffer, nullptr);
+}
+
+void free_image(
+    VkDevice device,
+    VkImageView image_view,
+    VkImage image,
+    VkSampler sampler,
+    VkDeviceMemory memory) {
+  if (sampler != VK_NULL_HANDLE) {
+    vkDestroySampler(device, sampler, nullptr);
+  }
+  if (image_view != VK_NULL_HANDLE) {
+    vkDestroyImageView(device, image_view, nullptr);
+  }
+  if (image != VK_NULL_HANDLE) {
+    vkDestroyImage(device, image, nullptr);
+  }
+  if (memory != VK_NULL_HANDLE) {
+    vkFreeMemory(device, memory, nullptr);
+  }
+}
+
+static bool find_memory_index_from_bits(
     VkPhysicalDevice vk_physical,
-    VkMemoryRequirements2 memory_requirements,
-    VkMemoryPropertyFlags aims) {
+    uint32_t memory_type_bits,
+    VkMemoryPropertyFlags aims,
+    uint32_t* memory_type_out) {
   VkPhysicalDeviceMemoryProperties mem_properties;
   vkGetPhysicalDeviceMemoryProperties(vk_physical, &mem_properties);
 
-  uint32_t memory_type = 0;
-  for (size_t i = 0; i < 31; ++i) {
-    if (memory_requirements.memoryRequirements.memoryTypeBits & (0x1 << i)) {
-      memory_type = i;
-      if ((mem_properties.memoryTypes[i].propertyFlags & aims) == aims)
-        break;
+  for (uint32_t i = 0; i < mem_properties.memoryTypeCount; ++i) {
+    if ((memory_type_bits & (0x1u << i)) != 0) {
+      if ((mem_properties.memoryTypes[i].propertyFlags & aims) == aims) {
+        *memory_type_out = i;
+        return true;
+      }
     }
   }
-  return memory_type;
+  return false;
 }
 
-/**
- * Tensor allocation helper function
- */
-VkResult allocate_tensor(
+static bool find_memory_index(
+    VkPhysicalDevice vk_physical,
+    VkMemoryRequirements2 memory_requirements,
+    VkMemoryPropertyFlags aims,
+    uint32_t* memory_type_out) {
+  return find_memory_index_from_bits(
+      vk_physical,
+      memory_requirements.memoryRequirements.memoryTypeBits,
+      aims,
+      memory_type_out);
+}
+
+VkResult allocate_memory(
     VkPhysicalDevice physical,
+    VkDevice device,
+    VkMemoryRequirements2 memory_requirements,
+    VkMemoryPropertyFlags aims,
+    VkDeviceMemory* memory,
+    uint32_t* memory_type_index_out = nullptr) {
+  uint32_t memory_index = 0;
+  if (!find_memory_index(physical, memory_requirements, aims, &memory_index)) {
+    ET_LOG(
+        Error,
+        "Failed to find compatible Vulkan memory type for aims 0x%x",
+        static_cast<unsigned int>(aims));
+    return VK_ERROR_FEATURE_NOT_PRESENT;
+  }
+  const VkMemoryAllocateInfo allocate_info = {
+      .sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
+      .pNext = nullptr,
+      .allocationSize = memory_requirements.memoryRequirements.size,
+      .memoryTypeIndex = memory_index,
+  };
+  VkResult result = vkAllocateMemory(device, &allocate_info, nullptr, memory);
+  if (result == VK_SUCCESS && memory_type_index_out != nullptr) {
+    *memory_type_index_out = memory_index;
+  }
+  return result;
+}
+
+VkResult create_tensor_unbound(
     VkDevice device,
     VkFormat format,
     uint32_t shape_size,
     const int64_t* shape,
     uint32_t stride_size,
-    const int64_t* stride,
+    const int64_t* strides,
     VkTensorDescriptionARM* description,
-    VkTensorViewARM* tensor_view,
     VkTensorARM* tensor,
-    VkDeviceMemory* memory) {
-  VkResult result;
-
+    VkMemoryRequirements2* memory_requirements) {
   *description = VkTensorDescriptionARM{
       .sType = VK_STRUCTURE_TYPE_TENSOR_DESCRIPTION_ARM,
       .pNext = nullptr,
@@ -126,13 +602,13 @@ VkResult allocate_tensor(
       .format = format,
       .dimensionCount = shape_size,
       .pDimensions = shape,
-      // Note: stride_data of 0's causes size==0, null means stride==size
-      .pStrides = (0 == stride_size ? nullptr : stride),
+      .pStrides = (0 == stride_size ? nullptr : strides),
       .usage = VK_TENSOR_USAGE_SHADER_BIT_ARM |
           VK_TENSOR_USAGE_TRANSFER_SRC_BIT_ARM |
           VK_TENSOR_USAGE_TRANSFER_DST_BIT_ARM |
           VK_TENSOR_USAGE_DATA_GRAPH_BIT_ARM,
   };
+
   const VkTensorCreateInfoARM create_info = {
       .sType = VK_STRUCTURE_TYPE_TENSOR_CREATE_INFO_ARM,
       .pNext = nullptr,
@@ -143,58 +619,63 @@ VkResult allocate_tensor(
       .pQueueFamilyIndices = nullptr,
   };
 
-  result = vkCreateTensorARM(device, &create_info, nullptr, tensor);
+  VkResult result = vkCreateTensorARM(device, &create_info, nullptr, tensor);
   if (result != VK_SUCCESS) {
     ET_LOG(Error, "Failed to CreateTensor, error %d", result);
     return result;
   }
 
-  // Get backing memory requirements
   const VkTensorMemoryRequirementsInfoARM memory_requirements_info = {
       .sType = VK_STRUCTURE_TYPE_TENSOR_MEMORY_REQUIREMENTS_INFO_ARM,
       .pNext = nullptr,
       .tensor = *tensor,
   };
-  VkMemoryRequirements2 memory_requirements = {
+  *memory_requirements = VkMemoryRequirements2{
       .sType = VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2,
       .pNext = nullptr,
   };
   vkGetTensorMemoryRequirementsARM(
-      device, &memory_requirements_info, &memory_requirements);
+      device, &memory_requirements_info, memory_requirements);
+  return VK_SUCCESS;
+}
 
-  VkMemoryPropertyFlags aims = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT |
-      VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
-      VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
-  uint32_t memory_index = get_memory_index(physical, memory_requirements, aims);
-
-  // Allocate memory
-  const VkMemoryAllocateInfo allocate_info = {
-      .sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
+VkTensorDescriptionARM make_data_graph_descriptor(
+    VkFormat format,
+    uint32_t shape_size,
+    const int64_t* shape,
+    uint32_t stride_size,
+    const int64_t* strides) {
+  return VkTensorDescriptionARM{
+      .sType = VK_STRUCTURE_TYPE_TENSOR_DESCRIPTION_ARM,
       .pNext = nullptr,
-      .allocationSize = memory_requirements.memoryRequirements.size,
-      .memoryTypeIndex = memory_index,
+      .tiling = VK_TENSOR_TILING_LINEAR_ARM,
+      .format = format,
+      .dimensionCount = shape_size,
+      .pDimensions = shape,
+      .pStrides = (0 == stride_size ? nullptr : strides),
+      .usage = VK_TENSOR_USAGE_SHADER_BIT_ARM |
+          VK_TENSOR_USAGE_TRANSFER_SRC_BIT_ARM |
+          VK_TENSOR_USAGE_TRANSFER_DST_BIT_ARM |
+          VK_TENSOR_USAGE_DATA_GRAPH_BIT_ARM,
   };
+}
 
-  result = vkAllocateMemory(device, &allocate_info, nullptr, memory);
-  if (result != VK_SUCCESS) {
-    ET_LOG(Error, "Failed to allocate tensor memory, error %d", result);
-    vkDestroyTensorARM(device, *tensor, nullptr);
-    return result;
-  }
-
-  // Bind tensor to memory
+VkResult bind_tensor_memory_and_create_view(
+    VkDevice device,
+    VkFormat format,
+    VkTensorARM tensor,
+    VkDeviceMemory memory,
+    VkTensorViewARM* tensor_view) {
   const VkBindTensorMemoryInfoARM bind_info = {
       .sType = VK_STRUCTURE_TYPE_BIND_TENSOR_MEMORY_INFO_ARM,
       .pNext = nullptr,
-      .tensor = *tensor,
-      .memory = *memory,
+      .tensor = tensor,
+      .memory = memory,
       .memoryOffset = 0,
   };
-  result = vkBindTensorMemoryARM(device, 1, &bind_info);
+  VkResult result = vkBindTensorMemoryARM(device, 1, &bind_info);
   if (result != VK_SUCCESS) {
     ET_LOG(Error, "Failed to bind tensor memory, error %d", result);
-    vkDestroyTensorARM(device, *tensor, nullptr);
-    vkFreeMemory(device, *memory, nullptr);
     return result;
   }
 
@@ -202,18 +683,430 @@ VkResult allocate_tensor(
       .sType = VK_STRUCTURE_TYPE_TENSOR_VIEW_CREATE_INFO_ARM,
       .pNext = nullptr,
       .flags = 0,
-      .tensor = *tensor,
+      .tensor = tensor,
       .format = format,
   };
-  VkResult res_tv =
-      vkCreateTensorViewARM(device, &tensor_view_info, nullptr, tensor_view);
-  ET_LOG(Info, "    tensor view (success %d)", res_tv == VK_SUCCESS);
+  return vkCreateTensorViewARM(device, &tensor_view_info, nullptr, tensor_view);
+}
 
-  return res_tv;
+VkResult create_buffer_unbound(
+    VkDevice device,
+    VkDeviceSize size,
+    VkBufferUsageFlags usage,
+    VkBuffer* buffer,
+    VkMemoryRequirements2* memory_requirements) {
+  VkBufferCreateInfo buffer_info = {
+      .sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
+      .pNext = nullptr,
+      .flags = 0,
+      .size = size,
+      .usage = usage,
+      .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
+      .queueFamilyIndexCount = 0,
+      .pQueueFamilyIndices = nullptr,
+  };
+  VkResult result = vkCreateBuffer(device, &buffer_info, nullptr, buffer);
+  if (result != VK_SUCCESS) {
+    ET_LOG(Error, "Failed to create buffer, error %d", result);
+    return result;
+  }
+
+  VkMemoryRequirements memory_requirements1 = {};
+  vkGetBufferMemoryRequirements(device, *buffer, &memory_requirements1);
+  *memory_requirements = VkMemoryRequirements2{
+      .sType = VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2,
+      .pNext = nullptr,
+      .memoryRequirements = memory_requirements1,
+  };
+  return VK_SUCCESS;
+}
+
+VkResult
+bind_buffer_memory(VkDevice device, VkBuffer buffer, VkDeviceMemory memory) {
+  return vkBindBufferMemory(device, buffer, memory, 0);
+}
+
+VkResult create_image_unbound(
+    VkDevice device,
+    VkFormat format,
+    VkExtent3D extent,
+    VkImageUsageFlags usage,
+    VkImage* image,
+    VkMemoryRequirements2* memory_requirements) {
+  const VkImageCreateInfo image_info = {
+      .sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
+      .pNext = nullptr,
+      .flags = 0,
+      .imageType = VK_IMAGE_TYPE_2D,
+      .format = format,
+      .extent = extent,
+      .mipLevels = 1,
+      .arrayLayers = 1,
+      .samples = VK_SAMPLE_COUNT_1_BIT,
+      .tiling = VK_IMAGE_TILING_OPTIMAL,
+      .usage = usage,
+      .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
+      .queueFamilyIndexCount = 0,
+      .pQueueFamilyIndices = nullptr,
+      .initialLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+  };
+  VkResult result = vkCreateImage(device, &image_info, nullptr, image);
+  if (result != VK_SUCCESS) {
+    ET_LOG(Error, "Failed to create image, error %d", result);
+    return result;
+  }
+
+  VkMemoryRequirements reqs = {};
+  vkGetImageMemoryRequirements(device, *image, &reqs);
+  *memory_requirements = VkMemoryRequirements2{
+      .sType = VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2,
+      .pNext = nullptr,
+      .memoryRequirements = reqs,
+  };
+  return VK_SUCCESS;
+}
+
+VkResult bind_image_memory_and_create_view(
+    VkDevice device,
+    VkFormat format,
+    VkImage image,
+    VkDeviceMemory memory,
+    VkImageView* image_view) {
+  VkResult result = vkBindImageMemory(device, image, memory, 0);
+  if (result != VK_SUCCESS) {
+    ET_LOG(Error, "Failed to bind image memory, error %d", result);
+    return result;
+  }
+
+  const VkImageViewCreateInfo view_info = {
+      .sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
+      .pNext = nullptr,
+      .flags = 0,
+      .image = image,
+      .viewType = VK_IMAGE_VIEW_TYPE_2D,
+      .format = format,
+      .components =
+          {
+              .r = VK_COMPONENT_SWIZZLE_IDENTITY,
+              .g = VK_COMPONENT_SWIZZLE_IDENTITY,
+              .b = VK_COMPONENT_SWIZZLE_IDENTITY,
+              .a = VK_COMPONENT_SWIZZLE_IDENTITY,
+          },
+      .subresourceRange =
+          {
+              .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
+              .baseMipLevel = 0,
+              .levelCount = 1,
+              .baseArrayLayer = 0,
+              .layerCount = 1,
+          },
+  };
+  return vkCreateImageView(device, &view_info, nullptr, image_view);
+}
+
+VkResult allocate_buffer(
+    VkPhysicalDevice physical,
+    VkDevice device,
+    VkDeviceSize size,
+    VkBufferUsageFlags usage,
+    VkBuffer* buffer,
+    VkDeviceMemory* memory) {
+  VkBufferCreateInfo buffer_info = {
+      .sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
+      .pNext = nullptr,
+      .flags = 0,
+      .size = size,
+      .usage = usage,
+      .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
+      .queueFamilyIndexCount = 0,
+      .pQueueFamilyIndices = nullptr,
+  };
+  VkResult result = vkCreateBuffer(device, &buffer_info, nullptr, buffer);
+  if (result != VK_SUCCESS) {
+    ET_LOG(Error, "Failed to create buffer, error %d", result);
+    return result;
+  }
+
+  VkMemoryRequirements memory_requirements = {};
+  vkGetBufferMemoryRequirements(device, *buffer, &memory_requirements);
+  VkMemoryRequirements2 memory_requirements2 = {
+      .sType = VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2,
+      .pNext = nullptr,
+      .memoryRequirements = memory_requirements,
+  };
+
+  VkMemoryPropertyFlags aims = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT |
+      VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
+      VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+  uint32_t memory_index = 0;
+  if (!find_memory_index(physical, memory_requirements2, aims, &memory_index)) {
+    ET_LOG(Error, "Failed to find buffer memory type");
+    vkDestroyBuffer(device, *buffer, nullptr);
+    *buffer = VK_NULL_HANDLE;
+    return VK_ERROR_FEATURE_NOT_PRESENT;
+  }
+
+  const VkMemoryAllocateInfo allocate_info = {
+      .sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
+      .pNext = nullptr,
+      .allocationSize = memory_requirements.size,
+      .memoryTypeIndex = memory_index,
+  };
+  result = vkAllocateMemory(device, &allocate_info, nullptr, memory);
+  if (result != VK_SUCCESS) {
+    ET_LOG(Error, "Failed to allocate buffer memory, error %d", result);
+    return result;
+  }
+
+  result = vkBindBufferMemory(device, *buffer, *memory, 0);
+  if (result != VK_SUCCESS) {
+    ET_LOG(Error, "Failed to bind buffer memory, error %d", result);
+    return result;
+  }
+
+  return VK_SUCCESS;
+}
+
+VkResult allocate_sampler(
+    VkDevice device,
+    VkFilter min_filter,
+    VkFilter mag_filter,
+    VkSamplerAddressMode address_mode_u,
+    VkSamplerAddressMode address_mode_v,
+    VkBorderColor border_color,
+    VkSampler* sampler) {
+  const VkSamplerCreateInfo sampler_info = {
+      .sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO,
+      .pNext = nullptr,
+      .flags = 0,
+      .magFilter = mag_filter,
+      .minFilter = min_filter,
+      .mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST,
+      .addressModeU = address_mode_u,
+      .addressModeV = address_mode_v,
+      .addressModeW = address_mode_v,
+      .mipLodBias = 0.0f,
+      .anisotropyEnable = VK_FALSE,
+      .maxAnisotropy = 1.0f,
+      .compareEnable = VK_FALSE,
+      .compareOp = VK_COMPARE_OP_NEVER,
+      .minLod = 0.0f,
+      .maxLod = 0.0f,
+      .borderColor = border_color,
+      .unnormalizedCoordinates = VK_FALSE,
+  };
+  return vkCreateSampler(device, &sampler_info, nullptr, sampler);
+}
+
+static std::optional<uint32_t> get_resource_alias_group_id(
+    const unique_ptr<vgflib::ModelResourceTableDecoder>& resource_decoder,
+    uint32_t resource_index) {
+#if EXECUTORCH_ARM_VGF_HAS_DECODER_V10_APIS
+  auto alias_group = resource_decoder->getAliasGroupId(resource_index);
+  if (!alias_group.has_value()) {
+    return std::nullopt;
+  }
+  return static_cast<uint32_t>(*alias_group);
+#else
+  (void)resource_decoder;
+  (void)resource_index;
+  return std::nullopt;
+#endif
+}
+
+static bool allocate_resource_sampler(
+    const unique_ptr<vgflib::ModelResourceTableDecoder>& resource_decoder,
+    uint32_t resource_index,
+    VkDevice device,
+    VkSampler* sampler_out) {
+#if EXECUTORCH_ARM_VGF_HAS_DECODER_V10_APIS
+  auto sampler_config =
+      resource_decoder->getSamplerConfigHandle(resource_index);
+  if (sampler_config == nullptr) {
+    ET_LOG(
+        Error,
+        "Missing sampler config for combined image sampler resource %u",
+        resource_index);
+    return false;
+  }
+
+  auto result = allocate_sampler(
+      device,
+      static_cast<VkFilter>(
+          resource_decoder->getSamplerConfigMinFilter(sampler_config)),
+      static_cast<VkFilter>(
+          resource_decoder->getSamplerConfigMagFilter(sampler_config)),
+      static_cast<VkSamplerAddressMode>(
+          resource_decoder->getSamplerConfigAddressModeU(sampler_config)),
+      static_cast<VkSamplerAddressMode>(
+          resource_decoder->getSamplerConfigAddressModeV(sampler_config)),
+      static_cast<VkBorderColor>(
+          resource_decoder->getSamplerConfigBorderColor(sampler_config)),
+      sampler_out);
+#else
+  (void)resource_decoder;
+  auto result = allocate_sampler(
+      device,
+      VK_FILTER_LINEAR,
+      VK_FILTER_LINEAR,
+      VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE,
+      VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE,
+      VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK,
+      sampler_out);
+#endif
+  if (result != VK_SUCCESS) {
+    ET_LOG(
+        Error,
+        "Failed to create sampler for VGF resource %u, error %d",
+        resource_index,
+        result);
+    return false;
+  }
+  return true;
+}
+
+static auto get_module_spirv_code(
+    unique_ptr<vgflib::ModuleTableDecoder>& module_decoder,
+    uint32_t module_index) {
+#if EXECUTORCH_ARM_VGF_HAS_DECODER_V10_APIS
+  return module_decoder->getSPIRVModuleCode(module_index);
+#else
+  return module_decoder->getModuleCode(module_index);
+#endif
+}
+
+static uint32_t get_segment_descriptor_set_index(
+    const unique_ptr<vgflib::ModelSequenceTableDecoder>& sequence_decoder,
+    uint32_t segment_index,
+    uint32_t descriptor_index) {
+#if EXECUTORCH_ARM_VGF_HAS_DECODER_V10_APIS
+  return sequence_decoder->getSegmentDescriptorSetIndex(
+      segment_index, descriptor_index);
+#else
+  (void)sequence_decoder;
+  (void)segment_index;
+  return descriptor_index;
+#endif
+}
+
+VkResult transition_image_layout(
+    VkDevice device,
+    VkCommandPool command_pool,
+    VkQueue queue,
+    VkImage image,
+    VkImageLayout old_layout,
+    VkImageLayout new_layout) {
+  VkCommandBuffer command_buffer = VK_NULL_HANDLE;
+  const VkCommandBufferAllocateInfo allocate_info = {
+      .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO,
+      .pNext = nullptr,
+      .commandPool = command_pool,
+      .level = VK_COMMAND_BUFFER_LEVEL_PRIMARY,
+      .commandBufferCount = 1,
+  };
+  VkResult result =
+      vkAllocateCommandBuffers(device, &allocate_info, &command_buffer);
+  if (result != VK_SUCCESS) {
+    return result;
+  }
+
+  const VkCommandBufferBeginInfo begin_info = {
+      .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
+      .pNext = nullptr,
+      .flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT,
+      .pInheritanceInfo = nullptr,
+  };
+  result = vkBeginCommandBuffer(command_buffer, &begin_info);
+  if (result != VK_SUCCESS) {
+    vkFreeCommandBuffers(device, command_pool, 1, &command_buffer);
+    return result;
+  }
+
+  const VkImageMemoryBarrier2 image_barrier = {
+      .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2,
+      .pNext = nullptr,
+      .srcStageMask = old_layout == VK_IMAGE_LAYOUT_UNDEFINED
+          ? VK_PIPELINE_STAGE_2_NONE
+          : (VK_PIPELINE_STAGE_2_TRANSFER_BIT |
+             VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT |
+             VK_PIPELINE_STAGE_2_DATA_GRAPH_BIT_ARM),
+      .srcAccessMask = old_layout == VK_IMAGE_LAYOUT_UNDEFINED
+          ? VK_ACCESS_2_NONE
+          : (VK_ACCESS_2_TRANSFER_READ_BIT | VK_ACCESS_2_TRANSFER_WRITE_BIT |
+             VK_ACCESS_2_SHADER_READ_BIT | VK_ACCESS_2_SHADER_WRITE_BIT |
+             VK_ACCESS_2_DATA_GRAPH_READ_BIT_ARM |
+             VK_ACCESS_2_DATA_GRAPH_WRITE_BIT_ARM),
+
+      .dstStageMask = VK_PIPELINE_STAGE_2_TRANSFER_BIT |
+          VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT |
+          VK_PIPELINE_STAGE_2_DATA_GRAPH_BIT_ARM,
+      .dstAccessMask = VK_ACCESS_2_TRANSFER_READ_BIT |
+          VK_ACCESS_2_TRANSFER_WRITE_BIT | VK_ACCESS_2_SHADER_READ_BIT |
+          VK_ACCESS_2_SHADER_WRITE_BIT | VK_ACCESS_2_DATA_GRAPH_READ_BIT_ARM |
+          VK_ACCESS_2_DATA_GRAPH_WRITE_BIT_ARM,
+      .oldLayout = old_layout,
+      .newLayout = new_layout,
+      .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+      .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+      .image = image,
+      .subresourceRange =
+          {
+              .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
+              .baseMipLevel = 0,
+              .levelCount = 1,
+              .baseArrayLayer = 0,
+              .layerCount = 1,
+          },
+  };
+  const VkDependencyInfo dependency_info = {
+      .sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO,
+      .pNext = nullptr,
+      .memoryBarrierCount = 0,
+      .pMemoryBarriers = nullptr,
+      .bufferMemoryBarrierCount = 0,
+      .pBufferMemoryBarriers = nullptr,
+      .imageMemoryBarrierCount = 1,
+      .pImageMemoryBarriers = &image_barrier,
+  };
+  vkCmdPipelineBarrier2(command_buffer, &dependency_info);
+
+  result = vkEndCommandBuffer(command_buffer);
+  if (result != VK_SUCCESS) {
+    vkFreeCommandBuffers(device, command_pool, 1, &command_buffer);
+    return result;
+  }
+
+  const VkSubmitInfo submit_info = {
+      .sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,
+      .pNext = nullptr,
+      .waitSemaphoreCount = 0,
+      .pWaitSemaphores = nullptr,
+      .pWaitDstStageMask = nullptr,
+      .commandBufferCount = 1,
+      .pCommandBuffers = &command_buffer,
+      .signalSemaphoreCount = 0,
+      .pSignalSemaphores = nullptr,
+  };
+  result = vkQueueSubmit(queue, 1, &submit_info, VK_NULL_HANDLE);
+  if (result == VK_SUCCESS) {
+    result = vkQueueWaitIdle(queue);
+  }
+  vkFreeCommandBuffers(device, command_pool, 1, &command_buffer);
+  return result;
 }
 
 static void debug_print_sequence(
     unique_ptr<vgflib::ModelSequenceTableDecoder>& sequence_decoder) {
+  auto module_type_to_string = [](vgflib::ModuleType type) {
+    switch (type) {
+      case vgflib::ModuleType::GRAPH:
+        return "GRAPH";
+      case vgflib::ModuleType::COMPUTE:
+        return "COMPUTE";
+      default:
+        return "UNKNOWN";
+    }
+  };
   ET_LOG(Info, "VGF Sequences:");
   for (int i = 0; i < sequence_decoder->modelSequenceTableSize(); i++) {
     ET_LOG(
@@ -230,8 +1123,8 @@ static void debug_print_sequence(
         dispatch_shape[2]);
     ET_LOG(
         Info,
-        "    is graph? %d",
-        vgflib::ModuleType::GRAPH == sequence_decoder->getSegmentType(i));
+        "    segment type %s",
+        module_type_to_string(sequence_decoder->getSegmentType(i)));
     ET_LOG(
         Info,
         "    module index %d",
@@ -249,75 +1142,27 @@ static void debug_print_sequence(
   }
 }
 
-#if defined(ET_ARM_VGF_DEBUG)
-static void debug_print_resources(
-    unique_ptr<vgflib::ModelResourceTableDecoder>& resource_decoder) {
-  ET_LOG(Info, "Resources:");
-  for (int i = 0; i < resource_decoder->size(); i++) {
-    ET_LOG(Info, "  MRT entry %d", i);
-    if (!resource_decoder->getDescriptorType(i).has_value()) {
-      ET_LOG(Info, "    DescriptorType NONE");
-    } else {
-      ET_LOG(
-          Info,
-          "    DescriptorType %u, is tensor? %d",
-          resource_decoder->getDescriptorType(i).value(),
-          resource_decoder->getDescriptorType(i).value() ==
-              VK_DESCRIPTOR_TYPE_TENSOR_ARM);
-    }
-    ET_LOG(
-        Info,
-        "    VkFormat %u from vgf format %u",
-        vgflib::ToVkFormat(resource_decoder->getVkFormat(i)),
-        resource_decoder->getVkFormat(i));
-    switch (resource_decoder->getCategory(i)) {
-      case vgflib::ResourceCategory::INPUT:
-      case vgflib::ResourceCategory::OUTPUT: {
-        ET_LOG(Info, "    Category INPUT/OUTPUT");
-        // Log the tensor layout metadata carried in the resource table.
-        auto shape = resource_decoder->getTensorShape(i);
-        const vector<int64_t> the_shape(shape.begin(), shape.end());
-        auto stride = resource_decoder->getTensorStride(i);
-        const vector<int64_t> the_stride(stride.begin(), stride.end());
-        ET_LOG(
-            Info,
-            "    rank %ld, stride rank %ld",
-            the_shape.size(),
-            the_stride.size());
-        for (int j = 0; j < the_shape.size(); j++) {
-          ET_LOG(
-              Info,
-              "      %d: dim %lld",
-              j,
-              static_cast<long long>(the_shape[j]));
-        }
-        // Show the memory property combination the runtime currently targets.
-        ET_LOG(
-            Info,
-            "      memory flags %s",
-            memory_flags_to_string(
-                VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT |
-                VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
-                VK_MEMORY_PROPERTY_HOST_COHERENT_BIT)
-                .c_str());
-        break;
-      }
-      case vgflib::ResourceCategory::INTERMEDIATE:
-        ET_LOG(Info, "    Category INTERMEDIATE");
-        break;
-      case vgflib::ResourceCategory::CONSTANT:
-        ET_LOG(Info, "    Category CONSTANT");
-        break;
-      default:
-        ET_LOG(Info, "    Category UNKNOWN");
-        break;
-    }
+template <typename Handle>
+static const void* log_handle_ptr(Handle handle) {
+  if constexpr (std::is_pointer_v<Handle>) {
+    return handle;
+  } else {
+    return reinterpret_cast<const void*>(static_cast<uintptr_t>(handle));
   }
 }
-#endif
 
 static void debug_print_modules(
     unique_ptr<vgflib::ModuleTableDecoder>& module_decoder) {
+  auto module_type_to_string = [](vgflib::ModuleType type) {
+    switch (type) {
+      case vgflib::ModuleType::GRAPH:
+        return "GRAPH";
+      case vgflib::ModuleType::COMPUTE:
+        return "COMPUTE";
+      default:
+        return "UNKNOWN";
+    }
+  };
   ET_LOG(Info, "VGF Modules:");
   for (int i = 0; i < module_decoder->size(); i++) {
     auto name = string(module_decoder->getModuleName(i));
@@ -325,10 +1170,7 @@ static void debug_print_modules(
     auto type = module_decoder->getModuleType(i);
     auto spirv = module_decoder->getModuleCode(i);
     ET_LOG(Info, "  Module(%d) '%s':", i, name.c_str());
-    ET_LOG(
-        Info,
-        "    is graph? %d",
-        vgflib::ModuleType::GRAPH == module_decoder->getModuleType(i));
+    ET_LOG(Info, "    type %s", module_type_to_string(type));
     ET_LOG(Info, "    entrypoint '%s'", entrypoint.c_str());
     ET_LOG(Info, "    has spirv %d", module_decoder->hasSPIRV(i));
     ET_LOG(
@@ -376,102 +1218,304 @@ bool VgfRepr::process_vgf(
     return false;
   }
 
-  // Parse the sequences in the VGF (while there can be multiple sequences of
-  // COMPUTE and GRAPH segments in the sequence, we currently expect a single
-  // GRAPH segment to be present.
-  const int segment_id = 0;
-
+  // Parse the sequences in the VGF (there can be multiple segments).
   debug_print_sequence(sequence_decoder);
-#if defined(ET_ARM_VGF_DEBUG)
-  debug_print_resources(resource_decoder);
-#endif
-  if (sequence_decoder->modelSequenceTableSize() != 1) {
-    ET_LOG(Error, "Expected sequence length 1");
-    return false;
-  }
-  if (sequence_decoder->getSegmentType(segment_id) !=
-      vgflib::ModuleType::GRAPH) {
-    ET_LOG(Error, "Expected segment to be of type GRAPH");
+  const int segment_count = sequence_decoder->modelSequenceTableSize();
+  if (segment_count <= 0) {
+    ET_LOG(Error, "Expected at least one segment");
     return false;
   }
 
-  // Extract first segment and it's associated module
+  // Extract modules
   debug_print_modules(module_decoder);
-  auto segment_name = string(sequence_decoder->getSegmentName(segment_id));
-  auto segment_module = sequence_decoder->getSegmentModuleIndex(segment_id);
-
-  auto segment_m_name = string(module_decoder->getModuleName(segment_module));
-  auto segment_m_entrypoint =
-      string(module_decoder->getModuleEntryPoint(segment_module));
-  auto segment_m_spirv = module_decoder->getModuleCode(segment_module);
-
-  // Build a shader from the module
-  VkShaderModuleCreateInfo smci{
-      .sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO,
-      .pNext = nullptr,
-      .flags = 0,
-      .codeSize = segment_m_spirv.size() * sizeof(uint32_t),
-      .pCode = segment_m_spirv.begin(),
-  };
-  result = vkCreateShaderModule(vk_device, &smci, nullptr, &vk_shader);
-  if (result != VK_SUCCESS) {
-    ET_LOG(Error, "Failed to load shader from segment %d", segment_module);
-    return false;
-  }
-
-  // Record our shader and entrypoint string
-  vector<tuple<VkShaderModule, string>> shader_modules;
-  shader_modules.push_back({vk_shader, segment_m_entrypoint});
 
   // Load our resource (tensors, constants) into their appropriate Vk objects
-  vector<VkTensorDescriptionARM> descriptors;
-  vector<tuple<VkTensorARM, VkTensorViewARM>> resources;
-  vector<VkDataGraphPipelineConstantARM> constants;
-
+  struct ResourceBinding {
+    VkDescriptorType descriptor_type = VK_DESCRIPTOR_TYPE_MAX_ENUM;
+    VkTensorViewARM tensor_view = VK_NULL_HANDLE;
+    VkBuffer buffer = VK_NULL_HANDLE;
+    VkImageView image_view = VK_NULL_HANDLE;
+    VkSampler sampler = VK_NULL_HANDLE;
+    VkDeviceSize buffer_size = 0;
+  };
+  vector<VkTensorDescriptionARM> descriptors(resource_decoder->size());
+  vector<bool> descriptor_valid(resource_decoder->size(), false);
+  vector<ResourceBinding> resource_bindings(resource_decoder->size());
+  vector<int> resource_index_to_io_index(resource_decoder->size(), -1);
+  struct AliasBacking {
+    VkDeviceMemory memory = VK_NULL_HANDLE;
+    VkDeviceSize allocation_size = 0;
+    uint32_t memory_type_bits = 0;
+    uint32_t memory_type_index = UINT32_MAX;
+    VkMemoryPropertyFlags required_memory_properties = 0;
+    bool requirements_ready = false;
+  };
+  struct AliasGroupUsage {
+    bool has_image = false;
+    bool has_tensor_like = false;
+  };
+  struct AliasImageState {
+    bool needs_tensor_aliasing = false;
+    VkImageLayout current_layout = VK_IMAGE_LAYOUT_UNDEFINED;
+    vector<VkImage> images;
+  };
+  unordered_map<uint32_t, AliasBacking> alias_backings;
+  unordered_map<uint32_t, AliasGroupUsage> alias_group_usage;
+  unordered_map<uint32_t, AliasLogicalContract> alias_logical_contracts;
+  unordered_map<uint32_t, AliasImageState> alias_image_states;
   int IO_count = resource_decoder->size();
+
   for (int i = 0; i < IO_count; i++) {
-    auto resource_type = resource_decoder->getDescriptorType(i).value_or(0);
+    auto alias_group = get_resource_alias_group_id(resource_decoder, i);
+    if (!alias_group.has_value()) {
+      continue;
+    }
+    auto& usage = alias_group_usage[*alias_group];
+    auto descriptor_type = resolve_descriptor_type(resource_decoder, i);
+    if (is_image_descriptor_type(descriptor_type)) {
+      usage.has_image = true;
+    }
+    if (is_tensor_like_descriptor_type(descriptor_type)) {
+      usage.has_tensor_like = true;
+    }
+  }
+
+  auto alias_memory_properties_for_descriptor_type =
+      [](VkDescriptorType descriptor_type) -> VkMemoryPropertyFlags {
+    if (is_tensor_like_descriptor_type(descriptor_type)) {
+      return VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT |
+          VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
+          VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+    }
+    if (is_image_descriptor_type(descriptor_type)) {
+      return VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+    }
+    return 0;
+  };
+
+  for (int i = 0; i < IO_count; i++) {
+    auto alias_group = get_resource_alias_group_id(resource_decoder, i);
+    if (!alias_group.has_value()) {
+      continue;
+    }
+
+    auto resource_type = resolve_descriptor_type(resource_decoder, i);
     auto resource_format = vgflib::ToVkFormat(resource_decoder->getVkFormat(i));
+    auto shape = resource_decoder->getTensorShape(i);
+    auto stride = resource_decoder->getTensorStride(i);
+    const vector<int64_t> the_shape(shape.begin(), shape.end());
+    const vector<int64_t> the_stride(stride.begin(), stride.end());
+
+    if (!validate_alias_group_logical_contract(
+            *alias_group,
+            i,
+            resource_type,
+            resource_format,
+            the_shape,
+            the_stride,
+            &alias_logical_contracts[*alias_group])) {
+      return false;
+    }
+
+    VkMemoryRequirements2 memory_requirements = {
+        .sType = VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2,
+        .pNext = nullptr,
+    };
+    if (resource_type == VK_DESCRIPTOR_TYPE_TENSOR_ARM) {
+      VkTensorDescriptionARM tensor_description;
+      VkTensorARM tensor = VK_NULL_HANDLE;
+      result = create_tensor_unbound(
+          vk_device,
+          resource_format,
+          shape.size() == 0 ? 1 : static_cast<uint32_t>(shape.size()),
+          shape.size() == 0 ? &kScalarSentinelDimension : shape.begin(),
+          static_cast<uint32_t>(stride.size()),
+          stride.begin(),
+          &tensor_description,
+          &tensor,
+          &memory_requirements);
+      if (result != VK_SUCCESS) {
+        ET_LOG(
+            Error,
+            "Failed to query tensor memory requirements for VGF resource %d",
+            i);
+        return false;
+      }
+      destroy_tensor(vk_device, VK_NULL_HANDLE, tensor);
+    } else if (resource_type == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER) {
+      const VkDeviceSize buffer_size = element_count_from_shape(the_shape) *
+          get_format_size(resource_format);
+      VkBuffer buffer = VK_NULL_HANDLE;
+      result = create_buffer_unbound(
+          vk_device,
+          buffer_size,
+          VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
+          &buffer,
+          &memory_requirements);
+      if (result != VK_SUCCESS) {
+        ET_LOG(
+            Error,
+            "Failed to query buffer memory requirements for VGF resource %d",
+            i);
+        return false;
+      }
+      destroy_buffer(vk_device, buffer);
+    } else if (is_image_descriptor_type(resource_type)) {
+      VkExtent3D image_extent = {};
+      if (!validate_image_shape_and_format(
+              the_shape, resource_format, &image_extent)) {
+        return false;
+      }
+      const VkImageUsageFlags image_usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
+          VK_IMAGE_USAGE_TRANSFER_DST_BIT |
+          ((alias_group_usage[*alias_group].has_tensor_like)
+               ? VK_IMAGE_USAGE_TENSOR_ALIASING_BIT_ARM
+               : 0) |
+          ((resource_type == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE)
+               ? VK_IMAGE_USAGE_STORAGE_BIT
+               : VK_IMAGE_USAGE_SAMPLED_BIT);
+      VkImage image = VK_NULL_HANDLE;
+      result = create_image_unbound(
+          vk_device,
+          resource_format,
+          image_extent,
+          image_usage,
+          &image,
+          &memory_requirements);
+      if (result != VK_SUCCESS) {
+        ET_LOG(
+            Error,
+            "Failed to query image memory requirements for VGF resource %d",
+            i);
+        return false;
+      }
+      vkDestroyImage(vk_device, image, nullptr);
+    } else {
+      ET_LOG(
+          Error,
+          "Alias group %u contains unsupported resource %d",
+          *alias_group,
+          i);
+      return false;
+    }
+
+    auto& alias_backing = alias_backings[*alias_group];
+    if (!alias_backing.requirements_ready) {
+      alias_backing.requirements_ready = true;
+      alias_backing.allocation_size =
+          memory_requirements.memoryRequirements.size;
+      alias_backing.memory_type_bits =
+          memory_requirements.memoryRequirements.memoryTypeBits;
+      alias_backing.required_memory_properties =
+          alias_memory_properties_for_descriptor_type(resource_type);
+    } else {
+      alias_backing.allocation_size = std::max(
+          alias_backing.allocation_size,
+          memory_requirements.memoryRequirements.size);
+      alias_backing.memory_type_bits &=
+          memory_requirements.memoryRequirements.memoryTypeBits;
+      alias_backing.required_memory_properties |=
+          alias_memory_properties_for_descriptor_type(resource_type);
+    }
+  }
+
+  for (auto& [alias_group, alias_backing] : alias_backings) {
+    if (!alias_backing.requirements_ready) {
+      continue;
+    }
+    if (alias_backing.memory_type_bits == 0) {
+      ET_LOG(
+          Error,
+          "Alias group %u has no common Vulkan memory type bits",
+          alias_group);
+      return false;
+    }
+    if (!find_memory_index_from_bits(
+            vk_physical,
+            alias_backing.memory_type_bits,
+            alias_backing.required_memory_properties,
+            &alias_backing.memory_type_index)) {
+      ET_LOG(
+          Error,
+          "Alias group %u has no compatible Vulkan memory type",
+          alias_group);
+      return false;
+    }
+  }
+
+  for (int i = 0; i < IO_count; i++) {
+    auto resource_type = resolve_descriptor_type(resource_decoder, i);
+    auto resource_format = vgflib::ToVkFormat(resource_decoder->getVkFormat(i));
+    auto alias_group = get_resource_alias_group_id(resource_decoder, i);
 
     // Get tensor shape and strides
     auto shape = resource_decoder->getTensorShape(i);
     auto stride = resource_decoder->getTensorStride(i);
+    const vector<int64_t> the_shape(shape.begin(), shape.end());
+    const vector<int64_t> the_stride(stride.begin(), stride.end());
     const auto shape_size = shape.size();
+    const bool uses_alias_group = alias_group.has_value();
+
+    auto get_alias_backing = [&]() -> AliasBacking* {
+      if (!uses_alias_group) {
+        return nullptr;
+      }
+      return &alias_backings[*alias_group];
+    };
+
+    auto prepare_alias_memory =
+        [&](const VkMemoryRequirements2& memory_requirements,
+            const char* resource_kind,
+            VkDeviceMemory* memory_out,
+            bool* owns_memory_out) -> bool {
+      auto* alias_backing = get_alias_backing();
+      if (alias_backing == nullptr) {
+        return false;
+      }
+
+      const uint32_t type_mask = 1u << alias_backing->memory_type_index;
+      if ((memory_requirements.memoryRequirements.memoryTypeBits & type_mask) ==
+              0 ||
+          memory_requirements.memoryRequirements.size >
+              alias_backing->allocation_size) {
+        ET_LOG(
+            Error,
+            "Alias group %u is incompatible with %s resource %d",
+            *alias_group,
+            resource_kind,
+            i);
+        return false;
+      }
+
+      if (alias_backing->memory == VK_NULL_HANDLE) {
+        const VkMemoryAllocateInfo allocate_info = {
+            .sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
+            .pNext = nullptr,
+            .allocationSize = alias_backing->allocation_size,
+            .memoryTypeIndex = alias_backing->memory_type_index,
+        };
+        VkResult alias_alloc_result = vkAllocateMemory(
+            vk_device, &allocate_info, nullptr, &alias_backing->memory);
+        if (alias_alloc_result != VK_SUCCESS) {
+          ET_LOG(
+              Error,
+              "Failed to allocate aliased %s memory for VGF resource %d",
+              resource_kind,
+              i);
+          return false;
+        }
+        *owns_memory_out = true;
+      } else {
+        *owns_memory_out = false;
+      }
+
+      *memory_out = alias_backing->memory;
+      return true;
+    };
 
     switch (resource_decoder->getCategory(i)) {
       case vgflib::ResourceCategory::INPUT:
       case vgflib::ResourceCategory::OUTPUT: {
-        // Expect IO to be a tensor type
-        if (resource_type != VK_DESCRIPTOR_TYPE_TENSOR_ARM) {
-          ET_LOG(
-              Error,
-              "Expected tensor type descriptor %u got %u",
-              VK_DESCRIPTOR_TYPE_TENSOR_ARM,
-              resource_type);
-          return false;
-        }
-
-        // Allocate a tensor with backing memory
-        VkTensorARM tensor;
-        VkTensorViewARM tensor_view;
-        VkDeviceMemory tensor_memory;
-        VkTensorDescriptionARM tensor_description;
-        result = allocate_tensor(
-            vk_physical,
-            vk_device,
-            resource_format,
-            shape_size == 0 ? 1 : static_cast<uint32_t>(shape_size),
-            shape_size == 0 ? &kScalarSentinelDimension : shape.begin(),
-            static_cast<uint32_t>(stride.size()),
-            stride.begin(),
-            &tensor_description,
-            &tensor_view,
-            &tensor,
-            &tensor_memory);
-        if (result != VK_SUCCESS) {
-          ET_LOG(Error, "Failed to allocate tensor for VGF resource %d", i);
-          return false;
-        }
         size_t e_size = get_format_size(resource_format);
         if (0 == e_size) {
           ET_LOG(Error, "failed to get element size of VkFormat");
@@ -480,21 +1524,394 @@ bool VgfRepr::process_vgf(
 
         bool is_in =
             resource_decoder->getCategory(i) == vgflib::ResourceCategory::INPUT;
-        IOs.push_back(
-            IO{vector<int64_t>(shape.begin(), shape.end()),
-               vector<int64_t>(stride.begin(), stride.end()),
-               e_size,
-               tensor,
-               tensor_view,
-               tensor_memory,
-               is_in});
-        resources.push_back({tensor, tensor_view});
-        descriptors.push_back(tensor_description);
+
+        if (resource_type == VK_DESCRIPTOR_TYPE_TENSOR_ARM) {
+          VkTensorARM tensor = VK_NULL_HANDLE;
+          VkTensorViewARM tensor_view = VK_NULL_HANDLE;
+          VkTensorDescriptionARM tensor_description;
+          VkMemoryRequirements2 tensor_memory_requirements = {
+              .sType = VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2,
+              .pNext = nullptr,
+          };
+          result = create_tensor_unbound(
+              vk_device,
+              resource_format,
+              shape_size == 0 ? 1 : static_cast<uint32_t>(shape_size),
+              shape_size == 0 ? &kScalarSentinelDimension : shape.begin(),
+              static_cast<uint32_t>(stride.size()),
+              stride.begin(),
+              &tensor_description,
+              &tensor,
+              &tensor_memory_requirements);
+          if (result != VK_SUCCESS) {
+            ET_LOG(Error, "Failed to allocate tensor for VGF resource %d", i);
+            return false;
+          }
+          VkDeviceMemory tensor_memory = VK_NULL_HANDLE;
+          bool owns_memory = true;
+          auto* alias_backing = get_alias_backing();
+          if (alias_backing != nullptr) {
+            if (!prepare_alias_memory(
+                    tensor_memory_requirements,
+                    "tensor",
+                    &tensor_memory,
+                    &owns_memory)) {
+              destroy_tensor(vk_device, VK_NULL_HANDLE, tensor);
+              return false;
+            }
+          } else {
+            const VkMemoryPropertyFlags aims =
+                VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT |
+                VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
+                VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+            result = allocate_memory(
+                vk_physical,
+                vk_device,
+                tensor_memory_requirements,
+                aims,
+                &tensor_memory);
+            if (result != VK_SUCCESS) {
+              destroy_tensor(vk_device, VK_NULL_HANDLE, tensor);
+              ET_LOG(
+                  Error,
+                  "Failed to allocate tensor memory for VGF resource %d",
+                  i);
+              return false;
+            }
+          }
+          result = bind_tensor_memory_and_create_view(
+              vk_device, resource_format, tensor, tensor_memory, &tensor_view);
+          if (result != VK_SUCCESS) {
+            if (owns_memory) {
+              vkFreeMemory(vk_device, tensor_memory, nullptr);
+            }
+            destroy_tensor(vk_device, VK_NULL_HANDLE, tensor);
+            ET_LOG(Error, "Failed to bind tensor for VGF resource %d", i);
+            return false;
+          }
+
+          IOs.push_back(
+              IO{the_shape,
+                 the_stride,
+                 e_size,
+                 element_count_from_shape(the_shape) * e_size,
+                 VK_DESCRIPTOR_TYPE_TENSOR_ARM,
+                 tensor,
+                 tensor_view,
+                 VK_NULL_HANDLE,
+                 VK_NULL_HANDLE,
+                 VK_NULL_HANDLE,
+                 VK_NULL_HANDLE,
+                 VK_NULL_HANDLE,
+                 tensor_memory,
+                 {0, 0, 0},
+                 owns_memory,
+                 true,
+                 is_in});
+          resource_index_to_io_index[i] = static_cast<int>(IOs.size() - 1);
+
+          resource_bindings[i] = ResourceBinding{
+              .descriptor_type = VK_DESCRIPTOR_TYPE_TENSOR_ARM,
+              .tensor_view = tensor_view,
+              .buffer = VK_NULL_HANDLE,
+              .image_view = VK_NULL_HANDLE,
+              .sampler = VK_NULL_HANDLE,
+              .buffer_size = 0,
+          };
+          descriptors[i] = tensor_description;
+          descriptor_valid[i] = true;
+        } else if (resource_type == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER) {
+          VkDeviceSize buffer_size =
+              element_count_from_shape(the_shape) * e_size;
+
+          VkBuffer buffer = VK_NULL_HANDLE;
+          VkMemoryRequirements2 buffer_memory_requirements = {
+              .sType = VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2,
+              .pNext = nullptr,
+          };
+          result = create_buffer_unbound(
+              vk_device,
+              buffer_size,
+              VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
+              &buffer,
+              &buffer_memory_requirements);
+          if (result != VK_SUCCESS) {
+            ET_LOG(Error, "Failed to allocate buffer for VGF resource %d", i);
+            return false;
+          }
+          VkDeviceMemory buffer_memory = VK_NULL_HANDLE;
+          bool owns_memory = true;
+          auto* alias_backing = get_alias_backing();
+          if (alias_backing != nullptr) {
+            if (!prepare_alias_memory(
+                    buffer_memory_requirements,
+                    "buffer",
+                    &buffer_memory,
+                    &owns_memory)) {
+              destroy_buffer(vk_device, buffer);
+              return false;
+            }
+          } else {
+            const VkMemoryPropertyFlags aims =
+                VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT |
+                VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
+                VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+            result = allocate_memory(
+                vk_physical,
+                vk_device,
+                buffer_memory_requirements,
+                aims,
+                &buffer_memory);
+            if (result != VK_SUCCESS) {
+              destroy_buffer(vk_device, buffer);
+              ET_LOG(
+                  Error,
+                  "Failed to allocate buffer memory for VGF resource %d",
+                  i);
+              return false;
+            }
+          }
+          result = bind_buffer_memory(vk_device, buffer, buffer_memory);
+          if (result != VK_SUCCESS) {
+            if (owns_memory) {
+              vkFreeMemory(vk_device, buffer_memory, nullptr);
+            }
+            destroy_buffer(vk_device, buffer);
+            ET_LOG(
+                Error, "Failed to bind buffer memory for VGF resource %d", i);
+            return false;
+          }
+
+          IOs.push_back(
+              IO{the_shape,
+                 the_stride,
+                 e_size,
+                 static_cast<size_t>(buffer_size),
+                 VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+                 VK_NULL_HANDLE,
+                 VK_NULL_HANDLE,
+                 buffer,
+                 VK_NULL_HANDLE,
+                 VK_NULL_HANDLE,
+                 VK_NULL_HANDLE,
+                 VK_NULL_HANDLE,
+                 buffer_memory,
+                 {0, 0, 0},
+                 owns_memory,
+                 true,
+                 is_in});
+          resource_index_to_io_index[i] = static_cast<int>(IOs.size() - 1);
+
+          resource_bindings[i] = ResourceBinding{
+              .descriptor_type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+              .tensor_view = VK_NULL_HANDLE,
+              .buffer = buffer,
+              .image_view = VK_NULL_HANDLE,
+              .sampler = VK_NULL_HANDLE,
+              .buffer_size = buffer_size,
+          };
+        } else if (
+            resource_type == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER ||
+            resource_type == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE ||
+            resource_type == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE) {
+          VkExtent3D image_extent = {};
+          size_t image_allocation_size = 0;
+          if (!validate_image_shape_and_format(
+                  the_shape,
+                  resource_format,
+                  &image_extent,
+                  &image_allocation_size)) {
+            return false;
+          }
+          const VkImageUsageFlags image_usage =
+              VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
+              VK_IMAGE_USAGE_TRANSFER_DST_BIT |
+              ((uses_alias_group &&
+                alias_group_usage[*alias_group].has_tensor_like)
+                   ? VK_IMAGE_USAGE_TENSOR_ALIASING_BIT_ARM
+                   : 0) |
+              ((resource_type == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE)
+                   ? VK_IMAGE_USAGE_STORAGE_BIT
+                   : VK_IMAGE_USAGE_SAMPLED_BIT);
+          VkImage image = VK_NULL_HANDLE;
+          VkImageView image_view = VK_NULL_HANDLE;
+          VkMemoryRequirements2 image_memory_requirements = {
+              .sType = VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2,
+              .pNext = nullptr,
+          };
+          result = create_image_unbound(
+              vk_device,
+              resource_format,
+              image_extent,
+              image_usage,
+              &image,
+              &image_memory_requirements);
+          if (result != VK_SUCCESS) {
+            ET_LOG(Error, "Failed to allocate image for VGF resource %d", i);
+            return false;
+          }
+          VkDeviceMemory image_memory = VK_NULL_HANDLE;
+          bool owns_image_memory = true;
+          auto* alias_backing = get_alias_backing();
+          if (alias_backing != nullptr) {
+            if (!prepare_alias_memory(
+                    image_memory_requirements,
+                    "image",
+                    &image_memory,
+                    &owns_image_memory)) {
+              free_image(
+                  vk_device,
+                  VK_NULL_HANDLE,
+                  image,
+                  VK_NULL_HANDLE,
+                  VK_NULL_HANDLE);
+              return false;
+            }
+          } else {
+            const VkMemoryPropertyFlags aims =
+                VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+            result = allocate_memory(
+                vk_physical,
+                vk_device,
+                image_memory_requirements,
+                aims,
+                &image_memory);
+            if (result != VK_SUCCESS) {
+              free_image(
+                  vk_device,
+                  VK_NULL_HANDLE,
+                  image,
+                  VK_NULL_HANDLE,
+                  VK_NULL_HANDLE);
+              ET_LOG(
+                  Error,
+                  "Failed to allocate image memory for VGF resource %d",
+                  i);
+              return false;
+            }
+          }
+          result = bind_image_memory_and_create_view(
+              vk_device, resource_format, image, image_memory, &image_view);
+          if (result != VK_SUCCESS) {
+            free_image(
+                vk_device,
+                VK_NULL_HANDLE,
+                image,
+                VK_NULL_HANDLE,
+                owns_image_memory ? image_memory : VK_NULL_HANDLE);
+            ET_LOG(Error, "Failed to bind image for VGF resource %d", i);
+            return false;
+          }
+          const bool needs_tensor_aliasing = uses_alias_group &&
+              alias_group_usage[*alias_group].has_tensor_like;
+          const VkImageLayout initial_layout = needs_tensor_aliasing
+              ? VK_IMAGE_LAYOUT_TENSOR_ALIASING_ARM
+              : VK_IMAGE_LAYOUT_GENERAL;
+          result = transition_image_layout(
+              vk_device,
+              vk_command_pool,
+              vk_queue,
+              image,
+              VK_IMAGE_LAYOUT_UNDEFINED,
+              initial_layout);
+          if (result != VK_SUCCESS) {
+            ET_LOG(Error, "Failed to transition image for VGF resource %d", i);
+            free_image(
+                vk_device,
+                image_view,
+                image,
+                VK_NULL_HANDLE,
+                owns_image_memory ? image_memory : VK_NULL_HANDLE);
+            return false;
+          }
+
+          VkSampler sampler = VK_NULL_HANDLE;
+          if (resource_type == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER) {
+            if (!allocate_resource_sampler(
+                    resource_decoder, i, vk_device, &sampler)) {
+              free_image(
+                  vk_device,
+                  image_view,
+                  image,
+                  VK_NULL_HANDLE,
+                  owns_image_memory ? image_memory : VK_NULL_HANDLE);
+              return false;
+            }
+          }
+          if (uses_alias_group) {
+            auto& alias_state = alias_image_states[*alias_group];
+            alias_state.needs_tensor_aliasing = needs_tensor_aliasing;
+            alias_state.current_layout = initial_layout;
+            alias_state.images.push_back(image);
+          }
+          VkBuffer staging_buffer = VK_NULL_HANDLE;
+          VkDeviceMemory staging_memory = VK_NULL_HANDLE;
+          result = allocate_buffer(
+              vk_physical,
+              vk_device,
+              image_allocation_size,
+              VK_BUFFER_USAGE_TRANSFER_SRC_BIT |
+                  VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+              &staging_buffer,
+              &staging_memory);
+          if (result != VK_SUCCESS) {
+            ET_LOG(
+                Error,
+                "Failed to allocate staging buffer for image VGF resource %d",
+                i);
+            free_image(
+                vk_device,
+                image_view,
+                image,
+                sampler,
+                owns_image_memory ? image_memory : VK_NULL_HANDLE);
+            return false;
+          }
+
+          IOs.push_back(
+              IO{the_shape,
+                 the_stride,
+                 e_size,
+                 image_allocation_size,
+                 resource_type,
+                 VK_NULL_HANDLE,
+                 VK_NULL_HANDLE,
+                 staging_buffer,
+                 image,
+                 image_view,
+                 sampler,
+                 image_memory,
+                 staging_memory,
+                 image_extent,
+                 true,
+                 owns_image_memory,
+                 is_in});
+          resource_index_to_io_index[i] = static_cast<int>(IOs.size() - 1);
+
+          resource_bindings[i] = ResourceBinding{
+              .descriptor_type = resource_type,
+              .tensor_view = VK_NULL_HANDLE,
+              .buffer = VK_NULL_HANDLE,
+              .image_view = image_view,
+              .sampler = sampler,
+              .buffer_size = image_allocation_size,
+          };
+          descriptors[i] = make_data_graph_descriptor(
+              resource_format,
+              shape_size == 0 ? 1 : static_cast<uint32_t>(shape_size),
+              shape_size == 0 ? &kScalarSentinelDimension : shape.begin(),
+              static_cast<uint32_t>(stride.size()),
+              stride.begin());
+          descriptor_valid[i] = true;
+        } else {
+          ET_LOG(Error, "Unsupported descriptor type %u", resource_type);
+          return false;
+        }
         break;
       }
       case vgflib::ResourceCategory::CONSTANT:
-        // Constants just need a descriptor
-        descriptors.push_back(VkTensorDescriptionARM{
+        // Constants just need a descriptor; only graph segments can bind them.
+        descriptors[i] = VkTensorDescriptionARM{
             .sType = VK_STRUCTURE_TYPE_TENSOR_DESCRIPTION_ARM,
             .pNext = nullptr,
             .tiling = VK_TENSOR_TILING_LINEAR_ARM,
@@ -506,259 +1923,955 @@ bool VgfRepr::process_vgf(
             // Note: stride_data of 0's causes size==0, null means stride==size
             .pStrides = (0 == stride.size() ? nullptr : stride.begin()),
             .usage = VK_TENSOR_USAGE_DATA_GRAPH_BIT_ARM,
-        });
+        };
+        descriptor_valid[i] = true;
         break;
-      case vgflib::ResourceCategory::INTERMEDIATE:
-        ET_LOG(Error, "Unsupported resource category INTERMEDIATE");
-        return false;
+      case vgflib::ResourceCategory::INTERMEDIATE: {
+        size_t e_size = get_format_size(resource_format);
+        if (0 == e_size) {
+          ET_LOG(Error, "failed to get element size of VkFormat");
+          return false;
+        }
+        if (resource_type == VK_DESCRIPTOR_TYPE_TENSOR_ARM) {
+          VkTensorARM tensor = VK_NULL_HANDLE;
+          VkTensorViewARM tensor_view = VK_NULL_HANDLE;
+          VkTensorDescriptionARM tensor_description;
+          VkMemoryRequirements2 tensor_memory_requirements = {
+              .sType = VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2,
+              .pNext = nullptr,
+          };
+          result = create_tensor_unbound(
+              vk_device,
+              resource_format,
+              shape_size == 0 ? 1 : static_cast<uint32_t>(shape_size),
+              shape_size == 0 ? &kScalarSentinelDimension : shape.begin(),
+              static_cast<uint32_t>(stride.size()),
+              stride.begin(),
+              &tensor_description,
+              &tensor,
+              &tensor_memory_requirements);
+          if (result != VK_SUCCESS) {
+            ET_LOG(Error, "Failed to allocate tensor for VGF resource %d", i);
+            return false;
+          }
+          VkDeviceMemory tensor_memory = VK_NULL_HANDLE;
+          bool owns_memory = true;
+          auto* alias_backing = get_alias_backing();
+          if (alias_backing != nullptr) {
+            if (!prepare_alias_memory(
+                    tensor_memory_requirements,
+                    "tensor",
+                    &tensor_memory,
+                    &owns_memory)) {
+              destroy_tensor(vk_device, VK_NULL_HANDLE, tensor);
+              return false;
+            }
+          } else {
+            const VkMemoryPropertyFlags aims =
+                VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT |
+                VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
+                VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+            result = allocate_memory(
+                vk_physical,
+                vk_device,
+                tensor_memory_requirements,
+                aims,
+                &tensor_memory);
+            if (result != VK_SUCCESS) {
+              destroy_tensor(vk_device, VK_NULL_HANDLE, tensor);
+              ET_LOG(
+                  Error,
+                  "Failed to allocate tensor memory for VGF resource %d",
+                  i);
+              return false;
+            }
+          }
+          result = bind_tensor_memory_and_create_view(
+              vk_device, resource_format, tensor, tensor_memory, &tensor_view);
+          if (result != VK_SUCCESS) {
+            if (owns_memory) {
+              vkFreeMemory(vk_device, tensor_memory, nullptr);
+            }
+            destroy_tensor(vk_device, VK_NULL_HANDLE, tensor);
+            ET_LOG(Error, "Failed to bind tensor for VGF resource %d", i);
+            return false;
+          }
+
+          extra_allocs.push_back(ResourceAlloc{
+              .descriptor_type = VK_DESCRIPTOR_TYPE_TENSOR_ARM,
+              .tensor = tensor,
+              .tensor_view = tensor_view,
+              .buffer = VK_NULL_HANDLE,
+              .image = VK_NULL_HANDLE,
+              .image_view = VK_NULL_HANDLE,
+              .sampler = VK_NULL_HANDLE,
+              .image_memory = VK_NULL_HANDLE,
+              .memory = tensor_memory,
+              .owns_memory = owns_memory,
+              .owns_image_memory = true,
+          });
+
+          resource_bindings[i] = ResourceBinding{
+              .descriptor_type = VK_DESCRIPTOR_TYPE_TENSOR_ARM,
+              .tensor_view = tensor_view,
+              .buffer = VK_NULL_HANDLE,
+              .image_view = VK_NULL_HANDLE,
+              .sampler = VK_NULL_HANDLE,
+              .buffer_size = 0,
+          };
+          descriptors[i] = tensor_description;
+          descriptor_valid[i] = true;
+        } else if (resource_type == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER) {
+          VkDeviceSize buffer_size =
+              element_count_from_shape(the_shape) * e_size;
+
+          VkBuffer buffer = VK_NULL_HANDLE;
+          VkMemoryRequirements2 buffer_memory_requirements = {
+              .sType = VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2,
+              .pNext = nullptr,
+          };
+          result = create_buffer_unbound(
+              vk_device,
+              buffer_size,
+              VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
+              &buffer,
+              &buffer_memory_requirements);
+          if (result != VK_SUCCESS) {
+            ET_LOG(Error, "Failed to allocate buffer for VGF resource %d", i);
+            return false;
+          }
+          VkDeviceMemory buffer_memory = VK_NULL_HANDLE;
+          bool owns_memory = true;
+          auto* alias_backing = get_alias_backing();
+          if (alias_backing != nullptr) {
+            if (!prepare_alias_memory(
+                    buffer_memory_requirements,
+                    "buffer",
+                    &buffer_memory,
+                    &owns_memory)) {
+              destroy_buffer(vk_device, buffer);
+              return false;
+            }
+          } else {
+            const VkMemoryPropertyFlags aims =
+                VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT |
+                VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
+                VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+            result = allocate_memory(
+                vk_physical,
+                vk_device,
+                buffer_memory_requirements,
+                aims,
+                &buffer_memory);
+            if (result != VK_SUCCESS) {
+              destroy_buffer(vk_device, buffer);
+              ET_LOG(
+                  Error,
+                  "Failed to allocate buffer memory for VGF resource %d",
+                  i);
+              return false;
+            }
+          }
+          result = bind_buffer_memory(vk_device, buffer, buffer_memory);
+          if (result != VK_SUCCESS) {
+            if (owns_memory) {
+              vkFreeMemory(vk_device, buffer_memory, nullptr);
+            }
+            destroy_buffer(vk_device, buffer);
+            ET_LOG(
+                Error, "Failed to bind buffer memory for VGF resource %d", i);
+            return false;
+          }
+
+          extra_allocs.push_back(ResourceAlloc{
+              .descriptor_type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+              .tensor = VK_NULL_HANDLE,
+              .tensor_view = VK_NULL_HANDLE,
+              .buffer = buffer,
+              .image = VK_NULL_HANDLE,
+              .image_view = VK_NULL_HANDLE,
+              .sampler = VK_NULL_HANDLE,
+              .image_memory = VK_NULL_HANDLE,
+              .memory = buffer_memory,
+              .owns_memory = owns_memory,
+              .owns_image_memory = true,
+          });
+
+          resource_bindings[i] = ResourceBinding{
+              .descriptor_type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+              .tensor_view = VK_NULL_HANDLE,
+              .buffer = buffer,
+              .image_view = VK_NULL_HANDLE,
+              .sampler = VK_NULL_HANDLE,
+              .buffer_size = buffer_size,
+          };
+        } else if (
+            resource_type == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER ||
+            resource_type == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE ||
+            resource_type == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE) {
+          VkExtent3D image_extent = {};
+          if (!validate_image_shape_and_format(
+                  the_shape, resource_format, &image_extent)) {
+            return false;
+          }
+          const VkImageUsageFlags image_usage =
+              VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
+              VK_IMAGE_USAGE_TRANSFER_DST_BIT |
+              ((uses_alias_group &&
+                alias_group_usage[*alias_group].has_tensor_like)
+                   ? VK_IMAGE_USAGE_TENSOR_ALIASING_BIT_ARM
+                   : 0) |
+              ((resource_type == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE)
+                   ? VK_IMAGE_USAGE_STORAGE_BIT
+                   : VK_IMAGE_USAGE_SAMPLED_BIT);
+          VkImage image = VK_NULL_HANDLE;
+          VkImageView image_view = VK_NULL_HANDLE;
+          VkMemoryRequirements2 image_memory_requirements = {
+              .sType = VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2,
+              .pNext = nullptr,
+          };
+          result = create_image_unbound(
+              vk_device,
+              resource_format,
+              image_extent,
+              image_usage,
+              &image,
+              &image_memory_requirements);
+          if (result != VK_SUCCESS) {
+            ET_LOG(Error, "Failed to allocate image for VGF resource %d", i);
+            return false;
+          }
+          VkDeviceMemory image_memory = VK_NULL_HANDLE;
+          bool owns_image_memory = true;
+          auto* alias_backing = get_alias_backing();
+          if (alias_backing != nullptr) {
+            if (!prepare_alias_memory(
+                    image_memory_requirements,
+                    "image",
+                    &image_memory,
+                    &owns_image_memory)) {
+              free_image(
+                  vk_device,
+                  VK_NULL_HANDLE,
+                  image,
+                  VK_NULL_HANDLE,
+                  VK_NULL_HANDLE);
+              return false;
+            }
+          } else {
+            const VkMemoryPropertyFlags aims =
+                VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+            result = allocate_memory(
+                vk_physical,
+                vk_device,
+                image_memory_requirements,
+                aims,
+                &image_memory);
+            if (result != VK_SUCCESS) {
+              free_image(
+                  vk_device,
+                  VK_NULL_HANDLE,
+                  image,
+                  VK_NULL_HANDLE,
+                  VK_NULL_HANDLE);
+              ET_LOG(
+                  Error,
+                  "Failed to allocate image memory for VGF resource %d",
+                  i);
+              return false;
+            }
+          }
+          result = bind_image_memory_and_create_view(
+              vk_device, resource_format, image, image_memory, &image_view);
+          if (result != VK_SUCCESS) {
+            free_image(
+                vk_device,
+                VK_NULL_HANDLE,
+                image,
+                VK_NULL_HANDLE,
+                owns_image_memory ? image_memory : VK_NULL_HANDLE);
+            ET_LOG(Error, "Failed to bind image for VGF resource %d", i);
+            return false;
+          }
+          const bool needs_tensor_aliasing = uses_alias_group &&
+              alias_group_usage[*alias_group].has_tensor_like;
+          const VkImageLayout initial_layout = needs_tensor_aliasing
+              ? VK_IMAGE_LAYOUT_TENSOR_ALIASING_ARM
+              : VK_IMAGE_LAYOUT_GENERAL;
+          result = transition_image_layout(
+              vk_device,
+              vk_command_pool,
+              vk_queue,
+              image,
+              VK_IMAGE_LAYOUT_UNDEFINED,
+              initial_layout);
+          if (result != VK_SUCCESS) {
+            ET_LOG(Error, "Failed to transition image for VGF resource %d", i);
+            free_image(
+                vk_device,
+                image_view,
+                image,
+                VK_NULL_HANDLE,
+                owns_image_memory ? image_memory : VK_NULL_HANDLE);
+            return false;
+          }
+
+          VkSampler sampler = VK_NULL_HANDLE;
+          if (resource_type == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER) {
+            if (!allocate_resource_sampler(
+                    resource_decoder, i, vk_device, &sampler)) {
+              free_image(
+                  vk_device,
+                  image_view,
+                  image,
+                  VK_NULL_HANDLE,
+                  owns_image_memory ? image_memory : VK_NULL_HANDLE);
+              return false;
+            }
+          }
+          if (uses_alias_group) {
+            auto& alias_state = alias_image_states[*alias_group];
+            alias_state.needs_tensor_aliasing = needs_tensor_aliasing;
+            alias_state.current_layout = initial_layout;
+            alias_state.images.push_back(image);
+          }
+
+          extra_allocs.push_back(ResourceAlloc{
+              .descriptor_type = resource_type,
+              .tensor = VK_NULL_HANDLE,
+              .tensor_view = VK_NULL_HANDLE,
+              .buffer = VK_NULL_HANDLE,
+              .image = image,
+              .image_view = image_view,
+              .sampler = sampler,
+              .image_memory = image_memory,
+              .memory = VK_NULL_HANDLE,
+              .owns_memory = true,
+              .owns_image_memory = owns_image_memory,
+          });
+
+          resource_bindings[i] = ResourceBinding{
+              .descriptor_type = resource_type,
+              .tensor_view = VK_NULL_HANDLE,
+              .buffer = VK_NULL_HANDLE,
+              .image_view = image_view,
+              .sampler = sampler,
+              .buffer_size = 0,
+          };
+          descriptors[i] = make_data_graph_descriptor(
+              resource_format,
+              shape_size == 0 ? 1 : static_cast<uint32_t>(shape_size),
+              shape_size == 0 ? &kScalarSentinelDimension : shape.begin(),
+              static_cast<uint32_t>(stride.size()),
+              stride.begin());
+          descriptor_valid[i] = true;
+        } else {
+          ET_LOG(Error, "Unsupported descriptor type %u", resource_type);
+          return false;
+        }
+      } break;
       default:
         ET_LOG(Info, "Unsupported resource category UNKNOWN");
         return false;
     }
   }
 
-  // Constants table - mapping of shader bindings to MRT's and their descriptors
-  auto constant_indexes =
-      sequence_decoder->getSegmentConstantIndexes(segment_id);
-  for (uint32_t i : constant_indexes) {
-    auto mrt_i = constant_decoder->getConstantMrtIndex(i);
-    auto constant_data = constant_decoder->getConstant(i);
-    constants.push_back(VkDataGraphPipelineConstantARM{
-        .sType = VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_CONSTANT_ARM,
-        .pNext = &descriptors[mrt_i],
-        .id = i,
-        .pConstantData = constant_data.begin(),
-    });
-  }
-
-  // Prepare our layout bindings from the segment's information
-  vector<VkDescriptorSetLayoutBinding> layout_bindings;
-  vector<VkDataGraphPipelineResourceInfoARM> data_graph_resources;
-
-  auto set_count =
-      sequence_decoder->getSegmentDescriptorSetInfosSize(segment_id);
-  for (uint32_t d_idx = 0; d_idx < set_count; d_idx++) {
-    auto handle =
-        sequence_decoder->getDescriptorBindingSlotsHandle(segment_id, d_idx);
-    auto binding_count = sequence_decoder->getBindingsSize(handle);
-    for (int binding = 0; binding < binding_count; binding++) {
-      auto binding_index =
-          sequence_decoder->getBindingSlotBinding(handle, binding);
-      auto MRT_index =
-          sequence_decoder->getBindingSlotMrtIndex(handle, binding);
-      auto MRT_type = resource_decoder->getDescriptorType(MRT_index).value();
-
-      const VkDescriptorSetLayoutBinding layout_binding{
-          .binding = binding_index,
-          .descriptorType = vgflib::ToVkDescriptorType(MRT_type),
-          .descriptorCount = 1,
-          .stageFlags = VK_SHADER_STAGE_ALL,
-          .pImmutableSamplers = nullptr,
-      };
-      layout_bindings.push_back(layout_binding);
-
-      const VkDataGraphPipelineResourceInfoARM resource{
-          .sType = VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_RESOURCE_INFO_ARM,
-          // Note: we populate the resource_descriptors 1:1 with the MRT table,
-          // so can directly use that index into the resource_descriptors
-          .pNext = &descriptors[MRT_index],
-          .descriptorSet = d_idx,
-          .binding = binding_index,
-          .arrayElement = 0,
-      };
-      data_graph_resources.push_back(resource);
+  // Build per-segment pipelines and descriptor sets.
+  segments.clear();
+  segments.reserve(segment_count);
+  for (int segment_id = 0; segment_id < segment_count; ++segment_id) {
+    const auto segment_type = sequence_decoder->getSegmentType(segment_id);
+    if (segment_type != vgflib::ModuleType::GRAPH &&
+        segment_type != vgflib::ModuleType::COMPUTE) {
+      ET_LOG(Error, "Unsupported segment type");
+      return false;
     }
-  }
 
-  // create fixed layout for this module
-  const VkDescriptorSetLayoutCreateInfo layout_info = {
-      .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO,
-      .pNext = nullptr,
-      .flags = 0,
-      .bindingCount = static_cast<uint32_t>(layout_bindings.size()),
-      .pBindings = layout_bindings.data(),
-  };
-  result =
-      vkCreateDescriptorSetLayout(vk_device, &layout_info, nullptr, &vk_layout);
-  if (result != VK_SUCCESS) {
-    ET_LOG(Error, "Failed to create descriptor layout");
-    return false;
-  }
+    SegmentState segment;
+    segment.segment_id = segment_id;
+    segment.use_data_graph_pipeline =
+        (segment_type == vgflib::ModuleType::GRAPH);
+    auto dispatch_shape = sequence_decoder->getSegmentDispatchShape(segment_id);
+    segment.dispatch_shape = {
+        dispatch_shape[0], dispatch_shape[1], dispatch_shape[2]};
 
-  std::vector<VkDescriptorPoolSize> poolSizes;
-  poolSizes.reserve(layout_bindings.size());
-  for (const auto& b : layout_bindings) {
-    bool found = false;
-    for (size_t idx = 0; idx < poolSizes.size(); ++idx) {
-      if (poolSizes[idx].type == b.descriptorType) {
-        poolSizes[idx].descriptorCount += b.descriptorCount;
-        found = true;
-        break;
+    auto segment_name = string(sequence_decoder->getSegmentName(segment_id));
+    auto segment_module = sequence_decoder->getSegmentModuleIndex(segment_id);
+    ET_LOG(
+        Info,
+        "VGF segment '%s' module=%u type=%s dispatch=[%u,%u,%u]",
+        segment_name.c_str(),
+        segment_module,
+        segment.use_data_graph_pipeline ? "GRAPH" : "COMPUTE",
+        dispatch_shape[0],
+        dispatch_shape[1],
+        dispatch_shape[2]);
+
+    auto segment_m_name = string(module_decoder->getModuleName(segment_module));
+    auto segment_m_entrypoint =
+        string(module_decoder->getModuleEntryPoint(segment_module));
+    ET_LOG(
+        Info,
+        "VGF module '%s' entrypoint='%s' type=%s has_spirv=%d",
+        segment_m_name.c_str(),
+        segment_m_entrypoint.c_str(),
+        (module_decoder->getModuleType(segment_module) ==
+                 vgflib::ModuleType::GRAPH
+             ? "GRAPH"
+             : "COMPUTE"),
+        module_decoder->hasSPIRV(segment_module));
+    if (!module_decoder->hasSPIRV(segment_module)) {
+      ET_LOG(Error, "Module %d does not contain SPIR-V code", segment_module);
+      return false;
+    }
+    auto segment_m_spirv =
+        get_module_spirv_code(module_decoder, segment_module);
+    ET_LOG(Info, "SPIR-V code size (words) %zu", segment_m_spirv.size());
+
+    VkShaderModuleCreateInfo smci{
+        .sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .codeSize = segment_m_spirv.size() * sizeof(uint32_t),
+        .pCode = segment_m_spirv.begin(),
+    };
+    result =
+        vkCreateShaderModule(vk_device, &smci, nullptr, &segment.vk_shader);
+    if (result != VK_SUCCESS) {
+      ET_LOG(Error, "Failed to load shader from segment %d", segment_module);
+      return false;
+    }
+
+    // Constants table (graph segments only)
+    vector<VkDataGraphPipelineConstantARM> constants;
+    auto constant_indexes =
+        sequence_decoder->getSegmentConstantIndexes(segment_id);
+    if (!segment.use_data_graph_pipeline && !constant_indexes.empty()) {
+      ET_LOG(Error, "Constants are not supported with compute segments");
+      return false;
+    }
+    if (segment.use_data_graph_pipeline) {
+      for (uint32_t i : constant_indexes) {
+        auto mrt_i = constant_decoder->getConstantMrtIndex(i);
+        if (!descriptor_valid[mrt_i]) {
+          ET_LOG(Error, "Missing descriptor for constant MRT index %u", mrt_i);
+          return false;
+        }
+        auto constant_data = constant_decoder->getConstant(i);
+        constants.push_back(VkDataGraphPipelineConstantARM{
+            .sType = VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_CONSTANT_ARM,
+            .pNext = &descriptors[mrt_i],
+            .id = i,
+            .pConstantData = constant_data.begin(),
+        });
       }
     }
-    if (!found) {
-      poolSizes.push_back({b.descriptorType, b.descriptorCount});
+
+    // Prepare layout bindings from this segment's information
+    vector<VkDescriptorSetLayoutBinding> layout_bindings;
+    vector<VkDataGraphPipelineResourceInfoARM> data_graph_resources;
+    auto set_count =
+        sequence_decoder->getSegmentDescriptorSetInfosSize(segment_id);
+    if (set_count != 1) {
+      ET_LOG(
+          Error,
+          "Only a single descriptor set is currently supported, got %zu for segment %d",
+          set_count,
+          segment_id);
+      return false;
+    }
+    for (uint32_t d_idx = 0; d_idx < set_count; d_idx++) {
+      auto handle =
+          sequence_decoder->getDescriptorBindingSlotsHandle(segment_id, d_idx);
+      auto binding_count = sequence_decoder->getBindingsSize(handle);
+      for (int binding = 0; binding < binding_count; binding++) {
+        auto binding_index =
+            sequence_decoder->getBindingSlotBinding(handle, binding);
+        auto MRT_index =
+            sequence_decoder->getBindingSlotMrtIndex(handle, binding);
+        auto MRT_type = resolve_descriptor_type(resource_decoder, MRT_index);
+
+        if (segment.use_data_graph_pipeline &&
+            MRT_type == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER) {
+          ET_LOG(
+              Error, "Storage buffers are not supported with graph segments");
+          return false;
+        }
+
+        const VkDescriptorSetLayoutBinding layout_binding{
+            .binding = binding_index,
+            .descriptorType = MRT_type,
+            .descriptorCount = 1,
+            .stageFlags = VK_SHADER_STAGE_ALL,
+            .pImmutableSamplers = nullptr,
+        };
+        layout_bindings.push_back(layout_binding);
+
+        if (segment.use_data_graph_pipeline) {
+          if (!descriptor_valid[MRT_index]) {
+            ET_LOG(Error, "Missing descriptor for MRT index %u", MRT_index);
+            return false;
+          }
+          const VkDataGraphPipelineResourceInfoARM resource{
+              .sType = VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_RESOURCE_INFO_ARM,
+              .pNext = &descriptors[MRT_index],
+              .descriptorSet = d_idx,
+              .binding = binding_index,
+              .arrayElement = 0,
+          };
+          data_graph_resources.push_back(resource);
+        }
+      }
+    }
+
+    const VkDescriptorSetLayoutCreateInfo layout_info = {
+        .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .bindingCount = static_cast<uint32_t>(layout_bindings.size()),
+        .pBindings = layout_bindings.data(),
+    };
+    result = vkCreateDescriptorSetLayout(
+        vk_device, &layout_info, nullptr, &segment.vk_layout);
+    if (result != VK_SUCCESS) {
+      ET_LOG(Error, "Failed to create descriptor layout");
+      return false;
+    }
+
+    std::vector<VkDescriptorPoolSize> poolSizes;
+    poolSizes.reserve(layout_bindings.size());
+    for (const auto& b : layout_bindings) {
+      bool found = false;
+      for (size_t idx = 0; idx < poolSizes.size(); ++idx) {
+        if (poolSizes[idx].type == b.descriptorType) {
+          poolSizes[idx].descriptorCount += b.descriptorCount;
+          found = true;
+          break;
+        }
+      }
+      if (!found) {
+        poolSizes.push_back({b.descriptorType, b.descriptorCount});
+      }
+    }
+
+    const VkDescriptorPoolCreateInfo descriptor_pool_info = {
+        .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .maxSets = static_cast<uint32_t>(set_count),
+        .poolSizeCount = static_cast<uint32_t>(poolSizes.size()),
+        .pPoolSizes = poolSizes.data(),
+    };
+    result = vkCreateDescriptorPool(
+        vk_device, &descriptor_pool_info, nullptr, &segment.vk_descriptor_pool);
+    if (result != VK_SUCCESS) {
+      ET_LOG(Error, "Failed to create descriptor pool");
+      return false;
+    }
+
+    const VkDescriptorSetAllocateInfo descriptor_set_info = {
+        .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO,
+        .pNext = nullptr,
+        .descriptorPool = segment.vk_descriptor_pool,
+        .descriptorSetCount = static_cast<uint32_t>(set_count),
+        .pSetLayouts = &segment.vk_layout,
+    };
+
+    segment.descriptor_sets.resize(set_count);
+    result = vkAllocateDescriptorSets(
+        vk_device, &descriptor_set_info, segment.descriptor_sets.data());
+    if (result != VK_SUCCESS) {
+      ET_LOG(Error, "Failed to allocate descriptor sets");
+      return false;
+    }
+
+    for (uint32_t d_idx = 0; d_idx < set_count; d_idx++) {
+      const auto set_index =
+          get_segment_descriptor_set_index(sequence_decoder, segment_id, d_idx);
+      if (set_index != d_idx) {
+        ET_LOG(
+            Error,
+            "Explicit descriptor set index %u is not supported for segment %d descriptor %u",
+            set_index,
+            segment_id,
+            d_idx);
+        return false;
+      }
+
+      auto descriptor_slots =
+          sequence_decoder->getDescriptorBindingSlotsHandle(segment_id, d_idx);
+      auto descriptor_count =
+          sequence_decoder->getBindingsSize(descriptor_slots);
+      ET_LOG(
+          Info, "VGF descriptor set %u bindings: %zu", d_idx, descriptor_count);
+      for (uint32_t i = 0; i < descriptor_count; i++) {
+        auto binding =
+            sequence_decoder->getBindingSlotBinding(descriptor_slots, i);
+        auto mrt_i =
+            sequence_decoder->getBindingSlotMrtIndex(descriptor_slots, i);
+        const auto& binding_info = resource_bindings[mrt_i];
+        if (binding_info.descriptor_type == VK_DESCRIPTOR_TYPE_TENSOR_ARM) {
+          ET_LOG(
+              Info,
+              "Updating descriptor: segment=%u set=%u binding=%u mrt=%u type=VK_DESCRIPTOR_TYPE_TENSOR_ARM",
+              segment_id,
+              d_idx,
+              binding,
+              mrt_i);
+          VkWriteDescriptorSetTensorARM write_desc = {
+              .sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_TENSOR_ARM,
+              .pNext = nullptr,
+              .tensorViewCount = 1,
+              .pTensorViews = &binding_info.tensor_view,
+          };
+          VkWriteDescriptorSet desc_set = {
+              .sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
+              .pNext = &write_desc,
+              .dstSet = segment.descriptor_sets[d_idx],
+              .dstBinding = binding,
+              .dstArrayElement = 0,
+              .descriptorCount = 1,
+              .descriptorType = VK_DESCRIPTOR_TYPE_TENSOR_ARM,
+              .pImageInfo = nullptr,
+              .pBufferInfo = nullptr,
+              .pTexelBufferView = nullptr,
+          };
+          vkUpdateDescriptorSets(vk_device, 1, &desc_set, 0, nullptr);
+        } else if (
+            binding_info.descriptor_type == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER) {
+          ET_LOG(
+              Info,
+              "Updating descriptor: segment=%u set=%u binding=%u mrt=%u type=VK_DESCRIPTOR_TYPE_STORAGE_BUFFER",
+              segment_id,
+              d_idx,
+              binding,
+              mrt_i);
+          VkDescriptorBufferInfo buffer_info = {
+              .buffer = binding_info.buffer,
+              .offset = 0,
+              .range = binding_info.buffer_size,
+          };
+          VkWriteDescriptorSet desc_set = {
+              .sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
+              .pNext = nullptr,
+              .dstSet = segment.descriptor_sets[d_idx],
+              .dstBinding = binding,
+              .dstArrayElement = 0,
+              .descriptorCount = 1,
+              .descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+              .pImageInfo = nullptr,
+              .pBufferInfo = &buffer_info,
+              .pTexelBufferView = nullptr,
+          };
+          vkUpdateDescriptorSets(vk_device, 1, &desc_set, 0, nullptr);
+        } else if (
+            binding_info.descriptor_type ==
+                VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER ||
+            binding_info.descriptor_type == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE ||
+            binding_info.descriptor_type == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE) {
+          const char* type_name = binding_info.descriptor_type ==
+                  VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER
+              ? "VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER"
+              : (binding_info.descriptor_type ==
+                         VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE
+                     ? "VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE"
+                     : "VK_DESCRIPTOR_TYPE_STORAGE_IMAGE");
+          ET_LOG(
+              Info,
+              "Updating descriptor: segment=%u set=%u binding=%u mrt=%u type=%s image_view=%p sampler=%p",
+              segment_id,
+              d_idx,
+              binding,
+              mrt_i,
+              type_name,
+              log_handle_ptr(binding_info.image_view),
+              log_handle_ptr(binding_info.sampler));
+          VkDescriptorImageInfo image_info = {
+              .sampler = binding_info.sampler,
+              .imageView = binding_info.image_view,
+              .imageLayout = VK_IMAGE_LAYOUT_GENERAL,
+          };
+          VkWriteDescriptorSet desc_set = {
+              .sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
+              .pNext = nullptr,
+              .dstSet = segment.descriptor_sets[d_idx],
+              .dstBinding = binding,
+              .dstArrayElement = 0,
+              .descriptorCount = 1,
+              .descriptorType = binding_info.descriptor_type,
+              .pImageInfo = &image_info,
+              .pBufferInfo = nullptr,
+              .pTexelBufferView = nullptr,
+          };
+          vkUpdateDescriptorSets(vk_device, 1, &desc_set, 0, nullptr);
+        } else {
+          ET_LOG(
+              Error,
+              "Unsupported descriptor type %u for descriptor binding",
+              binding_info.descriptor_type);
+          return false;
+        }
+      }
+    }
+
+    VkPipelineLayoutCreateInfo pipeline_layout_info = {
+        .sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .setLayoutCount = 1,
+        .pSetLayouts = &segment.vk_layout,
+        .pushConstantRangeCount = 0,
+        .pPushConstantRanges = nullptr,
+    };
+    result = vkCreatePipelineLayout(
+        vk_device, &pipeline_layout_info, nullptr, &segment.vk_pipeline_layout);
+    if (result != VK_SUCCESS) {
+      ET_LOG(Error, "Failed to create pipeline layout");
+      return false;
+    }
+
+    if (segment.use_data_graph_pipeline) {
+      VkDataGraphPipelineShaderModuleCreateInfoARM shader_info{
+          .sType =
+              VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_SHADER_MODULE_CREATE_INFO_ARM,
+          .pNext = nullptr,
+          .module = segment.vk_shader,
+          .pName = segment_m_entrypoint.c_str(),
+          .pSpecializationInfo = nullptr,
+          .constantCount = static_cast<uint32_t>(constants.size()),
+          .pConstants = constants.data(),
+      };
+
+      VkDataGraphPipelineCreateInfoARM graph_pipeline_info{
+          .sType = VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_CREATE_INFO_ARM,
+          .pNext = &shader_info,
+          .flags = VK_PIPELINE_CREATE_2_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT |
+              VK_PIPELINE_CREATE_2_EARLY_RETURN_ON_FAILURE_BIT_KHR,
+          .layout = segment.vk_pipeline_layout,
+          .resourceInfoCount =
+              static_cast<uint32_t>(data_graph_resources.size()),
+          .pResourceInfos = data_graph_resources.data(),
+      };
+
+      result = vkCreateDataGraphPipelinesARM(
+          vk_device,
+          VK_NULL_HANDLE,
+          VK_NULL_HANDLE,
+          1,
+          &graph_pipeline_info,
+          nullptr,
+          &segment.vk_pipeline);
+      if (result != VK_SUCCESS) {
+        ET_LOG(Error, "Failed to create DataGraphPipeline");
+        return false;
+      }
+
+      VkDataGraphPipelineSessionCreateInfoARM pipeline_session_info{
+          .sType =
+              VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_SESSION_CREATE_INFO_ARM,
+          .pNext = nullptr,
+          .flags = 0,
+          .dataGraphPipeline = segment.vk_pipeline,
+      };
+      result = vkCreateDataGraphPipelineSessionARM(
+          vk_device, &pipeline_session_info, nullptr, &segment.vk_session);
+      if (result != VK_SUCCESS) {
+        ET_LOG(Error, "Failed to create DataGraphPipelineSession");
+        return false;
+      }
+
+      VkDataGraphPipelineSessionBindPointRequirementsInfoARM
+          bind_point_requirements_info = {
+              .sType =
+                  VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_SESSION_BIND_POINT_REQUIREMENTS_INFO_ARM,
+              .pNext = nullptr,
+              .session = segment.vk_session,
+          };
+
+      uint32_t bind_point_count = 0;
+      result = vkGetDataGraphPipelineSessionBindPointRequirementsARM(
+          vk_device, &bind_point_requirements_info, &bind_point_count, nullptr);
+      if (result != VK_SUCCESS) {
+        ET_LOG(Error, "Failed to get session bind point count");
+        return false;
+      }
+
+      vector<VkDataGraphPipelineSessionBindPointRequirementARM>
+          bind_point_requirements;
+      bind_point_requirements.resize(bind_point_count);
+      result = vkGetDataGraphPipelineSessionBindPointRequirementsARM(
+          vk_device,
+          &bind_point_requirements_info,
+          &bind_point_count,
+          bind_point_requirements.data());
+      if (result != VK_SUCCESS) {
+        ET_LOG(Error, "Failed to get session bind point requirements");
+        return false;
+      }
+
+      for (const auto& bind_point_requirement : bind_point_requirements) {
+        if (bind_point_requirement.bindPointType !=
+            VK_DATA_GRAPH_PIPELINE_SESSION_BIND_POINT_TYPE_MEMORY_ARM) {
+          ET_LOG(
+              Error,
+              "Expected VK_DATA_GRAPH_PIPELINE_SESSION_BIND_POINT_TYPE_MEMORY_ARM");
+          return false;
+        }
+        if (bind_point_requirement.bindPoint !=
+            VK_DATA_GRAPH_PIPELINE_SESSION_BIND_POINT_TRANSIENT_ARM) {
+          ET_LOG(
+              Error,
+              "Expected VK_DATA_GRAPH_PIPELINE_SESSION_BIND_POINT_TRANSIENT_ARM");
+          return false;
+        }
+        if (bind_point_requirement.numObjects != 1) {
+          ET_LOG(Error, "Expected only one object for the bindpoint");
+          return false;
+        }
+
+        VkDataGraphPipelineSessionMemoryRequirementsInfoARM
+            memory_requirements_info = {
+                .sType =
+                    VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_SESSION_MEMORY_REQUIREMENTS_INFO_ARM,
+                .pNext = nullptr,
+                .session = segment.vk_session,
+                .bindPoint = bind_point_requirement.bindPoint,
+                .objectIndex = 0,
+            };
+        VkMemoryRequirements2 memory_requirements = {
+            .sType = VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2,
+            .pNext = nullptr,
+        };
+        vkGetDataGraphPipelineSessionMemoryRequirementsARM(
+            vk_device, &memory_requirements_info, &memory_requirements);
+
+        VkMemoryPropertyFlags aims = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT |
+            VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
+            VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+        uint32_t memory_index = 0;
+        if (!find_memory_index(
+                vk_physical, memory_requirements, aims, &memory_index)) {
+          ET_LOG(
+              Error,
+              "Failed to find data-graph session memory type for segment %d",
+              segment.segment_id);
+          return false;
+        }
+
+        VkMemoryAllocateInfo memory_allocate_info = {
+            .sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
+            .pNext = nullptr,
+            .allocationSize = memory_requirements.memoryRequirements.size,
+            .memoryTypeIndex = memory_index,
+        };
+
+        VkDeviceMemory memory;
+        result = vkAllocateMemory(
+            vk_device, &memory_allocate_info, nullptr, &memory);
+        if (result != VK_SUCCESS) {
+          ET_LOG(Error, "Failed to allocate memory for intermediates");
+          return false;
+        }
+        intermediates.push_back(memory);
+
+        VkBindDataGraphPipelineSessionMemoryInfoARM bind_info = {
+            .sType =
+                VK_STRUCTURE_TYPE_BIND_DATA_GRAPH_PIPELINE_SESSION_MEMORY_INFO_ARM,
+            .pNext = nullptr,
+            .session = segment.vk_session,
+            .bindPoint = bind_point_requirement.bindPoint,
+            .objectIndex = 0,
+            .memory = memory,
+            .memoryOffset = 0,
+        };
+        result =
+            vkBindDataGraphPipelineSessionMemoryARM(vk_device, 1, &bind_info);
+        if (result != VK_SUCCESS) {
+          ET_LOG(Error, "Failed to bind intermediates memory");
+          return false;
+        }
+      }
+    } else {
+      VkPipelineShaderStageCreateInfo stage_info{
+          .sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
+          .pNext = nullptr,
+          .flags = 0,
+          .stage = VK_SHADER_STAGE_COMPUTE_BIT,
+          .module = segment.vk_shader,
+          .pName = segment_m_entrypoint.c_str(),
+          .pSpecializationInfo = nullptr,
+      };
+      VkComputePipelineCreateInfo compute_info{
+          .sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO,
+          .pNext = nullptr,
+          .flags = 0,
+          .stage = stage_info,
+          .layout = segment.vk_pipeline_layout,
+          .basePipelineHandle = VK_NULL_HANDLE,
+          .basePipelineIndex = -1,
+      };
+      result = vkCreateComputePipelines(
+          vk_device,
+          VK_NULL_HANDLE,
+          1,
+          &compute_info,
+          nullptr,
+          &segment.vk_pipeline);
+      if (result != VK_SUCCESS) {
+        ET_LOG(Error, "Failed to create compute pipeline");
+        return false;
+      }
+    }
+
+    segments.push_back(std::move(segment));
+  }
+
+  // Map model sequence inputs/outputs to IO indices
+  auto input_handle =
+      sequence_decoder->getModelSequenceInputBindingSlotsHandle();
+  auto output_handle =
+      sequence_decoder->getModelSequenceOutputBindingSlotsHandle();
+  auto input_names_handle =
+      sequence_decoder->getModelSequenceInputNamesHandle();
+  auto output_names_handle =
+      sequence_decoder->getModelSequenceOutputNamesHandle();
+  const size_t model_input_count =
+      sequence_decoder->getNamesSize(input_names_handle);
+  const size_t model_output_count =
+      sequence_decoder->getNamesSize(output_names_handle);
+  this->model_input_count = model_input_count;
+  this->model_output_count = model_output_count;
+  model_input_io_index.assign(model_input_count, -1);
+  model_output_io_index.assign(model_output_count, -1);
+
+  const size_t input_binding_count =
+      sequence_decoder->getBindingsSize(input_handle);
+  const size_t output_binding_count =
+      sequence_decoder->getBindingsSize(output_handle);
+  for (size_t i = 0; i < input_binding_count && i < model_input_count; ++i) {
+    auto mrt_i = sequence_decoder->getBindingSlotMrtIndex(input_handle, i);
+    if (mrt_i < resource_index_to_io_index.size()) {
+      model_input_io_index[i] = resource_index_to_io_index[mrt_i];
     }
   }
-
-  // Create descriptor pool and descriptors for pipeline
-  const VkDescriptorPoolCreateInfo descriptor_pool_info = {
-      .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
-      .pNext = nullptr,
-      .flags = 0,
-      .maxSets = static_cast<uint32_t>(set_count),
-      .poolSizeCount = static_cast<uint32_t>(poolSizes.size()),
-      .pPoolSizes = poolSizes.data(),
-  };
-  result = vkCreateDescriptorPool(
-      vk_device, &descriptor_pool_info, nullptr, &vk_descriptor_pool);
-  if (result != VK_SUCCESS) {
-    ET_LOG(Error, "Failed to create descriptor pool");
-    return false;
+  for (size_t i = 0; i < output_binding_count && i < model_output_count; ++i) {
+    auto mrt_i = sequence_decoder->getBindingSlotMrtIndex(output_handle, i);
+    if (mrt_i < resource_index_to_io_index.size()) {
+      model_output_io_index[i] = resource_index_to_io_index[mrt_i];
+    }
   }
-
-  const VkDescriptorSetAllocateInfo descriptor_set_info = {
-      .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO,
-      .pNext = nullptr,
-      .descriptorPool = vk_descriptor_pool,
-      .descriptorSetCount = static_cast<uint32_t>(set_count),
-      .pSetLayouts = &vk_layout,
-  };
-
-  // Alloc descriptor sets
-  // currently, as we require modelSequenceTableSize to == 1
-  // we can only get one descriptor set.
-  descriptor_sets.resize(layout_bindings.size());
-  result = vkAllocateDescriptorSets(
-      vk_device, &descriptor_set_info, descriptor_sets.data());
-  if (result != VK_SUCCESS) {
-    ET_LOG(Error, "Failed to allocate descriptor sets");
-    return false;
+  ET_LOG(
+      Info,
+      "Model IO mapping: inputs=%zu outputs=%zu (bindings in=%zu out=%zu)",
+      model_input_count,
+      model_output_count,
+      input_binding_count,
+      output_binding_count);
+  for (size_t i = 0; i < model_input_count; ++i) {
+    ET_LOG(Info, "  input[%zu] -> IO[%d]", i, model_input_io_index[i]);
   }
-
-  // write descriptor updates for every input
-  auto input_slots =
-      sequence_decoder->getSegmentInputBindingSlotsHandle(segment_id);
-  auto input_size = sequence_decoder->getBindingsSize(input_slots);
-  for (uint32_t i = 0; i < input_size; i++) {
-    auto binding = sequence_decoder->getBindingSlotBinding(input_slots, i);
-    auto mrt_i = sequence_decoder->getBindingSlotMrtIndex(input_slots, i);
-
-    VkWriteDescriptorSetTensorARM write_desc = {
-        .sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_TENSOR_ARM,
-        .pNext = nullptr,
-        .tensorViewCount = 1,
-        .pTensorViews = &get<1>(resources[i]),
-    };
-    VkWriteDescriptorSet desc_set = {
-        .sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
-        .pNext = &write_desc,
-        .dstSet = descriptor_sets[0],
-        .dstBinding = binding,
-        .dstArrayElement = 0,
-        .descriptorCount = 1,
-        .descriptorType = VK_DESCRIPTOR_TYPE_TENSOR_ARM,
-        .pImageInfo = nullptr,
-        .pBufferInfo = nullptr,
-        .pTexelBufferView = nullptr,
-    };
-    vkUpdateDescriptorSets(vk_device, 1, &desc_set, 0, nullptr);
-  }
-
-  // write descriptor updates for every output
-  auto output_slots =
-      sequence_decoder->getSegmentOutputBindingSlotsHandle(segment_id);
-  auto output_size = sequence_decoder->getBindingsSize(output_slots);
-  for (uint32_t i = 0; i < output_size; i++) {
-    auto binding = sequence_decoder->getBindingSlotBinding(output_slots, i);
-    auto mrt_i = sequence_decoder->getBindingSlotMrtIndex(output_slots, i);
-
-    VkWriteDescriptorSetTensorARM write_desc = {
-        .sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_TENSOR_ARM,
-        .pNext = nullptr,
-        .tensorViewCount = 1,
-        .pTensorViews = &get<1>(resources[i + input_size]),
-    };
-    VkWriteDescriptorSet desc_set = {
-        .sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
-        .pNext = &write_desc,
-        .dstSet = descriptor_sets[0],
-        .dstBinding = binding,
-        .dstArrayElement = 0,
-        .descriptorCount = 1,
-        .descriptorType = VK_DESCRIPTOR_TYPE_TENSOR_ARM,
-        .pImageInfo = nullptr,
-        .pBufferInfo = nullptr,
-        .pTexelBufferView = nullptr,
-    };
-    vkUpdateDescriptorSets(vk_device, 1, &desc_set, 0, nullptr);
-  }
-
-  // create our pipeline
-  VkPipelineLayoutCreateInfo pipeline_layout_info = {
-      .sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO,
-      .pNext = nullptr,
-      .flags = 0,
-      .setLayoutCount = 1,
-      .pSetLayouts = &vk_layout,
-      .pushConstantRangeCount = 0,
-      .pPushConstantRanges = nullptr,
-  };
-  result = vkCreatePipelineLayout(
-      vk_device, &pipeline_layout_info, nullptr, &vk_pipeline_layout);
-  if (result != VK_SUCCESS) {
-    ET_LOG(Error, "Failed to create pipeline layout");
-    return false;
-  }
-
-  // Shader Module Create
-  VkDataGraphPipelineShaderModuleCreateInfoARM shader_info{
-      .sType =
-          VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_SHADER_MODULE_CREATE_INFO_ARM,
-      .pNext = nullptr,
-      .module = get<0>(shader_modules[0]),
-      .pName = get<1>(shader_modules[0]).c_str(),
-      .pSpecializationInfo = nullptr,
-      .constantCount = static_cast<uint32_t>(constants.size()),
-      .pConstants = constants.data(),
-  };
-
-  // Prepare Graph Pipeline
-  VkDataGraphPipelineCreateInfoARM graph_pipeline_info{
-      .sType = VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_CREATE_INFO_ARM,
-      .pNext = &shader_info,
-      .flags = VK_PIPELINE_CREATE_2_EARLY_RETURN_ON_FAILURE_BIT_KHR,
-      .layout = vk_pipeline_layout,
-      .resourceInfoCount = static_cast<uint32_t>(data_graph_resources.size()),
-      .pResourceInfos = data_graph_resources.data(),
-  };
-
-  result = vkCreateDataGraphPipelinesARM(
-      vk_device, // device
-      VK_NULL_HANDLE, // deferredOperation
-      VK_NULL_HANDLE, // VkPipelineCache
-      1, // createInfoCount
-      &graph_pipeline_info, // pCreateInfos
-      nullptr, // pAllocator
-      &vk_pipeline // pPipelines (VkPipeline*)
-  );
-  if (result != VK_SUCCESS) {
-    ET_LOG(Error, "Failed to create DataGraphPipeline");
-    return false;
-  }
-
-  // prepare the graph pipeline session
-  VkDataGraphPipelineSessionCreateInfoARM pipeline_session_info{
-      .sType = VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_SESSION_CREATE_INFO_ARM,
-      .pNext = nullptr,
-      .flags = 0,
-      .dataGraphPipeline = vk_pipeline,
-  };
-  result = vkCreateDataGraphPipelineSessionARM(
-      vk_device, &pipeline_session_info, nullptr, &vk_session);
-  if (result != VK_SUCCESS) {
-    ET_LOG(Error, "Failed to create DataGraphPipelineSession");
-    return false;
+  for (size_t i = 0; i < model_output_count; ++i) {
+    ET_LOG(Info, "  output[%zu] -> IO[%d]", i, model_output_io_index[i]);
   }
 
   // Allocate command buffer
@@ -774,120 +2887,6 @@ bool VgfRepr::process_vgf(
     ET_LOG(Error, "Failed to allocate command buffers");
     return false;
   }
-
-  // Allocate intermediates memory based on the pipeline requirements provided
-  // by the driver
-  VkDataGraphPipelineSessionBindPointRequirementsInfoARM
-      bind_point_requirements_info = {
-          .sType =
-              VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_SESSION_BIND_POINT_REQUIREMENTS_INFO_ARM,
-          .pNext = nullptr,
-          .session = vk_session,
-      };
-
-  uint32_t bind_point_count = 0;
-  result = vkGetDataGraphPipelineSessionBindPointRequirementsARM(
-      vk_device, &bind_point_requirements_info, &bind_point_count, nullptr);
-  if (result != VK_SUCCESS) {
-    ET_LOG(Error, "Failed to get session bind point count");
-    return false;
-  }
-
-  vector<VkDataGraphPipelineSessionBindPointRequirementARM> bind_point_requirements(
-      bind_point_count,
-      {
-          .sType =
-              VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_SESSION_BIND_POINT_REQUIREMENT_ARM,
-          .pNext = nullptr,
-      });
-
-  result = vkGetDataGraphPipelineSessionBindPointRequirementsARM(
-      vk_device,
-      &bind_point_requirements_info,
-      &bind_point_count,
-      bind_point_requirements.data());
-  if (result != VK_SUCCESS) {
-    ET_LOG(Error, "Failed to get session bind point requirements");
-    return false;
-  }
-
-  // Given the bind points, just make individual allocations and bind them
-  for (const auto& bind_point_requirement : bind_point_requirements) {
-    // These are the only allowed type and bindpoint with the current spec
-    if (bind_point_requirement.bindPointType !=
-        VK_DATA_GRAPH_PIPELINE_SESSION_BIND_POINT_TYPE_MEMORY_ARM) {
-      ET_LOG(
-          Error,
-          "Expected VK_DATA_GRAPH_PIPELINE_SESSION_BIND_POINT_TYPE_MEMORY_ARM");
-      return false;
-    }
-    if (bind_point_requirement.bindPoint !=
-        VK_DATA_GRAPH_PIPELINE_SESSION_BIND_POINT_TRANSIENT_ARM) {
-      ET_LOG(
-          Error,
-          "Expected VK_DATA_GRAPH_PIPELINE_SESSION_BIND_POINT_TRANSIENT_ARM");
-      return false;
-    }
-    if (bind_point_requirement.numObjects != 1) {
-      ET_LOG(Error, "Expected only one object for the bindpoint");
-      return false;
-    }
-
-    VkDataGraphPipelineSessionMemoryRequirementsInfoARM memory_requirements_info = {
-        .sType =
-            VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_SESSION_MEMORY_REQUIREMENTS_INFO_ARM,
-        .pNext = nullptr,
-        .session = vk_session,
-        .bindPoint = bind_point_requirement.bindPoint,
-        .objectIndex = 0, // NOTE: tied to numObjects assert above
-    };
-    VkMemoryRequirements2 memory_requirements = {
-        .sType = VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2,
-        .pNext = nullptr,
-    };
-    vkGetDataGraphPipelineSessionMemoryRequirementsARM(
-        vk_device, &memory_requirements_info, &memory_requirements);
-
-    VkMemoryPropertyFlags aims = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT |
-        VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
-        VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
-    uint32_t memory_index =
-        get_memory_index(vk_physical, memory_requirements, aims);
-
-    VkMemoryAllocateInfo memory_allocate_info = {
-        .sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
-        .pNext = nullptr,
-        .allocationSize = memory_requirements.memoryRequirements.size,
-        .memoryTypeIndex = memory_index,
-    };
-
-    VkDeviceMemory memory;
-    result =
-        vkAllocateMemory(vk_device, &memory_allocate_info, nullptr, &memory);
-    if (result != VK_SUCCESS) {
-      ET_LOG(Error, "Failed to allocate memory for intermediates");
-      return false;
-    }
-    // so we can free this object in destructor
-    intermediates.push_back(memory);
-
-    VkBindDataGraphPipelineSessionMemoryInfoARM bind_info = {
-        .sType =
-            VK_STRUCTURE_TYPE_BIND_DATA_GRAPH_PIPELINE_SESSION_MEMORY_INFO_ARM,
-        .pNext = nullptr,
-        .session = vk_session,
-        .bindPoint = bind_point_requirement.bindPoint,
-        .objectIndex = 0, // NOTE: tied to numObjects assert above
-        .memory = memory,
-        .memoryOffset = 0,
-    };
-    result = vkBindDataGraphPipelineSessionMemoryARM(vk_device, 1, &bind_info);
-    if (result != VK_SUCCESS) {
-      ET_LOG(Error, "Failed to bind intermediates memory");
-      return false;
-    }
-  }
-
   // Populate command once with our dispatch information
   VkCommandBufferBeginInfo beginInfo{
       VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO};
@@ -898,8 +2897,10 @@ bool VgfRepr::process_vgf(
       .sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER_2,
       .srcStageMask = VK_PIPELINE_STAGE_2_HOST_BIT,
       .srcAccessMask = VK_ACCESS_2_HOST_WRITE_BIT,
-      .dstStageMask = VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT,
-      .dstAccessMask = VK_ACCESS_2_SHADER_READ_BIT,
+      .dstStageMask =
+          VK_PIPELINE_STAGE_2_TRANSFER_BIT | vgf_execution_stage_mask(),
+      .dstAccessMask =
+          VK_ACCESS_2_TRANSFER_READ_BIT | vgf_execution_read_access_mask(),
   };
   VkDependencyInfo dependency_info = {
       .sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO,
@@ -908,29 +2909,209 @@ bool VgfRepr::process_vgf(
   };
   vkCmdPipelineBarrier2(vk_execute_cmd, &dependency_info);
 
-  // bind pipeline + descriptor set
-  vkCmdBindPipeline(
-      vk_execute_cmd, VK_PIPELINE_BIND_POINT_DATA_GRAPH_ARM, vk_pipeline);
+  bool has_input_image = false;
+  for (const auto& io : IOs) {
+    if (io.is_input &&
+        (io.descriptor_type == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER ||
+         io.descriptor_type == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE ||
+         io.descriptor_type == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE)) {
+      has_input_image = true;
+      const VkBufferImageCopy copy_region = {
+          .bufferOffset = 0,
+          .bufferRowLength = 0,
+          .bufferImageHeight = 0,
+          .imageSubresource =
+              {
+                  .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
+                  .mipLevel = 0,
+                  .baseArrayLayer = 0,
+                  .layerCount = 1,
+              },
+          .imageOffset = {0, 0, 0},
+          .imageExtent = io.image_extent,
+      };
+      vkCmdCopyBufferToImage(
+          vk_execute_cmd,
+          io.buffer,
+          io.image,
+          VK_IMAGE_LAYOUT_GENERAL,
+          1,
+          &copy_region);
+    }
+  }
 
-  vkCmdBindDescriptorSets(
-      vk_execute_cmd,
-      VK_PIPELINE_BIND_POINT_DATA_GRAPH_ARM,
-      vk_pipeline_layout,
-      0, // first set
-      1,
-      descriptor_sets.data(), // descriptor set count + pointer
-      0,
-      nullptr // no dynamic offsets
-  );
+  if (has_input_image) {
+    VkMemoryBarrier2 input_image_barrier = {
+        .sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER_2,
+        .srcStageMask = VK_PIPELINE_STAGE_2_TRANSFER_BIT,
+        .srcAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT,
+        .dstStageMask = vgf_execution_stage_mask(),
+        .dstAccessMask = vgf_execution_read_access_mask() |
+            vgf_execution_write_access_mask(),
+    };
+    VkDependencyInfo input_image_dependency = {
+        .sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO,
+        .memoryBarrierCount = 1,
+        .pMemoryBarriers = &input_image_barrier,
+    };
+    vkCmdPipelineBarrier2(vk_execute_cmd, &input_image_dependency);
+  }
 
-  // Dispatch the graph command
-  vkCmdDispatchDataGraphARM(vk_execute_cmd, vk_session, nullptr);
+  // Bind and dispatch each segment in order.
+  for (size_t seg_idx = 0; seg_idx < segments.size(); ++seg_idx) {
+    const auto& segment = segments[seg_idx];
+    unordered_map<uint32_t, VkImageLayout> desired_alias_layouts;
+    auto set_count =
+        sequence_decoder->getSegmentDescriptorSetInfosSize(segment.segment_id);
+    for (uint32_t d_idx = 0; d_idx < set_count; d_idx++) {
+      auto descriptor_slots = sequence_decoder->getDescriptorBindingSlotsHandle(
+          segment.segment_id, d_idx);
+      auto descriptor_count =
+          sequence_decoder->getBindingsSize(descriptor_slots);
+      for (uint32_t i = 0; i < descriptor_count; i++) {
+        auto mrt_i =
+            sequence_decoder->getBindingSlotMrtIndex(descriptor_slots, i);
+        auto alias_group = get_resource_alias_group_id(resource_decoder, mrt_i);
+        if (!alias_group.has_value()) {
+          continue;
+        }
+        auto alias_state_it = alias_image_states.find(*alias_group);
+        if (alias_state_it == alias_image_states.end() ||
+            !alias_state_it->second.needs_tensor_aliasing) {
+          continue;
+        }
+        const auto descriptor_type = resource_bindings[mrt_i].descriptor_type;
+        const auto desired_layout = is_image_descriptor_type(descriptor_type)
+            ? VK_IMAGE_LAYOUT_GENERAL
+            : VK_IMAGE_LAYOUT_TENSOR_ALIASING_ARM;
+        auto desired_it = desired_alias_layouts.find(*alias_group);
+        if (desired_it == desired_alias_layouts.end()) {
+          desired_alias_layouts[*alias_group] = desired_layout;
+        } else if (desired_it->second != desired_layout) {
+          ET_LOG(
+              Error,
+              "Alias group %u mixes image and tensor-like descriptor use in segment %d",
+              *alias_group,
+              segment.segment_id);
+          return false;
+        }
+      }
+    }
+    for (auto& [alias_group, desired_layout] : desired_alias_layouts) {
+      auto& alias_state = alias_image_states[alias_group];
+      if (alias_state.current_layout == desired_layout) {
+        continue;
+      }
+      for (auto image : alias_state.images) {
+        record_image_layout_transition(
+            vk_execute_cmd, image, alias_state.current_layout, desired_layout);
+      }
+      alias_state.current_layout = desired_layout;
+    }
+
+    VkPipelineBindPoint bind_point = segment.use_data_graph_pipeline
+        ? VK_PIPELINE_BIND_POINT_DATA_GRAPH_ARM
+        : VK_PIPELINE_BIND_POINT_COMPUTE;
+    vkCmdBindPipeline(vk_execute_cmd, bind_point, segment.vk_pipeline);
+
+    vkCmdBindDescriptorSets(
+        vk_execute_cmd,
+        bind_point,
+        segment.vk_pipeline_layout,
+        0, // first set
+        1,
+        segment.descriptor_sets.data(),
+        0,
+        nullptr);
+
+    if (segment.use_data_graph_pipeline) {
+      vkCmdDispatchDataGraphARM(vk_execute_cmd, segment.vk_session, nullptr);
+    } else {
+      vkCmdDispatch(
+          vk_execute_cmd,
+          segment.dispatch_shape[0],
+          segment.dispatch_shape[1],
+          segment.dispatch_shape[2]);
+    }
+
+    if (seg_idx + 1 < segments.size()) {
+      VkMemoryBarrier2 segment_barrier = {
+          .sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER_2,
+          .srcStageMask = vgf_execution_stage_mask(),
+          .srcAccessMask = vgf_execution_write_access_mask(),
+          .dstStageMask = vgf_execution_stage_mask(),
+          .dstAccessMask = vgf_execution_read_access_mask() |
+              vgf_execution_write_access_mask(),
+      };
+      VkDependencyInfo segment_dep = {
+          .sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO,
+          .memoryBarrierCount = 1,
+          .pMemoryBarriers = &segment_barrier,
+      };
+      vkCmdPipelineBarrier2(vk_execute_cmd, &segment_dep);
+    }
+  }
 
   // Sync data back
+  const bool has_output_image =
+      std::any_of(IOs.begin(), IOs.end(), [](const auto& io) {
+        return !io.is_input &&
+            (io.descriptor_type == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE ||
+             io.descriptor_type == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER ||
+             io.descriptor_type == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE);
+      });
+
+  if (has_output_image) {
+    VkMemoryBarrier2 output_image_barrier = {
+        .sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER_2,
+        .srcStageMask = vgf_execution_stage_mask(),
+        .srcAccessMask = vgf_execution_write_access_mask(),
+        .dstStageMask = VK_PIPELINE_STAGE_2_TRANSFER_BIT,
+        .dstAccessMask = VK_ACCESS_2_TRANSFER_READ_BIT,
+    };
+    VkDependencyInfo output_image_dependency = {
+        .sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO,
+        .memoryBarrierCount = 1,
+        .pMemoryBarriers = &output_image_barrier,
+    };
+    vkCmdPipelineBarrier2(vk_execute_cmd, &output_image_dependency);
+
+    for (const auto& io : IOs) {
+      if (!io.is_input &&
+          (io.descriptor_type == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE ||
+           io.descriptor_type == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER ||
+           io.descriptor_type == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE)) {
+        const VkBufferImageCopy copy_region = {
+            .bufferOffset = 0,
+            .bufferRowLength = 0,
+            .bufferImageHeight = 0,
+            .imageSubresource =
+                {
+                    .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
+                    .mipLevel = 0,
+                    .baseArrayLayer = 0,
+                    .layerCount = 1,
+                },
+            .imageOffset = {0, 0, 0},
+            .imageExtent = io.image_extent,
+        };
+        vkCmdCopyImageToBuffer(
+            vk_execute_cmd,
+            io.image,
+            VK_IMAGE_LAYOUT_GENERAL,
+            io.buffer,
+            1,
+            &copy_region);
+      }
+    }
+  }
+
   VkMemoryBarrier2 barrier_2 = {
       .sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER_2,
-      .srcStageMask = VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT,
-      .srcAccessMask = VK_ACCESS_2_SHADER_WRITE_BIT,
+      .srcStageMask =
+          VK_PIPELINE_STAGE_2_TRANSFER_BIT | vgf_execution_stage_mask(),
+      .srcAccessMask =
+          VK_ACCESS_2_TRANSFER_WRITE_BIT | vgf_execution_write_access_mask(),
       .dstStageMask = VK_PIPELINE_STAGE_2_HOST_BIT,
       .dstAccessMask = VK_ACCESS_2_HOST_READ_BIT,
   };
@@ -966,15 +3147,99 @@ bool VgfRepr::execute_vgf() {
 
 void VgfRepr::free_vgf() {
   vkFreeCommandBuffers(vk_device, vk_command_pool, 1, &vk_execute_cmd);
-  vkDestroyDataGraphPipelineSessionARM(vk_device, vk_session, nullptr);
-  vkDestroyPipeline(vk_device, vk_pipeline, nullptr);
-  vkDestroyPipelineLayout(vk_device, vk_pipeline_layout, nullptr);
-  vkDestroyDescriptorPool(vk_device, vk_descriptor_pool, nullptr);
-  vkDestroyDescriptorSetLayout(vk_device, vk_layout, nullptr);
-  vkDestroyShaderModule(vk_device, vk_shader, nullptr);
+  vector<VkDeviceMemory> owned_memory;
+  auto remember_owned_memory = [&](VkDeviceMemory memory) {
+    if (memory == VK_NULL_HANDLE) {
+      return;
+    }
+    if (find(owned_memory.begin(), owned_memory.end(), memory) ==
+        owned_memory.end()) {
+      owned_memory.push_back(memory);
+    }
+  };
+  for (auto& segment : segments) {
+    if (segment.use_data_graph_pipeline &&
+        segment.vk_session != VK_NULL_HANDLE) {
+      vkDestroyDataGraphPipelineSessionARM(
+          vk_device, segment.vk_session, nullptr);
+    }
+    if (segment.vk_pipeline != VK_NULL_HANDLE) {
+      vkDestroyPipeline(vk_device, segment.vk_pipeline, nullptr);
+    }
+    if (segment.vk_pipeline_layout != VK_NULL_HANDLE) {
+      vkDestroyPipelineLayout(vk_device, segment.vk_pipeline_layout, nullptr);
+    }
+    if (segment.vk_descriptor_pool != VK_NULL_HANDLE) {
+      vkDestroyDescriptorPool(vk_device, segment.vk_descriptor_pool, nullptr);
+    }
+    if (segment.vk_layout != VK_NULL_HANDLE) {
+      vkDestroyDescriptorSetLayout(vk_device, segment.vk_layout, nullptr);
+    }
+    if (segment.vk_shader != VK_NULL_HANDLE) {
+      vkDestroyShaderModule(vk_device, segment.vk_shader, nullptr);
+    }
+  }
+  segments.clear();
   for (int i = 0; i < IOs.size(); i++) {
-    free_tensor(
-        vk_device, IOs[i].tensor_view, IOs[i].tensor, IOs[i].tensor_memory);
+    if (IOs[i].descriptor_type == VK_DESCRIPTOR_TYPE_TENSOR_ARM) {
+      if (IOs[i].owns_memory) {
+        remember_owned_memory(IOs[i].memory);
+      }
+      destroy_tensor(vk_device, IOs[i].tensor_view, IOs[i].tensor);
+    } else if (IOs[i].descriptor_type == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER) {
+      if (IOs[i].owns_memory) {
+        remember_owned_memory(IOs[i].memory);
+      }
+      destroy_buffer(vk_device, IOs[i].buffer);
+    } else if (
+        IOs[i].descriptor_type == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER ||
+        IOs[i].descriptor_type == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE ||
+        IOs[i].descriptor_type == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE) {
+      if (IOs[i].owns_memory) {
+        remember_owned_memory(IOs[i].memory);
+      }
+      destroy_buffer(vk_device, IOs[i].buffer);
+      if (IOs[i].owns_image_memory) {
+        remember_owned_memory(IOs[i].image_memory);
+      }
+      free_image(
+          vk_device,
+          IOs[i].image_view,
+          IOs[i].image,
+          IOs[i].sampler,
+          VK_NULL_HANDLE);
+    }
+  }
+  IOs.clear();
+  for (const auto& alloc : extra_allocs) {
+    if (alloc.descriptor_type == VK_DESCRIPTOR_TYPE_TENSOR_ARM) {
+      if (alloc.owns_memory) {
+        remember_owned_memory(alloc.memory);
+      }
+      destroy_tensor(vk_device, alloc.tensor_view, alloc.tensor);
+    } else if (alloc.descriptor_type == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER) {
+      if (alloc.owns_memory) {
+        remember_owned_memory(alloc.memory);
+      }
+      destroy_buffer(vk_device, alloc.buffer);
+    } else if (
+        alloc.descriptor_type == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER ||
+        alloc.descriptor_type == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE ||
+        alloc.descriptor_type == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE) {
+      if (alloc.owns_image_memory) {
+        remember_owned_memory(alloc.image_memory);
+      }
+      free_image(
+          vk_device,
+          alloc.image_view,
+          alloc.image,
+          alloc.sampler,
+          VK_NULL_HANDLE);
+    }
+  }
+  extra_allocs.clear();
+  for (auto memory : owned_memory) {
+    vkFreeMemory(vk_device, memory, nullptr);
   }
   for (auto memory : intermediates) {
     vkFreeMemory(vk_device, memory, nullptr);
@@ -993,13 +3258,30 @@ static uint32_t get_format_size(VkFormat format) {
     case VK_FORMAT_R16_UINT:
     case VK_FORMAT_R16_SINT:
     case VK_FORMAT_R16_SFLOAT:
+    case VK_FORMAT_R8G8_UINT:
+    case VK_FORMAT_R8G8_SINT:
       return 2;
+    case VK_FORMAT_R16G16_UINT:
+    case VK_FORMAT_R16G16_SINT:
+    case VK_FORMAT_R16G16_SFLOAT:
     case VK_FORMAT_R32_UINT:
     case VK_FORMAT_R32_SINT:
     case VK_FORMAT_R32_SFLOAT:
+    case VK_FORMAT_R8G8B8A8_UINT:
+    case VK_FORMAT_R8G8B8A8_SINT:
       return 4;
+    case VK_FORMAT_R32G32_UINT:
+    case VK_FORMAT_R32G32_SINT:
+    case VK_FORMAT_R32G32_SFLOAT:
+    case VK_FORMAT_R16G16B16A16_UINT:
+    case VK_FORMAT_R16G16B16A16_SINT:
+    case VK_FORMAT_R16G16B16A16_SFLOAT:
     case VK_FORMAT_R64_SINT:
       return 8;
+    case VK_FORMAT_R32G32B32A32_UINT:
+    case VK_FORMAT_R32G32B32A32_SINT:
+    case VK_FORMAT_R32G32B32A32_SFLOAT:
+      return 16;
     default:
       ET_LOG(Error, "Unknown tensor format");
       return 0;

--- a/backends/arm/runtime/VGFSetup.h
+++ b/backends/arm/runtime/VGFSetup.h
@@ -5,8 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <array>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 using namespace std;
 
@@ -31,11 +33,48 @@ typedef struct IO {
   vector<int64_t> size;
   vector<int64_t> stride;
   size_t elt_size;
+  size_t allocation_size;
+  VkDescriptorType descriptor_type;
   VkTensorARM tensor;
   VkTensorViewARM tensor_view;
-  VkDeviceMemory tensor_memory;
+  VkBuffer buffer;
+  VkImage image;
+  VkImageView image_view;
+  VkSampler sampler;
+  VkDeviceMemory image_memory;
+  VkDeviceMemory memory;
+  VkExtent3D image_extent;
+  bool owns_memory = true;
+  bool owns_image_memory = true;
   bool is_input;
 } IO;
+
+typedef struct SegmentState {
+  int segment_id = -1;
+  bool use_data_graph_pipeline = true;
+  VkPipeline vk_pipeline = VK_NULL_HANDLE;
+  VkPipelineLayout vk_pipeline_layout = VK_NULL_HANDLE;
+  VkDescriptorPool vk_descriptor_pool = VK_NULL_HANDLE;
+  VkDescriptorSetLayout vk_layout = VK_NULL_HANDLE;
+  std::vector<VkDescriptorSet> descriptor_sets;
+  VkDataGraphPipelineSessionARM vk_session = VK_NULL_HANDLE;
+  VkShaderModule vk_shader = VK_NULL_HANDLE;
+  std::array<uint32_t, 3> dispatch_shape = {1, 1, 1};
+} SegmentState;
+
+typedef struct ResourceAlloc {
+  VkDescriptorType descriptor_type = VK_DESCRIPTOR_TYPE_MAX_ENUM;
+  VkTensorARM tensor = VK_NULL_HANDLE;
+  VkTensorViewARM tensor_view = VK_NULL_HANDLE;
+  VkBuffer buffer = VK_NULL_HANDLE;
+  VkImage image = VK_NULL_HANDLE;
+  VkImageView image_view = VK_NULL_HANDLE;
+  VkSampler sampler = VK_NULL_HANDLE;
+  VkDeviceMemory image_memory = VK_NULL_HANDLE;
+  VkDeviceMemory memory = VK_NULL_HANDLE;
+  bool owns_memory = true;
+  bool owns_image_memory = true;
+} ResourceAlloc;
 
 /*
  * In memory, and in-vulkan-object representation of the loaded
@@ -79,10 +118,16 @@ class VgfRepr {
    */
   vector<IO> IOs;
   vector<VkDeviceMemory> intermediates;
+  vector<int> model_input_io_index;
+  vector<int> model_output_io_index;
+  size_t model_input_count = 0;
+  size_t model_output_count = 0;
+  std::vector<SegmentState> segments;
+  std::vector<ResourceAlloc> extra_allocs;
 
   bool map_io(IO* io, void** handle) {
     VkResult result =
-        vkMapMemory(vk_device, io->tensor_memory, 0, VK_WHOLE_SIZE, 0, handle);
+        vkMapMemory(vk_device, io->memory, 0, VK_WHOLE_SIZE, 0, handle);
     if (result != VK_SUCCESS) {
       ET_LOG(Error, "Failed to map Vulkan IO memory");
       return false;
@@ -91,7 +136,7 @@ class VgfRepr {
   }
 
   void unmap_io(IO* io) {
-    vkUnmapMemory(vk_device, io->tensor_memory);
+    vkUnmapMemory(vk_device, io->memory);
   }
 
   ~VgfRepr() {
@@ -109,14 +154,7 @@ class VgfRepr {
   // per-VgfRepr-instance objects allocated in process_vgf, used (can be more
   // than once) in execute_vgf
   VkCommandBuffer vk_execute_cmd = VK_NULL_HANDLE;
-  VkDataGraphPipelineSessionARM vk_session = VK_NULL_HANDLE;
-  VkPipeline vk_pipeline = VK_NULL_HANDLE;
-  VkPipelineLayout vk_pipeline_layout = VK_NULL_HANDLE;
-  VkDescriptorPool vk_descriptor_pool;
-  VkDescriptorSetLayout vk_layout;
-  VkShaderModule vk_shader;
   // Note: the vector of tensor memory is stored in IOs above
-  vector<VkDescriptorSet> descriptor_sets;
 };
 
 } // namespace vgf

--- a/backends/arm/test/BUCK
+++ b/backends/arm/test/BUCK
@@ -50,6 +50,42 @@ fbcode_target(_kind = runtime.python_library,
 )
 
 fbcode_target(_kind = runtime.python_library,
+    name = "custom_vgf_test_utils",
+    srcs = ["_custom_vgf_test_utils.py"],
+    resources = [
+        "assets/test_add_buffer.glsl",
+        "assets/test_grid_read_tensor_debug.glsl",
+        "assets/test_grid_sample_buffer_nchw_debug.glsl",
+        "assets/test_grid_sample_sampler.glsl",
+        "assets/test_grid_sample_sampler_buffer_debug.glsl",
+        "assets/test_identity_buffer.glsl",
+        "assets/test_identity_image_packed_buffer.glsl",
+        "assets/test_threes_buffer.glsl",
+        "assets/test_threes_image_packed_buffer.glsl",
+    ],
+    deps = [
+        "//caffe2:torch",
+        "//executorch/backends/arm:constants",
+        "//executorch/backends/arm/_passes:passes",
+        "//executorch/backends/arm/tosa/dialect:lib",
+        "//executorch/exir:lib",
+    ],
+)
+
+fbcode_target(_kind = runtime.python_library,
+    name = "vgf_runtime_test_utils",
+    srcs = ["runtime/_vgf_runtime_test_utils.py"],
+    deps = [
+        ":custom_vgf_test_utils",
+        ":runner_utils",
+        "//executorch/backends/arm:vgf",
+        "//executorch/backends/arm/_passes:passes",
+        "//executorch/exir:lib",
+        "fbsource//third-party/pypi/pytest:pytest",
+    ],
+)
+
+fbcode_target(_kind = runtime.python_library,
     name = "arm_tester_serialize",
     srcs = ["tester/serialize.py"],
     deps = [

--- a/backends/arm/test/_custom_vgf_test_utils.py
+++ b/backends/arm/test/_custom_vgf_test_utils.py
@@ -1,0 +1,999 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import base64
+import json
+import operator
+import subprocess  # nosec B404 - required to invoke trusted local shader tool
+from collections.abc import Callable
+from pathlib import Path
+from typing import Optional
+
+import torch
+import torch.nn.functional as F
+from executorch.backends.arm._passes.arm_pass import ArmPass
+from executorch.backends.arm.constants import NHWC_INVERSE_ORDER, NHWC_ORDER
+from executorch.backends.arm.tosa.dialect.ops.custom import (
+    has_fake_tosa_impl,
+    register_fake_tosa,
+)
+from executorch.exir.dialects._ops import ops as exir_ops
+from torch.fx.passes.infra.pass_base import PassResult
+from torch.fx.passes.shape_prop import _extract_tensor_metadata
+from torch.library import impl, register_fake
+
+TEST_SHADER_NAMESPACE = "arm_test_vulkan_custom_shader"
+TEST_SHADER_DOMAIN = "com.arm.VulkanCustomShader"
+TEST_GRID_SAMPLE_OPERATOR = "torch.nn.functional.grid_sample"
+TEST_GRID_READ_TENSOR_OPERATOR = "arm.test.grid_read_tensor_debug"
+TEST_ADD_OPERATOR = "torch.add"
+
+THREES_NAMESPACE = "arm_test_shader_ops"
+THREES_DOMAIN = "com.arm.VulkanCustomShader"
+THREES_OPERATOR = "arm.test.threes"
+THREES_IMAGE_PACKED_OPERATOR = "arm.test.threes_image_packed"
+IDENTITY_OPERATOR = "arm.test.identity"
+IDENTITY_IMAGE_PACKED_OPERATOR = "arm.test.identity_image_packed"
+
+_TEST_SHADER_LIB: Optional[torch.library.Library] = None
+_TEST_THREES_LIB: Optional[torch.library.Library] = None
+_TEST_SHADER_REGISTERED = False
+_TEST_THREES_REGISTERED = False
+_GRID_SAMPLE_TOSA_FAKE_IMPLS: dict[
+    bool,
+    Callable[[list[torch.Tensor], str, str, list[int]], list[torch.Tensor]],
+] = {}
+_ADD_TOSA_FAKE_IMPL: (
+    Callable[[list[torch.Tensor], str, str, list[int]], list[torch.Tensor]] | None
+) = None
+_THREES_TOSA_FAKE_IMPLS: dict[
+    str,
+    Callable[[list[torch.Tensor], str, str, list[int]], list[torch.Tensor]],
+] = {}
+
+_ASSET_DIR = Path(__file__).resolve().parent / "assets"
+
+
+def _set_fake_tensor_meta(node: torch.fx.Node, value) -> None:
+    node.meta["val"] = value
+    if isinstance(value, list):
+        if value:
+            node.meta["tensor_meta"] = _extract_tensor_metadata(value[0])
+    else:
+        node.meta["tensor_meta"] = _extract_tensor_metadata(value)
+
+
+def _decode_payload_attrs(implementation_attrs: list[int]) -> dict[str, object]:
+    return json.loads(bytes(implementation_attrs).decode("utf-8"))
+
+
+def _grid_sample_tosa_fake(
+    inputs: list[torch.Tensor],
+    implementation_attrs: list[int],
+) -> torch.Tensor:
+    input_tensor, grid = inputs
+    payload = _decode_payload_attrs(implementation_attrs)
+    if payload.get("input_0_type") == "Image":
+        return torch.empty(
+            (
+                input_tensor.shape[0],
+                grid.shape[1],
+                grid.shape[2],
+                input_tensor.shape[-1],
+            ),
+            dtype=input_tensor.dtype,
+            device=input_tensor.device,
+        )
+    return torch.empty(
+        (
+            input_tensor.shape[0],
+            input_tensor.shape[1],
+            grid.shape[1],
+            grid.shape[2],
+        ),
+        dtype=input_tensor.dtype,
+        device=input_tensor.device,
+    )
+
+
+def _grid_read_tensor_tosa_fake(inputs: list[torch.Tensor]) -> torch.Tensor:
+    _, grid = inputs
+    return torch.empty(
+        (grid.shape[0], grid.shape[3], grid.shape[1], grid.shape[2]),
+        dtype=grid.dtype,
+        device=grid.device,
+    )
+
+
+def _compile_glsl_to_spirv(shader_name: str) -> bytes:
+    result = (
+        subprocess.run(  # nosec B603, B607 - trusted local tool with fixed arguments
+            [
+                "glslc",
+                "-fshader-stage=compute",
+                "-o",
+                "-",
+                str(_ASSET_DIR / shader_name),
+            ],
+            check=True,
+            stdout=subprocess.PIPE,
+        )
+    )
+    return result.stdout
+
+
+def register_test_shader_library_ops() -> None:  # noqa: C901
+    global _TEST_SHADER_LIB, _TEST_SHADER_REGISTERED, _GRID_SAMPLE_TOSA_FAKE_IMPLS, _ADD_TOSA_FAKE_IMPL
+    if _TEST_SHADER_REGISTERED:
+        return
+
+    _TEST_SHADER_LIB = torch.library.Library(TEST_SHADER_NAMESPACE, "DEF")
+    lib = _TEST_SHADER_LIB
+    lib.define(
+        "grid_sample(Tensor input, Tensor grid, str? mode=None, "
+        "str? padding_mode=None, bool? align_corners=None) -> Tensor"
+    )
+    lib.define(
+        "grid_sample_buffer_debug(Tensor input, Tensor grid, str? mode=None, "
+        "str? padding_mode=None, bool? align_corners=None) -> Tensor"
+    )
+    lib.define(
+        "grid_sample_buffer_nchw_debug(Tensor input, Tensor grid, str? mode=None, "
+        "str? padding_mode=None, bool? align_corners=None) -> Tensor"
+    )
+    lib.define(
+        "grid_read_tensor_debug(Tensor input, Tensor grid, str? mode=None, "
+        "str? padding_mode=None, bool? align_corners=None) -> Tensor"
+    )
+    lib.define("add(Tensor a, Tensor b) -> Tensor")
+
+    @impl(lib, "grid_sample", dispatch_key="CompositeExplicitAutograd")
+    def _grid_sample_impl(
+        input: torch.Tensor,
+        grid: torch.Tensor,
+        mode: Optional[str] = None,
+        padding_mode: Optional[str] = None,
+        align_corners: Optional[bool] = None,
+    ) -> torch.Tensor:
+        return F.grid_sample(
+            input,
+            grid,
+            mode=mode or "bilinear",
+            padding_mode=padding_mode or "zeros",
+            align_corners=align_corners,
+        )
+
+    @register_fake(f"{TEST_SHADER_NAMESPACE}::grid_sample")
+    def _grid_sample_fake(
+        input: torch.Tensor,
+        grid: torch.Tensor,
+        mode: Optional[str] = None,
+        padding_mode: Optional[str] = None,
+        align_corners: Optional[bool] = None,
+    ) -> torch.Tensor:
+        _ = (mode, padding_mode, align_corners)
+        return torch.empty(
+            (
+                input.shape[0],
+                input.shape[1],
+                grid.shape[1],
+                grid.shape[2],
+            ),
+            dtype=input.dtype,
+            device=input.device,
+        )
+
+    @impl(lib, "grid_sample_buffer_debug", dispatch_key="CompositeExplicitAutograd")
+    def _grid_sample_buffer_debug_impl(
+        input: torch.Tensor,
+        grid: torch.Tensor,
+        mode: Optional[str] = None,
+        padding_mode: Optional[str] = None,
+        align_corners: Optional[bool] = None,
+    ) -> torch.Tensor:
+        return F.grid_sample(
+            input,
+            grid,
+            mode=mode or "bilinear",
+            padding_mode=padding_mode or "zeros",
+            align_corners=align_corners,
+        )
+
+    @register_fake(f"{TEST_SHADER_NAMESPACE}::grid_sample_buffer_debug")
+    def _grid_sample_buffer_debug_fake(
+        input: torch.Tensor,
+        grid: torch.Tensor,
+        mode: Optional[str] = None,
+        padding_mode: Optional[str] = None,
+        align_corners: Optional[bool] = None,
+    ) -> torch.Tensor:
+        return _grid_sample_fake(
+            input,
+            grid,
+            mode=mode,
+            padding_mode=padding_mode,
+            align_corners=align_corners,
+        )
+
+    @impl(
+        lib, "grid_sample_buffer_nchw_debug", dispatch_key="CompositeExplicitAutograd"
+    )
+    def _grid_sample_buffer_nchw_debug_impl(
+        input: torch.Tensor,
+        grid: torch.Tensor,
+        mode: Optional[str] = None,
+        padding_mode: Optional[str] = None,
+        align_corners: Optional[bool] = None,
+    ) -> torch.Tensor:
+        return F.grid_sample(
+            input,
+            grid,
+            mode=mode or "bilinear",
+            padding_mode=padding_mode or "zeros",
+            align_corners=align_corners,
+        ).contiguous()
+
+    @register_fake(f"{TEST_SHADER_NAMESPACE}::grid_sample_buffer_nchw_debug")
+    def _grid_sample_buffer_nchw_debug_fake(
+        input: torch.Tensor,
+        grid: torch.Tensor,
+        mode: Optional[str] = None,
+        padding_mode: Optional[str] = None,
+        align_corners: Optional[bool] = None,
+    ) -> torch.Tensor:
+        _ = (mode, padding_mode, align_corners)
+        return torch.empty(
+            (input.shape[0], input.shape[1], grid.shape[1], grid.shape[2]),
+            dtype=input.dtype,
+            device=input.device,
+        )
+
+    @impl(lib, "grid_read_tensor_debug", dispatch_key="CompositeExplicitAutograd")
+    def _grid_read_tensor_debug_impl(
+        input: torch.Tensor,
+        grid: torch.Tensor,
+        mode: Optional[str] = None,
+        padding_mode: Optional[str] = None,
+        align_corners: Optional[bool] = None,
+    ) -> torch.Tensor:
+        _ = (input, mode, padding_mode, align_corners)
+        return grid.permute(0, 3, 1, 2).contiguous()
+
+    @register_fake(f"{TEST_SHADER_NAMESPACE}::grid_read_tensor_debug")
+    def _grid_read_tensor_debug_fake(
+        input: torch.Tensor,
+        grid: torch.Tensor,
+        mode: Optional[str] = None,
+        padding_mode: Optional[str] = None,
+        align_corners: Optional[bool] = None,
+    ) -> torch.Tensor:
+        _ = (input, mode, padding_mode, align_corners)
+        return torch.empty(
+            (grid.shape[0], grid.shape[3], grid.shape[1], grid.shape[2]),
+            dtype=grid.dtype,
+            device=grid.device,
+        )
+
+    @register_fake_tosa(f"{TEST_GRID_SAMPLE_OPERATOR}.align_corners.True")
+    def _grid_sample_tosa_fake_true(
+        inputs: list[torch.Tensor],
+        operator_name: str,
+        domain_name: str,
+        implementation_attrs: list[int],
+    ) -> list[torch.Tensor]:
+        _ = implementation_attrs
+        assert operator_name == f"{TEST_GRID_SAMPLE_OPERATOR}.align_corners.True"
+        assert domain_name == TEST_SHADER_DOMAIN
+        return [_grid_sample_tosa_fake(inputs, implementation_attrs)]
+
+    @register_fake_tosa(f"{TEST_GRID_SAMPLE_OPERATOR}.align_corners.False")
+    def _grid_sample_tosa_fake_false(
+        inputs: list[torch.Tensor],
+        operator_name: str,
+        domain_name: str,
+        implementation_attrs: list[int],
+    ) -> list[torch.Tensor]:
+        _ = implementation_attrs
+        assert operator_name == f"{TEST_GRID_SAMPLE_OPERATOR}.align_corners.False"
+        assert domain_name == TEST_SHADER_DOMAIN
+        return [_grid_sample_tosa_fake(inputs, implementation_attrs)]
+
+    _GRID_SAMPLE_TOSA_FAKE_IMPLS = {
+        True: _grid_sample_tosa_fake_true,
+        False: _grid_sample_tosa_fake_false,
+    }
+
+    @register_fake_tosa(TEST_GRID_READ_TENSOR_OPERATOR)
+    def _grid_read_tensor_tosa_fake_impl(
+        inputs: list[torch.Tensor],
+        operator_name: str,
+        domain_name: str,
+        implementation_attrs: list[int],
+    ) -> list[torch.Tensor]:
+        _ = implementation_attrs
+        assert operator_name == TEST_GRID_READ_TENSOR_OPERATOR
+        assert domain_name == TEST_SHADER_DOMAIN
+        return [_grid_read_tensor_tosa_fake(inputs)]
+
+    @impl(lib, "add", dispatch_key="CompositeExplicitAutograd")
+    def _add_impl(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+        return a + b
+
+    @register_fake(f"{TEST_SHADER_NAMESPACE}::add")
+    def _add_fake(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+        return torch.empty_like(a)
+
+    @register_fake_tosa(TEST_ADD_OPERATOR)
+    def _add_tosa_fake_impl(
+        inputs: list[torch.Tensor],
+        operator_name: str,
+        domain_name: str,
+        implementation_attrs: list[int],
+    ) -> list[torch.Tensor]:
+        _ = implementation_attrs
+        assert operator_name == TEST_ADD_OPERATOR
+        assert domain_name == TEST_SHADER_DOMAIN
+        return [_add_fake(inputs[0], inputs[1])]
+
+    _ADD_TOSA_FAKE_IMPL = _add_tosa_fake_impl
+    _TEST_SHADER_REGISTERED = True
+
+
+def register_test_threes_library_ops() -> None:  # noqa: C901
+    global _TEST_THREES_LIB, _TEST_THREES_REGISTERED, _THREES_TOSA_FAKE_IMPLS
+    if _TEST_THREES_REGISTERED:
+        return
+
+    _TEST_THREES_LIB = torch.library.Library(THREES_NAMESPACE, "DEF")
+    lib = _TEST_THREES_LIB
+    lib.define("threes(Tensor x) -> Tensor")
+    lib.define("threes_image_packed(Tensor x) -> Tensor")
+    lib.define("identity(Tensor x) -> Tensor")
+    lib.define("identity_image_packed(Tensor x) -> Tensor")
+
+    @impl(lib, "threes", dispatch_key="CompositeExplicitAutograd")
+    def _threes_impl(x: torch.Tensor) -> torch.Tensor:
+        return x * 3.0 + 33.0
+
+    @register_fake(f"{THREES_NAMESPACE}::threes")
+    def _threes_fake(x: torch.Tensor) -> torch.Tensor:
+        return torch.empty_like(x)
+
+    @impl(lib, "threes_image_packed", dispatch_key="CompositeExplicitAutograd")
+    def _threes_image_packed_impl(x: torch.Tensor) -> torch.Tensor:
+        return x * 3.0 + 33.0
+
+    @register_fake(f"{THREES_NAMESPACE}::threes_image_packed")
+    def _threes_image_packed_fake(x: torch.Tensor) -> torch.Tensor:
+        return torch.empty_like(x)
+
+    @impl(lib, "identity", dispatch_key="CompositeExplicitAutograd")
+    def _identity_impl(x: torch.Tensor) -> torch.Tensor:
+        return x
+
+    @register_fake(f"{THREES_NAMESPACE}::identity")
+    def _identity_fake(x: torch.Tensor) -> torch.Tensor:
+        return torch.empty_like(x)
+
+    @impl(lib, "identity_image_packed", dispatch_key="CompositeExplicitAutograd")
+    def _identity_image_packed_impl(x: torch.Tensor) -> torch.Tensor:
+        return x
+
+    @register_fake(f"{THREES_NAMESPACE}::identity_image_packed")
+    def _identity_image_packed_fake(x: torch.Tensor) -> torch.Tensor:
+        return torch.empty_like(x)
+
+    @register_fake_tosa(THREES_OPERATOR)
+    def _threes_tosa_fake_impl(
+        inputs: list[torch.Tensor],
+        operator_name: str,
+        domain_name: str,
+        implementation_attrs: list[int],
+    ) -> list[torch.Tensor]:
+        _ = implementation_attrs
+        assert operator_name == THREES_OPERATOR
+        assert domain_name == THREES_DOMAIN
+        return [_threes_fake(inputs[0])]
+
+    @register_fake_tosa(THREES_IMAGE_PACKED_OPERATOR)
+    def _threes_image_packed_tosa_fake_impl(
+        inputs: list[torch.Tensor],
+        operator_name: str,
+        domain_name: str,
+        implementation_attrs: list[int],
+    ) -> list[torch.Tensor]:
+        _ = implementation_attrs
+        assert operator_name == THREES_IMAGE_PACKED_OPERATOR
+        assert domain_name == THREES_DOMAIN
+        return [_threes_image_packed_fake(inputs[0])]
+
+    @register_fake_tosa(IDENTITY_OPERATOR)
+    def _identity_tosa_fake_impl(
+        inputs: list[torch.Tensor],
+        operator_name: str,
+        domain_name: str,
+        implementation_attrs: list[int],
+    ) -> list[torch.Tensor]:
+        _ = implementation_attrs
+        assert operator_name == IDENTITY_OPERATOR
+        assert domain_name == THREES_DOMAIN
+        return [_identity_fake(inputs[0])]
+
+    @register_fake_tosa(IDENTITY_IMAGE_PACKED_OPERATOR)
+    def _identity_image_packed_tosa_fake_impl(
+        inputs: list[torch.Tensor],
+        operator_name: str,
+        domain_name: str,
+        implementation_attrs: list[int],
+    ) -> list[torch.Tensor]:
+        _ = implementation_attrs
+        assert operator_name == IDENTITY_IMAGE_PACKED_OPERATOR
+        assert domain_name == THREES_DOMAIN
+        return [_identity_image_packed_fake(inputs[0])]
+
+    _THREES_TOSA_FAKE_IMPLS = {
+        THREES_OPERATOR: _threes_tosa_fake_impl,
+        THREES_IMAGE_PACKED_OPERATOR: _threes_image_packed_tosa_fake_impl,
+        IDENTITY_OPERATOR: _identity_tosa_fake_impl,
+        IDENTITY_IMAGE_PACKED_OPERATOR: _identity_image_packed_tosa_fake_impl,
+    }
+    _TEST_THREES_REGISTERED = True
+
+
+def register_test_shader_partition_ops(partitioner) -> None:
+    partitioner.register_custom_partition_op(
+        torch.ops.arm_test_vulkan_custom_shader.grid_sample.default
+    )
+    partitioner.register_custom_partition_op(
+        torch.ops.arm_test_vulkan_custom_shader.grid_sample_buffer_debug.default
+    )
+    partitioner.register_custom_partition_op(
+        torch.ops.arm_test_vulkan_custom_shader.grid_sample_buffer_nchw_debug.default
+    )
+    partitioner.register_custom_partition_op(
+        torch.ops.arm_test_vulkan_custom_shader.grid_read_tensor_debug.default
+    )
+    partitioner.register_custom_partition_op(
+        torch.ops.arm_test_vulkan_custom_shader.add.default
+    )
+
+
+def register_test_threes_partition_ops(partitioner) -> None:
+    partitioner.register_custom_partition_op(
+        torch.ops.arm_test_shader_ops.threes.default
+    )
+    partitioner.register_custom_partition_op(
+        torch.ops.arm_test_shader_ops.threes_image_packed.default
+    )
+    partitioner.register_custom_partition_op(
+        torch.ops.arm_test_shader_ops.identity.default
+    )
+    partitioner.register_custom_partition_op(
+        torch.ops.arm_test_shader_ops.identity_image_packed.default
+    )
+
+
+def rewrite_aten_grid_sample_to_test_shader(graph_module: torch.fx.GraphModule) -> bool:
+    graph = graph_module.graph
+    modified = False
+    for node in list(graph.nodes):
+        if node.op != "call_function" or "grid_sampler" not in str(node.target):
+            continue
+        input_tensor = node.args[0]
+        grid = node.args[1]
+        with graph.inserting_before(node):
+            new_node = graph.call_function(
+                torch.ops.arm_test_vulkan_custom_shader.grid_sample.default,
+                args=(input_tensor, grid),
+                kwargs={
+                    "mode": node.kwargs.get("mode"),
+                    "padding_mode": node.kwargs.get("padding_mode"),
+                    "align_corners": node.kwargs.get("align_corners"),
+                },
+            )
+            new_node.meta = dict(node.meta)
+            input_val = input_tensor.meta["val"]
+            grid_val = grid.meta["val"]
+            _set_fake_tensor_meta(
+                new_node,
+                torch.empty(
+                    (
+                        input_val.shape[0],
+                        input_val.shape[1],
+                        grid_val.shape[1],
+                        grid_val.shape[2],
+                    ),
+                    dtype=input_val.dtype,
+                    device=input_val.device,
+                ),
+            )
+        node.replace_all_uses_with(new_node)
+        graph.erase_node(node)
+        modified = True
+    if modified:
+        graph_module.recompile()
+    return modified
+
+
+def rewrite_aten_add_to_test_shader(graph_module: torch.fx.GraphModule) -> bool:
+    graph = graph_module.graph
+    modified = False
+    for node in list(graph.nodes):
+        if node.op != "call_function" or node.target != torch.ops.aten.add.Tensor:
+            continue
+        with graph.inserting_before(node):
+            new_node = graph.call_function(
+                torch.ops.arm_test_vulkan_custom_shader.add.default,
+                args=node.args[:2],
+                kwargs={},
+            )
+            new_node.meta = dict(node.meta)
+        node.replace_all_uses_with(new_node)
+        graph.erase_node(node)
+        modified = True
+    if modified:
+        graph_module.recompile()
+    return modified
+
+
+class EncodeSamplerGridSampleToTosaCustomPass(ArmPass):
+    _passes_required_after = set()
+
+    @staticmethod
+    def _infer_vkformat(input_node: torch.fx.Node, expect_nchw: bool) -> str:
+        val = input_node.meta["val"]
+        shape = tuple(val.shape)
+        channels = int(shape[1] if expect_nchw else shape[-1])
+        if val.dtype != torch.float32:
+            raise RuntimeError(f"Unsupported dtype for vkformat: {val.dtype}")
+        if channels == 1:
+            return "VK_FORMAT_R32_SFLOAT"
+        if channels == 2:
+            return "VK_FORMAT_R32G32_SFLOAT"
+        if channels == 4:
+            return "VK_FORMAT_R32G32B32A32_SFLOAT"
+        if channels == 3:
+            raise ValueError(
+                "Image-backed grid_sample requires 1, 2, or 4 channels; got 3"
+            )
+        raise RuntimeError(f"Unsupported channel count for grid_sample: {channels}")
+
+    @staticmethod
+    def _make_nhwc_fake(
+        input_val: torch.Tensor,
+        grid_val: torch.Tensor,
+    ) -> torch.Tensor:
+        return torch.empty(
+            (
+                input_val.shape[0],
+                grid_val.shape[1],
+                grid_val.shape[2],
+                input_val.shape[1],
+            ),
+            dtype=input_val.dtype,
+            device=input_val.device,
+        )
+
+    def call(self, graph_module):  # noqa: C901
+        graph = graph_module.graph
+        modified = False
+        for node in list(graph.nodes):
+            if node.op != "call_function":
+                continue
+            target_name = str(node.target)
+            if (
+                "arm_test_vulkan_custom_shader.grid_sample" not in target_name
+                and "arm_test_vulkan_custom_shader.grid_read_tensor_debug"
+                not in target_name
+            ):
+                continue
+
+            input_tensor, grid = node.args[:2]
+            mode = node.kwargs.get("mode") or "bilinear"
+            padding_mode = node.kwargs.get("padding_mode") or "zeros"
+            align_corners = node.kwargs.get("align_corners")
+
+            sampler = {}
+            if mode == "bilinear":
+                sampler["mag_filter"] = "VK_FILTER_LINEAR"
+                sampler["min_filter"] = "VK_FILTER_LINEAR"
+            elif mode == "nearest":
+                sampler["mag_filter"] = "VK_FILTER_NEAREST"
+                sampler["min_filter"] = "VK_FILTER_NEAREST"
+            elif mode == "bicubic":
+                sampler["mag_filter"] = "VK_FILTER_LINEAR"
+                sampler["min_filter"] = "VK_FILTER_LINEAR"
+            else:
+                raise RuntimeError(f"Unsupported grid_sample mode: {mode}")
+
+            if padding_mode == "zeros":
+                sampler["address_mode_u"] = "VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER"
+                sampler["address_mode_v"] = "VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER"
+                sampler["border_color"] = "VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK"
+            elif padding_mode == "border":
+                sampler["address_mode_u"] = "VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE"
+                sampler["address_mode_v"] = "VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE"
+            elif padding_mode == "reflection":
+                sampler["address_mode_u"] = "VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT"
+                sampler["address_mode_v"] = "VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT"
+            else:
+                raise RuntimeError(
+                    f"Unsupported grid_sample padding_mode: {padding_mode}"
+                )
+
+            shader_name = "test_grid_sample_sampler.glsl"
+            input_type = "Image"
+            input_descriptor_type = "VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER"
+            input_vkformat = self._infer_vkformat(input_tensor, expect_nchw=True)
+            output_type = "Image"
+            output_descriptor_type = "VK_DESCRIPTOR_TYPE_STORAGE_IMAGE"
+            output_vkformat = self._infer_vkformat(input_tensor, expect_nchw=True)
+            include_sampler = True
+            if "grid_sample_buffer_nchw_debug" in target_name:
+                shader_name = "test_grid_sample_buffer_nchw_debug.glsl"
+                input_type = "Buffer"
+                input_descriptor_type = "VK_DESCRIPTOR_TYPE_STORAGE_BUFFER"
+                input_vkformat = "VK_FORMAT_R32_SFLOAT"
+                output_type = "Buffer"
+                output_descriptor_type = "VK_DESCRIPTOR_TYPE_STORAGE_BUFFER"
+                output_vkformat = "VK_FORMAT_R32_SFLOAT"
+                include_sampler = False
+            elif "grid_read_tensor_debug" in target_name:
+                shader_name = "test_grid_read_tensor_debug.glsl"
+                input_type = "Buffer"
+                input_descriptor_type = "VK_DESCRIPTOR_TYPE_STORAGE_BUFFER"
+                input_vkformat = "VK_FORMAT_R32_SFLOAT"
+                output_type = "Buffer"
+                output_descriptor_type = "VK_DESCRIPTOR_TYPE_STORAGE_BUFFER"
+                output_vkformat = "VK_FORMAT_R32_SFLOAT"
+                include_sampler = False
+            elif "grid_sample_buffer_debug" in target_name:
+                shader_name = "test_grid_sample_sampler_buffer_debug.glsl"
+                output_type = "Buffer"
+                output_descriptor_type = "VK_DESCRIPTOR_TYPE_STORAGE_BUFFER"
+                output_vkformat = "VK_FORMAT_R32_SFLOAT"
+            payload = {
+                "entry_point": "main",
+                "workgroup_sizes": [8, 8, 1],
+                "is_vkshader": True,
+                "shader_code": base64.b64encode(
+                    _compile_glsl_to_spirv(shader_name)
+                ).decode("ascii"),
+                "shader_language": "SPIR-V",
+                "push_constants": "",
+                "input_0_binding": 0,
+                "input_1_binding": 1,
+                "output_0_binding": 2,
+                "input_0_vkdescriptortype": input_descriptor_type,
+                "input_1_vkdescriptortype": "VK_DESCRIPTOR_TYPE_TENSOR_ARM",
+                "output_0_vkdescriptortype": output_descriptor_type,
+                "input_0_descriptorset": 0,
+                "input_1_descriptorset": 0,
+                "output_0_descriptorset": 0,
+                "input_0_type": input_type,
+                "input_1_type": "Tensor",
+                "output_0_type": output_type,
+                "input_0_vkformat": input_vkformat,
+                "input_1_vkformat": "VK_FORMAT_R32_SFLOAT",
+                "output_0_vkformat": output_vkformat,
+            }
+            if include_sampler:
+                payload["input_0_sampler"] = sampler
+            implementation_attrs = list(json.dumps(payload).encode("utf-8"))
+            operator_name = (
+                TEST_GRID_READ_TENSOR_OPERATOR
+                if "grid_read_tensor_debug" in target_name
+                else f"{TEST_GRID_SAMPLE_OPERATOR}.align_corners.{align_corners is True}"
+            )
+
+            if not has_fake_tosa_impl(operator_name):
+                raise RuntimeError(
+                    f"tosa.CUSTOM fake impl is not registered for {operator_name}"
+                )
+
+            with graph.inserting_before(node):
+                use_nhwc_shader_contract = (
+                    "grid_sample_buffer_nchw_debug" not in target_name
+                    and "grid_read_tensor_debug" not in target_name
+                )
+                custom_input = input_tensor
+                if use_nhwc_shader_contract:
+                    custom_input = graph.call_function(
+                        exir_ops.edge.aten.permute_copy.default,
+                        args=(input_tensor, list(NHWC_ORDER)),
+                        kwargs={},
+                    )
+                    custom_input.meta = dict(input_tensor.meta)
+                    _set_fake_tensor_meta(
+                        custom_input,
+                        exir_ops.edge.aten.permute_copy.default(
+                            input_tensor.meta["val"], list(NHWC_ORDER)
+                        ),
+                    )
+
+                tosa_custom = graph.call_function(
+                    exir_ops.backend.tosa.CUSTOM.default,
+                    args=([custom_input, grid],),
+                    kwargs={
+                        "operator_name": operator_name,
+                        "domain_name": TEST_SHADER_DOMAIN,
+                        "implementation_attrs": implementation_attrs,
+                    },
+                )
+                if (
+                    "grid_sample_buffer_nchw_debug" in target_name
+                    or "grid_read_tensor_debug" in target_name
+                ):
+                    grid_val = grid.meta["val"]
+                    if "grid_read_tensor_debug" in target_name:
+                        fake_outputs = [
+                            torch.empty(
+                                (
+                                    grid_val.shape[0],
+                                    grid_val.shape[3],
+                                    grid_val.shape[1],
+                                    grid_val.shape[2],
+                                ),
+                                dtype=grid_val.dtype,
+                                device=grid_val.device,
+                            )
+                        ]
+                    else:
+                        input_val = input_tensor.meta["val"]
+                        fake_outputs = [
+                            torch.empty(
+                                (
+                                    input_val.shape[0],
+                                    input_val.shape[1],
+                                    grid_val.shape[1],
+                                    grid_val.shape[2],
+                                ),
+                                dtype=input_val.dtype,
+                                device=input_val.device,
+                            )
+                        ]
+                else:
+                    fake_outputs = [
+                        self._make_nhwc_fake(input_tensor.meta["val"], grid.meta["val"])
+                    ]
+                tosa_custom.meta = dict(node.meta)
+                _set_fake_tensor_meta(tosa_custom, fake_outputs)
+                custom_output = graph.call_function(
+                    operator.getitem, args=(tosa_custom, 0), kwargs={}
+                )
+                custom_output.meta = dict(node.meta)
+                _set_fake_tensor_meta(custom_output, fake_outputs[0])
+
+                if use_nhwc_shader_contract:
+                    output = graph.call_function(
+                        exir_ops.edge.aten.permute_copy.default,
+                        args=(custom_output, list(NHWC_INVERSE_ORDER)),
+                        kwargs={},
+                    )
+                    output.meta = dict(node.meta)
+                    _set_fake_tensor_meta(
+                        output,
+                        exir_ops.edge.aten.permute_copy.default(
+                            custom_output.meta["val"], list(NHWC_INVERSE_ORDER)
+                        ),
+                    )
+                else:
+                    output = custom_output
+
+            node.replace_all_uses_with(output)
+            graph.erase_node(node)
+            modified = True
+
+        if modified:
+            graph_module.recompile()
+        return PassResult(graph_module, modified)
+
+
+class EncodeTestAddToTosaCustomPass(ArmPass):
+    _passes_required_after = set()
+
+    def call(self, graph_module):
+        graph = graph_module.graph
+        modified = False
+        for node in list(graph.nodes):
+            if node.op != "call_function":
+                continue
+            if "arm_test_vulkan_custom_shader.add" not in str(node.target):
+                continue
+
+            a, b = node.args[:2]
+            payload = {
+                "entry_point": "main",
+                "workgroup_sizes": [64, 1, 1],
+                "is_vkshader": True,
+                "shader_code": base64.b64encode(
+                    _compile_glsl_to_spirv("test_add_buffer.glsl")
+                ).decode("ascii"),
+                "shader_language": "SPIR-V",
+                "push_constants": "",
+                "input_0_binding": 0,
+                "input_1_binding": 1,
+                "output_0_binding": 2,
+                "input_0_type": "Buffer",
+                "input_1_type": "Buffer",
+                "output_0_type": "Buffer",
+                "input_0_vkdescriptortype": "VK_DESCRIPTOR_TYPE_STORAGE_BUFFER",
+                "input_1_vkdescriptortype": "VK_DESCRIPTOR_TYPE_STORAGE_BUFFER",
+                "output_0_vkdescriptortype": "VK_DESCRIPTOR_TYPE_STORAGE_BUFFER",
+                "input_0_descriptorset": 0,
+                "input_1_descriptorset": 0,
+                "output_0_descriptorset": 0,
+                "input_0_vkformat": "VK_FORMAT_R32_SFLOAT",
+                "input_1_vkformat": "VK_FORMAT_R32_SFLOAT",
+                "output_0_vkformat": "VK_FORMAT_R32_SFLOAT",
+            }
+            implementation_attrs = list(json.dumps(payload).encode("utf-8"))
+            with graph.inserting_before(node):
+                tosa_custom = graph.call_function(
+                    exir_ops.backend.tosa.CUSTOM.default,
+                    args=([a, b],),
+                    kwargs={
+                        "operator_name": TEST_ADD_OPERATOR,
+                        "domain_name": TEST_SHADER_DOMAIN,
+                        "implementation_attrs": implementation_attrs,
+                    },
+                )
+                add_tosa_fake_impl = _ADD_TOSA_FAKE_IMPL
+                assert add_tosa_fake_impl is not None
+                fake_outputs = add_tosa_fake_impl(
+                    [a.meta["val"], b.meta["val"]],
+                    TEST_ADD_OPERATOR,
+                    TEST_SHADER_DOMAIN,
+                    implementation_attrs,
+                )
+                tosa_custom.meta = dict(node.meta)
+                _set_fake_tensor_meta(tosa_custom, fake_outputs)
+                output = graph.call_function(
+                    operator.getitem, args=(tosa_custom, 0), kwargs={}
+                )
+                output.meta = dict(node.meta)
+                _set_fake_tensor_meta(output, fake_outputs[0])
+
+            node.replace_all_uses_with(output)
+            graph.erase_node(node)
+            modified = True
+
+        if modified:
+            graph_module.recompile()
+        return PassResult(graph_module, modified)
+
+
+class EncodeThreesToTosaCustomPass(ArmPass):
+    _passes_required_after = set()
+
+    @staticmethod
+    def _make_nhwc_fake(input_val: torch.Tensor) -> torch.Tensor:
+        return torch.empty(
+            (
+                input_val.shape[0],
+                input_val.shape[2],
+                input_val.shape[3],
+                input_val.shape[1],
+            ),
+            dtype=input_val.dtype,
+            device=input_val.device,
+        )
+
+    def call(self, graph_module):
+        graph = graph_module.graph
+        modified = False
+        for node in list(graph.nodes):
+            if node.op != "call_function":
+                continue
+            target_name = str(node.target)
+            if (
+                "arm_test_shader_ops.threes" not in target_name
+                and "arm_test_shader_ops.identity" not in target_name
+            ):
+                continue
+
+            (x,) = node.args[:1]
+            operator_name = THREES_OPERATOR
+            shader_name = "test_threes_buffer.glsl"
+            use_nhwc_shader_contract = False
+            if "threes_image_packed" in target_name:
+                operator_name = THREES_IMAGE_PACKED_OPERATOR
+                use_nhwc_shader_contract = True
+            elif "identity_image_packed" in target_name:
+                operator_name = IDENTITY_IMAGE_PACKED_OPERATOR
+                shader_name = "test_identity_buffer.glsl"
+                use_nhwc_shader_contract = True
+            elif "identity" in target_name:
+                operator_name = IDENTITY_OPERATOR
+                shader_name = "test_identity_buffer.glsl"
+            payload = {
+                "entry_point": "main",
+                "workgroup_sizes": [64, 1, 1],
+                "is_vkshader": True,
+                "shader_code": base64.b64encode(
+                    _compile_glsl_to_spirv(shader_name)
+                ).decode("ascii"),
+                "shader_language": "SPIR-V",
+                "push_constants": "",
+                "input_0_binding": 0,
+                "output_0_binding": 1,
+                "input_0_type": "Buffer",
+                "output_0_type": "Buffer",
+                "input_0_vkdescriptortype": "VK_DESCRIPTOR_TYPE_STORAGE_BUFFER",
+                "output_0_vkdescriptortype": "VK_DESCRIPTOR_TYPE_STORAGE_BUFFER",
+                "input_0_descriptorset": 0,
+                "output_0_descriptorset": 0,
+                "input_0_vkformat": "VK_FORMAT_R32_SFLOAT",
+                "output_0_vkformat": "VK_FORMAT_R32_SFLOAT",
+            }
+            implementation_attrs = list(json.dumps(payload).encode("utf-8"))
+
+            with graph.inserting_before(node):
+                custom_input = x
+                if use_nhwc_shader_contract:
+                    custom_input = graph.call_function(
+                        exir_ops.edge.aten.permute_copy.default,
+                        args=(x, list(NHWC_ORDER)),
+                        kwargs={},
+                    )
+                    custom_input.meta = dict(x.meta)
+                    _set_fake_tensor_meta(
+                        custom_input,
+                        exir_ops.edge.aten.permute_copy.default(
+                            x.meta["val"], list(NHWC_ORDER)
+                        ),
+                    )
+
+                tosa_custom = graph.call_function(
+                    exir_ops.backend.tosa.CUSTOM.default,
+                    args=([custom_input],),
+                    kwargs={
+                        "operator_name": operator_name,
+                        "domain_name": THREES_DOMAIN,
+                        "implementation_attrs": implementation_attrs,
+                    },
+                )
+                if use_nhwc_shader_contract:
+                    fake_outputs = [self._make_nhwc_fake(x.meta["val"])]
+                else:
+                    fake_outputs = _THREES_TOSA_FAKE_IMPLS[operator_name](
+                        [x.meta["val"]],
+                        operator_name,
+                        THREES_DOMAIN,
+                        implementation_attrs,
+                    )
+                tosa_custom.meta = dict(node.meta)
+                _set_fake_tensor_meta(tosa_custom, fake_outputs)
+                custom_output = graph.call_function(
+                    operator.getitem, args=(tosa_custom, 0), kwargs={}
+                )
+                custom_output.meta = dict(node.meta)
+                _set_fake_tensor_meta(custom_output, fake_outputs[0])
+
+                if use_nhwc_shader_contract:
+                    output = graph.call_function(
+                        exir_ops.edge.aten.permute_copy.default,
+                        args=(custom_output, list(NHWC_INVERSE_ORDER)),
+                        kwargs={},
+                    )
+                    output.meta = dict(node.meta)
+                    _set_fake_tensor_meta(
+                        output,
+                        exir_ops.edge.aten.permute_copy.default(
+                            custom_output.meta["val"], list(NHWC_INVERSE_ORDER)
+                        ),
+                    )
+                else:
+                    output = custom_output
+
+            node.replace_all_uses_with(output)
+            graph.erase_node(node)
+            modified = True
+
+        if modified:
+            graph_module.recompile()
+        return PassResult(graph_module, modified)

--- a/backends/arm/test/assets/test_add_buffer.glsl
+++ b/backends/arm/test/assets/test_add_buffer.glsl
@@ -1,0 +1,17 @@
+// Copyright 2026 Arm Limited and/or its affiliates.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#version 450
+layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
+layout(set=0, binding=0) buffer A { float a[]; };
+layout(set=0, binding=1) buffer B { float b[]; };
+layout(set=0, binding=2) buffer OutputBuffer { float outBuffer[]; };
+void main() {
+  uint idx = gl_GlobalInvocationID.x;
+  if (idx >= outBuffer.length()) {
+    return;
+  }
+  outBuffer[idx] = a[idx] + b[idx];
+}

--- a/backends/arm/test/assets/test_grid_read_tensor_debug.glsl
+++ b/backends/arm/test/assets/test_grid_read_tensor_debug.glsl
@@ -1,0 +1,33 @@
+// Copyright 2026 Arm Limited and/or its affiliates.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#version 450
+#extension GL_ARM_tensors : require
+
+layout(set=0, binding=0) readonly buffer InputBuffer { float input_data[]; };
+layout(set=0, binding=1) uniform tensorARM<float, 4> grid;
+layout(set=0, binding=2) buffer OutputBuffer { float out_data[]; };
+layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
+
+void main() {
+  const uint width = 9u;
+  const uint height = 4u;
+  ivec2 gid = ivec2(gl_GlobalInvocationID.xy);
+  if (gid.x >= int(width) || gid.y >= int(height)) {
+    return;
+  }
+
+  uint xCoords[4] = uint[](0u, uint(gid.y), uint(gid.x), 0u);
+  uint yCoords[4] = uint[](0u, uint(gid.y), uint(gid.x), 1u);
+  float xVal[1];
+  float yVal[1];
+  tensorReadARM(grid, xCoords, xVal);
+  tensorReadARM(grid, yCoords, yVal);
+
+  uint plane_size = width * height;
+  uint base = uint(gid.y) * width + uint(gid.x);
+  out_data[base] = xVal[0];
+  out_data[plane_size + base] = yVal[0];
+}

--- a/backends/arm/test/assets/test_grid_sample_buffer_nchw_debug.glsl
+++ b/backends/arm/test/assets/test_grid_sample_buffer_nchw_debug.glsl
@@ -1,0 +1,73 @@
+// Copyright 2026 Arm Limited and/or its affiliates.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#version 450
+#extension GL_ARM_tensors : require
+
+layout(set=0, binding=0) readonly buffer InputBuffer { float input_data[]; };
+layout(set=0, binding=1) uniform tensorARM<float, 4> grid;
+layout(set=0, binding=2) buffer OutputBuffer { float out_data[]; };
+layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
+
+vec2 readGridXY(ivec2 p) {
+  uint xCoords[4] = uint[](0u, uint(p.y), uint(p.x), 0u);
+  uint yCoords[4] = uint[](0u, uint(p.y), uint(p.x), 1u);
+  float xVal[1];
+  float yVal[1];
+  tensorReadARM(grid, xCoords, xVal);
+  tensorReadARM(grid, yCoords, yVal);
+  return vec2(xVal[0], yVal[0]);
+}
+
+float readInput(uint c, int y, int x) {
+  const int width = 8;
+  const int height = 8;
+  if (x < 0 || x >= width || y < 0 || y >= height) {
+    return 0.0;
+  }
+  uint idx = (c * uint(height) + uint(y)) * uint(width) + uint(x);
+  return input_data[idx];
+}
+
+void main() {
+  const int in_width = 8;
+  const int in_height = 8;
+  const int out_width = 9;
+  const int out_height = 4;
+
+  ivec2 gid = ivec2(gl_GlobalInvocationID.xy);
+  if (gid.x >= out_width || gid.y >= out_height) {
+    return;
+  }
+
+  vec2 gridXY = readGridXY(gid);
+  float ix = ((gridXY.x + 1.0) * float(in_width) - 1.0) * 0.5;
+  float iy = ((gridXY.y + 1.0) * float(in_height) - 1.0) * 0.5;
+
+  int x0 = int(floor(ix));
+  int y0 = int(floor(iy));
+  int x1 = x0 + 1;
+  int y1 = y0 + 1;
+
+  float wx1 = ix - float(x0);
+  float wy1 = iy - float(y0);
+  float wx0 = 1.0 - wx1;
+  float wy0 = 1.0 - wy1;
+
+  for (uint c = 0u; c < 4u; ++c) {
+    float v00 = readInput(c, y0, x0);
+    float v01 = readInput(c, y0, x1);
+    float v10 = readInput(c, y1, x0);
+    float v11 = readInput(c, y1, x1);
+    float sample_val =
+        v00 * wx0 * wy0 +
+        v01 * wx1 * wy0 +
+        v10 * wx0 * wy1 +
+        v11 * wx1 * wy1;
+    uint out_idx =
+        (c * uint(out_height) + uint(gid.y)) * uint(out_width) + uint(gid.x);
+    out_data[out_idx] = sample_val;
+  }
+}

--- a/backends/arm/test/assets/test_grid_sample_sampler.glsl
+++ b/backends/arm/test/assets/test_grid_sample_sampler.glsl
@@ -1,0 +1,28 @@
+// Copyright 2026 Arm Limited and/or its affiliates.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#version 450
+#extension GL_ARM_tensors : require
+layout(set=0, binding=0) uniform sampler2D inputImage;
+layout(set=0, binding=1) uniform tensorARM<float, 4> grid;
+layout(set=0, binding=2, rgba32f) uniform writeonly image2D outImage;
+layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
+vec2 readGridXY(ivec2 p) {
+  uint xCoords[4] = uint[](0u, uint(p.y), uint(p.x), 0u);
+  uint yCoords[4] = uint[](0u, uint(p.y), uint(p.x), 1u);
+  float xVal[1];
+  float yVal[1];
+  tensorReadARM(grid, xCoords, xVal);
+  tensorReadARM(grid, yCoords, yVal);
+  return vec2(xVal[0], yVal[0]);
+}
+void main() {
+  ivec2 outSize = imageSize(outImage);
+  ivec2 gid = ivec2(gl_GlobalInvocationID.xy);
+  if (gid.x >= outSize.x || gid.y >= outSize.y) { return; }
+  vec2 gridXY = readGridXY(gid);
+  vec2 uv = (gridXY + vec2(1.0)) * 0.5;
+  imageStore(outImage, gid, texture(inputImage, uv));
+}

--- a/backends/arm/test/assets/test_grid_sample_sampler_buffer_debug.glsl
+++ b/backends/arm/test/assets/test_grid_sample_sampler_buffer_debug.glsl
@@ -1,0 +1,40 @@
+// Copyright 2026 Arm Limited and/or its affiliates.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#version 450
+#extension GL_ARM_tensors : require
+
+layout(set=0, binding=0) uniform sampler2D inputImage;
+layout(set=0, binding=1) uniform tensorARM<float, 4> grid;
+layout(set=0, binding=2) buffer OutputBuffer { float out_data[]; };
+layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
+
+vec2 readGridXY(ivec2 p) {
+  uint xCoords[4] = uint[](0u, uint(p.y), uint(p.x), 0u);
+  uint yCoords[4] = uint[](0u, uint(p.y), uint(p.x), 1u);
+  float xVal[1];
+  float yVal[1];
+  tensorReadARM(grid, xCoords, xVal);
+  tensorReadARM(grid, yCoords, yVal);
+  return vec2(xVal[0], yVal[0]);
+}
+
+void main() {
+  const uint width = 9u;
+  const uint height = 4u;
+  ivec2 gid = ivec2(gl_GlobalInvocationID.xy);
+  if (gid.x >= int(width) || gid.y >= int(height)) {
+    return;
+  }
+
+  vec2 gridXY = readGridXY(gid);
+  vec2 uv = (gridXY + vec2(1.0)) * 0.5;
+  vec4 sample_val = texture(inputImage, uv);
+  uint base = uint((gid.y * int(width) + gid.x) * 4);
+  out_data[base + 0u] = sample_val.r;
+  out_data[base + 1u] = sample_val.g;
+  out_data[base + 2u] = sample_val.b;
+  out_data[base + 3u] = sample_val.a;
+}

--- a/backends/arm/test/assets/test_identity_buffer.glsl
+++ b/backends/arm/test/assets/test_identity_buffer.glsl
@@ -1,0 +1,16 @@
+// Copyright 2026 Arm Limited and/or its affiliates.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#version 450
+layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
+layout(set = 0, binding = 0) buffer In { float x[]; };
+layout(set = 0, binding = 1) buffer OutputBuffer { float out_data[]; };
+void main() {
+  uint idx = gl_GlobalInvocationID.x;
+  if (idx >= out_data.length()) {
+    return;
+  }
+  out_data[idx] = x[idx];
+}

--- a/backends/arm/test/assets/test_identity_image_packed_buffer.glsl
+++ b/backends/arm/test/assets/test_identity_image_packed_buffer.glsl
@@ -1,0 +1,28 @@
+// Copyright 2026 Arm Limited and/or its affiliates.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#version 450
+layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
+layout(set = 0, binding = 0) buffer In { float x[]; };
+layout(set = 0, binding = 1) buffer OutputBuffer { float out_data[]; };
+
+void main() {
+  const uint channels = 4u;
+  const uint width = 8u;
+  const uint height = 8u;
+  const uint spatial = width * height;
+
+  uint idx = gl_GlobalInvocationID.x;
+  if (idx >= out_data.length()) {
+    return;
+  }
+
+  uint c = idx / spatial;
+  uint rem = idx % spatial;
+  uint y = rem / width;
+  uint x_coord = rem % width;
+  uint out_idx = (y * width + x_coord) * channels + c;
+  out_data[out_idx] = x[idx];
+}

--- a/backends/arm/test/assets/test_threes_buffer.glsl
+++ b/backends/arm/test/assets/test_threes_buffer.glsl
@@ -1,0 +1,16 @@
+// Copyright 2026 Arm Limited and/or its affiliates.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#version 450
+layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
+layout(set = 0, binding = 0) buffer In { float x[]; };
+layout(set = 0, binding = 1) buffer OutputBuffer { float out_data[]; };
+void main() {
+  uint idx = gl_GlobalInvocationID.x;
+  if (idx >= out_data.length()) {
+    return;
+  }
+  out_data[idx] = x[idx] * 3.0 + 33.0;
+}

--- a/backends/arm/test/assets/test_threes_image_packed_buffer.glsl
+++ b/backends/arm/test/assets/test_threes_image_packed_buffer.glsl
@@ -1,0 +1,28 @@
+// Copyright 2026 Arm Limited and/or its affiliates.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#version 450
+layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
+layout(set = 0, binding = 0) buffer In { float x[]; };
+layout(set = 0, binding = 1) buffer OutputBuffer { float out_data[]; };
+
+void main() {
+  const uint channels = 4u;
+  const uint width = 8u;
+  const uint height = 8u;
+  const uint spatial = width * height;
+
+  uint idx = gl_GlobalInvocationID.x;
+  if (idx >= out_data.length()) {
+    return;
+  }
+
+  uint c = idx / spatial;
+  uint rem = idx % spatial;
+  uint y = rem / width;
+  uint x_coord = rem % width;
+  uint out_idx = (y * width + x_coord) * channels + c;
+  out_data[out_idx] = x[idx] * 3.0 + 33.0;
+}

--- a/backends/arm/test/misc/test_custom_shader_payloads.py
+++ b/backends/arm/test/misc/test_custom_shader_payloads.py
@@ -1,0 +1,177 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import base64
+import json
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
+
+from backends.arm.test._custom_vgf_test_utils import (
+    EncodeSamplerGridSampleToTosaCustomPass,
+    register_test_shader_library_ops,
+    rewrite_aten_grid_sample_to_test_shader,
+)
+from executorch.backends.arm.tosa.specification import (
+    TosaLoweringContext,
+    TosaSpecification,
+)
+from executorch.backends.arm.vgf.shaders.grid_sampler import (
+    build_grid_sampler_2d_payload,
+    decode_payload,
+    encode_payload,
+    GRID_SAMPLER_2D_SHADER_BINARY,
+    GRID_SAMPLER_2D_SHADER_ENTRY_POINT,
+    GRID_SAMPLER_2D_SHADER_LANGUAGE,
+    GRID_SAMPLER_2D_SHADER_SOURCE,
+    GRID_SAMPLER_2D_VK_FORMAT,
+    GRID_SAMPLER_2D_WORKGROUP_SIZES,
+)
+from torch.export import export
+
+
+class _GridSampleModule(torch.nn.Module):
+    def __init__(
+        self,
+        mode: str = "bilinear",
+        padding_mode: str = "zeros",
+        align_corners: bool = False,
+    ) -> None:
+        super().__init__()
+        self.mode = mode
+        self.padding_mode = padding_mode
+        self.align_corners = align_corners
+
+    def forward(self, x: torch.Tensor, grid: torch.Tensor) -> torch.Tensor:
+        return F.grid_sample(
+            x,
+            grid,
+            mode=self.mode,
+            padding_mode=self.padding_mode,
+            align_corners=self.align_corners,
+        )
+
+
+def _decode_sampler_payload(
+    mode: str | None = None,
+    padding_mode: str | None = None,
+    align_corners: bool = False,
+) -> dict[str, object]:
+    if shutil.which("glslc") is None:
+        pytest.skip("glslc not found")
+    register_test_shader_library_ops()
+    module = _GridSampleModule("bilinear", "zeros", align_corners)
+    example_inputs = (
+        torch.randn(1, 4, 8, 8).contiguous(memory_format=torch.channels_last),
+        torch.randn(1, 4, 4, 2),
+    )
+    exported = export(module, example_inputs)
+    graph_module = exported.graph_module
+    rewrite_aten_grid_sample_to_test_shader(graph_module)
+
+    for node in graph_module.graph.nodes:
+        if "arm_test_vulkan_custom_shader.grid_sample" not in str(node.target):
+            continue
+        updated_kwargs = dict(node.kwargs)
+        if mode is not None:
+            updated_kwargs["mode"] = mode
+        if padding_mode is not None:
+            updated_kwargs["padding_mode"] = padding_mode
+        node.kwargs = updated_kwargs
+
+    with TosaLoweringContext(TosaSpecification.create_from_string("TOSA-1.0+FP")):
+        EncodeSamplerGridSampleToTosaCustomPass().call(graph_module)
+
+    custom_node = next(
+        node
+        for node in graph_module.graph.nodes
+        if "tosa.CUSTOM.default" in str(node.target)
+    )
+    return json.loads(bytes(custom_node.kwargs["implementation_attrs"]).decode("utf-8"))
+
+
+# Covers basic payload encoding and decoding for shader metadata.
+# Checks bindings, workgroup sizes, language, and formats are preserved.
+def test_buffer_shader_payload_encodes_bindings_and_formats():
+    payload = decode_payload(
+        encode_payload(
+            build_grid_sampler_2d_payload(
+                interpolation_mode=0,
+                padding_mode=0,
+                align_corners=False,
+            )
+        )
+    )
+
+    assert payload["entry_point"] == GRID_SAMPLER_2D_SHADER_ENTRY_POINT
+    assert payload["workgroup_sizes"] == GRID_SAMPLER_2D_WORKGROUP_SIZES
+    assert payload["shader_language"] == GRID_SAMPLER_2D_SHADER_LANGUAGE
+    assert payload["input_0_binding"] == 0
+    assert payload["input_1_binding"] == 1
+    assert payload["output_0_binding"] == 2
+    assert payload["input_0_vkformat"] == GRID_SAMPLER_2D_VK_FORMAT
+    assert payload["input_1_vkformat"] == GRID_SAMPLER_2D_VK_FORMAT
+    assert payload["output_0_vkformat"] == GRID_SAMPLER_2D_VK_FORMAT
+
+
+# Covers sampler-specific payload fields for sampled image inputs.
+# Checks filter, address mode, and border color are encoded in the payload.
+def test_sampler_shader_payload_encodes_sampler_fields():
+    payload = _decode_sampler_payload()
+
+    assert (
+        payload["input_0_vkdescriptortype"]
+        == "VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER"
+    )
+    assert payload["input_1_vkdescriptortype"] == "VK_DESCRIPTOR_TYPE_TENSOR_ARM"
+    assert payload["input_1_vkformat"] == "VK_FORMAT_R32_SFLOAT"
+    assert payload["output_0_vkdescriptortype"] == "VK_DESCRIPTOR_TYPE_STORAGE_IMAGE"
+    assert payload["input_0_sampler"] == {
+        "address_mode_u": "VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER",
+        "address_mode_v": "VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER",
+        "border_color": "VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK",
+        "mag_filter": "VK_FILTER_LINEAR",
+        "min_filter": "VK_FILTER_LINEAR",
+    }
+
+
+# Covers the local shader asset contract used by the tests.
+# Checks the expected GLSL/SPIR-V asset names and that the SPIR-V bytes look valid.
+def test_shader_payload_uses_expected_glsl_and_spirv_asset():
+    buffer_payload = build_grid_sampler_2d_payload(
+        interpolation_mode=0,
+        padding_mode=0,
+        align_corners=False,
+    )
+
+    assert GRID_SAMPLER_2D_SHADER_SOURCE == "grid_sampler.glsl"
+    assert GRID_SAMPLER_2D_SHADER_BINARY == "grid_sampler.spirv.b64"
+    assert buffer_payload["shader_language"] == "SPIR-V"
+    assert base64.b64decode(buffer_payload["shader_code"])[:4] == b"\x03\x02\x23\x07"
+
+
+# Covers validation of unsupported shader option values.
+# Checks invalid mode and padding_mode values raise instead of encoding silently.
+def test_shader_payload_rejects_invalid_mode_values():
+    with pytest.raises(RuntimeError, match="Unsupported grid_sample mode"):
+        _decode_sampler_payload(mode="garbage")
+
+    with pytest.raises(RuntimeError, match="Unsupported grid_sample padding_mode"):
+        _decode_sampler_payload(padding_mode="garbage")
+
+
+# Covers storage-image outputs, which should not carry sampler state.
+# Checks output payloads omit sampler metadata for storage images.
+def test_storage_image_payload_does_not_require_sampler_fields():
+    payload = _decode_sampler_payload()
+
+    assert payload["output_0_vkdescriptortype"] == "VK_DESCRIPTOR_TYPE_STORAGE_IMAGE"
+    assert "output_0_sampler" not in payload

--- a/backends/arm/test/misc/test_vgf_backend.py
+++ b/backends/arm/test/misc/test_vgf_backend.py
@@ -1,0 +1,107 @@
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+from executorch.backends.arm._passes import RewriteConvPass
+from executorch.backends.arm._passes.arm_pass_manager import (
+    _registered_pass_insertions,
+    clear_registered_pass_insertions,
+    PassInsertions,
+)
+from executorch.backends.arm.vgf import backend as vgf_backend, VgfCompileSpec
+from executorch.exir.backend.backend_details import PreprocessResult
+from executorch.exir.pass_base import ExportPass
+from torch.export.exported_program import ExportedProgram
+from torch.fx import GraphModule
+from torch.fx.passes.infra.pass_base import PassResult
+
+
+class DummyPass(ExportPass):
+    def call(self, graph_module: GraphModule) -> PassResult:
+        return PassResult(graph_module, False)
+
+
+def _registry_state() -> dict[type, tuple[list[type], list[type]]]:
+    return {
+        pass_type: (
+            [type(pass_) for pass_ in insertions.before_passes],
+            [type(pass_) for pass_ in insertions.after_passes],
+        )
+        for pass_type, insertions in _registered_pass_insertions.items()
+    }
+
+
+def _set_up_fake_vgf_preprocess(monkeypatch) -> None:
+    monkeypatch.setattr(
+        vgf_backend.TOSABackend,
+        "filter_tosa_compile_specs",
+        lambda compile_spec: [],
+    )
+    monkeypatch.setattr(
+        vgf_backend,
+        "arm_get_first_delegation_tag",
+        lambda graph_module: "",
+    )
+    monkeypatch.setattr(
+        vgf_backend.VgfBackend,
+        "_compile_tosa_flatbuffer",
+        staticmethod(lambda tosa_flatbuffer, compile_spec, tag_name="": b"vgf"),
+    )
+
+
+def _fake_exported_program() -> ExportedProgram:
+    return cast(ExportedProgram, SimpleNamespace(graph_module=None))
+
+
+def test_vgf_preprocess_restores_pass_registry(monkeypatch) -> None:
+    clear_registered_pass_insertions()
+    try:
+        _registered_pass_insertions[RewriteConvPass] = PassInsertions(
+            before_passes=[DummyPass()],
+        )
+        original_registry = _registry_state()
+        _set_up_fake_vgf_preprocess(monkeypatch)
+        monkeypatch.setattr(
+            vgf_backend.TOSABackend,
+            "_preprocess",
+            lambda edge_program, compile_specs: PreprocessResult(processed_bytes=b""),
+        )
+
+        result = vgf_backend.VgfBackend.preprocess(
+            _fake_exported_program(), VgfCompileSpec()._to_list()
+        )
+
+        assert result.processed_bytes == b"vgf"
+        assert _registry_state() == original_registry
+    finally:
+        clear_registered_pass_insertions()
+
+
+def test_vgf_preprocess_restores_pass_registry_on_failure(monkeypatch) -> None:
+    clear_registered_pass_insertions()
+    try:
+        _registered_pass_insertions[RewriteConvPass] = PassInsertions(
+            before_passes=[DummyPass()],
+        )
+        original_registry = _registry_state()
+        _set_up_fake_vgf_preprocess(monkeypatch)
+
+        def _raise(*args, **kwargs):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(vgf_backend.TOSABackend, "_preprocess", _raise)
+
+        with pytest.raises(RuntimeError, match="boom"):
+            vgf_backend.VgfBackend.preprocess(
+                _fake_exported_program(), VgfCompileSpec()._to_list()
+            )
+
+        assert _registry_state() == original_registry
+    finally:
+        clear_registered_pass_insertions()

--- a/backends/arm/test/ops/test_custom_shader_lowering.py
+++ b/backends/arm/test/ops/test_custom_shader_lowering.py
@@ -1,0 +1,252 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import json
+import shutil
+import sys
+from pathlib import Path
+
+import executorch.backends.arm.tosa.dialect  # noqa: F401
+import pytest
+import torch
+import torch.nn.functional as F
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
+
+from backends.arm.test._custom_vgf_test_utils import (
+    EncodeSamplerGridSampleToTosaCustomPass,
+    EncodeTestAddToTosaCustomPass,
+    EncodeThreesToTosaCustomPass,
+    register_test_shader_library_ops,
+    register_test_threes_library_ops,
+    rewrite_aten_add_to_test_shader,
+    rewrite_aten_grid_sample_to_test_shader,
+    TEST_ADD_OPERATOR,
+    TEST_GRID_READ_TENSOR_OPERATOR,
+    TEST_GRID_SAMPLE_OPERATOR,
+    TEST_SHADER_DOMAIN,
+    THREES_DOMAIN,
+    THREES_OPERATOR,
+)
+from executorch.backends.arm.tosa.specification import (
+    TosaLoweringContext,
+    TosaSpecification,
+)
+from executorch.backends.arm.vgf._passes.rewrite_grid_sampler_to_tosa_custom import (
+    RewriteGridSamplerToTosaCustomPass,
+)
+from executorch.backends.arm.vgf.shaders.grid_sampler import decode_payload
+from executorch.exir import to_edge
+from executorch.exir.dialects._ops import ops as exir_ops
+from torch.export import export
+
+
+class _AddModule(torch.nn.Module):
+    def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        return x + y
+
+
+class _GridSampleModule(torch.nn.Module):
+    def forward(self, x: torch.Tensor, grid: torch.Tensor) -> torch.Tensor:
+        return F.grid_sample(
+            x,
+            grid,
+            mode="bilinear",
+            padding_mode="zeros",
+            align_corners=False,
+        )
+
+
+class _ThreesModule(torch.nn.Module):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.ops.arm_test_shader_ops.threes.default(x)
+
+
+class _GridReadTensorModule(torch.nn.Module):
+    def forward(self, x: torch.Tensor, grid: torch.Tensor) -> torch.Tensor:
+        return torch.ops.arm_test_vulkan_custom_shader.grid_read_tensor_debug.default(
+            x,
+            grid,
+            "bilinear",
+            "zeros",
+            False,
+        )
+
+
+# Covers lowering of a standalone custom op to a buffer-backed tosa.CUSTOM.
+# Checks the emitted custom node carries the expected operator, domain, and buffer descriptors.
+def test_new_custom_op_lowers_to_tosa_custom_buffer_shader():
+    if shutil.which("glslc") is None:
+        pytest.skip("glslc not found")
+    register_test_threes_library_ops()
+    exported = export(_ThreesModule(), (torch.randn(16),))
+
+    with TosaLoweringContext(TosaSpecification.create_from_string("TOSA-1.0+FP")):
+        EncodeThreesToTosaCustomPass().call(exported.graph_module)
+
+    custom_node = next(
+        node
+        for node in exported.graph_module.graph.nodes
+        if node.target == exir_ops.backend.tosa.CUSTOM.default
+    )
+    payload = json.loads(
+        bytes(custom_node.kwargs["implementation_attrs"]).decode("utf-8")
+    )
+
+    assert custom_node.kwargs["operator_name"] == THREES_OPERATOR
+    assert custom_node.kwargs["domain_name"] == THREES_DOMAIN
+    assert payload["input_0_vkdescriptortype"] == "VK_DESCRIPTOR_TYPE_STORAGE_BUFFER"
+    assert payload["output_0_vkdescriptortype"] == "VK_DESCRIPTOR_TYPE_STORAGE_BUFFER"
+
+
+# Covers replacing aten.add with a shader-backed custom op.
+# Checks the rewritten node lowers to tosa.CUSTOM with storage-buffer descriptors.
+def test_replacement_op_lowers_to_tosa_custom_shader():
+    if shutil.which("glslc") is None:
+        pytest.skip("glslc not found")
+    register_test_shader_library_ops()
+    exported = export(_AddModule(), (torch.randn(16), torch.randn(16)))
+    rewrite_aten_add_to_test_shader(exported.graph_module)
+
+    with TosaLoweringContext(TosaSpecification.create_from_string("TOSA-1.0+FP")):
+        EncodeTestAddToTosaCustomPass().call(exported.graph_module)
+
+    custom_node = next(
+        node
+        for node in exported.graph_module.graph.nodes
+        if node.target == exir_ops.backend.tosa.CUSTOM.default
+    )
+    payload = json.loads(
+        bytes(custom_node.kwargs["implementation_attrs"]).decode("utf-8")
+    )
+
+    assert custom_node.kwargs["operator_name"] == TEST_ADD_OPERATOR
+    assert custom_node.kwargs["domain_name"] == TEST_SHADER_DOMAIN
+    assert payload["input_0_vkdescriptortype"] == "VK_DESCRIPTOR_TYPE_STORAGE_BUFFER"
+    assert payload["output_0_vkdescriptortype"] == "VK_DESCRIPTOR_TYPE_STORAGE_BUFFER"
+
+
+# Covers the in-tree grid-sampler rewrite path.
+# Checks grid_sampler_2d.default lowers to tosa.CUSTOM with the Vulkan shader domain.
+def test_in_tree_grid_sampler_lowers_to_tosa_custom():
+    edge_model = to_edge(
+        export(_GridSampleModule(), (torch.randn(1, 3, 8, 8), torch.randn(1, 4, 4, 2)))
+    )
+
+    with TosaLoweringContext(TosaSpecification.create_from_string("TOSA-1.0+FP")):
+        transformed = edge_model.transform([RewriteGridSamplerToTosaCustomPass()])
+
+    nodes = list(transformed.exported_program().graph.nodes)
+    custom_node = next(
+        node for node in nodes if node.target == exir_ops.backend.tosa.CUSTOM.default
+    )
+
+    assert custom_node.kwargs["operator_name"] == TEST_GRID_SAMPLE_OPERATOR
+    assert custom_node.kwargs["domain_name"] == "com.arm.VulkanCustomShader"
+
+
+# Covers sampler/image descriptor selection during lowering.
+# Checks the lowered payload uses combined-image-sampler input, tensor grid input, and storage-image output.
+def test_sampler_shader_lowering_emits_expected_descriptor_types():
+    if shutil.which("glslc") is None:
+        pytest.skip("glslc not found")
+    register_test_shader_library_ops()
+    exported = export(
+        _GridSampleModule(),
+        (
+            torch.randn(1, 4, 8, 8).contiguous(memory_format=torch.channels_last),
+            torch.randn(1, 4, 4, 2),
+        ),
+    )
+    rewrite_aten_grid_sample_to_test_shader(exported.graph_module)
+
+    with TosaLoweringContext(TosaSpecification.create_from_string("TOSA-1.0+FP")):
+        EncodeSamplerGridSampleToTosaCustomPass().call(exported.graph_module)
+
+    custom_node = next(
+        node
+        for node in exported.graph_module.graph.nodes
+        if node.target == exir_ops.backend.tosa.CUSTOM.default
+    )
+    payload = json.loads(
+        bytes(custom_node.kwargs["implementation_attrs"]).decode("utf-8")
+    )
+
+    assert (
+        payload["input_0_vkdescriptortype"]
+        == "VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER"
+    )
+    assert payload["input_1_vkdescriptortype"] == "VK_DESCRIPTOR_TYPE_TENSOR_ARM"
+    assert payload["output_0_vkdescriptortype"] == "VK_DESCRIPTOR_TYPE_STORAGE_IMAGE"
+
+
+def test_grid_read_shader_lowering_uses_distinct_custom_operator():
+    if shutil.which("glslc") is None:
+        pytest.skip("glslc not found")
+    register_test_shader_library_ops()
+    exported = export(
+        _GridReadTensorModule(),
+        (
+            torch.randn(1, 4, 8, 8).contiguous(memory_format=torch.channels_last),
+            torch.randn(1, 4, 9, 2),
+        ),
+    )
+
+    with TosaLoweringContext(TosaSpecification.create_from_string("TOSA-1.0+FP")):
+        EncodeSamplerGridSampleToTosaCustomPass().call(exported.graph_module)
+
+    custom_node = next(
+        node
+        for node in exported.graph_module.graph.nodes
+        if node.target == exir_ops.backend.tosa.CUSTOM.default
+    )
+
+    assert custom_node.kwargs["operator_name"] == TEST_GRID_READ_TENSOR_OPERATOR
+
+
+def test_sampler_shader_lowering_rejects_three_channel_image_payload():
+    if shutil.which("glslc") is None:
+        pytest.skip("glslc not found")
+    register_test_shader_library_ops()
+    exported = export(
+        _GridSampleModule(),
+        (
+            torch.randn(1, 3, 8, 8).contiguous(memory_format=torch.channels_last),
+            torch.randn(1, 4, 4, 2),
+        ),
+    )
+    rewrite_aten_grid_sample_to_test_shader(exported.graph_module)
+
+    with (
+        TosaLoweringContext(TosaSpecification.create_from_string("TOSA-1.0+FP")),
+        pytest.raises(
+            ValueError,
+            match="Image-backed grid_sample requires 1, 2, or 4 channels; got 3",
+        ),
+    ):
+        EncodeSamplerGridSampleToTosaCustomPass().call(exported.graph_module)
+
+
+# Covers decoding of implementation_attrs after lowering.
+# Checks the payload exposes the expected entry point and binding numbering.
+def test_shader_lowering_decodes_expected_implementation_attrs():
+    edge_model = to_edge(
+        export(_GridSampleModule(), (torch.randn(1, 3, 8, 8), torch.randn(1, 4, 4, 2)))
+    )
+
+    with TosaLoweringContext(TosaSpecification.create_from_string("TOSA-1.0+FP")):
+        transformed = edge_model.transform([RewriteGridSamplerToTosaCustomPass()])
+
+    custom_node = next(
+        node
+        for node in transformed.exported_program().graph.nodes
+        if node.target == exir_ops.backend.tosa.CUSTOM.default
+    )
+    payload = decode_payload(custom_node.kwargs["implementation_attrs"])
+
+    assert payload["entry_point"] == "main"
+    assert payload["input_0_binding"] == 0
+    assert payload["input_1_binding"] == 1
+    assert payload["output_0_binding"] == 2

--- a/backends/arm/test/ops/test_custom_shader_lowering.py
+++ b/backends/arm/test/ops/test_custom_shader_lowering.py
@@ -25,7 +25,6 @@ from backends.arm.test._custom_vgf_test_utils import (
     rewrite_aten_grid_sample_to_test_shader,
     TEST_ADD_OPERATOR,
     TEST_GRID_READ_TENSOR_OPERATOR,
-    TEST_GRID_SAMPLE_OPERATOR,
     TEST_SHADER_DOMAIN,
     THREES_DOMAIN,
     THREES_OPERATOR,
@@ -37,7 +36,10 @@ from executorch.backends.arm.tosa.specification import (
 from executorch.backends.arm.vgf._passes.rewrite_grid_sampler_to_tosa_custom import (
     RewriteGridSamplerToTosaCustomPass,
 )
-from executorch.backends.arm.vgf.shaders.grid_sampler import decode_payload
+from executorch.backends.arm.vgf.shaders.grid_sampler import (
+    decode_payload,
+    grid_sampler_2d_operator_name,
+)
 from executorch.exir import to_edge
 from executorch.exir.dialects._ops import ops as exir_ops
 from torch.export import export
@@ -143,7 +145,11 @@ def test_in_tree_grid_sampler_lowers_to_tosa_custom():
         node for node in nodes if node.target == exir_ops.backend.tosa.CUSTOM.default
     )
 
-    assert custom_node.kwargs["operator_name"] == TEST_GRID_SAMPLE_OPERATOR
+    assert custom_node.kwargs["operator_name"] == grid_sampler_2d_operator_name(
+        interpolation_mode=0,
+        padding_mode=0,
+        align_corners=False,
+    )
     assert custom_node.kwargs["domain_name"] == "com.arm.VulkanCustomShader"
 
 

--- a/backends/arm/test/passes/test_custom_op_rewrite.py
+++ b/backends/arm/test/passes/test_custom_op_rewrite.py
@@ -1,0 +1,257 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import json
+import operator
+from collections.abc import Callable
+
+import executorch.backends.arm.tosa.dialect  # noqa: F401
+import pytest
+import torch
+from executorch.backends.arm._passes.arm_pass import ArmPass
+from executorch.backends.arm.tosa.dialect.ops.custom import (
+    has_fake_tosa_impl,
+    register_fake_tosa,
+)
+from executorch.backends.arm.tosa.specification import (
+    TosaLoweringContext,
+    TosaSpecification,
+)
+from executorch.exir import to_edge
+from executorch.exir.dialects._ops import ops as exir_ops
+from torch.export import export
+from torch.fx.passes.infra.pass_base import PassResult
+from torch.library import impl, Library, register_fake
+
+_TEST_LIB: Library | None = None
+_TEST_OPS_REGISTERED = False
+_TEST_NAMESPACE = "arm_test_mylibrary"
+_TEST_DOMAIN = "com.arm.test"
+
+
+def _register_test_ops() -> None:
+    global _TEST_LIB, _TEST_OPS_REGISTERED
+    if _TEST_OPS_REGISTERED:
+        return
+
+    test_lib = torch.library.Library(_TEST_NAMESPACE, "DEF")
+    _TEST_LIB = test_lib
+    test_lib.define("test_op(Tensor x) -> Tensor")
+
+    @impl(test_lib, "test_op", dispatch_key="CompositeExplicitAutograd")
+    def _test_op_impl(x: torch.Tensor) -> torch.Tensor:
+        return x + 7.0
+
+    @register_fake(f"{_TEST_NAMESPACE}::test_op")
+    def _test_op_fake(x: torch.Tensor) -> torch.Tensor:
+        return torch.empty_like(x)
+
+    @register_fake_tosa("mylibrary.test_op")
+    def _test_op_tosa_fake_impl(
+        inputs: list[torch.Tensor],
+        operator_name: str,
+        domain_name: str,
+        implementation_attrs: list[int],
+    ) -> list[torch.Tensor]:
+        assert operator_name == "mylibrary.test_op"
+        assert domain_name == _TEST_DOMAIN
+        _ = implementation_attrs
+        return [torch.empty_like(inputs[0])]
+
+    @register_fake_tosa("mylibrary.add_replacement")
+    def _add_replacement_tosa_fake_impl(
+        inputs: list[torch.Tensor],
+        operator_name: str,
+        domain_name: str,
+        implementation_attrs: list[int],
+    ) -> list[torch.Tensor]:
+        assert operator_name == "mylibrary.add_replacement"
+        assert domain_name == _TEST_DOMAIN
+        _ = implementation_attrs
+        return [torch.empty_like(inputs[0])]
+
+    _TEST_OPS_REGISTERED = True
+
+
+class _EncodeWrappedOpToTosaCustomPass(ArmPass):
+    _passes_required_after = set()
+
+    def __init__(
+        self,
+        operator_name: str,
+        matcher: Callable[[object], bool],
+    ) -> None:
+        self._operator_name = operator_name
+        self._matcher = matcher
+
+    def call(self, graph_module):
+        graph = graph_module.graph
+        modified = False
+        for node in list(graph.nodes):
+            if node.op != "call_function":
+                continue
+            if not self._matcher(node.target):
+                continue
+            if not has_fake_tosa_impl(self._operator_name):
+                raise RuntimeError(
+                    f"tosa.CUSTOM fake impl is not registered for {self._operator_name}"
+                )
+
+            inputs = [arg for arg in node.args if isinstance(arg, torch.fx.Node)]
+            payload = {
+                "operator_name": self._operator_name,
+                "binding_count": len(inputs),
+            }
+            impl_list = list(json.dumps(payload, sort_keys=True).encode("utf-8"))
+            fake_outputs = [torch.empty_like(inputs[0].meta["val"])]
+
+            with graph.inserting_before(node):
+                tosa_custom = graph.call_function(
+                    exir_ops.backend.tosa.CUSTOM.default,
+                    args=(inputs,),
+                    kwargs={
+                        "operator_name": self._operator_name,
+                        "domain_name": _TEST_DOMAIN,
+                        "implementation_attrs": impl_list,
+                    },
+                )
+                tosa_custom.meta = dict(node.meta)
+                tosa_custom.meta["val"] = fake_outputs
+
+                output = graph.call_function(operator.getitem, args=(tosa_custom, 0))
+                output.meta = dict(node.meta)
+                output.meta["val"] = fake_outputs[0]
+
+            node.replace_all_uses_with(output)
+            graph.erase_node(node)
+            modified = True
+
+        if modified:
+            graph_module.recompile()
+        return PassResult(graph_module, modified)
+
+
+class _SingleCustomOpModule(torch.nn.Module):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.ops.arm_test_mylibrary.test_op.default(x)
+
+
+class _AddModule(torch.nn.Module):
+    def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        return x + y
+
+
+class _AddAndMulModule(torch.nn.Module):
+    def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        return (x + y) * y
+
+
+def _transform(module: torch.nn.Module, example_inputs: tuple, pass_: ArmPass):
+    edge_model = to_edge(export(module, example_inputs))
+    with TosaLoweringContext(TosaSpecification.create_from_string("TOSA-1.0+FP")):
+        return edge_model.transform([pass_])
+
+
+# Covers adding a brand new op and wrapping it as tosa.CUSTOM.
+# Checks the rewrite emits the custom node plus the single-output getitem pattern.
+def test_register_new_custom_op_rewrite_to_tosa_custom():
+    _register_test_ops()
+    transformed = _transform(
+        _SingleCustomOpModule(),
+        (torch.randn(2, 3),),
+        _EncodeWrappedOpToTosaCustomPass(
+            "mylibrary.test_op",
+            lambda target: "arm_test_mylibrary" in str(target),
+        ),
+    )
+    nodes = list(transformed.exported_program().graph.nodes)
+
+    custom_node = next(
+        node for node in nodes if node.target == exir_ops.backend.tosa.CUSTOM.default
+    )
+    output_node = next(node for node in nodes if node.target == operator.getitem)
+
+    assert custom_node.kwargs["operator_name"] == "mylibrary.test_op"
+    assert custom_node.kwargs["domain_name"] == _TEST_DOMAIN
+    assert output_node.args[0] == custom_node
+    assert output_node.args[1] == 0
+
+
+# Covers replacing an existing aten op instead of introducing a new one.
+# Checks aten.add is removed and replaced by a tosa.CUSTOM node.
+def test_replace_existing_aten_add_with_custom_op():
+    _register_test_ops()
+    transformed = _transform(
+        _AddModule(),
+        (torch.randn(2, 3), torch.randn(2, 3)),
+        _EncodeWrappedOpToTosaCustomPass(
+            "mylibrary.add_replacement",
+            lambda target: target == exir_ops.edge.aten.add.Tensor,
+        ),
+    )
+    nodes = list(transformed.exported_program().graph.nodes)
+
+    assert not any(node.target == exir_ops.edge.aten.add.Tensor for node in nodes)
+    assert any(node.target == exir_ops.backend.tosa.CUSTOM.default for node in nodes)
+
+
+# Covers rewrite selectivity when the graph contains both target and non-target ops.
+# Checks add is rewritten while unrelated ops like mul remain in the graph.
+def test_rewrite_only_targets_intended_operator():
+    _register_test_ops()
+    transformed = _transform(
+        _AddAndMulModule(),
+        (torch.randn(2, 3), torch.randn(2, 3)),
+        _EncodeWrappedOpToTosaCustomPass(
+            "mylibrary.add_replacement",
+            lambda target: target == exir_ops.edge.aten.add.Tensor,
+        ),
+    )
+    nodes = list(transformed.exported_program().graph.nodes)
+
+    assert not any(node.target == exir_ops.edge.aten.add.Tensor for node in nodes)
+    assert any(node.target == exir_ops.edge.aten.mul.Tensor for node in nodes)
+
+
+# Covers the failure path when no fake-TOSA implementation is registered.
+# Checks the pass raises a clear error instead of producing a broken custom node.
+def test_missing_fake_impl_fails_cleanly():
+    _register_test_ops()
+    with torch.no_grad():
+        with TosaLoweringContext(TosaSpecification.create_from_string("TOSA-1.0+FP")):
+            exported = to_edge(export(_SingleCustomOpModule(), (torch.randn(2, 3),)))
+            with pytest.raises(
+                RuntimeError,
+                match="tosa.CUSTOM fake impl is not registered for missing.test_op",
+            ):
+                _EncodeWrappedOpToTosaCustomPass(
+                    "missing.test_op",
+                    lambda target: "arm_test_mylibrary" in str(target),
+                ).call(exported.exported_program().graph_module)
+
+
+# Covers the current single-output custom-op convention.
+# Checks tosa.CUSTOM keeps list-valued meta and getitem keeps the selected tensor meta.
+def test_custom_op_rewrite_preserves_single_output_getitem_meta():
+    _register_test_ops()
+    transformed = _transform(
+        _SingleCustomOpModule(),
+        (torch.randn(2, 3),),
+        _EncodeWrappedOpToTosaCustomPass(
+            "mylibrary.test_op",
+            lambda target: "arm_test_mylibrary" in str(target),
+        ),
+    )
+    nodes = list(transformed.exported_program().graph.nodes)
+    custom_node = next(
+        node for node in nodes if node.target == exir_ops.backend.tosa.CUSTOM.default
+    )
+    output_node = next(node for node in nodes if node.target == operator.getitem)
+
+    assert isinstance(custom_node.meta["val"], list)
+    assert len(custom_node.meta["val"]) == 1
+    assert tuple(output_node.meta["val"].shape) == tuple(
+        custom_node.meta["val"][0].shape
+    )

--- a/backends/arm/test/passes/test_rewrite_grid_sampler_to_tosa_custom_pass.py
+++ b/backends/arm/test/passes/test_rewrite_grid_sampler_to_tosa_custom_pass.py
@@ -16,11 +16,11 @@ from executorch.backends.arm.vgf._passes.rewrite_grid_sampler_to_tosa_custom imp
 from executorch.backends.arm.vgf.shaders.grid_sampler import (
     CUSTOM_SHADER_DOMAIN_NAME,
     decode_payload,
-    GRID_SAMPLER_2D_OPERATOR_NAME,
     GRID_SAMPLER_2D_SHADER_ENTRY_POINT,
     GRID_SAMPLER_2D_SHADER_LANGUAGE,
     GRID_SAMPLER_2D_VK_FORMAT,
     GRID_SAMPLER_2D_WORKGROUP_SIZES,
+    grid_sampler_2d_operator_name,
 )
 from executorch.exir import to_edge
 from executorch.exir.dialects._ops import ops as exir_ops
@@ -69,7 +69,11 @@ def test_rewrite_grid_sampler_to_tosa_custom_no_target():
     custom_node = next(
         node for node in nodes if node.target == exir_ops.backend.tosa.CUSTOM.default
     )
-    assert custom_node.kwargs["operator_name"] == GRID_SAMPLER_2D_OPERATOR_NAME
+    assert custom_node.kwargs["operator_name"] == grid_sampler_2d_operator_name(
+        interpolation_mode=0,
+        padding_mode=0,
+        align_corners=False,
+    )
     assert custom_node.kwargs["domain_name"] == CUSTOM_SHADER_DOMAIN_NAME
 
     payload = decode_payload(custom_node.kwargs["implementation_attrs"])

--- a/backends/arm/test/passes/test_rewrite_grid_sampler_to_tosa_custom_pass.py
+++ b/backends/arm/test/passes/test_rewrite_grid_sampler_to_tosa_custom_pass.py
@@ -16,11 +16,11 @@ from executorch.backends.arm.vgf._passes.rewrite_grid_sampler_to_tosa_custom imp
 from executorch.backends.arm.vgf.shaders.grid_sampler import (
     CUSTOM_SHADER_DOMAIN_NAME,
     decode_payload,
+    grid_sampler_2d_operator_name,
     GRID_SAMPLER_2D_SHADER_ENTRY_POINT,
     GRID_SAMPLER_2D_SHADER_LANGUAGE,
     GRID_SAMPLER_2D_VK_FORMAT,
     GRID_SAMPLER_2D_WORKGROUP_SIZES,
-    grid_sampler_2d_operator_name,
 )
 from executorch.exir import to_edge
 from executorch.exir.dialects._ops import ops as exir_ops

--- a/backends/arm/test/runner_utils.py
+++ b/backends/arm/test/runner_utils.py
@@ -845,11 +845,19 @@ def vkml_emulation_layer_installed() -> bool:
     existing_layers = set(vk_instance_layers.split(":"))
     layers_exists = required_layers.issubset(existing_layers)
 
-    # Check LD_LIBRARY_PATH for "emulation-layer/deploy"
+    # Check dynamic library search paths for the emulation layer deploy dir.
+    library_paths = []
     ld_library_path = os.environ.get("LD_LIBRARY_PATH", "")
+    dyld_library_path = os.environ.get("DYLD_LIBRARY_PATH", "")
+    if ld_library_path:
+        library_paths.extend(ld_library_path.split(os.path.pathsep))
+    if dyld_library_path:
+        library_paths.extend(dyld_library_path.split(os.path.pathsep))
+
     deploy_exists = False
-    for path in ld_library_path.split(os.path.pathsep):
-        if "emulation-layer/deploy" in path and os.path.isdir(path):
+    deploy_markers = ("emulation-layer/deploy", "emulation_layer/deploy")
+    for path in library_paths:
+        if any(marker in path for marker in deploy_markers) and os.path.isdir(path):
             deploy_exists = True
 
     return layers_exists and deploy_exists

--- a/backends/arm/test/runtime/_vgf_runtime_test_utils.py
+++ b/backends/arm/test/runtime/_vgf_runtime_test_utils.py
@@ -1,0 +1,350 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import functools
+import json
+import shutil
+import subprocess  # nosec B404 - required to invoke trusted local VGF dump tool
+import sys
+import warnings
+from pathlib import Path
+
+import pytest
+import torch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
+
+from backends.arm.test._custom_vgf_test_utils import (
+    EncodeSamplerGridSampleToTosaCustomPass,
+    EncodeTestAddToTosaCustomPass,
+    EncodeThreesToTosaCustomPass,
+    register_test_shader_library_ops,
+    register_test_shader_partition_ops,
+    register_test_threes_library_ops,
+    register_test_threes_partition_ops,
+    rewrite_aten_add_to_test_shader,
+    rewrite_aten_grid_sample_to_test_shader,
+)
+from executorch.backends.arm._passes import RewriteMatmulPass
+from executorch.backends.arm._passes.arm_pass_manager import (
+    clear_registered_pass_insertions,
+    register_pass_insertions_after,
+)
+from executorch.backends.arm.test.runner_utils import (
+    arm_executor_runner_exists,
+    get_elf_path,
+    run_target,
+    vkml_emulation_layer_installed,
+)
+from executorch.backends.arm.vgf import VgfCompileSpec, VgfPartitioner
+from executorch.backends.arm.vgf.model_converter import (
+    find_model_converter_binary,
+    model_converter_env,
+)
+from executorch.exir import EdgeCompileConfig, to_edge_transform_and_lower
+from executorch.exir.pass_base import ExportPass
+from torch.export import export
+
+
+def runtime_available() -> bool:
+    return vkml_emulation_layer_installed() and arm_executor_runner_exists(
+        "vkml_emulation_layer"
+    )
+
+
+def ensure_vgf_runtime() -> None:
+    if not runtime_available():
+        pytest.xfail("VGF runtime is not available on this system")
+
+
+def ensure_glslc() -> None:
+    if shutil.which("glslc") is None:
+        pytest.skip("glslc not found")
+
+
+@functools.lru_cache(maxsize=1)
+def _model_converter_is_legacy_release() -> tuple[bool, str]:
+    model_converter = find_model_converter_binary()
+    if model_converter is None:
+        warnings.warn(
+            "Could not find model-converter while evaluating the VGF runtime "
+            "legacy-version xfail gate; assuming a newer/custom build.",
+            stacklevel=2,
+        )
+        return False, ""
+
+    try:
+        result = subprocess.run(  # nosec B603 - trusted local tool
+            [model_converter, "--version"],
+            check=True,
+            capture_output=True,
+            text=True,
+            env=model_converter_env(),
+        )
+    except Exception as exc:
+        warnings.warn(
+            "Failed to query model-converter --version while evaluating the VGF "
+            f"runtime legacy-version xfail gate ({exc}); assuming a newer/custom "
+            "build.",
+            stacklevel=2,
+        )
+        return False, ""
+
+    version_text = (result.stdout or result.stderr).strip()
+    if not version_text:
+        warnings.warn(
+            "model-converter --version returned no output while evaluating the VGF "
+            "runtime legacy-version xfail gate; assuming a newer/custom build.",
+            stacklevel=2,
+        )
+        return False, ""
+
+    if "d8c1b8e" in version_text:
+        return (
+            True,
+            "released model-converter build d8c1b8e predates required VGF custom "
+            "shader features; use a newer source build",
+        )
+
+    warnings.warn(
+        "model-converter legacy-version xfail gate expected d8c1b8e; detected "
+        f"{version_text!r}. Assuming a newer/custom build.",
+        stacklevel=2,
+    )
+    return False, ""
+
+
+def xfail_if_legacy_model_converter_release() -> pytest.MarkDecorator:
+    is_legacy_release, reason = _model_converter_is_legacy_release()
+    return pytest.mark.xfail(is_legacy_release, reason=reason, strict=False)
+
+
+def find_single_vgf_json(output_dir: Path) -> Path:
+    matches = sorted(output_dir.glob("*.vgf.json"))
+    if not matches:
+        raise FileNotFoundError(f"No .vgf.json file found in {output_dir}")
+    if len(matches) != 1:
+        raise RuntimeError(
+            f"Expected one .vgf.json file in {output_dir}, found {len(matches)}"
+        )
+    return matches[0]
+
+
+def find_single_vgf_file(output_dir: Path) -> Path:
+    matches = sorted(output_dir.glob("*.vgf"))
+    if not matches:
+        raise FileNotFoundError(f"No .vgf file found in {output_dir}")
+    if len(matches) != 1:
+        raise RuntimeError(
+            f"Expected one .vgf file in {output_dir}, found {len(matches)}"
+        )
+    return matches[0]
+
+
+def load_vgf_json(output_dir: Path) -> dict:
+    try:
+        vgf_json_path = find_single_vgf_json(output_dir)
+    except FileNotFoundError as exc:
+        if shutil.which("vgf_dump") is None:
+            raise RuntimeError(
+                f"No .vgf.json file found in {output_dir}, and `vgf_dump` was not "
+                "found on PATH. `vgf_dump` is expected to be installed alongside "
+                "`model_converter`; check that the model-converter tools are "
+                "installed and available on PATH."
+            ) from exc
+        vgf_path = find_single_vgf_file(output_dir)
+        vgf_json_path = vgf_path.with_suffix(vgf_path.suffix + ".json")
+        subprocess.run(  # nosec B603, B607 - trusted local tool with fixed arguments
+            ["vgf_dump", "-i", str(vgf_path), "-o", str(vgf_json_path)],
+            check=True,
+        )
+    return json.loads(vgf_json_path.read_text())
+
+
+def make_identity_grid(height: int, width: int) -> torch.Tensor:
+    x_coords = (2.0 * (torch.arange(width, dtype=torch.float32) + 0.5) / width) - 1.0
+    y_coords = (2.0 * (torch.arange(height, dtype=torch.float32) + 0.5) / height) - 1.0
+    yy, xx = torch.meshgrid(y_coords, x_coords, indexing="ij")
+    return torch.stack((xx, yy), dim=-1).unsqueeze(0)
+
+
+def make_input_tensor(height: int, width: int) -> torch.Tensor:
+    xx = torch.arange(width, dtype=torch.float32).view(1, width).repeat(height, 1)
+    yy = torch.arange(height, dtype=torch.float32).view(height, 1).repeat(1, width)
+    c0 = xx + 10.0 * yy + 1.0
+    c1 = 100.0 + xx
+    c2 = 200.0 + yy
+    c3 = torch.ones_like(xx)
+    return torch.stack((c0, c1, c2, c3), dim=0).unsqueeze(0)
+
+
+def make_sampler_probe_inputs() -> tuple[torch.Tensor, torch.Tensor]:
+    xx = torch.arange(8, dtype=torch.float32).view(1, 8).repeat(8, 1)
+    yy = torch.arange(8, dtype=torch.float32).view(8, 1).repeat(1, 8)
+    ramp = xx + 10.0 * yy + 1.0
+    zeros = torch.zeros_like(ramp)
+    ones = torch.ones_like(ramp)
+    x = torch.stack((ramp, zeros, zeros, ones), dim=0).unsqueeze(0)
+    x = x.contiguous(memory_format=torch.channels_last)
+
+    coarse_x_pix = torch.tensor(
+        [0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0], dtype=torch.float32
+    )
+    fine_x_pix = torch.linspace(0.26, 0.28, steps=9, dtype=torch.float32)
+    y_pix = torch.tensor([3.0, 0.5, 0.0, 0.0], dtype=torch.float32)
+
+    grid = torch.empty((1, y_pix.numel(), coarse_x_pix.numel(), 2), dtype=torch.float32)
+    for row_idx, y_val in enumerate(y_pix.tolist()):
+        x_positions = fine_x_pix if row_idx == 2 else coarse_x_pix
+        grid[0, row_idx, :, 0] = (2.0 * x_positions + 1.0) / x.shape[-1] - 1.0
+        grid[0, row_idx, :, 1] = (2.0 * y_val + 1.0) / x.shape[-2] - 1.0
+    return x, grid
+
+
+def execute_edge_manager(
+    edge_mgr, example_inputs: tuple, output_dir: Path
+) -> torch.Tensor:
+    ensure_vgf_runtime()
+    exec_prog = edge_mgr.to_executorch()
+    outputs = run_target(
+        exec_prog,
+        example_inputs,
+        output_dir,
+        "vkml_emulation_layer",
+        get_elf_path("vkml_emulation_layer"),
+    )
+    return outputs[0]
+
+
+def lower_in_tree_vgf(module: torch.nn.Module, example_inputs: tuple, output_dir: Path):
+    ensure_vgf_runtime()
+    exported = export(module, example_inputs)
+    expected = module(*example_inputs)
+    vgf_spec = VgfCompileSpec()
+    vgf_spec.dump_intermediate_artifacts_to(str(output_dir))
+    partitioner = VgfPartitioner(vgf_spec)
+    edge_mgr = to_edge_transform_and_lower(
+        exported,
+        partitioner=[partitioner],
+        compile_config=EdgeCompileConfig(_check_ir_validity=False),
+    )
+    actual = execute_edge_manager(edge_mgr, example_inputs, output_dir)
+    return expected, actual, load_vgf_json(output_dir)
+
+
+def _lower_custom_vgf(
+    module: torch.nn.Module,
+    example_inputs: tuple,
+    output_dir: Path,
+    *,
+    use_add: bool = False,
+    use_sampler: bool = False,
+    use_threes: bool = False,
+):
+    ensure_vgf_runtime()
+    ensure_glslc()
+    if use_add or use_sampler:
+        register_test_shader_library_ops()
+    if use_threes:
+        register_test_threes_library_ops()
+    exported = export(module, example_inputs)
+    if use_add:
+        rewrite_aten_add_to_test_shader(exported.graph_module)
+    if use_sampler:
+        rewrite_aten_grid_sample_to_test_shader(exported.graph_module)
+    expected = module(*example_inputs)
+    vgf_spec = VgfCompileSpec()
+    vgf_spec.dump_intermediate_artifacts_to(str(output_dir))
+    partitioner = VgfPartitioner(vgf_spec)
+    if use_add or use_sampler:
+        register_test_shader_partition_ops(partitioner)
+    if use_threes:
+        register_test_threes_partition_ops(partitioner)
+    clear_registered_pass_insertions()
+    passes: list[ExportPass] = []
+    if use_add:
+        passes.append(EncodeTestAddToTosaCustomPass())
+    if use_sampler:
+        passes.append(EncodeSamplerGridSampleToTosaCustomPass())
+    if use_threes:
+        passes.append(EncodeThreesToTosaCustomPass())
+    register_pass_insertions_after(RewriteMatmulPass, passes)
+    try:
+        edge_mgr = to_edge_transform_and_lower(
+            exported,
+            partitioner=[partitioner],
+            compile_config=EdgeCompileConfig(_check_ir_validity=False),
+        )
+    finally:
+        clear_registered_pass_insertions()
+    actual = execute_edge_manager(edge_mgr, example_inputs, output_dir)
+    return expected, actual, load_vgf_json(output_dir)
+
+
+def lower_add_vgf(module: torch.nn.Module, example_inputs: tuple, output_dir: Path):
+    return _lower_custom_vgf(
+        module,
+        example_inputs,
+        output_dir,
+        use_add=True,
+    )
+
+
+def lower_sampler_vgf(module: torch.nn.Module, example_inputs: tuple, output_dir: Path):
+    return _lower_custom_vgf(
+        module,
+        example_inputs,
+        output_dir,
+        use_sampler=True,
+    )
+
+
+def lower_add_and_sampler_vgf(
+    module: torch.nn.Module, example_inputs: tuple, output_dir: Path
+):
+    return _lower_custom_vgf(
+        module,
+        example_inputs,
+        output_dir,
+        use_add=True,
+        use_sampler=True,
+    )
+
+
+def lower_sampler_and_threes_vgf(
+    module: torch.nn.Module, example_inputs: tuple, output_dir: Path
+):
+    return _lower_custom_vgf(
+        module,
+        example_inputs,
+        output_dir,
+        use_sampler=True,
+        use_threes=True,
+    )
+
+
+def lower_threes_vgf(module: torch.nn.Module, example_inputs: tuple, output_dir: Path):
+    return _lower_custom_vgf(
+        module,
+        example_inputs,
+        output_dir,
+        use_threes=True,
+    )
+
+
+def alias_groups(vgf_json: dict) -> dict[int, list[dict]]:
+    groups: dict[int, list[dict]] = {}
+    for resource in vgf_json.get("resources", []):
+        alias_group_id = resource.get("alias_group_id")
+        if alias_group_id is None:
+            continue
+        groups.setdefault(int(alias_group_id), []).append(resource)
+    return groups
+
+
+def segment_types(vgf_json: dict) -> list[str]:
+    return [segment["type"] for segment in vgf_json["model_sequence"]["segments"]]

--- a/backends/arm/test/runtime/test_vgf_aliasing_runtime.py
+++ b/backends/arm/test/runtime/test_vgf_aliasing_runtime.py
@@ -1,0 +1,133 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import sys
+from pathlib import Path
+
+import torch
+import torch.nn.functional as F
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
+
+from backends.arm.test.runtime._vgf_runtime_test_utils import (
+    alias_groups,
+    lower_sampler_vgf,
+    lower_threes_vgf,
+    make_sampler_probe_inputs,
+    xfail_if_legacy_model_converter_release,
+)
+from executorch.backends.arm.test import common
+
+pytestmark = xfail_if_legacy_model_converter_release()
+
+
+class _ThreesModule(torch.nn.Module):
+    def forward(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+        x = a + b
+        return torch.ops.arm_test_shader_ops.threes.default(x)
+
+
+class _SamplerGraphConsumer(torch.nn.Module):
+    def forward(self, x: torch.Tensor, grid: torch.Tensor) -> torch.Tensor:
+        y = F.grid_sample(
+            x,
+            grid,
+            mode="bilinear",
+            padding_mode="zeros",
+            align_corners=False,
+        )
+        return y * 0.5 + 3.0
+
+
+class _GraphSamplerGraphConsumer(torch.nn.Module):
+    def forward(self, x: torch.Tensor, grid: torch.Tensor) -> torch.Tensor:
+        x = x * 2.0 + 1.0
+        y = F.grid_sample(
+            x,
+            grid,
+            mode="bilinear",
+            padding_mode="zeros",
+            align_corners=False,
+        )
+        return y * 0.5 + 3.0
+
+
+# Covers runtime execution for the standalone threes buffer shader path.
+# Checks numerics match eager execution and that tensor/buffer aliasing appears in the VGF.
+@common.SkipIfNoModelConverter
+def test_tensor_buffer_alias_group_executes_correctly(tmp_path):
+    a = torch.randn(256)
+    b = torch.randn(256)
+    expected, actual, vgf_json = lower_threes_vgf(_ThreesModule(), (a, b), tmp_path)
+    groups = alias_groups(vgf_json)
+
+    assert torch.allclose(expected, actual, atol=1e-5, rtol=0.0)
+    assert any(
+        {resource["vk_descriptor_type"] for resource in group}
+        >= {
+            "VK_DESCRIPTOR_TYPE_TENSOR_ARM",
+            "VK_DESCRIPTOR_TYPE_STORAGE_BUFFER",
+        }
+        for group in groups.values()
+    )
+
+
+# Covers runtime execution for storage-image to tensor aliasing.
+# Checks numerics match eager execution and that tensor/storage-image aliasing is present.
+@common.SkipIfNoModelConverter
+def test_tensor_image_alias_group_executes_correctly(tmp_path):
+    x, grid = make_sampler_probe_inputs()
+    expected, actual, vgf_json = lower_sampler_vgf(
+        _SamplerGraphConsumer(), (x, grid), tmp_path
+    )
+    groups = alias_groups(vgf_json)
+
+    assert torch.allclose(expected, actual, atol=1e-3, rtol=1e-2)
+    assert any(
+        {resource["vk_descriptor_type"] for resource in group}
+        >= {
+            "VK_DESCRIPTOR_TYPE_TENSOR_ARM",
+            "VK_DESCRIPTOR_TYPE_STORAGE_IMAGE",
+        }
+        for group in groups.values()
+    )
+
+
+# Covers graph-to-sampler aliasing on the sampled-image path.
+# Checks the VGF contains an alias group spanning tensor and combined-image-sampler resources.
+@common.SkipIfNoModelConverter
+def test_image_sampler_alias_group_executes_correctly(tmp_path):
+    x, grid = make_sampler_probe_inputs()
+    _, _, vgf_json = lower_sampler_vgf(
+        _GraphSamplerGraphConsumer(), (x, grid), tmp_path
+    )
+    groups = alias_groups(vgf_json)
+
+    assert any(
+        {resource["vk_descriptor_type"] for resource in group}
+        >= {
+            "VK_DESCRIPTOR_TYPE_TENSOR_ARM",
+            "VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER",
+        }
+        for group in groups.values()
+    )
+
+
+# Covers shader-to-graph aliasing on the sampled-image path.
+# Checks the VGF contains an alias group spanning storage-image and tensor resources.
+@common.SkipIfNoModelConverter
+def test_graph_consumes_tensor_alias_of_image_output(tmp_path):
+    x, grid = make_sampler_probe_inputs()
+    _, _, vgf_json = lower_sampler_vgf(_SamplerGraphConsumer(), (x, grid), tmp_path)
+    groups = alias_groups(vgf_json)
+
+    assert any(
+        {resource["vk_descriptor_type"] for resource in group}
+        >= {
+            "VK_DESCRIPTOR_TYPE_STORAGE_IMAGE",
+            "VK_DESCRIPTOR_TYPE_TENSOR_ARM",
+        }
+        for group in groups.values()
+    )

--- a/backends/arm/test/runtime/test_vgf_combinations_runtime.py
+++ b/backends/arm/test/runtime/test_vgf_combinations_runtime.py
@@ -1,0 +1,465 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import sys
+from pathlib import Path
+
+import torch
+import torch.nn.functional as F
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
+
+from backends.arm.test.runtime._vgf_runtime_test_utils import (
+    alias_groups,
+    lower_sampler_and_threes_vgf,
+    lower_sampler_vgf,
+    lower_threes_vgf,
+    make_sampler_probe_inputs,
+    segment_types,
+    xfail_if_legacy_model_converter_release,
+)
+from executorch.backends.arm.test import common
+
+pytestmark = xfail_if_legacy_model_converter_release()
+
+
+def _has_alias_pair(vgf_json: dict, lhs: str, rhs: str) -> bool:
+    for group in alias_groups(vgf_json).values():
+        descriptor_types = {resource["vk_descriptor_type"] for resource in group}
+        if {lhs, rhs}.issubset(descriptor_types):
+            return True
+    return False
+
+
+def _has_alias_relations(vgf_json: dict, lhs: str, bridge: str, rhs: str) -> bool:
+    return _has_alias_pair(vgf_json, lhs, bridge) and _has_alias_pair(
+        vgf_json, bridge, rhs
+    )
+
+
+class _ComputeComputeThrees(torch.nn.Module):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        y = torch.ops.arm_test_shader_ops.threes.default(x)
+        return torch.ops.arm_test_shader_ops.threes.default(y)
+
+
+class _GraphComputeComputeThrees(torch.nn.Module):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = x * 2.0
+        y = torch.ops.arm_test_shader_ops.threes.default(x)
+        return torch.ops.arm_test_shader_ops.threes.default(y)
+
+
+class _ComputeGraphGraphThrees(torch.nn.Module):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        y = torch.ops.arm_test_shader_ops.threes.default(x)
+        y = y * 0.5
+        return y * 2.0
+
+
+class _GraphThenThrees(torch.nn.Module):
+    def forward(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+        return torch.ops.arm_test_shader_ops.threes.default(a + b)
+
+
+class _GraphThenSampler(torch.nn.Module):
+    def forward(self, x: torch.Tensor, grid: torch.Tensor) -> torch.Tensor:
+        x = x * 2.0 + 1.0
+        return F.grid_sample(
+            x,
+            grid,
+            mode="bilinear",
+            padding_mode="zeros",
+            align_corners=False,
+        )
+
+
+class _SamplerThenGraph(torch.nn.Module):
+    def forward(self, x: torch.Tensor, grid: torch.Tensor) -> torch.Tensor:
+        y = F.grid_sample(
+            x,
+            grid,
+            mode="bilinear",
+            padding_mode="zeros",
+            align_corners=False,
+        )
+        return y * 0.5 + 3.0
+
+
+class _SamplerThenSampler(torch.nn.Module):
+    def forward(
+        self, x: torch.Tensor, grid0: torch.Tensor, grid1: torch.Tensor
+    ) -> torch.Tensor:
+        y = F.grid_sample(
+            x,
+            grid0,
+            mode="bilinear",
+            padding_mode="zeros",
+            align_corners=False,
+        )
+        return F.grid_sample(
+            y,
+            grid1,
+            mode="bilinear",
+            padding_mode="zeros",
+            align_corners=False,
+        )
+
+
+class _SamplerThenThrees(torch.nn.Module):
+    def forward(self, x: torch.Tensor, grid: torch.Tensor) -> torch.Tensor:
+        y = F.grid_sample(
+            x,
+            grid,
+            mode="bilinear",
+            padding_mode="zeros",
+            align_corners=False,
+        )
+        return torch.ops.arm_test_shader_ops.threes.default(y)
+
+
+class _IdentityBufferOnly(torch.nn.Module):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.ops.arm_test_shader_ops.identity.default(x)
+
+
+class _IdentitySampler(torch.nn.Module):
+    def forward(self, x: torch.Tensor, grid: torch.Tensor) -> torch.Tensor:
+        return F.grid_sample(
+            x,
+            grid,
+            mode="bilinear",
+            padding_mode="zeros",
+            align_corners=False,
+        )
+
+
+class _IdentitySamplerBufferDebug(torch.nn.Module):
+    def forward(self, x: torch.Tensor, grid: torch.Tensor) -> torch.Tensor:
+        return torch.ops.arm_test_vulkan_custom_shader.grid_sample_buffer_debug.default(
+            x,
+            grid,
+            mode="bilinear",
+            padding_mode="zeros",
+            align_corners=False,
+        )
+
+
+class _IdentitySamplerBufferNchwDebug(torch.nn.Module):
+    def forward(self, x: torch.Tensor, grid: torch.Tensor) -> torch.Tensor:
+        return torch.ops.arm_test_vulkan_custom_shader.grid_sample_buffer_nchw_debug.default(
+            x,
+            grid,
+            mode="bilinear",
+            padding_mode="zeros",
+            align_corners=False,
+        )
+
+
+class _GridReadTensorDebug(torch.nn.Module):
+    def forward(self, x: torch.Tensor, grid: torch.Tensor) -> torch.Tensor:
+        return torch.ops.arm_test_vulkan_custom_shader.grid_read_tensor_debug.default(
+            x,
+            grid,
+            mode="bilinear",
+            padding_mode="zeros",
+            align_corners=False,
+        )
+
+
+class _IdentityPackedThenSamplerBufferDebug(torch.nn.Module):
+    def forward(self, x: torch.Tensor, grid: torch.Tensor) -> torch.Tensor:
+        y = torch.ops.arm_test_shader_ops.identity_image_packed.default(x)
+        return torch.ops.arm_test_vulkan_custom_shader.grid_sample_buffer_debug.default(
+            y,
+            grid,
+            mode="bilinear",
+            padding_mode="zeros",
+            align_corners=False,
+        )
+
+
+class _IdentityBufferThenSamplerBufferNchwDebug(torch.nn.Module):
+    def forward(self, x: torch.Tensor, grid: torch.Tensor) -> torch.Tensor:
+        y = torch.ops.arm_test_shader_ops.identity.default(x)
+        return torch.ops.arm_test_vulkan_custom_shader.grid_sample_buffer_nchw_debug.default(
+            y,
+            grid,
+            mode="bilinear",
+            padding_mode="zeros",
+            align_corners=False,
+        )
+
+
+class _IdentityPackedThenSampler(torch.nn.Module):
+    def forward(self, x: torch.Tensor, grid: torch.Tensor) -> torch.Tensor:
+        y = torch.ops.arm_test_shader_ops.identity_image_packed.default(x)
+        return F.grid_sample(
+            y,
+            grid,
+            mode="bilinear",
+            padding_mode="zeros",
+            align_corners=False,
+        )
+
+
+class _ThreesThenSampler(torch.nn.Module):
+    def forward(self, x: torch.Tensor, grid: torch.Tensor) -> torch.Tensor:
+        y = torch.ops.arm_test_shader_ops.threes.default(x)
+        return F.grid_sample(
+            y,
+            grid,
+            mode="bilinear",
+            padding_mode="zeros",
+            align_corners=False,
+        )
+
+
+# Covers a pure compute-to-compute path using two unary buffer-backed custom shader stages.
+# Checks the lowered VGF contains two compute segments and runtime output matches eager execution within runtime tolerance.
+@common.SkipIfNoModelConverter
+def test_compute_compute_sequence_executes(tmp_path):
+    x = torch.randn(256)
+    expected, actual, vgf_json = lower_threes_vgf(
+        _ComputeComputeThrees(), (x,), tmp_path
+    )
+
+    assert torch.allclose(expected, actual, atol=1e-4, rtol=0.0)
+    assert segment_types(vgf_json) == ["COMPUTE", "COMPUTE"]
+
+
+# Covers a graph-to-compute-to-compute flow with a graph op before two unary custom shader stages.
+# Checks the lowered VGF contains graph then compute then compute and runtime output matches eager execution within runtime tolerance.
+@common.SkipIfNoModelConverter
+def test_graph_compute_compute_sequence_executes(tmp_path):
+    x = torch.randn(256)
+    expected, actual, vgf_json = lower_threes_vgf(
+        _GraphComputeComputeThrees(), (x,), tmp_path
+    )
+
+    assert torch.allclose(expected, actual, atol=1e-4, rtol=0.0)
+    assert segment_types(vgf_json) == ["GRAPH", "COMPUTE", "COMPUTE"]
+
+
+# Covers a unary compute flow followed by two graph ops in the source graph.
+# Checks runtime output matches eager execution and that VGF emits graph segments around the compute stage for constants and tail graph work.
+@common.SkipIfNoModelConverter
+def test_compute_graph_graph_sequence_executes(tmp_path):
+    x = torch.randn(256)
+    expected, actual, vgf_json = lower_threes_vgf(
+        _ComputeGraphGraphThrees(), (x,), tmp_path
+    )
+
+    assert torch.allclose(expected, actual, atol=1e-4, rtol=0.0)
+    assert segment_types(vgf_json) == ["GRAPH", "COMPUTE", "GRAPH"]
+
+
+# Covers the tensor/storage-buffer alias handoff used by graph-to-buffer custom shader execution.
+# Checks a single alias group contains both tensor and storage-buffer descriptors.
+@common.SkipIfNoModelConverter
+def test_tensor_storage_buffer_alias_pair(tmp_path):
+    a = torch.randn(256)
+    b = torch.randn(256)
+    _, _, vgf_json = lower_threes_vgf(_GraphThenThrees(), (a, b), tmp_path)
+
+    assert _has_alias_pair(
+        vgf_json,
+        "VK_DESCRIPTOR_TYPE_TENSOR_ARM",
+        "VK_DESCRIPTOR_TYPE_STORAGE_BUFFER",
+    )
+
+
+# Covers the tensor/combined-image-sampler alias handoff used by graph-to-sampler execution.
+# Checks a single alias group contains both tensor and combined-image-sampler descriptors.
+@common.SkipIfNoModelConverter
+def test_tensor_combined_image_sampler_alias_pair(tmp_path):
+    x, grid = make_sampler_probe_inputs()
+    _, _, vgf_json = lower_sampler_vgf(_GraphThenSampler(), (x, grid), tmp_path)
+
+    assert _has_alias_pair(
+        vgf_json,
+        "VK_DESCRIPTOR_TYPE_TENSOR_ARM",
+        "VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER",
+    )
+
+
+# Covers the tensor/storage-image alias handoff used by shader-to-graph execution.
+# Checks a single alias group contains both tensor and storage-image descriptors.
+@common.SkipIfNoModelConverter
+def test_tensor_storage_image_alias_pair(tmp_path):
+    x, grid = make_sampler_probe_inputs()
+    _, _, vgf_json = lower_sampler_vgf(_SamplerThenGraph(), (x, grid), tmp_path)
+
+    assert _has_alias_pair(
+        vgf_json,
+        "VK_DESCRIPTOR_TYPE_TENSOR_ARM",
+        "VK_DESCRIPTOR_TYPE_STORAGE_IMAGE",
+    )
+
+
+# Covers the storage-image/combined-image-sampler alias handoff across consecutive sampler stages.
+# Checks a single alias group contains both storage-image and combined-image-sampler descriptors.
+@common.SkipIfNoModelConverter
+def test_storage_image_combined_image_sampler_alias_pair(tmp_path):
+    x, grid0 = make_sampler_probe_inputs()
+    grid1 = grid0.clone()
+    _, actual, vgf_json = lower_sampler_vgf(
+        _SamplerThenSampler(), (x, grid0, grid1), tmp_path
+    )
+
+    assert actual is not None
+    assert _has_alias_pair(
+        vgf_json,
+        "VK_DESCRIPTOR_TYPE_STORAGE_IMAGE",
+        "VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER",
+    )
+
+
+# Covers a runtime smoke test for tensor-backed alias connectivity between storage-image and storage-buffer stages.
+# Checks the VGF contains image<->tensor and tensor<->buffer alias relations on this path.
+# This intentionally checks only part of the connectivity story; exact bridge/resource topology belongs to VGF generator testing.
+@common.SkipIfNoModelConverter
+def test_storage_image_storage_buffer_alias_relations(tmp_path):
+    x, grid = make_sampler_probe_inputs()
+    expected, actual, vgf_json = lower_sampler_and_threes_vgf(
+        _SamplerThenThrees(), (x, grid), tmp_path
+    )
+
+    assert torch.allclose(expected, actual, atol=1e-3, rtol=1e-2)
+    assert _has_alias_relations(
+        vgf_json,
+        "VK_DESCRIPTOR_TYPE_STORAGE_IMAGE",
+        "VK_DESCRIPTOR_TYPE_TENSOR_ARM",
+        "VK_DESCRIPTOR_TYPE_STORAGE_BUFFER",
+    )
+
+
+# Covers a runtime smoke test for tensor-backed alias connectivity between storage-buffer and combined-image-sampler stages.
+# Checks the VGF contains buffer<->tensor and tensor<->combined-image-sampler alias relations on this path.
+# This intentionally checks only part of the connectivity story; exact bridge/resource topology belongs to VGF generator testing.
+@common.SkipIfNoModelConverter
+def test_storage_buffer_combined_image_sampler_alias_relations(tmp_path):
+    x, grid = make_sampler_probe_inputs()
+    expected, actual, vgf_json = lower_sampler_and_threes_vgf(
+        _ThreesThenSampler(), (x, grid), tmp_path
+    )
+
+    assert torch.allclose(expected, actual, atol=1e-3, rtol=1e-2)
+    assert _has_alias_relations(
+        vgf_json,
+        "VK_DESCRIPTOR_TYPE_STORAGE_BUFFER",
+        "VK_DESCRIPTOR_TYPE_TENSOR_ARM",
+        "VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER",
+    )
+
+
+# Temporary step-by-step debug for the storage-buffer -> combined-image-sampler path.
+# Checks identity-buffer, sampler-only, and identity-buffer-then-sampler stages separately and reports which stage first diverges.
+@common.SkipIfNoModelConverter
+def test_storage_buffer_combined_image_sampler_alias_pair_debug_steps(tmp_path):
+    x, grid = make_sampler_probe_inputs()
+    top_left_x = (2.0 * 0.0 + 1.0) / x.shape[-1] - 1.0
+    top_left_y = (2.0 * 0.0 + 1.0) / x.shape[-2] - 1.0
+    grid[..., 0] = top_left_x
+    grid[..., 1] = top_left_y
+
+    identity_dir = tmp_path / "identity_buffer_only"
+    identity_dir.mkdir()
+    expected_identity, actual_identity, _ = lower_threes_vgf(
+        _IdentityBufferOnly(), (x,), identity_dir
+    )
+
+    sampler_dir = tmp_path / "sampler_only"
+    sampler_dir.mkdir()
+    expected_sampler, actual_sampler, _ = lower_sampler_vgf(
+        _IdentitySamplerBufferDebug(), (x, grid), sampler_dir
+    )
+
+    sampler_buffer_nchw_dir = tmp_path / "sampler_buffer_nchw_only"
+    sampler_buffer_nchw_dir.mkdir()
+    expected_sampler_buffer_nchw, actual_sampler_buffer_nchw, _ = lower_sampler_vgf(
+        _IdentitySamplerBufferNchwDebug(), (x, grid), sampler_buffer_nchw_dir
+    )
+
+    grid_read_dir = tmp_path / "grid_read_tensor_only"
+    grid_read_dir.mkdir()
+    expected_grid_read, actual_grid_read, _ = lower_sampler_vgf(
+        _GridReadTensorDebug(), (x, grid), grid_read_dir
+    )
+
+    pipeline_dir = tmp_path / "identity_buffer_then_sampler"
+    pipeline_dir.mkdir()
+    expected_pipeline, actual_pipeline, _ = lower_sampler_and_threes_vgf(
+        _IdentityPackedThenSamplerBufferDebug(), (x, grid), pipeline_dir
+    )
+
+    pipeline_buffer_nchw_dir = tmp_path / "identity_buffer_then_sampler_buffer_nchw"
+    pipeline_buffer_nchw_dir.mkdir()
+    expected_pipeline_buffer_nchw, actual_pipeline_buffer_nchw, _ = (
+        lower_sampler_and_threes_vgf(
+            _IdentityBufferThenSamplerBufferNchwDebug(),
+            (x, grid),
+            pipeline_buffer_nchw_dir,
+        )
+    )
+
+    failures = []
+    if not torch.allclose(expected_identity, actual_identity, atol=1e-6, rtol=0.0):
+        failures.append(
+            "identity_buffer_only "
+            f"max_abs_diff={(expected_identity - actual_identity).abs().max().item():.6f}"
+        )
+    if not torch.allclose(expected_sampler, actual_sampler, atol=1e-3, rtol=1e-2):
+        torch.set_printoptions(threshold=100000, linewidth=240, sci_mode=False)
+        print("sampler_only expected:")
+        print(expected_sampler)
+        print("sampler_only actual:")
+        print(actual_sampler)
+        failures.append(
+            "sampler_only "
+            f"max_abs_diff={(expected_sampler - actual_sampler).abs().max().item():.6f}"
+        )
+    if not torch.allclose(
+        expected_sampler_buffer_nchw,
+        actual_sampler_buffer_nchw,
+        atol=1e-3,
+        rtol=1e-2,
+    ):
+        torch.set_printoptions(threshold=100000, linewidth=240, sci_mode=False)
+        print("sampler_buffer_nchw_only expected:")
+        print(expected_sampler_buffer_nchw)
+        print("sampler_buffer_nchw_only actual:")
+        print(actual_sampler_buffer_nchw)
+        failures.append(
+            "sampler_buffer_nchw_only "
+            f"max_abs_diff={(expected_sampler_buffer_nchw - actual_sampler_buffer_nchw).abs().max().item():.6f}"
+        )
+    if not torch.allclose(expected_grid_read, actual_grid_read, atol=1e-6, rtol=0.0):
+        torch.set_printoptions(threshold=100000, linewidth=240, sci_mode=False)
+        print("grid_read_tensor_only expected:")
+        print(expected_grid_read)
+        print("grid_read_tensor_only actual:")
+        print(actual_grid_read)
+        failures.append(
+            "grid_read_tensor_only "
+            f"max_abs_diff={(expected_grid_read - actual_grid_read).abs().max().item():.6f}"
+        )
+    if not torch.allclose(expected_pipeline, actual_pipeline, atol=1e-3, rtol=1e-2):
+        failures.append(
+            "identity_buffer_then_sampler "
+            f"max_abs_diff={(expected_pipeline - actual_pipeline).abs().max().item():.6f}"
+        )
+    if not torch.allclose(
+        expected_pipeline_buffer_nchw,
+        actual_pipeline_buffer_nchw,
+        atol=1e-3,
+        rtol=1e-2,
+    ):
+        failures.append(
+            "identity_buffer_then_sampler_buffer_nchw "
+            f"max_abs_diff={(expected_pipeline_buffer_nchw - actual_pipeline_buffer_nchw).abs().max().item():.6f}"
+        )
+
+    assert not failures, "; ".join(failures)

--- a/backends/arm/test/runtime/test_vgf_multi_segment_runtime.py
+++ b/backends/arm/test/runtime/test_vgf_multi_segment_runtime.py
@@ -1,0 +1,153 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import sys
+from pathlib import Path
+
+import torch
+import torch.nn.functional as F
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
+
+from backends.arm.test.runtime._vgf_runtime_test_utils import (
+    lower_in_tree_vgf,
+    lower_sampler_vgf,
+    make_identity_grid,
+    make_input_tensor,
+    make_sampler_probe_inputs,
+    xfail_if_legacy_model_converter_release,
+)
+from executorch.backends.arm.test import common
+
+pytestmark = xfail_if_legacy_model_converter_release()
+
+
+class _GraphThenShader(torch.nn.Module):
+    def forward(self, x: torch.Tensor, grid: torch.Tensor) -> torch.Tensor:
+        return F.grid_sample(
+            x * 2.0 + 1.0,
+            grid,
+            mode="bilinear",
+            padding_mode="zeros",
+            align_corners=False,
+        )
+
+
+class _ShaderThenGraph(torch.nn.Module):
+    def forward(self, x: torch.Tensor, grid: torch.Tensor) -> torch.Tensor:
+        y = F.grid_sample(
+            x, grid, mode="bilinear", padding_mode="zeros", align_corners=False
+        )
+        return y * 0.5 + 3.0
+
+
+class _GraphShaderGraph(torch.nn.Module):
+    def forward(self, x: torch.Tensor, grid: torch.Tensor) -> torch.Tensor:
+        x = x * 2.0 + 1.0
+        y = F.grid_sample(
+            x, grid, mode="bilinear", padding_mode="zeros", align_corners=False
+        )
+        return y * 0.5 + 3.0
+
+
+class _ShaderGraphShader(torch.nn.Module):
+    def forward(
+        self, x: torch.Tensor, grid0: torch.Tensor, grid1: torch.Tensor
+    ) -> torch.Tensor:
+        y = F.grid_sample(
+            x, grid0, mode="bilinear", padding_mode="zeros", align_corners=False
+        )
+        y = y * 0.5 + 3.0
+        return F.grid_sample(
+            y, grid1, mode="bilinear", padding_mode="zeros", align_corners=False
+        )
+
+
+class _GraphShaderGraphShader(torch.nn.Module):
+    def forward(
+        self, x: torch.Tensor, grid0: torch.Tensor, grid1: torch.Tensor
+    ) -> torch.Tensor:
+        x = x * 2.0 + 1.0
+        y = F.grid_sample(
+            x, grid0, mode="bilinear", padding_mode="zeros", align_corners=False
+        )
+        y = y * 0.5 + 3.0
+        return F.grid_sample(
+            y, grid1, mode="bilinear", padding_mode="zeros", align_corners=False
+        )
+
+
+# Covers a simple graph-to-shader two-segment pipeline.
+# Checks numerics match eager execution across the segment boundary.
+@common.SkipIfNoModelConverter
+def test_graph_then_shader_segment_executes(tmp_path):
+    x = make_input_tensor(4, 4)
+    grid = make_identity_grid(4, 4)
+    expected, actual, _ = lower_in_tree_vgf(_GraphThenShader(), (x, grid), tmp_path)
+
+    assert torch.allclose(expected, actual, atol=1e-6, rtol=0.0)
+
+
+# Covers a simple shader-to-graph two-segment pipeline.
+# Checks numerics match eager execution across the segment boundary.
+@common.SkipIfNoModelConverter
+def test_shader_then_graph_segment_executes(tmp_path):
+    x = make_input_tensor(4, 4)
+    grid = make_identity_grid(4, 4)
+    expected, actual, _ = lower_in_tree_vgf(_ShaderThenGraph(), (x, grid), tmp_path)
+
+    assert torch.allclose(expected, actual, atol=1e-6, rtol=0.0)
+
+
+# Covers a graph-shader-graph three-segment pipeline.
+# Checks runtime execution remains correct through both handoff directions.
+@common.SkipIfNoModelConverter
+def test_graph_shader_graph_executes(tmp_path):
+    x = make_input_tensor(4, 4)
+    grid = make_identity_grid(4, 4)
+    expected, actual, _ = lower_in_tree_vgf(_GraphShaderGraph(), (x, grid), tmp_path)
+
+    assert torch.allclose(expected, actual, atol=1e-6, rtol=0.0)
+
+
+# Covers a shader-graph-shader three-segment pipeline.
+# Checks repeated segment transitions preserve correctness through runtime execution.
+@common.SkipIfNoModelConverter
+def test_shader_graph_shader_executes(tmp_path):
+    x = make_input_tensor(4, 4)
+    grid0 = make_identity_grid(4, 4)
+    grid1 = make_identity_grid(4, 4)
+    expected, actual, _ = lower_in_tree_vgf(
+        _ShaderGraphShader(), (x, grid0, grid1), tmp_path
+    )
+
+    assert torch.allclose(expected, actual, atol=1e-6, rtol=0.0)
+
+
+# Covers a longer mixed graph/shader pipeline with four logical stages.
+# Checks numerics remain correct through multiple segment transitions.
+@common.SkipIfNoModelConverter
+def test_graph_shader_graph_shader_executes(tmp_path):
+    x = make_input_tensor(4, 4)
+    grid0 = make_identity_grid(4, 4)
+    grid1 = make_identity_grid(4, 4)
+    expected, actual, _ = lower_in_tree_vgf(
+        _GraphShaderGraphShader(), (x, grid0, grid1), tmp_path
+    )
+
+    assert torch.allclose(expected, actual, atol=1e-6, rtol=0.0)
+
+
+# Covers the multi-segment sampler/image runtime path specifically.
+# Checks repeated sampled stages match eager execution within the expected tolerance.
+@common.SkipIfNoModelConverter
+def test_multi_segment_sampler_path_executes(tmp_path):
+    x, grid0 = make_sampler_probe_inputs()
+    grid1 = grid0.clone()
+    expected, actual, _ = lower_sampler_vgf(
+        _ShaderGraphShader(), (x, grid0, grid1), tmp_path
+    )
+
+    assert torch.allclose(expected, actual, atol=1e-3, rtol=1e-2)

--- a/backends/arm/test/runtime/test_vgf_sampler_image_runtime.py
+++ b/backends/arm/test/runtime/test_vgf_sampler_image_runtime.py
@@ -1,0 +1,110 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import sys
+from pathlib import Path
+
+import torch
+import torch.nn.functional as F
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
+
+from backends.arm.test.runtime._vgf_runtime_test_utils import (
+    lower_sampler_vgf,
+    make_identity_grid,
+    make_input_tensor,
+    make_sampler_probe_inputs,
+    xfail_if_legacy_model_converter_release,
+)
+from executorch.backends.arm.test import common
+
+pytestmark = xfail_if_legacy_model_converter_release()
+
+
+class _IdentitySampler(torch.nn.Module):
+    def forward(self, x: torch.Tensor, grid: torch.Tensor) -> torch.Tensor:
+        return F.grid_sample(
+            x,
+            grid,
+            mode="bilinear",
+            padding_mode="zeros",
+            align_corners=False,
+        )
+
+
+class _GraphConsumerSampler(torch.nn.Module):
+    def forward(self, x: torch.Tensor, grid: torch.Tensor) -> torch.Tensor:
+        y = F.grid_sample(
+            x,
+            grid,
+            mode="bilinear",
+            padding_mode="zeros",
+            align_corners=False,
+        )
+        return y * 0.5 + 3.0
+
+
+# Covers the basic sampler/image runtime path.
+# Checks sampled-image input can be read and returned correctly at runtime.
+@common.SkipIfNoModelConverter
+def test_sampled_image_to_tensor_identity_read(tmp_path):
+    x = make_input_tensor(4, 4).contiguous(memory_format=torch.channels_last)
+    grid = make_identity_grid(4, 4)
+    expected, actual, _ = lower_sampler_vgf(_IdentitySampler(), (x, grid), tmp_path)
+
+    assert torch.allclose(expected, actual, atol=1e-6, rtol=0.0)
+
+
+# Covers exact texel-center sampling behavior.
+# Checks exact sample points match eager output on the clean probe rows.
+@common.SkipIfNoModelConverter
+def test_sampled_image_exact_texel_center_reads(tmp_path):
+    x, grid = make_sampler_probe_inputs()
+    expected, actual, _ = lower_sampler_vgf(_IdentitySampler(), (x, grid), tmp_path)
+
+    assert torch.equal(expected[0, 0, 0], actual[0, 0, 0])
+    assert torch.equal(expected[0, 0, 1], actual[0, 0, 1])
+
+
+# Covers linear interpolation behavior on the sampler path.
+# Checks runtime output matches eager output within the expected tolerance.
+@common.SkipIfNoModelConverter
+def test_sampled_image_linear_interpolation_probe(tmp_path):
+    x, grid = make_sampler_probe_inputs()
+    expected, actual, _ = lower_sampler_vgf(_IdentitySampler(), (x, grid), tmp_path)
+
+    assert torch.allclose(expected, actual, atol=1e-3, rtol=1e-2)
+
+
+# Covers storage-image output feeding later graph/tensor consumption.
+# Checks the runtime numerics match and the generated VGF contains a storage-image resource.
+@common.SkipIfNoModelConverter
+def test_storage_image_output_can_round_trip_to_graph_tensor(tmp_path):
+    x, grid = make_sampler_probe_inputs()
+    expected, actual, vgf_json = lower_sampler_vgf(
+        _GraphConsumerSampler(), (x, grid), tmp_path
+    )
+
+    assert torch.allclose(expected, actual, atol=1e-3, rtol=1e-2)
+    assert any(
+        resource["vk_descriptor_type"] == "VK_DESCRIPTOR_TYPE_STORAGE_IMAGE"
+        for resource in vgf_json["resources"]
+    )
+
+
+# Covers sampler metadata requirements for combined-image-sampler resources.
+# Checks every combined-image-sampler MRT entry carries sampler_config in the VGF dump.
+@common.SkipIfNoModelConverter
+def test_combined_image_sampler_requires_sampler_config(tmp_path):
+    x, grid = make_sampler_probe_inputs()
+    _, _, vgf_json = lower_sampler_vgf(_GraphConsumerSampler(), (x, grid), tmp_path)
+    combined_image_samplers = [
+        resource
+        for resource in vgf_json["resources"]
+        if resource["vk_descriptor_type"] == "VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER"
+    ]
+
+    assert combined_image_samplers
+    assert all("sampler_config" in resource for resource in combined_image_samplers)

--- a/backends/arm/test/runtime/test_vgf_tensor_buffer_runtime.py
+++ b/backends/arm/test/runtime/test_vgf_tensor_buffer_runtime.py
@@ -1,0 +1,165 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
+
+from backends.arm.test.runtime._vgf_runtime_test_utils import (
+    alias_groups,
+    lower_add_vgf,
+    lower_in_tree_vgf,
+    make_identity_grid,
+    make_input_tensor,
+    xfail_if_legacy_model_converter_release,
+)
+from executorch.backends.arm.test import common
+
+pytestmark = xfail_if_legacy_model_converter_release()
+
+
+class _IdentityGridSample(torch.nn.Module):
+    def forward(self, x: torch.Tensor, grid: torch.Tensor) -> torch.Tensor:
+        return F.grid_sample(
+            x,
+            grid,
+            mode="bilinear",
+            padding_mode="zeros",
+            align_corners=False,
+        )
+
+
+class _GraphToShader(torch.nn.Module):
+    def forward(self, x: torch.Tensor, grid: torch.Tensor) -> torch.Tensor:
+        return F.grid_sample(
+            x * 2.0 + 1.0,
+            grid,
+            mode="bilinear",
+            padding_mode="zeros",
+            align_corners=False,
+        )
+
+
+class _ShaderToGraph(torch.nn.Module):
+    def forward(self, x: torch.Tensor, grid: torch.Tensor) -> torch.Tensor:
+        y = F.grid_sample(
+            x, grid, mode="bilinear", padding_mode="zeros", align_corners=False
+        )
+        return y * 0.5 + 3.0
+
+
+class _EndToEnd(torch.nn.Module):
+    def forward(self, x: torch.Tensor, grid: torch.Tensor) -> torch.Tensor:
+        y = F.grid_sample(
+            x * 2.0 + 1.0,
+            grid,
+            mode="bilinear",
+            padding_mode="zeros",
+            align_corners=False,
+        )
+        return y * 0.5 + 3.0
+
+
+class _BinaryAddShader(torch.nn.Module):
+    def forward(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+        return a + b
+
+
+class _DuplicatedInputAddShader(torch.nn.Module):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x + x
+
+
+# Covers the simplest runtime path through the in-tree grid-sample flow.
+# Checks runtime execution matches eager output for an identity-style sample.
+@common.SkipIfNoModelConverter
+def test_tensor_input_buffer_output_identity_shader(tmp_path):
+    x = make_input_tensor(4, 4)
+    grid = make_identity_grid(4, 4)
+    expected, actual, _ = lower_in_tree_vgf(_IdentityGridSample(), (x, grid), tmp_path)
+
+    assert torch.allclose(expected, actual, atol=1e-6, rtol=0.0)
+
+
+# Covers graph work feeding the shader path.
+# Checks a graph-produced tensor is consumed correctly by the runtime shader segment.
+@common.SkipIfNoModelConverter
+def test_graph_tensor_to_shader_buffer_handoff(tmp_path):
+    x = make_input_tensor(4, 4)
+    grid = make_identity_grid(4, 4)
+    expected, actual, _ = lower_in_tree_vgf(_GraphToShader(), (x, grid), tmp_path)
+
+    assert torch.allclose(expected, actual, atol=1e-6, rtol=0.0)
+
+
+# Covers graph work after the shader path.
+# Checks shader output is consumed correctly by following graph ops at runtime.
+@common.SkipIfNoModelConverter
+def test_shader_buffer_to_graph_tensor_handoff(tmp_path):
+    x = make_input_tensor(4, 4)
+    grid = make_identity_grid(4, 4)
+    expected, actual, _ = lower_in_tree_vgf(_ShaderToGraph(), (x, grid), tmp_path)
+
+    assert torch.allclose(expected, actual, atol=1e-6, rtol=0.0)
+
+
+# Covers artifact-level tensor/buffer aliasing in the generated VGF.
+# Checks at least one alias group spans tensor and storage-buffer descriptors.
+@common.SkipIfNoModelConverter
+def test_tensor_buffer_alias_group_reuses_backing_memory(tmp_path):
+    x = make_input_tensor(4, 4)
+    grid = make_identity_grid(4, 4)
+    _, _, vgf_json = lower_in_tree_vgf(_GraphToShader(), (x, grid), tmp_path)
+    groups = alias_groups(vgf_json)
+
+    assert groups
+    assert any(
+        {resource["vk_descriptor_type"] for resource in group}
+        >= {
+            "VK_DESCRIPTOR_TYPE_TENSOR_ARM",
+            "VK_DESCRIPTOR_TYPE_STORAGE_BUFFER",
+        }
+        for group in groups.values()
+    )
+
+
+# Covers the end-to-end tensor/buffer runtime flow with graph ops on both sides.
+# Checks numerics across the full lowered pipeline match eager execution.
+@common.SkipIfNoModelConverter
+def test_tensor_buffer_runtime_executes_end_to_end(tmp_path):
+    x = make_input_tensor(4, 4)
+    grid = make_identity_grid(4, 4)
+    expected, actual, _ = lower_in_tree_vgf(_EndToEnd(), (x, grid), tmp_path)
+
+    assert torch.allclose(expected, actual, atol=1e-6, rtol=0.0)
+
+
+# Covers the standalone two-input storage-buffer shader path.
+# Checks runtime execution matches eager output for a minimal binary add case.
+@common.SkipIfNoModelConverter
+def test_two_input_add_buffer_shader_executes(tmp_path):
+    a = torch.randn(256)
+    b = torch.randn(256)
+    expected, actual, _ = lower_add_vgf(_BinaryAddShader(), (a, b), tmp_path)
+
+    assert torch.allclose(expected, actual, atol=1e-6, rtol=0.0)
+
+
+# Covers the two-input storage-buffer shader path when both inputs are the same tensor.
+# Checks runtime execution matches eager output for the duplicated-input add case.
+@pytest.mark.xfail(
+    reason="model-converter drops duplicated custom shader inputs", strict=True
+)
+@common.SkipIfNoModelConverter
+def test_two_input_add_buffer_shader_with_duplicated_input_executes(tmp_path):
+    x = torch.randn(256)
+    expected, actual, _ = lower_add_vgf(_DuplicatedInputAddShader(), (x,), tmp_path)
+
+    assert torch.allclose(expected, actual, atol=1e-6, rtol=0.0)

--- a/backends/arm/test/targets.bzl
+++ b/backends/arm/test/targets.bzl
@@ -43,6 +43,7 @@ def define_arm_tests():
         "ops/test_gelu.py",
         "ops/test_bmm.py",
         "ops/test_split.py",
+        "ops/test_custom_shader_lowering.py",
     ]
 
     # Quantization
@@ -60,10 +61,20 @@ def define_arm_tests():
         "misc/test_tosa_spec.py",
         "misc/test_bn_relu_folding_qat.py",
         "misc/test_custom_partition.py",
+        "misc/test_custom_shader_payloads.py",
         "misc/test_debug_hook.py",
         "misc/test_mxfp_linear_ao.py",
         "misc/test_post_quant_device_switch.py",
+        "misc/test_vgf_backend.py",
         # "misc/test_dim_order.py", (TODO - T238390249)
+    ]
+
+    test_files += [
+        "runtime/test_vgf_aliasing_runtime.py",
+        "runtime/test_vgf_combinations_runtime.py",
+        "runtime/test_vgf_multi_segment_runtime.py",
+        "runtime/test_vgf_sampler_image_runtime.py",
+        "runtime/test_vgf_tensor_buffer_runtime.py",
     ]
 
     # Deprecation tests
@@ -104,6 +115,8 @@ def define_arm_tests():
                 "//executorch/backends/arm/test:arm_tester" if runtime.is_oss else "//executorch/backends/arm/test/tester/fb:arm_tester_fb",
                 "//executorch/backends/arm/test:conftest",
                 "//executorch/backends/arm/test/misc:dw_convs_shared_weights_module",
+                "//executorch/backends/arm/test:custom_vgf_test_utils",
+                "//executorch/backends/arm/test:vgf_runtime_test_utils",
                 "//executorch/backends/arm:ao_ext",
                 "//executorch/backends/arm:ethosu",
                 "//executorch/backends/arm/tosa:compile_spec",

--- a/backends/arm/vgf/_passes/rewrite_grid_sampler_to_tosa_custom.py
+++ b/backends/arm/vgf/_passes/rewrite_grid_sampler_to_tosa_custom.py
@@ -15,14 +15,13 @@ from executorch.backends.arm.vgf.shaders.grid_sampler import (
     build_grid_sampler_2d_payload,
     CUSTOM_SHADER_DOMAIN_NAME,
     encode_payload,
-    GRID_SAMPLER_2D_OPERATOR_NAME,
+    grid_sampler_2d_operator_name,
 )
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass, PassResult
 from torch.fx.passes.shape_prop import _extract_tensor_metadata
 
 
-@register_fake_tosa(GRID_SAMPLER_2D_OPERATOR_NAME)
 def _grid_sampler_2d_custom_fake_impl(
     inputs, operator_name, domain_name, implementation_attrs
 ) -> list[torch.Tensor]:
@@ -40,6 +39,40 @@ def _grid_sampler_2d_custom_fake_impl(
             device=input_tensor.device,
         )
     ]
+
+
+def _register_grid_sampler_2d_custom_fake_impl(
+    interpolation_mode: int,
+    padding_mode: int,
+    align_corners: bool,
+) -> None:
+    operator_name = grid_sampler_2d_operator_name(
+        interpolation_mode=interpolation_mode,
+        padding_mode=padding_mode,
+        align_corners=align_corners,
+    )
+
+    def _grid_sampler_2d_custom_fake_impl_variant(
+        inputs, operator_name, domain_name, implementation_attrs
+    ) -> list[torch.Tensor]:
+        return _grid_sampler_2d_custom_fake_impl(
+            inputs,
+            operator_name,
+            domain_name,
+            implementation_attrs,
+        )
+
+    register_fake_tosa(operator_name)(_grid_sampler_2d_custom_fake_impl_variant)
+
+
+for interpolation_mode in (0, 1, 2):
+    for padding_mode in (0, 1, 2):
+        for align_corners in (False, True):
+            _register_grid_sampler_2d_custom_fake_impl(
+                interpolation_mode=interpolation_mode,
+                padding_mode=padding_mode,
+                align_corners=align_corners,
+            )
 
 
 def _set_fake_tensor_meta(node: torch.fx.Node, value) -> None:
@@ -87,6 +120,11 @@ class RewriteGridSamplerToTosaCustomPass(ArmPass):
                 padding_mode=padding_mode,
                 align_corners=align_corners,
             )
+            operator_name = grid_sampler_2d_operator_name(
+                interpolation_mode=interpolation_mode,
+                padding_mode=padding_mode,
+                align_corners=align_corners,
+            )
 
             with graph_module.graph.inserting_before(node):
                 nhwc_input = create_node(
@@ -107,7 +145,7 @@ class RewriteGridSamplerToTosaCustomPass(ArmPass):
                     op_target=exir_ops.backend.tosa.CUSTOM.default,
                     args=([nhwc_input, grid],),
                     kwargs={
-                        "operator_name": GRID_SAMPLER_2D_OPERATOR_NAME,
+                        "operator_name": operator_name,
                         "domain_name": CUSTOM_SHADER_DOMAIN_NAME,
                         "implementation_attrs": implementation_attrs,
                     },
@@ -124,7 +162,7 @@ class RewriteGridSamplerToTosaCustomPass(ArmPass):
                 )
                 custom_output = _grid_sampler_2d_custom_fake_impl(
                     [nhwc_input.meta["val"], grid.meta["val"]],
-                    GRID_SAMPLER_2D_OPERATOR_NAME,
+                    operator_name,
                     CUSTOM_SHADER_DOMAIN_NAME,
                     implementation_attrs,
                 )[0]

--- a/backends/arm/vgf/_passes/rewrite_grid_sampler_to_tosa_custom.py
+++ b/backends/arm/vgf/_passes/rewrite_grid_sampler_to_tosa_custom.py
@@ -9,6 +9,7 @@ from typing import Set, Type
 import torch
 from executorch.backends.arm._passes import ArmPass
 from executorch.backends.arm._passes.arm_pass_utils import create_node
+from executorch.backends.arm.constants import NHWC_INVERSE_ORDER, NHWC_ORDER
 from executorch.backends.arm.tosa.dialect.ops.custom import register_fake_tosa
 from executorch.backends.arm.vgf.shaders.grid_sampler import (
     build_grid_sampler_2d_payload,
@@ -18,6 +19,7 @@ from executorch.backends.arm.vgf.shaders.grid_sampler import (
 )
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass, PassResult
+from torch.fx.passes.shape_prop import _extract_tensor_metadata
 
 
 @register_fake_tosa(GRID_SAMPLER_2D_OPERATOR_NAME)
@@ -26,19 +28,27 @@ def _grid_sampler_2d_custom_fake_impl(
 ) -> list[torch.Tensor]:
     _ = (operator_name, domain_name, implementation_attrs)
     input_tensor, grid = inputs
-    output_shape = (
-        input_tensor.shape[0],
-        input_tensor.shape[1],
-        grid.shape[1],
-        grid.shape[2],
-    )
     return [
         torch.empty(
-            output_shape,
+            (
+                input_tensor.shape[0],
+                grid.shape[1],
+                grid.shape[2],
+                input_tensor.shape[-1],
+            ),
             dtype=input_tensor.dtype,
             device=input_tensor.device,
         )
     ]
+
+
+def _set_fake_tensor_meta(node: torch.fx.Node, value) -> None:
+    node.meta["val"] = value
+    if isinstance(value, list):
+        if value:
+            node.meta["tensor_meta"] = _extract_tensor_metadata(value[0])
+    else:
+        node.meta["tensor_meta"] = _extract_tensor_metadata(value)
 
 
 class RewriteGridSamplerToTosaCustomPass(ArmPass):
@@ -79,10 +89,23 @@ class RewriteGridSamplerToTosaCustomPass(ArmPass):
             )
 
             with graph_module.graph.inserting_before(node):
+                nhwc_input = create_node(
+                    graph_module.graph,
+                    op_target=exir_ops.edge.aten.permute_copy.default,
+                    args=(input_tensor, list(NHWC_ORDER)),
+                    from_node=input_tensor,
+                )
+                _set_fake_tensor_meta(
+                    nhwc_input,
+                    exir_ops.edge.aten.permute_copy.default(
+                        input_tensor.meta["val"], list(NHWC_ORDER)
+                    ),
+                )
+
                 custom_node = create_node(
                     graph_module.graph,
                     op_target=exir_ops.backend.tosa.CUSTOM.default,
-                    args=([input_tensor, grid],),
+                    args=([nhwc_input, grid],),
                     kwargs={
                         "operator_name": GRID_SAMPLER_2D_OPERATOR_NAME,
                         "domain_name": CUSTOM_SHADER_DOMAIN_NAME,
@@ -99,10 +122,31 @@ class RewriteGridSamplerToTosaCustomPass(ArmPass):
                     args=(custom_node, 0),
                     kwargs={},
                 )
-                # The getitem is a temporary FX node removed during TOSA
-                # serialization. Keep the original tensor metadata until then.
+                custom_output = _grid_sampler_2d_custom_fake_impl(
+                    [nhwc_input.meta["val"], grid.meta["val"]],
+                    GRID_SAMPLER_2D_OPERATOR_NAME,
+                    CUSTOM_SHADER_DOMAIN_NAME,
+                    implementation_attrs,
+                )[0]
+                _set_fake_tensor_meta(custom_node, [custom_output])
                 getitem_node.meta = dict(node.meta)
-                node.replace_all_uses_with(getitem_node)
+                _set_fake_tensor_meta(getitem_node, custom_output)
+
+            with graph_module.graph.inserting_after(getitem_node):
+                output = create_node(
+                    graph_module.graph,
+                    op_target=exir_ops.edge.aten.permute_copy.default,
+                    args=(getitem_node, list(NHWC_INVERSE_ORDER)),
+                    from_node=node,
+                )
+                output.meta = dict(node.meta)
+                _set_fake_tensor_meta(
+                    output,
+                    exir_ops.edge.aten.permute_copy.default(
+                        custom_output, list(NHWC_INVERSE_ORDER)
+                    ),
+                )
+                node.replace_all_uses_with(output)
                 graph_module.graph.erase_node(node)
 
         if modified:

--- a/backends/arm/vgf/backend.py
+++ b/backends/arm/vgf/backend.py
@@ -21,13 +21,17 @@ from typing import final, List
 
 from executorch.backends.arm._passes import RewriteConvPass
 from executorch.backends.arm._passes.arm_pass_manager import (
+    _registered_pass_insertions,
+    PassInsertions,
     register_pass_insertions_before,
 )
 from executorch.backends.arm.tosa.backend import (  # type: ignore[import-not-found]
     arm_get_first_delegation_tag,
     TOSABackend,
 )
-from executorch.backends.arm.vgf._passes import RewriteGridSamplerToTosaCustomPass
+from executorch.backends.arm.vgf._passes.rewrite_grid_sampler_to_tosa_custom import (  # type: ignore[import-not-found]
+    RewriteGridSamplerToTosaCustomPass,
+)
 
 from executorch.backends.arm.vgf.compile_spec import (  # type: ignore[import-not-found]
     VgfCompileSpec,
@@ -48,19 +52,36 @@ from torch.export.exported_program import ExportedProgram
 # debug functionality
 logger = logging.getLogger(__name__)
 
-_grid_sampler_rewrite_registered = False
-
 
 def _register_grid_sampler_rewrite_pass() -> None:
     """Register VGF-only custom shader lowering passes."""
-    global _grid_sampler_rewrite_registered
-    if _grid_sampler_rewrite_registered:
+    existing_insertions = _registered_pass_insertions.get(RewriteConvPass)
+    if existing_insertions is not None and any(
+        isinstance(pass_, RewriteGridSamplerToTosaCustomPass)
+        for pass_ in existing_insertions.before_passes
+    ):
         return
     register_pass_insertions_before(
         RewriteConvPass,
         [RewriteGridSamplerToTosaCustomPass()],
     )
-    _grid_sampler_rewrite_registered = True
+
+
+def _snapshot_registered_pass_insertions() -> dict[type, PassInsertions]:
+    return {
+        pass_type: PassInsertions(
+            before_passes=list(insertions.before_passes),
+            after_passes=list(insertions.after_passes),
+        )
+        for pass_type, insertions in _registered_pass_insertions.items()
+    }
+
+
+def _restore_registered_pass_insertions(
+    snapshot: dict[type, PassInsertions],
+) -> None:
+    _registered_pass_insertions.clear()
+    _registered_pass_insertions.update(snapshot)
 
 
 @final
@@ -115,24 +136,28 @@ class VgfBackend(BackendDetails):
         """
         logger.info(f"{VgfBackend.__name__} preprocess")
 
-        _register_grid_sampler_rewrite_pass()
-        compile_spec = VgfCompileSpec._from_list(compile_specs)
-        # deduce TOSA compile_spec from VGF compile spec. We get a new
-        # compile spec list, containing only elements relevant for the
-        # TOSABackend.
-        tosa_compile_spec = TOSABackend.filter_tosa_compile_specs(compile_spec)
+        insertions_snapshot = _snapshot_registered_pass_insertions()
+        try:
+            _register_grid_sampler_rewrite_pass()
+            compile_spec = VgfCompileSpec._from_list(compile_specs)
+            # deduce TOSA compile_spec from VGF compile spec. We get a new
+            # compile spec list, containing only elements relevant for the
+            # TOSABackend.
+            tosa_compile_spec = TOSABackend.filter_tosa_compile_specs(compile_spec)
 
-        # Backends doesn't allow inheritance, as stated in comments in exir/backend/backend_api.py
-        # ('All backend implementation are final...'), so use composition instead.
-        # preprocess returns the serialized TOSA flatbuffer in .processed_bytes,
-        # which can be passed on to next compilation step.
-        tosa_preprocess = TOSABackend._preprocess(edge_program, tosa_compile_spec)
+            # Backends doesn't allow inheritance, as stated in comments in exir/backend/backend_api.py
+            # ('All backend implementation are final...'), so use composition instead.
+            # preprocess returns the serialized TOSA flatbuffer in .processed_bytes,
+            # which can be passed on to next compilation step.
+            tosa_preprocess = TOSABackend._preprocess(edge_program, tosa_compile_spec)
 
-        tag_name = arm_get_first_delegation_tag(edge_program.graph_module)
+            tag_name = arm_get_first_delegation_tag(edge_program.graph_module)
 
-        binary = VgfBackend._compile_tosa_flatbuffer(
-            tosa_preprocess.processed_bytes, compile_spec, tag_name
-        )
+            binary = VgfBackend._compile_tosa_flatbuffer(
+                tosa_preprocess.processed_bytes, compile_spec, tag_name
+            )
+        finally:
+            _restore_registered_pass_insertions(insertions_snapshot)
 
         return PreprocessResult(processed_bytes=binary)
 

--- a/backends/arm/vgf/shaders/grid_sampler.glsl
+++ b/backends/arm/vgf/shaders/grid_sampler.glsl
@@ -1,3 +1,8 @@
+// Copyright 2026 Arm Limited and/or its affiliates.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
 #version 450
 
 layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;

--- a/backends/arm/vgf/shaders/grid_sampler.py
+++ b/backends/arm/vgf/shaders/grid_sampler.py
@@ -40,6 +40,29 @@ def _mode_name(
     return names[mode]
 
 
+def grid_sampler_2d_operator_name(
+    interpolation_mode: int,
+    padding_mode: int,
+    align_corners: bool,
+) -> str:
+    interpolation = _mode_name(
+        int(interpolation_mode),
+        _INTERPOLATION_MODE_NAMES,
+        "interpolation_mode",
+    )
+    padding = _mode_name(
+        int(padding_mode),
+        _PADDING_MODE_NAMES,
+        "padding_mode",
+    )
+    return (
+        f"{GRID_SAMPLER_2D_OPERATOR_NAME}"
+        f".mode.{interpolation}"
+        f".padding.{padding}"
+        f".align_corners.{align_corners}"
+    )
+
+
 def build_grid_sampler_2d_payload(
     interpolation_mode: int,
     padding_mode: int,

--- a/examples/arm/custom_operators.md
+++ b/examples/arm/custom_operators.md
@@ -1,0 +1,92 @@
+# Arm Custom Operators
+
+As a practical extension of `torch.library`, the Arm backends provide a way to
+keep selected custom operators inside delegated partitions and lower them to
+backend-specific implementations such as shaders or other target-side code.
+
+Arm custom operators are lowered through the Arm TOSA dialect as `tosa.CUSTOM`
+nodes. In practice this means a user-visible library op is first captured in the
+graph, then rewritten to `tosa.CUSTOM` with a stable `operator_name`,
+`domain_name`, and `implementation_attrs` payload that describes the shader or
+other backend-specific implementation contract.
+
+The main APIs involved are:
+- register the operator with the Arm partitioner using `partitioner.register_custom_partition_op(...)` so it can stay inside the delegated graph
+- add a pass that rewrites the `torch.library` op to `tosa.CUSTOM` in the Arm backend.
+- provide the target-side implementation, for example a GLSL shader
+- provide a function that builds the `tosa.CUSTOM` definition and payload
+
+For a minimal end-to-end example showing the required pieces in Python, see
+`examples/arm/custom_operators.py`.
+
+
+## Resource Layout
+
+### Overview
+
+#### Useful Mental Model
+- Tensor/buffer resources: scalar view, channels in shape.
+- Image resources: packed texel view, channels in format.
+- If you alias tensor and image over the same backing, both views must describe the same logical data consistently.
+
+#### General EValue Tensor Rules
+- Treat shader resources as dense, contiguous tensors in the layout declared by the compiled resource contract.
+- For current 4D shader-local feature tensors, that means `NHWC`.
+- For tensor-like grid and buffer resources, channels remain in the shape and storage is scalar-contiguous in that declared order.
+- Do not rely on row padding, channel padding, or partial copies.
+- Runtime copies raw bytes only. It does not repack, pad, or reinterpret layout for you.
+- If the shader ABI wants a different order, lowering must permute before the `tosa.CUSTOM` node and permute back after it.
+
+### Contract
+
+#### Channels-Last Rules For Current `tosa.CUSTOM` Shader Paths
+- To comply with Vulkan texture layout requirements, we focus on channels last.
+- For the current Arm/VGF 4D custom-shader ABI, shader-local feature tensors are channels-last.
+- That means the internal shader contract is `NHWC`, not graph-visible `NCHW`.
+- Lowering is responsible for inserting `NCHW -> NHWC` before the custom node and `NHWC -> NCHW` after it when needed.
+- Shader authors should implement against the shader-local layout, not the surrounding graph layout.
+- Adjacent shader regions may optimize away redundant permutes, but that is an optimization. The ABI remains explicit.
+
+#### `VK_DESCRIPTOR_TYPE_TENSOR_ARM`
+- This is a scalar tensor contract.
+- `VkFormat` means scalar element format, not packed channel format.
+- For fp32 tensors coming from EValues, use `VK_FORMAT_R32_SFLOAT`.
+- Channels stay in the shape.
+- Example: a grid tensor is `[N, Hout, Wout, 2]` with `VK_FORMAT_R32_SFLOAT`.
+- A 3-channel tensor is fine here as shape `[..., 3]` with scalar format.
+- If tensor/image aliasing is used, tensor-like alias members must use scalar formats.
+
+#### `VK_DESCRIPTOR_TYPE_STORAGE_BUFFER`
+- Same practical data contract as tensor-like resources: scalar, linear, contiguous bytes.
+- `VkFormat` is scalar element format.
+- Channels stay in the shape.
+- If the shader ABI is NHWC, the buffer contents are NHWC scalar linearization.
+- Do not use this as an implicit packed-image contract.
+
+#### `VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER`
+- This is a packed image contract.
+- Logical shape must be `[H, W, C]` or `[1, H, W, C]`.
+- If rank 4, batch must be `1`.
+- The image extent is `W x H`.
+- Channels are packed into the image `VkFormat`.
+- Channel count must exactly match the image format component count.
+- Supported current packed image cases are:
+  - `C=1` -> `VK_FORMAT_R32_SFLOAT`
+  - `C=2` -> `VK_FORMAT_R32G32_SFLOAT`
+  - `C=4` -> `VK_FORMAT_R32G32B32A32_SFLOAT`
+- `C=3` is not supported for image-backed resources in the current contract.
+
+#### `VK_DESCRIPTOR_TYPE_STORAGE_IMAGE`
+- Same packing rules as sampled images.
+- Writable image-backed output.
+- Shape must be `[H, W, C]` or `[1, H, W, C]`, with `N=1` if rank 4.
+- `C` must exactly match the image format component count.
+- No implicit `3 -> 4` promotion or padding is allowed.
+- If you need image-backed output, output channels must be `1`, `2`, or `4`.
+
+#### 3-Channel Limitation
+- `C=3` is allowed for tensor/buffer paths because channels remain in the shape.
+- `C=3` is rejected for image-backed resources because the current contract only supports exact 1/2/4-component packed image formats.
+- If you need image semantics for 3-channel data, you must either:
+  - pad to 4 channels explicitly before the custom node, or
+  - stay on a tensor/buffer path

--- a/examples/arm/custom_operators.py
+++ b/examples/arm/custom_operators.py
@@ -1,0 +1,522 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Minimal standalone Arm/VGF custom-shader examples.
+
+This example shows the full stack for two GLSL operators:
+- a scalar buffer-backed operator
+- an RGBA image-backed operator
+- the PyTorch fake implementation needed for export
+- the `tosa.CUSTOM` fake implementation needed for lowering
+- a small rewrite pass that wraps the custom op as `tosa.CUSTOM`
+- VGF lowering and runtime execution against the produced `.pte`
+
+Prerequisites:
+- `glslc` available on `PATH`
+- the Arm `model_converter` tools installed and available to the VGF backend
+- a runtime build exposing `VgfBackend`
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import operator
+import shutil
+import subprocess  # nosec B404 - fixed local tool invocation
+from pathlib import Path
+from typing import Callable, cast
+
+import executorch.backends.arm.tosa.dialect  # noqa: F401
+import torch
+from executorch.backends.arm._passes import ArmPass, RewriteMatmulPass
+from executorch.backends.arm._passes.arm_pass_manager import (
+    register_pass_insertions_after,
+)
+from executorch.backends.arm.constants import NHWC_INVERSE_ORDER, NHWC_ORDER
+from executorch.backends.arm.tosa.dialect.ops.custom import (
+    has_fake_tosa_impl,
+    register_fake_tosa,
+)
+from executorch.backends.arm.vgf import VgfCompileSpec, VgfPartitioner
+from executorch.exir import EdgeCompileConfig, to_edge_transform_and_lower
+from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.extension.export_util.utils import save_pte_program
+from executorch.runtime import Runtime
+from torch.export import export
+from torch.fx.passes.infra.pass_base import PassResult
+from torch.fx.passes.shape_prop import _extract_tensor_metadata
+from torch.library import register_fake
+
+CUSTOM_NAMESPACE = "arm_example_custom_shader"
+SCALE_ADD_OPERATOR = f"{CUSTOM_NAMESPACE}::scale_add"
+RGBA_BIAS_OPERATOR = f"{CUSTOM_NAMESPACE}::rgba_bias"
+TOSA_SCALE_ADD_OPERATOR = "examples.arm.scale_add"
+TOSA_RGBA_BIAS_OPERATOR = "examples.arm.rgba_bias"
+CUSTOM_DOMAIN = "com.arm.VulkanCustomShader"
+ARTIFACT_DIR = Path("arm_custom_operator_vgf")
+SCALE_ADD_PTE_NAME = "scale_add_vgf.pte"
+RGBA_BIAS_PTE_NAME = "rgba_bias_vgf.pte"
+
+TensorUnary = Callable[[torch.Tensor], torch.Tensor]
+
+_SCALE_ADD_SHADER_SOURCE_NAME = "scale_add.comp"
+_SCALE_ADD_SPIRV_NAME = "scale_add.spv"
+_SCALE_ADD_SHADER_SOURCE = """#version 450
+layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
+layout(set = 0, binding = 0) buffer In { float x[]; };
+layout(set = 0, binding = 1) buffer Out { float y[]; };
+void main() {
+  uint idx = gl_GlobalInvocationID.x;
+  if (idx >= y.length()) {
+    return;
+  }
+  y[idx] = x[idx] * 2.0 + 5.0;
+}
+"""
+
+_RGBA_BIAS_SHADER_SOURCE_NAME = "rgba_bias.comp"
+_RGBA_BIAS_SPIRV_NAME = "rgba_bias.spv"
+_RGBA_BIAS_SHADER_SOURCE = """#version 450
+layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
+layout(set = 0, binding = 0) uniform sampler2D in_image;
+layout(set = 0, binding = 1, rgba32f) uniform writeonly image2D out_image;
+void main() {
+  ivec2 coord = ivec2(gl_GlobalInvocationID.xy);
+  ivec2 size = imageSize(out_image);
+  if (coord.x >= size.x || coord.y >= size.y) {
+    return;
+  }
+  vec2 uv = (vec2(coord) + vec2(0.5)) / vec2(size);
+  vec4 value = texture(in_image, uv);
+  imageStore(out_image, coord, value + vec4(10.0, 20.0, 30.0, 40.0));
+}
+"""
+
+
+def _build_scale_add_payload(output_dir: Path) -> list[int]:
+    payload = {
+        "entry_point": "main",
+        "workgroup_sizes": [64, 1, 1],
+        "is_vkshader": True,
+        "shader_code": _compile_shader(
+            output_dir,
+            _SCALE_ADD_SHADER_SOURCE_NAME,
+            _SCALE_ADD_SPIRV_NAME,
+            _SCALE_ADD_SHADER_SOURCE,
+        ),
+        "shader_language": "SPIR-V",
+        "push_constants": "",
+        "input_0_binding": 0,
+        "output_0_binding": 1,
+        "input_0_type": "Buffer",
+        "output_0_type": "Buffer",
+        "input_0_vkdescriptortype": "VK_DESCRIPTOR_TYPE_STORAGE_BUFFER",
+        "output_0_vkdescriptortype": "VK_DESCRIPTOR_TYPE_STORAGE_BUFFER",
+        "input_0_descriptorset": 0,
+        "output_0_descriptorset": 0,
+        "input_0_vkformat": "VK_FORMAT_R32_SFLOAT",
+        "output_0_vkformat": "VK_FORMAT_R32_SFLOAT",
+    }
+    return list(json.dumps(payload, sort_keys=True).encode("utf-8"))
+
+
+def _build_rgba_bias_payload(output_dir: Path) -> list[int]:
+    payload = {
+        "entry_point": "main",
+        "workgroup_sizes": [8, 8, 1],
+        "is_vkshader": True,
+        "shader_code": _compile_shader(
+            output_dir,
+            _RGBA_BIAS_SHADER_SOURCE_NAME,
+            _RGBA_BIAS_SPIRV_NAME,
+            _RGBA_BIAS_SHADER_SOURCE,
+        ),
+        "shader_language": "SPIR-V",
+        "push_constants": "",
+        "input_0_binding": 0,
+        "output_0_binding": 1,
+        "input_0_type": "Image",
+        "output_0_type": "Image",
+        "input_0_vkdescriptortype": "VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER",
+        "output_0_vkdescriptortype": "VK_DESCRIPTOR_TYPE_STORAGE_IMAGE",
+        "input_0_descriptorset": 0,
+        "output_0_descriptorset": 0,
+        "input_0_vkformat": "VK_FORMAT_R32G32B32A32_SFLOAT",
+        "output_0_vkformat": "VK_FORMAT_R32G32B32A32_SFLOAT",
+        "input_0_sampler": {
+            "mag_filter": "VK_FILTER_LINEAR",
+            "min_filter": "VK_FILTER_LINEAR",
+            "address_mode_u": "VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER",
+            "address_mode_v": "VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER",
+            "border_color": "VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK",
+        },
+    }
+    return list(json.dumps(payload, sort_keys=True).encode("utf-8"))
+
+
+def register_example_custom_op() -> None:
+    """Register the Python-side pieces of the custom-op contract.
+
+    The custom shader flow has two layers of operator identity:
+
+    1. A normal `torch.library` op used by the eager model and by export.
+    2. A `tosa.CUSTOM` operator name plus payload used by Arm lowering.
+
+    Both layers need their own fake implementations:
+    - the PyTorch fake keeps export/shape propagation working before rewrite
+    - the TOSA fake keeps `tosa.CUSTOM` shape propagation working after rewrite
+    """
+
+    # Step 1: register the user-visible library op together with its eager
+    # implementation. `@torch.library.custom_op` defines the library schema
+    # directly from the Python signature, so there is no separate `.define(...)`
+    # call in this example.
+    @torch.library.custom_op(SCALE_ADD_OPERATOR, mutates_args=())
+    def _scale_add_impl(x: torch.Tensor) -> torch.Tensor:
+        return x * 2.0 + 5.0
+
+    # Step 2: register the PyTorch fake for the library op. Export uses this
+    # for metadata propagation before we rewrite the op to `tosa.CUSTOM`.
+    def _scale_add_fake_impl(x: torch.Tensor) -> torch.Tensor:
+        return torch.empty_like(x)
+
+    cast(TensorUnary, register_fake(SCALE_ADD_OPERATOR)(_scale_add_fake_impl))
+
+    # Step 3: register the stable TOSA custom operator name used by the Arm
+    # lowering. This name must match the `operator_name` that the rewrite pass
+    # emits into the `tosa.CUSTOM` node.
+    #
+    # The TOSA dialect schema is:
+    #   CUSTOM(Tensor[] inputs, str operator_name, str domain_name,
+    #          int[] implementation_attrs) -> Tensor[]
+    #
+    # The dialect helper unwraps the outer `Tensor[]` before invoking the fake,
+    # so this fake receives `inputs=[x]`, not `inputs=[[x]]`. The fake must
+    # still return a list because `tosa.CUSTOM` is a list-valued op.
+    @register_fake_tosa(TOSA_SCALE_ADD_OPERATOR)
+    def _scale_add_tosa_fake(
+        inputs: list[torch.Tensor],
+        operator_name: str,
+        domain_name: str,
+        implementation_attrs: list[int],
+    ) -> list[torch.Tensor]:
+        assert operator_name == TOSA_SCALE_ADD_OPERATOR
+        assert domain_name == CUSTOM_DOMAIN
+        _ = implementation_attrs
+        return [torch.empty_like(inputs[0])]
+
+    # Steps 4-6: register a second library op that uses RGBA storage images
+    # internally. The eager op still uses the normal graph-visible NCHW shape;
+    # the rewrite pass adds the NCHW <-> NHWC bridge around the image shader.
+    @torch.library.custom_op(RGBA_BIAS_OPERATOR, mutates_args=())
+    def _rgba_bias_impl(x: torch.Tensor) -> torch.Tensor:
+        bias = x.new_tensor([10.0, 20.0, 30.0, 40.0]).view(1, 4, 1, 1)
+        return x + bias
+
+    def _rgba_bias_fake_impl(x: torch.Tensor) -> torch.Tensor:
+        return torch.empty_like(x)
+
+    cast(TensorUnary, register_fake(RGBA_BIAS_OPERATOR)(_rgba_bias_fake_impl))
+
+    @register_fake_tosa(TOSA_RGBA_BIAS_OPERATOR)
+    def _rgba_bias_tosa_fake(
+        inputs: list[torch.Tensor],
+        operator_name: str,
+        domain_name: str,
+        implementation_attrs: list[int],
+    ) -> list[torch.Tensor]:
+        assert operator_name == TOSA_RGBA_BIAS_OPERATOR
+        assert domain_name == CUSTOM_DOMAIN
+        _ = implementation_attrs
+        return [torch.empty_like(inputs[0])]
+
+
+class EncodeScaleAddToTosaCustomPass(ArmPass):
+    """Rewrite the library op to a `tosa.CUSTOM` node with shader payload.
+
+    This pass is the bridge between the user-visible library op and the Arm
+    custom-shader lowering contract. After partitioning has kept the library op
+    inside the delegated region, this pass replaces it with:
+    - a `tosa.CUSTOM` node carrying the Vulkan shader payload
+    - a `getitem` extracting the single tensor output
+    """
+
+    _passes_required_after = set()
+
+    def __init__(self, output_dir: Path) -> None:
+        self._implementation_attrs = _build_scale_add_payload(output_dir)
+
+    def call(self, graph_module):
+        graph = graph_module.graph
+        modified = False
+        for node in list(graph.nodes):
+            if node.op != "call_function" or SCALE_ADD_OPERATOR not in str(node.target):
+                continue
+            if not has_fake_tosa_impl(TOSA_SCALE_ADD_OPERATOR):
+                raise RuntimeError(
+                    f"tosa.CUSTOM fake impl is not registered for {TOSA_SCALE_ADD_OPERATOR}"
+                )
+
+            (x,) = node.args
+            fake_outputs = [torch.empty_like(x.meta["val"])]
+            with graph.inserting_before(node):
+                custom_node = graph.call_function(
+                    exir_ops.backend.tosa.CUSTOM.default,
+                    args=([x],),
+                    kwargs={
+                        "operator_name": TOSA_SCALE_ADD_OPERATOR,
+                        "domain_name": CUSTOM_DOMAIN,
+                        "implementation_attrs": self._implementation_attrs,
+                    },
+                )
+                custom_node.meta = dict(node.meta)
+                _set_fake_tensor_meta(custom_node, fake_outputs)
+
+                output = graph.call_function(
+                    operator.getitem,
+                    args=(custom_node, 0),
+                    kwargs={},
+                )
+                output.meta = dict(node.meta)
+                _set_fake_tensor_meta(output, fake_outputs[0])
+
+            node.replace_all_uses_with(output)
+            graph.erase_node(node)
+            modified = True
+
+        if modified:
+            graph.lint()
+            graph_module.recompile()
+        return PassResult(graph_module, modified)
+
+
+class EncodeRgbaBiasToTosaCustomPass(ArmPass):
+    """Rewrite the RGBA library op to `tosa.CUSTOM` with image resources."""
+
+    _passes_required_after = set()
+
+    def __init__(self, output_dir: Path) -> None:
+        self._implementation_attrs = _build_rgba_bias_payload(output_dir)
+
+    def call(self, graph_module):
+        graph = graph_module.graph
+        modified = False
+        for node in list(graph.nodes):
+            if node.op != "call_function" or RGBA_BIAS_OPERATOR not in str(node.target):
+                continue
+            if not has_fake_tosa_impl(TOSA_RGBA_BIAS_OPERATOR):
+                raise RuntimeError(
+                    f"tosa.CUSTOM fake impl is not registered for {TOSA_RGBA_BIAS_OPERATOR}"
+                )
+
+            (x,) = node.args
+            nhwc_value = exir_ops.edge.aten.permute_copy.default(
+                x.meta["val"], list(NHWC_ORDER)
+            )
+            fake_outputs = [torch.empty_like(nhwc_value)]
+            with graph.inserting_before(node):
+                nhwc_input = graph.call_function(
+                    exir_ops.edge.aten.permute_copy.default,
+                    args=(x, list(NHWC_ORDER)),
+                    kwargs={},
+                )
+                nhwc_input.meta = dict(x.meta)
+                _set_fake_tensor_meta(nhwc_input, nhwc_value)
+
+                custom_node = graph.call_function(
+                    exir_ops.backend.tosa.CUSTOM.default,
+                    args=([nhwc_input],),
+                    kwargs={
+                        "operator_name": TOSA_RGBA_BIAS_OPERATOR,
+                        "domain_name": CUSTOM_DOMAIN,
+                        "implementation_attrs": self._implementation_attrs,
+                    },
+                )
+                custom_node.meta = dict(node.meta)
+                _set_fake_tensor_meta(custom_node, fake_outputs)
+
+                nhwc_output = graph.call_function(
+                    operator.getitem,
+                    args=(custom_node, 0),
+                    kwargs={},
+                )
+                nhwc_output.meta = dict(node.meta)
+                _set_fake_tensor_meta(nhwc_output, fake_outputs[0])
+
+                output = graph.call_function(
+                    exir_ops.edge.aten.permute_copy.default,
+                    args=(nhwc_output, list(NHWC_INVERSE_ORDER)),
+                    kwargs={},
+                )
+                output.meta = dict(node.meta)
+                _set_fake_tensor_meta(
+                    output,
+                    exir_ops.edge.aten.permute_copy.default(
+                        fake_outputs[0], list(NHWC_INVERSE_ORDER)
+                    ),
+                )
+
+            node.replace_all_uses_with(output)
+            graph.erase_node(node)
+            modified = True
+
+        if modified:
+            graph.lint()
+            graph_module.recompile()
+        return PassResult(graph_module, modified)
+
+
+class ScaleAddModel(torch.nn.Module):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.ops.arm_example_custom_shader.scale_add.default(x)
+
+
+class RgbaBiasModel(torch.nn.Module):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.ops.arm_example_custom_shader.rgba_bias.default(x)
+
+
+def main() -> None:
+    ARTIFACT_DIR.mkdir(parents=True, exist_ok=True)
+
+    # Steps 1-3: register a custom op into the torch.library and enable
+    # ArmBackend handling.
+    register_example_custom_op()
+
+    # Install the rewrite passes once up front. Each lowering block below then
+    # registers the relevant library op with its own partitioner instance.
+    # `register_pass_insertions_after(...)` updates global Arm pass state, which
+    # is acceptable here because this is a standalone example script.
+    register_pass_insertions_after(
+        RewriteMatmulPass,
+        [
+            EncodeScaleAddToTosaCustomPass(ARTIFACT_DIR / "scale_add"),
+            EncodeRgbaBiasToTosaCustomPass(ARTIFACT_DIR / "rgba_bias"),
+        ],
+    )
+
+    runtime = Runtime.get()
+    if not runtime.backend_registry.is_available("VgfBackend"):
+        raise RuntimeError("VgfBackend is not available in this build.")
+
+    scale_add_model = ScaleAddModel().eval()
+    scale_add_x = torch.linspace(-2.0, 2.0, steps=16, dtype=torch.float32).reshape(4, 4)
+    scale_add_expected = scale_add_model(scale_add_x)
+
+    scale_add_exported = export(scale_add_model, (scale_add_x,))
+    scale_add_spec = VgfCompileSpec()
+    scale_add_spec.dump_intermediate_artifacts_to(str(ARTIFACT_DIR / "scale_add"))
+    scale_add_partitioner = VgfPartitioner(scale_add_spec)
+    scale_add_partitioner.register_custom_partition_op(
+        torch.ops.arm_example_custom_shader.scale_add.default
+    )
+    scale_add_edge_manager = to_edge_transform_and_lower(
+        scale_add_exported,
+        partitioner=[scale_add_partitioner],
+        compile_config=EdgeCompileConfig(_check_ir_validity=False),
+    )
+    scale_add_exec_program = scale_add_edge_manager.to_executorch()
+    scale_add_pte_path = ARTIFACT_DIR / "scale_add" / SCALE_ADD_PTE_NAME
+    save_pte_program(scale_add_exec_program, str(scale_add_pte_path))
+
+    scale_add_program = runtime.load_program(str(scale_add_pte_path))
+    scale_add_method = scale_add_program.load_method("forward")
+    assert scale_add_method is not None
+    scale_add_actual = scale_add_method.execute((scale_add_x,))[0]
+
+    if not torch.allclose(scale_add_expected, scale_add_actual, atol=1e-6, rtol=0.0):
+        diff = (scale_add_expected - scale_add_actual).abs()
+        raise AssertionError(
+            f"Scale-add runtime mismatch. max_abs_diff={diff.max().item():.6f}"
+        )
+
+    rgba_bias_model = RgbaBiasModel().eval()
+    rgba_bias_x = torch.arange(1.0, 61.0, dtype=torch.float32).reshape(1, 4, 3, 5)
+    rgba_bias_expected = rgba_bias_model(rgba_bias_x)
+
+    rgba_bias_exported = export(rgba_bias_model, (rgba_bias_x,))
+    rgba_bias_spec = VgfCompileSpec()
+    rgba_bias_spec.dump_intermediate_artifacts_to(str(ARTIFACT_DIR / "rgba_bias"))
+    rgba_bias_partitioner = VgfPartitioner(rgba_bias_spec)
+    rgba_bias_partitioner.register_custom_partition_op(
+        torch.ops.arm_example_custom_shader.rgba_bias.default
+    )
+    rgba_bias_edge_manager = to_edge_transform_and_lower(
+        rgba_bias_exported,
+        partitioner=[rgba_bias_partitioner],
+        compile_config=EdgeCompileConfig(_check_ir_validity=False),
+    )
+    rgba_bias_exec_program = rgba_bias_edge_manager.to_executorch()
+    rgba_bias_pte_path = ARTIFACT_DIR / "rgba_bias" / RGBA_BIAS_PTE_NAME
+    save_pte_program(rgba_bias_exec_program, str(rgba_bias_pte_path))
+
+    rgba_bias_program = runtime.load_program(str(rgba_bias_pte_path))
+    rgba_bias_method = rgba_bias_program.load_method("forward")
+    assert rgba_bias_method is not None
+    rgba_bias_actual = rgba_bias_method.execute((rgba_bias_x,))[0]
+
+    if not torch.allclose(rgba_bias_expected, rgba_bias_actual, atol=1e-6, rtol=0.0):
+        diff = (rgba_bias_expected - rgba_bias_actual).abs()
+        raise AssertionError(
+            f"RGBA image runtime mismatch. max_abs_diff={diff.max().item():.6f}"
+        )
+
+    print(f"Artifacts: {ARTIFACT_DIR.resolve()}")
+    print("Scale-add input:")
+    print(scale_add_x)
+    print("Scale-add expected:")
+    print(scale_add_expected)
+    print("Scale-add runtime:")
+    print(scale_add_actual)
+    print("RGBA input:")
+    print(rgba_bias_x)
+    print("RGBA expected:")
+    print(rgba_bias_expected)
+    print("RGBA runtime:")
+    print(rgba_bias_actual)
+    print("Match: True")
+
+
+# Helpers
+def _ensure_glslc() -> str:
+    glslc = shutil.which("glslc")
+    if glslc is None:
+        raise RuntimeError("`glslc` was not found on PATH.")
+    return glslc
+
+
+def _set_fake_tensor_meta(node: torch.fx.Node, value) -> None:
+    node.meta["val"] = value
+    if isinstance(value, list):
+        if value:
+            node.meta["tensor_meta"] = _extract_tensor_metadata(value[0])
+    else:
+        node.meta["tensor_meta"] = _extract_tensor_metadata(value)
+
+
+def _compile_shader(
+    output_dir: Path, shader_name: str, spirv_name: str, shader_source: str
+) -> str:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    shader_path = output_dir / shader_name
+    spirv_path = output_dir / spirv_name
+    shader_path.write_text(shader_source, encoding="utf-8")
+    result = subprocess.run(  # nosec B603 - fixed trusted local tool
+        [_ensure_glslc(), str(shader_path), "-o", str(spirv_path)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"Failed to compile {shader_path} with glslc.\n"
+            f"stderr:\n{result.stderr}\nstdout:\n{result.stdout}"
+        )
+    return base64.b64encode(spirv_path.read_bytes()).decode("ascii")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This is a substantial commit which introduces support for shaders via
tosa.custom ops in the VGF runtime. These are supported via a new
segment type and intermediate resources and required a fairly large
refactoring of the VGF runtime to accomodate per-segment state.

The changes cover:

    Various bugfixes/improvements found when adding segment support
    Add VGF custom shader runtime tests
    Add single-segment compute support in VGF runtime
    Add per-segment VGF runtime state for multi-segment support
    Support intermediate VGF resources between segments
    Add image and sampler support to VGF runtime for shaders
    Add shared alias backing for VGF resources (VGF schema changes)
    Add image/tensor alias layouts for VGF resources
    Broaden VGF aliasing barriers for graph and compute

Specifically for users:

    Add custom operator VGF tutorial
    Define incoming tensor ABI/layout rules for shaders
    Fix VGF grid_sampler NHWC lowering and tests
    Defn. channel order for custom ops and passes due to https://github.com/pytorch/executorch/commit/1bb039ff3335b834aea67b4feb5eaf256a2a641e:

Signed-off-by: Rob Elliott [Robert.Elliott@arm.com](mailto:Robert.Elliott@arm.com)
Change-Id: Ie13e5561197ac141eee9d596a74993107933f921

TESTING:

For testing, there are new tests which are currently disabled until dependencies are packaged into new releases. For now the newer functionality for shaders and samplers and resource aliases are xfailed on the current release hash of model-converter. When the hash is bumped they will run and should pass.

For provenance the additional tests with a newer model-converter and vgf-lib produce:

pytest backends/arm/test/passes/test_custom_op_rewrite.py backends/arm/test/misc/test_custom_shader_payloads.py backends/arm/test/ops/test_custom_shader_lowering.py backends/arm/test/runtime/test_vgf_tensor_buffer_runtime.py backends/arm/test/runtime/test_vgf_sampler_image_runtime.py backends/arm/test/runtime/test_vgf_aliasing_runtime.py backends/arm/test/runtime/test_vgf_multi_segment_runtime.py backends/arm/test/runtime/test_vgf_combinations_runtime.py backends/arm/test/misc/test_extract_io_params_tosa.py backends/arm/test/misc/test_custom_shader_payload.py backends/arm/test/passes/test_rewrite_grid_sampler_to_tosa_custom_pass.py backends/arm/test/ops/test_grid_sampler.py

============================================================================================= 56 passed, 1 xfailed, 1 xpassed, 263 warnings in 44.39s ==============================================================================================

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @rascani