### PR TITLE
Qualcomm AI Engine Direct - Fix backend register issue on Windows

### DIFF
--- a/backends/qualcomm/runtime/QnnExecuTorch.h
+++ b/backends/qualcomm/runtime/QnnExecuTorch.h
@@ -37,6 +37,16 @@
 #define QNN_EXECUTORCH_EXPORT __attribute__((__visibility__("default")))
 #endif
 
+#if defined(_MSC_VER)
+#if defined(QNN_EXECUTORCH_BUILDING_DLL)
+#define QNN_EXECUTORCH_EXPORT __declspec(dllexport)
+#else
+#define QNN_EXECUTORCH_EXPORT __declspec(dllimport)
+#endif
+#else
+#define QNN_EXECUTORCH_EXPORT __attribute__((__visibility__("default")))
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
@@ -91,6 +101,9 @@ QNN_EXECUTORCH_EXPORT void QnnExecuTorchAddCustomMemTensorAddr(
 
 /// Free the allocated shared memory.
 QNN_EXECUTORCH_EXPORT void QnnExecuTorchFreeCustomMem(void* buffer_ptr);
+
+/// Register the QnnBackend with the ExecuTorch runtime.
+QNN_EXECUTORCH_EXPORT void QnnExecuTorchBackendRegister(void* register_fn);
 
 #ifdef __cplusplus
 }

--- a/backends/qualcomm/runtime/QnnExecuTorch.h
+++ b/backends/qualcomm/runtime/QnnExecuTorch.h
@@ -37,16 +37,6 @@
 #define QNN_EXECUTORCH_EXPORT __attribute__((__visibility__("default")))
 #endif
 
-#if defined(_MSC_VER)
-#if defined(QNN_EXECUTORCH_BUILDING_DLL)
-#define QNN_EXECUTORCH_EXPORT __declspec(dllexport)
-#else
-#define QNN_EXECUTORCH_EXPORT __declspec(dllimport)
-#endif
-#else
-#define QNN_EXECUTORCH_EXPORT __attribute__((__visibility__("default")))
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
@@ -102,7 +92,20 @@ QNN_EXECUTORCH_EXPORT void QnnExecuTorchAddCustomMemTensorAddr(
 /// Free the allocated shared memory.
 QNN_EXECUTORCH_EXPORT void QnnExecuTorchFreeCustomMem(void* buffer_ptr);
 
-/// Register the QnnBackend with the ExecuTorch runtime.
+/// Register the QNN backend with the ExecuTorch runtime living in the caller's
+/// module. On Windows the backend DLL and the runner exe each carry a private
+/// copy of executorch_core's backend registry, so the DLL's own static
+/// initializer cannot register into the exe's registry. The runner must call
+/// this from main() and pass a pointer to its own register_backend so that
+/// registration lands in the exe's address space.
+///
+/// @param[in] register_fn Pointer to executorch::runtime::register_backend.
+///     Its required signature is:
+///         executorch::runtime::Error (*)(
+///             const executorch::runtime::Backend&)
+///     The pointer crosses the DLL boundary as void* (C ABI) and is cast back
+///     to that signature inside the DLL. On non-Windows builds this is a no-op
+///     because ELF symbol interposition already shares a single registry.
 QNN_EXECUTORCH_EXPORT void QnnExecuTorchBackendRegister(void* register_fn);
 
 #ifdef __cplusplus

--- a/backends/qualcomm/runtime/QnnExecuTorchBackend.cpp
+++ b/backends/qualcomm/runtime/QnnExecuTorchBackend.cpp
@@ -351,10 +351,37 @@ void QnnExecuTorchBackend::erase_cached_delegate(
 }
 
 namespace {
+#if !defined(_MSC_VER)
 auto cls = QnnExecuTorchBackend();
 executorch::runtime::Backend backend{QNN_BACKEND, &cls};
+// On non-Windows platforms a single copy of executorch_core is shared between
+// the DLL and the exe, so the static initializer writes into the correct
+// registered_backends[] array.
 static auto success_with_compiler = register_backend(backend);
+#endif
 } // namespace
+
+#if defined(_MSC_VER)
+static QnnExecuTorchBackend cls_msvc;
+static executorch::runtime::Backend backend_msvc{QNN_BACKEND, &cls_msvc};
+#endif
+
 } // namespace qnn
 } // namespace backends
 } // namespace executorch
+
+#if defined(_MSC_VER)
+// On Windows the DLL and the exe each carry a private copy of executorch_core
+// globals. The runner calls this function at startup, passing its own
+// register_backend() so registration happens in the exe's address space.
+void QnnExecuTorchBackendRegister(void* register_fn) {
+  using RegisterFn = executorch::runtime::Error (*)(
+      const executorch::runtime::Backend&);
+  reinterpret_cast<RegisterFn>(register_fn)(
+      executorch::backends::qnn::backend_msvc);
+}
+#else
+void QnnExecuTorchBackendRegister(void*) {
+  // No-op
+}
+#endif

--- a/backends/qualcomm/runtime/QnnExecuTorchBackend.cpp
+++ b/backends/qualcomm/runtime/QnnExecuTorchBackend.cpp
@@ -374,14 +374,26 @@ static executorch::runtime::Backend backend_msvc{QNN_BACKEND, &cls_msvc};
 // On Windows the DLL and the exe each carry a private copy of executorch_core
 // globals. The runner calls this function at startup, passing its own
 // register_backend() so registration happens in the exe's address space.
+// See QnnExecuTorch.h for the required register_fn signature.
 void QnnExecuTorchBackendRegister(void* register_fn) {
-  using RegisterFn = executorch::runtime::Error (*)(
-      const executorch::runtime::Backend&);
-  reinterpret_cast<RegisterFn>(register_fn)(
+  using RegisterFn =
+      executorch::runtime::Error (*)(const executorch::runtime::Backend&);
+  if (register_fn == nullptr) {
+    ET_LOG(Error, "QnnExecuTorchBackendRegister called with null register_fn");
+    return;
+  }
+  executorch::runtime::Error err = reinterpret_cast<RegisterFn>(register_fn)(
       executorch::backends::qnn::backend_msvc);
+  if (err != executorch::runtime::Error::Ok) {
+    ET_LOG(
+        Error,
+        "Failed to register QNN backend: 0x%x",
+        static_cast<uint32_t>(err));
+  }
 }
 #else
 void QnnExecuTorchBackendRegister(void*) {
-  // No-op
+  // No-op: ELF symbol interposition already shares a single backend registry
+  // between the .so and the exe, so the static initializer above suffices.
 }
 #endif

--- a/examples/qualcomm/executor_runner/qnn_executor_runner.cpp
+++ b/examples/qualcomm/executor_runner/qnn_executor_runner.cpp
@@ -208,6 +208,8 @@ class CustomMemory {
 
 int main(int argc, char** argv) {
   executorch::runtime::runtime_init();
+  QnnExecuTorchBackendRegister(
+      reinterpret_cast<void*>(executorch::runtime::register_backend));
 
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   if (argc != 1) {

--- a/examples/qualcomm/oss_scripts/whisper/qnn_whisper_runner.cpp
+++ b/examples/qualcomm/oss_scripts/whisper/qnn_whisper_runner.cpp
@@ -13,7 +13,9 @@
  *
  */
 
+#include <executorch/backends/qualcomm/runtime/QnnExecuTorch.h>
 #include <executorch/examples/qualcomm/oss_scripts/whisper/runner/runner.h>
+#include <executorch/runtime/backend/interface.h>
 #include <executorch/runtime/platform/log.h>
 #include <gflags/gflags.h>
 #include <fstream>
@@ -95,6 +97,8 @@ std::vector<std::vector<std::vector<char>>> parse_input_list_file(
 }
 
 int main(int argc, char** argv) {
+  QnnExecuTorchBackendRegister(
+      reinterpret_cast<void*>(executorch::runtime::register_backend));
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   // create llama runner
   example::Runner runner(FLAGS_model_path, FLAGS_tokenizer_json_path);


### PR DESCRIPTION
## Background

On Linux, `qnn_executorch_backend.so` is a shared library that links `executorch_core.a` statically. This produces a `.so` that embeds its own copy of `register_backend`, `registered_backends`, and `num_registered_backends`. But those symbols are **ELF global (non-hidden) symbols**. When the runner exe also links `executorch_core.a`, it too has copies of those symbols — but **ELF's symbol interposition rule** says:

> When the dynamic linker resolves a symbol at runtime, the executable's definition takes priority over any .so's definition.

Even though the `.so` physically contains its own `register_backend` code, at runtime all calls to `register_backend` — including the static initializer inside the `.so` — **are redirected to the exe's copy by the dynamic linker**.

## Why it breaks on Windows?

Windows has no symbol interposition. Each module — the .dll and the .exe — resolves all statically linked symbols independently, and each carries a completely private copy of any data that came from statically archived code.

## The fix for Windows (compatible with Linux)

**The solution is to explicitly bridge the address-space split by passing the exe's own `register_backend` function pointer across the DLL boundary.**
The exe's registering function address is passed as `void*` to the DLL's `QnnExecuTorchBackendRegister`. Inside the DLL, the function pointer is a direct address into the exe's code. When the DLL executes `reinterpret_cast<RegisterFn>(register_fn)(backend_msvc)`, the CPU jumps into the exe's `register_backend` function, which writes into the exe's own `registered_backends[]`.