### PR TITLE
[ET-VK][q8ta] Fix Adreno pipeline-compile crash in q8ta_pixel_shuffle

### DIFF
--- a/backends/vulkan/runtime/graph/ops/glsl/q8ta_pixel_shuffle.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/q8ta_pixel_shuffle.glsl
@@ -122,7 +122,7 @@ void main() {
   // helper call needed. (Assumes r*r == inner_block_size == 4, enforced by the
   // C++ dispatch's r==2 and packed_dim_block_size==4 asserts.)
   const int byte_stride =
-      int(stride_at(inp, get_packed_dim(inp_layout))) * get_block_numel(inp_layout);
+      int(safe_idx(inp.strides[0], get_packed_dim(inp_layout))) * get_block_numel(inp_layout);
 
   // lane is the byte position within an int32 word, which equals
   // (intra_block_idx % 4) since block_numel is a multiple of 4. And


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #19989

The `q8ta_pixel_shuffle` shader crashed the Adreno 740 driver (Snapdragon 8 Gen 2, Galaxy S23) inside `CreateQGLCProgram` / `vkCreateComputePipelines` with a null-pointer SIGSEGV during pipeline compilation at `load_method`. This made the person_seg_v21 Vulkan model fail to load.

Root cause is the known Adreno A740 driver-compiler bug: dynamically indexing a UBO-backed vector with a specialization-constant-derived index. Line 124 used `stride_at(inp, get_packed_dim(inp_layout))`, which expands to `inp.strides[div_4(dim)][mod_4(dim)]` and dynamically indexes the UBO-backed strides vector by `get_packed_dim(inp_layout)` (= 2 for channels-packed). Other q8ta shaders compile fine because they use literal indices, and the sibling helpers in `block_load.glslh` / `block_store.glslh` were already hardened for this exact pattern with `safe_idx`.

The fix replaces the call with `safe_idx(inp.strides[0], get_packed_dim(inp_layout))`. Since the packed dim is a WHCN index in [0,3], `div_4(dim) == 0` and `mod_4(dim) == dim`, so `stride_at` was already only ever reading `inp.strides[0]`; `safe_idx` resolves the component access via an if/else chain at pipeline-creation time (zero runtime cost) and returns a bit-for-bit identical `byte_stride`. This mirrors the hardened pattern already used elsewhere in the backend.

Differential Revision: [D107443710](https://our.internmc.facebook.com/intern/diff/D107443710/)