### PR TITLE
[CI][binary-size] Wire bloaty measurement into linux size jobs

### DIFF
--- a/.ci/scripts/bloaty-measure.sh
+++ b/.ci/scripts/bloaty-measure.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Usage: bash .ci/scripts/bloaty-measure.sh <job_name> <head_elf> <strip_tool>
+#
+# Runs bloaty against the head ELF, writes metadata.json + full.txt +
+# head_only.txt to artifacts-to-be-uploaded/, and appends a markdown table
+# to $GITHUB_STEP_SUMMARY.
+#
+# Best-effort: never exits non-zero — the size jobs that source this should
+# not fail because of a bloaty hiccup.
+
+set -uo pipefail
+
+job_name=$1
+head_elf=$2
+strip_tool=$3
+head_sha=${GITHUB_HEAD_SHA:-${GITHUB_SHA:-unknown}}
+
+(
+  # conda-forge bloaty depends on a newer libstdc++ than the ubuntu-22.04
+  # docker images ship, so pull libstdcxx-ng into the same env and invoke
+  # via `conda run` so library paths are set correctly.
+  bloaty_env=/tmp/bloaty-conda-env
+  if [[ ! -x "${bloaty_env}/bin/bloaty" ]]; then
+    conda create -y -p "${bloaty_env}" -c conda-forge bloaty libstdcxx-ng || exit 1
+  fi
+  bloaty_cmd=("conda" "run" "--no-capture-output" "-p" "${bloaty_env}" "bloaty")
+  "${bloaty_cmd[@]}" --version || exit 1
+
+  tmp_out=/tmp/bloaty-out
+  rm -rf "${tmp_out}" && mkdir -p "${tmp_out}"
+  BLOATY="${bloaty_cmd[*]}" python3 .github/scripts/bloaty_diff.py measure \
+    --head "${head_elf}" \
+    --job "${job_name}" \
+    --binary-name size_test \
+    --head-sha "${head_sha}" \
+    --strip-tool "${strip_tool}" \
+    --out "${tmp_out}" || exit 1
+  mkdir -p artifacts-to-be-uploaded
+  mv "${tmp_out}"/* artifacts-to-be-uploaded/
+) || echo "bloaty report failed; continuing"

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -484,6 +484,7 @@ jobs:
       submodules: 'recursive'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout: 90
+      upload-artifact: bloaty-linux-gcc
       script: |
         # The generic Linux job chooses to use base env, not the one setup by the image
         CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
@@ -492,6 +493,13 @@ jobs:
         ./install_requirements.sh
         # build module for executorch.extension.pybindings.portable_lib
         bash test/build_size_test.sh
+
+        # Bloaty per-bucket size report (best-effort; never fails the size job).
+        mkdir -p /tmp/bloaty-elfs
+        cp cmake-out/test/size_test /tmp/bloaty-elfs/head.elf
+        GITHUB_HEAD_SHA="${{ github.event.pull_request.head.sha || github.sha }}" \
+          bash .ci/scripts/bloaty-measure.sh "linux-gcc" /tmp/bloaty-elfs/head.elf strip
+
         strip cmake-out/test/size_test
         output=$(ls -la cmake-out/test/size_test)
         arr=($output)
@@ -519,6 +527,7 @@ jobs:
       submodules: 'recursive'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout: 90
+      upload-artifact: bloaty-linux-clang
       script: |
         # The generic Linux job chooses to use base env, not the one setup by the image
         CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
@@ -528,6 +537,13 @@ jobs:
 
         # build module for executorch.extension.pybindings.portable_lib
         bash test/build_size_test.sh
+
+        # Bloaty per-bucket size report (best-effort; never fails the size job).
+        mkdir -p /tmp/bloaty-elfs
+        cp cmake-out/test/size_test /tmp/bloaty-elfs/head.elf
+        GITHUB_HEAD_SHA="${{ github.event.pull_request.head.sha || github.sha }}" \
+          bash .ci/scripts/bloaty-measure.sh "linux-clang" /tmp/bloaty-elfs/head.elf strip
+
         strip cmake-out/test/size_test
         output=$(ls -la cmake-out/test/size_test)
         arr=($output)
@@ -618,28 +634,8 @@ jobs:
         # Runs BEFORE the in-place strip below so the head ELF is still unstripped.
         mkdir -p /tmp/bloaty-elfs
         cp "${elf}" /tmp/bloaty-elfs/head.elf
-        (
-          # conda-forge bloaty depends on a newer libstdc++ than the docker image
-          # ships, so pull libstdcxx-ng into the same env and invoke via `conda run`.
-          bloaty_env=/tmp/bloaty-conda-env
-          if [[ ! -x "${bloaty_env}/bin/bloaty" ]]; then
-            conda create -y -p "${bloaty_env}" -c conda-forge bloaty libstdcxx-ng || exit 1
-          fi
-          bloaty_cmd=("conda" "run" "--no-capture-output" "-p" "${bloaty_env}" "bloaty")
-          "${bloaty_cmd[@]}" --version || exit 1
-
-          tmp_out=/tmp/bloaty-out
-          rm -rf "${tmp_out}" && mkdir -p "${tmp_out}"
-          BLOATY="${bloaty_cmd[*]}" python3 .github/scripts/bloaty_diff.py measure \
-            --head /tmp/bloaty-elfs/head.elf \
-            --job "arm-${{ matrix.os }}" \
-            --binary-name size_test \
-            --head-sha "${{ github.event.pull_request.head.sha || github.sha }}" \
-            --strip-tool "${toolchain_prefix}strip" \
-            --out "${tmp_out}" || exit 1
-          mkdir -p artifacts-to-be-uploaded
-          mv "${tmp_out}"/* artifacts-to-be-uploaded/
-        ) || echo "bloaty report failed; continuing"
+        GITHUB_HEAD_SHA="${{ github.event.pull_request.head.sha || github.sha }}" \
+          bash .ci/scripts/bloaty-measure.sh "arm-${{ matrix.os }}" /tmp/bloaty-elfs/head.elf "${toolchain_prefix}strip"
 
         # Add basic guard - TODO: refine this!
         ${toolchain_prefix}strip ${elf}


### PR DESCRIPTION
### Summary
Extracts the bloaty-measure shell fragment into .ci/scripts/bloaty-measure.sh and calls it from all three size jobs (arm-bare-metal/zephyr matrix + linux-gcc + linux-clang). Each job now uploads a bloaty-<job> artifact with metadata.json + full.txt + head_only.txt and emits a per-bucket markdown table to its GitHub Actions step summary.

No gate change. The existing `ls -la` threshold checks are untouched and will be replaced by per-bucket gating in a later PR in this stack.

### Test plan
Validate remaining size jobs now have step summaries and bloaty artifacts.

Authored with Claude.