### PR TITLE
Add RemoveBNTrackingMutationsPass (#19980)

### DIFF
--- a/backends/cadence/aot/BUCK
+++ b/backends/cadence/aot/BUCK
@@ -535,6 +535,22 @@ fbcode_target(_kind = python_unittest,
 )
 
 fbcode_target(_kind = python_unittest,
+    name = "test_remove_bn_tracking_pass",
+    srcs = [
+        "tests/test_remove_bn_tracking_pass.py",
+    ],
+    supports_static_listing = False,
+    typing = True,
+    deps = [
+        "//caffe2:torch",
+        "//executorch/backends/cadence/aot:remove_ops",
+        "//executorch/backends/cadence/aot/quantizer:quantizer",
+        "//executorch/exir:lib",
+        "//pytorch/ao:torchao",
+    ],
+)
+
+fbcode_target(_kind = python_unittest,
     name = "test_simplify_ops_passes",
     srcs = [
         "tests/test_simplify_ops_passes.py",

--- a/backends/cadence/aot/quantizer/patterns.py
+++ b/backends/cadence/aot/quantizer/patterns.py
@@ -1055,6 +1055,118 @@ class Conv2dReluPattern1(ConvReluBasePattern):
         return [torch.ops.aten.conv2d.default, torch.ops.aten.relu_.default]
 
 
+class ConvBNReluBasePattern(QuantizationPattern):
+    """Base class for Conv + BatchNorm + ReLU fusion (3-op pattern).
+
+    BatchNorm sits between conv and relu in QAT graphs, preventing the 2-op
+    Conv+ReLU pattern from matching. This pattern matches the full chain and
+    produces the same fused quantized conv op.
+    """
+
+    @abstractmethod
+    def partition_types(self) -> List[OpOverload]:
+        pass
+
+    def get_anchors(
+        self, gm: fx.GraphModule, fused_partition: List[fx.GraphModule]
+    ) -> Tuple[PartitionAnchors, fx.Node]:
+        # pyre-fixme[29]: `Union[BoundMethod[typing.Callable(torch._C.TensorBase.__ge...
+        conv_node = fused_partition[0].nodes[-1]
+        # pyre-fixme[29]: `Union[BoundMethod[typing.Callable(torch._C.TensorBase.__ge...
+        relu_node = fused_partition[2].nodes[-1]
+
+        bias_qspec = DerivedQuantizationSpec(
+            derived_from=[
+                (conv_node.args[0], conv_node),
+                (conv_node.args[1], conv_node),
+            ],
+            derive_qparams_fn=get_bias_qparams,
+            dtype=torch.int32,
+            quant_min=-(2**31),
+            quant_max=2**31 - 1,
+            qscheme=torch.per_tensor_affine,
+        )
+
+        bias = []
+        if len(conv_node.args) > 2 and conv_node.args[2] is not None:
+            bias = [(conv_node, 2, bias_qspec)]
+
+        return (
+            PartitionAnchors(
+                inputs=[(conv_node, 0)],
+                weights=[(conv_node, 1)],
+                # pyre-fixme[6]: Incompatible parameter type
+                biases=bias,
+                output=[(relu_node,)],
+            ),
+            relu_node,
+        )
+
+    def replacement_op(self) -> OpOverload:
+        return torch.ops.cadence.quantized_conv2d_nchw.per_tensor
+
+    def anchor_ops(self) -> tuple[OpOverload, ...]:
+        return (self.partition_types()[0],)
+
+    def fuse(self, gm: fx.GraphModule, anchor_node: fx.Node) -> fx.Node | None:
+        # This pattern exists only to drive annotation: it groups the conv
+        # input/weight with the relu output across the BatchNorm so the whole
+        # chain shares quantization params. Actual fusion is not performed here.
+        #
+        # By the time fusion runs, the BatchNorm must already have been folded
+        # into the conv at the float level -- torchao `prepare_pt2e` folds it
+        # before annotation for PTQ, and `FuseQATConvBN` folds it before
+        # `QuantFusionPass` for QAT -- leaving a plain conv+relu that the 2-op
+        # `ConvReluBasePattern` fuses. A `batch_norm` that survives to here was
+        # never folded; building a quantized conv from the conv weights/bias
+        # alone (as `fuse_conv` does) would silently drop the BatchNorm affine
+        # and corrupt numerics. Decline so the BatchNorm is preserved for a
+        # downstream pass instead of dropped.
+        return None
+
+
+class Conv1dBNReluPattern0(ConvBNReluBasePattern):
+    def partition_types(self) -> List[OpOverload]:
+        return [
+            torch.ops.aten.conv1d.default,
+            torch.ops.aten.batch_norm.default,
+            torch.ops.aten.relu.default,
+        ]
+
+    def replacement_op(self) -> OpOverload:
+        return torch.ops.cadence.quantized_conv1d_ncl.per_tensor
+
+
+class Conv1dBNReluPattern1(ConvBNReluBasePattern):
+    def partition_types(self) -> List[OpOverload]:
+        return [
+            torch.ops.aten.conv1d.default,
+            torch.ops.aten.batch_norm.default,
+            torch.ops.aten.relu_.default,
+        ]
+
+    def replacement_op(self) -> OpOverload:
+        return torch.ops.cadence.quantized_conv1d_ncl.per_tensor
+
+
+class Conv2dBNReluPattern0(ConvBNReluBasePattern):
+    def partition_types(self) -> List[OpOverload]:
+        return [
+            torch.ops.aten.conv2d.default,
+            torch.ops.aten.batch_norm.default,
+            torch.ops.aten.relu.default,
+        ]
+
+
+class Conv2dBNReluPattern1(ConvBNReluBasePattern):
+    def partition_types(self) -> List[OpOverload]:
+        return [
+            torch.ops.aten.conv2d.default,
+            torch.ops.aten.batch_norm.default,
+            torch.ops.aten.relu_.default,
+        ]
+
+
 class SoftmaxPattern(QuantizationPattern):
     def partition_types(self) -> List[OpOverload]:
         return [torch.ops.aten._softmax.default]

--- a/backends/cadence/aot/quantizer/quantizer.py
+++ b/backends/cadence/aot/quantizer/quantizer.py
@@ -17,9 +17,13 @@ from executorch.backends.cadence.aot.quantizer.patterns import (
     AddReluPattern1,
     BmmPattern,
     CatPattern,
+    Conv1dBNReluPattern0,
+    Conv1dBNReluPattern1,
     Conv1dPattern,
     Conv1dReluPattern0,
     Conv1dReluPattern1,
+    Conv2dBNReluPattern0,
+    Conv2dBNReluPattern1,
     Conv2dPattern,
     Conv2dReluPattern0,
     Conv2dReluPattern1,
@@ -395,7 +399,13 @@ class CadenceFusedConvReluQuantizer(CadenceQuantizer):
             quantizers = []
         a8w8 = qconfig_A8W8_qat if is_qat else qconfig_A8W8
         a8w8sym = qconfig_A8W8sym_qat if is_qat else qconfig_A8W8sym
-        # Order matters here, perform the "fused" patterns first
+        # Order matters here, perform the "fused" patterns first.
+        # 3-op conv+bn+relu patterns must come before 2-op conv+relu
+        # so they match when BN sits between conv and relu.
+        quantizers.append(CadenceAtenQuantizer(Conv1dBNReluPattern0(), a8w8sym))
+        quantizers.append(CadenceAtenQuantizer(Conv1dBNReluPattern1(), a8w8sym))
+        quantizers.append(CadenceAtenQuantizer(Conv2dBNReluPattern0(), a8w8sym))
+        quantizers.append(CadenceAtenQuantizer(Conv2dBNReluPattern1(), a8w8sym))
         quantizers.append(CadenceAtenQuantizer(Conv1dReluPattern0(), a8w8sym))
         quantizers.append(CadenceAtenQuantizer(Conv1dReluPattern1(), a8w8sym))
         quantizers.append(CadenceAtenQuantizer(Conv2dReluPattern0(), a8w8sym))

--- a/backends/cadence/aot/remove_ops.py
+++ b/backends/cadence/aot/remove_ops.py
@@ -30,9 +30,16 @@ from executorch.backends.transforms.remove_permutes_around_elementwise_ops impor
 )
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.dialects.edge._ops import EdgeOpOverload, EdgeOpOverloadPacket
-from executorch.exir.pass_base import ExportPass, PassResult
+from executorch.exir.pass_base import (
+    ExportedProgramPassBase,
+    ExportedProgramPassResult,
+    ExportPass,
+    PassResult,
+)
 from executorch.exir.pass_manager import PassManager, PassType
 from executorch.exir.passes import dead_code_elimination_pass
+from torch.export import ExportedProgram
+from torch.export.graph_signature import InputKind, OutputKind
 from torch.fx.node import Node
 from torch.utils import _pytree as pytree
 
@@ -867,6 +874,103 @@ class CommonRemovePasses:
         RemoveCatFromSliceCopyPass,
         RemoveCloneOpsTransformImported,
     ]
+
+
+class RemoveBNTrackingMutationsPass(ExportedProgramPassBase):
+    """Remove num_batches_tracked buffer mutations from an ExportedProgram.
+
+    run_decompositions() re-introduces num_batches_tracked mutable buffer
+    outputs even when batch_norm uses training=False. These mutations are
+    dead (the counter is never read in eval mode) but inflate the PTE.
+
+    Removes both the mutation outputs AND the dead input placeholders,
+    along with their corresponding graph signature entries and state dict
+    tensors.
+    """
+
+    def call(self, exported_program: ExportedProgram) -> ExportedProgramPassResult:
+        ep = exported_program
+        nbt_fqns = {
+            fqn
+            for fqn in ep.graph_signature.buffers_to_mutate.values()
+            if "num_batches_tracked" in fqn
+        }
+        if not nbt_fqns:
+            return ExportedProgramPassResult(ep, False)
+
+        nbt_output_names = {
+            name
+            for name, fqn in ep.graph_signature.buffers_to_mutate.items()
+            if fqn in nbt_fqns
+        }
+        # buffers_to_mutate / inputs_to_buffers are keyed by the FX node name
+        # (arg.name), which can differ from node.target when export
+        # uniquifies or sanitizes placeholder names. Match on node.name.
+        nbt_input_names = {
+            name
+            for name, fqn in ep.graph_signature.inputs_to_buffers.items()
+            if fqn in nbt_fqns
+        }
+
+        gm = ep.graph_module
+
+        # Remove mutation outputs
+        output_node = gm.graph.output_node()
+        output_args = list(output_node.args[0])
+        for idx in sorted(
+            (
+                i
+                for i, n in enumerate(output_args)
+                if isinstance(n, torch.fx.Node) and n.name in nbt_output_names
+            ),
+            reverse=True,
+        ):
+            output_args.pop(idx)
+        output_node.args = (tuple(output_args),)
+
+        gm.graph.eliminate_dead_code()
+
+        removed_nbt_fqns: Set[str] = set()
+
+        # Remove dead input placeholders
+        for node in list(gm.graph.nodes):
+            if (
+                node.op == "placeholder"
+                and node.name in nbt_input_names
+                and len(node.users) == 0
+            ):
+                removed_nbt_fqns.add(ep.graph_signature.inputs_to_buffers[node.name])
+                gm.graph.erase_node(node)
+
+        gm.recompile()
+
+        # Update output specs
+        ep.graph_signature.output_specs = [
+            s
+            for s in ep.graph_signature.output_specs
+            if not (
+                s.kind == OutputKind.BUFFER_MUTATION
+                and s.target is not None
+                and s.target in nbt_fqns
+            )
+        ]
+
+        ep.graph_signature.input_specs = [
+            s
+            for s in ep.graph_signature.input_specs
+            if not (
+                s.kind == InputKind.BUFFER
+                and s.target is not None
+                and s.target in removed_nbt_fqns
+            )
+        ]
+
+        # Remove state for buffers whose placeholders were removed.
+        for fqn in removed_nbt_fqns:
+            ep.state_dict.pop(fqn, None)
+            ep.constants.pop(fqn, None)
+
+        return ExportedProgramPassResult(ep, True)
 
 
 class CadenceRemoveNops:

--- a/backends/cadence/aot/tests/test_fusion_ops_passes.py
+++ b/backends/cadence/aot/tests/test_fusion_ops_passes.py
@@ -14,6 +14,8 @@ from typing import cast, Final, List, Tuple
 
 import executorch.backends.cadence.aot.ops_registrations  # noqa
 import torch
+
+from executorch.backends.cadence.aot import compiler
 from executorch.backends.cadence.aot.fuse_ops import (
     FuseBatchNormWithConv,
     FuseCascadedTransposeOrPermuteOps,
@@ -34,6 +36,9 @@ from executorch.backends.cadence.aot.pass_utils import (
     get_arg,
     op_counts_match,
 )
+from executorch.backends.cadence.aot.quantizer.quantizer import (
+    CadenceFusedConvReluQuantizer,
+)
 from executorch.backends.cadence.aot.typing_stubs import expand
 from executorch.backends.test.graph_builder import GraphBuilder
 from executorch.exir.dialects._ops import ops as exir_ops
@@ -42,6 +47,11 @@ from executorch.exir.pass_base import PassResult, ProxyValue
 
 from parameterized import parameterized
 from torch.utils import _pytree as pytree
+from torchao.quantization.pt2e import (
+    allow_exported_model_train_eval,
+    move_exported_model_to_eval,
+)
+from torchao.quantization.pt2e.quantize_pt2e import convert_pt2e, prepare_qat_pt2e
 
 
 def validate_numerics(
@@ -1951,3 +1961,70 @@ class TestFuseSliceSameDimPass(TestFusionPassesBase):
             (torch.randn(2, 3, 4, 5),),
             "FuseSliceSameDimPass",
         )
+
+
+class ConvBNReluEndToEndFusionTest(unittest.TestCase):
+    """End-to-end: conv+bn+relu folds BatchNorm and fuses a quantized conv.
+
+    Guards the positive path against silent skips. The 3-op
+    ConvBNReluBasePattern only drives annotation; the BatchNorm must be folded
+    so the 2-op ConvReluBasePattern fuses the resulting conv+relu. PTQ folds BN
+    before annotation (torchao prepare_pt2e); QAT folds it across the QAT
+    conv-bn fusion (prepare_qat_pt2e + move_exported_model_to_eval), then
+    FuseQATConvBN / the edge passes. Both lower to the Cadence edge program and
+    assert a quantized conv is produced and no batch_norm survives.
+
+    The QAT recipe mirrors modai/quantization.py::prepare_qat: capture in train
+    mode without ops_to_keep (so conv decomposes to `convolution`, which the QAT
+    conv-bn matcher recognizes) and call allow_exported_model_train_eval so that
+    move_exported_model_to_eval actually moves BatchNorm to its eval form.
+    """
+
+    class ConvBNReluModel(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.conv = torch.nn.Conv2d(3, 8, kernel_size=3, padding=1)
+            self.bn = torch.nn.BatchNorm2d(8)
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            return torch.relu(self.bn(self.conv(x)))
+
+    def _assert_fused_conv_no_bn(self, gm: torch.fx.GraphModule) -> None:
+        targets = [str(n.target) for n in gm.graph.nodes if n.op == "call_function"]
+        quantized_convs = [t for t in targets if "quantized" in t and "conv" in t]
+        self.assertGreaterEqual(
+            len(quantized_convs),
+            1,
+            f"expected a fused quantized conv, got call_function targets: {targets}",
+        )
+        batch_norms = [t for t in targets if "batch_norm" in t]
+        self.assertEqual(
+            len(batch_norms), 0, f"BatchNorm was not folded: {batch_norms}"
+        )
+
+    def test_ptq_conv_bn_relu_fuses(self) -> None:
+        model = self.ConvBNReluModel().eval()
+        inputs = (torch.randn(1, 3, 16, 16),)
+        fused = compiler.quantize_pt2(model, inputs, CadenceFusedConvReluQuantizer())
+        cadence_prog = compiler._lower_ep_to_cadence(fused)
+        self._assert_fused_conv_no_bn(cadence_prog.exported_program().graph_module)
+
+    def test_qat_conv_bn_relu_fuses(self) -> None:
+        model = self.ConvBNReluModel()
+        model.train()
+        inputs = (torch.randn(1, 3, 16, 16),)
+        quantizer = CadenceFusedConvReluQuantizer(is_qat=True)
+
+        captured = torch.export.export(model, inputs, strict=True).module()
+        prepared = prepare_qat_pt2e(captured, quantizer)
+        allow_exported_model_train_eval(prepared)
+        torch.quantization.enable_fake_quant(prepared)
+        for _ in range(3):
+            prepared(*inputs)
+        move_exported_model_to_eval(prepared)
+        converted = convert_pt2e(prepared)
+
+        exported = torch.export.export(converted, inputs)
+        fused = compiler.apply_pre_edge_transform_passes(exported, quantizer)
+        cadence_prog = compiler._lower_ep_to_cadence(fused)
+        self._assert_fused_conv_no_bn(cadence_prog.exported_program().graph_module)

--- a/backends/cadence/aot/tests/test_quantizer_ops.py
+++ b/backends/cadence/aot/tests/test_quantizer_ops.py
@@ -13,7 +13,10 @@ from typing import Callable
 
 import torch
 from executorch.backends.cadence.aot.quantizer import quantizer as quantizer_module
-from executorch.backends.cadence.aot.quantizer.patterns import AddmmPattern
+from executorch.backends.cadence.aot.quantizer.patterns import (
+    AddmmPattern,
+    Conv2dBNReluPattern0,
+)
 from executorch.backends.cadence.aot.quantizer.quantizer import (
     CadenceAtenQuantizer,
     CadenceDefaultQuantizer,
@@ -241,6 +244,15 @@ QUANTIZER_ANNOTATION_TEST_CASES: list[
         torch.ops.aten.relu.default,
         qconfig_A8W8sym.output_activation,
         # For fused conv2d+relu: [input_activation, weight] from conv2d node
+        [qconfig_A8W8sym.input_activation, qconfig_A8W8sym.weight],
+    ),
+    (
+        "fused_conv1d_bn_relu_A8W8sym",
+        lambda self: self._build_conv1d_bn_relu_graph(),
+        CadenceFusedConvReluQuantizer(),
+        torch.ops.aten.relu.default,
+        qconfig_A8W8sym.output_activation,
+        # For fused conv1d+bn+relu: [input_activation, weight] from conv1d node
         [qconfig_A8W8sym.input_activation, qconfig_A8W8sym.weight],
     ),
 ]
@@ -665,6 +677,64 @@ class QuantizerAnnotationTest(unittest.TestCase):
 
         return gm, relu_nodes[0], conv1d_nodes[0]
 
+    def _build_conv1d_bn_relu_graph(
+        self,
+    ) -> tuple[torch.fx.GraphModule, torch.fx.Node, torch.fx.Node]:
+        """Build a graph with conv1d + batch_norm + relu (3-op fused pattern)."""
+        builder = GraphBuilder()
+        x = builder.placeholder("x", torch.randn(1, 3, 10))
+        weight = builder.placeholder("weight", torch.randn(6, 3, 3))
+        bn_weight = builder.placeholder("bn_weight", torch.randn(6))
+        bn_bias = builder.placeholder("bn_bias", torch.randn(6))
+        bn_running_mean = builder.placeholder("bn_running_mean", torch.randn(6))
+        bn_running_var = builder.placeholder(
+            "bn_running_var", torch.abs(torch.randn(6))
+        )
+        conv1d = builder.call_operator(
+            op=torch.ops.aten.conv1d.default,
+            args=(x, weight),
+            meta=NodeMetadata(
+                {"source_fn_stack": [("conv1d", torch.ops.aten.conv1d.default)]}
+            ),
+        )
+        batch_norm = builder.call_operator(
+            op=torch.ops.aten.batch_norm.default,
+            args=(
+                conv1d,
+                bn_weight,
+                bn_bias,
+                bn_running_mean,
+                bn_running_var,
+                False,
+                0.1,
+                1e-5,
+                False,
+            ),
+            meta=NodeMetadata(
+                {"source_fn_stack": [("batch_norm", torch.ops.aten.batch_norm.default)]}
+            ),
+        )
+        relu = builder.call_operator(
+            op=torch.ops.aten.relu.default,
+            args=(batch_norm,),
+            meta=NodeMetadata(
+                {"source_fn_stack": [("relu", torch.ops.aten.relu.default)]}
+            ),
+        )
+        builder.output([relu])
+        gm = builder.get_graph_module()
+
+        relu_nodes = gm.graph.find_nodes(
+            op="call_function", target=torch.ops.aten.relu.default
+        )
+        self.assertEqual(len(relu_nodes), 1)
+        conv1d_nodes = gm.graph.find_nodes(
+            op="call_function", target=torch.ops.aten.conv1d.default
+        )
+        self.assertEqual(len(conv1d_nodes), 1)
+
+        return gm, relu_nodes[0], conv1d_nodes[0]
+
     @parameterized.expand(QUANTIZER_ANNOTATION_TEST_CASES)
     def test_quantizer_annotation(
         self,
@@ -813,6 +883,92 @@ class QuantizerOpsPreserveTest(unittest.TestCase):
             torch.ops.aten.rms_norm.default,
         ]
         self.assertCountEqual(actual, expected)
+
+
+class ConvBNReluFusionTest(unittest.TestCase):
+    """Tests for ConvBNReluBasePattern.fuse() correctness.
+
+    A BatchNorm sitting between conv and relu must be folded by an upstream
+    float-level pass (torchao prepare_pt2e for PTQ, FuseQATConvBN for QAT)
+    before quantizer fusion runs. If a real batch_norm survives to fuse(),
+    folding it into the already-quantized conv is not supported here, so fuse()
+    must decline rather than silently drop the BatchNorm affine (which would
+    corrupt numerics).
+    """
+
+    def _build_dq_conv_bn_relu_q_graph(
+        self,
+    ) -> tuple[torch.fx.GraphModule, torch.fx.Node]:
+        builder = GraphBuilder()
+        x_q = builder.placeholder(
+            "x_q", torch.randint(-128, 127, (1, 3, 8, 8), dtype=torch.int8)
+        )
+        w_q = builder.placeholder(
+            "w_q", torch.randint(-127, 127, (6, 3, 3, 3), dtype=torch.int8)
+        )
+        bn_weight = builder.placeholder("bn_weight", torch.randn(6))
+        bn_bias = builder.placeholder("bn_bias", torch.randn(6))
+        bn_mean = builder.placeholder("bn_mean", torch.randn(6))
+        bn_var = builder.placeholder("bn_var", torch.rand(6) + 1.0)
+
+        dq_input = builder.call_operator(
+            op=torch.ops.quantized_decomposed.dequantize_per_tensor.default,
+            args=(x_q, 0.1, 0, -128, 127, torch.int8),
+        )
+        dq_weight = builder.call_operator(
+            op=torch.ops.quantized_decomposed.dequantize_per_tensor.default,
+            args=(w_q, 0.05, 0, -127, 127, torch.int8),
+        )
+        conv = builder.call_operator(
+            op=torch.ops.aten.conv2d.default,
+            args=(dq_input, dq_weight),
+            meta=NodeMetadata(
+                {"source_fn_stack": [("conv2d", torch.ops.aten.conv2d.default)]}
+            ),
+        )
+        bn = builder.call_operator(
+            op=torch.ops.aten.batch_norm.default,
+            args=(conv, bn_weight, bn_bias, bn_mean, bn_var, False, 0.1, 1e-5, True),
+        )
+        relu = builder.call_operator(
+            op=torch.ops.aten.relu.default,
+            args=(bn,),
+        )
+        # out_zero_point == -128 keeps check_out_zero_point_is_min_range happy so
+        # fuse() would proceed to fuse_conv if it did not bail on the BatchNorm.
+        q = builder.call_operator(
+            op=torch.ops.quantized_decomposed.quantize_per_tensor.default,
+            args=(relu, 0.2, -128, -128, 127, torch.int8),
+        )
+        builder.output([q])
+        gm = builder.get_graph_module()
+
+        conv_nodes = gm.graph.find_nodes(
+            op="call_function", target=torch.ops.aten.conv2d.default
+        )
+        self.assertEqual(len(conv_nodes), 1, "Should find exactly one conv2d node")
+        return gm, conv_nodes[0]
+
+    def test_fuse_declines_when_batchnorm_present(self) -> None:
+        gm, conv_node = self._build_dq_conv_bn_relu_q_graph()
+
+        result = Conv2dBNReluPattern0().fuse(gm, conv_node)
+
+        # A real BatchNorm survived to fusion time: fuse() must decline rather
+        # than fold it away into a quantized conv.
+        self.assertIsNone(result)
+        bn_nodes = gm.graph.find_nodes(
+            op="call_function", target=torch.ops.aten.batch_norm.default
+        )
+        self.assertEqual(len(bn_nodes), 1, "BatchNorm must not be dropped")
+        fused_nodes = [
+            n
+            for n in gm.graph.nodes
+            if n.op == "call_function" and "quantized_conv" in str(n.target)
+        ]
+        self.assertEqual(
+            len(fused_nodes), 0, "conv must not be fused while BatchNorm is present"
+        )
 
 
 if __name__ == "__main__":

--- a/backends/cadence/aot/tests/test_remove_bn_tracking_pass.py
+++ b/backends/cadence/aot/tests/test_remove_bn_tracking_pass.py
@@ -1,0 +1,209 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+
+import torch
+import torch.nn as nn
+import torchao
+from executorch.backends.cadence.aot.remove_ops import RemoveBNTrackingMutationsPass
+from executorch.exir import to_edge
+from torch.export.graph_signature import InputKind, OutputKind
+from torchao.quantization.pt2e.quantize_pt2e import convert_pt2e, prepare_pt2e
+
+
+class SimpleBNModel(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.conv = nn.Conv1d(3, 8, kernel_size=3, padding=1)
+        self.bn = nn.BatchNorm1d(8)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.relu(self.bn(self.conv(x)))
+
+
+class MultiBNModel(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.conv1 = nn.Conv1d(3, 8, kernel_size=3, padding=1)
+        self.bn1 = nn.BatchNorm1d(8)
+        self.conv2 = nn.Conv1d(8, 16, kernel_size=3, padding=1)
+        self.bn2 = nn.BatchNorm1d(16)
+        self.fc = nn.Linear(16, 4)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = torch.relu(self.bn1(self.conv1(x)))
+        x = torch.relu(self.bn2(self.conv2(x)))
+        x = x.mean(dim=-1)
+        return self.fc(x)
+
+
+class ReadBNTrackingModel(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.bn = nn.BatchNorm1d(3)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        num_batches_tracked = self.bn.num_batches_tracked
+        assert num_batches_tracked is not None
+        return self.bn(x) + num_batches_tracked.to(dtype=x.dtype)
+
+
+def _qat_export_to_edge(
+    model: nn.Module,
+    example_input: tuple[torch.Tensor, ...],
+) -> torch.export.ExportedProgram:
+    """Simulate the QAT export path that produces BN tracking mutations.
+
+    QAT models are traced in training mode (model.train()), then converted
+    back to eval via move_exported_model_to_eval(). run_decompositions()
+    in to_edge() then re-introduces num_batches_tracked mutations.
+    """
+    from executorch.backends.cadence.aot.quantizer.quantizer import (
+        CadenceFusedConvReluQuantizer,
+    )
+
+    model.train()
+    captured = torch.export.export(model, example_input, strict=False).module()
+    prepared = prepare_pt2e(captured, CadenceFusedConvReluQuantizer(is_qat=True))
+
+    for _ in range(3):
+        prepared(*example_input)
+
+    torchao.quantization.pt2e.move_exported_model_to_eval(prepared)
+    converted = convert_pt2e(prepared)
+
+    exported = torch.export.export(converted, example_input)
+    edge = to_edge(exported)
+    return edge.exported_program()
+
+
+class RemoveBNTrackingMutationsTest(unittest.TestCase):
+    def _get_nbt_mutations(self, ep: torch.export.ExportedProgram) -> dict[str, str]:
+        return {
+            k: v
+            for k, v in ep.graph_signature.buffers_to_mutate.items()
+            if "num_batches_tracked" in v
+        }
+
+    def _get_nbt_placeholders(self, ep: torch.export.ExportedProgram) -> list[str]:
+        placeholders: list[str] = []
+        for n in ep.graph_module.graph.nodes:
+            if (
+                n.op == "placeholder"
+                and isinstance(n.target, str)
+                and "num_batches_tracked" in n.target
+            ):
+                placeholders.append(n.target)
+        return placeholders
+
+    def _get_nbt_input_specs(self, ep: torch.export.ExportedProgram) -> list[str]:
+        input_specs: list[str] = []
+        for s in ep.graph_signature.input_specs:
+            if (
+                s.kind == InputKind.BUFFER
+                and s.target is not None
+                and "num_batches_tracked" in s.target
+            ):
+                input_specs.append(s.target)
+        return input_specs
+
+    def _run_remove_pass_on_qat_model(
+        self,
+        model: nn.Module,
+        example_input: tuple[torch.Tensor, ...],
+    ) -> torch.export.ExportedProgram:
+        edge_ep = _qat_export_to_edge(model, example_input)
+        nbt = self._get_nbt_mutations(edge_ep)
+        self.assertGreater(
+            len(nbt), 0, "expected pre-pass num_batches_tracked mutations"
+        )
+
+        result = RemoveBNTrackingMutationsPass()(edge_ep)
+        self.assertTrue(result.modified)
+        return result.exported_program
+
+    def test_single_bn_no_tracking_mutations(self) -> None:
+        model = SimpleBNModel()
+        edge_ep = self._run_remove_pass_on_qat_model(model, (torch.randn(1, 3, 32),))
+        nbt = self._get_nbt_mutations(edge_ep)
+        self.assertEqual(len(nbt), 0, f"num_batches_tracked mutations present: {nbt}")
+
+    def test_multi_bn_no_tracking_mutations(self) -> None:
+        model = MultiBNModel()
+        edge_ep = self._run_remove_pass_on_qat_model(model, (torch.randn(1, 3, 32),))
+        nbt = self._get_nbt_mutations(edge_ep)
+        self.assertEqual(len(nbt), 0, f"num_batches_tracked mutations present: {nbt}")
+
+    def test_no_nbt_output_specs(self) -> None:
+        model = MultiBNModel()
+        edge_ep = self._run_remove_pass_on_qat_model(model, (torch.randn(1, 3, 32),))
+        nbt_specs = [
+            s
+            for s in edge_ep.graph_signature.output_specs
+            if s.kind == OutputKind.BUFFER_MUTATION
+            and s.target is not None
+            and "num_batches_tracked" in s.target
+        ]
+        self.assertEqual(
+            len(nbt_specs), 0, f"num_batches_tracked output specs present: {nbt_specs}"
+        )
+
+    def test_no_nbt_input_placeholders(self) -> None:
+        """All num_batches_tracked input placeholders should be removed."""
+        model = MultiBNModel()
+        edge_ep = self._run_remove_pass_on_qat_model(model, (torch.randn(1, 3, 32),))
+        nbt_placeholders = self._get_nbt_placeholders(edge_ep)
+        self.assertEqual(
+            len(nbt_placeholders),
+            0,
+            f"num_batches_tracked placeholders still present: {nbt_placeholders}",
+        )
+
+    def test_no_nbt_input_specs(self) -> None:
+        """No input_specs for num_batches_tracked buffers should remain."""
+        model = MultiBNModel()
+        edge_ep = self._run_remove_pass_on_qat_model(model, (torch.randn(1, 3, 32),))
+        nbt_input_specs = self._get_nbt_input_specs(edge_ep)
+        self.assertEqual(
+            len(nbt_input_specs),
+            0,
+            f"num_batches_tracked input specs still present: {nbt_input_specs}",
+        )
+
+    def test_live_nbt_input_spec_preserved(self) -> None:
+        model = ReadBNTrackingModel()
+        edge_ep = self._run_remove_pass_on_qat_model(model, (torch.randn(1, 3, 32),))
+
+        nbt_placeholders = self._get_nbt_placeholders(edge_ep)
+        nbt_input_specs = self._get_nbt_input_specs(edge_ep)
+        self.assertGreater(
+            len(nbt_placeholders),
+            0,
+            "expected live num_batches_tracked placeholder to remain",
+        )
+        self.assertEqual(len(nbt_placeholders), len(nbt_input_specs))
+
+    def test_no_bn_model_unaffected(self) -> None:
+        class NoBNModel(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.linear = nn.Linear(8, 4)
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return self.linear(x)
+
+        model = NoBNModel()
+        model.eval()
+        ep = torch.export.export(model, (torch.randn(1, 8),))
+        edge_ep = to_edge(ep).exported_program()
+        result = RemoveBNTrackingMutationsPass()(edge_ep)
+        self.assertFalse(result.modified)
+        self.assertEqual(
+            len(result.exported_program.graph_signature.buffers_to_mutate), 0
+        )


### PR DESCRIPTION
Summary:

`run_decompositions({})` in core PyTorch re-introduces `num_batches_tracked` mutable buffer outputs even when `batch_norm` uses `training=False`. This happens because the AOTAutograd functionalization pass unconditionally captures `BatchNorm`'s `num_batches_tracked` as a mutable buffer. The `to_edge_transform_and_lower` path avoids this, but the separate `to_edge()` path hits it.

Add a pass to `remove_ops.py` that strips `num_batches_tracked` buffer mutations from ExportedPrograms. We use the full ExportedProgramPassBase instead of just ExportPass so that we have access to the full program and signature, as we remove part of the input/output spec.

Add tests for a pass that removes `num_batches_tracked` buffer mutations from the edge program.

Reviewed By: ethansfng

Differential Revision: D107395650


