### PR TITLE
Relax CUDA buffer metadata test expectations

### DIFF
--- a/extension/module/test/module_device_memory_test.cpp
+++ b/extension/module/test/module_device_memory_test.cpp
@@ -146,17 +146,19 @@ TEST_F(ModuleDeviceMemoryTest, DeviceModelMethodMetaReportsCudaBuffer) {
   auto meta = module.method_meta("forward");
   ASSERT_TRUE(meta.ok());
 
-  // ModuleAddWithDevice has 1 planned buffer (48 bytes) on CUDA.
-  ASSERT_EQ(meta->num_memory_planned_buffers(), 1);
+  const size_t num_buffers = meta->num_memory_planned_buffers();
+  ASSERT_GT(num_buffers, 0);
 
-  auto size = meta->memory_planned_buffer_size(0);
-  ASSERT_TRUE(size.ok());
-  EXPECT_EQ(size.get(), 48);
-
-  auto device = meta->memory_planned_buffer_device(0);
-  ASSERT_TRUE(device.ok());
-  EXPECT_EQ(device->type(), DeviceType::CUDA);
-  EXPECT_EQ(device->index(), 0);
+  bool found_cuda_buffer = false;
+  for (size_t i = 0; i < num_buffers; ++i) {
+    auto device = meta->memory_planned_buffer_device(i);
+    ASSERT_TRUE(device.ok());
+    if (device->type() == DeviceType::CUDA) {
+      EXPECT_EQ(device->index(), 0);
+      found_cuda_buffer = true;
+    }
+  }
+  EXPECT_TRUE(found_cuda_buffer);
 }
 
 TEST_F(ModuleDeviceMemoryTest, DeviceModelWithSharedArenasReturnsNotSupported) {

--- a/runtime/executor/test/method_meta_test.cpp
+++ b/runtime/executor/test/method_meta_test.cpp
@@ -248,21 +248,24 @@ TEST_F(MethodMetaTest, MethodMetaBufferDeviceReturnsCudaForDeviceBuffer) {
   ASSERT_EQ(method_meta.error(), Error::Ok);
 
   // ModuleAddWithDevice exports with enable_non_cpu_memory_planning=True.
-  // The model delegates add(a,b) to CUDA, producing:
-  //   non_const_buffer_sizes: [0, 48]  (index 0 reserved)
-  //   non_const_buffer_device: [{buffer_idx=1, device_type=CUDA,
-  //   device_index=0}]
-  // So there is exactly 1 planned buffer (user-facing index 0), on CUDA.
-  ASSERT_EQ(method_meta->num_memory_planned_buffers(), 1);
+  // The model delegates add(a,b) to CUDA, so at least one planned buffer should
+  // be backed by CUDA memory. Explicit boundary copies may add CPU buffers too.
+  size_t num_buffers = method_meta->num_memory_planned_buffers();
+  ASSERT_GT(num_buffers, 0);
 
-  // Buffer 0 should be CUDA device.
-  auto device = method_meta->memory_planned_buffer_device(0);
-  ASSERT_TRUE(device.ok());
-  EXPECT_EQ(device->type(), executorch::runtime::etensor::DeviceType::CUDA);
-  EXPECT_EQ(device->index(), 0);
+  bool found_cuda_buffer = false;
+  for (size_t i = 0; i < num_buffers; ++i) {
+    auto device = method_meta->memory_planned_buffer_device(i);
+    ASSERT_TRUE(device.ok());
+    if (device->type() == executorch::runtime::etensor::DeviceType::CUDA) {
+      EXPECT_EQ(device->index(), 0);
+      found_cuda_buffer = true;
+    }
+  }
+  EXPECT_TRUE(found_cuda_buffer);
 
   // Out of range should return error.
   EXPECT_EQ(
-      method_meta->memory_planned_buffer_device(1).error(),
+      method_meta->memory_planned_buffer_device(num_buffers).error(),
       Error::InvalidArgument);
 }

--- a/runtime/executor/test/tensor_parser_device_test.cpp
+++ b/runtime/executor/test/tensor_parser_device_test.cpp
@@ -198,8 +198,8 @@ TEST_F(TensorParserDeviceTest, CUDADeviceParsedFromPteFile) {
 
   EXPECT_EQ(cuda_tensor_count, 3)
       << "Expected 3 CUDA tensors (2 delegate inputs + 1 delegate output)";
-  EXPECT_EQ(cpu_tensor_count, 0)
-      << "Expected 0 CPU tensors (all annotated as CUDA)";
+  EXPECT_EQ(cpu_tensor_count, 3)
+      << "Expected 3 CPU tensors (method inputs and outputs)";
 }
 
 TEST_F(TensorParserDeviceTest, NonDelegatedTensorsDefaultToCPU) {
@@ -256,11 +256,8 @@ TEST_F(TensorParserDeviceTest, CudaTensorDataPtrPointsToDeviceMemory) {
   Result<MethodMeta> method_meta = program->method_meta("forward");
   ASSERT_EQ(method_meta.error(), Error::Ok);
 
-  // ModuleAddWithDevice has:
-  //   non_const_buffer_sizes: [0, 48]  (index 0 reserved, buffer 0 = 48 bytes)
-  //   non_const_buffer_device: [{buffer_idx=1, device_type=CUDA}]
   const size_t num_buffers = method_meta->num_memory_planned_buffers();
-  ASSERT_EQ(num_buffers, 1);
+  ASSERT_GT(num_buffers, 0);
 
   // Set up device-aware planned memory.
   std::vector<Span<uint8_t>> planned_spans;


### PR DESCRIPTION
Summary: D99636777 adds explicit H2D/D2H boundary copy nodes, which can add CPU tensors and CPU planned buffers while preserving CUDA tensors at delegate boundaries. Update MethodMeta, Module device-memory, and TensorParser device tests to assert the relevant CUDA buffer/tensor behavior without assuming all tensors are CUDA, exactly one planned buffer, or a fixed device-buffer index.

Differential Revision: D107301389


