### PR TITLE
Fix constant_pad_nd->cat lowering dtype for quantized graphs

### DIFF
--- a/backends/cadence/aot/replace_ops.py
+++ b/backends/cadence/aot/replace_ops.py
@@ -632,6 +632,7 @@ class ReplacePadWithCatPass(RemoveOrReplacePassInterface):
         value = 0 if len(node.args) == 2 else node.args[2]
 
         arg_shape = input_node.meta["val"].shape
+        dtype = input_node.meta["val"].dtype
 
         # Convert orig_padding to a list for manipulation
         # pyre-ignore[6]: Argument type
@@ -663,7 +664,7 @@ class ReplacePadWithCatPass(RemoveOrReplacePassInterface):
                         left_padding_shape,
                         value,
                     ),
-                    kwargs={"dtype": torch.float32},
+                    kwargs={"dtype": dtype},
                 )
                 left_padding_node.meta = node.meta
             cat_tensors.append(left_padding_node)
@@ -683,7 +684,7 @@ class ReplacePadWithCatPass(RemoveOrReplacePassInterface):
                         right_padding_shape,
                         value,
                     ),
-                    kwargs={"dtype": torch.float32},
+                    kwargs={"dtype": dtype},
                 )
                 right_padding_node.meta = node.meta
             cat_tensors.append(right_padding_node)

--- a/backends/cadence/aot/tests/test_replace_ops_passes.py
+++ b/backends/cadence/aot/tests/test_replace_ops_passes.py
@@ -840,6 +840,30 @@ class TestReplaceOpsPasses(unittest.TestCase):
         )
 
     @torch.no_grad()
+    def test_replace_pad_with_cat_preserves_dtype(self) -> None:
+        # The padding constant tensors must match the input dtype, otherwise the
+        # resulting cat mixes dtypes and fails edge dialect dtype verification
+        # (e.g. for quantized int8 graphs).
+        x = torch.randint(-128, 127, (1, 2, 3), dtype=torch.int8)
+        original_gm = single_op_builder(
+            placeholders=(x,),
+            op=exir_ops.edge.aten.constant_pad_nd.default,
+            args=(x, [1, 1]),
+        )
+
+        p = ReplacePadWithCatPass()
+        result = cast(PassResult, p(original_gm))
+        self.assertTrue(result.modified)
+        graph_after_passes = result.graph_module
+
+        full_nodes = graph_after_passes.graph.find_nodes(
+            op="call_function", target=exir_ops.edge.aten.full.default
+        )
+        self.assertEqual(len(full_nodes), 2)
+        for full_node in full_nodes:
+            self.assertEqual(full_node.kwargs["dtype"], torch.int8)
+
+    @torch.no_grad()
     def test_replace_repeat_with_cat(self) -> None:
         x = torch.randn([3, 5])
         original_gm = single_op_builder(


### PR DESCRIPTION
Summary:
ReplacePadWithCatPass lowers aten.constant_pad_nd into a cat with
constant padding tensors, but hard-coded their dtype to torch.float32.

After D106526096 migrated the Helios/Jarvis compiler from turing.extend
to aten.constant_pad_nd, this pass started firing on quantized
(int8/uint8) graphs, producing a float32 cat whose inputs are int8.
This fails edge dialect dtype verification:

  SpecViolationError: These operators are taking Tensor inputs with
  mismatched dtypes: aten.cat.default {'tensors': torch.uint8,
  '__ret_0': torch.float32}

Derive the padding tensor dtype from the input tensor instead of
hard-coding float32. This is the dtype the cat needs to preserve.

Fixes the on_device_ai/Assistant/Jarvis/compiler:test_sharding
TestTuringZooModels failures tracked in T273949284.

___

Differential Revision: D107545428


