### PR TITLE
Arm backend: fix executor runner PTE macro handling

### DIFF
--- a/examples/arm/executor_runner/CMakeLists.txt
+++ b/examples/arm/executor_runner/CMakeLists.txt
@@ -565,7 +565,7 @@ if(SEMIHOSTING)
   target_compile_definitions(arm_executor_runner PUBLIC SEMIHOSTING)
 endif()
 
-if(ET_PTE_FILE_PATH)
+if(NOT ET_MODEL_PTE_ADDR AND NOT "${ET_PTE_FILE_PATH}" STREQUAL "")
   target_compile_definitions(arm_executor_runner PUBLIC ET_COMPILED_PTE)
 endif()
 


### PR DESCRIPTION
- Avoid defining ET_COMPILED_PTE when ET_MODEL_PTE_ADDR is used so the build system does not create mutually exclusive runner modes.



cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani