### PR TITLE
Arm backend: Enable and support KV cache on Llama

### DIFF
--- a/backends/arm/test/models/test_llama.py
+++ b/backends/arm/test/models/test_llama.py
@@ -34,7 +34,7 @@ from executorch.extension.llm.export.config.llm_config import LlmConfig
 from transformers import GenerationConfig, LlamaConfig, LlamaForCausalLM
 from transformers.integrations.executorch import TorchExportableModuleForDecoderOnlyLM
 
-input_t = Tuple[torch.Tensor]
+input_t = Tuple[torch.Tensor, ...]
 input_th = Tuple[torch.Tensor, torch.Tensor]
 
 # Add project dir to sys path to workaround importlib.import_module() conditions in model_factory.py
@@ -59,6 +59,15 @@ class HFPositionalAdapter(torch.nn.Module):
         else:
             cp = cache_position.to(torch.long)
         return self.inner(input_ids=input_ids, cache_position=cp)
+
+
+class LlamaPositionalAdapter(torch.nn.Module):
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+
+    def forward(self, tokens, input_pos):
+        return self.model(tokens, {"input_pos": input_pos})
 
 
 class TestLlama:
@@ -154,6 +163,7 @@ class TestLlama:
             params_file,
             "--model",
             model_name,
+            "--use_kv_cache",
         ]
 
         parser = build_args_parser()
@@ -161,6 +171,11 @@ class TestLlama:
         llm_config = LlmConfig.from_args(args)
 
         llama_model, llama_inputs, llama_meta = get_llama_model(llm_config)
+
+        if llm_config.model.use_kv_cache:
+            tokens, attn_options = llama_inputs
+            llama_model = LlamaPositionalAdapter(llama_model).eval()
+            llama_inputs = (tokens, attn_options["input_pos"])
 
         return llama_model, llama_inputs, llama_meta
 

--- a/backends/arm/test/tester/arm_tester.py
+++ b/backends/arm/test/tester/arm_tester.py
@@ -641,6 +641,18 @@ class ArmTester(tester.Tester):
                     test_stage.run_artifact(test_input)
                 )
 
+            # When we run with KV cache enabled, the model returns cache data in the results. This we need to strip away by extracting only USER_OUTPUT.
+            if hasattr(test_stage.artifact, "exported_program"):
+                output_specs = (
+                    test_stage.artifact.exported_program().graph_signature.output_specs
+                )
+                user_outputs = [
+                    output
+                    for output, spec in zip(test_outputs, output_specs)
+                    if spec.kind == OutputKind.USER_OUTPUT
+                ]
+                test_outputs = user_outputs
+
             logger.info(f"\n      Input: {original_input}")
             logger.info(f"\n Ref output: {reference_outputs}")
             logger.info(f"\nTest output: {test_outputs}")


### PR DESCRIPTION
- Run llama with use_kv_cache option
- Add LlamaPositionalAdapter to handle input_pos mismatch
- Extract USER_OUTPUT in arm test pipeline in order to avoid irrelevant cache data being accidentally analysed against the ref model

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani