### PR TITLE
Reduce windows CI

### DIFF
--- a/.github/workflows/cuda-windows.yml
+++ b/.github/workflows/cuda-windows.yml
@@ -23,10 +23,32 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  changed-files:
+    name: Get changed files
+    uses: ./.github/workflows/_get-changed-files.yml
+    with:
+      include-push-diff: true
+
+  run-decision:
+    name: CI run decision
+    uses: ./.github/workflows/_ci-run-decision.yml
+
   export-model-cuda-windows-artifact:
     name: export-model-cuda-windows-artifact
-    # Skip this job if the pull request is from a fork (HuggingFace secrets are not available)
-    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
+    # Skip this job if the pull request is from a fork (HuggingFace secrets are not available).
+    # Path-filtered on push: mirrors the workflow-level pull_request `paths:`
+    # filter so push commits that don't touch CUDA-relevant paths skip
+    # this job on non-sampled commits. See _ci-run-decision.yml for
+    # the sampling policy.
+    needs: [changed-files, run-decision]
+    if: |
+      (github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request') &&
+      (
+        contains(needs.changed-files.outputs.changed-files, 'backends/cuda') ||
+        contains(needs.changed-files.outputs.changed-files, 'backends/aoti') ||
+        contains(needs.changed-files.outputs.changed-files, '.github/workflows/cuda-windows.yml') ||
+        needs.run-decision.outputs.is-full-run == 'true'
+      )
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     permissions:
       id-token: write
@@ -114,7 +136,15 @@ jobs:
 
   test-model-cuda-windows-e2e:
     name: test-model-cuda-windows-e2e
-    needs: export-model-cuda-windows-artifact
+    # Same path filter as the export job above. If export was skipped
+    # (fork PR, non-sampled push, or no path match), this job is also
+    # auto-skipped via the `needs:` dependency — belt-and-suspenders.
+    needs: [changed-files, export-model-cuda-windows-artifact, run-decision]
+    if: |
+      contains(needs.changed-files.outputs.changed-files, 'backends/cuda') ||
+      contains(needs.changed-files.outputs.changed-files, 'backends/aoti') ||
+      contains(needs.changed-files.outputs.changed-files, '.github/workflows/cuda-windows.yml') ||
+      needs.run-decision.outputs.is-full-run == 'true'
     uses: pytorch/test-infra/.github/workflows/windows_job.yml@main
     strategy:
       fail-fast: false

--- a/.github/workflows/cuda-windows.yml
+++ b/.github/workflows/cuda-windows.yml
@@ -22,6 +22,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   changed-files:
     name: Get changed files
@@ -136,15 +139,20 @@ jobs:
 
   test-model-cuda-windows-e2e:
     name: test-model-cuda-windows-e2e
-    # Same path filter as the export job above. If export was skipped
-    # (fork PR, non-sampled push, or no path match), this job is also
-    # auto-skipped via the `needs:` dependency — belt-and-suspenders.
+    # Same path filter as the export job above. Also explicitly gated
+    # on the export job succeeding — when needs: jobs are *skipped*
+    # (e.g. fork PR), GitHub still evaluates this if:, so without the
+    # explicit success-check this job would run and then fail trying
+    # to download an artifact that was never produced.
     needs: [changed-files, export-model-cuda-windows-artifact, run-decision]
     if: |
-      contains(needs.changed-files.outputs.changed-files, 'backends/cuda') ||
-      contains(needs.changed-files.outputs.changed-files, 'backends/aoti') ||
-      contains(needs.changed-files.outputs.changed-files, '.github/workflows/cuda-windows.yml') ||
-      needs.run-decision.outputs.is-full-run == 'true'
+      needs.export-model-cuda-windows-artifact.result == 'success' &&
+      (
+        contains(needs.changed-files.outputs.changed-files, 'backends/cuda') ||
+        contains(needs.changed-files.outputs.changed-files, 'backends/aoti') ||
+        contains(needs.changed-files.outputs.changed-files, '.github/workflows/cuda-windows.yml') ||
+        needs.run-decision.outputs.is-full-run == 'true'
+      )
     uses: pytorch/test-infra/.github/workflows/windows_job.yml@main
     strategy:
       fail-fast: false

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -1037,6 +1037,10 @@ jobs:
       docker-image: ci-image:executorch-ubuntu-22.04-clang12
 
   test-models-windows:
+    needs: run-decision
+    if: |
+      github.event_name == 'pull_request' ||
+      needs.run-decision.outputs.is-full-run == 'true'
     uses: pytorch/test-infra/.github/workflows/windows_job.yml@main
     strategy:
       fail-fast: false

--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -18,8 +18,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changed-files:
+    name: Get changed files
+    uses: ./.github/workflows/_get-changed-files.yml
+    with:
+      include-push-diff: true
+
+  run-decision:
+    name: CI run decision
+    uses: ./.github/workflows/_ci-run-decision.yml
+
   build-windows-msvc:
     name: build-windows-msvc
+    needs: [changed-files, run-decision]
+    # Path-filtered: mirrors the workflow-level pull_request `paths:`
+    # filter above, so push commits that don't touch these paths skip
+    # this job on non-sampled commits. See _ci-run-decision.yml for
+    # the sampling policy.
+    if: |
+      contains(needs.changed-files.outputs.changed-files, '.ci/docker/ci_commit_pins/pytorch.txt') ||
+      contains(needs.changed-files.outputs.changed-files, '.ci/scripts/') ||
+      contains(needs.changed-files.outputs.changed-files, '.github/workflows/windows-msvc.yml') ||
+      needs.run-decision.outputs.is-full-run == 'true'
     uses: pytorch/test-infra/.github/workflows/windows_job.yml@main
     with:
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -17,6 +17,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   changed-files:
     name: Get changed files


### PR DESCRIPTION
Reduces windows CI by enabling path filters on PRs and sampling on main push.

See related https://github.com/pytorch/executorch/pull/19919