### PR TITLE
Propagate install_executorch failure status

### DIFF
--- a/install_executorch.sh
+++ b/install_executorch.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
 # Copyright 2026 Arm Limited and/or its affiliates.


### PR DESCRIPTION
The wrapper ran install_executorch.py and then configured git hooks. If the Python installer failed but git config succeeded, the final command overwrote the nonzero status and CI continued into pytest with the stale editable install left in env/.

Enable shell errexit so install_executorch.sh stops as soon as the Python installer fails. Successful installs still continue to configure git hooks, and hook setup failures still surface as wrapper failures.

Signed-off-by: Per Held <per.held@arm.com>

Change-Id: I8500ae776e70f234a24f7ee5d213b6366f11de48



cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani