### PR TITLE
Use fbcode_macros java_library and add oncall in android BUCK

### DIFF
--- a/shim_et/xplat/caffe2/android/BUCK
+++ b/shim_et/xplat/caffe2/android/BUCK
@@ -8,7 +8,8 @@
 # that is not applicable to ExecuTorch. This empty target allows the build
 # to succeed without running PyTorch-specific tests against ExecuTorch.
 
-load("@prelude//java:java_library.bzl", "java_library")
+load("@fbcode_macros//build_defs:java_library.bzl", "java_library")
+oncall("executorch")
 
 java_library(
     name = "test_host",


### PR DESCRIPTION
Switch the test_host target to the fbcode_macros java_library macro and declare the executorch oncall so the target conforms to fbcode BUCK conventions.
