### PR TITLE
[WIP - DO NOT MERGE] Arm backend: Improve permute fusing

### DIFF
--- a/backends/arm/_passes/__init__.py
+++ b/backends/arm/_passes/__init__.py
@@ -9,6 +9,7 @@ from .arm_pass import ArmOpTargetedPass, ArmPass  # noqa  # usort: skip
 from .accumulate_index_put_pass import AccumulateIndexPutPass  # noqa
 from .broadcast_args_pass import BroadcastArgsPass  # noqa
 from .canonicalize_gather_pass import CanonicalizeGatherPass  # noqa
+from .canonicalize_view_copy_permute_pass import CanonicalizeViewCopyPermutePass  # noqa
 from .cast_int64_pass import CastInt64BuffersToInt32Pass  # noqa
 from .cast_to_int32_pass import CastToInt32Pass  # noqa
 from .constant_folding_pass import ConstantFoldingPass  # noqa
@@ -114,6 +115,9 @@ from .fuse_constant_ops_pass import (  # noqa
 )
 from .fuse_duplicate_users_pass import FuseDuplicateUsersPass  # noqa
 from .fuse_equal_placeholders_pass import FuseEqualPlaceholdersPass  # noqa
+from .fuse_identical_input_transforms_pass import (  # noqa
+    FuseIdenticalInputTransformsPass,
+)
 from .fuse_quantized_activation_pass import FuseQuantizedActivationPass  # noqa
 from .fuse_view_copy_transform_pass import FuseViewCopyTransformPass  # noqa
 from .insert_const_shapes import InsertConstShapesPass  # noqa
@@ -140,6 +144,10 @@ from .normalize_index_put_none_indices_pass import (  # noqa
 )
 from .normalize_while_initial_args_pass import NormalizeWhileInitialArgsPass  # noqa
 from .promote_bool_operands_pass import PromoteBoolOperandsPass  # noqa
+from .propagate_permutes_views_pass import (  # noqa
+    PropagatePermuteViewsDownPass,
+    PropagatePermuteViewsUpPass,
+)
 from .remove_getitem_pass import RemoveGetItemPass  # noqa
 from .remove_graph_asserts_pass import RemoveGraphAssertsPass  # noqa
 from .remove_noop_pass import RemoveNoopPass  # noqa

--- a/backends/arm/_passes/arm_pass_manager.py
+++ b/backends/arm/_passes/arm_pass_manager.py
@@ -28,7 +28,6 @@ from executorch.backends.arm._passes import (
     ConvertInt64OutputOpsToInt32Pass,
     ConvertMinMaxPass,
     ConvertMmToBmmPass,
-    ConvertPermuteSingletonToViewPass,
     ConvertSplitToSlicePass,
     ConvertSqueezesToViewPass,
     ConvertToClampPass,
@@ -124,6 +123,8 @@ from executorch.backends.arm._passes import (
     NormalizeIndexPutNoneIndicesPass,
     NormalizeWhileInitialArgsPass,
     PromoteBoolOperandsPass,
+    PropagatePermuteViewsDownPass,
+    PropagatePermuteViewsUpPass,
     QuantizeClampArgumentsPass,
     RemoveGetItemPass,
     RemoveGraphAssertsPass,
@@ -135,7 +136,6 @@ from executorch.backends.arm._passes import (
     RewriteBoolBitwiseToLogicalPass,
     RewriteBoolToFp32CastViaInt8Pass,
     RewriteConvPass,
-    RewriteHighRankSingletonPermutePass,
     RewriteIndexPutPass,
     RewriteInplaceArithmeticPass,
     RewriteLeLtToGeGtPass,
@@ -156,12 +156,6 @@ from executorch.backends.arm.tosa.specification import (
     tosa_spec_in_set,
     TosaLoweringContext,
     TosaSpecification,
-)
-from executorch.backends.transforms.fuse_cascaded_transpose_or_permute_ops import (
-    FuseCascadedTransposeOrPermuteOps,
-)
-from executorch.backends.transforms.postpone_permute_below_squeeze_view import (
-    PostponePermuteOpBelowSqueezeOrUnsqueezeLikeView,
 )
 
 from executorch.exir import ExportedProgram
@@ -527,11 +521,9 @@ class ArmPassManager(PassManager):
                 RewriteMatmulPass(),
                 RewritePadPass(),
                 FuseViewCopyTransformPass(),
+                PropagatePermuteViewsDownPass(exported_program),
+                PropagatePermuteViewsUpPass(exported_program),
                 RemovePermutesAroundElementwiseTosaOps(),
-                PostponePermuteOpBelowSqueezeOrUnsqueezeLikeView(),
-                FuseCascadedTransposeOrPermuteOps(),
-                ConvertPermuteSingletonToViewPass(),
-                RewriteHighRankSingletonPermutePass(),
                 DecomposePermuteForU55Pass(),
                 RewriteSlicePass(),
                 InsertConstShapesPass(),

--- a/backends/arm/_passes/canonicalize_view_copy_permute_pass.py
+++ b/backends/arm/_passes/canonicalize_view_copy_permute_pass.py
@@ -1,0 +1,357 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from typing import cast, Sequence, Set, Type
+
+import torch
+from executorch.backends.arm._passes.arm_pass import ArmPass
+from executorch.backends.arm._passes.view_map import ViewMap
+from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import ExportPass
+
+from torch.fx import GraphModule, Node
+from torch.fx.node import Target
+from torch.fx.passes.infra.pass_base import PassResult
+
+_Dim = int | torch.SymInt
+
+
+class CanonicalizeViewCopyPermutePass(ArmPass):
+    """Canonicalize view/permute chains.
+
+    The pass repeatedly fuses adjacent compatible ops and swaps adjacent
+    view/permute pairs when the swap exposes more fusing.
+
+    """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
+
+    _VIEW_TARGET = exir_ops.edge.aten.view_copy.default
+    _PERMUTE_TARGET = exir_ops.edge.aten.permute_copy.default
+    _TARGETS = {_VIEW_TARGET, _PERMUTE_TARGET}
+
+    def call(self, graph_module: GraphModule) -> PassResult:
+        modified = False
+
+        for chain in self._collect_chains(graph_module):
+            updated_chain = chain
+
+            while True:
+                updated_chain, fused = self._fuse_sequential_ops(
+                    graph_module, updated_chain
+                )
+                modified = modified or fused
+
+                if len(updated_chain) < 2:
+                    break
+
+                if len(updated_chain) > 2:
+                    op1: Node = updated_chain[0]
+                    op2: Node | None = updated_chain[1]
+                    swapped_args = None
+                    i = 2
+                    while swapped_args is None and op2 is not None:
+                        swapped_args = self._maybe_swap_args(op1, op2)
+                        if swapped_args is None:
+                            op1 = op2
+                            op2 = updated_chain[i] if i < len(updated_chain) else None
+                            i += 1
+
+                    if swapped_args is not None:
+                        input_node = op1.args[0]
+                        assert isinstance(input_node, Node)
+                        assert op2 is not None
+                        op1_target = op1.target
+                        op2_target = op2.target
+                        self._set_node_op(op1, op2_target, input_node, swapped_args[0])
+                        self._set_node_op(op2, op1_target, op1, swapped_args[1])
+                        modified = True
+                    else:
+                        break
+                else:
+                    break
+
+        if modified:
+            graph_module.graph.eliminate_dead_code()
+            graph_module.recompile()
+            graph_module = super().call(graph_module).graph_module
+
+        return PassResult(graph_module, modified)
+
+    def _collect_chains(self, graph_module: GraphModule) -> list[list[Node]]:
+        """Returns a list of linear chains of view/permutes in the graph."""
+        chains: list[list[Node]] = []
+
+        view_permute_nodes = [
+            node for node in graph_module.graph.nodes if node.target in self._TARGETS
+        ]
+
+        while view_permute_nodes:
+            node = view_permute_nodes.pop(0)
+            chain = [node]
+            current = node
+
+            while len(current.users) == 1:
+                user = next(iter(current.users))
+                if user.target not in self._TARGETS:
+                    break
+                view_permute_nodes.remove(user)
+                chain.append(user)
+                current = user
+
+            chains.append(chain)
+
+        return chains
+
+    def _fuse_sequential_ops(
+        self, graph_module: GraphModule, chain: list[Node]
+    ) -> tuple[list[Node], bool]:
+        """Loop over chain and fuse adjacent ops and remove no-op views/permutes
+        until no more fusions are possible.
+
+        Returns the updated chain and whether any changes were made.
+
+        """
+
+        updated_chain = list(chain)
+        any_changed = False
+
+        while True:
+            changed = False
+            index = 0
+
+            while index < len(updated_chain):
+                node = updated_chain[index]
+                input_node = cast(Node, node.args[0])
+
+                if node.target == self._VIEW_TARGET and ViewMap.shapes_equal(
+                    self._shape(input_node), self._shape(node)
+                ):
+                    # Identity view
+                    self._remove_node(
+                        graph_module, updated_chain, index, replacement=input_node
+                    )
+                    changed = True
+                    any_changed = True
+                    continue
+
+                if node.target == self._PERMUTE_TARGET:
+
+                    dims = self._permute_dims(node)
+
+                    # Normalize dims
+                    if any(
+                        dim < 0 or dim >= len(self._shape(input_node)) for dim in dims
+                    ):
+                        dims = [
+                            ViewMap._normalize_dim(dim, len(self._shape(input_node)))
+                            for dim in dims
+                        ]
+                        self._set_node_op(node, self._PERMUTE_TARGET, input_node, dims)
+                        changed = True
+                        any_changed = True
+                        continue
+
+                    # Identity permute
+                    if dims == list(range(len(dims))):
+                        self._remove_node(
+                            graph_module, updated_chain, index, replacement=input_node
+                        )
+                        changed = True
+                        any_changed = True
+                        continue
+
+                    # Permute w/o data movement e.g. [1, 2] -> [2, 1] decomposes to view
+                    if self._is_singleton_permutation(self._shape(input_node), dims):
+                        self._set_node_op(
+                            node, self._VIEW_TARGET, input_node, self._shape(node)
+                        )
+                        changed = True
+                        any_changed = True
+                        continue
+
+                if index + 1 < len(updated_chain):
+                    next_node = updated_chain[index + 1]
+                    if (
+                        node.target == self._VIEW_TARGET
+                        and next_node.target == self._VIEW_TARGET
+                    ):
+                        # Fuse conscutive views
+                        self._set_node_op(
+                            node, self._VIEW_TARGET, input_node, self._shape(next_node)
+                        )
+                        self._remove_node(
+                            graph_module, updated_chain, index + 1, replacement=node
+                        )
+                        changed = True
+                        any_changed = True
+                        continue
+
+                    if (
+                        node.target == self._PERMUTE_TARGET
+                        and next_node.target == self._PERMUTE_TARGET
+                    ):
+                        # Fuse consecutive permutes
+                        dims = self._permute_dims(node)
+                        next_dims = self._permute_dims(next_node)
+                        self._set_node_op(
+                            node,
+                            self._PERMUTE_TARGET,
+                            input_node,
+                            [dims[dim] for dim in next_dims],
+                        )
+                        self._remove_node(
+                            graph_module, updated_chain, index + 1, replacement=node
+                        )
+                        changed = True
+                        any_changed = True
+                        continue
+
+                index += 1
+
+            if not changed:
+                return updated_chain, any_changed
+
+    def _maybe_swap_args(
+        self, op1: Node, op2: Node
+    ) -> tuple[Sequence[_Dim], Sequence[_Dim]] | None:
+        """Returns updated arguments for a valid op swap, or None if the ops
+        cannot be swapped.
+        """
+        input_node = op1.args[0]
+        assert isinstance(input_node, Node)
+        input_val = input_node.meta["val"]
+
+        if op1.target == self._PERMUTE_TARGET and op2.target == self._VIEW_TARGET:
+            return self._permute_view_swap(input_val, op1, op2)
+
+        if op1.target == self._VIEW_TARGET and op2.target == self._PERMUTE_TARGET:
+            return self._view_permute_swap(op1, op2)
+
+        return None
+
+    def _permute_view_swap(
+        self, input_val: torch.Tensor, permute_node: Node, view_node: Node
+    ) -> tuple[list[_Dim], list[int]] | None:
+        x_shape = cast(list[_Dim], list(input_val.shape))
+        permute_dims = ViewMap._normalize_dims(
+            self._permute_dims(permute_node), len(x_shape)
+        )
+
+        view_map = ViewMap(view_node)
+        if not view_map.is_valid_map:
+            return None
+
+        permuted_axis = self._inverse_permutation(permute_dims)
+        target_axis_order = view_map.map_source_to_target(
+            permuted_axis, include_unbacked_singletons=True
+        )
+
+        if not view_map.validate_mapped_permute(permuted_axis, target_axis_order):
+            return None
+
+        view_shape_before_permute = [
+            view_map.target_shape[target_axis] for target_axis in target_axis_order
+        ]
+
+        return (
+            view_shape_before_permute,
+            self._inverse_permutation(target_axis_order),
+        )
+
+    def _view_permute_swap(
+        self, view_node: Node, permute_node: Node
+    ) -> tuple[list[int], list[_Dim]] | None:
+        view_map = ViewMap(view_node)
+        if not view_map.is_valid_map:
+            return None
+
+        permute_dims = self._permute_dims(permute_node)
+        mapped_dims = view_map.map_target_to_source(
+            permute_dims, include_unbacked_singletons=True
+        )
+
+        if not view_map.validate_mapped_permute(mapped_dims, permute_dims):
+            return None
+
+        return mapped_dims, self._shape(permute_node)
+
+    @staticmethod
+    def _inverse_permutation(permutation: Sequence[int]) -> list[int]:
+        inverse = [0] * len(permutation)
+        for index, dim in enumerate(permutation):
+            inverse[dim] = index
+        return inverse
+
+    @classmethod
+    def _is_singleton_permutation(
+        cls, shape: Sequence[_Dim], permutation: Sequence[int]
+    ) -> bool:
+        rank = len(shape)
+        normalized_perm = [ViewMap._normalize_dim(dim, rank) for dim in permutation]
+        if not ViewMap._is_permutation(normalized_perm, rank):
+            return False
+
+        non_singleton_axes = [
+            axis for axis, dim in enumerate(shape) if not ViewMap._dim_equals(dim, 1)
+        ]
+        permuted_non_singleton_axes = [
+            axis for axis in normalized_perm if not ViewMap._dim_equals(shape[axis], 1)
+        ]
+        return permuted_non_singleton_axes == non_singleton_axes
+
+    def _remove_node(
+        self,
+        graph_module: GraphModule,
+        chain: list[Node],
+        index: int,
+        replacement: Node,
+    ) -> None:
+        node = chain[index]
+        assert node is not replacement
+
+        node.replace_all_uses_with(replacement)
+        graph_module.graph.erase_node(node)
+        del chain[index]
+
+    def _set_node_op(
+        self,
+        node: Node,
+        target: Target,
+        input_node: Node,
+        arg: Sequence[_Dim],
+    ) -> None:
+        node.target = target
+        node.args = (input_node, list(arg))
+        self._refresh_meta(node)
+
+    def _permute_dims(self, node: Node) -> list[int]:
+        assert node.target == self._PERMUTE_TARGET, "Expected permute node"
+        return list(cast(Sequence[int], node.args[1]))
+
+    @classmethod
+    def _refresh_meta(cls, node: Node) -> None:
+        input_node = node.args[0]
+        assert isinstance(input_node, Node)
+        input_val = input_node.meta.get("val")
+        if input_val is None:
+            return
+
+        if node.target == cls._VIEW_TARGET:
+            output_shape = cast(list[_Dim], node.args[1])
+        elif node.target == cls._PERMUTE_TARGET:
+            output_shape = [
+                input_val.shape[dim] for dim in cast(list[int], node.args[1])
+            ]
+        else:
+            return
+
+        node.meta["val"] = input_val.new_empty(output_shape)
+
+    @staticmethod
+    def _shape(node: Node) -> list[_Dim]:
+        return cast(list[_Dim], list(node.meta["val"].shape))

--- a/backends/arm/_passes/fuse_duplicate_users_pass.py
+++ b/backends/arm/_passes/fuse_duplicate_users_pass.py
@@ -34,6 +34,7 @@ class FuseDuplicateUsersPass(ArmPass):
         graph = graph_module.graph
         modified = False
 
+        node_order = {node: index for index, node in enumerate(graph.nodes)}
         producers: Deque[Node] = deque(node for node in graph.nodes)
 
         while producers:
@@ -48,7 +49,7 @@ class FuseDuplicateUsersPass(ArmPass):
             if len(user_nodes) < 2:
                 continue
 
-            candidate_groups = self._get_candidate_groups(user_nodes)
+            candidate_groups = self._get_candidate_groups(node_order, user_nodes)
 
             signature_to_user: Dict[Tuple[Hashable, ...], Node] = {}
             for group in candidate_groups:
@@ -84,7 +85,7 @@ class FuseDuplicateUsersPass(ArmPass):
 
         return PassResult(graph_module, modified)
 
-    def _get_candidate_groups(self, user_nodes):
+    def _get_candidate_groups(self, node_order, user_nodes):
         users_by_target: Dict[Tuple[str, Hashable], List[Node]] = {}
         for user in user_nodes:
             if user.graph is None:
@@ -98,9 +99,12 @@ class FuseDuplicateUsersPass(ArmPass):
             target_signature = (user.op, target_key)
             users_by_target.setdefault(target_signature, []).append(user)
 
-        candidate_groups = [
-            group for group in users_by_target.values() if len(group) > 1
-        ]
+        candidate_groups = []
+        for group in users_by_target.values():
+            if len(group) > 1:
+                candidate_groups.append(
+                    sorted(group, key=lambda node: node_order[node])
+                )
 
         return candidate_groups
 

--- a/backends/arm/_passes/fuse_identical_input_transforms_pass.py
+++ b/backends/arm/_passes/fuse_identical_input_transforms_pass.py
@@ -1,0 +1,278 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+import copy
+from typing import Any, cast, Iterable, Set, Type
+
+import torch
+
+from executorch.backends.arm._passes.arm_pass import ArmPass
+from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import ExportPass, PassResult
+from torch.fx import GraphModule, Node
+
+
+class FuseIdenticalInputTransformsPass(ArmPass):
+    """Sink identical input transforms through pointwise ops.
+
+    Example:
+
+        add(permute(x), permute(y))
+
+    becomes:
+
+        permute(add(x, y))
+
+    The pass is intentionally limited to pointwise/elementwise nodes.
+
+    """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
+
+    _VIEW_TARGET = exir_ops.edge.aten.view_copy.default
+    _VIEW_DEFAULT_TARGET = exir_ops.edge.aten.view.default
+    _PERMUTE_TARGET = exir_ops.edge.aten.permute_copy.default
+    _TARGETS = {_VIEW_TARGET, _VIEW_DEFAULT_TARGET, _PERMUTE_TARGET}
+
+    _ELEMENTWISE_TARGETS = {
+        exir_ops.edge.aten.add.Tensor,
+        exir_ops.edge.aten.mul.Tensor,
+        exir_ops.edge.aten.sub.Tensor,
+        exir_ops.edge.aten.hardtanh.default,
+        exir_ops.edge.aten.clamp.default,
+    }
+
+    def call(self, graph_module: GraphModule) -> PassResult:
+        graph = graph_module.graph
+        modified = False
+
+        while True:
+            iteration_modified = False
+            for node in list(graph.nodes):
+                while self._sink_identical_input_transforms(node):
+                    iteration_modified = True
+
+            if not iteration_modified:
+                break
+            modified = True
+
+        if modified:
+            graph.eliminate_dead_code()
+            graph.lint()
+            graph_module.recompile()
+            graph_module = super().call(graph_module).graph_module
+
+        return PassResult(graph_module, modified)
+
+    def _sink_identical_input_transforms(self, node: Node) -> bool:
+        if not self._is_elementwise_node(node):
+            return False
+
+        input_transforms = self._identical_input_transforms(node)
+        if input_transforms is None:
+            return False
+
+        producers_and_shapes = self._producer_nodes_and_shapes(input_transforms)
+        if producers_and_shapes is None:
+            return False
+        producers, producer_shapes = producers_and_shapes
+
+        transform = input_transforms[0]
+        transform_args = self._transform_args_for_node(transform, node)
+        if transform_args is None:
+            return False
+
+        node_val = node.meta.get("val")
+        if not isinstance(node_val, torch.Tensor):
+            return False
+
+        for input_transform, producer in zip(input_transforms, producers):
+            node.replace_input_with(input_transform, producer)
+        for input_transform in input_transforms:
+            if len(input_transform.users) == 0:
+                node.graph.erase_node(input_transform)
+
+        node.meta = copy.copy(node.meta)
+        node.meta["val"] = node_val.new_empty(producer_shapes[0])
+
+        with node.graph.inserting_after(node):
+            new_node = node.graph.call_function(
+                cast(Any, transform.target),
+                args=transform_args,
+                kwargs=dict(transform.kwargs),
+            )
+        new_node.meta = self._meta_from_input(new_node, transform)
+
+        for user in list(node.users):
+            if user is not new_node:
+                user.replace_input_with(node, new_node)
+
+        return True
+
+    def _identical_input_transforms(self, node: Node) -> list[Node] | None:
+        input_transforms = list(node.all_input_nodes)
+        if len(input_transforms) < 2:
+            return None
+        if any(
+            not self._is_transform_node(input_node) for input_node in input_transforms
+        ):
+            return None
+        if len(set(input_transforms)) != len(input_transforms):
+            return None
+
+        transform = input_transforms[0]
+        if any(
+            not self._is_equivalent_transform(input_node, transform)
+            for input_node in input_transforms
+        ):
+            return None
+        if any(
+            any(user is not node for user in input_transform.users)
+            for input_transform in input_transforms
+        ):
+            return None
+        return input_transforms
+
+    def _producer_nodes_and_shapes(
+        self, input_transforms: list[Node]
+    ) -> tuple[list[Node], list[tuple[int, ...]]] | None:
+        producers = []
+        producer_shapes = []
+        for input_transform in input_transforms:
+            producer = self._node_input(input_transform)
+            producer_val = producer.meta.get("val") if producer is not None else None
+            if producer is None or not isinstance(producer_val, torch.Tensor):
+                return None
+            producers.append(producer)
+            producer_shapes.append(tuple(producer_val.shape))
+
+        if any(shape != producer_shapes[0] for shape in producer_shapes):
+            return None
+        return producers, producer_shapes
+
+    def _is_elementwise_node(self, node: Node) -> bool:
+        if node.op != "call_function":
+            return False
+        if node.target in self._ELEMENTWISE_TARGETS:
+            return True
+
+        op = getattr(node.target, "_op", None)
+        return op is not None and hasattr(op, "tags") and torch.Tag.pointwise in op.tags
+
+    def _is_transform_node(self, node: Node) -> bool:
+        return node.op == "call_function" and node.target in self._TARGETS
+
+    def _node_input(self, node: Node) -> Node | None:
+        input_node = node.args[0] if len(node.args) > 0 else node.kwargs.get("input")
+        return input_node if isinstance(input_node, Node) else None
+
+    def _is_equivalent_transform(self, node: Node, transform: Node) -> bool:
+        if not self._is_transform_node(node) or node.target != transform.target:
+            return False
+        if not self._has_matching_transform_ranks(node, transform):
+            return False
+        return self._transform_signature(node) == self._transform_signature(transform)
+
+    def _has_matching_transform_ranks(self, node: Node, transform: Node) -> bool:
+        node_input = self._node_input(node)
+        transform_input = self._node_input(transform)
+        node_input_val = node_input.meta.get("val") if node_input is not None else None
+        transform_input_val = (
+            transform_input.meta.get("val") if transform_input is not None else None
+        )
+        node_output_val = node.meta.get("val")
+        transform_output_val = transform.meta.get("val")
+        if not (
+            isinstance(node_input_val, torch.Tensor)
+            and isinstance(transform_input_val, torch.Tensor)
+            and isinstance(node_output_val, torch.Tensor)
+            and isinstance(transform_output_val, torch.Tensor)
+        ):
+            return False
+        return len(node_input_val.shape) == len(transform_input_val.shape) and len(
+            node_output_val.shape
+        ) == len(transform_output_val.shape)
+
+    def _transform_signature(self, node: Node) -> tuple[tuple[Any, ...], Any]:
+        return (tuple(node.args[1:]), tuple(sorted(node.kwargs.items())))
+
+    def _transform_args_for_node(
+        self, transform: Node, node: Node
+    ) -> tuple[Any, ...] | None:
+        if transform.target == self._PERMUTE_TARGET:
+            permutation = self._get_permutation(transform)
+            node_val = node.meta.get("val")
+            if (
+                permutation is None
+                or not isinstance(node_val, torch.Tensor)
+                or len(node_val.shape) != len(permutation)
+            ):
+                return None
+            return (node, *transform.args[1:])
+
+        if transform.target in (self._VIEW_TARGET, self._VIEW_DEFAULT_TARGET):
+            node_val = node.meta.get("val")
+            transform_val = transform.meta.get("val")
+            if not (
+                isinstance(node_val, torch.Tensor)
+                and isinstance(transform_val, torch.Tensor)
+                and self._same_numel(node_val.shape, transform_val.shape)
+            ):
+                return None
+            return (node, *transform.args[1:])
+
+        return None
+
+    def _meta_from_input(self, new_node: Node, original_node: Node) -> dict:
+        node_meta = copy.copy(original_node.meta)
+        node_val = node_meta.get("val")
+        input_node = self._node_input(new_node)
+        input_val = input_node.meta.get("val") if input_node is not None else None
+        if isinstance(node_val, torch.Tensor) and isinstance(input_val, torch.Tensor):
+            if new_node.target == self._PERMUTE_TARGET:
+                permutation = self._get_permutation(new_node)
+                if permutation is not None:
+                    try:
+                        node_meta["val"] = node_val.new_empty(
+                            tuple(input_val.shape[dim] for dim in permutation)
+                        )
+                    except RuntimeError:
+                        pass
+            elif len(new_node.args) > 1:
+                try:
+                    node_meta["val"] = node_val.new_empty(
+                        tuple(cast(Iterable[int], new_node.args[1]))
+                    )
+                except RuntimeError:
+                    pass
+        return node_meta
+
+    def _get_permutation(self, permute_node: Node) -> list[int] | None:
+        if permute_node.target != self._PERMUTE_TARGET:
+            return None
+        if len(permute_node.args) >= 2:
+            raw_permute = list(cast(list[int], permute_node.args[1]))
+        else:
+            raw_dims = permute_node.kwargs.get("dims", permute_node.kwargs.get("dim"))
+            if raw_dims is None:
+                return None
+            raw_permute = list(cast(list[int], raw_dims))
+
+        rank = len(raw_permute)
+        normalized_permute = [dim + rank if dim < 0 else dim for dim in raw_permute]
+        if sorted(normalized_permute) != list(range(rank)):
+            return None
+        return normalized_permute
+
+    def _same_numel(self, first: Iterable[Any], second: Iterable[Any]) -> bool:
+        first_numel = 1
+        for dim in first:
+            first_numel *= dim
+        second_numel = 1
+        for dim in second:
+            second_numel *= dim
+        return first_numel == second_numel

--- a/backends/arm/_passes/propagate_permutes_views_pass.py
+++ b/backends/arm/_passes/propagate_permutes_views_pass.py
@@ -1,0 +1,634 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+import copy
+from collections.abc import Callable, Iterable, Sequence
+from typing import Any, cast, Set, Type
+
+import torch
+from executorch.backends.arm._passes.view_map import PermuteMap, ViewMap
+
+from executorch.exir import ExportedProgram
+from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import ExportPass, PassResult
+
+from .arm_pass import ArmPass
+from .canonicalize_view_copy_permute_pass import CanonicalizeViewCopyPermutePass
+from .fuse_duplicate_users_pass import FuseDuplicateUsersPass
+from .fuse_identical_input_transforms_pass import FuseIdenticalInputTransformsPass
+
+
+class PropagatePermuteViewsPass(ArmPass):
+    """Move permute/view nodes towards graph inputs."""
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
+
+    _VIEW_TARGET = exir_ops.edge.aten.view_copy.default
+    _VIEW_DEFAULT_TARGET = exir_ops.edge.aten.view.default
+    _PERMUTE_TARGET = exir_ops.edge.aten.permute_copy.default
+    _TARGETS = {_VIEW_TARGET, _VIEW_DEFAULT_TARGET, _PERMUTE_TARGET}
+
+    _REDUCTION_TARGETS = {
+        exir_ops.edge.aten.mean.dim,
+        exir_ops.edge.aten.sum.dim_IntList,
+    }
+    _ARG_UPDATE_TARGETS = {
+        *_REDUCTION_TARGETS,
+        exir_ops.edge.aten.slice_copy.Tensor,
+    }
+
+    def __init__(self, exported_program: ExportedProgram | None = None) -> None:
+        super().__init__()
+        self.exported_program = exported_program
+
+    @staticmethod
+    def _dim_arg(arg: Any) -> int | Sequence[int] | None:
+        if isinstance(arg, int):
+            return arg
+        if isinstance(arg, Sequence) and not isinstance(arg, (str, bytes)):
+            return cast(Sequence[int], arg)
+        return None
+
+    def call(self, graph_module: torch.fx.GraphModule) -> PassResult:
+        modified = False
+
+        result = self.fuse_vertical(graph_module)
+        graph_module = result.graph_module
+        modified |= result.modified
+        result = self.fuse_horizontal(graph_module)
+        graph_module = result.graph_module
+        modified |= result.modified
+        if result.modified:
+            graph_module = self._retrace(graph_module)
+
+        while True:
+            iteration_modified = False
+            for node in list(graph_module.graph.nodes):
+                if node.target in self._TARGETS:
+                    iteration_modified |= self._propagate(node)
+
+            if iteration_modified:
+                graph_module = self._retrace(graph_module)
+                result = self.fuse_horizontal(graph_module)
+                graph_module = result.graph_module
+                iteration_modified |= result.modified
+                result = self.fuse_vertical(graph_module)
+                graph_module = result.graph_module
+                iteration_modified |= result.modified
+
+            modified |= iteration_modified
+            if not iteration_modified:
+                break
+
+        if modified:
+            graph_module.graph.eliminate_dead_code()
+            graph_module.graph.lint()
+            graph_module.recompile()
+
+        return PassResult(graph_module, modified)
+
+    def _retrace(self, graph_module: torch.fx.GraphModule) -> torch.fx.GraphModule:
+        graph_module.graph.eliminate_dead_code()
+        graph_module.graph.lint()
+        graph_module.recompile()
+        return super().call(graph_module).graph_module
+
+    def _propagate(self, node: torch.fx.Node) -> bool:
+        """Propagate a single permute/view node."""
+
+        frontier = node
+        moved = False
+        while True:
+            neighbours = list(self._get_neighbours(frontier))
+
+            if len(neighbours) == 0:
+                assert node.op in (
+                    "placeholder",
+                    "output",
+                ), f"{self.__class__.__name__} reached an endpoint node which is not a placeholder or output: {frontier}"
+                break
+
+            if len(neighbours) > 1:
+                break
+
+            neighbour = neighbours[0]
+            if self.is_elementwise(neighbour) and self._is_unary_elementwise(neighbour):
+                frontier = neighbour
+                moved = True
+                continue
+
+            if self.is_swappable(neighbour):
+                swapped_args = self._maybe_swap_args(node, neighbour)
+                if swapped_args is None:
+                    break
+                node.args = swapped_args[0]
+                neighbour.args = swapped_args[1]
+                frontier = neighbour
+                moved = True
+                continue
+
+            # Unhandled case, stop propagation
+            break
+
+        if not moved:
+            return False
+
+        self._move_node(node, frontier)
+        return True
+
+    def fuse_vertical(self, graph_module: torch.fx.GraphModule) -> PassResult:
+        """Fuse consecutive permute/view nodes."""
+        return CanonicalizeViewCopyPermutePass().call(graph_module)
+
+    def fuse_horizontal(self, graph_module: torch.fx.GraphModule) -> PassResult:
+        """Fuse parallel permute/view nodes going into/ out a single node."""
+        raise NotImplementedError()
+
+    def _run_horizontal_passes(
+        self,
+        graph_module: torch.fx.GraphModule,
+        passes: Sequence[ExportPass],
+    ) -> PassResult:
+        modified = False
+        for pass_ in passes:
+            result = pass_.call(graph_module)
+            graph_module = result.graph_module
+            modified |= result.modified
+        return PassResult(graph_module, modified)
+
+    def _get_neighbours(self, node: torch.fx.Node) -> Iterable[torch.fx.Node]:
+        """Return the next nodes in the direction of propagation."""
+        raise NotImplementedError()
+
+    def _maybe_swap_args(
+        self, node: torch.fx.Node, neighbour: torch.fx.Node
+    ) -> Any | None:
+        """If the node can be swapped with its neighbour, return the new args
+        for the neighbour and new shape, otherwise return None.
+        """
+        if node.target == self._PERMUTE_TARGET:
+            return self._maybe_swap_permute_args(node, neighbour)
+        elif node.target in {self._VIEW_TARGET, self._VIEW_DEFAULT_TARGET}:
+            return self._maybe_swap_view_args(node, neighbour)
+        else:
+            raise ValueError(
+                f"Unexpected node target {node.target} in {self.__class__.__name__}"
+            )
+
+    def _maybe_swap_permute_args(
+        self, node: torch.fx.Node, neighbour: torch.fx.Node
+    ) -> Any | None:
+        raise NotImplementedError()
+
+    def _maybe_swap_view_args(
+        self, node: torch.fx.Node, neighbour: torch.fx.Node
+    ) -> Any | None:
+        raise NotImplementedError()
+
+    def _move_node(self, node: torch.fx.Node, frontier: torch.fx.Node) -> None:
+        """Update the graph to move the node into its new position."""
+        raise NotImplementedError()
+
+    def is_elementwise(self, node: torch.fx.Node) -> bool:
+        if node.op != "call_function":
+            return False
+
+        if node.target in {
+            exir_ops.backend.tosa.RESCALE.default,
+            exir_ops.backend.tosa.TABLE.default,
+        }:
+            return True
+
+        op = getattr(node.target, "_op", None)
+        if op is not None and hasattr(op, "tags"):
+            return torch.Tag.pointwise in op.tags
+        return False
+
+    def is_swappable(self, neighbour: torch.fx.Node) -> bool:
+        return neighbour.target in self._ARG_UPDATE_TARGETS
+
+    def _is_unary_elementwise(self, node: torch.fx.Node) -> bool:
+        return len(node.all_input_nodes) == 1
+
+
+class PropagatePermutesDownConcatPass(ArmPass):
+    """Sink matching input permutes through concat."""
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
+
+    _CAT_TARGETS = {exir_ops.edge.aten.cat.default, torch.ops.aten.cat.default}
+    _PERMUTE_TARGETS = {
+        exir_ops.edge.aten.permute_copy.default,
+        torch.ops.aten.permute_copy.default,
+        torch.ops.aten.permute.default,
+    }
+
+    def call(self, graph_module: torch.fx.GraphModule) -> PassResult:
+        modified = False
+
+        while True:
+            iteration_modified = False
+            for node in list(graph_module.graph.nodes):
+                iteration_modified |= self._sink_matching_input_permutes(node)
+
+            if not iteration_modified:
+                break
+            modified = True
+
+        if modified:
+            graph_module.graph.eliminate_dead_code()
+            graph_module.graph.lint()
+            graph_module.recompile()
+            graph_module = super().call(graph_module).graph_module
+
+        return PassResult(graph_module, modified)
+
+    def _sink_matching_input_permutes(self, node: torch.fx.Node) -> bool:
+        if node.op != "call_function" or node.target not in self._CAT_TARGETS:
+            return False
+
+        cat_inputs = self._cat_inputs(node)
+        if cat_inputs is None or len(cat_inputs) == 0:
+            return False
+        if any(
+            input_node.target not in self._PERMUTE_TARGETS for input_node in cat_inputs
+        ):
+            return False
+
+        permute_dims = self._permutation(cat_inputs[0])
+        if permute_dims is None:
+            return False
+        if any(
+            self._permutation(input_node) != permute_dims for input_node in cat_inputs
+        ):
+            return False
+        if any(
+            any(user is not node for user in input_node.users)
+            for input_node in cat_inputs
+        ):
+            return False
+
+        cat_dim = self._cat_dim(node)
+        if cat_dim is None:
+            return False
+        new_cat_dim = PermuteMap(cat_inputs[0]).map_target_to_source(cat_dim)[0]
+
+        producers = [
+            cast(torch.fx.Node, input_node.args[0]) for input_node in cat_inputs
+        ]
+        output_val = node.meta.get("val")
+        if not isinstance(output_val, torch.Tensor):
+            return False
+
+        node.args = (producers, new_cat_dim, *node.args[2:])
+        node.meta = copy.copy(node.meta)
+        node.meta["val"] = self._cat_output_meta_val(producers, new_cat_dim, output_val)
+
+        users = list(node.users)
+        with node.graph.inserting_after(node):
+            permute = node.graph.call_function(
+                cast(Callable[..., Any], cat_inputs[0].target),
+                args=(node, permute_dims),
+                kwargs=dict(cat_inputs[0].kwargs),
+            )
+        permute.meta = copy.copy(cat_inputs[0].meta)
+        permute.meta["val"] = output_val
+
+        for user in users:
+            user.replace_input_with(node, permute)
+
+        for input_node in cat_inputs:
+            if len(input_node.users) == 0:
+                node.graph.erase_node(input_node)
+
+        return True
+
+    def _cat_inputs(self, node: torch.fx.Node) -> list[torch.fx.Node] | None:
+        if len(node.args) == 0 or not isinstance(node.args[0], (list, tuple)):
+            return None
+        inputs = node.args[0]
+        if not all(isinstance(input_node, torch.fx.Node) for input_node in inputs):
+            return None
+        return list(cast(Sequence[torch.fx.Node], inputs))
+
+    def _cat_dim(self, node: torch.fx.Node) -> int | None:
+        dim = node.args[1] if len(node.args) >= 2 else node.kwargs.get("dim", 0)
+        return dim if isinstance(dim, int) else None
+
+    def _permutation(self, node: torch.fx.Node) -> list[int] | None:
+        if node.target not in self._PERMUTE_TARGETS or len(node.args) < 2:
+            return None
+
+        dims = list(cast(Sequence[int], node.args[1]))
+        rank = len(dims)
+        normalized_dims = [dim + rank if dim < 0 else dim for dim in dims]
+        if sorted(normalized_dims) != list(range(rank)):
+            return None
+        return normalized_dims
+
+    def _cat_output_meta_val(
+        self,
+        producers: list[torch.fx.Node],
+        cat_dim: int,
+        fallback: torch.Tensor,
+    ) -> torch.Tensor:
+        producer_vals = [producer.meta.get("val") for producer in producers]
+        if not all(isinstance(val, torch.Tensor) for val in producer_vals):
+            return fallback
+
+        producer_shapes = [
+            list(cast(torch.Tensor, producer_val).shape)
+            for producer_val in producer_vals
+        ]
+        output_shape = producer_shapes[0]
+        output_shape[cat_dim] = sum(shape[cat_dim] for shape in producer_shapes)
+        return fallback.new_empty(tuple(output_shape))
+
+
+class PropagatePermuteUpConcatPass(ArmPass):
+    """Hoist output permutes across concat when input permutes are no-ops."""
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
+
+    _CAT_TARGETS = {exir_ops.edge.aten.cat.default, torch.ops.aten.cat.default}
+    _PERMUTE_TARGETS = {
+        exir_ops.edge.aten.permute_copy.default,
+        torch.ops.aten.permute_copy.default,
+        torch.ops.aten.permute.default,
+    }
+    _VIEW_TARGET = exir_ops.edge.aten.view_copy.default
+
+    def call(self, graph_module: torch.fx.GraphModule) -> PassResult:
+        modified = False
+
+        while True:
+            iteration_modified = False
+            for node in list(graph_module.graph.nodes):
+                iteration_modified |= self._hoist_noop_input_permutes(node)
+
+            if not iteration_modified:
+                break
+            modified = True
+
+        if modified:
+            graph_module.graph.eliminate_dead_code()
+            graph_module.graph.lint()
+            graph_module.recompile()
+            graph_module = super().call(graph_module).graph_module
+
+        return PassResult(graph_module, modified)
+
+    def _hoist_noop_input_permutes(self, node: torch.fx.Node) -> bool:
+        if node.op != "call_function" or node.target not in self._PERMUTE_TARGETS:
+            return False
+        if len(node.all_input_nodes) != 1:
+            return False
+
+        cat_node = node.all_input_nodes[0]
+        if cat_node.target not in self._CAT_TARGETS or any(
+            user is not node for user in cat_node.users
+        ):
+            return False
+
+        permutation = self._permutation(node)
+        if permutation is None:
+            return False
+
+        cat_inputs = self._cat_inputs(cat_node)
+        if cat_inputs is None or len(cat_inputs) == 0:
+            return False
+
+        cat_dim = self._cat_dim(cat_node)
+        if cat_dim is None:
+            return False
+        new_cat_dim = PermuteMap(node).map_source_to_target(cat_dim)[0]
+
+        if any(
+            not self._is_data_movement_free_permutation(input_node, permutation)
+            for input_node in cat_inputs
+        ):
+            return False
+
+        new_inputs = [
+            self._maybe_insert_view_for_permute(input_node, permutation, cat_node)
+            for input_node in cat_inputs
+        ]
+        cat_node.args = (new_inputs, new_cat_dim, *cat_node.args[2:])
+        cat_node.meta = copy.copy(node.meta)
+
+        node.replace_all_uses_with(cat_node)
+        node.graph.erase_node(node)
+        return True
+
+    def _cat_inputs(self, node: torch.fx.Node) -> list[torch.fx.Node] | None:
+        if len(node.args) == 0 or not isinstance(node.args[0], (list, tuple)):
+            return None
+        inputs = node.args[0]
+        if not all(isinstance(input_node, torch.fx.Node) for input_node in inputs):
+            return None
+        return list(cast(Sequence[torch.fx.Node], inputs))
+
+    def _cat_dim(self, node: torch.fx.Node) -> int | None:
+        dim = node.args[1] if len(node.args) >= 2 else node.kwargs.get("dim", 0)
+        return dim if isinstance(dim, int) else None
+
+    def _permutation(self, node: torch.fx.Node) -> list[int] | None:
+        if node.target not in self._PERMUTE_TARGETS or len(node.args) < 2:
+            return None
+
+        dims = list(cast(Sequence[int], node.args[1]))
+        rank = len(dims)
+        normalized_dims = [dim + rank if dim < 0 else dim for dim in dims]
+        if sorted(normalized_dims) != list(range(rank)):
+            return None
+        return normalized_dims
+
+    def _is_data_movement_free_permutation(
+        self, node: torch.fx.Node, permutation: Sequence[int]
+    ) -> bool:
+        input_val = node.meta.get("val")
+        if not isinstance(input_val, torch.Tensor):
+            return False
+        return CanonicalizeViewCopyPermutePass._is_singleton_permutation(
+            input_val.shape, permutation
+        )
+
+    def _maybe_insert_view_for_permute(
+        self,
+        node: torch.fx.Node,
+        permutation: Sequence[int],
+        insert_before: torch.fx.Node,
+    ) -> torch.fx.Node:
+        input_val = node.meta.get("val")
+        if not isinstance(input_val, torch.Tensor):
+            return node
+
+        output_shape = [input_val.shape[dim] for dim in permutation]
+        if ViewMap.shapes_equal(input_val.shape, output_shape):
+            return node
+
+        with node.graph.inserting_before(insert_before):
+            view = node.graph.call_function(
+                self._VIEW_TARGET,
+                args=(node, output_shape),
+            )
+        view.meta = copy.copy(node.meta)
+        view.meta["val"] = input_val.new_empty(tuple(output_shape))
+        return view
+
+
+class PropagatePermuteViewsUpPass(PropagatePermuteViewsPass):
+    """Move permute/view nodes towards graph inputs."""
+
+    def fuse_horizontal(self, graph_module):
+        return self._run_horizontal_passes(
+            graph_module,
+            (
+                FuseIdenticalInputTransformsPass(),
+                FuseDuplicateUsersPass(),
+                PropagatePermutesDownConcatPass(),
+                PropagatePermuteUpConcatPass(),
+            ),
+        )
+
+    def _get_neighbours(self, node: torch.fx.Node) -> Iterable[torch.fx.Node]:
+        return list(node.all_input_nodes)
+
+    def _maybe_swap_permute_args(
+        self, node: torch.fx.Node, neighbour: torch.fx.Node
+    ) -> Any | None:
+        permute_map = PermuteMap(node)
+        args = self._dim_arg(neighbour.args[1])
+        if args is None:
+            return None
+        mapped_args = permute_map.map_source_to_target(args)
+        new_args: int | list[int] = (
+            mapped_args[0] if isinstance(args, int) else mapped_args
+        )
+        return (node.args, (*neighbour.args[:1], new_args, *neighbour.args[2:]))
+
+    def _maybe_swap_view_args(self, node, neighbour):
+        view_map = ViewMap(node)
+        if not view_map.is_valid_map or len(neighbour.all_input_nodes) != 1:
+            return None
+
+        input_val = neighbour.all_input_nodes[0].meta["val"]
+        new_shape = view_map.target_shape_for_source_shape(list(input_val.shape))
+        if new_shape is None:
+            return None
+
+        if neighbour.target in self._REDUCTION_TARGETS:
+            if len(neighbour.args) <= 2 or neighbour.args[2] is not True:
+                return None
+            new_dims = view_map.map_source_to_target(neighbour.args[1])
+            if not view_map.validate_mapped_reduction(new_dims):
+                return None
+        elif neighbour.target == exir_ops.edge.aten.slice_copy.Tensor:
+            new_dims = view_map.map_source_to_target(neighbour.args[1])
+            if len(new_dims) != 1:
+                return None
+            new_dims = new_dims[0]
+        else:
+            return None
+
+        new_neighbour_args = (*neighbour.args[:1], new_dims, *neighbour.args[2:])
+        return ((*node.args[:1], new_shape), new_neighbour_args)
+
+    def _move_node(self, node: torch.fx.Node, frontier: torch.fx.Node) -> None:
+        original_input = node.all_input_nodes[0]
+        if frontier.op == "placeholder":
+            producer = frontier
+            frontier_user = next(
+                user for user in list(frontier.users) if user is not node
+            )
+        else:
+            producer = frontier.all_input_nodes[0]
+            frontier_user = frontier
+
+        node.replace_input_with(original_input, producer)
+        frontier_user.replace_input_with(producer, node)
+
+        for user in list(node.users):
+            if user is not frontier_user:
+                user.replace_input_with(node, original_input)
+
+        frontier_user.prepend(node)
+
+
+class PropagatePermuteViewsDownPass(PropagatePermuteViewsPass):
+    """Move permute/view nodes towards graph outputs."""
+
+    def fuse_horizontal(self, graph_module):
+        return self._run_horizontal_passes(
+            graph_module,
+            (
+                FuseIdenticalInputTransformsPass(),
+                FuseDuplicateUsersPass(),
+                PropagatePermutesDownConcatPass(),
+                PropagatePermuteUpConcatPass(),
+            ),
+        )
+
+    def _get_neighbours(self, node: torch.fx.Node) -> Iterable[torch.fx.Node]:
+        return list(node.users.keys())
+
+    def _maybe_swap_permute_args(
+        self, node: torch.fx.Node, neighbour: torch.fx.Node
+    ) -> Any | None:
+        permute_map = PermuteMap(node)
+        args = self._dim_arg(neighbour.args[1])
+        if args is None:
+            return None
+        mapped_args = permute_map.map_target_to_source(args)
+        new_args: int | list[int] = (
+            mapped_args[0] if isinstance(args, int) else mapped_args
+        )
+        return (node.args, (*neighbour.args[:1], new_args, *neighbour.args[2:]))
+
+    def _maybe_swap_view_args(self, node, neighbour):
+        view_map = ViewMap(node)
+        if not view_map.is_valid_map:
+            return None
+
+        if neighbour.target in self._REDUCTION_TARGETS:
+            if len(neighbour.args) <= 2 or neighbour.args[2] is not True:
+                return None
+            new_dims = view_map.map_target_to_source(neighbour.args[1])
+            if not view_map.validate_mapped_source_reduction(new_dims):
+                return None
+        elif neighbour.target == exir_ops.edge.aten.slice_copy.Tensor:
+            new_dims = view_map.map_target_to_source(neighbour.args[1])
+            if len(new_dims) != 1:
+                return None
+            new_dims = new_dims[0]
+        else:
+            return None
+
+        output_val = neighbour.meta["val"]
+        new_neighbour_args = (*neighbour.args[:1], new_dims, *neighbour.args[2:])
+        return ((*node.args[:1], list(output_val.shape)), new_neighbour_args)
+
+    def _move_node(self, node: torch.fx.Node, frontier: torch.fx.Node) -> None:
+        original_user = next(iter(node.users))
+        producer = node.all_input_nodes[0]
+        if frontier.op == "output":
+            frontier_input = frontier.all_input_nodes[0]
+        else:
+            frontier_input = frontier
+        frontier_users = list(frontier_input.users)
+
+        original_user.replace_input_with(node, producer)
+        node.replace_input_with(producer, frontier_input)
+
+        for user in frontier_users:
+            if user is not node:
+                user.replace_input_with(frontier_input, node)
+
+        if frontier.op == "output":
+            frontier.prepend(node)
+        else:
+            frontier.append(node)

--- a/backends/arm/_passes/remove_permutes_around_elementwise_tosa_ops.py
+++ b/backends/arm/_passes/remove_permutes_around_elementwise_tosa_ops.py
@@ -3,6 +3,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import torch
+
 from executorch.backends.arm._passes.insert_table_ops import TableOps
 from executorch.backends.transforms.remove_permutes_around_elementwise_ops import (
     RemovePermutesAroundElementwiseOps,
@@ -21,15 +23,35 @@ class RemovePermutesAroundElementwiseTosaOps(RemovePermutesAroundElementwiseOps)
             }
         )
 
-    def permute_subgraph(self, subgraph) -> bool:
-        # Original function will always permute constant nodes which is wrong for table ops
-        # Remove constant tosa.TABLE edges before running full function
+    @staticmethod
+    def _is_scalar_constant_value(node):
+        value = node.meta.get("val")
+        return isinstance(value, torch.Tensor) and value.numel() == 1
+
+    def _is_constant(self, node):
+        if super()._is_constant(node):
+            return True
+
+        if node.op != "placeholder":
+            return False
+
+        target = str(node.target)
+        if not target.endswith(("_fused_const", "_pre_computed")):
+            return False
+
+        return self._is_scalar_constant_value(node)
+
+    def permute_subgraph(self, subgraph):
+        # Original function will always permute constant nodes. Skip constants
+        # where the compensating permute is either wrong or a no-op.
         new_constant_edges_in = set()
         for const_node, user_node in subgraph.constant_edges_in:
-            if user_node.target == exir_ops.backend.tosa.TABLE.default:
+            if (
+                user_node.target == exir_ops.backend.tosa.TABLE.default
+                or self._is_scalar_constant_value(const_node)
+            ):
                 continue
-            else:
-                new_constant_edges_in.add((const_node, user_node))
+            new_constant_edges_in.add((const_node, user_node))
 
         subgraph.constant_edges_in = new_constant_edges_in
         return super().permute_subgraph(subgraph)

--- a/backends/arm/_passes/view_map.py
+++ b/backends/arm/_passes/view_map.py
@@ -1,0 +1,490 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from typing import cast, Iterable, Sequence
+
+import sympy  # type: ignore[import-untyped]
+import torch
+
+from executorch.exir.dialects._ops import ops as exir_ops
+from torch.fx import Node
+
+_Dim = int | torch.SymInt
+_Piece = tuple[int, int]
+
+
+class ViewMap:
+    """Map dimensions across a view."""
+
+    def __init__(self, view_node: Node) -> None:
+        input_node = view_node.args[0]
+        assert isinstance(input_node, Node) and (
+            view_node.target == exir_ops.edge.aten.view_copy.default
+        )
+        input_val = input_node.meta["val"]
+        assert isinstance(input_val, torch.Tensor)
+
+        self.source_shape = cast(list[_Dim], list(input_val.shape))
+        self.target_shape = list(cast(Sequence[_Dim], view_node.args[1]))
+        self.source_to_target_pieces = self._build_piece_map(
+            self.source_shape, self.target_shape
+        )
+
+    @classmethod
+    def from_shapes(
+        cls, source_shape: Sequence[_Dim], target_shape: Sequence[_Dim]
+    ) -> ViewMap:
+        view_map = cls.__new__(cls)
+        view_map.source_shape = list(source_shape)
+        view_map.target_shape = list(target_shape)
+        view_map.source_to_target_pieces = cls._build_piece_map(
+            view_map.source_shape, view_map.target_shape
+        )
+        return view_map
+
+    @property
+    def is_valid_map(self) -> bool:
+        return self.source_to_target_pieces is not None
+
+    @property
+    def source_rank(self) -> int:
+        return len(self.source_shape)
+
+    @property
+    def target_rank(self) -> int:
+        return len(self.target_shape)
+
+    def map_source_to_target(
+        self,
+        source_dims: int | Sequence[int],
+        *,
+        include_unbacked_singletons: bool = False,
+    ) -> list[int]:
+        """Map source dims to target dims."""
+        normalized_dims = self._normalize_dims(source_dims, self.source_rank)
+        source_to_target_pieces = self._valid_source_to_target_pieces()
+
+        mapped_dims = [
+            target_axis
+            for dim in normalized_dims
+            for target_axis, _ in source_to_target_pieces[dim]
+        ]
+
+        mapped_dims_unique: list[int] = []
+        for dim in mapped_dims:
+            if dim not in mapped_dims_unique:
+                mapped_dims_unique.append(dim)
+        if include_unbacked_singletons:
+            mapped_dims_unique = [
+                target_axis
+                for target_axis, target_dim in enumerate(self.target_shape)
+                if target_axis not in mapped_dims_unique
+                and self._dim_equals(target_dim, 1)
+            ] + mapped_dims_unique
+        return mapped_dims_unique
+
+    def map_target_to_source(
+        self,
+        target_dims: int | Sequence[int],
+        *,
+        include_unbacked_singletons: bool = False,
+    ) -> list[int]:
+        """Map target dims to source dims."""
+        normalized_dims = self._normalize_dims(target_dims, self.target_rank)
+        source_to_target_pieces = self._valid_source_to_target_pieces()
+
+        mapped_dims = [
+            source_axis
+            for dim in normalized_dims
+            for source_axis, target_pieces in enumerate(source_to_target_pieces)
+            if any(target_axis == dim for target_axis, _ in target_pieces)
+        ]
+
+        if include_unbacked_singletons:
+            mapped_dims_unique: list[int] = []
+            for dim in mapped_dims:
+                if dim not in mapped_dims_unique:
+                    mapped_dims_unique.append(dim)
+
+            mapped_dims = mapped_dims_unique
+            seen_dims = set(mapped_dims)
+            for source_dim, source_dim_size in reversed(
+                list(enumerate(self.source_shape))
+            ):
+                if source_dim not in seen_dims and self._dim_equals(source_dim_size, 1):
+                    insert_at = next(
+                        (
+                            index
+                            for index, dim in enumerate(mapped_dims)
+                            if dim > source_dim
+                        ),
+                        len(mapped_dims),
+                    )
+                    mapped_dims.insert(insert_at, source_dim)
+                    seen_dims.add(source_dim)
+
+        return mapped_dims
+
+    def validate_mapped_permute(
+        self,
+        input_permute_dims: Sequence[int],
+        permute_dims: Sequence[int],
+    ) -> bool:
+        source_permute = self._normalize_dims(input_permute_dims, self.source_rank)
+        target_permute = self._normalize_dims(permute_dims, self.target_rank)
+        if not self._is_permutation(source_permute, self.source_rank):
+            return False
+        if len(set(target_permute)) != len(target_permute) or any(
+            dim < 0 or dim >= self.target_rank for dim in target_permute
+        ):
+            return False
+
+        target_to_source_pieces = self._target_to_source_pieces()
+        required_target_axes = {
+            target_axis
+            for target_axis, pieces in enumerate(target_to_source_pieces)
+            if any(
+                not self._dim_equals(self.source_shape[source_axis], 1)
+                for source_axis, _ in pieces
+            )
+        }
+        if not required_target_axes.issubset(target_permute):
+            return False
+
+        permuted_pieces = [
+            piece
+            for target_axis in target_permute
+            for piece in target_to_source_pieces[target_axis]
+            if not self._dim_equals(self.source_shape[piece[0]], 1)
+        ]
+
+        source_axes: list[int] = []
+        seen_axes: set[int] = set()
+        index = 0
+
+        while index < len(permuted_pieces):
+            source_axis = permuted_pieces[index][0]
+            parts: list[int] = []
+            while (
+                index < len(permuted_pieces)
+                and permuted_pieces[index][0] == source_axis
+            ):
+                parts.append(permuted_pieces[index][1])
+                index += 1
+
+            if source_axis in seen_axes or parts != list(range(len(parts))):
+                return False
+            seen_axes.add(source_axis)
+            source_axes.append(source_axis)
+
+        return source_axes == [
+            dim
+            for dim in source_permute
+            if not self._dim_equals(self.source_shape[dim], 1)
+        ]
+
+    def validate_mapped_reduction(self, dims: Iterable[int]) -> bool:
+        target_dims = sorted(set(self._normalize_dims(list(dims), self.target_rank)))
+        if not target_dims:
+            return False
+        return target_dims == list(range(target_dims[0], target_dims[-1] + 1))
+
+    def validate_mapped_source_reduction(self, dims: Iterable[int]) -> bool:
+        source_dims = sorted(set(self._normalize_dims(list(dims), self.source_rank)))
+        if not source_dims:
+            return False
+        return source_dims == list(range(source_dims[0], source_dims[-1] + 1))
+
+    def source_to_single_target_permutation(self) -> list[int] | None:
+        mapped_dims = []
+        for source_axis in range(self.source_rank):
+            target_axes = self.map_source_to_target(source_axis)
+            if len(target_axes) != 1:
+                return None
+            mapped_dims.append(target_axes[0])
+        return (
+            mapped_dims if self._is_permutation(mapped_dims, len(mapped_dims)) else None
+        )
+
+    def target_to_single_source_permutation(self) -> list[int] | None:
+        mapped_dims = []
+        for target_axis in range(self.target_rank):
+            source_axes = self.map_target_to_source(target_axis)
+            if len(source_axes) != 1:
+                return None
+            mapped_dims.append(source_axes[0])
+        return (
+            mapped_dims if self._is_permutation(mapped_dims, len(mapped_dims)) else None
+        )
+
+    def target_shape_for_source_shape(
+        self, source_shape: Sequence[_Dim]
+    ) -> list[_Dim] | None:
+        if len(source_shape) != self.source_rank:
+            return None
+
+        target_shape: list[_Dim] = [1] * self.target_rank
+        handled_target_axes = self._fill_coalesced_target_axes(
+            source_shape, target_shape
+        )
+
+        for source_axis in range(self.source_rank):
+            if self._fill_target_axes_for_source_axis(
+                source_axis, source_shape, target_shape, handled_target_axes
+            ):
+                continue
+            return None
+
+        return target_shape if self.same_numel(source_shape, target_shape) else None
+
+    def _fill_coalesced_target_axes(
+        self,
+        source_shape: Sequence[_Dim],
+        target_shape: list[_Dim],
+    ) -> set[int]:
+        handled_target_axes: set[int] = set()
+        for target_axis in range(self.target_rank):
+            source_axes = self.map_target_to_source(target_axis)
+            if len(source_axes) > 1:
+                target_shape[target_axis] = self.numel(
+                    source_shape[source_axis] for source_axis in source_axes
+                )
+                handled_target_axes.add(target_axis)
+        return handled_target_axes
+
+    def _fill_target_axes_for_source_axis(
+        self,
+        source_axis: int,
+        source_shape: Sequence[_Dim],
+        target_shape: list[_Dim],
+        handled_target_axes: set[int],
+    ) -> bool:
+        target_axes = self.map_source_to_target(source_axis)
+        if not target_axes:
+            return True
+        if any(target_axis in handled_target_axes for target_axis in target_axes):
+            return True
+        if len(target_axes) == 1:
+            target_shape[target_axes[0]] = source_shape[source_axis]
+            return True
+
+        target_dims = [self.target_shape[target_axis] for target_axis in target_axes]
+        if self._dim_equals(source_shape[source_axis], self.source_shape[source_axis]):
+            self._set_target_dims(target_shape, target_axes, target_dims)
+            return True
+        if self._dim_equals(self.numel(target_dims), 1):
+            target_shape[target_axes[0]] = source_shape[source_axis]
+            return True
+        if self._dim_equals(self.numel(target_dims), self.source_shape[source_axis]):
+            self._set_target_dims(target_shape, target_axes, target_dims)
+            return True
+        return False
+
+    @staticmethod
+    def _set_target_dims(
+        target_shape: list[_Dim],
+        target_axes: Sequence[int],
+        target_dims: Sequence[_Dim],
+    ) -> None:
+        for target_axis, target_dim in zip(target_axes, target_dims):
+            target_shape[target_axis] = target_dim
+
+    @classmethod
+    def _build_piece_map(  # noqa: C901
+        cls, source_shape: Sequence[_Dim], target_shape: Sequence[_Dim]
+    ) -> list[list[_Piece]] | None:
+        """Map each source axis to the target-axis pieces it becomes.
+
+        Each piece is represented as (target_axis, source_axis_part). The part
+        index lets the caller reject permutations that reorder pieces split out
+        of the same source axis.
+
+        E.g. a view [4, 3, 2] -> [2, 2, 6] is mapped as [[(0, 0), (1, 1)], [(2,
+        0)], [(2, 0)]].
+
+        """
+        source_axes = [
+            axis for axis, dim in enumerate(source_shape) if not cls._dim_equals(dim, 1)
+        ]
+        target_axes = [
+            axis for axis, dim in enumerate(target_shape) if not cls._dim_equals(dim, 1)
+        ]
+
+        piece_map: list[list[_Piece]] = [[] for _ in source_shape]
+        if not source_axes or not target_axes:
+            if source_axes or target_axes:
+                return None
+            cls._add_singleton_pieces(piece_map, source_shape, target_shape)
+            return piece_map
+
+        source_index = 0
+        target_index = 0
+        source_part = 0
+        source_axis = source_axes[source_index]
+        target_axis = target_axes[target_index]
+        source_remaining = source_shape[source_axis]
+        target_remaining = target_shape[target_axis]
+
+        while source_index < len(source_axes) and target_index < len(target_axes):
+            piece_map[source_axis].append((target_axis, source_part))
+
+            if cls._dim_equals(source_remaining, target_remaining):
+                source_index += 1
+                target_index += 1
+                source_part = 0
+                if source_index < len(source_axes):
+                    source_axis = source_axes[source_index]
+                    source_remaining = source_shape[source_axis]
+                if target_index < len(target_axes):
+                    target_axis = target_axes[target_index]
+                    target_remaining = target_shape[target_axis]
+                continue
+
+            if isinstance(source_remaining, int) and isinstance(target_remaining, int):
+                if (0 < target_remaining < source_remaining) and (
+                    source_remaining % target_remaining == 0
+                ):
+                    source_remaining //= target_remaining
+                    source_part += 1
+                    target_index += 1
+                    if target_index < len(target_axes):
+                        target_axis = target_axes[target_index]
+                        target_remaining = target_shape[target_axis]
+                    continue
+
+                if (0 < source_remaining < target_remaining) and (
+                    target_remaining % source_remaining == 0
+                ):
+                    target_remaining //= source_remaining
+                    source_index += 1
+                    source_part = 0
+                    if source_index < len(source_axes):
+                        source_axis = source_axes[source_index]
+                        source_remaining = source_shape[source_axis]
+                    continue
+
+                return None
+
+            return None
+
+        if source_index != len(source_axes) or target_index != len(target_axes):
+            return None
+        cls._add_singleton_pieces(piece_map, source_shape, target_shape)
+        return piece_map
+
+    @classmethod
+    def _add_singleton_pieces(
+        cls,
+        piece_map: list[list[_Piece]],
+        source_shape: Sequence[_Dim],
+        target_shape: Sequence[_Dim],
+    ) -> None:
+        mapped_source_axes = {
+            source_axis for source_axis, pieces in enumerate(piece_map) if pieces
+        }
+        mapped_target_axes = {
+            target_axis for pieces in piece_map for target_axis, _ in pieces
+        }
+        source_singletons = [
+            axis
+            for axis, dim in enumerate(source_shape)
+            if axis not in mapped_source_axes and cls._dim_equals(dim, 1)
+        ]
+        target_singletons = [
+            axis
+            for axis, dim in enumerate(target_shape)
+            if axis not in mapped_target_axes and cls._dim_equals(dim, 1)
+        ]
+
+        if len(source_singletons) == len(target_singletons):
+            for source_axis, target_axis in zip(source_singletons, target_singletons):
+                piece_map[source_axis].append((target_axis, 0))
+        elif len(source_singletons) == 1:
+            for target_axis in target_singletons:
+                piece_map[source_singletons[0]].append((target_axis, 0))
+        elif len(target_singletons) == 1:
+            for source_axis in source_singletons:
+                piece_map[source_axis].append((target_singletons[0], 0))
+        else:
+            for source_axis, target_axis in zip(source_singletons, target_singletons):
+                piece_map[source_axis].append((target_axis, 0))
+
+    def _target_to_source_pieces(self) -> list[list[_Piece]]:
+        target_to_source: list[list[_Piece]] = [[] for _ in self.target_shape]
+        for source_axis, pieces in enumerate(self._valid_source_to_target_pieces()):
+            for target_axis, source_part in pieces:
+                target_to_source[target_axis].append((source_axis, source_part))
+        return target_to_source
+
+    def _valid_source_to_target_pieces(self) -> list[list[_Piece]]:
+        assert self.source_to_target_pieces is not None
+        return self.source_to_target_pieces
+
+    @staticmethod
+    def _normalize_dim(dim: int, rank: int) -> int:
+        return dim if dim >= 0 else dim + rank
+
+    @classmethod
+    def _normalize_dims(cls, dims: int | Sequence[int], rank: int) -> list[int]:
+        if isinstance(dims, int):
+            return [cls._normalize_dim(dims, rank)]
+        return [cls._normalize_dim(dim, rank) for dim in dims]
+
+    @staticmethod
+    def _is_permutation(dims: Sequence[int], rank: int) -> bool:
+        return sorted(dims) == list(range(rank))
+
+    @staticmethod
+    def _dim_expr(dim: _Dim) -> sympy.Basic:
+        return sympy.Integer(dim) if isinstance(dim, int) else dim.node.expr
+
+    @classmethod
+    def _dim_equals(cls, lhs: _Dim, rhs: _Dim) -> bool:
+        if isinstance(lhs, int) and isinstance(rhs, int):
+            return lhs == rhs
+        return sympy.simplify(cls._dim_expr(lhs) - cls._dim_expr(rhs)) == 0
+
+    @classmethod
+    def shapes_equal(cls, lhs: Sequence[_Dim], rhs: Sequence[_Dim]) -> bool:
+        return len(lhs) == len(rhs) and all(
+            cls._dim_equals(lhs_dim, rhs_dim) for lhs_dim, rhs_dim in zip(lhs, rhs)
+        )
+
+    @staticmethod
+    def numel(shape: Iterable[_Dim]) -> _Dim:
+        numel: _Dim = 1
+        for dim in shape:
+            numel *= dim
+        return numel
+
+    @classmethod
+    def same_numel(
+        cls, first_shape: Iterable[_Dim], second_shape: Iterable[_Dim]
+    ) -> bool:
+        return cls.numel(first_shape) == cls.numel(second_shape)
+
+
+class PermuteMap:
+    """Map dimensions across a permute."""
+
+    def __init__(self, permute_node: Node) -> None:
+        permute_dims = permute_node.args[1]
+        assert isinstance(permute_dims, Sequence) and not isinstance(
+            permute_dims, (str, bytes)
+        )
+        self.permute_dims = list(cast(Sequence[int], permute_dims))
+
+    def map_source_to_target(self, source_dims: int | Sequence[int]) -> list[int]:
+        normalized_dims = ViewMap._normalize_dims(source_dims, len(self.permute_dims))
+        inverse_permute = [0] * len(self.permute_dims)
+        for target_dim, source_dim in enumerate(self.permute_dims):
+            inverse_permute[source_dim] = target_dim
+        return [inverse_permute[dim] for dim in normalized_dims]
+
+    def map_target_to_source(self, target_dims: int | Sequence[int]) -> list[int]:
+        normalized_dims = ViewMap._normalize_dims(target_dims, len(self.permute_dims))
+        return [self.permute_dims[dim] for dim in normalized_dims]

--- a/backends/arm/test/misc/test_transpose_counts.py
+++ b/backends/arm/test/misc/test_transpose_counts.py
@@ -392,7 +392,7 @@ cases = {
     "grouped_conv": TransposeCountCase(
         GroupedConvModule(),
         (torch.randn(1, 4, 8, 8),),
-        4,
+        2,
     ),
     "transpose_conv": TransposeCountCase(
         TransposeConvModule(),
@@ -408,12 +408,12 @@ cases = {
     "maxpool2d_dilation": TransposeCountCase(
         MaxPool2dDilatedModule(),
         (torch.randn(1, 2, 8, 8),),
-        4,
+        2,
     ),
     "lstm": TransposeCountCase(
         LstmModule(),
         (torch.randn(2, 4, 8),),
-        2,
+        1,
     ),
     "groupnorm": TransposeCountCase(
         GroupNormModule(),
@@ -428,7 +428,7 @@ cases = {
     "multihead_attention_rank3": TransposeCountCase(
         MultiheadAttentionModule(),
         (torch.randn(2, 4, 8),),
-        8,
+        7,
     ),
     "cumsum_rank3_dim0": TransposeCountCase(
         CumsumModule(),
@@ -441,31 +441,31 @@ cases = {
         0,
     ),
     "model_1_conv_maxpool_residual_linear": TransposeCountCase(
-        Model1ConvMaxPoolResidualLinear(), (torch.randn(2, 8, 64),), 5
+        Model1ConvMaxPoolResidualLinear(), (torch.randn(2, 8, 64),), 1
     ),
     "model_2_conv_mha_linear_layernorm": TransposeCountCase(
-        Model2ConvMhaLinearLayerNorm(), (torch.randn(2, 8, 32),), 9
+        Model2ConvMhaLinearLayerNorm(), (torch.randn(2, 8, 32),), 8
     ),
     "model_3_lstm_linear": TransposeCountCase(
-        Model3LstmLinear(), (torch.randn(2, 16, 8),), 2
+        Model3LstmLinear(), (torch.randn(2, 16, 8),), 1
     ),
     "model_4_conv_lstm_linear_layernorm": TransposeCountCase(
-        Model4ConvLstmLinearLayerNorm(), (torch.randn(2, 8, 32),), 3
+        Model4ConvLstmLinearLayerNorm(), (torch.randn(2, 8, 32),), 2
     ),
     "model_5_dwconv_gelu_layernorm_avgpool": TransposeCountCase(
-        Model5DwConvGeluLayerNormAvgPool(), (torch.randn(1, 8, 16, 16),), 4
+        Model5DwConvGeluLayerNormAvgPool(), (torch.randn(1, 8, 16, 16),), 2
     ),
     "model_6_gru_linear": TransposeCountCase(
-        Model6GruLinear(), (torch.randn(2, 16, 8),), 2
+        Model6GruLinear(), (torch.randn(2, 16, 8),), 1
     ),
     "model_7_dwconv_batchnorm_linear": TransposeCountCase(
         Model7DwConvBatchNormLinear(), (torch.randn(2, 8, 64),), 1
     ),
     "model_8_conv_batchnorm_maxpool_residual": TransposeCountCase(
-        Model8ConvBatchNormMaxPoolResidual(), (torch.randn(1, 8, 16, 16),), 4
+        Model8ConvBatchNormMaxPoolResidual(), (torch.randn(1, 8, 16, 16),), 2
     ),
     "model_9_dilated_conv_batchnorm_avgpool_residual": TransposeCountCase(
-        Model9DilatedConvBatchNormAvgPoolResidual(), (torch.randn(1, 8, 16, 16),), 4
+        Model9DilatedConvBatchNormAvgPoolResidual(), (torch.randn(1, 8, 16, 16),), 2
     ),
     "model_10_dwconv_batchnorm_linear_cat": TransposeCountCase(
         Model10DwConvBatchNormLinearCat(), (torch.randn(2, 8, 64),), 1
@@ -495,7 +495,7 @@ cases_channels_last = {
     "conv3d_rank5_channels_last": TransposeCountCase(
         Conv3dModule(),
         (torch.randn(1, 2, 6, 6, 6).to(memory_format=torch.channels_last_3d),),
-        3,
+        1,
     ),
     "linear_rank4_channels_last": TransposeCountCase(
         LinearModule(),
@@ -513,7 +513,7 @@ cases_channels_last = {
     "pixel_shuffle_channels_last": TransposeCountCase(
         PixelShuffleModule(),
         (torch.randn(1, 8, 2, 2).to(memory_format=torch.channels_last),),
-        3,
+        1,
     ),
     "grouped_conv_channels_last": TransposeCountCase(
         GroupedConvModule(),
@@ -538,7 +538,7 @@ cases_channels_last = {
     "maxpool2d_dilation_channels_last": TransposeCountCase(
         MaxPool2dDilatedModule(),
         (torch.randn(1, 2, 8, 8).to(memory_format=torch.channels_last),),
-        6,
+        3,
     ),
     "groupnorm_channels_last": TransposeCountCase(
         GroupNormModule(),


### PR DESCRIPTION
Adds multiple new passes to accomplish this:

**CanonicalizeViewCopyPermutePass**
Rewrites op chains such as e.g. PERMUTE -> PERMUTE -> VIEW -> PERMUTE -> ... to minimal form by iteratively fusing ops and swapping permute/view pairs.

**FuseIdenticalInputTransformsPass**
Analogue to FuseDuplicateUsers except that it handles identical inputs and moves them down across elementwise ops

**PropagatePermuteViewUp/DownPass**
Groups Permutes and views together by propagating them upwards through elementwise ops/ reduction ops and slices, stopping at branching nodes and memor format sensitive ops. Then consecutive ops are fused together by the CanonicalizeViewCopyPass and duplicate inputs/outpus are fused by FuseIdenticalInputTransformsPass and FuseDuplicateUsers.

Note that fusing over branches could be handled
in this pass if implemented, but currently this is left to the existing RemovePermutesAroundElementwiseTosaOps pass.

**Other changes**
- FuseDuplicateUsersPass: Bug fix
- RemovePermutesAroundElementwiseTosaOps: Minor fix allow scalar multiplication in branch.
- ViewMap/PermuteMap: New helper classes for mapping axes across a view/permute

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani