### PR TITLE
Arm backend: Fix pre-push copyright header detection

### DIFF
--- a/backends/arm/scripts/pre-push
+++ b/backends/arm/scripts/pre-push
@@ -184,7 +184,8 @@ for COMMIT in ${COMMITS}; do
         esac
 
         file_header=$(head "$committed_file")
-        if ! echo "$file_header" | grep -qi "Arm"; then
+        arm_copyright_regex="Copyright .*Arm Limited and/or its affiliates"
+        if ! echo "$file_header" | grep -Eqi "$arm_copyright_regex"; then
             echo -e "${WARNING} No Arm copyright header in ${committed_file}"\
             " (skipping license year check)"
             continue


### PR DESCRIPTION
The license check used any Arm substring in the first header lines to decide whether a file had an Arm copyright header.

That misclassified files with includes such as arm_neon.h as having an Arm header, then failed them when the current Arm year was absent.

Match the actual Arm copyright line instead so non-Arm headers are skipped while real Arm headers still get the year check.


Change-Id: Iafda07d8e2cf379672939a268fc3c39fc0ab895e



cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani