### PR TITLE
Arm backend: implement EthosUBackend::is_available() hardware check

### DIFF
--- a/backends/arm/runtime/EthosUBackend.cpp
+++ b/backends/arm/runtime/EthosUBackend.cpp
@@ -76,8 +76,7 @@ class EthosUBackend final : public ::executorch::runtime::BackendInterface {
   ~EthosUBackend() = default;
 
   virtual bool is_available() const override {
-    // TODO: revise to use a register check/init function
-    return 1;
+    return platform_is_available();
   }
 
   Result<DelegateHandle*> init(

--- a/backends/arm/runtime/EthosUBackend_Cortex_A.cpp
+++ b/backends/arm/runtime/EthosUBackend_Cortex_A.cpp
@@ -323,6 +323,23 @@ Error invoke_linux_driver(
 }
 } // namespace
 
+bool platform_is_available() {
+  // Open the NPU device driver; thrown if it is absent or unopenable.
+  const LinuxDriverOptions defaults;
+  try {
+    EthosU::Device device(defaults.device_path.c_str());
+    (void)device;
+    return true;
+  } catch (const std::exception& e) {
+    ET_LOG(
+        Info,
+        "Ethos-U device %s not available: %s",
+        defaults.device_path.c_str(),
+        e.what());
+    return false;
+  }
+}
+
 PlatformState* platform_init(
     ArrayRef<CompileSpec> specs,
     MemoryAllocator* allocator) {

--- a/backends/arm/runtime/EthosUBackend_Cortex_M.cpp
+++ b/backends/arm/runtime/EthosUBackend_Cortex_M.cpp
@@ -54,6 +54,21 @@ namespace arm {
 
 struct PlatformState {};
 
+// TODO: Upstream ethosu_driver_is_registered() into the core driver.
+// Keep the weak fallback until all builds are confirmed to be using a driver
+// with ethosu_driver_is_registered() implemented, at which point the weak
+// fallback can be removed.
+extern "C" __attribute__((weak)) bool ethosu_driver_is_registered(void) {
+  return true;
+}
+
+bool platform_is_available() {
+  // Check whether ethosu_init() was called before ExecuTorch runs.
+  // If ethosu_init() was not called and this unconditionally returned true,
+  // then the firmware freezes without any error.
+  return ethosu_driver_is_registered();
+}
+
 PlatformState* platform_init(
     executorch::runtime::ArrayRef<executorch::runtime::CompileSpec> /*specs*/,
     executorch::runtime::MemoryAllocator* /*allocator*/) {

--- a/backends/arm/runtime/EthosUBackend_Internal.h
+++ b/backends/arm/runtime/EthosUBackend_Internal.h
@@ -77,6 +77,9 @@ extern unsigned char* ethosu_fast_scratch;
 extern size_t ethosu_fast_scratch_size;
 }
 
+// Returns whether the Ethos-U device driver is available
+bool platform_is_available();
+
 PlatformState* platform_init(
     executorch::runtime::ArrayRef<executorch::runtime::CompileSpec> specs,
     executorch::runtime::MemoryAllocator* allocator);


### PR DESCRIPTION
### Summary

`EthosUBackend::is_available()` returned `1` unconditionally. `Method::load()` calls `is_available()` before `init()` and returns `Error::NotFound` with a clear message when the backend is unavailable — but that check was never triggered.

The consequence differs by platform:
- **Cortex-M (baremetal):** `ethosu_init()` must be called by the firmware before ExecuTorch runs — it registers the NPU driver handle that `ethosu_reserve_driver()` later waits for. If it goes missing for some reason, the program hangs silently inside `ethosu_reserve_driver()` which waits forever on a semaphore. No error is returned, no log is produced, and the device appears frozen.
- **Cortex-A (Linux):** the device file `/dev/ethosu0` may be absent if the kernel module is not loaded. the error was logged but attributed to the driver invocation rather than to availability.

```mermaid
flowchart LR
    subgraph before["Before - is_available() = return 1"]
        direction TB
        B1["Method::load()"]
        B2["is_available()\nunconditionally returns true"]
        B3["init()\nexecute()"]
        B4["ethosu_reserve_driver()"]
        B5["invoke_linux_driver()\n-> cryptic driver error\nfails late"]
        SEM(["Semaphore count = 0\n==\nethosu_init() never called"])

        B1 --> B2 --> B3
        B3 -- Cortex-M --> B4
        B3 -- Cortex-A --> B5
        B4 -->|semaphore_take\nWAIT_FOREVER| SEM
        SEM -->|"🔄 spinning forever\nno error / no log"| SEM
    end

    subgraph after["After - is_available() checks hardware"]
        direction TB
        A1["Method::load()"]
        A2{"is_available()"}
        A3["ethosu_driver_is_registered()\nregistered_drivers == NULL"]
        A4["EthosU::Device('/dev/ethosu0')\nthrows if absent"]
        A5["Error::NotFound\n early / clear message"]

        A1 --> A2
        A2 -- Cortex-M --> A3
        A2 -- Cortex-A --> A4
        A3 -- false --> A5
        A4 -- throws --> A5
    end

    before ~~~ after
```

### Changes
- **Cortex-M** — adds `ethosu_driver_is_registered()` to `ethos-u-core-driver`. It checks `registered_drivers != NULL` — and answers "was `ethosu_init()` called?" The semaphore count is always `> 0` when `registered_drivers != NULL`, so a `true` return guarantees `ethosu_reserve_driver()` will not block.
- **Cortex-A** — probes the default device path by constructing `EthosU::Device`, which throws if the device is absent or unopenable.

| File | Change |
| --- | --- |
| `EthosUBackend_Internal.h` | Declare `platform_is_available()` |
| `EthosUBackend.cpp` | Replace "TODO" with actual implementation |
| `EthosUBackend_Cortex_M.cpp` | Implement via `ethosu_driver_is_registered()`; weak symbol fallback (`return true`) for build paths where the patch is not applied |
| `EthosUBackend_Cortex_A.cpp` | Implement via `EthosU::Device` probe |
| `corstone_utils.cmake` | Add `patch_repo` call for `core_software/core_driver` (Corstone SDK) |
| `examples/arm/ethos-u-setup/core_driver/0001-Add-ethosu_driver_is_registered.patch` | Add `ethosu_driver_is_registered()` to the driver; applied to both the Corstone SDK and Zephyr `hal_ethos_u` |
| `zephyr/CMakeLists.txt` | Apply the patch to `hal_ethos_u` at CMake configure time |

`ethosu_driver_is_registered()` is added via a patch file rather than an upstream contribution because ExecuTorch already uses this mechanism for the Ethos-U SDK. This PR extends the same pattern to `core_driver`.
The weak symbol ensures any other build path not reached by the patch degrades to `return true` rather than failing at link time.

### Tests
No tests added. Other backends like VGFBackend, XNNPACK, and MLX each have real `is_available()` implementations and were merged without tests.
The implementations here are similarly straightforward; I think end-to-end coverage would require disproportionate infrastructure for changes of this size.

```bash
$ lintrunner backends/arm/runtime/EthosUBackend*.cpp \
             backends/arm/runtime/EthosUBackend_Internal.h \
             backends/arm/scripts/corstone_utils.cmake
ok No lint issues.
```


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani