### PR TITLE
Pack the native log tail into ExecutorchRuntimeException's message. (#19947)

### DIFF
--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/ExecutorchRuntimeException.kt
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/ExecutorchRuntimeException.kt
@@ -84,7 +84,7 @@ constructor(
           }
         }
       } catch (e: Exception) {
-        sb.append("Failed to retrieve detailed logs: ").append(e.message)
+        return ""
       }
       return sb.toString()
     }
@@ -124,10 +124,28 @@ constructor(
 
     @DoNotStrip
     @JvmStatic
-    fun makeExecutorchException(errorCode: Int, details: String?): RuntimeException =
-        when (errorCode) {
-          INVALID_ARGUMENT -> ExecutorchInvalidArgumentException(details)
-          else -> ExecutorchRuntimeException(errorCode, details)
-        }
+    fun makeExecutorchException(errorCode: Int, details: String?): RuntimeException {
+      val nativeTail =
+          try {
+            ErrorHelper.getDetailedErrorLogs()
+                .removePrefix("\nDetailed logs:\n")
+                .replace(Regex("\\s+"), " ")
+                .trim()
+          } catch (t: Throwable) {
+            ""
+          }
+      val enrichedDetails =
+          if (nativeTail.isNotBlank()) {
+            "${details ?: "No details provided"} | nativeLog=${nativeTail.takeLast(NATIVE_LOG_TAIL_MAX_CHARS)}"
+          } else {
+            details
+          }
+      return when (errorCode) {
+        INVALID_ARGUMENT -> ExecutorchInvalidArgumentException(enrichedDetails)
+        else -> ExecutorchRuntimeException(errorCode, enrichedDetails)
+      }
+    }
+
+    private const val NATIVE_LOG_TAIL_MAX_CHARS = 2048
   }
 }


### PR DESCRIPTION
Summary:

The fix changes the native log truncation from keeping the prefix (first 2048 characters) to keeping the suffix/tail (last 2048 characters) of the log string. This ensures that the most relevant recent log lines are preserved for diagnosing failures, rather than the older log entries at the beginning. using takeLast ensures we keep the most recent log lines which are most relevant for diagnosing failures

Reviewed By: SS-JIA

Differential Revision: D107196396


