### PR TITLE
[cuda backend] store scale/zero in int4_plain_mm in [N, n_groups] layout

### DIFF
--- a/backends/cuda/coalesced_int4_tensor.py
+++ b/backends/cuda/coalesced_int4_tensor.py
@@ -1,0 +1,119 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""ExecuTorch-internal INT4 tensor for the CUDA W4A8 dp4a decode kernel.
+
+``CudaCoalescedInt4Tensor`` is an ExecuTorch-internal tensor subclass. It is
+**NOT** torchao's ``Int4Tensor`` and is intentionally not a subclass of it, so
+torchao's ``Int4Tensor`` F.linear handlers never match it via the method
+resolution order. The CUDA decode/prefill dispatch (``int4_dispatch.py``) is
+selected by *type* — it is registered on this class only — so stock
+``Int4Tensor`` weights keep falling back to torchao's default (mslk/tinygemm)
+path.
+
+Layout difference from torchao ``Int4Tensor``:
+    qdata      : packed int4 weight (N, K/2), nibble-packed (same as Int4Tensor)
+    scale      : (N, n_groups) — the *coalesced* layout, transposed from
+                 torchao's documented (n_groups, N)
+    zero_point : (N, n_groups) — coalesced, transposed from (n_groups, N)
+
+The coalesced [N, n_groups] layout is exactly what the W4A8 dp4a matvec kernel
+(``executorch_cuda::int4_plain_mm`` / ``int4_plain_mm.cuh``) reads row-for-row
+with qdata, so the exported decode graph carries no per-step transpose. The
+transpose is owned by :meth:`from_int4_tensor` so it is baked into the
+serialized weight constant once at pack time.
+"""
+
+from typing import List, Optional
+
+import torch
+from torchao.quantization.quantize_.workflows.int4.int4_tensor import Int4Tensor
+from torchao.utils import TorchAOBaseTensor
+
+__all__ = [
+    "CudaCoalescedInt4Tensor",
+]
+
+
+class CudaCoalescedInt4Tensor(TorchAOBaseTensor):
+    """INT4 weight with scale/zero_point in the coalesced [N, n_groups] layout.
+
+    ExecuTorch-internal; see the module docstring. Mirrors torchao
+    ``Int4Tensor``'s data/attribute layout (so the common tensor utilities and
+    serialization work) but owns the [n_groups, N] -> [N, n_groups] transpose
+    of scale/zero_point via :meth:`from_int4_tensor`.
+    """
+
+    tensor_data_names = ["qdata", "scale", "zero_point"]
+    tensor_attribute_names = ["block_size", "shape"]
+    optional_tensor_data_names = ["act_pre_scale"]
+    optional_tensor_attribute_names = ["activation_dtype"]
+
+    def __new__(
+        cls,
+        qdata: torch.Tensor,
+        scale: torch.Tensor,
+        zero_point: torch.Tensor,
+        block_size: List[int],
+        shape: torch.Size,
+        act_pre_scale: Optional[torch.Tensor] = None,
+        activation_dtype: Optional[torch.dtype] = None,
+    ):
+        kwargs = {}
+        kwargs["device"] = qdata.device
+        kwargs["dtype"] = scale.dtype
+        kwargs["requires_grad"] = False
+        return torch.Tensor._make_wrapper_subclass(cls, shape, **kwargs)  # type: ignore[attr-defined]
+
+    def __init__(
+        self,
+        qdata: torch.Tensor,
+        scale: torch.Tensor,
+        zero_point: torch.Tensor,
+        block_size: List[int],
+        shape: torch.Size,
+        act_pre_scale: Optional[torch.Tensor] = None,
+        activation_dtype: Optional[torch.dtype] = None,
+    ):
+        super().__init__()
+        self.qdata = qdata
+        self.scale = scale
+        self.zero_point = zero_point
+        self.block_size = block_size
+        self.activation_dtype = (
+            activation_dtype if activation_dtype is not None else torch.bfloat16
+        )
+        self.act_pre_scale = act_pre_scale
+
+    def _quantization_type(self):
+        s = f"shape={self.shape}, block_size={self.block_size}, device={self.device}, activation_dtype={self.activation_dtype}"
+        if self.act_pre_scale is not None:
+            s += f", act_pre_scale.shape={self.act_pre_scale.shape}"
+        return s
+
+    @classmethod
+    def from_int4_tensor(cls, t: Int4Tensor) -> "CudaCoalescedInt4Tensor":
+        """Build a coalesced tensor from a torchao ``Int4Tensor``.
+
+        Owns the transpose: torchao stores scale/zero_point as (n_groups, N);
+        the CUDA decode kernel reads (N, n_groups). The ``.t().contiguous()``
+        here is baked into the serialized weight constant so the exported
+        decode graph has no per-step transpose/clone.
+        """
+        return cls(
+            t.qdata,
+            t.scale.t().contiguous(),
+            t.zero_point.t().contiguous(),
+            t.block_size,
+            t.shape,
+            t.act_pre_scale,
+            t.activation_dtype,
+        )
+
+
+# Allow a model with CudaCoalescedInt4Tensor weights to be loaded with
+# `weights_only=True` (mirrors torchao Int4Tensor).
+torch.serialization.add_safe_globals([CudaCoalescedInt4Tensor])

--- a/backends/cuda/quantize_op_dispatch/__init__.py
+++ b/backends/cuda/quantize_op_dispatch/__init__.py
@@ -10,8 +10,8 @@ Importing this package overrides the F.linear dispatch of torchao quantized
 weight tensors so that torch.export traces through ExecuTorch's custom ops and
 dequant logic instead of torchao's defaults. It registers:
 
-  * INT4 (``Int4Tensor``)               → ``executorch_cuda::int4_plain_mm``
-  * INT8 (``IntxUnpackedToInt8Tensor``)  → ``executorch_cuda::int8_plain_mm``
+  * INT4 (``CudaCoalescedInt4Tensor``)  → ``executorch_cuda::int4_plain_mm``
+  * INT8 (``IntxUnpackedToInt8Tensor``) → ``executorch_cuda::int8_plain_mm``
 
 See ``int4_dispatch`` and ``int8_dispatch`` for the per-dtype details.
 

--- a/backends/cuda/quantize_op_dispatch/int4_dispatch.py
+++ b/backends/cuda/quantize_op_dispatch/int4_dispatch.py
@@ -4,12 +4,14 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-"""Int4Tensor F.linear dispatch for CUDA — runs at eager / export trace time.
+"""CudaCoalescedInt4Tensor F.linear dispatch for CUDA — runs at eager / export trace time.
 
-This module overrides Int4Tensor's F.linear dispatch so that torch.export
-traces through our custom op and dequant logic instead of torchao's default
-(mslk/tinygemm). The code here executes during eager inference and during
-AOTI export tracing — it does NOT run at .pte runtime.
+This module registers an F.linear dispatch on ``CudaCoalescedInt4Tensor`` (an
+ExecuTorch-internal subclass, see ``coalesced_int4_tensor.py``) so that
+torch.export traces through our custom op and dequant logic. Routing is by
+*type*: stock torchao ``Int4Tensor`` weights are left untouched and keep using
+torchao's default (mslk/tinygemm) path. The code here executes during eager
+inference and during AOTI export tracing — it does NOT run at .pte runtime.
 
 At .pte runtime, the captured graph is executed by the AOTI-generated .so:
   - The custom op ``executorch_cuda::int4_plain_mm`` maps to a C shim that
@@ -22,17 +24,17 @@ Dispatch strategy (determines what gets captured in the export graph):
   Prefill (M>4): Inline dequant + F.linear (standard PyTorch ops)
 
 Importing the parent ``quantize_op_dispatch`` package registers this dispatch
-override (along with the INT8 one) before using nn.Linear with Int4Tensor
-weights::
+override (along with the INT8 one) before using nn.Linear with
+CudaCoalescedInt4Tensor weights::
 
     import executorch.backends.cuda.quantize_op_dispatch  # noqa: F401
 """
 
 import torch
 import torch.nn.functional as F
+from executorch.backends.cuda.coalesced_int4_tensor import CudaCoalescedInt4Tensor
 from executorch.backends.cuda.quantize_op_dispatch._library import lib as _lib
 from torch.library import impl
-from torchao.quantization.quantize_.workflows.int4.int4_tensor import Int4Tensor
 
 # ---------------------------------------------------------------------------
 # Custom op for decode (M=1): dp4a matvec in C shim, dequant+F.linear in eager
@@ -52,11 +54,18 @@ def _meta(self, qdata, scale, zero, group_size):
 
 @impl(_lib, "int4_plain_mm", "CUDA")
 def _cuda(self, qdata, scale, zero, group_size):
+    # scale/zero are stored in the coalesced [N, n_groups] layout (transposed
+    # at pack time, see pack_cuda.pack_linear_for_cuda), which is exactly what
+    # _dequant_matmul expects.
     return _dequant_matmul(self, qdata, scale, zero, group_size)
 
 
 def _dequant_matmul(x, qdata, scale, zero, group_size):
-    """Dequant INT4 weights to input dtype and call F.linear."""
+    """Dequant INT4 weights to input dtype and call F.linear.
+
+    scale/zero are in the coalesced [N, n_groups] layout (baked into the
+    weight constant at pack time), aligned row-for-row with qdata's [N, *].
+    """
     N, K_half = qdata.shape
     K = K_half * 2
     n_groups = K // group_size
@@ -68,20 +77,20 @@ def _dequant_matmul(x, qdata, scale, zero, group_size):
     high = ((p >> 4) & 0x0F).to(dtype)
     data = torch.stack([low, high], dim=-1).reshape(N, n_groups, group_size)
 
-    s = scale.to(dtype).t().unsqueeze(-1)
-    z = zero.to(dtype).t().unsqueeze(-1)
+    s = scale.to(dtype).unsqueeze(-1)
+    z = zero.to(dtype).unsqueeze(-1)
     w_deq = ((data - z) * s).reshape(N, K)
 
     return F.linear(x, w_deq)
 
 
 # ---------------------------------------------------------------------------
-# Int4Tensor F.linear dispatch
+# CudaCoalescedInt4Tensor F.linear dispatch
 # ---------------------------------------------------------------------------
 
 aten = torch.ops.aten
-_implements = Int4Tensor.implements
-_implements_torch_function = Int4Tensor.implements_torch_function
+_implements = CudaCoalescedInt4Tensor.implements
+_implements_torch_function = CudaCoalescedInt4Tensor.implements_torch_function
 
 
 @_implements([aten.linear.default])
@@ -101,6 +110,11 @@ def _(func, types, args, kwargs):
 
     M = x_2d.shape[0]
     if M <= 4:
+        # scale/zero are already in the coalesced [N, n_groups] layout the
+        # decode kernel reads directly (baked into the weight constant at pack
+        # time). Passing them straight through keeps the export graph free of
+        # any per-step transpose/clone, so the coalesced layout is realized
+        # without recomputing it every decode step.
         out = torch.ops.executorch_cuda.int4_plain_mm(x_2d, qdata, scale, zero, gs)
     else:
         out = _dequant_matmul(x_2d, qdata, scale, zero, gs)

--- a/backends/cuda/runtime/shims/int4_plain_mm.cu
+++ b/backends/cuda/runtime/shims/int4_plain_mm.cu
@@ -52,8 +52,43 @@ AOTITorchError aoti_torch_cuda_int4_plain_mm(
       InvalidArgument,
       "aoti_torch_cuda_int4_plain_mm: ret0 is null");
 
+  // Validate the coalesced scale/zero layout [N, K/group_size]
+
+  const int64_t N = qdata->size(0);
+  const int64_t K = qdata->size(1) * 2;
+
+  ET_CHECK_OR_RETURN_ERROR(
+      group_size > 0 && (group_size & (group_size - 1)) == 0,
+      InvalidArgument,
+      "aoti_torch_cuda_int4_plain_mm: group_size=%lld must be a positive power of 2",
+      static_cast<long long>(group_size));
+
+  const int64_t n_groups = K / group_size;
+
+  ET_CHECK_OR_RETURN_ERROR(
+      scale->dim() == 2 && zero->dim() == 2,
+      InvalidArgument,
+      "aoti_torch_cuda_int4_plain_mm: scale/zero must be 2D (got scale.dim()=%lld, zero.dim()=%lld)",
+      static_cast<long long>(scale->dim()),
+      static_cast<long long>(zero->dim()));
+
+  ET_CHECK_OR_RETURN_ERROR(
+      scale->size(0) == N && zero->size(0) == N,
+      InvalidArgument,
+      "aoti_torch_cuda_int4_plain_mm: scale/zero must be coalesced [N, K/group_size] (AOT layout); native [n_groups, N] is not supported - repack via pack_linear_for_cuda. Expected size(0)=N=%lld, got scale.size(0)=%lld, zero.size(0)=%lld",
+      static_cast<long long>(N),
+      static_cast<long long>(scale->size(0)),
+      static_cast<long long>(zero->size(0)));
+
+  ET_CHECK_OR_RETURN_ERROR(
+      scale->size(1) == n_groups && zero->size(1) == n_groups,
+      InvalidArgument,
+      "aoti_torch_cuda_int4_plain_mm: scale/zero must be coalesced [N, K/group_size] (AOT layout); native [n_groups, N] is not supported - repack via pack_linear_for_cuda. Expected size(1)=K/group_size=%lld, got scale.size(1)=%lld, zero.size(1)=%lld",
+      static_cast<long long>(n_groups),
+      static_cast<long long>(scale->size(1)),
+      static_cast<long long>(zero->size(1)));
+
   int32_t M = self->size(0);
-  int32_t N = qdata->size(0);
   Tensor* C = nullptr;
   std::array<int64_t, 2> c_shape = {M, N};
   std::array<int64_t, 2> c_stride = {N, 1};

--- a/backends/cuda/runtime/shims/int4_plain_mm.cuh
+++ b/backends/cuda/runtime/shims/int4_plain_mm.cuh
@@ -9,7 +9,7 @@
 // W4A8 dp4a matvec for INT4 decode (M <= 4).
 //
 // Reads plain nibble-packed [N, K//2] weights (Int4Tensor format).
-// Scale/zero layout: [K//gs, N] (Int4Tensor's native layout).
+// Scale/zero layout: [N, K//gs] (transposed AOT for coalesced loads).
 //
 // Dynamically quantizes bf16 activations to INT8 (per-32-element blocks),
 // then uses dp4a for fused int4×int8 dot products with 16-byte vectorized
@@ -98,18 +98,28 @@ __global__ void quantize_activations_q8_kernel(
 }
 
 // ---------------------------------------------------------------------------
-// W4A8 dp4a matvec kernel
+// Coalesced-scale W4A8 dp4a matvec
+//
+// Reads scale/zero in the transposed [N, n_groups] layout (transposed AOT at
+// export time). With group_size >= 32, one uint4 (32 weights) maps to exactly
+// one activation block and one weight group, so within a warp the 32 lanes
+// touch 32 consecutive groups. In [N, n_groups] layout those 32 group scales
+// are contiguous => a single coalesced load, vs 32 stride-N cache lines in the
+// native layout. For the gemma group_size=32 weights this is the dominant
+// decode-matvec cost.
 // ---------------------------------------------------------------------------
 
-__global__ void __launch_bounds__(MV_THREADS) int4_w4a8_matvec_kernel(
-    const uint8_t* __restrict__ qdata,
-    const __nv_bfloat16* __restrict__ w_scale,
-    const __nv_bfloat16* __restrict__ w_zero,
-    const Q8Block* __restrict__ q8,
-    __nv_bfloat16* __restrict__ out,
-    int32_t N,
-    int32_t K,
-    int32_t gs_shift) {
+__global__ void __launch_bounds__(MV_THREADS)
+    int4_w4a8_matvec_coalesced_kernel(
+        const uint8_t* __restrict__ qdata,
+        const __nv_bfloat16* __restrict__ w_scale_t, // [N, n_groups]
+        const __nv_bfloat16* __restrict__ w_zero_t, // [N, n_groups]
+        const Q8Block* __restrict__ q8,
+        __nv_bfloat16* __restrict__ out,
+        int32_t N,
+        int32_t K,
+        int32_t gs_shift,
+        int32_t n_groups) {
   const int32_t n = blockIdx.x * MV_NWARPS + threadIdx.y;
   const int32_t m = blockIdx.y;
   if (n >= N)
@@ -120,9 +130,10 @@ __global__ void __launch_bounds__(MV_THREADS) int4_w4a8_matvec_kernel(
   const int32_t n_q8_blocks = K / Q8_BLOCK_SIZE;
 
   const uint8_t* qrow = qdata + static_cast<int64_t>(n) * K_half;
-  const __nv_bfloat16* scale_base = w_scale + n;
-  const __nv_bfloat16* zero_base = w_zero + n;
-  const int32_t scale_stride = N;
+  const __nv_bfloat16* scale_row =
+      w_scale_t + static_cast<int64_t>(n) * n_groups;
+  const __nv_bfloat16* zero_row =
+      w_zero_t + static_cast<int64_t>(n) * n_groups;
   const Q8Block* q8_row = q8 + static_cast<int64_t>(m) * n_q8_blocks;
 
   const uint4* qrow16 = reinterpret_cast<const uint4*>(qrow);
@@ -145,8 +156,8 @@ __global__ void __launch_bounds__(MV_THREADS) int4_w4a8_matvec_kernel(
       int32_t g = k_word >> gs_shift;
 
       if (g != prev_g) {
-        ws = __bfloat162float(__ldg(&scale_base[g * scale_stride]));
-        wz = __bfloat162float(__ldg(&zero_base[g * scale_stride]));
+        ws = __bfloat162float(__ldg(&scale_row[g]));
+        wz = __bfloat162float(__ldg(&zero_row[g]));
         prev_g = g;
       }
 
@@ -227,8 +238,8 @@ static Q8Block* get_q8_buffer(size_t needed) {
 void _int4_plain_mm_cuda(
     const Tensor& A, // [M, K] bf16
     const Tensor& qdata, // [N, K//2] uint8
-    const Tensor& scale, // [K//gs, N] bf16
-    const Tensor& zero, // [K//gs, N] bf16
+    const Tensor& scale, // [N, K//gs] bf16
+    const Tensor& zero, // [N, K//gs] bf16
     int64_t group_size,
     Tensor* output) { // [M, N] bf16, pre-allocated
   int32_t M = A.size(0);
@@ -245,9 +256,9 @@ void _int4_plain_mm_cuda(
   ET_CHECK(qdata.dim() == 2);
   ET_CHECK(qdata.size(1) == K / 2);
   ET_CHECK(scale.dim() == 2);
-  ET_CHECK(scale.size(1) == N);
+  ET_CHECK(scale.size(0) == N);
   ET_CHECK(zero.dim() == 2);
-  ET_CHECK(zero.size(1) == N);
+  ET_CHECK(zero.size(0) == N);
 
   int32_t gs = static_cast<int32_t>(group_size);
   ET_CHECK_MSG(
@@ -279,15 +290,15 @@ void _int4_plain_mm_cuda(
   // dp4a matvec
   dim3 grid((N + MV_NWARPS - 1) / MV_NWARPS, M);
   dim3 block(MV_WARP_SIZE, MV_NWARPS);
-  int4_w4a8_matvec_kernel<<<grid, block, 0, stream>>>(
+
+  int32_t n_groups = static_cast<int32_t>(scale.size(1));
+  int4_w4a8_matvec_coalesced_kernel<<<grid, block, 0, stream>>>(
       reinterpret_cast<const uint8_t*>(qdata.data_ptr()),
       reinterpret_cast<const __nv_bfloat16*>(scale.data_ptr()),
       reinterpret_cast<const __nv_bfloat16*>(zero.data_ptr()),
       q8_buf,
       reinterpret_cast<__nv_bfloat16*>(output->data_ptr()),
-      N,
-      K,
-      gs_shift);
+      N, K, gs_shift, n_groups);
 }
 
 } // namespace executorch::backends::cuda

--- a/backends/cuda/runtime/shims/tests/test_aoti_torch_cuda_int4_plain_mm.cpp
+++ b/backends/cuda/runtime/shims/tests/test_aoti_torch_cuda_int4_plain_mm.cpp
@@ -70,6 +70,18 @@ class AOTITorchInt4PlainMMTest : public ::testing::Test {
     cudaMemcpy(host_data, t->data_ptr(), bytes, cudaMemcpyDeviceToHost);
   }
 
+  // Transpose a uint16 [rows, cols] row-major buffer into [cols, rows].
+  // Used to convert native [n_groups, N] scale/zero literals into the
+  // [N, n_groups] layout the shim now expects (transposed AOT at export).
+  static std::vector<uint16_t>
+  transpose_u16(const uint16_t* src, int rows, int cols) {
+    std::vector<uint16_t> dst(static_cast<size_t>(rows) * cols);
+    for (int r = 0; r < rows; r++)
+      for (int c = 0; c < cols; c++)
+        dst[static_cast<size_t>(c) * rows + r] = src[r * cols + c];
+    return dst;
+  }
+
   // Run the shim and return the output tensor (asserts success).
   Tensor* run(
       Tensor* A,
@@ -111,7 +123,7 @@ class AOTITorchInt4PlainMMTest : public ::testing::Test {
 };
 
 // MultiGroupRandom: M=1, N=4, K=32, gs=16
-// scale/zero layout: [K//gs=2, N=4]
+// scale/zero layout: [N=4, K//gs=2] (transposed AOT)
 TEST_F(AOTITorchInt4PlainMMTest, MultiGroupRandom) {
   int64_t M = 1, K = 32, N = 4, gs = 16;
 
@@ -132,14 +144,17 @@ TEST_F(AOTITorchInt4PlainMMTest, MultiGroupRandom) {
   uint16_t expected[] = {0xBFCC, 0x3FB5, 0x4046, 0xC01E};
   // clang-format on
 
+  int64_t ng = K / gs;
   Tensor* A = create_bf16({M, K});
   Tensor* qdata = create_uint8({N, K / 2});
-  Tensor* scale = create_bf16({K / gs, N});
-  Tensor* zero = create_bf16({K / gs, N});
+  Tensor* scale = create_bf16({N, ng});
+  Tensor* zero = create_bf16({N, ng});
+  auto scale_t = transpose_u16(scale_host, ng, N);
+  auto zero_t = transpose_u16(zero_host, ng, N);
   upload(A, A_host, sizeof(A_host));
   upload(qdata, qdata_host, sizeof(qdata_host));
-  upload(scale, scale_host, sizeof(scale_host));
-  upload(zero, zero_host, sizeof(zero_host));
+  upload(scale, scale_t.data(), scale_t.size() * sizeof(uint16_t));
+  upload(zero, zero_t.data(), zero_t.size() * sizeof(uint16_t));
 
   Tensor* output = run(A, qdata, scale, zero, gs);
   ASSERT_NE(output, nullptr);
@@ -149,7 +164,7 @@ TEST_F(AOTITorchInt4PlainMMTest, MultiGroupRandom) {
 }
 
 // SingleGroup: M=1, N=8, K=32, gs=32
-// scale/zero layout: [K//gs=1, N=8]
+// scale/zero layout: [N=8, K//gs=1] (transposed AOT)
 TEST_F(AOTITorchInt4PlainMMTest, SingleGroup) {
   int64_t M = 1, K = 32, N = 8, gs = 32;
 
@@ -178,14 +193,17 @@ TEST_F(AOTITorchInt4PlainMMTest, SingleGroup) {
   uint16_t expected[] = {0xC031, 0x3BF8, 0x3E81, 0xBF19, 0x3FCB, 0xBF56, 0x4076, 0x3F20};
   // clang-format on
 
+  int64_t ng = K / gs;
   Tensor* A = create_bf16({M, K});
   Tensor* qdata = create_uint8({N, K / 2});
-  Tensor* scale = create_bf16({K / gs, N});
-  Tensor* zero = create_bf16({K / gs, N});
+  Tensor* scale = create_bf16({N, ng});
+  Tensor* zero = create_bf16({N, ng});
+  auto scale_t = transpose_u16(scale_host, ng, N);
+  auto zero_t = transpose_u16(zero_host, ng, N);
   upload(A, A_host, sizeof(A_host));
   upload(qdata, qdata_host, sizeof(qdata_host));
-  upload(scale, scale_host, sizeof(scale_host));
-  upload(zero, zero_host, sizeof(zero_host));
+  upload(scale, scale_t.data(), scale_t.size() * sizeof(uint16_t));
+  upload(zero, zero_t.data(), zero_t.size() * sizeof(uint16_t));
 
   Tensor* output = run(A, qdata, scale, zero, gs);
   ASSERT_NE(output, nullptr);
@@ -195,7 +213,7 @@ TEST_F(AOTITorchInt4PlainMMTest, SingleGroup) {
 }
 
 // PrefillBatch: M=8, N=4, K=64, gs=32
-// scale/zero layout: [K//gs=2, N=4]
+// scale/zero layout: [N=4, K//gs=2] (transposed AOT)
 TEST_F(AOTITorchInt4PlainMMTest, PrefillBatch) {
   int64_t M = 8, K = 64, N = 4, gs = 32;
 
@@ -224,14 +242,17 @@ TEST_F(AOTITorchInt4PlainMMTest, PrefillBatch) {
   uint16_t expected[] = {0x40BD, 0xC0E3, 0x4037, 0x40A9, 0x406F, 0x4116, 0x3F8D, 0xC01F, 0xC039, 0xC043, 0x3F86, 0x410A, 0x3F07, 0xC100, 0x4019, 0x40D7, 0x40A9, 0x40F1, 0xBF89, 0x406F, 0x40FE, 0xBFB8, 0xBF88, 0x406A, 0x4004, 0x3EDE, 0x3E17, 0x4102, 0xC081, 0xC0BA, 0xBFFB, 0x3F25};
   // clang-format on
 
+  int64_t ng = K / gs;
   Tensor* A = create_bf16({M, K});
   Tensor* qdata = create_uint8({N, K / 2});
-  Tensor* scale = create_bf16({K / gs, N});
-  Tensor* zero = create_bf16({K / gs, N});
+  Tensor* scale = create_bf16({N, ng});
+  Tensor* zero = create_bf16({N, ng});
+  auto scale_t = transpose_u16(scale_host, ng, N);
+  auto zero_t = transpose_u16(zero_host, ng, N);
   upload(A, A_host, sizeof(A_host));
   upload(qdata, qdata_host, sizeof(qdata_host));
-  upload(scale, scale_host, sizeof(scale_host));
-  upload(zero, zero_host, sizeof(zero_host));
+  upload(scale, scale_t.data(), scale_t.size() * sizeof(uint16_t));
+  upload(zero, zero_t.data(), zero_t.size() * sizeof(uint16_t));
 
   Tensor* output = run(A, qdata, scale, zero, gs);
   ASSERT_NE(output, nullptr);
@@ -241,7 +262,7 @@ TEST_F(AOTITorchInt4PlainMMTest, PrefillBatch) {
 }
 
 // GroupSize128: M=1, N=2, K=256, gs=128
-// scale/zero layout: [K//gs=2, N=2]
+// scale/zero layout: [N=2, K//gs=2] (transposed AOT)
 TEST_F(AOTITorchInt4PlainMMTest, GroupSize128) {
   int64_t M = 1, K = 256, N = 2, gs = 128;
 
@@ -286,14 +307,17 @@ TEST_F(AOTITorchInt4PlainMMTest, GroupSize128) {
   uint16_t expected[] = {0xC013, 0xBF05};
   // clang-format on
 
+  int64_t ng = K / gs;
   Tensor* A = create_bf16({M, K});
   Tensor* qdata = create_uint8({N, K / 2});
-  Tensor* scale = create_bf16({K / gs, N});
-  Tensor* zero = create_bf16({K / gs, N});
+  Tensor* scale = create_bf16({N, ng});
+  Tensor* zero = create_bf16({N, ng});
+  auto scale_t = transpose_u16(scale_host, ng, N);
+  auto zero_t = transpose_u16(zero_host, ng, N);
   upload(A, A_host, sizeof(A_host));
   upload(qdata, qdata_host, sizeof(qdata_host));
-  upload(scale, scale_host, sizeof(scale_host));
-  upload(zero, zero_host, sizeof(zero_host));
+  upload(scale, scale_t.data(), scale_t.size() * sizeof(uint16_t));
+  upload(zero, zero_t.data(), zero_t.size() * sizeof(uint16_t));
 
   Tensor* output = run(A, qdata, scale, zero, gs);
   ASSERT_NE(output, nullptr);
@@ -307,8 +331,8 @@ TEST_F(AOTITorchInt4PlainMMTest, NullInputHandling) {
 
   Tensor* A = create_bf16({M, K});
   Tensor* qdata = create_uint8({N, K / 2});
-  Tensor* scale = create_bf16({K / gs, N});
-  Tensor* zero = create_bf16({K / gs, N});
+  Tensor* scale = create_bf16({N, K / gs});
+  Tensor* zero = create_bf16({N, K / gs});
   Tensor* output = nullptr;
 
   EXPECT_EQ(
@@ -357,7 +381,7 @@ TEST_F(AOTITorchInt4PlainMMTest, RealInt4TensorLayout) {
       0x63, 0x9A, 0x95, 0x78, 0x95, 0x69, 0xF8, 0x58, 0x65, 0x0A, 0x6B, 0x47,
       0x9C, 0x5C, 0x6A, 0x35, 0xA2, 0x8A, 0x74, 0x93, 0x28, 0x6D, 0xF0, 0xAB,
       0x23, 0xA6, 0xA6, 0x3A};
-  // scale/zero are [K//gs, N] = [2, 8] — Int4Tensor's native layout
+  // scale/zero are [N, K//gs] = [8, 2] — transposed AOT for the coalesced kernel
   uint16_t scale_host[] = {
       0x3E46, 0x3E94, 0x3E8F, 0x3E94, 0x3E94, 0x3E8D, 0x3EA5, 0x3EA5,
       0x3E9F, 0x3EAD, 0x3E91, 0x3EA0, 0x3E88, 0x3EB7, 0x3E89, 0x3E92};
@@ -380,13 +404,15 @@ TEST_F(AOTITorchInt4PlainMMTest, RealInt4TensorLayout) {
 
   Tensor* A = create_bf16({M, K});
   Tensor* qdata = create_uint8({N, K / 2});
-  // Note: scale/zero shape is [n_groups, N], NOT [N, n_groups]
-  Tensor* scale = create_bf16({n_groups, N});
-  Tensor* zero = create_bf16({n_groups, N});
+  // scale/zero shape is [N, n_groups] (transposed AOT)
+  Tensor* scale = create_bf16({N, n_groups});
+  Tensor* zero = create_bf16({N, n_groups});
+  auto scale_t = transpose_u16(scale_host, n_groups, N);
+  auto zero_t = transpose_u16(zero_host, n_groups, N);
   upload(A, A_host, sizeof(A_host));
   upload(qdata, qdata_host, sizeof(qdata_host));
-  upload(scale, scale_host, sizeof(scale_host));
-  upload(zero, zero_host, sizeof(zero_host));
+  upload(scale, scale_t.data(), scale_t.size() * sizeof(uint16_t));
+  upload(zero, zero_t.data(), zero_t.size() * sizeof(uint16_t));
 
   Tensor* output = run(A, qdata, scale, zero, gs);
   ASSERT_NE(output, nullptr);
@@ -394,4 +420,26 @@ TEST_F(AOTITorchInt4PlainMMTest, RealInt4TensorLayout) {
   EXPECT_EQ(output->size(1), N);
   // W4A8 adds quantization noise vs bf16 reference — use wider tolerance
   check_bf16_output(output, expected, M * N, 0.5f);
+}
+
+// RejectsNativeLayout: scale/zero passed in the un-transposed native
+// [n_groups, N] layout (instead of the coalesced [N, n_groups] AOT layout)
+// must be rejected gracefully with Error::InvalidArgument, not crash.
+// K=64, gs=32 -> n_groups=2, N=8; native scale is [2, 8] while the shim
+// expects coalesced [8, 2]. n_groups != N so the shape guard can catch it.
+TEST_F(AOTITorchInt4PlainMMTest, RejectsNativeLayout) {
+  int64_t M = 1, K = 64, N = 8, gs = 32;
+  int64_t n_groups = K / gs; // 2
+
+  Tensor* A = create_bf16({M, K});
+  Tensor* qdata = create_uint8({N, K / 2});
+  // Native torchao layout [n_groups, N] = [2, 8], NOT the coalesced
+  // [N, n_groups] = [8, 2] the shim expects.
+  Tensor* scale = create_bf16({n_groups, N});
+  Tensor* zero = create_bf16({n_groups, N});
+  Tensor* output = nullptr;
+
+  EXPECT_EQ(
+      aoti_torch_cuda_int4_plain_mm(A, qdata, scale, zero, gs, &output),
+      Error::InvalidArgument);
 }

--- a/backends/cuda/tests/test_int4_dispatch.py
+++ b/backends/cuda/tests/test_int4_dispatch.py
@@ -24,13 +24,21 @@ Usage:
   python -m pytest backends/cuda/tests/test_int4_dispatch.py -v
 """
 
+import contextlib
 import unittest
+from unittest import mock
 
 import executorch.backends.cuda.quantize_op_dispatch.int4_dispatch  # noqa: F401
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from executorch.examples.models.gemma4_31b.quant.quantize import quantize_weight
+from executorch.backends.cuda.coalesced_int4_tensor import CudaCoalescedInt4Tensor
+from executorch.backends.cuda.quantize_op_dispatch.int4_dispatch import _dequant_matmul
+from executorch.examples.models.gemma4_31b.quant.pack_cuda import pack_linear_for_cuda
+from executorch.examples.models.gemma4_31b.quant.quantize import (
+    dequantize_weight,
+    quantize_weight,
+)
 from executorch.examples.models.gemma4_31b.quant.recipe import QuantConfig
 
 
@@ -51,8 +59,9 @@ def _make_int4_linear(N, K, group_size=128, symmetric=False, bias=False):
     )
     int4_w = quantize_weight(w_bf16, config)
 
-    module = nn.Linear(K, N, bias=bias, dtype=torch.bfloat16, device="cuda")
-    module.weight = nn.Parameter(int4_w.cuda(), requires_grad=False)
+    module = nn.Linear(K, N, bias=bias, dtype=torch.bfloat16)
+    pack_linear_for_cuda(module, {"weight": int4_w})
+    module.cuda()
     return module, w_bf16.cuda()
 
 
@@ -174,7 +183,7 @@ class TestDeviceMovement(unittest.TestCase):
         config = QuantConfig(bits=4, group_size=128, symmetric=False, method="min_max")
         int4_w = quantize_weight(w_bf16, config)
         module = nn.Linear(512, 256, bias=False)
-        module.weight = nn.Parameter(int4_w, requires_grad=False)
+        pack_linear_for_cuda(module, {"weight": int4_w})
         module = module.to("cuda")
         x = torch.randn(1, 512, dtype=torch.bfloat16, device="cuda")
         self._check(module(x), F.linear(x, w_bf16.cuda()))
@@ -205,6 +214,115 @@ class TestLargeShapes(unittest.TestCase):
         module, w_ref = _make_int4_linear(21504, 5376)
         x = torch.randn(128, 5376, dtype=torch.bfloat16, device="cuda")
         self._check(module(x), F.linear(x, w_ref))
+
+
+def _make_int4_tensor(N, K, group_size=128, symmetric=False):
+    """Build a stock torchao ``Int4Tensor`` (NOT packed/coalesced) on CPU."""
+    w = torch.randn(N, K, dtype=torch.bfloat16)
+    config = QuantConfig(
+        bits=4, group_size=group_size, symmetric=symmetric, method="min_max"
+    )
+    return quantize_weight(w, config), w
+
+
+@contextlib.contextmanager
+def _record_int4_plain_mm():
+    """Record calls to the decode custom op without needing a GPU.
+
+    Replaces ``torch.ops.executorch_cuda.int4_plain_mm`` (whose real impl is the
+    CUDA C shim) with a recorder that computes the result via the eager CPU
+    dequant, so the dispatch handler still returns a valid tensor.
+    """
+    calls = []
+
+    def _fake(self, qdata, scale, zero, group_size):
+        calls.append((tuple(self.shape), group_size))
+        return _dequant_matmul(self, qdata, scale, zero, group_size)
+
+    with mock.patch.object(torch.ops.executorch_cuda, "int4_plain_mm", _fake):
+        yield calls
+
+
+class TestDispatchRouting(unittest.TestCase):
+    """Type-based routing: only CudaCoalescedInt4Tensor reaches int4_plain_mm.
+
+    These tests run without a GPU by recording calls to the decode custom op
+    and computing the result with the eager CPU dequant. They guard the
+    comment-8 refactor: the CUDA decode path must be selected by weight *type*,
+    not by globally overriding torchao ``Int4Tensor``'s F.linear.
+    """
+
+    def setUp(self):
+        torch.manual_seed(0)
+
+    def _rel_err(self, out, ref):
+        return (
+            (out.float() - ref.float()).abs().mean() / ref.float().abs().mean()
+        ).item()
+
+    def test_stock_int4tensor_does_not_route_to_int4_plain_mm(self):
+        """A plain torchao Int4Tensor must fall back to torchao's default path."""
+        t, _ = _make_int4_tensor(16, 64, group_size=32)
+        x = torch.randn(1, 64, dtype=torch.bfloat16)  # M=1 (decode regime)
+        with _record_int4_plain_mm() as calls:
+            # torchao's default path uses mslk/CUDA and is not exercised on CPU;
+            # we only assert that our decode op is NOT reached.
+            with contextlib.suppress(Exception):
+                F.linear(x, t)
+        self.assertEqual(calls, [])
+
+    def test_coalesced_tensor_routes_to_int4_plain_mm(self):
+        """CudaCoalescedInt4Tensor with M<=4 routes to the decode custom op."""
+        t, _ = _make_int4_tensor(16, 64, group_size=32)
+        c = CudaCoalescedInt4Tensor.from_int4_tensor(t)
+        x = torch.randn(1, 64, dtype=torch.bfloat16)  # M=1 (decode regime)
+        with _record_int4_plain_mm() as calls:
+            out = F.linear(x, c)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(out.shape, (1, 16))
+
+    def test_coalesced_tensor_prefill_uses_dequant(self):
+        """M>4 uses inline dequant (no custom op) and is numerically correct."""
+        t, _ = _make_int4_tensor(16, 64, group_size=32)
+        c = CudaCoalescedInt4Tensor.from_int4_tensor(t)
+        x = torch.randn(8, 64, dtype=torch.bfloat16)  # M=8 > 4 (prefill regime)
+        with _record_int4_plain_mm() as calls:
+            out = F.linear(x, c)
+        self.assertEqual(calls, [])
+        ref = F.linear(x, dequantize_weight(t, torch.bfloat16))
+        self.assertLess(self._rel_err(out, ref), 0.02)
+
+    def test_square_shape_not_misrouted(self):
+        """N == n_groups (square scale) stock tensor is still not routed.
+
+        K = group_size * N makes scale square (n_groups == N); the old shape
+        heuristic could not distinguish this coalesced-looking case. Type-based
+        routing makes the scale shape irrelevant.
+        """
+        t, _ = _make_int4_tensor(4, 128, group_size=32)
+        self.assertEqual(tuple(t.scale.shape), (4, 4))  # (n_groups, N), square
+        x = torch.randn(1, 128, dtype=torch.bfloat16)
+        with _record_int4_plain_mm() as calls:
+            with contextlib.suppress(Exception):
+                F.linear(x, t)
+        self.assertEqual(calls, [])
+
+    def test_from_int4_tensor_transpose_correct(self):
+        """from_int4_tensor owns the (n_groups, N) -> (N, n_groups) transpose."""
+        t, _ = _make_int4_tensor(24, 192, group_size=64)
+        c = CudaCoalescedInt4Tensor.from_int4_tensor(t)
+        n_groups = 192 // 64
+        self.assertEqual(tuple(t.scale.shape), (n_groups, 24))  # torchao layout
+        self.assertEqual(tuple(c.scale.shape), (24, n_groups))  # coalesced layout
+        self.assertTrue(torch.equal(c.scale, t.scale.t().contiguous()))
+        self.assertTrue(torch.equal(c.zero_point, t.zero_point.t().contiguous()))
+        # End-to-end decode result matches a reference dequant of the original.
+        x = torch.randn(2, 192, dtype=torch.bfloat16)
+        with _record_int4_plain_mm() as calls:
+            out = F.linear(x, c)
+        self.assertEqual(len(calls), 1)
+        ref = F.linear(x, dequantize_weight(t, torch.bfloat16))
+        self.assertLess(self._rel_err(out, ref), 0.02)
 
 
 if __name__ == "__main__":

--- a/examples/models/gemma4_31b/quant/pack_cuda.py
+++ b/examples/models/gemma4_31b/quant/pack_cuda.py
@@ -6,8 +6,10 @@
 
 """CUDA packer: assign quantized weights to model modules.
 
-Passes ``Int4Tensor`` and ``IntxUnpackedToInt8Tensor`` through as
-``nn.Parameter`` without conversion.  The quantize_op_dispatch package
+Converts ``Int4Tensor`` weights to the ExecuTorch-internal
+``CudaCoalescedInt4Tensor`` (which owns the scale/zero transpose to the
+coalesced [N, n_groups] layout) and passes ``IntxUnpackedToInt8Tensor`` through
+as ``nn.Parameter`` without conversion. The quantize_op_dispatch package
 (``int4_dispatch`` / ``int8_dispatch``) handles F.linear at runtime.
 
 No CUDA is required for packing.  The backend-agnostic ``pack_model``
@@ -28,11 +30,24 @@ from .pack import ModulePackerFn, pack_model  # noqa: F401
 
 def pack_linear_for_cuda(module: nn.Module, weights: dict[str, torch.Tensor]) -> None:
     """Assign a quantized weight to an ``nn.Linear`` module."""
+    from executorch.backends.cuda.coalesced_int4_tensor import CudaCoalescedInt4Tensor
     from torchao.quantization import IntxUnpackedToInt8Tensor
     from torchao.quantization.quantize_.workflows.int4.int4_tensor import Int4Tensor
 
     w = weights["weight"]
-    if isinstance(w, (Int4Tensor, IntxUnpackedToInt8Tensor)):
+    if isinstance(w, Int4Tensor):
+        # Convert to the ExecuTorch-internal CudaCoalescedInt4Tensor, which
+        # repacks scale/zero from torchao's native [n_groups, N] layout into the
+        # coalesced [N, n_groups] layout the CUDA decode kernel reads (see
+        # int4_dispatch.py / int4_plain_mm.cuh). The transpose lives in
+        # CudaCoalescedInt4Tensor.from_int4_tensor, so it is baked into the
+        # serialized weight constant and the exported decode graph carries NO
+        # per-step transpose/clone — AOTInductor (freezing=False) does not
+        # constant-fold ops on parameters, so the transpose must already live in
+        # the constant for the coalesced layout to pay off.
+        w = CudaCoalescedInt4Tensor.from_int4_tensor(w)
+        module.weight = nn.Parameter(w, requires_grad=False)
+    elif isinstance(w, IntxUnpackedToInt8Tensor):
         module.weight = nn.Parameter(w, requires_grad=False)
     else:
         raise ValueError(f"Unsupported weight type: {type(w).__name__}")


### PR DESCRIPTION
This PR updates int4_plain_mm in cuda backend to reads scale/zero in the transposed [N, n_groups] layout instead of [n_groups, N]. In this way every warp can load both scale and zero together in one cache line, instead of 32 cache lines previously. 

gemma4-31b decode perf: ~27 token/s -> 37.36 token/s.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani