### PR TITLE
Add Apple-accelerated implementations for ImageProcessor (#20037)

### DIFF
--- a/extension/image/CMakeLists.txt
+++ b/extension/image/CMakeLists.txt
@@ -6,26 +6,50 @@
 
 cmake_minimum_required(VERSION 3.19)
 
-# stb_image_resize: lightweight header-only library used by the resize step in
-# image_processor.cpp.
-include(FetchContent)
-FetchContent_Declare(
-  stb
-  GIT_REPOSITORY https://github.com/nothings/stb.git
-  GIT_TAG f0569113c93ad095470c54bf34a17b36646bbbb5
-)
-FetchContent_MakeAvailable(stb)
+if(APPLE)
+  enable_language(OBJCXX)
+  add_library(
+    extension_image image_processor_common.cpp image_processor_apple.cpp
+                    image_processor_apple_gpu.mm
+  )
+  set_source_files_properties(
+    image_processor_apple_gpu.mm PROPERTIES COMPILE_FLAGS "-fobjc-arc"
+  )
+  find_library(ACCELERATE_FRAMEWORK Accelerate REQUIRED)
+  find_library(COREGRAPHICS_FRAMEWORK CoreGraphics REQUIRED)
+  find_library(COREIMAGE_FRAMEWORK CoreImage REQUIRED)
+  find_library(COREVIDEO_FRAMEWORK CoreVideo REQUIRED)
+  find_library(FOUNDATION_FRAMEWORK Foundation REQUIRED)
+  target_link_libraries(
+    extension_image
+    PRIVATE ${ACCELERATE_FRAMEWORK} ${COREGRAPHICS_FRAMEWORK}
+            ${COREIMAGE_FRAMEWORK} ${COREVIDEO_FRAMEWORK}
+            ${FOUNDATION_FRAMEWORK}
+  )
+else()
+  # stb_image_resize: lightweight header-only library used by the resize step in
+  # image_processor.cpp. Only the portable (non-Apple) path uses stb; the Apple
+  # path resizes via vImage, so the fetch is scoped here to avoid downloading
+  # stb on Apple builds.
+  include(FetchContent)
+  FetchContent_Declare(
+    stb
+    GIT_REPOSITORY https://github.com/nothings/stb.git
+    GIT_TAG f0569113c93ad095470c54bf34a17b36646bbbb5
+  )
+  FetchContent_MakeAvailable(stb)
 
-add_library(extension_image image_processor_common.cpp image_processor.cpp)
+  add_library(extension_image image_processor_common.cpp image_processor.cpp)
+
+  # stb_image_resize.h lives under deprecated/ in current stb. Private: only the
+  # .cpp uses it, not the installed public headers.
+  target_include_directories(
+    extension_image PRIVATE ${stb_SOURCE_DIR} ${stb_SOURCE_DIR}/deprecated
+  )
+endif()
 
 target_include_directories(
   extension_image PUBLIC ${_common_include_directories}
-)
-
-# stb_image_resize.h lives under deprecated/ in current stb. Private: only the
-# .cpp uses it, not the installed public headers.
-target_include_directories(
-  extension_image PRIVATE ${stb_SOURCE_DIR} ${stb_SOURCE_DIR}/deprecated
 )
 
 target_link_libraries(extension_image PUBLIC executorch_core extension_tensor)
@@ -36,9 +60,16 @@ install(
   DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
 
-install(FILES image_processor.h image_processor_config.h
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/executorch/extension/image
-)
+if(APPLE)
+  install(FILES image_processor.h image_processor_config.h
+                image_processor_apple.h
+          DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/executorch/extension/image
+  )
+else()
+  install(FILES image_processor.h image_processor_config.h
+          DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/executorch/extension/image
+  )
+endif()
 
 if(BUILD_TESTING)
   add_subdirectory(test)

--- a/extension/image/image_processor_apple.cpp
+++ b/extension/image/image_processor_apple.cpp
@@ -1,0 +1,1332 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Apple-accelerated implementation of ImageProcessor. Compiled only on Apple
+// targets via build rules. The CPU pipeline uses Accelerate (vImage/vDSP) and
+// CoreGraphics, both pure C APIs; the GPU fast paths call into the Core Image
+// helpers in image_processor_apple_gpu.mm.
+//
+// Supported inputs:
+//   ColorFormat:     BGRA, RGBA
+//   YUVFormat:       NV12, NV21
+//   ResizeMode:      STRETCH, LETTERBOX
+//   LetterboxAnchor: CENTER, TOP_LEFT
+//   Orientation:     UP
+
+#include <executorch/extension/image/image_processor.h>
+#include <executorch/extension/image/image_processor_apple.h>
+
+#include <algorithm>
+#include <cstring>
+#include <memory>
+#include <vector>
+
+#include <Accelerate/Accelerate.h>
+#include <CoreGraphics/CoreGraphics.h>
+
+#if defined(__ARM_NEON)
+#include <arm_neon.h>
+#endif
+
+#include <executorch/runtime/core/error.h>
+#include <executorch/runtime/core/exec_aten/util/tensor_util.h>
+#include "image_processor_apple_gpu.h"
+
+namespace executorch {
+namespace extension {
+namespace image {
+
+using runtime::Error;
+using runtime::Result;
+
+namespace {
+
+// Standard video-range pixel range for ITU_R_601_4 YUV→RGB conversion. The
+// signal occupies [16, 235] (luma) / [16, 240] (chroma); vImage derives the
+// expansion gain from these bounds, mapping that range to the full [0, 255]
+// output. (Using full-range bounds here would apply unity gain and decode
+// video-range frames with washed-out contrast.)
+constexpr vImage_YpCbCrPixelRange kYpCbCrPixelRange_Video = {
+    .Yp_bias = 16,
+    .CbCr_bias = 128,
+    .YpRangeMax = 235,
+    .CbCrRangeMax = 240,
+    .YpMax = 235,
+    .YpMin = 16,
+    .CbCrMax = 240,
+    .CbCrMin = 16};
+
+// Full-range pixel range: luma and chroma span the entire [0, 255].
+constexpr vImage_YpCbCrPixelRange kYpCbCrPixelRange_Full = {
+    .Yp_bias = 0,
+    .CbCr_bias = 128,
+    .YpRangeMax = 255,
+    .CbCrRangeMax = 255,
+    .YpMax = 255,
+    .YpMin = 0,
+    .CbCrMax = 255,
+    .CbCrMin = 0};
+
+// Convert an Orientation to the EXIF orientation code (1-8) that the Core Image
+// helpers (ci_process_*) expect. The enum is laid out to match the EXIF
+// numbering; the cast's validity is anchored by the static_assert here, the one
+// place that knows both the enum and the EXIF contract.
+constexpr int32_t to_exif_orientation(Orientation orientation) {
+  static_assert(
+      static_cast<int32_t>(Orientation::UP) == 1,
+      "Orientation::UP must equal the EXIF code for up (1)");
+  return static_cast<int32_t>(orientation);
+}
+
+// CVPixelBuffer formats process_pixelbuffer can handle. Both the GPU and CPU
+// paths are limited to these, so the format is validated once up front.
+bool is_supported_pixel_format(OSType pixel_format) {
+  switch (pixel_format) {
+    case kCVPixelFormatType_32BGRA:
+    case kCVPixelFormatType_32RGBA:
+    case kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange:
+    case kCVPixelFormatType_420YpCbCr8BiPlanarFullRange:
+    case kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange:
+    case kCVPixelFormatType_420YpCbCr10BiPlanarFullRange:
+      return true;
+    default:
+      return false;
+  }
+}
+
+// Scratch buffer storage strategy.
+//
+// ImageProcessor owns an Impl struct (pImpl) containing the config plus
+// several ScratchBuffer<T> members for intermediate work in
+// process()/process_yuv(). Each ScratchBuffer reuses its allocation across
+// calls on the same processor; resize() reuses existing capacity and
+// shrinks if capacity > 4× needed AND > 1MB to bound peak memory.
+template <typename T>
+class ScratchBuffer {
+ public:
+  T* resize(size_t needed) {
+    constexpr size_t kShrinkThreshold = 1024 * 1024 / sizeof(T);
+    const bool shrink = capacity_ > needed * 4 && capacity_ > kShrinkThreshold;
+    if (needed > capacity_ || shrink) {
+      // new T[] leaves trivial T uninitialized (no zero-fill), matching a raw
+      // allocation; std::vector::resize would value-initialize on growth.
+      buf_.reset(needed ? new T[needed] : nullptr);
+      capacity_ = needed;
+    }
+    return buf_.get();
+  }
+  T* data() {
+    return buf_.get();
+  }
+
+ private:
+  std::unique_ptr<T[]> buf_;
+  size_t capacity_ = 0;
+};
+
+} // namespace
+
+// Platform-specific implementation for ImageProcessor (pImpl).
+//
+// One Impl instance per ImageProcessor. Buffers grow on demand and are
+// reused across calls on the same processor. NOT thread-safe: callers must
+// not call process()/process_yuv() on the same instance from multiple
+// threads (see image_processor.h).
+class ImageProcessor::Impl {
+ public:
+  ImageProcessorConfig config;
+  ScratchBuffer<uint8_t> conv; // to_bgra() output
+  ScratchBuffer<uint8_t> resized; // resize_and_pad_bgra() output
+  ScratchBuffer<uint8_t> scale_temp; // vImageScale_ARGB8888 temp buffer
+  ScratchBuffer<uint8_t> gpu_resized; // GPU path intermediate buffer
+  ScratchBuffer<uint8_t> bgra; // process_yuv() intermediate BGRA
+  ScratchBuffer<uint8_t> narrow_y; // P010→8-bit narrowed Y plane
+  ScratchBuffer<uint8_t> narrow_uv; // P010→8-bit narrowed CbCr plane
+  ScratchBuffer<uint8_t> uv_swap; // NV21→NV12 chroma-swapped CbCr plane
+
+  // Lazy force-CPU proxy used when the owning processor can use the GPU but a
+  // frame must run on the CPU pipeline (small input, GPU readback, or GPU
+  // failure). The proxy never attempts the GPU. Allocated on first need so
+  // CPU-only processors do not pay for it.
+  std::unique_ptr<ImageProcessor> cpu_proxy;
+};
+
+namespace {
+
+// Narrow a semi-planar 16-bit plane to 8-bit by taking the high byte of each
+// sample. P010 stores its 10 valid bits in the high bits of each 16-bit word,
+// so the high byte is the top 8 bits (matching the previous scalar `>> 8`).
+// Uses NEON (8 samples/iteration) where available, with a scalar fallback for
+// the row remainder and non-ARM targets.
+void narrow_plane_p010_to_8bit(
+    const uint8_t* src_base,
+    int32_t src_stride_bytes,
+    uint8_t* dst,
+    int32_t samples_per_row,
+    int32_t rows) {
+  for (int32_t row = 0; row < rows; ++row) {
+    const auto* src = reinterpret_cast<const uint16_t*>(
+        src_base + static_cast<size_t>(row) * src_stride_bytes);
+    uint8_t* d = dst + static_cast<size_t>(row) * samples_per_row;
+    int32_t i = 0;
+#if defined(__ARM_NEON)
+    for (; i + 8 <= samples_per_row; i += 8) {
+      vst1_u8(d + i, vshrn_n_u16(vld1q_u16(src + i), 8));
+    }
+#endif
+    for (; i < samples_per_row; ++i) {
+      d[i] = static_cast<uint8_t>(src[i] >> 8);
+    }
+  }
+}
+
+// Swap the two interleaved chroma channels (Cb<->Cr) of a CbCr8 plane into a
+// tightly-packed destination (stride = chroma_w * 2). Converts NV21 (Cr,Cb)
+// chroma to NV12 (Cb,Cr) so the standard NV12 conversion can be reused.
+// Swapping the chroma is the correct NV21 handling; swapping the decoded R/B is
+// not, because BT.601 weights Cr (->R) and Cb (->B) differently and the green
+// channel mixes both.
+//
+// Each CbCr pair is a 16-bit unit, so the swap is a byte reversal within each
+// halfword. NEON does 8 pairs (16 bytes) per vrev16q_u8; the scalar loop covers
+// the row remainder and non-ARM targets.
+void swap_chroma_cbcr(
+    const uint8_t* src,
+    int32_t src_stride,
+    uint8_t* dst,
+    int32_t chroma_w,
+    int32_t chroma_h) {
+  const int32_t row_bytes = chroma_w * 2;
+  for (int32_t row = 0; row < chroma_h; ++row) {
+    const uint8_t* s = src + static_cast<size_t>(row) * src_stride;
+    uint8_t* d = dst + static_cast<size_t>(row) * row_bytes;
+    int32_t i = 0;
+#if defined(__ARM_NEON)
+    for (; i + 16 <= row_bytes; i += 16) {
+      vst1q_u8(d + i, vrev16q_u8(vld1q_u8(s + i)));
+    }
+#endif
+    for (; i + 2 <= row_bytes; i += 2) {
+      d[i] = s[i + 1];
+      d[i + 1] = s[i];
+    }
+  }
+}
+
+// Convert BGRA/RGBA input to BGRA8888.
+// `height * dst_stride` bytes; `dst_stride` must be at least `width * 4`.
+Error to_bgra(
+    const uint8_t* src,
+    int32_t width,
+    int32_t height,
+    int32_t src_stride,
+    ColorFormat format,
+    uint8_t* dst,
+    size_t dst_stride) {
+  if (format == ColorFormat::BGRA) {
+    for (int32_t y = 0; y < height; ++y) {
+      std::memcpy(
+          dst + static_cast<size_t>(y) * dst_stride,
+          src + static_cast<size_t>(y) * src_stride,
+          static_cast<size_t>(width) * 4);
+    }
+    return Error::Ok;
+  }
+
+  // RGBA→BGRA: swap channels 0↔2 with vImage (NEON accelerated)
+  vImage_Buffer src_buf = {
+      const_cast<uint8_t*>(src),
+      static_cast<vImagePixelCount>(height),
+      static_cast<vImagePixelCount>(width),
+      static_cast<size_t>(src_stride)};
+  vImage_Buffer dst_buf = {
+      dst,
+      static_cast<vImagePixelCount>(height),
+      static_cast<vImagePixelCount>(width),
+      dst_stride};
+  const uint8_t permuteMap[4] = {2, 1, 0, 3}; // RGBA→BGRA
+  vImagePermuteChannels_ARGB8888(
+      &src_buf, &dst_buf, permuteMap, kvImageNoFlags);
+  return Error::Ok;
+}
+
+// GPU resize dimension parameters.
+struct GpuResizeDims {
+  int32_t resize_w, resize_h, final_w, final_h;
+};
+
+// Compute GPU resize dimensions. The GPU handles crop + resize; padding
+// (LETTERBOX) is applied during normalize.
+void compute_gpu_dims(
+    int32_t width,
+    int32_t height,
+    NormalizedRect roi,
+    const ImageProcessorConfig& config,
+    GpuResizeDims& out) {
+  const int32_t roi_w = static_cast<int32_t>(width * roi.width);
+  const int32_t roi_h = static_cast<int32_t>(height * roi.height);
+  compute_resize_dims(
+      roi_w,
+      roi_h,
+      config,
+      out.resize_w,
+      out.resize_h,
+      out.final_w,
+      out.final_h);
+}
+
+// Apply ROI crop on BGRA data via pointer arithmetic.
+// Updates cur_data/cur_w/cur_h in place; cur_stride is unchanged.
+void apply_roi_crop_bgra(
+    uint8_t*& cur_data,
+    int32_t& cur_w,
+    int32_t& cur_h,
+    int32_t cur_stride,
+    NormalizedRect roi) {
+  if (roi.x == 0.0f && roi.y == 0.0f && roi.width == 1.0f &&
+      roi.height == 1.0f) {
+    return;
+  }
+  const int32_t src_w = cur_w;
+  const int32_t src_h = cur_h;
+  // Guard against a sub-pixel ROI truncating to a zero-size crop, which would
+  // produce an empty buffer and a 0-dim resize; keep at least one pixel.
+  cur_w = std::max(1, static_cast<int32_t>(src_w * roi.width));
+  cur_h = std::max(1, static_cast<int32_t>(src_h * roi.height));
+  // Clamp the crop origin so the (min-1-clamped) crop stays inside the source.
+  // Without this, a high roi.x/roi.y can push the read window past the buffer
+  // end -> out-of-bounds read in the downstream resize.
+  const int32_t roi_x =
+      std::min(static_cast<int32_t>(src_w * roi.x), src_w - cur_w);
+  const int32_t roi_y =
+      std::min(static_cast<int32_t>(src_h * roi.y), src_h - cur_h);
+  cur_data = cur_data + roi_y * cur_stride + roi_x * 4;
+}
+
+// Result view into a thread-local BGRA buffer after resize.
+struct BgraView {
+  const uint8_t* data;
+  int32_t width, height, stride;
+};
+
+// Resize BGRA data using vImageScale (bilinear, NEON-accelerated).
+// Letterbox padding is applied during normalization so pad pixels get the
+// correct pad_value instead of being normalized from zero.
+//
+// Caller pre-sizes `dst` to at least `resize_h * resize_w * 4` bytes (where
+// resize_w/resize_h come from compute_resize_dims) and passes a
+// scale_temp buffer pointer (use compute_scale_temp_size to query the size,
+// or pass nullptr to skip the temp). Returns the BgraView plus final
+// dimensions via out params.
+Error resize_and_pad_bgra(
+    const uint8_t* src,
+    int32_t cur_w,
+    int32_t cur_h,
+    int32_t src_stride,
+    const ImageProcessorConfig& config,
+    uint8_t* dst,
+    size_t dst_stride,
+    void* scale_temp,
+    BgraView& result,
+    int32_t& final_w_out,
+    int32_t& final_h_out) {
+  int32_t resize_w, resize_h, final_w, final_h;
+  compute_resize_dims(
+      cur_w, cur_h, config, resize_w, resize_h, final_w, final_h);
+  final_w_out = final_w;
+  final_h_out = final_h;
+
+  vImage_Buffer src_buf = {
+      const_cast<uint8_t*>(src),
+      static_cast<vImagePixelCount>(cur_h),
+      static_cast<vImagePixelCount>(cur_w),
+      static_cast<size_t>(src_stride)};
+  vImage_Buffer dst_buf = {
+      dst,
+      static_cast<vImagePixelCount>(resize_h),
+      static_cast<vImagePixelCount>(resize_w),
+      dst_stride};
+
+  vImage_Error verr =
+      vImageScale_ARGB8888(&src_buf, &dst_buf, scale_temp, kvImageNoFlags);
+  ET_CHECK_OR_RETURN_ERROR(
+      verr == kvImageNoError, Internal, "vImageScale_ARGB8888 failed");
+
+  result.data = dst;
+  result.width = resize_w;
+  result.height = resize_h;
+  result.stride = static_cast<int32_t>(dst_stride);
+  return Error::Ok;
+}
+
+// Query the temp buffer size required by vImageScale_ARGB8888 (bilinear)
+// for the given source/destination dimensions. Returns 0 when no temp
+// buffer is needed.
+size_t compute_scale_temp_size(
+    int32_t src_w,
+    int32_t src_h,
+    int32_t dst_w,
+    int32_t dst_h) {
+  vImage_Buffer src_buf = {
+      nullptr,
+      static_cast<vImagePixelCount>(src_h),
+      static_cast<vImagePixelCount>(src_w),
+      static_cast<size_t>(src_w) * 4};
+  vImage_Buffer dst_buf = {
+      nullptr,
+      static_cast<vImagePixelCount>(dst_h),
+      static_cast<vImagePixelCount>(dst_w),
+      static_cast<size_t>(dst_w) * 4};
+  vImage_Error temp_size = vImageScale_ARGB8888(
+      &src_buf, &dst_buf, nullptr, kvImageGetTempBufferSize);
+  return temp_size > 0 ? static_cast<size_t>(temp_size) : 0;
+}
+
+// Deinterleave BGRA uint8 → planar RGB float with fused normalization.
+// Handles offset for letterbox padding.
+//
+// Per channel (R, G, B): vDSP_vfltu8 reads the matching byte from BGRA via
+// stride=4 and converts uint8→float, then vDSP_vsmsa applies the fused
+// affine `out = in * (scale_factor / std_dev) + (-mean / std_dev)` in-place.
+Error deinterleave_bgra_to_chw(
+    const uint8_t* bgra_data,
+    int32_t src_w,
+    int32_t src_h,
+    int32_t src_stride,
+    float* output,
+    int32_t final_w,
+    int32_t final_h,
+    int32_t offset_x,
+    int32_t offset_y,
+    const Normalization& norm) {
+  const size_t spatial = static_cast<size_t>(final_w) * final_h;
+
+  // Per-channel affine coefficients for `out = in * a + b`.
+  // BGRA byte layout: byte 0 = B, byte 1 = G, byte 2 = R; norm.{mean,std_dev}
+  // are indexed in RGB order (channel 0 = R, 1 = G, 2 = B).
+  const float a_r = norm.scale_factor / norm.std_dev[0];
+  const float a_g = norm.scale_factor / norm.std_dev[1];
+  const float a_b = norm.scale_factor / norm.std_dev[2];
+  const float b_r = -norm.mean[0] / norm.std_dev[0];
+  const float b_g = -norm.mean[1] / norm.std_dev[1];
+  const float b_b = -norm.mean[2] / norm.std_dev[2];
+
+  // When the bias is zero (e.g. zeroToOne / mean=0), a plain scale (vsmul) is
+  // cheaper than the fused scale+add (vsmsa).
+  const bool no_offset = (b_r == 0.0f && b_g == 0.0f && b_b == 0.0f);
+  auto scale_bias =
+      [no_offset](float* p, const float* a, const float* b, vDSP_Length n) {
+        if (no_offset) {
+          vDSP_vsmul(p, 1, a, p, 1, n);
+        } else {
+          vDSP_vsmsa(p, 1, a, b, p, 1, n);
+        }
+      };
+
+  // Output planes in CHW order: R, G, B. Each plane is final_w × final_h
+  // floats; we write a src_h × src_w region starting at (offset_y, offset_x).
+  float* r_plane = output + 0 * spatial;
+  float* g_plane = output + 1 * spatial;
+  float* b_plane = output + 2 * spatial;
+
+  // Fast path: source is contiguous and destination region is the entire
+  // plane (offsets 0, src dims == final dims).
+  if (src_stride == src_w * 4 && offset_x == 0 && offset_y == 0 &&
+      src_w == final_w && src_h == final_h) {
+    const vDSP_Length n = static_cast<vDSP_Length>(src_w) * src_h;
+    vDSP_vfltu8(bgra_data + 2, 4, r_plane, 1, n);
+    scale_bias(r_plane, &a_r, &b_r, n);
+    vDSP_vfltu8(bgra_data + 1, 4, g_plane, 1, n);
+    scale_bias(g_plane, &a_g, &b_g, n);
+    vDSP_vfltu8(bgra_data + 0, 4, b_plane, 1, n);
+    scale_bias(b_plane, &a_b, &b_b, n);
+    return Error::Ok;
+  }
+
+  // Slow path: row-by-row to handle stride padding and/or letterbox offsets.
+  for (int32_t y = 0; y < src_h; ++y) {
+    const uint8_t* src_row = bgra_data + y * src_stride;
+    const ptrdiff_t dst_off = (y + offset_y) * final_w + offset_x;
+    float* r_dst = r_plane + dst_off;
+    float* g_dst = g_plane + dst_off;
+    float* b_dst = b_plane + dst_off;
+    const vDSP_Length n = static_cast<vDSP_Length>(src_w);
+    vDSP_vfltu8(src_row + 2, 4, r_dst, 1, n);
+    scale_bias(r_dst, &a_r, &b_r, n);
+    vDSP_vfltu8(src_row + 1, 4, g_dst, 1, n);
+    scale_bias(g_dst, &a_g, &b_g, n);
+    vDSP_vfltu8(src_row + 0, 4, b_dst, 1, n);
+    scale_bias(b_dst, &a_b, &b_b, n);
+  }
+  return Error::Ok;
+}
+
+} // namespace
+
+// --- ImageProcessor class ---
+
+ImageProcessor::ImageProcessor() : impl_(std::make_unique<Impl>()) {}
+
+ImageProcessor::ImageProcessor(ImageProcessorConfig config)
+    : impl_(std::make_unique<Impl>()) {
+  impl_->config = config;
+}
+
+ImageProcessor::~ImageProcessor() = default;
+ImageProcessor::ImageProcessor(ImageProcessor&&) noexcept = default;
+ImageProcessor& ImageProcessor::operator=(ImageProcessor&&) noexcept = default;
+
+ImageProcessor::Impl& ImageProcessor::impl() const noexcept {
+  return *impl_;
+}
+
+const ImageProcessorConfig& ImageProcessor::config() const {
+  return impl_->config;
+}
+
+// --- File-local normalization helpers ---
+//
+// These back the Apple GPU/CPU pipelines and process_pixelbuffer(); they
+// are intentionally not part of the public surface (image_processor_apple.h
+// exposes only process_pixelbuffer).
+
+namespace {
+
+// Fill a caller-owned CHW float buffer from resized BGRA8 data. `out` must hold
+// 3*final_w*final_h floats. For LETTERBOX (content smaller than output) the pad
+// region is set to pad_value and content is placed at the anchor offset;
+// otherwise every element is written and the fill is skipped.
+Error normalize_bgra_into(
+    const ImageProcessor& proc,
+    const uint8_t* bgra_data,
+    int32_t width,
+    int32_t height,
+    int32_t final_w,
+    int32_t final_h,
+    int32_t stride,
+    float* out) {
+  ET_CHECK_OR_RETURN_ERROR(
+      bgra_data != nullptr, InvalidArgument, "data is null");
+  ET_CHECK_OR_RETURN_ERROR(
+      width <= final_w && height <= final_h,
+      InvalidArgument,
+      "data dimensions must not exceed final dimensions");
+
+  const auto& config = proc.config();
+  const size_t total = static_cast<size_t>(3) * final_w * final_h;
+
+  int32_t offset_x = 0, offset_y = 0;
+  if (width != final_w || height != final_h) {
+    std::fill(out, out + total, config.pad_value);
+    const auto offset = compute_letterbox_offset(
+        width, height, final_w, final_h, config.letterbox_anchor);
+    offset_x = offset.first;
+    offset_y = offset.second;
+  }
+
+  return deinterleave_bgra_to_chw(
+      bgra_data,
+      width,
+      height,
+      stride,
+      out,
+      final_w,
+      final_h,
+      offset_x,
+      offset_y,
+      config.normalization);
+}
+
+// CPU fallback that writes the normalized result into `out`. Routes through a
+// force-CPU proxy when the processor can use the GPU so its scratch is reused.
+Error process_bgra_cpu_only_into(
+    const ImageProcessor& proc,
+    const uint8_t* bgra,
+    int32_t width,
+    int32_t height,
+    NormalizedRect roi,
+    executorch::aten::Tensor& out) {
+  if (is_cpu_only(proc.config())) {
+    return proc.process_into(
+        bgra,
+        width,
+        height,
+        width * 4,
+        ColorFormat::BGRA,
+        out,
+        Orientation::UP,
+        roi);
+  }
+  auto& cpu_proxy = proc.impl().cpu_proxy;
+  if (!cpu_proxy) {
+    ImageProcessorConfig cpu_config = proc.config();
+    cpu_config.gpu_min_input_pixels = ImageProcessorConfig::kGpuNever;
+    cpu_proxy = std::make_unique<ImageProcessor>(cpu_config);
+  }
+  return cpu_proxy->process_into(
+      bgra,
+      width,
+      height,
+      width * 4,
+      ColorFormat::BGRA,
+      out,
+      Orientation::UP,
+      roi);
+}
+
+// Validate that `out` is a contiguous Float [1, 3, target_h, target_w] tensor.
+Error check_out_tensor(
+    const ImageProcessorConfig& config,
+    executorch::aten::Tensor& out) {
+  ET_CHECK_OR_RETURN_ERROR(
+      out.scalar_type() == executorch::aten::ScalarType::Float &&
+          out.dim() == 4 && out.size(0) == 1 && out.size(1) == 3 &&
+          out.size(2) == config.target_height &&
+          out.size(3) == config.target_width,
+      InvalidArgument,
+      "out must be a Float [1, 3, target_h, target_w] tensor");
+  // The CHW write indexes `out` as tightly packed; a non-contiguous tensor
+  // would scatter the result and corrupt memory.
+  ET_CHECK_OR_RETURN_ERROR(
+      executorch::ET_RUNTIME_NAMESPACE::tensor_is_contiguous(out),
+      InvalidArgument,
+      "out must be contiguous");
+  return Error::Ok;
+}
+
+} // namespace
+
+Error ImageProcessor::process_into(
+    const uint8_t* data,
+    int32_t width,
+    int32_t height,
+    int32_t stride_bytes,
+    ColorFormat input_format,
+    executorch::aten::Tensor& out,
+    Orientation /*orientation*/,
+    NormalizedRect roi) const {
+  const auto& config = impl_->config;
+  ET_CHECK_OR_RETURN_ERROR(data != nullptr, InvalidArgument, "data is null");
+  ET_CHECK_OR_RETURN_ERROR(
+      width > 0 && height > 0, InvalidArgument, "invalid dimensions");
+  ET_CHECK_OR_RETURN_ERROR(
+      config.target_width > 0 && config.target_height > 0,
+      InvalidArgument,
+      "invalid target dimensions");
+  // The fused normalization divides by std_dev per channel. The factories
+  // guarantee nonzero, but a hand-rolled Normalization could pass a 0.
+  for (int32_t c = 0; c < 3; ++c) {
+    ET_CHECK_OR_RETURN_ERROR(
+        config.normalization.std_dev[c] != 0.0f,
+        InvalidArgument,
+        "normalization std_dev must be nonzero");
+  }
+  ET_CHECK_OR_RETURN_ERROR(
+      stride_bytes >= width * bytes_per_pixel(input_format),
+      InvalidArgument,
+      "stride too small");
+  ET_CHECK_OR_RETURN_ERROR(
+      roi.x >= 0 && roi.y >= 0 && roi.width > 0 && roi.height > 0 &&
+          roi.x + roi.width <= 1.0f + 1e-6f &&
+          roi.y + roi.height <= 1.0f + 1e-6f,
+      InvalidArgument,
+      "invalid ROI");
+  auto out_err = check_out_tensor(config, out);
+  if (out_err != Error::Ok) {
+    return out_err;
+  }
+  float* out_ptr = out.mutable_data_ptr<float>();
+
+  // GPU fast path: crop + resize in a single Core Image pass.
+  if (should_use_gpu(config, width, height)) {
+    const CIPixelFormatValue ci_format = (input_format == ColorFormat::BGRA)
+        ? CI_PIXEL_FORMAT_BGRA8
+        : CI_PIXEL_FORMAT_RGBA8;
+    GpuResizeDims gpu;
+    compute_gpu_dims(width, height, roi, config, gpu);
+    auto& gpu_resized = impl_->gpu_resized;
+    gpu_resized.resize(static_cast<size_t>(gpu.resize_w) * gpu.resize_h * 4);
+    int ret = ci_process_to_bgra(
+        data,
+        width,
+        height,
+        stride_bytes,
+        ci_format,
+        to_exif_orientation(Orientation::UP),
+        roi.x,
+        roi.y,
+        roi.width,
+        roi.height,
+        gpu.resize_w,
+        gpu.resize_h,
+        gpu_resized.data(),
+        gpu.resize_w * 4);
+    if (ret == 0) {
+      return normalize_bgra_into(
+          *this,
+          gpu_resized.data(),
+          gpu.resize_w,
+          gpu.resize_h,
+          gpu.final_w,
+          gpu.final_h,
+          gpu.resize_w * 4,
+          out_ptr);
+    }
+    ET_LOG(Debug, "GPU BGRA resize failed (ret=%d), falling back to CPU", ret);
+  }
+
+  // CPU path. Step 1: convert to BGRA.
+  uint8_t* bgra_data = nullptr;
+  int32_t cur_w = width;
+  int32_t cur_h = height;
+  int32_t cur_stride;
+  if (input_format == ColorFormat::BGRA) {
+    bgra_data = const_cast<uint8_t*>(data);
+    cur_stride = stride_bytes;
+  } else {
+    const size_t conv_stride = static_cast<size_t>(width) * 4;
+    bgra_data = impl_->conv.resize(conv_stride * height);
+    auto err = to_bgra(
+        data,
+        width,
+        height,
+        stride_bytes,
+        input_format,
+        bgra_data,
+        conv_stride);
+    if (err != Error::Ok) {
+      return err;
+    }
+    cur_stride = static_cast<int32_t>(conv_stride);
+  }
+
+  // Step 2: ROI crop (pointer arithmetic on BGRA data).
+  uint8_t* cur_data = bgra_data;
+  apply_roi_crop_bgra(cur_data, cur_w, cur_h, cur_stride, roi);
+
+  // Step 3: resize. Letterbox padding is applied during normalization.
+  BgraView resized;
+  int32_t final_w, final_h;
+  {
+    int32_t resize_w, resize_h, fw, fh;
+    compute_resize_dims(cur_w, cur_h, config, resize_w, resize_h, fw, fh);
+    const size_t resized_stride = static_cast<size_t>(resize_w) * 4;
+    uint8_t* resize_dst = impl_->resized.resize(resized_stride * resize_h);
+    const size_t temp_size =
+        compute_scale_temp_size(cur_w, cur_h, resize_w, resize_h);
+    void* scale_temp =
+        temp_size > 0 ? impl_->scale_temp.resize(temp_size) : nullptr;
+    auto resize_err = resize_and_pad_bgra(
+        cur_data,
+        cur_w,
+        cur_h,
+        cur_stride,
+        config,
+        resize_dst,
+        resized_stride,
+        scale_temp,
+        resized,
+        final_w,
+        final_h);
+    if (resize_err != Error::Ok) {
+      return resize_err;
+    }
+  }
+
+  // Step 4: normalize BGRA → CHW float buffer.
+  return normalize_bgra_into(
+      *this,
+      resized.data,
+      resized.width,
+      resized.height,
+      final_w,
+      final_h,
+      resized.stride,
+      out_ptr);
+}
+
+Error ImageProcessor::process_yuv_into(
+    const uint8_t* y_plane,
+    int32_t y_stride,
+    const uint8_t* uv_plane,
+    int32_t uv_stride,
+    int32_t width,
+    int32_t height,
+    YUVFormat format,
+    executorch::aten::Tensor& out,
+    Orientation /*orientation*/,
+    NormalizedRect roi,
+    YUVRange range) const {
+  const auto& config = impl_->config;
+  ET_CHECK_OR_RETURN_ERROR(
+      y_plane != nullptr, InvalidArgument, "y_plane is null");
+  ET_CHECK_OR_RETURN_ERROR(
+      uv_plane != nullptr, InvalidArgument, "uv_plane is null");
+  ET_CHECK_OR_RETURN_ERROR(
+      format == YUVFormat::NV12 || format == YUVFormat::NV21,
+      InvalidArgument,
+      "semi-planar overload requires NV12 or NV21");
+  ET_CHECK_OR_RETURN_ERROR(
+      width > 0 && height > 0, InvalidArgument, "invalid dimensions");
+  ET_CHECK_OR_RETURN_ERROR(
+      width % 2 == 0 && height % 2 == 0,
+      InvalidArgument,
+      "width and height must be even");
+  ET_CHECK_OR_RETURN_ERROR(
+      y_stride >= width, InvalidArgument, "y_stride too small");
+  ET_CHECK_OR_RETURN_ERROR(
+      uv_stride >= width, InvalidArgument, "uv_stride too small");
+  ET_CHECK_OR_RETURN_ERROR(
+      config.target_width > 0 && config.target_height > 0,
+      InvalidArgument,
+      "invalid target dimensions");
+  auto out_err = check_out_tensor(config, out);
+  if (out_err != Error::Ok) {
+    return out_err;
+  }
+  float* out_ptr = out.mutable_data_ptr<float>();
+
+  // NV21 stores chroma as Cr,Cb. Swap it to NV12's Cb,Cr ordering once, up
+  // front, so both the GPU and CPU paths below are format-agnostic (always
+  // NV12).
+  const uint8_t* cbcr = uv_plane;
+  int32_t cbcr_stride = uv_stride;
+  if (format == YUVFormat::NV21) {
+    const int32_t chroma_w = (width + 1) / 2;
+    const int32_t chroma_h = (height + 1) / 2;
+    uint8_t* swapped =
+        impl_->uv_swap.resize(static_cast<size_t>(chroma_w) * 2 * chroma_h);
+    swap_chroma_cbcr(uv_plane, uv_stride, swapped, chroma_w, chroma_h);
+    cbcr = swapped;
+    cbcr_stride = chroma_w * 2;
+  }
+
+  // GPU fast path: YUV→RGB + crop + resize in a single Core Image pass.
+  if (should_use_gpu(config, width, height)) {
+    GpuResizeDims gpu;
+    compute_gpu_dims(width, height, roi, config, gpu);
+    auto& gpu_resized = impl_->gpu_resized;
+    gpu_resized.resize(static_cast<size_t>(gpu.resize_w) * gpu.resize_h * 4);
+    int ret = ci_process_yuv_to_bgra(
+        y_plane,
+        y_stride,
+        cbcr,
+        cbcr_stride,
+        width,
+        height,
+        static_cast<int32_t>(range),
+        to_exif_orientation(Orientation::UP),
+        roi.x,
+        roi.y,
+        roi.width,
+        roi.height,
+        gpu.resize_w,
+        gpu.resize_h,
+        gpu_resized.data(),
+        gpu.resize_w * 4);
+    if (ret == 0) {
+      return normalize_bgra_into(
+          *this,
+          gpu_resized.data(),
+          gpu.resize_w,
+          gpu.resize_h,
+          gpu.final_w,
+          gpu.final_h,
+          gpu.resize_w * 4,
+          out_ptr);
+    }
+    ET_LOG(Debug, "GPU YUV resize failed (ret=%d), falling back to CPU", ret);
+  }
+
+  // CPU path: vImage YUV→BGRA (ITU-R 601), honoring the sample range.
+  auto makeConversion = [](const vImage_YpCbCrPixelRange& pixel_range) {
+    vImage_YpCbCrToARGB info;
+    vImageConvert_YpCbCrToARGB_GenerateConversion(
+        kvImage_YpCbCrToARGBMatrix_ITU_R_601_4,
+        &pixel_range,
+        &info,
+        kvImage420Yp8_CbCr8,
+        kvImageARGB8888,
+        kvImageNoFlags);
+    return info;
+  };
+  static const vImage_YpCbCrToARGB cachedVideo =
+      makeConversion(kYpCbCrPixelRange_Video);
+  static const vImage_YpCbCrToARGB cachedFull =
+      makeConversion(kYpCbCrPixelRange_Full);
+  const auto& info = (range == YUVRange::FULL) ? cachedFull : cachedVideo;
+
+  // ARGB→BGRA channel order (chroma already normalized to NV12 above).
+  const uint8_t permuteMap[4] = {3, 2, 1, 0};
+
+  // CPU fast path: scale Y/CbCr planes first, then convert at target size.
+  // Eligible when ROI is the full image and post-resize dims are even.
+  const bool fast_eligible =
+      roi.x == 0.0f && roi.y == 0.0f && roi.width == 1.0f && roi.height == 1.0f;
+  if (fast_eligible) {
+    GpuResizeDims dims;
+    compute_gpu_dims(width, height, roi, config, dims);
+    if ((dims.resize_w & 1) == 0 && (dims.resize_h & 1) == 0) {
+      const int32_t rw = dims.resize_w;
+      const int32_t rh = dims.resize_h;
+
+      const size_t y_bytes = static_cast<size_t>(rw) * rh;
+      const size_t uv_bytes = y_bytes / 2;
+      uint8_t* yuv_planar = impl_->conv.resize(y_bytes + uv_bytes);
+      uint8_t* y_small = yuv_planar;
+      uint8_t* uv_small = yuv_planar + y_bytes;
+
+      vImage_Buffer y_src = {
+          const_cast<uint8_t*>(y_plane),
+          static_cast<vImagePixelCount>(height),
+          static_cast<vImagePixelCount>(width),
+          static_cast<size_t>(y_stride)};
+      vImage_Buffer y_dst = {
+          y_small,
+          static_cast<vImagePixelCount>(rh),
+          static_cast<vImagePixelCount>(rw),
+          static_cast<size_t>(rw)};
+      vImage_Error verr =
+          vImageScale_Planar8(&y_src, &y_dst, nullptr, kvImageNoFlags);
+      ET_CHECK_OR_RETURN_ERROR(
+          verr == kvImageNoError,
+          Internal,
+          "vImageScale_Planar8 (Y) failed: %zd",
+          verr);
+
+      vImage_Buffer uv_src = {
+          const_cast<uint8_t*>(cbcr),
+          static_cast<vImagePixelCount>((height + 1) / 2),
+          static_cast<vImagePixelCount>((width + 1) / 2),
+          static_cast<size_t>(cbcr_stride)};
+      // Interleaved CbCr destination: rw/2 samples per row × 2 bytes = rw
+      // bytes.
+      const size_t uv_dst_stride = static_cast<size_t>(rw);
+      vImage_Buffer uv_dst = {
+          uv_small,
+          static_cast<vImagePixelCount>(rh / 2),
+          static_cast<vImagePixelCount>(rw / 2),
+          uv_dst_stride};
+      verr = vImageScale_CbCr8(&uv_src, &uv_dst, nullptr, kvImageNoFlags);
+      ET_CHECK_OR_RETURN_ERROR(
+          verr == kvImageNoError,
+          Internal,
+          "vImageScale_CbCr8 failed: %zd",
+          verr);
+
+      const size_t small_bgra_stride = static_cast<size_t>(rw) * 4;
+      auto& bgra = impl_->bgra;
+      uint8_t* bgra_small = bgra.resize(small_bgra_stride * rh);
+      vImage_Buffer bgra_dst = {
+          bgra_small,
+          static_cast<vImagePixelCount>(rh),
+          static_cast<vImagePixelCount>(rw),
+          small_bgra_stride};
+      verr = vImageConvert_420Yp8_CbCr8ToARGB8888(
+          &y_dst, &uv_dst, &bgra_dst, &info, permuteMap, 255, kvImageNoFlags);
+      ET_CHECK_OR_RETURN_ERROR(
+          verr == kvImageNoError,
+          Internal,
+          "vImageConvert_420Yp8_CbCr8ToARGB8888 (fast) failed: %zd",
+          verr);
+
+      return normalize_bgra_into(
+          *this,
+          bgra_small,
+          rw,
+          rh,
+          dims.final_w,
+          dims.final_h,
+          static_cast<int32_t>(small_bgra_stride),
+          out_ptr);
+    }
+  }
+
+  // CPU path: full-resolution YUV→BGRA conversion.
+  vImage_Buffer yBuf = {
+      const_cast<uint8_t*>(y_plane),
+      static_cast<vImagePixelCount>(height),
+      static_cast<vImagePixelCount>(width),
+      static_cast<size_t>(y_stride)};
+  vImage_Buffer uvBuf = {
+      const_cast<uint8_t*>(cbcr),
+      static_cast<vImagePixelCount>((height + 1) / 2),
+      static_cast<vImagePixelCount>((width + 1) / 2),
+      static_cast<size_t>(cbcr_stride)};
+
+  const size_t bgra_stride = static_cast<size_t>(width) * 4;
+  auto& bgra = impl_->bgra;
+  bgra.resize(static_cast<size_t>(height) * bgra_stride);
+  vImage_Buffer dstBuf = {
+      bgra.data(),
+      static_cast<vImagePixelCount>(height),
+      static_cast<vImagePixelCount>(width),
+      bgra_stride};
+
+  auto vErr = vImageConvert_420Yp8_CbCr8ToARGB8888(
+      &yBuf, &uvBuf, &dstBuf, &info, permuteMap, 255, kvImageNoFlags);
+  ET_CHECK_OR_RETURN_ERROR(
+      vErr == kvImageNoError,
+      Internal,
+      "vImageConvert_420Yp8_CbCr8ToARGB8888 failed: %zd",
+      vErr);
+
+  return process_bgra_cpu_only_into(
+      *this, bgra.data(), width, height, roi, out);
+}
+
+// Allocate a CHW float tensor sized to the configured target and fill it via
+// process_into.
+Result<TensorPtr> ImageProcessor::process(
+    const uint8_t* data,
+    int32_t width,
+    int32_t height,
+    int32_t stride_bytes,
+    ColorFormat input_format,
+    Orientation /*orientation*/,
+    NormalizedRect roi) const {
+  ET_CHECK_OR_RETURN_ERROR(
+      impl_->config.target_width > 0 && impl_->config.target_height > 0,
+      InvalidArgument,
+      "invalid target dimensions");
+
+  const int32_t final_w = impl_->config.target_width;
+  const int32_t final_h = impl_->config.target_height;
+  const size_t total = static_cast<size_t>(3) * final_w * final_h;
+  std::unique_ptr<float[]> output(new float[total]);
+
+  std::vector<int32_t> shape = {1, 3, final_h, final_w};
+  std::vector<executorch::aten::SizesType> tensor_shape(
+      shape.begin(), shape.end());
+  auto out = make_tensor_ptr(
+      std::move(tensor_shape),
+      static_cast<void*>(output.release()),
+      executorch::aten::ScalarType::Float,
+      executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND,
+      [](void* p) { delete[] static_cast<float*>(p); });
+
+  auto err = process_into(
+      data,
+      width,
+      height,
+      stride_bytes,
+      input_format,
+      *out,
+      Orientation::UP,
+      roi);
+  if (err != Error::Ok) {
+    return err;
+  }
+  return out;
+}
+
+// Allocate a CHW float tensor sized to the configured target and fill it via
+// process_yuv_into.
+Result<TensorPtr> ImageProcessor::process_yuv(
+    const uint8_t* y_plane,
+    int32_t y_stride,
+    const uint8_t* uv_plane,
+    int32_t uv_stride,
+    int32_t width,
+    int32_t height,
+    YUVFormat format,
+    Orientation /*orientation*/,
+    NormalizedRect roi,
+    YUVRange range) const {
+  ET_CHECK_OR_RETURN_ERROR(
+      impl_->config.target_width > 0 && impl_->config.target_height > 0,
+      InvalidArgument,
+      "invalid target dimensions");
+
+  const int32_t final_w = impl_->config.target_width;
+  const int32_t final_h = impl_->config.target_height;
+  const size_t total = static_cast<size_t>(3) * final_w * final_h;
+  std::unique_ptr<float[]> output(new float[total]);
+
+  std::vector<int32_t> shape = {1, 3, final_h, final_w};
+  std::vector<executorch::aten::SizesType> tensor_shape(
+      shape.begin(), shape.end());
+  auto out = make_tensor_ptr(
+      std::move(tensor_shape),
+      static_cast<void*>(output.release()),
+      executorch::aten::ScalarType::Float,
+      executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND,
+      [](void* p) { delete[] static_cast<float*>(p); });
+
+  auto err = process_yuv_into(
+      y_plane,
+      y_stride,
+      uv_plane,
+      uv_stride,
+      width,
+      height,
+      format,
+      *out,
+      Orientation::UP,
+      roi,
+      range);
+  if (err != Error::Ok) {
+    return err;
+  }
+  return out;
+}
+
+// --- Apple-specific public helpers (declared in image_processor_apple.h) ---
+
+// Run the pixel-buffer pipeline and write the normalized CHW float result into
+// `out`, which must be a contiguous Float tensor shaped [1, 3, target_h,
+// target_w]. GPU-enabled processors render directly into `out`; CPU processors
+// route through the per-format CPU pipeline. No per-call output allocation.
+Error process_pixelbuffer_into(
+    const ImageProcessor& processor,
+    CVPixelBufferRef pixelBuffer,
+    Orientation orientation,
+    executorch::aten::Tensor& out) {
+  ET_CHECK_OR_RETURN_ERROR(
+      pixelBuffer != nullptr, InvalidArgument, "pixelBuffer is null");
+
+  const int32_t width =
+      static_cast<int32_t>(CVPixelBufferGetWidth(pixelBuffer));
+  const int32_t height =
+      static_cast<int32_t>(CVPixelBufferGetHeight(pixelBuffer));
+  const OSType pixelFormat = CVPixelBufferGetPixelFormatType(pixelBuffer);
+
+  ET_CHECK_OR_RETURN_ERROR(
+      width > 0 && height > 0, InvalidArgument, "invalid dimensions");
+  ET_CHECK_OR_RETURN_ERROR(
+      processor.config().target_width > 0 &&
+          processor.config().target_height > 0,
+      InvalidArgument,
+      "invalid target dimensions");
+  ET_CHECK_OR_RETURN_ERROR(
+      is_supported_pixel_format(pixelFormat),
+      InvalidArgument,
+      "unsupported CVPixelBuffer format");
+
+  // Full-range buffers carry samples across the entire [0, 255]; everything
+  // else is video range. The conversion must match to avoid color distortion.
+  const YUVRange yuv_range =
+      (pixelFormat == kCVPixelFormatType_420YpCbCr8BiPlanarFullRange ||
+       pixelFormat == kCVPixelFormatType_420YpCbCr10BiPlanarFullRange)
+      ? YUVRange::FULL
+      : YUVRange::VIDEO;
+
+  // Validate the caller-provided output tensor and obtain its buffer. Use the
+  // shared helper so the contiguity check matches the CPU paths below; the GPU
+  // branch writes `out` as tightly-packed CHW and would corrupt memory on a
+  // non-contiguous tensor.
+  if (Error err = check_out_tensor(processor.config(), out); err != Error::Ok) {
+    return err;
+  }
+  float* out_ptr = out.mutable_data_ptr<float>();
+
+  // GPU pixel-buffer-direct fast path. Core Image renders the resized image to
+  // 8-bit BGRA (4 B/px, vs 16 B/px for float) to keep the GPU→CPU readback
+  // small; normalize does the uint8->float conversion.
+  if (should_use_gpu(processor.config(), width, height)) {
+    int32_t resize_w, resize_h, final_w, final_h;
+    compute_resize_dims(
+        width,
+        height,
+        processor.config(),
+        resize_w,
+        resize_h,
+        final_w,
+        final_h);
+
+    auto& gpu_resized = processor.impl().gpu_resized;
+    gpu_resized.resize(static_cast<size_t>(resize_w) * resize_h * 4);
+    const int32_t bgra_stride = resize_w * 4;
+
+    // process_pixelbuffer processes the full image; kFullImage is the ROI
+    // forwarded to the helper.
+    static_assert(
+        kFullImage.x == 0.0f && kFullImage.y == 0.0f &&
+            kFullImage.width == 1.0f && kFullImage.height == 1.0f,
+        "kFullImage must be {0,0,1,1}");
+    int ret = ci_process_pixelbuffer_to_bgra(
+        pixelBuffer,
+        to_exif_orientation(orientation),
+        kFullImage.x,
+        kFullImage.y,
+        kFullImage.width,
+        kFullImage.height,
+        resize_w,
+        resize_h,
+        gpu_resized.data(),
+        bgra_stride);
+
+    if (ret == 0) {
+      return normalize_bgra_into(
+          processor,
+          gpu_resized.data(),
+          resize_w,
+          resize_h,
+          final_w,
+          final_h,
+          bgra_stride,
+          out_ptr);
+    }
+    ET_LOG(
+        Debug,
+        "GPU pixelbuffer resize failed (ret=%d), falling back to CPU",
+        ret);
+    // GPU failed — fall through to CPU path.
+  }
+
+  // CPU path. Lock the pixel buffer's base address and dispatch on format.
+  // When the processor can use the GPU, route through a force-CPU proxy
+  // (cached on the processor's pImpl) so process()/process_yuv() do not
+  // re-attempt the GPU path on the bytes just locked into CPU memory.
+  const ImageProcessor* cpu_processor = &processor;
+  if (!is_cpu_only(processor.config())) {
+    auto& cpu_proxy = processor.impl().cpu_proxy;
+    if (!cpu_proxy) {
+      ImageProcessorConfig cpu_config = processor.config();
+      cpu_config.gpu_min_input_pixels = ImageProcessorConfig::kGpuNever;
+      cpu_proxy = std::make_unique<ImageProcessor>(cpu_config);
+    }
+    cpu_processor = cpu_proxy.get();
+  }
+
+  if (CVPixelBufferLockBaseAddress(pixelBuffer, kCVPixelBufferLock_ReadOnly) !=
+      kCVReturnSuccess) {
+    return Error::AccessFailed;
+  }
+  Error result = [&]() -> Error {
+    // BGRA / RGBA: hand bytes directly to the CPU pipeline.
+    if (pixelFormat == kCVPixelFormatType_32BGRA ||
+        pixelFormat == kCVPixelFormatType_32RGBA) {
+      const ColorFormat fmt = (pixelFormat == kCVPixelFormatType_32BGRA)
+          ? ColorFormat::BGRA
+          : ColorFormat::RGBA;
+      const auto* data =
+          static_cast<const uint8_t*>(CVPixelBufferGetBaseAddress(pixelBuffer));
+      const int32_t stride =
+          static_cast<int32_t>(CVPixelBufferGetBytesPerRow(pixelBuffer));
+      return cpu_processor->process_into(
+          data, width, height, stride, fmt, out, orientation, kFullImage);
+    }
+
+    // 8-bit NV12 (semi-planar Y + interleaved CbCr).
+    if (pixelFormat == kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange ||
+        pixelFormat == kCVPixelFormatType_420YpCbCr8BiPlanarFullRange) {
+      const auto* y = static_cast<const uint8_t*>(
+          CVPixelBufferGetBaseAddressOfPlane(pixelBuffer, 0));
+      const int32_t y_stride = static_cast<int32_t>(
+          CVPixelBufferGetBytesPerRowOfPlane(pixelBuffer, 0));
+      const auto* uv = static_cast<const uint8_t*>(
+          CVPixelBufferGetBaseAddressOfPlane(pixelBuffer, 1));
+      const int32_t uv_stride = static_cast<int32_t>(
+          CVPixelBufferGetBytesPerRowOfPlane(pixelBuffer, 1));
+      return cpu_processor->process_yuv_into(
+          y,
+          y_stride,
+          uv,
+          uv_stride,
+          width,
+          height,
+          YUVFormat::NV12,
+          out,
+          orientation,
+          kFullImage,
+          yuv_range);
+    }
+
+    // 10-bit P010: narrow each 16-bit sample to its high byte (8-bit NV12),
+    // then dispatch to process_yuv.
+    if (pixelFormat == kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange ||
+        pixelFormat == kCVPixelFormatType_420YpCbCr10BiPlanarFullRange) {
+      const int32_t y_stride16 = static_cast<int32_t>(
+          CVPixelBufferGetBytesPerRowOfPlane(pixelBuffer, 0));
+      const int32_t uv_stride16 = static_cast<int32_t>(
+          CVPixelBufferGetBytesPerRowOfPlane(pixelBuffer, 1));
+      const auto* y16 = static_cast<const uint16_t*>(
+          CVPixelBufferGetBaseAddressOfPlane(pixelBuffer, 0));
+      const auto* uv16 = static_cast<const uint16_t*>(
+          CVPixelBufferGetBaseAddressOfPlane(pixelBuffer, 1));
+
+      const int32_t uv_height = (height + 1) / 2;
+      const int32_t uv_width = (width + 1) / 2;
+      const int32_t uv_samples_per_row = uv_width * 2;
+
+      // Reuse per-processor scratch (no per-frame malloc/free) and narrow with
+      // NEON instead of a scalar high-byte loop.
+      auto& narrow_y = cpu_processor->impl().narrow_y;
+      auto& narrow_uv = cpu_processor->impl().narrow_uv;
+      uint8_t* y8 = narrow_y.resize(static_cast<size_t>(width) * height);
+      uint8_t* uv8 =
+          narrow_uv.resize(static_cast<size_t>(uv_samples_per_row) * uv_height);
+
+      narrow_plane_p010_to_8bit(
+          reinterpret_cast<const uint8_t*>(y16), y_stride16, y8, width, height);
+      narrow_plane_p010_to_8bit(
+          reinterpret_cast<const uint8_t*>(uv16),
+          uv_stride16,
+          uv8,
+          uv_samples_per_row,
+          uv_height);
+
+      return cpu_processor->process_yuv_into(
+          y8,
+          width,
+          uv8,
+          uv_samples_per_row,
+          width,
+          height,
+          YUVFormat::NV12,
+          out,
+          orientation,
+          kFullImage,
+          yuv_range);
+    }
+
+    return Error::InvalidArgument;
+  }();
+  CVPixelBufferUnlockBaseAddress(pixelBuffer, kCVPixelBufferLock_ReadOnly);
+  return result;
+}
+
+// Allocate a CHW float tensor sized to the configured target and fill it via
+// process_pixelbuffer_into.
+Result<TensorPtr> process_pixelbuffer(
+    const ImageProcessor& processor,
+    CVPixelBufferRef pixelBuffer,
+    Orientation orientation) {
+  ET_CHECK_OR_RETURN_ERROR(
+      processor.config().target_width > 0 &&
+          processor.config().target_height > 0,
+      InvalidArgument,
+      "invalid target dimensions");
+
+  const int32_t final_w = processor.config().target_width;
+  const int32_t final_h = processor.config().target_height;
+  const size_t total = static_cast<size_t>(3) * final_w * final_h;
+  std::unique_ptr<float[]> output(new float[total]);
+
+  std::vector<int32_t> shape = {1, 3, final_h, final_w};
+  std::vector<executorch::aten::SizesType> tensor_shape(
+      shape.begin(), shape.end());
+  auto out = make_tensor_ptr(
+      std::move(tensor_shape),
+      static_cast<void*>(output.release()),
+      executorch::aten::ScalarType::Float,
+      executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND,
+      [](void* p) { delete[] static_cast<float*>(p); });
+
+  auto err =
+      process_pixelbuffer_into(processor, pixelBuffer, orientation, *out);
+  if (err != Error::Ok) {
+    return err;
+  }
+  return out;
+}
+
+} // namespace image
+} // namespace extension
+} // namespace executorch

--- a/extension/image/image_processor_apple.h
+++ b/extension/image/image_processor_apple.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Apple-specific ImageProcessor entry point. Available only on Apple
+// platforms; used by the Objective-C / Swift bindings to process a
+// CVPixelBuffer directly. The normalization/conversion machinery this
+// builds on is file-local to image_processor_apple.cpp and is intentionally
+// not exposed here.
+
+#pragma once
+
+#ifdef __APPLE__
+
+#include <CoreVideo/CoreVideo.h>
+
+#include <executorch/extension/image/image_processor.h>
+
+namespace executorch {
+namespace extension {
+namespace image {
+
+/// Process a CVPixelBuffer directly into a normalized float tensor.
+///
+/// Apple-only entry point that avoids the GPU→CPU→GPU round trip that the
+/// generic `process(raw_bytes)` path incurs for IOSurface-backed pixel
+/// buffers. When the input qualifies for the GPU path (source pixels >=
+/// config.gpu_min_input_pixels), wraps the CVPixelBuffer's IOSurface as a
+/// CIImage (zero-copy), runs resize on GPU, reads back to CPU once at the
+/// post-resize target dims, and applies vDSP-based normalization. On GPU
+/// failure or for CPU-bound inputs, falls
+/// back to a CPU pipeline that locks the pixel buffer's base address and
+/// dispatches to `process()` / `process_yuv()` based on the pixel format.
+///
+/// Supported pixel formats: BGRA (32BGRA), RGBA (32RGBA), 8-bit NV12
+/// (420YpCbCr8BiPlanar*), and 10-bit P010 (420YpCbCr10BiPlanar*; narrowed
+/// to 8-bit NV12 internally before processing). Other formats return
+/// Error::InvalidArgument.
+///
+/// All scratch buffers used by both paths live on the processor's pImpl
+/// (`gpu_resized` for the GPU readback, `cpu_proxy` for the GPU→CPU
+/// fallback's separate force-CPU processor). Repeated calls on the
+/// same processor reuse the same allocations.
+///
+/// @param orientation Orientation of the pixel-buffer contents. Currently
+/// only `Orientation::UP` is supported: the buffer is treated as already
+/// upright. The parameter reserves the slot for future orientation correction
+/// and is forwarded to the underlying pipeline. Orientation cannot be derived
+/// from a CVPixelBuffer, so the caller must supply an upright buffer (e.g. by
+/// configuring the capture connection) until non-UP orientations are
+/// supported.
+runtime::Result<TensorPtr> process_pixelbuffer(
+    const ImageProcessor& processor,
+    CVPixelBufferRef pixelBuffer,
+    Orientation orientation = Orientation::UP);
+
+/// Reuse-friendly variant of process_pixelbuffer that writes into a
+/// caller-owned tensor instead of allocating one per call. `out` must be a
+/// contiguous Float tensor shaped [1, 3, target_height, target_width]; the
+/// result is written into its storage and the same tensor can be reused across
+/// frames. The returned result aliases `out`, so the caller must finish
+/// consuming the previous result before the next call.
+///
+/// Supported pixel formats and orientation handling match process_pixelbuffer.
+runtime::Error process_pixelbuffer_into(
+    const ImageProcessor& processor,
+    CVPixelBufferRef pixelBuffer,
+    Orientation orientation,
+    executorch::aten::Tensor& out);
+
+} // namespace image
+} // namespace extension
+} // namespace executorch
+
+#endif // __APPLE__

--- a/extension/image/image_processor_apple_gpu.h
+++ b/extension/image/image_processor_apple_gpu.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Internal header for Core Image GPU-accelerated helpers.
+// Provides C-linkage functions so image_processor_apple.cpp can call them
+// without becoming Objective-C++.
+
+#pragma once
+
+#ifdef __APPLE__
+
+#include <CoreVideo/CVPixelBuffer.h>
+#include <cstdint>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// C-ABI tokens for the pixel formats the GPU raw-bytes path accepts. These are
+// mapped to the real CIFormat values (kCIFormat*, which are runtime globals) in
+// image_processor_apple_gpu.mm. The values here are private tokens and need not
+// match kCIFormat*.
+typedef enum {
+  CI_PIXEL_FORMAT_BGRA8 = 14,
+  CI_PIXEL_FORMAT_RGBA8 = 24,
+} CIPixelFormatValue;
+
+// Process interleaved pixel data through Core Image GPU pipeline:
+// orient → ROI crop → resize → render to BGRA output at target size.
+// Returns 0 on success, non-zero on failure.
+int ci_process_to_bgra(
+    const uint8_t* pixel_in,
+    int32_t width,
+    int32_t height,
+    int32_t stride,
+    CIPixelFormatValue pixel_format,
+    int32_t orientation, // Orientation enum value (1-8)
+    float roi_x,
+    float roi_y,
+    float roi_width,
+    float roi_height,
+    int32_t target_width,
+    int32_t target_height,
+    uint8_t* bgra_out,
+    int32_t out_stride);
+
+// Process NV12 YUV input through Core Image GPU pipeline:
+// YUV→RGB + orient → ROI crop → resize → render to BGRA output.
+// Returns 0 on success, non-zero on failure.
+// Chroma must already be in NV12 (Cb,Cr) order; callers with NV21 input swap
+// the chroma beforehand, since CoreVideo has no native NV21 pixel format.
+// yuv_range: 0 = video range, 1 = full range
+int ci_process_yuv_to_bgra(
+    const uint8_t* y_plane,
+    int32_t y_stride,
+    const uint8_t* uv_plane,
+    int32_t uv_stride,
+    int32_t width,
+    int32_t height,
+    int32_t yuv_range,
+    int32_t orientation,
+    float roi_x,
+    float roi_y,
+    float roi_width,
+    float roi_height,
+    int32_t target_width,
+    int32_t target_height,
+    uint8_t* bgra_out,
+    int32_t out_stride);
+
+// Process a CVPixelBuffer directly through the Core Image GPU pipeline,
+// rendering to 8-bit BGRA. Zero-copy for camera buffers. Renders 4 B/px
+// instead of RGBAf's 16 B/px to cut GPU→CPU readback bandwidth ~4x; the
+// uint8→float conversion is done by the normalize step. Returns 0 on success.
+int ci_process_pixelbuffer_to_bgra(
+    CVPixelBufferRef pixelBuffer,
+    int32_t orientation,
+    float roi_x,
+    float roi_y,
+    float roi_width,
+    float roi_height,
+    int32_t target_width,
+    int32_t target_height,
+    uint8_t* bgra_out,
+    int32_t out_stride);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // __APPLE__

--- a/extension/image/image_processor_apple_gpu.mm
+++ b/extension/image/image_processor_apple_gpu.mm
@@ -1,0 +1,273 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Core Image GPU-accelerated helpers for ImageProcessor.
+// Provides C-linkage functions callable from pure C++ code.
+
+#import <CoreImage/CoreImage.h>
+#import <CoreVideo/CoreVideo.h>
+
+#include "image_processor_apple_gpu.h"
+
+// Shared CIContext for GPU rendering. Created once per process via dispatch_once.
+// CIContext is thread-safe for rendering operations; multiple threads can call
+// render:toBitmap: concurrently without synchronization.
+static CIContext* sharedCIContext() {
+  static CIContext* ctx = nil;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    ctx = [CIContext contextWithOptions:@{
+      kCIContextWorkingColorSpace : [NSNull null],
+      kCIContextWorkingFormat : @(kCIFormatBGRA8),
+      kCIContextCacheIntermediates : @NO,
+      kCIContextUseSoftwareRenderer : @NO,
+    }];
+  });
+  return ctx;
+}
+
+static CIImage* applyOrientation(CIImage* image, int32_t orientation) {
+  if (orientation <= 1 || orientation > 8) {
+    return image;
+  }
+  return [image imageByApplyingOrientation:orientation];
+}
+
+static CIImage* applyROI(
+    CIImage* image,
+    float roi_x,
+    float roi_y,
+    float roi_width,
+    float roi_height) {
+  if (roi_x == 0.0f && roi_y == 0.0f && roi_width == 1.0f &&
+      roi_height == 1.0f) {
+    return image;
+  }
+  CGRect extent = image.extent;
+  // Core Image's coordinate origin is bottom-left (y increases upward), but
+  // roi_y is specified top-down (matching the CPU pipeline and the raw pixel
+  // buffer). Flip it so the crop selects the same region on both paths:
+  // a top-down [roi_y, roi_y + roi_height] maps to a bottom-up origin of
+  // (1 - roi_y - roi_height).
+  CGRect crop = CGRectMake(
+      extent.origin.x + roi_x * extent.size.width,
+      extent.origin.y + (1.0f - roi_y - roi_height) * extent.size.height,
+      roi_width * extent.size.width,
+      roi_height * extent.size.height);
+  CIImage* cropped = [image imageByCroppingToRect:crop];
+  // Rebase the cropped region to the coordinate-space origin. applyResize
+  // scales about (0,0) and the render helpers use bounds {0,0,tw,th}, so a
+  // non-zero ROI origin must be removed here — otherwise the content ends up
+  // offset by crop.origin * scale and render samples the wrong (largely empty)
+  // region. The full-image case returns early above, so this extra transform
+  // only runs for actual sub-image ROIs.
+  return [cropped
+      imageByApplyingTransform:CGAffineTransformMakeTranslation(
+                                   -crop.origin.x, -crop.origin.y)];
+}
+
+static CIImage* applyResize(
+    CIImage* image,
+    int32_t target_width,
+    int32_t target_height) {
+  CGRect extent = image.extent;
+  CGFloat sx = (CGFloat)target_width / extent.size.width;
+  CGFloat sy = (CGFloat)target_height / extent.size.height;
+  return [image imageByApplyingTransform:CGAffineTransformMakeScale(sx, sy)];
+}
+
+static int renderToBGRA(
+    CIImage* image,
+    int32_t target_width,
+    int32_t target_height,
+    uint8_t* bgra_out,
+    int32_t out_stride) {
+  CIContext* ctx = sharedCIContext();
+  // render:toBitmap: returns void and cannot report a rasterization failure,
+  // so validate the inputs here. A failed CIFilter earlier in the pipeline
+  // yields a nil or empty-extent image; rejecting it lets the caller fall back
+  // to the CPU path.
+  if (!ctx || !image || CGRectIsEmpty(image.extent)) {
+    return -1;
+  }
+  CGRect bounds = CGRectMake(0, 0, target_width, target_height);
+  [ctx render:image
+      toBitmap:bgra_out
+      rowBytes:out_stride
+        bounds:bounds
+        format:kCIFormatBGRA8
+    colorSpace:nil];
+  return 0;
+}
+
+int ci_process_to_bgra(
+    const uint8_t* pixel_in,
+    int32_t width,
+    int32_t height,
+    int32_t stride,
+    CIPixelFormatValue pixel_format,
+    int32_t orientation,
+    float roi_x,
+    float roi_y,
+    float roi_width,
+    float roi_height,
+    int32_t target_width,
+    int32_t target_height,
+    uint8_t* bgra_out,
+    int32_t out_stride) {
+  if (!pixel_in || !bgra_out || width <= 0 || height <= 0 ||
+      target_width <= 0 || target_height <= 0) {
+    return -1;
+  }
+  @autoreleasepool {
+    NSData* data = [NSData dataWithBytesNoCopy:(void*)pixel_in
+                                        length:(NSUInteger)((size_t)stride * (size_t)height)
+                                  freeWhenDone:NO];
+    // Map the C-ABI format value to the real CIFormat. kCIFormat* are runtime
+    // globals (not compile-time constants), so passing the raw enum value as a
+    // CIFormat is unsafe. A mismatch yields a misinterpreted (black) image.
+    CIFormat ci_format;
+    switch (pixel_format) {
+      case CI_PIXEL_FORMAT_BGRA8:
+        ci_format = kCIFormatBGRA8;
+        break;
+      case CI_PIXEL_FORMAT_RGBA8:
+        ci_format = kCIFormatRGBA8;
+        break;
+      default:
+        return -1; // Unknown format; caller falls back to the CPU path.
+    }
+    CIImage* image = [CIImage
+        imageWithBitmapData:data
+                bytesPerRow:stride
+                       size:CGSizeMake(width, height)
+                     format:ci_format
+                 colorSpace:nil];
+    if (!image) {
+      return -1;
+    }
+    image = applyOrientation(image, orientation);
+    image = applyROI(image, roi_x, roi_y, roi_width, roi_height);
+    image = applyResize(image, target_width, target_height);
+    return renderToBGRA(image, target_width, target_height, bgra_out, out_stride);
+  }
+}
+
+int ci_process_yuv_to_bgra(
+    const uint8_t* y_plane,
+    int32_t y_stride,
+    const uint8_t* uv_plane,
+    int32_t uv_stride,
+    int32_t width,
+    int32_t height,
+    int32_t yuv_range,
+    int32_t orientation,
+    float roi_x,
+    float roi_y,
+    float roi_width,
+    float roi_height,
+    int32_t target_width,
+    int32_t target_height,
+    uint8_t* bgra_out,
+    int32_t out_stride) {
+  if (!y_plane || !uv_plane || !bgra_out || width <= 0 || height <= 0 ||
+      target_width <= 0 || target_height <= 0) {
+    return -1;
+  }
+  @autoreleasepool {
+    // Create a CVPixelBuffer wrapping the Y and UV planes. Chroma is expected in
+    // NV12 (Cb,Cr) order; callers with NV21 input swap the chroma beforehand,
+    // since CoreVideo has no native NV21 pixel format.
+    //
+    // Memory safety: CVPixelBufferCreateWithPlanarBytes wraps the input planes
+    // without copying. The planes must remain valid until rendering completes.
+    // This is guaranteed here because render completes synchronously within
+    // this @autoreleasepool before the function returns.
+    const OSType cv_format = (yuv_range != 0)
+        ? kCVPixelFormatType_420YpCbCr8BiPlanarFullRange
+        : kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange;
+    CVPixelBufferRef pixelBuffer = NULL;
+
+    const int32_t chroma_w = (width + 1) / 2;
+    const int32_t chroma_h = (height + 1) / 2;
+
+    void* planeBaseAddresses[2] = {
+        (void*)y_plane, (void*)uv_plane};
+    size_t planeWidths[2] = {
+        (size_t)width, (size_t)chroma_w};
+    size_t planeHeights[2] = {
+        (size_t)height, (size_t)chroma_h};
+    size_t planeBytesPerRow[2] = {
+        (size_t)y_stride, (size_t)uv_stride};
+
+    CVReturn status = CVPixelBufferCreateWithPlanarBytes(
+        kCFAllocatorDefault,
+        width,
+        height,
+        cv_format,
+        NULL, // dataPtr
+        0,    // dataSize
+        2,    // numberOfPlanes
+        planeBaseAddresses,
+        planeWidths,
+        planeHeights,
+        planeBytesPerRow,
+        NULL, // releaseCallback
+        NULL, // releaseRefCon
+        NULL, // pixelBufferAttributes
+        &pixelBuffer);
+
+    if (status != kCVReturnSuccess || !pixelBuffer) {
+      return -1;
+    }
+
+    // imageWithCVPixelBuffer: retains the pixel buffer, so releasing our
+    // reference here is safe: the CIImage keeps the buffer (and the caller-owned
+    // planes it wraps without copying) alive through the synchronous render.
+    CIImage* image = [CIImage imageWithCVPixelBuffer:pixelBuffer];
+    CVPixelBufferRelease(pixelBuffer);
+
+    if (!image) {
+      return -1;
+    }
+
+    image = applyOrientation(image, orientation);
+    image = applyROI(image, roi_x, roi_y, roi_width, roi_height);
+    image = applyResize(image, target_width, target_height);
+    return renderToBGRA(image, target_width, target_height, bgra_out, out_stride);
+  }
+}
+
+int ci_process_pixelbuffer_to_bgra(
+    CVPixelBufferRef pixelBuffer,
+    int32_t orientation,
+    float roi_x,
+    float roi_y,
+    float roi_width,
+    float roi_height,
+    int32_t target_width,
+    int32_t target_height,
+    uint8_t* bgra_out,
+    int32_t out_stride) {
+  if (!pixelBuffer || !bgra_out || target_width <= 0 || target_height <= 0) {
+    return -1;
+  }
+  @autoreleasepool {
+    // Zero-copy: CIImage wraps the CVPixelBuffer's IOSurface directly. Renders
+    // to 8-bit BGRA (4 B/px) rather than RGBAf (16 B/px) to cut readback
+    // bandwidth ~4x; the uint8->float conversion happens during normalization.
+    CIImage* image = [CIImage imageWithCVPixelBuffer:pixelBuffer];
+    if (!image) {
+      return -1;
+    }
+    image = applyOrientation(image, orientation);
+    image = applyROI(image, roi_x, roi_y, roi_width, roi_height);
+    image = applyResize(image, target_width, target_height);
+    return renderToBGRA(image, target_width, target_height, bgra_out, out_stride);
+  }
+}

--- a/extension/image/targets.bzl
+++ b/extension/image/targets.bzl
@@ -1,5 +1,22 @@
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "get_aten_mode_options", "runtime")
 
+# Linker flags to pull in the Apple frameworks referenced by
+# image_processor_apple_gpu.mm (CoreImage CIContext/CIImage, Foundation NS*
+# classes, etc.). Applied via exported_linker_flags so they reach the final
+# link of any binary/test that depends on image_processor.
+_APPLE_FRAMEWORK_LINKER_FLAGS = [
+    "-Wl,-framework",
+    "-Wl,Accelerate",
+    "-Wl,-framework",
+    "-Wl,CoreGraphics",
+    "-Wl,-framework",
+    "-Wl,CoreImage",
+    "-Wl,-framework",
+    "-Wl,CoreVideo",
+    "-Wl,-framework",
+    "-Wl,Foundation",
+]
+
 def define_common_targets():
     """Defines targets that should be shared between fbcode and xplat.
 
@@ -12,13 +29,24 @@ def define_common_targets():
 
         runtime.cxx_library(
             name = "image_processor" + aten_suffix,
-            srcs = [
-                "image_processor_common.cpp",
-                "image_processor.cpp",
+            srcs = ["image_processor_common.cpp"] + select({
+                "DEFAULT": ["image_processor.cpp"],
+                "ovr_config//os:iphoneos": [
+                    "image_processor_apple.cpp",
+                    "image_processor_apple_gpu.mm",
+                ],
+                "ovr_config//os:macos-arm64": [
+                    "image_processor_apple.cpp",
+                    "image_processor_apple_gpu.mm",
+                ],
+            }),
+            headers = [
+                "image_processor_apple_gpu.h",
             ],
             exported_headers = [
                 "image_processor.h",
                 "image_processor_config.h",
+                "image_processor_apple.h",
             ],
             visibility = ["PUBLIC"],
             deps = [
@@ -32,4 +60,23 @@ def define_common_targets():
             external_deps = [
                 "stb",
             ],
+            fbobjc_frameworks = [
+                "Accelerate",
+                "CoreGraphics",
+                "CoreImage",
+                "CoreVideo",
+                "Foundation",
+            ],
+            # `fbobjc_frameworks` links the frameworks into this (static)
+            # library but does not propagate to dependents' final link, and the
+            # fbobjc_ flags don't apply on the macOS host cfg. Export the
+            # framework link flags gated on the same platforms where the Apple
+            # sources are compiled, so any binary/test depending on
+            # image_processor links the CoreImage/Foundation/etc. symbols used
+            # by image_processor_apple_gpu.mm instead of re-declaring them.
+            exported_linker_flags = select({
+                "DEFAULT": [],
+                "ovr_config//os:iphoneos": _APPLE_FRAMEWORK_LINKER_FLAGS,
+                "ovr_config//os:macos-arm64": _APPLE_FRAMEWORK_LINKER_FLAGS,
+            }),
         )

--- a/extension/image/test/CMakeLists.txt
+++ b/extension/image/test/CMakeLists.txt
@@ -17,7 +17,7 @@ set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
 
 include(${EXECUTORCH_ROOT}/tools/cmake/Test.cmake)
 
-set(_test_srcs image_processor_test.cpp)
+set(_test_srcs image_processor_test.cpp image_processor_apple_test.cpp)
 
 et_cxx_test(
   extension_image_test SOURCES ${_test_srcs} EXTRA_LIBS extension_image

--- a/extension/image/test/image_processor_apple_test.cpp
+++ b/extension/image/test/image_processor_apple_test.cpp
@@ -1,0 +1,692 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Apple-specific ImageProcessor tests. These exercise the Core Image GPU paths
+// and the CVPixelBuffer entry point, asserting they match the CPU pipeline for
+// cases the portable tests cannot reach. The whole file is gated on __APPLE__
+// so it is an empty translation unit on non-Apple platforms.
+
+#ifdef __APPLE__
+
+#include <executorch/extension/image/image_processor.h>
+#include <executorch/extension/image/image_processor_apple.h>
+
+#include <cstdint>
+#include <vector>
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <CoreVideo/CoreVideo.h>
+#include <gtest/gtest.h>
+
+#include <executorch/extension/tensor/tensor_ptr.h>
+#include <executorch/runtime/platform/platform.h>
+
+using namespace executorch::extension::image;
+using executorch::extension::make_tensor_ptr;
+using executorch::extension::TensorPtr;
+using executorch::runtime::Error;
+
+// Initialize PAL before running tests (needed for ET_LOG on error paths).
+class AppleImageProcessorTestEnvironment : public ::testing::Environment {
+ public:
+  void SetUp() override {
+    et_pal_init();
+  }
+};
+
+const ::testing::Environment* const apple_image_processor_test_env =
+    ::testing::AddGlobalTestEnvironment(new AppleImageProcessorTestEnvironment);
+
+namespace {
+
+// Build the {kCVPixelBufferIOSurfacePropertiesKey: {}} attributes dictionary
+// that requests IOSurface-backed storage (needed for the zero-copy GPU path).
+// Uses CoreFoundation rather than Objective-C literals so this file stays plain
+// C++. Caller owns the returned dictionary and must CFRelease it.
+CFDictionaryRef make_iosurface_attrs() {
+  CFDictionaryRef empty = CFDictionaryCreate(
+      kCFAllocatorDefault,
+      nullptr,
+      nullptr,
+      0,
+      &kCFTypeDictionaryKeyCallBacks,
+      &kCFTypeDictionaryValueCallBacks);
+  const void* keys[] = {kCVPixelBufferIOSurfacePropertiesKey};
+  const void* values[] = {empty};
+  CFDictionaryRef attrs = CFDictionaryCreate(
+      kCFAllocatorDefault,
+      keys,
+      values,
+      1,
+      &kCFTypeDictionaryKeyCallBacks,
+      &kCFTypeDictionaryValueCallBacks);
+  CFRelease(empty);
+  return attrs;
+}
+
+// Horizontally-split content: left half [0, w/2) one solid color, right half
+// [w/2, w) another. Used to detect a wrong-region ROI crop.
+std::vector<uint8_t> make_split_bgra(
+    int32_t w,
+    int32_t h,
+    uint8_t lr,
+    uint8_t lg,
+    uint8_t lb,
+    uint8_t rr,
+    uint8_t rg,
+    uint8_t rb) {
+  std::vector<uint8_t> img(static_cast<size_t>(w) * h * 4);
+  for (int32_t y = 0; y < h; ++y) {
+    for (int32_t x = 0; x < w; ++x) {
+      const size_t i = (static_cast<size_t>(y) * w + x) * 4;
+      const bool right = x >= w / 2;
+      img[i + 0] = right ? rb : lb; // B
+      img[i + 1] = right ? rg : lg; // G
+      img[i + 2] = right ? rr : lr; // R
+      img[i + 3] = 255;
+    }
+  }
+  return img;
+}
+
+// Vertically-split content: top half [0, h/2) one solid color, bottom half
+// [h/2, h) another. Used to detect a wrong-region (or vertically-flipped) ROI
+// crop along the y-axis.
+std::vector<uint8_t> make_vsplit_bgra(
+    int32_t w,
+    int32_t h,
+    uint8_t tr,
+    uint8_t tg,
+    uint8_t tb,
+    uint8_t br,
+    uint8_t bg,
+    uint8_t bb) {
+  std::vector<uint8_t> img(static_cast<size_t>(w) * h * 4);
+  for (int32_t y = 0; y < h; ++y) {
+    for (int32_t x = 0; x < w; ++x) {
+      const size_t i = (static_cast<size_t>(y) * w + x) * 4;
+      const bool bottom = y >= h / 2;
+      img[i + 0] = bottom ? bb : tb; // B
+      img[i + 1] = bottom ? bg : tg; // G
+      img[i + 2] = bottom ? br : tr; // R
+      img[i + 3] = 255;
+    }
+  }
+  return img;
+}
+
+// Create a solid-color 32BGRA CVPixelBuffer (caller releases).
+CVPixelBufferRef
+make_bgra_pixelbuffer(int32_t w, int32_t h, uint8_t r, uint8_t g, uint8_t b) {
+  CVPixelBufferRef pb = nullptr;
+  const CVReturn status = CVPixelBufferCreate(
+      kCFAllocatorDefault, w, h, kCVPixelFormatType_32BGRA, nullptr, &pb);
+  if (status != kCVReturnSuccess || pb == nullptr) {
+    return nullptr;
+  }
+  CVPixelBufferLockBaseAddress(pb, 0);
+  auto* base = static_cast<uint8_t*>(CVPixelBufferGetBaseAddress(pb));
+  const size_t stride = CVPixelBufferGetBytesPerRow(pb);
+  for (int32_t y = 0; y < h; ++y) {
+    for (int32_t x = 0; x < w; ++x) {
+      uint8_t* px = base + static_cast<size_t>(y) * stride + x * 4;
+      px[0] = b;
+      px[1] = g;
+      px[2] = r;
+      px[3] = 255;
+    }
+  }
+  CVPixelBufferUnlockBaseAddress(pb, 0);
+  return pb;
+}
+
+// Create a 10-bit P010 (420YpCbCr10BiPlanar) CVPixelBuffer (caller releases).
+CVPixelBufferRef
+make_p010_pixelbuffer(int32_t w, int32_t h, uint8_t y_val, uint8_t uv_val) {
+  CVPixelBufferRef pb = nullptr;
+  CFDictionaryRef attrs = make_iosurface_attrs();
+  const CVReturn status = CVPixelBufferCreate(
+      kCFAllocatorDefault,
+      w,
+      h,
+      kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange,
+      attrs,
+      &pb);
+  CFRelease(attrs);
+  if (status != kCVReturnSuccess || pb == nullptr) {
+    return nullptr;
+  }
+
+  CVPixelBufferLockBaseAddress(pb, 0);
+
+  // Fill Y plane (16-bit values, upper 8 bits contain the 10-bit data)
+  uint16_t* y_base =
+      static_cast<uint16_t*>(CVPixelBufferGetBaseAddressOfPlane(pb, 0));
+  const size_t y_stride = CVPixelBufferGetBytesPerRowOfPlane(pb, 0) / 2;
+  const uint16_t y_val_10bit = static_cast<uint16_t>(y_val) << 8;
+  for (int32_t y = 0; y < h; ++y) {
+    for (int32_t x = 0; x < w; ++x) {
+      y_base[y * y_stride + x] = y_val_10bit;
+    }
+  }
+
+  // Fill UV plane (interleaved 16-bit CbCr values)
+  uint16_t* uv_base =
+      static_cast<uint16_t*>(CVPixelBufferGetBaseAddressOfPlane(pb, 1));
+  const size_t uv_stride = CVPixelBufferGetBytesPerRowOfPlane(pb, 1) / 2;
+  const int32_t uv_h = (h + 1) / 2;
+  const int32_t uv_w = (w + 1) / 2;
+  const uint16_t uv_val_10bit = static_cast<uint16_t>(uv_val) << 8;
+  for (int32_t y = 0; y < uv_h; ++y) {
+    for (int32_t x = 0; x < uv_w; ++x) {
+      uv_base[y * uv_stride + x * 2] = uv_val_10bit; // Cb
+      uv_base[y * uv_stride + x * 2 + 1] = uv_val_10bit; // Cr
+    }
+  }
+
+  CVPixelBufferUnlockBaseAddress(pb, 0);
+  return pb;
+}
+
+// Create an 8-bit NV12 (420YpCbCr8BiPlanar) CVPixelBuffer in the given range
+// (pass kCVPixelFormatType_420YpCbCr8BiPlanar{Video,Full}Range). Plane 0 is the
+// Y plane; plane 1 is interleaved CbCr. Caller releases.
+CVPixelBufferRef make_nv12_pixelbuffer(
+    int32_t w,
+    int32_t h,
+    uint8_t y_val,
+    uint8_t cb_val,
+    uint8_t cr_val,
+    OSType format) {
+  CVPixelBufferRef pb = nullptr;
+  CFDictionaryRef attrs = make_iosurface_attrs();
+  const CVReturn status =
+      CVPixelBufferCreate(kCFAllocatorDefault, w, h, format, attrs, &pb);
+  CFRelease(attrs);
+  if (status != kCVReturnSuccess || pb == nullptr) {
+    return nullptr;
+  }
+
+  CVPixelBufferLockBaseAddress(pb, 0);
+
+  uint8_t* y_base =
+      static_cast<uint8_t*>(CVPixelBufferGetBaseAddressOfPlane(pb, 0));
+  const size_t y_stride = CVPixelBufferGetBytesPerRowOfPlane(pb, 0);
+  for (int32_t y = 0; y < h; ++y) {
+    for (int32_t x = 0; x < w; ++x) {
+      y_base[y * y_stride + x] = y_val;
+    }
+  }
+
+  uint8_t* uv_base =
+      static_cast<uint8_t*>(CVPixelBufferGetBaseAddressOfPlane(pb, 1));
+  const size_t uv_stride = CVPixelBufferGetBytesPerRowOfPlane(pb, 1);
+  const int32_t uv_h = (h + 1) / 2;
+  const int32_t uv_w = (w + 1) / 2;
+  for (int32_t y = 0; y < uv_h; ++y) {
+    for (int32_t x = 0; x < uv_w; ++x) {
+      uv_base[y * uv_stride + x * 2] = cb_val; // Cb
+      uv_base[y * uv_stride + x * 2 + 1] = cr_val; // Cr
+    }
+  }
+
+  CVPixelBufferUnlockBaseAddress(pb, 0);
+  return pb;
+}
+
+ImageProcessorConfig make_config(int32_t w, int32_t h) {
+  ImageProcessorConfig config;
+  config.target_width = w;
+  config.target_height = h;
+  return config;
+}
+
+// Solid-color semi-planar YUV in CPU memory (raw planes, no CVPixelBuffer).
+// NV12 stores chroma as Cb,Cr; NV21 as Cr,Cb -- so the SAME logical (cb, cr)
+// decodes to the same RGB under either format, letting a test assert NV21 ==
+// NV12 to prove the Cr<->Cb correction is applied. `y` is w*h bytes (stride w);
+// `uv` is (w/2 * h/2) interleaved chroma pairs (stride w). Requires even w, h.
+struct PlanarYuv {
+  std::vector<uint8_t> y;
+  std::vector<uint8_t> uv;
+};
+
+PlanarYuv make_solid_yuv(
+    int32_t w,
+    int32_t h,
+    uint8_t y_val,
+    uint8_t cb,
+    uint8_t cr,
+    YUVFormat format) {
+  PlanarYuv out;
+  out.y.assign(static_cast<size_t>(w) * h, y_val);
+  const int32_t cw = w / 2;
+  const int32_t ch = h / 2;
+  out.uv.resize(static_cast<size_t>(cw) * ch * 2);
+  const bool nv12 = (format == YUVFormat::NV12);
+  for (int32_t i = 0; i < cw * ch; ++i) {
+    out.uv[i * 2 + 0] = nv12 ? cb : cr;
+    out.uv[i * 2 + 1] = nv12 ? cr : cb;
+  }
+  return out;
+}
+
+// Config of the given target size forced onto the CPU path.
+ImageProcessorConfig cpu_config(int32_t w, int32_t h) {
+  auto config = make_config(w, h);
+  config.gpu_min_input_pixels = ImageProcessorConfig::kGpuNever;
+  return config;
+}
+
+// Config of the given target size forced onto the GPU path.
+ImageProcessorConfig gpu_config(int32_t w, int32_t h) {
+  auto config = make_config(w, h);
+  config.gpu_min_input_pixels = ImageProcessorConfig::kGpuAlways;
+  return config;
+}
+
+// Assert two CHW float result tensors are elementwise close.
+void expect_tensors_near(
+    const TensorPtr& a,
+    const TensorPtr& b,
+    float eps = 0.05f) {
+  ASSERT_EQ(a->numel(), b->numel());
+  const float* pa = a->const_data_ptr<float>();
+  const float* pb = b->const_data_ptr<float>();
+  for (int64_t i = 0; i < a->numel(); ++i) {
+    EXPECT_NEAR(pa[i], pb[i], eps) << "mismatch at " << i;
+  }
+}
+
+} // namespace
+
+// Verifies the Core Image ROI crop is rebased to the coordinate-space origin
+// so the render bounds {0,0,tw,th} sample the correct region.
+TEST(AppleRoiTest, OffsetRoiCpuGpuEquivalence) {
+  // Right-half ROI (x-offset only, full height) on horizontally-split content.
+  // The x-only offset keeps this focused on the render-bounds origin and
+  // sidesteps the separate y-axis convention question.
+  const int32_t w = 8, h = 8;
+  auto bgra =
+      make_split_bgra(w, h, /*left*/ 30, 60, 90, /*right*/ 200, 150, 100);
+  const NormalizedRect roi{0.5f, 0.0f, 0.5f, 1.0f};
+
+  ImageProcessor cpu(cpu_config(4, 4));
+  ImageProcessor gpu(gpu_config(4, 4));
+  auto cpu_res = cpu.process(
+      bgra.data(), w, h, w * 4, ColorFormat::BGRA, Orientation::UP, roi);
+  auto gpu_res = gpu.process(
+      bgra.data(), w, h, w * 4, ColorFormat::BGRA, Orientation::UP, roi);
+  ASSERT_TRUE(cpu_res.ok());
+  ASSERT_TRUE(gpu_res.ok());
+  expect_tensors_near(cpu_res.get(), gpu_res.get());
+
+  // The right-half ROI is the solid 'right' color, so the result must be that
+  // color -- guards against selecting the wrong region even if cpu == gpu.
+  EXPECT_NEAR(
+      cpu_res.get()->const_data_ptr<float>()[0], 200.0f / 255.0f, 0.02f);
+}
+
+// Mirror of OffsetRoiCpuGpuEquivalence for the y-axis: a bottom-half ROI
+// (y-offset only, full width) on vertically-split content. Core Image's
+// coordinate origin is bottom-left while the CPU pipeline treats the buffer as
+// top-origin, so a y-offset ROI is the case where the two conventions could
+// diverge. Verifies they crop the same region and, via the anchor below,
+// the correct (non-flipped) one.
+TEST(AppleRoiTest, OffsetRoiYAxisCpuGpuEquivalence) {
+  const int32_t w = 8, h = 8;
+  auto bgra =
+      make_vsplit_bgra(w, h, /*top*/ 30, 60, 90, /*bottom*/ 200, 150, 100);
+  const NormalizedRect roi{0.0f, 0.5f, 1.0f, 0.5f};
+
+  ImageProcessor cpu(cpu_config(4, 4));
+  ImageProcessor gpu(gpu_config(4, 4));
+  auto cpu_res = cpu.process(
+      bgra.data(), w, h, w * 4, ColorFormat::BGRA, Orientation::UP, roi);
+  auto gpu_res = gpu.process(
+      bgra.data(), w, h, w * 4, ColorFormat::BGRA, Orientation::UP, roi);
+  ASSERT_TRUE(cpu_res.ok());
+  ASSERT_TRUE(gpu_res.ok());
+  expect_tensors_near(cpu_res.get(), gpu_res.get());
+
+  // The bottom-half ROI is the solid 'bottom' color, so the result must be that
+  // color -- guards against selecting the wrong (e.g. vertically-flipped)
+  // region even if cpu == gpu.
+  EXPECT_NEAR(
+      cpu_res.get()->const_data_ptr<float>()[0], 200.0f / 255.0f, 0.02f);
+}
+
+// Verifies RGBAf letterbox normalization follows the strided sub-rectangle
+// rather than treating it as one contiguous block.
+TEST(ApplePixelBufferTest, ImageNetLetterboxCpuGpuEquivalence) {
+  // A tall (portrait) input letterboxed into a square target produces
+  // horizontal padding (resize_w < target_width), routing the GPU RGBAf path
+  // through the strided per-row normalize. With a non-identity (imagenet)
+  // normalization, a single contiguous vDSP pass would corrupt the pad columns
+  // between rows and skip trailing content rows. The GPU pixel-buffer path must
+  // match the CPU pipeline (which normalizes BGRA per-row).
+  CVPixelBufferRef pb = make_bgra_pixelbuffer(4, 12, 200, 100, 50);
+  ASSERT_NE(pb, nullptr);
+
+  auto make = [](bool cpu_only) {
+    ImageProcessorConfig c = make_config(8, 8);
+    c.resize_mode = ResizeMode::LETTERBOX;
+    c.letterbox_anchor = LetterboxAnchor::CENTER;
+    c.pad_value = 0.0f;
+    c.normalization = Normalization::imagenet();
+    c.gpu_min_input_pixels = cpu_only ? ImageProcessorConfig::kGpuNever
+                                      : ImageProcessorConfig::kGpuAlways;
+    return c;
+  };
+
+  ImageProcessor cpu(make(true));
+  ImageProcessor gpu(make(false));
+  auto cpu_res = process_pixelbuffer(cpu, pb);
+  auto gpu_res = process_pixelbuffer(gpu, pb);
+  CVPixelBufferRelease(pb);
+
+  ASSERT_TRUE(cpu_res.ok());
+  ASSERT_TRUE(gpu_res.ok());
+  expect_tensors_near(cpu_res.get(), gpu_res.get());
+}
+
+// Verifies 10-bit P010 (420YpCbCr10BiPlanar) pixel buffer format works.
+TEST(ApplePixelBufferTest, P010Format) {
+  CVPixelBufferRef pb = make_p010_pixelbuffer(8, 6, 128, 128);
+  ASSERT_NE(pb, nullptr);
+
+  ImageProcessor processor(make_config(4, 4));
+  auto result = process_pixelbuffer(processor, pb);
+  CVPixelBufferRelease(pb);
+
+  ASSERT_TRUE(result.ok());
+  auto& tensor = result.get();
+  EXPECT_EQ(tensor->size(0), 1);
+  EXPECT_EQ(tensor->size(1), 3);
+  EXPECT_EQ(tensor->size(2), 4);
+  EXPECT_EQ(tensor->size(3), 4);
+
+  const float* data = tensor->const_data_ptr<float>();
+  // Y=128, U=128, V=128 should produce mid-range RGB values
+  const float r0 = data[0];
+  EXPECT_GT(r0, 0.3f);
+  EXPECT_LT(r0, 0.7f);
+
+  // All pixels should be consistent (solid color input)
+  for (int i = 1; i < 16; ++i) {
+    EXPECT_NEAR(data[i], r0, 0.03f) << "R at " << i;
+  }
+}
+
+// Verifies P010 format produces similar results on CPU and GPU.
+TEST(ApplePixelBufferTest, P010CpuGpuEquivalence) {
+  CVPixelBufferRef pb = make_p010_pixelbuffer(8, 6, 128, 128);
+  ASSERT_NE(pb, nullptr);
+
+  ImageProcessor cpu(cpu_config(4, 4));
+  ImageProcessor gpu(gpu_config(4, 4));
+  auto cpu_res = process_pixelbuffer(cpu, pb);
+  auto gpu_res = process_pixelbuffer(gpu, pb);
+  CVPixelBufferRelease(pb);
+
+  ASSERT_TRUE(cpu_res.ok());
+  ASSERT_TRUE(gpu_res.ok());
+  expect_tensors_near(cpu_res.get(), gpu_res.get());
+}
+
+// 8-bit NV12 carries its quantization range in its pixel-format type
+// (...8BiPlanarVideoRange vs ...8BiPlanarFullRange). The decode must honor it:
+// the GPU path (Core Image) reads the range from the buffer and decodes
+// correctly, and the CPU pipeline must match.
+//
+// Neutral chroma (Cb=Cr=128) makes R=G=B a function of luma alone, so the
+// matrix (601 vs 709) is irrelevant and only the range matters:
+//   full range:  channel = Y / 255
+//   video range: channel = clamp((Y - 16) / 219, 0, 1)
+// At Y=235 these diverge maximally: full ~= 0.922, video clamps to 1.0
+// (diff ~0.078, well beyond kEps). A CPU decode that assumes video range for a
+// full-range buffer therefore reads ~1.0 and fails this comparison.
+TEST(ApplePixelBufferTest, FullRangeNV12CpuGpuEquivalence) {
+  const int32_t w = 8, h = 6;
+  // Bright gray that is full-range white-ish but *above* the video-range white
+  // point (235), so a video-range decode over-stretches it to clipping.
+  const uint8_t y_val = 235;
+
+  CVPixelBufferRef pb = make_nv12_pixelbuffer(
+      w,
+      h,
+      y_val,
+      /*cb*/ 128,
+      /*cr*/ 128,
+      kCVPixelFormatType_420YpCbCr8BiPlanarFullRange);
+  ASSERT_NE(pb, nullptr);
+
+  ImageProcessor cpu(cpu_config(4, 4));
+  ImageProcessor gpu(gpu_config(4, 4));
+  auto cpu_res = process_pixelbuffer(cpu, pb);
+  auto gpu_res = process_pixelbuffer(gpu, pb);
+  CVPixelBufferRelease(pb);
+
+  ASSERT_TRUE(cpu_res.ok());
+  ASSERT_TRUE(gpu_res.ok());
+
+  // Anchor the correct answer: full-range neutral-chroma gray decodes to ~Y/255
+  // per channel, with the GPU path as the reference.
+  EXPECT_NEAR(
+      gpu_res.get()->const_data_ptr<float>()[0],
+      static_cast<float>(y_val) / 255.0f,
+      0.03f);
+  expect_tensors_near(cpu_res.get(), gpu_res.get());
+}
+
+// RGBA raw bytes take a separate route from BGRA on both backends (GPU uses
+// CI_PIXEL_FORMAT_RGBA8; CPU permutes via to_bgra). Distinct R/G/B values make
+// a wrong channel mapping detectable. The two backends must agree.
+TEST(AppleColorFormatTest, RgbaRawBytesCpuGpuEquivalence) {
+  const int32_t w = 8, h = 8;
+  const uint8_t R = 200, G = 120, B = 40;
+  std::vector<uint8_t> rgba(static_cast<size_t>(w) * h * 4);
+  for (int32_t i = 0; i < w * h; ++i) {
+    rgba[i * 4 + 0] = R;
+    rgba[i * 4 + 1] = G;
+    rgba[i * 4 + 2] = B;
+    rgba[i * 4 + 3] = 255;
+  }
+
+  ImageProcessor cpu(cpu_config(4, 4));
+  ImageProcessor gpu(gpu_config(4, 4));
+  auto cpu_res = cpu.process(
+      rgba.data(), w, h, w * 4, ColorFormat::RGBA, Orientation::UP, kFullImage);
+  auto gpu_res = gpu.process(
+      rgba.data(), w, h, w * 4, ColorFormat::RGBA, Orientation::UP, kFullImage);
+  ASSERT_TRUE(cpu_res.ok());
+  ASSERT_TRUE(gpu_res.ok());
+  expect_tensors_near(cpu_res.get(), gpu_res.get());
+
+  // Channel-order anchor: output is CHW (R, G, B planes). A BGRA/RGBA mixup
+  // would swap the R and B planes.
+  const float* cpu_data = cpu_res.get()->const_data_ptr<float>();
+  const size_t spatial = static_cast<size_t>(4) * 4;
+  EXPECT_NEAR(cpu_data[0], R / 255.0f, 0.02f); // R plane
+  EXPECT_NEAR(cpu_data[2 * spatial], B / 255.0f, 0.02f); // B plane
+}
+
+// Combined x+y ROI offset (bottom-right quarter). The single-axis ROI tests
+// cover x and y independently; this locks in both offsets together. Built
+// inline as four red quadrants (TL=50, TR=100, BL=150, BR=200) so the selected
+// region's color is unambiguous.
+TEST(AppleRoiTest, OffsetRoiXYCpuGpuEquivalence) {
+  const int32_t w = 8;
+  const int32_t h = 8;
+  std::vector<uint8_t> bgra(static_cast<size_t>(w) * h * 4);
+  for (int32_t y = 0; y < h; ++y) {
+    for (int32_t x = 0; x < w; ++x) {
+      const size_t i = (static_cast<size_t>(y) * w + x) * 4;
+      const bool bottom = y >= h / 2;
+      const bool right = x >= w / 2;
+      bgra[i + 0] = 0; // B
+      bgra[i + 1] = 0; // G
+      bgra[i + 2] = bottom ? (right ? 200 : 150) : (right ? 100 : 50); // R
+      bgra[i + 3] = 255;
+    }
+  }
+  // Bottom-right quarter -> the BR quadrant (R=200).
+  const NormalizedRect roi{0.5f, 0.5f, 0.5f, 0.5f};
+
+  ImageProcessor cpu(cpu_config(4, 4));
+  ImageProcessor gpu(gpu_config(4, 4));
+  auto cpu_res = cpu.process(
+      bgra.data(), w, h, w * 4, ColorFormat::BGRA, Orientation::UP, roi);
+  auto gpu_res = gpu.process(
+      bgra.data(), w, h, w * 4, ColorFormat::BGRA, Orientation::UP, roi);
+  ASSERT_TRUE(cpu_res.ok());
+  ASSERT_TRUE(gpu_res.ok());
+  expect_tensors_near(cpu_res.get(), gpu_res.get());
+
+  // Bottom-right quadrant is solid R=200; guards against selecting the wrong
+  // corner even if cpu == gpu.
+  EXPECT_NEAR(
+      cpu_res.get()->const_data_ptr<float>()[0], 200.0f / 255.0f, 0.02f);
+}
+
+// process_yuv() raw-planes GPU path (ci_process_yuv_to_bgra, which synthesizes
+// a CVPixelBuffer from the planes) is otherwise untested -- the pixel-buffer
+// tests go through a different helper (ci_process_pixelbuffer_to_bgra).
+// Non-neutral chroma exercises the full YUV->RGB matrix; both backends use
+// BT.601 and must agree.
+TEST(AppleYuvTest, Nv12ProcessYuvCpuGpuEquivalence) {
+  const int32_t w = 8, h = 6;
+  const auto yuv =
+      make_solid_yuv(w, h, /*y*/ 150, /*cb*/ 100, /*cr*/ 180, YUVFormat::NV12);
+
+  ImageProcessor cpu(cpu_config(4, 4));
+  ImageProcessor gpu(gpu_config(4, 4));
+  auto cpu_res =
+      cpu.process_yuv(yuv.y.data(), w, yuv.uv.data(), w, w, h, YUVFormat::NV12);
+  auto gpu_res =
+      gpu.process_yuv(yuv.y.data(), w, yuv.uv.data(), w, w, h, YUVFormat::NV12);
+  ASSERT_TRUE(cpu_res.ok());
+  ASSERT_TRUE(gpu_res.ok());
+  expect_tensors_near(cpu_res.get(), gpu_res.get());
+}
+
+// NV21 reaches Apple only via process_yuv (CoreVideo has no NV21 pixel format),
+// and its Cr<->Cb correction is implemented differently per backend (CPU
+// permute vs GPU CIColorMatrix), so they can drift. Verify CPU == GPU, and that
+// NV21 decodes identically to an NV12 buffer carrying the same logical chroma
+// -- i.e. the swap is actually applied (a no-op swap would diverge under the
+// non-neutral chroma used here).
+TEST(AppleYuvTest, Nv21ProcessYuvCpuGpuEquivalence) {
+  const int32_t w = 8;
+  const int32_t h = 6;
+  const uint8_t yv = 150, cb = 100, cr = 180;
+  const auto nv21 = make_solid_yuv(w, h, yv, cb, cr, YUVFormat::NV21);
+  const auto nv12 = make_solid_yuv(w, h, yv, cb, cr, YUVFormat::NV12);
+
+  ImageProcessor cpu(cpu_config(4, 4));
+  ImageProcessor gpu(gpu_config(4, 4));
+  auto nv21_cpu = cpu.process_yuv(
+      nv21.y.data(), w, nv21.uv.data(), w, w, h, YUVFormat::NV21);
+  auto nv21_gpu = gpu.process_yuv(
+      nv21.y.data(), w, nv21.uv.data(), w, w, h, YUVFormat::NV21);
+  auto nv12_cpu = cpu.process_yuv(
+      nv12.y.data(), w, nv12.uv.data(), w, w, h, YUVFormat::NV12);
+  ASSERT_TRUE(nv21_cpu.ok());
+  ASSERT_TRUE(nv21_gpu.ok());
+  ASSERT_TRUE(nv12_cpu.ok());
+
+  expect_tensors_near(nv21_cpu.get(), nv21_gpu.get()); // cpu matches gpu
+  expect_tensors_near(nv21_cpu.get(), nv12_cpu.get()); // chroma swap applied
+}
+
+// process_pixelbuffer_into writes into a caller-owned tensor in place and must
+// produce the same result as the allocating process_pixelbuffer variant.
+// Verifies the result is written into `out`'s existing storage (no realloc).
+TEST(ApplePixelBufferIntoTest, WritesIntoOutAndMatchesProcessPixelbuffer) {
+  CVPixelBufferRef pb = make_bgra_pixelbuffer(8, 8, 200, 100, 50);
+  ASSERT_NE(pb, nullptr);
+
+  ImageProcessor processor(make_config(4, 4));
+  auto ref = process_pixelbuffer(processor, pb);
+  ASSERT_TRUE(ref.ok());
+
+  auto out = make_tensor_ptr({1, 3, 4, 4}, std::vector<float>(3 * 4 * 4));
+  const float* storage = out->const_data_ptr<float>();
+  auto err = process_pixelbuffer_into(processor, pb, Orientation::UP, *out);
+  CVPixelBufferRelease(pb);
+
+  ASSERT_EQ(err, Error::Ok);
+  // Result landed in the caller-provided buffer, not a freshly allocated one.
+  EXPECT_EQ(out->const_data_ptr<float>(), storage);
+  expect_tensors_near(out, ref.get());
+}
+
+// The same `out` tensor (and its backing allocation) can be reused across
+// frames; each call overwrites it with the current frame's result.
+TEST(ApplePixelBufferIntoTest, ReuseAcrossFrames) {
+  ImageProcessor processor(make_config(4, 4));
+  auto out = make_tensor_ptr({1, 3, 4, 4}, std::vector<float>(3 * 4 * 4));
+  const float* storage = out->const_data_ptr<float>();
+
+  CVPixelBufferRef pb1 = make_bgra_pixelbuffer(8, 8, 200, 100, 50);
+  ASSERT_NE(pb1, nullptr);
+  ASSERT_EQ(
+      process_pixelbuffer_into(processor, pb1, Orientation::UP, *out),
+      Error::Ok);
+  auto ref1 = process_pixelbuffer(processor, pb1);
+  CVPixelBufferRelease(pb1);
+  ASSERT_TRUE(ref1.ok());
+  expect_tensors_near(out, ref1.get());
+
+  // A second, differently-colored frame written into the same tensor.
+  CVPixelBufferRef pb2 = make_bgra_pixelbuffer(8, 8, 10, 220, 130);
+  ASSERT_NE(pb2, nullptr);
+  ASSERT_EQ(
+      process_pixelbuffer_into(processor, pb2, Orientation::UP, *out),
+      Error::Ok);
+  auto ref2 = process_pixelbuffer(processor, pb2);
+  CVPixelBufferRelease(pb2);
+  ASSERT_TRUE(ref2.ok());
+  expect_tensors_near(out, ref2.get());
+
+  // Same backing storage reused across both frames (no per-call allocation).
+  EXPECT_EQ(out->const_data_ptr<float>(), storage);
+}
+
+// process_pixelbuffer_into requires a contiguous Float [1, 3, target_h,
+// target_w] output; a mismatched tensor must be rejected rather than corrupt
+// memory. Mirrors ProcessIntoValidationTest in image_processor_test.cpp.
+TEST(ApplePixelBufferIntoTest, RejectsMalformedOutputTensor) {
+  CVPixelBufferRef pb = make_bgra_pixelbuffer(8, 8, 200, 100, 50);
+  ASSERT_NE(pb, nullptr);
+  ImageProcessor processor(make_config(4, 4));
+
+  // Wrong spatial size (target is 4x4).
+  auto wrong_size =
+      make_tensor_ptr({1, 3, 8, 8}, std::vector<float>(3 * 8 * 8));
+  EXPECT_EQ(
+      process_pixelbuffer_into(processor, pb, Orientation::UP, *wrong_size),
+      Error::InvalidArgument);
+
+  // Wrong rank.
+  auto wrong_rank = make_tensor_ptr({3, 4, 4}, std::vector<float>(3 * 4 * 4));
+  EXPECT_EQ(
+      process_pixelbuffer_into(processor, pb, Orientation::UP, *wrong_rank),
+      Error::InvalidArgument);
+
+  // Wrong dtype (Int, not Float).
+  auto wrong_dtype =
+      make_tensor_ptr({1, 3, 4, 4}, std::vector<int32_t>(3 * 4 * 4));
+  EXPECT_EQ(
+      process_pixelbuffer_into(processor, pb, Orientation::UP, *wrong_dtype),
+      Error::InvalidArgument);
+
+  CVPixelBufferRelease(pb);
+}
+
+#endif // __APPLE__

--- a/extension/image/test/image_processor_test.cpp
+++ b/extension/image/test/image_processor_test.cpp
@@ -794,6 +794,58 @@ TEST_P(ProcessTest, YuvFullRangeVsVideoRange) {
   EXPECT_GT(video_data[0] - full_data[0], 0.05f);
 }
 
+TEST_P(ProcessTest, YuvFullRangeNonNeutralChroma) {
+  // Full range + non-neutral chroma: the existing full-range test uses neutral
+  // chroma (R=G=B from luma alone, chroma irrelevant) and the non-neutral tests
+  // run video range, so this is the only case that validates the full-range
+  // BT.601 chroma decode end to end. Reference RGB is computed from the
+  // full-range BT.601 definition, independent of the implementation:
+  //   R = Y + 1.402   * (Cr - 128)
+  //   G = Y - 0.344136 * (Cb - 128) - 0.714136 * (Cr - 128)
+  //   B = Y + 1.772   * (Cb - 128)
+  // with Y, Cb, Cr in full-range [0, 255]. Values are chosen so no channel
+  // clamps, so a wrong matrix or bias surfaces directly on every channel.
+  const int32_t w = 4, h = 4;
+  const uint8_t y_val = 150, cb = 100, cr = 180;
+  auto img = make_yuv(w, h, y_val, cb, cr, YUVFormat::NV12);
+  ImageProcessor p(cfg(2, 2));
+
+  auto full = p.process_yuv(
+      img.y.data(),
+      w,
+      img.uv.data(),
+      w,
+      w,
+      h,
+      YUVFormat::NV12,
+      Orientation::UP,
+      kFullImage,
+      YUVRange::FULL);
+  ASSERT_TRUE(full.ok());
+
+  const float dcb = static_cast<float>(cb) - 128.0f;
+  const float dcr = static_cast<float>(cr) - 128.0f;
+  const float r = static_cast<float>(y_val) + 1.402f * dcr;
+  const float g = static_cast<float>(y_val) - 0.344136f * dcb - 0.714136f * dcr;
+  const float b = static_cast<float>(y_val) + 1.772f * dcb;
+
+  // Solid image: every pixel of each CHW channel plane equals that channel's
+  // decoded value. Target is 2x2, so 4 pixels per channel.
+  std::vector<float> expected(static_cast<size_t>(3) * 2 * 2);
+  for (int i = 0; i < 4; ++i) {
+    expected[i] = r / 255.0f;
+    expected[4 + i] = g / 255.0f;
+    expected[8 + i] = b / 255.0f;
+  }
+
+  expect_tensor_near(
+      full.get()->const_data_ptr<float>(),
+      expected.data(),
+      expected.size(),
+      0.02f,
+      "full-range non-neutral chroma");
+}
+
 TEST_P(ProcessTest, YuvDefaultsToVideoRange) {
   // Y=235 neutral chroma decodes to ~1.0 under video range; the default range
   // must match an explicit VIDEO request.

--- a/extension/image/test/targets.bzl
+++ b/extension/image/test/targets.bzl
@@ -19,3 +19,19 @@ def define_common_targets():
                 "//executorch/extension/image:image_processor" + aten_suffix,
             ],
         )
+
+    # Apple-specific GPU / CVPixelBuffer tests. The source is gated on
+    # __APPLE__, so on non-Apple platforms this builds as an empty (passing)
+    # test. CoreVideo is needed for the test's own CVPixelBuffer creation.
+    runtime.cxx_test(
+        name = "apple_test",
+        srcs = [
+            "image_processor_apple_test.cpp",
+        ],
+        deps = [
+            "//executorch/extension/image:image_processor",
+        ],
+        fbobjc_frameworks = [
+            "CoreVideo.framework",
+        ],
+    )


### PR DESCRIPTION
Summary:

Adds accelerated implementations for D106898421 for Apple platforms. On Apple platforms, the Apple implementation TUs (image_processor_apple.cpp) are selected for compilation. They use Accelerate for CPU, and CoreImage/Video for GPU.

In addition, image_processor_apple.h introduces Apple-specific APIs:

```
* process_pixelbuffer
* process_pixelbuffer_into
```

Which automatically route to RGB or YUV helpers based on the pixelbuffer.

Reviewed By: sddongxh

Differential Revision: D106898414


